### PR TITLE
docs(readme): restructure into a front door (P1) + residual T1 fixes + badges

### DIFF
--- a/README.md
+++ b/README.md
@@ -3,28 +3,182 @@
 > Governance backplane for AI agents acting on infrastructure —
 > policy-gated, audit-grade, MCP-native. Apache 2.0.
 
+[![Release](https://img.shields.io/github/v/release/evoila/meho)](https://github.com/evoila/meho/releases)
+[![CI](https://github.com/evoila/meho/actions/workflows/ci.yml/badge.svg?branch=main)](https://github.com/evoila/meho/actions/workflows/ci.yml)
 [![License](https://img.shields.io/badge/license-Apache--2.0-blue.svg)](./LICENSE)
 [![OSS](https://img.shields.io/badge/OSS-public%20from%20day%201-success.svg)](./CONTRIBUTING.md#public-from-day-1-deliberately)
-<!-- placeholder: green-smoke-counter badge — populated by consumer-side
-     rdc-deploy-stability action. Contract: docs/acceptance/green-counter.md.
-     Replace this comment with a Shields.io endpoint badge linking to the
-     consumer-side counter JSON once the endpoint is live; the maintainer
-     files the consumer-side issue using
-     docs/cross-repo/issue-58-consumer-ticket-body.md verbatim. -->
 
-**Status:** v0.9.0 released (2026-05-31). The backplane image, Helm chart, and operator CLI are all shipped and cosign-signed.
+## The problem
 
-## What this is
+AI agents are getting good enough to *do* infrastructure work — roll a
+credential, drain a node, restart a service — not just describe it. But
+handing an agent a long-lived admin token and a shell is how you get an
+un-auditable, over-privileged actor loose in production. The moment an
+agent can act, you need the same controls you'd demand of any operator:
+who is allowed to do what, with credentials that expire, against which
+targets, with every action recorded and reviewable.
 
-MEHO sits between AI agents (Claude Code, Cursor, Cline, Continue,
-custom MCP clients) and the infrastructure they operate against
-(Kubernetes, vCenter / VCF, NSX, public cloud, network appliances,
-secrets stores). Every operation is policy-gated, every credential
-short-lived and federated, every result reduced server-side, every
-action broadcast to a real-time feed, every interaction audited,
-every context lookup tenant-scoped and version-aware.
+Today that control plane doesn't exist. Each team bolts ad-hoc wrappers
+around an MCP server, or trusts the agent runtime to behave. MEHO is the
+missing layer.
 
-The agent runtime is *not* part of MEHO. Bring your own.
+## What MEHO is
+
+MEHO is the layer that turns **"any MCP client"** into **"any MCP client
+*operating against real infrastructure under audit*."**
+
+It sits between AI agents (Claude Code, Cursor, Cline, Continue, custom
+MCP clients) and the infrastructure they operate against (Kubernetes,
+vCenter / VCF, NSX, public cloud, network appliances, secrets stores).
+Every operation passes through a single governed seam before it touches
+anything real.
+
+The agent runtime is *not* part of MEHO. **Bring your own agent** — MEHO
+governs what it's allowed to do.
+
+### What it guarantees
+
+Every interaction through MEHO is:
+
+- **Policy-gated** — operations are authorised against the caller's role
+  and per-target grants before they execute.
+- **Credential-federated** — the agent never holds a backend credential;
+  a short-lived Keycloak OIDC token is exchanged with Vault for a
+  just-in-time backend credential per operation.
+- **Server-reduced** — results are reduced server-side, so the agent
+  sees a compact, relevant view instead of raw firehose output.
+- **Broadcast** — every action is published to a real-time activity feed
+  other agents and humans can watch.
+- **Audited** — every interaction lands as an immutable audit row in
+  PostgreSQL, attributed to the calling principal.
+- **Tenant-scoped & version-aware** — every context lookup is scoped to
+  the caller's tenant and aware of resource versions.
+
+## See it work
+
+The [`examples/r4-local-claude/`](./examples/r4-local-claude/) reference
+pattern wires your local Claude Code to a MEHO backplane under your own
+Keycloak identity. The full walkthrough is in
+[`GUIDE.md`](./examples/r4-local-claude/GUIDE.md); the shape of one
+audited round-trip is below.
+
+**1. Point your MCP client at MEHO.** Drop this into your repo as
+`.mcp.json` (full example, including the `mcp-remote` stdio variant, in
+[`mcp.json.example`](./examples/r4-local-claude/mcp.json.example)):
+
+```json
+{
+  "mcpServers": {
+    "meho": {
+      "type": "http",
+      "url": "https://meho.example.com/mcp",
+      "headers": {
+        "Authorization": "Bearer ${MEHO_MCP_TOKEN}"
+      }
+    }
+  }
+}
+```
+
+The token comes from `meho login https://meho.example.com` (Keycloak
+device-code flow) — the agent never sees a backend credential.
+
+**2. Ask the agent to do something.** In your Claude Code session:
+
+> what's interesting on the MEHO backplane right now?
+
+The session calls the `search_memory` tool over MCP. MEHO authorises the
+call against your role, executes it under a just-in-time credential, and
+reduces the result before the agent ever sees it.
+
+**3. The operation leaves an audit trail.** Every `tools/call` lands one
+immutable audit row, attributed to *your* Keycloak `sub` — and emits a
+broadcast event other watchers can see:
+
+```bash
+meho audit query --op-id search_memory --limit 1 --json \
+  | jq '.rows[0] | {principal_sub, op_id, occurred_at}'
+# -> {"principal_sub": "<your-keycloak-sub>", "op_id": "search_memory", ...}
+```
+
+The same identity model, RBAC, and audit trail apply whether the caller
+is your local Claude session or a 24/7 hosted triage agent — there are
+no parallel auth boundaries to learn.
+
+## Architecture
+
+```mermaid
+flowchart LR
+    A["MCP clients<br/>(Claude Code · Cursor · Cline · custom)"]
+    subgraph MEHO["MEHO backplane"]
+        direction TB
+        P["policy gate"]
+        T["token exchange<br/>(Keycloak → Vault)"]
+        R["server-side reduce"]
+        AU["audit (Postgres)"]
+        B["broadcast (Valkey)"]
+    end
+    I["Infrastructure<br/>(Kubernetes · vCenter/VCF · NSX · cloud · appliances · secrets)"]
+
+    A -->|"MCP over OIDC"| MEHO
+    P --> T --> R
+    R --> AU
+    R --> B
+    MEHO -->|"governed operation"| I
+```
+
+MEHO ships as three operator-facing artefacts:
+
+- **Backplane** — Python / FastAPI service that brokers MCP operations
+  against infrastructure. Receives short-lived Keycloak-issued OIDC
+  tokens, exchanges them with Vault for backend credentials, executes
+  policy-gated operations, writes audit rows to PostgreSQL, and
+  broadcasts activity to Valkey. Container image at
+  `ghcr.io/evoila/meho`. Codebase walkthrough:
+  [`docs/codebase/backend.md`](./docs/codebase/backend.md).
+- **Helm chart** — `meho-chart` published as an OCI artefact at
+  `ghcr.io/evoila/meho-chart`. Renders the Deployment, Service, Ingress,
+  NetworkPolicy, pre-install migration Job, the bundled Valkey broadcast
+  subchart, and the typed `values.schema.json` contract that rejects
+  misconfigured installs at `helm install` / `helm upgrade` /
+  `helm template`. Chart walkthrough:
+  [`docs/codebase/devops.md`](./docs/codebase/devops.md).
+- **Operator CLI** — `meho` Go binary (cobra) with ~40 command groups
+  spanning auth (`login`, `status`, `version`), the operation surface
+  (`operation`, `connector`, `targets`, `audit`, `broadcast`,
+  `retrieval`, `kb`, `runbook`, `memory`), agents + scheduling (`agent`,
+  `agent-principal`, `approvals`, `scheduler`), per-vendor connector
+  aliases (`vmware`, `nsx`, `k8s`, `vault`, `harbor`, `keycloak`,
+  `argocd`, `gcloud`, `bind9`, `pfsense`, and more), and admin/migration
+  tooling (`admin`, `migrate`). Released as multi-platform tarballs
+  (`linux/macOS × amd64/arm64`) on every `v*` tag, each individually
+  cosign-signed. Full command reference:
+  [`docs/codebase/cli.md`](./docs/codebase/cli.md).
+
+The agent runtime (Claude Code, Cursor, …) lives outside the deploy
+contract — operators bring their own MCP client.
+
+## Who it's for / not for
+
+**MEHO is for you if:**
+
+- You run AI agents (hosted or local MCP clients) that need to *act* on
+  real infrastructure, not just read about it.
+- You need every agent action policy-gated, credential-federated, and
+  audited — for compliance, blast-radius control, or plain peace of mind.
+- You operate VMware/VCF, Kubernetes, network appliances, or cloud and
+  want one governed seam in front of all of them.
+- You want to bring your own agent runtime and keep your audit trail in
+  systems you control (Postgres, your own Keycloak + Vault).
+
+**MEHO is probably not for you if:**
+
+- You want an agent *runtime* — MEHO governs agents, it doesn't run the
+  model. Bring your own MCP client.
+- You only need read-only chat over infrastructure with no write path,
+  no per-action authorisation, and no audit requirement.
+- You're looking for a hosted SaaS — MEHO is self-hosted (you run the
+  backplane, Postgres, Keycloak, and Vault).
 
 ## Deploy
 
@@ -50,10 +204,10 @@ kind create cluster --name meho-dev
 #    and Keycloak yourself.
 #    See deploy/values-examples/values-kind.yaml for the Postgres manifest.
 
-# 3. Install the chart from its OCI artefact (published by Task #41).
+# 3. Install the chart from its OCI artefact.
 #    Pin to an immutable image tag — sha-<git-sha> from a green CI run
-#    on main, or a v<x.y.z> release tag. Goal #11 deploy discipline
-#    rejects :latest entirely and treats :main as a dev-only moving alias
+#    on main, or a v<x.y.z> release tag. Deploy discipline rejects
+#    :latest entirely and treats :main as a dev-only moving alias
 #    (not a deploy target).
 helm install meho-dev oci://ghcr.io/evoila/meho-chart \
   --version <chart-version> \
@@ -78,7 +232,7 @@ the existing-k8s path below.
 
 ### Existing k8s (~5 min, requires Vault + Keycloak + Postgres)
 
-The supported v0.1 deploy shape: a Kubernetes cluster running an
+The supported deploy shape: a Kubernetes cluster running an
 ingress-nginx controller, a HashiCorp Vault with the `meho-mcp` OIDC
 role bound to your Keycloak issuer, a Keycloak realm + client fronting
 the backplane, and a PostgreSQL database reachable from the cluster.
@@ -100,8 +254,8 @@ Postgres credentials Secret (synced from Vault by ESO).
 
 ### Verify image + chart + CLI signatures
 
-Every operator-facing artefact is cosign keyless-signed (ADR 0006) under
-the workflow that produced it. There is no public key to distribute —
+Every operator-facing artefact is cosign keyless-signed under the
+workflow that produced it. There is no public key to distribute —
 verification compares the Fulcio-issued certificate's `subject` against
 a regex anchored on the source workflow's path and tag ref. A maliciously
 re-tagged fork cannot produce a bundle that satisfies it.
@@ -131,36 +285,6 @@ chart and image specifics live in
 [`cli/README.md`](./cli/README.md#verify-signatures) and
 [`docs/codebase/devops.md`](./docs/codebase/devops.md).
 
-## Architecture
-
-MEHO ships as three operator-facing artefacts:
-
-- **Backplane** — Python / FastAPI service that brokers MCP operations
-  against infrastructure. Receives short-lived Keycloak-issued OIDC
-  tokens, exchanges them with Vault for backend credentials, executes
-  policy-gated operations, writes audit rows to PostgreSQL, and
-  broadcasts activity to Valkey. Container image at
-  `ghcr.io/evoila/meho`. Codebase walkthrough:
-  [`docs/codebase/backend.md`](./docs/codebase/backend.md).
-- **Helm chart** — `meho-chart` published as an OCI artefact at
-  `ghcr.io/evoila/meho-chart` (Task #41). Renders the Deployment,
-  Service, Ingress, NetworkPolicy, pre-install migration Job, the
-  bundled Valkey broadcast subchart (ADR 0005), and the typed
-  `values.schema.json` contract (Task #38) that rejects misconfigured
-  installs at `helm install` / `helm upgrade` / `helm template`. Chart
-  walkthrough: [`docs/codebase/devops.md`](./docs/codebase/devops.md).
-- **Operator CLI** — `meho` Go binary (cobra). Wires `version`,
-  `login` (Keycloak device-code flow, Task #44), and `status`
-  (server-driven discovery, Task #45) for v0.9.0. Released as
-  multi-platform tarballs (`linux/macOS × amd64/arm64`) on every
-  `v*` tag, each individually cosign-signed (Task #47). CLI
-  walkthrough: [`docs/codebase/cli.md`](./docs/codebase/cli.md).
-
-The agent runtime (Claude Code, Cursor, …) lives outside the deploy
-contract — operators bring their own MCP client. MEHO is the layer
-that turns "any MCP client" into "any MCP client *operating against
-real infrastructure under audit*."
-
 ## Container image
 
 The backplane is published to GitHub Container Registry as a multi-arch
@@ -181,41 +305,19 @@ docker pull ghcr.io/evoila/meho:v0.9.0
 the latest main-branch build and is intended for **dev only** (the
 `docker pull` recipe above). Operators deploying MEHO must pin to an
 immutable `:sha-<...>` or `:v<x.y.z>` reference — `:main` is not a
-deploy target (Goal #11 deploy discipline). Every image is
-cosign-signed (Task #34) using the same keyless flow described above.
-
-### Maintainer one-time setup
-
-The first time `image.yml` pushes to `ghcr.io/evoila/meho`, GHCR creates
-the package as **private**. A maintainer must flip visibility to
-**public** once so anonymous `docker pull` works:
-
-```bash
-gh api --method PATCH /orgs/evoila/packages/container/meho \
-  -f visibility=public
-```
-
-Or via the UI: GitHub org `evoila` → Packages → `meho` → Package settings →
-Change visibility → **Public**.
-
-Verify:
-
-```bash
-gh api /orgs/evoila/packages/container/meho --jq '.visibility'   # -> "public"
-docker logout ghcr.io && docker pull ghcr.io/evoila/meho:main    # -> succeeds
-```
+deploy target. Every image is cosign-signed using the same keyless flow
+described above.
 
 ## Verifying CLI release artefacts
 
 Every CLI tarball published at <https://github.com/evoila/meho/releases>
-is signed via cosign keyless (ADR 0006). The signature, the
-Fulcio-issued certificate, and the Rekor transparency-log inclusion
-proof are bundled into a single `.cosign.bundle` JSON file attached
-to the release alongside each `.tar.gz` and the combined `SHA256SUMS`
-file.
+is signed via cosign keyless. The signature, the Fulcio-issued
+certificate, and the Rekor transparency-log inclusion proof are bundled
+into a single `.cosign.bundle` JSON file attached to the release
+alongside each `.tar.gz` and the combined `SHA256SUMS` file.
 
 ```bash
-TAG=v0.1.0
+TAG=<version>   # e.g. v0.9.0 — the release tag you are verifying
 TARBALL=meho_${TAG#v}_linux_amd64.tar.gz
 BASE=https://github.com/evoila/meho/releases/download/${TAG}
 
@@ -236,14 +338,13 @@ meho version
 
 The identity-claim regex is anchored on `cli-release.yml` and
 `refs/tags/v` — same shape as `chart.yml` (chart signing) and
-`image.yml` (container image signing) per ADR 0006. A maliciously
-re-tagged workflow on a fork cannot produce a bundle that satisfies
-it.
+`image.yml` (container image signing). A maliciously re-tagged workflow
+on a fork cannot produce a bundle that satisfies it.
 
 `SHA256SUMS` is signed the same way; verify it once, then
 `sha256sum -c SHA256SUMS` against any subset of tarballs the
 operator actually downloaded (two-step trust chain). The full
-recipe and ADR-0006 rationale live in
+recipe and signing rationale live in
 [`cli/README.md#verify-signatures`](./cli/README.md#verify-signatures).
 
 ## Helm chart values reference
@@ -252,10 +353,9 @@ The deploy contract lives at [`deploy/charts/meho/`](./deploy/charts/meho/).
 `values.yaml` ships safe-by-default — every field the backplane cannot
 start without is **blank** and the bundled
 [`values.schema.json`](./deploy/charts/meho/values.schema.json) (JSON
-Schema draft-07, Task #38) rejects empty required values at
-`helm install` / `helm upgrade` / `helm template` time with a clear
-path. Unknown keys at any level fail with
-`additional properties '<name>' not allowed`.
+Schema draft-07) rejects empty required values at `helm install` /
+`helm upgrade` / `helm template` time with a clear path. Unknown keys at
+any level fail with `additional properties '<name>' not allowed`.
 
 Operator-required (MUST be set; the schema rejects empty defaults):
 
@@ -278,17 +378,17 @@ Common operator overrides (safe defaults provided; tune as needed):
 
 | Path | Default | Notes |
 | --- | --- | --- |
-| `replicaCount` | `1` | v0.1 ships single-replica; HA lands in v0.2. |
-| `image.repository` | `ghcr.io/evoila/meho` | OCI repo from the G2.4 image pipeline. |
+| `replicaCount` | `1` | Single-replica baseline. |
+| `image.repository` | `ghcr.io/evoila/meho` | OCI repo from the image pipeline. |
 | `image.pullPolicy` | `IfNotPresent` | `Always` \| `IfNotPresent` \| `Never`. |
 | `service.type` / `service.port` | `ClusterIP` / `8000` | Service shape. |
 | `ingress.className` | `""` | Cluster default IngressClass when empty. |
 | `probes.liveness.*` / `probes.readiness.*` | `/healthz` / `/ready` httpGet + tuned timings | Operator-tunable; never disabled. |
-| `resources.requests` / `resources.limits` | `100m`/`256Mi` / `1000m`/`1Gi` | Conservative v0.1 chassis baselines. |
+| `resources.requests` / `resources.limits` | `100m`/`256Mi` / `1000m`/`1Gi` | Conservative chassis baselines. |
 | `networkPolicy.ingressControllerNamespace` | `ingress-nginx` | RKE2 default; override per cluster. |
-| `audit.postgresOnly` | `true` | v0.1; S3 mirror is v0.2. |
-| `broadcast.enabled` | `true` | v0.1 deploys its own Valkey subchart (G2.5-T3). |
-| `connectors.enabled` | `[]` | v0.1 chassis ships no connectors. |
+| `audit.postgresOnly` | `true` | Postgres-only audit sink baseline. |
+| `broadcast.enabled` | `true` | Deploys the bundled Valkey broadcast subchart. |
+| `connectors.enabled` | `[]` | Opt-in list; pick from the shipped connector catalog (see [`docs/architecture/connectors.md`](./docs/architecture/connectors.md) — VMware/VCF, NSX, Kubernetes, Vault, Harbor, Keycloak, ArgoCD, GCloud, BIND9, pfSense, and more). |
 
 See [`docs/codebase/devops.md`](./docs/codebase/devops.md) for the full
 chart contract, probe semantics, NetworkPolicy posture, install/upgrade
@@ -296,13 +396,11 @@ flow, and verification commands.
 
 ## v0.2 upgrade prerequisites
 
-The v0.2 backplane (Initiative
-[#222](https://github.com/evoila/meho/issues/222)) reads two new
-claims (`tenant_id` + `tenant_role`) from every authenticated access
-token. v0.1 chassis-era tokens do not carry those claims; operators
-upgrading from v0.1 to v0.2 must apply the realm-side configuration
-that mints them, or every authenticated request returns
-`401 missing_tenant_claim`.
+The v0.2 backplane reads two new claims (`tenant_id` + `tenant_role`)
+from every authenticated access token. v0.1 chassis-era tokens do not
+carry those claims; operators upgrading from v0.1 to v0.2 must apply the
+realm-side configuration that mints them, or every authenticated request
+returns `401 missing_tenant_claim`.
 
 The realm-side recipe (group attribute + realm role protocol mappers,
 verification + troubleshooting) lives at
@@ -321,9 +419,9 @@ Codebase walkthroughs:
 - **CLI** — [`docs/codebase/cli.md`](./docs/codebase/cli.md)
 - **Chart + deploy** — [`docs/codebase/devops.md`](./docs/codebase/devops.md)
 
-`docs.meho.ai` (rendered reference docs, runbooks, connector authoring
-guide) lands in v0.2 once the first connector + wrapper-replacement
-work in Goal #59 closes.
+Architecture references live under
+[`docs/architecture/`](./docs/architecture/) — topology, the operations
+substrate, audit, MCP surface, and the connector catalog.
 
 ## Contributing
 
@@ -336,6 +434,11 @@ from commit #1; operator-sensitive coordination lives in
 ## Security
 
 Vulnerability reports: see [`SECURITY.md`](./SECURITY.md).
+
+## Releasing
+
+Maintainers: the release runbook (including one-time GHCR package
+visibility setup) lives in [`docs/RELEASING.md`](./docs/RELEASING.md).
 
 ## Changelog
 
@@ -360,3 +463,5 @@ for the sign-off discipline.
 This repository was bootstrapped on 2026-05-09 as a strategic reset.
 The prior MEHO codebase lives at `evoila-bosnia/MEHO.X`, deprecated
 and retained for reference.
+</content>
+</invoke>

--- a/docs/RELEASING.md
+++ b/docs/RELEASING.md
@@ -172,6 +172,28 @@ The push fans out to `cli-release.yml`, `image.yml`, `chart.yml`.
 - [ ] Chart published to `oci://ghcr.io/evoila/meho-chart` (`chart.yml` green).
 - [ ] CLI tarballs attached to the Release; `meho version` prints `vX.Y.Z`.
 
+#### Maintainer one-time setup — GHCR package visibility
+
+The first time `image.yml` pushes to `ghcr.io/evoila/meho`, GHCR creates
+the package as **private**. A maintainer must flip visibility to
+**public** once so anonymous `docker pull` works (this is a one-time
+action, not per-release):
+
+```bash
+gh api --method PATCH /orgs/evoila/packages/container/meho \
+  -f visibility=public
+```
+
+Or via the UI: GitHub org `evoila` → Packages → `meho` → Package settings →
+Change visibility → **Public**.
+
+Verify:
+
+```bash
+gh api /orgs/evoila/packages/container/meho --jq '.visibility'   # -> "public"
+docker logout ghcr.io && docker pull ghcr.io/evoila/meho:main    # -> succeeds
+```
+
 ### 6. Deploy + smoke
 
 - [ ] Deploy to `rke2-infra`.


### PR DESCRIPTION
## Summary

- Restructures `README.md` from a deploy manual into a front door:
  problem statement → **What MEHO is** (with the promoted "any MCP client
  *operating against real infrastructure under audit*" killer line) →
  scannable six-guarantee list → **See it work** → **Architecture**
  (GitHub-native Mermaid diagram) → **Who it's for / not for** → Deploy.
- **See it work** surfaces `examples/r4-local-claude/`: the MCP-client
  config block, one audited operation round-trip, and the audit row /
  broadcast event it produces.
- Strips internal scaffolding from the public page — the green-counter
  placeholder badge comment, all `Task #N`/`Goal #N`/`Initiative #N`/
  `G2.x`/bare `ADR 0006` IDs, and the maintainer GHCR visibility runbook
  (relocated to `docs/RELEASING.md` step 5).
- Folds in the residual T1 accuracy items #1453 left on main: removes the
  dead `docs.meho.ai` host reference, replaces `TAG=v0.1.0` with a
  `<version>` placeholder, fixes the `connectors.enabled` "ships no
  connectors" claim (now links the connector catalog), and replaces the
  stale 3-verb CLI claim with the real ~40-group command surface
  (grounded in `cli/internal/cmd/root.go`).
- Adds a shields.io release badge and a CI-status badge to the badge row.

## Test plan

- [x] `grep -nE "Task #[0-9]|Goal #[0-9]|Initiative #[0-9]|G2\.[0-9]" README.md` → empty
- [x] `grep -n "green-counter" README.md` → empty
- [x] `grep -n "Maintainer one-time setup" README.md` → empty; `grep -n "visibility=public" docs/RELEASING.md` → match
- [x] `grep -n "docs.meho.ai" README.md` / `grep -n "TAG=v0.1.0" README.md` / `grep -n "ships no connectors" README.md` → all empty
- [x] ` ```mermaid ` fence present; release + CI badges present in the badge row
- [x] killer line present in top "What MEHO is" section; guarantees render as 6 bullets; "Who it's for / not for" section present
- [x] CLI surface (~40 groups), connector catalog, and tag facts grounded in `cli/internal/cmd/root.go`, `backend/src/meho_backplane/connectors/`, and `git tag`
- [x] all referenced in-repo links resolve (GUIDE.md, mcp.json.example, docs/architecture/, docs/codebase/, docs/RELEASING.md)
- [x] pre-commit hooks (trailing-whitespace, end-of-file-fixer, conventional-commit) pass

## Out of scope

- Factual corrections beyond the T1 residuals (→ T1 #1448, mostly landed).
- "Why MEHO" moat section, comparison table, FAQ, values-table relocation (→ T4).
- CI drift guard (→ T2).

<!-- auto-implement-issue: fresh, iteration 1 -->

Closes #1450
