### PR TITLE
docs(scheduler): Vault agent-credentials path uses the sanitised UPPER-CASED client_id (#1508)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -141,6 +141,10 @@ connector-related release-notes line.
   so the misconfiguration is visible at fire time; no synthetic user turn
   is injected (#1505).
 
+### Documentation
+
+- Document that the scheduler's Vault agent-credentials path uses the **sanitised, UPPER-CASED** `client_id`, not the raw `identity_ref`: `vault_path_for_client_id` substitutes the sanitised + `upper()`-cased form into `SCHEDULER_AGENT_VAULT_PATH_PATTERN`, so `agent:ops-writer` resolves to `secret/data/agents/AGENT_OPS_WRITER/credentials`. Write and read share the one helper and cannot diverge; `docs/codebase/scheduler.md` and the `settings.py` field comment now carry a worked example so an operator hand-provisioning the Vault secret/policy targets the right path (#1508).
+
 ## [0.10.1] - 2026-06-04
 
 ### Fixed

--- a/backend/src/meho_backplane/settings.py
+++ b/backend/src/meho_backplane/settings.py
@@ -1003,8 +1003,12 @@ class Settings(BaseModel):
     scheduler_agent_secret_env_pattern: str = Field(default="MEHO_AGENT_SECRET_{client_id}")
     # The Vault KV-v2 *API* path (mount + ``data/`` infix + logical path)
     # where agent ``client_credentials`` secrets live. Registration writes
-    # here; the scheduler reads here. ``{client_id}`` is substituted with
-    # the sanitised identity_ref. The default addresses the ``secret/``
+    # here; the scheduler reads here -- both via ``vault_path_for_client_id``,
+    # so the two cannot diverge. ``{client_id}`` is substituted with the
+    # **sanitised, UPPER-CASED** identity_ref (non-alphanumeric chars to
+    # ``_``, then ``upper()``), e.g. ``agent:ops-writer`` ->
+    # ``secret/data/agents/AGENT_OPS_WRITER/credentials`` -- not the raw
+    # ``agent:ops-writer`` key. The default addresses the ``secret/``
     # KV-v2 mount; the leading ``secret/data/`` is the raw API path Vault's
     # HTTP surface uses, which the read/write helpers split into hvac's
     # ``(mount_point, logical_path)`` form.

--- a/docs/codebase/scheduler.md
+++ b/docs/codebase/scheduler.md
@@ -124,8 +124,17 @@ pod env var only when Vault yields nothing (#1478). The lookup chain:
      [`read_agent_secret`](../../backend/src/meho_backplane/scheduler/vault_credentials.py)
      reads the secret from `SCHEDULER_AGENT_VAULT_PATH_PATTERN`
      (default `secret/data/agents/{client_id}/credentials`) under
-     `VAULT_SCHEDULER_TOKEN`. The raw KV-v2 API path is split into
-     hvac's `(mount_point, logical_path)` form by `split_kv_v2_api_path`.
+     `VAULT_SCHEDULER_TOKEN`. The `{client_id}` token is **not** the raw
+     `identity_ref` — `vault_path_for_client_id` substitutes the
+     **sanitised, UPPER-CASED** form (non-alphanumeric chars to `_`,
+     then `.upper()`), the same shape the env-var key uses below. For
+     `agent:ops-writer` the resolved path is
+     `secret/data/agents/AGENT_OPS_WRITER/credentials` (not a raw
+     `agent:ops-writer` key). Both the read here and the write below call
+     this one helper, so the two paths cannot diverge — an operator
+     hand-provisioning the Vault secret or policy must target the
+     sanitised path. The raw KV-v2 API path is split into hvac's
+     `(mount_point, logical_path)` form by `split_kv_v2_api_path`.
      This is the path registration writes to (see below), so an agent
      registered + defined purely over the API is schedulable with **no
      pod env var and no redeploy**. A missing path / unset token / read
@@ -148,8 +157,12 @@ The write side: registering an agent principal
 captures the Keycloak-generated client secret (`get_client_secret`) and
 persists it to Vault at `SCHEDULER_AGENT_VAULT_PATH_PATTERN`
 ([`write_agent_secret`](../../backend/src/meho_backplane/scheduler/vault_credentials.py)),
-under the same scheduler service token. A Vault-write failure rolls back
-the just-created Keycloak client so registration never produces an
+under the same scheduler service token. The write resolves the path
+through the **same** `vault_path_for_client_id` helper as the read, so it
+lands on the sanitised, UPPER-CASED path (`agent:ops-writer` →
+`secret/data/agents/AGENT_OPS_WRITER/credentials`) — write and read can
+never target different keys. A Vault-write failure rolls back the
+just-created Keycloak client so registration never produces an
 unschedulable agent.
 
 `VAULT_SCHEDULER_TOKEN` is a static token bound to a narrow read/write


### PR DESCRIPTION
## Summary

- Document that the scheduler's Vault agent-credentials path substitutes the **sanitised, UPPER-CASED** `client_id`, not the raw `identity_ref`. `vault_path_for_client_id` computes `agent_client_id_from_identity_ref(client_id).upper()` (the `[^A-Za-z0-9_]` regex maps every non-alphanumeric char to `_`, then `.upper()`) and formats it into `SCHEDULER_AGENT_VAULT_PATH_PATTERN`, so `agent:ops-writer` resolves to `secret/data/agents/AGENT_OPS_WRITER/credentials`.
- Add the worked example (matching the env-var example's style) to `docs/codebase/scheduler.md` on both the read and write sides, and tighten the `settings.py` field comment with the same example.
- Behavior is correct and unchanged — `write_agent_secret` and `read_agent_secret` both call the one `vault_path_for_client_id` helper, so write and read paths cannot diverge. This was the **doc gap**: the docs worked the env-var example but showed only the literal `{client_id}` Vault pattern while stressing "the identity_ref verbatim is the client_id", which could lead an operator hand-provisioning the Vault secret/policy to target the wrong path.

## Test plan

- [x] `ruff check backend/src/meho_backplane/settings.py` — clean
- [x] `ruff format --check backend/src/meho_backplane/settings.py` — already formatted
- [x] `python3 -m py_compile backend/src/meho_backplane/settings.py` — OK (comment-only change)
- [x] `.claude/hooks/code-quality.py --diff` — 0 blockers (1 pre-existing `settings.py` file-size warning, not introduced here)
- [x] Worked example verified against `vault_path_for_client_id` / `agent_client_id_from_identity_ref` and the `scheduler_agent_vault_path_pattern` default: `agent:ops-writer` → `secret/data/agents/AGENT_OPS_WRITER/credentials` (write == read form)
- [x] AC1: `docs/codebase/scheduler.md` documents the sanitised-UPPER-CASED Vault-path form with a worked example matching the env-var example's style
- [x] AC2: the example is consistent with `vault_path_for_client_id` (write == read form)

## Out of scope

- Changing the sanitisation / path format — behavior is correct; this is documentation-only (per the issue's Out of scope).

<!-- auto-implement-issue: fresh, iteration 1 -->

Closes #1508
