### PR TITLE
fix(scheduler): bound run_scheduled's wait so a hung run can't wedge the tick (#1502)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -93,6 +93,15 @@ connector-related release-notes line.
 ### Fixed
 
 - Wire the agent-run lease/heartbeat into the fire path so a hung, crashed, or worker-killed run is reliably reaped to a terminal `failed` state instead of staying `running` forever; the run loop now stamps a lease on start and heartbeats while alive, and child (`invoke_agent`) runs are leased too (#1501).
+- Bound the scheduler tick's wait on a scheduled agent run so a hung or
+  approval-gated run can no longer block later triggers — or strand the
+  process-wide advisory lock — until a pod restart. `run_scheduled` now
+  waits on the run via `asyncio.wait_for(asyncio.shield(task), …)` capped
+  at `AGENT_SYNC_TIMEOUT_SECONDS` (default 30s, mirroring the human
+  `run()` path); a run still executing at the deadline keeps running in
+  the background (`converted_to_async`) while the serial tick returns and
+  releases its advisory lock each cadence
+  ([#1502](https://github.com/evoila/meho/issues/1502)).
 
 ## [0.10.1] - 2026-06-04
 

--- a/backend/src/meho_backplane/agent/invocation.py
+++ b/backend/src/meho_backplane/agent/invocation.py
@@ -117,7 +117,7 @@ from meho_backplane.operations.budget_enforcement import (
     evaluate_pre_run_budget,
 )
 from meho_backplane.operations.identity_budget import TokenUsage
-from meho_backplane.settings import get_settings
+from meho_backplane.settings import Settings, get_settings
 
 __all__ = [
     "AgentDisabledError",
@@ -849,30 +849,22 @@ class AgentInvoker:
             error=view.error,
         )
 
-    async def run_scheduled(
+    async def _authenticate_scheduled_agent(
         self,
         name: str,
-        inputs: str,
         *,
         agent_client_id: str,
         agent_client_secret: SecretStr,
-    ) -> AgentRunOutcome:
-        """Run an agent autonomously under its own ``client_credentials`` identity.
+        settings: Settings,
+    ) -> tuple[Operator, AgentDefinitionRead]:
+        """Authenticate the agent's own identity and resolve its owned definition.
 
-        No human initiator: the agent authenticates as itself via the
-        ``client_credentials`` grant (a single
-        :func:`~meho_backplane.auth.agent_token.get_client_credentials_token`
-        call), so it is the *subject* (``operator_sub``=agent) and there is no
-        separate actor — ``actor_sub`` stays ``NULL`` on every audit row the
-        run produces (this method deliberately does **not** bind
-        :func:`~meho_backplane.auth.delegation.actor_delegation`, unlike the
-        human-initiated :meth:`run`).
-
-        The scheduler that decides *when* to fire a run and supplies the agent
-        credentials (from Vault / config) is G11.3's
-        ``SCHEDULED``-trigger scope; this method is the authentication +
-        audit-shape seam it calls. Blocks until the loop completes (autonomous
-        runs have no client waiting on a sync timeout).
+        Obtains a ``client_credentials`` token for *agent_client_id*, verifies
+        the issued JWT, loads the named definition, and asserts the
+        authenticated client owns it. Returns the verified ``operator`` and the
+        ``entry`` for the caller to launch. Split out of :meth:`run_scheduled`
+        so that method stays focused on the run-lifecycle (create row → launch
+        → bounded wait) rather than the auth-and-bind preamble.
 
         ``agent_client_secret`` is a :class:`~pydantic.SecretStr` so it can
         never be rendered into a log line as a frame local on any exception
@@ -881,10 +873,11 @@ class AgentInvoker:
 
         Raises:
             AgentTokenError: the ``client_credentials`` grant failed.
+            AgentInvocationError: the authenticated client does not own the
+                named definition (cross-agent launch refused).
             AgentNotFoundError / AgentDisabledError: no enabled definition
                 named *name* in the agent's tenant.
         """
-        settings = get_settings()
         # Request the audience we then verify, so the token carries it even on
         # realms without a default audience mapper.
         token = await get_client_credentials_token(
@@ -912,6 +905,79 @@ class AgentInvoker:
                 f"scheduled run rejected: agent credentials for {agent_client_id!r} "
                 f"do not own definition {name!r} (identity_ref={entry.identity_ref!r})"
             )
+        return operator, entry
+
+    async def run_scheduled(
+        self,
+        name: str,
+        inputs: str,
+        *,
+        agent_client_id: str,
+        agent_client_secret: SecretStr,
+    ) -> AgentRunOutcome:
+        """Run an agent autonomously under its own ``client_credentials`` identity.
+
+        No human initiator: the agent authenticates as itself via the
+        ``client_credentials`` grant (a single
+        :func:`~meho_backplane.auth.agent_token.get_client_credentials_token`
+        call), so it is the *subject* (``operator_sub``=agent) and there is no
+        separate actor — ``actor_sub`` stays ``NULL`` on every audit row the
+        run produces (this method deliberately does **not** bind
+        :func:`~meho_backplane.auth.delegation.actor_delegation`, unlike the
+        human-initiated :meth:`run`).
+
+        The scheduler that decides *when* to fire a run and supplies the agent
+        credentials (from Vault / config) is G11.3's
+        ``SCHEDULED``-trigger scope; this method is the authentication +
+        audit-shape seam it calls. The wait on the loop is **bounded** by
+        :attr:`Settings.agent_sync_timeout_seconds` (mirroring :meth:`run`):
+        a run still executing at the deadline keeps going in the background
+        (it is shielded from the wait's cancellation) and the call returns a
+        :class:`AgentRunOutcome` flagged ``converted_to_async``. Without this
+        bound a single hung or approval-gated run would block the serial
+        scheduler tick — and strand the tick's advisory lock — until a pod
+        restart (#1502); the lifecycle/reaper, not this wait, owns reclaiming
+        an abandoned background run.
+
+        Authentication + identity binding (token grant, JWT verify,
+        owns-definition guard) is delegated to
+        :meth:`_authenticate_scheduled_agent`.
+
+        Raises:
+            AgentTokenError: the ``client_credentials`` grant failed.
+            AgentInvocationError: the authenticated client does not own the
+                named definition.
+            AgentNotFoundError / AgentDisabledError: no enabled definition
+                named *name* in the agent's tenant.
+        """
+        settings = get_settings()
+        operator, entry = await self._authenticate_scheduled_agent(
+            name,
+            agent_client_id=agent_client_id,
+            agent_client_secret=agent_client_secret,
+            settings=settings,
+        )
+        return await self._launch_scheduled_run(
+            name, inputs, operator=operator, entry=entry, settings=settings
+        )
+
+    async def _launch_scheduled_run(
+        self,
+        name: str,
+        inputs: str,
+        *,
+        operator: Operator,
+        entry: AgentDefinitionRead,
+        settings: Settings,
+    ) -> AgentRunOutcome:
+        """Budget-gate, persist, launch, and bounded-wait a scheduled run.
+
+        The run-lifecycle half of :meth:`run_scheduled`, kept separate from the
+        auth-and-bind preamble. The wait on the background loop is bounded by
+        ``settings.agent_sync_timeout_seconds``; on timeout the still-running
+        handle is returned (``converted_to_async``) so the serial scheduler tick
+        is not blocked and its advisory lock is released each cadence (#1502).
+        """
         definition = self._to_agent_definition(entry)
         # G11.5-T6 #1080 — same pre-execution gate as :meth:`run`.
         # A scheduler-fired run is the most common cost-runaway shape
@@ -944,7 +1010,27 @@ class AgentInvoker:
             operator_sub=operator.sub,
             tenant_id=str(operator.tenant_id),
         )
-        await task
+        try:
+            # Bound the wait so a hung/approval-gated run cannot block the
+            # serial scheduler tick (and strand its advisory lock) until a
+            # pod restart (#1502). Shield so the timeout abandons the *wait*,
+            # not the run — the loop keeps going in the background and stays
+            # pollable / reapable; the reaper owns reclaiming an abandoned run.
+            await asyncio.wait_for(
+                asyncio.shield(task),
+                timeout=settings.agent_sync_timeout_seconds,
+            )
+        except TimeoutError:
+            _log.info(
+                "agent_scheduled_converted_to_async",
+                run_id=str(run_id),
+                timeout=settings.agent_sync_timeout_seconds,
+            )
+            return AgentRunOutcome(
+                run_id=run_id,
+                status=AgentRunStatus.RUNNING,
+                converted_to_async=True,
+            )
         view = await self.poll(operator, run_id)
         return AgentRunOutcome(
             run_id=run_id,

--- a/backend/src/meho_backplane/scheduler/loop.py
+++ b/backend/src/meho_backplane/scheduler/loop.py
@@ -32,10 +32,16 @@ scheduler. On each cadence (default 30s, settable via
    result means another claimer beat us to it and we skip the fire.
 
 4. **Invoke the agent** through the G11.1-T4
-   :class:`~meho_backplane.agent.invocation.AgentInvoker` in async mode
-   so the scheduler tick returns promptly; the actual agent loop runs
-   as a separate background task in the invoker's run store. The
-   ``agent_run`` row's ``trigger`` column is set to
+   :class:`~meho_backplane.agent.invocation.AgentInvoker` via
+   :meth:`~meho_backplane.agent.invocation.AgentInvoker.run_scheduled`.
+   The actual agent loop runs as a background task in the invoker's run
+   store; ``run_scheduled`` waits on it **bounded** by
+   ``AGENT_SYNC_TIMEOUT_SECONDS`` (default 30s) and, on timeout, returns
+   the still-running handle (``converted_to_async``) while the loop keeps
+   going in the background. This bound is what keeps the serial tick
+   returning promptly — and the advisory lock released each tick — even
+   when a run hangs or blocks on a ``requires_approval`` wait (#1502).
+   The ``agent_run`` row's ``trigger`` column is set to
    ``AgentRunTrigger.SCHEDULED`` for provenance.
 
 5. **Release the advisory lock** in a ``finally`` so a crash mid-tick

--- a/backend/tests/test_agent_invocation.py
+++ b/backend/tests/test_agent_invocation.py
@@ -955,3 +955,80 @@ async def test_run_scheduled_allows_matching_agent_definition(
         )
     # Guard passed — the run row creation was reached.
     create_spy.assert_awaited_once()
+
+
+# ---------------------------------------------------------------------------
+# #1502: run_scheduled bounds its wait so a hung run cannot block the serial
+# scheduler tick (and strand the advisory lock) until a pod restart.
+# ---------------------------------------------------------------------------
+
+
+def _blocking_model(gate: asyncio.Event) -> FunctionModel:
+    """A model whose first turn awaits *gate* — simulates a hung HTTP call."""
+
+    async def fn(messages: list[ModelMessage], info: AgentInfo) -> ModelResponse:
+        await gate.wait()
+        return ModelResponse(parts=[TextPart("eventually")])
+
+    return FunctionModel(fn)
+
+
+async def test_run_scheduled_bounds_wait_and_converts_to_async(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """A scheduled run still executing at the deadline returns a running handle.
+
+    The wait abandons (``converted_to_async``) instead of blocking forever, so
+    the serial scheduler tick can return and release its advisory lock; the
+    background loop keeps running and is later reaped/finalised (#1502).
+    """
+    await _seed_definition(name="reporter")
+    gate = asyncio.Event()
+    invoker = AgentInvoker(runtime=PydanticAgentRun(model_factory=lambda: _blocking_model(gate)))
+
+    # The scheduled path obtains a client_credentials token and verifies the
+    # JWT before launching; stub both seams (no Keycloak in unit tests). The
+    # verified operator must own the seeded ``agent:reporter`` definition.
+    monkeypatch.setattr(
+        "meho_backplane.agent.invocation.get_client_credentials_token",
+        AsyncMock(return_value="agent-token"),
+    )
+    monkeypatch.setattr(
+        "meho_backplane.agent.invocation.verify_jwt_for_audience",
+        AsyncMock(return_value=_make_operator(sub="sa-reporter")),
+    )
+
+    # Drive the bound near zero so the wait abandons deterministically while the
+    # background loop is still parked on the gate — no real long-running call.
+    monkeypatch.setenv("AGENT_SYNC_TIMEOUT_SECONDS", "0.05")
+    get_settings.cache_clear()
+
+    try:
+        outcome = await asyncio.wait_for(
+            invoker.run_scheduled(
+                "reporter",
+                "go",
+                agent_client_id="agent:reporter",
+                agent_client_secret=SecretStr("s3cr3t"),
+            ),
+            # Generous ceiling: the call must return on the 0.05s inner bound,
+            # well under this; exceeding it means run_scheduled blocked on the
+            # still-gated loop — the bug this guards against.
+            timeout=5.0,
+        )
+    finally:
+        # Release the background loop so it finalises cleanly regardless of
+        # outcome (avoids a "Task was destroyed but it is pending" warning).
+        gate.set()
+
+    assert outcome.converted_to_async is True
+    assert outcome.status is AgentRunStatus.RUNNING
+
+    # The abandoned loop keeps running and reaches a terminal state once the
+    # gate is released — the wait was abandoned, not the run.
+    for _ in range(200):
+        view = await invoker.poll(_make_operator(sub="sa-reporter"), outcome.run_id)
+        if view.status is AgentRunStatus.SUCCEEDED:
+            break
+        await asyncio.sleep(0.01)
+    assert view.status is AgentRunStatus.SUCCEEDED

--- a/backend/tests/test_scheduler.py
+++ b/backend/tests/test_scheduler.py
@@ -59,6 +59,7 @@ from meho_backplane.db.engine import get_sessionmaker
 from meho_backplane.db.models import (
     AgentPrincipal,
     AgentRun,
+    AgentRunStatus,
     AgentRunTrigger,
     ScheduledTrigger,
     ScheduledTriggerKind,
@@ -983,3 +984,112 @@ async def test_one_off_scheduler_invoke_refused_on_budget_marks_fired_and_does_n
     async with sessionmaker() as session:
         rows_after = list((await session.execute(select(AgentRun))).scalars().all())
     assert rows_after == []
+
+
+# ---------------------------------------------------------------------------
+# #1502: a blocking run does not stall later triggers in the same tick, and
+# the tick returns promptly so the advisory lock is released each cadence.
+# ---------------------------------------------------------------------------
+
+
+def _first_run_blocks_invoker(gate: asyncio.Event) -> AgentInvoker:
+    """An invoker whose *first* run blocks on *gate*; later runs answer fast.
+
+    ``model_factory`` is invoked once per run (per ``PydanticAgentRun.start``),
+    so a call-count latch makes only the first scheduled run hang — modelling
+    one stuck trigger followed by a healthy one within a single tick.
+    """
+    calls = {"n": 0}
+
+    def factory() -> FunctionModel:
+        calls["n"] += 1
+        if calls["n"] == 1:
+
+            async def blocking(messages: list[ModelMessage], info: AgentInfo) -> ModelResponse:
+                await gate.wait()
+                return ModelResponse(parts=[TextPart("eventually")])
+
+            return FunctionModel(blocking)
+        return _final_text("done")
+
+    return AgentInvoker(runtime=PydanticAgentRun(model_factory=factory))
+
+
+@pytest.mark.asyncio
+async def test_blocking_run_does_not_stall_later_triggers_in_same_tick(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """A hung first run converts-to-async; the second due trigger still fires.
+
+    Two cron triggers are due in the same tick. The first agent run blocks
+    (a hung model call). Before #1502 the bare ``await task`` would hold the
+    serial ``for row in rows`` loop — and the advisory lock — until the run
+    returned (in the realistic case, an approval wait of up to 30 min) or a
+    pod restart. With ``run_scheduled``'s wait bounded by
+    ``AGENT_SYNC_TIMEOUT_SECONDS``, the first run is abandoned to the
+    background and the tick proceeds to fire the second trigger, then returns
+    promptly so the lock is freed each cadence.
+    """
+    agent_id = await _seed_tenant_and_agent()
+    base = datetime(2026, 5, 25, 12, 0, 0, tzinfo=UTC)
+    first = await _create_cron(agent_definition_id=agent_id, base=base)
+    second = await _create_cron(agent_definition_id=agent_id, base=base)
+    # Both overdue so a single tick claims and fires both.
+    await _force_due(first.id, datetime(2026, 1, 1, tzinfo=UTC))
+    await _force_due(second.id, datetime(2026, 1, 1, tzinfo=UTC))
+
+    gate = asyncio.Event()
+    invoker = _first_run_blocks_invoker(gate)
+
+    # Bound the per-run wait low; the tick must return well under the ceiling
+    # even though the first run is still parked on the (never-set-in-tick) gate.
+    # ``run_scheduled`` reads ``get_settings()`` itself, so set the env var and
+    # clear the lru cache (mirrors test_long_sync_run_converts_to_async).
+    monkeypatch.setenv("AGENT_SYNC_TIMEOUT_SECONDS", "0.05")
+    get_settings.cache_clear()
+
+    try:
+        # The whole tick must finish quickly — a regression (bare await) would
+        # hang here until the 5s ceiling trips, failing the test.
+        fires = await asyncio.wait_for(run_one_tick(invoker=invoker), timeout=5.0)
+
+        # Both triggers fired in the one tick despite the first run blocking.
+        assert fires == 2
+
+        # The second (healthy) run reaches a durable row promptly. The first
+        # is still running in the background (parked on the gate), so we assert
+        # at least one run row exists now and the tick already returned.
+        runs = await _wait_for_agent_runs(1, trigger=AgentRunTrigger.SCHEDULED)
+        assert len(runs) >= 1
+
+        # Both cron rows advanced (the fire/advance commit happens before the
+        # bounded wait), so neither is stuck re-claiming on the next tick.
+        for tid in (first.id, second.id):
+            advanced = await _get_trigger(tid)
+            assert advanced.status == ScheduledTriggerStatus.ACTIVE.value
+            next_fire = _aware(advanced.next_fire_at)
+            assert next_fire is not None
+            assert next_fire > datetime(2026, 1, 1, tzinfo=UTC)
+    finally:
+        # Let the abandoned background loop finish so it does not leak a
+        # pending task past the test (clean pytest-asyncio shutdown).
+        gate.set()
+
+    # Both background runs ultimately reach a terminal state — the wait was
+    # abandoned, not the run. Poll the durable rows until both finalise (the
+    # blocked run's row is created RUNNING up front and updated on completion).
+    sessionmaker = get_sessionmaker()
+    deadline = asyncio.get_event_loop().time() + 3.0
+    final_runs: list[AgentRun] = []
+    while asyncio.get_event_loop().time() < deadline:
+        async with sessionmaker() as session:
+            final_runs = list((await session.execute(select(AgentRun))).scalars().all())
+        if len(final_runs) == 2 and all(
+            r.status == AgentRunStatus.SUCCEEDED.value for r in final_runs
+        ):
+            break
+        await asyncio.sleep(0.05)
+    assert len(final_runs) == 2
+    assert all(r.status == AgentRunStatus.SUCCEEDED.value for r in final_runs), [
+        r.status for r in final_runs
+    ]

--- a/docs/codebase/scheduler.md
+++ b/docs/codebase/scheduler.md
@@ -254,9 +254,13 @@ State lives in the `scheduled_trigger` row. On pod restart:
   on the next tick and transitions to `fired`.
 
 The "compute next then fire" discipline (advance BEFORE invoking the
-agent) is what guarantees this: even a slow agent run cannot delay the
-next tick, because `next_fire_at` is already persisted at the next
-scheduled instant by the time the agent run starts.
+agent) is what guarantees single-fire: `next_fire_at` is already
+persisted at the next scheduled instant by the time the agent run
+starts, so a missed/duplicated claim cannot replay it. The wait on
+the agent loop itself is separately bounded inside `run_scheduled`
+(`AGENT_SYNC_TIMEOUT_SECONDS`, default 30 s) so a hung or
+approval-gated run cannot stall later ticks or strand the advisory
+lock — see "Known issues / limitations" (#1502).
 
 ## Dependencies
 
@@ -296,6 +300,17 @@ scheduled instant by the time the agent run starts.
 - **`AgentRunTrigger.SCHEDULED` provenance** — passed through to
   `AgentInvoker.run`'s new `trigger` kwarg. Audit queries that filter by
   trigger see scheduled runs distinctly from direct invocations.
+- **A blocking run is abandoned, not reclaimed, by this loop** (#1502) —
+  `run_scheduled` bounds its wait by `AGENT_SYNC_TIMEOUT_SECONDS`
+  (default 30 s) and, on timeout, returns the still-running handle
+  (`converted_to_async`) while the agent loop keeps running in the
+  background. This is what keeps the serial tick non-blocking and frees
+  the advisory lock each tick even when a run hangs or blocks on a
+  `requires_approval` wait (up to `AGENT_APPROVAL_WAIT_TIMEOUT_SECONDS`,
+  default 30 min). The lock is therefore held at most one bounded wait
+  per blocking run per tick, not for the run's whole lifetime. Driving
+  the abandoned background run to a terminal state (lease/heartbeat
+  reaper) is a separate concern (T1 #1501), not this loop's job.
 - **Pause / resume not exposed yet** — the T5 admin surface ships
   create / list / cancel; pause-then-resume of an active trigger is
   not in v0.2. `ScheduledTriggerStatus.PAUSED` exists in the enum and


### PR DESCRIPTION
## Summary

- **SEV-1 scheduler wedge fix.** A hung / long-running / approval-gated scheduled agent run blocked the entire serial scheduler tick loop and stranded the process-wide advisory lock until a pod restart. Root cause: `run_scheduled` did a bare, unbounded `await task`, while `run_one_tick` releases the advisory lock only in its `finally` — after the serial `for row in rows` loop. A run blocking on an in-process `requires_approval` wait (up to `AGENT_APPROVAL_WAIT_TIMEOUT_SECONDS`, default 30 min) therefore stalled every later tick, and the never-released lock made other replicas skip too.
- **Fix mirrors the human `run()` path.** `run_scheduled` now waits via `asyncio.wait_for(asyncio.shield(task), timeout=agent_sync_timeout_seconds)`. On timeout the *wait* is abandoned (not the run — `shield` keeps the loop running in the background, pollable/reapable) and a `RUNNING` outcome flagged `converted_to_async` is returned, so the tick proceeds to the next due trigger and frees the advisory lock each cadence. Reclaiming the abandoned background run is the reaper's job (T1 #1501), out of scope here.
- **Docstring drift corrected.** The `loop.py` module docstring falsely claimed the invoker runs "in async mode so the scheduler tick returns promptly"; `run_scheduled` has no `async_mode` parameter and awaited to completion. Both the docstring and `docs/codebase/scheduler.md` now describe the bounded wait.
- **Readability:** the auth-and-bind preamble and run-lifecycle epilogue of `run_scheduled` are split into `_authenticate_scheduled_agent` / `_launch_scheduled_run` (behavior-preserving; keeps the method under the size budget).

## Test plan

- [x] `ruff check` / `ruff format --check` — clean on all touched files.
- [x] `mypy` (`invocation.py`, `loop.py`) — clean.
- [x] `code-quality.py --diff` — 0 blockers (remaining warnings are pre-existing file/function-size debt, not introduced here).
- [x] **AC1** — a blocking run no longer prevents subsequent due triggers from firing on the same tick: `tests/test_scheduler.py::test_blocking_run_does_not_stall_later_triggers_in_same_tick` seeds two due cron triggers, blocks the first agent's loop on an `asyncio.Event`, and asserts both fire (`fires == 2`) with both `next_fire_at`s advanced.
- [x] **AC2** — `run_one_tick` returns within a bounded time regardless of an in-flight run's duration: the same test wraps the tick in `asyncio.wait_for(..., timeout=5.0)` (a regression to the bare `await` hangs past the ceiling). `tests/test_agent_invocation.py::test_run_scheduled_bounds_wait_and_converts_to_async` proves the per-run wait is bounded and returns `converted_to_async`. Since the lock is acquired+released inside `run_one_tick`'s session scope, a bounded return implies a bounded lock hold.
- [x] **AC3** — `loop.py` module docstring matches actual behavior (bounded wait, not async mode).
- [x] Full affected suites green: `tests/test_agent_invocation.py` + `tests/test_scheduler.py` — 49 passed. Regression sweep (`test_secret_leak_checks`, `test_agent_approval_resume`, `test_scheduler_credentials`, `test_agent_run_reaper`, `test_api_v1_agent_runs`) — 65 passed.

## Out of scope

- Reclaiming the hung run itself (lease/heartbeat reaper) — separate task **T1 #1501**.
- Changing `agent_approval_wait_timeout_seconds`.
- Pre-existing file/function-size warnings on `invocation.py` / `loop.py` flagged by the quality gate (legacy debt, not touched-symbol scope).

<!-- auto-implement-issue: fresh, iteration 1 -->

Closes #1502


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Scheduled agent runs now respect a bounded wait (default 30s). If exceeded, the run converts to background execution while the scheduler tick completes and releases the advisory lock, preventing later triggers from being stalled.

* **Tests**
  * Added regression tests verifying bounded wait, conversion-to-background behavior, and that subsequent scheduled triggers in the same tick proceed.

* **Documentation**
  * Clarified scheduler docs about the bounded wait, lock release, and the limitation when runs are abandoned to background.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->