### PR TITLE
fix(scheduler): source agent client_credentials from Vault, not pod env (#1478)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -90,6 +90,17 @@ connector-related release-notes line.
 
 ## [Unreleased]
 
+### Fixed
+
+- Scheduler now sources an agent's `client_credentials` secret from Vault
+  instead of a pod environment variable, so an agent registered + defined
+  purely over the API is schedulable with no `MEHO_AGENT_SECRET_*` env var
+  and no redeploy. Registration captures the Keycloak-generated client
+  secret and persists it to Vault under a scheduler service token
+  (`VAULT_SCHEDULER_TOKEN`); `resolve_agent_credentials` reads it
+  Vault-first, keeping the env var as a documented break-glass fallback
+  (#1478).
+
 ## [0.10.0] - 2026-06-01
 
 The **connector write-surface** release: MEHO connectors graduate from

--- a/backend/src/meho_backplane/api/v1/agent_principals.py
+++ b/backend/src/meho_backplane/api/v1/agent_principals.py
@@ -66,6 +66,7 @@ from meho_backplane.auth.keycloak_admin import (
 )
 from meho_backplane.auth.operator import Operator, TenantRole
 from meho_backplane.auth.rbac import require_role
+from meho_backplane.scheduler.vault_credentials import SchedulerVaultBrokerError
 
 __all__ = ["router"]
 
@@ -200,6 +201,16 @@ async def register_agent_principal(
         ) from exc
     except KeycloakAdminError as exc:
         raise _handle_admin_error(exc) from exc
+    except SchedulerVaultBrokerError as exc:
+        # ``VAULT_SCHEDULER_TOKEN`` is set but the Vault write failed
+        # (unreachable / denied). 502 upstream failure; the just-created
+        # Keycloak client is already rolled back. (An *unset* token is not
+        # an error — the service skips the write and the agent uses the
+        # env-var fallback.)
+        raise HTTPException(
+            status_code=http_status.HTTP_502_BAD_GATEWAY,
+            detail="scheduler_vault_write_error",
+        ) from exc
     except ValueError as exc:
         raise HTTPException(
             status_code=http_status.HTTP_422_UNPROCESSABLE_ENTITY,

--- a/backend/src/meho_backplane/auth/agent_principals.py
+++ b/backend/src/meho_backplane/auth/agent_principals.py
@@ -68,6 +68,10 @@ from meho_backplane.auth.keycloak_admin import (
 )
 from meho_backplane.db.engine import get_sessionmaker
 from meho_backplane.db.models import AgentPrincipal
+from meho_backplane.scheduler.vault_credentials import (
+    SchedulerVaultNotConfiguredError,
+    write_agent_secret,
+)
 
 __all__ = [
     "AgentPrincipalCreate",
@@ -156,20 +160,25 @@ class AgentPrincipalService:
     ) -> AgentPrincipalRead:
         """Register a new agent principal.
 
-        Creates the Keycloak client first; on success inserts the DB row.
-        If the Keycloak creation fails the DB row is never written.
+        Creates the Keycloak client first, captures its generated
+        ``client_credentials`` secret, and persists that secret to Vault
+        via :meth:`_persist_secret_to_vault` (so the operator-less
+        scheduler can read it back — G0.19-T2 #1478); on success inserts
+        the DB row. If any step fails the Keycloak client is rolled back
+        and the DB row is never written.
 
         Raises
         ------
         ValueError
             When *name* contains characters outside the safe alphabet.
         AgentPrincipalExistsError
-            When a principal with the same name already exists in this
-            tenant (unique-index violation on DB or Keycloak 409).
-        KeycloakAdminNotConfiguredError
-            When Keycloak admin credentials are not configured.
-        KeycloakAdminError
-            On any Keycloak Admin API failure.
+            Duplicate ``(tenant_id, name)`` (DB unique-index or Keycloak 409).
+        KeycloakAdminNotConfiguredError / KeycloakAdminError
+            Keycloak admin unconfigured / any Admin API failure.
+        SchedulerVaultBrokerError
+            Vault configured but the secret write failed — see
+            :meth:`_persist_secret_to_vault` (an *unset* token is a
+            skip-with-warning, not a raise).
         """
         if not _NAME_PATTERN.fullmatch(payload.name):
             raise ValueError(
@@ -180,7 +189,10 @@ class AgentPrincipalService:
         owner = payload.owner_sub or created_by_sub
         client_id = _keycloak_client_id(payload.name)
 
-        # Phase 1: create Keycloak client (fail before DB on error).
+        # Phase 1: create Keycloak client + capture its generated secret
+        # in the same admin session (create_client returns only the
+        # internal UUID; Keycloak never echoes the generated secret on
+        # create). Fail before any DB write on error.
         kc_client = KeycloakAdminClient.from_settings()
         try:
             async with kc_client:
@@ -190,14 +202,21 @@ class AgentPrincipalService:
                     tenant_id=str(tenant_id),
                     owner_sub=owner,
                 )
+                client_secret = await kc_client.get_client_secret(internal_id)
         except KeycloakClientConflictError as exc:
             raise AgentPrincipalExistsError(payload.name) from exc
 
-        # Phase 2: insert the DB row. If anything fails after the Keycloak
-        # client was created, delete that client before surfacing the error:
-        # a created client with no MEHO row is an orphaned, token-issuing
-        # identity that can never be listed or revoked through MEHO — exactly
-        # the unreachable-kill-switch failure this lifecycle exists to prevent.
+        # Phase 1b: persist the captured secret to Vault for the scheduler.
+        await self._persist_secret_to_vault(
+            client_id,
+            client_secret,
+            internal_id=internal_id,
+            tenant_id=tenant_id,
+            name=payload.name,
+        )
+
+        # Phase 2: insert the DB row (rolls back the Keycloak client on
+        # any failure — see _insert_row).
         row = AgentPrincipal(
             tenant_id=tenant_id,
             name=payload.name,
@@ -207,6 +226,31 @@ class AgentPrincipalService:
             revoked=False,
             created_by_sub=created_by_sub,
         )
+        entry = await self._insert_row(row, internal_id=internal_id, name=payload.name)
+        self._log.info(
+            "agent_principal_register",
+            tenant_id=str(tenant_id),
+            name=payload.name,
+            keycloak_client_id=client_id,
+            created_by_sub=created_by_sub,
+        )
+        return entry
+
+    async def _insert_row(
+        self,
+        row: AgentPrincipal,
+        *,
+        internal_id: str,
+        name: str,
+    ) -> AgentPrincipalRead:
+        """Insert the agent-principal DB row; roll back the KC client on failure.
+
+        If anything fails after the Keycloak client was created, delete
+        that client before surfacing the error: a created client with no
+        MEHO row is an orphaned, token-issuing identity that can never be
+        listed or revoked through MEHO — exactly the unreachable-kill-switch
+        failure this lifecycle exists to prevent.
+        """
         sessionmaker = get_sessionmaker()
         try:
             async with sessionmaker() as session:
@@ -216,24 +260,57 @@ class AgentPrincipalService:
                 except IntegrityError as exc:
                     await session.rollback()
                     if _is_unique_violation(exc):
-                        raise AgentPrincipalExistsError(payload.name) from exc
+                        raise AgentPrincipalExistsError(name) from exc
                     raise
                 await session.refresh(row)
                 entry = AgentPrincipalRead.model_validate(row)
                 await session.commit()
         except BaseException as exc:
             await self._rollback_orphan_client(
-                internal_id, tenant_id=tenant_id, name=payload.name, cause=exc
+                internal_id, tenant_id=row.tenant_id, name=name, cause=exc
             )
             raise
-        self._log.info(
-            "agent_principal_register",
-            tenant_id=str(tenant_id),
-            name=payload.name,
-            keycloak_client_id=client_id,
-            created_by_sub=created_by_sub,
-        )
         return entry
+
+    async def _persist_secret_to_vault(
+        self,
+        client_id: str,
+        client_secret: str,
+        *,
+        internal_id: str,
+        tenant_id: uuid.UUID,
+        name: str,
+    ) -> None:
+        """Persist the captured Keycloak secret to Vault (G0.19-T2 #1478).
+
+        Two failure postures:
+
+        * **Vault not configured** (``VAULT_SCHEDULER_TOKEN`` unset) — skip
+          the write with a WARN and continue. The deployment has opted out
+          of the Vault path; the agent stays schedulable via the env-var
+          fallback (the documented break-glass). Keeps registration
+          backward-compatible with env-var-only deployments rather than
+          hard-failing them on the new requirement.
+        * **Vault configured but the write failed** (unreachable / denied)
+          — roll back the just-created Keycloak client and surface the
+          error. A client whose secret was *meant* to reach Vault but
+          didn't would be unschedulable with no signal, so we fail closed,
+          same posture as a Phase-2 DB failure.
+        """
+        try:
+            await write_agent_secret(client_id, client_secret)
+        except SchedulerVaultNotConfiguredError:
+            self._log.warning(
+                "agent_principal_register_vault_skip",
+                tenant_id=str(tenant_id),
+                name=name,
+                reason="scheduler_vault_not_configured",
+            )
+        except BaseException as exc:
+            await self._rollback_orphan_client(
+                internal_id, tenant_id=tenant_id, name=name, cause=exc
+            )
+            raise
 
     async def _rollback_orphan_client(
         self,

--- a/backend/src/meho_backplane/auth/keycloak_admin.py
+++ b/backend/src/meho_backplane/auth/keycloak_admin.py
@@ -307,6 +307,62 @@ class KeycloakAdminClient:
             )
         return internal_id
 
+    async def get_client_secret(self, keycloak_internal_id: str) -> str:
+        """Return the ``client_credentials`` secret for an existing client.
+
+        Calls ``GET /clients/{id}/client-secret`` (G0.19-T2 #1478). The
+        Keycloak Admin REST API returns a ``CredentialRepresentation``
+        ``{"type": "secret", "value": "<secret>"}``; this method extracts
+        and returns the ``value``. Used by the agent-principal register
+        path to capture the secret Keycloak generated for the new
+        confidential client (``create_client`` only returns the internal
+        UUID — the generated secret is never echoed there) so it can be
+        persisted to Vault for the operator-less scheduler to read.
+
+        The secret is **never** logged or surfaced in an error message —
+        only its absence is.
+
+        Raises
+        ------
+        KeycloakClientNotFoundError
+            The internal id is unknown (Keycloak 404).
+        KeycloakAdminError
+            A non-404 failure, or a 200 whose body carries no usable
+            ``value`` (a public client / a client without a secret).
+        """
+        assert self._http is not None
+        assert self._token
+        log = structlog.get_logger(__name__)
+        url = f"{self._admin_url}/clients/{keycloak_internal_id}/client-secret"
+        try:
+            resp = await self._http.get(url, headers=self._auth_headers())
+        except httpx.HTTPError as exc:
+            raise KeycloakAdminError(
+                f"Keycloak get_client_secret network error: {type(exc).__name__}"
+            ) from exc
+        if resp.status_code == 404:
+            raise KeycloakClientNotFoundError(f"Keycloak client {keycloak_internal_id!r} not found")
+        if resp.status_code != 200:
+            log.warning(
+                "keycloak_get_client_secret_failed",
+                keycloak_internal_id=keycloak_internal_id,
+                status=resp.status_code,
+            )
+            raise KeycloakAdminError(f"Keycloak get_client_secret failed: HTTP {resp.status_code}")
+        representation: dict[str, Any] = resp.json()
+        secret = str(representation.get("value", "")).strip()
+        if not secret:
+            # A confidential client always has a secret; an empty value
+            # means the client is public (no secret) or the realm is
+            # misconfigured. Surface it as an admin error rather than
+            # persisting an empty credential the scheduler can't use.
+            raise KeycloakAdminError(
+                f"Keycloak get_client_secret returned no secret value for "
+                f"client {keycloak_internal_id!r} (public client or "
+                "misconfigured realm?)"
+            )
+        return secret
+
     async def disable_client(self, keycloak_internal_id: str) -> None:
         """Disable the Keycloak client identified by *keycloak_internal_id*.
 

--- a/backend/src/meho_backplane/scheduler/credentials.py
+++ b/backend/src/meho_backplane/scheduler/credentials.py
@@ -8,19 +8,33 @@ The scheduler fires agent runs via
 (G11.2-T2 #1096) which expects ``(agent_client_id, agent_client_secret)``
 for the Keycloak ``client_credentials`` grant. The scheduler is
 operator-less (no JWT to hand to
-:func:`~meho_backplane.auth.vault.vault_client_for_operator`), so the
-v0.2 credential source is the backplane pod's environment variable
-matrix. Operators wire agent secrets into the pod the same way
-``ANTHROPIC_API_KEY`` is wired today (Helm chart secret /
-external-secrets / sealed-secret); the env-var name is derived from the
-agent's ``identity_ref`` via the
-:attr:`Settings.scheduler_agent_secret_env_pattern` pattern.
+:func:`~meho_backplane.auth.vault.vault_client_for_operator`), so it
+sources the secret under its own **static service token** rather than a
+per-operator Keycloak JWT.
 
-The forward-compat Vault path
-(:attr:`Settings.scheduler_agent_vault_path_pattern`) is shipped but
-unused -- a future G11.2 follow-up will swap this module's
-:func:`resolve_agent_credentials` over to a scheduler-service-token
-Vault read without changing the call site.
+Resolution order (G0.19-T2 #1478)
+---------------------------------
+
+:func:`resolve_agent_credentials` is **Vault-first**:
+
+1. **Vault** — read the agent's secret from
+   :attr:`Settings.scheduler_agent_vault_path_pattern` under
+   :attr:`Settings.vault_scheduler_token`
+   (:func:`meho_backplane.scheduler.vault_credentials.read_agent_secret`).
+   This is the path registration writes to
+   (:meth:`~meho_backplane.auth.agent_principals.AgentPrincipalService.register`),
+   so an agent registered + defined purely over the API is schedulable
+   with **no pod env var and no redeploy**.
+2. **Env var (fallback / break-glass)** — when Vault yields nothing (not
+   configured, secret absent), read the secret from the env var derived
+   from :attr:`Settings.scheduler_agent_secret_env_pattern`. Operators
+   wire agent secrets into the pod the same way ``ANTHROPIC_API_KEY`` is
+   wired when Vault is unavailable.
+
+When **neither** source yields a secret, the resolver raises
+:class:`AgentCredentialsUnresolvedError` (loud, trigger-preserving — the
+loop logs ``scheduler_credentials_unresolved`` and leaves the trigger
+``active`` for the next tick).
 
 Identity-ref -> client-id derivation
 ------------------------------------
@@ -44,9 +58,10 @@ sanitised identity_ref:
 * Default pattern ``MEHO_AGENT_SECRET_{client_id}`` therefore yields
   ``MEHO_AGENT_SECRET_AGENT_INCIDENT_TRIAGE``.
 
-The function is deterministic + pure (no side effects, no I/O beyond
-:func:`os.environ`'s lookup) so unit tests can exercise it without
-fixtures by monkey-patching the env directly.
+:func:`agent_client_id_from_identity_ref` is deterministic + pure (no
+side effects, no I/O) so the env-var-name derivation can be unit-tested
+without fixtures. :func:`resolve_agent_credentials` performs a Vault read
+(I/O) before falling back to :func:`os.environ`.
 """
 
 from __future__ import annotations
@@ -54,7 +69,11 @@ from __future__ import annotations
 import os
 import re
 
+import structlog
+
 from meho_backplane.settings import get_settings
+
+_log = structlog.get_logger(__name__)
 
 __all__ = [
     "AgentCredentialsUnresolvedError",
@@ -96,44 +115,92 @@ def agent_client_id_from_identity_ref(identity_ref: str) -> str:
     return _ENV_NAME_FORBIDDEN.sub("_", identity_ref)
 
 
-def resolve_agent_credentials(identity_ref: str) -> tuple[str, str]:
+def _env_var_name_for(identity_ref: str) -> str:
+    """Return the env-var name the secret pattern resolves to for *identity_ref*.
+
+    Substitutes the sanitised + upper-cased identity_ref into
+    :attr:`Settings.scheduler_agent_secret_env_pattern`, then upper-cases
+    the whole result. Operators who set a non-upper-cased pattern (e.g.
+    ``meho_agent_secret_{client_id}``) otherwise resolve to a mixed-case
+    env-var name that Linux's case-sensitive lookup would miss — the
+    precondition gate would skip every fire with a
+    ``credentials_unresolved`` warning pointing at the secret rather than
+    the case-mismatch. The contract is "the whole substituted name is
+    upper-cased"; this makes the code match it.
+    """
+    settings = get_settings()
+    sanitised = agent_client_id_from_identity_ref(identity_ref).upper()
+    return settings.scheduler_agent_secret_env_pattern.format(client_id=sanitised).upper()
+
+
+def _secret_from_env(identity_ref: str) -> str:
+    """Return the agent secret from the env var, or ``""`` when unset/empty."""
+    return os.environ.get(_env_var_name_for(identity_ref), "").strip()
+
+
+async def resolve_agent_credentials(identity_ref: str) -> tuple[str, str]:
     """Resolve ``(client_id, client_secret)`` for a scheduled-fire agent.
 
     *identity_ref* is :attr:`AgentDefinition.identity_ref` (the
     Keycloak client-id reference set at definition-create time).
+
+    **Vault-first** (G0.19-T2 #1478): the secret is read from Vault under
+    the scheduler's static service token, falling back to the env-var
+    path only when Vault yields nothing. See the module docstring for the
+    full resolution order.
 
     Returns the tuple :meth:`AgentInvoker.run_scheduled` expects:
 
     * ``client_id`` -- the identity_ref verbatim (Keycloak's
       client-id namespace tolerates the ``:`` separators MEHO uses,
       so no transformation is needed for the grant request).
-    * ``client_secret`` -- read from the env-var whose name the
-      :attr:`Settings.scheduler_agent_secret_env_pattern` resolves to
-      against the sanitised + upper-cased *identity_ref*.
+    * ``client_secret`` -- the resolved secret (Vault, else env var).
 
     Raises:
-        AgentCredentialsUnresolvedError: the resolved env-var is not
-            set or empty. Operator must wire the secret before the
-            trigger can fire.
+        AgentCredentialsUnresolvedError: neither Vault nor the env-var
+            fallback yielded a secret. The loop logs
+            ``scheduler_credentials_unresolved`` and leaves the trigger
+            active for the next tick.
     """
-    settings = get_settings()
-    sanitised = agent_client_id_from_identity_ref(identity_ref).upper()
-    # Upper-case the *whole* substituted name, not just the
-    # ``client_id`` token. Operators who set a non-upper-cased pattern
-    # (e.g. ``meho_agent_secret_{client_id}``) otherwise resolve to a
-    # mixed-case env-var name that Linux's case-sensitive lookup would
-    # miss -- the precondition gate would skip every fire with a
-    # ``credentials_unresolved`` warning that points at the secret
-    # rather than the case-mismatch. The contract in this module's
-    # docstring is "the whole substituted name is upper-cased"; this
-    # ``.upper()`` makes the code match it.
-    env_name = settings.scheduler_agent_secret_env_pattern.format(client_id=sanitised).upper()
-    secret = os.environ.get(env_name, "").strip()
-    if not secret:
-        raise AgentCredentialsUnresolvedError(
-            f"no client_credentials secret resolved for identity_ref={identity_ref!r}; "
-            f"expected env var {env_name!r} to be set. Wire the agent's Keycloak "
-            "client secret into the backplane pod (Helm chart secret / "
-            "external-secrets / sealed-secret) and retry."
+    # Local import avoids a module-load cycle (vault_credentials imports
+    # this module's sanitiser for its Vault-path derivation).
+    from meho_backplane.scheduler.vault_credentials import (
+        SchedulerVaultBrokerError,
+        SchedulerVaultNotConfiguredError,
+        read_agent_secret,
+    )
+
+    # 1. Vault-first.
+    try:
+        vault_secret = await read_agent_secret(identity_ref)
+    except SchedulerVaultNotConfiguredError:
+        # No scheduler Vault identity wired — fall through to the env-var
+        # path silently (the documented fallback configuration).
+        vault_secret = None
+    except SchedulerVaultBrokerError as exc:
+        # Vault is configured but the read failed (unreachable, denied,
+        # malformed). Log at WARN and try the env-var fallback rather than
+        # failing the fire outright — a transient Vault blip shouldn't
+        # block an agent whose secret is also wired into the pod env.
+        _log.warning(
+            "scheduler_vault_read_failed",
+            identity_ref=identity_ref,
+            reason=str(exc),
         )
-    return identity_ref, secret
+        vault_secret = None
+    if vault_secret:
+        return identity_ref, vault_secret
+
+    # 2. Env-var fallback / break-glass.
+    env_secret = _secret_from_env(identity_ref)
+    if env_secret:
+        return identity_ref, env_secret
+
+    env_name = _env_var_name_for(identity_ref)
+    raise AgentCredentialsUnresolvedError(
+        f"no client_credentials secret resolved for identity_ref={identity_ref!r}; "
+        f"neither the Vault path (scheduler_agent_vault_path_pattern, read under "
+        f"VAULT_SCHEDULER_TOKEN) nor the fallback env var {env_name!r} yielded a "
+        "secret. Register the agent over the API (persists the secret to Vault) or "
+        "wire the agent's Keycloak client secret into the backplane pod env and retry."
+    )

--- a/backend/src/meho_backplane/scheduler/loop.py
+++ b/backend/src/meho_backplane/scheduler/loop.py
@@ -348,10 +348,12 @@ async def _prepare_invocation(row: ScheduledTrigger) -> _PreparedInvocation | No
     * **definition disabled** -- the agent definition exists but
       ``enabled=False``. Same recovery shape: flip the flag, schedule
       resumes.
-    * **credentials unresolved** -- the env var derived from the
-      :attr:`Settings.scheduler_agent_secret_env_pattern` pattern is
-      not set or empty. The operator wires the secret (Helm chart /
-      external-secrets / sealed-secret); the next tick retries.
+    * **credentials unresolved** -- neither the Vault path
+      (:attr:`Settings.scheduler_agent_vault_path_pattern`, read under
+      ``VAULT_SCHEDULER_TOKEN``) nor the fallback env var derived from
+      :attr:`Settings.scheduler_agent_secret_env_pattern` yields a
+      secret. Registering the agent over the API persists the secret to
+      Vault; the next tick retries.
 
     The lookup session is opened fresh -- separate from the claim
     session whose transaction is still open at the caller -- so the
@@ -379,7 +381,7 @@ async def _prepare_invocation(row: ScheduledTrigger) -> _PreparedInvocation | No
         )
         return None
     try:
-        agent_client_id, agent_client_secret = resolve_agent_credentials(
+        agent_client_id, agent_client_secret = await resolve_agent_credentials(
             definition.identity_ref,
         )
     except AgentCredentialsUnresolvedError as exc:

--- a/backend/src/meho_backplane/scheduler/vault_credentials.py
+++ b/backend/src/meho_backplane/scheduler/vault_credentials.py
@@ -1,0 +1,303 @@
+# SPDX-License-Identifier: Apache-2.0
+# Copyright (c) 2026 evoila Group
+
+"""Scheduler-service-token Vault broker for agent client_credentials secrets.
+
+G0.19-T2 (#1478). Two operations, both authenticated with the scheduler's
+**static service token** (:attr:`Settings.vault_scheduler_token`) rather
+than a per-operator Keycloak JWT:
+
+* :func:`write_agent_secret` — called from
+  :meth:`~meho_backplane.auth.agent_principals.AgentPrincipalService.register`
+  to persist a freshly-registered agent's Keycloak ``client_credentials``
+  secret into Vault, so the operator-less scheduler can read it back
+  without a pod env-var wire-up + redeploy.
+* :func:`read_agent_secret` — called from
+  :func:`~meho_backplane.scheduler.credentials.resolve_agent_credentials`
+  (Vault-first) to source the secret for a scheduled fire.
+
+Why a static service token, not AppRole
+=======================================
+
+The scheduler is operator-less: :func:`vault_client_for_operator` is
+JWT/OIDC-bound and there is no operator JWT on the tick loop. The
+architecture doc (``docs/architecture/connector-auth.md`` §Option B)
+records AppRole as the alternative service identity but flags its
+``secret_id`` bootstrap (secret-zero) cost. A static token bound to a
+narrow read/write policy on the agent-credentials path is the
+lowest-friction shippable identity — it reuses hvac's
+``Client(token=…)`` primitive (the same one the live-Vault test harness
+uses) with no ``secret_id`` exchange. An operator who prefers AppRole
+runs a Vault Agent sidecar that renews a token into
+``VAULT_SCHEDULER_TOKEN``: additive, no code change here.
+
+Path convention
+===============
+
+:attr:`Settings.scheduler_agent_vault_path_pattern` is the **raw Vault
+HTTP API path** (default ``secret/data/agents/{client_id}/credentials``)
+— it embeds the mount (``secret``) and the KV-v2 ``data/`` infix. hvac's
+``secrets.kv.v2`` helpers want the **logical** path relative to the
+mount (they insert ``data/`` themselves — verified against hvac 2.4.0).
+:func:`split_kv_v2_api_path` reconciles the two so the shipped default
+setting keeps working unchanged (#823 promised "a code swap, not an
+env-var rename").
+
+The secret payload shape is ``{"client_secret": "<value>"}``; the read
+returns the ``client_secret`` field. No secret value ever enters a log
+event or an error message — only the path and the field *name* do.
+"""
+
+from __future__ import annotations
+
+import asyncio
+
+import hvac
+import hvac.exceptions
+import requests.exceptions
+import structlog
+
+from meho_backplane.auth.vault import _build_client
+from meho_backplane.settings import Settings, get_settings
+
+__all__ = [
+    "SECRET_FIELD",
+    "SchedulerVaultBrokerError",
+    "SchedulerVaultNotConfiguredError",
+    "read_agent_secret",
+    "split_kv_v2_api_path",
+    "vault_path_for_client_id",
+    "write_agent_secret",
+]
+
+_log = structlog.get_logger(__name__)
+
+#: The single field name the agent-credentials secret payload carries.
+#: Both the write (register) and the read (scheduler) agree on this key.
+SECRET_FIELD: str = "client_secret"
+
+
+class SchedulerVaultBrokerError(Exception):
+    """Base class for scheduler-service-token Vault broker failures.
+
+    Raised on read/write failures that are *not* the
+    not-configured case (which has its own subclass so callers can choose
+    to fall back to the env-var path rather than fail).
+    """
+
+
+class SchedulerVaultNotConfiguredError(SchedulerVaultBrokerError):
+    """The scheduler Vault service token is unset.
+
+    Distinct from :class:`SchedulerVaultBrokerError` so
+    :func:`~meho_backplane.scheduler.credentials.resolve_agent_credentials`
+    can treat "no Vault identity configured" as "fall back to the env-var
+    path" rather than a hard failure, while a genuine Vault read/write
+    error (network, permission, malformed payload) surfaces as the base
+    class.
+    """
+
+
+def split_kv_v2_api_path(api_path: str) -> tuple[str, str]:
+    """Split a raw KV-v2 *API* path into ``(mount_point, logical_path)``.
+
+    hvac's ``secrets.kv.v2`` helpers take the mount separately and a
+    *logical* path relative to it (they insert the ``data/`` segment on
+    the wire themselves). The configured
+    :attr:`Settings.scheduler_agent_vault_path_pattern` is the raw API
+    path that embeds both the mount and the ``data/`` infix, e.g.
+    ``secret/data/agents/agent_reporter/credentials``. This helper splits
+    that into ``("secret", "agents/agent_reporter/credentials")``.
+
+    Rules:
+
+    * A ``<mount>/data/<rest>`` shape splits on the **first** ``data``
+      segment: mount is everything before it, logical path everything
+      after. This handles non-default mounts (``kv/data/…`` →
+      ``("kv", "…")``).
+    * A path with no ``data/`` segment is treated as already-logical on
+      the default ``secret`` mount — defensive, so a hand-edited pattern
+      that drops the ``data/`` infix still resolves rather than 404s.
+
+    Raises
+    ------
+    ValueError
+        The path is empty, or splits to an empty logical path (a pattern
+        like ``secret/data/`` with nothing after the infix is a
+        misconfiguration that would read/write the mount root).
+    """
+    stripped = api_path.strip().strip("/")
+    if not stripped:
+        raise ValueError(f"empty Vault KV-v2 path: {api_path!r}")
+    segments = stripped.split("/")
+    try:
+        data_idx = segments.index("data")
+    except ValueError:
+        # No ``data/`` infix — treat the whole thing as a logical path on
+        # the default ``secret`` mount.
+        return "secret", stripped
+    mount = "/".join(segments[:data_idx]) or "secret"
+    logical = "/".join(segments[data_idx + 1 :])
+    if not logical:
+        raise ValueError(
+            f"Vault KV-v2 path {api_path!r} has no logical path after the "
+            "'data/' segment; it would address the mount root"
+        )
+    return mount, logical
+
+
+def vault_path_for_client_id(client_id: str, *, settings: Settings | None = None) -> str:
+    """Render the configured Vault path pattern for *client_id*.
+
+    Substitutes the sanitised-and-upper-cased ``{client_id}`` token into
+    :attr:`Settings.scheduler_agent_vault_path_pattern`. The sanitisation
+    mirrors the env-var derivation in
+    :func:`~meho_backplane.scheduler.credentials.agent_client_id_from_identity_ref`
+    so the Vault key and the env-var key are derived from one identity in
+    a consistent shape (``agent:reporter`` → ``AGENT_REPORTER``).
+    """
+    # Local import avoids a module-load cycle: credentials imports this
+    # module's read path, so importing credentials at top level here would
+    # be circular.
+    from meho_backplane.scheduler.credentials import agent_client_id_from_identity_ref
+
+    if settings is None:
+        settings = get_settings()
+    sanitised = agent_client_id_from_identity_ref(client_id).upper()
+    return settings.scheduler_agent_vault_path_pattern.format(client_id=sanitised)
+
+
+def _scheduler_client(settings: Settings) -> hvac.Client:
+    """Build a token-authenticated hvac client for the scheduler identity.
+
+    Raises :class:`SchedulerVaultNotConfiguredError` when
+    :attr:`Settings.vault_scheduler_token` is unset — the caller decides
+    whether that is a hard failure (register) or a fall-back trigger
+    (scheduler read).
+    """
+    token = settings.vault_scheduler_token.strip()
+    if not token:
+        raise SchedulerVaultNotConfiguredError(
+            "VAULT_SCHEDULER_TOKEN is not set; the scheduler has no Vault "
+            "read/write identity for agent client_credentials secrets"
+        )
+    # Reuse the auth.vault client builder so vault_addr / namespace /
+    # timeout mapping stays single-sourced; bind the static token instead
+    # of a JWT-login-issued one.
+    return _build_client(settings, token=token)
+
+
+async def write_agent_secret(identity_ref: str, client_secret: str) -> str:
+    """Persist *client_secret* for *identity_ref* to Vault; return the path.
+
+    Called from the agent-principal register path after the Keycloak
+    client is created and its secret fetched. Writes
+    ``{SECRET_FIELD: client_secret}`` as a KV-v2 secret at the configured
+    path under the scheduler service token.
+
+    Returns the rendered Vault API path (for logging / audit), never the
+    secret value.
+
+    Raises
+    ------
+    SchedulerVaultNotConfiguredError
+        ``VAULT_SCHEDULER_TOKEN`` is unset. The register caller treats this
+        as "the deployment opted out of the Vault path" and skips the write
+        with a warning (env-var fallback remains); the read caller treats
+        it as "fall back to the env var".
+    SchedulerVaultBrokerError
+        Vault is unreachable or rejected the write.
+    """
+    settings = get_settings()
+    api_path = vault_path_for_client_id(identity_ref, settings=settings)
+    mount, logical = split_kv_v2_api_path(api_path)
+    client = _scheduler_client(settings)
+    try:
+        await asyncio.to_thread(
+            client.secrets.kv.v2.create_or_update_secret,
+            path=logical,
+            secret={SECRET_FIELD: client_secret},
+            mount_point=mount,
+        )
+    except (requests.exceptions.ConnectionError, requests.exceptions.Timeout) as exc:
+        raise SchedulerVaultBrokerError(
+            f"vault unreachable writing agent secret at {api_path!r}: {type(exc).__name__}"
+        ) from exc
+    except hvac.exceptions.VaultError as exc:
+        raise SchedulerVaultBrokerError(
+            f"vault rejected agent-secret write at {api_path!r}: {type(exc).__name__}"
+        ) from exc
+    _log.info(
+        "scheduler_agent_secret_written",
+        identity_ref=identity_ref,
+        vault_path=api_path,
+    )
+    return api_path
+
+
+async def read_agent_secret(identity_ref: str) -> str | None:
+    """Read the agent ``client_secret`` for *identity_ref* from Vault.
+
+    Returns the secret string, or ``None`` when the secret does not exist
+    (Vault 404 / missing path) so the caller can fall back to the env-var
+    path. A ``None`` return is the "not in Vault" signal — distinct from a
+    raised error, which signals an *infrastructure* failure the caller
+    must not silently swallow.
+
+    Raises
+    ------
+    SchedulerVaultNotConfiguredError
+        ``VAULT_SCHEDULER_TOKEN`` is unset — the caller treats this as
+        "Vault not available, try the env-var fallback".
+    SchedulerVaultBrokerError
+        Vault is unreachable or rejected the read for a reason other than
+        a missing path.
+    """
+    settings = get_settings()
+    api_path = vault_path_for_client_id(identity_ref, settings=settings)
+    mount, logical = split_kv_v2_api_path(api_path)
+    client = _scheduler_client(settings)
+    try:
+        payload = await asyncio.to_thread(
+            client.secrets.kv.v2.read_secret_version,
+            path=logical,
+            mount_point=mount,
+            raise_on_deleted_version=False,
+        )
+    except hvac.exceptions.InvalidPath:
+        # KV-v2 read of a non-existent path raises InvalidPath (404). This
+        # is the "agent secret not in Vault yet" case — return None so the
+        # resolver falls back to the env var rather than failing the fire.
+        return None
+    except (requests.exceptions.ConnectionError, requests.exceptions.Timeout) as exc:
+        raise SchedulerVaultBrokerError(
+            f"vault unreachable reading agent secret at {api_path!r}: {type(exc).__name__}"
+        ) from exc
+    except hvac.exceptions.VaultError as exc:
+        raise SchedulerVaultBrokerError(
+            f"vault rejected agent-secret read at {api_path!r}: {type(exc).__name__}"
+        ) from exc
+    secret = _unwrap_secret(payload)
+    if not secret:
+        return None
+    return secret
+
+
+def _unwrap_secret(payload: object) -> str:
+    """Pull ``SECRET_FIELD`` out of an hvac KV-v2 read payload as a string.
+
+    KV-v2's read returns ``{"data": {"data": {<kv>}, "metadata": {...}}}``;
+    the secret content is the nested ``data["data"]``. Returns the
+    stripped ``SECRET_FIELD`` value, or ``""`` when the payload is
+    malformed or the field is absent (caller treats ``""`` as "not in
+    Vault"). Mirrors the structural-unwrap discipline in
+    :mod:`meho_backplane.connectors._shared.vault_creds`.
+    """
+    outer = payload.get("data") if isinstance(payload, dict) else None
+    secret_data = outer.get("data") if isinstance(outer, dict) else None
+    if not isinstance(secret_data, dict):
+        return ""
+    value = secret_data.get(SECRET_FIELD)
+    if value is None:
+        return ""
+    return str(value).strip()

--- a/backend/src/meho_backplane/settings.py
+++ b/backend/src/meho_backplane/settings.py
@@ -161,6 +161,22 @@ class Settings(BaseModel):
         fail-closed quickly rather than starve request capacity. The
         v0.1 dogfood load is per-request login, so the timeout governs
         worst-case request latency directly.
+    vault_scheduler_token:
+        Static Vault token the **scheduler** authenticates with to read
+        agent ``client_credentials`` secrets (G0.19-T2 #1478). The
+        scheduler is operator-less — it has no Keycloak JWT to forward to
+        Vault's JWT/OIDC auth method — so it reads under its own service
+        identity instead. A token bound to a narrow policy that grants
+        read on ``scheduler_agent_vault_path_pattern`` (default
+        ``secret/data/agents/*/credentials``) is the lowest-friction
+        service identity: it reuses the ``hvac.Client(token=…)`` primitive
+        with no AppRole ``secret_id`` bootstrap. Default ``""`` (unset)
+        leaves Vault-sourced scheduling inoperative; the scheduler then
+        falls back to the env-var path
+        (:attr:`scheduler_agent_secret_env_pattern`). Never logged; never
+        surfaced in API responses. Operators wanting AppRole instead of a
+        static token can wrap a Vault Agent sidecar that writes the token
+        to this env var — additive, no code change.
     database_url:
         SQLAlchemy URL for the PostgreSQL database, e.g.
         ``postgresql+asyncpg://meho:<password>@<host>:5432/meho``.
@@ -774,6 +790,7 @@ class Settings(BaseModel):
     vault_oidc_mount_path: str = Field(default="jwt", min_length=1)
     vault_namespace: str | None = None
     vault_timeout_seconds: float = Field(default=10.0, gt=0)
+    vault_scheduler_token: str = Field(default="", repr=False)
     database_url: str = Field(min_length=1)
     database_pool_size: int = Field(default=10, gt=0)
     database_pool_timeout: float = Field(default=30.0, gt=0)
@@ -959,28 +976,38 @@ class Settings(BaseModel):
     # shape so operators using an external scheduler can opt out.
     scheduler_tick_interval_seconds: int = Field(default=30, ge=1, le=3600)
     scheduler_enabled: bool = True
-    # G11.3-T2 #823 — autonomous-agent credential sourcing for the
-    # scheduler. ``run_scheduled`` (G11.2-T2 #1096) wants
-    # ``(client_id, client_secret)``; the scheduler resolves
+    # G11.3-T2 #823 / G0.19-T2 #1478 — autonomous-agent credential
+    # sourcing for the scheduler. ``run_scheduled`` (G11.2-T2 #1096)
+    # wants ``(client_id, client_secret)``; the scheduler resolves
     # ``client_id`` from the trigger's :class:`AgentDefinition.identity_ref`
-    # and reads the matching secret from an environment variable whose
-    # name is derived from this pattern. ``{client_id}`` is substituted
-    # at fire time and the result is uppercased + non-alphanumeric chars
-    # replaced with underscores so an ``identity_ref`` like ``agent:reporter``
-    # resolves to ``MEHO_AGENT_SECRET_AGENT_REPORTER``.
+    # and resolves the secret **Vault-first** (see
+    # :func:`meho_backplane.scheduler.credentials.resolve_agent_credentials`):
+    # it reads the agent's secret from Vault at
+    # ``scheduler_agent_vault_path_pattern`` under the scheduler's static
+    # service token (:attr:`vault_scheduler_token`), and falls back to an
+    # environment variable derived from this pattern only when the Vault
+    # read yields nothing. ``{client_id}`` is substituted at fire time and
+    # the result is uppercased + non-alphanumeric chars replaced with
+    # underscores so an ``identity_ref`` like ``agent:reporter`` resolves
+    # to ``MEHO_AGENT_SECRET_AGENT_REPORTER``.
     #
-    # Why env-var sourcing rather than Vault: ``vault_client_for_operator``
-    # is JWT/OIDC-bound and the scheduler is operator-less. Until a
-    # scheduler-service-token Vault auth path lands (G11.2 follow-up),
-    # operators wire agent secrets into the backplane pod's env (Helm
+    # The env-var path is the documented **fallback / break-glass**: an
+    # operator can wire an agent secret into the backplane pod's env (Helm
     # secret / external-secrets / sealed-secret) the same way
-    # ``ANTHROPIC_API_KEY`` is wired today. The
-    # ``scheduler_agent_vault_path_pattern`` setting below is reserved
-    # for the future Vault path; it ships configured but unused so the
-    # transition is a code swap, not an env-var rename.
+    # ``ANTHROPIC_API_KEY`` is wired when Vault is unavailable. The
+    # Vault-first path is what makes an API-registered agent schedulable
+    # with no pod env var + no redeploy: registration persists the
+    # Keycloak secret to Vault at ``scheduler_agent_vault_path_pattern``
+    # (see :meth:`AgentPrincipalService.register`) and the scheduler reads
+    # it straight back.
     scheduler_agent_secret_env_pattern: str = Field(default="MEHO_AGENT_SECRET_{client_id}")
-    # Forward-compat: the Vault KVv2 path the scheduler will read once
-    # service-token auth lands. Configured but unused in v0.2.
+    # The Vault KV-v2 *API* path (mount + ``data/`` infix + logical path)
+    # where agent ``client_credentials`` secrets live. Registration writes
+    # here; the scheduler reads here. ``{client_id}`` is substituted with
+    # the sanitised identity_ref. The default addresses the ``secret/``
+    # KV-v2 mount; the leading ``secret/data/`` is the raw API path Vault's
+    # HTTP surface uses, which the read/write helpers split into hvac's
+    # ``(mount_point, logical_path)`` form.
     scheduler_agent_vault_path_pattern: str = Field(
         default="secret/data/agents/{client_id}/credentials"
     )
@@ -1182,6 +1209,7 @@ def get_settings() -> Settings:
         vault_timeout_seconds=float(
             os.environ.get("VAULT_TIMEOUT_SECONDS", "10.0"),
         ),
+        vault_scheduler_token=os.environ.get("VAULT_SCHEDULER_TOKEN", "").strip(),
         database_url=os.environ["DATABASE_URL"],
         database_pool_size=int(os.environ.get("DATABASE_POOL_SIZE", "10")),
         database_pool_timeout=float(

--- a/backend/tests/integration/test_scheduler_vault_credentials_dev_e2e.py
+++ b/backend/tests/integration/test_scheduler_vault_credentials_dev_e2e.py
@@ -1,0 +1,194 @@
+# SPDX-License-Identifier: Apache-2.0
+# Copyright (c) 2026 evoila Group
+
+"""G0.19-T2 (#1478) — live Vault dev-mode harness for the scheduler broker.
+
+Boots a real ``hashicorp/vault:1.18`` server in dev mode via testcontainers
+and exercises the scheduler-service-token credential broker
+(:mod:`meho_backplane.scheduler.vault_credentials`) and the Vault-first
+:func:`meho_backplane.scheduler.credentials.resolve_agent_credentials`
+against the **live** Vault — not a mock. This is the layer that proves the
+DoD: an agent's ``client_credentials`` secret written at registration is
+read back by the operator-less scheduler with **no pod env var set**.
+
+What it covers
+==============
+
+* :func:`write_agent_secret` persists a secret at the configured Vault
+  path under a static service token, and :func:`read_agent_secret` reads
+  it back — full hvac KV-v2 round-trip, real ``data/`` infix handling.
+* :func:`resolve_agent_credentials` returns the Vault-sourced secret with
+  **no** ``MEHO_AGENT_SECRET_*`` env var present (the autonomous-loop AC).
+* A secret absent from Vault and absent from the env var raises
+  :class:`AgentCredentialsUnresolvedError` (loud, trigger-preserving).
+
+CI selection
+============
+
+Lives under ``tests/integration/`` (deselected by the unit lane, run by
+the integration lane). A Docker-socket-absent sandbox skips cleanly via
+the same heuristic every other testcontainers suite uses.
+
+Secrets
+=======
+
+The dev-root token is generated *into* the container via
+``VAULT_DEV_ROOT_TOKEN_ID`` and only held in module state. The scheduler
+service token is the same dev-root token (dev mode has root policy);
+production binds a narrow read/write policy. The seeded ``client_secret``
+is a throwaway value on an in-memory Vault that never persists.
+"""
+
+from __future__ import annotations
+
+import os
+from collections.abc import Iterator
+from pathlib import Path
+
+import hvac
+import pytest
+
+from meho_backplane.scheduler.credentials import (
+    AgentCredentialsUnresolvedError,
+    resolve_agent_credentials,
+)
+from meho_backplane.scheduler.vault_credentials import (
+    SECRET_FIELD,
+    read_agent_secret,
+    write_agent_secret,
+)
+from meho_backplane.settings import get_settings
+
+
+def _docker_socket_present() -> bool:
+    return Path("/var/run/docker.sock").exists() or os.environ.get("DOCKER_HOST") is not None
+
+
+DOCKER_AVAILABLE: bool = _docker_socket_present()
+SKIP_REASON: str = (
+    "Docker socket unavailable in this sandbox; runs in CI where containers are provisioned."
+)
+
+#: Dev-mode root token, generated *into* the container. Throwaway, scoped
+#: to a per-test-run in-memory Vault. Doubles as the scheduler service
+#: token for the test (dev mode grants it root policy).
+_DEV_ROOT_TOKEN: str = "meho-dev-root-1478"
+
+_IDENTITY_REF: str = "agent:reporter"
+_AGENT_SECRET: str = "dev-only-client-secret-1478"
+
+
+@pytest.fixture(scope="module")
+def vault_dev_addr() -> Iterator[str]:
+    """Boot ``hashicorp/vault:1.18 -dev`` and yield its address.
+
+    Module scope amortises the container boot. Image overridable via
+    ``MEHO_TEST_VAULT_IMAGE`` so the CI runner pulls through the in-cluster
+    Harbor proxy (same env-knob shape as the other Vault dev fixtures).
+    """
+    if not DOCKER_AVAILABLE:
+        pytest.skip(SKIP_REASON)
+
+    from testcontainers.core.container import DockerContainer
+
+    from tests._strategies import wait_for_log_message
+
+    image = os.environ.get("MEHO_TEST_VAULT_IMAGE", "hashicorp/vault:1.18")
+    container = (
+        DockerContainer(image)
+        .with_env("VAULT_DEV_ROOT_TOKEN_ID", _DEV_ROOT_TOKEN)
+        .with_env("VAULT_DEV_LISTEN_ADDRESS", "0.0.0.0:8200")
+        .with_exposed_ports(8200)
+        .with_kwargs(cap_add=["IPC_LOCK"])
+    )
+    try:
+        container.start()
+    except Exception as exc:
+        pytest.skip(f"vault dev container failed to start ({type(exc).__name__}): {exc}")
+
+    try:
+        wait_for_log_message(container, "Vault server started!", timeout=60)
+        host = container.get_container_host_ip()
+        port = container.get_exposed_port(8200)
+        yield f"http://{host}:{port}"
+    finally:
+        container.stop()
+
+
+@pytest.fixture
+def _scheduler_vault_env(vault_dev_addr: str, monkeypatch: pytest.MonkeyPatch) -> Iterator[None]:
+    """Pin Settings to the live Vault + scheduler service token.
+
+    Crucially does **not** set any ``MEHO_AGENT_SECRET_*`` env var — the
+    DoD is that the secret resolves from Vault with no pod env var.
+    """
+    monkeypatch.setenv("KEYCLOAK_ISSUER_URL", "https://keycloak.test/realms/meho")
+    monkeypatch.setenv("KEYCLOAK_AUDIENCE", "meho-backplane")
+    monkeypatch.setenv("VAULT_ADDR", vault_dev_addr)
+    monkeypatch.setenv("VAULT_SCHEDULER_TOKEN", _DEV_ROOT_TOKEN)
+    # Belt-and-suspenders: ensure no env-var secret is present so a pass
+    # cannot come from the fallback path.
+    monkeypatch.delenv("MEHO_AGENT_SECRET_AGENT_REPORTER", raising=False)
+    get_settings.cache_clear()
+    yield
+    get_settings.cache_clear()
+
+
+async def test_write_then_read_round_trip(_scheduler_vault_env: None) -> None:
+    """write_agent_secret -> read_agent_secret round-trips against live Vault."""
+    api_path = await write_agent_secret(_IDENTITY_REF, _AGENT_SECRET)
+    assert api_path == "secret/data/agents/AGENT_REPORTER/credentials"
+
+    read_back = await read_agent_secret(_IDENTITY_REF)
+    assert read_back == _AGENT_SECRET
+
+
+async def test_read_missing_returns_none(_scheduler_vault_env: None) -> None:
+    """A never-written agent path reads back as ``None`` (env fallback signal)."""
+    assert await read_agent_secret("agent:never-written") is None
+
+
+async def test_resolve_is_vault_sourced_with_no_env_var(
+    _scheduler_vault_env: None,
+) -> None:
+    """The scheduler resolves the secret from Vault with NO pod env var set.
+
+    This is the headline DoD: an API-registered agent (whose secret was
+    persisted to Vault at registration) is schedulable without an operator
+    wiring ``MEHO_AGENT_SECRET_*`` into the pod env.
+    """
+    await write_agent_secret(_IDENTITY_REF, _AGENT_SECRET)
+
+    client_id, secret = await resolve_agent_credentials(_IDENTITY_REF)
+
+    assert client_id == _IDENTITY_REF
+    assert secret == _AGENT_SECRET
+    # Prove the env var really was absent (no accidental fallback).
+    assert os.environ.get("MEHO_AGENT_SECRET_AGENT_REPORTER") is None
+
+
+async def test_resolve_raises_when_neither_vault_nor_env(
+    _scheduler_vault_env: None,
+) -> None:
+    """Secret in neither Vault nor env -> AgentCredentialsUnresolvedError."""
+    with pytest.raises(AgentCredentialsUnresolvedError):
+        await resolve_agent_credentials("agent:no-secret-anywhere")
+
+
+async def test_seeded_payload_field_shape(vault_dev_addr: str, _scheduler_vault_env: None) -> None:
+    """The persisted payload uses the agreed SECRET_FIELD key.
+
+    A direct root-client read confirms the write shape independently of the
+    broker's own read path (defends against a write/read key drift).
+    """
+    import asyncio
+
+    await write_agent_secret(_IDENTITY_REF, _AGENT_SECRET)
+    root = hvac.Client(url=vault_dev_addr, token=_DEV_ROOT_TOKEN)
+    payload = await asyncio.to_thread(
+        root.secrets.kv.v2.read_secret_version,
+        path="agents/AGENT_REPORTER/credentials",
+        mount_point="secret",
+        raise_on_deleted_version=False,
+    )
+    assert payload["data"]["data"] == {SECRET_FIELD: _AGENT_SECRET}

--- a/backend/tests/test_api_v1_agent_principals.py
+++ b/backend/tests/test_api_v1_agent_principals.py
@@ -137,14 +137,32 @@ async def _fetch_principals(tenant_id: uuid.UUID) -> list[AgentPrincipal]:
 
 
 def _mock_kc_ok(internal_id: str = _KC_INTERNAL_ID) -> MagicMock:
-    """Return a mock KeycloakAdminClient that succeeds on create and disable."""
+    """Return a mock KeycloakAdminClient that succeeds on create/secret/disable."""
     mock_client = AsyncMock()
     mock_client.create_client = AsyncMock(return_value=internal_id)
+    mock_client.get_client_secret = AsyncMock(return_value="generated-secret")
     mock_client.disable_client = AsyncMock(return_value=None)
     mock_client.__aenter__ = AsyncMock(return_value=mock_client)
     mock_client.__aexit__ = AsyncMock(return_value=None)
     factory = MagicMock(return_value=mock_client)
     return factory
+
+
+@pytest.fixture(autouse=True)
+def _stub_vault_write(monkeypatch: pytest.MonkeyPatch) -> None:
+    """Stub the scheduler Vault write the register path now performs (#1478).
+
+    Registration persists the captured Keycloak secret to Vault under the
+    scheduler service token; these route tests have no live Vault, so the
+    write is stubbed to a no-op. The Vault-persistence behaviour itself is
+    covered by ``test_auth_agent_principals.py`` (unit) and the
+    integration suite (live Vault + Keycloak).
+    """
+
+    async def _noop_write(identity_ref: str, client_secret: str) -> str:
+        return f"secret/data/agents/{identity_ref}/credentials"
+
+    monkeypatch.setattr("meho_backplane.auth.agent_principals.write_agent_secret", _noop_write)
 
 
 # ---------------------------------------------------------------------------
@@ -652,3 +670,147 @@ async def test_register_rolls_back_orphan_client_on_db_failure(client: TestClien
     assert resp.status_code == 409, resp.text
     # The just-created (now orphaned) Keycloak client must be deleted.
     mock_client.delete_client.assert_awaited_once_with(new_internal_id)
+
+
+# ---------------------------------------------------------------------------
+# Vault secret persistence at registration (G0.19-T2 #1478)
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.asyncio
+async def test_register_persists_captured_secret_to_vault(
+    client: TestClient, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    """Register captures the Keycloak secret and persists it to Vault.
+
+    The scheduler reads the secret Vault-first, so registration must write
+    it there for an API-registered agent to be schedulable without a pod
+    env-var wire-up.
+    """
+    await _seed_tenants()
+    key = make_rsa_keypair("kid-vault")
+    factory = _mock_kc_ok()
+
+    captured: dict[str, str] = {}
+
+    async def _capture_write(identity_ref: str, client_secret: str) -> str:
+        captured["identity_ref"] = identity_ref
+        captured["secret"] = client_secret
+        return f"secret/data/agents/{identity_ref}/credentials"
+
+    monkeypatch.setattr("meho_backplane.auth.agent_principals.write_agent_secret", _capture_write)
+
+    with (
+        patch(
+            "meho_backplane.auth.agent_principals.KeycloakAdminClient.from_settings",
+            factory,
+        ),
+        respx.mock as r,
+    ):
+        mock_discovery_and_jwks(r, public_jwks(key))
+        resp = client.post(
+            "/api/v1/agent-principals",
+            json={"name": "vault-bot"},
+            headers={"Authorization": f"Bearer {_token(key)}"},
+        )
+
+    assert resp.status_code == 201, resp.text
+    # The captured secret is the one Keycloak's get_client_secret returned.
+    assert captured == {
+        "identity_ref": "agent:vault-bot",
+        "secret": "generated-secret",
+    }
+
+
+@pytest.mark.asyncio
+async def test_register_rolls_back_client_on_vault_write_failure(
+    client: TestClient, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    """A Vault-write failure rolls back the just-created Keycloak client.
+
+    Registering an agent whose secret never reached Vault would leave it
+    unschedulable (the scheduler reads Vault-first), so register fails
+    closed and deletes the orphaned client.
+    """
+    await _seed_tenants()
+    key = make_rsa_keypair("kid-vault-fail")
+    new_internal_id = "dd000000-0000-0000-0000-00000000aaaa"
+    mock_client = AsyncMock()
+    mock_client.create_client = AsyncMock(return_value=new_internal_id)
+    mock_client.get_client_secret = AsyncMock(return_value="generated-secret")
+    mock_client.delete_client = AsyncMock(return_value=None)
+    mock_client.__aenter__ = AsyncMock(return_value=mock_client)
+    mock_client.__aexit__ = AsyncMock(return_value=None)
+    factory = MagicMock(return_value=mock_client)
+
+    from meho_backplane.scheduler.vault_credentials import SchedulerVaultBrokerError
+
+    async def _failing_write(identity_ref: str, client_secret: str) -> str:
+        raise SchedulerVaultBrokerError("vault unreachable")
+
+    monkeypatch.setattr("meho_backplane.auth.agent_principals.write_agent_secret", _failing_write)
+
+    with (
+        patch(
+            "meho_backplane.auth.agent_principals.KeycloakAdminClient.from_settings",
+            factory,
+        ),
+        respx.mock as r,
+    ):
+        mock_discovery_and_jwks(r, public_jwks(key))
+        resp = client.post(
+            "/api/v1/agent-principals",
+            json={"name": "vault-fail-bot"},
+            headers={"Authorization": f"Bearer {_token(key)}"},
+        )
+
+    # The route maps the broker error to 502; the key assertions are the
+    # rollback + no DB row.
+    assert resp.status_code == 502, resp.text
+    mock_client.delete_client.assert_awaited_once_with(new_internal_id)
+    assert await _fetch_principals(_TENANT_A) == []
+
+
+@pytest.mark.asyncio
+async def test_register_skips_vault_when_token_unset(
+    client: TestClient, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    """No ``VAULT_SCHEDULER_TOKEN`` -> register skips the Vault write (no 5xx).
+
+    Backward compatibility: an env-var-only deployment that has not wired a
+    scheduler Vault token still registers agents successfully; the agent
+    relies on the env-var fallback. Uses the *real* ``write_agent_secret``
+    (the autouse stub is overridden) to exercise the not-configured branch.
+    """
+    await _seed_tenants()
+    key = make_rsa_keypair("kid-no-token")
+    factory = _mock_kc_ok()
+
+    # Override the autouse no-op stub with the real broker write, and
+    # ensure no scheduler Vault token is configured.
+    import meho_backplane.scheduler.vault_credentials as vc_module
+
+    monkeypatch.setattr(
+        "meho_backplane.auth.agent_principals.write_agent_secret",
+        vc_module.write_agent_secret,
+    )
+    monkeypatch.delenv("VAULT_SCHEDULER_TOKEN", raising=False)
+    get_settings.cache_clear()
+
+    with (
+        patch(
+            "meho_backplane.auth.agent_principals.KeycloakAdminClient.from_settings",
+            factory,
+        ),
+        respx.mock as r,
+    ):
+        mock_discovery_and_jwks(r, public_jwks(key))
+        resp = client.post(
+            "/api/v1/agent-principals",
+            json={"name": "no-token-bot"},
+            headers={"Authorization": f"Bearer {_token(key)}"},
+        )
+
+    assert resp.status_code == 201, resp.text
+    rows = await _fetch_principals(_TENANT_A)
+    assert [row.name for row in rows] == ["no-token-bot"]

--- a/backend/tests/test_keycloak_admin.py
+++ b/backend/tests/test_keycloak_admin.py
@@ -159,3 +159,53 @@ async def test_delete_client_unexpected_status_raises() -> None:
         async with _client() as kc:
             with pytest.raises(KeycloakAdminError):
                 await kc.delete_client(_INTERNAL_ID)
+
+
+@pytest.mark.asyncio
+async def test_get_client_secret_returns_value() -> None:
+    """``get_client_secret`` extracts the ``value`` field (G0.19-T2 #1478)."""
+    with respx.mock as r:
+        _mock_token(r)
+        r.get(f"{_ADMIN_URL}/clients/{_INTERNAL_ID}/client-secret").mock(
+            return_value=httpx.Response(200, json={"type": "secret", "value": "gen-secret"})
+        )
+        async with _client() as kc:
+            secret = await kc.get_client_secret(_INTERNAL_ID)
+    assert secret == "gen-secret"
+
+
+@pytest.mark.asyncio
+async def test_get_client_secret_not_found_raises() -> None:
+    with respx.mock as r:
+        _mock_token(r)
+        r.get(f"{_ADMIN_URL}/clients/{_INTERNAL_ID}/client-secret").mock(
+            return_value=httpx.Response(404)
+        )
+        async with _client() as kc:
+            with pytest.raises(KeycloakClientNotFoundError):
+                await kc.get_client_secret(_INTERNAL_ID)
+
+
+@pytest.mark.asyncio
+async def test_get_client_secret_empty_value_raises() -> None:
+    """An empty ``value`` (public client / misconfig) is an admin error."""
+    with respx.mock as r:
+        _mock_token(r)
+        r.get(f"{_ADMIN_URL}/clients/{_INTERNAL_ID}/client-secret").mock(
+            return_value=httpx.Response(200, json={"type": "secret", "value": ""})
+        )
+        async with _client() as kc:
+            with pytest.raises(KeycloakAdminError):
+                await kc.get_client_secret(_INTERNAL_ID)
+
+
+@pytest.mark.asyncio
+async def test_get_client_secret_unexpected_status_raises() -> None:
+    with respx.mock as r:
+        _mock_token(r)
+        r.get(f"{_ADMIN_URL}/clients/{_INTERNAL_ID}/client-secret").mock(
+            return_value=httpx.Response(500)
+        )
+        async with _client() as kc:
+            with pytest.raises(KeycloakAdminError):
+                await kc.get_client_secret(_INTERNAL_ID)

--- a/backend/tests/test_scheduler_credentials.py
+++ b/backend/tests/test_scheduler_credentials.py
@@ -1,44 +1,42 @@
 # SPDX-License-Identifier: Apache-2.0
 # Copyright (c) 2026 evoila Group
 
-"""Unit tests for :mod:`meho_backplane.scheduler.credentials` (G11.3-T2 #823).
+"""Unit tests for :mod:`meho_backplane.scheduler.credentials` (#823, #1478).
 
 The credential-resolution shim sits between the scheduler loop and
 :meth:`AgentInvoker.run_scheduled` (G11.2-T2 #1096) -- it sources the
 ``(client_id, client_secret)`` pair the ``client_credentials`` grant
-needs by looking the secret up via an env-var pattern derived from
-the agent's ``identity_ref``.
+needs. Resolution is **Vault-first** (G0.19-T2 #1478): the secret is read
+from Vault under the scheduler's static service token, falling back to an
+env-var pattern derived from the agent's ``identity_ref`` only when Vault
+yields nothing.
 
 Coverage matrix
 ---------------
 
 * **Sanitiser** -- ``agent:reporter`` -> ``AGENT_REPORTER`` (default
-  upper-case + non-alnum -> ``_``); edge cases:
-  ``agent:incident-triage`` -> ``AGENT_INCIDENT_TRIAGE``; trailing /
-  leading punctuation collapses; already-clean strings are pass-through.
-* **Resolution happy path** -- when the env var derived from the
-  pattern + identity_ref is set, return ``(identity_ref, secret)``
-  exactly. Identity_ref is *not* sanitised in the returned tuple
-  (Keycloak's client-id namespace tolerates the original form).
-* **Missing env var raises** -- unset env -> the loop's "skip + log"
-  path is exercised by :class:`AgentCredentialsUnresolvedError`.
-* **Empty env var raises** -- ``MEHO_AGENT_SECRET_X=""`` is the same
-  as not setting it (strip semantics; defends against Helm template
-  leaks that render an empty value).
-* **Custom env pattern** -- a non-default
-  ``SCHEDULER_AGENT_SECRET_ENV_PATTERN`` is honoured (operators wiring
-  agent secrets through a non-MEHO env prefix).
+  upper-case + non-alnum -> ``_``); edge cases.
+* **Vault-first happy path** -- when Vault returns a secret, it wins over
+  the env var.
+* **Env-var fallback** -- Vault not configured / secret absent -> the env
+  var resolves.
+* **Vault read error -> env fallback** -- a transient broker error falls
+  back to the env var rather than failing the fire.
+* **Both miss raises** -- neither Vault nor env -> the loop's "skip + log"
+  path via :class:`AgentCredentialsUnresolvedError`.
 
-These tests live separately from :mod:`tests.test_scheduler` so the
-credential boundary stays its own audited unit -- regressions in the
-sanitiser or env-pattern expansion fail here without being masked by
-the integration-shaped scheduler-loop tests.
+The Vault read seam is mocked here (the resolver imports
+:func:`read_agent_secret` lazily); the live-Vault round-trip is covered
+by the integration suite.
 """
 
 from __future__ import annotations
 
+from typing import Any
+
 import pytest
 
+import meho_backplane.scheduler.vault_credentials as vault_credentials
 from meho_backplane.scheduler.credentials import (
     AgentCredentialsUnresolvedError,
     agent_client_id_from_identity_ref,
@@ -58,6 +56,22 @@ def _required_settings_env(monkeypatch: pytest.MonkeyPatch):
     get_settings.cache_clear()
 
 
+def _patch_vault_read(monkeypatch: pytest.MonkeyPatch, result: Any) -> None:
+    """Stub :func:`read_agent_secret` to return *result* (or raise it).
+
+    The resolver imports ``read_agent_secret`` lazily from the
+    ``vault_credentials`` module, so patching the module attribute is what
+    the import resolves to.
+    """
+
+    async def _fake(identity_ref: str) -> str | None:
+        if isinstance(result, BaseException):
+            raise result
+        return result
+
+    monkeypatch.setattr(vault_credentials, "read_agent_secret", _fake)
+
+
 @pytest.mark.parametrize(
     ("identity_ref", "expected"),
     [
@@ -65,10 +79,8 @@ def _required_settings_env(monkeypatch: pytest.MonkeyPatch):
         ("agent:incident-triage", "agent_incident_triage"),
         ("agent:billing.summary", "agent_billing_summary"),
         ("agent:multi:colon:ref", "agent_multi_colon_ref"),
-        # Already env-clean -- no rewrite needed.
         ("AGENT_X", "AGENT_X"),
         ("agent_x", "agent_x"),
-        # Edge: leading + trailing punctuation collapse.
         (":foo:", "_foo_"),
     ],
 )
@@ -77,80 +89,118 @@ def test_sanitiser_collapses_non_env_chars(identity_ref: str, expected: str) -> 
     assert agent_client_id_from_identity_ref(identity_ref) == expected
 
 
-def test_resolve_returns_identity_ref_verbatim_as_client_id(
+async def test_vault_first_secret_wins_over_env(
     monkeypatch: pytest.MonkeyPatch,
 ) -> None:
-    """The returned ``client_id`` is the *identity_ref verbatim* (no sanitisation).
+    """When Vault returns a secret, it is used even if the env var is set."""
+    _patch_vault_read(monkeypatch, "vault-secret")
+    monkeypatch.setenv("MEHO_AGENT_SECRET_AGENT_REPORTER", "env-secret")
 
-    Keycloak's client-id namespace tolerates the ``:`` separators MEHO
-    uses, and the ``client_credentials`` grant carries the original
-    identifier. The sanitisation applies only to the env-var-name
-    derivation.
-    """
-    monkeypatch.setenv("MEHO_AGENT_SECRET_AGENT_REPORTER", "s3cr3t")
-
-    client_id, client_secret = resolve_agent_credentials("agent:reporter")
+    client_id, secret = await resolve_agent_credentials("agent:reporter")
 
     assert client_id == "agent:reporter"
-    assert client_secret == "s3cr3t"
+    assert secret == "vault-secret"
 
 
-def test_resolve_uses_sanitised_uppercased_env_name(
+async def test_env_fallback_when_vault_returns_none(
     monkeypatch: pytest.MonkeyPatch,
 ) -> None:
-    """Env-var name is sanitised then upper-cased.
+    """Vault secret absent (``None``) -> the env-var fallback resolves."""
+    _patch_vault_read(monkeypatch, None)
+    monkeypatch.setenv("MEHO_AGENT_SECRET_AGENT_REPORTER", "env-secret")
 
-    Pattern default ``MEHO_AGENT_SECRET_{client_id}`` against
-    ``agent:incident-triage`` -> ``MEHO_AGENT_SECRET_AGENT_INCIDENT_TRIAGE``.
+    client_id, secret = await resolve_agent_credentials("agent:reporter")
+
+    assert client_id == "agent:reporter"
+    assert secret == "env-secret"
+
+
+async def test_env_fallback_when_vault_not_configured(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """No ``VAULT_SCHEDULER_TOKEN`` -> NotConfigured -> env fallback.
+
+    Exercises the real :func:`read_agent_secret`, which raises
+    :class:`SchedulerVaultNotConfiguredError` before touching Vault when
+    the token is unset; the resolver swallows it and falls back.
     """
+    monkeypatch.delenv("VAULT_SCHEDULER_TOKEN", raising=False)
+    monkeypatch.setenv("MEHO_AGENT_SECRET_AGENT_REPORTER", "env-secret")
+    get_settings.cache_clear()
+
+    _, secret = await resolve_agent_credentials("agent:reporter")
+
+    assert secret == "env-secret"
+
+
+async def test_vault_broker_error_falls_back_to_env(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """A Vault read error falls back to the env var rather than failing.
+
+    A transient Vault outage must not block an agent whose secret is also
+    wired into the pod env (break-glass).
+    """
+    _patch_vault_read(
+        monkeypatch,
+        vault_credentials.SchedulerVaultBrokerError("vault unreachable"),
+    )
+    monkeypatch.setenv("MEHO_AGENT_SECRET_AGENT_REPORTER", "env-secret")
+
+    _, secret = await resolve_agent_credentials("agent:reporter")
+
+    assert secret == "env-secret"
+
+
+async def test_resolve_uses_sanitised_uppercased_env_name(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """Env-var name is sanitised then upper-cased (fallback path)."""
+    _patch_vault_read(monkeypatch, None)
     monkeypatch.setenv(
         "MEHO_AGENT_SECRET_AGENT_INCIDENT_TRIAGE",
         "triage-secret",
     )
 
-    _, secret = resolve_agent_credentials("agent:incident-triage")
+    _, secret = await resolve_agent_credentials("agent:incident-triage")
 
     assert secret == "triage-secret"
 
 
-def test_resolve_missing_env_raises(monkeypatch: pytest.MonkeyPatch) -> None:
-    """An unset env var -> :class:`AgentCredentialsUnresolvedError`."""
+async def test_resolve_missing_both_raises(monkeypatch: pytest.MonkeyPatch) -> None:
+    """Neither Vault nor env -> :class:`AgentCredentialsUnresolvedError`."""
+    _patch_vault_read(monkeypatch, None)
     monkeypatch.delenv("MEHO_AGENT_SECRET_AGENT_REPORTER", raising=False)
 
     with pytest.raises(AgentCredentialsUnresolvedError, match=r"agent:reporter"):
-        resolve_agent_credentials("agent:reporter")
+        await resolve_agent_credentials("agent:reporter")
 
 
-def test_resolve_empty_env_raises(monkeypatch: pytest.MonkeyPatch) -> None:
+async def test_resolve_empty_env_with_no_vault_raises(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
     """An empty env-var value is treated as unset (Helm template defence)."""
+    _patch_vault_read(monkeypatch, None)
     monkeypatch.setenv("MEHO_AGENT_SECRET_AGENT_REPORTER", "")
 
     with pytest.raises(AgentCredentialsUnresolvedError):
-        resolve_agent_credentials("agent:reporter")
+        await resolve_agent_credentials("agent:reporter")
 
 
-def test_resolve_whitespace_only_env_raises(
+async def test_resolve_whitespace_only_env_raises(
     monkeypatch: pytest.MonkeyPatch,
 ) -> None:
-    """Whitespace-only env-var value is treated as unset.
-
-    Defence against a Helm template that renders ``"\n"`` for an
-    unbound secret -- a literal-newline secret would pass an
-    ``if env_value`` check but fail Keycloak's grant request.
-    """
+    """Whitespace-only env-var value is treated as unset."""
+    _patch_vault_read(monkeypatch, None)
     monkeypatch.setenv("MEHO_AGENT_SECRET_AGENT_REPORTER", "   \n\t  ")
 
     with pytest.raises(AgentCredentialsUnresolvedError):
-        resolve_agent_credentials("agent:reporter")
+        await resolve_agent_credentials("agent:reporter")
 
 
-def test_custom_env_pattern_honoured(monkeypatch: pytest.MonkeyPatch) -> None:
-    """A non-default ``SCHEDULER_AGENT_SECRET_ENV_PATTERN`` reroutes the lookup.
-
-    Operators wiring agent secrets through a non-``MEHO_AGENT_SECRET_``
-    prefix swap the pattern; the resolver must read from the alternate
-    name without code changes.
-    """
+async def test_custom_env_pattern_honoured(monkeypatch: pytest.MonkeyPatch) -> None:
+    """A non-default ``SCHEDULER_AGENT_SECRET_ENV_PATTERN`` reroutes the lookup."""
+    _patch_vault_read(monkeypatch, None)
     monkeypatch.setenv(
         "SCHEDULER_AGENT_SECRET_ENV_PATTERN",
         "OPS_AGENT_{client_id}_PASSPHRASE",
@@ -158,25 +208,16 @@ def test_custom_env_pattern_honoured(monkeypatch: pytest.MonkeyPatch) -> None:
     monkeypatch.setenv("OPS_AGENT_AGENT_REPORTER_PASSPHRASE", "rotating-key")
     get_settings.cache_clear()
 
-    _, secret = resolve_agent_credentials("agent:reporter")
+    _, secret = await resolve_agent_credentials("agent:reporter")
 
     assert secret == "rotating-key"
 
 
-def test_resolve_uppercases_full_env_var_name_even_with_lowercase_pattern(
+async def test_resolve_uppercases_full_env_var_name_even_with_lowercase_pattern(
     monkeypatch: pytest.MonkeyPatch,
 ) -> None:
-    """A lower-cased pattern still resolves to the upper-cased env var.
-
-    The module docstring promises "the whole substituted name is
-    upper-cased". An operator who sets a non-upper-cased pattern
-    (e.g. ``meho_agent_secret_{client_id}`` -- common shape if their
-    Helm value template renders that way) must still find their secret
-    at ``MEHO_AGENT_SECRET_AGENT_REPORTER`` rather than at a literal
-    lower-case key. Linux env-var lookup is case-sensitive, so if the
-    code only upper-cased the ``client_id`` substitution this test
-    would fail with :class:`AgentCredentialsUnresolvedError`.
-    """
+    """A lower-cased pattern still resolves to the upper-cased env var."""
+    _patch_vault_read(monkeypatch, None)
     monkeypatch.setenv(
         "SCHEDULER_AGENT_SECRET_ENV_PATTERN",
         "meho_agent_secret_{client_id}",
@@ -184,7 +225,7 @@ def test_resolve_uppercases_full_env_var_name_even_with_lowercase_pattern(
     monkeypatch.setenv("MEHO_AGENT_SECRET_AGENT_REPORTER", "the-secret")
     get_settings.cache_clear()
 
-    _, secret = resolve_agent_credentials("agent:reporter")
+    _, secret = await resolve_agent_credentials("agent:reporter")
 
     assert secret == "the-secret"
 
@@ -202,13 +243,7 @@ def test_settings_rejects_malformed_scheduler_secret_pattern(
     monkeypatch: pytest.MonkeyPatch,
     bad_pattern: str,
 ) -> None:
-    """The settings validator fails fast at load on malformed patterns.
-
-    Pull-up to :class:`Settings` construction so a typo'd env var
-    surfaces as a startup error with an actionable message rather
-    than at first scheduled fire (when it would either collapse
-    every agent onto one shared secret or raise on every fire).
-    """
+    """The settings validator fails fast at load on malformed patterns."""
     monkeypatch.setenv("SCHEDULER_AGENT_SECRET_ENV_PATTERN", bad_pattern)
     get_settings.cache_clear()
 
@@ -231,20 +266,15 @@ def test_settings_accepts_valid_scheduler_secret_pattern(
     assert settings.scheduler_agent_secret_env_pattern == "CORP_AGENT_{client_id}_SECRET"
 
 
-def test_error_message_names_expected_env_var(
+async def test_error_message_names_expected_env_var(
     monkeypatch: pytest.MonkeyPatch,
 ) -> None:
-    """The :class:`AgentCredentialsUnresolvedError` message names the env-var
-    operators need to set.
-
-    A reader of the scheduler's WARN log line should be able to copy
-    the env-var name from the error into their Helm values without
-    deriving the sanitisation by hand.
-    """
+    """The error names the env var operators need to set (fallback path)."""
+    _patch_vault_read(monkeypatch, None)
     monkeypatch.delenv("MEHO_AGENT_SECRET_AGENT_BILLING_SUMMARY", raising=False)
 
     with pytest.raises(AgentCredentialsUnresolvedError) as excinfo:
-        resolve_agent_credentials("agent:billing.summary")
+        await resolve_agent_credentials("agent:billing.summary")
 
     msg = str(excinfo.value)
     assert "MEHO_AGENT_SECRET_AGENT_BILLING_SUMMARY" in msg

--- a/backend/tests/test_scheduler_vault_credentials.py
+++ b/backend/tests/test_scheduler_vault_credentials.py
@@ -1,0 +1,204 @@
+# SPDX-License-Identifier: Apache-2.0
+# Copyright (c) 2026 evoila Group
+
+"""Unit tests for :mod:`meho_backplane.scheduler.vault_credentials` (#1478).
+
+The scheduler-service-token Vault broker writes an agent's
+``client_credentials`` secret at registration and reads it back at fire
+time, both under the scheduler's static service token. These tests cover:
+
+* the raw-API-path -> ``(mount, logical_path)`` splitter;
+* the not-configured guard (no ``VAULT_SCHEDULER_TOKEN``);
+* the write happy path (payload shape + path derivation);
+* the read happy path, the not-found (``None``) path, and error mapping.
+
+The hvac client is faked via the ``_build_client`` seam — no running
+Vault. The live round-trip is covered by the integration suite.
+"""
+
+from __future__ import annotations
+
+from typing import Any
+
+import hvac.exceptions
+import pytest
+import requests.exceptions
+
+import meho_backplane.scheduler.vault_credentials as vc
+from meho_backplane.settings import get_settings
+
+
+@pytest.fixture(autouse=True)
+def _required_settings_env(monkeypatch: pytest.MonkeyPatch):
+    monkeypatch.setenv("KEYCLOAK_ISSUER_URL", "https://keycloak.test/realms/meho")
+    monkeypatch.setenv("KEYCLOAK_AUDIENCE", "meho-backplane")
+    monkeypatch.setenv("VAULT_ADDR", "https://vault.test")
+    monkeypatch.setenv("VAULT_SCHEDULER_TOKEN", "scheduler-tok")
+    get_settings.cache_clear()
+    yield
+    get_settings.cache_clear()
+
+
+class _FakeKvV2:
+    """In-memory stand-in for ``client.secrets.kv.v2``."""
+
+    def __init__(self) -> None:
+        self.writes: list[dict[str, Any]] = []
+        self.read_result: Any = None
+        self.read_raises: BaseException | None = None
+        self.last_read: dict[str, Any] | None = None
+
+    def create_or_update_secret(
+        self, *, path: str, secret: dict[str, Any], mount_point: str
+    ) -> dict[str, Any]:
+        self.writes.append({"path": path, "secret": secret, "mount_point": mount_point})
+        return {"data": {"version": 1}}
+
+    def read_secret_version(
+        self, *, path: str, mount_point: str, raise_on_deleted_version: bool
+    ) -> Any:
+        self.last_read = {"path": path, "mount_point": mount_point}
+        if self.read_raises is not None:
+            raise self.read_raises
+        return self.read_result
+
+
+class _FakeSecrets:
+    def __init__(self, kv: _FakeKvV2) -> None:
+        self.kv = type("KV", (), {"v2": kv})()
+
+
+class _FakeClient:
+    def __init__(self, kv: _FakeKvV2) -> None:
+        self.secrets = _FakeSecrets(kv)
+
+
+@pytest.fixture
+def fake_kv(monkeypatch: pytest.MonkeyPatch) -> _FakeKvV2:
+    """Patch the ``_build_client`` seam to return a fake hvac client."""
+    kv = _FakeKvV2()
+
+    def _fake_build_client(_settings: Any, *, token: str | None = None) -> _FakeClient:
+        # Assert the scheduler token is threaded through.
+        assert token == "scheduler-tok"
+        return _FakeClient(kv)
+
+    monkeypatch.setattr(vc, "_build_client", _fake_build_client)
+    return kv
+
+
+# --- splitter ---------------------------------------------------------
+
+
+@pytest.mark.parametrize(
+    ("api_path", "expected"),
+    [
+        (
+            "secret/data/agents/AGENT_REPORTER/credentials",
+            ("secret", "agents/AGENT_REPORTER/credentials"),
+        ),
+        ("kv/data/foo/bar", ("kv", "foo/bar")),
+        ("secret/data/x", ("secret", "x")),
+        # No data/ infix -> treated as logical on default mount.
+        ("agents/x/credentials", ("secret", "agents/x/credentials")),
+        # Surrounding slashes tolerated.
+        ("/secret/data/a/b/", ("secret", "a/b")),
+    ],
+)
+def test_split_kv_v2_api_path(api_path: str, expected: tuple[str, str]) -> None:
+    assert vc.split_kv_v2_api_path(api_path) == expected
+
+
+@pytest.mark.parametrize("bad", ["", "   ", "secret/data/", "secret/data"])
+def test_split_kv_v2_api_path_rejects_empty_logical(bad: str) -> None:
+    with pytest.raises(ValueError):
+        vc.split_kv_v2_api_path(bad)
+
+
+def test_vault_path_for_client_id_sanitises_and_uppercases() -> None:
+    path = vc.vault_path_for_client_id("agent:reporter")
+    assert path == "secret/data/agents/AGENT_REPORTER/credentials"
+
+
+# --- not configured ---------------------------------------------------
+
+
+async def test_write_not_configured_raises(monkeypatch: pytest.MonkeyPatch) -> None:
+    monkeypatch.delenv("VAULT_SCHEDULER_TOKEN", raising=False)
+    get_settings.cache_clear()
+    with pytest.raises(vc.SchedulerVaultNotConfiguredError):
+        await vc.write_agent_secret("agent:reporter", "s3cr3t")
+
+
+async def test_read_not_configured_raises(monkeypatch: pytest.MonkeyPatch) -> None:
+    monkeypatch.delenv("VAULT_SCHEDULER_TOKEN", raising=False)
+    get_settings.cache_clear()
+    with pytest.raises(vc.SchedulerVaultNotConfiguredError):
+        await vc.read_agent_secret("agent:reporter")
+
+
+# --- write ------------------------------------------------------------
+
+
+async def test_write_persists_secret_at_derived_path(fake_kv: _FakeKvV2) -> None:
+    api_path = await vc.write_agent_secret("agent:reporter", "gen-secret")
+
+    assert api_path == "secret/data/agents/AGENT_REPORTER/credentials"
+    assert len(fake_kv.writes) == 1
+    write = fake_kv.writes[0]
+    assert write["mount_point"] == "secret"
+    assert write["path"] == "agents/AGENT_REPORTER/credentials"
+    assert write["secret"] == {vc.SECRET_FIELD: "gen-secret"}
+
+
+async def test_write_unreachable_maps_to_broker_error(fake_kv: _FakeKvV2) -> None:
+    def _boom(**_: Any) -> None:
+        raise requests.exceptions.ConnectionError("down")
+
+    fake_kv.create_or_update_secret = _boom  # type: ignore[assignment]
+    with pytest.raises(vc.SchedulerVaultBrokerError):
+        await vc.write_agent_secret("agent:reporter", "s")
+
+
+# --- read -------------------------------------------------------------
+
+
+async def test_read_returns_secret(fake_kv: _FakeKvV2) -> None:
+    fake_kv.read_result = {
+        "data": {"data": {vc.SECRET_FIELD: "gen-secret"}, "metadata": {"version": 1}}
+    }
+    secret = await vc.read_agent_secret("agent:reporter")
+    assert secret == "gen-secret"
+    assert fake_kv.last_read == {
+        "path": "agents/AGENT_REPORTER/credentials",
+        "mount_point": "secret",
+    }
+
+
+async def test_read_missing_path_returns_none(fake_kv: _FakeKvV2) -> None:
+    """A KV-v2 read of a non-existent path (InvalidPath) returns ``None``."""
+    fake_kv.read_raises = hvac.exceptions.InvalidPath("404")
+    assert await vc.read_agent_secret("agent:reporter") is None
+
+
+async def test_read_missing_field_returns_none(fake_kv: _FakeKvV2) -> None:
+    """A payload without the secret field is treated as 'not in Vault'."""
+    fake_kv.read_result = {"data": {"data": {"other": "x"}, "metadata": {}}}
+    assert await vc.read_agent_secret("agent:reporter") is None
+
+
+async def test_read_malformed_payload_returns_none(fake_kv: _FakeKvV2) -> None:
+    fake_kv.read_result = {"data": {}}
+    assert await vc.read_agent_secret("agent:reporter") is None
+
+
+async def test_read_unreachable_maps_to_broker_error(fake_kv: _FakeKvV2) -> None:
+    fake_kv.read_raises = requests.exceptions.Timeout("slow")
+    with pytest.raises(vc.SchedulerVaultBrokerError):
+        await vc.read_agent_secret("agent:reporter")
+
+
+async def test_read_vault_error_maps_to_broker_error(fake_kv: _FakeKvV2) -> None:
+    fake_kv.read_raises = hvac.exceptions.Forbidden("denied")
+    with pytest.raises(vc.SchedulerVaultBrokerError):
+        await vc.read_agent_secret("agent:reporter")

--- a/docs/codebase/scheduler.md
+++ b/docs/codebase/scheduler.md
@@ -103,31 +103,57 @@ DBOS rebase swaps only the loop module.
 
 ### Autonomous-agent credentials
 
-The scheduler is operator-less (no JWT to forward), so it sources the
-``client_credentials`` grant identity from the backplane pod's env
-vars rather than Vault. The lookup chain:
+The scheduler is operator-less (no Keycloak JWT to forward to Vault's
+JWT/OIDC auth method), so it sources the `client_credentials` secret
+**Vault-first** under its own static service token, falling back to a
+pod env var only when Vault yields nothing (#1478). The lookup chain:
 
 1. The trigger's `agent_definition_id` resolves to an
-   `AgentDefinition.identity_ref` (e.g. `agent:reporter`).
+   `AgentDefinition.identity_ref` (e.g. `agent:reporter`). The
+   `identity_ref` verbatim is the `client_id` passed to `run_scheduled`
+   (Keycloak's namespace tolerates the `:` separator).
 2. `resolve_agent_credentials(identity_ref)` (in
    [scheduler/credentials.py](../../backend/src/meho_backplane/scheduler/credentials.py))
    sanitises the ref (non-alphanumeric chars to `_`, upper-case) and
-   substitutes it into `SCHEDULER_AGENT_SECRET_ENV_PATTERN`
-   (default `MEHO_AGENT_SECRET_{client_id}`). For
-   `agent:reporter` the resolved env var is
-   `MEHO_AGENT_SECRET_AGENT_REPORTER`.
-3. The env-var value becomes the `client_secret`; the `client_id`
-   passed to `run_scheduled` is the `identity_ref` verbatim
-   (Keycloak's namespace tolerates the `:` separator).
-4. An unset / empty env var raises `AgentCredentialsUnresolvedError`;
-   the loop logs `scheduler_credentials_unresolved` and skips the
-   fire. The trigger stays `active` so an operator who wires the
-   secret unblocks the schedule on the next tick — no parking.
+   resolves the secret:
+   - **Vault (first).**
+     [`read_agent_secret`](../../backend/src/meho_backplane/scheduler/vault_credentials.py)
+     reads the secret from `SCHEDULER_AGENT_VAULT_PATH_PATTERN`
+     (default `secret/data/agents/{client_id}/credentials`) under
+     `VAULT_SCHEDULER_TOKEN`. The raw KV-v2 API path is split into
+     hvac's `(mount_point, logical_path)` form by `split_kv_v2_api_path`.
+     This is the path registration writes to (see below), so an agent
+     registered + defined purely over the API is schedulable with **no
+     pod env var and no redeploy**. A missing path / unset token / read
+     error falls through to the env var.
+   - **Env var (fallback / break-glass).** When Vault yields nothing,
+     the secret is read from the env var derived from
+     `SCHEDULER_AGENT_SECRET_ENV_PATTERN` (default
+     `MEHO_AGENT_SECRET_{client_id}`). For `agent:reporter` the
+     resolved env var is `MEHO_AGENT_SECRET_AGENT_REPORTER`. Operators
+     wire it the same way `ANTHROPIC_API_KEY` is wired when Vault is
+     unavailable.
+3. When **neither** source yields a secret,
+   `AgentCredentialsUnresolvedError` is raised; the loop logs
+   `scheduler_credentials_unresolved` and skips the fire. The trigger
+   stays `active` so a subsequent tick retries once the secret is
+   available — no parking.
 
-The `SCHEDULER_AGENT_VAULT_PATH_PATTERN` setting is reserved for a
-future G11.2 follow-up that will swap the env-var path for a
-scheduler-service-token Vault read; ships configured but unused in
-v0.2.
+The write side: registering an agent principal
+([`AgentPrincipalService.register`](../../backend/src/meho_backplane/auth/agent_principals.py))
+captures the Keycloak-generated client secret (`get_client_secret`) and
+persists it to Vault at `SCHEDULER_AGENT_VAULT_PATH_PATTERN`
+([`write_agent_secret`](../../backend/src/meho_backplane/scheduler/vault_credentials.py)),
+under the same scheduler service token. A Vault-write failure rolls back
+the just-created Keycloak client so registration never produces an
+unschedulable agent.
+
+`VAULT_SCHEDULER_TOKEN` is a static token bound to a narrow read/write
+policy on the agent-credentials path — the lowest-friction
+operator-less Vault identity (it reuses hvac's `Client(token=…)`
+primitive with no AppRole `secret_id` bootstrap). Operators preferring
+AppRole run a Vault Agent sidecar that renews a token into the env var:
+additive, no code change.
 
 ### Precondition gate vs invoke-time failure
 
@@ -135,11 +161,11 @@ The two fire paths follow the same lifecycle shape:
 
 1. **Prepare** (`_prepare_invocation`) — look up the agent definition
    (FK; real-FK lookup-by-primary-key) and resolve the agent's
-   `client_credentials` pair from the env var pattern. Returns
+   `client_credentials` pair Vault-first (env-var fallback). Returns
    `None` (skip without state writes) when any precondition fails:
    - the agent definition was removed since trigger creation, or
    - the definition is disabled, or
-   - the agent's secret env var is not set / empty.
+   - the agent's secret is in neither Vault nor the fallback env var.
 2. **Advance / mark-fired** — only when the prepare step succeeded.
    The conditional `UPDATE` (status / next_fire_at guard) commits
    the row's state transition.


### PR DESCRIPTION
## Summary

- The scheduler is operator-less and previously sourced an agent's `client_credentials` secret only from a pod env var (`MEHO_AGENT_SECRET_*`); the Vault path setting was defined-but-never-read. An agent registered + defined purely over the API was therefore **not schedulable** until an operator wired its secret into the pod env and redeployed — the registration path and the run path disagreed about where the credential lived.
- **Capture-at-registration:** `AgentPrincipalService.register` now fetches the Keycloak-generated client secret (`KeycloakAdminClient.get_client_secret` → `GET .../clients/{id}/client-secret`) and persists it to Vault at `scheduler_agent_vault_path_pattern` under a scheduler service token. A Vault-write failure rolls back the just-created Keycloak client (fail-closed); an *unset* token skips the write with a warning (backward-compatible with env-var-only deployments).
- **Scheduler Vault read identity:** new `scheduler/vault_credentials.py` reads/writes the secret under a static `VAULT_SCHEDULER_TOKEN` (hvac `Client(token=…)`) — no per-operator JWT. `resolve_agent_credentials` is now **Vault-first** with the env var kept as a documented break-glass fallback; `scheduler_credentials_unresolved` still fires when neither source yields a secret.
- A static service token (not AppRole) is the lowest-friction operator-less Vault identity — it reuses the primitive the live-Vault test harness already uses, with no `secret_id` bootstrap. The doc records AppRole-via-Vault-Agent as an additive, no-code-change alternative.

## Test plan

- [x] `ruff check` / `ruff format --check` — clean
- [x] `mypy src/meho_backplane/` — no issues (430 files)
- [x] `python3 .claude/hooks/code-quality.py --diff` — 0 blockers
- [x] Unit: `test_scheduler_credentials.py` (Vault-first / fallback / both-miss), `test_scheduler_vault_credentials.py` (path splitter, write/read round-trip, not-configured, error mapping), `test_keycloak_admin.py` (`get_client_secret`), `test_api_v1_agent_principals.py` (persist-to-Vault, rollback-on-write-failure, skip-when-token-unset), `test_scheduler.py` — all green
- [x] Integration (live Vault dev container, `tests/integration/test_scheduler_vault_credentials_dev_e2e.py`): write→read round-trip, resolution from Vault with **no** pod env var set, raises when neither source yields. Skips-in-sandbox (no Docker); runs in CI.
- [x] `docs/codebase/scheduler.md` updated to Vault-first; "ships configured but unused" removed. CHANGELOG `[Unreleased]` bullet added.

## Out of scope

- Agent secret rotation / Vault lease renewal (deferred per the issue).
- Helm chart wiring of `VAULT_SCHEDULER_TOKEN` (env-driven; chart `secretKeyRef` surface is a separate devops follow-up — recorded as adjacent finding).
- Changing the env-var fallback naming/derivation.

<!-- auto-implement-issue: fresh, iteration 1 -->

Closes #1478
