### PR TITLE
feat(connectors): G3.13-T3 keycloak CLI verbs + MCP review + recorded-fixture E2E + onboarding doc

### DIFF
--- a/backend/tests/test_connectors_keycloak_e2e.py
+++ b/backend/tests/test_connectors_keycloak_e2e.py
@@ -449,6 +449,89 @@ async def test_keycloak_e2e_all_ops_use_admin_token_never_operator_jwt(
 
 
 # ---------------------------------------------------------------------------
+# Admin-token-refresh through the dispatch stack (G3.13-T3 #1395)
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.asyncio
+async def test_keycloak_e2e_admin_token_refreshes_across_dispatch(
+    keycloak_e2e: KeycloakConnector,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """The admin token is re-minted mid-stream when its TTL lapses between dispatches.
+
+    G3.13-T3 (#1395) calls out the **dispatch + admin-token-refresh
+    path** specifically: the token-refresh lifecycle observed through the
+    full ``call_operation`` stack (not just a direct ``auth_headers``
+    unit call). This drives two dispatched read ops with the connector's
+    monotonic clock advanced past the cached token's effective TTL
+    between them, and asserts:
+
+    * the token endpoint is hit **twice** (mint, then re-mint after expiry),
+    * both dispatched ops still return ``status="ok"`` (the re-mint is
+      transparent to the caller), and
+    * every admin REST GET still carries the admin Bearer, never the
+      operator JWT (the refresh does not leak the operator token onto the
+      Keycloak surface).
+
+    The token fixture returns ``expires_in=60``; with the connector's
+    30 s refresh margin the effective TTL is 30 s, so advancing the clock
+    by 31 s forces a re-mint on the second dispatch.
+    """
+    clock = {"now": 1000.0}
+    monkeypatch.setattr(
+        "meho_backplane.connectors.keycloak.connector.time.monotonic",
+        lambda: clock["now"],
+    )
+
+    with respx.mock(base_url=_KC_BASE_URL, assert_all_called=False) as mock:
+        token_route = mock.post("/realms/master/protocol/openid-connect/token").respond(
+            # expires_in=60, refresh margin 30 -> effective TTL 30 s.
+            200,
+            json={"access_token": _ADMIN_TOKEN, "expires_in": 60},
+        )
+        mock.get("/admin/realms/evba").respond(200, json=_FIXTURE_REALM)
+        mock.get("/admin/realms/evba/clients").respond(200, json=_FIXTURE_CLIENTS)
+
+        first = await call_operation(
+            _OPERATOR,
+            {
+                "connector_id": _CONNECTOR_ID,
+                "op_id": "keycloak.realm.get",
+                "target": {"name": _TARGET_NAME},
+                "params": {},
+            },
+        )
+        assert first["status"] == "ok", f"first dispatch failed: {first.get('error')}"
+        assert token_route.call_count == 1, "first dispatch should mint the admin token once"
+
+        # Advance the connector's monotonic clock past the 30 s effective
+        # TTL so the cached token is stale for the next dispatch.
+        clock["now"] = 1000.0 + 31.0
+
+        second = await call_operation(
+            _OPERATOR,
+            {
+                "connector_id": _CONNECTOR_ID,
+                "op_id": "keycloak.client.list",
+                "target": {"name": _TARGET_NAME},
+                "params": {},
+            },
+        )
+        assert second["status"] == "ok", f"second dispatch failed: {second.get('error')}"
+        # The expired token forced a re-mint on the second dispatch.
+        assert token_route.call_count == 2, "expired token should be re-minted on the next dispatch"
+
+        # Neither dispatch leaked the operator JWT onto the Keycloak admin
+        # surface; the admin GETs carried the re-minted admin Bearer.
+        for call in mock.calls:
+            req = call.request
+            if req.url.path.startswith("/admin/"):
+                assert req.headers.get("authorization") == f"Bearer {_ADMIN_TOKEN}"
+            assert _OPERATOR.raw_jwt not in (req.headers.get("authorization") or "")
+
+
+# ---------------------------------------------------------------------------
 # search_operations visibility (acceptance criterion a)
 # ---------------------------------------------------------------------------
 

--- a/cli/internal/cmd/keycloak/client.go
+++ b/cli/internal/cmd/keycloak/client.go
@@ -1,0 +1,236 @@
+// SPDX-License-Identifier: Apache-2.0
+// Copyright (c) 2026 evoila Group
+
+package keycloak
+
+import (
+	"fmt"
+	"io"
+	"strings"
+
+	"github.com/spf13/cobra"
+
+	"github.com/evoila/meho/cli/internal/output"
+)
+
+// newClientCmd returns the `meho keycloak client` parent with two
+// sub-verbs: `list` (keycloak.client.list) and `get`
+// (keycloak.client.get).
+func newClientCmd() *cobra.Command {
+	cmd := &cobra.Command{
+		Use:          "client",
+		Short:        "Keycloak client sub-verbs (list, get)",
+		SilenceUsage: true,
+	}
+	cmd.AddCommand(newClientListCmd())
+	cmd.AddCommand(newClientGetCmd())
+	return cmd
+}
+
+// newClientListCmd returns the `meho keycloak client list` command.
+//
+// Maps to op_id `keycloak.client.list`. GETs
+// /admin/realms/{realm}/clients and returns the clients as
+// {rows, total}. Optional --client-id maps to Keycloak's ?clientId=
+// exact-match filter; --max caps the result count. Confidential-client
+// secrets are redacted from every row.
+func newClientListCmd() *cobra.Command {
+	var (
+		targetName        string
+		clientID          string
+		maxResults        int
+		jsonOut           bool
+		backplaneOverride string
+	)
+	cmd := &cobra.Command{
+		Use:   "list",
+		Short: "List Keycloak clients in the managed realm (secrets redacted)",
+		Long: "list dispatches keycloak.client.list and renders the clients as\n" +
+			"a table of clientId / enabled / publicClient / internal id.\n" +
+			"--client-id filters to a single client by its human clientId;\n" +
+			"--max caps the result count. Each row's secret is redacted.\n" +
+			"--json emits the full OperationResult envelope.\n\n" +
+			"Use `meho keycloak client get --id <uuid>` for one client's full\n" +
+			"config; the internal uuid is the `id` field of a list row.\n\n" +
+			"Exit codes: 0=ok, 1=error/denied, 2=auth_expired,\n" +
+			"3=unreachable, 4=unexpected.",
+		Example: "  meho keycloak client list --target rdc-keycloak\n" +
+			"  meho keycloak client list --target rdc-keycloak --client-id meho-backplane\n" +
+			"  meho keycloak client list --target rdc-keycloak --json | jq '.result.rows[].id'",
+		Args:          cobra.NoArgs,
+		SilenceUsage:  true,
+		SilenceErrors: true,
+		RunE: func(cmd *cobra.Command, _ []string) error {
+			return runClientList(cmd, targetName, clientID, maxResults, jsonOut, backplaneOverride)
+		},
+	}
+	cmd.Flags().StringVar(&targetName, "target", "",
+		"target slug to dispatch against (required)")
+	cmd.Flags().StringVar(&clientID, "client-id", "",
+		"filter to a single client by its human clientId (Keycloak ?clientId=)")
+	cmd.Flags().IntVar(&maxResults, "max", 0,
+		"cap on the number of clients returned (0 = no cap)")
+	cmd.Flags().BoolVar(&jsonOut, "json", false,
+		"emit the full OperationResult envelope as JSON")
+	cmd.Flags().StringVar(&backplaneOverride, "backplane", "",
+		"backplane URL (defaults to the URL from the most recent `meho login`)")
+	return cmd
+}
+
+func runClientList(
+	cmd *cobra.Command,
+	targetName, clientID string,
+	maxResults int,
+	jsonOut bool,
+	backplaneOverride string,
+) error {
+	backplaneURL, err := resolveBackplane(backplaneOverride)
+	if err != nil {
+		return output.RenderError(cmd.ErrOrStderr(), classifyBackplaneError(err), jsonOut)
+	}
+	params := map[string]any{}
+	if clientID != "" {
+		params["client_id"] = clientID
+	}
+	if maxResults > 0 {
+		params["max"] = maxResults
+	}
+	r, err := dispatchOp(cmd.Context(), backplaneURL, "keycloak.client.list", targetName, params)
+	if err != nil {
+		return renderRequestError(cmd, backplaneURL, err, jsonOut)
+	}
+	return renderCallResult(cmd, "keycloak.client.list", r, jsonOut, printClientList)
+}
+
+func printClientList(w io.Writer, r *CallResult) {
+	fmt.Fprintf(w, "%s keycloak.client.list — status=%s (%.0fms)\n",
+		ConnectorID, r.Status, r.DurationMs)
+	if r.Status != "ok" {
+		printErrorTrailer(w, r)
+		return
+	}
+	rows, total, err := decodeRowsResult(r.Result)
+	if err != nil || rows == nil {
+		fallbackResultRender(w, r)
+		return
+	}
+	fmt.Fprintf(w, "  %-30s %-8s %-7s %s\n", "CLIENT_ID", "ENABLED", "PUBLIC", "INTERNAL_ID")
+	for _, row := range rows {
+		clientID := truncate(stringField(row, "clientId"), 30)
+		enabled := fmt.Sprintf("%t", boolField(row, "enabled"))
+		public := fmt.Sprintf("%t", boolField(row, "publicClient"))
+		id := stringField(row, "id")
+		fmt.Fprintf(w, "  %-30s %-8s %-7s %s\n", clientID, enabled, public, id)
+	}
+	fmt.Fprintf(w, "  (%d clients)\n", total)
+}
+
+// newClientGetCmd returns the `meho keycloak client get` command.
+//
+// Maps to op_id `keycloak.client.get`. GETs
+// /admin/realms/{realm}/clients/{id} where --id is the client's
+// internal UUID (the `id` field from `keycloak client list`, NOT the
+// human clientId). Returns the full ClientRepresentation; the client
+// secret is redacted.
+func newClientGetCmd() *cobra.Command {
+	var (
+		targetName        string
+		clientUUID        string
+		jsonOut           bool
+		backplaneOverride string
+	)
+	cmd := &cobra.Command{
+		Use:   "get",
+		Short: "Read one Keycloak client's full config by internal UUID (secret redacted)",
+		Long: "get dispatches keycloak.client.get for the client whose internal\n" +
+			"UUID is --id (the `id` field from `meho keycloak client list`,\n" +
+			"NOT the human clientId). Renders the redirect URIs, web origins,\n" +
+			"and protocol mappers; the client secret is redacted. --json emits\n" +
+			"the full OperationResult envelope.\n\n" +
+			"Exit codes: 0=ok, 1=error/denied, 2=auth_expired,\n" +
+			"3=unreachable, 4=unexpected.",
+		Example: "  meho keycloak client get --target rdc-keycloak --id 11111111-1111-1111-1111-111111111111\n" +
+			"  meho keycloak client get --target rdc-keycloak --id <uuid> --json | jq '.result.client'",
+		Args:          cobra.NoArgs,
+		SilenceUsage:  true,
+		SilenceErrors: true,
+		RunE: func(cmd *cobra.Command, _ []string) error {
+			return runClientGet(cmd, targetName, clientUUID, jsonOut, backplaneOverride)
+		},
+	}
+	cmd.Flags().StringVar(&targetName, "target", "",
+		"target slug to dispatch against (required)")
+	cmd.Flags().StringVar(&clientUUID, "id", "",
+		"the client's internal UUID (from `meho keycloak client list`) (required)")
+	cmd.Flags().BoolVar(&jsonOut, "json", false,
+		"emit the full OperationResult envelope as JSON")
+	cmd.Flags().StringVar(&backplaneOverride, "backplane", "",
+		"backplane URL (defaults to the URL from the most recent `meho login`)")
+	if err := cmd.MarkFlagRequired("id"); err != nil {
+		panic(err) // programmer error: the flag is defined directly above
+	}
+	return cmd
+}
+
+func runClientGet(
+	cmd *cobra.Command,
+	targetName, clientUUID string,
+	jsonOut bool,
+	backplaneOverride string,
+) error {
+	backplaneURL, err := resolveBackplane(backplaneOverride)
+	if err != nil {
+		return output.RenderError(cmd.ErrOrStderr(), classifyBackplaneError(err), jsonOut)
+	}
+	params := map[string]any{"id": clientUUID}
+	r, err := dispatchOp(cmd.Context(), backplaneURL, "keycloak.client.get", targetName, params)
+	if err != nil {
+		return renderRequestError(cmd, backplaneURL, err, jsonOut)
+	}
+	return renderCallResult(cmd, "keycloak.client.get", r, jsonOut, printClientGet)
+}
+
+func printClientGet(w io.Writer, r *CallResult) {
+	fmt.Fprintf(w, "%s keycloak.client.get — status=%s (%.0fms)\n",
+		ConnectorID, r.Status, r.DurationMs)
+	if r.Status != "ok" {
+		printErrorTrailer(w, r)
+		return
+	}
+	client, err := decodeWrappedObject(r.Result, "client")
+	if err != nil || client == nil {
+		fallbackResultRender(w, r)
+		return
+	}
+	fmt.Fprintf(w, "  clientId:      %s\n", stringField(client, "clientId"))
+	fmt.Fprintf(w, "  id:            %s\n", stringField(client, "id"))
+	fmt.Fprintf(w, "  enabled:       %t\n", boolField(client, "enabled"))
+	fmt.Fprintf(w, "  publicClient:  %t\n", boolField(client, "publicClient"))
+	printStringList(w, "redirectUris", client["redirectUris"])
+	printStringList(w, "webOrigins", client["webOrigins"])
+	if mappers, ok := client["protocolMappers"].([]any); ok && len(mappers) > 0 {
+		names := make([]string, 0, len(mappers))
+		for _, m := range mappers {
+			if md, ok := m.(map[string]any); ok {
+				names = append(names, stringField(md, "name"))
+			}
+		}
+		fmt.Fprintf(w, "  protocolMappers: %s\n", strings.Join(names, ", "))
+	}
+}
+
+// printStringList renders a JSON array of strings under a label,
+// skipping the line entirely when the value is absent or empty.
+func printStringList(w io.Writer, label string, v any) {
+	arr, ok := v.([]any)
+	if !ok || len(arr) == 0 {
+		return
+	}
+	parts := make([]string, 0, len(arr))
+	for _, item := range arr {
+		if s, ok := item.(string); ok {
+			parts = append(parts, s)
+		}
+	}
+	fmt.Fprintf(w, "  %-14s %s\n", label+":", strings.Join(parts, ", "))
+}

--- a/cli/internal/cmd/keycloak/client_scope.go
+++ b/cli/internal/cmd/keycloak/client_scope.go
@@ -1,0 +1,107 @@
+// SPDX-License-Identifier: Apache-2.0
+// Copyright (c) 2026 evoila Group
+
+package keycloak
+
+import (
+	"fmt"
+	"io"
+
+	"github.com/spf13/cobra"
+
+	"github.com/evoila/meho/cli/internal/output"
+)
+
+// newClientScopeCmd returns the `meho keycloak client-scope` parent with
+// one sub-verb: `list` (keycloak.client_scope.list).
+func newClientScopeCmd() *cobra.Command {
+	cmd := &cobra.Command{
+		Use:          "client-scope",
+		Short:        "Keycloak client-scope sub-verbs (list)",
+		SilenceUsage: true,
+	}
+	cmd.AddCommand(newClientScopeListCmd())
+	return cmd
+}
+
+// newClientScopeListCmd returns the `meho keycloak client-scope list`
+// command.
+//
+// Maps to op_id `keycloak.client_scope.list`. GETs
+// /admin/realms/{realm}/client-scopes and returns the scopes as
+// {rows, total}. Each row is a ClientScopeRepresentation carrying the
+// scope's protocol mappers and attributes.
+func newClientScopeListCmd() *cobra.Command {
+	var (
+		targetName        string
+		jsonOut           bool
+		backplaneOverride string
+	)
+	cmd := &cobra.Command{
+		Use:   "list",
+		Short: "List Keycloak client scopes in the managed realm",
+		Long: "list dispatches keycloak.client_scope.list and renders the realm's\n" +
+			"client scopes (name / protocol / protocol-mapper count) — the\n" +
+			"reusable mapper/role bundles clients attach as default or\n" +
+			"optional scopes. --json emits the full OperationResult envelope.\n\n" +
+			"Exit codes: 0=ok, 1=error/denied, 2=auth_expired,\n" +
+			"3=unreachable, 4=unexpected.",
+		Example: "  meho keycloak client-scope list --target rdc-keycloak\n" +
+			"  meho keycloak client-scope list --target rdc-keycloak --json | jq '.result.rows[].name'",
+		Args:          cobra.NoArgs,
+		SilenceUsage:  true,
+		SilenceErrors: true,
+		RunE: func(cmd *cobra.Command, _ []string) error {
+			return runClientScopeList(cmd, targetName, jsonOut, backplaneOverride)
+		},
+	}
+	cmd.Flags().StringVar(&targetName, "target", "",
+		"target slug to dispatch against (required)")
+	cmd.Flags().BoolVar(&jsonOut, "json", false,
+		"emit the full OperationResult envelope as JSON")
+	cmd.Flags().StringVar(&backplaneOverride, "backplane", "",
+		"backplane URL (defaults to the URL from the most recent `meho login`)")
+	return cmd
+}
+
+func runClientScopeList(
+	cmd *cobra.Command,
+	targetName string,
+	jsonOut bool,
+	backplaneOverride string,
+) error {
+	backplaneURL, err := resolveBackplane(backplaneOverride)
+	if err != nil {
+		return output.RenderError(cmd.ErrOrStderr(), classifyBackplaneError(err), jsonOut)
+	}
+	r, err := dispatchOp(cmd.Context(), backplaneURL, "keycloak.client_scope.list", targetName, nil)
+	if err != nil {
+		return renderRequestError(cmd, backplaneURL, err, jsonOut)
+	}
+	return renderCallResult(cmd, "keycloak.client_scope.list", r, jsonOut, printClientScopeList)
+}
+
+func printClientScopeList(w io.Writer, r *CallResult) {
+	fmt.Fprintf(w, "%s keycloak.client_scope.list — status=%s (%.0fms)\n",
+		ConnectorID, r.Status, r.DurationMs)
+	if r.Status != "ok" {
+		printErrorTrailer(w, r)
+		return
+	}
+	rows, total, err := decodeRowsResult(r.Result)
+	if err != nil || rows == nil {
+		fallbackResultRender(w, r)
+		return
+	}
+	fmt.Fprintf(w, "  %-30s %-18s %s\n", "NAME", "PROTOCOL", "MAPPERS")
+	for _, row := range rows {
+		name := truncate(stringField(row, "name"), 30)
+		protocol := stringField(row, "protocol")
+		mapperCount := 0
+		if mappers, ok := row["protocolMappers"].([]any); ok {
+			mapperCount = len(mappers)
+		}
+		fmt.Fprintf(w, "  %-30s %-18s %d\n", name, protocol, mapperCount)
+	}
+	fmt.Fprintf(w, "  (%d client scopes)\n", total)
+}

--- a/cli/internal/cmd/keycloak/dispatch.go
+++ b/cli/internal/cmd/keycloak/dispatch.go
@@ -1,0 +1,127 @@
+// SPDX-License-Identifier: Apache-2.0
+// Copyright (c) 2026 evoila Group
+
+package keycloak
+
+import (
+	"context"
+	"encoding/json"
+	"fmt"
+	"io"
+
+	"github.com/spf13/cobra"
+
+	"github.com/evoila/meho/cli/internal/dispatch"
+)
+
+// Aliases + binding to the shared dispatch core (cli/internal/dispatch).
+// The keycloak verb tree is authored against the shared
+// dispatch.Connector pattern G0.12-T16 #1274 established (matching
+// pfsense / gcloud / bind9 / k8s): the authed transport (lazy
+// *api.AuthedClient over the generated typed surface) lives inside
+// dispatch.Connector itself.
+type (
+	// CallResult is the decoded OperationResult envelope.
+	CallResult = dispatch.CallResult
+	// callRequestBody is the on-the-wire OperationCall body (asserted by tests).
+	callRequestBody = dispatch.CallRequestBody
+)
+
+// conn binds this package's pre-baked connector_id to the shared
+// dispatch core.
+var conn = dispatch.New(ConnectorID)
+
+// dispatchOp is a thin wrapper around conn.Call kept so the per-verb
+// files call the unqualified name they were authored against.
+func dispatchOp(
+	ctx context.Context,
+	backplaneURL, opID, targetSlug string,
+	params map[string]any,
+) (*CallResult, error) {
+	return conn.Call(ctx, backplaneURL, opID, targetSlug, params)
+}
+
+// renderCallResult is a thin wrapper around conn.Render for the same
+// reason as dispatchOp above.
+func renderCallResult(
+	cmd *cobra.Command,
+	opID string,
+	r *CallResult,
+	jsonOut bool,
+	prettyPrinter func(w io.Writer, r *CallResult),
+) error {
+	return conn.Render(cmd, opID, r, jsonOut, prettyPrinter)
+}
+
+// printErrorTrailer surfaces the dispatcher error + extras envelope.
+// Used by the per-verb pretty-printers' non-ok branch.
+func printErrorTrailer(w io.Writer, r *CallResult) {
+	if r.Error != nil && *r.Error != "" {
+		fmt.Fprintf(w, "meho: connector error: %s\n", *r.Error)
+	} else {
+		fmt.Fprintf(w, "meho: connector status=%s\n", r.Status)
+	}
+	if len(r.Extras) > 0 && string(r.Extras) != "null" {
+		fmt.Fprintln(w, "extras:")
+		pretty, err := dispatch.PrettyJSON(r.Extras)
+		if err == nil {
+			fmt.Fprintln(w, pretty)
+		} else {
+			fmt.Fprintln(w, string(r.Extras))
+		}
+	}
+}
+
+// fallbackResultRender dumps the result envelope verbatim when the
+// typed per-verb decode fails.
+func fallbackResultRender(w io.Writer, r *CallResult) {
+	if len(r.Result) == 0 || string(r.Result) == "null" {
+		return
+	}
+	pretty, err := dispatch.PrettyJSON(r.Result)
+	if err == nil {
+		fmt.Fprintln(w, pretty)
+		return
+	}
+	fmt.Fprintln(w, string(r.Result))
+}
+
+// decodeRowsResult decodes the canonical `{"rows": [...], "total": N}`
+// envelope the set-shaped keycloak read ops return (client.list,
+// client_scope.list, user.list).
+func decodeRowsResult(raw json.RawMessage) ([]map[string]any, int, error) {
+	if len(raw) == 0 || string(raw) == "null" {
+		return nil, 0, nil
+	}
+	var envelope struct {
+		Rows  []map[string]any `json:"rows"`
+		Total int              `json:"total"`
+	}
+	if err := json.Unmarshal(raw, &envelope); err != nil {
+		return nil, 0, fmt.Errorf("decode rows: %w", err)
+	}
+	return envelope.Rows, envelope.Total, nil
+}
+
+// decodeWrappedObject decodes a single-key object envelope where the op
+// nests its payload under `key` (realm.get → {"realm": {...}},
+// client.get → {"client": {...}}, role_mapping.get →
+// {"role_mappings": {...}}). Returns the inner object.
+func decodeWrappedObject(raw json.RawMessage, key string) (map[string]any, error) {
+	if len(raw) == 0 || string(raw) == "null" {
+		return nil, nil
+	}
+	var envelope map[string]json.RawMessage
+	if err := json.Unmarshal(raw, &envelope); err != nil {
+		return nil, fmt.Errorf("decode envelope: %w", err)
+	}
+	inner, ok := envelope[key]
+	if !ok || len(inner) == 0 || string(inner) == "null" {
+		return nil, nil
+	}
+	var obj map[string]any
+	if err := json.Unmarshal(inner, &obj); err != nil {
+		return nil, fmt.Errorf("decode %s: %w", key, err)
+	}
+	return obj, nil
+}

--- a/cli/internal/cmd/keycloak/keycloak.go
+++ b/cli/internal/cmd/keycloak/keycloak.go
@@ -1,0 +1,244 @@
+// SPDX-License-Identifier: Apache-2.0
+// Copyright (c) 2026 evoila Group
+
+// Package keycloak hosts the cobra commands under `meho keycloak ...`
+// for G3.13-T3 (#1395) of Initiative #1388. The verb tree is a thin
+// Cobra layer over `POST /api/v1/operations/call`, identical pattern to
+// `meho pfsense ...` (#850) and `meho gcloud ...` (#851), pre-baking the
+// `connector_id="keycloak-admin-26.x"` argument so operators don't type
+// the connector ID on every dispatch:
+//
+//   - `meho keycloak realm get [--target T]`         — keycloak.realm.get
+//   - `meho keycloak client list [--client-id C] [--max N] [--target T]` — keycloak.client.list
+//   - `meho keycloak client get --id UUID [--target T]` — keycloak.client.get
+//   - `meho keycloak client-scope list [--target T]`  — keycloak.client_scope.list
+//   - `meho keycloak user list [--username U] [--max N] [--target T]` — keycloak.user.list
+//   - `meho keycloak role-mapping get --id UUID [--target T]` — keycloak.role_mapping.get
+//
+// Every verb is a thin Cobra command that POSTs to
+// `/api/v1/operations/call` with a pre-baked connector_id. No new
+// backend code; no new HTTP routes — the CLI alias verbs are pure
+// operator ergonomics over the existing dispatcher surface (per
+// CLAUDE.md postulate 5: agent surface stays narrow-waist meta-tools;
+// vendor-specific tooling lives only in the CLI).
+//
+// The `meho keycloak` surface is operator-only — the MCP / agent
+// surface continues to reach Keycloak ops via the narrow-waist
+// search_operations + call_operation meta-tools. The connector
+// authenticates to the Keycloak Admin REST API with a separate Vault-
+// sourced admin credential (the admin-vs-operator split documented in
+// docs/cross-repo/keycloak-onboarding.md); the dispatch path the CLI
+// rides over is the same admin-token Bearer path the agent surface uses.
+//
+// This is distinct from the `meho admin keycloak ...` deployer-onramp
+// subtree (#791), which bootstraps Keycloak clients during initial
+// deployment; this tree reads the managed realm's live configuration
+// through the registered `keycloak-admin-26.x` connector.
+package keycloak
+
+import (
+	"errors"
+	"fmt"
+	"net/url"
+	"strings"
+
+	"github.com/spf13/cobra"
+
+	"github.com/evoila/meho/cli/internal/api"
+	"github.com/evoila/meho/cli/internal/auth"
+	"github.com/evoila/meho/cli/internal/dispatch"
+	"github.com/evoila/meho/cli/internal/output"
+)
+
+// ConnectorID is the pre-baked connector_id every verb under
+// `meho keycloak ...` dispatches against. Exported so the per-verb
+// files and tests reference the same constant; a future re-versioning
+// (keycloak-admin-27.x) lands as a single line edit here.
+//
+// The id encodes the registry-v2 natural key triple
+// "(product="keycloak", version="26.x", impl_id="keycloak-admin")" per
+// the connector_id parser convention in
+// `backend/src/meho_backplane/operations/_lookup.py::parse_connector_id`:
+// the trailing `-26.x` segment is the version; everything before is the
+// impl_id (`keycloak-admin`); the product is the first hyphen segment of
+// the impl_id (`keycloak`).
+const ConnectorID = "keycloak-admin-26.x"
+
+// NewRootCmd returns the `meho keycloak` parent command. cmd/root.go
+// grafts this onto the top-level command tree alongside the other
+// built-in verb trees. The parent itself takes no args and prints its
+// own help; every piece of behaviour lives in the per-subcommand RunE
+// closures.
+//
+// Sub-tree layout follows the issue #1395 verb table:
+//   - `keycloak realm get`           — flat sub-tree
+//   - `keycloak client <list|get>`   — sub-tree
+//   - `keycloak client-scope list`   — sub-tree
+//   - `keycloak user list`           — sub-tree
+//   - `keycloak role-mapping get`    — sub-tree
+func NewRootCmd() *cobra.Command {
+	cmd := &cobra.Command{
+		Use:   "keycloak",
+		Short: "Pre-scoped CLI verbs for the keycloak-admin-26.x connector",
+		Long: "keycloak is the operator-facing verb tree for the\n" +
+			"keycloak-admin-26.x connector (registry triple\n" +
+			"(product=\"keycloak\", version=\"26.x\", impl_id=\"keycloak-admin\")).\n" +
+			"Each verb dispatches through POST /api/v1/operations/call with\n" +
+			"connector_id=\"keycloak-admin-26.x\" pre-baked so operators don't\n" +
+			"type the connector ID on every command. All shipped ops are\n" +
+			"read-only; the write surface is the deferred approval-gated T4\n" +
+			"follow-up (#1406).\n\n" +
+			"Per CLAUDE.md postulate 5, these alias verbs are operator-only\n" +
+			"ergonomics — they are not mirrored on the MCP surface. Agents\n" +
+			"continue to use search_operations / call_operation against the\n" +
+			"narrow-waist meta-tool contract.\n\n" +
+			"Auth note: the connector authenticates to the Keycloak Admin REST\n" +
+			"API with a Vault-sourced admin credential, NOT the operator's\n" +
+			"OIDC token (the admin-vs-operator split — see\n" +
+			"docs/cross-repo/keycloak-onboarding.md). The operator's session\n" +
+			"only authorises the Vault read that backs the admin-token mint.",
+		SilenceUsage: true,
+	}
+	cmd.AddCommand(newRealmCmd())
+	cmd.AddCommand(newClientCmd())
+	cmd.AddCommand(newClientScopeCmd())
+	cmd.AddCommand(newUserCmd())
+	cmd.AddCommand(newRoleMappingCmd())
+	return cmd
+}
+
+// errNoBackplaneConfigured wraps auth.ErrConfigNotFound so callers can
+// distinguish "operator never logged in" (→ auth_expired exit code 2 —
+// the right fix is `meho login`) from URL-parse failures (→ unexpected
+// exit code 4 — the right fix is correcting argv).
+type errNoBackplaneConfigured struct{ inner error }
+
+func (e *errNoBackplaneConfigured) Error() string {
+	return "no backplane URL configured; run `meho login <url>` first or pass --backplane <url>"
+}
+func (e *errNoBackplaneConfigured) Unwrap() error { return e.inner }
+
+// resolveBackplane mirrors the pfsense / gcloud sibling helpers:
+// --backplane override flag wins; otherwise read the URL the most
+// recent `meho login` wrote to config.json.
+func resolveBackplane(override string) (string, error) {
+	if override != "" {
+		return normaliseURL(override)
+	}
+	cfg, err := auth.LoadConfig()
+	if err != nil {
+		if errors.Is(err, auth.ErrConfigNotFound) {
+			return "", &errNoBackplaneConfigured{inner: err}
+		}
+		return "", err
+	}
+	return normaliseURL(cfg.BackplaneURL)
+}
+
+// classifyBackplaneError maps a resolveBackplane error to the right
+// output.StructuredError category. Identical routing to the pfsense /
+// gcloud siblings: missing-config → auth_expired; everything else →
+// unexpected.
+func classifyBackplaneError(err error) *output.StructuredError {
+	if errors.Is(err, auth.ErrConfigNotFound) {
+		return output.AuthExpired(err.Error())
+	}
+	return output.Unexpected(err.Error())
+}
+
+// normaliseURL strips trailing slashes + parses the URL to fail fast on
+// garbage input. Mirrors the pfsense / gcloud siblings.
+func normaliseURL(s string) (string, error) {
+	trimmed := strings.TrimRight(strings.TrimSpace(s), "/")
+	if trimmed == "" {
+		return "", errors.New("backplane URL is empty")
+	}
+	u, err := url.ParseRequestURI(trimmed)
+	if err != nil {
+		return "", fmt.Errorf("invalid backplane URL %q: %w", s, err)
+	}
+	if u.Host == "" {
+		return "", fmt.Errorf("backplane URL %q has no host", s)
+	}
+	u.Path = strings.TrimRight(u.Path, "/")
+	return u.String(), nil
+}
+
+// renderRequestError translates an error from the dispatch core into
+// the right output.RenderError category. Same classification ladder as
+// the pfsense / gcloud siblings: token-not-found / no-refresh-token →
+// auth_expired; HTTP-error → unexpected; transport → unreachable.
+func renderRequestError(
+	cmd *cobra.Command,
+	backplaneURL string,
+	err error,
+	jsonOut bool,
+) error {
+	if api.IsTokenNotFound(err) {
+		return output.RenderError(cmd.ErrOrStderr(),
+			output.AuthExpired(fmt.Sprintf(
+				"no stored credentials for %s; run `meho login %s`",
+				backplaneURL, backplaneURL,
+			)),
+			jsonOut,
+		)
+	}
+	if api.IsNoRefreshToken(err) {
+		return output.RenderError(cmd.ErrOrStderr(),
+			output.AuthExpired(fmt.Sprintf(
+				"stored token rejected and no refresh_token present; run `meho login %s`",
+				backplaneURL,
+			)),
+			jsonOut,
+		)
+	}
+	var apiErr *dispatch.APIResponseError
+	if errors.As(err, &apiErr) {
+		return output.RenderError(cmd.ErrOrStderr(),
+			output.Unexpected(fmt.Sprintf("call %s: HTTP %d: %s",
+				backplaneURL, apiErr.StatusCode, apiErr.Body)),
+			jsonOut,
+		)
+	}
+	return output.RenderError(cmd.ErrOrStderr(),
+		output.Unreachable(fmt.Sprintf("call %s: %v", backplaneURL, err)),
+		jsonOut,
+	)
+}
+
+// truncate cuts s to maxLen runes, appending an ellipsis when
+// truncation happened. Operates on runes (not bytes) so multi-byte
+// UTF-8 survives without producing an invalid UTF-8 cut. Same
+// implementation as the pfsense / gcloud siblings.
+func truncate(s string, maxLen int) string {
+	if maxLen < 1 {
+		return ""
+	}
+	runes := []rune(s)
+	if len(runes) <= maxLen {
+		return s
+	}
+	return string(runes[:maxLen-1]) + "…"
+}
+
+// stringField pulls a string field from a row entry, returning empty
+// string when the field is missing or wrong type.
+func stringField(e map[string]any, key string) string {
+	v, ok := e[key]
+	if !ok {
+		return ""
+	}
+	if s, ok := v.(string); ok {
+		return s
+	}
+	return ""
+}
+
+// boolField pulls a bool field from a row entry, defaulting to false
+// when the field is missing or wrong type.
+func boolField(e map[string]any, key string) bool {
+	if v, ok := e[key].(bool); ok {
+		return v
+	}
+	return false
+}

--- a/cli/internal/cmd/keycloak/keycloak_test.go
+++ b/cli/internal/cmd/keycloak/keycloak_test.go
@@ -1,0 +1,404 @@
+// SPDX-License-Identifier: Apache-2.0
+// Copyright (c) 2026 evoila Group
+
+package keycloak
+
+import (
+	"context"
+	"encoding/json"
+	"errors"
+	"net/http"
+	"net/http/httptest"
+	"os"
+	"path/filepath"
+	"strings"
+	"testing"
+
+	"github.com/evoila/meho/cli/internal/auth"
+)
+
+// ---------- helper tests (pure-function) ----------
+
+// TestConnectorIDIsFrozen pins the pre-baked connector_id constant.
+// Every verb file dispatches against this value; a regression here
+// would silently rebind every alias verb to a different connector.
+// The id encodes the registry-v2 natural key triple
+// `("keycloak", "26.x", "keycloak-admin")` per parse_connector_id's
+// grammar.
+func TestConnectorIDIsFrozen(t *testing.T) {
+	if ConnectorID != "keycloak-admin-26.x" {
+		t.Fatalf("ConnectorID drifted: got %q want %q", ConnectorID, "keycloak-admin-26.x")
+	}
+}
+
+func TestTruncatePassthroughAndCut(t *testing.T) {
+	tests := []struct {
+		name   string
+		in     string
+		maxLen int
+		want   string
+	}{
+		{"within budget", "abc", 5, "abc"},
+		{"over budget ascii", "abcdef", 4, "abc…"},
+		{"multi-byte safe", "café world", 5, "café…"},
+		{"zero budget", "x", 0, ""},
+	}
+	for _, tt := range tests {
+		if got := truncate(tt.in, tt.maxLen); got != tt.want {
+			t.Errorf("%s: truncate(%q, %d) = %q; want %q", tt.name, tt.in, tt.maxLen, got, tt.want)
+		}
+	}
+}
+
+func TestNormaliseURLBasic(t *testing.T) {
+	got, err := normaliseURL("https://meho.test/")
+	if err != nil {
+		t.Fatalf("normaliseURL: %v", err)
+	}
+	if got != "https://meho.test" {
+		t.Fatalf("expected trailing slash stripped; got %q", got)
+	}
+	if _, err := normaliseURL("   "); err == nil || !strings.Contains(err.Error(), "empty") {
+		t.Fatalf("empty should reject; got %v", err)
+	}
+}
+
+func TestClassifyBackplaneErrorRoutesByCause(t *testing.T) {
+	wrapped := &errNoBackplaneConfigured{inner: auth.ErrConfigNotFound}
+	se := classifyBackplaneError(wrapped)
+	if se == nil || se.Code != "auth_expired" {
+		t.Fatalf("wrapped ErrConfigNotFound should classify as auth_expired; got %+v", se)
+	}
+	se = classifyBackplaneError(errors.New("parse failure"))
+	if se == nil || se.Code != "unexpected_response" {
+		t.Fatalf("parse failure should classify as unexpected_response; got %+v", se)
+	}
+}
+
+func TestJoinOrNone(t *testing.T) {
+	if got := joinOrNone(nil); got != "(none)" {
+		t.Fatalf("empty should render (none); got %q", got)
+	}
+	if got := joinOrNone([]string{"a", "b"}); got != "a, b" {
+		t.Fatalf("join: got %q", got)
+	}
+}
+
+func TestRoleNamesExtractsNameField(t *testing.T) {
+	raw := []any{
+		map[string]any{"id": "x", "name": "tenant_admin"},
+		map[string]any{"id": "y", "name": "view-realm"},
+		map[string]any{"id": "z"}, // missing name — skipped
+	}
+	got := roleNames(raw)
+	if len(got) != 2 || got[0] != "tenant_admin" || got[1] != "view-realm" {
+		t.Fatalf("roleNames: %+v", got)
+	}
+	if roleNames("not-an-array") != nil {
+		t.Fatalf("roleNames of non-array should be nil")
+	}
+}
+
+// ---------- decode helpers ----------
+
+func TestDecodeRowsResultHappy(t *testing.T) {
+	raw := json.RawMessage(`{"rows":[{"clientId":"meho-backplane","id":"uuid-1"}],"total":1}`)
+	rows, total, err := decodeRowsResult(raw)
+	if err != nil {
+		t.Fatalf("decodeRowsResult: %v", err)
+	}
+	if total != 1 || len(rows) != 1 || rows[0]["clientId"] != "meho-backplane" {
+		t.Fatalf("decoded: rows=%+v total=%d", rows, total)
+	}
+}
+
+func TestDecodeRowsResultNullAndEmpty(t *testing.T) {
+	for _, raw := range []json.RawMessage{nil, json.RawMessage(`null`)} {
+		rows, total, err := decodeRowsResult(raw)
+		if err != nil {
+			t.Fatalf("decodeRowsResult empty: %v", err)
+		}
+		if rows != nil || total != 0 {
+			t.Fatalf("empty should be nil rows / 0 total; got %+v / %d", rows, total)
+		}
+	}
+}
+
+func TestDecodeWrappedObject(t *testing.T) {
+	raw := json.RawMessage(`{"realm":{"realm":"evba","enabled":true}}`)
+	obj, err := decodeWrappedObject(raw, "realm")
+	if err != nil {
+		t.Fatalf("decodeWrappedObject: %v", err)
+	}
+	if obj["realm"] != "evba" || obj["enabled"] != true {
+		t.Fatalf("decoded: %+v", obj)
+	}
+	// Missing key → nil, no error.
+	miss, err := decodeWrappedObject(raw, "client")
+	if err != nil || miss != nil {
+		t.Fatalf("missing key should be nil/nil; got %+v / %v", miss, err)
+	}
+}
+
+// ---------- dispatcher wire-shape tests ----------
+
+type mockHandler = http.HandlerFunc
+
+func mockBackplane(t *testing.T, routes map[string]mockHandler) *httptest.Server {
+	t.Helper()
+	return httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		key := r.Method + " " + r.URL.Path
+		if h, ok := routes[key]; ok {
+			h(w, r)
+			return
+		}
+		if h, ok := routes[""]; ok {
+			h(w, r)
+			return
+		}
+		t.Errorf("mockBackplane: unhandled route %s", key)
+		w.WriteHeader(404)
+	}))
+}
+
+func writeJSON(t *testing.T, w http.ResponseWriter, status int, body any) {
+	t.Helper()
+	raw, err := json.Marshal(body)
+	if err != nil {
+		t.Errorf("writeJSON marshal: %v", err)
+		w.WriteHeader(500)
+		return
+	}
+	w.Header().Set("Content-Type", "application/json")
+	w.WriteHeader(status)
+	if _, err := w.Write(raw); err != nil {
+		t.Errorf("writeJSON write: %v", err)
+	}
+}
+
+func primeToken(t *testing.T, backplaneURL string) {
+	t.Helper()
+	dir := t.TempDir()
+	t.Setenv("XDG_CONFIG_HOME", dir)
+	cfg := filepath.Join(dir, "meho", "config.json")
+	if err := os.MkdirAll(filepath.Dir(cfg), 0o700); err != nil {
+		t.Fatalf("mkdir config: %v", err)
+	}
+	cfgBlob, _ := json.Marshal(map[string]string{"backplane_url": backplaneURL})
+	if err := os.WriteFile(cfg, cfgBlob, 0o600); err != nil {
+		t.Fatalf("write config: %v", err)
+	}
+	service, user := auth.KeyForBackplane(backplaneURL)
+	store, err := auth.NewTokenStore()
+	if err != nil {
+		t.Fatalf("NewTokenStore: %v", err)
+	}
+	if err := store.Save(service, user, auth.StoredToken{
+		AccessToken:  "test-bearer",
+		BackplaneURL: backplaneURL,
+	}); err != nil {
+		t.Fatalf("store.Save: %v", err)
+	}
+}
+
+// TestDispatchOpBakesConnectorID — every verb dispatches with
+// connector_id="keycloak-admin-26.x" pre-baked.
+func TestDispatchOpBakesConnectorID(t *testing.T) {
+	srv := mockBackplane(t, map[string]mockHandler{
+		"POST /api/v1/operations/call": func(w http.ResponseWriter, r *http.Request) {
+			var body callRequestBody
+			if err := json.NewDecoder(r.Body).Decode(&body); err != nil {
+				t.Errorf("decode body: %v", err)
+				w.WriteHeader(400)
+				return
+			}
+			if body.ConnectorID != "keycloak-admin-26.x" {
+				t.Errorf("connector_id: got %q want keycloak-admin-26.x", body.ConnectorID)
+			}
+			if body.OpID != "keycloak.realm.get" {
+				t.Errorf("op_id: got %q want keycloak.realm.get", body.OpID)
+			}
+			writeJSON(t, w, 200, CallResult{
+				Status: "ok",
+				OpID:   "keycloak.realm.get",
+				Result: json.RawMessage(`{"realm":{"realm":"evba"}}`),
+			})
+		},
+	})
+	defer srv.Close()
+	primeToken(t, srv.URL)
+
+	r, err := dispatchOp(context.Background(), srv.URL, "keycloak.realm.get", "rdc-keycloak", nil)
+	if err != nil {
+		t.Fatalf("dispatchOp: %v", err)
+	}
+	if r.Status != "ok" {
+		t.Fatalf("dispatch status: %s", r.Status)
+	}
+}
+
+// TestDispatchOpTargetSlugWrappedAsName — a non-empty target slug must
+// surface as `{"name": "<slug>"}` so the dispatcher's resolver pulls it
+// under the canonical TargetRef shape.
+func TestDispatchOpTargetSlugWrappedAsName(t *testing.T) {
+	srv := mockBackplane(t, map[string]mockHandler{
+		"POST /api/v1/operations/call": func(w http.ResponseWriter, r *http.Request) {
+			var raw map[string]any
+			if err := json.NewDecoder(r.Body).Decode(&raw); err != nil {
+				t.Errorf("decode: %v", err)
+				w.WriteHeader(400)
+				return
+			}
+			tgt, _ := raw["target"].(map[string]any)
+			if tgt == nil || tgt["name"] != "rdc-keycloak" {
+				t.Errorf("target should wrap slug as {name: ...}; got %v", raw["target"])
+			}
+			writeJSON(t, w, 200, CallResult{Status: "ok", OpID: "keycloak.realm.get"})
+		},
+	})
+	defer srv.Close()
+	primeToken(t, srv.URL)
+
+	if _, err := dispatchOp(context.Background(), srv.URL, "keycloak.realm.get", "rdc-keycloak", nil); err != nil {
+		t.Fatalf("dispatchOp: %v", err)
+	}
+}
+
+// TestDispatchOpForwardsParams — the client.get / role_mapping.get verbs
+// forward an `id` param; client.list forwards client_id + max. Assert
+// the param map reaches the wire unchanged.
+func TestDispatchOpForwardsParams(t *testing.T) {
+	srv := mockBackplane(t, map[string]mockHandler{
+		"POST /api/v1/operations/call": func(w http.ResponseWriter, r *http.Request) {
+			var body callRequestBody
+			if err := json.NewDecoder(r.Body).Decode(&body); err != nil {
+				t.Errorf("decode body: %v", err)
+				w.WriteHeader(400)
+				return
+			}
+			if body.Params["id"] != "client-uuid-1" {
+				t.Errorf("params.id: got %v want client-uuid-1", body.Params["id"])
+			}
+			writeJSON(t, w, 200, CallResult{Status: "ok", OpID: "keycloak.client.get",
+				Result: json.RawMessage(`{"client":{"clientId":"meho-backplane"}}`)})
+		},
+	})
+	defer srv.Close()
+	primeToken(t, srv.URL)
+
+	r, err := dispatchOp(context.Background(), srv.URL, "keycloak.client.get", "rdc-keycloak",
+		map[string]any{"id": "client-uuid-1"})
+	if err != nil {
+		t.Fatalf("dispatchOp: %v", err)
+	}
+	if r.Status != "ok" {
+		t.Fatalf("dispatch status: %s", r.Status)
+	}
+}
+
+// TestAllOpsUseCanonicalOpIDs — pin the 6 canonical keycloak op_ids the
+// CLI dispatches. Any drift here surfaces as a test failure rather than
+// a silent 404 from the backplane op registry.
+func TestAllOpsUseCanonicalOpIDs(t *testing.T) {
+	expectedOps := []string{
+		"keycloak.realm.get",
+		"keycloak.client.list",
+		"keycloak.client.get",
+		"keycloak.client_scope.list",
+		"keycloak.user.list",
+		"keycloak.role_mapping.get",
+	}
+
+	dispatched := make(map[string]bool)
+	srv := mockBackplane(t, map[string]mockHandler{
+		"POST /api/v1/operations/call": func(w http.ResponseWriter, r *http.Request) {
+			var body callRequestBody
+			if err := json.NewDecoder(r.Body).Decode(&body); err != nil {
+				t.Errorf("decode body: %v", err)
+				w.WriteHeader(400)
+				return
+			}
+			dispatched[body.OpID] = true
+			writeJSON(t, w, 200, CallResult{Status: "ok", OpID: body.OpID,
+				Result: json.RawMessage(`{"rows":[],"total":0}`)})
+		},
+	})
+	defer srv.Close()
+	primeToken(t, srv.URL)
+
+	for _, opID := range expectedOps {
+		if _, err := dispatchOp(context.Background(), srv.URL, opID, "rdc-keycloak", nil); err != nil {
+			t.Fatalf("dispatchOp %s: %v", opID, err)
+		}
+	}
+	for _, opID := range expectedOps {
+		if !dispatched[opID] {
+			t.Errorf("op_id %q was not dispatched", opID)
+		}
+	}
+}
+
+// ---------- command-tree shape tests ----------
+
+// TestNewRootCmdHasExpectedSubcommands — the root command must expose
+// the expected verb names so `meho keycloak --help` lists them.
+func TestNewRootCmdHasExpectedSubcommands(t *testing.T) {
+	root := NewRootCmd()
+	want := map[string]bool{
+		"realm":        false,
+		"client":       false,
+		"client-scope": false,
+		"user":         false,
+		"role-mapping": false,
+	}
+	for _, sub := range root.Commands() {
+		want[sub.Name()] = true
+	}
+	for name, found := range want {
+		if !found {
+			t.Errorf("root command is missing subcommand %q", name)
+		}
+	}
+}
+
+func TestClientHasListAndGet(t *testing.T) {
+	c := newClientCmd()
+	subs := make(map[string]bool)
+	for _, s := range c.Commands() {
+		subs[s.Name()] = true
+	}
+	for _, name := range []string{"list", "get"} {
+		if !subs[name] {
+			t.Errorf("client is missing sub-verb %q", name)
+		}
+	}
+}
+
+// TestClientGetRequiresID — `client get` must mark --id required so a
+// missing UUID fails before dispatch rather than 404ing at the backplane.
+func TestClientGetRequiresID(t *testing.T) {
+	cmd := newClientGetCmd()
+	flag := cmd.Flags().Lookup("id")
+	if flag == nil {
+		t.Fatalf("client get is missing the --id flag")
+	}
+	if ann := flag.Annotations[cobraRequiredAnnotation]; len(ann) == 0 || ann[0] != "true" {
+		t.Errorf("client get --id should be marked required; annotations=%v", flag.Annotations)
+	}
+}
+
+func TestRoleMappingGetRequiresID(t *testing.T) {
+	cmd := newRoleMappingGetCmd()
+	flag := cmd.Flags().Lookup("id")
+	if flag == nil {
+		t.Fatalf("role-mapping get is missing the --id flag")
+	}
+	if ann := flag.Annotations[cobraRequiredAnnotation]; len(ann) == 0 || ann[0] != "true" {
+		t.Errorf("role-mapping get --id should be marked required; annotations=%v", flag.Annotations)
+	}
+}
+
+// cobraRequiredAnnotation is the pflag annotation key cobra sets via
+// MarkFlagRequired. Pinned here so the required-flag tests don't import
+// cobra internals.
+const cobraRequiredAnnotation = "cobra_annotation_bash_completion_one_required_flag"

