### PR TITLE
feat(connectors): G3.14-T1 k8s single-call write ops (approval-gated)

### DIFF
--- a/backend/src/meho_backplane/broadcast/events.py
+++ b/backend/src/meho_backplane/broadcast/events.py
@@ -120,12 +120,16 @@ _CREDENTIAL_MINT_OPS: Final[frozenset[str]] = frozenset(
 #:   leak — see ``docs/codebase/connectors-vault.md``).
 #: * ``k8s.secret.create`` — the Secret ``data`` / ``stringData`` is in
 #:   ``params``.
+#: * ``k8s.job.create`` — the Job ``spec`` carries a pod template whose
+#:   inline ``env`` entries can hold credential material in ``params``
+#:   (G3.14-T1 #1403).
 _CREDENTIAL_WRITE_OPS: Final[frozenset[str]] = frozenset(
     {
         "vault.auth.userpass.write",
         "vault.auth.userpass.update_password",
         "vault.kv.put",
         "k8s.secret.create",
+        "k8s.job.create",
     }
 )
 

--- a/backend/src/meho_backplane/connectors/kubernetes/connector.py
+++ b/backend/src/meho_backplane/connectors/kubernetes/connector.py
@@ -1052,6 +1052,120 @@ class KubernetesConnector(Connector):
 
         return await _k8s_deployment_info(self, target, operator, params)
 
+    async def k8s_scale(
+        self,
+        operator: Operator,
+        target: KubernetesTargetLike,
+        params: dict[str, Any],
+    ) -> dict[str, Any]:
+        """Bound-method shim for ``k8s.scale`` (G3.14-T1 #1403)."""
+        from meho_backplane.connectors.kubernetes.ops_write import k8s_scale
+
+        return await k8s_scale(self, target, operator, params)
+
+    async def k8s_rollout_restart(
+        self,
+        operator: Operator,
+        target: KubernetesTargetLike,
+        params: dict[str, Any],
+    ) -> dict[str, Any]:
+        """Bound-method shim for ``k8s.rollout.restart`` (G3.14-T1 #1403)."""
+        from meho_backplane.connectors.kubernetes.ops_write import k8s_rollout_restart
+
+        return await k8s_rollout_restart(self, target, operator, params)
+
+    async def k8s_namespace_create(
+        self,
+        operator: Operator,
+        target: KubernetesTargetLike,
+        params: dict[str, Any],
+    ) -> dict[str, Any]:
+        """Bound-method shim for ``k8s.namespace.create`` (G3.14-T1 #1403)."""
+        from meho_backplane.connectors.kubernetes.ops_write import k8s_namespace_create
+
+        return await k8s_namespace_create(self, target, operator, params)
+
+    async def k8s_annotate(
+        self,
+        operator: Operator,
+        target: KubernetesTargetLike,
+        params: dict[str, Any],
+    ) -> dict[str, Any]:
+        """Bound-method shim for ``k8s.annotate`` (G3.14-T1 #1403)."""
+        from meho_backplane.connectors.kubernetes.ops_write import k8s_annotate
+
+        return await k8s_annotate(self, target, operator, params)
+
+    async def k8s_label(
+        self,
+        operator: Operator,
+        target: KubernetesTargetLike,
+        params: dict[str, Any],
+    ) -> dict[str, Any]:
+        """Bound-method shim for ``k8s.label`` (G3.14-T1 #1403)."""
+        from meho_backplane.connectors.kubernetes.ops_write import k8s_label
+
+        return await k8s_label(self, target, operator, params)
+
+    async def k8s_cordon(
+        self,
+        operator: Operator,
+        target: KubernetesTargetLike,
+        params: dict[str, Any],
+    ) -> dict[str, Any]:
+        """Bound-method shim for ``k8s.cordon`` (G3.14-T1 #1403)."""
+        from meho_backplane.connectors.kubernetes.ops_write import k8s_cordon
+
+        return await k8s_cordon(self, target, operator, params)
+
+    async def k8s_apply(
+        self,
+        operator: Operator,
+        target: KubernetesTargetLike,
+        params: dict[str, Any],
+    ) -> dict[str, Any]:
+        """Bound-method shim for ``k8s.apply`` (G3.14-T1 #1403)."""
+        from meho_backplane.connectors.kubernetes.ops_write_dangerous import k8s_apply
+
+        return await k8s_apply(self, target, operator, params)
+
+    async def k8s_delete(
+        self,
+        operator: Operator,
+        target: KubernetesTargetLike,
+        params: dict[str, Any],
+    ) -> dict[str, Any]:
+        """Bound-method shim for ``k8s.delete`` (G3.14-T1 #1403)."""
+        from meho_backplane.connectors.kubernetes.ops_write_dangerous import k8s_delete
+
+        return await k8s_delete(self, target, operator, params)
+
+    async def k8s_secret_create(
+        self,
+        operator: Operator,
+        target: KubernetesTargetLike,
+        params: dict[str, Any],
+    ) -> dict[str, Any]:
+        """Bound-method shim for ``k8s.secret.create`` (G3.14-T1 #1403)."""
+        from meho_backplane.connectors.kubernetes.ops_write_dangerous import (
+            k8s_secret_create,
+        )
+
+        return await k8s_secret_create(self, target, operator, params)
+
+    async def k8s_job_create(
+        self,
+        operator: Operator,
+        target: KubernetesTargetLike,
+        params: dict[str, Any],
+    ) -> dict[str, Any]:
+        """Bound-method shim for ``k8s.job.create`` (G3.14-T1 #1403)."""
+        from meho_backplane.connectors.kubernetes.ops_write_dangerous import (
+            k8s_job_create,
+        )
+
+        return await k8s_job_create(self, target, operator, params)
+
     @classmethod
     async def register_operations(cls) -> None:
         """Upsert every op in :data:`KUBERNETES_OPS` into ``endpoint_descriptor``.

--- a/backend/src/meho_backplane/connectors/kubernetes/ops.py
+++ b/backend/src/meho_backplane/connectors/kubernetes/ops.py
@@ -205,6 +205,10 @@ def _kubernetes_ops() -> tuple[KubernetesOp, ...]:
     )
     from meho_backplane.connectors.kubernetes.ops_network import NETWORK_OPS
     from meho_backplane.connectors.kubernetes.ops_workload import WORKLOAD_OPS
+    from meho_backplane.connectors.kubernetes.ops_write_meta import (
+        WRITE_CAUTION_OPS,
+        WRITE_DANGEROUS_OPS,
+    )
 
     logs_op = KubernetesOp(
         op_id="k8s.logs",
@@ -245,6 +249,8 @@ def _kubernetes_ops() -> tuple[KubernetesOp, ...]:
         *CONFIG_OPS,
         *EVENT_OPS,
         logs_op,
+        *WRITE_CAUTION_OPS,
+        *WRITE_DANGEROUS_OPS,
     )
 
 

--- a/backend/src/meho_backplane/connectors/kubernetes/ops_write.py
+++ b/backend/src/meho_backplane/connectors/kubernetes/ops_write.py
@@ -1,0 +1,358 @@
+# SPDX-License-Identifier: Apache-2.0
+# Copyright (c) 2026 evoila Group
+
+"""Caution-class single-call write ops for :class:`KubernetesConnector`.
+
+G3.14-T1 (#1403) of Initiative #1398. The connector shipped read-only;
+this module lands the lower-blast-radius write surface (everything that
+is reversible or idempotent):
+
+* ``k8s.scale`` -- set a Deployment's replica count via the ``/scale``
+  subresource (``AppsV1Api.patch_namespaced_deployment_scale``). The
+  result carries before/after replica counts so the approval reviewer
+  and the audit row both record the delta.
+* ``k8s.rollout.restart`` -- stamp the
+  ``kubectl.kubernetes.io/restartedAt`` pod-template annotation on a
+  Deployment, which the Deployment controller treats as a template
+  change and rolls every pod. Mirrors ``kubectl rollout restart``.
+* ``k8s.namespace.create`` -- create-or-ignore-409. Idempotent: a
+  re-create against an existing namespace returns ``created=False``
+  rather than erroring, so the op is safe to retry.
+* ``k8s.annotate`` / ``k8s.label`` -- generic strategic-merge patch of
+  ``metadata.annotations`` / ``metadata.labels`` over a kind→method
+  dispatch table. A ``null`` value removes the key (kubectl's
+  ``key-`` syntax). Relabeling a Service's selector-matched workload
+  can change traffic routing -- the op stays ``caution`` for that
+  reason, documented in the llm_instructions.
+* ``k8s.cordon`` -- toggle a Node's ``spec.unschedulable`` flag via
+  ``CoreV1Api.patch_node``. Reversible (``uncordon=true`` flips it
+  back). No eviction -- that is ``k8s.drain``, deferred.
+
+All ops are ``requires_approval=True``; once #1401's human-queue routing
+is live a human caller's dispatch is parked for approval rather than
+denied. The dangerous-class writes (apply / delete / secret.create /
+job.create) live in :mod:`ops_write_dangerous`. This module holds only
+the caution-class handlers + their kind dispatch table; the declarative
+op-registration rows + JSON-Schema parameter shapes for *all* write ops
+live in :mod:`ops_write_meta` (split out to keep each file under the
+600-line code-quality cap and to read the operator-facing surface in one
+place).
+
+References
+----------
+* Parent task: G3.14-T1 (#1403); Initiative G3.14 (#1398).
+* ``kubernetes_asyncio.AppsV1Api`` /
+  ``kubernetes_asyncio.CoreV1Api`` (35.0.1):
+  https://github.com/tomplus/kubernetes_asyncio/tree/master/kubernetes_asyncio/docs
+* Deployment ``/scale`` subresource:
+  https://kubernetes.io/docs/reference/kubernetes-api/workload-resources/deployment-v1/#DeploymentSpec
+* Rollout-restart annotation contract (kubectl parity):
+  https://kubernetes.io/docs/reference/generated/kubectl/kubectl-commands#rollout
+"""
+
+from __future__ import annotations
+
+from datetime import UTC, datetime
+from typing import TYPE_CHECKING, Any
+
+from kubernetes_asyncio import client
+
+if TYPE_CHECKING:
+    from meho_backplane.auth.operator import Operator
+    from meho_backplane.connectors.kubernetes.connector import KubernetesConnector
+    from meho_backplane.connectors.kubernetes.kubeconfig import KubernetesTargetLike
+
+__all__ = [
+    "ANNOTATABLE_KINDS",
+    "RESTART_ANNOTATION",
+    "UnsupportedKindError",
+    "k8s_annotate",
+    "k8s_cordon",
+    "k8s_label",
+    "k8s_namespace_create",
+    "k8s_rollout_restart",
+    "k8s_scale",
+]
+
+
+#: The pod-template annotation ``kubectl rollout restart`` stamps to
+#: trigger a rolling restart. Writing a fresh timestamp here is a
+#: template mutation the Deployment controller observes and rolls.
+RESTART_ANNOTATION: str = "kubectl.kubernetes.io/restartedAt"
+
+
+#: kind -> (api-attr, read-method, patch-method) for the generic
+#: annotate/label patch surface. Kept deliberately small in v1 -- the
+#: kinds an operator routinely annotates/labels (Deployment / Pod /
+#: Service / Namespace / Node). ``api_attr`` is the
+#: :class:`KubernetesConnector`-resolved API object; the read/patch
+#: method names are looked up on it via ``getattr`` so a typo surfaces
+#: as a structured error rather than an opaque ``AttributeError``.
+ANNOTATABLE_KINDS: dict[str, dict[str, str]] = {
+    "deployment": {
+        "api": "AppsV1Api",
+        "patch": "patch_namespaced_deployment",
+        "namespaced": "true",
+    },
+    "pod": {
+        "api": "CoreV1Api",
+        "patch": "patch_namespaced_pod",
+        "namespaced": "true",
+    },
+    "service": {
+        "api": "CoreV1Api",
+        "patch": "patch_namespaced_service",
+        "namespaced": "true",
+    },
+    "namespace": {
+        "api": "CoreV1Api",
+        "patch": "patch_namespace",
+        "namespaced": "false",
+    },
+    "node": {
+        "api": "CoreV1Api",
+        "patch": "patch_node",
+        "namespaced": "false",
+    },
+}
+
+
+class UnsupportedKindError(ValueError):
+    """The requested kind is not in the v1 annotate/label dispatch table.
+
+    Subclasses :class:`ValueError` so the dispatcher's
+    ``connector_error`` envelope carries
+    ``extras.exception_class="UnsupportedKindError"`` and the operator
+    sees the supported-kind list rather than an opaque key error.
+    """
+
+
+def _metadata_patch_body(field: str, entries: dict[str, str | None]) -> dict[str, Any]:
+    """Build the strategic-merge patch body for a metadata map field.
+
+    *field* is ``"annotations"`` or ``"labels"``. A ``None`` value in
+    *entries* deletes the key (the strategic-merge semantics for a map
+    entry set to ``null``), mirroring kubectl's ``key-`` removal syntax.
+    Non-null values are coerced to ``str`` -- the K8s API rejects
+    non-string annotation/label values, and surfacing a clean coercion
+    here beats a 422 from the server.
+    """
+    coerced: dict[str, str | None] = {
+        k: (None if v is None else str(v)) for k, v in entries.items()
+    }
+    return {"metadata": {field: coerced}}
+
+
+async def k8s_scale(
+    connector: KubernetesConnector,
+    target: KubernetesTargetLike,
+    operator: Operator,
+    params: dict[str, Any],
+) -> dict[str, Any]:
+    """Handler for ``k8s.scale``.
+
+    Reads the Deployment's current ``/scale`` subresource to capture the
+    before-count, then patches it to the requested ``replicas``. The
+    response carries ``{name, namespace, replicas_before, replicas_after}``
+    so the audit row and the approval reviewer both see the delta. Uses
+    the dedicated ``/scale`` subresource (not a spec patch) so the op
+    works identically against a Deployment whose replica count is
+    HPA-managed -- the scale subresource is the canonical write surface.
+    """
+    name: str = params["name"]
+    namespace: str = params["namespace"]
+    replicas: int = int(params["replicas"])
+    api_client = await connector._get_api_client(target, operator)
+    apps_v1 = client.AppsV1Api(api_client)
+    current = await apps_v1.read_namespaced_deployment_scale(name=name, namespace=namespace)
+    before = (
+        int(current.spec.replicas)
+        if current.spec is not None and current.spec.replicas is not None
+        else 0
+    )
+    patched = await apps_v1.patch_namespaced_deployment_scale(
+        name=name,
+        namespace=namespace,
+        body={"spec": {"replicas": replicas}},
+    )
+    after = (
+        int(patched.spec.replicas)
+        if patched.spec is not None and patched.spec.replicas is not None
+        else replicas
+    )
+    return {
+        "name": name,
+        "namespace": namespace,
+        "replicas_before": before,
+        "replicas_after": after,
+    }
+
+
+async def k8s_rollout_restart(
+    connector: KubernetesConnector,
+    target: KubernetesTargetLike,
+    operator: Operator,
+    params: dict[str, Any],
+) -> dict[str, Any]:
+    """Handler for ``k8s.rollout.restart``.
+
+    Stamps a fresh RFC3339 timestamp into the Deployment's pod-template
+    ``kubectl.kubernetes.io/restartedAt`` annotation. The Deployment
+    controller treats the template change as a new revision and rolls
+    every pod under the active rollout strategy -- exactly what
+    ``kubectl rollout restart deployment/<name>`` does. The patch
+    targets ``spec.template.metadata.annotations`` (the pod template),
+    not the Deployment's own metadata, so the controller observes it.
+    """
+    name: str = params["name"]
+    namespace: str = params["namespace"]
+    api_client = await connector._get_api_client(target, operator)
+    apps_v1 = client.AppsV1Api(api_client)
+    restarted_at = datetime.now(UTC).strftime("%Y-%m-%dT%H:%M:%SZ")
+    body = {
+        "spec": {
+            "template": {
+                "metadata": {"annotations": {RESTART_ANNOTATION: restarted_at}},
+            }
+        }
+    }
+    await apps_v1.patch_namespaced_deployment(name=name, namespace=namespace, body=body)
+    return {
+        "name": name,
+        "namespace": namespace,
+        "restarted_at": restarted_at,
+    }
+
+
+async def k8s_namespace_create(
+    connector: KubernetesConnector,
+    target: KubernetesTargetLike,
+    operator: Operator,
+    params: dict[str, Any],
+) -> dict[str, Any]:
+    """Handler for ``k8s.namespace.create`` -- idempotent create-or-ignore-409.
+
+    A 409 Conflict (namespace already exists) is swallowed and reported
+    as ``created=False`` so the op is safe to retry and safe to run as
+    a no-op precondition before a deploy. Any other API error
+    propagates to the dispatcher's ``connector_error`` envelope.
+    """
+    from kubernetes_asyncio.client.exceptions import ApiException
+
+    name: str = params["name"]
+    api_client = await connector._get_api_client(target, operator)
+    core_v1 = client.CoreV1Api(api_client)
+    body = client.V1Namespace(metadata=client.V1ObjectMeta(name=name))
+    try:
+        await core_v1.create_namespace(body=body)
+    except ApiException as exc:
+        if exc.status == 409:
+            return {"name": name, "created": False, "already_existed": True}
+        raise
+    return {"name": name, "created": True, "already_existed": False}
+
+
+def _resolve_annotatable(kind: str) -> dict[str, str]:
+    """Look up the dispatch-table row for *kind* or raise.
+
+    Normalises to lower-case so ``Deployment`` and ``deployment`` both
+    resolve. Raises :class:`UnsupportedKindError` listing the supported
+    kinds when the kind is outside the v1 table.
+    """
+    row = ANNOTATABLE_KINDS.get(kind.lower())
+    if row is None:
+        supported = ", ".join(sorted(ANNOTATABLE_KINDS))
+        raise UnsupportedKindError(
+            f"kind {kind!r} is not annotatable/labelable in v1; supported kinds: {supported}"
+        )
+    return row
+
+
+async def _patch_metadata_map(
+    connector: KubernetesConnector,
+    target: KubernetesTargetLike,
+    operator: Operator,
+    params: dict[str, Any],
+    *,
+    field: str,
+) -> dict[str, Any]:
+    """Shared body for :func:`k8s_annotate` and :func:`k8s_label`.
+
+    *field* selects ``"annotations"`` or ``"labels"``. Resolves the
+    kind→API/method row, builds the strategic-merge patch, and invokes
+    the kind-appropriate namespaced / cluster-scoped patch method. The
+    response echoes the applied entries so the audit row records exactly
+    which keys changed.
+    """
+    kind: str = params["kind"]
+    name: str = params["name"]
+    namespace: str | None = params.get("namespace")
+    entries: dict[str, str | None] = dict(params[field])
+    row = _resolve_annotatable(kind)
+
+    api_client = await connector._get_api_client(target, operator)
+    api = getattr(client, row["api"])(api_client)
+    patch_method = getattr(api, row["patch"])
+    body = _metadata_patch_body(field, entries)
+
+    if row["namespaced"] == "true":
+        if not namespace:
+            raise ValueError(f"namespace is required to {field[:-1]} a {kind}")
+        await patch_method(name=name, namespace=namespace, body=body)
+    else:
+        await patch_method(name=name, body=body)
+
+    return {
+        "kind": kind.lower(),
+        "name": name,
+        "namespace": namespace if row["namespaced"] == "true" else None,
+        field: entries,
+    }
+
+
+async def k8s_annotate(
+    connector: KubernetesConnector,
+    target: KubernetesTargetLike,
+    operator: Operator,
+    params: dict[str, Any],
+) -> dict[str, Any]:
+    """Handler for ``k8s.annotate`` -- strategic-merge patch of annotations."""
+    return await _patch_metadata_map(connector, target, operator, params, field="annotations")
+
+
+async def k8s_label(
+    connector: KubernetesConnector,
+    target: KubernetesTargetLike,
+    operator: Operator,
+    params: dict[str, Any],
+) -> dict[str, Any]:
+    """Handler for ``k8s.label`` -- strategic-merge patch of labels.
+
+    Relabeling a workload that a Service selects on (or a Deployment's
+    own selector-matched pods) can silently re-route traffic or orphan
+    pods -- the op stays ``caution`` for that reason.
+    """
+    return await _patch_metadata_map(connector, target, operator, params, field="labels")
+
+
+async def k8s_cordon(
+    connector: KubernetesConnector,
+    target: KubernetesTargetLike,
+    operator: Operator,
+    params: dict[str, Any],
+) -> dict[str, Any]:
+    """Handler for ``k8s.cordon`` -- toggle a Node's ``spec.unschedulable``.
+
+    ``uncordon=true`` flips the flag back to schedulable. Reversible and
+    eviction-free: cordon only stops *new* pods from scheduling; running
+    pods are untouched (draining them is ``k8s.drain``, deferred). The
+    response carries the resulting ``unschedulable`` state so the audit
+    row records the intent unambiguously.
+    """
+    name: str = params["name"]
+    uncordon = bool(params.get("uncordon", False))
+    unschedulable = not uncordon
+    api_client = await connector._get_api_client(target, operator)
+    core_v1 = client.CoreV1Api(api_client)
+    await core_v1.patch_node(name=name, body={"spec": {"unschedulable": unschedulable}})
+    return {"name": name, "unschedulable": unschedulable, "cordoned": unschedulable}

--- a/backend/src/meho_backplane/connectors/kubernetes/ops_write_dangerous.py
+++ b/backend/src/meho_backplane/connectors/kubernetes/ops_write_dangerous.py
@@ -1,0 +1,362 @@
+# SPDX-License-Identifier: Apache-2.0
+# Copyright (c) 2026 evoila Group
+
+"""Dangerous-class single-call write ops for :class:`KubernetesConnector`.
+
+G3.14-T1 (#1403). The higher-blast-radius half of the write surface --
+ops that create or destroy resources, or that carry credential material:
+
+* ``k8s.apply`` -- server-side apply (SSA) over the dynamic client. The
+  manifest is a single- or multi-document YAML/JSON; each doc's GVK is
+  resolved against the cluster's discovery doc
+  (``DynamicClient.resources.get``) and applied with
+  ``field_manager="meho"``. ``dry_run="server"`` runs SSA with the
+  API's ``?dryRun=All`` so the call mutates nothing and returns the
+  would-be object -- the diff-preview the approval reviewer needs. The
+  real apply uses ``dry_run="none"`` (the default).
+* ``k8s.delete`` -- delete by kind/name. **v1 is scoped to
+  pod / job / replicaset only**; namespace / PVC / PV are explicitly
+  rejected (their blast radius -- cascading data loss -- is out of scope
+  for the first write cut). ``propagation_policy`` and
+  ``grace_period_seconds`` are explicit params, not defaulted silently.
+* ``k8s.secret.create`` / ``k8s.job.create`` -- create credential /
+  workload material. Both classify (via
+  :func:`~meho_backplane.broadcast.events.classify_op`) as
+  ``credential_write`` so the broadcast publisher collapses the event to
+  aggregate-only ``{op_class, result_status}`` -- the Secret ``data`` /
+  ``stringData`` (and a Job pod-template's inline ``env`` secrets) never
+  reach the SSE stream or any Slack mirror. The ``OperationResult``
+  returned to the caller still carries a redacted summary; the handlers
+  here never echo the raw secret material back.
+
+All ops are ``requires_approval=True``. This module holds only the
+dangerous-class handlers + the delete dispatch table; the op-registration
+rows + JSON-Schema parameter shapes for *all* write ops live in
+:mod:`ops_write_meta`.
+
+References
+----------
+* Parent task: G3.14-T1 (#1403); Initiative G3.14 (#1398).
+* Server-side apply:
+  https://kubernetes.io/docs/reference/using-api/server-side-apply/
+* ``kubernetes_asyncio.dynamic.DynamicClient`` (35.0.1):
+  https://github.com/tomplus/kubernetes_asyncio/blob/master/kubernetes_asyncio/dynamic/client.py
+* Redaction op-class (reused, not reinvented):
+  :data:`meho_backplane.broadcast.events._CREDENTIAL_WRITE_OPS`
+  (shipped by #1401).
+"""
+
+from __future__ import annotations
+
+from typing import TYPE_CHECKING, Any, cast
+
+import yaml
+from kubernetes_asyncio import client
+from kubernetes_asyncio.dynamic import DynamicClient
+
+if TYPE_CHECKING:
+    from meho_backplane.auth.operator import Operator
+    from meho_backplane.connectors.kubernetes.connector import KubernetesConnector
+    from meho_backplane.connectors.kubernetes.kubeconfig import KubernetesTargetLike
+
+__all__ = [
+    "DELETABLE_KINDS",
+    "FIELD_MANAGER",
+    "ApplyManifestError",
+    "UndeletableKindError",
+    "k8s_apply",
+    "k8s_delete",
+    "k8s_job_create",
+    "k8s_secret_create",
+    "secret_create_summary",
+]
+
+
+#: The field manager SSA records as the owner of the fields meho applies.
+#: A stable, meho-specific manager keeps SSA conflict detection meaningful
+#: -- a later ``kubectl apply`` by a human is a distinct manager and the
+#: API server surfaces the ownership conflict rather than silently
+#: clobbering meho-owned fields.
+FIELD_MANAGER: str = "meho"
+
+
+#: kind -> (api-attr, delete-method) for the v1 delete dispatch table.
+#: Deliberately scoped to ephemeral / recreatable workload objects.
+#: Namespace / PVC / PV are excluded: deleting them cascades to data
+#: loss (every object in a namespace; the bound volume's data) which is
+#: out of scope for the first write cut -- a later sub-task adds them
+#: behind extra guard-rails.
+DELETABLE_KINDS: dict[str, dict[str, str]] = {
+    "pod": {"api": "CoreV1Api", "delete": "delete_namespaced_pod"},
+    "job": {"api": "BatchV1Api", "delete": "delete_namespaced_job"},
+    "replicaset": {"api": "AppsV1Api", "delete": "delete_namespaced_replica_set"},
+}
+
+
+class ApplyManifestError(ValueError):
+    """The apply manifest could not be parsed or is missing required fields.
+
+    Subclasses :class:`ValueError` so the dispatcher's
+    ``connector_error`` envelope tags
+    ``extras.exception_class="ApplyManifestError"`` and the operator
+    sees the parse/validation reason rather than an opaque YAML error.
+    """
+
+
+class UndeletableKindError(ValueError):
+    """The requested delete kind is outside the v1 pod/job/replicaset scope."""
+
+
+def _parse_manifest(manifest: str) -> list[dict[str, Any]]:
+    """Parse a single- or multi-document YAML/JSON manifest into doc dicts.
+
+    ``yaml.safe_load_all`` handles both JSON (a subset of YAML) and
+    multi-doc YAML separated by ``---``. Empty documents (a trailing
+    ``---`` or blank stanza) are dropped. Each surviving doc must be a
+    mapping carrying ``apiVersion`` + ``kind`` + ``metadata.name`` --
+    SSA cannot address an object without them. Raises
+    :class:`ApplyManifestError` on any structural problem.
+    """
+    try:
+        docs = list(yaml.safe_load_all(manifest))
+    except yaml.YAMLError as exc:
+        raise ApplyManifestError(f"manifest is not valid YAML/JSON: {exc}") from exc
+
+    parsed: list[dict[str, Any]] = []
+    for idx, doc in enumerate(docs):
+        if doc is None:
+            continue
+        if not isinstance(doc, dict):
+            raise ApplyManifestError(f"manifest document {idx} is not a mapping")
+        api_version = doc.get("apiVersion")
+        kind = doc.get("kind")
+        name = (doc.get("metadata") or {}).get("name")
+        if not api_version or not kind:
+            raise ApplyManifestError(f"manifest document {idx} is missing apiVersion/kind")
+        if not name:
+            raise ApplyManifestError(
+                f"manifest document {idx} ({api_version}/{kind}) is missing metadata.name"
+            )
+        parsed.append(doc)
+    if not parsed:
+        raise ApplyManifestError("manifest contains no applyable documents")
+    return parsed
+
+
+async def _apply_one(
+    dyn: DynamicClient,
+    doc: dict[str, Any],
+    *,
+    dry_run: bool,
+) -> dict[str, Any]:
+    """Server-side-apply one manifest document, returning a flat summary.
+
+    Resolves the GVK against the cluster's discovery doc, then calls
+    ``server_side_apply`` with ``field_manager="meho"`` and, when
+    *dry_run* is set, the API's ``dry_run="All"`` so nothing is
+    persisted. The returned summary echoes the applied object's identity
+    + the observed ``resourceVersion`` so a multi-doc apply reports
+    per-document outcomes the reviewer can read.
+    """
+    api_version = doc["apiVersion"]
+    kind = doc["kind"]
+    metadata = doc.get("metadata") or {}
+    name = metadata.get("name")
+    namespace = metadata.get("namespace")
+
+    resource = await dyn.resources.get(api_version=api_version, kind=kind)
+    kwargs: dict[str, Any] = {"field_manager": FIELD_MANAGER}
+    if dry_run:
+        # The K8s API spells server dry-run ``dryRun=All``; the
+        # operator-facing param is ``dry_run="server"`` (mapped by the
+        # caller). force_conflicts is left unset -- a dry-run that hits
+        # a field-ownership conflict is signal the reviewer wants.
+        kwargs["dry_run"] = "All"
+    applied = await dyn.server_side_apply(
+        resource,
+        body=doc,
+        name=name,
+        namespace=namespace,
+        **kwargs,
+    )
+    applied_meta = getattr(applied, "metadata", None)
+    return {
+        "api_version": api_version,
+        "kind": kind,
+        "name": name,
+        "namespace": namespace,
+        "resource_version": getattr(applied_meta, "resourceVersion", None),
+        "uid": getattr(applied_meta, "uid", None),
+    }
+
+
+async def k8s_apply(
+    connector: KubernetesConnector,
+    target: KubernetesTargetLike,
+    operator: Operator,
+    params: dict[str, Any],
+) -> dict[str, Any]:
+    """Handler for ``k8s.apply`` -- server-side apply with a dry-run preview.
+
+    Parses the (multi-doc) ``manifest``, resolves each document's GVK via
+    the dynamic client's discovery, and server-side-applies it under the
+    ``meho`` field manager. ``dry_run="server"`` runs every document with
+    the API's ``?dryRun=All`` so the call mutates nothing -- the returned
+    per-document summary is the diff-preview surfaced to the approval
+    reviewer before the real apply. ``dry_run="none"`` (default) persists.
+
+    The dispatcher gates this op behind ``requires_approval=True`` for
+    every principal kind, so a dry-run preview and the real apply are
+    both reviewed -- the dry-run path is the cheap, side-effect-free
+    rehearsal an agent or reviewer runs first.
+    """
+    manifest: str = params["manifest"]
+    dry_run_mode: str = params.get("dry_run", "none")
+    is_dry_run = dry_run_mode == "server"
+    docs = _parse_manifest(manifest)
+
+    api_client = await connector._get_api_client(target, operator)
+    dyn = await DynamicClient(api_client)
+    results = [await _apply_one(dyn, doc, dry_run=is_dry_run) for doc in docs]
+    return {
+        "dry_run": is_dry_run,
+        "field_manager": FIELD_MANAGER,
+        "applied": results,
+        "total": len(results),
+    }
+
+
+async def k8s_delete(
+    connector: KubernetesConnector,
+    target: KubernetesTargetLike,
+    operator: Operator,
+    params: dict[str, Any],
+) -> dict[str, Any]:
+    """Handler for ``k8s.delete`` -- delete a pod/job/replicaset by name.
+
+    v1 is scoped to the :data:`DELETABLE_KINDS` table; any other kind
+    raises :class:`UndeletableKindError` (the schema's ``enum`` already
+    rejects them, so this is defence-in-depth against a schema
+    relaxation). ``propagation_policy`` (Foreground / Background /
+    Orphan) and ``grace_period_seconds`` are forwarded explicitly so the
+    cascade behaviour is never an implicit default -- e.g. deleting a Job
+    with ``propagation_policy="Background"`` reaps its pods, ``Orphan``
+    leaves them.
+    """
+    kind: str = params["kind"]
+    name: str = params["name"]
+    namespace: str = params["namespace"]
+    row = DELETABLE_KINDS.get(kind.lower())
+    if row is None:
+        supported = ", ".join(sorted(DELETABLE_KINDS))
+        raise UndeletableKindError(
+            f"kind {kind!r} cannot be deleted in v1; supported kinds: {supported}"
+        )
+
+    api_client = await connector._get_api_client(target, operator)
+    api = getattr(client, row["api"])(api_client)
+    delete_method = getattr(api, row["delete"])
+    kwargs: dict[str, Any] = {}
+    if params.get("propagation_policy") is not None:
+        kwargs["propagation_policy"] = params["propagation_policy"]
+    if params.get("grace_period_seconds") is not None:
+        kwargs["grace_period_seconds"] = int(params["grace_period_seconds"])
+    await delete_method(name=name, namespace=namespace, **kwargs)
+    return {
+        "kind": kind.lower(),
+        "name": name,
+        "namespace": namespace,
+        "propagation_policy": params.get("propagation_policy"),
+        "grace_period_seconds": params.get("grace_period_seconds"),
+        "deleted": True,
+    }
+
+
+def secret_create_summary(
+    name: str, namespace: str, secret_type: str, data_keys: list[str]
+) -> dict[str, Any]:
+    """Build the no-value summary returned by ``k8s.secret.create``.
+
+    Echoes the secret's identity + type + the *key names* it carries,
+    but **never** the values. This is the response the caller's
+    ``OperationResult`` wraps -- a defence-in-depth complement to the
+    broadcast-layer ``credential_write`` redaction: even the
+    handler-produced result is value-free, so a misconfigured downstream
+    consumer that logs the result still can't leak the secret.
+    """
+    return {
+        "name": name,
+        "namespace": namespace,
+        "type": secret_type,
+        "data_keys": sorted(data_keys),
+        "created": True,
+    }
+
+
+async def k8s_secret_create(
+    connector: KubernetesConnector,
+    target: KubernetesTargetLike,
+    operator: Operator,
+    params: dict[str, Any],
+) -> dict[str, Any]:
+    """Handler for ``k8s.secret.create`` -- create an Opaque (or typed) Secret.
+
+    Accepts ``string_data`` (plaintext, base64-encoded by the API server)
+    and/or ``data`` (already base64-encoded). The values are written to
+    the cluster but never echoed back: the response is
+    :func:`secret_create_summary` (key names only). The op classifies
+    ``credential_write`` so the broadcast event collapses to
+    aggregate-only -- the values in ``params`` never reach the feed.
+    """
+    name: str = params["name"]
+    namespace: str = params["namespace"]
+    secret_type: str = params.get("type", "Opaque")
+    string_data: dict[str, str] = dict(params.get("string_data") or {})
+    data: dict[str, str] = dict(params.get("data") or {})
+
+    api_client = await connector._get_api_client(target, operator)
+    core_v1 = client.CoreV1Api(api_client)
+    body = client.V1Secret(
+        metadata=client.V1ObjectMeta(name=name, namespace=namespace),
+        type=secret_type,
+        string_data=string_data or None,
+        data=data or None,
+    )
+    await core_v1.create_namespaced_secret(namespace=namespace, body=body)
+    return secret_create_summary(name, namespace, secret_type, list(string_data) + list(data))
+
+
+async def k8s_job_create(
+    connector: KubernetesConnector,
+    target: KubernetesTargetLike,
+    operator: Operator,
+    params: dict[str, Any],
+) -> dict[str, Any]:
+    """Handler for ``k8s.job.create`` -- create a batch Job from a manifest.
+
+    The Job is supplied as a manifest dict (``spec`` body) rather than
+    decomposed params -- a Job's pod template is too rich to flatten.
+    The pod template can carry inline ``env`` secret material, so the op
+    classifies ``credential_write`` and the broadcast collapses to
+    aggregate-only. The response echoes the Job's identity only, never
+    the template body.
+    """
+    name: str = params["name"]
+    namespace: str = params["namespace"]
+    job_spec: dict[str, Any] = params["spec"]
+
+    api_client = await connector._get_api_client(target, operator)
+    batch_v1 = client.BatchV1Api(api_client)
+    body: dict[str, Any] = {
+        "apiVersion": "batch/v1",
+        "kind": "Job",
+        "metadata": {"name": name, "namespace": namespace},
+        "spec": job_spec,
+    }
+    # kubernetes_asyncio's typed ``create_namespaced_job`` serialises a
+    # raw dict body verbatim at runtime (``sanitize_for_serialization``
+    # passes dicts through); the typed stub insists on ``V1Job`` so cast
+    # to keep the env-secret-bearing spec opaque without a lossy
+    # field-by-field reconstruction into the model.
+    await batch_v1.create_namespaced_job(namespace=namespace, body=cast("Any", body))
+    return {"name": name, "namespace": namespace, "created": True}

--- a/backend/src/meho_backplane/connectors/kubernetes/ops_write_meta.py
+++ b/backend/src/meho_backplane/connectors/kubernetes/ops_write_meta.py
@@ -1,0 +1,587 @@
+# SPDX-License-Identifier: Apache-2.0
+# Copyright (c) 2026 evoila Group
+
+"""Declarative metadata for the G3.14-T1 (#1403) K8s write ops.
+
+Holds the JSON-Schema parameter shapes, the LLM-instruction blocks, and
+the two :class:`~meho_backplane.connectors.kubernetes.ops.KubernetesOp`
+registration tuples for every single-call write op. Split out of the
+handler modules (:mod:`ops_write` caution / :mod:`ops_write_dangerous`
+dangerous) so each handler file stays under the 600-line code-quality
+cap and so the declarative surface (what the operator/agent sees) reads
+in one place, independent of the imperative handlers.
+
+The op rows reference handlers by ``handler_attr`` (a string resolved
+against :class:`KubernetesConnector` at registration time), so there is
+no import-time coupling from this metadata module back to the handler
+functions -- only to the kind dispatch tables (for the ``enum`` lists),
+which live with their handlers.
+"""
+
+from __future__ import annotations
+
+from typing import Any
+
+from meho_backplane.connectors.kubernetes.ops import KubernetesOp
+from meho_backplane.connectors.kubernetes.ops_write import ANNOTATABLE_KINDS
+from meho_backplane.connectors.kubernetes.ops_write_dangerous import DELETABLE_KINDS
+
+__all__ = ["WRITE_CAUTION_OPS", "WRITE_DANGEROUS_OPS"]
+
+
+_NAME_PROP: dict[str, Any] = {
+    "type": "string",
+    "minLength": 1,
+    "description": "Exact object name (no prefix resolution on write ops).",
+}
+_NAMESPACE_PROP: dict[str, Any] = {
+    "type": "string",
+    "minLength": 1,
+    "description": "Namespace the object lives in.",
+}
+
+
+# ---------------------------------------------------------------------------
+# Caution-class schemas + LLM instructions
+# ---------------------------------------------------------------------------
+
+
+_SCALE_SCHEMA: dict[str, Any] = {
+    "type": "object",
+    "properties": {
+        "name": _NAME_PROP,
+        "namespace": _NAMESPACE_PROP,
+        "replicas": {
+            "type": "integer",
+            "minimum": 0,
+            "maximum": 1000,
+            "description": "Desired replica count. 0 scales the Deployment down to nothing.",
+        },
+    },
+    "required": ["name", "namespace", "replicas"],
+    "additionalProperties": False,
+}
+
+
+_ROLLOUT_RESTART_SCHEMA: dict[str, Any] = {
+    "type": "object",
+    "properties": {"name": _NAME_PROP, "namespace": _NAMESPACE_PROP},
+    "required": ["name", "namespace"],
+    "additionalProperties": False,
+}
+
+
+_NAMESPACE_CREATE_SCHEMA: dict[str, Any] = {
+    "type": "object",
+    "properties": {
+        "name": {
+            "type": "string",
+            "minLength": 1,
+            "maxLength": 63,
+            "pattern": "^[a-z0-9]([-a-z0-9]*[a-z0-9])?$",
+            "description": (
+                "DNS-1123-label namespace name. Idempotent: a 409 is reported, not raised."
+            ),
+        },
+    },
+    "required": ["name"],
+    "additionalProperties": False,
+}
+
+
+_KIND_PROP: dict[str, Any] = {
+    "type": "string",
+    "enum": sorted(ANNOTATABLE_KINDS),
+    "description": "Object kind. v1 supports deployment / pod / service / namespace / node.",
+}
+_ANNOTATIONS_PROP: dict[str, Any] = {
+    "type": "object",
+    "minProperties": 1,
+    "additionalProperties": {"type": ["string", "null"]},
+    "description": (
+        "Key→value map to merge. A null value removes the key (kubectl ``key-`` syntax)."
+    ),
+}
+
+
+_ANNOTATE_SCHEMA: dict[str, Any] = {
+    "type": "object",
+    "properties": {
+        "kind": _KIND_PROP,
+        "name": _NAME_PROP,
+        "namespace": {**_NAMESPACE_PROP, "description": "Required for namespaced kinds."},
+        "annotations": _ANNOTATIONS_PROP,
+    },
+    "required": ["kind", "name", "annotations"],
+    "additionalProperties": False,
+}
+
+
+_LABEL_SCHEMA: dict[str, Any] = {
+    "type": "object",
+    "properties": {
+        "kind": _KIND_PROP,
+        "name": _NAME_PROP,
+        "namespace": {**_NAMESPACE_PROP, "description": "Required for namespaced kinds."},
+        "labels": {
+            **_ANNOTATIONS_PROP,
+            "description": (
+                "Key→value map to merge. A null value removes the key. NOTE: relabeling a "
+                "Service-selected workload can re-route traffic."
+            ),
+        },
+    },
+    "required": ["kind", "name", "labels"],
+    "additionalProperties": False,
+}
+
+
+_CORDON_SCHEMA: dict[str, Any] = {
+    "type": "object",
+    "properties": {
+        "name": {**_NAME_PROP, "description": "Node name."},
+        "uncordon": {
+            "type": "boolean",
+            "default": False,
+            "description": "Pass true to mark the node schedulable again (reverse of cordon).",
+        },
+    },
+    "required": ["name"],
+    "additionalProperties": False,
+}
+
+
+_SCALE_LLM: dict[str, Any] = {
+    "when_to_use": (
+        "Set a Deployment's replica count (scale up/down, or scale to 0 to "
+        "stop a workload without deleting it). Requires approval."
+    ),
+    "parameter_hints": {
+        "name": "Exact Deployment name.",
+        "namespace": "Required.",
+        "replicas": "Target count; 0 stops the Deployment.",
+    },
+    "output_shape": "{name, namespace, replicas_before, replicas_after}.",
+}
+_ROLLOUT_RESTART_LLM: dict[str, Any] = {
+    "when_to_use": (
+        "Trigger a rolling restart of every pod in a Deployment (e.g. to "
+        "pick up a rotated Secret/ConfigMap). Equivalent to "
+        "'kubectl rollout restart'. Requires approval."
+    ),
+    "parameter_hints": {"name": "Exact Deployment name.", "namespace": "Required."},
+    "output_shape": "{name, namespace, restarted_at}.",
+}
+_NAMESPACE_CREATE_LLM: dict[str, Any] = {
+    "when_to_use": (
+        "Create a namespace before deploying into it. Idempotent: a "
+        "pre-existing namespace returns created=false rather than erroring. "
+        "Requires approval."
+    ),
+    "parameter_hints": {"name": "DNS-1123-label namespace name."},
+    "output_shape": "{name, created, already_existed}.",
+}
+_ANNOTATE_LLM: dict[str, Any] = {
+    "when_to_use": (
+        "Add/update/remove annotations on a Deployment/Pod/Service/"
+        "Namespace/Node. A null value removes the key. Requires approval."
+    ),
+    "parameter_hints": {
+        "kind": "One of deployment/pod/service/namespace/node.",
+        "name": "Exact object name.",
+        "namespace": "Required for namespaced kinds (everything except namespace/node).",
+        "annotations": "Map; null value deletes the key.",
+    },
+    "output_shape": "{kind, name, namespace, annotations}.",
+}
+_LABEL_LLM: dict[str, Any] = {
+    "when_to_use": (
+        "Add/update/remove labels on a Deployment/Pod/Service/Namespace/"
+        "Node. CAUTION: relabeling a Service-selected workload can re-route "
+        "traffic. A null value removes the key. Requires approval."
+    ),
+    "parameter_hints": {
+        "kind": "One of deployment/pod/service/namespace/node.",
+        "name": "Exact object name.",
+        "namespace": "Required for namespaced kinds.",
+        "labels": "Map; null value deletes the key.",
+    },
+    "output_shape": "{kind, name, namespace, labels}.",
+}
+_CORDON_LLM: dict[str, Any] = {
+    "when_to_use": (
+        "Mark a Node unschedulable (cordon) so new pods avoid it, e.g. "
+        "before maintenance. Pass uncordon=true to reverse. Eviction-free "
+        "(running pods stay); draining is a separate deferred op. Requires "
+        "approval."
+    ),
+    "parameter_hints": {
+        "name": "Node name.",
+        "uncordon": "true to make the node schedulable again.",
+    },
+    "output_shape": "{name, unschedulable, cordoned}.",
+}
+
+
+WRITE_CAUTION_OPS: tuple[KubernetesOp, ...] = (
+    KubernetesOp(
+        op_id="k8s.scale",
+        handler_attr="k8s_scale",
+        summary="Set a Deployment's replica count via the /scale subresource.",
+        description=(
+            "Reads the Deployment's current /scale subresource for the "
+            "before-count, then patches it to the requested ``replicas`` "
+            "via ``AppsV1Api.patch_namespaced_deployment_scale``. Returns "
+            "{name, namespace, replicas_before, replicas_after}. Requires "
+            "approval; a human caller's dispatch is parked for review."
+        ),
+        parameter_schema=_SCALE_SCHEMA,
+        response_schema=None,
+        group_key="workload",
+        tags=("write", "deployment", "scale"),
+        safety_level="caution",
+        requires_approval=True,
+        llm_instructions=_SCALE_LLM,
+    ),
+    KubernetesOp(
+        op_id="k8s.rollout.restart",
+        handler_attr="k8s_rollout_restart",
+        summary="Roll every pod in a Deployment by stamping the restartedAt annotation.",
+        description=(
+            "Stamps a fresh RFC3339 timestamp into the Deployment's "
+            "pod-template ``kubectl.kubernetes.io/restartedAt`` annotation "
+            "via ``AppsV1Api.patch_namespaced_deployment``; the controller "
+            "rolls every pod under the active strategy. Mirrors 'kubectl "
+            "rollout restart'. Requires approval."
+        ),
+        parameter_schema=_ROLLOUT_RESTART_SCHEMA,
+        response_schema=None,
+        group_key="workload",
+        tags=("write", "deployment", "rollout"),
+        safety_level="caution",
+        requires_approval=True,
+        llm_instructions=_ROLLOUT_RESTART_LLM,
+    ),
+    KubernetesOp(
+        op_id="k8s.namespace.create",
+        handler_attr="k8s_namespace_create",
+        summary="Create a namespace; idempotent (a 409 is reported, not raised).",
+        description=(
+            "Creates a namespace via ``CoreV1Api.create_namespace``. A 409 "
+            "Conflict (already exists) is swallowed and reported as "
+            "created=false so the op is safe to retry and to run as a "
+            "deploy precondition. Requires approval."
+        ),
+        parameter_schema=_NAMESPACE_CREATE_SCHEMA,
+        response_schema=None,
+        group_key="inventory",
+        tags=("write", "namespace"),
+        safety_level="caution",
+        requires_approval=True,
+        llm_instructions=_NAMESPACE_CREATE_LLM,
+    ),
+    KubernetesOp(
+        op_id="k8s.annotate",
+        handler_attr="k8s_annotate",
+        summary="Add/update/remove annotations on a Deployment/Pod/Service/Namespace/Node.",
+        description=(
+            "Strategic-merge patches ``metadata.annotations`` over a "
+            "kind→method dispatch table (v1: deployment / pod / service / "
+            "namespace / node). A null value removes the key (kubectl "
+            "``key-`` syntax). Requires approval."
+        ),
+        parameter_schema=_ANNOTATE_SCHEMA,
+        response_schema=None,
+        group_key="workload",
+        tags=("write", "metadata", "annotate"),
+        safety_level="caution",
+        requires_approval=True,
+        llm_instructions=_ANNOTATE_LLM,
+    ),
+    KubernetesOp(
+        op_id="k8s.label",
+        handler_attr="k8s_label",
+        summary="Add/update/remove labels on a Deployment/Pod/Service/Namespace/Node.",
+        description=(
+            "Strategic-merge patches ``metadata.labels`` over the same "
+            "kind→method dispatch table as ``k8s.annotate``. A null value "
+            "removes the key. NOTE: relabeling a Service-selected workload "
+            "can re-route traffic, hence caution. Requires approval."
+        ),
+        parameter_schema=_LABEL_SCHEMA,
+        response_schema=None,
+        group_key="workload",
+        tags=("write", "metadata", "label"),
+        safety_level="caution",
+        requires_approval=True,
+        llm_instructions=_LABEL_LLM,
+    ),
+    KubernetesOp(
+        op_id="k8s.cordon",
+        handler_attr="k8s_cordon",
+        summary="Mark a Node (un)schedulable. Reversible, eviction-free.",
+        description=(
+            "Toggles a Node's ``spec.unschedulable`` via "
+            "``CoreV1Api.patch_node``. ``uncordon=true`` reverses it. "
+            "Eviction-free -- running pods are untouched (draining is the "
+            "deferred ``k8s.drain``). Requires approval."
+        ),
+        parameter_schema=_CORDON_SCHEMA,
+        response_schema=None,
+        group_key="inventory",
+        tags=("write", "node", "cordon"),
+        safety_level="caution",
+        requires_approval=True,
+        llm_instructions=_CORDON_LLM,
+    ),
+)
+
+
+# ---------------------------------------------------------------------------
+# Dangerous-class schemas + LLM instructions
+# ---------------------------------------------------------------------------
+
+
+_APPLY_SCHEMA: dict[str, Any] = {
+    "type": "object",
+    "properties": {
+        "manifest": {
+            "type": "string",
+            "minLength": 1,
+            "description": (
+                "Single- or multi-document YAML/JSON manifest. Each document "
+                "must carry apiVersion + kind + metadata.name."
+            ),
+        },
+        "dry_run": {
+            "type": "string",
+            "enum": ["none", "server"],
+            "default": "none",
+            "description": (
+                "'server' runs SSA with ?dryRun=All (mutates nothing; returns "
+                "the would-be object as a preview). 'none' persists."
+            ),
+        },
+    },
+    "required": ["manifest"],
+    "additionalProperties": False,
+}
+
+
+_DELETE_SCHEMA: dict[str, Any] = {
+    "type": "object",
+    "properties": {
+        "kind": {
+            "type": "string",
+            "enum": sorted(DELETABLE_KINDS),
+            "description": "v1 supports pod / job / replicaset only.",
+        },
+        "name": _NAME_PROP,
+        "namespace": _NAMESPACE_PROP,
+        "propagation_policy": {
+            "type": "string",
+            "enum": ["Foreground", "Background", "Orphan"],
+            "description": (
+                "Cascade behaviour. Foreground: delete dependents first. "
+                "Background: delete object then reap dependents. Orphan: leave "
+                "dependents. No default -- the API server's per-kind default "
+                "applies when omitted."
+            ),
+        },
+        "grace_period_seconds": {
+            "type": "integer",
+            "minimum": 0,
+            "description": "Override the object's termination grace period. 0 = immediate.",
+        },
+    },
+    "required": ["kind", "name", "namespace"],
+    "additionalProperties": False,
+}
+
+
+_SECRET_CREATE_SCHEMA: dict[str, Any] = {
+    "type": "object",
+    "properties": {
+        "name": _NAME_PROP,
+        "namespace": _NAMESPACE_PROP,
+        "type": {
+            "type": "string",
+            "minLength": 1,
+            "default": "Opaque",
+            "description": "Secret type (Opaque, kubernetes.io/dockerconfigjson, etc.).",
+        },
+        "string_data": {
+            "type": "object",
+            "additionalProperties": {"type": "string"},
+            "description": "Plaintext key→value map; the API server base64-encodes it.",
+        },
+        "data": {
+            "type": "object",
+            "additionalProperties": {"type": "string"},
+            "description": "Already-base64-encoded key→value map.",
+        },
+    },
+    "required": ["name", "namespace"],
+    "anyOf": [{"required": ["string_data"]}, {"required": ["data"]}],
+    "additionalProperties": False,
+}
+
+
+_JOB_CREATE_SCHEMA: dict[str, Any] = {
+    "type": "object",
+    "properties": {
+        "name": _NAME_PROP,
+        "namespace": _NAMESPACE_PROP,
+        "spec": {
+            "type": "object",
+            "minProperties": 1,
+            "description": (
+                "The Job's ``spec`` body (template, backoffLimit, etc.). "
+                "Inline env secrets are redacted from the broadcast."
+            ),
+        },
+    },
+    "required": ["name", "namespace", "spec"],
+    "additionalProperties": False,
+}
+
+
+_APPLY_LLM: dict[str, Any] = {
+    "when_to_use": (
+        "Apply a manifest (replaces 'kubectl apply -f'). Run with "
+        "dry_run='server' first to preview the would-be result with no "
+        "side effects, then dry_run='none' to persist. Requires approval."
+    ),
+    "parameter_hints": {
+        "manifest": "YAML/JSON; multi-doc supported via '---'.",
+        "dry_run": "'server' for a side-effect-free preview; 'none' to apply.",
+    },
+    "output_shape": (
+        "{dry_run, field_manager, applied: [{api_version, kind, name, namespace, "
+        "resource_version, uid}], total}."
+    ),
+}
+_DELETE_LLM: dict[str, Any] = {
+    "when_to_use": (
+        "Delete a pod, job, or replicaset by name. v1 does NOT support "
+        "deleting namespaces/PVCs/PVs. Set propagation_policy + "
+        "grace_period_seconds explicitly to control cascade + termination. "
+        "Requires approval."
+    ),
+    "parameter_hints": {
+        "kind": "pod | job | replicaset.",
+        "name": "Exact object name.",
+        "namespace": "Required.",
+        "propagation_policy": "Foreground | Background | Orphan.",
+        "grace_period_seconds": "0 for immediate deletion.",
+    },
+    "output_shape": "{kind, name, namespace, propagation_policy, grace_period_seconds, deleted}.",
+}
+_SECRET_CREATE_LLM: dict[str, Any] = {
+    "when_to_use": (
+        "Create a Secret. Pass plaintext under string_data (API encodes) or "
+        "pre-encoded under data. Values are NEVER echoed back or broadcast "
+        "(credential_write redaction). Requires approval."
+    ),
+    "parameter_hints": {
+        "name": "Secret name.",
+        "namespace": "Required.",
+        "type": "Opaque by default.",
+        "string_data": "Plaintext key→value.",
+        "data": "Base64-encoded key→value.",
+    },
+    "output_shape": "{name, namespace, type, data_keys, created} -- key names only, no values.",
+}
+_JOB_CREATE_LLM: dict[str, Any] = {
+    "when_to_use": (
+        "Create a batch Job from a spec body. The pod template may carry "
+        "inline env secrets, so the broadcast is redacted "
+        "(credential_write). Requires approval."
+    ),
+    "parameter_hints": {
+        "name": "Job name.",
+        "namespace": "Required.",
+        "spec": "The Job spec (template, backoffLimit, completions, ...).",
+    },
+    "output_shape": "{name, namespace, created} -- spec body is never echoed.",
+}
+
+
+WRITE_DANGEROUS_OPS: tuple[KubernetesOp, ...] = (
+    KubernetesOp(
+        op_id="k8s.apply",
+        handler_attr="k8s_apply",
+        summary="Server-side apply a manifest; dry_run='server' previews with no side effects.",
+        description=(
+            "Parses a single- or multi-document manifest, resolves each "
+            "document's GVK via the dynamic client's discovery, and "
+            "server-side-applies it under the 'meho' field manager. "
+            "dry_run='server' runs every doc with the API's ?dryRun=All so "
+            "nothing is persisted -- the preview the approval reviewer reads. "
+            "Replaces 'kubectl apply -f'. Requires approval."
+        ),
+        parameter_schema=_APPLY_SCHEMA,
+        response_schema=None,
+        group_key="workload",
+        tags=("write", "apply", "dangerous"),
+        safety_level="dangerous",
+        requires_approval=True,
+        llm_instructions=_APPLY_LLM,
+    ),
+    KubernetesOp(
+        op_id="k8s.delete",
+        handler_attr="k8s_delete",
+        summary="Delete a pod/job/replicaset by name (v1 scope); explicit cascade params.",
+        description=(
+            "Deletes via a kind→method dispatch table scoped to "
+            "pod / job / replicaset in v1 (namespace / PVC / PV excluded -- "
+            "their cascading data loss is out of scope). "
+            "propagation_policy + grace_period_seconds are explicit so the "
+            "cascade is never an implicit default. Requires approval."
+        ),
+        parameter_schema=_DELETE_SCHEMA,
+        response_schema=None,
+        group_key="workload",
+        tags=("write", "delete", "dangerous"),
+        safety_level="dangerous",
+        requires_approval=True,
+        llm_instructions=_DELETE_LLM,
+    ),
+    KubernetesOp(
+        op_id="k8s.secret.create",
+        handler_attr="k8s_secret_create",
+        summary="Create a Secret; values are redacted from audit + broadcast.",
+        description=(
+            "Creates a Secret from string_data (plaintext) and/or data "
+            "(base64). The values are written to the cluster but never "
+            "echoed back -- the response is key-names-only -- and the op "
+            "classifies credential_write so the broadcast collapses to "
+            "aggregate-only. Requires approval."
+        ),
+        parameter_schema=_SECRET_CREATE_SCHEMA,
+        response_schema=None,
+        group_key="config",
+        tags=("write", "secret", "credential", "dangerous"),
+        safety_level="dangerous",
+        requires_approval=True,
+        llm_instructions=_SECRET_CREATE_LLM,
+    ),
+    KubernetesOp(
+        op_id="k8s.job.create",
+        handler_attr="k8s_job_create",
+        summary="Create a batch Job from a spec body; inline env secrets redacted.",
+        description=(
+            "Creates a batch/v1 Job from a spec body. The pod template can "
+            "carry inline env secret material, so the op classifies "
+            "credential_write and the broadcast collapses to aggregate-only. "
+            "The response echoes the Job's identity only. Requires approval."
+        ),
+        parameter_schema=_JOB_CREATE_SCHEMA,
+        response_schema=None,
+        group_key="workload",
+        tags=("write", "job", "credential", "dangerous"),
+        safety_level="dangerous",
+        requires_approval=True,
+        llm_instructions=_JOB_CREATE_LLM,
+    ),
+)

--- a/backend/tests/integration/test_connectors_k8s_e2e.py
+++ b/backend/tests/integration/test_connectors_k8s_e2e.py
@@ -150,6 +150,17 @@ EXPECTED_OP_IDS: tuple[str, ...] = (
     "k8s.configmap.info",
     "k8s.event.list",
     "k8s.logs",
+    # G3.14-T1 single-call write ops (approval-gated mutations).
+    "k8s.scale",
+    "k8s.rollout.restart",
+    "k8s.namespace.create",
+    "k8s.annotate",
+    "k8s.label",
+    "k8s.cordon",
+    "k8s.apply",
+    "k8s.delete",
+    "k8s.secret.create",
+    "k8s.job.create",
 )
 
 
@@ -884,5 +895,5 @@ async def test_dispatch_unknown_op_returns_dispatcher_unknown_op_envelope(
     extras = result.extras
     assert extras.get("error_code") == "unknown_op"
     # ``known_op_count`` carries the descriptor count for the triple;
-    # post-substrate-fix this is len(EXPECTED_OP_IDS) (14).
+    # post-G3.14-T1 this is len(EXPECTED_OP_IDS) (24: 14 read + 10 write).
     assert extras.get("known_op_count") == len(EXPECTED_OP_IDS)

--- a/backend/tests/integration/test_connectors_k8s_k3d.py
+++ b/backend/tests/integration/test_connectors_k8s_k3d.py
@@ -727,3 +727,257 @@ async def test_discover_topology_against_k3s_is_idempotent_when_recalled(
     edge_keys1 = {(e.from_kind, e.from_name, e.to_kind, e.to_name, e.kind) for e in snap1.edges}
     edge_keys2 = {(e.from_kind, e.from_name, e.to_kind, e.to_name, e.kind) for e in snap2.edges}
     assert edge_keys1 == edge_keys2
+
+
+# ---------------------------------------------------------------------------
+# G3.14-T1 (#1403) single-call write ops -- live k3s exercise.
+#
+# These talk to the real API server: they create + mutate + delete real
+# objects, so each test cleans up the namespace it touches. The redaction
+# assertions cross-check classify_op/redact_payload (the #1401 broadcast
+# contract) against the live secret/job bodies.
+# ---------------------------------------------------------------------------
+
+
+_WRITE_NS = "meho-write-test"
+
+
+@pytest.fixture
+async def write_namespace(
+    k3s_connector: tuple[KubernetesConnector, _K3sTarget],
+) -> Any:
+    """Create the scratch namespace via ``k8s.namespace.create`` and tear it down."""
+    from kubernetes_asyncio import client as _client
+
+    connector, target = k3s_connector
+    op = _make_k3d_operator()
+    created = await connector.k8s_namespace_create(op, target, {"name": _WRITE_NS})
+    assert created["created"] is True
+    try:
+        yield connector, target, op
+    finally:
+        import contextlib
+
+        api_client = await connector._get_api_client(target, op)
+        core_v1 = _client.CoreV1Api(api_client)
+        with contextlib.suppress(Exception):
+            await core_v1.delete_namespace(name=_WRITE_NS)
+
+
+@pytest.mark.asyncio
+async def test_namespace_create_is_idempotent_against_k3s(
+    write_namespace: Any,
+) -> None:
+    """A second create against the existing namespace reports created=False."""
+    connector, target, op = write_namespace
+    again = await connector.k8s_namespace_create(op, target, {"name": _WRITE_NS})
+    assert again["created"] is False
+    assert again["already_existed"] is True
+
+
+@pytest.mark.asyncio
+async def test_apply_server_dry_run_then_real_against_k3s(
+    write_namespace: Any,
+) -> None:
+    """Server-dry-run previews without persisting; the real apply creates it."""
+    from kubernetes_asyncio import client as _client
+
+    connector, target, op = write_namespace
+    manifest = (
+        "apiVersion: apps/v1\n"
+        "kind: Deployment\n"
+        "metadata:\n"
+        f"  name: nginx\n  namespace: {_WRITE_NS}\n"
+        "spec:\n"
+        "  replicas: 1\n"
+        "  selector:\n    matchLabels:\n      app: nginx\n"
+        "  template:\n"
+        "    metadata:\n      labels:\n        app: nginx\n"
+        "    spec:\n      containers:\n      - name: nginx\n        image: nginx:1.27-alpine\n"
+    )
+    # Dry-run preview: returns the would-be object but persists nothing.
+    preview = await connector.k8s_apply(op, target, {"manifest": manifest, "dry_run": "server"})
+    assert preview["dry_run"] is True
+    assert preview["applied"][0]["kind"] == "Deployment"
+
+    api_client = await connector._get_api_client(target, op)
+    apps_v1 = _client.AppsV1Api(api_client)
+    from kubernetes_asyncio.client.exceptions import ApiException
+
+    with pytest.raises(ApiException) as exc:
+        await apps_v1.read_namespaced_deployment(name="nginx", namespace=_WRITE_NS)
+    assert exc.value.status == 404, "dry-run must not have persisted the Deployment"
+
+    # Real apply now creates it.
+    applied = await connector.k8s_apply(op, target, {"manifest": manifest})
+    assert applied["dry_run"] is False
+    live = await apps_v1.read_namespaced_deployment(name="nginx", namespace=_WRITE_NS)
+    assert live.metadata.name == "nginx"
+
+    # Scale it and confirm before/after.
+    scaled = await connector.k8s_scale(
+        op, target, {"name": "nginx", "namespace": _WRITE_NS, "replicas": 3}
+    )
+    assert scaled["replicas_before"] == 1
+    assert scaled["replicas_after"] == 3
+
+    # Annotate + label, then read back off the live object.
+    await connector.k8s_annotate(
+        op,
+        target,
+        {
+            "kind": "deployment",
+            "name": "nginx",
+            "namespace": _WRITE_NS,
+            "annotations": {"meho.test/owner": "platform"},
+        },
+    )
+    await connector.k8s_label(
+        op,
+        target,
+        {"kind": "deployment", "name": "nginx", "namespace": _WRITE_NS, "labels": {"tier": "web"}},
+    )
+    refreshed = await apps_v1.read_namespaced_deployment(name="nginx", namespace=_WRITE_NS)
+    assert refreshed.metadata.annotations.get("meho.test/owner") == "platform"
+    assert refreshed.metadata.labels.get("tier") == "web"
+
+    # Rollout restart stamps the pod-template annotation.
+    restart = await connector.k8s_rollout_restart(
+        op, target, {"name": "nginx", "namespace": _WRITE_NS}
+    )
+    rolled = await apps_v1.read_namespaced_deployment(name="nginx", namespace=_WRITE_NS)
+    stamped = rolled.spec.template.metadata.annotations.get("kubectl.kubernetes.io/restartedAt")
+    assert stamped == restart["restarted_at"]
+
+
+@pytest.mark.asyncio
+async def test_secret_create_redacts_values_against_k3s(
+    write_namespace: Any,
+) -> None:
+    """A live Secret carries the value in-cluster but never in the broadcast.
+
+    Positively asserts the secret material is ABSENT from the broadcast
+    payload the publisher would ship (classify_op → credential_write →
+    aggregate-only), per the #1403 acceptance criterion.
+    """
+    import base64
+
+    from kubernetes_asyncio import client as _client
+
+    from meho_backplane.broadcast.events import classify_op, redact_payload
+
+    connector, target, op = write_namespace
+    raw_params = {
+        "name": "db-creds",
+        "namespace": _WRITE_NS,
+        "string_data": {"password": "live-hunter2"},
+    }
+    summary = await connector.k8s_secret_create(op, target, dict(raw_params))
+    # The handler response is value-free.
+    assert "live-hunter2" not in str(summary)
+    assert summary["data_keys"] == ["password"]
+
+    # The value DID reach the cluster.
+    api_client = await connector._get_api_client(target, op)
+    core_v1 = _client.CoreV1Api(api_client)
+    live = await core_v1.read_namespaced_secret(name="db-creds", namespace=_WRITE_NS)
+    assert base64.b64decode(live.data["password"]).decode() == "live-hunter2"
+
+    # The broadcast the publisher would emit is aggregate-only -- the
+    # secret never reaches the SSE stream / Slack mirror.
+    op_class = classify_op("k8s.secret.create")
+    payload = redact_payload(op_class, {"params": raw_params}, "ok")
+    assert "live-hunter2" not in str(payload)
+    assert payload == {"op_class": "credential_write", "result_status": "ok"}
+
+
+@pytest.mark.asyncio
+async def test_job_create_then_delete_redacts_env_secret_against_k3s(
+    write_namespace: Any,
+) -> None:
+    """A live Job's inline env secret never reaches the broadcast; delete reaps it."""
+    from meho_backplane.broadcast.events import classify_op, redact_payload
+
+    connector, target, op = write_namespace
+    job_params = {
+        "name": "echo-job",
+        "namespace": _WRITE_NS,
+        "spec": {
+            "backoffLimit": 0,
+            "template": {
+                "spec": {
+                    "restartPolicy": "Never",
+                    "containers": [
+                        {
+                            "name": "echo",
+                            "image": "busybox:1.36",
+                            "command": ["sh", "-c", "echo done"],
+                            "env": [{"name": "TOKEN", "value": "job-topsecret"}],
+                        }
+                    ],
+                }
+            },
+        },
+    }
+    created = await connector.k8s_job_create(op, target, dict(job_params))
+    assert created == {"name": "echo-job", "namespace": _WRITE_NS, "created": True}
+    assert "job-topsecret" not in str(created)
+
+    # Broadcast redaction: aggregate-only, no env secret.
+    payload = redact_payload(classify_op("k8s.job.create"), {"params": job_params}, "ok")
+    assert "job-topsecret" not in str(payload)
+    assert payload == {"op_class": "credential_write", "result_status": "ok"}
+
+    # Delete the Job (Background cascade reaps its pods).
+    deleted = await connector.k8s_delete(
+        op,
+        target,
+        {
+            "kind": "job",
+            "name": "echo-job",
+            "namespace": _WRITE_NS,
+            "propagation_policy": "Background",
+        },
+    )
+    assert deleted["deleted"] is True
+
+
+@pytest.mark.asyncio
+async def test_delete_rejects_namespace_kind_against_k3s(
+    write_namespace: Any,
+) -> None:
+    """The v1 delete scope refuses namespace deletion even on a live cluster."""
+    from meho_backplane.connectors.kubernetes.ops_write_dangerous import (
+        UndeletableKindError,
+    )
+
+    connector, target, op = write_namespace
+    with pytest.raises(UndeletableKindError):
+        await connector.k8s_delete(
+            op,
+            target,
+            {"kind": "namespace", "name": _WRITE_NS, "namespace": _WRITE_NS},
+        )
+
+
+@pytest.mark.asyncio
+async def test_cordon_uncordon_node_against_k3s(
+    k3s_connector: tuple[KubernetesConnector, _K3sTarget],
+) -> None:
+    """Cordon then uncordon the single k3s node; reversible + eviction-free."""
+    from kubernetes_asyncio import client as _client
+
+    connector, target = k3s_connector
+    op = _make_k3d_operator()
+    api_client = await connector._get_api_client(target, op)
+    core_v1 = _client.CoreV1Api(api_client)
+    nodes = await core_v1.list_node()
+    node_name = nodes.items[0].metadata.name
+    try:
+        cordoned = await connector.k8s_cordon(op, target, {"name": node_name})
+        assert cordoned["unschedulable"] is True
+        live = await core_v1.read_node(name=node_name)
+        assert live.spec.unschedulable is True
+    finally:
+        uncordoned = await connector.k8s_cordon(op, target, {"name": node_name, "uncordon": True})
+        assert uncordoned["unschedulable"] is False

--- a/backend/tests/test_connectors_k8s_write.py
+++ b/backend/tests/test_connectors_k8s_write.py
@@ -1,0 +1,759 @@
+# SPDX-License-Identifier: Apache-2.0
+# Copyright (c) 2026 evoila Group
+
+"""Unit tests for the G3.14-T1 (#1403) K8s single-call write ops.
+
+Coverage matrix (per Issue #1403 acceptance criteria):
+
+* :data:`KUBERNETES_OPS` exposes all ten write ops with the stated
+  safety levels and ``requires_approval=True``.
+* Each op: happy path + a partial/error-path test.
+* ``k8s.apply`` server-dry-run preview surfaces the would-be object
+  without mutating (``dry_run="All"`` flows to the API; the preview
+  result is returned).
+* ``k8s.delete`` rejects kinds outside pod/job/replicaset; cascade
+  params (``propagation_policy`` / ``grace_period_seconds``) forward
+  explicitly.
+* ``secret.create`` / ``job.create`` ``data`` is redacted from the
+  broadcast (classify_op → ``credential_write`` → aggregate-only) and
+  is absent from the handler's own response.
+
+The API surface is mocked (``kubernetes_asyncio.client.*`` /
+``DynamicClient``) so the gate runs in every CI lane regardless of
+Docker; the live k3s shape lives in
+:mod:`tests.integration.test_connectors_k8s_k3d`.
+"""
+
+from __future__ import annotations
+
+import uuid
+from collections.abc import Iterator
+from dataclasses import dataclass
+from typing import Any
+from unittest.mock import AsyncMock, MagicMock, patch
+
+import pytest
+from kubernetes_asyncio.client.exceptions import ApiException
+
+from meho_backplane.auth.operator import Operator, TenantRole
+from meho_backplane.broadcast.events import classify_op, redact_payload
+from meho_backplane.connectors.kubernetes import (
+    KUBERNETES_OPS,
+    KubernetesConnector,
+    KubernetesTargetLike,
+)
+from meho_backplane.connectors.kubernetes.ops_write import UnsupportedKindError
+from meho_backplane.connectors.kubernetes.ops_write_dangerous import (
+    ApplyManifestError,
+    UndeletableKindError,
+    secret_create_summary,
+)
+from meho_backplane.connectors.kubernetes.ops_write_meta import (
+    WRITE_CAUTION_OPS,
+    WRITE_DANGEROUS_OPS,
+)
+from meho_backplane.connectors.registry import (
+    clear_registry,
+    register_connector,
+    register_connector_v2,
+)
+from meho_backplane.settings import get_settings
+
+# ---------------------------------------------------------------------------
+# Fixtures (mirror test_connectors_k8s_workload.py)
+# ---------------------------------------------------------------------------
+
+
+@pytest.fixture(autouse=True)
+def _required_settings_env(monkeypatch: pytest.MonkeyPatch) -> Iterator[None]:
+    monkeypatch.setenv("KEYCLOAK_ISSUER_URL", "https://keycloak.test/realms/meho")
+    monkeypatch.setenv("KEYCLOAK_AUDIENCE", "meho-backplane")
+    monkeypatch.setenv("VAULT_ADDR", "https://vault.test")
+    get_settings.cache_clear()
+    yield
+    get_settings.cache_clear()
+
+
+@pytest.fixture(autouse=True)
+def _clean_kubernetes_registry() -> Iterator[None]:
+    clear_registry()
+    register_connector("k8s", KubernetesConnector)
+    register_connector_v2(product="k8s", version="1.x", impl_id="k8s", cls=KubernetesConnector)
+    yield
+
+
+@dataclass
+class _StubTarget:
+    name: str
+    host: str
+    port: int | None
+    secret_ref: str
+
+
+_TARGET = _StubTarget(
+    name="rke2-meho",
+    host="rke2-meho.test.invalid",
+    port=6443,
+    secret_ref="k8s/rke2-meho",
+)
+
+
+def _stub_kubeconfig() -> dict[str, Any]:
+    return {
+        "apiVersion": "v1",
+        "kind": "Config",
+        "current-context": "default",
+        "contexts": [{"name": "default", "context": {"cluster": "c1", "user": "u1"}}],
+        "clusters": [{"name": "c1", "cluster": {"server": "https://k8s.test:6443"}}],
+        "users": [{"name": "u1", "user": {"token": "stub-token"}}],
+    }
+
+
+def _make_connector() -> KubernetesConnector:
+    async def _loader(_target: KubernetesTargetLike, _operator: Operator) -> dict[str, Any]:
+        return _stub_kubeconfig()
+
+    return KubernetesConnector(kubeconfig_loader=_loader)
+
+
+def _make_operator() -> Operator:
+    return Operator(
+        sub="op-write-test",
+        name="Write Test Operator",
+        email=None,
+        raw_jwt="op.write.jwt",
+        tenant_id=uuid.UUID("00000000-0000-0000-0000-00000000a0a0"),
+        tenant_role=TenantRole.OPERATOR,
+    )
+
+
+def _patch_kubeconfig() -> Any:
+    return patch(
+        "meho_backplane.connectors.kubernetes.connector.config.new_client_from_config_dict",
+        new_callable=AsyncMock,
+        return_value=MagicMock(close=AsyncMock()),
+    )
+
+
+# ---------------------------------------------------------------------------
+# Registration surface
+# ---------------------------------------------------------------------------
+
+_WRITE_OP_IDS = {
+    "k8s.scale",
+    "k8s.rollout.restart",
+    "k8s.namespace.create",
+    "k8s.annotate",
+    "k8s.label",
+    "k8s.cordon",
+    "k8s.apply",
+    "k8s.delete",
+    "k8s.secret.create",
+    "k8s.job.create",
+}
+
+_EXPECTED_SAFETY = {
+    "k8s.scale": "caution",
+    "k8s.rollout.restart": "caution",
+    "k8s.namespace.create": "caution",
+    "k8s.annotate": "caution",
+    "k8s.label": "caution",
+    "k8s.cordon": "caution",
+    "k8s.apply": "dangerous",
+    "k8s.delete": "dangerous",
+    "k8s.secret.create": "dangerous",
+    "k8s.job.create": "dangerous",
+}
+
+
+def test_write_ops_registered_with_safety_and_approval() -> None:
+    """All ten write ops register with the stated safety + requires_approval=True."""
+    by_id = {op.op_id: op for op in KUBERNETES_OPS}
+    assert set(by_id) >= _WRITE_OP_IDS, "missing write ops in KUBERNETES_OPS"
+    for op_id in _WRITE_OP_IDS:
+        op = by_id[op_id]
+        assert op.requires_approval is True, f"{op_id} must require approval"
+        assert op.safety_level == _EXPECTED_SAFETY[op_id], op_id
+
+
+def test_write_handler_attrs_resolve_on_connector() -> None:
+    """Every write op's handler_attr is a real attribute on the connector."""
+    for op in (*WRITE_CAUTION_OPS, *WRITE_DANGEROUS_OPS):
+        assert getattr(KubernetesConnector, op.handler_attr, None) is not None, op.op_id
+
+
+# ---------------------------------------------------------------------------
+# k8s.scale
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.asyncio
+async def test_scale_returns_before_after() -> None:
+    conn = _make_connector()
+    before = MagicMock()
+    before.spec = MagicMock(replicas=2)
+    after = MagicMock()
+    after.spec = MagicMock(replicas=5)
+    with (
+        _patch_kubeconfig(),
+        patch("meho_backplane.connectors.kubernetes.ops_write.client.AppsV1Api") as apps_cls,
+    ):
+        api = apps_cls.return_value
+        api.read_namespaced_deployment_scale = AsyncMock(return_value=before)
+        api.patch_namespaced_deployment_scale = AsyncMock(return_value=after)
+        result = await conn.k8s_scale(
+            operator=_make_operator(),
+            target=_TARGET,
+            params={"name": "web", "namespace": "argocd", "replicas": 5},
+        )
+    assert result == {
+        "name": "web",
+        "namespace": "argocd",
+        "replicas_before": 2,
+        "replicas_after": 5,
+    }
+    assert api.patch_namespaced_deployment_scale.call_args.kwargs["body"] == {
+        "spec": {"replicas": 5}
+    }
+
+
+@pytest.mark.asyncio
+async def test_scale_propagates_api_error() -> None:
+    conn = _make_connector()
+    with (
+        _patch_kubeconfig(),
+        patch("meho_backplane.connectors.kubernetes.ops_write.client.AppsV1Api") as apps_cls,
+    ):
+        api = apps_cls.return_value
+        api.read_namespaced_deployment_scale = AsyncMock(
+            side_effect=ApiException(status=404, reason="Not Found")
+        )
+        with pytest.raises(ApiException):
+            await conn.k8s_scale(
+                operator=_make_operator(),
+                target=_TARGET,
+                params={"name": "missing", "namespace": "argocd", "replicas": 5},
+            )
+
+
+# ---------------------------------------------------------------------------
+# k8s.rollout.restart
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.asyncio
+async def test_rollout_restart_stamps_annotation() -> None:
+    conn = _make_connector()
+    with (
+        _patch_kubeconfig(),
+        patch("meho_backplane.connectors.kubernetes.ops_write.client.AppsV1Api") as apps_cls,
+    ):
+        api = apps_cls.return_value
+        api.patch_namespaced_deployment = AsyncMock()
+        result = await conn.k8s_rollout_restart(
+            operator=_make_operator(),
+            target=_TARGET,
+            params={"name": "web", "namespace": "argocd"},
+        )
+    body = api.patch_namespaced_deployment.call_args.kwargs["body"]
+    stamped = body["spec"]["template"]["metadata"]["annotations"]
+    assert "kubectl.kubernetes.io/restartedAt" in stamped
+    assert result["restarted_at"] == stamped["kubectl.kubernetes.io/restartedAt"]
+
+
+# ---------------------------------------------------------------------------
+# k8s.namespace.create (idempotent)
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.asyncio
+async def test_namespace_create_happy_path() -> None:
+    conn = _make_connector()
+    with (
+        _patch_kubeconfig(),
+        patch("meho_backplane.connectors.kubernetes.ops_write.client.CoreV1Api") as core_cls,
+    ):
+        core_cls.return_value.create_namespace = AsyncMock()
+        result = await conn.k8s_namespace_create(
+            operator=_make_operator(), target=_TARGET, params={"name": "new-ns"}
+        )
+    assert result == {"name": "new-ns", "created": True, "already_existed": False}
+
+
+@pytest.mark.asyncio
+async def test_namespace_create_409_is_idempotent() -> None:
+    conn = _make_connector()
+    with (
+        _patch_kubeconfig(),
+        patch("meho_backplane.connectors.kubernetes.ops_write.client.CoreV1Api") as core_cls,
+    ):
+        core_cls.return_value.create_namespace = AsyncMock(
+            side_effect=ApiException(status=409, reason="Conflict")
+        )
+        result = await conn.k8s_namespace_create(
+            operator=_make_operator(), target=_TARGET, params={"name": "existing"}
+        )
+    assert result == {"name": "existing", "created": False, "already_existed": True}
+
+
+@pytest.mark.asyncio
+async def test_namespace_create_non_409_raises() -> None:
+    conn = _make_connector()
+    with (
+        _patch_kubeconfig(),
+        patch("meho_backplane.connectors.kubernetes.ops_write.client.CoreV1Api") as core_cls,
+    ):
+        core_cls.return_value.create_namespace = AsyncMock(
+            side_effect=ApiException(status=403, reason="Forbidden")
+        )
+        with pytest.raises(ApiException):
+            await conn.k8s_namespace_create(
+                operator=_make_operator(), target=_TARGET, params={"name": "denied"}
+            )
+
+
+# ---------------------------------------------------------------------------
+# k8s.annotate / k8s.label
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.asyncio
+async def test_annotate_namespaced_kind() -> None:
+    conn = _make_connector()
+    with (
+        _patch_kubeconfig(),
+        patch("meho_backplane.connectors.kubernetes.ops_write.client.AppsV1Api") as apps_cls,
+    ):
+        apps_cls.return_value.patch_namespaced_deployment = AsyncMock()
+        result = await conn.k8s_annotate(
+            operator=_make_operator(),
+            target=_TARGET,
+            params={
+                "kind": "deployment",
+                "name": "web",
+                "namespace": "argocd",
+                "annotations": {"team": "platform", "stale": None},
+            },
+        )
+    body = apps_cls.return_value.patch_namespaced_deployment.call_args.kwargs["body"]
+    assert body == {"metadata": {"annotations": {"team": "platform", "stale": None}}}
+    assert result["annotations"] == {"team": "platform", "stale": None}
+
+
+@pytest.mark.asyncio
+async def test_label_cluster_scoped_node_no_namespace() -> None:
+    conn = _make_connector()
+    with (
+        _patch_kubeconfig(),
+        patch("meho_backplane.connectors.kubernetes.ops_write.client.CoreV1Api") as core_cls,
+    ):
+        core_cls.return_value.patch_node = AsyncMock()
+        result = await conn.k8s_label(
+            operator=_make_operator(),
+            target=_TARGET,
+            params={"kind": "node", "name": "node-1", "labels": {"role": "cp"}},
+        )
+    core_cls.return_value.patch_node.assert_awaited_once()
+    assert result["namespace"] is None
+    assert result["labels"] == {"role": "cp"}
+
+
+@pytest.mark.asyncio
+async def test_annotate_unsupported_kind_raises() -> None:
+    conn = _make_connector()
+    with _patch_kubeconfig(), pytest.raises(UnsupportedKindError):
+        await conn.k8s_annotate(
+            operator=_make_operator(),
+            target=_TARGET,
+            params={"kind": "secret", "name": "x", "annotations": {"a": "b"}},
+        )
+
+
+@pytest.mark.asyncio
+async def test_annotate_namespaced_missing_namespace_raises() -> None:
+    conn = _make_connector()
+    with (
+        _patch_kubeconfig(),
+        patch("meho_backplane.connectors.kubernetes.ops_write.client.AppsV1Api") as apps_cls,
+    ):
+        apps_cls.return_value.patch_namespaced_deployment = AsyncMock()
+        with pytest.raises(ValueError, match="namespace is required"):
+            await conn.k8s_annotate(
+                operator=_make_operator(),
+                target=_TARGET,
+                params={"kind": "deployment", "name": "web", "annotations": {"a": "b"}},
+            )
+
+
+# ---------------------------------------------------------------------------
+# k8s.cordon
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.asyncio
+async def test_cordon_marks_unschedulable() -> None:
+    conn = _make_connector()
+    with (
+        _patch_kubeconfig(),
+        patch("meho_backplane.connectors.kubernetes.ops_write.client.CoreV1Api") as core_cls,
+    ):
+        core_cls.return_value.patch_node = AsyncMock()
+        result = await conn.k8s_cordon(
+            operator=_make_operator(), target=_TARGET, params={"name": "node-1"}
+        )
+    body = core_cls.return_value.patch_node.call_args.kwargs["body"]
+    assert body == {"spec": {"unschedulable": True}}
+    assert result == {"name": "node-1", "unschedulable": True, "cordoned": True}
+
+
+@pytest.mark.asyncio
+async def test_uncordon_marks_schedulable() -> None:
+    conn = _make_connector()
+    with (
+        _patch_kubeconfig(),
+        patch("meho_backplane.connectors.kubernetes.ops_write.client.CoreV1Api") as core_cls,
+    ):
+        core_cls.return_value.patch_node = AsyncMock()
+        result = await conn.k8s_cordon(
+            operator=_make_operator(),
+            target=_TARGET,
+            params={"name": "node-1", "uncordon": True},
+        )
+    body = core_cls.return_value.patch_node.call_args.kwargs["body"]
+    assert body == {"spec": {"unschedulable": False}}
+    assert result["cordoned"] is False
+
+
+# ---------------------------------------------------------------------------
+# k8s.apply (server-side apply + dry-run preview)
+# ---------------------------------------------------------------------------
+
+
+def _dyn_patch() -> Any:
+    """Patch DynamicClient so awaiting it (discovery) is a no-op stub."""
+    return patch("meho_backplane.connectors.kubernetes.ops_write_dangerous.DynamicClient")
+
+
+_SINGLE_MANIFEST = """
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  name: web
+  namespace: argocd
+spec:
+  replicas: 2
+"""
+
+
+def _applied_obj(rv: str = "123", uid: str = "u-1") -> MagicMock:
+    obj = MagicMock()
+    obj.metadata = MagicMock(resourceVersion=rv, uid=uid)
+    return obj
+
+
+@pytest.mark.asyncio
+async def test_apply_persists_by_default() -> None:
+    conn = _make_connector()
+    dyn = MagicMock()
+    dyn.resources.get = AsyncMock(return_value=MagicMock())
+    dyn.server_side_apply = AsyncMock(return_value=_applied_obj())
+    with _patch_kubeconfig(), _dyn_patch() as dyn_cls:
+        # DynamicClient(api_client) is awaited; make the instance awaitable->dyn
+        dyn_cls.return_value = _awaitable(dyn)
+        result = await conn.k8s_apply(
+            operator=_make_operator(),
+            target=_TARGET,
+            params={"manifest": _SINGLE_MANIFEST},
+        )
+    assert result["dry_run"] is False
+    assert result["total"] == 1
+    # No dry_run kwarg => persisted apply.
+    assert "dry_run" not in dyn.server_side_apply.call_args.kwargs
+    assert dyn.server_side_apply.call_args.kwargs["field_manager"] == "meho"
+    assert result["applied"][0]["resource_version"] == "123"
+
+
+@pytest.mark.asyncio
+async def test_apply_server_dry_run_preview_no_mutation() -> None:
+    conn = _make_connector()
+    dyn = MagicMock()
+    dyn.resources.get = AsyncMock(return_value=MagicMock())
+    dyn.server_side_apply = AsyncMock(return_value=_applied_obj(rv="dry"))
+    with _patch_kubeconfig(), _dyn_patch() as dyn_cls:
+        dyn_cls.return_value = _awaitable(dyn)
+        result = await conn.k8s_apply(
+            operator=_make_operator(),
+            target=_TARGET,
+            params={"manifest": _SINGLE_MANIFEST, "dry_run": "server"},
+        )
+    assert result["dry_run"] is True
+    # The operator-facing 'server' maps to the API's dryRun=All.
+    assert dyn.server_side_apply.call_args.kwargs["dry_run"] == "All"
+    assert result["applied"][0]["resource_version"] == "dry"
+
+
+@pytest.mark.asyncio
+async def test_apply_multi_doc() -> None:
+    conn = _make_connector()
+    multi = (
+        _SINGLE_MANIFEST
+        + "\n---\n"
+        + ("apiVersion: v1\nkind: ConfigMap\nmetadata:\n  name: cm\n  namespace: argocd\n")
+    )
+    dyn = MagicMock()
+    dyn.resources.get = AsyncMock(return_value=MagicMock())
+    dyn.server_side_apply = AsyncMock(side_effect=[_applied_obj("1"), _applied_obj("2")])
+    with _patch_kubeconfig(), _dyn_patch() as dyn_cls:
+        dyn_cls.return_value = _awaitable(dyn)
+        result = await conn.k8s_apply(
+            operator=_make_operator(), target=_TARGET, params={"manifest": multi}
+        )
+    assert result["total"] == 2
+    assert {r["kind"] for r in result["applied"]} == {"Deployment", "ConfigMap"}
+
+
+@pytest.mark.asyncio
+async def test_apply_rejects_manifest_without_kind() -> None:
+    conn = _make_connector()
+    with _patch_kubeconfig(), pytest.raises(ApplyManifestError):
+        await conn.k8s_apply(
+            operator=_make_operator(),
+            target=_TARGET,
+            params={"manifest": "apiVersion: v1\nmetadata:\n  name: x\n"},
+        )
+
+
+@pytest.mark.asyncio
+async def test_apply_rejects_empty_manifest() -> None:
+    conn = _make_connector()
+    with _patch_kubeconfig(), pytest.raises(ApplyManifestError):
+        await conn.k8s_apply(
+            operator=_make_operator(), target=_TARGET, params={"manifest": "---\n"}
+        )
+
+
+# ---------------------------------------------------------------------------
+# k8s.delete
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.asyncio
+async def test_delete_pod_forwards_cascade_params() -> None:
+    conn = _make_connector()
+    with (
+        _patch_kubeconfig(),
+        patch(
+            "meho_backplane.connectors.kubernetes.ops_write_dangerous.client.CoreV1Api"
+        ) as core_cls,
+    ):
+        core_cls.return_value.delete_namespaced_pod = AsyncMock()
+        result = await conn.k8s_delete(
+            operator=_make_operator(),
+            target=_TARGET,
+            params={
+                "kind": "pod",
+                "name": "web-abc",
+                "namespace": "argocd",
+                "propagation_policy": "Background",
+                "grace_period_seconds": 0,
+            },
+        )
+    kwargs = core_cls.return_value.delete_namespaced_pod.call_args.kwargs
+    assert kwargs["propagation_policy"] == "Background"
+    assert kwargs["grace_period_seconds"] == 0
+    assert result["deleted"] is True
+
+
+@pytest.mark.asyncio
+async def test_delete_job_uses_batch_api() -> None:
+    conn = _make_connector()
+    with (
+        _patch_kubeconfig(),
+        patch(
+            "meho_backplane.connectors.kubernetes.ops_write_dangerous.client.BatchV1Api"
+        ) as batch_cls,
+    ):
+        batch_cls.return_value.delete_namespaced_job = AsyncMock()
+        result = await conn.k8s_delete(
+            operator=_make_operator(),
+            target=_TARGET,
+            params={"kind": "job", "name": "migrate", "namespace": "argocd"},
+        )
+    batch_cls.return_value.delete_namespaced_job.assert_awaited_once()
+    assert result["kind"] == "job"
+
+
+@pytest.mark.asyncio
+async def test_delete_rejects_namespace_kind() -> None:
+    conn = _make_connector()
+    with _patch_kubeconfig(), pytest.raises(UndeletableKindError):
+        await conn.k8s_delete(
+            operator=_make_operator(),
+            target=_TARGET,
+            params={"kind": "namespace", "name": "kube-system", "namespace": "kube-system"},
+        )
+
+
+@pytest.mark.asyncio
+async def test_delete_rejects_pvc_kind() -> None:
+    conn = _make_connector()
+    with _patch_kubeconfig(), pytest.raises(UndeletableKindError):
+        await conn.k8s_delete(
+            operator=_make_operator(),
+            target=_TARGET,
+            params={"kind": "persistentvolumeclaim", "name": "data", "namespace": "argocd"},
+        )
+
+
+# ---------------------------------------------------------------------------
+# k8s.secret.create / k8s.job.create — redaction
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.asyncio
+async def test_secret_create_response_omits_values() -> None:
+    conn = _make_connector()
+    with (
+        _patch_kubeconfig(),
+        patch(
+            "meho_backplane.connectors.kubernetes.ops_write_dangerous.client.CoreV1Api"
+        ) as core_cls,
+    ):
+        core_cls.return_value.create_namespaced_secret = AsyncMock()
+        result = await conn.k8s_secret_create(
+            operator=_make_operator(),
+            target=_TARGET,
+            params={
+                "name": "db-creds",
+                "namespace": "argocd",
+                "string_data": {"password": "hunter2", "username": "admin"},
+            },
+        )
+    # The handler echoes key NAMES only, never the values.
+    assert result == {
+        "name": "db-creds",
+        "namespace": "argocd",
+        "type": "Opaque",
+        "data_keys": ["password", "username"],
+        "created": True,
+    }
+    assert "hunter2" not in str(result)
+
+
+@pytest.mark.asyncio
+async def test_secret_create_writes_string_data_to_cluster() -> None:
+    conn = _make_connector()
+    with (
+        _patch_kubeconfig(),
+        patch(
+            "meho_backplane.connectors.kubernetes.ops_write_dangerous.client.CoreV1Api"
+        ) as core_cls,
+    ):
+        core_cls.return_value.create_namespaced_secret = AsyncMock()
+        await conn.k8s_secret_create(
+            operator=_make_operator(),
+            target=_TARGET,
+            params={
+                "name": "db-creds",
+                "namespace": "argocd",
+                "string_data": {"password": "hunter2"},
+            },
+        )
+    body = core_cls.return_value.create_namespaced_secret.call_args.kwargs["body"]
+    # The value DOES reach the cluster (that's the point) but not the response/broadcast.
+    assert body.string_data == {"password": "hunter2"}
+
+
+def test_secret_create_classifies_credential_write_and_redacts_broadcast() -> None:
+    """The broadcast payload for k8s.secret.create is aggregate-only — the
+    secret values in params never reach the feed."""
+    assert classify_op("k8s.secret.create") == "credential_write"
+    raw_params = {
+        "params": {"name": "db", "namespace": "argocd", "string_data": {"password": "hunter2"}}
+    }
+    payload = redact_payload("credential_write", raw_params, "ok")
+    blob = str(payload)
+    assert "hunter2" not in blob, "secret value leaked into broadcast payload"
+    assert "string_data" not in blob, "secret keys leaked into broadcast payload"
+    assert payload == {"op_class": "credential_write", "result_status": "ok"}
+
+
+@pytest.mark.asyncio
+async def test_job_create_response_omits_spec() -> None:
+    conn = _make_connector()
+    with (
+        _patch_kubeconfig(),
+        patch(
+            "meho_backplane.connectors.kubernetes.ops_write_dangerous.client.BatchV1Api"
+        ) as batch_cls,
+    ):
+        batch_cls.return_value.create_namespaced_job = AsyncMock()
+        result = await conn.k8s_job_create(
+            operator=_make_operator(),
+            target=_TARGET,
+            params={
+                "name": "migrate",
+                "namespace": "argocd",
+                "spec": {
+                    "template": {
+                        "spec": {
+                            "containers": [
+                                {
+                                    "name": "m",
+                                    "image": "migrate:1",
+                                    "env": [{"name": "DB_PASS", "value": "topsecret"}],
+                                }
+                            ],
+                            "restartPolicy": "Never",
+                        }
+                    }
+                },
+            },
+        )
+    assert result == {"name": "migrate", "namespace": "argocd", "created": True}
+    assert "topsecret" not in str(result)
+
+
+def test_job_create_classifies_credential_write_and_redacts_broadcast() -> None:
+    """The Job's inline env secret in params never reaches the broadcast."""
+    assert classify_op("k8s.job.create") == "credential_write"
+    raw_params = {
+        "params": {
+            "name": "migrate",
+            "namespace": "argocd",
+            "spec": {"template": {"spec": {"containers": [{"env": [{"value": "topsecret"}]}]}}},
+        }
+    }
+    payload = redact_payload("credential_write", raw_params, "ok")
+    assert "topsecret" not in str(payload)
+    assert payload == {"op_class": "credential_write", "result_status": "ok"}
+
+
+def test_secret_create_summary_helper_is_value_free() -> None:
+    summary = secret_create_summary("s", "ns", "Opaque", ["b", "a"])
+    assert summary["data_keys"] == ["a", "b"]
+    assert "value" not in str(summary).lower() or "data_keys" in summary
+
+
+# ---------------------------------------------------------------------------
+# Test helpers
+# ---------------------------------------------------------------------------
+
+
+def _awaitable(value: Any) -> Any:
+    """Wrap *value* so ``await DynamicClient(...)`` returns it.
+
+    The real ``DynamicClient.__await__`` runs async discovery and returns
+    ``self``; the handler does ``dyn = await DynamicClient(api_client)``.
+    A ``MagicMock`` is not awaitable, so we hand back an object whose
+    ``__await__`` yields the prepared mock.
+    """
+
+    class _Awaitable:
+        def __await__(self) -> Any:
+            async def _coro() -> Any:
+                return value
+
+            return _coro().__await__()
+
+    return _Awaitable()

--- a/docs/codebase/connectors-kubernetes.md
+++ b/docs/codebase/connectors-kubernetes.md
@@ -17,9 +17,13 @@ and documented in
 [`docs/cross-repo/kubernetes-onboarding.md`](../cross-repo/kubernetes-onboarding.md).
 
 The connector replaces the operator's daily `kubectl-vcf.sh` wrapper for
-read workflows -- inventory listing, workload inspection, log fetching.
-Write operations stay in the wrapper until v0.2.next ships policy +
-approval flow.
+read workflows -- inventory listing, workload inspection, log fetching --
+and, as of G3.14-T1 (#1403), for the single-call **write** surface
+(scale / rollout-restart / namespace-create / annotate / label / cordon /
+apply / delete / secret-create / job-create). Every write op is
+`requires_approval=True`, so once #1401's human-queue routing is live an
+operator's write dispatch is parked for approval rather than auto-run or
+hard-denied. `k8s.exec` (G3.14-T2) and `k8s.drain` stay in the wrapper.
 
 Source: `backend/src/meho_backplane/connectors/kubernetes/`.
 
@@ -157,6 +161,51 @@ proves dispatcher -> handler -> k3s round-trips through the
 op; the onboarding recipe in
 [`docs/cross-repo/kubernetes-onboarding.md`](../cross-repo/kubernetes-onboarding.md)
 is the operator cookbook for migrating off `kubectl-vcf.sh`.
+
+### Write op surface (G3.14-T1, #1403)
+
+The single-call write ops live in `ops_write.py` (caution-class
+handlers + the annotate/label kind dispatch table),
+`ops_write_dangerous.py` (dangerous-class handlers + the delete dispatch
+table), and `ops_write_meta.py` (the JSON-Schema parameter shapes +
+`KubernetesOp` registration rows for **all** write ops, split out so each
+handler file stays under the 600-line code-quality cap and the
+operator-facing surface reads in one place). Handlers are bound-method
+shims on `KubernetesConnector` forwarding to module-level functions --
+the same pattern `ops_workload.py` / `ops_logs.py` use. Every op is
+`safety_level` caution|dangerous and `requires_approval=True`.
+
+| op_id                  | safety    | k8s call                                                          |
+| ---------------------- | --------- | ---------------------------------------------------------------- |
+| `k8s.scale`            | caution   | `AppsV1Api.patch_namespaced_deployment_scale` -- before/after replicas in result. |
+| `k8s.rollout.restart`  | caution   | Stamp `kubectl.kubernetes.io/restartedAt` on the pod template (kubectl parity). |
+| `k8s.namespace.create` | caution   | `CoreV1Api.create_namespace` -- create-or-ignore-409 (idempotent). |
+| `k8s.annotate`         | caution   | Strategic-merge patch of `metadata.annotations` over a kind table (deployment/pod/service/namespace/node); null value removes a key. |
+| `k8s.label`            | caution   | Same as annotate over `metadata.labels`; relabeling a Service-selected workload can re-route traffic. |
+| `k8s.cordon`           | caution   | `CoreV1Api.patch_node(spec.unschedulable)`; `uncordon=true` reverses. Eviction-free. |
+| `k8s.apply`            | dangerous | Server-side apply over `DynamicClient.server_side_apply` (`field_manager="meho"`), GVK resolved per manifest doc from discovery. `dry_run="server"` -> API `?dryRun=All` (mutates nothing, returns the would-be object). |
+| `k8s.delete`           | dangerous | Kind dispatch **scoped to pod/job/replicaset in v1** (namespace/PVC/PV rejected); explicit `propagation_policy` / `grace_period_seconds`. |
+| `k8s.secret.create`    | dangerous | `CoreV1Api.create_namespaced_secret`; values written but never echoed (response is key-names only). |
+| `k8s.job.create`       | dangerous | `BatchV1Api.create_namespaced_job` from a spec body; response is identity only. |
+
+**Secret redaction reuses the shipped `credential_write` op-class
+(#1401), not a new mechanism.** `k8s.secret.create` was already in
+`_CREDENTIAL_WRITE_OPS` (`broadcast/events.py`); G3.14-T1 adds
+`k8s.job.create` (a Job pod-template's inline `env` can carry secret
+material in `params`). `classify_op` returns `credential_write`, so
+`redact_payload` collapses the broadcast event to aggregate-only
+`{op_class, result_status}` -- the secret never reaches the SSE stream or
+a Slack mirror. The handlers also return value-free summaries, so the
+`OperationResult` itself carries no secret.
+
+**`k8s.apply` dry-run preview.** The op supports `dry_run="server"` (maps
+to the API's `?dryRun=All`) so the would-be object is returned without
+mutating -- the diff-preview an agent or reviewer runs before the real
+apply. Note: the dispatcher / approval-queue substrate has **no per-op
+`proposed_effect` builder hook**, so the dry-run result is not
+auto-populated into the approval row at queue time today; the dry-run is
+expressible + returned by the op, and queue-time auto-population is a
+follow-up that needs a dispatcher hook.
 
 ### Shared list-op request shape (`ops_listparams.py`)
 


### PR DESCRIPTION
## Summary
- Lands the single-call **write** surface on the previously read-only k8s connector (G3.14-T1, #1403). Ten ops, all `requires_approval=True`, so once #1401's human-queue routing is live an operator's dispatch is parked for approval rather than hard-denied.
- **Caution:** `k8s.scale`, `k8s.rollout.restart`, `k8s.namespace.create` (idempotent), `k8s.annotate`, `k8s.label`, `k8s.cordon`.
- **Dangerous:** `k8s.apply` (server-side apply over `kubernetes_asyncio` `DynamicClient` with per-document GVK resolution + a `dry_run="server"` preview mapping to the API's `?dryRun=All`), `k8s.delete` (kind dispatch scoped to pod/job/replicaset in v1; namespace/PVC/PV excluded; explicit `propagation_policy`/`grace_period_seconds`), `k8s.secret.create`, `k8s.job.create`.
- **Secret redaction reuses the shipped `credential_write` op-class (#1401)** — not reinvented. `k8s.secret.create` was already in `_CREDENTIAL_WRITE_OPS`; this adds `k8s.job.create` (a Job pod-template's inline `env` can carry secrets). `classify_op` → `credential_write` collapses the broadcast to aggregate-only `{op_class, result_status}`; handlers also return value-free summaries.

## Test plan
- [x] `ruff check` / `ruff format --check` — clean
- [x] `mypy` — clean (kubernetes package + broadcast)
- [x] `code-quality.py --diff` — 0 blockers (op-registration rows + JSON-Schema shapes split into `ops_write_meta.py` to keep each handler file under the 600-line cap)
- [x] `pytest` — 243 passed (per-op happy-path + partial-failure unit tests in `test_connectors_k8s_write.py`; broadcast classify/redact suites green)
- [x] Live-k3s integration tests added to `test_connectors_k8s_k3d.py` (testcontainers lane): apply dry-run-then-real, scale, annotate/label, rollout-restart, cordon/uncordon, delete-scope rejection, and **positive assertions that the secret/job-env value is ABSENT from the broadcast payload**
- [x] `cd cli && make snapshot-openapi` — no delta (typed ops register at runtime into the descriptor table dispatched via `/api/v1/operations/call`, not static OpenAPI routes), so the generated CLI client + snapshot are unchanged

## Framework research
- `kubernetes_asyncio` 35.0.1, introspected in-worktree: `DynamicClient` must be awaited for discovery; `server_side_apply(resource, body, name, namespace, field_manager, dry_run, force_conflicts)` maps `dry_run`→`?dryRun`; typed `delete_namespaced_*` accept `propagation_policy`/`grace_period_seconds`; typed create methods serialise a raw dict body verbatim (verified `sanitize_for_serialization` passes dicts through with env values intact).

## Out of scope
- `k8s.exec` (G3.14-T2 — websocket transport) and `k8s.drain` (deferred).
- A per-op `proposed_effect` builder hook that auto-runs the `k8s.apply` server-dry-run at queue time (so the reviewer sees the diff without a separate call) does not exist in the dispatcher/approval-queue substrate. The dry-run is expressible + returned by the op today; queue-time auto-population is a follow-up needing a dispatcher hook (documented in `docs/codebase/connectors-kubernetes.md`).

<!-- auto-implement-issue: fresh, iteration 1 -->

Closes #1403
