### PR TITLE
feat(connectors): G3.15-T3 vault auth credential lifecycle write ops + request/response secret redaction

### DIFF
--- a/backend/src/meho_backplane/broadcast/events.py
+++ b/backend/src/meho_backplane/broadcast/events.py
@@ -151,6 +151,17 @@ _WRITE_SUFFIXES: Final[tuple[str, ...]] = (
     ".delete",
     ".patch",
     ".put",
+    # ``.write`` is the Vault mutating-write verb spelling for the auth
+    # and sys-policy surfaces (G3.15 #1410/#1411): ``vault.auth.approle.write``
+    # creates an AppRole (no secret in params → plain ``write``),
+    # ``vault.sys.policy.write`` writes a policy document. Without this
+    # suffix they fall through to ``other`` and broadcast their full
+    # params. The secret-bearing ``.write`` ops
+    # (``vault.auth.userpass.write`` / ``vault.auth.userpass.update_password``)
+    # are pinned in :data:`_CREDENTIAL_WRITE_OPS`, which ``classify_op``
+    # consults BEFORE this suffix branch, so this addition never downgrades
+    # a credential write to plain ``write``.
+    ".write",
     # bind9 record-write verbs (G3.4-T3 #589). The bind9 connector
     # uses ``.add`` / ``.remove`` rather than ``.create`` / ``.delete``
     # to match the consumer wrapper's verb shape (``--add-a-record``
@@ -310,7 +321,10 @@ def classify_op(op_id: str) -> str:
        map to ``write``. Checked before the dot-suffix branches since
        ingested ops carry no meho verb suffix.
     6. ``write`` — mutation suffixes (``.create`` / ``.update`` /
-       ``.delete`` / ``.patch``).
+       ``.delete`` / ``.patch`` / ``.put`` / ``.write``). The
+       secret-bearing ``.write`` ops (``vault.auth.userpass.write`` /
+       ``.update_password``) are pinned in step 3's allowlist, so they
+       never reach this branch.
     7. ``read`` — non-mutating verb suffixes (``.list`` / ``.info`` /
        ``.get`` / ``.about`` / ``.ls``).
     8. ``other`` — everything else. Falls through to full-detail

--- a/backend/src/meho_backplane/connectors/vault/ops.py
+++ b/backend/src/meho_backplane/connectors/vault/ops.py
@@ -71,6 +71,7 @@ from typing import Any
 import meho_backplane.auth.vault as _auth_vault
 from meho_backplane.auth.operator import Operator
 from meho_backplane.connectors.vault.ops_auth import register_vault_auth_operations
+from meho_backplane.connectors.vault.ops_auth_write import register_vault_auth_write_operations
 from meho_backplane.operations.typed_register import register_typed_operation
 from meho_backplane.retrieval.embedding import EmbeddingService
 
