### PR TITLE
fix(agent): wire lease/heartbeat into the run fire path so the reaper can reclaim hung runs (#1501)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -90,6 +90,10 @@ connector-related release-notes line.
 
 ## [Unreleased]
 
+### Fixed
+
+- Wire the agent-run lease/heartbeat into the fire path so a hung, crashed, or worker-killed run is reliably reaped to a terminal `failed` state instead of staying `running` forever; the run loop now stamps a lease on start and heartbeats while alive, and child (`invoke_agent`) runs are leased too (#1501).
+
 ## [0.10.1] - 2026-06-04
 
 ### Fixed

--- a/backend/src/meho_backplane/agent/invocation.py
+++ b/backend/src/meho_backplane/agent/invocation.py
@@ -72,6 +72,9 @@ the operator's tenant owns (cross-tenant run ids surface as
 from __future__ import annotations
 
 import asyncio
+import contextlib
+import os
+import socket
 import uuid
 from collections.abc import AsyncIterator
 from dataclasses import dataclass
@@ -233,6 +236,66 @@ class _RunState:
 #: initiative resolves the logical model tier to this concrete pair through
 #: the settings default; the multi-provider resolver is G11.5.
 _DEFAULT_PROVIDER: Final[str] = "anthropic"
+
+
+def _lease_owner() -> str:
+    """Compute a stable per-process identifier for the run's ``lease_owner``.
+
+    ``"<hostname>:<pid>"`` -- the same shape
+    :func:`meho_backplane.events.drain._claimer_identity` uses for the
+    outbox-drain claimer. Visible from PG diagnostics, no PII, no secret
+    material; an operator chasing a reaped run can map the
+    ``prior_lease_owner`` the reaper records straight back to the pod /
+    process whose worker died.
+    """
+    return f"{socket.gethostname()}:{os.getpid()}"
+
+
+async def _heartbeat_loop(run_id: uuid.UUID, owner: str) -> None:
+    """Extend *run_id*'s lease on a cadence until cancelled or the lease is lost.
+
+    Wiring the lease lifecycle into the fire path (#1501) closes the
+    G11.3-T4 #825 gap: :func:`run_lifecycle.claim_lease` stamps the lease
+    at run-start, but without a heartbeat the lease expires under any run
+    that outlives one TTL window and the reaper would reclaim a perfectly
+    healthy worker. This sidecar bumps ``lease_expires_at`` forward every
+    ``ttl_seconds / 2`` so a live worker keeps its lease, while a worker
+    that has died (its event loop gone) stops heartbeating and the reaper
+    reclaims the run after the TTL lapses.
+
+    Each heartbeat opens its own short-lived committed transaction -- the
+    conditional ``UPDATE`` in :func:`run_lifecycle.heartbeat` is atomic, so
+    no longer-held session is needed. A :class:`run_lifecycle.LeaseLostError`
+    means the reaper (or an operator cancel) already took the run over: the
+    loop logs and returns so it stops touching a row it no longer owns.
+    :class:`asyncio.CancelledError` (the run finished, the sidecar is being
+    torn down) propagates verbatim.
+    """
+    settings = get_settings()
+    ttl_seconds = settings.agent_run_lease_ttl_seconds
+    # Heartbeat at half the TTL so a single missed beat (a transient DB
+    # blip, a short GC pause) still leaves one full window of slack before
+    # the reaper reclaims -- the same two-window margin the reaper's
+    # default tick/TTL pairing documents.
+    interval = max(1.0, ttl_seconds / 2.0)
+    sessionmaker = get_sessionmaker()
+    while True:
+        await asyncio.sleep(interval)
+        try:
+            async with sessionmaker() as session:
+                await run_lifecycle.heartbeat(
+                    session,
+                    run_id=run_id,
+                    owner=owner,
+                    ttl_seconds=ttl_seconds,
+                )
+                await session.commit()
+        except run_lifecycle.LeaseLostError:
+            # The reaper reclaimed the row or an operator cancelled it
+            # out from under us. Stop heartbeating -- the run is no
+            # longer ours to keep alive.
+            _log.info("agent_run_lease_lost", run_id=str(run_id), owner=owner)
+            return
 
 
 def _log_decision(
@@ -479,16 +542,31 @@ class AgentInvoker:
         provider: str,
         model: str,
         trigger: AgentRunTrigger = AgentRunTrigger.DIRECT,
-    ) -> uuid.UUID:
-        """Insert a ``pending`` run row, transition it to ``running``, commit.
+    ) -> tuple[uuid.UUID, str]:
+        """Insert a ``pending`` run row, claim a lease, go ``running``, commit.
 
         Done in its own committed transaction *before* the loop starts so
         the run is pollable the instant :meth:`run` returns a handle — even
         in async mode where the background task has not made progress yet.
-        Returns the run id (the durable handle + audit-lineage key). A
-        human-initiated :meth:`run` records ``DIRECT``; an autonomous
-        :meth:`run_scheduled` records ``SCHEDULED``.
+        Returns ``(run_id, lease_owner)``: the run id is the durable handle
+        + audit-lineage key; the lease owner is the per-process stamp the
+        heartbeat sidecar reuses so its conditional ``UPDATE`` matches the
+        row this worker claimed. A human-initiated :meth:`run` records
+        ``DIRECT``; an autonomous :meth:`run_scheduled` records
+        ``SCHEDULED``.
+
+        The lease is stamped (#1501 / G11.3-T4 #825) in the *same*
+        transaction as the ``pending`` -> ``running`` transition, so a
+        committed run is never ``running`` without a lease: the reaper's
+        claim query (``status='running' AND lease_expires_at < now()``)
+        can therefore reclaim this run once its lease lapses, instead of
+        the row staying stuck ``running`` forever. The in-flight policy
+        is left at the row default (``fail_into_audit``) -- a direct /
+        scheduled run has no firing-trigger row to snapshot, and
+        ``fail_into_audit`` is the conservative reclaim outcome the
+        reaper applies.
         """
+        owner = _lease_owner()
         sessionmaker = get_sessionmaker()
         async with sessionmaker() as session:
             row = await run_lifecycle.create_run(
@@ -500,9 +578,15 @@ class AgentInvoker:
                 agent_definition_id=entry.id,
             )
             await run_lifecycle.start_run(session, row, provider=provider, model=model)
+            await run_lifecycle.claim_lease(
+                session,
+                row,
+                owner=owner,
+                ttl_seconds=get_settings().agent_run_lease_ttl_seconds,
+            )
             run_id = row.id
             await session.commit()
-        return run_id
+        return run_id, owner
 
     @staticmethod
     async def _finalize_run(
@@ -579,6 +663,7 @@ class AgentInvoker:
         inputs: str,
         *,
         meta: AgentRunAuditMeta,
+        lease_owner: str,
     ) -> None:
         """Background coroutine: run the loop and record its terminal state.
 
@@ -588,6 +673,17 @@ class AgentInvoker:
         re-raises — a failed run is a recorded ``failed`` row, not a crashed
         background task (an unhandled task exception would surface only as a
         log warning at GC time).
+
+        A heartbeat sidecar (:func:`_heartbeat_loop`) runs alongside the
+        loop for its whole lifetime (#1501): it keeps the run's lease fresh
+        so the reaper does not reclaim a healthy long-running worker, and is
+        cancelled in the ``finally`` once the loop terminates (success,
+        failure, or cancel). If *this* task dies (worker recycle, unhandled
+        crash), the sidecar dies with it -- the lease then lapses and the
+        reaper drives the row to ``failed`` rather than leaving it stuck
+        ``running``. The lifecycle's terminal-transition helpers already
+        clear the lease, so a cleanly-finished run drops its lease before
+        the sidecar is even cancelled; the cancel is belt-and-suspenders.
 
         Binds three contextvars around the loop, each scoped to this run:
 
@@ -610,6 +706,10 @@ class AgentInvoker:
         run_token = current_agent_run_id_var.set(run_id)
         session_token = agent_session_id_var.set(run_id)
         meta_token = agent_run_audit_meta_var.set(meta)
+        heartbeat = asyncio.create_task(
+            _heartbeat_loop(run_id, lease_owner),
+            name=f"agent-heartbeat-{run_id}",
+        )
         try:
             try:
                 handle = self._runtime.start(definition, operator, inputs)
@@ -637,6 +737,14 @@ class AgentInvoker:
                 usage=usage,
             )
         finally:
+            # Stop the heartbeat sidecar before resetting the contextvars:
+            # the run has reached its terminal state (or is being cancelled),
+            # so the lease no longer needs extending. Awaiting the cancel
+            # keeps a stray "Task was destroyed but it is pending!" warning
+            # from surfacing at GC under pytest-asyncio shutdown.
+            heartbeat.cancel()
+            with contextlib.suppress(asyncio.CancelledError):
+                await heartbeat
             agent_run_audit_meta_var.reset(meta_token)
             agent_session_id_var.reset(session_token)
             current_agent_run_id_var.reset(run_token)
@@ -690,13 +798,16 @@ class AgentInvoker:
         # actor_delegation (empty identity_ref) raises before the row is
         # committed — never a ``running`` row with no backing task.
         with actor_delegation(entry.identity_ref):
-            run_id = await self._create_run_row(operator, entry, provider=provider, model=model)
+            run_id, lease_owner = await self._create_run_row(
+                operator, entry, provider=provider, model=model
+            )
             task = self._launch_run(
                 run_id,
                 definition,
                 operator,
                 inputs,
                 meta=AgentRunAuditMeta(model=model, provider=provider),
+                lease_owner=lease_owner,
             )
 
         _log.info(
@@ -809,7 +920,7 @@ class AgentInvoker:
         # rather than a human.
         definition = await self._enforce_pre_run_budget(operator, definition)
         provider, model = _split_model_id(settings.agent_default_model)
-        run_id = await self._create_run_row(
+        run_id, lease_owner = await self._create_run_row(
             operator,
             entry,
             provider=provider,
@@ -824,6 +935,7 @@ class AgentInvoker:
             operator,
             inputs,
             meta=AgentRunAuditMeta(model=model, provider=provider),
+            lease_owner=lease_owner,
         )
         _log.info(
             "agent_scheduled_started",
@@ -849,6 +961,7 @@ class AgentInvoker:
         inputs: str,
         *,
         meta: AgentRunAuditMeta,
+        lease_owner: str,
     ) -> asyncio.Task[None]:
         """Launch the loop as a background task anchored in the run store.
 
@@ -861,10 +974,19 @@ class AgentInvoker:
         per-tool-call audit row's payload (G11.4-T5 #1074) -- carried
         into the background task via
         :data:`~meho_backplane.operations._audit.agent_run_audit_meta_var`
-        in :meth:`_run_loop_to_completion`.
+        in :meth:`_run_loop_to_completion`. *lease_owner* is the
+        per-process stamp :meth:`_create_run_row` wrote with the lease;
+        the loop's heartbeat sidecar reuses it (#1501).
         """
         task = asyncio.create_task(
-            self._run_loop_to_completion(run_id, definition, operator, inputs, meta=meta),
+            self._run_loop_to_completion(
+                run_id,
+                definition,
+                operator,
+                inputs,
+                meta=meta,
+                lease_owner=lease_owner,
+            ),
             name=f"agent-invoke-{run_id}",
         )
         self._store[run_id] = _RunState(
@@ -926,7 +1048,9 @@ class AgentInvoker:
         definition = await self._enforce_pre_run_budget(operator, definition)
         settings = get_settings()
         provider, model = _split_model_id(settings.agent_default_model)
-        run_id = await self._create_run_row(operator, entry, provider=provider, model=model)
+        run_id, lease_owner = await self._create_run_row(
+            operator, entry, provider=provider, model=model
+        )
 
         terminal_output: dict[str, object] | None = None
         terminal_error: str | None = None
@@ -944,6 +1068,15 @@ class AgentInvoker:
         meta_token = agent_run_audit_meta_var.set(
             AgentRunAuditMeta(model=model, provider=provider),
         )
+        # Heartbeat sidecar (#1501): the streamed run executes inline in the
+        # SSE coroutine, so a hung tool call or a slow model would let the
+        # lease lapse and the reaper reclaim a live stream. Keep the lease
+        # fresh for the stream's lifetime; cancel it once the stream
+        # terminates (final/error event, client disconnect, cancel).
+        heartbeat = asyncio.create_task(
+            _heartbeat_loop(run_id, lease_owner),
+            name=f"agent-heartbeat-{run_id}",
+        )
         try:
             async for event in self._runtime.stream_events(definition, operator, inputs, run_id):
                 if event.kind is AgentRunEventKind.FINAL:
@@ -952,6 +1085,9 @@ class AgentInvoker:
                     terminal_error = str(event.data.get("error"))
                 yield run_id, event
         finally:
+            heartbeat.cancel()
+            with contextlib.suppress(asyncio.CancelledError):
+                await heartbeat
             agent_run_audit_meta_var.reset(meta_token)
             agent_session_id_var.reset(session_token)
             current_agent_run_id_var.reset(run_token)
@@ -985,8 +1121,8 @@ async def _record_child_run(
     operator: Operator,
     definition: AgentDefinition,
     parent_run_id: uuid.UUID | None,
-) -> uuid.UUID:
-    """Persist a child ``agent_run`` row linked to its parent; return its id.
+) -> tuple[uuid.UUID, str]:
+    """Persist a child ``agent_run`` row linked to its parent; return ``(id, owner)``.
 
     The :class:`~meho_backplane.agent.invoke.ChildRunRecorder` the live invoker
     injects (G11.1-T7 #1067). The seam value object carries neither the
@@ -997,12 +1133,15 @@ async def _record_child_run(
     so the child run is inspectable while it executes (mirrors
     :meth:`AgentInvoker._create_run_row`).
 
-    The row's *terminal* state is deliberately not written here: the
-    ``ChildRunRecorder`` protocol returns only the new id, and the child loop's
-    success/failure surfaces through the parent run. Finalizing child rows to
-    ``succeeded`` / ``failed`` is a follow-up — it needs a protocol extension
-    (a finalizer hook), out of #1067's "wire the existing mechanism" scope. A
-    definition deleted between resolution and recording raises
+    Like the top-level path (#1501), the row is leased in the same
+    transaction as the ``running`` transition; the lease owner is returned so
+    the ``invoke_agent`` tool can heartbeat the child for its loop's lifetime
+    and the reaper can reclaim a child whose worker died mid-flight.
+
+    The row's *terminal* state is closed by the companion
+    :func:`_finalize_child_run` (G11.1-T8 #1087) after the child loop returns,
+    so the child reaches ``succeeded`` / ``failed``. A definition deleted
+    between resolution and recording raises
     :class:`~meho_backplane.agent.run.AgentRunError`, surfaced by
     ``invoke_agent`` as a ``ModelRetry``.
     """
@@ -1012,6 +1151,7 @@ async def _record_child_run(
         raise AgentRunError(f"agent definition {definition.name!r} no longer exists")
     settings = get_settings()
     provider, model = _split_model_id(settings.agent_default_model)
+    owner = _lease_owner()
     sessionmaker = get_sessionmaker()
     async with sessionmaker() as session:
         row = await run_lifecycle.create_run(
@@ -1024,9 +1164,15 @@ async def _record_child_run(
             parent_run_id=parent_run_id,
         )
         await run_lifecycle.start_run(session, row, provider=provider, model=model)
+        await run_lifecycle.claim_lease(
+            session,
+            row,
+            owner=owner,
+            ttl_seconds=settings.agent_run_lease_ttl_seconds,
+        )
         child_run_id = row.id
         await session.commit()
-    return child_run_id
+    return child_run_id, owner
 
 
 async def _finalize_child_run(

--- a/backend/src/meho_backplane/agent/invoke.py
+++ b/backend/src/meho_backplane/agent/invoke.py
@@ -86,6 +86,8 @@ module reaching into either.
 
 from __future__ import annotations
 
+import asyncio
+import contextlib
 import uuid
 from contextvars import ContextVar
 from typing import TYPE_CHECKING, Any, Protocol
@@ -232,7 +234,7 @@ class ChildRunner(Protocol):
 
 
 class ChildRunRecorder(Protocol):
-    """Persist a child ``agent_run`` row linked to its parent, return its id.
+    """Persist a child ``agent_run`` row linked to its parent; return ``(id, lease_owner)``.
 
     Optional -- injected by the T4 #811 invocation surface / T6 #813 lifecycle
     service, which own the DB session. Called *after* the depth check passes and
@@ -241,6 +243,13 @@ class ChildRunRecorder(Protocol):
     the duration of its loop (so a grand-child invocation links to it). When no
     recorder is wired, the in-process bounds still hold; the lineage row is just
     not written.
+
+    The recorder stamps a lease on the child row at creation (#1501) and
+    returns its ``lease_owner`` alongside the id so the ``invoke_agent`` tool
+    can heartbeat the child for the duration of its loop -- a child that
+    outlives its lease TTL, or whose worker dies mid-flight, is then reclaimed
+    by the reaper instead of staying stuck ``running``, the same contract the
+    top-level run path enforces.
     """
 
     async def __call__(
@@ -249,7 +258,7 @@ class ChildRunRecorder(Protocol):
         operator: Operator,
         definition: AgentDefinition,
         parent_run_id: uuid.UUID | None,
-    ) -> uuid.UUID: ...
+    ) -> tuple[uuid.UUID, str]: ...
 
 
 class ChildRunFinalizer(Protocol):
@@ -280,6 +289,22 @@ class ChildRunFinalizer(Protocol):
         output: Any,
         error: str | None,
     ) -> None: ...
+
+
+async def _stop_child_heartbeat(task: asyncio.Task[None] | None) -> None:
+    """Cancel a child run's heartbeat sidecar and await its unwind.
+
+    A no-op when *task* is ``None`` (no recorder wired, or the heartbeat was
+    already stopped on this code path). Swallows the expected
+    :class:`asyncio.CancelledError` so tearing the sidecar down never surfaces
+    as a stray task exception, mirroring the disposal shape the lifespan-owned
+    sweepers use (#1501).
+    """
+    if task is None:
+        return
+    task.cancel()
+    with contextlib.suppress(asyncio.CancelledError):
+        await task
 
 
 def _check_invoke_depth(child_agent_name: str) -> int:
@@ -387,8 +412,9 @@ def make_invoke_agent_tool(
 
         parent_run_id = current_agent_run_id_var.get()
         child_run_id: uuid.UUID | None = None
+        child_lease_owner: str | None = None
         if recorder is not None:
-            child_run_id = await recorder(
+            child_run_id, child_lease_owner = await recorder(
                 operator=operator,
                 definition=definition,
                 parent_run_id=parent_run_id,
@@ -413,6 +439,23 @@ def make_invoke_agent_tool(
             operator_sub=operator.sub,
             tenant_id=str(operator.tenant_id),
         )
+        # Heartbeat the child's lease for the duration of its loop (#1501).
+        # The child runs inline under the parent task; if the parent task
+        # dies mid-child both stop, the child's lease lapses, and the reaper
+        # reclaims the child row instead of leaving it stuck ``running``. The
+        # sidecar is cancelled in the ``finally`` once the child loop ends.
+        # A local import avoids the module-scope cycle with
+        # ``meho_backplane.agent.invocation`` (which imports this module to
+        # wire the ``invoke_agent`` tool) -- the same lazy-import discipline
+        # the ``AgentRunError`` handler below uses.
+        child_heartbeat: asyncio.Task[None] | None = None
+        if child_run_id is not None and child_lease_owner is not None:
+            from meho_backplane.agent.invocation import _heartbeat_loop
+
+            child_heartbeat = asyncio.create_task(
+                _heartbeat_loop(child_run_id, child_lease_owner),
+                name=f"agent-heartbeat-{child_run_id}",
+            )
         try:
             # Bound 2 -- budget. Sharing ctx.usage threads the child's turns
             # into the parent's running total; the shared UsageLimits the loop
@@ -433,6 +476,12 @@ def make_invoke_agent_tool(
                 error=str(exc),
                 operator_sub=operator.sub,
             )
+            # Stop the heartbeat before finalizing: the child's terminal
+            # transition clears the lease, so a still-beating sidecar would
+            # only race to a no-op LeaseLostError. Cancelling first keeps the
+            # ordering clean.
+            await _stop_child_heartbeat(child_heartbeat)
+            child_heartbeat = None
             # Close the recorded child row to ``failed`` before re-raising, so a
             # failed / over-budget child does not stay stuck ``running``. Only a
             # recorded child has a row to finalize (no recorder -> child_run_id
@@ -447,6 +496,11 @@ def make_invoke_agent_tool(
                 f"Try a different approach or answer directly."
             ) from exc
         finally:
+            # Belt-and-suspenders: stop the heartbeat on every exit path
+            # (success, cancel, the ModelRetry re-raise above) so the sidecar
+            # never outlives the child loop. ``_stop_child_heartbeat`` is a
+            # no-op when it was already stopped in the except branch.
+            await _stop_child_heartbeat(child_heartbeat)
             current_agent_run_id_var.reset(run_id_token)
             _agent_name_chain_var.reset(chain_token)
             agent_invoke_depth_var.reset(depth_token)

--- a/backend/tests/integration/test_agent_approval_resume_broadcast_e2e.py
+++ b/backend/tests/integration/test_agent_approval_resume_broadcast_e2e.py
@@ -1,0 +1,216 @@
+# SPDX-License-Identifier: Apache-2.0
+# Copyright (c) 2026 evoila Group
+
+"""Real-Valkey delivery check for the agent approval-resume wait (#1501).
+
+Initiative G0.20 (#1500), Task #1501. The agent runtime's resume-on-approval
+path (:mod:`meho_backplane.agent.approval_wait`) blocks on a real per-tenant
+Valkey stream via ``XREAD BLOCK`` until the operator's
+``approval.{approved,rejected}`` decision event arrives. The unit suite
+(:mod:`tests.test_agent_approval_resume`) stubs
+:func:`~meho_backplane.broadcast.client.get_broadcast_blocking_client` with an
+``AsyncMock`` whose ``xread`` replays a hand-built entry, so a *real* Valkey
+delivery gap -- a wire-shape mismatch between
+:func:`~meho_backplane.operations.approval_queue.publish_approval_event` (the
+``XADD`` side) and :func:`~meho_backplane.agent.approval_wait.wait_for_approval_decision`
+(the ``XREAD`` side), or a cursor bug -- would be invisible to it.
+
+This integration test closes that gap. It boots a real Valkey container,
+publishes a genuine ``approval.approved`` event through the production
+publisher, and asserts the production wait observes it end to end across the
+real stream. The publish ordering mirrors production: the wait parks on
+``XREAD`` with the ``"$"`` tail cursor *before* the decision is published, so
+the test exercises exactly the live-delivery sequence (park → operator decides
+→ event lands → wait returns ``"approved"``).
+
+The Postgres / app stack is deliberately not booted: the only substrate the
+broadcast-delivery contract depends on is Valkey. The durable decision row +
+the in-process resume re-dispatch are covered by the unit suite; the open
+question this test answers is "does a real Valkey carry the publisher's event
+to the agent's waiter unchanged?".
+"""
+
+from __future__ import annotations
+
+import asyncio
+import os
+import uuid
+from collections.abc import AsyncIterator, Iterator
+from datetime import UTC, datetime
+from pathlib import Path
+
+import pytest
+
+from meho_backplane.agent.approval_wait import wait_for_approval_decision
+from meho_backplane.broadcast.client import (
+    dispose_broadcast_blocking_client,
+    dispose_broadcast_client,
+    get_broadcast_client,
+    reset_broadcast_blocking_client_for_testing,
+    reset_broadcast_client_for_testing,
+)
+from meho_backplane.db.models import ApprovalRequest
+from meho_backplane.operations.approval_queue import publish_approval_event
+from meho_backplane.settings import get_settings
+
+pytestmark = pytest.mark.asyncio
+
+_TENANT: uuid.UUID = uuid.UUID("11111111-1111-1111-1111-111111111111")
+
+
+def _docker_socket_present() -> bool:
+    """Docker usable when the unix socket (or ``DOCKER_HOST``) is present.
+
+    Mirrors :func:`tests.integration.conftest._docker_socket_present` so the
+    skip condition stays uniform across the testcontainer suites.
+    """
+    return Path("/var/run/docker.sock").exists() or os.environ.get("DOCKER_HOST") is not None
+
+
+_DOCKER_AVAILABLE: bool = _docker_socket_present()
+_DOCKER_SKIP_REASON: str = (
+    "Docker socket unavailable in this sandbox; runs in CI where containers are provisioned."
+)
+
+
+@pytest.fixture(scope="module")
+def valkey_url() -> Iterator[str]:
+    """Boot a Valkey 8 container; yield ``redis://host:port``.
+
+    Same image-override knob (``MEHO_TEST_VALKEY_IMAGE``) and module-scoped
+    boot-once shape :mod:`tests.integration.test_broadcast_overrides_e2e` and
+    :mod:`tests.integration.test_broadcast_load` use.
+    """
+    if not _DOCKER_AVAILABLE:
+        pytest.skip(_DOCKER_SKIP_REASON)
+    from testcontainers.redis import RedisContainer
+
+    image = os.environ.get("MEHO_TEST_VALKEY_IMAGE", "valkey/valkey:8")
+    with RedisContainer(image) as container:
+        host = container.get_container_host_ip()
+        port = container.get_exposed_port(6379)
+        yield f"redis://{host}:{port}"
+
+
+@pytest.fixture
+async def broadcast_runtime(
+    valkey_url: str,
+    monkeypatch: pytest.MonkeyPatch,
+) -> AsyncIterator[str]:
+    """Pin ``BROADCAST_REDIS_URL`` at the container, reset both client caches.
+
+    The publisher uses the fast client (``XADD``); the agent wait uses the
+    blocking client (``XREAD BLOCK``). Both honour ``BROADCAST_REDIS_URL`` but
+    are cached per-process, so both caches are reset here so the next getter on
+    either path builds against the testcontainer. ``FLUSHDB`` wipes any prior
+    stream state so the wait's ``"$"`` tail cursor starts from a clean stream.
+    """
+    monkeypatch.setenv("BROADCAST_REDIS_URL", valkey_url)
+    monkeypatch.setenv("KEYCLOAK_ISSUER_URL", "https://keycloak.test/realms/meho")
+    monkeypatch.setenv("KEYCLOAK_AUDIENCE", "meho-backplane")
+    monkeypatch.setenv("VAULT_ADDR", "https://vault.test")
+    get_settings.cache_clear()
+    reset_broadcast_client_for_testing()
+    reset_broadcast_blocking_client_for_testing()
+    await get_broadcast_client().flushdb()
+    try:
+        yield valkey_url
+    finally:
+        await dispose_broadcast_client()
+        await dispose_broadcast_blocking_client()
+        get_settings.cache_clear()
+
+
+def _approval_request(*, request_id: uuid.UUID) -> ApprovalRequest:
+    """Build a minimal in-memory ``ApprovalRequest`` for the publisher.
+
+    :func:`publish_approval_event` reads only ``id`` / ``connector_id`` /
+    ``op_id`` off the request to shape the broadcast payload, so a row that is
+    never persisted is sufficient for the delivery check -- the DB-backed
+    decision row is the unit suite's concern, not this test's.
+    """
+    return ApprovalRequest(
+        id=request_id,
+        tenant_id=_TENANT,
+        principal_sub="agent:reader",
+        op_id="vault.kv.write",
+        connector_id="vault-1.x",
+        params_hash="deadbeef",
+        proposed_effect={},
+        status="approved",
+        created_at=datetime.now(UTC),
+    )
+
+
+async def test_approve_event_reaches_agent_wait_over_real_valkey(
+    broadcast_runtime: str,
+) -> None:
+    """#1501 AC3: a real ``approval.approved`` delivery resumes the agent wait.
+
+    Park the production wait on the real stream first (so its ``"$"`` cursor
+    tails from before the decision, exactly as production does -- the
+    ``approval.pending`` event precedes the wait), then publish a genuine
+    ``approval.approved`` event through the production publisher. The wait must
+    observe it across the real Valkey and return ``"approved"``. A wire-shape
+    or cursor mismatch that the broadcast-stubbing unit test cannot see fails
+    here.
+    """
+    request_id = uuid.uuid4()
+
+    wait_task = asyncio.create_task(
+        wait_for_approval_decision(
+            tenant_id=_TENANT,
+            approval_request_id=request_id,
+            timeout_seconds=20.0,
+        )
+    )
+    # Let the waiter reach its first ``XREAD BLOCK`` so its ``"$"`` cursor is
+    # anchored before we publish -- otherwise the publish could land in the
+    # gap between task creation and the first read.
+    await asyncio.sleep(0.5)
+
+    await publish_approval_event(
+        tenant_id=_TENANT,
+        request=_approval_request(request_id=request_id),
+        decision="approved",
+        principal_sub="op-human",
+        audit_id=uuid.uuid4(),
+    )
+
+    decision = await asyncio.wait_for(wait_task, timeout=20.0)
+    assert decision == "approved"
+
+
+async def test_other_request_decision_does_not_resume_then_times_out(
+    broadcast_runtime: str,
+) -> None:
+    """A real decision for a *different* request id does not satisfy the wait.
+
+    Proves the request-id filter holds across the real wire (not just against
+    the stubbed entry): an unrelated tenant-mate's ``approval.approved`` lands
+    in the same stream but the wait keeps blocking and ends in ``"timeout"``
+    once its (short) cap lapses. Guards against a delivery path that matched on
+    stream membership alone.
+    """
+    waited_for = uuid.uuid4()
+    other_request = uuid.uuid4()
+
+    wait_task = asyncio.create_task(
+        wait_for_approval_decision(
+            tenant_id=_TENANT,
+            approval_request_id=waited_for,
+            timeout_seconds=2.0,
+        )
+    )
+    await asyncio.sleep(0.5)
+
+    await publish_approval_event(
+        tenant_id=_TENANT,
+        request=_approval_request(request_id=other_request),
+        decision="approved",
+        principal_sub="op-human",
+        audit_id=uuid.uuid4(),
+    )
+
+    decision = await asyncio.wait_for(wait_task, timeout=10.0)
+    assert decision == "timeout"

--- a/backend/tests/test_agent_invocation.py
+++ b/backend/tests/test_agent_invocation.py
@@ -31,6 +31,7 @@ from __future__ import annotations
 
 import asyncio
 from collections.abc import Iterator
+from datetime import UTC, datetime, timedelta
 from typing import Any
 from unittest.mock import AsyncMock
 from uuid import UUID, uuid4
@@ -51,6 +52,10 @@ from meho_backplane.agent.invocation import (
     _record_child_run,
     _resolve_child_definition,
 )
+from meho_backplane.agent.reaper import (
+    AGENT_RUN_REAPER_INTERRUPTION_REASON,
+    _run_one_tick,
+)
 from meho_backplane.agent.run import AgentDefinition, AgentRunEventKind, PydanticAgentRun
 from meho_backplane.agents.schemas import AgentDefinitionCreate, AgentModelTier
 from meho_backplane.agents.service import AgentDefinitionService
@@ -59,7 +64,13 @@ from meho_backplane.connectors.base import Connector
 from meho_backplane.connectors.registry import clear_registry, register_connector_v2
 from meho_backplane.connectors.schemas import FingerprintResult, OperationResult, ProbeResult
 from meho_backplane.db.engine import get_sessionmaker
-from meho_backplane.db.models import AgentPrincipal, AgentRunStatus, AgentRunTrigger, Tenant
+from meho_backplane.db.models import (
+    AgentPrincipal,
+    AgentRunStatus,
+    AgentRunTrigger,
+    ScheduledTriggerInFlightPolicy,
+    Tenant,
+)
 from meho_backplane.db.models import AgentRun as AgentRunRow
 from meho_backplane.operations import agent_run as run_lifecycle
 from meho_backplane.operations import register_typed_operation, reset_dispatcher_caches
@@ -375,6 +386,90 @@ async def test_poll_unknown_handle_is_not_found() -> None:
     invoker = _invoker_with(_final_text("x"))
     with pytest.raises(AgentRunNotFoundError):
         await invoker.poll(_make_operator(), uuid4())
+
+
+# ---------------------------------------------------------------------------
+# Lease/heartbeat wiring into the fire path (#1501)
+# ---------------------------------------------------------------------------
+
+
+async def test_create_run_row_stamps_lease_so_run_is_reapable() -> None:
+    """#1501: ``_create_run_row`` claims a lease, so a live run has a non-NULL
+    ``lease_expires_at`` and the reaper's claim query can reach it.
+
+    The pre-#1501 defect was that ``_create_run_row`` only called
+    ``create_run`` + ``start_run`` -- never ``claim_lease`` -- so every run
+    committed with ``lease_expires_at = NULL`` and the reaper
+    (``WHERE lease_expires_at IS NOT NULL AND < now``) could never reclaim a
+    hung/crashed run. Here we drive the real run-creation transaction and
+    assert the lease + owner landed.
+    """
+    await _seed_definition()
+    invoker = _invoker_with(_final_text("x"))
+    entry = await AgentDefinitionService().get(_TENANT_A, "reader")
+    assert entry is not None
+
+    run_id, lease_owner = await invoker._create_run_row(
+        _make_operator(), entry, provider="anthropic", model="claude-sonnet-4-6"
+    )
+
+    # The owner is the per-process worker stamp ("<hostname>:<pid>" shape).
+    assert ":" in lease_owner
+
+    sessionmaker = get_sessionmaker()
+    async with sessionmaker() as session:
+        row = await session.get(AgentRunRow, run_id)
+        assert row is not None
+        assert row.status == AgentRunStatus.RUNNING.value
+        # The lease is stamped in the same committed transaction as the
+        # pending -> running transition: a committed run is never
+        # ``running`` without a lease.
+        assert row.lease_owner == lease_owner
+        assert row.lease_expires_at is not None
+        # The default in-flight policy is the conservative reclaim outcome.
+        assert row.in_flight_policy == ScheduledTriggerInFlightPolicy.FAIL_INTO_AUDIT.value
+
+
+async def test_hung_run_with_expired_lease_is_reaped_to_failed() -> None:
+    """#1501 acceptance: a run created through the real fire path whose lease
+    has expired (simulated dead worker) is transitioned to ``failed`` by the
+    reaper within one reap interval.
+
+    Drives ``_create_run_row`` (the production lease-stamping path), back-dates
+    the lease to simulate a worker that died without releasing it, then runs
+    one reaper tick. With the default ``fail_into_audit`` policy the row lands
+    terminal ``failed`` with the reaper's interruption reason -- the
+    "no run silently lost" contract, end to end through the wired fire path.
+    """
+    await _seed_definition()
+    invoker = _invoker_with(_final_text("x"))
+    entry = await AgentDefinitionService().get(_TENANT_A, "reader")
+    assert entry is not None
+
+    run_id, _owner = await invoker._create_run_row(
+        _make_operator(), entry, provider="anthropic", model="claude-sonnet-4-6"
+    )
+
+    sessionmaker = get_sessionmaker()
+    # Simulate the worker dying: the lease lapsed two minutes ago and no
+    # heartbeat extended it.
+    async with sessionmaker() as session:
+        row = await session.get(AgentRunRow, run_id)
+        assert row is not None
+        row.lease_expires_at = datetime.now(UTC) - timedelta(seconds=120)
+        await session.commit()
+
+    await _run_one_tick()
+
+    async with sessionmaker() as session:
+        row = await session.get(AgentRunRow, run_id)
+        assert row is not None
+        assert row.status == AgentRunStatus.FAILED.value
+        assert row.error == AGENT_RUN_REAPER_INTERRUPTION_REASON
+        assert row.ended_at is not None
+        # Terminal transition cleared the lease.
+        assert row.lease_owner is None
+        assert row.lease_expires_at is None
 
 
 # ---------------------------------------------------------------------------
@@ -737,7 +832,9 @@ async def test_finalize_child_run_swallows_illegal_transition() -> None:
     # state out-of-band, simulating a cancel landing before the finalizer runs.
     child_def = await _resolve_child_definition(op, "child")
     assert child_def is not None
-    child_run_id = await _record_child_run(operator=op, definition=child_def, parent_run_id=None)
+    child_run_id, _lease_owner = await _record_child_run(
+        operator=op, definition=child_def, parent_run_id=None
+    )
 
     sessionmaker = get_sessionmaker()
     async with sessionmaker() as session:

--- a/backend/tests/test_agent_invoke.py
+++ b/backend/tests/test_agent_invoke.py
@@ -350,7 +350,7 @@ async def test_child_run_linked_to_parent_in_lineage() -> None:
         operator: Operator,
         definition: AgentDefinition,
         parent_run_id: UUID | None,
-    ) -> UUID:
+    ) -> tuple[UUID, str]:
         recorded.append(
             {
                 "tenant_id": operator.tenant_id,
@@ -358,7 +358,7 @@ async def test_child_run_linked_to_parent_in_lineage() -> None:
                 "parent_run_id": parent_run_id,
             }
         )
-        return child_run_id
+        return child_run_id, "test-worker:0"
 
     invoke_tool = make_invoke_agent_tool(
         resolver=resolver, child_runner=child_runner, recorder=recorder
@@ -392,15 +392,15 @@ def _resolver_for(child_def: AgentDefinition) -> ChildAgentResolver:
 
 
 async def _recorder_returning(child_run_id: UUID) -> ChildRunRecorder:
-    """A recorder that records the requested child and returns *child_run_id*."""
+    """A recorder that records the requested child and returns ``(id, owner)``."""
 
     async def recorder(
         *,
         operator: Operator,
         definition: AgentDefinition,
         parent_run_id: UUID | None,
-    ) -> UUID:
-        return child_run_id
+    ) -> tuple[UUID, str]:
+        return child_run_id, "test-worker:0"
 
     return recorder
 

--- a/backend/tests/test_examples_r1_tiered_triage.py
+++ b/backend/tests/test_examples_r1_tiered_triage.py
@@ -509,12 +509,14 @@ async def test_escalation_cap_enforced_in_recorder_hook() -> None:
     )
 
     # First two escalations land cleanly; the recorder returns a
-    # fresh UUID for each (mirroring the production invocation
-    # surface's child_run_id contract).
-    first_id = await recorder(operator=operator, definition=deep, parent_run_id=None)
-    second_id = await recorder(operator=operator, definition=deep, parent_run_id=None)
+    # fresh ``(UUID, lease_owner)`` for each (mirroring the production
+    # invocation surface's child_run_id + lease contract, #1501).
+    first_id, first_owner = await recorder(operator=operator, definition=deep, parent_run_id=None)
+    second_id, second_owner = await recorder(operator=operator, definition=deep, parent_run_id=None)
     assert isinstance(first_id, uuid.UUID)
     assert isinstance(second_id, uuid.UUID)
+    assert first_owner == "example-harness:0"
+    assert second_owner == "example-harness:0"
     assert observed == [deep.name, deep.name]
 
     # Third attempt trips the cap. ModelRetry surfaces inside the

--- a/docs/codebase/agent-run.md
+++ b/docs/codebase/agent-run.md
@@ -61,10 +61,28 @@ What is **not** in T6 or T4 (other tasks own these):
   cadence so the reaper does not reclaim a healthy run; the loop must
   also honour `LeaseLostError` by aborting immediately (any further
   side effects would be at-least-twice).
-- The trigger-firing path that calls `claim_lease` +
-  `snapshot_in_flight_policy` at run-start — G11.3-T2 (#823, cron + one-off)
-  and G11.3-T3 (#824, event subscription). T4 ships the substrate;
-  T2/T3 wire the call site.
+- The `snapshot_in_flight_policy` call site that copies a *firing
+  trigger's* `resume | fail_into_audit` onto the run at run-start —
+  G11.3-T2 (#823, cron + one-off) and G11.3-T3 (#824, event
+  subscription). Those tasks own the scheduled/event dispatch path that
+  has a trigger row to snapshot. (The `claim_lease` half of the
+  fire-path wiring is **no longer** future work — see below.)
+- **`claim_lease` at run-start is now wired (#1501).** The run fire
+  path (`agent/invocation.py`) stamps a lease in the **same committed
+  transaction** as the `pending -> running` transition, so a committed
+  run is never `running` without a lease and the reaper's claim query
+  (`status='running' AND lease_expires_at < now()`) can actually match
+  a real run. A heartbeat sidecar (`_heartbeat_loop`) bumps the lease
+  forward at `ttl_seconds/2` while the run is alive and is cancelled on
+  every exit path; if the worker task dies the sidecar dies with it,
+  the lease lapses, and the reaper drives the row to `failed`. This
+  ships across all three run shapes: the background run loop
+  (`_run_loop_to_completion`), the inline SSE stream (`stream`), and
+  child `invoke_agent` runs (`_record_child_run` returns
+  `(run_id, lease_owner)` so the `invoke_agent` tool heartbeats the
+  child for its loop's lifetime). Direct / scheduled / agent-invoked
+  runs leave `in_flight_policy` at the row default (`fail_into_audit`)
+  — they have no firing-trigger row to snapshot.
 - Per-tool-call raw+redacted audit rows + replay — G11.4/C2 (this is the
   run-level record those rows link to via `agent_session_id`).
 - Cost computation — G11.5/C3. The `cost` column is recorded here but
@@ -208,9 +226,11 @@ one transaction):
 ## In-flight reaper (T4 #825)
 
 `backend/src/meho_backplane/agent/reaper.py` owns the *reclaim* half of
-the no-silently-lost contract. The trigger-firing path (T2 / T3) writes
-the lease at run-start; the healthy worker bumps it forward via
-`heartbeat`; the reaper scans for expired leases on a fixed cadence
+the no-silently-lost contract. The run fire path (`agent/invocation.py`,
+#1501) writes the lease at run-start in the same transaction as
+`pending -> running`; the healthy worker bumps it forward via
+`heartbeat` (a `_heartbeat_loop` sidecar); the reaper scans for expired
+leases on a fixed cadence
 (`AGENT_RUN_REAPER_TICK_INTERVAL_SECONDS`, default 30s) and applies the
 per-run `in_flight_policy`:
 
@@ -310,6 +330,11 @@ Settings (all in `Settings`, all opt-out via env):
   #800 (G11 agentic ops runtime).
 - Initiative #804 (G11.3 Scheduler), Task #825 (T4 — lease/heartbeat
   + reaper).
+- #1501 — wires `claim_lease` + the `_heartbeat_loop` sidecar into the
+  run fire path (`backend/src/meho_backplane/agent/invocation.py`,
+  `agent/invoke.py`) across the background loop, the inline SSE stream,
+  and child `invoke_agent` runs, so the T4 reaper can reclaim a hung
+  run.
 - Migration `0017_create_agent_run.py` (T6 — table) +
   `0026_add_agent_run_lease_reaper.py` (T4 — lease columns); model
   `AgentRun` in `backend/src/meho_backplane/db/models.py`; service

--- a/examples/r1-tiered-triage/workflow.py
+++ b/examples/r1-tiered-triage/workflow.py
@@ -476,12 +476,16 @@ def make_policy_persisting_hooks(
         operator: Operator,
         definition: AgentDefinition,
         parent_run_id: uuid.UUID | None,
-    ) -> uuid.UUID:
-        # Synthetic id -- the harness has no DB row to point at. A
-        # production invocation surface would create a real
-        # ``agent_run`` row here and return its id; the harness gets
-        # away with a fresh UUID because the only consumer of the id
-        # is the finalizer, which keys on the output, not on the row.
+    ) -> tuple[uuid.UUID, str]:
+        # Synthetic id + lease owner -- the harness has no DB row to
+        # point at. A production invocation surface would create a real
+        # ``agent_run`` row here, stamp a lease, and return its id +
+        # ``lease_owner`` (the per-process worker stamp the
+        # ``invoke_agent`` heartbeat reuses); the harness gets away with
+        # a fresh UUID + a static owner because the only consumer of the
+        # id is the finalizer (which keys on the output, not the row),
+        # and the heartbeat never beats before the synthetic child loop
+        # returns.
         import uuid as _uuid_mod
 
         # Cap enforcement: refuse the escalation *before* the child
@@ -506,7 +510,7 @@ def make_policy_persisting_hooks(
             # escalation target (the deep tier); seeing N entries here
             # means N events the cheap tier classified as interesting.
             escalations_observed.append(definition.name)
-        return _uuid_mod.uuid4()
+        return _uuid_mod.uuid4(), "example-harness:0"
 
     async def _finalize(
         run_id: uuid.UUID,


### PR DESCRIPTION
## Summary

- The in-flight lease/heartbeat lifecycle (G11.3-T4 #825) was built and tested but **never wired into the run path** — `_create_run_row` only called `create_run` + `start_run`, so every agent run committed with `lease_expires_at = NULL`. The reaper's claim query (`status='running' AND lease_expires_at IS NOT NULL AND < now`) could therefore never match a real run, leaving a hung/crashed/worker-killed run stuck `status=running` forever with no terminal, audited state (SEV-1; defeats #825's "no run silently lost" contract).
- This PR stamps a lease on every run at start (in the same committed transaction as `pending -> running`) and runs a heartbeat sidecar while the run is alive, across all three run shapes — the background loop, the inline SSE stream, and child (`invoke_agent`) runs. If the worker task dies, the sidecar dies with it, the lease lapses, and the reaper drives the row to `failed` (the default `fail_into_audit` policy) instead of leaving it `running`.
- A `LeaseLostError` (the reaper or an operator cancel already reclaimed the row) stops the heartbeat cleanly so a partitioned worker stops touching a row it no longer owns.
- The `ChildRunRecorder` protocol now returns `(run_id, lease_owner)` so `invoke_agent` can heartbeat the child for its loop's lifetime — child runs are leased too, per the "all agent runs" scope.

The reaper itself already reaped correctly once leases existed (its tests pass); the bug was purely that nothing stamped a lease. The reaper is left unchanged — its resume-dispatch path (`T2/T3 will wire that filter`) is out of this task's scope.

## Test plan

- [x] `ruff check src/ tests/` — clean
- [x] `ruff format --check src/ tests/` — clean (876 files)
- [x] `mypy src/` — clean (430 source files)
- [x] `pytest tests/ --ignore=tests/integration` — 6675 passed, 194 skipped
- [x] **AC1** — `_create_run_row` claims a lease so a live run has a non-NULL `lease_expires_at`: `test_create_run_row_stamps_lease_so_run_is_reapable`
- [x] **AC2** — a run whose lease expired (simulated dead worker) is transitioned to `failed` by the reaper within one tick, exercised end-to-end through the real fire path: `test_hung_run_with_expired_lease_is_reaped_to_failed`
- [x] **AC3** — an integration test exercises the approval-resume wait through **real** Valkey broadcast delivery (the existing unit test stubs the broadcast client, so a real delivery gap would be invisible): `tests/integration/test_agent_approval_resume_broadcast_e2e.py` (testcontainers Valkey; runs in CI, skips when no Docker socket)

## Out of scope

- The scheduler tick blocking on a long run (`run_scheduled` bounded-wait) — sibling task #1502.
- The direct-operator-op execute-after-approve path — sibling task #1503.
- The reaper cancelling the in-process `asyncio.Task` — the loop observes terminal status at its next turn boundary via the existing cancellation seam (documented on `cancel_run`).

<!-- auto-implement-issue: fresh, iteration 1 -->

Closes #1501
