### PR TITLE
feat(mcp): async-202 job-handle offload for meho.connector.ingest (#1531)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -178,6 +178,21 @@ connector-related release-notes line.
   (reusing the #1386 `LlmClientUnavailable` Anthropic-Messages precedent).
   Single-shot Q→cited-A only; no new REST/CLI surface (the tool is
   auto-discovered) (#1526).
+- `meho.connector.ingest` MCP tool gains an `async=true` mode + a
+  companion `meho.connector.ingest_status` poll tool (G3.5-T2),
+  carrying the #1303 REST async-202 offload to the agent-facing MCP
+  surface so a real vendor-spec ingest (e.g. SDDC Manager 9.0) returns
+  a job handle immediately instead of blocking the parse+register+LLM-
+  grouping pipeline past the agent's tool-call deadline. The async path
+  reuses the existing in-memory `IngestJobRegistry` + `run_ingest_job`,
+  so a job started over MCP is poll-able over the REST
+  `GET /api/v1/connectors/ingest/jobs/{job_id}` endpoint and vice versa;
+  the poll tool reports the run through to a terminal `succeeded`
+  (final ingestion + grouping counts) or `failed` (`error_class` +
+  `error`). `dry_run=true` and `async` unset keep the inline-return
+  shape (no regression). The ingest tools moved into a new
+  `connector_ingest` module alongside the existing `connector_admin`
+  review/edit tools (#1531).
 
 ### Documentation
 

--- a/backend/src/meho_backplane/mcp/tools/_connector_shared.py
+++ b/backend/src/meho_backplane/mcp/tools/_connector_shared.py
@@ -1,0 +1,97 @@
+# SPDX-License-Identifier: Apache-2.0
+# Copyright (c) 2026 evoila Group
+
+"""Shared constants + coercion helpers for the connector admin MCP tools.
+
+The connector admin surface is split across two tool modules by
+responsibility:
+
+* :mod:`meho_backplane.mcp.tools.connector_ingest` — the ingest
+  pipeline tools (``meho.connector.ingest`` + ``meho.connector.ingest_status``)
+  that wrap :class:`IngestionPipelineService` + the in-memory job registry.
+* :mod:`meho_backplane.mcp.tools.connector_admin` — the review /
+  edit / state-machine tools (``list`` / ``review`` / ``edit_group`` /
+  ``edit_op`` / ``enable`` / ``disable``) that wrap :class:`ReviewService`
+  and :func:`list_ingested_connectors`.
+
+Both modules share the ``connector_id`` / ``tenant_id`` schema snippets,
+the op-class taxonomy strings, and the JSON-safe serialiser; they live
+here so a future convention tweak edits one string instead of two
+modules — the single-source discipline #407 called out for the
+``connector_id`` description.
+"""
+
+from __future__ import annotations
+
+import json
+from typing import Any, Final
+from uuid import UUID
+
+# Op-class strings keep parity with the audit table conventions used
+# by :mod:`meho_backplane.broadcast.classify` for the credential /
+# audit / read / write taxonomy. List + review + ingest_status are
+# read; the ingest + mutators are write.
+_OP_CLASS_READ: Final[str] = "read"
+_OP_CLASS_WRITE: Final[str] = "write"
+
+
+# Shared snippet documenting the connector_id format on every tool
+# that accepts one. Authored once so a future convention tweak edits
+# one string instead of six.
+_CONNECTOR_ID_DESCRIPTION: Final[str] = (
+    "Operator-facing connector identifier — '<impl_id>-<version>' "
+    "(e.g. 'vmware-rest-9.0', 'vault-1.x'). Split into the parsed "
+    "(product, version, impl_id) triple by the same rule the CLI "
+    "uses."
+)
+
+#: Optional tenant scope shared across every tool. Omit (or pass
+#: ``null``) for the built-in / global connector pool — that scope is
+#: ``tenant_admin``-only. Pass the operator's own tenant UUID to
+#: operate on tenant-curated rows.
+_TENANT_ID_PROPERTY: Final[dict[str, Any]] = {
+    "type": ["string", "null"],
+    "format": "uuid",
+    "description": (
+        "Tenant scope for this operation. Omit or pass null for "
+        "built-in / global connectors (tenant_admin only). Pass the "
+        "operator's own tenant UUID for tenant-curated rows; cross-"
+        "tenant requests are rejected."
+    ),
+}
+
+
+def _coerce_tenant_id(raw: Any) -> UUID | None:
+    """Convert the ``tenant_id`` argument from JSON-RPC into ``UUID | None``.
+
+    The JSON-Schema-validated value is always either a UUID string or
+    ``None``; the helper preserves ``None`` and parses the string. A
+    malformed UUID surfaces at JSON-Schema validation time (because of
+    the ``format: uuid`` annotation interpreted by
+    :mod:`jsonschema`'s format-checker chain). This helper assumes the
+    schema validator has already run.
+    """
+    if raw is None:
+        return None
+    return UUID(raw)
+
+
+def _model_dump_json_safe(model: Any) -> dict[str, Any]:
+    """Serialise a Pydantic model to a JSON-safe dict.
+
+    Uses ``mode="json"`` so UUIDs and datetimes serialise as strings
+    rather than native Python objects (the dispatcher's
+    :func:`json.dumps` over the response would otherwise raise
+    :class:`TypeError`). Mirrors the meho_status reference tool's
+    serialisation discipline.
+    """
+    raw = model.model_dump(mode="json")
+    # Round-trip via ``json`` to surface any latent non-serialisable
+    # field at registration time rather than at the dispatcher's
+    # ``json.dumps`` call. The cost is one extra encode/decode per
+    # tool call; the benefit is that a Pydantic field shape that
+    # ``mode="json"`` can't handle (e.g. a future ``set[UUID]``) is
+    # rejected here with the offending field named in the traceback
+    # rather than as a generic dispatcher error.
+    rehydrated: dict[str, Any] = json.loads(json.dumps(raw))
+    return rehydrated

--- a/backend/src/meho_backplane/mcp/tools/connector_admin.py
+++ b/backend/src/meho_backplane/mcp/tools/connector_admin.py
@@ -1,19 +1,27 @@
 # SPDX-License-Identifier: Apache-2.0
 # Copyright (c) 2026 evoila Group
 
-"""Admin MCP tools for the connector ingest + review pipeline (G0.7-T7).
+"""Admin MCP tools for the connector review + state-machine surface (G0.7-T7).
 
-Seven tools under the ``meho.connector.*`` namespace, deliberately
+Six tools under the ``meho.connector.*`` namespace, deliberately
 separate from the agent-surface meta-tools
 (:mod:`~meho_backplane.mcp.tools.operations`):
 
-* ``meho.connector.ingest`` — run the ingest pipeline. **tenant_admin**.
 * ``meho.connector.list`` — list ingested connectors. **operator**.
 * ``meho.connector.review`` — get the review payload. **operator**.
 * ``meho.connector.edit_group`` — edit one group. **tenant_admin**.
 * ``meho.connector.edit_op`` — edit one op override. **tenant_admin**.
 * ``meho.connector.enable`` — flip the connector to enabled. **tenant_admin**.
 * ``meho.connector.disable`` — flip the connector to disabled. **tenant_admin**.
+
+The ingest-pipeline tools (``meho.connector.ingest`` +
+``meho.connector.ingest_status``) live in the sibling
+:mod:`meho_backplane.mcp.tools.connector_ingest` module; the two files
+split the admin tools by responsibility (pipeline vs. review) so
+neither grows past the code-quality file-size budget. The shared
+``connector_id`` / ``tenant_id`` schema snippets, op-class taxonomy
+strings, and JSON-safe serialiser live in
+:mod:`meho_backplane.mcp.tools._connector_shared`.
 
 Why these are not in the agent surface
 ======================================
@@ -45,12 +53,9 @@ Each tool's handler is a thin shim that wraps the canonical
 service layer T5 (CLI) and T6 (REST routes) also consume — there
 is no parallel "admin service" class here:
 
-1. ``meho.connector.ingest`` constructs a per-call
-   :class:`IngestionPipelineService` bound to the calling
-   :class:`Operator` and calls :meth:`IngestionPipelineService.ingest`.
-2. ``meho.connector.list`` calls the
+1. ``meho.connector.list`` calls the
    :func:`list_ingested_connectors` query helper directly.
-3. Every other tool constructs :class:`ReviewService` and
+2. Every other tool constructs :class:`ReviewService` and
    delegates to its existing read / edit / state-machine methods.
 
 PATCH-style handlers (``edit_group`` / ``edit_op``) build the
@@ -73,9 +78,10 @@ Per-tool ``inputSchema`` notes
 ==============================
 
 Every schema uses ``additionalProperties: false`` (issue AC 4). The
-``connector_id`` field appears on six of the seven tools (everything
-but ``ingest``) and is documented identically across them: an operator-
-facing ``<impl_id>-<version>`` string.
+``connector_id`` field appears on all six tools and is documented
+identically across them via the shared
+:data:`~meho_backplane.mcp.tools._connector_shared._CONNECTOR_ID_DESCRIPTION`
+snippet: an operator-facing ``<impl_id>-<version>`` string.
 
 The ``tenant_id`` field is optional everywhere. ``null`` / omitted →
 the built-in scope, which is accessible only to ``tenant_admin`` per
@@ -86,26 +92,23 @@ tenant-curated connectors.
 
 from __future__ import annotations
 
-import json
-from typing import Any, Final
-from uuid import UUID
+from typing import Any
 
 import structlog
 
-from meho_backplane.api.v1.connectors_ingest import get_llm_client_factory
 from meho_backplane.auth.operator import Operator, TenantRole
 from meho_backplane.mcp.registry import ToolDefinition, register_mcp_tool
-from meho_backplane.mcp.server import McpInvalidParamsError
+from meho_backplane.mcp.tools._connector_shared import (
+    _CONNECTOR_ID_DESCRIPTION,
+    _OP_CLASS_READ,
+    _OP_CLASS_WRITE,
+    _TENANT_ID_PROPERTY,
+    _coerce_tenant_id,
+    _model_dump_json_safe,
+)
 from meho_backplane.operations.ingest import (
     ConnectorStatusFilter,
-    IngestionPipelineService,
-    IngestRequest,
     ReviewService,
-    SpecSource,
-    UncoveredVersionLabel,
-    VersionMismatchError,
-    build_uncovered_version_label_detail,
-    build_version_mismatch_detail,
     list_ingested_connectors,
 )
 
@@ -114,156 +117,9 @@ __all__: list[str] = []
 _log = structlog.get_logger(__name__)
 
 
-# Op-class strings keep parity with the audit table conventions used
-# by :mod:`meho_backplane.broadcast.classify` for the credential /
-# audit / read / write taxonomy. List + review are read; the five
-# mutators are write.
-_OP_CLASS_READ: Final[str] = "read"
-_OP_CLASS_WRITE: Final[str] = "write"
-
-
-# Shared snippet documenting the connector_id format on every tool
-# that accepts one. Authored once so a future convention tweak edits
-# one string instead of six.
-_CONNECTOR_ID_DESCRIPTION: Final[str] = (
-    "Operator-facing connector identifier — '<impl_id>-<version>' "
-    "(e.g. 'vmware-rest-9.0', 'vault-1.x'). Split into the parsed "
-    "(product, version, impl_id) triple by the same rule the CLI "
-    "uses."
-)
-
-#: Optional tenant scope shared across every tool. Omit (or pass
-#: ``null``) for the built-in / global connector pool — that scope is
-#: ``tenant_admin``-only. Pass the operator's own tenant UUID to
-#: operate on tenant-curated rows.
-_TENANT_ID_PROPERTY: Final[dict[str, Any]] = {
-    "type": ["string", "null"],
-    "format": "uuid",
-    "description": (
-        "Tenant scope for this operation. Omit or pass null for "
-        "built-in / global connectors (tenant_admin only). Pass the "
-        "operator's own tenant UUID for tenant-curated rows; cross-"
-        "tenant requests are rejected."
-    ),
-}
-
-
-# ---------------------------------------------------------------------------
-# Argument coercion helpers
-# ---------------------------------------------------------------------------
-
-
-def _coerce_tenant_id(raw: Any) -> UUID | None:
-    """Convert the ``tenant_id`` argument from JSON-RPC into ``UUID | None``.
-
-    The JSON-Schema-validated value is always either a UUID string or
-    ``None``; the helper preserves ``None`` and parses the string. A
-    malformed UUID surfaces at JSON-Schema validation time (because of
-    the ``format: uuid`` annotation interpreted by
-    :mod:`jsonschema`'s format-checker chain). This helper assumes the
-    schema validator has already run.
-    """
-    if raw is None:
-        return None
-    return UUID(raw)
-
-
 # ---------------------------------------------------------------------------
 # Handler implementations
 # ---------------------------------------------------------------------------
-
-
-async def _ingest_handler(
-    operator: Operator,
-    arguments: dict[str, Any],
-) -> dict[str, Any]:
-    """Run the full T1 + T2 + T3 ingest pipeline.
-
-    Translates the MCP arguments into the canonical
-    :class:`IngestRequest` (from :mod:`api_schemas`) and delegates to
-    :meth:`IngestionPipelineService.ingest`. The handler reads the
-    **active** LLM-client factory via
-    :func:`meho_backplane.api.v1.connectors_ingest.get_llm_client_factory`,
-    so it shares the production factory FastAPI lifespan startup installs
-    (:func:`~meho_backplane.operations.ingest.build_anthropic_ingest_llm_client`,
-    reusing ``settings.anthropic_api_key``) rather than pinning the
-    fail-closed default — without this, the MCP surface would 503 even on
-    a deploy where the REST / CLI surfaces group successfully (#1386). On
-    a deploy that configured no key the factory still raises
-    :class:`LlmClientUnavailable`, surfaced here as the JSON-RPC error.
-
-    The response is the canonical :class:`IngestResponse` shape the
-    REST route at ``POST /api/v1/connectors/ingest`` also returns.
-    """
-    request = IngestRequest(
-        product=arguments["product"],
-        version=arguments["version"],
-        impl_id=arguments["impl_id"],
-        specs=[SpecSource(uri=spec["uri"]) for spec in arguments["specs"]],
-        base_url=arguments.get("base_url"),
-        dry_run=bool(arguments.get("dry_run", False)),
-    )
-    # Post-validator invariant: the MCP path always constructs the
-    # explicit-quadruple shape (the JSON-Schema layer doesn't expose
-    # ``catalog_entry`` — that lives only on the REST surface today),
-    # so product/version/impl_id are guaranteed non-None. The asserts
-    # pin the invariant for mypy after the schema's optional typing
-    # widened to support the REST ``catalog_entry`` shape
-    # (G0.14-T9 / #1150).
-    assert request.product is not None
-    assert request.version is not None
-    assert request.impl_id is not None
-    tenant_id = _coerce_tenant_id(arguments.get("tenant_id"))
-    service = IngestionPipelineService(
-        operator,
-        llm_client_factory=get_llm_client_factory(),
-    )
-    # G0.9.1-T5 (#777): VersionMismatchError + UncoveredVersionLabel are
-    # caller-input validation errors (the operator's ``version`` label
-    # is incompatible with the supplied spec / not covered by any
-    # registered class) — JSON-RPC ``-32602`` Invalid Params, with the
-    # structured detail on ``error.data`` per spec §5.1. Mirrors the
-    # REST 422 envelope built by
-    # :mod:`meho_backplane.api.v1.connectors_ingest`; the shared
-    # builders in :mod:`meho_backplane.operations.ingest.error_envelopes`
-    # are the single source of truth so the wire shape can't drift.
-    # Without this, the dispatcher's generic ``except Exception`` arm in
-    # :func:`meho_backplane.mcp.server._dispatch_to_handler` would
-    # surface ``-32603 "internal error: VersionMismatchError"`` and
-    # discard the (already-detailed) exception message — opaque to the
-    # agent operator and misclassified as a server fault.
-    try:
-        result = await service.ingest(
-            product=request.product,
-            version=request.version,
-            impl_id=request.impl_id,
-            specs=request.specs,
-            base_url=request.base_url,
-            tenant_id=tenant_id,
-            dry_run=request.dry_run,
-        )
-    except VersionMismatchError as exc:
-        raise McpInvalidParamsError(
-            str(exc),
-            data=build_version_mismatch_detail(exc),
-        ) from exc
-    except UncoveredVersionLabel as exc:
-        raise McpInvalidParamsError(
-            str(exc),
-            data=build_uncovered_version_label_detail(exc),
-        ) from exc
-    ingestion_model, grouping_model = result.to_api_models()
-    # Build the canonical IngestResponse manually rather than
-    # constructing a new instance and round-tripping the inner
-    # models — Pydantic's frozen=True forbids mutation on the way
-    # back out anyway, and the explicit shape here is the same wire
-    # contract the REST router emits.
-    return {
-        "ingestion": ingestion_model.model_dump(mode="json"),
-        "grouping": (
-            grouping_model.model_dump(mode="json") if grouping_model is not None else None
-        ),
-    }
 
 
 async def _list_handler(
@@ -389,87 +245,8 @@ async def _disable_handler(
 
 
 # ---------------------------------------------------------------------------
-# Serialisation helper
-# ---------------------------------------------------------------------------
-
-
-def _model_dump_json_safe(model: Any) -> dict[str, Any]:
-    """Serialise a Pydantic model to a JSON-safe dict.
-
-    Uses ``mode="json"`` so UUIDs and datetimes serialise as strings
-    rather than native Python objects (the dispatcher's
-    :func:`json.dumps` over the response would otherwise raise
-    :class:`TypeError`). Mirrors the meho_status reference tool's
-    serialisation discipline.
-    """
-    raw = model.model_dump(mode="json")
-    # Round-trip via ``json`` to surface any latent non-serialisable
-    # field at registration time rather than at the dispatcher's
-    # ``json.dumps`` call. The cost is one extra encode/decode per
-    # tool call; the benefit is that a Pydantic field shape that
-    # ``mode="json"`` can't handle (e.g. a future ``set[UUID]``) is
-    # rejected here with the offending field named in the traceback
-    # rather than as a generic dispatcher error.
-    rehydrated: dict[str, Any] = json.loads(json.dumps(raw))
-    return rehydrated
-
-
-# ---------------------------------------------------------------------------
 # Tool registrations
 # ---------------------------------------------------------------------------
-
-
-register_mcp_tool(
-    definition=ToolDefinition(
-        name="meho.connector.ingest",
-        description=(
-            "Ingest one or more OpenAPI specs into a MEHO connector "
-            "(tenant_admin only). Parses each spec, registers the "
-            "operations into the endpoint_descriptor table, and runs the "
-            "LLM-summarised grouping pass. The connector lands in "
-            "'staged' state — operators must review groups + per-op flags "
-            "and then call meho.connector.enable before the connector's "
-            "operations become dispatchable. "
-            "Use when adding a new vendor surface (product=vmware "
-            "version=9.0 impl_id=vmware-rest specs=[...]); supports "
-            "merging multiple specs under one connector (vSphere ingests "
-            "vcenter.yaml + vi-json.yaml). "
-            "Do NOT use for typed connectors (Vault, K8s, bind9) — those "
-            "register via register_typed_operation() at connector init "
-            "and never need this tool. Pass dry_run=true to validate "
-            "specs without writing to the DB."
-        ),
-        inputSchema={
-            "type": "object",
-            "properties": {
-                "product": {"type": "string", "minLength": 1, "maxLength": 64},
-                "version": {"type": "string", "minLength": 1, "maxLength": 64},
-                "impl_id": {"type": "string", "minLength": 1, "maxLength": 128},
-                "specs": {
-                    "type": "array",
-                    "minItems": 1,
-                    "maxItems": 16,
-                    "items": {
-                        "type": "object",
-                        "properties": {
-                            "uri": {"type": "string", "minLength": 1, "maxLength": 2048},
-                        },
-                        "required": ["uri"],
-                        "additionalProperties": False,
-                    },
-                },
-                "base_url": {"type": ["string", "null"], "maxLength": 2048},
-                "dry_run": {"type": "boolean", "default": False},
-                "tenant_id": _TENANT_ID_PROPERTY,
-            },
-            "required": ["product", "version", "impl_id", "specs"],
-            "additionalProperties": False,
-        },
-        required_role=TenantRole.TENANT_ADMIN,
-        op_class=_OP_CLASS_WRITE,
-    ),
-    handler=_ingest_handler,
-)
 
 
 register_mcp_tool(

--- a/backend/src/meho_backplane/mcp/tools/connector_ingest.py
+++ b/backend/src/meho_backplane/mcp/tools/connector_ingest.py
@@ -1,0 +1,516 @@
+# SPDX-License-Identifier: Apache-2.0
+# Copyright (c) 2026 evoila Group
+
+"""Ingest-pipeline MCP tools for the connector admin surface.
+
+Two tools under the ``meho.connector.*`` namespace that drive the
+spec-ingestion pipeline + its async job offload:
+
+* ``meho.connector.ingest`` — run the ingest pipeline. **tenant_admin**.
+* ``meho.connector.ingest_status`` — poll an async ingest job. **operator**.
+
+The review / edit / state-machine tools (``list`` / ``review`` /
+``edit_group`` / ``edit_op`` / ``enable`` / ``disable``) live in the
+sibling :mod:`meho_backplane.mcp.tools.connector_admin` module; the two
+files split the seven-plus-one admin tools by responsibility (pipeline
+vs. review) so neither grows past the code-quality file-size budget.
+Both import the shared schema snippets + coercion helpers from
+:mod:`meho_backplane.mcp.tools._connector_shared`.
+
+Async ingest offload (#1531)
+============================
+
+A real (``dry_run=false``) ingest of a real-world vendor OpenAPI spec
+(SDDC Manager 9.0, ~375 ops; vmware/9.0, 1275 ops) runs the parser +
+register + LLM-grouping pipeline for tens of seconds. Run inline on the
+MCP request, that blocks past the agent's tool-call deadline and the
+call times out with no handle to recover the result — the register +
+grouping phases still commit in their own sessions (no work is lost),
+but the agent can't confirm the connector populated.
+
+This tool carries the #1303 REST async-202 offload to the MCP surface,
+reusing the same in-memory
+:class:`~meho_backplane.operations.ingest.IngestJobRegistry` +
+:func:`~meho_backplane.operations.ingest.run_ingest_job` the REST route
+drives. With ``async=true`` (and ``dry_run=false``) the handler creates
+a job row, fires the pipeline off the request via
+:func:`asyncio.create_task`, and returns an
+:class:`~meho_backplane.operations.ingest.IngestJobHandle` immediately;
+the agent polls ``meho.connector.ingest_status`` to completion. A run
+started over MCP is poll-able over the REST
+``GET /api/v1/connectors/ingest/jobs/{job_id}`` endpoint and vice versa
+— the shared registry is the single source of truth, the same
+cross-surface property :mod:`meho_backplane.mcp.tools.agent_runs` has
+for agent runs (#811).
+
+``dry_run=true`` and ``async=false`` keep the existing **inline** shape
+— the pipeline runs on the request and the full
+:class:`~meho_backplane.operations.ingest.IngestResponse` returns
+synchronously. ``dry_run`` is the parse-only fast path (no DB / LLM
+hops); small-spec callers and CI fixtures stay synchronous by leaving
+``async`` unset. ``async`` is ignored on the dry-run path, mirroring
+the REST route.
+
+Error mapping
+=============
+
+``VersionMismatchError`` / ``UncoveredVersionLabel`` are caller-input
+validation errors that surface as JSON-RPC ``-32602`` with the shared
+structured detail on ``error.data`` (G0.9.1-T5 #777). These are only
+catchable on the **inline** path — the async path has already returned
+a handle by the time the pipeline raises, so a failure there flips the
+job to ``failed`` and the diagnostic surfaces via ``error`` /
+``error_class`` on the ``meho.connector.ingest_status`` response
+(same trade-off the REST async path makes). A missing / cross-tenant
+job id on the poll tool surfaces as ``-32602`` ``ingest_job_not_found``.
+"""
+
+from __future__ import annotations
+
+import asyncio
+from typing import Any, Final
+from uuid import UUID
+
+import structlog
+
+from meho_backplane.api.v1.connectors_ingest import get_llm_client_factory
+from meho_backplane.auth.operator import Operator, TenantRole
+from meho_backplane.mcp.registry import ToolDefinition, register_mcp_tool
+from meho_backplane.mcp.server import McpInvalidParamsError
+from meho_backplane.mcp.tools._connector_shared import (
+    _OP_CLASS_READ,
+    _OP_CLASS_WRITE,
+    _TENANT_ID_PROPERTY,
+    _coerce_tenant_id,
+    _model_dump_json_safe,
+)
+from meho_backplane.operations.ingest import (
+    IngestionPipelineResult,
+    IngestionPipelineService,
+    IngestJob,
+    IngestJobHandle,
+    IngestJobNotFoundError,
+    IngestJobStatusResponse,
+    IngestRequest,
+    SpecSource,
+    UncoveredVersionLabel,
+    VersionMismatchError,
+    build_uncovered_version_label_detail,
+    build_version_mismatch_detail,
+    get_job_registry,
+    run_ingest_job,
+)
+
+__all__: list[str] = []
+
+_log = structlog.get_logger(__name__)
+
+
+#: Strong references to in-flight background tasks. Python's
+#: :func:`asyncio.create_task` does not retain its tasks; without an
+#: external reference the garbage collector can drop the task
+#: mid-execution. Cleared by each task's completion callback so a
+#: steady stream of async ingests doesn't grow the set unbounded.
+#: Mirrors the REST route's ``_background_tasks`` map
+#: (:mod:`meho_backplane.api.v1.connectors_ingest`); the MCP surface
+#: keys by the task itself (a ``set``) rather than by job id because
+#: the MCP path has no cancel-by-id verb yet.
+_background_tasks: set[asyncio.Task[None]] = set()
+
+
+# ---------------------------------------------------------------------------
+# meho.connector.ingest
+# ---------------------------------------------------------------------------
+
+
+def _build_ingest_request(arguments: dict[str, Any]) -> IngestRequest:
+    """Translate the JSON-Schema-validated MCP arguments into an IngestRequest.
+
+    The MCP path always constructs the explicit-quadruple shape (the
+    JSON-Schema layer doesn't expose ``catalog_entry`` — that lives
+    only on the REST surface today), so product / version / impl_id are
+    guaranteed non-None after validation. The asserts pin the invariant
+    for mypy after the schema's optional typing widened to support the
+    REST ``catalog_entry`` shape (G0.14-T9 / #1150).
+    """
+    request = IngestRequest(
+        product=arguments["product"],
+        version=arguments["version"],
+        impl_id=arguments["impl_id"],
+        specs=[SpecSource(uri=spec["uri"]) for spec in arguments["specs"]],
+        base_url=arguments.get("base_url"),
+        dry_run=bool(arguments.get("dry_run", False)),
+    )
+    assert request.product is not None
+    assert request.version is not None
+    assert request.impl_id is not None
+    return request
+
+
+async def _ingest_handler(
+    operator: Operator,
+    arguments: dict[str, Any],
+) -> dict[str, Any]:
+    """Run the full T1 + T2 + T3 ingest pipeline (inline or async).
+
+    Translates the MCP arguments into the canonical
+    :class:`IngestRequest` and delegates to
+    :meth:`IngestionPipelineService.ingest`. The handler reads the
+    **active** LLM-client factory via
+    :func:`meho_backplane.api.v1.connectors_ingest.get_llm_client_factory`,
+    so it shares the production factory FastAPI lifespan startup installs
+    rather than pinning the fail-closed default (#1386).
+
+    ``async=true`` (and ``dry_run=false``) returns an
+    :class:`IngestJobHandle` immediately and runs the pipeline off the
+    request (#1531). ``dry_run=true`` / ``async=false`` keep the inline
+    shape and return the canonical :class:`IngestResponse`.
+    """
+    request = _build_ingest_request(arguments)
+    tenant_id = _coerce_tenant_id(arguments.get("tenant_id"))
+    service = IngestionPipelineService(
+        operator,
+        llm_client_factory=get_llm_client_factory(),
+    )
+    # Async offload only when the operator opted in *and* this is a real
+    # write — ``dry_run`` is the parse-only fast path that never blocks
+    # long enough to matter, so it stays inline and ``async`` is ignored
+    # there (mirrors the REST route).
+    if bool(arguments.get("async", False)) and not request.dry_run:
+        return await _spawn_async_ingest(
+            service=service,
+            request=request,
+            operator=operator,
+            tenant_id=tenant_id,
+        )
+    return await _run_inline_ingest(
+        service=service,
+        request=request,
+        tenant_id=tenant_id,
+    )
+
+
+async def _run_inline_ingest(
+    *,
+    service: IngestionPipelineService,
+    request: IngestRequest,
+    tenant_id: UUID | None,
+) -> dict[str, Any]:
+    """Run the pipeline on the request and return the canonical IngestResponse.
+
+    The inline path is the pre-#1531 behaviour, preserved verbatim for
+    ``dry_run=true`` and ``async=false`` callers (no regression). The
+    typed caller-input exceptions map to JSON-RPC ``-32602`` with the
+    shared structured detail on ``error.data`` (G0.9.1-T5 #777); the
+    shared builders in :mod:`operations/ingest/error_envelopes` are the
+    single source of truth so the REST 422 envelope and the MCP
+    ``error.data`` member can't drift.
+    """
+    assert request.product is not None
+    assert request.version is not None
+    assert request.impl_id is not None
+    try:
+        result = await service.ingest(
+            product=request.product,
+            version=request.version,
+            impl_id=request.impl_id,
+            specs=request.specs,
+            base_url=request.base_url,
+            tenant_id=tenant_id,
+            dry_run=request.dry_run,
+        )
+    except VersionMismatchError as exc:
+        raise McpInvalidParamsError(
+            str(exc),
+            data=build_version_mismatch_detail(exc),
+        ) from exc
+    except UncoveredVersionLabel as exc:
+        raise McpInvalidParamsError(
+            str(exc),
+            data=build_uncovered_version_label_detail(exc),
+        ) from exc
+    ingestion_model, grouping_model = result.to_api_models()
+    # Build the canonical IngestResponse shape manually — the explicit
+    # dict here is the same wire contract the REST router emits.
+    return {
+        "ingestion": ingestion_model.model_dump(mode="json"),
+        "grouping": (
+            grouping_model.model_dump(mode="json") if grouping_model is not None else None
+        ),
+    }
+
+
+async def _spawn_async_ingest(
+    *,
+    service: IngestionPipelineService,
+    request: IngestRequest,
+    operator: Operator,
+    tenant_id: UUID | None,
+) -> dict[str, Any]:
+    """Create a job row, fire the pipeline off the request, return a handle.
+
+    Carries the #1303 REST async-202 offload onto the MCP surface
+    (#1531). Reuses the shared :class:`IngestJobRegistry` +
+    :func:`run_ingest_job` the REST route drives, so a run started over
+    MCP is poll-able over REST and vice versa. The handle returns
+    immediately — well inside the agent's tool-call deadline — and the
+    long-running parse + register + LLM-grouping pass runs in a
+    background :func:`asyncio.create_task` (not the request).
+
+    The job is scoped to the operator's tenant; the poll tool applies
+    the same cross-tenant 404 conflation. A typed caller-input failure
+    (version mismatch / uncovered label) raised by the pipeline now
+    flips the job to ``failed`` and surfaces via the poll response's
+    ``error`` / ``error_class`` rather than as an inline ``-32602`` —
+    the same trade-off the REST async path documents.
+
+    ``request`` is already in the explicit-quadruple shape — its
+    product / version / impl_id are non-None (proven at construction by
+    :func:`_build_ingest_request`). :meth:`IngestJobRegistry.create`
+    takes ``str | None`` for those descriptors, so no re-assert is
+    needed here; the closure's stricter :meth:`ingest` call carries the
+    ``# type: ignore`` that pins the runtime guarantee for mypy.
+    """
+    registry = get_job_registry()
+    job = await registry.create(
+        operator_sub=operator.sub,
+        tenant_id=tenant_id,
+        catalog_entry=None,  # the MCP path is always explicit-quadruple
+        product=request.product,
+        version=request.version,
+        impl_id=request.impl_id,
+        spec_uris=[spec.uri for spec in request.specs],
+    )
+
+    async def _pipeline_call() -> IngestionPipelineResult:
+        return await service.ingest(
+            product=request.product,  # type: ignore[arg-type]
+            version=request.version,  # type: ignore[arg-type]
+            impl_id=request.impl_id,  # type: ignore[arg-type]
+            specs=request.specs,
+            base_url=request.base_url,
+            tenant_id=tenant_id,
+            dry_run=False,
+        )
+
+    # ``asyncio.create_task`` (not the request itself) so the work
+    # survives the tool call returning the handle. Parallels the REST
+    # route's ``_spawn_async_ingest`` and every other background-worker
+    # spawn in the backplane.
+    task = asyncio.create_task(
+        run_ingest_job(job.job_id, pipeline_call=_pipeline_call),
+        name=f"mcp-ingest-job-{job.job_id}",
+    )
+    _track_background_task(task)
+
+    handle = IngestJobHandle(
+        job_id=job.job_id,
+        status=job.status,
+        poll_url=f"/api/v1/connectors/ingest/jobs/{job.job_id}",
+    )
+    return _model_dump_json_safe(handle)
+
+
+def _track_background_task(task: asyncio.Task[None]) -> None:
+    """Hold a strong reference to *task* until it completes.
+
+    See :data:`_background_tasks` for the rationale — a bare
+    :func:`asyncio.create_task` task can be GC'd mid-execution if no
+    code retains a reference. The completion callback removes the
+    reference; double-removal is tolerated (``set.discard``).
+    """
+    _background_tasks.add(task)
+    task.add_done_callback(_background_tasks.discard)
+
+
+# ---------------------------------------------------------------------------
+# meho.connector.ingest_status
+# ---------------------------------------------------------------------------
+
+
+async def _ingest_status_handler(
+    operator: Operator,
+    arguments: dict[str, Any],
+) -> dict[str, Any]:
+    """Poll an async ingest job's durable status by handle.
+
+    Companion to the async path of :func:`_ingest_handler`. Reads the
+    in-memory :class:`IngestJob` row from the shared registry, applies
+    the tenant-isolation gate (a non-admin operator probing a built-in
+    job, or any operator probing another tenant's job, sees the same
+    ``ingest_job_not_found`` a missing id returns), and projects the
+    row into the :class:`IngestJobStatusResponse` wire shape the REST
+    poll endpoint also returns.
+
+    An unknown / cross-tenant / malformed handle surfaces as JSON-RPC
+    ``-32602`` (``handle must be a valid job id (UUID)`` /
+    ``ingest_job_not_found``) — the closest spec-blessed shape for
+    "bad input" / "not found", matching the connector-ingest error
+    convention.
+    """
+    raw = arguments["job_id"]
+    try:
+        job_id = UUID(raw)
+    except (ValueError, TypeError, AttributeError) as exc:
+        raise McpInvalidParamsError("handle must be a valid job id (UUID)") from exc
+    registry = get_job_registry()
+    try:
+        job = await registry.get(
+            job_id,
+            tenant_id=operator.tenant_id,
+            is_tenant_admin=operator.tenant_role is TenantRole.TENANT_ADMIN,
+        )
+    except IngestJobNotFoundError as exc:
+        raise McpInvalidParamsError("ingest_job_not_found") from exc
+    return _model_dump_json_safe(_job_to_response(job))
+
+
+def _job_to_response(job: IngestJob) -> IngestJobStatusResponse:
+    """Project an :class:`IngestJob` into its Pydantic response shape.
+
+    Mirrors the REST route's ``_job_to_response`` projection so the MCP
+    poll response and the REST poll response carry an identical wire
+    shape. A terminal success populates ``ingestion`` (+ optional
+    ``grouping``); a terminal failure populates ``error`` +
+    ``error_class``; ``running`` leaves both clusters ``None`` so
+    clients branch on ``status`` rather than presence-checking.
+    """
+    ingestion_model = None
+    grouping_model = None
+    if job.status == "succeeded" and job.result is not None:
+        ingestion_model, grouping_model = job.result.to_api_models()
+    return IngestJobStatusResponse(
+        job_id=job.job_id,
+        status=job.status,
+        catalog_entry=job.catalog_entry,
+        product=job.product,
+        version=job.version,
+        impl_id=job.impl_id,
+        spec_uris=list(job.spec_uris),
+        started_at=job.started_at,
+        ended_at=job.ended_at,
+        ingestion=ingestion_model,
+        grouping=grouping_model,
+        error=job.error,
+        error_class=job.error_class,
+    )
+
+
+# ---------------------------------------------------------------------------
+# Tool registrations
+# ---------------------------------------------------------------------------
+
+
+_INGEST_DESCRIPTION: Final[str] = (
+    "Ingest one or more OpenAPI specs into a MEHO connector "
+    "(tenant_admin only). Parses each spec, registers the operations "
+    "into the endpoint_descriptor table, and runs the LLM-summarised "
+    "grouping pass. The connector lands in 'staged' state — operators "
+    "must review groups + per-op flags and then call "
+    "meho.connector.enable before the connector's operations become "
+    "dispatchable. "
+    "Use when adding a new vendor surface (product=vmware version=9.0 "
+    "impl_id=vmware-rest specs=[...]); supports merging multiple specs "
+    "under one connector (vSphere ingests vcenter.yaml + vi-json.yaml). "
+    "For a real-world vendor spec set async=true to get a job handle "
+    "back immediately (the parse+register+grouping pass blocks past the "
+    "tool-call timeout otherwise); then poll meho.connector.ingest_status "
+    "with the returned job_id until status is 'succeeded' or 'failed'. "
+    "dry_run=true validates specs without writing and always returns "
+    "inline (async is ignored). "
+    "Do NOT use for typed connectors (Vault, K8s, bind9) — those "
+    "register via register_typed_operation() at connector init and "
+    "never need this tool."
+)
+
+
+register_mcp_tool(
+    definition=ToolDefinition(
+        name="meho.connector.ingest",
+        description=_INGEST_DESCRIPTION,
+        inputSchema={
+            "type": "object",
+            "properties": {
+                "product": {"type": "string", "minLength": 1, "maxLength": 64},
+                "version": {"type": "string", "minLength": 1, "maxLength": 64},
+                "impl_id": {"type": "string", "minLength": 1, "maxLength": 128},
+                "specs": {
+                    "type": "array",
+                    "minItems": 1,
+                    "maxItems": 16,
+                    "items": {
+                        "type": "object",
+                        "properties": {
+                            "uri": {"type": "string", "minLength": 1, "maxLength": 2048},
+                        },
+                        "required": ["uri"],
+                        "additionalProperties": False,
+                    },
+                },
+                "base_url": {"type": ["string", "null"], "maxLength": 2048},
+                "dry_run": {"type": "boolean", "default": False},
+                "async": {
+                    "type": "boolean",
+                    "default": False,
+                    "description": (
+                        "Return a job handle immediately and run the "
+                        "pipeline off the request, instead of blocking "
+                        "for the full parse + register + grouping pass. "
+                        "Required for real-world vendor specs, which "
+                        "block past the agent's tool-call deadline when "
+                        "run inline. Poll meho.connector.ingest_status "
+                        "with the returned job_id. Ignored when "
+                        "dry_run=true (the parse-only path stays inline)."
+                    ),
+                },
+                "tenant_id": _TENANT_ID_PROPERTY,
+            },
+            "required": ["product", "version", "impl_id", "specs"],
+            "additionalProperties": False,
+        },
+        required_role=TenantRole.TENANT_ADMIN,
+        op_class=_OP_CLASS_WRITE,
+    ),
+    handler=_ingest_handler,
+)
+
+
+register_mcp_tool(
+    definition=ToolDefinition(
+        name="meho.connector.ingest_status",
+        description=(
+            "Poll the durable status of an async connector-ingest job "
+            "by handle (operator-level). Use after a "
+            "meho.connector.ingest call made with async=true returned a "
+            "job_id — call this repeatedly until status is 'succeeded' "
+            "(carries the final ingestion + grouping counts so you can "
+            "confirm the connector populated) or 'failed' (carries "
+            "error_class + error). While the pipeline runs the status is "
+            "'running' and the result clusters are null; branch on "
+            "status rather than presence-checking the fields. Reads the "
+            "same in-memory job registry the REST "
+            "GET /api/v1/connectors/ingest/jobs/{job_id} endpoint uses, "
+            "so a run started over either surface is pollable from the "
+            "other. Do NOT use for a sync (inline) ingest — those return "
+            "the full result directly and mint no job_id. An unknown / "
+            "cross-tenant handle returns 'ingest_job_not_found'."
+        ),
+        inputSchema={
+            "type": "object",
+            "properties": {
+                "job_id": {
+                    "type": "string",
+                    "minLength": 1,
+                    "description": (
+                        "The job handle (a UUID) returned by an async meho.connector.ingest call."
+                    ),
+                },
+            },
+            "required": ["job_id"],
+            "additionalProperties": False,
+        },
+        required_role=TenantRole.OPERATOR,
+        op_class=_OP_CLASS_READ,
+    ),
+    handler=_ingest_status_handler,
+)

--- a/backend/tests/mcp_test_fixtures.py
+++ b/backend/tests/mcp_test_fixtures.py
@@ -156,6 +156,7 @@ def isolated_registry() -> Iterator[None]:
         audit,
         broadcast_overrides,
         connector_admin,
+        connector_ingest,
         docs,
         knowledge,
         meho_status,
@@ -180,6 +181,14 @@ def isolated_registry() -> Iterator[None]:
     # this fixture after the first one runs in the process.
     importlib.reload(result_query)
     importlib.reload(connector_admin)
+    # G3.5-T2 (#1531): the connector-ingest MCP tools
+    # (``meho.connector.ingest`` + ``meho.connector.ingest_status``) split
+    # out of ``connector_admin`` into their own module; they join the
+    # reload list for the same reason every other tool module does -- the
+    # autouse ``clear_registries()`` above would otherwise leave them
+    # unregistered in any test file that imports this fixture after the
+    # first one runs in the process.
+    importlib.reload(connector_ingest)
     importlib.reload(audit)
     importlib.reload(broadcast_overrides)
     # G6.4-T1 (#1091): meho.broadcast.recent (agent-facing read of recent

--- a/backend/tests/test_mcp_tools_connector_admin.py
+++ b/backend/tests/test_mcp_tools_connector_admin.py
@@ -1,14 +1,20 @@
 # SPDX-License-Identifier: Apache-2.0
 # Copyright (c) 2026 evoila Group
 
-"""Tests for the 7 admin MCP tools registered by G0.7-T7 (#407).
+"""Tests for the connector review / state-machine admin MCP tools (G0.7-T7 #407).
+
+Covers the six ``meho.connector.*`` review / edit / enable / disable
+tools. The ingest-pipeline tools (``meho.connector.ingest`` +
+``meho.connector.ingest_status``) split out into their own handler
+module (#1531) and are tested in
+``test_mcp_tools_connector_ingest.py``.
 
 Coverage matrix:
 
 * ``tools/list`` exposes the right subset of admin tools per role:
-  - ``read_only`` operator sees ZERO ``meho.connector.*`` tools.
+  - ``read_only`` operator sees ZERO of these ``meho.connector.*`` tools.
   - ``operator`` operator sees the 2 read tools (``list`` + ``review``).
-  - ``tenant_admin`` operator sees all 7 tools.
+  - ``tenant_admin`` operator sees all six review / edit tools.
 * Each tool's ``inputSchema`` is strict JSON-Schema 2020-12 with
   ``additionalProperties: false`` (#407 AC 4).
 * Tool descriptions name when to use / when not to (AI engineering
@@ -16,8 +22,6 @@ Coverage matrix:
 * ``tools/call`` dispatch to a stubbed canonical service layer:
   - ``meho.connector.list`` returns the stubbed ConnectorListItem rows.
   - ``meho.connector.review`` returns the stubbed ConnectorReviewPayload.
-  - ``meho.connector.ingest`` (tenant_admin) wires the request through
-    :class:`IngestionPipelineService`.
   - ``meho.connector.edit_group`` writes via ReviewService and only
     forwards explicitly named fields (PATCH-semantic intent).
   - ``meho.connector.enable`` flips status via ReviewService.
@@ -26,12 +30,10 @@ Coverage matrix:
   envelope) even when guessing the tool name.
 
 Why we stub the canonical service layer rather than spin up a real
-:class:`IngestionPipelineService`: the production service touches the
-DB, the embedding pipeline, and an injectable LLM client; a unit test
-that drives all three is the canary on T8 (#408). These tests are
-about the MCP handler shim — the contract under test is "the handler
-converts MCP arguments into the canonical service-layer call shape
-correctly", not "the pipeline ingests vSphere".
+:class:`ReviewService`: the production service touches the DB; a unit
+test that drives it is the canary on T8 (#408). These tests are about
+the MCP handler shim — the contract under test is "the handler converts
+MCP arguments into the canonical service-layer call shape correctly".
 """
 
 from __future__ import annotations
@@ -43,20 +45,13 @@ from typing import Any
 import pytest
 from fastapi.testclient import TestClient
 
-from meho_backplane.api.v1.connectors_ingest import get_llm_client_factory
 from meho_backplane.auth.operator import Operator, TenantRole
 from meho_backplane.operations.ingest import (
     ConnectorListItem,
     ConnectorReviewGroup,
     ConnectorReviewPayload,
-    GroupingResult,
-    IngestionPipelineResult,
-    IngestionResult,
-    UncoveredVersionLabel,
-    VersionMismatchError,
 )
 from tests.mcp_test_fixtures import (
-    OPERATOR_TENANT_ID,
     client_with_operator,  # noqa: F401 — pytest-discovered fixture
     isolated_registry,  # noqa: F401 — pytest-discovered autouse fixture
     post_mcp,
@@ -66,43 +61,6 @@ from tests.mcp_test_fixtures import (
 # ---------------------------------------------------------------------------
 # Canonical service-layer stubs (T6's #488 surface)
 # ---------------------------------------------------------------------------
-
-
-class _FakeIngestionPipelineService:
-    """Records every ingest call + returns a canned IngestionPipelineResult."""
-
-    def __init__(self, operator: Operator, **kwargs: Any) -> None:
-        self.operator = operator
-        self.init_kwargs = kwargs
-        self.ingest_calls: list[dict[str, Any]] = []
-
-    async def ingest(self, **kwargs: Any) -> IngestionPipelineResult:
-        self.ingest_calls.append(kwargs)
-        connector_id = f"{kwargs['impl_id']}-{kwargs['version']}"
-        ingestion = IngestionResult(
-            inserted_count=10,
-            updated_count=0,
-            skipped_count=0,
-            connector_registered=True,
-            operations_grouped=False,
-        )
-        grouping = (
-            None
-            if kwargs.get("dry_run")
-            else GroupingResult(
-                connector_id=connector_id,
-                groups_created=3,
-                operations_assigned=10,
-                operations_unassigned=0,
-                llm_call_count=2,
-                llm_duration_ms=123.4,
-            )
-        )
-        return IngestionPipelineResult(
-            connector_id=connector_id,
-            ingestion=ingestion,
-            grouping=grouping,
-        )
 
 
 class _FakeReviewService:
@@ -172,25 +130,15 @@ class _FakeReviewService:
 def stubbed_services(monkeypatch: pytest.MonkeyPatch) -> Iterator[dict[str, Any]]:
     """Patch the canonical service classes the MCP handlers construct.
 
-    The handler module resolved :class:`IngestionPipelineService` and
-    :class:`ReviewService` at import time from
-    :mod:`meho_backplane.operations.ingest`, and
+    The handler module resolved :class:`ReviewService` at import time
+    from :mod:`meho_backplane.operations.ingest`, and
     :func:`list_ingested_connectors` similarly. Patching those names
     on the handler module's local reference is the cleanest seam —
     subsequent constructor / function calls inside the handlers
     resolve to the fakes for the duration of the fixture.
     """
-    captured_pipeline: list[_FakeIngestionPipelineService] = []
     captured_review: list[_FakeReviewService] = []
     captured_list_calls: list[dict[str, Any]] = []
-
-    def _pipeline_factory(
-        operator: Operator,
-        **kwargs: Any,
-    ) -> _FakeIngestionPipelineService:
-        instance = _FakeIngestionPipelineService(operator, **kwargs)
-        captured_pipeline.append(instance)
-        return instance
 
     def _review_factory(operator: Operator, **_kwargs: Any) -> _FakeReviewService:
         instance = _FakeReviewService(operator)
@@ -218,12 +166,10 @@ def stubbed_services(monkeypatch: pytest.MonkeyPatch) -> Iterator[dict[str, Any]
 
     import meho_backplane.mcp.tools.connector_admin as ca_mod
 
-    monkeypatch.setattr(ca_mod, "IngestionPipelineService", _pipeline_factory)
     monkeypatch.setattr(ca_mod, "ReviewService", _review_factory)
     monkeypatch.setattr(ca_mod, "list_ingested_connectors", _fake_list_ingested_connectors)
 
     yield {
-        "pipeline": captured_pipeline,
         "review": captured_review,
         "list_calls": captured_list_calls,
     }
@@ -234,8 +180,12 @@ def stubbed_services(monkeypatch: pytest.MonkeyPatch) -> Iterator[dict[str, Any]
 # ---------------------------------------------------------------------------
 
 
+# The review / edit / state-machine tools this module owns. The
+# ingest-pipeline tools (``meho.connector.ingest`` +
+# ``meho.connector.ingest_status``) moved to
+# ``test_mcp_tools_connector_ingest.py`` alongside their handler module
+# (#1531); they're asserted there, not here.
 _ADMIN_TOOL_NAMES = {
-    "meho.connector.ingest",
     "meho.connector.list",
     "meho.connector.review",
     "meho.connector.edit_group",
@@ -466,103 +416,6 @@ def test_call_meho_connector_review_dispatches_to_review_service(
 
     [review] = stubbed_services["review"]
     assert review.review_calls == [("vmware-rest-9.0", None)]
-
-
-@pytest.mark.parametrize(
-    "client_with_operator",
-    [TenantRole.TENANT_ADMIN],
-    indirect=True,
-)
-def test_call_meho_connector_ingest_threads_specs_through(
-    client_with_operator: tuple[TestClient, Operator],  # noqa: F811
-    stubbed_services: dict[str, Any],
-) -> None:
-    """Ingest tool forwards specs + flags + tenant_id to the pipeline service."""
-    client, _op = client_with_operator
-    response = post_mcp(
-        client,
-        {
-            "jsonrpc": "2.0",
-            "id": 1,
-            "method": "tools/call",
-            "params": {
-                "name": "meho.connector.ingest",
-                "arguments": {
-                    "product": "vmware",
-                    "version": "9.0",
-                    "impl_id": "vmware-rest",
-                    "specs": [
-                        {"uri": "docs:vcenter-9.0/vcenter.yaml"},
-                        {"uri": "docs:vcenter-9.0/vi-json.yaml"},
-                    ],
-                    "dry_run": True,
-                    "tenant_id": str(OPERATOR_TENANT_ID),
-                },
-            },
-        },
-    )
-    assert response.status_code == 200
-    payload = _unwrap_text_content(response.json())
-    # The canonical IngestResponse shape: nested ingestion + grouping.
-    assert payload["ingestion"]["connector_id"] == "vmware-rest-9.0"
-    assert payload["ingestion"]["inserted_count"] == 10
-    # Dry-run path: no grouping result.
-    assert payload["grouping"] is None
-
-    [pipeline] = stubbed_services["pipeline"]
-    [call_kwargs] = pipeline.ingest_calls
-    assert call_kwargs["product"] == "vmware"
-    assert call_kwargs["version"] == "9.0"
-    assert call_kwargs["impl_id"] == "vmware-rest"
-    assert call_kwargs["tenant_id"] == OPERATOR_TENANT_ID
-    assert call_kwargs["dry_run"] is True
-    assert len(call_kwargs["specs"]) == 2
-    assert call_kwargs["specs"][0].uri == "docs:vcenter-9.0/vcenter.yaml"
-    assert call_kwargs["specs"][1].uri == "docs:vcenter-9.0/vi-json.yaml"
-    # The MCP tool reads the *active* lifespan-wired factory holder via
-    # get_llm_client_factory() rather than pinning the fail-closed
-    # default (#1386) — so it shares whatever REST/CLI use. The
-    # TestClient lifespan wired build_anthropic_ingest_llm_client, so the
-    # factory the pipeline received is identically the active holder. (If
-    # the tool still hardcoded default_llm_client_factory, this would now
-    # fail, since lifespan changed the holder away from the default.)
-    assert pipeline.init_kwargs.get("llm_client_factory") is get_llm_client_factory()
-
-
-@pytest.mark.parametrize(
-    "client_with_operator",
-    [TenantRole.TENANT_ADMIN],
-    indirect=True,
-)
-def test_call_meho_connector_ingest_returns_grouping_when_not_dry_run(
-    client_with_operator: tuple[TestClient, Operator],  # noqa: F811
-    stubbed_services: dict[str, Any],
-) -> None:
-    """Non-dry-run path returns both ingestion + grouping in IngestResponse."""
-    client, _op = client_with_operator
-    response = post_mcp(
-        client,
-        {
-            "jsonrpc": "2.0",
-            "id": 1,
-            "method": "tools/call",
-            "params": {
-                "name": "meho.connector.ingest",
-                "arguments": {
-                    "product": "vmware",
-                    "version": "9.0",
-                    "impl_id": "vmware-rest",
-                    "specs": [{"uri": "docs:vcenter-9.0/vcenter.yaml"}],
-                    "tenant_id": str(OPERATOR_TENANT_ID),
-                },
-            },
-        },
-    )
-    assert response.status_code == 200
-    payload = _unwrap_text_content(response.json())
-    assert payload["ingestion"]["connector_id"] == "vmware-rest-9.0"
-    assert payload["grouping"]["groups_created"] == 3
-    assert payload["grouping"]["operations_assigned"] == 10
 
 
 @pytest.mark.parametrize(
@@ -818,182 +671,3 @@ def test_operator_role_cannot_call_tenant_admin_mutator(
     assert not stubbed_services["review"], (
         "operator role bypassed RBAC and reached the service layer"
     )
-
-
-# ---------------------------------------------------------------------------
-# G0.9.1-T5 (#777) — structured error envelopes on the MCP ingest path
-# ---------------------------------------------------------------------------
-
-
-class _RaisingIngestionPipelineService:
-    """A pipeline-service double whose ``ingest`` raises a pinned exception.
-
-    Used to exercise the typed-exception branches in
-    :func:`meho_backplane.mcp.tools.connector_admin._ingest_handler` without
-    spinning up the real DB-touching pipeline. Mirrors the
-    :class:`_FakeIngestionPipelineService` constructor signature so the
-    same monkeypatch seam in the production module works.
-    """
-
-    def __init__(self, exc: Exception) -> None:
-        self._exc = exc
-
-    def __call__(self, operator: Operator, **_kwargs: Any) -> _RaisingIngestionPipelineService:
-        # Reused as a factory: ``IngestionPipelineService(operator, ...)``
-        # in :mod:`connector_admin` calls this instance which returns
-        # itself, so a single fixture instance can serve one request.
-        return self
-
-    async def ingest(self, **_kwargs: Any) -> IngestionPipelineResult:
-        raise self._exc
-
-
-@pytest.fixture
-def patched_pipeline_raising_version_mismatch(
-    monkeypatch: pytest.MonkeyPatch,
-) -> VersionMismatchError:
-    """Install a pipeline service that raises a canned :class:`VersionMismatchError`.
-
-    Returns the exception instance so the test can compare its
-    structured attributes against the wire envelope verbatim.
-    """
-    exc = VersionMismatchError(
-        kind="spec_label_mismatch",
-        requested_version="8.0",
-        spec_info_versions=[("docs:vcenter-9.0/vcenter.yaml", "9.0.3")],
-    )
-    import meho_backplane.mcp.tools.connector_admin as ca_mod
-
-    monkeypatch.setattr(ca_mod, "IngestionPipelineService", _RaisingIngestionPipelineService(exc))
-    return exc
-
-
-@pytest.fixture
-def patched_pipeline_raising_uncovered_version(
-    monkeypatch: pytest.MonkeyPatch,
-) -> UncoveredVersionLabel:
-    """Install a pipeline service that raises a canned :class:`UncoveredVersionLabel`."""
-    exc = UncoveredVersionLabel(
-        product="t9-vmware",
-        version="7.0",
-        impl_id="t9-vmware-rest",
-        candidates=[("9.0", "t9-vmware-rest", "_RangedTestConnector", ">=8.5,<10.0")],
-    )
-    import meho_backplane.mcp.tools.connector_admin as ca_mod
-
-    monkeypatch.setattr(ca_mod, "IngestionPipelineService", _RaisingIngestionPipelineService(exc))
-    return exc
-
-
-@pytest.mark.parametrize(
-    "client_with_operator",
-    [TenantRole.TENANT_ADMIN],
-    indirect=True,
-)
-def test_call_meho_connector_ingest_version_mismatch_returns_invalid_params(
-    client_with_operator: tuple[TestClient, Operator],  # noqa: F811
-    patched_pipeline_raising_version_mismatch: VersionMismatchError,
-) -> None:
-    """Spec/label version mismatch surfaces as JSON-RPC ``-32602`` with structured ``data``.
-
-    AC #1 / AC #3 / AC #4. Pre-fix the dispatcher's catch-all wrapped
-    the exception as ``-32603 "internal error: VersionMismatchError"``,
-    discarding the (already-detailed) message. The fix raises
-    :class:`McpInvalidParamsError` with the shared
-    :func:`build_version_mismatch_detail` envelope on ``error.data``
-    so the operator-facing agent can self-correct without re-prompting.
-    """
-    client, _op = client_with_operator
-    response = post_mcp(
-        client,
-        {
-            "jsonrpc": "2.0",
-            "id": 1,
-            "method": "tools/call",
-            "params": {
-                "name": "meho.connector.ingest",
-                "arguments": {
-                    "product": "vmware",
-                    "version": "8.0",
-                    "impl_id": "vmware-rest",
-                    "specs": [{"uri": "docs:vcenter-9.0/vcenter.yaml"}],
-                },
-            },
-        },
-    )
-    assert response.status_code == 200
-    body = response.json()
-    assert "error" in body, body
-    # Caller-input validation, not a server fault — ``-32602``, NOT ``-32603``.
-    assert body["error"]["code"] == -32602, body["error"]
-    # The rendered message names both versions so a bare-string client
-    # still gets a self-correcting hint.
-    assert "9.0.3" in body["error"]["message"]
-    assert "8.0" in body["error"]["message"]
-    # The structured ``data`` member carries the same shape the REST
-    # 422 detail uses (G0.9-T8 #740) — both routes share
-    # :func:`build_version_mismatch_detail`.
-    data = body["error"]["data"]
-    assert data["kind"] == "spec_label_mismatch"
-    assert data["requested_version"] == "8.0"
-    assert data["spec_info_versions"] == [
-        {"spec_uri": "docs:vcenter-9.0/vcenter.yaml", "info_version": "9.0.3"},
-    ]
-    assert "9.0.3" in data["message"]
-
-
-@pytest.mark.parametrize(
-    "client_with_operator",
-    [TenantRole.TENANT_ADMIN],
-    indirect=True,
-)
-def test_call_meho_connector_ingest_uncovered_version_returns_invalid_params(
-    client_with_operator: tuple[TestClient, Operator],  # noqa: F811
-    patched_pipeline_raising_uncovered_version: UncoveredVersionLabel,
-) -> None:
-    """Uncovered ``version`` label surfaces as ``-32602`` with the registered ranges.
-
-    AC #2 / AC #3 / AC #4. The structured ``data`` enumerates every
-    registered class for the ``(product, impl_id)`` pair so the agent
-    picks a label inside one of the advertised ranges and retries
-    without re-prompting the operator.
-    """
-    client, _op = client_with_operator
-    response = post_mcp(
-        client,
-        {
-            "jsonrpc": "2.0",
-            "id": 1,
-            "method": "tools/call",
-            "params": {
-                "name": "meho.connector.ingest",
-                "arguments": {
-                    "product": "t9-vmware",
-                    "version": "7.0",
-                    "impl_id": "t9-vmware-rest",
-                    "specs": [{"uri": "docs:vcenter-9.0/vcenter.yaml"}],
-                },
-            },
-        },
-    )
-    assert response.status_code == 200
-    body = response.json()
-    assert "error" in body, body
-    assert body["error"]["code"] == -32602, body["error"]
-    # Rendered message mentions the label + at least one supported
-    # range so the agent has the diagnostic in plain prose too.
-    assert "version='7.0'" in body["error"]["message"]
-    assert ">=8.5,<10.0" in body["error"]["message"]
-    data = body["error"]["data"]
-    assert data["product"] == "t9-vmware"
-    assert data["version"] == "7.0"
-    assert data["impl_id"] == "t9-vmware-rest"
-    assert data["registered_classes"] == [
-        {
-            "class_name": "_RangedTestConnector",
-            "version": "9.0",
-            "impl_id": "t9-vmware-rest",
-            "supported_version_range": ">=8.5,<10.0",
-        },
-    ]
-    assert "_RangedTestConnector" in data["message"]

--- a/backend/tests/test_mcp_tools_connector_ingest.py
+++ b/backend/tests/test_mcp_tools_connector_ingest.py
@@ -1,0 +1,625 @@
+# SPDX-License-Identifier: Apache-2.0
+# Copyright (c) 2026 evoila Group
+
+"""Tests for the connector-ingest MCP tools (G3.5-T2 / #1531).
+
+Covers ``meho.connector.ingest`` + ``meho.connector.ingest_status``,
+the ingest-pipeline tools split out of ``connector_admin`` into
+:mod:`meho_backplane.mcp.tools.connector_ingest`. The review / edit /
+state-machine tools are tested in ``test_mcp_tools_connector_admin.py``.
+
+Coverage matrix:
+
+* ``tools/list`` visibility per role:
+  - ``read_only`` sees neither ingest tool.
+  - ``operator`` sees ``ingest_status`` (read) but NOT ``ingest`` (write).
+  - ``tenant_admin`` sees both.
+* Both tools' ``inputSchema`` is strict JSON-Schema 2020-12 with
+  ``additionalProperties: false``; descriptions name when (not) to use.
+* **Inline path** (``dry_run=true`` / ``async`` unset) returns the
+  canonical ``IngestResponse`` synchronously — the pre-#1531 behaviour
+  (no regression). Specs + flags + tenant_id thread through to the
+  service.
+* **Inline error envelopes**: ``VersionMismatchError`` /
+  ``UncoveredVersionLabel`` map to JSON-RPC ``-32602`` with structured
+  ``error.data`` (the inherited G0.9.1-T5 #777 contract).
+* **Async path** (``async=true``, ``dry_run=false``) returns a job
+  handle *before* the pipeline finishes (AC #1: prompt return, no block
+  on the grouping pass), and ``ingest_status`` polls the job through to
+  a terminal ``succeeded`` carrying the final counts (AC #2). A failure
+  surfaces via ``error`` / ``error_class`` on the poll response.
+* ``ingest_status`` tenant-isolation: a cross-tenant / unknown / built-in
+  handle returns ``ingest_job_not_found`` (``-32602``).
+
+The async / dispatch behaviour is unit-tested by calling the handler
+coroutines directly (``asyncio_mode = "auto"`` runs them on the test's
+event loop) with a controllable pipeline stub — the sync ``TestClient``
+portal tears the background task down on response return, which would
+defeat the "returns before the pipeline completes" contract these
+tests pin. The visibility / schema checks drive the real MCP transport.
+"""
+
+from __future__ import annotations
+
+import asyncio
+from collections.abc import Iterator
+from typing import Any
+
+import pytest
+from fastapi.testclient import TestClient
+
+import meho_backplane.mcp.tools.connector_ingest as ci_mod
+from meho_backplane.auth.operator import Operator, TenantRole
+from meho_backplane.mcp.server import McpInvalidParamsError
+from meho_backplane.operations.ingest import (
+    GroupingResult,
+    IngestionPipelineResult,
+    IngestionResult,
+    UncoveredVersionLabel,
+    VersionMismatchError,
+    get_job_registry,
+    reset_job_registry_for_tests,
+)
+from tests.mcp_test_fixtures import (
+    OPERATOR_TENANT_ID,
+    build_operator,
+    client_with_operator,  # noqa: F401 — pytest-discovered fixture
+    isolated_registry,  # noqa: F401 — pytest-discovered autouse fixture
+    post_mcp,
+    required_settings_env,  # noqa: F401 — pytest-discovered autouse fixture
+)
+
+_INGEST_TOOL = "meho.connector.ingest"
+_INGEST_STATUS_TOOL = "meho.connector.ingest_status"
+
+
+@pytest.fixture(autouse=True)
+def _isolated_job_registry() -> Iterator[None]:
+    """Reset the process-local ingest job registry around each test.
+
+    The handler drives the real :class:`IngestJobRegistry` singleton via
+    :func:`get_job_registry`; resetting it before and after keeps async
+    job rows from one test from leaking into the next.
+    """
+    reset_job_registry_for_tests()
+    yield
+    reset_job_registry_for_tests()
+
+
+def _canned_result(
+    *,
+    dry_run: bool,
+    connector_id: str = "vmware-rest-9.0",
+) -> IngestionPipelineResult:
+    """Build a representative pipeline result (grouping omitted on dry-run)."""
+    ingestion = IngestionResult(
+        inserted_count=10,
+        updated_count=0,
+        skipped_count=0,
+        connector_registered=True,
+        operations_grouped=not dry_run,
+    )
+    grouping = (
+        None
+        if dry_run
+        else GroupingResult(
+            connector_id=connector_id,
+            groups_created=3,
+            operations_assigned=10,
+            operations_unassigned=0,
+            llm_call_count=2,
+            llm_duration_ms=123.4,
+        )
+    )
+    return IngestionPipelineResult(
+        connector_id=connector_id,
+        ingestion=ingestion,
+        grouping=grouping,
+    )
+
+
+class _FakeIngestionPipelineService:
+    """Records every ingest call + returns a canned result.
+
+    Reused as a factory: the production handler calls
+    ``IngestionPipelineService(operator, llm_client_factory=...)`` which
+    resolves to ``__call__`` here, returning the same instance so a
+    single fixture can capture the call.
+    """
+
+    def __init__(self) -> None:
+        self.init_kwargs: dict[str, Any] = {}
+        self.ingest_calls: list[dict[str, Any]] = []
+
+    def __call__(self, operator: Operator, **kwargs: Any) -> _FakeIngestionPipelineService:
+        self.operator = operator
+        self.init_kwargs = kwargs
+        return self
+
+    async def ingest(self, **kwargs: Any) -> IngestionPipelineResult:
+        self.ingest_calls.append(kwargs)
+        return _canned_result(dry_run=bool(kwargs.get("dry_run")))
+
+
+class _BlockingIngestionPipelineService:
+    """A pipeline stub whose ``ingest`` blocks until a gate is released.
+
+    Used by the async-path test to prove the tool returns a handle
+    *before* the pipeline finishes: the handler fires the pipeline off
+    the request via ``asyncio.create_task`` and returns the handle while
+    ``ingest`` is still parked on :attr:`gate`. Releasing the gate lets
+    the background task complete, after which the poll tool reports
+    ``succeeded``.
+    """
+
+    def __init__(self) -> None:
+        self.gate = asyncio.Event()
+        self.started = asyncio.Event()
+        self.ingest_calls: list[dict[str, Any]] = []
+
+    def __call__(self, operator: Operator, **_kwargs: Any) -> _BlockingIngestionPipelineService:
+        return self
+
+    async def ingest(self, **kwargs: Any) -> IngestionPipelineResult:
+        self.ingest_calls.append(kwargs)
+        self.started.set()
+        await self.gate.wait()
+        return _canned_result(dry_run=False)
+
+
+class _RaisingIngestionPipelineService:
+    """A pipeline stub whose ``ingest`` raises a pinned exception."""
+
+    def __init__(self, exc: Exception) -> None:
+        self._exc = exc
+
+    def __call__(self, operator: Operator, **_kwargs: Any) -> _RaisingIngestionPipelineService:
+        return self
+
+    async def ingest(self, **_kwargs: Any) -> IngestionPipelineResult:
+        raise self._exc
+
+
+# ---------------------------------------------------------------------------
+# tools/list visibility + schema strictness (real MCP transport)
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.parametrize(
+    "client_with_operator",
+    [TenantRole.READ_ONLY],
+    indirect=True,
+)
+def test_ingest_tools_hidden_from_read_only(
+    client_with_operator: tuple[TestClient, Operator],  # noqa: F811
+) -> None:
+    """A read_only operator sees neither ingest tool."""
+    client, _op = client_with_operator
+    response = post_mcp(client, {"jsonrpc": "2.0", "id": 1, "method": "tools/list"})
+    names = {t["name"] for t in response.json()["result"]["tools"]}
+    assert _INGEST_TOOL not in names
+    assert _INGEST_STATUS_TOOL not in names
+
+
+@pytest.mark.parametrize(
+    "client_with_operator",
+    [TenantRole.OPERATOR],
+    indirect=True,
+)
+def test_ingest_status_visible_to_operator_but_ingest_is_not(
+    client_with_operator: tuple[TestClient, Operator],  # noqa: F811
+) -> None:
+    """``ingest_status`` is operator-read; ``ingest`` stays tenant_admin-write."""
+    client, _op = client_with_operator
+    response = post_mcp(client, {"jsonrpc": "2.0", "id": 1, "method": "tools/list"})
+    names = {t["name"] for t in response.json()["result"]["tools"]}
+    assert _INGEST_STATUS_TOOL in names
+    assert _INGEST_TOOL not in names
+
+
+@pytest.mark.parametrize(
+    "client_with_operator",
+    [TenantRole.TENANT_ADMIN],
+    indirect=True,
+)
+def test_both_ingest_tools_visible_to_tenant_admin(
+    client_with_operator: tuple[TestClient, Operator],  # noqa: F811
+) -> None:
+    """A tenant_admin sees both the ingest tool and its poll companion."""
+    client, _op = client_with_operator
+    response = post_mcp(client, {"jsonrpc": "2.0", "id": 1, "method": "tools/list"})
+    names = {t["name"] for t in response.json()["result"]["tools"]}
+    assert _INGEST_TOOL in names
+    assert _INGEST_STATUS_TOOL in names
+
+
+@pytest.mark.parametrize(
+    "client_with_operator",
+    [TenantRole.TENANT_ADMIN],
+    indirect=True,
+)
+def test_ingest_tool_schemas_are_strict_and_describe_async(
+    client_with_operator: tuple[TestClient, Operator],  # noqa: F811
+) -> None:
+    """Both schemas are strict 2020-12; ingest advertises async + the poll pairing."""
+    import jsonschema
+
+    client, _op = client_with_operator
+    response = post_mcp(client, {"jsonrpc": "2.0", "id": 1, "method": "tools/list"})
+    tools = {t["name"]: t for t in response.json()["result"]["tools"]}
+
+    for name in (_INGEST_TOOL, _INGEST_STATUS_TOOL):
+        schema = tools[name]["inputSchema"]
+        assert schema["type"] == "object"
+        assert schema["additionalProperties"] is False, f"{name}: not strict"
+        jsonschema.Draft202012Validator.check_schema(schema)
+        assert "required_role" not in tools[name]
+        assert "op_class" not in tools[name]
+        desc = tools[name]["description"].lower()
+        assert "use" in desc
+        assert "do not" in desc or "don't" in desc or "pair" in desc or "after" in desc
+
+    # The ingest schema carries the async flag and points at the poll tool.
+    ingest_schema = tools[_INGEST_TOOL]["inputSchema"]
+    assert ingest_schema["properties"]["async"]["type"] == "boolean"
+    assert _INGEST_STATUS_TOOL in tools[_INGEST_TOOL]["description"]
+    # The poll tool takes a job_id handle.
+    assert "job_id" in tools[_INGEST_STATUS_TOOL]["inputSchema"]["properties"]
+
+
+@pytest.mark.parametrize(
+    "client_with_operator",
+    [TenantRole.OPERATOR],
+    indirect=True,
+)
+def test_operator_cannot_call_ingest_write_tool(
+    client_with_operator: tuple[TestClient, Operator],  # noqa: F811
+) -> None:
+    """An operator guessing the hidden ``ingest`` name is rejected at the dispatcher."""
+    client, _op = client_with_operator
+    response = post_mcp(
+        client,
+        {
+            "jsonrpc": "2.0",
+            "id": 1,
+            "method": "tools/call",
+            "params": {
+                "name": _INGEST_TOOL,
+                "arguments": {
+                    "product": "vmware",
+                    "version": "9.0",
+                    "impl_id": "vmware-rest",
+                    "specs": [{"uri": "docs:vcenter-9.0/vcenter.yaml"}],
+                },
+            },
+        },
+    )
+    body = response.json()
+    assert "error" in body, body
+    assert body["error"]["code"] == -32602
+    assert "forbidden" in body["error"]["message"].lower()
+
+
+# ---------------------------------------------------------------------------
+# Inline path (dry_run / async unset) — no regression
+# ---------------------------------------------------------------------------
+
+
+async def test_inline_dry_run_returns_ingest_response_no_grouping(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """``dry_run=true`` runs inline and returns the canonical IngestResponse."""
+    fake = _FakeIngestionPipelineService()
+    monkeypatch.setattr(ci_mod, "IngestionPipelineService", fake)
+    op = build_operator(TenantRole.TENANT_ADMIN)
+
+    payload = await ci_mod._ingest_handler(
+        op,
+        {
+            "product": "vmware",
+            "version": "9.0",
+            "impl_id": "vmware-rest",
+            "specs": [
+                {"uri": "docs:vcenter-9.0/vcenter.yaml"},
+                {"uri": "docs:vcenter-9.0/vi-json.yaml"},
+            ],
+            "dry_run": True,
+            "async": True,  # ignored on the dry-run path
+            "tenant_id": str(OPERATOR_TENANT_ID),
+        },
+    )
+
+    # Inline (not a handle): nested ingestion + grouping=None.
+    assert payload["ingestion"]["connector_id"] == "vmware-rest-9.0"
+    assert payload["ingestion"]["inserted_count"] == 10
+    assert payload["grouping"] is None
+    assert "job_id" not in payload
+
+    [call] = fake.ingest_calls
+    assert call["product"] == "vmware"
+    assert call["dry_run"] is True
+    assert call["tenant_id"] == OPERATOR_TENANT_ID
+    assert [s.uri for s in call["specs"]] == [
+        "docs:vcenter-9.0/vcenter.yaml",
+        "docs:vcenter-9.0/vi-json.yaml",
+    ]
+    # No background job was created — dry-run never offloads even with
+    # ``async=true`` set (the inline payload above already proves the
+    # inline shape; this pins that no job row leaked into the registry).
+    assert len(get_job_registry()._jobs) == 0
+
+
+async def test_inline_default_returns_grouping(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """``async`` unset (default false) runs inline and returns ingestion + grouping."""
+    fake = _FakeIngestionPipelineService()
+    monkeypatch.setattr(ci_mod, "IngestionPipelineService", fake)
+    op = build_operator(TenantRole.TENANT_ADMIN)
+
+    payload = await ci_mod._ingest_handler(
+        op,
+        {
+            "product": "vmware",
+            "version": "9.0",
+            "impl_id": "vmware-rest",
+            "specs": [{"uri": "docs:vcenter-9.0/vcenter.yaml"}],
+        },
+    )
+    assert payload["ingestion"]["connector_id"] == "vmware-rest-9.0"
+    assert payload["grouping"]["groups_created"] == 3
+    assert "job_id" not in payload
+    [call] = fake.ingest_calls
+    assert call["dry_run"] is False
+
+
+async def test_inline_version_mismatch_maps_to_invalid_params(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """Inline VersionMismatchError surfaces as -32602 with structured data."""
+    exc = VersionMismatchError(
+        kind="spec_label_mismatch",
+        requested_version="8.0",
+        spec_info_versions=[("docs:vcenter-9.0/vcenter.yaml", "9.0.3")],
+    )
+    monkeypatch.setattr(ci_mod, "IngestionPipelineService", _RaisingIngestionPipelineService(exc))
+    op = build_operator(TenantRole.TENANT_ADMIN)
+
+    with pytest.raises(McpInvalidParamsError) as caught:
+        await ci_mod._ingest_handler(
+            op,
+            {
+                "product": "vmware",
+                "version": "8.0",
+                "impl_id": "vmware-rest",
+                "specs": [{"uri": "docs:vcenter-9.0/vcenter.yaml"}],
+            },
+        )
+    assert "9.0.3" in str(caught.value)
+    data = caught.value.data
+    assert data is not None
+    assert data["kind"] == "spec_label_mismatch"
+    assert data["requested_version"] == "8.0"
+
+
+async def test_inline_uncovered_version_maps_to_invalid_params(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """Inline UncoveredVersionLabel surfaces as -32602 with the registered ranges."""
+    exc = UncoveredVersionLabel(
+        product="t9-vmware",
+        version="7.0",
+        impl_id="t9-vmware-rest",
+        candidates=[("9.0", "t9-vmware-rest", "_RangedTestConnector", ">=8.5,<10.0")],
+    )
+    monkeypatch.setattr(ci_mod, "IngestionPipelineService", _RaisingIngestionPipelineService(exc))
+    op = build_operator(TenantRole.TENANT_ADMIN)
+
+    with pytest.raises(McpInvalidParamsError) as caught:
+        await ci_mod._ingest_handler(
+            op,
+            {
+                "product": "t9-vmware",
+                "version": "7.0",
+                "impl_id": "t9-vmware-rest",
+                "specs": [{"uri": "docs:vcenter-9.0/vcenter.yaml"}],
+            },
+        )
+    data = caught.value.data
+    assert data is not None
+    assert data["product"] == "t9-vmware"
+    assert data["version"] == "7.0"
+
+
+# ---------------------------------------------------------------------------
+# Async path — AC #1 (prompt return) + AC #2 (poll to terminal)
+# ---------------------------------------------------------------------------
+
+
+async def test_async_returns_handle_before_pipeline_completes(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """AC #1: ``async=true`` returns a job handle while the pipeline is still running.
+
+    The blocking stub parks ``ingest`` on a gate; the handler must
+    return the handle without awaiting completion (the whole point of
+    the offload — a real vendor-spec grouping pass blocks past the
+    agent's tool-call deadline). The returned handle is poll-able.
+    """
+    blocking = _BlockingIngestionPipelineService()
+    monkeypatch.setattr(ci_mod, "IngestionPipelineService", blocking)
+    op = build_operator(TenantRole.TENANT_ADMIN)
+
+    handle = await asyncio.wait_for(
+        ci_mod._ingest_handler(
+            op,
+            {
+                "product": "sddc-manager",
+                "version": "9.0",
+                "impl_id": "sddc-manager-rest",
+                "specs": [{"uri": "docs:sddc-9.0/sddc.yaml"}],
+                "async": True,
+            },
+        ),
+        timeout=2.0,
+    )
+
+    # The handle came back even though ``ingest`` is still parked.
+    assert handle["status"] == "running"
+    assert "job_id" in handle
+    assert handle["poll_url"] == f"/api/v1/connectors/ingest/jobs/{handle['job_id']}"
+    # The background task did start the pipeline (it's blocked on the gate).
+    await asyncio.wait_for(blocking.started.wait(), timeout=2.0)
+
+    # Polling now shows ``running`` (the pipeline hasn't finished).
+    running = await ci_mod._ingest_status_handler(op, {"job_id": handle["job_id"]})
+    assert running["status"] == "running"
+    assert running["ingestion"] is None
+    assert running["product"] == "sddc-manager"
+
+    # Release the gate; the background task completes and the job flips
+    # to ``succeeded`` carrying the final counts (AC #2).
+    blocking.gate.set()
+    terminal = await _poll_until_terminal(op, handle["job_id"])
+    assert terminal["status"] == "succeeded"
+    assert terminal["ingestion"]["inserted_count"] == 10
+    assert terminal["grouping"]["groups_created"] == 3
+    assert terminal["error"] is None
+
+
+async def test_async_failure_surfaces_on_poll(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """A pipeline failure on the async path lands on the poll response, not inline.
+
+    The async handler has already returned a handle by the time the
+    pipeline raises, so the diagnostic surfaces via ``error`` /
+    ``error_class`` on ``ingest_status`` (same trade-off the REST async
+    path documents) rather than as an inline ``-32602``.
+    """
+    exc = VersionMismatchError(
+        kind="spec_label_mismatch",
+        requested_version="8.0",
+        spec_info_versions=[("docs:vcenter-9.0/vcenter.yaml", "9.0.3")],
+    )
+    monkeypatch.setattr(ci_mod, "IngestionPipelineService", _RaisingIngestionPipelineService(exc))
+    op = build_operator(TenantRole.TENANT_ADMIN)
+
+    handle = await ci_mod._ingest_handler(
+        op,
+        {
+            "product": "vmware",
+            "version": "8.0",
+            "impl_id": "vmware-rest",
+            "specs": [{"uri": "docs:vcenter-9.0/vcenter.yaml"}],
+            "async": True,
+        },
+    )
+    assert handle["status"] == "running"
+
+    terminal = await _poll_until_terminal(op, handle["job_id"])
+    assert terminal["status"] == "failed"
+    assert terminal["error_class"] == "VersionMismatchError"
+    assert terminal["error"] is not None
+    assert terminal["ingestion"] is None
+
+
+async def test_ingest_status_unknown_handle_is_not_found(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """An unknown job id returns ``ingest_job_not_found`` (-32602)."""
+    op = build_operator(TenantRole.TENANT_ADMIN)
+    with pytest.raises(McpInvalidParamsError) as caught:
+        await ci_mod._ingest_status_handler(
+            op,
+            {"job_id": "00000000-0000-0000-0000-0000000000ff"},
+        )
+    assert "ingest_job_not_found" in str(caught.value)
+
+
+async def test_ingest_status_malformed_handle_is_invalid_params() -> None:
+    """A non-UUID handle is rejected with an invalid-params diagnostic."""
+    op = build_operator(TenantRole.TENANT_ADMIN)
+    with pytest.raises(McpInvalidParamsError) as caught:
+        await ci_mod._ingest_status_handler(op, {"job_id": "not-a-uuid"})
+    assert "valid job id" in str(caught.value).lower()
+
+
+async def test_ingest_status_cross_tenant_is_not_found(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """An operator cannot poll a job that belongs to another tenant.
+
+    The async ingest runs under the originating operator's tenant; a
+    different-tenant operator polling the same handle sees the same
+    ``ingest_job_not_found`` a missing id returns (the cross-tenant 404
+    conflation the registry enforces).
+    """
+    blocking = _BlockingIngestionPipelineService()
+    blocking.gate.set()  # let it complete immediately
+    monkeypatch.setattr(ci_mod, "IngestionPipelineService", blocking)
+    owner = build_operator(TenantRole.TENANT_ADMIN)
+
+    # Scope the job to the owner's tenant by passing ``tenant_id``
+    # explicitly — the MCP path defaults to the built-in (None) scope
+    # when the arg is omitted, so an explicit tenant id is what makes
+    # the job tenant-bound and the cross-tenant probe meaningful.
+    handle = await ci_mod._ingest_handler(
+        owner,
+        {
+            "product": "vmware",
+            "version": "9.0",
+            "impl_id": "vmware-rest",
+            "specs": [{"uri": "docs:vcenter-9.0/vcenter.yaml"}],
+            "async": True,
+            "tenant_id": str(OPERATOR_TENANT_ID),
+        },
+    )
+    await _poll_until_terminal(owner, handle["job_id"])
+
+    # A second operator in a different tenant probes the same handle.
+    from uuid import UUID
+
+    intruder = Operator(
+        sub="intruder",
+        name="Intruder",
+        email=None,
+        raw_jwt="fixture-jwt-not-real",
+        tenant_id=UUID("00000000-0000-0000-0000-0000000000bb"),
+        tenant_role=TenantRole.TENANT_ADMIN,
+    )
+    with pytest.raises(McpInvalidParamsError) as caught:
+        await ci_mod._ingest_status_handler(intruder, {"job_id": handle["job_id"]})
+    assert "ingest_job_not_found" in str(caught.value)
+
+
+async def _poll_until_terminal(
+    operator: Operator,
+    job_id: str,
+    *,
+    attempts: int = 50,
+) -> dict[str, Any]:
+    """Drive ``ingest_status`` until the job leaves the ``running`` state.
+
+    Yields control between polls so the background ``asyncio.create_task``
+    pipeline coroutine gets scheduled. Fails the test if the job never
+    reaches a terminal state within the attempt budget rather than
+    hanging.
+    """
+    for _ in range(attempts):
+        payload = await ci_mod._ingest_status_handler(operator, {"job_id": job_id})
+        if payload["status"] != "running":
+            return payload
+        await asyncio.sleep(0.01)
+    raise AssertionError(f"job {job_id} never reached a terminal state")  # pragma: no cover
+
+
+def test_job_registry_accessor_is_importable() -> None:
+    """Sanity: the handler module wires the shared registry accessor.
+
+    Guards against a refactor that re-points the MCP path at a private
+    registry instance instead of the process-wide singleton the REST
+    poll endpoint reads — the cross-surface poll property (#811-style)
+    depends on both surfaces sharing :func:`get_job_registry`.
+    """
+    assert ci_mod.get_job_registry is get_job_registry

--- a/docs/codebase/spec-ingestion.md
+++ b/docs/codebase/spec-ingestion.md
@@ -211,12 +211,22 @@ enable workflow over the T6 REST routes.
 
 ### T7 (admin MCP tools) at a glance
 
-`backend/src/meho_backplane/mcp/tools/connector_admin.py` registers
-seven MCP tools at module import:
+The admin MCP tools register at module import across two files, split
+by responsibility so neither grows past the code-quality file-size
+budget:
+
+* `backend/src/meho_backplane/mcp/tools/connector_ingest.py` — the
+  two ingest-pipeline tools (`ingest` + `ingest_status`).
+* `backend/src/meho_backplane/mcp/tools/connector_admin.py` — the six
+  review / edit / state-machine tools.
+* `backend/src/meho_backplane/mcp/tools/_connector_shared.py` — the
+  `connector_id` / `tenant_id` schema snippets, op-class strings, and
+  the JSON-safe serialiser both tool modules import.
 
 | Tool | Required role | Wraps |
 |------|---------------|-------|
-| `meho.connector.ingest` | `tenant_admin` | `IngestionPipelineService.ingest()` |
+| `meho.connector.ingest` | `tenant_admin` | `IngestionPipelineService.ingest()` (+ `IngestJobRegistry` on async) |
+| `meho.connector.ingest_status` | `operator` | `IngestJobRegistry.get()` |
 | `meho.connector.list` | `operator` | `list_ingested_connectors()` |
 | `meho.connector.review` | `operator` | `ReviewService.get_review_payload()` |
 | `meho.connector.edit_group` | `tenant_admin` | `ReviewService.edit_group()` |
@@ -249,16 +259,37 @@ arguments` key-presence checks so omitted fields never reach
 indistinguishable from an omission with `arguments.get(...)`). Only
 fields the operator explicitly named are forwarded.
 
+**Async offload on the MCP path (G3.5-T2 #1531).** `meho.connector.ingest`
+carries the same #1303 async-202 offload the REST route has: with
+`async=true` (and `dry_run=false`) the handler creates a job row in the
+shared `IngestJobRegistry`, fires the pipeline off the request via
+`asyncio.create_task`, and returns an `IngestJobHandle` immediately —
+well inside the agent's tool-call deadline. The agent polls
+`meho.connector.ingest_status` with the returned `job_id` until the
+status is `succeeded` (carries the final ingestion + grouping counts)
+or `failed` (carries `error_class` + `error`). Because both surfaces
+share `get_job_registry()`, a run started over MCP is poll-able over
+the REST `GET /api/v1/connectors/ingest/jobs/{job_id}` endpoint and
+vice versa. `dry_run=true` and `async` unset keep the inline shape —
+the pipeline runs on the request and the full `IngestResponse` returns
+synchronously (no regression for small-spec / CI callers). This
+parallels the `meho.agents.run` + `meho.agents.run_status` async
+precedent (#811).
+
 The `ingest` handler additionally maps `VersionMismatchError` and
 `UncoveredVersionLabel` to JSON-RPC `-32602 Invalid Params` with
-the structured detail on `error.data` (G0.9.1-T5 #777). Both
-exceptions describe caller-input mistakes — the operator's `version`
-label disagrees with the supplied spec, or falls outside every
-registered class's advertised range — so `-32602` is the right code
-(not `-32603 Internal Error`, which the pre-fix generic catch-all
-emitted). The structured `data` payload is built by the shared
-helpers in `operations/ingest/error_envelopes.py` so the REST 422
-detail and the MCP `error.data` member share one source of truth.
+the structured detail on `error.data` (G0.9.1-T5 #777) **on the inline
+path**. Both exceptions describe caller-input mistakes — the operator's
+`version` label disagrees with the supplied spec, or falls outside
+every registered class's advertised range — so `-32602` is the right
+code (not `-32603 Internal Error`, which the pre-fix generic catch-all
+emitted). The structured `data` payload is built by the shared helpers
+in `operations/ingest/error_envelopes.py` so the REST 422 detail and
+the MCP `error.data` member share one source of truth. On the **async**
+path the handle has already returned by the time the pipeline raises,
+so the same failures surface via `error` / `error_class` on the
+`ingest_status` poll response instead (the trade-off the REST async
+path also makes).
 
 ## Key types
 
@@ -842,7 +873,7 @@ pulled in. The parser tolerates partial / underspecified docs and
 relies on T4's review queue to surface ambiguities to a human before
 operations go live.
 
-## Async ingest mode (G0.16-T1 / #1303)
+## Async ingest mode (G0.16-T1 / #1303; MCP carry G3.5-T2 / #1531)
 
 `POST /api/v1/connectors/ingest` defaults to `async=true`: the route
 fires the pipeline off the request thread via `asyncio.create_task`
@@ -906,6 +937,22 @@ exempt). A pod restart blows the registry away on purpose -- a job
 whose pod died was never going to finish. Durable cross-restart
 jobs are a v0.9 follow-up (the same migration that lands
 operator-cancellable jobs).
+
+**The MCP surface shares the offload (G3.5-T2 / #1531).** The
+`meho.connector.ingest` admin MCP tool carries the same async shape:
+`async=true` (with `dry_run=false`) creates a job in the **same**
+`IngestJobRegistry` (via `get_job_registry()`), fires the pipeline off
+the request with `asyncio.create_task`, and returns an `IngestJobHandle`
+inside the agent's tool-call deadline; the agent polls
+`meho.connector.ingest_status` (which reads the registry through the
+same accessor) until the job is `succeeded` / `failed`. Because both
+surfaces resolve the one process-wide registry, a job started over MCP
+is poll-able over `GET /api/v1/connectors/ingest/jobs/{job_id}` and
+vice versa. The MCP path defaults `async=false` (inline) so existing
+small-spec / CI callers are unaffected; it is the agent-facing surface
+that real vendor specs blocked past the tool-call timeout before this
+carry. See the "T7 (admin MCP tools) at a glance" section above for
+the per-tool wiring + the inline-vs-async error-surface split.
 
 ## LLM-client wiring
 


### PR DESCRIPTION
## Summary
- Carries the #1303 REST async-202 offload to the agent-facing
  `meho.connector.ingest` MCP tool: with `async=true` (and
  `dry_run=false`) it creates a job in the existing in-memory
  `IngestJobRegistry`, fires the pipeline off the request via
  `asyncio.create_task`, and returns an `IngestJobHandle` immediately —
  inside the agent's tool-call deadline — instead of blocking the
  parse+register+LLM-grouping pass past it on a real vendor spec.
- Adds an operator-role `meho.connector.ingest_status` poll tool that
  reports the job through to a terminal `succeeded` (final ingestion +
  grouping counts) or `failed` (`error_class` + `error`). Both surfaces
  resolve the one process-wide registry via `get_job_registry()`, so a
  job started over MCP is poll-able over the REST
  `GET /api/v1/connectors/ingest/jobs/{job_id}` endpoint and vice versa
  (the `meho.agents.run` + `run_status` async precedent, #811).
- Preserves the inline-return shape for `dry_run=true` and `async`
  unset (no regression for small-spec / CI callers); `async` is ignored
  on the dry-run parse-only path, mirroring the REST route.
- Splits the ingest tools into a new `connector_ingest` module (shared
  schema snippets / helpers in `_connector_shared`) alongside the
  existing `connector_admin` review/edit tools, keeping each file under
  the code-quality file-size budget.

## Test plan
- [x] `ruff check` — clean (changed surface + `mcp/tools/`)
- [x] `ruff format --check` — clean
- [x] `mypy backend/src/meho_backplane/mcp/tools/` — clean (24 files)
- [x] `code-quality.py --diff` — 0 blockers (3 advisory file/function-size warnings)
- [x] AC #1 — `test_async_returns_handle_before_pipeline_completes`:
      a blocking-pipeline stub proves the tool returns the handle while
      `ingest` is still parked, and the handle is immediately pollable.
- [x] AC #2 — same test polls `ingest_status` through to `succeeded`
      with `inserted_count` + `groups_created`; `test_async_failure_surfaces_on_poll`
      covers the terminal `failed` + `error_class` path.
- [x] AC #3 — `test_inline_dry_run_returns_ingest_response_no_grouping`
      and `test_inline_default_returns_grouping` prove `dry_run=true` /
      `async` unset keep the inline `IngestResponse` shape and create no
      job row.
- [x] Visibility / RBAC: `ingest` hidden from operator/read_only,
      `ingest_status` operator-visible, both visible to tenant_admin;
      cross-tenant + unknown + malformed poll handles rejected.
- [x] `pytest tests/test_mcp_tools_connector_ingest.py tests/test_mcp_tools_connector_admin.py` — 27 passed
- [x] `pytest -k "mcp or connectors_ingest or registry"` — 775 passed, 18 skipped (no regression from the module split)

## Out of scope
- The MCP bare-error DX consolidation (`-32603` → typed `SpecError`
  detail) is sibling task #1534 — not touched here.
- Durable cross-restart / operator-cancellable jobs remain the v0.9
  follow-up the `IngestJobRegistry` docstring already notes.

<!-- auto-implement-issue: fresh, iteration 1 -->

Closes #1531
