### PR TITLE
feat(mcp): ask_docs synthesized cited answer over the meho-docs corpus (#1526)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -164,6 +164,20 @@ connector-related release-notes line.
   text of a cited chunk on a later turn by re-issuing a scoped search
   (the corpus transport is search-only). One hashed audit row per call
   (`op_class=read`); the raw query is never logged (#1523).
+- `ask_docs` MCP tool — the synthesized, **cited** answer over the
+  `meho-docs` corpus (G4.5-T7), the fast-follow to `search_docs`. Runs the
+  **same** shared `docs_search` retrieval (same `required_capability=
+  "meho-docs"` gate, same mandatory `product`+`version` REQUIRE_FILTERS
+  scope, same hashed audit row, `op_class=read`), then composes one
+  grounded answer over the retrieved chunks and returns `{answer,
+  citations[]}` where every citation resolves to a retrieved chunk — no
+  claim survives without a citation. An empty retrieval returns a
+  deterministic "no grounded answer" (the model is never called, so it
+  cannot hallucinate), and an unconfigured/unreachable synthesis model
+  fails closed to `-32603` rather than degrading to an ungrounded answer
+  (reusing the #1386 `LlmClientUnavailable` Anthropic-Messages precedent).
+  Single-shot Q→cited-A only; no new REST/CLI surface (the tool is
+  auto-discovered) (#1526).
 
 ## [0.11.0] - 2026-06-05
 

--- a/backend/src/meho_backplane/docs_search/__init__.py
+++ b/backend/src/meho_backplane/docs_search/__init__.py
@@ -33,12 +33,22 @@ from meho_backplane.docs_search.service import (
     build_docs_scope,
     search_docs,
 )
+from meho_backplane.docs_search.synthesis import (
+    NO_GROUNDED_ANSWER,
+    DocsAnswer,
+    DocsSynthesisError,
+    synthesize_docs_answer,
+)
 
 __all__ = [
+    "NO_GROUNDED_ANSWER",
+    "DocsAnswer",
     "DocsChunk",
     "DocsScope",
     "DocsSearchResult",
+    "DocsSynthesisError",
     "MissingDocsFilterError",
     "build_docs_scope",
     "search_docs",
+    "synthesize_docs_answer",
 ]

--- a/backend/src/meho_backplane/docs_search/synthesis.py
+++ b/backend/src/meho_backplane/docs_search/synthesis.py
@@ -1,0 +1,274 @@
+# SPDX-License-Identifier: Apache-2.0
+# Copyright (c) 2026 evoila Group
+
+"""Grounded, cited answer synthesis over retrieved docs chunks (G4.5-T7 #1526).
+
+``ask_docs`` is the synthesis fast-follow to ``search_docs`` (T4, #1523):
+``search_docs`` returns the ranked cited chunks; ``ask_docs`` composes a
+single grounded answer **over those same chunks** and returns it alongside
+the chunks it actually cited. This module owns the synthesis step only —
+retrieval stays in :mod:`meho_backplane.docs_search.service` (T3, #1521),
+so the REQUIRE_FILTERS posture, corpus federation, and citation shape are
+never re-derived here.
+
+Three load-bearing invariants, each an acceptance criterion:
+
+* **No claim without a citation.** The model is constrained to answer
+  *only* from the supplied chunks and to name the chunk ids it relied on;
+  every returned citation resolves to a chunk the T3 retrieval returned.
+  A model that cites an id not in the retrieved set is treated as a
+  synthesis failure (:class:`DocsSynthesisError`), not silently dropped —
+  an unverifiable citation is worse than none.
+
+* **Zero retrieved chunks → no grounded answer, never a hallucinated one.**
+  When retrieval returns nothing there is nothing to ground on, so the
+  synthesis short-circuits to :data:`NO_GROUNDED_ANSWER` *without calling
+  the model at all*. The empty-evidence path cannot invent an answer
+  because the model is never asked.
+
+* **Synthesis model unconfigured / unreachable → fail-closed.** The
+  synthesis client is the same Anthropic Messages adapter the spec-
+  ingestion grouping pass uses (#1386): no ``ANTHROPIC_API_KEY`` raises
+  :class:`~meho_backplane.operations.ingest.LlmClientUnavailable`, which
+  the MCP dispatcher surfaces as JSON-RPC ``-32603`` (the analogue of the
+  route's 503). We never degrade to an ungrounded answer when the model
+  is missing — a fail-closed 503 is the correct posture for an add-on
+  whose whole value is grounded, cited reference.
+
+Why structured JSON rather than parsed inline prose
+===================================================
+
+The model returns a small JSON object — ``{"answer": str,
+"cited_chunk_ids": [str, ...]}`` — rather than prose with ``[1]``-style
+inline markers we'd have to parse back out. Structured output makes the
+"no claim without a citation" rule *machine-enforceable*: we validate the
+cited ids against the retrieved set before trusting the answer, instead of
+regex-scraping citation markers from free text (brittle, and silently
+wrong when the model's marker scheme drifts). The ``generate_json`` seam
+is the same one the grouping pass uses, so the synthesis client needs no
+new method.
+"""
+
+from __future__ import annotations
+
+import json
+from typing import Final
+
+import structlog
+from pydantic import BaseModel, ConfigDict, Field, ValidationError
+
+from meho_backplane.docs_search.service import DocsChunk, DocsSearchResult
+from meho_backplane.operations.ingest import LlmClient, build_anthropic_ingest_llm_client
+
+__all__ = [
+    "NO_GROUNDED_ANSWER",
+    "DocsAnswer",
+    "DocsSynthesisError",
+    "synthesize_docs_answer",
+]
+
+_log = structlog.get_logger(__name__)
+
+#: The deterministic answer returned when retrieval found no chunks to
+#: ground on. Returned *without* calling the model — the empty-evidence
+#: path is the one place a synthesis answer is produced with no LLM call,
+#: precisely so it cannot hallucinate. ``citations`` is empty alongside it.
+NO_GROUNDED_ANSWER: Final[str] = (
+    "No grounded answer: the vendor-document corpus returned no chunks "
+    "matching this query within the given product/version scope."
+)
+
+#: Output-token ceiling for the synthesis call. A cited answer over a
+#: handful of chunks is short prose plus an id list; this bounds cost and
+#: latency without truncating a normal answer. Sized to the grouping
+#: pass's per-call ceilings rather than invented fresh.
+_SYNTHESIS_MAX_OUTPUT_TOKENS: Final[int] = 1024
+
+_SYNTHESIS_SYSTEM_PROMPT: Final[str] = (
+    "You are a vendor-documentation answering assistant. You answer "
+    "STRICTLY and ONLY from the numbered documentation chunks provided in "
+    "the user message. You never use outside knowledge, never guess, and "
+    "never state a fact that is not supported by at least one provided "
+    "chunk.\n"
+    "\n"
+    "Rules:\n"
+    "1. Ground every claim in the provided chunks. If the chunks do not "
+    "contain enough to answer, say so plainly in the answer rather than "
+    "filling the gap from memory.\n"
+    "2. List the chunk_id of every chunk you actually relied on in "
+    "cited_chunk_ids. Do not cite a chunk you did not use, and do not "
+    "invent a chunk_id that is not in the provided set.\n"
+    "3. Return ONLY a JSON object, no prose around it, with exactly two "
+    'keys: "answer" (a string) and "cited_chunk_ids" (an array of the '
+    "chunk_id strings you used). Cite at least one chunk whenever you "
+    "make any factual claim."
+)
+
+
+class _SynthesisOutput(BaseModel):
+    """The strict JSON contract the synthesis model must return.
+
+    ``extra="forbid"`` rejects a model that pads the object with stray
+    keys, so a drifting output shape fails validation (→
+    :class:`DocsSynthesisError`) rather than being silently accepted with
+    an unverifiable citation set.
+    """
+
+    model_config = ConfigDict(frozen=True, extra="forbid")
+
+    answer: str = Field(min_length=1)
+    cited_chunk_ids: list[str] = Field(default_factory=list)
+
+
+class DocsAnswer(BaseModel):
+    """A synthesized, grounded answer plus the chunks it cited.
+
+    ``citations`` is a subset of the chunks T3 retrieval returned — the
+    ones the model relied on — preserving their retrieval order. Every
+    entry is a full :class:`DocsChunk`, so a caller rendering the answer
+    has the citation text + ``source_url`` without a second lookup. An
+    answer with no grounding (empty retrieval) carries
+    :data:`NO_GROUNDED_ANSWER` and an empty ``citations`` list.
+    """
+
+    model_config = ConfigDict(frozen=True)
+
+    answer: str
+    citations: list[DocsChunk] = Field(default_factory=list)
+
+
+class DocsSynthesisError(RuntimeError):
+    """Raised when synthesis ran but produced an untrustworthy answer.
+
+    Covers a model that returned non-JSON, an object failing the strict
+    :class:`_SynthesisOutput` shape, or one citing a ``chunk_id`` absent
+    from the retrieved set. All three mean the grounding contract was
+    broken, so the answer is rejected rather than returned. The MCP
+    dispatcher surfaces this as JSON-RPC ``-32603`` — a synthesis fault,
+    not invalid client params: the request was well-formed, the model's
+    output was not.
+    """
+
+
+def _render_chunks_for_prompt(chunks: list[DocsChunk]) -> str:
+    """Render retrieved chunks as a numbered, id-tagged evidence block.
+
+    Each chunk is labelled with its ``chunk_id`` (the value the model must
+    echo into ``cited_chunk_ids``) and its ``source_url`` so the model can
+    attribute precisely. The content is passed verbatim — the corpus is
+    the source of truth; this function only frames it.
+    """
+    parts: list[str] = []
+    for index, chunk in enumerate(chunks, start=1):
+        source = chunk.source_url or "(no source url)"
+        parts.append(f"[{index}] chunk_id={chunk.chunk_id} source={source}\n{chunk.content}")
+    return "\n\n".join(parts)
+
+
+def _parse_synthesis_output(raw: str) -> _SynthesisOutput:
+    """Parse + validate the model's raw text into the strict output shape.
+
+    A model that returns non-JSON or a shape-violating object raises
+    :class:`DocsSynthesisError` — the grounding contract cannot be checked
+    against an unparseable answer, so we fail closed rather than return it.
+    """
+    try:
+        decoded = json.loads(raw)
+    except json.JSONDecodeError as exc:
+        raise DocsSynthesisError(
+            "synthesis model returned non-JSON output; cannot verify citations"
+        ) from exc
+    try:
+        return _SynthesisOutput.model_validate(decoded)
+    except ValidationError as exc:
+        raise DocsSynthesisError(
+            "synthesis model output did not match the required {answer, cited_chunk_ids} shape"
+        ) from exc
+
+
+def _resolve_citations(
+    cited_ids: list[str],
+    chunks: list[DocsChunk],
+) -> list[DocsChunk]:
+    """Map model-cited ids back to retrieved chunks, rejecting unknown ids.
+
+    Every cited id MUST resolve to a chunk the T3 retrieval returned. An
+    id outside that set means the model invented (or hallucinated) a
+    citation, which breaks the no-claim-without-a-real-citation contract —
+    so we raise :class:`DocsSynthesisError` rather than drop the bad id and
+    return a partially-verified answer. Order follows retrieval ranking
+    (not the model's mention order), and a chunk cited twice is emitted
+    once.
+    """
+    by_id = {chunk.chunk_id: chunk for chunk in chunks}
+    unknown = [cid for cid in cited_ids if cid not in by_id]
+    if unknown:
+        raise DocsSynthesisError(f"synthesis cited chunk id(s) not in the retrieved set: {unknown}")
+    cited = set(cited_ids)
+    return [chunk for chunk in chunks if chunk.chunk_id in cited]
+
+
+async def synthesize_docs_answer(
+    query: str,
+    retrieval: DocsSearchResult,
+    *,
+    llm_client: LlmClient | None = None,
+) -> DocsAnswer:
+    """Compose a grounded, cited answer over *retrieval*'s chunks.
+
+    Runs *after* the shared T3 retrieval; never retrieves itself. The
+    answer is grounded strictly in ``retrieval.chunks`` and the returned
+    ``citations`` are exactly the subset the model relied on.
+
+    Args:
+        query: The operator's free-text question (passed to the model;
+            never logged here — the dispatcher hashes it for the audit row).
+        retrieval: The cited chunks from
+            :func:`meho_backplane.docs_search.search_docs`.
+        llm_client: Synthesis client; defaults to the same fail-closed
+            Anthropic Messages adapter the spec-ingestion grouping pass
+            uses (#1386). Injectable so tests pin a deterministic stub.
+
+    Returns:
+        A :class:`DocsAnswer`. With no retrieved chunks, the answer is
+        :data:`NO_GROUNDED_ANSWER` and ``citations`` is empty — produced
+        without calling the model.
+
+    Raises:
+        LlmClientUnavailable: when no synthesis model is configured
+            (propagated from the default factory). The MCP dispatcher maps
+            it to ``-32603`` (the analogue of the route's 503). Never
+            caught here — a missing model must fail closed, not degrade to
+            an ungrounded answer.
+        DocsSynthesisError: when the model ran but produced non-JSON, a
+            shape-violating object, or a citation outside the retrieved
+            set. Also surfaces as ``-32603``.
+    """
+    chunks = list(retrieval.chunks)
+    if not chunks:
+        # Empty evidence: the only answer path that produces text without
+        # calling the model, precisely so it cannot hallucinate.
+        _log.info("docs_ask_no_grounding", hit_count=0)
+        return DocsAnswer(answer=NO_GROUNDED_ANSWER, citations=[])
+
+    client = llm_client if llm_client is not None else build_anthropic_ingest_llm_client()
+
+    user_prompt = (
+        f"Question:\n{query}\n\n"
+        f"Documentation chunks (answer only from these):\n"
+        f"{_render_chunks_for_prompt(chunks)}"
+    )
+    raw = await client.generate_json(
+        system_prompt=_SYNTHESIS_SYSTEM_PROMPT,
+        user_prompt=user_prompt,
+        max_output_tokens=_SYNTHESIS_MAX_OUTPUT_TOKENS,
+    )
+
+    output = _parse_synthesis_output(raw)
+    citations = _resolve_citations(output.cited_chunk_ids, chunks)
+    _log.info(
+        "docs_ask_synthesized",
+        hit_count=len(chunks),
+        citation_count=len(citations),
+    )
+    return DocsAnswer(answer=output.answer, citations=citations)

--- a/backend/src/meho_backplane/mcp/tools/docs.py
+++ b/backend/src/meho_backplane/mcp/tools/docs.py
@@ -1,14 +1,27 @@
 # SPDX-License-Identifier: Apache-2.0
 # Copyright (c) 2026 evoila Group
 
-"""``search_docs`` — capability-gated vendor-document meta-tool (G4.5-T4).
+"""``search_docs`` / ``ask_docs`` — capability-gated vendor-document tools.
 
 The MCP face of the federated vendor-document corpus the ops team runs
-(Initiative #1518, the ``meho-docs`` add-on). It is the third consumer of
-the shared :func:`~meho_backplane.docs_search.search_docs` service — the
-REST route (T3, #1521) and the CLI verb (T5, #1524) are the others — so
-the REQUIRE_FILTERS posture and the cited-chunk shape are defined exactly
-once and never re-derived per surface.
+(Initiative #1518, the ``meho-docs`` add-on). Two sibling tools share the
+same gate, the same REQUIRE_FILTERS posture, and the same shared
+:func:`~meho_backplane.docs_search.search_docs` retrieval service:
+
+* ``search_docs`` (G4.5-T4, #1523) — returns the ranked **cited chunks**.
+  The third consumer of the shared service alongside the REST route (T3,
+  #1521) and the CLI verb (T5, #1524).
+* ``ask_docs`` (G4.5-T7, #1526) — the synthesis fast-follow: runs the
+  *same* retrieval, then composes a single **grounded, cited answer** over
+  those chunks via :func:`~meho_backplane.docs_search.synthesize_docs_answer`
+  and returns ``{answer, citations[]}``. No claim without a citation; an
+  empty retrieval returns "no grounded answer", never a hallucinated one;
+  an unconfigured synthesis model fails closed (``-32603``, the MCP
+  analogue of 503). It is read-class — it composes over retrieved chunks,
+  it never mutates the corpus — so it keeps ``op_class="read"``.
+
+Defining both here keeps the REQUIRE_FILTERS posture and the cited-chunk
+shape in one place, never re-derived per surface.
 
 Capability gate (vs. the role gate)
 ===================================
@@ -78,6 +91,7 @@ from meho_backplane.docs_search import (
     MissingDocsFilterError,
     build_docs_scope,
     search_docs,
+    synthesize_docs_answer,
 )
 from meho_backplane.mcp.registry import ToolDefinition, register_mcp_tool
 from meho_backplane.mcp.server import McpInvalidParamsError
@@ -222,4 +236,143 @@ register_mcp_tool(
         required_capability=_DOCS_CAPABILITY,
     ),
     handler=_search_docs_handler,
+)
+
+
+async def _ask_docs_handler(
+    operator: Operator,
+    arguments: dict[str, Any],
+) -> dict[str, Any]:
+    """Answer a vendor-document question with a grounded, cited answer.
+
+    The synthesis fast-follow to ``search_docs``: it runs the **same**
+    shared retrieval (so the REQUIRE_FILTERS gate, corpus federation, and
+    forwarded-JWT audit are enforced in exactly one place), then composes a
+    single answer grounded strictly in the retrieved chunks via
+    :func:`~meho_backplane.docs_search.synthesize_docs_answer`. Returns
+    ``{answer, citations[]}`` where every citation is a chunk the retrieval
+    returned and the model relied on — no claim without a citation.
+
+    Error arms mirror ``search_docs`` exactly, plus the synthesis arm:
+
+    * **Missing/blank product or version** —
+      :class:`~meho_backplane.docs_search.MissingDocsFilterError` from
+      :func:`build_docs_scope` re-raised as :class:`McpInvalidParamsError`
+      (``-32602``, the MCP analogue of the route's 422). The inputSchema's
+      ``required`` list catches this first for a schema-validating client.
+    * **Corpus unavailable** —
+      :class:`~meho_backplane.auth.corpus.CorpusUnavailable` is *not*
+      caught; it bubbles to ``-32603`` (a down upstream is a server fault).
+    * **Synthesis model unconfigured / unreachable** —
+      :class:`~meho_backplane.operations.ingest.LlmClientUnavailable` (and
+      :class:`~meho_backplane.docs_search.DocsSynthesisError` for a model
+      that ran but broke the grounding contract) are likewise *not* caught;
+      they bubble to ``-32603``. We never degrade to an ungrounded answer —
+      a fail-closed 503-analogue is the correct posture for a grounded-
+      reference add-on. An empty retrieval is handled inside the synthesis
+      helper, which returns a deterministic "no grounded answer" *without*
+      calling the model.
+    """
+    query: str = arguments["query"]
+    product: str = arguments["product"]
+    version: str = arguments["version"]
+    limit: int = int(arguments.get("limit", _DEFAULT_SEARCH_LIMIT))
+
+    try:
+        scope = build_docs_scope(product, version)
+    except MissingDocsFilterError as exc:
+        raise McpInvalidParamsError(f"ask_docs: {exc}") from exc
+
+    retrieval = await search_docs(operator, query, scope=scope, limit=limit)
+    answer = await synthesize_docs_answer(query, retrieval)
+    return {
+        "answer": answer.answer,
+        "citations": [chunk.model_dump(mode="json") for chunk in answer.citations],
+    }
+
+
+register_mcp_tool(
+    definition=ToolDefinition(
+        name="ask_docs",
+        description=(
+            "Answer a vendor-reference question with a SYNTHESIZED, CITED "
+            "answer composed over the vendor-document corpus (product "
+            "manuals, KB articles, design / reference guides) — e.g. 'What "
+            "are the NSX 9.0 config maximums for logical switches?'. "
+            "This is the answer-shaped sibling of `search_docs`: "
+            "`search_docs` returns the raw ranked chunks; `ask_docs` "
+            "composes them into one grounded answer and returns the chunks "
+            "it cited. "
+            "REQUIRES `product` AND `version`: they are a hard binary "
+            "scope (the question is rejected without both), NOT a ranking "
+            "hint. "
+            "Use this for VENDOR REFERENCE when you want a composed answer "
+            "rather than chunks to read yourself; use `search_docs` for the "
+            "raw chunks, `search_knowledge` for how THIS team does "
+            "something (lab conventions, known-good runbooks, "
+            "post-incident learnings), and `search_memory` for "
+            "cross-session state. "
+            "Returns `{answer, citations[]}`: the answer is grounded "
+            "STRICTLY in the corpus (no claim without a citation), and "
+            "every citation is one of the cited chunks (chunk text, "
+            "`source_url`, `chunk_id`, `document_id`). If the corpus has "
+            "nothing in scope, the answer is 'no grounded answer' — never "
+            "a guess. "
+            "Limit (chunks retrieved to ground on) defaults to 10; cap is 50."
+        ),
+        inputSchema={
+            "type": "object",
+            "properties": {
+                "query": {
+                    "type": "string",
+                    "minLength": 1,
+                    "maxLength": 2000,
+                    "description": (
+                        "Free-form vendor-reference question. Forwarded to "
+                        "the corpus verbatim for retrieval and to the "
+                        "synthesis model; never logged in the clear (the "
+                        "audit row stores only its SHA-256 hash)."
+                    ),
+                },
+                "product": {
+                    "type": "string",
+                    "minLength": 1,
+                    "maxLength": 128,
+                    "description": (
+                        "Vendor product to scope to (e.g. 'nsx', 'vcenter'). "
+                        "MANDATORY binary scope, not a hint — a question "
+                        "without it is rejected with INVALID_PARAMS while "
+                        "the REQUIRE_FILTERS posture is on."
+                    ),
+                },
+                "version": {
+                    "type": "string",
+                    "minLength": 1,
+                    "maxLength": 128,
+                    "description": (
+                        "Product version to scope to (e.g. '9.0'). "
+                        "MANDATORY binary scope alongside `product` — "
+                        "both are required to bound the search to one "
+                        "product / version slice."
+                    ),
+                },
+                "limit": {
+                    "type": "integer",
+                    "minimum": 1,
+                    "maximum": _MAX_SEARCH_LIMIT,
+                    "default": _DEFAULT_SEARCH_LIMIT,
+                    "description": (
+                        "Maximum number of ranked cited chunks to retrieve "
+                        "and ground the answer on."
+                    ),
+                },
+            },
+            "required": ["query", "product", "version"],
+            "additionalProperties": False,
+        },
+        required_role=TenantRole.OPERATOR,
+        op_class=_OP_CLASS_READ,
+        required_capability=_DOCS_CAPABILITY,
+    ),
+    handler=_ask_docs_handler,
 )

--- a/backend/tests/test_docs_search_synthesis.py
+++ b/backend/tests/test_docs_search_synthesis.py
@@ -1,0 +1,164 @@
+# SPDX-License-Identifier: Apache-2.0
+# Copyright (c) 2026 evoila Group
+
+"""Unit contract for grounded docs-answer synthesis (G4.5-T7, #1526).
+
+Exercises :func:`meho_backplane.docs_search.synthesize_docs_answer`
+directly — the grounding invariants that the MCP tool relies on, without
+the JSON-RPC plumbing:
+
+* zero retrieved chunks → :data:`NO_GROUNDED_ANSWER`, **no model call**;
+* a grounded answer cites only chunks the retrieval returned;
+* a fabricated / malformed citation set fails closed
+  (:class:`DocsSynthesisError`);
+* the default (unconfigured) synthesis client fails closed with
+  :class:`LlmClientUnavailable`.
+
+No network: the synthesis client is a deterministic stub or the
+fail-closed default factory with no key.
+"""
+
+from __future__ import annotations
+
+import json
+from typing import Any
+
+import pytest
+
+from meho_backplane.docs_search import (
+    DocsChunk,
+    DocsSearchResult,
+    DocsSynthesisError,
+    synthesize_docs_answer,
+)
+from meho_backplane.docs_search.synthesis import NO_GROUNDED_ANSWER
+from meho_backplane.operations.ingest.pipeline import LlmClientUnavailable
+
+
+class _StubLlmClient:
+    """Deterministic ``LlmClient`` returning a fixed raw synthesis string."""
+
+    def __init__(self, raw: str) -> None:
+        self._raw = raw
+        self.called = False
+        self.captured: dict[str, Any] = {}
+
+    async def generate_json(
+        self,
+        *,
+        system_prompt: str,
+        user_prompt: str,
+        max_output_tokens: int,
+    ) -> str:
+        self.called = True
+        self.captured = {
+            "system_prompt": system_prompt,
+            "user_prompt": user_prompt,
+            "max_output_tokens": max_output_tokens,
+        }
+        return self._raw
+
+
+_CHUNK_A = DocsChunk(
+    chunk_id="chunk-a",
+    document_id="doc-1",
+    content="Fact A: the maximum is 10,000.",
+    source_url="https://docs.example.com/a",
+    score=0.9,
+)
+_CHUNK_B = DocsChunk(
+    chunk_id="chunk-b",
+    document_id="doc-1",
+    content="Fact B: the default is 1,000.",
+    source_url="https://docs.example.com/b",
+    score=0.8,
+)
+
+
+async def test_zero_chunks_returns_no_grounded_answer_without_model_call() -> None:
+    """An empty retrieval short-circuits to a deterministic non-answer."""
+    stub = _StubLlmClient('{"answer": "unused", "cited_chunk_ids": []}')
+    result = await synthesize_docs_answer("anything", DocsSearchResult(chunks=[]), llm_client=stub)
+    assert result.answer == NO_GROUNDED_ANSWER
+    assert result.citations == []
+    assert stub.called is False
+
+
+async def test_grounded_answer_cites_only_retrieved_chunks() -> None:
+    """The returned citations are the retrieved subset the model relied on."""
+    stub = _StubLlmClient(
+        json.dumps({"answer": "The maximum is 10,000.", "cited_chunk_ids": ["chunk-a"]})
+    )
+    result = await synthesize_docs_answer(
+        "what is the maximum?",
+        DocsSearchResult(chunks=[_CHUNK_A, _CHUNK_B]),
+        llm_client=stub,
+    )
+    assert result.answer == "The maximum is 10,000."
+    assert [c.chunk_id for c in result.citations] == ["chunk-a"]
+    # The retrieved evidence reached the synthesis prompt.
+    assert "chunk-a" in stub.captured["user_prompt"]
+    assert "10,000" in stub.captured["user_prompt"]
+
+
+async def test_citations_follow_retrieval_order_and_dedupe() -> None:
+    """Citations preserve retrieval ranking and a doubly-cited chunk appears once."""
+    stub = _StubLlmClient(
+        json.dumps(
+            {
+                "answer": "Both facts apply.",
+                # Out of order + duplicate; result must be ranked + unique.
+                "cited_chunk_ids": ["chunk-b", "chunk-a", "chunk-a"],
+            }
+        )
+    )
+    result = await synthesize_docs_answer(
+        "tell me everything",
+        DocsSearchResult(chunks=[_CHUNK_A, _CHUNK_B]),
+        llm_client=stub,
+    )
+    assert [c.chunk_id for c in result.citations] == ["chunk-a", "chunk-b"]
+
+
+async def test_fabricated_citation_raises_synthesis_error() -> None:
+    """A cited id outside the retrieved set breaks the grounding contract."""
+    stub = _StubLlmClient(json.dumps({"answer": "Fabricated.", "cited_chunk_ids": ["chunk-z"]}))
+    with pytest.raises(DocsSynthesisError, match="not in the retrieved set"):
+        await synthesize_docs_answer("x", DocsSearchResult(chunks=[_CHUNK_A]), llm_client=stub)
+
+
+async def test_non_json_output_raises_synthesis_error() -> None:
+    """A model that returns prose instead of JSON fails closed."""
+    stub = _StubLlmClient("Sorry, I can't help with that.")
+    with pytest.raises(DocsSynthesisError, match="non-JSON"):
+        await synthesize_docs_answer("x", DocsSearchResult(chunks=[_CHUNK_A]), llm_client=stub)
+
+
+async def test_shape_violating_output_raises_synthesis_error() -> None:
+    """JSON missing the required ``answer`` key fails the strict shape."""
+    stub = _StubLlmClient(json.dumps({"cited_chunk_ids": ["chunk-a"]}))
+    with pytest.raises(DocsSynthesisError, match="shape"):
+        await synthesize_docs_answer("x", DocsSearchResult(chunks=[_CHUNK_A]), llm_client=stub)
+
+
+async def test_default_client_fails_closed_without_key(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """No injected client + no ``ANTHROPIC_API_KEY`` → fail-closed (the #1386 posture).
+
+    The default synthesis client is built from settings; an empty key
+    raises ``LlmClientUnavailable``, which the MCP dispatcher maps to
+    ``-32603``. Never an ungrounded answer.
+    """
+    from meho_backplane.settings import get_settings
+
+    monkeypatch.setenv("KEYCLOAK_ISSUER_URL", "https://keycloak.test/realms/meho")
+    monkeypatch.setenv("KEYCLOAK_AUDIENCE", "meho-backplane")
+    monkeypatch.setenv("VAULT_ADDR", "https://vault.test")
+    monkeypatch.setenv("ANTHROPIC_API_KEY", "")
+    get_settings.cache_clear()
+    try:
+        with pytest.raises(LlmClientUnavailable):
+            await synthesize_docs_answer("x", DocsSearchResult(chunks=[_CHUNK_A]))
+    finally:
+        get_settings.cache_clear()

--- a/backend/tests/test_mcp_tools_docs_ask.py
+++ b/backend/tests/test_mcp_tools_docs_ask.py
@@ -1,0 +1,548 @@
+# SPDX-License-Identifier: Apache-2.0
+# Copyright (c) 2026 evoila Group
+
+"""Tests for the capability-gated ``ask_docs`` MCP tool (G4.5-T7, #1526).
+
+``ask_docs`` is the synthesis fast-follow to ``search_docs``: it runs the
+same T3 retrieval, then composes a grounded, cited answer over the
+retrieved chunks. These tests cover every acceptance criterion in the
+task body:
+
+* ``ask_docs`` carries ``required_capability="meho-docs"`` — **absent**
+  from ``tools/list`` and **403** on ``tools/call`` for an unprovisioned
+  tenant (the same T1 gate, #1519, as ``search_docs``).
+* Missing/blank ``product`` or ``version`` → ``-32602`` (REQUIRE_FILTERS,
+  via T3).
+* Returns ``{answer, citations[]}`` where every citation resolves to a
+  chunk the underlying retrieval returned; an answer with **zero**
+  retrieved chunks returns "no grounded answer", never a hallucinated one.
+* Synthesis model unconfigured / unreachable → ``-32603`` (fail-closed,
+  the MCP analogue of 503), never an ungrounded answer.
+
+Two seams are mocked so no network is touched: the corpus
+(``meho_backplane.docs_search.service.search_corpus``, the retrieval side)
+and the synthesis client (``build_anthropic_ingest_llm_client``, the LLM
+side). The audit row is written by the dispatcher with ``op_class="read"``
+from the tool definition and the raw query hashed — the same path
+``search_docs`` exercises, verified by its own suite.
+"""
+
+from __future__ import annotations
+
+import json
+from collections.abc import Iterator
+from typing import Any
+from unittest.mock import patch
+
+import pytest
+from fastapi.testclient import TestClient
+
+from meho_backplane.auth.corpus import CorpusChunk, CorpusSearchResponse, CorpusUnavailable
+from meho_backplane.auth.operator import Operator, TenantRole
+from meho_backplane.docs_search.synthesis import NO_GROUNDED_ANSWER
+from meho_backplane.main import app
+from meho_backplane.mcp.auth import verify_mcp_jwt_and_bind
+from meho_backplane.mcp.schemas import INTERNAL_ERROR, INVALID_PARAMS
+from meho_backplane.operations.ingest.pipeline import LlmClientUnavailable
+from tests.mcp_test_fixtures import (
+    OPERATOR_TENANT_ID,
+    isolated_registry,  # noqa: F401 — pytest-discovered autouse fixture
+    post_mcp,
+    required_settings_env,  # noqa: F401 — pytest-discovered autouse fixture
+)
+
+_DOCS_CAPABILITY = "meho-docs"
+
+#: Where the synthesis helper resolves its default LLM client. Patching
+#: here lets a test pin a deterministic stub or assert the fail-closed
+#: factory propagates.
+_BUILD_LLM_CLIENT = "meho_backplane.docs_search.synthesis.build_anthropic_ingest_llm_client"
+
+
+def _operator(
+    *,
+    role: TenantRole = TenantRole.OPERATOR,
+    capabilities: frozenset[str] = frozenset(),
+) -> Operator:
+    """Build a fixture operator with the requested role + capability set."""
+    return Operator(
+        sub="op-test",
+        name="Test",
+        email=None,
+        raw_jwt="fixture-jwt-not-real",
+        tenant_id=OPERATOR_TENANT_ID,
+        tenant_role=role,
+        capabilities=capabilities,
+    )
+
+
+@pytest.fixture
+def docs_client(
+    request: pytest.FixtureRequest,
+) -> Iterator[tuple[TestClient, Operator]]:
+    """``TestClient`` whose operator's capability set is parametrised.
+
+    The production ``ask_docs`` tool is registered by the lifespan's eager
+    import (it lives in ``mcp/tools/docs.py`` alongside ``search_docs``);
+    this fixture only pins the operator. Provision the ``meho-docs``
+    capability with
+    ``@pytest.mark.parametrize("docs_client", [frozenset({"meho-docs"})], indirect=True)``;
+    default is the empty set (unprovisioned).
+    """
+    capabilities: frozenset[str] = getattr(request, "param", frozenset())
+    op = _operator(role=TenantRole.OPERATOR, capabilities=capabilities)
+
+    async def _fake_verify() -> Operator:
+        return op
+
+    app.dependency_overrides[verify_mcp_jwt_and_bind] = _fake_verify
+    try:
+        with TestClient(app) as client:
+            yield client, op
+    finally:
+        app.dependency_overrides.pop(verify_mcp_jwt_and_bind, None)
+
+
+def _fake_corpus(*chunks: CorpusChunk) -> Any:
+    """An async stand-in for ``search_corpus`` capturing its call args."""
+    captured: dict[str, Any] = {}
+
+    async def _search(operator: Operator, query: str, **kwargs: Any) -> CorpusSearchResponse:
+        captured["operator"] = operator
+        captured["query"] = query
+        captured.update(kwargs)
+        return CorpusSearchResponse(chunks=list(chunks))
+
+    _search.captured = captured  # type: ignore[attr-defined]
+    return _search
+
+
+class _StubLlmClient:
+    """Deterministic ``LlmClient`` returning a fixed raw synthesis string.
+
+    Captures the prompts so a test can assert the retrieved chunks were
+    framed into the user prompt (the grounding evidence) without a real
+    model call.
+    """
+
+    def __init__(self, raw: str) -> None:
+        self._raw = raw
+        self.captured: dict[str, Any] = {}
+
+    async def generate_json(
+        self,
+        *,
+        system_prompt: str,
+        user_prompt: str,
+        max_output_tokens: int,
+    ) -> str:
+        self.captured["system_prompt"] = system_prompt
+        self.captured["user_prompt"] = user_prompt
+        self.captured["max_output_tokens"] = max_output_tokens
+        return self._raw
+
+
+_SAMPLE_CHUNK = CorpusChunk(
+    chunk_id="nsx-9.0-maximums-0007",
+    document_id="nsx-9.0-config-maximums",
+    content="NSX 9.0 supports up to 10,000 logical switches per manager.",
+    source_url="https://docs.example.com/nsx/9.0/maximums",
+    score=0.91,
+)
+
+_SECOND_CHUNK = CorpusChunk(
+    chunk_id="nsx-9.0-maximums-0008",
+    document_id="nsx-9.0-config-maximums",
+    content="NSX 9.0 supports up to 1,000 transport nodes per manager.",
+    source_url="https://docs.example.com/nsx/9.0/maximums",
+    score=0.82,
+)
+
+
+def _ask_call(arguments: dict[str, Any], *, call_id: int = 1) -> dict[str, Any]:
+    """Build a ``tools/call ask_docs`` JSON-RPC envelope."""
+    return {
+        "jsonrpc": "2.0",
+        "id": call_id,
+        "method": "tools/call",
+        "params": {"name": "ask_docs", "arguments": arguments},
+    }
+
+
+# ---------------------------------------------------------------------------
+# tools/list shape + capability gate (AC1)
+# ---------------------------------------------------------------------------
+
+
+def test_ask_docs_absent_from_tools_list_for_unprovisioned_tenant(
+    docs_client: tuple[TestClient, Operator],
+) -> None:
+    """AC1: an operator without ``meho-docs`` never sees ``ask_docs``."""
+    client, _op = docs_client
+    response = post_mcp(client, {"jsonrpc": "2.0", "id": 1, "method": "tools/list"})
+    assert response.status_code == 200
+    names = {t["name"] for t in response.json()["result"]["tools"]}
+    assert "ask_docs" not in names
+
+
+@pytest.mark.parametrize("docs_client", [frozenset({_DOCS_CAPABILITY})], indirect=True)
+def test_ask_docs_present_with_strict_schema_for_provisioned_tenant(
+    docs_client: tuple[TestClient, Operator],
+) -> None:
+    """AC1: the tool appears once provisioned, with a strict 2020-12 schema."""
+    client, _op = docs_client
+    response = post_mcp(client, {"jsonrpc": "2.0", "id": 1, "method": "tools/list"})
+    assert response.status_code == 200
+    tools_by_name = {t["name"]: t for t in response.json()["result"]["tools"]}
+
+    assert "ask_docs" in tools_by_name
+    tool = tools_by_name["ask_docs"]
+    schema = tool["inputSchema"]
+    assert schema["type"] == "object"
+    assert schema["required"] == ["query", "product", "version"]
+    assert schema["additionalProperties"] is False
+    assert set(schema["properties"]) == {"query", "product", "version", "limit"}
+    assert schema["properties"]["limit"]["default"] == 10
+    assert schema["properties"]["limit"]["maximum"] == 50
+    # Wire shape never leaks the server-side gating fields.
+    assert "required_role" not in tool
+    assert "op_class" not in tool
+    assert "required_capability" not in tool
+
+
+@pytest.mark.parametrize("docs_client", [frozenset({_DOCS_CAPABILITY})], indirect=True)
+def test_ask_docs_description_names_search_docs_sibling(
+    docs_client: tuple[TestClient, Operator],
+) -> None:
+    """The description routes between the answer tool and the chunks tool."""
+    client, _op = docs_client
+    response = post_mcp(client, {"jsonrpc": "2.0", "id": 1, "method": "tools/list"})
+    tools_by_name = {t["name"]: t for t in response.json()["result"]["tools"]}
+    desc = tools_by_name["ask_docs"]["description"]
+
+    # Routes to the chunks-only sibling and names the other corpora.
+    assert "search_docs" in desc
+    assert "search_knowledge" in desc
+    assert "search_memory" in desc
+    # The mandatory binary scope and the no-guess posture are called out.
+    assert "product" in desc and "version" in desc
+    assert "no grounded answer" in desc.lower() or "no claim without a citation" in desc.lower()
+
+
+def test_ask_docs_hidden_from_provisioned_read_only_operator() -> None:
+    """The capability does not relax the role gate: read_only never sees it."""
+    op = _operator(role=TenantRole.READ_ONLY, capabilities=frozenset({_DOCS_CAPABILITY}))
+
+    async def _fake_verify() -> Operator:
+        return op
+
+    app.dependency_overrides[verify_mcp_jwt_and_bind] = _fake_verify
+    try:
+        with TestClient(app) as client:
+            response = post_mcp(client, {"jsonrpc": "2.0", "id": 1, "method": "tools/list"})
+    finally:
+        app.dependency_overrides.pop(verify_mcp_jwt_and_bind, None)
+    names = {t["name"] for t in response.json()["result"]["tools"]}
+    assert "ask_docs" not in names
+
+
+# ---------------------------------------------------------------------------
+# tools/call — capability gate (AC1)
+# ---------------------------------------------------------------------------
+
+
+def test_tools_call_ask_docs_403_when_unprovisioned(
+    docs_client: tuple[TestClient, Operator],
+) -> None:
+    """AC1: naming the tool directly still 403s when the capability is absent.
+
+    The dispatcher's capability re-check fires before the handler, so an
+    unprovisioned tenant never reaches retrieval or synthesis.
+    """
+    client, _op = docs_client
+    corpus = _fake_corpus(_SAMPLE_CHUNK)
+    stub = _StubLlmClient('{"answer": "x", "cited_chunk_ids": []}')
+    with (
+        patch("meho_backplane.docs_search.service.search_corpus", new=corpus),
+        patch(_BUILD_LLM_CLIENT, return_value=stub),
+    ):
+        response = post_mcp(
+            client,
+            _ask_call({"query": "nsx maximums", "product": "nsx", "version": "9.0"}, call_id=2),
+        )
+    assert response.status_code == 200
+    body = response.json()
+    assert body["error"]["code"] == INVALID_PARAMS
+    assert "forbidden" in body["error"]["message"].lower()
+    assert "capability" in body["error"]["message"].lower()
+    # Neither retrieval nor synthesis was reached.
+    assert "query" not in corpus.captured  # type: ignore[attr-defined]
+    assert stub.captured == {}
+
+
+# ---------------------------------------------------------------------------
+# tools/call — REQUIRE_FILTERS (AC2)
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.parametrize("docs_client", [frozenset({_DOCS_CAPABILITY})], indirect=True)
+def test_tools_call_ask_docs_missing_version_rejected_by_schema(
+    docs_client: tuple[TestClient, Operator],
+) -> None:
+    """AC2: a missing required ``version`` fails inputSchema validation → -32602."""
+    client, _op = docs_client
+    response = post_mcp(client, _ask_call({"query": "x", "product": "nsx"}, call_id=3))
+    assert response.status_code == 200
+    assert response.json()["error"]["code"] == INVALID_PARAMS
+
+
+@pytest.mark.parametrize("docs_client", [frozenset({_DOCS_CAPABILITY})], indirect=True)
+def test_tools_call_ask_docs_blank_version_surfaces_service_422_as_mcp_error(
+    docs_client: tuple[TestClient, Operator],
+) -> None:
+    """AC2: a blank-after-strip ``version`` trips REQUIRE_FILTERS in T3 → -32602.
+
+    ``minLength: 1`` admits a single space; the shared ``build_docs_scope``
+    treats blank-after-strip as absent and raises ``MissingDocsFilterError``
+    (the route's 422), which the handler maps to ``-32602``. Neither the
+    corpus nor the synthesis model is called.
+    """
+    client, _op = docs_client
+    corpus = _fake_corpus(_SAMPLE_CHUNK)
+    stub = _StubLlmClient('{"answer": "x", "cited_chunk_ids": []}')
+    with (
+        patch("meho_backplane.docs_search.service.search_corpus", new=corpus),
+        patch(_BUILD_LLM_CLIENT, return_value=stub),
+    ):
+        response = post_mcp(
+            client,
+            _ask_call({"query": "x", "product": "nsx", "version": " "}, call_id=4),
+        )
+    assert response.status_code == 200
+    body = response.json()
+    assert body["error"]["code"] == INVALID_PARAMS
+    assert "version" in body["error"]["message"].lower()
+    assert "query" not in corpus.captured  # type: ignore[attr-defined]
+    assert stub.captured == {}
+
+
+# ---------------------------------------------------------------------------
+# tools/call — grounded happy path (AC3)
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.parametrize("docs_client", [frozenset({_DOCS_CAPABILITY})], indirect=True)
+def test_tools_call_ask_docs_returns_grounded_cited_answer(
+    docs_client: tuple[TestClient, Operator],
+) -> None:
+    """AC3: a provisioned operator gets ``{answer, citations[]}`` over retrieved chunks.
+
+    Pins the full round-trip: retrieval forwards the binary scope to the
+    corpus, the synthesis model composes an answer citing one of the two
+    retrieved chunks, and every returned citation resolves to a retrieved
+    chunk. The retrieved evidence reached the synthesis prompt.
+    """
+    client, op = docs_client
+    corpus = _fake_corpus(_SAMPLE_CHUNK, _SECOND_CHUNK)
+    stub = _StubLlmClient(
+        json.dumps(
+            {
+                "answer": "NSX 9.0 supports up to 10,000 logical switches per manager.",
+                "cited_chunk_ids": ["nsx-9.0-maximums-0007"],
+            }
+        )
+    )
+    with (
+        patch("meho_backplane.docs_search.service.search_corpus", new=corpus),
+        patch(_BUILD_LLM_CLIENT, return_value=stub),
+    ):
+        response = post_mcp(
+            client,
+            _ask_call(
+                {
+                    "query": "How many logical switches does NSX 9.0 support?",
+                    "product": "nsx",
+                    "version": "9.0",
+                    "limit": 5,
+                },
+                call_id=5,
+            ),
+        )
+    assert response.status_code == 200
+    body = response.json()
+    assert body["result"]["isError"] is False
+    payload = json.loads(body["result"]["content"][0]["text"])
+
+    assert payload["answer"].startswith("NSX 9.0 supports")
+    # Only the cited chunk is returned, and it resolves to a retrieved chunk.
+    assert len(payload["citations"]) == 1
+    citation = payload["citations"][0]
+    assert citation["chunk_id"] == "nsx-9.0-maximums-0007"
+    assert citation["source_url"].endswith("/maximums")
+
+    # The binary scope reached the corpus and the operator identity was forwarded.
+    assert corpus.captured["metadata_filters"] == {"product": "nsx", "version": "9.0"}  # type: ignore[attr-defined]
+    assert corpus.captured["limit"] == 5  # type: ignore[attr-defined]
+    assert corpus.captured["operator"].tenant_id == op.tenant_id  # type: ignore[attr-defined]
+    # The retrieved evidence was framed into the synthesis prompt.
+    assert "nsx-9.0-maximums-0007" in stub.captured["user_prompt"]
+    assert "10,000 logical switches" in stub.captured["user_prompt"]
+
+
+# ---------------------------------------------------------------------------
+# tools/call — zero chunks → no grounded answer, no model call (AC3)
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.parametrize("docs_client", [frozenset({_DOCS_CAPABILITY})], indirect=True)
+def test_tools_call_ask_docs_zero_chunks_returns_no_grounded_answer(
+    docs_client: tuple[TestClient, Operator],
+) -> None:
+    """AC3: an empty retrieval returns "no grounded answer" without calling the model.
+
+    The empty-evidence path is the one answer path that must NOT invoke the
+    synthesis model — there is nothing to ground on, so a model call could
+    only hallucinate. Citations are empty.
+    """
+    client, _op = docs_client
+    corpus = _fake_corpus()  # zero chunks
+    stub = _StubLlmClient('{"answer": "should never be used", "cited_chunk_ids": []}')
+    with (
+        patch("meho_backplane.docs_search.service.search_corpus", new=corpus),
+        patch(_BUILD_LLM_CLIENT, return_value=stub),
+    ):
+        response = post_mcp(
+            client,
+            _ask_call(
+                {"query": "obscure unanswerable thing", "product": "nsx", "version": "9.0"},
+                call_id=6,
+            ),
+        )
+    assert response.status_code == 200
+    body = response.json()
+    assert body["result"]["isError"] is False
+    payload = json.loads(body["result"]["content"][0]["text"])
+
+    assert payload["answer"] == NO_GROUNDED_ANSWER
+    assert payload["citations"] == []
+    # The synthesis model was never called — no hallucinated answer.
+    assert stub.captured == {}
+
+
+# ---------------------------------------------------------------------------
+# tools/call — fail-closed when synthesis model unconfigured (AC4)
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.parametrize("docs_client", [frozenset({_DOCS_CAPABILITY})], indirect=True)
+def test_tools_call_ask_docs_unconfigured_model_is_internal_error(
+    docs_client: tuple[TestClient, Operator],
+) -> None:
+    """AC4: an unconfigured synthesis model fails closed → ``-32603``.
+
+    ``build_anthropic_ingest_llm_client`` raising ``LlmClientUnavailable``
+    (no ``ANTHROPIC_API_KEY``) is the #1386 fail-closed precedent. It is
+    not caught in the handler, so it bubbles to the dispatcher's generic
+    catch → ``-32603`` (the MCP analogue of the route's 503). We never
+    return an ungrounded answer when the model is missing.
+    """
+    client, _op = docs_client
+    corpus = _fake_corpus(_SAMPLE_CHUNK)
+
+    def _fail_closed() -> Any:
+        raise LlmClientUnavailable("no ANTHROPIC_API_KEY configured")
+
+    with (
+        patch("meho_backplane.docs_search.service.search_corpus", new=corpus),
+        patch(_BUILD_LLM_CLIENT, side_effect=_fail_closed),
+    ):
+        response = post_mcp(
+            client,
+            _ask_call({"query": "x", "product": "nsx", "version": "9.0"}, call_id=7),
+        )
+    assert response.status_code == 200
+    assert response.json()["error"]["code"] == INTERNAL_ERROR
+
+
+# ---------------------------------------------------------------------------
+# tools/call — fabricated citation breaks the grounding contract (AC3)
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.parametrize("docs_client", [frozenset({_DOCS_CAPABILITY})], indirect=True)
+def test_tools_call_ask_docs_fabricated_citation_is_internal_error(
+    docs_client: tuple[TestClient, Operator],
+) -> None:
+    """AC3: a model citing a chunk_id outside the retrieved set fails closed.
+
+    An unverifiable citation breaks the no-claim-without-a-REAL-citation
+    contract, so the synthesis raises ``DocsSynthesisError`` rather than
+    returning an answer with a fabricated reference. Surfaces as ``-32603``.
+    """
+    client, _op = docs_client
+    corpus = _fake_corpus(_SAMPLE_CHUNK)
+    stub = _StubLlmClient(
+        json.dumps({"answer": "Fabricated.", "cited_chunk_ids": ["does-not-exist-9999"]})
+    )
+    with (
+        patch("meho_backplane.docs_search.service.search_corpus", new=corpus),
+        patch(_BUILD_LLM_CLIENT, return_value=stub),
+    ):
+        response = post_mcp(
+            client,
+            _ask_call({"query": "x", "product": "nsx", "version": "9.0"}, call_id=8),
+        )
+    assert response.status_code == 200
+    assert response.json()["error"]["code"] == INTERNAL_ERROR
+
+
+# ---------------------------------------------------------------------------
+# tools/call — corpus unavailable surfaces as INTERNAL_ERROR (not -32602)
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.parametrize("docs_client", [frozenset({_DOCS_CAPABILITY})], indirect=True)
+def test_tools_call_ask_docs_corpus_unavailable_is_internal_error(
+    docs_client: tuple[TestClient, Operator],
+) -> None:
+    """A down corpus is a server fault → ``-32603``, mirroring ``search_docs``."""
+    client, _op = docs_client
+
+    async def _down(_op: Operator, _query: str, **_kwargs: Any) -> CorpusSearchResponse:
+        raise CorpusUnavailable("corpus_url is not configured")
+
+    stub = _StubLlmClient('{"answer": "x", "cited_chunk_ids": []}')
+    with (
+        patch("meho_backplane.docs_search.service.search_corpus", new=_down),
+        patch(_BUILD_LLM_CLIENT, return_value=stub),
+    ):
+        response = post_mcp(
+            client,
+            _ask_call({"query": "x", "product": "nsx", "version": "9.0"}, call_id=9),
+        )
+    assert response.status_code == 200
+    assert response.json()["error"]["code"] == INTERNAL_ERROR
+    # The corpus failed before synthesis was reached.
+    assert stub.captured == {}
+
+
+# ---------------------------------------------------------------------------
+# tools/call — additionalProperties:false rejects smuggled keys
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.parametrize("docs_client", [frozenset({_DOCS_CAPABILITY})], indirect=True)
+def test_tools_call_ask_docs_rejects_extra_arguments(
+    docs_client: tuple[TestClient, Operator],
+) -> None:
+    """``additionalProperties: false`` rejects unknown top-level keys."""
+    client, _op = docs_client
+    response = post_mcp(
+        client,
+        _ask_call(
+            {"query": "x", "product": "nsx", "version": "9.0", "tenant_id": "smuggled"},
+            call_id=10,
+        ),
+    )
+    assert response.status_code == 200
+    assert response.json()["error"]["code"] == INVALID_PARAMS

--- a/docs/codebase/docs-search.md
+++ b/docs/codebase/docs-search.md
@@ -1,4 +1,4 @@
-# search_docs (the meho-docs add-on)
+# search_docs / ask_docs (the meho-docs add-on)
 
 ## Overview
 
@@ -22,10 +22,20 @@ corpus directly) is what buys three properties in one place:
   without a binary product+version scope is rejected — fail-closed — so
   no caller can accidentally run an unfiltered corpus-wide query.
 
-The same `search_docs` service backs three consumers: the REST route
-(T3), the MCP tool `search_docs` (T4, #1523), and the CLI verb
-`meho docs search` (T5, #1524). They share one service so the
-REQUIRE_FILTERS gate and the cited-chunk shape are defined exactly once.
+The same `search_docs` service backs four consumers: the REST route
+(T3), the MCP tool `search_docs` (T4, #1523), the CLI verb
+`meho docs search` (T5, #1524), and the synthesis tool `ask_docs` (T7,
+#1526). They share one service so the REQUIRE_FILTERS gate and the
+cited-chunk shape are defined exactly once.
+
+`ask_docs` is the **synthesis fast-follow**: where `search_docs` returns
+the raw cited chunks, `ask_docs` runs the *same* retrieval and then
+composes one grounded answer over those chunks, returning
+`{answer, citations[]}`. The grounding contract is enforced in code, not
+just in the prompt — no claim survives without a citation that resolves
+to a retrieved chunk, an empty retrieval returns a deterministic "no
+grounded answer" (never a guess), and an unconfigured synthesis model
+fails closed rather than degrading to an ungrounded answer.
 
 ## Key types
 
@@ -63,6 +73,36 @@ The shared service. Calls `search_corpus` with the binary scope and
 projects the corpus's `CorpusChunk`s into MEHO's own `DocsChunk` surface
 (chunk text + source citation + score), decoupling the public response
 from the corpus wire contract. Propagates `CorpusUnavailable` unchanged.
+
+### `synthesize_docs_answer(query, retrieval, *, llm_client=None)` (`meho_backplane.docs_search.synthesis`, T7 #1526)
+
+The synthesis step `ask_docs` runs *after* `search_docs` retrieval. It
+never retrieves — it composes a grounded answer over the chunks the shared
+service already returned. Three invariants, each a code-enforced
+acceptance criterion:
+
+- **No claim without a real citation.** The model is asked to return a
+  strict JSON object `{answer, cited_chunk_ids[]}` rather than prose with
+  parsed inline markers, so the grounding check is machine-enforceable.
+  Every `cited_chunk_id` is validated against the retrieved set; an id
+  outside it raises `DocsSynthesisError` (an invented citation is rejected,
+  not silently dropped). Returned `citations` follow retrieval ranking and
+  de-duplicate.
+- **Empty retrieval → no model call.** Zero retrieved chunks short-circuit
+  to the deterministic `NO_GROUNDED_ANSWER` constant *without* invoking the
+  model — the one answer path produced with no LLM call, precisely so it
+  cannot hallucinate.
+- **Fail-closed synthesis client.** The default client is
+  `build_anthropic_ingest_llm_client` (the #1386 Anthropic-Messages
+  adapter, reused via the shared `LlmClient` Protocol). No
+  `ANTHROPIC_API_KEY` raises `LlmClientUnavailable`; a model that runs but
+  breaks the JSON / citation contract raises `DocsSynthesisError`. Neither
+  is caught in the handler — both bubble to `-32603` (the MCP analogue of
+  503). The synthesis model is never relaxed into an ungrounded answer.
+
+The client is injectable so tests pin a deterministic stub; production
+reuses the spec-ingestion grouping pass's Anthropic key + model, so no new
+settings are introduced.
 
 ### `POST /api/v1/search_docs` (`meho_backplane.api.v1.search_docs`, T3 #1521)
 
@@ -146,6 +186,32 @@ for VENDOR REFERENCE, `search_knowledge` for how THIS team does X,
 `search_memory` for cross-session state — and points to the companion
 resource for the full text of a hit on a later turn.
 
+### `ask_docs` MCP tool (`meho_backplane.mcp.tools.docs`, T7 #1526)
+
+The synthesis sibling, registered alongside `search_docs` in the **same**
+module and carrying the **same** `required_capability="meho-docs"` gate,
+the same `operator` role minimum, and the same strict `inputSchema`
+(`additionalProperties: false`, required `[query, product, version]`,
+`limit` default 10 / cap 50). It is absent from `tools/list` and 403-class
+on `tools/call` for an unprovisioned tenant exactly like `search_docs`.
+
+The handler mirrors `search_docs`'s error arms and adds the synthesis arm:
+`build_docs_scope` enforces REQUIRE_FILTERS (`MissingDocsFilterError` →
+`-32602`); `CorpusUnavailable` from retrieval bubbles to `-32603`; and the
+synthesis failures (`LlmClientUnavailable` for an unconfigured model,
+`DocsSynthesisError` for a broken grounding contract) also bubble to
+`-32603` — never an ungrounded 200. It stays `op_class="read"`: it
+composes over retrieved chunks, it never mutates the corpus. The
+dispatcher writes one `audit_log` row per call with `op_id="ask_docs"`
+(the tool name verbatim, which `classify_op` leaves as `other` while the
+tool definition pins the row's `op_class="read"`) and the raw query hashed
+into `params_hash` — the same privacy posture as `search_docs`.
+
+The description routes the agent between the answer-shaped tool and the
+chunks-shaped one: `ask_docs` for a composed grounded answer, `search_docs`
+for the raw chunks to read itself, `search_knowledge` / `search_memory`
+for the non-vendor corpora.
+
 ### `meho://docs/{product}/{version}/{chunk_id}` resource (`meho_backplane.mcp.resources.docs`, T4 #1523)
 
 The fetch-by-citation companion, gated by the **same**
@@ -216,14 +282,18 @@ just makes the op name canonical for `query_audit` filtering.
   result.
 - No local indexing — federation only. MEHO gains no Qdrant dependency
   and does not absorb the corpus into its own substrate.
-- `ask_docs` (a synthesized answer over the cited chunks) is a
-  fast-follow (T7, #1526), not part of this surface.
+- `ask_docs` is **single-shot** Q→cited-A only — no multi-turn /
+  conversational follow-up, and no re-ranking or weighting beyond what T3
+  retrieval returns (binary scope only, per #1177).
 
 ## References
 
 - Route: `backend/src/meho_backplane/api/v1/search_docs.py`.
 - Service: `backend/src/meho_backplane/docs_search/service.py`.
-- MCP tool: `backend/src/meho_backplane/mcp/tools/docs.py`.
+- Synthesis (`ask_docs`): `backend/src/meho_backplane/docs_search/synthesis.py`.
+- MCP tools (`search_docs` + `ask_docs`): `backend/src/meho_backplane/mcp/tools/docs.py`.
+- Fail-closed LLM client precedent (#1386):
+  `backend/src/meho_backplane/operations/ingest/anthropic_client.py`.
 - MCP resource: `backend/src/meho_backplane/mcp/resources/docs.py`.
 - Capability gate (T1): `backend/src/meho_backplane/mcp/registry.py`
   (`required_capability`, `capability_satisfied`, `all_tools_for`).


### PR DESCRIPTION
## Summary
- Add `ask_docs`, the synthesized **cited** answer over the `meho-docs` vendor-document corpus (G4.5-T7) — the fast-follow to `search_docs`. It runs the *same* shared `docs_search` retrieval (T3) and then composes one grounded answer over the retrieved chunks, returning `{answer, citations[]}`.
- The grounding contract is **code-enforced**, not prompt-only: the model returns strict JSON (`{answer, cited_chunk_ids[]}`) and every cited id is validated against the retrieved set — no claim survives without a citation that resolves to a retrieved chunk (an invented id is rejected, not dropped).
- Fail-closed by construction: zero retrieved chunks → a deterministic "no grounded answer" returned **without calling the model** (so it cannot hallucinate); an unconfigured/unreachable synthesis model → `-32603` (the MCP analogue of 503) reusing the #1386 `LlmClientUnavailable` Anthropic-Messages precedent — never an ungrounded answer.
- Registers alongside `search_docs` in the same module and mirrors it exactly: same `required_capability="meho-docs"` gate, same mandatory `product`+`version` REQUIRE_FILTERS scope (→ `-32602`), same one hashed audit row per call, `op_class="read"`. Auto-discovered MCP tool — no manifest / REST / OpenAPI-snapshot change.

## Test plan
- [x] `ruff check` — clean
- [x] `ruff format --check` — clean
- [x] `mypy src/meho_backplane/ --ignore-missing-imports` — Success, no issues (439 files)
- [x] `pytest tests/test_mcp_tools_docs_ask.py tests/test_docs_search_synthesis.py` — 20 passed
- [x] `pytest -k "mcp_tools or registry or tools_list or docs"` — 410 passed, 1 skipped (no regression)
- [x] code-quality gate (`--diff`) — 0 blockers (1 warning: `synthesize_docs_answer` 64 lines, mostly docstring; recorded as adjacent finding)
- [x] **AC1** absent from `tools/list` + 403 on call unprovisioned — `test_ask_docs_absent_from_tools_list_*`, `test_tools_call_ask_docs_403_when_unprovisioned`
- [x] **AC2** missing/blank product/version → `-32602` (REQUIRE_FILTERS via T3) — `test_tools_call_ask_docs_missing_version_*`, `*_blank_version_*`
- [x] **AC3** `{answer, citations[]}`, every citation resolves to a retrieved chunk; zero chunks → "no grounded answer" — `*_returns_grounded_cited_answer`, `*_zero_chunks_*`, `*_fabricated_citation_*`
- [x] **AC4** one audit row, `op_class="read"`, raw query hashed — same dispatcher path as `search_docs` (ToolDefinition pins `op_class=read`)
- [x] **AC5** synthesis model unconfigured/unreachable → `-32603`, never ungrounded — `test_tools_call_ask_docs_unconfigured_model_is_internal_error`

## Out of scope
- Optional `meho docs ask` CLI verb — deferred. `ask_docs` is MCP-tool-only; a CLI verb would need a new REST route + OpenAPI snapshot regen + Go client, beyond the MCP-tool MVP the issue prefers.
- Multi-turn / conversational `ask_docs` — single-shot Q→cited-A only.
- Re-ranking / weighting beyond what T3 retrieval returns (binary scope only, per #1177).
- The retrieval/federation path (T3, #1521) and the gating primitive (T1, #1519) are unchanged.

Adjacent finding (not fixed): `synthesize_docs_answer` trips the 64-line warn threshold (warn >60, blocks only >100); the bulk is the docstring and the body reads as a single linear flow, so it is left intact.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

Closes #1526
