### PR TITLE
feat(connectors): G3.12-T1 ArgoCdConnector skeleton — bearer-token Vault loader + fingerprint(GET /api/version) + dual registration

### DIFF
--- a/backend/src/meho_backplane/connectors/argocd/__init__.py
+++ b/backend/src/meho_backplane/connectors/argocd/__init__.py
@@ -1,0 +1,74 @@
+# SPDX-License-Identifier: Apache-2.0
+# Copyright (c) 2026 evoila Group
+
+"""meho_backplane.connectors.argocd — ArgoCdConnector package.
+
+Importing this package registers :class:`ArgoCdConnector` against the v2
+connector registry under the natural key
+``(product="argocd", version="3.x", impl_id="argocd-api")`` **and** the
+``(product="argocd", version="", impl_id="")`` wildcard fallback — dual
+registration from day one per G0.15-T6 (#1215).
+
+Registration is **synchronous (import time)** only at this Task's stage:
+the v2 registry entries land via
+:func:`~meho_backplane.connectors.registry.register_connector_v2` so the
+lookup tables are populated before the lifespan begins and a probe firing
+during startup sees a fully-populated registry. The
+:func:`~meho_backplane.connectors.registry._eager_import_connectors` walk
+discovers this subpackage by directory name, so no manual import-list edit
+is needed elsewhere.
+
+The asynchronous (lifespan startup) typed-op registrar — queued via
+:func:`~meho_backplane.operations.typed_register.register_typed_op_registrar`
+the way Harbor (#621) and bind9 (#367) do — is deliberately **not** queued
+here. G3.12-T1 ships the substrate (connector class + bearer-token
+credential loader + fingerprint + dual registration) with zero operations;
+the curated read core (``argocd.app.list`` / ``argocd.app.get`` /
+``argocd.app.diff`` / ``argocd.app.resource_tree`` /
+``argocd.appproject.list`` / ``argocd.repo.list``) and its registrar arrive
+in G3.12-T2. Queuing an empty registrar now would add a no-op startup hook
+with nothing to upsert.
+
+The v1 :func:`~meho_backplane.connectors.registry.register_connector` entry
+point is intentionally **not** called: ArgoCD has no v1 chassis history,
+and the v1 entry would land as ``("argocd", "", "")`` and confuse the
+resolver tie-break ladder. Only the v2 triple (+ wildcard) advertises this
+class — the same decision Harbor, bind9, NSX, and SDDC Manager made.
+"""
+
+from meho_backplane.connectors.argocd.connector import ArgoCdConnector
+from meho_backplane.connectors.argocd.session import (
+    ARGOCD_TOKEN_FIELD,
+    ArgoCdCredentialsLoader,
+    ArgoCdTargetLike,
+    load_credentials_from_vault,
+)
+from meho_backplane.connectors.registry import register_connector_v2
+
+# v2 entry -- the canonical resolver key. The versioned triple always wins
+# the resolver tie-break when both it and the wildcard are present.
+register_connector_v2(
+    product="argocd",
+    version="3.x",
+    impl_id="argocd-api",
+    cls=ArgoCdConnector,
+)
+
+# G0.15-T6 (#1215) wildcard fallback -- a target with ``version=None``
+# (fresh, unfingerprinted, no operator-asserted version yet) resolves to
+# this connector through the resolver's ``versioned_over_wildcard`` step
+# rather than 501-ing with ``no_connector``.
+register_connector_v2(
+    product="argocd",
+    version="",
+    impl_id="",
+    cls=ArgoCdConnector,
+)
+
+__all__ = [
+    "ARGOCD_TOKEN_FIELD",
+    "ArgoCdConnector",
+    "ArgoCdCredentialsLoader",
+    "ArgoCdTargetLike",
+    "load_credentials_from_vault",
+]

