### PR TITLE
feat(mcp): capability-gated search_docs tool + companion docs resource (#1523)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -147,6 +147,23 @@ connector-related release-notes line.
   the backplane and corpus federation enforce the real boundary), so a
   forged claim changes only what the CLI shows, not what the server
   allows (#1524).
+- `search_docs` MCP tool + `meho://docs/{product}/{version}/{chunk_id}`
+  companion resource — the agent-facing face of the `meho-docs` add-on
+  (G4.5-T4). Both are gated by `required_capability="meho-docs"` (T1):
+  absent from `tools/list` / `resources/templates/list` for a tenant
+  without the add-on and 403-class on call, present and callable once
+  provisioned. The tool takes `query` + the **mandatory** `product` +
+  `version` binary scope (strict 2020-12 `inputSchema`,
+  `additionalProperties:false`) and federates through the shared
+  `docs_search` service (T3) to the external corpus, returning ranked
+  cited chunks; a missing/blank scope surfaces the REQUIRE_FILTERS
+  rejection as an MCP `-32602`, a down corpus as `-32603`. Its
+  description routes the agent — `search_docs` for vendor reference,
+  `search_knowledge` for how-we-do-X, `search_memory` for cross-session
+  state — and points at the companion resource, which recovers the full
+  text of a cited chunk on a later turn by re-issuing a scoped search
+  (the corpus transport is search-only). One hashed audit row per call
+  (`op_class=read`); the raw query is never logged (#1523).
 
 ## [0.11.0] - 2026-06-05
 

--- a/backend/src/meho_backplane/mcp/resources/docs.py
+++ b/backend/src/meho_backplane/mcp/resources/docs.py
@@ -1,0 +1,161 @@
+# SPDX-License-Identifier: Apache-2.0
+# Copyright (c) 2026 evoila Group
+
+"""``meho://docs/{product}/{version}/{chunk_id}`` — docs chunk resource (G4.5-T4).
+
+The fetch-by-citation companion to the :mod:`search_docs` meta-tool. An
+agent that kept only a hit's citation (``product`` / ``version`` /
+``chunk_id``) from an earlier ``search_docs`` call — but not the full
+chunk text — reads this resource on a later turn to recover the text
+without re-running and re-scanning the whole search.
+
+Gated identically to the tool
+=============================
+
+The template carries the same ``required_capability="meho-docs"`` gate as
+``search_docs`` (G4.5-T1, #1519): a tenant without the ``meho-docs``
+add-on never sees it in ``resources/templates/list`` and a
+``resources/read`` on a known URI is rejected with a 403-class error
+before the handler runs. The gate is enforced at list time
+(:func:`~meho_backplane.mcp.registry.all_resource_templates_for`) and
+again at read time
+(:func:`~meho_backplane.mcp.handlers.handle_resources_read`).
+
+Why the URI carries the scope (and how the fetch works)
+=======================================================
+
+The corpus federation client (T2, :mod:`meho_backplane.auth.corpus`)
+exposes search-by-query only — there is no fetch-chunk-by-id endpoint to
+proxy. So this resource recovers a chunk by **re-issuing a scoped corpus
+search** through the same shared
+:func:`~meho_backplane.docs_search.search_docs` service the tool uses,
+then selecting the hit whose ``chunk_id`` matches the URI. That is why the
+``product`` and ``version`` are in the URI rather than just a bare
+``chunk_id``: they are the mandatory binary scope the re-search needs, and
+encoding them lets :func:`~meho_backplane.docs_search.build_docs_scope`
+enforce the same REQUIRE_FILTERS posture the tool enforces (a blank
+segment can't physically match the ``[^/]+`` template, so the gate is
+belt-and-suspenders here). The ``chunk_id`` is used as the re-search query
+text — chunk ids are document-derived tokens, so the corpus's own ranking
+surfaces the matching chunk near the top of a bounded re-search — and the
+exact-id match is then taken from the returned chunks.
+
+Rejection arms (all ``-32602`` INVALID_PARAMS)
+==============================================
+
+* **Blank scope segment** —
+  :class:`~meho_backplane.docs_search.MissingDocsFilterError` from
+  :func:`build_docs_scope` (only reachable with the gate on and a
+  segment that survived the template but is blank-after-strip) maps to
+  :class:`McpInvalidParamsError`.
+* **Chunk not found in the scope** — the re-search returned no chunk
+  whose ``chunk_id`` matches. Collapses to "docs chunk not found"
+  without revealing whether the scope is empty or the id is simply
+  absent, so the resource is not a probe oracle for the corpus contents.
+
+A corpus that is unavailable raises the typed
+:class:`~meho_backplane.auth.corpus.CorpusUnavailable`, which is *not*
+caught here: it bubbles to the dispatcher's generic catch and surfaces as
+``-32603`` Internal Error — the read was well-formed; the upstream is
+down.
+
+Response shape
+==============
+
+``resources/read`` returns a ``contents[]`` array; the dispatcher wraps
+this handler's return value in one text block whose ``text`` is the
+JSON-serialised :class:`~meho_backplane.docs_search.DocsChunk`
+(``chunk_id`` / ``document_id`` / ``content`` / ``source_url`` /
+``score``). ``mimeType`` is ``text/markdown`` — vendor-doc chunk content
+is prose, often Markdown-shaped.
+"""
+
+from __future__ import annotations
+
+from typing import Any, Final
+
+from meho_backplane.auth.operator import Operator, TenantRole
+from meho_backplane.docs_search import (
+    MissingDocsFilterError,
+    build_docs_scope,
+    search_docs,
+)
+from meho_backplane.mcp.registry import (
+    ResourceTemplateDefinition,
+    register_mcp_resource,
+)
+from meho_backplane.mcp.server import McpInvalidParamsError
+
+#: Same capability gate as the ``search_docs`` tool — the resource is the
+#: tool's companion and must not be reachable when the tool is hidden.
+_DOCS_CAPABILITY: Final[str] = "meho-docs"
+
+#: How many chunks to request when re-searching for the cited chunk. A
+#: small bound keeps the corpus round-trip cheap; the exact ``chunk_id``
+#: match is taken from whatever the corpus returns within this window.
+_FETCH_SEARCH_LIMIT: Final[int] = 50
+
+
+async def _docs_chunk_handler(
+    operator: Operator,
+    bound: dict[str, str],
+) -> dict[str, Any]:
+    """Return the cited :class:`~meho_backplane.docs_search.DocsChunk` for the URI.
+
+    Rebuilds the binary product+version scope from the URI segments,
+    re-issues a scoped corpus search (the transport has no
+    fetch-by-id endpoint), and returns the chunk whose ``chunk_id``
+    matches the URI's ``{chunk_id}``. See the module docstring for why
+    the fetch is a re-search and for the rejection-arm contract.
+    """
+    product = bound["product"]
+    version = bound["version"]
+    chunk_id = bound["chunk_id"]
+
+    try:
+        scope = build_docs_scope(product, version)
+    except MissingDocsFilterError as exc:
+        raise McpInvalidParamsError(f"docs chunk: {exc}") from exc
+
+    # The transport is search-only, so recover the chunk by re-searching
+    # the bound scope and matching on the exact id. The chunk_id doubles
+    # as the query text — chunk ids are document-derived, so the corpus
+    # ranks the matching chunk highly within the bounded window.
+    result = await search_docs(
+        operator,
+        chunk_id,
+        scope=scope,
+        limit=_FETCH_SEARCH_LIMIT,
+    )
+    for chunk in result.chunks:
+        if chunk.chunk_id == chunk_id:
+            return chunk.model_dump(mode="json")
+
+    # Not-found collapse: never distinguish "empty scope" from "no such
+    # chunk" so the resource can't be used as a corpus-contents oracle.
+    raise McpInvalidParamsError(
+        f"docs chunk not found: product={product!r}, version={version!r}, chunk_id={chunk_id!r}",
+    )
+
+
+register_mcp_resource(
+    definition=ResourceTemplateDefinition(
+        uriTemplate="meho://docs/{product}/{version}/{chunk_id}",
+        name="Vendor-document chunk",
+        description=(
+            "Full text and citation of one vendor-document chunk, "
+            "identified by the product + version scope and the chunk id "
+            "from a `search_docs` hit. Use after `search_docs` has "
+            "returned a citation whose chunk text you no longer have in "
+            "context — this resource recovers the chunk's content plus "
+            "its `source_url` without re-running the whole search. "
+            "Returns INVALID_PARAMS for a blank scope segment or for a "
+            "(product, version, chunk_id) that doesn't resolve to a "
+            "chunk under the operator's federated corpus access."
+        ),
+        mimeType="text/markdown",
+        required_role=TenantRole.OPERATOR,
+        required_capability=_DOCS_CAPABILITY,
+    ),
+    handler=_docs_chunk_handler,
+)

--- a/backend/src/meho_backplane/mcp/tools/docs.py
+++ b/backend/src/meho_backplane/mcp/tools/docs.py
@@ -1,0 +1,225 @@
+# SPDX-License-Identifier: Apache-2.0
+# Copyright (c) 2026 evoila Group
+
+"""``search_docs`` — capability-gated vendor-document meta-tool (G4.5-T4).
+
+The MCP face of the federated vendor-document corpus the ops team runs
+(Initiative #1518, the ``meho-docs`` add-on). It is the third consumer of
+the shared :func:`~meho_backplane.docs_search.search_docs` service — the
+REST route (T3, #1521) and the CLI verb (T5, #1524) are the others — so
+the REQUIRE_FILTERS posture and the cited-chunk shape are defined exactly
+once and never re-derived per surface.
+
+Capability gate (vs. the role gate)
+===================================
+
+Unlike every kb / memory meta-tool — gated by ``required_role`` alone —
+``search_docs`` carries a second, orthogonal gate:
+``required_capability="meho-docs"`` (G4.5-T1, #1519). A tenant that has
+not provisioned the ``meho-docs`` add-on never sees the tool in
+``tools/list`` (true absence, not a greyed-out entry) and a ``tools/call``
+naming it directly is rejected with a 403-class error before the handler
+runs. The gate is enforced twice — once at list time
+(:func:`~meho_backplane.mcp.registry.all_tools_for`) and once at call
+time (:func:`~meho_backplane.mcp.handlers.handle_tools_call`) — so
+learning the name out-of-band cannot bypass it. This module only declares
+the gate; the registry + dispatcher own the enforcement.
+
+REQUIRE_FILTERS surfaces as an MCP error
+========================================
+
+``product`` and ``version`` are a **mandatory binary scope**, not a hint.
+The handler calls :func:`~meho_backplane.docs_search.build_docs_scope`,
+which raises :class:`~meho_backplane.docs_search.MissingDocsFilterError`
+when the REQUIRE_FILTERS gate is on and either is blank. The route renders
+that as HTTP 422; here it maps to :class:`McpInvalidParamsError`
+(JSON-RPC ``-32602``) — the MCP analogue of a 422, since a missing
+mandatory scope is invalid params, not a server fault. The inputSchema
+already declares both as ``required``, so a well-behaved client never
+reaches the service-side check; the map exists for the gate-off →
+gate-on settings flip and for clients that skip schema validation.
+
+Corpus-unavailable surfaces as an internal error
+================================================
+
+A federated corpus that is unconfigured, unreachable, or returns a
+non-2xx / malformed response raises the typed
+:class:`~meho_backplane.auth.corpus.CorpusUnavailable` from the transport.
+This is **not** invalid params — the operator's request was well-formed;
+the upstream is down — so it is *not* caught here. It bubbles to the
+dispatcher's generic catch and surfaces as JSON-RPC ``-32603`` Internal
+Error (the MCP analogue of the route's 503). The transport guarantees the
+corpus response body is never on the exception, so nothing leaks through
+the error message.
+
+Audit + tenant scoping
+======================
+
+The dispatcher in :mod:`meho_backplane.mcp.handlers` writes exactly one
+``audit_log`` row per ``tools/call`` with ``op_id="search_docs"`` and the
+``op_class="read"`` declared below, and hashes the raw arguments into
+``params_hash`` — so the query is recorded only as a hash, never in the
+clear, matching the route's ``meho.docs.search`` privacy posture. (The
+route's ``meho.docs.search`` op_id is an HTTP-path concern bound by the
+chassis middleware; the MCP audit op_id is the tool name verbatim so
+``classify_op`` resolves the ``.search`` → ``read`` sensitivity class
+correctly.) Tenant scoping rides the operator's forwarded JWT: the
+service hands ``operator.raw_jwt`` to the corpus, which authenticates and
+audits the call as the operator; there is no tool argument that names a
+tenant.
+"""
+
+from __future__ import annotations
+
+from typing import Any, Final
+
+from meho_backplane.auth.operator import Operator, TenantRole
+from meho_backplane.docs_search import (
+    MissingDocsFilterError,
+    build_docs_scope,
+    search_docs,
+)
+from meho_backplane.mcp.registry import ToolDefinition, register_mcp_tool
+from meho_backplane.mcp.server import McpInvalidParamsError
+
+__all__: list[str] = []
+
+
+#: The capability key a tenant must have provisioned to see / call
+#: ``search_docs``. Matches the ``meho-docs`` add-on name (Initiative
+#: #1518) and the key the JWT capability claim carries.
+_DOCS_CAPABILITY: Final[str] = "meho-docs"
+
+#: Read op-class — parity with :mod:`meho_backplane.broadcast.classify`'s
+#: taxonomy and with the route's ``audit_op_class="read"``. The raw query
+#: never reaches the broadcast feed (the dispatcher publishes only the
+#: hashed ``params_hash``), so ``read``'s full-detail broadcast is safe.
+_OP_CLASS_READ: Final[str] = "read"
+
+#: Default + maximum hit count. Mirrors the route's
+#: :class:`SearchDocsRequest` bounds (``default=10``, ``le=50``) so the
+#: three consumers of the shared service agree on the cap.
+_DEFAULT_SEARCH_LIMIT: Final[int] = 10
+_MAX_SEARCH_LIMIT: Final[int] = 50
+
+
+async def _search_docs_handler(
+    operator: Operator,
+    arguments: dict[str, Any],
+) -> dict[str, Any]:
+    """Federate a vendor-document query through the shared docs-search service.
+
+    Validates the mandatory product+version binary scope, then delegates
+    to :func:`~meho_backplane.docs_search.search_docs` — the same service
+    the REST route fronts — forwarding the operator's JWT so the corpus
+    authenticates and audits the call as the operator.
+
+    Two error arms:
+
+    * **Missing/blank product or version** —
+      :class:`~meho_backplane.docs_search.MissingDocsFilterError` from
+      :func:`build_docs_scope` (when REQUIRE_FILTERS is on) is re-raised
+      as :class:`McpInvalidParamsError` so the dispatcher emits the
+      spec-correct ``-32602`` (the MCP analogue of the route's 422). The
+      inputSchema's ``required`` list catches this first for a
+      schema-validating client; this arm covers the gate-off → gate-on
+      flip and non-validating clients.
+    * **Corpus unavailable** — the typed
+      :class:`~meho_backplane.auth.corpus.CorpusUnavailable` is *not*
+      caught here. It bubbles to the dispatcher's generic catch and
+      surfaces as ``-32603`` Internal Error (the MCP analogue of the
+      route's 503): a well-formed request against a down upstream is a
+      server-side fault, not invalid params.
+    """
+    query: str = arguments["query"]
+    product: str = arguments["product"]
+    version: str = arguments["version"]
+    limit: int = int(arguments.get("limit", _DEFAULT_SEARCH_LIMIT))
+
+    try:
+        scope = build_docs_scope(product, version)
+    except MissingDocsFilterError as exc:
+        raise McpInvalidParamsError(f"search_docs: {exc}") from exc
+
+    result = await search_docs(operator, query, scope=scope, limit=limit)
+    return {
+        "chunks": [chunk.model_dump(mode="json") for chunk in result.chunks],
+    }
+
+
+register_mcp_tool(
+    definition=ToolDefinition(
+        name="search_docs",
+        description=(
+            "Search the vendor-document corpus (product manuals, KB "
+            "articles, design / reference guides) for an authoritative "
+            "vendor fact — e.g. 'NSX config maximums for 9.0' or "
+            "'vCenter 8.0 supported snapshot depth'. "
+            "REQUIRES `product` AND `version`: they are a hard binary "
+            "scope (the query is rejected without both), NOT a ranking "
+            "hint. "
+            "Use this for VENDOR REFERENCE — what the documentation says. "
+            "Use `search_knowledge` instead for how THIS team does "
+            "something (lab conventions, known-good runbooks, "
+            "post-incident learnings), and `search_memory` for "
+            "cross-session state (what you or the operator established "
+            "earlier in this or a prior session). "
+            "Returns ranked cited chunks: each carries the chunk text, a "
+            "`source_url` citation, a `chunk_id`, and a `document_id`. "
+            "For the full text of a hit on a later turn (when you kept "
+            "only the citation), read `meho://docs/{product}/{version}/"
+            "{chunk_id}` via `resources/read`. "
+            "Limit defaults to 10; cap is 50."
+        ),
+        inputSchema={
+            "type": "object",
+            "properties": {
+                "query": {
+                    "type": "string",
+                    "minLength": 1,
+                    "maxLength": 2000,
+                    "description": (
+                        "Free-form vendor-reference query. Forwarded to the "
+                        "corpus verbatim; never logged in the clear (the "
+                        "audit row stores only its SHA-256 hash)."
+                    ),
+                },
+                "product": {
+                    "type": "string",
+                    "minLength": 1,
+                    "maxLength": 128,
+                    "description": (
+                        "Vendor product to scope to (e.g. 'nsx', 'vcenter'). "
+                        "MANDATORY binary scope, not a hint — a query "
+                        "without it is rejected with INVALID_PARAMS while "
+                        "the REQUIRE_FILTERS posture is on."
+                    ),
+                },
+                "version": {
+                    "type": "string",
+                    "minLength": 1,
+                    "maxLength": 128,
+                    "description": (
+                        "Product version to scope to (e.g. '9.0'). "
+                        "MANDATORY binary scope alongside `product` — "
+                        "both are required to bound the search to one "
+                        "product / version slice."
+                    ),
+                },
+                "limit": {
+                    "type": "integer",
+                    "minimum": 1,
+                    "maximum": _MAX_SEARCH_LIMIT,
+                    "default": _DEFAULT_SEARCH_LIMIT,
+                    "description": "Maximum number of ranked cited chunks to return.",
+                },
+            },
+            "required": ["query", "product", "version"],
+            "additionalProperties": False,
+        },
+        required_role=TenantRole.OPERATOR,
+        op_class=_OP_CLASS_READ,
+        required_capability=_DOCS_CAPABILITY,
+    ),
+    handler=_search_docs_handler,
+)

--- a/backend/tests/mcp_test_fixtures.py
+++ b/backend/tests/mcp_test_fixtures.py
@@ -141,6 +141,7 @@ def isolated_registry() -> Iterator[None]:
     the matching ``meho://memory/{scope}/{slug}`` resource
     (``mcp.resources.memory``) join for the same reason.
     """
+    from meho_backplane.mcp.resources import docs as docs_resource
     from meho_backplane.mcp.resources import kb as kb_resource
     from meho_backplane.mcp.resources import memory as memory_resource
     from meho_backplane.mcp.resources import (
@@ -155,6 +156,7 @@ def isolated_registry() -> Iterator[None]:
         audit,
         broadcast_overrides,
         connector_admin,
+        docs,
         knowledge,
         meho_status,
         operations,
@@ -186,6 +188,13 @@ def isolated_registry() -> Iterator[None]:
     # three because they share one file by design.
     importlib.reload(broadcast_tools)
     importlib.reload(knowledge)
+    # G4.5-T4 (#1523): the capability-gated ``search_docs`` MCP tool +
+    # its companion ``meho://docs/{product}/{version}/{chunk_id}``
+    # resource join the reload list for the same reason every other MCP
+    # module does -- the autouse ``clear_registries()`` above would
+    # otherwise leave them unregistered in any test file that imports
+    # this fixture after the first one runs in the process.
+    importlib.reload(docs)
     importlib.reload(topology)
     importlib.reload(topology_create_node)
     # G12.2-T4 (#1298): the runbook template MCP tools
@@ -226,6 +235,7 @@ def isolated_registry() -> Iterator[None]:
     importlib.reload(tenant_info)
     importlib.reload(tenant_feed)
     importlib.reload(kb_resource)
+    importlib.reload(docs_resource)
     importlib.reload(memory_resource)
     # G7.1-T4 (#316): the tenant-conventions per-slug resource
     # (``meho://tenant/{tenant_id}/conventions/{slug}``) joins the

--- a/backend/tests/test_mcp_resources_docs.py
+++ b/backend/tests/test_mcp_resources_docs.py
@@ -1,0 +1,284 @@
+# SPDX-License-Identifier: Apache-2.0
+# Copyright (c) 2026 evoila Group
+
+"""Tests for the ``meho://docs/{...}`` companion resource (G4.5-T4, #1523).
+
+Covers the resource-side acceptance criteria:
+
+* ``meho://docs/{product}/{version}/{chunk_id}`` is registered, gated by
+  the SAME ``required_capability="meho-docs"`` as the ``search_docs`` tool:
+  absent from ``resources/templates/list`` and 403-on-read for a tenant
+  without the capability; present + readable for one with it.
+* ``resources/read`` recovers the cited chunk's text (the corpus transport
+  has no fetch-by-id endpoint, so the handler re-issues a scoped search
+  and matches on ``chunk_id``).
+* A ``(product, version, chunk_id)`` that doesn't resolve collapses to
+  INVALID_PARAMS "not found" without leaking corpus contents.
+* The MEHO-internal RBAC + capability fields are stripped from the wire.
+
+The shared docs-search service federates to an external corpus; these
+unit tests mock
+:func:`meho_backplane.docs_search.service.search_corpus` so the read
+plumbing is exercised without a live corpus.
+"""
+
+from __future__ import annotations
+
+import json
+from collections.abc import Iterator
+from typing import Any
+from unittest.mock import patch
+
+import pytest
+from fastapi.testclient import TestClient
+
+from meho_backplane.auth.corpus import CorpusChunk, CorpusSearchResponse, CorpusUnavailable
+from meho_backplane.auth.operator import Operator, TenantRole
+from meho_backplane.main import app
+from meho_backplane.mcp.auth import verify_mcp_jwt_and_bind
+from meho_backplane.mcp.schemas import INTERNAL_ERROR, INVALID_PARAMS
+from tests.mcp_test_fixtures import (
+    OPERATOR_TENANT_ID,
+    isolated_registry,  # noqa: F401 — pytest-discovered autouse fixture
+    post_mcp,
+    required_settings_env,  # noqa: F401 — pytest-discovered autouse fixture
+)
+
+_DOCS_CAPABILITY = "meho-docs"
+_DOCS_URI = "meho://docs/nsx/9.0/nsx-9.0-maximums-0007"
+
+
+def _operator(
+    *,
+    role: TenantRole = TenantRole.OPERATOR,
+    capabilities: frozenset[str] = frozenset(),
+) -> Operator:
+    return Operator(
+        sub="op-test",
+        name="Test",
+        email=None,
+        raw_jwt="fixture-jwt-not-real",
+        tenant_id=OPERATOR_TENANT_ID,
+        tenant_role=role,
+        capabilities=capabilities,
+    )
+
+
+@pytest.fixture
+def docs_client(
+    request: pytest.FixtureRequest,
+) -> Iterator[tuple[TestClient, Operator]]:
+    """``TestClient`` with a capability-parametrised operator (default: unprovisioned)."""
+    capabilities: frozenset[str] = getattr(request, "param", frozenset())
+    op = _operator(role=TenantRole.OPERATOR, capabilities=capabilities)
+
+    async def _fake_verify() -> Operator:
+        return op
+
+    app.dependency_overrides[verify_mcp_jwt_and_bind] = _fake_verify
+    try:
+        with TestClient(app) as client:
+            yield client, op
+    finally:
+        app.dependency_overrides.pop(verify_mcp_jwt_and_bind, None)
+
+
+def _fake_corpus(*chunks: CorpusChunk) -> Any:
+    """An async stand-in for ``search_corpus`` capturing its call args."""
+    captured: dict[str, Any] = {}
+
+    async def _search(operator: Operator, query: str, **kwargs: Any) -> CorpusSearchResponse:
+        captured["operator"] = operator
+        captured["query"] = query
+        captured.update(kwargs)
+        return CorpusSearchResponse(chunks=list(chunks))
+
+    _search.captured = captured  # type: ignore[attr-defined]
+    return _search
+
+
+_SAMPLE_CHUNK = CorpusChunk(
+    chunk_id="nsx-9.0-maximums-0007",
+    document_id="nsx-9.0-config-maximums",
+    content="NSX 9.0 supports up to 10,000 logical switches per manager.",
+    source_url="https://docs.example.com/nsx/9.0/maximums",
+    score=0.91,
+)
+
+
+# ---------------------------------------------------------------------------
+# resources/templates/list — capability gate + wire shape
+# ---------------------------------------------------------------------------
+
+
+def test_docs_resource_absent_from_templates_list_when_unprovisioned(
+    docs_client: tuple[TestClient, Operator],
+) -> None:
+    """An operator without ``meho-docs`` never sees the template (true absence)."""
+    client, _op = docs_client
+    response = post_mcp(
+        client,
+        {"jsonrpc": "2.0", "id": 1, "method": "resources/templates/list"},
+    )
+    assert response.status_code == 200
+    templates = {t["uriTemplate"] for t in response.json()["result"]["resourceTemplates"]}
+    assert "meho://docs/{product}/{version}/{chunk_id}" not in templates
+
+
+@pytest.mark.parametrize("docs_client", [frozenset({_DOCS_CAPABILITY})], indirect=True)
+def test_docs_resource_present_with_stripped_wire_fields_when_provisioned(
+    docs_client: tuple[TestClient, Operator],
+) -> None:
+    """The template appears once provisioned; wire shape drops the gating fields."""
+    client, _op = docs_client
+    response = post_mcp(
+        client,
+        {"jsonrpc": "2.0", "id": 1, "method": "resources/templates/list"},
+    )
+    assert response.status_code == 200
+    templates = {t["uriTemplate"]: t for t in response.json()["result"]["resourceTemplates"]}
+    template = templates.get("meho://docs/{product}/{version}/{chunk_id}")
+    assert template is not None
+    assert template["mimeType"] == "text/markdown"
+    assert "required_role" not in template
+    assert "required_capability" not in template
+
+
+# ---------------------------------------------------------------------------
+# resources/read — capability gate (403 when unprovisioned)
+# ---------------------------------------------------------------------------
+
+
+def test_resources_read_docs_403_when_unprovisioned(
+    docs_client: tuple[TestClient, Operator],
+) -> None:
+    """Reading a known docs URI still 403s when the capability is absent.
+
+    The handler (and the corpus re-search) must never run, so knowing the
+    URI cannot bypass the gate.
+    """
+    client, _op = docs_client
+    fake = _fake_corpus(_SAMPLE_CHUNK)
+    with patch("meho_backplane.docs_search.service.search_corpus", new=fake):
+        response = post_mcp(
+            client,
+            {
+                "jsonrpc": "2.0",
+                "id": 2,
+                "method": "resources/read",
+                "params": {"uri": _DOCS_URI},
+            },
+        )
+    assert response.status_code == 200
+    body = response.json()
+    assert body["error"]["code"] == INVALID_PARAMS
+    assert "forbidden" in body["error"]["message"].lower()
+    assert "capability" in body["error"]["message"].lower()
+    assert "query" not in fake.captured  # type: ignore[attr-defined]
+
+
+# ---------------------------------------------------------------------------
+# resources/read — provisioned happy path
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.parametrize("docs_client", [frozenset({_DOCS_CAPABILITY})], indirect=True)
+def test_resources_read_docs_returns_matching_chunk_text(
+    docs_client: tuple[TestClient, Operator],
+) -> None:
+    """A provisioned read recovers the chunk whose id matches the URI.
+
+    The handler rebuilds the binary scope from the URI segments,
+    re-issues a scoped corpus search, and returns the exact-id match —
+    even when the corpus returns sibling chunks alongside it.
+    """
+    client, op = docs_client
+    other = CorpusChunk(
+        chunk_id="nsx-9.0-maximums-0008",
+        document_id="nsx-9.0-config-maximums",
+        content="An unrelated sibling chunk.",
+    )
+    fake = _fake_corpus(other, _SAMPLE_CHUNK)
+    with patch("meho_backplane.docs_search.service.search_corpus", new=fake):
+        response = post_mcp(
+            client,
+            {
+                "jsonrpc": "2.0",
+                "id": 3,
+                "method": "resources/read",
+                "params": {"uri": _DOCS_URI},
+            },
+        )
+    assert response.status_code == 200
+    body = response.json()
+    contents = body["result"]["contents"]
+    assert contents[0]["uri"] == _DOCS_URI
+    assert contents[0]["mimeType"] == "text/markdown"
+    chunk = json.loads(contents[0]["text"])
+    assert chunk["chunk_id"] == "nsx-9.0-maximums-0007"
+    assert chunk["content"].startswith("NSX 9.0 supports")
+    assert chunk["source_url"].endswith("/maximums")
+
+    # The binary scope reached the corpus and the operator identity was forwarded.
+    captured = fake.captured  # type: ignore[attr-defined]
+    assert captured["metadata_filters"] == {"product": "nsx", "version": "9.0"}
+    assert captured["operator"].tenant_id == op.tenant_id
+
+
+# ---------------------------------------------------------------------------
+# resources/read — not-found collapse + corpus-down internal error
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.parametrize("docs_client", [frozenset({_DOCS_CAPABILITY})], indirect=True)
+def test_resources_read_docs_unknown_chunk_collapses_to_not_found(
+    docs_client: tuple[TestClient, Operator],
+) -> None:
+    """A chunk id absent from the re-search collapses to INVALID_PARAMS not-found.
+
+    The message never distinguishes "empty scope" from "no such id" so
+    the resource can't be used as a corpus-contents oracle.
+    """
+    client, _op = docs_client
+    # The corpus returns only a non-matching chunk.
+    fake = _fake_corpus(
+        CorpusChunk(chunk_id="some-other-id", document_id="d", content="x"),
+    )
+    with patch("meho_backplane.docs_search.service.search_corpus", new=fake):
+        response = post_mcp(
+            client,
+            {
+                "jsonrpc": "2.0",
+                "id": 4,
+                "method": "resources/read",
+                "params": {"uri": _DOCS_URI},
+            },
+        )
+    assert response.status_code == 200
+    body = response.json()
+    assert body["error"]["code"] == INVALID_PARAMS
+    assert "not found" in body["error"]["message"].lower()
+
+
+@pytest.mark.parametrize("docs_client", [frozenset({_DOCS_CAPABILITY})], indirect=True)
+def test_resources_read_docs_corpus_unavailable_is_internal_error(
+    docs_client: tuple[TestClient, Operator],
+) -> None:
+    """A down corpus surfaces as ``-32603`` Internal Error, not invalid params."""
+    client, _op = docs_client
+
+    async def _down(_op: Operator, _query: str, **_kwargs: Any) -> CorpusSearchResponse:
+        raise CorpusUnavailable("corpus unreachable: ConnectError")
+
+    with patch("meho_backplane.docs_search.service.search_corpus", new=_down):
+        response = post_mcp(
+            client,
+            {
+                "jsonrpc": "2.0",
+                "id": 5,
+                "method": "resources/read",
+                "params": {"uri": _DOCS_URI},
+            },
+        )
+    assert response.status_code == 200
+    assert response.json()["error"]["code"] == INTERNAL_ERROR

--- a/backend/tests/test_mcp_tools_docs.py
+++ b/backend/tests/test_mcp_tools_docs.py
@@ -1,0 +1,480 @@
+# SPDX-License-Identifier: Apache-2.0
+# Copyright (c) 2026 evoila Group
+
+"""Tests for the capability-gated ``search_docs`` MCP tool (G4.5-T4, #1523).
+
+Covers every acceptance criterion in the task body:
+
+* ``search_docs`` is registered with ``required_capability="meho-docs"``;
+  it is **absent** from ``tools/list`` for a tenant without the
+  capability and **present** for one with it (T1's gate, #1519).
+* ``tools/call search_docs`` from an unprovisioned tenant → 403-class
+  error (the handler never runs); from a provisioned tenant with
+  product+version → cited chunks; missing/blank product or version →
+  the T3 422 surfaced as an MCP ``-32602`` error.
+* ``inputSchema`` is strict (``additionalProperties: false``, required
+  ``[query, product, version]``); the MEHO-internal RBAC + capability
+  fields are stripped from the wire shape.
+* The handler calls the shared docs-search service with the operator's
+  forwarded identity and the validated binary scope.
+* The description names the sibling tools (``search_knowledge`` /
+  ``search_memory``) and points to the companion resource.
+
+The shared docs-search service (T3, #1521) federates to an **external**
+corpus; these unit tests mock
+:func:`meho_backplane.docs_search.service.search_corpus` so the wire
+shape + scope plumbing are exercised without a live corpus. PG-real /
+live-corpus coverage is out of scope for the unit suite.
+"""
+
+from __future__ import annotations
+
+import json
+from collections.abc import Iterator
+from typing import Any
+from unittest.mock import patch
+
+import pytest
+from fastapi.testclient import TestClient
+
+from meho_backplane.auth.corpus import CorpusChunk, CorpusSearchResponse, CorpusUnavailable
+from meho_backplane.auth.operator import Operator, TenantRole
+from meho_backplane.main import app
+from meho_backplane.mcp.auth import verify_mcp_jwt_and_bind
+from meho_backplane.mcp.schemas import INTERNAL_ERROR, INVALID_PARAMS
+from meho_backplane.settings import get_settings
+from tests.mcp_test_fixtures import (
+    OPERATOR_TENANT_ID,
+    isolated_registry,  # noqa: F401 — pytest-discovered autouse fixture
+    post_mcp,
+    required_settings_env,  # noqa: F401 — pytest-discovered autouse fixture
+)
+
+_DOCS_CAPABILITY = "meho-docs"
+
+
+def _operator(
+    *,
+    role: TenantRole = TenantRole.OPERATOR,
+    capabilities: frozenset[str] = frozenset(),
+) -> Operator:
+    """Build a fixture operator with the requested role + capability set."""
+    return Operator(
+        sub="op-test",
+        name="Test",
+        email=None,
+        raw_jwt="fixture-jwt-not-real",
+        tenant_id=OPERATOR_TENANT_ID,
+        tenant_role=role,
+        capabilities=capabilities,
+    )
+
+
+@pytest.fixture
+def docs_client(
+    request: pytest.FixtureRequest,
+) -> Iterator[tuple[TestClient, Operator]]:
+    """``TestClient`` whose operator's capability set is parametrised.
+
+    The production ``search_docs`` tool is registered by the lifespan's
+    eager import (it lives in ``mcp/tools/docs.py``); this fixture only
+    pins the operator. Provision the ``meho-docs`` capability with
+    ``@pytest.mark.parametrize("docs_client", [frozenset({"meho-docs"})], indirect=True)``;
+    default is the empty set (unprovisioned).
+    """
+    capabilities: frozenset[str] = getattr(request, "param", frozenset())
+    op = _operator(role=TenantRole.OPERATOR, capabilities=capabilities)
+
+    async def _fake_verify() -> Operator:
+        return op
+
+    app.dependency_overrides[verify_mcp_jwt_and_bind] = _fake_verify
+    try:
+        with TestClient(app) as client:
+            yield client, op
+    finally:
+        app.dependency_overrides.pop(verify_mcp_jwt_and_bind, None)
+
+
+def _fake_corpus(
+    *chunks: CorpusChunk,
+) -> Any:
+    """An async stand-in for ``search_corpus`` capturing its call args."""
+    captured: dict[str, Any] = {}
+
+    async def _search(operator: Operator, query: str, **kwargs: Any) -> CorpusSearchResponse:
+        captured["operator"] = operator
+        captured["query"] = query
+        captured.update(kwargs)
+        return CorpusSearchResponse(chunks=list(chunks))
+
+    _search.captured = captured  # type: ignore[attr-defined]
+    return _search
+
+
+_SAMPLE_CHUNK = CorpusChunk(
+    chunk_id="nsx-9.0-maximums-0007",
+    document_id="nsx-9.0-config-maximums",
+    content="NSX 9.0 supports up to 10,000 logical switches per manager.",
+    source_url="https://docs.example.com/nsx/9.0/maximums",
+    score=0.91,
+)
+
+
+# ---------------------------------------------------------------------------
+# tools/list shape + capability gate (AC1, AC3)
+# ---------------------------------------------------------------------------
+
+
+def test_search_docs_absent_from_tools_list_for_unprovisioned_tenant(
+    docs_client: tuple[TestClient, Operator],
+) -> None:
+    """AC1: an operator without ``meho-docs`` never sees the tool (true absence)."""
+    client, _op = docs_client
+    response = post_mcp(client, {"jsonrpc": "2.0", "id": 1, "method": "tools/list"})
+    assert response.status_code == 200
+    names = {t["name"] for t in response.json()["result"]["tools"]}
+    assert "search_docs" not in names
+
+
+@pytest.mark.parametrize("docs_client", [frozenset({_DOCS_CAPABILITY})], indirect=True)
+def test_search_docs_present_with_strict_schema_for_provisioned_tenant(
+    docs_client: tuple[TestClient, Operator],
+) -> None:
+    """AC1 + AC3: the tool appears once provisioned, with a strict 2020-12 schema.
+
+    Required ``[query, product, version]``, ``additionalProperties:
+    false``, and the MEHO-internal RBAC + capability fields stripped by
+    :meth:`ToolDefinition.to_wire`.
+    """
+    client, _op = docs_client
+    response = post_mcp(client, {"jsonrpc": "2.0", "id": 1, "method": "tools/list"})
+    assert response.status_code == 200
+    tools_by_name = {t["name"]: t for t in response.json()["result"]["tools"]}
+
+    assert "search_docs" in tools_by_name
+    tool = tools_by_name["search_docs"]
+    schema = tool["inputSchema"]
+    assert schema["type"] == "object"
+    assert schema["required"] == ["query", "product", "version"]
+    assert schema["additionalProperties"] is False
+    assert set(schema["properties"]) == {"query", "product", "version", "limit"}
+    assert schema["properties"]["limit"]["default"] == 10
+    assert schema["properties"]["limit"]["maximum"] == 50
+    # Wire shape never leaks the server-side gating fields.
+    assert "required_role" not in tool
+    assert "op_class" not in tool
+    assert "required_capability" not in tool
+
+
+@pytest.mark.parametrize("docs_client", [frozenset({_DOCS_CAPABILITY})], indirect=True)
+def test_search_docs_description_names_siblings_and_companion_resource(
+    docs_client: tuple[TestClient, Operator],
+) -> None:
+    """AC: the description names what / when / when-NOT and the sibling tools.
+
+    Loose substring assertions so prose can evolve without churn; the
+    load-bearing routing hints (vendor reference vs. how-we-do-X vs.
+    cross-session state) and the companion-resource pointer must stay.
+    """
+    client, _op = docs_client
+    response = post_mcp(client, {"jsonrpc": "2.0", "id": 1, "method": "tools/list"})
+    tools_by_name = {t["name"]: t for t in response.json()["result"]["tools"]}
+    desc = tools_by_name["search_docs"]["description"]
+
+    # What: vendor-document corpus search.
+    assert "vendor-document corpus" in desc or "vendor document" in desc.lower()
+    # When-NOT: routes to the sibling tools.
+    assert "search_knowledge" in desc
+    assert "search_memory" in desc
+    # Mandatory binary scope is called out, not a hint.
+    assert "product" in desc and "version" in desc
+    # Companion resource pointer for the full text on a later turn.
+    assert "meho://docs/" in desc
+    assert "resources/read" in desc
+
+
+def test_search_docs_hidden_from_provisioned_read_only_operator() -> None:
+    """The capability does not relax the role gate: read_only never sees it."""
+    op = _operator(role=TenantRole.READ_ONLY, capabilities=frozenset({_DOCS_CAPABILITY}))
+
+    async def _fake_verify() -> Operator:
+        return op
+
+    app.dependency_overrides[verify_mcp_jwt_and_bind] = _fake_verify
+    try:
+        with TestClient(app) as client:
+            response = post_mcp(client, {"jsonrpc": "2.0", "id": 1, "method": "tools/list"})
+    finally:
+        app.dependency_overrides.pop(verify_mcp_jwt_and_bind, None)
+    names = {t["name"] for t in response.json()["result"]["tools"]}
+    assert "search_docs" not in names
+
+
+# ---------------------------------------------------------------------------
+# tools/call — capability gate (AC2)
+# ---------------------------------------------------------------------------
+
+
+def test_tools_call_search_docs_403_when_unprovisioned(
+    docs_client: tuple[TestClient, Operator],
+) -> None:
+    """AC2: naming the tool directly still 403s when the capability is absent.
+
+    The capability re-check in the dispatcher fires before the handler,
+    so an unprovisioned tenant that learned the name cannot reach the
+    corpus. Surfaces as INVALID_PARAMS with a ``forbidden`` / ``capability``
+    message (the JSON-RPC projection of a 403).
+    """
+    client, _op = docs_client
+    with patch(
+        "meho_backplane.docs_search.service.search_corpus",
+        new=_fake_corpus(_SAMPLE_CHUNK),
+    ) as spy:
+        response = post_mcp(
+            client,
+            {
+                "jsonrpc": "2.0",
+                "id": 2,
+                "method": "tools/call",
+                "params": {
+                    "name": "search_docs",
+                    "arguments": {"query": "nsx maximums", "product": "nsx", "version": "9.0"},
+                },
+            },
+        )
+    assert response.status_code == 200
+    body = response.json()
+    assert body["error"]["code"] == INVALID_PARAMS
+    assert "forbidden" in body["error"]["message"].lower()
+    assert "capability" in body["error"]["message"].lower()
+    # The handler never reached the corpus.
+    assert "query" not in spy.captured  # type: ignore[attr-defined]
+
+
+# ---------------------------------------------------------------------------
+# tools/call — provisioned happy path (AC2 positive)
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.parametrize("docs_client", [frozenset({_DOCS_CAPABILITY})], indirect=True)
+def test_tools_call_search_docs_returns_cited_chunks(
+    docs_client: tuple[TestClient, Operator],
+) -> None:
+    """AC2: a provisioned operator with product+version gets cited chunks.
+
+    Pins the wire round-trip: the handler projects the corpus chunk into
+    MEHO's ``DocsChunk`` surface, the dispatcher JSON-encodes it into
+    ``content[0].text``, and the binary scope reaches the corpus as
+    ``metadata_filters``.
+    """
+    client, op = docs_client
+    fake = _fake_corpus(_SAMPLE_CHUNK)
+    with patch("meho_backplane.docs_search.service.search_corpus", new=fake):
+        response = post_mcp(
+            client,
+            {
+                "jsonrpc": "2.0",
+                "id": 3,
+                "method": "tools/call",
+                "params": {
+                    "name": "search_docs",
+                    "arguments": {
+                        "query": "config maximums",
+                        "product": "nsx",
+                        "version": "9.0",
+                        "limit": 5,
+                    },
+                },
+            },
+        )
+    assert response.status_code == 200
+    body = response.json()
+    assert body["result"]["isError"] is False
+    payload = json.loads(body["result"]["content"][0]["text"])
+    assert "chunks" in payload
+    assert len(payload["chunks"]) == 1
+    chunk = payload["chunks"][0]
+    assert chunk["chunk_id"] == "nsx-9.0-maximums-0007"
+    assert chunk["content"].startswith("NSX 9.0 supports")
+    assert chunk["source_url"].endswith("/maximums")
+
+    # The binary product+version scope reached the corpus as filters, and
+    # the operator's identity was forwarded (never a caller-supplied one).
+    captured = fake.captured  # type: ignore[attr-defined]
+    assert captured["query"] == "config maximums"
+    assert captured["limit"] == 5
+    assert captured["metadata_filters"] == {"product": "nsx", "version": "9.0"}
+    assert captured["operator"].tenant_id == op.tenant_id
+
+
+# ---------------------------------------------------------------------------
+# tools/call — REQUIRE_FILTERS surfaces as an MCP error (AC2)
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.parametrize("docs_client", [frozenset({_DOCS_CAPABILITY})], indirect=True)
+def test_tools_call_search_docs_missing_version_rejected_by_schema(
+    docs_client: tuple[TestClient, Operator],
+) -> None:
+    """A missing required ``version`` fails inputSchema validation → -32602.
+
+    The strict schema catches the missing mandatory scope before the
+    handler runs — the first line of the REQUIRE_FILTERS defence.
+    """
+    client, _op = docs_client
+    response = post_mcp(
+        client,
+        {
+            "jsonrpc": "2.0",
+            "id": 4,
+            "method": "tools/call",
+            "params": {
+                "name": "search_docs",
+                "arguments": {"query": "x", "product": "nsx"},
+            },
+        },
+    )
+    assert response.status_code == 200
+    assert response.json()["error"]["code"] == INVALID_PARAMS
+
+
+@pytest.mark.parametrize("docs_client", [frozenset({_DOCS_CAPABILITY})], indirect=True)
+def test_tools_call_search_docs_blank_version_surfaces_service_422_as_mcp_error(
+    docs_client: tuple[TestClient, Operator],
+) -> None:
+    """A blank-after-strip ``version`` passes the schema but the service rejects it.
+
+    ``minLength: 1`` admits a single space; the shared
+    ``build_docs_scope`` treats blank-after-strip as absent and raises
+    ``MissingDocsFilterError`` (the route's 422), which the handler maps
+    to ``-32602`` — the MCP analogue. The corpus is never called.
+    """
+    client, _op = docs_client
+    fake = _fake_corpus(_SAMPLE_CHUNK)
+    with patch("meho_backplane.docs_search.service.search_corpus", new=fake):
+        response = post_mcp(
+            client,
+            {
+                "jsonrpc": "2.0",
+                "id": 5,
+                "method": "tools/call",
+                "params": {
+                    "name": "search_docs",
+                    "arguments": {"query": "x", "product": "nsx", "version": " "},
+                },
+            },
+        )
+    assert response.status_code == 200
+    body = response.json()
+    assert body["error"]["code"] == INVALID_PARAMS
+    assert "version" in body["error"]["message"].lower()
+    # The REQUIRE_FILTERS rejection short-circuits before the corpus call.
+    assert "query" not in fake.captured  # type: ignore[attr-defined]
+
+
+@pytest.mark.parametrize("docs_client", [frozenset({_DOCS_CAPABILITY})], indirect=True)
+def test_tools_call_search_docs_rejects_extra_arguments(
+    docs_client: tuple[TestClient, Operator],
+) -> None:
+    """``additionalProperties: false`` rejects unknown top-level keys."""
+    client, _op = docs_client
+    response = post_mcp(
+        client,
+        {
+            "jsonrpc": "2.0",
+            "id": 6,
+            "method": "tools/call",
+            "params": {
+                "name": "search_docs",
+                "arguments": {
+                    "query": "x",
+                    "product": "nsx",
+                    "version": "9.0",
+                    "tenant_id": "smuggled",
+                },
+            },
+        },
+    )
+    assert response.status_code == 200
+    assert response.json()["error"]["code"] == INVALID_PARAMS
+
+
+# ---------------------------------------------------------------------------
+# tools/call — corpus unavailable surfaces as INTERNAL_ERROR (not -32602)
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.parametrize("docs_client", [frozenset({_DOCS_CAPABILITY})], indirect=True)
+def test_tools_call_search_docs_corpus_unavailable_is_internal_error(
+    docs_client: tuple[TestClient, Operator],
+) -> None:
+    """A down corpus is a server fault → ``-32603``, not invalid params.
+
+    The well-formed request is not the client's fault; the typed
+    ``CorpusUnavailable`` is not caught in the handler and bubbles to the
+    dispatcher's generic catch (the MCP analogue of the route's 503).
+    """
+    client, _op = docs_client
+
+    async def _down(_op: Operator, _query: str, **_kwargs: Any) -> CorpusSearchResponse:
+        raise CorpusUnavailable("corpus_url is not configured")
+
+    with patch("meho_backplane.docs_search.service.search_corpus", new=_down):
+        response = post_mcp(
+            client,
+            {
+                "jsonrpc": "2.0",
+                "id": 7,
+                "method": "tools/call",
+                "params": {
+                    "name": "search_docs",
+                    "arguments": {"query": "x", "product": "nsx", "version": "9.0"},
+                },
+            },
+        )
+    assert response.status_code == 200
+    assert response.json()["error"]["code"] == INTERNAL_ERROR
+
+
+# ---------------------------------------------------------------------------
+# Settings hygiene — the gate-off path keeps the corpus reachable
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.parametrize("docs_client", [frozenset({_DOCS_CAPABILITY})], indirect=True)
+def test_tools_call_search_docs_gate_off_allows_partial_scope(
+    docs_client: tuple[TestClient, Operator],
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """With ``corpus_require_filters`` off, a blank version degrades to optional.
+
+    The schema's ``minLength: 1`` still requires the key be present and
+    non-empty per the wire contract, but a blank-after-strip value no
+    longer trips REQUIRE_FILTERS — it simply widens the corpus query
+    (only ``product`` reaches ``metadata_filters``).
+    """
+    monkeypatch.setenv("CORPUS_REQUIRE_FILTERS", "false")
+    get_settings.cache_clear()
+    client, _op = docs_client
+    fake = _fake_corpus()
+    try:
+        with patch("meho_backplane.docs_search.service.search_corpus", new=fake):
+            response = post_mcp(
+                client,
+                {
+                    "jsonrpc": "2.0",
+                    "id": 8,
+                    "method": "tools/call",
+                    "params": {
+                        "name": "search_docs",
+                        "arguments": {"query": "x", "product": "nsx", "version": " "},
+                    },
+                },
+            )
+    finally:
+        get_settings.cache_clear()
+    assert response.status_code == 200
+    assert response.json()["result"]["isError"] is False
+    # Only the non-blank product survived into the corpus filter.
+    assert fake.captured["metadata_filters"] == {"product": "nsx"}  # type: ignore[attr-defined]

--- a/docs/codebase/docs-search.md
+++ b/docs/codebase/docs-search.md
@@ -23,8 +23,8 @@ corpus directly) is what buys three properties in one place:
   no caller can accidentally run an unfiltered corpus-wide query.
 
 The same `search_docs` service backs three consumers: the REST route
-(this task, T3), the MCP tool `search_docs` (T4, #1523), and the CLI
-verb `meho docs search` (T5, #1524). They share one service so the
+(T3), the MCP tool `search_docs` (T4, #1523), and the CLI verb
+`meho docs search` (T5, #1524). They share one service so the
 REQUIRE_FILTERS gate and the cited-chunk shape are defined exactly once.
 
 ## Key types
@@ -115,6 +115,51 @@ require a new authenticated backend route plus an OpenAPI snapshot
 regen. The compiled-in + claim-probe shape achieves the same operator-
 visible outcome (absent from `--help`, non-runnable) without a backend
 change.
+### `search_docs` MCP tool (`meho_backplane.mcp.tools.docs`, T4 #1523)
+
+The agent-facing face. Registered against the G0.5 MCP registry,
+auto-discovered by `eager_import_mcp_modules` (no manifest edit).
+Carries a **second** gate beyond the `operator` role gate:
+`required_capability="meho-docs"` (G4.5-T1, #1519). A tenant that hasn't
+provisioned the `meho-docs` add-on never sees the tool in `tools/list`
+(true absence) and a `tools/call` naming it directly is rejected
+403-class before the handler runs — the gate is enforced at list time
+(`all_tools_for`) and again at call time (`handle_tools_call`).
+
+The `inputSchema` is strict JSON Schema 2020-12: `additionalProperties:
+false`, required `[query, product, version]`. That `required` list is the
+**first** line of the REQUIRE_FILTERS defence — a schema-validating
+client never reaches the service-side `build_docs_scope` check. When the
+gate-off → gate-on settings flip or a non-validating client does reach
+it, `MissingDocsFilterError` (the route's 422) maps to
+`McpInvalidParamsError` → JSON-RPC `-32602` (the MCP analogue of a 422).
+A `CorpusUnavailable` is **not** caught — a well-formed request against a
+down upstream is a server fault, so it bubbles to the dispatcher's
+generic catch as `-32603` Internal Error (the MCP analogue of the route's
+503). One `audit_log` row per call is written by the dispatcher with
+`op_id="search_docs"`, `op_class="read"`, and the raw arguments hashed
+into `params_hash` — never the query in the clear.
+
+The tool description is load-bearing routing UX (it is a prompt): it
+names the sibling tools so the agent learns the boundary — `search_docs`
+for VENDOR REFERENCE, `search_knowledge` for how THIS team does X,
+`search_memory` for cross-session state — and points to the companion
+resource for the full text of a hit on a later turn.
+
+### `meho://docs/{product}/{version}/{chunk_id}` resource (`meho_backplane.mcp.resources.docs`, T4 #1523)
+
+The fetch-by-citation companion, gated by the **same**
+`required_capability="meho-docs"`. The corpus transport (T2) is
+search-only — there is no fetch-chunk-by-id endpoint — so the handler
+recovers a chunk by **re-issuing a scoped corpus search** through the
+shared service and selecting the hit whose `chunk_id` matches the URI.
+That is why the URI carries `product` + `version`: they are the mandatory
+binary scope the re-search needs, and encoding them lets
+`build_docs_scope` enforce the same REQUIRE_FILTERS posture (belt-and-
+suspenders, since a blank segment can't match the `[^/]+` template). A
+`chunk_id` absent from the re-search collapses to `-32602` "not found"
+without distinguishing "empty scope" from "no such id", so the resource
+is not a corpus-contents oracle.
 
 ## Control flow (the REST route)
 
@@ -178,6 +223,10 @@ just makes the op name canonical for `query_audit` filtering.
 
 - Route: `backend/src/meho_backplane/api/v1/search_docs.py`.
 - Service: `backend/src/meho_backplane/docs_search/service.py`.
+- MCP tool: `backend/src/meho_backplane/mcp/tools/docs.py`.
+- MCP resource: `backend/src/meho_backplane/mcp/resources/docs.py`.
+- Capability gate (T1): `backend/src/meho_backplane/mcp/registry.py`
+  (`required_capability`, `capability_satisfied`, `all_tools_for`).
 - Transport: `backend/src/meho_backplane/auth/corpus.py`.
 - Audit binding precedent: `backend/src/meho_backplane/api/v1/retrieve.py`
   (query-hash privacy), `retrieve_eval.py` (op_id / op_class override).


### PR DESCRIPTION
## Summary

- Register the agent-facing surface of the `meho-docs` add-on (G4.5-T4,
  Initiative #1518): a `search_docs` MCP tool + a companion
  `meho://docs/{product}/{version}/{chunk_id}` resource, both gated by
  `required_capability="meho-docs"` (T1, #1519) and backed by the shared
  `docs_search` service (T3, #1521). Auto-discovered by
  `eager_import_mcp_modules` — no manifest edit, no REST/OpenAPI change.
- The tool takes `query` + the **mandatory** `product`+`version` binary
  scope under a strict JSON Schema 2020-12 `inputSchema`
  (`additionalProperties:false`, required `[query, product, version]`).
  The handler reuses T3's `build_docs_scope` + `search_docs`, so the
  REQUIRE_FILTERS posture lives in one place; a missing/blank scope
  surfaces as MCP `-32602` (the analogue of the route's 422), a down
  corpus as `-32603` (the analogue of the route's 503 — deliberately not
  caught, since a well-formed request against a down upstream is a server
  fault). One hashed audit row per call (`op_class=read`).
- The tool description routes the agent — `search_docs` for vendor
  reference, `search_knowledge` for how-we-do-X, `search_memory` for
  cross-session state — and points to the companion resource. Because the
  corpus transport (T2) is search-only, the resource recovers a cited
  chunk by re-issuing a scoped search and matching on `chunk_id`; the URI
  carries the scope it needs. An unresolved id collapses to a not-found
  that doesn't distinguish empty-scope from no-such-id (no oracle).

## Test plan

- [x] `ruff check` — clean (4 new files + fixtures)
- [x] `ruff format --check` — clean
- [x] `mypy` — clean (2 new source modules)
- [x] `.claude/hooks/code-quality.py --diff` — exit 0, no findings
- [x] `pytest tests/test_mcp_tools_docs.py tests/test_mcp_resources_docs.py` — 17 passed
- [x] Broader MCP/docs/corpus suite (`-k "mcp or docs or corpus"`) — 684 passed, 20 skipped (sandbox secret guards), 0 failed
- [x] AC: tool absent from `tools/list` for an unprovisioned tenant, present + callable once provisioned (uses T1's gate)
- [x] AC: `tools/call` from unprovisioned tenant → 403-class (handler never runs); provisioned + product+version → cited chunks; missing/blank scope → T3 422 surfaced as MCP `-32602`
- [x] AC: `inputSchema` strict (`additionalProperties:false`, required `[query, product, version]`); `to_wire()` strips RBAC + capability fields
- [x] AC: `meho://docs/{...}` resource registered + gated by the same capability; `resources/read` returns chunk text
- [x] AC: description names sibling tools + companion resource (what / when / when-NOT)
- [ ] AC: `@modelcontextprotocol/inspector` round-trip — runs in CI (`tests/integration/test_mcp_inspector.py` skips in the sandbox; needs the npm tool + live server)

## Out of scope

- The gating primitive (T1, #1519) and the backend route + shared service (T3, #1521) — built on, not reimplemented.
- CLI verb (T5, #1524); `ask_docs` (T7, #1526).

<!-- auto-implement-issue: fresh, iteration 1 -->

Closes #1523
