### PR TITLE
docs(changelog): roll [Unreleased] → [0.10.1] (G0.19 dogfood hardening + #1475)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -90,8 +90,20 @@ connector-related release-notes line.
 
 ## [Unreleased]
 
+## [0.10.1] - 2026-06-04
+
 ### Fixed
 
+- Connector credential handling: every Vault-sourced credential is now
+  whitespace-stripped before use (a `client_secret` stored with a
+  trailing newline was sent verbatim and rejected by Keycloak as
+  `unauthorized_client`, surfacing only as an opaque `HTTP 401`). A shared
+  `strip_credential_value()` in `_shared/vault_creds.py` is applied at
+  every credential-field extraction path (`load_basic_credentials`
+  consumers — vmware, nsx, harbor, sddc, argocd, vcf — plus the Keycloak
+  admin + GitHub App/PAT loaders), and `KeycloakAdminTokenError` now
+  surfaces the OAuth2 `error`/`error_description` instead of only the HTTP
+  status ([#1475](https://github.com/evoila/meho/issues/1475)).
 - **Security (credential disclosure): a failed scheduled agent run no
   longer writes the agent's `client_credentials` secret into the JSON
   logs.** On the `scheduler_fire_failed` path the secret was held as a


### PR DESCRIPTION
Rolls `[Unreleased]` → `## [0.10.1] - 2026-06-04` for the v0.10.1 patch cut.

## Scope
Patch release — all `### Fixed`, no features or breaking changes. Contents:
- The 8 **G0.19 v0.10.0-dogfood-hardening** fixes (#1478–#1483, #1487, #1488), landed via PRs #1485 / #1486 / #1489 / #1490 / #1491 / #1492 / #1495 / #1496.
- **Backfilled #1475** — connector Vault-credential whitespace strip + Keycloak `error_description` surfacing. It merged *after* the `v0.10.0` tag with no `[Unreleased]` bullet; the completeness audit caught the omission.

## Audit
Completeness audit clean: every PR merged since `v0.10.0` is represented (PRs covered via their issue-number bullets). Deliberately **not** bulleted: #1465 (roadmap-doc reconcile), #1493 (changelog-hygiene chore), #1484 (the G0.19 initiative meta-issue), #1447 (README initiative, shipped pre-`v0.10.0`).

Fresh empty `[Unreleased]` left for the next cut. No version files touched — version lives only in the tag.

⚠️ Do not tag `v0.10.1` until this merges and `main` CI is green.

🤖 Generated with [Claude Code](https://claude.com/claude-code)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Resolved credential whitespace handling issues affecting multiple authentication integrations.
  * Improved Keycloak authentication error messages to include OAuth2 error details for better troubleshooting.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->