### PR TITLE
fix(approvals): execute parked direct op on approve via /decide and MCP (#1503)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -102,6 +102,11 @@ connector-related release-notes line.
   the background (`converted_to_async`) while the serial tick returns and
   releases its advisory lock each cadence
   ([#1502](https://github.com/evoila/meho/issues/1502)).
+- Execute a parked direct operator op when it is approved via `/decide`
+  or the MCP/CLI by-id approve, not only via REST `/approve`: the
+  approval decision now drives the re-dispatch using the params stored on
+  the request at park time, so an approved direct write lands its effect
+  exactly once. Agent-run resume is `run_id`-gated and unchanged (#1503).
 
 ## [0.10.1] - 2026-06-04
 

--- a/backend/alembic/versions/0036_add_approval_request_params.py
+++ b/backend/alembic/versions/0036_add_approval_request_params.py
@@ -1,0 +1,87 @@
+# SPDX-License-Identifier: Apache-2.0
+# Copyright (c) 2026 evoila Group
+
+"""Add ``params`` to ``approval_request`` for direct-op approve re-dispatch.
+
+Revision ID: 0036
+Revises: 0035
+Create Date: 2026-06-04
+
+This migration is the schema substrate of Task #1503 (G0.20-T3) under
+Initiative #1500 (the v0.10.1 closed-loop dogfood hardening). It extends
+the ``approval_request`` table — created by migration
+``0023_create_approval_request`` (G11.2-T4, #817) — with a nullable
+``params`` JSON column.
+
+Why this column
+---------------
+
+A parked **direct** operator op (an operator calling a
+``requires_approval`` op directly, not via an agent run) that is then
+approved through ``/decide`` or the MCP/CLI by-id approve surface was
+never executed: those surfaces hold only the request id, not the
+original params, so they could record the decision but not re-dispatch.
+The only execute-after-approve path was REST ``/approve`` carrying the
+params in-band. Storing the params on the row turns it into a complete
+re-dispatch primitive (it already holds ``connector_id`` / ``op_id`` /
+``target_id``), so any approval surface can drive the post-approval
+re-dispatch with the stored params.
+
+The in-process agent-run resume path is unaffected: it keeps the params
+in memory and re-dispatches from there (the live-wait case), so it never
+reads this column.
+
+What this migration adds
+------------------------
+
+* ``params`` — nullable JSON (PG ``JSONB`` via the ORM ``with_variant``;
+  generic ``sa.JSON`` here so the recorded DDL stays dialect-portable,
+  same discipline as ``0030``'s redaction columns). ``NULL`` = a
+  pre-0036 row with no stored params (those rows predate the feature and
+  can only be resumed via REST ``/approve`` + params, exactly as
+  before). A row written on or after 0036 always carries the params.
+
+Dialect-portability decisions
+-----------------------------
+
+Mirrors the discipline 0001-0035 established:
+
+* ``params`` — nullable JSON, no server default (NULL is the sensible
+  initial value for every existing row). Generic ``sa.JSON`` mirrors
+  ``0030`` (``audit_log.raw_payload`` / ``redaction_manifest``): PG gets
+  the binary ``JSONB`` the ORM pins via ``with_variant``; SQLite gets
+  text JSON.
+
+Reversibility contract
+----------------------
+
+``downgrade()`` drops the column, reversing ``upgrade()``. The CI guard
+inspects only ``upgrade()``; destructive ops in ``downgrade()`` are
+allowed by design.
+"""
+
+from collections.abc import Sequence
+
+import sqlalchemy as sa
+from alembic import op
+
+# revision identifiers, used by Alembic.
+revision: str = "0036"
+down_revision: str | None = "0035"
+branch_labels: str | Sequence[str] | None = None
+depends_on: str | Sequence[str] | None = None
+
+
+def upgrade() -> None:
+    op.add_column(
+        "approval_request",
+        sa.Column(
+            "params",
+            sa.JSON(),
+            nullable=True,
+        ),
+    )
+
+
+def downgrade() -> None:
+    op.drop_column("approval_request", "params")

--- a/backend/src/meho_backplane/api/v1/approvals.py
+++ b/backend/src/meho_backplane/api/v1/approvals.py
@@ -64,7 +64,6 @@ from meho_backplane.auth.operator import Operator, TenantRole
 from meho_backplane.auth.rbac import require_role
 from meho_backplane.db.engine import get_sessionmaker
 from meho_backplane.db.models import ApprovalRequest, ApprovalRequestStatus
-from meho_backplane.operations._errors import result_denied
 from meho_backplane.operations.approval_queue import (
     ApprovalNotFoundError,
     ApprovalRequestAlreadyDecidedError,
@@ -75,8 +74,8 @@ from meho_backplane.operations.approval_queue import (
     get_request,
     publish_approval_event,
     reject_request,
+    resume_dispatch_after_approval,
 )
-from meho_backplane.targets.resolver import resolve_target_by_id
 
 __all__ = ["router"]
 
@@ -195,83 +194,82 @@ async def _resume_dispatch_after_approval(
     *,
     operator: Operator,
     request: ApprovalRequest,
-    params: dict[str, Any],
+    params: dict[str, Any] | None = None,
 ) -> Any:
-    """Re-hydrate the stored target and re-dispatch an approved op (G11.7-T1).
+    """Re-dispatch an approved op via the shared service-layer resume helper.
 
-    The approval row persists only ``target_id``, not the full target
-    object; a write op whose handler reads ``target.host`` /
-    ``target.name`` / ``target.fqdn`` would mis-resolve (or crash) if
-    re-dispatched with ``target=None``. This loads the live ``Target`` by
-    id (tenant-scoped, ``deleted_at IS NULL``) to restore the original
-    dispatch target.
-
-    A target soft-deleted (or otherwise revoked) between request and
-    approval resolves to ``None``. In that case the re-dispatch **fails
-    closed**: it returns a structured ``denied`` :class:`OperationResult`
-    and never calls :func:`dispatch`. Dispatching with ``target=None``
-    would let a typed handler that derives its connection from
-    ``connector_id`` / ``params`` execute an approved privileged write
-    *outside* the original target scope — the approval authorized a call
-    against a specific target, not "whatever the connector defaults to".
-
-    Tenant-wide ops (no original target) keep ``target_id IS NULL`` →
-    ``None`` and dispatch normally; the fail-closed branch fires only when
-    a concrete ``target_id`` was pinned at request time but no longer
-    resolves.
-
-    The re-dispatch bypasses the policy gate (``_approved=True``): the
-    committed approval decision is the authorization. Without the bypass
-    the re-dispatch would re-queue (a human/service principal now routes
-    ``requires_approval`` to ``needs-approval`` per G11.7-T1; an agent
-    re-hits ``needs-approval``), so the approved op would never execute
-    (#817 DoD: "approval runs the original dispatch").
+    Thin REST-side wrapper over
+    :func:`~meho_backplane.operations.approval_queue.resume_dispatch_after_approval`,
+    the single execute-after-approve entry point shared with ``/decide``
+    and the MCP by-id approve tool (#1503). The ``/approve`` route passes
+    the caller-supplied *params* (already hash-verified); ``/decide``
+    passes ``params=None`` and the service helper falls back to the
+    params stored on the row at park time. Target re-hydration + the
+    fail-closed branches (unresolvable target, missing stored params) live
+    in the service helper so every surface shares one behaviour.
     """
-    resolved_target: Any = None
-    if request.target_id is not None:
-        sessionmaker = get_sessionmaker()
+    return await resume_dispatch_after_approval(operator=operator, request=request, params=params)
+
+
+async def _capture_operator_decision(
+    *,
+    request_id: uuid.UUID,
+    decision: str,
+    reason: str,
+    operator: Operator,
+) -> ApprovalRequest:
+    """Commit a ``/decide`` operator decision + publish, mapping errors to HTTP.
+
+    Runs the approve/reject inside one transaction, publishes the
+    fail-open broadcast after commit, and projects the approval-queue
+    exceptions onto the same HTTP status codes the ``/approve`` route
+    uses. Returns the decided :class:`ApprovalRequest` (the caller decides
+    whether to re-dispatch). Extracted so :func:`decide_approval_request`
+    stays under the function-size limit and the exception ladder lives in
+    one place.
+    """
+    sessionmaker = get_sessionmaker()
+    try:
         async with sessionmaker() as session:
-            resolved_target = await resolve_target_by_id(
-                session, operator.tenant_id, request.target_id
-            )
-        if resolved_target is None:
-            # Fail closed: the approval row pinned a concrete target_id, but
-            # no live target resolves it now (soft-deleted between request
-            # and approval, or cross-tenant). Dispatching with target=None
-            # would let a typed handler that derives its connection from
-            # connector_id/params execute an approved privileged write
-            # *outside* the original target scope. Refuse instead — the
-            # approval authorized a call against a target that no longer
-            # exists.
-            _log.warning(
-                "approval_resume_target_unresolvable",
-                approval_request_id=str(request.id),
-                op_id=request.op_id,
-                connector_id=request.connector_id,
-                target_id=str(request.target_id),
-                operator_sub=operator.sub,
-            )
-            return result_denied(
-                request.op_id,
-                (
-                    f"approved target {request.target_id} no longer resolves "
-                    "(soft-deleted or revoked between request and approval); "
-                    "re-dispatch refused to avoid executing outside the "
-                    "original target scope"
-                ),
-                0.0,
-            )
-
-    from meho_backplane.operations.dispatcher import dispatch
-
-    return await dispatch(
-        operator=operator,
-        connector_id=request.connector_id,
-        op_id=request.op_id,
-        target=resolved_target,
-        params=params,
-        _approved=True,
-    )
+            if decision == "approved":
+                request = await approve_request(session, request_id, operator=operator, params=None)
+            else:
+                request = await reject_request(
+                    session, request_id, operator=operator, reason=reason
+                )
+            await session.commit()
+        # Publish AFTER commit (fail-open).
+        await publish_approval_event(
+            tenant_id=operator.tenant_id,
+            request=request,
+            decision=decision,
+            principal_sub=operator.sub,
+            audit_id=request._audit_id,  # type: ignore[attr-defined]
+        )
+    except ApprovalNotFoundError as exc:
+        raise HTTPException(
+            status_code=http_status.HTTP_404_NOT_FOUND,
+            detail="approval_request_not_found",
+        ) from exc
+    except UnauthorizedApprovalError as exc:
+        raise HTTPException(
+            status_code=http_status.HTTP_403_FORBIDDEN,
+            detail="insufficient_role",
+        ) from exc
+    except SelfApprovalForbiddenError as exc:
+        # Same token-prefix + ``str(exc)`` hint as the /approve path so
+        # /decide's self-approval rejection also names the
+        # ``APPROVAL_ALLOW_SELF_APPROVAL`` break-glass flag (#1483).
+        raise HTTPException(
+            status_code=http_status.HTTP_403_FORBIDDEN,
+            detail=f"self_approval_forbidden: {exc}",
+        ) from exc
+    except ApprovalRequestAlreadyDecidedError as exc:
+        raise HTTPException(
+            status_code=http_status.HTTP_409_CONFLICT,
+            detail=f"approval_request_already_{exc.status}",
+        ) from exc
+    return request
 
 
 # ---------------------------------------------------------------------------
@@ -523,11 +521,9 @@ class DecideRequestBody(BaseModel):
     """POST body for ``/decide`` — the operator-decision path.
 
     Distinct from :class:`ApproveRequestBody` (which requires the
-    original ``params`` for the agent / REST re-dispatch path). The
-    operator-decision path captures the decision durably (status flip +
-    decision audit row + ``approval_decided`` broadcast) without
-    re-dispatching — the agent's REST path is what re-dispatches with
-    the params it has.
+    original ``params`` for the REST re-dispatch path): ``/decide``
+    approves by request id alone — the params are read back from the
+    row the dispatcher stored at park time (#1503).
     """
 
     model_config = ConfigDict(extra="forbid")
@@ -542,13 +538,26 @@ class DecideRequestBody(BaseModel):
 
 
 class DecideResponseBody(BaseModel):
-    """Response for a successful operator decision."""
+    """Response for a successful operator decision.
+
+    The ``dispatch_*`` fields are populated only when ``/decide``
+    re-dispatched the approved op — i.e. an approved **direct** operator
+    op (no ``run_id``) whose stored params drove a fresh execution
+    (#1503). They stay ``None`` on a rejection and on an approved
+    **agent-run** request (``run_id`` set), where the in-process agent
+    runtime owns the re-dispatch and ``/decide`` only records the
+    decision (avoiding a double execution).
+    """
 
     model_config = ConfigDict(frozen=True)
 
     approval_request_id: uuid.UUID
     decision: str
     reason: str
+    dispatch_status: str | None = None
+    dispatch_op_id: str | None = None
+    dispatch_result: dict[str, Any] | list[Any] | None = None
+    dispatch_error: str | None = None
 
 
 @router.post(
@@ -560,14 +569,26 @@ async def decide_approval_request(
     body: DecideRequestBody,
     operator: Operator = _require_operator,
 ) -> DecideResponseBody:
-    """Capture an operator decision without re-dispatching (G11.2-T5).
+    """Capture an operator decision, re-dispatching a direct op (G11.2-T5, #1503).
 
     Flips the request to ``approved`` or ``rejected``, writes the
     decision audit row, and publishes the ``approval.{approved,rejected}``
-    broadcast event. **Does not** re-dispatch the original op — that is
-    the agent's path (``POST .../approve`` with ``params``, which uses
-    the ``_approved`` gate-bypass). Backs the CLI/MCP operator-decision
-    flow where the operator approves by id alone.
+    broadcast event. Backs the CLI/MCP operator-decision flow where the
+    operator approves by id alone.
+
+    On **approval of a direct operator op** (``run_id IS NULL``), the
+    decision then drives a re-dispatch using the params stored on the row
+    at park time (#1503) — so a parked direct write approved here lands
+    its effect exactly once, rather than being silently re-parked on the
+    next call. The request is already in a terminal ``approved`` state
+    before the re-dispatch, so a concurrent second decide hits the
+    already-decided guard (409) and cannot double-execute.
+
+    On approval of an **agent-run** request (``run_id`` set), ``/decide``
+    records the decision only and does **not** re-dispatch: the
+    in-process agent runtime awaits the ``approval.approved`` broadcast
+    and re-dispatches from its own in-memory params (the must-not-regress
+    path). Re-dispatching here too would execute the op twice.
     """
     structlog.contextvars.bind_contextvars(
         audit_op_id="approval.decide",
@@ -581,55 +602,39 @@ async def decide_approval_request(
             detail=f"decision must be 'approved' or 'rejected', got {body.decision!r}",
         )
 
-    sessionmaker = get_sessionmaker()
-    try:
-        async with sessionmaker() as session:
-            if decision == "approved":
-                request = await approve_request(
-                    session,
-                    request_id,
-                    operator=operator,
-                    params=None,
-                )
-            else:
-                request = await reject_request(
-                    session,
-                    request_id,
-                    operator=operator,
-                    reason=body.reason,
-                )
-            await session.commit()
-        # Publish AFTER commit (fail-open).
-        await publish_approval_event(
-            tenant_id=operator.tenant_id,
-            request=request,
-            decision=decision,
-            principal_sub=operator.sub,
-            audit_id=request._audit_id,  # type: ignore[attr-defined]
+    request = await _capture_operator_decision(
+        request_id=request_id,
+        decision=decision,
+        reason=body.reason,
+        operator=operator,
+    )
+
+    # Direct operator op (no agent run): the decision drives the execute
+    # (#1503). Stored params re-hydrate the dispatch; the committed
+    # approval is the authorization (``_approved=True``). Agent-run
+    # requests (run_id set) are resumed by the in-process agent runtime
+    # off the broadcast — re-dispatching here would double-execute.
+    if decision == "approved" and request.run_id is None:
+        dispatch_result = await _resume_dispatch_after_approval(
+            operator=operator, request=request, params=None
         )
-    except ApprovalNotFoundError as exc:
-        raise HTTPException(
-            status_code=http_status.HTTP_404_NOT_FOUND,
-            detail="approval_request_not_found",
-        ) from exc
-    except UnauthorizedApprovalError as exc:
-        raise HTTPException(
-            status_code=http_status.HTTP_403_FORBIDDEN,
-            detail="insufficient_role",
-        ) from exc
-    except SelfApprovalForbiddenError as exc:
-        # Same token-prefix + ``str(exc)`` hint as the /approve path
-        # so /decide's self-approval rejection also names the
-        # ``APPROVAL_ALLOW_SELF_APPROVAL`` break-glass flag (#1483).
-        raise HTTPException(
-            status_code=http_status.HTTP_403_FORBIDDEN,
-            detail=f"self_approval_forbidden: {exc}",
-        ) from exc
-    except ApprovalRequestAlreadyDecidedError as exc:
-        raise HTTPException(
-            status_code=http_status.HTTP_409_CONFLICT,
-            detail=f"approval_request_already_{exc.status}",
-        ) from exc
+        _log.info(
+            "approval_request_redispatched",
+            approval_request_id=str(request_id),
+            op_id=request.op_id,
+            dispatch_status=dispatch_result.status,
+            operator_sub=operator.sub,
+            via="decide",
+        )
+        return DecideResponseBody(
+            approval_request_id=request_id,
+            decision=decision,
+            reason=body.reason,
+            dispatch_status=dispatch_result.status,
+            dispatch_op_id=dispatch_result.op_id,
+            dispatch_result=dispatch_result.result,
+            dispatch_error=dispatch_result.error,
+        )
 
     return DecideResponseBody(
         approval_request_id=request_id,

--- a/backend/src/meho_backplane/db/models.py
+++ b/backend/src/meho_backplane/db/models.py
@@ -3815,8 +3815,17 @@ class ApprovalRequest(Base):
 
     * ``params_hash`` -- SHA-256 hex hash of the canonicalised params
       (from :func:`~meho_backplane.operations._validate.compute_params_hash`).
-      Does not persist the params themselves; the resume endpoint
-      re-hashes its params against this value to detect substitution.
+      The swap-defence value: a caller-supplied params dict on the REST
+      ``/approve`` path is re-hashed against this to detect substitution
+      between request and approval.
+
+    * ``params`` -- JSON nullable (JSONB on PG). The original dispatch
+      params, stored verbatim (#1503) so a parked **direct** operator op
+      approved via ``/decide`` or MCP by-id — surfaces that hold only the
+      request id, not the params — can re-dispatch with the stored params
+      rather than only recording the decision. Nullable so pre-0036 rows
+      remain valid. Internal re-dispatch input; never serialised onto a
+      read view or broadcast frame.
 
     * ``proposed_effect`` -- JSON (JSONB on PG). Human-readable summary of
       what the op would do if approved; populated at queue time; JSONB for
@@ -3868,6 +3877,21 @@ class ApprovalRequest(Base):
     connector_id: Mapped[str] = mapped_column(Text, nullable=False)
     target_id: Mapped[uuid.UUID | None] = mapped_column(Uuid(), nullable=True, default=None)
     params_hash: Mapped[str] = mapped_column(Text, nullable=False)
+    # Original dispatch params, stored verbatim so any approval surface
+    # (REST /decide, MCP by-id approve) can re-dispatch a parked *direct*
+    # operator op without the approver re-supplying them (#1503). REST
+    # /approve still supplies them in-band and verifies them against
+    # params_hash; the in-process agent-run resume uses its own in-memory
+    # params and ignores this column. Nullable so pre-0036 rows (which
+    # have no stored params) stay valid; a row written on or after 0036
+    # always carries the params. Internal re-dispatch input only -- never
+    # surfaced on a read view or broadcast frame (the swap-defence hash
+    # and the redacted proposed_effect remain the reviewer-facing fields).
+    params: Mapped[dict[str, object] | None] = mapped_column(
+        _PORTABLE_JSON,
+        nullable=True,
+        default=None,
+    )
     # Proposed effect -- human-readable summary for the reviewer.
     proposed_effect: Mapped[dict[str, object]] = mapped_column(
         _PORTABLE_JSON,

--- a/backend/src/meho_backplane/mcp/tools/approvals.py
+++ b/backend/src/meho_backplane/mcp/tools/approvals.py
@@ -72,6 +72,7 @@ from meho_backplane.operations.approval_queue import (
     list_pending,
     publish_approval_event,
     reject_request,
+    resume_dispatch_after_approval,
 )
 
 _log = structlog.get_logger(__name__)
@@ -350,8 +351,8 @@ async def _approve_handler(
         try:
             # Operator-decision path: no params supplied → approve_request
             # skips the hash check and just flips status + writes the
-            # decision audit row + publishes the approval_decided event.
-            # The agent's REST path (with params) is what re-dispatches.
+            # decision audit row. The params for the re-dispatch are read
+            # back from the row (stored at park time, #1503).
             row = await approve_request(
                 session,
                 request_id,
@@ -385,23 +386,54 @@ async def _approve_handler(
         principal_sub=operator.sub,
         audit_id=row._audit_id,  # type: ignore[attr-defined]
     )
-    return _row_to_dict(row)
+
+    result = _row_to_dict(row)
+
+    # Direct operator op (no agent run): the approve drives the execute
+    # (#1503). The committed approval is the authorization; the stored
+    # params re-hydrate the dispatch. Agent-run requests (run_id set) are
+    # resumed in-process by the agent runtime off the approval.approved
+    # broadcast — re-dispatching here too would double-execute, so this
+    # MCP tool only records the decision for them (its historical shape).
+    if row.run_id is None:
+        dispatch_result = await resume_dispatch_after_approval(
+            operator=operator, request=row, params=None
+        )
+        _log.info(
+            "approval_request_redispatched",
+            approval_request_id=str(request_id),
+            op_id=row.op_id,
+            dispatch_status=dispatch_result.status,
+            operator_sub=operator.sub,
+            via="mcp",
+        )
+        result["dispatch"] = {
+            "status": dispatch_result.status,
+            "op_id": dispatch_result.op_id,
+            "result": dispatch_result.result,
+            "error": dispatch_result.error,
+        }
+
+    return result
 
 
 register_mcp_tool(
     definition=ToolDefinition(
         name="meho.approvals.approve",
         description=(
-            "Approve a pending approval request (G11.2-T5 / #818). "
+            "Approve a pending approval request (G11.2-T5 / #818; #1503). "
             "Operator-level. Flips the request to 'approved', writes the "
             "decision audit row, and announces approval_decided on the "
-            "broadcast feed. The agent's REST resume path is what "
-            "re-dispatches the approved op (with the params it has + the "
-            "_approved gate-bypass) — this MCP tool captures the operator "
-            "decision durably. Only pending requests may be approved; any "
-            "other status returns approval_request_not_pending. Pass "
-            "either `approval_request_id` (canonical name; G0.18-T5 "
-            "#1358) or the deprecated `id` alias."
+            "broadcast feed. For a direct operator op (no agent run) the "
+            "approve then re-dispatches the op using the params stored at "
+            "park time, so the approved write lands exactly once; the "
+            "dispatch outcome is returned under `dispatch`. For an "
+            "agent-run request the in-process agent runtime resumes the "
+            "op off the broadcast, so this tool only records the decision. "
+            "Only pending requests may be approved; any other status "
+            "returns approval_request_not_pending. Pass either "
+            "`approval_request_id` (canonical name; G0.18-T5 #1358) or the "
+            "deprecated `id` alias."
         ),
         inputSchema={
             "type": "object",

--- a/backend/src/meho_backplane/operations/approval_queue.py
+++ b/backend/src/meho_backplane/operations/approval_queue.py
@@ -73,6 +73,7 @@ from meho_backplane.db.models import (
     ApprovalRequestStatus,
     AuditLog,
 )
+from meho_backplane.operations._errors import result_denied
 from meho_backplane.operations._validate import compute_params_hash
 
 __all__ = [
@@ -89,6 +90,7 @@ __all__ = [
     "list_pending",
     "publish_approval_event",
     "reject_request",
+    "resume_dispatch_after_approval",
 ]
 
 _log = structlog.get_logger(__name__)
@@ -276,8 +278,10 @@ async def create_pending_request(
         op_id: The operation id.
         target: The dispatch target (or ``None`` for tenant-wide ops).
             ``target.id`` is extracted when present.
-        params: The original dispatch params. Used to verify hash
-            consistency; not stored on the row.
+        params: The original dispatch params. Stored verbatim on the row
+            (#1503) so any approval surface (REST ``/decide``, MCP by-id
+            approve) can re-dispatch a parked direct operator op with the
+            stored params, and also used to verify hash consistency.
         params_hash: Pre-computed
             :func:`~meho_backplane.operations._validate.compute_params_hash`
             of *params*. Stored for resume-path verification.
@@ -323,6 +327,7 @@ async def create_pending_request(
         connector_id=connector_id,
         target_id=target_id,
         params_hash=params_hash,
+        params=params,
         proposed_effect=proposed_effect,
         status=ApprovalRequestStatus.PENDING.value,
         created_at=_now(),
@@ -524,6 +529,140 @@ async def reject_request(
     )
     request._audit_id = reject_audit_id  # type: ignore[attr-defined]
     return request
+
+
+async def resume_dispatch_after_approval(
+    *,
+    operator: Operator,
+    request: ApprovalRequest,
+    params: dict[str, Any] | None = None,
+) -> Any:
+    """Re-hydrate the stored target and re-dispatch an approved op (#1503, G11.7-T1).
+
+    The single execute-after-approve entry point shared by every operator
+    approval surface — REST ``/approve`` and ``/decide``, and the MCP
+    by-id approve tool. It re-runs the original dispatch under the
+    committed approval decision (``dispatch(..., _approved=True)``), so a
+    parked **direct** operator op is executed exactly once regardless of
+    which surface granted it. The in-process agent-run resume path does
+    not call this — it keeps the params in memory and re-dispatches from
+    there (see :mod:`meho_backplane.agent.approval_wait`).
+
+    *params* source:
+
+    * REST ``/approve`` passes the caller-supplied params (already
+      hash-verified against ``params_hash`` by :func:`approve_request`).
+    * ``/decide`` and the MCP by-id approve hold only the request id, so
+      they pass ``params=None`` and this helper falls back to the params
+      stored on the row at park time (``request.params``, #1503). A row
+      written before migration 0036 has ``params IS NULL`` and no
+      caller-supplied params — there is nothing to re-dispatch, so the
+      helper **fails closed** with a structured ``denied`` result naming
+      the gap (the op must be resumed via REST ``/approve`` + params, the
+      pre-0036 path).
+
+    Target re-hydration (G11.7-T1 #1401): the row persists only
+    ``target_id``, not the full target. A write op whose handler reads
+    ``target.host`` / ``target.name`` would mis-resolve (or crash) if
+    re-dispatched with ``target=None``, so a concrete ``target_id`` is
+    re-loaded by id (tenant-scoped, ``deleted_at IS NULL``). A target
+    soft-deleted (or revoked) between request and approval resolves to
+    ``None``; the re-dispatch then **fails closed** (structured ``denied``,
+    never calls :func:`dispatch`) rather than executing the approved
+    privileged write outside the original target scope. Tenant-wide ops
+    (no original target) keep ``target_id IS NULL`` → ``None`` and
+    dispatch normally.
+
+    The re-dispatch bypasses the policy gate (``_approved=True``): the
+    committed approval decision is the authorization. Without the bypass
+    the re-dispatch would re-queue (a human/service principal now routes
+    ``requires_approval`` to ``needs-approval`` per G11.7-T1; an agent
+    re-hits ``needs-approval``), so the approved op would never execute.
+    """
+    effective_params = params if params is not None else request.params
+    if effective_params is None:
+        # Pre-0036 row (params not stored) approved via a surface that
+        # carries no params (/decide, MCP by-id). Nothing to re-dispatch.
+        _log.warning(
+            "approval_resume_params_unavailable",
+            approval_request_id=str(request.id),
+            op_id=request.op_id,
+            connector_id=request.connector_id,
+            operator_sub=operator.sub,
+        )
+        return result_denied(
+            request.op_id,
+            (
+                f"approval request {request.id} has no stored params "
+                "(parked before migration 0036); re-dispatch refused — "
+                "approve via REST /approve with the original params instead"
+            ),
+            0.0,
+        )
+
+    resolved_target, denied = await _rehydrate_resume_target(operator, request)
+    if denied is not None:
+        return denied
+
+    from meho_backplane.operations.dispatcher import dispatch
+
+    return await dispatch(
+        operator=operator,
+        connector_id=request.connector_id,
+        op_id=request.op_id,
+        target=resolved_target,
+        params=effective_params,
+        _approved=True,
+    )
+
+
+async def _rehydrate_resume_target(
+    operator: Operator,
+    request: ApprovalRequest,
+) -> tuple[Any, Any]:
+    """Re-load the stored target by id for a resume re-dispatch (G11.7-T1 #1401).
+
+    Returns ``(resolved_target, None)`` on success — ``resolved_target``
+    is ``None`` for a tenant-wide op (no ``target_id`` pinned) and the
+    live :class:`Target` otherwise. Returns ``(None, denied_result)`` when
+    a concrete ``target_id`` was pinned at request time but no live target
+    resolves it now (soft-deleted / revoked between request and approval,
+    or cross-tenant): the caller must **fail closed** and not dispatch,
+    since dispatching with ``target=None`` would let a typed handler that
+    derives its connection from ``connector_id`` / ``params`` execute the
+    approved privileged write outside the original target scope.
+    """
+    if request.target_id is None:
+        return None, None
+
+    from meho_backplane.db.engine import get_sessionmaker
+    from meho_backplane.targets.resolver import resolve_target_by_id
+
+    sessionmaker = get_sessionmaker()
+    async with sessionmaker() as session:
+        resolved_target = await resolve_target_by_id(session, operator.tenant_id, request.target_id)
+    if resolved_target is not None:
+        return resolved_target, None
+
+    _log.warning(
+        "approval_resume_target_unresolvable",
+        approval_request_id=str(request.id),
+        op_id=request.op_id,
+        connector_id=request.connector_id,
+        target_id=str(request.target_id),
+        operator_sub=operator.sub,
+    )
+    denied = result_denied(
+        request.op_id,
+        (
+            f"approved target {request.target_id} no longer resolves "
+            "(soft-deleted or revoked between request and approval); "
+            "re-dispatch refused to avoid executing outside the "
+            "original target scope"
+        ),
+        0.0,
+    )
+    return None, denied
 
 
 async def expire_stale_requests(

--- a/backend/tests/test_api_v1_approvals.py
+++ b/backend/tests/test_api_v1_approvals.py
@@ -195,20 +195,25 @@ async def test_resume_refuses_when_pinned_target_no_longer_resolves(
         principal_kind=PrincipalKind.USER,
     )
     # Minimal stand-in for the ApprovalRequest ORM row: the resume helper
-    # only reads id / target_id / op_id / connector_id off it.
+    # reads id / target_id / op_id / connector_id / params off it.
     request = SimpleNamespace(
         id=uuid.uuid4(),
         target_id=target_id,
         op_id="vault.kv.put",
         connector_id="vault-1.x",
+        params={"path": "secret/x", "value": "s3cr3t"},
     )
 
     # The pinned target no longer resolves (soft-deleted between request
-    # and approval).
+    # and approval). The resume helper (now in the service layer) imports
+    # ``resolve_target_by_id`` lazily from ``targets.resolver``, so patch
+    # it at its source module.
+    import meho_backplane.targets.resolver as resolver_module
+
     async def _resolve_none(*_a: object, **_kw: object) -> None:
         return None
 
-    monkeypatch.setattr(approvals_module, "resolve_target_by_id", _resolve_none)
+    monkeypatch.setattr(resolver_module, "resolve_target_by_id", _resolve_none)
 
     # Spy on dispatch — it must NOT be reached on the fail-closed path.
     dispatch_calls: list[dict[str, Any]] = []
@@ -260,6 +265,7 @@ async def test_resume_dispatches_when_no_target_was_pinned(
         target_id=None,
         op_id="some.tenant_wide.op",
         connector_id="some-1.x",
+        params={"k": "v"},
     )
 
     seen: dict[str, Any] = {}

--- a/backend/tests/test_approval_queue.py
+++ b/backend/tests/test_approval_queue.py
@@ -82,6 +82,24 @@ async def _approval_test_dangerous_handler(
     return {"executed": True}
 
 
+#: Records each execution of ``_approval_test_recording_handler`` so a
+#: test can assert the approved op ran exactly once (#1503). Reset at the
+#: top of every test that uses it.
+_RECORDED_EXECUTIONS: list[dict[str, Any]] = []
+
+
+async def _approval_test_recording_handler(
+    operator: Operator, target: Any, params: dict[str, Any]
+) -> dict[str, Any]:
+    """Append each call to ``_RECORDED_EXECUTIONS`` and echo the params (#1503).
+
+    Lets a test prove a parked direct op approved via ``/decide`` or MCP
+    by-id re-dispatched with the stored params and executed exactly once.
+    """
+    _RECORDED_EXECUTIONS.append({"params": params})
+    return {"executed": True, "params": params}
+
+
 async def _approval_test_target_reading_handler(
     operator: Operator, target: Any, params: dict[str, Any]
 ) -> dict[str, Any]:
@@ -1454,6 +1472,265 @@ async def test_pause_reject_abort(
     assert len(dec_rows) == 1
     assert dec_rows[0].payload["decision"] == "rejected"
     assert dec_rows[0].payload["reason"] == "too risky"
+
+    reset_dispatcher_caches()
+    clear_registry()
+
+
+# ---------------------------------------------------------------------------
+# #1503 — parked direct operator op approved via /decide or MCP by-id is
+# re-dispatched using the stored params (execute-after-approve on every
+# surface, not only REST /approve). Must NOT double-execute an agent-run
+# request (the in-process agent runtime resumes those off the broadcast).
+# ---------------------------------------------------------------------------
+
+
+async def _register_recording_requires_approval_op(monkeypatch: pytest.MonkeyPatch) -> None:
+    """Register a ``requires_approval`` typed op backed by the recording handler.
+
+    Shared setup for the #1503 surface tests: a clean registry, a stubbed
+    broadcast publisher, and one ``rectest.write`` op whose handler appends
+    to ``_RECORDED_EXECUTIONS`` so a test can assert the approved op ran
+    exactly once.
+    """
+    from unittest.mock import AsyncMock
+
+    import meho_backplane.operations._audit as audit_module
+    from meho_backplane.connectors.base import Connector
+    from meho_backplane.connectors.registry import register_connector_v2
+    from meho_backplane.connectors.schemas import FingerprintResult, ProbeResult
+    from meho_backplane.operations import register_typed_operation
+
+    async def _capture(event: Any) -> None:
+        pass
+
+    monkeypatch.setattr(audit_module, "publish_event", _capture)
+
+    class _RecConnector(Connector):
+        product = "rectest"
+        version = "1.x"
+        impl_id = "rectest"
+        priority = 10
+
+        async def fingerprint(self, host: str, port: int | None) -> FingerprintResult:
+            return FingerprintResult(
+                probe=ProbeResult(reachable=True, probe_method="none"),
+                product="rectest",
+                version="1.x",
+            )
+
+        async def probe(self, target: Any) -> ProbeResult:  # type: ignore[override]
+            raise NotImplementedError
+
+        async def execute(  # type: ignore[override]
+            self, target: Any, op_id: str, params: dict[str, Any]
+        ) -> Any:
+            raise NotImplementedError
+
+    register_connector_v2(product="rectest", version="", impl_id="", cls=_RecConnector)
+
+    stub_emb = AsyncMock()
+    stub_emb.encode_one.return_value = [0.1] * 384
+    stub_emb.encode.return_value = [[0.1] * 384]
+    stub_emb.dimension = 384
+
+    await register_typed_operation(
+        product="rectest",
+        version="1.x",
+        impl_id="rectest",
+        op_id="rectest.write",
+        handler=_approval_test_recording_handler,
+        summary="Direct write op requiring approval.",
+        description="Test.",
+        parameter_schema={"type": "object"},
+        requires_approval=True,
+        when_to_use=None,
+        embedding_service=stub_emb,
+    )
+
+
+@pytest.mark.asyncio
+async def test_decide_approve_redispatches_direct_op_with_stored_params(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """A parked direct op approved via ``/decide`` executes once (#1503, AC1+AC2).
+
+    1. A human operator dispatches a ``requires_approval`` op directly →
+       parked (``awaiting_approval``); the row stores the original params.
+    2. A distinct operator approves via the ``/decide`` REST route (by id
+       alone, no params in-band).
+    3. ``/decide`` re-dispatches using the **stored** params → the handler
+       runs exactly once and the response carries the dispatch outcome.
+    """
+    from meho_backplane.api.v1.approvals import DecideRequestBody, decide_approval_request
+    from meho_backplane.connectors.registry import clear_registry
+    from meho_backplane.operations import dispatch, reset_dispatcher_caches
+
+    monkeypatch.setenv("KEYCLOAK_ISSUER_URL", "https://keycloak.test/realms/meho")
+    monkeypatch.setenv("KEYCLOAK_AUDIENCE", "meho-backplane")
+    monkeypatch.setenv("VAULT_ADDR", "https://vault.test")
+    get_settings.cache_clear()
+
+    _RECORDED_EXECUTIONS.clear()
+    reset_dispatcher_caches()
+    clear_registry()
+    await _register_recording_requires_approval_op(monkeypatch)
+
+    requester = _make_operator(sub="ops-human", principal_kind=PrincipalKind.USER)
+    params = {"path": "secret/db", "value": "s3cr3t"}
+
+    # Step 1: direct dispatch → parked.
+    result1 = await dispatch(
+        operator=requester,
+        connector_id="rectest-1.x",
+        op_id="rectest.write",
+        target=None,
+        params=params,
+    )
+    assert result1.status == "awaiting_approval", result1.error
+    approval_request_id = uuid.UUID(result1.extras["approval_request_id"])
+    assert _RECORDED_EXECUTIONS == [], "op must not run while parked"
+
+    # The row persisted the original params + has no run_id (direct op).
+    async with get_sessionmaker()() as s:
+        pending = await s.get(ApprovalRequest, approval_request_id)
+        assert pending is not None
+        assert pending.run_id is None
+        assert pending.params == params
+
+    # Step 2+3: a distinct operator decides "approved" via /decide.
+    reviewer = _make_operator(sub="ops-reviewer", principal_kind=PrincipalKind.USER)
+    response = await decide_approval_request(
+        approval_request_id,
+        DecideRequestBody(decision="approved"),
+        operator=reviewer,
+    )
+
+    assert response.decision == "approved"
+    assert response.dispatch_status == "ok", response.dispatch_error
+    assert response.dispatch_op_id == "rectest.write"
+    # Executed exactly once, with the stored params (not re-supplied).
+    assert len(_RECORDED_EXECUTIONS) == 1
+    assert _RECORDED_EXECUTIONS[0]["params"] == params
+
+    # The row is terminal (approved) — a second decide cannot double-execute.
+    async with get_sessionmaker()() as s:
+        decided = await s.get(ApprovalRequest, approval_request_id)
+        assert decided is not None
+        assert decided.status == ApprovalRequestStatus.APPROVED.value
+
+    reset_dispatcher_caches()
+    clear_registry()
+
+
+@pytest.mark.asyncio
+async def test_mcp_approve_redispatches_direct_op_with_stored_params(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """A parked direct op approved via MCP by-id executes once (#1503, AC1).
+
+    Mirrors the ``/decide`` test for the MCP ``meho.approvals.approve``
+    surface: approve by id alone → the handler re-dispatches with the
+    stored params, runs once, and returns the dispatch outcome under
+    ``dispatch``.
+    """
+    from meho_backplane.connectors.registry import clear_registry
+    from meho_backplane.mcp.tools.approvals import _approve_handler
+    from meho_backplane.operations import dispatch, reset_dispatcher_caches
+
+    monkeypatch.setenv("KEYCLOAK_ISSUER_URL", "https://keycloak.test/realms/meho")
+    monkeypatch.setenv("KEYCLOAK_AUDIENCE", "meho-backplane")
+    monkeypatch.setenv("VAULT_ADDR", "https://vault.test")
+    get_settings.cache_clear()
+
+    _RECORDED_EXECUTIONS.clear()
+    reset_dispatcher_caches()
+    clear_registry()
+    await _register_recording_requires_approval_op(monkeypatch)
+
+    requester = _make_operator(sub="ops-human", principal_kind=PrincipalKind.USER)
+    params = {"path": "secret/api", "value": "tok-123"}
+
+    result1 = await dispatch(
+        operator=requester,
+        connector_id="rectest-1.x",
+        op_id="rectest.write",
+        target=None,
+        params=params,
+    )
+    assert result1.status == "awaiting_approval", result1.error
+    approval_request_id = uuid.UUID(result1.extras["approval_request_id"])
+
+    reviewer = _make_operator(sub="ops-reviewer", principal_kind=PrincipalKind.USER)
+    out = await _approve_handler(reviewer, {"approval_request_id": str(approval_request_id)})
+
+    assert out["status"] == ApprovalRequestStatus.APPROVED.value
+    assert out["dispatch"]["status"] == "ok", out["dispatch"]["error"]
+    assert out["dispatch"]["op_id"] == "rectest.write"
+    assert len(_RECORDED_EXECUTIONS) == 1
+    assert _RECORDED_EXECUTIONS[0]["params"] == params
+
+    reset_dispatcher_caches()
+    clear_registry()
+
+
+@pytest.mark.asyncio
+async def test_decide_approve_does_not_redispatch_agent_run_request(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """An agent-run request approved via ``/decide`` is NOT re-dispatched (#1503, AC3).
+
+    The in-process agent runtime resumes an agent-run op off the
+    ``approval.approved`` broadcast. ``/decide`` re-dispatching it too
+    would execute the op twice. For a request with ``run_id`` set,
+    ``/decide`` must record the decision only and leave the
+    ``dispatch_*`` fields empty — the must-not-regress guard.
+    """
+    from meho_backplane.api.v1.approvals import DecideRequestBody, decide_approval_request
+    from meho_backplane.connectors.registry import clear_registry
+    from meho_backplane.operations import reset_dispatcher_caches
+
+    monkeypatch.setenv("KEYCLOAK_ISSUER_URL", "https://keycloak.test/realms/meho")
+    monkeypatch.setenv("KEYCLOAK_AUDIENCE", "meho-backplane")
+    monkeypatch.setenv("VAULT_ADDR", "https://vault.test")
+    get_settings.cache_clear()
+
+    _RECORDED_EXECUTIONS.clear()
+    reset_dispatcher_caches()
+    clear_registry()
+    await _register_recording_requires_approval_op(monkeypatch)
+
+    # Park an agent-run request directly (run_id set) — the realistic
+    # shape the agent runtime parks via the contextvar.
+    requester = _make_operator(sub="agent-run-sub", principal_kind=PrincipalKind.AGENT)
+    params = {"path": "secret/agent"}
+    run_id = uuid.uuid4()
+    async with get_sessionmaker()() as s:
+        pending = await create_pending_request(
+            s,
+            operator=requester,
+            connector_id="rectest-1.x",
+            op_id="rectest.write",
+            target=None,
+            params=params,
+            params_hash=compute_params_hash(params),
+            run_id=run_id,
+        )
+        await s.commit()
+    approval_request_id = pending.id
+
+    reviewer = _make_operator(sub="ops-reviewer", principal_kind=PrincipalKind.USER)
+    response = await decide_approval_request(
+        approval_request_id,
+        DecideRequestBody(decision="approved"),
+        operator=reviewer,
+    )
+
+    assert response.decision == "approved"
+    # No inline re-dispatch — the agent runtime owns that path.
+    assert response.dispatch_status is None
+    assert response.dispatch_op_id is None
+    assert _RECORDED_EXECUTIONS == [], "agent-run op must NOT execute from /decide"
 
     reset_dispatcher_caches()
     clear_registry()

--- a/backend/tests/test_migration_0036_approval_request_params.py
+++ b/backend/tests/test_migration_0036_approval_request_params.py
@@ -1,0 +1,144 @@
+# SPDX-License-Identifier: Apache-2.0
+# Copyright (c) 2026 evoila Group
+
+"""Behavioural tests for Alembic migration ``0036_add_approval_request_params``.
+
+Initiative #1500 (G0.20 v0.10.1 dogfood hardening), Task #1503. Adds the
+nullable ``approval_request.params`` JSON column — the dispatcher stores
+the original dispatch params on the row at park time so any approval
+surface (REST ``/decide``, MCP by-id approve) can re-dispatch a parked
+direct operator op with the stored params instead of only recording the
+decision. Soft-column discipline mirrors 0024 / 0030: nullable, no
+server default, reversible. The migration uses only generic ``sa.JSON``
+so PG and SQLite parity holds (the ORM pins ``JSONB`` on PG via
+``with_variant``).
+"""
+
+from __future__ import annotations
+
+from collections.abc import Iterator
+from pathlib import Path
+
+import pytest
+from alembic import command
+from alembic.config import Config
+from sqlalchemy import create_engine as sa_create_engine
+from sqlalchemy import text
+
+from meho_backplane.db.engine import reset_engine_for_testing
+from meho_backplane.db.migrations import alembic_config
+from meho_backplane.settings import get_settings
+
+
+@pytest.fixture
+def alembic_cfg(
+    monkeypatch: pytest.MonkeyPatch,
+    tmp_path: Path,
+) -> Iterator[tuple[Config, str]]:
+    """Pin env, reset caches, return an Alembic config + sync URL."""
+    db_path = tmp_path / "migration_0036.db"
+    async_url = f"sqlite+aiosqlite:///{db_path}"
+    sync_url = f"sqlite:///{db_path}"
+    monkeypatch.setenv("DATABASE_URL", async_url)
+    monkeypatch.setenv("KEYCLOAK_ISSUER_URL", "https://keycloak.test/realms/meho")
+    monkeypatch.setenv("KEYCLOAK_AUDIENCE", "meho-backplane")
+    monkeypatch.setenv("VAULT_ADDR", "https://vault.test")
+    get_settings.cache_clear()
+    reset_engine_for_testing()
+
+    cfg = alembic_config()
+    cfg.set_main_option("sqlalchemy.url", async_url)
+    try:
+        yield cfg, sync_url
+    finally:
+        get_settings.cache_clear()
+        reset_engine_for_testing()
+
+
+def _approval_request_columns(sync_url: str) -> list[tuple[str, int]]:
+    """Return ``(name, notnull)`` for every ``approval_request`` column."""
+    sync_eng = sa_create_engine(sync_url)
+    try:
+        with sync_eng.connect() as conn:
+            rows = conn.execute(text("PRAGMA table_info(approval_request)")).all()
+    finally:
+        sync_eng.dispose()
+    # PRAGMA columns: cid, name, type, notnull, dflt_value, pk.
+    return [(str(row[1]), int(row[3])) for row in rows]
+
+
+def _column_names(sync_url: str) -> set[str]:
+    return {name for name, _ in _approval_request_columns(sync_url)}
+
+
+def test_upgrade_adds_params_column_nullable(alembic_cfg: tuple[Config, str]) -> None:
+    """``upgrade head`` lands the ``params`` column as nullable JSON."""
+    cfg, sync_url = alembic_cfg
+    command.upgrade(cfg, "head")
+
+    columns = _approval_request_columns(sync_url)
+    by_name = dict(columns)
+    assert "params" in by_name, "params column must be present after upgrade"
+    # notnull flag (PRAGMA index 3): 0 == nullable.
+    assert by_name["params"] == 0, "params must be nullable"
+
+
+def test_downgrade_then_upgrade_round_trips(alembic_cfg: tuple[Config, str]) -> None:
+    """``downgrade 0035`` drops ``params``; ``upgrade head`` restores it."""
+    cfg, sync_url = alembic_cfg
+    command.upgrade(cfg, "head")
+    assert "params" in _column_names(sync_url)
+
+    command.downgrade(cfg, "0035")
+    assert "params" not in _column_names(sync_url)
+
+    command.upgrade(cfg, "head")
+    assert "params" in _column_names(sync_url)
+
+
+def test_existing_columns_untouched(alembic_cfg: tuple[Config, str]) -> None:
+    """Pre-0036 approval_request columns survive the ALTER."""
+    cfg, sync_url = alembic_cfg
+    command.upgrade(cfg, "head")
+
+    columns = _column_names(sync_url)
+    for column in (
+        "id",
+        "tenant_id",
+        "run_id",
+        "principal_sub",
+        "principal_act",
+        "op_id",
+        "connector_id",
+        "target_id",
+        "params_hash",
+        "proposed_effect",
+        "status",
+        "reviewed_by",
+        "decided_at",
+        "created_at",
+        "expires_at",
+    ):
+        assert column in columns, f"pre-0036 column {column!r} must survive"
+
+
+def test_orm_field_resolves_and_defaults_none() -> None:
+    """:attr:`ApprovalRequest.params` resolves and defaults to ``None``."""
+    import uuid
+    from datetime import UTC, datetime
+
+    from meho_backplane.db.models import ApprovalRequest
+
+    assert hasattr(ApprovalRequest, "params")
+    row = ApprovalRequest(
+        id=uuid.uuid4(),
+        tenant_id=uuid.uuid4(),
+        principal_sub="op-smoke",
+        op_id="some.op",
+        connector_id="some-1.x",
+        params_hash="deadbeef",
+        proposed_effect={},
+        status="pending",
+        created_at=datetime.now(UTC),
+    )
+    assert row.params is None

--- a/cli/api/openapi.json
+++ b/cli/api/openapi.json
@@ -6340,7 +6340,7 @@
           "approvals"
         ],
         "summary": "Decide Approval Request",
-        "description": "Capture an operator decision without re-dispatching (G11.2-T5).\n\nFlips the request to ``approved`` or ``rejected``, writes the\ndecision audit row, and publishes the ``approval.{approved,rejected}``\nbroadcast event. **Does not** re-dispatch the original op \u2014 that is\nthe agent's path (``POST .../approve`` with ``params``, which uses\nthe ``_approved`` gate-bypass). Backs the CLI/MCP operator-decision\nflow where the operator approves by id alone.",
+        "description": "Capture an operator decision, re-dispatching a direct op (G11.2-T5, #1503).\n\nFlips the request to ``approved`` or ``rejected``, writes the\ndecision audit row, and publishes the ``approval.{approved,rejected}``\nbroadcast event. Backs the CLI/MCP operator-decision flow where the\noperator approves by id alone.\n\nOn **approval of a direct operator op** (``run_id IS NULL``), the\ndecision then drives a re-dispatch using the params stored on the row\nat park time (#1503) \u2014 so a parked direct write approved here lands\nits effect exactly once, rather than being silently re-parked on the\nnext call. The request is already in a terminal ``approved`` state\nbefore the re-dispatch, so a concurrent second decide hits the\nalready-decided guard (409) and cannot double-execute.\n\nOn approval of an **agent-run** request (``run_id`` set), ``/decide``\nrecords the decision only and does **not** re-dispatch: the\nin-process agent runtime awaits the ``approval.approved`` broadcast\nand re-dispatches from its own in-memory params (the must-not-regress\npath). Re-dispatching here too would execute the op twice.",
         "operationId": "decide_approval_request_api_v1_approvals__request_id__decide_post",
         "parameters": [
           {
@@ -12204,7 +12204,7 @@
           "decision"
         ],
         "title": "DecideRequestBody",
-        "description": "POST body for ``/decide`` \u2014 the operator-decision path.\n\nDistinct from :class:`ApproveRequestBody` (which requires the\noriginal ``params`` for the agent / REST re-dispatch path). The\noperator-decision path captures the decision durably (status flip +\ndecision audit row + ``approval_decided`` broadcast) without\nre-dispatching \u2014 the agent's REST path is what re-dispatches with\nthe params it has."
+        "description": "POST body for ``/decide`` \u2014 the operator-decision path.\n\nDistinct from :class:`ApproveRequestBody` (which requires the\noriginal ``params`` for the REST re-dispatch path): ``/decide``\napproves by request id alone \u2014 the params are read back from the\nrow the dispatcher stored at park time (#1503)."
       },
       "DecideResponseBody": {
         "properties": {
@@ -12220,6 +12220,35 @@
           "reason": {
             "type": "string",
             "title": "Reason"
+          },
+          "dispatch_status": {
+            "type": "string",
+            "nullable": true,
+            "title": "Dispatch Status"
+          },
+          "dispatch_op_id": {
+            "type": "string",
+            "nullable": true,
+            "title": "Dispatch Op Id"
+          },
+          "dispatch_result": {
+            "anyOf": [
+              {
+                "additionalProperties": true,
+                "type": "object"
+              },
+              {
+                "items": {},
+                "type": "array"
+              }
+            ],
+            "nullable": true,
+            "title": "Dispatch Result"
+          },
+          "dispatch_error": {
+            "type": "string",
+            "nullable": true,
+            "title": "Dispatch Error"
           }
         },
         "type": "object",
@@ -12229,7 +12258,7 @@
           "reason"
         ],
         "title": "DecideResponseBody",
-        "description": "Response for a successful operator decision."
+        "description": "Response for a successful operator decision.\n\nThe ``dispatch_*`` fields are populated only when ``/decide``\nre-dispatched the approved op \u2014 i.e. an approved **direct** operator\nop (no ``run_id``) whose stored params drove a fresh execution\n(#1503). They stay ``None`` on a rejection and on an approved\n**agent-run** request (``run_id`` set), where the in-process agent\nruntime owns the re-dispatch and ``/decide`` only records the\ndecision (avoiding a double execution)."
       },
       "DeprecateTemplateResponse": {
         "properties": {

--- a/cli/internal/api/client.gen.go
+++ b/cli/internal/api/client.gen.go
@@ -2046,11 +2046,9 @@ type DbStatus struct {
 // DecideRequestBody POST body for “/decide“ — the operator-decision path.
 //
 // Distinct from :class:`ApproveRequestBody` (which requires the
-// original “params“ for the agent / REST re-dispatch path). The
-// operator-decision path captures the decision durably (status flip +
-// decision audit row + “approval_decided“ broadcast) without
-// re-dispatching — the agent's REST path is what re-dispatches with
-// the params it has.
+// original “params“ for the REST re-dispatch path): “/decide“
+// approves by request id alone — the params are read back from the
+// row the dispatcher stored at park time (#1503).
 type DecideRequestBody struct {
 	// Decision One of 'approved' / 'rejected'.
 	Decision string `json:"decision"`
@@ -2060,10 +2058,33 @@ type DecideRequestBody struct {
 }
 
 // DecideResponseBody Response for a successful operator decision.
+//
+// The “dispatch_*“ fields are populated only when “/decide“
+// re-dispatched the approved op — i.e. an approved **direct** operator
+// op (no “run_id“) whose stored params drove a fresh execution
+// (#1503). They stay “None“ on a rejection and on an approved
+// **agent-run** request (“run_id“ set), where the in-process agent
+// runtime owns the re-dispatch and “/decide“ only records the
+// decision (avoiding a double execution).
 type DecideResponseBody struct {
-	ApprovalRequestId openapi_types.UUID `json:"approval_request_id"`
-	Decision          string             `json:"decision"`
-	Reason            string             `json:"reason"`
+	ApprovalRequestId openapi_types.UUID                 `json:"approval_request_id"`
+	Decision          string                             `json:"decision"`
+	DispatchError     *string                            `json:"dispatch_error"`
+	DispatchOpId      *string                            `json:"dispatch_op_id"`
+	DispatchResult    *DecideResponseBody_DispatchResult `json:"dispatch_result"`
+	DispatchStatus    *string                            `json:"dispatch_status"`
+	Reason            string                             `json:"reason"`
+}
+
+// DecideResponseBodyDispatchResult0 defines model for .
+type DecideResponseBodyDispatchResult0 map[string]interface{}
+
+// DecideResponseBodyDispatchResult1 defines model for .
+type DecideResponseBodyDispatchResult1 = []interface{}
+
+// DecideResponseBody_DispatchResult defines model for DecideResponseBody.DispatchResult.
+type DecideResponseBody_DispatchResult struct {
+	union json.RawMessage
 }
 
 // DeprecateTemplateResponse Response for “runbook_deprecate_template“ -- the now-deprecated coordinates.
@@ -5925,6 +5946,68 @@ func (t CallOperationBody_Target) MarshalJSON() ([]byte, error) {
 }
 
 func (t *CallOperationBody_Target) UnmarshalJSON(b []byte) error {
+	err := t.union.UnmarshalJSON(b)
+	return err
+}
+
+// AsDecideResponseBodyDispatchResult0 returns the union data inside the DecideResponseBody_DispatchResult as a DecideResponseBodyDispatchResult0
+func (t DecideResponseBody_DispatchResult) AsDecideResponseBodyDispatchResult0() (DecideResponseBodyDispatchResult0, error) {
+	var body DecideResponseBodyDispatchResult0
+	err := json.Unmarshal(t.union, &body)
+	return body, err
+}
+
+// FromDecideResponseBodyDispatchResult0 overwrites any union data inside the DecideResponseBody_DispatchResult as the provided DecideResponseBodyDispatchResult0
+func (t *DecideResponseBody_DispatchResult) FromDecideResponseBodyDispatchResult0(v DecideResponseBodyDispatchResult0) error {
+	b, err := json.Marshal(v)
+	t.union = b
+	return err
+}
+
+// MergeDecideResponseBodyDispatchResult0 performs a merge with any union data inside the DecideResponseBody_DispatchResult, using the provided DecideResponseBodyDispatchResult0
+func (t *DecideResponseBody_DispatchResult) MergeDecideResponseBodyDispatchResult0(v DecideResponseBodyDispatchResult0) error {
+	b, err := json.Marshal(v)
+	if err != nil {
+		return err
+	}
+
+	merged, err := runtime.JSONMerge(t.union, b)
+	t.union = merged
+	return err
+}
+
+// AsDecideResponseBodyDispatchResult1 returns the union data inside the DecideResponseBody_DispatchResult as a DecideResponseBodyDispatchResult1
+func (t DecideResponseBody_DispatchResult) AsDecideResponseBodyDispatchResult1() (DecideResponseBodyDispatchResult1, error) {
+	var body DecideResponseBodyDispatchResult1
+	err := json.Unmarshal(t.union, &body)
+	return body, err
+}
+
+// FromDecideResponseBodyDispatchResult1 overwrites any union data inside the DecideResponseBody_DispatchResult as the provided DecideResponseBodyDispatchResult1
+func (t *DecideResponseBody_DispatchResult) FromDecideResponseBodyDispatchResult1(v DecideResponseBodyDispatchResult1) error {
+	b, err := json.Marshal(v)
+	t.union = b
+	return err
+}
+
+// MergeDecideResponseBodyDispatchResult1 performs a merge with any union data inside the DecideResponseBody_DispatchResult, using the provided DecideResponseBodyDispatchResult1
+func (t *DecideResponseBody_DispatchResult) MergeDecideResponseBodyDispatchResult1(v DecideResponseBodyDispatchResult1) error {
+	b, err := json.Marshal(v)
+	if err != nil {
+		return err
+	}
+
+	merged, err := runtime.JSONMerge(t.union, b)
+	t.union = merged
+	return err
+}
+
+func (t DecideResponseBody_DispatchResult) MarshalJSON() ([]byte, error) {
+	b, err := t.union.MarshalJSON()
+	return b, err
+}
+
+func (t *DecideResponseBody_DispatchResult) UnmarshalJSON(b []byte) error {
 	err := t.union.UnmarshalJSON(b)
 	return err
 }

--- a/docs/codebase/agent-runtime.md
+++ b/docs/codebase/agent-runtime.md
@@ -366,13 +366,23 @@ The substrate preserves the operator/agent split G11.2 established:
 | REST `/approve` with `params` | inline | inline (human as operator + agent) |
 | REST `/decide`, MCP, CLI | durable row + broadcast | **agent runtime via wait+wrap** |
 
-Storing the `params` on the approval row would turn the table into a
-re-dispatch primitive holding secrets-bearing call payloads — a security
-and audit-surface tradeoff the issue body documents (`#1117` "Why not store
-params on approval_request"). The agent-side in-memory params are
-authoritative for the live-wait case this Task targets. Resuming agent
-runs whose process died between dispatch and approval is explicitly
-out-of-scope for v1.
+For the **agent-run** case this Task targets, the agent-side in-memory
+params are authoritative: the live `call_operation` wait holds them and
+re-dispatches from there, so `#1117` deliberately did not store `params`
+on the approval row. Resuming agent runs whose process died between
+dispatch and approval is explicitly out-of-scope for v1.
+
+The **direct operator op** case is different — there is no in-process
+wait holding the params, so a parked direct op approved by id alone
+(`/decide`, MCP, CLI) had nothing to re-dispatch. #1503 (G0.20-T3) adds a
+nullable `approval_request.params` column (migration 0036) so a direct
+op's stored params drive the post-approval re-dispatch on any surface.
+That column is `run_id`-gated at the re-dispatch sites: an agent-run
+request (`run_id` set) is never re-dispatched from `/decide`/MCP — the
+broadcast-driven runtime resume above remains its only re-dispatch path,
+so this section's behaviour is unchanged. The params column is internal
+re-dispatch input only and is never surfaced on a read view or broadcast
+frame. See [approvals.md § G0.20-T3](approvals.md#g020-t3--execute-a-parked-direct-op-on-approve-via-every-surface-1503).
 
 ### Audit attribution
 

--- a/docs/codebase/approvals.md
+++ b/docs/codebase/approvals.md
@@ -1,10 +1,12 @@
-# Approvals (G11.2-T4 + T5; G11.7-T1 policy hardening)
+# Approvals (G11.2-T4 + T5; G11.7-T1 policy hardening; G0.20-T3 direct-op execute)
 
 **Initiative:** #803 — G11.2 Agent identity + RBAC + approval;
-#1397 — G11.7 Approval-policy hardening
+#1397 — G11.7 Approval-policy hardening; #1500 — G0.20 v0.10.1 dogfood
+hardening
 **Tasks:** #817 (T4 — durable approval queue) + #818 (T5 — operator
 surfacing channel) + #1401 (G11.7-T1 — queue humans, self-approval
-guard, resume-target fix, write-op secret redaction)
+guard, resume-target fix, write-op secret redaction) + #1503 (G0.20-T3
+— execute a parked direct operator op on approve via every surface)
 
 ## Overview
 
@@ -131,6 +133,67 @@ routed to `NEEDS_APPROVAL`, re-running the gate on resume would re-queue
 the call instead of executing it, so the bypass is what lets the
 approved op run.
 
+## G0.20-T3 — execute a parked direct op on approve via every surface (#1503)
+
+Before #1503 the **only** execute-after-approve path for a parked
+**direct** operator op (an operator calling a `requires_approval` op
+directly, not via an agent run) was REST `POST .../approve` carrying the
+original `params` in-band. Approving the same parked write via `/decide`
+or the MCP/CLI by-id approve surface committed the decision but never
+re-dispatched — and simply re-calling the op re-parked it. So an
+operator who approved a colleague's parked direct write through the
+activity feed / `/decide` / MCP saw it marked approved while the write
+never landed.
+
+Two changes close that gap, scoped to the **direct**-op path:
+
+1. **Store the params on the row.** `approval_request.params` (nullable
+   JSON, migration
+   `backend/alembic/versions/0036_add_approval_request_params.py`) holds
+   the original dispatch params, written by `create_pending_request` at
+   park time. The row already held `connector_id` / `op_id` /
+   `target_id`; adding `params` makes it a complete re-dispatch
+   primitive, so a surface that holds only the request id can still
+   re-execute the exact original call. The column is **internal
+   re-dispatch input only** — it is never serialised onto a read view
+   (`_view`, the MCP `_row_to_dict`) or a broadcast frame; the redacted
+   `proposed_effect` and the swap-defence `params_hash` remain the
+   reviewer-facing fields. (This reverses, for the direct-op path only,
+   the "keep params off the row" tradeoff #1117 made for the agent-run
+   case — see [agent-runtime.md § Awaiting-approval resume](agent-runtime.md#awaiting-approval-resume-t9-1117).)
+
+2. **Re-dispatch from the approve decision on every surface.** The
+   single execute-after-approve entry point is
+   `approval_queue.resume_dispatch_after_approval` — it re-hydrates the
+   stored target by id (G11.7-T1 fail-closed semantics preserved) and
+   re-dispatches with `dispatch(..., _approved=True)`, falling back to
+   the stored `request.params` when the surface supplies none. REST
+   `/approve` (caller params, hash-verified), REST `/decide`, and the
+   MCP `meho.approvals.approve` tool all route through it. `/decide` and
+   the MCP tool return the dispatch outcome (`dispatch_*` fields /
+   `dispatch` block) alongside the decision.
+
+**The `run_id` gate (no double-execution / agent-run regression
+guard).** `/decide` and the MCP approve tool re-dispatch **only when
+`run_id IS NULL`** — i.e. a direct operator op. An **agent-run** request
+(`run_id` set) is still resumed in-process by the agent runtime off the
+`approval.approved` broadcast (the must-not-regress path); re-dispatching
+it from `/decide`/MCP too would execute the op twice. So the agent-run
+resume path is untouched: it keeps its in-memory params, ignores the new
+column, and remains the sole re-dispatcher for `run_id`-bearing requests.
+
+**Double-execution prevention (terminal-state guard).**
+`approve_request` flips the row to `approved` (terminal) and commits
+*before* the re-dispatch runs. A concurrent second `/decide`/approve on
+the same row hits the already-decided guard (409 / `not_pending`), so the
+stored params drive exactly one execution.
+
+**Pre-0036 rows.** A row parked before migration 0036 has `params IS
+NULL`. Approving it via `/decide`/MCP (no in-band params) finds nothing
+to re-dispatch, so `resume_dispatch_after_approval` **fails closed** with
+a structured `denied` result naming the gap — the operator resumes it via
+REST `/approve` + params, exactly as before 0036.
+
 ## `proposed_effect` builder hook (#1437)
 
 `ApprovalRequest.proposed_effect` holds what the reviewer sees in the
@@ -190,6 +253,7 @@ their own builders as needed.
 | `GET` | `/api/v1/approvals` | operator | List, filtered by `status` (default: `pending`). |
 | `GET` | `/api/v1/approvals/{id}` | operator | **Inspect one request** (T5). 404 on cross-tenant. |
 | `POST` | `/api/v1/approvals/{id}/approve` | operator | Approve. Requires `params` (hash-verified). Re-hydrates the target by id, then re-dispatches with `dispatch(..., _approved=True)`. 403 `self_approval_forbidden` when the approver is the requester and break-glass is off (G11.7-T1). |
+| `POST` | `/api/v1/approvals/{id}/decide` | operator | Decide (`approved` / `rejected`) by id alone. For an approved **direct** op (`run_id IS NULL`) re-dispatches with the **stored** params (#1503) and returns the outcome in `dispatch_*`; for an agent-run request records the decision only (the agent runtime resumes). |
 | `POST` | `/api/v1/approvals/{id}/reject` | operator | Reject. The op never executes. |
 
 ### MCP (`backend/src/meho_backplane/mcp/tools/approvals.py`)
@@ -200,9 +264,11 @@ Four `meho.approvals.*` tools (all `TenantRole.OPERATOR`-gated):
 - `meho.approvals.get` — full detail by id.
 - `meho.approvals.approve` — operator-decision path (status flip + audit +
   `approval.approved` broadcast; **no `params` required** —
-  `approve_request` skips the hash check when called without params, because
-  the operator decision path does not have the agent's params). The
-  agent's REST path retains the hash check and is what re-dispatches.
+  `approve_request` skips the hash check when called without params). For
+  an approved **direct** op (`run_id IS NULL`) it then re-dispatches using
+  the stored params (#1503) and returns the outcome under `dispatch`; for
+  an agent-run request the in-process agent runtime resumes the op off the
+  broadcast, so the tool only records the decision.
 - `meho.approvals.reject` — same shape; optional `reason`.
 
 RBAC is enforced at two layers: the MCP registry filter hides write
@@ -255,20 +321,22 @@ explicit `meho.approvals.{approve,reject}` tools.
 
 ## Agent-runtime resume on `approval.{approved,rejected}` (T9 #1117)
 
-The operator/agent split: operator paths capture the decision durably and
-publish a broadcast event; the agent runtime subscribes and resumes (or
-surfaces the rejection) from its own side. Each path:
+The operator/agent split, keyed on whether the parked request belongs to
+an **agent run** (`run_id` set) or a **direct operator op** (`run_id IS
+NULL`):
 
-| Path | Decision capture | Re-dispatch |
-|---|---|---|
-| REST `/approve` with `params` | inline | inline — the human operator's call re-dispatches with `_approved=True` (the human-driven express lane). |
-| REST `/decide`, MCP, CLI | durable row + broadcast | **agent runtime**: the wrapped `call_operation` in `meho_backplane/agent/toolset.py` + `meho_backplane/agent/run.py` blocks on `meho_backplane.agent.approval_wait.wait_for_approval_decision` and re-invokes the dispatcher via `call_operation_with_approval` on approval, or surfaces the rejection to the model. |
+| Path | Decision capture | Re-dispatch (agent run) | Re-dispatch (direct op) |
+|---|---|---|---|
+| REST `/approve` with `params` | inline | inline (`_approved=True`, the human-driven express lane) | inline (caller params, hash-verified) |
+| REST `/decide`, MCP, CLI | durable row + broadcast | **agent runtime**: the wrapped `call_operation` in `meho_backplane/agent/toolset.py` + `meho_backplane/agent/run.py` blocks on `meho_backplane.agent.approval_wait.wait_for_approval_decision` and re-invokes the dispatcher via `call_operation_with_approval` on approval, or surfaces the rejection to the model. | **inline** (#1503): the decision drives `resume_dispatch_after_approval` with the **stored** params (`run_id`-gated so this never fires for an agent run). |
 
-See [agent-runtime.md § Awaiting-approval resume](agent-runtime.md#awaiting-approval-resume-t9-1117)
-for the substrate's full shape, including the wait timeout
-(`Settings.agent_approval_wait_timeout_seconds`, default 30 min), the
-fail-open semantics on broadcast outage, and the security tradeoff that
-keeps `params` off the approval row.
+For an agent-run request the broadcast-driven runtime resume is the only
+re-dispatch path; `/decide`/MCP record the decision only. For a direct
+operator op (#1503) `/decide`/MCP re-dispatch inline with the stored
+params. See [agent-runtime.md § Awaiting-approval resume](agent-runtime.md#awaiting-approval-resume-t9-1117)
+for the agent-run substrate's full shape, including the wait timeout
+(`Settings.agent_approval_wait_timeout_seconds`, default 30 min) and the
+fail-open semantics on broadcast outage.
 
 ## References
 
@@ -277,5 +345,7 @@ keeps `params` off the approval row.
 - `backend/src/meho_backplane/mcp/tools/approvals.py` — MCP tools.
 - `cli/internal/cmd/approvals/` — CLI verbs.
 - `backend/alembic/versions/0023_create_approval_request.py` — schema.
+- `backend/alembic/versions/0036_add_approval_request_params.py` — `params` column for direct-op approve re-dispatch (#1503).
+- `backend/src/meho_backplane/operations/approval_queue.py::resume_dispatch_after_approval` — the single execute-after-approve entry point shared by every operator surface (#1503).
 - `backend/src/meho_backplane/agent/approval_wait.py` — agent-runtime resume substrate (T9 #1117): broadcast subscription + re-dispatch on approval.
 - `backend/src/meho_backplane/operations/meta_tools.py` — `call_operation_with_approval` (the gate-bypass re-dispatch entry point).


### PR DESCRIPTION
## Summary
- Execute a parked **direct** operator op when it is approved via `/decide` or the MCP/CLI by-id approve — not only via REST `/approve`. The approval decision now drives the re-dispatch, so an approved direct write lands its effect exactly once instead of being silently re-parked on the next call.
- Persist the original dispatch params on the approval row (new nullable `approval_request.params` column, migration `0036`) so a surface that holds only the request id can re-execute the exact original call. The column is internal re-dispatch input only — never surfaced on a read view or broadcast frame.
- Add `resume_dispatch_after_approval` in the service layer as the single execute-after-approve entry point shared by REST `/approve`, REST `/decide`, and `meho.approvals.approve` (re-hydrates the stored target with the G11.7-T1 fail-closed semantics, dispatches with `_approved=True`, falls back to the stored params when the surface supplies none).
- **No agent-run regression:** the re-dispatch is gated on `run_id IS NULL`. An agent-run request is still resumed in-process by the agent runtime off the `approval.approved` broadcast (its in-memory params remain authoritative); re-dispatching it from `/decide`/MCP too would double-execute, so it is deliberately excluded.

## Why
A parked direct op approved through the activity feed / `/decide` / MCP committed the decision but never re-dispatched, because only REST `/approve` carried the params and the row stored just a `params_hash`. Re-calling the op re-hit `requires_approval` and re-parked it. Storing the params turns the row into a complete re-dispatch primitive (it already held `connector_id` / `op_id` / `target_id`), and routing every surface through one helper makes execute-after-approve uniform. Double-execution is prevented by the terminal `approved` state committed before the re-dispatch (a concurrent second decide hits the already-decided 409).

## Test plan
- [x] `ruff check` / `ruff format --check` — clean
- [x] `mypy src/meho_backplane/ --ignore-missing-imports` — no issues (430 files)
- [x] `code-quality.py --diff` — 0 blockers (remaining warnings are pre-existing file-size debt)
- [x] **AC1** — a parked direct op approved via `/decide` and via MCP by-id executes exactly once: `tests/test_approval_queue.py::test_decide_approve_redispatches_direct_op_with_stored_params`, `::test_mcp_approve_redispatches_direct_op_with_stored_params` (assert one recorded execution with the stored params)
- [x] **AC2** — stored params drive the re-dispatch; double-execution prevented (terminal `approved` state): same tests assert `params == stored` and the row is `approved`
- [x] **AC3** — agent-run resume unchanged: `::test_decide_approve_does_not_redispatch_agent_run_request` plus the full `tests/test_agent_approval_resume.py` (10 tests) pass
- [x] Migration round-trip + ORM default: `tests/test_migration_0036_approval_request_params.py`
- [x] Focused suite green: `test_approval_queue` / `test_api_v1_approvals` / `test_mcp_tool_approvals` / `test_agent_approval_resume` / `test_migration_0036` — 60 passed
- [x] Broader sweep (`-k "dispatch or approval or migration or openapi or schema or models"`) — 966 passed, 104 skipped
- [x] CLI OpenAPI snapshot + generated client regenerated (`make snapshot-openapi && make generate`); `go build ./...` clean

## Out of scope
- Agent-run (in-process) resume — already works; preserved via the `run_id` gate.
- Park-time permission preflight (separate Vault-write task, #1504).
- Pre-0036 rows have `params IS NULL`; approving one via `/decide`/MCP fails closed with a structured `denied` (resume via REST `/approve` + params, as before).

<!-- auto-implement-issue: fresh, iteration 1 -->

Closes #1503