--- a/cli/internal/cmd/keycloak/realm.go
+++ b/cli/internal/cmd/keycloak/realm.go
@@ -1,0 +1,96 @@
+// SPDX-License-Identifier: Apache-2.0
+// Copyright (c) 2026 evoila Group
+
+package keycloak
+
+import (
+	"fmt"
+	"io"
+
+	"github.com/spf13/cobra"
+
+	"github.com/evoila/meho/cli/internal/output"
+)
+
+// newRealmCmd returns the `meho keycloak realm` parent with one
+// sub-verb: `get` (keycloak.realm.get).
+func newRealmCmd() *cobra.Command {
+	cmd := &cobra.Command{
+		Use:          "realm",
+		Short:        "Keycloak realm sub-verbs (get)",
+		SilenceUsage: true,
+	}
+	cmd.AddCommand(newRealmGetCmd())
+	return cmd
+}
+
+// newRealmGetCmd returns the `meho keycloak realm get` command.
+//
+// Maps to op_id `keycloak.realm.get`. GETs /admin/realms/{realm}
+// against the target's managed realm and returns the
+// RealmRepresentation (login settings, token lifespans, themes, SMTP,
+// realm-wide policy). Any nested secret is redacted.
+func newRealmGetCmd() *cobra.Command {
+	var (
+		targetName        string
+		jsonOut           bool
+		backplaneOverride string
+	)
+	cmd := &cobra.Command{
+		Use:   "get",
+		Short: "Read the managed realm's top-level configuration",
+		Long: "get dispatches keycloak.realm.get and renders the managed\n" +
+			"realm's top-level config (realm / enabled / sslRequired /\n" +
+			"loginTheme / token lifespans). Secrets are redacted by the\n" +
+			"connector. --json emits the full OperationResult envelope.\n\n" +
+			"Exit codes: 0=ok, 1=error/denied, 2=auth_expired,\n" +
+			"3=unreachable, 4=unexpected.",
+		Example: "  meho keycloak realm get --target rdc-keycloak\n" +
+			"  meho keycloak realm get --target rdc-keycloak --json | jq '.result.realm'",
+		Args:          cobra.NoArgs,
+		SilenceUsage:  true,
+		SilenceErrors: true,
+		RunE: func(cmd *cobra.Command, _ []string) error {
+			return runRealmGet(cmd, targetName, jsonOut, backplaneOverride)
+		},
+	}
+	cmd.Flags().StringVar(&targetName, "target", "",
+		"target slug to dispatch against (required)")
+	cmd.Flags().BoolVar(&jsonOut, "json", false,
+		"emit the full OperationResult envelope as JSON")
+	cmd.Flags().StringVar(&backplaneOverride, "backplane", "",
+		"backplane URL (defaults to the URL from the most recent `meho login`)")
+	return cmd
+}
+
+func runRealmGet(cmd *cobra.Command, targetName string, jsonOut bool, backplaneOverride string) error {
+	backplaneURL, err := resolveBackplane(backplaneOverride)
+	if err != nil {
+		return output.RenderError(cmd.ErrOrStderr(), classifyBackplaneError(err), jsonOut)
+	}
+	r, err := dispatchOp(cmd.Context(), backplaneURL, "keycloak.realm.get", targetName, nil)
+	if err != nil {
+		return renderRequestError(cmd, backplaneURL, err, jsonOut)
+	}
+	return renderCallResult(cmd, "keycloak.realm.get", r, jsonOut, printRealmGet)
+}
+
+func printRealmGet(w io.Writer, r *CallResult) {
+	fmt.Fprintf(w, "%s keycloak.realm.get — status=%s (%.0fms)\n", ConnectorID, r.Status, r.DurationMs)
+	if r.Status != "ok" {
+		printErrorTrailer(w, r)
+		return
+	}
+	realm, err := decodeWrappedObject(r.Result, "realm")
+	if err != nil || realm == nil {
+		fallbackResultRender(w, r)
+		return
+	}
+	for _, key := range []string{"realm", "enabled", "sslRequired", "loginTheme", "accessTokenLifespan"} {
+		v, ok := realm[key]
+		if !ok || v == nil {
+			continue
+		}
+		fmt.Fprintf(w, "  %-20s %v\n", key+":", v)
+	}
+}

