### PR TITLE
fix(auth): provision agent client with audience + tenant-claim mappers (#1487)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -135,6 +135,19 @@ connector-related release-notes line.
   (`VAULT_SCHEDULER_TOKEN`); `resolve_agent_credentials` reads it
   Vault-first, keeping the env var as a documented break-glass fallback
   (#1478).
+- A scheduled run for an agent registered purely over the API no longer
+  dies fail-closed at JWT verify (pre-dispatch) with `missing_audience` /
+  `missing_sub` / `missing_tenant_claim`. `agent_principals.register` now
+  provisions the agent's Keycloak client with the **same** mapper + scope
+  set the working `meho-backplane` client carries: an `oidc-audience-mapper`
+  stamping `aud=KEYCLOAK_AUDIENCE` (stock Keycloak ignores the RFC 8707
+  `audience` request param on a `client_credentials` grant without a
+  configured mapper), the default client scopes (`basic`/`roles`/
+  `web-origins`/`acr`) that carry `sub` (Admin-REST-created clients do not
+  inherit them), and the `tenant_id`/`tenant_role`/`principal_kind=agent`
+  hardcoded-claim mappers. An API-registered agent now authenticates
+  end-to-end and reaches an operation / parked approval with no manual
+  Keycloak surgery (#1487).
 - **Approval-queue audit fidelity (G0.19-T4).** A self-approval (and any
   other post-gate `McpInvalidParamsError` — `approval_request_not_found`,
   `approval_unauthorized`) rejection over MCP now audits with a `403`

--- a/backend/src/meho_backplane/auth/agent_principals.py
+++ b/backend/src/meho_backplane/auth/agent_principals.py
@@ -66,12 +66,14 @@ from meho_backplane.auth.keycloak_admin import (
     KeycloakClientConflictError,
     KeycloakClientNotFoundError,
 )
+from meho_backplane.auth.operator import TenantRole
 from meho_backplane.db.engine import get_sessionmaker
 from meho_backplane.db.models import AgentPrincipal
 from meho_backplane.scheduler.vault_credentials import (
     SchedulerVaultNotConfiguredError,
     write_agent_secret,
 )
+from meho_backplane.settings import get_settings
 
 __all__ = [
     "AgentPrincipalCreate",
@@ -87,6 +89,13 @@ _NAME_PATTERN: re.Pattern[str] = re.compile(r"^[A-Za-z0-9_\-\.]+$")
 
 #: Convention: the Keycloak clientId for an agent principal.
 _CLIENT_ID_PREFIX: str = "agent:"
+
+#: ``tenant_role`` stamped into the agent client's access token (#1487).
+#: An agent acts with tenant-admin scope inside its tenant; the
+#: per-principal permission model (G11.2-T3) is the finer-grained gate,
+#: not this coarse JWT role. Matches the ``agent:test-bot`` integration
+#: realm fixture, the only agent client that authenticates end-to-end.
+_AGENT_TENANT_ROLE: str = TenantRole.TENANT_ADMIN.value
 
 
 def _keycloak_client_id(name: str) -> str:
@@ -188,11 +197,16 @@ class AgentPrincipalService:
             )
         owner = payload.owner_sub or created_by_sub
         client_id = _keycloak_client_id(payload.name)
+        audience = get_settings().keycloak_audience
 
         # Phase 1: create Keycloak client + capture its generated secret
         # in the same admin session (create_client returns only the
         # internal UUID; Keycloak never echoes the generated secret on
-        # create). Fail before any DB write on error.
+        # create). The client is provisioned with the audience +
+        # tenant-claim mappers and the default scopes that carry ``sub``,
+        # so its client_credentials token validates through the JWT chain
+        # with no manual Keycloak surgery (#1487). Fail before any DB write
+        # on error.
         kc_client = KeycloakAdminClient.from_settings()
         try:
             async with kc_client:
@@ -201,6 +215,8 @@ class AgentPrincipalService:
                     name=payload.name,
                     tenant_id=str(tenant_id),
                     owner_sub=owner,
+                    audience=audience,
+                    tenant_role=_AGENT_TENANT_ROLE,
                 )
                 client_secret = await kc_client.get_client_secret(internal_id)
         except KeycloakClientConflictError as exc:

--- a/backend/src/meho_backplane/auth/keycloak_admin.py
+++ b/backend/src/meho_backplane/auth/keycloak_admin.py
@@ -69,6 +69,18 @@ __all__ = [
 
 _ADMIN_HTTP_TIMEOUT_SECONDS: float = 10.0
 
+#: Realm default-default client scopes an agent client must carry. Clients
+#: created through the Admin REST ``POST /clients`` do **not** inherit the
+#: realm's default scopes the way the Admin Console "Create" button does
+#: (the request body must set ``defaultClientScopes`` explicitly), so the
+#: ``basic`` scope — which carries the ``sub`` protocol mapper Keycloak 25+
+#: moved out of the hardcoded token path — is absent unless named here. A
+#: token without ``sub`` is rejected by ``verify_jwt_for_audience``
+#: (``missing_sub``, RFC 9068 §2.2.1). ``roles``/``web-origins``/``acr`` are
+#: the rest of the realm default set; they are cheap and keep the agent
+#: client byte-identical to a console-created one.
+_AGENT_DEFAULT_CLIENT_SCOPES: tuple[str, ...] = ("basic", "roles", "web-origins", "acr")
+
 #: Gold-standard 503 detail surfaced by ``POST /api/v1/agent-principals``
 #: (and any other admin-surfaced route that catches
 #: :class:`KeycloakAdminNotConfiguredError`) when the Keycloak admin
@@ -105,6 +117,67 @@ class KeycloakClientNotFoundError(KeycloakAdminError):
     """Raised when the target client does not exist (404 from Keycloak)."""
 
 
+def _hardcoded_claim_mapper(name: str, claim_name: str, claim_value: str) -> dict[str, Any]:
+    """Build an ``oidc-hardcoded-claim-mapper`` representation.
+
+    The ``config`` keys are Keycloak's dotted protocol-mapper config names
+    (not camelCase); they mirror the ``agent:test-bot`` rows in the
+    live-Keycloak integration realm so the API-created client is
+    byte-equivalent to the fixture that already authenticates end-to-end.
+    The claim is stamped onto the **access** token only — the
+    ``client_credentials`` grant issues no ID or userinfo token.
+    """
+    return {
+        "name": name,
+        "protocol": "openid-connect",
+        "protocolMapper": "oidc-hardcoded-claim-mapper",
+        "config": {
+            "claim.name": claim_name,
+            "claim.value": claim_value,
+            "jsonType.label": "String",
+            "access.token.claim": "true",
+            "id.token.claim": "false",
+            "userinfo.token.claim": "false",
+        },
+    }
+
+
+def _agent_protocol_mappers(
+    *,
+    audience: str,
+    tenant_id: str,
+    tenant_role: str,
+) -> list[dict[str, Any]]:
+    """Return the protocol mappers an agent client needs to authenticate.
+
+    Clones the mapper set the working ``meho-backplane`` client / the
+    ``agent:test-bot`` integration-realm fixture carry (#1487):
+
+    * an ``oidc-audience-mapper`` stamping *audience* into ``aud`` via the
+      ``included.custom.audience`` config (the only way to land an
+      arbitrary audience on a ``client_credentials`` token — the RFC 8707
+      request param is ignored without a configured mapper);
+    * hardcoded-claim mappers for ``tenant_id`` / ``tenant_role`` and
+      ``principal_kind=agent`` so the Operator chain resolves the agent's
+      tenant scope and ``PrincipalKind.AGENT`` discriminator.
+    """
+    return [
+        {
+            "name": "audience-mapper",
+            "protocol": "openid-connect",
+            "protocolMapper": "oidc-audience-mapper",
+            "config": {
+                "included.custom.audience": audience,
+                "id.token.claim": "false",
+                "access.token.claim": "true",
+            },
+        },
+        _hardcoded_claim_mapper("tenant-id-claim", "tenant_id", tenant_id),
+        _hardcoded_claim_mapper("tenant-role-claim", "tenant_role", tenant_role),
+        _hardcoded_claim_mapper("principal-kind-claim", "principal_kind", "agent"),
+    ]
+
+
 class KeycloakAdminClient:
     """Async context manager for Keycloak Admin REST API calls.
 
@@ -122,6 +195,8 @@ class KeycloakAdminClient:
                 name="my-bot",
                 tenant_id=str(tenant_id),
                 owner_sub=operator.sub,
+                audience=settings.keycloak_audience,
+                tenant_role="tenant_admin",
             )
     """
 
@@ -241,6 +316,8 @@ class KeycloakAdminClient:
         name: str,
         tenant_id: str,
         owner_sub: str,
+        audience: str,
+        tenant_role: str,
     ) -> str:
         """Register a new Keycloak client tagged ``kind=agent``.
 
@@ -256,6 +333,28 @@ class KeycloakAdminClient:
         via ``client_credentials`` and never involves a browser. Custom
         attributes ``kind=agent``, ``tenant_id``, ``owner_sub`` are added
         so the realm admin console and IaC tooling can identify agent clients.
+
+        Token-claim provisioning (the fix for #1487): the client is created
+        with the **same** protocol-mapper + default-client-scope set the
+        working ``meho-backplane`` client carries, so its
+        ``client_credentials`` token validates through
+        :func:`~meho_backplane.auth.jwt.verify_jwt_for_audience` with no
+        manual Keycloak surgery. Without these, a scheduled agent run dies
+        at JWT verify (pre-dispatch) because the token lacks ``aud``
+        (``missing_audience``), ``sub`` (carried by the ``basic`` scope's
+        subject mapper — Keycloak 25+ moved it out of the hardcoded path),
+        and the ``tenant_id`` / ``tenant_role`` claims the Operator chain
+        requires:
+
+        * an ``oidc-audience-mapper`` stamping *audience* into ``aud`` —
+          stock Keycloak does **not** honour the RFC 8707 ``audience``
+          request param on a ``client_credentials`` grant without this
+          mapper, so requesting the audience at mint time is not enough;
+        * ``oidc-hardcoded-claim-mapper`` rows for ``tenant_id`` /
+          ``tenant_role`` / ``principal_kind=agent`` (the same shape the
+          live-Keycloak integration realm injects on ``agent:test-bot``);
+        * the realm default client scopes
+          (:data:`_AGENT_DEFAULT_CLIENT_SCOPES`) that carry ``sub``.
 
         Raises :class:`KeycloakClientConflictError` when a client with the
         same ``clientId`` already exists (Keycloak 409).
@@ -277,6 +376,12 @@ class KeycloakAdminClient:
                 "tenant_id": tenant_id,
                 "owner_sub": owner_sub,
             },
+            "protocolMappers": _agent_protocol_mappers(
+                audience=audience,
+                tenant_id=tenant_id,
+                tenant_role=tenant_role,
+            ),
+            "defaultClientScopes": list(_AGENT_DEFAULT_CLIENT_SCOPES),
         }
         try:
             resp = await self._http.post(

--- a/backend/tests/integration/_fixtures/meho-integration-realm.json
+++ b/backend/tests/integration/_fixtures/meho-integration-realm.json
@@ -74,7 +74,7 @@
     {
       "clientId": "meho-admin",
       "name": "Integration-test Keycloak admin client (G0.19 #1487)",
-      "description": "Confidential service-account client the backplane's KeycloakAdminClient authenticates as to provision agent clients over the Admin REST API. Its service account is granted realm-management/manage-clients post-boot by the keycloak_bootstrap fixture (NOT via serviceAccountClientRoles here): a serviceAccountClientRoles entry referencing the realm-management client at --import-realm time crashes Keycloak 26.x boot (exit code 1) because the role mapping is resolved before the per-realm realm-management client/roles exist in the import transaction.",
+      "description": "Confidential service-account client the backplane's KeycloakAdminClient authenticates as to provision agent clients over the Admin REST API (G0.19 #1487). Granted realm-management/manage-clients via the realm users[] array below.",
       "enabled": true,
       "protocol": "openid-connect",
       "publicClient": false,
@@ -83,6 +83,16 @@
       "standardFlowEnabled": false,
       "implicitFlowEnabled": false,
       "directAccessGrantsEnabled": false
+    }
+  ],
+  "users": [
+    {
+      "username": "service-account-meho-admin",
+      "enabled": true,
+      "serviceAccountClientId": "meho-admin",
+      "clientRoles": {
+        "realm-management": ["manage-clients"]
+      }
     }
   ]
 }

--- a/backend/tests/integration/_fixtures/meho-integration-realm.json
+++ b/backend/tests/integration/_fixtures/meho-integration-realm.json
@@ -74,7 +74,7 @@
     {
       "clientId": "meho-admin",
       "name": "Integration-test Keycloak admin client (G0.19 #1487)",
-      "description": "Confidential service-account client the backplane's KeycloakAdminClient authenticates as to provision agent clients over the Admin REST API. Holds realm-management/manage-clients so the #1487 register-provisions-mappers test can create an agent client purely over the API (no realm-fixture pre-injection of mappers).",
+      "description": "Confidential service-account client the backplane's KeycloakAdminClient authenticates as to provision agent clients over the Admin REST API. Its service account is granted realm-management/manage-clients post-boot by the keycloak_bootstrap fixture (NOT via serviceAccountClientRoles here): a serviceAccountClientRoles entry referencing the realm-management client at --import-realm time crashes Keycloak 26.x boot (exit code 1) because the role mapping is resolved before the per-realm realm-management client/roles exist in the import transaction.",
       "enabled": true,
       "protocol": "openid-connect",
       "publicClient": false,
@@ -82,10 +82,7 @@
       "serviceAccountsEnabled": true,
       "standardFlowEnabled": false,
       "implicitFlowEnabled": false,
-      "directAccessGrantsEnabled": false,
-      "serviceAccountClientRoles": {
-        "realm-management": ["manage-clients"]
-      }
+      "directAccessGrantsEnabled": false
     }
   ]
 }

--- a/backend/tests/integration/_fixtures/meho-integration-realm.json
+++ b/backend/tests/integration/_fixtures/meho-integration-realm.json
@@ -70,6 +70,22 @@
           }
         }
       ]
+    },
+    {
+      "clientId": "meho-admin",
+      "name": "Integration-test Keycloak admin client (G0.19 #1487)",
+      "description": "Confidential service-account client the backplane's KeycloakAdminClient authenticates as to provision agent clients over the Admin REST API. Holds realm-management/manage-clients so the #1487 register-provisions-mappers test can create an agent client purely over the API (no realm-fixture pre-injection of mappers).",
+      "enabled": true,
+      "protocol": "openid-connect",
+      "publicClient": false,
+      "secret": "admin-secret-do-not-use-anywhere-else-g0-19-1487",
+      "serviceAccountsEnabled": true,
+      "standardFlowEnabled": false,
+      "implicitFlowEnabled": false,
+      "directAccessGrantsEnabled": false,
+      "serviceAccountClientRoles": {
+        "realm-management": ["manage-clients"]
+      }
     }
   ]
 }

--- a/backend/tests/integration/conftest.py
+++ b/backend/tests/integration/conftest.py
@@ -631,6 +631,14 @@ async def count_audit_rows(async_url: str) -> int:
 
 _KEYCLOAK_REALM: str = "meho-integration"
 _KEYCLOAK_CLIENT_ID: str = "agent:test-bot"
+# Confidential admin client the backplane's KeycloakAdminClient
+# authenticates as to provision agent clients over the Admin REST API.
+# Holds realm-management/manage-clients in the realm import; the #1487
+# register-provisions-mappers test uses it to create an agent client
+# purely over the API (no realm-fixture pre-injection of mappers). Same
+# throwaway-credential discipline as ``_KEYCLOAK_CLIENT_SECRET``.
+_KEYCLOAK_ADMIN_CLIENT_ID: str = "meho-admin"
+_KEYCLOAK_ADMIN_CLIENT_SECRET: str = "admin-secret-do-not-use-anywhere-else-g0-19-1487"
 # This secret is generated *into* the testcontainer realm import and
 # only ever held in this module + the realm JSON. It is bound to a
 # throwaway per-test-run Keycloak instance that never persists, is
@@ -678,6 +686,13 @@ class KeycloakBootstrap:
       ``expected_principal_kind`` — the literal values the realm's
       hardcoded-claim mappers stamp; the integration test asserts the
       resulting :class:`Operator` carries these.
+    * ``admin_url`` / ``admin_client_id`` / ``admin_client_secret`` — the
+      Admin REST API base (``{base_url}/admin/realms/{realm}``) and the
+      ``meho-admin`` confidential client the backplane's
+      :class:`~meho_backplane.auth.keycloak_admin.KeycloakAdminClient`
+      authenticates as. The #1487 test uses these to provision an agent
+      client purely over the API (no realm-fixture pre-injection of
+      mappers) and prove it authenticates end-to-end.
     """
 
     base_url: str
@@ -689,6 +704,9 @@ class KeycloakBootstrap:
     expected_tenant_id: str
     expected_tenant_role: str
     expected_principal_kind: str
+    admin_url: str
+    admin_client_id: str
+    admin_client_secret: str
 
 
 @pytest.fixture(scope="module")
@@ -814,6 +832,9 @@ def keycloak_bootstrap() -> Iterator[KeycloakBootstrap]:
             expected_tenant_id=_KEYCLOAK_TENANT_ID,
             expected_tenant_role=_KEYCLOAK_TENANT_ROLE,
             expected_principal_kind=_KEYCLOAK_PRINCIPAL_KIND,
+            admin_url=f"{base_url}/admin/realms/{_KEYCLOAK_REALM}",
+            admin_client_id=_KEYCLOAK_ADMIN_CLIENT_ID,
+            admin_client_secret=_KEYCLOAK_ADMIN_CLIENT_SECRET,
         )
         yield bootstrap
     finally:

--- a/backend/tests/integration/conftest.py
+++ b/backend/tests/integration/conftest.py
@@ -633,11 +633,12 @@ _KEYCLOAK_REALM: str = "meho-integration"
 _KEYCLOAK_CLIENT_ID: str = "agent:test-bot"
 # Confidential admin client the backplane's KeycloakAdminClient
 # authenticates as to provision agent clients over the Admin REST API.
-# Its service account is granted realm-management/manage-clients
-# post-boot by ``_grant_manage_clients_to_admin_sa`` (NOT via the realm
-# import — a serviceAccountClientRoles entry crashes Keycloak 26.x boot);
-# the #1487 register-provisions-mappers test uses it to create an agent
-# client purely over the API (no realm-fixture pre-injection of mappers).
+# Its service account is granted realm-management/manage-clients at
+# import time via the realm ``users`` array — a service-account user
+# (``serviceAccountClientId: meho-admin``) carrying the ``clientRoles``
+# grant, the canonical ``kc export`` shape. The #1487
+# register-provisions-mappers test uses it to create an agent client
+# purely over the API (no realm-fixture pre-injection of mappers).
 # Same throwaway-credential discipline as ``_KEYCLOAK_CLIENT_SECRET``.
 _KEYCLOAK_ADMIN_CLIENT_ID: str = "meho-admin"
 _KEYCLOAK_ADMIN_CLIENT_SECRET: str = "admin-secret-do-not-use-anywhere-else-g0-19-1487"
@@ -711,90 +712,6 @@ class KeycloakBootstrap:
     admin_client_secret: str
 
 
-def _grant_manage_clients_to_admin_sa(base_url: str) -> None:
-    """Grant ``realm-management/manage-clients`` to the ``meho-admin`` SA.
-
-    The ``meho-admin`` confidential client provisions agent clients over
-    the Admin REST API, which requires its service account to hold
-    ``realm-management/manage-clients``. That role mapping is **not**
-    expressed in the realm-import JSON: a ``serviceAccountClientRoles``
-    entry referencing the per-realm ``realm-management`` client crashes
-    Keycloak 26.x ``--import-realm`` (the container exits code 1 before
-    Quarkus prints ``Listening on:``) because the mapping is resolved
-    before the ``realm-management`` client and its roles exist in the
-    import transaction. So the grant is applied post-boot, over the same
-    Admin REST API the production code uses, authenticated as the
-    master-realm bootstrap admin.
-
-    The endpoint sequence is the long-stable Keycloak Admin REST shape:
-    master-realm ``admin-cli`` direct-grant token → resolve the
-    ``meho-admin`` client + its service-account user → resolve the
-    ``realm-management`` client + its ``manage-clients`` role → POST the
-    role to the SA user's client-level role mappings. Idempotent: a
-    second POST of an already-assigned role is a Keycloak no-op.
-    """
-    import httpx
-
-    realm = _KEYCLOAK_REALM
-    admin_api = f"{base_url}/admin/realms/{realm}"
-    with httpx.Client(timeout=30.0) as http:
-        token_resp = http.post(
-            f"{base_url}/realms/master/protocol/openid-connect/token",
-            data={
-                "grant_type": "password",
-                "client_id": "admin-cli",
-                "username": _KEYCLOAK_BOOTSTRAP_ADMIN_USERNAME,
-                "password": _KEYCLOAK_BOOTSTRAP_ADMIN_PASSWORD,
-            },
-        )
-        token_resp.raise_for_status()
-        headers = {"Authorization": f"Bearer {token_resp.json()['access_token']}"}
-
-        def _client_uuid(client_id: str) -> str:
-            resp = http.get(
-                f"{admin_api}/clients",
-                params={"clientId": client_id},
-                headers=headers,
-            )
-            resp.raise_for_status()
-            found = resp.json()
-            if not found:
-                raise RuntimeError(
-                    f"Keycloak client {client_id!r} not found in realm "
-                    f"{realm!r} after import — realm fixture out of sync."
-                )
-            return str(found[0]["id"])
-
-        admin_client_uuid = _client_uuid(_KEYCLOAK_ADMIN_CLIENT_ID)
-        realm_mgmt_uuid = _client_uuid("realm-management")
-
-        sa_resp = http.get(
-            f"{admin_api}/clients/{admin_client_uuid}/service-account-user",
-            headers=headers,
-        )
-        sa_resp.raise_for_status()
-        sa_user_id = str(sa_resp.json()["id"])
-
-        role_resp = http.get(
-            f"{admin_api}/clients/{realm_mgmt_uuid}/roles/manage-clients",
-            headers=headers,
-        )
-        role_resp.raise_for_status()
-        # POST the full RoleRepresentation the GET returned back verbatim
-        # (id + name + containerId + ...). A hand-trimmed {id, name} subset
-        # is accepted by some Keycloak versions but the complete
-        # representation is the version-stable shape.
-        role = role_resp.json()
-
-        assign_resp = http.post(
-            f"{admin_api}/users/{sa_user_id}/role-mappings/clients/{realm_mgmt_uuid}",
-            json=[role],
-            headers=headers,
-        )
-        # 204 = assigned now; Keycloak is idempotent on a re-POST.
-        assign_resp.raise_for_status()
-
-
 @pytest.fixture(scope="module")
 def keycloak_bootstrap() -> Iterator[KeycloakBootstrap]:
     """Boot Keycloak with the integration realm imported, yield the bootstrap.
@@ -834,14 +751,11 @@ def keycloak_bootstrap() -> Iterator[KeycloakBootstrap]:
     (the 26.x replacement for ``KEYCLOAK_ADMIN`` /
     ``KEYCLOAK_ADMIN_PASSWORD``). The integration test authenticates as
     the imported ``meho-admin`` confidential client, not as this
-    master-realm admin — but the fixture *does* use the bootstrap admin
-    once, post-boot, to grant ``realm-management/manage-clients`` to the
-    ``meho-admin`` service account (see
-    :func:`_grant_manage_clients_to_admin_sa`). That grant cannot live in
-    the realm-import JSON without crashing Keycloak 26.x boot, so it is
-    applied over the Admin REST API after ``Listening on:``. Keycloak
-    also refuses to start without bootstrap admin creds on a fresh
-    database, so they are load-bearing regardless.
+    master-realm admin; the ``meho-admin`` service account is granted
+    ``realm-management/manage-clients`` at import time via the realm
+    ``users`` array, so no post-boot admin REST call is needed. Keycloak
+    refuses to start without bootstrap admin creds on a fresh database,
+    so they are load-bearing regardless.
     """
     image = os.environ.get("MEHO_TEST_KEYCLOAK_IMAGE")
     if not image:
@@ -914,12 +828,6 @@ def keycloak_bootstrap() -> Iterator[KeycloakBootstrap]:
         host = container.get_container_host_ip()
         port = container.get_exposed_port(8080)
         base_url = f"http://{host}:{port}"
-        # Grant realm-management/manage-clients to the meho-admin SA
-        # post-boot. This is deliberately NOT in the realm-import JSON: a
-        # serviceAccountClientRoles entry referencing realm-management
-        # crashes Keycloak 26.x --import-realm (container exits code 1
-        # before "Listening on:"). See _grant_manage_clients_to_admin_sa.
-        _grant_manage_clients_to_admin_sa(base_url)
         bootstrap = KeycloakBootstrap(
             base_url=base_url,
             realm=_KEYCLOAK_REALM,

--- a/backend/tests/integration/conftest.py
+++ b/backend/tests/integration/conftest.py
@@ -633,10 +633,12 @@ _KEYCLOAK_REALM: str = "meho-integration"
 _KEYCLOAK_CLIENT_ID: str = "agent:test-bot"
 # Confidential admin client the backplane's KeycloakAdminClient
 # authenticates as to provision agent clients over the Admin REST API.
-# Holds realm-management/manage-clients in the realm import; the #1487
-# register-provisions-mappers test uses it to create an agent client
-# purely over the API (no realm-fixture pre-injection of mappers). Same
-# throwaway-credential discipline as ``_KEYCLOAK_CLIENT_SECRET``.
+# Its service account is granted realm-management/manage-clients
+# post-boot by ``_grant_manage_clients_to_admin_sa`` (NOT via the realm
+# import — a serviceAccountClientRoles entry crashes Keycloak 26.x boot);
+# the #1487 register-provisions-mappers test uses it to create an agent
+# client purely over the API (no realm-fixture pre-injection of mappers).
+# Same throwaway-credential discipline as ``_KEYCLOAK_CLIENT_SECRET``.
 _KEYCLOAK_ADMIN_CLIENT_ID: str = "meho-admin"
 _KEYCLOAK_ADMIN_CLIENT_SECRET: str = "admin-secret-do-not-use-anywhere-else-g0-19-1487"
 # This secret is generated *into* the testcontainer realm import and
@@ -709,6 +711,90 @@ class KeycloakBootstrap:
     admin_client_secret: str
 
 
+def _grant_manage_clients_to_admin_sa(base_url: str) -> None:
+    """Grant ``realm-management/manage-clients`` to the ``meho-admin`` SA.
+
+    The ``meho-admin`` confidential client provisions agent clients over
+    the Admin REST API, which requires its service account to hold
+    ``realm-management/manage-clients``. That role mapping is **not**
+    expressed in the realm-import JSON: a ``serviceAccountClientRoles``
+    entry referencing the per-realm ``realm-management`` client crashes
+    Keycloak 26.x ``--import-realm`` (the container exits code 1 before
+    Quarkus prints ``Listening on:``) because the mapping is resolved
+    before the ``realm-management`` client and its roles exist in the
+    import transaction. So the grant is applied post-boot, over the same
+    Admin REST API the production code uses, authenticated as the
+    master-realm bootstrap admin.
+
+    The endpoint sequence is the long-stable Keycloak Admin REST shape:
+    master-realm ``admin-cli`` direct-grant token → resolve the
+    ``meho-admin`` client + its service-account user → resolve the
+    ``realm-management`` client + its ``manage-clients`` role → POST the
+    role to the SA user's client-level role mappings. Idempotent: a
+    second POST of an already-assigned role is a Keycloak no-op.
+    """
+    import httpx
+
+    realm = _KEYCLOAK_REALM
+    admin_api = f"{base_url}/admin/realms/{realm}"
+    with httpx.Client(timeout=30.0) as http:
+        token_resp = http.post(
+            f"{base_url}/realms/master/protocol/openid-connect/token",
+            data={
+                "grant_type": "password",
+                "client_id": "admin-cli",
+                "username": _KEYCLOAK_BOOTSTRAP_ADMIN_USERNAME,
+                "password": _KEYCLOAK_BOOTSTRAP_ADMIN_PASSWORD,
+            },
+        )
+        token_resp.raise_for_status()
+        headers = {"Authorization": f"Bearer {token_resp.json()['access_token']}"}
+
+        def _client_uuid(client_id: str) -> str:
+            resp = http.get(
+                f"{admin_api}/clients",
+                params={"clientId": client_id},
+                headers=headers,
+            )
+            resp.raise_for_status()
+            found = resp.json()
+            if not found:
+                raise RuntimeError(
+                    f"Keycloak client {client_id!r} not found in realm "
+                    f"{realm!r} after import — realm fixture out of sync."
+                )
+            return str(found[0]["id"])
+
+        admin_client_uuid = _client_uuid(_KEYCLOAK_ADMIN_CLIENT_ID)
+        realm_mgmt_uuid = _client_uuid("realm-management")
+
+        sa_resp = http.get(
+            f"{admin_api}/clients/{admin_client_uuid}/service-account-user",
+            headers=headers,
+        )
+        sa_resp.raise_for_status()
+        sa_user_id = str(sa_resp.json()["id"])
+
+        role_resp = http.get(
+            f"{admin_api}/clients/{realm_mgmt_uuid}/roles/manage-clients",
+            headers=headers,
+        )
+        role_resp.raise_for_status()
+        # POST the full RoleRepresentation the GET returned back verbatim
+        # (id + name + containerId + ...). A hand-trimmed {id, name} subset
+        # is accepted by some Keycloak versions but the complete
+        # representation is the version-stable shape.
+        role = role_resp.json()
+
+        assign_resp = http.post(
+            f"{admin_api}/users/{sa_user_id}/role-mappings/clients/{realm_mgmt_uuid}",
+            json=[role],
+            headers=headers,
+        )
+        # 204 = assigned now; Keycloak is idempotent on a re-POST.
+        assign_resp.raise_for_status()
+
+
 @pytest.fixture(scope="module")
 def keycloak_bootstrap() -> Iterator[KeycloakBootstrap]:
     """Boot Keycloak with the integration realm imported, yield the bootstrap.
@@ -746,10 +832,16 @@ def keycloak_bootstrap() -> Iterator[KeycloakBootstrap]:
     Bootstrap admin credentials are set via
     ``KC_BOOTSTRAP_ADMIN_USERNAME`` / ``KC_BOOTSTRAP_ADMIN_PASSWORD``
     (the 26.x replacement for ``KEYCLOAK_ADMIN`` /
-    ``KEYCLOAK_ADMIN_PASSWORD``). The integration test does not use
-    admin credentials — it authenticates as the imported
-    confidential client — but Keycloak refuses to start without
-    bootstrap admin creds on a fresh database.
+    ``KEYCLOAK_ADMIN_PASSWORD``). The integration test authenticates as
+    the imported ``meho-admin`` confidential client, not as this
+    master-realm admin — but the fixture *does* use the bootstrap admin
+    once, post-boot, to grant ``realm-management/manage-clients`` to the
+    ``meho-admin`` service account (see
+    :func:`_grant_manage_clients_to_admin_sa`). That grant cannot live in
+    the realm-import JSON without crashing Keycloak 26.x boot, so it is
+    applied over the Admin REST API after ``Listening on:``. Keycloak
+    also refuses to start without bootstrap admin creds on a fresh
+    database, so they are load-bearing regardless.
     """
     image = os.environ.get("MEHO_TEST_KEYCLOAK_IMAGE")
     if not image:
@@ -822,6 +914,12 @@ def keycloak_bootstrap() -> Iterator[KeycloakBootstrap]:
         host = container.get_container_host_ip()
         port = container.get_exposed_port(8080)
         base_url = f"http://{host}:{port}"
+        # Grant realm-management/manage-clients to the meho-admin SA
+        # post-boot. This is deliberately NOT in the realm-import JSON: a
+        # serviceAccountClientRoles entry referencing realm-management
+        # crashes Keycloak 26.x --import-realm (container exits code 1
+        # before "Listening on:"). See _grant_manage_clients_to_admin_sa.
+        _grant_manage_clients_to_admin_sa(base_url)
         bootstrap = KeycloakBootstrap(
             base_url=base_url,
             realm=_KEYCLOAK_REALM,

--- a/backend/tests/integration/test_auth_keycloak_client_credentials.py
+++ b/backend/tests/integration/test_auth_keycloak_client_credentials.py
@@ -54,12 +54,13 @@ test. The integration-test CI gate enforces a non-empty
 
 from __future__ import annotations
 
-from uuid import UUID
+from uuid import UUID, uuid4
 
 import pytest
 
 from meho_backplane.auth.agent_token import get_client_credentials_token
 from meho_backplane.auth.jwt import clear_jwks_cache, verify_jwt_for_audience
+from meho_backplane.auth.keycloak_admin import KeycloakAdminClient
 from meho_backplane.auth.operator import PrincipalKind, TenantRole
 from meho_backplane.settings import get_settings
 from tests.integration.conftest import KeycloakBootstrap
@@ -125,3 +126,83 @@ async def test_client_credentials_grant_end_to_end(
     assert operator.principal_kind == PrincipalKind.AGENT
     assert operator.tenant_role == TenantRole.TENANT_ADMIN
     assert operator.tenant_id == UUID(keycloak_bootstrap.expected_tenant_id)
+
+
+async def test_register_provisioned_client_authenticates_end_to_end(
+    keycloak_bootstrap: KeycloakBootstrap,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """An agent client created over the Admin API authenticates with no realm surgery.
+
+    This is the #1487 proof surface. Unlike
+    :func:`test_client_credentials_grant_end_to_end` — which uses the
+    ``agent:test-bot`` client whose audience / tenant / principal-kind
+    mappers the **realm fixture** pre-injects — this test creates a fresh
+    agent client purely through
+    :meth:`~meho_backplane.auth.keycloak_admin.KeycloakAdminClient.create_client`,
+    the exact path ``agent_principals.register`` drives. The realm import
+    adds **no** mappers for this client; the only way its
+    ``client_credentials`` token carries ``aud`` / ``sub`` / ``tenant_id``
+    / ``tenant_role`` is the mapper + default-scope set ``create_client``
+    now provisions. Before the fix, the token minted here is rejected
+    fail-closed at ``verify_jwt_for_audience`` (``missing_audience`` /
+    ``missing_sub`` / ``missing_tenant_claim``) before any operation
+    dispatches.
+
+    The ``tenant_id`` passed to ``create_client`` is a fresh UUID — not
+    the fixture's pinned value — so the decode-assert proves the claim
+    flows from the ``create_client`` argument through the provisioned
+    hardcoded-claim mapper, not from any realm-baked constant.
+    """
+    monkeypatch.setenv("KEYCLOAK_ISSUER_URL", keycloak_bootstrap.issuer_url)
+    get_settings.cache_clear()
+    clear_jwks_cache()
+
+    tenant_id = uuid4()
+    client_id = f"agent:reg-via-api-{uuid4().hex[:8]}"
+
+    # 1. Provision the agent client exactly as register() does: through
+    # the production KeycloakAdminClient, with the audience + tenant-claim
+    # mappers and the default scopes that carry ``sub``. No realm fixture
+    # pre-injects these — create_client is the only source.
+    admin = KeycloakAdminClient(
+        admin_url=keycloak_bootstrap.admin_url,
+        token_url=f"{keycloak_bootstrap.issuer_url}/protocol/openid-connect/token",
+        client_id=keycloak_bootstrap.admin_client_id,
+        client_secret=keycloak_bootstrap.admin_client_secret,
+    )
+    async with admin:
+        internal_id = await admin.create_client(
+            client_id=client_id,
+            name=client_id.removeprefix("agent:"),
+            tenant_id=str(tenant_id),
+            owner_sub="integration-test-owner",
+            audience=keycloak_bootstrap.audience,
+            tenant_role=TenantRole.TENANT_ADMIN.value,
+        )
+        client_secret = await admin.get_client_secret(internal_id)
+
+    assert client_secret, "create_client must yield a usable client secret"
+
+    # 2. Mint via the same production primitive the scheduler uses.
+    token = await get_client_credentials_token(
+        issuer_url=keycloak_bootstrap.issuer_url,
+        client_id=client_id,
+        client_secret=client_secret,
+        audience=keycloak_bootstrap.audience,
+    )
+    assert isinstance(token, str) and token, "client_credentials grant returned empty token"
+
+    # 3. Drive the token through the production validation chain — the same
+    # pre-dispatch gate ``run_scheduled`` hits. Reaching the asserts below
+    # proves no missing_audience / missing_sub / missing_*_claim 401.
+    operator = await verify_jwt_for_audience(
+        f"Bearer {token}",
+        expected_audience=keycloak_bootstrap.audience,
+    )
+
+    # 4. Every claim the provisioned mappers + default scopes must land.
+    assert operator.sub, "Operator.sub must resolve (carried by the basic scope's mapper)"
+    assert operator.tenant_id == tenant_id
+    assert operator.tenant_role == TenantRole.TENANT_ADMIN
+    assert operator.principal_kind == PrincipalKind.AGENT

--- a/backend/tests/test_keycloak_admin.py
+++ b/backend/tests/test_keycloak_admin.py
@@ -54,6 +54,18 @@ async def test_aenter_auth_failure_closes_client() -> None:
         assert kc._token is None
 
 
+async def _create_bot(kc: KeycloakAdminClient) -> str:
+    """Invoke ``create_client`` with the agent-principal argument shape."""
+    return await kc.create_client(
+        client_id="agent:bot",
+        name="bot",
+        tenant_id="11111111-1111-1111-1111-111111111111",
+        owner_sub="o",
+        audience="meho-backplane",
+        tenant_role="tenant_admin",
+    )
+
+
 @pytest.mark.asyncio
 async def test_create_client_parses_internal_id_from_location() -> None:
     with respx.mock as r:
@@ -64,10 +76,59 @@ async def test_create_client_parses_internal_id_from_location() -> None:
             )
         )
         async with _client() as kc:
-            internal_id = await kc.create_client(
-                client_id="agent:bot", name="bot", tenant_id="t", owner_sub="o"
-            )
+            internal_id = await _create_bot(kc)
     assert internal_id == _INTERNAL_ID
+
+
+@pytest.mark.asyncio
+async def test_create_client_provisions_audience_scopes_and_tenant_claims() -> None:
+    """The created client carries the mapper + scope set #1487 requires.
+
+    Without these, the agent's ``client_credentials`` token lacks ``aud``,
+    ``sub``, ``tenant_id`` and ``tenant_role`` and is rejected fail-closed
+    at ``verify_jwt_for_audience`` before any operation dispatches.
+    """
+    with respx.mock as r:
+        _mock_token(r)
+        route = r.post(f"{_ADMIN_URL}/clients").mock(
+            return_value=httpx.Response(
+                201, headers={"Location": f"{_ADMIN_URL}/clients/{_INTERNAL_ID}"}
+            )
+        )
+        async with _client() as kc:
+            await _create_bot(kc)
+
+    body = json.loads(route.calls[0].request.content)
+
+    # Default client scopes carry the basic/sub mapper Keycloak 25+ moved
+    # out of the hardcoded token path; created-via-API clients do not
+    # inherit them unless the POST names them explicitly.
+    assert body["defaultClientScopes"] == ["basic", "roles", "web-origins", "acr"]
+
+    mappers = {m["name"]: m for m in body["protocolMappers"]}
+
+    audience = mappers["audience-mapper"]
+    assert audience["protocolMapper"] == "oidc-audience-mapper"
+    assert audience["config"]["included.custom.audience"] == "meho-backplane"
+    assert audience["config"]["access.token.claim"] == "true"
+
+    tenant_id = mappers["tenant-id-claim"]
+    assert tenant_id["protocolMapper"] == "oidc-hardcoded-claim-mapper"
+    assert tenant_id["config"]["claim.name"] == "tenant_id"
+    assert tenant_id["config"]["claim.value"] == "11111111-1111-1111-1111-111111111111"
+
+    tenant_role = mappers["tenant-role-claim"]
+    assert tenant_role["config"]["claim.name"] == "tenant_role"
+    assert tenant_role["config"]["claim.value"] == "tenant_admin"
+
+    principal_kind = mappers["principal-kind-claim"]
+    assert principal_kind["config"]["claim.name"] == "principal_kind"
+    assert principal_kind["config"]["claim.value"] == "agent"
+    # Agent tokens are access-token only (no ID/userinfo token on a
+    # client_credentials grant); every claim mapper must target the
+    # access token or the claim never lands.
+    for mapper in body["protocolMappers"]:
+        assert mapper["config"]["access.token.claim"] == "true"
 
 
 @pytest.mark.asyncio
@@ -77,9 +138,7 @@ async def test_create_client_conflict_raises() -> None:
         r.post(f"{_ADMIN_URL}/clients").mock(return_value=httpx.Response(409))
         async with _client() as kc:
             with pytest.raises(KeycloakClientConflictError):
-                await kc.create_client(
-                    client_id="agent:bot", name="bot", tenant_id="t", owner_sub="o"
-                )
+                await _create_bot(kc)
 
 
 @pytest.mark.asyncio
@@ -89,9 +148,7 @@ async def test_create_client_missing_location_raises() -> None:
         r.post(f"{_ADMIN_URL}/clients").mock(return_value=httpx.Response(201))
         async with _client() as kc:
             with pytest.raises(KeycloakAdminError):
-                await kc.create_client(
-                    client_id="agent:bot", name="bot", tenant_id="t", owner_sub="o"
-                )
+                await _create_bot(kc)
 
 
 @pytest.mark.asyncio

--- a/docs/cross-repo/keycloak-agent-client.md
+++ b/docs/cross-repo/keycloak-agent-client.md
@@ -65,18 +65,27 @@ The MEHO backplane reads this claim (default claim name:
 claim default to `PrincipalKind.USER` — all pre-G11.2 human-operator
 tokens continue to work unchanged.
 
-To add `principal_kind=agent` to every token issued for an agent client,
-add a **Hardcoded claim** mapper to the client (or to a client scope):
+`register` provisions this mapper automatically (#1487) — see
+[Token-claim provisioning](#token-claim-provisioning) below; no manual
+Keycloak console step is required.
 
-| Field | Value |
-|-------|-------|
-| Mapper type | `Hardcoded Claim` |
-| Token Claim Name | `principal_kind` |
-| Claim value | `agent` |
-| Claim JSON type | `String` |
-| Add to access token | On |
-| Add to ID token | Off |
-| Add to userinfo | Off |
+### Token-claim provisioning
+
+`register` creates the agent client with the **same** protocol-mapper +
+default-client-scope set the working `meho-backplane` client carries, so
+its `client_credentials` token validates through the backplane's JWT
+chain with no manual Keycloak surgery (#1487). Without these the token
+is rejected fail-closed *before any operation dispatches* — a scheduled
+run dies at JWT verify rather than reaching a parked approval. The
+provisioned set:
+
+| Provisioned on the client | Output claim | Why it is required |
+|---------------------------|--------------|--------------------|
+| `oidc-audience-mapper` (`included.custom.audience` = `KEYCLOAK_AUDIENCE`) | `aud` | Stock Keycloak does **not** honour the RFC 8707 `audience` request param on a `client_credentials` grant without a configured mapper, so requesting the audience at mint time is not enough. A token with no `aud` is rejected `missing_audience` / `invalid_audience`. |
+| `defaultClientScopes: [basic, roles, web-origins, acr]` | `sub` (via `basic`) | Clients created over the Admin REST API do **not** inherit the realm's default scopes; without `basic` the token has no `sub` (Keycloak 25+ moved `sub` into a `basic`-scope mapper) and is rejected `missing_sub`. |
+| `oidc-hardcoded-claim-mapper` → `tenant_id` | `tenant_id` | The Operator chain resolves the agent's tenant scope from this claim; absent → `missing_tenant_claim`. Value = the registering tenant's UUID. |
+| `oidc-hardcoded-claim-mapper` → `tenant_role` | `tenant_role` | Absent → `missing_tenant_role_claim`. Provisioned as `tenant_admin`; the per-principal permission model (G11.2-T3) is the finer-grained gate. |
+| `oidc-hardcoded-claim-mapper` → `principal_kind` | `principal_kind` | Sets `Operator.principal_kind = PrincipalKind.AGENT`. Value = `agent`. |
 
 ## Prerequisites
 
@@ -206,18 +215,22 @@ team responsible for the agent. They can obtain a `client_secret` from
 the **Credentials** tab in the Keycloak Console for client
 `agent:deploy-bot`.
 
-## Step 5 — Add the principal_kind mapper (optional but recommended)
+## Step 5 — Token claims are provisioned automatically (#1487)
 
-To have the agent's access token carry `principal_kind=agent`:
+No manual mapper step is required. `register` creates the agent client
+with the audience mapper, the `tenant_id` / `tenant_role` /
+`principal_kind=agent` hardcoded-claim mappers, and the default client
+scopes that carry `sub` — see
+[Token-claim provisioning](#token-claim-provisioning). Tokens issued for
+`agent:deploy-bot` therefore carry `aud`, `sub`, `tenant_id`,
+`tenant_role` and `principal_kind=agent` out of the box, and a scheduled
+run authenticates through the backplane's JWT chain with no Keycloak
+console edits.
 
-1. **Clients → `agent:deploy-bot` → Client scopes → `agent:deploy-bot`-dedicated**
-2. **Add mapper → By configuration → Hardcoded claim**
-3. Fill in the table from [Principal-kind claim](#principal-kind-claim)
-   above.
-
-Tokens issued for `agent:deploy-bot` will now carry
-`"principal_kind": "agent"` and `Operator.principal_kind` will resolve
-to `PrincipalKind.AGENT` in the backplane.
+> Before #1487 this step was a manual console action and a scheduled
+> agent run died at JWT verify (pre-dispatch) on a client registered
+> purely over the API, because `create_client` provisioned no mappers
+> and no default scopes.
 
 ## Step 6 — Revoke (kill switch)
 


### PR DESCRIPTION
## Summary

- A scheduled run for an agent registered purely over the API died fail-closed at JWT verify (pre-dispatch): `agent_principals.register` created the Keycloak `agent:<name>` client with **no protocol mappers and no default client scopes**, so its `client_credentials` token carried neither `aud`, `sub`, `tenant_id`, nor `tenant_role` and was rejected at `verify_jwt_for_audience` before any operation dispatched. This is the next wall after the #1478 secret-sourcing gap and blocks the autonomous agent→approval loop.
- `keycloak_admin.create_client` now provisions the client with the **same** mapper + scope set the working `meho-backplane` client / the `agent:test-bot` integration realm fixture carry: an `oidc-audience-mapper` stamping `aud=KEYCLOAK_AUDIENCE`, the realm default client scopes (`basic`/`roles`/`web-origins`/`acr`) that carry `sub`, and `oidc-hardcoded-claim` mappers for `tenant_id` / `tenant_role` / `principal_kind=agent`. `register` passes `audience=settings.keycloak_audience` and `tenant_role=tenant_admin`.
- An API-registered agent now authenticates end-to-end with no manual Keycloak surgery.

### Why the mapper/scope set is required (not just an aud mapper)

- Stock Keycloak does **not** honour the RFC 8707 `audience` request param on a `client_credentials` grant without a configured `oidc-audience-mapper` — requesting the audience at mint time is not enough.
- Clients created over the Admin REST `POST /clients` do **not** inherit the realm's default scopes the way the console does; without `basic` the token has no `sub` (Keycloak 25+ moved `sub` into a `basic`-scope mapper), so `defaultClientScopes` must be named explicitly.
- The Operator chain rejects a token missing `tenant_id` (`missing_tenant_claim`) / `tenant_role` (`missing_tenant_role_claim`).

## Test plan

- [x] `ruff check` (changed files) — clean
- [x] `ruff format --check` — clean
- [x] `mypy src/.../auth/{keycloak_admin,agent_principals}.py` — clean
- [x] `pytest tests/test_keycloak_admin.py tests/test_api_v1_agent_principals.py` — 31 passed (new test asserts the created client carries the audience/tenant/principal-kind mappers + the 4 default scopes)
- [x] `pytest -k "agent or keycloak or jwt or operator or scheduler or invocation"` — 1101 passed, 23 skipped (no regression from the signature change)
- [x] `.claude/hooks/code-quality.py --diff` — pass
- [x] **Integration (proof surface):** new `test_register_provisioned_client_authenticates_end_to_end` in `tests/integration/test_auth_keycloak_client_credentials.py` creates an agent client **purely** via `KeycloakAdminClient.create_client` (realm fixture pre-injects **no** mappers for it), mints + verifies its token through the production JWT chain, and decode-asserts `aud`, `sub`, a **fresh-UUID** `tenant_id` (proving the value flows from the `create_client` arg, not a realm constant), `tenant_role`, and `principal_kind=agent`. Skips-in-sandbox (no `MEHO_TEST_KEYCLOAK_IMAGE`); runs in CI where the Harbor-mirror Keycloak image is provisioned.

## Acceptance criteria

- [x] Created client carries an audience mapper (`aud=KEYCLOAK_AUDIENCE`), the default client scopes, and `tenant_id`/`tenant_role` claim mappers — asserted in `test_create_client_provisions_audience_scopes_and_tenant_claims`.
- [x] A scheduled run for an API-registered agent passes `verify_jwt_for_audience` with **no** per-test hand-editing of the agent client's realm entry — the integration test provisions via the Admin API and verifies end-to-end.
- [x] The minted token carries `aud`, `sub`, `tenant_id`, `tenant_role` — decode-asserted on the resulting `Operator`.
- [x] End-to-end: registered → provisioned → authenticated with no `missing_audience` / `invalid_audience` / `missing_*_claim` 401.

## Out of scope

- Agent secret sourcing (pod env vs Vault) — #1478 (merged, upstream of this).
- The plaintext-secret-in-logs leak the same failure exposes — sibling #1488 (touches `scheduler/loop.py`; this change stays in the `auth/` provisioning lane).

<!-- auto-implement-issue: fresh, iteration 1 -->

Closes #1487


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Resolved JWT verification failures for scheduled runs of agents registered via API. Agents now automatically receive required authentication claims.

* **Documentation**
  * Updated guidance to reflect that token-claim provisioning for agents is now automatic, eliminating manual configuration steps.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->