### PR TITLE
feat(docs): search_docs route — mandatory REQUIRE_FILTERS + central audit (#1521)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -116,6 +116,22 @@ connector-related release-notes line.
   fail-closed `CorpusUnavailable` error (corpus unconfigured, unreachable,
   or non-2xx) that the upcoming `search_docs` route maps to HTTP 503
   (#1520). Transport only — the `search_docs` route lands separately.
+- `POST /api/v1/search_docs` — the federated vendor-document retrieval
+  route of the `meho-docs` add-on (G4.5-T3). Operator role minimum,
+  tenant-scoped via the forwarded operator JWT. Enforces a **mandatory
+  binary product+version scope** (REQUIRE_FILTERS): a request missing
+  either is rejected `422` (fail-closed), never forwarded as an
+  unfiltered corpus query — the scope is a containment filter, not a
+  ranking weight (#1178 / #1177). Enforcement is gated by
+  `CORPUS_REQUIRE_FILTERS` (default on). The route federates to the
+  external corpus via the T2 client (`CorpusUnavailable` → `503`, never
+  an empty `200`) and binds one central audit row per query under the
+  named op `meho.docs.search` (`op_class=read`), storing the query only
+  as a SHA-256 hash plus the product/version scope and hit count — so
+  `query_audit` / who-touched surface every docs query without leaking
+  the raw query. The scope-validation + corpus-call + cited-chunk shape
+  live in a shared `docs_search` service the future MCP tool (T4) and
+  CLI verb (T5) reuse (#1521).
 
 ## [0.11.0] - 2026-06-05
 

--- a/backend/src/meho_backplane/api/v1/search_docs.py
+++ b/backend/src/meho_backplane/api/v1/search_docs.py
@@ -1,0 +1,258 @@
+# SPDX-License-Identifier: Apache-2.0
+# Copyright (c) 2026 evoila Group
+
+"""``POST /api/v1/search_docs`` -- federated vendor-document retrieval.
+
+G4.5-T3 (#1521) of Initiative #1518 (the ``meho-docs`` add-on). The
+route is the REST face of the shared
+:func:`~meho_backplane.docs_search.search_docs` service: it federates a
+free-text query through the backplane to the external vendor-document
+corpus the ops team runs (T2, :mod:`meho_backplane.auth.corpus`) rather
+than hitting the corpus directly. Routing through the backplane is what
+lands every query in the audit trail, forwards the operator JWT once,
+and enforces the mandatory product/version posture centrally.
+
+REQUIRE_FILTERS (the binary scope)
+----------------------------------
+
+``product`` AND ``version`` are **mandatory** -- a request missing
+either is rejected **422** (fail-closed) by
+:func:`~meho_backplane.docs_search.build_docs_scope` rather than
+forwarded as an unfiltered corpus query. The filter is a **binary
+scope** passed verbatim to the corpus (the #1178 / #1177 decision:
+containment, not RRF weighting) -- it is never expressed as a ranking
+weight. Enforcement is gated by ``settings.corpus_require_filters``
+(default on); with the gate off the filter degrades to optional and the
+corpus owns the policy.
+
+RBAC + tenant scoping
+---------------------
+
+``operator`` role minimum (mirrors :mod:`meho_backplane.api.v1.retrieve`)
+-- ``read_only`` operators get 403 via :func:`require_role` before the
+handler runs. The query is tenant-scoped by construction: there is no
+surface that accepts a tenant id from the body; the forwarded JWT (and
+the corpus's own audit) carries ``operator.tenant_id``.
+
+Central audit contract
+----------------------
+
+The handler binds the ``audit_*`` contextvars **before** the corpus
+call so a handler exception still produces an audit row with the partial
+payload:
+
+* ``audit_op_id = "meho.docs.search"`` -- the canonical op_id every
+  ``search_docs`` audit row carries, so ``query_audit`` / who-touched
+  filter on ``payload->>'op_id' = 'meho.docs.search'``.
+* ``audit_op_class = "read"`` -- this is a read operation. The broadcast
+  payload for ``read`` is full-detail, which is safe here because the
+  bound payload is *only* the hash + binary scope + hit count -- the
+  **raw query is never bound** (only its SHA-256 digest), so nothing
+  operator-sensitive can leak through the feed.
+* ``audit_query_hash`` -- SHA-256 hex of the UTF-8 query; the raw query
+  is never stored.
+* ``audit_product`` / ``audit_version`` -- the binary scope (these are
+  the operator-chosen product/version, not tenant-shaped identifiers, so
+  they are recorded in the clear for who-touched attribution).
+* ``audit_hit_count`` -- bound after the corpus returns.
+
+Corpus-unavailable contract
+---------------------------
+
+The transport's typed
+:class:`~meho_backplane.auth.corpus.CorpusUnavailable` (corpus
+unconfigured, unreachable, or non-2xx / malformed) is mapped to HTTP
+**503** -- never a silent empty 200. The exception's message is the
+only thing surfaced; the corpus response body is never attached (the
+transport already guarantees that), so a corpus error page cannot leak
+through the 503 detail.
+
+Out of scope (per the Initiative body)
+--------------------------------------
+
+* MCP tool registration + capability gating (T4, #1523) and the
+  ``meho docs search`` CLI verb (T5, #1524) -- both reuse the shared
+  :func:`~meho_backplane.docs_search.search_docs` service this route
+  fronts.
+* ``ask_docs`` (synthesized answer) -- fast-follow (T7, #1526).
+* Local indexing of the corpus -- federation only.
+"""
+
+from __future__ import annotations
+
+import hashlib
+
+import structlog
+from fastapi import APIRouter, Depends, HTTPException, status
+from pydantic import BaseModel, ConfigDict, Field
+
+from meho_backplane.auth.corpus import CorpusUnavailable
+from meho_backplane.auth.operator import Operator, TenantRole
+from meho_backplane.auth.rbac import require_role
+from meho_backplane.docs_search import (
+    DocsChunk,
+    MissingDocsFilterError,
+    build_docs_scope,
+    search_docs,
+)
+
+__all__ = ["router"]
+
+router = APIRouter(prefix="/api/v1", tags=["docs"])
+
+
+#: Module-level ``Depends`` closure for the route's RBAC gate. Built
+#: once at import time (rather than inline) to satisfy ruff's B008 rule,
+#: matching the convention :mod:`meho_backplane.api.v1.retrieve`
+#: established.
+_require_operator = Depends(require_role(TenantRole.OPERATOR))
+
+
+class SearchDocsRequest(BaseModel):
+    """POST body for ``/api/v1/search_docs``.
+
+    ``product`` / ``version`` are the **mandatory binary scope** under
+    the REQUIRE_FILTERS posture -- they are typed optional here so a
+    missing value is rejected by the service with a route-shaped 422
+    naming the absent key(s), rather than Pydantic's generic
+    ``field_required`` (which would not say *why* the scope is mandatory
+    or honour the ``corpus_require_filters`` gate-off path).
+
+    ``extra="forbid"`` rejects unknown fields at 422 so a client sending
+    a pre-rename key fails loud rather than running with the defaults --
+    the same posture every public v1 request schema ships under.
+    """
+
+    model_config = ConfigDict(frozen=True, extra="forbid")
+
+    query: str = Field(min_length=1, max_length=2000)
+    product: str | None = Field(default=None, max_length=128)
+    version: str | None = Field(default=None, max_length=128)
+    limit: int = Field(default=10, ge=1, le=50)
+
+
+class SearchDocsResponse(BaseModel):
+    """Successful response shape for ``/api/v1/search_docs``.
+
+    ``chunks`` is the corpus's ranked cited-chunk list (best first),
+    projected into MEHO's :class:`~meho_backplane.docs_search.DocsChunk`
+    surface so the wire contract is decoupled from the corpus's. Frozen
+    so an accidental post-construction mutation surfaces as a pydantic
+    error rather than a silently-altered response.
+    """
+
+    model_config = ConfigDict(frozen=True)
+
+    chunks: list[DocsChunk]
+
+
+def _compute_query_hash(query: str) -> str:
+    """SHA-256 hex digest of *query* (UTF-8 encoded).
+
+    Matches the encoding contract :func:`meho_backplane.api.v1.retrieve._compute_query_hash`
+    uses so an analyst correlating a known query against ``audit_log``
+    can use a single hash function across both retrieval surfaces. The
+    raw query is never stored -- only this digest.
+    """
+    return hashlib.sha256(query.encode("utf-8")).hexdigest()
+
+
+@router.post(
+    "/search_docs",
+    response_model=SearchDocsResponse,
+    responses={
+        422: {
+            "description": (
+                "The mandatory binary product+version scope is absent "
+                "(REQUIRE_FILTERS). A docs query without both filters is "
+                "rejected rather than forwarded as an unfiltered corpus "
+                "query."
+            ),
+        },
+        503: {
+            "description": (
+                "The external corpus is unavailable -- unconfigured, "
+                "unreachable, or returned a non-2xx / malformed response. "
+                "Fail-closed; never an empty 200."
+            ),
+        },
+    },
+)
+async def search_docs_endpoint(
+    body: SearchDocsRequest,
+    operator: Operator = _require_operator,
+) -> SearchDocsResponse:
+    """Federate a vendor-document query to the corpus, returning cited chunks.
+
+    Enforces the mandatory binary product+version scope (422 when the
+    REQUIRE_FILTERS gate is on and either is absent), forwards the
+    operator JWT to the corpus via the shared
+    :func:`~meho_backplane.docs_search.search_docs` service, and binds
+    the central ``meho.docs.search`` audit row. ``read_only`` operators
+    get 403 via :func:`require_role` before reaching this handler.
+
+    The audit contextvars are bound **before** the corpus call so a
+    handler exception (including the :class:`CorpusUnavailable` → 503
+    branch) still produces an audit row with the query identity + binary
+    scope preserved. The raw query is never bound -- only its SHA-256
+    hash.
+    """
+    # Validate the binary scope first; a 422 here must NOT bind an audit
+    # row implying a corpus call happened. The scope build is the
+    # REQUIRE_FILTERS gate.
+    try:
+        scope = build_docs_scope(body.product, body.version)
+    except MissingDocsFilterError as exc:
+        raise HTTPException(
+            status_code=status.HTTP_422_UNPROCESSABLE_CONTENT,
+            detail=str(exc),
+        ) from exc
+
+    log = structlog.get_logger()
+    # Pre-bind everything the audit middleware lifts into
+    # ``audit_log.payload``. ``hit_count`` is bound after the corpus
+    # returns; the rest are known up-front so a handler exception (e.g.
+    # the corpus 503 branch) still records the query identity + scope.
+    # The raw query is never bound -- only its SHA-256 hash.
+    structlog.contextvars.bind_contextvars(
+        audit_op_id="meho.docs.search",
+        audit_op_class="read",
+        audit_query_hash=_compute_query_hash(body.query),
+        audit_product=scope.product,
+        audit_version=scope.version,
+    )
+
+    try:
+        result = await search_docs(
+            operator,
+            body.query,
+            scope=scope,
+            limit=body.limit,
+        )
+    except CorpusUnavailable as exc:
+        # Fail-closed: an unconfigured / unreachable / non-2xx corpus is
+        # 503, never an empty 200. The transport guarantees the corpus
+        # response body is never on the exception, so nothing leaks
+        # through the detail.
+        log.warning(
+            "search_docs_corpus_unavailable",
+            operator_sub=operator.sub,
+            product=scope.product,
+            version=scope.version,
+            corpus_status=exc.status,
+        )
+        raise HTTPException(
+            status_code=status.HTTP_503_SERVICE_UNAVAILABLE,
+            detail=str(exc),
+        ) from exc
+
+    structlog.contextvars.bind_contextvars(audit_hit_count=len(result.chunks))
+    log.info(
+        "search_docs_endpoint_completed",
+        operator_sub=operator.sub,
+        tenant_id=str(operator.tenant_id),
+        product=scope.product,
+        version=scope.version,
+        hit_count=len(result.chunks),
+    )
+    return SearchDocsResponse(chunks=result.chunks)

--- a/backend/src/meho_backplane/docs_search/__init__.py
+++ b/backend/src/meho_backplane/docs_search/__init__.py
@@ -1,0 +1,44 @@
+# SPDX-License-Identifier: Apache-2.0
+# Copyright (c) 2026 evoila Group
+
+"""Shared ``search_docs`` retrieval service (G4.5-T3 #1521).
+
+The ``meho-docs`` add-on (Initiative #1518) federates vendor-document
+queries through the backplane to the external corpus the ops team runs
+(T2, :mod:`meho_backplane.auth.corpus`). This package is the **one**
+shared entrypoint that surface — :func:`search_docs` — used by both the
+REST route (``POST /api/v1/search_docs``, T3) and the future MCP tool
+(T4, #1523) / CLI verb (T5, #1524). Keeping the scope-validation,
+corpus call, and cited-chunk projection in a service module (rather than
+inline in the route) is what lets T4/T5 reuse the exact same posture
+without re-implementing the REQUIRE_FILTERS gate or the citation shape.
+
+The mandatory product+version filter — a **binary scope**, never a
+ranking weight (the #1178 / #1177 decision) — is enforced here:
+:func:`build_docs_scope` rejects a missing/blank ``product`` or
+``version`` with :class:`MissingDocsFilterError`, which the route renders as
+HTTP 422 (fail-closed). Enforcement is gated by
+``settings.corpus_require_filters`` (default on); the central audit
+binding (``op_id="meho.docs.search"``) stays in the route, next to the
+``audit_*`` contextvars the chassis middleware lifts into the row.
+"""
+
+from __future__ import annotations
+
+from meho_backplane.docs_search.service import (
+    DocsChunk,
+    DocsScope,
+    DocsSearchResult,
+    MissingDocsFilterError,
+    build_docs_scope,
+    search_docs,
+)
+
+__all__ = [
+    "DocsChunk",
+    "DocsScope",
+    "DocsSearchResult",
+    "MissingDocsFilterError",
+    "build_docs_scope",
+    "search_docs",
+]

--- a/backend/src/meho_backplane/docs_search/service.py
+++ b/backend/src/meho_backplane/docs_search/service.py
@@ -1,0 +1,235 @@
+# SPDX-License-Identifier: Apache-2.0
+# Copyright (c) 2026 evoila Group
+
+"""The shared ``search_docs`` service: scope validation + corpus call.
+
+Two responsibilities, both shared across the REST route (T3), the MCP
+tool (T4), and the CLI verb (T5):
+
+1. :func:`build_docs_scope` — enforce the **mandatory** product+version
+   filter as a binary scope. When ``settings.corpus_require_filters`` is
+   on (the default), a missing or blank ``product`` / ``version`` raises
+   :class:`MissingDocsFilterError`, which the route renders HTTP 422
+   (fail-closed). The filter is a scope passed verbatim to the corpus —
+   never a ranking weight (#1178 / #1177). With the gate **off**, the
+   filter degrades to optional: present keys still scope, absent keys
+   simply widen the search (the corpus is the policy owner in that mode).
+
+2. :func:`search_docs` — call T2's :func:`~meho_backplane.auth.corpus.search_corpus`
+   with the operator's forwarded JWT and the binary scope, then project
+   the corpus's chunks into MEHO's own cited-chunk surface
+   (:class:`DocsChunk`). The transport's typed
+   :class:`~meho_backplane.auth.corpus.CorpusUnavailable` propagates
+   unchanged so the route maps it to HTTP 503 — never a silent empty 200.
+
+The audit binding (``op_id="meho.docs.search"`` + ``op_class="read"`` +
+``audit_query_hash`` + product/version/hit_count) lives in the route,
+not here, because the ``audit_*`` contextvars are HTTP-request-scoped
+and the chassis middleware is what writes the row. This module never
+touches the raw query beyond forwarding it to the corpus.
+"""
+
+from __future__ import annotations
+
+import structlog
+from pydantic import BaseModel, ConfigDict, Field
+
+from meho_backplane.auth.corpus import CorpusChunk, search_corpus
+from meho_backplane.auth.operator import Operator
+from meho_backplane.settings import get_settings
+
+__all__ = [
+    "DocsChunk",
+    "DocsScope",
+    "DocsSearchResult",
+    "MissingDocsFilterError",
+    "build_docs_scope",
+    "search_docs",
+]
+
+_log = structlog.get_logger(__name__)
+
+#: The two binary-scope keys forwarded to the corpus as
+#: ``metadata_filters``. Both are mandatory under the REQUIRE_FILTERS
+#: posture; the corpus keys its per-chunk ``metadata`` off these names.
+_PRODUCT_KEY = "product"
+_VERSION_KEY = "version"
+
+
+class MissingDocsFilterError(ValueError):
+    """Raised when a mandatory ``product`` / ``version`` filter is absent.
+
+    The REQUIRE_FILTERS posture is fail-closed: a docs query without a
+    binary product+version scope is rejected rather than forwarded as an
+    unfiltered corpus query (which would scan the whole vendor corpus and
+    defeat the per-product/version scoping the add-on exists to enforce).
+    The route maps this to HTTP 422. ``missing`` lists which key(s) were
+    absent or blank so the caller's error detail can name them without
+    re-deriving the gap.
+    """
+
+    def __init__(self, missing: list[str]) -> None:
+        self.missing = missing
+        joined = ", ".join(missing)
+        super().__init__(
+            f"search_docs requires a binary {joined} filter "
+            "(product and version are mandatory scopes, not ranking weights)"
+        )
+
+
+class DocsScope(BaseModel):
+    """The validated binary product+version scope for a docs query.
+
+    Frozen value object built by :func:`build_docs_scope`. :meth:`as_filters`
+    renders it into the ``{key: scalar}`` ``metadata_filters`` shape the
+    corpus federation client (T2) forwards verbatim — the same containment
+    contract the local retrieval substrate uses (PG ``metadata @>`` ),
+    mirrored on the corpus side. Only positively-set keys are emitted, so
+    the gate-off path can carry a partial scope without injecting ``None``
+    values the corpus would have to special-case.
+    """
+
+    model_config = ConfigDict(frozen=True)
+
+    product: str | None = Field(default=None)
+    version: str | None = Field(default=None)
+
+    def as_filters(self) -> dict[str, str]:
+        """Render the scope as a ``{key: scalar}`` corpus filter dict."""
+        filters: dict[str, str] = {}
+        if self.product is not None:
+            filters[_PRODUCT_KEY] = self.product
+        if self.version is not None:
+            filters[_VERSION_KEY] = self.version
+        return filters
+
+
+class DocsChunk(BaseModel):
+    """One cited chunk in MEHO's ``search_docs`` response surface.
+
+    A stable projection of the corpus's :class:`~meho_backplane.auth.corpus.CorpusChunk`
+    into the shape the MCP tool (T4) and CLI (T5) render: chunk text +
+    source citation + score. Decoupling MEHO's surface from the corpus's
+    wire contract means a corpus field rename doesn't churn the public
+    ``search_docs`` response; the projection in :func:`_project_chunk` is
+    the one place that mapping lives.
+    """
+
+    model_config = ConfigDict(frozen=True)
+
+    chunk_id: str
+    document_id: str
+    content: str
+    source_url: str | None = None
+    score: float | None = None
+
+
+class DocsSearchResult(BaseModel):
+    """The result of a ``search_docs`` call: the ordered cited chunks.
+
+    ``chunks`` preserves the corpus's ranking (best first). Frozen so a
+    consumer accidentally mutating the result post-construction surfaces
+    as a pydantic error rather than a silently-altered response.
+    """
+
+    model_config = ConfigDict(frozen=True)
+
+    chunks: list[DocsChunk] = Field(default_factory=list)
+
+
+def build_docs_scope(product: str | None, version: str | None) -> DocsScope:
+    """Validate the binary product+version scope, fail-closed under the gate.
+
+    When ``settings.corpus_require_filters`` is on (the default), **both**
+    ``product`` and ``version`` must be non-blank; either missing raises
+    :class:`MissingDocsFilterError` (HTTP 422 at the route). With the gate off,
+    the scope degrades to optional — whatever is provided still scopes the
+    corpus query, whatever is absent simply widens it. Blank-after-strip
+    values are treated as absent so a ``product=" "`` cannot smuggle past
+    the mandatory gate.
+
+    Args:
+        product: The vendor product to scope to (e.g. ``"vmware"``).
+        version: The product version to scope to (e.g. ``"9.0"``).
+
+    Returns:
+        A :class:`DocsScope` carrying the normalised (stripped) values.
+
+    Raises:
+        MissingDocsFilterError: when the REQUIRE_FILTERS gate is on and either
+            ``product`` or ``version`` is missing or blank.
+    """
+    norm_product = product.strip() if product and product.strip() else None
+    norm_version = version.strip() if version and version.strip() else None
+
+    if get_settings().corpus_require_filters:
+        missing: list[str] = []
+        if norm_product is None:
+            missing.append(_PRODUCT_KEY)
+        if norm_version is None:
+            missing.append(_VERSION_KEY)
+        if missing:
+            raise MissingDocsFilterError(missing)
+
+    return DocsScope(product=norm_product, version=norm_version)
+
+
+def _project_chunk(chunk: CorpusChunk) -> DocsChunk:
+    """Project a corpus chunk into MEHO's cited-chunk surface."""
+    return DocsChunk(
+        chunk_id=chunk.chunk_id,
+        document_id=chunk.document_id,
+        content=chunk.content,
+        source_url=chunk.source_url,
+        score=chunk.score,
+    )
+
+
+async def search_docs(
+    operator: Operator,
+    query: str,
+    *,
+    scope: DocsScope,
+    limit: int = 10,
+) -> DocsSearchResult:
+    """Search the external corpus for *operator* within *scope*.
+
+    Forwards the operator JWT (via T2's :func:`search_corpus`) so the
+    corpus authenticates + audits the call as the operator, scopes the
+    search to the binary product+version filter, and projects the cited
+    chunks into MEHO's surface. The query itself is never logged here —
+    only its presence is implied; the route binds the SHA-256 hash to the
+    audit row.
+
+    Args:
+        operator: The verified operator whose JWT is forwarded to the corpus.
+        query: The free-text search query.
+        scope: The validated binary product+version scope from
+            :func:`build_docs_scope`.
+        limit: Maximum number of chunks to request.
+
+    Returns:
+        A :class:`DocsSearchResult` carrying the corpus's ranked cited chunks.
+
+    Raises:
+        CorpusUnavailable: propagated unchanged from
+            :func:`~meho_backplane.auth.corpus.search_corpus` when the
+            corpus is unconfigured, unreachable, or returns a non-2xx /
+            malformed response. The route maps it to HTTP 503.
+    """
+    filters = scope.as_filters()
+    response = await search_corpus(
+        operator,
+        query,
+        metadata_filters=filters or None,
+        limit=limit,
+    )
+    chunks = [_project_chunk(c) for c in response.chunks]
+    _log.info(
+        "docs_search_completed",
+        operator_sub=operator.sub,
+        product=scope.product,
+        version=scope.version,
+        hit_count=len(chunks),
+    )
+    return DocsSearchResult(chunks=chunks)

--- a/backend/src/meho_backplane/main.py
+++ b/backend/src/meho_backplane/main.py
@@ -90,6 +90,7 @@ from meho_backplane.api.v1.retrieve_usage import router as api_v1_retrieve_usage
 from meho_backplane.api.v1.runbook_runs import router as api_v1_runbook_runs_router
 from meho_backplane.api.v1.runbook_templates import router as api_v1_runbook_templates_router
 from meho_backplane.api.v1.scheduler import router as api_v1_scheduler_router
+from meho_backplane.api.v1.search_docs import router as api_v1_search_docs_router
 from meho_backplane.api.v1.targets import router as api_v1_targets_router
 from meho_backplane.api.v1.topology import router as api_v1_topology_router
 from meho_backplane.api.well_known import router as well_known_router
@@ -581,6 +582,17 @@ app.include_router(api_v1_retrieve_eval_router)
 # counts can leak retire-decision intent so the broadcast event ships
 # in aggregate-only mode.
 app.include_router(api_v1_retrieve_retire_router)
+# G4.5-T3 (#1521) — federated vendor-document retrieval at
+# `POST /api/v1/search_docs` (the `meho-docs` add-on, Initiative #1518).
+# Operator role minimum; tenant-scoped via the forwarded operator JWT.
+# Enforces the mandatory binary product+version scope (422 fail-closed
+# under `corpus_require_filters`, default on), federates to the external
+# corpus via the T2 client (`CorpusUnavailable` → 503, never an empty
+# 200), and binds the central audit row under the canonical op_id
+# `meho.docs.search` + `read` class via the `audit_op_id` /
+# `audit_op_class` contextvar overrides. The MCP tool (T4) and CLI verb
+# (T5) reuse the same `docs_search.search_docs` service this route fronts.
+app.include_router(api_v1_search_docs_router)
 # G0.3-T3 (#254) — targets CRUD surface. All 5 routes are tenant-scoped
 # via the JWT's tenant_id claim; cross-tenant reads are impossible.
 # G9.1-T5 (#453) extends this router with GET /api/v1/targets/discover

--- a/backend/tests/test_search_docs_route.py
+++ b/backend/tests/test_search_docs_route.py
@@ -1,0 +1,559 @@
+# SPDX-License-Identifier: Apache-2.0
+# Copyright (c) 2026 evoila Group
+
+"""Behavioural tests for :mod:`meho_backplane.api.v1.search_docs` (G4.5-T3 #1521).
+
+Coverage matrix (Task #1521 acceptance criteria):
+
+* **REQUIRE_FILTERS** -- a request missing ``product`` or ``version`` (or
+  carrying a blank one) is rejected **422** when the
+  ``corpus_require_filters`` gate is on; with both present the corpus is
+  called and cited chunks are returned. With the gate off, a partial /
+  absent scope is accepted and forwarded as-is.
+* **Binary scope, not a weight** -- the product+version scope reaches the
+  T2 federation client as ``metadata_filters`` (a binary containment
+  scope), verified via the mock; it is never expressed as a ranking
+  weight.
+* **RBAC + tenant** -- ``read_only`` → 403; ``operator`` → 200; the
+  forwarded operator carries the JWT's ``tenant_id`` (tenant-scoped by
+  construction). Unauthenticated → 401.
+* **Central audit** -- one audit row per query, ``op_id="meho.docs.search"``,
+  ``op_class="read"``, the raw query stored only as a SHA-256 hash, plus
+  ``product`` / ``version`` / ``hit_count``; the row is returned by
+  :func:`~meho_backplane.audit_query.query.query_audit` filtered on that
+  ``op_id``.
+* **Corpus-unavailable** -- a :class:`CorpusUnavailable` from the
+  federation client → 503 (fail-closed), never an empty 200.
+
+The corpus call is mocked at :func:`meho_backplane.docs_search.service.search_corpus`
+(the service's import site) so the route tests don't depend on a live
+corpus; the audit read-back uses the autouse SQLite engine the chassis
+audit tests share.
+"""
+
+from __future__ import annotations
+
+import json
+from collections.abc import Iterator
+from unittest.mock import AsyncMock, patch
+from uuid import UUID
+
+import pytest
+import respx
+import structlog
+from fastapi import FastAPI
+from fastapi.testclient import TestClient
+from sqlalchemy import select
+
+from meho_backplane.api.v1.search_docs import _compute_query_hash
+from meho_backplane.api.v1.search_docs import router as search_docs_router
+from meho_backplane.audit import AuditMiddleware
+from meho_backplane.audit_query import AuditQueryFilters, query_audit
+from meho_backplane.auth.corpus import CorpusChunk, CorpusSearchResponse, CorpusUnavailable
+from meho_backplane.auth.jwt import clear_jwks_cache
+from meho_backplane.auth.operator import TenantRole
+from meho_backplane.db.engine import get_sessionmaker
+from meho_backplane.db.models import AuditLog
+from meho_backplane.middleware import RequestContextMiddleware
+from meho_backplane.settings import get_settings
+
+from ._oidc_jwt_helpers import AUDIENCE as _AUDIENCE
+from ._oidc_jwt_helpers import ISSUER as _ISSUER
+from ._oidc_jwt_helpers import make_rsa_keypair as _make_rsa_keypair
+from ._oidc_jwt_helpers import mint_token as _mint_token
+from ._oidc_jwt_helpers import mock_discovery_and_jwks as _mock_discovery_and_jwks
+from ._oidc_jwt_helpers import public_jwks as _public_jwks
+
+# ---------------------------------------------------------------------------
+# Settings + JWKS cache fixtures
+# ---------------------------------------------------------------------------
+
+
+@pytest.fixture(autouse=True)
+def _settings_env(monkeypatch: pytest.MonkeyPatch) -> Iterator[None]:
+    """Pin every env var :class:`Settings` reads, around every test.
+
+    ``CORPUS_URL`` is set so the corpus is "configured" (the federation
+    client is mocked at the service import site regardless, so the URL is
+    never dialled); ``CORPUS_REQUIRE_FILTERS`` defaults on. Tests that
+    exercise the gate-off path override it via :func:`_settings_env`'s
+    monkeypatch + ``cache_clear``.
+    """
+    monkeypatch.setenv("KEYCLOAK_ISSUER_URL", _ISSUER)
+    monkeypatch.setenv("KEYCLOAK_AUDIENCE", _AUDIENCE)
+    monkeypatch.setenv("KEYCLOAK_JWKS_CACHE_TTL_SECONDS", "300")
+    monkeypatch.setenv("KEYCLOAK_JWT_LEEWAY_SECONDS", "30")
+    monkeypatch.setenv("VAULT_ADDR", "https://vault.test")
+    monkeypatch.setenv("VAULT_OIDC_ROLE", "meho-mcp")
+    monkeypatch.setenv("VAULT_OIDC_MOUNT_PATH", "jwt")
+    monkeypatch.setenv("VAULT_TIMEOUT_SECONDS", "5.0")
+    monkeypatch.delenv("VAULT_NAMESPACE", raising=False)
+    monkeypatch.setenv("CORPUS_URL", "https://corpus.test/search")
+    monkeypatch.setenv("CORPUS_REQUIRE_FILTERS", "true")
+    get_settings.cache_clear()
+    yield
+    get_settings.cache_clear()
+
+
+@pytest.fixture(autouse=True)
+def _isolated_jwks_cache() -> Iterator[None]:
+    """Empty the module-level JWKS cache around every test."""
+    clear_jwks_cache()
+    yield
+    clear_jwks_cache()
+
+
+# ---------------------------------------------------------------------------
+# App construction with the search_docs route + audit middleware
+# ---------------------------------------------------------------------------
+
+
+def _build_app() -> FastAPI:
+    """Return a :class:`FastAPI` mirroring prod with the route mounted.
+
+    Includes the production middleware stack so the audit-payload tests
+    see the same contextvar-binding flow production uses. The corpus
+    client is patched at the service import site per-test.
+    """
+    app = FastAPI()
+    app.add_middleware(AuditMiddleware)
+    app.add_middleware(RequestContextMiddleware)
+    app.include_router(search_docs_router)
+    return app
+
+
+@pytest.fixture
+def client() -> Iterator[TestClient]:
+    """``TestClient`` driving a fresh app per test."""
+    yield TestClient(_build_app())
+
+
+# ---------------------------------------------------------------------------
+# Helpers
+# ---------------------------------------------------------------------------
+
+
+def _make_chunk(chunk_id: str = "c1", content: str = "vSAN disk groups...") -> CorpusChunk:
+    """Build a :class:`CorpusChunk` for stub corpus responses."""
+    return CorpusChunk(
+        chunk_id=chunk_id,
+        document_id="doc-7",
+        content=content,
+        source_url="https://docs.vendor.test/vsan#disk-groups",
+        score=0.91,
+        metadata={"product": "vmware", "version": "9.0"},
+    )
+
+
+def _mock_corpus(*chunks: CorpusChunk) -> AsyncMock:
+    """An ``AsyncMock`` standing in for ``search_corpus`` returning *chunks*."""
+    return AsyncMock(return_value=CorpusSearchResponse(chunks=list(chunks)))
+
+
+# ---------------------------------------------------------------------------
+# Pure helper coverage
+# ---------------------------------------------------------------------------
+
+
+def test_compute_query_hash_is_deterministic_sha256() -> None:
+    """Query hash is SHA-256 of UTF-8 (64 hex chars), matching retrieve."""
+    h = _compute_query_hash("vsan disk groups")
+    assert len(h) == 64
+    assert h == _compute_query_hash("vsan disk groups")
+    int(h, 16)  # parses as hex
+
+
+# ---------------------------------------------------------------------------
+# Happy path + binary scope forwarding
+# ---------------------------------------------------------------------------
+
+
+def test_search_docs_returns_200_with_cited_chunks(client: TestClient) -> None:
+    """``operator`` JWT + product+version → 200 with cited chunks."""
+    key = _make_rsa_keypair("kid-A")
+    tenant_id = UUID("33333333-3333-3333-3333-333333333333")
+    token = _mint_token(
+        key,
+        sub="op-1",
+        tenant_role=TenantRole.OPERATOR.value,
+        tenant_id=str(tenant_id),
+    )
+
+    fake_corpus = _mock_corpus(_make_chunk("c1"), _make_chunk("c2", "another"))
+    with (
+        respx.mock as mock_router,
+        patch("meho_backplane.docs_search.service.search_corpus", new=fake_corpus),
+    ):
+        _mock_discovery_and_jwks(mock_router, _public_jwks(key))
+        response = client.post(
+            "/api/v1/search_docs",
+            json={"query": "vsan disk groups", "product": "vmware", "version": "9.0", "limit": 5},
+            headers={"Authorization": f"Bearer {token}"},
+        )
+
+    assert response.status_code == 200
+    body = response.json()
+    assert len(body["chunks"]) == 2
+    assert body["chunks"][0]["chunk_id"] == "c1"
+    assert body["chunks"][0]["content"] == "vSAN disk groups..."
+    assert body["chunks"][0]["source_url"] == "https://docs.vendor.test/vsan#disk-groups"
+    assert body["chunks"][0]["score"] == 0.91
+
+    # The corpus client was called as the operator (forwarded JWT) with
+    # the query + limit; the operator object carries the JWT tenant_id.
+    fake_corpus.assert_awaited_once()
+    call_args = fake_corpus.await_args
+    operator_arg = call_args.args[0]
+    assert operator_arg.tenant_id == tenant_id
+    assert call_args.args[1] == "vsan disk groups"
+    assert call_args.kwargs["limit"] == 5
+
+
+def test_product_version_forwarded_as_binary_filter_not_weight(client: TestClient) -> None:
+    """The product+version scope reaches the corpus as ``metadata_filters``.
+
+    The scope is a binary containment filter (#1178 / #1177), so it must
+    arrive on the T2 client's ``metadata_filters`` kwarg verbatim -- never
+    as a ``weight`` / boost parameter.
+    """
+    key = _make_rsa_keypair("kid-A")
+    token = _mint_token(key, sub="op-2", tenant_role=TenantRole.OPERATOR.value)
+
+    fake_corpus = _mock_corpus()
+    with (
+        respx.mock as mock_router,
+        patch("meho_backplane.docs_search.service.search_corpus", new=fake_corpus),
+    ):
+        _mock_discovery_and_jwks(mock_router, _public_jwks(key))
+        response = client.post(
+            "/api/v1/search_docs",
+            json={"query": "esxi upgrade", "product": "vmware", "version": "8.0"},
+            headers={"Authorization": f"Bearer {token}"},
+        )
+
+    assert response.status_code == 200
+    call_kwargs = fake_corpus.await_args.kwargs
+    assert call_kwargs["metadata_filters"] == {"product": "vmware", "version": "8.0"}
+    # The scope is a filter, not a weight: no weighting kwarg is passed.
+    assert "weight" not in call_kwargs
+    assert "weights" not in call_kwargs
+    assert "boost" not in call_kwargs
+
+
+# ---------------------------------------------------------------------------
+# REQUIRE_FILTERS (422 fail-closed)
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.parametrize(
+    ("body", "missing"),
+    [
+        ({"query": "q", "version": "9.0"}, "product"),
+        ({"query": "q", "product": "vmware"}, "version"),
+        ({"query": "q"}, "product"),
+        ({"query": "q", "product": "  ", "version": "9.0"}, "product"),
+        ({"query": "q", "product": "vmware", "version": ""}, "version"),
+    ],
+)
+def test_missing_or_blank_filter_rejects_with_422(
+    client: TestClient, body: dict[str, str], missing: str
+) -> None:
+    """A missing / blank product or version → 422 (REQUIRE_FILTERS).
+
+    The corpus client must NOT be called when the mandatory scope is
+    absent -- an unfiltered corpus query is exactly what fail-closed
+    prevents.
+    """
+    key = _make_rsa_keypair("kid-A")
+    token = _mint_token(key, sub="op-rf", tenant_role=TenantRole.OPERATOR.value)
+    fake_corpus = _mock_corpus()
+    with (
+        respx.mock as mock_router,
+        patch("meho_backplane.docs_search.service.search_corpus", new=fake_corpus),
+    ):
+        _mock_discovery_and_jwks(mock_router, _public_jwks(key))
+        response = client.post(
+            "/api/v1/search_docs",
+            json=body,
+            headers={"Authorization": f"Bearer {token}"},
+        )
+    assert response.status_code == 422
+    assert missing in json.dumps(response.json()["detail"])
+    fake_corpus.assert_not_awaited()
+
+
+def test_gate_off_accepts_partial_scope_and_forwards_present_keys(
+    client: TestClient, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    """With ``corpus_require_filters`` off, a partial scope is accepted.
+
+    Whatever filter is present still scopes the corpus query; absent
+    keys simply widen it (the corpus owns the policy in this mode). The
+    enforcement is gated, per the Initiative -- not hard-wired.
+    """
+    monkeypatch.setenv("CORPUS_REQUIRE_FILTERS", "false")
+    get_settings.cache_clear()
+
+    key = _make_rsa_keypair("kid-A")
+    token = _mint_token(key, sub="op-gate-off", tenant_role=TenantRole.OPERATOR.value)
+    fake_corpus = _mock_corpus(_make_chunk())
+    with (
+        respx.mock as mock_router,
+        patch("meho_backplane.docs_search.service.search_corpus", new=fake_corpus),
+    ):
+        _mock_discovery_and_jwks(mock_router, _public_jwks(key))
+        response = client.post(
+            "/api/v1/search_docs",
+            json={"query": "q", "product": "vmware"},  # no version
+            headers={"Authorization": f"Bearer {token}"},
+        )
+
+    assert response.status_code == 200
+    # Only the present key is forwarded; no `version: None` is injected.
+    assert fake_corpus.await_args.kwargs["metadata_filters"] == {"product": "vmware"}
+
+
+def test_empty_query_rejects_with_422(client: TestClient) -> None:
+    """``query=""`` fails Pydantic min_length validation."""
+    key = _make_rsa_keypair("kid-A")
+    token = _mint_token(key, sub="op-eq", tenant_role=TenantRole.OPERATOR.value)
+    with respx.mock as mock_router:
+        _mock_discovery_and_jwks(mock_router, _public_jwks(key))
+        response = client.post(
+            "/api/v1/search_docs",
+            json={"query": "", "product": "vmware", "version": "9.0"},
+            headers={"Authorization": f"Bearer {token}"},
+        )
+    assert response.status_code == 422
+
+
+# ---------------------------------------------------------------------------
+# Corpus unavailable (503 fail-closed)
+# ---------------------------------------------------------------------------
+
+
+def test_corpus_unavailable_maps_to_503_not_empty_200(client: TestClient) -> None:
+    """A :class:`CorpusUnavailable` from the client → 503, never empty 200."""
+    key = _make_rsa_keypair("kid-A")
+    token = _mint_token(key, sub="op-503", tenant_role=TenantRole.OPERATOR.value)
+    fake_corpus = AsyncMock(side_effect=CorpusUnavailable("corpus unreachable: ConnectError"))
+    with (
+        respx.mock as mock_router,
+        patch("meho_backplane.docs_search.service.search_corpus", new=fake_corpus),
+    ):
+        _mock_discovery_and_jwks(mock_router, _public_jwks(key))
+        response = client.post(
+            "/api/v1/search_docs",
+            json={"query": "q", "product": "vmware", "version": "9.0"},
+            headers={"Authorization": f"Bearer {token}"},
+        )
+    assert response.status_code == 503
+    assert "chunks" not in response.json()
+
+
+def test_unconfigured_corpus_maps_to_503(
+    client: TestClient, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    """An unset ``CORPUS_URL`` → the real client raises → 503.
+
+    Uses the *real* :func:`search_corpus` (no patch) with ``CORPUS_URL``
+    cleared, proving the unconfigured branch fails closed end-to-end
+    rather than via the mock.
+    """
+    monkeypatch.delenv("CORPUS_URL", raising=False)
+    get_settings.cache_clear()
+
+    key = _make_rsa_keypair("kid-A")
+    token = _mint_token(key, sub="op-unconfig", tenant_role=TenantRole.OPERATOR.value)
+    with respx.mock as mock_router:
+        _mock_discovery_and_jwks(mock_router, _public_jwks(key))
+        response = client.post(
+            "/api/v1/search_docs",
+            json={"query": "q", "product": "vmware", "version": "9.0"},
+            headers={"Authorization": f"Bearer {token}"},
+        )
+    assert response.status_code == 503
+
+
+# ---------------------------------------------------------------------------
+# RBAC (401 / 403)
+# ---------------------------------------------------------------------------
+
+
+def test_unauthenticated_request_returns_401(client: TestClient) -> None:
+    """No Authorization header → 401."""
+    response = client.post(
+        "/api/v1/search_docs",
+        json={"query": "q", "product": "vmware", "version": "9.0"},
+    )
+    assert response.status_code == 401
+
+
+def test_read_only_role_returns_403(client: TestClient) -> None:
+    """``read_only`` JWT → 403 (route gated on OPERATOR)."""
+    key = _make_rsa_keypair("kid-A")
+    token = _mint_token(key, sub="op-ro", tenant_role=TenantRole.READ_ONLY.value)
+    with respx.mock as mock_router, structlog.testing.capture_logs() as cap_logs:
+        _mock_discovery_and_jwks(mock_router, _public_jwks(key))
+        response = client.post(
+            "/api/v1/search_docs",
+            json={"query": "q", "product": "vmware", "version": "9.0"},
+            headers={"Authorization": f"Bearer {token}"},
+        )
+    assert response.status_code == 403
+    assert response.json() == {"detail": "insufficient_role"}
+    insufficient = [e for e in cap_logs if e.get("event") == "insufficient_role"]
+    assert len(insufficient) == 1
+    assert insufficient[0]["operator_sub"] == "op-ro"
+
+
+def test_admin_role_returns_200(client: TestClient) -> None:
+    """``tenant_admin`` JWT passes the operator gate (admin >= operator)."""
+    key = _make_rsa_keypair("kid-A")
+    token = _mint_token(key, sub="op-admin", tenant_role=TenantRole.TENANT_ADMIN.value)
+    fake_corpus = _mock_corpus()
+    with (
+        respx.mock as mock_router,
+        patch("meho_backplane.docs_search.service.search_corpus", new=fake_corpus),
+    ):
+        _mock_discovery_and_jwks(mock_router, _public_jwks(key))
+        response = client.post(
+            "/api/v1/search_docs",
+            json={"query": "q", "product": "vmware", "version": "9.0"},
+            headers={"Authorization": f"Bearer {token}"},
+        )
+    assert response.status_code == 200
+
+
+# ---------------------------------------------------------------------------
+# Central audit contract
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.asyncio
+async def test_audit_row_carries_op_id_hash_and_scope_not_raw_query(client: TestClient) -> None:
+    """One audit row: ``op_id=meho.docs.search``, ``op_class=read``, hash + scope.
+
+    The raw query MUST NOT appear anywhere in the payload -- only its
+    SHA-256 digest. ``product`` / ``version`` (operator-chosen scopes,
+    not tenant-shaped identifiers) and ``hit_count`` are recorded.
+    """
+    key = _make_rsa_keypair("kid-A")
+    raw_query = "how do I expand a vsan disk group"
+    token = _mint_token(key, sub="op-audit", tenant_role=TenantRole.OPERATOR.value)
+    fake_corpus = _mock_corpus(_make_chunk("c1"), _make_chunk("c2"))
+    with (
+        respx.mock as mock_router,
+        patch("meho_backplane.docs_search.service.search_corpus", new=fake_corpus),
+    ):
+        _mock_discovery_and_jwks(mock_router, _public_jwks(key))
+        response = client.post(
+            "/api/v1/search_docs",
+            json={"query": raw_query, "product": "vmware", "version": "9.0"},
+            headers={"Authorization": f"Bearer {token}"},
+        )
+    assert response.status_code == 200
+
+    sessionmaker = get_sessionmaker()
+    async with sessionmaker() as session:
+        result = await session.execute(
+            select(AuditLog).where(AuditLog.path == "/api/v1/search_docs")
+        )
+        rows = result.scalars().all()
+
+    assert len(rows) == 1
+    payload = rows[0].payload
+    assert payload["op_id"] == "meho.docs.search"
+    assert payload["op_class"] == "read"
+    assert payload["query_hash"] == _compute_query_hash(raw_query)
+    assert payload["product"] == "vmware"
+    assert payload["version"] == "9.0"
+    assert payload["hit_count"] == 2
+
+    serialised = json.dumps(payload)
+    assert raw_query not in serialised
+    assert len(payload["query_hash"]) == 64
+
+
+@pytest.mark.asyncio
+async def test_query_audit_finds_row_by_op_id(client: TestClient) -> None:
+    """The audit row is returned by ``query_audit`` filtered on the op_id.
+
+    Closes the loop that who-touched / ``query_audit`` surface every
+    docs query under the named op -- the reason the route binds a canonical
+    ``op_id`` rather than the path-derived default.
+    """
+    key = _make_rsa_keypair("kid-A")
+    tenant_id = UUID("44444444-4444-4444-4444-444444444444")
+    token = _mint_token(
+        key,
+        sub="op-qa",
+        tenant_role=TenantRole.OPERATOR.value,
+        tenant_id=str(tenant_id),
+    )
+    fake_corpus = _mock_corpus(_make_chunk())
+    with (
+        respx.mock as mock_router,
+        patch("meho_backplane.docs_search.service.search_corpus", new=fake_corpus),
+    ):
+        _mock_discovery_and_jwks(mock_router, _public_jwks(key))
+        response = client.post(
+            "/api/v1/search_docs",
+            json={"query": "vsan", "product": "vmware", "version": "9.0"},
+            headers={"Authorization": f"Bearer {token}"},
+        )
+    assert response.status_code == 200
+
+    sessionmaker = get_sessionmaker()
+    async with sessionmaker() as session:
+        result = await query_audit(
+            AuditQueryFilters(op_id="meho.docs.search"),
+            tenant_id=tenant_id,
+            session=session,
+        )
+
+    assert len(result.rows) == 1
+    assert result.rows[0].op_id == "meho.docs.search"
+    assert result.rows[0].op_class == "read"
+
+
+@pytest.mark.asyncio
+async def test_audit_row_written_on_corpus_503(client: TestClient) -> None:
+    """A 503 still produces an audit row with the query identity + scope.
+
+    The contextvars are bound *before* the corpus call, so the
+    fail-closed path is still attributable: who searched for what
+    (hashed), scoped to which product/version, even though it failed.
+    ``hit_count`` is absent (bound only after a successful return).
+    """
+    key = _make_rsa_keypair("kid-A")
+    raw_query = "esxi boot loop"
+    token = _mint_token(key, sub="op-503-audit", tenant_role=TenantRole.OPERATOR.value)
+    fake_corpus = AsyncMock(side_effect=CorpusUnavailable("corpus returned HTTP 502", status=502))
+    with (
+        respx.mock as mock_router,
+        patch("meho_backplane.docs_search.service.search_corpus", new=fake_corpus),
+    ):
+        _mock_discovery_and_jwks(mock_router, _public_jwks(key))
+        response = client.post(
+            "/api/v1/search_docs",
+            json={"query": raw_query, "product": "vmware", "version": "8.0"},
+            headers={"Authorization": f"Bearer {token}"},
+        )
+    assert response.status_code == 503
+
+    sessionmaker = get_sessionmaker()
+    async with sessionmaker() as session:
+        result = await session.execute(
+            select(AuditLog).where(AuditLog.path == "/api/v1/search_docs")
+        )
+        rows = result.scalars().all()
+
+    assert len(rows) == 1
+    payload = rows[0].payload
+    assert payload["op_id"] == "meho.docs.search"
+    assert payload["query_hash"] == _compute_query_hash(raw_query)
+    assert payload["product"] == "vmware"
+    assert payload["version"] == "8.0"
+    assert "hit_count" not in payload
+    assert raw_query not in json.dumps(payload)

--- a/cli/api/openapi.json
+++ b/cli/api/openapi.json
@@ -403,6 +403,56 @@
         }
       }
     },
+    "/api/v1/search_docs": {
+      "post": {
+        "tags": [
+          "docs"
+        ],
+        "summary": "Search Docs Endpoint",
+        "description": "Federate a vendor-document query to the corpus, returning cited chunks.\n\nEnforces the mandatory binary product+version scope (422 when the\nREQUIRE_FILTERS gate is on and either is absent), forwards the\noperator JWT to the corpus via the shared\n:func:`~meho_backplane.docs_search.search_docs` service, and binds\nthe central ``meho.docs.search`` audit row. ``read_only`` operators\nget 403 via :func:`require_role` before reaching this handler.\n\nThe audit contextvars are bound **before** the corpus call so a\nhandler exception (including the :class:`CorpusUnavailable` \u2192 503\nbranch) still produces an audit row with the query identity + binary\nscope preserved. The raw query is never bound -- only its SHA-256\nhash.",
+        "operationId": "search_docs_endpoint_api_v1_search_docs_post",
+        "parameters": [
+          {
+            "name": "authorization",
+            "in": "header",
+            "required": false,
+            "schema": {
+              "type": "string",
+              "nullable": true,
+              "title": "Authorization"
+            }
+          }
+        ],
+        "requestBody": {
+          "required": true,
+          "content": {
+            "application/json": {
+              "schema": {
+                "$ref": "#/components/schemas/SearchDocsRequest"
+              }
+            }
+          }
+        },
+        "responses": {
+          "200": {
+            "description": "Successful Response",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/SearchDocsResponse"
+                }
+              }
+            }
+          },
+          "422": {
+            "description": "The mandatory binary product+version scope is absent (REQUIRE_FILTERS). A docs query without both filters is rejected rather than forwarded as an unfiltered corpus query."
+          },
+          "503": {
+            "description": "The external corpus is unavailable -- unconfigured, unreachable, or returned a non-2xx / malformed response. Fail-closed; never an empty 200."
+          }
+        }
+      }
+    },
     "/api/v1/targets": {
       "get": {
         "tags": [
@@ -12285,6 +12335,40 @@
         "title": "DeprecateTemplateResponse",
         "description": "Response for ``runbook_deprecate_template`` -- the now-deprecated coordinates."
       },
+      "DocsChunk": {
+        "properties": {
+          "chunk_id": {
+            "type": "string",
+            "title": "Chunk Id"
+          },
+          "document_id": {
+            "type": "string",
+            "title": "Document Id"
+          },
+          "content": {
+            "type": "string",
+            "title": "Content"
+          },
+          "source_url": {
+            "type": "string",
+            "nullable": true,
+            "title": "Source Url"
+          },
+          "score": {
+            "type": "number",
+            "nullable": true,
+            "title": "Score"
+          }
+        },
+        "type": "object",
+        "required": [
+          "chunk_id",
+          "document_id",
+          "content"
+        ],
+        "title": "DocsChunk",
+        "description": "One cited chunk in MEHO's ``search_docs`` response surface.\n\nA stable projection of the corpus's :class:`~meho_backplane.auth.corpus.CorpusChunk`\ninto the shape the MCP tool (T4) and CLI (T5) render: chunk text +\nsource citation + score. Decoupling MEHO's surface from the corpus's\nwire contract means a corpus field rename doesn't churn the public\n``search_docs`` response; the projection in :func:`_project_chunk` is\nthe one place that mapping lives."
+      },
       "DraftTemplateRequest": {
         "properties": {
           "slug": {
@@ -14696,6 +14780,59 @@
         ],
         "title": "ScheduledTriggerStatus",
         "description": "Closed lifecycle status of a :class:`ScheduledTrigger`.\n\nInitiative #804 (G11.3 Scheduler), Task #822 (T1). The admin\nsurface (T5 #826) walks triggers through this state machine; the\ndispatcher (T2/T3) only fires rows with :attr:`ACTIVE`.\n\nMembers:\n\n* :attr:`ACTIVE` -- the trigger is eligible for dispatch.\n* :attr:`PAUSED` -- the trigger is temporarily disabled by an\n  operator. ``next_fire_at`` is preserved so resuming reactivates\n  without recomputing.\n* :attr:`CANCELLED` -- terminal. The trigger row is retained for\n  audit purposes but never fires again.\n* :attr:`FIRED` -- terminal one-off state. Migration ``0025`` (T2\n  #823) widened the enum so a one-off trigger transitions\n  ``ACTIVE -> FIRED`` after its single dispatch instead of going\n  to ``CANCELLED`` (which carries operator-intent semantics).\n  :class:`ScheduledTrigger` rows in this state are retained for\n  audit (last-fired-at + identity_sub) but never re-dispatched."
+      },
+      "SearchDocsRequest": {
+        "properties": {
+          "query": {
+            "type": "string",
+            "maxLength": 2000,
+            "minLength": 1,
+            "title": "Query"
+          },
+          "product": {
+            "type": "string",
+            "maxLength": 128,
+            "nullable": true,
+            "title": "Product"
+          },
+          "version": {
+            "type": "string",
+            "maxLength": 128,
+            "nullable": true,
+            "title": "Version"
+          },
+          "limit": {
+            "type": "integer",
+            "maximum": 50.0,
+            "minimum": 1.0,
+            "title": "Limit",
+            "default": 10
+          }
+        },
+        "additionalProperties": false,
+        "type": "object",
+        "required": [
+          "query"
+        ],
+        "title": "SearchDocsRequest",
+        "description": "POST body for ``/api/v1/search_docs``.\n\n``product`` / ``version`` are the **mandatory binary scope** under\nthe REQUIRE_FILTERS posture -- they are typed optional here so a\nmissing value is rejected by the service with a route-shaped 422\nnaming the absent key(s), rather than Pydantic's generic\n``field_required`` (which would not say *why* the scope is mandatory\nor honour the ``corpus_require_filters`` gate-off path).\n\n``extra=\"forbid\"`` rejects unknown fields at 422 so a client sending\na pre-rename key fails loud rather than running with the defaults --\nthe same posture every public v1 request schema ships under."
+      },
+      "SearchDocsResponse": {
+        "properties": {
+          "chunks": {
+            "items": {
+              "$ref": "#/components/schemas/DocsChunk"
+            },
+            "type": "array",
+            "title": "Chunks"
+          }
+        },
+        "type": "object",
+        "required": [
+          "chunks"
+        ],
+        "title": "SearchDocsResponse",
+        "description": "Successful response shape for ``/api/v1/search_docs``.\n\n``chunks`` is the corpus's ranked cited-chunk list (best first),\nprojected into MEHO's :class:`~meho_backplane.docs_search.DocsChunk`\nsurface so the wire contract is decoupled from the corpus's. Frozen\nso an accidental post-construction mutation surfaces as a pydantic\nerror rather than a silently-altered response."
       },
       "ShowTemplateResponse": {
         "properties": {

--- a/cli/internal/api/client.gen.go
+++ b/cli/internal/api/client.gen.go
@@ -2094,6 +2094,22 @@ type DeprecateTemplateResponse struct {
 	Version int    `json:"version"`
 }
 
+// DocsChunk One cited chunk in MEHO's “search_docs“ response surface.
+//
+// A stable projection of the corpus's :class:`~meho_backplane.auth.corpus.CorpusChunk`
+// into the shape the MCP tool (T4) and CLI (T5) render: chunk text +
+// source citation + score. Decoupling MEHO's surface from the corpus's
+// wire contract means a corpus field rename doesn't churn the public
+// “search_docs“ response; the projection in :func:`_project_chunk` is
+// the one place that mapping lives.
+type DocsChunk struct {
+	ChunkId    string   `json:"chunk_id"`
+	Content    string   `json:"content"`
+	DocumentId string   `json:"document_id"`
+	Score      *float32 `json:"score"`
+	SourceUrl  *string  `json:"source_url"`
+}
+
 // DraftTemplateRequest Request body for “runbook_draft_template“ -- create a new draft.
 //
 // :attr:`slug` is validated against :data:`SLUG_PATTERN` (the kb slug
@@ -3712,6 +3728,36 @@ type ScheduledTriggerRead struct {
 //     :class:`ScheduledTrigger` rows in this state are retained for
 //     audit (last-fired-at + identity_sub) but never re-dispatched.
 type ScheduledTriggerStatus string
+
+// SearchDocsRequest POST body for “/api/v1/search_docs“.
+//
+// “product“ / “version“ are the **mandatory binary scope** under
+// the REQUIRE_FILTERS posture -- they are typed optional here so a
+// missing value is rejected by the service with a route-shaped 422
+// naming the absent key(s), rather than Pydantic's generic
+// “field_required“ (which would not say *why* the scope is mandatory
+// or honour the “corpus_require_filters“ gate-off path).
+//
+// “extra="forbid"“ rejects unknown fields at 422 so a client sending
+// a pre-rename key fails loud rather than running with the defaults --
+// the same posture every public v1 request schema ships under.
+type SearchDocsRequest struct {
+	Limit   *int    `json:"limit,omitempty"`
+	Product *string `json:"product"`
+	Query   string  `json:"query"`
+	Version *string `json:"version"`
+}
+
+// SearchDocsResponse Successful response shape for “/api/v1/search_docs“.
+//
+// “chunks“ is the corpus's ranked cited-chunk list (best first),
+// projected into MEHO's :class:`~meho_backplane.docs_search.DocsChunk`
+// surface so the wire contract is decoupled from the corpus's. Frozen
+// so an accidental post-construction mutation surfaces as a pydantic
+// error rather than a silently-altered response.
+type SearchDocsResponse struct {
+	Chunks []DocsChunk `json:"chunks"`
+}
 
 // ShowTemplateResponse Full template surface returned by “runbook_show_template“.
 //
@@ -5367,6 +5413,11 @@ type CancelTriggerApiV1SchedulerTriggersTriggerIdDeleteParams struct {
 	Authorization *string             `json:"authorization,omitempty"`
 }
 
+// SearchDocsEndpointApiV1SearchDocsPostParams defines parameters for SearchDocsEndpointApiV1SearchDocsPost.
+type SearchDocsEndpointApiV1SearchDocsPostParams struct {
+	Authorization *string `json:"authorization,omitempty"`
+}
+
 // ListTargetsApiV1TargetsGetParams defines parameters for ListTargetsApiV1TargetsGet.
 type ListTargetsApiV1TargetsGetParams struct {
 	Product *string `form:"product,omitempty" json:"product,omitempty"`
@@ -5733,6 +5784,9 @@ type PublishTemplateApiV1RunbooksTemplatesSlugPublishPostJSONRequestBody = Under
 
 // CreateTriggerApiV1SchedulerTriggersPostJSONRequestBody defines body for CreateTriggerApiV1SchedulerTriggersPost for application/json ContentType.
 type CreateTriggerApiV1SchedulerTriggersPostJSONRequestBody = ScheduledTriggerCreate
+
+// SearchDocsEndpointApiV1SearchDocsPostJSONRequestBody defines body for SearchDocsEndpointApiV1SearchDocsPost for application/json ContentType.
+type SearchDocsEndpointApiV1SearchDocsPostJSONRequestBody = SearchDocsRequest
 
 // CreateTargetApiV1TargetsPostJSONRequestBody defines body for CreateTargetApiV1TargetsPost for application/json ContentType.
 type CreateTargetApiV1TargetsPostJSONRequestBody = TargetCreate
@@ -6918,6 +6972,11 @@ type ClientInterface interface {
 
 	// CancelTriggerApiV1SchedulerTriggersTriggerIdDelete request
 	CancelTriggerApiV1SchedulerTriggersTriggerIdDelete(ctx context.Context, triggerId openapi_types.UUID, params *CancelTriggerApiV1SchedulerTriggersTriggerIdDeleteParams, reqEditors ...RequestEditorFn) (*http.Response, error)
+
+	// SearchDocsEndpointApiV1SearchDocsPostWithBody request with any body
+	SearchDocsEndpointApiV1SearchDocsPostWithBody(ctx context.Context, params *SearchDocsEndpointApiV1SearchDocsPostParams, contentType string, body io.Reader, reqEditors ...RequestEditorFn) (*http.Response, error)
+
+	SearchDocsEndpointApiV1SearchDocsPost(ctx context.Context, params *SearchDocsEndpointApiV1SearchDocsPostParams, body SearchDocsEndpointApiV1SearchDocsPostJSONRequestBody, reqEditors ...RequestEditorFn) (*http.Response, error)
 
 	// ListTargetsApiV1TargetsGet request
 	ListTargetsApiV1TargetsGet(ctx context.Context, params *ListTargetsApiV1TargetsGetParams, reqEditors ...RequestEditorFn) (*http.Response, error)
@@ -8595,6 +8654,30 @@ func (c *Client) CreateTriggerApiV1SchedulerTriggersPost(ctx context.Context, pa
 
 func (c *Client) CancelTriggerApiV1SchedulerTriggersTriggerIdDelete(ctx context.Context, triggerId openapi_types.UUID, params *CancelTriggerApiV1SchedulerTriggersTriggerIdDeleteParams, reqEditors ...RequestEditorFn) (*http.Response, error) {
 	req, err := NewCancelTriggerApiV1SchedulerTriggersTriggerIdDeleteRequest(c.Server, triggerId, params)
+	if err != nil {
+		return nil, err
+	}
+	req = req.WithContext(ctx)
+	if err := c.applyEditors(ctx, req, reqEditors); err != nil {
+		return nil, err
+	}
+	return c.Client.Do(req)
+}
+
+func (c *Client) SearchDocsEndpointApiV1SearchDocsPostWithBody(ctx context.Context, params *SearchDocsEndpointApiV1SearchDocsPostParams, contentType string, body io.Reader, reqEditors ...RequestEditorFn) (*http.Response, error) {
+	req, err := NewSearchDocsEndpointApiV1SearchDocsPostRequestWithBody(c.Server, params, contentType, body)
+	if err != nil {
+		return nil, err
+	}
+	req = req.WithContext(ctx)
+	if err := c.applyEditors(ctx, req, reqEditors); err != nil {
+		return nil, err
+	}
+	return c.Client.Do(req)
+}
+
+func (c *Client) SearchDocsEndpointApiV1SearchDocsPost(ctx context.Context, params *SearchDocsEndpointApiV1SearchDocsPostParams, body SearchDocsEndpointApiV1SearchDocsPostJSONRequestBody, reqEditors ...RequestEditorFn) (*http.Response, error) {
+	req, err := NewSearchDocsEndpointApiV1SearchDocsPostRequest(c.Server, params, body)
 	if err != nil {
 		return nil, err
 	}
@@ -15157,6 +15240,61 @@ func NewCancelTriggerApiV1SchedulerTriggersTriggerIdDeleteRequest(server string,
 	return req, nil
 }
 
+// NewSearchDocsEndpointApiV1SearchDocsPostRequest calls the generic SearchDocsEndpointApiV1SearchDocsPost builder with application/json body
+func NewSearchDocsEndpointApiV1SearchDocsPostRequest(server string, params *SearchDocsEndpointApiV1SearchDocsPostParams, body SearchDocsEndpointApiV1SearchDocsPostJSONRequestBody) (*http.Request, error) {
+	var bodyReader io.Reader
+	buf, err := json.Marshal(body)
+	if err != nil {
+		return nil, err
+	}
+	bodyReader = bytes.NewReader(buf)
+	return NewSearchDocsEndpointApiV1SearchDocsPostRequestWithBody(server, params, "application/json", bodyReader)
+}
+
+// NewSearchDocsEndpointApiV1SearchDocsPostRequestWithBody generates requests for SearchDocsEndpointApiV1SearchDocsPost with any type of body
+func NewSearchDocsEndpointApiV1SearchDocsPostRequestWithBody(server string, params *SearchDocsEndpointApiV1SearchDocsPostParams, contentType string, body io.Reader) (*http.Request, error) {
+	var err error
+
+	serverURL, err := url.Parse(server)
+	if err != nil {
+		return nil, err
+	}
+
+	operationPath := fmt.Sprintf("/api/v1/search_docs")
+	if operationPath[0] == '/' {
+		operationPath = "." + operationPath
+	}
+
+	queryURL, err := serverURL.Parse(operationPath)
+	if err != nil {
+		return nil, err
+	}
+
+	req, err := http.NewRequest("POST", queryURL.String(), body)
+	if err != nil {
+		return nil, err
+	}
+
+	req.Header.Add("Content-Type", contentType)
+
+	if params != nil {
+
+		if params.Authorization != nil {
+			var headerParam0 string
+
+			headerParam0, err = runtime.StyleParamWithLocation("simple", false, "authorization", runtime.ParamLocationHeader, *params.Authorization)
+			if err != nil {
+				return nil, err
+			}
+
+			req.Header.Set("authorization", headerParam0)
+		}
+
+	}
+
+	return req, nil
+}
+
 // NewListTargetsApiV1TargetsGetRequest generates requests for ListTargetsApiV1TargetsGet
 func NewListTargetsApiV1TargetsGetRequest(server string, params *ListTargetsApiV1TargetsGetParams) (*http.Request, error) {
 	var err error
@@ -20079,6 +20217,11 @@ type ClientWithResponsesInterface interface {
 	// CancelTriggerApiV1SchedulerTriggersTriggerIdDeleteWithResponse request
 	CancelTriggerApiV1SchedulerTriggersTriggerIdDeleteWithResponse(ctx context.Context, triggerId openapi_types.UUID, params *CancelTriggerApiV1SchedulerTriggersTriggerIdDeleteParams, reqEditors ...RequestEditorFn) (*CancelTriggerApiV1SchedulerTriggersTriggerIdDeleteResponse, error)
 
+	// SearchDocsEndpointApiV1SearchDocsPostWithBodyWithResponse request with any body
+	SearchDocsEndpointApiV1SearchDocsPostWithBodyWithResponse(ctx context.Context, params *SearchDocsEndpointApiV1SearchDocsPostParams, contentType string, body io.Reader, reqEditors ...RequestEditorFn) (*SearchDocsEndpointApiV1SearchDocsPostResponse, error)
+
+	SearchDocsEndpointApiV1SearchDocsPostWithResponse(ctx context.Context, params *SearchDocsEndpointApiV1SearchDocsPostParams, body SearchDocsEndpointApiV1SearchDocsPostJSONRequestBody, reqEditors ...RequestEditorFn) (*SearchDocsEndpointApiV1SearchDocsPostResponse, error)
+
 	// ListTargetsApiV1TargetsGetWithResponse request
 	ListTargetsApiV1TargetsGetWithResponse(ctx context.Context, params *ListTargetsApiV1TargetsGetParams, reqEditors ...RequestEditorFn) (*ListTargetsApiV1TargetsGetResponse, error)
 
@@ -22248,6 +22391,28 @@ func (r CancelTriggerApiV1SchedulerTriggersTriggerIdDeleteResponse) Status() str
 
 // StatusCode returns HTTPResponse.StatusCode
 func (r CancelTriggerApiV1SchedulerTriggersTriggerIdDeleteResponse) StatusCode() int {
+	if r.HTTPResponse != nil {
+		return r.HTTPResponse.StatusCode
+	}
+	return 0
+}
+
+type SearchDocsEndpointApiV1SearchDocsPostResponse struct {
+	Body         []byte
+	HTTPResponse *http.Response
+	JSON200      *SearchDocsResponse
+}
+
+// Status returns HTTPResponse.Status
+func (r SearchDocsEndpointApiV1SearchDocsPostResponse) Status() string {
+	if r.HTTPResponse != nil {
+		return r.HTTPResponse.Status
+	}
+	return http.StatusText(0)
+}
+
+// StatusCode returns HTTPResponse.StatusCode
+func (r SearchDocsEndpointApiV1SearchDocsPostResponse) StatusCode() int {
 	if r.HTTPResponse != nil {
 		return r.HTTPResponse.StatusCode
 	}
@@ -25042,6 +25207,23 @@ func (c *ClientWithResponses) CancelTriggerApiV1SchedulerTriggersTriggerIdDelete
 		return nil, err
 	}
 	return ParseCancelTriggerApiV1SchedulerTriggersTriggerIdDeleteResponse(rsp)
+}
+
+// SearchDocsEndpointApiV1SearchDocsPostWithBodyWithResponse request with arbitrary body returning *SearchDocsEndpointApiV1SearchDocsPostResponse
+func (c *ClientWithResponses) SearchDocsEndpointApiV1SearchDocsPostWithBodyWithResponse(ctx context.Context, params *SearchDocsEndpointApiV1SearchDocsPostParams, contentType string, body io.Reader, reqEditors ...RequestEditorFn) (*SearchDocsEndpointApiV1SearchDocsPostResponse, error) {
+	rsp, err := c.SearchDocsEndpointApiV1SearchDocsPostWithBody(ctx, params, contentType, body, reqEditors...)
+	if err != nil {
+		return nil, err
+	}
+	return ParseSearchDocsEndpointApiV1SearchDocsPostResponse(rsp)
+}
+
+func (c *ClientWithResponses) SearchDocsEndpointApiV1SearchDocsPostWithResponse(ctx context.Context, params *SearchDocsEndpointApiV1SearchDocsPostParams, body SearchDocsEndpointApiV1SearchDocsPostJSONRequestBody, reqEditors ...RequestEditorFn) (*SearchDocsEndpointApiV1SearchDocsPostResponse, error) {
+	rsp, err := c.SearchDocsEndpointApiV1SearchDocsPost(ctx, params, body, reqEditors...)
+	if err != nil {
+		return nil, err
+	}
+	return ParseSearchDocsEndpointApiV1SearchDocsPostResponse(rsp)
 }
 
 // ListTargetsApiV1TargetsGetWithResponse request returning *ListTargetsApiV1TargetsGetResponse
@@ -28600,6 +28782,32 @@ func ParseCancelTriggerApiV1SchedulerTriggersTriggerIdDeleteResponse(rsp *http.R
 			return nil, err
 		}
 		response.JSON422 = &dest
+
+	}
+
+	return response, nil
+}
+
+// ParseSearchDocsEndpointApiV1SearchDocsPostResponse parses an HTTP response from a SearchDocsEndpointApiV1SearchDocsPostWithResponse call
+func ParseSearchDocsEndpointApiV1SearchDocsPostResponse(rsp *http.Response) (*SearchDocsEndpointApiV1SearchDocsPostResponse, error) {
+	bodyBytes, err := io.ReadAll(rsp.Body)
+	defer func() { _ = rsp.Body.Close() }()
+	if err != nil {
+		return nil, err
+	}
+
+	response := &SearchDocsEndpointApiV1SearchDocsPostResponse{
+		Body:         bodyBytes,
+		HTTPResponse: rsp,
+	}
+
+	switch {
+	case strings.Contains(rsp.Header.Get("Content-Type"), "json") && rsp.StatusCode == 200:
+		var dest SearchDocsResponse
+		if err := json.Unmarshal(bodyBytes, &dest); err != nil {
+			return nil, err
+		}
+		response.JSON200 = &dest
 
 	}
 

--- a/docs/codebase/docs-search.md
+++ b/docs/codebase/docs-search.md
@@ -1,0 +1,139 @@
+# search_docs (the meho-docs add-on)
+
+## Overview
+
+`search_docs` is the federated vendor-document retrieval surface of the
+`meho-docs` add-on (Initiative #1518). Unlike `search_memory` /
+`search_knowledge` — which read MEHO's own Postgres+pgvector substrate
+(see [retrieval.md](retrieval.md)) — `search_docs` does **not** ingest
+the vendor corpus. It proxies each query through the backplane to the
+**external** corpus service the ops team runs, forwarding the operator's
+JWT so the corpus authenticates and audits the call as the operator.
+
+Routing through the backplane (rather than letting clients hit the
+corpus directly) is what buys three properties in one place:
+
+- **Central audit.** Every query lands one `audit_log` row under the
+  named op `meho.docs.search`, so `query_audit` / who-touched surface
+  it (the raw query is hashed, never stored).
+- **JWT federation handled once.** The operator JWT forwarding lives in
+  the T2 client, not in every consumer.
+- **Mandatory product/version posture enforced centrally.** A docs query
+  without a binary product+version scope is rejected — fail-closed — so
+  no caller can accidentally run an unfiltered corpus-wide query.
+
+The same `search_docs` service backs three consumers: the REST route
+(this task, T3), the MCP tool `search_docs` (T4, #1523), and the CLI
+verb `meho docs search` (T5, #1524). They share one service so the
+REQUIRE_FILTERS gate and the cited-chunk shape are defined exactly once.
+
+## Key types
+
+### `search_corpus(...)` (`meho_backplane.auth.corpus`, T2 #1520)
+
+The transport. An async `httpx` client that POSTs a search request to
+`settings.corpus_url` carrying `Authorization: Bearer <operator.raw_jwt>`,
+bounded by `settings.corpus_timeout_seconds`. Models the corpus's
+response behind a small frozen Pydantic adapter (`CorpusChunk` /
+`CorpusSearchResponse`, `extra="ignore"` so additive corpus fields are
+absorbed silently while a dropped consumed field fails loudly).
+
+Fail-closed by construction: an unconfigured (`corpus_url` unset),
+unreachable, non-2xx, or malformed-response corpus all collapse to one
+typed `CorpusUnavailable`. The exception carries the upstream HTTP
+status (when the failure was a non-2xx response) but **never** the
+response body — a corpus error page cannot leak through.
+
+### `build_docs_scope(product, version)` (`meho_backplane.docs_search.service`)
+
+The REQUIRE_FILTERS gate. When `settings.corpus_require_filters` is on
+(the default), both `product` and `version` must be non-blank; either
+missing raises `MissingDocsFilter` (HTTP 422 at the route). With the
+gate off, the scope degrades to optional — present keys still scope the
+query, absent keys widen it (the corpus owns the policy in that mode).
+Blank-after-strip values are treated as absent so `product=" "` cannot
+smuggle past the gate. Returns a frozen `DocsScope` whose `as_filters()`
+renders the `{key: scalar}` `metadata_filters` shape — a **binary
+containment scope**, never a ranking weight (the #1178 / #1177
+decision).
+
+### `search_docs(operator, query, *, scope, limit)` (`meho_backplane.docs_search.service`)
+
+The shared service. Calls `search_corpus` with the binary scope and
+projects the corpus's `CorpusChunk`s into MEHO's own `DocsChunk` surface
+(chunk text + source citation + score), decoupling the public response
+from the corpus wire contract. Propagates `CorpusUnavailable` unchanged.
+
+### `POST /api/v1/search_docs` (`meho_backplane.api.v1.search_docs`, T3 #1521)
+
+The REST face. `operator` role minimum (`read_only` → 403). Validates
+the scope first (422 before any audit binding), then binds the audit
+contextvars and calls the service.
+
+## Control flow (the REST route)
+
+1. `require_role(TenantRole.OPERATOR)` gates the request (`read_only` →
+   403, unauthenticated → 401) before the handler runs.
+2. `build_docs_scope(product, version)` enforces REQUIRE_FILTERS. A
+   `MissingDocsFilter` → HTTP 422; the corpus is never called. (A 422
+   here binds no audit context — it does not imply a corpus call
+   happened.)
+3. The handler binds the `audit_*` contextvars **before** the corpus
+   call: `audit_op_id="meho.docs.search"`, `audit_op_class="read"`,
+   `audit_query_hash` (SHA-256 of the UTF-8 query — the raw query is
+   never bound), `audit_product`, `audit_version`. `AuditMiddleware`
+   strips the `audit_` prefix and merges these into `audit_log.payload`,
+   so a handler exception still produces an attributable row.
+4. `search_docs(...)` forwards the operator JWT to the corpus and
+   returns the cited chunks. `CorpusUnavailable` → HTTP 503
+   (fail-closed; never an empty 200).
+5. On success, `audit_hit_count` is bound and the cited chunks are
+   returned as `SearchDocsResponse`.
+
+### Why `op_class="read"` is safe for the broadcast feed
+
+`read` is not in the sensitive op-class set
+(`credential_read` / `credential_mint` / `credential_write` /
+`audit_query`), so `redact_payload` publishes the **full** payload to
+the per-tenant broadcast feed. That is safe here because the bound
+payload is only the query *hash*, the binary product/version scope, and
+the hit count — the **raw query is never bound**. (Contrast
+`retrieve/eval`, which binds `op_class="audit_query"` to force
+aggregate-only broadcast precisely because its payload could carry
+operator-sensitive query intent.) `meho.docs.search` ends in `.search`,
+which `classify_op` would also map to `read` — the explicit override
+just makes the op name canonical for `query_audit` filtering.
+
+## Dependencies
+
+- `meho_backplane.auth.corpus` — the T2 federation transport.
+- `meho_backplane.auth.operator.Operator` — carries `raw_jwt` (forwarded
+  to the corpus) and `tenant_id` (the tenant boundary).
+- `meho_backplane.auth.rbac.require_role` — the OPERATOR gate.
+- `meho_backplane.audit` (`AuditMiddleware`) — lifts the `audit_*`
+  contextvars into the `audit_log` row.
+- `meho_backplane.settings` — `corpus_url` / `corpus_audience` /
+  `corpus_timeout_seconds` / `corpus_require_filters`
+  (`CORPUS_*` env vars).
+
+## Known issues / boundaries
+
+- The corpus request/response contract is a **consumer-side** dependency
+  (the corpus is owned by the ops team). The `CorpusChunk` adapter pins
+  only the fields MEHO consumes; a corpus that drops a consumed field
+  fails closed as `CorpusUnavailable` rather than returning a partial
+  result.
+- No local indexing — federation only. MEHO gains no Qdrant dependency
+  and does not absorb the corpus into its own substrate.
+- `ask_docs` (a synthesized answer over the cited chunks) is a
+  fast-follow (T7, #1526), not part of this surface.
+
+## References
+
+- Route: `backend/src/meho_backplane/api/v1/search_docs.py`.
+- Service: `backend/src/meho_backplane/docs_search/service.py`.
+- Transport: `backend/src/meho_backplane/auth/corpus.py`.
+- Audit binding precedent: `backend/src/meho_backplane/api/v1/retrieve.py`
+  (query-hash privacy), `retrieve_eval.py` (op_id / op_class override).
+- Binary-filters-not-weights decision: #1178 / #1177; PG JSONB
+  containment <https://www.postgresql.org/docs/16/datatype-json.html#JSON-CONTAINMENT>.


### PR DESCRIPTION
## Summary

- Add `POST /api/v1/search_docs`, the federated vendor-document retrieval surface of the `meho-docs` add-on (G4.5-T3, Initiative #1518). It fronts a shared `docs_search` service so the future MCP tool (T4, #1523) and CLI verb (T5, #1524) reuse one scope-validation + corpus-call + cited-chunk implementation.
- **REQUIRE_FILTERS:** `product` AND `version` are a mandatory binary scope — fail-closed `422` when either is absent or blank, gated by `corpus_require_filters` (default on). The scope is forwarded to the corpus as `metadata_filters` containment, a binary scope and never a ranking weight (#1178 / #1177), so an unfiltered corpus-wide query is structurally impossible while the gate is on.
- Federates via the T2 client (#1520): `CorpusUnavailable` → `503` (never an empty `200`). Tenant-scoped via the forwarded operator JWT; role-gated to OPERATOR.
- Binds one central audit row per query under the named op `meho.docs.search` (`op_class=read`), storing the query only as a SHA-256 hash plus the product/version scope and hit count — so `query_audit` / who-touched surface every docs query without leaking the raw query. The contextvars are bound before the corpus call, so the `503` fail-closed path is still attributable.

## Test plan

- [x] `ruff check` / `ruff format --check` — clean on the touched set.
- [x] `mypy src/meho_backplane/api/v1/search_docs.py src/meho_backplane/docs_search/` — no issues.
- [x] `pytest tests/test_search_docs_route.py` — 18 passed (REQUIRE_FILTERS 422 incl. blank-scope + gate-off, binary-filter-not-weight forwarding, RBAC 401/403/200, tenant-scope, `CorpusUnavailable` → 503 incl. real unconfigured-corpus end-to-end, central audit by `op_id` via `query_audit`, hash-not-raw-query, audit-row-on-503).
- [x] Regression: `tests/test_api_v1_retrieve.py` (30), `tests/test_corpus_client.py`, `tests/test_app_starts.py` (12) — green.
- [x] Code-quality gate (`--diff`) — 0 blockers.
- [x] OpenAPI snapshot + Go client regenerated (`make snapshot-openapi && make generate`); `go build ./...` clean.

## Out of scope

- MCP tool registration + capability gating (T4, #1523) and the `meho docs search` CLI verb (T5, #1524) — both reuse the shared `docs_search.search_docs` service this route fronts.
- `ask_docs` synthesized answer (T7, #1526); local indexing of the corpus (federation only).
- Adjacent findings (not addressed): `main.py` is 964 lines (pre-existing, > 600 warn) and `_run_lifespan_startup` is 96 lines (pre-existing); `search_docs_endpoint` is 78 lines (warn > 60, mostly docstring + audit binding + try/except) — all warnings, not blockers.

<!-- auto-implement-issue: fresh, iteration 1 -->

Closes #1521
