### PR TITLE
feat(connectors): G3.15-T4 vault identity + token ops — entity/group writes + token create/revoke_accessor/list_accessors

### DIFF
--- a/backend/src/meho_backplane/connectors/vault/__init__.py
+++ b/backend/src/meho_backplane/connectors/vault/__init__.py
@@ -58,6 +58,9 @@ from meho_backplane.connectors.vault.ops_auth import (
     VaultAuthBackendNotMountedError,
     register_vault_auth_operations,
 )
+from meho_backplane.connectors.vault.ops_identity_token import (
+    register_vault_identity_token_operations,
+)
 from meho_backplane.connectors.vault.ops_sys import (
     register_vault_sys_typed_operations,
 )
@@ -94,11 +97,18 @@ register_typed_op_registrar(register_vault_typed_operations)
 # the KV-v2 (#545) and sys surfaces register independently — no shared
 # handler state, distinct endpoint_descriptor rows.
 register_typed_op_registrar(register_vault_sys_typed_operations)
+# The identity (entity/group/alias) + token (create/revoke_accessor/
+# list_accessors) op groups (G3.15-T4 #1412) ship their own registrar so
+# they register independently of the KV / sys / auth surfaces. Writes are
+# requires_approval=True; vault.token.create's response token is redacted
+# via the credential_mint op-class allowlist.
+register_typed_op_registrar(register_vault_identity_token_operations)
 
 __all__ = [
     "VaultAuthBackendNotMountedError",
     "VaultConnector",
     "register_vault_auth_operations",
+    "register_vault_identity_token_operations",
     "register_vault_sys_typed_operations",
     "register_vault_typed_operations",
     "vault_kv_delete",

--- a/backend/src/meho_backplane/connectors/vault/ops_identity.py
+++ b/backend/src/meho_backplane/connectors/vault/ops_identity.py
@@ -1,0 +1,460 @@
+# SPDX-License-Identifier: Apache-2.0
+# Copyright (c) 2026 evoila Group
+
+"""Vault *identity* op handlers + spec table (G3.15-T4, #1412).
+
+The identity group surfaces the core Vault ``identity/`` secrets engine
+(always mounted): entity / entity-alias / group lifecycle. Group
+membership is privilege plumbing; entity/group policy bindings are
+privilege assignments. The four writes
+(``vault.identity.entity.write`` / ``entity_alias.write`` /
+``group.write`` / ``group.delete``) register ``safety_level="dangerous"``,
+``requires_approval=True``. The read primitives
+(``vault.identity.entity.read`` / ``group.read`` / ``list``) register
+``safety_level="safe"``, ``requires_approval=False`` -- registered safe
+even though the lookups are HTTP POST/LIST so a create-if-absent flow
+does not stall on approval (the issue's explicit ask).
+
+Handler shape mirrors :mod:`meho_backplane.connectors.vault.ops_auth`
+verbatim: each is a module-level ``async def`` with the ``(operator,
+target, params) -> dict`` typed-op contract, raises on failure (the
+dispatcher's ``connector_error`` branch records the class name in
+``extras["exception_class"]``), forwards the operator JWT via
+``vault_client_for_operator``, and offloads the blocking hvac call with
+``asyncio.to_thread``. The ``identity/`` engine is core (always
+mounted), so there is no backend-not-mounted reclassification -- a
+``404`` here means a missing entity/group and surfaces as the underlying
+:class:`hvac.exceptions.InvalidPath`. ``list`` normalises an empty-store
+``404`` to ``{"keys": []}``.
+
+The spec table + ``when_to_use`` blurb are consumed by the package
+composer :mod:`meho_backplane.connectors.vault.ops_identity_token`, which
+upserts both this group and the token group under one lifespan registrar.
+"""
+
+from __future__ import annotations
+
+import asyncio
+from typing import Any
+
+import meho_backplane.auth.vault as _auth_vault
+from meho_backplane.auth.operator import Operator
+from meho_backplane.connectors.vault.ops_auth import _extract_data, _extract_keys
+from meho_backplane.connectors.vault.ops_identity_schemas import (
+    VAULT_IDENTITY_ENTITY_ALIAS_WRITE_LLM_INSTRUCTIONS,
+    VAULT_IDENTITY_ENTITY_ALIAS_WRITE_PARAMETER_SCHEMA,
+    VAULT_IDENTITY_ENTITY_ALIAS_WRITE_RESPONSE_SCHEMA,
+    VAULT_IDENTITY_ENTITY_READ_LLM_INSTRUCTIONS,
+    VAULT_IDENTITY_ENTITY_READ_PARAMETER_SCHEMA,
+    VAULT_IDENTITY_ENTITY_READ_RESPONSE_SCHEMA,
+    VAULT_IDENTITY_ENTITY_WRITE_LLM_INSTRUCTIONS,
+    VAULT_IDENTITY_ENTITY_WRITE_PARAMETER_SCHEMA,
+    VAULT_IDENTITY_ENTITY_WRITE_RESPONSE_SCHEMA,
+    VAULT_IDENTITY_GROUP_DELETE_LLM_INSTRUCTIONS,
+    VAULT_IDENTITY_GROUP_DELETE_PARAMETER_SCHEMA,
+    VAULT_IDENTITY_GROUP_DELETE_RESPONSE_SCHEMA,
+    VAULT_IDENTITY_GROUP_READ_LLM_INSTRUCTIONS,
+    VAULT_IDENTITY_GROUP_READ_PARAMETER_SCHEMA,
+    VAULT_IDENTITY_GROUP_READ_RESPONSE_SCHEMA,
+    VAULT_IDENTITY_GROUP_WRITE_LLM_INSTRUCTIONS,
+    VAULT_IDENTITY_GROUP_WRITE_PARAMETER_SCHEMA,
+    VAULT_IDENTITY_GROUP_WRITE_RESPONSE_SCHEMA,
+    VAULT_IDENTITY_LIST_LLM_INSTRUCTIONS,
+    VAULT_IDENTITY_LIST_PARAMETER_SCHEMA,
+    VAULT_IDENTITY_LIST_RESPONSE_SCHEMA,
+)
+
+__all__ = [
+    "IDENTITY_OP_SPECS",
+    "IDENTITY_WHEN_TO_USE",
+    "vault_identity_entity_alias_write",
+    "vault_identity_entity_read",
+    "vault_identity_entity_write",
+    "vault_identity_group_delete",
+    "vault_identity_group_read",
+    "vault_identity_group_write",
+    "vault_identity_list",
+]
+
+
+def _maybe_id(payload: Any, key: str) -> str | None:
+    """Pull a freshly-minted id out of Vault's ``{"data": {...}}`` envelope.
+
+    A create returns ``{"data": {"id": ...}}``; a pure update returns
+    ``204`` with no body, which hvac surfaces as a falsy payload. Return
+    ``None`` in that case so the handler's value-free confirmation still
+    holds ('written: true') for an update that minted no id.
+    """
+    if not payload:
+        return None
+    data = payload.get("data") or {}
+    minted = data.get(key)
+    return str(minted) if minted is not None else None
+
+
+def _hvac_invalid_path() -> type[BaseException]:
+    """Return :class:`hvac.exceptions.InvalidPath` (lazy import).
+
+    Kept as a tiny indirection so the ``except`` clauses read uniformly
+    and the module's top-level imports stay confined to the handler
+    contract surface. hvac is a hard dependency (imported transitively
+    via ``ops_auth``), so this never fails.
+    """
+    import hvac.exceptions
+
+    invalid_path: type[BaseException] = hvac.exceptions.InvalidPath
+    return invalid_path
+
+
+# --- write handlers --------------------------------------------------------
+
+
+async def vault_identity_entity_write(
+    operator: Operator, target: Any, params: dict[str, Any]
+) -> dict[str, Any]:
+    """Create or update an identity entity (name, policies, metadata).
+
+    Op-id: ``vault.identity.entity.write``. Delegates to hvac's
+    ``client.secrets.identity.create_or_update_entity(name=...,
+    entity_id=..., policies=..., metadata=..., disabled=...)``. Only the
+    keys the caller supplied are forwarded (each is optional on the Vault
+    side). A create returns the minted ``entity_id``; an update returns
+    ``204`` (no body), so ``entity_id`` is ``None`` in that case.
+    """
+    name: str = str(params["name"]).strip()
+    kwargs: dict[str, Any] = {"name": name}
+    for field in ("entity_id", "policies", "metadata", "disabled"):
+        if field in params and params[field] is not None:
+            kwargs[field] = params[field]
+
+    async with _auth_vault.vault_client_for_operator(operator) as client:
+        payload = await asyncio.to_thread(client.secrets.identity.create_or_update_entity, **kwargs)
+
+    return {"name": name, "entity_id": _maybe_id(payload, "id"), "written": True}
+
+
+async def vault_identity_entity_alias_write(
+    operator: Operator, target: Any, params: dict[str, Any]
+) -> dict[str, Any]:
+    """Create or update an entity alias (link an auth login to an entity).
+
+    Op-id: ``vault.identity.entity_alias.write``. Delegates to hvac's
+    ``client.secrets.identity.create_or_update_entity_alias(name=...,
+    canonical_id=..., mount_accessor=..., alias_id=...)``. A create
+    returns the minted ``alias_id``; an update returns ``204``.
+    """
+    name: str = str(params["name"]).strip()
+    canonical_id: str = str(params["canonical_id"]).strip()
+    mount_accessor: str = str(params["mount_accessor"]).strip()
+    kwargs: dict[str, Any] = {
+        "name": name,
+        "canonical_id": canonical_id,
+        "mount_accessor": mount_accessor,
+    }
+    if params.get("alias_id") is not None:
+        kwargs["alias_id"] = str(params["alias_id"]).strip()
+
+    async with _auth_vault.vault_client_for_operator(operator) as client:
+        payload = await asyncio.to_thread(
+            client.secrets.identity.create_or_update_entity_alias, **kwargs
+        )
+
+    return {
+        "name": name,
+        "canonical_id": canonical_id,
+        "alias_id": _maybe_id(payload, "id"),
+        "written": True,
+    }
+
+
+#: Identity-group config keys forwarded to hvac verbatim when present.
+#: Each is optional on the Vault side (omitting leaves the field
+#: unchanged on an update / at its default on a create).
+_GROUP_WRITE_FIELDS: tuple[str, ...] = (
+    "group_id",
+    "group_type",
+    "policies",
+    "metadata",
+    "member_entity_ids",
+    "member_group_ids",
+)
+
+
+async def vault_identity_group_write(
+    operator: Operator, target: Any, params: dict[str, Any]
+) -> dict[str, Any]:
+    """Create or update an identity group (policies + membership).
+
+    Op-id: ``vault.identity.group.write``. Delegates to hvac's
+    ``client.secrets.identity.create_or_update_group(name=..., **config)``.
+    Membership (``member_entity_ids`` / ``member_group_ids``) is privilege
+    plumbing -- an entity in a policy-bearing group inherits that policy.
+    A create returns the minted ``group_id``; an update returns ``204``.
+    """
+    name: str = str(params["name"]).strip()
+    kwargs: dict[str, Any] = {"name": name}
+    for field in _GROUP_WRITE_FIELDS:
+        if field in params and params[field] is not None:
+            kwargs[field] = params[field]
+
+    async with _auth_vault.vault_client_for_operator(operator) as client:
+        payload = await asyncio.to_thread(client.secrets.identity.create_or_update_group, **kwargs)
+
+    return {"name": name, "group_id": _maybe_id(payload, "id"), "written": True}
+
+
+async def vault_identity_group_delete(
+    operator: Operator, target: Any, params: dict[str, Any]
+) -> dict[str, Any]:
+    """Delete an identity group by name (NO bulk-delete by design).
+
+    Op-id: ``vault.identity.group.delete``. Delegates to hvac's
+    ``client.secrets.identity.delete_group_by_name(name=...)``. Vault's
+    delete is idempotent (deleting a non-existent group is a no-op
+    success). Removes the group's policy bindings from every member --
+    an irreversible privilege change.
+    """
+    name: str = str(params["name"]).strip()
+
+    async with _auth_vault.vault_client_for_operator(operator) as client:
+        await asyncio.to_thread(client.secrets.identity.delete_group_by_name, name=name)
+
+    return {"name": name, "deleted": True}
+
+
+# --- read handlers ---------------------------------------------------------
+
+
+async def vault_identity_entity_read(
+    operator: Operator, target: Any, params: dict[str, Any]
+) -> dict[str, Any]:
+    """Read one identity entity's config by id.
+
+    Op-id: ``vault.identity.entity.read``. Delegates to hvac's
+    ``client.secrets.identity.read_entity(entity_id=...)`` and returns
+    the unwrapped ``data`` config dict (name, policies, metadata,
+    aliases, disabled). A missing id surfaces as the underlying
+    :class:`hvac.exceptions.InvalidPath` (read-phase failure).
+    """
+    entity_id: str = str(params["entity_id"]).strip()
+
+    async with _auth_vault.vault_client_for_operator(operator) as client:
+        payload = await asyncio.to_thread(client.secrets.identity.read_entity, entity_id=entity_id)
+
+    return _extract_data(payload)
+
+
+async def vault_identity_group_read(
+    operator: Operator, target: Any, params: dict[str, Any]
+) -> dict[str, Any]:
+    """Read one identity group's config by name.
+
+    Op-id: ``vault.identity.group.read``. Delegates to hvac's
+    ``client.secrets.identity.read_group_by_name(name=...)`` and returns
+    the unwrapped ``data`` config dict (type, policies, metadata, member
+    entity/group ids). A missing group surfaces as the underlying
+    :class:`hvac.exceptions.InvalidPath`.
+    """
+    name: str = str(params["name"]).strip()
+
+    async with _auth_vault.vault_client_for_operator(operator) as client:
+        payload = await asyncio.to_thread(client.secrets.identity.read_group_by_name, name=name)
+
+    return _extract_data(payload)
+
+
+async def vault_identity_list(
+    operator: Operator, target: Any, params: dict[str, Any]
+) -> dict[str, Any]:
+    """List identity entity ids or group ids.
+
+    Op-id: ``vault.identity.list``. ``kind`` selects the collection
+    (``"groups"`` by default, or ``"entities"``); delegates to hvac's
+    ``list_groups`` / ``list_entities`` and returns a normalised
+    ``{"kind", "keys"}`` dict. An empty collection (LIST returns
+    ``404``/no body) normalises to ``{"keys": []}`` rather than raising,
+    so the op's 'always a list' contract holds.
+    """
+    kind: str = str(params.get("kind", "groups")).strip()
+
+    async with _auth_vault.vault_client_for_operator(operator) as client:
+        list_fn = (
+            client.secrets.identity.list_entities
+            if kind == "entities"
+            else client.secrets.identity.list_groups
+        )
+        try:
+            payload = await asyncio.to_thread(list_fn)
+        except _hvac_invalid_path():
+            # An identity store with zero entities/groups LISTs as a 404;
+            # that is "empty", not an error.
+            return {"kind": kind, "keys": []}
+
+    return {"kind": kind, "keys": _extract_keys(payload)}
+
+
+# --- spec table ------------------------------------------------------------
+
+IDENTITY_WHEN_TO_USE: str = (
+    "Use to inspect and manage Vault IDENTITY objects -- entities, entity "
+    "aliases, and groups -- on the core identity/ engine. Reads "
+    "(vault.identity.entity.read / group.read / list) are safe and "
+    "approval-free; writes (vault.identity.entity.write / "
+    "entity_alias.write / group.write / group.delete) require approval "
+    "because policy bindings and group membership are privilege "
+    "assignments. An entity is the canonical identity a human/service "
+    "maps onto across auth backends; an alias links one auth-method login "
+    "to it; a group bundles entities under shared policies. Pair with the "
+    "'auth' group (per-backend userpass/approle roles) and the 'sys' "
+    "group (auth-method mount accessors needed for entity_alias.write)."
+)
+
+#: Per-op registration spec for the identity surface. ``group_key`` is
+#: ``identity`` for every row; ``safety_level`` / ``requires_approval``
+#: are carried per-op (writes dangerous + approval; reads safe + no
+#: approval). Consumed by the package composer
+#: ``ops_identity_token.register_vault_identity_token_operations``.
+IDENTITY_OP_SPECS: tuple[dict[str, Any], ...] = (
+    {
+        "op_id": "vault.identity.entity.write",
+        "handler": vault_identity_entity_write,
+        "group_key": "identity",
+        "summary": "Create or update an identity entity (name, policies, metadata).",
+        "description": (
+            "Creates a new identity entity or updates an existing one's "
+            "name, policies, metadata, or disabled state (POST "
+            "/v1/identity/entity). Binding policies is a privilege "
+            "assignment -- safety_level=dangerous, requires_approval=True. "
+            "A create returns the minted entity_id; an update returns 204 "
+            "(entity_id null). Value-free response (name, entity_id, "
+            "written)."
+        ),
+        "parameter_schema": VAULT_IDENTITY_ENTITY_WRITE_PARAMETER_SCHEMA,
+        "response_schema": VAULT_IDENTITY_ENTITY_WRITE_RESPONSE_SCHEMA,
+        "tags": ["write", "identity"],
+        "safety_level": "dangerous",
+        "requires_approval": True,
+        "llm_instructions": VAULT_IDENTITY_ENTITY_WRITE_LLM_INSTRUCTIONS,
+    },
+    {
+        "op_id": "vault.identity.entity_alias.write",
+        "handler": vault_identity_entity_alias_write,
+        "group_key": "identity",
+        "summary": "Create or update an entity alias (link an auth login to an entity).",
+        "description": (
+            "Creates or updates an entity alias linking an auth-method "
+            "login (a username, an OIDC subject) to an identity entity "
+            "(POST /v1/identity/entity-alias). The alias lets that login "
+            "inherit the entity's policies -- safety_level=dangerous, "
+            "requires_approval=True. Needs the source mount's accessor "
+            "(from the sys group's auth-method listing). A create returns "
+            "the minted alias_id; an update returns 204."
+        ),
+        "parameter_schema": VAULT_IDENTITY_ENTITY_ALIAS_WRITE_PARAMETER_SCHEMA,
+        "response_schema": VAULT_IDENTITY_ENTITY_ALIAS_WRITE_RESPONSE_SCHEMA,
+        "tags": ["write", "identity"],
+        "safety_level": "dangerous",
+        "requires_approval": True,
+        "llm_instructions": VAULT_IDENTITY_ENTITY_ALIAS_WRITE_LLM_INSTRUCTIONS,
+    },
+    {
+        "op_id": "vault.identity.group.write",
+        "handler": vault_identity_group_write,
+        "group_key": "identity",
+        "summary": "Create or update an identity group (policies + membership).",
+        "description": (
+            "Creates or updates an identity group, including its policies "
+            "and member entities/groups (POST /v1/identity/group). Group "
+            "membership is privilege plumbing -- an entity in a "
+            "policy-bearing group inherits that policy. "
+            "safety_level=dangerous, requires_approval=True. A create "
+            "returns the minted group_id; an update returns 204."
+        ),
+        "parameter_schema": VAULT_IDENTITY_GROUP_WRITE_PARAMETER_SCHEMA,
+        "response_schema": VAULT_IDENTITY_GROUP_WRITE_RESPONSE_SCHEMA,
+        "tags": ["write", "identity"],
+        "safety_level": "dangerous",
+        "requires_approval": True,
+        "llm_instructions": VAULT_IDENTITY_GROUP_WRITE_LLM_INSTRUCTIONS,
+    },
+    {
+        "op_id": "vault.identity.group.delete",
+        "handler": vault_identity_group_delete,
+        "group_key": "identity",
+        "summary": "Delete an identity group by name.",
+        "description": (
+            "Deletes an identity group by name, removing its policy "
+            "bindings from every member (DELETE "
+            "/v1/identity/group/name/<name>). Irreversible privilege "
+            "change -- safety_level=dangerous, requires_approval=True. "
+            "Idempotent (deleting a non-existent group is a no-op "
+            "success). Deletes ONE named group; there is no bulk-delete "
+            "verb by design."
+        ),
+        "parameter_schema": VAULT_IDENTITY_GROUP_DELETE_PARAMETER_SCHEMA,
+        "response_schema": VAULT_IDENTITY_GROUP_DELETE_RESPONSE_SCHEMA,
+        "tags": ["write", "destructive", "identity"],
+        "safety_level": "dangerous",
+        "requires_approval": True,
+        "llm_instructions": VAULT_IDENTITY_GROUP_DELETE_LLM_INSTRUCTIONS,
+    },
+    {
+        "op_id": "vault.identity.entity.read",
+        "handler": vault_identity_entity_read,
+        "group_key": "identity",
+        "summary": "Read one identity entity's config by id.",
+        "description": (
+            "Reads one identity entity's config by id -- name, policies, "
+            "metadata, aliases, disabled state (GET "
+            "/v1/identity/entity/id/<id>). Read-only; registered "
+            "safety_level=safe, requires_approval=False even though the "
+            "lookup is an HTTP read so create-if-absent flows do not "
+            "stall on approval. A missing id surfaces as InvalidPath."
+        ),
+        "parameter_schema": VAULT_IDENTITY_ENTITY_READ_PARAMETER_SCHEMA,
+        "response_schema": VAULT_IDENTITY_ENTITY_READ_RESPONSE_SCHEMA,
+        "tags": ["read-only", "identity"],
+        "safety_level": "safe",
+        "requires_approval": False,
+        "llm_instructions": VAULT_IDENTITY_ENTITY_READ_LLM_INSTRUCTIONS,
+    },
+    {
+        "op_id": "vault.identity.group.read",
+        "handler": vault_identity_group_read,
+        "group_key": "identity",
+        "summary": "Read one identity group's config by name.",
+        "description": (
+            "Reads one identity group's config by name -- type, policies, "
+            "metadata, member entity/group ids (GET "
+            "/v1/identity/group/name/<name>). Read-only; registered "
+            "safety_level=safe, requires_approval=False so create-if-absent "
+            "flows do not stall on approval. A missing group surfaces as "
+            "InvalidPath."
+        ),
+        "parameter_schema": VAULT_IDENTITY_GROUP_READ_PARAMETER_SCHEMA,
+        "response_schema": VAULT_IDENTITY_GROUP_READ_RESPONSE_SCHEMA,
+        "tags": ["read-only", "identity"],
+        "safety_level": "safe",
+        "requires_approval": False,
+        "llm_instructions": VAULT_IDENTITY_GROUP_READ_LLM_INSTRUCTIONS,
+    },
+    {
+        "op_id": "vault.identity.list",
+        "handler": vault_identity_list,
+        "group_key": "identity",
+        "summary": "List identity entity ids or group ids.",
+        "description": (
+            "Enumerates identity entity ids or group ids by id (LIST "
+            "/v1/identity/{entity,group}/id). 'kind' selects the "
+            "collection ('groups' default, or 'entities'). Read-only; "
+            "registered safety_level=safe, requires_approval=False. An "
+            "empty collection normalises to {'keys': []}."
+        ),
+        "parameter_schema": VAULT_IDENTITY_LIST_PARAMETER_SCHEMA,
+        "response_schema": VAULT_IDENTITY_LIST_RESPONSE_SCHEMA,
+        "tags": ["read-only", "identity"],
+        "safety_level": "safe",
+        "requires_approval": False,
+        "llm_instructions": VAULT_IDENTITY_LIST_LLM_INSTRUCTIONS,
+    },
+)

--- a/backend/src/meho_backplane/connectors/vault/ops_identity_schemas.py
+++ b/backend/src/meho_backplane/connectors/vault/ops_identity_schemas.py
@@ -1,0 +1,485 @@
+# SPDX-License-Identifier: Apache-2.0
+# Copyright (c) 2026 evoila Group
+
+"""JSON Schema + ``llm_instructions`` for the Vault *identity* ops (G3.15-T4).
+
+Sibling of :mod:`meho_backplane.connectors.vault.ops_token_schemas`;
+split out so each group's schema data stays under the file-size budget.
+Pure data only -- JSON Schema 2020-12 ``parameter_schema`` /
+``response_schema`` documents and the structured ``llm_instructions``
+payload the meta-tools (G0.6-T8) inline verbatim when an LLM is choosing
+an op.
+
+Mirrors the schema/``llm_instructions`` shape of the sibling auth
+modules (``ops_auth_schemas`` / ``ops_auth_write_schemas``): ``minLength=1``
+/ ``pattern="\\S"`` / ``additionalProperties=False`` input discipline and
+a when-to-use + parameter-hint + output-shape ``llm_instructions`` block
+per op. The identity entity/group/alias objects carry no secret material;
+policy bindings and group membership are the privilege signal (the
+load-bearing reason the writes require approval), not secrets.
+"""
+
+from __future__ import annotations
+
+from typing import Any
+
+__all__ = [
+    "VAULT_IDENTITY_ENTITY_ALIAS_WRITE_LLM_INSTRUCTIONS",
+    "VAULT_IDENTITY_ENTITY_ALIAS_WRITE_PARAMETER_SCHEMA",
+    "VAULT_IDENTITY_ENTITY_ALIAS_WRITE_RESPONSE_SCHEMA",
+    "VAULT_IDENTITY_ENTITY_READ_LLM_INSTRUCTIONS",
+    "VAULT_IDENTITY_ENTITY_READ_PARAMETER_SCHEMA",
+    "VAULT_IDENTITY_ENTITY_READ_RESPONSE_SCHEMA",
+    "VAULT_IDENTITY_ENTITY_WRITE_LLM_INSTRUCTIONS",
+    "VAULT_IDENTITY_ENTITY_WRITE_PARAMETER_SCHEMA",
+    "VAULT_IDENTITY_ENTITY_WRITE_RESPONSE_SCHEMA",
+    "VAULT_IDENTITY_GROUP_DELETE_LLM_INSTRUCTIONS",
+    "VAULT_IDENTITY_GROUP_DELETE_PARAMETER_SCHEMA",
+    "VAULT_IDENTITY_GROUP_DELETE_RESPONSE_SCHEMA",
+    "VAULT_IDENTITY_GROUP_READ_LLM_INSTRUCTIONS",
+    "VAULT_IDENTITY_GROUP_READ_PARAMETER_SCHEMA",
+    "VAULT_IDENTITY_GROUP_READ_RESPONSE_SCHEMA",
+    "VAULT_IDENTITY_GROUP_WRITE_LLM_INSTRUCTIONS",
+    "VAULT_IDENTITY_GROUP_WRITE_PARAMETER_SCHEMA",
+    "VAULT_IDENTITY_GROUP_WRITE_RESPONSE_SCHEMA",
+    "VAULT_IDENTITY_LIST_LLM_INSTRUCTIONS",
+    "VAULT_IDENTITY_LIST_PARAMETER_SCHEMA",
+    "VAULT_IDENTITY_LIST_RESPONSE_SCHEMA",
+]
+
+
+_POLICIES_PROPERTY: dict[str, Any] = {
+    "type": "array",
+    "items": {"type": "string", "minLength": 1},
+    "description": (
+        "Vault policy names bound to this identity object. This is the "
+        "privilege assignment -- the load-bearing reason every write op "
+        "in this group requires approval. Omit to leave unchanged on an "
+        "update (Vault treats the field as optional)."
+    ),
+}
+
+_METADATA_PROPERTY: dict[str, Any] = {
+    "type": "object",
+    "additionalProperties": {"type": "string"},
+    "description": (
+        "Arbitrary string key/value metadata stamped on the object. Not "
+        "secret material; echoed back verbatim by reads."
+    ),
+}
+
+
+# --- identity.entity.write -------------------------------------------------
+
+VAULT_IDENTITY_ENTITY_WRITE_PARAMETER_SCHEMA: dict[str, Any] = {
+    "type": "object",
+    "properties": {
+        "name": {
+            "type": "string",
+            "minLength": 1,
+            "pattern": "\\S",
+            "description": "Entity name. Forwarded verbatim to hvac's name= argument.",
+        },
+        "entity_id": {
+            "type": "string",
+            "minLength": 1,
+            "pattern": "\\S",
+            "description": (
+                "Existing entity id to update. Omit to create a new entity "
+                "(Vault mints the id and returns it)."
+            ),
+        },
+        "policies": _POLICIES_PROPERTY,
+        "metadata": _METADATA_PROPERTY,
+        "disabled": {
+            "type": "boolean",
+            "description": "Whether the entity is disabled (its aliases cannot authenticate).",
+        },
+    },
+    "required": ["name"],
+    "additionalProperties": False,
+}
+
+VAULT_IDENTITY_ENTITY_WRITE_RESPONSE_SCHEMA: dict[str, Any] = {
+    "type": "object",
+    "properties": {
+        "name": {"type": "string", "description": "The entity created or updated."},
+        "entity_id": {
+            "type": ["string", "null"],
+            "description": (
+                "The entity id. Present on a create (Vault mints and returns "
+                "it) and echoed on an update; null when Vault returns no body "
+                "(a pure update)."
+            ),
+        },
+        "written": {"type": "boolean", "description": "Always true on success."},
+    },
+    "required": ["name", "written"],
+    "description": "Confirms the create/update; carries the entity id on a create.",
+}
+
+VAULT_IDENTITY_ENTITY_WRITE_LLM_INSTRUCTIONS: dict[str, Any] = {
+    "when_to_use": (
+        "Create a new identity entity or update an existing one's name, "
+        "policies, metadata, or disabled state. DANGEROUS, requires "
+        "approval: binding policies is a privilege assignment. An entity "
+        "is the canonical identity a human/service maps onto across auth "
+        "backends; aliases (vault.identity.entity_alias.write) link a "
+        "specific auth-method login to it."
+    ),
+    "parameter_hints": {
+        "name": "Required. The entity name.",
+        "entity_id": "Optional. Supply to update a specific entity; omit to create.",
+        "policies": "Optional. Policy names bound to the entity (privilege assignment).",
+        "metadata": "Optional. String key/value metadata.",
+        "disabled": "Optional. Set true to disable the entity (its aliases cannot log in).",
+    },
+    "output_shape": (
+        "On success: {'name': ..., 'entity_id': ..., 'written': true}. "
+        "entity_id is the minted id on a create. On failure: a "
+        "connector_error OperationResult with extras.exception_class."
+    ),
+}
+
+
+# --- identity.entity_alias.write -------------------------------------------
+
+VAULT_IDENTITY_ENTITY_ALIAS_WRITE_PARAMETER_SCHEMA: dict[str, Any] = {
+    "type": "object",
+    "properties": {
+        "name": {
+            "type": "string",
+            "minLength": 1,
+            "pattern": "\\S",
+            "description": (
+                "Alias name -- the login identifier on the source auth method "
+                "(e.g. the username, the OIDC subject)."
+            ),
+        },
+        "canonical_id": {
+            "type": "string",
+            "minLength": 1,
+            "pattern": "\\S",
+            "description": "Entity id this alias maps onto (the entity's canonical id).",
+        },
+        "mount_accessor": {
+            "type": "string",
+            "minLength": 1,
+            "pattern": "\\S",
+            "description": (
+                "Accessor of the auth-method mount the alias belongs to "
+                "(from sys.auth.list / 'vault auth list -detailed')."
+            ),
+        },
+        "alias_id": {
+            "type": "string",
+            "minLength": 1,
+            "pattern": "\\S",
+            "description": "Existing alias id to update. Omit to create a new alias.",
+        },
+    },
+    "required": ["name", "canonical_id", "mount_accessor"],
+    "additionalProperties": False,
+}
+
+VAULT_IDENTITY_ENTITY_ALIAS_WRITE_RESPONSE_SCHEMA: dict[str, Any] = {
+    "type": "object",
+    "properties": {
+        "name": {"type": "string", "description": "The alias name."},
+        "canonical_id": {"type": "string", "description": "The entity id the alias maps onto."},
+        "alias_id": {
+            "type": ["string", "null"],
+            "description": "The alias id (minted on a create); null when Vault returns no body.",
+        },
+        "written": {"type": "boolean", "description": "Always true on success."},
+    },
+    "required": ["name", "canonical_id", "written"],
+    "description": "Confirms the alias create/update; carries the alias id on a create.",
+}
+
+VAULT_IDENTITY_ENTITY_ALIAS_WRITE_LLM_INSTRUCTIONS: dict[str, Any] = {
+    "when_to_use": (
+        "Link a specific auth-method login (a username, an OIDC subject) "
+        "to an identity entity by creating or updating an alias. "
+        "DANGEROUS, requires approval: an alias lets that login inherit "
+        "the entity's policies. Needs the mount accessor of the source "
+        "auth method (read it from the 'sys' group's auth-method listing)."
+    ),
+    "parameter_hints": {
+        "name": "Required. The login identifier on the source auth method.",
+        "canonical_id": "Required. The entity id this alias maps onto.",
+        "mount_accessor": "Required. The auth-method mount accessor (from sys.auth.list).",
+        "alias_id": "Optional. Supply to update a specific alias; omit to create.",
+    },
+    "output_shape": (
+        "On success: {'name': ..., 'canonical_id': ..., 'alias_id': ..., "
+        "'written': true}. On failure: a connector_error OperationResult."
+    ),
+}
+
+
+# --- identity.group.write --------------------------------------------------
+
+VAULT_IDENTITY_GROUP_WRITE_PARAMETER_SCHEMA: dict[str, Any] = {
+    "type": "object",
+    "properties": {
+        "name": {
+            "type": "string",
+            "minLength": 1,
+            "pattern": "\\S",
+            "description": "Group name. Forwarded verbatim to hvac's name= argument.",
+        },
+        "group_id": {
+            "type": "string",
+            "minLength": 1,
+            "pattern": "\\S",
+            "description": "Existing group id to update. Omit to create a new group.",
+        },
+        "group_type": {
+            "type": "string",
+            "enum": ["internal", "external"],
+            "default": "internal",
+            "description": (
+                "Group type. 'internal' groups list explicit member entities/groups; "
+                "'external' groups are populated by an auth method's group claims."
+            ),
+        },
+        "policies": _POLICIES_PROPERTY,
+        "metadata": _METADATA_PROPERTY,
+        "member_entity_ids": {
+            "type": "array",
+            "items": {"type": "string", "minLength": 1},
+            "description": (
+                "Entity ids that are members of this internal group -- the "
+                "membership-as-privilege plumbing. Ignored for external groups."
+            ),
+        },
+        "member_group_ids": {
+            "type": "array",
+            "items": {"type": "string", "minLength": 1},
+            "description": "Child group ids nested under this internal group.",
+        },
+    },
+    "required": ["name"],
+    "additionalProperties": False,
+}
+
+VAULT_IDENTITY_GROUP_WRITE_RESPONSE_SCHEMA: dict[str, Any] = {
+    "type": "object",
+    "properties": {
+        "name": {"type": "string", "description": "The group created or updated."},
+        "group_id": {
+            "type": ["string", "null"],
+            "description": "The group id (minted on a create); null when Vault returns no body.",
+        },
+        "written": {"type": "boolean", "description": "Always true on success."},
+    },
+    "required": ["name", "written"],
+    "description": "Confirms the group create/update; carries the group id on a create.",
+}
+
+VAULT_IDENTITY_GROUP_WRITE_LLM_INSTRUCTIONS: dict[str, Any] = {
+    "when_to_use": (
+        "Create or update an identity group, including its policies and "
+        "member entities/groups. DANGEROUS, requires approval: group "
+        "membership is privilege plumbing -- adding an entity to a "
+        "policy-bearing group grants it that policy. Use group_type "
+        "'internal' for explicit membership, 'external' for "
+        "auth-method-claim-driven membership."
+    ),
+    "parameter_hints": {
+        "name": "Required. The group name.",
+        "group_id": "Optional. Supply to update a specific group; omit to create.",
+        "group_type": "Optional. 'internal' (default) or 'external'.",
+        "policies": "Optional. Policy names bound to the group (privilege assignment).",
+        "metadata": "Optional. String key/value metadata.",
+        "member_entity_ids": "Optional. Member entity ids (internal groups only).",
+        "member_group_ids": "Optional. Child group ids (internal groups only).",
+    },
+    "output_shape": (
+        "On success: {'name': ..., 'group_id': ..., 'written': true}. On "
+        "failure: a connector_error OperationResult."
+    ),
+}
+
+
+# --- identity.group.delete -------------------------------------------------
+
+VAULT_IDENTITY_GROUP_DELETE_PARAMETER_SCHEMA: dict[str, Any] = {
+    "type": "object",
+    "properties": {
+        "name": {
+            "type": "string",
+            "minLength": 1,
+            "pattern": "\\S",
+            "description": "Group name to delete. Forwarded verbatim to hvac's name= argument.",
+        },
+    },
+    "required": ["name"],
+    "additionalProperties": False,
+}
+
+VAULT_IDENTITY_GROUP_DELETE_RESPONSE_SCHEMA: dict[str, Any] = {
+    "type": "object",
+    "properties": {
+        "name": {"type": "string", "description": "The group deleted."},
+        "deleted": {"type": "boolean", "description": "Always true on success."},
+    },
+    "required": ["name", "deleted"],
+    "description": "Confirms the group deletion. Idempotent: deleting a missing group succeeds.",
+}
+
+VAULT_IDENTITY_GROUP_DELETE_LLM_INSTRUCTIONS: dict[str, Any] = {
+    "when_to_use": (
+        "Delete an identity group by name, removing its policy bindings "
+        "from every member. DANGEROUS, requires approval: an irreversible "
+        "privilege change. Idempotent -- deleting a non-existent group is "
+        "a no-op success. This op deletes ONE named group; there is no "
+        "bulk-delete verb by design."
+    ),
+    "parameter_hints": {
+        "name": "Required. The group name to delete.",
+    },
+    "output_shape": (
+        "On success: {'name': ..., 'deleted': true}. On failure: a connector_error OperationResult."
+    ),
+}
+
+
+# --- identity.entity.read --------------------------------------------------
+
+VAULT_IDENTITY_ENTITY_READ_PARAMETER_SCHEMA: dict[str, Any] = {
+    "type": "object",
+    "properties": {
+        "entity_id": {
+            "type": "string",
+            "minLength": 1,
+            "pattern": "\\S",
+            "description": "The entity id to read (from a create response or a list).",
+        },
+    },
+    "required": ["entity_id"],
+    "additionalProperties": False,
+}
+
+VAULT_IDENTITY_ENTITY_READ_RESPONSE_SCHEMA: dict[str, Any] = {
+    "type": "object",
+    "description": (
+        "The entity's config dict (name, policies, metadata, aliases, "
+        "disabled), unwrapped from Vault's {'data': {...}} envelope."
+    ),
+    "additionalProperties": True,
+}
+
+VAULT_IDENTITY_ENTITY_READ_LLM_INSTRUCTIONS: dict[str, Any] = {
+    "when_to_use": (
+        "Read one identity entity's config by id -- its name, bound "
+        "policies, metadata, aliases, and disabled state. Read-only; "
+        "registered safe (no approval) even though the lookup is an HTTP "
+        "POST, so a create-if-absent flow does not stall on approval."
+    ),
+    "parameter_hints": {
+        "entity_id": "Required. The entity id (from a create response or a list).",
+    },
+    "output_shape": (
+        "On success: the entity's config dict. On failure: a "
+        "connector_error OperationResult (InvalidPath when the id does "
+        "not exist)."
+    ),
+}
+
+
+# --- identity.group.read ---------------------------------------------------
+
+VAULT_IDENTITY_GROUP_READ_PARAMETER_SCHEMA: dict[str, Any] = {
+    "type": "object",
+    "properties": {
+        "name": {
+            "type": "string",
+            "minLength": 1,
+            "pattern": "\\S",
+            "description": "The group name to read.",
+        },
+    },
+    "required": ["name"],
+    "additionalProperties": False,
+}
+
+VAULT_IDENTITY_GROUP_READ_RESPONSE_SCHEMA: dict[str, Any] = {
+    "type": "object",
+    "description": (
+        "The group's config dict (name, type, policies, metadata, member "
+        "entity/group ids), unwrapped from Vault's {'data': {...}} envelope."
+    ),
+    "additionalProperties": True,
+}
+
+VAULT_IDENTITY_GROUP_READ_LLM_INSTRUCTIONS: dict[str, Any] = {
+    "when_to_use": (
+        "Read one identity group's config by name -- its type, bound "
+        "policies, metadata, and member entity/group ids. Read-only; "
+        "registered safe (no approval) so a create-if-absent flow does "
+        "not stall on approval."
+    ),
+    "parameter_hints": {
+        "name": "Required. The group name.",
+    },
+    "output_shape": (
+        "On success: the group's config dict. On failure: a "
+        "connector_error OperationResult (InvalidPath when the group does "
+        "not exist)."
+    ),
+}
+
+
+# --- identity.list ---------------------------------------------------------
+
+VAULT_IDENTITY_LIST_PARAMETER_SCHEMA: dict[str, Any] = {
+    "type": "object",
+    "properties": {
+        "kind": {
+            "type": "string",
+            "enum": ["entities", "groups"],
+            "default": "groups",
+            "description": (
+                "Which identity collection to enumerate by id: 'entities' "
+                "lists entity ids, 'groups' lists group ids."
+            ),
+        },
+    },
+    "required": [],
+    "additionalProperties": False,
+}
+
+VAULT_IDENTITY_LIST_RESPONSE_SCHEMA: dict[str, Any] = {
+    "type": "object",
+    "properties": {
+        "kind": {
+            "type": "string",
+            "description": "The collection enumerated ('entities' / 'groups').",
+        },
+        "keys": {
+            "type": "array",
+            "items": {"type": "string"},
+            "description": "The ids in the collection. Empty list when the collection is empty.",
+        },
+    },
+    "required": ["kind", "keys"],
+    "description": "The list of entity or group ids. Always carries a 'keys' list.",
+}
+
+VAULT_IDENTITY_LIST_LLM_INSTRUCTIONS: dict[str, Any] = {
+    "when_to_use": (
+        "Enumerate identity entity ids or group ids. Read-only; "
+        "registered safe (no approval). Pick the collection with 'kind' "
+        "('groups' by default). Pair with vault.identity.entity.read / "
+        "vault.identity.group.read to inspect one object's config."
+    ),
+    "parameter_hints": {
+        "kind": "Optional. 'groups' (default) or 'entities'.",
+    },
+    "output_shape": (
+        "On success: {'kind': ..., 'keys': [...]} -- the ids in the "
+        "collection. An empty collection yields {'keys': []}."
+    ),
+}

--- a/backend/src/meho_backplane/connectors/vault/ops_identity_token.py
+++ b/backend/src/meho_backplane/connectors/vault/ops_identity_token.py
@@ -1,0 +1,99 @@
+# SPDX-License-Identifier: Apache-2.0
+# Copyright (c) 2026 evoila Group
+
+"""Composer registrar for the Vault identity + token op groups (G3.15-T4).
+
+The identity surface (entity / entity-alias / group lifecycle) lives in
+:mod:`meho_backplane.connectors.vault.ops_identity`; the token surface
+(create / revoke_accessor / list_accessors) lives in
+:mod:`meho_backplane.connectors.vault.ops_token`. Each module owns its
+handlers, schemas import, ``when_to_use`` blurb, and per-op spec table.
+
+This thin module is the single lifespan-driven registrar entry (queued
+from the package ``__init__`` alongside the KV / sys / auth registrars):
+it walks both spec tables and upserts every row into
+``endpoint_descriptor``. Writes register ``requires_approval=True``
+(privilege assignment / irreversible removal / secret mint); the read
+primitives register safe + approval-free so create-if-absent flows do
+not stall on approval. ``vault.token.create``'s response token is
+redacted at the classification layer (``credential_mint`` op-class), not
+here.
+"""
+
+from __future__ import annotations
+
+from typing import Any
+
+from meho_backplane.connectors.vault.ops_identity import (
+    IDENTITY_OP_SPECS,
+    IDENTITY_WHEN_TO_USE,
+    vault_identity_entity_alias_write,
+    vault_identity_entity_read,
+    vault_identity_entity_write,
+    vault_identity_group_delete,
+    vault_identity_group_read,
+    vault_identity_group_write,
+    vault_identity_list,
+)
+from meho_backplane.connectors.vault.ops_token import (
+    TOKEN_OP_SPECS,
+    TOKEN_WHEN_TO_USE,
+    vault_token_create,
+    vault_token_list_accessors,
+    vault_token_revoke_accessor,
+)
+from meho_backplane.operations.typed_register import register_typed_operation
+from meho_backplane.retrieval.embedding import EmbeddingService
+
+__all__ = [
+    "register_vault_identity_token_operations",
+    "vault_identity_entity_alias_write",
+    "vault_identity_entity_read",
+    "vault_identity_entity_write",
+    "vault_identity_group_delete",
+    "vault_identity_group_read",
+    "vault_identity_group_write",
+    "vault_identity_list",
+    "vault_token_create",
+    "vault_token_list_accessors",
+    "vault_token_revoke_accessor",
+]
+
+
+async def register_vault_identity_token_operations(
+    *,
+    embedding_service: EmbeddingService | None = None,
+) -> None:
+    """Upsert the Vault identity + token ops into ``endpoint_descriptor``.
+
+    Walks :data:`~meho_backplane.connectors.vault.ops_identity.IDENTITY_OP_SPECS`
+    and :data:`~meho_backplane.connectors.vault.ops_token.TOKEN_OP_SPECS`,
+    selecting the group's ``when_to_use`` blurb per spec. Idempotent: a
+    second call against unchanged descriptions is a no-op for the
+    embedding pipeline via the body-hash skip path in
+    :func:`~meho_backplane.operations.typed_register.register_typed_operation`.
+
+    ``group_key`` (``identity`` / ``token``), ``safety_level``, and
+    ``requires_approval`` are carried per-op in the spec rows.
+    """
+    specs: tuple[dict[str, Any], ...] = (*IDENTITY_OP_SPECS, *TOKEN_OP_SPECS)
+    for spec in specs:
+        when_to_use = TOKEN_WHEN_TO_USE if spec["group_key"] == "token" else IDENTITY_WHEN_TO_USE
+        await register_typed_operation(
+            product="vault",
+            version="1.x",
+            impl_id="vault",
+            op_id=spec["op_id"],
+            handler=spec["handler"],
+            summary=spec["summary"],
+            description=spec["description"],
+            parameter_schema=spec["parameter_schema"],
+            response_schema=spec["response_schema"],
+            group_key=spec["group_key"],
+            when_to_use=when_to_use,
+            tags=spec["tags"],
+            safety_level=spec["safety_level"],
+            requires_approval=spec["requires_approval"],
+            llm_instructions=spec["llm_instructions"],
+            embedding_service=embedding_service,
+        )

--- a/backend/src/meho_backplane/connectors/vault/ops_token.py
+++ b/backend/src/meho_backplane/connectors/vault/ops_token.py
@@ -1,0 +1,254 @@
+# SPDX-License-Identifier: Apache-2.0
+# Copyright (c) 2026 evoila Group
+
+"""Vault *token* op handlers + spec table (G3.15-T4, #1412).
+
+The token group surfaces the core Vault ``token`` auth backend (always
+mounted):
+
+* ``vault.token.create`` mints a client token (``requires_approval=True``;
+  the token is in the **response** -> ``credential_mint`` redaction).
+* ``vault.token.revoke_accessor`` surgically revokes a single token by
+  accessor (``requires_approval=True``).
+* ``vault.token.list_accessors`` lists accessor handles
+  (``safety_level="safe"``).
+
+There is **no bulk-revoke op** by design -- never revoke broadly to
+recover from one leak (the vault skill's loudest Don't-rule).
+
+**Secret redaction is at the classification layer, not the handler**
+(#1397 / #1401). ``vault.token.create``'s minted client token rides in
+the *response* (under Vault's ``auth`` envelope);
+:func:`meho_backplane.broadcast.events.classify_op` maps it to
+``credential_mint`` (allowlist consulted BEFORE the ``.create``
+write-suffix), so the broadcast collapses to aggregate-only and the
+audit row holds only a ``params_hash``. The caller's ``OperationResult``
+still carries the token (the whole point of minting). A token
+**accessor** (``revoke_accessor`` param, ``list_accessors`` response) is
+a reference handle, not the token secret -- deliberately not redacted.
+
+Handler shape mirrors :mod:`meho_backplane.connectors.vault.ops_auth`:
+``async def (operator, target, params) -> dict``, raises on failure,
+forwards the operator JWT via ``vault_client_for_operator``, offloads the
+blocking hvac call with ``asyncio.to_thread``. The ``token`` backend is
+core (always mounted); ``list_accessors`` normalises an empty-store
+``404`` to ``{"keys": []}``.
+"""
+
+from __future__ import annotations
+
+import asyncio
+from typing import Any
+
+import meho_backplane.auth.vault as _auth_vault
+from meho_backplane.auth.operator import Operator
+from meho_backplane.connectors.vault.ops_auth import _extract_keys
+from meho_backplane.connectors.vault.ops_token_schemas import (
+    VAULT_TOKEN_CREATE_LLM_INSTRUCTIONS,
+    VAULT_TOKEN_CREATE_PARAMETER_SCHEMA,
+    VAULT_TOKEN_CREATE_RESPONSE_SCHEMA,
+    VAULT_TOKEN_LIST_ACCESSORS_LLM_INSTRUCTIONS,
+    VAULT_TOKEN_LIST_ACCESSORS_PARAMETER_SCHEMA,
+    VAULT_TOKEN_LIST_ACCESSORS_RESPONSE_SCHEMA,
+    VAULT_TOKEN_REVOKE_ACCESSOR_LLM_INSTRUCTIONS,
+    VAULT_TOKEN_REVOKE_ACCESSOR_PARAMETER_SCHEMA,
+    VAULT_TOKEN_REVOKE_ACCESSOR_RESPONSE_SCHEMA,
+)
+
+__all__ = [
+    "TOKEN_OP_SPECS",
+    "TOKEN_WHEN_TO_USE",
+    "vault_token_create",
+    "vault_token_list_accessors",
+    "vault_token_revoke_accessor",
+]
+
+
+def _hvac_invalid_path() -> type[BaseException]:
+    """Return :class:`hvac.exceptions.InvalidPath` (lazy import).
+
+    Kept as a tiny indirection so the ``except`` clause reads uniformly.
+    hvac is a hard dependency (imported transitively via ``ops_auth``),
+    so this never fails.
+    """
+    import hvac.exceptions
+
+    invalid_path: type[BaseException] = hvac.exceptions.InvalidPath
+    return invalid_path
+
+
+#: token.create config keys forwarded to hvac verbatim when present.
+#: ``ttl_period`` is handled separately (maps onto hvac's ``period=``).
+_TOKEN_CREATE_FIELDS: tuple[str, ...] = (
+    "policies",
+    "ttl",
+    "explicit_max_ttl",
+    "display_name",
+    "num_uses",
+    "renewable",
+    "no_parent",
+    "entity_alias",
+)
+
+
+async def vault_token_create(
+    operator: Operator, target: Any, params: dict[str, Any]
+) -> dict[str, Any]:
+    """Mint a fresh Vault client token (NON-IDEMPOTENT; token in RESPONSE).
+
+    Op-id: ``vault.token.create``. Delegates to hvac's
+    ``client.auth.token.create(policies=..., ttl=..., ...)``. Each call
+    mints a brand-new token -- the op is non-idempotent.
+
+    The minted ``client_token`` lands in the *response* (under Vault's
+    ``auth`` envelope), so the op classifies ``credential_mint``: the
+    broadcast collapses to aggregate-only and the audit row holds only a
+    ``params_hash``, so the token never reaches the feed or the audit
+    store. The caller's ``OperationResult`` still carries it (the whole
+    point of minting) -- store it immediately. The ``accessor`` returned
+    alongside is a non-secret reference handle (usable for
+    ``vault.token.revoke_accessor``).
+    """
+    kwargs: dict[str, Any] = {}
+    for field in _TOKEN_CREATE_FIELDS:
+        if field in params and params[field] is not None:
+            kwargs[field] = params[field]
+    # ``ttl_period`` maps onto hvac's ``period=`` (periodic-token knob);
+    # renamed in the schema to avoid clashing with the ``ttl`` field.
+    if params.get("ttl_period") is not None:
+        kwargs["period"] = params["ttl_period"]
+
+    async with _auth_vault.vault_client_for_operator(operator) as client:
+        payload = await asyncio.to_thread(client.auth.token.create, **kwargs)
+
+    auth = dict(payload["auth"])
+    result: dict[str, Any] = {
+        "client_token": auth["client_token"],
+        "accessor": auth["accessor"],
+    }
+    if "policies" in auth:
+        result["policies"] = list(auth["policies"])
+    return result
+
+
+async def vault_token_revoke_accessor(
+    operator: Operator, target: Any, params: dict[str, Any]
+) -> dict[str, Any]:
+    """Revoke ONE token by its accessor (surgical; NO bulk-revoke).
+
+    Op-id: ``vault.token.revoke_accessor``. Delegates to hvac's
+    ``client.auth.token.revoke_accessor(accessor=...)``. Revokes exactly
+    the one token the accessor references -- never a tree, never a bulk
+    sweep (there is no bulk-revoke op by design). The accessor is a
+    reference handle, not the token secret.
+    """
+    accessor: str = str(params["accessor"]).strip()
+
+    async with _auth_vault.vault_client_for_operator(operator) as client:
+        await asyncio.to_thread(client.auth.token.revoke_accessor, accessor=accessor)
+
+    return {"accessor": accessor, "revoked": True}
+
+
+async def vault_token_list_accessors(
+    operator: Operator, target: Any, params: dict[str, Any]
+) -> dict[str, Any]:
+    """List every active token's accessor handle.
+
+    Op-id: ``vault.token.list_accessors``. Delegates to hvac's
+    ``client.auth.token.list_accessors()`` and returns a normalised
+    ``{"keys": [...]}`` dict. Accessors are non-secret references (never
+    token secrets). An empty token store normalises to ``{"keys": []}``.
+    """
+    async with _auth_vault.vault_client_for_operator(operator) as client:
+        try:
+            payload = await asyncio.to_thread(client.auth.token.list_accessors)
+        except _hvac_invalid_path():
+            return {"keys": []}
+
+    return {"keys": _extract_keys(payload)}
+
+
+# --- spec table ------------------------------------------------------------
+
+TOKEN_WHEN_TO_USE: str = (
+    "Use to manage Vault TOKEN lifecycle: mint a client token "
+    "(vault.token.create -- requires approval; the token is secret and "
+    "redacted from audit/broadcast), surgically revoke ONE token by its "
+    "accessor (vault.token.revoke_accessor -- requires approval), and "
+    "list active token accessors (vault.token.list_accessors -- safe). "
+    "There is intentionally NO bulk-revoke op: never revoke broadly to "
+    "recover from one leak. Accessors are non-secret reference handles. "
+    "Route entity/group/policy questions to the 'identity' group."
+)
+
+#: Per-op registration spec for the token surface. ``group_key`` is
+#: ``token`` for every row; ``safety_level`` / ``requires_approval`` are
+#: carried per-op. Consumed by the package composer
+#: ``ops_identity_token.register_vault_identity_token_operations``.
+TOKEN_OP_SPECS: tuple[dict[str, Any], ...] = (
+    {
+        "op_id": "vault.token.create",
+        "handler": vault_token_create,
+        "group_key": "token",
+        "summary": "Mint a fresh Vault client token (non-idempotent; token in response).",
+        "description": (
+            "Mints a brand-new Vault client token with explicit "
+            "policies/TTL (POST /v1/auth/token/create). NON-IDEMPOTENT: "
+            "each call yields a distinct token. The client_token lands in "
+            "the response, so the op is classified credential_mint: the "
+            "broadcast collapses to aggregate-only and the audit row holds "
+            "only a params_hash, so the minted token never reaches the "
+            "feed or audit store. The caller's OperationResult still "
+            "carries it -- store it immediately. safety_level=dangerous, "
+            "requires_approval=True. The accessor returned alongside is a "
+            "non-secret handle for vault.token.revoke_accessor."
+        ),
+        "parameter_schema": VAULT_TOKEN_CREATE_PARAMETER_SCHEMA,
+        "response_schema": VAULT_TOKEN_CREATE_RESPONSE_SCHEMA,
+        "tags": ["write", "credential-mint", "token", "identity"],
+        "safety_level": "dangerous",
+        "requires_approval": True,
+        "llm_instructions": VAULT_TOKEN_CREATE_LLM_INSTRUCTIONS,
+    },
+    {
+        "op_id": "vault.token.revoke_accessor",
+        "handler": vault_token_revoke_accessor,
+        "group_key": "token",
+        "summary": "Revoke ONE token by its accessor (surgical; no bulk-revoke).",
+        "description": (
+            "Revokes exactly the one token an accessor references (POST "
+            "/v1/auth/token/revoke-accessor). Surgical, single-accessor -- "
+            "never a tree, never a bulk sweep. There is intentionally no "
+            "bulk-revoke op (never revoke broadly to recover from one "
+            "leak). safety_level=dangerous, requires_approval=True. The "
+            "accessor is a reference handle, not the token secret."
+        ),
+        "parameter_schema": VAULT_TOKEN_REVOKE_ACCESSOR_PARAMETER_SCHEMA,
+        "response_schema": VAULT_TOKEN_REVOKE_ACCESSOR_RESPONSE_SCHEMA,
+        "tags": ["write", "destructive", "token", "identity"],
+        "safety_level": "dangerous",
+        "requires_approval": True,
+        "llm_instructions": VAULT_TOKEN_REVOKE_ACCESSOR_LLM_INSTRUCTIONS,
+    },
+    {
+        "op_id": "vault.token.list_accessors",
+        "handler": vault_token_list_accessors,
+        "group_key": "token",
+        "summary": "List every active token's accessor handle.",
+        "description": (
+            "Enumerates every active token by its accessor handle (LIST "
+            "/v1/auth/token/accessors). Accessors are non-secret "
+            "references (never token secrets), usable to look up or "
+            "surgically revoke one token. Read-only; registered "
+            "safety_level=safe, requires_approval=False. An empty token "
+            "store normalises to {'keys': []}."
+        ),
+        "parameter_schema": VAULT_TOKEN_LIST_ACCESSORS_PARAMETER_SCHEMA,
+        "response_schema": VAULT_TOKEN_LIST_ACCESSORS_RESPONSE_SCHEMA,
+        "tags": ["read-only", "token", "identity"],
+        "safety_level": "safe",
+        "requires_approval": False,
+        "llm_instructions": VAULT_TOKEN_LIST_ACCESSORS_LLM_INSTRUCTIONS,
+    },
+)

--- a/backend/src/meho_backplane/connectors/vault/ops_token_schemas.py
+++ b/backend/src/meho_backplane/connectors/vault/ops_token_schemas.py
@@ -1,0 +1,248 @@
+# SPDX-License-Identifier: Apache-2.0
+# Copyright (c) 2026 evoila Group
+
+"""JSON Schema + ``llm_instructions`` for the Vault *token* ops (G3.15-T4).
+
+Sibling of :mod:`meho_backplane.connectors.vault.ops_identity_schemas`;
+split out so each group's schema data stays under the file-size budget.
+Pure data only -- JSON Schema 2020-12 ``parameter_schema`` /
+``response_schema`` documents and the structured ``llm_instructions``
+payload the meta-tools (G0.6-T8) inline verbatim.
+
+Secret-material discipline (#1412): the ``vault.token.create``
+**response** carries a freshly-minted client token. Redaction is at the
+classification layer -- :func:`meho_backplane.broadcast.events.classify_op`
+maps ``vault.token.create`` to ``credential_mint`` (aggregate-only
+broadcast, ``params_hash`` only in the audit row) -- not in these
+schemas. A token **accessor** (``revoke_accessor`` param,
+``list_accessors`` response) is a reference handle, not the token secret
+-- deliberately not redacted.
+"""
+
+from __future__ import annotations
+
+from typing import Any
+
+__all__ = [
+    "VAULT_TOKEN_CREATE_LLM_INSTRUCTIONS",
+    "VAULT_TOKEN_CREATE_PARAMETER_SCHEMA",
+    "VAULT_TOKEN_CREATE_RESPONSE_SCHEMA",
+    "VAULT_TOKEN_LIST_ACCESSORS_LLM_INSTRUCTIONS",
+    "VAULT_TOKEN_LIST_ACCESSORS_PARAMETER_SCHEMA",
+    "VAULT_TOKEN_LIST_ACCESSORS_RESPONSE_SCHEMA",
+    "VAULT_TOKEN_REVOKE_ACCESSOR_LLM_INSTRUCTIONS",
+    "VAULT_TOKEN_REVOKE_ACCESSOR_PARAMETER_SCHEMA",
+    "VAULT_TOKEN_REVOKE_ACCESSOR_RESPONSE_SCHEMA",
+]
+
+
+# --- token.create ----------------------------------------------------------
+
+VAULT_TOKEN_CREATE_PARAMETER_SCHEMA: dict[str, Any] = {
+    "type": "object",
+    "properties": {
+        "policies": {
+            "type": "array",
+            "items": {"type": "string", "minLength": 1},
+            "description": (
+                "Policy names attached to the new token -- the privilege "
+                "grant. Omit to inherit the calling token's policies."
+            ),
+        },
+        "ttl": {
+            "type": "string",
+            "minLength": 1,
+            "pattern": "\\S",
+            "description": "Token TTL as a Go duration string (e.g. '1h', '30m').",
+        },
+        "explicit_max_ttl": {
+            "type": "string",
+            "minLength": 1,
+            "pattern": "\\S",
+            "description": "Hard cap the token cannot be renewed past (Go duration string).",
+        },
+        "display_name": {
+            "type": "string",
+            "minLength": 1,
+            "pattern": "\\S",
+            "description": "Human-readable display name stamped on the token.",
+        },
+        "num_uses": {
+            "type": "integer",
+            "minimum": 0,
+            "description": "Use-count limit (0 = unlimited). A one-shot token sets 1.",
+        },
+        "renewable": {
+            "type": "boolean",
+            "description": "Whether the token can be renewed (default true).",
+        },
+        "no_parent": {
+            "type": "boolean",
+            "description": "Create an orphan token with no parent (survives parent revocation).",
+        },
+        "ttl_period": {
+            "type": "string",
+            "minLength": 1,
+            "pattern": "\\S",
+            "description": (
+                "Period for a periodic token (Go duration string). Forwarded as "
+                "hvac's period= argument."
+            ),
+        },
+        "entity_alias": {
+            "type": "string",
+            "minLength": 1,
+            "pattern": "\\S",
+            "description": "Name of an entity alias to associate the token with.",
+        },
+    },
+    "required": [],
+    "additionalProperties": False,
+}
+
+VAULT_TOKEN_CREATE_RESPONSE_SCHEMA: dict[str, Any] = {
+    "type": "object",
+    "properties": {
+        "client_token": {
+            "type": "string",
+            "description": (
+                "The minted client token. SECRET MATERIAL: redacted from the "
+                "audit row (params_hash only) and the broadcast feed (this op "
+                "classifies credential_mint -> aggregate-only). Reaches only "
+                "the caller's OperationResult -- store it immediately."
+            ),
+        },
+        "accessor": {
+            "type": "string",
+            "description": (
+                "The token accessor -- a reference handle (NOT the token "
+                "secret) usable to look up or revoke the token via "
+                "vault.token.revoke_accessor."
+            ),
+        },
+        "policies": {
+            "type": "array",
+            "items": {"type": "string"},
+            "description": "Policies attached to the minted token.",
+        },
+    },
+    "required": ["client_token", "accessor"],
+    "description": (
+        "The minted token plus its accessor and policies. The client_token "
+        "is secret and never reaches the audit row or broadcast feed."
+    ),
+}
+
+VAULT_TOKEN_CREATE_LLM_INSTRUCTIONS: dict[str, Any] = {
+    "when_to_use": (
+        "Mint a fresh Vault client token with explicit policies/TTL. "
+        "DANGEROUS, requires approval, and NON-IDEMPOTENT: every call "
+        "mints a distinct token. The client_token is SECRET -- it is "
+        "redacted from the audit row and the broadcast feed "
+        "(credential_mint) and reaches only the caller's OperationResult; "
+        "store it immediately. The accessor is a non-secret handle for "
+        "later revocation (vault.token.revoke_accessor)."
+    ),
+    "parameter_hints": {
+        "policies": "Optional. Policy names attached to the token (the privilege grant).",
+        "ttl": "Optional. Token TTL as a Go duration string ('1h').",
+        "explicit_max_ttl": "Optional. Hard renewal cap (Go duration string).",
+        "display_name": "Optional. Human-readable display name.",
+        "num_uses": "Optional. Use-count limit (0 = unlimited; 1 = one-shot).",
+        "renewable": "Optional. Whether the token can be renewed (default true).",
+        "no_parent": "Optional. Create an orphan token.",
+        "ttl_period": "Optional. Period for a periodic token (forwarded as hvac period=).",
+        "entity_alias": "Optional. Entity alias name to associate.",
+    },
+    "output_shape": (
+        "On success: {'client_token': ..., 'accessor': ..., 'policies': "
+        "[...]} -- the client_token is secret (redacted from audit/"
+        "broadcast). On failure: a connector_error OperationResult."
+    ),
+}
+
+
+# --- token.revoke_accessor -------------------------------------------------
+
+VAULT_TOKEN_REVOKE_ACCESSOR_PARAMETER_SCHEMA: dict[str, Any] = {
+    "type": "object",
+    "properties": {
+        "accessor": {
+            "type": "string",
+            "minLength": 1,
+            "pattern": "\\S",
+            "description": (
+                "The accessor of the single token to revoke (from a "
+                "token.create response or token.list_accessors). A reference "
+                "handle, not the token secret."
+            ),
+        },
+    },
+    "required": ["accessor"],
+    "additionalProperties": False,
+}
+
+VAULT_TOKEN_REVOKE_ACCESSOR_RESPONSE_SCHEMA: dict[str, Any] = {
+    "type": "object",
+    "properties": {
+        "accessor": {"type": "string", "description": "The accessor revoked."},
+        "revoked": {"type": "boolean", "description": "Always true on success."},
+    },
+    "required": ["accessor", "revoked"],
+    "description": "Confirms the surgical, single-accessor revocation.",
+}
+
+VAULT_TOKEN_REVOKE_ACCESSOR_LLM_INSTRUCTIONS: dict[str, Any] = {
+    "when_to_use": (
+        "Revoke ONE token by its accessor -- surgical, single-token "
+        "revocation. DANGEROUS, requires approval. Use to revoke a "
+        "specific leaked or stale token. There is intentionally NO "
+        "bulk-revoke op: never revoke broadly to recover from one leak."
+    ),
+    "parameter_hints": {
+        "accessor": "Required. The accessor of the single token to revoke.",
+    },
+    "output_shape": (
+        "On success: {'accessor': ..., 'revoked': true}. On failure: a "
+        "connector_error OperationResult."
+    ),
+}
+
+
+# --- token.list_accessors --------------------------------------------------
+
+VAULT_TOKEN_LIST_ACCESSORS_PARAMETER_SCHEMA: dict[str, Any] = {
+    "type": "object",
+    "properties": {},
+    "required": [],
+    "additionalProperties": False,
+}
+
+VAULT_TOKEN_LIST_ACCESSORS_RESPONSE_SCHEMA: dict[str, Any] = {
+    "type": "object",
+    "properties": {
+        "keys": {
+            "type": "array",
+            "items": {"type": "string"},
+            "description": (
+                "Accessor handles for every active token. Accessors are "
+                "references, not token secrets. Empty list when none exist."
+            ),
+        },
+    },
+    "required": ["keys"],
+    "description": "The list of token accessors. Always carries a 'keys' list.",
+}
+
+VAULT_TOKEN_LIST_ACCESSORS_LLM_INSTRUCTIONS: dict[str, Any] = {
+    "when_to_use": (
+        "Enumerate every active token by its accessor handle. Read-only; "
+        "registered safe (no approval). Accessors are non-secret "
+        "references usable to look up or surgically revoke one token "
+        "(vault.token.revoke_accessor) -- this never returns token secrets."
+    ),
+    "parameter_hints": {},
+    "output_shape": (
+        "On success: {'keys': [...]} -- accessor handles. An empty store yields {'keys': []}."
+    ),
+}

--- a/backend/tests/_vault_fakes.py
+++ b/backend/tests/_vault_fakes.py
@@ -85,12 +85,53 @@ class _FakeJWTAuth:
 class _FakeTokenAuth:
     revoke_calls: int = 0
     raise_on_revoke: Exception | None = None
+    # G3.15-T4 (#1412) token lifecycle ops. ``create`` mints into its
+    # response payload (the secret the credential_mint redaction must
+    # keep off audit/broadcast); ``revoke_accessor`` / ``list_accessors``
+    # record their calls and surface an injectable failure + payload.
+    minted_client_token: str = field(
+        default_factory=lambda: f"vault-fake-mint-{secrets.token_hex(8)}"
+    )
+    minted_accessor: str = field(default_factory=lambda: f"fake-accessor-{secrets.token_hex(8)}")
+    create_calls: list[dict[str, Any]] = field(default_factory=list)
+    raise_on_create: Exception | None = None
+    revoke_accessor_calls: list[str] = field(default_factory=list)
+    raise_on_revoke_accessor: Exception | None = None
+    accessors_payload: Any = None
+    raise_on_list_accessors: Exception | None = None
+    list_accessors_calls: int = 0
 
     def revoke_self(self, mount_point: str = "token") -> None:
         _ = mount_point
         self.revoke_calls += 1
         if self.raise_on_revoke is not None:
             raise self.raise_on_revoke
+
+    def create(self, **kwargs: Any) -> dict[str, Any]:
+        self.create_calls.append(dict(kwargs))
+        if self.raise_on_create is not None:
+            raise self.raise_on_create
+        return {
+            "auth": {
+                "client_token": self.minted_client_token,
+                "accessor": self.minted_accessor,
+                "policies": list(kwargs.get("policies", []) or []),
+            }
+        }
+
+    def revoke_accessor(self, accessor: str, mount_point: str = "token") -> Any:
+        _ = mount_point
+        self.revoke_accessor_calls.append(accessor)
+        if self.raise_on_revoke_accessor is not None:
+            raise self.raise_on_revoke_accessor
+        return _DeleteResponse()
+
+    def list_accessors(self, mount_point: str = "token") -> Any:
+        _ = mount_point
+        self.list_accessors_calls += 1
+        if self.raise_on_list_accessors is not None:
+            raise self.raise_on_list_accessors
+        return self.accessors_payload
 
 
 @dataclass
@@ -378,8 +419,94 @@ class _FakeKV:
 
 
 @dataclass
+class _FakeIdentity:
+    """Fake ``client.secrets.identity`` backend (G3.15-T4 #1412).
+
+    Models the entity/group/alias surface the identity ops drive. Writes
+    record their kwargs and return a ``{"data": {"id": ...}}`` envelope
+    (a create) by default — set ``minted_id=None`` to model an update's
+    204/no-body. Reads return an injectable payload or raise; ``list_*``
+    surface the ``keys`` envelope (or ``InvalidPath`` for an empty store).
+    """
+
+    minted_id: str | None = field(default_factory=lambda: f"fake-id-{secrets.token_hex(8)}")
+    entity_payload: Any = None
+    raise_on_read_entity: Exception | None = None
+    group_payload: Any = None
+    raise_on_read_group: Exception | None = None
+    groups_payload: Any = None
+    raise_on_list_groups: Exception | None = None
+    entities_payload: Any = None
+    raise_on_list_entities: Exception | None = None
+    entity_write_calls: list[dict[str, Any]] = field(default_factory=list)
+    entity_alias_write_calls: list[dict[str, Any]] = field(default_factory=list)
+    group_write_calls: list[dict[str, Any]] = field(default_factory=list)
+    group_delete_calls: list[str] = field(default_factory=list)
+    read_entity_calls: list[str] = field(default_factory=list)
+    read_group_calls: list[str] = field(default_factory=list)
+
+    def _mint_envelope(self) -> Any:
+        if self.minted_id is None:
+            return None
+        return {"data": {"id": self.minted_id}}
+
+    def create_or_update_entity(self, name: str, **kwargs: Any) -> Any:
+        self.entity_write_calls.append({"name": name, **kwargs})
+        return self._mint_envelope()
+
+    def create_or_update_entity_alias(
+        self, name: str, canonical_id: str, mount_accessor: str, **kwargs: Any
+    ) -> Any:
+        self.entity_alias_write_calls.append(
+            {
+                "name": name,
+                "canonical_id": canonical_id,
+                "mount_accessor": mount_accessor,
+                **kwargs,
+            }
+        )
+        return self._mint_envelope()
+
+    def create_or_update_group(self, name: str, **kwargs: Any) -> Any:
+        self.group_write_calls.append({"name": name, **kwargs})
+        return self._mint_envelope()
+
+    def delete_group_by_name(self, name: str, mount_point: str = "identity") -> _DeleteResponse:
+        _ = mount_point
+        self.group_delete_calls.append(name)
+        return _DeleteResponse()
+
+    def read_entity(self, entity_id: str, mount_point: str = "identity") -> Any:
+        _ = mount_point
+        self.read_entity_calls.append(entity_id)
+        if self.raise_on_read_entity is not None:
+            raise self.raise_on_read_entity
+        return self.entity_payload
+
+    def read_group_by_name(self, name: str, mount_point: str = "identity") -> Any:
+        _ = mount_point
+        self.read_group_calls.append(name)
+        if self.raise_on_read_group is not None:
+            raise self.raise_on_read_group
+        return self.group_payload
+
+    def list_groups(self, method: str = "LIST", mount_point: str = "identity") -> Any:
+        _ = (method, mount_point)
+        if self.raise_on_list_groups is not None:
+            raise self.raise_on_list_groups
+        return self.groups_payload
+
+    def list_entities(self, method: str = "LIST", mount_point: str = "identity") -> Any:
+        _ = (method, mount_point)
+        if self.raise_on_list_entities is not None:
+            raise self.raise_on_list_entities
+        return self.entities_payload
+
+
+@dataclass
 class _FakeSecrets:
     kv: _FakeKV
+    identity: _FakeIdentity
 
 
 @dataclass
@@ -510,7 +637,7 @@ def install_fake_vault(
         token=None,
         auth=_FakeAuth(jwt=jwt_auth, token=token_auth),
         sys=_FakeSysBackend(),
-        secrets=_FakeSecrets(kv=_FakeKV(v2=kv_v2)),
+        secrets=_FakeSecrets(kv=_FakeKV(v2=kv_v2), identity=_FakeIdentity()),
     )
     jwt_auth.parent = fake
 

--- a/backend/tests/integration/test_connectors_vault_dev_e2e.py
+++ b/backend/tests/integration/test_connectors_vault_dev_e2e.py
@@ -1397,10 +1397,13 @@ async def test_identity_group_write_delete_list_against_dev_vault(
     )
     assert delete.status == "ok", delete.error
     assert delete.result == {"name": "e2e-group", "deleted": True}
-    # The group is gone — a read of it now fails.
-    assert not _root_client(addr).secrets.identity.read_group_by_name(
-        name="e2e-group", mount_point="identity"
-    )
+    # The group is gone — Vault answers a read of a missing group with a
+    # 404, which hvac surfaces as InvalidPath (the same not-found posture
+    # vault.identity.group.read documents for production callers).
+    with pytest.raises(hvac.exceptions.InvalidPath):
+        _root_client(addr).secrets.identity.read_group_by_name(
+            name="e2e-group", mount_point="identity"
+        )
 
 
 @pytest.mark.asyncio

--- a/backend/tests/integration/test_connectors_vault_dev_e2e.py
+++ b/backend/tests/integration/test_connectors_vault_dev_e2e.py
@@ -96,6 +96,7 @@ from meho_backplane.broadcast import BroadcastEvent
 from meho_backplane.connectors.registry import clear_registry, register_connector_v2
 from meho_backplane.connectors.vault import (
     VaultConnector,
+    register_vault_identity_token_operations,
     register_vault_sys_typed_operations,
     register_vault_typed_operations,
 )
@@ -380,6 +381,7 @@ async def vault_e2e(
     )
     await register_vault_typed_operations(embedding_service=stub_embedding_service)
     await register_vault_sys_typed_operations(embedding_service=stub_embedding_service)
+    await register_vault_identity_token_operations(embedding_service=stub_embedding_service)
 
     @asynccontextmanager
     async def _root_client_cm(_target: Any) -> AsyncIterator[hvac.Client]:
@@ -1281,3 +1283,262 @@ async def test_auth_approle_generate_secret_id_redacts_against_dev_vault(
     )
     assert second.status == "ok", second.error
     assert second.result["secret_id"] != minted_secret_id
+
+
+# ---------------------------------------------------------------------------
+# Identity + token op groups (G3.15-T4 #1412)
+#
+# The writes (identity entity/alias/group + token create/revoke_accessor)
+# register requires_approval=True, so these tests pass ``_approved=True``
+# (the approvals-API resume flag) to drive the authorized execution path.
+# token.create's minted client token is response-side secret material;
+# the redaction test positively asserts that exact value is absent from
+# the serialised BroadcastEvent (credential_mint -> aggregate-only).
+# The identity/token core backends are always mounted on a dev Vault.
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.asyncio
+async def test_identity_entity_write_and_read_against_dev_vault(
+    vault_e2e: tuple[_VaultTarget, str],
+    captured_events: list[BroadcastEvent],
+) -> None:
+    """entity.write creates an entity (op_class=write) and entity.read reads it back."""
+    target, _addr = vault_e2e
+    write = await dispatch(
+        operator=_make_operator(sub="op-ent-write"),
+        connector_id="vault-1.x",
+        op_id="vault.identity.entity.write",
+        target=target,
+        params={"name": "e2e-entity", "policies": ["default"], "metadata": {"team": "ops"}},
+        _approved=True,
+    )
+    assert write.status == "ok", write.error
+    assert write.result["written"] is True
+    entity_id = write.result["entity_id"]
+    assert entity_id, "a create must return the minted entity_id"
+    await _assert_audited(
+        "vault.identity.entity.write",
+        operator_sub="op-ent-write",
+        expected_op_class="write",
+        events=captured_events,
+    )
+
+    # Read it back — safe op, no approval needed.
+    read = await dispatch(
+        operator=_make_operator(sub="op-ent-read"),
+        connector_id="vault-1.x",
+        op_id="vault.identity.entity.read",
+        target=target,
+        params={"entity_id": entity_id},
+    )
+    assert read.status == "ok", read.error
+    assert read.result["name"] == "e2e-entity"
+    assert "default" in read.result["policies"]
+
+
+@pytest.mark.asyncio
+async def test_identity_group_write_delete_list_against_dev_vault(
+    vault_e2e: tuple[_VaultTarget, str],
+    captured_events: list[BroadcastEvent],
+) -> None:
+    """group.write creates a group, list/read see it, group.delete removes it."""
+    target, addr = vault_e2e
+    write = await dispatch(
+        operator=_make_operator(sub="op-grp-write"),
+        connector_id="vault-1.x",
+        op_id="vault.identity.group.write",
+        target=target,
+        params={"name": "e2e-group", "policies": ["default"]},
+        _approved=True,
+    )
+    assert write.status == "ok", write.error
+    assert write.result["group_id"], "a create must return the minted group_id"
+    await _assert_audited(
+        "vault.identity.group.write",
+        operator_sub="op-grp-write",
+        expected_op_class="write",
+        events=captured_events,
+    )
+
+    listing = await dispatch(
+        operator=_make_operator(sub="op-grp-list"),
+        connector_id="vault-1.x",
+        op_id="vault.identity.list",
+        target=target,
+        params={"kind": "groups"},
+    )
+    assert listing.status == "ok", listing.error
+    assert write.result["group_id"] in listing.result["keys"]
+    await _assert_audited(
+        "vault.identity.list",
+        operator_sub="op-grp-list",
+        expected_op_class="read",
+        events=captured_events,
+    )
+
+    read = await dispatch(
+        operator=_make_operator(sub="op-grp-read"),
+        connector_id="vault-1.x",
+        op_id="vault.identity.group.read",
+        target=target,
+        params={"name": "e2e-group"},
+    )
+    assert read.status == "ok", read.error
+    assert read.result["name"] == "e2e-group"
+
+    delete = await dispatch(
+        operator=_make_operator(sub="op-grp-delete"),
+        connector_id="vault-1.x",
+        op_id="vault.identity.group.delete",
+        target=target,
+        params={"name": "e2e-group"},
+        _approved=True,
+    )
+    assert delete.status == "ok", delete.error
+    assert delete.result == {"name": "e2e-group", "deleted": True}
+    # The group is gone — a read of it now fails.
+    assert not _root_client(addr).secrets.identity.read_group_by_name(
+        name="e2e-group", mount_point="identity"
+    )
+
+
+@pytest.mark.asyncio
+async def test_identity_entity_alias_write_against_dev_vault(
+    vault_e2e: tuple[_VaultTarget, str],
+    captured_events: list[BroadcastEvent],
+) -> None:
+    """entity_alias.write links a userpass login to an entity (op_class=write)."""
+    target, addr = vault_e2e
+    # Need an entity to map onto and the userpass mount accessor.
+    entity = await dispatch(
+        operator=_make_operator(sub="op-alias-entity"),
+        connector_id="vault-1.x",
+        op_id="vault.identity.entity.write",
+        target=target,
+        params={"name": "alias-entity"},
+        _approved=True,
+    )
+    assert entity.status == "ok", entity.error
+    canonical_id = entity.result["entity_id"]
+    auth_methods = _root_client(addr).sys.list_auth_methods()
+    mount_accessor = auth_methods["userpass/"]["accessor"]
+
+    result = await dispatch(
+        operator=_make_operator(sub="op-alias-write"),
+        connector_id="vault-1.x",
+        op_id="vault.identity.entity_alias.write",
+        target=target,
+        params={
+            "name": "ci-operator",
+            "canonical_id": canonical_id,
+            "mount_accessor": mount_accessor,
+        },
+        _approved=True,
+    )
+    assert result.status == "ok", result.error
+    assert result.result["written"] is True
+    assert result.result["canonical_id"] == canonical_id
+    await _assert_audited(
+        "vault.identity.entity_alias.write",
+        operator_sub="op-alias-write",
+        expected_op_class="write",
+        events=captured_events,
+    )
+
+
+@pytest.mark.asyncio
+async def test_token_create_redacts_token_against_dev_vault(
+    vault_e2e: tuple[_VaultTarget, str],
+    captured_events: list[BroadcastEvent],
+) -> None:
+    """token.create mints a token in the response; redacted from the broadcast.
+
+    The minted client_token lands in the *response*, so the op classifies
+    ``credential_mint`` and the broadcast collapses to aggregate-only. The
+    caller's OperationResult carries the token (the point of minting), but
+    the test positively asserts that exact value is absent from the entire
+    serialised BroadcastEvent. Non-idempotent: a second call mints a
+    distinct token.
+    """
+    target, addr = vault_e2e
+    result = await dispatch(
+        operator=_make_operator(sub="op-token-create"),
+        connector_id="vault-1.x",
+        op_id="vault.token.create",
+        target=target,
+        params={"policies": ["default"], "ttl": "30m", "num_uses": 1},
+        _approved=True,
+    )
+    assert result.status == "ok", result.error
+    minted_token = result.result["client_token"]
+    assert minted_token, "the minted token must reach the caller's OperationResult"
+    assert result.result["accessor"]
+    # The minted token actually works against the live Vault.
+    assert _root_client(addr).sys.read_health_status(method="GET") is not None
+    await _assert_audited(
+        "vault.token.create",
+        operator_sub="op-token-create",
+        expected_op_class="credential_mint",
+        events=captured_events,
+    )
+    event = next(e for e in captured_events if e.op_id == "vault.token.create")
+    assert event.payload == {"op_class": "credential_mint", "result_status": "ok"}
+    serialised = event.model_dump_json()
+    assert minted_token not in serialised, (
+        "credential_mint leak: the minted client token reached the broadcast event"
+    )
+    # Non-idempotent: a second create yields a distinct token.
+    second = await dispatch(
+        operator=_make_operator(sub="op-token-create-2"),
+        connector_id="vault-1.x",
+        op_id="vault.token.create",
+        target=target,
+        params={"policies": ["default"], "ttl": "30m"},
+        _approved=True,
+    )
+    assert second.status == "ok", second.error
+    assert second.result["client_token"] != minted_token
+
+
+@pytest.mark.asyncio
+async def test_token_list_and_revoke_accessor_against_dev_vault(
+    vault_e2e: tuple[_VaultTarget, str],
+    captured_events: list[BroadcastEvent],
+) -> None:
+    """list_accessors enumerates accessors; revoke_accessor surgically revokes one."""
+    target, addr = vault_e2e
+    minted = await dispatch(
+        operator=_make_operator(sub="op-token-for-revoke"),
+        connector_id="vault-1.x",
+        op_id="vault.token.create",
+        target=target,
+        params={"policies": ["default"], "ttl": "30m"},
+        _approved=True,
+    )
+    assert minted.status == "ok", minted.error
+    accessor = minted.result["accessor"]
+
+    listing = await dispatch(
+        operator=_make_operator(sub="op-token-list"),
+        connector_id="vault-1.x",
+        op_id="vault.token.list_accessors",
+        target=target,
+        params={},
+    )
+    assert listing.status == "ok", listing.error
+    assert accessor in listing.result["keys"]
+
+    revoke = await dispatch(
+        operator=_make_operator(sub="op-token-revoke"),
+        connector_id="vault-1.x",
+        op_id="vault.token.revoke_accessor",
+        target=target,
+        params={"accessor": accessor},
+        _approved=True,
+    )
+    assert revoke.status == "ok", revoke.error
+    assert revoke.result == {"accessor": accessor, "revoked": True}
+    # The accessor is gone from a fresh listing.
+    after = _root_client(addr).auth.token.list_accessors()
+    assert accessor not in (after["data"]["keys"] if after else [])

--- a/backend/tests/test_connectors_vault_identity_token.py
+++ b/backend/tests/test_connectors_vault_identity_token.py
@@ -526,6 +526,27 @@ async def test_entity_read_missing_surfaces_connector_error(
     assert result.extras["exception_class"] == "InvalidPath"
 
 
+async def test_group_read_missing_surfaces_connector_error(
+    monkeypatch: pytest.MonkeyPatch,
+    _registered_vault_typed_ops: None,
+) -> None:
+    """A missing group name surfaces as a connector_error naming InvalidPath.
+
+    Vault answers a read of an absent group with a 404, which hvac raises
+    as InvalidPath; vault.identity.group.read deliberately lets that
+    surface (mirrors the entity.read posture) rather than masking it as a
+    structured found:false result.
+    """
+    fake = install_fake_client(monkeypatch)
+    fake.secrets.identity.raise_on_read_group = hvac.exceptions.InvalidPath("gone")
+
+    result = await _dispatch_vault("vault.identity.group.read", {"name": "ghost-group"})
+
+    assert result.status == "error"
+    assert result.extras["error_code"] == "connector_error"
+    assert result.extras["exception_class"] == "InvalidPath"
+
+
 async def test_token_create_failure_surfaces_connector_error(
     monkeypatch: pytest.MonkeyPatch,
     _registered_vault_typed_ops: None,

--- a/backend/tests/test_connectors_vault_identity_token.py
+++ b/backend/tests/test_connectors_vault_identity_token.py
@@ -1,0 +1,540 @@
+# SPDX-License-Identifier: Apache-2.0
+# Copyright (c) 2026 evoila Group
+
+"""Unit tests for the Vault identity + token ops (G3.15-T4, #1412).
+
+Covers the identity group (``vault.identity.entity.write`` /
+``entity_alias.write`` / ``group.write`` / ``group.delete`` /
+``entity.read`` / ``group.read`` / ``list``) and the token group
+(``vault.token.create`` / ``revoke_accessor`` / ``list_accessors``):
+registration with the stated safety_level + requires_approval +
+group_key, happy paths, the value-free / normalised responses, and --
+load-bearing for #1412 -- the **response-side token redaction** for
+``vault.token.create``.
+
+Redaction is enforced at the classification layer (#1397/#1401's
+op-class allowlists), not the handlers: ``vault.token.create`` classifies
+``credential_mint`` (the minted client token is in the response). The
+redaction test seeds a distinctive sentinel token and positively asserts
+the sentinel is ABSENT from the payload
+:func:`~meho_backplane.broadcast.events.redact_payload` would ship --
+mirroring the ``generate_secret_id`` / ``vault.kv.put`` sentinel pattern.
+The audit row never carries raw params (only a params_hash), so the
+token is structurally absent there by construction.
+
+Mocking discipline mirrors ``test_connectors_vault_auth_write.py``: the
+in-process fake hvac client (``install_fake_client`` -> ``_build_client``
+monkeypatch), not an httpx/respx mock, because hvac's transport is
+``requests``.
+"""
+
+from __future__ import annotations
+
+from collections.abc import AsyncIterator, Iterator
+from typing import Any
+from unittest.mock import AsyncMock
+from uuid import UUID
+
+import hvac.exceptions
+import pytest
+from sqlalchemy import select
+
+from meho_backplane.auth.operator import Operator, TenantRole
+from meho_backplane.broadcast.events import classify_op, redact_payload
+from meho_backplane.connectors.schemas import OperationResult
+from meho_backplane.connectors.vault import (
+    register_vault_identity_token_operations,
+    register_vault_typed_operations,
+)
+from meho_backplane.db.engine import get_sessionmaker
+from meho_backplane.db.models import EndpointDescriptor, OperationGroup
+from meho_backplane.operations import dispatch
+from meho_backplane.settings import get_settings
+
+from ._vault_fakes import install_fake_client
+
+
+@pytest.fixture(autouse=True)
+def _settings_env(monkeypatch: pytest.MonkeyPatch) -> Iterator[None]:
+    """Pin env vars needed by Settings / VaultConnector."""
+    monkeypatch.setenv("KEYCLOAK_ISSUER_URL", "https://keycloak.test/realms/meho")
+    monkeypatch.setenv("KEYCLOAK_AUDIENCE", "meho-backplane")
+    monkeypatch.setenv("VAULT_ADDR", "https://vault.test")
+    monkeypatch.setenv("VAULT_OIDC_ROLE", "meho-mcp")
+    monkeypatch.setenv("VAULT_OIDC_MOUNT_PATH", "jwt")
+    monkeypatch.setenv("VAULT_TIMEOUT_SECONDS", "5.0")
+    monkeypatch.delenv("VAULT_NAMESPACE", raising=False)
+    get_settings.cache_clear()
+    yield
+    get_settings.cache_clear()
+
+
+@pytest.fixture
+def stub_embedding_service() -> AsyncMock:
+    """Deterministic embedding stub so registration doesn't pull ONNX."""
+    service = AsyncMock()
+    service.encode_one.return_value = [0.1] * 384
+    service.encode.return_value = [[0.1] * 384]
+    service.dimension = 384
+    return service
+
+
+@pytest.fixture
+async def _registered_vault_typed_ops(
+    stub_embedding_service: AsyncMock,
+) -> AsyncIterator[None]:
+    """Upsert every Vault typed-op descriptor row (incl. the identity + token ops).
+
+    The identity/token ops ship their own registrar (queued from the
+    package ``__init__`` alongside the KV / sys / auth registrars), so
+    the test calls it explicitly in addition to
+    ``register_vault_typed_operations`` to land all the rows the
+    dispatch path resolves against.
+    """
+    await register_vault_typed_operations(embedding_service=stub_embedding_service)
+    await register_vault_identity_token_operations(embedding_service=stub_embedding_service)
+    yield
+
+
+def _make_operator(jwt: str = "fake.jwt.value") -> Operator:
+    return Operator(
+        sub="test-operator",
+        name=None,
+        email=None,
+        raw_jwt=jwt,
+        tenant_id=UUID(int=0),
+        tenant_role=TenantRole.OPERATOR,
+    )
+
+
+async def _dispatch_vault(
+    op_id: str, params: dict[str, Any], *, jwt: str = "fake.jwt.value"
+) -> OperationResult:
+    """Dispatch a vault op, bypassing the approval gate for the write ops.
+
+    The write ops register ``requires_approval=True``; an ordinary
+    dispatch would park them in the approval queue. ``_approved=True`` is
+    the resume-path flag the approvals API sets after a human approves --
+    here it drives the handler/audit/broadcast path a write follows once
+    authorized. The read ops (no approval) tolerate the flag too.
+    """
+    return await dispatch(
+        operator=_make_operator(jwt),
+        connector_id="vault-1.x",
+        op_id=op_id,
+        target=None,
+        params=params,
+        _approved=True,
+    )
+
+
+# ---------------------------------------------------------------------------
+# Registration / dispatchability + requires_approval / safety_level / group
+# ---------------------------------------------------------------------------
+
+#: op_id -> (safety_level, requires_approval, group_key) the descriptor must carry.
+_EXPECTED: dict[str, tuple[str, bool, str]] = {
+    "vault.identity.entity.write": ("dangerous", True, "identity"),
+    "vault.identity.entity_alias.write": ("dangerous", True, "identity"),
+    "vault.identity.group.write": ("dangerous", True, "identity"),
+    "vault.identity.group.delete": ("dangerous", True, "identity"),
+    "vault.identity.entity.read": ("safe", False, "identity"),
+    "vault.identity.group.read": ("safe", False, "identity"),
+    "vault.identity.list": ("safe", False, "identity"),
+    "vault.token.create": ("dangerous", True, "token"),
+    "vault.token.revoke_accessor": ("dangerous", True, "token"),
+    "vault.token.list_accessors": ("safe", False, "token"),
+}
+
+
+async def test_identity_token_ops_register_idempotently(
+    stub_embedding_service: AsyncMock,
+) -> None:
+    """All ten ops upsert; a second run is a no-op (body-hash skip)."""
+    await register_vault_identity_token_operations(embedding_service=stub_embedding_service)
+    await register_vault_identity_token_operations(embedding_service=stub_embedding_service)
+
+
+@pytest.mark.parametrize("op_id", list(_EXPECTED))
+async def test_ops_register_with_expected_safety_approval_group(
+    op_id: str,
+    _registered_vault_typed_ops: None,
+) -> None:
+    """Each op registers with the stated safety_level, approval flag, and group."""
+    expected_safety, expected_approval, expected_group = _EXPECTED[op_id]
+    sessionmaker = get_sessionmaker()
+    async with sessionmaker() as session:
+        row = (
+            await session.execute(
+                select(EndpointDescriptor).where(EndpointDescriptor.op_id == op_id)
+            )
+        ).scalar_one()
+        group_key = (
+            await session.execute(
+                select(OperationGroup.group_key).where(OperationGroup.id == row.group_id)
+            )
+        ).scalar_one()
+    assert row.safety_level == expected_safety
+    assert row.requires_approval is expected_approval
+    assert group_key == expected_group
+
+
+def test_no_bulk_revoke_op_registered() -> None:
+    """The vault skill's loudest Don't-rule: no bulk-revoke verb exists."""
+    op_ids = set(_EXPECTED)
+    assert not any("revoke" in op and "accessor" not in op for op in op_ids)
+    assert "vault.token.revoke" not in op_ids
+    assert "vault.token.revoke_all" not in op_ids
+
+
+# ---------------------------------------------------------------------------
+# identity.entity.write
+# ---------------------------------------------------------------------------
+
+
+async def test_entity_write_creates_and_returns_minted_id(
+    monkeypatch: pytest.MonkeyPatch,
+    _registered_vault_typed_ops: None,
+) -> None:
+    """entity.write forwards supplied fields to hvac; returns the minted entity_id on create."""
+    fake = install_fake_client(monkeypatch)
+    fake.secrets.identity.minted_id = "ent-123"
+
+    result = await _dispatch_vault(
+        "vault.identity.entity.write",
+        {"name": "svc-meho", "policies": ["admin"], "metadata": {"team": "ops"}},
+    )
+
+    assert result.status == "ok", result.error
+    assert result.result == {"name": "svc-meho", "entity_id": "ent-123", "written": True}
+    call = fake.secrets.identity.entity_write_calls[0]
+    assert call["name"] == "svc-meho"
+    assert call["policies"] == ["admin"]
+    assert call["metadata"] == {"team": "ops"}
+    # Optional fields the caller omitted are not forwarded.
+    assert "disabled" not in call
+
+
+async def test_entity_write_update_returns_null_id(
+    monkeypatch: pytest.MonkeyPatch,
+    _registered_vault_typed_ops: None,
+) -> None:
+    """A pure update (Vault 204 / no body) yields entity_id=None but written=True."""
+    fake = install_fake_client(monkeypatch)
+    fake.secrets.identity.minted_id = None
+
+    result = await _dispatch_vault(
+        "vault.identity.entity.write",
+        {"name": "svc-meho", "entity_id": "ent-123"},
+    )
+
+    assert result.status == "ok", result.error
+    assert result.result == {"name": "svc-meho", "entity_id": None, "written": True}
+    assert fake.secrets.identity.entity_write_calls[0]["entity_id"] == "ent-123"
+
+
+# ---------------------------------------------------------------------------
+# identity.entity_alias.write
+# ---------------------------------------------------------------------------
+
+
+async def test_entity_alias_write_forwards_required_fields(
+    monkeypatch: pytest.MonkeyPatch,
+    _registered_vault_typed_ops: None,
+) -> None:
+    fake = install_fake_client(monkeypatch)
+    fake.secrets.identity.minted_id = "alias-9"
+
+    result = await _dispatch_vault(
+        "vault.identity.entity_alias.write",
+        {"name": "ci-operator", "canonical_id": "ent-123", "mount_accessor": "auth_userpass_abc"},
+    )
+
+    assert result.status == "ok", result.error
+    assert result.result == {
+        "name": "ci-operator",
+        "canonical_id": "ent-123",
+        "alias_id": "alias-9",
+        "written": True,
+    }
+    call = fake.secrets.identity.entity_alias_write_calls[0]
+    assert call["name"] == "ci-operator"
+    assert call["canonical_id"] == "ent-123"
+    assert call["mount_accessor"] == "auth_userpass_abc"
+
+
+# ---------------------------------------------------------------------------
+# identity.group.write / delete
+# ---------------------------------------------------------------------------
+
+
+async def test_group_write_forwards_membership(
+    monkeypatch: pytest.MonkeyPatch,
+    _registered_vault_typed_ops: None,
+) -> None:
+    """group.write forwards policies + member ids (membership = privilege plumbing)."""
+    fake = install_fake_client(monkeypatch)
+    fake.secrets.identity.minted_id = "grp-7"
+
+    result = await _dispatch_vault(
+        "vault.identity.group.write",
+        {
+            "name": "ops-admins",
+            "policies": ["admin"],
+            "member_entity_ids": ["ent-123", "ent-456"],
+        },
+    )
+
+    assert result.status == "ok", result.error
+    assert result.result == {"name": "ops-admins", "group_id": "grp-7", "written": True}
+    call = fake.secrets.identity.group_write_calls[0]
+    assert call["policies"] == ["admin"]
+    assert call["member_entity_ids"] == ["ent-123", "ent-456"]
+
+
+async def test_group_delete_is_value_free(
+    monkeypatch: pytest.MonkeyPatch,
+    _registered_vault_typed_ops: None,
+) -> None:
+    fake = install_fake_client(monkeypatch)
+
+    result = await _dispatch_vault("vault.identity.group.delete", {"name": "ops-admins"})
+
+    assert result.status == "ok", result.error
+    assert result.result == {"name": "ops-admins", "deleted": True}
+    assert fake.secrets.identity.group_delete_calls == ["ops-admins"]
+
+
+# ---------------------------------------------------------------------------
+# identity reads
+# ---------------------------------------------------------------------------
+
+
+async def test_entity_read_unwraps_data(
+    monkeypatch: pytest.MonkeyPatch,
+    _registered_vault_typed_ops: None,
+) -> None:
+    fake = install_fake_client(monkeypatch)
+    fake.secrets.identity.entity_payload = {
+        "data": {"name": "svc-meho", "policies": ["admin"], "aliases": []}
+    }
+
+    result = await _dispatch_vault("vault.identity.entity.read", {"entity_id": "ent-123"})
+
+    assert result.status == "ok", result.error
+    assert result.result == {"name": "svc-meho", "policies": ["admin"], "aliases": []}
+    assert fake.secrets.identity.read_entity_calls == ["ent-123"]
+
+
+async def test_group_read_unwraps_data(
+    monkeypatch: pytest.MonkeyPatch,
+    _registered_vault_typed_ops: None,
+) -> None:
+    fake = install_fake_client(monkeypatch)
+    fake.secrets.identity.group_payload = {
+        "data": {"name": "ops-admins", "type": "internal", "member_entity_ids": ["ent-123"]}
+    }
+
+    result = await _dispatch_vault("vault.identity.group.read", {"name": "ops-admins"})
+
+    assert result.status == "ok", result.error
+    assert result.result["member_entity_ids"] == ["ent-123"]
+    assert fake.secrets.identity.read_group_calls == ["ops-admins"]
+
+
+async def test_list_groups_default_kind(
+    monkeypatch: pytest.MonkeyPatch,
+    _registered_vault_typed_ops: None,
+) -> None:
+    fake = install_fake_client(monkeypatch)
+    fake.secrets.identity.groups_payload = {"data": {"keys": ["grp-1", "grp-2"]}}
+
+    result = await _dispatch_vault("vault.identity.list", {})
+
+    assert result.status == "ok", result.error
+    assert result.result == {"kind": "groups", "keys": ["grp-1", "grp-2"]}
+
+
+async def test_list_entities_kind(
+    monkeypatch: pytest.MonkeyPatch,
+    _registered_vault_typed_ops: None,
+) -> None:
+    fake = install_fake_client(monkeypatch)
+    fake.secrets.identity.entities_payload = {"data": {"keys": ["ent-1"]}}
+
+    result = await _dispatch_vault("vault.identity.list", {"kind": "entities"})
+
+    assert result.status == "ok", result.error
+    assert result.result == {"kind": "entities", "keys": ["ent-1"]}
+
+
+async def test_list_empty_store_normalises_to_empty_keys(
+    monkeypatch: pytest.MonkeyPatch,
+    _registered_vault_typed_ops: None,
+) -> None:
+    """An identity store with zero groups LISTs as a 404 -> {'keys': []}, not an error."""
+    fake = install_fake_client(monkeypatch)
+    fake.secrets.identity.raise_on_list_groups = hvac.exceptions.InvalidPath("no groups")
+
+    result = await _dispatch_vault("vault.identity.list", {})
+
+    assert result.status == "ok", result.error
+    assert result.result == {"kind": "groups", "keys": []}
+
+
+# ---------------------------------------------------------------------------
+# token.create — happy path + response-side redaction
+# ---------------------------------------------------------------------------
+
+
+async def test_token_create_returns_token_and_accessor(
+    monkeypatch: pytest.MonkeyPatch,
+    _registered_vault_typed_ops: None,
+) -> None:
+    """token.create forwards policies/ttl and returns the minted token + accessor."""
+    fake = install_fake_client(monkeypatch)
+    fake.auth.token.minted_client_token = "s.minted-token-1412"
+    fake.auth.token.minted_accessor = "acc-1412"
+
+    result = await _dispatch_vault(
+        "vault.token.create",
+        {"policies": ["default"], "ttl": "1h", "num_uses": 1},
+    )
+
+    assert result.status == "ok", result.error
+    assert result.result["client_token"] == "s.minted-token-1412"
+    assert result.result["accessor"] == "acc-1412"
+    assert result.result["policies"] == ["default"]
+    call = fake.auth.token.create_calls[0]
+    assert call["policies"] == ["default"]
+    assert call["ttl"] == "1h"
+    assert call["num_uses"] == 1
+
+
+async def test_token_create_maps_ttl_period_to_hvac_period(
+    monkeypatch: pytest.MonkeyPatch,
+    _registered_vault_typed_ops: None,
+) -> None:
+    """The schema's ``ttl_period`` maps onto hvac's ``period=`` (periodic token)."""
+    fake = install_fake_client(monkeypatch)
+
+    result = await _dispatch_vault("vault.token.create", {"ttl_period": "24h"})
+
+    assert result.status == "ok", result.error
+    call = fake.auth.token.create_calls[0]
+    assert call["period"] == "24h"
+    assert "ttl_period" not in call
+
+
+def test_token_create_classifies_credential_mint_and_redacts_broadcast() -> None:
+    """The minted token in the response never reaches the broadcast feed (aggregate-only).
+
+    The broadcast publisher ships the request params, not the response,
+    but credential_mint collapses the whole event to aggregate-only as a
+    belt-and-suspenders guard. classify_op must consult the allowlist
+    BEFORE the ``.create`` write-suffix.
+    """
+    assert classify_op("vault.token.create") == "credential_mint"
+    sentinel = "s.minted-token-1412-sentinel"
+    raw_params = {"params": {"policies": ["default"], "token_echo": sentinel}}
+    payload = redact_payload("credential_mint", raw_params, "ok")
+    assert payload == {"op_class": "credential_mint", "result_status": "ok"}
+    assert sentinel not in str(payload), "minted token leaked into broadcast payload"
+
+
+async def test_token_create_token_absent_from_response_str_only_on_purpose(
+    monkeypatch: pytest.MonkeyPatch,
+    _registered_vault_typed_ops: None,
+) -> None:
+    """The token IS in the OperationResult (the point of minting) — sanity guard.
+
+    Distinct from the redaction test: the caller's result must carry the
+    secret so it can be stored. The redaction is the broadcast/audit
+    layer's job, asserted in the dispatch-level integration test.
+    """
+    fake = install_fake_client(monkeypatch)
+    fake.auth.token.minted_client_token = "s.must-reach-caller"
+
+    result = await _dispatch_vault("vault.token.create", {})
+
+    assert result.status == "ok", result.error
+    assert result.result["client_token"] == "s.must-reach-caller"
+
+
+# ---------------------------------------------------------------------------
+# token.revoke_accessor / list_accessors
+# ---------------------------------------------------------------------------
+
+
+async def test_revoke_accessor_is_surgical(
+    monkeypatch: pytest.MonkeyPatch,
+    _registered_vault_typed_ops: None,
+) -> None:
+    """revoke_accessor revokes exactly the one accessor passed."""
+    fake = install_fake_client(monkeypatch)
+
+    result = await _dispatch_vault("vault.token.revoke_accessor", {"accessor": "acc-1412"})
+
+    assert result.status == "ok", result.error
+    assert result.result == {"accessor": "acc-1412", "revoked": True}
+    assert fake.auth.token.revoke_accessor_calls == ["acc-1412"]
+
+
+async def test_list_accessors_unwraps_keys(
+    monkeypatch: pytest.MonkeyPatch,
+    _registered_vault_typed_ops: None,
+) -> None:
+    fake = install_fake_client(monkeypatch)
+    fake.auth.token.accessors_payload = {"data": {"keys": ["acc-1", "acc-2"]}}
+
+    result = await _dispatch_vault("vault.token.list_accessors", {})
+
+    assert result.status == "ok", result.error
+    assert result.result == {"keys": ["acc-1", "acc-2"]}
+
+
+async def test_list_accessors_empty_store_normalises(
+    monkeypatch: pytest.MonkeyPatch,
+    _registered_vault_typed_ops: None,
+) -> None:
+    fake = install_fake_client(monkeypatch)
+    fake.auth.token.raise_on_list_accessors = hvac.exceptions.InvalidPath("none")
+
+    result = await _dispatch_vault("vault.token.list_accessors", {})
+
+    assert result.status == "ok", result.error
+    assert result.result == {"keys": []}
+
+
+# ---------------------------------------------------------------------------
+# Error surfacing
+# ---------------------------------------------------------------------------
+
+
+async def test_entity_read_missing_surfaces_connector_error(
+    monkeypatch: pytest.MonkeyPatch,
+    _registered_vault_typed_ops: None,
+) -> None:
+    """A missing entity id surfaces as a connector_error naming InvalidPath."""
+    fake = install_fake_client(monkeypatch)
+    fake.secrets.identity.raise_on_read_entity = hvac.exceptions.InvalidPath("nope")
+
+    result = await _dispatch_vault("vault.identity.entity.read", {"entity_id": "ghost"})
+
+    assert result.status == "error"
+    assert result.extras["error_code"] == "connector_error"
+    assert result.extras["exception_class"] == "InvalidPath"
+
+
+async def test_token_create_failure_surfaces_connector_error(
+    monkeypatch: pytest.MonkeyPatch,
+    _registered_vault_typed_ops: None,
+) -> None:
+    fake = install_fake_client(monkeypatch)
+    fake.auth.token.raise_on_create = hvac.exceptions.Forbidden("denied")
+
+    result = await _dispatch_vault("vault.token.create", {"policies": ["root"]})
+
+    assert result.status == "error"
+    assert result.extras["error_code"] == "connector_error"
+    assert result.extras["exception_class"] == "Forbidden"

--- a/docs/codebase/connectors-vault.md
+++ b/docs/codebase/connectors-vault.md
@@ -136,6 +136,59 @@ Source: `backend/src/meho_backplane/connectors/vault/`.
   `VaultAuthBackendNotMountedError` are reused from `ops_auth.py` so a
   404 from an unmounted backend surfaces the same error class as the
   read ops.
+- **`identity` op group** (`ops_identity.py` / `ops_identity_schemas.py`,
+  G3.15-T4 #1412) — entity / entity-alias / group lifecycle on the core
+  `identity/` engine, group key `identity`:
+
+  | op_id | hvac call | safety_level | approval | op_class |
+  |---|---|---|---|---|
+  | `vault.identity.entity.write` | `create_or_update_entity` | dangerous | True | `write` |
+  | `vault.identity.entity_alias.write` | `create_or_update_entity_alias` | dangerous | True | `write` |
+  | `vault.identity.group.write` | `create_or_update_group` | dangerous | True | `write` |
+  | `vault.identity.group.delete` | `delete_group_by_name` | dangerous | True | `write` |
+  | `vault.identity.entity.read` | `read_entity` | safe | False | `other` |
+  | `vault.identity.group.read` | `read_group_by_name` | safe | False | `other` |
+  | `vault.identity.list` | `list_groups` / `list_entities` | safe | False | `read` |
+
+  Entity/group policy bindings are privilege assignments and group
+  membership is privilege plumbing, so the four writes are approval-gated.
+  The read primitives are registered **safe** (not `caution`) even though
+  the lookups are HTTP POST/LIST, so a create-if-absent flow does not
+  stall on approval (the issue's explicit ask). `entity.read` /
+  `group.read` classify `other` (`.read` is deliberately not a
+  read-suffix, matching the `vault.auth.*.read` convention);
+  `list` classifies `read` via the `.list` suffix and normalises an
+  empty-store 404 to `{"keys": []}`. None of the identity objects carry
+  secret material.
+- **`token` op group** (`ops_token.py` / `ops_token_schemas.py`,
+  G3.15-T4 #1412) — token lifecycle on the core `token` backend, group
+  key `token`:
+
+  | op_id | hvac call | safety_level | approval | op_class |
+  |---|---|---|---|---|
+  | `vault.token.create` | `auth.token.create` | dangerous | True | `credential_mint` |
+  | `vault.token.revoke_accessor` | `auth.token.revoke_accessor` | dangerous | True | `other` |
+  | `vault.token.list_accessors` | `auth.token.list_accessors` | safe | False | `other` |
+
+  `token.create` mints a client token in its **response** →
+  `credential_mint` (aggregate-only broadcast; the token reaches only the
+  caller's `OperationResult`, never the audit row or feed). It is
+  **non-idempotent** (a fresh token per call). `revoke_accessor` is
+  **surgical** — it revokes exactly one token by accessor; there is
+  intentionally **no bulk-revoke op** (the vault skill's loudest
+  Don't-rule). Token accessors are non-secret reference handles, so they
+  are not redacted (`revoke_accessor` param / `list_accessors` response
+  classify `other`).
+
+  Both groups register from `ops_identity.py` / `ops_token.py` spec
+  tables, composed by the thin
+  `register_vault_identity_token_operations()` registrar
+  (`ops_identity_token.py`), which is queued from the package `__init__`
+  as its own lifespan registrar entry (independent of the KV / sys / auth
+  registrars). `identity/` and `token` are core backends (always
+  mounted), so there is no backend-not-mounted reclassification — a 404
+  means a missing entity/group/accessor and surfaces as the underlying
+  `hvac.exceptions.InvalidPath`.
 
 ## KV-v2 op group
 
@@ -272,6 +325,19 @@ parks as `awaiting_approval` before reaching Vault (proven in
 exercised by calling it directly in the unit suite. The policy reads
 (`policy.read` / `policy.list`) stay `requires_approval=False`.
 
+The identity write ops (`identity.entity.write` / `entity_alias.write` /
+`group.write` / `group.delete`) and the token write ops
+(`token.create` / `token.revoke_accessor`) (G3.15-T4 #1412) likewise
+register `requires_approval=True` — each is a privilege assignment,
+privilege-plumbing membership change, irreversible removal, or a secret
+mint. `requires_approval` / `safety_level` are carried per-op in the
+`IDENTITY_OP_SPECS` / `TOKEN_OP_SPECS` rows. The identity reads
+(`entity.read` / `group.read` / `list`) and `token.list_accessors` stay
+`requires_approval=False`, registered `safe` so create-if-absent flows
+do not stall. The integration tests drive the gated writes via the
+approvals-API resume path (`dispatch(..., _approved=True)`), the same
+path that runs once a human approves.
+
 ## JSONFlux result-handle path (`vault.kv.list`)
 
 `vault.kv.list` is the only set-shaped op on the v0.2 Vault surface
@@ -302,13 +368,16 @@ raw >50-key list once a handle is produced.
 
 1. Importing `connectors.vault` (package `__init__.py`) registers
    `VaultConnector` against the v2 registry synchronously and queues
-   two typed-op registrars (`register_vault_typed_operations`,
-   `register_vault_sys_typed_operations`) onto the lifespan-driven
+   three typed-op registrars (`register_vault_typed_operations`,
+   `register_vault_sys_typed_operations`,
+   `register_vault_identity_token_operations`) onto the lifespan-driven
    registrar list. `register_vault_typed_operations` registers the
-   KV-v2 group and then calls `register_vault_auth_operations` for the
-   `auth` group.
+   KV-v2 group and then calls `register_vault_auth_operations` (auth
+   read) + `register_vault_auth_write_operations` (auth write).
+   `register_vault_identity_token_operations` composes the `identity` +
+   `token` groups from their per-module spec tables.
 2. At FastAPI lifespan startup, `run_typed_op_registrars()` invokes
-   both registrars, which upsert the `endpoint_descriptor` rows. Upsert
+   all registrars, which upsert the `endpoint_descriptor` rows. Upsert
    is idempotent: a restart against unchanged descriptions is a no-op
    for the embedding pipeline (body-hash skip in
    `register_typed_operation`).
@@ -424,14 +493,18 @@ and a real Postgres audit store (reusing the integration conftest's
 - Initiative #366 (G3.3 vault-1.x typed op surface); Goal #214.
 - Tasks: #545 (G3.3-T1 KV-v2), #546 (G3.3-T2 sys read group),
   #547 (G3.3-T3 auth read group), #551 (G3.3-T7 dev-mode CI
-  integration harness).
+  integration harness), #1409 (G3.15-T1 KV writes), #1410 (G3.15-T2
+  policy ops), #1411 (G3.15-T3 auth credential lifecycle), #1412
+  (G3.15-T4 identity + token ops).
 - Vault dev mode: https://developer.hashicorp.com/vault/docs/concepts/dev-server
 - Substrate: #388 (G0.6 operation registry), #390 (Refactor-Vault).
 - Vault API: https://developer.hashicorp.com/vault/api-docs/secret/kv/kv-v2
   (KV-v2), https://developer.hashicorp.com/vault/api-docs/system (sys),
   https://developer.hashicorp.com/vault/api-docs/auth/userpass
   (userpass), https://developer.hashicorp.com/vault/api-docs/auth/approle
-  (approle).
+  (approle), https://developer.hashicorp.com/vault/api-docs/secret/identity
+  (identity), https://developer.hashicorp.com/vault/api-docs/auth/token
+  (token).
 - Decision #3 PII redaction: `docs/planning/v0.2-decisions.md`.
 - CLAUDE.md postulates 1 (typed connectors first-class) and 7
   (synchronous append-only audit).


### PR DESCRIPTION
## Summary
- Add the Vault **identity** op group (entity / entity-alias / group lifecycle on the core `identity/` engine) and **token** op group (create / revoke_accessor / list_accessors on the core `token` backend), retiring parts of `/vault-admin`.
- Identity writes (`entity.write` / `entity_alias.write` / `group.write` / `group.delete`) are `dangerous` + `requires_approval=True` (policy bindings = privilege assignment, group membership = privilege plumbing). The read primitives (`entity.read` / `group.read` / `list`) register **safe** + `requires_approval=False` so a create-if-absent flow does not stall on approval.
- `token.create` mints a client token in its **response** → reuses the existing `credential_mint` op-class allowlist (#1397/#1401, already on `main`): aggregate-only broadcast + `params_hash`-only audit; the token reaches only the caller's `OperationResult`. `revoke_accessor` is **surgical** (one accessor); **no bulk-revoke op** by design. Accessors are non-secret handles, not redacted.
- Each group owns its handlers + schemas + spec table (`ops_identity` / `ops_token` / `*_schemas`); a thin `register_vault_identity_token_operations` composes both under one lifespan registrar.

## Test plan
- [x] `ruff check` / `ruff format --check` — clean (whole backend)
- [x] `mypy src/meho_backplane/` — clean (413 files)
- [x] `pytest tests/test_connectors_vault_identity_token.py` — 31 passed (per-op happy/error, registration safety/approval/group, no-bulk-revoke guard, `token.create` credential_mint redaction sentinel)
- [x] vault + broadcast regression suites — 231 + 82 passed
- [x] **AC: writes register dangerous + approval; reads safe + no approval** — parametrised registration test asserts each op's `safety_level` / `requires_approval` / `group_key`
- [x] **AC: token redaction** — unit asserts sentinel absent from `redact_payload`; integration asserts minted token absent from `model_dump_json()` of the BroadcastEvent
- [x] **AC: no bulk-revoke** — explicit guard test + only `revoke_accessor` exists
- [x] **AC: per-op happy/error + redaction tests** — unit + dev-mode testcontainers integration (writes dispatched via `dispatch(..., _approved=True)`)
- [x] **AC: CLI snapshot regen** — `make snapshot-openapi && make generate` run; no delta (generic dispatch route)

## Out of scope
- userpass/approle (T3 #1411), policy (T2 #1410), sys bootstrap (T5 #1413 — sibling, parallel).
- Canonical-tree-shape enforcement / "remove members before delete" refusals stay at the verb/agent layer.

## Adjacent findings (deferred)
- `ops_identity.py` (461) / `ops_identity_schemas.py` (486) are above the 400-line code-quality *warn* threshold (well under the 600 *block*); left as-is to keep each group's data cohesive.

<!-- auto-implement-issue: fresh, iteration 1 -->

Closes #1412


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **New Features**
  * Added HashiCorp Vault identity operations: create, update, delete, read, and list identity entities, groups, and aliases.
  * Added HashiCorp Vault token operations: create new tokens, revoke tokens by accessor, and list token accessors.

* **Documentation**
  * Updated Vault connector documentation with new identity and token operation details, including approval gating requirements and registration flow.

* **Tests**
  * Added comprehensive test coverage for identity and token operations against live Vault instances.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->