### PR TITLE
fix(connectors): make NSX 9.x (VCF 9) ingestable into a dispatchable connector (#1530)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -179,6 +179,20 @@ connector-related release-notes line.
   Single-shot Q→cited-A only; no new REST/CLI surface (the tool is
   auto-discovered) (#1526).
 
+### Fixed
+
+- NSX 9.x (VCF 9) is now ingestable into a dispatchable connector.
+  NSX-T 4.x was renumbered onto the VCF train at VCF 9.0, but
+  `NsxConnector` advertised `supported_version_range=">=4.0,<5.0"`, so a
+  VCF-9 NSX appliance (which reports NSX 9.0.x and a 9.x `info.version`)
+  could not be ingested under any label — the spec/label gate and the
+  class version-range gate pincered every version. The range is widened
+  to `">=4.0,<10.0"` and the class pin + catalog row track the
+  VCF-9-aligned `9.0` line (the standalone NSX-T 4.x line still
+  dispatches through the same class), and `apply_nsx_core_curation` gains
+  a `connector_id` keyword so it curates the ops the ingest actually
+  landed (e.g. `nsx-rest-9.1.0.0`) (#1530).
+
 ### Documentation
 
 - Operator runbook for the `meho-docs` add-on:

--- a/backend/src/meho_backplane/connectors/nsx/__init__.py
+++ b/backend/src/meho_backplane/connectors/nsx/__init__.py
@@ -5,15 +5,23 @@
 
 Importing this package registers :class:`NsxConnector` against the v2
 connector registry under
-``(product="nsx", version="4.2", impl_id="nsx-rest")``. The chassis
+``(product="nsx", version="9.0", impl_id="nsx-rest")``. The chassis
 lifespan calls
 :func:`~meho_backplane.connectors.registry._eager_import_connectors`
 which walks every ``connectors/<product>/`` subpackage at startup, so
 the registration lands before any dispatch can occur.
 
+The version pin tracks the VCF-9-aligned NSX product line (#1530):
+NSX-T 4.x was renumbered onto the VCF train at VCF 9.0, so a live
+appliance reports NSX 9.0.x. The class's
+``supported_version_range=">=4.0,<10.0"`` keeps the standalone
+NSX-T 4.x line dispatchable through the same class -- the resolver
+keys on the :class:`packaging.specifiers.SpecifierSet`, not the
+class-pinned ``version``.
+
 The v1 :func:`~meho_backplane.connectors.registry.register_connector`
 entry point is deliberately **not** called. The connector advertises
-an explicit ``(version="4.2", impl_id="nsx-rest")`` key; the v1 entry
+an explicit ``(version="9.0", impl_id="nsx-rest")`` key; the v1 entry
 would land as ``("nsx", "", "")`` and confuse
 :func:`~meho_backplane.connectors.resolver.resolve_connector`'s
 tie-break ladder. Same pattern :mod:`meho_backplane.connectors.vmware_rest`
@@ -22,13 +30,13 @@ established.
 Once G0.7-T8 (#408) lands its
 :func:`ensure_connector_class_registered` auto-shim in main, the
 idempotency check there will no-op on the
-``(product="nsx", version="4.2", impl_id="nsx-rest")`` triple because
+``(product="nsx", version="9.0", impl_id="nsx-rest")`` triple because
 this module has already registered the hand-rolled class. Until then,
 this module is the only registration path; no behavioural drift
 results from the absence of the auto-shim infrastructure.
 
 Operations for this connector arrive in #614 via G0.7 spec ingestion
-of ``nsx-4.2/policy.yaml`` + ``nsx-4.2/manager.yaml`` against the
+of the NSX ``policy.yaml`` + ``manager.yaml`` corpus against the
 ``endpoint_descriptor`` table. This Task ships only the skeleton.
 """
 
@@ -56,7 +64,7 @@ from meho_backplane.connectors.registry import register_connector_v2
 
 register_connector_v2(
     product="nsx",
-    version="4.2",
+    version="9.0",
     impl_id="nsx-rest",
     cls=NsxConnector,
 )

--- a/backend/src/meho_backplane/connectors/nsx/connector.py
+++ b/backend/src/meho_backplane/connectors/nsx/connector.py
@@ -1,11 +1,11 @@
 # SPDX-License-Identifier: Apache-2.0
 # Copyright (c) 2026 evoila Group
 
-"""NsxConnector -- hand-rolled HttpConnector subclass for NSX 4.x.
+"""NsxConnector -- hand-rolled HttpConnector subclass for NSX.
 
 Skeleton-only -- auth + fingerprint + probe + the G0.6 dispatch shim.
-Operations arrive in #614 via G0.7 spec ingestion against
-``nsx-4.2/policy.yaml`` + ``nsx-4.2/manager.yaml``.
+Operations arrive in #614 via G0.7 spec ingestion against the NSX
+``policy.yaml`` + ``manager.yaml`` corpus the appliance serves.
 
 Registered against the v2 registry at module-import time via
 :func:`~meho_backplane.connectors.registry.register_connector_v2` in
@@ -13,8 +13,23 @@ Registered against the v2 registry at module-import time via
 idempotency check (in
 :func:`~meho_backplane.operations.ingest.connector_registration.ensure_connector_class_registered`
 once #408's pipeline lands in main) no-ops on subsequent ingests
-against the same ``(product="nsx", version="4.2", impl_id="nsx-rest")``
+against the same ``(product="nsx", version="9.0", impl_id="nsx-rest")``
 triple.
+
+VCF-9 version renumber (#1530)
+------------------------------
+
+NSX-T 4.x was renumbered onto the VCF train at VCF 9.0 -- a live
+VCF-9 appliance reports NSX 9.0.x and the vendor spec carries
+``info.version`` in the 9.x scheme. The :attr:`supported_version_range`
+spans ``>=4.0,<10.0`` so a single class covers both the standalone
+NSX-T 4.x line and the VCF-9-aligned 9.x line; dispatch and the
+ingest version-range pre-flight key on the
+:class:`packaging.specifiers.SpecifierSet`, not the class-pinned
+:attr:`version`, so the one class resolves every label in the band.
+Same renumber posture :class:`VmwareRestConnector` took for the
+vSphere 8.x -> 9.0 jump (``version="9.0"``,
+``supported_version_range=">=8.5,<10.0"``).
 
 Auth divergence from the vSphere precedent
 ------------------------------------------
@@ -156,7 +171,7 @@ def _is_acceptable_auth_model(value: Any) -> bool:
 
 
 class NsxConnector(HttpConnector):
-    """NSX 4.x REST connector with session-cookie + XSRF auth.
+    """NSX REST connector with session-cookie + XSRF auth.
 
     Per-target XSRF token cached in :attr:`_session_tokens`; the
     accompanying ``JSESSIONID`` cookie is held by the per-target
@@ -172,11 +187,14 @@ class NsxConnector(HttpConnector):
 
     # G0.6 v2 registry metadata. The (product, version, impl_id) triple
     # matches the dispatcher's parse_connector_id contract:
-    # ``"nsx-rest-4.2"`` -> (``"nsx"``, ``"4.2"``, ``"nsx-rest"``).
+    # ``"nsx-rest-9.0"`` -> (``"nsx"``, ``"9.0"``, ``"nsx-rest"``). The
+    # version pin tracks the VCF-9-aligned product line (#1530); the
+    # ``>=4.0,<10.0`` range keeps the standalone NSX-T 4.x line
+    # dispatchable through the same class.
     product = "nsx"
-    version = "4.2"
+    version = "9.0"
     impl_id = "nsx-rest"
-    supported_version_range = ">=4.0,<5.0"
+    supported_version_range = ">=4.0,<10.0"
     priority = 1
 
     def __init__(
@@ -456,7 +474,7 @@ class NsxConnector(HttpConnector):
         nil-UUID tenant_id + a fixed system sentinel ``sub``; the
         connector's natural key is encoded as the dispatcher's
         ``connector_id`` per ``parse_connector_id``'s contract:
-        ``"nsx-rest-4.2"`` -> (product=``"nsx"``, version=``"4.2"``,
+        ``"nsx-rest-9.0"`` -> (product=``"nsx"``, version=``"9.0"``,
         impl_id=``"nsx-rest"``).
         """
         # Lazy import -- meho_backplane.operations.dispatch transitively

--- a/backend/src/meho_backplane/connectors/nsx/core_ops.py
+++ b/backend/src/meho_backplane/connectors/nsx/core_ops.py
@@ -1,13 +1,19 @@
 # SPDX-License-Identifier: Apache-2.0
 # Copyright (c) 2026 evoila Group
 
-"""NSX 4.2 read-only v0.2 core — curated operator-enabled subset.
+"""NSX read-only v0.2 core — curated operator-enabled subset.
 
 This module names the **9 read-only NSX operations** the G3.5 NSX
-v0.2 ship enables out of the much larger
-``nsx-4.2/policy.yaml`` + ``nsx-4.2/manager.yaml`` corpus that the
-G0.7 spec-ingestion pipeline lands under
-``connector_id="nsx-rest-4.2"``. The curation is two-layered:
+v0.2 ship enables out of the much larger ``policy.yaml`` +
+``manager.yaml`` corpus that the G0.7 spec-ingestion pipeline lands
+under the NSX connector triple. NSX-T 4.x was renumbered onto the
+VCF train at VCF 9.0 (#1530), so :data:`NSX_VERSION` tracks the
+VCF-9-aligned ``"9.0"`` line and :data:`NSX_CONNECTOR_ID` is the
+default ``"nsx-rest-9.0"`` slug; :func:`apply_nsx_core_curation`
+accepts a ``connector_id`` override so an operator who ingested
+under a finer 9.x label (e.g. ``"nsx-rest-9.1.0.0"``) can still
+curate the ops the ingest actually landed. The curation is
+two-layered:
 
 * :data:`NSX_CORE_GROUPS` — the operator-reviewed ``when_to_use``
   hint per LLM-grouping pass output group. Each entry's
@@ -33,8 +39,10 @@ review step — the actual curation is applied through
 :func:`apply_nsx_core_curation` against an existing ingested
 connector.
 
-The 9 ops (paths cross-checked against NSX REST API guide v4.2,
-2026-04 snapshot at https://developer.broadcom.com/xapis/nsx-data-center-rest-api/latest/):
+The 9 ops (paths cross-checked against the NSX REST API guide,
+2026-04 snapshot at https://developer.broadcom.com/xapis/nsx-data-center-rest-api/latest/;
+the manager (``/api/v1/...``) and policy (``/policy/api/v1/...``)
+path families are stable across the 4.x and VCF-9-aligned 9.x lines):
 
 1. ``GET:/api/v1/node`` — ``nsx.about`` — manager version / build /
    node UUID (the same surface :meth:`NsxConnector.fingerprint`
@@ -123,6 +131,7 @@ from uuid import UUID
 
 import structlog
 
+from meho_backplane.operations.ingest.payload import ConnectorReviewPayload
 from meho_backplane.operations.ingest.service import ReviewService
 
 __all__ = [
@@ -146,11 +155,14 @@ _log = structlog.get_logger(__name__)
 #: don't import the connector class (avoids re-running the registry
 #: side-effects in the ``__init__``).
 NSX_PRODUCT: Final[str] = "nsx"
-NSX_VERSION: Final[str] = "4.2"
+NSX_VERSION: Final[str] = "9.0"
 NSX_IMPL_ID: Final[str] = "nsx-rest"
 
 #: Connector-id slug the G0.6 dispatcher's ``parse_connector_id``
-#: round-trips back to the triple above: ``"nsx-rest-4.2"``.
+#: round-trips back to the triple above: ``"nsx-rest-9.0"``. This is
+#: the *default* curation target; :func:`apply_nsx_core_curation`
+#: takes a ``connector_id`` override for ingests landed under a
+#: finer 9.x label.
 NSX_CONNECTOR_ID: Final[str] = f"{NSX_IMPL_ID}-{NSX_VERSION}"
 
 
@@ -177,7 +189,7 @@ class NsxCoreOp:
 
     ``op_id`` follows the ``METHOD:path`` shape every
     ``source_kind='ingested'`` row uses; the path matches an entry
-    in NSX 4.2's ``policy.yaml`` (``/policy/api/v1/...``) or
+    in NSX's ``policy.yaml`` (``/policy/api/v1/...``) or
     ``manager.yaml`` (``/api/v1/...``).
 
     ``llm_instructions`` is the per-op JSON blob the meta-tools
@@ -355,8 +367,9 @@ def _instructions(
 #: op_id (``GET:/path`` form ingested ops use), the curated group
 #: assignment, and the operator-reviewed ``llm_instructions`` blob.
 #:
-#: Sourced against NSX REST API v4.2 docs at
-#: https://developer.broadcom.com/xapis/nsx-data-center-rest-api/latest/.
+#: Sourced against the NSX REST API docs at
+#: https://developer.broadcom.com/xapis/nsx-data-center-rest-api/latest/
+#: (path families unchanged across 4.x and the VCF-9-aligned 9.x line).
 NSX_CORE_OPS: Final[tuple[NsxCoreOp, ...]] = (
     NsxCoreOp(
         op_id="GET:/api/v1/node",
@@ -565,6 +578,7 @@ async def apply_nsx_core_curation(
     review_service: ReviewService,
     *,
     tenant_id: UUID | None,
+    connector_id: str = NSX_CONNECTOR_ID,
 ) -> None:
     """Apply the curated 9-op read core against an ingested NSX connector.
 
@@ -607,6 +621,16 @@ async def apply_nsx_core_curation(
     contract); built-in scope (``tenant_id=None``) is the default
     for NSX content, same convention vSphere uses.
 
+    *connector_id* defaults to :data:`NSX_CONNECTOR_ID`
+    (``"nsx-rest-9.0"``) but accepts an override for the case the
+    operator ingested under a finer 9.x label than the class pin
+    — ingested ops land under the **operator-supplied** ``version``
+    label (e.g. a VCF-9 appliance spec ingested as
+    ``version="9.1.0.0"`` lands ``connector_id="nsx-rest-9.1.0.0"``),
+    while :data:`NSX_CONNECTOR_ID` only mirrors the registered
+    class pin. Pass the connector_id the ingest actually produced
+    (#1530).
+
     Re-running is safe but not idempotent at the audit layer.
     :meth:`enable_group` short-circuits on groups already in
     ``review_status='enabled'`` (no audit row), but
@@ -617,91 +641,125 @@ async def apply_nsx_core_curation(
     ``meho.connector.edit_*`` audit rows but never corrupt state.
 
     Raises :class:`~meho_backplane.operations.ingest.ConnectorNotFoundError`
-    if no groups exist for ``nsx-rest-4.2`` under *tenant_id* (the
+    if no groups exist for *connector_id* under *tenant_id* (the
     operator must run ``meho connector ingest`` against the NSX
     specs before this helper applies).
     """
     # Step 1 — read the current state so we can compute the
     # per-group non-core op set.
-    payload = await review_service.get_review_payload(
-        NSX_CONNECTOR_ID,
-        tenant_id,
+    payload = await review_service.get_review_payload(connector_id, tenant_id)
+
+    # Step 2 — disable non-core ops in each curated group so the
+    # subsequent enable_group cascade skips them.
+    await _disable_non_core_ops(
+        review_service, payload, tenant_id=tenant_id, connector_id=connector_id
     )
+    # Steps 3 + 4 — land the reviewed group metadata, then enable each
+    # curated group (cascade respects the step-2 exclusion list).
+    await _enable_curated_groups(review_service, tenant_id=tenant_id, connector_id=connector_id)
+    # Step 5 — land the curated llm_instructions blob per core op.
+    await _land_core_op_instructions(review_service, tenant_id=tenant_id, connector_id=connector_id)
 
-    # Build the per-group allow-list from the curated NSX_CORE_OPS.
-    # ``policy-firewall`` carries two entries (security-policy.list
-    # + rule.list); every other curated group carries exactly one.
-    core_op_ids_by_group: dict[str, set[str]] = {}
+
+def _core_op_ids_by_group() -> dict[str, set[str]]:
+    """Map each curated ``group_key`` to its allow-list of core op_ids.
+
+    ``policy-firewall`` carries two entries (security-policy.list +
+    rule.list); every other curated group carries exactly one.
+    """
+    by_group: dict[str, set[str]] = {}
     for op in NSX_CORE_OPS:
-        core_op_ids_by_group.setdefault(op.group_key, set()).add(op.op_id)
+        by_group.setdefault(op.group_key, set()).add(op.op_id)
+    return by_group
 
-    # Step 2 — disable non-core ops in each curated group via the
-    # operator-override audit-log path so the subsequent
-    # ``enable_group`` cascade skips them.
+
+async def _disable_non_core_ops(
+    review_service: ReviewService,
+    payload: ConnectorReviewPayload,
+    *,
+    tenant_id: UUID | None,
+    connector_id: str,
+) -> None:
+    """Write an operator-override disable row for every non-core op.
+
+    Walks each curated group's ops and disables the ones outside
+    :data:`NSX_CORE_OPS` via the audit-log override path so the
+    follow-on :meth:`ReviewService.enable_group` cascade skips them.
+    The override row is always written — even when the op already
+    appears ``is_enabled=False`` — because the cascade consults the
+    audit log (see
+    :func:`~meho_backplane.operations.ingest._internals.operator_disabled_op_ids`),
+    not the live column value, and a freshly-ingested op carries no
+    ``edit_op`` audit history.
+    """
+    allow_by_group = _core_op_ids_by_group()
     for group_payload in payload.groups:
-        allow_list = core_op_ids_by_group.get(group_payload.group_key)
+        allow_list = allow_by_group.get(group_payload.group_key)
         if allow_list is None:
             # Non-curated group — left entirely alone; its
-            # review_status stays at whatever the ingest pass set
-            # it to (typically 'staged').
+            # review_status stays at whatever the ingest pass set it
+            # to (typically 'staged').
             continue
         for review_op in group_payload.ops:
             if review_op.op_id in allow_list:
                 continue
-            # Always write the override audit row, even when the
-            # op already appears ``is_enabled=False``. The
-            # cascade in :meth:`enable_group` consults the audit
-            # log (see
-            # :func:`~meho_backplane.operations.ingest._internals.operator_disabled_op_ids`),
-            # not the live column value — a freshly-ingested op
-            # is ``is_enabled=False`` by default but carries no
-            # ``edit_op`` audit history, so the cascade would
-            # re-enable it without an explicit override row.
             await review_service.edit_op(
-                NSX_CONNECTOR_ID,
+                connector_id,
                 review_op.op_id,
                 tenant_id=tenant_id,
                 is_enabled=False,
             )
             _log.info(
                 "nsx_non_core_op_disabled",
-                connector_id=NSX_CONNECTOR_ID,
+                connector_id=connector_id,
                 op_id=review_op.op_id,
                 group_key=group_payload.group_key,
             )
 
-    # Steps 3 + 4 — land the operator-reviewed group metadata, then
-    # enable each curated group. The cascade respects the
-    # operator-override exclusion list built in step 2.
+
+async def _enable_curated_groups(
+    review_service: ReviewService,
+    *,
+    tenant_id: UUID | None,
+    connector_id: str,
+) -> None:
+    """Land the reviewed group metadata + enable each curated group."""
     for group in NSX_CORE_GROUPS:
         await review_service.edit_group(
-            NSX_CONNECTOR_ID,
+            connector_id,
             group.group_key,
             tenant_id=tenant_id,
             name=group.name,
             when_to_use=group.when_to_use,
         )
         await review_service.enable_group(
-            NSX_CONNECTOR_ID,
+            connector_id,
             group.group_key,
             tenant_id=tenant_id,
         )
         _log.info(
             "nsx_core_group_enabled",
-            connector_id=NSX_CONNECTOR_ID,
+            connector_id=connector_id,
             group_key=group.group_key,
         )
 
-    # Step 5 — land the curated llm_instructions blob per core op.
+
+async def _land_core_op_instructions(
+    review_service: ReviewService,
+    *,
+    tenant_id: UUID | None,
+    connector_id: str,
+) -> None:
+    """Land the curated ``llm_instructions`` blob on each core op."""
     for op in NSX_CORE_OPS:
         await review_service.edit_op(
-            NSX_CONNECTOR_ID,
+            connector_id,
             op.op_id,
             tenant_id=tenant_id,
             llm_instructions=op.llm_instructions,
         )
         _log.info(
             "nsx_core_op_curated",
-            connector_id=NSX_CONNECTOR_ID,
+            connector_id=connector_id,
             op_id=op.op_id,
         )

--- a/backend/src/meho_backplane/operations/ingest/catalog.yaml
+++ b/backend/src/meho_backplane/operations/ingest/catalog.yaml
@@ -135,25 +135,40 @@ entries:
       OpenAPI-3-converted, MEHO-verified ingest. See #743 / harbor-onboarding.md.
 
   - product: nsx
-    version: "4.2"
+    version: "9.0"
     impl_id: nsx-rest
     requires_connector_class: NsxConnector
     upstream:
       - "https://<nsx-mgr-fqdn>/api/v1/spec/openapi/nsx_api.yaml"
-      - "https://developer.broadcom.com/xapis/nsx-t-data-center-rest-api/latest/"
+      - "https://developer.broadcom.com/xapis/nsx-data-center-rest-api/latest/"
     # G0.18-T8 (#1361, RDC #789 N8): the first upstream is fqdn-
     # templated (placeholder ``<nsx-mgr-fqdn>``); the second is the
     # Broadcom Developer Portal text/html landing page. Neither
     # supports catalog-driven ingest server-side. Operators fetch
     # from the appliance and pass via ``--spec``.
     catalog_ingest: spec-only
+    # #1530: NSX-T 4.x was renumbered onto the VCF train at VCF 9.0;
+    # a live VCF-9 appliance reports NSX 9.0.x and serves a spec
+    # whose info.version is in the 9.x scheme (e.g. 9.1.0.0). The
+    # catalog version label tracks the VCF-9-aligned "9.0" product
+    # line; NsxConnector's supported_version_range (">=4.0,<10.0")
+    # keeps the standalone NSX-T 4.x line dispatchable through the
+    # same class. The 9.x band is declared compatible so an operator
+    # who ingests under the appliance's finer 9.x info.version clears
+    # the spec/label gate without a catalog hand-edit.
+    spec_info_versions_compatible:
+      - "9.x.x"
     spec_info_version: null
     sha256: null
     notes: >-
       Generic-ingested. NSX Manager serves the OpenAPI spec at
       /api/v1/spec/openapi/nsx_api.yaml (appliance-served, fqdn-templated);
-      the Broadcom Developer Portal mirrors the reference. spec_info_version
-      pending first verified ingest. See #743.
+      the Broadcom Developer Portal mirrors the reference. NSX-T 4.x was
+      renumbered onto the VCF train at VCF 9.0 (#1530) -- a VCF-9 appliance
+      reports NSX 9.0.x and the spec's info.version is in the 9.x scheme;
+      NsxConnector covers both 4.x and 9.x via supported_version_range
+      ">=4.0,<10.0". spec_info_version pending first verified ingest.
+      See #743 / #1530.
 
   - product: gh
     version: "3"

--- a/backend/tests/acceptance/_nsx_canary_fixtures.py
+++ b/backend/tests/acceptance/_nsx_canary_fixtures.py
@@ -17,7 +17,7 @@ Why a minimal direct-insert path (not the full G0.7 canary ingest)
 ==================================================================
 
 The full two-spec NSX ingestion via :func:`IngestionPipelineService`
-needs live ``nsx-4.2/policy.yaml`` + ``manager.yaml`` (~30 MB
+needs the live NSX ``policy.yaml`` + ``manager.yaml`` (~30 MB
 combined) reachable on the CI runner — the same env-gated pattern
 :mod:`tests.acceptance._vcenter_spec` codifies for vSphere. That
 live two-spec acceptance test is a follow-up to this Task (see the
@@ -114,15 +114,16 @@ NSX_CANARY_BASE_URL: str = "https://nsx-canary.test.invalid"
 
 #: Persisted as ``Target.fingerprint`` — what the connector resolver
 #: reads to bind the target's ``product`` + ``version`` against the
-#: ``NsxConnector.supported_version_range`` advertisement (``>=4.0,<5.0``).
-#: The probe route normally writes this dict at first-probe time;
-#: the dispatch tests seed it directly so the resolver binds the
-#: connector without a real probe round-trip.
+#: ``NsxConnector.supported_version_range`` advertisement (``>=4.0,<10.0``).
+#: The ``build`` mirrors a VCF-9 appliance's NSX 9.x report (#1530);
+#: the probe route normally writes this dict at first-probe time, the
+#: dispatch tests seed it directly so the resolver binds the connector
+#: without a real probe round-trip.
 NSX_CANARY_FINGERPRINT: dict[str, object] = FingerprintResult(
     vendor="vmware",
     product="nsx",
     version=NSX_VERSION,
-    build="4.2.1.0.0",
+    build="9.0.2.0.0",
     reachable=True,
     probed_at=datetime(2026, 5, 18, 12, 0, 0, tzinfo=UTC),
     probe_method="GET /api/v1/node",
@@ -284,7 +285,7 @@ async def _insert_nsx_descriptors() -> None:
 def _spec_tag_for(path: str) -> str:
     """Return the ``spec:<source>`` tag matching the path's upstream NSX spec.
 
-    NSX 4.2's OpenAPI corpus is split across two files:
+    NSX's OpenAPI corpus is split across two files:
 
     * ``policy.yaml`` — the modern declarative policy API; every
       path begins with ``/policy/api/v1/...``.
@@ -294,15 +295,15 @@ def _spec_tag_for(path: str) -> str:
     The G0.7 ingestion pipeline tags every persisted row with
     ``spec:<source>`` so operators can audit per-spec coverage via
     ``meho connector review``. The seeded fixture mirrors that
-    contract — the 6 policy-API ops carry ``spec:nsx-4.2/policy.yaml``,
-    the 3 manager-API ops carry ``spec:nsx-4.2/manager.yaml``. A
-    flat single-tag default would misrepresent the corpus split and
-    drift the dispatch-smoke set away from what a real two-spec
-    ingest would land.
+    contract — the 6 policy-API ops carry ``spec:nsx-9.0/policy.yaml``,
+    the 3 manager-API ops carry ``spec:nsx-9.0/manager.yaml`` (the
+    VCF-9-aligned line, #1530). A flat single-tag default would
+    misrepresent the corpus split and drift the dispatch-smoke set
+    away from what a real two-spec ingest would land.
     """
     if path.startswith("/policy/"):
-        return "spec:nsx-4.2/policy.yaml"
-    return "spec:nsx-4.2/manager.yaml"
+        return "spec:nsx-9.0/policy.yaml"
+    return "spec:nsx-9.0/manager.yaml"
 
 
 def _param_schema_for(path: str) -> dict[str, object]:
@@ -360,7 +361,7 @@ def _register_nsx_routes(mock: respx.MockRouter) -> None:
     dispatch tests don't need an out-of-band download path like the
     fastembed model fetch the vSphere agent-flow test triggers).
     """
-    # Session establish. NSX 4.2 returns 200 with the JSESSIONID
+    # Session establish. NSX returns 200 with the JSESSIONID
     # cookie + X-XSRF-TOKEN header; the body is empty.
     mock.post("/api/session/create").respond(
         200,
@@ -374,7 +375,7 @@ def _register_nsx_routes(mock: respx.MockRouter) -> None:
         200,
         json={
             "node_version": NSX_VERSION,
-            "kernel_version": "4.2.1.0.0",
+            "kernel_version": "9.0.2.0.0",
             "node_uuid": "deadbeef-1111-2222-3333-cafebabecafe",
             "hostname": "nsxmgr-canary",
             "external_id": "canary-external-id",
@@ -484,8 +485,8 @@ async def ingested_nsx_canary(
     1. Insert built-in :class:`OperationGroup` + :class:`EndpointDescriptor`
        rows for the 9 curated NSX core ops.
     2. Seed a :class:`Target` carrying the :data:`NSX_CANARY_FINGERPRINT`
-       so the resolver binds :class:`NsxConnector` (version 4.2 fits
-       its ``">=4.0,<5.0"`` advertisement).
+       so the resolver binds :class:`NsxConnector` (version 9.0 fits
+       its ``">=4.0,<10.0"`` advertisement).
     3. Resolve + cache the :class:`NsxConnector` instance the
        dispatcher will use, patching only its ``_session_loader``.
        The httpx client is **not** patched — respx intercepts the

--- a/backend/tests/test_api_v1_connectors_ingest.py
+++ b/backend/tests/test_api_v1_connectors_ingest.py
@@ -882,7 +882,7 @@ async def test_list_registered_row_spec_only_catalog_entry_points_at_spec(
     """Catalog-hit + ``catalog_ingest="spec-only"``: row carries the ``--spec`` verb.
 
     G0.18-T8 (#1361) / RDC #789 N8. The VCF-family rows
-    (``vmware/9.0``, ``sddc-manager/9.0``, ``nsx/4.2``) ship with
+    (``vmware/9.0``, ``sddc-manager/9.0``, ``nsx/9.0``) ship with
     ``catalog_ingest: spec-only`` because their upstream URLs are
     Broadcom Developer Portal HTML landing pages (vmware, sddc-manager)
     or fqdn-templated appliance URLs (nsx) — neither shape can drive
@@ -1210,7 +1210,7 @@ def _every_v2_connector_registered() -> Iterator[None]:
         ("harbor", "2.x", "harbor-rest", HarborConnector),
         ("hetzner-robot", "2026.04", "hetzner-rest", HetznerRobotConnector),
         ("k8s", "1.x", "k8s", KubernetesConnector),
-        ("nsx", "4.2", "nsx-rest", NsxConnector),
+        ("nsx", "9.0", "nsx-rest", NsxConnector),
         ("sddc-manager", "9.0", "sddc-rest", SddcManagerConnector),
         ("vault", "1.x", "vault", VaultConnector),
         ("vmware", "9.0", "vmware-rest", VmwareRestConnector),
@@ -2577,7 +2577,7 @@ def test_ingest_packaged_catalog_html_portal_entries_carry_warning_notes() -> No
     ``sddc-manager/9.0`` -- the two confirmed offenders -- both carry
     the warning mirroring the ``harbor/2.x`` Swagger-2.0 precedent. The
     other ``spec_info_version: null`` entries are excluded by earlier
-    422 gates -- ``nsx/4.2`` via ``catalog_entry_templated_upstream``
+    422 gates -- ``nsx/9.0`` via ``catalog_entry_templated_upstream``
     (FQDN placeholder), the three typed connectors (``vault/1.x``,
     ``k8s/1.x``, ``bind9/9.x``) via ``catalog_entry_typed_connector``
     (``upstream: null``) -- so they never reach the fetch path the

--- a/backend/tests/test_connectors_nsx_auth.py
+++ b/backend/tests/test_connectors_nsx_auth.py
@@ -118,11 +118,32 @@ def test_nsx_connector_subclasses_http_connector() -> None:
     """Sanity check: the connector inherits from HttpConnector with the right metadata."""
     assert issubclass(NsxConnector, HttpConnector)
     assert NsxConnector.product == "nsx"
-    assert NsxConnector.version == "4.2"
+    # #1530: VCF-9 renumber — class pin tracks the "9.0" line, range
+    # keeps the standalone NSX-T 4.x line dispatchable.
+    assert NsxConnector.version == "9.0"
     assert NsxConnector.impl_id == "nsx-rest"
-    assert NsxConnector.supported_version_range == ">=4.0,<5.0"
+    assert NsxConnector.supported_version_range == ">=4.0,<10.0"
     # Outranks a future GenericRestConnector auto-shim defensively.
     assert NsxConnector.priority == 1
+
+
+def test_nsx_supported_range_covers_both_4x_and_vcf9_9x() -> None:
+    """The widened range covers standalone NSX-T 4.x and VCF-9-aligned 9.x.
+
+    #1530: a VCF-9 appliance reports NSX 9.0.x and its spec carries
+    ``info.version`` in the 9.x scheme (e.g. 9.1.0.0). The widened
+    ``>=4.0,<10.0`` advertisement is what lets the ingest version-range
+    pre-flight and the runtime resolver accept a 9.x label against this
+    one class; 10.0 and above stay out of band.
+    """
+    from packaging.specifiers import SpecifierSet
+    from packaging.version import Version
+
+    spec = SpecifierSet(NsxConnector.supported_version_range)
+    for covered in ("4.0", "4.2", "9.0", "9.0.2", "9.1.0.0", "9.9"):
+        assert Version(covered) in spec, f"{covered} should be covered by {spec}"
+    for excluded in ("3.9", "10.0", "10.1"):
+        assert Version(excluded) not in spec, f"{excluded} should be out of band for {spec}"
 
 
 def test_importing_package_registers_against_v2_registry() -> None:
@@ -130,7 +151,7 @@ def test_importing_package_registers_against_v2_registry() -> None:
     from meho_backplane.connectors.registry import all_connectors_v2
 
     registry = all_connectors_v2()
-    key = ("nsx", "4.2", "nsx-rest")
+    key = ("nsx", "9.0", "nsx-rest")
     assert key in registry
     assert registry[key] is NsxConnector
 

--- a/backend/tests/test_connectors_nsx_credread.py
+++ b/backend/tests/test_connectors_nsx_credread.py
@@ -70,7 +70,13 @@ from ._vault_fakes import install_fake_client
 _CANARY_USERNAME = "svc-nsx-canary"
 _CANARY_PASSWORD = "p4ss-canary-must-not-leak-credread-nsx"
 
-#: The connector triple ``nsx-rest-4.2`` decodes to.
+#: The connector triple ``nsx-rest-4.2`` decodes to. Deliberately a
+#: 4.x label (not the VCF-9-aligned "9.0" class pin) so this test
+#: doubles as a regression guard that a standalone NSX-T 4.x target
+#: still dispatches through the widened-range NsxConnector (#1530):
+#: the test registers this triple against a fresh registry and the
+#: target's fingerprint reports ``version=4.2``, so the resolver binds
+#: via the ``>=4.0,<10.0`` SpecifierSet, not the class pin.
 _PRODUCT = "nsx"
 _VERSION = "4.2"
 _IMPL_ID = "nsx-rest"

--- a/backend/tests/test_connectors_nsx_e2e.py
+++ b/backend/tests/test_connectors_nsx_e2e.py
@@ -296,7 +296,7 @@ async def nsx_e2e_401_canary(
                 200,
                 json={
                     "node_version": NSX_VERSION,
-                    "kernel_version": "4.2.1.0.0",
+                    "kernel_version": "9.0.2.0.0",
                     "node_uuid": "deadbeef-retry-test",
                     "hostname": "nsx-retry.test.invalid",
                 },

--- a/backend/tests/test_connectors_nsx_vcf9_ingest.py
+++ b/backend/tests/test_connectors_nsx_vcf9_ingest.py
@@ -1,0 +1,281 @@
+# SPDX-License-Identifier: Apache-2.0
+# Copyright (c) 2026 evoila Group
+
+"""VCF-9 NSX 9.x ingest + dispatch + curation tests (#1530).
+
+NSX-T 4.x was renumbered onto the VCF train at VCF 9.0 — a live
+appliance reports NSX 9.0.x and the vendor spec carries ``info.version``
+in the 9.x scheme (observed ``9.1.0.0``). Before #1530 the
+:class:`~meho_backplane.connectors.nsx.NsxConnector` advertised
+``supported_version_range=">=4.0,<5.0"``, so a VCF-9 NSX appliance was
+un-ingestable into a *dispatchable* connector under any label: labelling
+``version=9.1.0.0`` cleared the spec/label gate but the class
+version-range pre-flight rejected it; labelling ``version=4.2`` cleared
+the range but failed the spec/label match.
+
+This module pins the three legs of the fix:
+
+* **Ingest version-range pre-flight** —
+  :func:`check_version_covered_by_registered_class` accepts a VCF-9 9.x
+  label against the registered :class:`NsxConnector` and still rejects
+  a 10.x label that falls outside the widened band.
+* **Runtime dispatch** —
+  :func:`~meho_backplane.connectors.resolver.resolve_connector` binds a
+  9.x-fingerprinted NSX target to :class:`NsxConnector`.
+* **Core-op curation** —
+  :func:`~meho_backplane.connectors.nsx.apply_nsx_core_curation` resolves
+  the connector_id the ingest actually landed under (e.g.
+  ``nsx-rest-9.1.0.0`` from an operator-supplied 9.x label), not the
+  hard-coded 4.2 slug it used before.
+
+SQLite via the autouse ``_default_database_url`` conftest fixture; no
+``pg_engine`` required. Runs in the ``meho-runners-ci`` lane alongside the
+other ``backend/tests/test_connectors_nsx_*.py`` files; no Docker.
+"""
+
+from __future__ import annotations
+
+import uuid
+from collections.abc import Iterator
+
+import pytest
+
+from meho_backplane.auth.operator import Operator, TenantRole
+from meho_backplane.connectors.nsx import (
+    NSX_CONNECTOR_ID,
+    NSX_CORE_GROUPS,
+    NSX_CORE_OPS,
+    NSX_IMPL_ID,
+    NSX_PRODUCT,
+    NsxConnector,
+    apply_nsx_core_curation,
+)
+from meho_backplane.connectors.resolver import resolve_connector
+from meho_backplane.db.engine import get_sessionmaker
+from meho_backplane.db.models import EndpointDescriptor, OperationGroup
+from meho_backplane.operations.ingest import (
+    ReviewService,
+    UncoveredVersionLabel,
+    check_version_covered_by_registered_class,
+)
+from meho_backplane.settings import get_settings
+
+#: The ``info.version`` a VCF-9 NSX appliance's spec carries (per the
+#: #1530 origin report, RDC ci-01). An operator labels the ingest with
+#: this value so it matches the spec, then dispatches under the derived
+#: ``connector_id="nsx-rest-9.1.0.0"``.
+_VCF9_LABEL = "9.1.0.0"
+_VCF9_CONNECTOR_ID = f"{NSX_IMPL_ID}-{_VCF9_LABEL}"
+
+_TEST_TENANT = uuid.UUID("9f000000-0000-0000-0000-0000000009f0")
+
+
+@pytest.fixture(autouse=True)
+def _required_settings_env(monkeypatch: pytest.MonkeyPatch) -> Iterator[None]:
+    """Pin the Settings env vars Operator construction reads transitively."""
+    monkeypatch.setenv("KEYCLOAK_ISSUER_URL", "https://keycloak.test/realms/meho")
+    monkeypatch.setenv("KEYCLOAK_AUDIENCE", "meho-backplane")
+    monkeypatch.setenv("VAULT_ADDR", "https://vault.test")
+    get_settings.cache_clear()
+    yield
+    get_settings.cache_clear()
+
+
+def _make_operator() -> Operator:
+    """Build a tenant-admin operator for the curation leg."""
+    return Operator(
+        sub=f"nsx-vcf9-test-{uuid.uuid4()}",
+        name="NSX VCF9 Ingest Test",
+        email=None,
+        raw_jwt="header.payload.signature",
+        tenant_id=_TEST_TENANT,
+        tenant_role=TenantRole.TENANT_ADMIN,
+    )
+
+
+class _FingerprintStub:
+    """Minimal ``target.fingerprint`` shape the resolver reads."""
+
+    def __init__(self, version: str) -> None:
+        self.version = version
+
+
+class _TargetStub:
+    """Duck-typed target carrying ``.product`` + ``.fingerprint.version``."""
+
+    def __init__(self, *, product: str, version: str) -> None:
+        self.product = product
+        self.fingerprint = _FingerprintStub(version)
+
+
+# ---------------------------------------------------------------------------
+# Leg 1 — ingest version-range pre-flight
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.parametrize("label", ["9.0", "9.0.2", "9.1.0.0", "9.9", "4.2"])
+def test_ingest_preflight_accepts_nsx_9x_and_4x_labels(label: str) -> None:
+    """The ingest range pre-flight accepts VCF-9 9.x (and still 4.x) labels.
+
+    Before #1530 the only registered ``(nsx, nsx-rest)`` class advertised
+    ``>=4.0,<5.0``, so a 9.x label raised :exc:`UncoveredVersionLabel`
+    here. The widened ``>=4.0,<10.0`` advertisement covers the whole
+    VCF-aligned band; the call returns ``None`` (no raise).
+    """
+    # Returns None on success; an uncovered label would raise.
+    check_version_covered_by_registered_class(
+        product=NSX_PRODUCT,
+        version=label,
+        impl_id=NSX_IMPL_ID,
+    )
+
+
+@pytest.mark.parametrize("label", ["10.0", "10.1", "3.9"])
+def test_ingest_preflight_rejects_out_of_band_labels(label: str) -> None:
+    """Labels outside ``>=4.0,<10.0`` still raise — the widen is bounded.
+
+    The fix widens the band to the VCF-aligned 9.x line, not to "any
+    version". A 10.x label (a hypothetical future NSX line that would
+    need its own class / range decision) and a pre-4.0 label both stay
+    uncovered so the operator gets the actionable
+    :exc:`UncoveredVersionLabel` 422 rather than a silent dead-letter
+    ingest.
+    """
+    with pytest.raises(UncoveredVersionLabel) as exc_info:
+        check_version_covered_by_registered_class(
+            product=NSX_PRODUCT,
+            version=label,
+            impl_id=NSX_IMPL_ID,
+        )
+    assert exc_info.value.product == NSX_PRODUCT
+    assert exc_info.value.version == label
+
+
+# ---------------------------------------------------------------------------
+# Leg 2 — runtime dispatch resolution
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.parametrize("version", ["9.0.2", "9.1.0.0", "4.2"])
+def test_resolver_dispatches_nsx_9x_target_to_nsx_connector(version: str) -> None:
+    """A 9.x-fingerprinted NSX target resolves to :class:`NsxConnector`.
+
+    The resolver keys on the class's PEP 440 ``supported_version_range``
+    (a :class:`packaging.specifiers.SpecifierSet`), not the class-pinned
+    ``version`` attribute — so widening the range is sufficient for
+    dispatch (#1530). The 4.x case proves the standalone NSX-T line still
+    binds through the same class.
+    """
+    target = _TargetStub(product=NSX_PRODUCT, version=version)
+    assert resolve_connector(target) is NsxConnector
+
+
+# ---------------------------------------------------------------------------
+# Leg 3 — core-op curation resolves the ingest's connector_id
+# ---------------------------------------------------------------------------
+
+
+async def _seed_groups_and_ops(*, connector_version: str) -> None:
+    """Seed the 9 curated NSX ops + groups under a given version label.
+
+    Mirrors the G0.7 ingest default: ``review_status='staged'`` groups,
+    ``is_enabled=False`` / ``source_kind='ingested'`` ops, scoped to the
+    operator tenant so the curation's audit-log path stays isolated.
+    """
+    sessionmaker = get_sessionmaker()
+    group_ids: dict[str, uuid.UUID] = {}
+    async with sessionmaker() as session:
+        for group in NSX_CORE_GROUPS:
+            group_id = uuid.uuid4()
+            session.add(
+                OperationGroup(
+                    id=group_id,
+                    tenant_id=_TEST_TENANT,
+                    product=NSX_PRODUCT,
+                    version=connector_version,
+                    impl_id=NSX_IMPL_ID,
+                    group_key=group.group_key,
+                    name=f"PLACEHOLDER {group.group_key}",
+                    when_to_use=f"PLACEHOLDER when_to_use {group.group_key}",
+                    review_status="staged",
+                ),
+            )
+            group_ids[group.group_key] = group_id
+
+        for op in NSX_CORE_OPS:
+            method, path = op.op_id.split(":", 1)
+            session.add(
+                EndpointDescriptor(
+                    tenant_id=_TEST_TENANT,
+                    product=NSX_PRODUCT,
+                    version=connector_version,
+                    impl_id=NSX_IMPL_ID,
+                    op_id=op.op_id,
+                    source_kind="ingested",
+                    method=method,
+                    path=path,
+                    group_id=group_ids[op.group_key],
+                    summary=f"ingested op {op.op_id}",
+                    is_enabled=False,
+                ),
+            )
+        await session.commit()
+
+
+async def _enabled_state(*, connector_version: str) -> dict[str, bool]:
+    """Return ``{op_id: is_enabled}`` for the seeded connector version."""
+    from sqlalchemy import select
+
+    sessionmaker = get_sessionmaker()
+    async with sessionmaker() as session:
+        rows = (
+            (
+                await session.execute(
+                    select(EndpointDescriptor).where(
+                        EndpointDescriptor.tenant_id == _TEST_TENANT,
+                        EndpointDescriptor.product == NSX_PRODUCT,
+                        EndpointDescriptor.version == connector_version,
+                        EndpointDescriptor.impl_id == NSX_IMPL_ID,
+                    )
+                )
+            )
+            .scalars()
+            .all()
+        )
+    return {row.op_id: row.is_enabled for row in rows}
+
+
+@pytest.mark.asyncio
+async def test_curation_resolves_operator_supplied_9x_connector_id() -> None:
+    """``apply_nsx_core_curation`` curates ops under the ingest's 9.x id.
+
+    Ingested rows land under the **operator-supplied** ``version`` label,
+    so a VCF-9 spec ingested as ``version=9.1.0.0`` produces
+    ``connector_id="nsx-rest-9.1.0.0"`` — not the class pin's
+    ``nsx-rest-9.0``. Passing that id to the parameterised helper (#1530)
+    enables exactly the 9 curated ops the ingest landed.
+    """
+    await _seed_groups_and_ops(connector_version=_VCF9_LABEL)
+
+    await apply_nsx_core_curation(
+        ReviewService(_make_operator()),
+        tenant_id=_TEST_TENANT,
+        connector_id=_VCF9_CONNECTOR_ID,
+    )
+
+    state = await _enabled_state(connector_version=_VCF9_LABEL)
+    core_op_ids = {op.op_id for op in NSX_CORE_OPS}
+    assert state, "expected the seeded 9.x ops to be present"
+    assert all(state[op_id] for op_id in core_op_ids), (
+        f"every curated 9.x core op should be enabled after curation; got {state}"
+    )
+
+
+def test_default_connector_id_tracks_the_vcf9_class_pin() -> None:
+    """The curation helper's default ``connector_id`` is ``nsx-rest-9.0``.
+
+    The default mirrors the registered class pin (#1530). An operator who
+    ingested under the exact ``9.0`` label can call the helper without an
+    override; finer 9.x labels supply the override.
+    """
+    assert NSX_CONNECTOR_ID == "nsx-rest-9.0"

--- a/backend/tests/test_operations_ingest_catalog.py
+++ b/backend/tests/test_operations_ingest_catalog.py
@@ -66,7 +66,10 @@ _EXPECTED_PRODUCT_VERSION = {
     ("vmware", "9.0"),
     ("sddc-manager", "9.0"),
     ("harbor", "2.x"),
-    ("nsx", "4.2"),
+    # #1530: NSX-T 4.x was renumbered onto the VCF train at VCF 9.0;
+    # the catalog row tracks the VCF-9-aligned "9.0" line (NsxConnector
+    # covers both 4.x and 9.x via supported_version_range ">=4.0,<10.0").
+    ("nsx", "9.0"),
     ("gh", "3"),
     ("vault", "1.x"),
     ("k8s", "1.x"),
@@ -744,12 +747,15 @@ def test_shipped_catalog_gh3_carries_compatibility_opt_in() -> None:
     assert info_version_matches_compatibility("1.1.4", gh.spec_info_versions_compatible)
 
 
-def test_shipped_catalog_only_gh_and_vmware_rows_opt_in() -> None:
+def test_shipped_catalog_only_gh_vmware_and_nsx_rows_opt_in() -> None:
     """The opt-in is targeted. ``gh`` opts in to bridge the v3-vs-1.1.4
     divergence (T5 #1307); ``vmware`` opts in as a belt-and-suspenders
     declaration over the existing PEP-440 prefix-match (T6 Finding H
-    #1312). All other rows keep ``spec_info_versions_compatible`` null."""
-    expected_opt_in = {"gh", "vmware"}
+    #1312); ``nsx`` opts in to the ``9.x.x`` band so a VCF-9 appliance
+    spec (info.version in the 9.x scheme) clears the spec/label gate
+    under the renumbered "9.0" catalog label (#1530). All other rows
+    keep ``spec_info_versions_compatible`` null."""
+    expected_opt_in = {"gh", "vmware", "nsx"}
     for entry in load_catalog().entries:
         if entry.product in expected_opt_in:
             continue
@@ -797,16 +803,17 @@ def test_shipped_catalog_marks_vcf_family_rows_spec_only() -> None:
     * ``vmware/9.0`` + ``sddc-manager/9.0`` — Broadcom Developer Portal
       ``text/html`` landing pages; the route's existing
       ``catalog_entry_upstream_not_spec`` 422 fires.
-    * ``nsx/4.2`` — first upstream is fqdn-templated
+    * ``nsx/9.0`` — first upstream is fqdn-templated
       (``<nsx-mgr-fqdn>``); the route's
-      ``catalog_entry_templated_upstream`` 422 fires.
+      ``catalog_entry_templated_upstream`` 422 fires. (Row renumbered
+      from ``nsx/4.2`` for the VCF-9 alignment, #1530.)
 
     Marking these rows ``"spec-only"`` is what lets the listing emit
     an honest ``--spec`` ``next_step`` hint instead of the previous
     "spec available in catalog; run ingest" line that sent operators
     into a 422.
     """
-    spec_only_pairs = {("vmware", "9.0"), ("sddc-manager", "9.0"), ("nsx", "4.2")}
+    spec_only_pairs = {("vmware", "9.0"), ("sddc-manager", "9.0"), ("nsx", "9.0")}
     for entry in load_catalog().entries:
         if (entry.product, entry.version) in spec_only_pairs:
             assert entry.catalog_ingest == "spec-only", (

--- a/docs/codebase/connectors-nsx.md
+++ b/docs/codebase/connectors-nsx.md
@@ -1,10 +1,10 @@
-# Connector: nsx (NSX 4.x)
+# Connector: nsx (NSX 4.x + VCF-9 9.x)
 
 ## Overview
 
 The `nsx` connector is the hand-rolled `HttpConnector` subclass that
 dispatches ingested NSX REST operations under the
-`(product="nsx", version="4.2", impl_id="nsx-rest")` registry triple.
+`(product="nsx", version="9.0", impl_id="nsx-rest")` registry triple.
 G3.5-T1 (#613) shipped the skeleton -- session-cookie / XSRF auth,
 fingerprint, probe, and the G0.6 dispatch shim. G3.5-T2 (#614) adds
 the **operator-review curation substrate**: the 9 read-only core
@@ -13,14 +13,27 @@ hints + the `apply_nsx_core_curation` helper that the operator
 review step calls against the G0.7-ingested connector. CLI verbs +
 MCP review + recorded-fixture E2E arrive in G3.5-T3 (#615).
 
+**VCF-9 version renumber (#1530).** NSX-T 4.x was renumbered onto the
+VCF train at VCF 9.0 -- a live VCF-9 appliance reports NSX 9.0.x and
+the vendor spec carries `info.version` in the 9.x scheme (observed
+`9.1.0.0`). The class pin tracks the VCF-9-aligned `"9.0"` line and
+`supported_version_range` was widened to `">=4.0,<10.0"` so a single
+class covers both the standalone NSX-T 4.x line and the VCF-9 9.x
+line. Dispatch and the ingest version-range pre-flight key on the
+`SpecifierSet`, not the class pin, so the one class resolves every
+label in the band. Same renumber posture `VmwareRestConnector` took
+for the vSphere 8.x -> 9.0 jump.
+
 Source: `backend/src/meho_backplane/connectors/nsx/`.
 
 ## Key types
 
 - **`NsxConnector`** (`connector.py`) -- `HttpConnector` subclass.
-  Class attributes: `product="nsx"`, `version="4.2"`,
-  `impl_id="nsx-rest"`, `supported_version_range=">=4.0,<5.0"`,
-  `priority=1`. The priority outranks a future
+  Class attributes: `product="nsx"`, `version="9.0"`,
+  `impl_id="nsx-rest"`, `supported_version_range=">=4.0,<10.0"`,
+  `priority=1`. The version pin tracks the VCF-9-aligned product line
+  (#1530); the widened range keeps the standalone NSX-T 4.x line
+  dispatchable through the same class. The priority outranks a future
   `GenericRestConnector` auto-shim (priority=0) defensively if both
   somehow register for the same triple.
 - **`NsxTargetLike`** (`session.py`) -- runtime-checkable Protocol
@@ -69,12 +82,14 @@ Source: `backend/src/meho_backplane/connectors/nsx/`.
    `connectors/<product>/` subpackage in name-sorted order.
 2. Importing `meho_backplane.connectors.nsx` triggers the
    module-level
-   `register_connector_v2(product="nsx", version="4.2", impl_id="nsx-rest", cls=NsxConnector)`
+   `register_connector_v2(product="nsx", version="9.0", impl_id="nsx-rest", cls=NsxConnector)`
    call.
-3. The registry's v2 table now resolves `("nsx", "4.2", "nsx-rest")`
+3. The registry's v2 table now resolves `("nsx", "9.0", "nsx-rest")`
    to `NsxConnector`. The G0.7 auto-shim's idempotency check (in
    `ensure_connector_class_registered`, once #408's pipeline lands
    in main) no-ops on subsequent ingests against the same triple.
+   The resolver binds a target by `supported_version_range`
+   membership, so a 4.x or 9.x fingerprinted target both bind here.
 
 ### Per-target session
 
@@ -148,7 +163,7 @@ instead of hammering NSX's audit log.
 `execute(target, op_id, params)` synthesises a minimal `Operator`
 (nil-UUID tenant_id + `sub="system:nsx-rest-connector-shim"`) and
 delegates to `meho_backplane.operations.dispatch` with
-`connector_id="nsx-rest-4.2"`. Pre-G0.6 chassis routes that still
+`connector_id="nsx-rest-9.0"`. Pre-G0.6 chassis routes that still
 invoke `Connector.execute` directly reach the dispatcher through
 this shim; post-G0.6 callers (the `/api/v1/operations/call` route,
 MCP `call_operation`, the CLI verbs once #615 lands) construct a
@@ -189,8 +204,8 @@ concern, same posture vSphere takes for proactive refresh.
 ## Operator-review curation flow (G3.5-T2)
 
 The `core_ops.py` constants land the operator-review side of the
-G0.7 ingest. After a G0.7 ingest of `nsx-4.2/policy.yaml` +
-`manager.yaml` lands the full NSX descriptor set in the
+G0.7 ingest. After a G0.7 ingest of the NSX `policy.yaml` +
+`manager.yaml` corpus lands the full NSX descriptor set in the
 `endpoint_descriptor` table (every row `is_enabled=False`,
 `source_kind='ingested'`), the operator runs:
 
@@ -200,6 +215,19 @@ from meho_backplane.operations.ingest import ReviewService
 
 review_service = ReviewService(operator)
 await apply_nsx_core_curation(review_service, tenant_id=None)
+```
+
+Ingested ops land under the **operator-supplied** `version` label,
+so a VCF-9 spec ingested as `version="9.1.0.0"` produces
+`connector_id="nsx-rest-9.1.0.0"` rather than the class pin's
+`nsx-rest-9.0` (#1530). `apply_nsx_core_curation` takes a
+`connector_id` keyword (default `NSX_CONNECTOR_ID = "nsx-rest-9.0"`)
+so the operator passes the id the ingest actually produced:
+
+```python
+await apply_nsx_core_curation(
+    review_service, tenant_id=None, connector_id="nsx-rest-9.1.0.0"
+)
 ```
 
 The helper drives the substrate through three substrate calls per
@@ -221,7 +249,7 @@ posture `edit_group` takes for `when_to_use`).
 
 ## Known issues
 
-- The full G0.7 ingest of `nsx-4.2/policy.yaml` + `manager.yaml` is
+- The full G0.7 ingest of the NSX `policy.yaml` + `manager.yaml` is
   operator-driven via `meho connector ingest` (the runbook lives at
   `docs/cross-repo/g35-nsx-canary.md`). The env-gated canary
   acceptance test that automates the live two-spec ingest in CI is a


### PR DESCRIPTION
## Summary

- NSX-T 4.x was renumbered onto the VCF train at VCF 9.0: a live VCF-9 appliance reports NSX 9.0.x and the vendor spec carries `info.version` in the 9.x scheme (observed `9.1.0.0`). `NsxConnector` advertised `supported_version_range=">=4.0,<5.0"`, so a VCF-9 NSX appliance was **un-ingestable into a dispatchable connector under any label** — labelling `version=9.1.0.0` cleared the spec/label gate but the class version-range pre-flight rejected it; labelling `version=4.2` cleared the range but failed the spec/label match. The two gates pincered every version (SEV-1).
- **Widen** `NsxConnector.supported_version_range` to `">=4.0,<10.0"` so one class covers both the standalone NSX-T 4.x line and the VCF-9-aligned 9.x line. Dispatch and the ingest range pre-flight key on the `SpecifierSet`, not the class pin, so a range widen is sufficient for dispatch.
- **Re-seed** the class pin + the catalog row to the VCF-9-aligned `"9.0"` line so the registered-connector `next_step` and `meho connector list` reference the 9.x major (not 4.2). The standalone NSX-T 4.x line still dispatches through the same class.
- **Parameterise** `apply_nsx_core_curation` with a `connector_id` keyword (default `nsx-rest-9.0`) so it curates the ops the ingest actually landed — ingested rows land under the operator-supplied label (e.g. `nsx-rest-9.1.0.0`), not the class pin. Same renumber posture `VmwareRestConnector` took for the vSphere 8.x → 9.0 jump.

## Test plan

- [x] `ruff check src/meho_backplane/ tests/` — clean
- [x] `ruff format --check` (changed Python files) — clean
- [x] `mypy src/meho_backplane/connectors/nsx/` — clean
- [x] `code-quality.py --diff` — 0 blockers (refactored `apply_nsx_core_curation` 155→85 lines by extracting phase helpers)
- [x] `pytest -k "nsx or catalog or ingest or resolver ..."` — 625 passed, 29 skipped (env-gated)
- [x] **AC1** (VCF-9 9.x ingests into a connector that resolves + authenticates, fixture-backed): new `test_connectors_nsx_vcf9_ingest.py` (ingest pre-flight accepts 9.x) + the auth/session/E2E suites now running against the 9.0 class
- [x] **AC2** (`connector list` nsx 9.x entry; `next_step` + catalog row reference 9.x): catalog row + registry pin are `nsx 9.0`; `test_operations_ingest_catalog.py` asserts the `("nsx","9.0")` pair + spec-only
- [x] **AC3** (resolver dispatches a 9.x nsx target to `NsxConnector`): `test_resolver_dispatches_nsx_9x_target_to_nsx_connector`
- [x] **AC4** (`apply_nsx_core_curation` applies to the 9.x connector_id / hardcode parameterised): `test_curation_resolves_operator_supplied_9x_connector_id`

## Out of scope

- meho-side Swagger-2.0 acceptance — consumer converts; sibling task #1532.
- The bare-error DX on the MCP ingest path — consolidated MCP error-parity sibling task #1534.
- Adjacent findings (recorded, deferred): pre-existing file/function-size **warnings** on `connectors/nsx/connector.py` (520 lines) and `core_ops.py` (766 lines); `_session_token` is 75 lines. All pre-existing debt, no blocker.

<!-- auto-implement-issue: fresh, iteration 1 -->

Closes #1530
