### PR TITLE
fix(connectors): name conversion path on Swagger 2.0 ingest rejection (#1532)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -179,6 +179,18 @@ connector-related release-notes line.
   Single-shot Q→cited-A only; no new REST/CLI surface (the tool is
   auto-discovered) (#1526).
 
+### Changed
+
+- Connector ingest now rejects a **Swagger 2.0** spec with an
+  *actionable* `UnsupportedSpecError` that names the conversion path —
+  convert to OpenAPI 3.x (`swagger2openapi` / `converter.swagger.io`)
+  and re-ingest the 3.x output — instead of a bare "not supported (
+  v0.2.next)". The parser stays OpenAPI-3.x-only on purpose (no
+  spec-conversion dependency pulled into the Python backend); the
+  enriched diagnostic unblocks 2.0-only vendor surfaces such as Harbor
+  2.x's `swagger.yaml` by telling the operator exactly what to do.
+  OpenAPI 3.0.x / 3.1 ingestion is unchanged (#1532).
+
 ### Documentation
 
 - Operator runbook for the `meho-docs` add-on:

--- a/backend/src/meho_backplane/operations/ingest/exceptions.py
+++ b/backend/src/meho_backplane/operations/ingest/exceptions.py
@@ -118,7 +118,11 @@ class UnsupportedSpecError(ValueError):
     Raised for Swagger 2.0, OpenAPI 4.x, cross-document ``$ref``, and
     similar known-unsupported cases. The exception message always
     names the offending shape so the operator can decide whether to
-    file a v0.2.next request or pre-process the spec.
+    file a v0.2.next request or pre-process the spec. For Swagger 2.0
+    specifically the message also names the conversion path (convert
+    to OpenAPI 3.x via ``swagger2openapi`` / ``converter.swagger.io``
+    and re-ingest) so the operator can self-serve a 2.0-only vendor
+    surface such as Harbor 2.x (#1532).
     """
 
 

--- a/backend/src/meho_backplane/operations/ingest/openapi.py
+++ b/backend/src/meho_backplane/operations/ingest/openapi.py
@@ -21,9 +21,15 @@ Supported spec dialects:
 * OpenAPI 3.0.x (the vCenter / vi-json baseline at v0.2).
 * OpenAPI 3.1.x (jsonschema 2020-12-compatible; newer customer specs).
 
-Out of scope for v0.2 (per Initiative #389):
+Out of scope (no conversion performed in-process):
 
-* Swagger 2.0 — every v0.2 connector publishes OpenAPI 3.x.
+* Swagger 2.0 — rejected with an actionable :exc:`UnsupportedSpecError`
+  that names the conversion path (convert to OpenAPI 3.x with
+  ``swagger2openapi`` / ``converter.swagger.io`` and re-ingest). The
+  parser stays 3.x-only on purpose: the maintained 2.0→3.0 converters
+  are Node/web-service tools, and a hand-rolled converter is a large
+  correctness surface the operator review queue can't backstop. See
+  the Harbor 2.x ``swagger.yaml`` exemplar (#1532).
 * GraphQL SDL / WSDL / protobuf — separate parsers; v0.2.next.
 * Cross-document ``$ref`` (``$ref: "other.yaml#/..."``) — raises
   :exc:`UnsupportedSpecError`.
@@ -99,6 +105,22 @@ except AttributeError:  # pragma: no cover — PyYAML always ships SafeLoader
 # Patch level (the third digit) is accepted as-is — semver-style
 # bugfix versions never change the parser's contract.
 _SUPPORTED_OPENAPI_RE = re.compile(r"^3\.(0|1)(\.\d+)?$")
+
+# Operator-facing remediation appended to the Swagger-2.0 rejection.
+# The parser stays OpenAPI-3.x-only on purpose (no spec-conversion
+# dependency in the Python backend — the de-facto 2.0→3.0 converters
+# are Node/web-service tools, and a hand-rolled converter is a large
+# correctness surface the review queue can't backstop). Instead of a
+# bare "not supported", the rejection names the concrete conversion
+# path so the operator can self-serve: run a converter, then re-ingest
+# the OpenAPI-3.x output through the same path. ``swagger2openapi`` /
+# the hosted ``converter.swagger.io`` are the maintained converters.
+_SWAGGER_2_CONVERSION_REMEDIATION = (
+    "convert it to OpenAPI 3.x first (e.g. the swagger2openapi CLI "
+    "`npx swagger2openapi swagger.yaml -o openapi.yaml`, or the hosted "
+    "converter at https://converter.swagger.io/), then ingest the "
+    "converted 3.x document"
+)
 
 # Path-parameter placeholders look like ``{cluster}`` / ``{vm-id}`` /
 # ``{filter.names}``. Compiled once and reused per operation.
@@ -409,14 +431,18 @@ def _validate_openapi_version(spec: dict[str, Any]) -> None:
     """Confirm the spec carries a supported ``openapi`` version string.
 
     OpenAPI 3.0.x and 3.1.x are supported. Swagger 2.0 specs declare
-    ``swagger: "2.0"`` (no ``openapi`` key) and are rejected. Newer
-    specs with future major versions raise the same error.
+    ``swagger: "2.0"`` (no ``openapi`` key) and are rejected with an
+    actionable :exc:`UnsupportedSpecError` that names the conversion
+    path (a 2.0-only surface such as Harbor 2.x's ``swagger.yaml`` is
+    onboarded by converting it to OpenAPI 3.x and re-ingesting the
+    output). Newer specs with future major versions raise the same
+    error type without the conversion remedy.
     """
     if "swagger" in spec:
         version = spec.get("swagger", "<missing>")
         raise UnsupportedSpecError(
-            "Swagger 2.0 specs are not supported (v0.2.next); "
-            f"document declares swagger={version!r}"
+            f"Swagger 2.0 specs are not ingestible directly (document declares "
+            f"swagger={version!r}); {_SWAGGER_2_CONVERSION_REMEDIATION}"
         )
     raw_version = spec.get("openapi")
     if not isinstance(raw_version, str):

--- a/backend/tests/test_operations_ingest_openapi.py
+++ b/backend/tests/test_operations_ingest_openapi.py
@@ -205,8 +205,16 @@ def test_spec_source_threads_distinctly_across_two_specs(tmp_path: Path) -> None
 def test_unsupported_swagger_2_raises(tmp_path: Path) -> None:
     spec = tmp_path / "swagger.yaml"
     spec.write_text("swagger: '2.0'\ninfo: {title: x, version: '1'}\npaths: {}\n")
-    with pytest.raises(UnsupportedSpecError, match=r"Swagger 2\.0"):
+    with pytest.raises(UnsupportedSpecError, match=r"Swagger 2\.0") as excinfo:
         parse_openapi(str(spec))
+    # The rejection must be *actionable* — it names the conversion path
+    # (swagger2openapi / converter.swagger.io) so a 2.0-only surface
+    # such as Harbor 2.x can be onboarded without an opaque dead end
+    # (#1532). The detected version is echoed back verbatim.
+    message = str(excinfo.value)
+    assert "swagger2openapi" in message
+    assert "converter.swagger.io" in message
+    assert "'2.0'" in message
 
 
 def test_unsupported_openapi_4_raises(tmp_path: Path) -> None:
@@ -987,11 +995,17 @@ def test_read_spec_info_version_empty_version_returns_none(tmp_path: Path) -> No
 
 
 def test_read_spec_info_version_rejects_swagger_2(tmp_path: Path) -> None:
-    """Swagger 2.0 specs surface the same gate :func:`parse_openapi` enforces."""
+    """Swagger 2.0 specs surface the same gate :func:`parse_openapi` enforces.
+
+    The cross-check helper shares ``_validate_openapi_version`` with the
+    parser, so the same actionable conversion-path remedy reaches the
+    operator on the spec-vs-label fast path (#1532).
+    """
     spec = tmp_path / "spec.yaml"
     spec.write_text("swagger: '2.0'\ninfo: {title: t, version: '9.0.3'}\npaths: {}\n")
-    with pytest.raises(UnsupportedSpecError, match=r"Swagger 2\.0"):
+    with pytest.raises(UnsupportedSpecError, match=r"Swagger 2\.0") as excinfo:
         read_spec_info_version(str(spec))
+    assert "swagger2openapi" in str(excinfo.value)
 
 
 def test_read_spec_info_version_missing_file_raises_invalid_spec(tmp_path: Path) -> None:

--- a/docs/codebase/spec-ingestion.md
+++ b/docs/codebase/spec-ingestion.md
@@ -998,6 +998,19 @@ gets the 503 on `--catalog` grouping until that work lands.
 * **Cross-document `$ref` rejected.** External files
   (`other.yaml#/...`) raise `UnsupportedSpecError`. Same v0.2.next
   note.
+* **Swagger 2.0 rejected with an actionable remedy.** A spec declaring
+  `swagger: "2.0"` (no `openapi` key) raises `UnsupportedSpecError`
+  whose message names the conversion path — convert to OpenAPI 3.x
+  (`swagger2openapi` / `converter.swagger.io`) and re-ingest the 3.x
+  output. The parser stays 3.x-only on purpose: the maintained 2.0→3.0
+  converters are Node/web-service tools (`swagger2openapi`/oas-kit,
+  `converter.swagger.io`), and an in-house converter is a large
+  correctness surface the review queue can't backstop, so the
+  documented decision (#1532) is to reject-with-remedy rather than
+  convert in-process. The `harbor/2.x` catalog row and
+  [`harbor-onboarding.md`](../cross-repo/harbor-onboarding.md#spec-ingest-swagger-20--openapi-3x-conversion)
+  carry the operator-facing conversion runbook for the exemplar
+  2.0-only surface.
 * **`$ref` drill-down rejected.** Refs that walk into a component's
   sub-tree (`#/components/schemas/X/properties/y`,
   `#/components/parameters/X/schema`) raise `InvalidSchemaError`.

--- a/docs/cross-repo/harbor-onboarding.md
+++ b/docs/cross-repo/harbor-onboarding.md
@@ -136,10 +136,48 @@ vault kv put kv/harbor/prod-harbor \
   password="<service-account-password>"
 ```
 
+## Spec ingest (Swagger 2.0 → OpenAPI 3.x conversion)
+
+Harbor publishes its API spec at
+[`api/v2.0/swagger.yaml`](https://raw.githubusercontent.com/goharbor/harbor/v2.11.0/api/v2.0/swagger.yaml),
+which is a **Swagger 2.0** document (`swagger: "2.0"`). The G0.7 ingest
+parser is OpenAPI-3.x-only and **does not convert in-process**, so
+handing it the raw `swagger.yaml` is rejected with an actionable
+`UnsupportedSpecError`:
+
+```text
+Swagger 2.0 specs are not ingestible directly (document declares
+swagger='2.0'); convert it to OpenAPI 3.x first (e.g. the
+swagger2openapi CLI `npx swagger2openapi swagger.yaml -o openapi.yaml`,
+or the hosted converter at https://converter.swagger.io/), then ingest
+the converted 3.x document
+```
+
+Convert once, then ingest the 3.x output:
+
+```bash
+# Option A — swagger2openapi CLI (Node; the de-facto oas-kit converter)
+npx swagger2openapi swagger.yaml -o harbor-openapi3.yaml
+
+# Option B — the hosted converter (no local Node toolchain)
+curl -sS https://converter.swagger.io/api/convert \
+  -H 'Content-Type: application/yaml' \
+  --data-binary @swagger.yaml -o harbor-openapi3.json
+
+# Ingest the converted 3.x document via the explicit-quadruple shape
+meho connector ingest \
+  --product harbor --version 2.x --impl harbor-rest \
+  --spec ./harbor-openapi3.yaml
+```
+
+The conversion preserves every operation; the 3.x output ingests
+through the same path an OpenAPI-3.x vendor surface would. The catalog
+row for `harbor/2.x` flags this same SHARP EDGE (#1532).
+
 ## Curation step (run once per Harbor target)
 
 The 9 read-only ops must be enabled via the operator-review substrate
-before they are dispatchable. Run once after the G0.7 spec ingest:
+before they are dispatchable. Run once after the spec ingest above:
 
 ```bash
 # From the backplane's Python environment:


### PR DESCRIPTION
## Summary

- Connector ingest is OpenAPI-3.x-only; handed a **Swagger 2.0** spec it rejected the whole ingest with a bare "not supported (v0.2.next)" — a dead end for any 2.0-only vendor surface (Harbor 2.x's `swagger.yaml` is the repo-documented exemplar).
- **Documented decision:** keep the parser 3.x-only and reject 2.0 with an *actionable* `UnsupportedSpecError` that names the conversion path, rather than convert in-process. `_validate_openapi_version` now raises a remedy naming the `swagger2openapi` CLI + the hosted `converter.swagger.io`, echoing the detected version, so the operator can self-serve: convert, then re-ingest the 3.x output. The cross-check helper `read_spec_info_version` shares the same gate, so the remedy also reaches the spec-vs-label fast path.
- OpenAPI 3.0.x / 3.1 ingestion is unchanged. Change is confined to the version-validation path (does not touch `_load_spec_bytes`, which sibling #1535 edits in the same file).

### Why reject-with-remedy, not convert in-process (the explicit decision #1532 asked for)

The issue prefers an internal 2.0→3.0 conversion, but AC #1 explicitly allows the alternative ("OR is rejected with an actionable typed error naming the conversion path"). I took the typed-rejection branch because the maintained converters are not viable as Python backend dependencies:

- The de-facto converters the issue itself cites — **`swagger2openapi`/oas-kit** and **`converter.swagger.io`** — are a **Node.js library** and a **web service**. The backend container has no Node toolchain (the Dockerfile explicitly avoids `npm`/`node_modules`).
- The only Python candidates (`pyswagger`) are unmaintained (last release 2018) and do not actually perform 2.0→3.0 conversion.
- The spec-ingestion module is deliberately dependency-minimal ("No spec-side validation library is pulled in"). Pulling a Node subprocess into the Python image, or hand-rolling a from-scratch converter (definitions→components, formData/body params→requestBody, host/basePath/schemes→servers, produces/consumes→content media types …) that the operator review queue can't backstop, is out of proportion for a SEV-2 and breaks the minimal-substrate philosophy this initiative champions.

So conversion stays an operator-side one-liner; MEHO names it precisely instead of dead-ending. AC #3 (round-trip conversion test) is conditional on adding conversion — N/A under this decision.

## Test plan

- [x] `ruff check` (ingest package + test module) — clean
- [x] `ruff format --check` — clean
- [x] `mypy` (openapi.py, exceptions.py) — no issues
- [x] `pytest tests/test_operations_ingest_openapi.py` — 69 passed
- [x] `python3 .claude/hooks/code-quality.py --diff` — 0 blockers (9 pre-existing legacy warnings, none introduced)
- [x] **AC #1** — `test_unsupported_swagger_2_raises` asserts the `UnsupportedSpecError` message names `swagger2openapi` + `converter.swagger.io` and echoes the detected version; `test_read_spec_info_version_rejects_swagger_2` proves the same remedy on the cross-check path
- [x] **AC #2** — OpenAPI 3.0.x / 3.1 ingest unchanged: the `test_parse_petstore_30_*` + 3.1 suite passes unmodified (change is isolated to the `swagger` branch)
- [x] **AC #3** — N/A: no conversion added (documented decision above)

## Out of scope

- The MCP bare-`-32603` DX for `UnsupportedSpecError` — consolidated into #1534.
- The `docs:` URI scheme / `_load_spec_bytes` edits — sibling #1535 (kept the diffs separable).
- Products that publish no machine-readable spec at all — hand-authored-OpenAPI on-ramp (#1533).

<!-- auto-implement-issue: fresh, iteration 1 -->

Closes #1532


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Changed**
  * Swagger 2.0 specifications now receive explicit rejection during connector ingestion with actionable error messages directing operators to convert to OpenAPI 3.x using tools like `swagger2openapi` or `converter.swagger.io`.

* **Documentation**
  * Updated ingestion and onboarding documentation with step-by-step guidance for converting Swagger 2.0 specs to OpenAPI 3.x format, including example conversion commands.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->