### PR TITLE
feat(docs): doc_collections registry (collections-as-data) (#1550)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -90,6 +90,19 @@ connector-related release-notes line.
 
 ## [Unreleased]
 
+### Doc-collection registry (#1550)
+
+- Add the `doc_collections` table (collections-as-data) — one row per
+  documentation corpus, the docs analogue of the `targets` registry.
+  Operator-set identity + backend binding (`collection_key` / `vendor` /
+  `backend{type, ref}`) with probe-written liveness (`doc_count` /
+  `last_ingested_at` / `readiness`, populated later). Global + tenant
+  scoping via the dual partial-unique-index idiom, a tenant-first
+  `resolve_doc_collection` lookup with a typed not-found, and a single
+  `project_doc_collection_to_summary` ORM→wire projection. Foundational
+  substrate for the catalogue and collection-scoped `search_docs`; no
+  agent-facing surface yet.
+
 ### CLI — `targets discover` points at the real registration verb (#1536)
 
 - Repoint `meho targets discover` (help text, post-run output, and the

--- a/backend/alembic/versions/0037_create_doc_collections.py
+++ b/backend/alembic/versions/0037_create_doc_collections.py
@@ -1,0 +1,241 @@
+# SPDX-License-Identifier: Apache-2.0
+# Copyright (c) 2026 evoila Group
+
+"""Create the doc_collections table (collections-as-data registry).
+
+Revision ID: 0037
+Revises: 0036
+Create Date: 2026-06-06
+
+This migration is the schema foundation of Initiative #1548 (G4.6
+Doc-collection catalogue), Task #1550 (T1). It adds the
+``doc_collections`` table — one row per documentation corpus an agent
+can search. The table is the docs analogue of ``targets``:
+``list_targets`` answers "what infra can I act on?", the catalogue
+built on this table (T4 #1553) answers "what docs can I search?".
+
+The registry is **authoritative for identity + backend binding**
+(operator-set ``collection_key`` / ``vendor`` / ``backend``), with
+**liveness fields probe-written from the backend** (``doc_count`` /
+``last_ingested_at`` / ``readiness``, T6 #1555). This mirrors the
+targets-as-data split (``targets`` rows + ``Target.fingerprint``
+written by the probe).
+
+Tenancy — NULLABLE tenant_id
+----------------------------
+
+``tenant_id`` is NULL for global / shared collections (every tenant
+sees them) and populated for tenant-curated collections, the same
+global+tenant idiom ``operation_group`` established in migration 0005.
+No FK to ``tenant.id`` by the soft-FK discipline 0002 established for
+``audit_log.tenant_id``; the application layer enforces referential
+integrity until a tightening migration adds the FK.
+
+Unique-constraint shape — partial unique indexes
+------------------------------------------------
+
+The natural key is ``collection_key``, but the same key may
+legitimately appear in both a global row (``tenant_id IS NULL``) and a
+tenant-curated row (``tenant_id IS NOT NULL``) — the resolver prefers
+the tenant row. A single ``UNIQUE (tenant_id, collection_key)``
+constraint would *not* enforce "two global rows with the same key
+collide" — NULL != NULL in SQL UNIQUE semantics, so any number of
+``tenant_id IS NULL`` rows with identical ``collection_key`` would
+commit cleanly.
+
+The fix is two **partial unique indexes** (the ``operation_group``
+pattern from migration 0005):
+
+* one ``WHERE tenant_id IS NULL`` on ``(collection_key)`` for
+  global/shared rows
+* one ``WHERE tenant_id IS NOT NULL`` on ``(tenant_id, collection_key)``
+  for tenant-scoped rows (the ``tenant_id`` column is in the key so two
+  tenants can each curate the same ``collection_key`` without collision)
+
+PostgreSQL supports the syntax natively; SQLite has supported partial
+indexes since 3.8.0 (we run 3.45+). SQLAlchemy emits the ``WHERE``
+clause for both dialects via the ``postgresql_where`` / ``sqlite_where``
+keyword pair on :func:`op.create_index`.
+
+CHECK constraint — portable enum enforcement
+--------------------------------------------
+
+``status`` is a bounded enum (``'provisioning'`` / ``'ready'`` /
+``'rebuilding'`` / ``'disabled'``). Per the discipline every prior
+migration follows (see ``ck_operation_group_review_status`` in 0005),
+it is ``TEXT NOT NULL`` + a ``CHECK (status IN (...))`` constraint
+rather than a PG-specific named ``ENUM`` type — identical enforcement
+on both dialects, no named type lifecycle to track when the enum
+widens.
+
+Dialect-portability decisions
+-----------------------------
+
+Mirrors the discipline 0001 through 0036 established; runs cleanly on
+both PostgreSQL (production / pgvector image) and SQLite (dev/test via
+aiosqlite).
+
+* ``id`` server default — ``gen_random_uuid()`` on PG; SQLite relies on
+  the ORM ``default=uuid.uuid4``.
+* ``created_at`` / ``updated_at`` server defaults — ``now()`` on PG;
+  SQLite leaves them to the ORM ``default=lambda: datetime.now(UTC)``.
+* ``products`` — native ``TEXT[]`` on PG (GIN-indexable containment),
+  JSON-text array on SQLite. NOT NULL with an empty-array default.
+* ``backend`` / ``readiness`` / ``extras`` — JSONB on PG, generic JSON
+  (text) on SQLite via :func:`sqlalchemy.JSON.with_variant`.
+* ``products`` GIN index — PG only, wrapped in ``if is_postgres:``
+  (SQLite cannot index a JSON/TEXT[] column with GIN semantics).
+
+Reversibility contract
+----------------------
+
+``downgrade()`` undoes everything ``upgrade()`` created in reverse
+order: GIN index (PG only) → partial-unique indexes → table. Explicit
+index drops keep the inverse symmetric on SQLite (which does not always
+cascade indexes on ``drop_table``).
+"""
+
+from collections.abc import Sequence
+
+import sqlalchemy as sa
+from alembic import op
+from sqlalchemy.dialects import postgresql
+
+# revision identifiers, used by Alembic.
+revision: str = "0037"
+down_revision: str | None = "0036"
+branch_labels: str | Sequence[str] | None = None
+depends_on: str | Sequence[str] | None = None
+
+
+def upgrade() -> None:
+    """Create the ``doc_collections`` table + its indexes."""
+    bind = op.get_bind()
+    is_postgres = bind.dialect.name == "postgresql"
+
+    # Portable JSONB → JSON variant; PG gets binary JSONB (GIN-friendly,
+    # indexable by ``@>``), SQLite gets text-stored JSON.
+    json_type = sa.JSON().with_variant(postgresql.JSONB(), "postgresql")
+
+    # ``products`` — native TEXT[] on PG (GIN-indexed containment),
+    # JSON-text array on SQLite (no native ARRAY type; the GIN index is
+    # also skipped there).
+    products_type = sa.JSON().with_variant(postgresql.ARRAY(sa.Text()), "postgresql")
+
+    op.create_table(
+        "doc_collections",
+        sa.Column(
+            "id",
+            sa.Uuid(),
+            primary_key=True,
+            nullable=False,
+            server_default=sa.text("gen_random_uuid()") if is_postgres else None,
+        ),
+        # tenant_id NULL → global/shared collection; non-null →
+        # tenant-curated. No FK to tenant.id by the soft-FK discipline.
+        sa.Column("tenant_id", sa.Uuid(), nullable=True),
+        sa.Column("collection_key", sa.Text(), nullable=False),
+        sa.Column("vendor", sa.Text(), nullable=False),
+        # ``products`` — NOT NULL, empty-array default. TEXT[] on PG,
+        # JSON array on SQLite. [] means "no products listed".
+        sa.Column(
+            "products",
+            products_type,
+            nullable=False,
+            server_default=(sa.text("'{}'::text[]") if is_postgres else sa.text("'[]'")),
+        ),
+        sa.Column("description", sa.Text(), nullable=True),
+        sa.Column("when_to_use", sa.Text(), nullable=True),
+        # Operator-set {type, ref} backend routing record (the T2 router
+        # key). NOT NULL — every collection binds to exactly one backend.
+        sa.Column(
+            "backend",
+            json_type,
+            nullable=False,
+            server_default=sa.text("'{}'::jsonb") if is_postgres else sa.text("'{}'"),
+        ),
+        # Lifecycle enum — bounded by the CHECK constraint below.
+        sa.Column(
+            "status",
+            sa.Text(),
+            nullable=False,
+            server_default=sa.text("'provisioning'"),
+        ),
+        # Probe-written liveness (T6 #1555); NULL until the first probe.
+        sa.Column("last_ingested_at", sa.DateTime(timezone=True), nullable=True),
+        sa.Column("doc_count", sa.Integer(), nullable=True),
+        sa.Column("readiness", json_type, nullable=True),
+        sa.Column(
+            "extras",
+            json_type,
+            nullable=False,
+            server_default=sa.text("'{}'::jsonb") if is_postgres else sa.text("'{}'"),
+        ),
+        sa.Column(
+            "created_at",
+            sa.DateTime(timezone=True),
+            nullable=False,
+            server_default=sa.text("now()") if is_postgres else None,
+        ),
+        sa.Column(
+            "updated_at",
+            sa.DateTime(timezone=True),
+            nullable=False,
+            server_default=sa.text("now()") if is_postgres else None,
+        ),
+        # Bounded-enum enforcement at the DB layer. Extend the IN(...)
+        # list when the lifecycle gains new states.
+        sa.CheckConstraint(
+            "status IN ('provisioning', 'ready', 'rebuilding', 'disabled')",
+            name="ck_doc_collections_status",
+        ),
+    )
+
+    # Partial unique indexes — see module docstring for the rationale
+    # (NULL != NULL in SQL UNIQUE; global rows need their own scope,
+    # tenant rows need theirs). The operation_group pattern from 0005.
+    op.create_index(
+        "doc_collections_global_idx",
+        "doc_collections",
+        ["collection_key"],
+        unique=True,
+        postgresql_where=sa.text("tenant_id IS NULL"),
+        sqlite_where=sa.text("tenant_id IS NULL"),
+    )
+    op.create_index(
+        "doc_collections_tenant_idx",
+        "doc_collections",
+        ["tenant_id", "collection_key"],
+        unique=True,
+        postgresql_where=sa.text("tenant_id IS NOT NULL"),
+        sqlite_where=sa.text("tenant_id IS NOT NULL"),
+    )
+
+    # GIN index on ``products`` — PostgreSQL only. SQLite has no GIN
+    # support and cannot index a JSON/TEXT[] column with GIN semantics;
+    # skipping on non-PG dialects keeps the migration dialect-portable.
+    if is_postgres:
+        op.create_index(
+            "doc_collections_products_gin_idx",
+            "doc_collections",
+            ["products"],
+            postgresql_using="gin",
+        )
+
+
+def downgrade() -> None:
+    """Reverse the upgrade — drop everything in reverse order.
+
+    Symmetric inverse of :func:`upgrade`. Indexes are dropped explicitly
+    so the reversal is clean on SQLite (which does not always cascade
+    indexes on ``drop_table``) as well as PostgreSQL.
+    """
+    bind = op.get_bind()
+    is_postgres = bind.dialect.name == "postgresql"
+
+    if is_postgres:
+        op.drop_index("doc_collections_products_gin_idx", table_name="doc_collections")
+
+    op.drop_index("doc_collections_tenant_idx", table_name="doc_collections")
+    op.drop_index("doc_collections_global_idx", table_name="doc_collections")
+    op.drop_table("doc_collections")

--- a/backend/alembic/versions/0037_create_doc_collections.py
+++ b/backend/alembic/versions/0037_create_doc_collections.py
@@ -147,12 +147,16 @@ def upgrade() -> None:
         sa.Column("description", sa.Text(), nullable=True),
         sa.Column("when_to_use", sa.Text(), nullable=True),
         # Operator-set {type, ref} backend routing record (the T2 router
-        # key). NOT NULL — every collection binds to exactly one backend.
+        # key). NOT NULL with no server_default — every collection must
+        # bind to exactly one backend, so a writer has to supply
+        # ``{type, ref}`` explicitly. Unlike ``products`` / ``extras``
+        # (empty is valid there), an empty ``backend`` is a routing-broken
+        # row, so there is no silent ``{}`` fallback. The table is new, so
+        # there are no existing rows to backfill.
         sa.Column(
             "backend",
             json_type,
             nullable=False,
-            server_default=sa.text("'{}'::jsonb") if is_postgres else sa.text("'{}'"),
         ),
         # Lifecycle enum — bounded by the CHECK constraint below.
         sa.Column(

--- a/backend/src/meho_backplane/db/models.py
+++ b/backend/src/meho_backplane/db/models.py
@@ -1123,12 +1123,15 @@ class DocCollection(Base):
     # (T4) and the initialize.instructions catalogue band.
     when_to_use: Mapped[str | None] = mapped_column(Text, nullable=True)
     # Operator-set ``{type, ref}`` backend routing record (the T2 router
-    # key). JSONB on PG, generic JSON (text) on SQLite. NOT NULL — every
-    # collection binds to exactly one backend.
+    # key). JSONB on PG, generic JSON (text) on SQLite. NOT NULL with no
+    # default — every collection must bind to exactly one backend, so a
+    # writer has to supply ``{type, ref}`` explicitly. Unlike
+    # ``products`` / ``extras`` / ``readiness`` (where empty is a valid
+    # state), an empty ``backend`` is a routing-broken row, so there is
+    # no silent ``{}`` fallback at the ORM or migration layer.
     backend: Mapped[dict[str, object]] = mapped_column(
         _PORTABLE_JSON,
         nullable=False,
-        default=dict,
     )
     status: Mapped[str] = mapped_column(
         Text,

--- a/backend/src/meho_backplane/db/models.py
+++ b/backend/src/meho_backplane/db/models.py
@@ -1035,6 +1035,165 @@ class OperationGroup(Base):
     )
 
 
+class DocCollection(Base):
+    """A named documentation corpus an agent can search (collections-as-data).
+
+    Initiative #1548 (G4.6 Doc-collection catalogue), Task #1550 (T1)
+    substrate. One row per corpus (e.g. ``vmware``). This table is the
+    docs analogue of :class:`Target` — ``list_targets`` answers "what
+    infra can I act on?", ``list_doc_collections`` (T4 #1553) answers
+    "what docs can I search?". The registry is **authoritative for
+    identity + backend binding** (operator-set); the liveness fields
+    (``doc_count`` / ``last_ingested_at`` / ``readiness``) are
+    probe-written from the backend (T6 #1555) — the same data split
+    ``targets`` rows + ``Target.fingerprint`` use.
+
+    ``tenant_id`` is NULL for global / shared collections (available to
+    every tenant) and populated for tenant-curated collections, the
+    NULLABLE-tenant idiom :class:`OperationGroup` established. No FK to
+    ``tenant.id`` in v0.x by the same soft-FK discipline as
+    ``audit_log.tenant_id``.
+
+    Uniqueness on ``collection_key`` is enforced by **two partial unique
+    indexes** rather than a single composite UNIQUE because SQL's
+    NULL != NULL semantics mean a single ``UNIQUE (tenant_id,
+    collection_key)`` would not catch two global rows sharing a
+    ``collection_key``. The split lets a global ``vmware`` row and a
+    tenant-curated ``vmware`` row coexist (the resolver prefers the
+    tenant row); see :class:`OperationGroup` for the precedent.
+
+    ``backend`` is the ``{type, ref}`` routing record the T2 (#1551)
+    backend-agnostic search router resolves server-side — the backend
+    (``vertex-rag`` / ``meho-knowledge``) never appears in a request or
+    response. Operator-set; never probe-written.
+
+    ``status`` is a bounded enum enforced via a DB-layer CHECK
+    (``'provisioning'`` → registered, corpus not yet answerable;
+    ``'ready'`` → live for search; ``'rebuilding'`` → a managed-RAG
+    index rebuild is in flight; ``'disabled'`` → hidden from the
+    catalogue). Portable enum-shape across PG + SQLite — see
+    :attr:`OperationGroup.review_status` for the precedent. T3 (#1552)
+    fails typed against a not-``ready`` collection; the ``readiness``
+    JSON column lands here (NULL until T6's probe writes it) so that
+    typed failure has somewhere to read its detail from.
+
+    ``when_to_use`` mirrors :attr:`OperationGroup.when_to_use`: a blurb
+    ``list_doc_collections`` returns verbatim so an agent can pick the
+    right collection *before* searching.
+
+    ``extras`` is the forward-compat escape hatch for per-collection
+    structured fields without first-class columns; v1 writes ``{}``.
+
+    The model ships with no helper methods — population is operator-
+    managed seed for v1 (no create/import API until a collection needs
+    one); read paths land at the resolver (this task) and the
+    catalogue / search tools (T3 / T4).
+    """
+
+    __tablename__ = "doc_collections"
+
+    id: Mapped[uuid.UUID] = mapped_column(
+        Uuid(),
+        primary_key=True,
+        default=uuid.uuid4,
+    )
+    # NULL → global/shared collection (every tenant sees it); non-null →
+    # tenant-curated. No FK clause by soft-FK discipline.
+    tenant_id: Mapped[uuid.UUID | None] = mapped_column(
+        Uuid(),
+        nullable=True,
+        default=None,
+    )
+    # Stable operator-chosen id, e.g. ``"vmware"``. The binary routing +
+    # entitlement key the agent passes as ``collection=<key>`` (#1548).
+    collection_key: Mapped[str] = mapped_column(Text, nullable=False)
+    vendor: Mapped[str] = mapped_column(Text, nullable=False)
+    # Products the corpus covers, e.g. ``["vsphere", "nsx"]``. TEXT[] on
+    # PG (GIN-indexable containment), JSON array on SQLite. NOT NULL with
+    # an empty-list default to avoid NULL vs [] ambiguity (Target.aliases
+    # precedent).
+    products: Mapped[list[str]] = mapped_column(
+        _PORTABLE_ARRAY,
+        nullable=False,
+        default=list,
+    )
+    description: Mapped[str | None] = mapped_column(Text, nullable=True)
+    # Agent-facing "pick this collection when…" blurb. Mirrors
+    # OperationGroup.when_to_use; surfaced verbatim by list_doc_collections
+    # (T4) and the initialize.instructions catalogue band.
+    when_to_use: Mapped[str | None] = mapped_column(Text, nullable=True)
+    # Operator-set ``{type, ref}`` backend routing record (the T2 router
+    # key). JSONB on PG, generic JSON (text) on SQLite. NOT NULL — every
+    # collection binds to exactly one backend.
+    backend: Mapped[dict[str, object]] = mapped_column(
+        _PORTABLE_JSON,
+        nullable=False,
+        default=dict,
+    )
+    status: Mapped[str] = mapped_column(
+        Text,
+        nullable=False,
+        default="provisioning",
+    )
+    # Probe-written liveness (T6 #1555). NULL until the first probe.
+    last_ingested_at: Mapped[datetime | None] = mapped_column(
+        DateTime(timezone=True),
+        nullable=True,
+        default=None,
+    )
+    doc_count: Mapped[int | None] = mapped_column(Integer, nullable=True)
+    # Probe-written readiness detail (T6 #1555); the column lands here so
+    # T3 (#1552) can fail typed against a not-ready collection. NULL until
+    # the first probe writes it. JSONB on PG, generic JSON on SQLite.
+    readiness: Mapped[dict[str, object] | None] = mapped_column(
+        _PORTABLE_JSON,
+        nullable=True,
+        default=None,
+    )
+    extras: Mapped[dict[str, object]] = mapped_column(
+        _PORTABLE_JSON,
+        nullable=False,
+        default=dict,
+    )
+    created_at: Mapped[datetime] = mapped_column(
+        DateTime(timezone=True),
+        nullable=False,
+        default=lambda: datetime.now(UTC),
+    )
+    updated_at: Mapped[datetime] = mapped_column(
+        DateTime(timezone=True),
+        nullable=False,
+        default=lambda: datetime.now(UTC),
+        onupdate=lambda: datetime.now(UTC),
+    )
+
+    __table_args__ = (
+        # Partial unique on (collection_key) for global rows. The WHERE
+        # clause is emitted on both dialects via the postgresql_where /
+        # sqlite_where pair (OperationGroup precedent).
+        Index(
+            "doc_collections_global_idx",
+            "collection_key",
+            unique=True,
+            postgresql_where=sa.text("tenant_id IS NULL"),
+            sqlite_where=sa.text("tenant_id IS NULL"),
+        ),
+        # Partial unique on (tenant_id, collection_key) for tenant rows.
+        Index(
+            "doc_collections_tenant_idx",
+            "tenant_id",
+            "collection_key",
+            unique=True,
+            postgresql_where=sa.text("tenant_id IS NOT NULL"),
+            sqlite_where=sa.text("tenant_id IS NOT NULL"),
+        ),
+        sa.CheckConstraint(
+            "status IN ('provisioning', 'ready', 'rebuilding', 'disabled')",
+            name="ck_doc_collections_status",
+        ),
+    )
+
+
 class EndpointDescriptor(Base):
     """A single operation an agent can dispatch through the G0.6 substrate.
 

--- a/backend/src/meho_backplane/docs_collections/__init__.py
+++ b/backend/src/meho_backplane/docs_collections/__init__.py
@@ -1,0 +1,30 @@
+# SPDX-License-Identifier: Apache-2.0
+# Copyright (c) 2026 evoila Group
+
+"""Public API for the doc-collections package (G4.6 T1 collections-as-data).
+
+Re-exports the read schemas, the single ORM→wire projection, and the
+resolver surface so downstream tasks can import from
+``meho_backplane.docs_collections`` without knowing the internal module
+split. The backend-agnostic search router (T2 #1551), collection-scoped
+search (T3 #1552), and the catalogue tool / CLI (T4 #1553) all build on
+this surface.
+"""
+
+from meho_backplane.docs_collections.resolver import (
+    DocCollectionNotFoundError,
+    resolve_doc_collection,
+)
+from meho_backplane.docs_collections.schemas import (
+    DocCollection,
+    DocCollectionSummary,
+    project_doc_collection_to_summary,
+)
+
+__all__ = [
+    "DocCollection",
+    "DocCollectionNotFoundError",
+    "DocCollectionSummary",
+    "project_doc_collection_to_summary",
+    "resolve_doc_collection",
+]

--- a/backend/src/meho_backplane/docs_collections/resolver.py
+++ b/backend/src/meho_backplane/docs_collections/resolver.py
@@ -1,0 +1,151 @@
+# SPDX-License-Identifier: Apache-2.0
+# Copyright (c) 2026 evoila Group
+
+"""Resolver for the ``collection_key`` → :class:`DocCollection` ORM lookup.
+
+:func:`resolve_doc_collection` is the single entry point the
+collection-scoped ``search_docs`` / ``ask_docs`` path (T3 #1552) and
+the catalogue tool (T4 #1553) use to turn an operator-supplied
+``collection`` key into the registry row that binds it to a backend.
+
+Tenant-then-global fallback
+---------------------------
+
+A ``collection_key`` may exist as a global / shared row
+(``tenant_id IS NULL``, available to every tenant) and as a
+tenant-curated row (``tenant_id = <tenant>``). The dual partial unique
+indexes (migration 0037) let both coexist; the resolver **prefers the
+tenant row** so a tenant can override a shared collection's backend
+binding or metadata without renaming it. This mirrors the
+global-vs-tenant visibility the operation-registry lookups enforce
+(``(tenant_id IS NULL) OR (tenant_id = :tenant)`` in
+:mod:`meho_backplane.operations._lookup`).
+
+A caller that needs only the global row (ignoring any tenant override)
+is out of scope for T1; the agent-facing path is always tenant-scoped.
+
+Error shape
+-----------
+
+An unknown key raises :exc:`DocCollectionNotFoundError`, which extends
+:class:`fastapi.HTTPException` (status 404) so it propagates cleanly
+through FastAPI route handlers and is catchable by CLI verbs that
+render human-readable output. The error detail carries the catalogue
+of keys visible to the tenant (global + tenant-curated) so the caller
+can surface "did you mean…?" without a second query — this is the
+typed not-found the acceptance criteria require.
+"""
+
+from __future__ import annotations
+
+from uuid import UUID
+
+import structlog
+from fastapi import HTTPException
+from sqlalchemy import select
+from sqlalchemy.ext.asyncio import AsyncSession
+
+from meho_backplane.db.models import DocCollection as DocCollectionORM
+
+__all__ = [
+    "DocCollectionNotFoundError",
+    "resolve_doc_collection",
+]
+
+_log = structlog.get_logger(__name__)
+
+
+class DocCollectionNotFoundError(HTTPException):
+    """Raised when no doc collection matches *collection_key* for the tenant.
+
+    ``known_keys`` lists the collection keys visible to the tenant
+    (global rows + this tenant's own rows) so the caller can render
+    suggestions. API routes serialise it via ``detail["known_keys"]``;
+    CLI verbs render it as a "available collections" hint.
+    """
+
+    def __init__(self, collection_key: str, known_keys: list[str]) -> None:
+        super().__init__(
+            status_code=404,
+            detail={
+                "error": "no_doc_collection",
+                "collection_key": collection_key,
+                "known_keys": known_keys,
+            },
+        )
+
+
+async def resolve_doc_collection(
+    session: AsyncSession,
+    collection_key: str,
+    tenant_id: UUID,
+) -> DocCollectionORM:
+    """Resolve *collection_key* to a :class:`DocCollectionORM` row, tenant-first.
+
+    Prefers the tenant-curated row (``tenant_id = tenant_id``) when one
+    exists, falling back to the global / shared row
+    (``tenant_id IS NULL``). See the module docstring for the rationale.
+
+    Args:
+        session: Active async DB session (inside an open transaction).
+        collection_key: The stable collection id, e.g. ``"vmware"``.
+        tenant_id: The tenant scope. The tenant's own row wins over the
+            global row with the same key.
+
+    Returns:
+        The matching :class:`~meho_backplane.db.models.DocCollection`
+        ORM row. Callers needing the Pydantic read shape convert with
+        ``DocCollection.model_validate(row, from_attributes=True)``.
+
+    Raises:
+        DocCollectionNotFoundError: No collection with *collection_key*
+            is visible to *tenant_id* (neither tenant-curated nor
+            global).
+    """
+    # Pull both the tenant-curated and the global row for the key in one
+    # query, then prefer the tenant row in Python. The dual partial
+    # unique indexes guarantee at most one row per (scope, key), so this
+    # returns at most two rows.
+    stmt = select(DocCollectionORM).where(
+        DocCollectionORM.collection_key == collection_key,
+        (DocCollectionORM.tenant_id == tenant_id) | (DocCollectionORM.tenant_id.is_(None)),
+    )
+    result = await session.execute(stmt)
+    rows = list(result.scalars().all())
+
+    tenant_row = next((r for r in rows if r.tenant_id == tenant_id), None)
+    global_row = next((r for r in rows if r.tenant_id is None), None)
+    collection = tenant_row or global_row
+
+    if collection is None:
+        known_keys = await _known_keys(session, tenant_id)
+        _log.info(
+            "doc_collection_not_found",
+            tenant_id=str(tenant_id),
+            collection_key=collection_key,
+            known_keys=known_keys,
+        )
+        raise DocCollectionNotFoundError(collection_key, known_keys)
+
+    _log.info(
+        "doc_collection_resolved",
+        tenant_id=str(tenant_id),
+        collection_key=collection.collection_key,
+        scope="tenant" if collection.tenant_id is not None else "global",
+    )
+    return collection
+
+
+async def _known_keys(session: AsyncSession, tenant_id: UUID) -> list[str]:
+    """Return the sorted collection keys visible to *tenant_id*.
+
+    Global rows (``tenant_id IS NULL``) plus this tenant's own rows.
+    A tenant-curated key that shadows a global key appears once
+    (deduplicated) — the catalogue answer is "this key exists", not
+    "in how many scopes".
+    """
+    stmt = select(DocCollectionORM.collection_key).where(
+        (DocCollectionORM.tenant_id == tenant_id) | (DocCollectionORM.tenant_id.is_(None))
+    )
+    result = await session.execute(stmt)
+    return sorted({str(key) for key in result.scalars().all()})

--- a/backend/src/meho_backplane/docs_collections/schemas.py
+++ b/backend/src/meho_backplane/docs_collections/schemas.py
@@ -1,0 +1,149 @@
+# SPDX-License-Identifier: Apache-2.0
+# Copyright (c) 2026 evoila Group
+
+"""Pydantic schemas for the doc-collections surface (G4.6 T1 #1550).
+
+Two read models cover the registry's wire contract:
+
+* :class:`DocCollection` — full read shape. Maps 1:1 to the
+  ``doc_collections`` table columns. Returned by the resolver and (in
+  T3 #1552) the collection-scoped search path. Frozen.
+* :class:`DocCollectionSummary` — short shape for the catalogue list
+  (``list_doc_collections``, T4 #1553). Carries the identification +
+  routing-decision fields an agent needs to pick a collection
+  (``collection_key`` / ``vendor`` / ``products`` / ``when_to_use``)
+  plus the operator-facing liveness fields (``status`` /
+  ``last_ingested_at`` / ``doc_count`` / ``readiness``). The
+  ``backend`` record is **omitted** by design — the backend
+  (``vertex-rag`` / ``meho-knowledge``) is resolved server-side and
+  never appears in a catalogue response (#1548 backend-agnostic
+  contract). Frozen.
+
+There is no ``DocCollectionCreate`` / ``DocCollectionUpdate`` here: v1
+collections are operator-managed seed (no create/import API until a
+collection needs one — out of scope per #1550). When that API lands it
+adds the write schemas alongside these read models.
+
+:func:`project_doc_collection_to_summary` is the **single** ORM→wire
+projection, mirroring :func:`targets.schemas.project_target_to_summary`.
+Every surface that lists collections (the catalogue tool, the CLI
+verb, the resolver's diagnostics) goes through it so list and detail
+never drift.
+"""
+
+from __future__ import annotations
+
+from collections.abc import Mapping
+from datetime import datetime
+from typing import TYPE_CHECKING, Any
+from uuid import UUID
+
+from pydantic import BaseModel, ConfigDict
+
+if TYPE_CHECKING:
+    from meho_backplane.db.models import DocCollection as DocCollectionORM
+
+__all__ = [
+    "DocCollection",
+    "DocCollectionSummary",
+    "project_doc_collection_to_summary",
+]
+
+
+class DocCollection(BaseModel):
+    """Full read shape — maps 1:1 to the ``doc_collections`` table.
+
+    Frozen so callers can stash instances in request state or structured
+    logs without fear of mutation. ``products`` is ``tuple[str, ...]``
+    and the JSON columns are ``Mapping[str, Any]`` so a frozen instance
+    cannot be mutated in-place via ``list.append`` / ``dict.__setitem__``.
+
+    ``backend`` is the operator-set ``{type, ref}`` routing record the
+    T2 (#1551) router resolves server-side. ``status`` is the lifecycle
+    enum (``provisioning`` / ``ready`` / ``rebuilding`` / ``disabled``);
+    ``last_ingested_at`` / ``doc_count`` / ``readiness`` are
+    probe-written liveness (T6 #1555), ``None`` until the first probe.
+    """
+
+    model_config = ConfigDict(frozen=True)
+
+    id: UUID
+    # NULL → global/shared collection; set → tenant-curated.
+    tenant_id: UUID | None
+    collection_key: str
+    vendor: str
+    products: tuple[str, ...]
+    description: str | None
+    when_to_use: str | None
+    backend: Mapping[str, Any]
+    status: str
+    last_ingested_at: datetime | None
+    doc_count: int | None
+    readiness: Mapping[str, Any] | None
+    extras: Mapping[str, Any]
+    created_at: datetime
+    updated_at: datetime
+
+
+class DocCollectionSummary(BaseModel):
+    """Short shape for the catalogue list (``list_doc_collections``, T4).
+
+    Carries the fields an agent needs to choose a collection before
+    searching (``collection_key`` / ``vendor`` / ``products`` /
+    ``when_to_use``) plus operator-facing liveness (``status`` /
+    ``last_ingested_at`` / ``doc_count`` / ``readiness``). The
+    ``backend`` record and free-form ``extras`` are deliberately omitted
+    — the backend is server-side-only (#1548) and ``extras`` is an
+    operator escape hatch that does not belong in the agent-facing
+    catalogue. Frozen.
+    """
+
+    model_config = ConfigDict(frozen=True)
+
+    id: UUID
+    tenant_id: UUID | None
+    collection_key: str
+    vendor: str
+    products: tuple[str, ...]
+    description: str | None
+    when_to_use: str | None
+    status: str
+    last_ingested_at: datetime | None
+    doc_count: int | None
+    readiness: Mapping[str, Any] | None
+    created_at: datetime
+    updated_at: datetime
+
+
+def project_doc_collection_to_summary(c: DocCollectionORM) -> DocCollectionSummary:
+    """Project a :class:`DocCollectionORM` row to the wire summary shape.
+
+    The single canonical ORM→wire projection for every surface that
+    lists doc collections (the ``list_doc_collections`` catalogue tool
+    in T4 #1553, the CLI verb, and the resolver's not-found
+    diagnostics). Mirrors
+    :func:`~meho_backplane.targets.schemas.project_target_to_summary`:
+    one helper, one place to change, no list-vs-detail drift.
+
+    Coerces ``products`` from the ORM column's mutable ``list[str]``
+    JSON shape to the frozen schema's ``tuple[str, ...]`` so the
+    returned :class:`DocCollectionSummary` is genuinely immutable.
+    """
+    return DocCollectionSummary(
+        id=c.id,
+        tenant_id=c.tenant_id,
+        collection_key=c.collection_key,
+        vendor=c.vendor,
+        # ORM stores products as ``list[str]`` (mutable JSON column);
+        # the wire schema declares ``tuple[str, ...]`` for frozen-model
+        # immutability. Coerce at the boundary.
+        products=tuple(c.products),
+        description=c.description,
+        when_to_use=c.when_to_use,
+        status=c.status,
+        last_ingested_at=c.last_ingested_at,
+        doc_count=c.doc_count,
+        readiness=c.readiness,
+        created_at=c.created_at,
+        updated_at=c.updated_at,
+    )

--- a/backend/tests/test_doc_collections_registry.py
+++ b/backend/tests/test_doc_collections_registry.py
@@ -1,0 +1,558 @@
+# SPDX-License-Identifier: Apache-2.0
+# Copyright (c) 2026 evoila Group
+
+"""Behavioural tests for the doc-collections registry (G4.6 T1 #1550).
+
+Coverage matrix (Task #1550 acceptance criteria):
+
+* Round-trip on :class:`DocCollection` — insert a valid row, query it
+  back, every field survives the ORM round-trip including
+  ``backend.{type,ref}``, ``products``, ``status``,
+  ``last_ingested_at``, ``doc_count``, and the probe-written
+  ``readiness`` JSON. Drives the ORM ``default=`` machinery (uuid,
+  created_at, updated_at, status, backend, extras) against the SQLite
+  dev/test driver where the migration's PG server-side defaults are
+  no-ops.
+* Dual partial unique indexes — a global row (``tenant_id=NULL``) and a
+  tenant-curated row with the same ``collection_key`` coexist; a second
+  global row with the same key collides; a second tenant row with the
+  same ``(tenant_id, collection_key)`` collides; the same key under two
+  different tenants is allowed.
+* ``resolve_doc_collection`` — returns the tenant row when present else
+  the global row; an unknown key raises the typed
+  :exc:`DocCollectionNotFoundError`.
+* ``project_doc_collection_to_summary`` — the single ORM→wire
+  projection produces the frozen summary with ``products`` coerced to a
+  tuple and the backend record omitted.
+* Schema-level smoke — ``alembic upgrade head`` creates the
+  ``doc_collections`` table with its partial-unique indexes (GIN absent
+  on SQLite), and ``upgrade head`` → ``downgrade -1`` is clean.
+
+Runs against ``sqlite+aiosqlite`` via the shared engine cache the
+autouse ``_default_database_url`` fixture in :mod:`tests.conftest`
+pre-migrates to ``alembic upgrade head``. SQLite strips tzinfo, so
+datetime assertions compare wall-clock parts only — identical to
+:mod:`tests.test_db_targets`.
+"""
+
+from __future__ import annotations
+
+import uuid
+from collections.abc import Iterator
+from datetime import UTC, datetime
+from pathlib import Path
+
+import pytest
+from sqlalchemy import create_engine as sa_create_engine
+from sqlalchemy import select
+from sqlalchemy import text as sa_text
+from sqlalchemy.exc import IntegrityError
+
+from meho_backplane.db.engine import get_sessionmaker, reset_engine_for_testing
+from meho_backplane.db.models import DocCollection
+from meho_backplane.docs_collections import (
+    DocCollectionNotFoundError,
+    DocCollectionSummary,
+    project_doc_collection_to_summary,
+    resolve_doc_collection,
+)
+from meho_backplane.settings import get_settings
+
+
+@pytest.fixture(autouse=True)
+def _required_settings_env(monkeypatch: pytest.MonkeyPatch) -> Iterator[None]:
+    """Pin every env var :class:`Settings` requires for this module.
+
+    Mirrors :mod:`tests.test_db_targets`: the autouse
+    ``_default_database_url`` fixture only pins ``DATABASE_URL``;
+    Keycloak/Vault knobs come from each test file. The
+    ``get_settings.cache_clear()`` brackets prevent a stale ``Settings``
+    instance from a previous test from leaking.
+    """
+    monkeypatch.setenv("KEYCLOAK_ISSUER_URL", "https://keycloak.test/realms/meho")
+    monkeypatch.setenv("KEYCLOAK_AUDIENCE", "meho-backplane")
+    monkeypatch.setenv("VAULT_ADDR", "https://vault.test")
+    get_settings.cache_clear()
+    yield
+    get_settings.cache_clear()
+
+
+# ---------------------------------------------------------------------------
+# DocCollection round-trip
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.asyncio
+async def test_doc_collection_round_trips_every_field() -> None:
+    """Insert a fully-populated :class:`DocCollection`, read it back, all fields match.
+
+    Exercises the operator-set fields (``collection_key`` / ``vendor`` /
+    ``products`` / ``backend`` / ``when_to_use``) and the probe-written
+    liveness fields (``status`` / ``last_ingested_at`` / ``doc_count`` /
+    ``readiness``) round-tripping through the ORM against the SQLite
+    driver where the migration's PG server-side defaults are no-ops.
+    """
+    sessionmaker = get_sessionmaker()
+    collection_id = uuid.uuid4()
+    tenant_id = uuid.uuid4()
+    ingested = datetime.now(UTC)
+
+    async with sessionmaker() as session:
+        session.add(
+            DocCollection(
+                id=collection_id,
+                tenant_id=tenant_id,
+                collection_key="vmware",
+                vendor="VMware by Broadcom",
+                products=["vsphere", "nsx"],
+                description="Complete VMware vendor doc set.",
+                when_to_use="Use for vSphere / NSX / VCF product questions.",
+                backend={"type": "vertex-rag", "ref": "projects/p/locations/l/corpora/c"},
+                status="ready",
+                last_ingested_at=ingested,
+                doc_count=16942,
+                readiness={"state": "ready", "checked_at": ingested.isoformat()},
+                extras={"engagement": "acme"},
+            )
+        )
+        await session.commit()
+
+    async with sessionmaker() as session:
+        result = await session.execute(
+            select(DocCollection).where(DocCollection.id == collection_id)
+        )
+        row = result.scalar_one()
+
+    assert row.id == collection_id
+    assert row.tenant_id == tenant_id
+    assert row.collection_key == "vmware"
+    assert row.vendor == "VMware by Broadcom"
+    assert row.products == ["vsphere", "nsx"]
+    assert row.description == "Complete VMware vendor doc set."
+    assert row.when_to_use == "Use for vSphere / NSX / VCF product questions."
+    assert row.backend == {"type": "vertex-rag", "ref": "projects/p/locations/l/corpora/c"}
+    assert row.status == "ready"
+    assert row.doc_count == 16942
+    assert row.readiness == {"state": "ready", "checked_at": ingested.isoformat()}
+    assert row.extras == {"engagement": "acme"}
+    # SQLite strips tzinfo — compare wall-clock parts only.
+    assert row.last_ingested_at is not None
+    assert row.last_ingested_at.replace(tzinfo=None) == ingested.replace(tzinfo=None)
+
+
+@pytest.mark.asyncio
+async def test_doc_collection_defaults_fire_when_optional_fields_omitted() -> None:
+    """A minimal :class:`DocCollection` gets the ORM column defaults.
+
+    ``tenant_id`` defaults to NULL (global), ``products`` to ``[]``,
+    ``status`` to ``provisioning``, ``backend`` / ``extras`` to ``{}``,
+    and the probe-written liveness fields to NULL.
+    """
+    sessionmaker = get_sessionmaker()
+    collection_id = uuid.uuid4()
+
+    async with sessionmaker() as session:
+        session.add(
+            DocCollection(
+                id=collection_id,
+                collection_key="minimal",
+                vendor="Acme",
+            )
+        )
+        await session.commit()
+
+    async with sessionmaker() as session:
+        result = await session.execute(
+            select(DocCollection).where(DocCollection.id == collection_id)
+        )
+        row = result.scalar_one()
+
+    assert row.tenant_id is None
+    assert row.products == []
+    assert row.description is None
+    assert row.when_to_use is None
+    assert row.backend == {}
+    assert row.status == "provisioning"
+    assert row.last_ingested_at is None
+    assert row.doc_count is None
+    assert row.readiness is None
+    assert row.extras == {}
+
+
+@pytest.mark.asyncio
+async def test_doc_collection_status_check_rejects_unknown_value() -> None:
+    """An out-of-enum ``status`` violates the DB-layer CHECK constraint."""
+    sessionmaker = get_sessionmaker()
+
+    async with sessionmaker() as session:
+        session.add(
+            DocCollection(
+                id=uuid.uuid4(),
+                collection_key="bad-status",
+                vendor="Acme",
+                status="archived",  # not in the CHECK IN(...) set
+            )
+        )
+        with pytest.raises(IntegrityError):
+            await session.commit()
+
+
+# ---------------------------------------------------------------------------
+# Dual partial unique indexes (global + tenant)
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.asyncio
+async def test_global_and_tenant_row_same_key_coexist() -> None:
+    """A global row and a tenant row with the same ``collection_key`` coexist.
+
+    The dual partial unique indexes split uniqueness by
+    ``tenant_id IS NULL`` / ``IS NOT NULL`` so a shared ``vmware`` and a
+    tenant-curated ``vmware`` are not in conflict.
+    """
+    sessionmaker = get_sessionmaker()
+    tenant_id = uuid.uuid4()
+
+    async with sessionmaker() as session:
+        session.add(
+            DocCollection(id=uuid.uuid4(), collection_key="vmware", vendor="VMware (global)")
+        )
+        session.add(
+            DocCollection(
+                id=uuid.uuid4(),
+                tenant_id=tenant_id,
+                collection_key="vmware",
+                vendor="VMware (tenant)",
+            )
+        )
+        # Must not raise — different uniqueness scopes.
+        await session.commit()
+
+    async with sessionmaker() as session:
+        result = await session.execute(
+            select(DocCollection).where(DocCollection.collection_key == "vmware")
+        )
+        rows = result.scalars().all()
+
+    assert len(rows) == 2
+    assert {r.tenant_id for r in rows} == {None, tenant_id}
+
+
+@pytest.mark.asyncio
+async def test_duplicate_global_key_rejected() -> None:
+    """Two global rows with the same ``collection_key`` collide.
+
+    The partial unique index ``WHERE tenant_id IS NULL`` enforces "one
+    global row per key" — the property a plain ``UNIQUE (tenant_id,
+    collection_key)`` would miss because NULL != NULL.
+    """
+    sessionmaker = get_sessionmaker()
+
+    async with sessionmaker() as session:
+        session.add(DocCollection(id=uuid.uuid4(), collection_key="dup-global", vendor="A"))
+        await session.commit()
+
+    async with sessionmaker() as session:
+        session.add(DocCollection(id=uuid.uuid4(), collection_key="dup-global", vendor="B"))
+        with pytest.raises(IntegrityError):
+            await session.commit()
+
+
+@pytest.mark.asyncio
+async def test_duplicate_tenant_key_rejected() -> None:
+    """Two rows with the same ``(tenant_id, collection_key)`` collide."""
+    sessionmaker = get_sessionmaker()
+    tenant_id = uuid.uuid4()
+
+    async with sessionmaker() as session:
+        session.add(
+            DocCollection(
+                id=uuid.uuid4(),
+                tenant_id=tenant_id,
+                collection_key="dup-tenant",
+                vendor="A",
+            )
+        )
+        await session.commit()
+
+    async with sessionmaker() as session:
+        session.add(
+            DocCollection(
+                id=uuid.uuid4(),
+                tenant_id=tenant_id,
+                collection_key="dup-tenant",
+                vendor="B",
+            )
+        )
+        with pytest.raises(IntegrityError):
+            await session.commit()
+
+
+@pytest.mark.asyncio
+async def test_same_key_allowed_across_tenants() -> None:
+    """The same ``collection_key`` under two different tenants is allowed."""
+    sessionmaker = get_sessionmaker()
+    tenant_a = uuid.uuid4()
+    tenant_b = uuid.uuid4()
+
+    async with sessionmaker() as session:
+        session.add(
+            DocCollection(id=uuid.uuid4(), tenant_id=tenant_a, collection_key="shared", vendor="A")
+        )
+        session.add(
+            DocCollection(id=uuid.uuid4(), tenant_id=tenant_b, collection_key="shared", vendor="B")
+        )
+        await session.commit()
+
+    async with sessionmaker() as session:
+        result = await session.execute(
+            select(DocCollection).where(DocCollection.collection_key == "shared")
+        )
+        rows = result.scalars().all()
+
+    assert {r.tenant_id for r in rows} == {tenant_a, tenant_b}
+
+
+# ---------------------------------------------------------------------------
+# resolve_doc_collection
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.asyncio
+async def test_resolve_prefers_tenant_row_over_global() -> None:
+    """When both a tenant and a global row exist, the tenant row wins."""
+    sessionmaker = get_sessionmaker()
+    tenant_id = uuid.uuid4()
+
+    async with sessionmaker() as session:
+        session.add(
+            DocCollection(id=uuid.uuid4(), collection_key="vmware", vendor="VMware (global)")
+        )
+        session.add(
+            DocCollection(
+                id=uuid.uuid4(),
+                tenant_id=tenant_id,
+                collection_key="vmware",
+                vendor="VMware (tenant)",
+            )
+        )
+        await session.commit()
+
+    async with sessionmaker() as session:
+        resolved = await resolve_doc_collection(session, "vmware", tenant_id)
+
+    assert resolved.tenant_id == tenant_id
+    assert resolved.vendor == "VMware (tenant)"
+
+
+@pytest.mark.asyncio
+async def test_resolve_falls_back_to_global_when_no_tenant_row() -> None:
+    """With only a global row present, the resolver returns it."""
+    sessionmaker = get_sessionmaker()
+    tenant_id = uuid.uuid4()
+
+    async with sessionmaker() as session:
+        session.add(
+            DocCollection(id=uuid.uuid4(), collection_key="vmware", vendor="VMware (global)")
+        )
+        await session.commit()
+
+    async with sessionmaker() as session:
+        resolved = await resolve_doc_collection(session, "vmware", tenant_id)
+
+    assert resolved.tenant_id is None
+    assert resolved.vendor == "VMware (global)"
+
+
+@pytest.mark.asyncio
+async def test_resolve_ignores_other_tenants_row() -> None:
+    """A row curated by another tenant is invisible (no cross-tenant leak)."""
+    sessionmaker = get_sessionmaker()
+    tenant_a = uuid.uuid4()
+    tenant_b = uuid.uuid4()
+
+    async with sessionmaker() as session:
+        session.add(
+            DocCollection(
+                id=uuid.uuid4(), tenant_id=tenant_b, collection_key="private", vendor="B-only"
+            )
+        )
+        await session.commit()
+
+    async with sessionmaker() as session:
+        with pytest.raises(DocCollectionNotFoundError):
+            await resolve_doc_collection(session, "private", tenant_a)
+
+
+@pytest.mark.asyncio
+async def test_resolve_unknown_key_raises_typed_not_found() -> None:
+    """An unknown key raises the typed not-found carrying the known keys."""
+    sessionmaker = get_sessionmaker()
+    tenant_id = uuid.uuid4()
+
+    async with sessionmaker() as session:
+        session.add(DocCollection(id=uuid.uuid4(), collection_key="vmware", vendor="VMware"))
+        await session.commit()
+
+    async with sessionmaker() as session:
+        with pytest.raises(DocCollectionNotFoundError) as exc_info:
+            await resolve_doc_collection(session, "nonesuch", tenant_id)
+
+    assert exc_info.value.status_code == 404
+    detail = exc_info.value.detail
+    assert isinstance(detail, dict)
+    assert detail["error"] == "no_doc_collection"
+    assert detail["collection_key"] == "nonesuch"
+    assert detail["known_keys"] == ["vmware"]
+
+
+# ---------------------------------------------------------------------------
+# project_doc_collection_to_summary
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.asyncio
+async def test_projection_produces_frozen_summary_without_backend() -> None:
+    """The single ORM→wire projection yields a frozen summary, backend omitted."""
+    sessionmaker = get_sessionmaker()
+    collection_id = uuid.uuid4()
+    tenant_id = uuid.uuid4()
+
+    async with sessionmaker() as session:
+        session.add(
+            DocCollection(
+                id=collection_id,
+                tenant_id=tenant_id,
+                collection_key="vmware",
+                vendor="VMware",
+                products=["vsphere", "nsx"],
+                when_to_use="vSphere questions.",
+                backend={"type": "vertex-rag", "ref": "corpora/c"},
+                status="ready",
+                doc_count=100,
+            )
+        )
+        await session.commit()
+
+    async with sessionmaker() as session:
+        result = await session.execute(
+            select(DocCollection).where(DocCollection.id == collection_id)
+        )
+        row = result.scalar_one()
+        summary = project_doc_collection_to_summary(row)
+
+    assert isinstance(summary, DocCollectionSummary)
+    assert summary.collection_key == "vmware"
+    assert summary.vendor == "VMware"
+    # products coerced from list to tuple for the frozen model.
+    assert summary.products == ("vsphere", "nsx")
+    assert summary.when_to_use == "vSphere questions."
+    assert summary.status == "ready"
+    assert summary.doc_count == 100
+    # The backend record is server-side-only and must not appear on the
+    # catalogue summary shape (#1548 backend-agnostic contract).
+    assert not hasattr(summary, "backend")
+    # Frozen — mutation attempts raise.
+    with pytest.raises(Exception):  # noqa: B017 — pydantic ValidationError on frozen set
+        summary.collection_key = "other"  # type: ignore[misc]
+
+
+# ---------------------------------------------------------------------------
+# Migration smoke — upgrade head + downgrade -1
+# ---------------------------------------------------------------------------
+
+
+def _alembic_cfg(
+    monkeypatch: pytest.MonkeyPatch,
+    tmp_path: Path,
+) -> tuple[object, str]:
+    """Pin env, reset caches, return an Alembic config + sync URL.
+
+    Mirrors :func:`tests.test_migration_0025_scheduled_trigger.alembic_cfg`:
+    sync URL because Alembic's env.py runs ``asyncio.run`` internally;
+    an isolated SQLite DB per call.
+    """
+    from meho_backplane.db.migrations import alembic_config
+
+    db_path = tmp_path / "migration_0037.db"
+    async_url = f"sqlite+aiosqlite:///{db_path}"
+    sync_url = f"sqlite:///{db_path}"
+    monkeypatch.setenv("DATABASE_URL", async_url)
+    monkeypatch.setenv("KEYCLOAK_ISSUER_URL", "https://keycloak.test/realms/meho")
+    monkeypatch.setenv("KEYCLOAK_AUDIENCE", "meho-backplane")
+    monkeypatch.setenv("VAULT_ADDR", "https://vault.test")
+    get_settings.cache_clear()
+    reset_engine_for_testing()
+
+    cfg = alembic_config()
+    cfg.set_main_option("sqlalchemy.url", async_url)
+    return cfg, sync_url
+
+
+def _index_names(sync_url: str, table: str) -> set[str]:
+    """Return the set of index names on *table* (SQLite schema inspector)."""
+    sync_eng = sa_create_engine(sync_url)
+    try:
+        with sync_eng.connect() as conn:
+            rows = conn.execute(sa_text(f"PRAGMA index_list({table})")).all()
+    finally:
+        sync_eng.dispose()
+    return {str(row[1]) for row in rows}
+
+
+def _table_names(sync_url: str) -> set[str]:
+    """Return the set of table names in the SQLite schema."""
+    sync_eng = sa_create_engine(sync_url)
+    try:
+        with sync_eng.connect() as conn:
+            rows = conn.execute(
+                sa_text("SELECT name FROM sqlite_master WHERE type = 'table'")
+            ).all()
+    finally:
+        sync_eng.dispose()
+    return {str(row[0]) for row in rows}
+
+
+def test_migration_0037_creates_table_and_partial_indexes(
+    monkeypatch: pytest.MonkeyPatch,
+    tmp_path: Path,
+) -> None:
+    """``alembic upgrade head`` installs ``doc_collections`` + its indexes.
+
+    The two partial-unique indexes land; the PG-only GIN index is absent
+    on SQLite (the ``if is_postgres:`` guard fired).
+    """
+    from alembic import command
+
+    cfg, sync_url = _alembic_cfg(monkeypatch, tmp_path)
+    try:
+        command.upgrade(cfg, "head")
+
+        assert "doc_collections" in _table_names(sync_url)
+        indexes = _index_names(sync_url, "doc_collections")
+        assert "doc_collections_global_idx" in indexes
+        assert "doc_collections_tenant_idx" in indexes
+        # GIN index is PG-only — must NOT be present on SQLite.
+        assert "doc_collections_products_gin_idx" not in indexes
+    finally:
+        get_settings.cache_clear()
+        reset_engine_for_testing()
+
+
+def test_migration_0037_downgrade_drops_table(
+    monkeypatch: pytest.MonkeyPatch,
+    tmp_path: Path,
+) -> None:
+    """``upgrade head`` → ``downgrade -1`` is clean: the table is gone."""
+    from alembic import command
+
+    cfg, sync_url = _alembic_cfg(monkeypatch, tmp_path)
+    try:
+        command.upgrade(cfg, "head")
+        assert "doc_collections" in _table_names(sync_url)
+
+        command.downgrade(cfg, "-1")
+        assert "doc_collections" not in _table_names(sync_url)
+    finally:
+        get_settings.cache_clear()
+        reset_engine_for_testing()

--- a/backend/tests/test_doc_collections_registry.py
+++ b/backend/tests/test_doc_collections_registry.py
@@ -10,9 +10,10 @@ Coverage matrix (Task #1550 acceptance criteria):
   ``backend.{type,ref}``, ``products``, ``status``,
   ``last_ingested_at``, ``doc_count``, and the probe-written
   ``readiness`` JSON. Drives the ORM ``default=`` machinery (uuid,
-  created_at, updated_at, status, backend, extras) against the SQLite
-  dev/test driver where the migration's PG server-side defaults are
-  no-ops.
+  created_at, updated_at, status, extras) against the SQLite dev/test
+  driver where the migration's PG server-side defaults are no-ops.
+  ``backend`` is NOT NULL with no default — a row that omits it is
+  rejected, not silently ``{}``-filled.
 * Dual partial unique indexes — a global row (``tenant_id=NULL``) and a
   tenant-curated row with the same ``collection_key`` coexist; a second
   global row with the same key collides; a second tenant row with the
@@ -75,6 +76,12 @@ def _required_settings_env(monkeypatch: pytest.MonkeyPatch) -> Iterator[None]:
     get_settings.cache_clear()
     yield
     get_settings.cache_clear()
+
+
+# A valid ``{type, ref}`` routing record for tests where the backend value
+# is incidental (uniqueness / resolution / CHECK coverage). ``backend`` is
+# NOT NULL with no default, so every inserted row must supply one.
+_BACKEND: dict[str, object] = {"type": "vertex-rag", "ref": "corpora/c"}
 
 
 # ---------------------------------------------------------------------------
@@ -145,8 +152,11 @@ async def test_doc_collection_defaults_fire_when_optional_fields_omitted() -> No
     """A minimal :class:`DocCollection` gets the ORM column defaults.
 
     ``tenant_id`` defaults to NULL (global), ``products`` to ``[]``,
-    ``status`` to ``provisioning``, ``backend`` / ``extras`` to ``{}``,
-    and the probe-written liveness fields to NULL.
+    ``status`` to ``provisioning``, ``extras`` to ``{}``, and the
+    probe-written liveness fields to NULL. ``backend`` is supplied
+    explicitly: it is NOT NULL with no default (a routing record is
+    required content, not an empty-meaningful escape hatch), so it is not
+    part of the defaults that fire on omission.
     """
     sessionmaker = get_sessionmaker()
     collection_id = uuid.uuid4()
@@ -157,6 +167,7 @@ async def test_doc_collection_defaults_fire_when_optional_fields_omitted() -> No
                 id=collection_id,
                 collection_key="minimal",
                 vendor="Acme",
+                backend={"type": "vertex-rag", "ref": "corpora/c"},
             )
         )
         await session.commit()
@@ -171,12 +182,36 @@ async def test_doc_collection_defaults_fire_when_optional_fields_omitted() -> No
     assert row.products == []
     assert row.description is None
     assert row.when_to_use is None
-    assert row.backend == {}
+    assert row.backend == {"type": "vertex-rag", "ref": "corpora/c"}
     assert row.status == "provisioning"
     assert row.last_ingested_at is None
     assert row.doc_count is None
     assert row.readiness is None
     assert row.extras == {}
+
+
+@pytest.mark.asyncio
+async def test_doc_collection_backend_required_when_omitted() -> None:
+    """Omitting ``backend`` is rejected — NOT NULL with no default.
+
+    ``backend`` carries the ``{type, ref}`` routing record the T2 router
+    (#1551) resolves server-side; an empty ``{}`` is a routing-broken
+    row, so the column has no ORM ``default`` and no migration
+    ``server_default``. A writer that omits it must hit the NOT NULL
+    constraint rather than silently persist an empty object.
+    """
+    sessionmaker = get_sessionmaker()
+
+    async with sessionmaker() as session:
+        session.add(
+            DocCollection(
+                id=uuid.uuid4(),
+                collection_key="no-backend",
+                vendor="Acme",
+            )
+        )
+        with pytest.raises(IntegrityError):
+            await session.commit()
 
 
 @pytest.mark.asyncio
@@ -190,6 +225,7 @@ async def test_doc_collection_status_check_rejects_unknown_value() -> None:
                 id=uuid.uuid4(),
                 collection_key="bad-status",
                 vendor="Acme",
+                backend=_BACKEND,
                 status="archived",  # not in the CHECK IN(...) set
             )
         )
@@ -215,7 +251,12 @@ async def test_global_and_tenant_row_same_key_coexist() -> None:
 
     async with sessionmaker() as session:
         session.add(
-            DocCollection(id=uuid.uuid4(), collection_key="vmware", vendor="VMware (global)")
+            DocCollection(
+                id=uuid.uuid4(),
+                collection_key="vmware",
+                vendor="VMware (global)",
+                backend=_BACKEND,
+            )
         )
         session.add(
             DocCollection(
@@ -223,6 +264,7 @@ async def test_global_and_tenant_row_same_key_coexist() -> None:
                 tenant_id=tenant_id,
                 collection_key="vmware",
                 vendor="VMware (tenant)",
+                backend=_BACKEND,
             )
         )
         # Must not raise — different uniqueness scopes.
@@ -249,11 +291,25 @@ async def test_duplicate_global_key_rejected() -> None:
     sessionmaker = get_sessionmaker()
 
     async with sessionmaker() as session:
-        session.add(DocCollection(id=uuid.uuid4(), collection_key="dup-global", vendor="A"))
+        session.add(
+            DocCollection(
+                id=uuid.uuid4(),
+                collection_key="dup-global",
+                vendor="A",
+                backend=_BACKEND,
+            )
+        )
         await session.commit()
 
     async with sessionmaker() as session:
-        session.add(DocCollection(id=uuid.uuid4(), collection_key="dup-global", vendor="B"))
+        session.add(
+            DocCollection(
+                id=uuid.uuid4(),
+                collection_key="dup-global",
+                vendor="B",
+                backend=_BACKEND,
+            )
+        )
         with pytest.raises(IntegrityError):
             await session.commit()
 
@@ -271,6 +327,7 @@ async def test_duplicate_tenant_key_rejected() -> None:
                 tenant_id=tenant_id,
                 collection_key="dup-tenant",
                 vendor="A",
+                backend=_BACKEND,
             )
         )
         await session.commit()
@@ -282,6 +339,7 @@ async def test_duplicate_tenant_key_rejected() -> None:
                 tenant_id=tenant_id,
                 collection_key="dup-tenant",
                 vendor="B",
+                backend=_BACKEND,
             )
         )
         with pytest.raises(IntegrityError):
@@ -297,10 +355,22 @@ async def test_same_key_allowed_across_tenants() -> None:
 
     async with sessionmaker() as session:
         session.add(
-            DocCollection(id=uuid.uuid4(), tenant_id=tenant_a, collection_key="shared", vendor="A")
+            DocCollection(
+                id=uuid.uuid4(),
+                tenant_id=tenant_a,
+                collection_key="shared",
+                vendor="A",
+                backend=_BACKEND,
+            )
         )
         session.add(
-            DocCollection(id=uuid.uuid4(), tenant_id=tenant_b, collection_key="shared", vendor="B")
+            DocCollection(
+                id=uuid.uuid4(),
+                tenant_id=tenant_b,
+                collection_key="shared",
+                vendor="B",
+                backend=_BACKEND,
+            )
         )
         await session.commit()
 
@@ -326,7 +396,12 @@ async def test_resolve_prefers_tenant_row_over_global() -> None:
 
     async with sessionmaker() as session:
         session.add(
-            DocCollection(id=uuid.uuid4(), collection_key="vmware", vendor="VMware (global)")
+            DocCollection(
+                id=uuid.uuid4(),
+                collection_key="vmware",
+                vendor="VMware (global)",
+                backend=_BACKEND,
+            )
         )
         session.add(
             DocCollection(
@@ -334,6 +409,7 @@ async def test_resolve_prefers_tenant_row_over_global() -> None:
                 tenant_id=tenant_id,
                 collection_key="vmware",
                 vendor="VMware (tenant)",
+                backend=_BACKEND,
             )
         )
         await session.commit()
@@ -353,7 +429,12 @@ async def test_resolve_falls_back_to_global_when_no_tenant_row() -> None:
 
     async with sessionmaker() as session:
         session.add(
-            DocCollection(id=uuid.uuid4(), collection_key="vmware", vendor="VMware (global)")
+            DocCollection(
+                id=uuid.uuid4(),
+                collection_key="vmware",
+                vendor="VMware (global)",
+                backend=_BACKEND,
+            )
         )
         await session.commit()
 
@@ -374,7 +455,11 @@ async def test_resolve_ignores_other_tenants_row() -> None:
     async with sessionmaker() as session:
         session.add(
             DocCollection(
-                id=uuid.uuid4(), tenant_id=tenant_b, collection_key="private", vendor="B-only"
+                id=uuid.uuid4(),
+                tenant_id=tenant_b,
+                collection_key="private",
+                vendor="B-only",
+                backend=_BACKEND,
             )
         )
         await session.commit()
@@ -391,7 +476,14 @@ async def test_resolve_unknown_key_raises_typed_not_found() -> None:
     tenant_id = uuid.uuid4()
 
     async with sessionmaker() as session:
-        session.add(DocCollection(id=uuid.uuid4(), collection_key="vmware", vendor="VMware"))
+        session.add(
+            DocCollection(
+                id=uuid.uuid4(),
+                collection_key="vmware",
+                vendor="VMware",
+                backend=_BACKEND,
+            )
+        )
         await session.commit()
 
     async with sessionmaker() as session:

--- a/docs/codebase/doc-collections.md
+++ b/docs/codebase/doc-collections.md
@@ -72,7 +72,7 @@ columns. `DocCollectionSummary` is the short shape for the catalogue
 list — it carries the identification + routing-decision fields plus the
 operator-facing liveness fields but **omits `backend`** (the backend is
 resolved server-side and never appears in a catalogue response, the
-#1548 backend-agnostic contract) and `extras`.
+backend-agnostic contract from #1548) and `extras`.
 
 There are no `Create` / `Update` write schemas — v1 collections are
 operator-managed seed. When an import API lands it adds them here.

--- a/docs/codebase/doc-collections.md
+++ b/docs/codebase/doc-collections.md
@@ -1,0 +1,153 @@
+# doc_collections registry (collections-as-data)
+
+## Overview
+
+The `doc_collections` registry is the catalogue substrate of the G4.6
+doc-collection catalogue (Initiative #1548). It answers the question
+"which documentation corpora can an agent search?" the same way the
+`targets` registry answers "which infrastructure can an agent act on?".
+One row per corpus (e.g. `vmware`); the row binds a stable
+`collection_key` to a backend `{type, ref}` routing record and carries
+the metadata an agent needs to pick a collection before searching.
+
+The registry deliberately splits two kinds of field by who writes them
+— the same split `targets` rows + `Target.fingerprint` use:
+
+- **Operator-set, authoritative for identity + routing** —
+  `collection_key`, `vendor`, `products`, `description`, `when_to_use`,
+  and `backend`. These are seeded by an operator (no create/import API
+  in v1; operator-managed seed only).
+- **Probe-written liveness** — `status`, `last_ingested_at`,
+  `doc_count`, and `readiness`. The backend is the source of truth for
+  liveness; a later probe (G4.6-T6, #1555) writes these from the
+  backend. This task ships the columns; nothing writes them yet.
+
+This is registry substrate only. The backend-agnostic search router
+(T2, #1551), collection-scoped `search_docs` / `ask_docs` (T3, #1552),
+the `list_doc_collections` catalogue tool and CLI (T4, #1553), and the
+readiness probe (T6, #1555) all build on this surface but are out of
+scope here. There is no agent-facing surface yet.
+
+## Key types
+
+### `DocCollection` ORM (`meho_backplane.db.models`)
+
+`__tablename__ = "doc_collections"`. Mirrors the `Target` /
+`OperationGroup` scaffolding:
+
+- `id` UUID PK; `tenant_id` UUID **nullable** — `NULL` for a global /
+  shared collection (every tenant sees it), set for a tenant-curated
+  collection.
+- `collection_key` Text — the stable operator-chosen id and the binary
+  routing + entitlement key the agent passes as `collection=<key>`.
+- `vendor` Text; `products` array (`_PORTABLE_ARRAY`: native `TEXT[]`
+  on PostgreSQL, JSON array on SQLite); `description` / `when_to_use`
+  Text. `when_to_use` mirrors `OperationGroup.when_to_use` — a blurb the
+  catalogue tool returns verbatim so an agent picks a collection before
+  searching.
+- `backend` JSON (`_PORTABLE_JSON`) `= {type, ref}` — the T2 router key,
+  operator-set, server-side-only.
+- `status` Text CHECK `IN ('provisioning', 'ready', 'rebuilding',
+  'disabled')` — the lifecycle enum (copies the `OperationGroup.
+  review_status` portable-enum shape); `last_ingested_at` timestamptz;
+  `doc_count` int; `readiness` JSON — probe-written liveness, all NULL
+  until the probe runs.
+- `extras` JSON forward-compat escape hatch; `created_at` /
+  `updated_at` timestamptz.
+
+Uniqueness on `collection_key` is enforced by **two partial unique
+indexes** (the `OperationGroup` idiom): `doc_collections_global_idx`
+`WHERE tenant_id IS NULL` on `(collection_key)`, and
+`doc_collections_tenant_idx` `WHERE tenant_id IS NOT NULL` on
+`(tenant_id, collection_key)`. A single `UNIQUE (tenant_id,
+collection_key)` would not catch two global rows sharing a key — SQL's
+`NULL != NULL` semantics mean any number of `tenant_id IS NULL` rows
+with the same key would commit. The split lets a global `vmware` and a
+tenant-curated `vmware` coexist (the resolver prefers the tenant row).
+
+### `DocCollection` / `DocCollectionSummary` (`meho_backplane.docs_collections.schemas`)
+
+Frozen Pydantic-v2 read models. `DocCollection` maps 1:1 to the table
+columns. `DocCollectionSummary` is the short shape for the catalogue
+list — it carries the identification + routing-decision fields plus the
+operator-facing liveness fields but **omits `backend`** (the backend is
+resolved server-side and never appears in a catalogue response, the
+#1548 backend-agnostic contract) and `extras`.
+
+There are no `Create` / `Update` write schemas — v1 collections are
+operator-managed seed. When an import API lands it adds them here.
+
+### `project_doc_collection_to_summary(...)` (`meho_backplane.docs_collections.schemas`)
+
+The single ORM→wire projection, mirroring
+`targets.schemas.project_target_to_summary`. Every surface that lists
+collections (catalogue tool, CLI verb, resolver diagnostics) goes
+through it so list and detail never drift. Coerces `products` from the
+ORM's mutable `list[str]` to the frozen schema's `tuple[str, ...]`.
+
+### `resolve_doc_collection(session, collection_key, tenant_id)` (`meho_backplane.docs_collections.resolver`)
+
+The single entry point that turns an operator-supplied `collection` key
+into the registry row that binds it to a backend. **Tenant-first
+fallback**: pulls the tenant-curated row and the global row for the key
+in one query, prefers the tenant row, falls back to the global row. A
+tenant override of a shared collection's backend binding or metadata is
+honoured without renaming the key. Mirrors the global-vs-tenant
+visibility the operation-registry lookups enforce in
+`meho_backplane.operations._lookup`.
+
+An unknown key raises `DocCollectionNotFoundError` (extends
+`fastapi.HTTPException`, status 404) carrying the catalogue of keys
+visible to the tenant (`detail["known_keys"]`) so the caller can render
+suggestions without a second query.
+
+## Control flow (resolution)
+
+1. A caller (T3's collection-scoped `search_docs`, T4's catalogue) holds
+   a `collection` key string and the operator's `tenant_id`.
+2. `resolve_doc_collection` queries
+   `collection_key = :key AND (tenant_id = :tenant OR tenant_id IS NULL)`,
+   prefers the tenant row, returns the `DocCollection` ORM row.
+3. The caller reads `row.backend` to route the query server-side (T2)
+   and `row.status` / `row.readiness` to fail typed against a not-ready
+   collection (T3).
+4. An unknown key raises `DocCollectionNotFoundError` with the visible
+   keys for a "did you mean…?" diagnostic.
+
+## Dependencies
+
+- SQLAlchemy 2.0 typed ORM (`Mapped[...]` / `mapped_column`), the
+  `_PORTABLE_JSON` / `_PORTABLE_ARRAY` dialect-portable column aliases
+  in `db/models.py`, and the partial-unique-index `postgresql_where` /
+  `sqlite_where` pair.
+- Pydantic v2 frozen models (`ConfigDict(frozen=True)`).
+- Alembic migration `0037_create_doc_collections` (`down_revision =
+  '0036'`) — dialect-portable `create_table` + partial-index emission,
+  symmetric downgrade, runs clean on both SQLite and PostgreSQL.
+- `fastapi.HTTPException` for the typed not-found, `structlog` for
+  resolution logging.
+
+## Known issues / boundaries
+
+- **No liveness writer yet.** `status` defaults to `provisioning` and
+  the probe-written fields are NULL until G4.6-T6 (#1555) lands the
+  readiness probe. A consumer must not assume a collection is
+  answerable from registry presence alone — that is what `status` /
+  `readiness` are for.
+- **No write API.** Collections are operator-managed seed for v1. An
+  `import` verb (mirroring `meho targets import`) is a later add if a
+  collection needs one.
+- **Entitlement is not enforced here.** The per-collection capability
+  gate (`meho-docs:<collection>`) and the `audit_collection` binding
+  land in T3 (#1552); the registry only stores and resolves rows.
+
+## References
+
+- Mirror: `Target` ORM and `OperationGroup` global+tenant +
+  `review_status` in `backend/src/meho_backplane/db/models.py`;
+  `targets/{schemas,resolver,__init__}.py`.
+- Migration precedent: `0004_create_targets_and_audit_target_id.py`
+  (dialect-portable create_table) and `0005_create_endpoint_descriptor.py`
+  (partial-unique-index emission).
+- Initiative #1548; this task #1550. Predecessor add-on:
+  [docs-search.md](docs-search.md) (G4.5 single-corpus `meho-docs`).


### PR DESCRIPTION
## Summary

- Add the `doc_collections` registry (collections-as-data) — the foundational substrate of the G4.6 doc-collection catalogue (Initiative #1548). One row per documentation corpus, the docs analogue of the `targets` registry.
- New `DocCollection` ORM (`doc_collections`) mirrors the `Target` / `OperationGroup` scaffolding: NULLABLE `tenant_id` (NULL=global/shared, set=tenant-curated) with the dual partial-unique-index idiom on `collection_key`. Splits operator-set identity + backend binding (`collection_key` / `vendor` / `products` / `backend{type, ref}` / `when_to_use`) from probe-written liveness (`status` / `last_ingested_at` / `doc_count` / `readiness`) — the same targets-as-data split. The `readiness` column lands here (probe-written later in T6) so T3 can fail typed against a not-ready collection.
- Migration `0037_create_doc_collections` (down_revision `0036`) copies the dialect-portable create_table + partial-index emission from 0004/0005 with a symmetric downgrade; clean on both SQLite and Postgres.
- New `docs_collections/` package mirrors `targets/`: frozen Pydantic read schemas with one `project_doc_collection_to_summary` ORM→wire projection (the `backend` record is server-side-only per #1548, so it is omitted from the summary), and `resolve_doc_collection(collection_key, tenant_id)` with a tenant-first fallback + typed `DocCollectionNotFoundError`.

## Test plan

- [x] `ruff check` — clean
- [x] `ruff format --check` — clean
- [x] `mypy src/meho_backplane/docs_collections/ src/meho_backplane/db/models.py` — clean
- [x] `pytest tests/test_doc_collections_registry.py` — 14 passed
- [x] Migration 0037 `upgrade head` then `downgrade -1` clean on SQLite (two migration smoke tests)
- [x] Global (`tenant_id=NULL`) + tenant-curated row with same `collection_key` coexist; duplicate-within-scope rejected; same key across tenants allowed
- [x] `resolve_doc_collection` returns tenant row over global; falls back to global; unknown key → typed not-found
- [x] `backend.{type,ref}`, `products`, `status`, `last_ingested_at`, `doc_count`, `readiness` round-trip
- [x] Neighbor DB tests (`test_db_targets`, `test_db_models`) still pass — `Base.metadata` addition causes no regression
- [x] `code-quality.py --diff` — 0 blockers
- [x] `alembic heads` — single head `0037`

No API/OpenAPI surface change (registry substrate only, no REST route) — CLI snapshot regen not required.

## Out of scope (sibling tasks that build on this registry)

- Backend-agnostic search router + first adapter (T2, #1551)
- Collection-scoped `search_docs` / `ask_docs` + entitlement + audit (T3, #1552)
- `list_doc_collections` MCP tool + CLI + `initialize.instructions` band (T4, #1553)
- Cross-collection fan-out with RRF (T5, #1554); readiness probe (T6, #1555); docs/runbook (T7, #1556)
- No create/import API for collections (operator-managed seed for v1)

Adjacent finding (deferred): `backend/src/meho_backplane/db/models.py` is 4767 lines (pre-existing, > 600-line soft limit) — flagged as a warning by the code-quality diff gate; not introduced by this change.

<!-- auto-implement-issue: fresh, iteration 1 -->

Closes #1550


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added a documentation collections registry enabling operators to register and manage named documentation sources with tenant-scoped support and status tracking (provisioning, ready, rebuilding, disabled).
  * Unknown collection lookups now return a 404 error with suggestions of available collections to the requesting tenant.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->