### PR TITLE
fix(connectors): typed connector_not_ingested hint for 0-row registered connectors

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -122,6 +122,15 @@ connector-related release-notes line.
   exist were corrected to the truthful guidance (re-call with narrower
   params / native pagination); string-shaped outputs such as `k8s.exec`
   are unaffected (#1479).
+- `list_operation_groups` / `search_operations` now return a typed
+  `connector_not_ingested` hint for a connector that is v2-registered but
+  not yet ingested (0 DB rows, `state="registered"`) instead of an opaque
+  `-32603 UnknownConnectorError` over MCP. The error carries the same
+  `meho connector ingest …` next-step verb the `GET /api/v1/connectors`
+  listing already emits (`-32602` + `error.data.reason` over MCP; `404`
+  with a structured `detail` over REST), and stays distinguishable from a
+  genuinely unknown connector_id so an agent can self-correct
+  ([#1482](https://github.com/evoila/meho/issues/1482)).
 
 ## [0.10.0] - 2026-06-01
 

--- a/backend/src/meho_backplane/api/v1/operations.py
+++ b/backend/src/meho_backplane/api/v1/operations.py
@@ -41,6 +41,7 @@ from meho_backplane.auth.operator import Operator, TenantRole
 from meho_backplane.auth.rbac import require_role
 from meho_backplane.operations.meta_tools import (
     CallOperationBody,
+    ConnectorNotIngestedError,
     OperationDescriptor,
     UnknownConnectorError,
     call_operation,
@@ -89,6 +90,29 @@ _require_operator = Depends(require_role(TenantRole.OPERATOR))
 _require_admin = Depends(require_role(TenantRole.TENANT_ADMIN))
 
 
+def _connector_not_ingested_404(exc: ConnectorNotIngestedError) -> HTTPException:
+    """Map :class:`ConnectorNotIngestedError` to a structured ``404``.
+
+    Both the registered-but-not-ingested case and the genuinely-unknown
+    case are ``404`` on REST (no resolvable connector to dispatch), but
+    they stay distinguishable: this one carries a structured ``detail``
+    with ``reason="connector_not_ingested"`` and the ``meho connector
+    ingest …`` ``next_step`` hint, mirroring the ``state="registered"``
+    row ``GET /api/v1/connectors`` already emits (#1482). An *unknown*
+    connector keeps its plain-string ``detail`` (the long-form mistyped-id
+    recovery hint).
+    """
+    return HTTPException(
+        status_code=404,
+        detail={
+            "message": str(exc),
+            "reason": "connector_not_ingested",
+            "connector_id": exc.connector_id,
+            "next_step": exc.next_step,
+        },
+    )
+
+
 @router.get("/groups")
 async def get_groups(
     connector_id: str = Query(
@@ -125,9 +149,13 @@ async def get_groups(
     ``connector_id`` (no operations registered for the parsed triple)
     is a ``404`` — not an empty ``200``: the empty-catalog trap was
     that a mis-shaped id looked identical to an empty connector. A
-    *known* connector with zero enabled groups still returns
-    ``{"groups": [], "next_cursor": null}`` (that empty is
-    operationally meaningful).
+    *registered-but-not-ingested* connector (v2-registered class, zero
+    DB rows) is also a ``404`` but with a structured ``detail``
+    carrying ``reason="connector_not_ingested"`` and the ``meho
+    connector ingest …`` ``next_step`` hint, distinct from the
+    unknown-connector ``404`` (#1482). A *known* connector with zero
+    enabled groups still returns ``{"groups": [], "next_cursor": null}``
+    (that empty is operationally meaningful).
 
     Pagination is keyset on ``group_key`` (G0.18-T5 #1358); the
     response carries ``next_cursor`` set to the last returned
@@ -138,6 +166,8 @@ async def get_groups(
             operator,
             {"connector_id": connector_id, "limit": limit, "cursor": cursor},
         )
+    except ConnectorNotIngestedError as exc:
+        raise _connector_not_ingested_404(exc) from exc
     except UnknownConnectorError as exc:
         raise HTTPException(status_code=404, detail=str(exc)) from exc
 
@@ -157,9 +187,11 @@ async def get_search(
     """Hybrid BM25 + cosine RRF over ``endpoint_descriptor`` rows.
 
     Delegates to :func:`search_operations`. See its docstring for the
-    full algorithm and tenant scoping. Unknown ``connector_id`` → ``404``
-    (same unknown-vs-known-empty contract as ``/groups``); a known
-    connector with no matching ops returns ``200`` with an empty list.
+    full algorithm and tenant scoping. Unknown ``connector_id`` → ``404``;
+    a registered-but-not-ingested connector → ``404`` with the typed
+    ``connector_not_ingested`` ``detail`` (same contract as ``/groups``,
+    #1482); a known connector with no matching ops returns ``200`` with
+    an empty list.
     """
     try:
         return await search_operations(
@@ -171,6 +203,8 @@ async def get_search(
                 "limit": limit,
             },
         )
+    except ConnectorNotIngestedError as exc:
+        raise _connector_not_ingested_404(exc) from exc
     except UnknownConnectorError as exc:
         raise HTTPException(status_code=404, detail=str(exc)) from exc
 

--- a/backend/src/meho_backplane/mcp/tools/operations.py
+++ b/backend/src/meho_backplane/mcp/tools/operations.py
@@ -55,7 +55,10 @@ from typing import Any
 
 from meho_backplane.auth.operator import Operator, TenantRole
 from meho_backplane.mcp.registry import ToolDefinition, register_mcp_tool
+from meho_backplane.mcp.server import McpInvalidParamsError
 from meho_backplane.operations.meta_tools import (
+    ConnectorNotIngestedError,
+    UnknownConnectorError,
     call_operation,
     list_operation_groups,
     search_operations,
@@ -69,20 +72,68 @@ __all__: list[str] = []
 # ---------------------------------------------------------------------------
 
 
+def _connector_error_to_invalid_params(
+    exc: UnknownConnectorError | ConnectorNotIngestedError,
+) -> McpInvalidParamsError:
+    """Map a connector-resolution domain error to a typed ``-32602``.
+
+    The discovery meta-tools raise a :class:`ValueError` subclass when a
+    ``connector_id`` does not resolve. Left to propagate, the dispatcher's
+    generic ``except Exception`` would mistranslate it into an opaque
+    ``-32603 "internal error: …"`` — exactly the trap #1482 removes.
+    Catching it here and re-raising :class:`McpInvalidParamsError` flips
+    the wire code to ``-32602 INVALID_PARAMS`` (the spec's "bad argument"
+    code) and threads a machine-readable ``error.data`` discriminator so
+    an agent can tell the two cases apart:
+
+    * :class:`ConnectorNotIngestedError` →
+      ``{"reason": "connector_not_ingested", "connector_id", "next_step"}``
+      — the connector exists but awaits ingest; ``next_step.verb`` is the
+      ``meho connector ingest …`` command to run.
+    * :class:`UnknownConnectorError` →
+      ``{"reason": "unknown_connector", "connector_id"}`` — no such
+      connector on this deploy.
+    """
+    if isinstance(exc, ConnectorNotIngestedError):
+        return McpInvalidParamsError(str(exc), data=exc.as_error_data())
+    return McpInvalidParamsError(
+        str(exc),
+        data={"reason": "unknown_connector", "connector_id": exc.connector_id},
+    )
+
+
 async def _list_operation_groups_handler(
     operator: Operator,
     arguments: dict[str, Any],
 ) -> dict[str, Any]:
-    """Thin shim over :func:`list_operation_groups`."""
-    return await list_operation_groups(operator, arguments)
+    """Thin shim over :func:`list_operation_groups`.
+
+    Translates the connector-resolution domain errors to a typed
+    ``-32602`` (see :func:`_connector_error_to_invalid_params`) so a
+    registered-but-not-ingested connector surfaces an actionable
+    ``connector_not_ingested`` hint instead of an opaque ``-32603``
+    (#1482).
+    """
+    try:
+        return await list_operation_groups(operator, arguments)
+    except (UnknownConnectorError, ConnectorNotIngestedError) as exc:
+        raise _connector_error_to_invalid_params(exc) from exc
 
 
 async def _search_operations_handler(
     operator: Operator,
     arguments: dict[str, Any],
 ) -> dict[str, Any]:
-    """Thin shim over :func:`search_operations`."""
-    return await search_operations(operator, arguments)
+    """Thin shim over :func:`search_operations`.
+
+    Shares :func:`_list_operation_groups_handler`'s connector-error
+    mapping so both discovery meta-tools surface the same typed
+    ``-32602`` taxonomy (#1482).
+    """
+    try:
+        return await search_operations(operator, arguments)
+    except (UnknownConnectorError, ConnectorNotIngestedError) as exc:
+        raise _connector_error_to_invalid_params(exc) from exc
 
 
 async def _call_operation_handler(
@@ -111,10 +162,15 @@ register_mcp_tool(
             "Argument: `connector_id` in `<impl_id>-<version>` form "
             '(e.g. "vmware-rest-9.0", "vault-1.x") -- NOT the bare '
             "product name. Returns groups in `group_key` order. An "
-            "UNKNOWN connector_id is an error (no such connector); a "
-            "KNOWN connector with no enabled groups returns an empty "
-            "list (operationally meaningful: it exists, nothing enabled "
-            "yet). Pagination (G0.18-T5 #1358): keyset on `group_key`; "
+            "UNKNOWN connector_id is an error (no such connector, "
+            "`-32602` with `data.reason=unknown_connector`); a "
+            "REGISTERED-BUT-NOT-INGESTED connector is also an error but "
+            "recoverable (`-32602` with `data.reason=connector_not_ingested` "
+            "and `data.next_step.verb` = the `meho connector ingest …` "
+            "command to run, then retry); a KNOWN connector with no "
+            "enabled groups returns an empty list (operationally "
+            "meaningful: it exists, nothing enabled yet). Pagination "
+            "(G0.18-T5 #1358): keyset on `group_key`; "
             "default `limit=100`, max 500; pass the response's "
             "`next_cursor` back as the next call's `cursor` to fetch "
             "the next page. A `null` `next_cursor` is the end."
@@ -214,9 +270,13 @@ register_mcp_tool(
             "`query` (required, free-form), `group` (optional, narrows "
             "to that group's ops), `limit` (default 10, max 50). "
             "`connector_id` is `<impl_id>-<version>` (NOT the bare "
-            "product name); an unknown connector_id is an error. An "
-            "unknown group, by contrast, narrows the result set to "
-            "zero hits and is not an error."
+            "product name); an unknown connector_id is an error "
+            "(`-32602`, `data.reason=unknown_connector`), and a "
+            "registered-but-not-ingested connector is a recoverable error "
+            "(`-32602`, `data.reason=connector_not_ingested` + "
+            "`data.next_step.verb` to run, then retry). An unknown group, "
+            "by contrast, narrows the result set to zero hits and is not "
+            "an error."
         ),
         inputSchema={
             "type": "object",

--- a/backend/src/meho_backplane/operations/_lookup.py
+++ b/backend/src/meho_backplane/operations/_lookup.py
@@ -28,10 +28,12 @@ from uuid import UUID
 
 from sqlalchemy import select
 
+from meho_backplane.connectors.registry import all_connectors_v2
 from meho_backplane.db.engine import get_sessionmaker
 from meho_backplane.db.models import EndpointDescriptor, OperationGroup
 
 __all__ = [
+    "connector_class_registered",
     "connector_exists",
     "count_known_ops",
     "lookup_descriptor",
@@ -220,3 +222,57 @@ async def connector_exists(
             .limit(1)
         )
         return group_hit.first() is not None
+
+
+def connector_class_registered(
+    *,
+    product: str,
+    version: str,
+    impl_id: str,
+) -> bool:
+    """Return whether a v2 connector *class* is registered for the parsed triple.
+
+    The discriminator behind the "registered but not ingested" signal.
+    :func:`connector_exists` probes only DB rows (``endpoint_descriptor`` /
+    ``operation_group``); a connector whose class is registered via
+    :func:`~meho_backplane.connectors.registry.register_connector_v2` but
+    has not yet had operations ingested / typed-registered has *zero* DB
+    rows, so ``connector_exists`` returns ``False`` for it. That case is
+    not "unknown connector" — it is "known class, awaiting ingest". This
+    helper tells the two apart so the meta-tools can return an
+    operator-actionable ``connector_not_ingested`` hint instead of an
+    opaque unknown-connector error.
+
+    *(product, version, impl_id)* is the triple
+    :func:`parse_connector_id` derived from the caller's ``connector_id``.
+    The v2 registry is keyed on the *registration* triple, which for most
+    connectors equals the parsed triple but for SDDC differs (registry
+    ``product="sddc-manager"`` vs parsed ``product="sddc"``). To match the
+    exact rows ``GET /api/v1/connectors`` labels ``state="registered"``
+    (see :func:`~meho_backplane.operations.ingest.list_connectors._class_side_only_items`),
+    each registry entry is rendered to its ``connector_id`` and re-parsed;
+    a registry entry counts as a hit only when its re-parsed triple equals
+    the caller's. This mirrors the listing's lossless-round-trip contract
+    (#773) so a ``connector_not_ingested`` answer here implies a
+    ``state="registered"`` row there, and vice versa.
+
+    v1-compat shim entries (the registry's ``(product, "", "")`` rows the
+    v1 :func:`~meho_backplane.connectors.registry.register_connector`
+    writes) are skipped: an empty ``version`` / ``impl_id`` is a
+    resolver-internal compatibility detail, never a separately registered
+    connector, and never the source of a ``state="registered"`` listing
+    row.
+
+    Registry-only (in-memory, process-local), so no DB round-trip — the
+    caller has already established (via :func:`connector_exists`) that the
+    DB has no rows for the triple.
+    """
+    for _reg_product, reg_version, reg_impl_id in all_connectors_v2():
+        if not reg_version or not reg_impl_id:
+            # v1-compat shim (product, "", "") — not a registered connector.
+            continue
+        connector_id = f"{reg_impl_id}-{reg_version}"
+        parsed_product, parsed_version, parsed_impl_id = parse_connector_id(connector_id)
+        if (parsed_product, parsed_version, parsed_impl_id) == (product, version, impl_id):
+            return True
+    return False

--- a/backend/src/meho_backplane/operations/ingest/list_connectors.py
+++ b/backend/src/meho_backplane/operations/ingest/list_connectors.py
@@ -91,9 +91,56 @@ from meho_backplane.operations.ingest.catalog import (
     load_catalog,
 )
 
-__all__ = ["list_ingested_connectors"]
+__all__ = ["list_ingested_connectors", "next_step_for_registered_connector"]
 
 _log = structlog.get_logger(__name__)
+
+
+def next_step_for_registered_connector(
+    *,
+    product: str,
+    version: str,
+    impl_id: str,
+) -> NextStep | None:
+    """Return the ingest ``next_step`` for a registered-but-not-ingested connector.
+
+    The meta-tools' ``connector_not_ingested`` signal (#1482) reuses the
+    exact hint ``GET /api/v1/connectors`` renders on a ``state="registered"``
+    row, so the in-product "what do I run next?" answer is identical across
+    the listing surface and the discovery meta-tools
+    (:func:`~meho_backplane.operations.meta_tools.list_operation_groups` /
+    :func:`~meho_backplane.operations.meta_tools.search_operations`).
+
+    *(product, version, impl_id)* is the triple
+    :func:`parse_connector_id` derived from the caller's ``connector_id`` —
+    the same parsed shape the listing emits. The catalog lookup, however,
+    is keyed on the *registry* product (SDDC registers under
+    ``"sddc-manager"`` while the listing emits ``"sddc"``), so this helper
+    re-finds the matching v2-registry entry by the same lossless
+    round-trip the listing uses and feeds the registry triple to
+    :func:`_next_step_for_registered`. Returns ``None`` when no registry
+    entry round-trips to the parsed triple (the connector is genuinely
+    unknown, not merely un-ingested) so the caller can fall through to the
+    unknown-connector path.
+    """
+    catalog = _load_catalog_or_none()
+    for reg_product, reg_version, reg_impl_id in sorted(all_connectors_v2().keys()):
+        parsed = _resolve_class_only_natural_key(
+            registry_product=reg_product,
+            registry_version=reg_version,
+            registry_impl_id=reg_impl_id,
+        )
+        if parsed is None:
+            continue
+        _connector_id, parsed_product, parsed_version, parsed_impl_id = parsed
+        if (parsed_product, parsed_version, parsed_impl_id) == (product, version, impl_id):
+            return _next_step_for_registered(
+                catalog=catalog,
+                registry_product=reg_product,
+                registry_version=reg_version,
+                registry_impl_id=reg_impl_id,
+            )
+    return None
 
 
 def _next_step_for_registered(

--- a/backend/src/meho_backplane/operations/meta_tools.py
+++ b/backend/src/meho_backplane/operations/meta_tools.py
@@ -80,14 +80,20 @@ from sqlalchemy import select
 from meho_backplane.auth.operator import Operator
 from meho_backplane.db.engine import get_sessionmaker
 from meho_backplane.db.models import EndpointDescriptor, OperationGroup
-from meho_backplane.operations._lookup import connector_exists, parse_connector_id
+from meho_backplane.operations._lookup import (
+    connector_class_registered,
+    connector_exists,
+    parse_connector_id,
+)
 from meho_backplane.operations._search import hybrid_search, resolve_group_id
 from meho_backplane.operations.dispatcher import dispatch
+from meho_backplane.operations.ingest.list_connectors import next_step_for_registered_connector
 from meho_backplane.targets.resolver import resolve_target
 
 __all__ = [
     "SEARCH_LIMIT_MAX",
     "CallOperationBody",
+    "ConnectorNotIngestedError",
     "OperationDescriptor",
     "OperationGroupSummary",
     "OperationSearchHit",
@@ -109,12 +115,73 @@ class UnknownConnectorError(ValueError):
     ``except Exception`` would otherwise mistranslate a clean
     "unknown connector" into a JSON-RPC ``INTERNAL_ERROR`` (a worse
     trap than the empty-200 this task removes). The REST route maps
-    this to ``404`` explicitly; the MCP/CLI surfaces let it propagate
-    as the structured handler error they already render. Subclasses
+    this to ``404`` explicitly; the MCP transport maps it to
+    ``INVALID_PARAMS`` (``-32602``) with a typed ``data`` payload (see
+    :mod:`meho_backplane.mcp.tools.operations`). Subclasses
     :class:`ValueError` to stay consistent with the other meta-tool
     domain exceptions (e.g. the missing-target ``ValueError`` mapped
     to ``400`` in :mod:`meho_backplane.api.v1.operations`).
+
+    Carries :attr:`connector_id` (the id the caller passed) so the MCP
+    transport can thread it onto the ``error.data`` discriminator
+    alongside its :class:`ConnectorNotIngestedError` sibling.
     """
+
+    def __init__(self, message: str, *, connector_id: str) -> None:
+        super().__init__(message)
+        self.connector_id = connector_id
+
+
+class ConnectorNotIngestedError(ValueError):
+    """Raised when a ``connector_id`` names a *registered-but-not-ingested* connector.
+
+    The connector's class is registered in the v2 registry (via
+    :func:`~meho_backplane.connectors.registry.register_connector_v2`) but
+    has no ``endpoint_descriptor`` / ``operation_group`` rows yet — the
+    "State 0.5" the ``GET /api/v1/connectors`` listing already surfaces as
+    ``state="registered"`` with a ``next_step`` ingest hint. The meta-tools
+    raise this *instead of* :class:`UnknownConnectorError` so the caller can
+    tell "exists, run ingest" apart from "no such connector" rather than
+    receiving an opaque ``-32603 UnknownConnectorError`` over MCP (#1482).
+
+    Carries the structured detail the surfaces self-correct against:
+
+    * :attr:`connector_id` — the id the caller passed.
+    * :attr:`next_step` — the ``{"verb", "rationale"}`` ingest hint built
+      from the same connector-spec-catalog lookup the listing uses
+      (:func:`~meho_backplane.operations.ingest.list_connectors._next_step_for_registered`),
+      or ``None`` when the catalog/registry could not produce one.
+
+    Subclasses :class:`ValueError` like its sibling so existing
+    ``except ValueError`` call sites keep their behaviour; the MCP handler
+    threads :attr:`as_error_data` onto the JSON-RPC ``error.data`` member
+    and the REST route maps it to ``404`` with the hint in ``detail``.
+    """
+
+    def __init__(
+        self,
+        message: str,
+        *,
+        connector_id: str,
+        next_step: dict[str, str] | None = None,
+    ) -> None:
+        super().__init__(message)
+        self.connector_id = connector_id
+        self.next_step = next_step
+
+    def as_error_data(self) -> dict[str, Any]:
+        """Render the structured ``error.data`` payload for the MCP surface.
+
+        Shape: ``{"reason": "connector_not_ingested", "connector_id": ...,
+        "next_step": {"verb", "rationale"} | None}``. ``reason`` is the
+        machine-readable discriminator an agent keys on to self-correct to
+        the ``next_step.verb`` ingest command.
+        """
+        return {
+            "reason": "connector_not_ingested",
+            "connector_id": self.connector_id,
+            "next_step": self.next_step,
+        }
 
 
 _log = structlog.get_logger(__name__)
@@ -375,8 +442,66 @@ def _raise_unknown_connector(connector_id: str) -> None:
         f"(e.g. 'vmware-rest-9.0', 'vault-1.x'). If this id appeared in "
         f"GET /api/v1/connectors, the listing is inconsistent with the "
         f"dispatcher's resolve path — please file a bug report; otherwise "
-        f"the id is mistyped or the connector is not registered on this deploy"
+        f"the id is mistyped or the connector is not registered on this deploy",
+        connector_id=connector_id,
     )
+
+
+async def _require_dispatchable_connector(
+    *,
+    operator: Operator,
+    connector_id: str,
+    product: str,
+    version: str,
+    impl_id: str,
+) -> None:
+    """Gate the discovery meta-tools on a *dispatchable* connector.
+
+    Shared by :func:`list_operation_groups` and :func:`search_operations`
+    so the two enforce the identical unknown / not-ingested / known
+    taxonomy. Three outcomes for the parsed *(product, version, impl_id)*
+    triple:
+
+    * **DB rows exist** (:func:`connector_exists` ``True``) — the connector
+      is ingested; return so the caller proceeds to its (possibly empty)
+      data query. An ingested connector with zero *enabled* groups still
+      falls here and yields the operationally-meaningful empty list — the
+      existence gate is enable-agnostic.
+    * **No DB rows, class registered** (:func:`connector_class_registered`
+      ``True``) — "State 0.5": the connector is v2-registered but awaiting
+      ingest. Raise :class:`ConnectorNotIngestedError` carrying the same
+      ``next_step`` ingest hint ``GET /api/v1/connectors`` renders on the
+      ``state="registered"`` row, so the agent can self-correct to the
+      ``meho connector ingest …`` verb instead of receiving an opaque
+      unknown-connector error (#1482).
+    * **No DB rows, no class** — genuinely unknown. Raise
+      :class:`UnknownConnectorError` (the long-form mistyped-id recovery
+      hint).
+    """
+    if await connector_exists(
+        tenant_id=operator.tenant_id,
+        product=product,
+        version=version,
+        impl_id=impl_id,
+    ):
+        return
+    if connector_class_registered(product=product, version=version, impl_id=impl_id):
+        next_step = next_step_for_registered_connector(
+            product=product,
+            version=version,
+            impl_id=impl_id,
+        )
+        verb = next_step.verb if next_step is not None else "meho connector ingest …"
+        raise ConnectorNotIngestedError(
+            f"connector {connector_id!r} is registered but not yet ingested "
+            f"(no operations available). Run `{verb}` to populate its "
+            f"operations, then retry. This is distinct from an unknown "
+            f"connector_id: the connector exists, it just has nothing to "
+            f"dispatch yet.",
+            connector_id=connector_id,
+            next_step=next_step.model_dump(mode="json") if next_step is not None else None,
+        )
+    _raise_unknown_connector(connector_id)
 
 
 async def list_operation_groups(
@@ -393,14 +518,23 @@ async def list_operation_groups(
     union of built-in (``tenant_id IS NULL``) and tenant-curated
     (``tenant_id == operator.tenant_id``) rows.
 
-    An *unknown* ``connector_id`` (no descriptors or groups registered
-    for the parsed ``(product, version, impl_id)`` triple) raises
-    :class:`UnknownConnectorError` — the REST route maps that to a
-    ``404``. A *known* connector with zero enabled groups still returns
-    an empty ``groups`` list (``200 []``): that empty is operationally
-    meaningful (the connector exists; nothing is enabled yet). The
-    distinction ends the "empty catalog" trap where a mis-shaped
-    ``connector_id`` looked indistinguishable from an empty connector.
+    Three connector-existence outcomes (gated by
+    :func:`_require_dispatchable_connector`):
+
+    * *Unknown* ``connector_id`` (no DB rows AND no registered class for
+      the parsed ``(product, version, impl_id)`` triple) raises
+      :class:`UnknownConnectorError` — the REST route maps that to a
+      ``404``, the MCP transport to ``-32602``.
+    * *Registered but not ingested* (the class is in the v2 registry but
+      has zero DB rows — "State 0.5") raises
+      :class:`ConnectorNotIngestedError` carrying the ``meho connector
+      ingest …`` ``next_step`` hint, so the caller self-corrects rather
+      than treating it as unknown (#1482).
+    * *Known/ingested* connector with zero enabled groups still returns
+      an empty ``groups`` list (``200 []``): that empty is operationally
+      meaningful (the connector exists; nothing is enabled yet). The
+      distinction ends the "empty catalog" trap where a mis-shaped
+      ``connector_id`` looked indistinguishable from an empty connector.
 
     Pagination (G0.18-T5 #1358)
     ---------------------------
@@ -418,13 +552,13 @@ async def list_operation_groups(
     connector_id = arguments["connector_id"]
     limit, cursor = _coerce_list_operation_groups_pagination(arguments)
     product, version, impl_id = parse_connector_id(connector_id)
-    if not await connector_exists(
-        tenant_id=operator.tenant_id,
+    await _require_dispatchable_connector(
+        operator=operator,
+        connector_id=connector_id,
         product=product,
         version=version,
         impl_id=impl_id,
-    ):
-        _raise_unknown_connector(connector_id)
+    )
     sessionmaker = get_sessionmaker()
     group_stmt = _build_operation_groups_query(
         product=product,
@@ -489,11 +623,13 @@ async def search_operations(
     debugging) can see whether a hit came from lexical match, semantic
     match, or both.
 
-    Like :func:`list_operation_groups`, an *unknown* ``connector_id``
-    raises :class:`UnknownConnectorError` (REST → ``404``) while a
-    *known* connector with no matching ops still returns an empty
-    ``hits`` list (``200 []``) — identical unknown-vs-known-empty
-    semantics across both meta-tools.
+    Shares :func:`list_operation_groups`'s connector-existence taxonomy
+    via :func:`_require_dispatchable_connector`: an *unknown*
+    ``connector_id`` raises :class:`UnknownConnectorError` (REST →
+    ``404``); a *registered-but-not-ingested* connector raises
+    :class:`ConnectorNotIngestedError` with the ingest ``next_step`` hint
+    (#1482); a *known* connector with no matching ops still returns an
+    empty ``hits`` list (``200 []``).
     """
     connector_id = arguments["connector_id"]
     query = arguments["query"]
@@ -505,19 +641,13 @@ async def search_operations(
         limit = SEARCH_LIMIT_MAX
 
     product, version, impl_id = parse_connector_id(connector_id)
-    if not await connector_exists(
-        tenant_id=operator.tenant_id,
+    await _require_dispatchable_connector(
+        operator=operator,
+        connector_id=connector_id,
         product=product,
         version=version,
         impl_id=impl_id,
-    ):
-        raise UnknownConnectorError(
-            f"unknown connector_id {connector_id!r} — expected <impl_id>-<version> "
-            f"(e.g. 'vmware-rest-9.0', 'vault-1.x'). If this id appeared in "
-            f"GET /api/v1/connectors, the listing is inconsistent with the "
-            f"dispatcher's resolve path — please file a bug report; otherwise "
-            f"the id is mistyped or the connector is not registered on this deploy"
-        )
+    )
     started = time.monotonic()
     sessionmaker = get_sessionmaker()
     async with sessionmaker() as session:

--- a/backend/tests/test_api_v1_operations.py
+++ b/backend/tests/test_api_v1_operations.py
@@ -39,7 +39,8 @@ from meho_backplane.api.v1.operations import router as operations_router
 from meho_backplane.audit import AuditMiddleware
 from meho_backplane.auth.jwt import clear_jwks_cache
 from meho_backplane.auth.operator import TenantRole
-from meho_backplane.connectors.registry import clear_registry
+from meho_backplane.connectors.base import Connector
+from meho_backplane.connectors.registry import clear_registry, register_connector_v2
 from meho_backplane.db.engine import get_sessionmaker
 from meho_backplane.db.models import EndpointDescriptor, OperationGroup
 from meho_backplane.middleware import RequestContextMiddleware
@@ -276,6 +277,58 @@ def test_get_groups_bare_product_name_returns_404(client: TestClient) -> None:
         )
     assert response.status_code == 404
     assert "vault" in response.json()["detail"]
+
+
+class _GhostRestConnector(Connector):
+    """v2-registered class whose ``connector_id`` round-trips losslessly.
+
+    ``ghost-rest-9.0`` → ``(product="ghost", version="9.0",
+    impl_id="ghost-rest")``. No DB rows seeded → State-0.5
+    registered-but-not-ingested (#1482).
+    """
+
+    product = "ghost"
+    version = "9.0"
+    impl_id = "ghost-rest"
+
+    async def fingerprint(self, target, operator=None):  # type: ignore[no-untyped-def]
+        raise NotImplementedError
+
+    async def probe(self, target):  # type: ignore[no-untyped-def]
+        raise NotImplementedError
+
+    async def execute(self, target, op_id, params):  # type: ignore[no-untyped-def]
+        raise NotImplementedError
+
+
+def test_get_groups_registered_not_ingested_returns_typed_404(client: TestClient) -> None:
+    """#1482: a registered-but-0-row connector → 404 with a typed detail.
+
+    The detail is a structured object carrying
+    ``reason="connector_not_ingested"`` and the ``meho connector ingest …``
+    next_step hint — distinct from the plain-string detail an *unknown*
+    connector_id returns, so the two 404s stay distinguishable on REST.
+    """
+    register_connector_v2(
+        product="ghost",
+        version="9.0",
+        impl_id="ghost-rest",
+        cls=_GhostRestConnector,
+    )
+    key = make_rsa_keypair("kid-A")
+    with respx.mock as mock_router:
+        mock_discovery_and_jwks(mock_router, public_jwks(key))
+        response = client.get(
+            "/api/v1/operations/groups?connector_id=ghost-rest-9.0",
+            headers={"Authorization": f"Bearer {_operator_token(key)}"},
+        )
+    assert response.status_code == 404
+    detail = response.json()["detail"]
+    assert isinstance(detail, dict)
+    assert detail["reason"] == "connector_not_ingested"
+    assert detail["connector_id"] == "ghost-rest-9.0"
+    assert detail["next_step"] is not None
+    assert "ingest" in detail["next_step"]["verb"]
 
 
 @pytest.mark.asyncio

--- a/backend/tests/test_mcp_tools_operations.py
+++ b/backend/tests/test_mcp_tools_operations.py
@@ -23,11 +23,14 @@ operator-or-above to pass the registry's RBAC list-time filter.
 from __future__ import annotations
 
 import json
+from collections.abc import Iterator
 
 import pytest
 from fastapi.testclient import TestClient
 
 from meho_backplane.auth.operator import Operator, TenantRole
+from meho_backplane.connectors.base import Connector
+from meho_backplane.connectors.registry import all_connectors_v2, register_connector_v2
 from tests.mcp_test_fixtures import (
     OPERATOR_TENANT_ID,
     client_with_operator,  # noqa: F401 — pytest-discovered fixture
@@ -316,3 +319,136 @@ def test_tools_call_call_operation_accepts_bare_string_target(
         # are fine here; the contract under test is "the schema did not
         # reject pre-handler with INVALID_PARAMS".
         assert body["error"]["code"] != INVALID_PARAMS, body
+
+
+# ---------------------------------------------------------------------------
+# #1482 — registered-but-not-ingested connector surfaces a typed -32602
+# ---------------------------------------------------------------------------
+
+
+class _GhostConnector(Connector):
+    """v2-registered class whose ``connector_id`` round-trips losslessly.
+
+    ``ghost-rest-9.0`` parses back to ``(product="ghost", version="9.0",
+    impl_id="ghost-rest")`` — the listing's lossless-round-trip contract.
+    No DB rows are seeded, so it is the State-0.5 registered-but-not-
+    ingested case the meta-tool gate must classify as
+    ``connector_not_ingested`` rather than an opaque ``-32603``.
+    """
+
+    product = "ghost"
+    version = "9.0"
+    impl_id = "ghost-rest"
+
+    async def fingerprint(self, target, operator=None):  # type: ignore[no-untyped-def]
+        raise NotImplementedError
+
+    async def probe(self, target):  # type: ignore[no-untyped-def]
+        raise NotImplementedError
+
+    async def execute(self, target, op_id, params):  # type: ignore[no-untyped-def]
+        raise NotImplementedError
+
+
+@pytest.fixture
+def _ghost_class_registered() -> Iterator[None]:
+    """Register the State-0.5 ghost connector class for the test, then remove it.
+
+    The connector registry is process-global and is NOT reset by the MCP
+    fixtures (which reset only the tool registry), so the registration is
+    torn down explicitly to keep cross-test isolation.
+    """
+    register_connector_v2(
+        product="ghost",
+        version="9.0",
+        impl_id="ghost-rest",
+        cls=_GhostConnector,
+    )
+    try:
+        yield
+    finally:
+        all_connectors_v2().pop(("ghost", "9.0", "ghost-rest"), None)
+        # ``all_connectors_v2`` returns a copy; mutate the live table.
+        from meho_backplane.connectors import registry as _registry
+
+        _registry._REGISTRY_V2.pop(("ghost", "9.0", "ghost-rest"), None)
+
+
+@pytest.mark.parametrize(
+    "client_with_operator",
+    [TenantRole.OPERATOR],
+    indirect=True,
+)
+def test_tools_call_list_operation_groups_not_ingested_is_typed_invalid_params(
+    client_with_operator: tuple[TestClient, Operator],  # noqa: F811
+    _ghost_class_registered: None,
+) -> None:
+    """#1482: a registered-but-0-row connector returns -32602, not -32603.
+
+    The headline acceptance: ``list_operation_groups`` over MCP for a
+    v2-registered, zero-DB-row connector surfaces a typed
+    ``connector_not_ingested`` hint (``-32602`` + structured
+    ``error.data``), not the opaque ``-32603 internal error:
+    UnknownConnectorError`` the generic ``except Exception`` produced.
+    """
+    from meho_backplane.mcp.schemas import INTERNAL_ERROR, INVALID_PARAMS
+
+    client, _op = client_with_operator
+    response = post_mcp(
+        client,
+        {
+            "jsonrpc": "2.0",
+            "id": 20,
+            "method": "tools/call",
+            "params": {
+                "name": "list_operation_groups",
+                "arguments": {"connector_id": "ghost-rest-9.0"},
+            },
+        },
+    )
+    assert response.status_code == 200
+    body = response.json()
+    assert "error" in body, body
+    assert body["error"]["code"] == INVALID_PARAMS
+    assert body["error"]["code"] != INTERNAL_ERROR
+    data = body["error"]["data"]
+    assert data["reason"] == "connector_not_ingested"
+    assert data["connector_id"] == "ghost-rest-9.0"
+    assert data["next_step"] is not None
+    assert "ingest" in data["next_step"]["verb"]
+
+
+@pytest.mark.parametrize(
+    "client_with_operator",
+    [TenantRole.OPERATOR],
+    indirect=True,
+)
+def test_tools_call_list_operation_groups_unknown_is_distinct_invalid_params(
+    client_with_operator: tuple[TestClient, Operator],  # noqa: F811
+    _ghost_class_registered: None,
+) -> None:
+    """#1482 AC3: a genuinely-unknown connector_id is distinguishable.
+
+    It also surfaces ``-32602`` (no longer ``-32603``), but with
+    ``data.reason="unknown_connector"`` — the agent can tell the two
+    cases apart from the structured payload alone.
+    """
+    from meho_backplane.mcp.schemas import INVALID_PARAMS
+
+    client, _op = client_with_operator
+    response = post_mcp(
+        client,
+        {
+            "jsonrpc": "2.0",
+            "id": 21,
+            "method": "tools/call",
+            "params": {
+                "name": "list_operation_groups",
+                "arguments": {"connector_id": "nonsuch-9.9"},
+            },
+        },
+    )
+    body = response.json()
+    assert body["error"]["code"] == INVALID_PARAMS
+    assert body["error"]["data"]["reason"] == "unknown_connector"
+    assert body["error"]["data"]["connector_id"] == "nonsuch-9.9"

--- a/backend/tests/test_operations_meta_tools.py
+++ b/backend/tests/test_operations_meta_tools.py
@@ -51,6 +51,7 @@ from meho_backplane.db.models import EndpointDescriptor, OperationGroup
 from meho_backplane.db.models import Target as TargetORM
 from meho_backplane.operations import register_typed_operation, reset_dispatcher_caches
 from meho_backplane.operations.meta_tools import (
+    ConnectorNotIngestedError,
     UnknownConnectorError,
     call_operation,
     describe_descriptor,
@@ -259,6 +260,139 @@ async def test_search_operations_unknown_connector_raises(
             operator,
             {"connector_id": "ghost-9.9", "query": "anything"},
         )
+
+
+class _RegisteredNotIngestedConnector(Connector):
+    """v2-registered class whose ``connector_id`` round-trips losslessly.
+
+    Registered as ``product="ghost"`` / ``version="9.0"`` /
+    ``impl_id="ghost-rest"`` so ``parse_connector_id("ghost-rest-9.0")``
+    recovers the same triple — the listing's lossless-round-trip contract
+    (#773). No DB rows are seeded for it, so it is the "State 0.5"
+    registered-but-not-ingested case.
+    """
+
+    product = "ghost"
+    version = "9.0"
+    impl_id = "ghost-rest"
+
+    async def fingerprint(self, target: Any, operator: Any = None) -> FingerprintResult:  # type: ignore[override]
+        raise NotImplementedError
+
+    async def probe(self, target: Any) -> ProbeResult:  # type: ignore[override]
+        raise NotImplementedError
+
+    async def execute(  # type: ignore[override]
+        self,
+        target: Any,
+        op_id: str,
+        params: dict[str, Any],
+    ) -> OperationResult:
+        raise NotImplementedError
+
+
+def _register_ghost_class() -> None:
+    """Register the State-0.5 ghost connector class (no DB rows)."""
+    register_connector_v2(
+        product="ghost",
+        version="9.0",
+        impl_id="ghost-rest",
+        cls=_RegisteredNotIngestedConnector,
+    )
+
+
+@pytest.mark.asyncio
+async def test_list_operation_groups_registered_not_ingested_raises_typed() -> None:
+    """#1482: a v2-registered, 0-row connector raises ConnectorNotIngestedError.
+
+    Distinct from UnknownConnectorError: the connector exists (its class is
+    registered) but has nothing to dispatch yet. The error carries the
+    ``meho connector ingest …`` next_step hint so the caller self-corrects.
+    """
+    _register_ghost_class()
+    operator = _make_operator()
+
+    with pytest.raises(ConnectorNotIngestedError) as excinfo:
+        await list_operation_groups(operator, {"connector_id": "ghost-rest-9.0"})
+
+    exc = excinfo.value
+    assert exc.connector_id == "ghost-rest-9.0"
+    assert "registered but not yet ingested" in str(exc)
+    # The hint points at the ingest verb (manual-mode for an off-catalog
+    # connector). Catalog-driven hints are exercised by the listing tests;
+    # here we assert the meta-tool surfaces *a* runnable ingest verb.
+    assert exc.next_step is not None
+    assert "ingest" in exc.next_step["verb"]
+    data = exc.as_error_data()
+    assert data["reason"] == "connector_not_ingested"
+    assert data["connector_id"] == "ghost-rest-9.0"
+
+
+@pytest.mark.asyncio
+async def test_search_operations_registered_not_ingested_raises_typed(
+    stub_embedding_service: AsyncMock,
+) -> None:
+    """#1482: search_operations shares the gate — same typed not-ingested error."""
+    _register_ghost_class()
+    operator = _make_operator()
+
+    with pytest.raises(ConnectorNotIngestedError) as excinfo:
+        await search_operations(
+            operator,
+            {"connector_id": "ghost-rest-9.0", "query": "anything"},
+        )
+
+    assert excinfo.value.connector_id == "ghost-rest-9.0"
+
+
+@pytest.mark.asyncio
+async def test_list_operation_groups_unknown_distinct_from_not_ingested() -> None:
+    """#1482 AC3: unknown and not-ingested are distinguishable by the caller.
+
+    With the ghost class registered, a *different* (unregistered)
+    connector_id still raises the plain UnknownConnectorError — never the
+    not-ingested error — so the two cases never collapse into one.
+    """
+    _register_ghost_class()
+    operator = _make_operator()
+
+    with pytest.raises(UnknownConnectorError) as excinfo:
+        await list_operation_groups(operator, {"connector_id": "nonsuch-9.9"})
+
+    # The unknown error is NOT the not-ingested subclass.
+    assert not isinstance(excinfo.value, ConnectorNotIngestedError)
+    assert excinfo.value.connector_id == "nonsuch-9.9"
+
+
+@pytest.mark.asyncio
+async def test_list_operation_groups_ingested_disabled_groups_returns_empty() -> None:
+    """#1482 AC4: an ingested connector with no *enabled* groups still returns [].
+
+    The connector has DB rows (a staged group), so ``connector_exists`` is
+    True and the not-ingested gate never fires — the empty list is the
+    operationally-meaningful "exists, nothing enabled yet" answer, not an
+    error. This guards against a regression where the new gate wrongly
+    re-classified a disabled-only ingested connector as not-ingested.
+    """
+    # Register the ghost class AND seed a staged (non-enabled) group under
+    # its triple, so it is ingested-but-nothing-enabled rather than 0-row.
+    _register_ghost_class()
+    await _seed_group(
+        tenant_id=None,
+        product="ghost",
+        version="9.0",
+        impl_id="ghost-rest",
+        group_key="staged-only",
+        name="Staged",
+        when_to_use="staged.",
+        review_status="staged",
+    )
+    operator = _make_operator()
+
+    result = await list_operation_groups(operator, {"connector_id": "ghost-rest-9.0"})
+
+    assert result["groups"] == []
+    assert result["next_cursor"] is None
 
 
 @pytest.mark.asyncio

--- a/cli/api/openapi.json
+++ b/cli/api/openapi.json
@@ -2176,7 +2176,7 @@
           "operations"
         ],
         "summary": "Get Groups",
-        "description": "List enabled operation groups for *connector_id*.\n\nDelegates to :func:`list_operation_groups`. An *unknown*\n``connector_id`` (no operations registered for the parsed triple)\nis a ``404`` \u2014 not an empty ``200``: the empty-catalog trap was\nthat a mis-shaped id looked identical to an empty connector. A\n*known* connector with zero enabled groups still returns\n``{\"groups\": [], \"next_cursor\": null}`` (that empty is\noperationally meaningful).\n\nPagination is keyset on ``group_key`` (G0.18-T5 #1358); the\nresponse carries ``next_cursor`` set to the last returned\n``group_key`` when a page is full, ``null`` otherwise.",
+        "description": "List enabled operation groups for *connector_id*.\n\nDelegates to :func:`list_operation_groups`. An *unknown*\n``connector_id`` (no operations registered for the parsed triple)\nis a ``404`` \u2014 not an empty ``200``: the empty-catalog trap was\nthat a mis-shaped id looked identical to an empty connector. A\n*registered-but-not-ingested* connector (v2-registered class, zero\nDB rows) is also a ``404`` but with a structured ``detail``\ncarrying ``reason=\"connector_not_ingested\"`` and the ``meho\nconnector ingest \u2026`` ``next_step`` hint, distinct from the\nunknown-connector ``404`` (#1482). A *known* connector with zero\nenabled groups still returns ``{\"groups\": [], \"next_cursor\": null}``\n(that empty is operationally meaningful).\n\nPagination is keyset on ``group_key`` (G0.18-T5 #1358); the\nresponse carries ``next_cursor`` set to the last returned\n``group_key`` when a page is full, ``null`` otherwise.",
         "operationId": "get_groups_api_v1_operations_groups_get",
         "parameters": [
           {
@@ -2275,7 +2275,7 @@
           "operations"
         ],
         "summary": "Get Search",
-        "description": "Hybrid BM25 + cosine RRF over ``endpoint_descriptor`` rows.\n\nDelegates to :func:`search_operations`. See its docstring for the\nfull algorithm and tenant scoping. Unknown ``connector_id`` \u2192 ``404``\n(same unknown-vs-known-empty contract as ``/groups``); a known\nconnector with no matching ops returns ``200`` with an empty list.",
+        "description": "Hybrid BM25 + cosine RRF over ``endpoint_descriptor`` rows.\n\nDelegates to :func:`search_operations`. See its docstring for the\nfull algorithm and tenant scoping. Unknown ``connector_id`` \u2192 ``404``;\na registered-but-not-ingested connector \u2192 ``404`` with the typed\n``connector_not_ingested`` ``detail`` (same contract as ``/groups``,\n#1482); a known connector with no matching ops returns ``200`` with\nan empty list.",
         "operationId": "get_search_api_v1_operations_search_get",
         "parameters": [
           {

--- a/docs/codebase/connector-release-readiness.md
+++ b/docs/codebase/connector-release-readiness.md
@@ -168,6 +168,23 @@ connectors surface in `GET /api/v1/connectors` with
 so operators see `connector registered ⇒ visible in list` rather
 than waiting for the first ingested or typed op to land.
 
+The discovery meta-tools agree with the listing on this state. Since
+[#1482](https://github.com/evoila/meho/issues/1482),
+`list_operation_groups` / `search_operations` raise a typed
+`ConnectorNotIngestedError` for a State-0.5 connector_id instead of the
+opaque unknown-connector error: over MCP it is a `-32602` carrying
+`error.data.reason="connector_not_ingested"` and the same
+`meho connector ingest …` `next_step` hint the `state="registered"`
+listing row emits; over REST it is a `404` with a structured `detail`
+of the same shape. A genuinely unknown connector_id stays
+distinguishable (`reason="unknown_connector"` over MCP, plain-string
+`detail` over REST), so an agent can self-correct "run ingest" without
+confusing it with "no such connector". The
+registered-vs-unknown discriminator is
+[`connector_class_registered`](../../backend/src/meho_backplane/operations/_lookup.py)
+(in-memory v2-registry probe, no DB round-trip); the shared hint is
+[`next_step_for_registered_connector`](../../backend/src/meho_backplane/operations/ingest/list_connectors.py).
+
 ## Why this is hard to get right
 
 The k3d / testcontainers test pattern injects an `override_loader` at


### PR DESCRIPTION
## Summary
- `list_operation_groups` / `search_operations` gated on `connector_exists` (DB-rows-only), so a v2-registered connector with **zero** `endpoint_descriptor` / `operation_group` rows (`state="registered"`) failed the gate, raised `UnknownConnectorError`, and the MCP transport's generic `except Exception` mistranslated it into an opaque `-32603 "internal error: UnknownConnectorError"`. An agent could not tell "doesn't exist" from "needs ingest".
- Adds `connector_class_registered` (an in-memory v2-registry probe re-parsing each registration's `connector_id` to match the listing's lossless round-trip contract) as the discriminator behind a new typed `ConnectorNotIngestedError`. The two discovery meta-tools now share one gate (`_require_dispatchable_connector`): **DB rows present** → proceed (ingested, meaningful-empty list preserved); **no rows + class registered** → `ConnectorNotIngestedError` carrying the same `meho connector ingest …` `next_step` hint the `GET /api/v1/connectors` `state="registered"` row emits; **no rows + no class** → `UnknownConnectorError` (unchanged).
- Surfaces the distinction on both transports: **MCP** maps both domain errors to `-32602` with a typed `error.data.reason` (`connector_not_ingested` vs `unknown_connector`); **REST** returns the not-ingested case as a `404` with a structured `detail` of the same shape, distinct from the unknown-connector plain-string `404`.

## Test plan
- [x] `ruff check` (full src + touched tests) — clean
- [x] `ruff format --check` — clean
- [x] `mypy` (5 touched source files) — clean
- [x] `code-quality.py --diff` — 0 blockers (14 pre-existing warnings on touched files)
- [x] **AC1** `list_operation_groups` on a v2-registered 0-row connector returns typed `connector_not_ingested` (not `-32603`) — `test_list_operation_groups_registered_not_ingested_raises_typed`, `test_tools_call_list_operation_groups_not_ingested_is_typed_invalid_params` (asserts `-32602` + `error.data.reason` + `next_step.verb`, and `!= -32603`)
- [x] **AC2** `search_operations` shares the gate — `test_search_operations_registered_not_ingested_raises_typed`
- [x] **AC3** genuinely-unknown stays distinguishable — `test_list_operation_groups_unknown_distinct_from_not_ingested`, `test_tools_call_list_operation_groups_unknown_is_distinct_invalid_params` (`reason="unknown_connector"`)
- [x] **AC4** ingested connector with no *enabled* groups still returns `[]` (no regression) — `test_list_operation_groups_ingested_disabled_groups_returns_empty`
- [x] REST 404 + typed detail — `test_get_groups_registered_not_ingested_returns_typed_404`
- [x] Regression sweep: `test_operations_meta_tools` / `test_mcp_tools_operations` / `test_api_v1_operations` / `test_api_v1_connectors_ingest` / `test_typed_connectors_metadata` / `test_operations_typed_register` (158 passed) + listing + dispatcher + agent-toolset suites green

## Out of scope
- **`call_operation` `unknown_op` envelope** (the issue's "consider" item): op-not-found is keyed on the descriptor lookup (a different axis than connector resolution) and changing the dispatcher's `unknown_op` shape would collide with the in-flight #1479 / PR #1485 dispatcher work. Recorded as an adjacent finding rather than folded in.
- Auto-ingesting on first discovery; the REST surface's existing 404 behaviour for genuinely-unknown ids.

<!-- auto-implement-issue: fresh, iteration 1 -->

Closes #1482


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Operations discovery endpoints now distinguish between unknown connectors and registered-but-not-ingested connectors, returning specific error messages with actionable guidance. This clarity applies to both REST and programmatic API protocols.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->