--- a/cli/internal/cmd/keycloak/role_mapping.go
+++ b/cli/internal/cmd/keycloak/role_mapping.go
@@ -1,0 +1,148 @@
+// SPDX-License-Identifier: Apache-2.0
+// Copyright (c) 2026 evoila Group
+
+package keycloak
+
+import (
+	"fmt"
+	"io"
+	"strings"
+
+	"github.com/spf13/cobra"
+
+	"github.com/evoila/meho/cli/internal/output"
+)
+
+// newRoleMappingCmd returns the `meho keycloak role-mapping` parent with
+// one sub-verb: `get` (keycloak.role_mapping.get).
+func newRoleMappingCmd() *cobra.Command {
+	cmd := &cobra.Command{
+		Use:          "role-mapping",
+		Short:        "Keycloak role-mapping sub-verbs (get)",
+		SilenceUsage: true,
+	}
+	cmd.AddCommand(newRoleMappingGetCmd())
+	return cmd
+}
+
+// newRoleMappingGetCmd returns the `meho keycloak role-mapping get`
+// command.
+//
+// Maps to op_id `keycloak.role_mapping.get`. GETs
+// /admin/realms/{realm}/users/{id}/role-mappings where --id is the
+// user's internal UUID (from `keycloak user list`). Returns the
+// MappingsRepresentation: realmMappings (realm-level roles) and
+// clientMappings (per-client roles).
+func newRoleMappingGetCmd() *cobra.Command {
+	var (
+		targetName        string
+		userUUID          string
+		jsonOut           bool
+		backplaneOverride string
+	)
+	cmd := &cobra.Command{
+		Use:   "get",
+		Short: "Read a Keycloak user's realm + client role mappings by UUID",
+		Long: "get dispatches keycloak.role_mapping.get for the user whose\n" +
+			"internal UUID is --id (the `id` field from\n" +
+			"`meho keycloak user list`). Renders the realm-level role names\n" +
+			"and the per-client role names. --json emits the full\n" +
+			"OperationResult envelope.\n\n" +
+			"Exit codes: 0=ok, 1=error/denied, 2=auth_expired,\n" +
+			"3=unreachable, 4=unexpected.",
+		Example: "  meho keycloak role-mapping get --target rdc-keycloak --id 22222222-2222-2222-2222-222222222222\n" +
+			"  meho keycloak role-mapping get --target rdc-keycloak --id <uuid> --json | jq '.result.role_mappings'",
+		Args:          cobra.NoArgs,
+		SilenceUsage:  true,
+		SilenceErrors: true,
+		RunE: func(cmd *cobra.Command, _ []string) error {
+			return runRoleMappingGet(cmd, targetName, userUUID, jsonOut, backplaneOverride)
+		},
+	}
+	cmd.Flags().StringVar(&targetName, "target", "",
+		"target slug to dispatch against (required)")
+	cmd.Flags().StringVar(&userUUID, "id", "",
+		"the user's internal UUID (from `meho keycloak user list`) (required)")
+	cmd.Flags().BoolVar(&jsonOut, "json", false,
+		"emit the full OperationResult envelope as JSON")
+	cmd.Flags().StringVar(&backplaneOverride, "backplane", "",
+		"backplane URL (defaults to the URL from the most recent `meho login`)")
+	if err := cmd.MarkFlagRequired("id"); err != nil {
+		panic(err) // programmer error: the flag is defined directly above
+	}
+	return cmd
+}
+
+func runRoleMappingGet(
+	cmd *cobra.Command,
+	targetName, userUUID string,
+	jsonOut bool,
+	backplaneOverride string,
+) error {
+	backplaneURL, err := resolveBackplane(backplaneOverride)
+	if err != nil {
+		return output.RenderError(cmd.ErrOrStderr(), classifyBackplaneError(err), jsonOut)
+	}
+	params := map[string]any{"id": userUUID}
+	r, err := dispatchOp(cmd.Context(), backplaneURL, "keycloak.role_mapping.get", targetName, params)
+	if err != nil {
+		return renderRequestError(cmd, backplaneURL, err, jsonOut)
+	}
+	return renderCallResult(cmd, "keycloak.role_mapping.get", r, jsonOut, printRoleMappingGet)
+}
+
+func printRoleMappingGet(w io.Writer, r *CallResult) {
+	fmt.Fprintf(w, "%s keycloak.role_mapping.get — status=%s (%.0fms)\n",
+		ConnectorID, r.Status, r.DurationMs)
+	if r.Status != "ok" {
+		printErrorTrailer(w, r)
+		return
+	}
+	mappings, err := decodeWrappedObject(r.Result, "role_mappings")
+	if err != nil || mappings == nil {
+		fallbackResultRender(w, r)
+		return
+	}
+	realmRoles := roleNames(mappings["realmMappings"])
+	fmt.Fprintf(w, "  realm roles:   %s\n", joinOrNone(realmRoles))
+
+	if clientMappings, ok := mappings["clientMappings"].(map[string]any); ok && len(clientMappings) > 0 {
+		fmt.Fprintln(w, "  client roles:")
+		for client, raw := range clientMappings {
+			cm, ok := raw.(map[string]any)
+			if !ok {
+				continue
+			}
+			names := roleNames(cm["mappings"])
+			fmt.Fprintf(w, "    %-24s %s\n", client+":", joinOrNone(names))
+		}
+	} else {
+		fmt.Fprintln(w, "  client roles:  (none)")
+	}
+}
+
+// roleNames pulls the `name` field from a JSON array of role-mapping
+// objects, returning the names in order.
+func roleNames(v any) []string {
+	arr, ok := v.([]any)
+	if !ok {
+		return nil
+	}
+	out := make([]string, 0, len(arr))
+	for _, item := range arr {
+		if m, ok := item.(map[string]any); ok {
+			if name := stringField(m, "name"); name != "" {
+				out = append(out, name)
+			}
+		}
+	}
+	return out
+}
+
+// joinOrNone renders a comma-joined list, or "(none)" when empty.
+func joinOrNone(names []string) string {
+	if len(names) == 0 {
+		return "(none)"
+	}
+	return strings.Join(names, ", ")
+}

