### PR TITLE
feat(connectors): G3.15-T2 vault policy ops — read/list (safe) + write/delete (approval-gated)

### DIFF
--- a/backend/src/meho_backplane/broadcast/events.py
+++ b/backend/src/meho_backplane/broadcast/events.py
@@ -156,6 +156,14 @@ _WRITE_SUFFIXES: Final[tuple[str, ...]] = (
     # branch.
     ".add",
     ".remove",
+    # Vault policy-write verb (G3.15-T2 #1410). ``vault.sys.policy.write``
+    # carries the full HCL/JSON policy body in its params; without
+    # ``.write`` in the write-suffix tuple it would fall through to
+    # ``other`` and broadcast the policy text to every operator. The
+    # ``_CREDENTIAL_WRITE_OPS`` allowlist is consulted first, so the
+    # ``.write``-shaped ``vault.auth.userpass.write`` keeps its
+    # ``credential_write`` class.
+    ".write",
 )
 
 #: Op-id suffixes that imply non-mutating read. ``.ls`` and ``.about``
@@ -305,9 +313,18 @@ def classify_op(op_id: str) -> str:
        map to ``write``. Checked before the dot-suffix branches since
        ingested ops carry no meho verb suffix.
     6. ``write`` — mutation suffixes (``.create`` / ``.update`` /
-       ``.delete`` / ``.patch``).
+       ``.delete`` / ``.patch`` / ``.put`` / ``.add`` / ``.remove`` /
+       ``.write``). The ``_CREDENTIAL_WRITE_OPS`` allowlist (step 3)
+       runs first, so a ``.write``-shaped secret-bearing op like
+       ``vault.auth.userpass.write`` keeps its ``credential_write``
+       class.
     7. ``read`` — non-mutating verb suffixes (``.list`` / ``.info`` /
-       ``.get`` / ``.about`` / ``.ls``).
+       ``.get`` / ``.about`` / ``.ls`` / ``.health`` / ``.seal_status``
+       / ``.versions``). ``.read`` is deliberately **not** a read
+       suffix: it would over-match the ``credential_read``-allowlisted
+       ``vault.kv.read`` (the allowlist wins, but the exclusion keeps
+       the policy single-sourced) and would reclassify the auth-config
+       ``.read`` ops that intentionally broadcast as ``other``.
     8. ``other`` — everything else. Falls through to full-detail
        broadcast per decision #3.
 

--- a/backend/src/meho_backplane/connectors/vault/ops_sys.py
+++ b/backend/src/meho_backplane/connectors/vault/ops_sys.py
@@ -1,24 +1,46 @@
 # SPDX-License-Identifier: Apache-2.0
 # Copyright (c) 2026 evoila Group
 
-"""Vault ``sys`` read op group — typed handlers + ``endpoint_descriptor``
+"""Vault ``sys`` op group — typed handlers + ``endpoint_descriptor``
 registration helper.
 
-Op-id namespace (v0.2): ``vault.sys.<verb>``. The four ops here are the
-read-only diagnostics surface the consumer's wrappers exercise daily:
+Op-id namespace: ``vault.sys.<verb>``. The group spans the read-only
+diagnostics surface the consumer's wrappers exercise daily plus the
+ACL-policy CRUD surface (G3.15-T2 #1410, defined in
+:mod:`meho_backplane.connectors.vault.ops_sys_policy` and registered here):
 
 * ``vault.sys.health`` — cluster health (``GET /v1/sys/health``).
 * ``vault.sys.seal_status`` — seal state (``GET /v1/sys/seal-status``).
 * ``vault.sys.mounts.list`` — enabled secret backends (``GET /v1/sys/mounts``).
 * ``vault.sys.auth.list`` — enabled auth backends (``GET /v1/sys/auth``).
+* ``vault.sys.policy.read`` — one ACL policy body (``GET /v1/sys/policy/<name>``).
+* ``vault.sys.policy.list`` — configured policy names (``GET /v1/sys/policy``).
+* ``vault.sys.policy.write`` — create/replace an ACL policy
+  (``PUT /v1/sys/policy/<name>``).
+* ``vault.sys.policy.delete`` — remove an ACL policy
+  (``DELETE /v1/sys/policy/<name>``).
 
-All four are ``safety_level='safe'`` and classify as ``op_class='read'``
-via :func:`~meho_backplane.broadcast.events.classify_op` (the ``.health``
-and ``.seal_status`` suffixes were added to that classifier's read-suffix
-tuple so the diagnostics surface broadcasts at the same sensitivity as
-``.list`` / ``.get`` ops — there is no secret content in any of these
-payloads). ``sys`` writes (unseal, mount/unmount, policy write) are out
-of scope for v0.2.
+The four diagnostics ops are ``safety_level='safe'`` /
+``requires_approval=False`` and classify as ``op_class='read'`` via
+:func:`~meho_backplane.broadcast.events.classify_op` (the ``.health`` /
+``.seal_status`` suffixes are in that classifier's read-suffix tuple so
+they broadcast at the same sensitivity as ``.list`` / ``.get`` ops —
+there is no secret content in any of these payloads). The two policy
+reads (``policy.read`` / ``policy.list``) are likewise ``safe`` /
+``requires_approval=False``; ``policy.list`` ends in ``.list`` so it
+classifies ``read``, while ``policy.read`` classifies ``other`` (its
+only param is the policy name — ``.read`` is deliberately absent from
+the read-suffix tuple, mirroring the ``vault.auth.*.read`` precedent
+that broadcasts auth-config reads as ``other``). ``vault.sys.policy.write``
+/ ``vault.sys.policy.delete`` are mutating: ``safety_level='dangerous'``
+with ``requires_approval=True`` (a bad HCL body can lock everyone out or
+silently widen access — the highest-blast-radius Vault mutation, so the
+G11.7 approval gate parks a dispatch before the handler runs). They
+classify as ``op_class='write'`` (the ``.write`` suffix was added to the
+classifier's write-suffix tuple so ``policy.write`` redacts its HCL body
+rather than broadcasting it as an ``other``-class full-detail event).
+Other ``sys`` writes (unseal, mount/unmount bootstrap) remain out of
+scope here (T5).
 
 Handler shape mirrors :mod:`meho_backplane.connectors.vault.ops`: each
 handler is a module-level ``async def`` typed op. Handlers that forward
@@ -72,6 +94,24 @@ from typing import Any
 
 import meho_backplane.auth.vault as _auth_vault
 from meho_backplane.auth.operator import Operator
+from meho_backplane.connectors.vault.ops_sys_policy import (
+    VAULT_SYS_POLICY_DELETE_LLM_INSTRUCTIONS,
+    VAULT_SYS_POLICY_DELETE_PARAMETER_SCHEMA,
+    VAULT_SYS_POLICY_DELETE_RESPONSE_SCHEMA,
+    VAULT_SYS_POLICY_LIST_LLM_INSTRUCTIONS,
+    VAULT_SYS_POLICY_LIST_PARAMETER_SCHEMA,
+    VAULT_SYS_POLICY_LIST_RESPONSE_SCHEMA,
+    VAULT_SYS_POLICY_READ_LLM_INSTRUCTIONS,
+    VAULT_SYS_POLICY_READ_PARAMETER_SCHEMA,
+    VAULT_SYS_POLICY_READ_RESPONSE_SCHEMA,
+    VAULT_SYS_POLICY_WRITE_LLM_INSTRUCTIONS,
+    VAULT_SYS_POLICY_WRITE_PARAMETER_SCHEMA,
+    VAULT_SYS_POLICY_WRITE_RESPONSE_SCHEMA,
+    vault_sys_policy_delete,
+    vault_sys_policy_list,
+    vault_sys_policy_read,
+    vault_sys_policy_write,
+)
 from meho_backplane.operations.typed_register import register_typed_operation
 from meho_backplane.retrieval.embedding import EmbeddingService
 from meho_backplane.settings import get_settings
@@ -81,6 +121,10 @@ __all__ = [
     "vault_sys_auth_list",
     "vault_sys_health",
     "vault_sys_mounts_list",
+    "vault_sys_policy_delete",
+    "vault_sys_policy_list",
+    "vault_sys_policy_read",
+    "vault_sys_policy_write",
     "vault_sys_seal_status",
 ]
 
@@ -447,7 +491,15 @@ async def register_vault_sys_typed_operations(
     *,
     embedding_service: EmbeddingService | None = None,
 ) -> None:
-    """Upsert the Vault ``sys`` read ops into ``endpoint_descriptor``.
+    """Upsert the Vault ``sys`` ops into ``endpoint_descriptor``.
+
+    Registers the four read-only diagnostics ops plus the four
+    ACL-policy ops (G3.15-T2 #1410: ``policy.read`` / ``policy.list``
+    safe, ``policy.write`` / ``policy.delete`` dangerous + approval-
+    gated). The policy handlers and schemas live in
+    :mod:`meho_backplane.connectors.vault.ops_sys_policy`; the
+    registration stays here so the whole ``sys`` group registers from
+    one place.
 
     Queued onto the lifespan-driven registrar list from the package
     ``__init__`` alongside
