### PR TITLE
feat(operations): proposed_effect builder hook auto-populates k8s.apply dry-run preview

### DIFF
--- a/backend/src/meho_backplane/operations/_preview.py
+++ b/backend/src/meho_backplane/operations/_preview.py
@@ -1,0 +1,233 @@
+# SPDX-License-Identifier: Apache-2.0
+# Copyright (c) 2026 evoila Group
+
+"""Per-op ``proposed_effect`` builder hook for the approval-park path.
+
+G11.7 follow-up (#1437). When the policy gate routes a dispatch to
+``needs-approval`` (:func:`~meho_backplane.operations.dispatcher.dispatch`
+Step 4 → :func:`_handle_needs_approval`), most ops have nothing to show
+the reviewer beyond the call's identity, so the durable
+:class:`~meho_backplane.db.models.ApprovalRequest` row stores the
+identifier-only default ``{op_id, connector_id, target_id}``.
+
+A small set of ops *can* compute a side-effect-free **preview** of what
+the approved call would do -- notably ``k8s.apply``'s server-side-apply
+dry-run (``dry_run="server"`` → the API's ``?dryRun=All``), which returns
+the would-be object without persisting anything. This module is the
+general, opt-in seam that lets such an op populate
+``ApprovalRequest.proposed_effect`` at queue time, so the human reviewer
+reads the diff in the approval queue rather than only in the
+post-approval op result.
+
+Design contract
+---------------
+
+* **Opt-in per op.** A builder is registered against an ``op_id``; ops
+  without a registered builder fall through to the identifier-only
+  default exactly as before -- no extra work, no new failure mode.
+* **Fail-soft.** A builder that raises (a dry-run that hits the API
+  server and errors, a transient connector fault) must never block the
+  park: :func:`build_proposed_effect` swallows the exception, logs it,
+  and returns ``None`` so the caller uses the default. Parking an
+  approval is the durable, safety-relevant action; a missing preview is
+  a degraded-but-acceptable outcome, an exception is not.
+* **Redaction-safe.** The preview lands in a durable row surfaced over
+  REST / MCP / CLI, so it must not carry secret material. The hook
+  reuses the single-sourced sensitivity classification from
+  :func:`~meho_backplane.broadcast.events.classify_op` (shipped by
+  G11.7-T1 #1401): an op that classifies as a credential class
+  (``credential_read`` / ``credential_mint`` / ``credential_write``)
+  never has a raw preview stored -- it collapses to an aggregate marker
+  the same way the broadcast layer collapses such ops. Builders are
+  themselves expected to return identity-only summaries (``k8s.apply``'s
+  dry-run echoes resource identity + ``resourceVersion`` + ``uid``, never
+  Secret ``data``), so this gate is defence-in-depth, not the only
+  guard.
+
+The k8s.apply builder is wired here (the only op in scope per #1437);
+additional ops register their own builders as the need arises (argocd
+writes are the separate follow-up #1452).
+"""
+
+from __future__ import annotations
+
+from dataclasses import dataclass
+from typing import TYPE_CHECKING, Any, Protocol
+
+import structlog
+
+from meho_backplane.broadcast.events import classify_op
+
+if TYPE_CHECKING:
+    from meho_backplane.auth.operator import Operator
+    from meho_backplane.connectors.base import Connector
+    from meho_backplane.db.models import EndpointDescriptor
+
+__all__ = [
+    "PreviewContext",
+    "build_proposed_effect",
+    "register_preview_builder",
+]
+
+_log = structlog.get_logger(__name__)
+
+#: Sensitivity classes whose preview must never be stored verbatim.
+#: Mirrors the aggregate-only set in
+#: :func:`~meho_backplane.broadcast.events.redact_payload`.
+_SENSITIVE_CLASSES: frozenset[str] = frozenset(
+    {"credential_read", "credential_mint", "credential_write"}
+)
+
+
+@dataclass(frozen=True)
+class PreviewContext:
+    """Everything a preview builder needs to compute a dry-run.
+
+    The dispatcher assembles this at the approval-park point and hands it
+    to the registered builder. The builder owns the connector call (e.g.
+    re-invoking the op's handler with a dry-run flag forced on); the
+    dispatcher only resolves the connector instance + descriptor.
+
+    Attributes:
+        descriptor: The looked-up :class:`EndpointDescriptor` for the op.
+        connector_instance: The resolved connector singleton, or ``None``
+            for module-level handlers that bind no connector.
+        operator: The authenticated operator whose dispatch parked.
+        target: The dispatch target (or ``None`` for tenant-wide ops).
+        params: The original dispatch params.
+    """
+
+    descriptor: EndpointDescriptor
+    connector_instance: Connector | None
+    operator: Operator
+    target: Any
+    params: dict[str, Any]
+
+
+class PreviewBuilder(Protocol):
+    """An op's opt-in preview computation.
+
+    Returns the preview dict to store in
+    :attr:`~meho_backplane.db.models.ApprovalRequest.proposed_effect`, or
+    ``None`` to decline (caller falls back to the identifier-only
+    default). May raise -- :func:`build_proposed_effect` treats a raise
+    as "no preview" rather than failing the park.
+    """
+
+    async def __call__(self, ctx: PreviewContext) -> dict[str, Any] | None: ...
+
+
+#: ``op_id`` -> registered preview builder. Opt-in: absence ⇒ no preview.
+_PREVIEW_BUILDERS: dict[str, PreviewBuilder] = {}
+
+
+def register_preview_builder(op_id: str, builder: PreviewBuilder) -> None:
+    """Register *builder* as the preview computation for *op_id*.
+
+    Idempotent re-registration overwrites -- registration happens at
+    import time so a re-import (test reload) is a no-op-equivalent.
+    """
+    _PREVIEW_BUILDERS[op_id] = builder
+
+
+async def build_proposed_effect(ctx: PreviewContext) -> dict[str, Any] | None:
+    """Compute the ``proposed_effect`` preview for a parking dispatch.
+
+    Looks up a builder for ``ctx.descriptor.op_id``; returns ``None``
+    (caller uses the identifier-only default) when no builder is
+    registered, when the op classifies as a credential class (the
+    preview is suppressed to stay redaction-safe), when the builder
+    declines, or when the builder raises (fail-soft -- the park proceeds
+    regardless).
+
+    On success the returned dict is wrapped with a ``"preview"`` envelope
+    key + the op's sensitivity ``"op_class"`` so the approval surface can
+    label it as a computed preview rather than the bare identifier
+    default.
+    """
+    op_id = ctx.descriptor.op_id
+    builder = _PREVIEW_BUILDERS.get(op_id)
+    if builder is None:
+        return None
+
+    op_class = classify_op(op_id)
+    if op_class in _SENSITIVE_CLASSES:
+        # A credential-class op must not surface request/response detail
+        # in a durable row. Refuse the preview outright rather than risk
+        # a builder that echoes secret material; the reviewer still sees
+        # the identifier-only default via the caller's fallback.
+        _log.info(
+            "proposed_effect_preview_suppressed",
+            op_id=op_id,
+            op_class=op_class,
+            reason="sensitive_op_class",
+        )
+        return None
+
+    try:
+        preview = await builder(ctx)
+    except Exception:
+        # Fail-soft: a preview is a convenience, the park is the
+        # safety-relevant action. Never let a dry-run fault block it.
+        _log.warning(
+            "proposed_effect_preview_failed",
+            op_id=op_id,
+            operator_sub=getattr(ctx.operator, "sub", None),
+            exc_info=True,
+        )
+        return None
+
+    if preview is None:
+        return None
+
+    return {
+        "op_class": op_class,
+        "preview": preview,
+    }
+
+
+async def _k8s_apply_preview(ctx: PreviewContext) -> dict[str, Any] | None:
+    """Preview builder for ``k8s.apply`` -- the server-side-apply dry-run.
+
+    Re-invokes the ``k8s_apply`` handler with ``dry_run="server"`` forced
+    on (the API's ``?dryRun=All``) so nothing is persisted; the returned
+    per-document summary (resource identity + ``resourceVersion`` +
+    ``uid``) is the diff-preview the reviewer reads. The handler echoes
+    no Secret ``data`` -- it operates on the manifest's GVK + metadata --
+    so the summary is identity-only and redaction-safe.
+
+    Returns ``None`` when no connector instance resolved (a k8s.apply
+    without a target can't dry-run) so the caller falls back to the
+    identifier-only default.
+    """
+    if ctx.connector_instance is None or ctx.target is None:
+        return None
+
+    from meho_backplane.connectors.kubernetes.connector import KubernetesConnector
+    from meho_backplane.connectors.kubernetes.ops_write_dangerous import k8s_apply
+
+    if not isinstance(ctx.connector_instance, KubernetesConnector):
+        return None
+
+    # Force the dry-run flag on regardless of what the caller passed:
+    # the preview must never persist, even if the parked call itself was
+    # a real apply (dry_run="none").
+    preview_params = {**ctx.params, "dry_run": "server"}
+    return await k8s_apply(
+        ctx.connector_instance,
+        ctx.target,
+        ctx.operator,
+        preview_params,
+    )
+
+
+def _register_builtin_builders() -> None:
+    """Wire the in-tree preview builders. Called at import time.
+
+    Only ``k8s.apply`` is wired in #1437; other ops register their own
+    builders as the need arises (the hook is general).
+    """
+    register_preview_builder("k8s.apply", _k8s_apply_preview)
+
+
+_register_builtin_builders()

