### PR TITLE
feat(connectors): park-time Vault KV write-capability preflight + write policy doc (#1504)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -117,6 +117,17 @@ connector-related release-notes line.
   module-level handler does not), so a legitimately target-less op still
   dispatches and the loud self-guard `RuntimeError` stays in place for
   genuine instance-cache faults (#1506).
+- Flag a Vault KV write (`vault.kv.put`/`patch`/`delete`) the dispatching
+  identity lacks capability for **at park time** instead of after a
+  four-eyes approval: `_handle_needs_approval` now probes
+  `POST sys/capabilities-self` on the target `<mount>/data/<path>` and
+  surfaces a `permission_preflight` banner (`will_be_denied: true` when
+  the token lacks `create`/`update`) on the approval row, so an operator
+  is not asked to approve a write Vault will then deny. The probe returns
+  only capability names — never a secret value — so it sidesteps the
+  credential-class redaction rule. Also documents the `meho-mcp` role's
+  required KV write-capability policy stanza + a `sys/capabilities-self`
+  verify command in `docs/cross-repo/connector-vault-policy.md` (#1504).
 
 ## [0.10.1] - 2026-06-04
 

--- a/backend/src/meho_backplane/connectors/vault/ops.py
+++ b/backend/src/meho_backplane/connectors/vault/ops.py
@@ -77,6 +77,7 @@ from meho_backplane.retrieval.embedding import EmbeddingService
 
 __all__ = [
     "VAULT_KV_READ_PARAMETER_SCHEMA",
+    "VAULT_KV_WRITE_CAPABILITIES",
     "register_vault_typed_operations",
     "vault_kv_delete",
     "vault_kv_list",
@@ -84,6 +85,8 @@ __all__ = [
     "vault_kv_put",
     "vault_kv_read",
     "vault_kv_versions",
+    "vault_kv_write_capability_preflight",
+    "vault_kv_write_target_path",
 ]
 
 #: Default KV-v2 mount point. hvac's ``mount_point`` parameter defaults
@@ -826,6 +829,156 @@ async def vault_kv_delete(
             mount_point=mount,
         )
         return {"deleted_versions": versions}
+
+
+# ---------------------------------------------------------------------------
+# Park-time write-capability preflight (G0.20-T4 #1504)
+# ---------------------------------------------------------------------------
+
+#: Vault ACL capabilities each KV-v2 write op needs on its target
+#: ``<mount>/data/<path>``, keyed by op-id. ``put`` / ``patch`` create
+#: a new secret version (``create`` for a first write, ``update`` for a
+#: subsequent one — Vault requires *both* on the path for an
+#: unconditional write); ``delete`` soft-deletes versions via
+#: ``POST <mount>/delete/<path>``, which Vault authorizes with ``update``
+#: on the *data* path (the canonical KV-v2 write capability). The doc
+#: stanza in ``docs/cross-repo/connector-vault-policy.md`` §6 grants
+#: exactly ``["create", "update"]`` on the templated write path, which
+#: satisfies every op here. A token "passes" the preflight when its
+#: capabilities on the data path are a superset of the op's requirement.
+VAULT_KV_WRITE_CAPABILITIES: dict[str, frozenset[str]] = {
+    "vault.kv.put": frozenset({"create", "update"}),
+    "vault.kv.patch": frozenset({"create", "update"}),
+    "vault.kv.delete": frozenset({"update"}),
+}
+
+
+def vault_kv_write_target_path(params: dict[str, Any]) -> str:
+    """Render the ``<mount>/data/<path>`` a KV-v2 write op authorizes against.
+
+    KV-v2 splits the API surface: the value lives under ``<mount>/data/``
+    and Vault authorizes a write (``put`` / ``patch`` / version
+    soft-delete) against that data path. The preflight queries
+    ``sys/capabilities-self`` on this exact string so the answer matches
+    what the real write would be authorized against.
+
+    Mirrors the ``mount`` / ``path`` defaulting + ``.strip()`` the write
+    handlers apply (default mount ``"secret"``; ``path`` is the location
+    under the mount, no leading slash). A ``KeyError`` propagates if
+    ``path`` is absent — but the dispatcher only reaches the preflight
+    after :func:`~meho_backplane.operations.dispatcher.validate_params`
+    has confirmed ``path`` is present, so the key is always set here.
+    """
+    mount = str(params.get("mount", _DEFAULT_KV_MOUNT)).strip()
+    path = str(params["path"]).strip().lstrip("/")
+    return f"{mount}/data/{path}"
+
+
+def _capabilities_grant_write(granted: list[str], required: frozenset[str]) -> bool:
+    """Decide whether *granted* Vault capabilities satisfy *required*.
+
+    Vault's ``root`` pseudo-capability (held by a root-class token)
+    authorizes everything, so its presence is a pass regardless of the
+    fine-grained list. The ``deny`` capability explicitly revokes access
+    even when paired with grants — an explicit ``deny`` on the path wins,
+    so it forces a fail. Otherwise the token passes only when every
+    required capability is present in the grant.
+    """
+    granted_set = set(granted)
+    if "deny" in granted_set:
+        return False
+    if "root" in granted_set:
+        return True
+    return required.issubset(granted_set)
+
+
+async def vault_kv_write_capability_preflight(
+    operator: Operator,
+    op_id: str,
+    params: dict[str, Any],
+) -> dict[str, Any] | None:
+    """Check, via ``sys/capabilities-self``, whether a KV-v2 write will be denied.
+
+    G0.20-T4 (#1504). Called at approval-park time (the dispatcher's
+    :func:`~meho_backplane.operations.dispatcher._handle_needs_approval`)
+    so a write Vault would reject surfaces a clear "this write will be
+    denied" on the approval row instead of failing only *after* a human
+    has spent a four-eyes review approving it.
+
+    The probe logs in exactly as the real write does
+    (:func:`~meho_backplane.auth.vault.vault_client_for_operator`, the
+    ``meho-mcp`` OIDC role) and issues ``POST sys/capabilities-self`` on
+    the op's ``<mount>/data/<path>``. ``sys/capabilities-self`` returns
+    only the *capability names* the calling token holds on the path
+    (``["create", "update"]`` / ``["read"]`` / ``["deny"]``) — **never
+    any secret material** — so it sidesteps the credential-class
+    preview-suppression rule that bars a value-revealing dry-run for a
+    credential write.
+
+    Identity caveat (documented, not enforced here): this probe runs
+    under the **dispatching** operator's token, but an approved
+    re-dispatch executes under the **reviewing** operator's token
+    (:func:`~meho_backplane.operations.approval_queue.resume_dispatch_after_approval`).
+    The two usually share the ``meho-mcp`` role policy, so the
+    dispatcher's answer is the right early signal; the reviewer must
+    nonetheless carry the same write grant. The result dict names the
+    probed ``principal_sub`` so the caveat is auditable on the row.
+
+    Returns ``None`` (no preflight result — caller stores the
+    identifier-only / builder default) when *op_id* is not a KV-v2 write,
+    or — **fail-soft** — when the probe itself errors (Vault unreachable,
+    role login fault, malformed response): a missing preflight must never
+    block the park, exactly as the ``proposed_effect`` builder hook
+    degrades. On success returns a redaction-safe summary:
+
+    ``{"check": "vault.capabilities-self", "path": <data-path>,
+    "required": [...], "granted": [...], "will_be_denied": bool,
+    "principal_sub": <dispatching-operator-sub>}``.
+    """
+    required = VAULT_KV_WRITE_CAPABILITIES.get(op_id)
+    if required is None:
+        return None
+
+    data_path = vault_kv_write_target_path(params)
+    try:
+        async with _auth_vault.vault_client_for_operator(operator) as client:
+            response = await asyncio.to_thread(
+                client.sys.get_capabilities,
+                paths=[data_path],
+            )
+    except Exception:
+        # Fail-soft: the park is the safety-relevant action; a probe that
+        # cannot reach Vault (or whose role login transiently fails) must
+        # not block it. The reviewer falls back to the identifier-only
+        # default and the post-approval write surfaces any real denial.
+        import structlog as _structlog
+
+        _structlog.get_logger(__name__).warning(
+            "vault_capability_preflight_failed",
+            op_id=op_id,
+            path=data_path,
+            operator_sub=operator.sub,
+            exc_info=True,
+        )
+        return None
+
+    # ``sys/capabilities-self`` returns the per-path capability list under
+    # the path key, with a top-level ``capabilities`` mirror for a single
+    # path. Prefer the path key; fall back to the mirror.
+    granted_raw = response.get(data_path)
+    if granted_raw is None:
+        granted_raw = response.get("capabilities")
+    granted = [str(c) for c in granted_raw] if isinstance(granted_raw, list) else []
+
+    will_be_denied = not _capabilities_grant_write(granted, required)
+    return {
+        "check": "vault.capabilities-self",
+        "path": data_path,
+        "required": sorted(required),
+        "granted": sorted(granted),
+        "will_be_denied": will_be_denied,
+        "principal_sub": operator.sub,
+    }
 
 
 #: Per-op registration specs for the KV-v2 group. One dict per op

--- a/backend/src/meho_backplane/operations/_preview.py
+++ b/backend/src/meho_backplane/operations/_preview.py
@@ -65,7 +65,9 @@ if TYPE_CHECKING:
 
 __all__ = [
     "PreviewContext",
+    "build_permission_preflight",
     "build_proposed_effect",
+    "register_permission_preflight",
     "register_preview_builder",
 ]
 
@@ -117,8 +119,35 @@ class PreviewBuilder(Protocol):
     async def __call__(self, ctx: PreviewContext) -> dict[str, Any] | None: ...
 
 
+class PermissionPreflight(Protocol):
+    """An op's opt-in park-time permission check.
+
+    Distinct from :class:`PreviewBuilder`: a preview computes *what the
+    write would do* (request/response shape) and is therefore suppressed
+    for credential-class ops; a permission preflight checks only *whether
+    the dispatching identity is authorized to perform the write* and
+    carries **no secret material** (e.g. Vault's ``sys/capabilities-self``
+    returns capability names, never secret values). It is therefore run
+    for every op with a registered preflight regardless of sensitivity
+    class -- the credential-class suppression that gates previews does
+    **not** apply here.
+
+    Returns a redaction-safe summary dict to merge into
+    :attr:`~meho_backplane.db.models.ApprovalRequest.proposed_effect`, or
+    ``None`` to decline (op isn't covered, or the probe failed soft). May
+    raise -- :func:`build_permission_preflight` treats a raise as "no
+    preflight" rather than failing the park.
+    """
+
+    async def __call__(self, ctx: PreviewContext) -> dict[str, Any] | None: ...
+
+
 #: ``op_id`` -> registered preview builder. Opt-in: absence ⇒ no preview.
 _PREVIEW_BUILDERS: dict[str, PreviewBuilder] = {}
+
+#: ``op_id`` -> registered permission preflight. Opt-in: absence ⇒ no
+#: preflight (and no entry in the approval row's ``permission_preflight``).
+_PERMISSION_PREFLIGHTS: dict[str, PermissionPreflight] = {}
 
 
 def register_preview_builder(op_id: str, builder: PreviewBuilder) -> None:
@@ -128,6 +157,15 @@ def register_preview_builder(op_id: str, builder: PreviewBuilder) -> None:
     import time so a re-import (test reload) is a no-op-equivalent.
     """
     _PREVIEW_BUILDERS[op_id] = builder
+
+
+def register_permission_preflight(op_id: str, preflight: PermissionPreflight) -> None:
+    """Register *preflight* as the park-time permission check for *op_id*.
+
+    Idempotent re-registration overwrites -- registration happens at
+    import time so a re-import (test reload) is a no-op-equivalent.
+    """
+    _PERMISSION_PREFLIGHTS[op_id] = preflight
 
 
 async def build_proposed_effect(ctx: PreviewContext) -> dict[str, Any] | None:
@@ -186,6 +224,48 @@ async def build_proposed_effect(ctx: PreviewContext) -> dict[str, Any] | None:
     }
 
 
+async def build_permission_preflight(ctx: PreviewContext) -> dict[str, Any] | None:
+    """Run the op's park-time permission check, if one is registered.
+
+    G0.20-T4 (#1504). Looks up a preflight for ``ctx.descriptor.op_id``;
+    returns ``None`` (no entry added to the approval row) when no
+    preflight is registered, when the preflight declines, or when it
+    raises (fail-soft -- the park proceeds regardless, mirroring
+    :func:`build_proposed_effect`).
+
+    Unlike :func:`build_proposed_effect`, this hook does **not** consult
+    the credential-class suppression set: a permission preflight returns
+    only authorization metadata (capability names, never a secret value),
+    so suppressing it for credential-class ops would defeat the whole
+    point -- a Vault ``vault.kv.put`` (which *is* ``credential_write``)
+    is exactly the op whose write Vault may deny post-approval. The
+    preflight is the redaction-safe way to surface that at park time.
+
+    On success the returned dict is stored under the ``"permission_preflight"``
+    key of the approval row's ``proposed_effect`` envelope so the
+    approval surface can render a "this write will be denied" banner.
+    """
+    op_id = ctx.descriptor.op_id
+    preflight = _PERMISSION_PREFLIGHTS.get(op_id)
+    if preflight is None:
+        return None
+
+    try:
+        result = await preflight(ctx)
+    except Exception:
+        # Fail-soft: a preflight is an early-warning convenience; the park
+        # is the safety-relevant action. Never let a probe fault block it.
+        _log.warning(
+            "permission_preflight_failed",
+            op_id=op_id,
+            operator_sub=getattr(ctx.operator, "sub", None),
+            exc_info=True,
+        )
+        return None
+
+    return result
+
+
 async def _k8s_apply_preview(ctx: PreviewContext) -> dict[str, Any] | None:
     """Preview builder for ``k8s.apply`` -- the server-side-apply dry-run.
 
@@ -221,13 +301,40 @@ async def _k8s_apply_preview(ctx: PreviewContext) -> dict[str, Any] | None:
     )
 
 
-def _register_builtin_builders() -> None:
-    """Wire the in-tree preview builders. Called at import time.
+async def _vault_kv_write_preflight(ctx: PreviewContext) -> dict[str, Any] | None:
+    """Permission preflight for the KV-v2 write ops (G0.20-T4 #1504).
 
-    Only ``k8s.apply`` is wired in #1437; other ops register their own
-    builders as the need arises (the hook is general).
+    Delegates to
+    :func:`~meho_backplane.connectors.vault.ops.vault_kv_write_capability_preflight`,
+    which logs in under the operator's ``meho-mcp`` role and issues
+    ``POST sys/capabilities-self`` on the op's ``<mount>/data/<path>`` to
+    learn whether the dispatching token holds the ``create`` / ``update``
+    capability the write needs. The response carries only capability
+    names -- no secret value -- so it is redaction-safe and runs even
+    though ``vault.kv.put`` / ``vault.kv.patch`` classify as
+    ``credential_write``.
+    """
+    from meho_backplane.connectors.vault.ops import vault_kv_write_capability_preflight
+
+    return await vault_kv_write_capability_preflight(
+        ctx.operator,
+        ctx.descriptor.op_id,
+        ctx.params,
+    )
+
+
+def _register_builtin_builders() -> None:
+    """Wire the in-tree preview builders + permission preflights.
+
+    Called at import time. ``k8s.apply`` registers a side-effect-free
+    dry-run preview (#1437); the KV-v2 write ops register a
+    capability-only permission preflight (#1504) -- a different hook
+    because a credential-class op's preview is suppressed but its
+    permission check (capability names, no secret) is not.
     """
     register_preview_builder("k8s.apply", _k8s_apply_preview)
+    for _write_op in ("vault.kv.put", "vault.kv.patch", "vault.kv.delete"):
+        register_permission_preflight(_write_op, _vault_kv_write_preflight)
 
 
 _register_builtin_builders()

--- a/backend/src/meho_backplane/operations/dispatcher.py
+++ b/backend/src/meho_backplane/operations/dispatcher.py
@@ -186,6 +186,7 @@ from meho_backplane.operations._lookup import (
 )
 from meho_backplane.operations._preview import (
     PreviewContext,
+    build_permission_preflight,
     build_proposed_effect,
 )
 from meho_backplane.operations._validate import (
@@ -904,43 +905,90 @@ async def _reduce_or_error(
         return result_connector_error(op_id, exc, duration_ms)
 
 
+def _identifier_default_effect(
+    *,
+    op_id: str,
+    connector_id: str,
+    target: Any,
+) -> dict[str, Any]:
+    """Build the identifier-only ``proposed_effect`` default.
+
+    Mirrors the default
+    :func:`~meho_backplane.operations.approval_queue.create_pending_request`
+    constructs when no preview is supplied, so a permission-preflight-only
+    park keeps the op identity on the row (``{op_id, connector_id,
+    target_id}``) and merely appends the preflight banner to it.
+    """
+    effect: dict[str, Any] = {"op_id": op_id, "connector_id": connector_id}
+    raw_tid = getattr(target, "id", None) if target is not None else None
+    if isinstance(raw_tid, uuid.UUID):
+        effect["target_id"] = str(raw_tid)
+    return effect
+
+
 async def _build_proposed_effect(
     *,
     op_id: str,
+    connector_id: str,
     descriptor: EndpointDescriptor,
     operator: Operator,
     target: Any,
     params: dict[str, Any],
 ) -> dict[str, Any] | None:
-    """Resolve the connector + invoke the op's preview builder, if any.
+    """Resolve the connector + run the op's preview builder and permission preflight.
 
-    G11.7 follow-up (#1437). Resolves the connector instance the same way
-    the execute path does (so a ``k8s.apply`` preview hits the same target
-    the real apply would), assembles a :class:`PreviewContext`, and
-    delegates to :func:`build_proposed_effect`. Returns ``None`` -- the
-    caller's identifier-only default -- when the op has no builder, when
-    connector resolution can't pick an instance, or (inside
-    :func:`build_proposed_effect`) when the builder declines or the op is
-    a credential class. Never raises: connector-resolution faults degrade
-    to "no preview" so the park always proceeds.
+    G11.7 follow-up (#1437) + G0.20-T4 (#1504). Resolves the connector
+    instance the same way the execute path does (so a ``k8s.apply``
+    preview hits the same target the real apply would), assembles a
+    :class:`PreviewContext`, and runs two independent, opt-in hooks:
+
+    * :func:`build_proposed_effect` -- the side-effect-free *preview* of
+      what the write would do. Suppressed for credential-class ops (the
+      durable row must not echo secret material), so most Vault/k8s
+      secret writes get ``None`` here.
+    * :func:`build_permission_preflight` -- the park-time *permission
+      check* (``vault.kv.put`` etc. probe ``sys/capabilities-self``).
+      Returns only capability names -- no secret value -- so it runs even
+      for credential-class ops and is merged under the
+      ``"permission_preflight"`` key.
+
+    Returns the merged envelope, or ``None`` when neither hook produced
+    anything (the caller then stores the identifier-only default). When
+    only the preflight fired, its result is merged onto the identifier
+    default-shaped base so the reviewer still sees the denial banner.
+    Never raises: connector-resolution faults degrade to "no preview" so
+    the park always proceeds.
     """
     try:
         connector_instance, resolution_error, _ = await _resolve_connector_instance(
             descriptor, target
         )
         if resolution_error is not None:
-            # The op can't be previewed against an unresolved connector;
-            # the reviewer still gets the identifier-only default.
-            return None
-        return await build_proposed_effect(
-            PreviewContext(
-                descriptor=descriptor,
-                connector_instance=connector_instance,
-                operator=operator,
-                target=target,
-                params=params,
-            )
+            connector_instance = None
+        ctx = PreviewContext(
+            descriptor=descriptor,
+            connector_instance=connector_instance,
+            operator=operator,
+            target=target,
+            params=params,
         )
+        preview = await build_proposed_effect(ctx)
+        preflight = await build_permission_preflight(ctx)
+        if preflight is None:
+            # No permission preflight ran -- preserve the prior contract
+            # (builder result, or ``None`` → identifier-only default).
+            return preview
+        # The preflight fired; attach it to whatever base the preview
+        # produced. When there is no preview (the common case: a
+        # suppressed credential-class write), use the same identifier-only
+        # shape ``create_pending_request`` would default to so the row
+        # still names the op alongside the denial banner.
+        if preview is not None:
+            base = dict(preview)
+        else:
+            base = _identifier_default_effect(op_id=op_id, connector_id=connector_id, target=target)
+        base["permission_preflight"] = preflight
+        return base
     except Exception:
         import structlog as _structlog
 
@@ -993,8 +1041,17 @@ async def _handle_needs_approval(
     # in the approval queue. Opt-in per op + fail-soft: ops without a
     # registered builder (and any builder that raises) yield ``None`` and
     # the queue stores the identifier-only default exactly as before.
+    #
+    # G0.20-T4 (#1504): the same hook also runs the op's park-time
+    # permission preflight (the Vault KV-write ops probe
+    # ``sys/capabilities-self``) and merges its capability-only,
+    # secret-free result under ``proposed_effect["permission_preflight"]``
+    # so a write Vault would deny surfaces a "this write will be denied"
+    # banner at park time instead of failing only after a four-eyes
+    # approval. Fail-soft too: a probe fault degrades to no banner.
     proposed_effect = await _build_proposed_effect(
         op_id=op_id,
+        connector_id=connector_id,
         descriptor=descriptor,
         operator=operator,
         target=target,

--- a/backend/tests/_vault_fakes.py
+++ b/backend/tests/_vault_fakes.py
@@ -556,6 +556,36 @@ class _FakeSysBackend:
     mount_enable_calls: list[dict[str, Any]] = field(default_factory=list)
     raise_on_mount_tune: Exception | None = None
     mount_tune_calls: list[dict[str, Any]] = field(default_factory=list)
+    # G0.20-T4 (#1504) park-time write-capability preflight. The Vault
+    # KV-write preflight calls ``client.sys.get_capabilities(paths=[...])``
+    # → ``POST sys/capabilities-self``. ``capabilities_by_path`` maps the
+    # probed data path to the capability list Vault would return; an
+    # unmapped path falls back to ``default_capabilities`` (defaults to
+    # the deny-by-omission empty list so a test that forgets to grant a
+    # path models a read-only role). ``raise_on_get_capabilities`` drives
+    # the fail-soft branch.
+    capabilities_by_path: dict[str, list[str]] = field(default_factory=dict)
+    default_capabilities: list[str] = field(default_factory=list)
+    raise_on_get_capabilities: Exception | None = None
+    get_capabilities_calls: list[dict[str, Any]] = field(default_factory=list)
+
+    def get_capabilities(
+        self, paths: list[str], token: str | None = None, accessor: str | None = None
+    ) -> dict[str, Any]:
+        self.get_capabilities_calls.append(
+            {"paths": list(paths), "token": token, "accessor": accessor}
+        )
+        if self.raise_on_get_capabilities is not None:
+            raise self.raise_on_get_capabilities
+        # Vault returns a per-path key plus a ``capabilities`` mirror for
+        # a single-path query. Model both so consumers can read either.
+        body: dict[str, Any] = {}
+        single = paths[0] if len(paths) == 1 else None
+        for p in paths:
+            body[p] = list(self.capabilities_by_path.get(p, self.default_capabilities))
+        if single is not None:
+            body["capabilities"] = list(body[single])
+        return body
 
     def read_health_status(self, *, method: str = "HEAD", **_kwargs: Any) -> Any:
         self.read_calls.append({"method": method})

--- a/backend/tests/test_connectors_vault.py
+++ b/backend/tests/test_connectors_vault.py
@@ -83,11 +83,16 @@ from meho_backplane.connectors.vault import (
     VaultConnector,
     register_vault_typed_operations,
 )
-from meho_backplane.connectors.vault.ops import _KV_OP_SPECS
+from meho_backplane.connectors.vault.ops import (
+    _KV_OP_SPECS,
+    VAULT_KV_WRITE_CAPABILITIES,
+    vault_kv_write_capability_preflight,
+    vault_kv_write_target_path,
+)
 from meho_backplane.operations import dispatch, reset_dispatcher_caches
 from meho_backplane.settings import get_settings
 
-from ._vault_fakes import install_fake_client
+from ._vault_fakes import install_fake_client, install_fake_vault
 
 # Shared fake for hvac's non-200 health response (standby / active-perf-standby).
 # Defined once here to avoid duplicating the class body in every test that
@@ -1078,3 +1083,150 @@ def test_kv_read_ops_do_not_require_approval(op_id: str) -> None:
     """Read-only KV-v2 ops omit ``requires_approval`` (default False)."""
     by_id = {spec["op_id"]: spec for spec in _KV_OP_SPECS}
     assert by_id[op_id].get("requires_approval", False) is False, op_id
+
+
+# ---------------------------------------------------------------------------
+# Park-time write-capability preflight (G0.20-T4 #1504)
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.parametrize(
+    ("params", "expected"),
+    [
+        ({"path": "meho/test/x"}, "secret/data/meho/test/x"),
+        ({"mount": "kv", "path": "meho/y"}, "kv/data/meho/y"),
+        # The handler-mirroring strip: leading slash + surrounding space.
+        ({"path": "  /meho/z  "}, "secret/data/meho/z"),
+    ],
+)
+def test_write_target_path_renders_data_path(params: dict[str, Any], expected: str) -> None:
+    """The preflight probes ``<mount>/data/<path>`` — the KV-v2 write path."""
+    assert vault_kv_write_target_path(params) == expected
+
+
+def test_write_capabilities_cover_every_write_op() -> None:
+    """Every ``requires_approval`` KV write op has a capability requirement."""
+    write_ops = {spec["op_id"] for spec in _KV_OP_SPECS if spec.get("requires_approval") is True}
+    assert write_ops == set(VAULT_KV_WRITE_CAPABILITIES)
+
+
+@pytest.mark.asyncio
+async def test_preflight_returns_none_for_non_write_op() -> None:
+    """A read op is not covered — the preflight declines (no probe, no banner)."""
+    result = await vault_kv_write_capability_preflight(
+        _make_operator(), "vault.kv.read", {"path": "meho/x"}
+    )
+    assert result is None
+
+
+@pytest.mark.asyncio
+async def test_preflight_flags_will_be_denied_for_read_only_role(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """A token with only ``read`` on the data path → ``will_be_denied=True``.
+
+    Models the exact incident #1504 chases: the ``meho-mcp`` role grants
+    read but no ``create``/``update`` on the write path. ``put`` needs
+    both, so the preflight flags the write as one that Vault will deny —
+    surfaced at park time instead of post-approval.
+    """
+    fake = install_fake_vault(monkeypatch)
+    fake.sys.capabilities_by_path = {"secret/data/meho/test/x": ["read"]}
+
+    result = await vault_kv_write_capability_preflight(
+        _make_operator(), "vault.kv.put", {"path": "meho/test/x"}
+    )
+
+    assert result is not None
+    assert result["check"] == "vault.capabilities-self"
+    assert result["path"] == "secret/data/meho/test/x"
+    assert result["required"] == ["create", "update"]
+    assert result["granted"] == ["read"]
+    assert result["will_be_denied"] is True
+    assert result["principal_sub"] == "test-operator"
+    # The probe queried capabilities-self (no token / accessor → self).
+    assert fake.sys.get_capabilities_calls == [
+        {"paths": ["secret/data/meho/test/x"], "token": None, "accessor": None}
+    ]
+    # No secret value is ever read — only the capability probe ran.
+    assert fake.secrets.kv.v2.read_calls == []
+
+
+@pytest.mark.asyncio
+async def test_preflight_passes_for_role_with_write(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """A token holding ``create``/``update`` on the path → ``will_be_denied=False``."""
+    fake = install_fake_vault(monkeypatch)
+    fake.sys.capabilities_by_path = {"secret/data/meho/test/x": ["create", "read", "update"]}
+
+    result = await vault_kv_write_capability_preflight(
+        _make_operator(), "vault.kv.put", {"path": "meho/test/x"}
+    )
+
+    assert result is not None
+    assert result["will_be_denied"] is False
+
+
+@pytest.mark.asyncio
+async def test_preflight_delete_needs_only_update(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """``vault.kv.delete`` authorizes against ``update`` on the data path."""
+    fake = install_fake_vault(monkeypatch)
+    fake.sys.capabilities_by_path = {"secret/data/meho/v": ["read", "update"]}
+
+    result = await vault_kv_write_capability_preflight(
+        _make_operator(), "vault.kv.delete", {"path": "meho/v", "versions": [1]}
+    )
+
+    assert result is not None
+    assert result["required"] == ["update"]
+    assert result["will_be_denied"] is False
+
+
+@pytest.mark.asyncio
+async def test_preflight_root_token_passes(monkeypatch: pytest.MonkeyPatch) -> None:
+    """A root-class token (capability ``root``) passes regardless of the list."""
+    fake = install_fake_vault(monkeypatch)
+    fake.sys.capabilities_by_path = {"secret/data/meho/x": ["root"]}
+
+    result = await vault_kv_write_capability_preflight(
+        _make_operator(), "vault.kv.put", {"path": "meho/x"}
+    )
+
+    assert result is not None
+    assert result["will_be_denied"] is False
+
+
+@pytest.mark.asyncio
+async def test_preflight_explicit_deny_fails(monkeypatch: pytest.MonkeyPatch) -> None:
+    """An explicit ``deny`` on the path forces ``will_be_denied=True``."""
+    fake = install_fake_vault(monkeypatch)
+    fake.sys.capabilities_by_path = {"secret/data/meho/x": ["create", "update", "deny"]}
+
+    result = await vault_kv_write_capability_preflight(
+        _make_operator(), "vault.kv.put", {"path": "meho/x"}
+    )
+
+    assert result is not None
+    assert result["will_be_denied"] is True
+
+
+@pytest.mark.asyncio
+async def test_preflight_fail_soft_when_probe_raises(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """A probe fault (Vault unreachable / login error) degrades to no banner.
+
+    Fail-soft mirrors the ``proposed_effect`` builder contract: a missing
+    preflight must never block the park.
+    """
+    fake = install_fake_vault(monkeypatch)
+    fake.sys.raise_on_get_capabilities = hvac.exceptions.VaultDown("sealed")
+
+    result = await vault_kv_write_capability_preflight(
+        _make_operator(), "vault.kv.put", {"path": "meho/x"}
+    )
+
+    assert result is None

--- a/backend/tests/test_operations_dispatcher.py
+++ b/backend/tests/test_operations_dispatcher.py
@@ -1947,6 +1947,81 @@ async def test_park_without_builder_uses_identifier_default(
         assert "preview" not in row.proposed_effect
 
 
+@pytest.mark.asyncio
+async def test_park_merges_permission_preflight_onto_identifier_default(
+    stub_embedding_service: AsyncMock,
+    captured_events: list[BroadcastEvent],
+) -> None:
+    """A parked write with a registered permission preflight stores its banner.
+
+    G0.20-T4 (#1504): a credential-class write has no preview (suppressed),
+    but its capability-only permission preflight still runs and is merged
+    under ``proposed_effect["permission_preflight"]`` — so the reviewer
+    sees "this write will be denied" at park time, alongside the
+    identifier-only default (op identity is preserved).
+    """
+    from meho_backplane.db.models import ApprovalRequest
+    from meho_backplane.operations._preview import (
+        _PERMISSION_PREFLIGHTS,
+        PreviewContext,
+        register_permission_preflight,
+    )
+
+    async def _preflight(ctx: PreviewContext) -> dict[str, Any]:
+        return {
+            "check": "vault.capabilities-self",
+            "path": f"secret/data/{ctx.params.get('path', '?')}",
+            "required": ["create", "update"],
+            "granted": ["read"],
+            "will_be_denied": True,
+            "principal_sub": ctx.operator.sub,
+        }
+
+    register_connector_v2(product="vault", version="", impl_id="", cls=_NoOpVaultConnector)
+    target = _FakeTarget(product="vault")
+    await register_typed_operation(
+        product="vault",
+        version="1.x",
+        impl_id="vault",
+        op_id="vault.kv.preflight_op",
+        handler=_module_handler_returning_dict,
+        summary="Op with a registered permission preflight.",
+        description="Parks for approval; the preflight flags a will-be-denied write.",
+        parameter_schema={"type": "object"},
+        safety_level="caution",
+        requires_approval=True,
+        when_to_use=None,
+        embedding_service=stub_embedding_service,
+    )
+    register_permission_preflight("vault.kv.preflight_op", _preflight)
+    try:
+        result = await dispatch(
+            operator=_make_operator(principal_kind=PrincipalKind.AGENT),
+            connector_id="vault-1.x",
+            op_id="vault.kv.preflight_op",
+            target=target,
+            params={"path": "meho/test/x"},
+        )
+        assert result.status == "awaiting_approval"
+        approval_request_id = UUID(result.extras["approval_request_id"])
+        sessionmaker = get_sessionmaker()
+        async with sessionmaker() as fresh:
+            row = await fresh.get(ApprovalRequest, approval_request_id)
+            assert row is not None
+            # Identifier default is preserved, with the preflight merged in.
+            assert row.proposed_effect["op_id"] == "vault.kv.preflight_op"
+            assert row.proposed_effect["connector_id"] == "vault-1.x"
+            assert row.proposed_effect["target_id"] == str(target.id)
+            preflight = row.proposed_effect["permission_preflight"]
+            assert preflight["will_be_denied"] is True
+            assert preflight["required"] == ["create", "update"]
+            assert preflight["granted"] == ["read"]
+            # No raw secret material — only the capability banner.
+            assert "data" not in row.proposed_effect
+    finally:
+        _PERMISSION_PREFLIGHTS.pop("vault.kv.preflight_op", None)
+
+
 # ---------------------------------------------------------------------------
 # compute_params_hash
 # ---------------------------------------------------------------------------

--- a/backend/tests/test_operations_preview.py
+++ b/backend/tests/test_operations_preview.py
@@ -34,7 +34,9 @@ from meho_backplane.auth.operator import Operator, TenantRole
 from meho_backplane.connectors.kubernetes import KubernetesConnector
 from meho_backplane.operations._preview import (
     PreviewContext,
+    build_permission_preflight,
     build_proposed_effect,
+    register_permission_preflight,
     register_preview_builder,
 )
 
@@ -207,3 +209,73 @@ async def test_credential_class_op_preview_suppressed() -> None:
     )
     assert await build_proposed_effect(ctx) is None
     assert builder_ran is False, "sensitive-class gate must run before the builder"
+
+
+# ---------------------------------------------------------------------------
+# Permission preflight hook (G0.20-T4 #1504)
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.asyncio
+async def test_permission_preflight_runs_for_credential_class_op() -> None:
+    """A permission preflight runs even when the op classifies credential-class.
+
+    This is the whole point of the separate hook: ``vault.kv.put`` IS
+    ``credential_write`` (so its *preview* is suppressed), yet its
+    capability-only *permission* check must still run — it carries no
+    secret material, and it is exactly the op whose write Vault may deny
+    post-approval.
+    """
+    ran = False
+
+    async def _preflight(_ctx: PreviewContext) -> dict[str, Any]:
+        nonlocal ran
+        ran = True
+        return {"check": "vault.capabilities-self", "will_be_denied": True}
+
+    register_permission_preflight("vault.kv.put", _preflight)
+    ctx = PreviewContext(
+        descriptor=_FakeDescriptor(op_id="vault.kv.put"),  # type: ignore[arg-type]
+        connector_instance=None,
+        operator=_operator(),
+        target=_FakeTarget(),
+        params={"path": "secret/data/x", "data": {"k": "v"}},
+    )
+
+    # The preview is suppressed (credential class), proving the preflight
+    # is a genuinely separate, non-suppressed path.
+    assert await build_proposed_effect(ctx) is None
+    result = await build_permission_preflight(ctx)
+    assert ran is True
+    assert result == {"check": "vault.capabilities-self", "will_be_denied": True}
+
+
+@pytest.mark.asyncio
+async def test_permission_preflight_none_without_registration() -> None:
+    """An op with no registered preflight yields ``None`` (no banner)."""
+    ctx = PreviewContext(
+        descriptor=_FakeDescriptor(op_id="some.unregistered.op"),  # type: ignore[arg-type]
+        connector_instance=None,
+        operator=_operator(),
+        target=_FakeTarget(),
+        params={},
+    )
+    assert await build_permission_preflight(ctx) is None
+
+
+@pytest.mark.asyncio
+async def test_permission_preflight_is_fail_soft() -> None:
+    """A preflight that raises degrades to ``None`` — the park always proceeds."""
+
+    async def _boom(_ctx: PreviewContext) -> dict[str, Any] | None:
+        raise RuntimeError("capabilities probe hit Vault and failed")
+
+    register_permission_preflight("test.preflight.boom", _boom)
+    ctx = PreviewContext(
+        descriptor=_FakeDescriptor(op_id="test.preflight.boom"),  # type: ignore[arg-type]
+        connector_instance=None,
+        operator=_operator(),
+        target=_FakeTarget(),
+        params={},
+    )
+    assert await build_permission_preflight(ctx) is None

--- a/docs/codebase/approvals.md
+++ b/docs/codebase/approvals.md
@@ -244,6 +244,49 @@ Application / AppProject — wired in
 `connectors/argocd/ops_write_preview.py`. Further connectors register
 their own builders as needed.
 
+## Permission preflight hook (#1504)
+
+The `proposed_effect` *preview* above is suppressed for credential-class
+ops — but a credential write (`vault.kv.put`) is precisely the op most
+likely to be **denied** by Vault *after* a human spends a four-eyes
+review approving it (the `meho-mcp` role grants `read` but no
+`create`/`update` on the write path). To surface that at park time
+without violating the redaction rule, `_preview.py` adds a **second**,
+parallel registry: `register_permission_preflight(op_id, preflight)` +
+`build_permission_preflight`.
+
+A permission preflight is distinct from a preview:
+
+- A **preview** says *what the write would do* (request/response shape) —
+  so it is suppressed for credential-class ops.
+- A **permission preflight** says *whether the dispatching identity is
+  authorized to perform the write* — it returns only authorization
+  metadata (Vault capability names, never a secret value), so it runs
+  for **every** registered op regardless of sensitivity class. The
+  credential-class suppression that gates previews does **not** apply.
+
+At the park point, `dispatcher._build_proposed_effect` runs **both**
+hooks and merges them: the preview (or the identifier-only default when
+there is no preview) is the base, and the preflight result is attached
+under `proposed_effect["permission_preflight"]`. Both are opt-in and
+fail-soft — a preflight that raises degrades to no banner; the park
+always proceeds.
+
+The KV-v2 write ops (`vault.kv.put` / `vault.kv.patch` /
+`vault.kv.delete`) register a preflight that probes
+`POST sys/capabilities-self` on the target `<mount>/data/<path>` and
+returns `{check, path, required, granted, will_be_denied, principal_sub}`
+— see
+[`docs/codebase/connectors-vault.md`](connectors-vault.md) "Park-time
+write-capability preflight" and
+[`docs/cross-repo/connector-vault-policy.md`](../cross-repo/connector-vault-policy.md)
+§6 for the write policy + verify command. **Whose token:** the preflight
+runs under the dispatching operator's token, but the approved re-dispatch
+runs under the **reviewing** operator's token
+(`resume_dispatch_after_approval`); both share the `meho-mcp` role policy,
+so the preflight is the right early signal while the reviewer must carry
+the same grant.
+
 ## Transports
 
 ### REST (`backend/src/meho_backplane/api/v1/approvals.py`)

--- a/docs/codebase/connectors-vault.md
+++ b/docs/codebase/connectors-vault.md
@@ -400,6 +400,66 @@ do not stall. The integration tests drive the gated writes via the
 approvals-API resume path (`dispatch(..., _approved=True)`), the same
 path that runs once a human approves.
 
+## Park-time write-capability preflight (G0.20-T4 #1504)
+
+A `requires_approval` KV write parks for a four-eyes review. That review
+is **wasted** if the approved write then hits Vault `permission denied` —
+the consumer incident (`claude-rdc-hetzner-dc#864`) was exactly this: the
+`meho-mcp` role's templated policy granted `read` but no
+`create`/`update` on the write path, so every approved KV write failed
+post-approval.
+
+To surface that **before** parking, `_handle_needs_approval`
+(`operations/dispatcher.py`) runs a permission preflight for the KV write
+ops. The preflight is `vault_kv_write_capability_preflight` (`ops.py`):
+it logs in exactly as the real write does
+(`vault_client_for_operator`, the `meho-mcp` role) and issues
+`POST sys/capabilities-self` on the op's `<mount>/data/<path>`
+(`client.sys.get_capabilities(paths=[...])`). It compares the granted
+capabilities against the per-op requirement in
+`VAULT_KV_WRITE_CAPABILITIES` (`put`/`patch` need `create`+`update`;
+`delete` needs `update`) and returns a redaction-safe summary:
+
+```python
+{"check": "vault.capabilities-self", "path": "secret/data/...",
+ "required": ["create", "update"], "granted": ["read"],
+ "will_be_denied": True, "principal_sub": "<dispatching-op-sub>"}
+```
+
+The dispatcher merges that under
+`ApprovalRequest.proposed_effect["permission_preflight"]`, so the
+approval surface can render a "this write will be denied" banner.
+
+Two design points keep this correct:
+
+- **It is a permission check, not a preview.** The
+  `proposed_effect` *builder* hook (`_preview.py::build_proposed_effect`)
+  is structurally **suppressed** for credential-class ops (a
+  value-revealing dry-run of a credential write would leak the secret).
+  `vault.kv.put`/`patch` classify `credential_write`, so they get **no**
+  builder preview. The preflight is a **separate** hook
+  (`_preview.py::build_permission_preflight` + a
+  `_PERMISSION_PREFLIGHTS` registry) that is **not** subject to that
+  suppression: `sys/capabilities-self` returns only capability names —
+  never a secret value — so it is redaction-safe and runs for exactly
+  the credential-class ops the preview can't cover.
+- **Whose token?** The preflight runs under the **dispatching**
+  operator's token (the only identity available at park time). An
+  *approved* re-dispatch runs under the **reviewing** operator's token
+  (`approval_queue.resume_dispatch_after_approval`). Both share the
+  `meho-mcp` role policy, so the dispatcher's answer is the right early
+  signal — but the reviewer's token must also carry the write grant.
+  The summary names the probed `principal_sub` so the caveat is auditable
+  on the row; the doc-side write policy + verify command live in
+  [`docs/cross-repo/connector-vault-policy.md`](../cross-repo/connector-vault-policy.md)
+  §6.
+
+Fail-soft, mirroring the `proposed_effect` builder: a probe fault (Vault
+unreachable, role login error) degrades to **no banner** (the park always
+proceeds); a non-write op short-circuits to `None`. Unit + dispatcher
+integration coverage in `test_connectors_vault.py`,
+`test_operations_preview.py`, and `test_operations_dispatcher.py`.
+
 ## JSONFlux result-handle path (`vault.kv.list`)
 
 `vault.kv.list` is the only set-shaped op on the v0.2 Vault surface

--- a/docs/cross-repo/connector-vault-policy.md
+++ b/docs/cross-repo/connector-vault-policy.md
@@ -291,6 +291,126 @@ Expected outcomes:
   kubeconfig out of every log event and every `OperationResult` — the
   policy doc's job is to keep it out of *Vault's* logs too (HMAC).
 
+## 6. KV-v2 write surface — the `meho-mcp` write policy (v0.10.0+)
+
+§2–§5 cover the **read** path every connector needs. v0.10.0 added a
+KV-v2 **write** surface — `vault.kv.put` (new version, wholesale
+replace), `vault.kv.patch` (merge fields onto the current version), and
+`vault.kv.delete` (soft-delete versions)
+([`connectors/vault/ops.py`](../../backend/src/meho_backplane/connectors/vault/ops.py)).
+These ops register `requires_approval=True`, so a human/operator write
+parks for a four-eyes review before it executes. **The review is wasted
+if the write then hits Vault `permission denied`** — the templated §2
+policy grants only `read`, with no `create`/`update` on the write path,
+so a freshly-provisioned `meho-mcp` role denies every KV write.
+
+This section documents the write-capability stanza the role needs, and a
+copy-paste `sys/capabilities-self` command to verify a token can write a
+path **before** an operator approves the parked write.
+
+### 6.1 Write-capability policy stanza
+
+Like the §2 reads, KV-v2 writes are scoped per operator through ACL
+policy templating. KV-v2 authorizes a write against the **`/data/`**
+path (the value path); `vault.kv.delete`'s version soft-delete
+(`POST <mount>/delete/<path>`) is likewise authorized by `update` on the
+data path. Add this stanza alongside the §2 read grants (it is
+*additive* — keep both):
+
+```hcl
+# Per-target connector secret WRITES, scoped to the operator's own
+# identity. <ACCESSOR> is the JWT mount accessor (resolve it as in §2).
+# `create` covers a first write to a path; `update` covers a subsequent
+# write (new version) and the version soft-delete. Vault requires BOTH
+# for an unconditional `vault.kv.put` / `vault.kv.patch`.
+path "secret/data/targets/{{identity.entity.aliases.<ACCESSOR>.name}}/*" {
+  capabilities = ["create", "read", "update"]
+}
+```
+
+Notes:
+
+- **`create` *and* `update` are both required** for `vault.kv.put` /
+  `vault.kv.patch`. Vault treats a first write to a non-existent path as
+  `create` and a write to an existing path as `update`; an unconditional
+  write (no CAS guard) can be either, so the policy must grant both or
+  the write fails the first time the path's existence flips. `read` is
+  carried here too so the §2 read grant and this write grant can collapse
+  into one stanza if you prefer (the connector's write path does not
+  itself read the value, but keeping `read` here is harmless and avoids
+  two near-identical path blocks).
+- **`vault.kv.delete` needs only `update`** on the data path — the
+  soft-delete is a write against the version metadata, not a separate
+  `delete` capability on `/data/`. The `["create", "read", "update"]`
+  grant above already covers it.
+- **No `/metadata/` write grant is needed** for these three ops. They
+  operate on `/data/` (and the version soft-delete endpoint, authorized
+  by `update` on `/data/`); destroying versions or deleting all metadata
+  (`vault kv metadata delete`) is **not** a wired op and deliberately
+  needs no grant.
+- The **same per-operator templating constraints** from §2 apply: no
+  glob inside the rendered `{{identity...}}` segment; the trailing `/*`
+  is a literal glob in the static path portion.
+
+### 6.2 Verify a token can write a path (`sys/capabilities-self`)
+
+The backplane runs this exact check at **park time** — when a
+`vault.kv.put`/`patch`/`delete` parks for approval, the dispatcher
+probes `POST sys/capabilities-self` on the target `secret/data/<path>`
+and surfaces a `permission_preflight` banner on the approval row
+(`will_be_denied: true` when the token lacks `create`/`update`), so an
+operator is **not** asked to approve a write that Vault will then reject
+([`operations/dispatcher.py`](../../backend/src/meho_backplane/operations/dispatcher.py)
+`_handle_needs_approval` →
+[`connectors/vault/ops.py`](../../backend/src/meho_backplane/connectors/vault/ops.py)
+`vault_kv_write_capability_preflight`). The probe returns only
+**capability names** — never a secret value — so it sidesteps the
+credential-class redaction rule that bars a value-revealing dry-run for
+a credential write.
+
+Run the same check by hand from a host holding the **operator's** Vault
+token (acquire it as in §4 — do *not* use a root/admin token, which
+would mask a missing operator grant):
+
+```bash
+# Replace <op-sub> with the operator's JWT `sub` and <target> with the
+# target name; this is the exact `/data/` path the connector writes.
+vault token capabilities "secret/data/targets/<op-sub>/<target>"
+# Expect for a writable path: create read update
+```
+
+Or, equivalently, against the raw API (what the backplane preflight
+calls — `POST /v1/sys/capabilities-self`):
+
+```bash
+vault write -format=json sys/capabilities-self \
+  paths="secret/data/targets/<op-sub>/<target>" \
+  | jq '.data.capabilities'
+# Expect: ["create","read","update"]  → the write will succeed
+# A read-only role returns: ["read"]  → the write WILL be denied
+```
+
+Expected outcomes:
+
+- **`create` + `update` present** → the parked write will execute on
+  approval; the approval row's `permission_preflight.will_be_denied` is
+  `false`.
+- **Only `read` (or `deny`)** → the write will be denied. The approval
+  row shows `will_be_denied: true` with the lacking capabilities. Fix
+  §6.1 (add the write stanza) or §3 (identity-alias mismatch), not the
+  connector.
+
+> **Reviewer-token caveat.** An *approved* re-dispatch executes under the
+> **reviewing** operator's token, not the original dispatcher's
+> ([`approvals.py`](../../backend/src/meho_backplane/api/v1/approvals.py)
+> → `resume_dispatch_after_approval`). The park-time preflight runs under
+> the **dispatching** operator's token (the only identity available at
+> park time). Both operators authenticate against the same `meho-mcp`
+> role, so they share this policy and the preflight is the right early
+> signal — but the reviewer's token must carry the §6.1 write grant too,
+> or the write fails post-approval despite a clean preflight. Verify the
+> reviewer's token with the same command above when in doubt.
+
 ## Scope note — `shared_service_account` only; `per_user`/`impersonation` deferred
 
 This runbook covers the **`shared_service_account`** auth model: one
@@ -331,5 +451,15 @@ v0.x — see the carve-out in
   read, rubric State 2): [`vmware-rest-onboarding.md`](./vmware-rest-onboarding.md)
   (G3.9-T3 #942)
 - Vault — [ACL policy templating](https://developer.hashicorp.com/vault/docs/concepts/policies)
+- Vault — [ACL policy capabilities (`create`/`update`/`read`/`delete`)](https://developer.hashicorp.com/vault/docs/concepts/policies#capabilities)
+- Vault — [`POST sys/capabilities-self`](https://developer.hashicorp.com/vault/api-docs/system/capabilities-self)
+  (returns a token's capabilities on a path; no secret material)
+- Vault — [KV v2 secrets engine API](https://developer.hashicorp.com/vault/api-docs/secret/kv/kv-v2)
+  (the `/data/` write path the §6 stanza grants)
 - Vault — [JWT/OIDC auth method](https://developer.hashicorp.com/vault/docs/auth/jwt)
 - Vault — [Audit devices](https://developer.hashicorp.com/vault/docs/audit)
+- Park-time preflight implementation:
+  [`backend/src/meho_backplane/operations/dispatcher.py`](../../backend/src/meho_backplane/operations/dispatcher.py)
+  (`_handle_needs_approval`) +
+  [`backend/src/meho_backplane/connectors/vault/ops.py`](../../backend/src/meho_backplane/connectors/vault/ops.py)
+  (`vault_kv_write_capability_preflight`)


### PR DESCRIPTION
## Summary

- A `requires_approval` Vault KV write (`vault.kv.put`/`patch`/`delete`) parks for a four-eyes review, but the approved write then fails with Vault `permission denied` post-approval — the `meho-mcp` role's templated policy grants `read`, with no `create`/`update` on the KV write path (the `claude-rdc-hetzner-dc#864` incident). This wastes the review.
- Adds a **park-time permission preflight**: `_handle_needs_approval` probes `POST sys/capabilities-self` on the target `<mount>/data/<path>` and merges a `permission_preflight` banner (`will_be_denied: true` when the token lacks `create`/`update`) onto the approval row, so an operator is **not** asked to approve a write Vault will then deny.
- The preflight is a **capabilities check only** — `sys/capabilities-self` returns capability names, never a secret value — so it sidesteps the credential-class preview-suppression rule. It is a *second*, parallel hook (`register_permission_preflight`/`build_permission_preflight`), distinct from the `proposed_effect` preview that is structurally suppressed for credential-class ops.
- Documents the `meho-mcp` role's required KV write-capability policy stanza (`["create", "update"]` on the templated write path) + a `vault token capabilities` / `sys/capabilities-self` verify command in `docs/cross-repo/connector-vault-policy.md` §6, including the reviewer-token caveat (an approved re-dispatch runs under the reviewing operator's token, so that token must carry the write grant too).

## Test plan

- [x] `ruff check` — clean (7 changed files)
- [x] `ruff format --check` — clean
- [x] `mypy` — no issues in the 3 changed source files
- [x] `code-quality.py --diff` — 0 blockers
- [x] **AC1 (doc)**: §6 documents the write-capability stanza + `sys/capabilities-self` verify command — verified by inspection.
- [x] **AC2 (park-time flag)**: a read-only-role write is flagged at park time — `test_preflight_flags_will_be_denied_for_read_only_role` (read-only role → `will_be_denied=True`) and `test_park_merges_permission_preflight_onto_identifier_default` (the parked `ApprovalRequest.proposed_effect` carries the banner).
- [x] **AC3 (capabilities-only, no secret read)**: `test_preflight_flags_will_be_denied_for_read_only_role` asserts `get_capabilities` was the only call and `read_calls == []` (no secret value read/previewed).
- [x] Preflight unit matrix: pass/deny/root/explicit-deny/delete-needs-update/fail-soft/non-write-op (`test_connectors_vault.py`), and the separate-hook + fail-soft contract (`test_operations_preview.py`).
- [x] Full relevant suites green: `tests/ -k "preview or vault or approval or dispatcher or broadcast"` — 1011 passed, 79 skipped, 0 failed.

## Design notes

- **Whose token.** The preflight runs under the **dispatching** operator's token (the only identity available at park time); an approved re-dispatch runs under the **reviewing** operator's token (`resume_dispatch_after_approval`). Both share the `meho-mcp` role policy, so the preflight is the right early signal — the doc spells out that the reviewer must also carry the write grant. The summary names the probed `principal_sub` so the caveat is auditable on the row.
- **Fail-soft**, mirroring the `proposed_effect` builder: a probe fault (Vault unreachable, role login error) degrades to no banner; the park always proceeds.

## Out of scope

- Changing the per-operator-JWT → `meho-mcp` role auth model (issue out-of-scope).
- A value-revealing dry-run preview for credential writes (deliberately excluded).

<!-- auto-implement-issue: fresh, iteration 1 -->

Closes #1504
