### PR TITLE
feat(connectors): G3.15-T1 vault kv writes — approval-gate put/delete + add kv.patch

### DIFF
--- a/backend/src/meho_backplane/broadcast/events.py
+++ b/backend/src/meho_backplane/broadcast/events.py
@@ -118,6 +118,10 @@ _CREDENTIAL_MINT_OPS: Final[frozenset[str]] = frozenset(
 #:   op shipped pre-G11.7 classified as plain ``write``, which broadcast
 #:   the written secret in full; reclassifying it here closes that latent
 #:   leak — see ``docs/codebase/connectors-vault.md``).
+#: * ``vault.kv.patch`` — same posture as ``vault.kv.put``: the merged
+#:   fields ride in ``params`` (G3.15-T1 #1409). Without the explicit
+#:   pin the ``.patch`` write-suffix would classify it plain ``write``
+#:   and broadcast the partial secret in full.
 #: * ``k8s.secret.create`` — the Secret ``data`` / ``stringData`` is in
 #:   ``params``.
 #: * ``k8s.job.create`` — the Job ``spec`` carries a pod template whose
@@ -128,6 +132,7 @@ _CREDENTIAL_WRITE_OPS: Final[frozenset[str]] = frozenset(
         "vault.auth.userpass.write",
         "vault.auth.userpass.update_password",
         "vault.kv.put",
+        "vault.kv.patch",
         "k8s.secret.create",
         "k8s.job.create",
     }

--- a/backend/src/meho_backplane/connectors/vault/ops.py
+++ b/backend/src/meho_backplane/connectors/vault/ops.py
@@ -79,6 +79,7 @@ __all__ = [
     "register_vault_typed_operations",
     "vault_kv_delete",
     "vault_kv_list",
+    "vault_kv_patch",
     "vault_kv_put",
     "vault_kv_read",
     "vault_kv_versions",
@@ -503,6 +504,103 @@ async def vault_kv_put(operator: Operator, target: Any, params: dict[str, Any]) 
 
 
 # ---------------------------------------------------------------------------
+# vault.kv.patch — merge-write fields onto the current version
+# ---------------------------------------------------------------------------
+
+#: ``vault.kv.patch`` param schema. ``data`` carries only the fields to
+#: merge; unlike ``kv.put`` it is NOT the full secret body — Vault reads
+#: the current version, JSON-merges ``data`` over it, and writes the
+#: result as a new version. hvac's ``patch`` exposes no ``cas`` guard
+#: (it issues its own internal read+write), so the schema omits one.
+VAULT_KV_PATCH_PARAMETER_SCHEMA: dict[str, Any] = {
+    "type": "object",
+    "properties": {
+        "mount": _MOUNT_PROPERTY,
+        "path": _PATH_PROPERTY,
+        "data": {
+            "type": "object",
+            "minProperties": 1,
+            "description": (
+                "Fields to merge onto the current version. Unlike "
+                "kv.put this is a partial — keys present here are added "
+                "or overwritten; keys absent here are preserved from the "
+                "current version. The secret must already exist."
+            ),
+        },
+    },
+    "required": ["path", "data"],
+    "additionalProperties": False,
+}
+
+_VAULT_KV_PATCH_RESPONSE_SCHEMA: dict[str, Any] = {
+    "type": "object",
+    "properties": {
+        "version": {
+            "type": ["integer", "null"],
+            "description": "The newly written KV v2 version number.",
+        },
+    },
+    "required": ["version"],
+}
+
+_VAULT_KV_PATCH_LLM_INSTRUCTIONS: dict[str, Any] = {
+    "when_to_use": (
+        "Merge one or more fields into an existing KV v2 secret without "
+        "supplying the whole body. Mutating — Vault reads the current "
+        "version, JSON-merges the supplied fields, and writes the result "
+        "as a new version (history is kept). Use to set or rotate a "
+        "single field ('vault-store patch --field') when you do not have "
+        "(or do not want to re-send) the other keys. The secret must "
+        "already exist — patching a missing path fails."
+    ),
+    "parameter_hints": {
+        "mount": "Optional. KV v2 mount point; defaults to 'secret'.",
+        "path": "Required. The existing secret path under the mount.",
+        "data": (
+            "Required. The fields to merge. Only these keys are "
+            "added/overwritten; every other key on the current version "
+            "is carried forward unchanged."
+        ),
+    },
+    "output_shape": (
+        "On success: {'version': <new int version>}. On failure: a "
+        "connector_error OperationResult with extras.exception_class — "
+        "patching a non-existent path surfaces as hvac's InvalidPath "
+        "class."
+    ),
+}
+
+
+async def vault_kv_patch(operator: Operator, target: Any, params: dict[str, Any]) -> dict[str, Any]:
+    """Merge fields onto the current version of a KV v2 secret.
+
+    Op-id: ``vault.kv.patch``. Mutating (``op_class=credential_write``,
+    ``safety_level=caution``, ``requires_approval=True``). Delegates to
+    hvac's ``secrets.kv.v2.patch`` (``PATCH
+    /v1/<mount>/data/<path>`` with the JSON-merge content type), which
+    reads the current version, merges the supplied fields over it, and
+    writes a new version. Unlike :func:`vault_kv_put` this is a partial
+    write — keys absent from ``data`` are preserved. The secret must
+    already exist; patching a missing path raises (surfaced as a
+    structured ``connector_error``). The structural unwrap raises on a
+    malformed hvac payload.
+    """
+    mount: str = str(params.get("mount", _DEFAULT_KV_MOUNT)).strip()
+    path: str = str(params["path"]).strip()
+    secret: dict[str, Any] = params["data"]
+
+    async with _auth_vault.vault_client_for_operator(operator) as client:
+        patch_payload = await asyncio.to_thread(
+            client.secrets.kv.v2.patch,
+            path=path,
+            secret=secret,
+            mount_point=mount,
+        )
+        version = patch_payload["data"]["version"]
+        return {"version": version}
+
+
+# ---------------------------------------------------------------------------
 # vault.kv.versions — version metadata for a secret
 # ---------------------------------------------------------------------------
 
@@ -727,15 +825,39 @@ _KV_OP_SPECS: tuple[dict[str, Any], ...] = (
             "v2 keeps version history; the write replaces the latest "
             "version wholesale (no merge). Optional Check-And-Set guard "
             "('cas'). safety_level=caution; the production-path "
-            "approval gate is G7/G10 policy territory. Failures land as "
-            "a connector_error OperationResult with "
-            "extras.exception_class naming the failure class."
+            "approval gate routes humans to the approval queue "
+            "(G11.7-T1 #1401). Failures land as a connector_error "
+            "OperationResult with extras.exception_class naming the "
+            "failure class."
         ),
         "parameter_schema": VAULT_KV_PUT_PARAMETER_SCHEMA,
         "response_schema": _VAULT_KV_PUT_RESPONSE_SCHEMA,
         "tags": ["write", "secret-write"],
         "safety_level": "caution",
+        "requires_approval": True,
         "llm_instructions": _VAULT_KV_PUT_LLM_INSTRUCTIONS,
+    },
+    {
+        "op_id": "vault.kv.patch",
+        "handler": vault_kv_patch,
+        "summary": "Merge fields onto the current version of a KV v2 secret.",
+        "description": (
+            "Merges the supplied fields onto the current version of the "
+            "secret at the KV v2 path via the operator's OIDC-forwarded "
+            "JWT, writing the result as a new version. Mutating partial "
+            "write — keys absent from the request are preserved (unlike "
+            "kv.put, which replaces wholesale). The secret must already "
+            "exist. safety_level=caution; requires_approval=True routes "
+            "humans to the approval queue (G11.7-T1 #1401). Failures "
+            "land as a connector_error OperationResult with "
+            "extras.exception_class naming the failure class."
+        ),
+        "parameter_schema": VAULT_KV_PATCH_PARAMETER_SCHEMA,
+        "response_schema": _VAULT_KV_PATCH_RESPONSE_SCHEMA,
+        "tags": ["write", "secret-write"],
+        "safety_level": "caution",
+        "requires_approval": True,
+        "llm_instructions": _VAULT_KV_PATCH_LLM_INSTRUCTIONS,
     },
     {
         "op_id": "vault.kv.versions",
@@ -765,15 +887,16 @@ _KV_OP_SPECS: tuple[dict[str, Any], ...] = (
             "operator's OIDC-forwarded JWT. Reversible — Vault marks "
             "the versions deleted and stops returning them from reads "
             "while retaining the underlying data (undeletable until "
-            "destroyed). safety_level=dangerous; the production-path "
-            "approval gate is G7/G10 policy territory. Failures land as "
-            "a connector_error OperationResult with "
+            "destroyed). safety_level=dangerous; requires_approval=True "
+            "routes humans to the approval queue (G11.7-T1 #1401). "
+            "Failures land as a connector_error OperationResult with "
             "extras.exception_class naming the failure class."
         ),
         "parameter_schema": VAULT_KV_DELETE_PARAMETER_SCHEMA,
         "response_schema": _VAULT_KV_DELETE_RESPONSE_SCHEMA,
         "tags": ["write", "destructive", "reversible"],
         "safety_level": "dangerous",
+        "requires_approval": True,
         "llm_instructions": _VAULT_KV_DELETE_LLM_INSTRUCTIONS,
     },
 )
