### PR TITLE
feat(connectors): G3.13-T1 KeycloakConnector skeleton + admin credential loader

### DIFF
--- a/backend/src/meho_backplane/connectors/keycloak/__init__.py
+++ b/backend/src/meho_backplane/connectors/keycloak/__init__.py
@@ -1,0 +1,93 @@
+# SPDX-License-Identifier: Apache-2.0
+# Copyright (c) 2026 evoila Group
+
+"""meho_backplane.connectors.keycloak -- KeycloakConnector package.
+
+G3.13-T1 (#1393) substrate. Importing the package registers
+:class:`KeycloakConnector` against the v2 connector registry under the
+natural key ``(product="keycloak", version="26.x", impl_id="keycloak-admin")``
+**and** the ``(product, "", "")`` wildcard, and queues the connector's
+typed-op registrar onto the lifespan-driven registrar list.
+
+Two-phase registration (same shape as ``connectors/bind9/__init__.py``):
+
+* **Synchronous (import time)** -- the v2 registry entries land via
+  :func:`~meho_backplane.connectors.registry.register_connector_v2` in
+  this module, so the registry lookup tables are populated before the
+  lifespan begins and a probe firing during startup sees a fully
+  populated registry.
+
+* **Asynchronous (lifespan startup)** --
+  :func:`~meho_backplane.operations.typed_register.run_typed_op_registrars`
+  invokes :func:`register_keycloak_typed_operations`, which delegates to
+  :meth:`KeycloakConnector.register_operations`. In T1 that method ships
+  **zero** ops -- the seam is wired now so T2 (read ops) only fills the
+  op walk; the registrar plumbing doesn't move.
+
+Like bind9, the keycloak connector does **not** call the v1
+``register_connector`` -- it has no chassis-route history. Both the
+versioned triple and the wildcard land via ``register_connector_v2``
+directly, keeping the resolver tie-break ladder unambiguous.
+"""
+
+from meho_backplane.connectors.keycloak.connector import KeycloakConnector
+from meho_backplane.connectors.registry import register_connector_v2
+from meho_backplane.operations.typed_register import register_typed_op_registrar
+from meho_backplane.retrieval.embedding import EmbeddingService
+
+
+async def register_keycloak_typed_operations(
+    *,
+    embedding_service: EmbeddingService | None = None,
+) -> None:
+    """Module-level registrar wrapper for ``KeycloakConnector.register_operations``.
+
+    The canonical typed-op registration pattern queues a module-level
+    ``async def register_xxx_typed_operations`` onto
+    :func:`~meho_backplane.operations.typed_register.run_typed_op_registrars`
+    via :func:`register_typed_op_registrar`. The ``embedding_service``
+    keyword-only parameter mirrors the bind9 sibling's contract -- the
+    runner passes the process-wide :class:`EmbeddingService` (or a
+    chassis-test stub) to every registrar via
+    ``registrar(embedding_service=...)``, so each registrar **must**
+    accept the kwarg or the lifespan crashes with :class:`TypeError`. T1
+    ships zero ops so the value is unused; the kwarg-accept-and-discard
+    shape matches the bind9 sibling.
+    """
+    del embedding_service  # T1 ships zero ops -- kwarg accepted for runner-compatibility
+    await KeycloakConnector.register_operations()
+
+
+__all__ = [
+    "KeycloakConnector",
+    "register_keycloak_typed_operations",
+]
+
+
+# v2 entry -- the canonical resolver key. keycloak has no v1 chassis
+# history, so the v1 ``register_connector`` write is intentionally
+# omitted (see module docstring).
+register_connector_v2(
+    product="keycloak",
+    version="26.x",
+    impl_id="keycloak-admin",
+    cls=KeycloakConnector,
+)
+
+# G0.15-T6 (#1215) wildcard fallback -- a target with ``version=None``
+# (fresh, unfingerprinted, no operator-asserted version yet) resolves to
+# this connector through the resolver's ``versioned_over_wildcard`` step
+# rather than 501-ing with ``no_connector``. The versioned entry above
+# always wins when both are present (resolver tie-break step 1).
+register_connector_v2(
+    product="keycloak",
+    version="",
+    impl_id="",
+    cls=KeycloakConnector,
+)
+
+# Queue the typed-op upsert onto the lifespan-driven registrar list. The
+# lifespan calls ``run_typed_op_registrars`` after _eager_import_connectors
+# so every connector subpackage has self-registered by the time the
+# runner iterates.
+register_typed_op_registrar(register_keycloak_typed_operations)

