### PR TITLE
test(connectors): assert composite preflight dispatch did not generically error (#1436)

### DIFF
--- a/backend/tests/test_connectors_vmware_rest_composites_write_e2e.py
+++ b/backend/tests/test_connectors_vmware_rest_composites_write_e2e.py
@@ -538,6 +538,8 @@ async def test_write_composite_passes_preflight_through_dispatch(
     """
     await _bootstrap_registry(stub_embedding_service)
     await _clear_requires_approval(set(_WRITE_COMPOSITES))
+    for op_id, payload in _benign_responses_for(composite_op_id).items():
+        _RESPONSES[op_id] = payload
 
     operator = _make_operator()
     target = _FakeVmwareTarget()
@@ -559,6 +561,17 @@ async def test_write_composite_passes_preflight_through_dispatch(
     # here; the point is the L2 dependency walk resolved every declared
     # ``_SUB_OPS_*`` op_id against the registered descriptor set.
     assert "composite_l2_missing" not in (result.error or ""), result.error
+    # AC1 (#1436): a *non*-``composite_l2_missing`` failure would still
+    # satisfy the negative check above — an ``unknown_op`` /
+    # ``invalid_params`` / ``connector_error`` generic error has a
+    # different error text yet is plainly not a passing pre-flight. Pin
+    # the positive outcome too (``status != "error"``) so only a genuine
+    # pre-flight pass through the production dispatch path satisfies the
+    # test. The benign leaf responses above let every composite reach its
+    # no-work business status (``OperationResult.status`` ∈ {ok, pending}),
+    # never a generic execution error.
+    assert result.status != "error", result.error
+    assert result.status in {"ok", "pending"}, (result.status, result.error)
 
 
 def _benign_params_for(composite_op_id: str) -> dict[str, Any]:
@@ -592,6 +605,49 @@ def _benign_params_for(composite_op_id: str) -> dict[str, Any]:
         },
         "vmware.composite.cluster.patch": {"cluster": "domain-c1"},
     }[composite_op_id]
+
+
+def _benign_responses_for(composite_op_id: str) -> dict[str, Any]:
+    """Per-op leaf responses that steer each composite to a no-work status.
+
+    The recorder's default leaf payload is ``{"value": {}}`` (an empty
+    *object* envelope). Composites whose first sub-op is a listing read
+    unwrap ``value`` and expect a *list*; the empty-object default trips
+    their ``isinstance(..., list)`` guard and raises ``RuntimeError`` —
+    surfacing as a generic ``connector_error`` (``status='error'``), which
+    is exactly the non-``composite_l2_missing`` failure AC1 (#1436) now
+    rejects. Returning an empty *list* envelope for those listing ops lets
+    the composite short-circuit to its benign no-work business status
+    (``no_recommendation`` / ``detached`` / ``completed`` / ...) so the
+    strengthened ``status != "error"`` assertion checks a genuine
+    pre-flight pass rather than masking an execution error.
+
+    ``vm.clone`` is fire-and-forget here (``wait_for_completion=False``):
+    it reads the source VM (the empty-object default is a valid non-list
+    payload) then deploys, so it needs a deploy envelope carrying a task
+    id to reach the benign ``pending`` status without a poll.
+    """
+    empty_listing: dict[str, Any] = {"value": []}
+    per_composite: dict[str, dict[str, Any]] = {
+        "vmware.composite.vm.create": {"GET:/vcenter/folder": empty_listing},
+        "vmware.composite.vm.clone": {
+            "POST:/vcenter/vm-template/library-items?action=deploy": {
+                "value": {"task": "task-benign"}
+            },
+        },
+        "vmware.composite.vm.snapshot.revert": {"GET:/vcenter/vm/{vm}/snapshot": empty_listing},
+        "vmware.composite.vm.migrate": {
+            "GET:/vcenter/cluster/{cluster}/drs/recommendations": empty_listing,
+        },
+        "vmware.composite.vm.power.bulk": {"GET:/vcenter/vm": empty_listing},
+        "vmware.composite.host.evacuate": {"GET:/vcenter/vm": empty_listing},
+        "vmware.composite.host.detach_from_vds": {
+            "GET:/vcenter/network/distributed-portgroup": empty_listing,
+            "GET:/vcenter/vm": empty_listing,
+        },
+        "vmware.composite.cluster.patch": {"GET:/vcenter/cluster/{cluster}/host": empty_listing},
+    }
+    return per_composite[composite_op_id]
 
 
 # ===========================================================================


### PR DESCRIPTION
## Summary
- Strengthen the G3.16-T2 AC1 preflight test so a genuine pre-flight pass — not any non-`composite_l2_missing` outcome — is the only thing that satisfies it. CodeRabbit flagged this as Major (M1) on #1432.
- Add `assert result.status != "error"` (plus `status in {ok, pending}`) on top of the existing `composite_l2_missing` negative check, so a generic `connector_error` / `unknown_op` / `invalid_params` failure can no longer masquerade as a passing pre-flight.
- Feed each composite minimal benign leaf responses (empty-list envelopes for listing ops; a deploy-task envelope for fire-and-forget `vm.clone`) so every composite reaches its real no-work business status instead of tripping its own list-shape guard on the recorder's empty-object default and raising a `RuntimeError`.

## Test plan
- [x] `ruff check` — clean
- [x] `ruff format --check` — clean
- [x] mypy — no net-new errors (tests/ is outside `[tool.mypy] files = ["src"]`; pre-existing baseline count unchanged)
- [x] `pytest tests/test_connectors_vmware_rest_composites_write_e2e.py` — 27 passed
- [x] AC1: the 8-composite parametrization passes with both assertions (no `composite_l2_missing` AND `status != "error"`)
- [x] AC3: a deliberately unregistered leaf still trips the test (verified via scratch sabotage → `composite_l2_missing` → fails); a generic `connector_error` (non-l2-missing) also now trips it via the status check
- [x] `.claude/hooks/code-quality.py --diff` — exit 0

## Out of scope
- Live ingest/enable operator step (G3.16-T1 runbook) and production composite code — this is a test-only change.

<!-- auto-implement-issue: fresh, iteration 1 -->

Closes #1436