--- a/backend/src/meho_backplane/connectors/argocd/connector.py
+++ b/backend/src/meho_backplane/connectors/argocd/connector.py
@@ -1,0 +1,401 @@
+# SPDX-License-Identifier: Apache-2.0
+# Copyright (c) 2026 evoila Group
+
+"""ArgoCdConnector — hand-rolled HttpConnector subclass for ArgoCD 3.x.
+
+Skeleton-only — bearer-token auth + fingerprint + probe + the G0.6
+dispatch shim. The curated read ops (``argocd.app.list`` /
+``argocd.app.get`` / ``argocd.app.diff`` / ``argocd.app.resource_tree`` /
+``argocd.appproject.list`` / ``argocd.repo.list``) arrive in G3.12-T2 via
+``register_typed_operation``.
+
+Registered against the v2 registry at module-import time via
+:func:`~meho_backplane.connectors.registry.register_connector_v2` in
+:mod:`meho_backplane.connectors.argocd.__init__` (versioned + wildcard,
+per G0.15-T6 dual registration).
+
+Auth
+----
+
+``argocd-server`` authenticates with a JWT **bearer token** sent on every
+request: ``Authorization: Bearer <token>``. The token is an ArgoCD
+project/account API token minted in ArgoCD (``argocd account
+generate-token`` or a ``project`` token) and stored under the target's
+``secret_ref`` as a KV-v2 secret with a ``token`` field. The connector
+caches the loaded token (read once from Vault via an injectable loader)
+and computes the ``Authorization: Bearer`` header on each
+:meth:`auth_headers` call.
+
+This is simpler than the SDDC Manager / vmware session-POST (no login
+round-trip, no session cookie) and the GitHub App-JWT exchange (no
+short-lived-token mint): the stored token is sent verbatim. There is no
+username component — unlike Harbor's Basic auth, the credential is a
+single opaque string.
+
+Auth model gating
+-----------------
+
+The bearer token is a shared service-account credential, so this
+connector locks to :attr:`AuthModel.SHARED_SERVICE_ACCOUNT` (or ``None``
+for pre-G0.3 targets where the column hasn't been populated yet).
+:meth:`auth_headers` rejects any other ``target.auth_model`` value with a
+clear :exc:`NotImplementedError` naming both the target and the requested
+mode — the same boundary the Harbor and SDDC Manager connectors enforce.
+
+Fingerprint
+-----------
+
+``GET /api/version`` returns ArgoCD's ``VersionMessage`` payload (an
+unauthenticated endpoint on ``argocd-server``). The connector surfaces
+``Version`` as the canonical ``version`` and carries the build-tool
+versions (``BuildDate``, ``KustomizeVersion``, ``HelmVersion``,
+``KubectlVersion``) under ``extras`` — the same payload an operator gets
+from ``argocd version -o json`` (server block). Field names are the
+gRPC-gateway-serialized proto field names (PascalCase) from
+``server/version/version.proto``.
+
+Probe
+-----
+
+``probe()`` delegates to ``fingerprint()`` — the same precedent the SDDC
+Manager and NSX connectors established. ``GET /api/version`` is a cheap,
+unauthenticated reachability check; ArgoCD exposes no dedicated composite
+health endpoint comparable to Harbor's ``/api/v2.0/health``, so the
+version probe is the right reachability surface.
+
+Operations
+----------
+
+This module ships zero operations — the G0.6 dispatch shim :meth:`execute`
+exists for ABC compatibility but the curated read ops land via
+G3.12-T2's ``register_typed_operation`` upserts. Until then, the
+connector is registered and discoverable but ``execute(target, op_id,
+...)`` against any ``op_id`` resolves to "unknown operation" at the
+dispatcher layer — the correct behaviour for a registered-but-empty
+connector at this Task's stage.
+"""
+
+from __future__ import annotations
+
+import asyncio
+from datetime import UTC, datetime
+from typing import Any
+
+import httpx
+import structlog
+from tenacity import retry, retry_if_exception, stop_after_attempt, wait_exponential
+
+from meho_backplane.auth.operator import Operator
+from meho_backplane.connectors._shared.system_operator import is_system_operator
+from meho_backplane.connectors.adapters.http import HttpConnector
+from meho_backplane.connectors.argocd.session import (
+    ARGOCD_TOKEN_FIELD,
+    ArgoCdCredentialsLoader,
+    ArgoCdTargetLike,
+    load_credentials_from_vault,
+)
+from meho_backplane.connectors.schemas import (
+    AuthModel,
+    FingerprintResult,
+    OperationResult,
+    ProbeResult,
+)
+
+__all__ = ["ArgoCdConnector"]
+
+_log = structlog.get_logger(__name__)
+
+#: The ArgoCD server version endpoint. Unauthenticated; returns the
+#: ``VersionMessage`` payload. Used by both fingerprint() and probe().
+_VERSION_PATH = "/api/version"
+_PROBE_METHOD = f"GET {_VERSION_PATH}"
+
+
+def _version_retryable(exc: BaseException) -> bool:
+    """Retry the version probe on connection errors and 5xx; never on 4xx.
+
+    Mirrors :func:`HttpConnector._retryable`'s policy. Defined locally so
+    the unauthenticated version GET (which bypasses the base
+    ``_request_json`` retry wrapper because it must not send an
+    ``Authorization`` header) keeps the same idempotent-GET retry
+    semantics without reaching into the adapter module's private name.
+    """
+    if isinstance(exc, (httpx.ConnectError, httpx.ConnectTimeout, httpx.ReadError)):
+        return True
+    if isinstance(exc, httpx.HTTPStatusError):
+        return 500 <= exc.response.status_code < 600
+    return False
+
+
+def _is_acceptable_auth_model(value: Any) -> bool:
+    """Return ``True`` iff *value* is the SHARED_SERVICE_ACCOUNT mode or unset.
+
+    Accepts the enum member, the equivalent string, and ``None`` (the
+    "auth_model column not yet populated" sentinel for pre-G0.3 targets).
+    Any other value is rejected by the caller. Same predicate the Harbor /
+    SDDC Manager / NSX precedents use; inlined here to keep connectors
+    decoupled.
+    """
+    if value is None:
+        return True
+    if value is AuthModel.SHARED_SERVICE_ACCOUNT:
+        return True
+    return bool(value == AuthModel.SHARED_SERVICE_ACCOUNT.value)
+
+
+class ArgoCdConnector(HttpConnector):
+    """ArgoCD 3.x REST connector with bearer-token auth.
+
+    Per-target token cached in :attr:`_creds_cache` (loaded once via the
+    injectable :class:`ArgoCdCredentialsLoader`). The bearer token is sent
+    on every request via ``Authorization: Bearer <token>`` — no session is
+    established and no 401-driven re-login is needed.
+
+    The :attr:`priority` is set to ``1`` so a future ``GenericRestConnector``
+    auto-shim that somehow registers for the same triple loses the
+    registry's tie-break ladder.
+    """
+
+    # G0.6 v2 registry metadata. The (product, version, impl_id) triple
+    # matches the dispatcher's parse_connector_id contract:
+    # ``"argocd-api-3.x"`` -> (``"argocd"``, ``"3.x"``, ``"argocd-api"``).
+    product = "argocd"
+    version = "3.x"
+    impl_id = "argocd-api"
+    supported_version_range = ">=2.0,<4.0"
+    priority = 1
+
+    def __init__(
+        self,
+        *,
+        credentials_loader: ArgoCdCredentialsLoader | None = None,
+    ) -> None:
+        super().__init__()
+        self._creds_cache: dict[str, dict[str, str]] = {}
+        self._creds_lock = asyncio.Lock()
+        self._credentials_loader: ArgoCdCredentialsLoader = (
+            credentials_loader if credentials_loader is not None else load_credentials_from_vault
+        )
+
+    async def auth_headers(self, target: ArgoCdTargetLike, operator: Operator) -> dict[str, str]:
+        """Return ``{"Authorization": "Bearer <token>"}`` for the request.
+
+        Loads the API token from Vault on first call against *target*,
+        caches it, and reuses the cached value on subsequent calls. The
+        full ``operator`` is forwarded to :meth:`_load_credentials` so the
+        live default loader reads the per-target Vault secret under the
+        operator's identity (``vault_client_for_operator(operator)``).
+        :attr:`AuthModel.SHARED_SERVICE_ACCOUNT` selects the Vault-sourced
+        token once the loader has resolved it; the operator's JWT only
+        authenticates the read, not the ArgoCD request itself.
+
+        Raises :exc:`NotImplementedError` if ``target.auth_model`` is
+        anything other than ``shared_service_account`` or ``None``.
+        """
+        auth_model = getattr(target, "auth_model", None)
+        if not _is_acceptable_auth_model(auth_model):
+            raise NotImplementedError(
+                f"ArgoCdConnector only supports auth_model="
+                f"{AuthModel.SHARED_SERVICE_ACCOUNT.value!r}; target "
+                f"{target.name!r} requested auth_model={auth_model!r}"
+            )
+        creds = await self._load_credentials(target, operator)
+        return {"Authorization": f"Bearer {creds[ARGOCD_TOKEN_FIELD]}"}
+
+    async def _load_credentials(
+        self, target: ArgoCdTargetLike, operator: Operator
+    ) -> dict[str, str]:
+        """Return the cached token for *target*, loading from Vault on first use.
+
+        The lock serialises concurrent first-use callers for the same
+        target; subsequent calls take the fast path under the same lock.
+        The loaded dict must contain a ``"token"`` key; a missing key
+        raises a :exc:`RuntimeError` naming the target and the missing key
+        so operators can identify a misconfigured Vault path.
+
+        ``operator`` is forwarded to the :class:`ArgoCdCredentialsLoader`
+        so the default loader can read the per-target Vault secret under
+        the operator's identity (G3.10-T1's live read). The default loader
+        is the thin argocd-specific entry point to the shared
+        operator-context Vault read; injected test loaders accept the same
+        ``(target, operator)`` pair.
+
+        The cache fast-path is closed to the synthesised system operator
+        (``is_system_operator``): a system/operator-less caller always runs
+        the loader so its fail-closed guard applies, and can never be
+        served a warm token a real operator primed but it could not resolve
+        itself (#1008). Real-operator behaviour is unchanged — cold load →
+        cache → reuse.
+        """
+        async with self._creds_lock:
+            cached = self._creds_cache.get(target.name)
+            if cached is not None and not is_system_operator(operator):
+                return cached
+            raw = await self._credentials_loader(target, operator)
+            if ARGOCD_TOKEN_FIELD not in raw:
+                raise RuntimeError(
+                    f"argocd credentials loader for target {target.name!r} returned a "
+                    f"dict missing required key {ARGOCD_TOKEN_FIELD!r}; need "
+                    "{'token': str}"
+                )
+            self._creds_cache[target.name] = raw
+            _log.info(
+                "argocd_credentials_loaded",
+                target=target.name,
+                host=target.host,
+            )
+            return raw
+
+    async def _get_version_unauthenticated(self, target: ArgoCdTargetLike) -> dict[str, Any]:
+        """Retried ``GET /api/version`` with **no** ``Authorization`` header.
+
+        ``argocd-server`` serves ``/api/version`` unauthenticated, so the
+        fingerprint/probe path must not require a resolvable bearer token —
+        it has to work on a freshly-registered target before its Vault
+        secret is configured. The base :meth:`HttpConnector._get_json`
+        always calls :meth:`auth_headers` (and thus the credential loader),
+        so this helper hits the pooled client directly. Retry semantics
+        match the base class: idempotent GET, 3 retries on connection
+        errors / 5xx with exponential backoff.
+        """
+
+        @retry(
+            stop=stop_after_attempt(4),
+            wait=wait_exponential(multiplier=0.5, min=0.5, max=2.0),
+            retry=retry_if_exception(_version_retryable),
+            reraise=True,
+        )
+        async def _do_get() -> dict[str, Any]:
+            client = await self._http_client(target)
+            resp = await client.get(_VERSION_PATH)
+            resp.raise_for_status()
+            return resp.json()  # type: ignore[no-any-return]
+
+        return await _do_get()
+
+    async def fingerprint(
+        self,
+        target: ArgoCdTargetLike,
+        operator: Operator | None = None,
+    ) -> FingerprintResult:
+        """Canonical fingerprint built from ``GET /api/version``.
+
+        ArgoCD's ``VersionMessage`` carries ``Version`` (the server
+        version, e.g. ``"v3.3.9+abc1234"``) plus the bundled build-tool
+        versions. ``Version`` becomes the canonical ``version``; the
+        build-tool fields land under ``extras`` so an operator gets the
+        same view ``argocd version -o json`` exposes for the server block.
+
+        The ``/api/version`` endpoint is unauthenticated, so the fingerprint
+        does not depend on a resolvable bearer token — it is reachable on a
+        freshly-registered target before its Vault secret is configured.
+
+        On transport or status failure, returns a non-reachable
+        :class:`FingerprintResult` whose ``extras["error"]`` carries the
+        exception class + message — the same pattern the Harbor / SDDC
+        Manager / NSX connectors established.
+
+        ``operator`` exists for ABC parity with the G0.16-T4 (#1306)
+        widening of the fingerprint surface. ArgoCD's version probe is
+        unauthenticated, so a system-context call suffices and no
+        per-operator Vault read is needed here.
+        """
+        del operator  # /api/version is unauthenticated — no per-operator read needed
+        probed_at = datetime.now(UTC)
+        try:
+            payload = await self._get_version_unauthenticated(target)
+        except (httpx.HTTPError, OSError, RuntimeError) as exc:
+            return FingerprintResult(
+                vendor="argoproj",
+                product="argocd",
+                reachable=False,
+                probed_at=probed_at,
+                probe_method=_PROBE_METHOD,
+                extras={"error": f"{type(exc).__name__}: {exc}"},
+            )
+        return FingerprintResult(
+            vendor="argoproj",
+            product="argocd",
+            version=payload.get("Version") or None,
+            reachable=True,
+            probed_at=probed_at,
+            probe_method=_PROBE_METHOD,
+            extras={
+                "BuildDate": payload.get("BuildDate"),
+                "KustomizeVersion": payload.get("KustomizeVersion"),
+                "HelmVersion": payload.get("HelmVersion"),
+                "KubectlVersion": payload.get("KubectlVersion"),
+            },
+        )
+
+    async def probe(self, target: ArgoCdTargetLike) -> ProbeResult:
+        """Reachability check delegating to :meth:`fingerprint`.
+
+        Same precedent as the SDDC Manager / NSX connectors: ArgoCD exposes
+        no dedicated composite health endpoint, so the unauthenticated
+        ``GET /api/version`` probe doubles as the reachability surface. A
+        reachable fingerprint maps to ``ProbeResult(ok=True)``; an
+        unreachable one carries the fingerprint's structured error string
+        as ``reason``.
+        """
+        probed_at = datetime.now(UTC)
+        fp = await self.fingerprint(target)
+        if fp.reachable:
+            return ProbeResult(ok=True, probed_at=probed_at)
+        return ProbeResult(
+            ok=False,
+            reason=str(fp.extras.get("error")) if fp.extras.get("error") else "unreachable",
+            probed_at=probed_at,
+        )
+
+    async def execute(
+        self,
+        target: ArgoCdTargetLike,
+        op_id: str,
+        params: dict[str, Any],
+    ) -> OperationResult:
+        """Legacy shim — delegates to the G0.6 dispatcher.
+
+        Mirrors :meth:`HarborConnector.execute`'s shape. Post-G0.6 callers
+        (``/api/v1/operations/call``, MCP ``call_operation``, the CLI verbs
+        once G3.12-T3 lands) construct a real :class:`Operator` and call
+        :func:`meho_backplane.operations.dispatch` directly — they don't
+        reach this method.
+
+        The connector's natural key is encoded as the dispatcher's
+        ``connector_id`` per ``parse_connector_id``'s contract:
+        ``"argocd-api-3.x"`` → (product=``"argocd"``, version=``"3.x"``,
+        impl_id=``"argocd-api"``).
+        """
+        from uuid import UUID
+
+        from meho_backplane.auth.operator import TenantRole
+        from meho_backplane.operations import dispatch
+
+        operator = Operator(
+            sub="system:argocd-api-connector-shim",
+            name=None,
+            email=None,
+            raw_jwt="",
+            tenant_id=UUID(int=0),
+            tenant_role=TenantRole.OPERATOR,
+        )
+        connector_id = f"{self.impl_id}-{self.version}"
+        return await dispatch(
+            operator=operator,
+            connector_id=connector_id,
+            op_id=op_id,
+            target=target,
+            params=params,
+        )
+
+    async def aclose(self) -> None:
+        """Clear the cached token, then tear down the httpx pool.
+
+        No server-side session to revoke — the bearer token is a static
+        credential. The cache is cleared so a post-aclose reuse of the same
+        connector instance starts clean.
+        """
+        async with self._creds_lock:
+            self._creds_cache.clear()
+        await super().aclose()

