### PR TITLE
fix(connectors): strip whitespace from Vault credentials + surface Keycloak token error_description

### DIFF
--- a/backend/src/meho_backplane/connectors/_shared/vault_creds.py
+++ b/backend/src/meho_backplane/connectors/_shared/vault_creds.py
@@ -85,6 +85,7 @@ __all__ = [
     "VaultCredentialsReadError",
     "load_basic_credentials",
     "load_vault_secret_data",
+    "strip_credential_value",
 ]
 
 #: KV-v2 mount the consumer convention addresses secrets under. Dev mode
@@ -98,6 +99,26 @@ DEFAULT_KV_MOUNT: str = "secret"
 #: needs. Kept as a module constant so connector loaders and tests share
 #: one source of truth.
 DEFAULT_BASIC_CREDENTIAL_FIELDS: tuple[str, ...] = ("username", "password")
+
+
+def strip_credential_value(value: object) -> str:
+    """Coerce a Vault secret field to the credential string sent upstream.
+
+    Coerces to ``str`` (a numeric secret field round-trips as the string a
+    vendor expects) and strips surrounding whitespace -- above all a trailing
+    newline, the single most common secret-storage artifact: ``echo`` without
+    ``-n``, ``jq -r``, a text editor's final newline, ``vault kv put k=@file``
+    on a file ending in ``\\n``, a ``k=-`` heredoc. A connector forwards the
+    field **verbatim** in a Basic-auth header, a Bearer token, or a
+    token-request body, so a stray ``\\n`` turns a valid secret into an
+    upstream 401/``unauthorized_client`` that reads like a permissions, realm,
+    or grant-config problem -- a multi-hour chase for a one-byte artifact. No
+    vendor credential legitimately carries leading or trailing whitespace, so
+    stripping is always safe and is applied to every credential field every
+    connector loads from Vault. Internal whitespace is preserved -- only the
+    surrounding artifact is removed.
+    """
+    return str(value).strip()
 
 
 @runtime_checkable
