### PR TITLE
feat(connectors): G3.13-T2 keycloak curated read ops (secret-redacted)

### DIFF
--- a/backend/src/meho_backplane/connectors/keycloak/__init__.py
+++ b/backend/src/meho_backplane/connectors/keycloak/__init__.py
@@ -50,11 +50,14 @@ async def register_keycloak_typed_operations(
     runner passes the process-wide :class:`EmbeddingService` (or a
     chassis-test stub) to every registrar via
     ``registrar(embedding_service=...)``, so each registrar **must**
-    accept the kwarg or the lifespan crashes with :class:`TypeError`. T1
-    ships zero ops so the value is unused; the kwarg-accept-and-discard
-    shape matches the bind9 sibling.
+    accept the kwarg or the lifespan crashes with :class:`TypeError`.
+    :meth:`KeycloakConnector.register_operations` resolves the
+    process-wide :class:`EmbeddingService` singleton itself through
+    :func:`~meho_backplane.operations.typed_register.register_typed_operation`,
+    so the kwarg is accepted-and-discarded here (the same shape the bind9
+    sibling uses).
     """
-    del embedding_service  # T1 ships zero ops -- kwarg accepted for runner-compatibility
+    del embedding_service  # register_typed_operation resolves the singleton itself
     await KeycloakConnector.register_operations()
 
 

--- a/backend/src/meho_backplane/connectors/keycloak/connector.py
+++ b/backend/src/meho_backplane/connectors/keycloak/connector.py
@@ -3,9 +3,10 @@
 
 """KeycloakConnector -- HttpConnector subclass for the Keycloak 26.x Admin REST API.
 
-G3.13-T1 (#1393) skeleton -- admin credential loader + fingerprint +
-dual registration. Read ops (T2) and onboarding docs (T3) layer on top;
-this module ships **zero** typed operations.
+G3.13-T1 (#1393) shipped the substrate -- admin credential loader +
+fingerprint + dual registration. G3.13-T2 (#1394) layers the six curated
+read ops onto that surface (realm/client/client-scope/user/role-mapping);
+onboarding docs (T3) and the approval-gated write surface (T4) follow.
 
 The load-bearing design point -- admin-vs-operator credential split
 =====================================================================
@@ -54,11 +55,13 @@ NSX / vRLI precedents established).
 Operations
 ==========
 
-This module ships zero operations -- the G0.6 dispatch shim
-:meth:`execute` exists for ABC compatibility and the
-:meth:`register_operations` classmethod is the seam T2 fills in. Until
-then the connector is registered + discoverable but ``execute`` against
-any ``op_id`` resolves to ``unknown_op`` at the dispatcher.
+The six T2 read ops live in
+:mod:`~meho_backplane.connectors.keycloak.ops_read` (metadata +
+handler logic); the connector exposes a thin bound-method shim per op
+and walks ``READ_OPS`` in :meth:`register_operations`. Each op dispatches
+via :meth:`auth_headers` (the admin-token Bearer) and scrubs secret
+material from its result. The G0.6 dispatch shim :meth:`execute` routes
+``op_id`` through the operator-aware dispatcher.
 
 References
 ----------
@@ -82,11 +85,12 @@ from typing import Any
 
 import httpx
 import structlog
+from tenacity import retry, retry_if_exception, stop_after_attempt, wait_exponential
 
 from meho_backplane.auth.operator import Operator
 from meho_backplane.connectors._shared.vault_creds import VaultCredentialsReadError
 from meho_backplane.connectors._shared.vcf_auth import is_acceptable_auth_model
-from meho_backplane.connectors.adapters.http import HttpConnector
+from meho_backplane.connectors.adapters.http import HttpConnector, _retryable
 from meho_backplane.connectors.keycloak.session import (
     KeycloakAdminCredentials,
     KeycloakAdminCredentialsLoader,
@@ -457,29 +461,195 @@ class KeycloakConnector(HttpConnector):
             probed_at=fp.probed_at,
         )
 
-    # -- typed-op registrar seam (T2 fills this in) ---------------------
+    # -- admin-auth JSON GET helpers ------------------------------------
+
+    async def _get_admin_json(
+        self,
+        target: KeycloakTargetLike,
+        path: str,
+        *,
+        operator: Operator,
+        params: dict[str, Any] | None = None,
+    ) -> dict[str, Any]:
+        """Retried admin-auth GET for an **object** response.
+
+        Thin alias over the inherited
+        :meth:`~meho_backplane.connectors.adapters.http.HttpConnector._get_json`
+        so the read-op handlers read uniformly against object endpoints
+        (``GET /admin/realms/{realm}``, one client, role-mappings). The
+        admin Bearer is applied by this connector's
+        :meth:`auth_headers`; the operator authorises only the Vault read
+        behind the token mint.
+        """
+        return await self._get_json(target, path, operator=operator, params=params)
+
+    @retry(
+        stop=stop_after_attempt(4),
+        wait=wait_exponential(multiplier=0.5, min=0.5, max=2.0),
+        retry=retry_if_exception(_retryable),
+        reraise=True,
+    )
+    async def _get_admin_list(
+        self,
+        target: KeycloakTargetLike,
+        path: str,
+        *,
+        operator: Operator,
+        params: dict[str, Any] | None = None,
+    ) -> list[Any]:
+        """Retried admin-auth GET for an **array** response.
+
+        Several Keycloak Admin REST list endpoints (``/clients``,
+        ``/client-scopes``, ``/users``) return a JSON **array**, not an
+        object, so the inherited :meth:`_get_json` (typed ``dict``) is the
+        wrong shape. This helper mirrors its retry / timeout / auth
+        contract — same idempotent-GET backoff as
+        :meth:`~meho_backplane.connectors.adapters.http.HttpConnector._request_json`
+        — but returns the parsed list. A non-list body (an error envelope
+        Keycloak occasionally returns as an object) yields an empty list
+        so a handler never iterates a dict.
+        """
+        client = await self._http_client(target)
+        headers = await self.auth_headers(target, operator)
+        resp = await client.request("GET", path, params=params, headers=headers)
+        resp.raise_for_status()
+        payload = resp.json()
+        return payload if isinstance(payload, list) else []
+
+    # -- typed-op handler shims (G3.13-T2 #1394) ------------------------
+
+    async def realm_get(
+        self, operator: Operator, target: KeycloakTargetLike, params: dict[str, Any]
+    ) -> dict[str, Any]:
+        """Bound-method shim for the ``keycloak.realm.get`` op (G3.13-T2 #1394)."""
+        from meho_backplane.connectors.keycloak.ops_read import keycloak_realm_get
+
+        return await keycloak_realm_get(self, operator, target, params)
+
+    async def client_list(
+        self, operator: Operator, target: KeycloakTargetLike, params: dict[str, Any]
+    ) -> dict[str, Any]:
+        """Bound-method shim for the ``keycloak.client.list`` op (G3.13-T2 #1394)."""
+        from meho_backplane.connectors.keycloak.ops_read import keycloak_client_list
+
+        return await keycloak_client_list(self, operator, target, params)
+
+    async def client_get(
+        self, operator: Operator, target: KeycloakTargetLike, params: dict[str, Any]
+    ) -> dict[str, Any]:
+        """Bound-method shim for the ``keycloak.client.get`` op (G3.13-T2 #1394)."""
+        from meho_backplane.connectors.keycloak.ops_read import keycloak_client_get
+
+        return await keycloak_client_get(self, operator, target, params)
+
+    async def client_scope_list(
+        self, operator: Operator, target: KeycloakTargetLike, params: dict[str, Any]
+    ) -> dict[str, Any]:
+        """Bound-method shim for the ``keycloak.client_scope.list`` op (G3.13-T2 #1394)."""
+        from meho_backplane.connectors.keycloak.ops_read import keycloak_client_scope_list
+
+        return await keycloak_client_scope_list(self, operator, target, params)
+
+    async def user_list(
+        self, operator: Operator, target: KeycloakTargetLike, params: dict[str, Any]
+    ) -> dict[str, Any]:
+        """Bound-method shim for the ``keycloak.user.list`` op (G3.13-T2 #1394)."""
+        from meho_backplane.connectors.keycloak.ops_read import keycloak_user_list
+
+        return await keycloak_user_list(self, operator, target, params)
+
+    async def role_mapping_get(
+        self, operator: Operator, target: KeycloakTargetLike, params: dict[str, Any]
+    ) -> dict[str, Any]:
+        """Bound-method shim for the ``keycloak.role_mapping.get`` op (G3.13-T2 #1394)."""
+        from meho_backplane.connectors.keycloak.ops_read import keycloak_role_mapping_get
+
+        return await keycloak_role_mapping_get(self, operator, target, params)
+
+    # -- typed-op registrar (G3.13-T2 #1394 fills the read-op walk) ------
 
     @classmethod
     async def register_operations(cls) -> None:
-        """Typed-op registrar seam -- ships **no** ops in T1 (G3.13-T1 #1393).
+        """Upsert every op in :data:`READ_OPS` into ``endpoint_descriptor``.
 
-        T1 is the substrate: the connector class, the admin credential
-        loader, fingerprint, and dual registration. Read ops land in T2,
-        which walks a ``KEYCLOAK_OPS`` table here exactly as
-        :meth:`~meho_backplane.connectors.pfsense.connector.PfSenseConnector.register_operations`
-        walks ``PFSENSE_OPS``. Wiring the no-op registrar now means the
-        lifespan's ``run_typed_op_registrars`` call already drives
-        Keycloak, so T2 only fills the op walk -- the seam doesn't move.
+        Called from the application lifespan after the registry has
+        eager-imported every connector module. Walks
+        :data:`~meho_backplane.connectors.keycloak.ops_read.READ_OPS` and
+        routes each row through
+        :func:`~meho_backplane.operations.typed_register.register_typed_operation`,
+        which derives ``handler_ref`` from the bound method's
+        ``__module__`` + ``__qualname__``, inserts on first call, and
+        skips the embedding compute on re-call with unchanged
+        summary / description / tags. Idempotent across pod restarts --
+        mirrors the bind9 / pfSense
+        :meth:`register_operations` shape.
 
-        Idempotent (a no-op is trivially idempotent across pod restarts).
+        G3.13-T2 (#1394) lands the six read ops
+        (``keycloak.realm.get`` / ``client.list`` / ``client.get`` /
+        ``client_scope.list`` / ``user.list`` / ``role_mapping.get``); the
+        write surface is the deferred approval-gated T4 follow-up.
         """
+        # Lazy imports: the operations package pulls in the embedding
+        # pipeline (ONNX runtime + a 100 MB+ model on first touch) that a
+        # pure-fingerprint / pure-probe unit test should not pay. Lifespan
+        # callers already have the embedding service warmed by the time
+        # this runs.
+        from meho_backplane.connectors.keycloak.ops_read import (
+            READ_OPS,
+            WHEN_TO_USE_BY_GROUP,
+        )
+        from meho_backplane.operations.typed_register import register_typed_operation
+
+        bindings: list[tuple[Any, Any]] = []
+        for op in READ_OPS:
+            handler = getattr(cls, op.handler_attr, None)
+            if handler is None:
+                raise AttributeError(
+                    f"KeycloakConnector op {op.op_id!r} declares "
+                    f"handler_attr={op.handler_attr!r} but the class has no such attribute"
+                )
+            bindings.append((op, handler))
+
+        for op, handler in bindings:
+            when_to_use: str | None
+            if op.group_key is None:
+                when_to_use = None
+            else:
+                when_to_use = WHEN_TO_USE_BY_GROUP.get(op.group_key)
+                if when_to_use is None:
+                    raise ValueError(
+                        f"KeycloakConnector op {op.op_id!r} declares "
+                        f"group_key={op.group_key!r} but no curated "
+                        f"when_to_use exists for that key. Add an entry to "
+                        f"WHEN_TO_USE_BY_GROUP in "
+                        f"meho_backplane.connectors.keycloak.ops_read so "
+                        f"list_operation_groups surfaces a real selection "
+                        f"signal instead of the auto-derive template."
+                    )
+            await register_typed_operation(
+                product=cls.product,
+                version=cls.version,
+                impl_id=cls.impl_id,
+                op_id=op.op_id,
+                handler=handler,
+                summary=op.summary,
+                description=op.description,
+                parameter_schema=op.parameter_schema,
+                response_schema=op.response_schema,
+                group_key=op.group_key,
+                when_to_use=when_to_use,
+                tags=list(op.tags),
+                safety_level=op.safety_level,
+                requires_approval=op.requires_approval,
+                llm_instructions=op.llm_instructions,
+            )
+
         _log.info(
             "keycloak_operations_registered",
-            count=0,
+            count=len(bindings),
             product=cls.product,
             version=cls.version,
             impl_id=cls.impl_id,
-            note="T1 substrate ships zero ops; read ops land in G3.13-T2",
         )
 
     # -- dispatcher shim ------------------------------------------------

--- a/backend/src/meho_backplane/connectors/keycloak/ops_read.py
+++ b/backend/src/meho_backplane/connectors/keycloak/ops_read.py
@@ -1,0 +1,594 @@
+# SPDX-License-Identifier: Apache-2.0
+# Copyright (c) 2026 evoila Group
+
+"""Curated read ops for :class:`KeycloakConnector` (G3.13-T2 #1394).
+
+Six ``safety_level="safe"`` / ``requires_approval=False`` read ops that
+surface the realm / client / client-scope / user / role-mapping config an
+operator would otherwise read with ``kcadm.sh get`` or the admin console:
+
+================================  =================================================
+op_id                             Admin REST API
+================================  =================================================
+``keycloak.realm.get``            ``GET /admin/realms/{realm}``
+``keycloak.client.list``          ``GET /admin/realms/{realm}/clients`` (``?clientId=``)
+``keycloak.client.get``           ``GET /admin/realms/{realm}/clients/{id}``
+``keycloak.client_scope.list``    ``GET /admin/realms/{realm}/client-scopes``
+``keycloak.user.list``            ``GET /admin/realms/{realm}/users`` (``?username=``/``?max=``)
+``keycloak.role_mapping.get``     ``GET /admin/realms/{realm}/users/{id}/role-mappings``
+================================  =================================================
+
+All ops dispatch via the **admin-auth** path the T1 substrate built
+(``auth_headers`` → admin token Bearer), never the operator-OIDC path.
+The realm is resolved from the target's ``managed_realm`` (``extras``
+override, default ``evba``) so an op never has to be told which realm to
+operate on — it operates on the realm the connector manages.
+
+Secret redaction
+================
+
+Every handler runs its response through
+:func:`~meho_backplane.connectors.keycloak.redaction.redact_secret_fields`
+before returning, so confidential-client secrets
+(``ClientRepresentation.secret``) and user credential material
+(``UserRepresentation.credentials``) never reach the
+:class:`~meho_backplane.connectors.schemas.OperationResult`. The scrub is
+recursive — a secret nested inside a protocol mapper or identity-provider
+config is caught too.
+
+Handler signature
+=================
+
+The dispatcher introspects the handler signature by parameter **name**:
+a handler declaring ``operator`` is invoked as
+``handler(operator=, target=, params=)`` (see
+:func:`meho_backplane.operations._branches.dispatch_typed`). The keycloak
+read ops need the operator to authorise the operator-context Vault read
+that backs the admin-token mint, so every handler takes ``operator`` —
+unlike the bind9 / pfsense handlers, whose SSH transport carries no
+per-operator credential.
+
+The op-metadata dataclass + ``READ_OPS`` tuple mirror the bind9
+(:mod:`~meho_backplane.connectors.bind9.ops`) and pfSense
+(:mod:`~meho_backplane.connectors.pfsense.ops_read`) precedents so the
+registration walk in
+:meth:`KeycloakConnector.register_operations` reads identically.
+
+References
+----------
+
+* Task: https://github.com/evoila/meho/issues/1394
+* Parent initiative: https://github.com/evoila/meho/issues/1388
+* Read-core precedents: G3.5 Harbor (#620) / SDDC Manager (#617).
+* Keycloak 26.3 Admin REST API:
+  https://www.keycloak.org/docs-api/26.3.3/rest-api/index.html
+* RealmRepresentation / ClientRepresentation / UserRepresentation /
+  MappingsRepresentation:
+  https://www.keycloak.org/docs-api/latest/javadocs/org/keycloak/representations/idm/package-summary.html
+"""
+
+from __future__ import annotations
+
+from dataclasses import dataclass
+from typing import TYPE_CHECKING, Any, Literal
+
+from meho_backplane.connectors.keycloak.redaction import redact_secret_fields
+from meho_backplane.connectors.keycloak.session import resolve_realm_config
+
+if TYPE_CHECKING:
+    from meho_backplane.auth.operator import Operator
+    from meho_backplane.connectors.keycloak.connector import KeycloakConnector
+    from meho_backplane.connectors.keycloak.session import KeycloakTargetLike
+
+__all__ = [
+    "READ_OPS",
+    "WHEN_TO_USE_BY_GROUP",
+    "KeycloakOp",
+    "keycloak_client_get",
+    "keycloak_client_list",
+    "keycloak_client_scope_list",
+    "keycloak_realm_get",
+    "keycloak_role_mapping_get",
+    "keycloak_user_list",
+]
+
+
+@dataclass(frozen=True)
+class KeycloakOp:
+    """Metadata for one keycloak op the connector registers at startup.
+
+    Fields mirror the keyword arguments
+    :func:`~meho_backplane.operations.typed_register.register_typed_operation`
+    accepts so the connector's ``register_operations()`` classmethod can
+    splat the dataclass into the helper without per-op boilerplate.
+    ``handler_attr`` is the attribute name on
+    :class:`~meho_backplane.connectors.keycloak.connector.KeycloakConnector`
+    exposing the async handler; the connector resolves the bound method
+    against itself at registration time so the dispatcher's
+    :func:`~meho_backplane.operations._handler_resolve.import_handler`
+    walk recovers the callable from the persisted
+    ``module.ClassName.method`` dotted path.
+    """
+
+    op_id: str
+    handler_attr: str
+    summary: str
+    description: str
+    parameter_schema: dict[str, Any]
+    response_schema: dict[str, Any] | None
+    group_key: str | None
+    tags: tuple[str, ...]
+    safety_level: Literal["safe", "caution", "dangerous"]
+    requires_approval: bool
+    llm_instructions: dict[str, Any] | None
+
+
+# ---------------------------------------------------------------------------
+# Handler functions (bound-method shims on KeycloakConnector)
+# ---------------------------------------------------------------------------
+
+
+async def keycloak_realm_get(
+    self: KeycloakConnector,
+    operator: Operator,
+    target: KeycloakTargetLike,
+    params: dict[str, Any],
+) -> dict[str, Any]:
+    """Return the managed realm's top-level config (``GET /admin/realms/{realm}``).
+
+    Op-id: ``keycloak.realm.get``. The realm is the target's
+    ``managed_realm``; no params. The :class:`RealmRepresentation` carries
+    realm-wide policy (login settings, token lifespans, SMTP, themes). Any
+    nested secret is scrubbed before return.
+    """
+    del params  # declared empty; intentionally ignored
+    realms = resolve_realm_config(target)
+    realm = await self._get_admin_json(
+        target, f"/admin/realms/{realms.managed_realm}", operator=operator
+    )
+    return {"realm": redact_secret_fields(realm)}
+
+
+async def keycloak_client_list(
+    self: KeycloakConnector,
+    operator: Operator,
+    target: KeycloakTargetLike,
+    params: dict[str, Any],
+) -> dict[str, Any]:
+    """List clients in the managed realm (``GET /admin/realms/{realm}/clients``).
+
+    Op-id: ``keycloak.client.list``. Optional ``client_id`` param maps to
+    Keycloak's ``?clientId=`` exact-match filter; ``max`` caps the result
+    count. Returns ``{rows, total}``; confidential-client secrets are
+    scrubbed from every row.
+    """
+    realms = resolve_realm_config(target)
+    query: dict[str, Any] = {}
+    client_id = params.get("client_id")
+    if isinstance(client_id, str) and client_id:
+        query["clientId"] = client_id
+    max_results = params.get("max")
+    if isinstance(max_results, int):
+        query["max"] = max_results
+    rows = await self._get_admin_list(
+        target,
+        f"/admin/realms/{realms.managed_realm}/clients",
+        operator=operator,
+        params=query or None,
+    )
+    scrubbed = [redact_secret_fields(row) for row in rows]
+    return {"rows": scrubbed, "total": len(scrubbed)}
+
+
+async def keycloak_client_get(
+    self: KeycloakConnector,
+    operator: Operator,
+    target: KeycloakTargetLike,
+    params: dict[str, Any],
+) -> dict[str, Any]:
+    """Return one client by internal id (``GET /admin/realms/{realm}/clients/{id}``).
+
+    Op-id: ``keycloak.client.get``. ``id`` is the client's **internal
+    UUID** (the ``id`` field from ``keycloak.client.list``, not the
+    human ``clientId``). The :class:`ClientRepresentation` carries the
+    flows (``authenticationFlowBindingOverrides``), redirect URIs
+    (``redirectUris``), and protocol mappers (``protocolMappers``) an
+    operator reads from the admin console. The client ``secret`` is
+    scrubbed.
+    """
+    realms = resolve_realm_config(target)
+    client_uuid = str(params["id"])
+    client = await self._get_admin_json(
+        target,
+        f"/admin/realms/{realms.managed_realm}/clients/{client_uuid}",
+        operator=operator,
+    )
+    return {"client": redact_secret_fields(client)}
+
+
+async def keycloak_client_scope_list(
+    self: KeycloakConnector,
+    operator: Operator,
+    target: KeycloakTargetLike,
+    params: dict[str, Any],
+) -> dict[str, Any]:
+    """List client scopes (``GET /admin/realms/{realm}/client-scopes``).
+
+    Op-id: ``keycloak.client_scope.list``. No params. Each
+    :class:`ClientScopeRepresentation` carries the scope's protocol
+    mappers and attributes. Returns ``{rows, total}``.
+    """
+    del params  # declared empty; intentionally ignored
+    realms = resolve_realm_config(target)
+    rows = await self._get_admin_list(
+        target,
+        f"/admin/realms/{realms.managed_realm}/client-scopes",
+        operator=operator,
+    )
+    scrubbed = [redact_secret_fields(row) for row in rows]
+    return {"rows": scrubbed, "total": len(scrubbed)}
+
+
+async def keycloak_user_list(
+    self: KeycloakConnector,
+    operator: Operator,
+    target: KeycloakTargetLike,
+    params: dict[str, Any],
+) -> dict[str, Any]:
+    """List users in the managed realm (``GET /admin/realms/{realm}/users``).
+
+    Op-id: ``keycloak.user.list``. Optional ``username`` maps to
+    Keycloak's ``?username=`` filter; ``max`` caps the result count.
+    Returns ``{rows, total}``. User credential material
+    (``UserRepresentation.credentials``) is scrubbed from every row — the
+    op never surfaces credentials.
+    """
+    realms = resolve_realm_config(target)
+    query: dict[str, Any] = {}
+    username = params.get("username")
+    if isinstance(username, str) and username:
+        query["username"] = username
+    max_results = params.get("max")
+    if isinstance(max_results, int):
+        query["max"] = max_results
+    rows = await self._get_admin_list(
+        target,
+        f"/admin/realms/{realms.managed_realm}/users",
+        operator=operator,
+        params=query or None,
+    )
+    scrubbed = [redact_secret_fields(row) for row in rows]
+    return {"rows": scrubbed, "total": len(scrubbed)}
+
+
+async def keycloak_role_mapping_get(
+    self: KeycloakConnector,
+    operator: Operator,
+    target: KeycloakTargetLike,
+    params: dict[str, Any],
+) -> dict[str, Any]:
+    """Return a user's role mappings (``GET .../users/{id}/role-mappings``).
+
+    Op-id: ``keycloak.role_mapping.get``. ``id`` is the user's internal
+    UUID. The :class:`MappingsRepresentation` carries ``realmMappings``
+    (realm-level roles) and ``clientMappings`` (per-client roles). No
+    secret material is present, but the response is run through the
+    scrubber for defence-in-depth consistency with the sibling ops.
+    """
+    realms = resolve_realm_config(target)
+    user_uuid = str(params["id"])
+    mappings = await self._get_admin_json(
+        target,
+        f"/admin/realms/{realms.managed_realm}/users/{user_uuid}/role-mappings",
+        operator=operator,
+    )
+    return {"role_mappings": redact_secret_fields(mappings)}
+
+
+# ---------------------------------------------------------------------------
+# Curated when_to_use blurbs (one per op group)
+# ---------------------------------------------------------------------------
+
+_WHEN_TO_USE_REALM = (
+    "Use to read the managed realm's top-level configuration — login "
+    "settings, token lifespans, themes, SMTP, and realm-wide policy — the "
+    "same view ``kcadm.sh get realms/<realm>`` or the admin console's "
+    "Realm Settings page shows. Call ``keycloak.realm.get`` when the "
+    "operator wants to inspect or audit realm-level config."
+)
+
+_WHEN_TO_USE_CLIENT = (
+    "Use for Keycloak client (OIDC/SAML relying-party) reads: list "
+    "clients in the realm (``keycloak.client.list``, optionally filtered "
+    "by ``client_id``) or fetch one client's full configuration by its "
+    "internal UUID (``keycloak.client.get`` — flows, redirect URIs, "
+    "protocol mappers). Confidential-client secrets are redacted. Call "
+    "``keycloak.client.list`` first to discover a client's internal ``id``, "
+    "then ``keycloak.client.get`` for its full representation."
+)
+
+_WHEN_TO_USE_CLIENT_SCOPE = (
+    "Use to list the realm's client scopes "
+    "(``keycloak.client_scope.list``) — the reusable bundles of protocol "
+    "mappers and role scope-mappings clients attach as default/optional "
+    "scopes. Call when the operator wants to audit which scopes (and "
+    "their mappers) exist before assigning them to a client."
+)
+
+_WHEN_TO_USE_USER = (
+    "Use to list realm users (``keycloak.user.list``, optionally filtered "
+    "by ``username``) or read a user's effective role mappings "
+    "(``keycloak.role_mapping.get`` by internal UUID — realm roles + "
+    "per-client roles). User credential material is never returned. Call "
+    "``keycloak.user.list`` to discover a user's internal ``id``, then "
+    "``keycloak.role_mapping.get`` for that user's role assignments."
+)
+
+#: Curated ``when_to_use`` blurb per op group, consumed by
+#: :meth:`KeycloakConnector.register_operations` (a group_key without an
+#: entry is a hard registration error). Co-located with the ops so the
+#: curation and the metadata stay together.
+WHEN_TO_USE_BY_GROUP: dict[str, str] = {
+    "realm": _WHEN_TO_USE_REALM,
+    "client": _WHEN_TO_USE_CLIENT,
+    "client_scope": _WHEN_TO_USE_CLIENT_SCOPE,
+    "user": _WHEN_TO_USE_USER,
+}
+
+_EMPTY_PARAMS: dict[str, Any] = {
+    "type": "object",
+    "properties": {},
+    "additionalProperties": False,
+}
+
+_REALM_REPR_SCHEMA: dict[str, Any] = {
+    "type": "object",
+    "properties": {"realm": {"type": "object"}},
+    "required": ["realm"],
+    "additionalProperties": True,
+}
+
+_ROWS_SCHEMA: dict[str, Any] = {
+    "type": "object",
+    "properties": {
+        "rows": {"type": "array", "items": {"type": "object"}},
+        "total": {"type": "integer"},
+    },
+    "required": ["rows", "total"],
+    "additionalProperties": True,
+}
+
+
+READ_OPS: tuple[KeycloakOp, ...] = (
+    KeycloakOp(
+        op_id="keycloak.realm.get",
+        handler_attr="realm_get",
+        summary="Read the managed Keycloak realm's top-level configuration.",
+        description=(
+            "GETs ``/admin/realms/{realm}`` against the target's managed "
+            "realm and returns the RealmRepresentation under ``realm`` — "
+            "login settings, token lifespans, themes, SMTP, and realm-wide "
+            "policy. The same view ``kcadm.sh get realms/<realm>`` shows. "
+            "Any nested secret is redacted. No params; dispatches via the "
+            "admin-auth path; safe to call on any reachable target."
+        ),
+        parameter_schema=_EMPTY_PARAMS,
+        response_schema=_REALM_REPR_SCHEMA,
+        group_key="realm",
+        tags=("read-only", "realm", "keycloak"),
+        safety_level="safe",
+        requires_approval=False,
+        llm_instructions={
+            "when_to_use": _WHEN_TO_USE_REALM,
+            "parameter_hints": {},
+            "output_shape": (
+                "``{realm: {<RealmRepresentation>}}``. The realm dict is the "
+                "raw Keycloak realm config with secrets redacted."
+            ),
+        },
+    ),
+    KeycloakOp(
+        op_id="keycloak.client.list",
+        handler_attr="client_list",
+        summary="List Keycloak clients in the managed realm (secrets redacted).",
+        description=(
+            "GETs ``/admin/realms/{realm}/clients`` and returns the "
+            "clients as ``{rows, total}``. Optional ``client_id`` maps to "
+            "Keycloak's ``?clientId=`` exact-match filter; ``max`` caps the "
+            "result count. Each row is a ClientRepresentation with its "
+            "``secret`` redacted. Use ``keycloak.client.get`` for one "
+            "client's full config by internal UUID. Dispatches via the "
+            "admin-auth path."
+        ),
+        parameter_schema={
+            "type": "object",
+            "properties": {
+                "client_id": {
+                    "type": "string",
+                    "description": "Exact clientId filter (Keycloak ?clientId=).",
+                },
+                "max": {
+                    "type": "integer",
+                    "description": "Cap on the number of clients returned.",
+                },
+            },
+            "additionalProperties": False,
+        },
+        response_schema=_ROWS_SCHEMA,
+        group_key="client",
+        tags=("read-only", "client", "keycloak"),
+        safety_level="safe",
+        requires_approval=False,
+        llm_instructions={
+            "when_to_use": _WHEN_TO_USE_CLIENT,
+            "parameter_hints": {
+                "client_id": "Pass to fetch a single client by its human clientId.",
+                "max": "Pass to limit large realms.",
+            },
+            "output_shape": (
+                "``{rows: [{<ClientRepresentation, secret redacted>}], "
+                "total: N}``. Each row's ``id`` is the internal UUID for "
+                "``keycloak.client.get``."
+            ),
+        },
+    ),
+    KeycloakOp(
+        op_id="keycloak.client.get",
+        handler_attr="client_get",
+        summary="Read one Keycloak client's full config by internal UUID (secret redacted).",
+        description=(
+            "GETs ``/admin/realms/{realm}/clients/{id}`` where ``id`` is "
+            "the client's internal UUID (the ``id`` from "
+            "``keycloak.client.list`` — NOT the human ``clientId``). "
+            "Returns the full ClientRepresentation under ``client``: "
+            "authentication flow bindings, redirect URIs, web origins, and "
+            "protocol mappers — the view an operator reads from the admin "
+            "console. The client ``secret`` is redacted. Dispatches via "
+            "the admin-auth path."
+        ),
+        parameter_schema={
+            "type": "object",
+            "properties": {
+                "id": {
+                    "type": "string",
+                    "description": "The client's internal UUID (from keycloak.client.list).",
+                },
+            },
+            "required": ["id"],
+            "additionalProperties": False,
+        },
+        response_schema={
+            "type": "object",
+            "properties": {"client": {"type": "object"}},
+            "required": ["client"],
+            "additionalProperties": True,
+        },
+        group_key="client",
+        tags=("read-only", "client", "keycloak"),
+        safety_level="safe",
+        requires_approval=False,
+        llm_instructions={
+            "when_to_use": _WHEN_TO_USE_CLIENT,
+            "parameter_hints": {
+                "id": "The internal UUID, not the clientId. Get it from keycloak.client.list."
+            },
+            "output_shape": (
+                "``{client: {<ClientRepresentation>}}`` with "
+                "``redirectUris``, ``protocolMappers``, and "
+                "``authenticationFlowBindingOverrides`` present; ``secret`` "
+                "redacted."
+            ),
+        },
+    ),
+    KeycloakOp(
+        op_id="keycloak.client_scope.list",
+        handler_attr="client_scope_list",
+        summary="List Keycloak client scopes in the managed realm.",
+        description=(
+            "GETs ``/admin/realms/{realm}/client-scopes`` and returns the "
+            "scopes as ``{rows, total}``. Each row is a "
+            "ClientScopeRepresentation carrying the scope's protocol "
+            "mappers and attributes — the reusable mapper/role bundles "
+            "clients attach as default or optional scopes. No params; "
+            "dispatches via the admin-auth path."
+        ),
+        parameter_schema=_EMPTY_PARAMS,
+        response_schema=_ROWS_SCHEMA,
+        group_key="client_scope",
+        tags=("read-only", "client-scope", "keycloak"),
+        safety_level="safe",
+        requires_approval=False,
+        llm_instructions={
+            "when_to_use": _WHEN_TO_USE_CLIENT_SCOPE,
+            "parameter_hints": {},
+            "output_shape": (
+                "``{rows: [{<ClientScopeRepresentation>}], total: N}`` with "
+                "each scope's ``protocolMappers`` present."
+            ),
+        },
+    ),
+    KeycloakOp(
+        op_id="keycloak.user.list",
+        handler_attr="user_list",
+        summary="List Keycloak users in the managed realm (no credentials).",
+        description=(
+            "GETs ``/admin/realms/{realm}/users`` and returns the users as "
+            "``{rows, total}``. Optional ``username`` maps to Keycloak's "
+            "``?username=`` filter; ``max`` caps the result count. Each row "
+            "is a UserRepresentation with its ``credentials`` redacted — "
+            "the op never surfaces credential material. Use "
+            "``keycloak.role_mapping.get`` for a user's role assignments. "
+            "Dispatches via the admin-auth path."
+        ),
+        parameter_schema={
+            "type": "object",
+            "properties": {
+                "username": {
+                    "type": "string",
+                    "description": "Username filter (Keycloak ?username=).",
+                },
+                "max": {
+                    "type": "integer",
+                    "description": "Cap on the number of users returned.",
+                },
+            },
+            "additionalProperties": False,
+        },
+        response_schema=_ROWS_SCHEMA,
+        group_key="user",
+        tags=("read-only", "user", "keycloak"),
+        safety_level="safe",
+        requires_approval=False,
+        llm_instructions={
+            "when_to_use": _WHEN_TO_USE_USER,
+            "parameter_hints": {
+                "username": "Pass to fetch a single user by username.",
+                "max": "Pass to limit large realms.",
+            },
+            "output_shape": (
+                "``{rows: [{<UserRepresentation, credentials redacted>}], "
+                "total: N}``. Each row's ``id`` is the internal UUID for "
+                "``keycloak.role_mapping.get``."
+            ),
+        },
+    ),
+    KeycloakOp(
+        op_id="keycloak.role_mapping.get",
+        handler_attr="role_mapping_get",
+        summary="Read a Keycloak user's realm + client role mappings by UUID.",
+        description=(
+            "GETs ``/admin/realms/{realm}/users/{id}/role-mappings`` where "
+            "``id`` is the user's internal UUID (from "
+            "``keycloak.user.list``). Returns the MappingsRepresentation "
+            "under ``role_mappings``: ``realmMappings`` (realm-level roles) "
+            "and ``clientMappings`` (per-client roles). Dispatches via the "
+            "admin-auth path."
+        ),
+        parameter_schema={
+            "type": "object",
+            "properties": {
+                "id": {
+                    "type": "string",
+                    "description": "The user's internal UUID (from keycloak.user.list).",
+                },
+            },
+            "required": ["id"],
+            "additionalProperties": False,
+        },
+        response_schema={
+            "type": "object",
+            "properties": {"role_mappings": {"type": "object"}},
+            "required": ["role_mappings"],
+            "additionalProperties": True,
+        },
+        group_key="user",
+        tags=("read-only", "role-mapping", "keycloak"),
+        safety_level="safe",
+        requires_approval=False,
+        llm_instructions={
+            "when_to_use": _WHEN_TO_USE_USER,
+            "parameter_hints": {"id": "The user's internal UUID, from keycloak.user.list."},
+            "output_shape": ("``{role_mappings: {realmMappings: [...], clientMappings: {...}}}``."),
+        },
+    ),
+)

--- a/backend/src/meho_backplane/connectors/keycloak/redaction.py
+++ b/backend/src/meho_backplane/connectors/keycloak/redaction.py
@@ -1,0 +1,93 @@
+# SPDX-License-Identifier: Apache-2.0
+# Copyright (c) 2026 evoila Group
+
+"""Secret scrubbing for keycloak read-op output (G3.13-T2 #1394).
+
+The curated read ops return the Admin REST representations an operator
+would otherwise read with ``kcadm.sh get``. Those representations carry
+**secret material** that has no place in an op result, an audit row, or
+the broadcast feed:
+
+* ``ClientRepresentation.secret`` — the confidential client's secret.
+  Present on ``GET /admin/realms/{realm}/clients`` and
+  ``GET /admin/realms/{realm}/clients/{id}`` for ``confidential`` clients.
+* ``UserRepresentation.credentials`` — the list of credential records
+  (password hashes, OTP seeds, etc.). The Admin API does not return these
+  on the default ``GET /users`` listing, but it *can* on a single-user
+  fetch or a future param change, so the read ops scrub it
+  unconditionally rather than relying on Keycloak's default projection.
+* ``secret`` on any nested representation (e.g. an OIDC identity-provider
+  config carried inside a client) — caught by the recursive walk.
+
+Why scrub at the connector boundary
+====================================
+
+MEHO's general posture is to redact secret material at the
+classification / broadcast layer (the ``credential_mint`` /
+``credential_write`` classifiers). That posture fits ops where the
+secret *is* the payload the operator asked for (``vault.token.create``
+returns the token; the broadcast redacts it but the caller still gets
+it). The keycloak read ops are the opposite case: the secret is
+**incidental** to a config read the operator never needs the secret for.
+Returning the secret in the op ``result`` — even with downstream
+broadcast redaction — would still place it in the synchronous response
+the caller receives. So these ops scrub at the source: the secret never
+enters the :class:`~meho_backplane.connectors.schemas.OperationResult` in
+the first place.
+
+The scrub is non-destructive to the operator's intent: every other field
+of the representation (flows, redirect URIs, protocol mappers, scope
+assignments, role mappings) passes through untouched.
+"""
+
+from __future__ import annotations
+
+from typing import Any
+
+__all__ = ["REDACTED", "redact_secret_fields"]
+
+#: Sentinel written in place of a scrubbed secret value. A non-empty
+#: marker (rather than dropping the key) keeps the shape stable so a
+#: caller can see that a secret *existed* without learning its value.
+REDACTED = "***REDACTED***"
+
+#: Field names whose value (scalar **or** subtree) is secret material and
+#: is replaced wholesale with :data:`REDACTED` wherever it appears in a
+#: representation (case-sensitive — Keycloak's JSON keys are stable
+#: camelCase / lowercase). Replacing the whole value rather than
+#: descending keeps a ``credentials`` *list* of hash records from leaking
+#: any element, and a scalar ``secret`` from leaking its value.
+_SECRET_FIELDS: frozenset[str] = frozenset(
+    {
+        "secret",  # ClientRepresentation.secret (confidential client secret)
+        "credentials",  # UserRepresentation.credentials (list of credential records)
+        "value",  # CredentialRepresentation.value (raw credential value)
+        "secretData",  # CredentialRepresentation.secretData (hash + salt blob)
+        "credentialData",  # CredentialRepresentation.credentialData (algo metadata)
+    }
+)
+
+
+def redact_secret_fields(value: Any) -> Any:
+    """Return *value* with Keycloak secret material scrubbed, recursively.
+
+    Walks dicts and lists. For every dict, keys in :data:`_SECRET_FIELDS`
+    (``secret`` / ``credentials`` / ``value`` / ``secretData`` /
+    ``credentialData``) have their whole value replaced with
+    :data:`REDACTED`; every other value is walked recursively so a secret
+    nested inside a protocol mapper or identity-provider config is still
+    caught.
+
+    Scalars (``str`` / ``int`` / ``bool`` / ``None``) pass through
+    unchanged. The input is not mutated — a new structure is returned so
+    the handler's scrub can never accidentally leave a half-redacted
+    object aliased somewhere else.
+    """
+    if isinstance(value, dict):
+        return {
+            key: REDACTED if key in _SECRET_FIELDS else redact_secret_fields(item)
+            for key, item in value.items()
+        }
+    if isinstance(value, list):
+        return [redact_secret_fields(item) for item in value]
+    return value

--- a/backend/tests/test_connectors_keycloak_auth.py
+++ b/backend/tests/test_connectors_keycloak_auth.py
@@ -471,13 +471,27 @@ async def test_mint_admin_token_raises_on_missing_access_token() -> None:
 
 
 # ---------------------------------------------------------------------------
-# Registrar seam -- T1 ships zero ops
+# Registrar seam -- T2 (#1394) fills the read-op walk
 # ---------------------------------------------------------------------------
 
 
-@pytest.mark.asyncio
-async def test_register_operations_ships_zero_ops() -> None:
-    """The registrar seam is wired but ships no ops in T1 (read ops land in T2)."""
-    # No exception, no DB writes -- the no-op registrar is callable so the
-    # lifespan's run_typed_op_registrars already drives Keycloak.
-    await KeycloakConnector.register_operations()
+def test_read_ops_handler_attrs_resolve_to_bound_methods() -> None:
+    """Every READ_OPS ``handler_attr`` resolves to a method on the connector.
+
+    Pins the registration walk's precondition (the ``getattr`` lookup in
+    :meth:`KeycloakConnector.register_operations`) without a DB round-trip
+    — the DB-backed upsert + dispatch is covered by the E2E suite.
+    """
+    from meho_backplane.connectors.keycloak.ops_read import READ_OPS, WHEN_TO_USE_BY_GROUP
+
+    assert len(READ_OPS) == 6
+    for op in READ_OPS:
+        handler = getattr(KeycloakConnector, op.handler_attr, None)
+        assert callable(handler), (
+            f"{op.op_id} handler_attr={op.handler_attr!r} is not a method on the connector"
+        )
+        assert op.safety_level == "safe"
+        assert op.requires_approval is False
+        assert "read-only" in op.tags
+        # Every grouped op has a curated when_to_use (registration asserts this).
+        assert op.group_key is not None and op.group_key in WHEN_TO_USE_BY_GROUP

--- a/backend/tests/test_connectors_keycloak_e2e.py
+++ b/backend/tests/test_connectors_keycloak_e2e.py
@@ -1,0 +1,467 @@
+# SPDX-License-Identifier: Apache-2.0
+# Copyright (c) 2026 evoila Group
+
+"""G3.13-T2 Keycloak recorded-fixture E2E test (#1394).
+
+Drives every curated keycloak read op through the full ``call_operation``
+dispatch stack against a respx-mocked Keycloak Admin REST API — no running
+Keycloak, no live Vault. The admin-credential loader is injected (stub),
+``respx`` replays pre-recorded Admin REST fixtures, and the connector
+instance is preseeded into the dispatcher's instance cache so dispatch
+uses the stub-loaded connector rather than a plain one that would try a
+live Vault read.
+
+Acceptance criteria verified (Issue #1394)
+==========================================
+
+(a) All 6 read ops dispatch through ``call_operation`` via the admin-auth
+    path and return ``status="ok"``; all 6 are visible to
+    ``search_operations``.
+(b) ``keycloak.client.get`` returns the client's flows
+    (``authenticationFlowBindingOverrides``), redirect URIs
+    (``redirectUris``), and protocol mappers (``protocolMappers``); the
+    confidential-client ``secret`` is redacted.
+(c) ``keycloak.user.list`` never surfaces credential material
+    (``credentials`` redacted).
+(d) Every op carries ``safety_level="safe"`` + ``requires_approval=False``
+    and a ``read-only`` tag (asserted on the ``READ_OPS`` table).
+
+Fixtures reproduce realistic-but-minimal Keycloak 26.x Admin REST output,
+including the secret material the redaction contract must scrub.
+"""
+
+from __future__ import annotations
+
+import uuid
+from collections.abc import AsyncIterator, Iterator
+from typing import Any
+
+import pytest
+import respx
+
+import meho_backplane.connectors.keycloak  # noqa: F401 -- import for registry side-effects
+from meho_backplane.auth.operator import Operator, TenantRole
+from meho_backplane.connectors.keycloak import KeycloakConnector
+from meho_backplane.connectors.keycloak.ops_read import READ_OPS
+from meho_backplane.connectors.keycloak.redaction import REDACTED
+from meho_backplane.connectors.keycloak.session import (
+    KeycloakAdminCredentials,
+    KeycloakClientCredentials,
+    KeycloakTargetLike,
+)
+from meho_backplane.db.engine import get_sessionmaker
+from meho_backplane.db.models import Target as TargetORM
+from meho_backplane.operations import reset_dispatcher_caches
+from meho_backplane.operations.dispatcher import set_default_reducer
+from meho_backplane.operations.meta_tools import call_operation, search_operations
+from meho_backplane.operations.reducer import PassThroughReducer
+
+_CONNECTOR_ID = "keycloak-admin-26.x"
+_TARGET_NAME = "rdc-keycloak-e2e"
+_KC_HOST = "keycloak-e2e.test.invalid"
+_KC_BASE_URL = f"https://{_KC_HOST}"
+_ADMIN_TOKEN = "kc-admin-token-e2e"
+_CLIENT_UUID = "11111111-1111-1111-1111-111111111111"
+_USER_UUID = "22222222-2222-2222-2222-222222222222"
+_CLIENT_SECRET_SENTINEL = "super-secret-client-secret-DO-NOT-LEAK"
+_USER_CRED_SENTINEL = "hashed-password-DO-NOT-LEAK"
+
+_OPERATOR_TENANT_ID = uuid.UUID("00000000-0000-0000-0000-0000000000ad")
+_OPERATOR = Operator(
+    sub="keycloak-e2e-test",
+    name="Keycloak E2E Test Operator",
+    email=None,
+    raw_jwt="<keycloak-e2e-raw-jwt>",
+    tenant_id=_OPERATOR_TENANT_ID,
+    tenant_role=TenantRole.TENANT_ADMIN,
+)
+
+EXPECTED_OP_IDS: tuple[str, ...] = (
+    "keycloak.realm.get",
+    "keycloak.client.list",
+    "keycloak.client.get",
+    "keycloak.client_scope.list",
+    "keycloak.user.list",
+    "keycloak.role_mapping.get",
+)
+
+
+# ---------------------------------------------------------------------------
+# Recorded Admin REST fixtures (minimal Keycloak 26.x shapes, with secrets)
+# ---------------------------------------------------------------------------
+
+_FIXTURE_REALM: dict[str, Any] = {
+    "realm": "evba",
+    "enabled": True,
+    "sslRequired": "external",
+    "loginTheme": "meho",
+    "accessTokenLifespan": 300,
+}
+
+_FIXTURE_CLIENT: dict[str, Any] = {
+    "id": _CLIENT_UUID,
+    "clientId": "meho-backplane",
+    "enabled": True,
+    "publicClient": False,
+    "secret": _CLIENT_SECRET_SENTINEL,
+    "redirectUris": ["https://meho.evba.lab/callback"],
+    "webOrigins": ["https://meho.evba.lab"],
+    "protocolMappers": [
+        {"name": "tenant_id", "protocol": "openid-connect", "config": {"claim.name": "tenant_id"}}
+    ],
+    "authenticationFlowBindingOverrides": {"browser": "flow-uuid-abc"},
+}
+
+_FIXTURE_CLIENTS: list[dict[str, Any]] = [_FIXTURE_CLIENT]
+
+_FIXTURE_CLIENT_SCOPES: list[dict[str, Any]] = [
+    {
+        "id": "scope-uuid-1",
+        "name": "roles",
+        "protocol": "openid-connect",
+        "protocolMappers": [{"name": "realm roles", "protocol": "openid-connect"}],
+    }
+]
+
+_FIXTURE_USERS: list[dict[str, Any]] = [
+    {
+        "id": _USER_UUID,
+        "username": "operator-a",
+        "enabled": True,
+        "emailVerified": True,
+        # The Admin API can surface credential records on some reads; the
+        # op must scrub them regardless of Keycloak's default projection.
+        "credentials": [{"type": "password", "secretData": _USER_CRED_SENTINEL}],
+    }
+]
+
+_FIXTURE_ROLE_MAPPINGS: dict[str, Any] = {
+    "realmMappings": [{"id": "role-uuid-1", "name": "tenant_admin"}],
+    "clientMappings": {
+        "meho-backplane": {
+            "id": _CLIENT_UUID,
+            "client": "meho-backplane",
+            "mappings": [{"id": "role-uuid-2", "name": "view-realm"}],
+        }
+    },
+}
+
+
+def _mount_admin_routes(mock: respx.MockRouter) -> None:
+    """Register the token endpoint + 6 admin REST fixture routes on *mock*."""
+    mock.post("/realms/master/protocol/openid-connect/token").respond(
+        200, json={"access_token": _ADMIN_TOKEN, "expires_in": 300}
+    )
+    mock.get("/admin/realms/evba").respond(200, json=_FIXTURE_REALM)
+    mock.get("/admin/realms/evba/clients").respond(200, json=_FIXTURE_CLIENTS)
+    mock.get(f"/admin/realms/evba/clients/{_CLIENT_UUID}").respond(200, json=_FIXTURE_CLIENT)
+    mock.get("/admin/realms/evba/client-scopes").respond(200, json=_FIXTURE_CLIENT_SCOPES)
+    mock.get("/admin/realms/evba/users").respond(200, json=_FIXTURE_USERS)
+    mock.get(f"/admin/realms/evba/users/{_USER_UUID}/role-mappings").respond(
+        200, json=_FIXTURE_ROLE_MAPPINGS
+    )
+
+
+# ---------------------------------------------------------------------------
+# Stub credential loader + seeded connector instance
+# ---------------------------------------------------------------------------
+
+
+def _stub_loader(
+    _target: KeycloakTargetLike, _operator: Operator
+) -> Any:  # pragma: no cover - trivial
+    """Return a fixed client-credentials admin credential (no live Vault)."""
+
+    async def _load() -> KeycloakAdminCredentials:
+        return KeycloakClientCredentials(client_id="meho-admin", client_secret="stub-secret")
+
+    return _load()
+
+
+async def _seed_keycloak_target() -> TargetORM:
+    """Insert the E2E target row (product=keycloak, version=26.x) and return it."""
+    sessionmaker = get_sessionmaker()
+    async with sessionmaker() as session:
+        target = TargetORM(
+            tenant_id=_OPERATOR_TENANT_ID,
+            name=_TARGET_NAME,
+            aliases=[],
+            product="keycloak",
+            host=_KC_HOST,
+            port=443,
+            fqdn=None,
+            secret_ref="rdc-hetzner-dc/keycloak/admin",
+            auth_model="shared_service_account",
+            vpn_required=False,
+            extras={},
+            fingerprint={"version": "26.0.5"},
+            notes="seeded by test_connectors_keycloak_e2e",
+        )
+        session.add(target)
+        await session.commit()
+        await session.refresh(target)
+        session.expunge(target)
+        return target
+
+
+def _wire_seeded_connector() -> KeycloakConnector:
+    """Preseed a stub-loader connector into the dispatcher's instance cache."""
+    instance = KeycloakConnector(credentials_loader=_stub_loader)
+    from meho_backplane.operations._handler_resolve import _CONNECTOR_INSTANCE_CACHE
+
+    _CONNECTOR_INSTANCE_CACHE[KeycloakConnector] = instance  # type: ignore[assignment]
+    return instance
+
+
+@pytest.fixture(autouse=True)
+def _required_settings_env(monkeypatch: pytest.MonkeyPatch) -> Iterator[None]:
+    """Pin env vars that :class:`Settings` requires for this module."""
+    from meho_backplane.settings import get_settings
+
+    monkeypatch.setenv("KEYCLOAK_ISSUER_URL", "https://keycloak.test/realms/meho")
+    monkeypatch.setenv("KEYCLOAK_AUDIENCE", "meho-backplane")
+    monkeypatch.setenv("VAULT_ADDR", "https://vault.test")
+    get_settings.cache_clear()
+    yield
+    get_settings.cache_clear()
+
+
+@pytest.fixture(autouse=True)
+def _reset_module_state() -> Iterator[None]:
+    """Reset dispatcher caches around every test."""
+    reset_dispatcher_caches()
+    yield
+    reset_dispatcher_caches()
+
+
+@pytest.fixture
+async def keycloak_e2e() -> AsyncIterator[KeycloakConnector]:
+    """Register the read ops, seed the target, and preseed the connector."""
+    set_default_reducer(PassThroughReducer())
+    await KeycloakConnector.register_operations()
+    await _seed_keycloak_target()
+    connector = _wire_seeded_connector()
+    yield connector
+    await connector.aclose()
+
+
+# ---------------------------------------------------------------------------
+# Op-table assertions (acceptance criterion d)
+# ---------------------------------------------------------------------------
+
+
+def test_keycloak_read_ops_registration_set() -> None:
+    """READ_OPS carries exactly the 6 curated read ops and no write op."""
+    op_ids = {op.op_id for op in READ_OPS}
+    assert op_ids == set(EXPECTED_OP_IDS)
+    assert len(READ_OPS) == 6
+
+
+def test_keycloak_read_ops_all_safe_no_approval_read_only_tag() -> None:
+    """Every op is safe, needs no approval, and carries the read-only tag."""
+    for op in READ_OPS:
+        assert op.safety_level == "safe", f"{op.op_id} should be safe"
+        assert op.requires_approval is False, f"{op.op_id} should not require approval"
+        assert "read-only" in op.tags, f"{op.op_id} should carry the read-only tag"
+
+
+def test_keycloak_no_write_op_registered() -> None:
+    """No op_id implies a mutating verb (create/update/delete/add/remove/set)."""
+    write_verbs = ("create", "update", "delete", "add", "remove", "set", "apply", "reset")
+    for op in READ_OPS:
+        suffix = op.op_id.rsplit(".", 1)[-1]
+        assert not any(suffix.startswith(v) for v in write_verbs), (
+            f"{op.op_id} looks like a write op — T2 ships read-only"
+        )
+
+
+# ---------------------------------------------------------------------------
+# Full dispatch path (acceptance criteria a, b, c)
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.asyncio
+async def test_keycloak_e2e_realm_get(keycloak_e2e: KeycloakConnector) -> None:
+    """keycloak.realm.get returns the realm config via the admin-auth path."""
+    with respx.mock(base_url=_KC_BASE_URL, assert_all_called=False) as mock:
+        _mount_admin_routes(mock)
+        result = await call_operation(
+            _OPERATOR,
+            {
+                "connector_id": _CONNECTOR_ID,
+                "op_id": "keycloak.realm.get",
+                "target": {"name": _TARGET_NAME},
+                "params": {},
+            },
+        )
+    assert result["status"] == "ok", f"realm.get failed: {result.get('error')}"
+    realm = result["result"]["realm"]
+    assert realm["realm"] == "evba"
+    assert realm["sslRequired"] == "external"
+
+
+@pytest.mark.asyncio
+async def test_keycloak_e2e_client_list_redacts_secret(keycloak_e2e: KeycloakConnector) -> None:
+    """keycloak.client.list returns rows with the client secret redacted."""
+    with respx.mock(base_url=_KC_BASE_URL, assert_all_called=False) as mock:
+        _mount_admin_routes(mock)
+        result = await call_operation(
+            _OPERATOR,
+            {
+                "connector_id": _CONNECTOR_ID,
+                "op_id": "keycloak.client.list",
+                "target": {"name": _TARGET_NAME},
+                "params": {},
+            },
+        )
+    assert result["status"] == "ok", f"client.list failed: {result.get('error')}"
+    rows = result["result"]["rows"]
+    assert result["result"]["total"] == 1
+    assert rows[0]["clientId"] == "meho-backplane"
+    assert rows[0]["secret"] == REDACTED
+    assert _CLIENT_SECRET_SENTINEL not in str(result)
+
+
+@pytest.mark.asyncio
+async def test_keycloak_e2e_client_get_returns_flows_uris_mappers(
+    keycloak_e2e: KeycloakConnector,
+) -> None:
+    """keycloak.client.get surfaces flows/redirect-URIs/mappers; secret redacted."""
+    with respx.mock(base_url=_KC_BASE_URL, assert_all_called=False) as mock:
+        _mount_admin_routes(mock)
+        result = await call_operation(
+            _OPERATOR,
+            {
+                "connector_id": _CONNECTOR_ID,
+                "op_id": "keycloak.client.get",
+                "target": {"name": _TARGET_NAME},
+                "params": {"id": _CLIENT_UUID},
+            },
+        )
+    assert result["status"] == "ok", f"client.get failed: {result.get('error')}"
+    client = result["result"]["client"]
+    # Acceptance: flows + redirect URIs + protocol mappers an operator reads.
+    assert client["redirectUris"] == ["https://meho.evba.lab/callback"]
+    assert client["protocolMappers"][0]["name"] == "tenant_id"
+    assert client["authenticationFlowBindingOverrides"]["browser"] == "flow-uuid-abc"
+    # Acceptance: secret redacted.
+    assert client["secret"] == REDACTED
+    assert _CLIENT_SECRET_SENTINEL not in str(result)
+
+
+@pytest.mark.asyncio
+async def test_keycloak_e2e_client_scope_list(keycloak_e2e: KeycloakConnector) -> None:
+    """keycloak.client_scope.list returns scopes with their protocol mappers."""
+    with respx.mock(base_url=_KC_BASE_URL, assert_all_called=False) as mock:
+        _mount_admin_routes(mock)
+        result = await call_operation(
+            _OPERATOR,
+            {
+                "connector_id": _CONNECTOR_ID,
+                "op_id": "keycloak.client_scope.list",
+                "target": {"name": _TARGET_NAME},
+                "params": {},
+            },
+        )
+    assert result["status"] == "ok", f"client_scope.list failed: {result.get('error')}"
+    rows = result["result"]["rows"]
+    assert rows[0]["name"] == "roles"
+    assert rows[0]["protocolMappers"][0]["name"] == "realm roles"
+
+
+@pytest.mark.asyncio
+async def test_keycloak_e2e_user_list_never_surfaces_credentials(
+    keycloak_e2e: KeycloakConnector,
+) -> None:
+    """keycloak.user.list returns users with credential material redacted."""
+    with respx.mock(base_url=_KC_BASE_URL, assert_all_called=False) as mock:
+        _mount_admin_routes(mock)
+        result = await call_operation(
+            _OPERATOR,
+            {
+                "connector_id": _CONNECTOR_ID,
+                "op_id": "keycloak.user.list",
+                "target": {"name": _TARGET_NAME},
+                "params": {},
+            },
+        )
+    assert result["status"] == "ok", f"user.list failed: {result.get('error')}"
+    rows = result["result"]["rows"]
+    assert rows[0]["username"] == "operator-a"
+    # Acceptance: credentials never surface.
+    assert rows[0]["credentials"] == REDACTED
+    assert _USER_CRED_SENTINEL not in str(result)
+
+
+@pytest.mark.asyncio
+async def test_keycloak_e2e_role_mapping_get(keycloak_e2e: KeycloakConnector) -> None:
+    """keycloak.role_mapping.get returns realm + client role mappings."""
+    with respx.mock(base_url=_KC_BASE_URL, assert_all_called=False) as mock:
+        _mount_admin_routes(mock)
+        result = await call_operation(
+            _OPERATOR,
+            {
+                "connector_id": _CONNECTOR_ID,
+                "op_id": "keycloak.role_mapping.get",
+                "target": {"name": _TARGET_NAME},
+                "params": {"id": _USER_UUID},
+            },
+        )
+    assert result["status"] == "ok", f"role_mapping.get failed: {result.get('error')}"
+    mappings = result["result"]["role_mappings"]
+    assert mappings["realmMappings"][0]["name"] == "tenant_admin"
+    assert "meho-backplane" in mappings["clientMappings"]
+
+
+@pytest.mark.asyncio
+async def test_keycloak_e2e_all_ops_use_admin_token_never_operator_jwt(
+    keycloak_e2e: KeycloakConnector,
+) -> None:
+    """Every dispatched op carries the admin Bearer, never the operator JWT."""
+    with respx.mock(base_url=_KC_BASE_URL, assert_all_called=False) as mock:
+        _mount_admin_routes(mock)
+        for op_id, params in (
+            ("keycloak.realm.get", {}),
+            ("keycloak.client.list", {}),
+            ("keycloak.client.get", {"id": _CLIENT_UUID}),
+            ("keycloak.client_scope.list", {}),
+            ("keycloak.user.list", {}),
+            ("keycloak.role_mapping.get", {"id": _USER_UUID}),
+        ):
+            result = await call_operation(
+                _OPERATOR,
+                {
+                    "connector_id": _CONNECTOR_ID,
+                    "op_id": op_id,
+                    "target": {"name": _TARGET_NAME},
+                    "params": params,
+                },
+            )
+            assert result["status"] == "ok", f"{op_id} failed: {result.get('error')}"
+
+        # No admin REST call carried the operator JWT; the GETs carried the
+        # admin Bearer minted via the admin-credential path.
+        for call in mock.calls:
+            req = call.request
+            if req.url.path.startswith("/admin/"):
+                assert req.headers.get("authorization") == f"Bearer {_ADMIN_TOKEN}"
+            assert _OPERATOR.raw_jwt not in (req.headers.get("authorization") or "")
+
+
+# ---------------------------------------------------------------------------
+# search_operations visibility (acceptance criterion a)
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.asyncio
+async def test_keycloak_e2e_ops_visible_to_search_operations(
+    keycloak_e2e: KeycloakConnector,
+) -> None:
+    """All 6 read ops are discoverable via search_operations on the connector."""
+    result = await search_operations(
+        _OPERATOR,
+        {"connector_id": _CONNECTOR_ID, "query": "keycloak realm client user role", "limit": 50},
+    )
+    surfaced = {hit["op_id"] for hit in result["hits"]}
+    missing = set(EXPECTED_OP_IDS) - surfaced
+    assert not missing, f"search_operations did not surface: {missing} (got {surfaced})"

--- a/backend/tests/test_connectors_keycloak_redaction.py
+++ b/backend/tests/test_connectors_keycloak_redaction.py
@@ -1,0 +1,69 @@
+# SPDX-License-Identifier: Apache-2.0
+# Copyright (c) 2026 evoila Group
+
+"""Unit tests for the keycloak read-op secret scrubber (G3.13-T2 #1394).
+
+Pins the recursive redaction contract directly — no event loop, no HTTP —
+so a regression in the scrubber surfaces as a fast, isolated failure
+rather than an E2E surprise.
+"""
+
+from __future__ import annotations
+
+from meho_backplane.connectors.keycloak.redaction import REDACTED, redact_secret_fields
+
+
+def test_scrubs_top_level_client_secret() -> None:
+    """A ClientRepresentation's ``secret`` is replaced, other fields kept."""
+    client = {"clientId": "meho-backplane", "secret": "s3cr3t", "redirectUris": ["/cb"]}
+    out = redact_secret_fields(client)
+    assert out["secret"] == REDACTED
+    assert out["clientId"] == "meho-backplane"
+    assert out["redirectUris"] == ["/cb"]
+
+
+def test_scrubs_user_credentials_subtree() -> None:
+    """A UserRepresentation's ``credentials`` list is replaced wholesale."""
+    user = {"username": "op", "credentials": [{"type": "password", "value": "hash"}]}
+    out = redact_secret_fields(user)
+    assert out["credentials"] == REDACTED
+    assert out["username"] == "op"
+
+
+def test_scrubs_nested_secret_in_protocol_mapper() -> None:
+    """A secret nested inside a list-of-dicts is caught by the recursive walk."""
+    client = {
+        "clientId": "c",
+        "protocolMappers": [
+            {"name": "m", "config": {"secret": "nested-secret", "claim.name": "x"}}
+        ],
+    }
+    out = redact_secret_fields(client)
+    mapper_config = out["protocolMappers"][0]["config"]
+    assert mapper_config["secret"] == REDACTED
+    assert mapper_config["claim.name"] == "x"
+
+
+def test_scrubs_credential_value_and_data_fields() -> None:
+    """``value`` / ``secretData`` / ``credentialData`` are all scrubbed."""
+    cred = {"type": "password", "value": "v", "secretData": "s", "credentialData": "d"}
+    out = redact_secret_fields(cred)
+    assert out["value"] == REDACTED
+    assert out["secretData"] == REDACTED
+    assert out["credentialData"] == REDACTED
+    assert out["type"] == "password"
+
+
+def test_input_not_mutated() -> None:
+    """The scrub returns a new structure; the input is left untouched."""
+    client = {"secret": "keep-me-original"}
+    out = redact_secret_fields(client)
+    assert client["secret"] == "keep-me-original"
+    assert out["secret"] == REDACTED
+
+
+def test_scalars_and_lists_pass_through() -> None:
+    """Non-secret scalars and plain lists are unchanged."""
+    assert redact_secret_fields("plain") == "plain"
+    assert redact_secret_fields(42) == 42
+    assert redact_secret_fields([1, {"a": 2}]) == [1, {"a": 2}]

--- a/docs/codebase/connectors-keycloak.md
+++ b/docs/codebase/connectors-keycloak.md
@@ -6,11 +6,11 @@
 API. MEHO runs Keycloak as its own identity provider on the RDC fleet;
 this connector manages that Keycloak through its Admin REST surface.
 
-G3.13-T1 (#1393) ships the **substrate**: the connector class, the admin
-credential loader, `fingerprint()`, and dual registry registration. Read
-operations land in T2 and onboarding docs in T3. The module ships **zero**
-typed operations — the typed-op registrar seam is wired (so the lifespan
-already drives Keycloak) but the op walk is empty until T2.
+G3.13-T1 (#1393) shipped the **substrate**: the connector class, the
+admin credential loader, `fingerprint()`, and dual registry registration.
+G3.13-T2 (#1394) layers the **six curated read ops** onto that surface
+(realm/client/client-scope/user/role-mapping). Onboarding docs land in T3
+and the approval-gated write surface in T4.
 
 Registry v2 triple: `(product="keycloak", version="26.x",
 impl_id="keycloak-admin")`, plus the `(keycloak, "", "")` wildcard so a
@@ -20,7 +20,17 @@ fresh target with no asserted version still resolves.
 
 - `KeycloakConnector` (`connectors/keycloak/connector.py`) — the
   `HttpConnector` subclass. Holds a per-target admin-token cache with
-  TTL-driven refresh and an injectable admin-credential loader.
+  TTL-driven refresh and an injectable admin-credential loader. Exposes a
+  thin bound-method shim per read op (`realm_get`, `client_list`,
+  `client_get`, `client_scope_list`, `user_list`, `role_mapping_get`) and
+  the `_get_admin_json` / `_get_admin_list` GET helpers (object vs array
+  responses).
+- `KeycloakOp` + `READ_OPS` (`connectors/keycloak/ops_read.py`) — the
+  op-metadata dataclass and the six-op registration table (the bind9 /
+  pfSense `ops`-table precedent). `WHEN_TO_USE_BY_GROUP` maps each op
+  group to its curated selection blurb.
+- `redact_secret_fields` (`connectors/keycloak/redaction.py`) — the
+  recursive scrubber every read handler runs its response through.
 - `KeycloakClientCredentials` / `KeycloakPasswordCredentials`
   (`connectors/keycloak/session.py`) — the two admin-credential shapes
   (tagged union `KeycloakAdminCredentials`).
@@ -95,6 +105,42 @@ The password shape accepts an optional `client_id` field (default
   `reachable=False`).
 - `probe(target)` — delegates to `fingerprint`; one admin round-trip
   covers reachability + admin-auth validity.
+- `register_operations()` — walks `READ_OPS`, resolves each
+  `handler_attr` to a bound method, looks the group's `when_to_use` up in
+  `WHEN_TO_USE_BY_GROUP` (a missing entry is a hard error), and upserts
+  via `register_typed_operation`. Idempotent across restarts.
+
+## Read ops (G3.13-T2)
+
+Six `safety_level="safe"` / `requires_approval=False` read ops, all
+tagged `read-only`, all dispatching via the admin-auth path. The realm is
+the target's `managed_realm` (no per-op realm param):
+
+| op_id | Admin REST API | returns |
+|---|---|---|
+| `keycloak.realm.get` | `GET /admin/realms/{realm}` | realm config |
+| `keycloak.client.list` | `GET .../clients` (`?clientId=`/`?max=`) | `{rows, total}` |
+| `keycloak.client.get` | `GET .../clients/{id}` | one client (flows, redirect URIs, mappers) |
+| `keycloak.client_scope.list` | `GET .../client-scopes` | `{rows, total}` |
+| `keycloak.user.list` | `GET .../users` (`?username=`/`?max=`) | `{rows, total}`, no credentials |
+| `keycloak.role_mapping.get` | `GET .../users/{id}/role-mappings` | realm + client role mappings |
+
+`client.get` / `role_mapping.get` take the **internal UUID** (`id`), not
+the human `clientId` / `username` — discover it via the matching `.list`
+op first.
+
+### Secret redaction
+
+Every handler runs its response through `redact_secret_fields` before
+returning, so the value of `secret` (confidential-client secret),
+`credentials` / `value` / `secretData` / `credentialData` (user
+credential material) is replaced with `***REDACTED***` — recursively,
+including secrets nested inside protocol mappers or identity-provider
+configs. The scrub happens at the connector boundary (not the broadcast
+layer) because these are config reads where the secret is incidental: it
+must never enter the synchronous `OperationResult` the caller receives.
+The write surface (T4) will continue to redact secret *inputs* at the
+classification layer per the general posture.
 
 ## Target configuration
 
@@ -125,8 +171,9 @@ Resolved through `resolve_realm_config`, which tolerates a missing
 
 ## Known issues / future work
 
-- T2 (#1394 et al.) fills the read-op walk in
-  `KeycloakConnector.register_operations`.
+- The write surface (client/user/scope/role-mapping CRUD,
+  `requires_approval=True`) is the deferred T4 follow-up; T2 ships
+  read-only.
 - No logout-revoke on `aclose` — admin access tokens are short-lived;
   revoke-on-close is deferred (same posture as NSX / vRLI).
 - `/admin/serverinfo` is undocumented (though stable across 26.x); the


### PR DESCRIPTION
## Summary
- Fill the `KeycloakConnector` typed-op registrar seam T1 (#1393) left empty with the **six curated read ops** (`keycloak.realm.get`, `keycloak.client.list`/`.get`, `keycloak.client_scope.list`, `keycloak.user.list`, `keycloak.role_mapping.get`) — all `safety_level="safe"`, `requires_approval=False`, tagged `read-only`, dispatching via the **admin-auth** path (admin-token Bearer), never operator-OIDC.
- Ops + metadata live in a new `ops_read` module (the bind9 / pfSense `ops`-table precedent); the connector exposes a thin bound-method shim per op and walks `READ_OPS` in `register_operations`. A new `_get_admin_list` helper handles the Admin REST list endpoints that return JSON **arrays** (clients / client-scopes / users), which the inherited dict-typed `_get_json` could not.
- **Secret redaction (load-bearing):** every handler runs its response through a recursive scrubber (new `redaction` module) that replaces confidential-client secrets (`ClientRepresentation.secret`) and user credential material (`credentials` + nested `value`/`secretData`/`credentialData`) with `***REDACTED***` before the result leaves the connector. `keycloak.user.list` never surfaces credentials. The scrub is at the connector boundary (not the broadcast layer) because these are config reads where the secret is incidental — it must never enter the synchronous `OperationResult`.
- No write/mutating op registered (deferred to T4).

## Test plan
- [x] `ruff check` / `ruff format --check` — clean (keycloak package + new/edited tests)
- [x] `mypy src/meho_backplane/connectors/keycloak/` — clean (5 files)
- [x] `pytest tests/test_connectors_keycloak_e2e.py tests/test_connectors_keycloak_redaction.py tests/test_connectors_keycloak_auth.py` — 32 passed
- [x] **AC: all 6 ops dispatch via admin-auth + visible to `search_operations`** — recorded-fixture E2E (`respx`-mocked Admin REST, injected credential loader, no live Vault) drives every op through `call_operation` (`status=ok`); `test_keycloak_e2e_ops_visible_to_search_operations` asserts all 6 surface; `test_..._all_ops_use_admin_token_never_operator_jwt` asserts the admin Bearer on every `/admin/` call and the operator JWT on none.
- [x] **AC: `client.get` returns flows/redirect-URIs/mappers; secret redacted** — `test_keycloak_e2e_client_get_returns_flows_uris_mappers` asserts `redirectUris` / `protocolMappers` / `authenticationFlowBindingOverrides` present and `secret == REDACTED`.
- [x] **AC: each op safe + no approval; recorded-fixture E2E for each** — asserted on the `READ_OPS` table and exercised per-op in the E2E suite.
- [x] **AC: no write op registered** — `test_keycloak_no_write_op_registered`.
- [x] `pytest tests/test_connectors_registry_v2.py` — 30 passed (no registry-coverage regression)
- [x] `code-quality.py --diff` — 0 blockers (4 pre-existing/precedent-shaped warnings)
- [x] `cd cli && make snapshot-openapi` — **no diff** (typed ops are runtime descriptor rows, not OpenAPI routes; the generated Go-client surface is unchanged, so no `make generate` regen needed)
- [x] `docs/codebase/connectors-keycloak.md` updated (read ops + redaction sections)

## Out of scope
- Write surface (client/user/scope/role-mapping CRUD, `requires_approval=True`) — deferred T4 follow-up.
- CLI verbs + MCP review + onboarding runbook — T3 (#... per initiative #1388).

<!-- auto-implement-issue: fresh, iteration 1 -->

Closes #1394
