### PR TITLE
feat(ui): G10.6-T3 runbooks lifecycle controls — publish / deprecate / fork-on-edit

### DIFF
--- a/backend/src/meho_backplane/runbooks/service.py
+++ b/backend/src/meho_backplane/runbooks/service.py
@@ -365,6 +365,26 @@ class RunbookTemplateService:
             slug=request.slug, version=request.version, status="deprecated"
         )
 
+    async def count_in_flight_runs(
+        self,
+        tenant_id: uuid.UUID,
+        slug: str,
+        version: int,
+    ) -> int:
+        """Count ``in_progress`` runs pinned to ``(tenant_id, slug, version)``.
+
+        The same projection :meth:`update_or_fork` reports in
+        :attr:`~meho_backplane.runbooks.schemas.ForkInfo.in_flight_run_count`,
+        exposed as a standalone read so the console's published-template
+        detail view can surface how many runs are still bound to the
+        version *before* an admin forks it (forking leaves those runs
+        pinned to the source). Tenant-scoped; a cross-tenant / missing
+        ``(slug, version)`` simply has zero matching runs and returns ``0``.
+        """
+        sessionmaker = get_sessionmaker()
+        async with sessionmaker() as session:
+            return await _count_in_flight_runs(session, tenant_id, slug, version)
+
     async def list_templates(
         self,
         tenant_id: uuid.UUID,

--- a/backend/src/meho_backplane/ui/routes/runbooks/lifecycle.py
+++ b/backend/src/meho_backplane/ui/routes/runbooks/lifecycle.py
@@ -1,0 +1,280 @@
+# SPDX-License-Identifier: Apache-2.0
+# Copyright (c) 2026 evoila Group
+
+"""Runbooks UI lifecycle controls: publish / deprecate handler bodies + wiring.
+
+Initiative #1381 (G10.6 Runbooks UI), Task #1384 (T3). The ``tenant_admin``
+lifecycle half of the ``/ui/runbooks*`` surface -- the publish / deprecate
+actions that drive a template through its state machine
+(``draft --publish--> published --deprecate--> deprecated``) over the same
+service the REST surface (:mod:`meho_backplane.api.v1.runbook_templates`) and
+the CLI (``meho runbook publish-template`` / ``deprecate-template``) use.
+
+Route inventory (all ``require_ui_admin``-gated):
+
+* ``POST /ui/runbooks/{slug}/publish``    -> :meth:`RunbookTemplateService.publish`
+  (mirrors REST ``POST /api/v1/runbooks/templates/{slug}/publish`` -- 200
+  idempotent / 400 not-draft / 404).
+* ``POST /ui/runbooks/{slug}/deprecate``  -> :meth:`RunbookTemplateService.deprecate`
+  (mirrors REST ``POST /api/v1/runbooks/templates/{slug}/deprecate`` -- 200
+  idempotent / 400 not-published / 404).
+
+Both target the **specific** ``version`` carried by the detail / list view the
+control was rendered into (the form posts a ``version`` field), so a stale
+catalog row that pointed at an older version acts on that version rather than
+silently retargeting the latest. The slug is the URL's job; the body carries
+the integer version only -- the same single-source-of-truth posture the REST
+``_VersionBody`` enforces.
+
+Split out of :mod:`meho_backplane.ui.routes.runbooks.routes` (the read
+surface, T1 #1382) and :mod:`meho_backplane.ui.routes.runbooks.editor` (the
+authoring surface, T2 #1383) so the lifecycle concern lives in its own module
+and no file crosses the code-quality size gate -- the same package-split
+convention the editor used. This module holds the action handlers + the
+fragment render; the FastAPI route wiring is :func:`register_lifecycle_routes`,
+called from :func:`build_runbooks_router` ahead of the ``/ui/runbooks/{slug}``
+catch-all.
+
+Response shape
+--------------
+
+Each action posts via HTMX against the detail view's ``#runbook-lifecycle``
+region and swaps the re-rendered :mod:`runbooks/_detail_actions.html` fragment
+back in. That fragment carries:
+
+* the lifecycle action row (the buttons valid for the new state), and
+* an ``hx-swap-oob`` copy of the status badge, so the header badge in
+  ``detail.html`` flips in place without a full-page reload, and
+* an inline DaisyUI alert region -- a typed 400 (publishing a non-draft, or
+  deprecating a non-published version) renders as an ``alert-error``; an
+  idempotent re-action (200 no-op) just refreshes the badge with no error.
+
+A 404 (missing slug / version, or a cross-tenant probe) is the one case that
+raises ``HTTPException`` rather than re-rendering the fragment: the version the
+control names no longer exists, so there is no coherent state to render -- the
+detail page the operator is on is stale and a reload is the right move.
+
+CSRF
+----
+
+The action buttons echo ``X-CSRF-Token`` via ``hx-headers`` (the token minted
+on the detail render + set as the JS-readable cookie). The
+:class:`~meho_backplane.ui.csrf.CSRFMiddleware` blocks any POST missing the
+double-submit token before the handler runs -- a forged operator POST with no
+token is a 403 at the CSRF gate; a forged operator POST *with* a token is a 403
+at :func:`~meho_backplane.ui.auth.middleware.require_ui_admin` (the role
+re-check is the real authority -- the hidden client controls are convenience
+only).
+
+References
+----------
+
+* HTMX 2.0.9 ``hx-swap-oob`` (out-of-band badge refresh):
+  https://htmx.org/attributes/hx-swap-oob/
+* DaisyUI 5.5.20 alert / badge: https://daisyui.com/components/alert/
+"""
+
+from __future__ import annotations
+
+from dataclasses import dataclass
+from typing import Final
+
+import structlog
+from fastapi import APIRouter, Depends, Form, HTTPException, Request
+from fastapi.responses import HTMLResponse
+
+from meho_backplane.runbooks.schemas import (
+    DeprecateTemplateRequest,
+    PublishTemplateRequest,
+    ShowTemplateResponse,
+)
+from meho_backplane.runbooks.service import (
+    RunbookTemplateService,
+    TemplateNotDraftError,
+    TemplateNotFoundError,
+    TemplateNotPublishedError,
+)
+from meho_backplane.ui.auth.middleware import UISessionContext, require_ui_admin
+from meho_backplane.ui.csrf import mint_csrf_token
+from meho_backplane.ui.routes.runbooks.editor import set_csrf_cookie
+from meho_backplane.ui.templating import get_templates
+
+__all__ = ["register_lifecycle_routes"]
+
+log = structlog.get_logger(__name__)
+
+#: Module-level ``Depends`` closure for the ``tenant_admin`` gate every
+#: lifecycle route requires (B008 idiom -- no call in a default arg). Mirrors
+#: the editor surface: ``require_ui_admin`` re-verifies the session's access
+#: token and raises 403 for ``operator`` / ``read_only`` before the handler
+#: body runs.
+_require_admin = Depends(require_ui_admin)
+
+#: Cap on the ``version`` form field's string length before integer parsing.
+#: A version is a small positive integer; this guards against an unbounded
+#: form value reaching :func:`int` rather than expressing a real ceiling.
+_MAX_VERSION_FIELD_LENGTH: Final[int] = 16
+
+
+@dataclass(frozen=True)
+class _ActionOutcome:
+    """Resolved outcome of a publish / deprecate action.
+
+    Exactly one of :attr:`template` (success -> re-render the fragment with
+    the new status) or :attr:`error_message` (a typed 400 -> inline alert,
+    badge unchanged) is the load-bearing field. On the error path
+    :attr:`template` still carries the row in its *current* (unchanged) state
+    so the fragment renders the correct badge + valid actions alongside the
+    alert.
+    """
+
+    template: ShowTemplateResponse
+    error_message: str | None
+
+
+async def _resolve_template(
+    session: UISessionContext, slug: str, version: int
+) -> ShowTemplateResponse:
+    """Load ``(slug, version)`` for the current tenant, or 404.
+
+    A missing / cross-tenant ``(slug, version)`` raises 404 -- the version the
+    control named no longer resolves, so the detail page is stale and a reload
+    is the right move (the fragment has no coherent state to render). The
+    service's tenant filter makes another tenant's row invisible, so a
+    cross-tenant probe collapses to the same 404 as a genuinely absent row.
+    """
+    try:
+        return await RunbookTemplateService().show_template(
+            session.tenant_id, slug, version=version
+        )
+    except TemplateNotFoundError as exc:
+        raise HTTPException(status_code=404, detail="runbook_template_not_found") from exc
+
+
+async def _publish(session: UISessionContext, slug: str, version: int) -> _ActionOutcome:
+    """Promote ``(slug, version)`` draft -> published; map the typed 400 to an alert.
+
+    Idempotent: re-publishing an already-published version is a service-layer
+    no-op (the fragment re-renders with the published badge, no error).
+    Publishing a deprecated version raises :class:`TemplateNotDraftError` ->
+    inline ``alert-error`` with the badge left on its current state.
+    """
+    try:
+        await RunbookTemplateService().publish(
+            session.tenant_id, PublishTemplateRequest(slug=slug, version=version)
+        )
+    except TemplateNotFoundError as exc:
+        raise HTTPException(status_code=404, detail="runbook_template_not_found") from exc
+    except TemplateNotDraftError as exc:
+        template = await _resolve_template(session, slug, version)
+        return _ActionOutcome(template=template, error_message=str(exc))
+    template = await _resolve_template(session, slug, version)
+    return _ActionOutcome(template=template, error_message=None)
+
+
+async def _deprecate(session: UISessionContext, slug: str, version: int) -> _ActionOutcome:
+    """Retire ``(slug, version)`` published -> deprecated; map the typed 400 to an alert.
+
+    Idempotent: re-deprecating an already-deprecated version is a service-layer
+    no-op. Deprecating a draft raises :class:`TemplateNotPublishedError` ->
+    inline ``alert-error`` with the badge unchanged.
+    """
+    try:
+        await RunbookTemplateService().deprecate(
+            session.tenant_id, DeprecateTemplateRequest(slug=slug, version=version)
+        )
+    except TemplateNotFoundError as exc:
+        raise HTTPException(status_code=404, detail="runbook_template_not_found") from exc
+    except TemplateNotPublishedError as exc:
+        template = await _resolve_template(session, slug, version)
+        return _ActionOutcome(template=template, error_message=str(exc))
+    template = await _resolve_template(session, slug, version)
+    return _ActionOutcome(template=template, error_message=None)
+
+
+async def _render_actions_fragment(
+    request: Request,
+    session: UISessionContext,
+    outcome: _ActionOutcome,
+) -> HTMLResponse:
+    """Render the ``_detail_actions.html`` fragment for an HTMX swap.
+
+    Carries the post-action status badge (with an ``hx-swap-oob`` copy that
+    refreshes the header badge), the lifecycle action row valid for the new
+    state, and -- on the typed-400 path -- the inline alert. CSRF is re-minted
+    (the prior token was consumed by this POST) so the next action carries a
+    live token; the cookie is refreshed to match.
+    """
+    template = outcome.template
+    in_flight = 0
+    if template.status == "published":
+        in_flight = await RunbookTemplateService().count_in_flight_runs(
+            session.tenant_id, template.slug, template.version
+        )
+    csrf_token = mint_csrf_token(str(session.session_id))
+    context = {
+        "template": template,
+        "is_admin": True,
+        "in_flight_run_count": in_flight,
+        "lifecycle_error": outcome.error_message,
+        "csrf_token": csrf_token,
+        "swap_badge": True,
+    }
+    response = get_templates().TemplateResponse(request, "runbooks/_detail_actions.html", context)
+    set_csrf_cookie(response, csrf_token)
+    return response
+
+
+def _parse_version(raw: str) -> int:
+    """Parse the ``version`` form field to a positive int, or 422.
+
+    The control always posts the integer version it was rendered against; a
+    non-integer / non-positive value is a malformed request (a tampered form),
+    so a 422 is the right boundary failure rather than a 500 deeper in.
+    """
+    try:
+        value = int(raw.strip())
+    except (TypeError, ValueError) as exc:
+        raise HTTPException(status_code=422, detail="version must be an integer") from exc
+    if value < 1:
+        raise HTTPException(status_code=422, detail="version must be >= 1")
+    return value
+
+
+def register_lifecycle_routes(router: APIRouter) -> None:
+    """Register the ``require_ui_admin``-gated publish / deprecate routes.
+
+    The T3 (#1384) lifecycle surface: the publish + deprecate POST handlers.
+    Called by
+    :func:`meho_backplane.ui.routes.runbooks.routes.build_runbooks_router`
+    after the read + editor routes so the literal segments are registered
+    BEFORE ``/ui/runbooks/{slug}`` (FastAPI is first-match-wins -- the
+    ``{slug}`` catch-all would otherwise swallow ``publish`` / ``deprecate``).
+    Every route declares ``_require_admin``: the server is the single source of
+    truth for the privilege; an ``operator`` gets 403 at the dependency, before
+    the handler body runs.
+    """
+
+    @router.post("/ui/runbooks/{slug}/publish", response_class=HTMLResponse)
+    async def runbooks_publish(
+        slug: str,
+        request: Request,
+        session: UISessionContext = _require_admin,
+        version: str = Form(default="", max_length=_MAX_VERSION_FIELD_LENGTH),
+    ) -> HTMLResponse:
+        """Publish ``(slug, version)`` (draft -> published); admin only."""
+        parsed = _parse_version(version)
+        outcome = await _publish(session, slug.strip(), parsed)
+        return await _render_actions_fragment(request, session, outcome)
+
+    @router.post("/ui/runbooks/{slug}/deprecate", response_class=HTMLResponse)
+    async def runbooks_deprecate(
+        slug: str,
+        request: Request,
+        session: UISessionContext = _require_admin,
+        version: str = Form(default="", max_length=_MAX_VERSION_FIELD_LENGTH),
+    ) -> HTMLResponse:
+        """Deprecate ``(slug, version)`` (published -> deprecated); admin only."""
+        parsed = _parse_version(version)
+        outcome = await _deprecate(session, slug.strip(), parsed)
+        return await _render_actions_fragment(request, session, outcome)

--- a/backend/src/meho_backplane/ui/routes/runbooks/lifecycle.py
+++ b/backend/src/meho_backplane/ui/routes/runbooks/lifecycle.py
@@ -115,6 +115,17 @@ _require_admin = Depends(require_ui_admin)
 #: form value reaching :func:`int` rather than expressing a real ceiling.
 _MAX_VERSION_FIELD_LENGTH: Final[int] = 16
 
+#: Prefix of the HTMX ``hx-target`` element id the **catalog** row action points
+#: at (``#runbook-row-alert-<slug>@<version>``). When the ``HX-Target`` request
+#: header starts with this prefix the action originated from the catalog list,
+#: so the handler returns the minimal ``runbooks/_row_alert.html`` slot fragment
+#: (an inline alert on a typed-400, empty on success) instead of the detail
+#: surface's full ``_detail_actions.html`` row. The detail surface targets
+#: ``#runbook-lifecycle`` and gets the full fragment. This is how the catalog
+#: path surfaces a typed-400 inline rather than swallowing it under the
+#: success-only ``runbooks-refresh`` reload.
+_CATALOG_ROW_ALERT_TARGET_PREFIX: Final[str] = "runbook-row-alert-"
+
 
 @dataclass(frozen=True)
 class _ActionOutcome:
@@ -192,6 +203,42 @@ async def _deprecate(session: UISessionContext, slug: str, version: int) -> _Act
     return _ActionOutcome(template=template, error_message=None)
 
 
+def _is_catalog_row_action(request: Request) -> bool:
+    """Return ``True`` when this POST was dispatched from the catalog row.
+
+    The catalog row action targets the per-row ``#runbook-row-alert-…`` slot, so
+    HTMX sends that element id in the ``HX-Target`` request header. The detail
+    surface targets ``#runbook-lifecycle`` instead. Branching on the target lets
+    one handler serve both surfaces with the right fragment: the catalog gets the
+    minimal alert slot (inline typed-400 / empty on success) and the detail page
+    gets the full action row + OOB badge refresh.
+    """
+    target = request.headers.get("HX-Target", "")
+    return target.startswith(_CATALOG_ROW_ALERT_TARGET_PREFIX)
+
+
+async def _render_row_alert_fragment(
+    request: Request,
+    session: UISessionContext,
+    outcome: _ActionOutcome,
+) -> HTMLResponse:
+    """Render the catalog ``_row_alert.html`` slot for an HTMX swap.
+
+    The catalog row action surfaces a typed-400 inline (``alert-error`` in the
+    per-row slot) and renders empty on success -- the button's success-only
+    ``runbooks-refresh`` then reloads the list so the new badge shows. The CSRF
+    cookie is re-minted + refreshed here too: the freshly-rendered list fragment
+    (after ``runbooks-refresh``) re-mints its own token, but on the typed-400
+    path the list is NOT reloaded, so the row's button must keep a token whose
+    cookie still matches for a retry against a corrected row.
+    """
+    csrf_token = mint_csrf_token(str(session.session_id))
+    context = {"lifecycle_error": outcome.error_message}
+    response = get_templates().TemplateResponse(request, "runbooks/_row_alert.html", context)
+    set_csrf_cookie(response, csrf_token)
+    return response
+
+
 async def _render_actions_fragment(
     request: Request,
     session: UISessionContext,
@@ -204,7 +251,15 @@ async def _render_actions_fragment(
     state, and -- on the typed-400 path -- the inline alert. CSRF is re-minted
     (the prior token was consumed by this POST) so the next action carries a
     live token; the cookie is refreshed to match.
+
+    When the action was dispatched from the **catalog** row (``HX-Target``
+    points at a ``#runbook-row-alert-…`` slot) the minimal catalog slot fragment
+    is returned instead -- the detail-shaped action row + OOB badge would be
+    nonsense swapped into a list row, and the catalog surfaces its typed-400
+    inline via :func:`_render_row_alert_fragment`.
     """
+    if _is_catalog_row_action(request):
+        return await _render_row_alert_fragment(request, session, outcome)
     template = outcome.template
     in_flight = 0
     if template.status == "published":

--- a/backend/src/meho_backplane/ui/routes/runbooks/routes.py
+++ b/backend/src/meho_backplane/ui/routes/runbooks/routes.py
@@ -307,7 +307,18 @@ async def _render_list_fragment(
     status: _StatusFilter | None,
     target_kind: str | None,
 ) -> HTMLResponse:
-    """Render the ``_list.html`` fragment for the HTMX filter controls."""
+    """Render the ``_list.html`` fragment for the HTMX filter controls.
+
+    The fragment re-mints the CSRF token into the admin row-action
+    Publish/Deprecate buttons (``hx-headers``), so the response **must** also
+    refresh the ``meho_csrf`` cookie to match -- otherwise the next row-action
+    POST presents a header token that no longer equals the stale cookie and the
+    :class:`~meho_backplane.ui.csrf.CSRFMiddleware` ``value_mismatch`` check
+    403s the action. Filter swaps and the post-action ``runbooks-refresh``
+    reload both re-render via this path, so a missing cookie refresh breaks the
+    catalog row action on the second interaction. Mirrors the cookie posture of
+    :func:`_render_index` / :func:`_render_detail` (mint -> ``_set_csrf_cookie``).
+    """
     summaries = await _list_summaries(session.tenant_id, status, target_kind)
     csrf_token = mint_csrf_token(str(session.session_id))
     is_admin = await _is_admin(session)
@@ -319,7 +330,9 @@ async def _render_list_fragment(
         "csrf_token": csrf_token,
         "active_surface": "runbooks",
     }
-    return get_templates().TemplateResponse(request, "runbooks/_list.html", context)
+    response = get_templates().TemplateResponse(request, "runbooks/_list.html", context)
+    _set_csrf_cookie(response, csrf_token)
+    return response
 
 
 async def _render_detail(

--- a/backend/src/meho_backplane/ui/routes/runbooks/routes.py
+++ b/backend/src/meho_backplane/ui/routes/runbooks/routes.py
@@ -112,6 +112,7 @@ from meho_backplane.ui.auth.session_store import load_session
 from meho_backplane.ui.csrf import CSRF_COOKIE_NAME, mint_csrf_token
 from meho_backplane.ui.routes.kb.render import pygments_css, render_markdown
 from meho_backplane.ui.routes.runbooks.editor_routes import register_editor_routes
+from meho_backplane.ui.routes.runbooks.lifecycle import register_lifecycle_routes
 from meho_backplane.ui.templating import get_templates
 
 __all__ = ["build_runbooks_router"]
@@ -203,6 +204,20 @@ async def _resolve_role(session_ctx: UISessionContext) -> Operator | None:
     return operator
 
 
+async def _is_admin(session_ctx: UISessionContext) -> bool:
+    """Resolve whether the session's operator is a ``tenant_admin``.
+
+    Thin wrapper over :func:`_resolve_role` returning just the admin verdict --
+    the catalog + list-fragment renders need the boolean (to show / hide the
+    lifecycle row actions) but not the full :class:`Operator`. Fails soft to
+    ``False`` (operator privileges) via :func:`_resolve_role`, so the row
+    actions are hidden whenever the role lift can't complete. The POST handlers
+    re-check server-side, so a hidden-but-forged action is still a 403.
+    """
+    operator = await _resolve_role(session_ctx)
+    return operator is not None and operator.tenant_role == TenantRole.TENANT_ADMIN
+
+
 def _render_steps(template: ShowTemplateResponse) -> list[dict[str, object]]:
     """Project the template's ordered steps into render-ready dicts.
 
@@ -267,10 +282,12 @@ async def _render_index(
     """
     summaries = await _list_summaries(session.tenant_id, status, target_kind)
     csrf_token = mint_csrf_token(str(session.session_id))
+    is_admin = await _is_admin(session)
     context = {
         "summaries": summaries,
         "status_filter": status or "",
         "target_kind_filter": target_kind or "",
+        "is_admin": is_admin,
         "operator_sub": session.operator_sub,
         "csrf_token": csrf_token,
         "active_surface": "runbooks",
@@ -292,10 +309,14 @@ async def _render_list_fragment(
 ) -> HTMLResponse:
     """Render the ``_list.html`` fragment for the HTMX filter controls."""
     summaries = await _list_summaries(session.tenant_id, status, target_kind)
+    csrf_token = mint_csrf_token(str(session.session_id))
+    is_admin = await _is_admin(session)
     context = {
         "summaries": summaries,
         "status_filter": status or "",
         "target_kind_filter": target_kind or "",
+        "is_admin": is_admin,
+        "csrf_token": csrf_token,
         "active_surface": "runbooks",
     }
     return get_templates().TemplateResponse(request, "runbooks/_list.html", context)
@@ -320,12 +341,24 @@ async def _render_detail(
     is_admin = operator is not None and operator.tenant_role == TenantRole.TENANT_ADMIN
     detail = await _resolve_detail(session, slug, version, is_admin=is_admin)
     csrf_token = mint_csrf_token(str(session.session_id))
+    # The fork-on-edit affordance surfaces how many runs are still pinned to a
+    # published version (forking leaves them bound to the source). Only a real,
+    # admin-visible published row needs the count; the restricted placeholder
+    # and non-published states show none.
+    in_flight_run_count = 0
+    if not detail.restricted and detail.template.status == "published":
+        in_flight_run_count = await RunbookTemplateService().count_in_flight_runs(
+            session.tenant_id, detail.template.slug, detail.template.version
+        )
     context = {
         "template": detail.template,
         "restricted": detail.restricted,
         "steps_rendered": detail.steps_rendered,
         "code_css": pygments_css(),
         "is_admin": is_admin,
+        "in_flight_run_count": in_flight_run_count,
+        "lifecycle_error": None,
+        "swap_badge": False,
         "operator_sub": session.operator_sub,
         "csrf_token": csrf_token,
         "active_surface": "runbooks",
@@ -377,6 +410,12 @@ def build_runbooks_router() -> APIRouter:
     # ``preview`` segments as slug parameters. Their handlers + the form
     # (de)serialisation live in ``runbooks.editor``.
     register_editor_routes(router)
+
+    # The T3 (#1384) lifecycle routes (``/ui/runbooks/{slug}/publish`` +
+    # ``/ui/runbooks/{slug}/deprecate`` POST) -- registered here, also BEFORE
+    # ``/ui/runbooks/{slug}`` so the literal ``publish`` / ``deprecate`` tail
+    # segments are not swallowed by the slug catch-all.
+    register_lifecycle_routes(router)
 
     @router.get("/ui/runbooks/{slug}", response_class=HTMLResponse)
     async def runbooks_detail(

--- a/backend/src/meho_backplane/ui/templates/runbooks/_detail_actions.html
+++ b/backend/src/meho_backplane/ui/templates/runbooks/_detail_actions.html
@@ -1,0 +1,160 @@
+{#-
+  SPDX-License-Identifier: Apache-2.0
+  Copyright (c) 2026 evoila Group
+
+  Runbook detail lifecycle action row + status badge + inline alert.
+
+  Initiative #1381 (G10.6 Runbooks UI), Task #1384 (T3). Rendered two ways:
+
+    * {% include %}-d into ``detail.html`` for the initial page render, and
+    * returned standalone by the publish / deprecate POST handlers
+      (``lifecycle.register_lifecycle_routes``) and swapped into
+      ``#runbook-lifecycle`` by HTMX after an action.
+
+  The wrapping ``#runbook-lifecycle`` element is the HTMX swap target. When
+  this fragment is returned from a POST, ``swap_badge`` is True so an
+  ``hx-swap-oob`` copy of the status badge also refreshes the header badge in
+  ``detail.html`` (which carries ``id="runbook-status-badge"``) without a
+  full-page reload.
+
+  Context variables:
+    template            -- ShowTemplateResponse: the resolved template, in its
+                           CURRENT (post-action, or pre-action on error) state
+    is_admin            -- bool: caller is tenant_admin (controls hidden for
+                           operators; the POST handlers re-check server-side)
+    in_flight_run_count -- int: in-progress runs pinned to this published
+                           version (surfaced on the fork-on-edit affordance)
+    lifecycle_error     -- str | None: typed-400 message -> inline alert-error
+    csrf_token          -- str: double-submit token echoed via hx-headers
+    swap_badge          -- bool: emit the hx-swap-oob header-badge refresh
+                           (True only on the POST re-render, not the include)
+-#}
+{%- macro status_badge(status, oob=False) -%}
+  {%- if status == "published" -%}
+    <span class="badge badge-success badge-outline" aria-label="Status: published"
+          {% if oob %}id="runbook-status-badge" hx-swap-oob="true"{% endif %}>published</span>
+  {%- elif status == "draft" -%}
+    <span class="badge badge-warning badge-outline" aria-label="Status: draft"
+          {% if oob %}id="runbook-status-badge" hx-swap-oob="true"{% endif %}>draft</span>
+  {%- else -%}
+    <span class="badge badge-ghost badge-outline" aria-label="Status: deprecated"
+          {% if oob %}id="runbook-status-badge" hx-swap-oob="true"{% endif %}>deprecated</span>
+  {%- endif -%}
+{%- endmacro -%}
+
+<div id="runbook-lifecycle" class="space-y-3"
+     x-data="{ confirm: '' }">
+
+  {# OOB header-badge refresh — only emitted from the POST re-render so the
+     header badge in detail.html flips in place after an action. #}
+  {% if swap_badge %}{{ status_badge(template.status, oob=True) }}{% endif %}
+
+  {# ---------- Inline lifecycle alert (typed 400) ---------- #}
+  {% if lifecycle_error %}
+    <div role="alert" class="alert alert-error text-sm" aria-live="assertive">
+      <span aria-hidden="true">&#9888;</span>
+      <span>{{ lifecycle_error }}</span>
+    </div>
+  {% endif %}
+
+  {% if is_admin %}
+    {# ---------- Lifecycle action row (tenant_admin only) ---------- #}
+    <div class="flex flex-wrap items-center gap-2">
+      {% if template.status == "draft" %}
+        {# Publish — promotes this draft version to published. #}
+        <button
+          type="button"
+          class="btn btn-success btn-sm"
+          x-on:click="confirm = 'publish'"
+          aria-label="Publish {{ template.slug }} v{{ template.version }}"
+        >
+          Publish
+        </button>
+      {% elif template.status == "published" %}
+        {# Deprecate — retires this published version. #}
+        <button
+          type="button"
+          class="btn btn-warning btn-sm"
+          x-on:click="confirm = 'deprecate'"
+          aria-label="Deprecate {{ template.slug }} v{{ template.version }}"
+        >
+          Deprecate
+        </button>
+        {# Edit (forks draft) — editing a published template forks a new draft
+           (reuses the T2 PATCH path via the editor route). Surface how many
+           runs are still pinned to this version so the admin knows what the
+           fork will leave behind. #}
+        <a
+          href="/ui/runbooks/{{ template.slug }}/edit"
+          class="btn btn-outline btn-sm"
+          aria-label="Edit {{ template.slug }} (forks a new draft)"
+        >
+          Edit (forks draft)
+        </a>
+        <span class="text-xs opacity-60" aria-live="polite">
+          {{ in_flight_run_count }} in-flight run{{ "" if in_flight_run_count == 1 else "s" }}
+          pinned to v{{ template.version }}
+        </span>
+      {% else %}
+        {# deprecated — terminal; no lifecycle action, but editing forks a
+           fresh draft from the latest version. #}
+        <a
+          href="/ui/runbooks/{{ template.slug }}/edit"
+          class="btn btn-outline btn-sm"
+          aria-label="Edit {{ template.slug }} (forks a new draft)"
+        >
+          Edit (forks draft)
+        </a>
+      {% endif %}
+    </div>
+
+    {# ---------- Alpine confirmation dialog (names slug + version) ---------- #}
+    {% if template.status in ("draft", "published") %}
+      {%- set action = "publish" if template.status == "draft" else "deprecate" -%}
+      <div
+        x-show="confirm === '{{ action }}'"
+        x-cloak
+        class="modal modal-open"
+        role="dialog"
+        aria-modal="true"
+        aria-label="Confirm {{ action }}"
+      >
+        <div class="modal-box">
+          <h3 class="text-lg font-semibold">
+            {{ "Publish" if action == "publish" else "Deprecate" }} this template?
+          </h3>
+          <p class="py-3 text-sm">
+            {% if action == "publish" %}
+              Promote <code class="font-mono">{{ template.slug }}</code>
+              <span class="font-mono">v{{ template.version }}</span> from draft to
+              <strong>published</strong>. Published versions are immutable; further
+              edits fork a new draft.
+            {% else %}
+              Retire <code class="font-mono">{{ template.slug }}</code>
+              <span class="font-mono">v{{ template.version }}</span> to
+              <strong>deprecated</strong>. New runs can no longer start against it.
+            {% endif %}
+          </p>
+          <div class="modal-action">
+            <button type="button" class="btn btn-ghost btn-sm" x-on:click="confirm = ''">
+              Cancel
+            </button>
+            <button
+              type="button"
+              class="btn btn-sm {{ 'btn-success' if action == 'publish' else 'btn-warning' }}"
+              hx-post="/ui/runbooks/{{ template.slug }}/{{ action }}"
+              hx-vals='{"version": "{{ template.version }}"}'
+              hx-target="#runbook-lifecycle"
+              hx-swap="outerHTML"
+              hx-headers='{"X-CSRF-Token": "{{ csrf_token | default('') }}"}'
+              x-on:click="confirm = ''"
+            >
+              {{ "Publish" if action == "publish" else "Deprecate" }}
+            </button>
+          </div>
+        </div>
+        <div class="modal-backdrop" x-on:click="confirm = ''"></div>
+      </div>
+    {% endif %}
+  {% endif %}
+</div>

--- a/backend/src/meho_backplane/ui/templates/runbooks/_list.html
+++ b/backend/src/meho_backplane/ui/templates/runbooks/_list.html
@@ -14,14 +14,23 @@
     summaries          -- list[TemplateSummary]: latest version per slug
     status_filter      -- str: active status filter ("" = all)
     target_kind_filter -- str: active target_kind filter ("" = all)
+    is_admin           -- bool: caller is tenant_admin (gates the row
+                          lifecycle actions; the POST handlers re-check
+                          server-side via require_ui_admin)
+    csrf_token         -- str: double-submit token echoed via hx-headers on
+                          the row publish / deprecate POSTs
 
   Layout:
     * Non-empty: DaisyUI table of slug / version / title / status badge /
-      target_kind / edited_at, each row linking to the detail page.
+      target_kind / edited_at, each row linking to the detail page. A
+      tenant_admin additionally sees a Publish (draft) / Deprecate (published)
+      row action, each behind an Alpine confirm dialog naming slug + version;
+      a successful action reloads the catalog so the new badge shows.
     * Empty: friendly empty-state card (filter-aware copy when a filter is
       active).
 -#}
-<div id="runbooks-list" class="space-y-3">
+<div id="runbooks-list" class="space-y-3"
+     {% if is_admin %}x-data="{ confirmKey: '' }"{% endif %}>
   {% if summaries %}
     <div class="card bg-base-100 border-base-300 overflow-x-auto border shadow-sm">
       <table class="table table-sm" aria-label="Runbook templates">
@@ -69,13 +78,73 @@
                 {{ tpl.edited_at.strftime("%Y-%m-%d %H:%M") }}
               </td>
               <td>
-                <a
-                  href="/ui/runbooks/{{ tpl.slug }}"
-                  class="btn btn-ghost btn-xs"
-                  aria-label="View template {{ tpl.slug }}"
-                >
-                  View
-                </a>
+                <div class="flex items-center justify-end gap-1">
+                  <a
+                    href="/ui/runbooks/{{ tpl.slug }}"
+                    class="btn btn-ghost btn-xs"
+                    aria-label="View template {{ tpl.slug }}"
+                  >
+                    View
+                  </a>
+                  {# Lifecycle row action — tenant_admin only. A Publish on a
+                     draft, a Deprecate on a published version; each names the
+                     specific (slug, version) the row shows. The POST handlers
+                     re-check require_ui_admin server-side. #}
+                  {% if is_admin and tpl.status in ("draft", "published") %}
+                    {%- set row_action = "publish" if tpl.status == "draft" else "deprecate" -%}
+                    {%- set row_key = tpl.slug ~ "@" ~ tpl.version -%}
+                    <button
+                      type="button"
+                      class="btn btn-xs {{ 'btn-success' if row_action == 'publish' else 'btn-warning' }}"
+                      x-on:click="confirmKey = '{{ row_key }}'"
+                      aria-label="{{ row_action | capitalize }} {{ tpl.slug }} v{{ tpl.version }}"
+                    >
+                      {{ row_action | capitalize }}
+                    </button>
+                    <div
+                      x-show="confirmKey === '{{ row_key }}'"
+                      x-cloak
+                      class="modal modal-open"
+                      role="dialog"
+                      aria-modal="true"
+                      aria-label="Confirm {{ row_action }} {{ tpl.slug }}"
+                    >
+                      <div class="modal-box">
+                        <h3 class="text-lg font-semibold">
+                          {{ row_action | capitalize }}
+                          <code class="font-mono">{{ tpl.slug }}</code>
+                          <span class="font-mono">v{{ tpl.version }}</span>?
+                        </h3>
+                        <p class="py-3 text-sm">
+                          {% if row_action == "publish" %}
+                            Promote this draft to <strong>published</strong>.
+                          {% else %}
+                            Retire this published version to <strong>deprecated</strong>.
+                          {% endif %}
+                        </p>
+                        <div class="modal-action">
+                          <button type="button" class="btn btn-ghost btn-sm"
+                                  x-on:click="confirmKey = ''">
+                            Cancel
+                          </button>
+                          <button
+                            type="button"
+                            class="btn btn-sm {{ 'btn-success' if row_action == 'publish' else 'btn-warning' }}"
+                            hx-post="/ui/runbooks/{{ tpl.slug }}/{{ row_action }}"
+                            hx-vals='{"version": "{{ tpl.version }}"}'
+                            hx-headers='{"X-CSRF-Token": "{{ csrf_token | default('') }}"}'
+                            hx-swap="none"
+                            x-on:click="confirmKey = ''"
+                            x-on:htmx:after-request="$dispatch('runbooks-refresh')"
+                          >
+                            {{ row_action | capitalize }}
+                          </button>
+                        </div>
+                      </div>
+                      <div class="modal-backdrop" x-on:click="confirmKey = ''"></div>
+                    </div>
+                  {% endif %}
+                </div>
               </td>
             </tr>
           {% endfor %}

--- a/backend/src/meho_backplane/ui/templates/runbooks/_list.html
+++ b/backend/src/meho_backplane/ui/templates/runbooks/_list.html
@@ -93,6 +93,11 @@
                   {% if is_admin and tpl.status in ("draft", "published") %}
                     {%- set row_action = "publish" if tpl.status == "draft" else "deprecate" -%}
                     {%- set row_key = tpl.slug ~ "@" ~ tpl.version -%}
+                    {#- CSS-safe element id for the per-row alert slot. A slug may
+                        carry ``.`` (SLUG_PATTERN allows it), which is invalid in a
+                        ``#id`` CSS selector, so the HTMX target id keys off the
+                        loop index (always a safe integer) rather than slug@ver. -#}
+                    {%- set row_id = loop.index -%}
                     <button
                       type="button"
                       class="btn btn-xs {{ 'btn-success' if row_action == 'publish' else 'btn-warning' }}"
@@ -127,15 +132,28 @@
                                   x-on:click="confirmKey = ''">
                             Cancel
                           </button>
+                          {# Row action POST. Targets the per-row alert slot
+                             (``hx-swap="innerHTML"``) so a typed-400 (publishing
+                             a non-draft / deprecating a non-published version on
+                             a stale row) renders inline as an alert rather than
+                             being swallowed. ``runbooks-refresh`` fires only on a
+                             SUCCESSFUL response whose body carries no alert-error
+                             — so the list reloads (new badge) on success but the
+                             error stays visible on a typed-400. The 200-with-
+                             alert shape (the handler maps the typed-400 to an
+                             inline alert in a 200 body, mirroring the detail
+                             surface) means $event.detail.successful alone isn't
+                             enough; we also check the response has no alert. #}
                           <button
                             type="button"
                             class="btn btn-sm {{ 'btn-success' if row_action == 'publish' else 'btn-warning' }}"
                             hx-post="/ui/runbooks/{{ tpl.slug }}/{{ row_action }}"
                             hx-vals='{"version": "{{ tpl.version }}"}'
                             hx-headers='{"X-CSRF-Token": "{{ csrf_token | default('') }}"}'
-                            hx-swap="none"
+                            hx-target="#runbook-row-alert-{{ row_id }}"
+                            hx-swap="innerHTML"
                             x-on:click="confirmKey = ''"
-                            x-on:htmx:after-request="$dispatch('runbooks-refresh')"
+                            x-on:htmx:after-request="if ($event.detail.successful && !($event.detail.xhr.response || '').includes('alert-error')) $dispatch('runbooks-refresh')"
                           >
                             {{ row_action | capitalize }}
                           </button>
@@ -143,6 +161,9 @@
                       </div>
                       <div class="modal-backdrop" x-on:click="confirmKey = ''"></div>
                     </div>
+                    {# Per-row inline alert slot — the row-action POST swaps a
+                       typed-400 alert in here; empty on success. #}
+                    <div id="runbook-row-alert-{{ row_id }}"></div>
                   {% endif %}
                 </div>
               </td>

--- a/backend/src/meho_backplane/ui/templates/runbooks/_row_alert.html
+++ b/backend/src/meho_backplane/ui/templates/runbooks/_row_alert.html
@@ -1,0 +1,32 @@
+{#-
+  SPDX-License-Identifier: Apache-2.0
+  Copyright (c) 2026 evoila Group
+
+  Runbooks catalog row-action result slot.
+
+  Initiative #1381 (G10.6 Runbooks UI), Task #1384 (T3). Returned by the
+  publish / deprecate POST handlers (``lifecycle.register_lifecycle_routes``)
+  when the action was dispatched from the **catalog** row (HTMX targets the
+  per-row ``#runbook-row-alert-<slug>@<version>`` slot, not the detail surface's
+  ``#runbook-lifecycle``). The catalog row action posts with this slot as its
+  ``hx-target`` (``hx-swap="innerHTML"``):
+
+    * On a typed-400 (publishing a non-draft / deprecating a non-published
+      version on a stale row) ``lifecycle_error`` is set, so the slot renders
+      an inline DaisyUI ``alert-error`` -- the same surface treatment the detail
+      view gives a typed-400, instead of silently swallowing it under a list
+      refresh.
+    * On success ``lifecycle_error`` is None, so the slot renders empty; the
+      catalog button's ``htmx:after-request`` handler then dispatches
+      ``runbooks-refresh`` (success-only) to reload the list so the new badge
+      shows.
+
+  Context variables:
+    lifecycle_error -- str | None: typed-400 message -> inline alert-error
+-#}
+{% if lifecycle_error %}
+  <div role="alert" class="alert alert-error mt-1 text-sm" aria-live="assertive">
+    <span aria-hidden="true">&#9888;</span>
+    <span>{{ lifecycle_error }}</span>
+  </div>
+{% endif %}

--- a/backend/src/meho_backplane/ui/templates/runbooks/detail.html
+++ b/backend/src/meho_backplane/ui/templates/runbooks/detail.html
@@ -37,30 +37,26 @@
       </a>
       <h1 class="font-mono text-2xl font-semibold">{{ template.slug }}</h1>
       <span class="font-mono opacity-60">v{{ template.version }}</span>
+      {# Header status badge. ``id`` is the hx-swap-oob target the lifecycle
+         fragment refreshes after a publish / deprecate action. #}
       {% if template.status == "published" %}
-        <span class="badge badge-success badge-outline" aria-label="Status: published">
-          published
-        </span>
+        <span id="runbook-status-badge" class="badge badge-success badge-outline"
+              aria-label="Status: published">published</span>
       {% elif template.status == "draft" %}
-        <span class="badge badge-warning badge-outline" aria-label="Status: draft">draft</span>
+        <span id="runbook-status-badge" class="badge badge-warning badge-outline"
+              aria-label="Status: draft">draft</span>
       {% else %}
-        <span class="badge badge-ghost badge-outline" aria-label="Status: deprecated">
-          deprecated
-        </span>
-      {% endif %}
-      {# Authoring entry point — tenant_admin only (the POST handler also gates
-         server-side). Editing a published template forks a new draft. #}
-      {% if is_admin %}
-        <a
-          href="/ui/runbooks/{{ template.slug }}/edit"
-          class="btn btn-outline btn-sm ml-auto"
-          aria-label="Edit template {{ template.slug }}"
-        >
-          Edit
-        </a>
+        <span id="runbook-status-badge" class="badge badge-ghost badge-outline"
+              aria-label="Status: deprecated">deprecated</span>
       {% endif %}
     </div>
+
+    {# Lifecycle controls — publish / deprecate / fork-on-edit. tenant_admin
+       only (the fragment hides them for operators; the POST handlers re-check
+       server-side via require_ui_admin). Withheld on the opacity-floor
+       restricted view (no metadata to act on). #}
     {% if not restricted %}
+      {% include "runbooks/_detail_actions.html" %}
       <p class="text-lg">{{ template.title }}</p>
       {% if template.description %}
         <p class="max-w-3xl opacity-70">{{ template.description }}</p>

--- a/backend/src/meho_backplane/ui/templates/runbooks/index.html
+++ b/backend/src/meho_backplane/ui/templates/runbooks/index.html
@@ -100,5 +100,19 @@
 
   {# ---------- List / catalog area ---------- #}
   {% include "runbooks/_list.html" %}
+
+  {# Catalog refresh hook. A row lifecycle action (publish / deprecate) fires a
+     ``runbooks-refresh`` event after its POST settles; this hidden element
+     re-fetches the list with the active filters so the row's status badge
+     reflects the new state. ``from:body`` lets the event bubble up from the
+     row's button regardless of where the modal rendered. #}
+  <div
+    hidden
+    hx-get="/ui/runbooks/list"
+    hx-target="#runbooks-list"
+    hx-swap="outerHTML"
+    hx-trigger="runbooks-refresh from:body"
+    hx-include="[name='status'], [name='target_kind']"
+  ></div>
 </section>
 {% endblock %}

--- a/backend/tests/test_ui_runbooks_lifecycle.py
+++ b/backend/tests/test_ui_runbooks_lifecycle.py
@@ -38,6 +38,7 @@ uses).
 from __future__ import annotations
 
 import asyncio
+import re
 import uuid
 import warnings
 from collections.abc import Iterator
@@ -335,6 +336,41 @@ def _status(tenant_id: uuid.UUID, slug: str, version: int) -> str:
         return tpl.status
 
     return asyncio.run(_do())
+
+
+#: Pull the ``meho_csrf`` value out of a raw ``Set-Cookie`` header. The cookie
+#: is ``Secure``, so the plain-``http`` TestClient does not auto-store it -- the
+#: real browser cookie/header round-trip is reconstructed by reading the
+#: Set-Cookie the server emitted and presenting it back verbatim (this is the
+#: exact path B1 broke: the list fragment minted a fresh header token but never
+#: refreshed this cookie).
+_CSRF_SETCOOKIE_RE = re.compile(rf"{CSRF_COOKIE_NAME}=([^;]+)")
+
+#: Pull the ``X-CSRF-Token`` the row-action button echoes via ``hx-headers`` out
+#: of the rendered ``_list.html`` fragment. This is the *header* half of the
+#: double-submit pair the catalog row POST will present.
+_ROW_HX_HEADERS_RE = re.compile(r'hx-headers=\'\{"X-CSRF-Token": "([^"]+)"\}\'')
+
+
+def _extract_csrf_cookie(response: Any) -> str:
+    """Return the ``meho_csrf`` value the response set, or fail the test.
+
+    Reads the raw ``Set-Cookie`` header rather than the TestClient cookie jar so
+    the ``Secure`` attribute (which the http TestClient honours by NOT storing
+    the cookie) does not hide it -- the value is exactly what a browser would
+    send back on the next request.
+    """
+    set_cookie = response.headers.get("set-cookie", "")
+    match = _CSRF_SETCOOKIE_RE.search(set_cookie)
+    assert match, f"no {CSRF_COOKIE_NAME} cookie set; got Set-Cookie={set_cookie!r}"
+    return match.group(1)
+
+
+def _extract_row_hx_token(body: str) -> str:
+    """Return the ``X-CSRF-Token`` the row-action button echoes via hx-headers."""
+    match = _ROW_HX_HEADERS_RE.search(body)
+    assert match, "no row-action hx-headers X-CSRF-Token found in the list fragment"
+    return match.group(1)
 
 
 # ---------------------------------------------------------------------------
@@ -703,3 +739,180 @@ def test_catalog_row_action_hidden_for_operator() -> None:
     assert response.status_code == 200, response.text
     body = response.text
     assert 'hx-post="/ui/runbooks/rotate-cert/publish"' not in body
+
+
+# ---------------------------------------------------------------------------
+# B1 regression — catalog row action survives the REAL cookie/header CSRF path
+# ---------------------------------------------------------------------------
+
+
+def test_catalog_row_action_real_csrf_cookie_header_pair_200() -> None:
+    """Row action POST through the REAL list-fragment cookie/header CSRF path -> 200.
+
+    Regression for B1: ``_render_list_fragment`` re-mints the CSRF token into the
+    row-action button's ``hx-headers`` but (before the fix) never refreshed the
+    ``meho_csrf`` cookie, so the next row POST presented a header token that no
+    longer matched the stale cookie and the CSRFMiddleware ``value_mismatch``
+    check 403'd. This test does NOT hand-mint a matching token into both header
+    and cookie (the way the other tests do, which is exactly why they missed B1).
+    Instead it drives the genuine flow: GET the HTMX list fragment, capture the
+    ``Set-Cookie`` ``meho_csrf`` value AND the token the row button echoes via
+    ``hx-headers``, assert they are the same minted value, then POST the row
+    action presenting THAT cookie + THAT header. A 200 proves the cookie/header
+    pair is internally consistent; a 403 would be the B1 desync.
+    """
+    _seed_tenant(_TENANT_A, "tenant-a")
+    version = _seed_template(tenant_id=_TENANT_A, slug="rotate-cert")
+    session_id, jwks = _admin_session()
+
+    mock = respx.mock(assert_all_called=False)
+    mock.start()
+    try:
+        _mock_discovery_and_jwks(mock, jwks)
+        client = _authenticated_client(session_id)
+
+        # GET the HTMX list fragment (the path filter swaps + post-action
+        # runbooks-refresh both render through here).
+        list_resp = client.get("/ui/runbooks/list", headers={"HX-Request": "true"})
+        assert list_resp.status_code == 200, list_resp.text
+
+        cookie_token = _extract_csrf_cookie(list_resp)
+        header_token = _extract_row_hx_token(list_resp.text)
+        # The fix guarantees the cookie and the echoed header are the SAME minted
+        # token; without it the cookie would be a stale (or absent) value.
+        assert cookie_token == header_token, (
+            "list-fragment CSRF cookie does not match the row button's "
+            "hx-headers token -- the B1 desync"
+        )
+
+        # POST the row action presenting the captured pair verbatim (the real
+        # browser round-trip), with no hand-minted override.
+        response = client.post(
+            "/ui/runbooks/rotate-cert/publish",
+            data={"version": str(version)},
+            headers={
+                CSRF_HEADER_NAME: header_token,
+                "HX-Request": "true",
+                "HX-Target": "runbook-row-alert-1",
+            },
+            cookies={CSRF_COOKIE_NAME: cookie_token},
+        )
+    finally:
+        mock.stop()
+
+    assert response.status_code == 200, response.text
+    # The action actually fired through the gate -- the draft is now published.
+    assert _status(_TENANT_A, "rotate-cert", version) == "published"
+
+
+# ---------------------------------------------------------------------------
+# M1 regression — catalog typed-400 renders inline, not swallowed by a refresh
+# ---------------------------------------------------------------------------
+
+
+def test_catalog_row_action_typed_400_renders_inline_alert() -> None:
+    """A typed-400 on the catalog row path returns an inline alert (M1).
+
+    Regression for M1: the catalog row button used to dispatch ``runbooks-refresh``
+    on every ``htmx:after-request`` regardless of outcome, so a typed-400
+    (publishing a non-draft on a stale row) was swallowed under the list reload.
+    The fix targets a per-row alert slot and returns the minimal
+    ``_row_alert.html`` fragment carrying the alert when the POST originated from
+    the catalog (``HX-Target`` points at ``runbook-row-alert-…``). This asserts
+    the catalog-shaped response surfaces the alert inline (and does NOT leak the
+    detail-surface action row / OOB badge into a list row).
+    """
+    _seed_tenant(_TENANT_A, "tenant-a")
+    # Deprecated version -> publishing it is a typed-400 (not draft).
+    version = _seed_template(tenant_id=_TENANT_A, slug="rotate-cert", deprecate=True)
+    session_id, jwks = _admin_session()
+
+    mock = respx.mock(assert_all_called=False)
+    mock.start()
+    try:
+        _mock_discovery_and_jwks(mock, jwks)
+        client = _authenticated_client(session_id)
+        csrf = _csrf_token(session_id)
+        response = client.post(
+            "/ui/runbooks/rotate-cert/publish",
+            data={"version": str(version)},
+            headers={**_csrf_kwargs(csrf)["headers"], "HX-Target": "runbook-row-alert-1"},
+            cookies=_csrf_kwargs(csrf)["cookies"],
+        )
+    finally:
+        mock.stop()
+
+    assert response.status_code == 200, response.text
+    body = response.text
+    # The typed-400 surfaces inline as a catalog alert.
+    assert "alert-error" in body
+    assert "not draft" in body
+    # The catalog response is the minimal slot -- NOT the detail action row /
+    # OOB header-badge (those would be nonsense swapped into a list row).
+    assert 'id="runbook-status-badge"' not in body
+    assert "Edit (forks draft)" not in body
+    # Status is unchanged.
+    assert _status(_TENANT_A, "rotate-cert", version) == "deprecated"
+
+
+def test_catalog_row_action_success_returns_empty_slot() -> None:
+    """A successful catalog row action returns an empty alert slot (no error)."""
+    _seed_tenant(_TENANT_A, "tenant-a")
+    version = _seed_template(tenant_id=_TENANT_A, slug="rotate-cert")
+    session_id, jwks = _admin_session()
+
+    mock = respx.mock(assert_all_called=False)
+    mock.start()
+    try:
+        _mock_discovery_and_jwks(mock, jwks)
+        client = _authenticated_client(session_id)
+        csrf = _csrf_token(session_id)
+        response = client.post(
+            "/ui/runbooks/rotate-cert/publish",
+            data={"version": str(version)},
+            headers={**_csrf_kwargs(csrf)["headers"], "HX-Target": "runbook-row-alert-1"},
+            cookies=_csrf_kwargs(csrf)["cookies"],
+        )
+    finally:
+        mock.stop()
+
+    assert response.status_code == 200, response.text
+    body = response.text
+    # No error alert on success; the button's success-only handler then fires
+    # runbooks-refresh to reload the list with the new badge.
+    assert "alert-error" not in body
+    assert _status(_TENANT_A, "rotate-cert", version) == "published"
+
+
+def test_catalog_row_button_gates_refresh_on_success() -> None:
+    """The catalog row button dispatches runbooks-refresh only on success (M1).
+
+    Asserts the rendered ``_list.html`` markup: the button targets the per-row
+    alert slot and its ``htmx:after-request`` handler is gated on
+    ``$event.detail.successful`` AND the response carrying no ``alert-error``
+    (the typed-400 returns a 200 body with the alert, so ``successful`` alone is
+    insufficient). This is the static counterpart to the behavioural typed-400
+    test -- it pins the client-side wiring the reviewer required.
+    """
+    _seed_tenant(_TENANT_A, "tenant-a")
+    _seed_template(tenant_id=_TENANT_A, slug="rotate-cert")
+    session_id, jwks = _admin_session()
+
+    mock = respx.mock(assert_all_called=False)
+    mock.start()
+    try:
+        _mock_discovery_and_jwks(mock, jwks)
+        client = _authenticated_client(session_id)
+        response = client.get("/ui/runbooks", headers={"HX-Request": "false"})
+    finally:
+        mock.stop()
+
+    assert response.status_code == 200, response.text
+    body = response.text
+    # The row action targets the per-row alert slot (so a typed-400 lands inline).
+    assert 'hx-target="#runbook-row-alert-' in body
+    assert 'id="runbook-row-alert-' in body
+    # The dispatch is gated: success AND no alert-error in the response body.
+    assert "$event.detail.successful" in body
+    assert "alert-error" in body  # appears in the gate expression
+    assert "$dispatch('runbooks-refresh')" in body

--- a/backend/tests/test_ui_runbooks_lifecycle.py
+++ b/backend/tests/test_ui_runbooks_lifecycle.py
@@ -1,0 +1,705 @@
+# SPDX-License-Identifier: Apache-2.0
+# Copyright (c) 2026 evoila Group
+
+"""Behavioural tests for the runbooks UI lifecycle controls.
+
+Initiative #1381 (G10.6 Runbooks UI), Task #1384 (T3). Acceptance criteria on
+issue #1384:
+
+* A ``tenant_admin`` can publish a ``draft`` from the UI (status -> published)
+  and deprecate a ``published`` version (status -> deprecated); an ``operator``
+  can neither see nor invoke the action -- a forged POST gets 403.
+* Publishing a non-draft (400 ``TemplateNotDraftError``) and deprecating a
+  non-published (400 ``TemplateNotPublishedError``) render as inline DaisyUI
+  alerts; an idempotent re-action returns 200 and refreshes the badge with no
+  error.
+* Each action is gated by an Alpine confirm dialog naming slug + version; the
+  CSRF token is required (missing token -> blocked by ``CSRFMiddleware``).
+* The published-template "Edit (forks draft)" affordance surfaces the
+  in-flight run count pinned to the version.
+
+Suite shape mirrors :mod:`backend.tests.test_ui_runbooks_editor` (the T2
+authoring surface, #1383): a minimal FastAPI app wired with the BFF
+middlewares + the UI surface router, SQLite-backed seeding via the real
+:class:`~meho_backplane.runbooks.service.RunbookTemplateService`, a pre-set
+session cookie, and a real RSA-signed JWT for the ``tenant_admin`` role lift
+(the lifecycle routes gate on ``require_ui_admin``, which re-verifies the
+session's access token). The ``operator`` path mints an operator-role JWT that
+decodes cleanly but fails the role rank check -> 403.
+
+The CSRF middleware is active, so every state-changing POST carries the
+double-submit token via :func:`_csrf_kwargs` (the same token as both the
+``X-CSRF-Token`` header and an explicit request cookie -- the editor's
+``Secure`` CSRF cookie is not echoed by the plain-``http`` TestClient, so the
+token is minted directly, the pattern :mod:`backend.tests.test_ui_kb_upload`
+uses).
+"""
+
+from __future__ import annotations
+
+import asyncio
+import uuid
+import warnings
+from collections.abc import Iterator
+from datetime import UTC, datetime, timedelta
+from typing import Any
+
+import pytest
+import respx
+from cryptography.fernet import Fernet
+from fastapi import FastAPI
+from fastapi.staticfiles import StaticFiles
+from fastapi.testclient import TestClient
+
+from meho_backplane.auth.jwt import clear_jwks_cache
+from meho_backplane.auth.operator import TenantRole
+from meho_backplane.db.engine import get_sessionmaker, reset_engine_for_testing
+from meho_backplane.db.models import RunbookRun, Tenant
+from meho_backplane.runbooks.schemas import (
+    ConfirmVerify,
+    DeprecateTemplateRequest,
+    DraftTemplateRequest,
+    ManualStep,
+    PublishTemplateRequest,
+    RunbookTemplateBody,
+)
+from meho_backplane.runbooks.service import RunbookTemplateService
+from meho_backplane.settings import get_settings
+from meho_backplane.ui.auth import SESSION_COOKIE_NAME, UISessionMiddleware
+from meho_backplane.ui.auth import build_router as build_ui_auth_router
+from meho_backplane.ui.auth.flow import (
+    clear_discovery_cache,
+    reset_verifier_store_for_testing,
+)
+from meho_backplane.ui.auth.session_store import (
+    create_session,
+    reset_fernet_cache_for_testing,
+)
+from meho_backplane.ui.csrf import (
+    CSRF_COOKIE_NAME,
+    CSRF_HEADER_NAME,
+    CSRFMiddleware,
+    mint_csrf_token,
+)
+from meho_backplane.ui.paths import static_root_dir
+from meho_backplane.ui.routes import build_router as build_ui_router
+from meho_backplane.ui.templating import reset_templating_for_testing
+from tests._oidc_jwt_helpers import (
+    make_rsa_keypair as _make_rsa_keypair,
+)
+from tests._oidc_jwt_helpers import (
+    mint_token as _mint_token,
+)
+from tests._oidc_jwt_helpers import (
+    mock_discovery_and_jwks as _mock_discovery_and_jwks,
+)
+from tests._oidc_jwt_helpers import (
+    public_jwks as _public_jwks,
+)
+
+# ---------------------------------------------------------------------------
+# Constants
+# ---------------------------------------------------------------------------
+
+_BACKPLANE_URL = "https://meho.test"
+_DEFAULT_ISSUER = "https://keycloak.test/realms/meho"
+_DEFAULT_AUDIENCE = "meho-backplane"
+
+_TENANT_A = uuid.UUID("aaaaaaaa-aaaa-aaaa-aaaa-aaaaaaaaaaaa")
+
+_OPERATOR_SUB = "op-42"
+
+# ---------------------------------------------------------------------------
+# Fixtures
+# ---------------------------------------------------------------------------
+
+
+@pytest.fixture(autouse=True)
+def _bff_env(monkeypatch: pytest.MonkeyPatch) -> Iterator[None]:
+    """Pin chassis + BFF env vars for every test (T1/T2-suite baseline)."""
+    monkeypatch.setenv("KEYCLOAK_ISSUER_URL", _DEFAULT_ISSUER)
+    monkeypatch.setenv("KEYCLOAK_AUDIENCE", _DEFAULT_AUDIENCE)
+    monkeypatch.setenv("VAULT_ADDR", "https://vault.test")
+    monkeypatch.setenv("BACKPLANE_URL", _BACKPLANE_URL)
+    monkeypatch.setenv("UI_SESSION_ENCRYPTION_KEY", Fernet.generate_key().decode())
+    monkeypatch.setenv("UI_KEYCLOAK_CLIENT_ID", "meho-web")
+    monkeypatch.setenv("UI_KEYCLOAK_CLIENT_SECRET", "test-client-secret")
+    get_settings.cache_clear()
+    reset_fernet_cache_for_testing()
+    reset_verifier_store_for_testing()
+    reset_templating_for_testing()
+    clear_discovery_cache()
+    clear_jwks_cache()
+    reset_engine_for_testing()
+    yield
+    get_settings.cache_clear()
+    reset_fernet_cache_for_testing()
+    reset_verifier_store_for_testing()
+    reset_templating_for_testing()
+    clear_discovery_cache()
+    clear_jwks_cache()
+    reset_engine_for_testing()
+
+
+# ---------------------------------------------------------------------------
+# Helpers
+# ---------------------------------------------------------------------------
+
+
+def _build_app() -> FastAPI:
+    """Minimal FastAPI app wired for runbooks UI tests (T1/T2-suite shape)."""
+    app = FastAPI()
+    app.add_middleware(CSRFMiddleware)
+    app.add_middleware(UISessionMiddleware)
+    app.mount(
+        "/ui/static",
+        StaticFiles(directory=str(static_root_dir()), check_dir=False),
+        name="ui_static",
+    )
+    app.include_router(build_ui_auth_router())
+    app.include_router(build_ui_router())
+    return app
+
+
+def _seed_tenant(tenant_id: uuid.UUID, slug: str) -> None:
+    """Insert one ``tenant`` row so FK constraints resolve."""
+
+    async def _do() -> None:
+        sessionmaker = get_sessionmaker()
+        async with sessionmaker() as session, session.begin():
+            session.add(Tenant(id=tenant_id, slug=slug, name=f"Tenant {slug}"))
+
+    asyncio.run(_do())
+
+
+def _manual_body() -> RunbookTemplateBody:
+    """One manual step + confirm verify."""
+    return RunbookTemplateBody(
+        title="Drain node",
+        description="Procedure for draining a node.",
+        target_kind="k8s-node",
+        steps=[
+            ManualStep(
+                id="drain",
+                title="Drain the node",
+                body="Run the **drain** command.",
+                type="manual",
+                verify=ConfirmVerify(type="confirm", prompt="Node drained?"),
+            ),
+        ],
+    )
+
+
+def _seed_template(
+    *,
+    tenant_id: uuid.UUID,
+    slug: str,
+    publish: bool = False,
+    deprecate: bool = False,
+) -> int:
+    """Create a draft (optionally publish + deprecate) and return its version."""
+
+    async def _do() -> int:
+        service = RunbookTemplateService()
+        resp = await service.create_draft(
+            tenant_id,
+            _OPERATOR_SUB,
+            DraftTemplateRequest(slug=slug, body=_manual_body()),
+        )
+        if publish or deprecate:
+            await service.publish(
+                tenant_id, PublishTemplateRequest(slug=slug, version=resp.version)
+            )
+        if deprecate:
+            await service.deprecate(
+                tenant_id, DeprecateTemplateRequest(slug=slug, version=resp.version)
+            )
+        return resp.version
+
+    return asyncio.run(_do())
+
+
+def _seed_run(
+    *,
+    tenant_id: uuid.UUID,
+    slug: str,
+    version: int,
+    state: str = "in_progress",
+) -> None:
+    """Insert one ``runbook_runs`` row pinned to ``(slug, version)``."""
+
+    async def _do() -> None:
+        sessionmaker = get_sessionmaker()
+        async with sessionmaker() as session:
+            session.add(
+                RunbookRun(
+                    tenant_id=tenant_id,
+                    template_slug=slug,
+                    template_version=version,
+                    assigned_to=_OPERATOR_SUB,
+                    target="host-1",
+                    params={},
+                    state=state,
+                    started_by=_OPERATOR_SUB,
+                    started_at=datetime.now(UTC),
+                )
+            )
+            await session.commit()
+
+    asyncio.run(_do())
+
+
+def _seed_session_sync(
+    *,
+    tenant_id: uuid.UUID,
+    access_token: str = "access-token-plaintext",
+    lifetime: timedelta = timedelta(hours=1),
+) -> uuid.UUID:
+    """Create a ``web_session`` row carrying *access_token* and return its UUID."""
+
+    async def _do() -> uuid.UUID:
+        sessionmaker = get_sessionmaker()
+        async with sessionmaker() as session, session.begin():
+            decrypted = await create_session(
+                session,
+                operator_sub=_OPERATOR_SUB,
+                tenant_id=tenant_id,
+                access_token=access_token,
+                refresh_token="refresh-token-plaintext",
+                lifetime=lifetime,
+            )
+            return decrypted.id
+
+    return asyncio.run(_do())
+
+
+def _authenticated_client(session_id: uuid.UUID) -> TestClient:
+    """Return a TestClient with the session cookie pre-set."""
+    client = TestClient(_build_app(), follow_redirects=False)
+    client.cookies.set(SESSION_COOKIE_NAME, str(session_id))
+    return client
+
+
+def _make_keypair_and_jwks() -> tuple[Any, dict[str, Any]]:
+    """Mint a stable RSA-2048 keypair + the matching JWKS document."""
+    with warnings.catch_warnings():
+        warnings.simplefilter("ignore")
+        keypair = _make_rsa_keypair("ui-runbooks-lifecycle-test-kid")
+    return keypair, _public_jwks(keypair)
+
+
+def _role_session(
+    role: TenantRole,
+    tenant_id: uuid.UUID = _TENANT_A,
+) -> tuple[uuid.UUID, dict[str, Any]]:
+    """Seed a session whose access token is a real JWT carrying *role*.
+
+    Returns the session id and the JWKS the ``require_ui_admin`` gate must
+    reach to verify the token. A ``TENANT_ADMIN`` token passes the gate; an
+    ``OPERATOR`` token decodes cleanly but fails the role rank check -> 403.
+    """
+    keypair, jwks = _make_keypair_and_jwks()
+    access_token = _mint_token(
+        keypair,
+        sub=_OPERATOR_SUB,
+        tenant_id=str(tenant_id),
+        tenant_role=role.value,
+    )
+    session_id = _seed_session_sync(tenant_id=tenant_id, access_token=access_token)
+    return session_id, jwks
+
+
+def _admin_session(tenant_id: uuid.UUID = _TENANT_A) -> tuple[uuid.UUID, dict[str, Any]]:
+    """Seed an admin session whose access token is a real tenant_admin JWT."""
+    return _role_session(TenantRole.TENANT_ADMIN, tenant_id)
+
+
+def _csrf_token(session_id: uuid.UUID) -> str:
+    """Return a valid CSRF token for *session_id* (double-submit value)."""
+    return mint_csrf_token(str(session_id))
+
+
+def _csrf_kwargs(token: str) -> dict[str, Any]:
+    """Header + cookie kwargs that satisfy the double-submit CSRF check."""
+    return {
+        "headers": {CSRF_HEADER_NAME: token, "X-CSRF-Token": token},
+        "cookies": {CSRF_COOKIE_NAME: token},
+    }
+
+
+def _status(tenant_id: uuid.UUID, slug: str, version: int) -> str:
+    """Read the persisted status of ``(slug, version)`` for assertions."""
+
+    async def _do() -> str:
+        tpl = await RunbookTemplateService().show_template(tenant_id, slug, version=version)
+        return tpl.status
+
+    return asyncio.run(_do())
+
+
+# ---------------------------------------------------------------------------
+# Publish — admin 200, operator forged 403
+# ---------------------------------------------------------------------------
+
+
+def test_publish_draft_admin_flips_status() -> None:
+    """A tenant_admin publishes a draft -> 200, status flips to published, badge swaps."""
+    _seed_tenant(_TENANT_A, "tenant-a")
+    version = _seed_template(tenant_id=_TENANT_A, slug="rotate-cert")
+    session_id, jwks = _admin_session()
+
+    mock = respx.mock(assert_all_called=False)
+    mock.start()
+    try:
+        _mock_discovery_and_jwks(mock, jwks)
+        client = _authenticated_client(session_id)
+        csrf = _csrf_token(session_id)
+        response = client.post(
+            "/ui/runbooks/rotate-cert/publish",
+            data={"version": str(version)},
+            **_csrf_kwargs(csrf),
+        )
+    finally:
+        mock.stop()
+
+    assert response.status_code == 200, response.text
+    body = response.text
+    # The OOB header-badge refresh + the new published badge are in the fragment.
+    assert 'id="runbook-status-badge"' in body
+    assert 'hx-swap-oob="true"' in body
+    assert "published" in body
+    # A published template offers Deprecate next, not Publish.
+    assert "Deprecate" in body
+    # Persisted state actually flipped.
+    assert _status(_TENANT_A, "rotate-cert", version) == "published"
+
+
+def test_publish_operator_forged_post_forbidden_403() -> None:
+    """An operator's forged publish POST (valid CSRF) is 403 at require_ui_admin."""
+    _seed_tenant(_TENANT_A, "tenant-a")
+    version = _seed_template(tenant_id=_TENANT_A, slug="rotate-cert")
+    session_id, jwks = _role_session(TenantRole.OPERATOR)
+
+    mock = respx.mock(assert_all_called=False)
+    mock.start()
+    try:
+        _mock_discovery_and_jwks(mock, jwks)
+        client = _authenticated_client(session_id)
+        csrf = _csrf_token(session_id)
+        response = client.post(
+            "/ui/runbooks/rotate-cert/publish",
+            data={"version": str(version)},
+            **_csrf_kwargs(csrf),
+        )
+    finally:
+        mock.stop()
+
+    assert response.status_code == 403, response.text
+    # The action did not fire — still a draft.
+    assert _status(_TENANT_A, "rotate-cert", version) == "draft"
+
+
+def test_publish_missing_csrf_blocked() -> None:
+    """A publish POST with no CSRF token is blocked by CSRFMiddleware (not 200)."""
+    _seed_tenant(_TENANT_A, "tenant-a")
+    version = _seed_template(tenant_id=_TENANT_A, slug="rotate-cert")
+    session_id, jwks = _admin_session()
+
+    mock = respx.mock(assert_all_called=False)
+    mock.start()
+    try:
+        _mock_discovery_and_jwks(mock, jwks)
+        client = _authenticated_client(session_id)
+        # No CSRF header / cookie supplied.
+        response = client.post(
+            "/ui/runbooks/rotate-cert/publish",
+            data={"version": str(version)},
+        )
+    finally:
+        mock.stop()
+
+    assert response.status_code == 403, response.text
+    # The action did not fire — still a draft.
+    assert _status(_TENANT_A, "rotate-cert", version) == "draft"
+
+
+# ---------------------------------------------------------------------------
+# Deprecate — admin 200
+# ---------------------------------------------------------------------------
+
+
+def test_deprecate_published_admin_flips_status() -> None:
+    """A tenant_admin deprecates a published version -> 200, status flips."""
+    _seed_tenant(_TENANT_A, "tenant-a")
+    version = _seed_template(tenant_id=_TENANT_A, slug="rotate-cert", publish=True)
+    session_id, jwks = _admin_session()
+
+    mock = respx.mock(assert_all_called=False)
+    mock.start()
+    try:
+        _mock_discovery_and_jwks(mock, jwks)
+        client = _authenticated_client(session_id)
+        csrf = _csrf_token(session_id)
+        response = client.post(
+            "/ui/runbooks/rotate-cert/deprecate",
+            data={"version": str(version)},
+            **_csrf_kwargs(csrf),
+        )
+    finally:
+        mock.stop()
+
+    assert response.status_code == 200, response.text
+    assert "deprecated" in response.text
+    assert _status(_TENANT_A, "rotate-cert", version) == "deprecated"
+
+
+# ---------------------------------------------------------------------------
+# Typed 400 — inline alert rendering
+# ---------------------------------------------------------------------------
+
+
+def test_publish_non_draft_renders_inline_alert() -> None:
+    """Publishing a deprecated version (400 not-draft) renders an inline alert."""
+    _seed_tenant(_TENANT_A, "tenant-a")
+    version = _seed_template(tenant_id=_TENANT_A, slug="rotate-cert", deprecate=True)
+    session_id, jwks = _admin_session()
+
+    mock = respx.mock(assert_all_called=False)
+    mock.start()
+    try:
+        _mock_discovery_and_jwks(mock, jwks)
+        client = _authenticated_client(session_id)
+        csrf = _csrf_token(session_id)
+        response = client.post(
+            "/ui/runbooks/rotate-cert/publish",
+            data={"version": str(version)},
+            **_csrf_kwargs(csrf),
+        )
+    finally:
+        mock.stop()
+
+    # The handler maps the typed 400 to an inline DaisyUI alert (HTTP 200 carries
+    # the re-rendered fragment so HTMX swaps the alert in).
+    assert response.status_code == 200, response.text
+    body = response.text
+    assert "alert-error" in body
+    assert "not draft" in body
+    # The status is unchanged (still deprecated).
+    assert _status(_TENANT_A, "rotate-cert", version) == "deprecated"
+
+
+def test_deprecate_non_published_renders_inline_alert() -> None:
+    """Deprecating a draft (400 not-published) renders an inline alert."""
+    _seed_tenant(_TENANT_A, "tenant-a")
+    version = _seed_template(tenant_id=_TENANT_A, slug="rotate-cert")
+    session_id, jwks = _admin_session()
+
+    mock = respx.mock(assert_all_called=False)
+    mock.start()
+    try:
+        _mock_discovery_and_jwks(mock, jwks)
+        client = _authenticated_client(session_id)
+        csrf = _csrf_token(session_id)
+        response = client.post(
+            "/ui/runbooks/rotate-cert/deprecate",
+            data={"version": str(version)},
+            **_csrf_kwargs(csrf),
+        )
+    finally:
+        mock.stop()
+
+    assert response.status_code == 200, response.text
+    body = response.text
+    assert "alert-error" in body
+    assert "not published" in body
+    assert _status(_TENANT_A, "rotate-cert", version) == "draft"
+
+
+# ---------------------------------------------------------------------------
+# Idempotent re-action — 200 no-op, badge refreshed, no error
+# ---------------------------------------------------------------------------
+
+
+def test_republish_already_published_is_idempotent_no_error() -> None:
+    """Re-publishing an already-published version is a no-op (200, no alert)."""
+    _seed_tenant(_TENANT_A, "tenant-a")
+    version = _seed_template(tenant_id=_TENANT_A, slug="rotate-cert", publish=True)
+    session_id, jwks = _admin_session()
+
+    mock = respx.mock(assert_all_called=False)
+    mock.start()
+    try:
+        _mock_discovery_and_jwks(mock, jwks)
+        client = _authenticated_client(session_id)
+        csrf = _csrf_token(session_id)
+        response = client.post(
+            "/ui/runbooks/rotate-cert/publish",
+            data={"version": str(version)},
+            **_csrf_kwargs(csrf),
+        )
+    finally:
+        mock.stop()
+
+    assert response.status_code == 200, response.text
+    body = response.text
+    # Badge refreshed to published; no error alert.
+    assert "published" in body
+    assert "alert-error" not in body
+    assert _status(_TENANT_A, "rotate-cert", version) == "published"
+
+
+# ---------------------------------------------------------------------------
+# 404 — missing slug / version
+# ---------------------------------------------------------------------------
+
+
+def test_publish_missing_version_404() -> None:
+    """Publishing a (slug, version) that doesn't exist is 404 (stale detail)."""
+    _seed_tenant(_TENANT_A, "tenant-a")
+    _seed_template(tenant_id=_TENANT_A, slug="rotate-cert")
+    session_id, jwks = _admin_session()
+
+    mock = respx.mock(assert_all_called=False)
+    mock.start()
+    try:
+        _mock_discovery_and_jwks(mock, jwks)
+        client = _authenticated_client(session_id)
+        csrf = _csrf_token(session_id)
+        response = client.post(
+            "/ui/runbooks/rotate-cert/publish",
+            data={"version": "99"},
+            **_csrf_kwargs(csrf),
+        )
+    finally:
+        mock.stop()
+
+    assert response.status_code == 404, response.text
+
+
+# ---------------------------------------------------------------------------
+# Detail view — controls visible for admin, hidden for operator
+# ---------------------------------------------------------------------------
+
+
+def test_detail_publish_control_visible_for_admin_draft() -> None:
+    """A draft detail shows the Publish control to a tenant_admin."""
+    _seed_tenant(_TENANT_A, "tenant-a")
+    _seed_template(tenant_id=_TENANT_A, slug="rotate-cert")
+    session_id, jwks = _admin_session()
+
+    mock = respx.mock(assert_all_called=False)
+    mock.start()
+    try:
+        _mock_discovery_and_jwks(mock, jwks)
+        client = _authenticated_client(session_id)
+        response = client.get("/ui/runbooks/rotate-cert")
+    finally:
+        mock.stop()
+
+    assert response.status_code == 200, response.text
+    body = response.text
+    assert "Publish" in body
+    # The confirm dialog names the slug + version.
+    assert "rotate-cert" in body
+    assert 'hx-post="/ui/runbooks/rotate-cert/publish"' in body
+
+
+def test_detail_lifecycle_controls_hidden_for_operator() -> None:
+    """An operator who has completed a run sees the steps but no lifecycle controls."""
+    _seed_tenant(_TENANT_A, "tenant-a")
+    version = _seed_template(tenant_id=_TENANT_A, slug="rotate-cert", publish=True)
+    # A completed run unlocks the operator's step view (opacity floor), so the
+    # page renders fully -- the lifecycle controls must still be absent.
+    _seed_run(tenant_id=_TENANT_A, slug="rotate-cert", version=version, state="completed")
+    session_id, jwks = _role_session(TenantRole.OPERATOR)
+
+    mock = respx.mock(assert_all_called=False)
+    mock.start()
+    try:
+        _mock_discovery_and_jwks(mock, jwks)
+        client = _authenticated_client(session_id)
+        response = client.get("/ui/runbooks/rotate-cert")
+    finally:
+        mock.stop()
+
+    assert response.status_code == 200, response.text
+    body = response.text
+    # No publish/deprecate POST controls for an operator.
+    assert "/ui/runbooks/rotate-cert/deprecate" not in body
+    assert 'hx-post="/ui/runbooks/rotate-cert/publish"' not in body
+
+
+# ---------------------------------------------------------------------------
+# Fork-on-edit affordance — surfaces in_flight_run_count on a published detail
+# ---------------------------------------------------------------------------
+
+
+def test_detail_published_surfaces_fork_affordance_with_in_flight_count() -> None:
+    """A published detail shows the Edit (forks draft) affordance + in-flight count."""
+    _seed_tenant(_TENANT_A, "tenant-a")
+    version = _seed_template(tenant_id=_TENANT_A, slug="rotate-cert", publish=True)
+    # Two in-flight runs pinned to the published version.
+    _seed_run(tenant_id=_TENANT_A, slug="rotate-cert", version=version, state="in_progress")
+    _seed_run(tenant_id=_TENANT_A, slug="rotate-cert", version=version, state="in_progress")
+    session_id, jwks = _admin_session()
+
+    mock = respx.mock(assert_all_called=False)
+    mock.start()
+    try:
+        _mock_discovery_and_jwks(mock, jwks)
+        client = _authenticated_client(session_id)
+        response = client.get("/ui/runbooks/rotate-cert")
+    finally:
+        mock.stop()
+
+    assert response.status_code == 200, response.text
+    body = response.text
+    assert "Edit (forks draft)" in body
+    assert 'href="/ui/runbooks/rotate-cert/edit"' in body
+    # The in-flight count is surfaced (2 runs pinned to this version).
+    assert "2 in-flight runs" in body
+
+
+# ---------------------------------------------------------------------------
+# Catalog list — admin row actions present, operator's absent
+# ---------------------------------------------------------------------------
+
+
+def test_catalog_row_action_visible_for_admin() -> None:
+    """The catalog shows a Publish row action on a draft row for a tenant_admin."""
+    _seed_tenant(_TENANT_A, "tenant-a")
+    _seed_template(tenant_id=_TENANT_A, slug="rotate-cert")
+    session_id, jwks = _admin_session()
+
+    mock = respx.mock(assert_all_called=False)
+    mock.start()
+    try:
+        _mock_discovery_and_jwks(mock, jwks)
+        client = _authenticated_client(session_id)
+        response = client.get("/ui/runbooks")
+    finally:
+        mock.stop()
+
+    assert response.status_code == 200, response.text
+    body = response.text
+    assert 'hx-post="/ui/runbooks/rotate-cert/publish"' in body
+
+
+def test_catalog_row_action_hidden_for_operator() -> None:
+    """The catalog hides the lifecycle row actions from an operator."""
+    _seed_tenant(_TENANT_A, "tenant-a")
+    _seed_template(tenant_id=_TENANT_A, slug="rotate-cert")
+    session_id, jwks = _role_session(TenantRole.OPERATOR)
+
+    mock = respx.mock(assert_all_called=False)
+    mock.start()
+    try:
+        _mock_discovery_and_jwks(mock, jwks)
+        client = _authenticated_client(session_id)
+        response = client.get("/ui/runbooks")
+    finally:
+        mock.stop()
+
+    assert response.status_code == 200, response.text
+    body = response.text
+    assert 'hx-post="/ui/runbooks/rotate-cert/publish"' not in body

--- a/cli/api/openapi.json
+++ b/cli/api/openapi.json
@@ -9456,6 +9456,110 @@
         }
       }
     },
+    "/ui/runbooks/{slug}/publish": {
+      "post": {
+        "tags": [
+          "ui-runbooks"
+        ],
+        "summary": "Runbooks Publish",
+        "description": "Publish ``(slug, version)`` (draft -> published); admin only.",
+        "operationId": "runbooks_publish_ui_runbooks__slug__publish_post",
+        "parameters": [
+          {
+            "name": "slug",
+            "in": "path",
+            "required": true,
+            "schema": {
+              "type": "string",
+              "title": "Slug"
+            }
+          }
+        ],
+        "requestBody": {
+          "content": {
+            "application/x-www-form-urlencoded": {
+              "schema": {
+                "$ref": "#/components/schemas/Body_runbooks_publish_ui_runbooks__slug__publish_post"
+              }
+            }
+          }
+        },
+        "responses": {
+          "200": {
+            "description": "Successful Response",
+            "content": {
+              "text/html": {
+                "schema": {
+                  "type": "string"
+                }
+              }
+            }
+          },
+          "422": {
+            "description": "Validation Error",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/HTTPValidationError"
+                }
+              }
+            }
+          }
+        }
+      }
+    },
+    "/ui/runbooks/{slug}/deprecate": {
+      "post": {
+        "tags": [
+          "ui-runbooks"
+        ],
+        "summary": "Runbooks Deprecate",
+        "description": "Deprecate ``(slug, version)`` (published -> deprecated); admin only.",
+        "operationId": "runbooks_deprecate_ui_runbooks__slug__deprecate_post",
+        "parameters": [
+          {
+            "name": "slug",
+            "in": "path",
+            "required": true,
+            "schema": {
+              "type": "string",
+              "title": "Slug"
+            }
+          }
+        ],
+        "requestBody": {
+          "content": {
+            "application/x-www-form-urlencoded": {
+              "schema": {
+                "$ref": "#/components/schemas/Body_runbooks_deprecate_ui_runbooks__slug__deprecate_post"
+              }
+            }
+          }
+        },
+        "responses": {
+          "200": {
+            "description": "Successful Response",
+            "content": {
+              "text/html": {
+                "schema": {
+                  "type": "string"
+                }
+              }
+            }
+          },
+          "422": {
+            "description": "Validation Error",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/HTTPValidationError"
+                }
+              }
+            }
+          }
+        }
+      }
+    },
     "/ui/runbooks/{slug}": {
       "get": {
         "tags": [
@@ -10754,6 +10858,18 @@
         ],
         "title": "Body_kb_upload_single_ui_kb_upload_post"
       },
+      "Body_runbooks_deprecate_ui_runbooks__slug__deprecate_post": {
+        "properties": {
+          "version": {
+            "type": "string",
+            "maxLength": 16,
+            "title": "Version",
+            "default": ""
+          }
+        },
+        "type": "object",
+        "title": "Body_runbooks_deprecate_ui_runbooks__slug__deprecate_post"
+      },
       "Body_runbooks_editor_create_ui_runbooks_new_post": {
         "properties": {
           "slug": {
@@ -10824,6 +10940,18 @@
         },
         "type": "object",
         "title": "Body_runbooks_editor_update_ui_runbooks__slug__edit_post"
+      },
+      "Body_runbooks_publish_ui_runbooks__slug__publish_post": {
+        "properties": {
+          "version": {
+            "type": "string",
+            "maxLength": 16,
+            "title": "Version",
+            "default": ""
+          }
+        },
+        "type": "object",
+        "title": "Body_runbooks_publish_ui_runbooks__slug__publish_post"
       },
       "Body_ui_connectors_create_submit_ui_connectors_create_post": {
         "properties": {

--- a/cli/internal/api/client.gen.go
+++ b/cli/internal/api/client.gen.go
@@ -1049,6 +1049,11 @@ type BodyKbUploadSingleUiKbUploadPost struct {
 	Slug *string `json:"slug,omitempty"`
 }
 
+// BodyRunbooksDeprecateUiRunbooksSlugDeprecatePost defines model for Body_runbooks_deprecate_ui_runbooks__slug__deprecate_post.
+type BodyRunbooksDeprecateUiRunbooksSlugDeprecatePost struct {
+	Version *string `json:"version,omitempty"`
+}
+
 // BodyRunbooksEditorCreateUiRunbooksNewPost defines model for Body_runbooks_editor_create_ui_runbooks_new_post.
 type BodyRunbooksEditorCreateUiRunbooksNewPost struct {
 	Description *string `json:"description,omitempty"`
@@ -1069,6 +1074,11 @@ type BodyRunbooksEditorUpdateUiRunbooksSlugEditPost struct {
 	Steps       *string `json:"steps,omitempty"`
 	TargetKind  *string `json:"target_kind,omitempty"`
 	Title       *string `json:"title,omitempty"`
+}
+
+// BodyRunbooksPublishUiRunbooksSlugPublishPost defines model for Body_runbooks_publish_ui_runbooks__slug__publish_post.
+type BodyRunbooksPublishUiRunbooksSlugPublishPost struct {
+	Version *string `json:"version,omitempty"`
 }
 
 // BodyUiConnectorsCreateSubmitUiConnectorsCreatePost defines model for Body_ui_connectors_create_submit_ui_connectors_create_post.
@@ -5784,8 +5794,14 @@ type RunbooksEditorCreateUiRunbooksNewPostFormdataRequestBody = BodyRunbooksEdit
 // RunbooksEditorPreviewUiRunbooksPreviewPostFormdataRequestBody defines body for RunbooksEditorPreviewUiRunbooksPreviewPost for application/x-www-form-urlencoded ContentType.
 type RunbooksEditorPreviewUiRunbooksPreviewPostFormdataRequestBody = BodyRunbooksEditorPreviewUiRunbooksPreviewPost
 
+// RunbooksDeprecateUiRunbooksSlugDeprecatePostFormdataRequestBody defines body for RunbooksDeprecateUiRunbooksSlugDeprecatePost for application/x-www-form-urlencoded ContentType.
+type RunbooksDeprecateUiRunbooksSlugDeprecatePostFormdataRequestBody = BodyRunbooksDeprecateUiRunbooksSlugDeprecatePost
+
 // RunbooksEditorUpdateUiRunbooksSlugEditPostFormdataRequestBody defines body for RunbooksEditorUpdateUiRunbooksSlugEditPost for application/x-www-form-urlencoded ContentType.
 type RunbooksEditorUpdateUiRunbooksSlugEditPostFormdataRequestBody = BodyRunbooksEditorUpdateUiRunbooksSlugEditPost
+
+// RunbooksPublishUiRunbooksSlugPublishPostFormdataRequestBody defines body for RunbooksPublishUiRunbooksSlugPublishPost for application/x-www-form-urlencoded ContentType.
+type RunbooksPublishUiRunbooksSlugPublishPostFormdataRequestBody = BodyRunbooksPublishUiRunbooksSlugPublishPost
 
 // AsApproveResponseBodyDispatchResult0 returns the union data inside the ApproveResponseBody_DispatchResult as a ApproveResponseBodyDispatchResult0
 func (t ApproveResponseBody_DispatchResult) AsApproveResponseBodyDispatchResult0() (ApproveResponseBodyDispatchResult0, error) {
@@ -7071,6 +7087,11 @@ type ClientInterface interface {
 	// RunbooksDetailUiRunbooksSlugGet request
 	RunbooksDetailUiRunbooksSlugGet(ctx context.Context, slug string, params *RunbooksDetailUiRunbooksSlugGetParams, reqEditors ...RequestEditorFn) (*http.Response, error)
 
+	// RunbooksDeprecateUiRunbooksSlugDeprecatePostWithBody request with any body
+	RunbooksDeprecateUiRunbooksSlugDeprecatePostWithBody(ctx context.Context, slug string, contentType string, body io.Reader, reqEditors ...RequestEditorFn) (*http.Response, error)
+
+	RunbooksDeprecateUiRunbooksSlugDeprecatePostWithFormdataBody(ctx context.Context, slug string, body RunbooksDeprecateUiRunbooksSlugDeprecatePostFormdataRequestBody, reqEditors ...RequestEditorFn) (*http.Response, error)
+
 	// RunbooksEditorEditUiRunbooksSlugEditGet request
 	RunbooksEditorEditUiRunbooksSlugEditGet(ctx context.Context, slug string, reqEditors ...RequestEditorFn) (*http.Response, error)
 
@@ -7078,6 +7099,11 @@ type ClientInterface interface {
 	RunbooksEditorUpdateUiRunbooksSlugEditPostWithBody(ctx context.Context, slug string, contentType string, body io.Reader, reqEditors ...RequestEditorFn) (*http.Response, error)
 
 	RunbooksEditorUpdateUiRunbooksSlugEditPostWithFormdataBody(ctx context.Context, slug string, body RunbooksEditorUpdateUiRunbooksSlugEditPostFormdataRequestBody, reqEditors ...RequestEditorFn) (*http.Response, error)
+
+	// RunbooksPublishUiRunbooksSlugPublishPostWithBody request with any body
+	RunbooksPublishUiRunbooksSlugPublishPostWithBody(ctx context.Context, slug string, contentType string, body io.Reader, reqEditors ...RequestEditorFn) (*http.Response, error)
+
+	RunbooksPublishUiRunbooksSlugPublishPostWithFormdataBody(ctx context.Context, slug string, body RunbooksPublishUiRunbooksSlugPublishPostFormdataRequestBody, reqEditors ...RequestEditorFn) (*http.Response, error)
 
 	// UiTopologyTableUiTopologyGet request
 	UiTopologyTableUiTopologyGet(ctx context.Context, params *UiTopologyTableUiTopologyGetParams, reqEditors ...RequestEditorFn) (*http.Response, error)
@@ -9657,6 +9683,30 @@ func (c *Client) RunbooksDetailUiRunbooksSlugGet(ctx context.Context, slug strin
 	return c.Client.Do(req)
 }
 
+func (c *Client) RunbooksDeprecateUiRunbooksSlugDeprecatePostWithBody(ctx context.Context, slug string, contentType string, body io.Reader, reqEditors ...RequestEditorFn) (*http.Response, error) {
+	req, err := NewRunbooksDeprecateUiRunbooksSlugDeprecatePostRequestWithBody(c.Server, slug, contentType, body)
+	if err != nil {
+		return nil, err
+	}
+	req = req.WithContext(ctx)
+	if err := c.applyEditors(ctx, req, reqEditors); err != nil {
+		return nil, err
+	}
+	return c.Client.Do(req)
+}
+
+func (c *Client) RunbooksDeprecateUiRunbooksSlugDeprecatePostWithFormdataBody(ctx context.Context, slug string, body RunbooksDeprecateUiRunbooksSlugDeprecatePostFormdataRequestBody, reqEditors ...RequestEditorFn) (*http.Response, error) {
+	req, err := NewRunbooksDeprecateUiRunbooksSlugDeprecatePostRequestWithFormdataBody(c.Server, slug, body)
+	if err != nil {
+		return nil, err
+	}
+	req = req.WithContext(ctx)
+	if err := c.applyEditors(ctx, req, reqEditors); err != nil {
+		return nil, err
+	}
+	return c.Client.Do(req)
+}
+
 func (c *Client) RunbooksEditorEditUiRunbooksSlugEditGet(ctx context.Context, slug string, reqEditors ...RequestEditorFn) (*http.Response, error) {
 	req, err := NewRunbooksEditorEditUiRunbooksSlugEditGetRequest(c.Server, slug)
 	if err != nil {
@@ -9683,6 +9733,30 @@ func (c *Client) RunbooksEditorUpdateUiRunbooksSlugEditPostWithBody(ctx context.
 
 func (c *Client) RunbooksEditorUpdateUiRunbooksSlugEditPostWithFormdataBody(ctx context.Context, slug string, body RunbooksEditorUpdateUiRunbooksSlugEditPostFormdataRequestBody, reqEditors ...RequestEditorFn) (*http.Response, error) {
 	req, err := NewRunbooksEditorUpdateUiRunbooksSlugEditPostRequestWithFormdataBody(c.Server, slug, body)
+	if err != nil {
+		return nil, err
+	}
+	req = req.WithContext(ctx)
+	if err := c.applyEditors(ctx, req, reqEditors); err != nil {
+		return nil, err
+	}
+	return c.Client.Do(req)
+}
+
+func (c *Client) RunbooksPublishUiRunbooksSlugPublishPostWithBody(ctx context.Context, slug string, contentType string, body io.Reader, reqEditors ...RequestEditorFn) (*http.Response, error) {
+	req, err := NewRunbooksPublishUiRunbooksSlugPublishPostRequestWithBody(c.Server, slug, contentType, body)
+	if err != nil {
+		return nil, err
+	}
+	req = req.WithContext(ctx)
+	if err := c.applyEditors(ctx, req, reqEditors); err != nil {
+		return nil, err
+	}
+	return c.Client.Do(req)
+}
+
+func (c *Client) RunbooksPublishUiRunbooksSlugPublishPostWithFormdataBody(ctx context.Context, slug string, body RunbooksPublishUiRunbooksSlugPublishPostFormdataRequestBody, reqEditors ...RequestEditorFn) (*http.Response, error) {
+	req, err := NewRunbooksPublishUiRunbooksSlugPublishPostRequestWithFormdataBody(c.Server, slug, body)
 	if err != nil {
 		return nil, err
 	}
@@ -19073,6 +19147,53 @@ func NewRunbooksDetailUiRunbooksSlugGetRequest(server string, slug string, param
 	return req, nil
 }
 
+// NewRunbooksDeprecateUiRunbooksSlugDeprecatePostRequestWithFormdataBody calls the generic RunbooksDeprecateUiRunbooksSlugDeprecatePost builder with application/x-www-form-urlencoded body
+func NewRunbooksDeprecateUiRunbooksSlugDeprecatePostRequestWithFormdataBody(server string, slug string, body RunbooksDeprecateUiRunbooksSlugDeprecatePostFormdataRequestBody) (*http.Request, error) {
+	var bodyReader io.Reader
+	bodyStr, err := runtime.MarshalForm(body, nil)
+	if err != nil {
+		return nil, err
+	}
+	bodyReader = strings.NewReader(bodyStr.Encode())
+	return NewRunbooksDeprecateUiRunbooksSlugDeprecatePostRequestWithBody(server, slug, "application/x-www-form-urlencoded", bodyReader)
+}
+
+// NewRunbooksDeprecateUiRunbooksSlugDeprecatePostRequestWithBody generates requests for RunbooksDeprecateUiRunbooksSlugDeprecatePost with any type of body
+func NewRunbooksDeprecateUiRunbooksSlugDeprecatePostRequestWithBody(server string, slug string, contentType string, body io.Reader) (*http.Request, error) {
+	var err error
+
+	var pathParam0 string
+
+	pathParam0, err = runtime.StyleParamWithLocation("simple", false, "slug", runtime.ParamLocationPath, slug)
+	if err != nil {
+		return nil, err
+	}
+
+	serverURL, err := url.Parse(server)
+	if err != nil {
+		return nil, err
+	}
+
+	operationPath := fmt.Sprintf("/ui/runbooks/%s/deprecate", pathParam0)
+	if operationPath[0] == '/' {
+		operationPath = "." + operationPath
+	}
+
+	queryURL, err := serverURL.Parse(operationPath)
+	if err != nil {
+		return nil, err
+	}
+
+	req, err := http.NewRequest("POST", queryURL.String(), body)
+	if err != nil {
+		return nil, err
+	}
+
+	req.Header.Add("Content-Type", contentType)
+
+	return req, nil
+}
+
 // NewRunbooksEditorEditUiRunbooksSlugEditGetRequest generates requests for RunbooksEditorEditUiRunbooksSlugEditGet
 func NewRunbooksEditorEditUiRunbooksSlugEditGetRequest(server string, slug string) (*http.Request, error) {
 	var err error
@@ -19135,6 +19256,53 @@ func NewRunbooksEditorUpdateUiRunbooksSlugEditPostRequestWithBody(server string,
 	}
 
 	operationPath := fmt.Sprintf("/ui/runbooks/%s/edit", pathParam0)
+	if operationPath[0] == '/' {
+		operationPath = "." + operationPath
+	}
+
+	queryURL, err := serverURL.Parse(operationPath)
+	if err != nil {
+		return nil, err
+	}
+
+	req, err := http.NewRequest("POST", queryURL.String(), body)
+	if err != nil {
+		return nil, err
+	}
+
+	req.Header.Add("Content-Type", contentType)
+
+	return req, nil
+}
+
+// NewRunbooksPublishUiRunbooksSlugPublishPostRequestWithFormdataBody calls the generic RunbooksPublishUiRunbooksSlugPublishPost builder with application/x-www-form-urlencoded body
+func NewRunbooksPublishUiRunbooksSlugPublishPostRequestWithFormdataBody(server string, slug string, body RunbooksPublishUiRunbooksSlugPublishPostFormdataRequestBody) (*http.Request, error) {
+	var bodyReader io.Reader
+	bodyStr, err := runtime.MarshalForm(body, nil)
+	if err != nil {
+		return nil, err
+	}
+	bodyReader = strings.NewReader(bodyStr.Encode())
+	return NewRunbooksPublishUiRunbooksSlugPublishPostRequestWithBody(server, slug, "application/x-www-form-urlencoded", bodyReader)
+}
+
+// NewRunbooksPublishUiRunbooksSlugPublishPostRequestWithBody generates requests for RunbooksPublishUiRunbooksSlugPublishPost with any type of body
+func NewRunbooksPublishUiRunbooksSlugPublishPostRequestWithBody(server string, slug string, contentType string, body io.Reader) (*http.Request, error) {
+	var err error
+
+	var pathParam0 string
+
+	pathParam0, err = runtime.StyleParamWithLocation("simple", false, "slug", runtime.ParamLocationPath, slug)
+	if err != nil {
+		return nil, err
+	}
+
+	serverURL, err := url.Parse(server)
+	if err != nil {
+		return nil, err
+	}
+
+	operationPath := fmt.Sprintf("/ui/runbooks/%s/publish", pathParam0)
 	if operationPath[0] == '/' {
 		operationPath = "." + operationPath
 	}
@@ -20079,6 +20247,11 @@ type ClientWithResponsesInterface interface {
 	// RunbooksDetailUiRunbooksSlugGetWithResponse request
 	RunbooksDetailUiRunbooksSlugGetWithResponse(ctx context.Context, slug string, params *RunbooksDetailUiRunbooksSlugGetParams, reqEditors ...RequestEditorFn) (*RunbooksDetailUiRunbooksSlugGetResponse, error)
 
+	// RunbooksDeprecateUiRunbooksSlugDeprecatePostWithBodyWithResponse request with any body
+	RunbooksDeprecateUiRunbooksSlugDeprecatePostWithBodyWithResponse(ctx context.Context, slug string, contentType string, body io.Reader, reqEditors ...RequestEditorFn) (*RunbooksDeprecateUiRunbooksSlugDeprecatePostResponse, error)
+
+	RunbooksDeprecateUiRunbooksSlugDeprecatePostWithFormdataBodyWithResponse(ctx context.Context, slug string, body RunbooksDeprecateUiRunbooksSlugDeprecatePostFormdataRequestBody, reqEditors ...RequestEditorFn) (*RunbooksDeprecateUiRunbooksSlugDeprecatePostResponse, error)
+
 	// RunbooksEditorEditUiRunbooksSlugEditGetWithResponse request
 	RunbooksEditorEditUiRunbooksSlugEditGetWithResponse(ctx context.Context, slug string, reqEditors ...RequestEditorFn) (*RunbooksEditorEditUiRunbooksSlugEditGetResponse, error)
 
@@ -20086,6 +20259,11 @@ type ClientWithResponsesInterface interface {
 	RunbooksEditorUpdateUiRunbooksSlugEditPostWithBodyWithResponse(ctx context.Context, slug string, contentType string, body io.Reader, reqEditors ...RequestEditorFn) (*RunbooksEditorUpdateUiRunbooksSlugEditPostResponse, error)
 
 	RunbooksEditorUpdateUiRunbooksSlugEditPostWithFormdataBodyWithResponse(ctx context.Context, slug string, body RunbooksEditorUpdateUiRunbooksSlugEditPostFormdataRequestBody, reqEditors ...RequestEditorFn) (*RunbooksEditorUpdateUiRunbooksSlugEditPostResponse, error)
+
+	// RunbooksPublishUiRunbooksSlugPublishPostWithBodyWithResponse request with any body
+	RunbooksPublishUiRunbooksSlugPublishPostWithBodyWithResponse(ctx context.Context, slug string, contentType string, body io.Reader, reqEditors ...RequestEditorFn) (*RunbooksPublishUiRunbooksSlugPublishPostResponse, error)
+
+	RunbooksPublishUiRunbooksSlugPublishPostWithFormdataBodyWithResponse(ctx context.Context, slug string, body RunbooksPublishUiRunbooksSlugPublishPostFormdataRequestBody, reqEditors ...RequestEditorFn) (*RunbooksPublishUiRunbooksSlugPublishPostResponse, error)
 
 	// UiTopologyTableUiTopologyGetWithResponse request
 	UiTopologyTableUiTopologyGetWithResponse(ctx context.Context, params *UiTopologyTableUiTopologyGetParams, reqEditors ...RequestEditorFn) (*UiTopologyTableUiTopologyGetResponse, error)
@@ -23604,6 +23782,28 @@ func (r RunbooksDetailUiRunbooksSlugGetResponse) StatusCode() int {
 	return 0
 }
 
+type RunbooksDeprecateUiRunbooksSlugDeprecatePostResponse struct {
+	Body         []byte
+	HTTPResponse *http.Response
+	JSON422      *HTTPValidationError
+}
+
+// Status returns HTTPResponse.Status
+func (r RunbooksDeprecateUiRunbooksSlugDeprecatePostResponse) Status() string {
+	if r.HTTPResponse != nil {
+		return r.HTTPResponse.Status
+	}
+	return http.StatusText(0)
+}
+
+// StatusCode returns HTTPResponse.StatusCode
+func (r RunbooksDeprecateUiRunbooksSlugDeprecatePostResponse) StatusCode() int {
+	if r.HTTPResponse != nil {
+		return r.HTTPResponse.StatusCode
+	}
+	return 0
+}
+
 type RunbooksEditorEditUiRunbooksSlugEditGetResponse struct {
 	Body         []byte
 	HTTPResponse *http.Response
@@ -23642,6 +23842,28 @@ func (r RunbooksEditorUpdateUiRunbooksSlugEditPostResponse) Status() string {
 
 // StatusCode returns HTTPResponse.StatusCode
 func (r RunbooksEditorUpdateUiRunbooksSlugEditPostResponse) StatusCode() int {
+	if r.HTTPResponse != nil {
+		return r.HTTPResponse.StatusCode
+	}
+	return 0
+}
+
+type RunbooksPublishUiRunbooksSlugPublishPostResponse struct {
+	Body         []byte
+	HTTPResponse *http.Response
+	JSON422      *HTTPValidationError
+}
+
+// Status returns HTTPResponse.Status
+func (r RunbooksPublishUiRunbooksSlugPublishPostResponse) Status() string {
+	if r.HTTPResponse != nil {
+		return r.HTTPResponse.Status
+	}
+	return http.StatusText(0)
+}
+
+// StatusCode returns HTTPResponse.StatusCode
+func (r RunbooksPublishUiRunbooksSlugPublishPostResponse) StatusCode() int {
 	if r.HTTPResponse != nil {
 		return r.HTTPResponse.StatusCode
 	}
@@ -25578,6 +25800,23 @@ func (c *ClientWithResponses) RunbooksDetailUiRunbooksSlugGetWithResponse(ctx co
 	return ParseRunbooksDetailUiRunbooksSlugGetResponse(rsp)
 }
 
+// RunbooksDeprecateUiRunbooksSlugDeprecatePostWithBodyWithResponse request with arbitrary body returning *RunbooksDeprecateUiRunbooksSlugDeprecatePostResponse
+func (c *ClientWithResponses) RunbooksDeprecateUiRunbooksSlugDeprecatePostWithBodyWithResponse(ctx context.Context, slug string, contentType string, body io.Reader, reqEditors ...RequestEditorFn) (*RunbooksDeprecateUiRunbooksSlugDeprecatePostResponse, error) {
+	rsp, err := c.RunbooksDeprecateUiRunbooksSlugDeprecatePostWithBody(ctx, slug, contentType, body, reqEditors...)
+	if err != nil {
+		return nil, err
+	}
+	return ParseRunbooksDeprecateUiRunbooksSlugDeprecatePostResponse(rsp)
+}
+
+func (c *ClientWithResponses) RunbooksDeprecateUiRunbooksSlugDeprecatePostWithFormdataBodyWithResponse(ctx context.Context, slug string, body RunbooksDeprecateUiRunbooksSlugDeprecatePostFormdataRequestBody, reqEditors ...RequestEditorFn) (*RunbooksDeprecateUiRunbooksSlugDeprecatePostResponse, error) {
+	rsp, err := c.RunbooksDeprecateUiRunbooksSlugDeprecatePostWithFormdataBody(ctx, slug, body, reqEditors...)
+	if err != nil {
+		return nil, err
+	}
+	return ParseRunbooksDeprecateUiRunbooksSlugDeprecatePostResponse(rsp)
+}
+
 // RunbooksEditorEditUiRunbooksSlugEditGetWithResponse request returning *RunbooksEditorEditUiRunbooksSlugEditGetResponse
 func (c *ClientWithResponses) RunbooksEditorEditUiRunbooksSlugEditGetWithResponse(ctx context.Context, slug string, reqEditors ...RequestEditorFn) (*RunbooksEditorEditUiRunbooksSlugEditGetResponse, error) {
 	rsp, err := c.RunbooksEditorEditUiRunbooksSlugEditGet(ctx, slug, reqEditors...)
@@ -25602,6 +25841,23 @@ func (c *ClientWithResponses) RunbooksEditorUpdateUiRunbooksSlugEditPostWithForm
 		return nil, err
 	}
 	return ParseRunbooksEditorUpdateUiRunbooksSlugEditPostResponse(rsp)
+}
+
+// RunbooksPublishUiRunbooksSlugPublishPostWithBodyWithResponse request with arbitrary body returning *RunbooksPublishUiRunbooksSlugPublishPostResponse
+func (c *ClientWithResponses) RunbooksPublishUiRunbooksSlugPublishPostWithBodyWithResponse(ctx context.Context, slug string, contentType string, body io.Reader, reqEditors ...RequestEditorFn) (*RunbooksPublishUiRunbooksSlugPublishPostResponse, error) {
+	rsp, err := c.RunbooksPublishUiRunbooksSlugPublishPostWithBody(ctx, slug, contentType, body, reqEditors...)
+	if err != nil {
+		return nil, err
+	}
+	return ParseRunbooksPublishUiRunbooksSlugPublishPostResponse(rsp)
+}
+
+func (c *ClientWithResponses) RunbooksPublishUiRunbooksSlugPublishPostWithFormdataBodyWithResponse(ctx context.Context, slug string, body RunbooksPublishUiRunbooksSlugPublishPostFormdataRequestBody, reqEditors ...RequestEditorFn) (*RunbooksPublishUiRunbooksSlugPublishPostResponse, error) {
+	rsp, err := c.RunbooksPublishUiRunbooksSlugPublishPostWithFormdataBody(ctx, slug, body, reqEditors...)
+	if err != nil {
+		return nil, err
+	}
+	return ParseRunbooksPublishUiRunbooksSlugPublishPostResponse(rsp)
 }
 
 // UiTopologyTableUiTopologyGetWithResponse request returning *UiTopologyTableUiTopologyGetResponse
@@ -30240,6 +30496,32 @@ func ParseRunbooksDetailUiRunbooksSlugGetResponse(rsp *http.Response) (*Runbooks
 	return response, nil
 }
 
+// ParseRunbooksDeprecateUiRunbooksSlugDeprecatePostResponse parses an HTTP response from a RunbooksDeprecateUiRunbooksSlugDeprecatePostWithResponse call
+func ParseRunbooksDeprecateUiRunbooksSlugDeprecatePostResponse(rsp *http.Response) (*RunbooksDeprecateUiRunbooksSlugDeprecatePostResponse, error) {
+	bodyBytes, err := io.ReadAll(rsp.Body)
+	defer func() { _ = rsp.Body.Close() }()
+	if err != nil {
+		return nil, err
+	}
+
+	response := &RunbooksDeprecateUiRunbooksSlugDeprecatePostResponse{
+		Body:         bodyBytes,
+		HTTPResponse: rsp,
+	}
+
+	switch {
+	case strings.Contains(rsp.Header.Get("Content-Type"), "json") && rsp.StatusCode == 422:
+		var dest HTTPValidationError
+		if err := json.Unmarshal(bodyBytes, &dest); err != nil {
+			return nil, err
+		}
+		response.JSON422 = &dest
+
+	}
+
+	return response, nil
+}
+
 // ParseRunbooksEditorEditUiRunbooksSlugEditGetResponse parses an HTTP response from a RunbooksEditorEditUiRunbooksSlugEditGetWithResponse call
 func ParseRunbooksEditorEditUiRunbooksSlugEditGetResponse(rsp *http.Response) (*RunbooksEditorEditUiRunbooksSlugEditGetResponse, error) {
 	bodyBytes, err := io.ReadAll(rsp.Body)
@@ -30275,6 +30557,32 @@ func ParseRunbooksEditorUpdateUiRunbooksSlugEditPostResponse(rsp *http.Response)
 	}
 
 	response := &RunbooksEditorUpdateUiRunbooksSlugEditPostResponse{
+		Body:         bodyBytes,
+		HTTPResponse: rsp,
+	}
+
+	switch {
+	case strings.Contains(rsp.Header.Get("Content-Type"), "json") && rsp.StatusCode == 422:
+		var dest HTTPValidationError
+		if err := json.Unmarshal(bodyBytes, &dest); err != nil {
+			return nil, err
+		}
+		response.JSON422 = &dest
+
+	}
+
+	return response, nil
+}
+
+// ParseRunbooksPublishUiRunbooksSlugPublishPostResponse parses an HTTP response from a RunbooksPublishUiRunbooksSlugPublishPostWithResponse call
+func ParseRunbooksPublishUiRunbooksSlugPublishPostResponse(rsp *http.Response) (*RunbooksPublishUiRunbooksSlugPublishPostResponse, error) {
+	bodyBytes, err := io.ReadAll(rsp.Body)
+	defer func() { _ = rsp.Body.Close() }()
+	if err != nil {
+		return nil, err
+	}
+
+	response := &RunbooksPublishUiRunbooksSlugPublishPostResponse{
 		Body:         bodyBytes,
 		HTTPResponse: rsp,
 	}


### PR DESCRIPTION
## Summary
- Add the `tenant_admin` lifecycle layer onto the T1 read (#1382) + T2 authoring (#1383) runbooks surface: two `require_ui_admin`-gated POST handlers (`/ui/runbooks/{slug}/publish`, `/ui/runbooks/{slug}/deprecate`) driving `draft → published → deprecated` over the same `RunbookTemplateService` the REST surface and CLI use, targeting the specific `version` the detail/list view carries.
- Controls are server-authoritative: hidden in markup for `operator` and re-checked via `require_ui_admin` (a forged operator POST is **403**; a missing CSRF token is blocked by `CSRFMiddleware`). Success swaps the status badge (HTMX `hx-swap-oob`) and re-renders the action row; a typed **400** (publish non-draft / deprecate non-published) renders as an inline DaisyUI alert with the badge unchanged; idempotent re-actions (**200**) refresh the badge with no error; a missing `(slug, version)` is **404**. Each action sits behind an Alpine confirm dialog naming slug + version.
- The published-template **Edit (forks draft)** affordance reuses T2's PATCH path and surfaces the in-flight run count pinned to the version (new `count_in_flight_runs` service read). Catalog rows gain matching admin Publish/Deprecate row actions that reload the list to reflect the new badge.
- New routes appear in the OpenAPI snapshot → CLI snapshot + Go client regenerated.

## Test plan
- [x] `ruff check` + `ruff format --check` — clean
- [x] `mypy` — clean (3 source files, no issues)
- [x] `python3 .claude/hooks/code-quality.py --diff` — 0 blockers (only pre-existing warnings)
- [x] `pytest tests/test_ui_runbooks_lifecycle.py` — 13 passed
- [x] Regression: `test_ui_runbooks_editor` / `test_ui_runbooks_list` / `test_runbooks_template_service` / `test_runbook_templates_api` — 103 passed total
- [x] `cd cli && make snapshot-openapi && make generate` — snapshot + Go client regenerated; `go build ./...` OK
- [x] Acceptance: admin publish 200 / operator forged 403 / missing-CSRF blocked; deprecate 200; 400 not-draft + not-published inline alerts; idempotent re-action 200 no-op; 404 missing version; controls hidden for operator (detail + catalog); fork affordance surfaces in-flight count

## Out of scope
- Read catalog/detail (T1 #1382), draft/edit editor (T2 #1383, reused), docs/acceptance round-trip (T4), run-execution UI.

<!-- auto-implement-issue: fresh, iteration 1 -->

Closes #1384


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **New Features**
  * Admin users can now publish draft runbooks and deprecate published runbooks directly from the UI
  * Runbook templates display status badges indicating draft, published, or deprecated state
  * In-flight run counts are displayed for published templates to inform versioning decisions

* **Tests**
  * Added comprehensive test coverage for runbook lifecycle management and admin permission controls

<!-- end of auto-generated comment: release notes by coderabbit.ai -->