--- a/backend/src/meho_backplane/connectors/argocd/session.py
+++ b/backend/src/meho_backplane/connectors/argocd/session.py
@@ -1,0 +1,140 @@
+# SPDX-License-Identifier: Apache-2.0
+# Copyright (c) 2026 evoila Group
+
+"""Credential loading for the argocd connector.
+
+The hand-rolled :class:`~meho_backplane.connectors.argocd.connector.ArgoCdConnector`
+reads a single ``argocd-server`` API **bearer token** from the target's Vault
+path and sends it as ``Authorization: Bearer <token>`` on every request — no
+session is established and no login round-trip is performed; the header is
+recomputed from the cached token on each call.
+
+ArgoCD's auth model differs from Harbor's HTTP Basic and vmware's
+session-POST: ``argocd-server`` accepts a JWT bearer token minted as an
+ArgoCD project/account API token (``argocd account generate-token`` or a
+``project`` token). That single opaque string is the credential — there is
+no username component. It is stored under the target's ``secret_ref`` as a
+KV-v2 secret with a ``token`` field.
+
+The credential fetch (Vault path → ``{"token": ...}`` dict) is split out
+behind a narrow :class:`ArgoCdCredentialsLoader` callable so:
+
+* Production deploys reuse the default loader, which performs the **live**
+  operator-context KV-v2 read via the shared
+  :func:`~meho_backplane.connectors._shared.vault_creds.load_basic_credentials`
+  helper (G3.9-T2 #941 / G3.10-T1 #945 precedent), requesting just the
+  ``token`` field.
+* Unit tests inject their own (mock) loader returning a pre-built dict.
+* Integration tests pass a loader that yields the appropriate API token.
+
+The :class:`ArgoCdTargetLike` Protocol captures the minimum target shape the
+connector reads: ``name`` (for the per-target credential cache key), ``host``,
+``port`` (forwarded to :meth:`HttpConnector._base_url`), ``secret_ref`` (the
+Vault path the loader resolves), and ``auth_model`` (checked at the
+boundary). The bearer token is a shared service-account credential, so the
+target's ``auth_model`` is ``shared_service_account`` — the same boundary the
+Harbor and SDDC Manager connectors enforce.
+"""
+
+from __future__ import annotations
+
+from collections.abc import Awaitable, Callable
+from typing import Protocol, runtime_checkable
+
+from meho_backplane.auth.operator import Operator
+from meho_backplane.connectors._shared.vault_creds import load_basic_credentials
+
+__all__ = [
+    "ARGOCD_TOKEN_FIELD",
+    "ArgoCdCredentialsLoader",
+    "ArgoCdTargetLike",
+    "load_credentials_from_vault",
+]
+
+#: The single KV-v2 secret field the connector reads — the ArgoCD API
+#: bearer token. Kept as a module constant so the connector, the default
+#: loader, and the tests share one source of truth for the field name an
+#: operator must store under ``target.secret_ref``.
+ARGOCD_TOKEN_FIELD = "token"
+
+
+@runtime_checkable
+class ArgoCdTargetLike(Protocol):
+    """Minimum target shape :class:`ArgoCdConnector` reads.
+
+    Structural Protocol — the concrete ``Target`` model in
+    :mod:`meho_backplane.targets` (G0.3 #224) satisfies this Protocol
+    unchanged. ``auth_model`` is checked at the boundary so a target
+    tagged ``per_user`` or ``impersonation`` raises a clear error rather
+    than silently authenticating as the shared service account.
+
+    ``secret_ref`` is the Vault path the loader resolves to a dict carrying
+    the ``token`` field. It is ``str | None`` to match the concrete
+    ``Target.secret_ref`` column (nullable) and the shared
+    :class:`~meho_backplane.connectors._shared.vault_creds.BasicCredentialsTargetLike`
+    the loader forwards to; an unset ``secret_ref`` is rejected with a
+    clear error inside the loader (an unconfigured target), never a bare
+    ``KeyError``. ``port`` is optional — ``argocd-server`` defaults to 443
+    and :meth:`HttpConnector._base_url` already handles the
+    ``port is None or 443`` case correctly.
+    """
+
+    name: str
+    host: str
+    port: int | None
+    secret_ref: str | None
+    auth_model: str | None
+
+
+ArgoCdCredentialsLoader = Callable[[ArgoCdTargetLike, Operator], Awaitable[dict[str, str]]]
+"""Async callable resolving a (target, operator) pair to credentials.
+
+Returns a dict carrying the ``token`` key (the ArgoCD API bearer token).
+The connector's :meth:`ArgoCdConnector._load_credentials` invokes the
+loader exactly once per target (first-use), caching the resulting dict
+under ``target.name``. The return type is the looser ``dict[str, str]``
+(not a TypedDict) because production code returns a plain dict and the
+connector reads ``creds["token"]`` by key.
+
+The ``operator`` parameter carries the full
+:class:`~meho_backplane.auth.operator.Operator` (frozen) so the live
+loader reads the per-target secret under the operator's identity via
+``vault_client_for_operator(operator)`` — the locked decision in
+``docs/architecture/connector-auth.md``.
+"""
+
+
+async def load_credentials_from_vault(
+    target: ArgoCdTargetLike,
+    operator: Operator,
+) -> dict[str, str]:
+    """Default credential loader — live operator-context Vault KV-v2 read.
+
+    Reads ``target.secret_ref`` as a KV-v2 secret **under the operator's
+    identity** (the operator's validated Keycloak JWT is forwarded to
+    Vault's JWT/OIDC auth method) and returns the ``{"token": ...}`` pair
+    the connector sends as ``Authorization: Bearer <token>`` on every
+    ``argocd-server`` API call. Delegates to the shared
+    :func:`~meho_backplane.connectors._shared.vault_creds.load_basic_credentials`
+    helper (G3.9-T2 #941) with ``fields=("token",)`` so the read, the
+    no-secret-in-logs discipline, and the two-phase error contract are
+    defined once for every REST connector — this loader is the thin
+    argocd-specific entry point.
+
+    The error contract is the helper's:
+
+    * :class:`~meho_backplane.connectors._shared.vault_creds.VaultCredentialsReadError`
+      — read-phase failure (empty ``operator.raw_jwt`` for a
+      system-initiated call, unset ``target.secret_ref``, a malformed
+      KV-v2 payload, or a missing ``token`` field). Never a bare
+      ``KeyError``.
+    * :class:`~meho_backplane.auth.vault.VaultClientError` (and its
+      subclasses) — login-phase failure (Vault unreachable, role denied).
+      Propagated verbatim so callers can distinguish login from read.
+
+    A custom :class:`ArgoCdCredentialsLoader` can still be injected via
+    ``credentials_loader`` on :class:`ArgoCdConnector` (tests do exactly
+    that); this default is what production targets at rubric State 2
+    (``shared_service_account``) use.
+    """
+    return await load_basic_credentials(target, operator, fields=(ARGOCD_TOKEN_FIELD,))

