### PR TITLE
feat(approvals): G11.7-T1 queue humans + self-approval guard + resume-target fix + write-op redaction

### DIFF
--- a/backend/src/meho_backplane/api/v1/approvals.py
+++ b/backend/src/meho_backplane/api/v1/approvals.py
@@ -64,6 +64,7 @@ from meho_backplane.auth.operator import Operator, TenantRole
 from meho_backplane.auth.rbac import require_role
 from meho_backplane.db.engine import get_sessionmaker
 from meho_backplane.db.models import ApprovalRequest, ApprovalRequestStatus
+from meho_backplane.operations._errors import result_denied
 from meho_backplane.operations.approval_queue import (
     ApprovalNotFoundError,
     ApprovalRequestAlreadyDecidedError,
@@ -203,10 +204,21 @@ async def _resume_dispatch_after_approval(
     ``target.name`` / ``target.fqdn`` would mis-resolve (or crash) if
     re-dispatched with ``target=None``. This loads the live ``Target`` by
     id (tenant-scoped, ``deleted_at IS NULL``) to restore the original
-    dispatch target. A target soft-deleted between request and approval
-    resolves to ``None``, so the re-dispatch fails closed (structured
-    connector error) rather than reviving a tombstone. Tenant-wide ops
-    (no original target) keep ``target_id IS NULL`` → ``None``.
+    dispatch target.
+
+    A target soft-deleted (or otherwise revoked) between request and
+    approval resolves to ``None``. In that case the re-dispatch **fails
+    closed**: it returns a structured ``denied`` :class:`OperationResult`
+    and never calls :func:`dispatch`. Dispatching with ``target=None``
+    would let a typed handler that derives its connection from
+    ``connector_id`` / ``params`` execute an approved privileged write
+    *outside* the original target scope — the approval authorized a call
+    against a specific target, not "whatever the connector defaults to".
+
+    Tenant-wide ops (no original target) keep ``target_id IS NULL`` →
+    ``None`` and dispatch normally; the fail-closed branch fires only when
+    a concrete ``target_id`` was pinned at request time but no longer
+    resolves.
 
     The re-dispatch bypasses the policy gate (``_approved=True``): the
     committed approval decision is the authorization. Without the bypass
@@ -221,6 +233,33 @@ async def _resume_dispatch_after_approval(
         async with sessionmaker() as session:
             resolved_target = await resolve_target_by_id(
                 session, operator.tenant_id, request.target_id
+            )
+        if resolved_target is None:
+            # Fail closed: the approval row pinned a concrete target_id, but
+            # no live target resolves it now (soft-deleted between request
+            # and approval, or cross-tenant). Dispatching with target=None
+            # would let a typed handler that derives its connection from
+            # connector_id/params execute an approved privileged write
+            # *outside* the original target scope. Refuse instead — the
+            # approval authorized a call against a target that no longer
+            # exists.
+            _log.warning(
+                "approval_resume_target_unresolvable",
+                approval_request_id=str(request.id),
+                op_id=request.op_id,
+                connector_id=request.connector_id,
+                target_id=str(request.target_id),
+                operator_sub=operator.sub,
+            )
+            return result_denied(
+                request.op_id,
+                (
+                    f"approved target {request.target_id} no longer resolves "
+                    "(soft-deleted or revoked between request and approval); "
+                    "re-dispatch refused to avoid executing outside the "
+                    "original target scope"
+                ),
+                0.0,
             )
 
     from meho_backplane.operations.dispatcher import dispatch

--- a/backend/src/meho_backplane/api/v1/approvals.py
+++ b/backend/src/meho_backplane/api/v1/approvals.py
@@ -68,12 +68,14 @@ from meho_backplane.operations.approval_queue import (
     ApprovalNotFoundError,
     ApprovalRequestAlreadyDecidedError,
     ParamsMismatchError,
+    SelfApprovalForbiddenError,
     UnauthorizedApprovalError,
     approve_request,
     get_request,
     publish_approval_event,
     reject_request,
 )
+from meho_backplane.targets.resolver import resolve_target_by_id
 
 __all__ = ["router"]
 
@@ -188,6 +190,51 @@ def _view(row: ApprovalRequest) -> ApprovalRequestView:
     )
 
 
+async def _resume_dispatch_after_approval(
+    *,
+    operator: Operator,
+    request: ApprovalRequest,
+    params: dict[str, Any],
+) -> Any:
+    """Re-hydrate the stored target and re-dispatch an approved op (G11.7-T1).
+
+    The approval row persists only ``target_id``, not the full target
+    object; a write op whose handler reads ``target.host`` /
+    ``target.name`` / ``target.fqdn`` would mis-resolve (or crash) if
+    re-dispatched with ``target=None``. This loads the live ``Target`` by
+    id (tenant-scoped, ``deleted_at IS NULL``) to restore the original
+    dispatch target. A target soft-deleted between request and approval
+    resolves to ``None``, so the re-dispatch fails closed (structured
+    connector error) rather than reviving a tombstone. Tenant-wide ops
+    (no original target) keep ``target_id IS NULL`` → ``None``.
+
+    The re-dispatch bypasses the policy gate (``_approved=True``): the
+    committed approval decision is the authorization. Without the bypass
+    the re-dispatch would re-queue (a human/service principal now routes
+    ``requires_approval`` to ``needs-approval`` per G11.7-T1; an agent
+    re-hits ``needs-approval``), so the approved op would never execute
+    (#817 DoD: "approval runs the original dispatch").
+    """
+    resolved_target: Any = None
+    if request.target_id is not None:
+        sessionmaker = get_sessionmaker()
+        async with sessionmaker() as session:
+            resolved_target = await resolve_target_by_id(
+                session, operator.tenant_id, request.target_id
+            )
+
+    from meho_backplane.operations.dispatcher import dispatch
+
+    return await dispatch(
+        operator=operator,
+        connector_id=request.connector_id,
+        op_id=request.op_id,
+        target=resolved_target,
+        params=params,
+        _approved=True,
+    )
+
+
 # ---------------------------------------------------------------------------
 # Routes
 # ---------------------------------------------------------------------------
@@ -283,7 +330,8 @@ async def approve_approval_request(
     HTTP status codes:
 
     * 200 — approved + re-dispatched successfully.
-    * 403 — operator lacks ``operator`` role.
+    * 403 — operator lacks ``operator`` role, **or** the approver is the
+      requester and self-approval break-glass is disabled (G11.7-T1 #1401).
     * 404 — request not found (or belongs to another tenant).
     * 409 — request is already decided.
     * 422 — params hash mismatch.
@@ -322,6 +370,11 @@ async def approve_approval_request(
             status_code=http_status.HTTP_403_FORBIDDEN,
             detail="insufficient_role",
         ) from exc
+    except SelfApprovalForbiddenError as exc:
+        raise HTTPException(
+            status_code=http_status.HTTP_403_FORBIDDEN,
+            detail="self_approval_forbidden",
+        ) from exc
     except ApprovalRequestAlreadyDecidedError as exc:
         raise HTTPException(
             status_code=http_status.HTTP_409_CONFLICT,
@@ -333,21 +386,8 @@ async def approve_approval_request(
             detail="params_hash_mismatch",
         ) from exc
 
-    # Re-dispatch the original op with the approved params, bypassing the
-    # policy gate (``_approved=True``): the human approval recorded above is
-    # the authorization. Without the bypass the re-dispatch would be
-    # hard-denied (the reviewer is a human, denied on requires_approval) or
-    # re-queued (an agent re-hits needs-approval), so the approved op would
-    # never execute (#817 DoD: "approval runs the original dispatch").
-    from meho_backplane.operations.dispatcher import dispatch
-
-    dispatch_result = await dispatch(
-        operator=operator,
-        connector_id=request.connector_id,
-        op_id=request.op_id,
-        target=None,  # target resolved from connector_id; target_id in params if needed
-        params=body.params,
-        _approved=True,
+    dispatch_result = await _resume_dispatch_after_approval(
+        operator=operator, request=request, params=body.params
     )
 
     _log.info(
@@ -533,6 +573,11 @@ async def decide_approval_request(
         raise HTTPException(
             status_code=http_status.HTTP_403_FORBIDDEN,
             detail="insufficient_role",
+        ) from exc
+    except SelfApprovalForbiddenError as exc:
+        raise HTTPException(
+            status_code=http_status.HTTP_403_FORBIDDEN,
+            detail="self_approval_forbidden",
         ) from exc
     except ApprovalRequestAlreadyDecidedError as exc:
         raise HTTPException(

--- a/backend/src/meho_backplane/broadcast/events.py
+++ b/backend/src/meho_backplane/broadcast/events.py
@@ -91,6 +91,41 @@ _CREDENTIAL_READ_OPS: Final[frozenset[str]] = frozenset(
 _CREDENTIAL_MINT_OPS: Final[frozenset[str]] = frozenset(
     {
         "harbor.robot.create",
+        # G11.7-T1 #1401 — Vault auth ops whose *response* carries a
+        # freshly-minted secret. ``vault.token.create`` returns a client
+        # token; ``vault.auth.approle.generate_secret_id`` returns a
+        # SecretID. Both must collapse to aggregate-only so the minted
+        # credential never reaches the SSE stream or a Slack mirror. The
+        # ``OperationResult`` returned to the caller still carries it.
+        "vault.token.create",
+        "vault.auth.approle.generate_secret_id",
+    }
+)
+
+#: Op-ids that classify as ``credential_write`` (G11.7-T1 #1401). Unlike
+#: :data:`_CREDENTIAL_MINT_OPS` (secret in the *response*), these ops
+#: carry the secret in their *request params* — the broadcast publisher
+#: ships ``params`` (request-side), so a plain ``write`` classification
+#: would leak the written credential to every operator on the feed.
+#: Collapsing them to aggregate-only keeps the team-coordination signal
+#: ("someone wrote a credential at 14:23") without the secret material.
+#: The explicit allowlist comes before the ``.write`` / ``.create`` /
+#: ``.update`` suffix branch so these win over the plain ``write`` class.
+#:
+#: * ``vault.auth.userpass.write`` / ``vault.auth.userpass.update_password``
+#:   — the userpass password is in ``params``.
+#: * ``vault.kv.put`` — the KV-v2 secret ``data`` is in ``params`` (this
+#:   op shipped pre-G11.7 classified as plain ``write``, which broadcast
+#:   the written secret in full; reclassifying it here closes that latent
+#:   leak — see ``docs/codebase/connectors-vault.md``).
+#: * ``k8s.secret.create`` — the Secret ``data`` / ``stringData`` is in
+#:   ``params``.
+_CREDENTIAL_WRITE_OPS: Final[frozenset[str]] = frozenset(
+    {
+        "vault.auth.userpass.write",
+        "vault.auth.userpass.update_password",
+        "vault.kv.put",
+        "k8s.secret.create",
     }
 )
 
@@ -212,8 +247,8 @@ class BroadcastEvent(BaseModel):
     target_name: str | None = None
     op_id: str
     #: One of ``"read"`` / ``"write"`` / ``"credential_read"`` /
-    #: ``"credential_mint"`` / ``"audit_query"`` / ``"other"``.
-    #: Derived from :func:`classify_op` at publish time.
+    #: ``"credential_mint"`` / ``"credential_write"`` / ``"audit_query"``
+    #: / ``"other"``. Derived from :func:`classify_op` at publish time.
     op_class: str
     #: One of ``"ok"`` / ``"error"`` / ``"denied"``. The handler
     #: produces it; the broadcast publisher does not re-classify.
@@ -224,8 +259,9 @@ class BroadcastEvent(BaseModel):
     #: queries audit_log by this id.
     audit_id: UUID
     #: Redacted view per :func:`redact_payload`. NEVER raw params for
-    #: ``credential_read``, ``credential_mint``, or ``audit_query`` classes —
-    #: the redaction contract is upstream of this field.
+    #: ``credential_read``, ``credential_mint``, ``credential_write``, or
+    #: ``audit_query`` classes — the redaction contract is upstream of
+    #: this field.
     payload: dict[str, Any] = Field(default_factory=dict)
 
 
@@ -241,9 +277,17 @@ def classify_op(op_id: str) -> str:
        check.
     2. ``credential_mint`` — explicit allowlist for ops that return a
        freshly-minted secret in their response payload (e.g.
-       ``harbor.robot.create``). Checked before the ``.create`` suffix
-       so the allowlist wins over the mutation-suffix branch.
-    3. ``audit_query`` — every op-id with the ``audit.`` or
+       ``harbor.robot.create``, ``vault.token.create``). Checked before
+       the ``.create`` suffix so the allowlist wins over the
+       mutation-suffix branch.
+    3. ``credential_write`` — explicit allowlist for write ops whose
+       *request params* carry a secret (e.g.
+       ``vault.auth.userpass.write``, ``vault.kv.put``,
+       ``k8s.secret.create``). Checked before the write-suffix branch
+       so the secret-bearing params collapse to aggregate-only instead
+       of broadcasting in full under the plain ``write`` class
+       (G11.7-T1 #1401).
+    4. ``audit_query`` — every op-id with the ``audit.`` or
        ``meho.audit.`` prefix classifies as audit_query regardless of
        the verb suffix. The ``meho.audit.`` arm catches the admin
        replay meta-tool (``meho.audit.replay``, G8.2-T6 #1014): the
@@ -251,16 +295,16 @@ def classify_op(op_id: str) -> str:
        the tool name verbatim, so without this arm the replay tool
        would fall through to ``other`` and broadcast its full
        ``ReplayNode`` payload instead of the aggregate-only view.
-    4. ``read`` / ``write`` — HTTP-method-prefixed ingested op IDs
+    5. ``read`` / ``write`` — HTTP-method-prefixed ingested op IDs
        (e.g. ``GET:/api/v2.0/systeminfo``). ``GET:`` and ``HEAD:``
        map to ``read``; ``POST:``, ``PUT:``, ``PATCH:``, ``DELETE:``
        map to ``write``. Checked before the dot-suffix branches since
        ingested ops carry no meho verb suffix.
-    5. ``write`` — mutation suffixes (``.create`` / ``.update`` /
+    6. ``write`` — mutation suffixes (``.create`` / ``.update`` /
        ``.delete`` / ``.patch``).
-    6. ``read`` — non-mutating verb suffixes (``.list`` / ``.info`` /
+    7. ``read`` — non-mutating verb suffixes (``.list`` / ``.info`` /
        ``.get`` / ``.about`` / ``.ls``).
-    7. ``other`` — everything else. Falls through to full-detail
+    8. ``other`` — everything else. Falls through to full-detail
        broadcast per decision #3.
 
     Examples
@@ -270,6 +314,12 @@ def classify_op(op_id: str) -> str:
     'credential_read'
     >>> classify_op("harbor.robot.create")
     'credential_mint'
+    >>> classify_op("vault.token.create")
+    'credential_mint'
+    >>> classify_op("vault.auth.userpass.write")
+    'credential_write'
+    >>> classify_op("vault.kv.put")
+    'credential_write'
     >>> classify_op("audit.query")
     'audit_query'
     >>> classify_op("meho.audit.replay")
@@ -289,6 +339,8 @@ def classify_op(op_id: str) -> str:
         return "credential_read"
     if op_id in _CREDENTIAL_MINT_OPS:
         return "credential_mint"
+    if op_id in _CREDENTIAL_WRITE_OPS:
+        return "credential_write"
     if op_id.startswith(("audit.", "meho.audit.")):
         return "audit_query"
     # Ingested ops use HTTP-method prefixes (e.g. "GET:/api/v2.0/systeminfo").
@@ -361,7 +413,8 @@ def redact_payload(
     pre-G6.3 default), the function falls back to decision #3 of
     ``docs/planning/v0.2-decisions.md`` -- aggregate for sensitive
     classes (``credential_read`` / ``credential_mint`` /
-    ``audit_query``), full for everything else. When ``"aggregate"`` or ``"full"`` is passed
+    ``credential_write`` / ``audit_query``), full for everything else.
+    When ``"aggregate"`` or ``"full"`` is passed
     explicitly, the resolver (:func:`compute_effective_broadcast_detail`)
     has already decided the effective detail and this function just
     renders it. Callers that don't go through the resolver
@@ -377,7 +430,7 @@ def redact_payload(
     if detail is None:
         effective_detail: Literal["full", "aggregate"] = (
             "aggregate"
-            if op_class in {"credential_read", "credential_mint", "audit_query"}
+            if op_class in {"credential_read", "credential_mint", "credential_write", "audit_query"}
             else "full"
         )
     else:

--- a/backend/src/meho_backplane/broadcast/overrides.py
+++ b/backend/src/meho_backplane/broadcast/overrides.py
@@ -108,8 +108,33 @@ _TENANT_CACHE: dict[UUID, tuple[list[BroadcastOverride], float]] = {}
 #: ``docs/planning/v0.2-decisions.md``. The resolver consults this set
 #: rather than re-importing the classifier's internal vocabulary, so a
 #: future change to :func:`classify_op`'s output taxonomy lands in one
-#: place.
-_SENSITIVE_OP_CLASSES: Final[frozenset[str]] = frozenset({"credential_read", "audit_query"})
+#: place. MUST stay in lockstep with the aggregate-by-default set in
+#: :func:`meho_backplane.broadcast.events.redact_payload` — both encode
+#: decision #3.
+#:
+#: Two tiers of sensitivity, differing on whether a per-call
+#: request-override may upgrade them to ``full``:
+#:
+#: * ``credential_read`` / ``audit_query`` — aggregate by default but an
+#:   operator may opt into full detail on their own feed (G6.3 #379): the
+#:   "secret" is a path string or an audit filter the requesting operator
+#:   already has the right to see.
+#: * ``credential_mint`` (G3.5-T9 #621) / ``credential_write``
+#:   (G11.7-T1 #1401) — aggregate by default AND non-upgradeable: the
+#:   payload is freshly-minted (response) or freshly-written (request)
+#:   *secret material*. Letting a request-override surface it on the feed
+#:   would defeat the redaction guarantee, so these are excluded from the
+#:   upgrade branch (:data:`_UPGRADEABLE_OP_CLASSES`).
+_SENSITIVE_OP_CLASSES: Final[frozenset[str]] = frozenset(
+    {"credential_read", "credential_mint", "credential_write", "audit_query"}
+)
+
+#: Subset of :data:`_SENSITIVE_OP_CLASSES` a per-call ``"full"``
+#: request-override is permitted to upgrade. Secret-material classes
+#: (``credential_mint`` / ``credential_write``) are deliberately absent —
+#: their broadcast stays aggregate-only no matter what override a caller
+#: requests, so the minted/written credential never reaches the feed.
+_UPGRADEABLE_OP_CLASSES: Final[frozenset[str]] = frozenset({"credential_read", "audit_query"})
 
 
 #: Origin label for the default branch (no override matched).
@@ -295,15 +320,21 @@ async def compute_effective_broadcast_detail(
 
     Precedence ladder (load-bearing -- the order is the policy):
 
-    1. ``request_override == "full"`` AND ``op_class`` is sensitive →
+    1. ``request_override == "full"`` AND ``op_class`` is
+       *upgradeable*-sensitive (``credential_read`` / ``audit_query``) →
        ``(op_class, "full", "request_override")``. The
        :func:`read_request_override` shim guarantees the only value
        reaching this branch is the literal ``"full"``; ``"aggregate"``
        requests are silently dropped at the shim, never here.
+       Secret-material classes (``credential_mint`` /
+       ``credential_write``) are *not* upgradeable and skip this branch.
     2. Per-tenant override row from the cache, glob-matched on
        ``op_id_pattern`` and scope-matched on ``raw_params`` →
        ``(op_class, row.detail, f"tenant_rule:{row.id}")``. Most
-       specific (scoped) beats op-wide; id-order tie-break.
+       specific (scoped) beats op-wide; id-order tie-break. A rule that
+       would upgrade a secret-material class to ``full`` is clamped back
+       to ``aggregate`` (G11.7-T1 #1401) — no override path may surface
+       a minted/written credential on the feed.
     3. Default → ``(op_class, _default_detail(op_class), "default")``.
 
     ``op_class_override`` lets the HTTP audit middleware honour a
@@ -325,7 +356,7 @@ async def compute_effective_broadcast_detail(
     """
     op_class = op_class_override if op_class_override else classify_op(op_id)
 
-    if request_override == "full" and op_class in _SENSITIVE_OP_CLASSES:
+    if request_override == "full" and op_class in _UPGRADEABLE_OP_CLASSES:
         return op_class, "full", _ORIGIN_REQUEST_OVERRIDE
 
     rules = await _load_tenant_rules(tenant_id)
@@ -341,6 +372,11 @@ async def compute_effective_broadcast_detail(
         # the runtime invariant for mypy without trusting an unchecked
         # str.
         detail: Literal["full", "aggregate"] = "full" if winner.detail == "full" else "aggregate"
+        # Secret-material classes are non-upgradeable (G11.7-T1 #1401):
+        # clamp a "full" tenant rule back to aggregate so no per-tenant
+        # override can surface a minted/written credential on the feed.
+        if detail == "full" and op_class in _SENSITIVE_OP_CLASSES - _UPGRADEABLE_OP_CLASSES:
+            detail = "aggregate"
         return op_class, detail, f"tenant_rule:{winner.id}"
 
     return op_class, _default_detail(op_class), _ORIGIN_DEFAULT

--- a/backend/src/meho_backplane/mcp/tools/approvals.py
+++ b/backend/src/meho_backplane/mcp/tools/approvals.py
@@ -65,6 +65,7 @@ from meho_backplane.mcp.server import McpInvalidParamsError
 from meho_backplane.operations.approval_queue import (
     ApprovalNotFoundError,
     ApprovalRequestAlreadyDecidedError,
+    SelfApprovalForbiddenError,
     UnauthorizedApprovalError,
     approve_request,
     get_request,
@@ -363,6 +364,13 @@ async def _approve_handler(
         except ApprovalRequestAlreadyDecidedError as exc:
             raise McpInvalidParamsError(
                 f"approval_request_not_pending: current status is {exc.status!r}"
+            ) from exc
+        except SelfApprovalForbiddenError as exc:
+            # G11.7-T1 #1401: requester != approver. Surfaced as an
+            # invalid-params error so the operator sees the refusal
+            # reason rather than a generic role failure.
+            raise McpInvalidParamsError(
+                "self_approval_forbidden: requester and approver must differ"
             ) from exc
         except UnauthorizedApprovalError as exc:
             raise McpInvalidParamsError(

--- a/backend/src/meho_backplane/operations/_validate.py
+++ b/backend/src/meho_backplane/operations/_validate.py
@@ -97,6 +97,47 @@ def validate_params(
     return out
 
 
+def _non_agent_verdict(
+    *,
+    operator: Operator,
+    descriptor: EndpointDescriptor,
+    target: Any,
+) -> tuple[PermissionVerdict, str | None]:
+    """Resolve the verdict for a human / service (non-agent) principal.
+
+    Preserves the v0.2 default-allow contract for ordinary ops, but
+    routes a ``requires_approval`` op to ``needs-approval`` (the approval
+    queue) rather than hard-denying it (G11.7-T1 #1401). Self-approval is
+    blocked at decide time by ``approve_request``'s requester != approver
+    guard — the gate's job here is only to park the call.
+    """
+    target_id_str = str(getattr(target, "id", None)) if target is not None else None
+    if descriptor.requires_approval:
+        _log.info(
+            "policy_gate_needs_approval",
+            operator_sub=operator.sub,
+            principal_kind=operator.principal_kind.value,
+            tenant_id=str(operator.tenant_id),
+            op_id=descriptor.op_id,
+            safety_level=descriptor.safety_level,
+            target_id=target_id_str,
+        )
+        return (
+            PermissionVerdict.NEEDS_APPROVAL,
+            "requires_approval is True; routed to the approval queue (G11.7-T1)",
+        )
+    _log.info(
+        "policy_gate_default_allow",
+        operator_sub=operator.sub,
+        principal_kind=operator.principal_kind.value,
+        tenant_id=str(operator.tenant_id),
+        op_id=descriptor.op_id,
+        safety_level=descriptor.safety_level,
+        target_id=target_id_str,
+    )
+    return PermissionVerdict.AUTO_EXECUTE, None
+
+
 async def policy_gate(
     *,
     operator: Operator,
@@ -117,7 +158,9 @@ async def policy_gate(
       :class:`~meho_backplane.db.models.ApprovalRequest` row and return an
       ``awaiting_approval`` result, via
       :func:`~meho_backplane.operations.approval_queue.create_pending_request`
-      (G11.2-T4, #817). Only agent principals reach this verdict.
+      (G11.2-T4, #817). Reached by both agent principals (verdict floor)
+      and, since G11.7-T1 (#1401), human/service principals on a
+      ``requires_approval`` op.
     * ``deny`` — write an audit row in ``denied`` status, return
       :func:`~meho_backplane.operations._errors.result_denied` with the
       *reason* string so the agent can reason about the refusal.
@@ -131,16 +174,29 @@ async def policy_gate(
     ---------------------
 
     The per-(principal, op, target) agent-permission model gates **agent
-    principals** (``principal_kind == agent``). Human operators and
-    service accounts keep the v0.2 contract — default-allow except an op
-    flagged ``requires_approval`` — so a caution/dangerous op a human
-    has always been able to run does not silently start pending/denying.
-    This is exactly G11.2-T4 (#817)'s stated split: replace the
-    ``requires_approval`` hard-deny with the pending path *for agents*;
-    humans keep current behaviour. The agent path additionally folds
-    ``requires_approval`` into the verdict as a ``needs-approval`` floor,
-    so an op the connector author marked as requiring approval is never
-    auto-executed by an agent regardless of its ``safety_level``.
+    principals** (``principal_kind == agent``) through
+    :func:`~meho_backplane.auth.permissions.resolve_verdict`. Human
+    operators and service accounts keep the v0.2 default-allow contract
+    for ordinary ops, but a ``requires_approval`` op now routes them to
+    the **approval queue** (``needs-approval``) rather than hard-denying.
+
+    G11.7-T1 (#1401) closes the Phase-C gap: ops-team operators
+    authenticate as ``USER`` principals
+    (:func:`meho_backplane.auth.operator`), so the old hard-deny meant
+    every governed connector write returned ``denied`` to the very
+    people meant to run it. Routing them to ``needs-approval`` reuses
+    the already-built queue/approve/resume substrate
+    (:func:`~meho_backplane.operations.approval_queue.create_pending_request`
+    accepts any operator; the REST/MCP/CLI approve surfaces and the
+    ``_approved=True`` resume path are unchanged) — it is a one-branch
+    policy change, not new infrastructure. A non-``requires_approval``
+    op a human has always been able to run still auto-executes, so no
+    existing human-runnable op regresses.
+
+    The agent path additionally folds ``requires_approval`` into the
+    verdict as a ``needs-approval`` floor, so an op the connector author
+    marked as requiring approval is never auto-executed by an agent
+    regardless of its ``safety_level``.
 
     The function is **async** — it opens its own DB session to load the
     caller's :class:`~meho_backplane.db.models.AgentPermission` rows,
@@ -148,27 +204,9 @@ async def policy_gate(
     The dispatcher's call site changes only in adding ``await``; the
     signature (operator / descriptor / target) stays identical to v0.2.
     """
-    # --- Human / service principals: preserve the v0.2 contract --------
+    # --- Human / service principals: default-allow, queue on approval --
     if operator.principal_kind is not PrincipalKind.AGENT:
-        if descriptor.requires_approval:
-            # v0.2 hard-deny is retained for non-agent principals; the
-            # approval queue (G11.2-T4) routes only agent runs to the
-            # pending path.
-            return (
-                PermissionVerdict.DENY,
-                "requires_approval is True; only agent principals are routed "
-                "to the approval queue (G11.2-T4)",
-            )
-        _log.info(
-            "policy_gate_default_allow",
-            operator_sub=operator.sub,
-            principal_kind=operator.principal_kind.value,
-            tenant_id=str(operator.tenant_id),
-            op_id=descriptor.op_id,
-            safety_level=descriptor.safety_level,
-            target_id=str(getattr(target, "id", None)) if target is not None else None,
-        )
-        return PermissionVerdict.AUTO_EXECUTE, None
+        return _non_agent_verdict(operator=operator, descriptor=descriptor, target=target)
 
     # --- Agent principals: per-(principal, op, target) verdict ----------
     target_id = getattr(target, "id", target) if target is not None else None

--- a/backend/src/meho_backplane/operations/approval_queue.py
+++ b/backend/src/meho_backplane/operations/approval_queue.py
@@ -79,6 +79,7 @@ __all__ = [
     "ApprovalNotFoundError",
     "ApprovalRequestAlreadyDecidedError",
     "ParamsMismatchError",
+    "SelfApprovalForbiddenError",
     "UnauthorizedApprovalError",
     "approve_request",
     "create_pending_request",
@@ -146,6 +147,32 @@ class ParamsMismatchError(ApprovalError):
         super().__init__(
             f"params hash mismatch on approval_request {request_id}; "
             "original params must be supplied unchanged"
+        )
+
+
+class SelfApprovalForbiddenError(ApprovalError):
+    """The approver is the same principal that requested the approval.
+
+    Raised by :func:`approve_request` when
+    ``operator.sub == request.principal_sub`` and the deployment has not
+    enabled the audited single-operator break-glass mode
+    (``Settings.approval_allow_self_approval``). Enforces the
+    requester != approver invariant (G11.7-T1 #1401): a single account
+    must not be able to both request and grant a privileged connector
+    write. The route layer maps this to 403.
+
+    Reject is deliberately *not* guarded — an operator withdrawing their
+    own pending request is not a privilege escalation.
+    """
+
+    def __init__(self, request_id: uuid.UUID, *, principal_sub: str) -> None:
+        self.request_id = request_id
+        self.principal_sub = principal_sub
+        super().__init__(
+            f"operator {principal_sub!r} may not approve approval_request "
+            f"{request_id}: requester and approver must differ "
+            "(set APPROVAL_ALLOW_SELF_APPROVAL=true for audited "
+            "single-operator break-glass)"
         )
 
 
@@ -335,7 +362,14 @@ async def approve_request(
     1. The row exists and belongs to ``operator.tenant_id`` (else 404).
     2. The operator holds at least the ``operator`` role (else 403).
     3. The row is still ``pending`` (else 409).
-    4. If *params* is supplied, ``compute_params_hash(params)`` matches
+    4. The approver is not the requester — ``operator.sub !=
+       request.principal_sub`` — unless the deployment enabled the
+       audited single-operator break-glass mode
+       (``Settings.approval_allow_self_approval``). Else 403,
+       :class:`SelfApprovalForbiddenError` (G11.7-T1 #1401). Checked
+       before the hash check so a self-approver learns *why* they are
+       refused rather than being told their params mismatch.
+    5. If *params* is supplied, ``compute_params_hash(params)`` matches
        the stored ``params_hash`` (else 422, :class:`ParamsMismatchError`).
        The hash check is **skipped** when *params* is ``None`` — the
        operator-decision path (G11.2-T5 MCP/CLI surface) approves by
@@ -372,20 +406,14 @@ async def approve_request(
         ApprovalNotFoundError: No row for *request_id* in this tenant.
         UnauthorizedApprovalError: Operator lacks ``operator`` role.
         ApprovalRequestAlreadyDecidedError: Row is not ``pending``.
+        SelfApprovalForbiddenError: Approver is the requester and
+            break-glass is disabled (G11.7-T1 #1401).
         ParamsMismatchError: Hash of *params* != stored ``params_hash``
             (only raised when *params* is supplied).
     """
-    _check_reviewer_role(operator)
-
-    request = await _load_for_tenant(session, request_id, operator.tenant_id)
-
-    if request.status != ApprovalRequestStatus.PENDING.value:
-        raise ApprovalRequestAlreadyDecidedError(request_id, request.status)
-
-    if params is not None:
-        incoming_hash = compute_params_hash(params)
-        if incoming_hash != request.params_hash:
-            raise ParamsMismatchError(request_id)
+    request = await _load_pending_for_approval(
+        session, request_id, operator=operator, params=params
+    )
 
     now = _now()
     request.status = ApprovalRequestStatus.APPROVED.value
@@ -580,6 +608,65 @@ def _check_reviewer_role(operator: Operator) -> None:
             operator_sub=operator.sub,
             role=operator.tenant_role.value,
         )
+
+
+def _check_self_approval(operator: Operator, request: ApprovalRequest) -> None:
+    """Raise :class:`SelfApprovalForbiddenError` on a self-approval.
+
+    Enforces requester != approver (G11.7-T1 #1401): the principal that
+    parked the request (``request.principal_sub``) may not also approve
+    it unless the deployment enabled the audited single-operator
+    break-glass mode (``Settings.approval_allow_self_approval``). The
+    comparison is on the stable ``sub`` claim, so a renamed display name
+    cannot launder a self-approval.
+
+    Imported lazily to keep the queue module decoupled from settings at
+    import time (mirrors the local ``TenantRole`` import in
+    :func:`_check_reviewer_role`).
+    """
+    if operator.sub != request.principal_sub:
+        return
+
+    from meho_backplane.settings import get_settings
+
+    if get_settings().approval_allow_self_approval:
+        _log.warning(
+            "approval_self_approval_break_glass",
+            approval_request_id=str(request.id),
+            op_id=request.op_id,
+            operator_sub=operator.sub,
+            tenant_id=str(operator.tenant_id),
+        )
+        return
+
+    raise SelfApprovalForbiddenError(request.id, principal_sub=operator.sub)
+
+
+async def _load_pending_for_approval(
+    session: AsyncSession,
+    request_id: uuid.UUID,
+    *,
+    operator: Operator,
+    params: dict[str, Any] | None,
+) -> ApprovalRequest:
+    """Load + validate a row for approval, raising on any precondition failure.
+
+    Runs the full approve precondition ladder in order so callers learn
+    the most specific reason first: role gate → tenant-scoped load →
+    pending guard → self-approval guard (G11.7-T1 #1401) → params-hash
+    check (only when *params* is supplied). Returns the validated
+    pending row; the caller flips status + writes the decision audit row.
+    """
+    _check_reviewer_role(operator)
+    request = await _load_for_tenant(session, request_id, operator.tenant_id)
+    if request.status != ApprovalRequestStatus.PENDING.value:
+        raise ApprovalRequestAlreadyDecidedError(request_id, request.status)
+    _check_self_approval(operator, request)
+    if params is not None:
+        incoming_hash = compute_params_hash(params)
+        if incoming_hash != request.params_hash:
+            raise ParamsMismatchError(request_id)
+    return request
 
 
 async def _load_for_tenant(

--- a/backend/src/meho_backplane/operations/dispatcher.py
+++ b/backend/src/meho_backplane/operations/dispatcher.py
@@ -907,11 +907,12 @@ async def dispatch(
     resume path (:mod:`meho_backplane.api.v1.approvals`) after a human
     operator has explicitly approved a parked ``needs-approval`` request.
     It skips the policy gate (Step 4) because the approval decision *is*
-    the authorization — re-running the gate would re-deny (the reviewer is
-    a human, hard-denied on ``requires_approval``) or re-queue (an agent
-    re-hits ``needs-approval``), so an approved op would never execute.
-    It is not part of the public agent/MCP/CLI surface; the gate is the
-    only authorization path for an ordinary dispatch.
+    the authorization — re-running the gate would re-queue the call (a
+    human/service principal now routes ``requires_approval`` to
+    ``needs-approval`` per G11.7-T1 #1401; an agent re-hits the same
+    floor), so the approved op would loop back into the queue and never
+    execute. It is not part of the public agent/MCP/CLI surface; the
+    gate is the only authorization path for an ordinary dispatch.
     """
     started = time.monotonic()
     params_hash = compute_params_hash(params)
@@ -965,9 +966,10 @@ async def dispatch(
         if verdict == PermissionVerdict.NEEDS_APPROVAL:
             # G11.2-T4 (#817): write a durable ApprovalRequest row (+ its
             # synchronous "request" audit row) and return an
-            # awaiting_approval result. Only agent principals reach this
-            # branch — the T3 gate hard-denies requires_approval for
-            # human/service principals.
+            # awaiting_approval result. Reached by an agent principal
+            # whose verdict floors to needs-approval AND (G11.7-T1 #1401)
+            # by a human/service principal hitting a requires_approval op
+            # — both park the call durably for an operator to decide.
             duration_ms = _elapsed_ms(started)
             return await _handle_needs_approval(
                 op_id=op_id,

--- a/backend/src/meho_backplane/settings.py
+++ b/backend/src/meho_backplane/settings.py
@@ -582,6 +582,20 @@ class Settings(BaseModel):
         human review across timezone-distant teams without tying up an
         agent loop indefinitely on a forgotten request. Set via
         ``AGENT_APPROVAL_WAIT_TIMEOUT_SECONDS``.
+    approval_allow_self_approval:
+        Self-approval break-glass switch (G11.7-T1 #1401). Default
+        ``False`` (fail-closed): the operator who requested a parked
+        approval may not approve their own request — requester !=
+        approver is enforced in
+        :func:`~meho_backplane.operations.approval_queue.approve_request`,
+        so a compromised or careless single account cannot both ask for
+        and grant a privileged connector write. Set
+        ``APPROVAL_ALLOW_SELF_APPROVAL=true`` only for an audited
+        single-operator break-glass deployment; the self-approval still
+        writes its decision audit row, so the use is forensically
+        visible. Reject is always allowed regardless of this flag — an
+        operator withdrawing their own pending request is never a
+        privilege escalation.
     openai_api_key:
         Bearer token the OpenAI-compatible backend builder
         (G11.5-T3 #1077) authenticates with. Empty (the default) is
@@ -790,6 +804,15 @@ class Settings(BaseModel):
     # elevation windows are typically hours, not days.
     grant_expiry_tick_interval_seconds: int = Field(default=300, ge=60, le=86400)
     grant_expiry_enabled: bool = True
+    # G11.7-T1 #1401 -- self-approval break-glass. Default False is
+    # fail-closed: the operator who requested a parked approval may not
+    # also approve it (requester != approver, enforced in
+    # ``approval_queue.approve_request``). Set
+    # ``APPROVAL_ALLOW_SELF_APPROVAL=true`` only for an audited
+    # single-operator break-glass deployment; every self-approval still
+    # writes its decision audit row, so the break-glass use is forensically
+    # visible.
+    approval_allow_self_approval: bool = False
     # G11.3-T4 #825 -- agent_run reaper knobs. Same opt-out shape as
     # GRANT_EXPIRY_ENABLED / MEMORY_EXPIRY_ENABLED so an operator
     # running an external lease-reclaim mechanism (DBOS Transact, a
@@ -1202,6 +1225,11 @@ def get_settings() -> Settings:
         ),
         grant_expiry_enabled=parse_bool_env(
             os.environ.get("GRANT_EXPIRY_ENABLED", "true"),
+        ),
+        # G11.7-T1 #1401 — fail-closed default: self-approval forbidden
+        # unless this break-glass switch is explicitly enabled.
+        approval_allow_self_approval=parse_bool_env(
+            os.environ.get("APPROVAL_ALLOW_SELF_APPROVAL", "false"),
         ),
         agent_run_reaper_enabled=parse_bool_env(
             os.environ.get("AGENT_RUN_REAPER_ENABLED", "true"),

--- a/backend/src/meho_backplane/targets/resolver.py
+++ b/backend/src/meho_backplane/targets/resolver.py
@@ -238,8 +238,8 @@ async def resolve_target_by_id(
     filter mirrors the resolver's soft-delete discipline (G0.14-T4
     #1145): a target soft-deleted between request and approval resolves
     to ``None`` so the caller fails closed (the re-dispatch returns a
-    structured ``no_connector`` / handler error) rather than reviving a
-    tombstoned target.
+    structured ``denied`` result and never executes) rather than
+    reviving a tombstoned target or dispatching against ``target=None``.
 
     Returns ``None`` when no live row matches the id in *tenant_id* (the
     caller decides how to surface the miss); cross-tenant ids are

--- a/backend/src/meho_backplane/targets/resolver.py
+++ b/backend/src/meho_backplane/targets/resolver.py
@@ -56,7 +56,12 @@ from sqlalchemy.ext.asyncio import AsyncSession
 from meho_backplane.db.models import Target as TargetORM
 from meho_backplane.targets.schemas import TargetSummary, project_target_to_summary
 
-__all__ = ["AmbiguousTargetError", "TargetNotFoundError", "resolve_target"]
+__all__ = [
+    "AmbiguousTargetError",
+    "TargetNotFoundError",
+    "resolve_target",
+    "resolve_target_by_id",
+]
 
 _log = structlog.get_logger(__name__)
 
@@ -211,6 +216,42 @@ async def resolve_target(
     )
     _log.info("target_resolved", target_id=str(target.id), name=target.name)
     return target
+
+
+async def resolve_target_by_id(
+    session: AsyncSession,
+    tenant_id: UUID,
+    target_id: UUID,
+) -> TargetORM | None:
+    """Load a live :class:`TargetORM` row by id, tenant-scoped.
+
+    The approval-queue resume path (G11.7-T1 #1401) stores only the
+    target's ``id`` on the :class:`~meho_backplane.db.models.ApprovalRequest`
+    row, not the full target object. On approve the REST route must
+    re-hydrate the target so a write op whose handler reads
+    ``target.host`` / ``target.name`` / ``target.fqdn`` resolves the
+    correct connector + target instead of silently dispatching against
+    ``target=None``.
+
+    Distinct from :func:`resolve_target` (name-or-alias) — this is the
+    id-keyed lookup the resume path needs. The ``deleted_at IS NULL``
+    filter mirrors the resolver's soft-delete discipline (G0.14-T4
+    #1145): a target soft-deleted between request and approval resolves
+    to ``None`` so the caller fails closed (the re-dispatch returns a
+    structured ``no_connector`` / handler error) rather than reviving a
+    tombstoned target.
+
+    Returns ``None`` when no live row matches the id in *tenant_id* (the
+    caller decides how to surface the miss); cross-tenant ids are
+    invisible by the WHERE clause.
+    """
+    stmt = select(TargetORM).where(
+        TargetORM.id == target_id,
+        TargetORM.tenant_id == tenant_id,
+        TargetORM.deleted_at.is_(None),
+    )
+    result = await session.execute(stmt)
+    return result.scalar_one_or_none()
 
 
 async def _alias_match(

--- a/backend/tests/integration/test_connectors_vault_dev_e2e.py
+++ b/backend/tests/integration/test_connectors_vault_dev_e2e.py
@@ -31,7 +31,9 @@ What this harness proves (issue #551 DoD)
   :func:`~meho_backplane.operations.dispatch`; each asserts the live
   response shape, that a synchronous ``audit_log`` row committed
   (CLAUDE.md postulate 7), and that the broadcast event's
-  ``op_class`` is correct — ``write`` for ``vault.kv.put`` /
+  ``op_class`` is correct — ``credential_write`` for ``vault.kv.put``
+  (its KV-v2 secret rides in the request params, so the broadcast
+  collapses to aggregate-only per G11.7-T1 #1401), ``write`` for
   ``vault.kv.delete``, ``credential_read`` for ``vault.kv.read`` /
   ``vault.kv.list``, ``read`` for the KV-v2 / sys metadata reads and
   the ``.list`` auth ops, and ``other`` for the two ``.read``
@@ -518,30 +520,66 @@ async def test_kv_put_against_dev_vault(
     vault_e2e: tuple[_VaultTarget, str],
     captured_events: list[BroadcastEvent],
 ) -> None:
-    """``vault.kv.put`` writes a new version; audited; op_class=write."""
+    """``vault.kv.put`` writes a new version; audited; op_class=credential_write.
+
+    G11.7-T1 (#1401) reclassified ``vault.kv.put`` from plain ``write`` to
+    ``credential_write``: the KV-v2 secret rides in the *request params*, so
+    a plain-``write`` classification broadcast the written secret in full to
+    every operator on the feed. ``credential_write`` collapses the broadcast
+    to aggregate-only (``{op_class, result_status}``) — the team-coordination
+    signal "someone wrote a credential" without the secret material.
+
+    This integration assertion strengthens the contract end-to-end: the
+    written secret value is seeded as a distinctive sentinel and the test
+    positively asserts it is **absent** from the *entire serialised
+    BroadcastEvent* (not just ``payload`` — a regression placing the secret
+    in a new top-level field would slip a payload-only check), mirroring
+    :func:`tests.test_broadcast_credential_write_dispatch
+    .test_credential_write_broadcast_is_aggregate_only`. The
+    :class:`~meho_backplane.connectors.schemas.OperationResult` and the
+    Vault read-back still carry the secret — only the broadcast is redacted.
+    """
     target, addr = vault_e2e
+    # Distinctive value so any appearance in the serialised broadcast event
+    # is an unambiguous leak (a short/common value like "v" could collide
+    # with field names or framework strings and make absence unprovable).
+    sentinel = "kvput-secret-sentinel-1401"
     operator = _make_operator(sub="op-kv-put")
     result = await dispatch(
         operator=operator,
         connector_id="vault-1.x",
         op_id="vault.kv.put",
         target=target,
-        params={"path": "app/written", "data": {"k": "v"}},
+        params={"path": "app/written", "data": {"k": sentinel}},
     )
     assert result.status == "ok", result.error
     assert result.result == {"version": 1}
-    # Read back through a fresh root client to prove the write landed.
+    # Read back through a fresh root client to prove the write landed — the
+    # secret is intact in Vault and in the caller's OperationResult; only the
+    # broadcast view is redacted.
     readback = _root_client(addr).secrets.kv.v2.read_secret_version(
         path="app/written",
         mount_point=_KV_MOUNT,
         raise_on_deleted_version=False,
     )
-    assert readback["data"]["data"] == {"k": "v"}
+    assert readback["data"]["data"] == {"k": sentinel}
     await _assert_audited(
         "vault.kv.put",
         operator_sub="op-kv-put",
-        expected_op_class="write",
+        expected_op_class="credential_write",
         events=captured_events,
+    )
+    # Positive secret-absence assertion (AC4): the redacted broadcast carries
+    # only the aggregate view and the sentinel never reaches the feed.
+    put_event = next(e for e in captured_events if e.op_id == "vault.kv.put")
+    assert put_event.payload == {
+        "op_class": "credential_write",
+        "result_status": "ok",
+    }
+    serialised = put_event.model_dump_json()
+    assert sentinel not in serialised, (
+        f"credential_write leak: {sentinel!r} reached the broadcast event for "
+        f"vault.kv.put — serialised event: {serialised}"
     )
 
 

--- a/backend/tests/test_agent_approval_resume.py
+++ b/backend/tests/test_agent_approval_resume.py
@@ -459,12 +459,15 @@ async def test_resume_re_dispatches_on_approval_via_decide_path(
     assert first.status == "awaiting_approval"
     approval_request_id = uuid.UUID(first.extras["approval_request_id"])
 
-    # Step 2: operator approves via the operator-decision path. This is the
-    # path /decide (REST) and meho.approvals.approve (MCP) take -- the
-    # ``approve_request`` call by id alone, **without** the params
-    # re-dispatch the legacy REST /approve+params route does.
+    # Step 2: a distinct human operator approves via the operator-decision
+    # path. This is the path /decide (REST) and meho.approvals.approve
+    # (MCP) take -- the ``approve_request`` call by id alone, **without**
+    # the params re-dispatch the legacy REST /approve+params route does.
+    # The reviewer must differ from the agent requester (self-approval
+    # guard, G11.7-T1 #1401).
+    reviewer = _make_operator(sub="human-reviewer", principal_kind=PrincipalKind.USER)
     async with get_sessionmaker()() as s:
-        row = await approve_request(s, approval_request_id, operator=operator, params=None)
+        row = await approve_request(s, approval_request_id, operator=reviewer, params=None)
         await s.commit()
     assert row.status == "approved"
 

--- a/backend/tests/test_api_v1_approvals.py
+++ b/backend/tests/test_api_v1_approvals.py
@@ -44,6 +44,7 @@ from __future__ import annotations
 
 import uuid
 from collections.abc import Iterator
+from types import SimpleNamespace
 from typing import Any
 
 import pytest
@@ -52,7 +53,7 @@ from fastapi.testclient import TestClient
 
 import meho_backplane.audit as _audit_module
 from meho_backplane.auth.jwt import clear_jwks_cache
-from meho_backplane.auth.operator import TenantRole
+from meho_backplane.auth.operator import Operator, PrincipalKind, TenantRole
 from meho_backplane.main import app
 from meho_backplane.settings import get_settings
 
@@ -159,3 +160,124 @@ def test_read_only_role_is_rejected_with_insufficient_role(
         response = client.request(method, path, headers=headers, json=body)
     assert response.status_code == 403, response.text
     assert response.json() == {"detail": "insufficient_role"}
+
+
+# ---------------------------------------------------------------------------
+# G11.7-T1 (#1401) — resume-target hardening must fail closed
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.asyncio
+async def test_resume_refuses_when_pinned_target_no_longer_resolves(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """A soft-deleted / unresolvable resume target is refused, not executed.
+
+    The approval row pins a concrete ``target_id``. If that target is
+    soft-deleted (or revoked) between request and approval,
+    ``resolve_target_by_id`` returns ``None``. The resume path must
+    **fail closed** — return a structured ``denied`` result and never
+    call ``dispatch`` — rather than dispatching with ``target=None``,
+    which would let a typed handler that derives its connection from
+    ``connector_id`` / ``params`` execute the approved privileged write
+    outside the original target scope (G11.7-T1 #1401, B1).
+    """
+    from meho_backplane.api.v1 import approvals as approvals_module
+
+    target_id = uuid.uuid4()
+    operator = Operator(
+        sub="op-resume-test",
+        name="Resume Test Operator",
+        email=None,
+        raw_jwt="<test-raw-jwt>",
+        tenant_id=_TENANT_A,
+        tenant_role=TenantRole.OPERATOR,
+        principal_kind=PrincipalKind.USER,
+    )
+    # Minimal stand-in for the ApprovalRequest ORM row: the resume helper
+    # only reads id / target_id / op_id / connector_id off it.
+    request = SimpleNamespace(
+        id=uuid.uuid4(),
+        target_id=target_id,
+        op_id="vault.kv.put",
+        connector_id="vault-1.x",
+    )
+
+    # The pinned target no longer resolves (soft-deleted between request
+    # and approval).
+    async def _resolve_none(*_a: object, **_kw: object) -> None:
+        return None
+
+    monkeypatch.setattr(approvals_module, "resolve_target_by_id", _resolve_none)
+
+    # Spy on dispatch — it must NOT be reached on the fail-closed path.
+    dispatch_calls: list[dict[str, Any]] = []
+
+    async def _dispatch_spy(**kwargs: Any) -> Any:
+        dispatch_calls.append(kwargs)
+        raise AssertionError("dispatch must not run when the pinned target is unresolvable")
+
+    import meho_backplane.operations.dispatcher as dispatcher_module
+
+    monkeypatch.setattr(dispatcher_module, "dispatch", _dispatch_spy)
+
+    result = await approvals_module._resume_dispatch_after_approval(
+        operator=operator,
+        request=request,  # type: ignore[arg-type]
+        params={"path": "secret/x", "value": "s3cr3t"},
+    )
+
+    assert dispatch_calls == [], "dispatch was called despite an unresolvable target"
+    assert result.status == "denied", result
+    assert result.op_id == "vault.kv.put"
+    assert str(target_id) in (result.error or "")
+
+
+@pytest.mark.asyncio
+async def test_resume_dispatches_when_no_target_was_pinned(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """A tenant-wide op (``target_id IS NULL``) still re-dispatches normally.
+
+    The fail-closed branch must fire only when a concrete ``target_id``
+    was pinned at request time. An approval whose request had no target
+    (tenant-wide op) must reach ``dispatch`` with ``target=None`` as
+    before — the hardening must not regress that path.
+    """
+    from meho_backplane.api.v1 import approvals as approvals_module
+
+    operator = Operator(
+        sub="op-resume-test",
+        name="Resume Test Operator",
+        email=None,
+        raw_jwt="<test-raw-jwt>",
+        tenant_id=_TENANT_A,
+        tenant_role=TenantRole.OPERATOR,
+        principal_kind=PrincipalKind.USER,
+    )
+    request = SimpleNamespace(
+        id=uuid.uuid4(),
+        target_id=None,
+        op_id="some.tenant_wide.op",
+        connector_id="some-1.x",
+    )
+
+    seen: dict[str, Any] = {}
+
+    async def _dispatch_spy(**kwargs: Any) -> Any:
+        seen.update(kwargs)
+        return SimpleNamespace(status="ok", op_id=kwargs["op_id"], result={}, error=None)
+
+    import meho_backplane.operations.dispatcher as dispatcher_module
+
+    monkeypatch.setattr(dispatcher_module, "dispatch", _dispatch_spy)
+
+    result = await approvals_module._resume_dispatch_after_approval(
+        operator=operator,
+        request=request,  # type: ignore[arg-type]
+        params={"k": "v"},
+    )
+
+    assert result.status == "ok"
+    assert seen["target"] is None
+    assert seen["_approved"] is True

--- a/backend/tests/test_approval_queue.py
+++ b/backend/tests/test_approval_queue.py
@@ -53,6 +53,7 @@ from meho_backplane.operations.approval_queue import (
     ApprovalNotFoundError,
     ApprovalRequestAlreadyDecidedError,
     ParamsMismatchError,
+    SelfApprovalForbiddenError,
     UnauthorizedApprovalError,
     approve_request,
     create_pending_request,
@@ -78,6 +79,20 @@ async def _approval_test_dangerous_handler(
 ) -> dict[str, Any]:
     """Module-level handler for ``reject-test.op`` (integration tests)."""
     return {"executed": True}
+
+
+async def _approval_test_target_reading_handler(
+    operator: Operator, target: Any, params: dict[str, Any]
+) -> dict[str, Any]:
+    """Handler that reads ``target.name`` — proves the resume target resolves.
+
+    G11.7-T1 #1401 resume-target hardening: a write op whose handler
+    consumes the target object must receive the re-hydrated target on the
+    approve re-dispatch, not ``None``. This handler echoes the target's
+    name so a test can assert it survived the round-trip; a ``None``
+    target would raise ``AttributeError`` and fail the dispatch.
+    """
+    return {"executed": True, "target_name": target.name, "params": params}
 
 
 # ---------------------------------------------------------------------------
@@ -224,13 +239,16 @@ async def test_create_pending_request_sets_run_id(session: AsyncSession) -> None
 @pytest.mark.asyncio
 async def test_approve_request_flips_status(session: AsyncSession) -> None:
     """approve_request transitions the row to 'approved'."""
-    operator = _make_operator()
+    # Requester != approver so the self-approval guard (G11.7-T1 #1401)
+    # does not fire — this test exercises the happy-path status flip.
+    requester = _make_operator(sub="requester-sub")
+    reviewer = _make_operator(sub="reviewer-sub")
     params = {"name": "test"}
     params_hash = compute_params_hash(params)
 
     pending = await create_pending_request(
         session,
-        operator=operator,
+        operator=requester,
         connector_id="vault-1.x",
         op_id="vault.kv.write",
         target=None,
@@ -240,24 +258,25 @@ async def test_approve_request_flips_status(session: AsyncSession) -> None:
     await session.commit()
 
     async with get_sessionmaker()() as s2:
-        updated = await approve_request(s2, pending.id, operator=operator, params=params)
+        updated = await approve_request(s2, pending.id, operator=reviewer, params=params)
         await s2.commit()
 
     assert updated.status == ApprovalRequestStatus.APPROVED.value
-    assert updated.reviewed_by == operator.sub
+    assert updated.reviewed_by == reviewer.sub
     assert updated.decided_at is not None
 
 
 @pytest.mark.asyncio
 async def test_approve_request_writes_decision_audit_row(session: AsyncSession) -> None:
     """approve_request writes a 'decision' audit row synchronously."""
-    operator = _make_operator()
+    requester = _make_operator(sub="requester-sub")
+    reviewer = _make_operator(sub="reviewer-sub")
     params = {}
     params_hash = compute_params_hash(params)
 
     pending = await create_pending_request(
         session,
-        operator=operator,
+        operator=requester,
         connector_id="vault-1.x",
         op_id="vault.kv.write",
         target=None,
@@ -267,7 +286,7 @@ async def test_approve_request_writes_decision_audit_row(session: AsyncSession) 
     await session.commit()
 
     async with get_sessionmaker()() as s2:
-        await approve_request(s2, pending.id, operator=operator, params=params)
+        await approve_request(s2, pending.id, operator=reviewer, params=params)
         await s2.commit()
 
     # Two audit rows total: one request + one decision.
@@ -292,13 +311,14 @@ async def test_approve_request_writes_decision_audit_row(session: AsyncSession) 
 @pytest.mark.asyncio
 async def test_approve_request_raises_on_hash_mismatch(session: AsyncSession) -> None:
     """Supplying different params raises ParamsMismatchError."""
-    operator = _make_operator()
+    requester = _make_operator(sub="requester-sub")
+    operator = _make_operator(sub="reviewer-sub")
     original_params = {"a": 1}
     params_hash = compute_params_hash(original_params)
 
     pending = await create_pending_request(
         session,
-        operator=operator,
+        operator=requester,
         connector_id="vault-1.x",
         op_id="vault.kv.write",
         target=None,
@@ -329,12 +349,13 @@ async def test_approve_request_params_none_skips_hash_check(
     audit row. The agent's REST path keeps supplying params (the swap
     defence stays on the agent branch).
     """
-    operator = _make_operator()
+    requester = _make_operator(sub="requester-sub")
+    operator = _make_operator(sub="reviewer-sub")
     original_params = {"x": 1, "secret": "z"}
     params_hash = compute_params_hash(original_params)
     pending = await create_pending_request(
         session,
-        operator=operator,
+        operator=requester,
         connector_id="vault-1.x",
         op_id="vault.kv.write",
         target=None,
@@ -376,12 +397,13 @@ async def test_publish_approval_event_audit_id_matches_decision_row(
     monkeypatch.setattr("meho_backplane.broadcast.publisher.publish_event", _capture)
     from meho_backplane.operations.approval_queue import publish_approval_event
 
-    operator = _make_operator()
+    requester = _make_operator(sub="requester-sub")
+    operator = _make_operator(sub="reviewer-sub")
     original_params = {"x": 1}
     params_hash = compute_params_hash(original_params)
     pending = await create_pending_request(
         session,
-        operator=operator,
+        operator=requester,
         connector_id="vault-1.x",
         op_id="vault.kv.write",
         target=None,
@@ -415,13 +437,14 @@ async def test_publish_approval_event_audit_id_matches_decision_row(
 @pytest.mark.asyncio
 async def test_approve_request_raises_on_already_decided(session: AsyncSession) -> None:
     """Approving an already-approved row raises ApprovalRequestAlreadyDecidedError."""
-    operator = _make_operator()
+    requester = _make_operator(sub="requester-sub")
+    operator = _make_operator(sub="reviewer-sub")
     params = {}
     params_hash = compute_params_hash(params)
 
     pending = await create_pending_request(
         session,
-        operator=operator,
+        operator=requester,
         connector_id="vault-1.x",
         op_id="vault.kv.write",
         target=None,
@@ -618,6 +641,123 @@ async def test_read_only_operator_cannot_reject(session: AsyncSession) -> None:
     async with get_sessionmaker()() as s2:
         with pytest.raises(UnauthorizedApprovalError):
             await reject_request(s2, pending.id, operator=read_only_op)
+
+
+# ---------------------------------------------------------------------------
+# Self-approval guard (G11.7-T1 #1401)
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.asyncio
+async def test_self_approval_forbidden_by_default(session: AsyncSession) -> None:
+    """The requester may not approve their own request (default fail-closed).
+
+    ``approval_allow_self_approval`` defaults to ``False`` — the operator
+    who parked the request (``principal_sub``) gets
+    :class:`SelfApprovalForbiddenError` (mapped to 403 at the route
+    layer) when they try to approve it. The role check passes (the
+    requester is an OPERATOR), so this isolates the requester != approver
+    guard.
+    """
+    requester = _make_operator(sub="solo-operator", role=TenantRole.OPERATOR)
+    params = {"name": "test"}
+    params_hash = compute_params_hash(params)
+
+    pending = await create_pending_request(
+        session,
+        operator=requester,
+        connector_id="vault-1.x",
+        op_id="vault.kv.put",
+        target=None,
+        params=params,
+        params_hash=params_hash,
+    )
+    await session.commit()
+
+    async with get_sessionmaker()() as s2:
+        with pytest.raises(SelfApprovalForbiddenError):
+            await approve_request(s2, pending.id, operator=requester, params=params)
+
+    # The row stays pending — a refused self-approval is not a decision.
+    async with get_sessionmaker()() as s3:
+        row = await s3.get(ApprovalRequest, pending.id)
+        assert row is not None
+        assert row.status == ApprovalRequestStatus.PENDING.value
+
+
+@pytest.mark.asyncio
+async def test_self_approval_allowed_under_break_glass(
+    session: AsyncSession, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    """Break-glass config lets a single operator self-approve, still audited.
+
+    ``APPROVAL_ALLOW_SELF_APPROVAL=true`` opts into the audited
+    single-operator mode: the self-approval succeeds (status flips) AND
+    still writes its decision audit row, so the break-glass use is
+    forensically visible.
+    """
+    monkeypatch.setenv("APPROVAL_ALLOW_SELF_APPROVAL", "true")
+    get_settings.cache_clear()
+
+    requester = _make_operator(sub="solo-operator", role=TenantRole.OPERATOR)
+    params = {"name": "test"}
+    params_hash = compute_params_hash(params)
+
+    pending = await create_pending_request(
+        session,
+        operator=requester,
+        connector_id="vault-1.x",
+        op_id="vault.kv.put",
+        target=None,
+        params=params,
+        params_hash=params_hash,
+    )
+    await session.commit()
+
+    async with get_sessionmaker()() as s2:
+        row = await approve_request(s2, pending.id, operator=requester, params=params)
+        await s2.commit()
+    assert row.status == ApprovalRequestStatus.APPROVED.value
+    assert row.reviewed_by == requester.sub
+
+    # Decision audit row still landed — break-glass is not silent.
+    async with get_sessionmaker()() as s3:
+        decision_rows = (
+            (await s3.execute(select(AuditLog).where(AuditLog.path == "approval.decision")))
+            .scalars()
+            .all()
+        )
+    assert len(decision_rows) == 1
+    assert decision_rows[0].payload["decision"] == "approved"
+
+
+@pytest.mark.asyncio
+async def test_self_reject_is_always_allowed(session: AsyncSession) -> None:
+    """An operator may reject (withdraw) their own request regardless of config.
+
+    Reject is unguarded — withdrawing one's own pending request is never
+    a privilege escalation, so the self-approval guard does not apply to
+    :func:`reject_request`.
+    """
+    requester = _make_operator(sub="solo-operator", role=TenantRole.OPERATOR)
+    params = {"name": "test"}
+    params_hash = compute_params_hash(params)
+
+    pending = await create_pending_request(
+        session,
+        operator=requester,
+        connector_id="vault-1.x",
+        op_id="vault.kv.put",
+        target=None,
+        params=params,
+        params_hash=params_hash,
+    )
+    await session.commit()
+
+    async with get_sessionmaker()() as s2:
+        row = await reject_request(s2, pending.id, operator=requester, reason="changed my mind")
+        await s2.commit()
+    assert row.status == ApprovalRequestStatus.REJECTED.value
 
 
 # ---------------------------------------------------------------------------
@@ -941,9 +1081,12 @@ async def test_pause_approve_resume_execute(
     assert result1.status == "awaiting_approval"
     approval_request_id = uuid.UUID(result1.extras["approval_request_id"])
 
-    # Step 2: approve the request.
+    # Step 2: approve the request. A distinct human reviewer approves —
+    # the requester (the agent run) may not approve its own request
+    # (self-approval guard, G11.7-T1 #1401).
+    reviewer = _make_operator(sub="human-reviewer-sub", principal_kind=PrincipalKind.USER)
     async with get_sessionmaker()() as s:
-        row = await approve_request(s, approval_request_id, operator=operator, params=params)
+        row = await approve_request(s, approval_request_id, operator=reviewer, params=params)
         await s.commit()
     assert row.status == ApprovalRequestStatus.APPROVED.value
 
@@ -961,6 +1104,173 @@ async def test_pause_approve_resume_execute(
         _approved=True,
     )
     assert result2.status == "ok"
+
+    reset_dispatcher_caches()
+    clear_registry()
+
+
+# ---------------------------------------------------------------------------
+# Human principal: queue (not hard-deny) + resume with explicit target
+# (G11.7-T1 #1401, integration-style)
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.asyncio
+async def test_human_requires_approval_queues_not_denies(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """A USER principal hitting requires_approval is queued, not denied (AC1).
+
+    Pre-G11.7 the policy gate hard-denied a human/service principal on a
+    ``requires_approval`` op (``status=denied``). This drives the full
+    round-trip for a USER principal:
+
+    1. First dispatch → ``awaiting_approval`` (queued + resumable), NOT
+       ``denied``.
+    2. A distinct human reviewer approves the parked request.
+    3. The approve re-dispatch (``_approved=True``) re-hydrates the
+       stored target by id and runs the op — the handler reads
+       ``target.name``, proving the resume target resolved (AC3) rather
+       than passing ``None``.
+    """
+    from unittest.mock import AsyncMock
+
+    import meho_backplane.operations._audit as audit_module
+    from meho_backplane.connectors.base import Connector
+    from meho_backplane.connectors.registry import clear_registry, register_connector_v2
+    from meho_backplane.connectors.schemas import FingerprintResult, ProbeResult
+    from meho_backplane.db.models import Target as TargetORM
+    from meho_backplane.operations import (
+        dispatch,
+        register_typed_operation,
+        reset_dispatcher_caches,
+    )
+    from meho_backplane.targets.resolver import resolve_target_by_id
+
+    monkeypatch.setenv("KEYCLOAK_ISSUER_URL", "https://keycloak.test/realms/meho")
+    monkeypatch.setenv("KEYCLOAK_AUDIENCE", "meho-backplane")
+    monkeypatch.setenv("VAULT_ADDR", "https://vault.test")
+    get_settings.cache_clear()
+
+    async def _capture(event: Any) -> None:
+        pass
+
+    monkeypatch.setattr(audit_module, "publish_event", _capture)
+
+    reset_dispatcher_caches()
+    clear_registry()
+
+    class _OkConnector(Connector):
+        product = "humantest"
+        version = "1.x"
+        impl_id = "humantest"
+        priority = 10
+
+        async def fingerprint(self, host: str, port: int | None) -> FingerprintResult:
+            return FingerprintResult(
+                probe=ProbeResult(reachable=True, probe_method="none"),
+                product="humantest",
+                version="1.x",
+            )
+
+        async def probe(self, target: Any) -> ProbeResult:  # type: ignore[override]
+            raise NotImplementedError
+
+        async def execute(  # type: ignore[override]
+            self, target: Any, op_id: str, params: dict[str, Any]
+        ) -> Any:
+            raise NotImplementedError
+
+    register_connector_v2(product="humantest", version="", impl_id="", cls=_OkConnector)
+
+    stub_emb = AsyncMock()
+    stub_emb.encode_one.return_value = [0.1] * 384
+    stub_emb.encode.return_value = [[0.1] * 384]
+    stub_emb.dimension = 384
+
+    await register_typed_operation(
+        product="humantest",
+        version="1.x",
+        impl_id="humantest",
+        op_id="humantest.write",
+        handler=_approval_test_target_reading_handler,
+        summary="Write op requiring approval.",
+        description="Test.",
+        parameter_schema={"type": "object"},
+        requires_approval=True,
+        when_to_use=None,
+        embedding_service=stub_emb,
+    )
+
+    # Persist a real Target row so resolve_target_by_id can re-hydrate it
+    # on the resume re-dispatch.
+    target_id = uuid.uuid4()
+    async with get_sessionmaker()() as s:
+        s.add(
+            TargetORM(
+                id=target_id,
+                tenant_id=_TENANT_ID,
+                name="prod-vault",
+                product="humantest",
+                host="vault.prod.invalid",
+                aliases=[],
+            )
+        )
+        await s.commit()
+
+    # The operator who runs the op is a *human* (USER) principal.
+    requester = _make_operator(sub="ops-human", principal_kind=PrincipalKind.USER)
+
+    class _Target:
+        product = "humantest"
+        id = target_id
+        name = "prod-vault"
+
+    params = {"path": "secret/db"}
+
+    # Step 1: human dispatch → awaiting_approval (NOT denied).
+    result1 = await dispatch(
+        operator=requester,
+        connector_id="humantest-1.x",
+        op_id="humantest.write",
+        target=_Target(),
+        params=params,
+    )
+    assert result1.status == "awaiting_approval", result1.error
+    assert result1.status != "denied"
+    approval_request_id = uuid.UUID(result1.extras["approval_request_id"])
+
+    # The pending row stored the target_id for the resume path.
+    async with get_sessionmaker()() as s:
+        pending_row = await s.get(ApprovalRequest, approval_request_id)
+        assert pending_row is not None
+        assert pending_row.target_id == target_id
+
+    # Step 2: a distinct human reviewer approves.
+    reviewer = _make_operator(sub="ops-reviewer", principal_kind=PrincipalKind.USER)
+    async with get_sessionmaker()() as s:
+        row = await approve_request(s, approval_request_id, operator=reviewer, params=params)
+        await s.commit()
+    assert row.status == ApprovalRequestStatus.APPROVED.value
+
+    # Step 3: resume — re-hydrate the target by id and re-dispatch. The
+    # handler reads target.name, so a None target would crash the op.
+    async with get_sessionmaker()() as s:
+        resolved = await resolve_target_by_id(s, _TENANT_ID, row.target_id)
+    assert resolved is not None
+    assert resolved.name == "prod-vault"
+
+    result2 = await dispatch(
+        operator=reviewer,
+        connector_id="humantest-1.x",
+        op_id="humantest.write",
+        target=resolved,
+        params=params,
+        _approved=True,
+    )
+    assert result2.status == "ok", result2.error
+    assert result2.result is not None
+    assert result2.result["target_name"] == "prod-vault"  # type: ignore[index]
 
     reset_dispatcher_caches()
     clear_registry()

--- a/backend/tests/test_broadcast_credential_write_dispatch.py
+++ b/backend/tests/test_broadcast_credential_write_dispatch.py
@@ -1,0 +1,200 @@
+# SPDX-License-Identifier: Apache-2.0
+# Copyright (c) 2026 evoila Group
+
+"""G11.7-T1 (#1401) ``credential_write`` broadcast-redaction dispatch test.
+
+Proves the request-side secret-redaction guarantee for the new Phase-C
+write ops whose secret rides in the *request params* (Vault
+``userpass.write`` / ``update_password``, ``vault.kv.put``, k8s
+``secret.create``): the broadcast feed must emit **aggregate-only** — the
+fact that a credential was written, never the secret material — while the
+:class:`~meho_backplane.connectors.schemas.OperationResult` returned to the
+caller is unaffected.
+
+Mechanism mirrors :mod:`tests.test_broadcast_credential_mint_dispatch`
+(``credential_mint``, response-side secret) but for the request-side
+class:
+
+* :func:`~meho_backplane.broadcast.events.classify_op` returns
+  ``"credential_write"`` for the listed ops.
+* :func:`~meho_backplane.broadcast.events.redact_payload` collapses
+  ``credential_write`` to ``{op_class, result_status}``.
+* The broadcast publisher is swapped for a recording stub so the emitted
+  :class:`~meho_backplane.broadcast.events.BroadcastEvent` is inspectable
+  without a Valkey container — so this test runs **unconditionally** (no
+  ``BROADCAST_REDIS_URL`` skip guard), closing the AC4 leak-assertion gap
+  deterministically in the sandbox.
+
+The assertion is by-exclusion on the *whole serialised event*, not just
+``payload``: a regression that placed the secret in a new top-level field
+would pass a ``payload``-only check.
+"""
+
+from __future__ import annotations
+
+import uuid
+from collections.abc import Iterator
+from typing import Any
+from unittest.mock import AsyncMock
+
+import pytest
+
+import meho_backplane.operations._audit as audit_module
+from meho_backplane.auth.operator import Operator, PrincipalKind, TenantRole
+from meho_backplane.broadcast import BroadcastEvent
+from meho_backplane.connectors.base import Connector
+from meho_backplane.connectors.registry import clear_registry, register_connector_v2
+from meho_backplane.connectors.schemas import FingerprintResult, ProbeResult
+from meho_backplane.operations import dispatch, register_typed_operation, reset_dispatcher_caches
+from meho_backplane.settings import get_settings
+
+#: Distinctive secret — any appearance in a serialised event is a leak.
+_SENTINEL_SECRET = "wr1tesecret0sentinel"
+
+_TENANT_ID = uuid.UUID("00000000-0000-0000-0000-0000000007a1")
+
+
+async def _write_handler(operator: Operator, target: Any, params: dict[str, Any]) -> dict[str, Any]:
+    """Echo a benign ack — the secret stays in params, never the response."""
+    return {"written": True}
+
+
+@pytest.fixture(autouse=True)
+def _required_settings_env(monkeypatch: pytest.MonkeyPatch) -> Iterator[None]:
+    monkeypatch.setenv("KEYCLOAK_ISSUER_URL", "https://keycloak.test/realms/meho")
+    monkeypatch.setenv("KEYCLOAK_AUDIENCE", "meho-backplane")
+    monkeypatch.setenv("VAULT_ADDR", "https://vault.test")
+    get_settings.cache_clear()
+    yield
+    get_settings.cache_clear()
+
+
+@pytest.fixture(autouse=True)
+def _reset_module_state() -> Iterator[None]:
+    reset_dispatcher_caches()
+    clear_registry()
+    yield
+    reset_dispatcher_caches()
+    clear_registry()
+
+
+@pytest.fixture
+def captured_events(monkeypatch: pytest.MonkeyPatch) -> list[BroadcastEvent]:
+    """Replace :func:`publish_event` with an in-memory recording stub."""
+    events: list[BroadcastEvent] = []
+
+    async def _capture(event: BroadcastEvent) -> None:
+        events.append(event)
+
+    monkeypatch.setattr(audit_module, "publish_event", _capture)
+    return events
+
+
+@pytest.fixture
+def stub_embedding_service() -> AsyncMock:
+    service = AsyncMock()
+    service.encode_one.return_value = [0.1] * 384
+    service.encode.return_value = [[0.1] * 384]
+    service.dimension = 384
+    return service
+
+
+def _make_operator() -> Operator:
+    return Operator(
+        sub="op-credential-write-test",
+        name="Credential Write Test Operator",
+        email=None,
+        raw_jwt="header.payload.signature",
+        tenant_id=_TENANT_ID,
+        tenant_role=TenantRole.OPERATOR,
+        principal_kind=PrincipalKind.AGENT,
+    )
+
+
+class _WriteConnector(Connector):
+    product = "credwrite"
+    version = "1.x"
+    impl_id = "credwrite"
+    priority = 10
+
+    async def fingerprint(self, host: str, port: int | None) -> FingerprintResult:
+        return FingerprintResult(
+            probe=ProbeResult(reachable=True, probe_method="none"),
+            product="credwrite",
+            version="1.x",
+        )
+
+    async def probe(self, target: Any) -> ProbeResult:  # type: ignore[override]
+        raise NotImplementedError
+
+    async def execute(  # type: ignore[override]
+        self, target: Any, op_id: str, params: dict[str, Any]
+    ) -> Any:
+        # Typed op: the registered handler does the work, not this.
+        raise NotImplementedError
+
+
+@pytest.mark.asyncio
+@pytest.mark.parametrize(
+    "op_id",
+    [
+        "vault.auth.userpass.write",
+        "vault.auth.userpass.update_password",
+        "vault.kv.put",
+        "k8s.secret.create",
+    ],
+)
+async def test_credential_write_broadcast_is_aggregate_only(
+    op_id: str,
+    captured_events: list[BroadcastEvent],
+    stub_embedding_service: AsyncMock,
+) -> None:
+    """A request-secret write broadcasts only ``{op_class, result_status}``.
+
+    AC4 (#1401): the written secret in ``params`` never appears in the
+    serialised BroadcastEvent. Driven through the real dispatcher +
+    broadcast path so the redaction is proven where it ships, not just
+    in a unit call to :func:`redact_payload`.
+    """
+    register_connector_v2(product="credwrite", version="", impl_id="", cls=_WriteConnector)
+    await register_typed_operation(
+        product="credwrite",
+        version="1.x",
+        impl_id="credwrite",
+        op_id=op_id,
+        handler=_write_handler,
+        summary="Secret-bearing write op.",
+        description="Test.",
+        parameter_schema={"type": "object"},
+        when_to_use=None,
+        embedding_service=stub_embedding_service,
+    )
+
+    operator = _make_operator()
+
+    class _Target:
+        product = "credwrite"
+        id = uuid.uuid4()
+        name = "cred-write-target"
+
+    # The secret rides in params — exactly what the broadcast must not leak.
+    result = await dispatch(
+        operator=operator,
+        connector_id="credwrite-1.x",
+        op_id=op_id,
+        target=_Target(),
+        params={"path": "secret/db", "data": {"password": _SENTINEL_SECRET}},
+    )
+    assert result.status == "ok", result.error
+
+    assert len(captured_events) == 1
+    event = captured_events[0]
+    assert event.op_id == op_id
+    assert event.op_class == "credential_write"
+    assert event.payload == {"op_class": "credential_write", "result_status": "ok"}
+
+    serialised = event.model_dump_json()
+    assert _SENTINEL_SECRET not in serialised, (
+        f"credential_write leak: {_SENTINEL_SECRET!r} reached the broadcast "
+        f"event for {op_id} — serialised event: {serialised}"
+    )

--- a/backend/tests/test_broadcast_events.py
+++ b/backend/tests/test_broadcast_events.py
@@ -186,6 +186,47 @@ class TestClassifyOp:
     @pytest.mark.parametrize(
         "op_id",
         [
+            "harbor.robot.create",
+            "vault.token.create",
+            "vault.auth.approle.generate_secret_id",
+        ],
+    )
+    def test_credential_mint_allowlist(self, op_id: str) -> None:
+        """Response-secret ops classify ``credential_mint`` (G11.7-T1 #1401).
+
+        ``vault.token.create`` / ``vault.auth.approle.generate_secret_id``
+        end in ``.create`` / a write-shaped verb but the allowlist is
+        consulted before the write-suffix branch, so the freshly-minted
+        secret in the response collapses to aggregate-only rather than
+        broadcasting under the plain ``write`` class.
+        """
+        assert classify_op(op_id) == "credential_mint"
+
+    @pytest.mark.parametrize(
+        "op_id",
+        [
+            "vault.auth.userpass.write",
+            "vault.auth.userpass.update_password",
+            "vault.kv.put",
+            "k8s.secret.create",
+        ],
+    )
+    def test_credential_write_allowlist(self, op_id: str) -> None:
+        """Request-secret write ops classify ``credential_write`` (G11.7-T1 #1401).
+
+        These ops carry the secret in their *request params*. The
+        allowlist is consulted before the ``.write`` / ``.put`` /
+        ``.create`` suffix branch so the broadcast (which ships params)
+        collapses to aggregate-only instead of leaking the written
+        credential under the plain ``write`` class. ``vault.kv.put``
+        moved here from ``write`` — it shipped pre-G11.7 broadcasting its
+        secret ``data`` in full.
+        """
+        assert classify_op(op_id) == "credential_write"
+
+    @pytest.mark.parametrize(
+        "op_id",
+        [
             "audit.query",
             "audit.show",
             "audit.recent",
@@ -255,10 +296,6 @@ class TestClassifyOp:
             ("vsphere.vm.update", "write"),
             ("vsphere.vm.delete", "write"),
             ("k8s.deployment.patch", "write"),
-            # KV-v2 write verb (G3.3-T1 #545). Without ``.put`` in the
-            # write-suffix tuple this would fall through to ``other``
-            # and broadcast the full secret payload.
-            ("vault.kv.put", "write"),
             # bind9 record-write verbs (G3.4-T3 #589). The bind9
             # connector uses ``.add`` / ``.remove`` to match the
             # consumer wrapper's verb shape; without these suffixes
@@ -338,6 +375,33 @@ class TestRedactPayload:
         assert result == {"op_class": "credential_read", "result_status": "ok"}
         assert "path" not in result
         assert "key" not in result
+
+    def test_credential_write_drops_secret_params(self) -> None:
+        """G11.7-T1 #1401 — a request-secret write redacts to aggregate-only.
+
+        The written credential lives in ``params``; the broadcast ships
+        params, so ``credential_write`` must collapse to
+        ``{op_class, result_status}`` with no trace of the secret.
+        """
+        result = redact_payload(
+            "credential_write",
+            {"path": "secret/db", "data": {"password": "s3kr3t-sentinel"}},
+            "ok",
+        )
+        assert result == {"op_class": "credential_write", "result_status": "ok"}
+        assert "s3kr3t-sentinel" not in str(result)
+        assert "data" not in result
+        assert "params" not in result
+
+    def test_credential_mint_drops_response_secret(self) -> None:
+        """G11.7-T1 #1401 — a response-secret mint redacts to aggregate-only."""
+        result = redact_payload(
+            "credential_mint",
+            {"token": "hvs.minted-sentinel", "role": "ci"},
+            "ok",
+        )
+        assert result == {"op_class": "credential_mint", "result_status": "ok"}
+        assert "hvs.minted-sentinel" not in str(result)
 
     def test_audit_query_drops_filter(self) -> None:
         """AC #7 — filter never reaches the stream; row_count is allowed."""

--- a/backend/tests/test_broadcast_overrides_resolver.py
+++ b/backend/tests/test_broadcast_overrides_resolver.py
@@ -202,6 +202,79 @@ class TestPrecedenceLadder:
         assert origin == "request_override"
 
     @pytest.mark.asyncio
+    @pytest.mark.parametrize(
+        ("op_id", "expected_class"),
+        [
+            ("vault.kv.put", "credential_write"),
+            ("vault.auth.userpass.write", "credential_write"),
+            ("vault.token.create", "credential_mint"),
+            ("vault.auth.approle.generate_secret_id", "credential_mint"),
+        ],
+    )
+    async def test_request_override_cannot_upgrade_secret_material_class(
+        self, op_id: str, expected_class: str
+    ) -> None:
+        """``request_override="full"`` is ignored on secret-material classes (G11.7-T1 #1401).
+
+        ``credential_write`` (request secret) and ``credential_mint``
+        (response secret) are non-upgradeable: no per-call override may
+        surface the credential on the feed. The resolver stays at the
+        aggregate default with ``origin="default"`` — the upgrade branch
+        is skipped entirely.
+        """
+        sessionmaker = get_sessionmaker()
+        async with sessionmaker() as session:
+            tenant_id = await _seed_tenant(session, slug=f"noupgrade-{expected_class}-{op_id[-6:]}")
+
+        op_class, detail, origin = await compute_effective_broadcast_detail(
+            op_id=op_id,
+            tenant_id=tenant_id,
+            raw_params={"data": {"password": "leak-me"}},
+            request_override="full",
+        )
+        assert op_class == expected_class
+        assert detail == "aggregate"
+        assert origin == "default"
+
+    @pytest.mark.asyncio
+    @pytest.mark.parametrize(
+        ("op_id", "expected_class"),
+        [
+            ("vault.kv.put", "credential_write"),
+            ("vault.token.create", "credential_mint"),
+        ],
+    )
+    async def test_tenant_rule_cannot_upgrade_secret_material_class(
+        self, op_id: str, expected_class: str
+    ) -> None:
+        """A ``detail="full"`` tenant rule is clamped to aggregate on secret-material classes.
+
+        Even an explicit per-tenant override row may not surface a
+        minted/written credential on the feed (G11.7-T1 #1401); the
+        resolver clamps the rule's ``full`` back to ``aggregate`` while
+        still attributing the matched rule in ``origin``.
+        """
+        sessionmaker = get_sessionmaker()
+        async with sessionmaker() as session:
+            tenant_id = await _seed_tenant(session, slug=f"clamp-{expected_class}-{op_id[-6:]}")
+            rule_id = await _seed_override(
+                session,
+                tenant_id=tenant_id,
+                op_id_pattern=op_id,
+                detail="full",
+            )
+
+        op_class, detail, origin = await compute_effective_broadcast_detail(
+            op_id=op_id,
+            tenant_id=tenant_id,
+            raw_params={"data": {"password": "leak-me"}},
+            request_override=None,
+        )
+        assert op_class == expected_class
+        assert detail == "aggregate"
+        assert origin == f"tenant_rule:{rule_id}"
+
+    @pytest.mark.asyncio
     async def test_request_override_ignored_on_non_sensitive_class(self) -> None:
         """``request_override="full"`` on a ``read`` op is a no-op (already full).
 

--- a/backend/tests/test_connectors_vault.py
+++ b/backend/tests/test_connectors_vault.py
@@ -818,7 +818,12 @@ async def test_execute_vault_kv_list_malformed_payload_is_structured_error(
         ("vault.kv.read", "credential_read"),
         ("vault.kv.list", "credential_read"),
         ("vault.kv.versions", "read"),
-        ("vault.kv.put", "write"),
+        # G11.7-T1 #1401 — ``vault.kv.put`` carries the secret ``data`` in
+        # its request params, so it now classifies ``credential_write``
+        # (aggregate-only broadcast) rather than plain ``write`` (which
+        # broadcast the written secret in full). ``vault.kv.delete``
+        # carries no secret and stays ``write``.
+        ("vault.kv.put", "credential_write"),
         ("vault.kv.delete", "write"),
     ],
 )
@@ -827,10 +832,12 @@ def test_kv_op_ids_classify_per_decision_3(op_id: str, expected_class: str) -> N
 
     The shipped G0.6 substrate has no per-row ``op_class`` column on
     ``endpoint_descriptor``; decision #3 locks the sensitivity
-    classifier on the op-id via ``_CREDENTIAL_READ_OPS``. This pins
-    the register-time contract the DoD asks for: ``vault.kv.read`` and
-    ``vault.kv.list`` are ``credential_read`` (aggregate-only
-    broadcast); ``vault.kv.versions`` is a plain metadata ``read``;
-    the mutating verbs are ``write``.
+    classifier on the op-id via ``_CREDENTIAL_READ_OPS`` /
+    ``_CREDENTIAL_WRITE_OPS``. This pins the register-time contract the
+    DoD asks for: ``vault.kv.read`` and ``vault.kv.list`` are
+    ``credential_read`` (aggregate-only broadcast); ``vault.kv.versions``
+    is a plain metadata ``read``; ``vault.kv.put`` is
+    ``credential_write`` (its secret ``data`` is in params); the
+    secret-free mutating verbs are ``write``.
     """
     assert classify_op(op_id) == expected_class

--- a/backend/tests/test_examples_r2_approval_gate.py
+++ b/backend/tests/test_examples_r2_approval_gate.py
@@ -164,10 +164,12 @@ async def session() -> AsyncIterator[AsyncSession]:
 def _make_agent_operator(sub: str = _AGENT_SUB) -> Operator:
     """Construct the agent's :class:`Operator`.
 
-    ``principal_kind=AGENT`` is load-bearing — only agent principals reach
-    the ``needs-approval`` branch of the policy gate; humans / service
-    accounts are hard-denied on a ``requires_approval`` op (the v0.2
-    contract preserved by :func:`policy_gate`).
+    ``principal_kind=AGENT`` here is the requester side of this example.
+    Both agent and human/service principals reach the ``needs-approval``
+    branch of the policy gate on a ``requires_approval`` op — the agent
+    via its per-(principal, op, target) verdict floor, the human/service
+    via the G11.7-T1 (#1401) queue-routing change that replaced the old
+    hard-deny. The reviewer in this test is a distinct human principal.
     """
     return Operator(
         sub=sub,

--- a/backend/tests/test_operations_dispatcher.py
+++ b/backend/tests/test_operations_dispatcher.py
@@ -28,8 +28,9 @@ Coverage matrix (G0.6-T5 / Task #396 acceptance criteria):
 * Pass-through reducer: the dispatcher invokes the reducer; the v0.2
   default returns the response unchanged + a ``None`` handle.
 * Handler-import error -> ``handler_unreachable`` error code.
-* Policy gate -- ``requires_approval=True`` -> ``denied`` with the
-  default-allow policy in v0.2.
+* Policy gate -- ``requires_approval=True`` routes a human/service
+  principal to the approval queue (``awaiting_approval``), not a
+  hard-deny (G11.7-T1 #1401); agents floor to ``needs-approval``.
 
 The audit + broadcast assertions read the actual ``audit_log`` rows
 written by the dispatcher (the conftest autouse fixture runs the
@@ -1587,15 +1588,18 @@ async def test_dispatch_human_caution_op_auto_executes(
 
 
 @pytest.mark.asyncio
-async def test_dispatch_human_requires_approval_op_denied(
+async def test_dispatch_human_requires_approval_op_queues(
     stub_embedding_service: AsyncMock,
     captured_events: list[BroadcastEvent],
 ) -> None:
-    """``requires_approval=True`` still hard-denies a **human** (v0.2 contract).
+    """``requires_approval=True`` queues a **human**, not hard-deny (G11.7-T1 #1401).
 
-    The approval queue (G11.2-T4) routes only agent runs to the pending
-    path; human/service principals retain the v0.2 hard-deny so the
-    enforcement signal does not silently disappear.
+    Pre-G11.7 the policy gate hard-denied a human/service principal on a
+    ``requires_approval`` op. G11.7-T1 (#1401) routes them to the
+    approval queue instead — ops-team operators are exactly the humans
+    Phase C expects to run governed writes, so a hard-deny defeated the
+    point. The op is parked + resumable (``awaiting_approval``), not
+    ``denied``.
     """
     register_connector_v2(product="vault", version="", impl_id="", cls=_NoOpVaultConnector)
     await register_typed_operation(
@@ -1605,7 +1609,7 @@ async def test_dispatch_human_requires_approval_op_denied(
         op_id="vault.kv.human_approval",
         handler=_module_handler_returning_dict,
         summary="Safe op flagged requires_approval.",
-        description="requires_approval stays enforced for humans.",
+        description="requires_approval routes humans to the queue.",
         parameter_schema={"type": "object"},
         safety_level="safe",
         requires_approval=True,
@@ -1620,8 +1624,9 @@ async def test_dispatch_human_requires_approval_op_denied(
         target=_FakeTarget(product="vault"),
         params={},
     )
-    assert result.status == "denied"
-    assert result.extras["error_code"] == "denied"
+    assert result.status == "awaiting_approval", result.error
+    assert result.status != "denied"
+    assert "approval_request_id" in result.extras
 
 
 @pytest.mark.asyncio

--- a/backend/tests/test_targets_resolver.py
+++ b/backend/tests/test_targets_resolver.py
@@ -27,6 +27,7 @@ from __future__ import annotations
 
 import uuid
 from collections.abc import Iterator
+from datetime import UTC, datetime
 
 import pytest
 from sqlalchemy.exc import IntegrityError
@@ -38,6 +39,7 @@ from meho_backplane.targets.resolver import (
     AmbiguousTargetError,
     TargetNotFoundError,
     resolve_target,
+    resolve_target_by_id,
 )
 
 
@@ -441,3 +443,87 @@ async def test_resolve_target_near_misses_exclude_soft_deleted() -> None:
     matches = exc_info.value.detail["matches"]
     names = {m["name"] for m in matches}
     assert names == {"rke2-infra-k8s"}
+
+
+# ---------------------------------------------------------------------------
+# resolve_target_by_id — the approval-queue resume path (G11.7-T1 #1401)
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.asyncio
+async def test_resolve_target_by_id_returns_live_row() -> None:
+    """A live row resolves by id within the tenant."""
+    sessionmaker = get_sessionmaker()
+    tenant_id = uuid.uuid4()
+    target = _make_target(
+        tenant_id=tenant_id, name="prod-vault", product="vault", host="vault.prod.invalid"
+    )
+    target_id = target.id
+
+    async with sessionmaker() as session:
+        session.add(target)
+        await session.commit()
+
+    async with sessionmaker() as session:
+        result = await resolve_target_by_id(session, tenant_id, target_id)
+
+    assert result is not None
+    assert result.id == target_id
+    assert result.name == "prod-vault"
+
+
+@pytest.mark.asyncio
+async def test_resolve_target_by_id_wrong_tenant_returns_none() -> None:
+    """Cross-tenant id is invisible — returns None (tenant isolation)."""
+    sessionmaker = get_sessionmaker()
+    tenant_a = uuid.uuid4()
+    tenant_b = uuid.uuid4()
+    target = _make_target(tenant_id=tenant_a, name="a-only", product="ssh", host="10.0.0.1")
+    target_id = target.id
+
+    async with sessionmaker() as session:
+        session.add(target)
+        await session.commit()
+
+    async with sessionmaker() as session:
+        result = await resolve_target_by_id(session, tenant_b, target_id)
+
+    assert result is None
+
+
+@pytest.mark.asyncio
+async def test_resolve_target_by_id_missing_returns_none() -> None:
+    """An unknown id returns None rather than raising."""
+    sessionmaker = get_sessionmaker()
+    async with sessionmaker() as session:
+        result = await resolve_target_by_id(session, uuid.uuid4(), uuid.uuid4())
+    assert result is None
+
+
+@pytest.mark.asyncio
+async def test_resolve_target_by_id_soft_deleted_returns_none() -> None:
+    """A soft-deleted target resolves to None — fail closed on resume.
+
+    A target tombstoned between approval-request and approval-decision
+    must not be revived on the resume re-dispatch; the caller gets None
+    and the dispatch fails closed (structured connector error).
+    """
+    sessionmaker = get_sessionmaker()
+    tenant_id = uuid.uuid4()
+    target = _make_target(
+        tenant_id=tenant_id,
+        name="retired-target",
+        product="ssh",
+        host="10.0.0.9",
+        deleted_at=datetime.now(UTC),
+    )
+    target_id = target.id
+
+    async with sessionmaker() as session:
+        session.add(target)
+        await session.commit()
+
+    async with sessionmaker() as session:
+        result = await resolve_target_by_id(session, tenant_id, target_id)
+
+    assert result is None

--- a/cli/api/openapi.json
+++ b/cli/api/openapi.json
@@ -6212,7 +6212,7 @@
           "approvals"
         ],
         "summary": "Approve Approval Request",
-        "description": "Approve a pending request and re-dispatch the original operation.\n\nThe ``params`` body must be the original params unchanged; the service\nre-hashes them and rejects with 422 on a mismatch. On a successful\napproval the original dispatch is re-executed and the result returned.\n\nHTTP status codes:\n\n* 200 \u2014 approved + re-dispatched successfully.\n* 403 \u2014 operator lacks ``operator`` role.\n* 404 \u2014 request not found (or belongs to another tenant).\n* 409 \u2014 request is already decided.\n* 422 \u2014 params hash mismatch.",
+        "description": "Approve a pending request and re-dispatch the original operation.\n\nThe ``params`` body must be the original params unchanged; the service\nre-hashes them and rejects with 422 on a mismatch. On a successful\napproval the original dispatch is re-executed and the result returned.\n\nHTTP status codes:\n\n* 200 \u2014 approved + re-dispatched successfully.\n* 403 \u2014 operator lacks ``operator`` role, **or** the approver is the\n  requester and self-approval break-glass is disabled (G11.7-T1 #1401).\n* 404 \u2014 request not found (or belongs to another tenant).\n* 409 \u2014 request is already decided.\n* 422 \u2014 params hash mismatch.",
         "operationId": "approve_approval_request_api_v1_approvals__request_id__approve_post",
         "parameters": [
           {

--- a/docs/codebase/approvals.md
+++ b/docs/codebase/approvals.md
@@ -1,12 +1,15 @@
-# Approvals (G11.2-T4 + T5)
+# Approvals (G11.2-T4 + T5; G11.7-T1 policy hardening)
 
-**Initiative:** #803 — G11.2 Agent identity + RBAC + approval
-**Tasks:** #817 (T4 — durable approval queue) + #818 (T5 — operator surfacing channel)
+**Initiative:** #803 — G11.2 Agent identity + RBAC + approval;
+#1397 — G11.7 Approval-policy hardening
+**Tasks:** #817 (T4 — durable approval queue) + #818 (T5 — operator
+surfacing channel) + #1401 (G11.7-T1 — queue humans, self-approval
+guard, resume-target fix, write-op secret redaction)
 
 ## Overview
 
 The approval substrate parks `requires_approval` / `caution` / `dangerous`
-agent dispatches durably and lets an operator approve or reject them
+dispatches durably and lets an operator approve or reject them
 across **REST, MCP, and CLI** transports. Two layers, one source of
 truth:
 
@@ -27,6 +30,61 @@ truth:
 The durable state is one `approval_request` row (table created by
 `backend/alembic/versions/0023_create_approval_request.py`, T4 #817).
 
+## G11.7-T1 policy hardening (#1401)
+
+Phase C of the wrapper-retirement effort moves connector **writes**
+behind this queue, and ops-team operators run those writes as **human**
+(`USER`) principals. Four policy changes harden the gate for that — all
+reusing the existing queue/approve/resume substrate (no new table,
+model, or resume endpoint):
+
+1. **Queue humans, don't hard-deny.** `policy_gate`
+   (`backend/src/meho_backplane/operations/_validate.py`) returns
+   `NEEDS_APPROVAL` — not `DENY` — when a non-agent principal hits a
+   `requires_approval=True` op. The op is parked + resumable, not
+   denied to the operator meant to run it. Non-`requires_approval` ops a
+   human has always been able to run still auto-execute (the v0.2
+   default-allow is preserved), so no existing human-runnable op
+   regresses.
+2. **Self-approval guard (requester != approver).** `approve_request`
+   raises `SelfApprovalForbiddenError` (→ HTTP 403 `self_approval_forbidden`
+   on REST, invalid-params on MCP) when `operator.sub ==
+   request.principal_sub`, unless the audited break-glass switch
+   `APPROVAL_ALLOW_SELF_APPROVAL=true`
+   (`Settings.approval_allow_self_approval`, default `False` =
+   fail-closed) is set. Even under break-glass the self-approval writes
+   its decision audit row, so the use is forensically visible. **Reject
+   is unguarded** — withdrawing one's own pending request is never a
+   privilege escalation. The guard runs after the role check and before
+   the params-hash check, so a self-approver gets the precise refusal
+   reason.
+3. **Resume target re-hydration.** The REST `…/approve` route persists
+   only `target_id` on the row, so it re-loads the live `Target` by id
+   (`targets.resolver.resolve_target_by_id`, tenant-scoped, `deleted_at
+   IS NULL`) before the `_approved=True` re-dispatch. A write op whose
+   handler reads `target.host` / `target.name` / `target.fqdn` now
+   resolves the correct target instead of `None`. A target soft-deleted
+   between request and approval resolves to `None`, so the re-dispatch
+   fails closed (structured connector error) rather than reviving a
+   tombstone. Tenant-wide ops (no original target) keep `target_id IS
+   NULL` → `None`.
+4. **Write-op secret redaction.** The broadcast/audit sensitivity
+   classifier gained two op-id classes so the new Phase-C write ops'
+   secrets never land in an audit row or broadcast frame —
+   `credential_write` for request-param secrets (`vault.kv.put`,
+   `vault.auth.userpass.write` / `update_password`, `k8s.secret.create`)
+   and `credential_mint` extended for response secrets
+   (`vault.token.create`, `vault.auth.approle.generate_secret_id`). Both
+   collapse to aggregate-only and are **non-upgradeable** — no per-call
+   or per-tenant override may surface the credential on the feed. See
+   `docs/codebase/broadcast.md`.
+
+The `_approved=True` re-dispatch gate-bypass (the resume authorization)
+is unchanged in mechanism but now matters for humans too: with humans
+routed to `NEEDS_APPROVAL`, re-running the gate on resume would re-queue
+the call instead of executing it, so the bypass is what lets the
+approved op run.
+
 ## Transports
 
 ### REST (`backend/src/meho_backplane/api/v1/approvals.py`)
@@ -35,7 +93,7 @@ The durable state is one `approval_request` row (table created by
 |---|---|---|---|
 | `GET` | `/api/v1/approvals` | operator | List, filtered by `status` (default: `pending`). |
 | `GET` | `/api/v1/approvals/{id}` | operator | **Inspect one request** (T5). 404 on cross-tenant. |
-| `POST` | `/api/v1/approvals/{id}/approve` | operator | Approve. Requires `params` (hash-verified) → re-dispatches the approved op with `dispatch(..., _approved=True)`. |
+| `POST` | `/api/v1/approvals/{id}/approve` | operator | Approve. Requires `params` (hash-verified). Re-hydrates the target by id, then re-dispatches with `dispatch(..., _approved=True)`. 403 `self_approval_forbidden` when the approver is the requester and break-glass is off (G11.7-T1). |
 | `POST` | `/api/v1/approvals/{id}/reject` | operator | Reject. The op never executes. |
 
 ### MCP (`backend/src/meho_backplane/mcp/tools/approvals.py`)

--- a/docs/codebase/broadcast.md
+++ b/docs/codebase/broadcast.md
@@ -57,6 +57,29 @@ Three layers, separated for traceability:
   Fields: `tenant_id`, `principal_sub`, `activity`, `target`,
   `scope`, `phase`. `event_kind = "agent_announcement"` discriminator
   so readers can dispatch on the kind.
+- `op_class` sensitivity taxonomy (`classify_op` / `redact_payload` in
+  `broadcast/events.py`) — derived from the op-id (no per-descriptor
+  column), drives how `payload` is redacted before publish:
+  - `read` / `write` — full detail (params pass through).
+  - `credential_read` (`vault.kv.read` / `.list`) — aggregate-only;
+    even the path string is withheld.
+  - `audit_query` (`audit.*` / `meho.audit.*`) — aggregate-only +
+    `row_count`; the query filter never broadcasts.
+  - `credential_mint` (`harbor.robot.create`, `vault.token.create`,
+    `vault.auth.approle.generate_secret_id`) — **response** carries a
+    freshly-minted secret; aggregate-only.
+  - `credential_write` (`vault.kv.put`, `vault.auth.userpass.write` /
+    `.update_password`, `k8s.secret.create`, G11.7-T1 #1401) —
+    **request params** carry the secret; aggregate-only.
+  - `other` — full detail.
+
+  `credential_read` and `audit_query` are *upgradeable*: a per-call or
+  per-tenant override may surface full detail to an operator who already
+  has the right to see the path/filter (G6.3 #379). `credential_mint`
+  and `credential_write` are *non-upgradeable* — they carry secret
+  material, so no override path (`compute_effective_broadcast_detail` in
+  `broadcast/overrides.py`) may upgrade them to full; a `full` tenant
+  rule on these classes is clamped back to aggregate.
 - `Operator` (`auth/operator.py`) — the JWT-bound principal the SSE
   feed reads its `tenant_id` from. UUID.
 - `UISessionContext` (`ui/auth/middleware.py`) — the session-cookie

--- a/docs/codebase/connectors-vault.md
+++ b/docs/codebase/connectors-vault.md
@@ -263,7 +263,8 @@ and a real Postgres audit store (reusing the integration conftest's
   unwrap → dispatcher → audit → broadcast path runs unchanged.
 - **Assertions.** Each op asserts the live response shape, a single
   synchronously-committed `audit_log` row (postulate 7), and the
-  broadcast `op_class` — `write` for `kv.put` / `kv.delete`,
+  broadcast `op_class` — `credential_write` for `kv.put` (G11.7-T1
+  #1401) and `write` for `kv.delete`,
   `credential_read` for `kv.read` / `kv.list`, `read` for the
   KV-v2 / sys metadata reads and the `.list` auth ops
   (`auth.userpass.list` / `auth.approle.list`), and `other` for the

--- a/docs/codebase/connectors-vault.md
+++ b/docs/codebase/connectors-vault.md
@@ -84,7 +84,7 @@ Source: `backend/src/meho_backplane/connectors/vault/`.
 | `vault.kv.read` | `read_secret_version` | safe | `credential_read` |
 | `vault.kv.list` | `list_secrets` | safe | `credential_read` |
 | `vault.kv.versions` | `read_secret_metadata` | safe | `read` |
-| `vault.kv.put` | `create_or_update_secret` | caution | `write` |
+| `vault.kv.put` | `create_or_update_secret` | caution | `credential_write` |
 | `vault.kv.delete` | `delete_secret_versions` | dangerous | `write` |
 
 All five register into operation group `kv`.
@@ -120,16 +120,26 @@ The G6 broadcast publisher emits an aggregate-only payload for
 `credential_read` and `audit_query` ops. The sensitivity class is
 derived **from the op-id**, not a per-descriptor field:
 `broadcast.events.classify_op` consults the `_CREDENTIAL_READ_OPS`
-allowlist (currently `{vault.kv.read, vault.kv.list}`) and the
-`_WRITE_SUFFIXES` / `_READ_SUFFIXES` tuples. The shipped G0.6
-`endpoint_descriptor` table has **no `op_class` column** — decision #3
-locks the classifier on the op-id, so the register-time signal is the
-op-id itself. `vault.kv.versions` reads only version metadata (never
-secret values) and is deliberately a plain `read`, not
-`credential_read`. The `.put` / `.versions` suffixes were added to the
-write / read suffix tuples by #545 — without that, `vault.kv.put`
-would have classified `other` and broadcast the written secret to
-every operator (the credential-leak fix).
+allowlist (currently `{vault.kv.read, vault.kv.list}`), the
+`_CREDENTIAL_WRITE_OPS` allowlist (G11.7-T1 #1401 — `{vault.kv.put,
+vault.auth.userpass.write, vault.auth.userpass.update_password,
+k8s.secret.create}`), and the `_WRITE_SUFFIXES` / `_READ_SUFFIXES`
+tuples. The shipped G0.6 `endpoint_descriptor` table has **no
+`op_class` column** — decision #3 locks the classifier on the op-id, so
+the register-time signal is the op-id itself. `vault.kv.versions` reads
+only version metadata (never secret values) and is deliberately a plain
+`read`, not `credential_read`.
+
+`vault.kv.put` classifies `credential_write` (G11.7-T1 #1401): the
+secret `data` is in the *request params*, and the broadcast ships
+params, so it must collapse to aggregate-only. It previously
+classified plain `write` via the `.put` write-suffix (#545), which kept
+it out of the `other` class but still broadcast the written secret in
+full — the `credential_write` reclassification closes that. Response-side
+secret-mint ops (`vault.token.create`,
+`vault.auth.approle.generate_secret_id`) classify `credential_mint`
+alongside `harbor.robot.create`. See `docs/codebase/broadcast.md` for
+the full sensitivity taxonomy.
 
 ## Approval gating
 


### PR DESCRIPTION
## Summary
- Routes a **human/service** principal hitting a `requires_approval=True` op to the approval **queue** (`NEEDS_APPROVAL`) instead of a hard `DENY` — Phase-C ops-team operators run as `USER` principals, so the old hard-deny returned `denied` to the very people meant to run governed writes. One-branch policy change reusing the existing queue/approve/resume substrate (no new table/model/endpoint).
- Enforces **requester ≠ approver** in `approve_request` (`SelfApprovalForbiddenError` → 403 REST / invalid-params MCP), with an audited fail-closed break-glass (`APPROVAL_ALLOW_SELF_APPROVAL`, default `False`). Reject stays unguarded; break-glass self-approvals still write their decision audit row.
- Hardens the REST approve **resume target**: re-hydrates the stored `target_id` (`resolve_target_by_id`, tenant-scoped, `deleted_at IS NULL`) before the `_approved=True` re-dispatch, so a write op whose handler reads `target.host/name/fqdn` resolves correctly instead of receiving `None`; soft-deleted targets fail closed.
- Extends broadcast/audit **secret redaction**: new `credential_write` class (request-param secrets — `vault.kv.put`, `vault.auth.userpass.write`/`update_password`, `k8s.secret.create`) and `credential_mint` extended for response secrets (`vault.token.create`, `vault.auth.approle.generate_secret_id`). Both aggregate-only and **non-upgradeable** by any override (also fixes a latent gap where `credential_mint` was missing from the override resolver's sensitive set).

## Test plan
- [x] `ruff check src/ tests/` — clean
- [x] `ruff format --check` (touched files) — clean
- [x] `mypy src/meho_backplane/ --ignore-missing-imports` — 395 files, clean
- [x] `code-quality.py --diff` — 0 blockers
- [x] Full non-integration suite — 6120 passed, 194 skipped (2 stale-contract tests updated to the new behavior)
- [x] **AC1** queued-not-denied: `test_dispatch_human_requires_approval_op_queues` + `test_human_requires_approval_queues_not_denies` (full USER round-trip: queue → approve → resume → execute)
- [x] **AC2** self-approval: `test_self_approval_forbidden_by_default`, `test_self_approval_allowed_under_break_glass` (still audited), `test_self_reject_is_always_allowed`
- [x] **AC3** resume target: `test_resolve_target_by_id_*` (live / wrong-tenant / missing / soft-deleted) + the round-trip handler reads `target.name`
- [x] **AC4** redaction: `test_broadcast_credential_write_dispatch` (dispatch-path capture, secret sentinel absent), `redact_payload`/`classify_op` unit tests, override resolver non-upgrade + tenant-rule-clamp tests
- [x] **AC5** no new queue infra — reuses `create_pending_request` / `approve_request` / `_approved` resume

## Out of scope
- The connector handlers for the new write ops (`vault.token.create`, `k8s.secret.create`, etc.) — this Task hardens the classifier/gate so those ops are safe-by-construction when their per-connector slices land (#1387 / #1388).
- HTML approve UI and topology/blast-radius policy (explicitly out of scope per the Initiative).

<!-- auto-implement-issue: fresh, iteration 1 -->

Closes #1401


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

# Release Notes

* **New Features**
  * Added self-approval restrictions for approval requests with optional break-glass control via configuration setting.
  * Enhanced secret redaction in audit logs and broadcast events—credential-related write operations now automatically redact sensitive payloads.
  * Improved approval workflow: human operators hitting approval-required operations are now routed to the approval queue instead of being denied.

* **Bug Fixes**
  * Fixed approval resume flow to properly re-hydrate dispatch targets before execution.

* **Documentation**
  * Updated approval and broadcast documentation to reflect policy hardening and secret-handling improvements.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->