### PR TITLE
feat(mcp): uniform meho.docs.* audit op_id on search_docs/ask_docs

### DIFF
--- a/backend/src/meho_backplane/mcp/handlers.py
+++ b/backend/src/meho_backplane/mcp/handlers.py
@@ -362,11 +362,14 @@ async def handle_tools_call(
         audit_id = uuid.uuid4()
         # G6.3-T2 (#379): resolve broadcast detail BEFORE the audit
         # row commits so ``broadcast_detail_origin`` lands on the
-        # row's payload. The op_id is the tool name verbatim so
-        # :func:`classify_op` matches credential / audit / read /
-        # write suffixes correctly (e.g. ``vault.kv.read`` →
-        # ``credential_read`` → aggregate-only redacted payload by
-        # default).
+        # row's payload. The broadcast / ``classify_op`` op_id is
+        # ``audit_name`` (the tool name verbatim) so :func:`classify_op`
+        # matches credential / audit / read / write suffixes correctly
+        # (e.g. ``vault.kv.read`` → ``credential_read`` → aggregate-only
+        # redacted payload by default). A handler may bind ``audit_op_id``
+        # to override only the *persisted* row's op_id (see the
+        # strip-and-merge override below); that never touches the
+        # broadcast / ``classify_op`` identity used here.
         #
         # ``resolver_params`` merges the raw tool ``arguments`` on top
         # of ``audit_payload`` so scope-matched override rules
@@ -423,6 +426,20 @@ async def handle_tools_call(
             _stripped = _k[len(_audit_prefix) :]
             if _stripped:
                 audit_payload.setdefault(_stripped, _v)
+        # G4.5-T8 (#1549): a handler may bind ``audit_op_id`` to declare a
+        # canonical, dotted op_id for the persisted row (e.g.
+        # ``meho.docs.search`` on ``search_docs``) so a who-touched /
+        # ``query_audit`` filter is transport-independent across REST / CLI
+        # / MCP. ``audit_payload["op_id"]`` is seeded to the bare tool name
+        # at dispatch entry, so the ``setdefault`` merge above can never
+        # apply it — an explicit override is required. This is the *only*
+        # ``audit_*`` key allowed to overwrite a seeded value; it changes
+        # only the persisted payload's identity, never ``audit_name`` (which
+        # still drives ``classify_op`` broadcast sensitivity and the row's
+        # path, so the read/write/credential taxonomy is unchanged).
+        _op_id_override = structlog.contextvars.get_contextvars().get("audit_op_id")
+        if isinstance(_op_id_override, str) and _op_id_override:
+            audit_payload["op_id"] = _op_id_override
         try:
             await write_mcp_audit_row(
                 audit_id=audit_id,

--- a/backend/src/meho_backplane/mcp/tools/docs.py
+++ b/backend/src/meho_backplane/mcp/tools/docs.py
@@ -69,22 +69,29 @@ Audit + tenant scoping
 ======================
 
 The dispatcher in :mod:`meho_backplane.mcp.handlers` writes exactly one
-``audit_log`` row per ``tools/call`` with ``op_id="search_docs"`` and the
-``op_class="read"`` declared below, and hashes the raw arguments into
-``params_hash`` — so the query is recorded only as a hash, never in the
-clear, matching the route's ``meho.docs.search`` privacy posture. (The
-route's ``meho.docs.search`` op_id is an HTTP-path concern bound by the
-chassis middleware; the MCP audit op_id is the tool name verbatim so
-``classify_op`` resolves the ``.search`` → ``read`` sensitivity class
-correctly.) Tenant scoping rides the operator's forwarded JWT: the
-service hands ``operator.raw_jwt`` to the corpus, which authenticates and
-audits the call as the operator; there is no tool argument that names a
-tenant.
+``audit_log`` row per ``tools/call`` with the ``op_class="read"`` declared
+below, and hashes the raw arguments into ``params_hash`` — so the query is
+recorded only as a hash, never in the clear, matching the route's
+``meho.docs.search`` privacy posture. The op_id on that row is the
+**canonical, uniform** ``meho.docs.search`` / ``meho.docs.ask`` — the same
+token the REST route and the CLI verb bind (G4.5-T8 #1549) — so a
+who-touched / ``query_audit`` filter on ``op_id="meho.docs.*"`` is
+transport-independent and catches the MCP face (the primary agent surface)
+alongside REST + CLI. Each handler binds it via the ``audit_op_id``
+contextvar, which the dispatcher lifts into the persisted row's payload
+op_id. The bare tool name (``search_docs`` / ``ask_docs``) is still what
+the broadcast path passes to ``classify_op``, so the read-class broadcast
+sensitivity is unchanged — only the persisted audit identity is unified.
+Tenant scoping rides the operator's forwarded JWT: the service hands
+``operator.raw_jwt`` to the corpus, which authenticates and audits the
+call as the operator; there is no tool argument that names a tenant.
 """
 
 from __future__ import annotations
 
 from typing import Any, Final
+
+import structlog
 
 from meho_backplane.auth.operator import Operator, TenantRole
 from meho_backplane.docs_search import (
@@ -116,6 +123,17 @@ _OP_CLASS_READ: Final[str] = "read"
 _DEFAULT_SEARCH_LIMIT: Final[int] = 10
 _MAX_SEARCH_LIMIT: Final[int] = 50
 
+#: Canonical audit op_ids — the SAME tokens the REST route binds
+#: (:func:`meho_backplane.api.v1.search_docs` binds ``meho.docs.search``)
+#: and the CLI verb carries, so a who-touched / ``query_audit`` filter on
+#: ``op_id="meho.docs.*"`` is transport-independent across REST / CLI / MCP
+#: (G4.5-T8 #1549). Bound into the ``audit_op_id`` contextvar, which the
+#: dispatcher lifts into the persisted ``audit_log.payload`` op_id; the
+#: broadcast / ``classify_op`` op_id stays the bare tool name, so the
+#: read-class broadcast sensitivity is unchanged.
+_SEARCH_OP_ID: Final[str] = "meho.docs.search"
+_ASK_OP_ID: Final[str] = "meho.docs.ask"
+
 
 async def _search_docs_handler(
     operator: Operator,
@@ -145,6 +163,14 @@ async def _search_docs_handler(
       route's 503): a well-formed request against a down upstream is a
       server-side fault, not invalid params.
     """
+    # Bind the canonical op_id so the persisted audit row is filterable by
+    # ``op_id="meho.docs.search"`` the same way the REST + CLI faces are
+    # (G4.5-T8 #1549). The dispatcher lifts ``audit_op_id`` into the row's
+    # payload op_id; ``op_class="read"`` (declared on the ToolDefinition)
+    # and the broadcast / ``classify_op`` op_id (the bare tool name) are
+    # unchanged. Bound up-front so a handler exception still records the
+    # canonical identity on the row.
+    structlog.contextvars.bind_contextvars(audit_op_id=_SEARCH_OP_ID)
     query: str = arguments["query"]
     product: str = arguments["product"]
     version: str = arguments["version"]
@@ -273,6 +299,11 @@ async def _ask_docs_handler(
       helper, which returns a deterministic "no grounded answer" *without*
       calling the model.
     """
+    # Same canonical-op_id binding as ``search_docs`` — ``ask_docs`` audit
+    # rows are filterable by ``op_id="meho.docs.ask"`` across all three
+    # faces (G4.5-T8 #1549). ``op_class`` stays ``read``; ask is a
+    # read-class compose over retrieved chunks.
+    structlog.contextvars.bind_contextvars(audit_op_id=_ASK_OP_ID)
     query: str = arguments["query"]
     product: str = arguments["product"]
     version: str = arguments["version"]

--- a/backend/tests/test_mcp_tools_docs.py
+++ b/backend/tests/test_mcp_tools_docs.py
@@ -36,9 +36,12 @@ from unittest.mock import patch
 
 import pytest
 from fastapi.testclient import TestClient
+from sqlalchemy import select
 
 from meho_backplane.auth.corpus import CorpusChunk, CorpusSearchResponse, CorpusUnavailable
 from meho_backplane.auth.operator import Operator, TenantRole
+from meho_backplane.db.engine import get_sessionmaker
+from meho_backplane.db.models import AuditLog
 from meho_backplane.main import app
 from meho_backplane.mcp.auth import verify_mcp_jwt_and_bind
 from meho_backplane.mcp.schemas import INTERNAL_ERROR, INVALID_PARAMS
@@ -48,9 +51,18 @@ from tests.mcp_test_fixtures import (
     isolated_registry,  # noqa: F401 — pytest-discovered autouse fixture
     post_mcp,
     required_settings_env,  # noqa: F401 — pytest-discovered autouse fixture
+    seeded_operator_tenant,  # noqa: F401 — pytest-discovered fixture
 )
 
 _DOCS_CAPABILITY = "meho-docs"
+
+
+async def _mcp_audit_rows() -> list[AuditLog]:
+    """Read every MCP-method ``audit_log`` row, oldest first."""
+    sessionmaker = get_sessionmaker()
+    async with sessionmaker() as session:
+        result = await session.execute(select(AuditLog).order_by(AuditLog.occurred_at))
+        return [row for row in result.scalars().all() if row.method == "MCP"]
 
 
 def _operator(
@@ -478,3 +490,94 @@ def test_tools_call_search_docs_gate_off_allows_partial_scope(
     assert response.json()["result"]["isError"] is False
     # Only the non-blank product survived into the corpus filter.
     assert fake.captured["metadata_filters"] == {"product": "nsx"}  # type: ignore[attr-defined]
+
+
+# ---------------------------------------------------------------------------
+# Uniform audit op_id across faces (G4.5-T8 #1549)
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.asyncio
+@pytest.mark.parametrize("docs_client", [frozenset({_DOCS_CAPABILITY})], indirect=True)
+async def test_tools_call_search_docs_audit_row_carries_canonical_op_id(
+    docs_client: tuple[TestClient, Operator],
+    seeded_operator_tenant: None,  # noqa: F811
+) -> None:
+    """G4.5-T8: the MCP audit row's ``op_id`` is the canonical ``meho.docs.search``.
+
+    The DoD requires every ``search_docs`` audit row — REST, CLI, *and*
+    MCP — be filterable by ``op_id="meho.docs.search"``. The handler binds
+    the ``audit_op_id`` contextvar; the dispatcher lifts it into the
+    persisted row, overriding the bare tool name. ``op_class`` stays
+    ``read`` (declared on the ToolDefinition) and the raw query is recorded
+    only as ``params_hash``, never in the clear.
+    """
+    client, _op = docs_client
+    with patch("meho_backplane.docs_search.service.search_corpus", new=_fake_corpus(_SAMPLE_CHUNK)):
+        response = post_mcp(
+            client,
+            {
+                "jsonrpc": "2.0",
+                "id": 9,
+                "method": "tools/call",
+                "params": {
+                    "name": "search_docs",
+                    "arguments": {"query": "config maximums", "product": "nsx", "version": "9.0"},
+                },
+            },
+        )
+    assert response.status_code == 200
+    assert response.json()["result"]["isError"] is False
+
+    rows = await _mcp_audit_rows()
+    assert len(rows) == 1
+    payload = rows[0].payload
+    assert payload["op_id"] == "meho.docs.search"
+    assert payload["op_class"] == "read"
+    # The raw query is hashed, never recorded in the clear.
+    assert "config maximums" not in json.dumps(payload)
+    assert payload["params_hash"]
+
+
+@pytest.mark.asyncio
+@pytest.mark.parametrize("docs_client", [frozenset({_DOCS_CAPABILITY})], indirect=True)
+async def test_query_audit_op_id_filter_catches_mcp_search_docs(
+    docs_client: tuple[TestClient, Operator],
+    seeded_operator_tenant: None,  # noqa: F811
+) -> None:
+    """G4.5-T8 AC2: a ``query_audit`` ``op_id`` filter returns the MCP call.
+
+    Before the fix the MCP row landed under the bare tool name
+    ``search_docs``, so a who-touched / ``query_audit`` filter on
+    ``op_id="meho.docs.search"`` caught REST + CLI but missed every MCP
+    call — the primary agent surface. This pins that the MCP face is now in
+    the trail under the canonical op_id.
+    """
+    from meho_backplane.audit_query import AuditQueryFilters, query_audit
+
+    client, _op = docs_client
+    with patch("meho_backplane.docs_search.service.search_corpus", new=_fake_corpus(_SAMPLE_CHUNK)):
+        response = post_mcp(
+            client,
+            {
+                "jsonrpc": "2.0",
+                "id": 10,
+                "method": "tools/call",
+                "params": {
+                    "name": "search_docs",
+                    "arguments": {"query": "nsx maximums", "product": "nsx", "version": "9.0"},
+                },
+            },
+        )
+    assert response.status_code == 200
+
+    sessionmaker = get_sessionmaker()
+    async with sessionmaker() as session:
+        result = await query_audit(
+            AuditQueryFilters(op_id="meho.docs.search"),
+            tenant_id=OPERATOR_TENANT_ID,
+            session=session,
+        )
+    assert len(result.rows) == 1
+    assert result.rows[0].op_id == "meho.docs.search"
+    assert result.rows[0].op_class == "read"

--- a/backend/tests/test_mcp_tools_docs_ask.py
+++ b/backend/tests/test_mcp_tools_docs_ask.py
@@ -36,9 +36,12 @@ from unittest.mock import patch
 
 import pytest
 from fastapi.testclient import TestClient
+from sqlalchemy import select
 
 from meho_backplane.auth.corpus import CorpusChunk, CorpusSearchResponse, CorpusUnavailable
 from meho_backplane.auth.operator import Operator, TenantRole
+from meho_backplane.db.engine import get_sessionmaker
+from meho_backplane.db.models import AuditLog
 from meho_backplane.docs_search.synthesis import NO_GROUNDED_ANSWER
 from meho_backplane.main import app
 from meho_backplane.mcp.auth import verify_mcp_jwt_and_bind
@@ -49,6 +52,7 @@ from tests.mcp_test_fixtures import (
     isolated_registry,  # noqa: F401 — pytest-discovered autouse fixture
     post_mcp,
     required_settings_env,  # noqa: F401 — pytest-discovered autouse fixture
+    seeded_operator_tenant,  # noqa: F401 — pytest-discovered fixture
 )
 
 _DOCS_CAPABILITY = "meho-docs"
@@ -546,3 +550,58 @@ def test_tools_call_ask_docs_rejects_extra_arguments(
     )
     assert response.status_code == 200
     assert response.json()["error"]["code"] == INVALID_PARAMS
+
+
+# ---------------------------------------------------------------------------
+# Uniform audit op_id across faces (G4.5-T8 #1549)
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.asyncio
+@pytest.mark.parametrize("docs_client", [frozenset({_DOCS_CAPABILITY})], indirect=True)
+async def test_tools_call_ask_docs_audit_row_carries_canonical_op_id(
+    docs_client: tuple[TestClient, Operator],
+    seeded_operator_tenant: None,  # noqa: F811
+) -> None:
+    """G4.5-T8: the MCP ``ask_docs`` audit row's ``op_id`` is ``meho.docs.ask``.
+
+    Mirrors ``search_docs``: the handler binds the ``audit_op_id``
+    contextvar so the persisted row is filterable by the canonical, uniform
+    op_id across REST / CLI / MCP. ``op_class`` stays ``read`` (ask is a
+    read-class compose over retrieved chunks) and the raw query is recorded
+    only as ``params_hash``.
+    """
+    client, _op = docs_client
+    corpus = _fake_corpus(_SAMPLE_CHUNK)
+    stub = _StubLlmClient(
+        json.dumps(
+            {
+                "answer": "NSX 9.0 supports up to 10,000 logical switches per manager.",
+                "cited_chunk_ids": ["nsx-9.0-maximums-0007"],
+            }
+        )
+    )
+    with (
+        patch("meho_backplane.docs_search.service.search_corpus", new=corpus),
+        patch(_BUILD_LLM_CLIENT, return_value=stub),
+    ):
+        response = post_mcp(
+            client,
+            _ask_call(
+                {"query": "logical switch maximums", "product": "nsx", "version": "9.0"},
+                call_id=11,
+            ),
+        )
+    assert response.status_code == 200
+    assert response.json()["result"]["isError"] is False
+
+    sessionmaker = get_sessionmaker()
+    async with sessionmaker() as session:
+        result = await session.execute(select(AuditLog).order_by(AuditLog.occurred_at))
+        mcp_rows = [row for row in result.scalars().all() if row.method == "MCP"]
+    assert len(mcp_rows) == 1
+    payload = mcp_rows[0].payload
+    assert payload["op_id"] == "meho.docs.ask"
+    assert payload["op_class"] == "read"
+    assert "logical switch maximums" not in json.dumps(payload)
+    assert payload["params_hash"]

--- a/docs/codebase/docs-search.md
+++ b/docs/codebase/docs-search.md
@@ -177,8 +177,12 @@ A `CorpusUnavailable` is **not** caught — a well-formed request against a
 down upstream is a server fault, so it bubbles to the dispatcher's
 generic catch as `-32603` Internal Error (the MCP analogue of the route's
 503). One `audit_log` row per call is written by the dispatcher with
-`op_id="search_docs"`, `op_class="read"`, and the raw arguments hashed
-into `params_hash` — never the query in the clear.
+`op_id="meho.docs.search"` (the handler binds the `audit_op_id` contextvar
+and the dispatcher lifts it into the persisted row, so the op id is the
+canonical, uniform token across REST / CLI / MCP — G4.5-T8 #1549),
+`op_class="read"`, and the raw arguments hashed into `params_hash` — never
+the query in the clear. The bare tool name still drives the broadcast
+`classify_op` path, so broadcast sensitivity is unchanged.
 
 The tool description is load-bearing routing UX (it is a prompt): it
 names the sibling tools so the agent learns the boundary — `search_docs`
@@ -202,10 +206,12 @@ synthesis failures (`LlmClientUnavailable` for an unconfigured model,
 `DocsSynthesisError` for a broken grounding contract) also bubble to
 `-32603` — never an ungrounded 200. It stays `op_class="read"`: it
 composes over retrieved chunks, it never mutates the corpus. The
-dispatcher writes one `audit_log` row per call with `op_id="ask_docs"`
-(the tool name verbatim, which `classify_op` leaves as `other` while the
-tool definition pins the row's `op_class="read"`) and the raw query hashed
-into `params_hash` — the same privacy posture as `search_docs`.
+dispatcher writes one `audit_log` row per call with `op_id="meho.docs.ask"`
+(the handler binds `audit_op_id`, lifted into the persisted row — uniform
+across REST / CLI / MCP per G4.5-T8 #1549; the bare tool name still feeds
+`classify_op`, which leaves it as `other` while the tool definition pins
+the row's `op_class="read"`) and the raw query hashed into `params_hash` —
+the same privacy posture as `search_docs`.
 
 The description routes the agent between the answer-shaped tool and the
 chunks-shaped one: `ask_docs` for a composed grounded answer, `search_docs`

--- a/docs/cross-repo/meho-docs-addon.md
+++ b/docs/cross-repo/meho-docs-addon.md
@@ -46,11 +46,13 @@ hit the corpus directly) buys three properties in one place:
 
 - **Central audit.** Every query lands one `audit_log` row
   (`op_class=read`), so `meho audit query` / who-touched surface it. The
-  op id depends on the face: the REST route and the CLI verb (which calls
-  the route) audit under `meho.docs.search`; the MCP `search_docs` tool
-  audits under `search_docs` (the dispatcher uses the tool name verbatim
-  — see [Audit row visible](#audit-row-visible-who-touched)). The raw
-  query is stored only as a SHA-256 hash — never in the clear.
+  op id is **uniform across all three faces**: REST, CLI, and MCP all
+  audit `search_docs` under `meho.docs.search` and `ask_docs` under
+  `meho.docs.ask`. A who-touched / `meho audit query op_id=meho.docs.search`
+  filter therefore catches every query regardless of the face it came in
+  on — including the MCP agent surface (see
+  [Audit row visible](#audit-row-visible-who-touched)). The raw query is
+  stored only as a SHA-256 hash — never in the clear.
 - **JWT federation handled once.** Operator-JWT forwarding lives in the
   backplane's corpus client, not in every consumer.
 - **Mandatory product/version scope enforced centrally.** A docs query
@@ -201,41 +203,33 @@ that array is the one source of truth for what the tenant has provisioned
 ### Audit row visible (who-touched)
 
 Every `search_docs` query — from any of the three faces — writes one
-`audit_log` row (`op_class=read`). The op id, however, **differs by
-face**, because the HTTP route and the MCP dispatcher use independent
-audit-binding conventions:
+`audit_log` row (`op_class=read`), and the op id is the **same canonical
+token regardless of face**:
 
-| Face | op id | Why |
+| Face | op id | How |
 |---|---|---|
-| REST route `POST /api/v1/search_docs` | `meho.docs.search` | The route binds the canonical op id via the chassis audit middleware (`audit_op_id="meho.docs.search"`). |
+| REST route `POST /api/v1/search_docs` | `meho.docs.search` | The route binds it via the chassis audit middleware (`audit_op_id="meho.docs.search"`). |
 | CLI verb `meho docs search` | `meho.docs.search` | The verb calls the REST route, so it shares the route's op id. |
-| MCP tool `search_docs` | `search_docs` | The MCP dispatcher audits every `tools/call` under the **tool name verbatim** — it has no HTTP path to bind, so the op id is the tool name, not the route's. |
+| MCP tool `search_docs` | `meho.docs.search` | The handler binds `audit_op_id="meho.docs.search"`; the MCP dispatcher lifts that contextvar into the persisted row's op id (G4.5-T8, #1549). The bare tool name still drives `classify_op` broadcast sensitivity, so `op_class=read` is unchanged. |
 
-So the op-id you filter on depends on where the query came from. Surface
+Because the op id is uniform, one filter catches every face — including
+the MCP agent surface, the primary place agents reach the corpus. Surface
 the rows with the audit verbs (the raw query is never stored; only its
 SHA-256 hash plus the product/version scope and hit count):
 
 ```bash
-# REST + CLI queries (op-id is a glob):
+# All search_docs queries — REST, CLI, and MCP — in one pass:
 meho audit query --op-id 'meho.docs.search' --since 24h
-
-# MCP/agent-session queries audit under the tool name:
-meho audit query --op-id 'search_docs' --since 24h
-
-# Both faces in one pass — `*` is the glob wildcard (op-id glob: `*` ↔
-# SQL `%`). `*search*` spans the route op id and the tool name because
-# both contain "search" (it also catches any other "search" op such as
-# search_knowledge / search_memory, so it is broader than docs-only):
-meho audit query --op-id '*search*' --since 24h
 
 # Or, if the corpus result cited a known target, see who touched it
 # (target-anchored — face-agnostic):
 meho audit who-touched <target> --since 24h
 ```
 
-> The MCP `ask_docs` tool (the synthesis fast-follow, G4.5-T7) follows
-> the same MCP convention: it audits under op id `ask_docs`, not
-> `meho.docs.search`. Filter `--op-id 'ask_docs'` for those rows.
+> The MCP `ask_docs` tool (the synthesis fast-follow, G4.5-T7) audits
+> uniformly too: op id `meho.docs.ask` across REST / CLI / MCP. Filter
+> `--op-id 'meho.docs.ask'` for those rows, or `--op-id 'meho.docs.*'`
+> for both search and ask.
 
 Whichever face produced it, a docs query that hit the corpus produces a
 row with `op_class=read`, the bound `product` / `version` scope, the


### PR DESCRIPTION
## Summary
- Make the MCP `search_docs` / `ask_docs` audit rows carry the **canonical, uniform** `op_id` — `meho.docs.search` / `meho.docs.ask` — so a who-touched / `query_audit` filter is transport-independent across REST / CLI / **MCP**. Previously MCP rows landed under the bare tool name, so an `op_id="meho.docs.search"` filter caught REST + CLI but missed every MCP call (the primary agent surface). This completes the G4.5 DoD.
- **Root-cause correction over the issue's sketch:** binding `audit_op_id` in the handler alone is a no-op for the row's `op_id`. The dispatcher seeds `audit_payload["op_id"]` to the tool name at entry, and both the strip-and-merge (`setdefault`) and `write_mcp_audit_row` (caller-wins) preserve that seed — confirmed empirically (the row stayed `search_docs` with only the contextvar bound). The fix needs the **dispatcher** to honor a handler-bound `audit_op_id` as an explicit override. So this PR touches `mcp/handlers.py` in addition to the docs tool/tests/doc the issue named.
- The override is scoped to the **persisted row identity only**: `audit_name` (which feeds `classify_op` broadcast sensitivity and the row path) is unchanged, so `op_class` stays `read`, the broadcast taxonomy is untouched, and the raw query stays hashed (`params_hash`).
- Side-benefit: the previously-ineffective `audit_op_id` bindings on the sibling MCP tools (`agent_runs`, `agents`, `scheduler`, `approvals`, `agent_grants`, `agent_principals`) now finally land their documented dotted op_ids on the persisted row — restoring the transport-independent filtering their own docstrings already claimed.

## Test plan
- [x] `ruff check src/ tests/` — clean
- [x] `ruff format --check src/ tests/` — clean (900 files)
- [x] `mypy src/` — clean (441 source files)
- [x] `python3 .claude/hooks/code-quality.py --diff` — 0 blockers (4 pre-existing warnings in touched files)
- [x] **AC1** — `test_tools_call_search_docs_audit_row_carries_canonical_op_id` + `test_tools_call_ask_docs_audit_row_carries_canonical_op_id`: MCP `tools/call` audit row carries `op_id="meho.docs.search"` / `"meho.docs.ask"`.
- [x] **AC2** — `test_query_audit_op_id_filter_catches_mcp_search_docs`: a `query_audit` filter on `op_id="meho.docs.search"` returns the MCP-originated call.
- [x] **AC3** — same tests assert `op_class` stays `read` and the raw query is only hashed (`params_hash`, query text absent from payload); broadcast/`classify_op` path verified unchanged (still keyed on the bare tool name).
- [x] **AC4** — add-on runbook `docs/cross-repo/meho-docs-addon.md` + codebase doc `docs/codebase/docs-search.md` corrected from "op_id differs by face" to a single uniform `meho.docs.*` op_id across REST/CLI/MCP.
- [x] Regression sweep: `tests/ -k "mcp or audit or docs or scheduler or approval or agent"` → 1633 passed, 70 skipped, 0 failed. Sensitive precedent `test_set_via_mcp_writes_audit_row_with_override_diff` and `test_rest_audit_row_is_written_on_create` (scheduler) still green.

## Out of scope
- The `query_audit` MCP tool's own `op_id="query_audit"` divergence (it binds no `audit_op_id`, so its rows are unaffected and `docs/architecture/audit.md` / `docs/cross-repo/audit-query.md` remain accurate).
- Catalogue / collection work (G4.6, #1548); renaming the REST op_id or tool names.
- Adjacent finding: `mcp/handlers.py` is 809 lines (pre-existing, > the 600-line guidance) and `mcp/tools/docs.py` is now 410 lines (> 400 warn). Both pre-date this change; not split here.

<!-- auto-implement-issue: fresh, iteration 1 -->

Closes #1549
