### PR TITLE
chore(ci): make README version guard tolerate a badge-only version surface

### DIFF
--- a/.github/workflows/readme-version-check.yml
+++ b/.github/workflows/readme-version-check.yml
@@ -79,8 +79,17 @@ jobs:
               | grep -oE 'v[0-9]+\.[0-9]+(\.[0-9]+)?' \
               || true
           )"
+          # No **Status:** token is fine *if* the README relies on the
+          # self-updating shields.io release badge: that endpoint renders
+          # the latest release dynamically and carries no static version
+          # string, so it cannot drift. Fail only when neither an honest
+          # textual version nor the badge is present.
           if [ -z "$readme_version" ]; then
-            echo "::error file=README.md::Could not find a vX.Y(.Z) version token on the README '**Status:**' line."
+            if grep -qF 'img.shields.io/github/v/release/evoila/meho' README.md; then
+              echo "No '**Status:**' version token, but the self-updating release badge is present — drift is not possible. OK."
+              exit 0
+            fi
+            echo "::error file=README.md::No vX.Y(.Z) token on the '**Status:**' line and no self-updating release badge found; the README has no honest version surface."
             exit 1
           fi
 


### PR DESCRIPTION
## Summary
- The README version-drift guard (`.github/workflows/readme-version-check.yml`) hard-failed when the README had no `**Status:**` line — even though the self-updating shields.io release badge cannot drift (dynamic endpoint, no static version string).
- Now the "no Status token" branch passes when the release badge is present, and fails only when *neither* a textual version nor the badge exists. Status-line behavior (equal / dotted-prefix match vs. latest tag) is unchanged.
- Closes the latent failure mode surfaced during #1447: #1456 dropped the Status line for the badge and turned this required check red until #1458 restored it.

## Test plan
- [x] YAML parses (`yaml.safe_load`) — valid
- [x] `shellcheck` on the embedded run script — clean
- [x] Behavioral test of the guard logic, 5 scenarios:
  - [x] badge present + no Status line → exit 0
  - [x] neither badge nor Status → exit 1
  - [x] Status matches latest tag (`v0.9.0`) → exit 0
  - [x] Status wrong (`v0.1`) → exit 1
  - [x] both badge + Status → exit 0
- [x] `git diff --name-only origin/main` → only `.github/workflows/readme-version-check.yml`
- [x] `permissions: contents: read` unchanged; action stays SHA-pinned; SPDX header retained

## Out of scope
- Parsing a version number out of the badge (there is none — presence is the only signal).

<!-- auto-implement-issue: fresh, iteration 1 -->

Closes #1459
