### PR TITLE
feat(connectors): G3.12-T4 ArgoCD approval-gated write ops + CLI write verbs

### DIFF
--- a/backend/src/meho_backplane/connectors/argocd/__init__.py
+++ b/backend/src/meho_backplane/connectors/argocd/__init__.py
@@ -27,8 +27,11 @@ G3.12-T2 (#1391). :func:`register_argocd_typed_operations` delegates to
 curated read-core descriptors (``argocd.app.list`` / ``argocd.app.get`` /
 ``argocd.app.diff`` / ``argocd.app.resource_tree`` /
 ``argocd.appproject.list`` / ``argocd.repo.list``) — all ``safety_level="safe"``,
-``requires_approval=False``, read-only. The write ops (``app.sync`` /
-``rollback`` / ``set``) remain a deferred, approval-gated follow-up.
+``requires_approval=False``, read-only. The approval-gated write ops
+(``app.sync`` / ``rollback`` / ``set`` / ``refresh`` / ``delete`` +
+``appproject.create`` / ``update``, every one ``requires_approval=True``)
+land on the same registrar walk in G3.12-T4 (#1405) — see
+:mod:`meho_backplane.connectors.argocd.ops_write`.
 
 The v1 :func:`~meho_backplane.connectors.registry.register_connector` entry
 point is intentionally **not** called: ArgoCD has no v1 chassis history,
@@ -42,6 +45,10 @@ from meho_backplane.connectors.argocd.ops import (
     ARGOCD_OPS,
     ARGOCD_WHEN_TO_USE_BY_GROUP,
     ArgoCdOp,
+)
+from meho_backplane.connectors.argocd.ops_write import (
+    ARGOCD_WHEN_TO_USE_WRITE_BY_GROUP,
+    ARGOCD_WRITE_OPS,
 )
 from meho_backplane.connectors.argocd.session import (
     ARGOCD_TOKEN_FIELD,
@@ -110,6 +117,8 @@ __all__ = [
     "ARGOCD_OPS",
     "ARGOCD_TOKEN_FIELD",
     "ARGOCD_WHEN_TO_USE_BY_GROUP",
+    "ARGOCD_WHEN_TO_USE_WRITE_BY_GROUP",
+    "ARGOCD_WRITE_OPS",
     "ArgoCdConnector",
     "ArgoCdCredentialsLoader",
     "ArgoCdOp",

--- a/backend/src/meho_backplane/connectors/argocd/connector.py
+++ b/backend/src/meho_backplane/connectors/argocd/connector.py
@@ -529,6 +529,106 @@ class ArgoCdConnector(HttpConnector):
         del params  # schema declares the param object empty
         return await self._get_json(target, "/api/v1/repositories", operator=operator)
 
+    # ------------------------------------------------------------------
+    # Write primitive + approval-gated write handlers (G3.12-T4 #1405)
+    #
+    # Every write op registers ``requires_approval=True`` so the dispatcher's
+    # policy gate routes a USER-principal dispatch to the human approve-queue
+    # (G11.7-T1 #1401) and floors an agent dispatch to needs-approval — the
+    # handlers below run only on the ``_approved=True`` resume path. The op
+    # metadata + handler bodies live in
+    # :mod:`meho_backplane.connectors.argocd.ops_write`; these are the
+    # bound-method shims the registrar resolves ``handler_attr`` against.
+    # ------------------------------------------------------------------
+
+    async def _write_json(
+        self,
+        target: ArgoCdTargetLike,
+        method: str,
+        path: str,
+        *,
+        operator: Operator,
+        json: dict[str, Any] | None = None,
+        params: dict[str, Any] | None = None,
+    ) -> dict[str, Any]:
+        """Issue a mutating (POST/PUT/DELETE) argocd-server request — never retried.
+
+        The base :meth:`HttpConnector._request_json` rejects non-idempotent
+        verbs to keep a side-effecting call from being silently re-fired on a
+        5xx; the write ops therefore go through this helper, which hits the
+        pooled client directly with the Vault-sourced bearer header. A
+        non-2xx raises :exc:`httpx.HTTPStatusError` (the dispatcher's
+        ``connector_error`` branch records it). A 204 / empty body parses to
+        ``{}`` so callers never index into ``None``.
+        """
+        verb = method.upper()
+        if verb not in {"POST", "PUT", "DELETE"}:
+            raise ValueError(f"_write_json only accepts POST/PUT/DELETE; got {verb!r}")
+        client = await self._http_client(target)
+        headers = await self.auth_headers(target, operator)
+        resp = await client.request(verb, path, params=params, json=json, headers=headers)
+        resp.raise_for_status()
+        if not resp.content:
+            return {}
+        parsed = resp.json()
+        return parsed if isinstance(parsed, dict) else {"result": parsed}
+
+    async def app_sync(
+        self, operator: Operator, target: ArgoCdTargetLike, params: dict[str, Any]
+    ) -> dict[str, Any]:
+        """Bound-method shim for ``argocd.app.sync`` (G3.12-T4 #1405)."""
+        from meho_backplane.connectors.argocd.ops_write import argocd_app_sync
+
+        return await argocd_app_sync(self, operator, target, params)
+
+    async def app_rollback(
+        self, operator: Operator, target: ArgoCdTargetLike, params: dict[str, Any]
+    ) -> dict[str, Any]:
+        """Bound-method shim for ``argocd.app.rollback`` (G3.12-T4 #1405)."""
+        from meho_backplane.connectors.argocd.ops_write import argocd_app_rollback
+
+        return await argocd_app_rollback(self, operator, target, params)
+
+    async def app_set(
+        self, operator: Operator, target: ArgoCdTargetLike, params: dict[str, Any]
+    ) -> dict[str, Any]:
+        """Bound-method shim for ``argocd.app.set`` (G3.12-T4 #1405)."""
+        from meho_backplane.connectors.argocd.ops_write import argocd_app_set
+
+        return await argocd_app_set(self, operator, target, params)
+
+    async def app_refresh(
+        self, operator: Operator, target: ArgoCdTargetLike, params: dict[str, Any]
+    ) -> dict[str, Any]:
+        """Bound-method shim for ``argocd.app.refresh`` (G3.12-T4 #1405)."""
+        from meho_backplane.connectors.argocd.ops_write import argocd_app_refresh
+
+        return await argocd_app_refresh(self, operator, target, params)
+
+    async def app_delete(
+        self, operator: Operator, target: ArgoCdTargetLike, params: dict[str, Any]
+    ) -> dict[str, Any]:
+        """Bound-method shim for ``argocd.app.delete`` (G3.12-T4 #1405)."""
+        from meho_backplane.connectors.argocd.ops_write import argocd_app_delete
+
+        return await argocd_app_delete(self, operator, target, params)
+
+    async def appproject_create(
+        self, operator: Operator, target: ArgoCdTargetLike, params: dict[str, Any]
+    ) -> dict[str, Any]:
+        """Bound-method shim for ``argocd.appproject.create`` (G3.12-T4 #1405)."""
+        from meho_backplane.connectors.argocd.ops_write import argocd_appproject_create
+
+        return await argocd_appproject_create(self, operator, target, params)
+
+    async def appproject_update(
+        self, operator: Operator, target: ArgoCdTargetLike, params: dict[str, Any]
+    ) -> dict[str, Any]:
+        """Bound-method shim for ``argocd.appproject.update`` (G3.12-T4 #1405)."""
+        from meho_backplane.connectors.argocd.ops_write import argocd_appproject_update
+
+        return await argocd_appproject_update(self, operator, target, params)
+
     @classmethod
     async def register_operations(cls) -> None:
         """Upsert every op in :data:`ARGOCD_OPS` into ``endpoint_descriptor``.
@@ -553,9 +653,21 @@ class ArgoCdConnector(HttpConnector):
             ARGOCD_OPS,
             ARGOCD_WHEN_TO_USE_BY_GROUP,
         )
+        from meho_backplane.connectors.argocd.ops_write import (
+            ARGOCD_WHEN_TO_USE_WRITE_BY_GROUP,
+            ARGOCD_WRITE_OPS,
+        )
         from meho_backplane.operations.typed_register import register_typed_operation
 
-        for op in ARGOCD_OPS:
+        # The read / write when_to_use maps are disjoint by group_key suffix
+        # (read groups are bare nouns; write groups carry a ``-write``
+        # suffix) so the merge never clobbers a read blurb with a write one.
+        when_to_use_by_group = {
+            **ARGOCD_WHEN_TO_USE_BY_GROUP,
+            **ARGOCD_WHEN_TO_USE_WRITE_BY_GROUP,
+        }
+
+        for op in (*ARGOCD_OPS, *ARGOCD_WRITE_OPS):
             handler = getattr(cls, op.handler_attr, None)
             if handler is None:
                 raise AttributeError(
@@ -566,14 +678,14 @@ class ArgoCdConnector(HttpConnector):
             if op.group_key is None:
                 when_to_use = None
             else:
-                when_to_use = ARGOCD_WHEN_TO_USE_BY_GROUP.get(op.group_key)
+                when_to_use = when_to_use_by_group.get(op.group_key)
                 if when_to_use is None:
                     raise ValueError(
                         f"ArgoCdConnector op {op.op_id!r} declares "
                         f"group_key={op.group_key!r} but no curated when_to_use "
                         f"exists for that key. Add an entry to "
-                        f"ARGOCD_WHEN_TO_USE_BY_GROUP in "
-                        f"meho_backplane.connectors.argocd.ops."
+                        f"ARGOCD_WHEN_TO_USE_BY_GROUP (ops.py) or "
+                        f"ARGOCD_WHEN_TO_USE_WRITE_BY_GROUP (ops_write_schemas.py)."
                     )
             await register_typed_operation(
                 product=cls.product,
@@ -594,7 +706,9 @@ class ArgoCdConnector(HttpConnector):
             )
         _log.info(
             "argocd_operations_registered",
-            count=len(ARGOCD_OPS),
+            count=len(ARGOCD_OPS) + len(ARGOCD_WRITE_OPS),
+            read_count=len(ARGOCD_OPS),
+            write_count=len(ARGOCD_WRITE_OPS),
             product=cls.product,
             version=cls.version,
             impl_id=cls.impl_id,

--- a/backend/src/meho_backplane/connectors/argocd/ops_write.py
+++ b/backend/src/meho_backplane/connectors/argocd/ops_write.py
@@ -1,0 +1,498 @@
+# SPDX-License-Identifier: Apache-2.0
+# Copyright (c) 2026 evoila Group
+
+"""Approval-gated write ops for :class:`ArgoCdConnector` (G3.12-T4 #1405).
+
+G3.12-T1/T2 (#1390/#1391) shipped the connector + the six curated read ops.
+This module adds the GitOps **write** surface — the mutating ops that retire
+the consumer's hand-run ``kubectl annotate application …
+argocd.argoproj.io/refresh=hard`` and ad-hoc ``argocd app sync / rollback /
+delete``:
+
+======================================  ===========  ==============================================
+op_id                                   safety       argocd-server REST API
+======================================  ===========  ==============================================
+``argocd.app.sync``                     dangerous    ``POST .../applications/{name}/sync``
+``argocd.app.rollback``                 dangerous    ``POST .../applications/{name}/rollback``
+``argocd.app.set``                      dangerous    ``PUT  .../applications/{name}/spec``
+``argocd.app.refresh``                  caution      ``GET  .../applications/{name}?refresh=hard``
+``argocd.app.delete``                   dangerous    ``DELETE .../applications/{name}``
+``argocd.appproject.create``            dangerous    ``POST .../projects``
+``argocd.appproject.update``            dangerous    ``PUT  .../projects/{name}``
+======================================  ===========  ==============================================
+
+Approval routing (load-bearing)
+===============================
+
+Every op registers ``requires_approval=True``. The dispatcher's policy gate
+(:func:`~meho_backplane.operations._validate.policy_gate`) routes a
+``USER``-principal dispatch of a ``requires_approval`` op to the human
+approve-queue (``needs-approval``) — G11.7-T1 (#1401) — rather than
+hard-denying it, and floors an agent dispatch to ``needs-approval``
+regardless of safety level. The handler functions below therefore run only
+on the ``_approved=True`` resume path, after a human has approved the parked
+request through the queue. There is no bypass and no hard-deny: the
+``requires_approval=True`` descriptor flag is the only thing the connector
+controls, and it is what engages the queue.
+
+operationState polling (sync / rollback)
+=========================================
+
+``app.sync`` and ``app.rollback`` POST a SyncOperation / rollback that
+ArgoCD runs **asynchronously**: the POST returns immediately with the
+Application object, and the result lands later under
+``status.operationState.phase``. The handlers mirror
+``vmware.composite.vm.clone``'s task-poll: after the POST they poll
+``GET .../applications/{name}`` until ``operationState.phase`` reaches a
+terminal value (``Succeeded`` / ``Failed`` / ``Error``) or a bounded timeout
+elapses, then return the final phase + message. The terminal set matches
+gitops-engine's ``OperationPhase.Completed()`` (Succeeded / Failed / Error).
+
+proposed_effect snapshots (set / delete / appproject.update)
+============================================================
+
+``app.set`` / ``appproject.update`` snapshot the spec **before** and
+**after** the change; ``app.delete`` snapshots the managed resource tree
+(the cascade list) before the delete. Each lands under a ``proposed_effect``
+key in the returned result so the reviewer/auditor sees exactly what shifted
+or what the cascade will remove. (The substrate computes the durable
+``ApprovalRequest.proposed_effect`` at park-time from params; this in-result
+block is the post-approval execution evidence the op author can compute —
+it needs a live read against the target, which only happens once approved.)
+
+References
+----------
+
+* Task: https://github.com/evoila/meho/issues/1405
+* Parent initiative: https://github.com/evoila/meho/issues/1387
+* Human approve-queue: G11.7-T1 #1401.
+* argocd-server gRPC-gateway mappings: ``server/application/application.proto``
+  + ``server/project/project.proto`` (``argoproj/argo-cd``).
+* OperationPhase terminal set: ``gitops-engine/pkg/sync/common`` —
+  ``OperationPhase.Completed()`` = {Succeeded, Failed, Error}.
+"""
+
+from __future__ import annotations
+
+import asyncio
+import time
+from typing import TYPE_CHECKING, Any
+from urllib.parse import quote
+
+if TYPE_CHECKING:
+    from meho_backplane.auth.operator import Operator
+    from meho_backplane.connectors.argocd.connector import ArgoCdConnector
+    from meho_backplane.connectors.argocd.session import ArgoCdTargetLike
+
+__all__ = [
+    "ARGOCD_WHEN_TO_USE_WRITE_BY_GROUP",
+    "ARGOCD_WRITE_OPS",
+    "TERMINAL_OPERATION_PHASES",
+    "argocd_app_delete",
+    "argocd_app_refresh",
+    "argocd_app_rollback",
+    "argocd_app_set",
+    "argocd_app_sync",
+    "argocd_appproject_create",
+    "argocd_appproject_update",
+]
+
+#: The terminal ``status.operationState.phase`` values an async sync /
+#: rollback settles into. Matches gitops-engine's
+#: ``OperationPhase.Completed()`` (Succeeded / Failed / Error); ``Running``
+#: and ``Terminating`` are the non-terminal phases the poll waits through.
+TERMINAL_OPERATION_PHASES: frozenset[str] = frozenset({"Succeeded", "Failed", "Error"})
+
+#: Default seconds to poll operationState for a terminal phase before giving
+#: up. Capped by the op's ``poll_timeout_seconds`` schema (max 1800).
+_DEFAULT_POLL_TIMEOUT = 300
+
+#: Seconds between operationState polls.
+_POLL_INTERVAL = 2.0
+
+
+def _quote_name(name: Any) -> str:
+    """URL-encode an Application / project name for a path segment."""
+    return quote(str(name), safe="")
+
+
+def _project_query(params: dict[str, Any]) -> dict[str, Any]:
+    """Build the optional ``project`` scoping query from *params*."""
+    project = params.get("project")
+    return {"project": project} if project else {}
+
+
+def _operation_state(app: dict[str, Any]) -> dict[str, Any]:
+    """Pull ``status.operationState`` out of an Application, or ``{}``."""
+    status = app.get("status")
+    if not isinstance(status, dict):
+        return {}
+    op_state = status.get("operationState")
+    return op_state if isinstance(op_state, dict) else {}
+
+
+def _synced_revision(op_state: dict[str, Any]) -> str | None:
+    """Pull the synced revision out of an operationState's SyncResult."""
+    sync_result = op_state.get("syncResult")
+    if isinstance(sync_result, dict):
+        revision = sync_result.get("revision")
+        if isinstance(revision, str):
+            return revision
+    return None
+
+
+async def _poll_operation_state(
+    self: ArgoCdConnector,
+    operator: Operator,
+    target: ArgoCdTargetLike,
+    *,
+    name: str,
+    query: dict[str, Any],
+    timeout_seconds: int,
+) -> dict[str, Any]:
+    """Poll ``GET .../applications/{name}`` until operationState is terminal.
+
+    Returns ``{phase, message, synced_revision, timed_out}`` where *phase* is
+    the terminal ``operationState.phase`` (Succeeded / Failed / Error), or —
+    on timeout — the last-observed phase with ``timed_out=True``. Mirrors
+    ``vmware.composite.vm.clone``'s ``_poll_clone_task`` bound-deadline loop.
+    """
+    encoded = _quote_name(name)
+    path = f"/api/v1/applications/{encoded}"
+    deadline = time.monotonic() + timeout_seconds
+    last_phase: str | None = None
+    last_message: str | None = None
+    last_revision: str | None = None
+    while time.monotonic() < deadline:
+        app = await self._get_json(target, path, operator=operator, params=query or None)
+        op_state = _operation_state(app)
+        phase = op_state.get("phase")
+        last_phase = phase if isinstance(phase, str) else last_phase
+        message = op_state.get("message")
+        last_message = message if isinstance(message, str) else last_message
+        last_revision = _synced_revision(op_state) or last_revision
+        if isinstance(phase, str) and phase in TERMINAL_OPERATION_PHASES:
+            return {
+                "phase": phase,
+                "message": last_message,
+                "synced_revision": last_revision,
+                "timed_out": False,
+            }
+        await asyncio.sleep(_POLL_INTERVAL)
+    return {
+        "phase": last_phase,
+        "message": last_message,
+        "synced_revision": last_revision,
+        "timed_out": True,
+    }
+
+
+# ---------------------------------------------------------------------------
+# Application writes
+# ---------------------------------------------------------------------------
+
+
+async def argocd_app_sync(
+    self: ArgoCdConnector,
+    operator: Operator,
+    target: ArgoCdTargetLike,
+    params: dict[str, Any],
+) -> dict[str, Any]:
+    """``argocd.app.sync`` — POST sync, poll operationState to terminal.
+
+    POSTs ``/api/v1/applications/{name}/sync`` with an ApplicationSyncRequest,
+    then polls ``status.operationState.phase`` to a terminal phase. Returns
+    the final phase + message + synced revision.
+    """
+    name = str(params["name"])
+    encoded = _quote_name(name)
+    body: dict[str, Any] = {"name": name}
+    if params.get("revision"):
+        body["revision"] = params["revision"]
+    if params.get("prune") is not None:
+        body["prune"] = bool(params["prune"])
+    if params.get("dry_run") is not None:
+        body["dryRun"] = bool(params["dry_run"])
+    if params.get("project"):
+        body["project"] = params["project"]
+    await self._write_json(
+        target, "POST", f"/api/v1/applications/{encoded}/sync", operator=operator, json=body
+    )
+    timeout = int(params.get("poll_timeout_seconds") or _DEFAULT_POLL_TIMEOUT)
+    outcome = await _poll_operation_state(
+        self,
+        operator,
+        target,
+        name=name,
+        query=_project_query(params),
+        timeout_seconds=timeout,
+    )
+    return {"name": name, **outcome}
+
+
+async def argocd_app_rollback(
+    self: ArgoCdConnector,
+    operator: Operator,
+    target: ArgoCdTargetLike,
+    params: dict[str, Any],
+) -> dict[str, Any]:
+    """``argocd.app.rollback`` — POST rollback, poll operationState to terminal.
+
+    POSTs ``/api/v1/applications/{name}/rollback`` with the int64 history
+    ``id`` of a prior deployed revision, then polls operationState to a
+    terminal phase. Returns the final phase + message.
+    """
+    name = str(params["name"])
+    encoded = _quote_name(name)
+    rollback_id = int(params["id"])
+    body: dict[str, Any] = {"name": name, "id": rollback_id}
+    if params.get("prune") is not None:
+        body["prune"] = bool(params["prune"])
+    if params.get("dry_run") is not None:
+        body["dryRun"] = bool(params["dry_run"])
+    if params.get("project"):
+        body["project"] = params["project"]
+    await self._write_json(
+        target, "POST", f"/api/v1/applications/{encoded}/rollback", operator=operator, json=body
+    )
+    timeout = int(params.get("poll_timeout_seconds") or _DEFAULT_POLL_TIMEOUT)
+    outcome = await _poll_operation_state(
+        self,
+        operator,
+        target,
+        name=name,
+        query=_project_query(params),
+        timeout_seconds=timeout,
+    )
+    return {"name": name, "rollback_id": rollback_id, **outcome}
+
+
+async def argocd_app_set(
+    self: ArgoCdConnector,
+    operator: Operator,
+    target: ArgoCdTargetLike,
+    params: dict[str, Any],
+) -> dict[str, Any]:
+    """``argocd.app.set`` — snapshot spec, PUT new spec, snapshot after.
+
+    Reads the current ApplicationSpec, PUTs the new one to
+    ``/api/v1/applications/{name}/spec``, and returns both snapshots under
+    ``proposed_effect`` so the reviewer sees what changed.
+    """
+    name = str(params["name"])
+    encoded = _quote_name(name)
+    query = _project_query(params)
+    before = await self._get_json(
+        target, f"/api/v1/applications/{encoded}", operator=operator, params=query or None
+    )
+    before_spec = before.get("spec") if isinstance(before, dict) else None
+    put_query: dict[str, Any] = dict(query)
+    if params.get("validate") is not None:
+        put_query["validate"] = bool(params["validate"])
+    after_spec = await self._write_json(
+        target,
+        "PUT",
+        f"/api/v1/applications/{encoded}/spec",
+        operator=operator,
+        json=dict(params["spec"]),
+        params=put_query or None,
+    )
+    return {
+        "name": name,
+        "updated": True,
+        "proposed_effect": {"before_spec": before_spec, "after_spec": after_spec},
+    }
+
+
+async def argocd_app_refresh(
+    self: ArgoCdConnector,
+    operator: Operator,
+    target: ArgoCdTargetLike,
+    params: dict[str, Any],
+) -> dict[str, Any]:
+    """``argocd.app.refresh`` — GET ``?refresh=hard`` to force a reconcile.
+
+    Forces ArgoCD to re-compare the app against Git immediately. Under an
+    automated selfHeal policy this can trigger an immediate auto-sync (noted
+    in the op's llm_instructions). Returns the refreshed sync + health status.
+    """
+    name = str(params["name"])
+    encoded = _quote_name(name)
+    hard = params.get("hard")
+    refresh = "normal" if hard is False else "hard"
+    query = _project_query(params)
+    query["refresh"] = refresh
+    app = await self._get_json(
+        target, f"/api/v1/applications/{encoded}", operator=operator, params=query
+    )
+    raw_status = app.get("status") if isinstance(app, dict) else None
+    status: dict[str, Any] = raw_status if isinstance(raw_status, dict) else {}
+    raw_sync = status.get("sync")
+    sync: dict[str, Any] = raw_sync if isinstance(raw_sync, dict) else {}
+    raw_health = status.get("health")
+    health: dict[str, Any] = raw_health if isinstance(raw_health, dict) else {}
+    return {
+        "name": name,
+        "refresh": refresh,
+        "sync_status": sync.get("status"),
+        "health_status": health.get("status"),
+    }
+
+
+def _cascade_resources(tree: dict[str, Any]) -> list[dict[str, Any]]:
+    """Reduce a resource-tree's nodes to a compact cascade list."""
+    nodes = tree.get("nodes") if isinstance(tree, dict) else None
+    if not isinstance(nodes, list):
+        return []
+    out: list[dict[str, Any]] = []
+    for node in nodes:
+        if not isinstance(node, dict):
+            continue
+        out.append(
+            {
+                "group": node.get("group"),
+                "kind": node.get("kind"),
+                "namespace": node.get("namespace"),
+                "name": node.get("name"),
+            }
+        )
+    return out
+
+
+async def argocd_app_delete(
+    self: ArgoCdConnector,
+    operator: Operator,
+    target: ArgoCdTargetLike,
+    params: dict[str, Any],
+) -> dict[str, Any]:
+    """``argocd.app.delete`` — snapshot the cascade list, then DELETE.
+
+    With ``cascade=true`` (default) ArgoCD deletes the app's managed cluster
+    resources too. The handler first reads the resource tree to capture the
+    cascade list into ``proposed_effect.cascade_resources``, then DELETEs the
+    app.
+    """
+    name = str(params["name"])
+    encoded = _quote_name(name)
+    cascade = params.get("cascade")
+    cascade = True if cascade is None else bool(cascade)
+    query = _project_query(params)
+
+    cascade_resources: list[dict[str, Any]] = []
+    if cascade:
+        tree = await self._get_json(
+            target,
+            f"/api/v1/applications/{encoded}/resource-tree",
+            operator=operator,
+            params=query or None,
+        )
+        cascade_resources = _cascade_resources(tree)
+
+    delete_query: dict[str, Any] = dict(query)
+    delete_query["cascade"] = "true" if cascade else "false"
+    propagation = params.get("propagation_policy")
+    if propagation:
+        delete_query["propagationPolicy"] = propagation
+    await self._write_json(
+        target,
+        "DELETE",
+        f"/api/v1/applications/{encoded}",
+        operator=operator,
+        params=delete_query,
+    )
+    return {
+        "name": name,
+        "deleted": True,
+        "cascade": cascade,
+        "proposed_effect": {"cascade_resources": cascade_resources},
+    }
+
+
+# ---------------------------------------------------------------------------
+# AppProject writes
+# ---------------------------------------------------------------------------
+
+
+def _project_name(project: dict[str, Any]) -> str:
+    """Pull metadata.name out of an AppProject object."""
+    metadata = project.get("metadata") if isinstance(project, dict) else None
+    if isinstance(metadata, dict):
+        name = metadata.get("name")
+        if isinstance(name, str) and name:
+            return name
+    raise ValueError("argocd appproject write requires project.metadata.name")
+
+
+async def argocd_appproject_create(
+    self: ArgoCdConnector,
+    operator: Operator,
+    target: ArgoCdTargetLike,
+    params: dict[str, Any],
+) -> dict[str, Any]:
+    """``argocd.appproject.create`` — POST a ProjectCreateRequest.
+
+    POSTs ``/api/v1/projects`` with ``{project: AppProject, upsert}``. An
+    AppProject is the tenancy/authorization boundary for its Applications.
+    """
+    project = dict(params["project"])
+    name = _project_name(project)
+    body: dict[str, Any] = {"project": project, "upsert": bool(params.get("upsert", False))}
+    await self._write_json(target, "POST", "/api/v1/projects", operator=operator, json=body)
+    return {"name": name, "created": True}
+
+
+async def argocd_appproject_update(
+    self: ArgoCdConnector,
+    operator: Operator,
+    target: ArgoCdTargetLike,
+    params: dict[str, Any],
+) -> dict[str, Any]:
+    """``argocd.appproject.update`` — snapshot, PUT a ProjectUpdateRequest.
+
+    Snapshots the project's spec before/after the PUT to
+    ``/api/v1/projects/{name}`` into ``proposed_effect`` so the reviewer sees
+    how the tenancy boundary shifted.
+    """
+    project = dict(params["project"])
+    name = _project_name(project)
+    encoded = _quote_name(name)
+
+    before_spec: Any = None
+    projects = await self._get_json(target, "/api/v1/projects", operator=operator)
+    items = projects.get("items") if isinstance(projects, dict) else None
+    if isinstance(items, list):
+        for item in items:
+            if isinstance(item, dict) and _project_metadata_name(item) == name:
+                before_spec = item.get("spec")
+                break
+
+    body: dict[str, Any] = {"project": project}
+    updated = await self._write_json(
+        target, "PUT", f"/api/v1/projects/{encoded}", operator=operator, json=body
+    )
+    after_spec = updated.get("spec") if isinstance(updated, dict) else None
+    return {
+        "name": name,
+        "updated": True,
+        "proposed_effect": {"before_spec": before_spec, "after_spec": after_spec},
+    }
+
+
+def _project_metadata_name(item: dict[str, Any]) -> str | None:
+    """Pull metadata.name from an AppProject list item, or None."""
+    metadata = item.get("metadata")
+    if isinstance(metadata, dict):
+        name = metadata.get("name")
+        if isinstance(name, str):
+            return name
+    return None
+
+
+# The op-metadata table + curated blurbs + JSON-schema fragments live in a
+# sibling module so this handler module stays under the file-size budget.
+# Re-exported here so the connector's ``register_operations`` walk keeps
+# importing both from ``ops_write``.
+from meho_backplane.connectors.argocd.ops_write_schemas import (  # noqa: E402
+    ARGOCD_WHEN_TO_USE_WRITE_BY_GROUP,
+    ARGOCD_WRITE_OPS,
+)

--- a/backend/src/meho_backplane/connectors/argocd/ops_write_schemas.py
+++ b/backend/src/meho_backplane/connectors/argocd/ops_write_schemas.py
@@ -1,0 +1,484 @@
+# SPDX-License-Identifier: Apache-2.0
+# Copyright (c) 2026 evoila Group
+
+"""Write-op metadata + curated blurbs for the argocd connector (G3.12-T4 #1405).
+
+Split out of :mod:`~meho_backplane.connectors.argocd.ops_write` so the
+handler module stays under the code-quality file-size budget (mirrors the
+keycloak ``ops_write`` / ``ops_write_schemas`` split #1406). Carries the
+``ARGOCD_WRITE_OPS`` registration table, the per-group ``when_to_use``
+blurbs (``ARGOCD_WHEN_TO_USE_WRITE_BY_GROUP``), and the reusable JSON-schema
+fragments. The handlers live in ``ops_write``; the connector imports
+``ARGOCD_WRITE_OPS`` + ``ARGOCD_WHEN_TO_USE_WRITE_BY_GROUP`` (re-exported
+from ``ops_write``) for its ``register_operations`` walk.
+
+Every op registers ``requires_approval=True`` — no write reaches the
+``argocd-server`` REST surface until a human approves the parked request
+through the queue (G11.7-T1 #1401 routes a ``USER``-principal
+``requires_approval`` dispatch to ``needs-approval`` rather than
+hard-denying it). The agent/MCP path additionally floors every one of these
+to ``needs-approval`` regardless of safety level.
+
+Endpoint + field facts are pinned to the ``argoproj/argo-cd``
+``server/application/application.proto`` + ``server/project/project.proto``
+gRPC-gateway mappings (mirrored in ``assets/swagger.json``):
+
+* ``POST /api/v1/applications/{name}/sync`` — ``ApplicationSyncRequest``.
+* ``POST /api/v1/applications/{name}/rollback`` — ``ApplicationRollbackRequest``
+  (``id`` is the int64 history id of a prior deployed revision).
+* ``PUT  /api/v1/applications/{name}/spec`` — ``ApplicationSpec`` body.
+* ``GET  /api/v1/applications/{name}?refresh=hard`` — the hard-refresh
+  (a GET that forces an immediate reconcile; under ``selfHeal`` it can
+  trigger an auto-sync — flagged in the op's ``llm_instructions``).
+* ``DELETE /api/v1/applications/{name}?cascade=…`` — cascade delete.
+* ``POST /api/v1/projects`` — ``ProjectCreateRequest`` (``{project, upsert}``).
+* ``PUT  /api/v1/projects/{name}`` — ``ProjectUpdateRequest`` (``{project}``).
+"""
+
+from __future__ import annotations
+
+from typing import Any
+
+from meho_backplane.connectors.argocd.ops import ArgoCdOp
+
+__all__ = ["ARGOCD_WHEN_TO_USE_WRITE_BY_GROUP", "ARGOCD_WRITE_OPS"]
+
+
+# ---------------------------------------------------------------------------
+# Curated when_to_use blurbs (one per write op group)
+# ---------------------------------------------------------------------------
+
+_WHEN_TO_USE_APP_WRITE = (
+    "Use to drive an ArgoCD Application's GitOps lifecycle: kick a sync "
+    "(argocd.app.sync) and wait for it to reach a terminal phase, roll an "
+    "app back to a prior deployed revision (argocd.app.rollback), change an "
+    "app's spec / target-revision (argocd.app.set), force an immediate "
+    "reconcile (argocd.app.refresh), or remove an app and its managed "
+    "resources (argocd.app.delete). Every one of these is approval-gated — a "
+    "dispatch parks for a human to approve before it touches the cluster. The "
+    "right group when the operator wants to CHANGE cluster state, not just "
+    "inspect it (use the read group argocd.app.* for inspection)."
+)
+
+_WHEN_TO_USE_APPPROJECT_WRITE = (
+    "Use to define or amend the multi-tenant guardrails an AppProject "
+    "enforces: create a new AppProject (argocd.appproject.create) or update "
+    "an existing one's allow-lists / roles (argocd.appproject.update). Both "
+    "are approval-gated — an AppProject is the tenancy/authorization boundary "
+    "for every Application bound to it, so a change here widens or narrows "
+    "what those apps may deploy and where. The right group when the operator "
+    "is provisioning a tenant or adjusting what a project permits."
+)
+
+#: Curated ``when_to_use`` blurb per write op group. The group keys carry a
+#: ``-write`` suffix so they never collide with the read-op group keys in
+#: :data:`~meho_backplane.connectors.argocd.ops.ARGOCD_WHEN_TO_USE_BY_GROUP`
+#: when the connector merges both maps in ``register_operations``.
+ARGOCD_WHEN_TO_USE_WRITE_BY_GROUP: dict[str, str] = {
+    "argocd-apps-write": _WHEN_TO_USE_APP_WRITE,
+    "argocd-projects-write": _WHEN_TO_USE_APPPROJECT_WRITE,
+}
+
+
+# ---------------------------------------------------------------------------
+# Reusable JSON-schema fragments
+# ---------------------------------------------------------------------------
+
+_APP_NAME_PROPERTY: dict[str, Any] = {
+    "type": "string",
+    "minLength": 1,
+    "pattern": "\\S",
+    "description": "ArgoCD Application name (metadata.name), e.g. 'guestbook'.",
+}
+
+_PROJECT_QUERY_PROPERTY: dict[str, Any] = {
+    "type": "string",
+    "minLength": 1,
+    "pattern": "\\S",
+    "description": (
+        "Optional AppProject name to scope the operation to. When set, "
+        "ArgoCD returns 404 if the app is not in this project (an "
+        "authorization scoping hint)."
+    ),
+}
+
+#: The poll-timeout knob shared by the two long-running, operationState-polling
+#: ops (sync / rollback). Bounded so a stuck operation cannot block the
+#: dispatch indefinitely; on timeout the handler returns the last-observed
+#: phase with ``timed_out=True`` rather than raising.
+_POLL_TIMEOUT_PROPERTY: dict[str, Any] = {
+    "type": "integer",
+    "minimum": 1,
+    "maximum": 1800,
+    "description": (
+        "Seconds to poll status.operationState for a terminal phase "
+        "(Succeeded / Failed / Error) before giving up (default 300). On "
+        "timeout the op returns the last-observed phase with timed_out=true."
+    ),
+}
+
+_WRITE_CONFIRM_SCHEMA: dict[str, Any] = {
+    "type": "object",
+    "additionalProperties": True,
+}
+
+
+ARGOCD_WRITE_OPS: tuple[ArgoCdOp, ...] = (
+    # -- argocd.app.sync ---------------------------------------------------
+    ArgoCdOp(
+        op_id="argocd.app.sync",
+        handler_attr="app_sync",
+        summary="Sync an ArgoCD Application and wait for a terminal phase (approval-gated).",
+        description=(
+            "POSTs /api/v1/applications/{name}/sync to reconcile an "
+            "Application to its desired Git state, then polls "
+            "status.operationState.phase until it reaches a terminal phase "
+            "(Succeeded / Failed / Error) or the poll timeout elapses. "
+            "Returns the final phase + message and the SyncResult revision. "
+            "A bad sync reconciles the whole app at once, so this is "
+            "safety_level=dangerous, requires_approval=True. Optional "
+            "revision / prune / dry_run shape the SyncOperation."
+        ),
+        parameter_schema={
+            "type": "object",
+            "properties": {
+                "name": _APP_NAME_PROPERTY,
+                "project": _PROJECT_QUERY_PROPERTY,
+                "revision": {
+                    "type": "string",
+                    "minLength": 1,
+                    "description": "Git revision to sync to (default: the app's target revision).",
+                },
+                "prune": {
+                    "type": "boolean",
+                    "description": "Delete resources no longer defined in Git (default false).",
+                },
+                "dry_run": {
+                    "type": "boolean",
+                    "description": "Render + validate without applying (default false).",
+                },
+                "poll_timeout_seconds": _POLL_TIMEOUT_PROPERTY,
+            },
+            "required": ["name"],
+            "additionalProperties": False,
+        },
+        response_schema=_WRITE_CONFIRM_SCHEMA,
+        group_key="argocd-apps-write",
+        tags=("write", "argocd", "gitops", "sync"),
+        safety_level="dangerous",
+        requires_approval=True,
+        llm_instructions={
+            "when_to_use": _WHEN_TO_USE_APP_WRITE,
+            "parameter_hints": {
+                "name": "The Application's metadata.name.",
+                "revision": "Omit to sync to the app's configured targetRevision.",
+                "prune": "true also deletes cluster resources dropped from Git — extra-dangerous.",
+            },
+            "output_shape": (
+                "{name, phase, message, synced_revision, timed_out}. phase is "
+                "the terminal operationState phase (Succeeded / Failed / "
+                "Error); timed_out=true means the poll gave up before a "
+                "terminal phase and phase is the last observed value."
+            ),
+        },
+    ),
+    # -- argocd.app.rollback -----------------------------------------------
+    ArgoCdOp(
+        op_id="argocd.app.rollback",
+        handler_attr="app_rollback",
+        summary="Roll an ArgoCD Application back to a prior deployed revision (approval-gated).",
+        description=(
+            "POSTs /api/v1/applications/{name}/rollback with the int64 "
+            "history id of a previously-deployed revision (from "
+            "status.history[].id), then polls "
+            "status.operationState.phase to a terminal phase (Succeeded / "
+            "Failed / Error) or the poll timeout. Returns the final phase + "
+            "message. safety_level=dangerous, requires_approval=True."
+        ),
+        parameter_schema={
+            "type": "object",
+            "properties": {
+                "name": _APP_NAME_PROPERTY,
+                "project": _PROJECT_QUERY_PROPERTY,
+                "id": {
+                    "type": "integer",
+                    "minimum": 0,
+                    "description": (
+                        "The deployment history id to roll back to "
+                        "(status.history[].id from argocd.app.get)."
+                    ),
+                },
+                "prune": {
+                    "type": "boolean",
+                    "description": (
+                        "Delete resources no longer defined at that revision (default false)."
+                    ),
+                },
+                "dry_run": {
+                    "type": "boolean",
+                    "description": "Render + validate without applying (default false).",
+                },
+                "poll_timeout_seconds": _POLL_TIMEOUT_PROPERTY,
+            },
+            "required": ["name", "id"],
+            "additionalProperties": False,
+        },
+        response_schema=_WRITE_CONFIRM_SCHEMA,
+        group_key="argocd-apps-write",
+        tags=("write", "argocd", "gitops", "rollback"),
+        safety_level="dangerous",
+        requires_approval=True,
+        llm_instructions={
+            "when_to_use": _WHEN_TO_USE_APP_WRITE,
+            "parameter_hints": {
+                "name": "The Application's metadata.name.",
+                "id": "A history id from status.history[] — NOT a Git SHA.",
+            },
+            "output_shape": (
+                "{name, rollback_id, phase, message, synced_revision, "
+                "timed_out}. phase is the terminal operationState phase."
+            ),
+        },
+    ),
+    # -- argocd.app.set ----------------------------------------------------
+    ArgoCdOp(
+        op_id="argocd.app.set",
+        handler_attr="app_set",
+        summary="Update an ArgoCD Application's spec / target revision (approval-gated).",
+        description=(
+            "PUTs /api/v1/applications/{name}/spec with a new ApplicationSpec "
+            "(target revision, source path/params, sync policy). Snapshots "
+            "the spec before and after the change into the result's "
+            "proposed_effect block so the reviewer/auditor sees exactly what "
+            "shifted. Under an automated selfHeal sync policy this is a "
+            "deferred whole-app reconcile, so it is safety_level=dangerous, "
+            "requires_approval=True."
+        ),
+        parameter_schema={
+            "type": "object",
+            "properties": {
+                "name": _APP_NAME_PROPERTY,
+                "project": _PROJECT_QUERY_PROPERTY,
+                "spec": {
+                    "type": "object",
+                    "description": (
+                        "The full ApplicationSpec to set (replaces the "
+                        "current spec). Read the current spec via "
+                        "argocd.app.get first and edit it."
+                    ),
+                    "additionalProperties": True,
+                },
+                "validate": {
+                    "type": "boolean",
+                    "description": "Server-side validate the new spec (default true).",
+                },
+            },
+            "required": ["name", "spec"],
+            "additionalProperties": False,
+        },
+        response_schema=_WRITE_CONFIRM_SCHEMA,
+        group_key="argocd-apps-write",
+        tags=("write", "argocd", "gitops"),
+        safety_level="dangerous",
+        requires_approval=True,
+        llm_instructions={
+            "when_to_use": _WHEN_TO_USE_APP_WRITE,
+            "parameter_hints": {
+                "spec": "The full ApplicationSpec — get the current one first and edit it.",
+            },
+            "output_shape": (
+                "{name, updated, proposed_effect: {before_spec, after_spec}}. "
+                "Compare before_spec vs after_spec to see what changed."
+            ),
+        },
+    ),
+    # -- argocd.app.refresh ------------------------------------------------
+    ArgoCdOp(
+        op_id="argocd.app.refresh",
+        handler_attr="app_refresh",
+        summary="Force an immediate reconcile of an ArgoCD Application (approval-gated).",
+        description=(
+            "GETs /api/v1/applications/{name}?refresh=hard to force ArgoCD to "
+            "re-compare the app against Git immediately (a hard refresh also "
+            "re-renders manifests, bypassing the manifest cache). This does "
+            "not itself mutate the cluster, but under an automated selfHeal "
+            "sync policy the freshly-detected drift can trigger an immediate "
+            "auto-sync — so it is safety_level=caution, requires_approval=True. "
+            "Returns the refreshed sync + health status."
+        ),
+        parameter_schema={
+            "type": "object",
+            "properties": {
+                "name": _APP_NAME_PROPERTY,
+                "project": _PROJECT_QUERY_PROPERTY,
+                "hard": {
+                    "type": "boolean",
+                    "description": (
+                        "true (default) for a hard refresh (re-render "
+                        "manifests, bypass cache); false for a normal refresh."
+                    ),
+                },
+            },
+            "required": ["name"],
+            "additionalProperties": False,
+        },
+        response_schema=_WRITE_CONFIRM_SCHEMA,
+        group_key="argocd-apps-write",
+        tags=("write", "argocd", "gitops", "refresh"),
+        safety_level="caution",
+        requires_approval=True,
+        llm_instructions={
+            "when_to_use": _WHEN_TO_USE_APP_WRITE,
+            "parameter_hints": {
+                "hard": (
+                    "true is the governed replacement for the hand-run "
+                    "'kubectl annotate application … argocd.argoproj.io/"
+                    "refresh=hard'."
+                ),
+            },
+            "output_shape": (
+                "{name, refresh, sync_status, health_status}. CAUTION: under "
+                "selfHeal, a refresh that reveals drift can trigger an "
+                "immediate auto-sync."
+            ),
+        },
+    ),
+    # -- argocd.app.delete -------------------------------------------------
+    ArgoCdOp(
+        op_id="argocd.app.delete",
+        handler_attr="app_delete",
+        summary="Delete an ArgoCD Application with cascade (approval-gated).",
+        description=(
+            "DELETEs /api/v1/applications/{name}. With cascade=true (the "
+            "default) ArgoCD also deletes every Kubernetes resource the app "
+            "manages. Before deleting, the handler snapshots the app's "
+            "resource tree into the result's proposed_effect.cascade_resources "
+            "list so the reviewer/auditor sees exactly which cluster objects "
+            "the cascade will remove. safety_level=dangerous, "
+            "requires_approval=True."
+        ),
+        parameter_schema={
+            "type": "object",
+            "properties": {
+                "name": _APP_NAME_PROPERTY,
+                "project": _PROJECT_QUERY_PROPERTY,
+                "cascade": {
+                    "type": "boolean",
+                    "description": (
+                        "Also delete the app's managed cluster resources "
+                        "(default true). false leaves them orphaned."
+                    ),
+                },
+                "propagation_policy": {
+                    "type": "string",
+                    "enum": ["foreground", "background", "orphan"],
+                    "description": "Kubernetes deletion propagation policy (default foreground).",
+                },
+            },
+            "required": ["name"],
+            "additionalProperties": False,
+        },
+        response_schema=_WRITE_CONFIRM_SCHEMA,
+        group_key="argocd-apps-write",
+        tags=("write", "argocd", "gitops", "delete"),
+        safety_level="dangerous",
+        requires_approval=True,
+        llm_instructions={
+            "when_to_use": _WHEN_TO_USE_APP_WRITE,
+            "parameter_hints": {
+                "cascade": "true (default) removes managed cluster resources too.",
+            },
+            "output_shape": (
+                "{name, deleted, cascade, proposed_effect: "
+                "{cascade_resources: [{group, kind, namespace, name}, ...]}}. "
+                "The cascade_resources list is the set of cluster objects the "
+                "delete will (cascade=true) remove."
+            ),
+        },
+    ),
+    # -- argocd.appproject.create ------------------------------------------
+    ArgoCdOp(
+        op_id="argocd.appproject.create",
+        handler_attr="appproject_create",
+        summary="Create an ArgoCD AppProject (approval-gated).",
+        description=(
+            "POSTs /api/v1/projects with a ProjectCreateRequest "
+            "({project: AppProject, upsert}). An AppProject is the "
+            "tenancy/authorization boundary for every Application bound to "
+            "it — its sourceRepos / destinations / resource allow-lists gate "
+            "what those apps may deploy and where. safety_level=dangerous, "
+            "requires_approval=True."
+        ),
+        parameter_schema={
+            "type": "object",
+            "properties": {
+                "project": {
+                    "type": "object",
+                    "description": "The AppProject object ({metadata, spec}).",
+                    "additionalProperties": True,
+                },
+                "upsert": {
+                    "type": "boolean",
+                    "description": "Update the project if it already exists (default false).",
+                },
+            },
+            "required": ["project"],
+            "additionalProperties": False,
+        },
+        response_schema=_WRITE_CONFIRM_SCHEMA,
+        group_key="argocd-projects-write",
+        tags=("write", "argocd", "gitops", "appproject"),
+        safety_level="dangerous",
+        requires_approval=True,
+        llm_instructions={
+            "when_to_use": _WHEN_TO_USE_APPPROJECT_WRITE,
+            "parameter_hints": {
+                "project": "AppProject object; at minimum {metadata: {name}, spec: {...}}.",
+                "upsert": "true makes the create idempotent (update-if-exists).",
+            },
+            "output_shape": "{name, created}.",
+        },
+    ),
+    # -- argocd.appproject.update ------------------------------------------
+    ArgoCdOp(
+        op_id="argocd.appproject.update",
+        handler_attr="appproject_update",
+        summary="Update an ArgoCD AppProject (approval-gated).",
+        description=(
+            "PUTs /api/v1/projects/{name} with a ProjectUpdateRequest "
+            "({project: AppProject}). Snapshots the project spec before and "
+            "after the change into the result's proposed_effect block so the "
+            "reviewer/auditor sees how the tenancy/authorization boundary "
+            "shifted. safety_level=dangerous, requires_approval=True."
+        ),
+        parameter_schema={
+            "type": "object",
+            "properties": {
+                "project": {
+                    "type": "object",
+                    "description": (
+                        "The full AppProject object to set (replaces the "
+                        "current one). Its metadata.name selects the project; "
+                        "read the current project via argocd.appproject.list "
+                        "first and edit it."
+                    ),
+                    "additionalProperties": True,
+                },
+            },
+            "required": ["project"],
+            "additionalProperties": False,
+        },
+        response_schema=_WRITE_CONFIRM_SCHEMA,
+        group_key="argocd-projects-write",
+        tags=("write", "argocd", "gitops", "appproject"),
+        safety_level="dangerous",
+        requires_approval=True,
+        llm_instructions={
+            "when_to_use": _WHEN_TO_USE_APPPROJECT_WRITE,
+            "parameter_hints": {
+                "project": "Full AppProject object; metadata.name selects which project.",
+            },
+            "output_shape": ("{name, updated, proposed_effect: {before_spec, after_spec}}."),
+        },
+    ),
+)

--- a/backend/tests/test_connectors_argocd_write_e2e.py
+++ b/backend/tests/test_connectors_argocd_write_e2e.py
@@ -1,0 +1,498 @@
+# SPDX-License-Identifier: Apache-2.0
+# Copyright (c) 2026 evoila Group
+
+"""G3.12-T4 ArgoCD write-op recorded-fixture E2E test (#1405).
+
+Drives the seven approval-gated argocd write ops through the dispatch stack
+against a respx-mocked ``argocd-server`` REST API. No running ArgoCD, no
+live Vault: the bearer-token loader is injected, ``respx`` replays the
+recorded write fixtures, and the connector instance is preseeded into the
+dispatcher's instance cache.
+
+Acceptance criteria verified (Issue #1405)
+==========================================
+
+* The seven write ops register with the stated safety levels, all
+  ``requires_approval=True`` (asserted on ``ARGOCD_WRITE_OPS``).
+* A ``USER``-principal dispatch of a write op routes to the human
+  approve-queue (``status=awaiting_approval``) rather than hard-deny — the
+  governance dependency #1401 — and never reaches the handler.
+* ``app.sync`` / ``app.rollback`` POST then poll ``status.operationState``
+  to a terminal phase (Succeeded / Failed / Error) and return the final
+  phase + message.
+* ``app.set`` / ``app.delete`` capture before/after (or the cascade list)
+  into ``proposed_effect``.
+* Every write carries the Vault-sourced Bearer; the token never leaks.
+
+The handler path is exercised with ``_approved=True`` (the approvals-API
+resume flag) so the test drives the real handler/poll/HTTP behaviour the way
+it runs *after* a human approves.
+"""
+
+from __future__ import annotations
+
+import uuid
+from collections.abc import AsyncIterator, Iterator
+from typing import Any
+
+import pytest
+import respx
+
+import meho_backplane.connectors.argocd  # noqa: F401 -- import for registry side-effects
+from meho_backplane.auth.operator import Operator, TenantRole
+from meho_backplane.connectors.argocd import ArgoCdConnector
+from meho_backplane.connectors.argocd.ops_write import (
+    ARGOCD_WRITE_OPS,
+    TERMINAL_OPERATION_PHASES,
+)
+from meho_backplane.connectors.argocd.session import ArgoCdTargetLike
+from meho_backplane.db.engine import get_sessionmaker
+from meho_backplane.db.models import Target as TargetORM
+from meho_backplane.operations import dispatch, reset_dispatcher_caches
+from meho_backplane.operations.dispatcher import set_default_reducer
+from meho_backplane.operations.reducer import PassThroughReducer
+from meho_backplane.targets.resolver import resolve_target
+
+_CONNECTOR_ID = "argocd-api-3.x"
+_TARGET_NAME = "rdc-argocd-write-e2e"
+_ARGOCD_HOST = "argocd-write-e2e.test.invalid"
+_ARGOCD_BASE_URL = f"https://{_ARGOCD_HOST}"
+_BEARER_TOKEN = "argocd-write-bearer-token-e2e-DO-NOT-LEAK"
+
+_OPERATOR_TENANT_ID = uuid.UUID("00000000-0000-0000-0000-0000000000aa")
+_OPERATOR = Operator(
+    sub="argocd-write-e2e-test",
+    name="ArgoCD Write E2E Test Operator",
+    email=None,
+    raw_jwt="<argocd-write-e2e-raw-jwt>",
+    tenant_id=_OPERATOR_TENANT_ID,
+    tenant_role=TenantRole.OPERATOR,
+)
+
+_APP_NAME = "guestbook"
+
+EXPECTED_WRITE_OP_IDS: tuple[str, ...] = (
+    "argocd.app.sync",
+    "argocd.app.rollback",
+    "argocd.app.set",
+    "argocd.app.refresh",
+    "argocd.app.delete",
+    "argocd.appproject.create",
+    "argocd.appproject.update",
+)
+
+EXPECTED_SAFETY: dict[str, str] = {
+    "argocd.app.sync": "dangerous",
+    "argocd.app.rollback": "dangerous",
+    "argocd.app.set": "dangerous",
+    "argocd.app.refresh": "caution",
+    "argocd.app.delete": "dangerous",
+    "argocd.appproject.create": "dangerous",
+    "argocd.appproject.update": "dangerous",
+}
+
+
+# ---------------------------------------------------------------------------
+# Recorded argocd-server REST fixtures
+# ---------------------------------------------------------------------------
+
+
+def _app_with_phase(phase: str, message: str = "", revision: str = "abc1234") -> dict[str, Any]:
+    """An Application carrying a given operationState.phase."""
+    return {
+        "metadata": {"name": _APP_NAME, "namespace": "argocd"},
+        "spec": {"project": "default", "source": {"targetRevision": "HEAD"}},
+        "status": {
+            "sync": {"status": "Synced"},
+            "health": {"status": "Healthy"},
+            "operationState": {
+                "phase": phase,
+                "message": message,
+                "syncResult": {"revision": revision},
+            },
+        },
+    }
+
+
+_APP_SPEC_BEFORE: dict[str, Any] = {
+    "metadata": {"name": _APP_NAME},
+    "spec": {
+        "project": "default",
+        "source": {"repoURL": "https://github.com/example/gitops", "targetRevision": "HEAD"},
+    },
+}
+
+_APP_SPEC_AFTER: dict[str, Any] = {
+    "project": "default",
+    "source": {"repoURL": "https://github.com/example/gitops", "targetRevision": "v2.0.0"},
+}
+
+_RESOURCE_TREE: dict[str, Any] = {
+    "nodes": [
+        {"group": "apps", "kind": "Deployment", "namespace": "guestbook", "name": "guestbook-ui"},
+        {"group": "", "kind": "Service", "namespace": "guestbook", "name": "guestbook-ui"},
+    ],
+    "orphanedNodes": [],
+}
+
+_PROJECT_LIST: dict[str, Any] = {
+    "items": [
+        {
+            "metadata": {"name": "team-a"},
+            "spec": {"sourceRepos": ["https://github.com/example/*"], "destinations": []},
+        }
+    ],
+}
+
+_PROJECT_AFTER: dict[str, Any] = {
+    "metadata": {"name": "team-a"},
+    "spec": {
+        "sourceRepos": ["https://github.com/example/*", "https://github.com/other/*"],
+        "destinations": [{"server": "https://kubernetes.default.svc", "namespace": "team-a"}],
+    },
+}
+
+
+# ---------------------------------------------------------------------------
+# Stub credential loader + seeded connector instance
+# ---------------------------------------------------------------------------
+
+
+def _stub_loader(_target: ArgoCdTargetLike, _operator: Operator) -> Any:  # pragma: no cover
+    async def _load() -> dict[str, str]:
+        return {"token": _BEARER_TOKEN}
+
+    return _load()
+
+
+async def _seed_argocd_target() -> TargetORM:
+    sessionmaker = get_sessionmaker()
+    async with sessionmaker() as session:
+        target = TargetORM(
+            tenant_id=_OPERATOR_TENANT_ID,
+            name=_TARGET_NAME,
+            aliases=[],
+            product="argocd",
+            host=_ARGOCD_HOST,
+            port=443,
+            fqdn=None,
+            secret_ref="rdc-hetzner-dc/argocd/api-token",
+            auth_model="shared_service_account",
+            vpn_required=False,
+            extras={},
+            fingerprint={"version": "3.x"},
+            preferred_impl_id="argocd-api",
+            notes="seeded by test_connectors_argocd_write_e2e",
+        )
+        session.add(target)
+        await session.commit()
+        await session.refresh(target)
+        session.expunge(target)
+        return target
+
+
+def _wire_seeded_connector() -> ArgoCdConnector:
+    instance = ArgoCdConnector(credentials_loader=_stub_loader)
+    from meho_backplane.operations._handler_resolve import _CONNECTOR_INSTANCE_CACHE
+
+    _CONNECTOR_INSTANCE_CACHE[ArgoCdConnector] = instance
+    return instance
+
+
+@pytest.fixture(autouse=True)
+def _required_settings_env(monkeypatch: pytest.MonkeyPatch) -> Iterator[None]:
+    from meho_backplane.settings import get_settings
+
+    monkeypatch.setenv("KEYCLOAK_ISSUER_URL", "https://keycloak.test/realms/meho")
+    monkeypatch.setenv("KEYCLOAK_AUDIENCE", "meho-backplane")
+    monkeypatch.setenv("VAULT_ADDR", "https://vault.test")
+    get_settings.cache_clear()
+    yield
+    get_settings.cache_clear()
+
+
+@pytest.fixture(autouse=True)
+def _reset_module_state() -> Iterator[None]:
+    reset_dispatcher_caches()
+    yield
+    reset_dispatcher_caches()
+
+
+@pytest.fixture
+async def argocd_write_e2e() -> AsyncIterator[ArgoCdConnector]:
+    set_default_reducer(PassThroughReducer())
+    await ArgoCdConnector.register_operations()
+    await _seed_argocd_target()
+    connector = _wire_seeded_connector()
+    yield connector
+    await connector.aclose()
+
+
+async def _dispatch(op_id: str, params: dict[str, Any], *, approved: bool = True) -> dict[str, Any]:
+    """Dispatch a write op. ``approved=True`` bypasses the gate (resume path).
+
+    With ``approved=False`` the dispatch hits the policy gate, which (for a
+    ``USER`` principal on a ``requires_approval`` op) routes to the human
+    approve-queue and returns ``awaiting_approval`` — the handler never runs.
+    """
+    sessionmaker = get_sessionmaker()
+    async with sessionmaker() as session:
+        resolved_target = await resolve_target(session, _OPERATOR.tenant_id, _TARGET_NAME)
+    result = await dispatch(
+        operator=_OPERATOR,
+        connector_id=_CONNECTOR_ID,
+        op_id=op_id,
+        target=resolved_target,
+        params=params,
+        _approved=approved,
+    )
+    dumped: dict[str, Any] = result.model_dump(mode="json")
+    return dumped
+
+
+# ---------------------------------------------------------------------------
+# Registration contract (acceptance criterion a)
+# ---------------------------------------------------------------------------
+
+
+def test_write_ops_registration_set() -> None:
+    """ARGOCD_WRITE_OPS carries exactly the seven write ops the issue lists."""
+    op_ids = {op.op_id for op in ARGOCD_WRITE_OPS}
+    assert op_ids == set(EXPECTED_WRITE_OP_IDS)
+    assert len(ARGOCD_WRITE_OPS) == 7
+
+
+def test_write_ops_safety_levels_and_approval() -> None:
+    """Every write op has the stated safety level and requires_approval=True."""
+    for op in ARGOCD_WRITE_OPS:
+        assert op.requires_approval is True, f"{op.op_id} must require approval"
+        assert op.safety_level == EXPECTED_SAFETY[op.op_id], (
+            f"{op.op_id} safety_level={op.safety_level} != {EXPECTED_SAFETY[op.op_id]}"
+        )
+        assert "write" in op.tags, f"{op.op_id} should carry the write tag"
+
+
+# ---------------------------------------------------------------------------
+# Approval routing (acceptance criterion: route to queue, not hard-deny / bypass)
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.asyncio
+async def test_write_op_routes_to_approve_queue_not_hard_deny(
+    argocd_write_e2e: ArgoCdConnector,
+) -> None:
+    """An un-approved USER dispatch parks in the queue — no hard-deny, no cluster call."""
+    with respx.mock(base_url=_ARGOCD_BASE_URL, assert_all_called=False) as mock:
+        sync_route = mock.post(f"/api/v1/applications/{_APP_NAME}/sync").respond(
+            200, json=_app_with_phase("Running")
+        )
+        result = await _dispatch("argocd.app.sync", {"name": _APP_NAME}, approved=False)
+    assert result["status"] == "awaiting_approval", result
+    # Parked, not denied: the handler never fired against argocd-server.
+    assert not sync_route.called, "a parked write must not reach the cluster"
+    assert result.get("extras", {}).get("approval_request_id")
+
+
+# ---------------------------------------------------------------------------
+# operationState polling (acceptance criterion: sync/rollback to terminal)
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.asyncio
+async def test_app_sync_polls_to_terminal_succeeded(
+    argocd_write_e2e: ArgoCdConnector,
+) -> None:
+    """app.sync POSTs the sync then polls operationState to Succeeded."""
+    phases = iter([_app_with_phase("Running"), _app_with_phase("Succeeded", "successfully synced")])
+    with respx.mock(base_url=_ARGOCD_BASE_URL, assert_all_called=False) as mock:
+        post_route = mock.post(f"/api/v1/applications/{_APP_NAME}/sync").respond(
+            200, json=_app_with_phase("Running")
+        )
+        mock.get(f"/api/v1/applications/{_APP_NAME}").mock(
+            side_effect=lambda _req: respx.MockResponse(200, json=next(phases))
+        )
+        result = await _dispatch(
+            "argocd.app.sync",
+            {"name": _APP_NAME, "prune": True, "poll_timeout_seconds": 30},
+        )
+    assert result["status"] == "ok", result.get("error")
+    assert post_route.called
+    assert result["result"]["phase"] == "Succeeded"
+    assert result["result"]["phase"] in TERMINAL_OPERATION_PHASES
+    assert result["result"]["message"] == "successfully synced"
+    assert result["result"]["timed_out"] is False
+    assert result["result"]["synced_revision"] == "abc1234"
+
+
+@pytest.mark.asyncio
+async def test_app_rollback_polls_to_terminal_failed(
+    argocd_write_e2e: ArgoCdConnector,
+) -> None:
+    """app.rollback POSTs with the history id then polls to a terminal Failed."""
+    with respx.mock(base_url=_ARGOCD_BASE_URL, assert_all_called=False) as mock:
+        post_route = mock.post(f"/api/v1/applications/{_APP_NAME}/rollback").respond(
+            200, json=_app_with_phase("Running")
+        )
+        mock.get(f"/api/v1/applications/{_APP_NAME}").respond(
+            200, json=_app_with_phase("Failed", "rollback failed: conflict")
+        )
+        result = await _dispatch(
+            "argocd.app.rollback",
+            {"name": _APP_NAME, "id": 7, "poll_timeout_seconds": 30},
+        )
+    assert result["status"] == "ok", result.get("error")
+    # The POST body carried the int64 history id, not a Git SHA.
+    body = post_route.calls.last.request.content
+    assert b'"id":7' in body.replace(b" ", b"")
+    assert result["result"]["rollback_id"] == 7
+    assert result["result"]["phase"] == "Failed"
+    assert result["result"]["message"] == "rollback failed: conflict"
+
+
+# ---------------------------------------------------------------------------
+# proposed_effect snapshots (acceptance criterion: set/delete capture effect)
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.asyncio
+async def test_app_set_captures_before_after_into_proposed_effect(
+    argocd_write_e2e: ArgoCdConnector,
+) -> None:
+    """app.set snapshots the spec before + after into proposed_effect."""
+    with respx.mock(base_url=_ARGOCD_BASE_URL, assert_all_called=False) as mock:
+        mock.get(f"/api/v1/applications/{_APP_NAME}").respond(200, json=_APP_SPEC_BEFORE)
+        put_route = mock.put(f"/api/v1/applications/{_APP_NAME}/spec").respond(
+            200, json=_APP_SPEC_AFTER
+        )
+        result = await _dispatch(
+            "argocd.app.set",
+            {"name": _APP_NAME, "spec": _APP_SPEC_AFTER},
+        )
+    assert result["status"] == "ok", result.get("error")
+    assert put_route.called
+    effect = result["result"]["proposed_effect"]
+    assert effect["before_spec"]["source"]["targetRevision"] == "HEAD"
+    assert effect["after_spec"]["source"]["targetRevision"] == "v2.0.0"
+
+
+@pytest.mark.asyncio
+async def test_app_delete_captures_cascade_list_into_proposed_effect(
+    argocd_write_e2e: ArgoCdConnector,
+) -> None:
+    """app.delete snapshots the managed resource tree as the cascade list."""
+    with respx.mock(base_url=_ARGOCD_BASE_URL, assert_all_called=False) as mock:
+        tree_route = mock.get(f"/api/v1/applications/{_APP_NAME}/resource-tree").respond(
+            200, json=_RESOURCE_TREE
+        )
+        delete_route = mock.delete(f"/api/v1/applications/{_APP_NAME}").respond(200, json={})
+        result = await _dispatch("argocd.app.delete", {"name": _APP_NAME})
+    assert result["status"] == "ok", result.get("error")
+    assert tree_route.called, "delete must snapshot the cascade list before deleting"
+    assert delete_route.called
+    # cascade=true is on the DELETE query.
+    assert "cascade=true" in str(delete_route.calls.last.request.url)
+    cascade = result["result"]["proposed_effect"]["cascade_resources"]
+    assert {(r["kind"], r["name"]) for r in cascade} == {
+        ("Deployment", "guestbook-ui"),
+        ("Service", "guestbook-ui"),
+    }
+    assert result["result"]["cascade"] is True
+
+
+@pytest.mark.asyncio
+async def test_app_delete_no_cascade_skips_tree_snapshot(
+    argocd_write_e2e: ArgoCdConnector,
+) -> None:
+    """cascade=false leaves managed resources and skips the tree read."""
+    with respx.mock(base_url=_ARGOCD_BASE_URL, assert_all_called=False) as mock:
+        tree_route = mock.get(f"/api/v1/applications/{_APP_NAME}/resource-tree").respond(
+            200, json=_RESOURCE_TREE
+        )
+        delete_route = mock.delete(f"/api/v1/applications/{_APP_NAME}").respond(200, json={})
+        result = await _dispatch("argocd.app.delete", {"name": _APP_NAME, "cascade": False})
+    assert result["status"] == "ok", result.get("error")
+    assert not tree_route.called
+    assert "cascade=false" in str(delete_route.calls.last.request.url)
+    assert result["result"]["proposed_effect"]["cascade_resources"] == []
+
+
+# ---------------------------------------------------------------------------
+# Refresh + appproject writes
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.asyncio
+async def test_app_refresh_hard_sets_query(argocd_write_e2e: ArgoCdConnector) -> None:
+    """app.refresh GETs ?refresh=hard and returns the refreshed status."""
+    with respx.mock(base_url=_ARGOCD_BASE_URL, assert_all_called=False) as mock:
+        get_route = mock.get(f"/api/v1/applications/{_APP_NAME}").respond(
+            200, json=_app_with_phase("Succeeded")
+        )
+        result = await _dispatch("argocd.app.refresh", {"name": _APP_NAME})
+    assert result["status"] == "ok", result.get("error")
+    assert "refresh=hard" in str(get_route.calls.last.request.url)
+    assert result["result"]["refresh"] == "hard"
+    assert result["result"]["sync_status"] == "Synced"
+
+
+@pytest.mark.asyncio
+async def test_appproject_create_posts_create_request(
+    argocd_write_e2e: ArgoCdConnector,
+) -> None:
+    """appproject.create POSTs {project, upsert} and returns the project name."""
+    with respx.mock(base_url=_ARGOCD_BASE_URL, assert_all_called=False) as mock:
+        post_route = mock.post("/api/v1/projects").respond(200, json=_PROJECT_AFTER)
+        result = await _dispatch(
+            "argocd.appproject.create",
+            {"project": _PROJECT_AFTER, "upsert": True},
+        )
+    assert result["status"] == "ok", result.get("error")
+    body = post_route.calls.last.request.content
+    assert b'"upsert":true' in body.replace(b" ", b"")
+    assert b'"project"' in body
+    assert result["result"]["name"] == "team-a"
+    assert result["result"]["created"] is True
+
+
+@pytest.mark.asyncio
+async def test_appproject_update_captures_before_after(
+    argocd_write_e2e: ArgoCdConnector,
+) -> None:
+    """appproject.update snapshots the project spec before + after."""
+    with respx.mock(base_url=_ARGOCD_BASE_URL, assert_all_called=False) as mock:
+        mock.get("/api/v1/projects").respond(200, json=_PROJECT_LIST)
+        put_route = mock.put("/api/v1/projects/team-a").respond(200, json=_PROJECT_AFTER)
+        result = await _dispatch(
+            "argocd.appproject.update",
+            {"project": _PROJECT_AFTER},
+        )
+    assert result["status"] == "ok", result.get("error")
+    assert put_route.called
+    effect = result["result"]["proposed_effect"]
+    assert len(effect["before_spec"]["sourceRepos"]) == 1
+    assert len(effect["after_spec"]["sourceRepos"]) == 2
+
+
+# ---------------------------------------------------------------------------
+# Bearer-token + secret-leak guarantee across the write set
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.asyncio
+async def test_all_writes_carry_bearer_and_never_leak_secret(
+    argocd_write_e2e: ArgoCdConnector,
+) -> None:
+    """Every write carries the Vault-sourced Bearer; the token never leaks."""
+    with respx.mock(base_url=_ARGOCD_BASE_URL, assert_all_called=False) as mock:
+        mock.post(f"/api/v1/applications/{_APP_NAME}/sync").respond(
+            200, json=_app_with_phase("Running")
+        )
+        mock.get(f"/api/v1/applications/{_APP_NAME}").respond(
+            200, json=_app_with_phase("Succeeded")
+        )
+        result = await _dispatch("argocd.app.sync", {"name": _APP_NAME, "poll_timeout_seconds": 30})
+        assert result["status"] == "ok", result.get("error")
+        assert _BEARER_TOKEN not in str(result)
+        for call in mock.calls:
+            assert call.request.headers.get("authorization") == f"Bearer {_BEARER_TOKEN}"
+            assert _OPERATOR.raw_jwt not in (call.request.headers.get("authorization") or "")

--- a/cli/internal/cmd/argocd/app.go
+++ b/cli/internal/cmd/argocd/app.go
@@ -17,14 +17,22 @@ import (
 // (argocd.app.diff), and `resource-tree` (argocd.app.resource_tree).
 func newAppCmd() *cobra.Command {
 	cmd := &cobra.Command{
-		Use:          "app",
-		Short:        "ArgoCD Application sub-verbs (list, get, diff, resource-tree)",
+		Use: "app",
+		Short: "ArgoCD Application sub-verbs (list, get, diff, resource-tree; " +
+			"sync, rollback, set, refresh, delete)",
 		SilenceUsage: true,
 	}
+	// Read verbs (G3.12-T3 #1392).
 	cmd.AddCommand(newAppListCmd())
 	cmd.AddCommand(newAppGetCmd())
 	cmd.AddCommand(newAppDiffCmd())
 	cmd.AddCommand(newAppResourceTreeCmd())
+	// Approval-gated write verbs (G3.12-T4 #1405).
+	cmd.AddCommand(newAppSyncCmd())
+	cmd.AddCommand(newAppRollbackCmd())
+	cmd.AddCommand(newAppSetCmd())
+	cmd.AddCommand(newAppRefreshCmd())
+	cmd.AddCommand(newAppDeleteCmd())
 	return cmd
 }
 

--- a/cli/internal/cmd/argocd/appproject.go
+++ b/cli/internal/cmd/argocd/appproject.go
@@ -17,10 +17,13 @@ import (
 func newAppProjectCmd() *cobra.Command {
 	cmd := &cobra.Command{
 		Use:          "appproject",
-		Short:        "ArgoCD AppProject sub-verbs (list)",
+		Short:        "ArgoCD AppProject sub-verbs (list; create, update)",
 		SilenceUsage: true,
 	}
 	cmd.AddCommand(newAppProjectListCmd())
+	// Approval-gated write verbs (G3.12-T4 #1405).
+	cmd.AddCommand(newAppProjectCreateCmd())
+	cmd.AddCommand(newAppProjectUpdateCmd())
 	return cmd
 }
 

--- a/cli/internal/cmd/argocd/write.go
+++ b/cli/internal/cmd/argocd/write.go
@@ -1,0 +1,421 @@
+// SPDX-License-Identifier: Apache-2.0
+// Copyright (c) 2026 evoila Group
+
+package argocd
+
+import (
+	"encoding/json"
+	"fmt"
+	"io"
+	"os"
+
+	"github.com/spf13/cobra"
+
+	"github.com/evoila/meho/cli/internal/output"
+)
+
+// G3.12-T4 (#1405) — the approval-gated write verbs under
+// `meho argocd ...`. Every write op registers requires_approval=True on the
+// backplane, so a dispatch returns status=awaiting_approval until a human
+// approves through the queue (G11.7-T1 #1401); the CLI surfaces that status
+// verbatim. The verbs are the governed replacement for the consumer's
+// hand-run `kubectl annotate application … argocd.argoproj.io/refresh=hard`
+// and ad-hoc `argocd app sync/rollback/delete`.
+//
+// Verb tree (write half):
+//   - argocd app sync     --name N [--revision R] [--prune] [--dry-run]  → argocd.app.sync
+//   - argocd app rollback --name N --id I [--prune] [--dry-run]          → argocd.app.rollback
+//   - argocd app set      --name N --spec-file F [--no-validate]         → argocd.app.set
+//   - argocd app refresh  --name N [--no-hard]                           → argocd.app.refresh
+//   - argocd app delete   --name N [--no-cascade] [--propagation-policy P] → argocd.app.delete
+//   - argocd appproject create --project-file F [--upsert]               → argocd.appproject.create
+//   - argocd appproject update --project-file F                          → argocd.appproject.update
+//
+// The Application spec / AppProject body is a JSON file (--spec-file /
+// --project-file) so an operator can feed the same JSON they'd `kubectl
+// apply`.
+
+// loadJSONObject reads a JSON object from the file at path. Returns a
+// structured error (mapped to exit code 4 / unexpected) when the file is
+// unreadable or not a JSON object.
+func loadJSONObject(path string) (map[string]any, *output.StructuredError) {
+	raw, err := os.ReadFile(path) // #nosec G304 -- operator-supplied path, operator-only CLI
+	if err != nil {
+		return nil, output.Unexpected(fmt.Sprintf("read file %q: %v", path, err))
+	}
+	var obj map[string]any
+	if err := json.Unmarshal(raw, &obj); err != nil {
+		return nil, output.Unexpected(fmt.Sprintf("parse file %q as JSON object: %v", path, err))
+	}
+	return obj, nil
+}
+
+// writeResultKeyOrder pins a stable render order for the write
+// confirmations' scalar fields so the output is diff-stable across ops.
+var writeResultKeyOrder = []string{
+	"name", "phase", "message", "synced_revision", "rollback_id",
+	"refresh", "sync_status", "health_status", "created", "updated",
+	"deleted", "cascade", "timed_out",
+}
+
+// printWriteResult is the shared pretty-printer for the write confirmations.
+// It renders the op header, the awaiting_approval hint when parked, then the
+// flat result object's scalar fields (proposed_effect / before-after blocks
+// are nested and only shown under --json).
+func printWriteResult(opID string) func(w io.Writer, r *CallResult) {
+	return func(w io.Writer, r *CallResult) {
+		fmt.Fprintf(w, "%s %s — status=%s (%.0fms)\n", ConnectorID, opID, r.Status, r.DurationMs)
+		if r.Status == "awaiting_approval" {
+			fmt.Fprintln(w, "  parked for human approval — approve via the approval queue, then re-dispatch")
+			return
+		}
+		if r.Status != "ok" {
+			printErrorTrailer(w, r)
+			return
+		}
+		obj, err := decodeObject(r.Result)
+		if err != nil || obj == nil {
+			fallbackResultRender(w, r)
+			return
+		}
+		for _, key := range writeResultKeyOrder {
+			if v, ok := obj[key]; ok && v != nil {
+				fmt.Fprintf(w, "  %-16s %v\n", key+":", v)
+			}
+		}
+		// Surface the proposed_effect cascade count / before-after presence
+		// as a one-liner so the operator knows the reviewer evidence exists
+		// (the full block rides under --json).
+		if eff, ok := obj["proposed_effect"].(map[string]any); ok {
+			if cascade, ok := eff["cascade_resources"].([]any); ok {
+				fmt.Fprintf(w, "  %-16s %d resource(s)\n", "cascade:", len(cascade))
+			}
+			if _, ok := eff["before_spec"]; ok {
+				fmt.Fprintf(w, "  %-16s before/after captured (see --json)\n", "proposed_effect:")
+			}
+		}
+	}
+}
+
+// dispatchWrite is the shared dispatch+render path for the write verbs.
+func dispatchWrite(
+	cmd *cobra.Command,
+	opID, targetName string,
+	params map[string]any,
+	jsonOut bool,
+	backplaneOverride string,
+) error {
+	backplaneURL, err := resolveBackplane(backplaneOverride)
+	if err != nil {
+		return output.RenderError(cmd.ErrOrStderr(), classifyBackplaneError(err), jsonOut)
+	}
+	r, err := dispatchOp(cmd.Context(), backplaneURL, opID, targetName, params)
+	if err != nil {
+		return renderRequestError(cmd, backplaneURL, err, jsonOut)
+	}
+	return renderCallResult(cmd, opID, r, jsonOut, printWriteResult(opID))
+}
+
+// writeFlags is the common flag bundle every write verb binds: --target,
+// --json, --backplane. The per-verb commands add their own flags.
+type writeFlags struct {
+	targetName        string
+	jsonOut           bool
+	backplaneOverride string
+}
+
+func (f *writeFlags) bind(cmd *cobra.Command) {
+	cmd.Flags().StringVar(&f.targetName, "target", "",
+		"target slug to dispatch against (required)")
+	cmd.Flags().BoolVar(&f.jsonOut, "json", false,
+		"emit the full OperationResult envelope as JSON")
+	cmd.Flags().StringVar(&f.backplaneOverride, "backplane", "",
+		"backplane URL (defaults to the URL from the most recent `meho login`)")
+}
+
+// renderLoadError renders a file-load StructuredError through the right
+// channel (JSON or text). Pulled out so each verb's RunE stays a one-liner.
+func renderLoadError(cmd *cobra.Command, se *output.StructuredError, jsonOut bool) error {
+	return output.RenderError(cmd.ErrOrStderr(), se, jsonOut)
+}
+
+// --- argocd app sync ---------------------------------------------------
+
+func newAppSyncCmd() *cobra.Command {
+	var (
+		f        writeFlags
+		appName  string
+		revision string
+		prune    bool
+		dryRun   bool
+		timeout  int
+	)
+	cmd := &cobra.Command{
+		Use:   "sync",
+		Short: "Sync an ArgoCD Application and wait for a terminal phase (approval-gated)",
+		Long: "sync dispatches argocd.app.sync (requires_approval=True): it reconciles\n" +
+			"the app to its desired Git state and polls operationState until a\n" +
+			"terminal phase (Succeeded/Failed/Error). The dispatch parks for human\n" +
+			"approval before it touches the cluster.\n\n" +
+			"Exit codes: 0=ok, 1=error/denied, 2=auth_expired, 3=unreachable, 4=unexpected.",
+		Example: "  meho argocd app sync --target rdc-argocd --name guestbook --prune",
+		Args:    cobra.NoArgs, SilenceUsage: true, SilenceErrors: true,
+		RunE: func(cmd *cobra.Command, _ []string) error {
+			params := map[string]any{"name": appName}
+			if revision != "" {
+				params["revision"] = revision
+			}
+			if prune {
+				params["prune"] = true
+			}
+			if dryRun {
+				params["dry_run"] = true
+			}
+			if timeout > 0 {
+				params["poll_timeout_seconds"] = timeout
+			}
+			return dispatchWrite(cmd, "argocd.app.sync", f.targetName, params, f.jsonOut, f.backplaneOverride)
+		},
+	}
+	f.bind(cmd)
+	cmd.Flags().StringVar(&appName, "name", "", "the Application's metadata.name (required)")
+	cmd.Flags().StringVar(&revision, "revision", "", "Git revision to sync to (default: app target revision)")
+	cmd.Flags().BoolVar(&prune, "prune", false, "delete resources no longer defined in Git")
+	cmd.Flags().BoolVar(&dryRun, "dry-run", false, "render + validate without applying")
+	cmd.Flags().IntVar(&timeout, "poll-timeout", 0, "seconds to poll operationState (default 300 backend-side)")
+	mustRequire(cmd, "name")
+	return cmd
+}
+
+// --- argocd app rollback -----------------------------------------------
+
+func newAppRollbackCmd() *cobra.Command {
+	var (
+		f          writeFlags
+		appName    string
+		rollbackID int
+		prune      bool
+		dryRun     bool
+		timeout    int
+	)
+	cmd := &cobra.Command{
+		Use:   "rollback",
+		Short: "Roll an ArgoCD Application back to a prior deployed revision (approval-gated)",
+		Long: "rollback dispatches argocd.app.rollback (requires_approval=True) with the\n" +
+			"int64 history id of a prior deployed revision (status.history[].id), then\n" +
+			"polls operationState to a terminal phase. Parks for human approval first.\n\n" +
+			"Exit codes: 0=ok, 1=error/denied, 2=auth_expired, 3=unreachable, 4=unexpected.",
+		Example: "  meho argocd app rollback --target rdc-argocd --name guestbook --id 7",
+		Args:    cobra.NoArgs, SilenceUsage: true, SilenceErrors: true,
+		RunE: func(cmd *cobra.Command, _ []string) error {
+			params := map[string]any{"name": appName, "id": rollbackID}
+			if prune {
+				params["prune"] = true
+			}
+			if dryRun {
+				params["dry_run"] = true
+			}
+			if timeout > 0 {
+				params["poll_timeout_seconds"] = timeout
+			}
+			return dispatchWrite(cmd, "argocd.app.rollback", f.targetName, params, f.jsonOut, f.backplaneOverride)
+		},
+	}
+	f.bind(cmd)
+	cmd.Flags().StringVar(&appName, "name", "", "the Application's metadata.name (required)")
+	cmd.Flags().IntVar(&rollbackID, "id", -1, "deployment history id to roll back to (required)")
+	cmd.Flags().BoolVar(&prune, "prune", false, "delete resources no longer defined at that revision")
+	cmd.Flags().BoolVar(&dryRun, "dry-run", false, "render + validate without applying")
+	cmd.Flags().IntVar(&timeout, "poll-timeout", 0, "seconds to poll operationState (default 300 backend-side)")
+	mustRequire(cmd, "name")
+	mustRequire(cmd, "id")
+	return cmd
+}
+
+// --- argocd app set ----------------------------------------------------
+
+func newAppSetCmd() *cobra.Command {
+	var (
+		f          writeFlags
+		appName    string
+		specFile   string
+		noValidate bool
+	)
+	cmd := &cobra.Command{
+		Use:   "set",
+		Short: "Update an ArgoCD Application's spec / target revision (approval-gated)",
+		Long: "set dispatches argocd.app.set (requires_approval=True): it PUTs a new\n" +
+			"ApplicationSpec read from --spec-file and captures the spec before/after\n" +
+			"into proposed_effect for the reviewer. Parks for human approval first.\n\n" +
+			"Exit codes: 0=ok, 1=error/denied, 2=auth_expired, 3=unreachable, 4=unexpected.",
+		Example: "  meho argocd app set --target rdc-argocd --name guestbook --spec-file spec.json",
+		Args:    cobra.NoArgs, SilenceUsage: true, SilenceErrors: true,
+		RunE: func(cmd *cobra.Command, _ []string) error {
+			spec, se := loadJSONObject(specFile)
+			if se != nil {
+				return renderLoadError(cmd, se, f.jsonOut)
+			}
+			params := map[string]any{"name": appName, "spec": spec}
+			if noValidate {
+				params["validate"] = false
+			}
+			return dispatchWrite(cmd, "argocd.app.set", f.targetName, params, f.jsonOut, f.backplaneOverride)
+		},
+	}
+	f.bind(cmd)
+	cmd.Flags().StringVar(&appName, "name", "", "the Application's metadata.name (required)")
+	cmd.Flags().StringVar(&specFile, "spec-file", "", "JSON file with the full ApplicationSpec (required)")
+	cmd.Flags().BoolVar(&noValidate, "no-validate", false, "skip server-side spec validation")
+	mustRequire(cmd, "name")
+	mustRequire(cmd, "spec-file")
+	return cmd
+}
+
+// --- argocd app refresh ------------------------------------------------
+
+func newAppRefreshCmd() *cobra.Command {
+	var (
+		f       writeFlags
+		appName string
+		noHard  bool
+	)
+	cmd := &cobra.Command{
+		Use:   "refresh",
+		Short: "Force an immediate reconcile of an ArgoCD Application (approval-gated)",
+		Long: "refresh dispatches argocd.app.refresh (requires_approval=True): the\n" +
+			"governed replacement for `kubectl annotate application …\n" +
+			"argocd.argoproj.io/refresh=hard`. CAUTION: under a selfHeal sync policy\n" +
+			"a refresh that reveals drift can trigger an immediate auto-sync. Parks\n" +
+			"for human approval first.\n\n" +
+			"Exit codes: 0=ok, 1=error/denied, 2=auth_expired, 3=unreachable, 4=unexpected.",
+		Example: "  meho argocd app refresh --target rdc-argocd --name guestbook",
+		Args:    cobra.NoArgs, SilenceUsage: true, SilenceErrors: true,
+		RunE: func(cmd *cobra.Command, _ []string) error {
+			params := map[string]any{"name": appName}
+			if noHard {
+				params["hard"] = false
+			}
+			return dispatchWrite(cmd, "argocd.app.refresh", f.targetName, params, f.jsonOut, f.backplaneOverride)
+		},
+	}
+	f.bind(cmd)
+	cmd.Flags().StringVar(&appName, "name", "", "the Application's metadata.name (required)")
+	cmd.Flags().BoolVar(&noHard, "no-hard", false, "do a normal refresh instead of a hard refresh")
+	mustRequire(cmd, "name")
+	return cmd
+}
+
+// --- argocd app delete -------------------------------------------------
+
+func newAppDeleteCmd() *cobra.Command {
+	var (
+		f           writeFlags
+		appName     string
+		noCascade   bool
+		propagation string
+	)
+	cmd := &cobra.Command{
+		Use:   "delete",
+		Short: "Delete an ArgoCD Application with cascade (approval-gated)",
+		Long: "delete dispatches argocd.app.delete (requires_approval=True): with cascade\n" +
+			"(default) it also removes the app's managed cluster resources. The handler\n" +
+			"snapshots that cascade list into proposed_effect for the reviewer. Parks\n" +
+			"for human approval first.\n\n" +
+			"Exit codes: 0=ok, 1=error/denied, 2=auth_expired, 3=unreachable, 4=unexpected.",
+		Example: "  meho argocd app delete --target rdc-argocd --name guestbook",
+		Args:    cobra.NoArgs, SilenceUsage: true, SilenceErrors: true,
+		RunE: func(cmd *cobra.Command, _ []string) error {
+			params := map[string]any{"name": appName}
+			if noCascade {
+				params["cascade"] = false
+			}
+			if propagation != "" {
+				params["propagation_policy"] = propagation
+			}
+			return dispatchWrite(cmd, "argocd.app.delete", f.targetName, params, f.jsonOut, f.backplaneOverride)
+		},
+	}
+	f.bind(cmd)
+	cmd.Flags().StringVar(&appName, "name", "", "the Application's metadata.name (required)")
+	cmd.Flags().BoolVar(&noCascade, "no-cascade", false, "leave managed cluster resources orphaned")
+	cmd.Flags().StringVar(&propagation, "propagation-policy", "", "deletion propagation policy (foreground|background|orphan)")
+	mustRequire(cmd, "name")
+	return cmd
+}
+
+// --- argocd appproject create ------------------------------------------
+
+func newAppProjectCreateCmd() *cobra.Command {
+	var (
+		f           writeFlags
+		projectFile string
+		upsert      bool
+	)
+	cmd := &cobra.Command{
+		Use:   "create",
+		Short: "Create an ArgoCD AppProject (approval-gated)",
+		Long: "create dispatches argocd.appproject.create (requires_approval=True): it\n" +
+			"POSTs an AppProject read from --project-file. An AppProject is the\n" +
+			"tenancy/authorization boundary for its Applications. Parks for human\n" +
+			"approval first.\n\n" +
+			"Exit codes: 0=ok, 1=error/denied, 2=auth_expired, 3=unreachable, 4=unexpected.",
+		Example: "  meho argocd appproject create --target rdc-argocd --project-file proj.json --upsert",
+		Args:    cobra.NoArgs, SilenceUsage: true, SilenceErrors: true,
+		RunE: func(cmd *cobra.Command, _ []string) error {
+			project, se := loadJSONObject(projectFile)
+			if se != nil {
+				return renderLoadError(cmd, se, f.jsonOut)
+			}
+			params := map[string]any{"project": project}
+			if upsert {
+				params["upsert"] = true
+			}
+			return dispatchWrite(cmd, "argocd.appproject.create", f.targetName, params, f.jsonOut, f.backplaneOverride)
+		},
+	}
+	f.bind(cmd)
+	cmd.Flags().StringVar(&projectFile, "project-file", "", "JSON file with the AppProject object (required)")
+	cmd.Flags().BoolVar(&upsert, "upsert", false, "update the project if it already exists")
+	mustRequire(cmd, "project-file")
+	return cmd
+}
+
+// --- argocd appproject update ------------------------------------------
+
+func newAppProjectUpdateCmd() *cobra.Command {
+	var (
+		f           writeFlags
+		projectFile string
+	)
+	cmd := &cobra.Command{
+		Use:   "update",
+		Short: "Update an ArgoCD AppProject (approval-gated)",
+		Long: "update dispatches argocd.appproject.update (requires_approval=True): it\n" +
+			"PUTs an AppProject read from --project-file and captures the project spec\n" +
+			"before/after into proposed_effect. Parks for human approval first.\n\n" +
+			"Exit codes: 0=ok, 1=error/denied, 2=auth_expired, 3=unreachable, 4=unexpected.",
+		Example: "  meho argocd appproject update --target rdc-argocd --project-file proj.json",
+		Args:    cobra.NoArgs, SilenceUsage: true, SilenceErrors: true,
+		RunE: func(cmd *cobra.Command, _ []string) error {
+			project, se := loadJSONObject(projectFile)
+			if se != nil {
+				return renderLoadError(cmd, se, f.jsonOut)
+			}
+			params := map[string]any{"project": project}
+			return dispatchWrite(cmd, "argocd.appproject.update", f.targetName, params, f.jsonOut, f.backplaneOverride)
+		},
+	}
+	f.bind(cmd)
+	cmd.Flags().StringVar(&projectFile, "project-file", "", "JSON file with the AppProject object (required)")
+	mustRequire(cmd, "project-file")
+	return cmd
+}
+
+// mustRequire marks a flag required and panics on the programmer error of
+// naming a flag that was not defined (mirrors the per-verb inline pattern in
+// app.go's read verbs).
+func mustRequire(cmd *cobra.Command, name string) {
+	if err := cmd.MarkFlagRequired(name); err != nil {
+		panic(err)
+	}
+}

--- a/cli/internal/cmd/argocd/write_test.go
+++ b/cli/internal/cmd/argocd/write_test.go
@@ -1,0 +1,224 @@
+// SPDX-License-Identifier: Apache-2.0
+// Copyright (c) 2026 evoila Group
+
+package argocd
+
+import (
+	"bytes"
+	"context"
+	"encoding/json"
+	"net/http"
+	"os"
+	"path/filepath"
+	"strings"
+	"testing"
+
+	"github.com/spf13/cobra"
+)
+
+// TestAppHasWriteVerbs — the five approval-gated app write verbs attach to
+// the `app` parent alongside the read verbs.
+func TestAppHasWriteVerbs(t *testing.T) {
+	c := newAppCmd()
+	subs := make(map[string]bool)
+	for _, s := range c.Commands() {
+		subs[s.Name()] = true
+	}
+	for _, name := range []string{"sync", "rollback", "set", "refresh", "delete"} {
+		if !subs[name] {
+			t.Errorf("app is missing write sub-verb %q", name)
+		}
+	}
+}
+
+// TestAppProjectHasWriteVerbs — create + update attach to the appproject parent.
+func TestAppProjectHasWriteVerbs(t *testing.T) {
+	c := newAppProjectCmd()
+	subs := make(map[string]bool)
+	for _, s := range c.Commands() {
+		subs[s.Name()] = true
+	}
+	for _, name := range []string{"create", "update"} {
+		if !subs[name] {
+			t.Errorf("appproject is missing write sub-verb %q", name)
+		}
+	}
+}
+
+// TestWriteVerbsDispatchCanonicalOpIDs — every write verb dispatches its
+// canonical op_id with the connector_id pre-baked.
+func TestWriteVerbsDispatchCanonicalOpIDs(t *testing.T) {
+	expected := []string{
+		"argocd.app.sync",
+		"argocd.app.rollback",
+		"argocd.app.set",
+		"argocd.app.refresh",
+		"argocd.app.delete",
+		"argocd.appproject.create",
+		"argocd.appproject.update",
+	}
+	dispatched := make(map[string]bool)
+	srv := mockBackplane(t, map[string]mockHandler{
+		"POST /api/v1/operations/call": func(w http.ResponseWriter, r *http.Request) {
+			var body callRequestBody
+			if err := json.NewDecoder(r.Body).Decode(&body); err != nil {
+				t.Errorf("decode body: %v", err)
+				w.WriteHeader(400)
+				return
+			}
+			if body.ConnectorID != "argocd-api-3.x" {
+				t.Errorf("connector_id: got %q", body.ConnectorID)
+			}
+			dispatched[body.OpID] = true
+			writeJSON(t, w, 200, CallResult{Status: "ok", OpID: body.OpID, Result: json.RawMessage(`{}`)})
+		},
+	})
+	defer srv.Close()
+	primeToken(t, srv.URL)
+
+	for _, opID := range expected {
+		if _, err := dispatchOp(context.Background(), srv.URL, opID, "rdc-argocd", map[string]any{"name": "x"}); err != nil {
+			t.Fatalf("dispatchOp %s: %v", opID, err)
+		}
+	}
+	for _, opID := range expected {
+		if !dispatched[opID] {
+			t.Errorf("op_id %q was not dispatched", opID)
+		}
+	}
+}
+
+// TestSyncForwardsSyncParams — `app sync --prune` forwards prune + name.
+func TestSyncForwardsSyncParams(t *testing.T) {
+	var got callRequestBody
+	srv := mockBackplane(t, map[string]mockHandler{
+		"POST /api/v1/operations/call": func(w http.ResponseWriter, r *http.Request) {
+			_ = json.NewDecoder(r.Body).Decode(&got)
+			writeJSON(t, w, 200, CallResult{Status: "ok", OpID: "argocd.app.sync",
+				Result: json.RawMessage(`{"name":"guestbook","phase":"Succeeded","timed_out":false}`)})
+		},
+	})
+	defer srv.Close()
+	primeToken(t, srv.URL)
+
+	cmd := newAppSyncCmd()
+	cmd.SetArgs([]string{"--target", "rdc-argocd", "--name", "guestbook", "--prune", "--backplane", srv.URL})
+	cmd.SetOut(&bytes.Buffer{})
+	cmd.SetErr(&bytes.Buffer{})
+	if err := cmd.Execute(); err != nil {
+		t.Fatalf("sync execute: %v", err)
+	}
+	if got.OpID != "argocd.app.sync" {
+		t.Errorf("op_id: got %q", got.OpID)
+	}
+	if got.Params["name"] != "guestbook" {
+		t.Errorf("name param: got %v", got.Params["name"])
+	}
+	if got.Params["prune"] != true {
+		t.Errorf("prune param: got %v", got.Params["prune"])
+	}
+}
+
+// TestPrintWriteResultAwaitingApproval — the awaiting_approval status renders
+// the human-approve hint, never an error trailer.
+func TestPrintWriteResultAwaitingApproval(t *testing.T) {
+	var buf bytes.Buffer
+	r := &CallResult{Status: "awaiting_approval", OpID: "argocd.app.sync", DurationMs: 5}
+	printWriteResult("argocd.app.sync")(&buf, r)
+	out := buf.String()
+	if !strings.Contains(out, "awaiting_approval") {
+		t.Errorf("expected status line; got %q", out)
+	}
+	if !strings.Contains(out, "parked for human approval") {
+		t.Errorf("expected approval hint; got %q", out)
+	}
+	if strings.Contains(out, "connector error") {
+		t.Errorf("awaiting_approval must not render an error trailer; got %q", out)
+	}
+}
+
+// TestPrintWriteResultCascade — the delete result's proposed_effect cascade
+// count is surfaced in the text render.
+func TestPrintWriteResultCascade(t *testing.T) {
+	var buf bytes.Buffer
+	r := &CallResult{
+		Status: "ok", OpID: "argocd.app.delete", DurationMs: 12,
+		Result: json.RawMessage(`{"name":"guestbook","deleted":true,"cascade":true,` +
+			`"proposed_effect":{"cascade_resources":[{"kind":"Deployment","name":"a"},{"kind":"Service","name":"b"}]}}`),
+	}
+	printWriteResult("argocd.app.delete")(&buf, r)
+	out := buf.String()
+	if !strings.Contains(out, "2 resource(s)") {
+		t.Errorf("expected cascade count; got %q", out)
+	}
+	if !strings.Contains(out, "deleted:") {
+		t.Errorf("expected deleted field; got %q", out)
+	}
+}
+
+// TestSetRequiresSpecFile — `app set` marks --name and --spec-file required.
+func TestSetRequiresSpecFile(t *testing.T) {
+	cmd := newAppSetCmd()
+	for _, flag := range []string{"name", "spec-file"} {
+		f := cmd.Flags().Lookup(flag)
+		if f == nil {
+			t.Fatalf("set missing --%s", flag)
+		}
+		if ann := f.Annotations[cobraRequiredAnnotation]; len(ann) == 0 || ann[0] != "true" {
+			t.Errorf("set --%s should be required; annotations=%v", flag, f.Annotations)
+		}
+	}
+}
+
+// TestRollbackRequiresID — `app rollback` marks --name and --id required.
+func TestRollbackRequiresID(t *testing.T) {
+	cmd := newAppRollbackCmd()
+	for _, flag := range []string{"name", "id"} {
+		f := cmd.Flags().Lookup(flag)
+		if f == nil {
+			t.Fatalf("rollback missing --%s", flag)
+		}
+		if ann := f.Annotations[cobraRequiredAnnotation]; len(ann) == 0 || ann[0] != "true" {
+			t.Errorf("rollback --%s should be required; annotations=%v", flag, f.Annotations)
+		}
+	}
+}
+
+// TestLoadJSONObject — reads a JSON object file; rejects non-object/garbage.
+func TestLoadJSONObject(t *testing.T) {
+	dir := t.TempDir()
+	good := filepath.Join(dir, "spec.json")
+	if err := os.WriteFile(good, []byte(`{"project":"default"}`), 0o600); err != nil {
+		t.Fatal(err)
+	}
+	obj, se := loadJSONObject(good)
+	if se != nil {
+		t.Fatalf("loadJSONObject good: %+v", se)
+	}
+	if obj["project"] != "default" {
+		t.Errorf("decoded: %+v", obj)
+	}
+	bad := filepath.Join(dir, "bad.json")
+	if err := os.WriteFile(bad, []byte(`[1,2,3]`), 0o600); err != nil {
+		t.Fatal(err)
+	}
+	if _, se := loadJSONObject(bad); se == nil {
+		t.Errorf("expected error decoding a JSON array as object")
+	}
+	if _, se := loadJSONObject(filepath.Join(dir, "nope.json")); se == nil {
+		t.Errorf("expected error for missing file")
+	}
+}
+
+// guard: the verb constructors return non-nil commands (cheap smoke).
+func TestWriteVerbConstructorsNonNil(t *testing.T) {
+	ctors := []func() *cobra.Command{
+		newAppSyncCmd, newAppRollbackCmd, newAppSetCmd, newAppRefreshCmd,
+		newAppDeleteCmd, newAppProjectCreateCmd, newAppProjectUpdateCmd,
+	}
+	for i, ctor := range ctors {
+		if ctor() == nil {
+			t.Errorf("ctor %d returned nil", i)
+		}
+	}
+}

--- a/docs/codebase/connectors-argocd.md
+++ b/docs/codebase/connectors-argocd.md
@@ -154,6 +154,60 @@ against `targetState` (Git-rendered desired). The per-app ops URL-encode the
 forward the optional `project` scoping query. `app.list` serialises `projects`
 as repeated query pairs (the gRPC-gateway repeated-field shape).
 
+### Approval-gated write ops (G3.12-T4)
+
+Seven mutating ops layer onto the same registrar walk (`register_operations`
+now iterates `(*ARGOCD_OPS, *ARGOCD_WRITE_OPS)`). Every one registers
+`requires_approval=True`. The op metadata lives in `ops_write_schemas.py`
+(`ARGOCD_WRITE_OPS` + `ARGOCD_WHEN_TO_USE_WRITE_BY_GROUP`, write group keys
+carry a `-write` suffix so they never collide with the read groups); the
+handler bodies live in `ops_write.py`; `ArgoCdConnector` exposes thin
+bound-method shims (`app_sync` / `app_rollback` / `app_set` / `app_refresh`
+/ `app_delete` / `appproject_create` / `appproject_update`) the registrar
+resolves `handler_attr` against.
+
+| op_id | safety | endpoint | notes |
+|---|---|---|---|
+| `argocd.app.sync` | dangerous | `POST /api/v1/applications/{name}/sync` | polls `status.operationState.phase` to terminal (Succeeded/Failed/Error); returns final phase + message + synced revision |
+| `argocd.app.rollback` | dangerous | `POST .../{name}/rollback` | int64 history `id`; same operationState poll |
+| `argocd.app.set` | dangerous | `PUT .../{name}/spec` | snapshots spec before/after into `proposed_effect` |
+| `argocd.app.refresh` | caution | `GET .../{name}?refresh=hard` | governed replacement for the hand-run `kubectl annotate … refresh=hard`; under selfHeal can trigger an auto-sync |
+| `argocd.app.delete` | dangerous | `DELETE .../{name}?cascade=…` | snapshots the managed resource tree (cascade list) into `proposed_effect` |
+| `argocd.appproject.create` | dangerous | `POST /api/v1/projects` | `{project, upsert}` — tenancy boundary |
+| `argocd.appproject.update` | dangerous | `PUT /api/v1/projects/{name}` | snapshots project spec before/after into `proposed_effect` |
+
+**Approval routing (no hard-deny, no bypass).** The connector only sets the
+`requires_approval=True` descriptor flag; the dispatcher's `policy_gate`
+(`_validate.py`) does the rest. Since G11.7-T1 (#1401) a `USER`-principal
+dispatch of a `requires_approval` op routes to the human approve-queue
+(`status=awaiting_approval` + an `approval_request_id` in `extras`) rather
+than hard-denying; an agent dispatch is floored to `needs-approval`
+regardless of safety level. The handler functions therefore execute only on
+the `_approved=True` resume path the approvals API sets after a human
+approves.
+
+**operationState polling.** `app.sync` / `app.rollback` POST a SyncOperation
+that ArgoCD runs asynchronously, so the handlers mirror
+`vmware.composite.vm.clone`'s task-poll: after the POST they poll
+`GET .../applications/{name}` until `status.operationState.phase` reaches a
+terminal value (the `TERMINAL_OPERATION_PHASES` set = Succeeded ∪ Failed ∪
+Error, matching gitops-engine's `OperationPhase.Completed()`), or a bounded
+`poll_timeout_seconds` (default 300) elapses — on timeout they return the
+last-observed phase with `timed_out=true`.
+
+**proposed_effect snapshots.** `app.set` / `appproject.update` read the
+current spec before the PUT and return `{before_spec, after_spec}` under a
+`proposed_effect` key; `app.delete` reads the resource tree before the
+DELETE and returns the cascade list. These ride in the op result (the
+post-approval execution evidence the reviewer/auditor sees) — the durable
+`ApprovalRequest.proposed_effect` the queue stores at park time is computed
+separately by `create_pending_request` from params.
+
+Writes go through the connector's `_write_json` helper (POST/PUT/DELETE,
+**not** retried — a side-effecting verb must not silently re-fire on a 5xx),
+which the base `HttpConnector._request_json` deliberately refuses for
+non-idempotent methods.
+
 ### execute() shim
 
 `execute()` synthesises a system `Operator` with
@@ -205,12 +259,19 @@ shim.
   loader preseeded into the dispatcher instance cache; asserts the Vault-sourced
   bearer rides every request, the token never leaks into the envelope, and all
   six ops are visible to `search_operations`.
+- `tests/test_connectors_argocd_write_e2e.py` — the G3.12-T4 write-op suite:
+  the seven write ops' registration + safety-level/`requires_approval`
+  invariants, the approve-queue routing of an un-approved `USER` dispatch
+  (`awaiting_approval`, handler never fires), the `app.sync`/`rollback`
+  operationState poll to a terminal phase, the `app.set`/`delete`/`appproject.update`
+  `proposed_effect` snapshots, and the bearer-rides-never-leaks guarantee.
 
 ## Known issues
 
-- The write ops (`argocd.app.sync` / `app.rollback` / `app.set`, gated by the
-  approval queue) and any full-Swagger L2 ingest are deferred follow-up Tasks
-  under Initiative #1387, per Hard rule 2 (no speculative optionality).
+- Any full-Swagger L2 ingest of the ArgoCD API is a deferred follow-up Task
+  under Initiative #1387, per Hard rule 2 (no speculative optionality). The
+  curated read core (G3.12-T2) + approval-gated write surface (G3.12-T4) are
+  the bounded operator-facing set.
 - The fingerprint surfaces only the four build-tool fields the operator
   cares about (`BuildDate`, `KustomizeVersion`, `HelmVersion`,
   `KubectlVersion`); the full `VersionMessage` (`GitCommit`, `GitTag`,

--- a/docs/cross-repo/argocd-onboarding.md
+++ b/docs/cross-repo/argocd-onboarding.md
@@ -8,7 +8,8 @@ Copyright (c) 2026 evoila Group
 > Operator-facing recipe for the G3.12 `argocd-api-3.x` op surface — how
 > to register an `argocd` target (host, port, the Vault bearer-token
 > `secret_ref`), the six curated read ops, the `GET /api/version` probe,
-> and the **deferred write surface**. The op handlers live in
+> and the **seven approval-gated write ops** (G3.12-T4 #1405). The op
+> handlers live in
 > [`backend/src/meho_backplane/connectors/argocd/`](../../backend/src/meho_backplane/connectors/argocd/);
 > the engineering-facing companion is
 > [`docs/codebase/connectors-argocd.md`](../codebase/connectors-argocd.md).
@@ -291,34 +292,37 @@ broadcast event. Each op's `llm_instructions` payload (registered at
 [`backend/src/meho_backplane/connectors/argocd/ops.py`](../../backend/src/meho_backplane/connectors/argocd/ops.py))
 is what `search_operations` surfaces to rank and guide the agent.
 
-## Writes are deferred (read-only by design)
+## Approval-gated write surface (G3.12-T4 #1405)
 
-This connector ships **no write or mutating op**. The ArgoCD verbs that
-change cluster state —
+The connector also ships the **mutating** GitOps surface — every op
+`requires_approval=True`, so a dispatch parks in the human approve-queue
+(`status=awaiting_approval`) and only runs after an operator approves
+through the queue (G11.7-T1 [#1401](https://github.com/evoila/meho/issues/1401)
+routes a `USER`-principal `requires_approval` dispatch to the queue rather
+than hard-denying it):
 
-- **`app.sync`** — trigger a sync (reconcile an app to its Git-desired
-  state),
-- **`app.rollback`** — roll an app back to a previous synced revision,
-- **`app.set`** / spec edits — change an Application's source, target
-  revision, or sync policy —
+| op_id | safety | CLI verb | what it does |
+| --- | --- | --- | --- |
+| `argocd.app.sync` | dangerous | `meho argocd app sync --name N [--prune] [--revision R]` | reconcile to Git-desired; polls operationState to a terminal phase |
+| `argocd.app.rollback` | dangerous | `meho argocd app rollback --name N --id I` | roll back to a prior deployed history id; polls to terminal |
+| `argocd.app.set` | dangerous | `meho argocd app set --name N --spec-file F` | replace the ApplicationSpec; captures before/after into `proposed_effect` |
+| `argocd.app.refresh` | caution | `meho argocd app refresh --name N` | the governed replacement for `kubectl annotate … refresh=hard`; under selfHeal can trigger an auto-sync |
+| `argocd.app.delete` | dangerous | `meho argocd app delete --name N` | cascade-delete; captures the cascade resource list into `proposed_effect` |
+| `argocd.appproject.create` | dangerous | `meho argocd appproject create --project-file F [--upsert]` | create the tenancy/authorization boundary |
+| `argocd.appproject.update` | dangerous | `meho argocd appproject update --project-file F` | amend a project's allow-lists; captures before/after |
 
-are an **approval-gated follow-up** under Initiative
-[#1387](https://github.com/evoila/meho/issues/1387), not part of this
-op surface. They are deliberately out of scope here (Hard rule: no
-speculative optionality — read parity first, writes land as a separate
-Task behind the approval queue, following the
-[github-write-ops-approval](./github-write-ops-approval.md) /
-[g316-vmware-write-activation](./g316-vmware-write-activation.md)
-precedent). Until they land, drive syncs/rollbacks through the `argocd`
-CLI or the ArgoCD UI; use this connector for **visibility** —
-"is this app in sync?", "what changed?", "which child resource is
-unhealthy?", "can ArgoCD reach this repo?".
+`app.sync` / `app.rollback` are long-running: after the POST they poll
+`status.operationState.phase` until it reaches a terminal value
+(Succeeded / Failed / Error) or `--poll-timeout` (default 300s) elapses,
+then return the final phase + message. `app.set` / `delete` /
+`appproject.update` snapshot the before/after (or cascade list) into the
+result's `proposed_effect` block so the reviewer sees exactly what the
+change does.
 
-`argocd.app.diff` is the read-only counterpart of `argocd app diff
-<app>`: it returns the managed-resources delta (each item's `liveState`
-vs `targetState`) without touching the cluster — the right op to confirm
-*what* a future `app.sync` would reconcile, before the write surface
-exists.
+`argocd.app.diff` (read) is the right op to confirm *what* a sync would
+reconcile **before** approving the `app.sync`: it returns the
+managed-resources delta (each item's `liveState` vs `targetState`)
+without touching the cluster.
 
 ## Troubleshooting
 
@@ -326,7 +330,8 @@ exists.
 | --- | --- | --- |
 | `no backplane URL configured` (exit 2) | Never logged in / no `--backplane`. | `meho login <url>` or pass `--backplane <url>`. |
 | `auth_expired` / stored token rejected | Keycloak operator token expired. | `meho login <url>` again. |
-| `status=error … operation not found` | The typed-op registrar didn't run (lifespan crash) or op_id drift. | Verify the backplane started cleanly; `meho connector list` should show `argocd-api-3.x` with six enabled ops. Check logs for `argocd_operations_registered`. |
+| `status=error … operation not found` | The typed-op registrar didn't run (lifespan crash) or op_id drift. | Verify the backplane started cleanly; `meho connector list` should show `argocd-api-3.x` with thirteen enabled ops (six read + seven write). Check logs for `argocd_operations_registered`. |
+| write op returns `status=awaiting_approval` | Expected — every write `requires_approval=True`; it's parked in the queue. | Approve via the approval queue (REST/MCP/CLI), then the run resumes; this is the designed governance gate, not an error. |
 | `status=error … unknown_connector` | Connector id drift — typed `argocd-3.x` instead of `argocd-api-3.x`. | Use `argocd-api-3.x`; the `-api` impl_id discriminator is part of the connector_id grammar. |
 | `RuntimeError … missing required key 'token'` | The Vault secret at `secret_ref` lacks the `token` field. | `meho vault kv get …` the path; the secret must carry a `token` key (no `username`). |
 | op returns ArgoCD `401` / `403` | The stored token is invalid or its RBAC lacks `get`/`list`. | Re-mint with `argocd account generate-token`; grant read-only RBAC on `applications` / `projects` / `repositories`. |
@@ -336,11 +341,11 @@ exists.
 ## References
 
 - Initiative: [#1387 G3.12 ArgoCD connector](https://github.com/evoila/meho/issues/1387); Goal [#214](https://github.com/evoila/meho/issues/214) (connector parity / wrapper retirement).
-- Tasks that shipped this surface: [#1390](https://github.com/evoila/meho/issues/1390) (skeleton — bearer auth + fingerprint + dual registration), [#1391](https://github.com/evoila/meho/issues/1391) (curated read core), [#1392](https://github.com/evoila/meho/issues/1392) (CLI/MCP review + recorded-fixture E2E + this doc).
+- Tasks that shipped this surface: [#1390](https://github.com/evoila/meho/issues/1390) (skeleton — bearer auth + fingerprint + dual registration), [#1391](https://github.com/evoila/meho/issues/1391) (curated read core), [#1392](https://github.com/evoila/meho/issues/1392) (CLI/MCP review + recorded-fixture E2E + this doc), [#1405](https://github.com/evoila/meho/issues/1405) (approval-gated write ops + CLI write verbs).
 - Engineering companion: [`docs/codebase/connectors-argocd.md`](../codebase/connectors-argocd.md).
 - Op handlers: [`backend/src/meho_backplane/connectors/argocd/`](../../backend/src/meho_backplane/connectors/argocd/) (`connector.py`, `ops.py`, `session.py`).
 - Recorded-fixture E2E: [`backend/tests/test_connectors_argocd_e2e.py`](../../backend/tests/test_connectors_argocd_e2e.py) (full `call_operation` + `search_operations` surface); read-core dispatch suite: [`backend/tests/test_connectors_argocd_reads.py`](../../backend/tests/test_connectors_argocd_reads.py).
 - Generic dispatch CLI: [`cli/internal/cmd/operation/`](../../cli/internal/cmd/operation/) (`call.go`, `search.go`, `groups.go`).
 - ArgoCD API docs: <https://argo-cd.readthedocs.io/en/stable/developer-guide/api-docs/>; `VersionMessage` proto: `argoproj/argo-cd` `server/version/version.proto`.
 - Vault federation setup: [`vault-onboarding.md`](./vault-onboarding.md). Onboarding-doc precedents: [`bind9-onboarding.md`](./bind9-onboarding.md), [`kubernetes-onboarding.md`](./kubernetes-onboarding.md), [`harbor-onboarding.md`](./harbor-onboarding.md).
-- Deferred write surface: tracked under Initiative [#1387](https://github.com/evoila/meho/issues/1387); approval-gated write precedents [`github-write-ops-approval.md`](./github-write-ops-approval.md), [`g316-vmware-write-activation.md`](./g316-vmware-write-activation.md).
+- Approval-gated write ops ([#1405](https://github.com/evoila/meho/issues/1405)) route through the human approve-queue (G11.7-T1 [#1401](https://github.com/evoila/meho/issues/1401)); related approval-write precedents [`github-write-ops-approval.md`](./github-write-ops-approval.md), [`g316-vmware-write-activation.md`](./g316-vmware-write-activation.md).


### PR DESCRIPTION
## Summary
- Adds the ArgoCD GitOps **write** surface (G3.12-T4) on top of the #1390/#1391/#1392 read substrate: seven mutating ops, every one `requires_approval=True`.
- Approval routing is the only thing the connector controls (the `requires_approval=True` descriptor flag) — the dispatcher's `policy_gate` routes a `USER`-principal dispatch to the human approve-queue (G11.7-T1 #1401) and floors an agent dispatch to `needs-approval`. **No hard-deny, no bypass**; the handlers run only on the `_approved=True` resume path.
- `app.sync`/`rollback` POST then poll `status.operationState.phase` to a terminal phase (Succeeded/Failed/Error) or `poll_timeout_seconds`, mirroring `vmware.composite.vm.clone`'s task-poll; `app.set`/`delete`/`appproject.update` capture before/after (or the cascade list) into `proposed_effect`.
- CLI: `meho argocd app sync|rollback|set|refresh|delete` + `meho argocd appproject create|update`. The verbs surface `awaiting_approval` verbatim. Endpoint/field facts pinned to argoproj/argo-cd `application.proto` + `project.proto`; terminal phase set matches gitops-engine's `OperationPhase.Completed()`.

| op_id | safety | endpoint |
|---|---|---|
| `argocd.app.sync` | dangerous | `POST .../{name}/sync` (polls operationState) |
| `argocd.app.rollback` | dangerous | `POST .../{name}/rollback` (polls operationState) |
| `argocd.app.set` | dangerous | `PUT .../{name}/spec` (before/after) |
| `argocd.app.refresh` | caution | `GET .../{name}?refresh=hard` |
| `argocd.app.delete` | dangerous | `DELETE .../{name}` (cascade list) |
| `argocd.appproject.create` | dangerous | `POST /api/v1/projects` |
| `argocd.appproject.update` | dangerous | `PUT /api/v1/projects/{name}` (before/after) |

## Test plan
- [x] `ruff check` / `ruff format --check` — clean
- [x] `mypy src/meho_backplane/connectors/argocd/` — Success, no issues
- [x] `pytest tests/test_connectors_argocd_write_e2e.py tests/test_connectors_argocd_e2e.py tests/test_connectors_argocd_reads.py` — 52 passed
- [x] `code-quality.py --diff` — exit 0
- [x] `go build ./... && go vet ./... && go test ./internal/cmd/argocd/...` — clean
- [x] Registration + safety-level/`requires_approval=True` invariants on `ARGOCD_WRITE_OPS`
- [x] Un-approved `USER` dispatch returns `awaiting_approval` + `approval_request_id`, handler never fires the cluster call (route-to-queue, not hard-deny)
- [x] `app.sync`/`rollback` poll operationState to a terminal phase + return final phase/message
- [x] `app.set`/`delete`/`appproject.update` capture before/after / cascade list into `proposed_effect`
- [x] Bearer rides every write; token never leaks
- [x] CLI snapshot regen run (`make snapshot-openapi && make generate`) — **byte-stable, no client delta** (write verbs are pure operator ergonomics over the existing `/operations/call` route)

## Out of scope
- Full-Swagger L2 ingest of the ArgoCD API (deferred follow-up under #1387).
- `idp`-style federation writes (not in this Task's op table).

<!-- auto-implement-issue: fresh, iteration 1 -->

Closes #1405
