### PR TITLE
fix(approvals): surface APPROVAL_ALLOW_SELF_APPROVAL break-glass hint (#1483)

### DIFF
--- a/backend/src/meho_backplane/api/v1/approvals.py
+++ b/backend/src/meho_backplane/api/v1/approvals.py
@@ -410,9 +410,13 @@ async def approve_approval_request(
             detail="insufficient_role",
         ) from exc
     except SelfApprovalForbiddenError as exc:
+        # Keep the ``self_approval_forbidden`` token prefix (stable for
+        # clients matching on it) but append ``str(exc)``, which carries
+        # the ``APPROVAL_ALLOW_SELF_APPROVAL=true`` break-glass hint the
+        # exception already constructs (#1483).
         raise HTTPException(
             status_code=http_status.HTTP_403_FORBIDDEN,
-            detail="self_approval_forbidden",
+            detail=f"self_approval_forbidden: {exc}",
         ) from exc
     except ApprovalRequestAlreadyDecidedError as exc:
         raise HTTPException(
@@ -614,9 +618,12 @@ async def decide_approval_request(
             detail="insufficient_role",
         ) from exc
     except SelfApprovalForbiddenError as exc:
+        # Same token-prefix + ``str(exc)`` hint as the /approve path
+        # so /decide's self-approval rejection also names the
+        # ``APPROVAL_ALLOW_SELF_APPROVAL`` break-glass flag (#1483).
         raise HTTPException(
             status_code=http_status.HTTP_403_FORBIDDEN,
-            detail="self_approval_forbidden",
+            detail=f"self_approval_forbidden: {exc}",
         ) from exc
     except ApprovalRequestAlreadyDecidedError as exc:
         raise HTTPException(

--- a/backend/src/meho_backplane/mcp/tools/approvals.py
+++ b/backend/src/meho_backplane/mcp/tools/approvals.py
@@ -368,10 +368,11 @@ async def _approve_handler(
         except SelfApprovalForbiddenError as exc:
             # G11.7-T1 #1401: requester != approver. Surfaced as an
             # invalid-params error so the operator sees the refusal
-            # reason rather than a generic role failure.
-            raise McpInvalidParamsError(
-                "self_approval_forbidden: requester and approver must differ"
-            ) from exc
+            # reason rather than a generic role failure. Append
+            # ``str(exc)`` so the message also carries the
+            # ``APPROVAL_ALLOW_SELF_APPROVAL=true`` break-glass hint the
+            # exception already constructs (#1483).
+            raise McpInvalidParamsError(f"self_approval_forbidden: {exc}") from exc
         except UnauthorizedApprovalError as exc:
             raise McpInvalidParamsError(
                 f"approval_unauthorized: role {exc.role!r} cannot approve"

--- a/backend/tests/test_api_v1_approvals.py
+++ b/backend/tests/test_api_v1_approvals.py
@@ -281,3 +281,59 @@ async def test_resume_dispatches_when_no_target_was_pinned(
     assert result.status == "ok"
     assert seen["target"] is None
     assert seen["_approved"] is True
+
+
+# ---------------------------------------------------------------------------
+# T6 (#1483) — self_approval_forbidden REST detail must carry the
+# APPROVAL_ALLOW_SELF_APPROVAL break-glass hint the exception constructs.
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.parametrize(
+    "path_suffix, body",
+    [
+        ("approve", {"params": {}}),
+        ("decide", {"decision": "approved"}),
+    ],
+)
+def test_self_approval_forbidden_detail_carries_break_glass_hint(
+    client: TestClient,
+    monkeypatch: pytest.MonkeyPatch,
+    path_suffix: str,
+    body: dict[str, Any],
+) -> None:
+    """403 ``self_approval_forbidden`` detail names ``APPROVAL_ALLOW_SELF_APPROVAL``.
+
+    The service raises :class:`SelfApprovalForbiddenError` whose message
+    already names the break-glass flag; both the ``/approve`` and the
+    operator-decision ``/decide`` route map it to 403. The wire ``detail``
+    must keep the machine-readable ``self_approval_forbidden`` token prefix
+    **and** carry the env-var hint so a solo operator sees the escape hatch
+    in the response body rather than a bare token (#1483).
+    """
+    from meho_backplane.api.v1 import approvals as approvals_module
+    from meho_backplane.operations.approval_queue import SelfApprovalForbiddenError
+
+    request_id = uuid.UUID("55555555-5555-5555-5555-555555555555")
+
+    async def _raise_self_approval(*_a: object, **_kw: object) -> None:
+        raise SelfApprovalForbiddenError(request_id, principal_sub="op-test")
+
+    # Both routes call the module-level ``approve_request``; patch it to
+    # raise before any DB row is touched.
+    monkeypatch.setattr(approvals_module, "approve_request", _raise_self_approval)
+
+    key = make_rsa_keypair("kid-op")
+    with respx.mock as r:
+        mock_discovery_and_jwks(r, public_jwks(key))
+        headers = {"Authorization": f"Bearer {_token(key, role=TenantRole.OPERATOR)}"}
+        response = client.post(
+            f"/api/v1/approvals/{request_id}/{path_suffix}",
+            headers=headers,
+            json=body,
+        )
+
+    assert response.status_code == 403, response.text
+    detail = response.json()["detail"]
+    assert detail.startswith("self_approval_forbidden"), detail
+    assert "APPROVAL_ALLOW_SELF_APPROVAL" in detail, detail

--- a/backend/tests/test_mcp_tool_approvals.py
+++ b/backend/tests/test_mcp_tool_approvals.py
@@ -39,7 +39,7 @@ from typing import Any
 import pytest
 from fastapi.testclient import TestClient
 
-from meho_backplane.auth.operator import Operator
+from meho_backplane.auth.operator import Operator, TenantRole
 from meho_backplane.mcp.schemas import INVALID_PARAMS
 from tests.mcp_test_fixtures import (
     client_with_operator,  # noqa: F401 — pytest-discovered fixture
@@ -113,3 +113,48 @@ def test_read_only_tools_call_approval_is_rejected_with_forbidden(
     assert "error" in body, body
     assert body["error"]["code"] == INVALID_PARAMS
     assert "forbidden" in body["error"]["message"].lower(), body
+
+
+# ---------------------------------------------------------------------------
+# T6 (#1483) — self_approval_forbidden MCP error must carry the
+# APPROVAL_ALLOW_SELF_APPROVAL break-glass hint the exception constructs.
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.parametrize("client_with_operator", [TenantRole.OPERATOR], indirect=True)
+def test_self_approval_forbidden_message_carries_break_glass_hint(
+    client_with_operator: tuple[TestClient, Operator],  # noqa: F811
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """``meho.approvals.approve`` self-approval error names ``APPROVAL_ALLOW_SELF_APPROVAL``.
+
+    The role gate passes for ``operator``; the handler then raises
+    :class:`SelfApprovalForbiddenError`, whose message already names the
+    break-glass flag. The MCP ``INVALID_PARAMS`` envelope must keep the
+    ``self_approval_forbidden`` token prefix **and** carry the env-var
+    hint so an agent/operator sees the escape hatch rather than a bare
+    token (#1483).
+    """
+    import uuid
+
+    from meho_backplane.mcp.tools import approvals as approvals_tool
+    from meho_backplane.operations.approval_queue import SelfApprovalForbiddenError
+
+    request_id = uuid.UUID("66666666-6666-6666-6666-666666666666")
+
+    async def _raise_self_approval(*_a: object, **_kw: object) -> None:
+        raise SelfApprovalForbiddenError(request_id, principal_sub="op-test")
+
+    monkeypatch.setattr(approvals_tool, "approve_request", _raise_self_approval)
+
+    client, _op = client_with_operator
+    resp = post_mcp(
+        client,
+        _tools_call("meho.approvals.approve", {"approval_request_id": str(request_id)}),
+    )
+    body = resp.json()
+    assert "error" in body, body
+    assert body["error"]["code"] == INVALID_PARAMS
+    message = body["error"]["message"]
+    assert message.startswith("self_approval_forbidden"), message
+    assert "APPROVAL_ALLOW_SELF_APPROVAL" in message, message

--- a/docs/codebase/approvals.md
+++ b/docs/codebase/approvals.md
@@ -52,7 +52,11 @@ model, or resume endpoint):
    request.principal_sub`, unless the audited break-glass switch
    `APPROVAL_ALLOW_SELF_APPROVAL=true`
    (`Settings.approval_allow_self_approval`, default `False` =
-   fail-closed) is set. Even under break-glass the self-approval writes
+   fail-closed) is set. Both wire strings keep the
+   `self_approval_forbidden` token as a prefix and append the
+   exception message, so the `APPROVAL_ALLOW_SELF_APPROVAL` break-glass
+   hint reaches the operator-facing REST `detail` and MCP error message
+   rather than being dropped to a bare token (#1483). Even under break-glass the self-approval writes
    its decision audit row, so the use is forensically visible. **Reject
    is unguarded** — withdrawing one's own pending request is never a
    privilege escalation. The guard runs after the role check and before


### PR DESCRIPTION
## Summary
- The REST `detail` and MCP error string for a self-approval rejection dropped the `APPROVAL_ALLOW_SELF_APPROVAL` break-glass hint that `SelfApprovalForbiddenError` already constructs, so a solo operator saw only a bare `self_approval_forbidden` token with no pointer to the audited single-operator escape hatch.
- Threads `str(exc)` into the wire string at all three catch sites — REST `/approve`, REST `/decide`, and MCP `meho.approvals.approve` — keeping `self_approval_forbidden` as a token prefix (clients matching on it still work) while the env-var hint now reaches the operator.
- Gate logic is unchanged — only the operator-facing message text. (T6, SEV-4.)

## Test plan
- [x] `ruff check` — clean (4 files)
- [x] `ruff format --check` — clean
- [x] `mypy src/meho_backplane/` — Success, no issues in 429 files
- [x] `pytest tests/test_api_v1_approvals.py tests/test_mcp_tool_approvals.py` — 15 passed
- [x] `code-quality.py --diff` — 0 blockers (5 pre-existing warnings on file/function size, not introduced here)
- [x] **AC1** — REST 403 `detail` for both `/approve` and `/decide` contains `APPROVAL_ALLOW_SELF_APPROVAL` (new parametrized test asserts the env-var name in the response body)
- [x] **AC2** — MCP `self_approval_forbidden` INVALID_PARAMS message contains the same hint (new test)
- [x] **AC3** — no behavior change to the gate itself (only message text; service-layer guard untouched, existing `test_approval_queue.py` self-approval cases still pass)

## Out of scope
- **Open question (deliberately not implemented):** making op-level `requires_approval` role-aware so a `tenant_admin`'s own direct write isn't gated. That is a policy-design change with real fail-open risk and needs its own discussion (per the issue's Out-of-scope section).
- Changing the default of `APPROVAL_ALLOW_SELF_APPROVAL`.
- Audit status-code / `principal_act` logic — owned by sibling task #1481.

## Adjacent findings (recorded, not addressed)
- `backend/src/meho_backplane/api/v1/approvals.py` is 639 lines (pre-existing, >600 soft limit) and several route handlers are >60 lines; `mcp/tools/approvals.py` is 498 lines. Pre-existing debt, out of scope.

<!-- auto-implement-issue: fresh, iteration 1 -->

Closes #1483
