### PR TITLE
feat(ui): G10.6-T2 runbooks authoring editor — draft + edit templates

### DIFF
--- a/backend/src/meho_backplane/ui/routes/runbooks/__init__.py
+++ b/backend/src/meho_backplane/ui/routes/runbooks/__init__.py
@@ -1,13 +1,17 @@
 # SPDX-License-Identifier: Apache-2.0
 # Copyright (c) 2026 evoila Group
 
-"""Runbooks UI read surface package (G10.6-T1, #1382).
+"""Runbooks UI surface package (G10.6).
 
 Exports :func:`build_runbooks_router` -- the ``/ui/runbooks*`` router
 factory the umbrella :func:`meho_backplane.ui.routes.build_router`
-mounts (ahead of the stubs aggregate, first-match-wins). The catalog +
-detail handlers and the opacity-floor logic live in
-:mod:`meho_backplane.ui.routes.runbooks.routes`.
+mounts (ahead of the stubs aggregate, first-match-wins). The read surface
+(catalog + detail + opacity-floor logic, T1 #1382) lives in
+:mod:`meho_backplane.ui.routes.runbooks.routes`; the ``tenant_admin``
+authoring editor (T2 #1383) lives in
+:mod:`meho_backplane.ui.routes.runbooks.editor` (form logic) +
+:mod:`meho_backplane.ui.routes.runbooks.editor_routes` (route wiring),
+registered onto the same router by the factory.
 """
 
 from __future__ import annotations

--- a/backend/src/meho_backplane/ui/routes/runbooks/editor.py
+++ b/backend/src/meho_backplane/ui/routes/runbooks/editor.py
@@ -1,0 +1,593 @@
+# SPDX-License-Identifier: Apache-2.0
+# Copyright (c) 2026 evoila Group
+
+"""Runbooks UI authoring editor: draft + edit template handler bodies.
+
+Initiative #1381 (G10.6 Runbooks UI), Task #1383 (T2). The authoring half
+of the ``/ui/runbooks*`` surface -- the ``tenant_admin`` editor that builds
+a valid :class:`~meho_backplane.runbooks.schemas.RunbookTemplateBody` from a
+structured, repeatable step form and submits it through the same service the
+REST surface uses:
+
+* ``POST /ui/runbooks/new``         -> :meth:`RunbookTemplateService.create_draft`
+  (mirrors REST ``POST /api/v1/runbooks/templates`` -- 201 / 409 / 422)
+* ``POST /ui/runbooks/{slug}/edit`` -> :meth:`RunbookTemplateService.update_or_fork`
+  (mirrors REST ``PATCH /api/v1/runbooks/templates/{slug}`` -- in-place vs fork)
+
+Split out of :mod:`meho_backplane.ui.routes.runbooks.routes` (the read
+surface, T1 #1382) so the read and authoring concerns live in separate
+modules and neither file crosses the code-quality size gate -- the same
+package-split convention :mod:`meho_backplane.ui.routes.memory` uses. This
+module holds the form-tree (de)serialisation + the create/edit submission
+logic; the FastAPI route wiring lives in
+:mod:`meho_backplane.ui.routes.runbooks.editor_routes`, which imports the
+helpers here.
+
+Form transport
+--------------
+
+The editor posts its entire step tree as one JSON string in the ``steps``
+form field (built by the Alpine model client-side) rather than as dozens of
+indexed form fields. The discriminated-union shape (manual vs operation_call
+step; confirm vs operation_call verify) survives the round-trip intact, and
+the server rebuilds one ``Step``-shaped dict per step before handing the whole
+body to Pydantic -- which performs the *authoritative* validation (non-empty
+title / description, the step-id pattern + uniqueness, the ``${...}``
+substitution allowlist). Client-side checks are convenience that block an
+obviously-bad submit early; the server is the source of truth and a server
+409 / 422 / 404 re-renders the editor inline with the entered data preserved.
+
+CSRF
+----
+
+State-changing requests carry the double-submit token via ``hx-headers`` /
+the cookie; the token is minted on render and **re-minted** on every
+re-render that follows a consumed POST (a validation error, or a fork
+notice). The prior token was consumed by the request, so both the cookie
+and the ``hx-headers`` echo must refresh or every subsequent HTMX call 403s.
+:func:`set_csrf_cookie` is the shared cookie-set the read surface also uses.
+
+References
+----------
+
+* HTMX 2.0.9 ``HX-Redirect`` response header (client-side navigation on a
+  204): https://htmx.org/reference/#response_headers
+* Pydantic v2 ``ValidationError.errors()`` shape (``loc`` / ``msg``):
+  https://docs.pydantic.dev/2.11/errors/validation_errors/
+"""
+
+from __future__ import annotations
+
+import json
+from dataclasses import dataclass
+from typing import Literal
+
+import structlog
+from fastapi import Request
+from fastapi.responses import HTMLResponse, Response
+from pydantic import ValidationError
+
+from meho_backplane.kb.schemas import InvalidKbSlugError, validate_slug
+from meho_backplane.runbooks.schemas import (
+    DraftTemplateRequest,
+    EditTemplateRequest,
+    RunbookTemplateBody,
+    ShowTemplateResponse,
+)
+from meho_backplane.runbooks.service import (
+    DuplicateDraftError,
+    RunbookTemplateService,
+    TemplateNotFoundError,
+)
+from meho_backplane.ui.auth.middleware import UISessionContext
+from meho_backplane.ui.csrf import CSRF_COOKIE_NAME, mint_csrf_token
+from meho_backplane.ui.templating import get_templates
+
+__all__ = [
+    "build_editor_context",
+    "empty_step",
+    "handle_editor_submit",
+    "set_csrf_cookie",
+    "template_to_form_steps",
+]
+
+log = structlog.get_logger(__name__)
+
+
+def set_csrf_cookie(response: Response, csrf_token: str) -> None:
+    """Set the JS-readable CSRF cookie on *response* (shared posture).
+
+    Mirrors the kb / dashboard surfaces: not ``HttpOnly`` (HTMX must read it
+    to echo ``X-CSRF-Token`` on any future state-changing request), ``Secure``
+    + ``SameSite=Strict``, scoped to ``/ui``. Shared by the read surface and
+    the authoring surface so the cookie attributes never drift between them.
+    """
+    response.set_cookie(
+        key=CSRF_COOKIE_NAME,
+        value=csrf_token,
+        httponly=False,
+        secure=True,
+        samesite="strict",
+        path="/ui",
+    )
+
+
+@dataclass(frozen=True)
+class _EditorResult:
+    """Outcome of a draft-create / edit-in-place authoring submission.
+
+    Exactly one of :attr:`redirect_slug` (success -> navigate to detail) or
+    :attr:`error_message` (failure -> re-render the editor inline) is set.
+    On the fork path (editing a published template) :attr:`fork_notice` is
+    populated so the editor can surface ``forked_from`` + the source
+    version's ``in_flight_run_count`` to the admin.
+    """
+
+    redirect_slug: str | None
+    error_message: str | None
+    fork_notice: dict[str, object] | None
+
+
+def empty_step() -> dict[str, object]:
+    """Return the seed shape for one blank step in a fresh editor.
+
+    The editor's Alpine model and the server-side prefill share this shape
+    so the discriminated-union form starts on the ``manual`` + ``confirm``
+    branch (the simplest valid step) with empty strings the operator fills
+    in. ``op_id`` / ``params`` / verify fields are carried for both branches
+    so an Alpine ``type`` toggle never has to synthesise missing keys.
+    """
+    return {
+        "id": "",
+        "title": "",
+        "body": "",
+        "type": "manual",
+        "op_id": "",
+        "params": "{}",
+        "verify": {
+            "type": "confirm",
+            "prompt": "",
+            "op_id": "",
+            "params": "{}",
+            "expect": "{}",
+        },
+    }
+
+
+def template_to_form_steps(template: ShowTemplateResponse) -> list[dict[str, object]]:
+    """Project an existing template's steps into the editor's flat form shape.
+
+    Inverse of :func:`_parse_form_steps`: the discriminated-union step /
+    verify models are flattened so the Alpine editor can bind every branch's
+    fields with ``x-model`` without inspecting Pydantic types. ``params`` /
+    ``expect`` dicts are re-serialised to pretty JSON strings (the shape the
+    JSON textareas edit); the unused branch's fields default to empty so a
+    ``type`` toggle reveals blank inputs rather than ``undefined``.
+    """
+    form_steps: list[dict[str, object]] = []
+    for step in template.steps:
+        verify = step.verify
+        form_verify: dict[str, object] = {
+            "type": verify.type,
+            "prompt": getattr(verify, "prompt", ""),
+            "op_id": getattr(verify, "op_id", ""),
+            "params": _dict_to_json(getattr(verify, "params", {})),
+            "expect": _dict_to_json(getattr(verify, "expect", {})),
+        }
+        form_steps.append(
+            {
+                "id": step.id,
+                "title": step.title,
+                "body": step.body,
+                "type": step.type,
+                "op_id": getattr(step, "op_id", ""),
+                "params": _dict_to_json(getattr(step, "params", {})),
+                "verify": form_verify,
+            }
+        )
+    return form_steps
+
+
+def _dict_to_json(value: object) -> str:
+    """Serialise a params/expect dict to a pretty JSON string for the form."""
+    if not isinstance(value, dict) or not value:
+        return "{}"
+    return json.dumps(value, indent=2, sort_keys=True)
+
+
+def _parse_json_object(raw: object, field: str) -> dict[str, object]:
+    """Parse a JSON-object string from the form, raising ``ValueError`` on junk.
+
+    The operation_call params / verify params / verify expect fields are
+    edited as raw JSON textareas in the form. An empty / whitespace value is
+    treated as ``{}`` (the empty payload). Anything that is not a JSON object
+    raises with a field-pointing message so the editor can surface it inline
+    -- the server stays the source of truth even for the JSON sub-fields the
+    client also pre-validates.
+    """
+    if raw is None:
+        return {}
+    text = raw if isinstance(raw, str) else json.dumps(raw)
+    text = text.strip()
+    if not text:
+        return {}
+    try:
+        parsed = json.loads(text)
+    except (json.JSONDecodeError, TypeError) as exc:
+        raise ValueError(f"{field}: not valid JSON ({exc})") from exc
+    if not isinstance(parsed, dict):
+        raise ValueError(f"{field}: must be a JSON object, got {type(parsed).__name__}")
+    return parsed
+
+
+def _parse_form_verify(raw_verify: object, step_index: int) -> dict[str, object]:
+    """Reassemble one step's verify gate from the flat editor payload.
+
+    ``confirm`` drops the operation_call fields; ``operation_call`` carries
+    ``op_id`` + the parsed JSON ``params`` / ``expect``. Raises
+    :class:`ValueError` on a structurally-broken verify (Pydantic then does
+    the authoritative validation when the dict is fed to the step model).
+    """
+    if not isinstance(raw_verify, dict):
+        raise ValueError(f"steps[{step_index}].verify: not an object")
+    verify_type = raw_verify.get("type")
+    if verify_type == "confirm":
+        return {"type": "confirm", "prompt": str(raw_verify.get("prompt", ""))}
+    if verify_type == "operation_call":
+        return {
+            "type": "operation_call",
+            "op_id": str(raw_verify.get("op_id", "")).strip(),
+            "params": _parse_json_object(
+                raw_verify.get("params"), f"steps[{step_index}].verify.params"
+            ),
+            "expect": _parse_json_object(
+                raw_verify.get("expect"), f"steps[{step_index}].verify.expect"
+            ),
+        }
+    raise ValueError(f"steps[{step_index}].verify.type: unknown verify type {verify_type!r}")
+
+
+def _parse_form_steps(raw_steps: object) -> list[dict[str, object]]:
+    """Reassemble the flat editor form payload into ``Step``-shaped dicts.
+
+    The editor posts its entire step tree as one JSON string (built by the
+    Alpine model) rather than dozens of indexed form fields -- the
+    discriminated-union shape survives the round-trip intact and the server
+    rebuilds one dict per step keyed exactly as
+    :class:`~meho_backplane.runbooks.schemas.Step` expects. ``manual`` steps
+    drop ``op_id`` / ``params``; ``operation_call`` steps carry them with the
+    JSON sub-fields parsed. The verify branch is reassembled the same way.
+
+    Raises :class:`ValueError` on a structurally-broken payload (not a list,
+    an entry that is not an object, an unknown ``type``, a malformed JSON
+    sub-field). Pydantic then performs the authoritative validation (step-id
+    pattern, uniqueness, substitution allowlist) when the dicts are fed to
+    :class:`RunbookTemplateBody`.
+    """
+    if not isinstance(raw_steps, list):
+        raise ValueError("steps: payload is not a list")
+    steps: list[dict[str, object]] = []
+    for index, entry in enumerate(raw_steps):
+        if not isinstance(entry, dict):
+            raise ValueError(f"steps[{index}]: not an object")
+        step_type = entry.get("type")
+        verify = _parse_form_verify(entry.get("verify"), index)
+        base: dict[str, object] = {
+            "id": str(entry.get("id", "")).strip(),
+            "title": str(entry.get("title", "")),
+            "body": str(entry.get("body", "")),
+            "verify": verify,
+        }
+        if step_type == "manual":
+            base["type"] = "manual"
+        elif step_type == "operation_call":
+            base["type"] = "operation_call"
+            base["op_id"] = str(entry.get("op_id", "")).strip()
+            base["params"] = _parse_json_object(entry.get("params"), f"steps[{index}].params")
+        else:
+            raise ValueError(f"steps[{index}].type: unknown step type {step_type!r}")
+        steps.append(base)
+    return steps
+
+
+def _format_validation_error(exc: ValidationError) -> str:
+    """Render a Pydantic ``ValidationError`` as a compact, operator-readable line.
+
+    The editor surfaces this verbatim in the inline error banner. Each error
+    is rendered as ``<dotted.loc>: <message>`` so an admin can map the
+    failure back to the offending field (``steps.0.id``, ``title``, etc.)
+    without parsing the raw Pydantic JSON.
+    """
+    parts: list[str] = []
+    for error in exc.errors():
+        loc = ".".join(str(segment) for segment in error.get("loc", ()))
+        message = error.get("msg", "invalid")
+        parts.append(f"{loc}: {message}" if loc else message)
+    return "; ".join(parts) if parts else "validation failed"
+
+
+def _build_body_from_form(
+    *,
+    title: str,
+    description: str,
+    target_kind: str,
+    raw_steps: object,
+) -> RunbookTemplateBody:
+    """Construct + validate a :class:`RunbookTemplateBody` from editor form fields.
+
+    Reassembles the step tree (:func:`_parse_form_steps`) and hands the whole
+    shape to Pydantic, which enforces the authoritative contract: the step-id
+    pattern, step-id uniqueness, and the ``${...}`` substitution allowlist. A
+    blank ``target_kind`` field maps to ``None`` (the column is nullable).
+
+    The non-empty ``title`` / ``description`` and the ``>=1 step`` floor are
+    authoring-surface contracts the shared :class:`RunbookTemplateBody` schema
+    does not enforce on its own (it permits an empty title and an empty steps
+    list), but a runbook with a blank title or no steps is meaningless to run
+    and the issue's body shape requires them. Enforce them here (the client
+    mirrors the same checks) so the editor never produces a degenerate
+    template. Raises :class:`ValueError` (form-shape / floor problems) or
+    :class:`pydantic.ValidationError` (schema-contract violations); the caller
+    maps both to the inline error banner.
+    """
+    if not title.strip():
+        raise ValueError("title: must not be empty")
+    if not description.strip():
+        raise ValueError("description: must not be empty")
+    steps = _parse_form_steps(raw_steps)
+    if not steps:
+        raise ValueError("steps: a runbook needs at least one step")
+    return RunbookTemplateBody(
+        title=title,
+        description=description,
+        target_kind=target_kind.strip() or None,
+        steps=steps,  # type: ignore[arg-type]
+    )
+
+
+async def _create_draft_from_form(
+    session: UISessionContext,
+    *,
+    slug: str,
+    body: RunbookTemplateBody,
+) -> _EditorResult:
+    """Create a new draft via the service; map service errors to inline form errors.
+
+    Mirrors the REST ``POST /api/v1/runbooks/templates`` contract over the
+    same service call the route handler uses -- 201 -> redirect to the new
+    draft's detail page; ``DuplicateDraftError`` (the slug already has a
+    version, i.e. the REST 409) and a slug failing :data:`SLUG_PATTERN`
+    (the REST 422) map to inline field errors rather than a raw status code.
+    Tenant + author identity come from the session, never the form.
+    """
+    try:
+        validate_slug(slug)
+    except InvalidKbSlugError as exc:
+        return _EditorResult(redirect_slug=None, error_message=f"slug: {exc}", fork_notice=None)
+
+    try:
+        await RunbookTemplateService().create_draft(
+            session.tenant_id,
+            session.operator_sub,
+            DraftTemplateRequest(slug=slug, body=body),
+        )
+    except DuplicateDraftError as exc:
+        return _EditorResult(redirect_slug=None, error_message=str(exc), fork_notice=None)
+    except InvalidKbSlugError as exc:
+        return _EditorResult(redirect_slug=None, error_message=f"slug: {exc}", fork_notice=None)
+    return _EditorResult(redirect_slug=slug, error_message=None, fork_notice=None)
+
+
+async def _edit_template_from_form(
+    session: UISessionContext,
+    *,
+    slug: str,
+    body: RunbookTemplateBody,
+) -> _EditorResult:
+    """Edit a draft in place, or fork a new draft from the latest published.
+
+    Mirrors the REST ``PATCH /api/v1/runbooks/templates/{slug}`` contract:
+    the service picks the in-place-vs-fork path. On the fork path (the slug's
+    only versions are published / deprecated) the response carries
+    ``forked_from``; the notice is surfaced to the admin so they see the
+    source version + its ``in_flight_run_count`` before navigating on. A slug
+    with no versions at all (or a cross-tenant probe) is
+    :class:`TemplateNotFoundError` -> inline error (the REST 404). Success
+    redirects to the resulting draft's detail page.
+    """
+    try:
+        validate_slug(slug)
+    except InvalidKbSlugError as exc:
+        return _EditorResult(redirect_slug=None, error_message=f"slug: {exc}", fork_notice=None)
+
+    try:
+        result = await RunbookTemplateService().update_or_fork(
+            session.tenant_id,
+            session.operator_sub,
+            EditTemplateRequest(slug=slug, body=body),
+        )
+    except TemplateNotFoundError:
+        return _EditorResult(
+            redirect_slug=None,
+            error_message=f"No runbook template {slug!r} to edit.",
+            fork_notice=None,
+        )
+    fork_notice: dict[str, object] | None = None
+    if result.forked_from is not None:
+        fork_notice = {
+            "slug": result.forked_from.slug,
+            "source_version": result.forked_from.version,
+            "new_version": result.version,
+            "in_flight_run_count": result.forked_from.in_flight_run_count,
+        }
+    return _EditorResult(redirect_slug=slug, error_message=None, fork_notice=fork_notice)
+
+
+def build_editor_context(
+    session: UISessionContext,
+    *,
+    mode: Literal["new", "edit"],
+    slug: str,
+    title: str,
+    description: str,
+    target_kind: str,
+    form_steps: list[dict[str, object]],
+    csrf_token: str,
+    error_message: str | None = None,
+    fork_notice: dict[str, object] | None = None,
+) -> dict[str, object]:
+    """Assemble the Jinja context the ``runbooks/editor.html`` template needs.
+
+    ``form_steps`` is JSON-serialised into ``initial_steps_json`` so the
+    Alpine model can hydrate from the server-rendered prefill (an edit
+    pre-loads the existing steps; a fresh ``new`` seeds one blank step). The
+    post target + submit verb differ by ``mode`` so a single template serves
+    both the draft-create and edit-in-place flows.
+    """
+    return {
+        "mode": mode,
+        "slug": slug,
+        "title": title,
+        "description": description,
+        "target_kind": target_kind,
+        "initial_steps_json": json.dumps(form_steps),
+        "submit_url": "/ui/runbooks/new" if mode == "new" else f"/ui/runbooks/{slug}/edit",
+        "submit_label": "Create draft" if mode == "new" else "Save changes",
+        "error_message": error_message,
+        "fork_notice": fork_notice,
+        "csrf_token": csrf_token,
+        "operator_sub": session.operator_sub,
+        "active_surface": "runbooks",
+        "page_title": "New runbook" if mode == "new" else f"Edit {slug}",
+        "ready": False,
+    }
+
+
+def _render_editor(
+    request: Request,
+    session: UISessionContext,
+    *,
+    mode: Literal["new", "edit"],
+    slug: str,
+    title: str,
+    description: str,
+    target_kind: str,
+    raw_steps: object,
+    status_code: int = 200,
+    error_message: str | None = None,
+    fork_notice: dict[str, object] | None = None,
+) -> HTMLResponse:
+    """Re-render the editor with the operator's entered data preserved.
+
+    CSRF is re-minted (the prior token was consumed by the POST that led
+    here) and the cookie refreshed so subsequent HTMX calls carry a live
+    token. A non-list ``raw_steps`` (the JSON payload was structurally
+    broken) falls back to a single blank step so the form is never empty.
+    """
+    csrf_token = mint_csrf_token(str(session.session_id))
+    form_steps = raw_steps if isinstance(raw_steps, list) else [empty_step()]
+    context = build_editor_context(
+        session,
+        mode=mode,
+        slug=slug,
+        title=title,
+        description=description,
+        target_kind=target_kind,
+        form_steps=form_steps,
+        csrf_token=csrf_token,
+        error_message=error_message,
+        fork_notice=fork_notice,
+    )
+    response = get_templates().TemplateResponse(
+        request, "runbooks/editor.html", context, status_code=status_code
+    )
+    set_csrf_cookie(response, csrf_token)
+    return response
+
+
+async def handle_editor_submit(
+    request: Request,
+    session: UISessionContext,
+    *,
+    mode: Literal["new", "edit"],
+    slug: str,
+    title: str,
+    description: str,
+    target_kind: str,
+    steps_json: str,
+) -> Response:
+    """Shared draft-create / edit-in-place submission handler.
+
+    Parses + validates the form into a :class:`RunbookTemplateBody`, then
+    dispatches to the create or edit service path. On a plain success returns
+    a 204 with ``HX-Redirect`` to the resulting draft's detail page. On a fork
+    success (an edit of a published template) re-renders the editor (200) in
+    ``edit`` mode against the new draft with the fork notice so the admin sees
+    the source version + ``in_flight_run_count`` from the PATCH response. On
+    any failure -- malformed form shape (:class:`ValueError`), a Pydantic
+    contract violation (:class:`ValidationError`), a duplicate slug, or a
+    missing template -- the editor is re-rendered inline at HTTP 422 with the
+    entered data preserved and a freshly-minted CSRF token.
+    """
+    raw_steps: object = []
+    error_message: str | None = None
+    body: RunbookTemplateBody | None = None
+    try:
+        raw_steps = json.loads(steps_json) if steps_json.strip() else []
+    except json.JSONDecodeError as exc:
+        error_message = f"steps: malformed payload ({exc})"
+
+    if error_message is None:
+        try:
+            body = _build_body_from_form(
+                title=title,
+                description=description,
+                target_kind=target_kind,
+                raw_steps=raw_steps,
+            )
+        except ValidationError as exc:
+            error_message = _format_validation_error(exc)
+        except ValueError as exc:
+            error_message = str(exc)
+
+    if body is not None:
+        if mode == "new":
+            result = await _create_draft_from_form(session, slug=slug, body=body)
+        else:
+            result = await _edit_template_from_form(session, slug=slug, body=body)
+        if result.redirect_slug is not None and result.fork_notice is None:
+            # Plain success (new draft, or in-place draft edit) -> navigate to
+            # the resulting draft's detail page via the HTMX redirect header.
+            return Response(
+                status_code=204,
+                headers={"HX-Redirect": f"/ui/runbooks/{result.redirect_slug}"},
+            )
+        if result.redirect_slug is not None and result.fork_notice is not None:
+            # Fork success: stay open in edit mode against the new draft with
+            # the fork notice so the admin sees the source version + its
+            # in_flight_run_count straight from the PATCH response.
+            return _render_editor(
+                request,
+                session,
+                mode="edit",
+                slug=result.redirect_slug,
+                title=title,
+                description=description,
+                target_kind=target_kind,
+                raw_steps=raw_steps,
+                fork_notice=result.fork_notice,
+            )
+        error_message = result.error_message
+
+    return _render_editor(
+        request,
+        session,
+        mode=mode,
+        slug=slug,
+        title=title,
+        description=description,
+        target_kind=target_kind,
+        raw_steps=raw_steps,
+        status_code=422,
+        error_message=error_message or "validation failed",
+    )

--- a/backend/src/meho_backplane/ui/routes/runbooks/editor_routes.py
+++ b/backend/src/meho_backplane/ui/routes/runbooks/editor_routes.py
@@ -1,0 +1,209 @@
+# SPDX-License-Identifier: Apache-2.0
+# Copyright (c) 2026 evoila Group
+
+"""Runbooks UI authoring editor: FastAPI route wiring.
+
+Initiative #1381 (G10.6 Runbooks UI), Task #1383 (T2). The route layer for
+the ``tenant_admin`` authoring surface -- the thin FastAPI registration that
+maps the editor URLs to the form-handling logic in
+:mod:`meho_backplane.ui.routes.runbooks.editor`. Split from that module so
+neither file crosses the code-quality size gate (this file is wiring; the
+other is form (de)serialisation + service calls).
+
+Route inventory (all ``require_ui_admin``-gated):
+
+* ``GET  /ui/runbooks/new``          -- render the blank-draft editor.
+* ``POST /ui/runbooks/new``          -- create a draft (mirrors REST POST).
+* ``POST /ui/runbooks/preview``      -- HTMX Markdown live-preview partial.
+* ``GET  /ui/runbooks/{slug}/edit``  -- render the editor pre-loaded.
+* ``POST /ui/runbooks/{slug}/edit``  -- edit-in-place / fork (mirrors REST PATCH).
+
+The literal ``new`` / ``preview`` segments are registered BEFORE the catalog
+factory's ``/ui/runbooks/{slug}`` route (FastAPI is first-match-wins), so
+:func:`register_editor_routes` is called from
+:func:`meho_backplane.ui.routes.runbooks.routes.build_runbooks_router` ahead
+of that catch-all.
+"""
+
+from __future__ import annotations
+
+from typing import Final
+
+from fastapi import APIRouter, Depends, Form, HTTPException, Request
+from fastapi.responses import HTMLResponse, Response
+
+from meho_backplane.runbooks.service import (
+    RunbookTemplateService,
+    TemplateNotFoundError,
+)
+from meho_backplane.ui.auth.middleware import UISessionContext, require_ui_admin
+from meho_backplane.ui.csrf import mint_csrf_token
+from meho_backplane.ui.routes.kb.render import pygments_css, render_markdown
+from meho_backplane.ui.routes.runbooks.editor import (
+    build_editor_context,
+    empty_step,
+    handle_editor_submit,
+    set_csrf_cookie,
+    template_to_form_steps,
+)
+from meho_backplane.ui.templating import get_templates
+
+__all__ = ["register_editor_routes"]
+
+#: Module-level ``Depends`` closure for the ``tenant_admin`` gate every
+#: authoring route requires (B008 idiom -- no call in a default arg).
+#: ``require_ui_admin`` chains ``require_ui_session`` and re-verifies the
+#: session's access token to read the role claim, raising 403 for
+#: ``operator`` / ``read_only``. The server is the single source of truth for
+#: the authoring privilege; the client-side toggles are convenience only.
+_require_admin = Depends(require_ui_admin)
+
+#: Cap on the editor ``steps`` form payload (the JSON-serialised step tree).
+#: A runbook template is a handful of steps with Markdown bodies; 256 KiB is
+#: generous headroom while keeping the form parse bounded. The server-side
+#: Pydantic validation is the real contract; this cap only guards against an
+#: unbounded form submission before parsing.
+_MAX_EDITOR_PAYLOAD_LENGTH: Final[int] = 256 * 1024
+
+#: Cap on the live-preview ``body`` field (one step's Markdown body). Matches
+#: the KB editor-preview cap so the same renderer sees the same ceiling.
+_MAX_PREVIEW_BODY_LENGTH: Final[int] = 65_536
+
+
+def _render_new_editor(request: Request, session: UISessionContext) -> HTMLResponse:
+    """Render the editor for a brand-new draft (one blank manual+confirm step).
+
+    Mints a fresh CSRF token + sets the cookie so the Alpine-driven form can
+    echo it in ``X-CSRF-Token`` on the preview + save requests.
+    """
+    csrf_token = mint_csrf_token(str(session.session_id))
+    context = build_editor_context(
+        session,
+        mode="new",
+        slug="",
+        title="",
+        description="",
+        target_kind="",
+        form_steps=[empty_step()],
+        csrf_token=csrf_token,
+    )
+    response = get_templates().TemplateResponse(request, "runbooks/editor.html", context)
+    set_csrf_cookie(response, csrf_token)
+    return response
+
+
+async def _render_edit_editor(
+    request: Request, session: UISessionContext, slug: str
+) -> HTMLResponse:
+    """Render the editor pre-loaded with an existing template's latest version.
+
+    Loads the latest version via the service and flattens its steps into the
+    editor's form shape. A missing / cross-tenant slug 404s (the service's
+    tenant filter makes another tenant's row invisible).
+    """
+    try:
+        template = await RunbookTemplateService().show_template(session.tenant_id, slug)
+    except TemplateNotFoundError as exc:
+        raise HTTPException(status_code=404, detail="runbook_template_not_found") from exc
+    csrf_token = mint_csrf_token(str(session.session_id))
+    context = build_editor_context(
+        session,
+        mode="edit",
+        slug=template.slug,
+        title=template.title,
+        description=template.description,
+        target_kind=template.target_kind or "",
+        form_steps=template_to_form_steps(template),
+        csrf_token=csrf_token,
+    )
+    response = get_templates().TemplateResponse(request, "runbooks/editor.html", context)
+    set_csrf_cookie(response, csrf_token)
+    return response
+
+
+def register_editor_routes(router: APIRouter) -> None:
+    """Register the ``require_ui_admin``-gated authoring routes on *router*.
+
+    The T2 (#1383) editor surface: the editor GET pages (``/ui/runbooks/new``
+    + ``/ui/runbooks/{slug}/edit``), the draft/edit POST handlers, and the
+    Markdown live-preview POST (``/ui/runbooks/preview``). Called by
+    :func:`meho_backplane.ui.routes.runbooks.routes.build_runbooks_router`
+    after the read routes so the literal ``new`` / ``preview`` segments are
+    registered BEFORE ``/ui/runbooks/{slug}`` (FastAPI is first-match-wins).
+    Every route declares ``_require_admin``: the server is the single source of
+    truth for the authoring privilege; an ``operator`` gets 403 at the
+    dependency, before the handler body runs. The route bodies are thin
+    delegations to the helpers above + in ``runbooks.editor``.
+    """
+
+    @router.get("/ui/runbooks/new", response_class=HTMLResponse)
+    async def runbooks_editor_new(
+        request: Request,
+        session: UISessionContext = _require_admin,
+    ) -> HTMLResponse:
+        """Render the authoring editor for a brand-new draft template."""
+        return _render_new_editor(request, session)
+
+    @router.post("/ui/runbooks/new", response_class=HTMLResponse)
+    async def runbooks_editor_create(
+        request: Request,
+        session: UISessionContext = _require_admin,
+        slug: str = Form(default=""),
+        title: str = Form(default=""),
+        description: str = Form(default=""),
+        target_kind: str = Form(default=""),
+        steps: str = Form(default="[]", max_length=_MAX_EDITOR_PAYLOAD_LENGTH),
+    ) -> Response:
+        """Create a new draft from the editor form (mirrors REST POST)."""
+        return await handle_editor_submit(
+            request,
+            session,
+            mode="new",
+            slug=slug.strip(),
+            title=title,
+            description=description,
+            target_kind=target_kind,
+            steps_json=steps,
+        )
+
+    @router.post("/ui/runbooks/preview", response_class=HTMLResponse)
+    async def runbooks_editor_preview(
+        request: Request,
+        session: UISessionContext = _require_admin,
+        body: str = Form(default="", max_length=_MAX_PREVIEW_BODY_LENGTH),
+    ) -> HTMLResponse:
+        """HTMX live-preview partial for a step's Markdown ``body`` (admin only)."""
+        rendered_body = render_markdown(body)
+        context = {"rendered_body": rendered_body, "code_css": pygments_css()}
+        return get_templates().TemplateResponse(request, "runbooks/_editor_preview.html", context)
+
+    @router.get("/ui/runbooks/{slug}/edit", response_class=HTMLResponse)
+    async def runbooks_editor_edit(
+        slug: str,
+        request: Request,
+        session: UISessionContext = _require_admin,
+    ) -> HTMLResponse:
+        """Render the authoring editor pre-loaded with an existing template."""
+        return await _render_edit_editor(request, session, slug)
+
+    @router.post("/ui/runbooks/{slug}/edit", response_class=HTMLResponse)
+    async def runbooks_editor_update(
+        slug: str,
+        request: Request,
+        session: UISessionContext = _require_admin,
+        title: str = Form(default=""),
+        description: str = Form(default=""),
+        target_kind: str = Form(default=""),
+        steps: str = Form(default="[]", max_length=_MAX_EDITOR_PAYLOAD_LENGTH),
+    ) -> Response:
+        """Edit a draft in place / fork from published (mirrors REST PATCH)."""
+        return await handle_editor_submit(
+            request,
+            session,
+            mode="edit",
+            slug=slug.strip(),
+            title=title,
+            description=description,
+            target_kind=target_kind,
+            steps_json=steps,
+        )

--- a/backend/src/meho_backplane/ui/routes/runbooks/routes.py
+++ b/backend/src/meho_backplane/ui/routes/runbooks/routes.py
@@ -111,6 +111,7 @@ from meho_backplane.ui.auth.middleware import UISessionContext, require_ui_sessi
 from meho_backplane.ui.auth.session_store import load_session
 from meho_backplane.ui.csrf import CSRF_COOKIE_NAME, mint_csrf_token
 from meho_backplane.ui.routes.kb.render import pygments_css, render_markdown
+from meho_backplane.ui.routes.runbooks.editor_routes import register_editor_routes
 from meho_backplane.ui.templating import get_templates
 
 __all__ = ["build_runbooks_router"]
@@ -368,6 +369,14 @@ def build_runbooks_router() -> APIRouter:
         target_kind: str | None = Query(default=None, max_length=_MAX_TARGET_KIND_LENGTH),
     ) -> HTMLResponse:
         return await _render_list_fragment(request, session, status, target_kind)
