### PR TITLE
feat(cli): meho docs search verb, capability-gated absent when unprovisioned (#1524)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -132,6 +132,21 @@ connector-related release-notes line.
   the raw query. The scope-validation + corpus-call + cited-chunk shape
   live in a shared `docs_search` service the future MCP tool (T4) and
   CLI verb (T5) reuse (#1521).
+- `meho docs search <query> --product <p> --version <v> [--limit N]
+  [--json]` — the operator-facing CLI verb of the `meho-docs` add-on
+  (G4.5-T5). Wraps `POST /api/v1/search_docs` via the shared generated
+  authed client (bearer + 401-refresh), mirrors the route's
+  REQUIRE_FILTERS gate client-side (missing `--product`/`--version` is
+  rejected before the round-trip), and renders cited chunks as a text
+  table or raw JSON. The `meho docs` tree compiles into every binary
+  but is gated on the tenant's `meho-docs` capability (read from the
+  bearer JWT's `capabilities` claim, T1): when unprovisioned the tree
+  is **hidden from `meho --help`** and every verb refuses with a typed
+  `addon_not_provisioned` error before any network call — true absence,
+  fail-closed. The claim is read unverified (a visibility affordance —
+  the backplane and corpus federation enforce the real boundary), so a
+  forged claim changes only what the CLI shows, not what the server
+  allows (#1524).
 
 ## [0.11.0] - 2026-06-05
 

--- a/cli/README.md
+++ b/cli/README.md
@@ -157,6 +157,37 @@ Fetch failures (404 before G2.2 ships the endpoint, offline
 operators, etc.) degrade silently to "no extra commands" — the
 local-only `login` / `status` / `version` set stays usable.
 
+## Capability-gated commands
+
+Some commands wrap a **tenant-provisioned add-on** rather than a
+core operation. `meho docs` (the meho-docs vendor-document add-on,
+G4.5) is the first: it compiles into every binary, but the tree is
+only usable when the tenant has the `meho-docs` capability.
+
+The gate reads the `capabilities` claim from the stored bearer JWT
+(the same claim the MCP registry filters tool visibility on) at
+command-tree-build time:
+
+- **Provisioned** (`meho-docs` in the claim) — `meho docs` is listed
+  in `meho --help` and `meho docs search …` runs.
+- **Unprovisioned** (claim absent / no login / unparseable token) —
+  `meho docs` is hidden from `meho --help` and every verb refuses
+  with a typed `addon_not_provisioned` error (exit 5) before any
+  network call. Fail-closed: anything that prevents resolving the
+  claim is treated as "not provisioned".
+
+The claim is read **unverified** — this is a visibility affordance,
+not a security check. The backplane re-validates the JWT and the
+add-on's federation enforces the real boundary on every call, so a
+forged capability claim can change what the CLI *shows* but not what
+the server *allows*.
+
+```bash
+# Mandatory binary scope: --product and --version (REQUIRE_FILTERS).
+meho docs search "nsx config maximums" --product vmware --version 9.0
+meho docs search "nsx config maximums" --product vmware --version 9.0 --json
+```
+
 ## Generated client
 
 `internal/api/client.gen.go` is produced by

--- a/cli/internal/cmd/docs/docs.go
+++ b/cli/internal/cmd/docs/docs.go
@@ -1,0 +1,426 @@
+// SPDX-License-Identifier: Apache-2.0
+// Copyright (c) 2026 evoila Group
+
+// Package docs hosts the cobra commands under `meho docs ...` for
+// G4.5-T5 (#1524) of Initiative #1518 (the meho-docs add-on). v0.11
+// ships one operator-facing verb that mirrors the `search_docs` MCP
+// tool (T4, #1523):
+//
+//   - `meho docs search <query> --product <p> --version <v>
+//     [--limit N] [--json]` — federated vendor-document retrieval via
+//     POST /api/v1/search_docs (T3, #1521). Role: operator. The
+//     product+version filter is the mandatory binary scope under the
+//     backend's REQUIRE_FILTERS posture; the CLI fails fast on a
+//     missing filter before the round-trip.
+//
+// Gating — true-absence-when-unprovisioned (option B, the
+// compiled-in fallback). The `meho docs` tree compiles into every
+// CLI binary, but its visibility is gated on the tenant-provisioned
+// `meho-docs` capability (T1, #1519). The capability is carried in
+// the operator's JWT `capabilities` claim (the same claim the MCP
+// registry filters tool visibility on). The CLI reads that claim
+// from the stored bearer token at command-tree-build time and:
+//
+//   - shows `meho docs` in `meho --help` only when the tenant has
+//     the `meho-docs` capability, and
+//   - refuses any invocation with a typed, non-zero
+//     "add-on not provisioned" error otherwise.
+//
+// Why decode the claim client-side rather than build a discovery
+// route: the server-driven discovery channel
+// (`discovery.Fetch` → GET /api/v1/commands) is anonymous by design
+// (it never imports internal/api or internal/auth, and it fetches
+// before login has produced a token), and its `Register` only grafts
+// *stub* commands ("not yet implemented locally") — it cannot toggle
+// the visibility of a real, compiled-in implementation per tenant. A
+// tenant-filtered manifest would contradict the discovery channel's
+// anonymous contract and require a new authenticated backend route +
+// an OpenAPI snapshot regen. The client-side claim probe is purely a
+// UX affordance: the real security boundary stays server-side (the
+// route's RBAC plus the corpus federation), so a forged capability
+// claim still cannot reach the corpus. Reading an *unverified* claim
+// to decide whether to *show* a command is safe precisely because the
+// gate never grants access on its own.
+//
+// Like the sibling kb verb tree (G0.12-T9 #1267), every call drives
+// the generated `api.ClientWithResponses` surface directly:
+// `api.NewAuthedClient` wires the bearer + lazy 401-refresh editor,
+// and the verb consumes the generated `api.SearchDocsRequest`,
+// `api.SearchDocsResponse`, and `api.DocsChunk` types — no
+// consumer-side copies of the backend pydantic models.
+package docs
+
+import (
+	"context"
+	"encoding/base64"
+	"encoding/json"
+	"errors"
+	"fmt"
+	"io"
+	"net/http"
+	"strings"
+
+	"github.com/spf13/cobra"
+
+	"github.com/evoila/meho/cli/internal/api"
+	"github.com/evoila/meho/cli/internal/auth"
+	"github.com/evoila/meho/cli/internal/output"
+)
+
+// Capability is the tenant-provisioned capability key that gates the
+// `meho docs` tree. It is the same key the backend's
+// `_extract_capabilities` surfaces on `Operator.capabilities` and
+// the MCP registry filters `search_docs` visibility on (T1, #1519),
+// kept as a single source of truth so the CLI gate and the server
+// gate agree on the string.
+const Capability = "meho-docs"
+
+// NewRootCmd returns the `meho docs` parent command, gated on the
+// `meho-docs` capability. The command tree compiles into every CLI
+// binary; `provisioned` (resolved from the stored token's JWT
+// capabilities claim) decides whether the parent is visible in
+// `meho --help` and whether its verbs run or refuse.
+//
+// When the tenant lacks the capability the parent is marked Hidden
+// and every leaf RunE short-circuits to a typed
+// `addon_not_provisioned` error (exit 5, the same family as
+// insufficient_role) before any network call. This makes the
+// command genuinely non-runnable for an unprovisioned tenant rather
+// than silently usable, while keeping the gate a UX affordance —
+// the server still enforces the real boundary.
+func NewRootCmd() *cobra.Command {
+	provisioned := tenantHasDocsCapability()
+	return newRootCmdWithGate(provisioned)
+}
+
+// newRootCmdWithGate builds the `meho docs` tree with the capability
+// gate forced to a known value. Split out so tests can drive both the
+// provisioned and unprovisioned shapes without seeding a token whose
+// claim decodes to a specific capability set.
+func newRootCmdWithGate(provisioned bool) *cobra.Command {
+	cmd := &cobra.Command{
+		Use:   "docs",
+		Short: "Search the meho-docs vendor-document add-on (provisioned tenants only)",
+		Long: "Operate the meho-docs add-on — backplane-federated " +
+			"retrieval over the external vendor-document corpus. The " +
+			"add-on is a tenant-provisioned capability: when it is not " +
+			"provisioned for your tenant, `meho docs` is hidden from " +
+			"`meho --help` and every verb refuses with a typed " +
+			"`addon_not_provisioned` error. Search routes through the " +
+			"backplane so every query is audited and the mandatory " +
+			"product+version scope is enforced centrally.",
+		// Hidden mirrors the absence the Initiative asks for: an
+		// unprovisioned tenant should not see the command in --help.
+		// The verb-level refusal (below) closes the "hidden but still
+		// invokable" gap cobra's Hidden alone leaves open.
+		Hidden:       !provisioned,
+		SilenceUsage: true,
+	}
+	cmd.AddCommand(newSearchCmd(provisioned))
+	return cmd
+}
+
+// errNotProvisioned is the typed refusal a docs verb returns when the
+// tenant lacks the meho-docs capability. It surfaces as
+// `addon_not_provisioned` (exit 5, the insufficient_role family) so
+// scripts can distinguish "you can't use this add-on" from a missing
+// flag (exit 4) or a transport failure (exit 3).
+func errNotProvisioned(cmd *cobra.Command, jsonOut bool) error {
+	return output.RenderError(
+		cmd.ErrOrStderr(),
+		&output.StructuredError{
+			Code: "addon_not_provisioned",
+			Detail: "the meho-docs add-on is not provisioned for your " +
+				"tenant; ask a tenant_admin to enable the `meho-docs` " +
+				"capability",
+			Exit: output.ExitInsufficientRole,
+		},
+		jsonOut,
+	)
+}
+
+// tenantHasDocsCapability reports whether the operator's stored token
+// carries the meho-docs capability in its JWT `capabilities` claim.
+//
+// Fail-closed: any failure to resolve or decode the token (no login,
+// unreadable store, malformed JWT, absent/garbage claim) returns
+// false, so the command stays hidden + refusing rather than visible.
+// This mirrors the backend's fail-closed `_extract_capabilities`
+// posture (T1, #1519): a missing/garbage capability claim must never
+// be read as a grant.
+//
+// The claim is read **unverified** — the CLI does not hold the realm
+// signing key and does not need it. This is a visibility affordance,
+// not a security check; the backplane re-validates the JWT and the
+// corpus federation enforces the real boundary on every call.
+func tenantHasDocsCapability() bool {
+	cfg, err := auth.LoadConfig()
+	if err != nil || cfg.BackplaneURL == "" {
+		return false
+	}
+	tok, err := loadStoredToken(cfg.BackplaneURL)
+	if err != nil || tok.AccessToken == "" {
+		return false
+	}
+	caps, err := capabilitiesFromJWT(tok.AccessToken)
+	if err != nil {
+		return false
+	}
+	_, ok := caps[Capability]
+	return ok
+}
+
+// loadStoredToken is the token-load seam — split out so docs_test.go
+// can stub it deterministically (the alternative, seeding a keyring /
+// file store with a token whose JWT decodes to a specific capability
+// set, is exercised in an end-to-end test, but the seam keeps the
+// gate's claim-decode logic unit-testable in isolation).
+var loadStoredToken = func(backplaneURL string) (auth.StoredToken, error) {
+	store, err := auth.NewTokenStore()
+	if err != nil {
+		return auth.StoredToken{}, err
+	}
+	service, user := auth.KeyForBackplane(backplaneURL)
+	return store.Load(service, user)
+}
+
+// capabilitiesFromJWT decodes the `capabilities` claim out of a JWT's
+// payload segment and returns it as a set. The token is parsed
+// structurally (split on '.', base64url-decode the payload) — the
+// signature is **not** verified, by design (see
+// tenantHasDocsCapability). Returns an error on any structural
+// failure so the caller can fail closed.
+//
+// The claim is read as a JSON array of strings (the shape the
+// backend's `_extract_capabilities` accepts); a claim that is absent,
+// null, or not an array yields the empty set (no error) so a token
+// minted before the capability mapper existed simply sees no
+// capabilities rather than erroring the whole gate.
+func capabilitiesFromJWT(token string) (map[string]struct{}, error) {
+	parts := strings.Split(token, ".")
+	if len(parts) != 3 {
+		return nil, errors.New("meho: token is not a JWT (expected 3 dot-separated segments)")
+	}
+	payload, err := base64.RawURLEncoding.DecodeString(parts[1])
+	if err != nil {
+		return nil, fmt.Errorf("meho: decode JWT payload: %w", err)
+	}
+	var claims struct {
+		Capabilities []string `json:"capabilities"`
+	}
+	if err := json.Unmarshal(payload, &claims); err != nil {
+		return nil, fmt.Errorf("meho: parse JWT claims: %w", err)
+	}
+	set := make(map[string]struct{}, len(claims.Capabilities))
+	for _, c := range claims.Capabilities {
+		if c != "" {
+			set[c] = struct{}{}
+		}
+	}
+	return set, nil
+}
+
+// errMissingAccessToken mirrors the kb verb tree's sentinel: the
+// stored token row exists but its access_token field is empty. A
+// credential-state failure (auth_expired, exit 2) rather than a
+// transport failure (unreachable, exit 3).
+var errMissingAccessToken = errors.New("meho: stored token has no access_token")
+
+// responseBodyCap bounds the bytes the docs transport reads off any
+// backplane response before surfacing `*http.MaxBytesError`. 1 MiB is
+// generous for a search_docs response: the backend caps `limit` at 50
+// and each DocsChunk is a single corpus chunk (content + citation +
+// score). Without the cap an adversarial or runaway backplane could
+// OOM the CLI because the generated `Parse*Response` helpers call
+// `io.ReadAll(rsp.Body)` before constructing the typed envelope.
+const responseBodyCap int64 = 1 << 20
+
+// newAuthedClient builds an api.AuthedClient for the supplied
+// backplane URL and verifies a non-empty bearer is loaded. Mirrors
+// the kb verb tree's helper (same stored-token + non-empty-bearer
+// gate, same transport-layer response-body cap) so the docs verbs
+// share one auth path.
+func newAuthedClient(ctx context.Context, backplaneURL string) (*api.AuthedClient, error) {
+	authed, err := api.NewAuthedClient(ctx, backplaneURL, api.AuthedClientOptions{
+		ResponseBodyLimit: responseBodyCap,
+	})
+	if err != nil {
+		return nil, err
+	}
+	if authed.AccessToken() == "" {
+		return nil, errMissingAccessToken
+	}
+	return authed, nil
+}
+
+// retryOn401 invokes call once and, on a 401, runs a one-shot bearer
+// refresh and re-issues call. Identical contract to the kb verb
+// tree's helper, generalised over the typed response envelope.
+func retryOn401[R any](
+	ctx context.Context,
+	authed *api.AuthedClient,
+	call func(ctx context.Context) (*R, error),
+	statusOf func(*R) int,
+) (*R, error) {
+	resp, err := call(ctx)
+	if err != nil {
+		return nil, err
+	}
+	if resp == nil || statusOf(resp) != http.StatusUnauthorized {
+		return resp, nil
+	}
+	if rerr := authed.Refresh(ctx); rerr != nil {
+		return resp, rerr
+	}
+	return call(ctx)
+}
+
+// renderRequestError translates a transport-layer request error into
+// the right output.StructuredError category. Same mapping the kb
+// verb tree uses: missing bearer / no-refresh-token / token-not-found
+// route to auth_expired (exit 2); body-cap and JSON-shape failures
+// route to unexpected_response (exit 4, a server-side contract
+// failure, not a transport-down failure); everything else is
+// unreachable (exit 3).
+func renderRequestError(
+	cmd *cobra.Command,
+	backplaneURL string,
+	err error,
+	jsonOut bool,
+) error {
+	if errors.Is(err, errMissingAccessToken) {
+		return output.RenderError(cmd.ErrOrStderr(),
+			output.AuthExpired(fmt.Sprintf(
+				"stored credentials for %s are incomplete; run `meho login %s`",
+				backplaneURL, backplaneURL,
+			)),
+			jsonOut,
+		)
+	}
+	if api.IsTokenNotFound(err) {
+		return output.RenderError(cmd.ErrOrStderr(),
+			output.AuthExpired(fmt.Sprintf(
+				"no stored credentials for %s; run `meho login %s`",
+				backplaneURL, backplaneURL,
+			)),
+			jsonOut,
+		)
+	}
+	if api.IsNoRefreshToken(err) {
+		return output.RenderError(cmd.ErrOrStderr(),
+			output.AuthExpired(fmt.Sprintf(
+				"stored token rejected and no refresh_token present; run `meho login %s`",
+				backplaneURL,
+			)),
+			jsonOut,
+		)
+	}
+	var maxBytesErr *http.MaxBytesError
+	var syntaxErr *json.SyntaxError
+	var unmarshalErr *json.UnmarshalTypeError
+	if errors.As(err, &maxBytesErr) ||
+		errors.As(err, &syntaxErr) ||
+		errors.As(err, &unmarshalErr) ||
+		errors.Is(err, io.ErrUnexpectedEOF) {
+		return output.RenderError(cmd.ErrOrStderr(),
+			output.Unexpected(fmt.Sprintf("call %s: %v", backplaneURL, err)),
+			jsonOut,
+		)
+	}
+	return output.RenderError(cmd.ErrOrStderr(),
+		output.Unreachable(fmt.Sprintf("call %s: %v", backplaneURL, err)),
+		jsonOut,
+	)
+}
+
+// renderHTTPStatus classifies a non-2xx search_docs response carried
+// in the typed envelope. The status set search_docs can return (per
+// the T3 route contract):
+//
+//   - 401 → auth_expired (token rejected / refresh impossible).
+//   - 403 → insufficient_role (read_only operator).
+//   - 422 → unexpected wrapping the REQUIRE_FILTERS detail (missing
+//     product/version — the CLI fails fast before the call, so a 422
+//     here means a contract drift worth surfacing rather than
+//     swallowing) or a too-long query / out-of-range limit.
+//   - 503 → unexpected with the corpus-unavailable detail (the
+//     external corpus is unconfigured / unreachable / non-2xx).
+//   - Other non-2xx → unexpected with the raw body.
+func renderHTTPStatus(
+	cmd *cobra.Command,
+	backplaneURL string,
+	statusCode int,
+	body []byte,
+	jsonOut bool,
+) error {
+	bodyStr := strings.TrimSpace(string(body))
+	switch statusCode {
+	case http.StatusUnauthorized:
+		return output.RenderError(cmd.ErrOrStderr(),
+			output.AuthExpired(fmt.Sprintf(
+				"backplane rejected the stored token; run `meho login %s`",
+				backplaneURL,
+			)),
+			jsonOut,
+		)
+	case http.StatusForbidden:
+		return output.RenderError(cmd.ErrOrStderr(),
+			output.InsufficientRole(decodeDetailString(bodyStr)),
+			jsonOut,
+		)
+	case http.StatusUnprocessableEntity:
+		return output.RenderError(cmd.ErrOrStderr(),
+			output.Unexpected(fmt.Sprintf("invalid request: %s", decodeDetailString(bodyStr))),
+			jsonOut,
+		)
+	case http.StatusServiceUnavailable:
+		return output.RenderError(cmd.ErrOrStderr(),
+			output.Unexpected(fmt.Sprintf(
+				"the vendor-document corpus is unavailable: %s",
+				decodeDetailString(bodyStr),
+			)),
+			jsonOut,
+		)
+	default:
+		return output.RenderError(cmd.ErrOrStderr(),
+			output.Unexpected(fmt.Sprintf("call %s: HTTP %d: %s",
+				backplaneURL, statusCode, bodyStr)),
+			jsonOut,
+		)
+	}
+}
+
+// detailEnvelope models FastAPI's HTTPException JSON shape.
+type detailEnvelope struct {
+	Detail json.RawMessage `json:"detail"`
+}
+
+// decodeDetailString pulls the `detail` field out of a FastAPI error
+// body when it's a plain string, falling back to the trimmed raw body
+// when the JSON shape doesn't match (non-JSON body or a structured
+// `detail` such as the FastAPI validation list). Mirrors the kb verb
+// tree's helper.
+func decodeDetailString(body string) string {
+	var env detailEnvelope
+	if err := json.Unmarshal([]byte(body), &env); err == nil {
+		var s string
+		if jerr := json.Unmarshal(env.Detail, &s); jerr == nil && s != "" {
+			return s
+		}
+	}
+	return strings.TrimSpace(body)
+}
+
+// truncate cuts s to maxLen runes, appending an ellipsis when
+// truncation happened. Rune-aware so multi-byte UTF-8 survives the
+// cut. Same shape as the sibling-package helpers.
+func truncate(s string, maxLen int) string {
+	if maxLen < 1 {
+		return ""
+	}
+	runes := []rune(s)
+	if len(runes) <= maxLen {
+		return s
+	}
+	return string(runes[:maxLen-1]) + "…"
+}

--- a/cli/internal/cmd/docs/search.go
+++ b/cli/internal/cmd/docs/search.go
@@ -1,0 +1,269 @@
+// SPDX-License-Identifier: Apache-2.0
+// Copyright (c) 2026 evoila Group
+
+package docs
+
+import (
+	"context"
+	"fmt"
+	"io"
+	"net/http"
+
+	"github.com/spf13/cobra"
+
+	"github.com/evoila/meho/cli/internal/api"
+	"github.com/evoila/meho/cli/internal/backplane"
+	"github.com/evoila/meho/cli/internal/output"
+)
+
+// newSearchCmd returns the `meho docs search` command.
+//
+// CLI shape (per issue #1524):
+//
+//	meho docs search <query> --product <p> --version <v> \
+//	  [--limit N] [--json] [--backplane <url>]
+//
+// Role: operator. Calls POST /api/v1/search_docs (T3, #1521) via the
+// shared authed client (bearer + 401-refresh). `provisioned` carries
+// the meho-docs capability gate resolved at command-tree-build time;
+// when false the verb refuses with a typed `addon_not_provisioned`
+// error before any flag validation or network call.
+//
+// product/version are the mandatory binary scope under the backend's
+// REQUIRE_FILTERS posture. The CLI fails fast on a missing filter
+// (exit 4) before the round-trip, mirroring the route's 422 rather
+// than incurring it.
+//
+// Exit codes:
+//   - 0   search returned cleanly (incl. zero-hit result)
+//   - 2   auth_expired
+//   - 3   unreachable
+//   - 4   unexpected_response (missing --product/--version,
+//     out-of-range --limit, a 422/503 from the route)
+//   - 5   insufficient_role / addon_not_provisioned
+func newSearchCmd(provisioned bool) *cobra.Command {
+	var (
+		product           string
+		version           string
+		limit             int
+		jsonOut           bool
+		backplaneOverride string
+	)
+	cmd := &cobra.Command{
+		Use:   "search <query>",
+		Short: "Search the vendor-document corpus (mandatory --product + --version)",
+		Long: "search calls POST /api/v1/search_docs and renders the " +
+			"ranked cited chunks as a text table. --product and " +
+			"--version are mandatory: they are the binary scope the " +
+			"backend's REQUIRE_FILTERS posture enforces (a docs query " +
+			"without both is rejected rather than run as an unfiltered " +
+			"corpus query). The query routes through the backplane so it " +
+			"is audited centrally; the raw query is never logged (only " +
+			"its hash). --json emits the raw SearchDocsResponse with the " +
+			"full DocsChunk shape (chunk id, document id, score, source " +
+			"url).",
+		Args:          cobra.ExactArgs(1),
+		SilenceUsage:  true,
+		SilenceErrors: true,
+		RunE: func(cmd *cobra.Command, args []string) error {
+			return runSearch(cmd, searchOptions{
+				Query:             args[0],
+				Product:           product,
+				Version:           version,
+				Limit:             limit,
+				Changed:           cmd.Flags().Changed("limit"),
+				JSONOut:           jsonOut,
+				BackplaneOverride: backplaneOverride,
+				Provisioned:       provisioned,
+			})
+		},
+	}
+	cmd.Flags().StringVar(&product, "product", "",
+		"vendor product to scope the search to (required)")
+	cmd.Flags().StringVar(&version, "version", "",
+		"product version to scope the search to (required)")
+	cmd.Flags().IntVar(&limit, "limit", 0,
+		"max chunks to return (1..50, server default 10 when omitted)")
+	cmd.Flags().BoolVar(&jsonOut, "json", false,
+		"emit raw SearchDocsResponse JSON (full DocsChunk shape)")
+	cmd.Flags().StringVar(&backplaneOverride, "backplane", "",
+		"backplane URL to query (defaults to the URL recorded by the most recent `meho login`)")
+	return cmd
+}
+
+type searchOptions struct {
+	Query   string
+	Product string
+	Version string
+	Limit   int
+	// Changed mirrors `cobra.Command.Flags().Changed("limit")` for the
+	// "operator-supplied 0 is an error; default-0 means 'use the
+	// server default'" gate. Threaded as a field rather than re-read
+	// off cmd so tests that drive runSearch directly (bypassing the
+	// cobra flag-parse path) can opt the gate in / out explicitly.
+	Changed           bool
+	JSONOut           bool
+	BackplaneOverride string
+	// Provisioned carries the meho-docs capability gate. When false,
+	// runSearch refuses with the typed addon_not_provisioned error
+	// before touching flags or the network.
+	Provisioned bool
+}
+
+func runSearch(cmd *cobra.Command, opts searchOptions) error {
+	// Capability gate first: an unprovisioned tenant must not be able
+	// to reach the flag validation, let alone the corpus. This closes
+	// the "Hidden but still invokable" gap cobra's Hidden leaves —
+	// the command is hidden from --help AND refuses when invoked by
+	// path.
+	if !opts.Provisioned {
+		return errNotProvisioned(cmd, opts.JSONOut)
+	}
+	if opts.Query == "" {
+		return output.RenderError(
+			cmd.ErrOrStderr(),
+			output.Unexpected("search requires a non-empty <query> argument"),
+			opts.JSONOut,
+		)
+	}
+	// REQUIRE_FILTERS, client-side: both product and version are
+	// mandatory. Fail fast with the same constraint the route would
+	// 422 on, so operators see it locally without a round-trip.
+	if opts.Product == "" || opts.Version == "" {
+		return output.RenderError(
+			cmd.ErrOrStderr(),
+			output.Unexpected("search requires both --product and --version (the mandatory binary scope)"),
+			opts.JSONOut,
+		)
+	}
+	// Fail fast on out-of-range --limit. The backend clamps with
+	// Field(ge=1, le=50); the CLI mirrors the bound. Zero is cobra's
+	// default for an unset IntVar — preserve that as the "no flag"
+	// sentinel (buildSearchBody omits the field on zero), but reject
+	// an explicit --limit=0 (outside the documented 1..50 range).
+	if opts.Limit < 0 || opts.Limit > 50 || (opts.Changed && opts.Limit == 0) {
+		return output.RenderError(
+			cmd.ErrOrStderr(),
+			output.Unexpected(fmt.Sprintf("--limit must be between 1 and 50 when provided; got %d", opts.Limit)),
+			opts.JSONOut,
+		)
+	}
+	backplaneURL, err := backplane.Resolve(opts.BackplaneOverride)
+	if err != nil {
+		return output.RenderError(cmd.ErrOrStderr(), backplane.ClassifyError(err), opts.JSONOut)
+	}
+	resp, err := searchDocs(cmd.Context(), backplaneURL, opts)
+	if err != nil {
+		return renderRequestError(cmd, backplaneURL, err, opts.JSONOut)
+	}
+	if resp.StatusCode() != http.StatusOK {
+		return renderHTTPStatus(cmd, backplaneURL, resp.StatusCode(), resp.Body, opts.JSONOut)
+	}
+	// Guard against 200 + missing-content-type leaving JSON200 nil. A
+	// malformed 200 must not be conflated with a genuinely-empty
+	// result set (which printSearchTable renders as "no docs hits").
+	if resp.JSON200 == nil {
+		return output.RenderError(
+			cmd.ErrOrStderr(),
+			output.Unexpected(fmt.Sprintf(
+				"call %s: HTTP 200 without a search_docs response payload",
+				backplaneURL,
+			)),
+			opts.JSONOut,
+		)
+	}
+	if opts.JSONOut {
+		return output.PrintJSON(cmd.OutOrStdout(), resp.JSON200)
+	}
+	printSearchTable(cmd.OutOrStdout(), resp.JSON200)
+	return nil
+}
+
+// buildSearchBody assembles the typed POST body for /api/v1/search_docs.
+// product/version flow as the binary scope (typed as *string on the
+// wire; non-empty by the time this is reached). Limit only lands on
+// the wire when the operator passed a positive --limit — the generated
+// field tag is `omitempty`, so a nil pointer keeps the JSON key absent
+// and the backend's Field(ge=1, le=50, default=10) applies.
+func buildSearchBody(opts searchOptions) api.SearchDocsRequest {
+	product := opts.Product
+	version := opts.Version
+	body := api.SearchDocsRequest{
+		Query:   opts.Query,
+		Product: &product,
+		Version: &version,
+	}
+	if opts.Limit > 0 {
+		limit := opts.Limit
+		body.Limit = &limit
+	}
+	return body
+}
+
+func searchDocs(
+	ctx context.Context,
+	backplaneURL string,
+	opts searchOptions,
+) (*api.SearchDocsEndpointApiV1SearchDocsPostResponse, error) {
+	authed, err := newAuthedClient(ctx, backplaneURL)
+	if err != nil {
+		return nil, err
+	}
+	reqBody := buildSearchBody(opts)
+	return retryOn401(ctx, authed,
+		func(ctx context.Context) (*api.SearchDocsEndpointApiV1SearchDocsPostResponse, error) {
+			return authed.SearchDocsEndpointApiV1SearchDocsPostWithResponse(
+				ctx,
+				&api.SearchDocsEndpointApiV1SearchDocsPostParams{},
+				reqBody,
+			)
+		},
+		func(r *api.SearchDocsEndpointApiV1SearchDocsPostResponse) int { return r.StatusCode() },
+	)
+}
+
+// printSearchTable renders the ranked cited chunks as a compact table.
+// Columns: RANK (1-based), SCORE (corpus score; "-" when the corpus
+// omitted it), DOCUMENT (the document id citation), SNIPPET (200-char
+// excerpt of the chunk content). The chunk id and source url are
+// available in --json output for citation drill-down; rendering them
+// in the table would overflow a default terminal width.
+func printSearchTable(w io.Writer, r *api.SearchDocsResponse) {
+	if r == nil || len(r.Chunks) == 0 {
+		fmt.Fprintln(w, "no docs hits for this query")
+		return
+	}
+	fmt.Fprintf(w, "%-5s %-8s %-40s %s\n", "RANK", "SCORE", "DOCUMENT", "SNIPPET")
+	for i, chunk := range r.Chunks {
+		fmt.Fprintf(w, "%-5d %-8s %-40s %s\n",
+			i+1,
+			formatScore(chunk.Score),
+			truncate(chunk.DocumentId, 40),
+			truncate(snippetOf(chunk.Content), 80),
+		)
+	}
+}
+
+// formatScore renders the corpus score, which is optional on the wire
+// (DocsChunk.Score is a *float32). A nil score renders as "-" so the
+// column stays aligned and an absent score isn't misread as 0.0000.
+func formatScore(score *float32) string {
+	if score == nil {
+		return "-"
+	}
+	return fmt.Sprintf("%.4f", *score)
+}
+
+// snippetOf returns the first ~200 chars of content so the table
+// render fits a default terminal width. Kept separate from truncate
+// (which trims to a final length with an ellipsis) so the snippet
+// width is independent of the truncate(maxLen) contract used for the
+// other columns.
+func snippetOf(content string) string {
+	const snippetChars = 200
+	runes := []rune(content)
+	if len(runes) <= snippetChars {
+		return content
+	}
+	return string(runes[:snippetChars]) + "…"
+}

--- a/cli/internal/cmd/docs/search_test.go
+++ b/cli/internal/cmd/docs/search_test.go
@@ -1,0 +1,550 @@
+// SPDX-License-Identifier: Apache-2.0
+// Copyright (c) 2026 evoila Group
+
+package docs
+
+import (
+	"bytes"
+	"context"
+	"encoding/base64"
+	"encoding/json"
+	"io"
+	"net/http"
+	"net/http/httptest"
+	"path/filepath"
+	"strings"
+	"testing"
+	"time"
+
+	"github.com/spf13/cobra"
+
+	"github.com/evoila/meho/cli/internal/api"
+	"github.com/evoila/meho/cli/internal/auth"
+	"github.com/evoila/meho/cli/internal/output"
+)
+
+// ptrFloat32 / ptrStr are small fixture helpers for the optional
+// *float32 / *string fields on api.DocsChunk.
+func ptrFloat32(v float32) *float32 { return &v }
+func ptrStr(v string) *string       { return &v }
+
+// makeJWT builds an unsigned-looking JWT (header.payload.signature)
+// whose payload carries the given capabilities claim. The signature
+// segment is a throwaway — the CLI decodes the claim unverified, so
+// the fixture never needs a real signature.
+func makeJWT(t *testing.T, capabilities []string) string {
+	t.Helper()
+	header := base64.RawURLEncoding.EncodeToString([]byte(`{"alg":"none","typ":"JWT"}`))
+	payloadJSON, err := json.Marshal(map[string]any{
+		"sub":          "operator-1",
+		"capabilities": capabilities,
+	})
+	if err != nil {
+		t.Fatalf("marshal payload: %v", err)
+	}
+	payload := base64.RawURLEncoding.EncodeToString(payloadJSON)
+	return header + "." + payload + ".sig"
+}
+
+// newRunCmd returns a bare cobra.Command wired with capture buffers
+// and a bounded context — the harness for driving runSearch directly.
+func newRunCmd(t *testing.T) (*cobra.Command, *bytes.Buffer, *bytes.Buffer) {
+	t.Helper()
+	cmd := &cobra.Command{}
+	var stdout, stderr bytes.Buffer
+	cmd.SetOut(&stdout)
+	cmd.SetErr(&stderr)
+	ctx, cancel := context.WithTimeout(context.Background(), 5*time.Second)
+	t.Cleanup(cancel)
+	cmd.SetContext(ctx)
+	return cmd, &stdout, &stderr
+}
+
+// seedXDGAndToken writes a config + token for backplaneURL into a
+// temp XDG home with the given access token, and returns the dir.
+func seedXDGAndToken(t *testing.T, backplaneURL, accessToken string) string {
+	t.Helper()
+	dir := t.TempDir()
+	t.Setenv("XDG_CONFIG_HOME", dir)
+	t.Setenv("MEHO_KEYRING_DISABLE", "1")
+	store, err := auth.NewFileStore()
+	if err != nil {
+		t.Fatalf("NewFileStore: %v", err)
+	}
+	service, user := auth.KeyForBackplane(backplaneURL)
+	if err := store.Save(service, user, auth.StoredToken{
+		BackplaneURL: backplaneURL,
+		AccessToken:  accessToken,
+		TokenType:    "Bearer",
+		Expiry:       time.Now().Add(1 * time.Hour),
+	}); err != nil {
+		t.Fatalf("store.Save: %v", err)
+	}
+	if err := auth.SaveConfigAt(
+		filepath.Join(dir, "meho", "config.json"),
+		auth.Config{BackplaneURL: backplaneURL},
+	); err != nil {
+		t.Fatalf("SaveConfigAt: %v", err)
+	}
+	return dir
+}
+
+func readJSONBodyOf(t *testing.T, raw []byte, into any) {
+	t.Helper()
+	if err := json.Unmarshal(raw, into); err != nil {
+		t.Fatalf("decode body: %v\n%s", err, raw)
+	}
+}
+
+// exitCodeOf extracts the propagated exit code from an error that
+// satisfies output.ExitCoder (the shape RenderError returns).
+func exitCodeOf(t *testing.T, err error) int {
+	t.Helper()
+	if err == nil {
+		t.Fatalf("expected an error carrying an exit code; got nil")
+	}
+	ec, ok := err.(output.ExitCoder)
+	if !ok {
+		t.Fatalf("error %v does not satisfy ExitCoder", err)
+	}
+	return ec.ExitCode()
+}
+
+// --- capability decode -----------------------------------------------
+
+func TestCapabilitiesFromJWTExtractsClaim(t *testing.T) {
+	tok := makeJWT(t, []string{"meho-docs", "other-cap"})
+	caps, err := capabilitiesFromJWT(tok)
+	if err != nil {
+		t.Fatalf("capabilitiesFromJWT: %v", err)
+	}
+	if _, ok := caps["meho-docs"]; !ok {
+		t.Errorf("expected meho-docs in caps; got %v", caps)
+	}
+	if _, ok := caps["other-cap"]; !ok {
+		t.Errorf("expected other-cap in caps; got %v", caps)
+	}
+}
+
+func TestCapabilitiesFromJWTAbsentClaimIsEmptySet(t *testing.T) {
+	// A token with no capabilities claim decodes to the empty set
+	// (no error) — fail-closed without erroring the whole gate.
+	header := base64.RawURLEncoding.EncodeToString([]byte(`{"alg":"none"}`))
+	payload := base64.RawURLEncoding.EncodeToString([]byte(`{"sub":"x"}`))
+	caps, err := capabilitiesFromJWT(header + "." + payload + ".sig")
+	if err != nil {
+		t.Fatalf("absent claim should not error; got %v", err)
+	}
+	if len(caps) != 0 {
+		t.Errorf("expected empty set; got %v", caps)
+	}
+}
+
+func TestCapabilitiesFromJWTRejectsNonJWT(t *testing.T) {
+	if _, err := capabilitiesFromJWT("not-a-jwt"); err == nil {
+		t.Errorf("expected error for non-JWT token")
+	}
+	if _, err := capabilitiesFromJWT("a.!!!.c"); err == nil {
+		t.Errorf("expected error for undecodable payload segment")
+	}
+}
+
+func TestTenantHasDocsCapabilityProvisioned(t *testing.T) {
+	defer stubLoadStoredToken(t, makeJWT(t, []string{"meho-docs"}), nil)()
+	defer stubConfig(t, "https://bp.example")()
+	if !tenantHasDocsCapability() {
+		t.Errorf("expected provisioned tenant to report the capability")
+	}
+}
+
+func TestTenantHasDocsCapabilityUnprovisioned(t *testing.T) {
+	defer stubLoadStoredToken(t, makeJWT(t, []string{"some-other-cap"}), nil)()
+	defer stubConfig(t, "https://bp.example")()
+	if tenantHasDocsCapability() {
+		t.Errorf("expected unprovisioned tenant to lack the capability")
+	}
+}
+
+// stubLoadStoredToken swaps loadStoredToken for a deterministic value
+// and returns a cleanup restoring the production seam.
+func stubLoadStoredToken(t *testing.T, accessToken string, err error) func() {
+	t.Helper()
+	prev := loadStoredToken
+	loadStoredToken = func(string) (auth.StoredToken, error) {
+		return auth.StoredToken{AccessToken: accessToken}, err
+	}
+	return func() { loadStoredToken = prev }
+}
+
+// stubConfig writes a config.json with the given backplane URL into a
+// temp XDG home so auth.LoadConfig resolves a non-empty URL.
+func stubConfig(t *testing.T, backplaneURL string) func() {
+	t.Helper()
+	dir := t.TempDir()
+	t.Setenv("XDG_CONFIG_HOME", dir)
+	if err := auth.SaveConfigAt(
+		filepath.Join(dir, "meho", "config.json"),
+		auth.Config{BackplaneURL: backplaneURL},
+	); err != nil {
+		t.Fatalf("SaveConfigAt: %v", err)
+	}
+	return func() {}
+}
+
+// --- gating shape ----------------------------------------------------
+
+func TestNewRootCmdHiddenWhenUnprovisioned(t *testing.T) {
+	cmd := newRootCmdWithGate(false)
+	if !cmd.Hidden {
+		t.Errorf("expected docs parent Hidden when unprovisioned")
+	}
+}
+
+func TestNewRootCmdVisibleWhenProvisioned(t *testing.T) {
+	cmd := newRootCmdWithGate(true)
+	if cmd.Hidden {
+		t.Errorf("expected docs parent visible when provisioned")
+	}
+}
+
+func TestRunSearchRefusesWhenUnprovisioned(t *testing.T) {
+	cmd, _, stderr := newRunCmd(t)
+	err := runSearch(cmd, searchOptions{
+		Query:       "x",
+		Product:     "vmware",
+		Version:     "9.0",
+		Provisioned: false,
+	})
+	if err == nil {
+		t.Fatalf("expected refusal for unprovisioned tenant")
+	}
+	if got := exitCodeOf(t, err); got != output.ExitInsufficientRole {
+		t.Errorf("expected exit %d; got %d", output.ExitInsufficientRole, got)
+	}
+	if !strings.Contains(stderr.String(), "addon_not_provisioned") {
+		t.Errorf("expected addon_not_provisioned code; got %q", stderr.String())
+	}
+}
+
+func TestRunSearchRefusalIsBeforeNetwork(t *testing.T) {
+	// An unprovisioned refusal must short-circuit before any HTTP
+	// call. Point at an unroutable URL: if the refusal fired first,
+	// no connection is attempted and the error is the typed refusal,
+	// not an unreachable.
+	cmd, _, stderr := newRunCmd(t)
+	err := runSearch(cmd, searchOptions{
+		Query:             "x",
+		Product:           "vmware",
+		Version:           "9.0",
+		Provisioned:       false,
+		BackplaneOverride: "http://127.0.0.1:0",
+	})
+	if err == nil {
+		t.Fatalf("expected refusal")
+	}
+	if !strings.Contains(stderr.String(), "addon_not_provisioned") {
+		t.Errorf("expected refusal before network; got %q", stderr.String())
+	}
+}
+
+// --- flag validation -------------------------------------------------
+
+func TestRunSearchRejectsEmptyQuery(t *testing.T) {
+	cmd, _, stderr := newRunCmd(t)
+	err := runSearch(cmd, searchOptions{Query: "", Product: "vmware", Version: "9.0", Provisioned: true})
+	if err == nil {
+		t.Fatalf("expected error for empty query")
+	}
+	if !strings.Contains(stderr.String(), "non-empty <query>") {
+		t.Errorf("expected query hint; got %q", stderr.String())
+	}
+}
+
+func TestRunSearchRejectsMissingProduct(t *testing.T) {
+	cmd, _, stderr := newRunCmd(t)
+	err := runSearch(cmd, searchOptions{Query: "x", Version: "9.0", Provisioned: true})
+	if err == nil {
+		t.Fatalf("expected error for missing --product")
+	}
+	if got := exitCodeOf(t, err); got != output.ExitUnexpected {
+		t.Errorf("expected exit %d; got %d", output.ExitUnexpected, got)
+	}
+	if !strings.Contains(stderr.String(), "--product and --version") {
+		t.Errorf("expected filter hint; got %q", stderr.String())
+	}
+}
+
+func TestRunSearchRejectsMissingVersion(t *testing.T) {
+	cmd, _, stderr := newRunCmd(t)
+	err := runSearch(cmd, searchOptions{Query: "x", Product: "vmware", Provisioned: true})
+	if err == nil {
+		t.Fatalf("expected error for missing --version")
+	}
+	if !strings.Contains(stderr.String(), "--product and --version") {
+		t.Errorf("expected filter hint; got %q", stderr.String())
+	}
+}
+
+func TestRunSearchRejectsOutOfRangeLimit(t *testing.T) {
+	cmd, _, stderr := newRunCmd(t)
+	err := runSearch(cmd, searchOptions{Query: "x", Product: "vmware", Version: "9.0", Limit: 51, Provisioned: true})
+	if err == nil {
+		t.Fatalf("expected error for over-budget limit")
+	}
+	if !strings.Contains(stderr.String(), "between 1 and 50") {
+		t.Errorf("expected range hint; got %q", stderr.String())
+	}
+}
+
+func TestRunSearchRejectsExplicitZeroLimit(t *testing.T) {
+	cmd, _, stderr := newRunCmd(t)
+	err := runSearch(cmd, searchOptions{
+		Query: "x", Product: "vmware", Version: "9.0",
+		Limit: 0, Changed: true, Provisioned: true,
+	})
+	if err == nil {
+		t.Fatalf("expected error for explicit --limit=0")
+	}
+	if !strings.Contains(stderr.String(), "between 1 and 50") {
+		t.Errorf("expected range hint; got %q", stderr.String())
+	}
+}
+
+// --- happy paths -----------------------------------------------------
+
+func TestRunSearchHappyPath(t *testing.T) {
+	var bodyOnWire api.SearchDocsRequest
+	mux := http.NewServeMux()
+	mux.HandleFunc("/api/v1/search_docs", func(w http.ResponseWriter, r *http.Request) {
+		if r.Method != http.MethodPost {
+			t.Errorf("expected POST; got %s", r.Method)
+		}
+		raw, _ := io.ReadAll(r.Body)
+		readJSONBodyOf(t, raw, &bodyOnWire)
+		w.Header().Set("Content-Type", "application/json")
+		_ = json.NewEncoder(w).Encode(api.SearchDocsResponse{
+			Chunks: []api.DocsChunk{
+				{
+					ChunkId:    "chunk-1",
+					Content:    "NSX configuration maximums for vSphere 9.0 are …",
+					DocumentId: "nsx-config-maximums-9.0",
+					Score:      ptrFloat32(0.95),
+					SourceUrl:  ptrStr("https://docs.example/nsx"),
+				},
+			},
+		})
+	})
+	srv := httptest.NewServer(mux)
+	defer srv.Close()
+	seedXDGAndToken(t, srv.URL, "eyJ.test.token")
+
+	cmd, stdout, stderr := newRunCmd(t)
+	err := runSearch(cmd, searchOptions{
+		Query: "nsx config maximums", Product: "vmware", Version: "9.0",
+		Provisioned: true, BackplaneOverride: srv.URL,
+	})
+	if err != nil {
+		t.Fatalf("runSearch: %v; stderr=%s", err, stderr.String())
+	}
+	if bodyOnWire.Product == nil || *bodyOnWire.Product != "vmware" {
+		t.Errorf("expected product=vmware on wire; got %+v", bodyOnWire)
+	}
+	if bodyOnWire.Version == nil || *bodyOnWire.Version != "9.0" {
+		t.Errorf("expected version=9.0 on wire; got %+v", bodyOnWire)
+	}
+	if bodyOnWire.Query != "nsx config maximums" {
+		t.Errorf("expected query in body; got %+v", bodyOnWire)
+	}
+	if bodyOnWire.Limit != nil {
+		t.Errorf("expected limit nil at zero (omitempty); got %+v", *bodyOnWire.Limit)
+	}
+	for _, want := range []string{"RANK", "SCORE", "DOCUMENT", "nsx-config-maximums-9.0", "0.9500"} {
+		if !strings.Contains(stdout.String(), want) {
+			t.Errorf("stdout missing %q in %q", want, stdout.String())
+		}
+	}
+}
+
+func TestRunSearchSendsLimitWhenSet(t *testing.T) {
+	var bodyOnWire api.SearchDocsRequest
+	mux := http.NewServeMux()
+	mux.HandleFunc("/api/v1/search_docs", func(w http.ResponseWriter, r *http.Request) {
+		raw, _ := io.ReadAll(r.Body)
+		readJSONBodyOf(t, raw, &bodyOnWire)
+		w.Header().Set("Content-Type", "application/json")
+		_ = json.NewEncoder(w).Encode(api.SearchDocsResponse{Chunks: nil})
+	})
+	srv := httptest.NewServer(mux)
+	defer srv.Close()
+	seedXDGAndToken(t, srv.URL, "eyJ.test.token")
+
+	cmd, _, _ := newRunCmd(t)
+	if err := runSearch(cmd, searchOptions{
+		Query: "x", Product: "vmware", Version: "9.0",
+		Limit: 25, Provisioned: true, BackplaneOverride: srv.URL,
+	}); err != nil {
+		t.Fatalf("runSearch: %v", err)
+	}
+	if bodyOnWire.Limit == nil || *bodyOnWire.Limit != 25 {
+		t.Errorf("expected limit=25; got %+v", bodyOnWire.Limit)
+	}
+}
+
+func TestRunSearchZeroHits(t *testing.T) {
+	mux := http.NewServeMux()
+	mux.HandleFunc("/api/v1/search_docs", func(w http.ResponseWriter, _ *http.Request) {
+		w.Header().Set("Content-Type", "application/json")
+		_ = json.NewEncoder(w).Encode(api.SearchDocsResponse{Chunks: []api.DocsChunk{}})
+	})
+	srv := httptest.NewServer(mux)
+	defer srv.Close()
+	seedXDGAndToken(t, srv.URL, "eyJ.test.token")
+
+	cmd, stdout, _ := newRunCmd(t)
+	if err := runSearch(cmd, searchOptions{
+		Query: "obscure", Product: "vmware", Version: "9.0",
+		Provisioned: true, BackplaneOverride: srv.URL,
+	}); err != nil {
+		t.Fatalf("runSearch: %v", err)
+	}
+	if !strings.Contains(stdout.String(), "no docs hits") {
+		t.Errorf("expected no-hits line; got %q", stdout.String())
+	}
+}
+
+func TestRunSearchJSONHappyPath(t *testing.T) {
+	mux := http.NewServeMux()
+	mux.HandleFunc("/api/v1/search_docs", func(w http.ResponseWriter, _ *http.Request) {
+		w.Header().Set("Content-Type", "application/json")
+		_ = json.NewEncoder(w).Encode(api.SearchDocsResponse{
+			Chunks: []api.DocsChunk{
+				{
+					ChunkId:    "chunk-1",
+					Content:    "body",
+					DocumentId: "doc-1",
+					Score:      ptrFloat32(0.5),
+					SourceUrl:  ptrStr("https://docs.example/x"),
+				},
+			},
+		})
+	})
+	srv := httptest.NewServer(mux)
+	defer srv.Close()
+	seedXDGAndToken(t, srv.URL, "eyJ.test.token")
+
+	cmd, stdout, _ := newRunCmd(t)
+	if err := runSearch(cmd, searchOptions{
+		Query: "x", Product: "vmware", Version: "9.0",
+		JSONOut: true, Provisioned: true, BackplaneOverride: srv.URL,
+	}); err != nil {
+		t.Fatalf("runSearch: %v", err)
+	}
+	var got api.SearchDocsResponse
+	if err := json.Unmarshal(stdout.Bytes(), &got); err != nil {
+		t.Fatalf("decode json output: %v\n%s", err, stdout.String())
+	}
+	if len(got.Chunks) != 1 || got.Chunks[0].ChunkId != "chunk-1" {
+		t.Errorf("expected the raw chunk in json output; got %+v", got)
+	}
+}
+
+// formatScore renders an absent corpus score as "-" so the table
+// doesn't misrepresent it as 0.0000.
+func TestRunSearchRendersAbsentScoreAsDash(t *testing.T) {
+	mux := http.NewServeMux()
+	mux.HandleFunc("/api/v1/search_docs", func(w http.ResponseWriter, _ *http.Request) {
+		w.Header().Set("Content-Type", "application/json")
+		_ = json.NewEncoder(w).Encode(api.SearchDocsResponse{
+			Chunks: []api.DocsChunk{
+				{ChunkId: "c", Content: "b", DocumentId: "doc-1", Score: nil},
+			},
+		})
+	})
+	srv := httptest.NewServer(mux)
+	defer srv.Close()
+	seedXDGAndToken(t, srv.URL, "eyJ.test.token")
+
+	cmd, stdout, _ := newRunCmd(t)
+	if err := runSearch(cmd, searchOptions{
+		Query: "x", Product: "vmware", Version: "9.0",
+		Provisioned: true, BackplaneOverride: srv.URL,
+	}); err != nil {
+		t.Fatalf("runSearch: %v", err)
+	}
+	line := firstChunkRow(t, stdout.String())
+	if !strings.Contains(line, " - ") {
+		t.Errorf("expected absent score rendered as '-'; got row %q", line)
+	}
+}
+
+func firstChunkRow(t *testing.T, table string) string {
+	t.Helper()
+	for _, l := range strings.Split(table, "\n") {
+		if strings.HasPrefix(l, "1 ") || strings.HasPrefix(l, "1    ") {
+			return l
+		}
+	}
+	t.Fatalf("no rank-1 row in table %q", table)
+	return ""
+}
+
+// --- HTTP status mapping ---------------------------------------------
+
+func TestRunSearchMaps403(t *testing.T) {
+	assertStatusMapping(t, http.StatusForbidden,
+		`{"detail":"operator role required"}`,
+		output.ExitInsufficientRole, "operator role required")
+}
+
+func TestRunSearchMaps422(t *testing.T) {
+	assertStatusMapping(t, http.StatusUnprocessableEntity,
+		`{"detail":"missing required filters: product, version"}`,
+		output.ExitUnexpected, "missing required filters")
+}
+
+func TestRunSearchMaps503(t *testing.T) {
+	assertStatusMapping(t, http.StatusServiceUnavailable,
+		`{"detail":"corpus unreachable"}`,
+		output.ExitUnexpected, "corpus is unavailable")
+}
+
+func assertStatusMapping(t *testing.T, status int, body string, wantExit int, wantSubstr string) {
+	t.Helper()
+	mux := http.NewServeMux()
+	mux.HandleFunc("/api/v1/search_docs", func(w http.ResponseWriter, _ *http.Request) {
+		w.Header().Set("Content-Type", "application/json")
+		w.WriteHeader(status)
+		_, _ = w.Write([]byte(body))
+	})
+	srv := httptest.NewServer(mux)
+	defer srv.Close()
+	seedXDGAndToken(t, srv.URL, "eyJ.test.token")
+
+	cmd, _, stderr := newRunCmd(t)
+	err := runSearch(cmd, searchOptions{
+		Query: "x", Product: "vmware", Version: "9.0",
+		Provisioned: true, BackplaneOverride: srv.URL,
+	})
+	if err == nil {
+		t.Fatalf("expected error for HTTP %d", status)
+	}
+	if got := exitCodeOf(t, err); got != wantExit {
+		t.Errorf("HTTP %d: expected exit %d; got %d (stderr=%q)", status, wantExit, got, stderr.String())
+	}
+	if !strings.Contains(stderr.String(), wantSubstr) {
+		t.Errorf("HTTP %d: expected stderr to contain %q; got %q", status, wantSubstr, stderr.String())
+	}
+}
+
+// --- command wiring --------------------------------------------------
+
+func TestSearchCmdRequiresExactlyOneArg(t *testing.T) {
+	cmd := newSearchCmd(true)
+	var stdout, stderr bytes.Buffer
+	cmd.SetOut(&stdout)
+	cmd.SetErr(&stderr)
+	cmd.SetArgs([]string{}) // no query
+	if err := cmd.Execute(); err == nil {
+		t.Errorf("expected error with no <query> arg")
+	}
+}

--- a/cli/internal/cmd/root.go
+++ b/cli/internal/cmd/root.go
@@ -24,6 +24,7 @@ import (
 	"github.com/evoila/meho/cli/internal/cmd/broadcast"
 	"github.com/evoila/meho/cli/internal/cmd/connector"
 	"github.com/evoila/meho/cli/internal/cmd/conventions"
+	"github.com/evoila/meho/cli/internal/cmd/docs"
 	"github.com/evoila/meho/cli/internal/cmd/gcloud"
 	"github.com/evoila/meho/cli/internal/cmd/harbor"
 	hetznerrobot "github.com/evoila/meho/cli/internal/cmd/hetzner-robot"
@@ -159,6 +160,20 @@ func newRootCmd() *cobra.Command {
 	// registerDynamicSubcommands so the backplane manifest cannot
 	// shadow the built-in `kb` parent.
 	root.AddCommand(kb.NewRootCmd())
+
+	// G4.5-T5 (#1524) -- the `meho docs` tree for Initiative #1518
+	// (the meho-docs add-on). One verb: `docs search` wraps the
+	// /api/v1/search_docs route (T3, #1521) for federated
+	// vendor-document retrieval. The tree compiles into every binary
+	// but is gated on the tenant-provisioned `meho-docs` capability
+	// (T1, #1519): `docs.NewRootCmd` reads the capability from the
+	// stored token's JWT claim and, when absent, marks the parent
+	// Hidden and makes every verb refuse with a typed
+	// `addon_not_provisioned` error — true absence for an
+	// unprovisioned tenant. Registered before
+	// registerDynamicSubcommands so the backplane manifest cannot
+	// shadow the built-in `docs` parent.
+	root.AddCommand(docs.NewRootCmd())
 
 	// G12.5-T1 (#1318) -- runbook template authoring verbs
 	// (list-templates / show-template / draft-template / edit-template /

--- a/docs/codebase/docs-search.md
+++ b/docs/codebase/docs-search.md
@@ -70,6 +70,52 @@ The REST face. `operator` role minimum (`read_only` → 403). Validates
 the scope first (422 before any audit binding), then binds the audit
 contextvars and calls the service.
 
+### `meho docs search` (`cli/internal/cmd/docs`, T5 #1524)
+
+The operator-facing CLI verb. `meho docs search <query> --product <p>
+--version <v> [--limit N] [--json]` POSTs to `/api/v1/search_docs` via
+the shared generated authed client (bearer + lazy 401-refresh), mirrors
+the route's REQUIRE_FILTERS gate client-side (a missing `--product` or
+`--version` is rejected before the round-trip), and renders the cited
+chunks as a text table or raw JSON. It consumes the generated
+`api.SearchDocsRequest` / `api.SearchDocsResponse` / `api.DocsChunk`
+types directly — no hand-typed copies of the backend schemas.
+
+**Gating — true absence when unprovisioned.** The `meho docs` tree
+compiles into every CLI binary, but it is gated on the tenant's
+`meho-docs` capability (the same capability T1 gates the MCP tool on).
+The CLI reads the `capabilities` claim from the stored bearer JWT at
+command-tree-build time and:
+
+- shows `meho docs` in `meho --help` and runs its verbs only when the
+  claim contains `meho-docs`;
+- otherwise marks the parent `Hidden` and makes every verb refuse with
+  a typed `addon_not_provisioned` error (exit 5) before any network
+  call.
+
+The claim is decoded **unverified** — the CLI holds no realm signing
+key and needs none. This is a visibility affordance, not a security
+boundary: the backplane re-validates the JWT on every request and the
+corpus federation enforces the real boundary, so a forged claim can
+change only what the CLI *shows*, never what the server *allows*.
+Reading an unverified claim is safe precisely because the gate never
+grants access on its own; it is fail-closed (no login / unreadable
+store / malformed token → not provisioned), mirroring the backend's
+fail-closed `_extract_capabilities`.
+
+**Why not the server-driven discovery channel.** True per-tenant
+absence via `discovery.Fetch` → `GET /api/v1/commands` was the
+preferred shape on paper, but the discovery channel is anonymous by
+design (it never imports `internal/api` / `internal/auth` and fetches
+before login produces a token) and its `Register` only grafts *stub*
+commands ("not yet implemented locally") — it cannot toggle the
+visibility of a real compiled-in implementation per tenant. A
+tenant-filtered manifest would contradict that anonymous contract and
+require a new authenticated backend route plus an OpenAPI snapshot
+regen. The compiled-in + claim-probe shape achieves the same operator-
+visible outcome (absent from `--help`, non-runnable) without a backend
+change.
+
 ## Control flow (the REST route)
 
 1. `require_role(TenantRole.OPERATOR)` gates the request (`read_only` →


### PR DESCRIPTION
## Summary

- Adds `meho docs search <query> --product <p> --version <v> [--limit N] [--json]` (G4.5-T5, #1524) — the operator-facing CLI mirror of the `search_docs` MCP tool. It wraps the T3 `POST /api/v1/search_docs` route (#1521) via the shared generated authed client (bearer + lazy 401-refresh), consuming the generated `api.SearchDocsRequest` / `api.SearchDocsResponse` / `api.DocsChunk` types directly, and renders cited chunks as a text table or raw JSON.
- `--product` and `--version` are **mandatory** and rejected client-side **before** the round-trip, mirroring the route's REQUIRE_FILTERS 422 (the binary scope, not a ranking weight).
- The `meho docs` tree is **absent for unprovisioned tenants**: hidden from `meho --help` and refusing every invocation with a typed `addon_not_provisioned` error (exit 5) when the tenant lacks the `meho-docs` capability.
- New package `cli/internal/cmd/docs/` (parent + search verb + tests), registered in `root.go` before `registerDynamicSubcommands` so the backplane manifest can't shadow it. README + `docs/codebase/docs-search.md` + CHANGELOG updated.

## Gating decision: **Option B** (compiled-in + capability-probe + Hidden + typed refusal)

The issue offered two gating shapes. I chose **B** and document why **A** was rejected as scope-ballooning:

**Why not A (true absence via a tenant-filtered `GET /api/v1/commands` discovery manifest):**
- The discovery channel (`cli/internal/discovery`) is **anonymous by design** — it explicitly never imports `internal/api` / `internal/auth` and fetches *before* login produces a token. A *tenant-filtered* manifest needs the operator JWT, which contradicts that anonymous contract.
- `discovery.Register` only grafts **stub** commands (`"… advertised by the backplane but not yet implemented in this CLI"`). It has no mechanism to toggle the visibility of a *real, compiled-in* implementation per tenant. Option A would require inverting the discovery model.
- It would also require a **new authenticated backend route** (`backend/.../api/v1/commands.py`) plus an OpenAPI snapshot regen — exactly the work the issue note says to avoid if A balloons.

**Why B is correct and safe:**
- The `meho-docs` capability source of truth (T1, #1519) is the JWT `capabilities` claim (`Operator.capabilities` ← `_extract_capabilities`) — the same claim the MCP registry filters tool visibility on. There is **no HTTP route** exposing capabilities (T1's read surface is the `meho://tenant/{id}/info` MCP resource), and the CLI doesn't speak MCP — but it already stores the bearer JWT, so it reads the claim client-side.
- The claim is decoded **unverified** by design: this is a **visibility affordance, not a security boundary**. The backplane re-validates the JWT on every request and the corpus federation enforces the real boundary, so a forged capability claim can only change what the CLI *shows*, never what the server *allows*. (The `search_docs` route itself gates on the `operator` role, not the capability — confirming the capability gate is a UX/tools-list concern, enforced server-side at the MCP and corpus layers.)
- **Fail-closed:** no login / unreadable store / malformed token / absent claim → not provisioned (hidden + refusing), mirroring the backend's fail-closed `_extract_capabilities`.
- **No backend route touched → no snapshot/codegen regen required.**

## Test plan

- [x] `go test ./cli/...` — green (43 packages, incl. the `root` package test that builds the full tree with the new `docs` registration).
- [x] `gofmt -l` — clean; `go vet ./cli/...` — clean; `go build ./...` — clean.
- [x] **Acceptance — happy path:** `TestRunSearchHappyPath` / `TestRunSearchJSONHappyPath` assert the wire body pins `product`/`version`/`query`, `--limit` flows as the typed pointer (omitted at zero), and the table + `--json` renders carry the cited chunk.
- [x] **Acceptance — absent when unprovisioned:** `TestNewRootCmdHiddenWhenUnprovisioned`, `TestRunSearchRefusesWhenUnprovisioned` (typed `addon_not_provisioned`, exit 5), `TestRunSearchRefusalIsBeforeNetwork` (short-circuits before any HTTP call).
- [x] **Acceptance — missing filters → client-side error before the call:** `TestRunSearchRejectsMissingProduct` / `…MissingVersion` (exit 4, no round-trip).
- [x] **Auth via shared authed client:** verb drives `SearchDocsEndpointApiV1SearchDocsPostWithResponse` through `api.NewAuthedClient` with the `retryOn401` refresh wrapper.
- [x] Capability decode covered: `TestCapabilitiesFromJWTExtractsClaim` / `…AbsentClaimIsEmptySet` / `…RejectsNonJWT`; HTTP status mapping (403/422/503) covered.
- [x] Code-quality hook (`code-quality.py --diff`) — exit 0 (Go + Markdown diff; file 426 lines < 600, functions < 100).

`golangci-lint` couldn't run in the sandbox (locally installed binary is built with go1.24 < the repo's go1.25 target); CI runs the correct version. Code was hand-audited against the enabled revive rules (`exported`, `error-strings`, `package-comments`, `unused-parameter`) and mirrors the passing `cli/internal/cmd/kb` sibling patterns.

## Out of scope

- Backend `search_docs` route (T3, #1521 — merged) and the capability gate (T1, #1519 — merged).
- MCP `search_docs` tool (T4, #1523) and `ask_docs` (T7, #1526).
- A general-purpose `/api/v1/commands` manifest for all commands (rejected per the gating analysis above).

<!-- auto-implement-issue: fresh, iteration 1 -->

Closes #1524


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added `meho docs search` command for querying documentation with filtering by product and version.
  * Supports optional limit on results and JSON output format.
  * Command is capability-gated and only available to provisioned tenants.

* **Documentation**
  * Added CLI documentation for capability-gated commands and docs search functionality.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->