### PR TITLE
docs(ui): G10.6-T4 runbooks surface docs + end-to-end acceptance

### DIFF
--- a/backend/tests/test_ui_runbooks_acceptance.py
+++ b/backend/tests/test_ui_runbooks_acceptance.py
@@ -1,0 +1,631 @@
+# SPDX-License-Identifier: Apache-2.0
+# Copyright (c) 2026 evoila Group
+
+"""End-to-end acceptance for the runbooks UI surface as a whole (G10.6).
+
+Initiative #1381 (G10.6 Runbooks UI), Task #1385 (T4 close-out). The
+per-task suites (:mod:`backend.tests.test_ui_runbooks_list` T1,
+:mod:`backend.tests.test_ui_runbooks_editor` T2,
+:mod:`backend.tests.test_ui_runbooks_lifecycle` T3) cover each route in
+isolation. This module asserts the *surface* -- the read + author +
+lifecycle paths exercised together against one app instance, plus the
+RBAC boundary and the nav/dashboard discoverability that close out the
+initiative.
+
+What the single end-to-end test pins (issue #1385 acceptance criteria):
+
+* operator browse -- catalog lists templates with status badges and the
+  ``status`` / ``target_kind`` filters narrow the list;
+* operator opacity-floor -- an operator with no completed run against a
+  template gets the graceful restricted-detail page (summary + notice),
+  **not** a raw 403/500;
+* ``tenant_admin`` authoring -- author a draft via the editor POST;
+* publish -> deprecate round-trip with observable status transitions
+  (draft -> published -> deprecated), read back through the read surface;
+* operator blocked (403) from author / publish / deprecate (the write
+  surfaces gate on ``require_ui_admin``);
+* the runbooks sidebar link + dashboard tile render.
+
+Harness shape mirrors the T1-T3 suites (KB read-surface precedent
+#870): a minimal FastAPI app wired with the BFF middlewares + the UI
+surface router, SQLite-backed seeding via the real
+:class:`~meho_backplane.runbooks.service.RunbookTemplateService`, and a
+pre-set session cookie. Admin paths mint a real ``tenant_admin`` JWT via
+``tests._oidc_jwt_helpers`` so ``require_ui_admin`` resolves; operator
+paths either rely on the soft-fail role lift (plaintext access token ->
+"no admin") for the read surface or mint a real ``operator`` JWT (which
+decodes cleanly but fails the role-rank check -> 403) for the write
+boundary.
+"""
+
+from __future__ import annotations
+
+import asyncio
+import json
+import uuid
+import warnings
+from collections.abc import Iterator
+from datetime import UTC, datetime, timedelta
+from typing import Any
+
+import pytest
+import respx
+from cryptography.fernet import Fernet
+from fastapi import FastAPI
+from fastapi.staticfiles import StaticFiles
+from fastapi.testclient import TestClient
+
+from meho_backplane.auth.jwt import clear_jwks_cache
+from meho_backplane.auth.operator import TenantRole
+from meho_backplane.db.engine import get_sessionmaker, reset_engine_for_testing
+from meho_backplane.db.models import RunbookRun, Tenant
+from meho_backplane.runbooks.schemas import (
+    ConfirmVerify,
+    DraftTemplateRequest,
+    ManualStep,
+    OperationCallStep,
+    OperationCallVerify,
+    RunbookTemplateBody,
+)
+from meho_backplane.runbooks.service import RunbookTemplateService
+from meho_backplane.settings import get_settings
+from meho_backplane.ui.auth import SESSION_COOKIE_NAME, UISessionMiddleware
+from meho_backplane.ui.auth import build_router as build_ui_auth_router
+from meho_backplane.ui.auth.flow import (
+    clear_discovery_cache,
+    reset_verifier_store_for_testing,
+)
+from meho_backplane.ui.auth.session_store import (
+    create_session,
+    reset_fernet_cache_for_testing,
+)
+from meho_backplane.ui.csrf import (
+    CSRF_COOKIE_NAME,
+    CSRF_HEADER_NAME,
+    CSRFMiddleware,
+    mint_csrf_token,
+)
+from meho_backplane.ui.paths import static_root_dir
+from meho_backplane.ui.routes import build_router as build_ui_router
+from meho_backplane.ui.templating import reset_templating_for_testing
+from tests._oidc_jwt_helpers import (
+    make_rsa_keypair as _make_rsa_keypair,
+)
+from tests._oidc_jwt_helpers import (
+    mint_token as _mint_token,
+)
+from tests._oidc_jwt_helpers import (
+    mock_discovery_and_jwks as _mock_discovery_and_jwks,
+)
+from tests._oidc_jwt_helpers import (
+    public_jwks as _public_jwks,
+)
+
+# ---------------------------------------------------------------------------
+# Constants
+# ---------------------------------------------------------------------------
+
+_BACKPLANE_URL = "https://meho.test"
+_DEFAULT_ISSUER = "https://keycloak.test/realms/meho"
+_DEFAULT_AUDIENCE = "meho-backplane"
+
+_TENANT_A = uuid.UUID("aaaaaaaa-aaaa-aaaa-aaaa-aaaaaaaaaaaa")
+
+_OPERATOR_SUB = "op-42"
+
+
+# ---------------------------------------------------------------------------
+# Fixtures
+# ---------------------------------------------------------------------------
+
+
+@pytest.fixture(autouse=True)
+def _bff_env(monkeypatch: pytest.MonkeyPatch) -> Iterator[None]:
+    """Pin chassis + BFF env vars for every test (KB-suite baseline)."""
+    monkeypatch.setenv("KEYCLOAK_ISSUER_URL", _DEFAULT_ISSUER)
+    monkeypatch.setenv("KEYCLOAK_AUDIENCE", _DEFAULT_AUDIENCE)
+    monkeypatch.setenv("VAULT_ADDR", "https://vault.test")
+    monkeypatch.setenv("BACKPLANE_URL", _BACKPLANE_URL)
+    monkeypatch.setenv("UI_SESSION_ENCRYPTION_KEY", Fernet.generate_key().decode())
+    monkeypatch.setenv("UI_KEYCLOAK_CLIENT_ID", "meho-web")
+    monkeypatch.setenv("UI_KEYCLOAK_CLIENT_SECRET", "test-client-secret")
+    get_settings.cache_clear()
+    reset_fernet_cache_for_testing()
+    reset_verifier_store_for_testing()
+    reset_templating_for_testing()
+    clear_discovery_cache()
+    clear_jwks_cache()
+    reset_engine_for_testing()
+    yield
+    get_settings.cache_clear()
+    reset_fernet_cache_for_testing()
+    reset_verifier_store_for_testing()
+    reset_templating_for_testing()
+    clear_discovery_cache()
+    clear_jwks_cache()
+    reset_engine_for_testing()
+
+
+# ---------------------------------------------------------------------------
+# App + seeding helpers (mirror the T1-T3 suites)
+# ---------------------------------------------------------------------------
+
+
+def _build_app() -> FastAPI:
+    """Minimal FastAPI app wired for the runbooks UI surface (KB-suite shape)."""
+    app = FastAPI()
+    app.add_middleware(CSRFMiddleware)
+    app.add_middleware(UISessionMiddleware)
+    app.mount(
+        "/ui/static",
+        StaticFiles(directory=str(static_root_dir()), check_dir=False),
+        name="ui_static",
+    )
+    app.include_router(build_ui_auth_router())
+    app.include_router(build_ui_router())
+    return app
+
+
+def _seed_tenant(tenant_id: uuid.UUID, slug: str) -> None:
+    """Insert one ``tenant`` row so FK constraints resolve."""
+
+    async def _do() -> None:
+        sessionmaker = get_sessionmaker()
+        async with sessionmaker() as session, session.begin():
+            session.add(Tenant(id=tenant_id, slug=slug, name=f"Tenant {slug}"))
+
+    asyncio.run(_do())
+
+
+def _manual_body(
+    *,
+    title: str = "Drain node",
+    target_kind: str | None = "k8s-node",
+) -> RunbookTemplateBody:
+    """One manual step + confirm verify."""
+    return RunbookTemplateBody(
+        title=title,
+        description="Procedure for draining a node.",
+        target_kind=target_kind,
+        steps=[
+            ManualStep(
+                id="drain",
+                title="Drain the node",
+                body="Run the **drain** command.",
+                type="manual",
+                verify=ConfirmVerify(type="confirm", prompt="Node drained?"),
+            ),
+        ],
+    )
+
+
+def _mixed_body() -> RunbookTemplateBody:
+    """One manual + one operation_call step; both verify kinds present."""
+    return RunbookTemplateBody(
+        title="Rotate certificate",
+        description="Rotate the cluster's serving certificate.",
+        target_kind="vmware-vcenter",
+        steps=[
+            ManualStep(
+                id="prep",
+                title="Prepare the change window",
+                body="Announce the maintenance window.",
+                type="manual",
+                verify=ConfirmVerify(type="confirm", prompt="Window announced?"),
+            ),
+            OperationCallStep(
+                id="rotate-cert",
+                title="Rotate the serving cert",
+                body="Dispatch the rotation operation.",
+                type="operation_call",
+                op_id="vmware.composite.cert.rotate",
+                params={"target": "${run.target}"},
+                verify=OperationCallVerify(
+                    type="operation_call",
+                    op_id="vmware.cert.status",
+                    params={"target": "${run.target}"},
+                    expect={"valid": True},
+                ),
+            ),
+        ],
+    )
+
+
+def _seed_template(
+    *,
+    tenant_id: uuid.UUID,
+    slug: str,
+    body: RunbookTemplateBody,
+) -> int:
+    """Create a draft template and return its version."""
+
+    async def _do() -> int:
+        resp = await RunbookTemplateService().create_draft(
+            tenant_id,
+            _OPERATOR_SUB,
+            DraftTemplateRequest(slug=slug, body=body),
+        )
+        return resp.version
+
+    return asyncio.run(_do())
+
+
+def _seed_run(
+    *,
+    tenant_id: uuid.UUID,
+    slug: str,
+    version: int,
+    assigned_to: str,
+    state: str = "completed",
+) -> None:
+    """Insert one ``runbook_runs`` row pinned to ``(slug, version)``."""
+
+    async def _do() -> None:
+        sessionmaker = get_sessionmaker()
+        async with sessionmaker() as session:
+            session.add(
+                RunbookRun(
+                    tenant_id=tenant_id,
+                    template_slug=slug,
+                    template_version=version,
+                    assigned_to=assigned_to,
+                    target="host-1",
+                    params={},
+                    state=state,
+                    started_by=assigned_to,
+                    started_at=datetime.now(UTC),
+                )
+            )
+            await session.commit()
+
+    asyncio.run(_do())
+
+
+def _seed_session_sync(
+    *,
+    tenant_id: uuid.UUID,
+    access_token: str = "access-token-plaintext",
+    lifetime: timedelta = timedelta(hours=1),
+) -> uuid.UUID:
+    """Create a ``web_session`` row carrying *access_token* and return its UUID."""
+
+    async def _do() -> uuid.UUID:
+        sessionmaker = get_sessionmaker()
+        async with sessionmaker() as session, session.begin():
+            decrypted = await create_session(
+                session,
+                operator_sub=_OPERATOR_SUB,
+                tenant_id=tenant_id,
+                access_token=access_token,
+                refresh_token="refresh-token-plaintext",
+                lifetime=lifetime,
+            )
+            return decrypted.id
+
+    return asyncio.run(_do())
+
+
+def _authenticated_client(session_id: uuid.UUID) -> TestClient:
+    """Return a TestClient with the session cookie pre-set."""
+    client = TestClient(_build_app(), follow_redirects=False)
+    client.cookies.set(SESSION_COOKIE_NAME, str(session_id))
+    return client
+
+
+def _make_keypair_and_jwks() -> tuple[Any, dict[str, Any]]:
+    """Mint a stable RSA-2048 keypair + the matching JWKS document."""
+    with warnings.catch_warnings():
+        warnings.simplefilter("ignore")
+        keypair = _make_rsa_keypair("ui-runbooks-acceptance-kid")
+    return keypair, _public_jwks(keypair)
+
+
+def _role_session(role: TenantRole) -> tuple[uuid.UUID, dict[str, Any]]:
+    """Seed a session whose access token is a real JWT carrying *role*.
+
+    Returns the session id and the JWKS the role lift must reach. A
+    ``TENANT_ADMIN`` token passes ``require_ui_admin``; an ``OPERATOR``
+    token decodes cleanly but fails the role rank check -> 403.
+    """
+    keypair, jwks = _make_keypair_and_jwks()
+    access_token = _mint_token(
+        keypair,
+        sub=_OPERATOR_SUB,
+        tenant_id=str(_TENANT_A),
+        tenant_role=role.value,
+    )
+    session_id = _seed_session_sync(tenant_id=_TENANT_A, access_token=access_token)
+    return session_id, jwks
+
+
+def _csrf_kwargs(session_id: uuid.UUID) -> dict[str, Any]:
+    """Header + cookie kwargs that satisfy the double-submit CSRF check.
+
+    The editor's CSRF cookie is ``Secure``, so the plain-``http`` TestClient
+    does not auto-store it; the browser round-trip is reconstructed by
+    presenting the same minted token as both the ``X-CSRF-Token`` header and
+    an explicit request cookie (the T2/T3 suites use the same shape).
+    """
+    token = mint_csrf_token(str(session_id))
+    return {
+        "headers": {CSRF_HEADER_NAME: token, "X-CSRF-Token": token},
+        "cookies": {CSRF_COOKIE_NAME: token},
+    }
+
+
+def _status(slug: str, version: int) -> str:
+    """Read the persisted status of ``(slug, version)`` for assertions."""
+
+    async def _do() -> str:
+        tpl = await RunbookTemplateService().show_template(_TENANT_A, slug, version=version)
+        return tpl.status
+
+    return asyncio.run(_do())
+
+
+def _authored_steps_json() -> str:
+    """A two-step editor payload: one manual+confirm, one operation_call.
+
+    The editor form serialises steps as a JSON string with ``params`` /
+    ``expect`` carried as nested JSON strings (the Alpine form shape the T2
+    suite exercises). Built via ``json.dumps`` so the nested-string escaping
+    is correct without hand-written backslashes.
+    """
+    steps = [
+        {
+            "id": "prep",
+            "title": "Prepare",
+            "body": "Announce the window.",
+            "type": "manual",
+            "op_id": "",
+            "params": "{}",
+            "verify": {
+                "type": "confirm",
+                "prompt": "Window announced?",
+                "op_id": "",
+                "params": "{}",
+                "expect": "{}",
+            },
+        },
+        {
+            "id": "rotate",
+            "title": "Rotate",
+            "body": "Dispatch rotation.",
+            "type": "operation_call",
+            "op_id": "vmware.cert.rotate",
+            "params": json.dumps({"target": "${run.target}"}),
+            "verify": {
+                "type": "operation_call",
+                "prompt": "",
+                "op_id": "vmware.cert.status",
+                "params": json.dumps({"target": "${run.target}"}),
+                "expect": json.dumps({"valid": True}),
+            },
+        },
+    ]
+    return json.dumps(steps)
+
+
+# ---------------------------------------------------------------------------
+# Cross-cutting end-to-end acceptance
+# ---------------------------------------------------------------------------
+
+
+def test_runbooks_surface_end_to_end() -> None:
+    """The runbooks surface as a whole: browse -> opacity floor -> author ->
+    publish -> deprecate, plus the operator write-boundary and nav/dashboard
+    discoverability, exercised against one app instance.
+
+    Asserted in one flow because the value of this test is the *interaction*
+    of the routes (a published-then-deprecated template read back through the
+    catalog, an operator who can browse but cannot author) -- properties the
+    per-route unit suites cannot observe in isolation.
+    """
+    _seed_tenant(_TENANT_A, "tenant-a")
+
+    # Two seeded drafts so the catalog + filters have something to show before
+    # any authoring happens.
+    _seed_template(tenant_id=_TENANT_A, slug="drain-node", body=_manual_body())
+    _seed_template(tenant_id=_TENANT_A, slug="rotate-cert", body=_mixed_body())
+
+    admin_session, admin_jwks = _role_session(TenantRole.TENANT_ADMIN)
+    operator_session, operator_jwks = _role_session(TenantRole.OPERATOR)
+    # A plaintext-token operator session: the role lift soft-fails to "no
+    # admin", so the read surface degrades to the opacity-floor restricted
+    # state rather than 5xx-ing.
+    operator_soft_session = _seed_session_sync(tenant_id=_TENANT_A)
+
+    admin_mock = respx.mock(assert_all_called=False)
+    admin_mock.start()
+    try:
+        _mock_discovery_and_jwks(admin_mock, admin_jwks)
+
+        # --- 1. Operator browse: catalog lists templates with badges. ------
+        op_client = _authenticated_client(operator_soft_session)
+        catalog = op_client.get("/ui/runbooks")
+        assert catalog.status_code == 200, catalog.text
+        assert "<title>Runbooks" in catalog.text
+        assert "drain-node" in catalog.text
+        assert "rotate-cert" in catalog.text
+        assert "draft" in catalog.text  # status badge
+        # The sidebar link is part of the full-page chrome.
+        assert 'href="/ui/runbooks"' in catalog.text
+
+        # --- 2. Operator filters: target_kind narrows the catalog. ---------
+        filtered = op_client.get("/ui/runbooks/list", params={"target_kind": "k8s-node"})
+        assert filtered.status_code == 200, filtered.text
+        assert "drain-node" in filtered.text  # target_kind=k8s-node
+        assert "rotate-cert" not in filtered.text  # target_kind=vmware-vcenter
+
+        status_filtered = op_client.get("/ui/runbooks/list", params={"status": "draft"})
+        assert status_filtered.status_code == 200, status_filtered.text
+        assert "drain-node" in status_filtered.text
+        # An out-of-vocab status is a clean 422 at the query boundary.
+        assert op_client.get("/ui/runbooks/list", params={"status": "bogus"}).status_code == 422
+
+        # --- 3. Operator opacity floor: restricted detail, NOT a raw 403. --
+        restricted = op_client.get("/ui/runbooks/drain-node")
+        assert restricted.status_code == 200, restricted.text
+        assert "Step details are restricted" in restricted.text
+        assert "drain-node" in restricted.text  # summary still renders
+        assert "Node drained?" not in restricted.text  # step internals withheld
+
+        # --- 4. Admin authors a brand-new draft via the editor POST. -------
+        admin_client = _authenticated_client(admin_session)
+        author = admin_client.post(
+            "/ui/runbooks/new",
+            data={
+                "slug": "cordon-host",
+                "title": "Cordon host",
+                "description": "Cordon and drain a host.",
+                "target_kind": "k8s-node",
+                "steps": _authored_steps_json(),
+            },
+            **_csrf_kwargs(admin_session),
+        )
+        assert author.status_code == 204, author.text
+        assert author.headers.get("HX-Redirect") == "/ui/runbooks/cordon-host"
+        authored_version = _status_version("cordon-host")
+        assert _status("cordon-host", authored_version) == "draft"
+
+        # --- 5. Lifecycle round-trip: publish -> deprecate, observable. ----
+        publish = admin_client.post(
+            "/ui/runbooks/cordon-host/publish",
+            data={"version": str(authored_version)},
+            **_csrf_kwargs(admin_session),
+        )
+        assert publish.status_code == 200, publish.text
+        assert "published" in publish.text
+        assert "Deprecate" in publish.text  # next valid action surfaces
+        assert _status("cordon-host", authored_version) == "published"
+
+        deprecate = admin_client.post(
+            "/ui/runbooks/cordon-host/deprecate",
+            data={"version": str(authored_version)},
+            **_csrf_kwargs(admin_session),
+        )
+        assert deprecate.status_code == 200, deprecate.text
+        assert "deprecated" in deprecate.text
+        assert _status("cordon-host", authored_version) == "deprecated"
+
+        # The transition is observable through the read surface: an admin
+        # detail render shows the deprecated badge.
+        admin_detail = admin_client.get("/ui/runbooks/cordon-host")
+        assert admin_detail.status_code == 200, admin_detail.text
+        assert "deprecated" in admin_detail.text
+    finally:
+        admin_mock.stop()
+
+    # The role lift caches the JWKS it fetched for the admin token; the
+    # operator token below is signed by a different keypair, so the stale
+    # admin JWKS would 401 (signature mismatch) instead of reaching the
+    # role-rank 403. Clear the cache so the operator token verifies against
+    # its own JWKS and the gate fails at the *role* check (the boundary under
+    # test), not the signature check.
+    clear_jwks_cache()
+
+    # --- 6. Operator write-boundary: author/publish/deprecate all 403. -----
+    operator_mock = respx.mock(assert_all_called=False)
+    operator_mock.start()
+    try:
+        _mock_discovery_and_jwks(operator_mock, operator_jwks)
+        op_client = _authenticated_client(operator_session)
+
+        author_forbidden = op_client.post(
+            "/ui/runbooks/new",
+            data={
+                "slug": "operator-attempt",
+                "title": "Nope",
+                "description": "",
+                "target_kind": "",
+                "steps": _authored_steps_json(),
+            },
+            **_csrf_kwargs(operator_session),
+        )
+        assert author_forbidden.status_code == 403, author_forbidden.text
+
+        publish_forbidden = op_client.post(
+            "/ui/runbooks/drain-node/publish",
+            data={"version": "1"},
+            **_csrf_kwargs(operator_session),
+        )
+        assert publish_forbidden.status_code == 403, publish_forbidden.text
+        # The forged publish did not fire — drain-node is still a draft.
+        assert _status("drain-node", 1) == "draft"
+
+        deprecate_forbidden = op_client.post(
+            "/ui/runbooks/drain-node/deprecate",
+            data={"version": "1"},
+            **_csrf_kwargs(operator_session),
+        )
+        assert deprecate_forbidden.status_code == 403, deprecate_forbidden.text
+
+        # The operator author attempt never persisted a row.
+        assert not _slug_exists("operator-attempt")
+    finally:
+        operator_mock.stop()
+
+    # --- 7. Discoverability: dashboard tile + sidebar link render. ---------
+    with respx.mock(assert_all_called=False):
+        dash_client = _authenticated_client(operator_soft_session)
+        dashboard = dash_client.get("/ui/")
+    assert dashboard.status_code == 200, dashboard.text
+    assert 'href="/ui/runbooks"' in dashboard.text  # tile + sidebar both link
+    assert "Runbooks" in dashboard.text
+
+
+def test_runbooks_post_completion_operator_sees_full_steps() -> None:
+    """An operator who completed a run crosses the opacity floor (full steps).
+
+    The complement to the restricted branch in the end-to-end flow: the same
+    operator, given a ``completed`` run against ``(slug, version)``, now sees
+    the full step internals -- confirming the floor is a gate, not a wall.
+    """
+    _seed_tenant(_TENANT_A, "tenant-a")
+    version = _seed_template(tenant_id=_TENANT_A, slug="drain-node", body=_manual_body())
+    _seed_run(
+        tenant_id=_TENANT_A,
+        slug="drain-node",
+        version=version,
+        assigned_to=_OPERATOR_SUB,
+        state="completed",
+    )
+
+    operator_soft_session = _seed_session_sync(tenant_id=_TENANT_A)
+    with respx.mock(assert_all_called=False):
+        client = _authenticated_client(operator_soft_session)
+        detail = client.get("/ui/runbooks/drain-node")
+
+    assert detail.status_code == 200, detail.text
+    assert "Step details are restricted" not in detail.text
+    assert "Drain the node" in detail.text
+    assert "Node drained?" in detail.text
+
+
+# ---------------------------------------------------------------------------
+# Persistence read-back helpers (used by the end-to-end assertions)
+# ---------------------------------------------------------------------------
+
+
+def _status_version(slug: str) -> int:
+    """Return the latest version number for *slug* (for lifecycle targeting)."""
+
+    async def _do() -> int:
+        tpl = await RunbookTemplateService().show_template(_TENANT_A, slug)
+        return tpl.version
+
+    return asyncio.run(_do())
+
+
+def _slug_exists(slug: str) -> bool:
+    """Return whether *slug* resolves to any version for tenant A."""
+    from meho_backplane.runbooks.service import TemplateNotFoundError
+
+    async def _do() -> bool:
+        try:
+            await RunbookTemplateService().show_template(_TENANT_A, slug)
+        except TemplateNotFoundError:
+            return False
+        return True
+
+    return asyncio.run(_do())