--- a/backend/src/meho_backplane/connectors/keycloak/connector.py
+++ b/backend/src/meho_backplane/connectors/keycloak/connector.py
@@ -1,0 +1,561 @@
+# SPDX-License-Identifier: Apache-2.0
+# Copyright (c) 2026 evoila Group
+
+"""KeycloakConnector -- HttpConnector subclass for the Keycloak 26.x Admin REST API.
+
+G3.13-T1 (#1393) skeleton -- admin credential loader + fingerprint +
+dual registration. Read ops (T2) and onboarding docs (T3) layer on top;
+this module ships **zero** typed operations.
+
+The load-bearing design point -- admin-vs-operator credential split
+=====================================================================
+
+MEHO is its own IdP: the backplane authenticates its callers with
+operator-OIDC tokens that Keycloak issues. The connector that *manages*
+that Keycloak must not authenticate through the same path, or it could
+never bootstrap a freshly deployed Keycloak whose operator-login clients
+aren't configured yet (the chicken-and-egg the issue body calls out).
+
+So the connector authenticates to the Keycloak **Admin REST API** with a
+**separate admin credential** loaded from Vault (consumer path
+``secret/rdc-hetzner-dc/keycloak/admin``) via
+:func:`~meho_backplane.connectors.keycloak.session.load_admin_credentials_from_vault`.
+It mints an admin access token through Keycloak's own token endpoint
+(``POST /realms/{admin_realm}/protocol/openid-connect/token``) and caches
+it with a TTL-driven refresh. The operator's OIDC token
+(``operator.raw_jwt``) authorises the *Vault read* (operator-context
+KV-v2, the locked Option A decision) but is **never** sent to Keycloak.
+The split is asserted in
+``tests/test_connectors_keycloak_auth.py`` -- a test proves the operator
+token does not appear on any admin call.
+
+Auth model gating
+=================
+
+The connector locks to :attr:`~meho_backplane.connectors.schemas.AuthModel.SHARED_SERVICE_ACCOUNT`
+(or ``None`` for pre-G0.3 targets), mirroring the VCF / Harbor / gh-rest
+precedents: the admin credential is a shared service account, not a
+per-operator identity. :meth:`auth_headers` rejects any other value with
+a clear :exc:`NotImplementedError` naming the target and the requested
+mode.
+
+Token lifecycle
+===============
+
+The admin token is cached per target with a refresh margin
+(:data:`_TOKEN_REFRESH_MARGIN_SECONDS`) subtracted from the
+``expires_in`` Keycloak returns, so a near-expiry token is re-minted
+before it fails a downstream call rather than after. :meth:`aclose`
+clears the token cache and tears down the httpx pool but issues no
+logout-revoke -- the access token is short-lived and a logout round-trip
+during lifespan shutdown is more risk than benefit (same posture the
+NSX / vRLI precedents established).
+
+Operations
+==========
+
+This module ships zero operations -- the G0.6 dispatch shim
+:meth:`execute` exists for ABC compatibility and the
+:meth:`register_operations` classmethod is the seam T2 fills in. Until
+then the connector is registered + discoverable but ``execute`` against
+any ``op_id`` resolves to ``unknown_op`` at the dispatcher.
+
+References
+----------
+
+* Issue: https://github.com/evoila/meho/issues/1393
+* Parent initiative: https://github.com/evoila/meho/issues/1388
+* Token endpoint + client_credentials grant:
+  https://www.keycloak.org/securing-apps/oidc-layers
+* Realm representation (GET /admin/realms/{realm}):
+  https://www.keycloak.org/docs-api/latest/javadocs/org/keycloak/representations/idm/RealmRepresentation.html
+* ServerInfo (GET /admin/serverinfo, systemInfo.version):
+  https://www.keycloak.org/docs-api/latest/javadocs/org/keycloak/representations/info/ServerInfoRepresentation.html
+"""
+
+from __future__ import annotations
+
+import asyncio
+import time
+from datetime import UTC, datetime
+from typing import Any
+
+import httpx
+import structlog
+
+from meho_backplane.auth.operator import Operator
+from meho_backplane.connectors._shared.vault_creds import VaultCredentialsReadError
+from meho_backplane.connectors._shared.vcf_auth import is_acceptable_auth_model
+from meho_backplane.connectors.adapters.http import HttpConnector
+from meho_backplane.connectors.keycloak.session import (
+    KeycloakAdminCredentials,
+    KeycloakAdminCredentialsLoader,
+    KeycloakClientCredentials,
+    KeycloakTargetLike,
+    RealmConfig,
+    load_admin_credentials_from_vault,
+    resolve_realm_config,
+)
+from meho_backplane.connectors.schemas import (
+    AuthModel,
+    FingerprintResult,
+    OperationResult,
+    ProbeResult,
+)
+
+__all__ = ["KeycloakAdminTokenError", "KeycloakConnector"]
+
+_log = structlog.get_logger(__name__)
+
+#: Seconds shaved off the token's ``expires_in`` so a near-expiry token
+#: is re-minted before a downstream call would fail on it. A 30 s margin
+#: comfortably covers clock skew + the round-trip of the admin call the
+#: token is fetched for.
+_TOKEN_REFRESH_MARGIN_SECONDS: float = 30.0
+
+#: Fallback TTL when Keycloak's token response omits / malforms
+#: ``expires_in``. Keycloak's admin access-token lifespan defaults to
+#: 60 s; we use that as a conservative floor so a malformed response
+#: doesn't pin a token forever.
+_DEFAULT_TOKEN_TTL_SECONDS: float = 60.0
+
+
+class KeycloakAdminTokenError(RuntimeError):
+    """The admin token endpoint round-trip failed.
+
+    Raised when ``POST /realms/{admin_realm}/protocol/openid-connect/token``
+    returns a non-2xx response or a body without a usable
+    ``access_token``. The message names the target and the admin realm;
+    it never echoes a credential value. Chains the underlying
+    :exc:`httpx.HTTPStatusError` when one is available so the operator
+    can see the upstream status code.
+    """
+
+
+def _token_request_body(creds: KeycloakAdminCredentials) -> dict[str, str]:
+    """Render the form body for the token request from *creds*.
+
+    ``client_credentials`` grant for :class:`KeycloakClientCredentials`;
+    ``password`` grant (direct access) for
+    :class:`KeycloakPasswordCredentials`. The body is form-encoded
+    (``application/x-www-form-urlencoded``) -- Keycloak's token endpoint
+    does not accept JSON.
+    """
+    if isinstance(creds, KeycloakClientCredentials):
+        return {
+            "grant_type": "client_credentials",
+            "client_id": creds.client_id,
+            "client_secret": creds.client_secret,
+        }
+    # KeycloakPasswordCredentials -- direct-access-grant password flow.
+    return {
+        "grant_type": "password",
+        "client_id": creds.client_id,
+        "username": creds.username,
+        "password": creds.password,
+    }
+
+
+def _parse_token_response(payload: Any) -> tuple[str, float]:
+    """Extract ``(access_token, ttl_seconds)`` from a token response body.
+
+    Returns the access token and the effective TTL (``expires_in`` minus
+    the refresh margin, floored at 1 s). Falls back to
+    :data:`_DEFAULT_TOKEN_TTL_SECONDS` when ``expires_in`` is missing or
+    not a number. Raises :exc:`KeycloakAdminTokenError` when the body
+    carries no usable ``access_token`` -- caller adds the target context.
+    """
+    token = payload.get("access_token") if isinstance(payload, dict) else None
+    if not isinstance(token, str) or not token:
+        raise KeycloakAdminTokenError("token response carried no usable 'access_token' field")
+    expires_in = payload.get("expires_in") if isinstance(payload, dict) else None
+    ttl = float(expires_in) if isinstance(expires_in, (int, float)) else _DEFAULT_TOKEN_TTL_SECONDS
+    effective = max(1.0, ttl - _TOKEN_REFRESH_MARGIN_SECONDS)
+    return token, effective
+
+
+class _CachedToken:
+    """An admin access token plus the monotonic clock time it expires at."""
+
+    __slots__ = ("expires_at", "token")
+
+    def __init__(self, token: str, expires_at: float) -> None:
+        self.token = token
+        self.expires_at = expires_at
+
+    def is_fresh(self, now: float) -> bool:
+        return now < self.expires_at
+
+
+class KeycloakConnector(HttpConnector):
+    """Keycloak 26.x Admin REST API connector with admin-token Bearer auth.
+
+    Registry v2 triple: ``("keycloak", "26.x", "keycloak-admin")``. The
+    ``26.x`` version targets the Keycloak 26 release series; a future
+    ``("keycloak", "27.x", ...)`` entry can ship alongside without
+    disturbing 26.x targets.
+
+    Per-target admin token cached in :attr:`_admin_tokens` with a
+    TTL-driven refresh; per-target admin credentials are loaded fresh on
+    each token mint (the secret read is cheap relative to the token
+    round-trip and avoids holding the credential in memory between
+    refreshes). The :attr:`priority` is ``1`` so a future generic-REST
+    auto-shim that somehow registers for the same triple loses the
+    resolver tie-break.
+    """
+
+    # G0.6 v2 registry metadata. The (product, version, impl_id) triple
+    # matches the dispatcher's parse_connector_id contract:
+    # ``"keycloak-admin-26.x"`` -> ("keycloak", "26.x", "keycloak-admin").
+    product = "keycloak"
+    version = "26.x"
+    impl_id = "keycloak-admin"
+    supported_version_range = ">=26.0,<27.0"
+    priority = 1
+
+    def __init__(
+        self,
+        *,
+        credentials_loader: KeycloakAdminCredentialsLoader | None = None,
+    ) -> None:
+        super().__init__()
+        self._admin_tokens: dict[str, _CachedToken] = {}
+        self._token_lock = asyncio.Lock()
+        self._credentials_loader: KeycloakAdminCredentialsLoader = (
+            credentials_loader
+            if credentials_loader is not None
+            else load_admin_credentials_from_vault
+        )
+
+    # -- auth -----------------------------------------------------------
+
+    async def auth_headers(self, target: KeycloakTargetLike, operator: Operator) -> dict[str, str]:
+        """Return ``{"Authorization": "Bearer <admin_token>"}`` for the request.
+
+        Lazily mints the admin token on first call against *target* and
+        on TTL expiry; otherwise reuses the cached token. The admin token
+        is obtained via the **admin** credential path -- a Vault-sourced
+        service-account / admin credential exchanged at Keycloak's token
+        endpoint -- and is deliberately distinct from the operator-OIDC
+        token. ``operator.raw_jwt`` authorises only the operator-context
+        Vault read of the admin credential; it is never sent to Keycloak.
+
+        Raises :exc:`NotImplementedError` (naming the target + requested
+        mode) when ``target.auth_model`` is anything other than
+        ``shared_service_account`` or ``None``.
+        """
+        auth_model = getattr(target, "auth_model", None)
+        if not is_acceptable_auth_model(auth_model):
+            raise NotImplementedError(
+                f"KeycloakConnector only supports auth_model="
+                f"{AuthModel.SHARED_SERVICE_ACCOUNT.value!r}; target "
+                f"{target.name!r} requested auth_model={auth_model!r}"
+            )
+        token = await self._admin_token(target, operator)
+        return {"Authorization": f"Bearer {token}"}
+
+    async def _admin_token(self, target: KeycloakTargetLike, operator: Operator) -> str:
+        """Return the cached admin token for *target*, minting on first use / expiry.
+
+        Fail-closed against an empty ``operator.raw_jwt`` *before* the
+        cache lookup -- a system-initiated caller (empty JWT) cannot read
+        the admin credential out of Vault, so it must never receive a
+        token primed by an authenticated caller. This mirrors the
+        defense-in-depth guard the VCF / gh credential caches enforce
+        (the loader's ``vault_client_for_operator`` chain is the primary
+        gate; this is the cache fast-path's enforcement of the same
+        invariant).
+
+        The lock serialises concurrent first-use / refresh callers for
+        one target; the slow token round-trip runs under the lock so two
+        concurrent callers don't both pay it.
+        """
+        if not operator.raw_jwt:
+            raise VaultCredentialsReadError(
+                "operator-context credential read requires an authenticated operator; "
+                f"target={target.name!r} has no operator JWT (system-initiated calls "
+                "cannot read the Keycloak admin credential)"
+            )
+        async with self._token_lock:
+            now = time.monotonic()
+            cached = self._admin_tokens.get(target.name)
+            if cached is not None and cached.is_fresh(now):
+                return cached.token
+            token, ttl = await self._mint_admin_token(target, operator)
+            self._admin_tokens[target.name] = _CachedToken(token, now + ttl)
+            return token
+
+    async def _mint_admin_token(
+        self, target: KeycloakTargetLike, operator: Operator
+    ) -> tuple[str, float]:
+        """Load the admin credential + exchange it at the token endpoint.
+
+        Returns ``(access_token, effective_ttl_seconds)``. The credential
+        read is operator-context (the operator's JWT -> Vault JWT/OIDC);
+        the token POST is form-encoded against
+        ``/realms/{admin_realm}/protocol/openid-connect/token`` with NO
+        ``Authorization`` header (the grant carries the credentials in
+        the body). A non-2xx response or a missing ``access_token``
+        raises :exc:`KeycloakAdminTokenError` naming the target + admin
+        realm.
+        """
+        realms = resolve_realm_config(target)
+        creds = await self._credentials_loader(target, operator)
+        client = await self._http_client(target)
+        token_path = f"/realms/{realms.admin_realm}/protocol/openid-connect/token"
+        try:
+            resp = await client.post(
+                token_path,
+                data=_token_request_body(creds),
+                headers={
+                    "Content-Type": "application/x-www-form-urlencoded",
+                    "Accept": "application/json",
+                },
+            )
+            resp.raise_for_status()
+            payload = resp.json()
+        except httpx.HTTPStatusError as exc:
+            raise KeycloakAdminTokenError(
+                f"admin token request for target {target.name!r} against admin realm "
+                f"{realms.admin_realm!r} returned HTTP {exc.response.status_code}"
+            ) from exc
+        except (httpx.HTTPError, ValueError) as exc:
+            raise KeycloakAdminTokenError(
+                f"admin token request for target {target.name!r} against admin realm "
+                f"{realms.admin_realm!r} failed: {type(exc).__name__}: {exc}"
+            ) from exc
+
+        try:
+            token, ttl = _parse_token_response(payload)
+        except KeycloakAdminTokenError as exc:
+            raise KeycloakAdminTokenError(
+                f"admin token request for target {target.name!r} against admin realm "
+                f"{realms.admin_realm!r}: {exc}"
+            ) from exc
+
+        _log.info(
+            "keycloak_admin_token_minted",
+            target=target.name,
+            host=getattr(target, "host", None),
+            admin_realm=realms.admin_realm,
+            grant=(
+                "client_credentials" if isinstance(creds, KeycloakClientCredentials) else "password"
+            ),
+            ttl_seconds=ttl,
+        )
+        return token, ttl
+
+    # -- fingerprint / probe -------------------------------------------
+
+    async def fingerprint(
+        self,
+        target: KeycloakTargetLike,
+        operator: Operator | None = None,
+    ) -> FingerprintResult:
+        """Authenticate via the admin path and round-trip ``GET /admin/realms/{realm}``.
+
+        Mints an admin token (admin credential path, **not** operator-OIDC),
+        then GETs the managed realm's top-level representation. The
+        returned :class:`~meho_backplane.connectors.schemas.FingerprintResult`
+        carries the realm metadata (``realm``, ``enabled``, ``sslRequired``,
+        ``loginTheme``) under ``extras`` plus, best-effort, the Keycloak
+        server version from ``GET /admin/serverinfo`` (``systemInfo.version``).
+        The serverinfo call is non-fatal: an older Keycloak that 404s the
+        undocumented endpoint still produces a reachable fingerprint with
+        ``version=None``.
+
+        Unlike the unauthenticated-version-probe connectors (vRLI), every
+        Keycloak admin endpoint requires the admin token, so the
+        fingerprint needs a real ``operator`` to read the admin credential
+        from Vault. A ``None`` operator (background caller) falls back to
+        the synthesised system operator, which fails closed at the live
+        Vault round-trip -- surfaced here as ``reachable=False`` +
+        ``extras["error"]`` rather than an unhandled exception.
+
+        Transport / auth failure → ``reachable=False`` with
+        ``extras["error"]`` carrying ``"<ExcType>: <message>"``.
+        """
+        from meho_backplane.connectors._shared.system_operator import (
+            synthesise_system_operator,
+        )
+
+        probed_at = datetime.now(UTC)
+        realms = resolve_realm_config(target)
+        probe_method = f"GET /admin/realms/{realms.managed_realm}"
+        effective_operator = operator if operator is not None else synthesise_system_operator()
+
+        try:
+            realm_repr = await self._get_json(
+                target,
+                f"/admin/realms/{realms.managed_realm}",
+                operator=effective_operator,
+            )
+        except (
+            httpx.HTTPError,
+            OSError,
+            ValueError,
+            KeycloakAdminTokenError,
+            VaultCredentialsReadError,
+        ) as exc:
+            return FingerprintResult(
+                vendor="keycloak",
+                product="keycloak",
+                reachable=False,
+                probed_at=probed_at,
+                probe_method=probe_method,
+                extras={"error": f"{type(exc).__name__}: {exc}"},
+            )
+
+        server_version = await self._server_version(target, effective_operator)
+
+        return FingerprintResult(
+            vendor="keycloak",
+            product="keycloak",
+            version=server_version,
+            reachable=True,
+            probed_at=probed_at,
+            probe_method=probe_method,
+            extras=_realm_extras(realm_repr, realms),
+        )
+
+    async def _server_version(self, target: KeycloakTargetLike, operator: Operator) -> str | None:
+        """Best-effort Keycloak server version from ``GET /admin/serverinfo``.
+
+        ``/admin/serverinfo`` is the (undocumented but stable) endpoint
+        the admin console's "Server Info" page reads; ``systemInfo.version``
+        carries the Keycloak version (e.g. ``"26.0.5"``). Any failure
+        (404 on an older server, transport error, malformed body) returns
+        ``None`` rather than failing the fingerprint -- the realm
+        round-trip is the canonical reachability signal, the version is a
+        nice-to-have.
+        """
+        try:
+            info = await self._get_json(target, "/admin/serverinfo", operator=operator)
+        except (httpx.HTTPError, OSError, ValueError, KeycloakAdminTokenError):
+            return None
+        system_info = info.get("systemInfo") if isinstance(info, dict) else None
+        version = system_info.get("version") if isinstance(system_info, dict) else None
+        return version if isinstance(version, str) and version else None
+
+    async def probe(self, target: KeycloakTargetLike) -> ProbeResult:
+        """Reachability + admin-auth check.
+
+        Delegates to :meth:`fingerprint` with the synthesised system
+        operator -- one admin round-trip covers both "is Keycloak up" and
+        "do the admin credentials work". A failed Vault read / token mint
+        surfaces as ``ok=False`` with the error reason, matching the
+        NSX / vRLI precedents. Because every Keycloak admin endpoint is
+        authenticated, ``ok=True`` implies the admin credential is valid,
+        not merely that the socket is open.
+        """
+        fp = await self.fingerprint(target)
+        if fp.reachable:
+            return ProbeResult(ok=True, probed_at=fp.probed_at)
+        return ProbeResult(
+            ok=False,
+            reason=str(fp.extras.get("error", "unreachable")),
+            probed_at=fp.probed_at,
+        )
+
+    # -- typed-op registrar seam (T2 fills this in) ---------------------
+
+    @classmethod
+    async def register_operations(cls) -> None:
+        """Typed-op registrar seam -- ships **no** ops in T1 (G3.13-T1 #1393).
+
+        T1 is the substrate: the connector class, the admin credential
+        loader, fingerprint, and dual registration. Read ops land in T2,
+        which walks a ``KEYCLOAK_OPS`` table here exactly as
+        :meth:`~meho_backplane.connectors.pfsense.connector.PfSenseConnector.register_operations`
+        walks ``PFSENSE_OPS``. Wiring the no-op registrar now means the
+        lifespan's ``run_typed_op_registrars`` call already drives
+        Keycloak, so T2 only fills the op walk -- the seam doesn't move.
+
+        Idempotent (a no-op is trivially idempotent across pod restarts).
+        """
+        _log.info(
+            "keycloak_operations_registered",
+            count=0,
+            product=cls.product,
+            version=cls.version,
+            impl_id=cls.impl_id,
+            note="T1 substrate ships zero ops; read ops land in G3.13-T2",
+        )
+
+    # -- dispatcher shim ------------------------------------------------
+
+    async def execute(
+        self,
+        target: KeycloakTargetLike,
+        op_id: str,
+        params: dict[str, Any],
+    ) -> OperationResult:
+        """Dispatcher shim -- delegates to the G0.6 operator-aware dispatch path.
+
+        Mirrors :meth:`VcfLogsConnector.execute`. The connector ships no
+        ops in T1, so any ``op_id`` resolves to ``unknown_op`` at the
+        dispatcher; the shim exists for ABC compatibility and so T2's ops
+        are reachable without touching this method. Synthesises a minimal
+        system :class:`~meho_backplane.auth.operator.Operator`; the
+        connector's natural key is encoded as the dispatcher's
+        ``connector_id`` per ``parse_connector_id``
+        (``"keycloak-admin-26.x"`` -> ("keycloak", "26.x",
+        "keycloak-admin")).
+        """
+        from uuid import UUID
+
+        from meho_backplane.auth.operator import Operator as _Operator
+        from meho_backplane.auth.operator import TenantRole
+        from meho_backplane.operations import dispatch
+
+        operator = _Operator(
+            sub="system:keycloak-admin-connector-shim",
+            name=None,
+            email=None,
+            raw_jwt="",
+            tenant_id=UUID(int=0),
+            tenant_role=TenantRole.OPERATOR,
+        )
+        connector_id = f"{self.impl_id}-{self.version}"
+        return await dispatch(
+            operator=operator,
+            connector_id=connector_id,
+            op_id=op_id,
+            target=target,
+            params=params,
+        )
+
+    async def aclose(self) -> None:
+        """Clear cached admin tokens then tear down the httpx pool.
+
+        No logout-revoke is issued -- the admin access token is
+        short-lived (the refresh margin keeps it fresh, expiry retires it)
+        and a per-target logout call during lifespan shutdown is more risk
+        than benefit (same posture the NSX / vRLI precedents established).
+        The token cache is cleared so a post-aclose reuse of the same
+        connector instance starts clean.
+        """
+        async with self._token_lock:
+            self._admin_tokens.clear()
+        await super().aclose()
+
+
+def _realm_extras(realm_repr: Any, realms: RealmConfig) -> dict[str, Any]:
+    """Project the realm representation into the fingerprint ``extras`` bag.
+
+    Pulls the operator-meaningful top-level fields
+    (``realm``/``enabled``/``sslRequired``/``loginTheme``) out of the
+    ``GET /admin/realms/{realm}`` body and records the resolved
+    admin-realm / managed-realm pair so an operator reading the
+    fingerprint can see which realm was probed and where the admin client
+    authenticated. Tolerates a non-dict body defensively.
+    """
+    repr_dict = realm_repr if isinstance(realm_repr, dict) else {}
+    return {
+        "realm": repr_dict.get("realm"),
+        "enabled": repr_dict.get("enabled"),
+        "ssl_required": repr_dict.get("sslRequired"),
+        "login_theme": repr_dict.get("loginTheme"),
+        "admin_realm": realms.admin_realm,
+        "managed_realm": realms.managed_realm,
+    }

