### PR TITLE
feat(connectors): G3.13-T4 keycloak approval-gated write ops that retire the 5 bootstrap scripts

### DIFF
--- a/backend/src/meho_backplane/broadcast/events.py
+++ b/backend/src/meho_backplane/broadcast/events.py
@@ -135,6 +135,14 @@ _CREDENTIAL_WRITE_OPS: Final[frozenset[str]] = frozenset(
         "vault.kv.patch",
         "k8s.secret.create",
         "k8s.job.create",
+        # G3.13-T4 #1406 — Keycloak user-credential write ops. Both source
+        # the password from Vault (it is never an inline param), so the
+        # request params carry only a Vault *path*. The pin is
+        # defence-in-depth: should a future param-shape change ever place
+        # credential material in params, the broadcast collapses to
+        # aggregate-only rather than shipping it on the feed.
+        "keycloak.user.create",
+        "keycloak.user.reset_password",
     }
 )
 
@@ -172,6 +180,13 @@ _WRITE_SUFFIXES: Final[tuple[str, ...]] = (
     # branch.
     ".add",
     ".remove",
+    # keycloak role-mapping privilege-grant verb (G3.13-T4 #1406).
+    # ``keycloak.role_mapping.assign`` is a mutating privilege grant; its
+    # params (user id/username + role names) carry no secret, so the plain
+    # ``write`` class (full detail) is correct — but without this suffix it
+    # falls through to ``other``. Classifying it ``write`` keeps the feed's
+    # mutation signal accurate.
+    ".assign",
 )
 
 #: Op-id suffixes that imply non-mutating read. ``.ls`` and ``.about``

--- a/backend/src/meho_backplane/connectors/keycloak/connector.py
+++ b/backend/src/meho_backplane/connectors/keycloak/connector.py
@@ -80,6 +80,7 @@ from __future__ import annotations
 
 import asyncio
 import time
+from dataclasses import dataclass
 from datetime import UTC, datetime
 from typing import Any
 
@@ -107,7 +108,7 @@ from meho_backplane.connectors.schemas import (
     ProbeResult,
 )
 
-__all__ = ["KeycloakAdminTokenError", "KeycloakConnector"]
+__all__ = ["KeycloakAdminTokenError", "KeycloakConnector", "KeycloakWriteResult"]
 
 _log = structlog.get_logger(__name__)
 
@@ -122,6 +123,42 @@ _TOKEN_REFRESH_MARGIN_SECONDS: float = 30.0
 #: 60 s; we use that as a conservative floor so a malformed response
 #: doesn't pin a token forever.
 _DEFAULT_TOKEN_TTL_SECONDS: float = 60.0
+
+#: Mutating verbs ``_write_admin`` accepts. Kept distinct from the
+#: inherited ``_IDEMPOTENT_METHODS`` so a write never rides the
+#: idempotent-GET retry decorator (re-firing a side effect on a transient
+#: 5xx is the bug that guard prevents).
+_MUTATING_METHODS: frozenset[str] = frozenset({"POST", "PUT"})
+
+
+@dataclass(frozen=True)
+class KeycloakWriteResult:
+    """Outcome of an admin-auth mutating request.
+
+    ``status_code`` is the HTTP status of the write; ``location`` is the
+    ``Location`` header Keycloak returns on a create (its trailing segment
+    is the new object's UUID); ``conflict`` is ``True`` when the write hit
+    an already-exists 409 that :meth:`KeycloakConnector._write_admin`
+    swallowed for idempotency.
+    """
+
+    status_code: int
+    location: str | None
+    conflict: bool
+
+    def created_uuid(self) -> str | None:
+        """Return the new object's UUID parsed from the ``Location`` header.
+
+        Keycloak create endpoints respond ``201`` with
+        ``Location: .../{resource}/{uuid}``; the UUID is the final
+        non-empty path segment. Returns ``None`` when there is no
+        ``Location`` (e.g. an idempotent 409, or an update that returns
+        ``204`` with no body).
+        """
+        if not self.location:
+            return None
+        segment = self.location.rstrip("/").rsplit("/", 1)[-1]
+        return segment or None
 
 
 class KeycloakAdminTokenError(RuntimeError):
@@ -516,6 +553,145 @@ class KeycloakConnector(HttpConnector):
         payload = resp.json()
         return payload if isinstance(payload, list) else []
 
