### PR TITLE
fix(cli): point targets discover at the real targets import verb

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -90,6 +90,14 @@ connector-related release-notes line.
 
 ## [Unreleased]
 
+### CLI — `targets discover` points at the real registration verb (#1536)
+
+- Repoint `meho targets discover` (help text, post-run output, and the
+  command doc-comment) from the nonexistent `meho targets create` to
+  `meho targets import`, the verb that actually registers a reviewed
+  candidate. The stale `(auto-registration is v0.2.next)` aside is
+  reworded so it no longer dangles on a verb that does not exist.
+
 ### Connector ingest — hand-authored spec on-ramp (#1533)
 
 - Document the hand-authored-OpenAPI-3.x → `--spec file://…` route as the

--- a/cli/internal/cmd/targets/discover.go
+++ b/cli/internal/cmd/targets/discover.go
@@ -26,8 +26,8 @@ import (
 // The G0.3-deferred verb (#256 explicitly defers it to G9.1-T6).
 // Iterates every connector registered for <product>, calling each
 // connector's list_candidates discovery hook, and surfaces the merged
-// candidate list for the operator to review before running
-// `meho targets create`. --seed-target scopes discovery to one
+// candidate list for the operator to review before registering
+// them with `meho targets import`. --seed-target scopes discovery to one
 // already-registered target's reach (e.g. peer clusters in the same
 // kubeconfig); it is resolved tenant-scoped server-side so a 404 on a
 // cross-tenant seed name is identical to a typo.
@@ -53,8 +53,8 @@ func newDiscoverCmd() *cobra.Command {
 			"potentially-reachable targets every connector registered " +
 			"for <product> inferred but that are not yet registered. " +
 			"The verb is read-only — it never creates `targets` rows; " +
-			"the operator reviews the candidates and runs " +
-			"`meho targets create`. --seed-target scopes discovery to " +
+			"the operator reviews the candidates and registers them " +
+			"with `meho targets import`. --seed-target scopes discovery to " +
 			"one already-registered target's reach (resolved tenant-" +
 			"scoped server-side; a cross-tenant seed 404s like a typo). " +
 			"Connectors that contributed nothing are listed under " +
@@ -176,6 +176,6 @@ func printDiscoverTables(w io.Writer, r *api.TargetsDiscoverResult) {
 	}
 	if len(r.Discovered) > 0 {
 		fmt.Fprintln(w, strings.TrimSpace(
-			"\nreview candidates, then register with `meho targets create` (auto-registration is v0.2.next)"))
+			"\nreview candidates, then register with `meho targets import` (one-shot auto-registration is not yet available)"))
 	}
 }

--- a/cli/internal/cmd/targets/discover_test.go
+++ b/cli/internal/cmd/targets/discover_test.go
@@ -70,7 +70,7 @@ func TestPrintDiscoverTablesRendersBoth(t *testing.T) {
 	for _, want := range []string{
 		"NAME", "HOST", "PORT", "CONFIDENCE", "esxi-2", "443", "high",
 		"SKIPPED", "REASON", "vmware-pyvmomi-7.0", "no candidates",
-		"meho targets create",
+		"meho targets import",
 	} {
 		if !strings.Contains(out, want) {
 			t.Errorf("printDiscoverTables missing %q in %q", want, out)


### PR DESCRIPTION
## Summary

- `meho targets discover` told operators to register a discovered candidate with `meho targets create` — a verb that does not exist (the `targets` parent registers only `list/describe/probe/import/discover`), so the one place the CLI guides registration named a command that errors out.
- Repoint all three references — the `--help` Long text, the post-run stdout after a successful discover, and the `newDiscoverCmd` doc-comment — at `meho targets import`, the verb that actually registers a reviewed candidate (and the one `docs/cross-repo/argocd-onboarding.md` documents).
- Reword the stale `(auto-registration is v0.2.next)` aside so it no longer dangles on a nonexistent verb; the deferred auto-registration capability itself is unchanged (no `create`/`register` verb or alias added — out of scope per the issue).
- Update the test that pinned the literal `meho targets create` string to assert the corrected `meho targets import`.

## Test plan

- [x] `gofmt -l` on both edited Go files — clean
- [x] `go vet ./internal/cmd/targets/` — clean
- [x] `go build ./...` (cli) — clean
- [x] `go test ./internal/cmd/targets/` — ok (incl. `TestPrintDiscoverTablesRendersBoth` now asserting `meho targets import`)
- [x] `go test ./...` (full cli suite) — all pass
- [x] OpenAPI snapshot unaffected — `git status` shows only the three intended files; `api/openapi.json` is backend-FastAPI-sourced, not fed by CLI help text, so no regen needed

## Out of scope

- A `targets create`/`register` verb or alias (genuinely deferred capability — the issue's desired state is repointing to `import`, not reviving the verb).
- The broader target-onboarding / credential-seeding flow (refuted as a gap in the issue's scope note).

## Adjacent finding (not fixed here — out of scope)

The backend FastAPI route + schema docstrings for `GET /api/v1/targets/discover` (`CandidateHint`, `TargetsDiscoverResult`) also reference `meho targets create`. These propagate into `cli/api/openapi.json` (the snapshot) and the generated `cli/internal/api/client.gen.go`. The real fix lives in the backend Python docstrings in `meho_backplane`; editing the generated snapshot/client directly would be reverted on next `make snapshot-openapi`/`make generate`. This is a separate backend-side wording change, not part of this CLI-only ticket.

<!-- auto-implement-issue: fresh, iteration 1 -->

Closes #1536
