### PR TITLE
feat(auth): backplane→corpus federation client + settings (#1520)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -109,6 +109,13 @@ connector-related release-notes line.
   now returns a `capabilities` array so MCP clients and the CLI read
   provisioning from one source of truth. The `meho-docs` add-on is the
   first consumer.
+- Backplane→corpus federation client for the `meho-docs` add-on: an
+  async client that forwards the operator JWT to the external
+  vendor-document corpus over HTTP, with `CORPUS_URL` / `CORPUS_AUDIENCE`
+  / `CORPUS_TIMEOUT_SECONDS` / `CORPUS_REQUIRE_FILTERS` settings and a
+  fail-closed `CorpusUnavailable` error (corpus unconfigured, unreachable,
+  or non-2xx) that the upcoming `search_docs` route maps to HTTP 503
+  (#1520). Transport only — the `search_docs` route lands separately.
 
 ## [0.11.0] - 2026-06-05
 

--- a/backend/src/meho_backplane/auth/__init__.py
+++ b/backend/src/meho_backplane/auth/__init__.py
@@ -20,12 +20,23 @@ Public surface:
 * :class:`VaultClientError`, :class:`VaultUnreachableError`,
   :class:`VaultRoleDeniedError` — backplane-side exception hierarchy
   callers raise / catch without importing hvac.
+* :func:`search_corpus` — async client that federates a ``search_docs``
+  query to the external vendor-document corpus over httpx, forwarding the
+  operator JWT (G4.5-T2 #1520). Returns a :class:`CorpusSearchResponse`
+  of :class:`CorpusChunk`; fails closed with :class:`CorpusUnavailable`
+  when the corpus is unconfigured, unreachable, or returns a non-2xx.
 
 Downstream code should never import private symbols (``_`` prefix) from
 :mod:`meho_backplane.auth.jwt` or :mod:`meho_backplane.auth.vault`; the
 cache helpers and threadpool wrappers are test-only.
 """
 
+from meho_backplane.auth.corpus import (
+    CorpusChunk,
+    CorpusSearchResponse,
+    CorpusUnavailable,
+    search_corpus,
+)
 from meho_backplane.auth.jwt import keycloak_readiness_probe, verify_jwt
 from meho_backplane.auth.operator import Operator, PrincipalKind
 from meho_backplane.auth.vault import (
@@ -37,12 +48,16 @@ from meho_backplane.auth.vault import (
 )
 
 __all__ = [
+    "CorpusChunk",
+    "CorpusSearchResponse",
+    "CorpusUnavailable",
     "Operator",
     "PrincipalKind",
     "VaultClientError",
     "VaultRoleDeniedError",
     "VaultUnreachableError",
     "keycloak_readiness_probe",
+    "search_corpus",
     "vault_client_for_operator",
     "vault_readiness_probe",
     "verify_jwt",

--- a/backend/src/meho_backplane/auth/corpus.py
+++ b/backend/src/meho_backplane/auth/corpus.py
@@ -1,0 +1,191 @@
+# SPDX-License-Identifier: Apache-2.0
+# Copyright (c) 2026 evoila Group
+
+"""Backplane→corpus federation client (G4.5-T2 #1520).
+
+The ``search_docs`` add-on (Initiative #1518) routes vendor-document
+queries through the backplane to an **external** corpus service the ops
+team runs, rather than ingesting the corpus into MEHO's own substrate.
+This module is the one place that federation happens: a thin async
+``httpx`` client that POSTs a search request to ``settings.corpus_url``
+carrying ``Authorization: Bearer <operator.raw_jwt>`` — so the corpus's
+own audit log sees the operator identity, exactly as
+:func:`~meho_backplane.auth.vault.vault_client_for_operator` forwards the
+operator JWT to Vault's OIDC auth.
+
+Fail-closed by construction. The corpus being unconfigured
+(``corpus_url`` unset), unreachable (network / timeout), or returning a
+non-2xx status all collapse to one typed :class:`CorpusUnavailable`,
+which the consuming ``search_docs`` route (T3, #1521) maps to HTTP 503 —
+never a silent empty result. This mirrors the
+``LlmClientUnavailable`` → 503 precedent (#1386).
+
+The corpus request/response contract is a **consumer-side** dependency
+(the corpus is owned elsewhere), so it is modelled behind a small typed
+Pydantic adapter (:class:`CorpusChunk` / :class:`CorpusSearchResponse`)
+that can be pinned without churning the call sites. The route, the
+mandatory REQUIRE_FILTERS posture, and the central audit binding are
+**out of scope here** — they land in T3.
+"""
+
+from __future__ import annotations
+
+from typing import Any
+
+import httpx
+import structlog
+from pydantic import BaseModel, ConfigDict, Field
+
+from meho_backplane.auth.operator import Operator
+from meho_backplane.settings import get_settings
+
+__all__ = [
+    "CorpusChunk",
+    "CorpusSearchResponse",
+    "CorpusUnavailable",
+    "search_corpus",
+]
+
+_log = structlog.get_logger(__name__)
+
+
+class CorpusUnavailable(RuntimeError):  # noqa: N818 -- "Unavailable" reads better than "Error" in the 503 detail
+    """Raised when the external corpus cannot serve a search request.
+
+    One typed error for every fail-closed branch — unconfigured,
+    unreachable, or a non-2xx response — so the consuming ``search_docs``
+    route (T3, #1521) maps it onto HTTP 503 without branching on the
+    cause. ``status`` carries the upstream HTTP status code when the
+    failure was a non-2xx corpus response (``None`` for an unconfigured
+    or unreachable corpus) so callers can log the cause without parsing
+    the message; the raw response body is **never** attached, so a
+    corpus error page cannot leak through the 503.
+    """
+
+    def __init__(self, message: str, *, status: int | None = None) -> None:
+        self.status = status
+        super().__init__(message)
+
+
+class CorpusChunk(BaseModel):
+    """One cited chunk returned by the external corpus.
+
+    A deliberately small, frozen adapter over the corpus's response
+    contract. The corpus is owned by the ops team, so its wire shape can
+    drift; pinning the fields MEHO actually consumes here means a corpus
+    change that adds fields is absorbed silently (``extra="ignore"``)
+    while a change that drops a consumed field fails loudly at parse
+    time — surfaced as :class:`CorpusUnavailable` rather than a partial
+    result. ``metadata`` keeps the corpus's per-chunk attributes (e.g.
+    ``product`` / ``version`` the T3 filters key off) without MEHO
+    having to model every one.
+    """
+
+    model_config = ConfigDict(frozen=True, extra="ignore")
+
+    chunk_id: str
+    document_id: str
+    content: str
+    source_url: str | None = None
+    score: float | None = None
+    metadata: dict[str, Any] = Field(default_factory=dict)
+
+
+class CorpusSearchResponse(BaseModel):
+    """Parsed corpus search result: the cited chunks for a query.
+
+    Frozen adapter; ``chunks`` is the ordered hit list (best first, as
+    the corpus ranks them). The consuming route (T3) projects these into
+    MEHO's own cited-chunk surface and binds the central audit row.
+    """
+
+    model_config = ConfigDict(frozen=True, extra="ignore")
+
+    chunks: list[CorpusChunk] = Field(default_factory=list)
+
+
+async def search_corpus(
+    operator: Operator,
+    query: str,
+    *,
+    metadata_filters: dict[str, Any] | None = None,
+    limit: int = 10,
+) -> CorpusSearchResponse:
+    """Search the external corpus as *operator*, returning cited chunks.
+
+    POSTs a JSON search request to ``settings.corpus_url`` with
+    ``Authorization: Bearer <operator.raw_jwt>`` so the corpus
+    authenticates and audits the call as the operator. The request is
+    bounded by ``settings.corpus_timeout_seconds`` across connect / read
+    / write so a slow or hung corpus raises rather than blocking the
+    event loop. ``settings.corpus_audience`` (RFC 8707), when set, is
+    forwarded as the requested resource indicator; the corpus may use it
+    to bind the token to itself.
+
+    Args:
+        operator: The verified operator whose JWT is forwarded.
+        query: The free-text search query.
+        metadata_filters: Optional binary ``{key: scalar}`` narrowing
+            (e.g. ``{"product": "vmware", "version": "9.0"}``). The
+            mandatory product/version REQUIRE_FILTERS posture is enforced
+            by the consuming route (T3, #1521), **not** here — this
+            transport forwards whatever filters it is given.
+        limit: Maximum number of chunks to request.
+
+    Raises:
+        CorpusUnavailable: when ``corpus_url`` is unset (unconfigured),
+            the corpus is unreachable / times out, or it returns a
+            non-2xx status. The upstream status is carried on the
+            exception (``status``) for non-2xx responses; the raw
+            response body is never included.
+    """
+    settings = get_settings()
+    corpus_url = settings.corpus_url
+    if not corpus_url:
+        # Fail-closed: an unconfigured corpus is unavailable, not empty.
+        raise CorpusUnavailable("corpus_url is not configured")
+
+    payload: dict[str, Any] = {"query": query, "limit": limit}
+    if metadata_filters:
+        payload["metadata_filters"] = metadata_filters
+    if settings.corpus_audience:
+        payload["audience"] = settings.corpus_audience
+
+    headers = {"Authorization": f"Bearer {operator.raw_jwt}"}
+    timeout = httpx.Timeout(settings.corpus_timeout_seconds)
+
+    try:
+        async with httpx.AsyncClient(timeout=timeout) as client:
+            response = await client.post(corpus_url, json=payload, headers=headers)
+    except httpx.HTTPError as exc:
+        # ConnectError / TimeoutException / any transport failure — the
+        # corpus is unreachable. Log the cause by type (never the JWT or
+        # the query body) and fail closed.
+        _log.warning("corpus_unreachable", error=type(exc).__name__)
+        raise CorpusUnavailable(f"corpus unreachable: {type(exc).__name__}") from exc
+
+    if response.status_code // 100 != 2:
+        # Non-2xx: surface the status for observability, but never the
+        # response body — a corpus error page must not leak through the
+        # 503 the route renders.
+        _log.warning("corpus_request_failed", status=response.status_code)
+        raise CorpusUnavailable(
+            f"corpus returned HTTP {response.status_code}",
+            status=response.status_code,
+        )
+
+    try:
+        body: Any = response.json()
+    except ValueError as exc:
+        # A 2xx with a non-JSON body is a broken corpus contract —
+        # fail closed rather than leaking a raw JSONDecodeError.
+        _log.warning("corpus_response_not_json")
+        raise CorpusUnavailable("corpus returned a non-JSON body") from exc
+
+    try:
+        return CorpusSearchResponse.model_validate(body)
+    except ValueError as exc:
+        # Schema drift (a consumed field dropped / wrong type) is also a
+        # broken contract; fail closed without echoing the payload.
+        _log.warning("corpus_response_invalid_schema")
+        raise CorpusUnavailable("corpus response did not match the expected schema") from exc

--- a/backend/src/meho_backplane/settings.py
+++ b/backend/src/meho_backplane/settings.py
@@ -1052,6 +1052,26 @@ class Settings(BaseModel):
     event_drain_tick_interval_seconds: int = Field(default=10, ge=1, le=3600)
     event_drain_enabled: bool = True
     mcp_require_session_id: bool = False
+    #: Absolute URL of the external vendor-document corpus search
+    #: endpoint the ``search_docs`` add-on (G4.5 #1518) federates to via a
+    #: forwarded operator JWT. Empty ("") means the add-on is not
+    #: configured; the federation client
+    #: (:func:`~meho_backplane.auth.corpus.search_corpus`) fails closed
+    #: with :class:`~meho_backplane.auth.corpus.CorpusUnavailable` (→ 503
+    #: at the T3 route) rather than returning a silent empty result.
+    corpus_url: str = ""
+    #: Optional RFC 8707 resource indicator (``aud``) the corpus binds
+    #: the forwarded token to. Empty ("") forwards no audience.
+    corpus_audience: str = ""
+    #: Bound on the corpus HTTP request (connect / read / write), in
+    #: seconds. A slow corpus raises ``CorpusUnavailable`` rather than
+    #: blocking the event loop.
+    corpus_timeout_seconds: float = Field(default=10.0, gt=0)
+    #: Whether the ``search_docs`` route (T3, #1521) must reject a query
+    #: that carries no product/version filter (REQUIRE_FILTERS). Default
+    #: ``True`` — fail-closed scope discipline. Consumed by T3, not by the
+    #: transport in this Task.
+    corpus_require_filters: bool = True
 
     @field_validator("broadcast_redis_url")
     @classmethod
@@ -1391,5 +1411,13 @@ def get_settings() -> Settings:
         ),
         mcp_require_session_id=parse_bool_env(
             os.environ.get("MCP_REQUIRE_SESSION_ID"),
+        ),
+        corpus_url=os.environ.get("CORPUS_URL", "").strip(),
+        corpus_audience=os.environ.get("CORPUS_AUDIENCE", "").strip(),
+        corpus_timeout_seconds=float(
+            os.environ.get("CORPUS_TIMEOUT_SECONDS", "10.0"),
+        ),
+        corpus_require_filters=parse_bool_env(
+            os.environ.get("CORPUS_REQUIRE_FILTERS", "true"),
         ),
     )

--- a/backend/tests/test_corpus_client.py
+++ b/backend/tests/test_corpus_client.py
@@ -1,0 +1,281 @@
+# SPDX-License-Identifier: Apache-2.0
+# Copyright (c) 2026 evoila Group
+
+"""Unit tests for the backplane→corpus federation client (G4.5-T2 #1520).
+
+Exercises :func:`~meho_backplane.auth.corpus.search_corpus` against an
+``httpx.MockTransport`` mounted on the real :class:`httpx.AsyncClient` —
+so the request the corpus would actually receive (URL, bearer header,
+JSON body) is asserted, and every fail-closed branch (unconfigured,
+unreachable, timeout, non-2xx) is shown to collapse to the one typed
+:class:`~meho_backplane.auth.corpus.CorpusUnavailable`. The forwarded
+operator JWT must never leak into a structlog event or the 503 detail.
+"""
+
+from __future__ import annotations
+
+from collections.abc import Iterator
+
+import httpx
+import pytest
+import structlog
+
+import meho_backplane.auth.corpus as corpus_mod
+from meho_backplane.auth.corpus import (
+    CorpusSearchResponse,
+    CorpusUnavailable,
+    search_corpus,
+)
+from meho_backplane.auth.operator import Operator
+from meho_backplane.settings import Settings, get_settings
+
+_CORPUS_URL = "https://corpus.test/search"
+_JWT = "header.payload.signature-secret"
+
+
+def _make_operator(jwt: str = _JWT) -> Operator:
+    """Build a minimal :class:`Operator` carrying the forwarded JWT."""
+    return Operator(
+        sub="op-1",
+        name="Alice",
+        email="alice@example.com",
+        raw_jwt=jwt,
+        tenant_id="00000000-0000-0000-0000-00000000a0a0",
+        tenant_role="operator",
+    )
+
+
+@pytest.fixture(autouse=True)
+def _settings_env(monkeypatch: pytest.MonkeyPatch) -> Iterator[None]:
+    """Pin the env every :class:`Settings` field reads, then reset the cache."""
+    monkeypatch.setenv("KEYCLOAK_ISSUER_URL", "https://keycloak.test/realms/meho")
+    monkeypatch.setenv("KEYCLOAK_AUDIENCE", "meho-backplane")
+    monkeypatch.setenv("VAULT_ADDR", "https://vault.test")
+    get_settings.cache_clear()
+    yield
+    get_settings.cache_clear()
+
+
+def _pin_settings(monkeypatch: pytest.MonkeyPatch, **overrides: object) -> Settings:
+    """Override ``corpus.get_settings`` with a Settings carrying *overrides*.
+
+    Builds the real Settings from the pinned env, then ``model_copy``-es
+    the corpus knobs the test cares about, so each test states its corpus
+    config explicitly without touching every other field.
+    """
+    settings = get_settings().model_copy(update=overrides)
+    monkeypatch.setattr(corpus_mod, "get_settings", lambda: settings)
+    return settings
+
+
+def _transport_capturing(
+    captured: list[httpx.Request],
+    response: httpx.Response,
+) -> httpx.MockTransport:
+    """A MockTransport that records the request and returns *response*."""
+
+    def _handler(request: httpx.Request) -> httpx.Response:
+        captured.append(request)
+        return response
+
+    return httpx.MockTransport(_handler)
+
+
+def _patch_async_client(
+    monkeypatch: pytest.MonkeyPatch,
+    transport: httpx.MockTransport,
+    captured_timeout: list[httpx.Timeout],
+) -> None:
+    """Force every ``AsyncClient`` the module builds onto *transport*.
+
+    ``search_corpus`` constructs its own ``AsyncClient`` internally, so we
+    wrap the real class to inject ``transport=`` (the documented
+    mock-injection seam) and record the ``timeout=`` the client was built
+    with — that is how the timeout-is-bounded assertion is made without a
+    real slow server.
+    """
+    real_async_client = httpx.AsyncClient
+
+    def _factory(*args: object, **kwargs: object) -> httpx.AsyncClient:
+        timeout = kwargs.get("timeout")
+        if isinstance(timeout, httpx.Timeout):
+            captured_timeout.append(timeout)
+        kwargs["transport"] = transport
+        return real_async_client(*args, **kwargs)
+
+    monkeypatch.setattr(corpus_mod.httpx, "AsyncClient", _factory)
+
+
+@pytest.mark.asyncio
+async def test_forwards_bearer_jwt_and_posts_query(monkeypatch: pytest.MonkeyPatch) -> None:
+    """The client POSTs to corpus_url with Authorization: Bearer <raw_jwt>."""
+    _pin_settings(monkeypatch, corpus_url=_CORPUS_URL)
+    captured: list[httpx.Request] = []
+    response = httpx.Response(
+        200,
+        json={
+            "chunks": [
+                {
+                    "chunk_id": "c1",
+                    "document_id": "d1",
+                    "content": "vSphere 9.0 supervisor cluster setup.",
+                    "source_url": "https://docs.example/vsphere",
+                    "score": 0.91,
+                    "metadata": {"product": "vmware", "version": "9.0"},
+                }
+            ]
+        },
+    )
+    transport = _transport_capturing(captured, response)
+    _patch_async_client(monkeypatch, transport, [])
+
+    result = await search_corpus(_make_operator(), "supervisor cluster", limit=5)
+
+    assert isinstance(result, CorpusSearchResponse)
+    assert len(result.chunks) == 1
+    assert result.chunks[0].chunk_id == "c1"
+    assert result.chunks[0].metadata == {"product": "vmware", "version": "9.0"}
+
+    sent = captured[0]
+    assert sent.method == "POST"
+    assert str(sent.url) == _CORPUS_URL
+    assert sent.headers["Authorization"] == f"Bearer {_JWT}"
+    import json
+
+    body = json.loads(sent.content.decode())
+    assert body["query"] == "supervisor cluster"
+    assert body["limit"] == 5
+
+
+@pytest.mark.asyncio
+async def test_metadata_filters_and_audience_forwarded(monkeypatch: pytest.MonkeyPatch) -> None:
+    """Given filters + a configured audience, both ride the request body."""
+    _pin_settings(monkeypatch, corpus_url=_CORPUS_URL, corpus_audience="meho-corpus")
+    captured: list[httpx.Request] = []
+    transport = _transport_capturing(captured, httpx.Response(200, json={"chunks": []}))
+    _patch_async_client(monkeypatch, transport, [])
+
+    await search_corpus(
+        _make_operator(),
+        "q",
+        metadata_filters={"product": "vmware", "version": "9.0"},
+    )
+
+    import json
+
+    body = json.loads(captured[0].content.decode())
+    assert body["metadata_filters"] == {"product": "vmware", "version": "9.0"}
+    assert body["audience"] == "meho-corpus"
+
+
+@pytest.mark.asyncio
+async def test_timeout_is_bounded_by_setting(monkeypatch: pytest.MonkeyPatch) -> None:
+    """The AsyncClient is built with the configured corpus timeout."""
+    _pin_settings(monkeypatch, corpus_url=_CORPUS_URL, corpus_timeout_seconds=3.5)
+    captured_timeout: list[httpx.Timeout] = []
+    transport = _transport_capturing([], httpx.Response(200, json={"chunks": []}))
+    _patch_async_client(monkeypatch, transport, captured_timeout)
+
+    await search_corpus(_make_operator(), "q")
+
+    assert captured_timeout, "AsyncClient was not built with an httpx.Timeout"
+    # httpx.Timeout(x) sets connect/read/write/pool all to x.
+    assert captured_timeout[0].read == 3.5
+    assert captured_timeout[0].connect == 3.5
+
+
+@pytest.mark.asyncio
+async def test_slow_corpus_raises_corpus_unavailable(monkeypatch: pytest.MonkeyPatch) -> None:
+    """A timeout from the transport maps to CorpusUnavailable, never a hang."""
+    _pin_settings(monkeypatch, corpus_url=_CORPUS_URL)
+
+    def _handler(request: httpx.Request) -> httpx.Response:
+        raise httpx.ReadTimeout("corpus too slow", request=request)
+
+    _patch_async_client(monkeypatch, httpx.MockTransport(_handler), [])
+
+    with pytest.raises(CorpusUnavailable) as exc:
+        await search_corpus(_make_operator(), "q")
+    assert exc.value.status is None
+
+
+@pytest.mark.asyncio
+async def test_unconfigured_corpus_url_fails_closed(monkeypatch: pytest.MonkeyPatch) -> None:
+    """corpus_url unset → CorpusUnavailable (fail-closed, not empty)."""
+    _pin_settings(monkeypatch, corpus_url="")
+    # No transport patch needed — the unconfigured guard fires before any I/O.
+    with pytest.raises(CorpusUnavailable):
+        await search_corpus(_make_operator(), "q")
+
+
+@pytest.mark.asyncio
+async def test_connect_error_fails_closed(monkeypatch: pytest.MonkeyPatch) -> None:
+    """An unreachable corpus (ConnectError) maps to CorpusUnavailable."""
+    _pin_settings(monkeypatch, corpus_url=_CORPUS_URL)
+
+    def _handler(request: httpx.Request) -> httpx.Response:
+        raise httpx.ConnectError("connection refused", request=request)
+
+    _patch_async_client(monkeypatch, httpx.MockTransport(_handler), [])
+
+    with pytest.raises(CorpusUnavailable) as exc:
+        await search_corpus(_make_operator(), "q")
+    assert exc.value.status is None
+
+
+@pytest.mark.asyncio
+async def test_non_2xx_carries_status_and_leaks_no_body(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """A non-2xx corpus response → CorpusUnavailable(status=...) with no body leak."""
+    _pin_settings(monkeypatch, corpus_url=_CORPUS_URL)
+    secret_body = "INTERNAL corpus stack trace with leaky-token-abc"
+    transport = _transport_capturing([], httpx.Response(502, text=secret_body))
+    _patch_async_client(monkeypatch, transport, [])
+
+    with pytest.raises(CorpusUnavailable) as exc:
+        await search_corpus(_make_operator(), "q")
+    assert exc.value.status == 502
+    assert secret_body not in str(exc.value)
+
+
+@pytest.mark.asyncio
+async def test_non_json_2xx_body_fails_closed(monkeypatch: pytest.MonkeyPatch) -> None:
+    """A 2xx with a non-JSON body is a broken contract → CorpusUnavailable."""
+    _pin_settings(monkeypatch, corpus_url=_CORPUS_URL)
+    transport = _transport_capturing([], httpx.Response(200, text="<html>not json</html>"))
+    _patch_async_client(monkeypatch, transport, [])
+
+    with pytest.raises(CorpusUnavailable):
+        await search_corpus(_make_operator(), "q")
+
+
+@pytest.mark.asyncio
+async def test_schema_drift_fails_closed(monkeypatch: pytest.MonkeyPatch) -> None:
+    """A consumed field of the wrong type fails validation → CorpusUnavailable."""
+    _pin_settings(monkeypatch, corpus_url=_CORPUS_URL)
+    transport = _transport_capturing(
+        [],
+        # ``content`` is required str; an int violates the contract.
+        httpx.Response(200, json={"chunks": [{"chunk_id": "c", "document_id": "d", "content": 7}]}),
+    )
+    _patch_async_client(monkeypatch, transport, [])
+
+    with pytest.raises(CorpusUnavailable):
+        await search_corpus(_make_operator(), "q")
+
+
+@pytest.mark.asyncio
+async def test_forwarded_jwt_never_logged(monkeypatch: pytest.MonkeyPatch) -> None:
+    """The forwarded operator JWT must not appear in any structlog event."""
+    _pin_settings(monkeypatch, corpus_url=_CORPUS_URL)
+    transport = _transport_capturing([], httpx.Response(503, text="down"))
+    _patch_async_client(monkeypatch, transport, [])
+
+    with structlog.testing.capture_logs() as logs, pytest.raises(CorpusUnavailable):
+        await search_corpus(_make_operator(), "q")
+
+    serialised = repr(logs)
+    assert _JWT not in serialised
+    # The failure is still observable by status.
+    assert any(event.get("status") == 503 for event in logs)


### PR DESCRIPTION
## Summary

- Adds `backend/src/meho_backplane/auth/corpus.py` — the single place the
  backplane federates a `search_docs` query to the **external** vendor-doc
  corpus: an async `httpx` client that POSTs to `settings.corpus_url`
  carrying `Authorization: Bearer <operator.raw_jwt>`, so the corpus
  authenticates and audits the call as the operator (mirrors
  `vault_client_for_operator`).
- Models the corpus's consumer-side response contract behind a small frozen
  Pydantic adapter (`CorpusChunk` / `CorpusSearchResponse`) so it can be
  pinned without churning call sites.
- **Fail-closed**: unconfigured (`corpus_url` unset), unreachable, non-2xx,
  non-JSON, or schema-drifting corpus all collapse to one typed
  `CorpusUnavailable` — which the consuming `search_docs` route (T3, #1521)
  maps to HTTP 503, never a silent empty result (the
  `LlmClientUnavailable` → 503 precedent, #1386). The forwarded JWT and the
  raw response body are never logged or attached to the error.
- New settings: `corpus_url`, `corpus_audience` (RFC 8707),
  `corpus_timeout_seconds` (default 10), `corpus_require_filters`
  (default `True`, consumed by T3).

## Test plan

- [x] `ruff check` — clean
- [x] `ruff format --check` — clean
- [x] `mypy src/meho_backplane/auth/ src/meho_backplane/settings.py` — clean
- [x] `pytest tests/test_corpus_client.py` — 10 passed
- [x] Bearer JWT forwarded to `corpus_url` — asserted via `httpx.MockTransport`
- [x] Timeout bounded by `corpus_timeout_seconds`; a slow corpus raises
      `CorpusUnavailable`, not a hang
- [x] `corpus_url` unset → `CorpusUnavailable` (fail-closed)
- [x] Non-2xx → `CorpusUnavailable` with the upstream status in context; no
      raw body leak
- [x] Forwarded JWT never appears in a structlog event
- [x] code-quality `--diff` gate — 0 blockers

## Out of scope

- The `search_docs` route / mandatory REQUIRE_FILTERS enforcement / central
  audit binding — that is T3 (#1521). This Task ships only the transport +
  settings.
- Minting a service token (`client_credentials`) — v1 forwards the operator
  JWT to preserve identity in the corpus audit log. The mint path
  (`auth/agent_token.py`) is the documented alternative if the corpus
  rejects forwarded user tokens.
- Adjacent finding (recorded, not fixed): `settings.py` is 1409 lines
  (pre-existing legacy size warning, untouched by this change beyond the
  four new `corpus_*` fields); `search_corpus` is 85 lines (warn >60, under
  the 100-line block threshold) — a single linear fail-closed
  request/parse pipeline kept intact for readability.

<!-- auto-implement-issue: fresh, iteration 1 -->

Closes #1520


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **New Features**
  * Added external document corpus integration with federated search capability for the meho-docs add-on.
  * Implemented fail-closed error handling for unavailable corpus scenarios with appropriate HTTP response status.
  * Introduced new configuration options for corpus endpoint setup and behavior customization.

* **Tests**
  * Added comprehensive test coverage for corpus search functionality and error handling scenarios.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->