### PR TITLE
docs(changelog): roll [Unreleased] → [0.11.0] (G0.20 dogfood hardening + jsonflux read-back)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -90,6 +90,8 @@ connector-related release-notes line.
 
 ## [Unreleased]
 
+## [0.11.0] - 2026-06-05
+
 ### Added
 
 - Add a read-back surface for materialized JSONFlux result handles over


### PR DESCRIPTION
Rolls `[Unreleased]` → `## [0.11.0] - 2026-06-05` for the v0.11.0 cut.

## Why minor (not v0.10.2)
`[Unreleased]` carries an **`### Added`** entry: #1507 ships a new agent-facing **`result_query` MCP meta-tool** + a Valkey-backed `ResultHandleStore` (read-back surface for materialized JSONFlux handles). A new feature → a minor bump pre-1.0, matching how v0.10.0 was cut as a feature minor.

## Scope — the G0.20 v0.10.1 dogfood-hardening cycle (#1500)
- **Added:** #1507 — jsonflux full-set spill + `result_query` read-back tool.
- **Fixed:** #1501 (lease/heartbeat → reaper reclaims hung runs), #1502 (bound `run_scheduled` wait — no tick wedge / advisory-lock stranding), #1503 (execute parked direct op on `/decide`/MCP approve), #1506 (`target_required` for no-target typed ops), #1504 (park-time Vault KV write preflight + policy doc), #1505 (typed `scheduled_run_no_input` instead of opaque 400).
- **Documentation:** #1508 — scheduler Vault path uses the sanitised UPPER-CASED client_id.

## Audit
Completeness audit clean — all 8 task issues (#1501–#1508) bulleted; the merge PRs #1509–#1516 are covered by their issue bullets. Fresh empty `[Unreleased]` left for the next cut. No version files touched (version lives in the tag).

⚠️ Do not tag `v0.11.0` until this merges and `main` CI is green.

🤖 Generated with [Claude Code](https://claude.com/claude-code)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Updated changelog to document the upcoming 0.11.0 release.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->