+    # -- admin-auth write helpers (G3.13-T4 #1406) ----------------------
+
+    async def _write_admin(
+        self,
+        target: KeycloakTargetLike,
+        method: str,
+        path: str,
+        *,
+        operator: Operator,
+        json: dict[str, Any] | None = None,
+        idempotent_conflict: bool = True,
+    ) -> KeycloakWriteResult:
+        """Issue an admin-auth mutating request (POST/PUT) — never retried.
+
+        Returns a :class:`KeycloakWriteResult` carrying the HTTP status,
+        the ``Location`` header (Keycloak's create endpoints return the
+        new object's URL there — the trailing path segment is the new
+        object's UUID), and a flag recording whether the request hit an
+        already-exists conflict.
+
+        Idempotency contract (issue acceptance criterion): when
+        *idempotent_conflict* is ``True`` (the default) an HTTP **409**
+        is swallowed and surfaced as ``conflict=True`` rather than raised,
+        so a re-run of a create is a no-op-equivalent success rather than
+        an error. Every other non-2xx status raises
+        :exc:`httpx.HTTPStatusError` (the dispatcher's ``connector_error``
+        branch records it). Mutating verbs are **not** retried — a 5xx on a
+        non-idempotent write must surface, not silently re-fire the side
+        effect.
+
+        The admin Bearer is applied by :meth:`auth_headers`; the operator
+        authorises only the Vault read behind the token mint and is never
+        sent to Keycloak.
+        """
+        verb = method.upper()
+        if verb not in _MUTATING_METHODS:
+            raise ValueError(
+                f"_write_admin only accepts mutating methods {sorted(_MUTATING_METHODS)}; "
+                f"got {verb!r}"
+            )
+        client = await self._http_client(target)
+        headers = await self.auth_headers(target, operator)
+        resp = await client.request(verb, path, json=json, headers=headers)
+        if idempotent_conflict and resp.status_code == 409:
+            return KeycloakWriteResult(status_code=409, location=None, conflict=True)
+        resp.raise_for_status()
+        return KeycloakWriteResult(
+            status_code=resp.status_code,
+            location=resp.headers.get("location"),
+            conflict=False,
+        )
+
+    async def _find_client_uuid(
+        self,
+        target: KeycloakTargetLike,
+        managed_realm: str,
+        client_id: str,
+        *,
+        operator: Operator,
+    ) -> str | None:
+        """Resolve a client's internal UUID from its human ``clientId``.
+
+        Keycloak addresses clients by an internal UUID ``id``, never the
+        human ``clientId`` — so every client write keys on the UUID, which
+        is discovered via ``GET .../clients?clientId=<clientId>`` (exact
+        match). Returns the first matching row's ``id`` or ``None`` when no
+        client carries that ``clientId``.
+        """
+        rows = await self._get_admin_list(
+            target,
+            f"/admin/realms/{managed_realm}/clients",
+            operator=operator,
+            params={"clientId": client_id},
+        )
+        for row in rows:
+            if isinstance(row, dict) and row.get("clientId") == client_id:
+                uuid_value = row.get("id")
+                if isinstance(uuid_value, str) and uuid_value:
+                    return uuid_value
+        return None
+
+    async def _find_user_uuid(
+        self,
+        target: KeycloakTargetLike,
+        managed_realm: str,
+        username: str,
+        *,
+        operator: Operator,
+    ) -> str | None:
+        """Resolve a user's internal UUID from their ``username``.
+
+        Keycloak's ``GET .../users?username=<u>`` filter is a substring
+        match by default, so the rows are re-filtered to the **exact**
+        username (case-insensitive, matching Keycloak's own username
+        casing rules) before returning a UUID. Returns ``None`` when no
+        exact match exists.
+        """
+        rows = await self._get_admin_list(
+            target,
+            f"/admin/realms/{managed_realm}/users",
+            operator=operator,
+            params={"username": username, "exact": "true"},
+        )
+        wanted = username.casefold()
+        for row in rows:
+            if isinstance(row, dict) and str(row.get("username", "")).casefold() == wanted:
+                uuid_value = row.get("id")
+                if isinstance(uuid_value, str) and uuid_value:
+                    return uuid_value
+        return None
+
+    async def _find_realm_role(
+        self,
+        target: KeycloakTargetLike,
+        managed_realm: str,
+        role_name: str,
+        *,
+        operator: Operator,
+    ) -> dict[str, Any] | None:
+        """Resolve a realm role's full representation by name.
+
+        The role-mapping assign endpoint takes the full RoleRepresentation
+        (``{id, name, ...}``) in its body, so the assign handler must fetch
+        it first via ``GET .../roles/{role-name}``. Returns ``None`` when
+        the role does not exist (a 404), so the handler can surface a clean
+        operator-actionable error rather than a raw transport failure.
+        """
+        try:
+            role = await self._get_admin_json(
+                target,
+                f"/admin/realms/{managed_realm}/roles/{role_name}",
+                operator=operator,
+            )
+        except httpx.HTTPStatusError as exc:
+            if exc.response.status_code == 404:
+                return None
+            raise
+        return role if isinstance(role, dict) else None
+
     # -- typed-op handler shims (G3.13-T2 #1394) ------------------------
 
     async def realm_get(
@@ -566,6 +742,80 @@ class KeycloakConnector(HttpConnector):
 
         return await keycloak_role_mapping_get(self, operator, target, params)
 
+    # -- typed-op write handler shims (G3.13-T4 #1406) ------------------
+
+    async def realm_create(
+        self, operator: Operator, target: KeycloakTargetLike, params: dict[str, Any]
+    ) -> dict[str, Any]:
+        """Bound-method shim for ``keycloak.realm.create`` (G3.13-T4 #1406)."""
+        from meho_backplane.connectors.keycloak.ops_write import keycloak_realm_create
+
+        return await keycloak_realm_create(self, operator, target, params)
+
+    async def realm_update(
+        self, operator: Operator, target: KeycloakTargetLike, params: dict[str, Any]
+    ) -> dict[str, Any]:
+        """Bound-method shim for ``keycloak.realm.update`` (G3.13-T4 #1406)."""
+        from meho_backplane.connectors.keycloak.ops_write import keycloak_realm_update
+
+        return await keycloak_realm_update(self, operator, target, params)
+
+    async def client_create(
+        self, operator: Operator, target: KeycloakTargetLike, params: dict[str, Any]
+    ) -> dict[str, Any]:
+        """Bound-method shim for ``keycloak.client.create`` (G3.13-T4 #1406)."""
+        from meho_backplane.connectors.keycloak.ops_write import keycloak_client_create
+
+        return await keycloak_client_create(self, operator, target, params)
+
+    async def client_update(
+        self, operator: Operator, target: KeycloakTargetLike, params: dict[str, Any]
+    ) -> dict[str, Any]:
+        """Bound-method shim for ``keycloak.client.update`` (G3.13-T4 #1406)."""
+        from meho_backplane.connectors.keycloak.ops_write import keycloak_client_update
+
+        return await keycloak_client_update(self, operator, target, params)
+
+    async def client_scope_create(
+        self, operator: Operator, target: KeycloakTargetLike, params: dict[str, Any]
+    ) -> dict[str, Any]:
+        """Bound-method shim for ``keycloak.client_scope.create`` (G3.13-T4 #1406)."""
+        from meho_backplane.connectors.keycloak.ops_write import keycloak_client_scope_create
+
+        return await keycloak_client_scope_create(self, operator, target, params)
+
+    async def protocol_mapper_create(
+        self, operator: Operator, target: KeycloakTargetLike, params: dict[str, Any]
+    ) -> dict[str, Any]:
+        """Bound-method shim for ``keycloak.protocol_mapper.create`` (G3.13-T4 #1406)."""
+        from meho_backplane.connectors.keycloak.ops_write import keycloak_protocol_mapper_create
+
+        return await keycloak_protocol_mapper_create(self, operator, target, params)
+
+    async def user_create(
+        self, operator: Operator, target: KeycloakTargetLike, params: dict[str, Any]
+    ) -> dict[str, Any]:
+        """Bound-method shim for ``keycloak.user.create`` (G3.13-T4 #1406)."""
+        from meho_backplane.connectors.keycloak.ops_write import keycloak_user_create
+
+        return await keycloak_user_create(self, operator, target, params)
+
+    async def user_reset_password(
+        self, operator: Operator, target: KeycloakTargetLike, params: dict[str, Any]
+    ) -> dict[str, Any]:
+        """Bound-method shim for ``keycloak.user.reset_password`` (G3.13-T4 #1406)."""
+        from meho_backplane.connectors.keycloak.ops_write import keycloak_user_reset_password
+
+        return await keycloak_user_reset_password(self, operator, target, params)
+
+    async def role_mapping_assign(
+        self, operator: Operator, target: KeycloakTargetLike, params: dict[str, Any]
+    ) -> dict[str, Any]:
+        """Bound-method shim for ``keycloak.role_mapping.assign`` (G3.13-T4 #1406)."""
+        from meho_backplane.connectors.keycloak.ops_write import keycloak_role_mapping_assign
+
+        return await keycloak_role_mapping_assign(self, operator, target, params)
+
     # -- typed-op registrar (G3.13-T2 #1394 fills the read-op walk) ------
 
     @classmethod
@@ -586,8 +836,13 @@ class KeycloakConnector(HttpConnector):
 
         G3.13-T2 (#1394) lands the six read ops
         (``keycloak.realm.get`` / ``client.list`` / ``client.get`` /
-        ``client_scope.list`` / ``user.list`` / ``role_mapping.get``); the
-        write surface is the deferred approval-gated T4 follow-up.
+        ``client_scope.list`` / ``user.list`` / ``role_mapping.get``).
+        G3.13-T4 (#1406) layers the approval-gated write ops
+        (``realm.create`` / ``realm.update`` / ``client.create`` /
+        ``client.update`` / ``client_scope.create`` /
+        ``protocol_mapper.create`` / ``user.create`` /
+        ``user.reset_password`` / ``role_mapping.assign``) onto the same
+        walk — every write registers ``requires_approval=True``.
         """
         # Lazy imports: the operations package pulls in the embedding
         # pipeline (ONNX runtime + a 100 MB+ model on first touch) that a
@@ -598,10 +853,19 @@ class KeycloakConnector(HttpConnector):
             READ_OPS,
             WHEN_TO_USE_BY_GROUP,
         )
+        from meho_backplane.connectors.keycloak.ops_write import (
+            WHEN_TO_USE_WRITE_BY_GROUP,
+            WRITE_OPS,
+        )
         from meho_backplane.operations.typed_register import register_typed_operation
 
+        # The two when_to_use maps are disjoint by group_key suffix
+        # (read groups are bare nouns; write groups carry a ``_write``
+        # suffix) so a merge never clobbers a read blurb with a write one.
+        when_to_use_by_group = {**WHEN_TO_USE_BY_GROUP, **WHEN_TO_USE_WRITE_BY_GROUP}
+
         bindings: list[tuple[Any, Any]] = []
-        for op in READ_OPS:
+        for op in (*READ_OPS, *WRITE_OPS):
             handler = getattr(cls, op.handler_attr, None)
             if handler is None:
                 raise AttributeError(
@@ -615,7 +879,7 @@ class KeycloakConnector(HttpConnector):
             if op.group_key is None:
                 when_to_use = None
             else:
-                when_to_use = WHEN_TO_USE_BY_GROUP.get(op.group_key)
+                when_to_use = when_to_use_by_group.get(op.group_key)
                 if when_to_use is None:
                     raise ValueError(
                         f"KeycloakConnector op {op.op_id!r} declares "

--- a/backend/src/meho_backplane/connectors/keycloak/ops_write.py
+++ b/backend/src/meho_backplane/connectors/keycloak/ops_write.py
@@ -1,0 +1,594 @@
+# SPDX-License-Identifier: Apache-2.0
+# Copyright (c) 2026 evoila Group
+
+"""Approval-gated write ops for :class:`KeycloakConnector` (G3.13-T4 #1406).
+
+Nine mutating ops that retire the consumer's five Keycloak bootstrap
+scripts (``keycloak-bootstrap-meho-{admin,cli,mcp,web}.sh`` and
+``keycloak-provision-meho-user.sh``). Every op registers
+``requires_approval=True`` — no write dispatches without going through
+the human approve-queue (G11.7-T1 #1401):
+
+==================================  ===========  ===========================================
+op_id                               safety       Admin REST API
+==================================  ===========  ===========================================
+``keycloak.realm.create``           dangerous    ``POST /admin/realms``
+``keycloak.realm.update``           caution      ``PUT .../realms/{realm}``
+``keycloak.client.create``          caution      ``POST .../realms/{realm}/clients``
+``keycloak.client.update``          caution      ``PUT .../clients/{id}``
+``keycloak.client_scope.create``    caution      ``POST .../client-scopes``
+``keycloak.protocol_mapper.create`` caution      ``POST .../clients/{id}/protocol-mappers/models``
+``keycloak.user.create``            caution      ``POST .../realms/{realm}/users``
+``keycloak.user.reset_password``    caution      ``PUT .../users/{id}/reset-password``
+``keycloak.role_mapping.assign``    dangerous    ``POST .../users/{id}/role-mappings/realm``
+==================================  ===========  ===========================================
+
+``keycloak.idp.create`` (identity-provider federation) is **deliberately
+deferred**: the issue (#1406) notes it is "not exercised by current
+scripts", so it stays out of this PR to keep scope on the script-retiring
+ops. A future task can add it under the same registrar walk.
+
+Name → UUID resolution (load-bearing)
+=====================================
+
+Keycloak addresses every object by an internal **UUID**, never its human
+name. So every write that targets an existing object first resolves the
+name to a UUID via a find-by-name dance on the connector
+(:meth:`~meho_backplane.connectors.keycloak.connector.KeycloakConnector._find_client_uuid`
+/ ``_find_user_uuid`` / ``_find_realm_role``). ``client.update`` /
+``user.reset_password`` / ``role_mapping.assign`` accept either the human
+name (``client_id`` / ``username`` / target ``username``) — resolved
+here — or an explicit ``id`` UUID when the caller already has it. A create
+returns the new object's UUID parsed from the ``Location`` header.
+
+Idempotency (load-bearing)
+==========================
+
+Re-running a create must be a no-op-equivalent success, not an error.
+``_write_admin`` swallows an HTTP **409 Conflict** (already-exists) and
+surfaces ``conflict=True``; the create handlers map that to
+``{created: false, conflict: true}`` with ``status="ok"`` so a re-run of a
+bootstrap script's create step does not fail the dispatch. The handler
+then resolves the existing object's UUID so the caller still gets the id
+it would have gotten on a fresh create.
+
+Password handling (critical security)
+=====================================
+
+``user.create`` and ``user.reset_password`` **never** carry the password
+inline in op params. The password is read from Vault under the operator's
+identity (``password_secret_ref`` — a KV-v2 path; optional
+``password_secret_mount`` / ``password_secret_key``) via the same
+``vault_client_for_operator`` primitive the Vault connector ops use. Two
+layers of defence keep the password out of audit + broadcast:
+
+* The **op params** carry only a Vault *path*, never the secret — so the
+  audit row's ``params_hash`` (params are never stored verbatim) hashes a
+  path, and the broadcast ``params`` view carries a path.
+* Both ops are additionally pinned in
+  :data:`meho_backplane.broadcast.events._CREDENTIAL_WRITE_OPS` so the
+  broadcast classifier collapses them to aggregate-only — defence in
+  depth for a future param-shape change.
+
+The handlers return **value-free** confirmations (username / realm /
+created flag), never the password.
+
+References
+----------
+
+* Task: https://github.com/evoila/meho/issues/1406
+* Parent initiative: https://github.com/evoila/meho/issues/1388
+* Human approve-queue + write-op redaction: G11.7-T1 #1401.
+* Keycloak 26.3 Admin REST API:
+  https://www.keycloak.org/docs-api/26.3.3/rest-api/index.html
+* RealmRepresentation / ClientRepresentation / ClientScopeRepresentation /
+  ProtocolMapperRepresentation / UserRepresentation /
+  CredentialRepresentation / RoleRepresentation:
+  https://www.keycloak.org/docs-api/latest/javadocs/org/keycloak/representations/idm/package-summary.html
+"""
+
+from __future__ import annotations
+
+import asyncio
+from typing import TYPE_CHECKING, Any
+
+import meho_backplane.auth.vault as _auth_vault
+from meho_backplane.connectors.keycloak.session import resolve_realm_config
+
+if TYPE_CHECKING:
+    from meho_backplane.auth.operator import Operator
+    from meho_backplane.connectors.keycloak.connector import KeycloakConnector
+    from meho_backplane.connectors.keycloak.session import KeycloakTargetLike
+
+__all__ = [
+    "WHEN_TO_USE_WRITE_BY_GROUP",
+    "WRITE_OPS",
+    "KeycloakPasswordSecretError",
+    "KeycloakRoleNotFoundError",
+    "KeycloakUserNotFoundError",
+    "keycloak_client_create",
+    "keycloak_client_scope_create",
+    "keycloak_client_update",
+    "keycloak_protocol_mapper_create",
+    "keycloak_realm_create",
+    "keycloak_realm_update",
+    "keycloak_role_mapping_assign",
+    "keycloak_user_create",
+    "keycloak_user_reset_password",
+]
+
+#: KV-v2 mount the password reader defaults to when the op omits
+#: ``password_secret_mount``. Mirrors the Vault connector's default mount.
+_DEFAULT_PASSWORD_MOUNT = "secret"
+
+#: Default field name read out of the Vault secret payload when the op
+#: omits ``password_secret_key``.
+_DEFAULT_PASSWORD_KEY = "password"
+
+
+class KeycloakPasswordSecretError(Exception):
+    """The Vault secret backing a user password is missing or malformed.
+
+    Raised when ``password_secret_ref`` resolves to a secret that lacks the
+    requested key (default ``password``) or carries a non-string / empty
+    value. The message names the path + key (never the value) so the
+    operator can fix the secret.
+    """
+
+
+class KeycloakUserNotFoundError(Exception):
+    """A user write targeted a username/UUID that does not exist."""
+
+
+class KeycloakRoleNotFoundError(Exception):
+    """A role-mapping assign referenced a realm role that does not exist."""
+
+
+# ---------------------------------------------------------------------------
+# Vault-sourced password reader (operator-context)
+# ---------------------------------------------------------------------------
+
+
+async def _read_password_from_vault(operator: Operator, params: dict[str, Any]) -> str:
+    """Read a user password from Vault under the operator's identity.
+
+    The password is **never** an inline param — only its Vault location is.
+    ``password_secret_ref`` is the KV-v2 path; ``password_secret_mount``
+    (default ``secret``) the mount; ``password_secret_key`` (default
+    ``password``) the field within the secret payload. Forwards the
+    operator's validated JWT to Vault's JWT/OIDC auth method via
+    :func:`~meho_backplane.auth.vault.vault_client_for_operator` (the same
+    operator-context read the connector's admin-credential loader uses) and
+    offloads the blocking hvac call with ``asyncio.to_thread``.
+
+    Raises :exc:`KeycloakPasswordSecretError` when the requested key is
+    absent or its value is not a non-empty string.
+    """
+    secret_ref = str(params["password_secret_ref"]).strip()
+    mount = str(params.get("password_secret_mount") or _DEFAULT_PASSWORD_MOUNT).strip()
+    key = str(params.get("password_secret_key") or _DEFAULT_PASSWORD_KEY).strip()
+
+    async with _auth_vault.vault_client_for_operator(operator) as client:
+        payload = await asyncio.to_thread(
+            client.secrets.kv.v2.read_secret_version,
+            path=secret_ref,
+            mount_point=mount,
+            raise_on_deleted_version=False,
+        )
+    secret_data = payload["data"]["data"]
+    value = secret_data.get(key) if isinstance(secret_data, dict) else None
+    if not isinstance(value, str) or not value:
+        raise KeycloakPasswordSecretError(
+            f"keycloak_password_secret: Vault secret at mount={mount!r} "
+            f"path={secret_ref!r} carries no usable string value under key "
+            f"{key!r}. Store the password under that key (or set "
+            f"password_secret_key) so the user write can source it without "
+            f"the password ever appearing in op params."
+        )
+    return value
+
+
+def _temporary_flag(params: dict[str, Any]) -> bool:
+    """Resolve the ``temporary`` credential flag (default ``False``).
+
+    Keycloak's CredentialRepresentation ``temporary=true`` forces a
+    password change on first login. Defaults to ``False`` (a permanent
+    password) — the bootstrap scripts provision service/operator accounts
+    with a permanent password.
+    """
+    return bool(params.get("temporary", False))
+
+
+# ---------------------------------------------------------------------------
+# Realm writes
+# ---------------------------------------------------------------------------
+
+
+async def keycloak_realm_create(
+    self: KeycloakConnector,
+    operator: Operator,
+    target: KeycloakTargetLike,
+    params: dict[str, Any],
+) -> dict[str, Any]:
+    """Create a realm (``POST /admin/realms``).
+
+    Op-id: ``keycloak.realm.create``. ``representation`` is the
+    RealmRepresentation body; its ``realm`` field is the realm name. A
+    409 (realm already exists) is treated as an idempotent success.
+    Returns a value-free confirmation: the realm name + created/conflict
+    flags.
+    """
+    representation = dict(params["representation"])
+    realm_name = str(representation.get("realm") or params.get("realm") or "").strip()
+    representation.setdefault("realm", realm_name)
+    result = await self._write_admin(
+        target, "POST", "/admin/realms", operator=operator, json=representation
+    )
+    return {
+        "realm": realm_name,
+        "created": not result.conflict,
+        "conflict": result.conflict,
+    }
+
+
+async def keycloak_realm_update(
+    self: KeycloakConnector,
+    operator: Operator,
+    target: KeycloakTargetLike,
+    params: dict[str, Any],
+) -> dict[str, Any]:
+    """Update a realm's top-level config (``PUT /admin/realms/{realm}``).
+
+    Op-id: ``keycloak.realm.update``. Defaults to the target's managed
+    realm; ``realm`` overrides it. ``representation`` is the partial
+    RealmRepresentation to merge. Returns a value-free confirmation.
+    """
+    realms = resolve_realm_config(target)
+    realm_name = str(params.get("realm") or realms.managed_realm).strip()
+    representation = dict(params["representation"])
+    representation.setdefault("realm", realm_name)
+    await self._write_admin(
+        target,
+        "PUT",
+        f"/admin/realms/{realm_name}",
+        operator=operator,
+        json=representation,
+        idempotent_conflict=False,
+    )
+    return {"realm": realm_name, "updated": True}
+
+
+# ---------------------------------------------------------------------------
+# Client writes
+# ---------------------------------------------------------------------------
+
+
+async def keycloak_client_create(
+    self: KeycloakConnector,
+    operator: Operator,
+    target: KeycloakTargetLike,
+    params: dict[str, Any],
+) -> dict[str, Any]:
+    """Create a client (``POST /admin/realms/{realm}/clients``).
+
+    Op-id: ``keycloak.client.create``. ``representation`` is the
+    ClientRepresentation (flows / redirect URIs / protocol mappers). A 409
+    (clientId already exists) is treated as an idempotent success, and the
+    existing client's UUID is resolved so the caller always gets an ``id``.
+    Returns the internal UUID + created/conflict flags — never the client
+    secret.
+    """
+    realms = resolve_realm_config(target)
+    representation = dict(params["representation"])
+    client_id = str(representation.get("clientId") or params.get("client_id") or "").strip()
+    representation.setdefault("clientId", client_id)
+    result = await self._write_admin(
+        target,
+        "POST",
+        f"/admin/realms/{realms.managed_realm}/clients",
+        operator=operator,
+        json=representation,
+    )
+    uuid = result.created_uuid()
+    if uuid is None and client_id:
+        # 409 (no Location) or a create that returned no Location header:
+        # resolve the existing client's UUID so the caller still gets an id.
+        uuid = await self._find_client_uuid(
+            target, realms.managed_realm, client_id, operator=operator
+        )
+    return {
+        "client_id": client_id,
+        "id": uuid,
+        "created": not result.conflict,
+        "conflict": result.conflict,
+    }
+
+
+async def keycloak_client_update(
+    self: KeycloakConnector,
+    operator: Operator,
+    target: KeycloakTargetLike,
+    params: dict[str, Any],
+) -> dict[str, Any]:
+    """Update a client (``PUT /admin/realms/{realm}/clients/{id}``).
+
+    Op-id: ``keycloak.client.update``. Keys on the client's internal UUID;
+    pass it directly via ``id``, or pass ``client_id`` (the human clientId)
+    and the handler resolves the UUID via ``?clientId=`` lookup.
+    ``representation`` is the partial ClientRepresentation. Raises
+    :exc:`KeycloakUserNotFoundError`'s sibling — a clear error — when the
+    clientId resolves to no client.
+    """
+    realms = resolve_realm_config(target)
+    uuid = _opt_str(params.get("id"))
+    client_id = _opt_str(params.get("client_id"))
+    if uuid is None:
+        if client_id is None:
+            raise ValueError("keycloak.client.update requires either 'id' (UUID) or 'client_id'")
+        uuid = await self._find_client_uuid(
+            target, realms.managed_realm, client_id, operator=operator
+        )
+        if uuid is None:
+            raise KeycloakUserNotFoundError(
+                f"keycloak.client.update: no client with clientId={client_id!r} in realm "
+                f"{realms.managed_realm!r}"
+            )
+    representation = dict(params["representation"])
+    representation.setdefault("id", uuid)
+    await self._write_admin(
+        target,
+        "PUT",
+        f"/admin/realms/{realms.managed_realm}/clients/{uuid}",
+        operator=operator,
+        json=representation,
+        idempotent_conflict=False,
+    )
+    return {"id": uuid, "client_id": client_id, "updated": True}
+
+
+async def keycloak_client_scope_create(
+    self: KeycloakConnector,
+    operator: Operator,
+    target: KeycloakTargetLike,
+    params: dict[str, Any],
+) -> dict[str, Any]:
+    """Create a client scope (``POST /admin/realms/{realm}/client-scopes``).
+
+    Op-id: ``keycloak.client_scope.create``. ``representation`` is the
+    ClientScopeRepresentation (its ``protocolMappers`` ride in the body).
+    A 409 (scope name already exists) is an idempotent success. Returns the
+    scope name + created/conflict flags.
+    """
+    realms = resolve_realm_config(target)
+    representation = dict(params["representation"])
+    name = str(representation.get("name") or params.get("name") or "").strip()
+    representation.setdefault("name", name)
+    result = await self._write_admin(
+        target,
+        "POST",
+        f"/admin/realms/{realms.managed_realm}/client-scopes",
+        operator=operator,
+        json=representation,
+    )
+    return {
+        "name": name,
+        "id": result.created_uuid(),
+        "created": not result.conflict,
+        "conflict": result.conflict,
+    }
+
+
+async def keycloak_protocol_mapper_create(
+    self: KeycloakConnector,
+    operator: Operator,
+    target: KeycloakTargetLike,
+    params: dict[str, Any],
+) -> dict[str, Any]:
+    """Add a protocol mapper to a client (``POST .../clients/{id}/protocol-mappers/models``).
+
+    Op-id: ``keycloak.protocol_mapper.create``. This is the op that wires
+    the ``tenant_id`` / ``tenant_role`` claims the backplane row-scopes on.
+    Keys on the client's internal UUID; pass it via ``id`` or pass
+    ``client_id`` (the human clientId) for name→UUID resolution.
+    ``representation`` is the ProtocolMapperRepresentation. A 409 (a mapper
+    with that name already exists on the client) is an idempotent success.
+    """
+    realms = resolve_realm_config(target)
+    uuid = _opt_str(params.get("id"))
+    client_id = _opt_str(params.get("client_id"))
+    if uuid is None:
+        if client_id is None:
+            raise ValueError(
+                "keycloak.protocol_mapper.create requires either 'id' (client UUID) or 'client_id'"
+            )
+        uuid = await self._find_client_uuid(
+            target, realms.managed_realm, client_id, operator=operator
+        )
+        if uuid is None:
+            raise KeycloakUserNotFoundError(
+                f"keycloak.protocol_mapper.create: no client with clientId={client_id!r} "
+                f"in realm {realms.managed_realm!r}"
+            )
+    representation = dict(params["representation"])
+    mapper_name = _opt_str(representation.get("name"))
+    result = await self._write_admin(
+        target,
+        "POST",
+        f"/admin/realms/{realms.managed_realm}/clients/{uuid}/protocol-mappers/models",
+        operator=operator,
+        json=representation,
+    )
+    return {
+        "client_uuid": uuid,
+        "client_id": client_id,
+        "mapper_name": mapper_name,
+        "created": not result.conflict,
+        "conflict": result.conflict,
+    }
+
+
+# ---------------------------------------------------------------------------
+# User writes (password sourced from Vault, never inline)
+# ---------------------------------------------------------------------------
+
+
+async def keycloak_user_create(
+    self: KeycloakConnector,
+    operator: Operator,
+    target: KeycloakTargetLike,
+    params: dict[str, Any],
+) -> dict[str, Any]:
+    """Create a user with a Vault-sourced password (``POST .../users``).
+
+    Op-id: ``keycloak.user.create``. ``representation`` is the
+    UserRepresentation (username / email / enabled / attributes). The
+    password is read from Vault (``password_secret_ref``) and set as a
+    permanent credential in the create body — it is **never** an inline
+    param. A 409 (username already exists) is an idempotent success; the
+    existing user's UUID is then resolved. Returns the UUID + value-free
+    flags, never the password.
+    """
+    realms = resolve_realm_config(target)
+    representation = dict(params["representation"])
+    username = str(representation.get("username") or params.get("username") or "").strip()
+    representation.setdefault("username", username)
+    representation.setdefault("enabled", True)
+
+    if params.get("password_secret_ref"):
+        password = await _read_password_from_vault(operator, params)
+        representation["credentials"] = [
+            {"type": "password", "value": password, "temporary": _temporary_flag(params)}
+        ]
+
+    result = await self._write_admin(
+        target,
+        "POST",
+        f"/admin/realms/{realms.managed_realm}/users",
+        operator=operator,
+        json=representation,
+    )
+    uuid = result.created_uuid()
+    if uuid is None and username:
+        uuid = await self._find_user_uuid(target, realms.managed_realm, username, operator=operator)
+    return {
+        "username": username,
+        "id": uuid,
+        "created": not result.conflict,
+        "conflict": result.conflict,
+    }
+
+
+async def keycloak_user_reset_password(
+    self: KeycloakConnector,
+    operator: Operator,
+    target: KeycloakTargetLike,
+    params: dict[str, Any],
+) -> dict[str, Any]:
+    """Reset a user's password from Vault (``PUT .../users/{id}/reset-password``).
+
+    Op-id: ``keycloak.user.reset_password``. Keys on the user's internal
+    UUID; pass it via ``id`` or pass ``username`` for name→UUID resolution.
+    The new password is read from Vault (``password_secret_ref``) and PUT
+    as a CredentialRepresentation — **never** an inline param. Returns a
+    value-free confirmation; the response never carries the password.
+    """
+    realms = resolve_realm_config(target)
+    uuid = _opt_str(params.get("id"))
+    username = _opt_str(params.get("username"))
+    if uuid is None:
+        if username is None:
+            raise ValueError(
+                "keycloak.user.reset_password requires either 'id' (UUID) or 'username'"
+            )
+        uuid = await self._find_user_uuid(target, realms.managed_realm, username, operator=operator)
+        if uuid is None:
+            raise KeycloakUserNotFoundError(
+                f"keycloak.user.reset_password: no user with username={username!r} in realm "
+                f"{realms.managed_realm!r}"
+            )
+    password = await _read_password_from_vault(operator, params)
+    credential = {"type": "password", "value": password, "temporary": _temporary_flag(params)}
+    await self._write_admin(
+        target,
+        "PUT",
+        f"/admin/realms/{realms.managed_realm}/users/{uuid}/reset-password",
+        operator=operator,
+        json=credential,
+        idempotent_conflict=False,
+    )
+    return {"id": uuid, "username": username, "password_reset": True}
+
+
+# ---------------------------------------------------------------------------
+# Role-mapping assign (privilege grant)
+# ---------------------------------------------------------------------------
+
+
+async def keycloak_role_mapping_assign(
+    self: KeycloakConnector,
+    operator: Operator,
+    target: KeycloakTargetLike,
+    params: dict[str, Any],
+) -> dict[str, Any]:
+    """Assign realm roles to a user (``POST .../users/{id}/role-mappings/realm``).
+
+    Op-id: ``keycloak.role_mapping.assign``. A privilege grant
+    (``safety_level="dangerous"``). Keys on the user's internal UUID (pass
+    ``id`` or ``username``). ``roles`` is a list of **realm role names**;
+    each is resolved to its full RoleRepresentation (the endpoint requires
+    ``{id, name}`` in the body). The realm role-mappings endpoint is
+    idempotent server-side — re-assigning an already-held role is a no-op —
+    so this op is naturally re-runnable. Raises
+    :exc:`KeycloakRoleNotFoundError` when a named role does not exist.
+    """
+    realms = resolve_realm_config(target)
+    uuid = _opt_str(params.get("id"))
+    username = _opt_str(params.get("username"))
+    if uuid is None:
+        if username is None:
+            raise ValueError(
+                "keycloak.role_mapping.assign requires either 'id' (UUID) or 'username'"
+            )
+        uuid = await self._find_user_uuid(target, realms.managed_realm, username, operator=operator)
+        if uuid is None:
+            raise KeycloakUserNotFoundError(
+                f"keycloak.role_mapping.assign: no user with username={username!r} in realm "
+                f"{realms.managed_realm!r}"
+            )
+    role_names = [str(r).strip() for r in params["roles"] if str(r).strip()]
+    role_reprs: list[dict[str, Any]] = []
+    for name in role_names:
+        role = await self._find_realm_role(target, realms.managed_realm, name, operator=operator)
+        if role is None:
+            raise KeycloakRoleNotFoundError(
+                f"keycloak.role_mapping.assign: realm role {name!r} does not exist in realm "
+                f"{realms.managed_realm!r}"
+            )
+        role_reprs.append(role)
+    await self._write_admin(
+        target,
+        "POST",
+        f"/admin/realms/{realms.managed_realm}/users/{uuid}/role-mappings/realm",
+        operator=operator,
+        json=role_reprs,  # type: ignore[arg-type]  # KC accepts a JSON array body here
+        idempotent_conflict=False,
+    )
+    return {"id": uuid, "username": username, "assigned_roles": role_names}
+
+
+def _opt_str(value: Any) -> str | None:
+    """Return a trimmed non-empty string, or ``None`` for absent/blank input."""
+    if isinstance(value, str):
+        trimmed = value.strip()
+        return trimmed or None
+    return None
+
+
+# The op-metadata table + curated blurbs + JSON-schema fragments live in a
+# sibling module so this handler module stays under the file-size budget.
+# Re-exported here so existing importers (and the connector's
+# ``register_operations`` walk) keep importing from ``ops_write``.
+from meho_backplane.connectors.keycloak.ops_write_schemas import (  # noqa: E402
+    WHEN_TO_USE_WRITE_BY_GROUP,
+    WRITE_OPS,
+)

--- a/backend/src/meho_backplane/connectors/keycloak/ops_write_schemas.py
+++ b/backend/src/meho_backplane/connectors/keycloak/ops_write_schemas.py
@@ -1,0 +1,470 @@
+# SPDX-License-Identifier: Apache-2.0
+# Copyright (c) 2026 evoila Group
+
+"""Op-metadata table + curated blurbs for the keycloak write ops (G3.13-T4 #1406).
+
+Split out of :mod:`~meho_backplane.connectors.keycloak.ops_write` so the
+handler module stays under the code-quality file-size budget (mirrors the
+Vault connector's ``ops_auth_write`` / ``ops_auth_write_schemas`` split).
+Carries the ``WRITE_OPS`` registration table, the per-group
+``when_to_use`` blurbs (``WHEN_TO_USE_WRITE_BY_GROUP``), and the reusable
+JSON-schema fragments. The handlers live in ``ops_write``; the connector
+imports ``WRITE_OPS`` + ``WHEN_TO_USE_WRITE_BY_GROUP`` (re-exported from
+``ops_write``) for its ``register_operations`` walk.
+"""
+
+from __future__ import annotations
+
+from typing import Any
+
+from meho_backplane.connectors.keycloak.ops_read import KeycloakOp
+
+__all__ = ["WHEN_TO_USE_WRITE_BY_GROUP", "WRITE_OPS"]
+
+
+# ---------------------------------------------------------------------------
+# Curated when_to_use blurbs (one per write op group)
+# ---------------------------------------------------------------------------
+
+_WHEN_TO_USE_REALM_WRITE = (
+    "Use to create a new Keycloak realm (``keycloak.realm.create``) or "
+    "update the managed realm's top-level config "
+    "(``keycloak.realm.update``). Both require human approval. Pass the "
+    "RealmRepresentation under ``representation``. Re-running a create is "
+    "idempotent (a 409 already-exists is treated as success)."
+)
+
+_WHEN_TO_USE_CLIENT_WRITE = (
+    "Use to create a Keycloak client (``keycloak.client.create``) or "
+    "update one (``keycloak.client.update``) — flows, redirect URIs, web "
+    "origins, mappers. Both require approval. Pass the "
+    "ClientRepresentation under ``representation``. Updates key on the "
+    "internal UUID — pass ``id`` directly, or pass ``client_id`` (the "
+    "human clientId) for name→UUID resolution. Create is idempotent on a "
+    "409 already-exists."
+)
+
+_WHEN_TO_USE_CLIENT_SCOPE_WRITE = (
+    "Use to create a reusable client scope "
+    "(``keycloak.client_scope.create``) — the bundle of protocol mappers "
+    "and role scope-mappings clients attach as default/optional scopes. "
+    "Requires approval. Pass the ClientScopeRepresentation under "
+    "``representation``. Idempotent on a 409 already-exists."
+)
+
+_WHEN_TO_USE_PROTOCOL_MAPPER_WRITE = (
+    "Use to add a protocol mapper to a client "
+    "(``keycloak.protocol_mapper.create``) — e.g. the ``tenant_id`` / "
+    "``tenant_role`` claim mappers the backplane row-scopes on. Requires "
+    "approval. Key on the client UUID (``id``) or pass ``client_id`` for "
+    "resolution; pass the ProtocolMapperRepresentation under "
+    "``representation``. Idempotent on a 409 already-exists."
+)
+
+_WHEN_TO_USE_USER_WRITE = (
+    "Use to create a user (``keycloak.user.create``) or reset a user's "
+    "password (``keycloak.user.reset_password``). Both require approval. "
+    "The password is NEVER passed inline — supply ``password_secret_ref`` "
+    "(a Vault KV-v2 path; optional ``password_secret_mount`` / "
+    "``password_secret_key``) and the connector reads it from Vault under "
+    "your identity. Create keys on ``username`` (idempotent on a 409); "
+    "reset keys on the user UUID (``id``) or ``username`` for resolution."
+)
+
+_WHEN_TO_USE_ROLE_MAPPING_WRITE = (
+    "Use to grant realm roles to a user "
+    "(``keycloak.role_mapping.assign``). A privilege grant — dangerous, "
+    "requires approval. Key on the user UUID (``id``) or ``username``; "
+    "pass ``roles`` as a list of realm role names. Each name is resolved "
+    "to its role representation; an unknown role errors. Re-assigning an "
+    "already-held role is a server-side no-op."
+)
+
+#: Curated ``when_to_use`` blurb per write op group. The group keys carry
+#: a ``_write`` suffix so they never collide with the read-op group keys
+#: in :data:`~meho_backplane.connectors.keycloak.ops_read.WHEN_TO_USE_BY_GROUP`
+#: when the connector merges both maps in ``register_operations``.
+WHEN_TO_USE_WRITE_BY_GROUP: dict[str, str] = {
+    "realm_write": _WHEN_TO_USE_REALM_WRITE,
+    "client_write": _WHEN_TO_USE_CLIENT_WRITE,
+    "client_scope_write": _WHEN_TO_USE_CLIENT_SCOPE_WRITE,
+    "protocol_mapper_write": _WHEN_TO_USE_PROTOCOL_MAPPER_WRITE,
+    "user_write": _WHEN_TO_USE_USER_WRITE,
+    "role_mapping_write": _WHEN_TO_USE_ROLE_MAPPING_WRITE,
+}
+
+# ---------------------------------------------------------------------------
+# Reusable JSON-schema fragments
+# ---------------------------------------------------------------------------
+
+_REPRESENTATION_PROP: dict[str, Any] = {
+    "type": "object",
+    "description": "The Keycloak Admin REST representation body for the object.",
+    "additionalProperties": True,
+}
+
+_PASSWORD_SECRET_PROPS: dict[str, Any] = {
+    "password_secret_ref": {
+        "type": "string",
+        "description": (
+            "Vault KV-v2 path the password is read from under the operator's "
+            "identity. The password is NEVER passed inline."
+        ),
+    },
+    "password_secret_mount": {
+        "type": "string",
+        "description": "Vault KV-v2 mount point (default 'secret').",
+    },
+    "password_secret_key": {
+        "type": "string",
+        "description": "Field within the Vault secret payload (default 'password').",
+    },
+    "temporary": {
+        "type": "boolean",
+        "description": "When true, forces a password change on first login (default false).",
+    },
+}
+
+_WRITE_CONFIRM_SCHEMA: dict[str, Any] = {
+    "type": "object",
+    "additionalProperties": True,
+}
+
+
+WRITE_OPS: tuple[KeycloakOp, ...] = (
+    KeycloakOp(
+        op_id="keycloak.realm.create",
+        handler_attr="realm_create",
+        summary="Create a Keycloak realm (approval-gated).",
+        description=(
+            "POSTs ``/admin/realms`` with the RealmRepresentation under "
+            "``representation``. The realm name is ``representation.realm`` "
+            "(or the ``realm`` param). A 409 already-exists is treated as an "
+            "idempotent success. requires_approval=True; dispatches via the "
+            "admin-auth path."
+        ),
+        parameter_schema={
+            "type": "object",
+            "properties": {
+                "representation": _REPRESENTATION_PROP,
+                "realm": {
+                    "type": "string",
+                    "description": "Realm name (if not in representation).",
+                },
+            },
+            "required": ["representation"],
+            "additionalProperties": False,
+        },
+        response_schema=_WRITE_CONFIRM_SCHEMA,
+        group_key="realm_write",
+        tags=("write", "realm", "keycloak"),
+        safety_level="dangerous",
+        requires_approval=True,
+        llm_instructions={
+            "when_to_use": _WHEN_TO_USE_REALM_WRITE,
+            "parameter_hints": {
+                "representation": "Full RealmRepresentation; at minimum {realm, enabled}.",
+            },
+            "output_shape": "``{realm, created, conflict}`` — no secret material.",
+        },
+    ),
+    KeycloakOp(
+        op_id="keycloak.realm.update",
+        handler_attr="realm_update",
+        summary="Update a Keycloak realm's top-level config (approval-gated).",
+        description=(
+            "PUTs ``/admin/realms/{realm}`` (default the target's managed "
+            "realm; ``realm`` overrides) with the partial "
+            "RealmRepresentation under ``representation``. "
+            "requires_approval=True; dispatches via the admin-auth path."
+        ),
+        parameter_schema={
+            "type": "object",
+            "properties": {
+                "representation": _REPRESENTATION_PROP,
+                "realm": {
+                    "type": "string",
+                    "description": "Realm to update (default managed_realm).",
+                },
+            },
+            "required": ["representation"],
+            "additionalProperties": False,
+        },
+        response_schema=_WRITE_CONFIRM_SCHEMA,
+        group_key="realm_write",
+        tags=("write", "realm", "keycloak"),
+        safety_level="caution",
+        requires_approval=True,
+        llm_instructions={
+            "when_to_use": _WHEN_TO_USE_REALM_WRITE,
+            "parameter_hints": {
+                "representation": "Partial RealmRepresentation to merge.",
+            },
+            "output_shape": "``{realm, updated}``.",
+        },
+    ),
+    KeycloakOp(
+        op_id="keycloak.client.create",
+        handler_attr="client_create",
+        summary="Create a Keycloak client (approval-gated).",
+        description=(
+            "POSTs ``/admin/realms/{realm}/clients`` with the "
+            "ClientRepresentation (flows / redirect URIs / mappers) under "
+            "``representation``. A 409 already-exists is idempotent; the "
+            "existing client's UUID is resolved. Returns the internal UUID "
+            "+ flags, never the client secret. requires_approval=True."
+        ),
+        parameter_schema={
+            "type": "object",
+            "properties": {
+                "representation": _REPRESENTATION_PROP,
+                "client_id": {
+                    "type": "string",
+                    "description": "clientId (if not in representation).",
+                },
+            },
+            "required": ["representation"],
+            "additionalProperties": False,
+        },
+        response_schema=_WRITE_CONFIRM_SCHEMA,
+        group_key="client_write",
+        tags=("write", "client", "keycloak"),
+        safety_level="caution",
+        requires_approval=True,
+        llm_instructions={
+            "when_to_use": _WHEN_TO_USE_CLIENT_WRITE,
+            "parameter_hints": {
+                "representation": "ClientRepresentation; at minimum {clientId}.",
+            },
+            "output_shape": "``{client_id, id, created, conflict}`` — secret never returned.",
+        },
+    ),
+    KeycloakOp(
+        op_id="keycloak.client.update",
+        handler_attr="client_update",
+        summary="Update a Keycloak client by UUID or clientId (approval-gated).",
+        description=(
+            "PUTs ``/admin/realms/{realm}/clients/{id}`` with the partial "
+            "ClientRepresentation under ``representation``. Keys on the "
+            "internal UUID — pass ``id`` directly, or pass ``client_id`` "
+            "(human clientId) for name→UUID resolution. "
+            "requires_approval=True."
+        ),
+        parameter_schema={
+            "type": "object",
+            "properties": {
+                "representation": _REPRESENTATION_PROP,
+                "id": {"type": "string", "description": "Client internal UUID."},
+                "client_id": {
+                    "type": "string",
+                    "description": "Human clientId (resolved to UUID if id absent).",
+                },
+            },
+            "required": ["representation"],
+            "additionalProperties": False,
+        },
+        response_schema=_WRITE_CONFIRM_SCHEMA,
+        group_key="client_write",
+        tags=("write", "client", "keycloak"),
+        safety_level="caution",
+        requires_approval=True,
+        llm_instructions={
+            "when_to_use": _WHEN_TO_USE_CLIENT_WRITE,
+            "parameter_hints": {
+                "id": "Client internal UUID (from keycloak.client.list).",
+                "client_id": "Human clientId; resolved to UUID when id is absent.",
+            },
+            "output_shape": "``{id, client_id, updated}``.",
+        },
+    ),
+    KeycloakOp(
+        op_id="keycloak.client_scope.create",
+        handler_attr="client_scope_create",
+        summary="Create a Keycloak client scope (approval-gated).",
+        description=(
+            "POSTs ``/admin/realms/{realm}/client-scopes`` with the "
+            "ClientScopeRepresentation (its ``protocolMappers`` ride in the "
+            "body) under ``representation``. A 409 already-exists is "
+            "idempotent. requires_approval=True."
+        ),
+        parameter_schema={
+            "type": "object",
+            "properties": {
+                "representation": _REPRESENTATION_PROP,
+                "name": {"type": "string", "description": "Scope name (if not in representation)."},
+            },
+            "required": ["representation"],
+            "additionalProperties": False,
+        },
+        response_schema=_WRITE_CONFIRM_SCHEMA,
+        group_key="client_scope_write",
+        tags=("write", "client-scope", "keycloak"),
+        safety_level="caution",
+        requires_approval=True,
+        llm_instructions={
+            "when_to_use": _WHEN_TO_USE_CLIENT_SCOPE_WRITE,
+            "parameter_hints": {
+                "representation": "ClientScopeRepresentation; at minimum {name, protocol}.",
+            },
+            "output_shape": "``{name, id, created, conflict}``.",
+        },
+    ),
+    KeycloakOp(
+        op_id="keycloak.protocol_mapper.create",
+        handler_attr="protocol_mapper_create",
+        summary="Add a protocol mapper to a client (approval-gated).",
+        description=(
+            "POSTs ``.../clients/{id}/protocol-mappers/models`` with the "
+            "ProtocolMapperRepresentation under ``representation`` — wires "
+            "claims like ``tenant_id`` / ``tenant_role``. Keys on the "
+            "client UUID (``id``) or ``client_id`` for resolution. A 409 "
+            "already-exists is idempotent. requires_approval=True."
+        ),
+        parameter_schema={
+            "type": "object",
+            "properties": {
+                "representation": _REPRESENTATION_PROP,
+                "id": {"type": "string", "description": "Client internal UUID."},
+                "client_id": {
+                    "type": "string",
+                    "description": "Human clientId (resolved to UUID if id absent).",
+                },
+            },
+            "required": ["representation"],
+            "additionalProperties": False,
+        },
+        response_schema=_WRITE_CONFIRM_SCHEMA,
+        group_key="protocol_mapper_write",
+        tags=("write", "protocol-mapper", "keycloak"),
+        safety_level="caution",
+        requires_approval=True,
+        llm_instructions={
+            "when_to_use": _WHEN_TO_USE_PROTOCOL_MAPPER_WRITE,
+            "parameter_hints": {
+                "representation": "ProtocolMapperRepresentation: {name, protocol, protocolMapper}.",
+                "client_id": "Human clientId; resolved to UUID when id is absent.",
+            },
+            "output_shape": "``{client_uuid, client_id, mapper_name, created, conflict}``.",
+        },
+    ),
+    KeycloakOp(
+        op_id="keycloak.user.create",
+        handler_attr="user_create",
+        summary="Create a user with a Vault-sourced password (approval-gated).",
+        description=(
+            "POSTs ``/admin/realms/{realm}/users`` with the "
+            "UserRepresentation under ``representation``. The password is "
+            "read from Vault (``password_secret_ref``) and set as a "
+            "credential — NEVER passed inline. A 409 already-exists is "
+            "idempotent; the existing user's UUID is resolved. Returns the "
+            "UUID + flags, never the password. requires_approval=True."
+        ),
+        parameter_schema={
+            "type": "object",
+            "properties": {
+                "representation": _REPRESENTATION_PROP,
+                "username": {
+                    "type": "string",
+                    "description": "Username (if not in representation).",
+                },
+                **_PASSWORD_SECRET_PROPS,
+            },
+            "required": ["representation"],
+            "additionalProperties": False,
+        },
+        response_schema=_WRITE_CONFIRM_SCHEMA,
+        group_key="user_write",
+        tags=("write", "user", "keycloak"),
+        safety_level="caution",
+        requires_approval=True,
+        llm_instructions={
+            "when_to_use": _WHEN_TO_USE_USER_WRITE,
+            "parameter_hints": {
+                "representation": "UserRepresentation; at minimum {username, enabled}.",
+                "password_secret_ref": "Vault KV-v2 path to the password. Never pass it inline.",
+            },
+            "output_shape": "``{username, id, created, conflict}`` — password never returned.",
+        },
+    ),
+    KeycloakOp(
+        op_id="keycloak.user.reset_password",
+        handler_attr="user_reset_password",
+        summary="Reset a user's password from Vault (approval-gated).",
+        description=(
+            "PUTs ``.../users/{id}/reset-password`` with a "
+            "CredentialRepresentation whose value is read from Vault "
+            "(``password_secret_ref``) — NEVER passed inline. Keys on the "
+            "user UUID (``id``) or ``username`` for resolution. Returns a "
+            "value-free confirmation. requires_approval=True."
+        ),
+        parameter_schema={
+            "type": "object",
+            "properties": {
+                "id": {"type": "string", "description": "User internal UUID."},
+                "username": {
+                    "type": "string",
+                    "description": "Username (resolved to UUID if id absent).",
+                },
+                **_PASSWORD_SECRET_PROPS,
+            },
+            "required": ["password_secret_ref"],
+            "additionalProperties": False,
+        },
+        response_schema=_WRITE_CONFIRM_SCHEMA,
+        group_key="user_write",
+        tags=("write", "user", "keycloak"),
+        safety_level="caution",
+        requires_approval=True,
+        llm_instructions={
+            "when_to_use": _WHEN_TO_USE_USER_WRITE,
+            "parameter_hints": {
+                "password_secret_ref": "Vault KV-v2 path to the new password. Never inline.",
+                "username": "Username; resolved to UUID when id is absent.",
+            },
+            "output_shape": "``{id, username, password_reset}`` — password never returned.",
+        },
+    ),
+    KeycloakOp(
+        op_id="keycloak.role_mapping.assign",
+        handler_attr="role_mapping_assign",
+        summary="Grant realm roles to a user — privilege grant (approval-gated).",
+        description=(
+            "POSTs ``.../users/{id}/role-mappings/realm`` with the resolved "
+            "RoleRepresentations for the named ``roles``. A privilege grant "
+            "(dangerous). Keys on the user UUID (``id``) or ``username``. "
+            "Each role name is resolved to its representation; an unknown "
+            "role errors. Re-assigning a held role is a server-side no-op. "
+            "requires_approval=True."
+        ),
+        parameter_schema={
+            "type": "object",
+            "properties": {
+                "id": {"type": "string", "description": "User internal UUID."},
+                "username": {
+                    "type": "string",
+                    "description": "Username (resolved to UUID if id absent).",
+                },
+                "roles": {
+                    "type": "array",
+                    "items": {"type": "string"},
+                    "description": "Realm role names to grant.",
+                },
+            },
+            "required": ["roles"],
+            "additionalProperties": False,
+        },
+        response_schema=_WRITE_CONFIRM_SCHEMA,
+        group_key="role_mapping_write",
+        tags=("write", "role-mapping", "keycloak"),
+        safety_level="dangerous",
+        requires_approval=True,
+        llm_instructions={
+            "when_to_use": _WHEN_TO_USE_ROLE_MAPPING_WRITE,
+            "parameter_hints": {
+                "roles": "List of realm role names (e.g. ['tenant_admin']).",
+                "username": "Username; resolved to UUID when id is absent.",
+            },
+            "output_shape": "``{id, username, assigned_roles}``.",
+        },
+    ),
+)

--- a/backend/tests/test_connectors_keycloak_write_e2e.py
+++ b/backend/tests/test_connectors_keycloak_write_e2e.py
@@ -1,0 +1,511 @@
+# SPDX-License-Identifier: Apache-2.0
+# Copyright (c) 2026 evoila Group
+
+"""G3.13-T4 Keycloak write-op recorded-fixture E2E test (#1406).
+
+Drives the nine approval-gated keycloak write ops through the full
+``call_operation`` dispatch stack against a respx-mocked Keycloak Admin
+REST API — no running Keycloak, no live Vault. The admin-credential loader
+and the user-password Vault read are both stubbed; ``respx`` replays the
+Admin REST create/update fixtures; the connector instance is preseeded into
+the dispatcher's instance cache.
+
+Acceptance criteria verified (Issue #1406)
+==========================================
+
+(a) The nine write ops register with the stated safety levels, all
+    ``requires_approval=True`` (asserted on ``WRITE_OPS``).
+(b) Writes resolve name→UUID: ``client.update`` /
+    ``protocol_mapper.create`` resolve a clientId to its UUID via
+    ``?clientId=``; ``user.reset_password`` / ``role_mapping.assign``
+    resolve a username to its UUID.
+(c) Writes are idempotent: a 409 already-exists on a create is treated as
+    success (``conflict=true``) with the existing object's UUID resolved.
+(d) ``user.create`` / ``user.reset_password`` never carry the password in
+    op params (it is sourced from Vault) and the password never appears in
+    the result, the audit params view, or the redacted broadcast payload.
+"""
+
+from __future__ import annotations
+
+import uuid
+from collections.abc import AsyncIterator, Iterator
+from typing import Any
+
+import pytest
+import respx
+
+import meho_backplane.connectors.keycloak  # noqa: F401 -- import for registry side-effects
+from meho_backplane.auth.operator import Operator, TenantRole
+from meho_backplane.broadcast.events import classify_op, redact_payload
+from meho_backplane.connectors.keycloak import KeycloakConnector
+from meho_backplane.connectors.keycloak.ops_write import WRITE_OPS
+from meho_backplane.connectors.keycloak.session import (
+    KeycloakAdminCredentials,
+    KeycloakClientCredentials,
+    KeycloakTargetLike,
+)
+from meho_backplane.db.engine import get_sessionmaker
+from meho_backplane.db.models import Target as TargetORM
+from meho_backplane.operations import dispatch, reset_dispatcher_caches
+from meho_backplane.operations.dispatcher import set_default_reducer
+from meho_backplane.operations.meta_tools import search_operations
+from meho_backplane.operations.reducer import PassThroughReducer
+from meho_backplane.targets.resolver import resolve_target
+
+_CONNECTOR_ID = "keycloak-admin-26.x"
+_TARGET_NAME = "rdc-keycloak-write-e2e"
+_KC_HOST = "keycloak-write-e2e.test.invalid"
+_KC_BASE_URL = f"https://{_KC_HOST}"
+_ADMIN_TOKEN = "kc-admin-token-write-e2e"
+_CLIENT_UUID = "33333333-3333-3333-3333-333333333333"
+_USER_UUID = "44444444-4444-4444-4444-444444444444"
+_NEW_CLIENT_UUID = "55555555-5555-5555-5555-555555555555"
+_NEW_USER_UUID = "66666666-6666-6666-6666-666666666666"
+
+#: The password sentinel the Vault stub returns. The whole point of the
+#: security assertion is that this string never escapes into the op
+#: result, the audit params view, or the broadcast payload.
+_PASSWORD_SENTINEL = "vault-sourced-password-DO-NOT-LEAK"
+_PASSWORD_SECRET_REF = "rdc-hetzner-dc/keycloak/operator-a-password"
+
+_OPERATOR_TENANT_ID = uuid.UUID("00000000-0000-0000-0000-0000000000ae")
+_OPERATOR = Operator(
+    sub="keycloak-write-e2e-test",
+    name="Keycloak Write E2E Test Operator",
+    email=None,
+    raw_jwt="<keycloak-write-e2e-raw-jwt>",
+    tenant_id=_OPERATOR_TENANT_ID,
+    tenant_role=TenantRole.TENANT_ADMIN,
+)
+
+EXPECTED_WRITE_OP_IDS: tuple[str, ...] = (
+    "keycloak.realm.create",
+    "keycloak.realm.update",
+    "keycloak.client.create",
+    "keycloak.client.update",
+    "keycloak.client_scope.create",
+    "keycloak.protocol_mapper.create",
+    "keycloak.user.create",
+    "keycloak.user.reset_password",
+    "keycloak.role_mapping.assign",
+)
+
+#: Expected (safety_level, requires_approval) per op — the registration
+#: contract the issue's op table pins.
+EXPECTED_SAFETY: dict[str, str] = {
+    "keycloak.realm.create": "dangerous",
+    "keycloak.realm.update": "caution",
+    "keycloak.client.create": "caution",
+    "keycloak.client.update": "caution",
+    "keycloak.client_scope.create": "caution",
+    "keycloak.protocol_mapper.create": "caution",
+    "keycloak.user.create": "caution",
+    "keycloak.user.reset_password": "caution",
+    "keycloak.role_mapping.assign": "dangerous",
+}
+
+
+# ---------------------------------------------------------------------------
+# Recorded Admin REST fixtures
+# ---------------------------------------------------------------------------
+
+_EXISTING_CLIENT = {"id": _CLIENT_UUID, "clientId": "meho-web", "enabled": True}
+_EXISTING_USER = {"id": _USER_UUID, "username": "operator-a", "enabled": True}
+_REALM_ROLE = {"id": "role-uuid-9", "name": "tenant_admin", "composite": False}
+
+
+def _location(path: str) -> dict[str, str]:
+    """Build a Location response header for a Keycloak create."""
+    return {"Location": f"{_KC_BASE_URL}{path}"}
+
+
+def _mount_token(mock: respx.MockRouter) -> None:
+    mock.post("/realms/master/protocol/openid-connect/token").respond(
+        200, json={"access_token": _ADMIN_TOKEN, "expires_in": 300}
+    )
+
+
+# ---------------------------------------------------------------------------
+# Stub credential loader + Vault password reader + seeded connector
+# ---------------------------------------------------------------------------
+
+
+def _stub_loader(_target: KeycloakTargetLike, _operator: Operator) -> Any:
+    async def _load() -> KeycloakAdminCredentials:
+        return KeycloakClientCredentials(client_id="meho-admin", client_secret="stub-secret")
+
+    return _load()
+
+
+async def _stub_read_password(_operator: Operator, params: dict[str, Any]) -> str:
+    """Stand in for the operator-context Vault read.
+
+    Asserts the password is sourced via a Vault *path*, never inline: the
+    op params must carry ``password_secret_ref`` and must NOT carry an
+    inline ``password``.
+    """
+    assert params.get("password_secret_ref") == _PASSWORD_SECRET_REF
+    assert "password" not in params, "password must never be an inline op param"
+    return _PASSWORD_SENTINEL
+
+
+async def _seed_keycloak_target() -> TargetORM:
+    sessionmaker = get_sessionmaker()
+    async with sessionmaker() as session:
+        target = TargetORM(
+            tenant_id=_OPERATOR_TENANT_ID,
+            name=_TARGET_NAME,
+            aliases=[],
+            product="keycloak",
+            host=_KC_HOST,
+            port=443,
+            fqdn=None,
+            secret_ref="rdc-hetzner-dc/keycloak/admin",
+            auth_model="shared_service_account",
+            vpn_required=False,
+            extras={},
+            fingerprint={"version": "26.0.5"},
+            notes="seeded by test_connectors_keycloak_write_e2e",
+        )
+        session.add(target)
+        await session.commit()
+        await session.refresh(target)
+        session.expunge(target)
+        return target
+
+
+def _wire_seeded_connector() -> KeycloakConnector:
+    instance = KeycloakConnector(credentials_loader=_stub_loader)
+    from meho_backplane.operations._handler_resolve import _CONNECTOR_INSTANCE_CACHE
+
+    _CONNECTOR_INSTANCE_CACHE[KeycloakConnector] = instance
+    return instance
+
+
+@pytest.fixture(autouse=True)
+def _required_settings_env(monkeypatch: pytest.MonkeyPatch) -> Iterator[None]:
+    from meho_backplane.settings import get_settings
+
+    monkeypatch.setenv("KEYCLOAK_ISSUER_URL", "https://keycloak.test/realms/meho")
+    monkeypatch.setenv("KEYCLOAK_AUDIENCE", "meho-backplane")
+    monkeypatch.setenv("VAULT_ADDR", "https://vault.test")
+    get_settings.cache_clear()
+    yield
+    get_settings.cache_clear()
+
+
+@pytest.fixture(autouse=True)
+def _reset_module_state() -> Iterator[None]:
+    reset_dispatcher_caches()
+    yield
+    reset_dispatcher_caches()
+
+
+@pytest.fixture
+async def keycloak_write_e2e(monkeypatch: pytest.MonkeyPatch) -> AsyncIterator[KeycloakConnector]:
+    set_default_reducer(PassThroughReducer())
+    # Stub the operator-context Vault read so no live Vault is needed.
+    monkeypatch.setattr(
+        "meho_backplane.connectors.keycloak.ops_write._read_password_from_vault",
+        _stub_read_password,
+    )
+    await KeycloakConnector.register_operations()
+    await _seed_keycloak_target()
+    connector = _wire_seeded_connector()
+    yield connector
+    await connector.aclose()
+
+
+async def _dispatch(op_id: str, params: dict[str, Any]) -> dict[str, Any]:
+    """Dispatch a write op, bypassing the approval gate.
+
+    Every write registers ``requires_approval=True``; an ordinary
+    ``call_operation`` would park the call in the approval queue
+    (``status=awaiting_approval``) and never reach the handler. ``_approved=True``
+    is the resume-path flag the approvals API sets after a human approves —
+    it lets the E2E drive the handler/audit/broadcast path that runs once a
+    write is authorised. The target is resolved by name the same way
+    ``call_operation`` resolves it.
+    """
+    sessionmaker = get_sessionmaker()
+    async with sessionmaker() as session:
+        resolved_target = await resolve_target(session, _OPERATOR.tenant_id, _TARGET_NAME)
+    result = await dispatch(
+        operator=_OPERATOR,
+        connector_id=_CONNECTOR_ID,
+        op_id=op_id,
+        target=resolved_target,
+        params=params,
+        _approved=True,
+    )
+    dumped: dict[str, Any] = result.model_dump(mode="json")
+    return dumped
+
+
+# ---------------------------------------------------------------------------
+# Registration contract (acceptance criterion a)
+# ---------------------------------------------------------------------------
+
+
+def test_write_ops_registration_set() -> None:
+    """WRITE_OPS carries exactly the nine write ops the issue lists."""
+    op_ids = {op.op_id for op in WRITE_OPS}
+    assert op_ids == set(EXPECTED_WRITE_OP_IDS)
+    assert len(WRITE_OPS) == 9
+
+
+def test_write_ops_safety_levels_and_approval() -> None:
+    """Every write op has the stated safety level and requires_approval=True."""
+    for op in WRITE_OPS:
+        assert op.requires_approval is True, f"{op.op_id} must require approval"
+        assert op.safety_level == EXPECTED_SAFETY[op.op_id], (
+            f"{op.op_id} safety_level={op.safety_level} != {EXPECTED_SAFETY[op.op_id]}"
+        )
+        assert "write" in op.tags, f"{op.op_id} should carry the write tag"
+
+
+def test_idp_create_is_deferred() -> None:
+    """idp.create is deliberately deferred — no idp write op is registered."""
+    assert not any("idp" in op.op_id for op in WRITE_OPS)
+
+
+# ---------------------------------------------------------------------------
+# Name → UUID resolution (acceptance criterion b)
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.asyncio
+async def test_client_update_resolves_clientid_to_uuid(
+    keycloak_write_e2e: KeycloakConnector,
+) -> None:
+    """client.update resolves a human clientId to its internal UUID before the PUT."""
+    with respx.mock(base_url=_KC_BASE_URL, assert_all_called=False) as mock:
+        _mount_token(mock)
+        list_route = mock.get("/admin/realms/evba/clients").respond(200, json=[_EXISTING_CLIENT])
+        put_route = mock.put(f"/admin/realms/evba/clients/{_CLIENT_UUID}").respond(204)
+        result = await _dispatch(
+            "keycloak.client.update",
+            {"client_id": "meho-web", "representation": {"enabled": False}},
+        )
+    assert result["status"] == "ok", result.get("error")
+    assert result["result"]["id"] == _CLIENT_UUID
+    assert list_route.called, "should have looked up the clientId → UUID"
+    assert put_route.called, "should have PUT against the resolved UUID"
+
+
+@pytest.mark.asyncio
+async def test_protocol_mapper_create_resolves_clientid(
+    keycloak_write_e2e: KeycloakConnector,
+) -> None:
+    """protocol_mapper.create resolves clientId → UUID and POSTs the mapper."""
+    with respx.mock(base_url=_KC_BASE_URL, assert_all_called=False) as mock:
+        _mount_token(mock)
+        mock.get("/admin/realms/evba/clients").respond(200, json=[_EXISTING_CLIENT])
+        post_route = mock.post(
+            f"/admin/realms/evba/clients/{_CLIENT_UUID}/protocol-mappers/models"
+        ).respond(201, headers=_location(f"/admin/realms/evba/clients/{_CLIENT_UUID}"))
+        result = await _dispatch(
+            "keycloak.protocol_mapper.create",
+            {
+                "client_id": "meho-web",
+                "representation": {
+                    "name": "tenant_id",
+                    "protocol": "openid-connect",
+                    "protocolMapper": "oidc-usermodel-attribute-mapper",
+                    "config": {"claim.name": "tenant_id"},
+                },
+            },
+        )
+    assert result["status"] == "ok", result.get("error")
+    assert result["result"]["client_uuid"] == _CLIENT_UUID
+    assert result["result"]["mapper_name"] == "tenant_id"
+    assert post_route.called
+
+
+@pytest.mark.asyncio
+async def test_role_mapping_assign_resolves_username_and_role(
+    keycloak_write_e2e: KeycloakConnector,
+) -> None:
+    """role_mapping.assign resolves username→UUID and role-name→representation."""
+    with respx.mock(base_url=_KC_BASE_URL, assert_all_called=False) as mock:
+        _mount_token(mock)
+        mock.get("/admin/realms/evba/users").respond(200, json=[_EXISTING_USER])
+        mock.get("/admin/realms/evba/roles/tenant_admin").respond(200, json=_REALM_ROLE)
+        post_route = mock.post(
+            f"/admin/realms/evba/users/{_USER_UUID}/role-mappings/realm"
+        ).respond(204)
+        result = await _dispatch(
+            "keycloak.role_mapping.assign",
+            {"username": "operator-a", "roles": ["tenant_admin"]},
+        )
+    assert result["status"] == "ok", result.get("error")
+    assert result["result"]["id"] == _USER_UUID
+    assert result["result"]["assigned_roles"] == ["tenant_admin"]
+    # The POST body carried the resolved RoleRepresentation, not the name.
+    body = post_route.calls.last.request.content
+    assert b"role-uuid-9" in body
+
+
+# ---------------------------------------------------------------------------
+# Idempotency (acceptance criterion c)
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.asyncio
+async def test_client_create_409_is_idempotent(keycloak_write_e2e: KeycloakConnector) -> None:
+    """A 409 already-exists on client.create is a success; the UUID is resolved."""
+    with respx.mock(base_url=_KC_BASE_URL, assert_all_called=False) as mock:
+        _mount_token(mock)
+        mock.post("/admin/realms/evba/clients").respond(409, json={"errorMessage": "exists"})
+        mock.get("/admin/realms/evba/clients").respond(200, json=[_EXISTING_CLIENT])
+        result = await _dispatch(
+            "keycloak.client.create",
+            {"representation": {"clientId": "meho-web"}},
+        )
+    assert result["status"] == "ok", result.get("error")
+    assert result["result"]["conflict"] is True
+    assert result["result"]["created"] is False
+    assert result["result"]["id"] == _CLIENT_UUID
+
+
+@pytest.mark.asyncio
+async def test_client_create_201_returns_new_uuid(keycloak_write_e2e: KeycloakConnector) -> None:
+    """A fresh client.create parses the new UUID out of the Location header."""
+    with respx.mock(base_url=_KC_BASE_URL, assert_all_called=False) as mock:
+        _mount_token(mock)
+        mock.post("/admin/realms/evba/clients").respond(
+            201, headers=_location(f"/admin/realms/evba/clients/{_NEW_CLIENT_UUID}")
+        )
+        result = await _dispatch(
+            "keycloak.client.create",
+            {"representation": {"clientId": "meho-fresh"}},
+        )
+    assert result["status"] == "ok", result.get("error")
+    assert result["result"]["created"] is True
+    assert result["result"]["conflict"] is False
+    assert result["result"]["id"] == _NEW_CLIENT_UUID
+
+
+@pytest.mark.asyncio
+async def test_realm_create_409_is_idempotent(keycloak_write_e2e: KeycloakConnector) -> None:
+    """A 409 already-exists on realm.create is a success (conflict=true)."""
+    with respx.mock(base_url=_KC_BASE_URL, assert_all_called=False) as mock:
+        _mount_token(mock)
+        mock.post("/admin/realms").respond(409, json={"errorMessage": "exists"})
+        result = await _dispatch(
+            "keycloak.realm.create",
+            {"representation": {"realm": "evba", "enabled": True}},
+        )
+    assert result["status"] == "ok", result.get("error")
+    assert result["result"]["conflict"] is True
+    assert result["result"]["realm"] == "evba"
+
+
+# ---------------------------------------------------------------------------
+# Password handling (acceptance criterion d) — critical security
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.asyncio
+async def test_user_create_sources_password_from_vault_never_leaks(
+    keycloak_write_e2e: KeycloakConnector,
+) -> None:
+    """user.create sources the password from Vault; it never leaks into the result."""
+    with respx.mock(base_url=_KC_BASE_URL, assert_all_called=False) as mock:
+        _mount_token(mock)
+        post_route = mock.post("/admin/realms/evba/users").respond(
+            201, headers=_location(f"/admin/realms/evba/users/{_NEW_USER_UUID}")
+        )
+        result = await _dispatch(
+            "keycloak.user.create",
+            {
+                "representation": {"username": "operator-b", "enabled": True},
+                "password_secret_ref": _PASSWORD_SECRET_REF,
+            },
+        )
+    assert result["status"] == "ok", result.get("error")
+    assert result["result"]["id"] == _NEW_USER_UUID
+    assert result["result"]["created"] is True
+    # The password is in the create body sent to Keycloak (expected) ...
+    assert _PASSWORD_SENTINEL.encode() in post_route.calls.last.request.content
+    # ... but NEVER in the op result returned to the caller / audit / broadcast.
+    assert _PASSWORD_SENTINEL not in str(result)
+
+
+@pytest.mark.asyncio
+async def test_user_reset_password_resolves_username_and_no_leak(
+    keycloak_write_e2e: KeycloakConnector,
+) -> None:
+    """user.reset_password resolves username→UUID and never leaks the password."""
+    with respx.mock(base_url=_KC_BASE_URL, assert_all_called=False) as mock:
+        _mount_token(mock)
+        mock.get("/admin/realms/evba/users").respond(200, json=[_EXISTING_USER])
+        put_route = mock.put(f"/admin/realms/evba/users/{_USER_UUID}/reset-password").respond(204)
+        result = await _dispatch(
+            "keycloak.user.reset_password",
+            {"username": "operator-a", "password_secret_ref": _PASSWORD_SECRET_REF},
+        )
+    assert result["status"] == "ok", result.get("error")
+    assert result["result"]["id"] == _USER_UUID
+    assert result["result"]["password_reset"] is True
+    assert _PASSWORD_SENTINEL.encode() in put_route.calls.last.request.content
+    assert _PASSWORD_SENTINEL not in str(result)
+
+
+def test_user_credential_ops_classify_credential_write() -> None:
+    """The password-touching ops collapse to aggregate-only on the broadcast feed."""
+    for op_id in ("keycloak.user.create", "keycloak.user.reset_password"):
+        assert classify_op(op_id) == "credential_write"
+        # The redacted broadcast payload never carries params (aggregate-only).
+        payload = redact_payload(
+            "credential_write",
+            {"password_secret_ref": _PASSWORD_SECRET_REF, "username": "operator-a"},
+            "ok",
+        )
+        assert "params" not in payload
+        assert payload == {"op_class": "credential_write", "result_status": "ok"}
+
+
+def test_role_mapping_assign_classifies_write() -> None:
+    """role_mapping.assign classifies as a plain write (mutation feed signal)."""
+    assert classify_op("keycloak.role_mapping.assign") == "write"
+
+
+# ---------------------------------------------------------------------------
+# Admin-token-only invariant + search visibility
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.asyncio
+async def test_writes_use_admin_token_never_operator_jwt(
+    keycloak_write_e2e: KeycloakConnector,
+) -> None:
+    """Every write carries the admin Bearer, never the operator JWT."""
+    with respx.mock(base_url=_KC_BASE_URL, assert_all_called=False) as mock:
+        _mount_token(mock)
+        mock.post("/admin/realms").respond(201, headers=_location("/admin/realms/evba"))
+        await _dispatch("keycloak.realm.create", {"representation": {"realm": "evba"}})
+        for call in mock.calls:
+            req = call.request
+            if req.url.path.startswith("/admin/"):
+                assert req.headers.get("authorization") == f"Bearer {_ADMIN_TOKEN}"
+            assert _OPERATOR.raw_jwt not in (req.headers.get("authorization") or "")
+
+
+@pytest.mark.asyncio
+async def test_write_ops_visible_to_search_operations(
+    keycloak_write_e2e: KeycloakConnector,
+) -> None:
+    """All nine write ops are discoverable via search_operations."""
+    result = await search_operations(
+        _OPERATOR,
+        {
+            "connector_id": _CONNECTOR_ID,
+            "query": "keycloak create update realm client user role password",
+            "limit": 50,
+        },
+    )
+    surfaced = {hit["op_id"] for hit in result["hits"]}
+    missing = set(EXPECTED_WRITE_OP_IDS) - surfaced
+    assert not missing, f"search_operations did not surface: {missing}"

--- a/cli/internal/cmd/keycloak/client.go
+++ b/cli/internal/cmd/keycloak/client.go
@@ -13,17 +13,119 @@ import (
 	"github.com/evoila/meho/cli/internal/output"
 )
 
-// newClientCmd returns the `meho keycloak client` parent with two
-// sub-verbs: `list` (keycloak.client.list) and `get`
-// (keycloak.client.get).
+// newClientCmd returns the `meho keycloak client` parent with the read
+// verbs `list` / `get` and the approval-gated write verbs `create`
+// (keycloak.client.create) and `update` (keycloak.client.update).
 func newClientCmd() *cobra.Command {
 	cmd := &cobra.Command{
 		Use:          "client",
-		Short:        "Keycloak client sub-verbs (list, get)",
+		Short:        "Keycloak client sub-verbs (list, get, create, update)",
 		SilenceUsage: true,
 	}
 	cmd.AddCommand(newClientListCmd())
 	cmd.AddCommand(newClientGetCmd())
+	cmd.AddCommand(newClientCreateCmd())
+	cmd.AddCommand(newClientUpdateCmd())
+	return cmd
+}
+
+// newClientCreateCmd returns the `meho keycloak client create` command
+// (keycloak.client.create — approval-gated). POSTs
+// /admin/realms/{realm}/clients with the ClientRepresentation from
+// --representation-file. A 409 already-exists is idempotent and the
+// existing client's UUID is resolved.
+func newClientCreateCmd() *cobra.Command {
+	var (
+		f       writeFlags
+		repFile string
+	)
+	cmd := &cobra.Command{
+		Use:   "create",
+		Short: "Create a Keycloak client (approval-gated)",
+		Long: "create dispatches keycloak.client.create with the\n" +
+			"ClientRepresentation (flows / redirect URIs / mappers) read from\n" +
+			"--representation-file (JSON). Requires approval; a 409\n" +
+			"already-exists is an idempotent success. The client secret is\n" +
+			"never returned.\n\n" +
+			"Exit codes: 0=ok, 1=error/denied, 2=auth_expired,\n" +
+			"3=unreachable, 4=unexpected.",
+		Example:       "  meho keycloak client create --target rdc-keycloak -f client-meho-web.json",
+		Args:          cobra.NoArgs,
+		SilenceUsage:  true,
+		SilenceErrors: true,
+		RunE: func(cmd *cobra.Command, _ []string) error {
+			rep, serr := loadRepresentation(repFile)
+			if serr != nil {
+				return output.RenderError(cmd.ErrOrStderr(), serr, f.jsonOut)
+			}
+			return dispatchWrite(cmd, "keycloak.client.create", f.targetName,
+				map[string]any{"representation": rep}, f.jsonOut, f.backplaneOverride)
+		},
+	}
+	f.bind(cmd)
+	cmd.Flags().StringVarP(&repFile, "representation-file", "f", "",
+		"path to a JSON file with the ClientRepresentation body (required)")
+	if err := cmd.MarkFlagRequired("representation-file"); err != nil {
+		panic(err) // programmer error: the flag is defined directly above
+	}
+	return cmd
+}
+
+// newClientUpdateCmd returns the `meho keycloak client update` command
+// (keycloak.client.update — approval-gated). PUTs
+// /admin/realms/{realm}/clients/{id}. Keys on the client UUID — pass --id
+// directly, or pass --client-id (the human clientId) for name→UUID
+// resolution.
+func newClientUpdateCmd() *cobra.Command {
+	var (
+		f          writeFlags
+		repFile    string
+		clientUUID string
+		clientID   string
+	)
+	cmd := &cobra.Command{
+		Use:   "update",
+		Short: "Update a Keycloak client by UUID or clientId (approval-gated)",
+		Long: "update dispatches keycloak.client.update with the partial\n" +
+			"ClientRepresentation from --representation-file (JSON). Keys on the\n" +
+			"internal UUID — pass --id directly, or pass --client-id (the human\n" +
+			"clientId) and the connector resolves the UUID. Requires approval.\n\n" +
+			"Exit codes: 0=ok, 1=error/denied, 2=auth_expired,\n" +
+			"3=unreachable, 4=unexpected.",
+		Example:       "  meho keycloak client update --target rdc-keycloak --client-id meho-web -f client-patch.json",
+		Args:          cobra.NoArgs,
+		SilenceUsage:  true,
+		SilenceErrors: true,
+		RunE: func(cmd *cobra.Command, _ []string) error {
+			if clientUUID == "" && clientID == "" {
+				return output.RenderError(cmd.ErrOrStderr(),
+					output.Unexpected("one of --id or --client-id is required"), f.jsonOut)
+			}
+			rep, serr := loadRepresentation(repFile)
+			if serr != nil {
+				return output.RenderError(cmd.ErrOrStderr(), serr, f.jsonOut)
+			}
+			params := map[string]any{"representation": rep}
+			if clientUUID != "" {
+				params["id"] = clientUUID
+			}
+			if clientID != "" {
+				params["client_id"] = clientID
+			}
+			return dispatchWrite(cmd, "keycloak.client.update", f.targetName,
+				params, f.jsonOut, f.backplaneOverride)
+		},
+	}
+	f.bind(cmd)
+	cmd.Flags().StringVarP(&repFile, "representation-file", "f", "",
+		"path to a JSON file with the partial ClientRepresentation body (required)")
+	cmd.Flags().StringVar(&clientUUID, "id", "",
+		"the client's internal UUID (skips name→UUID resolution)")
+	cmd.Flags().StringVar(&clientID, "client-id", "",
+		"the human clientId (resolved to UUID when --id is absent)")
+	if err := cmd.MarkFlagRequired("representation-file"); err != nil {
+		panic(err) // programmer error: the flag is defined directly above
+	}
 	return cmd
 }
 

--- a/cli/internal/cmd/keycloak/client_scope.go
+++ b/cli/internal/cmd/keycloak/client_scope.go
@@ -13,14 +13,56 @@ import (
 )
 
 // newClientScopeCmd returns the `meho keycloak client-scope` parent with
-// one sub-verb: `list` (keycloak.client_scope.list).
+// the read verb `list` (keycloak.client_scope.list) and the approval-gated
+// write verb `create` (keycloak.client_scope.create).
 func newClientScopeCmd() *cobra.Command {
 	cmd := &cobra.Command{
 		Use:          "client-scope",
-		Short:        "Keycloak client-scope sub-verbs (list)",
+		Short:        "Keycloak client-scope sub-verbs (list, create)",
 		SilenceUsage: true,
 	}
 	cmd.AddCommand(newClientScopeListCmd())
+	cmd.AddCommand(newClientScopeCreateCmd())
+	return cmd
+}
+
+// newClientScopeCreateCmd returns the `meho keycloak client-scope create`
+// command (keycloak.client_scope.create — approval-gated). POSTs
+// /admin/realms/{realm}/client-scopes with the ClientScopeRepresentation
+// from --representation-file. A 409 already-exists is idempotent.
+func newClientScopeCreateCmd() *cobra.Command {
+	var (
+		f       writeFlags
+		repFile string
+	)
+	cmd := &cobra.Command{
+		Use:   "create",
+		Short: "Create a Keycloak client scope (approval-gated)",
+		Long: "create dispatches keycloak.client_scope.create with the\n" +
+			"ClientScopeRepresentation (its protocolMappers ride in the body)\n" +
+			"read from --representation-file (JSON). Requires approval; a 409\n" +
+			"already-exists is an idempotent success.\n\n" +
+			"Exit codes: 0=ok, 1=error/denied, 2=auth_expired,\n" +
+			"3=unreachable, 4=unexpected.",
+		Example:       "  meho keycloak client-scope create --target rdc-keycloak -f scope-roles.json",
+		Args:          cobra.NoArgs,
+		SilenceUsage:  true,
+		SilenceErrors: true,
+		RunE: func(cmd *cobra.Command, _ []string) error {
+			rep, serr := loadRepresentation(repFile)
+			if serr != nil {
+				return output.RenderError(cmd.ErrOrStderr(), serr, f.jsonOut)
+			}
+			return dispatchWrite(cmd, "keycloak.client_scope.create", f.targetName,
+				map[string]any{"representation": rep}, f.jsonOut, f.backplaneOverride)
+		},
+	}
+	f.bind(cmd)
+	cmd.Flags().StringVarP(&repFile, "representation-file", "f", "",
+		"path to a JSON file with the ClientScopeRepresentation body (required)")
+	if err := cmd.MarkFlagRequired("representation-file"); err != nil {
+		panic(err) // programmer error: the flag is defined directly above
+	}
 	return cmd
 }
 

--- a/cli/internal/cmd/keycloak/keycloak.go
+++ b/cli/internal/cmd/keycloak/keycloak.go
@@ -15,6 +15,22 @@
 //   - `meho keycloak user list [--username U] [--max N] [--target T]` — keycloak.user.list
 //   - `meho keycloak role-mapping get --id UUID [--target T]` — keycloak.role_mapping.get
 //
+// G3.13-T4 (#1406) adds the approval-gated write verbs that retire the
+// five Keycloak bootstrap scripts (every write requires human approval
+// through the queue — G11.7-T1 #1401):
+//
+//   - `meho keycloak realm create -f F` / `realm update -f F`
+//   - `meho keycloak client create -f F` / `client update (--id|--client-id) -f F`
+//   - `meho keycloak client-scope create -f F`
+//   - `meho keycloak protocol-mapper create (--id|--client-id) -f F`
+//   - `meho keycloak user create -f F --password-secret-ref R`
+//   - `meho keycloak user reset-password (--id|--username) --password-secret-ref R`
+//   - `meho keycloak role-mapping assign (--id|--username) --role R`
+//
+// User passwords are NEVER passed inline — only a Vault path
+// (--password-secret-ref) — so the password never lands in shell history
+// or op params.
+//
 // Every verb is a thin Cobra command that POSTs to
 // `/api/v1/operations/call` with a pre-baked connector_id. No new
 // backend code; no new HTTP routes — the CLI alias verbs are pure
@@ -85,9 +101,10 @@ func NewRootCmd() *cobra.Command {
 			"(product=\"keycloak\", version=\"26.x\", impl_id=\"keycloak-admin\")).\n" +
 			"Each verb dispatches through POST /api/v1/operations/call with\n" +
 			"connector_id=\"keycloak-admin-26.x\" pre-baked so operators don't\n" +
-			"type the connector ID on every command. All shipped ops are\n" +
-			"read-only; the write surface is the deferred approval-gated T4\n" +
-			"follow-up (#1406).\n\n" +
+			"type the connector ID on every command. Read verbs are safe;\n" +
+			"the write verbs (create / update / reset-password / assign) are\n" +
+			"approval-gated — every write requires human approval through the\n" +
+			"queue before it dispatches.\n\n" +
 			"Per CLAUDE.md postulate 5, these alias verbs are operator-only\n" +
 			"ergonomics — they are not mirrored on the MCP surface. Agents\n" +
 			"continue to use search_operations / call_operation against the\n" +
@@ -102,6 +119,7 @@ func NewRootCmd() *cobra.Command {
 	cmd.AddCommand(newRealmCmd())
 	cmd.AddCommand(newClientCmd())
 	cmd.AddCommand(newClientScopeCmd())
+	cmd.AddCommand(newProtocolMapperCmd())
 	cmd.AddCommand(newUserCmd())
 	cmd.AddCommand(newRoleMappingCmd())
 	return cmd

--- a/cli/internal/cmd/keycloak/keycloak_test.go
+++ b/cli/internal/cmd/keycloak/keycloak_test.go
@@ -345,11 +345,12 @@ func TestAllOpsUseCanonicalOpIDs(t *testing.T) {
 func TestNewRootCmdHasExpectedSubcommands(t *testing.T) {
 	root := NewRootCmd()
 	want := map[string]bool{
-		"realm":        false,
-		"client":       false,
-		"client-scope": false,
-		"user":         false,
-		"role-mapping": false,
+		"realm":           false,
+		"client":          false,
+		"client-scope":    false,
+		"protocol-mapper": false,
+		"user":            false,
+		"role-mapping":    false,
 	}
 	for _, sub := range root.Commands() {
 		want[sub.Name()] = true

--- a/cli/internal/cmd/keycloak/protocol_mapper.go
+++ b/cli/internal/cmd/keycloak/protocol_mapper.go
@@ -1,0 +1,87 @@
+// SPDX-License-Identifier: Apache-2.0
+// Copyright (c) 2026 evoila Group
+
+package keycloak
+
+import (
+	"github.com/spf13/cobra"
+
+	"github.com/evoila/meho/cli/internal/output"
+)
+
+// newProtocolMapperCmd returns the `meho keycloak protocol-mapper` parent
+// with the approval-gated write verb `create`
+// (keycloak.protocol_mapper.create) — the op that wires the tenant_id /
+// tenant_role claims the backplane row-scopes on. There is no read verb in
+// this sub-tree; protocol mappers are read via `keycloak client get`
+// (they ride in the ClientRepresentation).
+func newProtocolMapperCmd() *cobra.Command {
+	cmd := &cobra.Command{
+		Use:          "protocol-mapper",
+		Short:        "Keycloak protocol-mapper sub-verbs (create)",
+		SilenceUsage: true,
+	}
+	cmd.AddCommand(newProtocolMapperCreateCmd())
+	return cmd
+}
+
+// newProtocolMapperCreateCmd returns the `meho keycloak protocol-mapper
+// create` command (keycloak.protocol_mapper.create — approval-gated).
+// POSTs .../clients/{id}/protocol-mappers/models with the
+// ProtocolMapperRepresentation from --representation-file. Keys on the
+// client UUID — pass --id directly, or pass --client-id for name→UUID
+// resolution. A 409 already-exists is idempotent.
+func newProtocolMapperCreateCmd() *cobra.Command {
+	var (
+		f          writeFlags
+		repFile    string
+		clientUUID string
+		clientID   string
+	)
+	cmd := &cobra.Command{
+		Use:   "create",
+		Short: "Add a protocol mapper to a Keycloak client (approval-gated)",
+		Long: "create dispatches keycloak.protocol_mapper.create with the\n" +
+			"ProtocolMapperRepresentation from --representation-file (JSON) —\n" +
+			"e.g. the tenant_id / tenant_role claim mappers the backplane\n" +
+			"row-scopes on. Keys on the client UUID — pass --id directly, or\n" +
+			"pass --client-id (the human clientId) for resolution. Requires\n" +
+			"approval; a 409 already-exists is an idempotent success.\n\n" +
+			"Exit codes: 0=ok, 1=error/denied, 2=auth_expired,\n" +
+			"3=unreachable, 4=unexpected.",
+		Example:       "  meho keycloak protocol-mapper create --target rdc-keycloak --client-id meho-web -f mapper-tenant-id.json",
+		Args:          cobra.NoArgs,
+		SilenceUsage:  true,
+		SilenceErrors: true,
+		RunE: func(cmd *cobra.Command, _ []string) error {
+			if clientUUID == "" && clientID == "" {
+				return output.RenderError(cmd.ErrOrStderr(),
+					output.Unexpected("one of --id or --client-id is required"), f.jsonOut)
+			}
+			rep, serr := loadRepresentation(repFile)
+			if serr != nil {
+				return output.RenderError(cmd.ErrOrStderr(), serr, f.jsonOut)
+			}
+			params := map[string]any{"representation": rep}
+			if clientUUID != "" {
+				params["id"] = clientUUID
+			}
+			if clientID != "" {
+				params["client_id"] = clientID
+			}
+			return dispatchWrite(cmd, "keycloak.protocol_mapper.create", f.targetName,
+				params, f.jsonOut, f.backplaneOverride)
+		},
+	}
+	f.bind(cmd)
+	cmd.Flags().StringVarP(&repFile, "representation-file", "f", "",
+		"path to a JSON file with the ProtocolMapperRepresentation body (required)")
+	cmd.Flags().StringVar(&clientUUID, "id", "",
+		"the client's internal UUID (skips name→UUID resolution)")
+	cmd.Flags().StringVar(&clientID, "client-id", "",
+		"the human clientId (resolved to UUID when --id is absent)")
+	if err := cmd.MarkFlagRequired("representation-file"); err != nil {
+		panic(err) // programmer error: the flag is defined directly above
+	}
+	return cmd
+}

--- a/cli/internal/cmd/keycloak/realm.go
+++ b/cli/internal/cmd/keycloak/realm.go
@@ -12,15 +12,103 @@ import (
 	"github.com/evoila/meho/cli/internal/output"
 )
 
-// newRealmCmd returns the `meho keycloak realm` parent with one
-// sub-verb: `get` (keycloak.realm.get).
+// newRealmCmd returns the `meho keycloak realm` parent with the read verb
+// `get` (keycloak.realm.get) and the approval-gated write verbs `create`
+// (keycloak.realm.create) and `update` (keycloak.realm.update).
 func newRealmCmd() *cobra.Command {
 	cmd := &cobra.Command{
 		Use:          "realm",
-		Short:        "Keycloak realm sub-verbs (get)",
+		Short:        "Keycloak realm sub-verbs (get, create, update)",
 		SilenceUsage: true,
 	}
 	cmd.AddCommand(newRealmGetCmd())
+	cmd.AddCommand(newRealmCreateCmd())
+	cmd.AddCommand(newRealmUpdateCmd())
+	return cmd
+}
+
+// newRealmCreateCmd returns the `meho keycloak realm create` command
+// (keycloak.realm.create — approval-gated). POSTs /admin/realms with the
+// RealmRepresentation from --representation-file. A 409 already-exists is
+// treated as an idempotent success.
+func newRealmCreateCmd() *cobra.Command {
+	var (
+		f       writeFlags
+		repFile string
+	)
+	cmd := &cobra.Command{
+		Use:   "create",
+		Short: "Create a Keycloak realm (approval-gated)",
+		Long: "create dispatches keycloak.realm.create with the\n" +
+			"RealmRepresentation read from --representation-file (JSON). The op\n" +
+			"requires approval; a 409 already-exists is an idempotent success.\n\n" +
+			"Exit codes: 0=ok, 1=error/denied, 2=auth_expired,\n" +
+			"3=unreachable, 4=unexpected.",
+		Example:       "  meho keycloak realm create --target rdc-keycloak -f realm-evba.json",
+		Args:          cobra.NoArgs,
+		SilenceUsage:  true,
+		SilenceErrors: true,
+		RunE: func(cmd *cobra.Command, _ []string) error {
+			rep, serr := loadRepresentation(repFile)
+			if serr != nil {
+				return output.RenderError(cmd.ErrOrStderr(), serr, f.jsonOut)
+			}
+			return dispatchWrite(cmd, "keycloak.realm.create", f.targetName,
+				map[string]any{"representation": rep}, f.jsonOut, f.backplaneOverride)
+		},
+	}
+	f.bind(cmd)
+	cmd.Flags().StringVarP(&repFile, "representation-file", "f", "",
+		"path to a JSON file with the RealmRepresentation body (required)")
+	if err := cmd.MarkFlagRequired("representation-file"); err != nil {
+		panic(err) // programmer error: the flag is defined directly above
+	}
+	return cmd
+}
+
+// newRealmUpdateCmd returns the `meho keycloak realm update` command
+// (keycloak.realm.update — approval-gated). PUTs /admin/realms/{realm}
+// (default the target's managed realm; --realm overrides) with the partial
+// RealmRepresentation from --representation-file.
+func newRealmUpdateCmd() *cobra.Command {
+	var (
+		f         writeFlags
+		repFile   string
+		realmName string
+	)
+	cmd := &cobra.Command{
+		Use:   "update",
+		Short: "Update a Keycloak realm's top-level config (approval-gated)",
+		Long: "update dispatches keycloak.realm.update with the partial\n" +
+			"RealmRepresentation from --representation-file (JSON). Defaults to\n" +
+			"the target's managed realm; --realm overrides. Requires approval.\n\n" +
+			"Exit codes: 0=ok, 1=error/denied, 2=auth_expired,\n" +
+			"3=unreachable, 4=unexpected.",
+		Example:       "  meho keycloak realm update --target rdc-keycloak -f realm-patch.json",
+		Args:          cobra.NoArgs,
+		SilenceUsage:  true,
+		SilenceErrors: true,
+		RunE: func(cmd *cobra.Command, _ []string) error {
+			rep, serr := loadRepresentation(repFile)
+			if serr != nil {
+				return output.RenderError(cmd.ErrOrStderr(), serr, f.jsonOut)
+			}
+			params := map[string]any{"representation": rep}
+			if realmName != "" {
+				params["realm"] = realmName
+			}
+			return dispatchWrite(cmd, "keycloak.realm.update", f.targetName,
+				params, f.jsonOut, f.backplaneOverride)
+		},
+	}
+	f.bind(cmd)
+	cmd.Flags().StringVarP(&repFile, "representation-file", "f", "",
+		"path to a JSON file with the partial RealmRepresentation body (required)")
+	cmd.Flags().StringVar(&realmName, "realm", "",
+		"realm to update (defaults to the target's managed realm)")
+	if err := cmd.MarkFlagRequired("representation-file"); err != nil {
+		panic(err) // programmer error: the flag is defined directly above
+	}
 	return cmd
 }
 

--- a/cli/internal/cmd/keycloak/role_mapping.go
+++ b/cli/internal/cmd/keycloak/role_mapping.go
@@ -14,14 +14,77 @@ import (
 )
 
 // newRoleMappingCmd returns the `meho keycloak role-mapping` parent with
-// one sub-verb: `get` (keycloak.role_mapping.get).
+// the read verb `get` (keycloak.role_mapping.get) and the approval-gated
+// write verb `assign` (keycloak.role_mapping.assign — a privilege grant).
 func newRoleMappingCmd() *cobra.Command {
 	cmd := &cobra.Command{
 		Use:          "role-mapping",
-		Short:        "Keycloak role-mapping sub-verbs (get)",
+		Short:        "Keycloak role-mapping sub-verbs (get, assign)",
 		SilenceUsage: true,
 	}
 	cmd.AddCommand(newRoleMappingGetCmd())
+	cmd.AddCommand(newRoleMappingAssignCmd())
+	return cmd
+}
+
+// newRoleMappingAssignCmd returns the `meho keycloak role-mapping assign`
+// command (keycloak.role_mapping.assign — approval-gated, dangerous: a
+// privilege grant). POSTs .../users/{id}/role-mappings/realm with the
+// resolved RoleRepresentations for the named --role values. Keys on the
+// user UUID (--id) or --username for resolution.
+func newRoleMappingAssignCmd() *cobra.Command {
+	var (
+		f        writeFlags
+		userUUID string
+		username string
+		roles    []string
+	)
+	cmd := &cobra.Command{
+		Use:   "assign",
+		Short: "Grant realm roles to a Keycloak user (approval-gated, privilege grant)",
+		Long: "assign dispatches keycloak.role_mapping.assign — a privilege grant\n" +
+			"(dangerous, requires approval). Keys on the user UUID — pass --id\n" +
+			"directly, or pass --username for resolution. Pass --role once per\n" +
+			"realm role name to grant. Each role name is resolved to its\n" +
+			"representation; an unknown role errors. Re-assigning a held role is\n" +
+			"a server-side no-op.\n\n" +
+			"Exit codes: 0=ok, 1=error/denied, 2=auth_expired,\n" +
+			"3=unreachable, 4=unexpected.",
+		Example:       "  meho keycloak role-mapping assign --target rdc-keycloak --username operator-a --role tenant_admin",
+		Args:          cobra.NoArgs,
+		SilenceUsage:  true,
+		SilenceErrors: true,
+		RunE: func(cmd *cobra.Command, _ []string) error {
+			if userUUID == "" && username == "" {
+				return output.RenderError(cmd.ErrOrStderr(),
+					output.Unexpected("one of --id or --username is required"), f.jsonOut)
+			}
+			if len(roles) == 0 {
+				return output.RenderError(cmd.ErrOrStderr(),
+					output.Unexpected("at least one --role is required"), f.jsonOut)
+			}
+			rolesAny := make([]any, len(roles))
+			for i, r := range roles {
+				rolesAny[i] = r
+			}
+			params := map[string]any{"roles": rolesAny}
+			if userUUID != "" {
+				params["id"] = userUUID
+			}
+			if username != "" {
+				params["username"] = username
+			}
+			return dispatchWrite(cmd, "keycloak.role_mapping.assign", f.targetName,
+				params, f.jsonOut, f.backplaneOverride)
+		},
+	}
+	f.bind(cmd)
+	cmd.Flags().StringVar(&userUUID, "id", "",
+		"the user's internal UUID (skips name→UUID resolution)")
+	cmd.Flags().StringVar(&username, "username", "",
+		"the username (resolved to UUID when --id is absent)")
+	cmd.Flags().StringArrayVar(&roles, "role", nil,
+		"realm role name to grant (repeatable)")
 	return cmd
 }
 

--- a/cli/internal/cmd/keycloak/user.go
+++ b/cli/internal/cmd/keycloak/user.go
@@ -12,15 +12,164 @@ import (
 	"github.com/evoila/meho/cli/internal/output"
 )
 
-// newUserCmd returns the `meho keycloak user` parent with one sub-verb:
-// `list` (keycloak.user.list).
+// newUserCmd returns the `meho keycloak user` parent with the read verb
+// `list` (keycloak.user.list) and the approval-gated write verbs `create`
+// (keycloak.user.create) and `reset-password`
+// (keycloak.user.reset_password).
 func newUserCmd() *cobra.Command {
 	cmd := &cobra.Command{
 		Use:          "user",
-		Short:        "Keycloak user sub-verbs (list)",
+		Short:        "Keycloak user sub-verbs (list, create, reset-password)",
 		SilenceUsage: true,
 	}
 	cmd.AddCommand(newUserListCmd())
+	cmd.AddCommand(newUserCreateCmd())
+	cmd.AddCommand(newUserResetPasswordCmd())
+	return cmd
+}
+
+// passwordSecretFlags is the shared flag bundle for the Vault-sourced
+// password: the path (--password-secret-ref) plus the optional mount /
+// key / temporary overrides. The password is NEVER a command-line flag —
+// only its Vault location is — so it never lands in shell history, ps
+// output, or the op params.
+type passwordSecretFlags struct {
+	ref       string
+	mount     string
+	key       string
+	temporary bool
+}
+
+func (p *passwordSecretFlags) bind(cmd *cobra.Command, required bool) {
+	cmd.Flags().StringVar(&p.ref, "password-secret-ref", "",
+		"Vault KV-v2 path the password is read from (the password is never passed inline)")
+	cmd.Flags().StringVar(&p.mount, "password-secret-mount", "",
+		"Vault KV-v2 mount point (default 'secret')")
+	cmd.Flags().StringVar(&p.key, "password-secret-key", "",
+		"field within the Vault secret payload (default 'password')")
+	cmd.Flags().BoolVar(&p.temporary, "temporary", false,
+		"force a password change on first login")
+	if required {
+		if err := cmd.MarkFlagRequired("password-secret-ref"); err != nil {
+			panic(err) // programmer error: the flag is defined directly above
+		}
+	}
+}
+
+// apply writes the password-secret params into the dispatch param map.
+// Only non-empty values are written so the connector's defaults apply.
+func (p *passwordSecretFlags) apply(params map[string]any) {
+	if p.ref != "" {
+		params["password_secret_ref"] = p.ref
+	}
+	if p.mount != "" {
+		params["password_secret_mount"] = p.mount
+	}
+	if p.key != "" {
+		params["password_secret_key"] = p.key
+	}
+	if p.temporary {
+		params["temporary"] = true
+	}
+}
+
+// newUserCreateCmd returns the `meho keycloak user create` command
+// (keycloak.user.create — approval-gated). POSTs
+// /admin/realms/{realm}/users with the UserRepresentation from
+// --representation-file. The password is read from Vault
+// (--password-secret-ref) and set as a credential — NEVER passed inline. A
+// 409 already-exists is idempotent.
+func newUserCreateCmd() *cobra.Command {
+	var (
+		f       writeFlags
+		pw      passwordSecretFlags
+		repFile string
+	)
+	cmd := &cobra.Command{
+		Use:   "create",
+		Short: "Create a Keycloak user with a Vault-sourced password (approval-gated)",
+		Long: "create dispatches keycloak.user.create with the UserRepresentation\n" +
+			"from --representation-file (JSON). The password is read from Vault\n" +
+			"(--password-secret-ref, optional --password-secret-mount /\n" +
+			"--password-secret-key) and set as a credential — it is NEVER passed\n" +
+			"on the command line or in op params. Requires approval; a 409\n" +
+			"already-exists is an idempotent success. The password is never\n" +
+			"returned.\n\n" +
+			"Exit codes: 0=ok, 1=error/denied, 2=auth_expired,\n" +
+			"3=unreachable, 4=unexpected.",
+		Example:       "  meho keycloak user create --target rdc-keycloak -f user-operator-a.json --password-secret-ref rdc-hetzner-dc/keycloak/operator-a",
+		Args:          cobra.NoArgs,
+		SilenceUsage:  true,
+		SilenceErrors: true,
+		RunE: func(cmd *cobra.Command, _ []string) error {
+			rep, serr := loadRepresentation(repFile)
+			if serr != nil {
+				return output.RenderError(cmd.ErrOrStderr(), serr, f.jsonOut)
+			}
+			params := map[string]any{"representation": rep}
+			pw.apply(params)
+			return dispatchWrite(cmd, "keycloak.user.create", f.targetName,
+				params, f.jsonOut, f.backplaneOverride)
+		},
+	}
+	f.bind(cmd)
+	pw.bind(cmd, false) // password optional on create (a user may be SSO-only)
+	cmd.Flags().StringVarP(&repFile, "representation-file", "f", "",
+		"path to a JSON file with the UserRepresentation body (required)")
+	if err := cmd.MarkFlagRequired("representation-file"); err != nil {
+		panic(err) // programmer error: the flag is defined directly above
+	}
+	return cmd
+}
+
+// newUserResetPasswordCmd returns the `meho keycloak user reset-password`
+// command (keycloak.user.reset_password — approval-gated). PUTs
+// .../users/{id}/reset-password with a CredentialRepresentation whose
+// value is read from Vault — NEVER passed inline. Keys on the user UUID
+// (--id) or --username for resolution.
+func newUserResetPasswordCmd() *cobra.Command {
+	var (
+		f        writeFlags
+		pw       passwordSecretFlags
+		userUUID string
+		username string
+	)
+	cmd := &cobra.Command{
+		Use:   "reset-password",
+		Short: "Reset a Keycloak user's password from Vault (approval-gated)",
+		Long: "reset-password dispatches keycloak.user.reset_password. The new\n" +
+			"password is read from Vault (--password-secret-ref) — NEVER passed\n" +
+			"on the command line. Keys on the user UUID — pass --id directly, or\n" +
+			"pass --username for name→UUID resolution. Requires approval.\n\n" +
+			"Exit codes: 0=ok, 1=error/denied, 2=auth_expired,\n" +
+			"3=unreachable, 4=unexpected.",
+		Example:       "  meho keycloak user reset-password --target rdc-keycloak --username operator-a --password-secret-ref rdc-hetzner-dc/keycloak/operator-a",
+		Args:          cobra.NoArgs,
+		SilenceUsage:  true,
+		SilenceErrors: true,
+		RunE: func(cmd *cobra.Command, _ []string) error {
+			if userUUID == "" && username == "" {
+				return output.RenderError(cmd.ErrOrStderr(),
+					output.Unexpected("one of --id or --username is required"), f.jsonOut)
+			}
+			params := map[string]any{}
+			pw.apply(params)
+			if userUUID != "" {
+				params["id"] = userUUID
+			}
+			if username != "" {
+				params["username"] = username
+			}
+			return dispatchWrite(cmd, "keycloak.user.reset_password", f.targetName,
+				params, f.jsonOut, f.backplaneOverride)
+		},
+	}
+	f.bind(cmd)
+	pw.bind(cmd, true) // password required on reset
+	cmd.Flags().StringVar(&userUUID, "id", "",
+		"the user's internal UUID (skips name→UUID resolution)")
+	cmd.Flags().StringVar(&username, "username", "",
+		"the username (resolved to UUID when --id is absent)")
 	return cmd
 }
 

--- a/cli/internal/cmd/keycloak/write.go
+++ b/cli/internal/cmd/keycloak/write.go
@@ -1,0 +1,144 @@
+// SPDX-License-Identifier: Apache-2.0
+// Copyright (c) 2026 evoila Group
+
+package keycloak
+
+import (
+	"encoding/json"
+	"fmt"
+	"io"
+	"os"
+
+	"github.com/spf13/cobra"
+
+	"github.com/evoila/meho/cli/internal/output"
+)
+
+// G3.13-T4 (#1406) — the approval-gated write verbs under
+// `meho keycloak ...`. Every write op registers requires_approval=True on
+// the backplane, so a dispatch returns status=awaiting_approval until a
+// human approves through the queue (G11.7-T1 #1401); the CLI surfaces that
+// status verbatim. The verbs retire the consumer's five Keycloak bootstrap
+// scripts (keycloak-bootstrap-meho-{admin,cli,mcp,web}.sh and
+// keycloak-provision-meho-user.sh) — see
+// docs/cross-repo/keycloak-onboarding.md for the script→op mapping.
+//
+// Verb tree (write half):
+//   - keycloak realm create   --representation-file F     → keycloak.realm.create
+//   - keycloak realm update   --representation-file F     → keycloak.realm.update
+//   - keycloak client create  --representation-file F     → keycloak.client.create
+//   - keycloak client update  (--id|--client-id) -f F     → keycloak.client.update
+//   - keycloak client-scope create --representation-file F→ keycloak.client_scope.create
+//   - keycloak protocol-mapper create (--id|--client-id) -f F → keycloak.protocol_mapper.create
+//   - keycloak user create    -f F --password-secret-ref R→ keycloak.user.create
+//   - keycloak user reset-password (--id|--username) --password-secret-ref R → keycloak.user.reset_password
+//   - keycloak role-mapping assign (--id|--username) --role R [--role ...] → keycloak.role_mapping.assign
+//
+// The representation body is a JSON file (--representation-file / -f) so an
+// operator can feed the same JSON a bootstrap script POSTed to kcadm.sh.
+// The password for user create / reset-password is NEVER passed on the
+// command line — only a Vault path (--password-secret-ref) — so it never
+// lands in shell history, ps output, or the op params.
+
+// loadRepresentation reads a JSON object from the file at path. Returns a
+// structured error (mapped to exit code 4 / unexpected) when the file is
+// unreadable or not a JSON object.
+func loadRepresentation(path string) (map[string]any, *output.StructuredError) {
+	raw, err := os.ReadFile(path) // #nosec G304 -- operator-supplied path, operator-only CLI
+	if err != nil {
+		return nil, output.Unexpected(fmt.Sprintf("read representation file %q: %v", path, err))
+	}
+	var rep map[string]any
+	if err := json.Unmarshal(raw, &rep); err != nil {
+		return nil, output.Unexpected(fmt.Sprintf("parse representation file %q as JSON object: %v", path, err))
+	}
+	return rep, nil
+}
+
+// printWriteResult is the shared pretty-printer for the value-free write
+// confirmations every write op returns. It renders the op header then the
+// flat result object's scalar fields (id / created / conflict / updated /
+// password_reset / assigned_roles …) — none of which ever carry secret
+// material.
+func printWriteResult(opID string) func(w io.Writer, r *CallResult) {
+	return func(w io.Writer, r *CallResult) {
+		fmt.Fprintf(w, "%s %s — status=%s (%.0fms)\n", ConnectorID, opID, r.Status, r.DurationMs)
+		if r.Status == "awaiting_approval" {
+			fmt.Fprintln(w, "  parked for human approval — approve via the approval queue, then re-dispatch")
+			return
+		}
+		if r.Status != "ok" {
+			printErrorTrailer(w, r)
+			return
+		}
+		obj, err := decodeFlatObject(r.Result)
+		if err != nil || obj == nil {
+			fallbackResultRender(w, r)
+			return
+		}
+		for _, key := range writeResultKeyOrder {
+			if v, ok := obj[key]; ok && v != nil {
+				fmt.Fprintf(w, "  %-16s %v\n", key+":", v)
+			}
+		}
+	}
+}
+
+// writeResultKeyOrder pins a stable render order for the write
+// confirmations' scalar fields so the output is diff-stable across ops.
+var writeResultKeyOrder = []string{
+	"realm", "name", "client_id", "client_uuid", "id", "username",
+	"mapper_name", "created", "updated", "conflict", "password_reset",
+	"assigned_roles",
+}
+
+// decodeFlatObject decodes the write confirmation envelope — a flat JSON
+// object of scalar fields (and the assigned_roles array) — into a map.
+func decodeFlatObject(raw json.RawMessage) (map[string]any, error) {
+	if len(raw) == 0 || string(raw) == "null" {
+		return nil, nil
+	}
+	var obj map[string]any
+	if err := json.Unmarshal(raw, &obj); err != nil {
+		return nil, fmt.Errorf("decode write result: %w", err)
+	}
+	return obj, nil
+}
+
+// dispatchWrite is the shared dispatch+render path for the write verbs:
+// resolve the backplane, dispatch the op with the assembled params, and
+// render the value-free confirmation.
+func dispatchWrite(
+	cmd *cobra.Command,
+	opID, targetName string,
+	params map[string]any,
+	jsonOut bool,
+	backplaneOverride string,
+) error {
+	backplaneURL, err := resolveBackplane(backplaneOverride)
+	if err != nil {
+		return output.RenderError(cmd.ErrOrStderr(), classifyBackplaneError(err), jsonOut)
+	}
+	r, err := dispatchOp(cmd.Context(), backplaneURL, opID, targetName, params)
+	if err != nil {
+		return renderRequestError(cmd, backplaneURL, err, jsonOut)
+	}
+	return renderCallResult(cmd, opID, r, jsonOut, printWriteResult(opID))
+}
+
+// writeFlags is the common flag bundle every write verb binds: --target,
+// --json, --backplane. The per-verb commands add their own flags.
+type writeFlags struct {
+	targetName        string
+	jsonOut           bool
+	backplaneOverride string
+}
+
+func (f *writeFlags) bind(cmd *cobra.Command) {
+	cmd.Flags().StringVar(&f.targetName, "target", "",
+		"target slug to dispatch against (required)")
+	cmd.Flags().BoolVar(&f.jsonOut, "json", false,
+		"emit the full OperationResult envelope as JSON")
+	cmd.Flags().StringVar(&f.backplaneOverride, "backplane", "",
+		"backplane URL (defaults to the URL from the most recent `meho login`)")
+}

--- a/cli/internal/cmd/keycloak/write_test.go
+++ b/cli/internal/cmd/keycloak/write_test.go
@@ -1,0 +1,272 @@
+// SPDX-License-Identifier: Apache-2.0
+// Copyright (c) 2026 evoila Group
+
+package keycloak
+
+import (
+	"bytes"
+	"context"
+	"encoding/json"
+	"net/http"
+	"os"
+	"path/filepath"
+	"strings"
+	"testing"
+)
+
+// ---------- command-tree shape tests for the write verbs (#1406) ----------
+
+func TestRealmHasWriteVerbs(t *testing.T) {
+	got := map[string]bool{}
+	for _, s := range newRealmCmd().Commands() {
+		got[s.Name()] = true
+	}
+	for _, name := range []string{"get", "create", "update"} {
+		if !got[name] {
+			t.Errorf("realm is missing sub-verb %q", name)
+		}
+	}
+}
+
+func TestClientHasWriteVerbs(t *testing.T) {
+	got := map[string]bool{}
+	for _, s := range newClientCmd().Commands() {
+		got[s.Name()] = true
+	}
+	for _, name := range []string{"create", "update"} {
+		if !got[name] {
+			t.Errorf("client is missing sub-verb %q", name)
+		}
+	}
+}
+
+func TestUserHasWriteVerbs(t *testing.T) {
+	got := map[string]bool{}
+	for _, s := range newUserCmd().Commands() {
+		got[s.Name()] = true
+	}
+	for _, name := range []string{"create", "reset-password"} {
+		if !got[name] {
+			t.Errorf("user is missing sub-verb %q", name)
+		}
+	}
+}
+
+func TestProtocolMapperHasCreate(t *testing.T) {
+	got := map[string]bool{}
+	for _, s := range newProtocolMapperCmd().Commands() {
+		got[s.Name()] = true
+	}
+	if !got["create"] {
+		t.Errorf("protocol-mapper is missing the create sub-verb")
+	}
+}
+
+func TestRoleMappingHasAssign(t *testing.T) {
+	got := map[string]bool{}
+	for _, s := range newRoleMappingCmd().Commands() {
+		got[s.Name()] = true
+	}
+	if !got["assign"] {
+		t.Errorf("role-mapping is missing the assign sub-verb")
+	}
+}
+
+// ---------- representation-file loader ----------
+
+func TestLoadRepresentationHappy(t *testing.T) {
+	dir := t.TempDir()
+	path := filepath.Join(dir, "rep.json")
+	if err := os.WriteFile(path, []byte(`{"realm":"evba","enabled":true}`), 0o600); err != nil {
+		t.Fatalf("write rep: %v", err)
+	}
+	rep, serr := loadRepresentation(path)
+	if serr != nil {
+		t.Fatalf("loadRepresentation: %v", serr)
+	}
+	if rep["realm"] != "evba" {
+		t.Errorf("realm: got %v", rep["realm"])
+	}
+}
+
+func TestLoadRepresentationRejectsNonObject(t *testing.T) {
+	dir := t.TempDir()
+	path := filepath.Join(dir, "rep.json")
+	if err := os.WriteFile(path, []byte(`[1,2,3]`), 0o600); err != nil {
+		t.Fatalf("write rep: %v", err)
+	}
+	if _, serr := loadRepresentation(path); serr == nil {
+		t.Errorf("loadRepresentation should reject a non-object JSON body")
+	}
+}
+
+func TestLoadRepresentationMissingFile(t *testing.T) {
+	if _, serr := loadRepresentation(filepath.Join(t.TempDir(), "nope.json")); serr == nil {
+		t.Errorf("loadRepresentation should error on a missing file")
+	}
+}
+
+// ---------- dispatch shape: every write op uses its canonical op_id ----------
+
+func TestWriteOpsDispatchCanonicalOpIDs(t *testing.T) {
+	dispatched := make(map[string]bool)
+	srv := mockBackplane(t, map[string]mockHandler{
+		"POST /api/v1/operations/call": func(w http.ResponseWriter, r *http.Request) {
+			var body callRequestBody
+			if err := json.NewDecoder(r.Body).Decode(&body); err != nil {
+				t.Errorf("decode body: %v", err)
+				w.WriteHeader(400)
+				return
+			}
+			if body.ConnectorID != "keycloak-admin-26.x" {
+				t.Errorf("connector_id: got %q", body.ConnectorID)
+			}
+			dispatched[body.OpID] = true
+			writeJSON(t, w, 200, CallResult{
+				Status: "ok", OpID: body.OpID,
+				Result: json.RawMessage(`{"created":true,"conflict":false}`),
+			})
+		},
+	})
+	defer srv.Close()
+	primeToken(t, srv.URL)
+
+	writeOps := []string{
+		"keycloak.realm.create",
+		"keycloak.realm.update",
+		"keycloak.client.create",
+		"keycloak.client.update",
+		"keycloak.client_scope.create",
+		"keycloak.protocol_mapper.create",
+		"keycloak.user.create",
+		"keycloak.user.reset_password",
+		"keycloak.role_mapping.assign",
+	}
+	for _, opID := range writeOps {
+		if _, err := dispatchOp(context.Background(), srv.URL, opID, "rdc-keycloak", nil); err != nil {
+			t.Fatalf("dispatchOp %s: %v", opID, err)
+		}
+	}
+	for _, opID := range writeOps {
+		if !dispatched[opID] {
+			t.Errorf("write op_id %q was not dispatched", opID)
+		}
+	}
+}
+
+// ---------- password is never on the command line ----------
+
+// TestUserCreatePassesSecretRefNotPassword — the user create verb must
+// send password_secret_ref (a Vault path) in params and NEVER an inline
+// password. This is the load-bearing security invariant of #1406.
+func TestUserCreatePassesSecretRefNotPassword(t *testing.T) {
+	var captured map[string]any
+	srv := mockBackplane(t, map[string]mockHandler{
+		"POST /api/v1/operations/call": func(w http.ResponseWriter, r *http.Request) {
+			if err := json.NewDecoder(r.Body).Decode(&captured); err != nil {
+				t.Errorf("decode: %v", err)
+				w.WriteHeader(400)
+				return
+			}
+			writeJSON(t, w, 200, CallResult{Status: "ok", OpID: "keycloak.user.create",
+				Result: json.RawMessage(`{"username":"operator-a","created":true}`)})
+		},
+	})
+	defer srv.Close()
+	primeToken(t, srv.URL)
+
+	dir := t.TempDir()
+	repPath := filepath.Join(dir, "user.json")
+	if err := os.WriteFile(repPath, []byte(`{"username":"operator-a","enabled":true}`), 0o600); err != nil {
+		t.Fatalf("write rep: %v", err)
+	}
+
+	cmd := newUserCreateCmd()
+	cmd.SetOut(&bytes.Buffer{})
+	cmd.SetErr(&bytes.Buffer{})
+	cmd.SetArgs([]string{
+		"--target", "rdc-keycloak",
+		"--representation-file", repPath,
+		"--password-secret-ref", "rdc/keycloak/operator-a",
+		"--backplane", srv.URL,
+	})
+	if err := cmd.Execute(); err != nil {
+		t.Fatalf("execute: %v", err)
+	}
+
+	params, _ := captured["params"].(map[string]any)
+	if params == nil {
+		t.Fatalf("no params captured: %v", captured)
+	}
+	if params["password_secret_ref"] != "rdc/keycloak/operator-a" {
+		t.Errorf("password_secret_ref not forwarded: %v", params["password_secret_ref"])
+	}
+	if _, leaked := params["password"]; leaked {
+		t.Errorf("password must NEVER appear in op params; got %v", params)
+	}
+	// Belt-and-suspenders: the literal flag value must not appear as an
+	// inline password anywhere in the request body.
+	blob, _ := json.Marshal(captured)
+	if strings.Contains(string(blob), `"password"`) {
+		t.Errorf("request body carries an inline password field: %s", blob)
+	}
+}
+
+// TestUserResetPasswordRequiresSecretRef — reset-password marks
+// --password-secret-ref required so a missing Vault path fails before
+// dispatch.
+func TestUserResetPasswordRequiresSecretRef(t *testing.T) {
+	cmd := newUserResetPasswordCmd()
+	flag := cmd.Flags().Lookup("password-secret-ref")
+	if flag == nil {
+		t.Fatalf("reset-password is missing --password-secret-ref")
+	}
+	if ann := flag.Annotations[cobraRequiredAnnotation]; len(ann) == 0 || ann[0] != "true" {
+		t.Errorf("--password-secret-ref should be required; annotations=%v", flag.Annotations)
+	}
+	// And there must be no inline --password flag at all.
+	if cmd.Flags().Lookup("password") != nil {
+		t.Errorf("reset-password must NOT expose an inline --password flag")
+	}
+}
+
+func TestRoleMappingAssignForwardsRoles(t *testing.T) {
+	var captured map[string]any
+	srv := mockBackplane(t, map[string]mockHandler{
+		"POST /api/v1/operations/call": func(w http.ResponseWriter, r *http.Request) {
+			if err := json.NewDecoder(r.Body).Decode(&captured); err != nil {
+				t.Errorf("decode: %v", err)
+				w.WriteHeader(400)
+				return
+			}
+			writeJSON(t, w, 200, CallResult{Status: "ok", OpID: "keycloak.role_mapping.assign",
+				Result: json.RawMessage(`{"assigned_roles":["tenant_admin"]}`)})
+		},
+	})
+	defer srv.Close()
+	primeToken(t, srv.URL)
+
+	cmd := newRoleMappingAssignCmd()
+	cmd.SetOut(&bytes.Buffer{})
+	cmd.SetErr(&bytes.Buffer{})
+	cmd.SetArgs([]string{
+		"--target", "rdc-keycloak",
+		"--username", "operator-a",
+		"--role", "tenant_admin",
+		"--backplane", srv.URL,
+	})
+	if err := cmd.Execute(); err != nil {
+		t.Fatalf("execute: %v", err)
+	}
+	params, _ := captured["params"].(map[string]any)
+	if params == nil {
+		t.Fatalf("no params captured")
+	}
+	roles, _ := params["roles"].([]any)
+	if len(roles) != 1 || roles[0] != "tenant_admin" {
+		t.Errorf("roles not forwarded: %v", params["roles"])
+	}
+	if params["username"] != "operator-a" {
+		t.Errorf("username not forwarded: %v", params["username"])
+	}
+}

--- a/docs/codebase/connectors-keycloak.md
+++ b/docs/codebase/connectors-keycloak.md
@@ -9,8 +9,12 @@ this connector manages that Keycloak through its Admin REST surface.
 G3.13-T1 (#1393) shipped the **substrate**: the connector class, the
 admin credential loader, `fingerprint()`, and dual registry registration.
 G3.13-T2 (#1394) layers the **six curated read ops** onto that surface
-(realm/client/client-scope/user/role-mapping). Onboarding docs land in T3
-and the approval-gated write surface in T4.
+(realm/client/client-scope/user/role-mapping); T3 (#1395) adds the CLI
+verbs + onboarding docs. G3.13-T4 (#1406) adds the **nine approval-gated
+write ops** (realm/client/client-scope/protocol-mapper/user/role-mapping
+creates + updates + reset-password) that retire the consumer's five
+Keycloak bootstrap scripts; `idp.create` is deferred (not exercised by
+those scripts).
 
 Registry v2 triple: `(product="keycloak", version="26.x",
 impl_id="keycloak-admin")`, plus the `(keycloak, "", "")` wildcard so a
@@ -23,12 +27,28 @@ fresh target with no asserted version still resolves.
   TTL-driven refresh and an injectable admin-credential loader. Exposes a
   thin bound-method shim per read op (`realm_get`, `client_list`,
   `client_get`, `client_scope_list`, `user_list`, `role_mapping_get`) and
-  the `_get_admin_json` / `_get_admin_list` GET helpers (object vs array
-  responses).
+  per write op (`realm_create`/`realm_update`, `client_create`/
+  `client_update`, `client_scope_create`, `protocol_mapper_create`,
+  `user_create`/`user_reset_password`, `role_mapping_assign`), the
+  `_get_admin_json` / `_get_admin_list` GET helpers (object vs array
+  responses), and the `_write_admin` mutating helper plus the
+  `_find_client_uuid` / `_find_user_uuid` / `_find_realm_role` name→UUID
+  resolvers.
 - `KeycloakOp` + `READ_OPS` (`connectors/keycloak/ops_read.py`) — the
-  op-metadata dataclass and the six-op registration table (the bind9 /
+  op-metadata dataclass and the six-op read registration table (the bind9 /
   pfSense `ops`-table precedent). `WHEN_TO_USE_BY_GROUP` maps each op
   group to its curated selection blurb.
+- `WRITE_OPS` + the write handlers (`connectors/keycloak/ops_write.py`) —
+  the nine approval-gated write ops, reusing the `KeycloakOp` dataclass.
+  Every op is `requires_approval=True`; a create treats HTTP 409 as an
+  idempotent success; `user.create`/`user.reset_password` source the
+  password from Vault via `_read_password_from_vault` (never inline).
+  `WHEN_TO_USE_WRITE_BY_GROUP` carries the write groups' blurbs (keyed with
+  a `_write` suffix so they never collide with the read groups when
+  `register_operations` merges both maps).
+- `KeycloakWriteResult` (`connectors/keycloak/connector.py`) — the
+  status + `Location` + `conflict` outcome of a mutating request;
+  `created_uuid()` parses the new object's UUID out of `Location`.
 - `redact_secret_fields` (`connectors/keycloak/redaction.py`) — the
   recursive scrubber every read handler runs its response through.
 - `KeycloakClientCredentials` / `KeycloakPasswordCredentials`
@@ -105,10 +125,19 @@ The password shape accepts an optional `client_id` field (default
   `reachable=False`).
 - `probe(target)` — delegates to `fingerprint`; one admin round-trip
   covers reachability + admin-auth validity.
-- `register_operations()` — walks `READ_OPS`, resolves each
-  `handler_attr` to a bound method, looks the group's `when_to_use` up in
-  `WHEN_TO_USE_BY_GROUP` (a missing entry is a hard error), and upserts
-  via `register_typed_operation`. Idempotent across restarts.
+- `register_operations()` — walks `READ_OPS` **and** `WRITE_OPS`,
+  resolves each `handler_attr` to a bound method, looks the group's
+  `when_to_use` up in the merged `WHEN_TO_USE_BY_GROUP` ∪
+  `WHEN_TO_USE_WRITE_BY_GROUP` (a missing entry is a hard error), and
+  upserts via `register_typed_operation`. Idempotent across restarts.
+- `_write_admin(target, method, path, *, operator, json, idempotent_conflict=True)`
+  — the mutating POST/PUT helper. Rejects non-mutating verbs, never
+  retries (a 5xx on a write must surface, not re-fire), and — when
+  `idempotent_conflict` — swallows an HTTP 409 into a
+  `KeycloakWriteResult(conflict=True)` rather than raising.
+- `_find_client_uuid` / `_find_user_uuid` / `_find_realm_role` — the
+  name→UUID (and role-name→representation) resolvers the write handlers
+  call before keying a mutation on the object's UUID.
 
 ## Read ops (G3.13-T2)
 
@@ -139,8 +168,43 @@ including secrets nested inside protocol mappers or identity-provider
 configs. The scrub happens at the connector boundary (not the broadcast
 layer) because these are config reads where the secret is incidental: it
 must never enter the synchronous `OperationResult` the caller receives.
-The write surface (T4) will continue to redact secret *inputs* at the
-classification layer per the general posture.
+The write surface redacts secret *inputs* at the classification layer per
+the general posture (see "Write ops" below).
+
+## Write ops (G3.13-T4)
+
+Nine approval-gated write ops (`requires_approval=True`), all dispatching
+via the admin-auth path, all keyed on the object's **UUID**:
+
+| op_id | safety | Admin REST API |
+|---|---|---|
+| `keycloak.realm.create` | dangerous | `POST /admin/realms` |
+| `keycloak.realm.update` | caution | `PUT .../realms/{realm}` |
+| `keycloak.client.create` | caution | `POST .../realms/{realm}/clients` |
+| `keycloak.client.update` | caution | `PUT .../clients/{id}` |
+| `keycloak.client_scope.create` | caution | `POST .../client-scopes` |
+| `keycloak.protocol_mapper.create` | caution | `POST .../clients/{id}/protocol-mappers/models` |
+| `keycloak.user.create` | caution | `POST .../realms/{realm}/users` |
+| `keycloak.user.reset_password` | caution | `PUT .../users/{id}/reset-password` |
+| `keycloak.role_mapping.assign` | dangerous | `POST .../users/{id}/role-mappings/realm` |
+
+Three load-bearing properties:
+
+- **Name→UUID resolution.** `client.update` / `protocol_mapper.create`
+  resolve `client_id` → UUID via `?clientId=`; `user.reset_password` /
+  `role_mapping.assign` resolve `username` → UUID via
+  `?username=&exact=true`; `role_mapping.assign` also resolves each realm
+  role name to its `RoleRepresentation`. A create returns the new UUID
+  from the `Location` header.
+- **Idempotency.** A create that hits HTTP 409 (already-exists) is a
+  success (`conflict: true`), and the existing object's UUID is resolved.
+- **Password handling.** `user.create` / `user.reset_password` source the
+  password from Vault (`_read_password_from_vault`, operator-context
+  `vault_client_for_operator`) via a `password_secret_ref` path param —
+  **never** an inline `password`. The password lands in the Keycloak
+  credential body but never in op params; audit stores a `params_hash`
+  (never raw params); and both ops are pinned in
+  `broadcast.events._CREDENTIAL_WRITE_OPS` → aggregate-only broadcast.
 
 ## Target configuration
 
@@ -171,9 +235,12 @@ Resolved through `resolve_realm_config`, which tolerates a missing
 
 ## Known issues / future work
 
-- The write surface (client/user/scope/role-mapping CRUD,
-  `requires_approval=True`) is the deferred T4 follow-up; T2 ships
-  read-only.
+- `keycloak.idp.create` (identity-provider federation) is deferred — not
+  exercised by the bootstrap scripts (#1406). A future task can add it
+  under the same registrar walk.
+- The write ops do **not** ship deletes — the bootstrap scripts only
+  create/update; a delete surface (client/user/scope removal) is a
+  separate follow-up if an operator workflow needs it.
 - No logout-revoke on `aclose` — admin access tokens are short-lived;
   revoke-on-close is deferred (same posture as NSX / vRLI).
 - `/admin/serverinfo` is undocumented (though stable across 26.x); the

--- a/docs/cross-repo/keycloak-onboarding.md
+++ b/docs/cross-repo/keycloak-onboarding.md
@@ -29,9 +29,11 @@ non-admin control surface (e.g. a `keycloak-account-26.x` over the
 Account REST API) without breaking the resolver's tie-break ladder; v0.1
 ships only the Admin REST surface.
 
-The v0.1 op surface (Initiative
-[#1388](https://github.com/evoila/meho/issues/1388)) is the read-only
-working set operators use to inspect and audit the managed realm:
+The op surface (Initiative
+[#1388](https://github.com/evoila/meho/issues/1388)) is a read working set
+to inspect and audit the managed realm, plus an approval-gated write set
+(G3.13-T4 #1406) that retires the consumer's five Keycloak bootstrap
+scripts. The read ops:
 
 | Group | Op ID | Admin REST API | Class |
 | --- | --- | --- | --- |
@@ -42,8 +44,9 @@ working set operators use to inspect and audit the managed realm:
 | `user` | `keycloak.user.list` | `GET .../users` (`?username=`/`?max=`) | read-only |
 | `user` | `keycloak.role_mapping.get` | `GET .../users/{id}/role-mappings` | read-only |
 
-Six ops total. All are `safety_level="safe"` and
-`requires_approval=False`. Every op dispatches through the same
+Six read ops. All are `safety_level="safe"` and
+`requires_approval=False`; the write ops (below) are `caution` /
+`dangerous` and all `requires_approval=True`. Every op dispatches through the same
 `POST /api/v1/operations/call` route the agent surface uses — auth,
 policy, audit, broadcast, and JSONFlux all run as documented in
 [CLAUDE.md](../../CLAUDE.md) §6. The CLI verb tree is operator ergonomics
@@ -55,6 +58,74 @@ every Keycloak op via the narrow-waist meta-tools, see the
 `client.get` and `role_mapping.get` take the client / user **internal
 UUID** (`id`), not the human `clientId` / `username` — discover it via
 the matching `.list` op first.
+
+### The write surface (G3.13-T4 #1406)
+
+The approval-gated **write** ops retire the consumer's five Keycloak
+bootstrap scripts. All are `requires_approval=True` — a write never
+dispatches without going through the human approve-queue (G11.7-T1
+#1401); a dispatch returns `status=awaiting_approval` until a human
+approves it through the queue.
+
+| Group | Op ID | Admin REST API | Safety |
+| --- | --- | --- | --- |
+| `realm` | `keycloak.realm.create` | `POST /admin/realms` | dangerous |
+| `realm` | `keycloak.realm.update` | `PUT .../realms/{realm}` | caution |
+| `client` | `keycloak.client.create` | `POST .../realms/{realm}/clients` | caution |
+| `client` | `keycloak.client.update` | `PUT .../clients/{id}` | caution |
+| `client_scope` | `keycloak.client_scope.create` | `POST .../client-scopes` | caution |
+| `protocol_mapper` | `keycloak.protocol_mapper.create` | `POST .../clients/{id}/protocol-mappers/models` | caution |
+| `user` | `keycloak.user.create` | `POST .../realms/{realm}/users` | caution |
+| `user` | `keycloak.user.reset_password` | `PUT .../users/{id}/reset-password` | caution |
+| `role_mapping` | `keycloak.role_mapping.assign` | `POST .../users/{id}/role-mappings/realm` | dangerous |
+
+Three properties are load-bearing for correctness and safety:
+
+- **Name → UUID resolution.** Keycloak addresses every object by an
+  internal UUID, never its human name. `client.update` /
+  `protocol_mapper.create` accept either `id` (the UUID) or `client_id`
+  (the human clientId, resolved via `?clientId=`); `user.reset_password`
+  / `role_mapping.assign` accept either `id` or `username` (resolved via
+  `?username=&exact=true`). A create returns the new object's UUID parsed
+  from the `Location` header.
+- **Idempotency.** A create that hits an HTTP **409 already-exists** is
+  treated as a no-op-equivalent success (`conflict: true`), and the
+  existing object's UUID is resolved — so re-running a bootstrap step is
+  safe.
+- **Password handling.** `user.create` / `user.reset_password` **never**
+  carry the password inline. Pass `password_secret_ref` (a Vault KV-v2
+  path; optional `password_secret_mount` / `password_secret_key`) and the
+  connector reads the password from Vault under the operator's identity.
+  The password is set as a credential on Keycloak but never enters the op
+  params, the audit row (audit stores a `params_hash`, never raw params),
+  or the broadcast feed (`keycloak.user.create` /
+  `keycloak.user.reset_password` classify as `credential_write` →
+  aggregate-only broadcast). The CLI exposes only `--password-secret-ref`,
+  never an inline `--password`, so the secret never lands in shell
+  history or `ps` output.
+
+`keycloak.idp.create` (identity-provider federation) is **deferred** —
+it is not exercised by the current bootstrap scripts (#1406), so it is
+out of scope for this surface. A future task can add it under the same
+registrar walk.
+
+#### Bootstrap-script → MEHO-op mapping
+
+The five consumer bootstrap scripts now have callable MEHO equivalents.
+Each script's operations decompose into the write ops above (drive them
+through `meho keycloak …` or the agent meta-tools, feeding the same JSON
+representations the scripts POSTed to `kcadm.sh`):
+
+| Bootstrap script | What it does | MEHO equivalent op(s) |
+| --- | --- | --- |
+| `keycloak-bootstrap-meho-admin.sh` | Realm + admin service-account client + its protocol mappers + role grants | `keycloak.realm.create`, `keycloak.client.create`, `keycloak.protocol_mapper.create`, `keycloak.role_mapping.assign` |
+| `keycloak-bootstrap-meho-cli.sh` | The `meho-cli` public client (device/PKCE flow) + tenant claim mappers | `keycloak.client.create`, `keycloak.protocol_mapper.create` |
+| `keycloak-bootstrap-meho-mcp.sh` | The `meho-mcp` confidential client + client scopes + `tenant_id`/`tenant_role` mappers | `keycloak.client.create`, `keycloak.client_scope.create`, `keycloak.protocol_mapper.create` |
+| `keycloak-bootstrap-meho-web.sh` | The `meho-web` client (redirect URIs / web origins) + claim mappers | `keycloak.client.create`, `keycloak.protocol_mapper.create` |
+| `keycloak-provision-meho-user.sh` | Provision an operator user with a Vault-sourced password + realm-role grant | `keycloak.user.create` (`password_secret_ref`), `keycloak.role_mapping.assign` |
+
+The never-built `scripts/keycloak.sh` umbrella is discharged by the
+`meho keycloak …` verb tree as a whole.
 
 > **Not** the `meho admin keycloak …` deployer-onramp. That subtree
 > (#791) bootstraps Keycloak clients during initial deployment, before a
@@ -355,19 +426,47 @@ agent — e.g. the `client` blurb tells the agent to call `client.list`
 first to discover a client's internal `id`, then `client.get` for its
 full representation.
 
-## Deferred: the write surface (T4 / #1406)
+### Write verb reference
 
-This op surface is **read-only**. The Keycloak **write** ops —
-realm / client / client-scope / protocol-mapper / user / role-mapping
-creates, updates, and deletes — are the deferred approval-gated
-follow-up, tracked as G3.13-T4
-([#1406](https://github.com/evoila/meho/issues/1406)). Those ops will
-ship with `requires_approval=True` (the write-gating posture every
-mutating connector op follows) and will retire the consumer's five
-Keycloak bootstrap scripts. Until T4 lands, all Keycloak mutation goes
-through the existing `meho admin keycloak …` deployer-onramp (#791) or
-direct `kcadm.sh` / admin-console operations; the `meho keycloak …` tree
-is inspection-only.
+Every write verb takes `--target <slug>`, `--json`, and `--backplane
+<url>` like the read verbs. Create / update verbs take the
+representation body from a JSON file via `--representation-file` / `-f`.
+
+```console
+# Create a realm (idempotent: re-running on an existing realm succeeds)
+$ meho keycloak realm create --target rdc-keycloak -f realm-evba.json
+
+# Update the managed realm's top-level config
+$ meho keycloak realm update --target rdc-keycloak -f realm-patch.json
+
+# Create a client; update one by clientId (resolved to its UUID)
+$ meho keycloak client create --target rdc-keycloak -f client-meho-web.json
+$ meho keycloak client update --target rdc-keycloak --client-id meho-web -f client-patch.json
+
+# Create a client scope
+$ meho keycloak client-scope create --target rdc-keycloak -f scope-roles.json
+
+# Add the tenant_id claim mapper to a client (by clientId)
+$ meho keycloak protocol-mapper create --target rdc-keycloak \
+    --client-id meho-web -f mapper-tenant-id.json
+
+# Create a user; the password is read from Vault, never passed inline
+$ meho keycloak user create --target rdc-keycloak -f user-operator-a.json \
+    --password-secret-ref rdc-hetzner-dc/keycloak/operator-a
+
+# Reset a user's password from Vault (by username → UUID)
+$ meho keycloak user reset-password --target rdc-keycloak \
+    --username operator-a --password-secret-ref rdc-hetzner-dc/keycloak/operator-a
+
+# Grant a realm role to a user (privilege grant; --role is repeatable)
+$ meho keycloak role-mapping assign --target rdc-keycloak \
+    --username operator-a --role tenant_admin
+```
+
+Because every write is `requires_approval=True`, the first dispatch
+returns `status=awaiting_approval` and parks the call in the approval
+queue. A human approves it through the queue; the approved write then
+runs against Keycloak.
 
 ## Audit and broadcast
 
@@ -381,9 +480,14 @@ Every `meho keycloak …` dispatch writes an audit row to the
 - `status` = `ok` / `error` / `denied`
 - `duration_ms` = connector wall-clock time
 
-Broadcast events follow the standard envelope (CLAUDE.md §6 §7). All six
-ops are `safety_level="safe"` and broadcast with `risk_level=LOW` unless
-the agent's policy engine overrides.
+Broadcast events follow the standard envelope (CLAUDE.md §6 §7). The six
+read ops are `safety_level="safe"` and broadcast with `risk_level=LOW`
+unless the agent's policy engine overrides. The write ops broadcast under
+their mutation class — `keycloak.role_mapping.assign` and the create /
+update verbs as `write`, and the two password ops
+(`keycloak.user.create` / `keycloak.user.reset_password`) as
+`credential_write`, which collapses the broadcast to aggregate-only so no
+credential material reaches the feed.
 
 ## Troubleshooting
 
@@ -407,7 +511,7 @@ the agent's policy engine overrides.
 | MCP `search_operations` / `call_operation` dispatch reviewed | ✅ this PR (`test_connectors_keycloak_e2e.py`) |
 | respx recorded-fixture E2E for all 6 ops + admin-token refresh through dispatch | ✅ `test_connectors_keycloak_e2e.py` |
 | `docs/cross-repo/keycloak-onboarding.md` with admin-vs-operator split + deferred-write note | ✅ this document |
-| G3.13-T4 #1406 — approval-gated write ops (retire the 5 bootstrap scripts) | ⏳ deferred follow-up |
+| G3.13-T4 #1406 — approval-gated write ops (realm/client/scope/protocol-mapper/user/role-mapping) that retire the 5 bootstrap scripts | ✅ this PR (`idp.create` deferred — not exercised by the scripts) |
 
 ## References
 
@@ -415,8 +519,8 @@ the agent's policy engine overrides.
   Goal [#214](https://github.com/evoila/meho/issues/214) (connector parity).
 - Tasks that shipped this surface: [#1393](https://github.com/evoila/meho/issues/1393) (T1 skeleton + auth),
   [#1394](https://github.com/evoila/meho/issues/1394) (T2 read ops),
-  [#1395](https://github.com/evoila/meho/issues/1395) (T3 CLI + MCP review + E2E + this doc).
-  Deferred write surface: [#1406](https://github.com/evoila/meho/issues/1406) (T4).
+  [#1395](https://github.com/evoila/meho/issues/1395) (T3 CLI + MCP review + E2E + this doc),
+  [#1406](https://github.com/evoila/meho/issues/1406) (T4 approval-gated write surface).
 - Connector source: [`backend/src/meho_backplane/connectors/keycloak/`](../../backend/src/meho_backplane/connectors/keycloak/).
 - CLI verbs: [`cli/internal/cmd/keycloak/`](../../cli/internal/cmd/keycloak/).
 - E2E tests: [`backend/tests/test_connectors_keycloak_e2e.py`](../../backend/tests/test_connectors_keycloak_e2e.py).


### PR DESCRIPTION
## Summary
- Adds the **nine approval-gated Keycloak write ops** (G3.13-T4 #1406) that retire the consumer's five bootstrap scripts: `realm.create`/`update`, `client.create`/`update`, `client_scope.create`, `protocol_mapper.create`, `user.create`, `user.reset_password`, `role_mapping.assign`. Every op registers `requires_approval=True` with the issue's safety levels (`realm.create` + `role_mapping.assign` **dangerous**; the rest **caution**) — no write dispatches without the human approve-queue (#1401).
- **Name → UUID resolution** on every write: clientId → UUID (`?clientId=`), username → UUID (`?username=&exact=true`), realm-role name → representation; a create parses the new UUID from the `Location` header. Resolution lives on the connector (`_find_client_uuid` / `_find_user_uuid` / `_find_realm_role`).
- **Idempotency**: `_write_admin` swallows HTTP 409 (already-exists) into `conflict=True` rather than raising, so re-running a create is a no-op-equivalent success and the existing object's UUID is resolved.
- **Password handling (critical)**: `user.create` / `user.reset_password` source the password from Vault (`password_secret_ref`, operator-context `vault_client_for_operator`) — **never** inline in op params. The password never enters the audit row (`params_hash` only) and both ops are pinned in `broadcast.events._CREDENTIAL_WRITE_OPS` → aggregate-only broadcast. The CLI exposes only `--password-secret-ref`, never an inline `--password`.
- CLI verbs added under `meho keycloak …` (create / update / reset-password / assign) with `--representation-file` for the JSON body. Onboarding + codebase docs updated with the write-op table and the **five-script → MEHO-op mapping**.

## idp.create — deferred (as the issue instructs)
`keycloak.idp.create` (identity-provider federation) is **not** implemented: the issue notes it is "not exercised by current scripts," and the requirement said to prefer skipping to keep scope on the script-retiring ops. Documented as deferred in the onboarding + codebase docs.

## Test plan
- [x] `ruff check` / `ruff format --check` — clean (keycloak package + broadcast/events.py + test)
- [x] `mypy` — clean (7 source files)
- [x] `pytest backend/tests/test_connectors_keycloak_write_e2e.py` — 15 passed (registration/safety contract, name→UUID resolution, 409-idempotency, Vault password sourcing + no-leak, credential_write classification, admin-token-only invariant, search visibility)
- [x] Read E2E + auth + redaction + broadcast suites still green — 135 passed
- [x] `code-quality.py --diff` — 0 blockers (split `ops_write.py` into `ops_write.py` + `ops_write_schemas.py` to stay under the 600-line file budget)
- [x] CLI: `go build` / `go vet` / `gofmt -l` clean; `go test ./internal/cmd/keycloak/` passes (write-verb shape, representation-file loader, password-never-on-CLI, role forwarding)
- [x] **CLI API snapshot**: ran `make snapshot-openapi && make generate` — `cli/api/openapi.json` and `cli/internal/api/client.gen.go` are **unchanged** (the verbs ride the existing `/api/v1/operations/call` route; no new HTTP routes). No drift to commit.

## Out of scope
- `keycloak.idp.create` — deferred (see above).
- Delete ops (client/user/scope removal) — the bootstrap scripts only create/update; a delete surface is a separate follow-up if a workflow needs it. Noted in the codebase doc's Known issues.

<!-- auto-implement-issue: fresh, iteration 1 -->

Closes #1406
