### PR TITLE
chore(tests): migrate testcontainers wait_for_logs(str) → LogMessageWaitStrategy across all fixtures

### DIFF
--- a/backend/tests/_strategies.py
+++ b/backend/tests/_strategies.py
@@ -1,0 +1,61 @@
+# SPDX-License-Identifier: Apache-2.0
+# Copyright (c) 2026 evoila Group
+
+"""Structured testcontainers wait strategies for the test fixtures.
+
+``testcontainers`` 4.x deprecated the string/callable form of
+``wait_for_logs(container, "msg", timeout=N)`` in favour of structured
+wait strategies. This module provides the one shape every fixture
+needs — "block until a log line appears, with a startup timeout" — so
+the migration is a single import instead of repeating the strategy
+construction (and the ``re.MULTILINE`` compile semantics) in each
+fixture.
+
+Usage::
+
+    from tests._strategies import wait_for_log_message
+
+    container.start()
+    wait_for_log_message(container, "Server started!", timeout=60)
+
+The call blocks until the message (a plain string compiled with
+``re.MULTILINE`` or a pre-compiled ``re.Pattern``) is found in the
+container's stdout/stderr, raising ``TimeoutError`` once the timeout
+elapses or ``RuntimeError`` if the container exits first — the same
+failure modes the deprecated ``wait_for_logs`` exposed, so existing
+``try/except`` fall-backs in the fixtures keep working unchanged.
+"""
+
+from __future__ import annotations
+
+import re
+from typing import TYPE_CHECKING
+
+from testcontainers.core.wait_strategies import LogMessageWaitStrategy
+
+if TYPE_CHECKING:
+    from testcontainers.core.waiting_utils import WaitStrategyTarget
+
+__all__ = ["wait_for_log_message"]
+
+
+def wait_for_log_message(
+    container: WaitStrategyTarget,
+    message: str | re.Pattern[str],
+    *,
+    timeout: float,
+) -> None:
+    """Block until ``message`` appears in ``container``'s logs.
+
+    Structured replacement for the deprecated
+    ``wait_for_logs(container, message, timeout=...)``. ``message`` is a
+    plain string (compiled internally with ``re.MULTILINE``) or a
+    pre-compiled ``re.Pattern``; ``timeout`` is the startup budget in
+    seconds.
+
+    Raises:
+        TimeoutError: the message did not appear within ``timeout``.
+        RuntimeError: the container exited before the message appeared.
+    """
+    strategy = LogMessageWaitStrategy(message).with_startup_timeout(timeout)
+    strategy.wait_until_ready(container)