--- a/cli/internal/cmd/keycloak/user.go
+++ b/cli/internal/cmd/keycloak/user.go
@@ -1,0 +1,122 @@
+// SPDX-License-Identifier: Apache-2.0
+// Copyright (c) 2026 evoila Group
+
+package keycloak
+
+import (
+	"fmt"
+	"io"
+
+	"github.com/spf13/cobra"
+
+	"github.com/evoila/meho/cli/internal/output"
+)
+
+// newUserCmd returns the `meho keycloak user` parent with one sub-verb:
+// `list` (keycloak.user.list).
+func newUserCmd() *cobra.Command {
+	cmd := &cobra.Command{
+		Use:          "user",
+		Short:        "Keycloak user sub-verbs (list)",
+		SilenceUsage: true,
+	}
+	cmd.AddCommand(newUserListCmd())
+	return cmd
+}
+
+// newUserListCmd returns the `meho keycloak user list` command.
+//
+// Maps to op_id `keycloak.user.list`. GETs
+// /admin/realms/{realm}/users and returns the users as {rows, total}.
+// Optional --username maps to Keycloak's ?username= filter; --max caps
+// the result count. User credential material is redacted from every row.
+func newUserListCmd() *cobra.Command {
+	var (
+		targetName        string
+		username          string
+		maxResults        int
+		jsonOut           bool
+		backplaneOverride string
+	)
+	cmd := &cobra.Command{
+		Use:   "list",
+		Short: "List Keycloak users in the managed realm (credentials redacted)",
+		Long: "list dispatches keycloak.user.list and renders the realm's users\n" +
+			"(username / enabled / emailVerified / internal id). --username\n" +
+			"filters to matching users; --max caps the result count. User\n" +
+			"credential material is never surfaced. --json emits the full\n" +
+			"OperationResult envelope.\n\n" +
+			"Use `meho keycloak role-mapping get --id <uuid>` for a user's\n" +
+			"role assignments; the internal uuid is the `id` field of a row.\n\n" +
+			"Exit codes: 0=ok, 1=error/denied, 2=auth_expired,\n" +
+			"3=unreachable, 4=unexpected.",
+		Example: "  meho keycloak user list --target rdc-keycloak\n" +
+			"  meho keycloak user list --target rdc-keycloak --username operator-a\n" +
+			"  meho keycloak user list --target rdc-keycloak --json | jq '.result.rows[].id'",
+		Args:          cobra.NoArgs,
+		SilenceUsage:  true,
+		SilenceErrors: true,
+		RunE: func(cmd *cobra.Command, _ []string) error {
+			return runUserList(cmd, targetName, username, maxResults, jsonOut, backplaneOverride)
+		},
+	}
+	cmd.Flags().StringVar(&targetName, "target", "",
+		"target slug to dispatch against (required)")
+	cmd.Flags().StringVar(&username, "username", "",
+		"filter to matching users by username (Keycloak ?username=)")
+	cmd.Flags().IntVar(&maxResults, "max", 0,
+		"cap on the number of users returned (0 = no cap)")
+	cmd.Flags().BoolVar(&jsonOut, "json", false,
+		"emit the full OperationResult envelope as JSON")
+	cmd.Flags().StringVar(&backplaneOverride, "backplane", "",
+		"backplane URL (defaults to the URL from the most recent `meho login`)")
+	return cmd
+}
+
+func runUserList(
+	cmd *cobra.Command,
+	targetName, username string,
+	maxResults int,
+	jsonOut bool,
+	backplaneOverride string,
+) error {
+	backplaneURL, err := resolveBackplane(backplaneOverride)
+	if err != nil {
+		return output.RenderError(cmd.ErrOrStderr(), classifyBackplaneError(err), jsonOut)
+	}
+	params := map[string]any{}
+	if username != "" {
+		params["username"] = username
+	}
+	if maxResults > 0 {
+		params["max"] = maxResults
+	}
+	r, err := dispatchOp(cmd.Context(), backplaneURL, "keycloak.user.list", targetName, params)
+	if err != nil {
+		return renderRequestError(cmd, backplaneURL, err, jsonOut)
+	}
+	return renderCallResult(cmd, "keycloak.user.list", r, jsonOut, printUserList)
+}
+
+func printUserList(w io.Writer, r *CallResult) {
+	fmt.Fprintf(w, "%s keycloak.user.list — status=%s (%.0fms)\n",
+		ConnectorID, r.Status, r.DurationMs)
+	if r.Status != "ok" {
+		printErrorTrailer(w, r)
+		return
+	}
+	rows, total, err := decodeRowsResult(r.Result)
+	if err != nil || rows == nil {
+		fallbackResultRender(w, r)
+		return
+	}
+	fmt.Fprintf(w, "  %-28s %-8s %-14s %s\n", "USERNAME", "ENABLED", "EMAIL_VERIFIED", "INTERNAL_ID")
+	for _, row := range rows {
+		username := truncate(stringField(row, "username"), 28)
+		enabled := fmt.Sprintf("%t", boolField(row, "enabled"))
+		verified := fmt.Sprintf("%t", boolField(row, "emailVerified"))
+		id := stringField(row, "id")
+		fmt.Fprintf(w, "  %-28s %-8s %-14s %s\n", username, enabled, verified, id)
+	}
+	fmt.Fprintf(w, "  (%d users)\n", total)
+}

