### PR TITLE
feat(connectors): wire ArgoCD write ops to park-time proposed_effect preview (#1452)

### DIFF
--- a/backend/src/meho_backplane/connectors/argocd/__init__.py
+++ b/backend/src/meho_backplane/connectors/argocd/__init__.py
@@ -40,6 +40,12 @@ resolver tie-break ladder. Only the v2 triple (+ wildcard) advertises this
 class — the same decision Harbor, bind9, NSX, and SDDC Manager made.
 """
 
+# Import for the registration side-effect: at module load this wires the
+# park-time ``proposed_effect`` preview builders for ``argocd.app.set`` /
+# ``app.delete`` / ``appproject.update`` onto the #1437 dispatcher hook
+# (G11.7 follow-up #1452) so the reviewer sees the diff / cascade in the
+# approval queue before approving.
+from meho_backplane.connectors.argocd import ops_write_preview  # noqa: F401
 from meho_backplane.connectors.argocd.connector import ArgoCdConnector
 from meho_backplane.connectors.argocd.ops import (
     ARGOCD_OPS,

--- a/backend/src/meho_backplane/connectors/argocd/ops_write.py
+++ b/backend/src/meho_backplane/connectors/argocd/ops_write.py
@@ -55,10 +55,26 @@ proposed_effect snapshots (set / delete / appproject.update)
 **after** the change; ``app.delete`` snapshots the managed resource tree
 (the cascade list) before the delete. Each lands under a ``proposed_effect``
 key in the returned result so the reviewer/auditor sees exactly what shifted
-or what the cascade will remove. (The substrate computes the durable
-``ApprovalRequest.proposed_effect`` at park-time from params; this in-result
-block is the post-approval execution evidence the op author can compute —
-it needs a live read against the target, which only happens once approved.)
+or what the cascade will remove.
+
+The same snapshot is *also* computed at **park time** — before any human
+approves — via the per-op preview-builder hook (G11.7 follow-up #1452,
+attaching to the #1437 dispatcher seam). The builders at the bottom of this
+module reuse the read-only snapshot helpers (:func:`_read_app_spec` /
+:func:`_read_cascade_resources` / :func:`_read_project_spec`) the handlers
+themselves use, issuing only the read GETs (``GET .../applications/{name}``,
+``.../resource-tree``, ``GET .../projects``) and never the mutating
+PUT/DELETE. The result is stored in the durable
+:attr:`~meho_backplane.db.models.ApprovalRequest.proposed_effect` so the
+reviewer sees the diff / cascade in the approval queue **before** approving,
+not only in the post-approval op result. ``after_spec`` at park time is the
+*proposed* spec the dispatch carried in ``params`` (what the approved call
+would apply); the in-result ``after_spec`` is the argocd-server-accepted
+spec echoed by the PUT response.
+
+The ops with no natural read-only preview (``app.sync`` / ``app.rollback`` /
+``app.refresh``) register no builder and park with the identifier-only
+default exactly as before.
 
 References
 ----------
@@ -267,6 +283,28 @@ async def argocd_app_rollback(
     return {"name": name, "rollback_id": rollback_id, **outcome}
 
 
+async def _read_app_spec(
+    self: ArgoCdConnector,
+    operator: Operator,
+    target: ArgoCdTargetLike,
+    *,
+    name: str,
+    query: dict[str, Any],
+) -> Any:
+    """Read-only: GET the Application and return its current ``spec``.
+
+    The single source of truth for the ``before_spec`` snapshot, shared by
+    the :func:`argocd_app_set` handler (post-approval) and its park-time
+    preview builder. Issues only ``GET /api/v1/applications/{name}`` — never
+    a mutating verb.
+    """
+    encoded = _quote_name(name)
+    before = await self._get_json(
+        target, f"/api/v1/applications/{encoded}", operator=operator, params=query or None
+    )
+    return before.get("spec") if isinstance(before, dict) else None
+
+
 async def argocd_app_set(
     self: ArgoCdConnector,
     operator: Operator,
@@ -282,10 +320,7 @@ async def argocd_app_set(
     name = str(params["name"])
     encoded = _quote_name(name)
     query = _project_query(params)
-    before = await self._get_json(
-        target, f"/api/v1/applications/{encoded}", operator=operator, params=query or None
-    )
-    before_spec = before.get("spec") if isinstance(before, dict) else None
+    before_spec = await _read_app_spec(self, operator, target, name=name, query=query)
     put_query: dict[str, Any] = dict(query)
     if params.get("validate") is not None:
         put_query["validate"] = bool(params["validate"])
@@ -359,6 +394,41 @@ def _cascade_resources(tree: dict[str, Any]) -> list[dict[str, Any]]:
     return out
 
 
+async def _read_cascade_resources(
+    self: ArgoCdConnector,
+    operator: Operator,
+    target: ArgoCdTargetLike,
+    *,
+    name: str,
+    cascade: bool,
+    query: dict[str, Any],
+) -> list[dict[str, Any]]:
+    """Read-only: GET the resource tree, reduce to the cascade list.
+
+    Shared by the :func:`argocd_app_delete` handler and its park-time
+    preview builder. Returns ``[]`` without any HTTP call when
+    ``cascade`` is ``False`` (a non-cascading delete removes no managed
+    resources, so there is nothing to preview). Issues only
+    ``GET /api/v1/applications/{name}/resource-tree``.
+    """
+    if not cascade:
+        return []
+    encoded = _quote_name(name)
+    tree = await self._get_json(
+        target,
+        f"/api/v1/applications/{encoded}/resource-tree",
+        operator=operator,
+        params=query or None,
+    )
+    return _cascade_resources(tree)
+
+
+def _delete_cascade_flag(params: dict[str, Any]) -> bool:
+    """Resolve the effective ``cascade`` flag (default ``True``)."""
+    cascade = params.get("cascade")
+    return True if cascade is None else bool(cascade)
+
+
 async def argocd_app_delete(
     self: ArgoCdConnector,
     operator: Operator,
@@ -374,19 +444,12 @@ async def argocd_app_delete(
     """
     name = str(params["name"])
     encoded = _quote_name(name)
-    cascade = params.get("cascade")
-    cascade = True if cascade is None else bool(cascade)
+    cascade = _delete_cascade_flag(params)
     query = _project_query(params)
 
-    cascade_resources: list[dict[str, Any]] = []
-    if cascade:
-        tree = await self._get_json(
-            target,
-            f"/api/v1/applications/{encoded}/resource-tree",
-            operator=operator,
-            params=query or None,
-        )
-        cascade_resources = _cascade_resources(tree)
+    cascade_resources = await _read_cascade_resources(
+        self, operator, target, name=name, cascade=cascade, query=query
+    )
 
     delete_query: dict[str, Any] = dict(query)
     delete_query["cascade"] = "true" if cascade else "false"
@@ -441,6 +504,29 @@ async def argocd_appproject_create(
     return {"name": name, "created": True}
 
 
+async def _read_project_spec(
+    self: ArgoCdConnector,
+    operator: Operator,
+    target: ArgoCdTargetLike,
+    *,
+    name: str,
+) -> Any:
+    """Read-only: GET the project list, return the named project's ``spec``.
+
+    argocd-server has no single-project GET on the gRPC-gateway; the list
+    endpoint is the read the handler and its park-time preview builder both
+    use to capture ``before_spec``. Issues only ``GET /api/v1/projects``;
+    returns ``None`` when the project is not (yet) present.
+    """
+    projects = await self._get_json(target, "/api/v1/projects", operator=operator)
+    items = projects.get("items") if isinstance(projects, dict) else None
+    if isinstance(items, list):
+        for item in items:
+            if isinstance(item, dict) and _project_metadata_name(item) == name:
+                return item.get("spec")
+    return None
+
+
 async def argocd_appproject_update(
     self: ArgoCdConnector,
     operator: Operator,
@@ -457,14 +543,7 @@ async def argocd_appproject_update(
     name = _project_name(project)
     encoded = _quote_name(name)
 
-    before_spec: Any = None
-    projects = await self._get_json(target, "/api/v1/projects", operator=operator)
-    items = projects.get("items") if isinstance(projects, dict) else None
-    if isinstance(items, list):
-        for item in items:
-            if isinstance(item, dict) and _project_metadata_name(item) == name:
-                before_spec = item.get("spec")
-                break
+    before_spec = await _read_project_spec(self, operator, target, name=name)
 
     body: dict[str, Any] = {"project": project}
     updated = await self._write_json(

--- a/backend/src/meho_backplane/connectors/argocd/ops_write_preview.py
+++ b/backend/src/meho_backplane/connectors/argocd/ops_write_preview.py
@@ -1,0 +1,150 @@
+# SPDX-License-Identifier: Apache-2.0
+# Copyright (c) 2026 evoila Group
+
+"""Park-time ``proposed_effect`` preview builders for the ArgoCD write ops.
+
+G11.7 follow-up (#1452). Wires the three ArgoCD write ops that can compute a
+side-effect-free preview onto the per-op builder hook shipped by #1437
+(:mod:`meho_backplane.operations._preview`):
+
+==============================  =====================================================
+op_id                           preview stored in ``ApprovalRequest.proposed_effect``
+==============================  =====================================================
+``argocd.app.set``              ``{before_spec, after_spec}``
+``argocd.appproject.update``    ``{before_spec, after_spec}``
+``argocd.app.delete``           ``{cascade_resources: [...]}``
+==============================  =====================================================
+
+Each builder reuses the **read-only** snapshot helpers the handlers in
+:mod:`meho_backplane.connectors.argocd.ops_write` already use
+(:func:`_read_app_spec` / :func:`_read_cascade_resources` /
+:func:`_read_project_spec`) — it issues only the read GETs
+(``GET /api/v1/applications/{name}``, ``.../resource-tree``,
+``GET /api/v1/projects``) and never the mutating PUT/DELETE. The mutation
+stays parked until a human approves; the builder only computes what the
+approved call *would* change so the reviewer reads the diff / cascade in the
+approval queue first.
+
+``after_spec`` at park time is the **proposed** spec the dispatch carried in
+``params`` — what the approved ``PUT`` would apply. (The handler's in-result
+``after_spec`` is the argocd-server-accepted spec echoed by the PUT response,
+which only exists post-approval.)
+
+The ops with no natural read-only preview (``app.sync`` / ``app.rollback`` /
+``app.refresh``) register no builder here, so they fall through to the
+dispatcher's identifier-only default — no preview, no regression.
+
+The whole-builder ``classify_op`` redaction gate runs in
+:func:`~meho_backplane.operations._preview.build_proposed_effect` before any
+builder fires: ``argocd.app.delete`` / ``appproject.update`` classify as
+``write`` and ``argocd.app.set`` as ``other`` — none is a credential class,
+so none is suppressed, and none of the snapshots carries secret material
+(an ApplicationSpec / AppProjectSpec / resource-tree node is GitOps
+topology, not credentials).
+"""
+
+from __future__ import annotations
+
+from typing import TYPE_CHECKING, Any
+
+from meho_backplane.connectors.argocd.connector import ArgoCdConnector
+from meho_backplane.connectors.argocd.ops_write import (
+    _delete_cascade_flag,
+    _project_name,
+    _project_query,
+    _read_app_spec,
+    _read_cascade_resources,
+    _read_project_spec,
+)
+from meho_backplane.operations._preview import (
+    PreviewContext,
+    register_preview_builder,
+)
+
+if TYPE_CHECKING:
+    from meho_backplane.connectors.argocd.session import ArgoCdTargetLike
+
+
+def _resolve_argocd(ctx: PreviewContext) -> tuple[ArgoCdConnector, ArgoCdTargetLike] | None:
+    """Return the resolved (connector, target) pair, or ``None`` to decline.
+
+    A preview needs both a live ArgoCD connector instance and a dispatch
+    target to read against; either missing ⇒ no preview (the caller falls
+    back to the identifier-only default).
+    """
+    connector = ctx.connector_instance
+    if not isinstance(connector, ArgoCdConnector) or ctx.target is None:
+        return None
+    return connector, ctx.target
+
+
+async def _app_set_preview(ctx: PreviewContext) -> dict[str, Any] | None:
+    """Preview ``argocd.app.set`` — read current spec, echo the proposed spec.
+
+    ``before_spec`` is the live ApplicationSpec (read-only GET); ``after_spec``
+    is the spec the parked dispatch would PUT. No mutation fires.
+    """
+    resolved = _resolve_argocd(ctx)
+    if resolved is None:
+        return None
+    connector, target = resolved
+    name = str(ctx.params["name"])
+    query = _project_query(ctx.params)
+    before_spec = await _read_app_spec(connector, ctx.operator, target, name=name, query=query)
+    after_spec = ctx.params.get("spec")
+    return {"before_spec": before_spec, "after_spec": after_spec}
+
+
+async def _app_delete_preview(ctx: PreviewContext) -> dict[str, Any] | None:
+    """Preview ``argocd.app.delete`` — read the managed resource tree (cascade).
+
+    Reads the resource tree to capture the cascade list a cascading delete
+    would remove. No DELETE fires. A non-cascading delete previews an empty
+    list (it removes no managed resources).
+    """
+    resolved = _resolve_argocd(ctx)
+    if resolved is None:
+        return None
+    connector, target = resolved
+    name = str(ctx.params["name"])
+    cascade = _delete_cascade_flag(ctx.params)
+    query = _project_query(ctx.params)
+    cascade_resources = await _read_cascade_resources(
+        connector, ctx.operator, target, name=name, cascade=cascade, query=query
+    )
+    return {"cascade_resources": cascade_resources}
+
+
+async def _appproject_update_preview(ctx: PreviewContext) -> dict[str, Any] | None:
+    """Preview ``argocd.appproject.update`` — read current spec, echo proposed.
+
+    ``before_spec`` is the live AppProjectSpec (read-only GET of the project
+    list); ``after_spec`` is the spec the parked dispatch would PUT. No
+    mutation fires.
+    """
+    resolved = _resolve_argocd(ctx)
+    if resolved is None:
+        return None
+    connector, target = resolved
+    project = ctx.params.get("project")
+    if not isinstance(project, dict):
+        return None
+    name = _project_name(project)
+    before_spec = await _read_project_spec(connector, ctx.operator, target, name=name)
+    after_spec = project.get("spec")
+    return {"before_spec": before_spec, "after_spec": after_spec}
+
+
+def _register_argocd_preview_builders() -> None:
+    """Wire the ArgoCD park-time preview builders. Called at import time.
+
+    Only the three ops with a natural read-only preview register; the rest
+    (``app.sync`` / ``app.rollback`` / ``app.refresh`` / ``appproject.create``)
+    fall through to the identifier-only default.
+    """
+    register_preview_builder("argocd.app.set", _app_set_preview)
+    register_preview_builder("argocd.app.delete", _app_delete_preview)
+    register_preview_builder("argocd.appproject.update", _appproject_update_preview)
+
+
+_register_argocd_preview_builders()

--- a/backend/tests/test_connectors_argocd_write_e2e.py
+++ b/backend/tests/test_connectors_argocd_write_e2e.py
@@ -478,6 +478,155 @@ async def test_appproject_update_captures_before_after(
 # ---------------------------------------------------------------------------
 
 
+# ---------------------------------------------------------------------------
+# Park-time proposed_effect preview (G11.7 follow-up #1452)
+#
+# These drive the *un-approved* USER park path: the dispatch routes to the
+# approve-queue and the per-op preview builder (#1437 hook, wired in
+# ops_write_preview) must populate the durable ApprovalRequest.proposed_effect
+# from READ-ONLY calls only — no POST/PUT/DELETE may fire before approval.
+# ---------------------------------------------------------------------------
+
+
+async def _parked_proposed_effect(approval_request_id: str) -> dict[str, Any]:
+    """Read back the durable ApprovalRequest.proposed_effect for a parked op."""
+    from meho_backplane.operations.approval_queue import get_request
+
+    sessionmaker = get_sessionmaker()
+    async with sessionmaker() as session:
+        request = await get_request(
+            session,
+            tenant_id=_OPERATOR_TENANT_ID,
+            request_id=uuid.UUID(approval_request_id),
+        )
+        return dict(request.proposed_effect)
+
+
+def _assert_no_mutation_fired(mock: respx.MockRouter) -> None:
+    """Assert the park path issued only read GETs — no POST/PUT/DELETE."""
+    for call in mock.calls:
+        assert call.request.method == "GET", (
+            f"park-time preview must be read-only; saw {call.request.method} {call.request.url}"
+        )
+
+
+@pytest.mark.asyncio
+async def test_park_app_set_populates_before_after_preview(
+    argocd_write_e2e: ArgoCdConnector,
+) -> None:
+    """A parked argocd.app.set has before_spec + after_spec before approval."""
+    with respx.mock(base_url=_ARGOCD_BASE_URL, assert_all_called=False) as mock:
+        get_route = mock.get(f"/api/v1/applications/{_APP_NAME}").respond(
+            200, json=_APP_SPEC_BEFORE
+        )
+        put_route = mock.put(f"/api/v1/applications/{_APP_NAME}/spec").respond(
+            200, json=_APP_SPEC_AFTER
+        )
+        result = await _dispatch(
+            "argocd.app.set",
+            {"name": _APP_NAME, "spec": _APP_SPEC_AFTER},
+            approved=False,
+        )
+        assert result["status"] == "awaiting_approval", result
+        # Read-only: the spec PUT never fired; only the before-read GET did.
+        assert get_route.called, "park-time preview must read the live spec"
+        assert not put_route.called, "no mutation may fire before approval"
+        _assert_no_mutation_fired(mock)
+
+    request_id = result["extras"]["approval_request_id"]
+    effect = await _parked_proposed_effect(request_id)
+    # The hook wraps the builder output in {op_class, preview}.
+    assert effect["op_class"] == "other"
+    preview = effect["preview"]
+    assert preview["before_spec"]["source"]["targetRevision"] == "HEAD"
+    # after_spec at park time is the proposed spec the approved PUT would apply.
+    assert preview["after_spec"]["source"]["targetRevision"] == "v2.0.0"
+
+
+@pytest.mark.asyncio
+async def test_park_app_delete_populates_cascade_preview(
+    argocd_write_e2e: ArgoCdConnector,
+) -> None:
+    """A parked argocd.app.delete has the cascade_resources list before approval."""
+    with respx.mock(base_url=_ARGOCD_BASE_URL, assert_all_called=False) as mock:
+        tree_route = mock.get(f"/api/v1/applications/{_APP_NAME}/resource-tree").respond(
+            200, json=_RESOURCE_TREE
+        )
+        delete_route = mock.delete(f"/api/v1/applications/{_APP_NAME}").respond(200, json={})
+        result = await _dispatch("argocd.app.delete", {"name": _APP_NAME}, approved=False)
+        assert result["status"] == "awaiting_approval", result
+        assert tree_route.called, "park-time preview must read the resource tree"
+        assert not delete_route.called, "no DELETE may fire before approval"
+        _assert_no_mutation_fired(mock)
+
+    request_id = result["extras"]["approval_request_id"]
+    effect = await _parked_proposed_effect(request_id)
+    assert effect["op_class"] == "write"
+    cascade = effect["preview"]["cascade_resources"]
+    assert {(r["kind"], r["name"]) for r in cascade} == {
+        ("Deployment", "guestbook-ui"),
+        ("Service", "guestbook-ui"),
+    }
+
+
+@pytest.mark.asyncio
+async def test_park_appproject_update_populates_before_after_preview(
+    argocd_write_e2e: ArgoCdConnector,
+) -> None:
+    """A parked argocd.appproject.update has before_spec + after_spec before approval."""
+    with respx.mock(base_url=_ARGOCD_BASE_URL, assert_all_called=False) as mock:
+        list_route = mock.get("/api/v1/projects").respond(200, json=_PROJECT_LIST)
+        put_route = mock.put("/api/v1/projects/team-a").respond(200, json=_PROJECT_AFTER)
+        result = await _dispatch(
+            "argocd.appproject.update",
+            {"project": _PROJECT_AFTER},
+            approved=False,
+        )
+        assert result["status"] == "awaiting_approval", result
+        assert list_route.called, "park-time preview must read the live project spec"
+        assert not put_route.called, "no mutation may fire before approval"
+        _assert_no_mutation_fired(mock)
+
+    request_id = result["extras"]["approval_request_id"]
+    effect = await _parked_proposed_effect(request_id)
+    assert effect["op_class"] == "write"
+    preview = effect["preview"]
+    assert len(preview["before_spec"]["sourceRepos"]) == 1
+    assert len(preview["after_spec"]["sourceRepos"]) == 2
+
+
+@pytest.mark.asyncio
+@pytest.mark.parametrize(
+    ("op_id", "params"),
+    [
+        ("argocd.app.sync", {"name": _APP_NAME}),
+        ("argocd.app.rollback", {"name": _APP_NAME, "id": 7}),
+        ("argocd.app.refresh", {"name": _APP_NAME}),
+    ],
+)
+async def test_park_no_builder_ops_use_identifier_only_default(
+    argocd_write_e2e: ArgoCdConnector,
+    op_id: str,
+    params: dict[str, Any],
+) -> None:
+    """sync / rollback / refresh park with the identifier-only default — no preview.
+
+    They register no builder, so proposed_effect stays the bare
+    ``{op_id, connector_id, target_id}`` and no cluster call fires on the
+    park path (the handler is never reached, and no preview read is issued).
+    """
+    with respx.mock(base_url=_ARGOCD_BASE_URL, assert_all_called=False) as mock:
+        result = await _dispatch(op_id, params, approved=False)
+        assert result["status"] == "awaiting_approval", result
+        assert not mock.calls, f"{op_id} must make no cluster call on the park path"
+
+    request_id = result["extras"]["approval_request_id"]
+    effect = await _parked_proposed_effect(request_id)
+    # Identifier-only default: no preview envelope, just the call identity.
+    assert "preview" not in effect
+    assert effect["op_id"] == op_id
+
+
 @pytest.mark.asyncio
 async def test_all_writes_carry_bearer_and_never_leak_secret(
     argocd_write_e2e: ArgoCdConnector,

--- a/docs/codebase/approvals.md
+++ b/docs/codebase/approvals.md
@@ -127,8 +127,13 @@ The only builder wired in #1437 is **`k8s.apply`**: it re-invokes the
 `k8s_apply` handler with `dry_run="server"` forced on (the API's
 `?dryRun=All`), so nothing persists and the per-document summary
 (resource identity + `resourceVersion` + `uid`) is the diff-preview the
-reviewer reads. Other ops (e.g. argocd writes, #1452) register their own
-builders as needed.
+reviewer reads. The ArgoCD write ops register their own builders the same
+way (#1452): `argocd.app.set` / `argocd.appproject.update` populate
+`{before_spec, after_spec}` and `argocd.app.delete` populates
+`{cascade_resources}` from read-only GETs against the live
+Application / AppProject — wired in
+`connectors/argocd/ops_write_preview.py`. Further connectors register
+their own builders as needed.
 
 ## Transports
 

--- a/docs/codebase/connectors-argocd.md
+++ b/docs/codebase/connectors-argocd.md
@@ -199,9 +199,25 @@ last-observed phase with `timed_out=true`.
 current spec before the PUT and return `{before_spec, after_spec}` under a
 `proposed_effect` key; `app.delete` reads the resource tree before the
 DELETE and returns the cascade list. These ride in the op result (the
-post-approval execution evidence the reviewer/auditor sees) — the durable
-`ApprovalRequest.proposed_effect` the queue stores at park time is computed
-separately by `create_pending_request` from params.
+post-approval execution evidence the reviewer/auditor sees).
+
+The **same** snapshot is also computed at **park time** — before any human
+approves — via the per-op preview-builder hook (G11.7 follow-up #1452, on
+the #1437 dispatcher seam). `ops_write_preview.py` registers a builder for
+`argocd.app.set`, `argocd.app.delete`, and `argocd.appproject.update`; each
+reuses the read-only snapshot helpers the handlers use (`_read_app_spec` /
+`_read_cascade_resources` / `_read_project_spec`), issuing **only** the read
+GETs (`GET .../applications/{name}`, `.../resource-tree`, `GET
+.../projects`) and never the mutating PUT/DELETE. The result lands in the
+durable `ApprovalRequest.proposed_effect` (wrapped `{op_class, preview}` by
+the hook) so the reviewer reads the diff / cascade in the approval queue
+*before* approving. `after_spec` at park time is the proposed spec the
+parked dispatch carried in `params`; the in-result `after_spec` is the
+argocd-server-accepted spec echoed by the PUT response, which only exists
+post-approval. The ops with no natural read-only preview (`app.sync` /
+`app.rollback` / `app.refresh` / `appproject.create`) register no builder
+and park with the identifier-only default `create_pending_request` computes
+from params.
 
 Writes go through the connector's `_write_json` helper (POST/PUT/DELETE,
 **not** retried — a side-effecting verb must not silently re-fire on a 5xx),


### PR DESCRIPTION
## Summary
- Wires `argocd.app.set`, `argocd.app.delete`, and `argocd.appproject.update` to the #1437 per-op `proposed_effect` builder hook so the reviewer sees the before/after spec diff (set / appproject.update) or the cascade resource list (delete) in the approval queue **before** approving — not only post-approval in the op result.
- New `connectors/argocd/ops_write_preview.py` registers the three builders; each reuses the read-only snapshot helpers extracted from the handlers (`_read_app_spec` / `_read_cascade_resources` / `_read_project_spec`), so the park path issues only the read GETs and never the mutating PUT/DELETE.
- Ops with no natural read-only preview (`app.sync` / `app.rollback` / `app.refresh`) register no builder and park with the identifier-only default — no regression. The hook's existing `classify_op` redaction gate already covers the new ops (write/other class, never credential; the snapshots are GitOps topology, no secrets).

## Test plan
- [x] `ruff check` — clean (argocd package + test)
- [x] `ruff format --check` — clean
- [x] `mypy src/meho_backplane/connectors/argocd/ --ignore-missing-imports` — Success, 7 files
- [x] `code-quality.py --diff` — exit 0 (ops_write.py 577 lines, under budget)
- [x] **set / appproject.update park rows carry `before_spec` + `after_spec`** — `test_park_app_set_populates_before_after_preview`, `test_park_appproject_update_populates_before_after_preview`
- [x] **delete park row carries `cascade_resources`** — `test_park_app_delete_populates_cascade_preview`
- [x] **park path is read-only (no POST/PUT/DELETE)** — `_assert_no_mutation_fired` asserts every park-path call is a GET; PUT/DELETE routes asserted `not called`
- [x] **sync / rollback / refresh park with identifier-only default, no preview, no cluster call** — `test_park_no_builder_ops_use_identifier_only_default` (parametrized)
- [x] no regression on the post-approval handler path — existing 12 argocd write E2E tests still pass; full run 18 passed
- [x] `pytest tests/test_connectors_argocd_write_e2e.py tests/test_operations_preview.py tests/test_operations_dispatcher.py tests/test_connectors_argocd_reads.py tests/test_connectors_argocd_e2e.py` — 95 passed

## Out of scope
- Non-ArgoCD connectors wiring to the hook (each its own #1437 follow-up).
- The dispatcher builder-hook mechanism itself (#1437, merged).

## Notes
- No FastAPI route / schema / `registered_product_tokens()` changes — connector-only, no OpenAPI delta, so no CLI snapshot regen needed.
- `after_spec` at park time is the proposed spec the dispatch carried in `params` (what the approved PUT would apply); the in-result `after_spec` is the argocd-server-accepted spec echoed by the PUT response, which only exists post-approval. Documented in `ops_write_preview.py` + `docs/codebase/connectors-argocd.md`.

<!-- auto-implement-issue: fresh, iteration 1 -->

Closes #1452
