### PR TITLE
feat(docs): backend-agnostic search router + first adapter (#1551)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -90,6 +90,23 @@ connector-related release-notes line.
 
 ## [Unreleased]
 
+### Backend-agnostic search router (#1551)
+
+- Add a `collection → backend{type, ref}` search router so one doc
+  collection can sit on a managed RAG and another on the JWT-forward
+  corpus behind the same `search_docs`, with the backend never appearing
+  in the request or response. New `docs_search/backends/` package: a
+  `SearchBackend` ABC (with a `probe()` seam for the later readiness
+  Task), a tiny `dict[type, SearchBackend]` registry, and
+  `resolve_backend` / `resolve_backend_or_label` (direct type lookup, no
+  tie-break ladder; unknown/unconfigured type → the existing 503 arm).
+  The single-corpus client is re-homed as the first `corpus-http`
+  adapter, resolving its endpoint/audience per collection from
+  `backend.ref` with the legacy `corpus_url` fallback for an unmigrated
+  single-collection deploy. The `search_docs` service routes through the
+  router via an additive, optional `collection` argument; threading a
+  mandatory collection request param is a downstream Task.
+
 ### Doc-collection registry (#1550)
 
 - Add the `doc_collections` table (collections-as-data) — one row per

--- a/backend/src/meho_backplane/auth/corpus.py
+++ b/backend/src/meho_backplane/auth/corpus.py
@@ -26,6 +26,19 @@ Pydantic adapter (:class:`CorpusChunk` / :class:`CorpusSearchResponse`)
 that can be pinned without churning the call sites. The route, the
 mandatory REQUIRE_FILTERS posture, and the central audit binding are
 **out of scope here** — they land in T3.
+
+G4.6-T2 (#1551) re-homes this transport behind the backend-agnostic
+search router: :class:`~meho_backplane.docs_search.backends.corpus_http.CorpusHttpBackend`
+wraps :func:`search_corpus` as the first
+:class:`~meho_backplane.docs_search.backends.base.SearchBackend` adapter,
+passing a per-collection ``corpus_url`` / ``audience`` resolved from the
+collection's ``backend.ref``. The optional ``corpus_url`` / ``audience``
+overrides on :func:`search_corpus` are the seam for that — ``None`` keeps
+the legacy global-settings behaviour for an unmigrated single-collection
+deploy. The wire adapters (:class:`CorpusChunk` /
+:class:`CorpusSearchResponse`) and the one typed
+:class:`CorpusUnavailable` stay here, imported by the adapter and every
+other consumer.
 """
 
 from __future__ import annotations
@@ -110,17 +123,19 @@ async def search_corpus(
     *,
     metadata_filters: dict[str, Any] | None = None,
     limit: int = 10,
+    corpus_url: str | None = None,
+    audience: str | None = None,
 ) -> CorpusSearchResponse:
     """Search the external corpus as *operator*, returning cited chunks.
 
-    POSTs a JSON search request to ``settings.corpus_url`` with
+    POSTs a JSON search request to *corpus_url* with
     ``Authorization: Bearer <operator.raw_jwt>`` so the corpus
     authenticates and audits the call as the operator. The request is
     bounded by ``settings.corpus_timeout_seconds`` across connect / read
     / write so a slow or hung corpus raises rather than blocking the
-    event loop. ``settings.corpus_audience`` (RFC 8707), when set, is
-    forwarded as the requested resource indicator; the corpus may use it
-    to bind the token to itself.
+    event loop. *audience* (RFC 8707), when set, is forwarded as the
+    requested resource indicator; the corpus may use it to bind the
+    token to itself.
 
     Args:
         operator: The verified operator whose JWT is forwarded.
@@ -131,32 +146,42 @@ async def search_corpus(
             by the consuming route (T3, #1521), **not** here — this
             transport forwards whatever filters it is given.
         limit: Maximum number of chunks to request.
+        corpus_url: The corpus search endpoint. ``None`` falls back to
+            ``settings.corpus_url`` — the single-collection deploy that
+            predates the per-collection backend router (T2 #1551). The
+            ``corpus-http`` backend adapter passes the collection's
+            ``backend.ref`` endpoint here so each collection can federate
+            to its own corpus.
+        audience: The RFC 8707 resource indicator to forward. ``None``
+            falls back to ``settings.corpus_audience``; an empty string
+            forwards no audience.
 
     Raises:
-        CorpusUnavailable: when ``corpus_url`` is unset (unconfigured),
+        CorpusUnavailable: when *corpus_url* is unset (unconfigured),
             the corpus is unreachable / times out, or it returns a
             non-2xx status. The upstream status is carried on the
             exception (``status``) for non-2xx responses; the raw
             response body is never included.
     """
     settings = get_settings()
-    corpus_url = settings.corpus_url
-    if not corpus_url:
+    resolved_url = corpus_url if corpus_url is not None else settings.corpus_url
+    if not resolved_url:
         # Fail-closed: an unconfigured corpus is unavailable, not empty.
         raise CorpusUnavailable("corpus_url is not configured")
+    resolved_audience = audience if audience is not None else settings.corpus_audience
 
     payload: dict[str, Any] = {"query": query, "limit": limit}
     if metadata_filters:
         payload["metadata_filters"] = metadata_filters
-    if settings.corpus_audience:
-        payload["audience"] = settings.corpus_audience
+    if resolved_audience:
+        payload["audience"] = resolved_audience
 
     headers = {"Authorization": f"Bearer {operator.raw_jwt}"}
     timeout = httpx.Timeout(settings.corpus_timeout_seconds)
 
     try:
         async with httpx.AsyncClient(timeout=timeout) as client:
-            response = await client.post(corpus_url, json=payload, headers=headers)
+            response = await client.post(resolved_url, json=payload, headers=headers)
     except httpx.HTTPError as exc:
         # ConnectError / TimeoutException / any transport failure — the
         # corpus is unreachable. Log the cause by type (never the JWT or

--- a/backend/src/meho_backplane/docs_search/__init__.py
+++ b/backend/src/meho_backplane/docs_search/__init__.py
@@ -25,6 +25,11 @@ binding (``op_id="meho.docs.search"``) stays in the route, next to the
 
 from __future__ import annotations
 
+from meho_backplane.docs_search.backends import (
+    SearchBackend,
+    resolve_backend,
+    resolve_backend_or_label,
+)
 from meho_backplane.docs_search.service import (
     DocsChunk,
     DocsScope,
@@ -48,7 +53,10 @@ __all__ = [
     "DocsSearchResult",
     "DocsSynthesisError",
     "MissingDocsFilterError",
+    "SearchBackend",
     "build_docs_scope",
+    "resolve_backend",
+    "resolve_backend_or_label",
     "search_docs",
     "synthesize_docs_answer",
 ]

--- a/backend/src/meho_backplane/docs_search/backends/__init__.py
+++ b/backend/src/meho_backplane/docs_search/backends/__init__.py
@@ -1,0 +1,55 @@
+# SPDX-License-Identifier: Apache-2.0
+# Copyright (c) 2026 evoila Group
+
+"""Backend-agnostic search router for doc collections (G4.6-T2 #1551).
+
+Public surface — the four pieces a collection's ``backend{type, ref}``
+routing record (T1 #1550) is resolved through:
+
+* :class:`SearchBackend` — the adapter ABC every backend implements
+  (``async search`` + the T6 ``probe`` seam).
+* :class:`CorpusHttpBackend` — the first concrete adapter, re-homing the
+  JWT-forward corpus client.
+* :func:`register_backend` / :func:`get_backend` / :func:`all_backends` —
+  the tiny type→impl registry (mirrors the connector registry, minus the
+  tie-break ladder).
+* :func:`resolve_backend` / :func:`resolve_backend_or_label` — the
+  ``collection → backend`` router. The raising form drops into the
+  ``search_docs`` seam (unroutable → existing 503); the labelled form is
+  the ``(impl, label, msg)`` shape T5 fan-out and T6 readiness branch on.
+
+Importing this package self-registers the shipped ``corpus-http`` adapter
+(via :mod:`meho_backplane.docs_search.backends.registry`), so a caller
+that imports :func:`resolve_backend` has a populated registry without a
+separate eager-import step.
+"""
+
+from meho_backplane.docs_search.backends.base import SearchBackend
+from meho_backplane.docs_search.backends.corpus_http import (
+    CORPUS_HTTP_BACKEND_TYPE,
+    CorpusHttpBackend,
+)
+from meho_backplane.docs_search.backends.registry import (
+    all_backends,
+    get_backend,
+    register_backend,
+)
+from meho_backplane.docs_search.backends.resolver import (
+    BackendRef,
+    ResolvedBackend,
+    resolve_backend,
+    resolve_backend_or_label,
+)
+
+__all__ = [
+    "CORPUS_HTTP_BACKEND_TYPE",
+    "BackendRef",
+    "CorpusHttpBackend",
+    "ResolvedBackend",
+    "SearchBackend",
+    "all_backends",
+    "get_backend",
+    "register_backend",
+    "resolve_backend",
+    "resolve_backend_or_label",
+]

--- a/backend/src/meho_backplane/docs_search/backends/base.py
+++ b/backend/src/meho_backplane/docs_search/backends/base.py
@@ -1,0 +1,126 @@
+# SPDX-License-Identifier: Apache-2.0
+# Copyright (c) 2026 evoila Group
+
+"""The backend-agnostic search-backend interface (G4.6-T2 #1551).
+
+A :class:`SearchBackend` is the seam that lets one doc collection sit on a
+managed RAG and another on ``meho-knowledge`` / Qdrant **behind the same
+``search_docs``** — the agent never sees which backend answered. The
+``collection → backend{type, ref}`` router
+(:func:`~meho_backplane.docs_search.backends.resolver.resolve_backend`)
+maps a collection's ``backend.type`` to one of these adapters; the chosen
+adapter does the actual federation and returns the corpus-shaped
+:class:`~meho_backplane.auth.corpus.CorpusSearchResponse` the
+``search_docs`` service already projects into MEHO's cited-chunk surface.
+
+The interface is deliberately the **same shape** the existing
+:func:`~meho_backplane.auth.corpus.search_corpus` transport already had —
+``async search(operator, query, *, metadata_filters, limit)`` returning a
+:class:`CorpusSearchResponse` — so re-homing today's single-corpus client
+as the first adapter (``CorpusHttpBackend``) is behaviour-preserving and
+the ``CorpusChunk → DocsChunk`` projection downstream is untouched.
+
+Adapters are **stateless singletons**: one instance per ``backend_type``
+is registered at import time (mirroring the connector registry,
+:mod:`meho_backplane.connectors.registry`). Per-collection configuration
+(endpoint, audience) is **not** adapter state — it rides on the
+collection's ``backend.ref`` and is passed to :meth:`search` per call, so
+a single ``CorpusHttpBackend`` instance serves every collection routed to
+the ``corpus-http`` type.
+
+:meth:`probe` is a forward seam for the readiness probe (T6 #1555). It
+defaults to raising :class:`NotImplementedError` so an adapter that has
+not implemented readiness reporting fails loudly rather than silently
+claiming "ready"; T6 overrides it on the adapters that gain a liveness
+endpoint.
+"""
+
+from __future__ import annotations
+
+from abc import ABC, abstractmethod
+from collections.abc import Mapping
+from typing import Any
+
+from meho_backplane.auth.corpus import CorpusSearchResponse
+from meho_backplane.auth.operator import Operator
+
+__all__ = ["SearchBackend"]
+
+
+class SearchBackend(ABC):
+    """Abstract search backend an entitled doc collection routes to.
+
+    Subclasses advertise themselves with a class-level
+    :attr:`backend_type` discriminator — the string the registry keys on
+    and the value a collection's ``backend.type`` selects. The router
+    does a **direct dict lookup** on that string (no version tie-break
+    ladder — collections bind to exactly one backend by construction).
+
+    One required async method, :meth:`search`, plus an optional
+    :meth:`probe` forward seam for T6. The signature mirrors the
+    re-homed corpus client so the ``search_docs`` service swaps its
+    direct transport call for ``backend.search(...)`` with the request
+    shape unchanged.
+    """
+
+    #: The routing discriminator. A collection whose ``backend.type``
+    #: equals this string resolves to this adapter. Set on every concrete
+    #: subclass; the registry rejects a duplicate registration of the
+    #: same type as a programming bug.
+    backend_type: str
+
+    @abstractmethod
+    async def search(
+        self,
+        operator: Operator,
+        query: str,
+        *,
+        backend_ref: Mapping[str, Any] | None = None,
+        metadata_filters: dict[str, Any] | None = None,
+        limit: int = 10,
+    ) -> CorpusSearchResponse:
+        """Search this backend as *operator*, returning corpus-shaped chunks.
+
+        Args:
+            operator: The verified operator. An adapter that federates to
+                an operator-audited backend forwards the operator JWT
+                (``operator.raw_jwt``); an adapter that authenticates with
+                its own service credentials (a later Task) uses *operator*
+                only for scoping / logging.
+            query: The free-text search query.
+            backend_ref: The collection's ``backend.ref`` — the
+                per-collection routing detail (endpoint, audience, index
+                id, …) the adapter needs beyond its type. ``None`` selects
+                the adapter's legacy / default configuration (the
+                single-collection deploy that predates the registry).
+            metadata_filters: Optional binary ``{key: scalar}`` narrowing
+                (e.g. ``{"product": "vmware", "version": "9.0"}``). The
+                mandatory-filter posture is enforced by the caller, not
+                here — the adapter forwards whatever it is given.
+            limit: Maximum number of chunks to request.
+
+        Returns:
+            A :class:`~meho_backplane.auth.corpus.CorpusSearchResponse`
+            of ranked cited chunks (best first).
+
+        Raises:
+            CorpusUnavailable: when the backend is unconfigured,
+                unreachable, or returns a malformed / non-2xx response.
+                Every fail-closed branch collapses to this one typed
+                error so the ``search_docs`` route maps it to HTTP 503
+                without branching on the cause (no new error taxonomy).
+        """
+        raise NotImplementedError
+
+    async def probe(
+        self,
+        backend_ref: Mapping[str, Any] | None = None,
+    ) -> Mapping[str, Any]:
+        """Report this backend's readiness for *backend_ref* (T6 #1555 seam).
+
+        Not implemented in T2. Defaults to raising so an adapter without
+        a liveness endpoint fails loudly rather than silently claiming
+        "ready"; the readiness probe Task (T6 #1555) overrides it on the
+        adapters that gain a liveness check.
+        """
+        raise NotImplementedError(f"{type(self).__name__} does not implement readiness probing")

--- a/backend/src/meho_backplane/docs_search/backends/corpus_http.py
+++ b/backend/src/meho_backplane/docs_search/backends/corpus_http.py
@@ -1,0 +1,118 @@
+# SPDX-License-Identifier: Apache-2.0
+# Copyright (c) 2026 evoila Group
+
+"""The first concrete search backend: the JWT-forward corpus client (G4.6-T2 #1551).
+
+:class:`CorpusHttpBackend` re-homes today's single-corpus federation
+client (:func:`~meho_backplane.auth.corpus.search_corpus`) behind the
+:class:`~meho_backplane.docs_search.backends.base.SearchBackend`
+interface, so the ``collection → backend`` router can select it by type
+exactly like any future adapter. It wraps the existing, well-tested
+transport rather than duplicating the httpx body — every fail-closed
+property (forwarded ``raw_jwt``, bounded timeout, one typed
+:class:`~meho_backplane.auth.corpus.CorpusUnavailable`) is inherited
+unchanged.
+
+This adapter fronts **whatever backend the ops corpus itself proxies** —
+it is the operator-JWT-forward path, not a backend-specific client. A
+second adapter that talks a managed RAG directly with its own service-
+account auth (e.g. ``vertex-rag``) is a deliberate later Task; it is
+**not** built here (see #1548 out-of-scope).
+
+Per-collection routing
+----------------------
+
+The adapter is a stateless singleton; per-collection configuration rides
+on the collection's ``backend.ref`` and is passed per call:
+
+* ``backend.ref["endpoint"]`` (alias ``url``) — the corpus search URL for
+  this collection. Absent → the legacy ``settings.corpus_url`` global, so
+  an unmigrated single-collection deploy keeps working with no ``ref``.
+* ``backend.ref["audience"]`` — the RFC 8707 resource indicator for this
+  collection. Absent → ``settings.corpus_audience``.
+
+A ``backend.ref`` that names neither (and a deploy whose legacy
+``corpus_url`` is also empty) is **unconfigured** and fails closed with
+:class:`CorpusUnavailable` — the same 503 arm as today, no new taxonomy.
+"""
+
+from __future__ import annotations
+
+from collections.abc import Mapping
+from typing import Any
+
+from meho_backplane.auth.corpus import CorpusSearchResponse, search_corpus
+from meho_backplane.auth.operator import Operator
+from meho_backplane.docs_search.backends.base import SearchBackend
+
+__all__ = ["CORPUS_HTTP_BACKEND_TYPE", "CorpusHttpBackend"]
+
+#: The routing discriminator for the JWT-forward corpus client. A
+#: collection whose ``backend.type`` equals this string resolves to
+#: :class:`CorpusHttpBackend`. Named for the transport (operator-JWT-
+#: forward over HTTP), not for whatever the ops corpus proxies behind it.
+CORPUS_HTTP_BACKEND_TYPE = "corpus-http"
+
+
+class CorpusHttpBackend(SearchBackend):
+    """JWT-forward corpus client behind the :class:`SearchBackend` seam.
+
+    Behaviourally identical to a direct
+    :func:`~meho_backplane.auth.corpus.search_corpus` call: forwards the
+    operator JWT, bounds the request by ``settings.corpus_timeout_seconds``,
+    and fails closed to one :class:`CorpusUnavailable`. The only addition
+    is per-collection endpoint / audience resolution from ``backend.ref``.
+    """
+
+    backend_type = CORPUS_HTTP_BACKEND_TYPE
+
+    async def search(
+        self,
+        operator: Operator,
+        query: str,
+        *,
+        backend_ref: Mapping[str, Any] | None = None,
+        metadata_filters: dict[str, Any] | None = None,
+        limit: int = 10,
+    ) -> CorpusSearchResponse:
+        """Federate the query to this collection's corpus as *operator*.
+
+        Resolves the endpoint and audience from *backend_ref*, falling
+        back to the legacy ``settings.corpus_url`` / ``corpus_audience``
+        globals when absent, then delegates to the shared transport.
+        """
+        endpoint, audience = _resolve_endpoint_audience(backend_ref)
+        return await search_corpus(
+            operator,
+            query,
+            metadata_filters=metadata_filters,
+            limit=limit,
+            corpus_url=endpoint,
+            audience=audience,
+        )
+
+
+def _resolve_endpoint_audience(
+    backend_ref: Mapping[str, Any] | None,
+) -> tuple[str | None, str | None]:
+    """Extract ``(endpoint, audience)`` overrides from *backend_ref*.
+
+    Returns ``None`` for either value the ref does not name so the
+    transport falls back to the legacy global setting (the single-
+    collection deploy). ``endpoint`` accepts ``"endpoint"`` or the
+    shorter ``"url"`` alias; only non-blank string values are honoured so
+    a ``ref`` carrying ``{"endpoint": ""}`` does not mask the legacy
+    fallback with an empty override.
+    """
+    if not backend_ref:
+        return None, None
+    endpoint = _str_or_none(backend_ref.get("endpoint")) or _str_or_none(backend_ref.get("url"))
+    audience = _str_or_none(backend_ref.get("audience"))
+    return endpoint, audience
+
+
+def _str_or_none(value: Any) -> str | None:
+    """Return *value* as a stripped non-empty str, else ``None``."""
+    if isinstance(value, str) and value.strip():
+        return value.strip()
+    return None

--- a/backend/src/meho_backplane/docs_search/backends/registry.py
+++ b/backend/src/meho_backplane/docs_search/backends/registry.py
@@ -1,0 +1,90 @@
+# SPDX-License-Identifier: Apache-2.0
+# Copyright (c) 2026 evoila Group
+
+"""Search-backend registry — a ``dict[type, SearchBackend]`` lookup (G4.6-T2 #1551).
+
+A deliberately tiny registry mirroring
+:mod:`meho_backplane.connectors.registry`, **minus the version
+tie-break ladder** — a doc collection binds to exactly one backend by
+construction, so the resolver is a direct dict lookup, never a
+candidate ranking (#1548 design decision 3).
+
+One adapter instance per ``backend_type`` is registered at import time.
+Adapters are stateless singletons (per-collection config rides on
+``backend.ref``, not on adapter state — see
+:mod:`meho_backplane.docs_search.backends.corpus_http`), so a single
+instance serves every collection routed to its type.
+
+Keeping the table keyed by type — rather than a literal ``if/elif`` over
+the one shipped adapter — means a second backend (the later
+``vertex-rag`` Task) is a one-line :func:`register_backend` call, not a
+control-flow edit at every call site.
+
+Duplicate registration of the same type raises :exc:`RuntimeError`: two
+modules claiming the same backend type is a programming bug that should
+surface as a deploy failure, not a silent last-writer-wins.
+"""
+
+from __future__ import annotations
+
+import structlog
+
+from meho_backplane.docs_search.backends.base import SearchBackend
+from meho_backplane.docs_search.backends.corpus_http import CorpusHttpBackend
+
+__all__ = [
+    "all_backends",
+    "get_backend",
+    "register_backend",
+]
+
+_log = structlog.get_logger(__name__)
+
+#: type → singleton adapter instance. Populated at import time below.
+_BACKENDS: dict[str, SearchBackend] = {}
+
+
+def register_backend(backend_type: str, impl: SearchBackend) -> None:
+    """Register *impl* under *backend_type* in the search-backend table.
+
+    Called at import time. *impl* is a ready-to-use singleton instance
+    (not a class) because adapters are stateless and per-collection
+    config is passed per call. The instance's :attr:`backend_type` must
+    match *backend_type* — a mismatch is a registration bug.
+
+    Raises:
+        TypeError: when *impl* is not a :class:`SearchBackend`, or its
+            :attr:`backend_type` disagrees with *backend_type*.
+        RuntimeError: when *backend_type* is already registered.
+    """
+    if not isinstance(impl, SearchBackend):
+        raise TypeError(
+            f"search backend for type={backend_type!r} must be a SearchBackend: {impl!r}"
+        )
+    if impl.backend_type != backend_type:
+        raise TypeError(
+            f"search backend registered under type={backend_type!r} "
+            f"advertises backend_type={impl.backend_type!r}"
+        )
+    if backend_type in _BACKENDS:
+        raise RuntimeError(
+            f"search backend already registered for type={backend_type!r}: "
+            f"existing={type(_BACKENDS[backend_type]).__name__}, attempted={type(impl).__name__}"
+        )
+    _BACKENDS[backend_type] = impl
+    _log.info("search_backend_registered", backend_type=backend_type, impl=type(impl).__name__)
+
+
+def get_backend(backend_type: str) -> SearchBackend | None:
+    """Look up the adapter for *backend_type*. Returns ``None`` if absent."""
+    return _BACKENDS.get(backend_type)
+
+
+def all_backends() -> dict[str, SearchBackend]:
+    """Return a snapshot of the registry — for diagnostics / fan-out (T5)."""
+    return dict(_BACKENDS)
+
+
+# Self-register the shipped adapter at import time. The first (and, in T2,
+# only) backend is the JWT-forward corpus client.
+register_backend(CorpusHttpBackend.backend_type, CorpusHttpBackend())

--- a/backend/src/meho_backplane/docs_search/backends/resolver.py
+++ b/backend/src/meho_backplane/docs_search/backends/resolver.py
@@ -1,0 +1,209 @@
+# SPDX-License-Identifier: Apache-2.0
+# Copyright (c) 2026 evoila Group
+
+"""The ``collection → backend`` router (G4.6-T2 #1551).
+
+:func:`resolve_backend` is the seam that maps a doc collection to the
+concrete :class:`~meho_backplane.docs_search.backends.base.SearchBackend`
+that answers its queries. It reads the collection's ``backend.type``
+(the operator-set ``{type, ref}`` routing record on the ``doc_collections``
+row, T1 #1550) and does a **direct dict lookup** in the registry — no
+version tie-break ladder, because a collection binds to exactly one
+backend by construction (#1548 design decision 3).
+
+Two entry points, mirroring the connector resolver's
+``resolve_connector`` / ``resolve_connector_or_label`` split
+(:mod:`meho_backplane.connectors.resolver`):
+
+* :func:`resolve_backend` — returns the adapter or raises
+  :class:`~meho_backplane.auth.corpus.CorpusUnavailable`. The seam in
+  ``docs_search.search_docs`` uses this directly: an unroutable
+  collection collapses to the **existing** 503 arm, no new error
+  taxonomy (#1551 acceptance).
+* :func:`resolve_backend_or_label` — the non-raising ``(impl, label,
+  msg)`` shape future callers (T5 fan-out, T6 readiness) branch on
+  without a try/except, exactly like
+  :func:`~meho_backplane.connectors.resolver.resolve_connector_or_label`.
+
+Legacy single-collection deploy
+-------------------------------
+
+``collection=None`` is the **unmigrated** path: a deploy that has not yet
+adopted the ``doc_collections`` registry and routes every ``search_docs``
+query to the one global ``corpus_url``. It resolves to the
+``corpus-http`` adapter with no ``backend.ref``, so the adapter falls
+back to the legacy global settings. This keeps T2 a pure router-insertion
+that does not require T3's required-``collection`` request param to ship
+first (#1548 / #1551 scope split).
+"""
+
+from __future__ import annotations
+
+from collections.abc import Mapping
+from typing import Any, Literal
+
+import structlog
+
+from meho_backplane.auth.corpus import CorpusUnavailable
+from meho_backplane.docs_search.backends.base import SearchBackend
+from meho_backplane.docs_search.backends.corpus_http import CORPUS_HTTP_BACKEND_TYPE
+from meho_backplane.docs_search.backends.registry import get_backend
+
+__all__ = [
+    "BackendRef",
+    "ResolvedBackend",
+    "resolve_backend",
+    "resolve_backend_or_label",
+]
+
+_log = structlog.get_logger(__name__)
+
+#: The label arm of the non-raising resolver. ``"unknown_backend"`` ==
+#: the collection's ``backend.type`` names no registered adapter (or the
+#: routing record is malformed / missing a type). One arm only — there is
+#: no ambiguity case to disambiguate (direct lookup, no tie-break).
+BackendLabel = Literal["unknown_backend"]
+
+
+class BackendRef:
+    """A resolved ``(adapter, ref)`` pair the seam calls ``search`` on.
+
+    Bundles the chosen :class:`SearchBackend` with the collection's
+    ``backend.ref`` so the caller passes a single object to the adapter
+    instead of re-reading the ref. ``ref`` is ``None`` for the legacy
+    single-collection path.
+    """
+
+    __slots__ = ("backend", "ref")
+
+    def __init__(self, backend: SearchBackend, ref: Mapping[str, Any] | None) -> None:
+        self.backend = backend
+        self.ref = ref
+
+
+#: Backwards-friendly alias used in type hints across the seam.
+ResolvedBackend = BackendRef
+
+
+def _read_routing_record(
+    collection: Any | None,
+) -> tuple[str, Mapping[str, Any] | None] | None:
+    """Read ``(backend_type, backend_ref)`` from *collection*.
+
+    Returns the legacy default ``(corpus-http, None)`` for
+    ``collection=None`` (unmigrated deploy). Returns ``None`` when the
+    collection's ``backend`` record is present but unroutable — missing
+    or non-string ``type`` — so the caller maps it to the unconfigured
+    arm. A non-mapping ``ref`` is normalised to ``None``.
+    """
+    if collection is None:
+        return CORPUS_HTTP_BACKEND_TYPE, None
+
+    backend_record = getattr(collection, "backend", None)
+    if not isinstance(backend_record, Mapping):
+        return None
+
+    backend_type = backend_record.get("type")
+    if not isinstance(backend_type, str) or not backend_type:
+        return None
+
+    ref = backend_record.get("ref")
+    ref_mapping = ref if isinstance(ref, Mapping) else None
+    return backend_type, ref_mapping
+
+
+def resolve_backend(collection: Any | None) -> BackendRef:
+    """Resolve *collection* to its search backend, fail-closed.
+
+    Reads ``collection.backend.type`` and looks the adapter up in the
+    registry by direct dict lookup. ``collection=None`` routes to the
+    legacy ``corpus-http`` adapter with no ref (the single-collection
+    deploy that predates the registry).
+
+    Args:
+        collection: The resolved doc collection (the
+            :class:`~meho_backplane.docs_collections.DocCollection` read
+            shape or the ORM row — anything exposing a ``backend``
+            mapping with ``{type, ref}``), or ``None`` for the legacy
+            single-collection path.
+
+    Returns:
+        A :class:`BackendRef` bundling the chosen adapter with the
+        collection's ``backend.ref``.
+
+    Raises:
+        CorpusUnavailable: when ``backend.type`` is missing / malformed
+            or names no registered adapter. This is the **existing** 503
+            arm (no new error taxonomy) — an unroutable collection is
+            "search unavailable", not a distinct failure mode the agent
+            sees.
+    """
+    backend, label, message = resolve_backend_or_label(collection)
+    if label is not None:
+        # Unroutable → the existing fail-closed 503 arm. The message names
+        # the offending type for operator logs; it never reaches the agent
+        # (the route renders a generic 503), so the backend id stays
+        # server-side per the backend-agnostic contract.
+        raise CorpusUnavailable(message or "doc collection has no routable search backend")
+    # label is None ⇒ backend is set (resolver invariant). Narrow for mypy.
+    assert backend is not None
+    return backend
+
+
+def resolve_backend_or_label(
+    collection: Any | None,
+) -> tuple[BackendRef | None, BackendLabel | None, str | None]:
+    """Run :func:`resolve_backend`'s lookup, translating failure to a label.
+
+    The non-raising sibling of :func:`resolve_backend`, mirroring
+    :func:`~meho_backplane.connectors.resolver.resolve_connector_or_label`
+    so the seam, the T5 fan-out, and the T6 readiness probe branch on the
+    same ``(impl, label, msg)`` triple instead of each catching
+    :class:`CorpusUnavailable`.
+
+    Returns:
+        * ``(BackendRef, None, None)`` — routed to a registered adapter.
+        * ``(None, "unknown_backend", message)`` — the collection's
+          ``backend.type`` is missing / malformed or names no registered
+          adapter. ``message`` names the offending type (or "missing")
+          for operator diagnostics.
+    """
+    record = _read_routing_record(collection)
+    if record is None:
+        key = _collection_key(collection)
+        _log.warning(
+            "doc_backend_unroutable",
+            collection_key=key,
+            reason="missing_or_malformed_type",
+        )
+        return None, "unknown_backend", f"doc collection {key!r} has no backend.type"
+
+    backend_type, ref = record
+    impl = get_backend(backend_type)
+    if impl is None:
+        key = _collection_key(collection)
+        _log.warning(
+            "doc_backend_unknown_type",
+            collection_key=key,
+            backend_type=backend_type,
+        )
+        return (
+            None,
+            "unknown_backend",
+            f"doc collection {key!r} routes to unregistered backend type {backend_type!r}",
+        )
+
+    _log.info(
+        "doc_backend_resolved",
+        collection_key=_collection_key(collection),
+        backend_type=backend_type,
+        impl=type(impl).__name__,
+    )
+    return BackendRef(impl, ref), None, None
+
+
+def _collection_key(collection: Any | None) -> str:
+    """Best-effort collection key for diagnostics (never raises)."""
+    if collection is None:
+        return "<legacy-single-collection>"
+    return str(getattr(collection, "collection_key", "<unknown>"))

--- a/backend/src/meho_backplane/docs_search/service.py
+++ b/backend/src/meho_backplane/docs_search/service.py
@@ -31,12 +31,18 @@ touches the raw query beyond forwarding it to the corpus.
 
 from __future__ import annotations
 
+from typing import TYPE_CHECKING
+
 import structlog
 from pydantic import BaseModel, ConfigDict, Field
 
 from meho_backplane.auth.corpus import CorpusChunk, search_corpus
 from meho_backplane.auth.operator import Operator
+from meho_backplane.docs_search.backends import resolve_backend
 from meho_backplane.settings import get_settings
+
+if TYPE_CHECKING:
+    from meho_backplane.docs_collections import DocCollection
 
 __all__ = [
     "DocsChunk",
@@ -191,45 +197,79 @@ async def search_docs(
     *,
     scope: DocsScope,
     limit: int = 10,
+    collection: DocCollection | None = None,
 ) -> DocsSearchResult:
-    """Search the external corpus for *operator* within *scope*.
+    """Search a doc collection's backend for *operator* within *scope*.
 
-    Forwards the operator JWT (via T2's :func:`search_corpus`) so the
-    corpus authenticates + audits the call as the operator, scopes the
-    search to the binary product+version filter, and projects the cited
-    chunks into MEHO's surface. The query itself is never logged here —
-    only its presence is implied; the route binds the SHA-256 hash to the
-    audit row.
+    Resolves *collection* to its concrete search backend via the
+    backend-agnostic router
+    (:func:`~meho_backplane.docs_search.backends.resolve_backend`) and
+    calls ``backend.search(...)`` — so one collection can sit on a
+    managed RAG and another on the JWT-forward corpus behind this one
+    entrypoint, and the agent never sees which backend answered. The
+    operator JWT is forwarded by the adapter (for the JWT-forward corpus
+    backend), the search is scoped to the binary product+version filter,
+    and the cited chunks are projected into MEHO's surface. The query
+    itself is never logged here — only its presence is implied; the route
+    binds the SHA-256 hash to the audit row.
+
+    ``collection=None`` is the **legacy single-collection** path: a
+    deploy that has not yet adopted the ``doc_collections`` registry
+    federates every query to the one global ``corpus_url`` via the
+    re-homed :func:`~meho_backplane.auth.corpus.search_corpus` transport.
+    The collection-scoped request param that makes *collection* mandatory
+    is T3 (#1552); T2 ships the router with this additive, non-breaking
+    seam so the legacy path keeps working unchanged.
 
     Args:
-        operator: The verified operator whose JWT is forwarded to the corpus.
+        operator: The verified operator whose JWT is forwarded to the
+            backend.
         query: The free-text search query.
         scope: The validated binary product+version scope from
             :func:`build_docs_scope`.
         limit: Maximum number of chunks to request.
+        collection: The resolved doc collection to search, or ``None`` for
+            the legacy single-collection corpus path.
 
     Returns:
-        A :class:`DocsSearchResult` carrying the corpus's ranked cited chunks.
+        A :class:`DocsSearchResult` carrying the backend's ranked cited
+        chunks.
 
     Raises:
-        CorpusUnavailable: propagated unchanged from
-            :func:`~meho_backplane.auth.corpus.search_corpus` when the
-            corpus is unconfigured, unreachable, or returns a non-2xx /
-            malformed response. The route maps it to HTTP 503.
+        CorpusUnavailable: when the collection routes to no registered
+            backend, or the chosen backend is unconfigured, unreachable,
+            or returns a non-2xx / malformed response. The route maps it
+            to HTTP 503 (the backend id never appears in the 503).
     """
     filters = scope.as_filters()
-    response = await search_corpus(
-        operator,
-        query,
-        metadata_filters=filters or None,
-        limit=limit,
-    )
+    if collection is None:
+        # Legacy single-collection deploy: federate to the one global
+        # corpus through the module-level transport seam. Kept distinct
+        # from the routed path so the pre-registry behaviour (and the
+        # callers patching ``service.search_corpus``) is untouched until
+        # T3 makes ``collection`` mandatory.
+        response = await search_corpus(
+            operator,
+            query,
+            metadata_filters=filters or None,
+            limit=limit,
+        )
+    else:
+        resolved = resolve_backend(collection)
+        response = await resolved.backend.search(
+            operator,
+            query,
+            backend_ref=resolved.ref,
+            metadata_filters=filters or None,
+            limit=limit,
+        )
     chunks = [_project_chunk(c) for c in response.chunks]
     _log.info(
         "docs_search_completed",
         operator_sub=operator.sub,
         product=scope.product,
         version=scope.version,
+        collection_key=collection.collection_key if collection is not None else None,
         hit_count=len(chunks),
     )
     return DocsSearchResult(chunks=chunks)

--- a/backend/tests/test_docs_backends_router.py
+++ b/backend/tests/test_docs_backends_router.py
@@ -1,0 +1,455 @@
+# SPDX-License-Identifier: Apache-2.0
+# Copyright (c) 2026 evoila Group
+
+"""Unit tests for the backend-agnostic search router (G4.6-T2 #1551).
+
+Three things are proven here:
+
+1. **The router is type-agnostic.** A fake backend registered under a
+   novel ``backend_type`` is selected purely by ``collection.backend.type``
+   — the router never special-cases the shipped adapter (AC4).
+2. **Fail-closed routing.** An unknown / malformed ``backend.type`` →
+   :class:`~meho_backplane.auth.corpus.CorpusUnavailable` (the existing
+   503 arm, no new taxonomy) (AC1). ``resolve_backend_or_label`` returns
+   the non-raising ``(impl, label, msg)`` sibling shape.
+3. **The re-homed adapter is behaviourally identical to today's
+   ``search_corpus``.** ``CorpusHttpBackend`` forwards the operator JWT,
+   bounds the timeout, fails closed, and reads its endpoint / audience
+   from the collection's ``backend.ref`` (legacy ``corpus_url`` fallback)
+   (AC2). The exhaustive transport assertions stay in
+   ``test_corpus_client``; here we assert the adapter is a faithful,
+   ref-aware delegate.
+
+The ``search_docs`` seam routing (``collection`` → ``resolve_backend`` →
+``backend.search``) is covered at the bottom: a collection with a fake
+backend makes ``search_docs`` return that backend's chunks, and the
+backend id never appears in the projected result (AC3).
+"""
+
+from __future__ import annotations
+
+from collections.abc import Iterator
+from datetime import UTC, datetime
+from typing import Any
+from uuid import uuid4
+
+import httpx
+import pytest
+
+import meho_backplane.auth.corpus as corpus_mod
+from meho_backplane.auth.corpus import (
+    CorpusChunk,
+    CorpusSearchResponse,
+    CorpusUnavailable,
+)
+from meho_backplane.auth.operator import Operator
+from meho_backplane.docs_collections import DocCollection
+from meho_backplane.docs_search import resolve_backend, resolve_backend_or_label, search_docs
+from meho_backplane.docs_search.backends import (
+    CORPUS_HTTP_BACKEND_TYPE,
+    CorpusHttpBackend,
+    SearchBackend,
+    all_backends,
+    get_backend,
+    register_backend,
+)
+from meho_backplane.docs_search.backends import registry as registry_mod
+from meho_backplane.docs_search.service import DocsScope
+from meho_backplane.settings import Settings, get_settings
+
+_JWT = "header.payload.signature-secret"
+_CORPUS_URL = "https://corpus.test/search"
+
+
+def _make_operator(jwt: str = _JWT) -> Operator:
+    """Build a minimal :class:`Operator` carrying the forwarded JWT."""
+    return Operator(
+        sub="op-1",
+        name="Alice",
+        email="alice@example.com",
+        raw_jwt=jwt,
+        tenant_id="00000000-0000-0000-0000-00000000a0a0",
+        tenant_role="operator",
+    )
+
+
+def _make_collection(
+    *,
+    backend: dict[str, Any],
+    collection_key: str = "vmware",
+) -> DocCollection:
+    """Build a frozen :class:`DocCollection` read shape with *backend*.
+
+    Only ``backend`` and ``collection_key`` matter for routing; the rest
+    are filled with valid placeholders so the frozen model validates.
+    """
+    now = datetime.now(UTC)
+    return DocCollection(
+        id=uuid4(),
+        tenant_id=None,
+        collection_key=collection_key,
+        vendor="vmware",
+        products=("vsphere",),
+        description=None,
+        when_to_use=None,
+        backend=backend,
+        status="ready",
+        last_ingested_at=None,
+        doc_count=None,
+        readiness=None,
+        extras={},
+        created_at=now,
+        updated_at=now,
+    )
+
+
+@pytest.fixture(autouse=True)
+def _settings_env(monkeypatch: pytest.MonkeyPatch) -> Iterator[None]:
+    """Pin the env every :class:`Settings` field reads, then reset the cache."""
+    monkeypatch.setenv("KEYCLOAK_ISSUER_URL", "https://keycloak.test/realms/meho")
+    monkeypatch.setenv("KEYCLOAK_AUDIENCE", "meho-backplane")
+    monkeypatch.setenv("VAULT_ADDR", "https://vault.test")
+    get_settings.cache_clear()
+    yield
+    get_settings.cache_clear()
+
+
+@pytest.fixture
+def _restore_registry() -> Iterator[None]:
+    """Snapshot the backend registry and restore it after the test.
+
+    Tests that register a fake backend must not leak it into the
+    process-wide registry the other tests (and the seam) read.
+    """
+    snapshot = all_backends()
+    yield
+    registry_mod._BACKENDS.clear()
+    registry_mod._BACKENDS.update(snapshot)
+
+
+def _pin_settings(monkeypatch: pytest.MonkeyPatch, **overrides: object) -> Settings:
+    """Override ``corpus.get_settings`` with a Settings carrying *overrides*."""
+    settings = get_settings().model_copy(update=overrides)
+    monkeypatch.setattr(corpus_mod, "get_settings", lambda: settings)
+    return settings
+
+
+def _patch_async_client(
+    monkeypatch: pytest.MonkeyPatch,
+    transport: httpx.MockTransport,
+    captured_timeout: list[httpx.Timeout] | None = None,
+) -> None:
+    """Force every ``AsyncClient`` the corpus module builds onto *transport*."""
+    real_async_client = httpx.AsyncClient
+
+    def _factory(*args: object, **kwargs: object) -> httpx.AsyncClient:
+        timeout = kwargs.get("timeout")
+        if captured_timeout is not None and isinstance(timeout, httpx.Timeout):
+            captured_timeout.append(timeout)
+        kwargs["transport"] = transport
+        return real_async_client(*args, **kwargs)
+
+    monkeypatch.setattr(corpus_mod.httpx, "AsyncClient", _factory)
+
+
+# ---------------------------------------------------------------------------
+# The shipped adapter is registered (AC2 / AC4 baseline)
+# ---------------------------------------------------------------------------
+
+
+def test_corpus_http_adapter_is_registered_by_default() -> None:
+    """The ``corpus-http`` adapter self-registers at import time."""
+    impl = get_backend(CORPUS_HTTP_BACKEND_TYPE)
+    assert isinstance(impl, CorpusHttpBackend)
+    assert impl.backend_type == CORPUS_HTTP_BACKEND_TYPE
+
+
+def test_registry_rejects_duplicate_type(_restore_registry: None) -> None:
+    """Re-registering a type is a programming bug → RuntimeError."""
+    with pytest.raises(RuntimeError):
+        register_backend(CORPUS_HTTP_BACKEND_TYPE, CorpusHttpBackend())
+
+
+def test_registry_rejects_mismatched_advertised_type(_restore_registry: None) -> None:
+    """An impl whose ``backend_type`` disagrees with the key is rejected."""
+    with pytest.raises(TypeError):
+        register_backend("some-other-type", CorpusHttpBackend())
+
+
+# ---------------------------------------------------------------------------
+# Routing is type-agnostic (AC4)
+# ---------------------------------------------------------------------------
+
+
+class _FakeBackend(SearchBackend):
+    """A stand-in backend selected purely by its registered type."""
+
+    backend_type = "fake-rag"
+
+    def __init__(self) -> None:
+        self.calls: list[dict[str, Any]] = []
+
+    async def search(
+        self,
+        operator: Operator,
+        query: str,
+        *,
+        backend_ref: Any = None,
+        metadata_filters: dict[str, Any] | None = None,
+        limit: int = 10,
+    ) -> CorpusSearchResponse:
+        self.calls.append(
+            {
+                "operator": operator,
+                "query": query,
+                "backend_ref": backend_ref,
+                "metadata_filters": metadata_filters,
+                "limit": limit,
+            }
+        )
+        return CorpusSearchResponse(
+            chunks=[
+                CorpusChunk(chunk_id="f1", document_id="fd1", content="the fake answer"),
+            ]
+        )
+
+
+def test_router_selects_backend_purely_by_type(_restore_registry: None) -> None:
+    """AC4: a fake backend is chosen solely by ``collection.backend.type``."""
+    fake = _FakeBackend()
+    register_backend(_FakeBackend.backend_type, fake)
+
+    collection = _make_collection(
+        backend={"type": "fake-rag", "ref": {"endpoint": "https://fake.test"}},
+    )
+    resolved = resolve_backend(collection)
+
+    assert resolved.backend is fake
+    assert resolved.ref == {"endpoint": "https://fake.test"}
+
+
+def test_router_label_form_routes(_restore_registry: None) -> None:
+    """The non-raising ``(impl, label, msg)`` shape returns the adapter."""
+    fake = _FakeBackend()
+    register_backend(_FakeBackend.backend_type, fake)
+    collection = _make_collection(backend={"type": "fake-rag", "ref": None})
+
+    impl, label, msg = resolve_backend_or_label(collection)
+
+    assert impl is not None
+    assert impl.backend is fake
+    assert label is None
+    assert msg is None
+
+
+def test_legacy_none_collection_routes_to_corpus_http() -> None:
+    """``collection=None`` (unmigrated deploy) → the corpus-http adapter, no ref."""
+    resolved = resolve_backend(None)
+    assert isinstance(resolved.backend, CorpusHttpBackend)
+    assert resolved.ref is None
+
+
+# ---------------------------------------------------------------------------
+# Fail-closed routing (AC1)
+# ---------------------------------------------------------------------------
+
+
+def test_unknown_backend_type_raises_corpus_unavailable() -> None:
+    """AC1: an unregistered ``backend.type`` → CorpusUnavailable (503 arm)."""
+    collection = _make_collection(backend={"type": "no-such-backend", "ref": None})
+    with pytest.raises(CorpusUnavailable):
+        resolve_backend(collection)
+
+
+def test_unknown_backend_type_label_form() -> None:
+    """The label form reports ``unknown_backend`` without raising."""
+    collection = _make_collection(backend={"type": "no-such-backend", "ref": None})
+    impl, label, msg = resolve_backend_or_label(collection)
+    assert impl is None
+    assert label == "unknown_backend"
+    assert msg is not None and "no-such-backend" in msg
+
+
+def test_missing_backend_type_raises_corpus_unavailable() -> None:
+    """A routing record without a ``type`` is unroutable → CorpusUnavailable."""
+    collection = _make_collection(backend={"ref": {"endpoint": "https://x.test"}})
+    with pytest.raises(CorpusUnavailable):
+        resolve_backend(collection)
+
+
+def test_blank_backend_type_is_unroutable() -> None:
+    """An empty-string ``type`` is treated as missing (not a registry key)."""
+    collection = _make_collection(backend={"type": "", "ref": None})
+    impl, label, _msg = resolve_backend_or_label(collection)
+    assert impl is None
+    assert label == "unknown_backend"
+
+
+# ---------------------------------------------------------------------------
+# The re-homed adapter is behaviourally identical to search_corpus (AC2)
+# ---------------------------------------------------------------------------
+
+
+async def test_adapter_forwards_jwt_and_uses_backend_ref_endpoint(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """AC2: the adapter forwards the JWT and POSTs to the ref's endpoint."""
+    # Legacy global is a different URL; the ref must win.
+    _pin_settings(monkeypatch, corpus_url="https://legacy.test/search")
+    captured: list[httpx.Request] = []
+
+    def _handler(request: httpx.Request) -> httpx.Response:
+        captured.append(request)
+        return httpx.Response(200, json={"chunks": []})
+
+    _patch_async_client(monkeypatch, httpx.MockTransport(_handler))
+
+    adapter = CorpusHttpBackend()
+    await adapter.search(
+        _make_operator(),
+        "supervisor cluster",
+        backend_ref={"endpoint": _CORPUS_URL, "audience": "meho-corpus"},
+        metadata_filters={"product": "vmware", "version": "9.0"},
+        limit=5,
+    )
+
+    sent = captured[0]
+    assert str(sent.url) == _CORPUS_URL  # ref endpoint, not the legacy global
+    assert sent.headers["Authorization"] == f"Bearer {_JWT}"
+    import json
+
+    body = json.loads(sent.content.decode())
+    assert body["query"] == "supervisor cluster"
+    assert body["limit"] == 5
+    assert body["metadata_filters"] == {"product": "vmware", "version": "9.0"}
+    assert body["audience"] == "meho-corpus"
+
+
+async def test_adapter_falls_back_to_legacy_corpus_url(monkeypatch: pytest.MonkeyPatch) -> None:
+    """A ref without an endpoint falls back to the legacy ``corpus_url``."""
+    _pin_settings(monkeypatch, corpus_url=_CORPUS_URL, corpus_audience="legacy-aud")
+    captured: list[httpx.Request] = []
+
+    def _handler(request: httpx.Request) -> httpx.Response:
+        captured.append(request)
+        return httpx.Response(200, json={"chunks": []})
+
+    _patch_async_client(monkeypatch, httpx.MockTransport(_handler))
+
+    adapter = CorpusHttpBackend()
+    await adapter.search(_make_operator(), "q", backend_ref=None)
+
+    sent = captured[0]
+    assert str(sent.url) == _CORPUS_URL
+    import json
+
+    body = json.loads(sent.content.decode())
+    assert body["audience"] == "legacy-aud"
+
+
+async def test_adapter_unconfigured_fails_closed(monkeypatch: pytest.MonkeyPatch) -> None:
+    """No ref endpoint AND no legacy corpus_url → CorpusUnavailable (fail-closed)."""
+    _pin_settings(monkeypatch, corpus_url="")
+    adapter = CorpusHttpBackend()
+    with pytest.raises(CorpusUnavailable):
+        await adapter.search(_make_operator(), "q", backend_ref=None)
+
+
+async def test_adapter_bounds_timeout(monkeypatch: pytest.MonkeyPatch) -> None:
+    """The adapter inherits the bounded corpus timeout (no unbounded hang)."""
+    _pin_settings(monkeypatch, corpus_url=_CORPUS_URL, corpus_timeout_seconds=3.5)
+    captured_timeout: list[httpx.Timeout] = []
+
+    def _handler(request: httpx.Request) -> httpx.Response:
+        return httpx.Response(200, json={"chunks": []})
+
+    _patch_async_client(monkeypatch, httpx.MockTransport(_handler), captured_timeout)
+
+    await CorpusHttpBackend().search(_make_operator(), "q", backend_ref=None)
+
+    assert captured_timeout
+    assert captured_timeout[0].read == 3.5
+
+
+async def test_adapter_blank_ref_endpoint_uses_legacy(monkeypatch: pytest.MonkeyPatch) -> None:
+    """A ref carrying an empty endpoint does not mask the legacy fallback."""
+    _pin_settings(monkeypatch, corpus_url=_CORPUS_URL)
+    captured: list[httpx.Request] = []
+
+    def _handler(request: httpx.Request) -> httpx.Response:
+        captured.append(request)
+        return httpx.Response(200, json={"chunks": []})
+
+    _patch_async_client(monkeypatch, httpx.MockTransport(_handler))
+
+    await CorpusHttpBackend().search(_make_operator(), "q", backend_ref={"endpoint": "   "})
+
+    assert str(captured[0].url) == _CORPUS_URL
+
+
+async def test_adapter_does_not_implement_probe_yet() -> None:
+    """``probe`` is a T6 seam — it must fail loudly, not claim ready."""
+    with pytest.raises(NotImplementedError):
+        await CorpusHttpBackend().probe()
+
+
+# ---------------------------------------------------------------------------
+# The search_docs seam routes through the backend (AC3)
+# ---------------------------------------------------------------------------
+
+
+async def test_search_docs_routes_through_resolved_backend(_restore_registry: None) -> None:
+    """AC3: search_docs with a collection returns the routed backend's chunks.
+
+    The backend id never appears in the projected result — the seam holds
+    the backend-agnostic contract.
+    """
+    fake = _FakeBackend()
+    register_backend(_FakeBackend.backend_type, fake)
+    collection = _make_collection(
+        backend={"type": "fake-rag", "ref": {"endpoint": "https://fake.test"}},
+    )
+
+    result = await search_docs(
+        _make_operator(),
+        "how do I configure NSX",
+        scope=DocsScope(product="vmware", version="9.0"),
+        limit=7,
+        collection=collection,
+    )
+
+    # Routed to the fake backend with the collection's ref + scope filters.
+    assert len(fake.calls) == 1
+    call = fake.calls[0]
+    assert call["backend_ref"] == {"endpoint": "https://fake.test"}
+    assert call["metadata_filters"] == {"product": "vmware", "version": "9.0"}
+    assert call["limit"] == 7
+
+    # The projected result carries the fake backend's chunk, and neither
+    # the backend type nor the routing record leaks into the DocsChunk
+    # surface (the backend-agnostic contract).
+    assert len(result.chunks) == 1
+    assert result.chunks[0].content == "the fake answer"
+    serialised = result.model_dump_json()
+    assert "fake-rag" not in serialised
+    assert "fake.test" not in serialised
+    assert "backend_type" not in serialised
+    assert set(result.chunks[0].model_dump()) == {
+        "chunk_id",
+        "document_id",
+        "content",
+        "source_url",
+        "score",
+    }
+
+
+async def test_search_docs_unroutable_collection_raises(_restore_registry: None) -> None:
+    """A collection routing to an unregistered backend → CorpusUnavailable (503)."""
+    collection = _make_collection(backend={"type": "ghost-backend", "ref": None})
+    with pytest.raises(CorpusUnavailable):
+        await search_docs(
+            _make_operator(),
+            "q",
+            scope=DocsScope(product="vmware", version="9.0"),
+            collection=collection,
+        )

--- a/docs/codebase/docs-search.md
+++ b/docs/codebase/docs-search.md
@@ -41,18 +41,62 @@ fails closed rather than degrading to an ungrounded answer.
 
 ### `search_corpus(...)` (`meho_backplane.auth.corpus`, T2 #1520)
 
-The transport. An async `httpx` client that POSTs a search request to
-`settings.corpus_url` carrying `Authorization: Bearer <operator.raw_jwt>`,
-bounded by `settings.corpus_timeout_seconds`. Models the corpus's
-response behind a small frozen Pydantic adapter (`CorpusChunk` /
-`CorpusSearchResponse`, `extra="ignore"` so additive corpus fields are
-absorbed silently while a dropped consumed field fails loudly).
+The transport. An async `httpx` client that POSTs a search request to a
+corpus URL carrying `Authorization: Bearer <operator.raw_jwt>`, bounded
+by `settings.corpus_timeout_seconds`. The URL and RFC 8707 audience are
+optional overrides (`corpus_url=` / `audience=`); `None` falls back to
+the global `settings.corpus_url` / `settings.corpus_audience` — the
+seam the `corpus-http` backend uses to pass a per-collection endpoint
+(see the router below). Models the corpus's response behind a small
+frozen Pydantic adapter (`CorpusChunk` / `CorpusSearchResponse`,
+`extra="ignore"` so additive corpus fields are absorbed silently while a
+dropped consumed field fails loudly).
 
-Fail-closed by construction: an unconfigured (`corpus_url` unset),
-unreachable, non-2xx, or malformed-response corpus all collapse to one
-typed `CorpusUnavailable`. The exception carries the upstream HTTP
-status (when the failure was a non-2xx response) but **never** the
-response body — a corpus error page cannot leak through.
+Fail-closed by construction: an unconfigured (no URL), unreachable,
+non-2xx, or malformed-response corpus all collapse to one typed
+`CorpusUnavailable`. The exception carries the upstream HTTP status (when
+the failure was a non-2xx response) but **never** the response body — a
+corpus error page cannot leak through.
+
+### Backend-agnostic search router (`meho_backplane.docs_search.backends`, T2 #1551)
+
+The `collection → backend` router that keeps MEHO a backplane, not a
+vector DB: one collection can sit on a managed RAG and another on the
+JWT-forward corpus **behind the same `search_docs`**, and the agent never
+sees which backend answered. Four pieces, modelled on the connector
+registry (`connectors/registry.py`) **minus the version tie-break ladder**
+(a collection binds to exactly one backend by construction, #1548):
+
+- `SearchBackend` (`backends/base.py`) — the adapter ABC. One required
+  `async search(operator, query, *, backend_ref, metadata_filters, limit)
+  -> CorpusSearchResponse` (the same shape as the re-homed transport, so
+  the seam swap is behaviour-preserving) plus a `probe()` forward seam
+  for the readiness probe (T6 #1555) that defaults to raising rather than
+  claiming "ready". A class-level `backend_type` string is the routing
+  discriminator.
+- `CorpusHttpBackend` (`backends/corpus_http.py`,
+  `backend_type="corpus-http"`) — the **first** concrete adapter. It
+  wraps `search_corpus` (the well-tested transport, not a copy of the
+  httpx body) and resolves the per-collection endpoint / audience from
+  the collection's `backend.ref` (keys `endpoint`/`url` and `audience`),
+  falling back to the legacy `corpus_url` / `corpus_audience` globals for
+  an unmigrated single-collection deploy. It fronts whatever the ops
+  corpus proxies; a direct managed-RAG adapter with its own
+  service-account auth is a deliberate **later Task**, not built here.
+- the registry (`backends/registry.py`) — a `dict[str, SearchBackend]`
+  with `register_backend(type, impl)` / `get_backend(type)` /
+  `all_backends()`. Importing the package self-registers `corpus-http`.
+  Duplicate registration of a type raises (a programming bug, not a
+  runtime condition).
+- `resolve_backend(collection)` / `resolve_backend_or_label(collection)`
+  (`backends/resolver.py`) — the router. Reads `collection.backend["type"]`
+  and does a direct dict lookup. The raising form drops into the
+  `search_docs` seam (an unknown / malformed type → `CorpusUnavailable`,
+  the **existing** 503 arm — no new error taxonomy, and the backend id
+  never reaches the agent). The `(impl, label, msg)` labelled form is the
+  non-raising sibling (mirroring `resolve_connector_or_label`) the T5
+  fan-out and T6 readiness probe branch on. `collection=None` routes to
+  `corpus-http` with no ref — the legacy single-collection path.
 
 ### `build_docs_scope(product, version)` (`meho_backplane.docs_search.service`)
 
@@ -67,12 +111,19 @@ renders the `{key: scalar}` `metadata_filters` shape — a **binary
 containment scope**, never a ranking weight (the #1178 / #1177
 decision).
 
-### `search_docs(operator, query, *, scope, limit)` (`meho_backplane.docs_search.service`)
+### `search_docs(operator, query, *, scope, limit, collection=None)` (`meho_backplane.docs_search.service`)
 
-The shared service. Calls `search_corpus` with the binary scope and
-projects the corpus's `CorpusChunk`s into MEHO's own `DocsChunk` surface
-(chunk text + source citation + score), decoupling the public response
-from the corpus wire contract. Propagates `CorpusUnavailable` unchanged.
+The shared service and the **router seam**. With a `collection`, it
+resolves the backend via `resolve_backend(collection)` and calls
+`backend.search(...)`; without one (`collection=None`, the legacy
+single-collection deploy) it federates to the global corpus via
+`search_corpus` directly. Either way it projects the backend's
+`CorpusChunk`s into MEHO's own `DocsChunk` surface (chunk text + source
+citation + score), decoupling the public response from the wire contract,
+and propagates `CorpusUnavailable` unchanged. The `collection` kwarg is
+additive and optional in T2 — T3 (#1552) threads the request param and
+makes it mandatory; the backend id never appears in the request or the
+projected response.
 
 ### `synthesize_docs_answer(query, retrieval, *, llm_client=None)` (`meho_backplane.docs_search.synthesis`, T7 #1526)
 
@@ -295,7 +346,11 @@ just makes the op name canonical for `query_audit` filtering.
 ## References
 
 - Route: `backend/src/meho_backplane/api/v1/search_docs.py`.
-- Service: `backend/src/meho_backplane/docs_search/service.py`.
+- Service (router seam): `backend/src/meho_backplane/docs_search/service.py`.
+- Backend router (T2 #1551): `backend/src/meho_backplane/docs_search/backends/`
+  (`base.py` ABC, `corpus_http.py` first adapter, `registry.py`,
+  `resolver.py`). Registry/ABC/resolver precedent:
+  `backend/src/meho_backplane/connectors/` (registry + base + resolver).
 - Synthesis (`ask_docs`): `backend/src/meho_backplane/docs_search/synthesis.py`.
 - MCP tools (`search_docs` + `ask_docs`): `backend/src/meho_backplane/mcp/tools/docs.py`.
 - Fail-closed LLM client precedent (#1386):


### PR DESCRIPTION
## Summary

- Introduce a **backend-agnostic search router** (`docs_search/backends/`): a `SearchBackend` ABC, a tiny `dict[type, SearchBackend]` registry, and `resolve_backend` / `resolve_backend_or_label` that map a doc collection to its backend via `collection.backend{type, ref}` (T1 #1550) with a **direct type lookup** — no version tie-break ladder (a collection binds to exactly one backend by construction). One collection can sit on a managed RAG and another on the JWT-forward corpus behind the same `search_docs`, and the agent never sees which backend answered.
- **Re-home the single-corpus client as the first adapter** (`CorpusHttpBackend`, `backend_type="corpus-http"`). It wraps the well-tested `search_corpus` transport (not a copy of the httpx body) and resolves its endpoint/audience **per collection** from `backend.ref`, falling back to the legacy `corpus_url`/`corpus_audience` globals for an unmigrated single-collection deploy. `search_corpus` gains optional `corpus_url`/`audience` overrides for that.
- **The seam:** `docs_search.search_docs` swaps its direct transport call for `resolve_backend(collection).backend.search(...)`. The `collection` argument is **additive and optional** in this Task — `collection=None` keeps the legacy single-collection path verbatim, so every existing caller and test is untouched. Threading a mandatory `collection` request param is the downstream T3 (#1552).
- Fail-closed routing with **no new error taxonomy**: an unknown / malformed `backend.type` collapses to the existing `CorpusUnavailable` → 503 arm, and the backend id never reaches the request or response.

Designed to be cleanly consumable by the downstream siblings: T3 calls the router for a resolved collection, T5 fans out across `all_backends()`, T6 fills the `SearchBackend.probe()` seam.

## Test plan

- [x] `ruff check` / `ruff format --check` — clean (touched files)
- [x] `mypy src/meho_backplane/docs_search/ src/meho_backplane/auth/corpus.py` — `Success: no issues found in 9 source files`
- [x] **New** `tests/test_docs_backends_router.py` — 18 passed (router type-agnosticism via a fake backend, unknown/missing/blank-type fail-closed, the re-homed adapter forwarding JWT + bounded timeout + ref endpoint/audience + legacy fallback, the `search_docs` seam, and the `probe()` T6 seam raising)
- [x] **Regression** — existing `test_corpus_client` (12), `test_search_docs_route`, `test_mcp_tools_docs`, `test_mcp_tools_docs_ask`, `test_mcp_resources_docs`, `test_doc_collections_registry`, `test_docs_search_synthesis` all green (83 passed); broader docs/corpus/collection/settings slice 259 passed, 2 skipped
- [x] OpenAPI snapshot regen (`cd cli && make snapshot-openapi`) → **zero diff** (no REST/OpenAPI surface change)

### Acceptance criteria

- [x] `resolve_backend(collection)` returns the adapter for `collection.backend.type`; unknown/unconfigured → `CorpusUnavailable` (503 unchanged)
- [x] The re-homed adapter is behaviourally identical to today's `search_corpus` (forwards `raw_jwt`, bounded timeout, fail-closed) — existing `test_corpus_client` assertions pass against it
- [x] `search_docs` routes through `resolve_backend` with the request shape unchanged; the backend id never appears in the request or response
- [x] A second (fake) backend registered in a test is selected purely by `collection.backend.type`
- [x] CI green; ruff + mypy clean

## Out of scope

- A real `vertex-rag` direct adapter (later Task); readiness probing (T6 #1555); the mandatory `collection` request param + per-collection entitlement + audit (T3 #1552); fan-out (T5 #1554); `list_doc_collections` (T4 #1553); docs runbook (T7 #1556).

<!-- auto-implement-issue: fresh, iteration 1 -->

Closes #1551