@@ -854,3 +855,9 @@ async def register_vault_typed_operations(
     # module so the auth surface stays independently reviewable while
     # the package keeps a single lifespan-driven registrar entry.
     await register_vault_auth_operations(embedding_service=embedding_service)
+    # Auth credential-lifecycle write group (G3.15-T3 #1411) -- the
+    # userpass/approle write half (create/update/delete + secret-id
+    # mint), all requires_approval=True with request/response secret
+    # redaction at the classification layer. Its own module, same
+    # single-registrar-entry discipline as the read group above.
+    await register_vault_auth_write_operations(embedding_service=embedding_service)

--- a/backend/src/meho_backplane/connectors/vault/ops_auth.py
+++ b/backend/src/meho_backplane/connectors/vault/ops_auth.py
@@ -14,12 +14,13 @@ authenticate to Vault:
 * ``vault.auth.approle.list``  -- ``LIST /v1/auth/<mount>/role``
 * ``vault.auth.approle.read``  -- ``GET  /v1/auth/<mount>/role/<role>``
 
-AppRole **secret-id generation** and every userpass/approle **write**
-(create/update/delete user or role) are explicitly out of scope for
-v0.2 -- secret-id generation is a high-risk write with policy
-implications, deferred to v0.2.next behind a policy gate (Initiative
-#366, Task #547 out-of-scope sections). Only the four read ops above
-land here.
+Only the four **read** ops above land in this module. The userpass /
+approle **write** half -- create/update/delete user or role plus
+AppRole secret-id generation, all ``requires_approval=True`` with
+request/response secret redaction -- lives in the sibling
+:mod:`meho_backplane.connectors.vault.ops_auth_write` module (G3.15-T3
+#1411), registered from the same package registrar so the read and
+write surfaces stay independently reviewable.
 
 Handler shape mirrors :mod:`meho_backplane.connectors.vault.ops`
 verbatim: each handler is a module-level ``async def`` with the

--- a/backend/src/meho_backplane/connectors/vault/ops_auth_write.py
+++ b/backend/src/meho_backplane/connectors/vault/ops_auth_write.py
@@ -1,0 +1,523 @@
+# SPDX-License-Identifier: Apache-2.0
+# Copyright (c) 2026 evoila Group
+
+"""Vault auth credential-lifecycle write handlers + registration (G3.15-T3).
+
+Op-id namespace: ``vault.auth.<backend>.<verb>``. This module ships the
+**write half** of the userpass + approle auth surface -- the credential
+lifecycle the consumer's ``/vault-admin`` wrapper exercises:
+
+* ``vault.auth.userpass.write`` -- ``create_or_update_user`` (dangerous;
+  password in params -> ``credential_write``; binds ``token_policies``).
+* ``vault.auth.userpass.update_password`` -- ``update_password_on_user``
+  (caution; password in params -> ``credential_write``).
+* ``vault.auth.userpass.delete`` -- ``delete_user`` (dangerous).
+* ``vault.auth.approle.write`` -- ``create_or_update_approle`` (dangerous).
+* ``vault.auth.approle.delete`` -- ``delete_role`` (dangerous).
+* ``vault.auth.approle.generate_secret_id`` -- ``generate_secret_id``
+  (dangerous; SecretID in the **response** -> ``credential_mint``;
+  non-idempotent -- mints a fresh SecretID each call).
+
+Every op registers ``requires_approval=True``: each is a privilege
+assignment, an irreversible identity removal, or a secret mint. The
+production-path approval routing (a human/service principal floors to
+the approval queue) is owned by the G11.7-T1 (#1401) policy gate; this
+module only marks the descriptors.
+
+**Secret redaction is at the classification layer, not the handler**
+(#1411 / #1401). The secret never reaches the audit row -- the audit
+payload stores a ``params_hash``, never the raw params -- and never
+reaches the broadcast feed, because
+:func:`meho_backplane.broadcast.events.classify_op` maps the two
+password ops to ``credential_write`` (request-secret, aggregate-only
+broadcast) and ``generate_secret_id`` to ``credential_mint``
+(response-secret, aggregate-only broadcast). The handlers add a second
+layer of defence by returning **value-free** confirmations for the
+write ops (username/role + assigned policies, never the password); the
+``generate_secret_id`` handler is the one exception -- it returns the
+minted SecretID to the caller's ``OperationResult`` (the whole point of
+minting), which classification keeps out of audit + broadcast.
+
+Handler shape mirrors
+:mod:`meho_backplane.connectors.vault.ops_auth` verbatim: each is a
+module-level ``async def`` with the ``(operator, target, params) ->
+dict`` typed-op contract, raises on failure (the dispatcher's
+``connector_error`` branch records the class name in
+``extras["exception_class"]``), forwards the operator JWT via
+``vault_client_for_operator``, and offloads the blocking hvac call with
+``asyncio.to_thread``. The backend-not-mounted reclassification reuses
+the read module's :class:`VaultAuthBackendNotMountedError` and probe
+helper so a 404 from an unmounted backend surfaces the same
+operator-actionable error class as the read ops.
+"""
+
+from __future__ import annotations
+
+import asyncio
+from typing import Any
+
+import hvac.exceptions
+
+import meho_backplane.auth.vault as _auth_vault
+from meho_backplane.auth.operator import Operator
+from meho_backplane.connectors.vault.ops_auth import (
+    VaultAuthBackendNotMountedError,
+    _reclassify_not_found,
+)
+from meho_backplane.connectors.vault.ops_auth_write_schemas import (
+    VAULT_AUTH_APPROLE_DELETE_LLM_INSTRUCTIONS,
+    VAULT_AUTH_APPROLE_DELETE_PARAMETER_SCHEMA,
+    VAULT_AUTH_APPROLE_DELETE_RESPONSE_SCHEMA,
+    VAULT_AUTH_APPROLE_GENERATE_SECRET_ID_LLM_INSTRUCTIONS,
+    VAULT_AUTH_APPROLE_GENERATE_SECRET_ID_PARAMETER_SCHEMA,
+    VAULT_AUTH_APPROLE_GENERATE_SECRET_ID_RESPONSE_SCHEMA,
+    VAULT_AUTH_APPROLE_WRITE_LLM_INSTRUCTIONS,
+    VAULT_AUTH_APPROLE_WRITE_PARAMETER_SCHEMA,
+    VAULT_AUTH_APPROLE_WRITE_RESPONSE_SCHEMA,
+    VAULT_AUTH_USERPASS_DELETE_LLM_INSTRUCTIONS,
+    VAULT_AUTH_USERPASS_DELETE_PARAMETER_SCHEMA,
+    VAULT_AUTH_USERPASS_DELETE_RESPONSE_SCHEMA,
+    VAULT_AUTH_USERPASS_UPDATE_PASSWORD_LLM_INSTRUCTIONS,
+    VAULT_AUTH_USERPASS_UPDATE_PASSWORD_PARAMETER_SCHEMA,
+    VAULT_AUTH_USERPASS_UPDATE_PASSWORD_RESPONSE_SCHEMA,
+    VAULT_AUTH_USERPASS_WRITE_LLM_INSTRUCTIONS,
+    VAULT_AUTH_USERPASS_WRITE_PARAMETER_SCHEMA,
+    VAULT_AUTH_USERPASS_WRITE_RESPONSE_SCHEMA,
+)
+from meho_backplane.operations.typed_register import register_typed_operation
+from meho_backplane.retrieval.embedding import EmbeddingService
+
+__all__ = [
+    "register_vault_auth_write_operations",
+    "vault_auth_approle_delete",
+    "vault_auth_approle_generate_secret_id",
+    "vault_auth_approle_write",
+    "vault_auth_userpass_delete",
+    "vault_auth_userpass_update_password",
+    "vault_auth_userpass_write",
+]
+
+
+# --- userpass write handlers -----------------------------------------------
+
+
+async def vault_auth_userpass_write(
+    operator: Operator, target: Any, params: dict[str, Any]
+) -> dict[str, Any]:
+    """Create or update a userpass user (password + token policies).
+
+    Op-id: ``vault.auth.userpass.write``. Delegates to hvac's
+    ``client.auth.userpass.create_or_update_user(username=...,
+    password=..., token_policies=..., mount_point=...)``. ``token_policies``
+    is forwarded as a kwarg so Vault's modern ``token_policies`` field is
+    set (the legacy ``policies`` alias is left untouched).
+
+    The password is in the request params and is classified
+    ``credential_write`` -- redacted from the audit row (params_hash
+    only) and the broadcast feed (aggregate-only). The response is
+    value-free: it echoes the username, mount, and assigned policies,
+    never the password.
+    """
+    username: str = str(params["username"]).strip()
+    password: str = str(params["password"])
+    mount: str = str(params.get("mount", "userpass")).strip()
+    token_policies = params.get("token_policies")
+
+    kwargs: dict[str, Any] = {
+        "username": username,
+        "password": password,
+        "mount_point": mount,
+    }
+    if token_policies is not None:
+        kwargs["token_policies"] = list(token_policies)
+
+    async with _auth_vault.vault_client_for_operator(operator) as client:
+        try:
+            await asyncio.to_thread(client.auth.userpass.create_or_update_user, **kwargs)
+        except hvac.exceptions.InvalidPath as exc:
+            raise VaultAuthBackendNotMountedError(
+                f"userpass auth backend not mounted at {mount!r}"
+            ) from exc
+
+    result: dict[str, Any] = {"username": username, "mount": mount, "written": True}
+    if token_policies is not None:
+        result["token_policies"] = list(token_policies)
+    return result
+
+
+async def vault_auth_userpass_update_password(
+    operator: Operator, target: Any, params: dict[str, Any]
+) -> dict[str, Any]:
+    """Rotate an existing userpass user's password.
+
+    Op-id: ``vault.auth.userpass.update_password``. Delegates to hvac's
+    ``client.auth.userpass.update_password_on_user(username=...,
+    password=..., mount_point=...)``. Password-only change: token
+    policies are untouched.
+
+    The new password is in the request params and classifies
+    ``credential_write`` -- redacted from audit + broadcast. The response
+    is value-free (username + mount + confirmation flag).
+
+    A missing user under a *mounted* backend surfaces as the underlying
+    :class:`hvac.exceptions.InvalidPath`; only the backend-absent case is
+    reclassified to :class:`VaultAuthBackendNotMountedError` (the read
+    handlers' probe contract).
+    """
+    username: str = str(params["username"]).strip()
+    password: str = str(params["password"])
+    mount: str = str(params.get("mount", "userpass")).strip()
+
+    async with _auth_vault.vault_client_for_operator(operator) as client:
+        try:
+            await asyncio.to_thread(
+                client.auth.userpass.update_password_on_user,
+                username=username,
+                password=password,
+                mount_point=mount,
+            )
+        except hvac.exceptions.InvalidPath as exc:
+            await _reclassify_not_found(client, exc, mount=mount, backend="userpass")
+
+    return {"username": username, "mount": mount, "password_updated": True}
+
+
+async def vault_auth_userpass_delete(
+    operator: Operator, target: Any, params: dict[str, Any]
+) -> dict[str, Any]:
+    """Delete a userpass user.
+
+    Op-id: ``vault.auth.userpass.delete``. Delegates to hvac's
+    ``client.auth.userpass.delete_user(username=..., mount_point=...)``.
+    Vault's delete is idempotent (deleting a non-existent user is a
+    no-op success), so a ``404`` here only ever means the backend itself
+    is not mounted -- reclassified to
+    :class:`VaultAuthBackendNotMountedError`.
+    """
+    username: str = str(params["username"]).strip()
+    mount: str = str(params.get("mount", "userpass")).strip()
+
+    async with _auth_vault.vault_client_for_operator(operator) as client:
+        try:
+            await asyncio.to_thread(
+                client.auth.userpass.delete_user,
+                username=username,
+                mount_point=mount,
+            )
+        except hvac.exceptions.InvalidPath as exc:
+            raise VaultAuthBackendNotMountedError(
+                f"userpass auth backend not mounted at {mount!r}"
+            ) from exc
+
+    return {"username": username, "mount": mount, "deleted": True}
+
+
+# --- approle write handlers ------------------------------------------------
+
+#: AppRole config keys forwarded to hvac's ``create_or_update_approle``
+#: verbatim when present in params. Each is optional on the Vault side
+#: (omitting leaves the field unchanged on an update / at its default on
+#: a create), so the handler only passes the keys the caller supplied.
+_APPROLE_WRITE_FIELDS: tuple[str, ...] = (
+    "token_policies",
+    "token_ttl",
+    "token_max_ttl",
+    "secret_id_ttl",
+    "secret_id_num_uses",
+    "bind_secret_id",
+)
+
+
+async def vault_auth_approle_write(
+    operator: Operator, target: Any, params: dict[str, Any]
+) -> dict[str, Any]:
+    """Create or update an AppRole's token/SecretID config.
+
+    Op-id: ``vault.auth.approle.write``. Delegates to hvac's
+    ``client.auth.approle.create_or_update_approle(role_name=...,
+    mount_point=..., **config)``. Only the config keys the caller
+    supplied are forwarded (each is optional on the Vault side). Mints no
+    SecretID -- that is ``generate_secret_id``.
+    """
+    role_name: str = str(params["role_name"]).strip()
+    mount: str = str(params.get("mount", "approle")).strip()
+
+    kwargs: dict[str, Any] = {"role_name": role_name, "mount_point": mount}
+    for field in _APPROLE_WRITE_FIELDS:
+        if field in params and params[field] is not None:
+            kwargs[field] = params[field]
+
+    async with _auth_vault.vault_client_for_operator(operator) as client:
+        try:
+            await asyncio.to_thread(client.auth.approle.create_or_update_approle, **kwargs)
+        except hvac.exceptions.InvalidPath as exc:
+            raise VaultAuthBackendNotMountedError(
+                f"approle auth backend not mounted at {mount!r}"
+            ) from exc
+
+    return {"role_name": role_name, "mount": mount, "written": True}
+
+
+async def vault_auth_approle_delete(
+    operator: Operator, target: Any, params: dict[str, Any]
+) -> dict[str, Any]:
+    """Delete an AppRole.
+
+    Op-id: ``vault.auth.approle.delete``. Delegates to hvac's
+    ``client.auth.approle.delete_role(role_name=..., mount_point=...)``.
+    Idempotent like userpass delete; a ``404`` only means the backend is
+    not mounted.
+    """
+    role_name: str = str(params["role_name"]).strip()
+    mount: str = str(params.get("mount", "approle")).strip()
+
+    async with _auth_vault.vault_client_for_operator(operator) as client:
+        try:
+            await asyncio.to_thread(
+                client.auth.approle.delete_role,
+                role_name=role_name,
+                mount_point=mount,
+            )
+        except hvac.exceptions.InvalidPath as exc:
+            raise VaultAuthBackendNotMountedError(
+                f"approle auth backend not mounted at {mount!r}"
+            ) from exc
+
+    return {"role_name": role_name, "mount": mount, "deleted": True}
+
+
+async def vault_auth_approle_generate_secret_id(
+    operator: Operator, target: Any, params: dict[str, Any]
+) -> dict[str, Any]:
+    """Mint a fresh SecretID for an AppRole (NON-IDEMPOTENT).
+
+    Op-id: ``vault.auth.approle.generate_secret_id``. Delegates to hvac's
+    ``client.auth.approle.generate_secret_id(role_name=..., metadata=...,
+    cidr_list=..., token_bound_cidrs=..., mount_point=...)``.
+
+    Each call mints a brand-new SecretID -- the op is non-idempotent.
+    The SecretID lands in the *response*, so the op classifies
+    ``credential_mint``: the broadcast collapses to aggregate-only and
+    the audit row holds only a params_hash, so the minted SecretID never
+    reaches the feed or the audit store. The caller's
+    ``OperationResult`` still carries it (the whole point of minting) --
+    it must be stored immediately.
+
+    A missing role under a *mounted* backend surfaces as the underlying
+    :class:`hvac.exceptions.InvalidPath`; only the backend-absent case is
+    reclassified to :class:`VaultAuthBackendNotMountedError`.
+    """
+    role_name: str = str(params["role_name"]).strip()
+    mount: str = str(params.get("mount", "approle")).strip()
+
+    kwargs: dict[str, Any] = {"role_name": role_name, "mount_point": mount}
+    for field in ("metadata", "cidr_list", "token_bound_cidrs"):
+        if field in params and params[field] is not None:
+            kwargs[field] = params[field]
+
+    async with _auth_vault.vault_client_for_operator(operator) as client:
+        try:
+            payload = await asyncio.to_thread(client.auth.approle.generate_secret_id, **kwargs)
+        except hvac.exceptions.InvalidPath as exc:
+            await _reclassify_not_found(client, exc, mount=mount, backend="approle")
+
+    data = dict(payload["data"])
+    result: dict[str, Any] = {
+        "secret_id": data["secret_id"],
+        "role_name": role_name,
+        "mount": mount,
+    }
+    if "secret_id_accessor" in data:
+        result["secret_id_accessor"] = data["secret_id_accessor"]
+    if "secret_id_ttl" in data:
+        result["secret_id_ttl"] = data["secret_id_ttl"]
+    return result
+
+
+# --- registration ----------------------------------------------------------
+
+#: Per-op registration spec for the auth-write surface. Each row carries
+#: its ``safety_level`` (the load-bearing signal the future policy gate
+#: keys on) and ``tags``; all register ``requires_approval=True`` and
+#: ``group_key="auth"`` in :func:`register_vault_auth_write_operations`.
+_AUTH_WRITE_OP_SPECS: tuple[dict[str, Any], ...] = (
+    {
+        "op_id": "vault.auth.userpass.write",
+        "handler": vault_auth_userpass_write,
+        "summary": "Create or update a userpass user (password + token policies).",
+        "description": (
+            "Creates a new userpass user or updates an existing one's "
+            "password and/or token policies (POST "
+            "/v1/auth/<mount>/users/<user>). The password rides in the "
+            "request params and is classified credential_write: redacted "
+            "from the audit row (params_hash only) and the broadcast feed "
+            "(aggregate-only). Binding token_policies is a privilege "
+            "assignment -- safety_level=dangerous, requires_approval=True. "
+            "The response is value-free (username, mount, assigned "
+            "policies; never the password). userpass not enabled raises "
+            "VaultAuthBackendNotMountedError, surfaced as a "
+            "connector_error OperationResult."
+        ),
+        "parameter_schema": VAULT_AUTH_USERPASS_WRITE_PARAMETER_SCHEMA,
+        "response_schema": VAULT_AUTH_USERPASS_WRITE_RESPONSE_SCHEMA,
+        "tags": ["write", "credential-write", "auth", "identity"],
+        "safety_level": "dangerous",
+        "llm_instructions": VAULT_AUTH_USERPASS_WRITE_LLM_INSTRUCTIONS,
+    },
+    {
+        "op_id": "vault.auth.userpass.update_password",
+        "handler": vault_auth_userpass_update_password,
+        "summary": "Rotate an existing userpass user's password.",
+        "description": (
+            "Rotates an existing userpass user's password without "
+            "touching their token policies (POST "
+            "/v1/auth/<mount>/users/<user>/password). The new password "
+            "rides in the request params and is classified "
+            "credential_write: redacted from the audit row and the "
+            "broadcast feed. safety_level=caution, requires_approval=True. "
+            "The response is value-free. A missing user under a mounted "
+            "backend surfaces as InvalidPath; userpass not enabled raises "
+            "VaultAuthBackendNotMountedError."
+        ),
+        "parameter_schema": VAULT_AUTH_USERPASS_UPDATE_PASSWORD_PARAMETER_SCHEMA,
+        "response_schema": VAULT_AUTH_USERPASS_UPDATE_PASSWORD_RESPONSE_SCHEMA,
+        "tags": ["write", "credential-write", "auth", "identity"],
+        "safety_level": "caution",
+        "llm_instructions": VAULT_AUTH_USERPASS_UPDATE_PASSWORD_LLM_INSTRUCTIONS,
+    },
+    {
+        "op_id": "vault.auth.userpass.delete",
+        "handler": vault_auth_userpass_delete,
+        "summary": "Delete a userpass user.",
+        "description": (
+            "Deletes a userpass user, revoking their login (DELETE "
+            "/v1/auth/<mount>/users/<user>). Irreversible removal of a "
+            "login identity -- safety_level=dangerous, "
+            "requires_approval=True. Idempotent (deleting a non-existent "
+            "user is a no-op success), so a 404 only means userpass is "
+            "not enabled at the mount -> VaultAuthBackendNotMountedError."
+        ),
+        "parameter_schema": VAULT_AUTH_USERPASS_DELETE_PARAMETER_SCHEMA,
+        "response_schema": VAULT_AUTH_USERPASS_DELETE_RESPONSE_SCHEMA,
+        "tags": ["write", "destructive", "auth", "identity"],
+        "safety_level": "dangerous",
+        "llm_instructions": VAULT_AUTH_USERPASS_DELETE_LLM_INSTRUCTIONS,
+    },
+    {
+        "op_id": "vault.auth.approle.write",
+        "handler": vault_auth_approle_write,
+        "summary": "Create or update an AppRole's token/SecretID config.",
+        "description": (
+            "Creates a new AppRole or updates an existing one's token and "
+            "SecretID policy/TTL configuration (POST "
+            "/v1/auth/<mount>/role/<role>). Binding token_policies is a "
+            "privilege assignment -- safety_level=dangerous, "
+            "requires_approval=True. Mints no SecretID (that is "
+            "generate_secret_id). approle not enabled raises "
+            "VaultAuthBackendNotMountedError."
+        ),
+        "parameter_schema": VAULT_AUTH_APPROLE_WRITE_PARAMETER_SCHEMA,
+        "response_schema": VAULT_AUTH_APPROLE_WRITE_RESPONSE_SCHEMA,
+        "tags": ["write", "auth", "identity"],
+        "safety_level": "dangerous",
+        "llm_instructions": VAULT_AUTH_APPROLE_WRITE_LLM_INSTRUCTIONS,
+    },
+    {
+        "op_id": "vault.auth.approle.delete",
+        "handler": vault_auth_approle_delete,
+        "summary": "Delete an AppRole.",
+        "description": (
+            "Deletes an AppRole, invalidating its role-id and all issued "
+            "SecretIDs (DELETE /v1/auth/<mount>/role/<role>). Irreversible "
+            "removal of a machine-login identity -- safety_level=dangerous, "
+            "requires_approval=True. Idempotent (deleting a non-existent "
+            "role is a no-op success), so a 404 only means approle is not "
+            "enabled -> VaultAuthBackendNotMountedError."
+        ),
+        "parameter_schema": VAULT_AUTH_APPROLE_DELETE_PARAMETER_SCHEMA,
+        "response_schema": VAULT_AUTH_APPROLE_DELETE_RESPONSE_SCHEMA,
+        "tags": ["write", "destructive", "auth", "identity"],
+        "safety_level": "dangerous",
+        "llm_instructions": VAULT_AUTH_APPROLE_DELETE_LLM_INSTRUCTIONS,
+    },
+    {
+        "op_id": "vault.auth.approle.generate_secret_id",
+        "handler": vault_auth_approle_generate_secret_id,
+        "summary": "Mint a fresh SecretID for an AppRole (non-idempotent).",
+        "description": (
+            "Mints a brand-new SecretID for an AppRole so a machine "
+            "identity can log in (POST "
+            "/v1/auth/<mount>/role/<role>/secret-id). NON-IDEMPOTENT: each "
+            "call yields a distinct SecretID. The SecretID lands in the "
+            "response, so the op is classified credential_mint: the "
+            "broadcast collapses to aggregate-only and the audit row holds "
+            "only a params_hash, so the minted SecretID never reaches the "
+            "feed or audit store. The caller's OperationResult still "
+            "carries it -- store it immediately. safety_level=dangerous, "
+            "requires_approval=True. approle not enabled raises "
+            "VaultAuthBackendNotMountedError; a missing role under a "
+            "mounted backend surfaces as InvalidPath."
+        ),
+        "parameter_schema": VAULT_AUTH_APPROLE_GENERATE_SECRET_ID_PARAMETER_SCHEMA,
+        "response_schema": VAULT_AUTH_APPROLE_GENERATE_SECRET_ID_RESPONSE_SCHEMA,
+        "tags": ["write", "credential-mint", "auth", "identity"],
+        "safety_level": "dangerous",
+        "llm_instructions": VAULT_AUTH_APPROLE_GENERATE_SECRET_ID_LLM_INSTRUCTIONS,
+    },
+)
+
+
+async def register_vault_auth_write_operations(
+    *,
+    embedding_service: EmbeddingService | None = None,
+) -> None:
+    """Upsert the six Vault auth-write ops into ``endpoint_descriptor``.
+
+    Called from
+    :func:`~meho_backplane.connectors.vault.ops.register_vault_typed_operations`
+    so the package keeps a single lifespan-driven registrar entry while
+    the auth-write surface lives in its own reviewable module. Idempotent:
+    a second call against unchanged descriptions is a no-op for the
+    embedding pipeline via the body-hash skip path in
+    :func:`~meho_backplane.operations.typed_register.register_typed_operation`.
+
+    Every op registers from :data:`_AUTH_WRITE_OP_SPECS` with
+    ``group_key="auth"`` and ``requires_approval=True`` -- credential
+    lifecycle writes (privilege assignment, identity removal, secret
+    mint).
+    """
+    auth_write_when_to_use = (
+        "Use to MUTATE the userpass and approle auth backends -- the "
+        "credential lifecycle: create/update a userpass user "
+        "(``vault.auth.userpass.write``), rotate a user's password "
+        "(``vault.auth.userpass.update_password``), delete a user "
+        "(``vault.auth.userpass.delete``), create/update an AppRole "
+        "(``vault.auth.approle.write``), delete an AppRole "
+        "(``vault.auth.approle.delete``), and mint a SecretID for an "
+        "AppRole (``vault.auth.approle.generate_secret_id``). Every op "
+        "requires approval. Passwords and minted SecretIDs are secret "
+        "material -- redacted from the audit row and the broadcast feed. "
+        "Pair with the read side of this group "
+        "(``vault.auth.{userpass,approle}.{list,read}``) to inspect "
+        "before mutating. Route token-identity and auth-mount questions "
+        "to the 'sys' group."
+    )
+    for spec in _AUTH_WRITE_OP_SPECS:
+        await register_typed_operation(
+            product="vault",
+            version="1.x",
+            impl_id="vault",
+            op_id=spec["op_id"],
+            handler=spec["handler"],
+            summary=spec["summary"],
+            description=spec["description"],
+            parameter_schema=spec["parameter_schema"],
+            response_schema=spec["response_schema"],
+            group_key="auth",
+            when_to_use=auth_write_when_to_use,
+            tags=spec["tags"],
+            safety_level=spec["safety_level"],
+            requires_approval=True,
+            llm_instructions=spec["llm_instructions"],
+            embedding_service=embedding_service,
+        )

--- a/backend/src/meho_backplane/connectors/vault/ops_auth_write_schemas.py
+++ b/backend/src/meho_backplane/connectors/vault/ops_auth_write_schemas.py
@@ -1,0 +1,493 @@
+# SPDX-License-Identifier: Apache-2.0
+# Copyright (c) 2026 evoila Group
+
+"""JSON Schema + ``llm_instructions`` for the Vault auth *write* ops.
+
+Split out of :mod:`meho_backplane.connectors.vault.ops_auth_write` so the
+handler/registration module stays focused on behaviour and both modules
+stay under the file-size budget. The blobs here are pure data --
+JSON Schema 2020-12 ``parameter_schema`` / ``response_schema`` documents
+and the structured ``llm_instructions`` payload the meta-tools (G0.6-T8)
+inline verbatim when an LLM is choosing an op.
+
+Mirrors the schema/``llm_instructions`` shape of the read-side
+:mod:`meho_backplane.connectors.vault.ops_auth_schemas` -- ``minLength=1``
+/ ``pattern="\\S"`` / ``additionalProperties=False`` input discipline,
+a shared optional ``mount`` property, and a when-to-use + parameter-hint
++ output-shape ``llm_instructions`` block per op.
+
+Secret-material discipline (G3.15-T3, #1411): the userpass password
+properties and the ``generate_secret_id`` response carry secret
+material. The redaction is enforced at the classification layer
+(:func:`meho_backplane.broadcast.events.classify_op` maps
+``vault.auth.userpass.write`` / ``.update_password`` to
+``credential_write`` and ``vault.auth.approle.generate_secret_id`` to
+``credential_mint``), not in these schemas -- the schemas only describe
+the wire shape. The ``llm_instructions`` flag the redaction behaviour
+and, for ``generate_secret_id``, its non-idempotent secret-minting
+nature so an agent does not re-issue it expecting a stable value.
+"""
+
+from __future__ import annotations
+
+from typing import Any
+
+__all__ = [
+    "VAULT_AUTH_APPROLE_DELETE_LLM_INSTRUCTIONS",
+    "VAULT_AUTH_APPROLE_DELETE_PARAMETER_SCHEMA",
+    "VAULT_AUTH_APPROLE_DELETE_RESPONSE_SCHEMA",
+    "VAULT_AUTH_APPROLE_GENERATE_SECRET_ID_LLM_INSTRUCTIONS",
+    "VAULT_AUTH_APPROLE_GENERATE_SECRET_ID_PARAMETER_SCHEMA",
+    "VAULT_AUTH_APPROLE_GENERATE_SECRET_ID_RESPONSE_SCHEMA",
+    "VAULT_AUTH_APPROLE_WRITE_LLM_INSTRUCTIONS",
+    "VAULT_AUTH_APPROLE_WRITE_PARAMETER_SCHEMA",
+    "VAULT_AUTH_APPROLE_WRITE_RESPONSE_SCHEMA",
+    "VAULT_AUTH_USERPASS_DELETE_LLM_INSTRUCTIONS",
+    "VAULT_AUTH_USERPASS_DELETE_PARAMETER_SCHEMA",
+    "VAULT_AUTH_USERPASS_DELETE_RESPONSE_SCHEMA",
+    "VAULT_AUTH_USERPASS_UPDATE_PASSWORD_LLM_INSTRUCTIONS",
+    "VAULT_AUTH_USERPASS_UPDATE_PASSWORD_PARAMETER_SCHEMA",
+    "VAULT_AUTH_USERPASS_UPDATE_PASSWORD_RESPONSE_SCHEMA",
+    "VAULT_AUTH_USERPASS_WRITE_LLM_INSTRUCTIONS",
+    "VAULT_AUTH_USERPASS_WRITE_PARAMETER_SCHEMA",
+    "VAULT_AUTH_USERPASS_WRITE_RESPONSE_SCHEMA",
+]
+
+
+def _mount_property(default: str) -> dict[str, Any]:
+    """Build the shared optional ``mount`` schema property.
+
+    ``mount`` is optional with a per-op default so non-default mounts
+    (``auth/userpass-prod``) work without a code change. ``pattern="\\S"``
+    rejects a whitespace-only override; the enclosing schema's
+    ``additionalProperties=False`` turns a typo (``{"moutn": "x"}``)
+    into a clear validation error instead of a silent default-mount
+    dispatch. Identical to the read-side helper -- kept local rather
+    than imported to keep the two schema modules independently
+    reviewable.
+    """
+    return {
+        "type": "string",
+        "minLength": 1,
+        "pattern": "\\S",
+        "default": default,
+        "description": (
+            f"Auth-method mount path (no leading slash, no 'auth/' prefix), "
+            f"default {default!r}. Override only when the backend was "
+            f"enabled at a non-default path (vault auth enable -path=...)."
+        ),
+    }
+
+
+def _mount_hint(default: str) -> str:
+    return f"Optional. Defaults to {default!r}. Supply only for a non-default mount path."
+
+
+_USERNAME_PROPERTY: dict[str, Any] = {
+    "type": "string",
+    "minLength": 1,
+    "pattern": "\\S",
+    "description": (
+        "userpass username (no mount prefix). Forwarded verbatim to hvac's username= argument."
+    ),
+}
+
+_PASSWORD_PROPERTY: dict[str, Any] = {
+    "type": "string",
+    "minLength": 1,
+    "pattern": "\\S",
+    "description": (
+        "The user's password. SECRET MATERIAL: redacted from the audit "
+        "row (only a params hash is stored) and from the broadcast feed "
+        "(this op classifies credential_write -> aggregate-only). Reaches "
+        "Vault verbatim; never echoed in the op response."
+    ),
+}
+
+_ROLE_NAME_PROPERTY: dict[str, Any] = {
+    "type": "string",
+    "minLength": 1,
+    "pattern": "\\S",
+    "description": (
+        "AppRole role name (no mount prefix). Forwarded verbatim to hvac's role_name= argument."
+    ),
+}
+
+
+# --- userpass.write --------------------------------------------------------
+
+VAULT_AUTH_USERPASS_WRITE_PARAMETER_SCHEMA: dict[str, Any] = {
+    "type": "object",
+    "properties": {
+        "username": _USERNAME_PROPERTY,
+        "password": _PASSWORD_PROPERTY,
+        "token_policies": {
+            "type": "array",
+            "items": {"type": "string", "minLength": 1},
+            "description": (
+                "Policies bound to tokens this user receives at login -- "
+                "the privilege assignment. Omit to leave unchanged on an "
+                "update (Vault treats the field as optional)."
+            ),
+        },
+        "mount": _mount_property("userpass"),
+    },
+    "required": ["username", "password"],
+    "additionalProperties": False,
+}
+
+VAULT_AUTH_USERPASS_WRITE_RESPONSE_SCHEMA: dict[str, Any] = {
+    "type": "object",
+    "properties": {
+        "username": {"type": "string", "description": "The user created or updated."},
+        "mount": {"type": "string", "description": "The mount the user lives on."},
+        "token_policies": {
+            "type": "array",
+            "items": {"type": "string"},
+            "description": "Policies assigned to the user (echoed from the request).",
+        },
+        "written": {"type": "boolean", "description": "Always true on success."},
+    },
+    "required": ["username", "written"],
+    "description": (
+        "Confirms the create/update. NEVER carries the password -- the "
+        "value-free echo reports the username, mount, and assigned "
+        "policies only."
+    ),
+}
+
+VAULT_AUTH_USERPASS_WRITE_LLM_INSTRUCTIONS: dict[str, Any] = {
+    "when_to_use": (
+        "Create a new userpass user or update an existing one's password "
+        "and/or token policies. Use when provisioning a human/service "
+        "login on the userpass backend. DANGEROUS, requires approval: "
+        "binding token_policies is a privilege assignment. The password "
+        "is SECRET -- it is redacted from the audit row and the broadcast "
+        "feed (credential_write), reaches Vault verbatim, and is never "
+        "echoed back."
+    ),
+    "parameter_hints": {
+        "username": "Required. The userpass username, no mount prefix.",
+        "password": "Required. The user's password (secret; redacted from audit/broadcast).",
+        "token_policies": (
+            "Optional. Policy names bound to the user's tokens (privilege "
+            "assignment). Omit to leave unchanged on an update."
+        ),
+        "mount": _mount_hint("userpass"),
+    },
+    "output_shape": (
+        "On success: {'username': ..., 'mount': ..., 'token_policies': "
+        "[...], 'written': true} -- never the password. On failure: a "
+        "connector_error OperationResult with extras.exception_class "
+        "naming the failure class ('VaultAuthBackendNotMountedError' when "
+        "userpass is not enabled at the mount)."
+    ),
+}
+
+
+# --- userpass.update_password ----------------------------------------------
+
+VAULT_AUTH_USERPASS_UPDATE_PASSWORD_PARAMETER_SCHEMA: dict[str, Any] = {
+    "type": "object",
+    "properties": {
+        "username": _USERNAME_PROPERTY,
+        "password": _PASSWORD_PROPERTY,
+        "mount": _mount_property("userpass"),
+    },
+    "required": ["username", "password"],
+    "additionalProperties": False,
+}
+
+VAULT_AUTH_USERPASS_UPDATE_PASSWORD_RESPONSE_SCHEMA: dict[str, Any] = {
+    "type": "object",
+    "properties": {
+        "username": {"type": "string", "description": "The user whose password changed."},
+        "mount": {"type": "string", "description": "The mount the user lives on."},
+        "password_updated": {"type": "boolean", "description": "Always true on success."},
+    },
+    "required": ["username", "password_updated"],
+    "description": ("Confirms the password rotation. NEVER carries the new password."),
+}
+
+VAULT_AUTH_USERPASS_UPDATE_PASSWORD_LLM_INSTRUCTIONS: dict[str, Any] = {
+    "when_to_use": (
+        "Rotate an existing userpass user's password without touching "
+        "their token policies. Use for a password-only change (the user "
+        "must already exist). Requires approval. The password is SECRET "
+        "-- redacted from the audit row and the broadcast feed "
+        "(credential_write), reaches Vault verbatim, never echoed back."
+    ),
+    "parameter_hints": {
+        "username": "Required. The existing userpass username, no mount prefix.",
+        "password": "Required. The new password (secret; redacted from audit/broadcast).",
+        "mount": _mount_hint("userpass"),
+    },
+    "output_shape": (
+        "On success: {'username': ..., 'mount': ..., 'password_updated': "
+        "true} -- never the password. On failure: a connector_error "
+        "OperationResult; extras.exception_class is "
+        "'VaultAuthBackendNotMountedError' when userpass is not enabled, "
+        "'InvalidPath' when the user does not exist under a mounted "
+        "backend."
+    ),
+}
+
+
+# --- userpass.delete -------------------------------------------------------
+
+VAULT_AUTH_USERPASS_DELETE_PARAMETER_SCHEMA: dict[str, Any] = {
+    "type": "object",
+    "properties": {
+        "username": _USERNAME_PROPERTY,
+        "mount": _mount_property("userpass"),
+    },
+    "required": ["username"],
+    "additionalProperties": False,
+}
+
+VAULT_AUTH_USERPASS_DELETE_RESPONSE_SCHEMA: dict[str, Any] = {
+    "type": "object",
+    "properties": {
+        "username": {"type": "string", "description": "The user deleted."},
+        "mount": {"type": "string", "description": "The mount the user lived on."},
+        "deleted": {"type": "boolean", "description": "Always true on success."},
+    },
+    "required": ["username", "deleted"],
+    "description": "Confirms the user removal.",
+}
+
+VAULT_AUTH_USERPASS_DELETE_LLM_INSTRUCTIONS: dict[str, Any] = {
+    "when_to_use": (
+        "Delete a userpass user, revoking their ability to log in. "
+        "DANGEROUS, requires approval -- irreversible removal of a login "
+        "identity. Vault's delete is idempotent: deleting a "
+        "non-existent user is a no-op success."
+    ),
+    "parameter_hints": {
+        "username": "Required. The userpass username to remove, no mount prefix.",
+        "mount": _mount_hint("userpass"),
+    },
+    "output_shape": (
+        "On success: {'username': ..., 'mount': ..., 'deleted': true}. On "
+        "failure: a connector_error OperationResult; extras.exception_class "
+        "is 'VaultAuthBackendNotMountedError' when userpass is not enabled."
+    ),
+}
+
+
+# --- approle.write ---------------------------------------------------------
+
+VAULT_AUTH_APPROLE_WRITE_PARAMETER_SCHEMA: dict[str, Any] = {
+    "type": "object",
+    "properties": {
+        "role_name": _ROLE_NAME_PROPERTY,
+        "token_policies": {
+            "type": "array",
+            "items": {"type": "string", "minLength": 1},
+            "description": "Policies bound to tokens this role issues.",
+        },
+        "token_ttl": {
+            "type": "integer",
+            "minimum": 0,
+            "description": "Default token TTL in seconds (0 = system default).",
+        },
+        "token_max_ttl": {
+            "type": "integer",
+            "minimum": 0,
+            "description": "Maximum token TTL in seconds (0 = system default).",
+        },
+        "secret_id_ttl": {
+            "type": "integer",
+            "minimum": 0,
+            "description": "TTL of SecretIDs issued for this role, seconds (0 = unlimited).",
+        },
+        "secret_id_num_uses": {
+            "type": "integer",
+            "minimum": 0,
+            "description": "Number of times a SecretID can be used (0 = unlimited).",
+        },
+        "bind_secret_id": {
+            "type": "boolean",
+            "description": "Whether a SecretID is required at login (default true).",
+        },
+        "mount": _mount_property("approle"),
+    },
+    "required": ["role_name"],
+    "additionalProperties": False,
+}
+
+VAULT_AUTH_APPROLE_WRITE_RESPONSE_SCHEMA: dict[str, Any] = {
+    "type": "object",
+    "properties": {
+        "role_name": {"type": "string", "description": "The role created or updated."},
+        "mount": {"type": "string", "description": "The mount the role lives on."},
+        "written": {"type": "boolean", "description": "Always true on success."},
+    },
+    "required": ["role_name", "written"],
+    "description": (
+        "Confirms the create/update. No SecretID is minted by this op -- "
+        "use vault.auth.approle.generate_secret_id for that."
+    ),
+}
+
+VAULT_AUTH_APPROLE_WRITE_LLM_INSTRUCTIONS: dict[str, Any] = {
+    "when_to_use": (
+        "Create a new AppRole or update an existing one's token / "
+        "SecretID policy and TTL configuration. DANGEROUS, requires "
+        "approval -- binding token_policies is a privilege assignment. "
+        "Does NOT mint a SecretID (that is generate_secret_id, a separate "
+        "op)."
+    ),
+    "parameter_hints": {
+        "role_name": "Required. The AppRole role name, no mount prefix.",
+        "token_policies": "Optional. Policy names bound to tokens this role issues.",
+        "token_ttl": "Optional. Default token TTL in seconds.",
+        "token_max_ttl": "Optional. Maximum token TTL in seconds.",
+        "secret_id_ttl": "Optional. TTL of SecretIDs issued for this role, seconds.",
+        "secret_id_num_uses": "Optional. How many times a SecretID can be used.",
+        "bind_secret_id": "Optional. Whether a SecretID is required at login.",
+        "mount": _mount_hint("approle"),
+    },
+    "output_shape": (
+        "On success: {'role_name': ..., 'mount': ..., 'written': true}. On "
+        "failure: a connector_error OperationResult; extras.exception_class "
+        "is 'VaultAuthBackendNotMountedError' when approle is not enabled."
+    ),
+}
+
+
+# --- approle.delete --------------------------------------------------------
+
+VAULT_AUTH_APPROLE_DELETE_PARAMETER_SCHEMA: dict[str, Any] = {
+    "type": "object",
+    "properties": {
+        "role_name": _ROLE_NAME_PROPERTY,
+        "mount": _mount_property("approle"),
+    },
+    "required": ["role_name"],
+    "additionalProperties": False,
+}
+
+VAULT_AUTH_APPROLE_DELETE_RESPONSE_SCHEMA: dict[str, Any] = {
+    "type": "object",
+    "properties": {
+        "role_name": {"type": "string", "description": "The role deleted."},
+        "mount": {"type": "string", "description": "The mount the role lived on."},
+        "deleted": {"type": "boolean", "description": "Always true on success."},
+    },
+    "required": ["role_name", "deleted"],
+    "description": "Confirms the role removal.",
+}
+
+VAULT_AUTH_APPROLE_DELETE_LLM_INSTRUCTIONS: dict[str, Any] = {
+    "when_to_use": (
+        "Delete an AppRole, invalidating its role-id and all issued "
+        "SecretIDs. DANGEROUS, requires approval -- irreversible removal "
+        "of a machine-login identity. Vault's delete is idempotent: "
+        "deleting a non-existent role is a no-op success."
+    ),
+    "parameter_hints": {
+        "role_name": "Required. The AppRole role name to remove, no mount prefix.",
+        "mount": _mount_hint("approle"),
+    },
+    "output_shape": (
+        "On success: {'role_name': ..., 'mount': ..., 'deleted': true}. On "
+        "failure: a connector_error OperationResult; extras.exception_class "
+        "is 'VaultAuthBackendNotMountedError' when approle is not enabled."
+    ),
+}
+
+
+# --- approle.generate_secret_id --------------------------------------------
+
+VAULT_AUTH_APPROLE_GENERATE_SECRET_ID_PARAMETER_SCHEMA: dict[str, Any] = {
+    "type": "object",
+    "properties": {
+        "role_name": _ROLE_NAME_PROPERTY,
+        "metadata": {
+            "type": "object",
+            "description": (
+                "Optional metadata tied to the SecretID (visible in token "
+                "metadata after login). Plain key/value strings."
+            ),
+            "additionalProperties": {"type": "string"},
+        },
+        "cidr_list": {
+            "type": "array",
+            "items": {"type": "string", "minLength": 1},
+            "description": "Optional CIDR blocks the SecretID may log in from.",
+        },
+        "token_bound_cidrs": {
+            "type": "array",
+            "items": {"type": "string", "minLength": 1},
+            "description": "Optional CIDR blocks tokens issued via this SecretID are bound to.",
+        },
+        "mount": _mount_property("approle"),
+    },
+    "required": ["role_name"],
+    "additionalProperties": False,
+}
+
+VAULT_AUTH_APPROLE_GENERATE_SECRET_ID_RESPONSE_SCHEMA: dict[str, Any] = {
+    "type": "object",
+    "properties": {
+        "secret_id": {
+            "type": "string",
+            "description": (
+                "The freshly-minted SecretID. SECRET, one-time value -- "
+                "store it immediately. Redacted from the audit row and the "
+                "broadcast feed (credential_mint); only the caller's "
+                "OperationResult carries it."
+            ),
+        },
+        "secret_id_accessor": {
+            "type": "string",
+            "description": (
+                "Non-secret accessor for the SecretID (use to revoke without the value)."
+            ),
+        },
+        "secret_id_ttl": {
+            "type": "integer",
+            "description": "TTL of the issued SecretID in seconds.",
+        },
+        "role_name": {"type": "string", "description": "The role the SecretID was minted for."},
+        "mount": {"type": "string", "description": "The mount the role lives on."},
+    },
+    "required": ["secret_id", "role_name"],
+    "description": (
+        "The minted SecretID plus its accessor and TTL. The secret_id is "
+        "secret material: present in the caller's OperationResult, absent "
+        "from the audit row and broadcast feed."
+    ),
+}
+
+VAULT_AUTH_APPROLE_GENERATE_SECRET_ID_LLM_INSTRUCTIONS: dict[str, Any] = {
+    "when_to_use": (
+        "Mint a new SecretID for an AppRole so a machine identity can log "
+        "in. DANGEROUS, requires approval. NON-IDEMPOTENT: each call mints "
+        "a brand-new SecretID -- calling twice yields two distinct "
+        "credentials, so never retry it expecting a stable value, and "
+        "never call it to 'read' an existing SecretID (there is no such "
+        "read; SecretIDs are write-only after minting). The response "
+        "carries the SecretID, a one-time secret -- store it immediately. "
+        "The SecretID is redacted from the audit row and the broadcast "
+        "feed (credential_mint classification); only your OperationResult "
+        "sees it."
+    ),
+    "parameter_hints": {
+        "role_name": "Required. The AppRole to mint a SecretID for, no mount prefix.",
+        "metadata": "Optional. String key/value metadata tied to the SecretID.",
+        "cidr_list": "Optional. CIDR blocks the SecretID may log in from.",
+        "token_bound_cidrs": "Optional. CIDR blocks issued tokens are bound to.",
+        "mount": _mount_hint("approle"),
+    },
+    "output_shape": (
+        "On success: {'secret_id': '<minted-secret>', "
+        "'secret_id_accessor': ..., 'secret_id_ttl': <int>, 'role_name': "
+        "..., 'mount': ...}. The secret_id is one-time -- save it now. On "
+        "failure: a connector_error OperationResult; extras.exception_class "
+        "is 'VaultAuthBackendNotMountedError' when approle is not enabled, "
+        "'InvalidPath' when the role does not exist under a mounted "
+        "backend."
+    ),
+}

--- a/backend/tests/_vault_fakes.py
+++ b/backend/tests/_vault_fakes.py
@@ -109,8 +109,18 @@ class _FakeUserpassAuth:
     users: dict[str, dict[str, Any]] = field(default_factory=dict)
     list_exc: Exception | None = None
     read_exc: Exception | None = None
+    # G3.15-T3 (#1411) write half. Per-verb call logs + exception knobs
+    # so the credential-lifecycle tests can target one op without
+    # disturbing the read ops. Defaults are benign so the pre-existing
+    # read-only suites that never touch these attributes keep passing.
+    write_exc: Exception | None = None
+    update_password_exc: Exception | None = None
+    delete_exc: Exception | None = None
     list_calls: list[dict[str, Any]] = field(default_factory=list)
     read_calls: list[dict[str, Any]] = field(default_factory=list)
+    write_calls: list[dict[str, Any]] = field(default_factory=list)
+    update_password_calls: list[dict[str, Any]] = field(default_factory=list)
+    delete_calls: list[dict[str, Any]] = field(default_factory=list)
 
     def list_user(self, mount_point: str = "userpass") -> dict[str, Any]:
         self.list_calls.append({"mount_point": mount_point})
@@ -123,6 +133,43 @@ class _FakeUserpassAuth:
         if self.read_exc is not None:
             raise self.read_exc
         return {"data": self.users[username]}
+
+    def create_or_update_user(
+        self,
+        username: str,
+        password: str | None = None,
+        mount_point: str = "userpass",
+        **kwargs: Any,
+    ) -> Any:
+        self.write_calls.append(
+            {
+                "username": username,
+                "password": password,
+                "mount_point": mount_point,
+                **kwargs,
+            }
+        )
+        if self.write_exc is not None:
+            raise self.write_exc
+        self.users[username] = {"token_policies": list(kwargs.get("token_policies", []))}
+        return _DeleteResponse(status_code=204)
+
+    def update_password_on_user(
+        self, username: str, password: str, mount_point: str = "userpass"
+    ) -> Any:
+        self.update_password_calls.append(
+            {"username": username, "password": password, "mount_point": mount_point}
+        )
+        if self.update_password_exc is not None:
+            raise self.update_password_exc
+        return _DeleteResponse(status_code=204)
+
+    def delete_user(self, username: str, mount_point: str = "userpass") -> Any:
+        self.delete_calls.append({"username": username, "mount_point": mount_point})
+        if self.delete_exc is not None:
+            raise self.delete_exc
+        self.users.pop(username, None)
+        return _DeleteResponse(status_code=204)
 
 
 @dataclass
@@ -137,8 +184,21 @@ class _FakeAppRoleAuth:
     roles: dict[str, dict[str, Any]] = field(default_factory=dict)
     list_exc: Exception | None = None
     read_exc: Exception | None = None
+    # G3.15-T3 (#1411) write half. ``secret_id`` is the value the
+    # generate_secret_id fake mints into its response payload so the
+    # redaction tests can seed a distinctive sentinel and positively
+    # assert its absence from the serialised broadcast event.
+    write_exc: Exception | None = None
+    delete_exc: Exception | None = None
+    generate_secret_id_exc: Exception | None = None
+    secret_id: str = "fake-secret-id"
+    secret_id_accessor: str = "fake-secret-id-accessor"
+    secret_id_ttl: int = 600
     list_calls: list[dict[str, Any]] = field(default_factory=list)
     read_calls: list[dict[str, Any]] = field(default_factory=list)
+    write_calls: list[dict[str, Any]] = field(default_factory=list)
+    delete_calls: list[dict[str, Any]] = field(default_factory=list)
+    generate_secret_id_calls: list[dict[str, Any]] = field(default_factory=list)
 
     def list_roles(self, mount_point: str = "approle") -> dict[str, Any]:
         self.list_calls.append({"mount_point": mount_point})
@@ -151,6 +211,38 @@ class _FakeAppRoleAuth:
         if self.read_exc is not None:
             raise self.read_exc
         return {"data": self.roles[role_name]}
+
+    def create_or_update_approle(
+        self, role_name: str, mount_point: str = "approle", **kwargs: Any
+    ) -> Any:
+        self.write_calls.append({"role_name": role_name, "mount_point": mount_point, **kwargs})
+        if self.write_exc is not None:
+            raise self.write_exc
+        self.roles[role_name] = dict(kwargs)
+        return _DeleteResponse(status_code=204)
+
+    def delete_role(self, role_name: str, mount_point: str = "approle") -> Any:
+        self.delete_calls.append({"role_name": role_name, "mount_point": mount_point})
+        if self.delete_exc is not None:
+            raise self.delete_exc
+        self.roles.pop(role_name, None)
+        return _DeleteResponse(status_code=204)
+
+    def generate_secret_id(
+        self, role_name: str, mount_point: str = "approle", **kwargs: Any
+    ) -> dict[str, Any]:
+        self.generate_secret_id_calls.append(
+            {"role_name": role_name, "mount_point": mount_point, **kwargs}
+        )
+        if self.generate_secret_id_exc is not None:
+            raise self.generate_secret_id_exc
+        return {
+            "data": {
+                "secret_id": self.secret_id,
+                "secret_id_accessor": self.secret_id_accessor,
+                "secret_id_ttl": self.secret_id_ttl,
+            }
+        }
 
 
 @dataclass

--- a/backend/tests/integration/test_connectors_vault_dev_e2e.py
+++ b/backend/tests/integration/test_connectors_vault_dev_e2e.py
@@ -885,3 +885,251 @@ async def test_auth_approle_read_against_dev_vault(
         expected_op_class="other",
         events=captured_events,
     )
+
+
+# ---------------------------------------------------------------------------
+# auth write group (G3.15-T3 #1411) — userpass + approle credential lifecycle
+#
+# Every write op registers ``requires_approval=True``; an ordinary dispatch
+# would park it in the approval queue (G11.7-T1 #1401). These tests pass
+# ``_approved=True`` (the approvals-API resume flag) to drive the
+# authorized execution path — the same handler/audit/broadcast path that
+# runs once a human approves — against the live Vault. The redaction
+# assertions positively prove the password (request-side) and the minted
+# SecretID (response-side) never reach the serialised broadcast event.
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.asyncio
+async def test_auth_userpass_write_redacts_password_against_dev_vault(
+    vault_e2e: tuple[_VaultTarget, str],
+    captured_events: list[BroadcastEvent],
+) -> None:
+    """``vault.auth.userpass.write`` creates a user; password absent from the broadcast.
+
+    The password rides in the request params, so the op classifies
+    ``credential_write`` (G11.7-T1 #1401) and the broadcast collapses to
+    aggregate-only. A distinctive sentinel password is seeded and the
+    test positively asserts it is absent from the *entire serialised
+    BroadcastEvent*; the write still lands in Vault (the user logs in).
+    """
+    target, addr = vault_e2e
+    sentinel = "userpass-write-pw-sentinel-1411"
+    operator = _make_operator(sub="op-up-write")
+    result = await dispatch(
+        operator=operator,
+        connector_id="vault-1.x",
+        op_id="vault.auth.userpass.write",
+        target=target,
+        params={"username": "minted-user", "password": sentinel, "token_policies": ["default"]},
+        _approved=True,
+    )
+    assert result.status == "ok", result.error
+    assert result.result["written"] is True
+    assert sentinel not in str(result.result)
+    # The write landed — the user can authenticate with the sentinel.
+    login = _root_client(addr).auth.userpass.login(
+        username="minted-user", password=sentinel, mount_point="userpass"
+    )
+    assert login["auth"]["client_token"]
+    await _assert_audited(
+        "vault.auth.userpass.write",
+        operator_sub="op-up-write",
+        expected_op_class="credential_write",
+        events=captured_events,
+    )
+    event = next(e for e in captured_events if e.op_id == "vault.auth.userpass.write")
+    assert event.payload == {"op_class": "credential_write", "result_status": "ok"}
+    serialised = event.model_dump_json()
+    assert sentinel not in serialised, (
+        f"credential_write leak: {sentinel!r} reached the broadcast event"
+    )
+
+
+@pytest.mark.asyncio
+async def test_auth_userpass_update_password_redacts_against_dev_vault(
+    vault_e2e: tuple[_VaultTarget, str],
+    captured_events: list[BroadcastEvent],
+) -> None:
+    """``vault.auth.userpass.update_password`` rotates a password; redacted from broadcast."""
+    target, addr = vault_e2e
+    # Seed a user to rotate so this test is independent of the create test.
+    _root_client(addr).auth.userpass.create_or_update_user(
+        username="rotate-user", password="initial-pw", policies=["default"], mount_point="userpass"
+    )
+    sentinel = "userpass-rotate-pw-sentinel-1411"
+    operator = _make_operator(sub="op-up-rotate")
+    result = await dispatch(
+        operator=operator,
+        connector_id="vault-1.x",
+        op_id="vault.auth.userpass.update_password",
+        target=target,
+        params={"username": "rotate-user", "password": sentinel},
+        _approved=True,
+    )
+    assert result.status == "ok", result.error
+    assert result.result == {
+        "username": "rotate-user",
+        "mount": "userpass",
+        "password_updated": True,
+    }
+    login = _root_client(addr).auth.userpass.login(
+        username="rotate-user", password=sentinel, mount_point="userpass"
+    )
+    assert login["auth"]["client_token"]
+    await _assert_audited(
+        "vault.auth.userpass.update_password",
+        operator_sub="op-up-rotate",
+        expected_op_class="credential_write",
+        events=captured_events,
+    )
+    event = next(e for e in captured_events if e.op_id == "vault.auth.userpass.update_password")
+    serialised = event.model_dump_json()
+    assert sentinel not in serialised, "rotated password leaked into broadcast event"
+
+
+@pytest.mark.asyncio
+async def test_auth_userpass_delete_against_dev_vault(
+    vault_e2e: tuple[_VaultTarget, str],
+    captured_events: list[BroadcastEvent],
+) -> None:
+    """``vault.auth.userpass.delete`` removes a user; op_class=write (no secret)."""
+    target, addr = vault_e2e
+    _root_client(addr).auth.userpass.create_or_update_user(
+        username="doomed-user", password="pw", policies=["default"], mount_point="userpass"
+    )
+    operator = _make_operator(sub="op-up-delete")
+    result = await dispatch(
+        operator=operator,
+        connector_id="vault-1.x",
+        op_id="vault.auth.userpass.delete",
+        target=target,
+        params={"username": "doomed-user"},
+        _approved=True,
+    )
+    assert result.status == "ok", result.error
+    assert result.result == {"username": "doomed-user", "mount": "userpass", "deleted": True}
+    # The user is gone — list no longer contains it.
+    listing = _root_client(addr).auth.userpass.list_user(mount_point="userpass")
+    assert "doomed-user" not in listing["data"]["keys"]
+    await _assert_audited(
+        "vault.auth.userpass.delete",
+        operator_sub="op-up-delete",
+        expected_op_class="write",
+        events=captured_events,
+    )
+
+
+@pytest.mark.asyncio
+async def test_auth_approle_write_against_dev_vault(
+    vault_e2e: tuple[_VaultTarget, str],
+    captured_events: list[BroadcastEvent],
+) -> None:
+    """``vault.auth.approle.write`` creates a role; op_class=write."""
+    target, addr = vault_e2e
+    operator = _make_operator(sub="op-ar-write")
+    result = await dispatch(
+        operator=operator,
+        connector_id="vault-1.x",
+        op_id="vault.auth.approle.write",
+        target=target,
+        params={"role_name": "minted-role", "token_policies": ["default"], "token_ttl": 600},
+        _approved=True,
+    )
+    assert result.status == "ok", result.error
+    assert result.result == {"role_name": "minted-role", "mount": "approle", "written": True}
+    role = _root_client(addr).auth.approle.read_role(role_name="minted-role", mount_point="approle")
+    assert "default" in role["data"]["token_policies"]
+    await _assert_audited(
+        "vault.auth.approle.write",
+        operator_sub="op-ar-write",
+        expected_op_class="write",
+        events=captured_events,
+    )
+
+
+@pytest.mark.asyncio
+async def test_auth_approle_delete_against_dev_vault(
+    vault_e2e: tuple[_VaultTarget, str],
+    captured_events: list[BroadcastEvent],
+) -> None:
+    """``vault.auth.approle.delete`` removes a role; op_class=write."""
+    target, addr = vault_e2e
+    _root_client(addr).auth.approle.create_or_update_approle(
+        role_name="doomed-role", token_policies=["default"], mount_point="approle"
+    )
+    operator = _make_operator(sub="op-ar-delete")
+    result = await dispatch(
+        operator=operator,
+        connector_id="vault-1.x",
+        op_id="vault.auth.approle.delete",
+        target=target,
+        params={"role_name": "doomed-role"},
+        _approved=True,
+    )
+    assert result.status == "ok", result.error
+    assert result.result == {"role_name": "doomed-role", "mount": "approle", "deleted": True}
+    listing = _root_client(addr).auth.approle.list_roles(mount_point="approle")
+    assert "doomed-role" not in listing["data"]["keys"]
+    await _assert_audited(
+        "vault.auth.approle.delete",
+        operator_sub="op-ar-delete",
+        expected_op_class="write",
+        events=captured_events,
+    )
+
+
+@pytest.mark.asyncio
+async def test_auth_approle_generate_secret_id_redacts_against_dev_vault(
+    vault_e2e: tuple[_VaultTarget, str],
+    captured_events: list[BroadcastEvent],
+) -> None:
+    """``vault.auth.approle.generate_secret_id`` mints a SecretID; redacted from broadcast.
+
+    The minted SecretID lands in the *response*, so the op classifies
+    ``credential_mint`` and the broadcast collapses to aggregate-only. The
+    caller's OperationResult carries the SecretID (the point of minting),
+    but the test positively asserts that exact value is absent from the
+    entire serialised BroadcastEvent. Non-idempotent: a second call mints
+    a distinct SecretID.
+    """
+    target, addr = vault_e2e
+    _root_client(addr).auth.approle.create_or_update_approle(
+        role_name="sid-role", token_policies=["default"], mount_point="approle"
+    )
+    operator = _make_operator(sub="op-ar-sid")
+    result = await dispatch(
+        operator=operator,
+        connector_id="vault-1.x",
+        op_id="vault.auth.approle.generate_secret_id",
+        target=target,
+        params={"role_name": "sid-role"},
+        _approved=True,
+    )
+    assert result.status == "ok", result.error
+    minted_secret_id = result.result["secret_id"]
+    assert minted_secret_id, "the minted SecretID must reach the caller's OperationResult"
+    assert result.result["role_name"] == "sid-role"
+    await _assert_audited(
+        "vault.auth.approle.generate_secret_id",
+        operator_sub="op-ar-sid",
+        expected_op_class="credential_mint",
+        events=captured_events,
+    )
+    event = next(e for e in captured_events if e.op_id == "vault.auth.approle.generate_secret_id")
+    assert event.payload == {"op_class": "credential_mint", "result_status": "ok"}
+    serialised = event.model_dump_json()
+    assert minted_secret_id not in serialised, (
+        "credential_mint leak: the minted SecretID reached the broadcast event"
+    )
+    # Non-idempotent: a second mint yields a distinct SecretID.
+    second = await dispatch(
+        operator=_make_operator(sub="op-ar-sid-2"),
+        connector_id="vault-1.x",
+        op_id="vault.auth.approle.generate_secret_id",
+        target=target,
+        params={"role_name": "sid-role"},
+        _approved=True,
+    )
+    assert second.status == "ok", second.error
+    assert second.result["secret_id"] != minted_secret_id

--- a/backend/tests/test_broadcast_events.py
+++ b/backend/tests/test_broadcast_events.py
@@ -304,10 +304,39 @@ class TestClassifyOp:
             # than redact under the ``write`` branch.
             ("bind9.record.add", "write"),
             ("bind9.record.remove", "write"),
+            # Vault ``.write`` mutating verb (G3.15 #1410/#1411).
+            # ``vault.auth.approle.write`` carries no secret in its
+            # params (a role definition), so it classifies as plain
+            # ``write`` via the ``.write`` suffix; ``vault.sys.policy.write``
+            # writes a policy document. Both would fall through to
+            # ``other`` without the ``.write`` suffix.
+            ("vault.auth.approle.write", "write"),
+            ("vault.sys.policy.write", "write"),
         ],
     )
     def test_write_suffixes(self, op_id: str, expected: str) -> None:
         assert classify_op(op_id) == expected
+
+    @pytest.mark.parametrize(
+        "op_id",
+        [
+            "vault.auth.userpass.write",
+            "vault.auth.userpass.update_password",
+        ],
+    )
+    def test_credential_write_allowlist_wins_over_write_suffix(self, op_id: str) -> None:
+        """Userpass ``.write`` ops stay ``credential_write``, never plain ``write``.
+
+        Critical safety precedence: ``vault.auth.userpass.write`` ends in
+        ``.write`` (a mutation suffix). The credential-write allowlist is
+        consulted in :func:`classify_op` *before* the ``.write`` suffix
+        branch, so the password riding in ``params`` collapses to
+        aggregate-only — it is never broadcast in full under the plain
+        ``write`` class. This test pins that ordering so a future suffix
+        reshuffle can't silently downgrade a credential write and leak the
+        password to every operator on the feed.
+        """
+        assert classify_op(op_id) == "credential_write"
 
     @pytest.mark.parametrize(
         "op_id",

--- a/backend/tests/test_connectors_vault_auth_write.py
+++ b/backend/tests/test_connectors_vault_auth_write.py
@@ -1,0 +1,593 @@
+# SPDX-License-Identifier: Apache-2.0
+# Copyright (c) 2026 evoila Group
+
+"""Unit tests for the Vault auth credential-lifecycle write ops (G3.15-T3, #1411).
+
+Covers ``vault.auth.userpass.{write,update_password,delete}`` +
+``vault.auth.approle.{write,delete,generate_secret_id}``: registration,
+happy paths, mount parameterisation, value-free responses, the
+backend-not-mounted structured error, schema-driven param validation,
+and -- load-bearing for #1411 -- the **request- and response-side
+secret redaction**.
+
+Redaction is enforced at the classification layer (#1401's op-class
+allowlists), not in the handlers: the password ops classify
+``credential_write`` (secret in request params) and
+``generate_secret_id`` classifies ``credential_mint`` (secret in
+response). The redaction tests seed a distinctive sentinel and
+positively assert the sentinel is ABSENT from the serialised broadcast
+payload :func:`~meho_backplane.broadcast.events.redact_payload` would
+ship -- mirroring the k8s.secret.create / vault.kv.put sentinel
+pattern. The audit row never carries raw params (only a params_hash),
+so the secret is structurally absent there by construction.
+
+Mocking discipline mirrors ``test_connectors_vault_auth.py``: the
+in-process fake hvac client (``install_fake_client`` ->
+``_build_client`` monkeypatch), not an httpx/respx mock, because hvac's
+transport is ``requests``.
+"""
+
+from __future__ import annotations
+
+from collections.abc import AsyncIterator, Iterator
+from typing import Any
+from unittest.mock import AsyncMock
+from uuid import UUID
+
+import hvac.exceptions
+import pytest
+from sqlalchemy import select
+
+from meho_backplane.auth.operator import Operator, TenantRole
+from meho_backplane.broadcast.events import classify_op, redact_payload
+from meho_backplane.connectors.schemas import OperationResult
+from meho_backplane.connectors.vault import register_vault_typed_operations
+from meho_backplane.connectors.vault.ops_auth_write import (
+    vault_auth_approle_generate_secret_id,
+    vault_auth_userpass_write,
+)
+from meho_backplane.connectors.vault.ops_auth_write_schemas import (
+    VAULT_AUTH_APPROLE_GENERATE_SECRET_ID_LLM_INSTRUCTIONS,
+)
+from meho_backplane.db.engine import get_sessionmaker
+from meho_backplane.db.models import EndpointDescriptor, OperationGroup
+from meho_backplane.operations import dispatch
+from meho_backplane.settings import get_settings
+
+from ._vault_fakes import install_fake_client
+
+
+@pytest.fixture(autouse=True)
+def _settings_env(monkeypatch: pytest.MonkeyPatch) -> Iterator[None]:
+    """Pin env vars needed by Settings / VaultConnector."""
+    monkeypatch.setenv("KEYCLOAK_ISSUER_URL", "https://keycloak.test/realms/meho")
+    monkeypatch.setenv("KEYCLOAK_AUDIENCE", "meho-backplane")
+    monkeypatch.setenv("VAULT_ADDR", "https://vault.test")
+    monkeypatch.setenv("VAULT_OIDC_ROLE", "meho-mcp")
+    monkeypatch.setenv("VAULT_OIDC_MOUNT_PATH", "jwt")
+    monkeypatch.setenv("VAULT_TIMEOUT_SECONDS", "5.0")
+    monkeypatch.delenv("VAULT_NAMESPACE", raising=False)
+    get_settings.cache_clear()
+    yield
+    get_settings.cache_clear()
+
+
+@pytest.fixture
+def stub_embedding_service() -> AsyncMock:
+    """Deterministic embedding stub so registration doesn't pull ONNX."""
+    service = AsyncMock()
+    service.encode_one.return_value = [0.1] * 384
+    service.encode.return_value = [[0.1] * 384]
+    service.dimension = 384
+    return service
+
+
+@pytest.fixture
+async def _registered_vault_typed_ops(
+    stub_embedding_service: AsyncMock,
+) -> AsyncIterator[None]:
+    """Upsert every Vault typed-op descriptor row (incl. the six auth-write ops)."""
+    await register_vault_typed_operations(embedding_service=stub_embedding_service)
+    yield
+
+
+def _make_operator(jwt: str = "fake.jwt.value") -> Operator:
+    return Operator(
+        sub="test-operator",
+        name=None,
+        email=None,
+        raw_jwt=jwt,
+        tenant_id=UUID(int=0),
+        tenant_role=TenantRole.OPERATOR,
+    )
+
+
+async def _dispatch_vault(
+    op_id: str, params: dict[str, Any], *, jwt: str = "fake.jwt.value"
+) -> OperationResult:
+    """Dispatch a vault op, bypassing the approval gate.
+
+    The write ops register ``requires_approval=True``; an ordinary
+    dispatch would park them in the approval queue. ``_approved=True`` is
+    the resume-path flag the approvals API sets after a human approves --
+    here it lets the unit test drive the handler/audit/broadcast path
+    that runs once a write is authorized.
+    """
+    return await dispatch(
+        operator=_make_operator(jwt),
+        connector_id="vault-1.x",
+        op_id=op_id,
+        target=None,
+        params=params,
+        _approved=True,
+    )
+
+
+# ---------------------------------------------------------------------------
+# Registration / dispatchability + requires_approval / safety_level
+# ---------------------------------------------------------------------------
+
+_WRITE_OP_IDS: list[str] = [
+    "vault.auth.userpass.write",
+    "vault.auth.userpass.update_password",
+    "vault.auth.userpass.delete",
+    "vault.auth.approle.write",
+    "vault.auth.approle.delete",
+    "vault.auth.approle.generate_secret_id",
+]
+
+
+async def test_auth_write_ops_register_idempotently(
+    stub_embedding_service: AsyncMock,
+) -> None:
+    """All six auth-write ops upsert; a second run is a no-op (body-hash skip)."""
+    await register_vault_typed_operations(embedding_service=stub_embedding_service)
+    await register_vault_typed_operations(embedding_service=stub_embedding_service)
+
+
+@pytest.mark.parametrize("op_id", _WRITE_OP_IDS)
+async def test_write_ops_register_with_approval_and_expected_safety(
+    op_id: str,
+    _registered_vault_typed_ops: None,
+) -> None:
+    """Each op registers requires_approval=True with the stated safety level."""
+    expected_safety = {
+        "vault.auth.userpass.write": "dangerous",
+        "vault.auth.userpass.update_password": "caution",
+        "vault.auth.userpass.delete": "dangerous",
+        "vault.auth.approle.write": "dangerous",
+        "vault.auth.approle.delete": "dangerous",
+        "vault.auth.approle.generate_secret_id": "dangerous",
+    }
+    sessionmaker = get_sessionmaker()
+    async with sessionmaker() as session:
+        row = (
+            await session.execute(
+                select(EndpointDescriptor).where(EndpointDescriptor.op_id == op_id)
+            )
+        ).scalar_one()
+        group_key = (
+            await session.execute(
+                select(OperationGroup.group_key).where(OperationGroup.id == row.group_id)
+            )
+        ).scalar_one()
+    assert row.requires_approval is True, f"{op_id} must require approval"
+    assert row.safety_level == expected_safety[op_id]
+    assert group_key == "auth"
+
+
+# ---------------------------------------------------------------------------
+# userpass.write — happy path + value-free response + redaction
+# ---------------------------------------------------------------------------
+
+
+async def test_userpass_write_creates_user_value_free_response(
+    monkeypatch: pytest.MonkeyPatch,
+    _registered_vault_typed_ops: None,
+) -> None:
+    """userpass.write forwards password + token_policies to hvac; response omits the password."""
+    fake = install_fake_client(monkeypatch)
+    sentinel = "userpass-write-pw-sentinel-1411"
+
+    result = await _dispatch_vault(
+        "vault.auth.userpass.write",
+        {"username": "ci", "password": sentinel, "token_policies": ["admin", "default"]},
+    )
+
+    assert result.status == "ok", result.error
+    assert result.result == {
+        "username": "ci",
+        "mount": "userpass",
+        "written": True,
+        "token_policies": ["admin", "default"],
+    }
+    # The password reaches Vault verbatim (the point of the write)...
+    call = fake.auth.userpass.write_calls[0]
+    assert call["password"] == sentinel
+    assert call["token_policies"] == ["admin", "default"]
+    assert call["mount_point"] == "userpass"
+    # ...but never the op response.
+    assert sentinel not in str(result.result)
+
+
+async def test_userpass_write_honours_non_default_mount(
+    monkeypatch: pytest.MonkeyPatch,
+    _registered_vault_typed_ops: None,
+) -> None:
+    fake = install_fake_client(monkeypatch)
+
+    result = await _dispatch_vault(
+        "vault.auth.userpass.write",
+        {"username": "svc", "password": "p", "mount": "userpass-prod"},
+    )
+
+    assert result.status == "ok", result.error
+    assert result.result["mount"] == "userpass-prod"
+    assert fake.auth.userpass.write_calls[0]["mount_point"] == "userpass-prod"
+
+
+def test_userpass_write_classifies_credential_write_and_redacts_broadcast() -> None:
+    """The password in params never reaches the broadcast feed (aggregate-only)."""
+    assert classify_op("vault.auth.userpass.write") == "credential_write"
+    sentinel = "userpass-write-pw-sentinel-1411"
+    raw_params = {"params": {"username": "ci", "password": sentinel, "token_policies": ["x"]}}
+    payload = redact_payload("credential_write", raw_params, "ok")
+    assert payload == {"op_class": "credential_write", "result_status": "ok"}
+    assert sentinel not in str(payload), "password leaked into broadcast payload"
+
+
+# ---------------------------------------------------------------------------
+# userpass.update_password — happy path + redaction
+# ---------------------------------------------------------------------------
+
+
+async def test_userpass_update_password_value_free_response(
+    monkeypatch: pytest.MonkeyPatch,
+    _registered_vault_typed_ops: None,
+) -> None:
+    fake = install_fake_client(monkeypatch)
+    sentinel = "userpass-rotate-pw-sentinel-1411"
+
+    result = await _dispatch_vault(
+        "vault.auth.userpass.update_password",
+        {"username": "ci", "password": sentinel},
+    )
+
+    assert result.status == "ok", result.error
+    assert result.result == {"username": "ci", "mount": "userpass", "password_updated": True}
+    assert fake.auth.userpass.update_password_calls[0]["password"] == sentinel
+    assert sentinel not in str(result.result)
+
+
+def test_update_password_classifies_credential_write_and_redacts_broadcast() -> None:
+    assert classify_op("vault.auth.userpass.update_password") == "credential_write"
+    sentinel = "userpass-rotate-pw-sentinel-1411"
+    raw_params = {"params": {"username": "ci", "password": sentinel}}
+    payload = redact_payload("credential_write", raw_params, "ok")
+    assert payload == {"op_class": "credential_write", "result_status": "ok"}
+    assert sentinel not in str(payload)
+
+
+# ---------------------------------------------------------------------------
+# userpass.delete — happy path + idempotency framing
+# ---------------------------------------------------------------------------
+
+
+async def test_userpass_delete_removes_user(
+    monkeypatch: pytest.MonkeyPatch,
+    _registered_vault_typed_ops: None,
+) -> None:
+    fake = install_fake_client(monkeypatch)
+    fake.auth.userpass.users = {"ci": {}}
+
+    result = await _dispatch_vault("vault.auth.userpass.delete", {"username": "ci"})
+
+    assert result.status == "ok", result.error
+    assert result.result == {"username": "ci", "mount": "userpass", "deleted": True}
+    assert fake.auth.userpass.delete_calls == [{"username": "ci", "mount_point": "userpass"}]
+
+
+# ---------------------------------------------------------------------------
+# approle.write / delete — happy paths
+# ---------------------------------------------------------------------------
+
+
+async def test_approle_write_forwards_only_supplied_config(
+    monkeypatch: pytest.MonkeyPatch,
+    _registered_vault_typed_ops: None,
+) -> None:
+    """Only the config keys the caller supplied flow to hvac (others stay unchanged)."""
+    fake = install_fake_client(monkeypatch)
+
+    result = await _dispatch_vault(
+        "vault.auth.approle.write",
+        {"role_name": "deploy", "token_policies": ["default"], "token_ttl": 1200},
+    )
+
+    assert result.status == "ok", result.error
+    assert result.result == {"role_name": "deploy", "mount": "approle", "written": True}
+    call = fake.auth.approle.write_calls[0]
+    assert call["role_name"] == "deploy"
+    assert call["token_policies"] == ["default"]
+    assert call["token_ttl"] == 1200
+    # secret_id_ttl / bind_secret_id were not supplied -> not forwarded.
+    assert "secret_id_ttl" not in call
+    assert "bind_secret_id" not in call
+
+
+async def test_approle_delete_removes_role(
+    monkeypatch: pytest.MonkeyPatch,
+    _registered_vault_typed_ops: None,
+) -> None:
+    fake = install_fake_client(monkeypatch)
+    fake.auth.approle.roles = {"deploy": {}}
+
+    result = await _dispatch_vault("vault.auth.approle.delete", {"role_name": "deploy"})
+
+    assert result.status == "ok", result.error
+    assert result.result == {"role_name": "deploy", "mount": "approle", "deleted": True}
+    assert fake.auth.approle.delete_calls == [{"role_name": "deploy", "mount_point": "approle"}]
+
+
+# ---------------------------------------------------------------------------
+# approle.generate_secret_id — mints SecretID in response, redacted from broadcast
+# ---------------------------------------------------------------------------
+
+
+async def test_generate_secret_id_returns_minted_secret(
+    monkeypatch: pytest.MonkeyPatch,
+    _registered_vault_typed_ops: None,
+) -> None:
+    """The minted SecretID reaches the caller's OperationResult (the point of minting)."""
+    fake = install_fake_client(monkeypatch)
+    sentinel = "minted-secret-id-sentinel-1411"
+    fake.auth.approle.secret_id = sentinel
+
+    result = await _dispatch_vault(
+        "vault.auth.approle.generate_secret_id",
+        {"role_name": "deploy"},
+    )
+
+    assert result.status == "ok", result.error
+    assert result.result["secret_id"] == sentinel
+    assert result.result["role_name"] == "deploy"
+    assert result.result["secret_id_accessor"] == "fake-secret-id-accessor"
+    assert result.result["secret_id_ttl"] == 600
+    assert fake.auth.approle.generate_secret_id_calls[0]["role_name"] == "deploy"
+
+
+async def test_generate_secret_id_is_non_idempotent(
+    monkeypatch: pytest.MonkeyPatch,
+    _registered_vault_typed_ops: None,
+) -> None:
+    """Two calls hit hvac twice — the op mints a fresh SecretID each time."""
+    fake = install_fake_client(monkeypatch)
+
+    await _dispatch_vault("vault.auth.approle.generate_secret_id", {"role_name": "deploy"})
+    await _dispatch_vault("vault.auth.approle.generate_secret_id", {"role_name": "deploy"})
+
+    assert len(fake.auth.approle.generate_secret_id_calls) == 2
+
+
+def test_generate_secret_id_classifies_credential_mint_and_redacts_broadcast() -> None:
+    """The minted SecretID (response-side) never reaches the broadcast feed."""
+    assert classify_op("vault.auth.approle.generate_secret_id") == "credential_mint"
+    sentinel = "minted-secret-id-sentinel-1411"
+    # The publisher ships request params, but credential_mint collapses to
+    # aggregate-only regardless — assert the response secret never appears
+    # even if it were (defensively) merged into the publisher's params.
+    raw_params = {"params": {"role_name": "deploy"}, "secret_id": sentinel}
+    payload = redact_payload("credential_mint", raw_params, "ok")
+    assert payload == {"op_class": "credential_mint", "result_status": "ok"}
+    assert sentinel not in str(payload), "minted SecretID leaked into broadcast payload"
+
+
+def test_generate_secret_id_llm_instructions_flag_non_idempotent_mint() -> None:
+    """AC3: the llm_instructions flag the non-idempotent, secret-minting nature."""
+    blob = str(VAULT_AUTH_APPROLE_GENERATE_SECRET_ID_LLM_INSTRUCTIONS).lower()
+    assert "non-idempotent" in blob
+    assert "secret" in blob
+    # The instruction explicitly tells the agent each call mints a new value.
+    assert "each call" in blob or "distinct" in blob
+
+
+# ---------------------------------------------------------------------------
+# backend-not-mounted -> structured connector_error
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.parametrize(
+    "op_id,params,backend",
+    [
+        (
+            "vault.auth.userpass.write",
+            {"username": "ci", "password": "p"},
+            "userpass",
+        ),
+        ("vault.auth.userpass.delete", {"username": "ci"}, "userpass"),
+        (
+            "vault.auth.approle.write",
+            {"role_name": "deploy"},
+            "approle",
+        ),
+        ("vault.auth.approle.delete", {"role_name": "deploy"}, "approle"),
+    ],
+)
+async def test_write_backend_not_mounted_surfaces_structured_error(
+    monkeypatch: pytest.MonkeyPatch,
+    op_id: str,
+    params: dict[str, Any],
+    backend: str,
+    _registered_vault_typed_ops: None,
+) -> None:
+    """A 404 from an unmounted backend reclassifies to VaultAuthBackendNotMountedError."""
+    fake = install_fake_client(monkeypatch)
+    backend_fake = getattr(fake.auth, backend)
+    backend_fake.write_exc = hvac.exceptions.InvalidPath("no handler for route")
+    backend_fake.delete_exc = hvac.exceptions.InvalidPath("no handler for route")
+
+    result = await _dispatch_vault(op_id, params)
+
+    assert result.status == "error"
+    assert result.extras.get("error_code") == "connector_error"
+    assert result.extras.get("exception_class") == "VaultAuthBackendNotMountedError"
+
+
+@pytest.mark.parametrize(
+    "op_id,params,backend",
+    [
+        (
+            "vault.auth.userpass.update_password",
+            {"username": "ci", "password": "p"},
+            "userpass",
+        ),
+        (
+            "vault.auth.approle.generate_secret_id",
+            {"role_name": "deploy"},
+            "approle",
+        ),
+    ],
+)
+async def test_probe_reclassifies_backend_absent_on_404(
+    monkeypatch: pytest.MonkeyPatch,
+    op_id: str,
+    params: dict[str, Any],
+    backend: str,
+    _registered_vault_typed_ops: None,
+) -> None:
+    """update_password / generate_secret_id 404 + LIST-probe 404 -> backend-absent error."""
+    fake = install_fake_client(monkeypatch)
+    backend_fake = getattr(fake.auth, backend)
+    backend_fake.update_password_exc = hvac.exceptions.InvalidPath("no handler")
+    backend_fake.generate_secret_id_exc = hvac.exceptions.InvalidPath("no handler")
+    backend_fake.list_exc = hvac.exceptions.InvalidPath("no handler")
+
+    result = await _dispatch_vault(op_id, params)
+
+    assert result.status == "error"
+    assert result.extras.get("exception_class") == "VaultAuthBackendNotMountedError"
+
+
+@pytest.mark.parametrize(
+    "op_id,params,backend",
+    [
+        (
+            "vault.auth.userpass.update_password",
+            {"username": "ghost", "password": "p"},
+            "userpass",
+        ),
+        (
+            "vault.auth.approle.generate_secret_id",
+            {"role_name": "ghost"},
+            "approle",
+        ),
+    ],
+)
+async def test_missing_entity_under_mounted_backend_keeps_invalid_path(
+    monkeypatch: pytest.MonkeyPatch,
+    op_id: str,
+    params: dict[str, Any],
+    backend: str,
+    _registered_vault_typed_ops: None,
+) -> None:
+    """404 on the op but the LIST probe succeeds (mounted) -> InvalidPath re-raised."""
+    fake = install_fake_client(monkeypatch)
+    backend_fake = getattr(fake.auth, backend)
+    backend_fake.update_password_exc = hvac.exceptions.InvalidPath("no secret found")
+    backend_fake.generate_secret_id_exc = hvac.exceptions.InvalidPath("no secret found")
+    # list_exc stays None -> the probe LIST succeeds (backend mounted).
+
+    result = await _dispatch_vault(op_id, params)
+
+    assert result.status == "error"
+    assert result.extras.get("exception_class") == "InvalidPath"
+
+
+# ---------------------------------------------------------------------------
+# schema-driven param validation
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.parametrize(
+    "op_id,params",
+    [
+        ("vault.auth.userpass.write", {"username": "ci"}),
+        ("vault.auth.userpass.write", {"password": "p"}),
+        ("vault.auth.userpass.write", {"username": "ci", "password": "  "}),
+        ("vault.auth.userpass.update_password", {"username": "ci"}),
+        ("vault.auth.userpass.delete", {}),
+        ("vault.auth.approle.write", {}),
+        ("vault.auth.approle.write", {"role_name": "r", "token_ttl": -1}),
+        ("vault.auth.approle.delete", {"role_name": "  "}),
+        ("vault.auth.approle.generate_secret_id", {}),
+        ("vault.auth.approle.generate_secret_id", {"role_name": "r", "unexpected": "x"}),
+    ],
+    ids=[
+        "userpass-write-missing-password",
+        "userpass-write-missing-username",
+        "userpass-write-whitespace-password",
+        "update-password-missing-password",
+        "userpass-delete-missing-username",
+        "approle-write-missing-role",
+        "approle-write-negative-ttl",
+        "approle-delete-whitespace-role",
+        "generate-secret-id-missing-role",
+        "generate-secret-id-additional-property",
+    ],
+)
+async def test_invalid_params_rejected_by_schema(
+    monkeypatch: pytest.MonkeyPatch,
+    op_id: str,
+    params: dict[str, Any],
+    _registered_vault_typed_ops: None,
+) -> None:
+    """Bad params are rejected by the schema before the handler runs (no Vault call)."""
+    fake = install_fake_client(monkeypatch)
+
+    result = await _dispatch_vault(op_id, params)
+
+    assert result.status == "error"
+    assert result.error is not None
+    assert result.error.startswith("invalid_params:")
+    assert result.extras.get("error_code") == "invalid_params"
+    # No write reached the fake backend.
+    assert fake.auth.userpass.write_calls == []
+    assert fake.auth.approle.write_calls == []
+    assert fake.auth.approle.generate_secret_id_calls == []
+
+
+# ---------------------------------------------------------------------------
+# handler-level guards (called directly, no dispatcher)
+# ---------------------------------------------------------------------------
+
+
+async def test_userpass_write_handler_omits_token_policies_when_absent(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """A create without token_policies neither forwards the kwarg nor echoes the key."""
+    fake = install_fake_client(monkeypatch)
+
+    result = await vault_auth_userpass_write(
+        _make_operator(), None, {"username": "ci", "password": "p"}
+    )
+
+    assert result == {"username": "ci", "mount": "userpass", "written": True}
+    assert "token_policies" not in fake.auth.userpass.write_calls[0]
+
+
+async def test_generate_secret_id_handler_omits_optional_response_keys(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """When Vault omits accessor/ttl, the handler returns only the required keys."""
+    fake = install_fake_client(monkeypatch)
+
+    def _minimal(role_name: str, mount_point: str = "approle", **_kwargs: Any) -> dict[str, Any]:
+        return {"data": {"secret_id": "only-the-id"}}
+
+    monkeypatch.setattr(fake.auth.approle, "generate_secret_id", _minimal)
+
+    result = await vault_auth_approle_generate_secret_id(
+        _make_operator(), None, {"role_name": "deploy"}
+    )
+
+    assert result == {"secret_id": "only-the-id", "role_name": "deploy", "mount": "approle"}

--- a/docs/codebase/connectors-vault.md
+++ b/docs/codebase/connectors-vault.md
@@ -71,11 +71,38 @@ Source: `backend/src/meho_backplane/connectors/vault/`.
   `vault.auth.approle.read` under group key `auth`, all
   `safety_level='safe'`. Mount path is parameterised (defaults
   `userpass` / `approle`); a not-mounted backend raises
-  `VaultAuthBackendNotMountedError`. AppRole secret-id generation is
-  deliberately out of scope (v0.2.next, behind a policy gate). It is
-  registered from its own module via the
-  `register_vault_auth_operations()` call at the end of
+  `VaultAuthBackendNotMountedError`. It is registered from its own
+  module via the `register_vault_auth_operations()` call at the end of
   `register_vault_typed_operations()`.
+- **`auth` write op group** (`ops_auth_write.py` /
+  `ops_auth_write_schemas.py`, G3.15-T3 #1411) —
+  `register_vault_auth_write_operations()` registers the userpass +
+  approle credential lifecycle under the same `auth` group key, all
+  `requires_approval=True`:
+
+  | op_id | hvac call | safety_level | op_class (broadcast) |
+  |---|---|---|---|
+  | `vault.auth.userpass.write` | `create_or_update_user` | dangerous | `credential_write` |
+  | `vault.auth.userpass.update_password` | `update_password_on_user` | caution | `credential_write` |
+  | `vault.auth.userpass.delete` | `delete_user` | dangerous | `write` |
+  | `vault.auth.approle.write` | `create_or_update_approle` | dangerous | `write` |
+  | `vault.auth.approle.delete` | `delete_role` | dangerous | `write` |
+  | `vault.auth.approle.generate_secret_id` | `generate_secret_id` | dangerous | `credential_mint` |
+
+  Passwords (userpass write / update_password) are **request-side**
+  secret material → `credential_write` (aggregate-only broadcast); the
+  handlers also return a value-free confirmation (username/mount/policies,
+  never the password). `generate_secret_id` mints a SecretID in its
+  **response** → `credential_mint`; it is **non-idempotent** (a fresh
+  SecretID per call), flagged as such in its `llm_instructions`, and the
+  minted value reaches only the caller's `OperationResult` (never the
+  audit row or broadcast). `delete` / `approle.write` carry no secret and
+  classify plain `write` off their suffix. Registered from its own
+  module via the `register_vault_auth_write_operations()` call at the end
+  of `register_vault_typed_operations()`. `_reclassify_not_found` /
+  `VaultAuthBackendNotMountedError` are reused from `ops_auth.py` so a
+  404 from an unmounted backend surfaces the same error class as the
+  read ops.
 
 ## KV-v2 op group
 
@@ -135,22 +162,32 @@ secret `data` is in the *request params*, and the broadcast ships
 params, so it must collapse to aggregate-only. It previously
 classified plain `write` via the `.put` write-suffix (#545), which kept
 it out of the `other` class but still broadcast the written secret in
-full — the `credential_write` reclassification closes that. Response-side
-secret-mint ops (`vault.token.create`,
+full — the `credential_write` reclassification closes that. The auth-write ops (G3.15-T3 #1411)
+`vault.auth.userpass.write` / `vault.auth.userpass.update_password` are
+also `credential_write` — the password is in their request params.
+Response-side secret-mint ops (`vault.token.create`,
 `vault.auth.approle.generate_secret_id`) classify `credential_mint`
-alongside `harbor.robot.create`. See `docs/codebase/broadcast.md` for
-the full sensitivity taxonomy.
+alongside `harbor.robot.create`: the minted value is in the response, so
+the broadcast collapses to aggregate-only and the audit row keeps only a
+`params_hash`, while the caller's `OperationResult` still carries the
+secret. See `docs/codebase/broadcast.md` for the full sensitivity
+taxonomy.
 
 ## Approval gating
 
-`vault.kv.put` (`caution`) and `vault.kv.delete` (`dangerous`)
-register with `requires_approval=False` — the dev default.
-`requires_approval` is a static boolean on the descriptor; the shipped
-G0.6 substrate has no per-path approval predicate. The
-production-path approval gate is G7/G10 policy territory (see the
-`EndpointDescriptor` model docstring: `caution`/`dangerous` ops "flow
-through G7 / G10 policy logic once those Goals land"). `safety_level`
-is the load-bearing signal that future gate keys on.
+The KV-v2 write ops `vault.kv.put` (`caution`) and `vault.kv.delete`
+(`dangerous`) register with `requires_approval=False` — the dev default.
+
+The auth-write ops (G3.15-T3 #1411) instead register
+`requires_approval=True`: each is a privilege assignment (binding
+`token_policies`), an irreversible identity removal, or a secret mint.
+By the G11.7-T1 (#1401) policy gate a human/service principal hitting a
+`requires_approval=True` op is routed to the approval queue (parked
+durably with synchronous `approval.request` / `approval.decision` audit
+rows) rather than hard-denied; the call executes on the approvals-API
+resume path once approved. `requires_approval` is a static boolean on
+the descriptor and `safety_level` is the load-bearing signal the gate
+keys on.
 
 ## JSONFlux result-handle path (`vault.kv.list`)
 


### PR DESCRIPTION
## Summary
- Adds the **userpass + approle write half** of the vault auth surface — the credential lifecycle (G3.15-T3): `vault.auth.userpass.{write,update_password,delete}` + `vault.auth.approle.{write,delete,generate_secret_id}`, all `requires_approval=True`.
- First vault ops carrying **secret material on both sides**: passwords in request params, minted SecretID in the response. Redaction is enforced at the classification layer (#1401's `credential_write` / `credential_mint` op-class allowlists already pin these op-ids) — the secret never reaches the audit row (`params_hash` only) or the broadcast feed (aggregate-only). `generate_secret_id` is non-idempotent (fresh SecretID per call), flagged in its `llm_instructions`, and returns the value only to the caller's `OperationResult`.
- Write surface lives in its own `ops_auth_write.py` / `ops_auth_write_schemas.py` (same single-registrar-entry discipline as the read group) and reuses `ops_auth.py`'s `VaultAuthBackendNotMountedError` + `_reclassify_not_found`.

## Test plan
- [x] `ruff check` / `ruff format --check` — clean (src + tests)
- [x] `mypy src/ --ignore-missing-imports` — clean (407 files)
- [x] `code-quality.py --diff` — 0 blockers
- [x] AC1: six ops register with stated safety levels, all `requires_approval=True` (`test_write_ops_register_with_approval_and_expected_safety`)
- [x] AC2: password params + minted SecretID redacted from audit + broadcast — positive sentinel-absence assertions on the serialised broadcast event (unit `test_*_classifies_*_and_redacts_broadcast`; integration `test_auth_userpass_write_redacts_password_*`, `test_auth_approle_generate_secret_id_redacts_*`)
- [x] AC3: `generate_secret_id` `llm_instructions` flag non-idempotent secret-minting nature (`test_generate_secret_id_llm_instructions_flag_non_idempotent_mint` + `test_generate_secret_id_is_non_idempotent`)
- [x] AC4: per-op happy-path + error tests (39 unit tests + 6 dev-Vault integration tests, runs in `Python (integration testcontainers)`)
- [x] AC5: `make snapshot-openapi && make generate` — no delta (ops dispatch via generic operation endpoint, not per-op REST routes)
- [x] hvac 2.4.0 method shapes verified by installed-library introspection

## Out of scope
- Identity (entity/group) + token ops (T4).
- Multi-step orchestration (create-user-then-add-to-group) — stays agent-orchestrated.

<!-- auto-implement-issue: fresh, iteration 1 -->

Closes #1411

🤖 Generated with [Claude Code](https://claude.com/claude-code)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added Vault authentication credential lifecycle operations: userpass account creation/update/deletion and AppRole configuration/deletion with secret ID generation.
  * Implemented approval requirements for all auth credential write operations to enhance security governance.

* **Security**
  * Sensitive credentials (passwords, generated secret IDs) are now properly redacted from audit logs and broadcast events while remaining available to operators.

* **Bug Fixes**
  * Enhanced operation classification to properly handle write-suffix operations.

* **Documentation**
  * Updated connector documentation with auth write operation details and credential redaction behavior.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->