--- a/docs/codebase/ui.md
+++ b/docs/codebase/ui.md
@@ -1924,4 +1924,128 @@ a 500.
 * `backend/src/meho_backplane/ui/templates/connectors/import.html` — full-page paste-box + upload form.
 * `backend/src/meho_backplane/ui/templates/connectors/_import_preview.html` — preview table fragment (CREATE/UPDATE badges + per-entry warnings + confirm form, or an inline parse error).
 * `backend/src/meho_backplane/ui/templates/connectors/_import_result.html` — result summary fragment (N created, M updated).
+
+## Runbooks surface (G10.6)
+
+Initiative [#1381](https://github.com/evoila/meho/issues/1381) (G10.6
+Runbooks UI). The console surface over the G12.2 runbook template layer —
+the catalog, the opacity-floor-aware detail view, the `tenant_admin`
+authoring editor, and the publish / deprecate lifecycle controls.
+Landed across three tasks: T1 (#1382) the read surface, T2 (#1383) the
+authoring editor, T3 (#1384) the lifecycle controls. The surface consumes
+the REST runbook-template layer (`/api/v1/runbooks/templates/*`,
+`backend/src/meho_backplane/api/v1/runbook_templates.py`) through the same
+`RunbookTemplateService` the REST routes and the `meho runbook` CLI use —
+no parallel data path. The runbooks stub registered in the T5 #866
+chassis is retired by this surface the same way broadcast / topology /
+memory / connectors retired theirs (the real router is mounted ahead of
+the stubs aggregate, first-match-wins).
+
+### Routes
+
+| Method | Path | Auth | Purpose |
+| ------ | ---- | ---- | ------- |
+| `GET` | `/ui/runbooks` | `require_ui_session` | Catalog page. Lists the latest version of each template slug for the operator's tenant (slug / version / title / status / target_kind / edited_at) as DaisyUI rows with status badges. `HX-Request: true` returns only the `runbooks/_list.html` fragment; a direct navigation returns the full page. |
+| `GET` | `/ui/runbooks/list` | `require_ui_session` | HTMX filter partial. Same projection as the catalog, parameterised by the `status` (`draft` / `published` / `deprecated`, a closed `Literal`) and `target_kind` query params the filter controls carry. An out-of-vocab `status` trips a clean 422 at the query boundary. Registered **before** `/ui/runbooks/{slug}` so the literal `list` segment is not swallowed as a slug. |
+| `GET` | `/ui/runbooks/{slug}` | `require_ui_session` | Template detail. Renders title / description / target_kind / status + the ordered steps (`manual` vs `operation_call`, op_id / params) and verify gates (`confirm` prompt vs `operation_call` op_id / params / expect). Step bodies are server-rendered Markdown via the shared KB renderer. Opacity-floor-gated (see below). `?version=<n>` pins a specific version. |
+| `GET` | `/ui/runbooks/new` | `require_ui_admin` | (T2 #1383) Blank-draft editor page. |
+| `POST` | `/ui/runbooks/new` | `require_ui_admin` | (T2 #1383) Create a draft from the editor form (mirrors REST `POST /api/v1/runbooks/templates`). Success → 204 + `HX-Redirect: /ui/runbooks/<slug>`; a duplicate slug / invalid body re-renders the editor inline (422) preserving entered data. |
+| `POST` | `/ui/runbooks/preview` | `require_ui_admin` | (T2 #1383) HTMX Markdown live-preview partial for one step's `body` (max 64 KiB), rendered via the shared KB renderer. |
+| `GET` | `/ui/runbooks/{slug}/edit` | `require_ui_admin` | (T2 #1383) Editor pre-loaded with the template's latest version. Missing / cross-tenant slug → 404. |
+| `POST` | `/ui/runbooks/{slug}/edit` | `require_ui_admin` | (T2 #1383) Edit-in-place (draft) / fork-on-edit (published → new draft), mirroring REST `PATCH`. The detail page surfaces how many runs are still pinned to the source version (the fork leaves them bound) via `count_in_flight_runs`. |
+| `POST` | `/ui/runbooks/{slug}/publish` | `require_ui_admin` | (T3 #1384) Promote `(slug, version)` draft → published (mirrors REST publish: 200 idempotent / 400 not-draft / 404). The body carries the integer `version` (the slug is the URL's job) so a stale catalog row acts on the version it was rendered against, not the latest. |
+| `POST` | `/ui/runbooks/{slug}/deprecate` | `require_ui_admin` | (T3 #1384) Retire `(slug, version)` published → deprecated (200 idempotent / 400 not-published / 404). Same version-in-body posture as publish. |
+
+**Route ordering.** The literal `list` / `new` / `preview` / `publish` /
+`deprecate` segments are registered **before** `/ui/runbooks/{slug}` in
+`build_runbooks_router()` so FastAPI's first-match-wins routing does not
+bind them to the slug path parameter.
+
+### Module layout
+
+* `backend/src/meho_backplane/ui/routes/runbooks/__init__.py` — exports the `build_runbooks_router` factory the umbrella `build_router()` mounts.
+* `backend/src/meho_backplane/ui/routes/runbooks/routes.py` — the read surface (T1). The catalog + filter-fragment + opacity-floor detail handlers, the `_resolve_role` / `_is_admin` role-lift helpers, and the factory itself (which calls `register_editor_routes` + `register_lifecycle_routes` before the `{slug}` catch-all).
+* `backend/src/meho_backplane/ui/routes/runbooks/editor.py` — the authoring form (de)serialisation + service calls (T2): `build_editor_context`, `handle_editor_submit`, `template_to_form_steps`, the CSRF cookie helper.
+* `backend/src/meho_backplane/ui/routes/runbooks/editor_routes.py` — thin FastAPI wiring for the T2 editor routes (`require_ui_admin`-gated). Split from `editor.py` so neither file crosses the code-quality size gate.
+* `backend/src/meho_backplane/ui/routes/runbooks/lifecycle.py` — the T3 publish / deprecate handler bodies + route wiring (`require_ui_admin`-gated). Maps the typed service errors (`TemplateNotDraftError` / `TemplateNotPublishedError`) to inline DaisyUI alerts, a missing version to 404, and a tampered `version` field to 422.
+* `backend/src/meho_backplane/ui/templates/runbooks/` — `index.html` (catalog page), `_list.html` (filter fragment), `detail.html` + `_detail_actions.html` (detail page + lifecycle action row), `editor.html` + `_step_fields.html` + `_editor_preview.html` (authoring editor), `_row_alert.html` (catalog row-action alert slot).
+
+### RBAC gating (`require_ui_session` vs `require_ui_admin`)
+
+The read routes gate on `require_ui_session` (any authenticated operator)
+— `UISessionContext` carries `operator_sub` + `tenant_id` only, so it
+omits the tenant role to keep read paths free of a JWT-decode round-trip.
+The write routes (author / edit / preview / publish / deprecate) chain
+`require_ui_admin`, which loads the `DecryptedSession`, re-verifies the
+session's access token via `verify_jwt_for_audience`, and raises HTTP 403
+(`detail="tenant_admin_required"`) for `operator` / `read_only`. The
+server is the single source of truth for the authoring privilege: the
+client-side controls are hidden for non-admins optimistically, but a
+forged POST still hits the 403 at the dependency before the handler body
+runs. A forged POST missing the double-submit CSRF token is blocked
+earlier still, by `CSRFMiddleware` (403 at the CSRF gate).
+
+The detail render needs the admin-vs-operator distinction the opacity
+floor turns on, even though its route only requires a session. It
+resolves it via `_resolve_role` — the same access-token re-verification
+`require_ui_admin` performs, but **fails soft**: any hiccup (the session
+row vanished mid-request, JWKS transiently unreachable, a token/session
+identity mismatch) returns `None`, and the caller treats the request as a
+plain operator. The restricted-detail render is the safe default; an
+unavailable role lift never 5xx-es the read surface. This mirrors
+`connectors.operator.resolve_role_probe`.
+
+### Opacity floor (restricted detail, not a raw 403)
+
+The G12.3-T4 (#1309) carve-out the REST `show` route enforces is mirrored
+on the console. A `tenant_admin` always sees the full steps. An
+`operator` sees the full steps only when they have a `completed` or
+`abandoned` run against the resolved `(slug, version)` — the
+`RunbookRunService.can_show_template_post_completion` predicate. An
+operator with no such run (or only an in-flight run) is **not** shown a
+raw 403: the detail view renders the catalog-level summary (title /
+description / target_kind / status / step count) plus a clear "step
+details are restricted until you complete a run of this template" notice,
+withholding the step internals. This matches the REST surface's
+`403 detail="opacity_floor"` posture while keeping the console a navigable
+page rather than an error.
+
+A missing / cross-tenant slug collapses to that same restricted page for
+an operator (anti-enumeration — existence never leaks via a status-code
+differential), and to a 404 for an admin. The restricted placeholder
+carries only the slug the operator typed and epoch-sentinel timestamps —
+no real template metadata leaks.
+
+### Lifecycle fragment + HTMX wiring
+
+Each publish / deprecate action posts via HTMX. On the **detail** page it
+targets `#runbook-lifecycle` and swaps the re-rendered
+`runbooks/_detail_actions.html` fragment — which carries the action row
+valid for the new state, an `hx-swap-oob` copy of the status badge (so the
+header badge flips without a full-page reload), and an inline alert region
+(a typed 400 renders as `alert-error`; an idempotent re-action just
+refreshes the badge). On the **catalog** row the action targets a per-row
+`#runbook-row-alert-…` slot and gets the minimal `_row_alert.html`
+fragment instead (the detail-shaped action row + OOB badge would be
+nonsense swapped into a list row); the handler branches on the
+`HX-Target` header. The CSRF cookie is re-minted + refreshed on every
+fragment render so the next action carries a token whose cookie still
+matches — a missing refresh would 403 the second interaction at the
+double-submit check.
+
+### Cross-tenant isolation
+
+Every handler derives tenant identity from `UISessionContext`; no query
+parameter or form field overrides it. The `RunbookTemplateService` tenant
+filter makes another tenant's row invisible, so a cross-tenant slug probe
+surfaces as the restricted state (operator) or a 404 (admin / lifecycle /
+editor) — the same anti-enumeration posture the `/api/v1/runbooks/templates`
+surface uses.
+
+### Tests
+
+* `backend/tests/test_ui_runbooks_list.py` — the T1 read surface: auth boundary, catalog render + status badges, empty state, HTMX fragment branch, `status` / `target_kind` filters, the 422 on an out-of-vocab status, admin full-step detail (both step + verify kinds, Markdown-rendered), the opacity-floor branches (no run / in-progress run → restricted; completed run → full steps; missing slug → restricted for operator, 404 for admin), cross-tenant isolation, dashboard tile + sidebar link.
+* `backend/tests/test_ui_runbooks_editor.py` — the T2 authoring editor: admin renders (new / edit), operator 403, draft create round-trip (both step + verify kinds), server-side validation re-renders (duplicate slug, bad step id, disallowed substitution) preserving entered data, fork-on-edit from published, in-place edit of a draft, the Markdown live-preview (admin-only).
+* `backend/tests/test_ui_runbooks_lifecycle.py` — the T3 lifecycle controls: admin publish / deprecate flips status + swaps the OOB badge, operator forged POST → 403, missing-CSRF → 403, the typed-400 inline alerts (publishing a non-draft, deprecating a non-published version), idempotent re-actions, the catalog-row vs detail-page fragment branch, version-in-body targeting.
+* `backend/tests/test_ui_runbooks_acceptance.py` — the **cross-cutting** end-to-end acceptance (T4 #1385): one test exercises the surface as a whole against a single app instance — operator browse (catalog + filters) → operator opacity-floor restricted-detail (not a raw 403) → `tenant_admin` author (draft) → publish → deprecate round-trip with status transitions read back through the read surface → operator blocked (403) from author / publish / deprecate → sidebar link + dashboard tile render. A companion test pins the post-completion operator crossing the floor (completed run → full steps).
 * `backend/tests/test_ui_connectors_import.py` — `build_plan` mapping / classification unit tests (extras spill, explicit-extras merge, fingerprint drop, sparse UPDATE) + behavioural tests: auth / RBAC (403 operator, 403 missing CSRF), preview (paste + upload + parse error + missing-field error + schema-invalid-value inline error), confirm (in-process create + update, sparse PATCH preserves omitted columns, malformed-YAML no-write, schema-invalid entry 422 + zero writes), cross-tenant isolation (import lands in caller tenant only; same-name in another tenant does not flip CREATE→UPDATE).


### PR DESCRIPTION
## Summary
- Close out the **G10.6 Runbooks UI** initiative (#1381): document the surface and pin it with one cross-cutting end-to-end acceptance test. Docs-and-tests only — no runbooks-surface behaviour changed (all shipped in T1 #1382 / T2 #1383 / T3 #1384).
- `docs/codebase/ui.md` gains a **"Runbooks surface (G10.6)"** section matching the depth of the existing per-surface sections (broadcast / kb / connectors / memory / topology): route table (read + author + lifecycle), module layout, `require_ui_session` (read) vs `require_ui_admin` (author/lifecycle) gating, the opacity-floor restricted-detail behaviour, the lifecycle HTMX fragment / OOB-badge wiring, cross-tenant isolation, and the test inventory. Grounded in the merged code under `backend/src/meho_backplane/ui/routes/runbooks/`, not guessed.
- `backend/tests/test_ui_runbooks_acceptance.py` asserts the surface **as a whole** in one flow, complementing the per-route T1–T3 unit suites.
- Goal #336's Execution-Initiatives `#1381` line flipped to `- [x]` (surface complete).

## Test plan
- [x] `ruff check` / `ruff format --check` (new test) — clean
- [x] `mypy` (CI-scoped to `src/`) — `Success: no issues found in 401 source files`
- [x] `pytest tests/test_ui_runbooks_acceptance.py` — 2 passed
- [x] Full runbooks UI suite `tests/test_ui_runbooks_{acceptance,list,editor,lifecycle}.py` — 52 passed
- [x] Acceptance criteria verified by the end-to-end test: catalog lists templates with badges + working `status`/`target_kind` filters; operator without a completed run gets the restricted-detail state (200, not a raw 403); `tenant_admin` author→publish→deprecate round-trip with observable status transitions read back through the read surface; `operator` blocked (403) from author/publish/deprecate; sidebar link + dashboard tile render.
- [x] OpenAPI snapshot unchanged — `cd cli && make snapshot-openapi` yields no diff (no routes/schemas touched).

## Out of scope
- New runbooks-surface behaviour (all in T1–T3); run-execution UI; cross-version history.

<!-- auto-implement-issue: fresh, iteration 1 -->

Closes #1385