--- a/backend/src/meho_backplane/operations/dispatcher.py
+++ b/backend/src/meho_backplane/operations/dispatcher.py
@@ -174,6 +174,10 @@ from meho_backplane.operations._lookup import (
     lookup_descriptor,
     parse_connector_id,
 )
+from meho_backplane.operations._preview import (
+    PreviewContext,
+    build_proposed_effect,
+)
 from meho_backplane.operations._validate import (
     compute_params_hash,
     policy_gate,
@@ -808,6 +812,55 @@ async def _reduce_or_error(
         return result_connector_error(op_id, exc, duration_ms)
 
 
+async def _build_proposed_effect(
+    *,
+    op_id: str,
+    descriptor: EndpointDescriptor,
+    operator: Operator,
+    target: Any,
+    params: dict[str, Any],
+) -> dict[str, Any] | None:
+    """Resolve the connector + invoke the op's preview builder, if any.
+
+    G11.7 follow-up (#1437). Resolves the connector instance the same way
+    the execute path does (so a ``k8s.apply`` preview hits the same target
+    the real apply would), assembles a :class:`PreviewContext`, and
+    delegates to :func:`build_proposed_effect`. Returns ``None`` -- the
+    caller's identifier-only default -- when the op has no builder, when
+    connector resolution can't pick an instance, or (inside
+    :func:`build_proposed_effect`) when the builder declines or the op is
+    a credential class. Never raises: connector-resolution faults degrade
+    to "no preview" so the park always proceeds.
+    """
+    try:
+        connector_instance, resolution_error, _ = await _resolve_connector_instance(
+            descriptor, target
+        )
+        if resolution_error is not None:
+            # The op can't be previewed against an unresolved connector;
+            # the reviewer still gets the identifier-only default.
+            return None
+        return await build_proposed_effect(
+            PreviewContext(
+                descriptor=descriptor,
+                connector_instance=connector_instance,
+                operator=operator,
+                target=target,
+                params=params,
+            )
+        )
+    except Exception:
+        import structlog as _structlog
+
+        _structlog.get_logger(__name__).warning(
+            "proposed_effect_resolution_failed",
+            op_id=op_id,
+            operator_sub=operator.sub,
+            exc_info=True,
+        )
+        return None
+
+
 async def _handle_needs_approval(
     *,
     op_id: str,
@@ -842,6 +895,20 @@ async def _handle_needs_approval(
 
     run_id = current_agent_run_id_var.get()
 
+    # G11.7 follow-up (#1437): give an op that can compute a
+    # side-effect-free preview (notably ``k8s.apply``'s server-dry-run) a
+    # chance to populate ``proposed_effect`` so the reviewer sees the diff
+    # in the approval queue. Opt-in per op + fail-soft: ops without a
+    # registered builder (and any builder that raises) yield ``None`` and
+    # the queue stores the identifier-only default exactly as before.
+    proposed_effect = await _build_proposed_effect(
+        op_id=op_id,
+        descriptor=descriptor,
+        operator=operator,
+        target=target,
+        params=params,
+    )
+
     try:
         sessionmaker = get_sessionmaker()
         async with sessionmaker() as session:
@@ -854,6 +921,7 @@ async def _handle_needs_approval(
                 params=params,
                 params_hash=params_hash,
                 run_id=run_id,
+                proposed_effect=proposed_effect,
             )
             await session.commit()
         # Publish AFTER commit so a phantom event cannot outlive a failed

--- a/backend/tests/test_operations_dispatcher.py
+++ b/backend/tests/test_operations_dispatcher.py
@@ -1671,6 +1671,123 @@ async def test_dispatch_agent_requires_approval_floors_safe_op_to_pending(
     assert "approval_request_id" in result.extras
 
 
+@pytest.mark.asyncio
+async def test_park_populates_proposed_effect_from_builder(
+    stub_embedding_service: AsyncMock,
+    captured_events: list[BroadcastEvent],
+) -> None:
+    """A parked op with a registered preview builder stores its preview.
+
+    G11.7 follow-up (#1437): when the policy gate routes an op to
+    ``needs-approval``, the dispatcher invokes the op's opt-in
+    ``proposed_effect`` builder and stores the result on the durable
+    :class:`ApprovalRequest` row -- so the reviewer reads the preview in
+    the approval queue, not just in the post-approval op result.
+    """
+    from meho_backplane.db.models import ApprovalRequest
+    from meho_backplane.operations._preview import (
+        _PREVIEW_BUILDERS,
+        PreviewContext,
+        register_preview_builder,
+    )
+
+    async def _preview(ctx: PreviewContext) -> dict[str, Any]:
+        return {"would_change": ["deployment/web"], "param_echo": ctx.params}
+
+    register_connector_v2(product="vault", version="", impl_id="", cls=_NoOpVaultConnector)
+    await register_typed_operation(
+        product="vault",
+        version="1.x",
+        impl_id="vault",
+        op_id="vault.kv.preview_op",
+        handler=_module_handler_returning_dict,
+        summary="Op with a registered preview builder.",
+        description="Parks for approval and populates proposed_effect.",
+        parameter_schema={"type": "object"},
+        safety_level="safe",
+        requires_approval=True,
+        when_to_use=None,
+        embedding_service=stub_embedding_service,
+    )
+    register_preview_builder("vault.kv.preview_op", _preview)
+    try:
+        result = await dispatch(
+            operator=_make_operator(principal_kind=PrincipalKind.AGENT),
+            connector_id="vault-1.x",
+            op_id="vault.kv.preview_op",
+            target=_FakeTarget(product="vault"),
+            params={"path": "secret/data/x"},
+        )
+        assert result.status == "awaiting_approval"
+        approval_request_id = UUID(result.extras["approval_request_id"])
+        sessionmaker = get_sessionmaker()
+        async with sessionmaker() as fresh:
+            row = await fresh.get(ApprovalRequest, approval_request_id)
+            assert row is not None
+            # The builder's preview landed under the {op_class, preview}
+            # envelope -- not the identifier-only default.
+            assert row.proposed_effect["op_class"] == "other"
+            assert row.proposed_effect["preview"]["would_change"] == ["deployment/web"]
+            # The identifier-only default keys are NOT present (a built
+            # preview replaces the default, it doesn't merge into it).
+            assert "op_id" not in row.proposed_effect
+    finally:
+        _PREVIEW_BUILDERS.pop("vault.kv.preview_op", None)
+
+
+@pytest.mark.asyncio
+async def test_park_without_builder_uses_identifier_default(
+    stub_embedding_service: AsyncMock,
+    captured_events: list[BroadcastEvent],
+) -> None:
+    """An op with no preview builder parks with the identifier-only default.
+
+    G11.7 follow-up (#1437): the hook is opt-in. An op that registers no
+    builder must park exactly as before -- the durable row carries the
+    ``{op_id, connector_id, target_id}`` default, with no error and no
+    regression.
+    """
+    from meho_backplane.db.models import ApprovalRequest
+
+    register_connector_v2(product="vault", version="", impl_id="", cls=_NoOpVaultConnector)
+    target = _FakeTarget(product="vault")
+    await register_typed_operation(
+        product="vault",
+        version="1.x",
+        impl_id="vault",
+        op_id="vault.kv.no_preview_op",
+        handler=_module_handler_returning_dict,
+        summary="Op without a preview builder.",
+        description="Parks for approval; no proposed_effect builder registered.",
+        parameter_schema={"type": "object"},
+        safety_level="safe",
+        requires_approval=True,
+        when_to_use=None,
+        embedding_service=stub_embedding_service,
+    )
+
+    result = await dispatch(
+        operator=_make_operator(principal_kind=PrincipalKind.AGENT),
+        connector_id="vault-1.x",
+        op_id="vault.kv.no_preview_op",
+        target=target,
+        params={},
+    )
+    assert result.status == "awaiting_approval"
+    approval_request_id = UUID(result.extras["approval_request_id"])
+    sessionmaker = get_sessionmaker()
+    async with sessionmaker() as fresh:
+        row = await fresh.get(ApprovalRequest, approval_request_id)
+        assert row is not None
+        # Identifier-only default -- no built-preview envelope.
+        assert row.proposed_effect == {
+            "op_id": "vault.kv.no_preview_op",
+            "connector_id": "vault-1.x",
+            "target_id": str(target.id),
+        }
+        assert "preview" not in row.proposed_effect
+
+
 # ---------------------------------------------------------------------------
 # compute_params_hash
 # ---------------------------------------------------------------------------

--- a/backend/tests/test_operations_preview.py
+++ b/backend/tests/test_operations_preview.py
@@ -1,0 +1,209 @@
+# SPDX-License-Identifier: Apache-2.0
+# Copyright (c) 2026 evoila Group
+
+"""Unit tests for the per-op ``proposed_effect`` builder hook.
+
+G11.7 follow-up (#1437). :mod:`meho_backplane.operations._preview` is the
+opt-in seam that lets an op compute a side-effect-free preview at
+approval-park time so the reviewer reads the diff in the approval queue.
+
+Coverage matrix (per Issue #1437 acceptance criteria):
+
+* ``k8s.apply`` parks with its server-dry-run summary populated, and the
+  builder forces ``dry_run="server"`` regardless of the parked params'
+  ``dry_run`` -- the preview never persists.
+* An op with no registered builder yields ``None`` (caller falls back to
+  the identifier-only default).
+* A builder that raises is fail-soft: the hook returns ``None`` rather
+  than propagating, so the park always proceeds.
+* A credential-class op is suppressed (no raw preview in the durable
+  row), reusing the :func:`classify_op` sensitivity classification.
+
+The kubernetes API surface is mocked so the test runs in every CI lane.
+"""
+
+from __future__ import annotations
+
+import uuid
+from dataclasses import dataclass
+from typing import Any
+
+import pytest
+
+from meho_backplane.auth.operator import Operator, TenantRole
+from meho_backplane.connectors.kubernetes import KubernetesConnector
+from meho_backplane.operations._preview import (
+    PreviewContext,
+    build_proposed_effect,
+    register_preview_builder,
+)
+
+
+@dataclass
+class _FakeDescriptor:
+    """Minimal stand-in -- the hook only reads ``op_id``."""
+
+    op_id: str
+
+
+def _operator() -> Operator:
+    return Operator(
+        sub="op-preview-test",
+        name="Preview Test Operator",
+        email=None,
+        raw_jwt="op.preview.jwt",
+        tenant_id=uuid.UUID("00000000-0000-0000-0000-00000000a0a0"),
+        tenant_role=TenantRole.OPERATOR,
+    )
+
+
+class _FakeTarget:
+    def __init__(self) -> None:
+        self.id = uuid.uuid4()
+        self.name = "rke2-meho"
+
+
+_SINGLE_MANIFEST = """
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  name: web
+  namespace: argocd
+spec:
+  replicas: 2
+"""
+
+
+@pytest.mark.asyncio
+async def test_k8s_apply_preview_forces_server_dry_run(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """The k8s.apply builder runs the SSA dry-run and wraps the summary.
+
+    The parked params carry ``dry_run="none"`` (a real apply), yet the
+    preview must force ``dry_run="server"`` so it never persists. The
+    returned dict is the ``{op_class, preview}`` envelope; the preview is
+    the handler's identity-only summary (redaction-safe).
+    """
+    captured: dict[str, Any] = {}
+
+    async def _fake_apply(
+        connector: KubernetesConnector,
+        target: Any,
+        operator: Operator,
+        params: dict[str, Any],
+    ) -> dict[str, Any]:
+        captured["params"] = params
+        return {
+            "dry_run": True,
+            "field_manager": "meho",
+            "applied": [
+                {
+                    "api_version": "apps/v1",
+                    "kind": "Deployment",
+                    "name": "web",
+                    "namespace": "argocd",
+                    "resource_version": "dry",
+                    "uid": "u-1",
+                }
+            ],
+            "total": 1,
+        }
+
+    monkeypatch.setattr(
+        "meho_backplane.connectors.kubernetes.ops_write_dangerous.k8s_apply",
+        _fake_apply,
+    )
+
+    connector = KubernetesConnector(kubeconfig_loader=None)  # type: ignore[arg-type]
+    ctx = PreviewContext(
+        descriptor=_FakeDescriptor(op_id="k8s.apply"),  # type: ignore[arg-type]
+        connector_instance=connector,
+        operator=_operator(),
+        target=_FakeTarget(),
+        params={"manifest": _SINGLE_MANIFEST, "dry_run": "none"},
+    )
+
+    effect = await build_proposed_effect(ctx)
+
+    assert effect is not None
+    # The dry-run flag is forced on even though the parked call was a real apply.
+    assert captured["params"]["dry_run"] == "server"
+    assert effect["op_class"] == "other"
+    assert effect["preview"]["dry_run"] is True
+    assert effect["preview"]["applied"][0]["resource_version"] == "dry"
+    # Identity-only summary: no Secret data / manifest body echoed.
+    assert "data" not in effect["preview"]["applied"][0]
+
+
+@pytest.mark.asyncio
+async def test_k8s_apply_preview_none_without_connector() -> None:
+    """No resolved connector instance ⇒ no preview (caller uses default)."""
+    ctx = PreviewContext(
+        descriptor=_FakeDescriptor(op_id="k8s.apply"),  # type: ignore[arg-type]
+        connector_instance=None,
+        operator=_operator(),
+        target=_FakeTarget(),
+        params={"manifest": _SINGLE_MANIFEST},
+    )
+    assert await build_proposed_effect(ctx) is None
+
+
+@pytest.mark.asyncio
+async def test_no_builder_op_yields_none() -> None:
+    """An op without a registered builder parks with no preview."""
+    ctx = PreviewContext(
+        descriptor=_FakeDescriptor(op_id="vault.kv.put"),  # type: ignore[arg-type]
+        connector_instance=None,
+        operator=_operator(),
+        target=_FakeTarget(),
+        params={"path": "secret/data/x"},
+    )
+    assert await build_proposed_effect(ctx) is None
+
+
+@pytest.mark.asyncio
+async def test_builder_that_raises_is_fail_soft() -> None:
+    """A builder exception degrades to no-preview, never propagates."""
+
+    async def _boom(_ctx: PreviewContext) -> dict[str, Any] | None:
+        raise RuntimeError("dry-run hit the API and failed")
+
+    register_preview_builder("test.preview.boom", _boom)
+    ctx = PreviewContext(
+        descriptor=_FakeDescriptor(op_id="test.preview.boom"),  # type: ignore[arg-type]
+        connector_instance=None,
+        operator=_operator(),
+        target=_FakeTarget(),
+        params={},
+    )
+    # No exception escapes; the park proceeds with the identifier-only default.
+    assert await build_proposed_effect(ctx) is None
+
+
+@pytest.mark.asyncio
+async def test_credential_class_op_preview_suppressed() -> None:
+    """A credential-class op never stores a raw preview (redaction-safe).
+
+    Even with a registered builder, an op classifying as a credential
+    class (here ``k8s.secret.create`` → ``credential_write``) is
+    suppressed before the builder runs -- the durable approval row must
+    not carry secret material.
+    """
+    builder_ran = False
+
+    async def _leaky(_ctx: PreviewContext) -> dict[str, Any] | None:
+        nonlocal builder_ran
+        builder_ran = True
+        return {"secret_value": "super-secret"}
+
+    register_preview_builder("k8s.secret.create", _leaky)
+    ctx = PreviewContext(
+        descriptor=_FakeDescriptor(op_id="k8s.secret.create"),  # type: ignore[arg-type]
+        connector_instance=None,
+        operator=_operator(),
+        target=_FakeTarget(),
+        params={"name": "creds", "namespace": "ns", "string_data": {"k": "v"}},
+    )
+    assert await build_proposed_effect(ctx) is None
+    assert builder_ran is False, "sensitive-class gate must run before the builder"

--- a/docs/codebase/approvals.md
+++ b/docs/codebase/approvals.md
@@ -85,6 +85,51 @@ routed to `NEEDS_APPROVAL`, re-running the gate on resume would re-queue
 the call instead of executing it, so the bypass is what lets the
 approved op run.
 
+## `proposed_effect` builder hook (#1437)
+
+`ApprovalRequest.proposed_effect` holds what the reviewer sees in the
+queue. By default `create_pending_request`
+(`backend/src/meho_backplane/operations/approval_queue.py`) stores an
+identifier-only summary — `{op_id, connector_id, target_id}`. Some ops
+can do better: they can compute a **side-effect-free preview** of what
+the approved call would do, so the reviewer reads the diff in the queue
+rather than only in the post-approval op result.
+
+The per-op preview is opt-in via a builder registry in
+`backend/src/meho_backplane/operations/_preview.py`:
+
+- `register_preview_builder(op_id, builder)` registers an
+  `async (PreviewContext) -> dict | None` callable for an op-id.
+  `PreviewContext` carries the resolved connector instance + descriptor +
+  operator + target + params.
+- At the park point, `dispatcher._handle_needs_approval` resolves the
+  connector instance (same path the execute branch uses) and calls
+  `build_proposed_effect`. The result — wrapped as
+  `{op_class, preview}` — is passed to `create_pending_request` as
+  `proposed_effect`; `None` falls back to the identifier-only default.
+
+Three invariants make the hook safe to wire on the park path:
+
+1. **Opt-in / no regression.** An op with no registered builder yields
+   `None` and parks exactly as before.
+2. **Fail-soft.** A builder that raises (a dry-run that hits the API and
+   errors) degrades to `None`; the park — the safety-relevant action —
+   always proceeds. Connector-resolution faults degrade the same way.
+3. **Redaction-safe.** `build_proposed_effect` classifies the op via
+   `classify_op` (the same single-sourced sensitivity classification used
+   for broadcast/audit redaction, #1401) and **suppresses** the preview
+   for any credential class (`credential_read` / `credential_mint` /
+   `credential_write`) before the builder even runs — a durable row
+   never carries secret material. Builders are themselves expected to
+   return identity-only summaries.
+
+The only builder wired in #1437 is **`k8s.apply`**: it re-invokes the
+`k8s_apply` handler with `dry_run="server"` forced on (the API's
+`?dryRun=All`), so nothing persists and the per-document summary
+(resource identity + `resourceVersion` + `uid`) is the diff-preview the
+reviewer reads. Other ops (e.g. argocd writes, #1452) register their own
+builders as needed.
+
 ## Transports
 
 ### REST (`backend/src/meho_backplane/api/v1/approvals.py`)


### PR DESCRIPTION
## Summary
- Adds a general, opt-in per-op `proposed_effect` builder hook so an op that can compute a side-effect-free preview populates `ApprovalRequest.proposed_effect` at queue time — the reviewer sees the diff in the approval queue, not just in the post-approval op result.
- Wires only `k8s.apply` (its server-side-apply dry-run, `dry_run="server"` → `?dryRun=All`), forced on so the preview never persists; the per-document summary (resource identity + `resourceVersion` + `uid`) is the diff-preview.
- Three invariants on the park path: **opt-in** (no builder → identifier-only default, no regression), **fail-soft** (a builder/resolution fault degrades to no-preview, never blocks the park), **redaction-safe** (credential-class ops suppressed via the single-sourced `classify_op` classification from #1401 — no secret material in the durable row).
- Hook is general; argocd writes are the separate follow-up #1452.

## Test plan
- [x] `ruff check` / `ruff format --check` — clean
- [x] `mypy src/.../_preview.py src/.../dispatcher.py` — no issues
- [x] `pytest tests/test_operations_preview.py` — 5 passed (k8s.apply forces dry-run + envelope; no-connector; no-builder; fail-soft raise; credential-class suppression)
- [x] `pytest tests/test_operations_dispatcher.py -k preview` — 2 passed (park populates `proposed_effect` from builder; park without builder uses identifier-only default)
- [x] Regression sweep: `test_approval_queue`, `test_connectors_k8s_write`, `test_dispatcher_redaction_integration`, `test_broadcast_credential_write_dispatch`, `test_connectors_k8s_dispatcher_shim` — all pass
- [x] `code-quality.py --diff` — 0 blockers
- [x] `cli/ make snapshot-openapi` — byte-stable, no OpenAPI/CLI codegen delta (backend-dispatcher-only; `proposed_effect` already `dict[str, Any]` in all surfaces)

## Out of scope
- Preview builders for ops other than `k8s.apply` (hook is general; argocd writes → #1452).
- Topology/blast-radius-aware policy (per #1397).

<!-- auto-implement-issue: fresh, iteration 1 -->

Closes #1437


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added opt-in previews to approval requests, enabling reviewers to see the proposed effect of operations before approving.
  * Kubernetes apply operations now display expected resource changes in approval previews using safe dry-run mode.

* **Documentation**
  * Added documentation describing the approval preview mechanism and its safety guarantees.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->