### PR TITLE
docs(connectors): bless hand-authored-OpenAPI-3.x --spec on-ramp (#1533)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -90,6 +90,16 @@ connector-related release-notes line.
 
 ## [Unreleased]
 
+### Connector ingest — hand-authored spec on-ramp (#1533)
+
+- Document the hand-authored-OpenAPI-3.x → `--spec file://…` route as the
+  intended on-ramp for products that publish **no** OpenAPI spec (VCF
+  Fleet / vRSLCM, Hetzner Robot): a "Product publishes no OpenAPI spec"
+  section in `docs/cross-repo/connector-ingestion.md` with a minimal
+  worked example, and the catalog-miss `next_step` rationale widened to
+  name it so a 0-op `state=registered` connector no longer reads as a
+  dead end.
+
 ### Added
 
 - Add a corpus-agnostic per-tenant **capability gate** on the MCP tool +

--- a/backend/src/meho_backplane/operations/ingest/list_connectors.py
+++ b/backend/src/meho_backplane/operations/ingest/list_connectors.py
@@ -183,7 +183,14 @@ def _next_step_for_registered(
       rationale calls out the missing catalog entry so the operator
       knows they need to source the OpenAPI spec themselves. Manual
       mode is the same path G0.7-T5 already supports for one-off /
-      not-yet-curated specs (see ``ingest.go``'s mode dispatch).
+      not-yet-curated specs (see ``ingest.go``'s mode dispatch). The
+      rationale also names the **hand-authored** route so a spec-less
+      product (the vendor publishes no OpenAPI at all — VCF Fleet /
+      vRSLCM, Hetzner Robot) doesn't read as a dead end: author a
+      minimal OpenAPI 3.x covering just the ops you need and pass it
+      via ``--spec file://…`` (#1533 / ci-07). See
+      ``docs/cross-repo/connector-ingestion.md`` §"Product publishes
+      no OpenAPI spec".
 
     *catalog* is ``None`` when the package-data load failed (a malformed
     catalog at startup would have crashed the lifespan, so this branch
@@ -219,7 +226,10 @@ def _next_step_for_registered(
         ),
         rationale=(
             "not in catalog; run manual ingest with --spec pointing at the "
-            "vendor OpenAPI spec (file:// / https:// / docs:<...>)"
+            "vendor OpenAPI spec (file:// / https:// / docs:<...>). If the "
+            "product publishes no OpenAPI spec at all, author a minimal "
+            "OpenAPI 3.x covering just the ops you need and pass it via "
+            "--spec file://… (see connector-ingestion.md)"
         ),
     )
 

--- a/backend/tests/fixtures/openapi/handauthored_minimal_30.yaml
+++ b/backend/tests/fixtures/openapi/handauthored_minimal_30.yaml
@@ -1,0 +1,43 @@
+# A hand-authored minimal OpenAPI 3.0.3 spec for a product whose vendor
+# publishes no OpenAPI document at all (the #1533 / ci-07 on-ramp). It
+# covers just the two ops an operator needs to dispatch — list servers
+# and reset one — and is the worked example in
+# docs/cross-repo/connector-ingestion.md §"Product publishes no OpenAPI
+# spec". Modelled on Hetzner Robot (HTML/Markdown docs only).
+openapi: 3.0.3
+info:
+  title: Hetzner Robot (hand-authored)
+  version: "1.0"
+paths:
+  /server:
+    get:
+      summary: List dedicated servers
+      description: Returns every dedicated server on the account.
+      operationId: listServers
+      tags:
+        - server
+      responses:
+        "200":
+          description: A list of servers.
+          content:
+            application/json:
+              schema:
+                type: array
+                items:
+                  type: object
+  /reset/{server_ip}:
+    post:
+      summary: Trigger a hardware reset
+      description: Sends a reset signal to the server addressed by server_ip.
+      operationId: resetServer
+      tags:
+        - server
+      parameters:
+        - name: server_ip
+          in: path
+          required: true
+          schema:
+            type: string
+      responses:
+        "200":
+          description: Reset accepted.

--- a/backend/tests/test_api_v1_connectors_ingest.py
+++ b/backend/tests/test_api_v1_connectors_ingest.py
@@ -947,7 +947,11 @@ async def test_list_registered_row_without_catalog_entry_points_at_manual_mode(
       manual-mode invocation), echoing the registry's natural key so
       the operator copies the right values verbatim;
     * carry a rationale that says the catalog has no entry so the
-      operator knows they need to source the OpenAPI spec themselves.
+      operator knows they need to source the OpenAPI spec themselves;
+    * name the hand-authored on-ramp (#1533 / ci-07) so a spec-less
+      product whose vendor publishes no OpenAPI at all doesn't read as
+      a dead end — the operator can author a minimal OpenAPI 3.x and
+      pass it via ``--spec file://…``.
     """
     tenant_a = uuid.uuid4()
     key, token = _operator_token(tenant_id=tenant_a)
@@ -969,6 +973,10 @@ async def test_list_registered_row_without_catalog_entry_points_at_manual_mode(
     rationale = custom["next_step"]["rationale"]
     assert "not in catalog" in rationale
     assert "--spec" in rationale
+    # The widened rationale (#1533) must name the hand-authored route so
+    # a spec-less product doesn't read as a dead end.
+    assert "author a minimal OpenAPI 3.x" in rationale
+    assert "file://" in rationale
 
 
 @pytest.mark.asyncio

--- a/backend/tests/test_operations_ingest_openapi.py
+++ b/backend/tests/test_operations_ingest_openapi.py
@@ -37,6 +37,7 @@ PETSTORE_31_JSON = FIXTURES / "petstore_31.json"
 PARAMETER_REFS_30 = FIXTURES / "parameter_refs_30.yaml"
 RESPONSE_REFS_30 = FIXTURES / "response_refs_30.yaml"
 REQUEST_BODY_REFS_30 = FIXTURES / "request_body_refs_30.yaml"
+HANDAUTHORED_MINIMAL_30 = FIXTURES / "handauthored_minimal_30.yaml"
 
 
 def _by_op_id(rows: list[EndpointDescriptorProto]) -> dict[str, EndpointDescriptorProto]:
@@ -182,6 +183,50 @@ def test_parse_petstore_31_json_route() -> None:
     rows = parse_openapi(str(PETSTORE_31_JSON))
     assert {r.op_id for r in rows} == {"GET:/zoos"}
     assert rows[0].response_schema == {"type": "array", "items": {"type": "string"}}
+
+
+# -- hand-authored minimal spec (#1533 / ci-07 on-ramp) --------------------
+
+
+def test_parse_handauthored_minimal_spec_via_file_uri() -> None:
+    """A hand-authored minimal OpenAPI 3.x ingests via a ``file://`` URI.
+
+    #1533 / ci-07: for a product whose vendor publishes no OpenAPI doc
+    at all (VCF Fleet / vRSLCM, Hetzner Robot), the supported on-ramp is
+    to author a minimal OpenAPI 3.x covering just the needed ops and
+    pass it to ``meho connector ingest … --spec file://…``. A
+    hand-authored spec is identical to a downloaded one once it reaches
+    the parser; this test is the worked example proving the end-to-end
+    parse from a ``file://`` URI, matching the workflow documented in
+    ``docs/cross-repo/connector-ingestion.md`` §"Product publishes no
+    OpenAPI spec".
+
+    ``Path.as_uri()`` is the cross-platform ``file://`` form the
+    operator types after ``meho connector ingest`` resolves their local
+    path; the parser's ``file`` scheme branch round-trips it through
+    ``url2pathname`` back to the on-disk file.
+    """
+    file_uri = HANDAUTHORED_MINIMAL_30.as_uri()
+    assert file_uri.startswith("file://")
+
+    rows = parse_openapi(file_uri, spec_source="spec:hetzner-robot.yaml")
+    ops = _by_op_id(rows)
+
+    assert set(ops) == {"GET:/server", "POST:/reset/{server_ip}"}
+
+    list_servers = ops["GET:/server"]
+    assert list_servers.summary == "List dedicated servers"
+    assert list_servers.safety_level == "safe"
+    # The hand-authored source tag threads through unchanged so an
+    # operator can audit which spec a row came from in review.
+    assert "spec:hetzner-robot.yaml" in list_servers.tags
+
+    reset = ops["POST:/reset/{server_ip}"]
+    # POST is a write → "caution" under the same heuristic a downloaded
+    # spec gets; the path param is required.
+    assert reset.safety_level == "caution"
+    assert reset.parameter_schema["properties"]["server_ip"]["x-meho-param-loc"] == "path"
+    assert "server_ip" in reset.parameter_schema["required"]
 
 
 # -- spec_source merging ---------------------------------------------------

--- a/docs/cross-repo/connector-ingestion.md
+++ b/docs/cross-repo/connector-ingestion.md
@@ -44,6 +44,73 @@ Vendor specs live in one of three places, in priority order:
 2. **The vendor's published URL** (e.g. `https://developer.vmware.com/.../vcenter-rest-9.0.yaml`). Use a full `https://` URL.
 3. **A local download.** Use a full `file:///` path.
 
+All three sources assume the vendor *publishes* an OpenAPI document somewhere. If it doesn't, jump to the next section before concluding the connector is un-ingestable.
+
+#### Product publishes no OpenAPI spec
+
+Some products ship **no** OpenAPI document at all — only HTML/Markdown reference docs (Hetzner Robot), or a proprietary management API with no published spec (VCF Fleet / vRSLCM `/lcm/`). For these, `meho connector ingest` is **not** a dead end, and the catalog-miss `next_step` hint on a `state=registered`, 0-operation connector points you here.
+
+The ingest pipeline only ever sees the *bytes* of an OpenAPI 3.x document — it does not care whether a vendor published those bytes or you typed them by hand. So the supported on-ramp is:
+
+1. **Author a minimal OpenAPI 3.x** covering just the operations you need today. You do **not** have to model the vendor's entire API — a handful of ops is enough to unblock an agent workflow, and you can extend the spec and re-ingest later (re-ingest is idempotent on unchanged rows).
+2. **Save it locally** and ingest it with a `file://` URI, exactly as you would a downloaded spec:
+
+   ```bash
+   meho connector ingest \
+     --product hetzner-robot --version 1.0 --impl hetzner-rest \
+     --spec file:///abs/path/hetzner-robot.yaml \
+     --dry-run
+   ```
+
+A minimal worked example for a spec-less product (two ops — list servers, reset one):
+
+```yaml
+# hetzner-robot.yaml
+openapi: 3.0.3
+info:
+  title: Hetzner Robot (hand-authored)
+  version: "1.0"
+paths:
+  /server:
+    get:
+      summary: List dedicated servers
+      operationId: listServers
+      tags: [server]
+      responses:
+        "200":
+          description: A list of servers.
+          content:
+            application/json:
+              schema:
+                type: array
+                items:
+                  type: object
+  /reset/{server_ip}:
+    post:
+      summary: Trigger a hardware reset
+      operationId: resetServer
+      tags: [server]
+      parameters:
+        - name: server_ip
+          in: path
+          required: true
+          schema:
+            type: string
+      responses:
+        "200":
+          description: Reset accepted.
+```
+
+`--dry-run` against this file prints `operations: 2 total (2 inserted …)`; drop `--dry-run` to ingest for real, then continue from [Step 2](#step-2--ingest-the-spec). The parser applies the **same** safety heuristic a downloaded spec gets (`GET` → `safe`, `POST` → `caution`, `DELETE` → `dangerous`), so review the staged groups (Step 4) and mark per-op overrides (Step 6) the same way.
+
+Authoring tips:
+
+- Use the verbs and paths the vendor's HTML/Markdown docs already describe, so the ingested `op_id` (e.g. `POST:/reset/{server_ip}`) reads naturally at the agent surface.
+- Give each operation a `summary` and `description` — these feed the LLM grouping pass and the agent's `when_to_use` retrieval, so a one-line `summary` is worth more than a bare path.
+- A bad path-param shape or a malformed `$ref` surfaces under `--dry-run` before any DB write; iterate on the file until the dry-run op count matches what you intended.
+
+> **Why not auto-derive the spec?** Parsing vendor HTML/Markdown into OpenAPI, or deriving ops from a typed client, is a deliberately **deferred** capability ([initiative #1529 out-of-scope](https://github.com/evoila/meho/issues/1529)). A small hand-authored spec is the cheaper answer than an HTML→OpenAPI inference engine — author the ops you need, not the vendor's whole surface. Conform to [OpenAPI 3.0.3](https://spec.openapis.org/oas/v3.0.3.html) or [3.1.1](https://spec.openapis.org/oas/v3.1.1.html); the parser rejects Swagger 2.0 with a conversion-path remedy (see [`connector-catalog.md`](connector-catalog.md)).
+
 Validate the spec before committing to a tenant-wide ingestion:
 
 ```bash


### PR DESCRIPTION
## Summary

- For a product that publishes **no** OpenAPI spec (VCF Fleet / vRSLCM, Hetzner Robot), `connector ingest` read as a dead end — the catalog-miss `next_step` pointed `--spec` at a vendor spec that does not exist. meho already accepts a hand-authored OpenAPI 3.x via `--spec file://…` identically to a downloaded one; the supported route was just undiscoverable.
- Adds a "Product publishes no OpenAPI spec" section to `docs/cross-repo/connector-ingestion.md` describing the author-a-minimal-3.x → `--spec file://…` workflow, with a minimal worked example (two ops).
- Widens the catalog-miss `next_step` rationale in `list_connectors.py` to name the hand-authored option, so a 0-op `state=registered` connector for a spec-less product no longer reads as a dead end.
- Adds a parser test that ingests a hand-authored minimal OpenAPI 3.0.3 fixture via a `file://` URI end-to-end (AC #3).

## Test plan

- [x] `ruff check` (touched files) — clean
- [x] `ruff format --check` (touched files) — clean
- [x] `mypy list_connectors.py` — clean
- [x] `pytest tests/test_operations_ingest_openapi.py tests/test_api_v1_connectors_ingest.py` — 128 passed
- [x] `code-quality.py --diff` — 0 blockers (pre-existing file-/function-size warnings only)
- [x] **AC #1** — docs section added with minimal worked example (`docs/cross-repo/connector-ingestion.md` §"Product publishes no OpenAPI spec")
- [x] **AC #2** — catalog-miss `next_step` rationale names the hand-authored option; `test_list_registered_row_without_catalog_entry_points_at_manual_mode` asserts `author a minimal OpenAPI 3.x` + `file://`
- [x] **AC #3** — `test_parse_handauthored_minimal_spec_via_file_uri` ingests a hand-authored minimal OpenAPI 3.0.3 via `file://` (`GET:/server`, `POST:/reset/{server_ip}`)

## Out of scope

- The spec-from-docs / spec-from-wrapper inference **capability** (HTML/Markdown → OpenAPI, or derive ops from a typed client) — deliberately deferred per initiative #1529; a small hand-authored spec is the cheaper substrate.
- The MCP bare-`-32603` symptom for `UpstreamNotSpecError` — consolidated MCP error-parity task (#1534).

## Adjacent findings (deferred)

- `list_connectors.py` is a pre-existing 806-line file with several functions over the 60-line soft warn; `_next_step_for_registered` grew to 89 lines with this change's docstring/rationale. All warnings, 0 blockers — out of scope for this docs/UX task.

<!-- auto-implement-issue: fresh, iteration 1 -->

Closes #1533