@@ -463,19 +515,25 @@ async def register_vault_sys_typed_operations(
     # ``list_operation_groups``. Differentiates this diagnostic group
     # from the sibling ``kv`` (secret CRUD) and ``auth`` (identity
     # inspection) groups so the agent routes 'is Vault up?' / 'where
-    # are things mounted?' questions here.
+    # are things mounted?' questions here. G3.15-T2 (#1410) extends it
+    # with the ACL-policy CRUD verbs.
     sys_when_to_use = (
-        "Use for Vault target diagnostics and mount-surface "
-        "introspection: 'is this Vault reachable / unsealed / "
-        "serving traffic?' (sys.health), 'is it sealed and how "
-        "many key shares are needed?' (sys.seal_status), 'which "
-        "secret engines are mounted at which paths?' "
-        "(sys.mounts.list), 'which auth methods are mounted?' "
-        "(sys.auth.list). Read-only; returns mount metadata, never "
-        "secret values. The right group when triaging connectivity "
-        "or mapping mountpoints before drilling into a path with "
-        "the 'kv' group, or before drilling into per-backend role "
-        "config (read-only) via the 'auth' group."
+        "Use for Vault target diagnostics, mount-surface "
+        "introspection, and ACL-policy management: 'is this Vault "
+        "reachable / unsealed / serving traffic?' (sys.health), 'is "
+        "it sealed and how many key shares are needed?' "
+        "(sys.seal_status), 'which secret engines are mounted at "
+        "which paths?' (sys.mounts.list), 'which auth methods are "
+        "mounted?' (sys.auth.list), 'what does this policy grant / "
+        "which policies exist?' (sys.policy.read / sys.policy.list), "
+        "and creating, replacing, or deleting an ACL policy "
+        "(sys.policy.write / sys.policy.delete — dangerous, approval-"
+        "gated). The diagnostics and policy-read ops are read-only and "
+        "return mount/policy metadata, never secret values. The right "
+        "group when triaging connectivity, mapping mountpoints before "
+        "drilling into a path with the 'kv' group, inspecting per-"
+        "backend role config (read-only) via the 'auth' group, or "
+        "governing who can read which secrets via ACL policies."
     )
     await register_typed_operation(
         product="vault",
@@ -571,5 +629,101 @@ async def register_vault_sys_typed_operations(
         safety_level="safe",
         requires_approval=False,
         llm_instructions=_VAULT_SYS_AUTH_LIST_LLM_INSTRUCTIONS,
+        embedding_service=embedding_service,
+    )
+    # G3.15-T2 (#1410) ACL-policy ops. Reads are safe; writes/deletes are
+    # dangerous + approval-gated (a bad HCL body can lock everyone out).
+    await register_typed_operation(
+        product="vault",
+        version="1.x",
+        impl_id="vault",
+        op_id="vault.sys.policy.read",
+        handler=vault_sys_policy_read,
+        summary="Read one HashiCorp Vault ACL policy body by name.",
+        description=(
+            "Reads GET /v1/sys/policy/<name> via the operator's OIDC-"
+            "forwarded JWT and returns {'name', 'rules'} where 'rules' "
+            "is the stored HCL/JSON policy body. Read-only; returns ACL "
+            "policy text, not secret values."
+        ),
+        parameter_schema=VAULT_SYS_POLICY_READ_PARAMETER_SCHEMA,
+        response_schema=VAULT_SYS_POLICY_READ_RESPONSE_SCHEMA,
+        group_key="sys",
+        when_to_use=sys_when_to_use,
+        tags=["read-only", "policy", "acl"],
+        safety_level="safe",
+        requires_approval=False,
+        llm_instructions=VAULT_SYS_POLICY_READ_LLM_INSTRUCTIONS,
+        embedding_service=embedding_service,
+    )
+    await register_typed_operation(
+        product="vault",
+        version="1.x",
+        impl_id="vault",
+        op_id="vault.sys.policy.list",
+        handler=vault_sys_policy_list,
+        summary="List the configured ACL policy names on a HashiCorp Vault target.",
+        description=(
+            "Reads GET /v1/sys/policy via the operator's OIDC-forwarded "
+            "JWT and returns {'policies': [<name>, ...]} (always includes "
+            "the built-in 'default' / 'root'). Read-only; names only, no "
+            "policy bodies."
+        ),
+        parameter_schema=VAULT_SYS_POLICY_LIST_PARAMETER_SCHEMA,
+        response_schema=VAULT_SYS_POLICY_LIST_RESPONSE_SCHEMA,
+        group_key="sys",
+        when_to_use=sys_when_to_use,
+        tags=["read-only", "policy", "acl"],
+        safety_level="safe",
+        requires_approval=False,
+        llm_instructions=VAULT_SYS_POLICY_LIST_LLM_INSTRUCTIONS,
+        embedding_service=embedding_service,
+    )
+    await register_typed_operation(
+        product="vault",
+        version="1.x",
+        impl_id="vault",
+        op_id="vault.sys.policy.write",
+        handler=vault_sys_policy_write,
+        summary="Create or replace a HashiCorp Vault ACL policy (dangerous, approval-gated).",
+        description=(
+            "Writes PUT /v1/sys/policy/<name> via the operator's OIDC-"
+            "forwarded JWT, replacing any existing policy of the same "
+            "name in full with the supplied HCL/JSON body. DANGEROUS: a "
+            "bad body can lock operators out or silently widen access. "
+            "Approval-gated. Returns {'name', 'written': true} on success."
+        ),
+        parameter_schema=VAULT_SYS_POLICY_WRITE_PARAMETER_SCHEMA,
+        response_schema=VAULT_SYS_POLICY_WRITE_RESPONSE_SCHEMA,
+        group_key="sys",
+        when_to_use=sys_when_to_use,
+        tags=["write", "policy", "acl", "dangerous"],
+        safety_level="dangerous",
+        requires_approval=True,
+        llm_instructions=VAULT_SYS_POLICY_WRITE_LLM_INSTRUCTIONS,
+        embedding_service=embedding_service,
+    )
+    await register_typed_operation(
+        product="vault",
+        version="1.x",
+        impl_id="vault",
+        op_id="vault.sys.policy.delete",
+        handler=vault_sys_policy_delete,
+        summary="Delete a HashiCorp Vault ACL policy by name (dangerous, approval-gated).",
+        description=(
+            "Deletes DELETE /v1/sys/policy/<name> via the operator's "
+            "OIDC-forwarded JWT. DANGEROUS: removing a policy immediately "
+            "revokes the access it granted to every token/entity bound "
+            "to it. Approval-gated. Returns {'name', 'deleted': true} on "
+            "success (deleting a non-existent policy is a no-op success)."
+        ),
+        parameter_schema=VAULT_SYS_POLICY_DELETE_PARAMETER_SCHEMA,
+        response_schema=VAULT_SYS_POLICY_DELETE_RESPONSE_SCHEMA,
+        group_key="sys",
+        when_to_use=sys_when_to_use,
+        tags=["write", "policy", "acl", "dangerous"],
+        safety_level="dangerous",
+        requires_approval=True,
+        llm_instructions=VAULT_SYS_POLICY_DELETE_LLM_INSTRUCTIONS,
         embedding_service=embedding_service,
     )

--- a/backend/src/meho_backplane/connectors/vault/ops_sys_policy.py
+++ b/backend/src/meho_backplane/connectors/vault/ops_sys_policy.py
@@ -1,0 +1,414 @@
+# SPDX-License-Identifier: Apache-2.0
+# Copyright (c) 2026 evoila Group
+
+"""Vault ``sys`` ACL-policy ops — typed handlers, schemas, LLM hints.
+
+Op-ids (G3.15-T2 #1410), all under the ``sys`` operation group and
+registered from :func:`meho_backplane.connectors.vault.ops_sys.register_vault_sys_typed_operations`:
+
+* ``vault.sys.policy.read`` — read one policy body (``GET /v1/sys/policy/<name>``).
+* ``vault.sys.policy.list`` — list configured policy names (``GET /v1/sys/policy``).
+* ``vault.sys.policy.write`` — create/replace a policy
+  (``PUT /v1/sys/policy/<name>``).
+* ``vault.sys.policy.delete`` — delete a policy (``DELETE /v1/sys/policy/<name>``).
+
+``read`` / ``list`` are ``safety_level='safe'`` / ``requires_approval=False``.
+``write`` / ``delete`` are ``safety_level='dangerous'`` /
+``requires_approval=True`` — a bad HCL body can lock everyone out or
+silently widen access, the highest-blast-radius Vault mutation, so they
+belong behind the approval gate (the issue's "dumb substrate, smart
+agent" rule: this layer is a thin pass-through; verb-layer linting of the
+policy body is out of scope — Vault itself rejects malformed HCL).
+
+Broadcast ``op_class`` (via
+:func:`~meho_backplane.broadcast.events.classify_op`): ``policy.list`` →
+``read`` (``.list`` suffix); ``policy.read`` → ``other`` (its only param
+is the policy name; ``.read`` is deliberately not a read-suffix, matching
+the ``vault.auth.*.read`` precedent); ``policy.write`` / ``policy.delete``
+→ ``write`` (the ``.write`` / ``.delete`` suffixes redact the HCL body
+rather than broadcasting it in full).
+
+This module is split out of ``ops_sys.py`` purely to keep each file under
+the repository's 600-line size budget; the ``register_typed_operation``
+calls stay in ``ops_sys.py`` so the whole ``sys`` group registers from
+one place. The handlers follow the exact shape of the authenticated sys
+read ops: ``(operator, target, params)``, the operator JWT forwarded via
+:func:`~meho_backplane.auth.vault.vault_client_for_operator`, and the
+synchronous hvac call offloaded with :func:`asyncio.to_thread` because
+hvac is ``requests``-based and FastAPI does not auto-offload blocking I/O
+inside an ``async def``. Handlers **raise** on failure; the dispatcher's
+``connector_error`` branch records the exception class in
+``extras["exception_class"]`` (no raw traceback to the agent).
+"""
+
+from __future__ import annotations
+
+import asyncio
+from typing import Any
+
+import meho_backplane.auth.vault as _auth_vault
+from meho_backplane.auth.operator import Operator
+
+__all__ = [
+    "VAULT_SYS_POLICY_DELETE_LLM_INSTRUCTIONS",
+    "VAULT_SYS_POLICY_DELETE_PARAMETER_SCHEMA",
+    "VAULT_SYS_POLICY_DELETE_RESPONSE_SCHEMA",
+    "VAULT_SYS_POLICY_LIST_LLM_INSTRUCTIONS",
+    "VAULT_SYS_POLICY_LIST_PARAMETER_SCHEMA",
+    "VAULT_SYS_POLICY_LIST_RESPONSE_SCHEMA",
+    "VAULT_SYS_POLICY_READ_LLM_INSTRUCTIONS",
+    "VAULT_SYS_POLICY_READ_PARAMETER_SCHEMA",
+    "VAULT_SYS_POLICY_READ_RESPONSE_SCHEMA",
+    "VAULT_SYS_POLICY_WRITE_LLM_INSTRUCTIONS",
+    "VAULT_SYS_POLICY_WRITE_PARAMETER_SCHEMA",
+    "VAULT_SYS_POLICY_WRITE_RESPONSE_SCHEMA",
+    "vault_sys_policy_delete",
+    "vault_sys_policy_list",
+    "vault_sys_policy_read",
+    "vault_sys_policy_write",
+]
+
+
+#: Shared ``name`` schema fragment for the three name-addressed policy
+#: ops. ``pattern="^(?=.*\\S)[^/]+$"`` mirrors the KV-v2 ``mount``
+#: fragment in :mod:`meho_backplane.connectors.vault.ops`: the
+#: ``(?=.*\S)`` lookahead makes an all-whitespace value a validation-time
+#: ``invalid_params`` failure rather than a value that ``.strip()``s to
+#: ``""`` and degrades to a runtime ``connector_error``; ``[^/]+``
+#: rejects a slash-bearing name (Vault policy names are flat handles).
+_POLICY_NAME_PROPERTY: dict[str, Any] = {
+    "type": "string",
+    "pattern": r"^(?=.*\S)[^/]+$",
+    "description": (
+        "The ACL policy name (a flat handle, e.g. 'meho-mcp'). Vault "
+        "lower-cases policy names server-side."
+    ),
+}
+
+
+VAULT_SYS_POLICY_READ_PARAMETER_SCHEMA: dict[str, Any] = {
+    "type": "object",
+    "properties": {"name": _POLICY_NAME_PROPERTY},
+    "required": ["name"],
+    "additionalProperties": False,
+}
+
+
+#: ``vault.sys.policy.list`` takes no parameter — it returns every
+#: configured policy name. A stray key is a validation error.
+VAULT_SYS_POLICY_LIST_PARAMETER_SCHEMA: dict[str, Any] = {
+    "type": "object",
+    "properties": {},
+    "additionalProperties": False,
+}
+
+
+VAULT_SYS_POLICY_WRITE_PARAMETER_SCHEMA: dict[str, Any] = {
+    "type": "object",
+    "properties": {
+        "name": _POLICY_NAME_PROPERTY,
+        "policy": {
+            "type": "string",
+            "minLength": 1,
+            "description": (
+                "The policy body as HCL or JSON. REPLACES any existing "
+                "policy of the same name in full (not a merge). Vault "
+                "itself rejects a malformed body; this op does not "
+                "pre-validate beyond requiring a non-empty string."
+            ),
+        },
+    },
+    "required": ["name", "policy"],
+    "additionalProperties": False,
+}
+
+
+VAULT_SYS_POLICY_DELETE_PARAMETER_SCHEMA: dict[str, Any] = {
+    "type": "object",
+    "properties": {"name": _POLICY_NAME_PROPERTY},
+    "required": ["name"],
+    "additionalProperties": False,
+}
+
+
+VAULT_SYS_POLICY_READ_RESPONSE_SCHEMA: dict[str, Any] = {
+    "type": "object",
+    "properties": {
+        "name": {
+            "type": "string",
+            "description": "The policy name echoed back by Vault.",
+        },
+        "rules": {
+            "type": ["string", "null"],
+            "description": (
+                "The policy body (HCL or JSON) Vault has stored for this "
+                "name, or null when Vault returned no body."
+            ),
+        },
+    },
+    "required": ["name", "rules"],
+}
+
+
+VAULT_SYS_POLICY_LIST_RESPONSE_SCHEMA: dict[str, Any] = {
+    "type": "object",
+    "properties": {
+        "policies": {
+            "type": "array",
+            "items": {"type": "string"},
+            "description": (
+                "The configured ACL policy names (always includes the "
+                "built-in 'default' and 'root' policies)."
+            ),
+        },
+    },
+    "required": ["policies"],
+}
+
+
+VAULT_SYS_POLICY_WRITE_RESPONSE_SCHEMA: dict[str, Any] = {
+    "type": "object",
+    "properties": {
+        "name": {
+            "type": "string",
+            "description": "The policy name that was created or replaced.",
+        },
+        "written": {
+            "type": "boolean",
+            "description": "Always True on success (Vault returns HTTP 204).",
+        },
+    },
+    "required": ["name", "written"],
+}
+
+
+VAULT_SYS_POLICY_DELETE_RESPONSE_SCHEMA: dict[str, Any] = {
+    "type": "object",
+    "properties": {
+        "name": {
+            "type": "string",
+            "description": "The policy name that was deleted.",
+        },
+        "deleted": {
+            "type": "boolean",
+            "description": (
+                "Always True on success (Vault returns HTTP 204; deleting "
+                "a non-existent policy is a no-op success on Vault's side)."
+            ),
+        },
+    },
+    "required": ["name", "deleted"],
+}
+
+
+VAULT_SYS_POLICY_READ_LLM_INSTRUCTIONS: dict[str, Any] = {
+    "when_to_use": (
+        "Read the ACL policy body (HCL/JSON rules) for a named Vault "
+        "policy. Use to inspect what a policy grants before editing it, "
+        "or to answer 'what does the meho-mcp policy allow?'. Read-only; "
+        "returns policy rules, not secret values."
+    ),
+    "parameter_hints": {
+        "name": "The policy name, e.g. 'meho-mcp' or 'default'.",
+    },
+    "output_shape": (
+        "{'name': <str>, 'rules': <str|null>}. On a missing policy or "
+        "transport failure: a connector_error OperationResult with "
+        "extras.exception_class."
+    ),
+}
+
+
+VAULT_SYS_POLICY_LIST_LLM_INSTRUCTIONS: dict[str, Any] = {
+    "when_to_use": (
+        "List the names of every configured ACL policy on the Vault "
+        "target. Use to discover which policies exist before reading or "
+        "editing one. Read-only; returns names only, no policy bodies."
+    ),
+    "parameter_hints": {},
+    "output_shape": (
+        "{'policies': [<name>, ...]} including the built-in 'default' / "
+        "'root'. On failure: connector_error with extras.exception_class."
+    ),
+}
+
+
+VAULT_SYS_POLICY_WRITE_LLM_INSTRUCTIONS: dict[str, Any] = {
+    "when_to_use": (
+        "Create a new ACL policy or replace an existing one in full. "
+        "DANGEROUS and approval-gated: a bad HCL body can lock operators "
+        "out or silently widen access. Always read the current body "
+        "(vault.sys.policy.read) first and diff your change. Never use "
+        "for the built-in 'root' policy."
+    ),
+    "parameter_hints": {
+        "name": "The policy name to create or replace.",
+        "policy": (
+            "The full policy body as HCL or JSON. This REPLACES the "
+            "existing body — it is not a merge."
+        ),
+    },
+    "output_shape": (
+        "{'name': <str>, 'written': true} on success (HTTP 204). On a "
+        "malformed body or transport failure: connector_error with "
+        "extras.exception_class."
+    ),
+}
+
+
+VAULT_SYS_POLICY_DELETE_LLM_INSTRUCTIONS: dict[str, Any] = {
+    "when_to_use": (
+        "Delete an ACL policy by name. DANGEROUS and approval-gated: "
+        "removing a policy immediately revokes the access it granted to "
+        "every token/entity bound to it. Confirm no live identity depends "
+        "on it first. Never delete the built-in 'default' / 'root' "
+        "policies."
+    ),
+    "parameter_hints": {
+        "name": "The policy name to delete.",
+    },
+    "output_shape": (
+        "{'name': <str>, 'deleted': true} on success (HTTP 204; deleting "
+        "a non-existent policy is a no-op success). On failure: "
+        "connector_error with extras.exception_class."
+    ),
+}
+
+
+def _extract_rules(response: Any) -> str | None:
+    """Pull the policy body out of an hvac ``read_policy`` response.
+
+    Vault's legacy ``GET /v1/sys/policy/<name>`` endpoint returns the
+    rules both at the envelope top level (``{"name", "rules"}``) and,
+    on newer servers, nested under ``data`` (``{"data": {"name",
+    "rules"|"policy"}}``). hvac forwards the JSON verbatim. Probe the
+    nested ``data`` object first (the modern shape), then the top
+    level, accepting either the ``rules`` or ``policy`` key spelling.
+    """
+    if not isinstance(response, dict):
+        return None
+    data = response.get("data")
+    if isinstance(data, dict):
+        nested = data.get("rules", data.get("policy"))
+        if nested is not None:
+            return str(nested)
+    top = response.get("rules", response.get("policy"))
+    return None if top is None else str(top)
+
+
+def _extract_policy_names(response: Any) -> list[str]:
+    """Pull the policy-name list out of an hvac ``list_policies`` response.
+
+    Like :func:`_extract_rules`, ``GET /v1/sys/policy`` returns the
+    ``policies`` array both top-level and under ``data`` depending on
+    the server version. Prefer the nested ``data.policies`` (modern
+    shape), fall back to the top-level key.
+    """
+    if not isinstance(response, dict):
+        return []
+    data = response.get("data")
+    if isinstance(data, dict) and isinstance(data.get("policies"), list):
+        return [str(name) for name in data["policies"]]
+    policies = response.get("policies")
+    if isinstance(policies, list):
+        return [str(name) for name in policies]
+    return []
+
+
+async def vault_sys_policy_read(
+    operator: Operator, target: Any, params: dict[str, Any]
+) -> dict[str, Any]:
+    """Read one ACL policy body (``GET /v1/sys/policy/<name>``).
+
+    Op-id: ``vault.sys.policy.read``. Safe / read-only. Forwards the
+    operator JWT and offloads the blocking ``sys.read_policy`` call.
+
+    Returns ``{"name": <name>, "rules": <body|None>}``.
+
+    Raises
+    ------
+    meho_backplane.auth.vault.VaultClientError
+        Login-phase failure. Wrapped into ``connector_error``.
+    Exception
+        Any error hvac raises from the policy read.
+    """
+    name: str = str(params["name"]).strip()
+    async with _auth_vault.vault_client_for_operator(operator) as client:
+        response = await asyncio.to_thread(client.sys.read_policy, name=name)
+        return {"name": name, "rules": _extract_rules(response)}
+
+
+async def vault_sys_policy_list(
+    operator: Operator, target: Any, params: dict[str, Any]
+) -> dict[str, Any]:
+    """List configured ACL policy names (``GET /v1/sys/policy``).
+
+    Op-id: ``vault.sys.policy.list``. Safe / read-only.
+
+    Returns ``{"policies": [<name>, ...]}``.
+
+    Raises
+    ------
+    meho_backplane.auth.vault.VaultClientError
+        Login-phase failure. Wrapped into ``connector_error``.
+    Exception
+        Any error hvac raises from the policy list.
+    """
+    _ = params  # schema-validated empty object; no inputs to extract.
+    async with _auth_vault.vault_client_for_operator(operator) as client:
+        response = await asyncio.to_thread(client.sys.list_policies)
+        return {"policies": _extract_policy_names(response)}
+
+
+async def vault_sys_policy_write(
+    operator: Operator, target: Any, params: dict[str, Any]
+) -> dict[str, Any]:
+    """Create or replace an ACL policy (``PUT /v1/sys/policy/<name>``).
+
+    Op-id: ``vault.sys.policy.write``. DANGEROUS / approval-gated.
+    Delegates to hvac's ``sys.create_or_update_policy(name, policy)``;
+    the ``policy`` body is HCL or JSON and replaces any existing policy
+    of the same name in full. Vault returns HTTP 204 on success (no
+    body), so the handler synthesizes ``{"name", "written": True}`` —
+    a reaching-here-means-success contract (hvac raises on a non-2xx).
+
+    Raises
+    ------
+    meho_backplane.auth.vault.VaultClientError
+        Login-phase failure. Wrapped into ``connector_error``.
+    Exception
+        Any error hvac raises from the policy write (e.g. a malformed
+        HCL body Vault rejects with a 400).
+    """
+    name: str = str(params["name"]).strip()
+    policy: str = params["policy"]
+    async with _auth_vault.vault_client_for_operator(operator) as client:
+        await asyncio.to_thread(
+            client.sys.create_or_update_policy,
+            name=name,
+            policy=policy,
+        )
+        return {"name": name, "written": True}
+
+
+async def vault_sys_policy_delete(
+    operator: Operator, target: Any, params: dict[str, Any]
+) -> dict[str, Any]:
+    """Delete an ACL policy (``DELETE /v1/sys/policy/<name>``).
+
+    Op-id: ``vault.sys.policy.delete``. DANGEROUS / approval-gated.
+    Delegates to hvac's ``sys.delete_policy(name)``. Vault returns HTTP
+    204 (deleting a non-existent policy is a no-op success), so the
+    handler synthesizes ``{"name", "deleted": True}``.
+
+    Raises
+    ------
+    meho_backplane.auth.vault.VaultClientError
+        Login-phase failure. Wrapped into ``connector_error``.
+    Exception
+        Any error hvac raises from the policy delete.
+    """
+    name: str = str(params["name"]).strip()
+    async with _auth_vault.vault_client_for_operator(operator) as client:
+        await asyncio.to_thread(client.sys.delete_policy, name=name)
+        return {"name": name, "deleted": True}

--- a/backend/tests/_vault_fakes.py
+++ b/backend/tests/_vault_fakes.py
@@ -290,6 +290,21 @@ class _FakeSysBackend:
     auth_methods_payload: Any = None
     raise_on_auth_methods: Exception | None = None
     auth_methods_calls: int = 0
+    # G3.15-T2 (#1410) ACL-policy ops. Same payload / raise pair shape as
+    # the sibling sys-read knobs above so the policy-op tests inject a
+    # success body or a failure independently. ``write`` / ``delete``
+    # record the call args (Vault returns 204 with no body, so there is
+    # no payload to inject — only a failure knob).
+    policy_read_payload: Any = None
+    raise_on_policy_read: Exception | None = None
+    policy_read_calls: list[dict[str, Any]] = field(default_factory=list)
+    policy_list_payload: Any = None
+    raise_on_policy_list: Exception | None = None
+    policy_list_calls: int = 0
+    raise_on_policy_write: Exception | None = None
+    policy_write_calls: list[dict[str, Any]] = field(default_factory=list)
+    raise_on_policy_delete: Exception | None = None
+    policy_delete_calls: list[dict[str, Any]] = field(default_factory=list)
 
     def read_health_status(self, *, method: str = "HEAD", **_kwargs: Any) -> Any:
         self.read_calls.append({"method": method})
@@ -314,6 +329,35 @@ class _FakeSysBackend:
         if self.raise_on_auth_methods is not None:
             raise self.raise_on_auth_methods
         return self.auth_methods_payload
+
+    def read_policy(self, name: str) -> Any:
+        self.policy_read_calls.append({"name": name})
+        if self.raise_on_policy_read is not None:
+            raise self.raise_on_policy_read
+        return self.policy_read_payload
+
+    def list_policies(self) -> Any:
+        self.policy_list_calls += 1
+        if self.raise_on_policy_list is not None:
+            raise self.raise_on_policy_list
+        return self.policy_list_payload
+
+    def create_or_update_policy(
+        self, name: str, policy: str, pretty_print: bool = True
+    ) -> _DeleteResponse:
+        self.policy_write_calls.append(
+            {"name": name, "policy": policy, "pretty_print": pretty_print}
+        )
+        if self.raise_on_policy_write is not None:
+            raise self.raise_on_policy_write
+        # Vault returns 204 with no body; hvac yields the requests.Response.
+        return _DeleteResponse()
+
+    def delete_policy(self, name: str) -> _DeleteResponse:
+        self.policy_delete_calls.append({"name": name})
+        if self.raise_on_policy_delete is not None:
+            raise self.raise_on_policy_delete
+        return _DeleteResponse()
 
 
 @dataclass
@@ -384,6 +428,12 @@ def install_fake_client(
     mounts_exc: Exception | None = None,
     auth_methods_payload: Any = None,
     auth_methods_exc: Exception | None = None,
+    policy_read_payload: Any = None,
+    policy_read_exc: Exception | None = None,
+    policy_list_payload: Any = None,
+    policy_list_exc: Exception | None = None,
+    policy_write_exc: Exception | None = None,
+    policy_delete_exc: Exception | None = None,
     keys: list[str] | None = None,
     versions_meta: dict[str, Any] | None = None,
     list_exc: Exception | None = None,
@@ -400,9 +450,11 @@ def install_fake_client(
     login / revoke / health-read / kv-read exception injection plus
     secret and KV-version overrides, the G3.3-T2 (#546) sys read
     group's seal-status / mounts / auth-methods payload + exception
-    injection, and the G3.3-T1 KV-v2 verbs (list / put / versions /
+    injection, the G3.3-T1 KV-v2 verbs (list / put / versions /
     delete) with per-verb exception injection and key/version-metadata
-    overrides.
+    overrides, and the G3.15-T2 (#1410) ACL-policy verbs (read / list
+    payload + exception injection; write / delete exception injection,
+    write/delete returning 204 with no body).
     """
     fake = install_fake_vault(monkeypatch, kv_version=kv_version if kv_version is not None else 11)
     fake.auth.jwt.raise_on_login = login_exc
@@ -415,6 +467,12 @@ def install_fake_client(
     fake.sys.raise_on_mounts = mounts_exc
     fake.sys.auth_methods_payload = auth_methods_payload
     fake.sys.raise_on_auth_methods = auth_methods_exc
+    fake.sys.policy_read_payload = policy_read_payload
+    fake.sys.raise_on_policy_read = policy_read_exc
+    fake.sys.policy_list_payload = policy_list_payload
+    fake.sys.raise_on_policy_list = policy_list_exc
+    fake.sys.raise_on_policy_write = policy_write_exc
+    fake.sys.raise_on_policy_delete = policy_delete_exc
     kv = fake.secrets.kv.v2
     if secret is not None:
         kv.secret = secret

--- a/backend/tests/integration/test_connectors_vault_dev_e2e.py
+++ b/backend/tests/integration/test_connectors_vault_dev_e2e.py
@@ -5,7 +5,8 @@
 
 Boots a real ``hashicorp/vault:1.18`` server in dev mode via
 testcontainers, seeds the surfaces every op in Initiative #366 touches
-(KV-v2 ``secret/``, ``userpass``, ``approle``), then dispatches every
+(KV-v2 ``secret/``, ``userpass``, ``approle``, and a ``ci-readonly`` ACL
+policy for the G3.15-T2 #1410 policy reads), then dispatches every
 registered ``vault.kv.*`` / ``vault.sys.*`` / ``vault.auth.*`` op
 through the **real G0.6 dispatcher** against the live Vault and a real
 Postgres audit store. The unit suites (``test_connectors_vault*.py``)
@@ -43,7 +44,10 @@ What this harness proves (issue #551 DoD)
   ``credential_read``-allowlisted ``vault.kv.read``; the auth-config
   ``.read`` ops therefore classify ``other``, the safe
   over-broadcast direction for non-secret auth-method metadata
-  (decision #3). The test assertions below encode this split.
+  (decision #3). ``vault.sys.policy.read`` (G3.15-T2 #1410) shares
+  this ``other`` classification for the same reason — its only param
+  is the policy name — while ``vault.sys.policy.list`` is ``read`` via
+  the ``.list`` suffix. The test assertions below encode this split.
 * The dev-root token is generated into the container via
   ``VAULT_DEV_ROOT_TOKEN_ID`` and only ever held in the fixture's
   return value — it is never written to a workflow log, a committed
@@ -286,6 +290,16 @@ def _seed_vault(addr: str) -> None:
         token_policies=["default"],
         token_ttl="1h",
         mount_point="approle",
+    )
+
+    # --- ACL policy (G3.15-T2 #1410) -------------------------------
+    # A named policy so vault.sys.policy.read / .list have a non-builtin
+    # target to assert on. Reads only — the dangerous write/delete ops
+    # are approval-gated, so a dispatch parks before reaching Vault and
+    # is covered by the unit suite.
+    client.sys.create_or_update_policy(
+        name="ci-readonly",
+        policy='path "secret/data/app/*" {\n  capabilities = ["read", "list"]\n}\n',
     )
 
 
@@ -755,6 +769,64 @@ async def test_sys_auth_list_against_dev_vault(
     await _assert_audited(
         "vault.sys.auth.list",
         operator_sub="op-sys-auth",
+        expected_op_class="read",
+        events=captured_events,
+    )
+
+
+@pytest.mark.asyncio
+async def test_sys_policy_read_against_dev_vault(
+    vault_e2e: tuple[_VaultTarget, str],
+    captured_events: list[BroadcastEvent],
+) -> None:
+    """``vault.sys.policy.read`` returns the seeded ci-readonly body; op_class=read."""
+    target, _ = vault_e2e
+    operator = _make_operator(sub="op-policy-read")
+    result = await dispatch(
+        operator=operator,
+        connector_id="vault-1.x",
+        op_id="vault.sys.policy.read",
+        target=target,
+        params={"name": "ci-readonly"},
+    )
+    assert result.status == "ok", result.error
+    assert isinstance(result.result, dict)
+    assert result.result["name"] == "ci-readonly"
+    assert "secret/data/app/*" in (result.result["rules"] or "")
+    await _assert_audited(
+        "vault.sys.policy.read",
+        operator_sub="op-policy-read",
+        # ``.read`` is not a read-suffix; policy.read's only param is the
+        # policy name, so it broadcasts ``other`` (full params) like the
+        # vault.auth.*.read ops.
+        expected_op_class="other",
+        events=captured_events,
+    )
+
+
+@pytest.mark.asyncio
+async def test_sys_policy_list_against_dev_vault(
+    vault_e2e: tuple[_VaultTarget, str],
+    captured_events: list[BroadcastEvent],
+) -> None:
+    """``vault.sys.policy.list`` includes the seeded policy + builtins; op_class=read."""
+    target, _ = vault_e2e
+    operator = _make_operator(sub="op-policy-list")
+    result = await dispatch(
+        operator=operator,
+        connector_id="vault-1.x",
+        op_id="vault.sys.policy.list",
+        target=target,
+        params={},
+    )
+    assert result.status == "ok", result.error
+    assert isinstance(result.result, dict)
+    policies = result.result["policies"]
+    assert "ci-readonly" in policies
+    assert "default" in policies
+    await _assert_audited(
+        "vault.sys.policy.list",
+        operator_sub="op-policy-list",
         expected_op_class="read",
         events=captured_events,
     )

--- a/backend/tests/test_broadcast_events.py
+++ b/backend/tests/test_broadcast_events.py
@@ -284,6 +284,11 @@ class TestClassifyOp:
             # metadata only (no secret values) → ``read``, not
             # ``credential_read``.
             ("vault.kv.versions", "read"),
+            # Vault ACL-policy list (G3.15-T2 #1410): ``.list`` suffix →
+            # ``read`` (policy names, no secret content). ``policy.read``
+            # is intentionally ``other`` (see test_unknown_falls_through_
+            # to_other) — ``.read`` is not a read-suffix.
+            ("vault.sys.policy.list", "read"),
         ],
     )
     def test_read_suffixes(self, op_id: str, expected: str) -> None:
@@ -303,6 +308,12 @@ class TestClassifyOp:
             # than redact under the ``write`` branch.
             ("bind9.record.add", "write"),
             ("bind9.record.remove", "write"),
+            # Vault ACL-policy write (G3.15-T2 #1410). ``policy.write``
+            # carries the full HCL body in its params; the ``.write``
+            # suffix redacts it under the ``write`` branch rather than
+            # broadcasting the policy text as an ``other``-class event.
+            ("vault.sys.policy.write", "write"),
+            ("vault.sys.policy.delete", "write"),
         ],
     )
     def test_write_suffixes(self, op_id: str, expected: str) -> None:
@@ -315,6 +326,12 @@ class TestClassifyOp:
             "weird",
             "vsphere.vm.poweron",  # not a write suffix
             "",
+            # G3.15-T2 #1410: ``.read`` is deliberately not a read-suffix
+            # (it would over-match the credential_read-allowlisted
+            # vault.kv.read and the auth-config .read ops). vault.sys.
+            # policy.read's only param is the policy name, so ``other``
+            # (full params) is the safe, consistent classification.
+            "vault.sys.policy.read",
         ],
     )
     def test_unknown_falls_through_to_other(self, op_id: str) -> None:

--- a/backend/tests/test_connectors_vault_sys.py
+++ b/backend/tests/test_connectors_vault_sys.py
@@ -30,6 +30,23 @@ repeats):
   :class:`VaultClientError` subclass name in
   ``extras["exception_class"]``.
 
+ACL-policy ops (G3.15-T2 #1410) add:
+
+* ``policy.read`` / ``policy.list`` register safe + ``requires_approval``
+  False; ``policy.write`` / ``policy.delete`` register dangerous +
+  ``requires_approval`` True, all in the ``sys`` group.
+* ``classify_op`` maps the reads to ``read`` and the writes to ``write``.
+* ``policy.read`` unwraps the ``data.rules`` envelope (modern + legacy
+  top-level shapes; null when absent); ``policy.list`` returns the
+  policy-name array; the write/delete handlers forward to hvac and
+  synthesize the 204-success payload.
+* A ``policy.write`` / ``policy.delete`` *dispatch* is parked as
+  ``awaiting_approval`` by the G11.7 policy gate before the handler runs;
+  the handler's own logic is exercised by calling it directly.
+* Schema rejects slash/blank names, empty/missing bodies, and stray keys
+  (validation runs ahead of the approval gate). Vault-side / login
+  failures surface structurally.
+
 Test isolation mirrors ``test_connectors_vault.py``: the production
 code builds Vault clients through the single ``_build_client`` seam;
 the shared ``tests/_vault_fakes.py`` ``install_fake_client`` helper
@@ -61,6 +78,10 @@ from meho_backplane.connectors.schemas import OperationResult
 from meho_backplane.connectors.vault import (
     VaultConnector,
     register_vault_sys_typed_operations,
+)
+from meho_backplane.connectors.vault.ops_sys_policy import (
+    vault_sys_policy_delete,
+    vault_sys_policy_write,
 )
 from meho_backplane.operations import dispatch, reset_dispatcher_caches
 from meho_backplane.settings import get_settings
@@ -383,3 +404,329 @@ async def test_authenticated_sys_op_login_failure_surfaces_vault_client_error(
     assert result.error.startswith("connector_error:")
     assert result.extras.get("error_code") == "connector_error"
     assert result.extras.get("exception_class") == expected_exc_class
+
+
+# ---------------------------------------------------------------------------
+# vault.sys.policy.* — ACL-policy ops (G3.15-T2 #1410)
+# ---------------------------------------------------------------------------
+
+
+_POLICY_SAFE_OP_IDS = (
+    "vault.sys.policy.read",
+    "vault.sys.policy.list",
+)
+_POLICY_DANGEROUS_OP_IDS = (
+    "vault.sys.policy.write",
+    "vault.sys.policy.delete",
+)
+
+
+async def _policy_descriptor(op_id: str) -> Any:
+    """Fetch the endpoint_descriptor + its group for a policy op."""
+    from sqlalchemy import select
+
+    from meho_backplane.db.engine import get_sessionmaker
+    from meho_backplane.db.models import EndpointDescriptor, OperationGroup
+
+    sessionmaker = get_sessionmaker()
+    async with sessionmaker() as session:
+        row = (
+            await session.execute(
+                select(EndpointDescriptor).where(
+                    EndpointDescriptor.product == "vault",
+                    EndpointDescriptor.version == "1.x",
+                    EndpointDescriptor.impl_id == "vault",
+                    EndpointDescriptor.op_id == op_id,
+                )
+            )
+        ).scalar_one()
+        group = (
+            await session.execute(select(OperationGroup).where(OperationGroup.id == row.group_id))
+        ).scalar_one()
+        return row, group
+
+
+@pytest.mark.parametrize("op_id", _POLICY_SAFE_OP_IDS)
+async def test_policy_read_ops_register_safe_no_approval(
+    op_id: str,
+    _registered_vault_sys_ops: None,
+) -> None:
+    """policy.read / policy.list register safe, group 'sys', no approval."""
+    row, group = await _policy_descriptor(op_id)
+    assert row.source_kind == "typed"
+    assert row.safety_level == "safe"
+    assert row.requires_approval is False
+    assert group.group_key == "sys"
+
+
+@pytest.mark.parametrize("op_id", _POLICY_DANGEROUS_OP_IDS)
+async def test_policy_write_ops_register_dangerous_with_approval(
+    op_id: str,
+    _registered_vault_sys_ops: None,
+) -> None:
+    """policy.write / policy.delete register dangerous + requires_approval."""
+    row, group = await _policy_descriptor(op_id)
+    assert row.source_kind == "typed"
+    assert row.safety_level == "dangerous"
+    assert row.requires_approval is True
+    assert group.group_key == "sys"
+
+
+@pytest.mark.parametrize(
+    ("op_id", "expected"),
+    [
+        # ``policy.read``'s only param is the policy name; ``.read`` is
+        # deliberately not a read-suffix (would over-match vault.kv.read),
+        # so it classifies ``other`` like the vault.auth.*.read ops.
+        ("vault.sys.policy.read", "other"),
+        ("vault.sys.policy.list", "read"),
+        ("vault.sys.policy.write", "write"),
+        ("vault.sys.policy.delete", "write"),
+    ],
+)
+def test_policy_ops_classify(op_id: str, expected: str) -> None:
+    """policy.list → read; policy.read → other; writes/deletes redact under ``write``."""
+    assert classify_op(op_id) == expected
+
+
+async def test_policy_read_returns_name_and_rules(
+    monkeypatch: pytest.MonkeyPatch,
+    _registered_vault_sys_ops: None,
+) -> None:
+    """policy.read unwraps the envelope ``data.rules`` and forwards the JWT."""
+    rules = 'path "secret/data/*" {\n  capabilities = ["read"]\n}\n'
+    fake = install_fake_client(
+        monkeypatch,
+        policy_read_payload={"data": {"name": "meho-mcp", "rules": rules}},
+    )
+    result = await _dispatch_vault("vault.sys.policy.read", {"name": "meho-mcp"}, jwt="op-jwt")
+
+    assert result.status == "ok", result.error
+    assert result.result == {"name": "meho-mcp", "rules": rules}
+    assert fake.sys.policy_read_calls == [{"name": "meho-mcp"}]
+    assert fake.auth.jwt.login_calls == [{"role": "meho-mcp", "jwt": "op-jwt", "path": "jwt"}]
+    assert fake.auth.token.revoke_calls == 1
+
+
+async def test_policy_read_accepts_top_level_rules(
+    monkeypatch: pytest.MonkeyPatch,
+    _registered_vault_sys_ops: None,
+) -> None:
+    """Legacy Vault returns ``rules`` at the envelope top level (no ``data``)."""
+    install_fake_client(
+        monkeypatch,
+        policy_read_payload={"name": "default", "rules": "# default policy\n"},
+    )
+    result = await _dispatch_vault("vault.sys.policy.read", {"name": "default"})
+
+    assert result.status == "ok", result.error
+    assert result.result == {"name": "default", "rules": "# default policy\n"}
+
+
+async def test_policy_read_missing_body_yields_null_rules(
+    monkeypatch: pytest.MonkeyPatch,
+    _registered_vault_sys_ops: None,
+) -> None:
+    """A response carrying no rules surfaces ``rules=None`` (not a crash)."""
+    install_fake_client(monkeypatch, policy_read_payload={"data": {"name": "empty"}})
+    result = await _dispatch_vault("vault.sys.policy.read", {"name": "empty"})
+
+    assert result.status == "ok", result.error
+    assert result.result == {"name": "empty", "rules": None}
+
+
+async def test_policy_list_unwraps_envelope_data(
+    monkeypatch: pytest.MonkeyPatch,
+    _registered_vault_sys_ops: None,
+) -> None:
+    """policy.list returns the policy names from the envelope ``data``."""
+    names = ["default", "meho-mcp", "root"]
+    fake = install_fake_client(
+        monkeypatch,
+        policy_list_payload={"data": {"policies": names}, "policies": names},
+    )
+    result = await _dispatch_vault("vault.sys.policy.list", {})
+
+    assert result.status == "ok", result.error
+    assert result.result == {"policies": names}
+    assert fake.sys.policy_list_calls == 1
+
+
+# ``policy.write`` / ``policy.delete`` are ``requires_approval=True``, so a
+# full ``dispatch()`` for a human/service principal is intercepted by the
+# G11.7 policy gate and parked as ``awaiting_approval`` *before* the
+# handler runs (see ``test_policy_write_ops_are_approval_gated_on_dispatch``).
+# The handler's hvac-forwarding + payload-shape + error contract is
+# therefore exercised by calling the handler directly with the fake
+# client installed.
+
+
+async def test_policy_write_handler_forwards_body_and_returns_written(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """policy.write handler forwards name+body to hvac and reports written=True."""
+    body = 'path "secret/data/app/*" {\n  capabilities = ["read", "list"]\n}\n'
+    fake = install_fake_client(monkeypatch)
+    result = await vault_sys_policy_write(
+        _make_operator("op-jwt"), None, {"name": "app-ro", "policy": body}
+    )
+
+    assert result == {"name": "app-ro", "written": True}
+    assert fake.sys.policy_write_calls == [{"name": "app-ro", "policy": body, "pretty_print": True}]
+    assert fake.auth.jwt.login_calls == [{"role": "meho-mcp", "jwt": "op-jwt", "path": "jwt"}]
+    assert fake.auth.token.revoke_calls == 1
+
+
+async def test_policy_delete_handler_forwards_name_and_returns_deleted(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """policy.delete handler forwards the name and reports deleted=True."""
+    fake = install_fake_client(monkeypatch)
+    result = await vault_sys_policy_delete(_make_operator(), None, {"name": "app-ro"})
+
+    assert result == {"name": "app-ro", "deleted": True}
+    assert fake.sys.policy_delete_calls == [{"name": "app-ro"}]
+    assert fake.auth.token.revoke_calls == 1
+
+
+@pytest.mark.parametrize(
+    ("op_id", "params"),
+    [
+        ("vault.sys.policy.write", {"name": "app-ro", "policy": "# body\n"}),
+        ("vault.sys.policy.delete", {"name": "app-ro"}),
+    ],
+)
+async def test_policy_write_ops_are_approval_gated_on_dispatch(
+    monkeypatch: pytest.MonkeyPatch,
+    op_id: str,
+    params: dict[str, Any],
+    _registered_vault_sys_ops: None,
+) -> None:
+    """DoD: a write/delete dispatch parks as ``awaiting_approval`` (handler never runs)."""
+    fake = install_fake_client(monkeypatch)
+    result = await _dispatch_vault(op_id, params)
+
+    assert result.status == "awaiting_approval", result.error
+    assert result.extras.get("error_code") == "awaiting_approval"
+    assert result.extras.get("approval_request_id")
+    # The handler must not have reached Vault — the gate parks first.
+    assert fake.sys.policy_write_calls == []
+    assert fake.sys.policy_delete_calls == []
+
+
+@pytest.mark.parametrize(
+    ("op_id", "params"),
+    [
+        ("vault.sys.policy.read", {"name": "secret/data"}),
+        ("vault.sys.policy.read", {"name": "  "}),
+        ("vault.sys.policy.read", {}),
+        ("vault.sys.policy.write", {"name": "ok", "policy": ""}),
+        ("vault.sys.policy.write", {"name": "ok"}),
+        ("vault.sys.policy.write", {"name": "secret/x", "policy": "y"}),
+        ("vault.sys.policy.delete", {"name": "secret/x"}),
+        ("vault.sys.policy.list", {"name": "x"}),
+    ],
+)
+async def test_policy_op_rejects_invalid_params(
+    monkeypatch: pytest.MonkeyPatch,
+    op_id: str,
+    params: dict[str, Any],
+    _registered_vault_sys_ops: None,
+) -> None:
+    """Schema rejects slash/blank names, empty/missing bodies, stray keys.
+
+    Validation runs ahead of the approval gate, so even the
+    ``requires_approval`` write/delete ops surface ``invalid_params``
+    rather than ``awaiting_approval`` for a malformed call.
+    """
+    install_fake_client(monkeypatch)
+    result = await _dispatch_vault(op_id, params)
+
+    assert result.status == "error"
+    assert result.extras.get("error_code") == "invalid_params"
+
+
+# --- read/list error + login-failure: these dispatch all the way to the
+# handler (they are not approval-gated), so the dispatcher's connector_error
+# branch is exercised end to end. ---
+
+
+@pytest.mark.parametrize(
+    ("op_id", "params", "exc_kwarg"),
+    [
+        ("vault.sys.policy.read", {"name": "x"}, "policy_read_exc"),
+        ("vault.sys.policy.list", {}, "policy_list_exc"),
+    ],
+)
+async def test_policy_read_op_vault_error_surfaces_structured_error(
+    monkeypatch: pytest.MonkeyPatch,
+    op_id: str,
+    params: dict[str, Any],
+    exc_kwarg: str,
+    _registered_vault_sys_ops: None,
+) -> None:
+    """A Vault-side error on a read op → connector_error, no traceback."""
+    install_fake_client(
+        monkeypatch,
+        **{exc_kwarg: hvac.exceptions.InvalidRequest("failed to parse policy")},
+    )
+    result = await _dispatch_vault(op_id, params)
+
+    assert result.status == "error"
+    assert result.error is not None
+    assert result.error.startswith("connector_error:")
+    assert result.extras.get("error_code") == "connector_error"
+    assert result.extras.get("exception_class") == "InvalidRequest"
+
+
+@pytest.mark.parametrize(
+    ("op_id", "params"),
+    [
+        ("vault.sys.policy.read", {"name": "x"}),
+        ("vault.sys.policy.list", {}),
+    ],
+)
+async def test_policy_read_op_login_failure_surfaces_vault_client_error(
+    monkeypatch: pytest.MonkeyPatch,
+    op_id: str,
+    params: dict[str, Any],
+    _registered_vault_sys_ops: None,
+) -> None:
+    """Login-phase failure on a read op → connector_error w/ VaultClientError class."""
+    install_fake_client(monkeypatch, login_exc=hvac.exceptions.Forbidden("role denied"))
+    result = await _dispatch_vault(op_id, params)
+
+    assert result.status == "error"
+    assert result.extras.get("exception_class") == "VaultRoleDeniedError"
+
+
+# --- write/delete handler-level error propagation (the handler runs only
+# after approval in production; here we drive it directly to prove it
+# re-raises Vault errors for the dispatcher's connector_error branch). ---
+
+
+@pytest.mark.parametrize(
+    ("handler", "params", "exc_kwarg"),
+    [
+        (vault_sys_policy_write, {"name": "x", "policy": "bad"}, "policy_write_exc"),
+        (vault_sys_policy_delete, {"name": "x"}, "policy_delete_exc"),
+    ],
+)
+async def test_policy_write_handler_reraises_vault_error(
+    monkeypatch: pytest.MonkeyPatch,
+    handler: Any,
+    params: dict[str, Any],
+    exc_kwarg: str,
+) -> None:
+    """The write/delete handler propagates a Vault-side error to the caller.
+
+    The dispatcher's ``connector_error`` branch (proven for the read ops
+    above) then turns this into a structured result; the handler's
+    contract is simply "raise on failure".
+    """
+    install_fake_client(
+        monkeypatch,
+        **{exc_kwarg: hvac.exceptions.InvalidRequest("failed to parse policy")},
+    )
+    with pytest.raises(hvac.exceptions.InvalidRequest):
+        await handler(_make_operator(), None, params)

--- a/docs/codebase/connectors-vault.md
+++ b/docs/codebase/connectors-vault.md
@@ -44,9 +44,10 @@ Source: `backend/src/meho_backplane/connectors/vault/`.
   `vault.kv.read`; G3.3-T1 #545 adds list/put/versions/delete). Group
   key `kv`. `vault.kv.read` / `vault.kv.list` are classified
   `credential_read` (decision #3 — aggregate-only broadcast).
-- **`sys` read op group** (`ops_sys.py`, G3.3-T2 #546) —
-  `register_vault_sys_typed_operations()` registers four read-only
-  diagnostics ops under group key `sys`, all `safety_level='safe'`,
+- **`sys` op group** (`ops_sys.py`, G3.3-T2 #546; policy ops
+  G3.15-T2 #1410) — `register_vault_sys_typed_operations()` registers
+  four read-only diagnostics ops plus the four ACL-policy ops under
+  group key `sys`. The diagnostics ops are all `safety_level='safe'`,
   `requires_approval=False`:
   - `vault.sys.health` — `GET /v1/sys/health`. **Shares** the
     probe-path implementation: calls `auth.vault._build_client`
@@ -65,6 +66,38 @@ Source: `backend/src/meho_backplane/connectors/vault/`.
   The three authenticated ops forward the operator JWT via
   `vault_client_for_operator` and offload the blocking `hvac` call with
   `asyncio.to_thread`.
+
+  The ACL-policy ops (`ops_sys_policy.py` — handlers/schemas split out
+  to keep `ops_sys.py` under the 600-line file budget; registered from
+  the same `register_vault_sys_typed_operations()` so the whole `sys`
+  group lands from one place):
+
+  | op_id | hvac call | safety_level | requires_approval | op_class |
+  |---|---|---|---|---|
+  | `vault.sys.policy.read` | `sys.read_policy` | safe | False | `other` |
+  | `vault.sys.policy.list` | `sys.list_policies` | safe | False | `read` |
+  | `vault.sys.policy.write` | `sys.create_or_update_policy` | dangerous | True | `write` |
+  | `vault.sys.policy.delete` | `sys.delete_policy` | dangerous | True | `write` |
+
+  All four forward the operator JWT via `vault_client_for_operator` and
+  offload the sync `hvac` call with `asyncio.to_thread`. `policy.read`
+  unwraps the `data.rules` (or `data.policy`) envelope, falling back to
+  the legacy top-level keys → `{name, rules}` (rules `None` when
+  absent). `policy.list` returns `{policies: [...]}` from the
+  envelope's `data.policies`. `policy.write` / `policy.delete` return
+  Vault's HTTP 204 with no body, so the handlers synthesize
+  `{name, written: true}` / `{name, deleted: true}` (reaching-here =
+  success; hvac raises on non-2xx). The shared `name` param uses
+  `pattern="^(?=.*\S)[^/]+$"` (the KV-v2 `mount` fragment's shape): a
+  blank name fails validation rather than degrading to a runtime error,
+  and a slash-bearing name is rejected. `policy.write`'s `policy` param
+  is a non-empty HCL/JSON body that **replaces** the policy in full (not
+  a merge); the verb layer / agent owns any body linting — this op is a
+  thin pass-through and lets Vault reject malformed HCL. `policy.read`
+  classifies `other` (its only param is the policy name; `.read` is not
+  a read-suffix — see "Broadcast PII discipline"), `policy.list` `read`
+  via the `.list` suffix, and `policy.write` / `policy.delete` `write`
+  (the `.write` / `.delete` suffixes redact the HCL body).
 - **`auth` read op group** (`ops_auth.py`, G3.3-T3 #547) —
   `register_vault_auth_operations()` registers `vault.auth.userpass.list`
   / `vault.auth.userpass.read` / `vault.auth.approle.list` /
@@ -141,16 +174,41 @@ secret-mint ops (`vault.token.create`,
 alongside `harbor.robot.create`. See `docs/codebase/broadcast.md` for
 the full sensitivity taxonomy.
 
+`vault.sys.policy.write` (G3.15-T2 #1410) classifies `write` via the
+`.write` write-suffix (added to `_WRITE_SUFFIXES` for this op): the HCL
+policy body is in the request params, so without the suffix it would
+fall through to `other` and broadcast the policy text in full. The
+`_CREDENTIAL_WRITE_OPS` allowlist is consulted first, so the
+`.write`-shaped `vault.auth.userpass.write` keeps its `credential_write`
+class. `vault.sys.policy.delete` is `write` via `.delete`;
+`vault.sys.policy.list` is `read` via `.list`. `vault.sys.policy.read`
+classifies `other` — `.read` is deliberately **not** a read-suffix (it
+would over-match the `credential_read`-allowlisted `vault.kv.read`), and
+the policy-read param is only the policy name, so the `other` full-param
+broadcast is the consistent, safe direction (same rationale as the
+`vault.auth.*.read` auth-config ops).
+
 ## Approval gating
 
 `vault.kv.put` (`caution`) and `vault.kv.delete` (`dangerous`)
 register with `requires_approval=False` — the dev default.
-`requires_approval` is a static boolean on the descriptor; the shipped
-G0.6 substrate has no per-path approval predicate. The
-production-path approval gate is G7/G10 policy territory (see the
-`EndpointDescriptor` model docstring: `caution`/`dangerous` ops "flow
-through G7 / G10 policy logic once those Goals land"). `safety_level`
-is the load-bearing signal that future gate keys on.
+`requires_approval` is a static boolean on the descriptor consulted by
+the G11.7-T1 (#1401) policy gate: an op with `requires_approval=True`
+is routed to the approval queue (verdict `NEEDS_APPROVAL`) and the
+dispatch returns `status="awaiting_approval"` with an
+`approval_request_id` in `extras` — the handler does **not** run until
+a human approves. `safety_level` is the load-bearing severity signal
+the gate and the UI surface key on.
+
+`vault.sys.policy.write` / `vault.sys.policy.delete` (G3.15-T2 #1410)
+are the first Vault ops to register `requires_approval=True`
+(`safety_level='dangerous'`): a bad HCL body can lock everyone out or
+silently widen access, so both are approval-gated. A dispatch by a
+human/service principal therefore parks as `awaiting_approval` before
+reaching Vault (proven in `test_connectors_vault_sys.py`); the
+handler's hvac-forwarding logic is exercised by calling it directly in
+the unit suite. The policy reads (`policy.read` / `policy.list`) stay
+`requires_approval=False`.
 
 ## JSONFlux result-handle path (`vault.kv.list`)
 
@@ -293,8 +351,9 @@ and a real Postgres audit store (reusing the integration conftest's
   call. Acceptable under v0.2 dogfood load (per-request login is
   already the v0.1/v0.2 model); revisit if a per-operator token cache
   lands.
-- `sys` writes (unseal, mount/unmount, policy write) are deliberately
-  out of scope for v0.2.
+- `sys` policy writes (`policy.write` / `policy.delete`) landed in
+  G3.15-T2 (#1410), approval-gated. Other `sys` writes (unseal,
+  mount/unmount bootstrap) remain out of scope here (G3.15-T5).
 - AppRole secret-id generation is out of scope for v0.2 (high-risk
   write with policy implications; v0.2.next behind a policy gate).
 


### PR DESCRIPTION
## Summary
- Adds the four `vault.sys.policy.*` ops to the Vault `sys` group so ACL-policy management moves off the break-glass `vault.sh` wrapper onto the governed surface: `policy.read` / `policy.list` (safe) and `policy.write` / `policy.delete` (dangerous, `requires_approval=True`).
- Policy writes are the highest-blast-radius Vault mutation, so write/delete are approval-gated — the G11.7 policy gate parks a dispatch as `awaiting_approval` before the handler runs.
- Handlers/schemas live in a new `ops_sys_policy.py` (thin pass-throughs: operator JWT via `vault_client_for_operator`, sync hvac calls offloaded with `asyncio.to_thread`); registration stays in `ops_sys.py` so the whole `sys` group lands from one place and the file stays under the 600-line budget.
- Broadcast classifier: `.write` added to `_WRITE_SUFFIXES` so `policy.write` redacts its HCL body instead of broadcasting it as a full-detail `other` event. `policy.list` → `read` (`.list`); `policy.read` stays `other` (`.read` is deliberately not a read-suffix — would over-match the credential_read-allowlisted `vault.kv.read`; param is only the policy name, matching the `vault.auth.*.read` precedent).

## Test plan
- [x] `ruff check` / `ruff format --check` — clean (all changed files)
- [x] `mypy src/meho_backplane/` — clean (406 files)
- [x] `pytest tests/test_connectors_vault_sys.py tests/test_broadcast_events.py` — 133 passed
- [x] sibling-regression sweep (`test_connectors_vault{,_auth}.py`, `test_broadcast_credential_read_dispatch.py`, `test_ui_broadcast_feed.py`) — green
- [x] `code-quality.py --diff` — 0 blockers
- [x] `make snapshot-openapi && make generate` in `cli/` — no delta (typed ops)
- [x] **AC: four ops register with stated safety levels** — `test_policy_read_ops_register_safe_no_approval` / `test_policy_write_ops_register_dangerous_with_approval`
- [x] **AC: `policy.write` accepts HCL/JSON body, dispatches via `create_or_update_policy` (`to_thread`)** — `test_policy_write_handler_forwards_body_and_returns_written`
- [x] **AC: per-op happy-path + error tests (mock `_build_client`)** — read/list/write/delete happy paths, envelope-unwrap, param validation, Vault + login error propagation, approval-gate parking
- [x] **AC: CLI snapshot regen** — run, no delta
- [x] live `policy.read` / `policy.list` dev-Vault e2e added (seeds a `ci-readonly` policy; runs in the integration testcontainers lane)

## Out of scope
- kv ops (T1); auth/identity/token (T3/T4); sys auth/mount bootstrap + unseal (T5).
- Policy-body linting beyond what Vault itself rejects (verb/agent-layer concern).

<!-- auto-implement-issue: fresh, iteration 1 -->

Closes #1410