--- a/backend/src/meho_backplane/connectors/keycloak/session.py
+++ b/backend/src/meho_backplane/connectors/keycloak/session.py
@@ -1,0 +1,288 @@
+# SPDX-License-Identifier: Apache-2.0
+# Copyright (c) 2026 evoila Group
+
+"""Target shape + admin-credential loader for the keycloak connector.
+
+The load-bearing design point of the Keycloak connector is the
+**admin-vs-operator credential split**. The backplane authenticates its
+*own* callers through operator-OIDC (a Keycloak-issued JWT carried on
+:attr:`~meho_backplane.auth.operator.Operator.raw_jwt`). The connector
+that *manages* Keycloak must not depend on that path: if operator-OIDC
+were the only way in, the connector could never bootstrap a freshly
+deployed Keycloak whose operator-login clients are not yet configured
+(the chicken-and-egg the issue body calls out). So the connector
+authenticates to the Keycloak Admin REST API with a **separate admin
+credential** sourced from Vault at the consumer path
+``secret/rdc-hetzner-dc/keycloak/admin``.
+
+Credential-protocol discriminator
+==================================
+
+The admin secret carries one of two shapes; the loader picks the path
+by inspecting **which fields the operator stored** (the same
+payload-shape discriminator the gh-rest connector uses for its
+App-vs-PAT picker — see ``connectors/github/session.py``):
+
+* ``client_id`` + ``client_secret`` present →
+  :class:`KeycloakClientCredentials` (the preferred
+  ``client_credentials`` grant against a service-account client such as
+  ``admin-cli`` or a dedicated ``meho-admin`` client).
+* ``username`` + ``password`` present (and the client-credentials shape
+  is not) → :class:`KeycloakPasswordCredentials` (the
+  ``password`` grant against ``admin-cli``, the break-glass fallback).
+* Neither shape present → :class:`KeycloakAmbiguousVaultPayloadError`
+  with a remediation-bearing message naming both field shapes and which
+  fields were present (no values echoed).
+
+Why the Vault read still threads the operator
+=============================================
+
+The *secret read itself* is an operator-context Vault KV-v2 read (the
+locked Option A decision in ``docs/architecture/connector-auth.md``):
+the operator's validated JWT is forwarded to Vault's JWT/OIDC auth
+method so the read is attributed to the operator's Vault Identity entity
+with per-operator RBAC + audit. That is **not** the same as reusing the
+operator's OIDC token to authenticate to *Keycloak* — the operator JWT
+authorises the Vault read; the admin credential read out of Vault is
+what authenticates to the Keycloak Admin API. The split is enforced in
+:class:`~meho_backplane.connectors.keycloak.connector.KeycloakConnector`:
+the operator token never appears in a request to the Keycloak admin
+surface.
+
+Target configuration
+=====================
+
+Base URL is derived from ``target.host`` / ``target.port`` by the
+:class:`~meho_backplane.connectors.adapters.http.HttpConnector` base.
+The three Keycloak-specific knobs live on ``target.extras`` (a free-form
+``Mapping`` on the concrete ``Target`` model) so they are
+target-configurable without a schema migration:
+
+* ``admin_realm`` — the realm the admin client authenticates against
+  (the admin-cli / service-account client typically lives in
+  ``master``). Defaults to :data:`DEFAULT_ADMIN_REALM`.
+* ``managed_realm`` — the realm the connector manages and fingerprints
+  (``evba`` on the RDC fleet). Defaults to :data:`DEFAULT_MANAGED_REALM`.
+
+Both are read through :func:`resolve_realm_config` which tolerates a
+missing ``extras`` attribute (pre-G0.3 stub targets) and falls back to
+the defaults.
+"""
+
+from __future__ import annotations
+
+from collections.abc import Awaitable, Callable, Mapping
+from dataclasses import dataclass
+from typing import Any, Protocol, runtime_checkable
+
+from meho_backplane.auth.operator import Operator
+from meho_backplane.connectors._shared.vault_creds import load_vault_secret_data
+
+__all__ = [
+    "DEFAULT_ADMIN_REALM",
+    "DEFAULT_MANAGED_REALM",
+    "KeycloakAdminCredentials",
+    "KeycloakAdminCredentialsLoader",
+    "KeycloakAmbiguousVaultPayloadError",
+    "KeycloakClientCredentials",
+    "KeycloakPasswordCredentials",
+    "KeycloakTargetLike",
+    "RealmConfig",
+    "load_admin_credentials_from_vault",
+    "resolve_realm_config",
+]
+
+#: The realm the admin client authenticates against. Keycloak's
+#: ``admin-cli`` client and most service-account admin clients live in
+#: ``master``; a target can override via ``extras["admin_realm"]``.
+DEFAULT_ADMIN_REALM: str = "master"
+
+#: The realm the connector manages + fingerprints. ``evba`` is the RDC
+#: fleet's managed realm; a target can override via
+#: ``extras["managed_realm"]``.
+DEFAULT_MANAGED_REALM: str = "evba"
+
+#: The four field names the credential-shape discriminator inspects. Kept
+#: as module constants so the loader and its tests share one source of
+#: truth and error messages stay diff-stable.
+_CLIENT_FIELDS: tuple[str, str] = ("client_id", "client_secret")
+_PASSWORD_FIELDS: tuple[str, str] = ("username", "password")
+
+
+@runtime_checkable
+class KeycloakTargetLike(Protocol):
+    """Minimum target shape :class:`KeycloakConnector` reads.
+
+    Structural Protocol — the concrete ``Target`` model in
+    :mod:`meho_backplane.targets` satisfies this unchanged (it carries
+    ``extras`` as a ``Mapping``); until a test needs the real model it
+    can pass a stub dataclass.
+
+    Fields:
+
+    * ``name`` — per-target cache key (admin token + realm config).
+    * ``host`` / ``port`` — forwarded to
+      :meth:`~meho_backplane.connectors.adapters.http.HttpConnector._base_url`.
+    * ``secret_ref`` — Vault KV-v2 path the loader resolves to the admin
+      credential payload (``client_id``/``client_secret`` or
+      ``username``/``password``).
+    * ``auth_model`` — checked at the boundary by
+      :func:`~meho_backplane.connectors._shared.vcf_auth.is_acceptable_auth_model`;
+      only ``"shared_service_account"`` / ``None`` accepted.
+    * ``extras`` — free-form mapping carrying the optional
+      ``admin_realm`` / ``managed_realm`` overrides.
+    """
+
+    name: str
+    host: str
+    port: int | None
+    secret_ref: str | None
+    auth_model: str | None
+    extras: Mapping[str, Any]
+
+
+@dataclass(frozen=True)
+class RealmConfig:
+    """Resolved admin-realm + managed-realm pair for one target."""
+
+    admin_realm: str
+    managed_realm: str
+
+
+def resolve_realm_config(target: KeycloakTargetLike) -> RealmConfig:
+    """Resolve a target's admin-realm + managed-realm from ``extras``.
+
+    Reads ``target.extras["admin_realm"]`` / ``["managed_realm"]`` and
+    falls back to :data:`DEFAULT_ADMIN_REALM` / :data:`DEFAULT_MANAGED_REALM`
+    when the key is absent, empty, or the ``extras`` attribute is missing
+    entirely (a pre-G0.3 stub target). Non-string / empty values fall
+    back to the default rather than producing a malformed realm path.
+    """
+    extras = getattr(target, "extras", None) or {}
+    admin = extras.get("admin_realm") if isinstance(extras, Mapping) else None
+    managed = extras.get("managed_realm") if isinstance(extras, Mapping) else None
+    return RealmConfig(
+        admin_realm=admin if isinstance(admin, str) and admin else DEFAULT_ADMIN_REALM,
+        managed_realm=managed if isinstance(managed, str) and managed else DEFAULT_MANAGED_REALM,
+    )
+
+
+# ---------------------------------------------------------------------------
+# Admin credential shapes (the client_credentials-vs-password discriminator)
+# ---------------------------------------------------------------------------
+
+
+@dataclass(frozen=True)
+class KeycloakClientCredentials:
+    """``client_credentials`` grant against a service-account client.
+
+    The preferred admin-auth path: a confidential client (``admin-cli``
+    with a secret, or a dedicated ``meho-admin`` client) with the
+    ``realm-management`` service-account roles needed to read realm
+    metadata.
+    """
+
+    client_id: str
+    client_secret: str
+
+
+@dataclass(frozen=True)
+class KeycloakPasswordCredentials:
+    """``password`` grant against ``admin-cli`` — the break-glass fallback.
+
+    Used when the operator stored an admin username/password rather than
+    a service-account client secret. ``client_id`` defaults to
+    ``admin-cli`` (the public client Keycloak ships for the
+    direct-access-grant password flow) but a target can override it via
+    a ``client_id`` field in the Vault secret.
+    """
+
+    username: str
+    password: str
+    client_id: str = "admin-cli"
+
+
+#: Tagged union of the two admin-credential shapes the connector accepts.
+KeycloakAdminCredentials = KeycloakClientCredentials | KeycloakPasswordCredentials
+
+#: Async callable resolving a ``(target, operator)`` pair to admin
+#: credentials. Injected on connector construction so production uses the
+#: live Vault read while unit tests pass a stub returning a pre-built
+#: credential object — the same dependency-injection seam the VCF / gh
+#: connectors expose.
+KeycloakAdminCredentialsLoader = Callable[
+    [KeycloakTargetLike, Operator], Awaitable[KeycloakAdminCredentials]
+]
+
+
+class KeycloakAmbiguousVaultPayloadError(Exception):
+    """The admin Vault secret carries neither admin-credential shape.
+
+    Raised when the KV-v2 payload at ``target.secret_ref`` has neither
+    the ``client_id`` + ``client_secret`` pair nor the ``username`` +
+    ``password`` pair. The message names both shapes and which fields
+    were present (no values echoed) so the operator can fix the secret.
+    """
+
+
+async def load_admin_credentials_from_vault(
+    target: KeycloakTargetLike,
+    operator: Operator,
+) -> KeycloakAdminCredentials:
+    """Default admin-credential loader — live operator-context Vault read.
+
+    Reads ``target.secret_ref`` as a KV-v2 secret **under the operator's
+    identity** (the operator's validated JWT is forwarded to Vault's
+    JWT/OIDC auth method via the shared
+    :func:`~meho_backplane.connectors._shared.vault_creds.load_vault_secret_data`
+    helper) and picks the admin-auth protocol from the payload shape:
+
+    * ``client_id`` + ``client_secret`` →
+      :class:`KeycloakClientCredentials`.
+    * ``username`` + ``password`` (when the client-credentials shape is
+      absent) → :class:`KeycloakPasswordCredentials`, carrying the
+      optional ``client_id`` override (default ``admin-cli``).
+    * neither → :class:`KeycloakAmbiguousVaultPayloadError`.
+
+    The error contract for the read itself is the shared helper's:
+    :class:`~meho_backplane.connectors._shared.vault_creds.VaultCredentialsReadError`
+    on read-phase failure (empty ``operator.raw_jwt`` for a
+    system-initiated call, unset ``secret_ref``, malformed payload) and
+    :class:`~meho_backplane.auth.vault.VaultClientError` on login-phase
+    failure. Both propagate verbatim so the connector can distinguish
+    login from read.
+
+    The returned credential object is ephemeral in-memory state — like
+    the shared helper's return, it must never enter a log event, an
+    :class:`~meho_backplane.connectors.schemas.OperationResult`, or any
+    durable artifact.
+    """
+    secret_data = await load_vault_secret_data(target, operator)
+    present = set(secret_data.keys())
+
+    if all(field in present for field in _CLIENT_FIELDS):
+        return KeycloakClientCredentials(
+            client_id=str(secret_data["client_id"]),
+            client_secret=str(secret_data["client_secret"]),
+        )
+    if all(field in present for field in _PASSWORD_FIELDS):
+        # ``client_id`` is optional in the password shape — Keycloak's
+        # direct-access-grant flow defaults to the ``admin-cli`` public
+        # client when the operator didn't store an explicit one.
+        client_id = secret_data.get("client_id")
+        return KeycloakPasswordCredentials(
+            username=str(secret_data["username"]),
+            password=str(secret_data["password"]),
+            client_id=str(client_id) if isinstance(client_id, str) and client_id else "admin-cli",
+        )
+
+    raise KeycloakAmbiguousVaultPayloadError(
+        "keycloak_ambiguous_vault_payload: Vault secret for target "
+        f"{target.name!r} (secret_ref={target.secret_ref!r}) does not carry "
+        "either admin-credential shape the keycloak connector supports. For "
+        f"the client_credentials path, populate both {list(_CLIENT_FIELDS)!r}; "
+        f"for the password break-glass fallback, populate both "
+        f"{list(_PASSWORD_FIELDS)!r}. Fields present in the secret: "
+        f"{sorted(present)!r}. See docs/codebase/connectors-keycloak.md "
+        "§ 'Admin credential discriminator' for the payload shape on each path."
+    )