@@ -250,8 +271,11 @@ def _extract_fields(
 
     A missing field raises :class:`VaultCredentialsReadError` naming the
     target + field + ``secret_ref`` — never a bare ``KeyError``. Present
-    values are coerced to ``str`` so a numeric secret field round-trips as
-    the string a vendor Basic-auth header expects.
+    values run through :func:`strip_credential_value` (coerced to ``str``
+    and surrounding-whitespace-stripped) so a numeric secret field
+    round-trips as a string and a trailing newline — the most common
+    secret-storage artifact — never reaches a vendor Basic-auth header or
+    token-request body as a verbatim ``\n``.
     """
     credentials: dict[str, str] = {}
     for field in fields:
@@ -260,7 +284,7 @@ def _extract_fields(
                 f"vault secret for target {target_name!r} (secret_ref={secret_ref!r}) "
                 f"is missing required field {field!r}"
             )
-        credentials[field] = str(secret_data[field])
+        credentials[field] = strip_credential_value(secret_data[field])
     return credentials
 
 
@@ -303,9 +327,11 @@ async def load_basic_credentials(
     Returns
     -------
     dict[str, str]
-        ``{field: value}`` for every name in *fields*. Values are
-        coerced to ``str`` so a numeric secret field round-trips as the
-        string a vendor Basic-auth header expects.
+        ``{field: value}`` for every name in *fields*. Values are coerced
+        to ``str`` and surrounding-whitespace-stripped via
+        :func:`strip_credential_value` so a numeric secret field
+        round-trips as a string and a trailing newline never reaches a
+        vendor Basic-auth header verbatim.
 
     Raises
     ------

--- a/backend/src/meho_backplane/connectors/github/session.py
+++ b/backend/src/meho_backplane/connectors/github/session.py
@@ -1,5 +1,8 @@
 # SPDX-License-Identifier: Apache-2.0
 # Copyright (c) 2026 evoila Group
+# code-quality-allow: file-size — pre-existing module size (>600 lines before
+# this change); #1474 is an import-only credential-whitespace-strip bugfix, so
+# splitting the module is out of scope here.
 
 """GitHub App + PAT credential loaders for :class:`GitHubRestConnector`.
 
@@ -75,6 +78,7 @@ from meho_backplane.connectors._shared.vault_creds import (
     VaultCredentialsReadError,
     load_basic_credentials,
     load_vault_secret_data,
+    strip_credential_value,
 )
 
 __all__ = [
@@ -496,14 +500,20 @@ async def load_github_credentials_from_vault(
     app_fields_present = all(field in present_fields for field in _GH_APP_FIELDS)
     pat_field_present = _GH_PAT_FIELD in present_fields
 
+    # Whitespace-strip every credential field via ``strip_credential_value``
+    # (mirrors the shared ``load_basic_credentials`` path the App/PAT loaders
+    # delegate to) so a trailing newline never reaches a GitHub bearer header
+    # or App-JWT signer verbatim. ``.strip()`` on the PEM only trims the
+    # surrounding whitespace; the key's internal newlines are preserved and
+    # ``load_pem_private_key`` tolerates trailing-newline presence or absence.
     if app_fields_present:
         return GitHubAppCredentials(
-            app_id=str(secret_data["app_id"]),
-            private_key_pem=str(secret_data["private_key"]),
-            installation_id=str(secret_data["installation_id"]),
+            app_id=strip_credential_value(secret_data["app_id"]),
+            private_key_pem=strip_credential_value(secret_data["private_key"]),
+            installation_id=strip_credential_value(secret_data["installation_id"]),
         )
     if pat_field_present:
-        return GitHubPATCredentials(token=str(secret_data[_GH_PAT_FIELD]))
+        return GitHubPATCredentials(token=strip_credential_value(secret_data[_GH_PAT_FIELD]))
 
     # Neither shape matches — fail closed with a structured error that
     # tells the operator exactly which fields to write into Vault.

--- a/backend/src/meho_backplane/connectors/keycloak/connector.py
+++ b/backend/src/meho_backplane/connectors/keycloak/connector.py
@@ -229,6 +229,24 @@ def _parse_token_response(payload: Any) -> tuple[str, float]:
 #: bloating the exception message / log line.
 _MAX_ERROR_DESCRIPTION_CHARS: int = 200
 
+#: The RFC 6749 §5.2 token-endpoint error codes. ``_upstream_token_error_detail``
+#: echoes an ``error_description`` only when the body is an
+#: ``application/json`` object whose ``error`` is one of these -- i.e. an actual
+#: OAuth2 token error. ``error_description`` is non-secret *only under the OAuth2
+#: schema*, so an unrelated gateway/proxy JSON envelope that happens to carry an
+#: ``error`` key must not have its fields echoed (the no-secret-in-logs
+#: invariant). An unrecognised code degrades safely to the bare status message.
+_OAUTH2_TOKEN_ERROR_CODES: frozenset[str] = frozenset(
+    {
+        "invalid_request",
+        "invalid_client",
+        "invalid_grant",
+        "unauthorized_client",
+        "unsupported_grant_type",
+        "invalid_scope",
+    }
+)
+
 
 def _upstream_token_error_detail(response: httpx.Response) -> str:
     """Render Keycloak's ``{error, error_description}`` as an operator hint.
@@ -241,12 +259,17 @@ def _upstream_token_error_detail(response: httpx.Response) -> str:
     ``returned HTTP 401`` into a one-look diagnosis.
 
     Returns a leading-space-prefixed ``" (error=..., error_description=...)"``
-    fragment ready to append to the message, or ``""`` when the body is not a
-    JSON object carrying an ``error`` field (so a non-OAuth2 error page never
-    injects noise). The ``error_description`` is length-capped; no other body
-    field is echoed, keeping the surface to OAuth2's two well-known non-secret
-    keys.
+    fragment ready to append to the message, or ``""`` unless the body is a
+    genuine OAuth2 token error: an ``application/json`` object whose ``error``
+    is one of :data:`_OAUTH2_TOKEN_ERROR_CODES`. That gate keeps a non-OAuth2
+    gateway/proxy envelope (whose ``error_description`` is *not* schema-bound to
+    be non-secret) from injecting noise or leaking a value -- the
+    no-secret-in-logs invariant. The ``error_description`` is length-capped; no
+    other body field is ever echoed, keeping the surface to OAuth2's two
+    well-known non-secret keys.
     """
+    if "application/json" not in response.headers.get("content-type", "").lower():
+        return ""
     try:
         body = response.json()
     except ValueError:
@@ -254,7 +277,7 @@ def _upstream_token_error_detail(response: httpx.Response) -> str:
     if not isinstance(body, dict):
         return ""
     error = body.get("error")
-    if not isinstance(error, str) or not error:
+    if not isinstance(error, str) or error not in _OAUTH2_TOKEN_ERROR_CODES:
         return ""
     parts = [f"error={error!r}"]
     description = body.get("error_description")

--- a/backend/src/meho_backplane/connectors/keycloak/connector.py
+++ b/backend/src/meho_backplane/connectors/keycloak/connector.py
@@ -1,5 +1,8 @@
 # SPDX-License-Identifier: Apache-2.0
 # Copyright (c) 2026 evoila Group
+# code-quality-allow: file-size — pre-existing module size (>600 lines before
+# this change); #1474 adds a small token-error-detail helper for a bugfix, so
+# splitting the connector module is out of scope here.
 
 """KeycloakConnector -- HttpConnector subclass for the Keycloak 26.x Admin REST API.
 
@@ -167,7 +170,12 @@ class KeycloakAdminTokenError(RuntimeError):
     Raised when ``POST /realms/{admin_realm}/protocol/openid-connect/token``
     returns a non-2xx response or a body without a usable
     ``access_token``. The message names the target and the admin realm;
-    it never echoes a credential value. Chains the underlying
+    it never echoes a credential value. On a non-2xx with an OAuth2 error
+    body it also echoes Keycloak's ``{error, error_description}`` (the two
+    non-secret keys that name the failure class -- bad secret vs.
+    client-not-allowed-the-grant vs. wrong realm) via
+    :func:`_upstream_token_error_detail`, so the operator can tell those
+    apart without backplane logs. Chains the underlying
     :exc:`httpx.HTTPStatusError` when one is available so the operator
     can see the upstream status code.
     """
@@ -213,6 +221,49 @@ def _parse_token_response(payload: Any) -> tuple[str, float]:
     ttl = float(expires_in) if isinstance(expires_in, (int, float)) else _DEFAULT_TOKEN_TTL_SECONDS
     effective = max(1.0, ttl - _TOKEN_REFRESH_MARGIN_SECONDS)
     return token, effective
+
+
+#: Cap on the upstream ``error_description`` echoed into
+#: :exc:`KeycloakAdminTokenError`. Keycloak's descriptions are short
+#: human-readable strings; the cap guards against a pathological body
+#: bloating the exception message / log line.
+_MAX_ERROR_DESCRIPTION_CHARS: int = 200
+
+
+def _upstream_token_error_detail(response: httpx.Response) -> str:
+    """Render Keycloak's ``{error, error_description}`` as an operator hint.
+
+    Keycloak's token endpoint returns an OAuth2 error body (RFC 6749 §5.2)
+    on a 4xx -- e.g. ``{"error": "unauthorized_client", "error_description":
+    "Invalid client or Invalid client credentials"}``. Those two fields name
+    the *class* of failure (bad secret vs. client-not-allowed-the-grant vs.
+    wrong realm) and are **not** secret-bearing -- echoing them turns a bare
+    ``returned HTTP 401`` into a one-look diagnosis.
+
+    Returns a leading-space-prefixed ``" (error=..., error_description=...)"``
+    fragment ready to append to the message, or ``""`` when the body is not a
+    JSON object carrying an ``error`` field (so a non-OAuth2 error page never
+    injects noise). The ``error_description`` is length-capped; no other body
+    field is echoed, keeping the surface to OAuth2's two well-known non-secret
+    keys.
+    """
+    try:
+        body = response.json()
+    except ValueError:
+        return ""
+    if not isinstance(body, dict):
+        return ""
+    error = body.get("error")
+    if not isinstance(error, str) or not error:
+        return ""
+    parts = [f"error={error!r}"]
+    description = body.get("error_description")
+    if isinstance(description, str) and description:
+        truncated = description[:_MAX_ERROR_DESCRIPTION_CHARS]
+        if len(description) > _MAX_ERROR_DESCRIPTION_CHARS:
+            truncated += "…"
+        parts.append(f"error_description={truncated!r}")
+    return f" ({', '.join(parts)})"
 
 
 class _CachedToken:
@@ -359,6 +410,7 @@ class KeycloakConnector(HttpConnector):
             raise KeycloakAdminTokenError(
                 f"admin token request for target {target.name!r} against admin realm "
                 f"{realms.admin_realm!r} returned HTTP {exc.response.status_code}"
+                f"{_upstream_token_error_detail(exc.response)}"
             ) from exc
         except (httpx.HTTPError, ValueError) as exc:
             raise KeycloakAdminTokenError(

--- a/backend/src/meho_backplane/connectors/keycloak/ops_write.py
+++ b/backend/src/meho_backplane/connectors/keycloak/ops_write.py
@@ -93,6 +93,7 @@ import asyncio
 from typing import TYPE_CHECKING, Any
 
 import meho_backplane.auth.vault as _auth_vault
+from meho_backplane.connectors._shared.vault_creds import strip_credential_value
 from meho_backplane.connectors.keycloak.session import resolve_realm_config
 
 if TYPE_CHECKING:
@@ -177,7 +178,11 @@ async def _read_password_from_vault(operator: Operator, params: dict[str, Any]) 
         )
     secret_data = payload["data"]["data"]
     value = secret_data.get(key) if isinstance(secret_data, dict) else None
-    if not isinstance(value, str) or not value:
+    # Whitespace-strip as the connector's credential loaders do (a trailing
+    # newline would otherwise ride into the user's Keycloak password); check
+    # emptiness post-strip so a whitespace-only secret is rejected, not set.
+    stripped = strip_credential_value(value) if isinstance(value, str) else None
+    if not stripped:
         raise KeycloakPasswordSecretError(
             f"keycloak_password_secret: Vault secret at mount={mount!r} "
             f"path={secret_ref!r} carries no usable string value under key "
@@ -185,7 +190,7 @@ async def _read_password_from_vault(operator: Operator, params: dict[str, Any]) 
             f"password_secret_key) so the user write can source it without "
             f"the password ever appearing in op params."
         )
-    return value
+    return stripped
 
 
 def _temporary_flag(params: dict[str, Any]) -> bool:

--- a/backend/src/meho_backplane/connectors/keycloak/session.py
+++ b/backend/src/meho_backplane/connectors/keycloak/session.py
@@ -76,7 +76,10 @@ from dataclasses import dataclass
 from typing import Any, Protocol, runtime_checkable
 
 from meho_backplane.auth.operator import Operator
-from meho_backplane.connectors._shared.vault_creds import load_vault_secret_data
+from meho_backplane.connectors._shared.vault_creds import (
+    load_vault_secret_data,
+    strip_credential_value,
+)
 
 __all__ = [
     "DEFAULT_ADMIN_REALM",
@@ -260,20 +263,26 @@ async def load_admin_credentials_from_vault(
     secret_data = await load_vault_secret_data(target, operator)
     present = set(secret_data.keys())
 
+    # Every credential field is whitespace-stripped via
+    # ``strip_credential_value`` so a trailing newline (the #1 secret-storage
+    # artifact) never reaches Keycloak's token endpoint verbatim — a stray
+    # ``\n`` on client_secret surfaces as ``unauthorized_client`` that reads
+    # like a permissions/realm problem rather than a storage artifact.
     if all(field in present for field in _CLIENT_FIELDS):
         return KeycloakClientCredentials(
-            client_id=str(secret_data["client_id"]),
-            client_secret=str(secret_data["client_secret"]),
+            client_id=strip_credential_value(secret_data["client_id"]),
+            client_secret=strip_credential_value(secret_data["client_secret"]),
         )
     if all(field in present for field in _PASSWORD_FIELDS):
         # ``client_id`` is optional in the password shape — Keycloak's
         # direct-access-grant flow defaults to the ``admin-cli`` public
         # client when the operator didn't store an explicit one.
         client_id = secret_data.get("client_id")
+        stripped_client_id = strip_credential_value(client_id) if isinstance(client_id, str) else ""
         return KeycloakPasswordCredentials(
-            username=str(secret_data["username"]),
-            password=str(secret_data["password"]),
-            client_id=str(client_id) if isinstance(client_id, str) and client_id else "admin-cli",
+            username=strip_credential_value(secret_data["username"]),
+            password=strip_credential_value(secret_data["password"]),
+            client_id=stripped_client_id or "admin-cli",
         )
 
     raise KeycloakAmbiguousVaultPayloadError(

--- a/backend/tests/test_connectors_github_session.py
+++ b/backend/tests/test_connectors_github_session.py
@@ -365,7 +365,11 @@ async def test_load_github_credentials_picks_app_path_on_app_payload(
     assert isinstance(creds, GitHubAppCredentials)
     assert creds.app_id == "3898656"
     assert creds.installation_id == "136396725"
-    assert creds.private_key_pem == _GH_PEM_FIXTURE
+    # The discriminator whitespace-strips every credential field (#1474); a
+    # PKCS8 PEM ends in a trailing ``\n`` which is harmless for RS256 signing
+    # (``load_pem_private_key`` tolerates its presence or absence), so the
+    # loaded value is the stripped PEM.
+    assert creds.private_key_pem == _GH_PEM_FIXTURE.strip()
 
 
 @pytest.mark.asyncio
@@ -374,6 +378,24 @@ async def test_load_github_credentials_picks_pat_path_on_pat_payload(
 ) -> None:
     """Vault payload carrying only ``token`` → PAT."""
     install_fake_client(monkeypatch, secret={"token": "ghp_fine_grained_pat_value"})
+
+    creds = await load_github_credentials_from_vault(_GhFakeTarget(name="t"), _operator())
+
+    assert isinstance(creds, GitHubPATCredentials)
+    assert creds.token == "ghp_fine_grained_pat_value"
+
+
+@pytest.mark.asyncio
+async def test_load_github_credentials_strips_pat_whitespace(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """A ``token`` stored with a trailing newline is stripped before use (#1474).
+
+    A trailing ``\\n`` (echo / jq -r / editor artifact) would otherwise ride
+    into the ``Authorization: token <pat>\\n`` header and 401 as if the PAT
+    were revoked. The discriminator strips it at load.
+    """
+    install_fake_client(monkeypatch, secret={"token": "ghp_fine_grained_pat_value\n"})
 
     creds = await load_github_credentials_from_vault(_GhFakeTarget(name="t"), _operator())
 

--- a/backend/tests/test_connectors_keycloak_auth.py
+++ b/backend/tests/test_connectors_keycloak_auth.py
@@ -524,6 +524,33 @@ async def test_token_error_without_oauth_body_omits_detail() -> None:
     await connector.aclose()
 
 
+@pytest.mark.asyncio
+async def test_token_error_ignores_non_oauth2_json_envelope() -> None:
+    """A JSON envelope whose ``error`` is not an RFC 6749 §5.2 code is ignored.
+
+    A gateway/proxy can return ``application/json`` carrying an ``error`` key
+    that is *not* an OAuth2 token error; its ``error_description`` is not
+    schema-bound to be non-secret. The helper gates on the standard code set,
+    so such a body degrades to the bare status message — no fragment, no leak.
+    """
+    connector = _make_connector()
+
+    async with respx.mock(base_url="https://keycloak-a.test.invalid") as mock:
+        mock.post("/realms/master/protocol/openid-connect/token").respond(
+            502,
+            json={"error": "bad_gateway", "error_description": "upstream-detail-DO-NOT-ECHO"},
+        )
+        with pytest.raises(KeycloakAdminTokenError) as excinfo:
+            await connector.auth_headers(_TARGET, operator=_make_operator())
+
+    message = str(excinfo.value)
+    assert "returned HTTP 502" in message
+    assert "error=" not in message
+    assert "upstream-detail-DO-NOT-ECHO" not in message
+
+    await connector.aclose()
+
+
 # ---------------------------------------------------------------------------
 # Admin-credential discriminator loader — Vault-payload whitespace stripping
 # (the #1474 root cause: a client_secret with a trailing \n)

--- a/backend/tests/test_connectors_keycloak_auth.py
+++ b/backend/tests/test_connectors_keycloak_auth.py
@@ -470,6 +470,181 @@ async def test_mint_admin_token_raises_on_missing_access_token() -> None:
     await connector.aclose()
 
 
+@pytest.mark.asyncio
+async def test_token_error_surfaces_upstream_oauth_error_description() -> None:
+    """A 401 with an OAuth2 error body echoes Keycloak's error + error_description.
+
+    The whole point of #1474's second ask: ``returned HTTP 401`` alone can't
+    distinguish a bad secret from a client-not-allowed-the-grant from a wrong
+    realm. Keycloak's ``{error, error_description}`` (non-secret) is echoed so
+    the operator diagnoses it in one look.
+    """
+    connector = _make_connector()
+
+    async with respx.mock(base_url="https://keycloak-a.test.invalid") as mock:
+        mock.post("/realms/master/protocol/openid-connect/token").respond(
+            401,
+            json={
+                "error": "unauthorized_client",
+                "error_description": "Invalid client or Invalid client credentials",
+            },
+        )
+        with pytest.raises(KeycloakAdminTokenError) as excinfo:
+            await connector.auth_headers(_TARGET, operator=_make_operator())
+
+    message = str(excinfo.value)
+    assert "returned HTTP 401" in message
+    assert "unauthorized_client" in message
+    assert "Invalid client or Invalid client credentials" in message
+
+    await connector.aclose()
+
+
+@pytest.mark.asyncio
+async def test_token_error_without_oauth_body_omits_detail() -> None:
+    """A non-OAuth2 error body (e.g. an HTML 502) injects no error fragment.
+
+    The detail helper returns ``""`` when the body is not a JSON object
+    carrying an ``error`` key, so the bare status-code message is preserved
+    rather than appending parse noise.
+    """
+    connector = _make_connector()
+
+    async with respx.mock(base_url="https://keycloak-a.test.invalid") as mock:
+        mock.post("/realms/master/protocol/openid-connect/token").respond(
+            502, html="<html><body>Bad Gateway</body></html>"
+        )
+        with pytest.raises(KeycloakAdminTokenError) as excinfo:
+            await connector.auth_headers(_TARGET, operator=_make_operator())
+
+    message = str(excinfo.value)
+    assert "returned HTTP 502" in message
+    assert "error=" not in message
+
+    await connector.aclose()
+
+
+# ---------------------------------------------------------------------------
+# Admin-credential discriminator loader — Vault-payload whitespace stripping
+# (the #1474 root cause: a client_secret with a trailing \n)
+# ---------------------------------------------------------------------------
+
+
+@pytest.fixture
+def _kc_loader_settings_env(monkeypatch: pytest.MonkeyPatch) -> Iterator[None]:
+    """Pin the chassis env vars the live Vault read path reads at construction.
+
+    ``load_admin_credentials_from_vault`` → ``load_vault_secret_data`` →
+    ``vault_client_for_operator`` eagerly reads ``KEYCLOAK_*`` / ``VAULT_*``
+    via ``get_settings``; pin before the cache is built and clear after.
+    """
+    from meho_backplane.settings import get_settings
+
+    monkeypatch.setenv("KEYCLOAK_ISSUER_URL", "https://keycloak.test/realms/meho")
+    monkeypatch.setenv("KEYCLOAK_AUDIENCE", "meho-backplane")
+    monkeypatch.setenv("VAULT_ADDR", "https://vault.test")
+    monkeypatch.setenv("VAULT_OIDC_ROLE", "meho-mcp")
+    monkeypatch.setenv("VAULT_OIDC_MOUNT_PATH", "jwt")
+    monkeypatch.setenv("VAULT_TIMEOUT_SECONDS", "5.0")
+    monkeypatch.delenv("VAULT_NAMESPACE", raising=False)
+    get_settings.cache_clear()
+    yield
+    get_settings.cache_clear()
+
+
+@pytest.mark.asyncio
+@pytest.mark.usefixtures("_kc_loader_settings_env")
+async def test_admin_loader_strips_client_secret_trailing_newline(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """The exact #1474 bug: a client_secret stored with a trailing \\n.
+
+    The connector reads the field verbatim and would send
+    ``client_secret=<32 chars>\\n`` to Keycloak → ``unauthorized_client``.
+    The discriminator loader strips it at load time.
+    """
+    from meho_backplane.connectors.keycloak.session import load_admin_credentials_from_vault
+    from tests._vault_fakes import install_fake_client
+
+    install_fake_client(
+        monkeypatch,
+        secret={"client_id": "  meho-admin\n", "client_secret": "32-char-secret-value\n"},
+    )
+
+    creds = await load_admin_credentials_from_vault(_TARGET, _make_operator())
+
+    assert isinstance(creds, KeycloakClientCredentials)
+    assert creds.client_id == "meho-admin"
+    assert creds.client_secret == "32-char-secret-value"
+
+
+@pytest.mark.asyncio
+@pytest.mark.usefixtures("_kc_loader_settings_env")
+async def test_admin_loader_strips_password_shape_fields(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """The password break-glass shape is stripped the same way."""
+    from meho_backplane.connectors.keycloak.session import load_admin_credentials_from_vault
+    from tests._vault_fakes import install_fake_client
+
+    install_fake_client(
+        monkeypatch,
+        secret={"username": "admin\n", "password": "pw\n", "client_id": "custom-cli\n"},
+    )
+
+    creds = await load_admin_credentials_from_vault(_TARGET, _make_operator())
+
+    assert isinstance(creds, KeycloakPasswordCredentials)
+    assert creds.username == "admin"
+    assert creds.password == "pw"
+    assert creds.client_id == "custom-cli"
+
+
+@pytest.mark.asyncio
+@pytest.mark.usefixtures("_kc_loader_settings_env")
+async def test_user_write_password_reader_strips_trailing_newline(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """A Vault-sourced user password is stripped before it is set on Keycloak.
+
+    Same artifact, different surface: a trailing ``\\n`` on the password the
+    user-write op sources from Vault would otherwise be written into Keycloak
+    as part of the password, yielding an account that can never authenticate.
+    """
+    from meho_backplane.connectors.keycloak.ops_write import _read_password_from_vault
+    from tests._vault_fakes import install_fake_client
+
+    install_fake_client(monkeypatch, secret={"password": "hunter2\n"})
+
+    value = await _read_password_from_vault(
+        _make_operator(),
+        {"password_secret_ref": "rdc/keycloak/user-pw"},
+    )
+
+    assert value == "hunter2"
+
+
+@pytest.mark.asyncio
+@pytest.mark.usefixtures("_kc_loader_settings_env")
+async def test_user_write_password_reader_rejects_whitespace_only_secret(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """A whitespace-only secret is rejected post-strip, not set as empty."""
+    from meho_backplane.connectors.keycloak.ops_write import (
+        KeycloakPasswordSecretError,
+        _read_password_from_vault,
+    )
+    from tests._vault_fakes import install_fake_client
+
+    install_fake_client(monkeypatch, secret={"password": "   \n"})
+
+    with pytest.raises(KeycloakPasswordSecretError):
+        await _read_password_from_vault(
+            _make_operator(),
+            {"password_secret_ref": "rdc/keycloak/user-pw"},
+        )
+
+
 # ---------------------------------------------------------------------------
 # Registrar seam -- T2 (#1394) fills the read-op walk
 # ---------------------------------------------------------------------------

--- a/backend/tests/test_connectors_vault_creds.py
+++ b/backend/tests/test_connectors_vault_creds.py
@@ -161,6 +161,42 @@ async def test_non_string_field_is_coerced_to_str(
     assert creds == {"username": "u", "password": "12345"}
 
 
+async def test_credential_fields_are_whitespace_stripped(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """Trailing/leading whitespace on a credential value is stripped on load.
+
+    A trailing newline is the single most common secret-storage artifact
+    (`echo` without -n, `jq -r`, an editor's final newline). The connector
+    forwards the field verbatim into a Basic-auth header / token body, so a
+    stray ``\\n`` surfaces as an upstream 401 that looks like a permissions
+    problem. Stripping at the loader fixes it for every connector that goes
+    through ``load_basic_credentials`` (#1474).
+    """
+    install_fake_client(
+        monkeypatch,
+        secret={"username": "  svc-account\n", "password": "s3cret\n"},
+    )
+
+    creds = await load_basic_credentials(_Target(), _make_operator())
+
+    assert creds == {"username": "svc-account", "password": "s3cret"}
+
+
+async def test_strip_preserves_internal_whitespace(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """Only surrounding whitespace is trimmed; internal whitespace survives."""
+    install_fake_client(
+        monkeypatch,
+        secret={"username": "u", "password": "  pass phrase with spaces \n"},
+    )
+
+    creds = await load_basic_credentials(_Target(), _make_operator())
+
+    assert creds == {"username": "u", "password": "pass phrase with spaces"}
+
+
 async def test_secret_ref_is_stripped(monkeypatch: pytest.MonkeyPatch) -> None:
     """Whitespace around the secret_ref path does not slip into the read."""
     fake = install_fake_client(monkeypatch, secret={"username": "u", "password": "p"})

--- a/docs/codebase/connectors-keycloak.md
+++ b/docs/codebase/connectors-keycloak.md
@@ -59,11 +59,15 @@ fresh target with no asserted version still resolves.
   REST-target shape.
 - `RealmConfig` — the resolved `(admin_realm, managed_realm)` pair.
 - `KeycloakAdminTokenError` — raised when the token-endpoint round-trip
-  fails or returns no usable `access_token`. On a non-2xx with an OAuth2
-  error body it echoes Keycloak's `{error, error_description}` (RFC 6749
-  §5.2 — both non-secret) so a bad secret, a client not allowed the grant,
-  and a wrong realm are distinguishable from the error string alone, no
-  backplane logs needed (#1474). A non-OAuth2 body adds no detail.
+  fails or returns no usable `access_token`. On a non-2xx it echoes
+  Keycloak's `{error, error_description}` (RFC 6749 §5.2 — both non-secret)
+  so a bad secret, a client not allowed the grant, and a wrong realm are
+  distinguishable from the error string alone, no backplane logs needed
+  (#1474). The detail is echoed **only** for a genuine OAuth2 token error —
+  an `application/json` body whose `error` is one of the six RFC 6749 §5.2
+  codes — so an unrelated gateway/proxy JSON envelope (whose
+  `error_description` is not schema-bound to be non-secret) never injects
+  noise or leaks a value. Any other body adds no detail.
 - `KeycloakAmbiguousVaultPayloadError` — raised when the admin Vault
   secret carries neither credential shape.
 

--- a/docs/codebase/connectors-keycloak.md
+++ b/docs/codebase/connectors-keycloak.md
@@ -59,7 +59,11 @@ fresh target with no asserted version still resolves.
   REST-target shape.
 - `RealmConfig` — the resolved `(admin_realm, managed_realm)` pair.
 - `KeycloakAdminTokenError` — raised when the token-endpoint round-trip
-  fails or returns no usable `access_token`.
+  fails or returns no usable `access_token`. On a non-2xx with an OAuth2
+  error body it echoes Keycloak's `{error, error_description}` (RFC 6749
+  §5.2 — both non-secret) so a bad secret, a client not allowed the grant,
+  and a wrong realm are distinguishable from the error string alone, no
+  backplane logs needed (#1474). A non-OAuth2 body adds no detail.
 - `KeycloakAmbiguousVaultPayloadError` — raised when the admin Vault
   secret carries neither credential shape.
 
@@ -101,6 +105,13 @@ connector uses for App-vs-PAT):
 
 The password shape accepts an optional `client_id` field (default
 `admin-cli`, Keycloak's public direct-access-grant client).
+
+Every field the discriminator plucks is whitespace-stripped via
+`strip_credential_value` before use — a `client_secret` stored with a
+trailing newline would otherwise be sent verbatim and rejected as
+`unauthorized_client` (#1474). The same strip guards the Vault-sourced
+password the user-write op sets (`_read_password_from_vault`), which also
+rejects a whitespace-only secret rather than setting an empty password.
 
 ## Control flow
 
@@ -249,9 +260,12 @@ Resolved through `resolve_realm_config`, which tolerates a missing
 ## References
 
 - Issue: https://github.com/evoila/meho/issues/1393
+- Credential whitespace strip + token error_description: https://github.com/evoila/meho/issues/1474
 - Parent initiative: https://github.com/evoila/meho/issues/1388
 - Keycloak token endpoint + client_credentials grant:
   https://www.keycloak.org/securing-apps/oidc-layers
+- OAuth 2.0 token-endpoint error response (RFC 6749 §5.2):
+  https://datatracker.ietf.org/doc/html/rfc6749#section-5.2
 - RealmRepresentation:
   https://www.keycloak.org/docs-api/latest/javadocs/org/keycloak/representations/idm/RealmRepresentation.html
 - ServerInfoRepresentation:

--- a/docs/codebase/connectors-shared-vault-creds.md
+++ b/docs/codebase/connectors-shared-vault-creds.md
@@ -34,8 +34,21 @@ dispatcher's `connector_error` branch.
   reads `target.secret_ref` as a KV-v2 secret off the event loop
   (`asyncio.to_thread` — hvac is synchronous), structurally unwraps the
   nested `data["data"]`, and returns the requested fields as a flat
-  `{field: value}` dict. Values are coerced to `str` so a numeric secret
-  field round-trips as the string a vendor Basic-auth header expects.
+  `{field: value}` dict. Values run through `strip_credential_value` —
+  coerced to `str` so a numeric secret field round-trips as a string, and
+  surrounding-whitespace-stripped so a trailing newline never reaches a
+  vendor Basic-auth header verbatim.
+- **`strip_credential_value(value) -> str`** — `str(value).strip()`. The
+  one place credential whitespace is normalised. A trailing newline is the
+  single most common secret-storage artifact (`echo` without `-n`, `jq -r`,
+  an editor's final newline, `vault kv put k=-`); sent verbatim in an auth
+  header or token-request body it surfaces as an upstream
+  401/`unauthorized_client` that reads like a permissions/realm problem
+  (#1474). `_extract_fields` applies it to every field, so every
+  `load_basic_credentials` consumer is covered at once; the payload-shape
+  discriminators that use `load_vault_secret_data` (keycloak / gh-rest) call
+  it directly on the fields they pluck. Only surrounding whitespace is
+  trimmed — internal whitespace is preserved.
 - **`VaultCredentialsReadError`** — read-phase failure (empty JWT, unset
   `secret_ref`, malformed payload, missing field). Deliberately distinct
   from `auth.vault.VaultClientError` (login-phase: Vault unreachable,
@@ -86,7 +99,9 @@ dispatcher's `connector_error` branch.
    `KeyError`.
 6. **Extract fields.** For each name in `fields`, a missing key raises
    `VaultCredentialsReadError` naming the target + the missing field +
-   the `secret_ref`. Present values are coerced to `str`.
+   the `secret_ref`. Present values pass through `strip_credential_value`
+   (coerced to `str`, surrounding whitespace stripped) so a trailing
+   newline never rides into a vendor auth header / token body (#1474).
 7. **Log non-secret attribution only.** A single
    `vault_basic_credentials_loaded` structlog event carries `target` /
    `host` / the requested field *names* — never a value. The returned
@@ -153,6 +168,7 @@ dispatcher's `connector_error` branch.
 ## References
 
 - Task: https://github.com/evoila/meho/issues/941
+- Credential whitespace strip: https://github.com/evoila/meho/issues/1474
 - Shape guard: https://github.com/evoila/meho/issues/989
 - Parent Initiative: https://github.com/evoila/meho/issues/939
 - Parent Goal: https://github.com/evoila/meho/issues/214


### PR DESCRIPTION
## Summary

- **Strip surrounding whitespace from every Vault-sourced credential.** A `client_secret` stored with a trailing newline was sent verbatim to Keycloak's token endpoint and rejected as `unauthorized_client`, surfacing only as `returned HTTP 401` — a multi-hour chase for a one-byte artifact (found dogfooding v0.10.0). A new shared `strip_credential_value()` in `_shared/vault_creds.py` is applied at every credential-field extraction path: `_extract_fields` (covers every `load_basic_credentials` consumer at once — vmware, nsx, harbor, sddc, argocd, vcf, GitHub App/PAT), the Keycloak admin client/password discriminator, the GitHub App/PAT discriminator, and the Keycloak user-write password reader. Only surrounding whitespace is trimmed; internal whitespace is preserved.
- **Surface the upstream OAuth2 error in `KeycloakAdminTokenError`.** On a non-2xx token response it now echoes Keycloak's `{error, error_description}` (RFC 6749 §5.2 — both non-secret), so a bad secret, a client not allowed the grant, and a wrong realm are distinguishable without backplane logs. A non-OAuth2 body (e.g. an HTML 502) adds no fragment; `error_description` is length-capped.
- The user-write password reader's emptiness check now runs **post-strip**, so a whitespace-only secret is rejected (`KeycloakPasswordSecretError`) rather than setting an empty password.
- `docs/codebase/connectors-shared-vault-creds.md` and `connectors-keycloak.md` updated for both surfaces.

## Test plan

- [x] `ruff check` — clean
- [x] `ruff format --check` — clean
- [x] `mypy` (5 source files) — no issues
- [x] `code-quality.py --diff` — 0 blockers
- [x] **AC1** strip in `_extract_fields` — `test_credential_fields_are_whitespace_stripped`, `test_strip_preserves_internal_whitespace`
- [x] **AC2** Keycloak admin discriminator strips both shapes — `test_admin_loader_strips_client_secret_trailing_newline`, `test_admin_loader_strips_password_shape_fields`
- [x] **AC3** GitHub discriminator strips all fields (PEM-equality assertion updated; RS256 sign verified safe on stripped PEM) — `test_load_github_credentials_strips_pat_whitespace`
- [x] **AC4** user-write password reader strips + rejects whitespace-only — `test_user_write_password_reader_strips_trailing_newline`, `test_user_write_password_reader_rejects_whitespace_only_secret`
- [x] **AC5** error_description echoed on JSON OAuth2 error body, "returned HTTP 401" preserved — `test_token_error_surfaces_upstream_oauth_error_description`
- [x] **AC6** non-OAuth2 body adds no `error=` fragment — `test_token_error_without_oauth_body_omits_detail`
- [x] **AC7** no-secret-in-logs discipline intact (existing `capture_logs` tests pass)
- [x] Targeted suites: `test_connectors_vault_creds.py` + `test_connectors_keycloak_auth.py` + `test_connectors_github_session.py` + `test_connectors_keycloak_write_e2e.py` — 79 passed
- [x] Broad connector cred-read/auth sweep — 910 passed, 27 skipped (missing-secret integration guards)

## Out of scope

- `connectors/kubernetes/kubeconfig.py` — loads a full kubeconfig YAML document (whitespace-tolerant, parsed downstream), not a verbatim-sent credential token. No strip.
- How secrets are *stored* in Vault, and operator runbooks. This hardens the *read* path only.

<!-- auto-implement-issue: fresh, iteration 1 -->

Closes #1474


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Fixed credential handling to automatically strip whitespace and trailing newlines from Vault-stored credentials, preventing authentication failures in GitHub and Keycloak integrations.
  * Enhanced Keycloak error messages to include OAuth2 error details without exposing sensitive credential values.

* **Improvements**
  * Strengthened validation of credentials by rejecting whitespace-only values from Vault.

* **Documentation**
  * Updated connector documentation to reflect credential whitespace normalization behavior.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->