+
+    # The T2 (#1383) authoring routes (``/ui/runbooks/new`` GET/POST +
+    # ``/ui/runbooks/preview`` POST + ``/ui/runbooks/{slug}/edit`` GET/POST)
+    # are registered here -- BEFORE ``/ui/runbooks/{slug}`` so FastAPI's
+    # first-match-wins routing does not swallow the literal ``new`` /
+    # ``preview`` segments as slug parameters. Their handlers + the form
+    # (de)serialisation live in ``runbooks.editor``.
+    register_editor_routes(router)
 
     @router.get("/ui/runbooks/{slug}", response_class=HTMLResponse)
     async def runbooks_detail(

--- a/backend/src/meho_backplane/ui/templates/runbooks/_editor_preview.html
+++ b/backend/src/meho_backplane/ui/templates/runbooks/_editor_preview.html
@@ -1,0 +1,34 @@
+{#-
+  SPDX-License-Identifier: Apache-2.0
+  Copyright (c) 2026 evoila Group
+
+  Runbooks editor live-preview partial.
+
+  Initiative #1381 (G10.6 Runbooks UI), Task #1383 (T2). Swapped into the
+  active step's ``.runbook-step-preview`` target by the hidden body
+  textarea's ``hx-trigger="input changed delay:500ms"`` listener. Reuses the
+  same shared KB Markdown renderer (and pygments CSS) the read surface uses so
+  the preview is byte-identical to the rendered step on the detail page.
+
+  Context variables:
+    rendered_body  -- Markup: server-rendered Markdown HTML
+    code_css       -- str: pygments CSS for the shared code formatter
+
+  The CSS is injected inline here (not in the parent template's
+  ``{% block scripts %}``) so the preview fragment is self-contained when
+  returned as an HTMX swap -- the parent's scripts block is not re-executed
+  on partial swaps.
+-#}
+<style>
+{{ code_css | safe }}
+
+pre.kb-code {
+  background: var(--b2, #e5e7eb);
+  border-radius: 0.375rem;
+  padding: 0.75rem;
+  overflow-x: auto;
+  font-size: 0.85em;
+  line-height: 1.5;
+}
+</style>
+{{ rendered_body }}

--- a/backend/src/meho_backplane/ui/templates/runbooks/_step_fields.html
+++ b/backend/src/meho_backplane/ui/templates/runbooks/_step_fields.html
@@ -1,0 +1,189 @@
+{#-
+  SPDX-License-Identifier: Apache-2.0
+  Copyright (c) 2026 evoila Group
+
+  Runbooks editor — one repeatable step's fields.
+
+  Initiative #1381 (G10.6 Runbooks UI), Task #1383 (T2). Rendered inside the
+  Alpine ``<template x-for="(step, idx) in steps">`` loop in ``editor.html``;
+  every binding here addresses the loop-local ``step`` object, so the whole
+  step tree lives in one Alpine model and is JSON-serialised into the hidden
+  ``steps`` form field on submit.
+
+  Discriminated-union toggles:
+    * ``step.type`` (manual / operation_call) — the ``operation_call`` block
+      (op_id + params) shows only when ``step.type === 'operation_call'``.
+    * ``step.verify.type`` (confirm / operation_call) — the confirm prompt vs
+      the operation_call op_id/params/expect block toggles on the verify type.
+
+  Body editor:
+    * Each step's ``body`` binds a textarea that CodeMirror 6 enhances on
+      mount (see the init script in ``editor.html``). The textarea carries a
+      debounced ``hx-post="/ui/runbooks/preview"`` that swaps the sibling
+      ``.runbook-step-preview`` pane with the server-rendered Markdown.
+
+  Client-side validation is convenience (the server re-validates everything):
+    * step id pattern ``^[a-z][a-z0-9\-]{0,63}$`` via the ``pattern`` attr +
+      an Alpine-computed duplicate/empty hint.
+-#}
+<div class="card bg-base-100 border-base-300 border shadow-sm" role="group"
+     x-bind:aria-label="'Step ' + (idx + 1)">
+  <div class="card-body space-y-3 py-4">
+    {# ----- Step header: index + remove/reorder ----- #}
+    <div class="flex flex-wrap items-center gap-2">
+      <span class="badge badge-neutral" x-text="idx + 1"></span>
+      <span class="text-sm font-medium opacity-60">Step</span>
+      <div class="ml-auto flex gap-1">
+        <button type="button" class="btn btn-ghost btn-xs"
+                x-bind:disabled="idx === 0"
+                x-on:click="moveStep(idx, -1)"
+                aria-label="Move step up">&uarr;</button>
+        <button type="button" class="btn btn-ghost btn-xs"
+                x-bind:disabled="idx === steps.length - 1"
+                x-on:click="moveStep(idx, 1)"
+                aria-label="Move step down">&darr;</button>
+        <button type="button" class="btn btn-ghost btn-xs text-error"
+                x-bind:disabled="steps.length === 1"
+                x-on:click="removeStep(idx)"
+                aria-label="Remove step">&times;</button>
+      </div>
+    </div>
+
+    {# ----- Step id + type ----- #}
+    <div class="flex flex-wrap gap-4">
+      <label class="form-control flex-1 min-w-48">
+        <div class="label py-0">
+          <span class="label-text font-medium">Step id</span>
+          <span class="label-text-alt opacity-60">lowercase, hyphens, unique</span>
+        </div>
+        <input type="text" class="input input-bordered input-sm font-mono"
+               x-model="step.id"
+               pattern="[a-z][a-z0-9\-]{0,63}"
+               placeholder="drain-node"
+               autocomplete="off"
+               x-bind:aria-label="'Step ' + (idx + 1) + ' id'" />
+        <div class="label py-0" x-show="stepIdError(idx)">
+          <span class="label-text-alt text-error" x-text="stepIdError(idx)"></span>
+        </div>
+      </label>
+      <label class="form-control min-w-48">
+        <div class="label py-0">
+          <span class="label-text font-medium">Type</span>
+        </div>
+        <select class="select select-bordered select-sm" x-model="step.type"
+                x-bind:aria-label="'Step ' + (idx + 1) + ' type'">
+          <option value="manual">manual</option>
+          <option value="operation_call">operation_call</option>
+        </select>
+      </label>
+    </div>
+
+    {# ----- Step title ----- #}
+    <label class="form-control">
+      <div class="label py-0"><span class="label-text font-medium">Title</span></div>
+      <input type="text" class="input input-bordered input-sm"
+             x-model="step.title" placeholder="Drain the node" autocomplete="off"
+             x-bind:aria-label="'Step ' + (idx + 1) + ' title'" />
+    </label>
+
+    {# ----- operation_call: op_id + params ----- #}
+    <div x-show="step.type === 'operation_call'" x-cloak class="space-y-3">
+      <label class="form-control">
+        <div class="label py-0">
+          <span class="label-text font-medium">Operation id</span>
+          <span class="label-text-alt opacity-60">registry op_id (free text)</span>
+        </div>
+        <input type="text" class="input input-bordered input-sm font-mono"
+               x-model="step.op_id" placeholder="vmware.composite.vm.create"
+               autocomplete="off"
+               x-bind:aria-label="'Step ' + (idx + 1) + ' operation id'" />
+      </label>
+      <label class="form-control">
+        <div class="label py-0">
+          <span class="label-text font-medium">Params (JSON)</span>
+          <span class="label-text-alt opacity-60">${run.target} / ${run.params.X} only</span>
+        </div>
+        <textarea class="textarea textarea-bordered textarea-sm font-mono" rows="3"
+                  x-model="step.params" placeholder="{}"
+                  x-bind:aria-label="'Step ' + (idx + 1) + ' params'"></textarea>
+      </label>
+    </div>
+
+    {# ----- Body editor + live preview (CodeMirror + HTMX) ----- #}
+    <div class="flex flex-wrap gap-4">
+      <div class="flex-1 min-w-64 space-y-1">
+        <div class="text-xs font-medium uppercase tracking-wide opacity-60">Body (Markdown)</div>
+        {# CodeMirror mounts onto this textarea; the textarea stays the
+           form-model source (x-model) and the HTMX preview trigger. #}
+        <textarea class="textarea textarea-bordered textarea-sm font-mono w-full runbook-step-body"
+                  rows="6"
+                  x-model="step.body"
+                  x-bind:data-step-index="idx"
+                  hx-post="/ui/runbooks/preview"
+                  hx-trigger="input changed delay:500ms"
+                  hx-target="closest .flex-wrap >> .runbook-step-preview"
+                  hx-swap="innerHTML"
+                  hx-vals='js:{body: event.target.value}'
+                  hx-headers='{"X-CSRF-Token": "{{ csrf_token | default('') }}"}'
+                  x-bind:aria-label="'Step ' + (idx + 1) + ' body'"></textarea>
+      </div>
+      <div class="flex-1 min-w-64 space-y-1">
+        <div class="text-xs font-medium uppercase tracking-wide opacity-60">Preview</div>
+        <div class="runbook-step-preview prose prose-sm max-w-none border-base-300 rounded-box border p-3 min-h-24"
+             aria-live="polite" x-bind:aria-label="'Step ' + (idx + 1) + ' preview'">
+          <p class="opacity-40 text-sm">Start typing to see a preview&hellip;</p>
+        </div>
+      </div>
+    </div>
+
+    {# ----- Verify gate ----- #}
+    <div class="border-base-300 border-t pt-3 space-y-3">
+      <div class="flex flex-wrap items-end gap-4">
+        <p class="text-xs font-semibold uppercase tracking-wide opacity-60">Verify</p>
+        <label class="form-control min-w-48">
+          <select class="select select-bordered select-sm" x-model="step.verify.type"
+                  x-bind:aria-label="'Step ' + (idx + 1) + ' verify type'">
+            <option value="confirm">confirm</option>
+            <option value="operation_call">operation_call</option>
+          </select>
+        </label>
+      </div>
+
+      {# confirm: a single prompt #}
+      <label class="form-control" x-show="step.verify.type === 'confirm'">
+        <div class="label py-0"><span class="label-text font-medium">Prompt</span></div>
+        <input type="text" class="input input-bordered input-sm"
+               x-model="step.verify.prompt" placeholder="Node drained?" autocomplete="off"
+               x-bind:aria-label="'Step ' + (idx + 1) + ' verify prompt'" />
+      </label>
+
+      {# operation_call: op_id + params + expect #}
+      <div x-show="step.verify.type === 'operation_call'" x-cloak class="space-y-3">
+        <label class="form-control">
+          <div class="label py-0"><span class="label-text font-medium">Operation id</span></div>
+          <input type="text" class="input input-bordered input-sm font-mono"
+                 x-model="step.verify.op_id" placeholder="vmware.cert.status"
+                 autocomplete="off"
+                 x-bind:aria-label="'Step ' + (idx + 1) + ' verify operation id'" />
+        </label>
+        <label class="form-control">
+          <div class="label py-0">
+            <span class="label-text font-medium">Params (JSON)</span>
+          </div>
+          <textarea class="textarea textarea-bordered textarea-sm font-mono" rows="2"
+                    x-model="step.verify.params" placeholder="{}"
+                    x-bind:aria-label="'Step ' + (idx + 1) + ' verify params'"></textarea>
+        </label>
+        <label class="form-control">
+          <div class="label py-0">
+            <span class="label-text font-medium">Expect (JSON)</span>
+            <span class="label-text-alt opacity-60">structural-equality match</span>
+          </div>
+          <textarea class="textarea textarea-bordered textarea-sm font-mono" rows="2"
+                    x-model="step.verify.expect" placeholder="{}"
+                    x-bind:aria-label="'Step ' + (idx + 1) + ' verify expect'"></textarea>
+        </label>
+      </div>
+    </div>
+  </div>
+</div>

--- a/backend/src/meho_backplane/ui/templates/runbooks/detail.html
+++ b/backend/src/meho_backplane/ui/templates/runbooks/detail.html
@@ -48,6 +48,17 @@
           deprecated
         </span>
       {% endif %}
+      {# Authoring entry point — tenant_admin only (the POST handler also gates
+         server-side). Editing a published template forks a new draft. #}
+      {% if is_admin %}
+        <a
+          href="/ui/runbooks/{{ template.slug }}/edit"
+          class="btn btn-outline btn-sm ml-auto"
+          aria-label="Edit template {{ template.slug }}"
+        >
+          Edit
+        </a>
+      {% endif %}
     </div>
     {% if not restricted %}
       <p class="text-lg">{{ template.title }}</p>

--- a/backend/src/meho_backplane/ui/templates/runbooks/editor.html
+++ b/backend/src/meho_backplane/ui/templates/runbooks/editor.html
@@ -1,0 +1,400 @@
+{#-
+  SPDX-License-Identifier: Apache-2.0
+  Copyright (c) 2026 evoila Group
+
+  Runbooks authoring editor: draft + edit a runbook template.
+
+  Initiative #1381 (G10.6 Runbooks UI), Task #1383 (T2). The tenant_admin
+  authoring surface — a structured, repeatable step editor that builds a
+  valid RunbookTemplateBody and POSTs it to /ui/runbooks/new (create) or
+  /ui/runbooks/{slug}/edit (edit/fork). The handler calls the same service
+  the REST surface uses; client-side validation here is convenience, the
+  server is the source of truth.
+
+  Alpine model:
+    * Top-level fields: slug (new only), title, description, target_kind.
+    * steps[]: the discriminated-union step tree, hydrated from
+      ``initial_steps_json`` (one blank step on a fresh new; the existing
+      steps on an edit). Add / remove / reorder mutate this array.
+    * On submit, the whole step tree is JSON-serialised into the hidden
+      ``steps`` form field so the union shape survives the round-trip; the
+      params/expect JSON textareas are passed through as raw strings and
+      parsed server-side.
+
+  CodeMirror 6 + HTMX preview: see ``_step_fields.html`` (each step's body
+  textarea is CM-enhanced and carries a debounced HTMX preview POST). The CM
+  bundle + the per-step init script are loaded in ``{% block scripts %}``.
+
+  CSRF: the submit form + every step's preview POST echo ``X-CSRF-Token`` via
+  ``hx-headers``; the token is minted on render (cookie set) and re-minted on
+  every error / fork re-render so subsequent HTMX calls carry a live token.
+
+  Context variables:
+    mode              -- "new" | "edit"
+    slug              -- str (locked on edit; the model's slug on new)
+    title/description/target_kind -- str: prefilled top-level fields
+    initial_steps_json -- str: JSON array hydrating the Alpine ``steps`` model
+    submit_url        -- str: POST target (/ui/runbooks/new | .../{slug}/edit)
+    submit_label      -- str: button label
+    error_message     -- str | None: inline error banner copy
+    fork_notice       -- dict | None: {slug, source_version, new_version,
+                         in_flight_run_count} surfaced after a fork-on-edit
+    csrf_token        -- str
+-#}
+{% extends "base.html" %}
+
+{% block page_title %}{{ page_title }} &middot; MEHO Operator Console{% endblock %}
+
+{% block content %}
+<section
+  class="space-y-4"
+  x-data="runbookEditor({
+    mode: '{{ mode }}',
+    initialSteps: {{ initial_steps_json | safe }},
+    slug: {{ slug | tojson }},
+    title: {{ title | tojson }},
+    description: {{ description | tojson }},
+    targetKind: {{ target_kind | tojson }}
+  })"
+>
+  {# ---------- Header ---------- #}
+  <header class="flex flex-wrap items-center justify-between gap-4">
+    <div class="flex items-center gap-3">
+      <a href="/ui/runbooks" class="btn btn-ghost btn-sm" aria-label="Back to runbooks catalog">
+        &larr; Catalog
+      </a>
+      <h1 class="text-2xl font-semibold">
+        {% if mode == "edit" %}Edit <span class="font-mono">{{ slug }}</span>{% else %}New runbook{% endif %}
+      </h1>
+    </div>
+  </header>
+
+  {# ---------- Error banner ---------- #}
+  {% if error_message %}
+  <div role="alert" class="alert alert-error text-sm" aria-live="assertive">
+    <span>{{ error_message }}</span>
+  </div>
+  {% endif %}
+
+  {# ---------- Fork notice (edit of a published template forked a draft) ---------- #}
+  {% if fork_notice %}
+  <div role="status" class="alert alert-info text-sm" aria-live="polite">
+    <div>
+      <p class="font-semibold">Forked a new draft</p>
+      <p>
+        Editing the published template forked a new draft
+        (<span class="font-mono">v{{ fork_notice.new_version }}</span>) from
+        <span class="font-mono">{{ fork_notice.slug }} v{{ fork_notice.source_version }}</span>.
+        That source version still has
+        <strong>{{ fork_notice.in_flight_run_count }}</strong>
+        in-flight run{{ "" if fork_notice.in_flight_run_count == 1 else "s" }}.
+      </p>
+    </div>
+  </div>
+  {% endif %}
+
+  {# ---------- Client-side validation summary ---------- #}
+  <div role="alert" class="alert alert-warning text-sm" x-show="validationErrors().length > 0"
+       x-cloak aria-live="polite">
+    <ul class="list-disc pl-4">
+      <template x-for="err in validationErrors()" x-bind:key="err">
+        <li x-text="err"></li>
+      </template>
+    </ul>
+  </div>
+
+  {# ---------- Form ---------- #}
+  <form
+    id="runbook-editor-form"
+    hx-post="{{ submit_url }}"
+    hx-target="#runbook-editor-form"
+    hx-swap="none"
+    hx-headers='{"X-CSRF-Token": "{{ csrf_token | default('') }}"}'
+    x-on:submit="syncSteps()"
+    x-bind:hx-disabled-elt="validationErrors().length > 0 ? 'find button[type=submit]' : null"
+  >
+    {# Top-level fields #}
+    <div class="card bg-base-100 border-base-300 border shadow-sm">
+      <div class="card-body space-y-3 py-4">
+        {% if mode == "new" %}
+        <label class="form-control">
+          <div class="label py-0">
+            <span class="label-text font-medium">Slug</span>
+            <span class="label-text-alt opacity-60">lowercase, dots/hyphens, required</span>
+          </div>
+          <input type="text" name="slug" class="input input-bordered input-sm font-mono"
+                 x-model="slug" pattern="[a-z]([a-z0-9.\-]*[a-z0-9])?"
+                 placeholder="rotate-cluster-cert" autocomplete="off" required
+                 aria-label="Template slug" />
+          <div class="label py-0" x-show="slugError()">
+            <span class="label-text-alt text-error" x-text="slugError()"></span>
+          </div>
+        </label>
+        {% else %}
+        {# Slug is locked on edit — the path is the source of truth. #}
+        <input type="hidden" name="slug" value="{{ slug }}" />
+        {% endif %}
+
+        <label class="form-control">
+          <div class="label py-0"><span class="label-text font-medium">Title</span></div>
+          <input type="text" name="title" class="input input-bordered input-sm"
+                 x-model="title" placeholder="Rotate the cluster certificate"
+                 autocomplete="off" required aria-label="Template title" />
+        </label>
+
+        <label class="form-control">
+          <div class="label py-0"><span class="label-text font-medium">Description</span></div>
+          <textarea name="description" class="textarea textarea-bordered textarea-sm" rows="2"
+                    x-model="description" placeholder="What this runbook does and when to run it."
+                    required aria-label="Template description"></textarea>
+        </label>
+
+        <label class="form-control max-w-md">
+          <div class="label py-0">
+            <span class="label-text font-medium">Target kind</span>
+            <span class="label-text-alt opacity-60">optional</span>
+          </div>
+          <input type="text" name="target_kind" class="input input-bordered input-sm font-mono"
+                 x-model="targetKind" placeholder="vmware.vcenter" autocomplete="off"
+                 aria-label="Template target kind" />
+        </label>
+      </div>
+    </div>
+
+    {# Hidden serialised step tree — populated on submit by syncSteps(). #}
+    <input type="hidden" name="steps" x-model="stepsJson" />
+
+    {# Steps #}
+    <div class="space-y-4 mt-4">
+      <div class="flex items-center justify-between">
+        <h2 class="text-xl font-semibold">
+          Steps <span class="text-sm font-normal opacity-60" x-text="'(' + steps.length + ')'"></span>
+        </h2>
+        <button type="button" class="btn btn-outline btn-sm" x-on:click="addStep()">
+          + Add step
+        </button>
+      </div>
+
+      <template x-for="(step, idx) in steps" x-bind:key="idx">
+        {% include "runbooks/_step_fields.html" %}
+      </template>
+    </div>
+
+    {# Actions #}
+    <div class="flex items-center justify-end gap-3 mt-4">
+      <a href="/ui/runbooks" class="btn btn-ghost btn-sm">Cancel</a>
+      <button type="submit" class="btn btn-primary btn-sm">{{ submit_label }}</button>
+    </div>
+  </form>
+</section>
+{% endblock %}
+
+{% block scripts %}
+{#-
+  CodeMirror 6 IIFE bundle (vendored, SHA256-pinned in VENDOR.md) exposing the
+  ``CM`` global: CM.EditorView, CM.EditorState, CM.basicSetup, CM.markdown,
+  CM.keymap, CM.defaultKeymap, CM.historyKeymap, CM.indentWithTab. Same wiring
+  as the KB editor (#872). Alpine is loaded globally by base.html.
+-#}
+<script src="/ui/static/src/vendor/codemirror-bundle.min.js" defer></script>
+<script defer>
+(function () {
+  "use strict";
+
+  // ----- Alpine model factory -----
+  // Registered before Alpine initialises (alpine:init) so the x-data
+  // ``runbookEditor(...)`` call in the template resolves. The component owns
+  // the discriminated-union step tree and serialises it on submit.
+  document.addEventListener("alpine:init", function () {
+    window.Alpine.data("runbookEditor", function (cfg) {
+      return {
+        mode: cfg.mode,
+        slug: cfg.slug || "",
+        title: cfg.title || "",
+        description: cfg.description || "",
+        targetKind: cfg.targetKind || "",
+        steps: cfg.initialSteps && cfg.initialSteps.length ? cfg.initialSteps : [blankStep()],
+        stepsJson: "[]",
+
+        addStep() {
+          this.steps.push(blankStep());
+        },
+        removeStep(idx) {
+          if (this.steps.length > 1) {
+            this.steps.splice(idx, 1);
+          }
+        },
+        moveStep(idx, delta) {
+          var target = idx + delta;
+          if (target < 0 || target >= this.steps.length) {
+            return;
+          }
+          var moved = this.steps.splice(idx, 1)[0];
+          this.steps.splice(target, 0, moved);
+        },
+
+        // Serialise the step tree into the hidden form field. Called on
+        // submit so the POST carries the full discriminated-union shape.
+        syncSteps() {
+          this.stepsJson = JSON.stringify(this.steps);
+        },
+
+        // ---- Client-side validation (convenience; server re-validates) ----
+        slugError() {
+          if (this.mode !== "new") {
+            return "";
+          }
+          var s = (this.slug || "").trim();
+          if (!s) {
+            return "Slug is required.";
+          }
+          if (!/^[a-z](?:[a-z0-9.\-]*[a-z0-9])?$/.test(s)) {
+            return "Slug must be lowercase letters/digits/dots/hyphens.";
+          }
+          return "";
+        },
+        stepIdError(idx) {
+          var id = (this.steps[idx].id || "").trim();
+          if (!id) {
+            return "Step id is required.";
+          }
+          if (!/^[a-z][a-z0-9\-]{0,63}$/.test(id)) {
+            return "Lowercase letters, digits, hyphens (no dots), ≤64 chars.";
+          }
+          for (var i = 0; i < this.steps.length; i++) {
+            if (i !== idx && (this.steps[i].id || "").trim() === id) {
+              return "Duplicate step id.";
+            }
+          }
+          return "";
+        },
+        validationErrors() {
+          var errs = [];
+          var slugErr = this.slugError();
+          if (slugErr) {
+            errs.push(slugErr);
+          }
+          if (!(this.title || "").trim()) {
+            errs.push("Title is required.");
+          }
+          if (!(this.description || "").trim()) {
+            errs.push("Description is required.");
+          }
+          if (!this.steps.length) {
+            errs.push("A runbook needs at least one step.");
+          }
+          for (var i = 0; i < this.steps.length; i++) {
+            var idErr = this.stepIdError(i);
+            if (idErr) {
+              errs.push("Step " + (i + 1) + ": " + idErr);
+            }
+            collectSubstitutionErrors(this.steps[i], i, errs);
+          }
+          return errs;
+        },
+      };
+    });
+  });
+
+  function blankStep() {
+    return {
+      id: "",
+      title: "",
+      body: "",
+      type: "manual",
+      op_id: "",
+      params: "{}",
+      verify: { type: "confirm", prompt: "", op_id: "", params: "{}", expect: "{}" },
+    };
+  }
+
+  // The substitution allowlist mirrors the server's validate_substitutions:
+  // only ${run.target} and ${run.params.X} (X = [a-z_][a-z0-9_]*) are legal.
+  var SUBST = /\$\{([^}]*)\}/g;
+  var PARAM = /^run\.params\.[a-z_][a-z0-9_]*$/;
+  function collectSubstitutionErrors(step, idx, errs) {
+    var strings = [step.body || ""];
+    if (step.type === "operation_call") {
+      strings.push(step.params || "");
+    }
+    if (step.verify && step.verify.type === "operation_call") {
+      strings.push(step.verify.params || "", step.verify.expect || "");
+    }
+    for (var s = 0; s < strings.length; s++) {
+      var m;
+      SUBST.lastIndex = 0;
+      while ((m = SUBST.exec(strings[s])) !== null) {
+        var inner = m[1];
+        if (inner !== "run.target" && !PARAM.test(inner)) {
+          errs.push("Step " + (idx + 1) + ": disallowed substitution " + m[0]);
+        }
+      }
+    }
+  }
+
+  // ----- CodeMirror enhancement of step body textareas -----
+  // Each ``.runbook-step-body`` textarea gets a CM 6 view mounted next to it;
+  // the textarea is hidden but stays the form/x-model source. CM writes the
+  // doc back into the textarea on every change and dispatches an ``input``
+  // event so both Alpine's x-model and the HTMX preview trigger fire — the
+  // same sync the KB editor uses.
+  function enhanceTextarea(ta) {
+    if (typeof CM === "undefined" || ta.dataset.cmMounted === "1") {
+      return;
+    }
+    ta.dataset.cmMounted = "1";
+    var holder = document.createElement("div");
+    holder.className = "border-base-300 rounded-box overflow-auto border font-mono text-sm";
+    ta.parentNode.insertBefore(holder, ta);
+    ta.classList.add("sr-only");
+    ta.setAttribute("tabindex", "-1");
+
+    var view = new CM.EditorView({
+      state: CM.EditorState.create({
+        doc: ta.value,
+        extensions: [
+          CM.basicSetup,
+          CM.markdown(),
+          CM.keymap.of([CM.indentWithTab].concat(CM.defaultKeymap, CM.historyKeymap)),
+          CM.EditorView.updateListener.of(function (update) {
+            if (update.docChanged) {
+              ta.value = update.state.doc.toString();
+              ta.dispatchEvent(new Event("input", { bubbles: true }));
+            }
+          }),
+        ],
+      }),
+      parent: holder,
+    });
+    ta._cmView = view;
+  }
+
+  function scanBodies() {
+    if (typeof CM === "undefined") {
+      return;
+    }
+    document.querySelectorAll(".runbook-step-body").forEach(enhanceTextarea);
+  }
+
+  // Initial scan once the DOM (and Alpine's x-for) has rendered, plus a
+  // rescan after HTMX settles new content and after Alpine adds a step.
+  function init() {
+    scanBodies();
+  }
+  if (document.readyState !== "loading") {
+    // base.html scripts are deferred, so the DOM is parsed; give Alpine a
+    // tick to render the x-for steps before the first scan.
+    setTimeout(init, 0);
+  } else {
+    document.addEventListener("DOMContentLoaded", function () { setTimeout(init, 0); });
+  }
+  document.body.addEventListener("htmx:afterSettle", scanBodies);
+  // Re-scan when a step is added/removed (Alpine re-renders the x-for).
+  document.addEventListener("click", function (e) {
+    if (e.target && e.target.closest && e.target.closest("#runbook-editor-form, [x-on\\:click]")) {
+      setTimeout(scanBodies, 0);
+    }
+  });
+})();
+</script>
+{% endblock %}

--- a/backend/src/meho_backplane/ui/templates/runbooks/index.html
+++ b/backend/src/meho_backplane/ui/templates/runbooks/index.html
@@ -38,6 +38,12 @@
         Browse the tenant's runbook templates and their lifecycle state.
       </p>
     </div>
+    {# Authoring entry point. The route is ``require_ui_admin``-gated, so an
+       operator who follows it gets a 403 from the server (the link is shown
+       to everyone — the server is the privilege boundary, not the markup). #}
+    <a href="/ui/runbooks/new" class="btn btn-primary btn-sm" aria-label="Author a new runbook template">
+      + New runbook
+    </a>
   </header>
 
   {# ---------- Filter bar ---------- #}

--- a/backend/tests/test_ui_runbooks_editor.py
+++ b/backend/tests/test_ui_runbooks_editor.py
@@ -1,0 +1,808 @@
+# SPDX-License-Identifier: Apache-2.0
+# Copyright (c) 2026 evoila Group
+
+"""Behavioural tests for the runbooks UI authoring editor.
+
+Initiative #1381 (G10.6 Runbooks UI), Task #1383 (T2). Acceptance criteria
+on issue #1383:
+
+* ``GET /ui/runbooks/new`` and ``/ui/runbooks/<slug>/edit`` return 200 for a
+  ``tenant_admin`` and 403 for an ``operator`` (server-enforced via
+  ``require_ui_admin``).
+* The form builds + submits a valid ``RunbookTemplateBody`` for both step
+  kinds and both verify-gate kinds; a manual step omits ``op_id``/``params``,
+  an operation_call step requires ``op_id``.
+* Client + server validation block a bad slug / bad/duplicate step id / a
+  disallowed ``${...}`` substitution; the server's 409 (duplicate) and 422
+  (validation) render as inline errors without losing entered data; CSRF is
+  re-minted on re-render.
+* Creating a draft round-trips: ``POST`` 204 ``HX-Redirect`` -> the detail
+  view shows the new draft (status ``draft``, version 1).
+* Editing a published template forks a new draft and the UI surfaces
+  ``forked_from`` + ``in_flight_run_count`` from the PATCH response.
+
+Suite shape mirrors :mod:`backend.tests.test_ui_runbooks_list` (the T1 read
+surface, #1382): a minimal FastAPI app wired with the BFF middlewares + the
+UI surface router, SQLite-backed seeding via the real
+:class:`~meho_backplane.runbooks.service.RunbookTemplateService`, a pre-set
+session cookie, and a real RSA-signed JWT for the ``tenant_admin`` role lift
+(the editor routes gate on ``require_ui_admin``, which re-verifies the
+session's access token). The ``operator`` path seeds a plaintext token so the
+admin gate's JWT decode fails -> 403.
+
+The CSRF middleware is active, so every state-changing POST carries the
+double-submit token via :func:`_csrf_kwargs` (the same token as both the
+``X-CSRF-Token`` header and an explicit request cookie -- the editor's
+``Secure`` CSRF cookie is not echoed by the plain-``http`` TestClient, so the
+token is minted directly, the pattern :mod:`backend.tests.test_ui_kb_upload`
+uses).
+"""
+
+from __future__ import annotations
+
+import asyncio
+import re
+import uuid
+import warnings
+from collections.abc import Iterator
+from datetime import UTC, datetime, timedelta
+from typing import Any
+
+import pytest
+import respx
+from cryptography.fernet import Fernet
+from fastapi import FastAPI
+from fastapi.staticfiles import StaticFiles
+from fastapi.testclient import TestClient
+
+from meho_backplane.auth.jwt import clear_jwks_cache
+from meho_backplane.auth.operator import TenantRole
+from meho_backplane.db.engine import get_sessionmaker, reset_engine_for_testing
+from meho_backplane.db.models import RunbookRun, Tenant
+from meho_backplane.runbooks.schemas import (
+    ConfirmVerify,
+    DraftTemplateRequest,
+    ManualStep,
+    PublishTemplateRequest,
+    RunbookTemplateBody,
+)
+from meho_backplane.runbooks.service import RunbookTemplateService
+from meho_backplane.settings import get_settings
+from meho_backplane.ui.auth import SESSION_COOKIE_NAME, UISessionMiddleware
+from meho_backplane.ui.auth import build_router as build_ui_auth_router
+from meho_backplane.ui.auth.flow import (
+    clear_discovery_cache,
+    reset_verifier_store_for_testing,
+)
+from meho_backplane.ui.auth.session_store import (
+    create_session,
+    reset_fernet_cache_for_testing,
+)
+from meho_backplane.ui.csrf import (
+    CSRF_COOKIE_NAME,
+    CSRF_HEADER_NAME,
+    CSRFMiddleware,
+    mint_csrf_token,
+)
+from meho_backplane.ui.paths import static_root_dir
+from meho_backplane.ui.routes import build_router as build_ui_router
+from meho_backplane.ui.templating import reset_templating_for_testing
+from tests._oidc_jwt_helpers import (
+    make_rsa_keypair as _make_rsa_keypair,
+)
+from tests._oidc_jwt_helpers import (
+    mint_token as _mint_token,
+)
+from tests._oidc_jwt_helpers import (
+    mock_discovery_and_jwks as _mock_discovery_and_jwks,
+)
+from tests._oidc_jwt_helpers import (
+    public_jwks as _public_jwks,
+)
+
+# ---------------------------------------------------------------------------
+# Constants
+# ---------------------------------------------------------------------------
+
+_BACKPLANE_URL = "https://meho.test"
+_DEFAULT_ISSUER = "https://keycloak.test/realms/meho"
+_DEFAULT_AUDIENCE = "meho-backplane"
+
+_TENANT_A = uuid.UUID("aaaaaaaa-aaaa-aaaa-aaaa-aaaaaaaaaaaa")
+
+_OPERATOR_SUB = "op-42"
+
+# ---------------------------------------------------------------------------
+# Fixtures
+# ---------------------------------------------------------------------------
+
+
+@pytest.fixture(autouse=True)
+def _bff_env(monkeypatch: pytest.MonkeyPatch) -> Iterator[None]:
+    """Pin chassis + BFF env vars for every test (T1-suite baseline)."""
+    monkeypatch.setenv("KEYCLOAK_ISSUER_URL", _DEFAULT_ISSUER)
+    monkeypatch.setenv("KEYCLOAK_AUDIENCE", _DEFAULT_AUDIENCE)
+    monkeypatch.setenv("VAULT_ADDR", "https://vault.test")
+    monkeypatch.setenv("BACKPLANE_URL", _BACKPLANE_URL)
+    monkeypatch.setenv("UI_SESSION_ENCRYPTION_KEY", Fernet.generate_key().decode())
+    monkeypatch.setenv("UI_KEYCLOAK_CLIENT_ID", "meho-web")
+    monkeypatch.setenv("UI_KEYCLOAK_CLIENT_SECRET", "test-client-secret")
+    get_settings.cache_clear()
+    reset_fernet_cache_for_testing()
+    reset_verifier_store_for_testing()
+    reset_templating_for_testing()
+    clear_discovery_cache()
+    clear_jwks_cache()
+    reset_engine_for_testing()
+    yield
+    get_settings.cache_clear()
+    reset_fernet_cache_for_testing()
+    reset_verifier_store_for_testing()
+    reset_templating_for_testing()
+    clear_discovery_cache()
+    clear_jwks_cache()
+    reset_engine_for_testing()
+
+
+# ---------------------------------------------------------------------------
+# Helpers
+# ---------------------------------------------------------------------------
+
+
+def _build_app() -> FastAPI:
+    """Minimal FastAPI app wired for runbooks UI tests (T1-suite shape)."""
+    app = FastAPI()
+    app.add_middleware(CSRFMiddleware)
+    app.add_middleware(UISessionMiddleware)
+    app.mount(
+        "/ui/static",
+        StaticFiles(directory=str(static_root_dir()), check_dir=False),
+        name="ui_static",
+    )
+    app.include_router(build_ui_auth_router())
+    app.include_router(build_ui_router())
+    return app
+
+
+def _seed_tenant(tenant_id: uuid.UUID, slug: str) -> None:
+    """Insert one ``tenant`` row so FK constraints resolve."""
+
+    async def _do() -> None:
+        sessionmaker = get_sessionmaker()
+        async with sessionmaker() as session, session.begin():
+            session.add(Tenant(id=tenant_id, slug=slug, name=f"Tenant {slug}"))
+
+    asyncio.run(_do())
+
+
+def _manual_body() -> RunbookTemplateBody:
+    """One manual step + confirm verify."""
+    return RunbookTemplateBody(
+        title="Drain node",
+        description="Procedure for draining a node.",
+        target_kind="k8s-node",
+        steps=[
+            ManualStep(
+                id="drain",
+                title="Drain the node",
+                body="Run the **drain** command.",
+                type="manual",
+                verify=ConfirmVerify(type="confirm", prompt="Node drained?"),
+            ),
+        ],
+    )
+
+
+def _seed_template(
+    *,
+    tenant_id: uuid.UUID,
+    slug: str,
+    body: RunbookTemplateBody | None = None,
+    publish: bool = False,
+) -> int:
+    """Create a draft template (optionally publishing it) and return its version."""
+    template_body = body if body is not None else _manual_body()
+
+    async def _do() -> int:
+        service = RunbookTemplateService()
+        resp = await service.create_draft(
+            tenant_id,
+            _OPERATOR_SUB,
+            DraftTemplateRequest(slug=slug, body=template_body),
+        )
+        if publish:
+            await service.publish(
+                tenant_id,
+                PublishTemplateRequest(slug=slug, version=resp.version),
+            )
+        return resp.version
+
+    return asyncio.run(_do())
+
+
+def _seed_run(
+    *,
+    tenant_id: uuid.UUID,
+    slug: str,
+    version: int,
+    state: str = "in_progress",
+) -> None:
+    """Insert one ``runbook_runs`` row pinned to ``(slug, version)``."""
+
+    async def _do() -> None:
+        sessionmaker = get_sessionmaker()
+        async with sessionmaker() as session:
+            session.add(
+                RunbookRun(
+                    tenant_id=tenant_id,
+                    template_slug=slug,
+                    template_version=version,
+                    assigned_to=_OPERATOR_SUB,
+                    target="host-1",
+                    params={},
+                    state=state,
+                    started_by=_OPERATOR_SUB,
+                    started_at=datetime.now(UTC),
+                )
+            )
+            await session.commit()
+
+    asyncio.run(_do())
+
+
+def _seed_session_sync(
+    *,
+    tenant_id: uuid.UUID,
+    access_token: str = "access-token-plaintext",
+    lifetime: timedelta = timedelta(hours=1),
+) -> uuid.UUID:
+    """Create a ``web_session`` row carrying *access_token* and return its UUID."""
+
+    async def _do() -> uuid.UUID:
+        sessionmaker = get_sessionmaker()
+        async with sessionmaker() as session, session.begin():
+            decrypted = await create_session(
+                session,
+                operator_sub=_OPERATOR_SUB,
+                tenant_id=tenant_id,
+                access_token=access_token,
+                refresh_token="refresh-token-plaintext",
+                lifetime=lifetime,
+            )
+            return decrypted.id
+
+    return asyncio.run(_do())
+
+
+def _authenticated_client(session_id: uuid.UUID) -> TestClient:
+    """Return a TestClient with the session cookie pre-set."""
+    client = TestClient(_build_app(), follow_redirects=False)
+    client.cookies.set(SESSION_COOKIE_NAME, str(session_id))
+    return client
+
+
+def _make_keypair_and_jwks() -> tuple[Any, dict[str, Any]]:
+    """Mint a stable RSA-2048 keypair + the matching JWKS document."""
+    with warnings.catch_warnings():
+        warnings.simplefilter("ignore")
+        keypair = _make_rsa_keypair("ui-runbooks-editor-test-kid")
+    return keypair, _public_jwks(keypair)
+
+
+def _role_session(
+    role: TenantRole,
+    tenant_id: uuid.UUID = _TENANT_A,
+) -> tuple[uuid.UUID, dict[str, Any]]:
+    """Seed a session whose access token is a real JWT carrying *role*.
+
+    Returns the session id and the JWKS the ``require_ui_admin`` gate must
+    reach to verify the token. A ``TENANT_ADMIN`` token passes the gate; an
+    ``OPERATOR`` token decodes cleanly but fails the role rank check -> 403.
+    """
+    keypair, jwks = _make_keypair_and_jwks()
+    access_token = _mint_token(
+        keypair,
+        sub=_OPERATOR_SUB,
+        tenant_id=str(tenant_id),
+        tenant_role=role.value,
+    )
+    session_id = _seed_session_sync(tenant_id=tenant_id, access_token=access_token)
+    return session_id, jwks
+
+
+def _admin_session(tenant_id: uuid.UUID = _TENANT_A) -> tuple[uuid.UUID, dict[str, Any]]:
+    """Seed an admin session whose access token is a real tenant_admin JWT."""
+    return _role_session(TenantRole.TENANT_ADMIN, tenant_id)
+
+
+def _csrf_token(session_id: uuid.UUID) -> str:
+    """Return a valid CSRF token for *session_id* (double-submit value).
+
+    Minted directly rather than scraped from the render response: the editor
+    sets the CSRF cookie with ``Secure``, and the TestClient speaks plain
+    ``http://testserver``, so a ``Secure`` cookie is not echoed back on the
+    follow-up POST. The double-submit contract is satisfied by passing the
+    same token as both the ``X-CSRF-Token`` header and an explicit request
+    cookie -- the pattern :mod:`backend.tests.test_ui_kb_upload` uses.
+    """
+    return mint_csrf_token(str(session_id))
+
+
+def _csrf_kwargs(token: str) -> dict[str, Any]:
+    """Header + cookie kwargs that satisfy the double-submit CSRF check."""
+    return {
+        "headers": {CSRF_HEADER_NAME: token, "X-CSRF-Token": token},
+        "cookies": {CSRF_COOKIE_NAME: token},
+    }
+
+
+# ---------------------------------------------------------------------------
+# Admin gating — GET /ui/runbooks/new and /ui/runbooks/<slug>/edit
+# ---------------------------------------------------------------------------
+
+
+def test_editor_new_admin_renders_200() -> None:
+    """``GET /ui/runbooks/new`` returns 200 + the editor for a tenant_admin."""
+    _seed_tenant(_TENANT_A, "tenant-a")
+    session_id, jwks = _admin_session()
+
+    mock = respx.mock(assert_all_called=False)
+    mock.start()
+    try:
+        _mock_discovery_and_jwks(mock, jwks)
+        client = _authenticated_client(session_id)
+        response = client.get("/ui/runbooks/new")
+    finally:
+        mock.stop()
+
+    assert response.status_code == 200, response.text
+    body = response.text
+    assert 'id="runbook-editor-form"' in body
+    assert 'name="slug"' in body
+    # CodeMirror bundle wired (same as KB editor).
+    assert "codemirror-bundle.min.js" in body
+    # CSRF cookie set on render.
+    assert CSRF_COOKIE_NAME in response.cookies
+
+
+def test_editor_new_operator_forbidden_403() -> None:
+    """``GET /ui/runbooks/new`` returns 403 for an operator (role below admin)."""
+    _seed_tenant(_TENANT_A, "tenant-a")
+    # A valid operator JWT decodes cleanly but ranks below tenant_admin -> 403.
+    session_id, jwks = _role_session(TenantRole.OPERATOR)
+
+    mock = respx.mock(assert_all_called=False)
+    mock.start()
+    try:
+        _mock_discovery_and_jwks(mock, jwks)
+        client = _authenticated_client(session_id)
+        response = client.get("/ui/runbooks/new")
+    finally:
+        mock.stop()
+
+    assert response.status_code == 403, response.text
+
+
+def test_editor_edit_admin_renders_prefilled_200() -> None:
+    """``GET /ui/runbooks/<slug>/edit`` returns 200 prefilled for a tenant_admin."""
+    _seed_tenant(_TENANT_A, "tenant-a")
+    _seed_template(tenant_id=_TENANT_A, slug="drain-node", body=_manual_body())
+    session_id, jwks = _admin_session()
+
+    mock = respx.mock(assert_all_called=False)
+    mock.start()
+    try:
+        _mock_discovery_and_jwks(mock, jwks)
+        client = _authenticated_client(session_id)
+        response = client.get("/ui/runbooks/drain-node/edit")
+    finally:
+        mock.stop()
+
+    assert response.status_code == 200, response.text
+    body = response.text
+    # Prefilled top-level fields + the existing step id present in the
+    # hydrated Alpine model JSON.
+    assert "Drain node" in body
+    assert "drain" in body
+    assert 'id="runbook-editor-form"' in body
+
+
+def test_editor_edit_operator_forbidden_403() -> None:
+    """``GET /ui/runbooks/<slug>/edit`` returns 403 for an operator (role below admin)."""
+    _seed_tenant(_TENANT_A, "tenant-a")
+    _seed_template(tenant_id=_TENANT_A, slug="drain-node", body=_manual_body())
+    session_id, jwks = _role_session(TenantRole.OPERATOR)
+
+    mock = respx.mock(assert_all_called=False)
+    mock.start()
+    try:
+        _mock_discovery_and_jwks(mock, jwks)
+        client = _authenticated_client(session_id)
+        response = client.get("/ui/runbooks/drain-node/edit")
+    finally:
+        mock.stop()
+
+    assert response.status_code == 403, response.text
+
+
+def test_editor_edit_missing_slug_404() -> None:
+    """A tenant_admin editing a missing slug gets 404."""
+    _seed_tenant(_TENANT_A, "tenant-a")
+    session_id, jwks = _admin_session()
+
+    mock = respx.mock(assert_all_called=False)
+    mock.start()
+    try:
+        _mock_discovery_and_jwks(mock, jwks)
+        client = _authenticated_client(session_id)
+        response = client.get("/ui/runbooks/does-not-exist/edit")
+    finally:
+        mock.stop()
+
+    assert response.status_code == 404, response.text
+
+
+# ---------------------------------------------------------------------------
+# Draft create round-trip — POST /ui/runbooks/new
+# ---------------------------------------------------------------------------
+
+
+def _steps_json_manual_and_opcall() -> str:
+    """A two-step payload: one manual+confirm, one operation_call+operation_call."""
+    return (
+        '[{"id":"prep","title":"Prepare","body":"Announce the window.",'
+        '"type":"manual","op_id":"","params":"{}",'
+        '"verify":{"type":"confirm","prompt":"Window announced?","op_id":"",'
+        '"params":"{}","expect":"{}"}},'
+        '{"id":"rotate","title":"Rotate","body":"Dispatch rotation.",'
+        '"type":"operation_call","op_id":"vmware.cert.rotate",'
+        '"params":"{\\"target\\": \\"${run.target}\\"}",'
+        '"verify":{"type":"operation_call","prompt":"","op_id":"vmware.cert.status",'
+        '"params":"{\\"target\\": \\"${run.target}\\"}","expect":"{\\"valid\\": true}"}}]'
+    )
+
+
+def test_create_draft_both_step_and_verify_kinds_roundtrips() -> None:
+    """A valid two-step body (both step + verify kinds) creates a draft (204 + redirect)."""
+    _seed_tenant(_TENANT_A, "tenant-a")
+    session_id, jwks = _admin_session()
+
+    mock = respx.mock(assert_all_called=False)
+    mock.start()
+    try:
+        _mock_discovery_and_jwks(mock, jwks)
+        client = _authenticated_client(session_id)
+        csrf = _csrf_token(session_id)
+        response = client.post(
+            "/ui/runbooks/new",
+            data={
+                "slug": "rotate-cert",
+                "title": "Rotate certificate",
+                "description": "Rotate the serving cert.",
+                "target_kind": "vmware.vcenter",
+                "steps": _steps_json_manual_and_opcall(),
+            },
+            **_csrf_kwargs(csrf),
+        )
+    finally:
+        mock.stop()
+
+    assert response.status_code == 204, response.text
+    assert response.headers.get("HX-Redirect") == "/ui/runbooks/rotate-cert"
+
+    # The draft round-trips: it now resolves at version 1, status draft.
+    async def _load() -> Any:
+        return await RunbookTemplateService().show_template(_TENANT_A, "rotate-cert")
+
+    tpl = asyncio.run(_load())
+    assert tpl.version == 1
+    assert tpl.status == "draft"
+    assert [s.id for s in tpl.steps] == ["prep", "rotate"]
+    # The operation_call step kept its op_id + params; the manual step has none.
+    op_step = tpl.steps[1]
+    assert op_step.type == "operation_call"
+    assert op_step.op_id == "vmware.cert.rotate"
+
+
+# ---------------------------------------------------------------------------
+# Server-side validation — duplicate slug (409) and bad body (422)
+# ---------------------------------------------------------------------------
+
+
+def test_create_duplicate_slug_renders_inline_error_422() -> None:
+    """A duplicate slug re-renders the editor inline (422) preserving entered data."""
+    _seed_tenant(_TENANT_A, "tenant-a")
+    _seed_template(tenant_id=_TENANT_A, slug="rotate-cert", body=_manual_body())
+    session_id, jwks = _admin_session()
+
+    mock = respx.mock(assert_all_called=False)
+    mock.start()
+    try:
+        _mock_discovery_and_jwks(mock, jwks)
+        client = _authenticated_client(session_id)
+        csrf = _csrf_token(session_id)
+        response = client.post(
+            "/ui/runbooks/new",
+            data={
+                "slug": "rotate-cert",
+                "title": "Rotate again",
+                "description": "Another one.",
+                "target_kind": "",
+                "steps": _steps_json_manual_and_opcall(),
+            },
+            **_csrf_kwargs(csrf),
+        )
+    finally:
+        mock.stop()
+
+    assert response.status_code == 422, response.text
+    body = response.text
+    # Inline error banner + the entered data preserved (title survives).
+    assert "already has a version" in body
+    assert "Rotate again" in body
+    # CSRF re-minted on the error re-render (a fresh cookie is set).
+    assert CSRF_COOKIE_NAME in response.cookies
+
+
+def test_create_invalid_step_id_renders_inline_error_422() -> None:
+    """A bad step id (dots are illegal) is rejected server-side -> inline 422."""
+    _seed_tenant(_TENANT_A, "tenant-a")
+    session_id, jwks = _admin_session()
+
+    bad_steps = (
+        '[{"id":"bad.id","title":"Prep","body":"x","type":"manual",'
+        '"op_id":"","params":"{}",'
+        '"verify":{"type":"confirm","prompt":"ok?","op_id":"","params":"{}","expect":"{}"}}]'
+    )
+    mock = respx.mock(assert_all_called=False)
+    mock.start()
+    try:
+        _mock_discovery_and_jwks(mock, jwks)
+        client = _authenticated_client(session_id)
+        csrf = _csrf_token(session_id)
+        response = client.post(
+            "/ui/runbooks/new",
+            data={
+                "slug": "bad-step",
+                "title": "Bad step",
+                "description": "Has a dotted step id.",
+                "target_kind": "",
+                "steps": bad_steps,
+            },
+            **_csrf_kwargs(csrf),
+        )
+    finally:
+        mock.stop()
+
+    assert response.status_code == 422, response.text
+    # Entered data preserved on the re-render.
+    assert "Bad step" in response.text
+    # No draft was persisted.
+
+    async def _missing() -> bool:
+        from meho_backplane.runbooks.service import TemplateNotFoundError
+
+        try:
+            await RunbookTemplateService().show_template(_TENANT_A, "bad-step")
+        except TemplateNotFoundError:
+            return True
+        return False
+
+    assert asyncio.run(_missing())
+
+
+def test_create_disallowed_substitution_renders_inline_error_422() -> None:
+    """A disallowed ``${...}`` substitution is rejected server-side -> inline 422."""
+    _seed_tenant(_TENANT_A, "tenant-a")
+    session_id, jwks = _admin_session()
+
+    bad_steps = (
+        '[{"id":"prep","title":"Prep","body":"Use ${run.secret} here.",'
+        '"type":"manual","op_id":"","params":"{}",'
+        '"verify":{"type":"confirm","prompt":"ok?","op_id":"","params":"{}","expect":"{}"}}]'
+    )
+    mock = respx.mock(assert_all_called=False)
+    mock.start()
+    try:
+        _mock_discovery_and_jwks(mock, jwks)
+        client = _authenticated_client(session_id)
+        csrf = _csrf_token(session_id)
+        response = client.post(
+            "/ui/runbooks/new",
+            data={
+                "slug": "subst-bad",
+                "title": "Subst bad",
+                "description": "Disallowed substitution.",
+                "target_kind": "",
+                "steps": bad_steps,
+            },
+            **_csrf_kwargs(csrf),
+        )
+    finally:
+        mock.stop()
+
+    assert response.status_code == 422, response.text
+    assert "disallowed substitution" in response.text
+
+
+# ---------------------------------------------------------------------------
+# Client-side validation parity — the editor markup carries the same rules
+# ---------------------------------------------------------------------------
+
+
+def test_editor_client_validation_mirrors_server_rules() -> None:
+    """The rendered editor carries the slug / step-id / substitution rules client-side."""
+    _seed_tenant(_TENANT_A, "tenant-a")
+    session_id, jwks = _admin_session()
+
+    mock = respx.mock(assert_all_called=False)
+    mock.start()
+    try:
+        _mock_discovery_and_jwks(mock, jwks)
+        client = _authenticated_client(session_id)
+        body = client.get("/ui/runbooks/new").text
+    finally:
+        mock.stop()
+
+    # Slug + step-id patterns + the substitution allowlist are all present in
+    # the client script (validation parity with the server).
+    assert "run.target" in body
+    assert "run\\.params\\." in body
+    assert "Duplicate step id." in body
+
+
+# ---------------------------------------------------------------------------
+# Fork-on-edit — editing a published template forks a new draft
+# ---------------------------------------------------------------------------
+
+
+def test_edit_published_forks_draft_and_surfaces_fork_notice() -> None:
+    """Editing a published template forks a draft + surfaces forked_from + in-flight count."""
+    _seed_tenant(_TENANT_A, "tenant-a")
+    version = _seed_template(
+        tenant_id=_TENANT_A,
+        slug="rotate-cert",
+        body=_manual_body(),
+        publish=True,
+    )
+    # One in-flight run pins the published version (counts toward the fork notice).
+    _seed_run(tenant_id=_TENANT_A, slug="rotate-cert", version=version, state="in_progress")
+    session_id, jwks = _admin_session()
+
+    edited_steps = (
+        '[{"id":"drain","title":"Drain the node","body":"Run the drain command.",'
+        '"type":"manual","op_id":"","params":"{}",'
+        '"verify":{"type":"confirm","prompt":"Node drained?","op_id":"",'
+        '"params":"{}","expect":"{}"}}]'
+    )
+    mock = respx.mock(assert_all_called=False)
+    mock.start()
+    try:
+        _mock_discovery_and_jwks(mock, jwks)
+        client = _authenticated_client(session_id)
+        csrf = _csrf_token(session_id)
+        response = client.post(
+            "/ui/runbooks/rotate-cert/edit",
+            data={
+                "slug": "rotate-cert",
+                "title": "Rotate certificate v2",
+                "description": "Edited copy.",
+                "target_kind": "k8s-node",
+                "steps": edited_steps,
+            },
+            **_csrf_kwargs(csrf),
+        )
+    finally:
+        mock.stop()
+
+    # Fork re-renders the editor (200) with the fork notice, not a redirect.
+    assert response.status_code == 200, response.text
+    body = response.text
+    assert "Forked a new draft" in body
+    # The new draft is v2; the source v1 had one in-flight run.
+    assert "v2" in body
+    assert re.search(r"rotate-cert v1", body)
+    assert ">1<" in body or "1</strong>" in body
+
+    # A new draft version now exists.
+    async def _latest() -> int:
+        tpl = await RunbookTemplateService().show_template(_TENANT_A, "rotate-cert")
+        return tpl.version
+
+    assert asyncio.run(_latest()) == version + 1
+
+
+def test_edit_draft_in_place_redirects() -> None:
+    """Editing an existing draft in place updates it + redirects (no fork notice)."""
+    _seed_tenant(_TENANT_A, "tenant-a")
+    _seed_template(tenant_id=_TENANT_A, slug="drain-node", body=_manual_body())
+    session_id, jwks = _admin_session()
+
+    edited_steps = (
+        '[{"id":"drain","title":"Drain the node (edited)","body":"x",'
+        '"type":"manual","op_id":"","params":"{}",'
+        '"verify":{"type":"confirm","prompt":"Done?","op_id":"","params":"{}","expect":"{}"}}]'
+    )
+    mock = respx.mock(assert_all_called=False)
+    mock.start()
+    try:
+        _mock_discovery_and_jwks(mock, jwks)
+        client = _authenticated_client(session_id)
+        csrf = _csrf_token(session_id)
+        response = client.post(
+            "/ui/runbooks/drain-node/edit",
+            data={
+                "slug": "drain-node",
+                "title": "Drain node (edited)",
+                "description": "Edited description.",
+                "target_kind": "k8s-node",
+                "steps": edited_steps,
+            },
+            **_csrf_kwargs(csrf),
+        )
+    finally:
+        mock.stop()
+
+    assert response.status_code == 204, response.text
+    assert response.headers.get("HX-Redirect") == "/ui/runbooks/drain-node"
+
+    async def _title() -> str:
+        tpl = await RunbookTemplateService().show_template(_TENANT_A, "drain-node")
+        return tpl.title
+
+    assert asyncio.run(_title()) == "Drain node (edited)"
+
+
+# ---------------------------------------------------------------------------
+# Live preview — POST /ui/runbooks/preview
+# ---------------------------------------------------------------------------
+
+
+def test_editor_preview_renders_markdown_for_admin() -> None:
+    """``POST /ui/runbooks/preview`` renders the posted body Markdown for an admin."""
+    _seed_tenant(_TENANT_A, "tenant-a")
+    session_id, jwks = _admin_session()
+
+    mock = respx.mock(assert_all_called=False)
+    mock.start()
+    try:
+        _mock_discovery_and_jwks(mock, jwks)
+        client = _authenticated_client(session_id)
+        csrf = _csrf_token(session_id)
+        response = client.post(
+            "/ui/runbooks/preview",
+            data={"body": "Run the **drain** command."},
+            **_csrf_kwargs(csrf),
+        )
+    finally:
+        mock.stop()
+
+    assert response.status_code == 200, response.text
+    assert "<strong>drain</strong>" in response.text
+
+
+def test_editor_preview_operator_forbidden() -> None:
+    """``POST /ui/runbooks/preview`` is admin-gated (403 for an operator).
+
+    A valid CSRF token is supplied so the CSRF middleware passes and the 403
+    comes from ``require_ui_admin`` (the role rank check), not the CSRF gate.
+    """
+    _seed_tenant(_TENANT_A, "tenant-a")
+    session_id, jwks = _role_session(TenantRole.OPERATOR)
+
+    mock = respx.mock(assert_all_called=False)
+    mock.start()
+    try:
+        _mock_discovery_and_jwks(mock, jwks)
+        client = _authenticated_client(session_id)
+        csrf = _csrf_token(session_id)
+        response = client.post(
+            "/ui/runbooks/preview",
+            data={"body": "x"},
+            **_csrf_kwargs(csrf),
+        )
+    finally:
+        mock.stop()
+
+    assert response.status_code == 403, response.text
+    assert "<strong>" not in response.text

--- a/cli/api/openapi.json
+++ b/cli/api/openapi.json
@@ -9261,6 +9261,201 @@
         }
       }
     },
+    "/ui/runbooks/new": {
+      "get": {
+        "tags": [
+          "ui-runbooks"
+        ],
+        "summary": "Runbooks Editor New",
+        "description": "Render the authoring editor for a brand-new draft template.",
+        "operationId": "runbooks_editor_new_ui_runbooks_new_get",
+        "responses": {
+          "200": {
+            "description": "Successful Response",
+            "content": {
+              "text/html": {
+                "schema": {
+                  "type": "string"
+                }
+              }
+            }
+          }
+        }
+      },
+      "post": {
+        "tags": [
+          "ui-runbooks"
+        ],
+        "summary": "Runbooks Editor Create",
+        "description": "Create a new draft from the editor form (mirrors REST POST).",
+        "operationId": "runbooks_editor_create_ui_runbooks_new_post",
+        "requestBody": {
+          "content": {
+            "application/x-www-form-urlencoded": {
+              "schema": {
+                "$ref": "#/components/schemas/Body_runbooks_editor_create_ui_runbooks_new_post"
+              }
+            }
+          }
+        },
+        "responses": {
+          "200": {
+            "description": "Successful Response",
+            "content": {
+              "text/html": {
+                "schema": {
+                  "type": "string"
+                }
+              }
+            }
+          },
+          "422": {
+            "description": "Validation Error",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/HTTPValidationError"
+                }
+              }
+            }
+          }
+        }
+      }
+    },
+    "/ui/runbooks/preview": {
+      "post": {
+        "tags": [
+          "ui-runbooks"
+        ],
+        "summary": "Runbooks Editor Preview",
+        "description": "HTMX live-preview partial for a step's Markdown ``body`` (admin only).",
+        "operationId": "runbooks_editor_preview_ui_runbooks_preview_post",
+        "requestBody": {
+          "content": {
+            "application/x-www-form-urlencoded": {
+              "schema": {
+                "$ref": "#/components/schemas/Body_runbooks_editor_preview_ui_runbooks_preview_post"
+              }
+            }
+          }
+        },
+        "responses": {
+          "200": {
+            "description": "Successful Response",
+            "content": {
+              "text/html": {
+                "schema": {
+                  "type": "string"
+                }
+              }
+            }
+          },
+          "422": {
+            "description": "Validation Error",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/HTTPValidationError"
+                }
+              }
+            }
+          }
+        }
+      }
+    },
+    "/ui/runbooks/{slug}/edit": {
+      "get": {
+        "tags": [
+          "ui-runbooks"
+        ],
+        "summary": "Runbooks Editor Edit",
+        "description": "Render the authoring editor pre-loaded with an existing template.",
+        "operationId": "runbooks_editor_edit_ui_runbooks__slug__edit_get",
+        "parameters": [
+          {
+            "name": "slug",
+            "in": "path",
+            "required": true,
+            "schema": {
+              "type": "string",
+              "title": "Slug"
+            }
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "Successful Response",
+            "content": {
+              "text/html": {
+                "schema": {
+                  "type": "string"
+                }
+              }
+            }
+          },
+          "422": {
+            "description": "Validation Error",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/HTTPValidationError"
+                }
+              }
+            }
+          }
+        }
+      },
+      "post": {
+        "tags": [
+          "ui-runbooks"
+        ],
+        "summary": "Runbooks Editor Update",
+        "description": "Edit a draft in place / fork from published (mirrors REST PATCH).",
+        "operationId": "runbooks_editor_update_ui_runbooks__slug__edit_post",
+        "parameters": [
+          {
+            "name": "slug",
+            "in": "path",
+            "required": true,
+            "schema": {
+              "type": "string",
+              "title": "Slug"
+            }
+          }
+        ],
+        "requestBody": {
+          "content": {
+            "application/x-www-form-urlencoded": {
+              "schema": {
+                "$ref": "#/components/schemas/Body_runbooks_editor_update_ui_runbooks__slug__edit_post"
+              }
+            }
+          }
+        },
+        "responses": {
+          "200": {
+            "description": "Successful Response",
+            "content": {
+              "text/html": {
+                "schema": {
+                  "type": "string"
+                }
+              }
+            }
+          },
+          "422": {
+            "description": "Validation Error",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/HTTPValidationError"
+                }
+              }
+            }
+          }
+        }
+      }
+    },
     "/ui/runbooks/{slug}": {
       "get": {
         "tags": [
@@ -10558,6 +10753,77 @@
           "file"
         ],
         "title": "Body_kb_upload_single_ui_kb_upload_post"
+      },
+      "Body_runbooks_editor_create_ui_runbooks_new_post": {
+        "properties": {
+          "slug": {
+            "type": "string",
+            "title": "Slug",
+            "default": ""
+          },
+          "title": {
+            "type": "string",
+            "title": "Title",
+            "default": ""
+          },
+          "description": {
+            "type": "string",
+            "title": "Description",
+            "default": ""
+          },
+          "target_kind": {
+            "type": "string",
+            "title": "Target Kind",
+            "default": ""
+          },
+          "steps": {
+            "type": "string",
+            "maxLength": 262144,
+            "title": "Steps",
+            "default": "[]"
+          }
+        },
+        "type": "object",
+        "title": "Body_runbooks_editor_create_ui_runbooks_new_post"
+      },
+      "Body_runbooks_editor_preview_ui_runbooks_preview_post": {
+        "properties": {
+          "body": {
+            "type": "string",
+            "maxLength": 65536,
+            "title": "Body",
+            "default": ""
+          }
+        },
+        "type": "object",
+        "title": "Body_runbooks_editor_preview_ui_runbooks_preview_post"
+      },
+      "Body_runbooks_editor_update_ui_runbooks__slug__edit_post": {
+        "properties": {
+          "title": {
+            "type": "string",
+            "title": "Title",
+            "default": ""
+          },
+          "description": {
+            "type": "string",
+            "title": "Description",
+            "default": ""
+          },
+          "target_kind": {
+            "type": "string",
+            "title": "Target Kind",
+            "default": ""
+          },
+          "steps": {
+            "type": "string",
+            "maxLength": 262144,
+            "title": "Steps",
+            "default": "[]"
+          }
+        },
+        "type": "object",
+        "title": "Body_runbooks_editor_update_ui_runbooks__slug__edit_post"
       },
       "Body_ui_connectors_create_submit_ui_connectors_create_post": {
         "properties": {

--- a/cli/internal/api/client.gen.go
+++ b/cli/internal/api/client.gen.go
@@ -1049,6 +1049,28 @@ type BodyKbUploadSingleUiKbUploadPost struct {
 	Slug *string `json:"slug,omitempty"`
 }
 
+// BodyRunbooksEditorCreateUiRunbooksNewPost defines model for Body_runbooks_editor_create_ui_runbooks_new_post.
+type BodyRunbooksEditorCreateUiRunbooksNewPost struct {
+	Description *string `json:"description,omitempty"`
+	Slug        *string `json:"slug,omitempty"`
+	Steps       *string `json:"steps,omitempty"`
+	TargetKind  *string `json:"target_kind,omitempty"`
+	Title       *string `json:"title,omitempty"`
+}
+
+// BodyRunbooksEditorPreviewUiRunbooksPreviewPost defines model for Body_runbooks_editor_preview_ui_runbooks_preview_post.
+type BodyRunbooksEditorPreviewUiRunbooksPreviewPost struct {
+	Body *string `json:"body,omitempty"`
+}
+
+// BodyRunbooksEditorUpdateUiRunbooksSlugEditPost defines model for Body_runbooks_editor_update_ui_runbooks__slug__edit_post.
+type BodyRunbooksEditorUpdateUiRunbooksSlugEditPost struct {
+	Description *string `json:"description,omitempty"`
+	Steps       *string `json:"steps,omitempty"`
+	TargetKind  *string `json:"target_kind,omitempty"`
+	Title       *string `json:"title,omitempty"`
+}
+
 // BodyUiConnectorsCreateSubmitUiConnectorsCreatePost defines model for Body_ui_connectors_create_submit_ui_connectors_create_post.
 type BodyUiConnectorsCreateSubmitUiConnectorsCreatePost struct {
 	Aliases   *string `json:"aliases"`
@@ -5756,6 +5778,15 @@ type UiMemoryPromoteModalUiMemoryScopeSlugPromoteGetJSONRequestBody = UISessionC
 // UiMemoryPromoteSubmitUiMemoryScopeSlugPromotePostFormdataRequestBody defines body for UiMemoryPromoteSubmitUiMemoryScopeSlugPromotePost for application/x-www-form-urlencoded ContentType.
 type UiMemoryPromoteSubmitUiMemoryScopeSlugPromotePostFormdataRequestBody = BodyUiMemoryPromoteSubmitUiMemoryScopeSlugPromotePost
 
+// RunbooksEditorCreateUiRunbooksNewPostFormdataRequestBody defines body for RunbooksEditorCreateUiRunbooksNewPost for application/x-www-form-urlencoded ContentType.
+type RunbooksEditorCreateUiRunbooksNewPostFormdataRequestBody = BodyRunbooksEditorCreateUiRunbooksNewPost
+
+// RunbooksEditorPreviewUiRunbooksPreviewPostFormdataRequestBody defines body for RunbooksEditorPreviewUiRunbooksPreviewPost for application/x-www-form-urlencoded ContentType.
+type RunbooksEditorPreviewUiRunbooksPreviewPostFormdataRequestBody = BodyRunbooksEditorPreviewUiRunbooksPreviewPost
+
+// RunbooksEditorUpdateUiRunbooksSlugEditPostFormdataRequestBody defines body for RunbooksEditorUpdateUiRunbooksSlugEditPost for application/x-www-form-urlencoded ContentType.
+type RunbooksEditorUpdateUiRunbooksSlugEditPostFormdataRequestBody = BodyRunbooksEditorUpdateUiRunbooksSlugEditPost
+
 // AsApproveResponseBodyDispatchResult0 returns the union data inside the ApproveResponseBody_DispatchResult as a ApproveResponseBodyDispatchResult0
 func (t ApproveResponseBody_DispatchResult) AsApproveResponseBodyDispatchResult0() (ApproveResponseBodyDispatchResult0, error) {
 	var body ApproveResponseBodyDispatchResult0
@@ -7024,8 +7055,29 @@ type ClientInterface interface {
 	// RunbooksListUiRunbooksListGet request
 	RunbooksListUiRunbooksListGet(ctx context.Context, params *RunbooksListUiRunbooksListGetParams, reqEditors ...RequestEditorFn) (*http.Response, error)
 
+	// RunbooksEditorNewUiRunbooksNewGet request
+	RunbooksEditorNewUiRunbooksNewGet(ctx context.Context, reqEditors ...RequestEditorFn) (*http.Response, error)
+
+	// RunbooksEditorCreateUiRunbooksNewPostWithBody request with any body
+	RunbooksEditorCreateUiRunbooksNewPostWithBody(ctx context.Context, contentType string, body io.Reader, reqEditors ...RequestEditorFn) (*http.Response, error)
+
+	RunbooksEditorCreateUiRunbooksNewPostWithFormdataBody(ctx context.Context, body RunbooksEditorCreateUiRunbooksNewPostFormdataRequestBody, reqEditors ...RequestEditorFn) (*http.Response, error)
+
+	// RunbooksEditorPreviewUiRunbooksPreviewPostWithBody request with any body
+	RunbooksEditorPreviewUiRunbooksPreviewPostWithBody(ctx context.Context, contentType string, body io.Reader, reqEditors ...RequestEditorFn) (*http.Response, error)
+
+	RunbooksEditorPreviewUiRunbooksPreviewPostWithFormdataBody(ctx context.Context, body RunbooksEditorPreviewUiRunbooksPreviewPostFormdataRequestBody, reqEditors ...RequestEditorFn) (*http.Response, error)
+
 	// RunbooksDetailUiRunbooksSlugGet request
 	RunbooksDetailUiRunbooksSlugGet(ctx context.Context, slug string, params *RunbooksDetailUiRunbooksSlugGetParams, reqEditors ...RequestEditorFn) (*http.Response, error)
+
+	// RunbooksEditorEditUiRunbooksSlugEditGet request
+	RunbooksEditorEditUiRunbooksSlugEditGet(ctx context.Context, slug string, reqEditors ...RequestEditorFn) (*http.Response, error)
+
+	// RunbooksEditorUpdateUiRunbooksSlugEditPostWithBody request with any body
+	RunbooksEditorUpdateUiRunbooksSlugEditPostWithBody(ctx context.Context, slug string, contentType string, body io.Reader, reqEditors ...RequestEditorFn) (*http.Response, error)
+
+	RunbooksEditorUpdateUiRunbooksSlugEditPostWithFormdataBody(ctx context.Context, slug string, body RunbooksEditorUpdateUiRunbooksSlugEditPostFormdataRequestBody, reqEditors ...RequestEditorFn) (*http.Response, error)
 
 	// UiTopologyTableUiTopologyGet request
 	UiTopologyTableUiTopologyGet(ctx context.Context, params *UiTopologyTableUiTopologyGetParams, reqEditors ...RequestEditorFn) (*http.Response, error)
@@ -9533,8 +9585,104 @@ func (c *Client) RunbooksListUiRunbooksListGet(ctx context.Context, params *Runb
 	return c.Client.Do(req)
 }
 
+func (c *Client) RunbooksEditorNewUiRunbooksNewGet(ctx context.Context, reqEditors ...RequestEditorFn) (*http.Response, error) {
+	req, err := NewRunbooksEditorNewUiRunbooksNewGetRequest(c.Server)
+	if err != nil {
+		return nil, err
+	}
+	req = req.WithContext(ctx)
+	if err := c.applyEditors(ctx, req, reqEditors); err != nil {
+		return nil, err
+	}
+	return c.Client.Do(req)
+}
+
+func (c *Client) RunbooksEditorCreateUiRunbooksNewPostWithBody(ctx context.Context, contentType string, body io.Reader, reqEditors ...RequestEditorFn) (*http.Response, error) {
+	req, err := NewRunbooksEditorCreateUiRunbooksNewPostRequestWithBody(c.Server, contentType, body)
+	if err != nil {
+		return nil, err
+	}
+	req = req.WithContext(ctx)
+	if err := c.applyEditors(ctx, req, reqEditors); err != nil {
+		return nil, err
+	}
+	return c.Client.Do(req)
+}
+
+func (c *Client) RunbooksEditorCreateUiRunbooksNewPostWithFormdataBody(ctx context.Context, body RunbooksEditorCreateUiRunbooksNewPostFormdataRequestBody, reqEditors ...RequestEditorFn) (*http.Response, error) {
+	req, err := NewRunbooksEditorCreateUiRunbooksNewPostRequestWithFormdataBody(c.Server, body)
+	if err != nil {
+		return nil, err
+	}
+	req = req.WithContext(ctx)
+	if err := c.applyEditors(ctx, req, reqEditors); err != nil {
+		return nil, err
+	}
+	return c.Client.Do(req)
+}
+
+func (c *Client) RunbooksEditorPreviewUiRunbooksPreviewPostWithBody(ctx context.Context, contentType string, body io.Reader, reqEditors ...RequestEditorFn) (*http.Response, error) {
+	req, err := NewRunbooksEditorPreviewUiRunbooksPreviewPostRequestWithBody(c.Server, contentType, body)
+	if err != nil {
+		return nil, err
+	}
+	req = req.WithContext(ctx)
+	if err := c.applyEditors(ctx, req, reqEditors); err != nil {
+		return nil, err
+	}
+	return c.Client.Do(req)
+}
+
+func (c *Client) RunbooksEditorPreviewUiRunbooksPreviewPostWithFormdataBody(ctx context.Context, body RunbooksEditorPreviewUiRunbooksPreviewPostFormdataRequestBody, reqEditors ...RequestEditorFn) (*http.Response, error) {
+	req, err := NewRunbooksEditorPreviewUiRunbooksPreviewPostRequestWithFormdataBody(c.Server, body)
+	if err != nil {
+		return nil, err
+	}
+	req = req.WithContext(ctx)
+	if err := c.applyEditors(ctx, req, reqEditors); err != nil {
+		return nil, err
+	}
+	return c.Client.Do(req)
+}
+
 func (c *Client) RunbooksDetailUiRunbooksSlugGet(ctx context.Context, slug string, params *RunbooksDetailUiRunbooksSlugGetParams, reqEditors ...RequestEditorFn) (*http.Response, error) {
 	req, err := NewRunbooksDetailUiRunbooksSlugGetRequest(c.Server, slug, params)
+	if err != nil {
+		return nil, err
+	}
+	req = req.WithContext(ctx)
+	if err := c.applyEditors(ctx, req, reqEditors); err != nil {
+		return nil, err
+	}
+	return c.Client.Do(req)
+}
+
+func (c *Client) RunbooksEditorEditUiRunbooksSlugEditGet(ctx context.Context, slug string, reqEditors ...RequestEditorFn) (*http.Response, error) {
+	req, err := NewRunbooksEditorEditUiRunbooksSlugEditGetRequest(c.Server, slug)
+	if err != nil {
+		return nil, err
+	}
+	req = req.WithContext(ctx)
+	if err := c.applyEditors(ctx, req, reqEditors); err != nil {
+		return nil, err
+	}
+	return c.Client.Do(req)
+}
+
+func (c *Client) RunbooksEditorUpdateUiRunbooksSlugEditPostWithBody(ctx context.Context, slug string, contentType string, body io.Reader, reqEditors ...RequestEditorFn) (*http.Response, error) {
+	req, err := NewRunbooksEditorUpdateUiRunbooksSlugEditPostRequestWithBody(c.Server, slug, contentType, body)
+	if err != nil {
+		return nil, err
+	}
+	req = req.WithContext(ctx)
+	if err := c.applyEditors(ctx, req, reqEditors); err != nil {
+		return nil, err
+	}
+	return c.Client.Do(req)
+}
+
+func (c *Client) RunbooksEditorUpdateUiRunbooksSlugEditPostWithFormdataBody(ctx context.Context, slug string, body RunbooksEditorUpdateUiRunbooksSlugEditPostFormdataRequestBody, reqEditors ...RequestEditorFn) (*http.Response, error) {
+	req, err := NewRunbooksEditorUpdateUiRunbooksSlugEditPostRequestWithFormdataBody(c.Server, slug, body)
 	if err != nil {
 		return nil, err
 	}
@@ -18762,6 +18910,113 @@ func NewRunbooksListUiRunbooksListGetRequest(server string, params *RunbooksList
 	return req, nil
 }
 
+// NewRunbooksEditorNewUiRunbooksNewGetRequest generates requests for RunbooksEditorNewUiRunbooksNewGet
+func NewRunbooksEditorNewUiRunbooksNewGetRequest(server string) (*http.Request, error) {
+	var err error
+
+	serverURL, err := url.Parse(server)
+	if err != nil {
+		return nil, err
+	}
+
+	operationPath := fmt.Sprintf("/ui/runbooks/new")
+	if operationPath[0] == '/' {
+		operationPath = "." + operationPath
+	}
+
+	queryURL, err := serverURL.Parse(operationPath)
+	if err != nil {
+		return nil, err
+	}
+
+	req, err := http.NewRequest("GET", queryURL.String(), nil)
+	if err != nil {
+		return nil, err
+	}
+
+	return req, nil
+}
+
+// NewRunbooksEditorCreateUiRunbooksNewPostRequestWithFormdataBody calls the generic RunbooksEditorCreateUiRunbooksNewPost builder with application/x-www-form-urlencoded body
+func NewRunbooksEditorCreateUiRunbooksNewPostRequestWithFormdataBody(server string, body RunbooksEditorCreateUiRunbooksNewPostFormdataRequestBody) (*http.Request, error) {
+	var bodyReader io.Reader
+	bodyStr, err := runtime.MarshalForm(body, nil)
+	if err != nil {
+		return nil, err
+	}
+	bodyReader = strings.NewReader(bodyStr.Encode())
+	return NewRunbooksEditorCreateUiRunbooksNewPostRequestWithBody(server, "application/x-www-form-urlencoded", bodyReader)
+}
+
+// NewRunbooksEditorCreateUiRunbooksNewPostRequestWithBody generates requests for RunbooksEditorCreateUiRunbooksNewPost with any type of body
+func NewRunbooksEditorCreateUiRunbooksNewPostRequestWithBody(server string, contentType string, body io.Reader) (*http.Request, error) {
+	var err error
+
+	serverURL, err := url.Parse(server)
+	if err != nil {
+		return nil, err
+	}
+
+	operationPath := fmt.Sprintf("/ui/runbooks/new")
+	if operationPath[0] == '/' {
+		operationPath = "." + operationPath
+	}
+
+	queryURL, err := serverURL.Parse(operationPath)
+	if err != nil {
+		return nil, err
+	}
+
+	req, err := http.NewRequest("POST", queryURL.String(), body)
+	if err != nil {
+		return nil, err
+	}
+
+	req.Header.Add("Content-Type", contentType)
+
+	return req, nil
+}
+
+// NewRunbooksEditorPreviewUiRunbooksPreviewPostRequestWithFormdataBody calls the generic RunbooksEditorPreviewUiRunbooksPreviewPost builder with application/x-www-form-urlencoded body
+func NewRunbooksEditorPreviewUiRunbooksPreviewPostRequestWithFormdataBody(server string, body RunbooksEditorPreviewUiRunbooksPreviewPostFormdataRequestBody) (*http.Request, error) {
+	var bodyReader io.Reader
+	bodyStr, err := runtime.MarshalForm(body, nil)
+	if err != nil {
+		return nil, err
+	}
+	bodyReader = strings.NewReader(bodyStr.Encode())
+	return NewRunbooksEditorPreviewUiRunbooksPreviewPostRequestWithBody(server, "application/x-www-form-urlencoded", bodyReader)
+}
+
+// NewRunbooksEditorPreviewUiRunbooksPreviewPostRequestWithBody generates requests for RunbooksEditorPreviewUiRunbooksPreviewPost with any type of body
+func NewRunbooksEditorPreviewUiRunbooksPreviewPostRequestWithBody(server string, contentType string, body io.Reader) (*http.Request, error) {
+	var err error
+
+	serverURL, err := url.Parse(server)
+	if err != nil {
+		return nil, err
+	}
+
+	operationPath := fmt.Sprintf("/ui/runbooks/preview")
+	if operationPath[0] == '/' {
+		operationPath = "." + operationPath
+	}
+
+	queryURL, err := serverURL.Parse(operationPath)
+	if err != nil {
+		return nil, err
+	}
+
+	req, err := http.NewRequest("POST", queryURL.String(), body)
+	if err != nil {
+		return nil, err
+	}
+
+	req.Header.Add("Content-Type", contentType)
+
+	return req, nil
+}
+
 // NewRunbooksDetailUiRunbooksSlugGetRequest generates requests for RunbooksDetailUiRunbooksSlugGet
 func NewRunbooksDetailUiRunbooksSlugGetRequest(server string, slug string, params *RunbooksDetailUiRunbooksSlugGetParams) (*http.Request, error) {
 	var err error
@@ -18814,6 +19069,87 @@ func NewRunbooksDetailUiRunbooksSlugGetRequest(server string, slug string, param
 	if err != nil {
 		return nil, err
 	}
+
+	return req, nil
+}
+
+// NewRunbooksEditorEditUiRunbooksSlugEditGetRequest generates requests for RunbooksEditorEditUiRunbooksSlugEditGet
+func NewRunbooksEditorEditUiRunbooksSlugEditGetRequest(server string, slug string) (*http.Request, error) {
+	var err error
+
+	var pathParam0 string
+
+	pathParam0, err = runtime.StyleParamWithLocation("simple", false, "slug", runtime.ParamLocationPath, slug)
+	if err != nil {
+		return nil, err
+	}
+
+	serverURL, err := url.Parse(server)
+	if err != nil {
+		return nil, err
+	}
+
+	operationPath := fmt.Sprintf("/ui/runbooks/%s/edit", pathParam0)
+	if operationPath[0] == '/' {
+		operationPath = "." + operationPath
+	}
+
+	queryURL, err := serverURL.Parse(operationPath)
+	if err != nil {
+		return nil, err
+	}
+
+	req, err := http.NewRequest("GET", queryURL.String(), nil)
+	if err != nil {
+		return nil, err
+	}
+
+	return req, nil
+}
+
+// NewRunbooksEditorUpdateUiRunbooksSlugEditPostRequestWithFormdataBody calls the generic RunbooksEditorUpdateUiRunbooksSlugEditPost builder with application/x-www-form-urlencoded body
+func NewRunbooksEditorUpdateUiRunbooksSlugEditPostRequestWithFormdataBody(server string, slug string, body RunbooksEditorUpdateUiRunbooksSlugEditPostFormdataRequestBody) (*http.Request, error) {
+	var bodyReader io.Reader
+	bodyStr, err := runtime.MarshalForm(body, nil)
+	if err != nil {
+		return nil, err
+	}
+	bodyReader = strings.NewReader(bodyStr.Encode())
+	return NewRunbooksEditorUpdateUiRunbooksSlugEditPostRequestWithBody(server, slug, "application/x-www-form-urlencoded", bodyReader)
+}
+
+// NewRunbooksEditorUpdateUiRunbooksSlugEditPostRequestWithBody generates requests for RunbooksEditorUpdateUiRunbooksSlugEditPost with any type of body
+func NewRunbooksEditorUpdateUiRunbooksSlugEditPostRequestWithBody(server string, slug string, contentType string, body io.Reader) (*http.Request, error) {
+	var err error
+
+	var pathParam0 string
+
+	pathParam0, err = runtime.StyleParamWithLocation("simple", false, "slug", runtime.ParamLocationPath, slug)
+	if err != nil {
+		return nil, err
+	}
+
+	serverURL, err := url.Parse(server)
+	if err != nil {
+		return nil, err
+	}
+
+	operationPath := fmt.Sprintf("/ui/runbooks/%s/edit", pathParam0)
+	if operationPath[0] == '/' {
+		operationPath = "." + operationPath
+	}
+
+	queryURL, err := serverURL.Parse(operationPath)
+	if err != nil {
+		return nil, err
+	}
+
+	req, err := http.NewRequest("POST", queryURL.String(), body)
+	if err != nil {
+		return nil, err
+	}
+
+	req.Header.Add("Content-Type", contentType)
 
 	return req, nil
 }
@@ -19727,8 +20063,29 @@ type ClientWithResponsesInterface interface {
 	// RunbooksListUiRunbooksListGetWithResponse request
 	RunbooksListUiRunbooksListGetWithResponse(ctx context.Context, params *RunbooksListUiRunbooksListGetParams, reqEditors ...RequestEditorFn) (*RunbooksListUiRunbooksListGetResponse, error)
 
+	// RunbooksEditorNewUiRunbooksNewGetWithResponse request
+	RunbooksEditorNewUiRunbooksNewGetWithResponse(ctx context.Context, reqEditors ...RequestEditorFn) (*RunbooksEditorNewUiRunbooksNewGetResponse, error)
+
+	// RunbooksEditorCreateUiRunbooksNewPostWithBodyWithResponse request with any body
+	RunbooksEditorCreateUiRunbooksNewPostWithBodyWithResponse(ctx context.Context, contentType string, body io.Reader, reqEditors ...RequestEditorFn) (*RunbooksEditorCreateUiRunbooksNewPostResponse, error)
+
+	RunbooksEditorCreateUiRunbooksNewPostWithFormdataBodyWithResponse(ctx context.Context, body RunbooksEditorCreateUiRunbooksNewPostFormdataRequestBody, reqEditors ...RequestEditorFn) (*RunbooksEditorCreateUiRunbooksNewPostResponse, error)
+
+	// RunbooksEditorPreviewUiRunbooksPreviewPostWithBodyWithResponse request with any body
+	RunbooksEditorPreviewUiRunbooksPreviewPostWithBodyWithResponse(ctx context.Context, contentType string, body io.Reader, reqEditors ...RequestEditorFn) (*RunbooksEditorPreviewUiRunbooksPreviewPostResponse, error)
+
+	RunbooksEditorPreviewUiRunbooksPreviewPostWithFormdataBodyWithResponse(ctx context.Context, body RunbooksEditorPreviewUiRunbooksPreviewPostFormdataRequestBody, reqEditors ...RequestEditorFn) (*RunbooksEditorPreviewUiRunbooksPreviewPostResponse, error)
+
 	// RunbooksDetailUiRunbooksSlugGetWithResponse request
 	RunbooksDetailUiRunbooksSlugGetWithResponse(ctx context.Context, slug string, params *RunbooksDetailUiRunbooksSlugGetParams, reqEditors ...RequestEditorFn) (*RunbooksDetailUiRunbooksSlugGetResponse, error)
+
+	// RunbooksEditorEditUiRunbooksSlugEditGetWithResponse request
+	RunbooksEditorEditUiRunbooksSlugEditGetWithResponse(ctx context.Context, slug string, reqEditors ...RequestEditorFn) (*RunbooksEditorEditUiRunbooksSlugEditGetResponse, error)
+
+	// RunbooksEditorUpdateUiRunbooksSlugEditPostWithBodyWithResponse request with any body
+	RunbooksEditorUpdateUiRunbooksSlugEditPostWithBodyWithResponse(ctx context.Context, slug string, contentType string, body io.Reader, reqEditors ...RequestEditorFn) (*RunbooksEditorUpdateUiRunbooksSlugEditPostResponse, error)
+
+	RunbooksEditorUpdateUiRunbooksSlugEditPostWithFormdataBodyWithResponse(ctx context.Context, slug string, body RunbooksEditorUpdateUiRunbooksSlugEditPostFormdataRequestBody, reqEditors ...RequestEditorFn) (*RunbooksEditorUpdateUiRunbooksSlugEditPostResponse, error)
 
 	// UiTopologyTableUiTopologyGetWithResponse request
 	UiTopologyTableUiTopologyGetWithResponse(ctx context.Context, params *UiTopologyTableUiTopologyGetParams, reqEditors ...RequestEditorFn) (*UiTopologyTableUiTopologyGetResponse, error)
@@ -23160,6 +23517,71 @@ func (r RunbooksListUiRunbooksListGetResponse) StatusCode() int {
 	return 0
 }
 
+type RunbooksEditorNewUiRunbooksNewGetResponse struct {
+	Body         []byte
+	HTTPResponse *http.Response
+}
+
+// Status returns HTTPResponse.Status
+func (r RunbooksEditorNewUiRunbooksNewGetResponse) Status() string {
+	if r.HTTPResponse != nil {
+		return r.HTTPResponse.Status
+	}
+	return http.StatusText(0)
+}
+
+// StatusCode returns HTTPResponse.StatusCode
+func (r RunbooksEditorNewUiRunbooksNewGetResponse) StatusCode() int {
+	if r.HTTPResponse != nil {
+		return r.HTTPResponse.StatusCode
+	}
+	return 0
+}
+
+type RunbooksEditorCreateUiRunbooksNewPostResponse struct {
+	Body         []byte
+	HTTPResponse *http.Response
+	JSON422      *HTTPValidationError
+}
+
+// Status returns HTTPResponse.Status
+func (r RunbooksEditorCreateUiRunbooksNewPostResponse) Status() string {
+	if r.HTTPResponse != nil {
+		return r.HTTPResponse.Status
+	}
+	return http.StatusText(0)
+}
+
+// StatusCode returns HTTPResponse.StatusCode
+func (r RunbooksEditorCreateUiRunbooksNewPostResponse) StatusCode() int {
+	if r.HTTPResponse != nil {
+		return r.HTTPResponse.StatusCode
+	}
+	return 0
+}
+
+type RunbooksEditorPreviewUiRunbooksPreviewPostResponse struct {
+	Body         []byte
+	HTTPResponse *http.Response
+	JSON422      *HTTPValidationError
+}
+
+// Status returns HTTPResponse.Status
+func (r RunbooksEditorPreviewUiRunbooksPreviewPostResponse) Status() string {
+	if r.HTTPResponse != nil {
+		return r.HTTPResponse.Status
+	}
+	return http.StatusText(0)
+}
+
+// StatusCode returns HTTPResponse.StatusCode
+func (r RunbooksEditorPreviewUiRunbooksPreviewPostResponse) StatusCode() int {
+	if r.HTTPResponse != nil {
+		return r.HTTPResponse.StatusCode
+	}
+	return 0
+}
+
 type RunbooksDetailUiRunbooksSlugGetResponse struct {
 	Body         []byte
 	HTTPResponse *http.Response
@@ -23176,6 +23598,50 @@ func (r RunbooksDetailUiRunbooksSlugGetResponse) Status() string {
 
 // StatusCode returns HTTPResponse.StatusCode
 func (r RunbooksDetailUiRunbooksSlugGetResponse) StatusCode() int {
+	if r.HTTPResponse != nil {
+		return r.HTTPResponse.StatusCode
+	}
+	return 0
+}
+
+type RunbooksEditorEditUiRunbooksSlugEditGetResponse struct {
+	Body         []byte
+	HTTPResponse *http.Response
+	JSON422      *HTTPValidationError
+}
+
+// Status returns HTTPResponse.Status
+func (r RunbooksEditorEditUiRunbooksSlugEditGetResponse) Status() string {
+	if r.HTTPResponse != nil {
+		return r.HTTPResponse.Status
+	}
+	return http.StatusText(0)
+}
+
+// StatusCode returns HTTPResponse.StatusCode
+func (r RunbooksEditorEditUiRunbooksSlugEditGetResponse) StatusCode() int {
+	if r.HTTPResponse != nil {
+		return r.HTTPResponse.StatusCode
+	}
+	return 0
+}
+
+type RunbooksEditorUpdateUiRunbooksSlugEditPostResponse struct {
+	Body         []byte
+	HTTPResponse *http.Response
+	JSON422      *HTTPValidationError
+}
+
+// Status returns HTTPResponse.Status
+func (r RunbooksEditorUpdateUiRunbooksSlugEditPostResponse) Status() string {
+	if r.HTTPResponse != nil {
+		return r.HTTPResponse.Status
+	}
+	return http.StatusText(0)
+}
+
+// StatusCode returns HTTPResponse.StatusCode
+func (r RunbooksEditorUpdateUiRunbooksSlugEditPostResponse) StatusCode() int {
 	if r.HTTPResponse != nil {
 		return r.HTTPResponse.StatusCode
 	}
@@ -25060,6 +25526,49 @@ func (c *ClientWithResponses) RunbooksListUiRunbooksListGetWithResponse(ctx cont
 	return ParseRunbooksListUiRunbooksListGetResponse(rsp)
 }
 
+// RunbooksEditorNewUiRunbooksNewGetWithResponse request returning *RunbooksEditorNewUiRunbooksNewGetResponse
+func (c *ClientWithResponses) RunbooksEditorNewUiRunbooksNewGetWithResponse(ctx context.Context, reqEditors ...RequestEditorFn) (*RunbooksEditorNewUiRunbooksNewGetResponse, error) {
+	rsp, err := c.RunbooksEditorNewUiRunbooksNewGet(ctx, reqEditors...)
+	if err != nil {
+		return nil, err
+	}
+	return ParseRunbooksEditorNewUiRunbooksNewGetResponse(rsp)
+}
+
+// RunbooksEditorCreateUiRunbooksNewPostWithBodyWithResponse request with arbitrary body returning *RunbooksEditorCreateUiRunbooksNewPostResponse
+func (c *ClientWithResponses) RunbooksEditorCreateUiRunbooksNewPostWithBodyWithResponse(ctx context.Context, contentType string, body io.Reader, reqEditors ...RequestEditorFn) (*RunbooksEditorCreateUiRunbooksNewPostResponse, error) {
+	rsp, err := c.RunbooksEditorCreateUiRunbooksNewPostWithBody(ctx, contentType, body, reqEditors...)
+	if err != nil {
+		return nil, err
+	}
+	return ParseRunbooksEditorCreateUiRunbooksNewPostResponse(rsp)
+}
+
+func (c *ClientWithResponses) RunbooksEditorCreateUiRunbooksNewPostWithFormdataBodyWithResponse(ctx context.Context, body RunbooksEditorCreateUiRunbooksNewPostFormdataRequestBody, reqEditors ...RequestEditorFn) (*RunbooksEditorCreateUiRunbooksNewPostResponse, error) {
+	rsp, err := c.RunbooksEditorCreateUiRunbooksNewPostWithFormdataBody(ctx, body, reqEditors...)
+	if err != nil {
+		return nil, err
+	}
+	return ParseRunbooksEditorCreateUiRunbooksNewPostResponse(rsp)
+}
+
+// RunbooksEditorPreviewUiRunbooksPreviewPostWithBodyWithResponse request with arbitrary body returning *RunbooksEditorPreviewUiRunbooksPreviewPostResponse
+func (c *ClientWithResponses) RunbooksEditorPreviewUiRunbooksPreviewPostWithBodyWithResponse(ctx context.Context, contentType string, body io.Reader, reqEditors ...RequestEditorFn) (*RunbooksEditorPreviewUiRunbooksPreviewPostResponse, error) {
+	rsp, err := c.RunbooksEditorPreviewUiRunbooksPreviewPostWithBody(ctx, contentType, body, reqEditors...)
+	if err != nil {
+		return nil, err
+	}
+	return ParseRunbooksEditorPreviewUiRunbooksPreviewPostResponse(rsp)
+}
+
+func (c *ClientWithResponses) RunbooksEditorPreviewUiRunbooksPreviewPostWithFormdataBodyWithResponse(ctx context.Context, body RunbooksEditorPreviewUiRunbooksPreviewPostFormdataRequestBody, reqEditors ...RequestEditorFn) (*RunbooksEditorPreviewUiRunbooksPreviewPostResponse, error) {
+	rsp, err := c.RunbooksEditorPreviewUiRunbooksPreviewPostWithFormdataBody(ctx, body, reqEditors...)
+	if err != nil {
+		return nil, err
+	}
+	return ParseRunbooksEditorPreviewUiRunbooksPreviewPostResponse(rsp)
+}
+
 // RunbooksDetailUiRunbooksSlugGetWithResponse request returning *RunbooksDetailUiRunbooksSlugGetResponse
 func (c *ClientWithResponses) RunbooksDetailUiRunbooksSlugGetWithResponse(ctx context.Context, slug string, params *RunbooksDetailUiRunbooksSlugGetParams, reqEditors ...RequestEditorFn) (*RunbooksDetailUiRunbooksSlugGetResponse, error) {
 	rsp, err := c.RunbooksDetailUiRunbooksSlugGet(ctx, slug, params, reqEditors...)
@@ -25067,6 +25576,32 @@ func (c *ClientWithResponses) RunbooksDetailUiRunbooksSlugGetWithResponse(ctx co
 		return nil, err
 	}
 	return ParseRunbooksDetailUiRunbooksSlugGetResponse(rsp)
+}
+
+// RunbooksEditorEditUiRunbooksSlugEditGetWithResponse request returning *RunbooksEditorEditUiRunbooksSlugEditGetResponse
+func (c *ClientWithResponses) RunbooksEditorEditUiRunbooksSlugEditGetWithResponse(ctx context.Context, slug string, reqEditors ...RequestEditorFn) (*RunbooksEditorEditUiRunbooksSlugEditGetResponse, error) {
+	rsp, err := c.RunbooksEditorEditUiRunbooksSlugEditGet(ctx, slug, reqEditors...)
+	if err != nil {
+		return nil, err
+	}
+	return ParseRunbooksEditorEditUiRunbooksSlugEditGetResponse(rsp)
+}
+
+// RunbooksEditorUpdateUiRunbooksSlugEditPostWithBodyWithResponse request with arbitrary body returning *RunbooksEditorUpdateUiRunbooksSlugEditPostResponse
+func (c *ClientWithResponses) RunbooksEditorUpdateUiRunbooksSlugEditPostWithBodyWithResponse(ctx context.Context, slug string, contentType string, body io.Reader, reqEditors ...RequestEditorFn) (*RunbooksEditorUpdateUiRunbooksSlugEditPostResponse, error) {
+	rsp, err := c.RunbooksEditorUpdateUiRunbooksSlugEditPostWithBody(ctx, slug, contentType, body, reqEditors...)
+	if err != nil {
+		return nil, err
+	}
+	return ParseRunbooksEditorUpdateUiRunbooksSlugEditPostResponse(rsp)
+}
+
+func (c *ClientWithResponses) RunbooksEditorUpdateUiRunbooksSlugEditPostWithFormdataBodyWithResponse(ctx context.Context, slug string, body RunbooksEditorUpdateUiRunbooksSlugEditPostFormdataRequestBody, reqEditors ...RequestEditorFn) (*RunbooksEditorUpdateUiRunbooksSlugEditPostResponse, error) {
+	rsp, err := c.RunbooksEditorUpdateUiRunbooksSlugEditPostWithFormdataBody(ctx, slug, body, reqEditors...)
+	if err != nil {
+		return nil, err
+	}
+	return ParseRunbooksEditorUpdateUiRunbooksSlugEditPostResponse(rsp)
 }
 
 // UiTopologyTableUiTopologyGetWithResponse request returning *UiTopologyTableUiTopologyGetResponse
@@ -29611,6 +30146,74 @@ func ParseRunbooksListUiRunbooksListGetResponse(rsp *http.Response) (*RunbooksLi
 	return response, nil
 }
 
+// ParseRunbooksEditorNewUiRunbooksNewGetResponse parses an HTTP response from a RunbooksEditorNewUiRunbooksNewGetWithResponse call
+func ParseRunbooksEditorNewUiRunbooksNewGetResponse(rsp *http.Response) (*RunbooksEditorNewUiRunbooksNewGetResponse, error) {
+	bodyBytes, err := io.ReadAll(rsp.Body)
+	defer func() { _ = rsp.Body.Close() }()
+	if err != nil {
+		return nil, err
+	}
+
+	response := &RunbooksEditorNewUiRunbooksNewGetResponse{
+		Body:         bodyBytes,
+		HTTPResponse: rsp,
+	}
+
+	return response, nil
+}
+
+// ParseRunbooksEditorCreateUiRunbooksNewPostResponse parses an HTTP response from a RunbooksEditorCreateUiRunbooksNewPostWithResponse call
+func ParseRunbooksEditorCreateUiRunbooksNewPostResponse(rsp *http.Response) (*RunbooksEditorCreateUiRunbooksNewPostResponse, error) {
+	bodyBytes, err := io.ReadAll(rsp.Body)
+	defer func() { _ = rsp.Body.Close() }()
+	if err != nil {
+		return nil, err
+	}
+
+	response := &RunbooksEditorCreateUiRunbooksNewPostResponse{
+		Body:         bodyBytes,
+		HTTPResponse: rsp,
+	}
+
+	switch {
+	case strings.Contains(rsp.Header.Get("Content-Type"), "json") && rsp.StatusCode == 422:
+		var dest HTTPValidationError
+		if err := json.Unmarshal(bodyBytes, &dest); err != nil {
+			return nil, err
+		}
+		response.JSON422 = &dest
+
+	}
+
+	return response, nil
+}
+
+// ParseRunbooksEditorPreviewUiRunbooksPreviewPostResponse parses an HTTP response from a RunbooksEditorPreviewUiRunbooksPreviewPostWithResponse call
+func ParseRunbooksEditorPreviewUiRunbooksPreviewPostResponse(rsp *http.Response) (*RunbooksEditorPreviewUiRunbooksPreviewPostResponse, error) {
+	bodyBytes, err := io.ReadAll(rsp.Body)
+	defer func() { _ = rsp.Body.Close() }()
+	if err != nil {
+		return nil, err
+	}
+
+	response := &RunbooksEditorPreviewUiRunbooksPreviewPostResponse{
+		Body:         bodyBytes,
+		HTTPResponse: rsp,
+	}
+
+	switch {
+	case strings.Contains(rsp.Header.Get("Content-Type"), "json") && rsp.StatusCode == 422:
+		var dest HTTPValidationError
+		if err := json.Unmarshal(bodyBytes, &dest); err != nil {
+			return nil, err
+		}
+		response.JSON422 = &dest
+
+	}
+
+	return response, nil
+}
+
 // ParseRunbooksDetailUiRunbooksSlugGetResponse parses an HTTP response from a RunbooksDetailUiRunbooksSlugGetWithResponse call
 func ParseRunbooksDetailUiRunbooksSlugGetResponse(rsp *http.Response) (*RunbooksDetailUiRunbooksSlugGetResponse, error) {
 	bodyBytes, err := io.ReadAll(rsp.Body)
@@ -29620,6 +30223,58 @@ func ParseRunbooksDetailUiRunbooksSlugGetResponse(rsp *http.Response) (*Runbooks
 	}
 
 	response := &RunbooksDetailUiRunbooksSlugGetResponse{
+		Body:         bodyBytes,
+		HTTPResponse: rsp,
+	}
+
+	switch {
+	case strings.Contains(rsp.Header.Get("Content-Type"), "json") && rsp.StatusCode == 422:
+		var dest HTTPValidationError
+		if err := json.Unmarshal(bodyBytes, &dest); err != nil {
+			return nil, err
+		}
+		response.JSON422 = &dest
+
+	}
+
+	return response, nil
+}
+
+// ParseRunbooksEditorEditUiRunbooksSlugEditGetResponse parses an HTTP response from a RunbooksEditorEditUiRunbooksSlugEditGetWithResponse call
+func ParseRunbooksEditorEditUiRunbooksSlugEditGetResponse(rsp *http.Response) (*RunbooksEditorEditUiRunbooksSlugEditGetResponse, error) {
+	bodyBytes, err := io.ReadAll(rsp.Body)
+	defer func() { _ = rsp.Body.Close() }()
+	if err != nil {
+		return nil, err
+	}
+
+	response := &RunbooksEditorEditUiRunbooksSlugEditGetResponse{
+		Body:         bodyBytes,
+		HTTPResponse: rsp,
+	}
+
+	switch {
+	case strings.Contains(rsp.Header.Get("Content-Type"), "json") && rsp.StatusCode == 422:
+		var dest HTTPValidationError
+		if err := json.Unmarshal(bodyBytes, &dest); err != nil {
+			return nil, err
+		}
+		response.JSON422 = &dest
+
+	}
+
+	return response, nil
+}
+
+// ParseRunbooksEditorUpdateUiRunbooksSlugEditPostResponse parses an HTTP response from a RunbooksEditorUpdateUiRunbooksSlugEditPostWithResponse call
+func ParseRunbooksEditorUpdateUiRunbooksSlugEditPostResponse(rsp *http.Response) (*RunbooksEditorUpdateUiRunbooksSlugEditPostResponse, error) {
+	bodyBytes, err := io.ReadAll(rsp.Body)
+	defer func() { _ = rsp.Body.Close() }()
+	if err != nil {
+		return nil, err
+	}
+
+	response := &RunbooksEditorUpdateUiRunbooksSlugEditPostResponse{
 		Body:         bodyBytes,
 		HTTPResponse: rsp,
 	}


### PR DESCRIPTION
## Summary

- Adds the **tenant_admin authoring editor** to the `/ui/runbooks` console (G10.6-T2), extending the T1 read surface in place: a structured, repeatable step editor that builds a valid `RunbookTemplateBody` and submits it through the same `RunbookTemplateService` the REST surface uses.
- New `require_ui_admin`-gated routes: `GET/POST /ui/runbooks/new` (create draft), `POST /ui/runbooks/preview` (HTMX Markdown live-preview), `GET/POST /ui/runbooks/{slug}/edit` (edit-in-place / fork-from-published).
- The discriminated-union step tree (manual vs operation_call step; confirm vs operation_call verify) is posted as one JSON `steps` field built by an Alpine model, rebuilt server-side and validated by Pydantic (the authoritative source of truth). Client-side validation mirrors the slug / step-id / `${...}` substitution-allowlist rules as convenience. Each step body is a CodeMirror 6 Markdown editor wired exactly as the KB editor, with a debounced server-rendered preview.
- Server `409` (duplicate slug) / `422` (validation) / `404` map to inline field errors with entered data preserved + CSRF re-minted; a fork-on-edit surfaces `forked_from` + `in_flight_run_count` from the PATCH response.

## Test plan

- [x] `ruff check` + `ruff format --check` — clean
- [x] `mypy` — clean (5 source files)
- [x] code-quality gate (`--diff`) — 0 blockers
- [x] `pytest tests/test_ui_runbooks_editor.py` — 14 passed
- [x] admin-gating: `GET /ui/runbooks/new` + `.../edit` → 200 admin / 403 operator (server-enforced) ✓
- [x] valid-body submission both step kinds + both verify kinds → draft created (204 + HX-Redirect), round-trips at v1/draft ✓
- [x] client + server validation: bad slug / dotted step id / disallowed `${run.secret}` → inline 422, entered data preserved, CSRF re-minted ✓
- [x] fork-on-edit: editing a published template forks a v2 draft + surfaces source version + in-flight run count ✓
- [x] in-place draft edit → 204 redirect ✓
- [x] live preview renders Markdown (admin) / 403 (operator) ✓
- [x] T1 read-surface suite + dashboard/KB UI suites still green (88 passed across the UI subset)
- [x] CLI OpenAPI snapshot regenerated (5 new `/ui/runbooks*` paths) + Go client regenerated; `go build ./...` OK

## Out of scope

- Publish/deprecate lifecycle controls (T3), op_id registry autocomplete (free-text op_id by design), docs/acceptance (T4), run-execution UI.
- `op_id` is free-text per the issue scope.

<!-- auto-implement-issue: fresh, iteration 1 -->

Closes #1383.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