--- a/backend/tests/test_connectors_keycloak_auth.py
+++ b/backend/tests/test_connectors_keycloak_auth.py
@@ -1,0 +1,483 @@
+# SPDX-License-Identifier: Apache-2.0
+# Copyright (c) 2026 evoila Group
+
+"""Unit tests for :class:`KeycloakConnector` admin-auth + fingerprint (G3.13-T1 #1393).
+
+Exercises the load-bearing Keycloak connector contract:
+
+* The **admin-vs-operator credential split** -- the connector mints an
+  admin token via the admin credential path
+  (``POST /realms/{admin_realm}/protocol/openid-connect/token``) and
+  sends ``Authorization: Bearer <admin_token>`` on admin calls. The
+  operator's OIDC token (``operator.raw_jwt``) is NEVER sent to Keycloak;
+  a dedicated test asserts the admin token, not the operator token,
+  reaches the admin surface.
+* ``client_credentials`` grant for a client-id/secret admin credential
+  and ``password`` grant for the break-glass username/password fallback.
+* Admin token caching with TTL refresh (a fresh token is reused; an
+  expired one is re-minted).
+* ``fingerprint()`` round-trips ``GET /admin/realms/{managed_realm}`` and
+  surfaces realm metadata + the server version from
+  ``GET /admin/serverinfo``; transport failure yields ``reachable=False``.
+* ``auth_model != "shared_service_account"`` (or ``None``) raises
+  :exc:`NotImplementedError`.
+* Empty ``operator.raw_jwt`` (system-initiated caller) fails closed.
+* Versioned + wildcard dual registration.
+
+Stubbing strategy: the credential loader is injected (no live Vault), and
+``respx`` mocks the Keycloak HTTP surface. ``base_url`` is
+``https://<host>`` (port 443 omitted by ``HttpConnector._base_url``).
+"""
+
+from __future__ import annotations
+
+from collections.abc import Iterator
+from dataclasses import dataclass, field
+from typing import Any
+from uuid import UUID
+
+import pytest
+import respx
+
+from meho_backplane.auth.operator import Operator, TenantRole
+from meho_backplane.connectors._shared.vault_creds import VaultCredentialsReadError
+from meho_backplane.connectors.adapters.http import HttpConnector
+from meho_backplane.connectors.keycloak import KeycloakConnector
+from meho_backplane.connectors.keycloak.connector import KeycloakAdminTokenError
+from meho_backplane.connectors.keycloak.session import (
+    KeycloakAdminCredentials,
+    KeycloakClientCredentials,
+    KeycloakPasswordCredentials,
+    KeycloakTargetLike,
+)
+from meho_backplane.connectors.registry import (
+    all_connectors_v2,
+    clear_registry,
+    register_connector_v2,
+)
+from meho_backplane.connectors.schemas import AuthModel
+
+_OPERATOR_JWT = "operator.oidc.token-DO-NOT-LEAK"
+_ADMIN_TOKEN = "kc-admin-token-abc-123"
+
+
+def _make_operator(raw_jwt: str = _OPERATOR_JWT) -> Operator:
+    """Return a minimal :class:`Operator` carrying a recognisable JWT.
+
+    The default ``raw_jwt`` is a sentinel string the split test scans the
+    captured admin requests for -- it must never appear on a Keycloak
+    admin call.
+    """
+    return Operator(
+        sub="test-operator",
+        name=None,
+        email=None,
+        raw_jwt=raw_jwt,
+        tenant_id=UUID(int=0),
+        tenant_role=TenantRole.OPERATOR,
+    )
+
+
+@pytest.fixture(autouse=True)
+def _clean_keycloak_registry() -> Iterator[None]:
+    """Re-register KeycloakConnector after sibling tests clear the registry.
+
+    ``test_connectors_registry_v2.py`` installs an autouse fixture that
+    calls :func:`clear_registry` between tests. Re-register before every
+    test in this module and clear after -- same pattern the vRLI / NSX
+    auth-test modules established.
+    """
+    clear_registry()
+    register_connector_v2(
+        product=KeycloakConnector.product,
+        version=KeycloakConnector.version,
+        impl_id=KeycloakConnector.impl_id,
+        cls=KeycloakConnector,
+    )
+    yield
+    clear_registry()
+
+
+# ---------------------------------------------------------------------------
+# Target stub -- satisfies KeycloakTargetLike Protocol structurally.
+# ---------------------------------------------------------------------------
+
+
+@dataclass
+class _StubTarget:
+    name: str
+    host: str
+    port: int | None = 443
+    secret_ref: str | None = "rdc-hetzner-dc/keycloak/admin"
+    auth_model: str | None = AuthModel.SHARED_SERVICE_ACCOUNT.value
+    extras: dict[str, Any] = field(default_factory=dict)
+
+
+_TARGET = _StubTarget(name="keycloak-a", host="keycloak-a.test.invalid")
+
+
+def _client_loader(
+    creds: KeycloakAdminCredentials,
+) -> Any:
+    """Return an injected loader yielding a fixed credential object."""
+
+    async def _load(_target: KeycloakTargetLike, _operator: Operator) -> KeycloakAdminCredentials:
+        return creds
+
+    return _load
+
+
+def _make_connector(
+    creds: KeycloakAdminCredentials | None = None,
+) -> KeycloakConnector:
+    """Build a connector wired with a stub credential loader."""
+    creds = creds or KeycloakClientCredentials(client_id="meho-admin", client_secret="s3cret")
+    return KeycloakConnector(credentials_loader=_client_loader(creds))
+
+
+# ---------------------------------------------------------------------------
+# ABC + registration plumbing
+# ---------------------------------------------------------------------------
+
+
+def test_keycloak_connector_subclasses_http_connector() -> None:
+    """The connector inherits from HttpConnector with the right v2 metadata."""
+    assert issubclass(KeycloakConnector, HttpConnector)
+    assert KeycloakConnector.product == "keycloak"
+    assert KeycloakConnector.version == "26.x"
+    assert KeycloakConnector.impl_id == "keycloak-admin"
+    assert KeycloakConnector.supported_version_range == ">=26.0,<27.0"
+    assert KeycloakConnector.priority == 1
+
+
+def test_package_import_registers_versioned_plus_wildcard() -> None:
+    """Importing the package registers BOTH versioned and wildcard v2 entries.
+
+    Drives the registry clear + reload itself so the assertion observes
+    the side-effect of importing the package rather than the autouse
+    fixture's re-registration -- the reload pattern the bind9 sibling
+    test uses for the same reason.
+    """
+    import importlib
+
+    import meho_backplane.connectors.keycloak as keycloak_pkg
+
+    clear_registry()
+    importlib.reload(keycloak_pkg)
+
+    v2 = all_connectors_v2()
+    assert v2[("keycloak", "26.x", "keycloak-admin")] is KeycloakConnector
+    # G0.15-T6 (#1215) wildcard fanout -- a fresh target with version=None
+    # resolves through the wildcard.
+    assert v2[("keycloak", "", "")] is KeycloakConnector
+
+
+# ---------------------------------------------------------------------------
+# Admin-vs-operator credential split (the load-bearing assertion)
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.asyncio
+async def test_admin_token_not_operator_token_used_on_admin_calls() -> None:
+    """The operator-OIDC token is NEVER sent to Keycloak; the admin token is.
+
+    This is the acceptance-criterion test for the admin-vs-operator
+    split. The connector mints an admin token via the token endpoint and
+    sends it as the Bearer on the admin realm GET; the operator's JWT
+    (used only to authorise the Vault credential read) must not appear on
+    any request to Keycloak.
+    """
+    connector = _make_connector()
+
+    async with respx.mock(base_url="https://keycloak-a.test.invalid") as mock:
+        token_route = mock.post("/realms/master/protocol/openid-connect/token").respond(
+            200, json={"access_token": _ADMIN_TOKEN, "expires_in": 60, "token_type": "Bearer"}
+        )
+        realm_route = mock.get("/admin/realms/evba").respond(
+            200, json={"realm": "evba", "enabled": True, "sslRequired": "external"}
+        )
+        mock.get("/admin/serverinfo").respond(200, json={"systemInfo": {"version": "26.0.5"}})
+        fp = await connector.fingerprint(_TARGET, operator=_make_operator())
+
+    assert fp.reachable is True
+
+    # The admin realm GET carried the admin token, NOT the operator token.
+    assert realm_route.called
+    realm_auth = realm_route.calls[0].request.headers.get("authorization")
+    assert realm_auth == f"Bearer {_ADMIN_TOKEN}"
+    assert _OPERATOR_JWT not in (realm_auth or "")
+
+    # The token POST itself carried no stale Authorization header (the
+    # grant credentials live in the form body) and never the operator JWT.
+    token_req = token_route.calls[0].request
+    assert "authorization" not in {k.lower() for k in token_req.headers}
+
+    # Defensive: the operator JWT appears on NO captured Keycloak request.
+    for call in mock.calls:
+        for value in call.request.headers.values():
+            assert _OPERATOR_JWT not in value
+        assert _OPERATOR_JWT not in call.request.read().decode(errors="ignore")
+
+    await connector.aclose()
+
+
+@pytest.mark.asyncio
+async def test_client_credentials_grant_form_body() -> None:
+    """A client-id/secret credential mints via the client_credentials grant."""
+    connector = _make_connector(
+        KeycloakClientCredentials(client_id="meho-admin", client_secret="s3cret")
+    )
+
+    async with respx.mock(base_url="https://keycloak-a.test.invalid") as mock:
+        token_route = mock.post("/realms/master/protocol/openid-connect/token").respond(
+            200, json={"access_token": _ADMIN_TOKEN, "expires_in": 60}
+        )
+        mock.get("/admin/realms/evba").respond(200, json={"realm": "evba", "enabled": True})
+        mock.get("/admin/serverinfo").respond(404)
+        await connector.fingerprint(_TARGET, operator=_make_operator())
+
+    body = token_route.calls[0].request.read().decode()
+    assert "grant_type=client_credentials" in body
+    assert "client_id=meho-admin" in body
+    assert "client_secret=s3cret" in body
+    ctype = token_route.calls[0].request.headers.get("content-type", "")
+    assert ctype.startswith("application/x-www-form-urlencoded")
+
+    await connector.aclose()
+
+
+@pytest.mark.asyncio
+async def test_password_grant_form_body() -> None:
+    """A username/password credential mints via the password grant on admin-cli."""
+    connector = _make_connector(KeycloakPasswordCredentials(username="admin", password="pw"))
+
+    async with respx.mock(base_url="https://keycloak-a.test.invalid") as mock:
+        token_route = mock.post("/realms/master/protocol/openid-connect/token").respond(
+            200, json={"access_token": _ADMIN_TOKEN, "expires_in": 60}
+        )
+        mock.get("/admin/realms/evba").respond(200, json={"realm": "evba", "enabled": True})
+        mock.get("/admin/serverinfo").respond(404)
+        await connector.fingerprint(_TARGET, operator=_make_operator())
+
+    body = token_route.calls[0].request.read().decode()
+    assert "grant_type=password" in body
+    assert "client_id=admin-cli" in body
+    assert "username=admin" in body
+    assert "password=pw" in body
+
+    await connector.aclose()
+
+
+# ---------------------------------------------------------------------------
+# Token caching + TTL refresh
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.asyncio
+async def test_admin_token_cached_across_calls() -> None:
+    """A fresh admin token is reused -- the token endpoint is hit once."""
+    connector = _make_connector()
+
+    async with respx.mock(base_url="https://keycloak-a.test.invalid") as mock:
+        token_route = mock.post("/realms/master/protocol/openid-connect/token").respond(
+            200, json={"access_token": _ADMIN_TOKEN, "expires_in": 3600}
+        )
+        h1 = await connector.auth_headers(_TARGET, operator=_make_operator())
+        h2 = await connector.auth_headers(_TARGET, operator=_make_operator())
+
+    assert h1 == h2 == {"Authorization": f"Bearer {_ADMIN_TOKEN}"}
+    assert token_route.call_count == 1
+
+    await connector.aclose()
+
+
+@pytest.mark.asyncio
+async def test_admin_token_re_minted_when_expired(monkeypatch: pytest.MonkeyPatch) -> None:
+    """An expired cached token is re-minted on the next call.
+
+    Drives the TTL path by advancing the monotonic clock the connector
+    caches against past the token's effective expiry.
+    """
+    connector = _make_connector()
+    clock = {"now": 1000.0}
+    monkeypatch.setattr(
+        "meho_backplane.connectors.keycloak.connector.time.monotonic",
+        lambda: clock["now"],
+    )
+
+    async with respx.mock(base_url="https://keycloak-a.test.invalid") as mock:
+        token_route = mock.post("/realms/master/protocol/openid-connect/token").respond(
+            # expires_in=60, refresh margin 30 -> effective TTL 30s.
+            200,
+            json={"access_token": _ADMIN_TOKEN, "expires_in": 60},
+        )
+        await connector.auth_headers(_TARGET, operator=_make_operator())
+        # Advance past the 30s effective TTL.
+        clock["now"] = 1000.0 + 31.0
+        await connector.auth_headers(_TARGET, operator=_make_operator())
+
+    assert token_route.call_count == 2
+
+    await connector.aclose()
+
+
+# ---------------------------------------------------------------------------
+# fingerprint
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.asyncio
+async def test_fingerprint_surfaces_realm_metadata_and_version() -> None:
+    """fingerprint() returns realm metadata + server version under extras."""
+    connector = _make_connector()
+
+    async with respx.mock(base_url="https://keycloak-a.test.invalid") as mock:
+        mock.post("/realms/master/protocol/openid-connect/token").respond(
+            200, json={"access_token": _ADMIN_TOKEN, "expires_in": 60}
+        )
+        mock.get("/admin/realms/evba").respond(
+            200,
+            json={
+                "realm": "evba",
+                "enabled": True,
+                "sslRequired": "external",
+                "loginTheme": "meho",
+            },
+        )
+        mock.get("/admin/serverinfo").respond(200, json={"systemInfo": {"version": "26.0.5"}})
+        fp = await connector.fingerprint(_TARGET, operator=_make_operator())
+
+    assert fp.reachable is True
+    assert fp.vendor == "keycloak"
+    assert fp.product == "keycloak"
+    assert fp.version == "26.0.5"
+    assert fp.probe_method == "GET /admin/realms/evba"
+    assert fp.extras["realm"] == "evba"
+    assert fp.extras["enabled"] is True
+    assert fp.extras["ssl_required"] == "external"
+    assert fp.extras["login_theme"] == "meho"
+    assert fp.extras["admin_realm"] == "master"
+    assert fp.extras["managed_realm"] == "evba"
+
+    await connector.aclose()
+
+
+@pytest.mark.asyncio
+async def test_fingerprint_version_none_when_serverinfo_unavailable() -> None:
+    """A 404 on /admin/serverinfo leaves version=None but keeps reachable=True."""
+    connector = _make_connector()
+
+    async with respx.mock(base_url="https://keycloak-a.test.invalid") as mock:
+        mock.post("/realms/master/protocol/openid-connect/token").respond(
+            200, json={"access_token": _ADMIN_TOKEN, "expires_in": 60}
+        )
+        mock.get("/admin/realms/evba").respond(200, json={"realm": "evba", "enabled": True})
+        mock.get("/admin/serverinfo").respond(404)
+        fp = await connector.fingerprint(_TARGET, operator=_make_operator())
+
+    assert fp.reachable is True
+    assert fp.version is None
+
+    await connector.aclose()
+
+
+@pytest.mark.asyncio
+async def test_fingerprint_unreachable_on_transport_error() -> None:
+    """A token-endpoint failure yields reachable=False with extras['error']."""
+    connector = _make_connector()
+
+    async with respx.mock(base_url="https://keycloak-a.test.invalid") as mock:
+        mock.post("/realms/master/protocol/openid-connect/token").respond(503)
+        fp = await connector.fingerprint(_TARGET, operator=_make_operator())
+
+    assert fp.reachable is False
+    assert "error" in fp.extras
+    assert fp.version is None
+
+    await connector.aclose()
+
+
+@pytest.mark.asyncio
+async def test_fingerprint_honours_target_realm_overrides() -> None:
+    """extras admin_realm / managed_realm steer the token + realm paths."""
+    target = _StubTarget(
+        name="keycloak-b",
+        host="keycloak-b.test.invalid",
+        extras={"admin_realm": "ops", "managed_realm": "tenant-x"},
+    )
+    connector = _make_connector()
+
+    async with respx.mock(base_url="https://keycloak-b.test.invalid") as mock:
+        token_route = mock.post("/realms/ops/protocol/openid-connect/token").respond(
+            200, json={"access_token": _ADMIN_TOKEN, "expires_in": 60}
+        )
+        realm_route = mock.get("/admin/realms/tenant-x").respond(
+            200, json={"realm": "tenant-x", "enabled": True}
+        )
+        mock.get("/admin/serverinfo").respond(404)
+        fp = await connector.fingerprint(target, operator=_make_operator())
+
+    assert token_route.called
+    assert realm_route.called
+    assert fp.extras["admin_realm"] == "ops"
+    assert fp.extras["managed_realm"] == "tenant-x"
+
+    await connector.aclose()
+
+
+# ---------------------------------------------------------------------------
+# Auth-model boundary + fail-closed guards
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.asyncio
+async def test_auth_headers_rejects_unsupported_auth_model() -> None:
+    """A non-shared_service_account auth_model raises NotImplementedError."""
+    connector = _make_connector()
+    target = _StubTarget(
+        name="keycloak-peruser",
+        host="keycloak-peruser.test.invalid",
+        auth_model=AuthModel.PER_USER.value,
+    )
+    with pytest.raises(NotImplementedError, match="keycloak-peruser"):
+        await connector.auth_headers(target, operator=_make_operator())
+
+    await connector.aclose()
+
+
+@pytest.mark.asyncio
+async def test_admin_token_fails_closed_without_operator_jwt() -> None:
+    """An empty operator.raw_jwt is rejected before the cache lookup."""
+    connector = _make_connector()
+    with pytest.raises(VaultCredentialsReadError, match="keycloak-a"):
+        await connector.auth_headers(_TARGET, operator=_make_operator(raw_jwt=""))
+
+    await connector.aclose()
+
+
+@pytest.mark.asyncio
+async def test_mint_admin_token_raises_on_missing_access_token() -> None:
+    """A 200 token response without access_token raises KeycloakAdminTokenError."""
+    connector = _make_connector()
+
+    async with respx.mock(base_url="https://keycloak-a.test.invalid") as mock:
+        mock.post("/realms/master/protocol/openid-connect/token").respond(
+            200, json={"token_type": "Bearer"}
+        )
+        with pytest.raises(KeycloakAdminTokenError, match="keycloak-a"):
+            await connector.auth_headers(_TARGET, operator=_make_operator())
+
+    await connector.aclose()
+
+
+# ---------------------------------------------------------------------------
+# Registrar seam -- T1 ships zero ops
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.asyncio
+async def test_register_operations_ships_zero_ops() -> None:
+    """The registrar seam is wired but ships no ops in T1 (read ops land in T2)."""
+    # No exception, no DB writes -- the no-op registrar is callable so the
+    # lifespan's run_typed_op_registrars already drives Keycloak.
+    await KeycloakConnector.register_operations()