--- a/backend/tests/acceptance/_vcsim.py
+++ b/backend/tests/acceptance/_vcsim.py
@@ -236,8 +236,8 @@ def _boot_vcsim_container(
 
     Yields one endpoint and tears the container down on context
     exit. The simulator emits ``export GOVC_URL=...`` to stdout once
-    the REST endpoint is serving; ``wait_for_logs`` blocks on that
-    line up to 30 s. Longer would mask a real boot failure as
+    the REST endpoint is serving; ``wait_for_log_message`` blocks on
+    that line up to 30 s. Longer would mask a real boot failure as
     flake; shorter risks slow CI runner pulls timing out before
     vcsim is ready.
     """
@@ -246,7 +246,8 @@ def _boot_vcsim_container(
     # the context manager lets the module collect on a no-Docker
     # sandbox (the env-var path doesn't reach here at all).
     from testcontainers.core.container import DockerContainer
-    from testcontainers.core.waiting_utils import wait_for_logs
+
+    from tests._strategies import wait_for_log_message
 
     image = os.environ.get("MEHO_TEST_VCSIM_IMAGE", "vmware/vcsim:latest")
     container = (
@@ -257,7 +258,7 @@ def _boot_vcsim_container(
 
     try:
         container.start()
-        wait_for_logs(container, "export GOVC_URL", timeout=30)
+        wait_for_log_message(container, "export GOVC_URL", timeout=30)
     except Exception:
         # Best-effort cleanup; surfacing the original boot exception
         # is more useful than the secondary stop() failure.

--- a/backend/tests/acceptance/test_g08_operations_call_vault_e2e.py
+++ b/backend/tests/acceptance/test_g08_operations_call_vault_e2e.py
@@ -165,7 +165,8 @@ def vault_dev_addr() -> Iterator[str]:
     # which probes the socket on import. Keeping it inside the fixture
     # lets the module collect on a no-Docker sandbox and skip cleanly.
     from testcontainers.core.container import DockerContainer
-    from testcontainers.core.waiting_utils import wait_for_logs
+
+    from tests._strategies import wait_for_log_message
 
     image = os.environ.get("MEHO_TEST_VAULT_IMAGE", "hashicorp/vault:1.18")
     container = (
@@ -185,7 +186,7 @@ def vault_dev_addr() -> Iterator[str]:
     container.start()
 
     try:
-        wait_for_logs(container, "Vault server started!", timeout=60)
+        wait_for_log_message(container, "Vault server started!", timeout=60)
         host = container.get_container_host_ip()
         port = container.get_exposed_port(8200)
         addr = f"http://{host}:{port}"

--- a/backend/tests/integration/conftest.py
+++ b/backend/tests/integration/conftest.py
@@ -749,7 +749,8 @@ def keycloak_bootstrap() -> Iterator[KeycloakBootstrap]:
     # which probes the socket on import, so keeping the import inside
     # the fixture lets the module collect on a no-Docker sandbox.
     from testcontainers.core.container import DockerContainer
-    from testcontainers.core.waiting_utils import wait_for_logs
+
+    from tests._strategies import wait_for_log_message
 
     realm_file = Path(__file__).parent / "_fixtures" / f"{_KEYCLOAK_REALM}-realm.json"
     if not realm_file.is_file():
@@ -799,7 +800,7 @@ def keycloak_bootstrap() -> Iterator[KeycloakBootstrap]:
         # "Listening on" prefix — the realm-import line that precedes
         # it is itself a useful but slightly Keycloak-version-specific
         # signal, so anchor on the Quarkus boot line instead.
-        wait_for_logs(container, "Listening on:", timeout=120)
+        wait_for_log_message(container, "Listening on:", timeout=120)
         host = container.get_container_host_ip()
         port = container.get_exposed_port(8080)
         base_url = f"http://{host}:{port}"

--- a/backend/tests/integration/test_connectors_bind9_container.py
+++ b/backend/tests/integration/test_connectors_bind9_container.py
@@ -179,7 +179,8 @@ def bind9_container_target() -> Iterator[_Bind9Target]:
     try:
         from testcontainers.core.container import DockerContainer
         from testcontainers.core.image import DockerImage
-        from testcontainers.core.waiting_utils import wait_for_logs
+
+        from tests._strategies import wait_for_log_message
     except ImportError as exc:  # pragma: no cover -- testcontainers ships these in 4.x
         pytest.skip(f"testcontainers missing module: {exc}")
 
@@ -204,11 +205,12 @@ def bind9_container_target() -> Iterator[_Bind9Target]:
         container.start()
         try:
             # Wait for sshd to log readiness before tests connect.
-            # ``wait_for_logs`` raises ``TimeoutError`` after 30 s of no
-            # match; we let it propagate so a regression in the inline
-            # entrypoint surfaces rather than silently skipping. The
-            # container is torn down in the outer ``finally`` regardless.
-            wait_for_logs(container, "Server listening on", timeout=30.0)
+            # ``wait_for_log_message`` raises ``TimeoutError`` after 30 s
+            # of no match; we let it propagate so a regression in the
+            # inline entrypoint surfaces rather than silently skipping.
+            # The container is torn down in the outer ``finally``
+            # regardless.
+            wait_for_log_message(container, "Server listening on", timeout=30.0)
             host = container.get_container_host_ip()
             port = int(container.get_exposed_port(22))
             # named starts in the background just before sshd; give

--- a/backend/tests/integration/test_connectors_harbor_container.py
+++ b/backend/tests/integration/test_connectors_harbor_container.py
@@ -158,7 +158,8 @@ def harbor_core_addr() -> Iterator[str]:
     # Late import: transitively probes Docker socket on import.
     from testcontainers.core.container import DockerContainer
     from testcontainers.core.network import Network
-    from testcontainers.core.waiting_utils import wait_for_logs
+
+    from tests._strategies import wait_for_log_message
 
     db_image = os.environ.get("MEHO_TEST_HARBOR_DB_IMAGE", "goharbor/harbor-db:v2.11.0")
     redis_image = os.environ.get("MEHO_TEST_HARBOR_REDIS_IMAGE", "redis:7-alpine")
@@ -218,7 +219,7 @@ def harbor_core_addr() -> Iterator[str]:
 
     try:
         # Give DB time to reach ready state before starting core.
-        wait_for_logs(db_container, "PostgreSQL init process complete", timeout=30)
+        wait_for_log_message(db_container, "PostgreSQL init process complete", timeout=30)
     except Exception:
         # Some harbor-db images don't log this line; fall through and
         # let core fail-fast if the DB isn't ready.
@@ -234,7 +235,7 @@ def harbor_core_addr() -> Iterator[str]:
 
     try:
         try:
-            wait_for_logs(core_container, "HTTP proxy is up", timeout=60)
+            wait_for_log_message(core_container, "HTTP proxy is up", timeout=60)
         except Exception:
             # Fall back: poll the /api/v2.0/systeminfo endpoint directly.
             host = core_container.get_container_host_ip()

--- a/backend/tests/integration/test_connectors_vault_creds_dev_e2e.py
+++ b/backend/tests/integration/test_connectors_vault_creds_dev_e2e.py
@@ -140,7 +140,8 @@ def vault_dev_addr() -> Iterator[str]:
     # which probes the socket on import. Keeping it inside the fixture
     # lets the module collect on a no-Docker sandbox and skip cleanly.
     from testcontainers.core.container import DockerContainer
-    from testcontainers.core.waiting_utils import wait_for_logs
+
+    from tests._strategies import wait_for_log_message
 
     image = os.environ.get("MEHO_TEST_VAULT_IMAGE", "hashicorp/vault:1.18")
     container = (
@@ -158,7 +159,7 @@ def vault_dev_addr() -> Iterator[str]:
         pytest.skip(f"vault dev container failed to start ({type(exc).__name__}): {exc}")
 
     try:
-        wait_for_logs(container, "Vault server started!", timeout=60)
+        wait_for_log_message(container, "Vault server started!", timeout=60)
         host = container.get_container_host_ip()
         port = container.get_exposed_port(8200)
         addr = f"http://{host}:{port}"

--- a/backend/tests/integration/test_connectors_vault_dev_e2e.py
+++ b/backend/tests/integration/test_connectors_vault_dev_e2e.py
@@ -190,7 +190,8 @@ def vault_dev_addr() -> Iterator[str]:
     # which probes the socket on import. Keeping it inside the fixture
     # lets the module collect on a no-Docker sandbox and skip cleanly.
     from testcontainers.core.container import DockerContainer
-    from testcontainers.core.waiting_utils import wait_for_logs
+
+    from tests._strategies import wait_for_log_message
 
     image = os.environ.get("MEHO_TEST_VAULT_IMAGE", "hashicorp/vault:1.18")
     container = (
@@ -212,7 +213,7 @@ def vault_dev_addr() -> Iterator[str]:
         # Vault logs this line once the dev server is unsealed and
         # serving; testcontainers polls the log stream until it appears
         # or the timeout trips.
-        wait_for_logs(container, "Vault server started!", timeout=60)
+        wait_for_log_message(container, "Vault server started!", timeout=60)
         host = container.get_container_host_ip()
         port = container.get_exposed_port(8200)
         addr = f"http://{host}:{port}"

--- a/backend/tests/integration/test_g3_4_bind9_e2e.py
+++ b/backend/tests/integration/test_g3_4_bind9_e2e.py
@@ -301,9 +301,8 @@ def bind9_container_target() -> Iterator[tuple[_Bind9Target, _ContainerCreds]]:
     try:
         from testcontainers.core.container import DockerContainer  # type: ignore[import-untyped]
         from testcontainers.core.image import DockerImage  # type: ignore[import-untyped]
-        from testcontainers.core.waiting_utils import (  # type: ignore[import-untyped]
-            wait_for_logs,
-        )
+
+        from tests._strategies import wait_for_log_message
     except ImportError as exc:  # pragma: no cover -- testcontainers ships these in 4.x
         pytest.skip(f"testcontainers missing module: {exc}")
 
@@ -318,7 +317,7 @@ def bind9_container_target() -> Iterator[tuple[_Bind9Target, _ContainerCreds]]:
         container = DockerContainer(tag).with_exposed_ports(22)
         container.start()
         try:
-            wait_for_logs(container, "Server listening on", timeout=30.0)
+            wait_for_log_message(container, "Server listening on", timeout=30.0)
             host = container.get_container_host_ip()
             port = int(container.get_exposed_port(22))
             # named starts in the background just before sshd; give


### PR DESCRIPTION
## Summary
- Migrate every testcontainers `wait_for_logs(container, <str>, timeout=N)` call to the structured `LogMessageWaitStrategy` API, which testcontainers 4.x deprecated the string/callable predicate form of (the `DeprecationWarning` from `testcontainers.core.waiting_utils` fired on every container-fixture boot).
- Add one shared helper `tests/_strategies.wait_for_log_message(container, message, *, timeout=...)` wrapping `LogMessageWaitStrategy(message).with_startup_timeout(timeout).wait_until_ready(container)` — the documented 4.x replacement — and route all eight call sites through it (six in `tests/integration/`, two in `tests/acceptance/`).
- Behaviour preserved: plain strings keep `re.MULTILINE` compile semantics, per-call timeouts are unchanged, and the same `TimeoutError` / `RuntimeError` failure modes propagate so the fixtures' existing `try/except` fall-backs keep working. Predicate-API migration only — no timeout/retry/container-shape changes (per the issue's Out-of-scope).

## Test plan
- [x] `ruff check` on all 9 touched files — clean
- [x] `ruff format --check` — clean (9 files already formatted)
- [x] `mypy tests/_strategies.py --ignore-missing-imports` — Success, no issues
- [x] `code-quality.py --diff` — exit 0
- [x] **No `wait_for_logs` deprecation:** `uv run pytest tests/integration/ -W "error::DeprecationWarning:testcontainers.core.waiting_utils"` → 19 passed, 185 skipped, 0 errors (the deprecation source named in the issue is escalated to an error and never fires). `grep -rn wait_for_logs tests/` confirms zero remaining call sites — only docstring references in `_strategies.py` remain.
- [x] Every affected fixture's `wait_for_logs(...)` call replaced with the structured equivalent.
- [x] Helper semantics smoke-tested: returns on match, raises `TimeoutError` on no-match within the startup budget, emits no `DeprecationWarning`.
- [ ] `Python (integration testcontainers)` green in CI — runs under Docker on the runner (container fixtures skip cleanly in the no-Docker sandbox).

## Notes
- The issue's literal AC command `pytest tests/integration/ -W error::DeprecationWarning` escalates *all* deprecations, including pre-existing unrelated ones (Python 3.12 sqlite3 datetime adapter, `authlib.jose`) that exist on `main` independent of this change. The contract — confirmed by the issue's "Source of the deprecation: `testcontainers.core.waiting_utils.wait_for_logs`" and the predicate-API-only scope — is that the **`wait_for_logs` deprecation specifically** is gone, which the scoped run above proves and the zero-call-site grep makes airtight.
- Helper placed at `tests/_strategies.py` (the `tests/` package root, matching the existing `tests/_*.py` helper convention) rather than `tests/integration/_strategies.py` as the issue sketched, so the two `tests/acceptance/` fixtures can import it too.

## Out of scope
- Reworking timeouts / retry counts / container shape — predicate-API migration only.
- Migrating off testcontainers-python or adding a different container runner.

<!-- auto-implement-issue: fresh, iteration 1 -->

Closes #1111


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Tests**
  * Introduced a new helper utility for consistent container readiness checks across test suites.
  * Standardized container startup synchronization logic, improving test reliability and consistency.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->