### PR TITLE
feat(connectors): G3.12-T2 ArgoCD curated read core via register_typed_operation

### DIFF
--- a/backend/src/meho_backplane/connectors/argocd/__init__.py
+++ b/backend/src/meho_backplane/connectors/argocd/__init__.py
@@ -20,14 +20,15 @@ is needed elsewhere.
 
 The asynchronous (lifespan startup) typed-op registrar — queued via
 :func:`~meho_backplane.operations.typed_register.register_typed_op_registrar`
-the way Harbor (#621) and bind9 (#367) do — is deliberately **not** queued
-here. G3.12-T1 ships the substrate (connector class + bearer-token
-credential loader + fingerprint + dual registration) with zero operations;
-the curated read core (``argocd.app.list`` / ``argocd.app.get`` /
+the way Harbor (#621) and bind9 (#367) do — lands in this module as of
+G3.12-T2 (#1391). :func:`register_argocd_typed_operations` delegates to
+:meth:`ArgoCdConnector.register_operations`, which walks
+:data:`~meho_backplane.connectors.argocd.ops.ARGOCD_OPS` and upserts the six
+curated read-core descriptors (``argocd.app.list`` / ``argocd.app.get`` /
 ``argocd.app.diff`` / ``argocd.app.resource_tree`` /
-``argocd.appproject.list`` / ``argocd.repo.list``) and its registrar arrive
-in G3.12-T2. Queuing an empty registrar now would add a no-op startup hook
-with nothing to upsert.
+``argocd.appproject.list`` / ``argocd.repo.list``) — all ``safety_level="safe"``,
+``requires_approval=False``, read-only. The write ops (``app.sync`` /
+``rollback`` / ``set``) remain a deferred, approval-gated follow-up.
 
 The v1 :func:`~meho_backplane.connectors.registry.register_connector` entry
 point is intentionally **not** called: ArgoCD has no v1 chassis history,
@@ -37,6 +38,11 @@ class — the same decision Harbor, bind9, NSX, and SDDC Manager made.
 """
 
 from meho_backplane.connectors.argocd.connector import ArgoCdConnector
+from meho_backplane.connectors.argocd.ops import (
+    ARGOCD_OPS,
+    ARGOCD_WHEN_TO_USE_BY_GROUP,
+    ArgoCdOp,
+)
 from meho_backplane.connectors.argocd.session import (
     ARGOCD_TOKEN_FIELD,
     ArgoCdCredentialsLoader,
@@ -44,6 +50,36 @@ from meho_backplane.connectors.argocd.session import (
     load_credentials_from_vault,
 )
 from meho_backplane.connectors.registry import register_connector_v2
+from meho_backplane.operations.typed_register import register_typed_op_registrar
+from meho_backplane.retrieval.embedding import EmbeddingService
+
+
+async def register_argocd_typed_operations(
+    *,
+    embedding_service: EmbeddingService | None = None,
+) -> None:
+    """Module-level registrar wrapper for ``ArgoCdConnector.register_operations``.
+
+    The canonical typed-op registration pattern (G0.6-T-Refactor-Vault #390)
+    is a module-level ``async def register_xxx_typed_operations`` queued onto
+    :func:`~meho_backplane.operations.typed_register.run_typed_op_registrars`
+    via :func:`register_typed_op_registrar`. argocd implements the underlying
+    op walk as a classmethod on :class:`ArgoCdConnector` (so the test suite
+    can exercise it without lifespan plumbing); this wrapper is the seam that
+    lets the standard registrar mechanism drive it.
+
+    The ``embedding_service`` keyword-only parameter mirrors the bind9 / K8s
+    sibling contract: :func:`run_typed_op_registrars` passes the process-wide
+    :class:`EmbeddingService` (or a chassis-test stub) to every registrar via
+    ``registrar(embedding_service=...)``, so each registrar **must** accept
+    the kwarg or the lifespan crashes with :class:`TypeError`. The wrapper
+    accepts-and-discards it because
+    :meth:`ArgoCdConnector.register_operations` resolves the embedding service
+    via ``register_typed_operation``'s process-wide singleton fallback.
+    """
+    del embedding_service  # see docstring -- kwarg accepted for runner-compatibility
+    await ArgoCdConnector.register_operations()
+
 
 # v2 entry -- the canonical resolver key. The versioned triple always wins
 # the resolver tie-break when both it and the wildcard are present.
@@ -65,10 +101,19 @@ register_connector_v2(
     cls=ArgoCdConnector,
 )
 
+# Queue the typed-op upsert onto the lifespan-driven registrar list. The
+# runner (``run_typed_op_registrars``) iterates after ``_eager_import_connectors``
+# so the descriptor rows land before the first dispatch.
+register_typed_op_registrar(register_argocd_typed_operations)
+
 __all__ = [
+    "ARGOCD_OPS",
     "ARGOCD_TOKEN_FIELD",
+    "ARGOCD_WHEN_TO_USE_BY_GROUP",
     "ArgoCdConnector",
     "ArgoCdCredentialsLoader",
+    "ArgoCdOp",
     "ArgoCdTargetLike",
     "load_credentials_from_vault",
+    "register_argocd_typed_operations",
 ]

--- a/backend/src/meho_backplane/connectors/argocd/connector.py
+++ b/backend/src/meho_backplane/connectors/argocd/connector.py
@@ -80,6 +80,7 @@ from __future__ import annotations
 import asyncio
 from datetime import UTC, datetime
 from typing import Any
+from urllib.parse import quote
 
 import httpx
 import structlog
@@ -387,6 +388,216 @@ class ArgoCdConnector(HttpConnector):
             op_id=op_id,
             target=target,
             params=params,
+        )
+
+    # ------------------------------------------------------------------
+    # Curated read ops (G3.12-T2 #1391)
+    #
+    # Each handler is a thin retried-GET against an argocd-server endpoint.
+    # The dispatcher binds these bound methods to the per-process connector
+    # instance at dispatch time and threads ``operator`` by parameter name
+    # (see :func:`~meho_backplane.operations._branches.dispatch_typed`); the
+    # ``operator`` is forwarded to :meth:`_get_json` so the credential loader
+    # reads the per-target bearer token under the operator's identity. All
+    # six are read-only — no write/mutating op ships in this Task.
+    # ------------------------------------------------------------------
+
+    async def app_list(
+        self,
+        operator: Operator,
+        target: ArgoCdTargetLike,
+        params: dict[str, Any],
+    ) -> dict[str, Any]:
+        """``argocd.app.list`` — ``GET /api/v1/applications``.
+
+        Optional ``projects`` (list of AppProject names) and ``selector``
+        (Kubernetes label selector) narrow the result. Returns ArgoCD's
+        ``ApplicationList`` (``{"items": [...], "metadata": {...}}``); each
+        item carries the app's sync + health status.
+        """
+        query: dict[str, Any] = {}
+        projects = params.get("projects")
+        if projects:
+            # ArgoCD's gRPC-gateway accepts the repeated ``projects`` query
+            # param as a list; httpx serialises a list value into repeated
+            # ``projects=a&projects=b`` pairs, which is exactly the wire shape.
+            query["projects"] = list(projects)
+        selector = params.get("selector")
+        if selector:
+            query["selector"] = selector
+        return await self._get_json(
+            target, "/api/v1/applications", operator=operator, params=query or None
+        )
+
+    async def app_get(
+        self,
+        operator: Operator,
+        target: ArgoCdTargetLike,
+        params: dict[str, Any],
+    ) -> dict[str, Any]:
+        """``argocd.app.get`` — ``GET /api/v1/applications/{name}``.
+
+        Returns the full ``Application`` object (spec + status). The
+        optional ``project`` query param scopes the lookup (ArgoCD returns
+        404 rather than the app if it is not in that project).
+        """
+        name = quote(str(params["name"]), safe="")
+        query: dict[str, Any] = {}
+        project = params.get("project")
+        if project:
+            query["project"] = project
+        return await self._get_json(
+            target, f"/api/v1/applications/{name}", operator=operator, params=query or None
+        )
+
+    async def app_diff(
+        self,
+        operator: Operator,
+        target: ArgoCdTargetLike,
+        params: dict[str, Any],
+    ) -> dict[str, Any]:
+        """``argocd.app.diff`` — ``GET /api/v1/applications/{name}/managed-resources``.
+
+        Returns the managed-resources delta — the same desired-vs-live drift
+        ``argocd app diff <app>`` renders. Each ``items`` entry carries
+        ``liveState`` / ``targetState`` (and the normalized / predicted pair
+        the controller compares) for one managed resource.
+        """
+        name = quote(str(params["name"]), safe="")
+        query: dict[str, Any] = {}
+        project = params.get("project")
+        if project:
+            query["project"] = project
+        return await self._get_json(
+            target,
+            f"/api/v1/applications/{name}/managed-resources",
+            operator=operator,
+            params=query or None,
+        )
+
+    async def app_resource_tree(
+        self,
+        operator: Operator,
+        target: ArgoCdTargetLike,
+        params: dict[str, Any],
+    ) -> dict[str, Any]:
+        """``argocd.app.resource_tree`` — ``GET /api/v1/applications/{name}/resource-tree``.
+
+        Returns the reconciled resource tree (``nodes`` / ``orphanedNodes`` /
+        ``hosts`` / ``shardsCount``); each node carries per-resource health
+        and sync status plus ``parentRefs`` linking it into the hierarchy.
+        """
+        name = quote(str(params["name"]), safe="")
+        query: dict[str, Any] = {}
+        project = params.get("project")
+        if project:
+            query["project"] = project
+        return await self._get_json(
+            target,
+            f"/api/v1/applications/{name}/resource-tree",
+            operator=operator,
+            params=query or None,
+        )
+
+    async def appproject_list(
+        self,
+        operator: Operator,
+        target: ArgoCdTargetLike,
+        params: dict[str, Any],
+    ) -> dict[str, Any]:
+        """``argocd.appproject.list`` — ``GET /api/v1/projects``.
+
+        Returns the ``AppProjectList`` (``{"items": [...], "metadata": {...}}``);
+        each item's ``spec`` carries the project allow-lists (``sourceRepos`` /
+        ``destinations`` / resource allow- and deny-lists).
+        """
+        del params  # schema declares the param object empty
+        return await self._get_json(target, "/api/v1/projects", operator=operator)
+
+    async def repo_list(
+        self,
+        operator: Operator,
+        target: ArgoCdTargetLike,
+        params: dict[str, Any],
+    ) -> dict[str, Any]:
+        """``argocd.repo.list`` — ``GET /api/v1/repositories``.
+
+        Returns the ``RepositoryList`` (``{"items": [...], "metadata": {...}}``);
+        each item carries the repo URL/type plus ``connectionState`` (whether
+        ArgoCD can currently reach and authenticate to the repo).
+        """
+        del params  # schema declares the param object empty
+        return await self._get_json(target, "/api/v1/repositories", operator=operator)
+
+    @classmethod
+    async def register_operations(cls) -> None:
+        """Upsert every op in :data:`ARGOCD_OPS` into ``endpoint_descriptor``.
+
+        Called from the application lifespan (via the registrar queued in
+        :mod:`meho_backplane.connectors.argocd.__init__`) after the registry
+        has eager-imported every connector module. Walks
+        :data:`~meho_backplane.connectors.argocd.ops.ARGOCD_OPS`, resolves
+        each op's ``handler_attr`` to the bound classmethod-visible handler,
+        looks the group's curated ``when_to_use`` blurb up in
+        :data:`~meho_backplane.connectors.argocd.ops.ARGOCD_WHEN_TO_USE_BY_GROUP`,
+        and routes each row through
+        :func:`~meho_backplane.operations.typed_register.register_typed_operation`.
+        Idempotent across pod restarts (the helper skips the embedding
+        recompute on unchanged summary / description / tags) — mirrors the
+        :meth:`Bind9Connector.register_operations` / Kubernetes shape.
+        """
+        # Lazy import: the operations package pulls in the embedding pipeline
+        # (ONNX runtime + model), which pure-fingerprint/probe unit tests
+        # should not pay. Lifespan callers have it warmed by the time this runs.
+        from meho_backplane.connectors.argocd.ops import (
+            ARGOCD_OPS,
+            ARGOCD_WHEN_TO_USE_BY_GROUP,
+        )
+        from meho_backplane.operations.typed_register import register_typed_operation
+
+        for op in ARGOCD_OPS:
+            handler = getattr(cls, op.handler_attr, None)
+            if handler is None:
+                raise AttributeError(
+                    f"ArgoCdConnector op {op.op_id!r} declares "
+                    f"handler_attr={op.handler_attr!r} but the class has no such attribute"
+                )
+            when_to_use: str | None
+            if op.group_key is None:
+                when_to_use = None
+            else:
+                when_to_use = ARGOCD_WHEN_TO_USE_BY_GROUP.get(op.group_key)
+                if when_to_use is None:
+                    raise ValueError(
+                        f"ArgoCdConnector op {op.op_id!r} declares "
+                        f"group_key={op.group_key!r} but no curated when_to_use "
+                        f"exists for that key. Add an entry to "
+                        f"ARGOCD_WHEN_TO_USE_BY_GROUP in "
+                        f"meho_backplane.connectors.argocd.ops."
+                    )
+            await register_typed_operation(
+                product=cls.product,
+                version=cls.version,
+                impl_id=cls.impl_id,
+                op_id=op.op_id,
+                handler=handler,
+                summary=op.summary,
+                description=op.description,
+                parameter_schema=op.parameter_schema,
+                response_schema=op.response_schema,
+                group_key=op.group_key,
+                when_to_use=when_to_use,
+                tags=list(op.tags),
+                safety_level=op.safety_level,
+                requires_approval=op.requires_approval,
+                llm_instructions=op.llm_instructions,
+            )
+        _log.info(
+            "argocd_operations_registered",
+            count=len(ARGOCD_OPS),
+            product=cls.product,
+            version=cls.version,
+            impl_id=cls.impl_id,
         )
 
     async def aclose(self) -> None:

--- a/backend/src/meho_backplane/connectors/argocd/ops.py
+++ b/backend/src/meho_backplane/connectors/argocd/ops.py
@@ -1,0 +1,510 @@
+# SPDX-License-Identifier: Apache-2.0
+# Copyright (c) 2026 evoila Group
+
+"""Curated read ops exposed by :class:`ArgoCdConnector` (G3.12-T2 #1391).
+
+G3.12-T1 (#1390) shipped the connector skeleton with zero operations. This
+module adds the **curated read core** — the bounded set of GitOps-visibility
+ops that let an RDC operator see what ArgoCD sees without reaching for the
+``argocd`` CLI or raw ``kubectl`` against the ``argocd`` namespace:
+
+* ``argocd.app.list`` -- ``GET /api/v1/applications`` (optional ``projects``
+  / ``selector`` filters); apps with sync/health status.
+* ``argocd.app.get`` -- ``GET /api/v1/applications/{name}``; one app's full
+  spec + status.
+* ``argocd.app.diff`` -- ``GET /api/v1/applications/{name}/managed-resources``;
+  the per-resource desired-vs-live drift an operator otherwise gets from
+  ``argocd app diff <app>`` (each item carries ``liveState`` / ``targetState``
+  / ``normalizedLiveState`` / ``predictedLiveState`` / ``diff``).
+* ``argocd.app.resource_tree`` -- ``GET /api/v1/applications/{name}/resource-tree``;
+  the reconciled resource tree with per-node sync/health.
+* ``argocd.appproject.list`` -- ``GET /api/v1/projects``; AppProjects + their
+  allow-lists.
+* ``argocd.repo.list`` -- ``GET /api/v1/repositories``; configured repos +
+  connection state.
+
+All six are ``safety_level="safe"`` + ``requires_approval=False`` and carry a
+``read-only`` tag — this Task registers no write/mutating op (``app.sync`` /
+``rollback`` / ``set`` are a deferred, approval-gated follow-up).
+
+The dataclass + tuple shape mirrors the bind9 (#367) and Kubernetes
+connectors so the registration walk in
+:func:`~meho_backplane.connectors.argocd.register_argocd_typed_operations`
+reads identically to those siblings. The handler methods live on
+:class:`~meho_backplane.connectors.argocd.connector.ArgoCdConnector` (each a
+thin ``_get_json`` call) so the descriptor's ``handler_ref`` round-trips
+through the dispatcher's
+:func:`~meho_backplane.operations._handler_resolve.import_handler` walk
+against a ``module.ClassName.method`` dotted path — the same shape Harbor's
+``robot_create`` / ``robot_delete`` handlers use.
+
+Endpoint + field facts are pinned to the ArgoCD ``argocd-server`` Swagger
+spec (``argoproj/argo-cd`` ``assets/swagger.json``): the application-collection
+endpoints wrap results under ``items``; ``managed-resources`` returns
+``{"items": [ResourceDiff, ...]}`` where each ``ResourceDiff`` carries the
+``liveState`` / ``targetState`` pair that drives the CLI diff. The
+``managed-resources`` and ``resource-tree`` paths use ``{applicationName}`` as
+their path placeholder; ``app.get`` uses ``{name}`` — both are populated from
+the handler's ``name`` param.
+"""
+
+from __future__ import annotations
+
+from dataclasses import dataclass
+from typing import Any, Literal
+
+__all__ = ["ARGOCD_OPS", "ARGOCD_WHEN_TO_USE_BY_GROUP", "ArgoCdOp"]
+
+
+@dataclass(frozen=True)
+class ArgoCdOp:
+    """Metadata for one argocd op the connector registers at startup.
+
+    Fields mirror the keyword arguments
+    :func:`~meho_backplane.operations.typed_register.register_typed_operation`
+    accepts so the registrar can splat the dataclass into the helper without
+    per-op boilerplate. ``handler_attr`` is the attribute name on
+    :class:`~meho_backplane.connectors.argocd.connector.ArgoCdConnector` that
+    exposes the async handler; the registrar resolves the bound method against
+    the class at registration time so the dispatcher's
+    :func:`~meho_backplane.operations._handler_resolve.import_handler` walk can
+    recover the callable from the persisted ``module.ClassName.method`` path.
+    """
+
+    op_id: str
+    handler_attr: str
+    summary: str
+    description: str
+    parameter_schema: dict[str, Any]
+    response_schema: dict[str, Any] | None
+    group_key: str | None
+    tags: tuple[str, ...]
+    safety_level: Literal["safe", "caution", "dangerous"]
+    requires_approval: bool
+    llm_instructions: dict[str, Any] | None
+
+
+#: Curated ``when_to_use`` blurbs per group. ``register_typed_operation``
+#: requires a non-empty string whenever ``group_key`` is set (G0.9-T4a #731);
+#: the registrar looks each op's ``group_key`` up here. Three groups: the
+#: application read surface, the project allow-list surface, and the
+#: repository inventory surface.
+ARGOCD_WHEN_TO_USE_BY_GROUP: dict[str, str] = {
+    "argocd-apps": (
+        "Use to inspect ArgoCD Applications and their GitOps reconciliation "
+        "state: list every app with its sync (Synced/OutOfSync) and health "
+        "(Healthy/Degraded/Progressing) status (argocd.app.list), read one "
+        "app's full spec + status (argocd.app.get), see the per-resource "
+        "desired-vs-live drift an operator gets from 'argocd app diff' "
+        "(argocd.app.diff), or walk the reconciled resource tree with "
+        "per-node health (argocd.app.resource_tree). The right group when the "
+        "question is 'is this app in sync?', 'what changed?', or 'which child "
+        "resources are unhealthy?'. Read-only — no sync/rollback here."
+    ),
+    "argocd-projects": (
+        "Use to list ArgoCD AppProjects and their allow-lists "
+        "(argocd.appproject.list): which source repos, destination "
+        "clusters/namespaces, and resource kinds each project permits. The "
+        "right group when confirming whether an Application's source or "
+        "destination is permitted by its project before (or while diagnosing) "
+        "a reconciliation, or when auditing multi-tenant guardrails."
+    ),
+    "argocd-repos": (
+        "Use to list the Git/Helm repositories configured in ArgoCD and their "
+        "connection state (argocd.repo.list): URL, type, and whether ArgoCD "
+        "can currently reach and authenticate to each. The right group when "
+        "diagnosing a 'ComparisonError'/'repository not accessible' app "
+        "condition or confirming a repo is registered before pointing an "
+        "Application at it."
+    ),
+}
+
+
+# ---------------------------------------------------------------------------
+# Shared parameter-schema fragments
+# ---------------------------------------------------------------------------
+
+#: The application-name path param shared by app.get / app.diff /
+#: app.resource_tree. Required, non-empty.
+_APP_NAME_PROPERTY: dict[str, Any] = {
+    "type": "string",
+    "minLength": 1,
+    "pattern": "\\S",
+    "description": "ArgoCD Application name (metadata.name), e.g. 'guestbook'.",
+}
+
+#: The optional ``project`` scoping query param ArgoCD accepts on the
+#: per-application endpoints. ArgoCD returns 404 (not 403) for an app the
+#: caller can't see when ``project`` is supplied, so it doubles as an
+#: authorization-scoping hint.
+_PROJECT_QUERY_PROPERTY: dict[str, Any] = {
+    "type": "string",
+    "minLength": 1,
+    "pattern": "\\S",
+    "description": (
+        "Optional AppProject name to scope the lookup to. When set, ArgoCD "
+        "returns 404 if the app is not in this project (an authorization "
+        "scoping hint)."
+    ),
+}
+
+
+# ---------------------------------------------------------------------------
+# argocd.app.list
+# ---------------------------------------------------------------------------
+
+_APP_LIST = ArgoCdOp(
+    op_id="argocd.app.list",
+    handler_attr="app_list",
+    summary="List ArgoCD Applications with their sync and health status.",
+    description=(
+        "Lists ArgoCD Applications via GET /api/v1/applications, optionally "
+        "filtered by one or more projects and/or a Kubernetes label selector. "
+        "Each item carries the app's spec (source repo/path/target revision, "
+        "destination cluster/namespace) plus its status — most usefully "
+        "status.sync.status (Synced / OutOfSync) and status.health.status "
+        "(Healthy / Degraded / Progressing / Missing). Use as the entry point "
+        "for any 'which apps are out of sync / unhealthy?' question. "
+        "safety_level=safe, read-only."
+    ),
+    parameter_schema={
+        "type": "object",
+        "properties": {
+            "projects": {
+                "type": "array",
+                "items": {"type": "string", "minLength": 1},
+                "description": (
+                    "Optional list of AppProject names to filter by. Omit to "
+                    "list applications across all projects the credential can see."
+                ),
+            },
+            "selector": {
+                "type": "string",
+                "minLength": 1,
+                "description": (
+                    "Optional Kubernetes label selector "
+                    "(e.g. 'team=payments,env=prod') filtering the returned apps."
+                ),
+            },
+        },
+        "additionalProperties": False,
+    },
+    response_schema={
+        "type": "object",
+        "properties": {
+            "items": {"type": ["array", "null"]},
+            "metadata": {"type": "object"},
+        },
+        "additionalProperties": True,
+    },
+    group_key="argocd-apps",
+    tags=("read-only", "argocd", "gitops"),
+    safety_level="safe",
+    requires_approval=False,
+    llm_instructions={
+        "when_to_use": (
+            "Call first when the operator asks about the fleet of ArgoCD apps "
+            "or wants to find which apps are OutOfSync or unhealthy. Narrow "
+            "with 'projects' and/or 'selector' when the operator named a "
+            "project or label."
+        ),
+        "parameter_hints": {
+            "projects": "List of AppProject names; omit for all projects.",
+            "selector": "Kubernetes label selector string; omit for no label filter.",
+        },
+        "output_shape": (
+            "{items: [Application, ...], metadata: {...}}. Read each item's "
+            "status.sync.status and status.health.status for the at-a-glance "
+            "state; metadata.name identifies the app for follow-up ops."
+        ),
+    },
+)
+
+
+# ---------------------------------------------------------------------------
+# argocd.app.get
+# ---------------------------------------------------------------------------
+
+_APP_GET = ArgoCdOp(
+    op_id="argocd.app.get",
+    handler_attr="app_get",
+    summary="Get one ArgoCD Application's full spec and status by name.",
+    description=(
+        "Returns a single ArgoCD Application via "
+        "GET /api/v1/applications/{name} — the full object: spec (source, "
+        "destination, sync policy) and status (sync state, health, "
+        "operationState, the conditions list, and the resources summary). "
+        "Use after argocd.app.list to drill into one app, or directly when "
+        "the operator names an app. safety_level=safe, read-only."
+    ),
+    parameter_schema={
+        "type": "object",
+        "properties": {
+            "name": _APP_NAME_PROPERTY,
+            "project": _PROJECT_QUERY_PROPERTY,
+        },
+        "required": ["name"],
+        "additionalProperties": False,
+    },
+    response_schema={
+        "type": "object",
+        "properties": {
+            "metadata": {"type": "object"},
+            "spec": {"type": "object"},
+            "status": {"type": "object"},
+        },
+        "additionalProperties": True,
+    },
+    group_key="argocd-apps",
+    tags=("read-only", "argocd", "gitops"),
+    safety_level="safe",
+    requires_approval=False,
+    llm_instructions={
+        "when_to_use": (
+            "Call when the operator names a specific app and wants its full "
+            "detail (sync policy, conditions, operationState) beyond the "
+            "summary argocd.app.list returns."
+        ),
+        "parameter_hints": {
+            "name": "The Application's metadata.name (from argocd.app.list).",
+            "project": "Optional AppProject to scope the lookup; omit unless known.",
+        },
+        "output_shape": (
+            "A single Application object: {metadata, spec, status}. "
+            "status.conditions surfaces ComparisonError / SyncError detail."
+        ),
+    },
+)
+
+
+# ---------------------------------------------------------------------------
+# argocd.app.diff
+# ---------------------------------------------------------------------------
+
+_APP_DIFF = ArgoCdOp(
+    op_id="argocd.app.diff",
+    handler_attr="app_diff",
+    summary="Return the desired-vs-live drift for an ArgoCD Application.",
+    description=(
+        "Returns the per-resource desired-vs-live drift for an ArgoCD "
+        "Application via GET /api/v1/applications/{name}/managed-resources — "
+        "the same managed-resources delta the 'argocd app diff <app>' CLI "
+        "renders. Each item is one managed resource carrying its group / kind "
+        "/ namespace / name plus liveState (the object currently in the "
+        "cluster), targetState (the desired object rendered from Git via "
+        "Helm/Kustomize), normalizedLiveState and predictedLiveState (the "
+        "normalized pair the controller actually compares), and a 'modified' "
+        "flag. Use to answer 'what exactly is out of sync?' for an OutOfSync "
+        "app. safety_level=safe, read-only."
+    ),
+    parameter_schema={
+        "type": "object",
+        "properties": {
+            "name": _APP_NAME_PROPERTY,
+            "project": _PROJECT_QUERY_PROPERTY,
+        },
+        "required": ["name"],
+        "additionalProperties": False,
+    },
+    response_schema={
+        "type": "object",
+        "properties": {
+            "items": {"type": ["array", "null"]},
+        },
+        "additionalProperties": True,
+    },
+    group_key="argocd-apps",
+    tags=("read-only", "argocd", "gitops", "diff"),
+    safety_level="safe",
+    requires_approval=False,
+    llm_instructions={
+        "when_to_use": (
+            "Call when an app is OutOfSync and the operator wants the concrete "
+            "delta — which managed resources differ and how their live state "
+            "diverges from the desired Git-rendered state. This is the "
+            "API-level equivalent of 'argocd app diff'."
+        ),
+        "parameter_hints": {
+            "name": "The Application's metadata.name.",
+            "project": "Optional AppProject to scope the lookup; omit unless known.",
+        },
+        "output_shape": (
+            "{items: [ResourceDiff, ...]}. Per item compare liveState vs "
+            "targetState (or the normalized*/predicted* pair); 'modified'=true "
+            "marks a drifted resource. liveState empty + targetState set means "
+            "a resource missing from the cluster."
+        ),
+    },
+)
+
+
+# ---------------------------------------------------------------------------
+# argocd.app.resource_tree
+# ---------------------------------------------------------------------------
+
+_APP_RESOURCE_TREE = ArgoCdOp(
+    op_id="argocd.app.resource_tree",
+    handler_attr="app_resource_tree",
+    summary="Return an ArgoCD Application's reconciled resource tree.",
+    description=(
+        "Returns the reconciled resource tree for an ArgoCD Application via "
+        "GET /api/v1/applications/{name}/resource-tree: the nodes (each "
+        "managed/child Kubernetes object with its group/kind/namespace/name, "
+        "parentRefs, health, and sync status), orphanedNodes (objects in the "
+        "destination namespace not managed by this app), hosts, and "
+        "shardsCount. Use to see the full hierarchy of what an app manages and "
+        "where in the tree a health problem sits. safety_level=safe, "
+        "read-only."
+    ),
+    parameter_schema={
+        "type": "object",
+        "properties": {
+            "name": _APP_NAME_PROPERTY,
+            "project": _PROJECT_QUERY_PROPERTY,
+        },
+        "required": ["name"],
+        "additionalProperties": False,
+    },
+    response_schema={
+        "type": "object",
+        "properties": {
+            "nodes": {"type": ["array", "null"]},
+            "orphanedNodes": {"type": ["array", "null"]},
+            "hosts": {"type": ["array", "null"]},
+            "shardsCount": {"type": ["integer", "string", "null"]},
+        },
+        "additionalProperties": True,
+    },
+    group_key="argocd-apps",
+    tags=("read-only", "argocd", "gitops"),
+    safety_level="safe",
+    requires_approval=False,
+    llm_instructions={
+        "when_to_use": (
+            "Call when the operator wants the child-resource hierarchy of an "
+            "app and per-node health/sync — e.g. to find which Deployment / "
+            "Pod under an app is Degraded, or to spot orphaned resources."
+        ),
+        "parameter_hints": {
+            "name": "The Application's metadata.name.",
+            "project": "Optional AppProject to scope the lookup; omit unless known.",
+        },
+        "output_shape": (
+            "{nodes: [ResourceNode, ...], orphanedNodes: [...], hosts: [...], "
+            "shardsCount: int}. Each node carries health.status and (where "
+            "applicable) parentRefs linking it into the tree."
+        ),
+    },
+)
+
+
+# ---------------------------------------------------------------------------
+# argocd.appproject.list
+# ---------------------------------------------------------------------------
+
+_APPPROJECT_LIST = ArgoCdOp(
+    op_id="argocd.appproject.list",
+    handler_attr="appproject_list",
+    summary="List ArgoCD AppProjects and their allow-lists.",
+    description=(
+        "Lists ArgoCD AppProjects via GET /api/v1/projects. Each item carries "
+        "the project's spec: sourceRepos (permitted Git repo URL globs), "
+        "destinations (permitted cluster server + namespace pairs), and the "
+        "cluster/namespace resource allow- and deny-lists that gate what "
+        "Applications in the project may deploy. Use to audit multi-tenant "
+        "guardrails or to confirm an app's source/destination is permitted by "
+        "its project. safety_level=safe, read-only."
+    ),
+    parameter_schema={
+        "type": "object",
+        "properties": {},
+        "additionalProperties": False,
+    },
+    response_schema={
+        "type": "object",
+        "properties": {
+            "items": {"type": ["array", "null"]},
+            "metadata": {"type": "object"},
+        },
+        "additionalProperties": True,
+    },
+    group_key="argocd-projects",
+    tags=("read-only", "argocd", "gitops"),
+    safety_level="safe",
+    requires_approval=False,
+    llm_instructions={
+        "when_to_use": (
+            "Call when the operator asks which projects exist or what a "
+            "project permits, or to check whether an Application's source repo "
+            "/ destination is allowed by its AppProject."
+        ),
+        "parameter_hints": {},
+        "output_shape": (
+            "{items: [AppProject, ...], metadata: {...}}. Read each item's "
+            "spec.sourceRepos and spec.destinations for the allow-lists."
+        ),
+    },
+)
+
+
+# ---------------------------------------------------------------------------
+# argocd.repo.list
+# ---------------------------------------------------------------------------
+
+_REPO_LIST = ArgoCdOp(
+    op_id="argocd.repo.list",
+    handler_attr="repo_list",
+    summary="List configured ArgoCD repositories and their connection state.",
+    description=(
+        "Lists the Git/Helm repositories configured in ArgoCD via "
+        "GET /api/v1/repositories. Each item carries the repo URL, type "
+        "(git/helm), name, and a connectionState (status Successful / Failed "
+        "plus a message and the attemptedAt timestamp) reflecting whether "
+        "ArgoCD can currently reach and authenticate to the repo. Use to "
+        "diagnose a 'repository not accessible' / ComparisonError app "
+        "condition or to confirm a repo is registered. safety_level=safe, "
+        "read-only."
+    ),
+    parameter_schema={
+        "type": "object",
+        "properties": {},
+        "additionalProperties": False,
+    },
+    response_schema={
+        "type": "object",
+        "properties": {
+            "items": {"type": ["array", "null"]},
+            "metadata": {"type": "object"},
+        },
+        "additionalProperties": True,
+    },
+    group_key="argocd-repos",
+    tags=("read-only", "argocd", "gitops"),
+    safety_level="safe",
+    requires_approval=False,
+    llm_instructions={
+        "when_to_use": (
+            "Call when the operator asks which repos ArgoCD knows about, or to "
+            "check repo reachability/auth when an app reports a "
+            "ComparisonError or 'repository not accessible' condition."
+        ),
+        "parameter_hints": {},
+        "output_shape": (
+            "{items: [Repository, ...], metadata: {...}}. Read each item's "
+            "connectionState.status (Successful / Failed) and .message."
+        ),
+    },
+)
+
+
+#: The ops :class:`ArgoCdConnector` registers at lifespan startup — the full
+#: G3.12-T2 read core. Ordered apps → projects → repos to match the
+#: operator's typical drill path.
+ARGOCD_OPS: tuple[ArgoCdOp, ...] = (
+    _APP_LIST,
+    _APP_GET,
+    _APP_DIFF,
+    _APP_RESOURCE_TREE,
+    _APPPROJECT_LIST,
+    _REPO_LIST,
+)

--- a/backend/tests/test_connectors_argocd_reads.py
+++ b/backend/tests/test_connectors_argocd_reads.py
@@ -1,0 +1,467 @@
+# SPDX-License-Identifier: Apache-2.0
+# Copyright (c) 2026 evoila Group
+
+"""Tests for the ArgoCD curated read core (G3.12-T2 #1391).
+
+Coverage matrix (per Task #1391 acceptance criteria):
+
+* **All six ops dispatch live** through :func:`~meho_backplane.operations.dispatch`
+  against an ``argocd-server`` target: ``argocd.app.list`` / ``argocd.app.get``
+  / ``argocd.app.diff`` / ``argocd.app.resource_tree`` /
+  ``argocd.appproject.list`` / ``argocd.repo.list`` each hit the correct
+  ArgoCD path with a bearer token and return ``status="ok"`` with the payload
+  in ``OperationResult.result``. respx mocks the wire; the in-process Vault
+  fake exercises the real default credential loader.
+* **`argocd.app.diff` returns the managed-resources delta** — the same
+  desired-vs-live drift ``argocd app diff <app>`` renders (each item carries
+  ``liveState`` / ``targetState``).
+* **Query-param plumbing** — ``app.list`` forwards ``projects`` (repeated) +
+  ``selector``; the per-app ops URL-encode ``name`` into the path and forward
+  the optional ``project`` scoping query.
+* **Visibility to `search_operations`** — after registration the ops are
+  retrievable by their connector_id.
+* **`ARGOCD_OPS` registration shape** — all six carry ``safety_level="safe"``,
+  ``requires_approval=False``, a ``read-only`` tag, ``additionalProperties=False``
+  on the parameter schema, and non-empty ``llm_instructions``. No write op is
+  registered.
+
+Mirrors :mod:`tests.test_connectors_argocd_credread` (G3.12-T1 #1390) for the
+dispatch lifecycle + Vault fake, and :mod:`tests.test_connectors_bind9_reads`
+(#588) for the metadata-table invariants.
+"""
+
+from __future__ import annotations
+
+import uuid
+from collections.abc import AsyncIterator, Iterator
+from typing import Any
+from unittest.mock import AsyncMock
+from uuid import UUID
+
+import pytest
+import respx
+from sqlalchemy.ext.asyncio import AsyncSession
+
+from meho_backplane.auth.operator import Operator, TenantRole
+from meho_backplane.connectors.argocd import ARGOCD_OPS, ArgoCdConnector
+from meho_backplane.connectors.registry import clear_registry, register_connector_v2
+from meho_backplane.db.engine import get_sessionmaker
+from meho_backplane.operations import dispatch, reset_dispatcher_caches
+from meho_backplane.operations._handler_resolve import reset_handler_cache
+from meho_backplane.operations.meta_tools import search_operations
+from meho_backplane.settings import get_settings
+
+from ._vault_fakes import install_fake_client
+
+_CANARY_TOKEN = "argocd-bearer-canary-must-not-leak-reads"
+
+_PRODUCT = "argocd"
+_VERSION = "3.x"
+_IMPL_ID = "argocd-api"
+_CONNECTOR_ID = "argocd-api-3.x"
+
+_ARGOCD_HOST = "argocd-reads.test.invalid"
+_ARGOCD_BASE_URL = f"https://{_ARGOCD_HOST}"
+
+
+@pytest.fixture(autouse=True)
+def _settings_env(monkeypatch: pytest.MonkeyPatch) -> Iterator[None]:
+    """Pin chassis env vars Settings reads (Vault client + dispatcher)."""
+    monkeypatch.setenv("KEYCLOAK_ISSUER_URL", "https://keycloak.test/realms/meho")
+    monkeypatch.setenv("KEYCLOAK_AUDIENCE", "meho-backplane")
+    monkeypatch.setenv("VAULT_ADDR", "https://vault.test")
+    monkeypatch.setenv("VAULT_OIDC_ROLE", "meho-mcp")
+    monkeypatch.setenv("VAULT_OIDC_MOUNT_PATH", "jwt")
+    monkeypatch.setenv("VAULT_TIMEOUT_SECONDS", "5.0")
+    monkeypatch.delenv("VAULT_NAMESPACE", raising=False)
+    get_settings.cache_clear()
+    yield
+    get_settings.cache_clear()
+
+
+@pytest.fixture(autouse=True)
+def _reset_module_state() -> Iterator[None]:
+    """Reset dispatcher/handler caches + connector registry around every test."""
+    reset_dispatcher_caches()
+    reset_handler_cache()
+    clear_registry()
+    register_connector_v2(
+        product=_PRODUCT,
+        version=_VERSION,
+        impl_id=_IMPL_ID,
+        cls=ArgoCdConnector,
+    )
+    yield
+    reset_dispatcher_caches()
+    reset_handler_cache()
+    clear_registry()
+
+
+@pytest.fixture
+def _stub_embedding(monkeypatch: pytest.MonkeyPatch) -> AsyncMock:
+    """Deterministic embedding stub so registration/search don't pull ONNX.
+
+    Patched at every site the typed-op pipeline and the search path resolve
+    an embedding service, so neither registration (``encode_endpoint_text``)
+    nor ``search_operations`` lazy-loads the fastembed model.
+    """
+    service = AsyncMock()
+    service.encode_one.return_value = [0.1] * 384
+    service.encode.return_value = [[0.1] * 384]
+    service.dimension = 384
+
+    def _fake_get_embedding_service() -> AsyncMock:
+        return service
+
+    # Registration computes the descriptor embedding via
+    # ``encode_endpoint_text`` (imported into the typed_register namespace);
+    # the search path resolves the query embedding via
+    # ``_search.get_embedding_service``. Stub both so neither lazy-loads ONNX.
+    monkeypatch.setattr(
+        "meho_backplane.operations.typed_register.encode_endpoint_text",
+        AsyncMock(return_value=[0.1] * 384),
+    )
+    monkeypatch.setattr(
+        "meho_backplane.operations._search.get_embedding_service",
+        _fake_get_embedding_service,
+    )
+    return service
+
+
+@pytest.fixture
+async def session() -> AsyncIterator[AsyncSession]:
+    """AsyncSession against the autouse-migrated per-worker SQLite engine."""
+    sessionmaker = get_sessionmaker()
+    async with sessionmaker() as s:
+        yield s
+
+
+class _ReadTarget:
+    """Target satisfying both ``ArgoCdTargetLike`` and the resolver shape."""
+
+    def __init__(self) -> None:
+        self.product = _PRODUCT
+        self.fingerprint = type("_FP", (), {"version": "3.3.9"})()
+        self.preferred_impl_id: str | None = None
+        self.id: UUID = uuid.uuid4()
+        self.name = "argocd-reads"
+        self.host = _ARGOCD_HOST
+        self.port = 443
+        self.secret_ref = "targets/op-reads/argocd-reads"
+        self.auth_model = "shared_service_account"
+
+
+def _make_operator() -> Operator:
+    """Operator carrying a non-empty raw_jwt (the fail-closed gate passes)."""
+    return Operator(
+        sub="op-reads-argocd",
+        name="ArgoCD Reads Operator",
+        email=None,
+        raw_jwt="op.reads.argocd.jwt",
+        tenant_id=UUID("00000000-0000-0000-0000-00000000a0a4"),
+        tenant_role=TenantRole.OPERATOR,
+    )
+
+
+async def _register_ops(_stub_embedding: AsyncMock) -> None:
+    """Walk ARGOCD_OPS through register_typed_operation against the test DB."""
+    await ArgoCdConnector.register_operations()
+
+
+# ---------------------------------------------------------------------------
+# Live dispatch — each op hits the right path with a bearer token
+# ---------------------------------------------------------------------------
+
+#: Canned ArgoCD payloads (shaped to the real wire envelopes).
+_APP_LIST_RESPONSE: dict[str, Any] = {
+    "metadata": {"resourceVersion": "100"},
+    "items": [
+        {
+            "metadata": {"name": "guestbook"},
+            "status": {
+                "sync": {"status": "OutOfSync"},
+                "health": {"status": "Degraded"},
+            },
+        }
+    ],
+}
+_APP_GET_RESPONSE: dict[str, Any] = {
+    "metadata": {"name": "guestbook"},
+    "spec": {"project": "default"},
+    "status": {"sync": {"status": "Synced"}, "health": {"status": "Healthy"}},
+}
+_APP_DIFF_RESPONSE: dict[str, Any] = {
+    "items": [
+        {
+            "group": "apps",
+            "kind": "Deployment",
+            "namespace": "guestbook",
+            "name": "guestbook-ui",
+            "liveState": '{"spec":{"replicas":1}}',
+            "targetState": '{"spec":{"replicas":3}}',
+            "normalizedLiveState": '{"spec":{"replicas":1}}',
+            "predictedLiveState": '{"spec":{"replicas":3}}',
+            "modified": True,
+        }
+    ]
+}
+_RESOURCE_TREE_RESPONSE: dict[str, Any] = {
+    "nodes": [
+        {
+            "group": "apps",
+            "kind": "Deployment",
+            "namespace": "guestbook",
+            "name": "guestbook-ui",
+            "health": {"status": "Degraded"},
+        }
+    ],
+    "orphanedNodes": [],
+    "hosts": [],
+    "shardsCount": "0",
+}
+_APPPROJECT_LIST_RESPONSE: dict[str, Any] = {
+    "metadata": {"resourceVersion": "5"},
+    "items": [
+        {
+            "metadata": {"name": "default"},
+            "spec": {"sourceRepos": ["*"], "destinations": [{"server": "*", "namespace": "*"}]},
+        }
+    ],
+}
+_REPO_LIST_RESPONSE: dict[str, Any] = {
+    "metadata": {},
+    "items": [
+        {
+            "repo": "https://github.com/example/gitops",
+            "type": "git",
+            "connectionState": {"status": "Successful", "message": ""},
+        }
+    ],
+}
+
+
+@pytest.mark.parametrize(
+    ("op_id", "params", "method", "path", "payload"),
+    [
+        ("argocd.app.list", {}, "GET", "/api/v1/applications", _APP_LIST_RESPONSE),
+        (
+            "argocd.app.get",
+            {"name": "guestbook"},
+            "GET",
+            "/api/v1/applications/guestbook",
+            _APP_GET_RESPONSE,
+        ),
+        (
+            "argocd.app.diff",
+            {"name": "guestbook"},
+            "GET",
+            "/api/v1/applications/guestbook/managed-resources",
+            _APP_DIFF_RESPONSE,
+        ),
+        (
+            "argocd.app.resource_tree",
+            {"name": "guestbook"},
+            "GET",
+            "/api/v1/applications/guestbook/resource-tree",
+            _RESOURCE_TREE_RESPONSE,
+        ),
+        ("argocd.appproject.list", {}, "GET", "/api/v1/projects", _APPPROJECT_LIST_RESPONSE),
+        ("argocd.repo.list", {}, "GET", "/api/v1/repositories", _REPO_LIST_RESPONSE),
+    ],
+)
+@pytest.mark.asyncio
+async def test_each_read_op_dispatches_live_and_returns_payload(
+    _stub_embedding: AsyncMock,
+    session: AsyncSession,
+    monkeypatch: pytest.MonkeyPatch,
+    op_id: str,
+    params: dict[str, Any],
+    method: str,
+    path: str,
+    payload: dict[str, Any],
+) -> None:
+    """Every curated read op dispatches end to end and returns the ArgoCD payload."""
+    await _register_ops(_stub_embedding)
+    install_fake_client(monkeypatch, secret={"token": _CANARY_TOKEN})
+
+    target = _ReadTarget()
+    operator = _make_operator()
+
+    async with respx.mock(base_url=_ARGOCD_BASE_URL, assert_all_called=False) as mock:
+        route = mock.request(method, path).respond(200, json=payload)
+        result = await dispatch(
+            operator=operator,
+            connector_id=_CONNECTOR_ID,
+            op_id=op_id,
+            target=target,
+            params=params,
+        )
+
+    assert result.status == "ok", result.error
+    assert result.result == payload
+    assert route.called and route.call_count == 1
+    sent_auth = route.calls[0].request.headers.get("authorization")
+    assert sent_auth == f"Bearer {_CANARY_TOKEN}"
+
+
+@pytest.mark.asyncio
+async def test_app_diff_returns_managed_resources_drift(
+    _stub_embedding: AsyncMock,
+    session: AsyncSession,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """AC: argocd.app.diff returns the desired-vs-live delta argocd-app-diff shows."""
+    await _register_ops(_stub_embedding)
+    install_fake_client(monkeypatch, secret={"token": _CANARY_TOKEN})
+
+    async with respx.mock(base_url=_ARGOCD_BASE_URL, assert_all_called=False) as mock:
+        mock.get("/api/v1/applications/guestbook/managed-resources").respond(
+            200, json=_APP_DIFF_RESPONSE
+        )
+        result = await dispatch(
+            operator=_make_operator(),
+            connector_id=_CONNECTOR_ID,
+            op_id="argocd.app.diff",
+            target=_ReadTarget(),
+            params={"name": "guestbook"},
+        )
+
+    assert result.status == "ok", result.error
+    assert isinstance(result.result, dict)
+    items = result.result["items"]
+    assert len(items) == 1
+    drift = items[0]
+    # The drift carries both halves of the comparison the CLI renders.
+    assert drift["liveState"] != drift["targetState"]
+    assert drift["modified"] is True
+
+
+@pytest.mark.asyncio
+async def test_app_list_forwards_projects_and_selector_query(
+    _stub_embedding: AsyncMock,
+    session: AsyncSession,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """app.list forwards repeated ``projects`` + a ``selector`` query param."""
+    await _register_ops(_stub_embedding)
+    install_fake_client(monkeypatch, secret={"token": _CANARY_TOKEN})
+
+    async with respx.mock(base_url=_ARGOCD_BASE_URL, assert_all_called=False) as mock:
+        route = mock.get("/api/v1/applications").respond(200, json=_APP_LIST_RESPONSE)
+        result = await dispatch(
+            operator=_make_operator(),
+            connector_id=_CONNECTOR_ID,
+            op_id="argocd.app.list",
+            target=_ReadTarget(),
+            params={"projects": ["team-a", "team-b"], "selector": "env=prod"},
+        )
+
+    assert result.status == "ok", result.error
+    sent_url = route.calls[0].request.url
+    assert sent_url.params.get_list("projects") == ["team-a", "team-b"]
+    assert sent_url.params.get("selector") == "env=prod"
+
+
+@pytest.mark.asyncio
+async def test_app_get_url_encodes_name_and_forwards_project_query(
+    _stub_embedding: AsyncMock,
+    session: AsyncSession,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """app.get URL-encodes the name into the path and forwards ``project``."""
+    await _register_ops(_stub_embedding)
+    install_fake_client(monkeypatch, secret={"token": _CANARY_TOKEN})
+
+    # A name with a slash must be percent-encoded so it stays one path segment.
+    async with respx.mock(base_url=_ARGOCD_BASE_URL, assert_all_called=False) as mock:
+        route = mock.get("/api/v1/applications/team%2Fapp").respond(200, json=_APP_GET_RESPONSE)
+        result = await dispatch(
+            operator=_make_operator(),
+            connector_id=_CONNECTOR_ID,
+            op_id="argocd.app.get",
+            target=_ReadTarget(),
+            params={"name": "team/app", "project": "default"},
+        )
+
+    assert result.status == "ok", result.error
+    assert route.called
+    assert route.calls[0].request.url.params.get("project") == "default"
+
+
+# ---------------------------------------------------------------------------
+# search_operations visibility
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.asyncio
+async def test_registered_ops_are_visible_to_search_operations(
+    _stub_embedding: AsyncMock,
+    session: AsyncSession,
+) -> None:
+    """AC: the registered read ops are retrievable via search_operations."""
+    await _register_ops(_stub_embedding)
+
+    result = await search_operations(
+        _make_operator(),
+        {"connector_id": _CONNECTOR_ID, "query": "argocd application sync status", "limit": 25},
+    )
+    found = {hit["op_id"] for hit in result["hits"]}
+    expected = {op.op_id for op in ARGOCD_OPS}
+    assert expected <= found, f"missing from search: {expected - found}"
+
+
+# ---------------------------------------------------------------------------
+# ARGOCD_OPS registration-shape invariants
+# ---------------------------------------------------------------------------
+
+_EXPECTED_OP_IDS = {
+    "argocd.app.list",
+    "argocd.app.get",
+    "argocd.app.diff",
+    "argocd.app.resource_tree",
+    "argocd.appproject.list",
+    "argocd.repo.list",
+}
+
+
+def test_argocd_ops_table_is_exactly_the_six_read_ops() -> None:
+    assert {op.op_id for op in ARGOCD_OPS} == _EXPECTED_OP_IDS
+
+
+@pytest.mark.parametrize("op_id", sorted(_EXPECTED_OP_IDS))
+def test_each_op_is_safe_no_approval_and_read_only(op_id: str) -> None:
+    op = next(o for o in ARGOCD_OPS if o.op_id == op_id)
+    assert op.safety_level == "safe"
+    assert op.requires_approval is False
+    assert "read-only" in op.tags
+
+
+@pytest.mark.parametrize("op_id", sorted(_EXPECTED_OP_IDS))
+def test_each_op_parameter_schema_disallows_additional_properties(op_id: str) -> None:
+    op = next(o for o in ARGOCD_OPS if o.op_id == op_id)
+    assert op.parameter_schema.get("additionalProperties") is False
+
+
+@pytest.mark.parametrize("op_id", sorted(_EXPECTED_OP_IDS))
+def test_each_op_has_llm_instructions_with_when_to_use_and_output_shape(op_id: str) -> None:
+    op = next(o for o in ARGOCD_OPS if o.op_id == op_id)
+    assert op.llm_instructions is not None
+    assert op.llm_instructions.get("when_to_use", "").strip() != ""
+    assert "output_shape" in op.llm_instructions
+
+
+def test_no_write_or_mutating_op_is_registered() -> None:
+    """AC: this Task ships read-only — no sync/rollback/set/write op."""
+    for op in ARGOCD_OPS:
+        assert op.safety_level == "safe"
+        assert not any(
+            token in op.op_id for token in (".sync", ".rollback", ".set", ".delete", ".create")
+        )
+        assert "write" not in op.tags
+
+
+def test_per_app_ops_require_name_param() -> None:
+    """app.get / app.diff / app.resource_tree must require the ``name`` param."""
+    for op_id in ("argocd.app.get", "argocd.app.diff", "argocd.app.resource_tree"):
+        op = next(o for o in ARGOCD_OPS if o.op_id == op_id)
+        assert op.parameter_schema.get("required") == ["name"]

--- a/docs/codebase/connectors-argocd.md
+++ b/docs/codebase/connectors-argocd.md
@@ -7,11 +7,11 @@ dispatches ArgoCD `argocd-server` REST operations under the
 `(product="argocd", version="3.x", impl_id="argocd-api")` registry triple
 (plus the `("argocd", "", "")` wildcard fallback). G3.12-T1 (#1390) ships the
 skeleton — bearer-token auth, fingerprint, probe, the G0.6 dispatch shim, and
-dual registration. The curated read core (`argocd.app.list` /
-`argocd.app.get` / `argocd.app.diff` / `argocd.app.resource_tree` /
-`argocd.appproject.list` / `argocd.repo.list`) arrives in G3.12-T2; CLI verbs
-+ MCP review + recorded-fixture E2E + `docs/cross-repo/argocd-onboarding.md`
-arrive in G3.12-T3.
+dual registration. G3.12-T2 (#1391) layers the curated read core on top:
+`argocd.app.list` / `argocd.app.get` / `argocd.app.diff` /
+`argocd.app.resource_tree` / `argocd.appproject.list` / `argocd.repo.list` —
+all `safety_level="safe"`, `requires_approval=False`, read-only. CLI verbs +
+MCP review + `docs/cross-repo/argocd-onboarding.md` arrive in G3.12-T3.
 
 Source: `backend/src/meho_backplane/connectors/argocd/`.
 
@@ -39,6 +39,16 @@ Source: `backend/src/meho_backplane/connectors/argocd/`.
 - **`ARGOCD_TOKEN_FIELD`** (`session.py`) — the single KV-v2 secret field name
   (`"token"`) an operator stores under `target.secret_ref`. Shared by the
   connector, the loader, and the tests.
+- **`ArgoCdOp`** + **`ARGOCD_OPS`** (`ops.py`) — the typed-op metadata dataclass
+  and the six-entry registration tuple (the curated read core). Mirrors the
+  bind9 `Bind9Op` / `BIND9_OPS` shape: one frozen dataclass per op carrying the
+  `register_typed_operation` kwargs plus a `handler_attr` naming the bound
+  method on `ArgoCdConnector`. **`ARGOCD_WHEN_TO_USE_BY_GROUP`** maps each op's
+  `group_key` (`argocd-apps` / `argocd-projects` / `argocd-repos`) to its
+  curated `when_to_use` blurb.
+- **`register_argocd_typed_operations`** (`__init__.py`) — the lifespan-driven
+  registrar (queued via `register_typed_op_registrar`) that delegates to
+  `ArgoCdConnector.register_operations()`.
 
 ## Control flow
 
@@ -107,6 +117,34 @@ structured `error` string as `reason`. ArgoCD exposes no dedicated composite
 health endpoint comparable to Harbor's `/api/v2.0/health`, so the
 unauthenticated `GET /api/version` probe is the right reachability surface.
 
+### Curated read ops (G3.12-T2)
+
+Six read-only ops are upserted into `endpoint_descriptor` at lifespan startup
+by `register_argocd_typed_operations` → `ArgoCdConnector.register_operations()`,
+which walks `ARGOCD_OPS` and routes each row through `register_typed_operation`
+(idempotent across pod restarts — re-embed is skipped on unchanged text). Each
+handler is a thin bound method on `ArgoCdConnector` (`app_list` / `app_get` /
+`app_diff` / `app_resource_tree` / `appproject_list` / `repo_list`) that the
+dispatcher binds to the per-process instance and threads `operator` into; the
+handler forwards `operator` to `_get_json` so the bearer token is read under
+the operator's identity.
+
+| op_id | endpoint | returns |
+|---|---|---|
+| `argocd.app.list` | `GET /api/v1/applications` (opt. `projects[]`, `selector`) | `{items, metadata}` — apps + sync/health status |
+| `argocd.app.get` | `GET /api/v1/applications/{name}` (opt. `project`) | one app's full spec + status |
+| `argocd.app.diff` | `GET /api/v1/applications/{name}/managed-resources` | `{items: [ResourceDiff]}` — `liveState`/`targetState` per resource |
+| `argocd.app.resource_tree` | `GET /api/v1/applications/{name}/resource-tree` | `{nodes, orphanedNodes, hosts, shardsCount}` |
+| `argocd.appproject.list` | `GET /api/v1/projects` | `{items, metadata}` — AppProjects + allow-lists |
+| `argocd.repo.list` | `GET /api/v1/repositories` | `{items, metadata}` — repos + connectionState |
+
+`argocd.app.diff` is the API-level equivalent of `argocd app diff <app>`: the
+managed-resources delta where each item's `liveState` (cluster) is compared
+against `targetState` (Git-rendered desired). The per-app ops URL-encode the
+`name` param into the path (so a slash in the name stays one segment) and
+forward the optional `project` scoping query. `app.list` serialises `projects`
+as repeated query pairs (the gRPC-gateway repeated-field shape).
+
 ### execute() shim
 
 `execute()` synthesises a system `Operator` with
@@ -144,13 +182,15 @@ shim.
   respx-mocked ArgoCD, plus the canary-token leak assertions.
 - `tests/test_connectors_registry_v2.py::test_argocd_connector_registered_under_v2_triple_and_wildcard`
   — asserts the dual registration resolves.
+- `tests/test_connectors_argocd_reads.py` — the G3.12-T2 read-core suite: each
+  of the six ops dispatched live through `dispatch` against respx-mocked
+  `argocd-server` (right path + bearer token + payload), `app.diff` returns the
+  managed-resources drift, query-param plumbing (`projects`/`selector`/`project`
+  + name URL-encoding), `search_operations` visibility, and the `ARGOCD_OPS`
+  registration-shape invariants (all `safe`/no-approval/`read-only`, no write op).
 
 ## Known issues
 
-- This Task ships **zero operations** — `execute(target, op_id, ...)` against
-  any `op_id` resolves to "unknown operation" at the dispatcher layer, the
-  correct behaviour for a registered-but-empty connector at this stage. The
-  curated read core lands in G3.12-T2.
 - The write ops (`argocd.app.sync` / `app.rollback` / `app.set`, gated by the
   approval queue) and any full-Swagger L2 ingest are deferred follow-up Tasks
   under Initiative #1387, per Hard rule 2 (no speculative optionality).
@@ -162,8 +202,9 @@ shim.
 
 ## References
 
-- Issues: #1390 (G3.12-T1 skeleton). Initiative: #1387 (G3.12 argocd
-  connector). Goal: #214 (connector parity / wrapper retirement).
+- Issues: #1390 (G3.12-T1 skeleton), #1391 (G3.12-T2 curated read core).
+  Initiative: #1387 (G3.12 argocd connector). Goal: #214 (connector parity /
+  wrapper retirement).
 - HttpConnector base: `backend/src/meho_backplane/connectors/adapters/http.py`
 - Shared Vault loader: `backend/src/meho_backplane/connectors/_shared/vault_creds.py`
 - ArgoCD API: https://argo-cd.readthedocs.io/en/stable/developer-guide/api-docs/


### PR DESCRIPTION
## Summary
- Layers the **six curated read ops** onto the G3.12-T1 `ArgoCdConnector` skeleton (merged in #1440): `argocd.app.list` / `app.get` / `app.diff` / `app.resource_tree` / `appproject.list` / `repo.list`, all `safety_level="safe"`, `requires_approval=False`, read-only. No write/mutating op ships here (deferred follow-up).
- `argocd.app.diff` returns ArgoCD's managed-resources delta — the same desired-vs-live drift `argocd app diff <app>` renders (each item carries `liveState` vs `targetState` plus the normalized/predicted pair the controller compares).
- Metadata lives in a frozen `ArgoCdOp` dataclass tuple (`ARGOCD_OPS`) mirroring the bind9 (#367) / k8s shape; handlers are thin `_get_json` bound methods on the connector so `handler_ref` round-trips the dispatcher; a lifespan-driven `register_argocd_typed_operations` registrar walks the tuple through `register_typed_operation`. Endpoint paths + field names pinned to the `argocd-server` Swagger spec.
- OpenAPI snapshot unchanged (typed ops are DB descriptors, not FastAPI routes; `argocd` was already a registered product since T1) — verified `cli/api/openapi.json` hash stable, so no client regen.

## Test plan
- [x] `ruff check` — clean (argocd connector + new test)
- [x] `ruff format --check` — clean
- [x] `mypy src/.../argocd/` — Success, no issues
- [x] `python3 .claude/hooks/code-quality.py --diff` — 0 blockers (3 pre-existing-file size warnings)
- [x] `pytest tests/test_connectors_argocd_reads.py` — 31 passed
- [x] `pytest` argocd auth + credread + registry_v2 + meta_tools + bind9_reads — 169 passed total, no regression
- [x] **AC: all 6 ops dispatch live** through `dispatch` against respx-mocked `argocd-server` — right path + bearer token + payload (parametrized over all six)
- [x] **AC: `app.diff` returns managed-resources drift** — asserts `liveState != targetState` + `modified` on the returned item
- [x] **AC: each op `safe` + no-approval + `read-only` tag** — metadata-table invariants
- [x] **AC: no write op registered** — explicit guard test
- [x] **AC: visible to `search_operations`** — all six retrievable post-registration
- [x] query-param plumbing: `projects` (repeated) + `selector` on list, name URL-encoding + `project` scoping on per-app ops

## Out of scope
- CLI verbs + MCP review + `docs/cross-repo/argocd-onboarding.md` — G3.12-T3 (#1392).
- Write ops (`app.sync` / `rollback` / `set`, approval-gated) — deferred follow-up under #1387.

<!-- auto-implement-issue: fresh, iteration 1 -->

Closes #1391


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **New Features**
  * Added six read-only ArgoCD operations: list and retrieve applications, compare application drift, view resource trees, list projects, and list repositories.

* **Documentation**
  * Updated ArgoCD connector documentation with details on available operations and their parameters.

* **Tests**
  * Added comprehensive test suite validating ArgoCD read operations and registration constraints.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->