### PR TITLE
fix(connectors): reject null data values in vault.kv.patch schema

### DIFF
--- a/backend/src/meho_backplane/connectors/vault/ops.py
+++ b/backend/src/meho_backplane/connectors/vault/ops.py
@@ -514,37 +514,64 @@ async def vault_kv_put(operator: Operator, target: Any, params: dict[str, Any]) 
 #: result as a new version. hvac's ``patch`` exposes no ``cas`` guard
 #: (it issues its own internal read+write), so the schema omits one.
 #:
-#: ``data``'s ``additionalProperties`` subschema pins each value to a
-#: non-null JSON type (``string``/``number``/``boolean``/``object``/
-#: ``array``). This is load-bearing: hvac's ``secrets.kv.v2.patch`` uses
-#: HashiCorp Vault's JSON Merge Patch (RFC 7396), under which a ``null``
-#: value **deletes** the key rather than setting it. The op is
-#: documented as add/overwrite-only (keys absent from ``data`` are
-#: preserved, keys present are added/overwritten), so a ``null`` slipping
-#: through would silently delete a secret field — a contract the schema
-#: now rejects at validation time (``invalid_params``). Field deletion,
-#: when wanted, goes through ``kv.put`` (wholesale replace) or
+#: ``data``'s values are constrained to a *recursive* non-null JSON
+#: subschema (:data:`_NON_NULL_JSON_VALUE_REF` → ``#/$defs/nonNullJsonValue``):
+#: a value may be a ``string``/``number``/``boolean``, or an ``object``
+#: whose every value recurses the same constraint, or an ``array`` whose
+#: every item recurses it — but never ``null`` at *any* depth. This is
+#: load-bearing: hvac's ``secrets.kv.v2.patch`` uses HashiCorp Vault's
+#: JSON Merge Patch (RFC 7396), whose merge algorithm is **recursive** —
+#: a ``null`` value deletes its key whether it sits at the top level or
+#: nested inside a merged object. The op is documented as
+#: add/overwrite-only (keys absent from ``data`` are preserved, keys
+#: present are added/overwritten), so a ``null`` slipping through at any
+#: nesting depth would silently delete a secret field — a contract the
+#: schema now rejects at validation time (``invalid_params``). Field
+#: deletion, when wanted, goes through ``kv.put`` (wholesale replace) or
 #: ``kv.delete`` (version soft-delete), not a surprising side effect of
 #: patch.