@@ -799,8 +922,9 @@ async def register_vault_typed_operations(
     process-wide singleton via the ``register_typed_operation`` body.
 
     Scope: G3.3-T1 registers the full KV-v2 group — ``vault.kv.read``,
-    ``vault.kv.list``, ``vault.kv.put``, ``vault.kv.versions``,
-    ``vault.kv.delete``. The identity-read group (Task #547,
+    ``vault.kv.list``, ``vault.kv.put``, ``vault.kv.patch``,
+    ``vault.kv.versions``, ``vault.kv.delete`` (``vault.kv.patch`` added
+    by G3.15-T1 #1409). The identity-read group (Task #547,
     ``vault.auth.userpass.list/read`` / ``vault.auth.approle.list/read``)
     is registered from its own module via the
     :func:`~meho_backplane.connectors.vault.ops_auth.register_vault_auth_operations`
@@ -811,15 +935,14 @@ async def register_vault_typed_operations(
     are needed.
 
     ``requires_approval`` for the mutating ops (``kv.put`` /
-    ``kv.delete``) is registered ``False`` (the dev default). The
-    shipped G0.6 substrate has no per-path approval predicate —
-    ``requires_approval`` is a static boolean on the descriptor and the
-    production-path gate is G7/G10 policy territory (see the
-    :class:`~meho_backplane.db.models.EndpointDescriptor` docstring:
-    ``caution``/``dangerous`` ops "flow through G7 / G10 policy logic
-    once those Goals land"). ``safety_level`` (``caution`` for
-    ``kv.put``, ``dangerous`` for ``kv.delete``) is the load-bearing
-    signal the future policy gate keys on.
+    ``kv.patch`` / ``kv.delete``) is registered ``True`` (G3.15-T1
+    #1409). It became meaningful once G11.7-T1 (#1401) routed human
+    principals hitting a ``requires_approval`` op to the approval queue
+    instead of hard-denying — so the gate parks the write for review
+    rather than blocking the operator. The read ops (``kv.read`` /
+    ``kv.list`` / ``kv.versions``) omit the key and default ``False``.
+    ``safety_level`` (``caution`` for ``kv.put`` / ``kv.patch``,
+    ``dangerous`` for ``kv.delete``) is the orthogonal posture signal.
     """
     # Curated by T4b (#732); surfaced verbatim by
     # ``list_operation_groups``. Differentiates the KV-v2 read/write
@@ -840,15 +963,20 @@ async def register_vault_typed_operations(
         "value itself."
     )
     for spec in _KV_OP_SPECS:
+        # ``requires_approval`` is carried per-op in the spec (default
+        # False for the read ops, which omit the key). The mutating KV
+        # ops (put / patch / delete) set it True so the dispatcher routes
+        # human principals to the approval queue rather than executing
+        # the write inline (G3.15-T1 #1409, on the G11.7-T1 #1401 queue).
         await register_typed_operation(
             product="vault",
             version="1.x",
             impl_id="vault",
             group_key="kv",
             when_to_use=kv_when_to_use,
-            requires_approval=False,
+            requires_approval=spec.get("requires_approval", False),
             embedding_service=embedding_service,
-            **spec,
+            **{k: v for k, v in spec.items() if k != "requires_approval"},
         )
     # Identity-read group (Task #547) -- registered from its own
     # module so the auth surface stays independently reviewable while

--- a/backend/tests/_vault_fakes.py
+++ b/backend/tests/_vault_fakes.py
@@ -187,10 +187,12 @@ class _FakeKVv2:
     )
     list_calls: list[dict[str, Any]] = field(default_factory=list)
     put_calls: list[dict[str, Any]] = field(default_factory=list)
+    patch_calls: list[dict[str, Any]] = field(default_factory=list)
     versions_calls: list[dict[str, Any]] = field(default_factory=list)
     delete_calls: list[dict[str, Any]] = field(default_factory=list)
     list_exc: Exception | None = None
     put_exc: Exception | None = None
+    patch_exc: Exception | None = None
     versions_exc: Exception | None = None
     delete_exc: Exception | None = None
 
@@ -228,6 +230,22 @@ class _FakeKVv2:
         )
         if self.put_exc is not None:
             raise self.put_exc
+        return {"data": {"version": self.version + 1}}
+
+    def patch(
+        self,
+        path: str,
+        secret: dict[str, Any],
+        mount_point: str = "secret",
+        **_kwargs: Any,
+    ) -> dict[str, Any]:
+        # hvac's ``patch`` takes no ``cas`` kwarg — it issues its own
+        # internal read+write. Mirror that signature so a stray ``cas``
+        # in a test would be a clear TypeError rather than silently
+        # accepted.
+        self.patch_calls.append({"path": path, "secret": secret, "mount_point": mount_point})
+        if self.patch_exc is not None:
+            raise self.patch_exc
         return {"data": {"version": self.version + 1}}
 
     def read_secret_metadata(
@@ -388,6 +406,7 @@ def install_fake_client(
     versions_meta: dict[str, Any] | None = None,
     list_exc: Exception | None = None,
     put_exc: Exception | None = None,
+    patch_exc: Exception | None = None,
     versions_exc: Exception | None = None,
     delete_exc: Exception | None = None,
 ) -> _FakeClient:
@@ -401,8 +420,8 @@ def install_fake_client(
     secret and KV-version overrides, the G3.3-T2 (#546) sys read
     group's seal-status / mounts / auth-methods payload + exception
     injection, and the G3.3-T1 KV-v2 verbs (list / put / versions /
-    delete) with per-verb exception injection and key/version-metadata
-    overrides.
+    patch / delete) with per-verb exception injection and
+    key/version-metadata overrides.
     """
     fake = install_fake_vault(monkeypatch, kv_version=kv_version if kv_version is not None else 11)
     fake.auth.jwt.raise_on_login = login_exc
@@ -425,6 +444,7 @@ def install_fake_client(
         kv.versions_meta = versions_meta
     kv.list_exc = list_exc
     kv.put_exc = put_exc
+    kv.patch_exc = patch_exc
     kv.versions_exc = versions_exc
     kv.delete_exc = delete_exc
     return fake

--- a/backend/tests/integration/test_connectors_vault_dev_e2e.py
+++ b/backend/tests/integration/test_connectors_vault_dev_e2e.py
@@ -552,6 +552,11 @@ async def test_kv_put_against_dev_vault(
         op_id="vault.kv.put",
         target=target,
         params={"path": "app/written", "data": {"k": sentinel}},
+        # ``vault.kv.put`` is now approval-gated (requires_approval=True, G3.15-T1
+        # #1409); the approvals-API resume flag drives the authorized-execution
+        # path so the write actually lands and the read-back + redaction
+        # assertions below still run (the same flag a human approval sets).
+        _approved=True,
     )
     assert result.status == "ok", result.error
     assert result.result == {"version": 1}
@@ -613,6 +618,10 @@ async def test_kv_patch_against_dev_vault(
         op_id="vault.kv.patch",
         target=target,
         params={"path": "app/to-patch", "data": {"rotate": sentinel, "added": "new"}},
+        # ``vault.kv.patch`` is approval-gated (requires_approval=True, G3.15-T1
+        # #1409); resume via the approvals-API flag so the partial-merge write
+        # executes and the read-back + redaction assertions still run.
+        _approved=True,
     )
     assert result.status == "ok", result.error
     assert result.result == {"version": 2}
@@ -694,6 +703,10 @@ async def test_kv_delete_against_dev_vault(
         op_id="vault.kv.delete",
         target=target,
         params={"path": "app/to-delete", "versions": [1]},
+        # ``vault.kv.delete`` is approval-gated (requires_approval=True, G3.15-T1
+        # #1409); resume via the approvals-API flag so the soft-delete executes
+        # and the audit/op_class assertions still run.
+        _approved=True,
     )
     assert result.status == "ok", result.error
     assert result.result == {"deleted_versions": [1]}

--- a/backend/tests/integration/test_connectors_vault_dev_e2e.py
+++ b/backend/tests/integration/test_connectors_vault_dev_e2e.py
@@ -32,9 +32,10 @@ What this harness proves (issue #551 DoD)
   response shape, that a synchronous ``audit_log`` row committed
   (CLAUDE.md postulate 7), and that the broadcast event's
   ``op_class`` is correct — ``credential_write`` for ``vault.kv.put``
-  (its KV-v2 secret rides in the request params, so the broadcast
-  collapses to aggregate-only per G11.7-T1 #1401), ``write`` for
-  ``vault.kv.delete``, ``credential_read`` for ``vault.kv.read`` /
+  and ``vault.kv.patch`` (their KV-v2 secret rides in the request
+  params, so the broadcast collapses to aggregate-only per G11.7-T1
+  #1401 / G3.15-T1 #1409), ``write`` for ``vault.kv.delete``,
+  ``credential_read`` for ``vault.kv.read`` /
   ``vault.kv.list``, ``read`` for the KV-v2 / sys metadata reads and
   the ``.list`` auth ops, and ``other`` for the two ``.read``
   auth-config ops (``vault.auth.userpass.read`` /
@@ -580,6 +581,68 @@ async def test_kv_put_against_dev_vault(
     assert sentinel not in serialised, (
         f"credential_write leak: {sentinel!r} reached the broadcast event for "
         f"vault.kv.put — serialised event: {serialised}"
+    )
+
+
+@pytest.mark.asyncio
+async def test_kv_patch_against_dev_vault(
+    vault_e2e: tuple[_VaultTarget, str],
+    captured_events: list[BroadcastEvent],
+) -> None:
+    """``vault.kv.patch`` merges a field; audited; op_class=credential_write.
+
+    Proves the partial-write semantics end-to-end: an existing secret is
+    seeded with two keys, ``vault.kv.patch`` merges a third (and rotates
+    one), and the read-back shows the untouched key preserved alongside
+    the merged fields — the distinguishing behaviour vs. ``vault.kv.put``
+    (wholesale replace). The merged sentinel value must be absent from
+    the serialised broadcast event (``credential_write`` redaction,
+    same posture as ``vault.kv.put``).
+    """
+    target, addr = vault_e2e
+    sentinel = "kvpatch-secret-sentinel-1409"
+    _root_client(addr).secrets.kv.v2.create_or_update_secret(
+        path="app/to-patch",
+        secret={"keep": "original", "rotate": "old"},
+        mount_point=_KV_MOUNT,
+    )
+    operator = _make_operator(sub="op-kv-patch")
+    result = await dispatch(
+        operator=operator,
+        connector_id="vault-1.x",
+        op_id="vault.kv.patch",
+        target=target,
+        params={"path": "app/to-patch", "data": {"rotate": sentinel, "added": "new"}},
+    )
+    assert result.status == "ok", result.error
+    assert result.result == {"version": 2}
+    # Read back: the untouched key survives, the rotated/added keys land —
+    # the partial-merge contract that separates patch from put.
+    readback = _root_client(addr).secrets.kv.v2.read_secret_version(
+        path="app/to-patch",
+        mount_point=_KV_MOUNT,
+        raise_on_deleted_version=False,
+    )
+    assert readback["data"]["data"] == {
+        "keep": "original",
+        "rotate": sentinel,
+        "added": "new",
+    }
+    await _assert_audited(
+        "vault.kv.patch",
+        operator_sub="op-kv-patch",
+        expected_op_class="credential_write",
+        events=captured_events,
+    )
+    patch_event = next(e for e in captured_events if e.op_id == "vault.kv.patch")
+    assert patch_event.payload == {
+        "op_class": "credential_write",
+        "result_status": "ok",
+    }
+    serialised = patch_event.model_dump_json()
+    assert sentinel not in serialised, (
+        f"credential_write leak: {sentinel!r} reached the broadcast event for "
+        f"vault.kv.patch — serialised event: {serialised}"
     )
 
 

--- a/backend/tests/test_broadcast_events.py
+++ b/backend/tests/test_broadcast_events.py
@@ -208,6 +208,7 @@ class TestClassifyOp:
             "vault.auth.userpass.write",
             "vault.auth.userpass.update_password",
             "vault.kv.put",
+            "vault.kv.patch",
             "k8s.secret.create",
         ],
     )

--- a/backend/tests/test_connectors_vault.py
+++ b/backend/tests/test_connectors_vault.py
@@ -83,6 +83,7 @@ from meho_backplane.connectors.vault import (
     VaultConnector,
     register_vault_typed_operations,
 )
+from meho_backplane.connectors.vault.ops import _KV_OP_SPECS
 from meho_backplane.operations import dispatch, reset_dispatcher_caches
 from meho_backplane.settings import get_settings
 
@@ -203,7 +204,11 @@ def _make_operator(jwt: str = "fake.jwt.value") -> Operator:
 
 
 async def _dispatch_vault(
-    op_id: str, params: dict[str, Any], *, jwt: str = "fake.jwt.value"
+    op_id: str,
+    params: dict[str, Any],
+    *,
+    jwt: str = "fake.jwt.value",
+    approved: bool = True,
 ) -> OperationResult:
     """Dispatch a vault op through the real operator-aware path.
 
@@ -213,6 +218,14 @@ async def _dispatch_vault(
     resolved by ``connector_id``, ``target`` is ``None`` (vault
     connection params come from settings). The handler reads the JWT
     from ``operator.raw_jwt`` — exactly the contract #629 establishes.
+
+    ``approved`` threads the dispatcher's ``_approved`` resume-path flag
+    (default ``True`` here). The mutating KV ops register
+    ``requires_approval=True`` (G3.15-T1 #1409), so without it the
+    policy gate would park the call at ``awaiting_approval`` and the
+    handler→hvac contract these tests assert would never run. The
+    parking behaviour itself is covered by ``test_approval_queue.py``;
+    these tests exercise the handler as the approval-resume path does.
     """
     return await dispatch(
         operator=_make_operator(jwt),
@@ -220,6 +233,7 @@ async def _dispatch_vault(
         op_id=op_id,
         target=None,
         params=params,
+        _approved=approved,
     )
 
 
@@ -659,6 +673,40 @@ async def test_execute_vault_kv_put_writes_new_version(
     ]
 
 
+@pytest.mark.parametrize(
+    "op_id,params",
+    [
+        ("vault.kv.put", {"path": "p", "data": {"k": "v"}}),
+        ("vault.kv.patch", {"path": "p", "data": {"k": "v"}}),
+        ("vault.kv.delete", {"path": "p", "versions": [1]}),
+    ],
+    ids=["put", "patch", "delete"],
+)
+async def test_execute_mutating_kv_op_parks_without_approval(
+    monkeypatch: pytest.MonkeyPatch,
+    op_id: str,
+    params: dict[str, Any],
+    _registered_vault_typed_ops: None,
+) -> None:
+    """A human principal hitting a mutating KV op is parked, not executed.
+
+    End-to-end proof that ``requires_approval=True`` (G3.15-T1 #1409) is
+    live on the registered descriptor: dispatching without the
+    approval-resume flag routes the call to the approval queue
+    (``awaiting_approval``) per G11.7-T1 (#1401) rather than reaching
+    hvac. The handler's ``*_calls`` log stays empty — the write never
+    ran.
+    """
+    fake = install_fake_client(monkeypatch)
+    result = await _dispatch_vault(op_id, params, approved=False)
+
+    assert result.status == "awaiting_approval", result.error
+    kv = fake.secrets.kv.v2
+    assert kv.put_calls == []
+    assert kv.patch_calls == []
+    assert kv.delete_calls == []
+
+
 async def test_execute_vault_kv_put_cas_omitted_passes_none(
     monkeypatch: pytest.MonkeyPatch,
     _registered_vault_typed_ops: None,
@@ -687,6 +735,77 @@ async def test_execute_vault_kv_put_invalid_params_returns_dispatcher_error(
     """Schema enforces ``required`` path+data and ``minProperties`` on data."""
     install_fake_client(monkeypatch)
     result = await _dispatch_vault("vault.kv.put", params)
+
+    assert result.status == "error"
+    assert result.error is not None
+    assert result.error.startswith("invalid_params:")
+    assert result.extras.get("error_code") == "invalid_params"
+
+
+async def test_execute_vault_kv_patch_merges_fields(
+    monkeypatch: pytest.MonkeyPatch,
+    _registered_vault_typed_ops: None,
+) -> None:
+    """``vault.kv.patch`` forwards the merge fields to hvac's ``patch``."""
+    fake = install_fake_client(monkeypatch, kv_version=4)
+    result = await _dispatch_vault(
+        "vault.kv.patch",
+        {"path": "meho/test", "data": {"token": "rotated"}},
+        jwt="op-jwt",
+    )
+
+    assert result.status == "ok", result.error
+    assert isinstance(result.result, dict)
+    assert result.result["version"] == 5
+    assert fake.secrets.kv.v2.patch_calls == [
+        {
+            "path": "meho/test",
+            "secret": {"token": "rotated"},
+            "mount_point": "secret",
+        },
+    ]
+
+
+async def test_execute_vault_kv_patch_honors_explicit_mount(
+    monkeypatch: pytest.MonkeyPatch,
+    _registered_vault_typed_ops: None,
+) -> None:
+    fake = install_fake_client(monkeypatch)
+    result = await _dispatch_vault(
+        "vault.kv.patch",
+        {"mount": "kv-prod", "path": "team", "data": {"k": "v"}},
+    )
+
+    assert result.status == "ok", result.error
+    assert fake.secrets.kv.v2.patch_calls == [
+        {"path": "team", "secret": {"k": "v"}, "mount_point": "kv-prod"},
+    ]
+
+
+@pytest.mark.parametrize(
+    "params",
+    [
+        {"path": "p"},
+        {"data": {"k": "v"}},
+        {"path": "p", "data": {}},
+        {"path": "p", "data": {"k": "v"}, "cas": 1},
+    ],
+    ids=["missing-data", "missing-path", "empty-data", "rejects-cas"],
+)
+async def test_execute_vault_kv_patch_invalid_params_returns_dispatcher_error(
+    monkeypatch: pytest.MonkeyPatch,
+    params: dict[str, Any],
+    _registered_vault_typed_ops: None,
+) -> None:
+    """Schema enforces required path+data, minProperties on data, and rejects ``cas``.
+
+    hvac's ``patch`` exposes no ``cas`` guard (it issues its own
+    internal read+write), so the schema's ``additionalProperties=False``
+    turns a stray ``cas`` into an ``invalid_params`` error rather than
+    silently dropping it.
+    """
+    install_fake_client(monkeypatch)
+    result = await _dispatch_vault("vault.kv.patch", params)
 
     assert result.status == "error"
     assert result.error is not None
@@ -764,10 +883,11 @@ async def test_execute_vault_kv_delete_invalid_params_returns_dispatcher_error(
     [
         ("vault.kv.list", {"path": "p"}, "list_exc"),
         ("vault.kv.put", {"path": "p", "data": {"k": "v"}}, "put_exc"),
+        ("vault.kv.patch", {"path": "p", "data": {"k": "v"}}, "patch_exc"),
         ("vault.kv.versions", {"path": "p"}, "versions_exc"),
         ("vault.kv.delete", {"path": "p", "versions": [1]}, "delete_exc"),
     ],
-    ids=["list", "put", "versions", "delete"],
+    ids=["list", "put", "patch", "versions", "delete"],
 )
 async def test_execute_kv_ops_vault_error_envelope_surfaces_connector_error(
     monkeypatch: pytest.MonkeyPatch,
@@ -824,6 +944,12 @@ async def test_execute_vault_kv_list_malformed_payload_is_structured_error(
         # broadcast the written secret in full). ``vault.kv.delete``
         # carries no secret and stays ``write``.
         ("vault.kv.put", "credential_write"),
+        # G3.15-T1 #1409 — ``vault.kv.patch`` carries the merged fields in
+        # its request params, same posture as ``vault.kv.put``, so it
+        # classifies ``credential_write`` rather than falling through to
+        # the ``.patch`` write-suffix (which would broadcast the partial
+        # secret in full).
+        ("vault.kv.patch", "credential_write"),
         ("vault.kv.delete", "write"),
     ],
 )
@@ -841,3 +967,42 @@ def test_kv_op_ids_classify_per_decision_3(op_id: str, expected_class: str) -> N
     secret-free mutating verbs are ``write``.
     """
     assert classify_op(op_id) == expected_class
+
+
+# ---------------------------------------------------------------------------
+# Register-time safety / approval contract (G3.15-T1 #1409)
+# ---------------------------------------------------------------------------
+
+#: The KV-v2 ops that register ``requires_approval=True`` plus their
+#: ``safety_level`` posture. Read ops are excluded — they default
+#: ``requires_approval=False``.
+_KV_APPROVAL_CONTRACT = {
+    "vault.kv.put": "caution",
+    "vault.kv.patch": "caution",
+    "vault.kv.delete": "dangerous",
+}
+
+
+@pytest.mark.parametrize("op_id,expected_safety", sorted(_KV_APPROVAL_CONTRACT.items()))
+def test_kv_mutating_ops_require_approval(op_id: str, expected_safety: str) -> None:
+    """Mutating KV-v2 ops register ``requires_approval=True`` + their safety level.
+
+    G3.15-T1 (#1409) flips ``vault.kv.put`` / ``vault.kv.delete`` to
+    ``requires_approval=True`` and adds ``vault.kv.patch`` (also
+    ``requires_approval=True``). The flag became meaningful once
+    G11.7-T1 (#1401) routed human principals hitting a
+    ``requires_approval`` op to the approval queue instead of
+    hard-denying. Asserting against ``_KV_OP_SPECS`` pins the
+    register-time contract without standing up a DB row.
+    """
+    by_id = {spec["op_id"]: spec for spec in _KV_OP_SPECS}
+    spec = by_id[op_id]
+    assert spec.get("requires_approval") is True, f"{op_id} must require approval"
+    assert spec["safety_level"] == expected_safety, op_id
+
+
+@pytest.mark.parametrize("op_id", ["vault.kv.read", "vault.kv.list", "vault.kv.versions"])
+def test_kv_read_ops_do_not_require_approval(op_id: str) -> None:
+    """Read-only KV-v2 ops omit ``requires_approval`` (default False)."""
+    by_id = {spec["op_id"]: spec for spec in _KV_OP_SPECS}
+    assert by_id[op_id].get("requires_approval", False) is False, op_id

--- a/docs/codebase/connectors-vault.md
+++ b/docs/codebase/connectors-vault.md
@@ -85,9 +85,21 @@ Source: `backend/src/meho_backplane/connectors/vault/`.
 | `vault.kv.list` | `list_secrets` | safe | `credential_read` |
 | `vault.kv.versions` | `read_secret_metadata` | safe | `read` |
 | `vault.kv.put` | `create_or_update_secret` | caution | `credential_write` |
+| `vault.kv.patch` | `patch` | caution | `credential_write` |
 | `vault.kv.delete` | `delete_secret_versions` | dangerous | `write` |
 
-All five register into operation group `kv`.
+All six register into operation group `kv`.
+
+**`kv.put` vs. `kv.patch`.** `kv.put` replaces the latest version
+wholesale (KV v2 does not merge — omitted keys are dropped). `kv.patch`
+is the partial-write counterpart (G3.15-T1 #1409): hvac's
+`secrets.kv.v2.patch` reads the current version, JSON-merges the
+supplied `data` over it, and writes the result as a new version, so
+keys absent from the request are preserved. The secret must already
+exist (patching a missing path fails). `patch` exposes no `cas` guard
+(it issues its own internal read+write), so the `kv.patch` schema —
+unlike `kv.put` — has no `cas` property and `additionalProperties=False`
+rejects a stray one.
 
 **Mount handling.** Every handler — including `vault.kv.read` —
 accepts an optional `mount` param (JSON Schema default `"secret"`,
@@ -121,9 +133,10 @@ The G6 broadcast publisher emits an aggregate-only payload for
 derived **from the op-id**, not a per-descriptor field:
 `broadcast.events.classify_op` consults the `_CREDENTIAL_READ_OPS`
 allowlist (currently `{vault.kv.read, vault.kv.list}`), the
-`_CREDENTIAL_WRITE_OPS` allowlist (G11.7-T1 #1401 — `{vault.kv.put,
-vault.auth.userpass.write, vault.auth.userpass.update_password,
-k8s.secret.create}`), and the `_WRITE_SUFFIXES` / `_READ_SUFFIXES`
+`_CREDENTIAL_WRITE_OPS` allowlist (G11.7-T1 #1401 / G3.15-T1 #1409 —
+`{vault.kv.put, vault.kv.patch, vault.auth.userpass.write,
+vault.auth.userpass.update_password, k8s.secret.create, k8s.job.create}`),
+and the `_WRITE_SUFFIXES` / `_READ_SUFFIXES`
 tuples. The shipped G0.6 `endpoint_descriptor` table has **no
 `op_class` column** — decision #3 locks the classifier on the op-id, so
 the register-time signal is the op-id itself. `vault.kv.versions` reads
@@ -135,7 +148,11 @@ secret `data` is in the *request params*, and the broadcast ships
 params, so it must collapse to aggregate-only. It previously
 classified plain `write` via the `.put` write-suffix (#545), which kept
 it out of the `other` class but still broadcast the written secret in
-full — the `credential_write` reclassification closes that. Response-side
+full — the `credential_write` reclassification closes that.
+`vault.kv.patch` (G3.15-T1 #1409) gets the same explicit pin for the
+same reason: its merged fields ride in `params`, and without the
+allowlist entry the `.patch` write-suffix would broadcast the partial
+secret in full. Response-side
 secret-mint ops (`vault.token.create`,
 `vault.auth.approle.generate_secret_id`) classify `credential_mint`
 alongside `harbor.robot.create`. See `docs/codebase/broadcast.md` for
@@ -143,14 +160,18 @@ the full sensitivity taxonomy.
 
 ## Approval gating
 
-`vault.kv.put` (`caution`) and `vault.kv.delete` (`dangerous`)
-register with `requires_approval=False` — the dev default.
-`requires_approval` is a static boolean on the descriptor; the shipped
-G0.6 substrate has no per-path approval predicate. The
-production-path approval gate is G7/G10 policy territory (see the
-`EndpointDescriptor` model docstring: `caution`/`dangerous` ops "flow
-through G7 / G10 policy logic once those Goals land"). `safety_level`
-is the load-bearing signal that future gate keys on.
+The mutating KV ops — `vault.kv.put` (`caution`), `vault.kv.patch`
+(`caution`), `vault.kv.delete` (`dangerous`) — register
+`requires_approval=True` (G3.15-T1 #1409). The flag became meaningful
+once G11.7-T1 (#1401) routed human principals hitting a
+`requires_approval` op to the **approval queue** (park for review)
+instead of hard-denying — so the gate no longer blocks the operator,
+it parks the write. The read ops (`vault.kv.read` / `vault.kv.list` /
+`vault.kv.versions`) omit the key and default `False`.
+`requires_approval` is carried per-op in `_KV_OP_SPECS`; the
+registration loop forwards `spec.get("requires_approval", False)`.
+`safety_level` is the orthogonal posture signal (it does not by itself
+gate execution).
 
 ## JSONFlux result-handle path (`vault.kv.list`)
 


### PR DESCRIPTION
## Summary

- Promote `vault.kv.put` / `vault.kv.delete` to `requires_approval=True` — meaningful now that G11.7-T1 (#1401) routes human principals hitting a `requires_approval` op to the **approval queue** (park for review) instead of hard-denying.
- Add `vault.kv.patch` (caution, `requires_approval=True`) — JSON-merge partial write via hvac 2.4.0 `secrets.kv.v2.patch` wrapped in `asyncio.to_thread`, what `vault-store patch --field` needs. Unlike `kv.put` it preserves keys absent from the request; `patch` has no `cas` guard so the schema omits one.
- `vault.kv.patch` joins the `_CREDENTIAL_WRITE_OPS` broadcast allowlist (same posture as `kv.put`): its merged fields ride in request params, so the broadcast collapses to aggregate-only — without the pin the `.patch` write-suffix would leak the partial secret.
- `requires_approval` is carried per-op in `_KV_OP_SPECS`; read ops omit it and default `False`.

## Test plan

- [x] `ruff check` / `ruff format --check` — clean on all changed files
- [x] `mypy src/meho_backplane/ --ignore-missing-imports` — Success, no issues
- [x] `pytest tests/test_connectors_vault.py` — 61 passed (incl. patch happy-path, explicit-mount, invalid-params w/ `cas`-rejection, error-envelope, gate-parks-without-approval, register-time `requires_approval`/`safety_level` contract)
- [x] `pytest -k "vault or broadcast or approval or classify or descriptor"` — 867 passed, 55 skipped
- [x] `code-quality.py --diff` — 0 blockers (6 pre-existing legacy warnings on touched files)
- [x] `cd cli && make snapshot-openapi && make generate` — no delta (typed ops register at runtime, not in the static OpenAPI schema)
- [x] Live-vault e2e patch case added (`tests/integration/test_connectors_vault_dev_e2e.py`) asserting partial-merge semantics + `credential_write` broadcast redaction — runs in the `Python (integration testcontainers)` lane
- [x] Docs updated: `docs/codebase/connectors-vault.md` (op table, `kv.put` vs `kv.patch`, broadcast allowlist, approval gating)

## Out of scope

- Policy / userpass / approle / identity / token / sys-bootstrap write ops — sibling Tasks T2–T5 (#1410–#1413) under the same Initiative.

<!-- auto-implement-issue: fresh, iteration 1 -->

Closes #1409


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

# Release Notes

* **New Features**
  * Added `vault.kv.patch` operation for partial/merge updates to Vault KV-v2 secrets, allowing selective field updates while preserving existing data.

* **Changes**
  * Mutating KV operations (`vault.kv.put`, `vault.kv.patch`, `vault.kv.delete`) now require approval before execution.
  * Enhanced credential redaction in broadcast events for sensitive write operations.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->