--- a/backend/tests/test_connectors_argocd_auth.py
+++ b/backend/tests/test_connectors_argocd_auth.py
@@ -1,0 +1,458 @@
+# SPDX-License-Identifier: Apache-2.0
+# Copyright (c) 2026 evoila Group
+
+"""Unit tests for :class:`ArgoCdConnector` auth + fingerprint/probe (G3.12-T1 #1390).
+
+Exercises bearer-token auth, per-target credential isolation + caching, the
+system-operator cache-bypass (#1008), the auth_model boundary gate, and the
+fingerprint/probe shapes against mocked ArgoCD ``argocd-server`` endpoints.
+
+Auth: no session token — ``Authorization: Bearer <token>`` sent on every
+request. The token is cached per target so Vault is only queried once per
+target per connector instance lifetime. Unlike Harbor's Basic auth there is
+no username component; the stored token is sent verbatim.
+"""
+
+from __future__ import annotations
+
+from collections.abc import Iterator
+from dataclasses import dataclass
+from uuid import UUID
+
+import pytest
+import respx
+
+from meho_backplane.auth.operator import Operator, TenantRole
+from meho_backplane.connectors._shared.system_operator import (
+    SYSTEM_OPERATOR_SUB,
+    synthesise_system_operator,
+)
+from meho_backplane.connectors._shared.vault_creds import VaultCredentialsReadError
+from meho_backplane.connectors.adapters.http import HttpConnector
+from meho_backplane.connectors.argocd import (
+    ArgoCdConnector,
+    ArgoCdTargetLike,
+)
+from meho_backplane.connectors.registry import (
+    all_connectors_v2,
+    clear_registry,
+    register_connector_v2,
+)
+from meho_backplane.connectors.schemas import AuthModel
+
+
+def _make_operator(raw_jwt: str = "op.jwt.value") -> Operator:
+    """Return a minimal :class:`Operator` for threading through the auth surface."""
+    return Operator(
+        sub="test-operator",
+        name=None,
+        email=None,
+        raw_jwt=raw_jwt,
+        tenant_id=UUID(int=0),
+        tenant_role=TenantRole.OPERATOR,
+    )
+
+
+@pytest.fixture(autouse=True)
+def _clean_argocd_registry() -> Iterator[None]:
+    """Re-register ArgoCdConnector after sibling tests clear the registry.
+
+    ``test_connectors_registry_v2.py`` installs an autouse fixture that
+    calls :func:`clear_registry` between tests. Re-register before every
+    test in this module and clear after — same pattern
+    :mod:`tests.test_connectors_harbor_auth` established.
+    """
+    clear_registry()
+    register_connector_v2(
+        product=ArgoCdConnector.product,
+        version=ArgoCdConnector.version,
+        impl_id=ArgoCdConnector.impl_id,
+        cls=ArgoCdConnector,
+    )
+    yield
+    clear_registry()
+
+
+# ---------------------------------------------------------------------------
+# Target stub — satisfies ArgoCdTargetLike Protocol structurally.
+# ---------------------------------------------------------------------------
+
+
+@dataclass
+class _StubTarget:
+    name: str
+    host: str
+    port: int | None
+    secret_ref: str
+    auth_model: str | None = AuthModel.SHARED_SERVICE_ACCOUNT.value
+
+
+_TARGET_A = _StubTarget(
+    name="argocd-infra",
+    host="argocd-infra.test.invalid",
+    port=443,
+    secret_ref="targets/argocd-infra",
+)
+_TARGET_B = _StubTarget(
+    name="argocd-ci",
+    host="argocd-ci.test.invalid",
+    port=443,
+    secret_ref="targets/argocd-ci",
+)
+
+
+async def _stub_loader(_target: ArgoCdTargetLike, _operator: Operator) -> dict[str, str]:
+    """Return a canned bearer token regardless of the target or operator."""
+    return {"token": "stub-bearer-token"}
+
+
+def _make_connector() -> ArgoCdConnector:
+    return ArgoCdConnector(credentials_loader=_stub_loader)
+
+
+# ---------------------------------------------------------------------------
+# ABC + registration plumbing
+# ---------------------------------------------------------------------------
+
+
+def test_argocd_connector_subclasses_http_connector() -> None:
+    assert issubclass(ArgoCdConnector, HttpConnector)
+    assert ArgoCdConnector.product == "argocd"
+    assert ArgoCdConnector.version == "3.x"
+    assert ArgoCdConnector.impl_id == "argocd-api"
+    assert ArgoCdConnector.supported_version_range == ">=2.0,<4.0"
+    assert ArgoCdConnector.priority == 1
+
+
+def test_importing_package_registers_versioned_and_wildcard_v2_entries() -> None:
+    """The package registers both the versioned triple and the wildcard fallback."""
+    import importlib
+
+    import meho_backplane.connectors.argocd as argocd_pkg
+
+    # The autouse fixture pre-registered only the versioned triple; clear it
+    # so the reloaded module body can re-run both register_connector_v2 calls
+    # (versioned + wildcard) without colliding with the duplicate guard.
+    clear_registry()
+    importlib.reload(argocd_pkg)
+
+    registry = all_connectors_v2()
+    versioned = ("argocd", "3.x", "argocd-api")
+    wildcard = ("argocd", "", "")
+    assert registry[versioned] is ArgoCdConnector
+    assert registry[wildcard] is ArgoCdConnector
+
+
+def test_default_credentials_loader_delegates_to_shared_basic_loader() -> None:
+    """The default loader is the thin wrapper around ``load_basic_credentials``.
+
+    The fail-closed precondition (empty ``operator.raw_jwt``) is asserted
+    via a :class:`VaultCredentialsReadError` on a system-initiated operator
+    (no Vault is touched).
+    """
+    import asyncio
+
+    from meho_backplane.connectors.argocd.session import load_credentials_from_vault
+
+    async def _check() -> None:
+        system_operator = _make_operator(raw_jwt="")
+        with pytest.raises(VaultCredentialsReadError, match=r"system-initiated"):
+            await load_credentials_from_vault(_TARGET_A, system_operator)
+
+    asyncio.run(_check())
+
+
+# ---------------------------------------------------------------------------
+# Bearer-token auth
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.asyncio
+async def test_auth_headers_sends_bearer_token() -> None:
+    """auth_headers() produces ``Authorization: Bearer <token>``."""
+    connector = _make_connector()
+    headers = await connector.auth_headers(_TARGET_A, operator=_make_operator())
+
+    assert headers == {"Authorization": "Bearer stub-bearer-token"}
+    await connector.aclose()
+
+
+@pytest.mark.asyncio
+async def test_auth_headers_reuses_cached_token_across_calls() -> None:
+    """Second auth_headers call against the same target does NOT re-invoke the loader."""
+    call_count = 0
+
+    async def _counting_loader(_target: ArgoCdTargetLike, _operator: Operator) -> dict[str, str]:
+        nonlocal call_count
+        call_count += 1
+        return {"token": "stub-bearer-token"}
+
+    connector = ArgoCdConnector(credentials_loader=_counting_loader)
+    h1 = await connector.auth_headers(_TARGET_A, operator=_make_operator())
+    h2 = await connector.auth_headers(_TARGET_A, operator=_make_operator())
+
+    assert h1 == h2
+    assert call_count == 1
+    await connector.aclose()
+
+
+@pytest.mark.asyncio
+async def test_per_target_isolation_keeps_tokens_separate() -> None:
+    """Two targets get two distinct cache entries; no cross-target leakage."""
+    call_log: list[str] = []
+
+    async def _tracking_loader(target: ArgoCdTargetLike, _operator: Operator) -> dict[str, str]:
+        call_log.append(target.name)
+        return {"token": f"token-{target.name}"}
+
+    connector = ArgoCdConnector(credentials_loader=_tracking_loader)
+    h_a = await connector.auth_headers(_TARGET_A, operator=_make_operator())
+    h_b = await connector.auth_headers(_TARGET_B, operator=_make_operator())
+
+    assert h_a == {"Authorization": "Bearer token-argocd-infra"}
+    assert h_b == {"Authorization": "Bearer token-argocd-ci"}
+    assert call_log == ["argocd-infra", "argocd-ci"]
+    await connector.aclose()
+
+
+# ---------------------------------------------------------------------------
+# System-operator cache-bypass (fail-closed; #1008)
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.asyncio
+async def test_warm_cache_not_served_to_system_operator_runs_loader() -> None:
+    """A warm cache primed by a real operator is NOT served to the system operator."""
+    call_log: list[str] = []
+
+    async def _counting_loader(_target: ArgoCdTargetLike, operator: Operator) -> dict[str, str]:
+        call_log.append(operator.sub)
+        return {"token": "stub-bearer-token"}
+
+    connector = ArgoCdConnector(credentials_loader=_counting_loader)
+    await connector.auth_headers(_TARGET_A, operator=_make_operator())
+    await connector.auth_headers(_TARGET_A, operator=synthesise_system_operator())
+
+    assert call_log == ["test-operator", SYSTEM_OPERATOR_SUB]
+    await connector.aclose()
+
+
+@pytest.mark.asyncio
+async def test_real_operator_reuse_unchanged_after_system_operator_call() -> None:
+    """Real-operator reuse is unaffected by the system-operator cache bypass."""
+    real_calls = 0
+
+    async def _counting_loader(_target: ArgoCdTargetLike, operator: Operator) -> dict[str, str]:
+        nonlocal real_calls
+        if operator.sub != SYSTEM_OPERATOR_SUB:
+            real_calls += 1
+        return {"token": "stub-bearer-token"}
+
+    connector = ArgoCdConnector(credentials_loader=_counting_loader)
+    await connector.auth_headers(_TARGET_A, operator=_make_operator())  # cold real load
+    await connector.auth_headers(_TARGET_A, operator=synthesise_system_operator())  # bypass
+    await connector.auth_headers(_TARGET_A, operator=_make_operator())  # warm real reuse
+
+    assert real_calls == 1
+    await connector.aclose()
+
+
+# ---------------------------------------------------------------------------
+# Credential loading failure modes
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.asyncio
+async def test_loader_missing_token_key_raises_runtime_error_naming_target() -> None:
+    async def _bad_loader(_target: ArgoCdTargetLike, _operator: Operator) -> dict[str, str]:
+        return {}
+
+    connector = ArgoCdConnector(credentials_loader=_bad_loader)
+    with pytest.raises(RuntimeError, match=r"token") as exc_info:
+        await connector.auth_headers(_TARGET_A, operator=_make_operator())
+
+    assert "argocd-infra" in str(exc_info.value)
+    await connector.aclose()
+
+
+# ---------------------------------------------------------------------------
+# Auth model gating
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.asyncio
+@pytest.mark.parametrize(
+    "auth_model",
+    [AuthModel.PER_USER.value, AuthModel.IMPERSONATION.value, "unknown-mode"],
+)
+async def test_auth_headers_rejects_non_shared_service_account_modes(auth_model: str) -> None:
+    """Per-user / impersonation modes raise NotImplementedError naming the target + mode."""
+    target = _StubTarget(
+        name="argocd-per-user",
+        host="argocd.test.invalid",
+        port=443,
+        secret_ref="targets/per-user",
+        auth_model=auth_model,
+    )
+    connector = _make_connector()
+
+    with pytest.raises(NotImplementedError) as exc_info:
+        await connector.auth_headers(target, operator=_make_operator())
+
+    assert "argocd-per-user" in str(exc_info.value)
+    assert auth_model in str(exc_info.value)
+    await connector.aclose()
+
+
+@pytest.mark.asyncio
+async def test_auth_headers_accepts_none_auth_model_for_pre_g03_targets() -> None:
+    """auth_model=None (pre-G0.3 column-not-yet-populated) is accepted."""
+    target = _StubTarget(
+        name="argocd-pre-g03",
+        host="argocd.test.invalid",
+        port=443,
+        secret_ref="targets/pre-g03",
+        auth_model=None,
+    )
+    connector = _make_connector()
+    headers = await connector.auth_headers(target, operator=_make_operator())
+    assert headers["Authorization"].startswith("Bearer ")
+    await connector.aclose()
+
+
+@pytest.mark.asyncio
+async def test_auth_headers_accepts_enum_member_for_auth_model() -> None:
+    """An AuthModel enum member (not just its string value) is accepted."""
+    target = _StubTarget(
+        name="argocd-enum",
+        host="argocd.test.invalid",
+        port=443,
+        secret_ref="targets/enum",
+    )
+    target.auth_model = AuthModel.SHARED_SERVICE_ACCOUNT  # type: ignore[assignment]
+    connector = _make_connector()
+    headers = await connector.auth_headers(target, operator=_make_operator())
+    assert headers["Authorization"].startswith("Bearer ")
+    await connector.aclose()
+
+
+# ---------------------------------------------------------------------------
+# fingerprint()
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.asyncio
+async def test_fingerprint_canonical_shape_on_reachable_target() -> None:
+    """fingerprint() against mocked GET /api/version returns the canonical shape."""
+    connector = _make_connector()
+
+    async with respx.mock(base_url="https://argocd-infra.test.invalid") as mock:
+        mock.get("/api/version").respond(
+            200,
+            json={
+                "Version": "v3.3.9+abc1234",
+                "BuildDate": "2026-01-15T00:00:00Z",
+                "GitCommit": "abc1234",
+                "KustomizeVersion": "v5.4.3 2024-05-16",
+                "HelmVersion": "v3.15.2+g1a500d5",
+                "KubectlVersion": "v0.30.1",
+                "JsonnetVersion": "v0.20.0",
+            },
+        )
+        fp = await connector.fingerprint(_TARGET_A)
+
+    assert fp.vendor == "argoproj"
+    assert fp.product == "argocd"
+    assert fp.version == "v3.3.9+abc1234"
+    assert fp.reachable is True
+    assert fp.probe_method == "GET /api/version"
+    assert fp.extras["KustomizeVersion"] == "v5.4.3 2024-05-16"
+    assert fp.extras["HelmVersion"] == "v3.15.2+g1a500d5"
+    assert fp.extras["KubectlVersion"] == "v0.30.1"
+    assert fp.extras["BuildDate"] == "2026-01-15T00:00:00Z"
+    await connector.aclose()
+
+
+@pytest.mark.asyncio
+async def test_fingerprint_does_not_require_a_bearer_token() -> None:
+    """``GET /api/version`` is unauthenticated — fingerprint never calls the loader."""
+
+    async def _exploding_loader(_target: ArgoCdTargetLike, _operator: Operator) -> dict[str, str]:
+        raise AssertionError("fingerprint must not read the bearer token")
+
+    connector = ArgoCdConnector(credentials_loader=_exploding_loader)
+
+    async with respx.mock(base_url="https://argocd-infra.test.invalid") as mock:
+        mock.get("/api/version").respond(200, json={"Version": "v3.3.9"})
+        fp = await connector.fingerprint(_TARGET_A)
+
+    assert fp.reachable is True
+    assert fp.version == "v3.3.9"
+    await connector.aclose()
+
+
+@pytest.mark.asyncio
+async def test_fingerprint_unreachable_returns_reachable_false_with_structured_error() -> None:
+    """Transport/status failure returns reachable=False with extras['error']."""
+    connector = _make_connector()
+
+    async with respx.mock(base_url="https://argocd-infra.test.invalid") as mock:
+        mock.get("/api/version").respond(503, json={"error": "unavailable"})
+        fp = await connector.fingerprint(_TARGET_A)
+
+    assert fp.vendor == "argoproj"
+    assert fp.product == "argocd"
+    assert fp.reachable is False
+    assert fp.probe_method == "GET /api/version"
+    error = fp.extras["error"]
+    assert "HTTPStatusError" in error or "503" in error
+    await connector.aclose()
+
+
+# ---------------------------------------------------------------------------
+# probe()
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.asyncio
+async def test_probe_returns_ok_true_when_version_reachable() -> None:
+    """probe() returns ok=True when GET /api/version round-trips."""
+    connector = _make_connector()
+
+    async with respx.mock(base_url="https://argocd-infra.test.invalid") as mock:
+        mock.get("/api/version").respond(200, json={"Version": "v3.3.9"})
+        result = await connector.probe(_TARGET_A)
+
+    assert result.ok is True
+    assert result.reason is None
+    await connector.aclose()
+
+
+@pytest.mark.asyncio
+async def test_probe_returns_ok_false_with_reason_on_transport_error() -> None:
+    """probe() returns ok=False + reason on transport/status failure."""
+    connector = _make_connector()
+
+    async with respx.mock(base_url="https://argocd-infra.test.invalid") as mock:
+        mock.get("/api/version").respond(503)
+        result = await connector.probe(_TARGET_A)
+
+    assert result.ok is False
+    assert result.reason is not None
+    await connector.aclose()
+
+
+# ---------------------------------------------------------------------------
+# aclose
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.asyncio
+async def test_aclose_clears_token_cache_and_pool() -> None:
+    """aclose() clears the in-memory token cache and tears down the httpx pool."""
+    connector = _make_connector()
+    await connector.auth_headers(_TARGET_A, operator=_make_operator())
+    assert "argocd-infra" in connector._creds_cache
+    await connector.aclose()
+    assert connector._creds_cache == {}
+    assert connector._clients == {}

