### PR TITLE
fix(redaction): extend _API_KEY label set to cover token/refresh_token/auth_token/session_token/secret_id/private_key (#94)

### DIFF
--- a/backend/src/meho_backplane/redaction/patterns.py
+++ b/backend/src/meho_backplane/redaction/patterns.py
@@ -90,14 +90,37 @@ _JWT = re.compile(
 )
 
 # Generic API keys / secret tokens. This is intentionally narrow: we
-# only match labelled secrets (``api[_-]?key``, ``token``, ``secret``,
-# ``password``) followed by ``=`` / ``:`` / `` `` and a non-trivial
-# value. A naked 40-char base64 string in a paragraph is **not** matched
-# here because the false-positive rate against opaque IDs (Git SHAs,
+# only match labelled secrets followed by ``=`` / ``:`` and a
+# non-trivial value. Covered labels:
+#
+#   ``api[_-]?key``, ``access[_-]?token``, ``refresh[_-]?token``,
+#   ``auth[_-]?token``, ``session[_-]?token``, ``token`` (bare),
+#   ``secret(?:[_-]?(?:key|id))?``, ``private[_-]?key``,
+#   ``password``, ``passwd``, ``pwd``, ``client[_-]?secret``
+#
+# More-specific ``*_token`` / ``secret[_-]?id`` / ``private[_-]?key``
+# members are listed before the broad bare ``token`` member so that the
+# leftmost-first alternation rule does not shadow them (both orders
+# match identically here since the value tail is group 0, but the
+# ordering makes the intent readable).
+#
+# A naked 40-char base64 string in a paragraph is **not** matched
+# because the false-positive rate against opaque IDs (Git SHAs,
 # build hashes, CSP nonces) would be intolerable; downstream Tier-2 NER
 # can take a second pass on free text.
 _API_KEY = re.compile(
-    r"\b(?:api[_-]?key|access[_-]?token|secret(?:[_-]?key)?|password|passwd|pwd|client[_-]?secret)"
+    r"\b(?:"
+    r"api[_-]?key"
+    r"|access[_-]?token"
+    r"|refresh[_-]?token"
+    r"|auth[_-]?token"
+    r"|session[_-]?token"
+    r"|secret(?:[_-]?(?:key|id))?"
+    r"|private[_-]?key"
+    r"|password|passwd|pwd"
+    r"|client[_-]?secret"
+    r"|token"
+    r")"
     r"\s*[=:]\s*['\"]?[A-Za-z0-9._\-+/=]{8,}['\"]?",
     re.IGNORECASE,
 )

--- a/backend/src/meho_backplane/redaction/policies/default.yaml
+++ b/backend/src/meho_backplane/redaction/policies/default.yaml
@@ -47,7 +47,7 @@ rules:
   - name: strip-api-key
     pattern: api_key
     action: redact
-    reason: "labelled credential pair (api_key/token/secret/password)"
+    reason: "labelled credential pair (api_key/token/refresh_token/auth_token/session_token/secret/secret_id/private_key/password/passwd/pwd/client_secret)"
 
   - name: strip-kubeconfig
     pattern: kubeconfig

--- a/backend/src/meho_backplane/redaction/policies/example.yaml
+++ b/backend/src/meho_backplane/redaction/policies/example.yaml
@@ -39,7 +39,7 @@ rules:
   - name: strip-api-key
     pattern: api_key
     action: redact
-    reason: "labelled credential pair (api_key/token/secret/password)"
+    reason: "labelled credential pair (api_key/token/refresh_token/auth_token/session_token/secret/secret_id/private_key/password/passwd/pwd/client_secret)"
 
   - name: strip-kubeconfig
     pattern: kubeconfig

--- a/backend/tests/test_dispatcher_redaction_integration.py
+++ b/backend/tests/test_dispatcher_redaction_integration.py
@@ -213,6 +213,27 @@ async def _handler_returning_bearer_token(
     }
 
 
+async def _handler_returning_refresh_token(
+    operator: Operator,
+    target: Any,
+    params: dict[str, Any],
+) -> dict[str, Any]:
+    """Simulate a connector response that embeds a refresh_token label.
+
+    Mirrors real-world OAuth error bodies (e.g. an ingested OpenAPI connector
+    echoing ``refresh_token: <value>`` in a structured error field) that
+    previously slipped through Tier-1 because the _API_KEY alternation did
+    not cover the bare ``refresh_token`` label.
+    """
+    # Fragments split so gitleaks' generic-api-key scanner does not
+    # false-positive on the test source.
+    raw_value = "rt_abcdefgh" + "ijkl1234"
+    return {
+        "error": "Authorization failed, refresh_token: " + raw_value,
+        "hint": "token expired",
+    }
+
+
 # ---------------------------------------------------------------------------
 # Tests
 # ---------------------------------------------------------------------------
@@ -452,3 +473,73 @@ async def test_default_safe_is_not_pass_through(
     assert result.status == "ok", result.error
     assert "Bearer eyJ" not in str(result.result)
     assert "[REDACTED:" in str(result.result)
+
+
+@pytest.mark.asyncio
+async def test_refresh_token_label_redacted_in_caller_view_raw_retained_in_audit(
+    stub_embedding_service: AsyncMock,
+    captured_events: list[BroadcastEvent],
+) -> None:
+    """Regression: a connector response embedding ``refresh_token: <value>``
+    must be redacted in the caller view AND the raw value must be retained in
+    the audit row with a ``strip-api-key`` manifest entry.
+
+    Acceptance criterion 5 from Task #94: covers one of the six labels that
+    previously slipped through Tier-1 (``refresh_token``); the other five are
+    covered by the unit tests in ``test_redaction_patterns.py``.
+    """
+    raw_value = "rt_abcdefgh" + "ijkl1234"  # same fragment split as the handler
+
+    register_connector_v2(product="vault", version="", impl_id="", cls=_NoOpVaultConnector)
+    await register_typed_operation(
+        product="vault",
+        version="1.x",
+        impl_id="vault",
+        op_id="vault.refresh-token.read",
+        handler=_handler_returning_refresh_token,
+        summary="Read with refresh_token in response.",
+        description="Read.",
+        parameter_schema={"type": "object"},
+        safety_level="safe",
+        when_to_use=None,
+        embedding_service=stub_embedding_service,
+    )
+
+    operator = _make_operator(principal_kind=PrincipalKind.USER)
+    target = _FakeTarget(product="vault")
+
+    result = await dispatch(
+        operator=operator,
+        connector_id="vault-1.x",
+        op_id="vault.refresh-token.read",
+        target=target,
+        params={},
+    )
+
+    # 1) Caller / agent view must not expose the raw token value.
+    assert result.status == "ok", result.error
+    serialised = str(result.result)
+    assert raw_value not in serialised
+    assert "[REDACTED:api_key]" in serialised
+
+    # 2) Audit row keeps the unredacted raw payload.
+    sessionmaker = get_sessionmaker()
+    async with sessionmaker() as fresh:
+        rows = (
+            (
+                await fresh.execute(
+                    select(AuditLog).where(AuditLog.path == "vault.refresh-token.read")
+                )
+            )
+            .scalars()
+            .all()
+        )
+    assert len(rows) == 1
+    row = rows[0]
+    assert row.raw_payload is not None
+    assert raw_value in str(row.raw_payload)
+
+    # 3) Manifest records a strip-api-key firing.
+    assert isinstance(row.redaction_manifest, list)
+    rule_names = {entry["rule"] for entry in row.redaction_manifest}
+    assert "strip-api-key" in rule_names

--- a/backend/tests/test_redaction_patterns.py
+++ b/backend/tests/test_redaction_patterns.py
@@ -50,6 +50,14 @@ _EXPECTED_NAMES = {
 _JWT_FIXTURE_POS = "eyJhbGciOiJIUzI1NiJ9" + "." + "eyJzdWIiOiIxMjM0NTY3ODkwIn0" + "." + "abcdefghij"
 _AUTH_HEADER_FIXTURE = "Authorization: Bearer " + _JWT_FIXTURE_POS
 _CLIENT_SECRET_FIXTURE_POS = "client_secret" + " = " + "ABCDEFGHIJKL" + "12345"
+# New label fixtures for the Task #94 extension. Assembled from fragments
+# for the same gitleaks-avoidance reason as the fixtures above.
+_TOKEN_FIXTURE_POS = "token" + ": " + "ghp_abcdefgh" + "1234"
+_REFRESH_TOKEN_FIXTURE_POS = "refresh_token" + ": " + "rt_abcdefgh" + "1234"
+_AUTH_TOKEN_FIXTURE_POS = "auth_token" + ": " + "at_abcdefgh" + "1234"
+_SESSION_TOKEN_FIXTURE_POS = "session_token" + ": " + "st_abcdefgh" + "1234"
+_SECRET_ID_FIXTURE_POS = "secret_id" + ": " + "11111111-2222" + "-3333-aaaa"
+_PRIVATE_KEY_FIXTURE_POS = "private_key" + ": " + "MIIEvQIBADA" + "NBgkq"
 
 
 def test_catalog_lists_expected_patterns() -> None:
@@ -148,6 +156,43 @@ def test_get_pattern_unknown_raises() -> None:
             "api_key",
             _CLIENT_SECRET_FIXTURE_POS,
             True,
+        ),
+        # api_key: new labels added by Task #94
+        (
+            "api_key",
+            _TOKEN_FIXTURE_POS,
+            True,
+        ),
+        (
+            "api_key",
+            _REFRESH_TOKEN_FIXTURE_POS,
+            True,
+        ),
+        (
+            "api_key",
+            _AUTH_TOKEN_FIXTURE_POS,
+            True,
+        ),
+        (
+            "api_key",
+            _SESSION_TOKEN_FIXTURE_POS,
+            True,
+        ),
+        (
+            "api_key",
+            _SECRET_ID_FIXTURE_POS,
+            True,
+        ),
+        (
+            "api_key",
+            _PRIVATE_KEY_FIXTURE_POS,
+            True,
+        ),
+        # api_key: negative control -- bare ``token`` in free prose must not fire
+        (
+            "api_key",
+            "the token machine is broken",
+            False,
         ),
         # kubeconfig: requires the apiVersion + kind preamble
         (
@@ -260,6 +305,13 @@ _PATTERN_TEST_ROWS: list[tuple[str, str, bool]] = [
     ("api_key", "the resource id is 12345-abcdef", False),
     ("api_key", "password: 's3cr3tValue!'", True),
     ("api_key", _CLIENT_SECRET_FIXTURE_POS, True),
+    ("api_key", _TOKEN_FIXTURE_POS, True),
+    ("api_key", _REFRESH_TOKEN_FIXTURE_POS, True),
+    ("api_key", _AUTH_TOKEN_FIXTURE_POS, True),
+    ("api_key", _SESSION_TOKEN_FIXTURE_POS, True),
+    ("api_key", _SECRET_ID_FIXTURE_POS, True),
+    ("api_key", _PRIVATE_KEY_FIXTURE_POS, True),
+    ("api_key", "the token machine is broken", False),
     ("kubeconfig", "apiVersion: v1\nkind: Config\n", True),
     ("kubeconfig", "apiVersion: v1\nkind: Pod\n", False),
     ("uuid", "tenant_id=12345678-1234-1234-1234-123456789abc", True),

--- a/docs/codebase/redaction.md
+++ b/docs/codebase/redaction.md
@@ -120,7 +120,7 @@ production traffic cannot reach that branch.
 | `authorization_header` | `Authorization: Bearer ...` / `Basic ...` header lines |
 | `bearer_token` | Bare `Bearer <opaque>` outside an Authorization header |
 | `jwt` | `ey<base64url>.<base64url>.<base64url>` three-segment tokens |
-| `api_key` | Labelled credential pairs (`api_key=`, `password:`, `client_secret=`...) |
+| `api_key` | Labelled credential pairs: `api_key`, `access_token`, `refresh_token`, `auth_token`, `session_token`, `token` (bare), `secret` / `secret_key` / `secret_id`, `private_key`, `password`, `passwd`, `pwd`, `client_secret` — each followed by `=` or `:` and an 8+ char value |
 | `kubeconfig` | YAML kubeconfig blobs (`apiVersion: v1` + `kind: Config`) |
 | `uuid` | RFC 4122 canonical 8-4-4-4-12 hex |
 | `ipv4` | Dotted-quad with 0-255 per-octet bounds |


### PR DESCRIPTION
## Summary
- Extends `_API_KEY` label alternation in `patterns.py` with 6 missing labels: `token` (bare), `refresh_token`, `auth_token`, `session_token`, `secret_id`, and `private_key`
- Reconciles the module docstring and both policy YAML `reason` strings with the actual coverage, so the documented set matches the regex and cannot silently drift again
- Adds positive + negative test fixtures in `test_redaction_patterns.py` and an end-to-end caller-redaction + raw-audit-retention test in `test_dispatcher_redaction_integration.py`

## Test plan
- [x] `ruff check` — clean
- [x] `ruff format --check` — clean
- [x] `mypy src/meho_backplane/redaction/` — no issues
- [x] `pytest tests/test_redaction_patterns.py tests/test_dispatcher_redaction_integration.py` — 36 passed
- [x] AC#1: all 6 new labels match (positive control verified with `get_pattern('api_key').search(...)`)
- [x] AC#2: negative control holds — bare `"the token machine is broken"` returns `None`
- [x] AC#3: new alternation members present in patterns.py (verified via grep)
- [x] AC#4: `test_every_pattern_has_both_polarities` passes — both-polarity coverage gate
- [x] AC#5: `test_refresh_token_label_redacted_in_caller_view_and_retained_in_audit_raw` — caller view shows `[REDACTED:api_key]`, raw value absent; `AuditLog.raw_payload` retains unredacted value, manifest records `strip-api-key` firing
- [x] AC#6: YAML reason strings now enumerate full label set

## Out of scope
- MCP `call_operation` outer-envelope broadcast fix → separate Task #93
- Tier-2 NER (Presidio adapter) — unchanged
- Key-aware (struct-key) redaction — engine stays value-content based

<!-- auto-implement-issue: fresh, iteration 1 -->

Closes #94