--- a/cli/internal/cmd/root.go
+++ b/cli/internal/cmd/root.go
@@ -29,6 +29,7 @@ import (
 	"github.com/evoila/meho/cli/internal/cmd/holodeck"
 	"github.com/evoila/meho/cli/internal/cmd/k8s"
 	"github.com/evoila/meho/cli/internal/cmd/kb"
+	"github.com/evoila/meho/cli/internal/cmd/keycloak"
 	"github.com/evoila/meho/cli/internal/cmd/memory"
 	"github.com/evoila/meho/cli/internal/cmd/migrate"
 	"github.com/evoila/meho/cli/internal/cmd/nsx"
@@ -397,6 +398,22 @@ func newRootCmd() *cobra.Command {
 	// Registered before registerDynamicSubcommands so the backplane
 	// manifest cannot shadow the built-in `gcloud` parent.
 	root.AddCommand(gcloud.NewRootCmd())
+
+	// G3.13-T3 (#1395) -- keycloak-admin-26.x operator alias verbs for
+	// Initiative #1388. The verb tree pre-bakes connector_id=
+	// "keycloak-admin-26.x" on top of the existing /api/v1/operations/call
+	// dispatcher route so operators don't type the connector ID on every
+	// invocation. The connector authenticates to the Keycloak Admin REST
+	// API with a Vault-sourced admin credential (the admin-vs-operator
+	// split — see docs/cross-repo/keycloak-onboarding.md), distinct from
+	// the operator's OIDC token. Ships the 6 read-only ops (realm get,
+	// client list/get, client-scope list, user list, role-mapping get)
+	// registered by G3.13-T1..T2 (#1393/#1394); the write surface is the
+	// deferred approval-gated T4 follow-up (#1406). Distinct from the
+	// `admin keycloak ...` deployer-onramp subtree (#791). Registered
+	// before registerDynamicSubcommands so the backplane manifest cannot
+	// shadow the built-in `keycloak` parent.
+	root.AddCommand(keycloak.NewRootCmd())
 
 	// G3.7-T9 (#852) -- hetzner-rest-2026.04 operator alias verbs for
 	// Initiative #370. The verb tree pre-bakes connector_id=

--- a/docs/cross-repo/keycloak-onboarding.md
+++ b/docs/cross-repo/keycloak-onboarding.md
@@ -1,0 +1,430 @@
+<!--
+SPDX-License-Identifier: Apache-2.0
+Copyright (c) 2026 evoila Group
+-->
+
+# Keycloak op surface onboarding — operator recipe
+
+> Operator-facing recipe for the G3.13 `keycloak-admin-26.x` op surface —
+> registering a `keycloak` target, the `meho keycloak …` verb tree, the
+> agent meta-tool path, and the load-bearing **admin-vs-operator
+> credential split**. The op handlers live in
+> [`backend/src/meho_backplane/connectors/keycloak/`](../../backend/src/meho_backplane/connectors/keycloak/);
+> the engineering-facing companion is
+> [`docs/codebase/connectors-keycloak.md`](../codebase/connectors-keycloak.md).
+> This doc is the cookbook every RDC operator reads when inspecting or
+> auditing the managed Keycloak realm through `meho keycloak …`.
+
+## What this surface is
+
+The `keycloak-admin-26.x` connector is a **typed** connector: hand-coded
+handlers over `httpx` against the Keycloak 26.x Admin REST API,
+registered into the G0.6 `endpoint_descriptor` table at backplane
+startup. It dispatches under the
+`(product="keycloak", version="26.x", impl_id="keycloak-admin")` registry
+triple — the connector id `keycloak-admin-26.x`.
+
+The `-admin` discriminator in the impl_id leaves room for a future
+non-admin control surface (e.g. a `keycloak-account-26.x` over the
+Account REST API) without breaking the resolver's tie-break ladder; v0.1
+ships only the Admin REST surface.
+
+The v0.1 op surface (Initiative
+[#1388](https://github.com/evoila/meho/issues/1388)) is the read-only
+working set operators use to inspect and audit the managed realm:
+
+| Group | Op ID | Admin REST API | Class |
+| --- | --- | --- | --- |
+| `realm` | `keycloak.realm.get` | `GET /admin/realms/{realm}` | read-only |
+| `client` | `keycloak.client.list` | `GET .../clients` (`?clientId=`/`?max=`) | read-only |
+| `client` | `keycloak.client.get` | `GET .../clients/{id}` | read-only |
+| `client_scope` | `keycloak.client_scope.list` | `GET .../client-scopes` | read-only |
+| `user` | `keycloak.user.list` | `GET .../users` (`?username=`/`?max=`) | read-only |
+| `user` | `keycloak.role_mapping.get` | `GET .../users/{id}/role-mappings` | read-only |
+
+Six ops total. All are `safety_level="safe"` and
+`requires_approval=False`. Every op dispatches through the same
+`POST /api/v1/operations/call` route the agent surface uses — auth,
+policy, audit, broadcast, and JSONFlux all run as documented in
+[CLAUDE.md](../../CLAUDE.md) §6. The CLI verb tree is operator ergonomics
+over that one route; it is **not** a separate data path and is **not**
+mirrored on the MCP surface (CLAUDE.md postulate 5 — the agent reaches
+every Keycloak op via the narrow-waist meta-tools, see the
+[agent meta-tool path](#the-agent-meta-tool-path) section).
+
+`client.get` and `role_mapping.get` take the client / user **internal
+UUID** (`id`), not the human `clientId` / `username` — discover it via
+the matching `.list` op first.
+
+> **Not** the `meho admin keycloak …` deployer-onramp. That subtree
+> (#791) bootstraps Keycloak clients during initial deployment, before a
+> connector target exists. This `meho keycloak …` tree reads the managed
+> realm's live configuration through the registered
+> `keycloak-admin-26.x` connector. Different lifecycle, different
+> credential path — see the [credential split](#the-admin-vs-operator-credential-split-load-bearing).
+
+## The admin-vs-operator credential split (load-bearing)
+
+MEHO is its own identity provider: the backplane authenticates its own
+callers with **operator-OIDC tokens that Keycloak issues**
+(`operator.raw_jwt`). The connector that *manages* that Keycloak must
+**not** authenticate through the same path, or it could never bootstrap a
+freshly deployed Keycloak whose operator-login clients are not yet
+configured — the chicken-and-egg. If the connector depended on
+operator-OIDC, a brand-new Keycloak (no `meho-backplane` client, no
+operator realm roles) would be unmanageable, because no operator could
+ever obtain a token from it in the first place.
+
+So the connector authenticates to the Keycloak **Admin REST API** with a
+**separate admin credential** sourced from Vault. The two credential
+paths are deliberately distinct:
+
+```
+Operator session (meho login)
+  └─ operator-OIDC JWT (operator.raw_jwt) — issued by the managed Keycloak
+       │
+       │  authorises ONLY the Vault read below
+       ▼
+  Vault KV-v2 read at target.secret_ref  (operator-context: the operator's
+  └─ admin credential                     JWT → Vault JWT/OIDC auth method,
+       │                                  per-operator RBAC + audit)
+       │  exchanged at Keycloak's OWN token endpoint
+       ▼
+  POST /realms/{admin_realm}/protocol/openid-connect/token  (form-encoded)
+  └─ admin access token
+       │
+       ▼
+  Authorization: Bearer <admin_token>   →  every Admin REST call
+```
+
+The split, restated:
+
+1. **Operator-OIDC path** — the operator's validated JWT authorises only
+   the operator-context Vault KV-v2 read of the admin credential (the
+   locked Option A decision in
+   [`docs/architecture/connector-auth.md`](../architecture/connector-auth.md)).
+   This is the same `load_vault_secret_data` helper every operator-context
+   connector uses; the read is attributed to the operator's Vault Identity
+   entity with per-operator RBAC + audit.
+2. **Admin-credential path** — the admin credential read out of Vault is
+   exchanged at Keycloak's own token endpoint for an admin access token,
+   which is then sent as the `Authorization: Bearer` on every Admin REST
+   call.
+
+**The operator's OIDC token is never sent to Keycloak.** It authorises
+the Vault read; the admin credential authenticates to Keycloak. A test
+(`test_keycloak_e2e_all_ops_use_admin_token_never_operator_jwt` in
+[`backend/tests/test_connectors_keycloak_e2e.py`](../../backend/tests/test_connectors_keycloak_e2e.py))
+asserts the operator JWT appears on no captured Keycloak request, and
+`test_keycloak_e2e_admin_token_refreshes_across_dispatch` asserts the
+same invariant holds across an admin-token re-mint mid-stream.
+
+### Admin token lifecycle
+
+The connector caches the admin token per target with a TTL-driven
+refresh: the effective TTL is the token's `expires_in` minus a 30 s
+refresh margin (floored at 1 s), so a near-expiry token is re-minted
+*before* a downstream Admin REST call would fail on it. The re-mint is
+transparent to the caller — a dispatched op whose cached token has lapsed
+silently triggers a fresh token-endpoint round-trip, then proceeds. The
+`aclose` path clears the cache but issues no logout-revoke (the token is
+short-lived; the revoke round-trip is more risk than benefit — same
+posture as NSX / vRLI).
+
+### Admin credential discriminator
+
+The admin Vault secret carries one of two shapes; the loader picks the
+grant from which fields the operator stored (the same payload-shape
+discriminator the gh-rest connector uses for App-vs-PAT):
+
+| Vault fields present | Credential | Grant |
+| --- | --- | --- |
+| `client_id` + `client_secret` | `KeycloakClientCredentials` | `client_credentials` (preferred — service-account client) |
+| `username` + `password` (no client pair) | `KeycloakPasswordCredentials` | `password` on `admin-cli` (break-glass) |
+| neither | `KeycloakAmbiguousVaultPayloadError` | — (remediation-bearing error) |
+
+The **preferred** path is `client_credentials` against a dedicated
+confidential service-account client (e.g. a `meho-admin` client, or
+`admin-cli` with a secret) holding the `realm-management` service-account
+roles needed to read the managed realm. The password grant against
+`admin-cli` is the break-glass fallback; the password shape accepts an
+optional `client_id` field (default `admin-cli`, Keycloak's public
+direct-access-grant client).
+
+## Prerequisites
+
+- **A reachable Keycloak 26.x deployment.** The connector talks the
+  Keycloak Admin REST API over HTTPS; `supported_version_range` is
+  `>=26.0,<27.0`.
+- **An admin credential stored in Vault.** A confidential service-account
+  client (preferred) or an admin username/password (break-glass), stored
+  at the target's `secret_ref` path. For the RDC fleet the consumer path
+  is `secret/rdc-hetzner-dc/keycloak/admin`. The service-account client
+  needs the `realm-management` roles to read the managed realm (at
+  minimum `view-realm`, `view-clients`, `view-users` for the six read
+  ops). See [credential split](#the-admin-vs-operator-credential-split-load-bearing).
+- **A registered `keycloak` target** in the MEHO `targets` table (see
+  below).
+- **An operator session.** `meho login <backplane-url>` writes the
+  session token the CLI reuses across every verb. The operator's JWT
+  authorises the Vault read that backs the admin-token mint; `operator`
+  role is the minimum.
+
+## Target configuration
+
+A keycloak target row carries:
+
+| Field | Example | Notes |
+| --- | --- | --- |
+| `name` | `rdc-keycloak` | Slug used with `--target` |
+| `product` | `keycloak` | Must be exactly `keycloak` |
+| `host` | `keycloak.rdc-hetzner-dc.evba.lab` | Keycloak host |
+| `port` | `443` | HTTPS port |
+| `secret_ref` | `rdc-hetzner-dc/keycloak/admin` | Vault KV-v2 path to the **admin** credential |
+| `auth_model` | `shared_service_account` | The only supported auth model (admin credential is a shared service account, not a per-operator identity) |
+| `preferred_impl_id` | `keycloak-admin` | G0.6 resolver tie-break override → pins the `keycloak-admin-26.x` connector |
+| `extras.admin_realm` | `master` | Realm the admin client authenticates against (default `master`) |
+| `extras.managed_realm` | `evba` | Realm the connector manages + fingerprints (default `evba`) |
+
+The two realm knobs live on `target.extras` (a free-form JSONB column) so
+they are target-configurable without a schema migration. Both fall back
+to their defaults (`master` / `evba`) when absent, so a target on the RDC
+fleet that uses those realms can omit `extras` entirely.
+
+`auth_headers` rejects any `auth_model` other than
+`shared_service_account` (or `None` for pre-G0.3 targets) with a clear
+`NotImplementedError` naming the target and the requested mode.
+
+### targets.yaml entry
+
+```yaml
+targets:
+  - name: rdc-keycloak
+    product: keycloak
+    host: keycloak.rdc-hetzner-dc.evba.lab
+    port: 443
+    secret_ref: rdc-hetzner-dc/keycloak/admin
+    auth_model: shared_service_account
+    preferred_impl_id: keycloak-admin
+    extras:
+      admin_realm: master
+      managed_realm: evba
+```
+
+Register with:
+
+```console
+$ meho targets import targets.yaml
+```
+
+Verify with:
+
+```console
+$ meho targets probe rdc-keycloak
+```
+
+A green probe confirms: the admin credential reads out of Vault, the
+admin token mints at `POST /realms/{admin_realm}/protocol/openid-connect/token`,
+and `GET /admin/realms/{managed_realm}` round-trips. Because every
+Keycloak admin endpoint is authenticated, `ok=true` implies the admin
+credential is **valid**, not merely that the socket is open. The probe is
+the same `GET /admin/realms/{realm}` call the connector's `fingerprint`
+issues; it surfaces `realm` / `enabled` / `sslRequired` / `loginTheme`
+plus the resolved `admin_realm` / `managed_realm` pair, and a best-effort
+server version from `GET /admin/serverinfo` (`systemInfo.version`).
+
+## Quick-start
+
+```console
+# Verify the target is reachable + admin credentials work
+$ meho targets probe rdc-keycloak
+
+# Read the managed realm's top-level config
+$ meho keycloak realm get --target rdc-keycloak
+
+# List clients in the realm
+$ meho keycloak client list --target rdc-keycloak
+
+# Filter to one client by its human clientId
+$ meho keycloak client list --target rdc-keycloak --client-id meho-backplane
+
+# Fetch one client's full config by its internal UUID
+$ meho keycloak client get --target rdc-keycloak --id 11111111-1111-1111-1111-111111111111
+
+# List client scopes
+$ meho keycloak client-scope list --target rdc-keycloak
+
+# List users (credentials never surface)
+$ meho keycloak user list --target rdc-keycloak --username operator-a
+
+# Read a user's realm + client role mappings by internal UUID
+$ meho keycloak role-mapping get --target rdc-keycloak --id 22222222-2222-2222-2222-222222222222
+
+# JSON output for piping to jq
+$ meho keycloak client list --target rdc-keycloak --json | jq '.result.rows[].id'
+$ meho keycloak realm get --target rdc-keycloak --json | jq '.result.realm.sslRequired'
+```
+
+## Verb reference
+
+Every verb takes `--target <slug>` (required for dispatch), `--json`
+(emit the full `OperationResult` envelope), and `--backplane <url>`
+(override the URL from the most recent `meho login`). Exit codes mirror
+`meho operation call`: 0=ok, 1=error/denied, 2=auth_expired,
+3=unreachable, 4=unexpected.
+
+### `meho keycloak realm get`
+
+Maps to `keycloak.realm.get`. GETs `/admin/realms/{realm}` against the
+target's managed realm and renders the realm-wide config (`realm`,
+`enabled`, `sslRequired`, `loginTheme`, token lifespans). Secrets are
+redacted by the connector.
+
+### `meho keycloak client list`
+
+Maps to `keycloak.client.list`. Renders the realm's clients as a table of
+`clientId` / `enabled` / `publicClient` / internal `id`.
+
+Flags:
+- `--client-id <id>` — filter to a single client by its human clientId
+  (Keycloak `?clientId=` exact match).
+- `--max <n>` — cap the result count.
+
+Each row's confidential-client `secret` is redacted. The internal `id` is
+the UUID `meho keycloak client get --id` expects.
+
+### `meho keycloak client get`
+
+Maps to `keycloak.client.get`. GETs `/admin/realms/{realm}/clients/{id}`
+where `--id` is the client's **internal UUID** (the `id` field from
+`client list`, NOT the human `clientId`). Renders the redirect URIs, web
+origins, and protocol-mapper names. The client `secret` is redacted.
+
+Flags:
+- `--id <uuid>` — **required**; the client's internal UUID.
+
+### `meho keycloak client-scope list`
+
+Maps to `keycloak.client_scope.list`. Renders the realm's client scopes
+(`name` / `protocol` / protocol-mapper count) — the reusable mapper/role
+bundles clients attach as default or optional scopes.
+
+### `meho keycloak user list`
+
+Maps to `keycloak.user.list`. Renders the realm's users (`username` /
+`enabled` / `emailVerified` / internal `id`). User credential material is
+never surfaced (redacted at the connector boundary).
+
+Flags:
+- `--username <name>` — filter to matching users (Keycloak `?username=`).
+- `--max <n>` — cap the result count.
+
+The internal `id` is the UUID `meho keycloak role-mapping get --id`
+expects.
+
+### `meho keycloak role-mapping get`
+
+Maps to `keycloak.role_mapping.get`. GETs
+`/admin/realms/{realm}/users/{id}/role-mappings` where `--id` is the
+user's **internal UUID** (from `user list`). Renders the realm-level role
+names and the per-client role names.
+
+Flags:
+- `--id <uuid>` — **required**; the user's internal UUID.
+
+## The agent meta-tool path
+
+Per [CLAUDE.md](../../CLAUDE.md) postulate 5, the agent surface is the
+narrow-waist meta-tools registered by G0.5 (#226). The CLI verbs are
+operator ergonomics over `POST /api/v1/operations/call`; the agent
+reaches every Keycloak op via:
+
+```
+search_operations(connector_id="keycloak-admin-26.x", query="realm client user role")
+call_operation(connector_id="keycloak-admin-26.x", op_id="keycloak.client.list",
+               target="rdc-keycloak", params={"client_id": "meho-backplane"})
+```
+
+`search_operations(connector_id="keycloak", …)` surfaces all six ops and
+`call_operation` dispatches them — verified by
+`test_keycloak_e2e_ops_visible_to_search_operations` and the per-op
+dispatch tests in
+[`backend/tests/test_connectors_keycloak_e2e.py`](../../backend/tests/test_connectors_keycloak_e2e.py).
+The `llm_instructions.when_to_use` blurb on each op group guides the
+agent — e.g. the `client` blurb tells the agent to call `client.list`
+first to discover a client's internal `id`, then `client.get` for its
+full representation.
+
+## Deferred: the write surface (T4 / #1406)
+
+This op surface is **read-only**. The Keycloak **write** ops —
+realm / client / client-scope / protocol-mapper / user / role-mapping
+creates, updates, and deletes — are the deferred approval-gated
+follow-up, tracked as G3.13-T4
+([#1406](https://github.com/evoila/meho/issues/1406)). Those ops will
+ship with `requires_approval=True` (the write-gating posture every
+mutating connector op follows) and will retire the consumer's five
+Keycloak bootstrap scripts. Until T4 lands, all Keycloak mutation goes
+through the existing `meho admin keycloak …` deployer-onramp (#791) or
+direct `kcadm.sh` / admin-console operations; the `meho keycloak …` tree
+is inspection-only.
+
+## Audit and broadcast
+
+Every `meho keycloak …` dispatch writes an audit row to the
+`operation_audit_log` table:
+
+- `connector_id = "keycloak-admin-26.x"`
+- `op_id` = the dispatched op (e.g. `keycloak.client.list`)
+- `target_id` = the resolved target row ID
+- `params_hash` = SHA-256 of the input params (for replay detection)
+- `status` = `ok` / `error` / `denied`
+- `duration_ms` = connector wall-clock time
+
+Broadcast events follow the standard envelope (CLAUDE.md §6 §7). All six
+ops are `safety_level="safe"` and broadcast with `risk_level=LOW` unless
+the agent's policy engine overrides.
+
+## Troubleshooting
+
+| Symptom | Cause | Fix |
+| --- | --- | --- |
+| `status=error connector_error: NotImplementedError: KeycloakConnector only supports auth_model='shared_service_account'` | Target `auth_model` is something else | Set `auth_model: shared_service_account` on the target; re-import |
+| `status=error connector_error: KeycloakAmbiguousVaultPayloadError` | The admin Vault secret carries neither credential shape | Populate `client_id`+`client_secret` (preferred) or `username`+`password` at `target.secret_ref` |
+| `status=error connector_error: KeycloakAdminTokenError … returned HTTP 401` | Admin credential invalid, or service-account client lacks `realm-management` roles | Verify the Vault secret; grant the service-account client the `view-*` realm-management roles |
+| `status=error connector_error: VaultCredentialsReadError … no operator JWT` | A system-initiated (background) caller tried to read the admin credential | Dispatch under an authenticated operator session — the admin-credential read is operator-context |
+| Probe fails, `extras.error` carries a transport error | Keycloak host/port unreachable or TLS failure | Verify `host`/`port`; check Keycloak is up and reachable from the backplane host |
+| `client get` / `role-mapping get` 404 | `--id` is the human clientId / username, not the internal UUID | Run `client list` / `user list` first; pass the `id` field from a row |
+| `status=denied` | operator token lacks the required role | Use a token with at least `operator` role |
+
+## Goal #214 G3.13 keycloak checklist
+
+| Checklist item | Status |
+| --- | --- |
+| G3.13-T1 #1393 — `KeycloakConnector` skeleton + admin credential loader + fingerprint + dual registration | ✅ merged |
+| G3.13-T2 #1394 — 6 curated read ops (realm / client / client-scope / user / role-mapping), secret-redacted | ✅ merged |
+| G3.13-T3 #1395 — `meho keycloak …` CLI verbs (all 6 ops) | ✅ this PR |
+| MCP `search_operations` / `call_operation` dispatch reviewed | ✅ this PR (`test_connectors_keycloak_e2e.py`) |
+| respx recorded-fixture E2E for all 6 ops + admin-token refresh through dispatch | ✅ `test_connectors_keycloak_e2e.py` |
+| `docs/cross-repo/keycloak-onboarding.md` with admin-vs-operator split + deferred-write note | ✅ this document |
+| G3.13-T4 #1406 — approval-gated write ops (retire the 5 bootstrap scripts) | ⏳ deferred follow-up |
+
+## References
+
+- Initiative: [#1388 G3.13 Keycloak connector](https://github.com/evoila/meho/issues/1388);
+  Goal [#214](https://github.com/evoila/meho/issues/214) (connector parity).
+- Tasks that shipped this surface: [#1393](https://github.com/evoila/meho/issues/1393) (T1 skeleton + auth),
+  [#1394](https://github.com/evoila/meho/issues/1394) (T2 read ops),
+  [#1395](https://github.com/evoila/meho/issues/1395) (T3 CLI + MCP review + E2E + this doc).
+  Deferred write surface: [#1406](https://github.com/evoila/meho/issues/1406) (T4).
+- Connector source: [`backend/src/meho_backplane/connectors/keycloak/`](../../backend/src/meho_backplane/connectors/keycloak/).
+- CLI verbs: [`cli/internal/cmd/keycloak/`](../../cli/internal/cmd/keycloak/).
+- E2E tests: [`backend/tests/test_connectors_keycloak_e2e.py`](../../backend/tests/test_connectors_keycloak_e2e.py).
+- Engineering codebase doc: [`docs/codebase/connectors-keycloak.md`](../codebase/connectors-keycloak.md).
+- Keycloak 26.3 Admin REST API: <https://www.keycloak.org/docs-api/26.3.3/rest-api/index.html>
+- Keycloak token endpoint + client_credentials grant: <https://www.keycloak.org/securing-apps/oidc-layers>
+- Related onboarding docs: [`targets-yaml.md`](./targets-yaml.md),
+  [`vault-onboarding.md`](./vault-onboarding.md),
+  [`connector-vault-policy.md`](./connector-vault-policy.md),
+  [`keycloak-tenant-claims.md`](./keycloak-tenant-claims.md).
+```


### PR DESCRIPTION
## Summary

- Makes the `keycloak-admin-26.x` read surface **operator-usable end-to-end**, the closing task of Initiative #1388 (after T1 skeleton #1393 and T2 read ops #1394) — mirroring the pfSense (#850) / gcloud (#851) closing-task shape.
- Adds the `meho keycloak …` CLI verb tree (six thin Cobra commands over `POST /api/v1/operations/call` with `connector_id="keycloak-admin-26.x"` pre-baked), a recorded-fixture E2E for the **dispatch + admin-token-refresh** path, and the `docs/cross-repo/keycloak-onboarding.md` runbook covering the load-bearing **admin-vs-operator credential split**.
- No new backend HTTP surface — the verbs ride the existing operations/call route, so the CLI OpenAPI snapshot is unchanged.

## What's in scope

- **CLI verbs** (`cli/internal/cmd/keycloak/`): `realm get`, `client list/get`, `client-scope list`, `user list`, `role-mapping get`. Same shared `dispatch.Connector` pattern as pfsense/gcloud; operator-only (not mirrored on MCP, per CLAUDE.md postulate 5). Distinct from the `admin keycloak …` deployer-onramp (#791). Registered in `root.go` before the dynamic manifest so it can't be shadowed.
- **MCP review**: `search_operations(connector_id="keycloak", …)` surfacing + `call_operation` dispatch for all six ops is already covered by the T2 E2E tests in `test_connectors_keycloak_e2e.py` (`test_keycloak_e2e_ops_visible_to_search_operations` + per-op dispatch tests); confirmed unchanged.
- **Admin-token-refresh E2E**: new `test_keycloak_e2e_admin_token_refreshes_across_dispatch` advances the connector's monotonic clock past the cached token's effective TTL between two dispatched ops, asserting the token endpoint is hit twice, both ops still return `ok`, and the re-mint never leaks the operator JWT onto the Keycloak admin surface.
- **Onboarding doc**: target registration (`secret_ref` → Vault admin path, `preferred_impl_id: keycloak-admin`, managed realm via `extras`), the six ops + `GET /admin/realms/{realm}` probe, the admin-credential vs operator-OIDC split (the bootstrap chicken-and-egg), and the deferred approval-gated write follow-up (T4 / #1406).

## Test plan

- [x] `go test ./...` (cli) — all pass, incl. new `internal/cmd/keycloak` package (connector-id frozen, canonical op_ids, param forwarding, required-flag, command-tree shape)
- [x] `gofmt -l` + `go build ./...` + `go vet` — clean
- [x] `uv run pytest tests/test_connectors_keycloak_{e2e,auth,redaction}.py` — 33 passed (incl. the new dispatch token-refresh test)
- [x] `uv run mypy src/` (CI scope) — clean
- [x] `ruff check` / `ruff format --check` on touched test file — clean
- [x] `code-quality.py --diff` — pass
- [x] `make snapshot-openapi && make generate` — no diff (verbs add no backend HTTP surface)

## Out of scope

- The Keycloak **write** ops (realm/client/scope/protocol-mapper/user/role-mapping CRUD, `requires_approval=True`) are the deferred follow-up tracked as G3.13-T4 (#1406).

<!-- auto-implement-issue: fresh, iteration 1 -->

Closes #1395