--- a/backend/tests/test_connectors_argocd_credread.py
+++ b/backend/tests/test_connectors_argocd_credread.py
@@ -1,0 +1,296 @@
+# SPDX-License-Identifier: Apache-2.0
+# Copyright (c) 2026 evoila Group
+
+"""Recorded-fixture E2E for the argocd live credential-read chain (G3.12-T1 #1390).
+
+Proves the **full** dispatch chain end to end with a real (default,
+non-injected) credential loader:
+
+    dispatch(...)
+      -> _resolve_connector_instance -> ArgoCdConnector()        # default loader
+      -> dispatch_ingested -> _request_json -> auth_headers
+      -> _load_credentials -> load_credentials_from_vault        # the live loader
+      -> load_basic_credentials (#941), fields=("token",)        # operator-context Vault read
+      -> GET <op path> (Authorization: Bearer <Vault-read token>)
+      -> OperationResult(status="ok")
+
+ArgoCD differs from Harbor in that the credential is a single bearer token
+(no username component) sent as ``Authorization: Bearer <token>`` on every
+request. The credential read still goes through the shared operator-context
+Vault helper; the token is then placed on the ``Authorization`` header
+verbatim.
+
+The two "real" leaves are stubbed at their boundaries so the gate runs in
+the secret-free unit lane (``pytest -n auto`` / ``--ignore=tests/integration``)
+with no Docker and no real secret:
+
+* **Vault** — the in-process fake (``install_fake_client``) patches
+  ``meho_backplane.auth.vault._build_client`` so the helper's real
+  JWT/OIDC login + KV-v2 read code path runs against a canned token. The
+  default loader is exercised verbatim — *not* an injected stub.
+* **ArgoCD** — respx replays the op ``GET`` (returns the read payload). No
+  network.
+
+Mirrors :mod:`tests.test_connectors_harbor_credread` (G3.10-T1 #945
+precedent) — same lifecycle, same canary-credential leak assertions.
+"""
+
+from __future__ import annotations
+
+import uuid
+from collections.abc import AsyncIterator, Iterator
+from datetime import UTC, datetime
+from typing import Any
+from unittest.mock import AsyncMock
+from uuid import UUID
+
+import pytest
+import respx
+from sqlalchemy.ext.asyncio import AsyncSession
+from structlog.testing import capture_logs
+
+import meho_backplane.operations._audit as audit_module
+from meho_backplane.auth.operator import Operator, TenantRole
+from meho_backplane.broadcast import BroadcastEvent
+from meho_backplane.connectors.argocd import ArgoCdConnector
+from meho_backplane.connectors.registry import clear_registry, register_connector_v2
+from meho_backplane.db.engine import get_sessionmaker
+from meho_backplane.db.models import EndpointDescriptor
+from meho_backplane.operations import dispatch, reset_dispatcher_caches
+from meho_backplane.settings import get_settings
+
+from ._vault_fakes import install_fake_client
+
+# ---------------------------------------------------------------------------
+# Canary credential value — asserted to NEVER appear in the result or logs.
+# ---------------------------------------------------------------------------
+
+_CANARY_TOKEN = "argocd-bearer-canary-must-not-leak-credread"
+
+#: The connector triple ``argocd-api-3.x`` decodes to.
+_PRODUCT = "argocd"
+_VERSION = "3.x"
+_IMPL_ID = "argocd-api"
+_CONNECTOR_ID = "argocd-api-3.x"
+
+#: A spec-relative ingested GET op against ArgoCD's application list endpoint.
+_OP_ID = "GET:/api/v1/applications"
+_OP_PATH = "/api/v1/applications"
+
+#: respx base URL the target points at. Port 443 keeps ``_base_url`` from
+#: appending ``:port`` so the router matches the connector's client URL.
+_ARGOCD_HOST = "argocd-credread.test.invalid"
+_ARGOCD_BASE_URL = f"https://{_ARGOCD_HOST}"
+
+#: The read op's response payload — shaped to look like an ArgoCD app list.
+_OP_RESPONSE: dict[str, Any] = {
+    "metadata": {"resourceVersion": "12345"},
+    "items": [{"metadata": {"name": "guestbook"}, "status": {"sync": {"status": "Synced"}}}],
+}
+
+
+@pytest.fixture(autouse=True)
+def _settings_env(monkeypatch: pytest.MonkeyPatch) -> Iterator[None]:
+    """Pin chassis env vars Settings reads (Vault client + dispatcher)."""
+    monkeypatch.setenv("KEYCLOAK_ISSUER_URL", "https://keycloak.test/realms/meho")
+    monkeypatch.setenv("KEYCLOAK_AUDIENCE", "meho-backplane")
+    monkeypatch.setenv("VAULT_ADDR", "https://vault.test")
+    monkeypatch.setenv("VAULT_OIDC_ROLE", "meho-mcp")
+    monkeypatch.setenv("VAULT_OIDC_MOUNT_PATH", "jwt")
+    monkeypatch.setenv("VAULT_TIMEOUT_SECONDS", "5.0")
+    monkeypatch.delenv("VAULT_NAMESPACE", raising=False)
+    get_settings.cache_clear()
+    yield
+    get_settings.cache_clear()
+
+
+@pytest.fixture(autouse=True)
+def _reset_module_state() -> Iterator[None]:
+    """Reset dispatcher caches + connector registry around every test."""
+    reset_dispatcher_caches()
+    clear_registry()
+    register_connector_v2(
+        product=_PRODUCT,
+        version=_VERSION,
+        impl_id=_IMPL_ID,
+        cls=ArgoCdConnector,
+    )
+    yield
+    reset_dispatcher_caches()
+    clear_registry()
+
+
+@pytest.fixture
+def stub_embedding_service() -> AsyncMock:
+    """Deterministic embedding stub for the seeded descriptor row."""
+    service = AsyncMock()
+    service.encode_one.return_value = [0.1] * 384
+    service.encode.return_value = [[0.1] * 384]
+    service.dimension = 384
+    return service
+
+
+@pytest.fixture
+def captured_events(monkeypatch: pytest.MonkeyPatch) -> list[BroadcastEvent]:
+    """Record broadcast events so the audit/broadcast leg is asserted."""
+    events: list[BroadcastEvent] = []
+
+    async def _capture(event: BroadcastEvent) -> None:
+        events.append(event)
+
+    monkeypatch.setattr(audit_module, "publish_event", _capture)
+    return events
+
+
+@pytest.fixture
+async def session() -> AsyncIterator[AsyncSession]:
+    """AsyncSession against the autouse-migrated per-worker SQLite engine."""
+    sessionmaker = get_sessionmaker()
+    async with sessionmaker() as s:
+        yield s
+
+
+class _CredReadTarget:
+    """Target satisfying both ``ArgoCdTargetLike`` and the resolver shape."""
+
+    def __init__(self) -> None:
+        self.product = _PRODUCT
+        # ``Connector.supported_version_range`` is ``">=2.0,<4.0"``; the
+        # resolver parses target.fingerprint.version as PEP 440, so use a
+        # concrete dotted version (not the wildcard ``"3.x"`` triple version
+        # that names the connector key but isn't PEP-440 parseable).
+        self.fingerprint = type("_FP", (), {"version": "3.3.9"})()
+        self.preferred_impl_id: str | None = None
+        self.id: UUID = uuid.uuid4()
+        self.name = "argocd-credread"
+        self.host = _ARGOCD_HOST
+        self.port = 443
+        self.secret_ref = "targets/op-credread/argocd-credread"
+        self.auth_model = "shared_service_account"
+
+
+def _make_operator() -> Operator:
+    """Operator carrying a non-empty raw_jwt (the fail-closed gate passes)."""
+    return Operator(
+        sub="op-credread-argocd",
+        name="ArgoCD Cred Read Operator",
+        email=None,
+        raw_jwt="op.credread.argocd.jwt",
+        tenant_id=UUID("00000000-0000-0000-0000-00000000a0a3"),
+        tenant_role=TenantRole.OPERATOR,
+    )
+
+
+async def _seed_descriptor(session: AsyncSession, embedding: list[float]) -> None:
+    """Insert one enabled ingested GET descriptor for the read op."""
+    descriptor = EndpointDescriptor(
+        id=uuid.uuid4(),
+        tenant_id=None,
+        product=_PRODUCT,
+        version=_VERSION,
+        impl_id=_IMPL_ID,
+        op_id=_OP_ID,
+        source_kind="ingested",
+        method="GET",
+        path=_OP_PATH,
+        handler_ref=None,
+        summary="List ArgoCD applications",
+        description="Return the ArgoCD application list.",
+        tags=["readiness"],
+        parameter_schema={"type": "object", "properties": {}},
+        response_schema=None,
+        llm_instructions=None,
+        safety_level="safe",
+        requires_approval=False,
+        is_enabled=True,
+        embedding=embedding,
+        custom_description=None,
+        custom_notes=None,
+        created_at=datetime.now(UTC),
+        updated_at=datetime.now(UTC),
+    )
+    session.add(descriptor)
+    await session.commit()
+
+
+@pytest.mark.asyncio
+async def test_dispatch_executes_full_credread_chain_returns_ok(
+    stub_embedding_service: AsyncMock,
+    session: AsyncSession,
+    captured_events: list[BroadcastEvent],
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """The full dispatch->loader->ArgoCD chain returns status="ok" with no injected loader."""
+    await _seed_descriptor(session, stub_embedding_service.encode_one.return_value)
+
+    # Vault leaf: the in-process fake returns the canary token via the real
+    # ``load_basic_credentials`` -> ``vault_client_for_operator`` path. No
+    # credentials_loader is injected — the resolver builds
+    # ``ArgoCdConnector()`` so the default loader runs.
+    fake = install_fake_client(monkeypatch, secret={"token": _CANARY_TOKEN})
+
+    target = _CredReadTarget()
+    operator = _make_operator()
+
+    async with respx.mock(base_url=_ARGOCD_BASE_URL, assert_all_called=False) as mock:
+        op_route = mock.get("/api/v1/applications").respond(200, json=_OP_RESPONSE)
+
+        result = await dispatch(
+            operator=operator,
+            connector_id=_CONNECTOR_ID,
+            op_id=_OP_ID,
+            target=target,
+            params={},
+        )
+
+    # The load-bearing assertion: the chain executed end to end.
+    assert result.status == "ok", result.error
+    assert isinstance(result.result, dict)
+    assert result.result == _OP_RESPONSE
+
+    # The default loader actually read Vault under the operator's identity.
+    assert fake.auth.jwt.login_calls[-1]["jwt"] == "op.credread.argocd.jwt"
+    assert fake.secrets.kv.v2.read_calls[-1]["path"] == target.secret_ref
+    # The read op hit the mocked ArgoCD instance with a bearer token.
+    assert op_route.called and op_route.call_count == 1
+    sent_auth = op_route.calls[0].request.headers.get("authorization")
+    assert sent_auth == f"Bearer {_CANARY_TOKEN}"
+    # One audit + one broadcast for the dispatched op.
+    assert len(captured_events) == 1
+
+
+@pytest.mark.asyncio
+async def test_credread_chain_never_leaks_credential_in_result_or_logs(
+    stub_embedding_service: AsyncMock,
+    session: AsyncSession,
+    captured_events: list[BroadcastEvent],
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """No credential value appears in the OperationResult or any captured log event."""
+    await _seed_descriptor(session, stub_embedding_service.encode_one.return_value)
+
+    install_fake_client(monkeypatch, secret={"token": _CANARY_TOKEN})
+
+    target = _CredReadTarget()
+    operator = _make_operator()
+
+    with capture_logs() as captured:
+        async with respx.mock(base_url=_ARGOCD_BASE_URL, assert_all_called=False) as mock:
+            mock.get("/api/v1/applications").respond(200, json=_OP_RESPONSE)
+
+            result = await dispatch(
+                operator=operator,
+                connector_id=_CONNECTOR_ID,
+                op_id=_OP_ID,
+                target=target,
+                params={},
+            )
+
+    assert result.status == "ok", result.error
+
+    # The token never rides the OperationResult (result, error, or extras).
+    assert _CANARY_TOKEN not in repr(result)
+    # The token never rides any structlog event.
+    assert _CANARY_TOKEN not in repr(captured)
+    # The token never rides the broadcast event payload either.
+    assert _CANARY_TOKEN not in repr(captured_events)

--- a/backend/tests/test_connectors_registry_v2.py
+++ b/backend/tests/test_connectors_registry_v2.py
@@ -325,6 +325,30 @@ def test_harbor_connector_registered_under_v2_triple() -> None:
     assert snapshot[key] is HarborConnector
 
 
+def test_argocd_connector_registered_under_v2_triple_and_wildcard() -> None:
+    """ArgoCdConnector package registers under (argocd, 3.x, argocd-api) + wildcard.
+
+    G3.12-T1 (#1390) ships dual registration from day one per G0.15-T6:
+    the versioned triple ``("argocd", "3.x", "argocd-api")`` and the
+    wildcard fallback ``("argocd", "", "")`` both resolve to the connector.
+    Same idempotent-registration pattern as the Harbor test above; the
+    wildcard leg is registered via a second ``_ensure_registered_v2``-style
+    guard since the connector class only carries the versioned triple in
+    its class attributes.
+    """
+    from meho_backplane.connectors.argocd import ArgoCdConnector
+
+    _ensure_registered_v2(ArgoCdConnector)
+    wildcard = ("argocd", "", "")
+    if wildcard not in all_connectors_v2():
+        register_connector_v2(product="argocd", version="", impl_id="", cls=ArgoCdConnector)
+
+    snapshot = all_connectors_v2()
+    versioned = ("argocd", "3.x", "argocd-api")
+    assert snapshot[versioned] is ArgoCdConnector
+    assert snapshot[wildcard] is ArgoCdConnector
+
+
 def test_vcf_automation_connector_registered_under_v2_triple() -> None:
     """VcfAutomationConnector package registers under (vcf-automation, 9.0, vcfa-rest).
 

--- a/cli/api/openapi.json
+++ b/cli/api/openapi.json
@@ -15191,6 +15191,7 @@
             "minLength": 1,
             "title": "Product",
             "enum": [
+              "argocd",
               "bind9",
               "gcloud",
               "gh",

--- a/cli/internal/api/client.gen.go
+++ b/cli/internal/api/client.gen.go
@@ -278,6 +278,7 @@ const (
 
 // Defines values for TargetCreateProduct.
 const (
+	Argocd        TargetCreateProduct = "argocd"
 	Bind9         TargetCreateProduct = "bind9"
 	Gcloud        TargetCreateProduct = "gcloud"
 	Gh            TargetCreateProduct = "gh"

--- a/docs/codebase/connectors-argocd.md
+++ b/docs/codebase/connectors-argocd.md
@@ -1,0 +1,173 @@
+# Connector: argocd (ArgoCD 3.x)
+
+## Overview
+
+The `argocd` connector is the hand-rolled `HttpConnector` subclass that
+dispatches ArgoCD `argocd-server` REST operations under the
+`(product="argocd", version="3.x", impl_id="argocd-api")` registry triple
+(plus the `("argocd", "", "")` wildcard fallback). G3.12-T1 (#1390) ships the
+skeleton — bearer-token auth, fingerprint, probe, the G0.6 dispatch shim, and
+dual registration. The curated read core (`argocd.app.list` /
+`argocd.app.get` / `argocd.app.diff` / `argocd.app.resource_tree` /
+`argocd.appproject.list` / `argocd.repo.list`) arrives in G3.12-T2; CLI verbs
++ MCP review + recorded-fixture E2E + `docs/cross-repo/argocd-onboarding.md`
+arrive in G3.12-T3.
+
+Source: `backend/src/meho_backplane/connectors/argocd/`.
+
+## Key types
+
+- **`ArgoCdConnector`** (`connector.py`) — `HttpConnector` subclass. Class
+  attributes: `product="argocd"`, `version="3.x"`, `impl_id="argocd-api"`,
+  `supported_version_range=">=2.0,<4.0"`, `priority=1`. The priority outranks
+  a future `GenericRestConnector` auto-shim (priority=0) defensively if both
+  somehow register for the same triple.
+- **`ArgoCdTargetLike`** (`session.py`) — runtime-checkable Protocol capturing
+  the minimum target shape the connector reads: `name`, `host`, `port`,
+  `secret_ref`, and `auth_model`. Replaced by the concrete `Target` model once
+  G0.3 (#224) lands.
+- **`ArgoCdCredentialsLoader`** (`session.py`) — async callable type resolving
+  a `(target, operator)` pair to `{"token": ...}`. The `operator: Operator`
+  carries the dispatched identity so the live loader reads the per-target
+  secret under the operator's JWT. Injectable on connector construction
+  (`ArgoCdConnector(credentials_loader=...)`) so unit and integration tests
+  override the default Vault loader.
+- **`load_credentials_from_vault`** (`session.py`) — default loader. Performs a
+  live operator-context Vault KV-v2 read of `target.secret_ref` under the
+  operator's identity, delegating to the shared `load_basic_credentials` helper
+  with `fields=("token",)`. Returns the `{"token": ...}` pair.
+- **`ARGOCD_TOKEN_FIELD`** (`session.py`) — the single KV-v2 secret field name
+  (`"token"`) an operator stores under `target.secret_ref`. Shared by the
+  connector, the loader, and the tests.
+
+## Control flow
+
+### Registration
+
+1. Lifespan calls `_eager_import_connectors()` in
+   `meho_backplane/connectors/registry.py`, which walks every
+   `connectors/<product>/` subpackage in name-sorted order (the `argocd`
+   subpackage is auto-discovered by directory name — no manual import-list
+   edit needed).
+2. Importing `meho_backplane.connectors.argocd` triggers two module-level
+   `register_connector_v2` calls: the versioned triple
+   `("argocd", "3.x", "argocd-api")` and the wildcard `("argocd", "", "")`.
+3. The registry's v2 table now resolves both keys to `ArgoCdConnector`. The
+   versioned entry wins the resolver tie-break when both are present; the
+   wildcard lets a fresh, unfingerprinted target (`version=None`) resolve to
+   the connector through the resolver's `versioned_over_wildcard` step rather
+   than 501-ing with `no_connector`.
+
+### Per-target credentials + bearer-token auth
+
+`argocd-server` authenticates with a JWT bearer token sent on every request:
+`Authorization: Bearer <token>`. The token is an ArgoCD project/account API
+token (`argocd account generate-token` or a `project` token) stored under
+`target.secret_ref` as a KV-v2 secret with a `token` field. There is no
+username component — unlike Harbor's Basic auth, the credential is a single
+opaque string.
+
+1. `ArgoCdConnector.auth_headers(target, operator)` is called. The
+   `operator: Operator` is the dispatched identity threaded down from the op
+   handler (the operator-context Vault read).
+2. `_load_credentials(target, operator)` acquires the per-instance
+   `asyncio.Lock`, checks the `_creds_cache` dict (keyed on `target.name`),
+   and calls the loader with `(target, operator)` on miss.
+3. The loader (default: `load_credentials_from_vault`, which reads the secret
+   under the operator's identity; injectable in tests) returns `{"token": ...}`.
+4. The result is cached under `target.name` and an `argocd_credentials_loaded`
+   log event is emitted (no secret value).
+5. `auth_headers` returns `{"Authorization": "Bearer <token>"}`.
+
+The cache fast-path is closed to the synthesised system operator
+(`is_system_operator`): a system/operator-less caller always re-runs the loader
+so its fail-closed guard applies and can never be served a warm token a real
+operator primed (#1008).
+
+### fingerprint()
+
+`GET /api/version` → ArgoCD's `VersionMessage` payload (an unauthenticated
+endpoint, so the fingerprint does not depend on a resolvable bearer token —
+it works on a freshly-registered target before its Vault secret is
+configured). `Version` (e.g. `"v3.3.9+abc1234"`) becomes the canonical
+`version`; the bundled build-tool versions land under `extras`:
+`BuildDate`, `KustomizeVersion`, `HelmVersion`, `KubectlVersion`. Field names
+are the gRPC-gateway-serialized proto field names (PascalCase) from
+`server/version/version.proto`.
+
+On transport or status error, returns `FingerprintResult(reachable=False,
+extras={"error": "<ExcType>: <message>"})`.
+
+### probe()
+
+`probe()` delegates to `fingerprint()` — the same precedent the SDDC Manager
+and NSX connectors established. A reachable fingerprint maps to
+`ProbeResult(ok=True)`; an unreachable one carries the fingerprint's
+structured `error` string as `reason`. ArgoCD exposes no dedicated composite
+health endpoint comparable to Harbor's `/api/v2.0/health`, so the
+unauthenticated `GET /api/version` probe is the right reachability surface.
+
+### execute() shim
+
+`execute()` synthesises a system `Operator` with
+`sub="system:argocd-api-connector-shim"` and delegates to
+`meho_backplane.operations.dispatch(connector_id="argocd-api-3.x", ...)`.
+Post-G0.6 callers (CLI verbs, MCP `call_operation`, `/api/v1/operations/call`)
+construct a real `Operator` and call `dispatch` directly — they bypass this
+shim.
+
+## Dependencies
+
+- **httpx** — async HTTP client with per-target pooling and retry decorator.
+  `fingerprint()` uses `_get_json` (retried idempotent GET).
+- **tenacity** — retry logic for idempotent GET requests (3 retries,
+  exponential backoff, 5xx + connection errors only).
+- **structlog** — structured logging for credential load events (no secret
+  value).
+- **`meho_backplane.connectors.adapters.http.HttpConnector`** — base class
+  providing `_get_json`, `_http_client`, and `aclose`.
+- **`meho_backplane.connectors._shared.vault_creds`** — `load_basic_credentials`
+  (operator-context KV-v2 read, two-phase error contract,
+  no-secret-in-logs discipline).
+- **`meho_backplane.connectors.schemas`** — `FingerprintResult`, `ProbeResult`,
+  `OperationResult`, `AuthModel`.
+
+## Tests
+
+- `tests/test_connectors_argocd_auth.py` — unit tests for bearer-token auth,
+  caching, per-target isolation, the system-operator cache bypass, the
+  auth_model boundary gate, and the fingerprint/probe shapes against mocked
+  `argocd-server` endpoints.
+- `tests/test_connectors_argocd_credread.py` — recorded-fixture E2E proving
+  the full `dispatch -> loader -> ArgoCD` chain returns `status="ok"` with the
+  live (non-injected) default loader against the in-process Vault fake +
+  respx-mocked ArgoCD, plus the canary-token leak assertions.
+- `tests/test_connectors_registry_v2.py::test_argocd_connector_registered_under_v2_triple_and_wildcard`
+  — asserts the dual registration resolves.
+
+## Known issues
+
+- This Task ships **zero operations** — `execute(target, op_id, ...)` against
+  any `op_id` resolves to "unknown operation" at the dispatcher layer, the
+  correct behaviour for a registered-but-empty connector at this stage. The
+  curated read core lands in G3.12-T2.
+- The write ops (`argocd.app.sync` / `app.rollback` / `app.set`, gated by the
+  approval queue) and any full-Swagger L2 ingest are deferred follow-up Tasks
+  under Initiative #1387, per Hard rule 2 (no speculative optionality).
+- The fingerprint surfaces only the four build-tool fields the operator
+  cares about (`BuildDate`, `KustomizeVersion`, `HelmVersion`,
+  `KubectlVersion`); the full `VersionMessage` (`GitCommit`, `GitTag`,
+  `GoVersion`, `Platform`, `JsonnetVersion`, `ExtraBuildInfo`) is available on
+  the wire but intentionally not surfaced.
+
+## References
+
+- Issues: #1390 (G3.12-T1 skeleton). Initiative: #1387 (G3.12 argocd
+  connector). Goal: #214 (connector parity / wrapper retirement).
+- HttpConnector base: `backend/src/meho_backplane/connectors/adapters/http.py`
+- Shared Vault loader: `backend/src/meho_backplane/connectors/_shared/vault_creds.py`
+- ArgoCD API: https://argo-cd.readthedocs.io/en/stable/developer-guide/api-docs/
+- `VersionMessage` proto: `argoproj/argo-cd` `server/version/version.proto`
+- Precedents: `connectors/harbor/` (bearer-vs-Basic single-vendor-REST shape,
+  cred loader + cache + system-operator bypass), `connectors/bind9/` (dual
+  registration), `connectors/nsx/` (probe delegates to fingerprint).


### PR DESCRIPTION
## Summary

- Lands the `ArgoCdConnector` substrate (G3.12-T1) under Initiative #1387 / Goal #214: an `HttpConnector` subclass that authenticates `argocd-server` with a static **bearer token** federated through the operator-context Vault credential broker (G3.9 #939 / G3.10 #944 precedent).
- `fingerprint()` round-trips the unauthenticated `GET /api/version` and returns the `VersionMessage` payload — `Version` as the canonical `version`, plus `BuildDate` / `KustomizeVersion` / `HelmVersion` / `KubectlVersion` under `extras`.
- **Dual** `register_connector_v2` registration from day one per G0.15-T6: versioned `(argocd, 3.x, argocd-api)` + wildcard `(argocd, "", "")`. Auto-discovered by `_eager_import_connectors` — no manual import-list edit.
- Ships **zero operations** — the curated read core and its typed-op registrar land in G3.12-T2 (mirrors the Harbor #619→#620 skeleton-then-ops split).

## Design notes

- The bearer token is a shared service-account credential read once from the target's Vault `secret_ref` (field `token`) under the dispatched operator's identity via the shared `load_basic_credentials` helper, cached per target, sent as `Authorization: Bearer <token>`. No username component (unlike Harbor Basic), no session round-trip (unlike vmware/SDDC), no JWT exchange (unlike GitHub App).
- `fingerprint()`/`probe()` deliberately bypass `auth_headers` because `/api/version` is unauthenticated — a freshly-registered target fingerprints **before** its Vault secret is configured. `probe()` delegates to `fingerprint()` (SDDC/NSX precedent; ArgoCD has no dedicated health endpoint).
- System-operator cache-bypass (#1008) and the `shared_service_account` auth_model boundary are enforced the same way Harbor/SDDC do.

## Test plan

- [x] `ruff check` — clean
- [x] `ruff format --check` — clean
- [x] `mypy` — clean (3 source files)
- [x] `pytest tests/test_connectors_argocd_auth.py tests/test_connectors_argocd_credread.py tests/test_connectors_registry_v2.py` — 52 passed
- [x] No-regression sweep: `test_connectors_registry`, `test_connectors_resolver`, `test_openapi_target_product_enum`, `test_ui_connectors_*`, `test_operations_ingest_catalog` — 199 passed
- [x] **AC1** (resolves via versioned+wildcard, appears in `all_connectors_v2()`): asserted in `test_connectors_registry_v2.py::test_argocd_connector_registered_under_v2_triple_and_wildcard` + verified live via `_eager_import_connectors()`.
- [x] **AC2** (fingerprint round-trips `GET /api/version` with the Vault-sourced bearer token, returns version payload): `test_connectors_argocd_auth.py` fingerprint shape tests + `test_connectors_argocd_credread.py` full dispatch→loader→bearer chain (live default loader against in-process Vault fake + respx ArgoCD), incl. canary-token leak assertions.
- [x] **AC3** (unit + recorded-fixture coverage; registry coverage still passes): above.
- [x] **AC4** (no typed ops beyond a registrar stub): zero ops registered, no registrar queued — documented in `__init__.py` and the codebase doc.
- [x] `code-quality.py --diff` — 0 blockers (1 warning: connector.py 402 lines, below the 600 block threshold; consistent with the Harbor connector size)

## Out of scope

- Curated read ops (`argocd.app.list/get/diff/resource_tree`, `argocd.appproject.list`, `argocd.repo.list`) — G3.12-T2.
- CLI verbs + MCP review + recorded-fixture E2E + `docs/cross-repo/argocd-onboarding.md` — G3.12-T3.
- Write ops (`app.sync`/`rollback`/`set`, approval-gated) and full-Swagger L2 ingest — deferred follow-ups under #1387 (no speculative optionality).

<!-- auto-implement-issue: fresh, iteration 1 -->

Closes #1390
