### PR TITLE
fix(agents): cascade-delete scheduled_trigger rows on agents.delete (#1480)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -184,6 +184,20 @@ connector-related release-notes line.
 
 ### Fixed
 
+- **`agents.delete` on a definition that ever had a `scheduled_trigger`
+  (including a cancelled one) no longer fails with an opaque
+  `-32603 "internal error: IntegrityError"` (MCP) / unhandled HTTP 500
+  (REST).** The `scheduled_trigger.agent_definition_id` FK was created
+  without an `ondelete` clause (default `NO ACTION`), so deleting a
+  once-scheduled definition violated the constraint — and because
+  `cancel()` retains the trigger row for audit and there is no API path
+  to hard-delete it, such a definition was permanently undeletable, only
+  `enabled=false`-able. Migration `0035` adds `ON DELETE CASCADE` to the
+  FK (a DB-level cascade, since the delete is a bulk Core statement that
+  bypasses ORM relationship cascades), so deleting a definition
+  cascade-deletes its dependent trigger rows on both MCP and REST.
+  `agent_run` history is a nullable soft-FK and is unaffected. (#1480)
+
 - Agent runtime no longer 404s on the shipped default model id: the
   `provider:` prefix of a pydantic-ai spec-form id
   (`anthropic:claude-sonnet-4-6`) is now stripped before constructing

--- a/backend/alembic/versions/0035_scheduled_trigger_fk_cascade.py
+++ b/backend/alembic/versions/0035_scheduled_trigger_fk_cascade.py
@@ -1,0 +1,140 @@
+# SPDX-License-Identifier: Apache-2.0
+# Copyright (c) 2026 evoila Group
+
+"""Add ``ON DELETE CASCADE`` to ``scheduled_trigger.agent_definition_id``.
+
+Revision ID: 0035
+Revises: 0034
+Create Date: 2026-06-03
+
+Issue #1480 (G0.19 v0.10.0 dogfood hardening). Migration ``0020`` (T1,
+PR #1064) created ``scheduled_trigger`` with a real
+``REFERENCES agent_definition(id)`` FK on ``agent_definition_id`` but no
+``ondelete`` clause -- so the constraint defaults to ``NO ACTION``.
+Deleting an ``agent_definition`` that ever had a trigger created against
+it (including a now-**cancelled** one, since
+:meth:`SchedulerService.cancel` retains the row for audit) violates that
+FK. The delete path issues a bulk Core ``DELETE`` whose uncaught
+:class:`~sqlalchemy.exc.IntegrityError` surfaced as a bare JSON-RPC
+``-32603 "internal error: IntegrityError"`` on MCP and an unhandled
+HTTP 500 on REST -- the definition was effectively undeletable via the
+API.
+
+Chosen shape: DB-level ``ON DELETE CASCADE``
+--------------------------------------------
+
+The delete is a **bulk Core statement** (``DELETE ... RETURNING name``),
+not a ``Session.delete``, so an ORM ``cascade=`` / ``passive_deletes``
+relationship would not fire (SQLAlchemy 2.0 ``cascade`` applies only to
+unit-of-work deletes; a database-level ``ON DELETE`` fires on bulk/Core
+statements). The cascade therefore lives in the FK clause itself.
+
+``CASCADE`` rather than ``SET NULL`` because ``agent_definition_id`` is
+``NOT NULL`` -- nulling it would break the column contract and the
+scheduler's "fire runs against this definition" invariant. There is no
+operator API path that hard-deletes a trigger row (``cancel()`` keeps it
+for audit), so a guard-with-typed-error shape would leave a
+once-scheduled definition permanently undeletable. ``scheduled_trigger``
+is the **only** hard FK to ``agent_definition`` (``agent_run`` is a
+nullable soft-FK with no ``ForeignKey`` clause, ``audit_log`` is a
+separate table) so the cascade is bounded to a single child table:
+deleting a definition removes the definition and its dependent schedule
+rows, while run history and audit logs survive.
+
+Portability: dialect-split FK rebuild
+--------------------------------------
+
+* **PostgreSQL** -- ``batch_alter_table`` runs online ``ALTER``
+  statements on PG, so we drop the server-generated FK by its
+  deterministic default name
+  (``scheduled_trigger_agent_definition_id_fkey``) and re-add it with
+  ``ondelete='CASCADE'``. No table recreate.
+* **SQLite** -- the FK was created unnamed; SQLite cannot
+  ``ALTER ... DROP CONSTRAINT`` a foreign key, so ``batch_alter_table``
+  performs the move-and-copy table recreate. A ``naming_convention`` is
+  passed so the existing FK reflects under a deterministic name we can
+  drop, and the FK is re-added with the cascade. This mirrors the
+  table-recreate cookbook the status-CHECK migrations (0017 / 0025)
+  already rely on.
+
+Reversibility contract
+----------------------
+
+``downgrade()`` rebuilds the FK back to the no-``ondelete`` (``NO
+ACTION``) shape that 0020 shipped, on both dialects, so the two halves
+are symmetric.
+"""
+
+from collections.abc import Sequence
+
+from alembic import op
+
+# revision identifiers, used by Alembic.
+revision: str = "0035"
+down_revision: str | None = "0034"
+branch_labels: str | Sequence[str] | None = None
+depends_on: str | Sequence[str] | None = None
+
+
+#: Deterministic name for the ``agent_definition_id`` FK.
+#:
+#: On PostgreSQL the constraint 0020 created carries the dialect-default
+#: name ``<table>_<column>_fkey``; we drop that exact name. On SQLite the
+#: FK is unnamed, so we hand ``batch_alter_table`` a ``naming_convention``
+#: that renders this same name on reflection, letting the drop /
+#: re-create reference a stable handle across both dialects.
+_FK_NAME = "scheduled_trigger_agent_definition_id_fkey"
+
+#: ``naming_convention`` whose ``fk`` template renders ``_FK_NAME`` for the
+#: ``(scheduled_trigger, agent_definition_id, agent_definition)`` triple,
+#: matching the PostgreSQL server-generated default so both dialects drop
+#: the same name.
+_NAMING_CONVENTION = {
+    "fk": "%(table_name)s_%(column_0_name)s_fkey",
+}
+
+
+def _rebuild_fk(*, ondelete: str | None) -> None:
+    """Drop and re-create the ``agent_definition_id`` FK with *ondelete*.
+
+    Dialect-split: PostgreSQL drops the server-named FK in place
+    (online ALTER); SQLite recreates the table via ``batch_alter_table``
+    with the naming convention that gives the unnamed FK a stable handle.
+    """
+    bind = op.get_bind()
+    is_postgres = bind.dialect.name == "postgresql"
+
+    if is_postgres:
+        op.drop_constraint(_FK_NAME, "scheduled_trigger", type_="foreignkey")
+        op.create_foreign_key(
+            _FK_NAME,
+            "scheduled_trigger",
+            "agent_definition",
+            ["agent_definition_id"],
+            ["id"],
+            ondelete=ondelete,
+        )
+        return
+
+    with op.batch_alter_table(
+        "scheduled_trigger",
+        naming_convention=_NAMING_CONVENTION,
+    ) as batch_op:
+        batch_op.drop_constraint(_FK_NAME, type_="foreignkey")
+        batch_op.create_foreign_key(
+            _FK_NAME,
+            "agent_definition",
+            ["agent_definition_id"],
+            ["id"],
+            ondelete=ondelete,
+        )
+
+
+def upgrade() -> None:
+    """Rebuild the FK with ``ON DELETE CASCADE``."""
+    _rebuild_fk(ondelete="CASCADE")
+
+
+def downgrade() -> None:
+    """Restore the no-``ondelete`` (``NO ACTION``) FK 0020 shipped."""
+    _rebuild_fk(ondelete=None)

--- a/backend/src/meho_backplane/db/models.py
+++ b/backend/src/meho_backplane/db/models.py
@@ -3479,11 +3479,16 @@ class ScheduledTrigger(Base):
       replayed tenant id surfaces as :class:`IntegrityError` at insert.
 
     * ``agent_definition_id`` -- UUID NOT NULL with a real
-      ``REFERENCES agent_definition(id)`` FK. The parent table already
-      exists at HEAD (``0016`` shipped ahead of this work), so the FK is
-      tightened here -- the sibling :class:`AgentRun` (``0017``) had to
-      use a soft-FK only because its migration landed in parallel with
-      ``0016``. A trigger cannot point at a deleted definition.
+      ``REFERENCES agent_definition(id) ON DELETE CASCADE`` FK. The
+      parent table already exists at HEAD (``0016`` shipped ahead of this
+      work), so the FK is tightened here -- the sibling
+      :class:`AgentRun` (``0017``) had to use a soft-FK only because its
+      migration landed in parallel with ``0016``. A trigger cannot point
+      at a definition that no longer exists: deleting the definition
+      cascade-deletes its triggers (``ondelete='CASCADE'`` added by
+      migration ``0035`` / #1480), so a once-scheduled definition stays
+      deletable instead of being pinned by an audit-retained cancelled
+      trigger.
 
     * ``kind`` -- Text NOT NULL with a DB-layer ``CHECK kind IN (...)``
       constraint enforcing the closed
@@ -3570,9 +3575,15 @@ class ScheduledTrigger(Base):
     )
     # Real REFERENCES agent_definition(id) FK -- the parent table exists
     # at HEAD (0016) so this Task tightens the FK 0017 had to leave soft.
+    # ``ondelete='CASCADE'`` (migration 0035, #1480): deleting a
+    # definition removes its dependent trigger rows -- including a
+    # cancelled one cancel() retains for audit -- so a once-scheduled
+    # definition is still deletable. The cascade must be the DB-level FK
+    # clause, not an ORM ``cascade=`` relationship: the delete path issues
+    # a bulk Core ``DELETE`` that bypasses unit-of-work cascades.
     agent_definition_id: Mapped[uuid.UUID] = mapped_column(
         Uuid(),
-        ForeignKey("agent_definition.id"),
+        ForeignKey("agent_definition.id", ondelete="CASCADE"),
         nullable=False,
     )
     kind: Mapped[str] = mapped_column(Text, nullable=False)

--- a/backend/tests/test_agents_delete_cascade.py
+++ b/backend/tests/test_agents_delete_cascade.py
@@ -1,0 +1,326 @@
+# SPDX-License-Identifier: Apache-2.0
+# Copyright (c) 2026 evoila Group
+
+"""``agents.delete`` cascades dependent ``scheduled_trigger`` rows (#1480).
+
+Issue #1480 (G0.19 v0.10.0 dogfood hardening). Migration ``0035`` adds
+``ON DELETE CASCADE`` to ``scheduled_trigger.agent_definition_id`` so a
+definition that ever had a trigger created against it -- including a
+now-**cancelled** one ``cancel()`` retains for audit -- is still
+deletable. Before the fix the bulk Core ``DELETE`` in
+:meth:`AgentDefinitionService.delete` hit the no-``ondelete`` FK and
+surfaced an opaque ``-32603 "internal error: IntegrityError"`` on MCP
+and an unhandled HTTP 500 on REST.
+
+Why this module opts into SQLite FK enforcement
+-----------------------------------------------
+
+SQLite enforces foreign keys only when ``PRAGMA foreign_keys = ON`` is
+issued per connection (default OFF). Production runs on PostgreSQL where
+FKs -- and therefore the new ``ON DELETE CASCADE`` -- are always
+enforced. Without the PRAGMA, the cascade never fires and a regression
+(e.g. the migration silently dropping the cascade) would pass on SQLite
+by accident. Setting ``MEHO_SQLITE_FOREIGN_KEYS=1`` and resetting the
+engine attaches the PRAGMA listener (see
+:func:`db.engine.create_engine_for_url`), mirroring the precedent in
+:mod:`tests.test_topology_history_hook`.
+
+The cascade is a **DB-level** FK clause, not an ORM ``cascade=``
+relationship, precisely because :meth:`AgentDefinitionService.delete`
+issues a bulk Core ``DELETE`` that bypasses the unit-of-work cascade.
+The service-layer test below proves the bulk Core delete triggers the
+DB-level cascade; the REST and MCP tests prove neither surface returns
+the opaque error any more.
+"""
+
+from __future__ import annotations
+
+import json
+import uuid
+from collections.abc import Iterator
+from datetime import UTC, datetime
+from typing import Any
+
+import pytest
+from fastapi.testclient import TestClient
+from sqlalchemy import func, select
+from sqlalchemy.ext.asyncio import AsyncSession
+
+from meho_backplane.agents.service import AgentDefinitionService
+from meho_backplane.auth.operator import Operator, TenantRole
+from meho_backplane.db.engine import get_sessionmaker, reset_engine_for_testing
+from meho_backplane.db.models import (
+    AgentDefinition,
+    AgentPrincipal,
+    ScheduledTrigger,
+    ScheduledTriggerInFlightPolicy,
+    ScheduledTriggerKind,
+    ScheduledTriggerStatus,
+    Tenant,
+)
+from meho_backplane.mcp.tools import agents as agents_mcp
+from meho_backplane.settings import get_settings
+from tests.mcp_test_fixtures import (
+    OPERATOR_TENANT_ID,
+    build_operator,
+    client_with_operator,  # noqa: F401 — pytest-discovered fixture
+    isolated_registry,  # noqa: F401 — pytest-discovered autouse fixture
+    post_mcp,
+    required_settings_env,  # noqa: F401 — pytest-discovered autouse fixture
+)
+
+
+@pytest.fixture(autouse=True)
+def _enforce_sqlite_foreign_keys(monkeypatch: pytest.MonkeyPatch) -> Iterator[None]:
+    """Opt this module in to SQLite foreign-key enforcement.
+
+    The whole point of #1480 is the ``ON DELETE CASCADE`` on
+    ``scheduled_trigger.agent_definition_id``; that cascade only fires
+    when SQLite has ``PRAGMA foreign_keys = ON``. Flipping
+    ``MEHO_SQLITE_FOREIGN_KEYS=1`` and resetting the cached engine
+    rebuilds it with the per-connection PRAGMA listener attached, on top
+    of the per-test DB the conftest already migrated to head (so the
+    0035 cascade FK is present). Mirrors
+    :func:`tests.test_topology_history_hook._enforce_sqlite_foreign_keys`.
+    """
+    monkeypatch.setenv("MEHO_SQLITE_FOREIGN_KEYS", "1")
+    reset_engine_for_testing()
+    yield
+    reset_engine_for_testing()
+
+
+@pytest.fixture(autouse=True)
+def _settings_env(monkeypatch: pytest.MonkeyPatch) -> Iterator[None]:
+    """Pin env vars :class:`Settings` requires (the conftest pins only URL)."""
+    monkeypatch.setenv("KEYCLOAK_ISSUER_URL", "https://keycloak.test/realms/meho")
+    monkeypatch.setenv("KEYCLOAK_AUDIENCE", "meho-backplane")
+    monkeypatch.setenv("VAULT_ADDR", "https://vault.test")
+    get_settings.cache_clear()
+    yield
+    get_settings.cache_clear()
+
+
+async def _seed_definition_with_triggers(
+    session: AsyncSession,
+    *,
+    tenant_id: uuid.UUID,
+    name: str = "incident-triage",
+) -> uuid.UUID:
+    """Insert a tenant + principal + definition + one active + one cancelled trigger.
+
+    Returns the definition id. The two triggers cover both blocking
+    shapes #1480 calls out: an ``active`` trigger (a live schedule) and
+    a ``cancelled`` one (``cancel()`` retains the row for audit). Both
+    hold the FK and -- pre-fix -- both blocked the delete.
+    """
+    now = datetime.now(UTC)
+    definition_id = uuid.uuid4()
+    existing = await session.execute(select(Tenant).where(Tenant.id == tenant_id))
+    if existing.scalar_one_or_none() is None:
+        # Commit the parent tenant on its own so the FK from
+        # agent_definition / agent_principal resolves under PRAGMA
+        # foreign_keys=ON regardless of unit-of-work flush ordering.
+        session.add(Tenant(id=tenant_id, slug=f"t-{tenant_id.hex[:8]}", name="T"))
+        await session.commit()
+    session.add(
+        AgentPrincipal(
+            id=uuid.uuid4(),
+            tenant_id=tenant_id,
+            name=name,
+            keycloak_client_id=f"agent:{name}",
+            keycloak_internal_id=f"kc-internal-{tenant_id.hex[:8]}-{name}",
+            owner_sub="op-admin",
+            revoked=False,
+            created_by_sub="op-admin",
+        )
+    )
+    session.add(
+        AgentDefinition(
+            id=definition_id,
+            tenant_id=tenant_id,
+            name=name,
+            identity_ref=f"agent:{name}",
+            model_tier="standard",
+            system_prompt="You triage incidents.",
+            toolset={},
+            turn_budget=10,
+            created_by_sub="op-admin",
+        )
+    )
+    for status in (ScheduledTriggerStatus.ACTIVE, ScheduledTriggerStatus.CANCELLED):
+        session.add(
+            ScheduledTrigger(
+                id=uuid.uuid4(),
+                tenant_id=tenant_id,
+                agent_definition_id=definition_id,
+                kind=ScheduledTriggerKind.CRON.value,
+                cron_expr="*/5 * * * *",
+                status=status.value,
+                in_flight_policy=ScheduledTriggerInFlightPolicy.FAIL_INTO_AUDIT.value,
+                identity_sub="__scheduler__",
+                created_by_sub="op-admin",
+                created_at=now,
+                updated_at=now,
+            )
+        )
+    await session.commit()
+    return definition_id
+
+
+async def _count_triggers(session: AsyncSession, definition_id: uuid.UUID) -> int:
+    result = await session.execute(
+        select(func.count())
+        .select_from(ScheduledTrigger)
+        .where(ScheduledTrigger.agent_definition_id == definition_id)
+    )
+    return int(result.scalar_one())
+
+
+# ---------------------------------------------------------------------------
+# Service layer -- the bulk Core DELETE triggers the DB-level cascade
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.asyncio
+async def test_service_delete_cascades_active_and_cancelled_triggers() -> None:
+    """``service.delete`` removes the definition and cascade-deletes its triggers.
+
+    Proves the bulk Core ``DELETE ... RETURNING`` fires the DB-level
+    ``ON DELETE CASCADE`` -- an ORM ``cascade=`` relationship would not,
+    since the delete never goes through the unit of work.
+    """
+    tenant_id = uuid.uuid4()
+    sessionmaker = get_sessionmaker()
+    async with sessionmaker() as session:
+        definition_id = await _seed_definition_with_triggers(session, tenant_id=tenant_id)
+        assert await _count_triggers(session, definition_id) == 2
+
+    service = AgentDefinitionService()
+    deleted = await service.delete(tenant_id, "incident-triage")
+    assert deleted is True
+
+    async with sessionmaker() as session:
+        gone = await session.execute(
+            select(AgentDefinition).where(AgentDefinition.id == definition_id)
+        )
+        assert gone.scalar_one_or_none() is None
+        # The dependent triggers -- active and cancelled alike -- went
+        # with the parent. No orphan rows pinning the FK.
+        assert await _count_triggers(session, definition_id) == 0
+
+
+@pytest.mark.asyncio
+async def test_service_delete_does_not_touch_other_definitions_triggers() -> None:
+    """The cascade is scoped to the deleted definition's triggers only."""
+    tenant_id = uuid.uuid4()
+    sessionmaker = get_sessionmaker()
+    async with sessionmaker() as session:
+        keep_id = await _seed_definition_with_triggers(session, tenant_id=tenant_id, name="keep-me")
+        drop_id = await _seed_definition_with_triggers(session, tenant_id=tenant_id, name="drop-me")
+
+    service = AgentDefinitionService()
+    assert await service.delete(tenant_id, "drop-me") is True
+
+    async with sessionmaker() as session:
+        assert await _count_triggers(session, drop_id) == 0
+        # The untouched definition keeps both of its triggers.
+        assert await _count_triggers(session, keep_id) == 2
+        survivor = await session.execute(
+            select(AgentDefinition).where(AgentDefinition.id == keep_id)
+        )
+        assert survivor.scalar_one_or_none() is not None
+
+
+# ---------------------------------------------------------------------------
+# REST surface -- clean 204, not an unhandled 500
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.asyncio
+async def test_rest_delete_scheduled_definition_returns_204() -> None:
+    """``DELETE /api/v1/agents/{name}`` on a scheduled definition is a clean 204.
+
+    Drives the real REST handler. Pre-fix this raised an uncaught
+    :class:`IntegrityError` -> HTTP 500; with the cascade it deletes the
+    definition + its triggers and returns 204 No Content.
+    """
+    sessionmaker = get_sessionmaker()
+    async with sessionmaker() as session:
+        definition_id = await _seed_definition_with_triggers(session, tenant_id=OPERATOR_TENANT_ID)
+
+    operator = build_operator(TenantRole.TENANT_ADMIN)
+    from meho_backplane.api.v1.agents import delete_agent
+
+    response = await delete_agent(name="incident-triage", operator=operator)
+    assert response.status_code == 204
+
+    async with sessionmaker() as session:
+        gone = await session.execute(
+            select(AgentDefinition).where(AgentDefinition.id == definition_id)
+        )
+        assert gone.scalar_one_or_none() is None
+        assert await _count_triggers(session, definition_id) == 0
+
+
+# ---------------------------------------------------------------------------
+# MCP surface -- {removed: true}, not -32603
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.asyncio
+async def test_mcp_delete_scheduled_definition_returns_removed() -> None:
+    """The ``meho.agents.delete`` handler returns ``{removed: true}``.
+
+    Drives the real MCP tool handler. Pre-fix the uncaught
+    :class:`IntegrityError` was mapped to ``-32603 "internal error:
+    IntegrityError"`` by the dispatcher's bare-``except`` arm; with the
+    cascade the handler returns its success payload.
+    """
+    sessionmaker = get_sessionmaker()
+    async with sessionmaker() as session:
+        definition_id = await _seed_definition_with_triggers(session, tenant_id=OPERATOR_TENANT_ID)
+
+    operator = build_operator(TenantRole.TENANT_ADMIN)
+    result = await agents_mcp._delete_handler(operator, {"name": "incident-triage"})
+    assert result == {"removed": True}
+
+    async with sessionmaker() as session:
+        gone = await session.execute(
+            select(AgentDefinition).where(AgentDefinition.id == definition_id)
+        )
+        assert gone.scalar_one_or_none() is None
+        assert await _count_triggers(session, definition_id) == 0
+
+
+@pytest.mark.parametrize("client_with_operator", [TenantRole.TENANT_ADMIN], indirect=True)
+@pytest.mark.asyncio
+async def test_mcp_delete_scheduled_definition_over_the_wire(
+    client_with_operator: tuple[TestClient, Operator],  # noqa: F811
+) -> None:
+    """End-to-end: a JSON-RPC ``tools/call`` delete on a scheduled definition succeeds.
+
+    Exercises the full dispatcher path -- the surface that produced the
+    original ``-32603`` envelope. Asserts no JSON-RPC ``error`` object is
+    present and the result is the ``{removed: true}`` payload.
+    """
+    client, operator = client_with_operator
+    sessionmaker = get_sessionmaker()
+    async with sessionmaker() as session:
+        await _seed_definition_with_triggers(session, tenant_id=operator.tenant_id)
+
+    response = post_mcp(
+        client,
+        {
+            "jsonrpc": "2.0",
+            "id": 1,
+            "method": "tools/call",
+            "params": {
+                "name": "meho.agents.delete",
+                "arguments": {"name": "incident-triage"},
+            },
+        },
+    )
+    body = response.json()
+    assert "error" not in body, body
+    payload: dict[str, Any] = json.loads(body["result"]["content"][0]["text"])
+    assert payload == {"removed": True}

--- a/backend/tests/test_migration_0035_scheduled_trigger_fk_cascade.py
+++ b/backend/tests/test_migration_0035_scheduled_trigger_fk_cascade.py
@@ -1,0 +1,241 @@
+# SPDX-License-Identifier: Apache-2.0
+# Copyright (c) 2026 evoila Group
+
+"""Behavioural tests for Alembic migration ``0035_scheduled_trigger_fk_cascade``.
+
+Issue #1480 (G0.19 v0.10.0 dogfood hardening). Migration 0035 rebuilds
+the ``scheduled_trigger.agent_definition_id`` FK with ``ON DELETE
+CASCADE`` so deleting an ``agent_definition`` cascade-deletes its
+dependent trigger rows (including a cancelled one retained for audit)
+instead of raising a foreign-key violation.
+
+Test matrix
+-----------
+
+* **Upgrade installs the cascade.** After ``upgrade 0035`` (with SQLite
+  ``PRAGMA foreign_keys=ON``), deleting the parent ``agent_definition``
+  via a raw bulk ``DELETE`` succeeds and removes the dependent
+  ``scheduled_trigger`` rows.
+* **Reflection shows ``ON DELETE CASCADE``.** ``PRAGMA
+  foreign_key_list(scheduled_trigger)`` reports ``CASCADE`` on the
+  ``agent_definition`` FK at 0035.
+* **Downgrade restores the blocking FK.** After ``downgrade "0034"`` the
+  cascade is gone (``on_delete`` back to ``NO ACTION``) and a bulk
+  parent delete raises ``IntegrityError`` again -- the 0020 behaviour.
+
+The tests follow the synchronous pattern of
+:mod:`tests.test_migration_0025_scheduled_trigger`:
+``alembic.command.upgrade`` runs ``asyncio.run`` internally via env.py's
+async cookbook, so each test function is sync. A fresh file-backed
+SQLite DB per test isolates the migration replay.
+"""
+
+from __future__ import annotations
+
+import uuid
+from collections.abc import Iterator
+from pathlib import Path
+
+import pytest
+from alembic import command
+from alembic.config import Config
+from sqlalchemy import create_engine as sa_create_engine
+from sqlalchemy import text
+from sqlalchemy.exc import IntegrityError
+
+from meho_backplane.db.engine import reset_engine_for_testing
+from meho_backplane.db.migrations import alembic_config
+from meho_backplane.settings import get_settings
+
+
+@pytest.fixture
+def alembic_cfg(
+    monkeypatch: pytest.MonkeyPatch,
+    tmp_path: Path,
+) -> Iterator[tuple[Config, str]]:
+    """Pin env, reset caches, return an Alembic config + sync URL.
+
+    Same shape as
+    :func:`tests.test_migration_0025_scheduled_trigger.alembic_cfg`:
+    sync because Alembic's env.py runs ``asyncio.run`` internally; an
+    isolated SQLite DB per test; settings + engine caches reset on entry
+    and exit.
+    """
+    db_path = tmp_path / "migration_0035.db"
+    async_url = f"sqlite+aiosqlite:///{db_path}"
+    sync_url = f"sqlite:///{db_path}"
+    monkeypatch.setenv("DATABASE_URL", async_url)
+    monkeypatch.setenv("KEYCLOAK_ISSUER_URL", "https://keycloak.test/realms/meho")
+    monkeypatch.setenv("KEYCLOAK_AUDIENCE", "meho-backplane")
+    monkeypatch.setenv("VAULT_ADDR", "https://vault.test")
+    get_settings.cache_clear()
+    reset_engine_for_testing()
+
+    cfg = alembic_config()
+    cfg.set_main_option("sqlalchemy.url", async_url)
+    try:
+        yield cfg, sync_url
+    finally:
+        get_settings.cache_clear()
+        reset_engine_for_testing()
+
+
+def _seed_definition_with_trigger(sync_url: str) -> tuple[uuid.UUID, uuid.UUID, uuid.UUID]:
+    """Insert tenant + agent_definition + one cancelled scheduled_trigger.
+
+    Returns ``(tenant_id, definition_id, trigger_id)``. The cancelled
+    status is deliberate: it is the exact row #1480 reports as blocking a
+    delete (``cancel()`` retains it for audit), so the cascade test
+    covers the worst case.
+    """
+    tenant_id = uuid.uuid4()
+    definition_id = uuid.uuid4()
+    trigger_id = uuid.uuid4()
+    slug = f"test-0035-{tenant_id.hex[:8]}"
+    name = f"test-0035-agent-{definition_id.hex[:8]}"
+
+    sync_eng = sa_create_engine(sync_url)
+    try:
+        with sync_eng.begin() as conn:
+            conn.execute(
+                text(
+                    "INSERT INTO tenant (id, slug, name, created_at) "
+                    "VALUES (:id, :slug, :name, :now)"
+                ),
+                {"id": str(tenant_id), "slug": slug, "name": slug, "now": "2026-06-03T00:00:00"},
+            )
+            conn.execute(
+                text(
+                    "INSERT INTO agent_definition "
+                    "(id, tenant_id, name, identity_ref, model_tier, "
+                    " system_prompt, toolset, turn_budget, enabled, "
+                    " created_by_sub, created_at, updated_at) "
+                    "VALUES (:id, :tenant_id, :name, :identity_ref, "
+                    " :model_tier, :system_prompt, :toolset, "
+                    " :turn_budget, :enabled, :sub, :now, :now)"
+                ),
+                {
+                    "id": str(definition_id),
+                    "tenant_id": str(tenant_id),
+                    "name": name,
+                    "identity_ref": f"agent:{name}",
+                    "model_tier": "standard",
+                    "system_prompt": "test",
+                    "toolset": "{}",
+                    "turn_budget": 2,
+                    "enabled": 1,
+                    "sub": "seed-admin",
+                    "now": "2026-06-03T00:00:00",
+                },
+            )
+            conn.execute(
+                text(
+                    "INSERT INTO scheduled_trigger "
+                    "(id, tenant_id, agent_definition_id, kind, cron_expr, "
+                    " timezone, status, in_flight_policy, identity_sub, "
+                    " created_by_sub, created_at, updated_at) "
+                    "VALUES (:id, :tenant_id, :definition_id, 'cron', "
+                    " '*/5 * * * *', 'UTC', 'cancelled', 'fail_into_audit', "
+                    " '__scheduler__', 'seed-admin', :now, :now)"
+                ),
+                {
+                    "id": str(trigger_id),
+                    "tenant_id": str(tenant_id),
+                    "definition_id": str(definition_id),
+                    "now": "2026-06-03T00:00:00",
+                },
+            )
+    finally:
+        sync_eng.dispose()
+    return tenant_id, definition_id, trigger_id
+
+
+def _fk_on_delete(sync_url: str) -> str | None:
+    """Return the ``on_delete`` action for the agent_definition FK, or None."""
+    sync_eng = sa_create_engine(sync_url)
+    try:
+        with sync_eng.connect() as conn:
+            rows = conn.execute(text("PRAGMA foreign_key_list(scheduled_trigger)")).all()
+    finally:
+        sync_eng.dispose()
+    for row in rows:
+        # PRAGMA columns: id, seq, table, from, to, on_update, on_delete, match
+        if str(row[2]) == "agent_definition":
+            return str(row[6])
+    return None
+
+
+def _delete_definition(sync_url: str, definition_id: uuid.UUID) -> None:
+    """Bulk-delete the parent definition with SQLite FK enforcement on."""
+    sync_eng = sa_create_engine(sync_url)
+    try:
+        with sync_eng.begin() as conn:
+            conn.execute(text("PRAGMA foreign_keys = ON"))
+            conn.execute(
+                text("DELETE FROM agent_definition WHERE id = :id"),
+                {"id": str(definition_id)},
+            )
+    finally:
+        sync_eng.dispose()
+
+
+def _trigger_count(sync_url: str, definition_id: uuid.UUID) -> int:
+    sync_eng = sa_create_engine(sync_url)
+    try:
+        with sync_eng.connect() as conn:
+            row = conn.execute(
+                text("SELECT COUNT(*) FROM scheduled_trigger WHERE agent_definition_id = :id"),
+                {"id": str(definition_id)},
+            ).scalar_one()
+    finally:
+        sync_eng.dispose()
+    return int(row)
+
+
+def test_upgrade_sets_on_delete_cascade(alembic_cfg: tuple[Config, str]) -> None:
+    """``upgrade 0035`` reflects ``CASCADE`` on the agent_definition FK."""
+    cfg, sync_url = alembic_cfg
+    command.upgrade(cfg, "0035")
+    assert _fk_on_delete(sync_url) == "CASCADE"
+
+
+def test_upgrade_cascade_deletes_dependent_triggers(
+    alembic_cfg: tuple[Config, str],
+) -> None:
+    """At 0035, a bulk parent delete cascade-deletes its triggers (no error).
+
+    This is the acceptance-criterion proof: a **bulk** ``DELETE`` (the
+    shape :meth:`AgentDefinitionService.delete` issues) triggers the
+    DB-level cascade. Pre-fix the same delete raised ``IntegrityError``.
+    """
+    cfg, sync_url = alembic_cfg
+    command.upgrade(cfg, "0035")
+
+    _tenant_id, definition_id, _trigger_id = _seed_definition_with_trigger(sync_url)
+    assert _trigger_count(sync_url, definition_id) == 1
+
+    _delete_definition(sync_url, definition_id)
+
+    assert _trigger_count(sync_url, definition_id) == 0
+
+
+def test_downgrade_restores_blocking_fk(alembic_cfg: tuple[Config, str]) -> None:
+    """``downgrade "0034"`` removes the cascade; a parent delete blocks again.
+
+    Round-trips the migration: after the downgrade the FK is back to the
+    no-``ondelete`` (``NO ACTION``) shape 0020 shipped, so deleting a
+    definition that still has a trigger raises ``IntegrityError`` -- the
+    exact regression #1480 fixed.
+    """
+    cfg, sync_url = alembic_cfg
+    command.upgrade(cfg, "0035")
+    command.downgrade(cfg, "0034")
+
+    assert _fk_on_delete(sync_url) in (None, "NO ACTION")
+
+    _tenant_id, definition_id, _trigger_id = _seed_definition_with_trigger(sync_url)
+    with pytest.raises(IntegrityError):
+        _delete_definition(sync_url, definition_id)
+
+    # The blocking trigger is still present -- the delete was refused.
+    assert _trigger_count(sync_url, definition_id) == 1

--- a/docs/codebase/agent-definition.md
+++ b/docs/codebase/agent-definition.md
@@ -141,6 +141,17 @@ existence is not leaked across the tenant boundary.
 cross-tenant returns `False` → 404. The CLI `delete` verb prompts for
 confirmation unless `--confirm` is passed.
 
+The delete is a **bulk Core** `DELETE`, so a definition's dependent
+`scheduled_trigger` rows are removed by the DB-level
+`ON DELETE CASCADE` on `scheduled_trigger.agent_definition_id`
+(migration `0035`, #1480), not by an ORM relationship cascade (which a
+bulk delete bypasses). This covers a cancelled trigger the scheduler
+retains for audit too — before 0035 such a row left an FK violation
+that surfaced as an opaque `-32603 "internal error: IntegrityError"`
+(MCP) / unhandled 500 (REST), making a once-scheduled definition
+undeletable via the API. `agent_run` history is a nullable soft-FK with
+no `ForeignKey` clause, so runs never block deletion and survive it.
+
 ## RBAC
 
 Reads (`list` / `show`) require `operator`; writes (`create` / `edit` /
@@ -208,3 +219,7 @@ event regardless of transport (REST vs MCP).
   `kb/service.py`.
 - Migration FK + dialect-portability discipline:
   `alembic/versions/0008_create_broadcast_override.py`.
+- Delete cascade onto `scheduled_trigger` (#1480):
+  `alembic/versions/0035_scheduled_trigger_fk_cascade.py` — dialect-split
+  FK rebuild (PG online `ALTER`, SQLite `batch_alter_table` table
+  recreate with a `naming_convention`).

--- a/docs/codebase/scheduler.md
+++ b/docs/codebase/scheduler.md
@@ -34,9 +34,11 @@ DBOS rebase swaps only the loop module.
 - `ScheduledTrigger` ([db/models.py](../../backend/src/meho_backplane/db/models.py))
   — the durable row. One per trigger. Columns:
   - `id`, `tenant_id` (real FK), `agent_definition_id` (real FK to
-    `agent_definition` — `ondelete` is the default NO ACTION, so a
-    definition cannot be removed while triggers reference it),
-    `identity_sub`, `created_by_sub`.
+    `agent_definition` with `ON DELETE CASCADE` — migration `0035`,
+    #1480 — so deleting a definition cascade-deletes its trigger rows,
+    including a cancelled one retained for audit; before 0035 the
+    default `NO ACTION` made a once-scheduled definition undeletable via
+    the API), `identity_sub`, `created_by_sub`.
   - `kind` (closed enum: `cron`/`one_off`), `cron_expr` (NULL for
     one-off), `fire_at` (one-off scheduled instant, NULL for cron),
     `timezone` (IANA name, default `UTC`).


### PR DESCRIPTION
## Summary

- `agents.delete` on a definition that ever had a `scheduled_trigger` — including a now-**cancelled** one `cancel()` retains for audit — was undeletable: the `scheduled_trigger.agent_definition_id` FK shipped with no `ondelete`, so the bulk Core `DELETE` raised an uncaught `IntegrityError` that surfaced as `-32603 "internal error: IntegrityError"` (MCP) / unhandled 500 (REST).
- Fix is a DB-level `ON DELETE CASCADE` (migration `0035`), not an ORM relationship cascade — the delete is a bulk Core statement that bypasses the unit of work, so only a database-level `ON DELETE` fires. `CASCADE` over `SET NULL` because the column is `NOT NULL`.
- Bounded blast radius: `scheduled_trigger` is the only hard FK to `agent_definition` (`agent_run` is a nullable soft-FK), so run history and audit logs survive the delete.
- Both MCP and REST surfaces covered; migration rebuilds the FK dialect-split (PG online `ALTER`, SQLite `batch_alter_table` table recreate with a `naming_convention`).

## Test plan

- [x] `ruff check` — clean
- [x] `ruff format --check` — clean
- [x] `mypy src/meho_backplane/` — Success, no issues in 395 files
- [x] `pytest` agent/scheduler/migration/mcp sweep — 649 passed, 11 skipped (sandbox-secret-gated), 0 failed
- [x] **Service layer (bulk Core delete fires the DB cascade):** `test_service_delete_cascades_active_and_cancelled_triggers` under `MEHO_SQLITE_FOREIGN_KEYS=1` — definition + its active and cancelled triggers all deleted
- [x] **Cascade is scoped:** `test_service_delete_does_not_touch_other_definitions_triggers`
- [x] **REST:** `DELETE /api/v1/agents/{name}` on a scheduled definition → clean 204, not 500
- [x] **MCP:** `meho.agents.delete` in-process and over-the-wire → `{removed: true}`, no `-32603` envelope
- [x] **Migration:** `upgrade 0035` reflects `CASCADE` and a bulk parent delete cascades; `downgrade 0034` restores the blocking FK (parent delete raises `IntegrityError` again)

## Out of scope

- `agent_run` history retention policy (runs already never blocked deletion — nullable soft-FK).
- Soft-delete / tombstoning of agent definitions.

<!-- auto-implement-issue: fresh, iteration 1 -->

Closes #1480