--- a/backend/tests/test_connectors_registry_v2.py
+++ b/backend/tests/test_connectors_registry_v2.py
@@ -445,6 +445,21 @@ def test_holodeck_connector_registered_under_v2_triple() -> None:
     assert snapshot[key] is HolodeckConnector
 
 
+def test_keycloak_connector_registered_under_v2_triple() -> None:
+    """KeycloakConnector package registers under (keycloak, 26.x, keycloak-admin).
+
+    G3.13-T1 (#1393) substrate. Same idempotent-registration pattern as
+    the SDDC Manager / Harbor / pfSense tests above.
+    """
+    from meho_backplane.connectors.keycloak import KeycloakConnector
+
+    _ensure_registered_v2(KeycloakConnector)
+    snapshot = all_connectors_v2()
+    key = ("keycloak", "26.x", "keycloak-admin")
+    assert key in snapshot
+    assert snapshot[key] is KeycloakConnector
+
+
 # ---------------------------------------------------------------------------
 # registered_product_tokens — G0.14-T3 #1144
 # ---------------------------------------------------------------------------

--- a/cli/api/openapi.json
+++ b/cli/api/openapi.json
@@ -15198,6 +15198,7 @@
               "hetzner-robot",
               "holodeck",
               "k8s",
+              "keycloak",
               "nsx",
               "pfsense",
               "sddc-manager",