+#:
+#: ``$defs``/``$ref`` resolve as a same-document reference: the
+#: dispatcher constructs ``Draft202012Validator(parameter_schema)`` with
+#: this dict as the root, so ``#/$defs/nonNullJsonValue`` resolves
+#: against it without an external registry.
+_NON_NULL_JSON_VALUE_REF: dict[str, Any] = {"$ref": "#/$defs/nonNullJsonValue"}
+
 VAULT_KV_PATCH_PARAMETER_SCHEMA: dict[str, Any] = {
     "type": "object",
+    "$defs": {
+        # A JSON value that contains no ``null`` at any depth: a scalar,
+        # an object whose values recurse this same constraint, or an
+        # array whose items recurse it. Mirrors RFC 7396's recursive
+        # merge so a nested ``null`` cannot reach Vault as a key DELETE.
+        "nonNullJsonValue": {
+            "oneOf": [
+                {"type": ["string", "number", "boolean"]},
+                {
+                    "type": "object",
+                    "additionalProperties": _NON_NULL_JSON_VALUE_REF,
+                },
+                {"type": "array", "items": _NON_NULL_JSON_VALUE_REF},
+            ],
+        },
+    },
     "properties": {
         "mount": _MOUNT_PROPERTY,
         "path": _PATH_PROPERTY,
         "data": {
             "type": "object",
             "minProperties": 1,
-            "additionalProperties": {
-                "type": ["string", "number", "boolean", "object", "array"],
-            },
+            "additionalProperties": _NON_NULL_JSON_VALUE_REF,
             "description": (
                 "Fields to merge onto the current version. Unlike "
                 "kv.put this is a partial — keys present here are added "
                 "or overwritten; keys absent here are preserved from the "
-                "current version. Values may not be null: Vault's JSON "
-                "Merge Patch treats a null value as a key DELETE, which "
-                "this add/overwrite-only op rejects (use kv.put or "
-                "kv.delete to remove data). The secret must already exist."
+                "current version. Values may not be null at any depth: "
+                "Vault's JSON Merge Patch recurses, treating a null value "
+                "as a key DELETE whether it is top-level or nested inside "
+                "a merged object/array, which this add/overwrite-only op "
+                "rejects (use kv.put or kv.delete to remove data). The "
+                "secret must already exist."
             ),
         },
     },
@@ -579,10 +606,12 @@ _VAULT_KV_PATCH_LLM_INSTRUCTIONS: dict[str, Any] = {
         "data": (
             "Required. The fields to merge. Only these keys are "
             "added/overwritten; every other key on the current version "
-            "is carried forward unchanged. Values must not be null — "
-            "Vault's JSON Merge Patch reads a null as 'delete this key', "
-            "which this add/overwrite-only op rejects. To remove a field, "
-            "use kv.put (full replace) or kv.delete (version soft-delete)."
+            "is carried forward unchanged. Values must not be null at any "
+            "depth — Vault's JSON Merge Patch recurses and reads a null "
+            "(top-level or nested inside a merged object/array) as 'delete "
+            "this key', which this add/overwrite-only op rejects. To remove "
+            "a field, use kv.put (full replace) or kv.delete (version "
+            "soft-delete)."
         ),
     },
     "output_shape": (
@@ -609,13 +638,15 @@ async def vault_kv_patch(operator: Operator, target: Any, params: dict[str, Any]
     malformed hvac payload.
 
     JSON Merge Patch (RFC 7396) — which hvac's ``patch`` uses — treats a
-    ``null`` value as a key DELETE. To keep this op genuinely
-    add/overwrite-only, :data:`VAULT_KV_PATCH_PARAMETER_SCHEMA` pins each
-    ``data`` value to a non-null type, so a ``null`` is rejected as
-    ``invalid_params`` before reaching Vault rather than silently
-    deleting a secret field. Field removal goes through
-    :func:`vault_kv_put` (wholesale replace) or :func:`vault_kv_delete`
-    (version soft-delete).
+    ``null`` value as a key DELETE, and its merge algorithm is
+    *recursive*: a ``null`` nested inside a merged object deletes that
+    nested key too. To keep this op genuinely add/overwrite-only at every
+    depth, :data:`VAULT_KV_PATCH_PARAMETER_SCHEMA` constrains each
+    ``data`` value to a recursive non-null JSON subschema, so a ``null``
+    anywhere in the payload is rejected as ``invalid_params`` before
+    reaching Vault rather than silently deleting a secret field. Field
+    removal goes through :func:`vault_kv_put` (wholesale replace) or
+    :func:`vault_kv_delete` (version soft-delete).
     """
     mount: str = str(params.get("mount", _DEFAULT_KV_MOUNT)).strip()
     path: str = str(params["path"]).strip()

--- a/backend/src/meho_backplane/connectors/vault/ops.py
+++ b/backend/src/meho_backplane/connectors/vault/ops.py
@@ -513,6 +513,19 @@ async def vault_kv_put(operator: Operator, target: Any, params: dict[str, Any]) 
 #: the current version, JSON-merges ``data`` over it, and writes the
 #: result as a new version. hvac's ``patch`` exposes no ``cas`` guard
 #: (it issues its own internal read+write), so the schema omits one.
+#:
+#: ``data``'s ``additionalProperties`` subschema pins each value to a
+#: non-null JSON type (``string``/``number``/``boolean``/``object``/
+#: ``array``). This is load-bearing: hvac's ``secrets.kv.v2.patch`` uses
+#: HashiCorp Vault's JSON Merge Patch (RFC 7396), under which a ``null``
+#: value **deletes** the key rather than setting it. The op is
+#: documented as add/overwrite-only (keys absent from ``data`` are
+#: preserved, keys present are added/overwritten), so a ``null`` slipping
+#: through would silently delete a secret field — a contract the schema
+#: now rejects at validation time (``invalid_params``). Field deletion,
+#: when wanted, goes through ``kv.put`` (wholesale replace) or
+#: ``kv.delete`` (version soft-delete), not a surprising side effect of
+#: patch.
 VAULT_KV_PATCH_PARAMETER_SCHEMA: dict[str, Any] = {
     "type": "object",
     "properties": {
@@ -521,11 +534,17 @@ VAULT_KV_PATCH_PARAMETER_SCHEMA: dict[str, Any] = {
         "data": {
             "type": "object",
             "minProperties": 1,
+            "additionalProperties": {
+                "type": ["string", "number", "boolean", "object", "array"],
+            },
             "description": (
                 "Fields to merge onto the current version. Unlike "
                 "kv.put this is a partial — keys present here are added "
                 "or overwritten; keys absent here are preserved from the "
-                "current version. The secret must already exist."
+                "current version. Values may not be null: Vault's JSON "
+                "Merge Patch treats a null value as a key DELETE, which "
+                "this add/overwrite-only op rejects (use kv.put or "
+                "kv.delete to remove data). The secret must already exist."
             ),
         },
     },
@@ -560,7 +579,10 @@ _VAULT_KV_PATCH_LLM_INSTRUCTIONS: dict[str, Any] = {
         "data": (
             "Required. The fields to merge. Only these keys are "
             "added/overwritten; every other key on the current version "
-            "is carried forward unchanged."
+            "is carried forward unchanged. Values must not be null — "
+            "Vault's JSON Merge Patch reads a null as 'delete this key', "
+            "which this add/overwrite-only op rejects. To remove a field, "
+            "use kv.put (full replace) or kv.delete (version soft-delete)."
         ),
     },
     "output_shape": (
@@ -585,6 +607,15 @@ async def vault_kv_patch(operator: Operator, target: Any, params: dict[str, Any]
     already exist; patching a missing path raises (surfaced as a
     structured ``connector_error``). The structural unwrap raises on a
     malformed hvac payload.
+
+    JSON Merge Patch (RFC 7396) — which hvac's ``patch`` uses — treats a
+    ``null`` value as a key DELETE. To keep this op genuinely
+    add/overwrite-only, :data:`VAULT_KV_PATCH_PARAMETER_SCHEMA` pins each
+    ``data`` value to a non-null type, so a ``null`` is rejected as
+    ``invalid_params`` before reaching Vault rather than silently
+    deleting a secret field. Field removal goes through
+    :func:`vault_kv_put` (wholesale replace) or :func:`vault_kv_delete`
+    (version soft-delete).
     """
     mount: str = str(params.get("mount", _DEFAULT_KV_MOUNT)).strip()
     path: str = str(params["path"]).strip()

--- a/backend/tests/test_connectors_vault.py
+++ b/backend/tests/test_connectors_vault.py
@@ -791,6 +791,8 @@ async def test_execute_vault_kv_patch_honors_explicit_mount(
         {"path": "p", "data": {"k": "v"}, "cas": 1},
         {"path": "p", "data": {"token": None}},
         {"path": "p", "data": {"keep": "v", "drop": None}},
+        {"path": "p", "data": {"creds": {"old": None}}},
+        {"path": "p", "data": {"items": [1, None]}},
     ],
     ids=[
         "missing-data",
@@ -799,6 +801,8 @@ async def test_execute_vault_kv_patch_honors_explicit_mount(
         "rejects-cas",
         "rejects-null-value",
         "rejects-null-among-non-null",
+        "rejects-nested-object-null",
+        "rejects-nested-array-null",
     ],
 )
 async def test_execute_vault_kv_patch_invalid_params_returns_dispatcher_error(
@@ -815,10 +819,13 @@ async def test_execute_vault_kv_patch_invalid_params_returns_dispatcher_error(
 
     A ``null`` data value is also rejected: hvac's ``patch`` uses JSON
     Merge Patch (RFC 7396), under which ``null`` *deletes* the key. The
-    op is documented add/overwrite-only, so the ``data``
-    ``additionalProperties`` subschema pins each value to a non-null
-    type and a ``null`` surfaces as ``invalid_params`` before it can
-    silently delete a secret field.
+    op is documented add/overwrite-only, so the ``data`` schema pins each
+    value to a *recursive* non-null subschema and a ``null`` surfaces as
+    ``invalid_params`` before it can silently delete a secret field. The
+    recursion matters because RFC 7396 merges nested objects too: a
+    nested ``null`` (``{"creds": {"old": None}}``) or an array element
+    ``null`` (``{"items": [1, None]}``) is rejected just like a
+    top-level one.
     """
     install_fake_client(monkeypatch)
     result = await _dispatch_vault("vault.kv.patch", params)
@@ -846,6 +853,36 @@ def test_vault_kv_patch_schema_rejects_null_data_value() -> None:
 
     assert validator.is_valid({"path": "meho/test", "data": {"token": "v"}})
     assert not validator.is_valid({"path": "meho/test", "data": {"token": None}})
+
+
+def test_vault_kv_patch_schema_rejects_nested_null_data_value() -> None:
+    """Schema-level guard: a ``null`` *nested* in ``data`` fails validation.
+
+    RFC 7396 JSON Merge Patch — which hvac's ``patch`` uses — recurses,
+    so ``{"creds": {"old": null}}`` deletes the nested ``old`` key just
+    like a top-level ``null`` would. The ``data`` schema therefore
+    constrains values with a *recursive* non-null subschema
+    (``$defs/nonNullJsonValue``): a ``null`` at any object/array nesting
+    depth must fail validation, while equivalent non-null nested
+    structures still validate. Without this, the top-level-only guard
+    would let a nested ``null`` reach Vault and silently delete a field —
+    the exact contract gap #1435 was filed to close.
+    """
+    from jsonschema import Draft202012Validator
+
+    from meho_backplane.connectors.vault.ops import VAULT_KV_PATCH_PARAMETER_SCHEMA
+
+    validator = Draft202012Validator(VAULT_KV_PATCH_PARAMETER_SCHEMA)
+
+    # Non-null nested object/array structures validate.
+    assert validator.is_valid({"path": "meho/test", "data": {"creds": {"user": "u", "pass": "p"}}})
+    assert validator.is_valid({"path": "meho/test", "data": {"items": [1, "two", True]}})
+    assert validator.is_valid({"path": "meho/test", "data": {"a": {"b": {"c": "deep"}}}})
+
+    # A null anywhere in the nested structure is rejected.
+    assert not validator.is_valid({"path": "meho/test", "data": {"creds": {"old": None}}})
+    assert not validator.is_valid({"path": "meho/test", "data": {"items": [1, None]}})
+    assert not validator.is_valid({"path": "meho/test", "data": {"a": {"b": {"c": None}}}})
 
 
 async def test_execute_vault_kv_versions_returns_metadata(

--- a/backend/tests/test_connectors_vault.py
+++ b/backend/tests/test_connectors_vault.py
@@ -789,20 +789,36 @@ async def test_execute_vault_kv_patch_honors_explicit_mount(
         {"data": {"k": "v"}},
         {"path": "p", "data": {}},
         {"path": "p", "data": {"k": "v"}, "cas": 1},
+        {"path": "p", "data": {"token": None}},
+        {"path": "p", "data": {"keep": "v", "drop": None}},
     ],
-    ids=["missing-data", "missing-path", "empty-data", "rejects-cas"],
+    ids=[
+        "missing-data",
+        "missing-path",
+        "empty-data",
+        "rejects-cas",
+        "rejects-null-value",
+        "rejects-null-among-non-null",
+    ],
 )
 async def test_execute_vault_kv_patch_invalid_params_returns_dispatcher_error(
     monkeypatch: pytest.MonkeyPatch,
     params: dict[str, Any],
     _registered_vault_typed_ops: None,
 ) -> None:
-    """Schema enforces required path+data, minProperties on data, and rejects ``cas``.
+    """Schema enforces required path+data, minProperties, rejects ``cas`` and null values.
 
     hvac's ``patch`` exposes no ``cas`` guard (it issues its own
     internal read+write), so the schema's ``additionalProperties=False``
     turns a stray ``cas`` into an ``invalid_params`` error rather than
     silently dropping it.
+
+    A ``null`` data value is also rejected: hvac's ``patch`` uses JSON
+    Merge Patch (RFC 7396), under which ``null`` *deletes* the key. The
+    op is documented add/overwrite-only, so the ``data``
+    ``additionalProperties`` subschema pins each value to a non-null
+    type and a ``null`` surfaces as ``invalid_params`` before it can
+    silently delete a secret field.
     """
     install_fake_client(monkeypatch)
     result = await _dispatch_vault("vault.kv.patch", params)
@@ -811,6 +827,25 @@ async def test_execute_vault_kv_patch_invalid_params_returns_dispatcher_error(
     assert result.error is not None
     assert result.error.startswith("invalid_params:")
     assert result.extras.get("error_code") == "invalid_params"
+
+
+def test_vault_kv_patch_schema_rejects_null_data_value() -> None:
+    """Schema-level guard: a ``null`` ``data`` value fails validation.
+
+    Asserts the contract directly against
+    :data:`VAULT_KV_PATCH_PARAMETER_SCHEMA` so it holds independently of
+    the dispatcher wiring. A non-null value of the same shape validates;
+    swapping it for ``null`` does not — matching the add/overwrite-only
+    docs (a JSON-Merge-Patch ``null`` would otherwise delete the key).
+    """
+    from jsonschema import Draft202012Validator
+
+    from meho_backplane.connectors.vault.ops import VAULT_KV_PATCH_PARAMETER_SCHEMA
+
+    validator = Draft202012Validator(VAULT_KV_PATCH_PARAMETER_SCHEMA)
+
+    assert validator.is_valid({"path": "meho/test", "data": {"token": "v"}})
+    assert not validator.is_valid({"path": "meho/test", "data": {"token": None}})
 
 
 async def test_execute_vault_kv_versions_returns_metadata(

--- a/docs/codebase/connectors-vault.md
+++ b/docs/codebase/connectors-vault.md
@@ -260,16 +260,21 @@ exist (patching a missing path fails). `patch` exposes no `cas` guard
 unlike `kv.put` — has no `cas` property and `additionalProperties=False`
 rejects a stray one.
 
-`kv.patch` is **add/overwrite-only**: its `data` schema constrains each
-value to a non-null JSON type (`string`/`number`/`boolean`/`object`/
-`array`). This is deliberate. hvac's `secrets.kv.v2.patch` speaks JSON
-Merge Patch (RFC 7396), under which a `null` value **deletes** the key
-rather than setting it. Allowing `null` would let a caller silently
-delete a secret field through an op documented as additive, so the
-schema rejects a null value at validation time (`invalid_params`)
-before it reaches Vault. Field removal is an explicit operation: use
-`kv.put` to replace the version wholesale (omitted keys drop) or
-`kv.delete` to soft-delete a version — never a side effect of `patch`.
+`kv.patch` is **add/overwrite-only at every depth**: its `data` schema
+constrains each value to a *recursive* non-null JSON subschema
+(`$defs/nonNullJsonValue`) — a scalar (`string`/`number`/`boolean`), or
+an `object` whose values recurse the same constraint, or an `array`
+whose items recurse it, but never `null` at any nesting level. This is
+deliberate. hvac's `secrets.kv.v2.patch` speaks JSON Merge Patch
+(RFC 7396), whose merge algorithm is **recursive**: a `null` value
+**deletes** its key whether it sits at the top level or nested inside a
+merged object. A top-level-only guard would still let
+`{"data": {"creds": {"old": null}}}` reach Vault and delete the nested
+`old` key, contradicting the additive contract — so the schema rejects a
+`null` at any depth at validation time (`invalid_params`) before it
+reaches Vault. Field removal is an explicit operation: use `kv.put` to
+replace the version wholesale (omitted keys drop) or `kv.delete` to
+soft-delete a version — never a side effect of `patch`.
 
 **Mount handling.** Every handler — including `vault.kv.read` —
 accepts an optional `mount` param (JSON Schema default `"secret"`,

--- a/docs/codebase/connectors-vault.md
+++ b/docs/codebase/connectors-vault.md
@@ -260,6 +260,17 @@ exist (patching a missing path fails). `patch` exposes no `cas` guard
 unlike `kv.put` — has no `cas` property and `additionalProperties=False`
 rejects a stray one.
 
+`kv.patch` is **add/overwrite-only**: its `data` schema constrains each
+value to a non-null JSON type (`string`/`number`/`boolean`/`object`/
+`array`). This is deliberate. hvac's `secrets.kv.v2.patch` speaks JSON
+Merge Patch (RFC 7396), under which a `null` value **deletes** the key
+rather than setting it. Allowing `null` would let a caller silently
+delete a secret field through an op documented as additive, so the
+schema rejects a null value at validation time (`invalid_params`)
+before it reaches Vault. Field removal is an explicit operation: use
+`kv.put` to replace the version wholesale (omitted keys drop) or
+`kv.delete` to soft-delete a version — never a side effect of `patch`.
+
 **Mount handling.** Every handler — including `vault.kv.read` —
 accepts an optional `mount` param (JSON Schema default `"secret"`,
 mirroring hvac's `mount_point` default) forwarded as hvac's


### PR DESCRIPTION
## Summary

- `vault.kv.patch` (G3.15-T1 #1409) delegates to hvac's `secrets.kv.v2.patch`, which speaks JSON Merge Patch (RFC 7396): a `null` value **deletes** the key. The op is documented add/overwrite-only, but its `data` schema permitted `null` — letting a caller silently delete a secret field through an op that never advertises deletion (CodeRabbit M1 on #1426).
- Resolved per the issue's preferred **Option 1 (reject `null`)**: the `data` `additionalProperties` subschema now pins each value to a non-null JSON type (`string`/`number`/`boolean`/`object`/`array`), so a `null` fails validation as `invalid_params` before reaching Vault. Field removal stays explicit via `kv.put` (wholesale replace) or `kv.delete` (version soft-delete).
- Schema, handler docstring, `llm_instructions`, and `docs/codebase/connectors-vault.md` now all agree the op is add/overwrite-only.

Chose Option 1 because the op's docs were already uniformly additive, KV-v2 already exposes explicit deletion paths (`kv.put`/`kv.delete`), and the issue names Option 1 the lower-surprise default absent a wanted delete-via-patch capability — none exists here.

## Test plan

- [x] `ruff check` (ops.py, test file) — clean
- [x] `ruff format --check` — clean
- [x] `mypy src/.../vault/ops.py` — clean
- [x] `pytest tests/test_connectors_vault.py` — 64 passed (added 2 dispatcher param cases + 1 schema-level test)
- [x] `pytest tests/test_broadcast_events.py` — 83 passed (no regression)
- [x] `code-quality.py --diff` — 0 blockers
- [x] Acceptance: schema + docs consistent (null rejected, add/overwrite-only); unit test `test_vault_kv_patch_schema_rejects_null_data_value` asserts the schema rejects a `null` data value
- [x] CLI snapshot regen (`make snapshot-openapi && make generate`) — ran; no change to `cli/api/openapi.json` (typed-op param schemas live in `endpoint_descriptor`/`describe_operation`, not the static OpenAPI doc)

## Out of scope

- Other vault ops; the approval-gating posture (unchanged per the issue).

<!-- auto-implement-issue: fresh, iteration 1 -->

Closes #1435
