### PR TITLE
fix(mcp): audit post-gate -32602 rejections as denied + populate principal_act

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -100,6 +100,17 @@ connector-related release-notes line.
   (`VAULT_SCHEDULER_TOKEN`); `resolve_agent_credentials` reads it
   Vault-first, keeping the env var as a documented break-glass fallback
   (#1478).
+- **Approval-queue audit fidelity (G0.19-T4).** A self-approval (and any
+  other post-gate `McpInvalidParamsError` — `approval_request_not_found`,
+  `approval_unauthorized`) rejection over MCP now audits with a `403`
+  "denied" status consistent with the JSON-RPC `-32602` wire outcome,
+  instead of a misleading `500`; the live broadcast event is classified
+  "denied", not "error". Delegated agent runs now record
+  `principal_act=agent:<name>` on the parked `ApprovalRequest` row (read
+  from the same `actor_sub` delegation context the audit log uses);
+  previously this field read a nonexistent `Operator.identity_act` and
+  was always null. Direct human approvals keep `principal_act=NULL`
+  (#1481).
 
 ## [0.10.0] - 2026-06-01
 

--- a/backend/src/meho_backplane/mcp/handlers.py
+++ b/backend/src/meho_backplane/mcp/handlers.py
@@ -185,6 +185,9 @@ async def handle_tools_list(
     return {"tools": visible}
 
 
+# code-quality-allow: pre-existing oversized MCP envelope dispatcher (>100
+# lines / C901 / PLR0915 on main before #1481); the #1481 audit-status fix
+# adds a small except arm, not the size — refactor is out of scope here.
 async def handle_tools_call(
     operator: Operator,
     params: dict[str, Any] | None,
@@ -317,6 +320,25 @@ async def handle_tools_call(
             "content": [{"type": "text", "text": json.dumps(result)}],
             "isError": False,
         }
+    except McpInvalidParamsError:
+        # Class-wide audit-status correction (#1481). A tool handler can
+        # raise ``McpInvalidParamsError`` *after* all the explicit
+        # pre-dispatch gates (name/arguments/unknown-tool/RBAC/schema)
+        # — e.g. ``_approve_handler`` rejecting a self-approval,
+        # ``approval_request_not_found``, or ``approval_unauthorized``.
+        # Those raises bypass every branch that set ``status_code``, so
+        # it is still the init 500 — a server-fault projection of what is
+        # actually a JSON-RPC ``-32602`` parameter/policy rejection on
+        # the wire. Project the whole class onto a 403 "denied" status so
+        # the audit row and the broadcast event
+        # (:func:`_classify_mcp_status`) classify the rejection
+        # consistently with the wire outcome instead of mis-reporting a
+        # crash. Explicit pre-dispatch branches already set 400/403/404,
+        # so they flow through here unchanged; only the residual init 500
+        # is corrected.
+        if status_code == 500:
+            status_code = 403
+        raise
     finally:
         duration_ms = (time.monotonic() - start) * 1000
         audit_id = uuid.uuid4()
@@ -472,6 +494,9 @@ async def handle_resources_templates_list(
     return {"resourceTemplates": visible}
 
 
+# code-quality-allow: pre-existing oversized resources/read handler (>100
+# lines on main before #1481); the #1481 audit-status fix adds a small
+# except arm, not the size — refactor is out of scope here.
 async def handle_resources_read(
     operator: Operator,
     params: dict[str, Any] | None,
@@ -566,6 +591,18 @@ async def handle_resources_read(
                 },
             ],
         }
+    except McpInvalidParamsError:
+        # Class-wide audit-status correction (#1481), mirroring
+        # :func:`handle_tools_call`. A resource handler that raises
+        # ``McpInvalidParamsError`` after the explicit gates leaves
+        # ``status_code`` at the init 500; the wire outcome is a
+        # ``-32602`` rejection, so project it onto a 403 "denied" status
+        # for the audit row and the broadcast event. Pre-dispatch
+        # branches (400/404/403) already set ``status_code`` and pass
+        # through untouched.
+        if status_code == 500:
+            status_code = 403
+        raise
     finally:
         duration_ms = (time.monotonic() - start) * 1000
         audit_id = uuid.uuid4()

--- a/backend/src/meho_backplane/operations/approval_queue.py
+++ b/backend/src/meho_backplane/operations/approval_queue.py
@@ -66,6 +66,7 @@ import structlog
 from sqlalchemy import select
 from sqlalchemy.ext.asyncio import AsyncSession
 
+from meho_backplane.auth.delegation import resolve_actor_sub
 from meho_backplane.auth.operator import Operator
 from meho_backplane.db.models import (
     ApprovalRequest,
@@ -243,6 +244,9 @@ async def _write_audit_row(
     await session.flush()
 
 
+# code-quality-allow: already over the 100-line limit on main before #1481
+# (105 lines); the principal_act source fix adds a handful of lines, not the
+# bulk — splitting the row-build + audit-write is out of scope for this fix.
 async def create_pending_request(
     session: AsyncSession,
     *,
@@ -299,7 +303,15 @@ async def create_pending_request(
         if target_id is not None:
             proposed_effect["target_id"] = str(target_id)
 
-    principal_act: str | None = getattr(operator, "identity_act", None)
+    # RFC 8693 ``act`` (#1481): the agent principal acting on the human
+    # subject's behalf on a delegated run, read from the same
+    # ``actor_delegation`` contextvar the synchronous audit log resolves
+    # (``resolve_actor_sub``). Keeps the row's ``principal_sub`` +
+    # ``principal_act`` lineage in lock-step with the audit log; a direct
+    # human / autonomous-agent call (no delegation bound) resolves to
+    # ``None``. The prior ``getattr(operator, "identity_act", None)`` was
+    # dead code — ``Operator`` has no such field, so it was always ``None``.
+    principal_act: str | None = resolve_actor_sub()
 
     request = ApprovalRequest(
         id=uuid.uuid4(),

--- a/backend/tests/test_approval_queue.py
+++ b/backend/tests/test_approval_queue.py
@@ -45,6 +45,7 @@ import pytest
 from sqlalchemy import select
 from sqlalchemy.ext.asyncio import AsyncSession
 
+from meho_backplane.auth.delegation import actor_delegation
 from meho_backplane.auth.operator import Operator, PrincipalKind, TenantRole
 from meho_backplane.db.engine import get_sessionmaker
 from meho_backplane.db.models import ApprovalRequest, ApprovalRequestStatus, AuditLog
@@ -177,6 +178,66 @@ async def test_create_pending_request_inserts_row(session: AsyncSession) -> None
     assert request.run_id is None
     assert request.reviewed_by is None
     assert request.decided_at is None
+
+
+@pytest.mark.asyncio
+async def test_create_pending_request_records_principal_act_on_delegated_run(
+    session: AsyncSession,
+) -> None:
+    """#1481 AC: a delegated agent run records ``principal_act=agent:<name>``.
+
+    A human-initiated agent run binds the acting agent into the
+    ``actor_delegation`` contextvar (RFC 8693 ``act``); the approval row
+    must carry that actor so its ``principal_sub`` + ``principal_act``
+    lineage matches the synchronous audit log's ``actor_sub``. The prior
+    ``getattr(operator, "identity_act", None)`` dropped it (dead read of
+    a nonexistent field).
+    """
+    # operator.sub is the *human* subject who triggered the run.
+    operator = _make_operator(sub="human-sub", principal_kind=PrincipalKind.USER)
+
+    with actor_delegation("agent:incident-bot"):
+        request = await create_pending_request(
+            session,
+            operator=operator,
+            connector_id="vault-1.x",
+            op_id="vault.kv.write",
+            target=None,
+            params={"key": "value"},
+            params_hash=compute_params_hash({"key": "value"}),
+        )
+    await session.commit()
+
+    assert request.principal_sub == "human-sub"
+    assert request.principal_act == "agent:incident-bot"
+
+
+@pytest.mark.asyncio
+async def test_create_pending_request_principal_act_null_without_delegation(
+    session: AsyncSession,
+) -> None:
+    """#1481 AC (no regression): a direct call with no actor binding
+    leaves ``principal_act`` NULL.
+
+    Outside an ``actor_delegation`` block, ``resolve_actor_sub()``
+    returns ``None`` — the correct value for a direct human request or
+    an autonomous agent run (the agent is the subject, with no separate
+    actor).
+    """
+    operator = _make_operator(sub="agent-sub")
+
+    request = await create_pending_request(
+        session,
+        operator=operator,
+        connector_id="vault-1.x",
+        op_id="vault.kv.write",
+        target=None,
+        params={},
+        params_hash=compute_params_hash({}),
+    )
+    await session.commit()
+
+    assert request.principal_act is None
 
 
 @pytest.mark.asyncio

--- a/backend/tests/test_mcp_audit.py
+++ b/backend/tests/test_mcp_audit.py
@@ -33,11 +33,13 @@ import pytest
 from fastapi.testclient import TestClient
 from sqlalchemy import select
 
-from meho_backplane.auth.operator import Operator
+from meho_backplane.auth.operator import Operator, TenantRole
 from meho_backplane.db.engine import get_sessionmaker
 from meho_backplane.db.models import AuditLog
 from meho_backplane.mcp.audit import compute_params_hash, write_mcp_audit_row
+from meho_backplane.mcp.registry import ToolDefinition, register_mcp_tool
 from meho_backplane.mcp.schemas import INTERNAL_ERROR, INVALID_PARAMS, INVALID_REQUEST
+from meho_backplane.mcp.server import McpInvalidParamsError
 from meho_backplane.settings import get_settings
 from tests.mcp_test_fixtures import (
     build_operator,
@@ -167,6 +169,76 @@ async def test_tools_call_unknown_tool_writes_audit_row_with_404(
     assert row.path == "/mcp/tools/call/no.such.tool"
     assert row.status_code == 404
     assert row.payload["op_class"] == "unknown"
+
+
+# ---------------------------------------------------------------------------
+# #1481: a post-gate McpInvalidParamsError audits as "denied" (403), not 500
+# ---------------------------------------------------------------------------
+
+
+async def _post_gate_rejecting_handler(
+    _operator: Operator,
+    _arguments: dict[str, Any],
+) -> dict[str, Any]:
+    """Tool handler that raises ``McpInvalidParamsError`` after all gates.
+
+    Models the production approval-queue rejections — self-approval,
+    ``approval_request_not_found``, ``approval_unauthorized`` — which
+    ``_approve_handler`` re-raises as :class:`McpInvalidParamsError`
+    *after* the dispatcher's name/argument/RBAC/schema checks have
+    already passed (so none of them set ``status_code``).
+    """
+    raise McpInvalidParamsError(
+        "self_approval_forbidden: requester and approver must differ",
+    )
+
+
+@pytest.mark.asyncio
+async def test_tools_call_post_gate_invalid_params_audits_as_denied_not_500(
+    client_with_operator: tuple[TestClient, Operator],
+) -> None:
+    """#1481: a post-gate ``McpInvalidParamsError`` audits as 403 "denied".
+
+    Regression for the bug where ``status_code`` initialised to 500 and
+    a handler-raised :class:`McpInvalidParamsError` (the wire
+    ``-32602``) never overwrote it, so the audit row recorded a fake
+    500 server crash for a clean policy rejection. The fix lives at the
+    dispatch boundary so the whole class is covered — self-approval,
+    ``approval_request_not_found``, ``approval_unauthorized``, and any
+    future post-gate ``McpInvalidParamsError`` — not just self-approval.
+    """
+    client, _op = client_with_operator
+
+    register_mcp_tool(
+        ToolDefinition(
+            name="test.post_gate_reject",
+            description="Raises McpInvalidParamsError after the gates (test only).",
+            inputSchema={"type": "object", "properties": {}, "additionalProperties": False},
+            required_role=TenantRole.READ_ONLY,
+            op_class="write",
+        ),
+        _post_gate_rejecting_handler,
+    )
+
+    response = post_mcp(
+        client,
+        {
+            "jsonrpc": "2.0",
+            "id": 5,
+            "method": "tools/call",
+            "params": {"name": "test.post_gate_reject", "arguments": {}},
+        },
+    )
+    # Wire outcome: -32602 INVALID_PARAMS (a parameter/policy rejection).
+    assert response.json()["error"]["code"] == INVALID_PARAMS
+
+    rows = await _audit_rows()
+    mcp_rows = [r for r in rows if r.method == "MCP"]
+    assert len(mcp_rows) == 1
+    row = mcp_rows[0]
+    assert row.path == "/mcp/tools/call/test.post_gate_reject"
+    # The audit projection now matches the "denied" wire outcome, not 500.
+    assert row.status_code == 403
 
 
 # ---------------------------------------------------------------------------
@@ -915,3 +987,24 @@ async def test_initialize_issued_session_id_round_trips_to_audit_row(
     mcp_rows = [r for r in rows if r.method == "MCP"]
     assert len(mcp_rows) == 1
     assert mcp_rows[0].agent_session_id == session_uuid
+
+
+# ---------------------------------------------------------------------------
+# #1481: broadcast classification of the corrected post-gate status
+# ---------------------------------------------------------------------------
+
+
+def test_classify_mcp_status_403_is_denied_not_error() -> None:
+    """#1481: the 403 a post-gate rejection now records classifies "denied".
+
+    Locks the broadcast half of the fix — once the audit ``status_code``
+    is corrected from the init 500 to 403, ``_classify_mcp_status`` maps
+    it to ``"denied"`` (not ``"error"``), so the live feed event
+    reflects a policy rejection rather than a fake server crash. 500
+    stays ``"error"`` so a genuine handler fault is still surfaced.
+    """
+    from meho_backplane.mcp.handlers import _classify_mcp_status
+
+    assert _classify_mcp_status(403) == "denied"
+    assert _classify_mcp_status(500) == "error"
+    assert _classify_mcp_status(200) == "ok"

--- a/docs/codebase/approvals.md
+++ b/docs/codebase/approvals.md
@@ -30,6 +30,48 @@ truth:
 The durable state is one `approval_request` row (table created by
 `backend/alembic/versions/0023_create_approval_request.py`, T4 #817).
 
+## Subject + actor attribution on the request row (#1481)
+
+The `approval_request` row carries the RFC 8693 two-claim attribution
+shape:
+
+- `principal_sub` = the subject — `operator.sub`, the party on whose
+  behalf the parked op runs (a human, or an autonomous agent acting as
+  itself).
+- `principal_act` = the actor — the agent principal currently wielding
+  the subject's authority on a *delegated* run, or `NULL` when there is
+  no separate actor.
+
+`create_pending_request` sources `principal_act` from
+`resolve_actor_sub()` (`backend/src/meho_backplane/auth/delegation.py`)
+— the same `actor_sub` contextvar the synchronous audit log reads. A
+human-initiated agent run binds the acting agent via `actor_delegation()`
+(`backend/src/meho_backplane/agent/invocation.py`) for the lifetime of
+the run task, so the parked row records `principal_sub=<human>` +
+`principal_act=agent:<name>`, keeping the approval row's lineage
+in lock-step with the audit log. A direct human call (no delegation
+bound) and an autonomous agent run both resolve to `principal_act=NULL`.
+(Before #1481 the field read a nonexistent `Operator.identity_act`
+attribute and was always `NULL`.)
+
+## MCP audit status for post-gate rejections (#1481)
+
+A `tools/call` that a tool handler rejects *after* the dispatch gates
+(name / arguments / unknown-tool / RBAC / schema) — e.g. the
+approval-queue's self-approval, `approval_request_not_found`, or
+`approval_unauthorized` re-raised as `McpInvalidParamsError` — returns
+JSON-RPC `-32602` on the wire. The MCP envelope handler
+(`backend/src/meho_backplane/mcp/handlers.py`) projects that whole class
+onto audit `status_code=403` ("denied") instead of the init `500`
+("error"), so the audit row and the live broadcast event
+(`_classify_mcp_status`) classify a clean policy rejection as denied
+rather than a fake server crash. The correction sits at the dispatch
+boundary (`except McpInvalidParamsError` in both `handle_tools_call` and
+`handle_resources_read`), so it covers every post-gate
+`McpInvalidParamsError`, not just self-approval; explicit pre-gate
+branches that already set `400`/`403`/`404` pass through untouched, and a
+genuine handler fault still records `500`.
+
 ## G11.7-T1 policy hardening (#1401)
 
 Phase C of the wrapper-retirement effort moves connector **writes**


### PR DESCRIPTION
## Summary

- Self-approval (and any sibling post-gate `McpInvalidParamsError` — `approval_request_not_found`, `approval_unauthorized`) rejections over MCP returned JSON-RPC `-32602` on the wire but audited `status_code=500`, so a SIEM grouping on `status_code` saw a fake server crash for a clean policy rejection and the live broadcast event mis-classified as "error". Fixed **at the dispatch boundary** (`except McpInvalidParamsError` in `handle_tools_call`, mirrored in `handle_resources_read`): the residual init-500 is projected onto a `403` "denied" status, so the **whole class** is covered, not just self-approval. Explicit `400`/`403`/`404` pre-gate branches pass through untouched; a genuine handler fault still records `500`.
- `create_pending_request` read `getattr(operator, "identity_act", None)` — dead code (`Operator` has no `identity_act` field), so `principal_act` was always null even for a delegated agent run whose audit log recorded `actor_sub=agent:<name>`. It now reads `resolve_actor_sub()`, the **same** actor-delegation contextvar the synchronous audit log uses, so a human-initiated agent run records `principal_sub=<human>` + `principal_act=agent:<name>`. Direct human / autonomous calls (no delegation bound) keep `principal_act=NULL`.
- Documents both behaviours in `docs/codebase/approvals.md`; adds a CHANGELOG `[Unreleased]` bullet (G0.19-T4).

## Test plan

- [x] `ruff check` / `ruff format --check` — clean (changed src + tests)
- [x] `mypy backend/src/.../handlers.py .../approval_queue.py` — clean
- [x] `python3 .claude/hooks/code-quality.py --diff` — 0 blockers (pre-existing oversized functions carry scoped `code-quality-allow` markers; refactor out of scope for a SEV-3 audit-fidelity fix)
- [x] **AC1** post-gate `McpInvalidParamsError` audits `status_code=403` (denied), not 500, and `_classify_mcp_status(403)=="denied"` — `test_tools_call_post_gate_invalid_params_audits_as_denied_not_500` + `test_classify_mcp_status_403_is_denied_not_error` (verified non-vacuous: the test fails when the fix is neutralized)
- [x] **AC2** class-wide — the fix sits at the dispatch boundary, exercised via a registered tool that raises post-gate (models self-approval / not-found / unauthorized)
- [x] **AC3** delegated agent run records `principal_act=agent:<name>` — `test_create_pending_request_records_principal_act_on_delegated_run`
- [x] **AC4** direct call (no delegation) keeps `principal_act=NULL` — `test_create_pending_request_principal_act_null_without_delegation`
- [x] `pytest tests/test_approval_queue.py tests/test_mcp_audit.py` — 54 passed; touched-area suites (agent-approval-resume, mcp-tool-approvals, api-v1-approvals) — 76 passed total

## Out of scope

- `self_approval_forbidden` REST/MCP error-string break-glass hint — T6 #1483 (parallel); this PR deliberately leaves the operator-facing error strings unchanged.
- Changing the four-eyes policy; backfilling `principal_act` on historical rows (per issue out-of-scope).
- Refactoring the pre-existing oversized `handle_tools_call` / `handle_resources_read` / `create_pending_request` functions.

<!-- auto-implement-issue: fresh, iteration 1 -->

Closes #1481