--- a/cli/internal/api/client.gen.go
+++ b/cli/internal/api/client.gen.go
@@ -285,6 +285,7 @@ const (
 	HetznerRobot  TargetCreateProduct = "hetzner-robot"
 	Holodeck      TargetCreateProduct = "holodeck"
 	K8s           TargetCreateProduct = "k8s"
+	Keycloak      TargetCreateProduct = "keycloak"
 	Nsx           TargetCreateProduct = "nsx"
 	Pfsense       TargetCreateProduct = "pfsense"
 	SddcManager   TargetCreateProduct = "sddc-manager"

--- a/docs/codebase/connectors-keycloak.md
+++ b/docs/codebase/connectors-keycloak.md
@@ -1,0 +1,144 @@
+# Connector: Keycloak (keycloak-admin)
+
+## Overview
+
+`KeycloakConnector` is the typed connector for the Keycloak Admin REST
+API. MEHO runs Keycloak as its own identity provider on the RDC fleet;
+this connector manages that Keycloak through its Admin REST surface.
+
+G3.13-T1 (#1393) ships the **substrate**: the connector class, the admin
+credential loader, `fingerprint()`, and dual registry registration. Read
+operations land in T2 and onboarding docs in T3. The module ships **zero**
+typed operations — the typed-op registrar seam is wired (so the lifespan
+already drives Keycloak) but the op walk is empty until T2.
+
+Registry v2 triple: `(product="keycloak", version="26.x",
+impl_id="keycloak-admin")`, plus the `(keycloak, "", "")` wildcard so a
+fresh target with no asserted version still resolves.
+
+## Key types
+
+- `KeycloakConnector` (`connectors/keycloak/connector.py`) — the
+  `HttpConnector` subclass. Holds a per-target admin-token cache with
+  TTL-driven refresh and an injectable admin-credential loader.
+- `KeycloakClientCredentials` / `KeycloakPasswordCredentials`
+  (`connectors/keycloak/session.py`) — the two admin-credential shapes
+  (tagged union `KeycloakAdminCredentials`).
+- `KeycloakTargetLike` — structural Protocol the concrete `Target` model
+  satisfies; adds `extras` (carrying the realm overrides) to the common
+  REST-target shape.
+- `RealmConfig` — the resolved `(admin_realm, managed_realm)` pair.
+- `KeycloakAdminTokenError` — raised when the token-endpoint round-trip
+  fails or returns no usable `access_token`.
+- `KeycloakAmbiguousVaultPayloadError` — raised when the admin Vault
+  secret carries neither credential shape.
+
+## The admin-vs-operator credential split (load-bearing)
+
+MEHO authenticates its own callers with operator-OIDC tokens that
+Keycloak issues. The connector that *manages* Keycloak must **not**
+authenticate through that path, or it could never bootstrap a freshly
+deployed Keycloak whose operator-login clients are not yet configured
+(a chicken-and-egg).
+
+So the connector uses a **separate admin credential**:
+
+1. The operator's validated JWT (`operator.raw_jwt`) authorises only an
+   operator-context Vault KV-v2 read of the admin credential at the
+   consumer path `secret/rdc-hetzner-dc/keycloak/admin` (the locked
+   Option A decision in `docs/architecture/connector-auth.md`).
+2. The connector exchanges that admin credential at Keycloak's own token
+   endpoint — `POST /realms/{admin_realm}/protocol/openid-connect/token`,
+   form-encoded — for an admin access token.
+3. The admin token is sent as `Authorization: Bearer <admin_token>` on
+   every Admin REST call.
+
+The operator's OIDC token is **never** sent to Keycloak. A unit test
+(`test_admin_token_not_operator_token_used_on_admin_calls`) asserts the
+operator JWT appears on no captured Keycloak request.
+
+### Admin credential discriminator
+
+The admin Vault secret carries one of two shapes; the loader picks the
+grant from the payload (the same payload-shape discriminator the gh-rest
+connector uses for App-vs-PAT):
+
+| Vault fields present | Credential | Grant |
+|---|---|---|
+| `client_id` + `client_secret` | `KeycloakClientCredentials` | `client_credentials` |
+| `username` + `password` (no client pair) | `KeycloakPasswordCredentials` | `password` on `admin-cli` |
+| neither | `KeycloakAmbiguousVaultPayloadError` | — |
+
+The password shape accepts an optional `client_id` field (default
+`admin-cli`, Keycloak's public direct-access-grant client).
+
+## Control flow
+
+- `auth_headers(target, operator)` — rejects any `auth_model` other than
+  `shared_service_account` / `None`, then returns the admin Bearer via
+  `_admin_token`.
+- `_admin_token` — fail-closed on empty `operator.raw_jwt` *before* the
+  cache lookup (a system caller must never get an authenticated caller's
+  cached token); returns the cached token if fresh, else mints via
+  `_mint_admin_token` under a per-connector lock.
+- `_mint_admin_token` — loads the admin credential (operator-context
+  Vault read), POSTs the form body to the token endpoint with no
+  `Authorization` header, parses `access_token` + `expires_in`, and
+  caches with `effective_ttl = expires_in - 30s` (floored at 1s).
+- `fingerprint(target, operator)` — mints the admin token, GETs
+  `/admin/realms/{managed_realm}`, and surfaces `realm` / `enabled` /
+  `ssl_required` / `login_theme` + the resolved realm pair under
+  `extras`. Best-effort server version from `/admin/serverinfo`
+  (`systemInfo.version`); a 404 there leaves `version=None` but keeps
+  `reachable=True`. A `None` operator falls back to the synthesised
+  system operator, which fails closed at the live Vault read (surfaced as
+  `reachable=False`).
+- `probe(target)` — delegates to `fingerprint`; one admin round-trip
+  covers reachability + admin-auth validity.
+
+## Target configuration
+
+Base URL is `https://{host}[:{port}]` from `HttpConnector._base_url`. The
+two realm knobs live on `target.extras` (no schema migration):
+
+- `admin_realm` — realm the admin client authenticates against (default
+  `master`).
+- `managed_realm` — realm the connector manages + fingerprints (default
+  `evba`).
+
+Resolved through `resolve_realm_config`, which tolerates a missing
+`extras` attribute and falls back to the defaults.
+
+## Dependencies
+
+- `connectors/adapters/http.py` — `HttpConnector` base (client pooling,
+  retry/timeout, `_get_json`).
+- `connectors/_shared/vault_creds.py` — `load_vault_secret_data` (the
+  operator-context KV-v2 read) and `VaultCredentialsReadError`.
+- `connectors/_shared/vcf_auth.py` — `is_acceptable_auth_model` (the
+  shared auth-model boundary gate).
+- `connectors/_shared/system_operator.py` — `synthesise_system_operator`
+  for the operator-less probe path.
+- `operations/typed_register.py` — `register_typed_op_registrar` (the
+  T2 seam).
+- `httpx` 0.28.x — async HTTP transport.
+
+## Known issues / future work
+
+- T2 (#1394 et al.) fills the read-op walk in
+  `KeycloakConnector.register_operations`.
+- No logout-revoke on `aclose` — admin access tokens are short-lived;
+  revoke-on-close is deferred (same posture as NSX / vRLI).
+- `/admin/serverinfo` is undocumented (though stable across 26.x); the
+  version read is best-effort and non-fatal by design.
+
+## References
+
+- Issue: https://github.com/evoila/meho/issues/1393
+- Parent initiative: https://github.com/evoila/meho/issues/1388
+- Keycloak token endpoint + client_credentials grant:
+  https://www.keycloak.org/securing-apps/oidc-layers
+- RealmRepresentation:
+  https://www.keycloak.org/docs-api/latest/javadocs/org/keycloak/representations/idm/RealmRepresentation.html
+- ServerInfoRepresentation:
+  https://www.keycloak.org/docs-api/latest/javadocs/org/keycloak/representations/info/ServerInfoRepresentation.html


### PR DESCRIPTION
## Summary
- Lands the **substrate** for the Keycloak Admin REST connector (G3.13-T1): `KeycloakConnector(HttpConnector)`, a Vault-backed admin credential loader, `fingerprint()`, and dual registry registration. Read ops (T2) and onboarding docs (T3) build on this.
- **The load-bearing design point — admin-vs-operator credential split.** MEHO authenticates its own callers with operator-OIDC tokens Keycloak issues; the connector that *manages* Keycloak must not depend on that path (bootstrap chicken-and-egg). The operator JWT authorises only the operator-context Vault read of a **separate** admin credential (`secret/rdc-hetzner-dc/keycloak/admin`); that credential is exchanged at Keycloak's token endpoint for an admin token, cached with TTL refresh, and sent on every Admin REST call. The operator token is **never** sent to Keycloak.
- Admin credential supports both the `client_credentials` grant (service-account client) and the `password` grant (`admin-cli` break-glass), picked from the Vault payload shape. Base URL + admin realm (default `master`) + managed realm (default `evba`) are target-configurable via `target.extras`.
- Registers versioned `(keycloak, 26.x, keycloak-admin)` + the `(keycloak, "", "")` wildcard, and queues a no-op typed-op registrar seam for T2. **No read ops yet.**

## Test plan
- [x] `ruff check` — clean
- [x] `ruff format --check` — clean
- [x] `mypy src/meho_backplane/` — Success: no issues found in 417 source files
- [x] `pytest tests/test_connectors_keycloak_auth.py tests/test_connectors_registry_v2.py` — 45 passed
- [x] **AC1** `keycloak` resolves via `register_connector_v2` (versioned + wildcard) — `test_package_import_registers_versioned_plus_wildcard`, `test_keycloak_connector_registered_under_v2_triple`, eager-import smoke
- [x] **AC2** `fingerprint()` authenticates via the admin path and round-trips `GET /admin/realms/{realm}` — `test_fingerprint_surfaces_realm_metadata_and_version`
- [x] **AC3** admin-vs-operator split enforced in code AND unit-tested (operator token asserted absent from all Keycloak calls) — `test_admin_token_not_operator_token_used_on_admin_calls`
- [x] **AC4** connector-registry coverage assertions still pass; no read ops — `test_register_operations_ships_zero_ops`, registry-v2 suite + resolver/base suites green
- [x] code-quality gate (`--diff`) — 0 blockers (3 size warnings, docstring-dominated; functions well under the 100-line block threshold)

## Out of scope
- Read ops (G3.13-T2) — the typed-op registrar seam is wired but ships zero ops.
- Onboarding docs (G3.13-T3).
- No logout-revoke on `aclose` (admin tokens are short-lived; same posture as NSX / vRLI).

<!-- auto-implement-issue: fresh, iteration 1 -->

Closes #1393


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **New Features**
  * Added Keycloak Admin connector to interact with Keycloak identity management systems
  * Supports client credentials and password grant authentication flows
  * Secures admin credentials through Vault integration
  * Includes realm reachability verification and metadata retrieval

* **Documentation**
  * Added comprehensive Keycloak connector documentation with configuration and usage guidance

<!-- end of auto-generated comment: release notes by coderabbit.ai -->