### PR TITLE
feat(connectors): G3.15-T5 vault sys bootstrap writes — auth/mount enable+tune

### DIFF
--- a/backend/src/meho_backplane/connectors/vault/ops_sys.py
+++ b/backend/src/meho_backplane/connectors/vault/ops_sys.py
@@ -94,6 +94,24 @@ from typing import Any
 
 import meho_backplane.auth.vault as _auth_vault
 from meho_backplane.auth.operator import Operator
+from meho_backplane.connectors.vault.ops_sys_bootstrap import (
+    VAULT_SYS_AUTH_ENABLE_LLM_INSTRUCTIONS,
+    VAULT_SYS_AUTH_ENABLE_PARAMETER_SCHEMA,
+    VAULT_SYS_AUTH_ENABLE_RESPONSE_SCHEMA,
+    VAULT_SYS_AUTH_TUNE_LLM_INSTRUCTIONS,
+    VAULT_SYS_AUTH_TUNE_PARAMETER_SCHEMA,
+    VAULT_SYS_AUTH_TUNE_RESPONSE_SCHEMA,
+    VAULT_SYS_MOUNTS_ENABLE_LLM_INSTRUCTIONS,
+    VAULT_SYS_MOUNTS_ENABLE_PARAMETER_SCHEMA,
+    VAULT_SYS_MOUNTS_ENABLE_RESPONSE_SCHEMA,
+    VAULT_SYS_MOUNTS_TUNE_LLM_INSTRUCTIONS,
+    VAULT_SYS_MOUNTS_TUNE_PARAMETER_SCHEMA,
+    VAULT_SYS_MOUNTS_TUNE_RESPONSE_SCHEMA,
+    vault_sys_auth_enable,
+    vault_sys_auth_tune,
+    vault_sys_mounts_enable,
+    vault_sys_mounts_tune,
+)
 from meho_backplane.connectors.vault.ops_sys_policy import (
     VAULT_SYS_POLICY_DELETE_LLM_INSTRUCTIONS,
     VAULT_SYS_POLICY_DELETE_PARAMETER_SCHEMA,
@@ -118,9 +136,13 @@ from meho_backplane.settings import get_settings
 
 __all__ = [
     "register_vault_sys_typed_operations",
+    "vault_sys_auth_enable",
     "vault_sys_auth_list",
+    "vault_sys_auth_tune",
     "vault_sys_health",
+    "vault_sys_mounts_enable",
     "vault_sys_mounts_list",
+    "vault_sys_mounts_tune",
     "vault_sys_policy_delete",
     "vault_sys_policy_list",
     "vault_sys_policy_read",
@@ -725,5 +747,109 @@ async def register_vault_sys_typed_operations(
         safety_level="dangerous",
         requires_approval=True,
         llm_instructions=VAULT_SYS_POLICY_DELETE_LLM_INSTRUCTIONS,
+        embedding_service=embedding_service,
+    )
+    # G3.15-T5 (#1413) sys bootstrap writes — auth-method + secret-mount
+    # enable/tune, the last slice of the /vault-admin write surface.
+    # Enables are dangerous (a new auth method / secret engine widens the
+    # cluster surface); tunes are caution (reconfigure an existing mount).
+    # All four are approval-gated. Enables are idempotent-tolerant (an
+    # already-enabled path returns created=False, not an error).
+    await register_typed_operation(
+        product="vault",
+        version="1.x",
+        impl_id="vault",
+        op_id="vault.sys.auth.enable",
+        handler=vault_sys_auth_enable,
+        summary="Enable a HashiCorp Vault auth method (dangerous, approval-gated).",
+        description=(
+            "Enables an auth method (userpass, approle, jwt, kubernetes, "
+            "...) at a mount path via POST /v1/sys/auth/<path>. DANGEROUS: "
+            "opens a new login path into the cluster. Approval-gated. "
+            "Idempotent — re-enabling the same type at the same path "
+            "returns {'created': false}. Returns {'path', 'method_type', "
+            "'created'}."
+        ),
+        parameter_schema=VAULT_SYS_AUTH_ENABLE_PARAMETER_SCHEMA,
+        response_schema=VAULT_SYS_AUTH_ENABLE_RESPONSE_SCHEMA,
+        group_key="sys",
+        when_to_use=sys_when_to_use,
+        tags=["write", "auth-methods", "bootstrap", "dangerous"],
+        safety_level="dangerous",
+        requires_approval=True,
+        llm_instructions=VAULT_SYS_AUTH_ENABLE_LLM_INSTRUCTIONS,
+        embedding_service=embedding_service,
+    )
+    await register_typed_operation(
+        product="vault",
+        version="1.x",
+        impl_id="vault",
+        op_id="vault.sys.auth.tune",
+        handler=vault_sys_auth_tune,
+        summary="Tune an enabled HashiCorp Vault auth method (caution, approval-gated).",
+        description=(
+            "Tunes an already-enabled auth method's mount config (lease "
+            "TTLs, description, listing visibility) via POST "
+            "/v1/sys/auth/<path>/tune. CAUTION: reconfigures an existing "
+            "mount; the method must already be enabled. Approval-gated. "
+            "Returns {'path', 'tuned': true} on success."
+        ),
+        parameter_schema=VAULT_SYS_AUTH_TUNE_PARAMETER_SCHEMA,
+        response_schema=VAULT_SYS_AUTH_TUNE_RESPONSE_SCHEMA,
+        group_key="sys",
+        when_to_use=sys_when_to_use,
+        tags=["write", "auth-methods", "bootstrap", "caution"],
+        safety_level="caution",
+        requires_approval=True,
+        llm_instructions=VAULT_SYS_AUTH_TUNE_LLM_INSTRUCTIONS,
+        embedding_service=embedding_service,
+    )
+    await register_typed_operation(
+        product="vault",
+        version="1.x",
+        impl_id="vault",
+        op_id="vault.sys.mounts.enable",
+        handler=vault_sys_mounts_enable,
+        summary="Enable a HashiCorp Vault secret engine (dangerous, approval-gated).",
+        description=(
+            "Enables a secret engine (kv, transit, pki, database, ...) at "
+            "a mount path via POST /v1/sys/mounts/<path>. DANGEROUS: "
+            "stands up a new secret-management surface. Approval-gated. "
+            "Idempotent — re-enabling the same type at the same path "
+            "returns {'created': false}. Returns {'path', 'backend_type', "
+            "'created'}."
+        ),
+        parameter_schema=VAULT_SYS_MOUNTS_ENABLE_PARAMETER_SCHEMA,
+        response_schema=VAULT_SYS_MOUNTS_ENABLE_RESPONSE_SCHEMA,
+        group_key="sys",
+        when_to_use=sys_when_to_use,
+        tags=["write", "mounts", "bootstrap", "dangerous"],
+        safety_level="dangerous",
+        requires_approval=True,
+        llm_instructions=VAULT_SYS_MOUNTS_ENABLE_LLM_INSTRUCTIONS,
+        embedding_service=embedding_service,
+    )
+    await register_typed_operation(
+        product="vault",
+        version="1.x",
+        impl_id="vault",
+        op_id="vault.sys.mounts.tune",
+        handler=vault_sys_mounts_tune,
+        summary="Tune an enabled HashiCorp Vault secret engine (caution, approval-gated).",
+        description=(
+            "Tunes an already-enabled secret engine's mount config (lease "
+            "TTLs, description, listing visibility) via POST "
+            "/v1/sys/mounts/<path>/tune. CAUTION: reconfigures an existing "
+            "mount; the engine must already be enabled. Approval-gated. "
+            "Returns {'path', 'tuned': true} on success."
+        ),
+        parameter_schema=VAULT_SYS_MOUNTS_TUNE_PARAMETER_SCHEMA,
+        response_schema=VAULT_SYS_MOUNTS_TUNE_RESPONSE_SCHEMA,
+        group_key="sys",
+        when_to_use=sys_when_to_use,
+        tags=["write", "mounts", "bootstrap", "caution"],
+        safety_level="caution",
+        requires_approval=True,
+        llm_instructions=VAULT_SYS_MOUNTS_TUNE_LLM_INSTRUCTIONS,
         embedding_service=embedding_service,
     )

--- a/backend/src/meho_backplane/connectors/vault/ops_sys_bootstrap.py
+++ b/backend/src/meho_backplane/connectors/vault/ops_sys_bootstrap.py
@@ -1,0 +1,537 @@
+# SPDX-License-Identifier: Apache-2.0
+# Copyright (c) 2026 evoila Group
+
+"""Vault ``sys`` bootstrap ops — auth-method + secret-mount enable/tune.
+
+Op-ids (G3.15-T5 #1413), all under the ``sys`` operation group and
+registered from :func:`meho_backplane.connectors.vault.ops_sys.register_vault_sys_typed_operations`:
+
+* ``vault.sys.auth.enable`` — enable an auth method
+  (``POST /v1/sys/auth/<path>``).
+* ``vault.sys.auth.tune`` — tune an enabled auth method's mount config
+  (``POST /v1/sys/auth/<path>/tune``).
+* ``vault.sys.mounts.enable`` — enable a secret backend
+  (``POST /v1/sys/mounts/<path>``).
+* ``vault.sys.mounts.tune`` — tune an enabled mount's config
+  (``POST /v1/sys/mounts/<path>/tune``).
+
+These are the bootstrap operations the ops team previously ran via the
+break-glass shell wrapper — the last slice of the ``/vault-admin`` write
+surface. All four are ``requires_approval=True``. The two ``.enable``
+ops are ``safety_level='dangerous'`` (enabling an auth method or secret
+engine widens the cluster's attack/credential surface); the two
+``.tune`` ops are ``safety_level='caution'`` (they reconfigure an
+already-enabled mount — lease TTLs, description, listing visibility —
+without standing up a new credential path).
+
+Idempotency. ``enable`` is treated as idempotent-tolerant: re-enabling
+an already-enabled method/engine at the same path is reported as
+``created=False`` success rather than a ``connector_error``. Vault
+returns HTTP 400 ``"path is already in use"`` on a duplicate enable; the
+handler unwraps that one signal into a success payload (matching the
+connector's existing error-unwrapping posture — the dispatcher's
+``connector_error`` branch still owns every *other* failure). A genuine
+configuration mismatch (different type at the same path) is a distinct
+Vault error and propagates. ``tune`` is naturally idempotent on Vault's
+side (re-applying the same config is a no-op 204) and needs no special
+handling.
+
+Broadcast ``op_class`` (via
+:func:`~meho_backplane.broadcast.events.classify_op`): all four classify
+``other`` — ``.enable`` / ``.tune`` are deliberately **not** added to
+the classifier's write-suffix tuple. Adding ``.enable`` there would
+reclassify the unrelated ``meho.connector.enable`` MCP admin tool (whose
+broadcast op_class is derived from ``classify_op`` on the tool name) from
+``other`` to ``write``, an out-of-scope behaviour change. None of these
+ops carry secret material in their params (auth/mount type, path, lease
+TTLs, descriptions — configuration only), so the full-detail ``other``
+broadcast leaks nothing; classifying them ``other`` is both the cleaner
+and the more scoped choice. See ``docs/codebase/connectors-vault.md``.
+
+Handler shape mirrors the sibling policy ops in
+:mod:`meho_backplane.connectors.vault.ops_sys_policy`:
+``(operator, target, params)``, the operator JWT forwarded via
+:func:`~meho_backplane.auth.vault.vault_client_for_operator`, and the
+synchronous hvac call offloaded with :func:`asyncio.to_thread` because
+hvac is ``requests``-based and FastAPI does not auto-offload blocking I/O
+inside an ``async def``. Handlers **raise** on failure; the dispatcher's
+``connector_error`` branch records the exception class in
+``extras["exception_class"]`` (no raw traceback to the agent).
+
+This module is split out of ``ops_sys.py`` purely to keep each file under
+the repository's 600-line size budget; the ``register_typed_operation``
+calls stay in ``ops_sys.py`` so the whole ``sys`` group registers from
+one place.
+"""
+
+from __future__ import annotations
+
+import asyncio
+from typing import Any
+
+import hvac.exceptions
+
+import meho_backplane.auth.vault as _auth_vault
+from meho_backplane.auth.operator import Operator
+
+__all__ = [
+    "VAULT_SYS_AUTH_ENABLE_LLM_INSTRUCTIONS",
+    "VAULT_SYS_AUTH_ENABLE_PARAMETER_SCHEMA",
+    "VAULT_SYS_AUTH_ENABLE_RESPONSE_SCHEMA",
+    "VAULT_SYS_AUTH_TUNE_LLM_INSTRUCTIONS",
+    "VAULT_SYS_AUTH_TUNE_PARAMETER_SCHEMA",
+    "VAULT_SYS_AUTH_TUNE_RESPONSE_SCHEMA",
+    "VAULT_SYS_MOUNTS_ENABLE_LLM_INSTRUCTIONS",
+    "VAULT_SYS_MOUNTS_ENABLE_PARAMETER_SCHEMA",
+    "VAULT_SYS_MOUNTS_ENABLE_RESPONSE_SCHEMA",
+    "VAULT_SYS_MOUNTS_TUNE_LLM_INSTRUCTIONS",
+    "VAULT_SYS_MOUNTS_TUNE_PARAMETER_SCHEMA",
+    "VAULT_SYS_MOUNTS_TUNE_RESPONSE_SCHEMA",
+    "vault_sys_auth_enable",
+    "vault_sys_auth_tune",
+    "vault_sys_mounts_enable",
+    "vault_sys_mounts_tune",
+]
+
+
+#: Shared ``path`` schema fragment for the four bootstrap ops. The
+#: ``(?=.*\S)`` lookahead makes an all-whitespace value a validation-time
+#: ``invalid_params`` failure (mirrors the policy-name fragment in
+#: :mod:`~meho_backplane.connectors.vault.ops_sys_policy`); a leading or
+#: trailing slash is rejected so the path is the bare mount point Vault
+#: expects (hvac appends the trailing slash itself). The path is where
+#: the method/engine is mounted, defaulting server-side to the type name
+#: when omitted — but it is required here so an agent must be explicit
+#: about *where* a dangerous mount lands.
+_MOUNT_PATH_PROPERTY: dict[str, Any] = {
+    "type": "string",
+    "pattern": r"^(?=.*\S)[^/]+$",
+    "description": (
+        "The mount path (a flat handle, no slashes, e.g. 'userpass' or "
+        "'kv-prod'). This is where the method/engine is mounted; it need "
+        "not match the type."
+    ),
+}
+
+
+#: Shared tune-config fragment. Vault's tune endpoint accepts a fixed set
+#: of mount-config knobs; only these are exposed (``additionalProperties``
+#: stays False on the parent object so a typo'd knob is a clear
+#: validation error). TTLs accept the Vault duration spellings ("768h",
+#: "30m") or an integer of seconds; hvac forwards them verbatim.
+_TUNE_PROPERTIES: dict[str, Any] = {
+    "default_lease_ttl": {
+        "type": ["string", "integer"],
+        "description": (
+            "Default lease TTL for the mount (Vault duration string like "
+            "'768h' or an integer of seconds)."
+        ),
+    },
+    "max_lease_ttl": {
+        "type": ["string", "integer"],
+        "description": ("Maximum lease TTL for the mount (duration string or seconds)."),
+    },
+    "description": {
+        "type": "string",
+        "description": "Human-readable mount description.",
+    },
+    "listing_visibility": {
+        "type": "string",
+        "enum": ["unauth", "hidden"],
+        "description": (
+            "Whether the mount appears in the unauthenticated UI listing "
+            "('unauth') or is hidden ('hidden')."
+        ),
+    },
+}
+
+
+VAULT_SYS_AUTH_ENABLE_PARAMETER_SCHEMA: dict[str, Any] = {
+    "type": "object",
+    "properties": {
+        "method_type": {
+            "type": "string",
+            "pattern": r"^(?=.*\S)\S+$",
+            "description": (
+                "The auth method type to enable, e.g. 'userpass', 'approle', 'jwt', 'kubernetes'."
+            ),
+        },
+        "path": _MOUNT_PATH_PROPERTY,
+        "description": {
+            "type": "string",
+            "description": "Optional human-readable description for the mount.",
+        },
+    },
+    "required": ["method_type", "path"],
+    "additionalProperties": False,
+}
+
+
+VAULT_SYS_MOUNTS_ENABLE_PARAMETER_SCHEMA: dict[str, Any] = {
+    "type": "object",
+    "properties": {
+        "backend_type": {
+            "type": "string",
+            "pattern": r"^(?=.*\S)\S+$",
+            "description": (
+                "The secret engine type to enable, e.g. 'kv', 'transit', 'pki', 'database'."
+            ),
+        },
+        "path": _MOUNT_PATH_PROPERTY,
+        "description": {
+            "type": "string",
+            "description": "Optional human-readable description for the mount.",
+        },
+    },
+    "required": ["backend_type", "path"],
+    "additionalProperties": False,
+}
+
+
+VAULT_SYS_AUTH_TUNE_PARAMETER_SCHEMA: dict[str, Any] = {
+    "type": "object",
+    "properties": {"path": _MOUNT_PATH_PROPERTY, **_TUNE_PROPERTIES},
+    "required": ["path"],
+    "additionalProperties": False,
+}
+
+
+VAULT_SYS_MOUNTS_TUNE_PARAMETER_SCHEMA: dict[str, Any] = {
+    "type": "object",
+    "properties": {"path": _MOUNT_PATH_PROPERTY, **_TUNE_PROPERTIES},
+    "required": ["path"],
+    "additionalProperties": False,
+}
+
+
+VAULT_SYS_AUTH_ENABLE_RESPONSE_SCHEMA: dict[str, Any] = {
+    "type": "object",
+    "properties": {
+        "path": {
+            "type": "string",
+            "description": "The mount path the auth method is enabled at.",
+        },
+        "method_type": {
+            "type": "string",
+            "description": "The enabled auth method type.",
+        },
+        "created": {
+            "type": "boolean",
+            "description": (
+                "True when this call enabled the method; False when it was "
+                "already enabled at this path (idempotent no-op success)."
+            ),
+        },
+    },
+    "required": ["path", "method_type", "created"],
+}
+
+
+VAULT_SYS_MOUNTS_ENABLE_RESPONSE_SCHEMA: dict[str, Any] = {
+    "type": "object",
+    "properties": {
+        "path": {
+            "type": "string",
+            "description": "The mount path the secret engine is enabled at.",
+        },
+        "backend_type": {
+            "type": "string",
+            "description": "The enabled secret engine type.",
+        },
+        "created": {
+            "type": "boolean",
+            "description": (
+                "True when this call enabled the engine; False when it was "
+                "already enabled at this path (idempotent no-op success)."
+            ),
+        },
+    },
+    "required": ["path", "backend_type", "created"],
+}
+
+
+VAULT_SYS_AUTH_TUNE_RESPONSE_SCHEMA: dict[str, Any] = {
+    "type": "object",
+    "properties": {
+        "path": {
+            "type": "string",
+            "description": "The auth-method mount path that was tuned.",
+        },
+        "tuned": {
+            "type": "boolean",
+            "description": "Always True on success (Vault returns HTTP 204).",
+        },
+    },
+    "required": ["path", "tuned"],
+}
+
+
+VAULT_SYS_MOUNTS_TUNE_RESPONSE_SCHEMA: dict[str, Any] = {
+    "type": "object",
+    "properties": {
+        "path": {
+            "type": "string",
+            "description": "The secret-engine mount path that was tuned.",
+        },
+        "tuned": {
+            "type": "boolean",
+            "description": "Always True on success (Vault returns HTTP 204).",
+        },
+    },
+    "required": ["path", "tuned"],
+}
+
+
+VAULT_SYS_AUTH_ENABLE_LLM_INSTRUCTIONS: dict[str, Any] = {
+    "when_to_use": (
+        "Enable a new auth method on the Vault target (userpass, approle, "
+        "jwt, kubernetes, ...). DANGEROUS and approval-gated: enabling an "
+        "auth method opens a new login path into the cluster. Idempotent — "
+        "re-enabling the same type at the same path returns created=False. "
+        "List the existing methods (vault.sys.auth.list) first to avoid a "
+        "path collision with a different type."
+    ),
+    "parameter_hints": {
+        "method_type": "The auth method type, e.g. 'userpass' or 'approle'.",
+        "path": "Where to mount it (defaults conceptually to the type name).",
+        "description": "Optional human-readable mount description.",
+    },
+    "output_shape": (
+        "{'path': <str>, 'method_type': <str>, 'created': <bool>}. "
+        "created=False means it was already enabled at this path. On a "
+        "type-mismatch collision or transport failure: connector_error "
+        "with extras.exception_class."
+    ),
+}
+
+
+VAULT_SYS_AUTH_TUNE_LLM_INSTRUCTIONS: dict[str, Any] = {
+    "when_to_use": (
+        "Tune an already-enabled auth method's mount config (lease TTLs, "
+        "description, listing visibility). CAUTION and approval-gated: "
+        "reconfigures an existing mount but does not stand up a new "
+        "credential path. The method must already be enabled."
+    ),
+    "parameter_hints": {
+        "path": "The auth-method mount path to tune, e.g. 'userpass'.",
+        "default_lease_ttl": "Default lease TTL ('768h' or seconds).",
+        "max_lease_ttl": "Maximum lease TTL ('768h' or seconds).",
+        "description": "New human-readable description.",
+        "listing_visibility": "'unauth' or 'hidden'.",
+    },
+    "output_shape": (
+        "{'path': <str>, 'tuned': true} on success (HTTP 204). On a "
+        "not-enabled path or transport failure: connector_error with "
+        "extras.exception_class."
+    ),
+}
+
+
+VAULT_SYS_MOUNTS_ENABLE_LLM_INSTRUCTIONS: dict[str, Any] = {
+    "when_to_use": (
+        "Enable a new secret engine on the Vault target (kv, transit, pki, "
+        "database, ...). DANGEROUS and approval-gated: stands up a new "
+        "secret-management surface. Idempotent — re-enabling the same type "
+        "at the same path returns created=False. List the existing mounts "
+        "(vault.sys.mounts.list) first to avoid a path collision."
+    ),
+    "parameter_hints": {
+        "backend_type": "The secret engine type, e.g. 'kv' or 'transit'.",
+        "path": "Where to mount it (defaults conceptually to the type name).",
+        "description": "Optional human-readable mount description.",
+    },
+    "output_shape": (
+        "{'path': <str>, 'backend_type': <str>, 'created': <bool>}. "
+        "created=False means it was already enabled at this path. On a "
+        "type-mismatch collision or transport failure: connector_error "
+        "with extras.exception_class."
+    ),
+}
+
+
+VAULT_SYS_MOUNTS_TUNE_LLM_INSTRUCTIONS: dict[str, Any] = {
+    "when_to_use": (
+        "Tune an already-enabled secret engine's mount config (lease TTLs, "
+        "description, listing visibility). CAUTION and approval-gated: "
+        "reconfigures an existing mount. The engine must already be enabled."
+    ),
+    "parameter_hints": {
+        "path": "The secret-engine mount path to tune, e.g. 'secret'.",
+        "default_lease_ttl": "Default lease TTL ('768h' or seconds).",
+        "max_lease_ttl": "Maximum lease TTL ('768h' or seconds).",
+        "description": "New human-readable description.",
+        "listing_visibility": "'unauth' or 'hidden'.",
+    },
+    "output_shape": (
+        "{'path': <str>, 'tuned': true} on success (HTTP 204). On a "
+        "not-enabled path or transport failure: connector_error with "
+        "extras.exception_class."
+    ),
+}
+
+
+#: The substring Vault embeds in the HTTP 400 it returns when an
+#: ``enable`` targets a path that is already mounted. Matched
+#: case-insensitively so the idempotency unwrap survives a Vault-side
+#: capitalisation tweak. A path-in-use 400 is the *only* error the
+#: enable handlers swallow into a ``created=False`` success — every other
+#: ``InvalidRequest`` (e.g. an unknown method type, a malformed config)
+#: re-raises for the dispatcher's ``connector_error`` branch.
+_ALREADY_IN_USE_MARKER: str = "already in use"
+
+
+def _is_path_already_in_use(exc: hvac.exceptions.InvalidRequest) -> bool:
+    """Return True when *exc* is Vault's "path already in use" 400.
+
+    Vault rejects a duplicate ``enable`` with HTTP 400 and a message
+    containing "path is already in use". hvac raises that as
+    :class:`hvac.exceptions.InvalidRequest` carrying the server message.
+    The check is substring + case-insensitive so it tolerates message
+    drift without matching unrelated 400s (a bad config, an unknown
+    type), which keep propagating to the dispatcher.
+    """
+    return _ALREADY_IN_USE_MARKER in str(exc).lower()
+
+
+def _tune_kwargs(params: dict[str, Any]) -> dict[str, Any]:
+    """Collect the supplied tune knobs into hvac kwargs.
+
+    The schema already constrains the key set and value shapes; this
+    just drops any knob the caller omitted so hvac's own
+    ``None``-skipping defaults apply (an absent knob leaves Vault's
+    current value untouched rather than resetting it).
+    """
+    return {key: params[key] for key in _TUNE_PROPERTIES if key in params}
+
+
+async def vault_sys_auth_enable(
+    operator: Operator, target: Any, params: dict[str, Any]
+) -> dict[str, Any]:
+    """Enable an auth method (``POST /v1/sys/auth/<path>``).
+
+    Op-id: ``vault.sys.auth.enable``. DANGEROUS / approval-gated.
+    Delegates to hvac's
+    ``sys.enable_auth_method(method_type, path, description)``. Vault
+    returns HTTP 204 on success; a duplicate enable returns HTTP 400
+    "path is already in use", which the handler unwraps into a
+    ``created=False`` idempotent success (see the module docstring).
+
+    Returns ``{"path", "method_type", "created"}``.
+
+    Raises
+    ------
+    meho_backplane.auth.vault.VaultClientError
+        Login-phase failure. Wrapped into ``connector_error``.
+    hvac.exceptions.InvalidRequest
+        Any 400 *other* than path-already-in-use (unknown type,
+        malformed config). Wrapped into ``connector_error``.
+    Exception
+        Any other error hvac raises from the enable.
+    """
+    method_type: str = str(params["method_type"]).strip()
+    path: str = str(params["path"]).strip()
+    description: str | None = params.get("description")
+    async with _auth_vault.vault_client_for_operator(operator) as client:
+        try:
+            await asyncio.to_thread(
+                client.sys.enable_auth_method,
+                method_type=method_type,
+                path=path,
+                description=description,
+            )
+        except hvac.exceptions.InvalidRequest as exc:
+            if not _is_path_already_in_use(exc):
+                raise
+            return {"path": path, "method_type": method_type, "created": False}
+        return {"path": path, "method_type": method_type, "created": True}
+
+
+async def vault_sys_mounts_enable(
+    operator: Operator, target: Any, params: dict[str, Any]
+) -> dict[str, Any]:
+    """Enable a secret engine (``POST /v1/sys/mounts/<path>``).
+
+    Op-id: ``vault.sys.mounts.enable``. DANGEROUS / approval-gated.
+    Delegates to hvac's
+    ``sys.enable_secrets_engine(backend_type, path, description)``. Same
+    204-success / path-in-use-idempotency contract as
+    :func:`vault_sys_auth_enable`.
+
+    Returns ``{"path", "backend_type", "created"}``.
+
+    Raises
+    ------
+    meho_backplane.auth.vault.VaultClientError
+        Login-phase failure. Wrapped into ``connector_error``.
+    hvac.exceptions.InvalidRequest
+        Any 400 *other* than path-already-in-use. Wrapped into
+        ``connector_error``.
+    Exception
+        Any other error hvac raises from the enable.
+    """
+    backend_type: str = str(params["backend_type"]).strip()
+    path: str = str(params["path"]).strip()
+    description: str | None = params.get("description")
+    async with _auth_vault.vault_client_for_operator(operator) as client:
+        try:
+            await asyncio.to_thread(
+                client.sys.enable_secrets_engine,
+                backend_type=backend_type,
+                path=path,
+                description=description,
+            )
+        except hvac.exceptions.InvalidRequest as exc:
+            if not _is_path_already_in_use(exc):
+                raise
+            return {"path": path, "backend_type": backend_type, "created": False}
+        return {"path": path, "backend_type": backend_type, "created": True}
+
+
+async def vault_sys_auth_tune(
+    operator: Operator, target: Any, params: dict[str, Any]
+) -> dict[str, Any]:
+    """Tune an enabled auth method (``POST /v1/sys/auth/<path>/tune``).
+
+    Op-id: ``vault.sys.auth.tune``. CAUTION / approval-gated. Delegates
+    to hvac's ``sys.tune_auth_method(path, **knobs)`` with only the
+    supplied tune knobs (an omitted knob leaves Vault's current value
+    untouched). Vault returns HTTP 204 on success, so the handler
+    synthesizes ``{"path", "tuned": True}`` — a reaching-here-means-
+    success contract (hvac raises on a non-2xx).
+
+    Raises
+    ------
+    meho_backplane.auth.vault.VaultClientError
+        Login-phase failure. Wrapped into ``connector_error``.
+    Exception
+        Any error hvac raises from the tune (e.g. a 400 for a path that
+        is not an enabled auth method).
+    """
+    path: str = str(params["path"]).strip()
+    kwargs = _tune_kwargs(params)
+    async with _auth_vault.vault_client_for_operator(operator) as client:
+        await asyncio.to_thread(client.sys.tune_auth_method, path=path, **kwargs)
+        return {"path": path, "tuned": True}
+
+
+async def vault_sys_mounts_tune(
+    operator: Operator, target: Any, params: dict[str, Any]
+) -> dict[str, Any]:
+    """Tune an enabled secret engine (``POST /v1/sys/mounts/<path>/tune``).
+
+    Op-id: ``vault.sys.mounts.tune``. CAUTION / approval-gated.
+    Delegates to hvac's ``sys.tune_mount_configuration(path, **knobs)``.
+    Same 204-success contract as :func:`vault_sys_auth_tune`.
+
+    Raises
+    ------
+    meho_backplane.auth.vault.VaultClientError
+        Login-phase failure. Wrapped into ``connector_error``.
+    Exception
+        Any error hvac raises from the tune.
+    """
+    path: str = str(params["path"]).strip()
+    kwargs = _tune_kwargs(params)
+    async with _auth_vault.vault_client_for_operator(operator) as client:
+        await asyncio.to_thread(client.sys.tune_mount_configuration, path=path, **kwargs)
+        return {"path": path, "tuned": True}

--- a/backend/tests/_vault_fakes.py
+++ b/backend/tests/_vault_fakes.py
@@ -415,6 +415,20 @@ class _FakeSysBackend:
     policy_write_calls: list[dict[str, Any]] = field(default_factory=list)
     raise_on_policy_delete: Exception | None = None
     policy_delete_calls: list[dict[str, Any]] = field(default_factory=list)
+    # G3.15-T5 (#1413) sys bootstrap writes — auth-method + secret-mount
+    # enable/tune. Each verb records its call args and gets a failure
+    # knob; the two enables return 204 (no body) on success, so there is
+    # no payload to inject — only the failure knob plus the call log so
+    # the idempotency / forwarding assertions can introspect what hvac
+    # was handed.
+    raise_on_auth_enable: Exception | None = None
+    auth_enable_calls: list[dict[str, Any]] = field(default_factory=list)
+    raise_on_auth_tune: Exception | None = None
+    auth_tune_calls: list[dict[str, Any]] = field(default_factory=list)
+    raise_on_mount_enable: Exception | None = None
+    mount_enable_calls: list[dict[str, Any]] = field(default_factory=list)
+    raise_on_mount_tune: Exception | None = None
+    mount_tune_calls: list[dict[str, Any]] = field(default_factory=list)
 
     def read_health_status(self, *, method: str = "HEAD", **_kwargs: Any) -> Any:
         self.read_calls.append({"method": method})
@@ -467,6 +481,38 @@ class _FakeSysBackend:
         self.policy_delete_calls.append({"name": name})
         if self.raise_on_policy_delete is not None:
             raise self.raise_on_policy_delete
+        return _DeleteResponse()
+
+    def enable_auth_method(
+        self, method_type: str, path: str | None = None, description: str | None = None
+    ) -> _DeleteResponse:
+        self.auth_enable_calls.append(
+            {"method_type": method_type, "path": path, "description": description}
+        )
+        if self.raise_on_auth_enable is not None:
+            raise self.raise_on_auth_enable
+        return _DeleteResponse()
+
+    def tune_auth_method(self, path: str, **kwargs: Any) -> _DeleteResponse:
+        self.auth_tune_calls.append({"path": path, **kwargs})
+        if self.raise_on_auth_tune is not None:
+            raise self.raise_on_auth_tune
+        return _DeleteResponse()
+
+    def enable_secrets_engine(
+        self, backend_type: str, path: str | None = None, description: str | None = None
+    ) -> _DeleteResponse:
+        self.mount_enable_calls.append(
+            {"backend_type": backend_type, "path": path, "description": description}
+        )
+        if self.raise_on_mount_enable is not None:
+            raise self.raise_on_mount_enable
+        return _DeleteResponse()
+
+    def tune_mount_configuration(self, path: str, **kwargs: Any) -> _DeleteResponse:
+        self.mount_tune_calls.append({"path": path, **kwargs})
+        if self.raise_on_mount_tune is not None:
+            raise self.raise_on_mount_tune
         return _DeleteResponse()
 
 
@@ -544,6 +590,10 @@ def install_fake_client(
     policy_list_exc: Exception | None = None,
     policy_write_exc: Exception | None = None,
     policy_delete_exc: Exception | None = None,
+    auth_enable_exc: Exception | None = None,
+    auth_tune_exc: Exception | None = None,
+    mount_enable_exc: Exception | None = None,
+    mount_tune_exc: Exception | None = None,
     keys: list[str] | None = None,
     versions_meta: dict[str, Any] | None = None,
     list_exc: Exception | None = None,
@@ -563,9 +613,13 @@ def install_fake_client(
     group's seal-status / mounts / auth-methods payload + exception
     injection, the G3.3-T1 KV-v2 verbs (list / put / versions / patch /
     delete) with per-verb exception injection and key/version-metadata
-    overrides, and the G3.15-T2 (#1410) ACL-policy verbs (read / list
+    overrides, the G3.15-T2 (#1410) ACL-policy verbs (read / list
     payload + exception injection; write / delete exception injection,
-    write/delete returning 204 with no body).
+    write/delete returning 204 with no body), and the G3.15-T5 (#1413)
+    sys bootstrap verbs (auth/mount enable + tune; exception injection
+    only — all four return 204 with no body, so an injected
+    :class:`hvac.exceptions.InvalidRequest` carrying "path is already in
+    use" drives the enable-idempotency unwrap).
     """
     fake = install_fake_vault(monkeypatch, kv_version=kv_version if kv_version is not None else 11)
     fake.auth.jwt.raise_on_login = login_exc
@@ -584,6 +638,10 @@ def install_fake_client(
     fake.sys.raise_on_policy_list = policy_list_exc
     fake.sys.raise_on_policy_write = policy_write_exc
     fake.sys.raise_on_policy_delete = policy_delete_exc
+    fake.sys.raise_on_auth_enable = auth_enable_exc
+    fake.sys.raise_on_auth_tune = auth_tune_exc
+    fake.sys.raise_on_mount_enable = mount_enable_exc
+    fake.sys.raise_on_mount_tune = mount_tune_exc
     kv = fake.secrets.kv.v2
     if secret is not None:
         kv.secret = secret

--- a/backend/tests/integration/test_connectors_vault_dev_e2e.py
+++ b/backend/tests/integration/test_connectors_vault_dev_e2e.py
@@ -909,6 +909,157 @@ async def test_sys_policy_list_against_dev_vault(
 
 
 # ---------------------------------------------------------------------------
+# sys bootstrap writes — auth/mount enable + tune (G3.15-T5 #1413). These
+# are approval-gated, so each dispatch passes ``_approved=True`` (the
+# approvals-API resume flag) to drive the authorized-execution path.
+# ``.enable`` / ``.tune`` are not write/read suffixes, so all four
+# broadcast ``other`` (full params; no secret material in the params).
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.asyncio
+async def test_sys_auth_enable_against_dev_vault(
+    vault_e2e: tuple[_VaultTarget, str],
+    captured_events: list[BroadcastEvent],
+) -> None:
+    """``vault.sys.auth.enable`` mounts a new auth method; op_class=other."""
+    target, addr = vault_e2e
+    operator = _make_operator(sub="op-auth-enable")
+    result = await dispatch(
+        operator=operator,
+        connector_id="vault-1.x",
+        op_id="vault.sys.auth.enable",
+        target=target,
+        params={"method_type": "userpass", "path": "userpass-new", "description": "ci"},
+        _approved=True,
+    )
+    assert result.status == "ok", result.error
+    assert result.result == {
+        "path": "userpass-new",
+        "method_type": "userpass",
+        "created": True,
+    }
+    # Read back through a root client: the method is mounted at the path.
+    methods = _root_client(addr).sys.list_auth_methods()
+    assert "userpass-new/" in methods["data"]
+    await _assert_audited(
+        "vault.sys.auth.enable",
+        operator_sub="op-auth-enable",
+        expected_op_class="other",
+        events=captured_events,
+    )
+
+
+@pytest.mark.asyncio
+async def test_sys_auth_enable_idempotent_on_existing_path(
+    vault_e2e: tuple[_VaultTarget, str],
+) -> None:
+    """Re-enabling the seeded ``userpass`` method → created=False (no error)."""
+    target, _ = vault_e2e
+    result = await dispatch(
+        operator=_make_operator(sub="op-auth-enable-dup"),
+        connector_id="vault-1.x",
+        op_id="vault.sys.auth.enable",
+        target=target,
+        # ``userpass`` is enabled by ``_seed_vault``; a duplicate enable
+        # is Vault's "path is already in use" 400 → idempotent success.
+        params={"method_type": "userpass", "path": "userpass"},
+        _approved=True,
+    )
+    assert result.status == "ok", result.error
+    assert result.result == {
+        "path": "userpass",
+        "method_type": "userpass",
+        "created": False,
+    }
+
+
+@pytest.mark.asyncio
+async def test_sys_mounts_enable_against_dev_vault(
+    vault_e2e: tuple[_VaultTarget, str],
+    captured_events: list[BroadcastEvent],
+) -> None:
+    """``vault.sys.mounts.enable`` mounts a new secret engine; op_class=other."""
+    target, addr = vault_e2e
+    operator = _make_operator(sub="op-mount-enable")
+    result = await dispatch(
+        operator=operator,
+        connector_id="vault-1.x",
+        op_id="vault.sys.mounts.enable",
+        target=target,
+        params={"backend_type": "kv", "path": "kv-prod"},
+        _approved=True,
+    )
+    assert result.status == "ok", result.error
+    assert result.result == {"path": "kv-prod", "backend_type": "kv", "created": True}
+    mounts = _root_client(addr).sys.list_mounted_secrets_engines()
+    assert "kv-prod/" in mounts["data"]
+    await _assert_audited(
+        "vault.sys.mounts.enable",
+        operator_sub="op-mount-enable",
+        expected_op_class="other",
+        events=captured_events,
+    )
+
+
+@pytest.mark.asyncio
+async def test_sys_auth_tune_against_dev_vault(
+    vault_e2e: tuple[_VaultTarget, str],
+    captured_events: list[BroadcastEvent],
+) -> None:
+    """``vault.sys.auth.tune`` reconfigures the seeded userpass mount; op_class=other."""
+    target, addr = vault_e2e
+    operator = _make_operator(sub="op-auth-tune")
+    result = await dispatch(
+        operator=operator,
+        connector_id="vault-1.x",
+        op_id="vault.sys.auth.tune",
+        target=target,
+        params={"path": "userpass", "default_lease_ttl": "1234s", "description": "tuned-up"},
+        _approved=True,
+    )
+    assert result.status == "ok", result.error
+    assert result.result == {"path": "userpass", "tuned": True}
+    # Read back the tuned config — the lease TTL landed.
+    cfg = _root_client(addr).sys.read_auth_method_tuning(path="userpass")
+    assert cfg["data"]["default_lease_ttl"] == 1234
+    await _assert_audited(
+        "vault.sys.auth.tune",
+        operator_sub="op-auth-tune",
+        expected_op_class="other",
+        events=captured_events,
+    )
+
+
+@pytest.mark.asyncio
+async def test_sys_mounts_tune_against_dev_vault(
+    vault_e2e: tuple[_VaultTarget, str],
+    captured_events: list[BroadcastEvent],
+) -> None:
+    """``vault.sys.mounts.tune`` reconfigures the dev ``secret/`` mount; op_class=other."""
+    target, addr = vault_e2e
+    operator = _make_operator(sub="op-mount-tune")
+    result = await dispatch(
+        operator=operator,
+        connector_id="vault-1.x",
+        op_id="vault.sys.mounts.tune",
+        target=target,
+        params={"path": _KV_MOUNT, "max_lease_ttl": "4321s"},
+        _approved=True,
+    )
+    assert result.status == "ok", result.error
+    assert result.result == {"path": _KV_MOUNT, "tuned": True}
+    cfg = _root_client(addr).sys.read_mount_configuration(path=_KV_MOUNT)
+    assert cfg["data"]["max_lease_ttl"] == 4321
+    await _assert_audited(
+        "vault.sys.mounts.tune",
+        operator_sub="op-mount-tune",
+        expected_op_class="other",
+        events=captured_events,
+    )
+
+
+# ---------------------------------------------------------------------------
 # auth group — userpass + approle read-only
 # ---------------------------------------------------------------------------
 

--- a/backend/tests/test_connectors_vault_sys.py
+++ b/backend/tests/test_connectors_vault_sys.py
@@ -79,6 +79,12 @@ from meho_backplane.connectors.vault import (
     VaultConnector,
     register_vault_sys_typed_operations,
 )
+from meho_backplane.connectors.vault.ops_sys_bootstrap import (
+    vault_sys_auth_enable,
+    vault_sys_auth_tune,
+    vault_sys_mounts_enable,
+    vault_sys_mounts_tune,
+)
 from meho_backplane.connectors.vault.ops_sys_policy import (
     vault_sys_policy_delete,
     vault_sys_policy_write,
@@ -730,3 +736,319 @@ async def test_policy_write_handler_reraises_vault_error(
     )
     with pytest.raises(hvac.exceptions.InvalidRequest):
         await handler(_make_operator(), None, params)
+
+
+# ---------------------------------------------------------------------------
+# vault.sys.{auth,mounts}.{enable,tune} — sys bootstrap writes (G3.15-T5 #1413)
+# ---------------------------------------------------------------------------
+
+
+_BOOTSTRAP_DANGEROUS_OP_IDS = (
+    "vault.sys.auth.enable",
+    "vault.sys.mounts.enable",
+)
+_BOOTSTRAP_CAUTION_OP_IDS = (
+    "vault.sys.auth.tune",
+    "vault.sys.mounts.tune",
+)
+_BOOTSTRAP_OP_IDS = _BOOTSTRAP_DANGEROUS_OP_IDS + _BOOTSTRAP_CAUTION_OP_IDS
+
+
+@pytest.mark.parametrize(
+    ("op_id", "expected_level"),
+    [
+        ("vault.sys.auth.enable", "dangerous"),
+        ("vault.sys.mounts.enable", "dangerous"),
+        ("vault.sys.auth.tune", "caution"),
+        ("vault.sys.mounts.tune", "caution"),
+    ],
+)
+async def test_bootstrap_ops_register_with_safety_and_approval(
+    op_id: str,
+    expected_level: str,
+    _registered_vault_sys_ops: None,
+) -> None:
+    """enable=dangerous, tune=caution; all four approval-gated, group 'sys'."""
+    row, group = await _policy_descriptor(op_id)
+    assert row.source_kind == "typed"
+    assert row.safety_level == expected_level
+    assert row.requires_approval is True
+    assert group.group_key == "sys"
+
+
+@pytest.mark.parametrize("op_id", _BOOTSTRAP_OP_IDS)
+def test_bootstrap_ops_classify_as_other(op_id: str) -> None:
+    """``.enable`` / ``.tune`` are not write/read suffixes → ``other``.
+
+    Deliberate: adding ``.enable`` to the broadcast classifier's
+    write-suffix tuple would reclassify the unrelated
+    ``meho.connector.enable`` MCP admin tool from ``other`` to ``write``.
+    None of these bootstrap ops carry secret material in their params, so
+    the full-detail ``other`` broadcast leaks nothing — classifying them
+    ``other`` is both the cleaner and the more scoped choice
+    (see ``docs/codebase/connectors-vault.md``).
+    """
+    assert classify_op(op_id) == "other"
+
+
+def test_adding_bootstrap_suffixes_would_not_reclassify_connector_admin() -> None:
+    """Guard: ``meho.connector.enable`` stays ``other`` (collision sentinel).
+
+    The broadcast op_class for the MCP connector-admin tools is derived
+    from ``classify_op(op_id)`` on the tool name. This pins the decision
+    NOT to add ``.enable`` to ``_WRITE_SUFFIXES`` — if a future change
+    does, this assertion fails and forces a re-audit of the collision.
+    """
+    assert classify_op("meho.connector.enable") == "other"
+
+
+async def test_auth_enable_handler_forwards_and_returns_created(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """auth.enable forwards type/path/description and reports created=True."""
+    fake = install_fake_client(monkeypatch)
+    result = await vault_sys_auth_enable(
+        _make_operator("op-jwt"),
+        None,
+        {"method_type": "userpass", "path": "userpass", "description": "ci login"},
+    )
+
+    assert result == {"path": "userpass", "method_type": "userpass", "created": True}
+    assert fake.sys.auth_enable_calls == [
+        {"method_type": "userpass", "path": "userpass", "description": "ci login"}
+    ]
+    assert fake.auth.jwt.login_calls == [{"role": "meho-mcp", "jwt": "op-jwt", "path": "jwt"}]
+    assert fake.auth.token.revoke_calls == 1
+
+
+async def test_mounts_enable_handler_forwards_and_returns_created(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """mounts.enable forwards type/path and reports created=True (no description)."""
+    fake = install_fake_client(monkeypatch)
+    result = await vault_sys_mounts_enable(
+        _make_operator(), None, {"backend_type": "transit", "path": "transit"}
+    )
+
+    assert result == {"path": "transit", "backend_type": "transit", "created": True}
+    assert fake.sys.mount_enable_calls == [
+        {"backend_type": "transit", "path": "transit", "description": None}
+    ]
+
+
+@pytest.mark.parametrize(
+    ("handler", "params", "exc_kwarg", "expected"),
+    [
+        (
+            vault_sys_auth_enable,
+            {"method_type": "userpass", "path": "userpass"},
+            "auth_enable_exc",
+            {"path": "userpass", "method_type": "userpass", "created": False},
+        ),
+        (
+            vault_sys_mounts_enable,
+            {"backend_type": "kv", "path": "secret"},
+            "mount_enable_exc",
+            {"path": "secret", "backend_type": "kv", "created": False},
+        ),
+    ],
+)
+async def test_enable_handler_is_idempotent_on_path_already_in_use(
+    monkeypatch: pytest.MonkeyPatch,
+    handler: Any,
+    params: dict[str, Any],
+    exc_kwarg: str,
+    expected: dict[str, Any],
+) -> None:
+    """A duplicate enable (400 'path is already in use') → created=False, not error."""
+    install_fake_client(
+        monkeypatch,
+        **{exc_kwarg: hvac.exceptions.InvalidRequest("path is already in use at userpass/")},
+    )
+    result = await handler(_make_operator(), None, params)
+    assert result == expected
+
+
+@pytest.mark.parametrize(
+    ("handler", "params", "exc_kwarg"),
+    [
+        (vault_sys_auth_enable, {"method_type": "bogus", "path": "x"}, "auth_enable_exc"),
+        (vault_sys_mounts_enable, {"backend_type": "bogus", "path": "x"}, "mount_enable_exc"),
+    ],
+)
+async def test_enable_handler_reraises_other_invalid_request(
+    monkeypatch: pytest.MonkeyPatch,
+    handler: Any,
+    params: dict[str, Any],
+    exc_kwarg: str,
+) -> None:
+    """A non-idempotency 400 (unknown type) propagates for connector_error."""
+    install_fake_client(
+        monkeypatch,
+        **{exc_kwarg: hvac.exceptions.InvalidRequest("unknown backend type: bogus")},
+    )
+    with pytest.raises(hvac.exceptions.InvalidRequest):
+        await handler(_make_operator(), None, params)
+
+
+async def test_auth_tune_handler_forwards_supplied_knobs_only(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """auth.tune forwards only the supplied knobs and reports tuned=True."""
+    fake = install_fake_client(monkeypatch)
+    result = await vault_sys_auth_tune(
+        _make_operator("op-jwt"),
+        None,
+        {"path": "userpass", "default_lease_ttl": "768h", "description": "tuned"},
+    )
+
+    assert result == {"path": "userpass", "tuned": True}
+    # Only the two supplied knobs are forwarded — an omitted knob leaves
+    # Vault's current value untouched (no max_lease_ttl in the call).
+    assert fake.sys.auth_tune_calls == [
+        {"path": "userpass", "default_lease_ttl": "768h", "description": "tuned"}
+    ]
+    assert fake.auth.token.revoke_calls == 1
+
+
+async def test_mounts_tune_handler_forwards_supplied_knobs_only(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """mounts.tune forwards only the supplied knobs and reports tuned=True."""
+    fake = install_fake_client(monkeypatch)
+    result = await vault_sys_mounts_tune(
+        _make_operator(), None, {"path": "secret", "max_lease_ttl": 3600}
+    )
+
+    assert result == {"path": "secret", "tuned": True}
+    assert fake.sys.mount_tune_calls == [{"path": "secret", "max_lease_ttl": 3600}]
+
+
+@pytest.mark.parametrize(
+    ("op_id", "params"),
+    [
+        ("vault.sys.auth.enable", {"method_type": "userpass", "path": "userpass"}),
+        ("vault.sys.auth.tune", {"path": "userpass", "default_lease_ttl": "1h"}),
+        ("vault.sys.mounts.enable", {"backend_type": "kv", "path": "kv-prod"}),
+        ("vault.sys.mounts.tune", {"path": "secret", "description": "x"}),
+    ],
+)
+async def test_bootstrap_ops_are_approval_gated_on_dispatch(
+    monkeypatch: pytest.MonkeyPatch,
+    op_id: str,
+    params: dict[str, Any],
+    _registered_vault_sys_ops: None,
+) -> None:
+    """DoD: a bootstrap dispatch parks as ``awaiting_approval`` (handler never runs)."""
+    fake = install_fake_client(monkeypatch)
+    result = await _dispatch_vault(op_id, params)
+
+    assert result.status == "awaiting_approval", result.error
+    assert result.extras.get("error_code") == "awaiting_approval"
+    assert result.extras.get("approval_request_id")
+    # The gate parks before any hvac call reaches Vault.
+    assert fake.sys.auth_enable_calls == []
+    assert fake.sys.auth_tune_calls == []
+    assert fake.sys.mount_enable_calls == []
+    assert fake.sys.mount_tune_calls == []
+
+
+async def test_bootstrap_op_dispatches_with_approved_flag(
+    monkeypatch: pytest.MonkeyPatch,
+    _registered_vault_sys_ops: None,
+) -> None:
+    """With the approvals-API resume flag, the dispatch reaches the handler."""
+    fake = install_fake_client(monkeypatch)
+    result = await dispatch(
+        operator=_make_operator(),
+        connector_id="vault-1.x",
+        op_id="vault.sys.auth.enable",
+        target=None,
+        params={"method_type": "userpass", "path": "userpass"},
+        _approved=True,
+    )
+
+    assert result.status == "ok", result.error
+    assert result.result == {"path": "userpass", "method_type": "userpass", "created": True}
+    assert fake.sys.auth_enable_calls == [
+        {"method_type": "userpass", "path": "userpass", "description": None}
+    ]
+
+
+@pytest.mark.parametrize(
+    ("op_id", "params"),
+    [
+        # blank / slash-bearing paths
+        ("vault.sys.auth.enable", {"method_type": "userpass", "path": "  "}),
+        ("vault.sys.auth.enable", {"method_type": "userpass", "path": "a/b"}),
+        # missing required field
+        ("vault.sys.auth.enable", {"path": "userpass"}),
+        ("vault.sys.mounts.enable", {"path": "secret"}),
+        # blank type
+        ("vault.sys.mounts.enable", {"backend_type": "  ", "path": "secret"}),
+        # stray key
+        ("vault.sys.auth.tune", {"path": "userpass", "bogus": "x"}),
+        # tune with no path
+        ("vault.sys.mounts.tune", {"default_lease_ttl": "1h"}),
+        # bad enum on listing_visibility
+        ("vault.sys.auth.tune", {"path": "userpass", "listing_visibility": "public"}),
+    ],
+)
+async def test_bootstrap_op_rejects_invalid_params(
+    monkeypatch: pytest.MonkeyPatch,
+    op_id: str,
+    params: dict[str, Any],
+    _registered_vault_sys_ops: None,
+) -> None:
+    """Schema rejects blank/slash paths, missing fields, stray keys, bad enums.
+
+    Validation runs ahead of the approval gate, so a malformed call
+    surfaces ``invalid_params`` rather than ``awaiting_approval``.
+    """
+    install_fake_client(monkeypatch)
+    result = await _dispatch_vault(op_id, params)
+
+    assert result.status == "error"
+    assert result.extras.get("error_code") == "invalid_params"
+
+
+@pytest.mark.parametrize(
+    ("handler", "params", "exc_kwarg"),
+    [
+        (vault_sys_auth_tune, {"path": "userpass"}, "auth_tune_exc"),
+        (vault_sys_mounts_tune, {"path": "secret"}, "mount_tune_exc"),
+    ],
+)
+async def test_tune_handler_reraises_vault_error(
+    monkeypatch: pytest.MonkeyPatch,
+    handler: Any,
+    params: dict[str, Any],
+    exc_kwarg: str,
+) -> None:
+    """The tune handler propagates a Vault-side error for connector_error."""
+    install_fake_client(
+        monkeypatch,
+        **{exc_kwarg: hvac.exceptions.InvalidRequest("cannot fetch sysview for path")},
+    )
+    with pytest.raises(hvac.exceptions.InvalidRequest):
+        await handler(_make_operator(), None, params)
+
+
+async def test_bootstrap_op_login_failure_surfaces_vault_client_error(
+    monkeypatch: pytest.MonkeyPatch,
+    _registered_vault_sys_ops: None,
+) -> None:
+    """Login-phase failure on an approved bootstrap dispatch → VaultClientError class."""
+    install_fake_client(monkeypatch, login_exc=hvac.exceptions.Forbidden("role denied"))
+    result = await dispatch(
+        operator=_make_operator(),
+        connector_id="vault-1.x",
+        op_id="vault.sys.mounts.enable",
+        target=None,
+        params={"backend_type": "kv", "path": "kv-prod"},
+        _approved=True,
+    )
+
+    assert result.status == "error"
+    assert result.extras.get("error_code") == "connector_error"
+    assert result.extras.get("exception_class") == "VaultRoleDeniedError"

--- a/docs/codebase/connectors-vault.md
+++ b/docs/codebase/connectors-vault.md
@@ -45,9 +45,11 @@ Source: `backend/src/meho_backplane/connectors/vault/`.
   key `kv`. `vault.kv.read` / `vault.kv.list` are classified
   `credential_read` (decision #3 — aggregate-only broadcast).
 - **`sys` op group** (`ops_sys.py`, G3.3-T2 #546; policy ops
-  G3.15-T2 #1410) — `register_vault_sys_typed_operations()` registers
-  four read-only diagnostics ops plus the four ACL-policy ops under
-  group key `sys`. The diagnostics ops are all `safety_level='safe'`,
+  G3.15-T2 #1410; bootstrap ops G3.15-T5 #1413) —
+  `register_vault_sys_typed_operations()` registers four read-only
+  diagnostics ops, the four ACL-policy ops, and the four bootstrap
+  enable/tune ops under group key `sys`. The diagnostics ops are all
+  `safety_level='safe'`,
   `requires_approval=False`:
   - `vault.sys.health` — `GET /v1/sys/health`. **Shares** the
     probe-path implementation: calls `auth.vault._build_client`
@@ -98,6 +100,50 @@ Source: `backend/src/meho_backplane/connectors/vault/`.
   a read-suffix — see "Broadcast PII discipline"), `policy.list` `read`
   via the `.list` suffix, and `policy.write` / `policy.delete` `write`
   (the `.write` / `.delete` suffixes redact the HCL body).
+
+  The sys bootstrap ops (`ops_sys_bootstrap.py` — same module-split
+  rationale as the policy ops; registered from the same
+  `register_vault_sys_typed_operations()`) move the auth-method /
+  secret-mount enable + tune operations off the break-glass shell
+  wrapper. All four are `requires_approval=True`:
+
+  | op_id | hvac call | safety_level | op_class |
+  |---|---|---|---|
+  | `vault.sys.auth.enable` | `sys.enable_auth_method` | dangerous | `other` |
+  | `vault.sys.auth.tune` | `sys.tune_auth_method` | caution | `other` |
+  | `vault.sys.mounts.enable` | `sys.enable_secrets_engine` | dangerous | `other` |
+  | `vault.sys.mounts.tune` | `sys.tune_mount_configuration` | caution | `other` |
+
+  Enables are `dangerous` (a new auth method / secret engine widens the
+  cluster's credential surface); tunes are `caution` (they reconfigure
+  an already-enabled mount — lease TTLs, description, listing
+  visibility — without standing up a new path). The `path` param uses
+  the policy-name pattern shape (`^(?=.*\S)[^/]+$`): a blank or
+  slash-bearing path fails validation. Enables take a required type
+  (`method_type` / `backend_type`) plus an optional `description`;
+  tunes take only the supplied config knobs (an omitted knob leaves
+  Vault's current value untouched). All four forward the operator JWT
+  via `vault_client_for_operator` and offload the sync `hvac` call with
+  `asyncio.to_thread`.
+
+  **Enable idempotency.** A duplicate `enable` (same type at an
+  already-mounted path) is Vault's HTTP 400 "path is already in use".
+  The enable handlers unwrap *that one* `hvac.exceptions.InvalidRequest`
+  into a `{created: false}` success (matching the connector's
+  error-unwrapping posture); every other 400 (unknown type, malformed
+  config) re-raises for the dispatcher's `connector_error` branch. Tunes
+  are naturally idempotent on Vault's side (a no-op 204) and synthesize
+  `{path, tuned: true}`.
+
+  **Broadcast classification.** All four classify `other` — `.enable` /
+  `.tune` are deliberately **not** added to the classifier's
+  write-suffix tuple. Adding `.enable` there would reclassify the
+  unrelated `meho.connector.enable` MCP admin tool (whose broadcast
+  op_class is derived from `classify_op` on the tool name) from `other`
+  to `write`, an out-of-scope behaviour change. None of these ops carry
+  secret material in their params (type, path, lease TTLs,
+  descriptions — config only), so the full-detail `other` broadcast
+  leaks nothing; `other` is both the cleaner and the more scoped choice.
 - **`auth` read op group** (`ops_auth.py`, G3.3-T3 #547) —
   `register_vault_auth_operations()` registers `vault.auth.userpass.list`
   / `vault.auth.userpass.read` / `vault.auth.approle.list` /
@@ -414,8 +460,11 @@ and a real Postgres audit store (reusing the integration conftest's
   already the v0.1/v0.2 model); revisit if a per-operator token cache
   lands.
 - `sys` policy writes (`policy.write` / `policy.delete`) landed in
-  G3.15-T2 (#1410), approval-gated. Other `sys` writes (unseal,
-  mount/unmount bootstrap) remain out of scope here (G3.15-T5).
+  G3.15-T2 (#1410), approval-gated; the sys bootstrap writes
+  (`auth.enable` / `auth.tune` / `mounts.enable` / `mounts.tune`)
+  landed in G3.15-T5 (#1413), also approval-gated. Unseal / rekey
+  (destructive cluster-lifecycle ops) remain out of scope — not in the
+  govc-parity verb set, not filed.
 - AppRole secret-id generation is out of scope for v0.2 (high-risk
   write with policy implications; v0.2.next behind a policy gate).
 


### PR DESCRIPTION
## Summary
- Add the four `vault.sys.{auth,mounts}.{enable,tune}` ops to the Vault `sys` group — the auth-method / secret-mount bootstrap operations the ops team previously ran via the break-glass shell wrapper, now on the governed, approval-gated operation surface. This is the last slice of the `/vault-admin` write surface.
- `auth.enable` / `mounts.enable` are `safety_level='dangerous'` (a new auth method / secret engine widens the cluster's credential surface); `auth.tune` / `mounts.tune` are `caution` (reconfigure an already-enabled mount). All four are `requires_approval=True`.
- Enables are idempotent-tolerant: Vault's HTTP 400 "path is already in use" unwraps to a `created=False` success (matching the connector's error-unwrapping posture); any other 400 re-raises for the dispatcher's `connector_error` branch.
- Handlers live in a new `ops_sys_bootstrap.py` (mirrors the policy-ops module split); registration stays in `ops_sys.py` so the whole `sys` group registers from one place.

## Broadcast classification (deliberate)
- The op-ids end in `.enable`/`.tune`. These are **not** added to `_WRITE_SUFFIXES`: adding `.enable` would reclassify the unrelated `meho.connector.enable` MCP admin tool (broadcast op_class derived from `classify_op` on the tool name) from `other` to `write` — an out-of-scope behaviour change. None of these ops carry secret material in their params, so the full-detail `other` broadcast leaks nothing. `other` is the cleaner, more-scoped choice; a guard test pins `meho.connector.enable` → `other` so a future suffix change forces a re-audit.

## Test plan
- [x] `ruff check` — clean
- [x] `ruff format --check` — clean
- [x] `mypy` — clean (no issues in 2 source files)
- [x] `pytest tests/test_connectors_vault_sys.py` — 83 passed (incl. the new bootstrap ops)
- [x] `pytest tests/test_broadcast_events.py tests/test_connectors_vault.py` — no regression (227 passed across the three files)
- [x] `code-quality.py --diff` — 0 blockers (warnings: `ops_sys.py` over the 600-line file budget — pre-existing, 729 lines on main before this change)
- [x] `cd cli && make snapshot-openapi && make generate` — no delta (connector ops, not REST routes)
- [x] AC: four ops register dangerous/caution + `requires_approval=True`, group `sys` — `test_bootstrap_ops_register_with_safety_and_approval`
- [x] AC: enable idempotent-tolerant — `test_enable_handler_is_idempotent_on_path_already_in_use` + `test_sys_auth_enable_idempotent_on_existing_path` (integration)
- [x] AC: per-op happy-path + error tests (mock `_build_client`) — handler-direct + dispatch + approval-gate + invalid-params + login/Vault-error tests
- [x] AC: CLI snapshot regen run — no delta
- [x] Integration (testcontainers, `Python (integration testcontainers)`): enable/tune against a live dev Vault dispatched with `_approved=True`, with read-back assertions and `op_class=other`

## Out of scope
- kv (T1), policy (T2), userpass/approle (T3), identity/token (T4) — sibling tasks.
- Unseal / rekey (destructive cluster-lifecycle) — not in the govc-parity verb set, not filed.

<!-- auto-implement-issue: fresh, iteration 1 -->

Closes #1413
