### PR TITLE
feat(docs): doc-collection backend readiness probe + lifecycle (#1555)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -112,6 +112,27 @@ connector-related release-notes line.
   surfaces enforce one policy. CLI client regenerated for the new
   `collection` request field.
 
+### Doc-collection readiness probe + lifecycle (#1555)
+
+- Make the doc-collection catalogue carry **backend readiness** so the
+  router hides managed-RAG operational footguns. Fill in the
+  `SearchBackend.probe(operator, *, backend_ref)` seam to return a typed
+  `BackendReadiness` (reachable / index-built / doc count / last ingest);
+  the `corpus-http` adapter reads it from the corpus `/status` endpoint
+  and serializes concurrent rebuilds **per project** inside the adapter
+  (an `asyncio.Lock` keyed on the corpus endpoint — no substrate
+  scheduler). New tenant_admin-gated routes
+  `POST /api/v1/doc_collections/{key}/probe|enable|disable`: the probe
+  **writes liveness back onto the row on success only** (a failed probe
+  leaves it untouched, the `probe_target` split) and transitions the
+  lifecycle `status` (`provisioning`/`rebuilding` → `ready` once the
+  index is built); enable/disable are idempotent and guarded (forbidden
+  transition → 409). A coarse `/ready` check reports each configured
+  search backend reachable. New `meho docs collections probe|enable|disable`
+  CLI verbs. The search-time "not-ready → typed 409/403" guard
+  (`ensure_collection_searchable`) ships here; wiring it into the
+  `search_docs` route is a downstream Task (#1552).
+
 ### Backend-agnostic search router (#1551)
 
 - Add a `collection → backend{type, ref}` search router so one doc

--- a/backend/src/meho_backplane/api/v1/doc_collections.py
+++ b/backend/src/meho_backplane/api/v1/doc_collections.py
@@ -1,0 +1,183 @@
+# SPDX-License-Identifier: Apache-2.0
+# Copyright (c) 2026 evoila Group
+
+"""``/api/v1/doc_collections`` — readiness probe + lifecycle (G4.6-T6 #1555).
+
+Three tenant-admin-gated write routes against a
+:class:`~meho_backplane.db.models.DocCollection` row, mirroring the
+``probe_target`` + connector enable/disable precedents:
+
+* ``POST /api/v1/doc_collections/{collection_key}/probe`` — probe the
+  collection's backend and **persist on success only** its ``readiness``
+  / ``doc_count`` / ``last_ingested_at`` + ``status`` transition onto the
+  row, then return the typed
+  :class:`~meho_backplane.docs_search.backends.base.BackendReadiness`. A
+  probe that fails (backend unconfigured / unreachable / non-2xx /
+  malformed, or the row routes to no registered backend) maps to **503**
+  and leaves the row untouched — the same write-back split
+  ``probe_target`` / ``Target.fingerprint`` use (``api/v1/targets.py``).
+* ``POST /api/v1/doc_collections/{collection_key}/enable`` — return a
+  disabled collection to service (→ ``provisioning``; a follow-up probe
+  promotes it to ``ready``). Idempotent; a forbidden source state → 409.
+* ``POST /api/v1/doc_collections/{collection_key}/disable`` — hide a
+  collection from search (→ ``disabled``). Idempotent; 409 on a forbidden
+  move (none, since ``disable`` is reachable from every live state — the
+  guard is belt-and-suspenders against an out-of-enum status).
+
+Why a probe **route** rather than an implicit probe-on-search: a probe
+talks to the managed-RAG backend (latency + serialized rebuilds), so it
+is an explicit operator/ops action that refreshes the cached liveness the
+search path then reads cheaply — exactly the ``probe_target`` →
+``Target.fingerprint`` → dispatch split. Collection-scoped search wiring
+(the ``status != 'ready'`` typed failure) lives in T3 (#1552), which
+calls the
+:func:`~meho_backplane.docs_collections.lifecycle.ensure_collection_searchable`
+guard this Task ships.
+
+RBAC + tenancy
+--------------
+
+``tenant_admin`` minimum on every route (these mutate registry state),
+matching the connector enable/disable gate. The collection is resolved
+tenant-first via
+:func:`~meho_backplane.docs_collections.resolve_doc_collection` so an
+admin probes / toggles the row visible to their tenant (their own
+curated row shadows a global one); an unknown key → 404 with the typed
+``known_keys`` hint.
+"""
+
+from __future__ import annotations
+
+import structlog
+from fastapi import APIRouter, Depends, HTTPException, Response, status
+from sqlalchemy.ext.asyncio import AsyncSession
+
+from meho_backplane.auth.corpus import CorpusUnavailable
+from meho_backplane.auth.operator import Operator, TenantRole
+from meho_backplane.auth.rbac import require_role
+from meho_backplane.db.engine import get_session
+from meho_backplane.docs_collections import (
+    probe_collection,
+    resolve_doc_collection,
+    set_collection_enabled,
+)
+from meho_backplane.docs_search.backends.base import BackendReadiness
+
+__all__ = ["router"]
+
+_log = structlog.get_logger(__name__)
+
+router = APIRouter(prefix="/api/v1/doc_collections", tags=["docs"])
+
+#: Module-level ``Depends`` closure for the tenant-admin gate. Built once
+#: (rather than inline) to satisfy ruff B008, matching the convention
+#: :mod:`meho_backplane.api.v1.targets` established.
+_require_admin = Depends(require_role(TenantRole.TENANT_ADMIN))
+
+
+@router.post(
+    "/{collection_key}/probe",
+    response_model=BackendReadiness,
+    responses={
+        404: {"description": "No collection with this key is visible to the tenant."},
+        409: {
+            "description": (
+                "The probe's readiness implies a status the lifecycle "
+                "forbids from the collection's current state (e.g. probing "
+                "a disabled collection)."
+            ),
+        },
+        503: {
+            "description": (
+                "The collection's backend is unavailable — unconfigured, "
+                "unreachable, non-2xx / malformed, or routes to no "
+                "registered backend. Fail-closed; the row's cached "
+                "liveness is left untouched (success-only write-back)."
+            ),
+        },
+    },
+)
+async def probe_collection_endpoint(
+    collection_key: str,
+    operator: Operator = _require_admin,
+    session: AsyncSession = Depends(get_session),
+) -> BackendReadiness:
+    """Probe a collection's backend and persist its liveness on success.
+
+    Resolves the collection tenant-first, reads its backend's typed
+    readiness (forwarding the operator JWT under the operator identity),
+    and on success persists ``readiness`` / ``doc_count`` /
+    ``last_ingested_at`` + the ``status`` transition onto the row. A
+    failed probe is mapped to 503 and leaves the row unchanged: the
+    ``get_session`` transaction rolls back on the raise, so nothing the
+    service flushed survives.
+    """
+    collection = await resolve_doc_collection(session, collection_key, operator.tenant_id)
+    try:
+        return await probe_collection(session, operator, collection)
+    except CorpusUnavailable as exc:
+        # Fail-closed: an unconfigured / unreachable / non-2xx / unroutable
+        # backend is 503. The transport never attaches the raw body, so
+        # nothing leaks through the detail. The row stays at its
+        # previously-cached liveness (the begin() block rolls back).
+        _log.warning(
+            "doc_collection_probe_unavailable",
+            collection_key=collection_key,
+            tenant_id=str(operator.tenant_id),
+            backend_status=exc.status,
+        )
+        raise HTTPException(
+            status_code=status.HTTP_503_SERVICE_UNAVAILABLE,
+            detail=str(exc),
+        ) from exc
+
+
+@router.post(
+    "/{collection_key}/enable",
+    status_code=status.HTTP_204_NO_CONTENT,
+    response_class=Response,
+    responses={
+        404: {"description": "No collection with this key is visible to the tenant."},
+        409: {"description": "Enable is forbidden from the collection's current state."},
+    },
+)
+async def enable_collection_endpoint(
+    collection_key: str,
+    operator: Operator = _require_admin,
+    session: AsyncSession = Depends(get_session),
+) -> Response:
+    """Return a disabled collection to service (→ ``provisioning``).
+
+    Idempotent: re-enabling an already-live collection writes nothing and
+    returns 204. A forbidden source state raises 409 via the lifecycle
+    guard. A follow-up probe promotes the re-enabled collection to
+    ``ready`` once its index confirms.
+    """
+    collection = await resolve_doc_collection(session, collection_key, operator.tenant_id)
+    await set_collection_enabled(session, collection, enabled=True)
+    return Response(status_code=status.HTTP_204_NO_CONTENT)
+
+
+@router.post(
+    "/{collection_key}/disable",
+    status_code=status.HTTP_204_NO_CONTENT,
+    response_class=Response,
+    responses={
+        404: {"description": "No collection with this key is visible to the tenant."},
+        409: {"description": "Disable is forbidden from the collection's current state."},
+    },
+)
+async def disable_collection_endpoint(
+    collection_key: str,
+    operator: Operator = _require_admin,
+    session: AsyncSession = Depends(get_session),
+) -> Response:
+    """Hide a collection from search (→ ``disabled``).
+
+    Idempotent and lifecycle-guarded — same shape as the enable handler.
+    A disabled collection fails ``search_docs`` typed (403) via the T3
+    search-time guard rather than returning an empty result.
+    """
+    collection = await resolve_doc_collection(session, collection_key, operator.tenant_id)
+    await set_collection_enabled(session, collection, enabled=False)
+    return Response(status_code=status.HTTP_204_NO_CONTENT)

--- a/backend/src/meho_backplane/auth/corpus.py
+++ b/backend/src/meho_backplane/auth/corpus.py
@@ -43,7 +43,9 @@ other consumer.
 
 from __future__ import annotations
 
+from datetime import datetime
 from typing import Any
+from urllib.parse import urlsplit, urlunsplit
 
 import httpx
 import structlog
@@ -55,7 +57,10 @@ from meho_backplane.settings import get_settings
 __all__ = [
     "CorpusChunk",
     "CorpusSearchResponse",
+    "CorpusStatusResponse",
     "CorpusUnavailable",
+    "corpus_status",
+    "derive_status_url",
     "search_corpus",
 ]
 
@@ -214,3 +219,121 @@ async def search_corpus(
         # broken contract; fail closed without echoing the payload.
         _log.warning("corpus_response_invalid_schema")
         raise CorpusUnavailable("corpus response did not match the expected schema") from exc
+
+
+class CorpusStatusResponse(BaseModel):
+    """Parsed corpus readiness response — the liveness the probe reads back.
+
+    The consumer-side adapter over the corpus's ``/status`` contract (the
+    readiness sibling of :class:`CorpusSearchResponse`). The probe Task
+    (T6 #1555) reads ``index_built`` / ``doc_count`` / ``last_ingested_at``
+    here and the collection-probe route persists them onto the
+    ``doc_collections`` row on success. ``extra="ignore"`` absorbs corpus
+    fields MEHO does not consume; a dropped consumed field fails parse
+    rather than silently degrading — surfaced as :class:`CorpusUnavailable`.
+
+    ``index_built`` is the managed-RAG footgun: ``False`` means the corpus
+    is reachable but its ANN index is not yet answerable (a rebuild is in
+    flight, or the corpus was registered but never ingested), so the
+    search path can fail typed instead of returning an empty 200. Frozen.
+    """
+
+    model_config = ConfigDict(frozen=True, extra="ignore")
+
+    index_built: bool
+    doc_count: int | None = None
+    last_ingested_at: datetime | None = None
+
+
+def derive_status_url(search_url: str) -> str:
+    """Derive the corpus readiness URL from its *search_url*.
+
+    The corpus exposes its readiness check as a sibling of the search
+    endpoint: the final path segment ``search`` is swapped for ``status``
+    (``https://corpus/v1/search`` → ``https://corpus/v1/status``). A URL
+    whose final segment is not ``search`` gets ``status`` appended as a
+    child segment so an unconventional layout still resolves to a single
+    deterministic readiness URL. Query string and fragment are dropped —
+    they are search-request shape, never part of the status endpoint.
+    """
+    parts = urlsplit(search_url)
+    path = parts.path.rstrip("/")
+    if path.rsplit("/", 1)[-1] == "search":
+        new_path = path[: -len("search")] + "status"
+    else:
+        new_path = f"{path}/status"
+    return urlunsplit((parts.scheme, parts.netloc, new_path, "", ""))
+
+
+async def corpus_status(
+    operator: Operator,
+    *,
+    corpus_url: str | None = None,
+    audience: str | None = None,
+) -> CorpusStatusResponse:
+    """Read the external corpus's readiness as *operator* (T6 #1555).
+
+    GETs the corpus readiness endpoint (:func:`derive_status_url` of the
+    search URL) with ``Authorization: Bearer <operator.raw_jwt>`` so the
+    corpus authenticates and audits the probe as the operator — the same
+    forward-the-JWT contract as :func:`search_corpus`. Bounded by
+    ``settings.corpus_timeout_seconds``; every fail-closed branch
+    collapses to one :class:`CorpusUnavailable` so the probe route never
+    persists a partial / stale liveness snapshot.
+
+    Args:
+        operator: The verified operator whose JWT is forwarded.
+        corpus_url: The corpus *search* endpoint (the readiness URL is
+            derived from it). ``None`` falls back to ``settings.corpus_url``
+            — the legacy single-collection deploy. The ``corpus-http``
+            backend adapter passes the collection's ``backend.ref``
+            endpoint so each collection probes its own corpus.
+        audience: The RFC 8707 resource indicator to forward as a query
+            param. ``None`` falls back to ``settings.corpus_audience``; an
+            empty string forwards none.
+
+    Raises:
+        CorpusUnavailable: when *corpus_url* is unset (unconfigured), the
+            corpus is unreachable / times out, returns a non-2xx status,
+            or returns a body that does not match
+            :class:`CorpusStatusResponse`. The upstream status rides on
+            the exception (``status``) for non-2xx; the raw body is never
+            attached.
+    """
+    settings = get_settings()
+    resolved_url = corpus_url if corpus_url is not None else settings.corpus_url
+    if not resolved_url:
+        # Fail-closed: an unconfigured corpus has no readiness to report.
+        raise CorpusUnavailable("corpus_url is not configured")
+    status_url = derive_status_url(resolved_url)
+    resolved_audience = audience if audience is not None else settings.corpus_audience
+
+    params = {"audience": resolved_audience} if resolved_audience else None
+    headers = {"Authorization": f"Bearer {operator.raw_jwt}"}
+    timeout = httpx.Timeout(settings.corpus_timeout_seconds)
+
+    try:
+        async with httpx.AsyncClient(timeout=timeout) as client:
+            response = await client.get(status_url, params=params, headers=headers)
+    except httpx.HTTPError as exc:
+        _log.warning("corpus_status_unreachable", error=type(exc).__name__)
+        raise CorpusUnavailable(f"corpus unreachable: {type(exc).__name__}") from exc
+
+    if response.status_code // 100 != 2:
+        _log.warning("corpus_status_request_failed", status=response.status_code)
+        raise CorpusUnavailable(
+            f"corpus returned HTTP {response.status_code}",
+            status=response.status_code,
+        )
+
+    try:
+        body: Any = response.json()
+    except ValueError as exc:
+        _log.warning("corpus_status_response_not_json")
+        raise CorpusUnavailable("corpus returned a non-JSON body") from exc
+
+    try:
+        return CorpusStatusResponse.model_validate(body)
+    except ValueError as exc:
+        _log.warning("corpus_status_response_invalid_schema")
+        raise CorpusUnavailable("corpus status response did not match the expected schema") from exc

--- a/backend/src/meho_backplane/docs_collections/__init__.py
+++ b/backend/src/meho_backplane/docs_collections/__init__.py
@@ -3,14 +3,22 @@
 
 """Public API for the doc-collections package (G4.6 T1 collections-as-data).
 
-Re-exports the read schemas, the single ORM→wire projection, and the
-resolver surface so downstream tasks can import from
-``meho_backplane.docs_collections`` without knowing the internal module
-split. The backend-agnostic search router (T2 #1551), collection-scoped
-search (T3 #1552), and the catalogue tool / CLI (T4 #1553) all build on
-this surface.
+Re-exports the read schemas, the single ORM→wire projection, the
+resolver surface, and (T6 #1555) the readiness/lifecycle surface so
+downstream tasks can import from ``meho_backplane.docs_collections``
+without knowing the internal module split. The backend-agnostic search
+router (T2 #1551), collection-scoped search (T3 #1552), and the catalogue
+tool / CLI (T4 #1553) all build on this surface; the probe / enable /
+disable routes and the search-time readiness guard build on the
+``lifecycle`` + ``service`` modules (T6 #1555).
 """
 
+from meho_backplane.docs_collections.lifecycle import (
+    DocCollectionDisabledError,
+    DocCollectionNotReadyError,
+    DocCollectionStateError,
+    ensure_collection_searchable,
+)
 from meho_backplane.docs_collections.resolver import (
     DocCollectionNotFoundError,
     resolve_doc_collection,
@@ -20,11 +28,21 @@ from meho_backplane.docs_collections.schemas import (
     DocCollectionSummary,
     project_doc_collection_to_summary,
 )
+from meho_backplane.docs_collections.service import (
+    probe_collection,
+    set_collection_enabled,
+)
 
 __all__ = [
     "DocCollection",
+    "DocCollectionDisabledError",
     "DocCollectionNotFoundError",
+    "DocCollectionNotReadyError",
+    "DocCollectionStateError",
     "DocCollectionSummary",
+    "ensure_collection_searchable",
+    "probe_collection",
     "project_doc_collection_to_summary",
     "resolve_doc_collection",
+    "set_collection_enabled",
 ]

--- a/backend/src/meho_backplane/docs_collections/lifecycle.py
+++ b/backend/src/meho_backplane/docs_collections/lifecycle.py
@@ -1,0 +1,293 @@
+# SPDX-License-Identifier: Apache-2.0
+# Copyright (c) 2026 evoila Group
+
+"""Doc-collection lifecycle: the ``status`` state machine + readiness mapping (T6 #1555).
+
+The ``doc_collections.status`` column is a four-state lifecycle enum
+(``provisioning`` / ``ready`` / ``rebuilding`` / ``disabled``, T1 #1550).
+This module owns the **rules** that govern moving between those states and
+the mapping from a backend's typed
+:class:`~meho_backplane.docs_search.backends.base.BackendReadiness` snapshot
+to the resulting status. It is the docs analogue of the connector
+enable/disable state machine
+(:class:`~meho_backplane.operations.ingest.exceptions.InvalidStateTransitionError`,
+``api/v1/connectors_ingest.py``); the lifecycle stays here, beside the
+resolver, rather than inline in a route so the probe route, the
+enable/disable route, and the search path read one source of truth.
+
+Two transition surfaces
+-----------------------
+
+* **Operator transitions** (``enable`` / ``disable``) —
+  :data:`OPERATOR_TRANSITIONS`. ``disable`` is reachable from any live
+  state; ``enable`` returns a disabled collection to service. Driven by
+  the tenant-admin-gated enable/disable route.
+* **Probe transitions** — :func:`status_for_readiness` maps a successful
+  probe's :class:`BackendReadiness` to the status the row should hold,
+  then :func:`apply_probe_transition` guards that move against
+  :data:`PROBE_TRANSITIONS`. A probe never re-enables a ``disabled``
+  collection — an operator's explicit disable wins over a liveness signal.
+
+Fail-closed, idempotent
+-----------------------
+
+A forbidden transition raises :class:`DocCollectionStateError` (HTTP 409),
+mirroring the connector machine's ``InvalidStateTransitionError`` → 409.
+A transition whose source already equals its target is a **no-op** (the
+idempotency the acceptance criteria require), not an error — re-enabling
+an enabled collection or re-probing a steady-state ``ready`` collection
+returns without a spurious 409.
+
+Search-time guard
+-----------------
+
+:func:`ensure_collection_searchable` is the typed guard the
+collection-scoped search path (T3 #1552) calls to fail typed against a
+not-``ready`` collection: ``rebuilding`` / ``provisioning`` →
+:class:`DocCollectionNotReadyError` (409, retryable), ``disabled`` →
+:class:`DocCollectionDisabledError` (403). T6 ships the guard; T3 wires
+it into the ``search_docs`` route — the mechanism here, the call site
+there.
+"""
+
+from __future__ import annotations
+
+from collections.abc import Mapping
+from typing import TYPE_CHECKING, Final
+
+from fastapi import HTTPException
+
+if TYPE_CHECKING:
+    from meho_backplane.docs_search.backends.base import BackendReadiness
+
+__all__ = [
+    "DOC_COLLECTION_STATUSES",
+    "OPERATOR_TRANSITIONS",
+    "PROBE_TRANSITIONS",
+    "STATUS_DISABLED",
+    "STATUS_PROVISIONING",
+    "STATUS_READY",
+    "STATUS_REBUILDING",
+    "DocCollectionDisabledError",
+    "DocCollectionNotReadyError",
+    "DocCollectionStateError",
+    "apply_operator_transition",
+    "apply_probe_transition",
+    "ensure_collection_searchable",
+    "status_for_readiness",
+]
+
+STATUS_PROVISIONING: Final = "provisioning"
+STATUS_READY: Final = "ready"
+STATUS_REBUILDING: Final = "rebuilding"
+STATUS_DISABLED: Final = "disabled"
+
+#: The four lifecycle states, matching the ``ck_doc_collections_status``
+#: CHECK constraint (migration 0037). The single source for "is this a
+#: valid status string" on the Python side.
+DOC_COLLECTION_STATUSES: Final[frozenset[str]] = frozenset(
+    {STATUS_PROVISIONING, STATUS_READY, STATUS_REBUILDING, STATUS_DISABLED}
+)
+
+#: Legal **probe-driven** moves: ``source → {allowed targets}``. A probe
+#: brings a freshly-provisioned or rebuilding collection to ``ready`` once
+#: the index is built, and moves a ``ready`` collection to ``rebuilding``
+#: when the index is no longer answerable. A probe never touches a
+#: ``disabled`` collection — operator intent outranks a liveness signal.
+PROBE_TRANSITIONS: Final[Mapping[str, frozenset[str]]] = {
+    STATUS_PROVISIONING: frozenset({STATUS_READY, STATUS_REBUILDING}),
+    STATUS_READY: frozenset({STATUS_REBUILDING}),
+    STATUS_REBUILDING: frozenset({STATUS_READY}),
+    STATUS_DISABLED: frozenset(),
+}
+
+#: Legal **operator** moves driven by the enable/disable route. ``disable``
+#: is reachable from any live state; ``enable`` returns a disabled
+#: collection to ``provisioning`` (a probe then promotes it to ``ready``
+#: once the index confirms). A disabled→disabled or the matching
+#: same-state re-call is the idempotent no-op the route swallows.
+OPERATOR_TRANSITIONS: Final[Mapping[str, frozenset[str]]] = {
+    STATUS_PROVISIONING: frozenset({STATUS_DISABLED}),
+    STATUS_READY: frozenset({STATUS_DISABLED}),
+    STATUS_REBUILDING: frozenset({STATUS_DISABLED}),
+    STATUS_DISABLED: frozenset({STATUS_PROVISIONING}),
+}
+
+
+class DocCollectionStateError(HTTPException):
+    """A requested ``status`` transition is forbidden by the lifecycle.
+
+    Raised by :func:`apply_operator_transition` / :func:`apply_probe_transition`
+    when ``to_status`` is not a legal successor of ``from_status``.
+    Extends :class:`fastapi.HTTPException` with status **409** so it
+    propagates cleanly through FastAPI route handlers — the same 409-on-
+    forbidden-transition contract the connector enable/disable routes
+    surface (``InvalidStateTransitionError`` → 409). The detail names both
+    states so an operator sees *why* the move was rejected without parsing
+    a generic conflict.
+    """
+
+    def __init__(self, *, collection_key: str, from_status: str, to_status: str) -> None:
+        self.from_status = from_status
+        self.to_status = to_status
+        super().__init__(
+            status_code=409,
+            detail={
+                "error": "invalid_collection_transition",
+                "collection_key": collection_key,
+                "from_status": from_status,
+                "to_status": to_status,
+            },
+        )
+
+
+class DocCollectionNotReadyError(HTTPException):
+    """A collection cannot serve search because its index is not ready.
+
+    The typed search-time failure for a ``provisioning`` / ``rebuilding``
+    collection — HTTP **409** (a conflict with the collection's current
+    lifecycle state, retryable once the rebuild finishes), never a silent
+    empty 200. The search path (T3 #1552) raises this via
+    :func:`ensure_collection_searchable`. ``retryable=True`` distinguishes
+    it from the disabled 403 so a client can back off rather than treat it
+    as terminal.
+    """
+
+    def __init__(self, *, collection_key: str, status: str) -> None:
+        self.status = status
+        super().__init__(
+            status_code=409,
+            detail={
+                "error": "collection_not_ready",
+                "collection_key": collection_key,
+                "status": status,
+                "retryable": True,
+            },
+        )
+
+
+class DocCollectionDisabledError(HTTPException):
+    """A disabled collection cannot serve search.
+
+    The typed search-time failure for a ``disabled`` collection — HTTP
+    **403** (the collection is hidden from service by operator action, not
+    a transient state), distinct from the retryable 409 a rebuild yields.
+    """
+
+    def __init__(self, *, collection_key: str) -> None:
+        super().__init__(
+            status_code=403,
+            detail={
+                "error": "collection_disabled",
+                "collection_key": collection_key,
+                "retryable": False,
+            },
+        )
+
+
+def status_for_readiness(readiness: BackendReadiness) -> str:
+    """Map a successful probe's :class:`BackendReadiness` to a target status.
+
+    * reachable **and** index built → ``ready`` (live for search).
+    * reachable but index **not** built → ``rebuilding`` (a managed-RAG
+      index rebuild is in flight, or the corpus was registered but never
+      ingested — either way not yet answerable).
+
+    An unreachable backend never reaches this function: the probe raises
+    :class:`~meho_backplane.auth.corpus.CorpusUnavailable` before returning
+    a :class:`BackendReadiness`, so the route persists nothing
+    (success-only write-back) and the status is left untouched. This
+    function therefore only ever resolves the *reachable* axis.
+    """
+    if readiness.index_built:
+        return STATUS_READY
+    return STATUS_REBUILDING
+
+
+def apply_probe_transition(
+    *,
+    collection_key: str,
+    from_status: str,
+    to_status: str,
+) -> str:
+    """Resolve the post-probe status, guarding the move against the machine.
+
+    Returns *to_status* when the move is legal, the unchanged *from_status*
+    when it is a no-op (source already at target — the idempotent
+    re-probe), and raises :class:`DocCollectionStateError` (409) when the
+    move is forbidden (e.g. a probe trying to wake a ``disabled``
+    collection). The caller persists the returned status only when it
+    differs from *from_status*.
+    """
+    return _resolve_transition(
+        transitions=PROBE_TRANSITIONS,
+        collection_key=collection_key,
+        from_status=from_status,
+        to_status=to_status,
+    )
+
+
+def apply_operator_transition(
+    *,
+    collection_key: str,
+    from_status: str,
+    to_status: str,
+) -> str:
+    """Resolve an operator enable/disable move, guarding it against the machine.
+
+    Same contract as :func:`apply_probe_transition` but against
+    :data:`OPERATOR_TRANSITIONS`: a same-state re-call is the idempotent
+    no-op the enable/disable route returns 204/200 for without a write; a
+    forbidden move raises :class:`DocCollectionStateError` (409).
+    """
+    return _resolve_transition(
+        transitions=OPERATOR_TRANSITIONS,
+        collection_key=collection_key,
+        from_status=from_status,
+        to_status=to_status,
+    )
+
+
+def _resolve_transition(
+    *,
+    transitions: Mapping[str, frozenset[str]],
+    collection_key: str,
+    from_status: str,
+    to_status: str,
+) -> str:
+    """Shared guard: no-op on same-state, raise 409 on a forbidden move."""
+    if from_status == to_status:
+        # Idempotent: the row is already where the caller wants it. No
+        # write, no audit, no 409 — the same swallow the connector
+        # enable/disable machine does for an already-at-target group.
+        return from_status
+    allowed = transitions.get(from_status, frozenset())
+    if to_status not in allowed:
+        raise DocCollectionStateError(
+            collection_key=collection_key,
+            from_status=from_status,
+            to_status=to_status,
+        )
+    return to_status
+
+
+def ensure_collection_searchable(*, collection_key: str, status: str) -> None:
+    """Raise the typed failure when *status* cannot serve search (T6 mechanism).
+
+    The guard the collection-scoped search path (T3 #1552) calls before
+    federating a query. ``ready`` returns silently; every other state
+    raises so the route fails typed rather than returning an empty 200:
+
+    * ``provisioning`` / ``rebuilding`` → :class:`DocCollectionNotReadyError`
+      (409, retryable).
+    * ``disabled`` → :class:`DocCollectionDisabledError` (403).
+
+    T6 ships this guard; T3 wires the call into the ``search_docs`` route.
+    A status outside the known enum is treated as not-ready (fail-closed)
+    rather than waved through.
+    """
+    if status == STATUS_READY:
+        return
+    if status == STATUS_DISABLED:
+        raise DocCollectionDisabledError(collection_key=collection_key)
+    raise DocCollectionNotReadyError(collection_key=collection_key, status=status)

--- a/backend/src/meho_backplane/docs_collections/service.py
+++ b/backend/src/meho_backplane/docs_collections/service.py
@@ -1,0 +1,168 @@
+# SPDX-License-Identifier: Apache-2.0
+# Copyright (c) 2026 evoila Group
+
+"""Probe write-back + operator lifecycle service for doc collections (T6 #1555).
+
+Two write paths against a :class:`~meho_backplane.db.models.DocCollection`
+row, both modelled on the ``probe_target`` / connector-enable precedents:
+
+* :func:`probe_collection` — resolve the row's backend, read its typed
+  :class:`~meho_backplane.docs_search.backends.base.BackendReadiness`, and
+  persist ``readiness`` / ``doc_count`` / ``last_ingested_at`` + the
+  ``status`` transition **on success only**. A probe that raises
+  :class:`~meho_backplane.auth.corpus.CorpusUnavailable` leaves the row
+  untouched — the same success-only write-back ``probe_target`` uses for
+  ``Target.fingerprint`` (``api/v1/targets.py``). The caller (the probe
+  route) owns the transaction boundary; this function flushes but never
+  commits, so the route's ``async with session.begin()`` is the commit /
+  rollback unit.
+* :func:`set_collection_enabled` — the operator enable/disable transition,
+  guarded by :data:`~meho_backplane.docs_collections.lifecycle.OPERATOR_TRANSITIONS`
+  and idempotent (a re-call against an already-at-target row writes
+  nothing).
+
+Both reflect state the backend / operator owns; neither triggers ingest
+or a rebuild (out of scope per #1555 — the heavy ingest is the ops side,
+meho probes + reflects).
+"""
+
+from __future__ import annotations
+
+from datetime import UTC, datetime
+
+import structlog
+from sqlalchemy.ext.asyncio import AsyncSession
+
+from meho_backplane.auth.operator import Operator
+from meho_backplane.db.models import DocCollection as DocCollectionORM
+from meho_backplane.docs_collections.lifecycle import (
+    STATUS_DISABLED,
+    STATUS_PROVISIONING,
+    apply_operator_transition,
+    apply_probe_transition,
+    status_for_readiness,
+)
+from meho_backplane.docs_search.backends import BackendReadiness, resolve_backend
+
+__all__ = [
+    "probe_collection",
+    "set_collection_enabled",
+]
+
+_log = structlog.get_logger(__name__)
+
+
+async def probe_collection(
+    session: AsyncSession,
+    operator: Operator,
+    collection: DocCollectionORM,
+) -> BackendReadiness:
+    """Probe *collection*'s backend and persist its liveness on success.
+
+    Resolves the row's ``backend{type, ref}`` to its concrete adapter
+    (:func:`~meho_backplane.docs_search.backends.resolve_backend`), reads
+    the typed :class:`BackendReadiness`, then — **only when the probe
+    succeeds** — writes ``readiness`` / ``doc_count`` / ``last_ingested_at``
+    and transitions ``status`` (``provisioning`` / ``rebuilding`` →
+    ``ready`` once the index is built, ``ready`` → ``rebuilding`` when it
+    is not).
+
+    Args:
+        session: Active async session inside the route's open
+            transaction. This function flushes the row write but does not
+            commit; the route's ``session.begin()`` owns commit / rollback.
+        operator: The verified operator whose JWT the backend adapter
+            forwards to probe under the operator identity.
+        collection: The resolved ORM row to probe and write back to.
+
+    Returns:
+        The :class:`BackendReadiness` snapshot that was persisted.
+
+    Raises:
+        CorpusUnavailable: the backend is unconfigured / unreachable /
+            non-2xx / malformed, **or** the row routes to no registered
+            backend. The row is left untouched (success-only write-back);
+            the route maps this to HTTP 503.
+        DocCollectionStateError: the readiness implies a status the
+            lifecycle forbids from the current state (e.g. a probe against
+            a ``disabled`` row). The row is left untouched; HTTP 409.
+    """
+    # ``resolve_backend`` raises CorpusUnavailable for an unroutable row —
+    # the same 503 arm the search path uses, no new taxonomy. Bundles the
+    # adapter with the row's ``backend.ref``.
+    resolved = resolve_backend(collection)
+    readiness = await resolved.backend.probe(operator, backend_ref=resolved.ref)
+
+    target_status = status_for_readiness(readiness)
+    new_status = apply_probe_transition(
+        collection_key=collection.collection_key,
+        from_status=collection.status,
+        to_status=target_status,
+    )
+
+    # Success-only write-back. Everything below this line runs only after
+    # the probe returned (a raise above left the row untouched).
+    collection.readiness = dict(readiness.detail)
+    collection.doc_count = readiness.doc_count
+    collection.last_ingested_at = readiness.last_ingested_at
+    collection.status = new_status
+    collection.updated_at = datetime.now(UTC)
+    await session.flush()
+
+    _log.info(
+        "doc_collection_probed",
+        collection_key=collection.collection_key,
+        tenant_scope="tenant" if collection.tenant_id is not None else "global",
+        index_built=readiness.index_built,
+        doc_count=readiness.doc_count,
+        status=new_status,
+    )
+    return readiness
+
+
+async def set_collection_enabled(
+    session: AsyncSession,
+    collection: DocCollectionORM,
+    *,
+    enabled: bool,
+) -> bool:
+    """Enable or disable *collection*, guarded + idempotent.
+
+    ``enabled=False`` transitions any live state to ``disabled``;
+    ``enabled=True`` returns a disabled collection to ``provisioning`` (a
+    follow-up probe promotes it to ``ready``). A re-call against an
+    already-at-target row is a no-op — no write, no timestamp bump.
+
+    Args:
+        session: Active async session inside the route's transaction.
+        collection: The resolved ORM row to transition.
+        enabled: ``True`` → enable (→ ``provisioning``); ``False`` →
+            ``disabled``.
+
+    Returns:
+        ``True`` when the row's status actually changed (a write
+        happened), ``False`` on the idempotent no-op path.
+
+    Raises:
+        DocCollectionStateError: the move is forbidden from the current
+            state; HTTP 409. The row is left untouched.
+    """
+    target_status = STATUS_PROVISIONING if enabled else STATUS_DISABLED
+    new_status = apply_operator_transition(
+        collection_key=collection.collection_key,
+        from_status=collection.status,
+        to_status=target_status,
+    )
+    if new_status == collection.status:
+        # Idempotent no-op — already at target.
+        return False
+    collection.status = new_status
+    collection.updated_at = datetime.now(UTC)
+    await session.flush()
+    _log.info(
+        "doc_collection_lifecycle_set",
+        collection_key=collection.collection_key,
+        enabled=enabled,
+        status=new_status,
+    )
+    return True

--- a/backend/src/meho_backplane/docs_search/backends/__init__.py
+++ b/backend/src/meho_backplane/docs_search/backends/__init__.py
@@ -24,7 +24,7 @@ that imports :func:`resolve_backend` has a populated registry without a
 separate eager-import step.
 """
 
-from meho_backplane.docs_search.backends.base import SearchBackend
+from meho_backplane.docs_search.backends.base import BackendReadiness, SearchBackend
 from meho_backplane.docs_search.backends.corpus_http import (
     CORPUS_HTTP_BACKEND_TYPE,
     CorpusHttpBackend,
@@ -43,6 +43,7 @@ from meho_backplane.docs_search.backends.resolver import (
 
 __all__ = [
     "CORPUS_HTTP_BACKEND_TYPE",
+    "BackendReadiness",
     "BackendRef",
     "CorpusHttpBackend",
     "ResolvedBackend",

--- a/backend/src/meho_backplane/docs_search/backends/base.py
+++ b/backend/src/meho_backplane/docs_search/backends/base.py
@@ -28,23 +28,70 @@ collection's ``backend.ref`` and is passed to :meth:`search` per call, so
 a single ``CorpusHttpBackend`` instance serves every collection routed to
 the ``corpus-http`` type.
 
-:meth:`probe` is a forward seam for the readiness probe (T6 #1555). It
-defaults to raising :class:`NotImplementedError` so an adapter that has
-not implemented readiness reporting fails loudly rather than silently
-claiming "ready"; T6 overrides it on the adapters that gain a liveness
-endpoint.
+:meth:`probe` is the readiness seam (T6 #1555): it queries the backend
+for index readiness, ``doc_count``, and ``last_ingested_at`` and returns
+a typed :class:`BackendReadiness`. The base method defaults to raising
+:class:`NotImplementedError` so an adapter that has not implemented
+readiness reporting fails loudly rather than silently claiming "ready";
+:class:`~meho_backplane.docs_search.backends.corpus_http.CorpusHttpBackend`
+overrides it. The collection-probe route persists the result onto the
+``doc_collections`` row **on success only**, the same write-back split
+``probe_target`` + ``Target.fingerprint`` use.
 """
 
 from __future__ import annotations
 
 from abc import ABC, abstractmethod
 from collections.abc import Mapping
+from datetime import datetime
 from typing import Any
+
+from pydantic import BaseModel, ConfigDict, Field
 
 from meho_backplane.auth.corpus import CorpusSearchResponse
 from meho_backplane.auth.operator import Operator
 
-__all__ = ["SearchBackend"]
+__all__ = ["BackendReadiness", "SearchBackend"]
+
+
+class BackendReadiness(BaseModel):
+    """Typed result of a :meth:`SearchBackend.probe` call (T6 #1555).
+
+    The liveness snapshot a probe reads back from a collection's backend.
+    The collection-probe route persists ``doc_count`` / ``last_ingested_at``
+    / ``readiness`` onto the ``doc_collections`` row and transitions
+    ``status`` from this result **on success only** — modelled on
+    :class:`~meho_backplane.connectors.schemas.FingerprintResult`, which
+    ``probe_target`` caches onto ``Target.fingerprint`` the same way.
+
+    ``index_built`` is the managed-RAG footgun this surface exists to
+    hide: a managed-RAG ANN index answers searches only once it has been
+    explicitly (re)built, and rebuilds serialize per project. ``False``
+    means the backend is reachable but the index is not yet answerable —
+    the probe maps it to ``status='rebuilding'`` / ``'provisioning'`` so
+    the search path can fail typed rather than return a silent empty 200.
+
+    Frozen so a persisted snapshot cannot be mutated after the probe
+    reads it. ``detail`` is the free-form JSON the ``readiness`` column
+    stores verbatim for operator diagnostics (never agent-facing).
+    """
+
+    model_config = ConfigDict(frozen=True)
+
+    #: Backend reachable at all (transport succeeded). ``False`` is the
+    #: 503 arm — distinct from reachable-but-index-not-built.
+    reachable: bool
+    #: Managed-RAG index built and answerable. ``False`` while a rebuild
+    #: is in flight or the corpus was registered but never ingested.
+    index_built: bool
+    #: Documents the backend reports for this collection; ``None`` when
+    #: the backend does not expose a count.
+    doc_count: int | None = None
+    #: Last successful ingest the backend reports; ``None`` when unknown.
+    last_ingested_at: datetime | None = None
+    #: Free-form per-backend diagnostics persisted to the ``readiness``
+    #: JSON column verbatim (e.g. ``{"probe_method": "status-endpoint"}``).
+    detail: Mapping[str, Any] = Field(default_factory=dict)
 
 
 class SearchBackend(ABC):
@@ -114,13 +161,56 @@ class SearchBackend(ABC):
 
     async def probe(
         self,
+        operator: Operator,
+        *,
         backend_ref: Mapping[str, Any] | None = None,
-    ) -> Mapping[str, Any]:
-        """Report this backend's readiness for *backend_ref* (T6 #1555 seam).
+    ) -> BackendReadiness:
+        """Report this backend's readiness for *backend_ref* (T6 #1555).
 
-        Not implemented in T2. Defaults to raising so an adapter without
-        a liveness endpoint fails loudly rather than silently claiming
-        "ready"; the readiness probe Task (T6 #1555) overrides it on the
-        adapters that gain a liveness check.
+        Queries the backend for index readiness, ``doc_count``, and
+        ``last_ingested_at`` (or a HEAD / status call) and returns a typed
+        :class:`BackendReadiness`. The signature mirrors :meth:`search`:
+        the collection's row is resolved to ``backend_ref`` by the router
+        before the call, so the adapter depends only on the backend
+        routing detail and never on the ``doc_collections`` ORM shape.
+
+        The collection-probe route persists the result onto the row **on
+        success only** (the ``probe_target`` / ``Target.fingerprint``
+        write-back split). A probe that *raises* leaves the row's cached
+        liveness untouched.
+
+        Args:
+            operator: The verified operator. An adapter that probes an
+                operator-audited backend forwards ``operator.raw_jwt``;
+                an adapter with its own service credentials (a later
+                Task) uses *operator* only for scoping / logging.
+            backend_ref: The collection's ``backend.ref`` routing detail
+                (endpoint, audience, index id, …). ``None`` selects the
+                adapter's legacy / default configuration.
+
+        Returns:
+            A :class:`BackendReadiness` snapshot the route persists.
+
+        Raises:
+            NotImplementedError: the base default — an adapter without a
+                liveness check fails loudly rather than silently claiming
+                "ready". Concrete adapters override this.
         """
         raise NotImplementedError(f"{type(self).__name__} does not implement readiness probing")
+
+    def is_configured(self) -> bool:
+        """Whether this backend has the minimum config to answer at all.
+
+        The **coarse** liveness signal the ``/ready`` backend-reachability
+        probe (T6 #1555) consults — a cheap, synchronous, credential-free
+        check (e.g. "is the corpus URL set?"), *not* a live round-trip to
+        the backend (that would need an operator JWT and would hammer the
+        backend on every readiness poll). Defaults to ``True`` so an
+        adapter with no external configuration (an in-process backend) is
+        reachable by construction; adapters that depend on an external
+        endpoint override this to report whether it is configured.
+
+        The per-collection liveness round-trip is :meth:`probe`; this is
+        the deploy-level "is the backend wired at all" gate.
+        """
+        return True

--- a/backend/src/meho_backplane/docs_search/backends/corpus_http.py
+++ b/backend/src/meho_backplane/docs_search/backends/corpus_http.py
@@ -34,16 +34,40 @@ on the collection's ``backend.ref`` and is passed per call:
 A ``backend.ref`` that names neither (and a deploy whose legacy
 ``corpus_url`` is also empty) is **unconfigured** and fails closed with
 :class:`CorpusUnavailable` — the same 503 arm as today, no new taxonomy.
+
+Readiness + per-project rebuild serialization (T6 #1555)
+-------------------------------------------------------
+
+:meth:`probe` reads the corpus's readiness (:func:`corpus_status`) and
+maps it to a typed
+:class:`~meho_backplane.docs_search.backends.base.BackendReadiness`.
+
+The managed-RAG "rebuilds serialize per project" constraint lives
+**inside this adapter** — a per-project :class:`asyncio.Lock` the probe
+holds while it talks to the corpus — rather than as a substrate-level
+scheduler (substrate minimalism, #1177). The lock key is the resolved
+corpus endpoint, so two concurrent probes against the *same* project's
+backend serialize while probes against *different* projects run
+concurrently; the serialized state is surfaced to operators via the
+``status='rebuilding'`` column the probe route writes, not via a new
+queue primitive.
 """
 
 from __future__ import annotations
 
+import asyncio
+from collections import defaultdict
 from collections.abc import Mapping
 from typing import Any
 
-from meho_backplane.auth.corpus import CorpusSearchResponse, search_corpus
+from meho_backplane.auth.corpus import (
+    CorpusSearchResponse,
+    corpus_status,
+    search_corpus,
+)
 from meho_backplane.auth.operator import Operator
-from meho_backplane.docs_search.backends.base import SearchBackend
+from meho_backplane.docs_search.backends.base import BackendReadiness, SearchBackend
+from meho_backplane.settings import get_settings
 
 __all__ = ["CORPUS_HTTP_BACKEND_TYPE", "CorpusHttpBackend"]
 
@@ -65,6 +89,18 @@ class CorpusHttpBackend(SearchBackend):
     """
 
     backend_type = CORPUS_HTTP_BACKEND_TYPE
+
+    def __init__(self) -> None:
+        # Per-project rebuild serialization. One lock per resolved corpus
+        # endpoint (a project's backend), minted on first use. A
+        # ``defaultdict`` rather than an explicit pre-seed because the set
+        # of collections is operator-data, not known at construction; the
+        # adapter is a process-singleton so this map is per-process,
+        # exactly the scope "serialize per project" needs (no cross-pod
+        # coordination — that would be the substrate scheduler #1177 rules
+        # out). The map only grows with the number of distinct endpoints,
+        # which is bounded by the collection count.
+        self._project_locks: defaultdict[str, asyncio.Lock] = defaultdict(asyncio.Lock)
 
     async def search(
         self,
@@ -90,6 +126,60 @@ class CorpusHttpBackend(SearchBackend):
             corpus_url=endpoint,
             audience=audience,
         )
+
+    async def probe(
+        self,
+        operator: Operator,
+        *,
+        backend_ref: Mapping[str, Any] | None = None,
+    ) -> BackendReadiness:
+        """Read this collection's corpus readiness, serialized per project.
+
+        Resolves the endpoint / audience from *backend_ref* (legacy
+        globals when absent) and reads the corpus's readiness via
+        :func:`~meho_backplane.auth.corpus.corpus_status`, holding the
+        per-project lock for the resolved endpoint so two concurrent
+        probes against the same project's backend serialize (the
+        "rebuilds serialize per project" constraint, in-adapter). A
+        reachable corpus whose ANN index is not yet built maps to
+        ``index_built=False`` so the probe route writes ``rebuilding`` /
+        ``provisioning`` rather than ``ready``.
+
+        Propagates :class:`~meho_backplane.auth.corpus.CorpusUnavailable`
+        on every fail-closed branch (unconfigured / unreachable / non-2xx
+        / malformed) so the route persists nothing on a failed probe
+        (success-only write-back).
+        """
+        endpoint, audience = _resolve_endpoint_audience(backend_ref)
+        # Key the serialization lock on the resolved project endpoint. The
+        # empty-string key covers the legacy single-collection deploy (one
+        # global corpus) so even its concurrent probes serialize.
+        lock_key = endpoint or ""
+        async with self._project_locks[lock_key]:
+            status = await corpus_status(
+                operator,
+                corpus_url=endpoint,
+                audience=audience,
+            )
+        return BackendReadiness(
+            reachable=True,
+            index_built=status.index_built,
+            doc_count=status.doc_count,
+            last_ingested_at=status.last_ingested_at,
+            detail={"probe_method": "corpus-status"},
+        )
+
+    def is_configured(self) -> bool:
+        """Whether the corpus endpoint is configured at the deploy level.
+
+        The coarse ``/ready`` signal: ``settings.corpus_url`` set. This is
+        the legacy global endpoint — a deploy with per-collection
+        ``backend.ref`` endpoints but no global ``corpus_url`` still routes
+        per-collection at search time, but the deploy-level reachability
+        gate keys off the global config the unmigrated path needs. A
+        credential-free, synchronous check: no JWT, no round-trip.
+        """
+        return bool(get_settings().corpus_url)
 
 
 def _resolve_endpoint_audience(

--- a/backend/src/meho_backplane/docs_search/readiness_probe.py
+++ b/backend/src/meho_backplane/docs_search/readiness_probe.py
@@ -1,0 +1,80 @@
+# SPDX-License-Identifier: Apache-2.0
+# Copyright (c) 2026 evoila Group
+
+"""Coarse ``/ready`` probe: each configured search backend is reachable (T6 #1555).
+
+Registered with :mod:`meho_backplane.health` from the FastAPI lifespan
+(:mod:`meho_backplane.main`), beside the Keycloak / Vault / DB / broadcast
+probes. It answers the deploy-level question "are the doc-search backends
+wired?" — a coarse liveness gate, not the per-collection round-trip
+:meth:`~meho_backplane.docs_search.backends.base.SearchBackend.probe`
+performs.
+
+Coarse by design
+----------------
+
+The probe consults each registered adapter's
+:meth:`~meho_backplane.docs_search.backends.base.SearchBackend.is_configured`
+— a cheap, synchronous, credential-free check (e.g. "is ``corpus_url``
+set?"). It deliberately does **not** issue a live round-trip to each
+backend: ``/ready`` is polled by the kubelet on a tight interval and a
+live probe would (a) need an operator JWT the readiness path has no
+business minting and (b) hammer the external corpus on every poll. The
+per-collection liveness round-trip is the explicit
+``POST /api/v1/doc_collections/{key}/probe`` operator action instead.
+
+Empty-registry note
+-------------------
+
+With no registered backends the probe reports ``ok=True`` with
+``detail="no backends registered"`` — the doc-search add-on being absent
+is not a backplane-unready signal (the four core probes gate readiness).
+The shipped ``corpus-http`` adapter self-registers at import, so a deploy
+that imported the docs package always has at least that one to report on.
+"""
+
+from __future__ import annotations
+
+import structlog
+
+from meho_backplane.docs_search.backends import all_backends
+from meho_backplane.health import ProbeResult
+
+__all__ = ["PROBE_NAME", "docs_backends_readiness_probe"]
+
+#: The ``name`` this probe registers under (and the ``checks[].name`` it
+#: surfaces in the ``/ready`` payload).
+PROBE_NAME = "docs_backends"
+
+_log = structlog.get_logger(__name__)
+
+
+def docs_backends_readiness_probe() -> ProbeResult:
+    """Report whether every configured search backend is reachable.
+
+    Synchronous (no I/O — :meth:`is_configured` is a config read), so the
+    health registry calls it inline. ``ok`` is the AND across every
+    registered adapter's :meth:`is_configured`; ``detail`` names the
+    unconfigured backend types so an operator's single ``GET /ready``
+    answers *which* backend is unwired without a second query. An empty
+    registry is ``ok=True`` (the docs add-on is optional; its absence does
+    not fail the backplane's readiness gate).
+    """
+    backends = all_backends()
+    if not backends:
+        return ProbeResult(name=PROBE_NAME, ok=True, detail="no backends registered")
+
+    unconfigured = sorted(
+        backend_type for backend_type, impl in backends.items() if not impl.is_configured()
+    )
+    if unconfigured:
+        # Coarse fail: at least one registered backend is not wired. Name
+        # the offending types (backend type strings are deploy config, not
+        # tenant data, so they are safe to surface on /ready).
+        _log.warning("docs_backends_unconfigured", unconfigured=unconfigured)
+        return ProbeResult(
+            name=PROBE_NAME,
+            ok=False,
+            detail=f"unconfigured: {', '.join(unconfigured)}",
+        )
+    return ProbeResult(name=PROBE_NAME, ok=True, detail=f"{len(backends)} backend(s) configured")

--- a/backend/src/meho_backplane/main.py
+++ b/backend/src/meho_backplane/main.py
@@ -78,6 +78,7 @@ from meho_backplane.api.v1.connectors_ingest import (
     set_llm_client_factory,
 )
 from meho_backplane.api.v1.conventions import router as api_v1_conventions_router
+from meho_backplane.api.v1.doc_collections import router as api_v1_doc_collections_router
 from meho_backplane.api.v1.feed import router as api_v1_feed_router
 from meho_backplane.api.v1.health import router as api_v1_health_router
 from meho_backplane.api.v1.kb import router as api_v1_kb_router
@@ -109,6 +110,7 @@ from meho_backplane.broadcast import (
 from meho_backplane.connectors.registry import _eager_import_connectors, registered_product_tokens
 from meho_backplane.db.engine import dispose_engine, get_engine
 from meho_backplane.db.migrations import db_migration_probe
+from meho_backplane.docs_search.readiness_probe import docs_backends_readiness_probe
 from meho_backplane.events import start_event_drain, stop_event_drain
 from meho_backplane.health import register_probe
 from meho_backplane.health import router as health_router
@@ -276,6 +278,10 @@ async def _run_lifespan_startup() -> None:
     register_probe("vault", vault_readiness_probe)
     register_probe("db", db_migration_probe)
     register_probe("broadcast", broadcast_readiness_probe)
+    # G4.6-T6 (#1555) — coarse "each configured search backend reachable"
+    # gate. Synchronous config read (no live round-trip); the
+    # per-collection liveness round-trip is the explicit probe route.
+    register_probe("docs_backends", docs_backends_readiness_probe)
     # Eager engine construction (G2.3-T2 #258); validates ``DATABASE_URL``
     # at startup so first-request latency doesn't absorb the pool build.
     get_engine()
@@ -593,6 +599,12 @@ app.include_router(api_v1_retrieve_retire_router)
 # `audit_op_class` contextvar overrides. The MCP tool (T4) and CLI verb
 # (T5) reuse the same `docs_search.search_docs` service this route fronts.
 app.include_router(api_v1_search_docs_router)
+# G4.6-T6 (#1555) — doc-collection readiness probe + lifecycle. Tenant-
+# admin-gated probe (success-only write-back of liveness onto the row,
+# mirroring probe_target → Target.fingerprint) + enable/disable
+# transitions. The collection-scoped search wiring that reads the
+# probe-written status lands in T3 (#1552).
+app.include_router(api_v1_doc_collections_router)
 # G0.3-T3 (#254) — targets CRUD surface. All 5 routes are tenant-scoped
 # via the JWT's tenant_id claim; cross-tenant reads are impossible.
 # G9.1-T5 (#453) extends this router with GET /api/v1/targets/discover

--- a/backend/tests/test_corpus_client.py
+++ b/backend/tests/test_corpus_client.py
@@ -23,7 +23,10 @@ import structlog
 import meho_backplane.auth.corpus as corpus_mod
 from meho_backplane.auth.corpus import (
     CorpusSearchResponse,
+    CorpusStatusResponse,
     CorpusUnavailable,
+    corpus_status,
+    derive_status_url,
     search_corpus,
 )
 from meho_backplane.auth.operator import Operator
@@ -279,3 +282,84 @@ async def test_forwarded_jwt_never_logged(monkeypatch: pytest.MonkeyPatch) -> No
     assert _JWT not in serialised
     # The failure is still observable by status.
     assert any(event.get("status") == 503 for event in logs)
+
+
+# ---------------------------------------------------------------------------
+# corpus_status (T6 #1555 readiness transport)
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.parametrize(
+    ("search_url", "expected"),
+    [
+        ("https://corpus.test/v1/search", "https://corpus.test/v1/status"),
+        ("https://corpus.test/v1/search/", "https://corpus.test/v1/status"),
+        ("https://corpus.test/corpus", "https://corpus.test/corpus/status"),
+        ("https://corpus.test/search?x=1", "https://corpus.test/status"),
+    ],
+)
+def test_derive_status_url(search_url: str, expected: str) -> None:
+    """The readiness URL is the search URL with its tail swapped to status."""
+    assert derive_status_url(search_url) == expected
+
+
+@pytest.mark.asyncio
+async def test_corpus_status_gets_status_url_with_bearer(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """corpus_status GETs the derived status URL forwarding the operator JWT."""
+    _pin_settings(monkeypatch, corpus_url=_CORPUS_URL)
+    captured: list[httpx.Request] = []
+    response = httpx.Response(
+        200,
+        json={
+            "index_built": True,
+            "doc_count": 17000,
+            "last_ingested_at": "2026-06-01T12:00:00Z",
+        },
+    )
+    transport = _transport_capturing(captured, response)
+    _patch_async_client(monkeypatch, transport, [])
+
+    result = await corpus_status(_make_operator())
+
+    assert isinstance(result, CorpusStatusResponse)
+    assert result.index_built is True
+    assert result.doc_count == 17000
+    assert len(captured) == 1
+    assert captured[0].method == "GET"
+    assert str(captured[0].url) == derive_status_url(_CORPUS_URL)
+    assert captured[0].headers["Authorization"] == f"Bearer {_JWT}"
+
+
+@pytest.mark.asyncio
+async def test_corpus_status_unconfigured_raises(monkeypatch: pytest.MonkeyPatch) -> None:
+    """An empty corpus_url is unavailable, not silently 'no readiness'."""
+    _pin_settings(monkeypatch, corpus_url="")
+    with pytest.raises(CorpusUnavailable):
+        await corpus_status(_make_operator())
+
+
+@pytest.mark.asyncio
+async def test_corpus_status_non_2xx_fails_closed(monkeypatch: pytest.MonkeyPatch) -> None:
+    """A non-2xx status collapses to CorpusUnavailable carrying the status."""
+    _pin_settings(monkeypatch, corpus_url=_CORPUS_URL)
+    transport = _transport_capturing([], httpx.Response(500, text="boom"))
+    _patch_async_client(monkeypatch, transport, [])
+
+    with pytest.raises(CorpusUnavailable) as exc:
+        await corpus_status(_make_operator())
+    assert exc.value.status == 500
+    # The corpus error body never leaks through the typed error.
+    assert "boom" not in str(exc.value)
+
+
+@pytest.mark.asyncio
+async def test_corpus_status_malformed_body_fails_closed(monkeypatch: pytest.MonkeyPatch) -> None:
+    """A 2xx body missing the required index_built fails parse → unavailable."""
+    _pin_settings(monkeypatch, corpus_url=_CORPUS_URL)
+    transport = _transport_capturing([], httpx.Response(200, json={"doc_count": 5}))
+    _patch_async_client(monkeypatch, transport, [])
+
+    with pytest.raises(CorpusUnavailable):
+        await corpus_status(_make_operator())

--- a/backend/tests/test_doc_collections_readiness.py
+++ b/backend/tests/test_doc_collections_readiness.py
@@ -1,0 +1,631 @@
+# SPDX-License-Identifier: Apache-2.0
+# Copyright (c) 2026 evoila Group
+
+"""Behavioural tests for the doc-collection readiness probe + lifecycle (G4.6-T6 #1555).
+
+Coverage matrix (Task #1555 acceptance criteria):
+
+* **Success-only write-back** — probing a collection writes ``readiness``
+  / ``doc_count`` / ``last_ingested_at`` and transitions ``status``; a
+  *failed* probe (backend raises ``CorpusUnavailable``) leaves the row
+  unchanged, including its previously-cached liveness. Mirrors
+  ``probe_target`` / ``Target.fingerprint``.
+* **Status transitions** — the lifecycle state machine: a probe promotes
+  ``provisioning`` → ``ready`` once the index is built and demotes
+  ``ready`` → ``rebuilding`` when it is not; a forbidden move (a probe
+  against a ``disabled`` row) raises ``DocCollectionStateError`` (409).
+  Enable / disable are idempotent and guarded.
+* **Search-time guard** — ``ensure_collection_searchable`` (the T6
+  mechanism T3 #1552 wires into the route): ``ready`` passes,
+  ``rebuilding`` / ``provisioning`` → 409 (retryable), ``disabled`` →
+  403; never an empty pass-through.
+* **Per-project rebuild serialization** — two concurrent probes against
+  the same backend endpoint serialize inside the adapter (the lock is
+  held across the corpus round-trip); probes against different endpoints
+  run concurrently.
+* **/ready backend reachability** — the coarse probe reports ``ok`` only
+  when every registered backend is configured, naming the unconfigured
+  ones.
+* **REST routes** — probe / enable / disable are tenant_admin-gated
+  (operator → 403), 404 on an unknown key, and the probe maps a backend
+  failure to 503 with the row untouched.
+
+Runs against ``sqlite+aiosqlite`` via the shared engine the autouse
+``_default_database_url`` conftest fixture pre-migrates to ``alembic
+upgrade head`` — identical to :mod:`tests.test_doc_collections_registry`.
+"""
+
+from __future__ import annotations
+
+import asyncio
+import uuid
+from collections.abc import Iterator
+from datetime import UTC, datetime
+from typing import Any
+
+import pytest
+import respx
+from fastapi import FastAPI
+from fastapi.testclient import TestClient
+
+from meho_backplane.audit import AuditMiddleware
+from meho_backplane.auth.corpus import CorpusStatusResponse, CorpusUnavailable
+from meho_backplane.auth.jwt import clear_jwks_cache
+from meho_backplane.auth.operator import Operator, PrincipalKind, TenantRole
+from meho_backplane.db.engine import get_sessionmaker, reset_engine_for_testing
+from meho_backplane.db.models import DocCollection
+from meho_backplane.docs_collections import (
+    DocCollectionDisabledError,
+    DocCollectionNotReadyError,
+    DocCollectionStateError,
+    ensure_collection_searchable,
+    probe_collection,
+    set_collection_enabled,
+)
+from meho_backplane.docs_collections.lifecycle import (
+    STATUS_DISABLED,
+    STATUS_PROVISIONING,
+    STATUS_READY,
+    STATUS_REBUILDING,
+    apply_operator_transition,
+    apply_probe_transition,
+    status_for_readiness,
+)
+from meho_backplane.docs_search.backends import BackendReadiness, CorpusHttpBackend
+from meho_backplane.docs_search.backends.base import SearchBackend
+from meho_backplane.docs_search.readiness_probe import docs_backends_readiness_probe
+from meho_backplane.middleware import RequestContextMiddleware
+from meho_backplane.settings import get_settings
+
+from ._oidc_jwt_helpers import (
+    AUDIENCE as _AUDIENCE,
+)
+from ._oidc_jwt_helpers import (
+    DEFAULT_TENANT_ID,
+    make_rsa_keypair,
+    mint_token,
+    mock_discovery_and_jwks,
+    public_jwks,
+)
+from ._oidc_jwt_helpers import (
+    ISSUER as _ISSUER,
+)
+
+_CORPUS_URL = "https://corpus.test/v1/search"
+
+
+@pytest.fixture(autouse=True)
+def _settings_env(monkeypatch: pytest.MonkeyPatch) -> Iterator[None]:
+    """Pin the env :class:`Settings` requires + a configured corpus."""
+    monkeypatch.setenv("KEYCLOAK_ISSUER_URL", _ISSUER)
+    monkeypatch.setenv("KEYCLOAK_AUDIENCE", _AUDIENCE)
+    monkeypatch.setenv("KEYCLOAK_JWKS_CACHE_TTL_SECONDS", "300")
+    monkeypatch.setenv("KEYCLOAK_JWT_LEEWAY_SECONDS", "30")
+    monkeypatch.setenv("VAULT_ADDR", "https://vault.test")
+    monkeypatch.setenv("VAULT_OIDC_ROLE", "meho-mcp")
+    monkeypatch.setenv("VAULT_OIDC_MOUNT_PATH", "jwt")
+    monkeypatch.setenv("VAULT_TIMEOUT_SECONDS", "5.0")
+    monkeypatch.delenv("VAULT_NAMESPACE", raising=False)
+    monkeypatch.setenv("CORPUS_URL", _CORPUS_URL)
+    monkeypatch.setenv("CORPUS_AUDIENCE", "")
+    get_settings.cache_clear()
+    yield
+    get_settings.cache_clear()
+
+
+@pytest.fixture(autouse=True)
+def _isolated_jwks_cache() -> Iterator[None]:
+    clear_jwks_cache()
+    yield
+    clear_jwks_cache()
+
+
+def _make_operator(tenant_id: str = DEFAULT_TENANT_ID) -> Operator:
+    """Build a verified operator without a live JWT round-trip."""
+    return Operator(
+        sub="admin-1",
+        tenant_id=uuid.UUID(tenant_id),
+        tenant_role=TenantRole.TENANT_ADMIN,
+        principal_kind=PrincipalKind.USER,
+        raw_jwt="header.payload.signature",
+        capabilities=frozenset({"meho-docs"}),
+    )
+
+
+async def _insert_collection(**kwargs: Any) -> DocCollection:
+    """Insert a DocCollection row via the test sessionmaker."""
+    defaults: dict[str, Any] = {
+        "id": uuid.uuid4(),
+        "tenant_id": uuid.UUID(DEFAULT_TENANT_ID),
+        "collection_key": "vmware",
+        "vendor": "VMware",
+        "products": ["vsphere"],
+        "description": None,
+        "when_to_use": None,
+        "backend": {"type": "corpus-http", "ref": {"endpoint": _CORPUS_URL}},
+        "status": STATUS_PROVISIONING,
+        "last_ingested_at": None,
+        "doc_count": None,
+        "readiness": None,
+        "extras": {},
+        "created_at": datetime.now(UTC),
+        "updated_at": datetime.now(UTC),
+    }
+    defaults.update(kwargs)
+    c = DocCollection(**defaults)
+    sm = get_sessionmaker()
+    async with sm() as session:
+        session.add(c)
+        await session.commit()
+    return c
+
+
+# ---------------------------------------------------------------------------
+# Lifecycle state machine (pure)
+# ---------------------------------------------------------------------------
+
+
+def test_status_for_readiness_maps_index_built() -> None:
+    assert status_for_readiness(BackendReadiness(reachable=True, index_built=True)) == STATUS_READY
+    assert (
+        status_for_readiness(BackendReadiness(reachable=True, index_built=False))
+        == STATUS_REBUILDING
+    )
+
+
+@pytest.mark.parametrize(
+    ("from_status", "to_status", "expected"),
+    [
+        (STATUS_PROVISIONING, STATUS_READY, STATUS_READY),
+        (STATUS_PROVISIONING, STATUS_REBUILDING, STATUS_REBUILDING),
+        (STATUS_READY, STATUS_REBUILDING, STATUS_REBUILDING),
+        (STATUS_REBUILDING, STATUS_READY, STATUS_READY),
+        (STATUS_READY, STATUS_READY, STATUS_READY),  # idempotent no-op
+    ],
+)
+def test_apply_probe_transition_allows_legal_moves(
+    from_status: str, to_status: str, expected: str
+) -> None:
+    assert (
+        apply_probe_transition(
+            collection_key="vmware", from_status=from_status, to_status=to_status
+        )
+        == expected
+    )
+
+
+def test_apply_probe_transition_rejects_waking_a_disabled_collection() -> None:
+    """A probe never re-enables a disabled collection — operator intent wins."""
+    with pytest.raises(DocCollectionStateError) as exc:
+        apply_probe_transition(
+            collection_key="vmware", from_status=STATUS_DISABLED, to_status=STATUS_READY
+        )
+    assert exc.value.status_code == 409
+    assert exc.value.from_status == STATUS_DISABLED
+    assert exc.value.to_status == STATUS_READY
+
+
+def test_apply_operator_transition_disable_from_any_live_state() -> None:
+    for src in (STATUS_PROVISIONING, STATUS_READY, STATUS_REBUILDING):
+        assert (
+            apply_operator_transition(
+                collection_key="vmware", from_status=src, to_status=STATUS_DISABLED
+            )
+            == STATUS_DISABLED
+        )
+
+
+def test_apply_operator_transition_enable_only_from_disabled() -> None:
+    assert (
+        apply_operator_transition(
+            collection_key="vmware", from_status=STATUS_DISABLED, to_status=STATUS_PROVISIONING
+        )
+        == STATUS_PROVISIONING
+    )
+    # disable is reachable from ready, but "enable" (→ provisioning) from a
+    # live state is a forbidden move.
+    with pytest.raises(DocCollectionStateError):
+        apply_operator_transition(
+            collection_key="vmware", from_status=STATUS_READY, to_status=STATUS_PROVISIONING
+        )
+
+
+# ---------------------------------------------------------------------------
+# Search-time guard (the T6 mechanism T3 #1552 wires in)
+# ---------------------------------------------------------------------------
+
+
+def test_ensure_searchable_passes_for_ready() -> None:
+    ensure_collection_searchable(collection_key="vmware", status=STATUS_READY)  # no raise
+
+
+@pytest.mark.parametrize("status", [STATUS_REBUILDING, STATUS_PROVISIONING])
+def test_ensure_searchable_409_for_not_ready(status: str) -> None:
+    with pytest.raises(DocCollectionNotReadyError) as exc:
+        ensure_collection_searchable(collection_key="vmware", status=status)
+    assert exc.value.status_code == 409
+    assert exc.value.detail["retryable"] is True
+    assert exc.value.detail["status"] == status
+
+
+def test_ensure_searchable_403_for_disabled() -> None:
+    with pytest.raises(DocCollectionDisabledError) as exc:
+        ensure_collection_searchable(collection_key="vmware", status=STATUS_DISABLED)
+    assert exc.value.status_code == 403
+    assert exc.value.detail["retryable"] is False
+
+
+def test_ensure_searchable_fails_closed_on_unknown_status() -> None:
+    """A status outside the enum is treated as not-ready, never waved through."""
+    with pytest.raises(DocCollectionNotReadyError):
+        ensure_collection_searchable(collection_key="vmware", status="bogus")
+
+
+# ---------------------------------------------------------------------------
+# probe_collection write-back (service)
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.asyncio
+async def test_probe_writes_liveness_and_promotes_to_ready(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """A successful probe writes liveness + transitions provisioning → ready."""
+    collection = await _insert_collection(status=STATUS_PROVISIONING)
+    ingested = datetime(2026, 6, 1, 12, 0, tzinfo=UTC)
+
+    async def _fake_probe(
+        self: SearchBackend, operator: Operator, *, backend_ref: Any = None
+    ) -> BackendReadiness:
+        return BackendReadiness(
+            reachable=True,
+            index_built=True,
+            doc_count=17000,
+            last_ingested_at=ingested,
+            detail={"probe_method": "corpus-status"},
+        )
+
+    monkeypatch.setattr(CorpusHttpBackend, "probe", _fake_probe)
+
+    operator = _make_operator()
+    sm = get_sessionmaker()
+    async with sm() as session, session.begin():
+        row = await session.get(DocCollection, collection.id)
+        assert row is not None
+        readiness = await probe_collection(session, operator, row)
+
+    assert readiness.doc_count == 17000
+    async with sm() as session:
+        row = await session.get(DocCollection, collection.id)
+        assert row is not None
+        assert row.status == STATUS_READY
+        assert row.doc_count == 17000
+        assert row.last_ingested_at.replace(tzinfo=UTC) == ingested
+        assert row.readiness == {"probe_method": "corpus-status"}
+
+
+@pytest.mark.asyncio
+async def test_probe_demotes_ready_to_rebuilding_when_index_not_built(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    collection = await _insert_collection(status=STATUS_READY, doc_count=10)
+
+    async def _fake_probe(
+        self: SearchBackend, operator: Operator, *, backend_ref: Any = None
+    ) -> BackendReadiness:
+        return BackendReadiness(reachable=True, index_built=False, doc_count=10)
+
+    monkeypatch.setattr(CorpusHttpBackend, "probe", _fake_probe)
+
+    sm = get_sessionmaker()
+    async with sm() as session, session.begin():
+        row = await session.get(DocCollection, collection.id)
+        assert row is not None
+        await probe_collection(session, _make_operator(), row)
+
+    async with sm() as session:
+        row = await session.get(DocCollection, collection.id)
+        assert row is not None
+        assert row.status == STATUS_REBUILDING
+
+
+@pytest.mark.asyncio
+async def test_failed_probe_leaves_row_unchanged(monkeypatch: pytest.MonkeyPatch) -> None:
+    """Success-only write-back: a raising probe persists nothing."""
+    before_ingest = datetime(2026, 5, 1, 9, 0, tzinfo=UTC)
+    collection = await _insert_collection(
+        status=STATUS_READY,
+        doc_count=42,
+        last_ingested_at=before_ingest,
+        readiness={"probe_method": "corpus-status"},
+    )
+
+    async def _raising_probe(
+        self: SearchBackend, operator: Operator, *, backend_ref: Any = None
+    ) -> BackendReadiness:
+        raise CorpusUnavailable("corpus unreachable: ConnectError")
+
+    monkeypatch.setattr(CorpusHttpBackend, "probe", _raising_probe)
+
+    sm = get_sessionmaker()
+    # The route's transaction (session.begin()) is what rolls back; emulate
+    # it here so the assertion proves the row survives a failed probe.
+    with pytest.raises(CorpusUnavailable):
+        async with sm() as session, session.begin():
+            row = await session.get(DocCollection, collection.id)
+            assert row is not None
+            await probe_collection(session, _make_operator(), row)
+
+    async with sm() as session:
+        row = await session.get(DocCollection, collection.id)
+        assert row is not None
+        assert row.status == STATUS_READY
+        assert row.doc_count == 42
+        assert row.last_ingested_at.replace(tzinfo=UTC) == before_ingest
+
+
+@pytest.mark.asyncio
+async def test_set_collection_enabled_is_idempotent() -> None:
+    collection = await _insert_collection(status=STATUS_READY)
+    sm = get_sessionmaker()
+    async with sm() as session, session.begin():
+        row = await session.get(DocCollection, collection.id)
+        assert row is not None
+        # Disable → change; disable again → no-op.
+        assert await set_collection_enabled(session, row, enabled=False) is True
+        assert await set_collection_enabled(session, row, enabled=False) is False
+        assert row.status == STATUS_DISABLED
+
+
+# ---------------------------------------------------------------------------
+# Per-project rebuild serialization (in-adapter lock)
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.asyncio
+async def test_concurrent_probes_same_project_serialize(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """Two probes against the same endpoint do not overlap inside the adapter."""
+    backend = CorpusHttpBackend()
+    overlap = {"max_in_flight": 0, "in_flight": 0}
+    gate = asyncio.Event()
+
+    async def _slow_status(
+        operator: Operator, *, corpus_url: str | None = None, audience: str | None = None
+    ) -> CorpusStatusResponse:
+        overlap["in_flight"] += 1
+        overlap["max_in_flight"] = max(overlap["max_in_flight"], overlap["in_flight"])
+        # Yield so a second coroutine gets a chance to run before this one
+        # releases — if the lock were absent, both would be in-flight here.
+        await gate.wait()
+        overlap["in_flight"] -= 1
+        return CorpusStatusResponse(index_built=True, doc_count=1)
+
+    monkeypatch.setattr(
+        "meho_backplane.docs_search.backends.corpus_http.corpus_status", _slow_status
+    )
+
+    ref = {"endpoint": _CORPUS_URL}
+    operator = _make_operator()
+    task_a = asyncio.create_task(backend.probe(operator, backend_ref=ref))
+    task_b = asyncio.create_task(backend.probe(operator, backend_ref=ref))
+    await asyncio.sleep(0.05)  # let both tasks reach the lock / status call
+    gate.set()
+    await asyncio.gather(task_a, task_b)
+
+    # Same-project lock means at most one probe is ever inside the corpus
+    # round-trip — never two concurrently.
+    assert overlap["max_in_flight"] == 1
+
+
+@pytest.mark.asyncio
+async def test_concurrent_probes_different_projects_run_concurrently(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """Probes against distinct endpoints are not serialized against each other."""
+    backend = CorpusHttpBackend()
+    overlap = {"max_in_flight": 0, "in_flight": 0}
+    gate = asyncio.Event()
+
+    async def _slow_status(
+        operator: Operator, *, corpus_url: str | None = None, audience: str | None = None
+    ) -> CorpusStatusResponse:
+        overlap["in_flight"] += 1
+        overlap["max_in_flight"] = max(overlap["max_in_flight"], overlap["in_flight"])
+        await gate.wait()
+        overlap["in_flight"] -= 1
+        return CorpusStatusResponse(index_built=True)
+
+    monkeypatch.setattr(
+        "meho_backplane.docs_search.backends.corpus_http.corpus_status", _slow_status
+    )
+
+    operator = _make_operator()
+    task_a = asyncio.create_task(
+        backend.probe(operator, backend_ref={"endpoint": "https://a.test/v1/search"})
+    )
+    task_b = asyncio.create_task(
+        backend.probe(operator, backend_ref={"endpoint": "https://b.test/v1/search"})
+    )
+    await asyncio.sleep(0.05)
+    gate.set()
+    await asyncio.gather(task_a, task_b)
+
+    # Different-project locks → both probes in-flight at once.
+    assert overlap["max_in_flight"] == 2
+
+
+# ---------------------------------------------------------------------------
+# /ready backend reachability probe
+# ---------------------------------------------------------------------------
+
+
+def test_ready_probe_ok_when_corpus_configured() -> None:
+    result = docs_backends_readiness_probe()
+    assert result.name == "docs_backends"
+    assert result.ok is True
+
+
+def test_ready_probe_fails_when_backend_unconfigured(monkeypatch: pytest.MonkeyPatch) -> None:
+    monkeypatch.setenv("CORPUS_URL", "")
+    get_settings.cache_clear()
+    result = docs_backends_readiness_probe()
+    assert result.ok is False
+    assert "corpus-http" in (result.detail or "")
+
+
+# ---------------------------------------------------------------------------
+# REST routes
+# ---------------------------------------------------------------------------
+
+
+def _build_app() -> FastAPI:
+    from meho_backplane.api.v1.doc_collections import router as doc_collections_router
+
+    app = FastAPI()
+    app.add_middleware(AuditMiddleware)
+    app.add_middleware(RequestContextMiddleware)
+    app.include_router(doc_collections_router)
+    return app
+
+
+@pytest.fixture
+def client() -> Iterator[TestClient]:
+    reset_engine_for_testing()
+    yield TestClient(_build_app())
+
+
+def _admin_token(key: Any) -> str:
+    return mint_token(key, sub="admin-1", tenant_role=TenantRole.TENANT_ADMIN.value)
+
+
+def _operator_token(key: Any) -> str:
+    return mint_token(key, sub="op-1", tenant_role=TenantRole.OPERATOR.value)
+
+
+@pytest.mark.asyncio
+async def test_probe_route_writes_back_and_returns_readiness(
+    client: TestClient, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    await _insert_collection(collection_key="vmware", status=STATUS_PROVISIONING)
+
+    async def _fake_probe(
+        self: SearchBackend, operator: Operator, *, backend_ref: Any = None
+    ) -> BackendReadiness:
+        return BackendReadiness(reachable=True, index_built=True, doc_count=5)
+
+    monkeypatch.setattr(CorpusHttpBackend, "probe", _fake_probe)
+
+    key = make_rsa_keypair("kid-A")
+    with respx.mock as mock_router:
+        mock_discovery_and_jwks(mock_router, public_jwks(key))
+        resp = client.post(
+            "/api/v1/doc_collections/vmware/probe",
+            headers={"Authorization": f"Bearer {_admin_token(key)}"},
+        )
+    assert resp.status_code == 200
+    body = resp.json()
+    assert body["reachable"] is True
+    assert body["index_built"] is True
+    assert body["doc_count"] == 5
+
+    sm = get_sessionmaker()
+    async with sm() as session:
+        from sqlalchemy import select
+
+        row = (
+            await session.execute(
+                select(DocCollection).where(DocCollection.collection_key == "vmware")
+            )
+        ).scalar_one()
+        assert row.status == STATUS_READY
+
+
+def test_probe_route_requires_tenant_admin(client: TestClient) -> None:
+    key = make_rsa_keypair("kid-A")
+    with respx.mock as mock_router:
+        mock_discovery_and_jwks(mock_router, public_jwks(key))
+        resp = client.post(
+            "/api/v1/doc_collections/vmware/probe",
+            headers={"Authorization": f"Bearer {_operator_token(key)}"},
+        )
+    assert resp.status_code == 403
+
+
+def test_probe_route_unknown_key_404(client: TestClient) -> None:
+    key = make_rsa_keypair("kid-A")
+    with respx.mock as mock_router:
+        mock_discovery_and_jwks(mock_router, public_jwks(key))
+        resp = client.post(
+            "/api/v1/doc_collections/nope/probe",
+            headers={"Authorization": f"Bearer {_admin_token(key)}"},
+        )
+    assert resp.status_code == 404
+
+
+@pytest.mark.asyncio
+async def test_probe_route_backend_unavailable_503_row_untouched(
+    client: TestClient, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    await _insert_collection(collection_key="vmware", status=STATUS_PROVISIONING)
+
+    async def _raising_probe(
+        self: SearchBackend, operator: Operator, *, backend_ref: Any = None
+    ) -> BackendReadiness:
+        raise CorpusUnavailable("corpus unreachable: ConnectError")
+
+    monkeypatch.setattr(CorpusHttpBackend, "probe", _raising_probe)
+
+    key = make_rsa_keypair("kid-A")
+    with respx.mock as mock_router:
+        mock_discovery_and_jwks(mock_router, public_jwks(key))
+        resp = client.post(
+            "/api/v1/doc_collections/vmware/probe",
+            headers={"Authorization": f"Bearer {_admin_token(key)}"},
+        )
+    assert resp.status_code == 503
+
+    sm = get_sessionmaker()
+    async with sm() as session:
+        from sqlalchemy import select
+
+        row = (
+            await session.execute(
+                select(DocCollection).where(DocCollection.collection_key == "vmware")
+            )
+        ).scalar_one()
+        # Unchanged: a failed probe is rolled back by the route transaction.
+        assert row.status == STATUS_PROVISIONING
+        assert row.doc_count is None
+
+
+@pytest.mark.asyncio
+async def test_disable_then_enable_route_roundtrip(client: TestClient) -> None:
+    await _insert_collection(collection_key="vmware", status=STATUS_READY)
+    key = make_rsa_keypair("kid-A")
+    with respx.mock as mock_router:
+        mock_discovery_and_jwks(mock_router, public_jwks(key))
+        disable = client.post(
+            "/api/v1/doc_collections/vmware/disable",
+            headers={"Authorization": f"Bearer {_admin_token(key)}"},
+        )
+        enable = client.post(
+            "/api/v1/doc_collections/vmware/enable",
+            headers={"Authorization": f"Bearer {_admin_token(key)}"},
+        )
+    assert disable.status_code == 204
+    assert enable.status_code == 204
+
+    sm = get_sessionmaker()
+    async with sm() as session:
+        from sqlalchemy import select
+
+        row = (
+            await session.execute(
+                select(DocCollection).where(DocCollection.collection_key == "vmware")
+            )
+        ).scalar_one()
+        # enable returns a disabled collection to provisioning (a probe
+        # then promotes it).
+        assert row.status == STATUS_PROVISIONING

--- a/backend/tests/test_docs_backends_router.py
+++ b/backend/tests/test_docs_backends_router.py
@@ -387,10 +387,16 @@ async def test_adapter_blank_ref_endpoint_uses_legacy(monkeypatch: pytest.Monkey
     assert str(captured[0].url) == _CORPUS_URL
 
 
-async def test_adapter_does_not_implement_probe_yet() -> None:
-    """``probe`` is a T6 seam — it must fail loudly, not claim ready."""
+async def test_base_probe_seam_fails_loudly_when_unimplemented() -> None:
+    """An adapter that does not override ``probe`` raises, never claims ready.
+
+    T6 (#1555) implements ``probe`` on ``CorpusHttpBackend``; the base
+    seam still fails loudly for an adapter (here ``_FakeBackend``) that
+    has not gained a liveness check, so it can never silently report
+    "ready" — the contract the base default guards.
+    """
     with pytest.raises(NotImplementedError):
-        await CorpusHttpBackend().probe()
+        await _FakeBackend().probe(_make_operator())
 
 
 # ---------------------------------------------------------------------------

--- a/cli/api/openapi.json
+++ b/cli/api/openapi.json
@@ -459,6 +459,172 @@
         }
       }
     },
+    "/api/v1/doc_collections/{collection_key}/probe": {
+      "post": {
+        "tags": [
+          "docs"
+        ],
+        "summary": "Probe Collection Endpoint",
+        "description": "Probe a collection's backend and persist its liveness on success.\n\nResolves the collection tenant-first, reads its backend's typed\nreadiness (forwarding the operator JWT under the operator identity),\nand on success persists ``readiness`` / ``doc_count`` /\n``last_ingested_at`` + the ``status`` transition onto the row. A\nfailed probe is mapped to 503 and leaves the row unchanged: the\n``get_session`` transaction rolls back on the raise, so nothing the\nservice flushed survives.",
+        "operationId": "probe_collection_endpoint_api_v1_doc_collections__collection_key__probe_post",
+        "parameters": [
+          {
+            "name": "collection_key",
+            "in": "path",
+            "required": true,
+            "schema": {
+              "type": "string",
+              "title": "Collection Key"
+            }
+          },
+          {
+            "name": "authorization",
+            "in": "header",
+            "required": false,
+            "schema": {
+              "type": "string",
+              "nullable": true,
+              "title": "Authorization"
+            }
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "Successful Response",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/BackendReadiness"
+                }
+              }
+            }
+          },
+          "404": {
+            "description": "No collection with this key is visible to the tenant."
+          },
+          "409": {
+            "description": "The probe's readiness implies a status the lifecycle forbids from the collection's current state (e.g. probing a disabled collection)."
+          },
+          "503": {
+            "description": "The collection's backend is unavailable \u2014 unconfigured, unreachable, non-2xx / malformed, or routes to no registered backend. Fail-closed; the row's cached liveness is left untouched (success-only write-back)."
+          },
+          "422": {
+            "description": "Validation Error",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/HTTPValidationError"
+                }
+              }
+            }
+          }
+        }
+      }
+    },
+    "/api/v1/doc_collections/{collection_key}/enable": {
+      "post": {
+        "tags": [
+          "docs"
+        ],
+        "summary": "Enable Collection Endpoint",
+        "description": "Return a disabled collection to service (\u2192 ``provisioning``).\n\nIdempotent: re-enabling an already-live collection writes nothing and\nreturns 204. A forbidden source state raises 409 via the lifecycle\nguard. A follow-up probe promotes the re-enabled collection to\n``ready`` once its index confirms.",
+        "operationId": "enable_collection_endpoint_api_v1_doc_collections__collection_key__enable_post",
+        "parameters": [
+          {
+            "name": "collection_key",
+            "in": "path",
+            "required": true,
+            "schema": {
+              "type": "string",
+              "title": "Collection Key"
+            }
+          },
+          {
+            "name": "authorization",
+            "in": "header",
+            "required": false,
+            "schema": {
+              "type": "string",
+              "nullable": true,
+              "title": "Authorization"
+            }
+          }
+        ],
+        "responses": {
+          "204": {
+            "description": "Successful Response"
+          },
+          "404": {
+            "description": "No collection with this key is visible to the tenant."
+          },
+          "409": {
+            "description": "Enable is forbidden from the collection's current state."
+          },
+          "422": {
+            "description": "Validation Error",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/HTTPValidationError"
+                }
+              }
+            }
+          }
+        }
+      }
+    },
+    "/api/v1/doc_collections/{collection_key}/disable": {
+      "post": {
+        "tags": [
+          "docs"
+        ],
+        "summary": "Disable Collection Endpoint",
+        "description": "Hide a collection from search (\u2192 ``disabled``).\n\nIdempotent and lifecycle-guarded \u2014 same shape as the enable handler.\nA disabled collection fails ``search_docs`` typed (403) via the T3\nsearch-time guard rather than returning an empty result.",
+        "operationId": "disable_collection_endpoint_api_v1_doc_collections__collection_key__disable_post",
+        "parameters": [
+          {
+            "name": "collection_key",
+            "in": "path",
+            "required": true,
+            "schema": {
+              "type": "string",
+              "title": "Collection Key"
+            }
+          },
+          {
+            "name": "authorization",
+            "in": "header",
+            "required": false,
+            "schema": {
+              "type": "string",
+              "nullable": true,
+              "title": "Authorization"
+            }
+          }
+        ],
+        "responses": {
+          "204": {
+            "description": "Successful Response"
+          },
+          "404": {
+            "description": "No collection with this key is visible to the tenant."
+          },
+          "409": {
+            "description": "Disable is forbidden from the collection's current state."
+          },
+          "422": {
+            "description": "Validation Error",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/HTTPValidationError"
+                }
+              }
+            }
+          }
+        }
+      }
+    },
     "/api/v1/targets": {
       "get": {
         "tags": [
@@ -10789,6 +10955,41 @@
         ],
         "title": "AuthModel",
         "description": "Per-target identity model per v0.1-spec L447-454."
+      },
+      "BackendReadiness": {
+        "properties": {
+          "reachable": {
+            "type": "boolean",
+            "title": "Reachable"
+          },
+          "index_built": {
+            "type": "boolean",
+            "title": "Index Built"
+          },
+          "doc_count": {
+            "type": "integer",
+            "nullable": true,
+            "title": "Doc Count"
+          },
+          "last_ingested_at": {
+            "type": "string",
+            "format": "date-time",
+            "nullable": true,
+            "title": "Last Ingested At"
+          },
+          "detail": {
+            "additionalProperties": true,
+            "type": "object",
+            "title": "Detail"
+          }
+        },
+        "type": "object",
+        "required": [
+          "reachable",
+          "index_built"
+        ],
+        "title": "BackendReadiness",
+        "description": "Typed result of a :meth:`SearchBackend.probe` call (T6 #1555).\n\nThe liveness snapshot a probe reads back from a collection's backend.\nThe collection-probe route persists ``doc_count`` / ``last_ingested_at``\n/ ``readiness`` onto the ``doc_collections`` row and transitions\n``status`` from this result **on success only** \u2014 modelled on\n:class:`~meho_backplane.connectors.schemas.FingerprintResult`, which\n``probe_target`` caches onto ``Target.fingerprint`` the same way.\n\n``index_built`` is the managed-RAG footgun this surface exists to\nhide: a managed-RAG ANN index answers searches only once it has been\nexplicitly (re)built, and rebuilds serialize per project. ``False``\nmeans the backend is reachable but the index is not yet answerable \u2014\nthe probe maps it to ``status='rebuilding'`` / ``'provisioning'`` so\nthe search path can fail typed rather than return a silent empty 200.\n\nFrozen so a persisted snapshot cannot be mutated after the probe\nreads it. ``detail`` is the free-form JSON the ``readiness`` column\nstores verbatim for operator diagnostics (never agent-facing)."
       },
       "BaselineMetricsOverride": {
         "properties": {

--- a/cli/internal/api/client.gen.go
+++ b/cli/internal/api/client.gen.go
@@ -998,6 +998,33 @@ type AuthConfigResponse struct {
 // AuthModel Per-target identity model per v0.1-spec L447-454.
 type AuthModel string
 
+// BackendReadiness Typed result of a :meth:`SearchBackend.probe` call (T6 #1555).
+//
+// The liveness snapshot a probe reads back from a collection's backend.
+// The collection-probe route persists “doc_count“ / “last_ingested_at“
+// / “readiness“ onto the “doc_collections“ row and transitions
+// “status“ from this result **on success only** — modelled on
+// :class:`~meho_backplane.connectors.schemas.FingerprintResult`, which
+// “probe_target“ caches onto “Target.fingerprint“ the same way.
+//
+// “index_built“ is the managed-RAG footgun this surface exists to
+// hide: a managed-RAG ANN index answers searches only once it has been
+// explicitly (re)built, and rebuilds serialize per project. “False“
+// means the backend is reachable but the index is not yet answerable —
+// the probe maps it to “status='rebuilding'“ / “'provisioning'“ so
+// the search path can fail typed rather than return a silent empty 200.
+//
+// Frozen so a persisted snapshot cannot be mutated after the probe
+// reads it. “detail“ is the free-form JSON the “readiness“ column
+// stores verbatim for operator diagnostics (never agent-facing).
+type BackendReadiness struct {
+	Detail         *map[string]interface{} `json:"detail,omitempty"`
+	DocCount       *int                    `json:"doc_count"`
+	IndexBuilt     bool                    `json:"index_built"`
+	LastIngestedAt *time.Time              `json:"last_ingested_at"`
+	Reachable      bool                    `json:"reachable"`
+}
+
 // BaselineMetricsOverride Per-surface baseline metrics supplied by the caller.
 //
 // Criterion 4 (MEHO ≥ baseline) needs side-by-side numbers from a
@@ -5182,6 +5209,21 @@ type ListHistoryApiV1ConventionsSlugHistoryGetParams struct {
 	Authorization *string `json:"authorization,omitempty"`
 }
 
+// DisableCollectionEndpointApiV1DocCollectionsCollectionKeyDisablePostParams defines parameters for DisableCollectionEndpointApiV1DocCollectionsCollectionKeyDisablePost.
+type DisableCollectionEndpointApiV1DocCollectionsCollectionKeyDisablePostParams struct {
+	Authorization *string `json:"authorization,omitempty"`
+}
+
+// EnableCollectionEndpointApiV1DocCollectionsCollectionKeyEnablePostParams defines parameters for EnableCollectionEndpointApiV1DocCollectionsCollectionKeyEnablePost.
+type EnableCollectionEndpointApiV1DocCollectionsCollectionKeyEnablePostParams struct {
+	Authorization *string `json:"authorization,omitempty"`
+}
+
+// ProbeCollectionEndpointApiV1DocCollectionsCollectionKeyProbePostParams defines parameters for ProbeCollectionEndpointApiV1DocCollectionsCollectionKeyProbePost.
+type ProbeCollectionEndpointApiV1DocCollectionsCollectionKeyProbePostParams struct {
+	Authorization *string `json:"authorization,omitempty"`
+}
+
 // FeedEndpointApiV1FeedGetParams defines parameters for FeedEndpointApiV1FeedGet.
 type FeedEndpointApiV1FeedGetParams struct {
 	// OpClass Filter by event op_class.
@@ -6843,6 +6885,15 @@ type ClientInterface interface {
 	// ListHistoryApiV1ConventionsSlugHistoryGet request
 	ListHistoryApiV1ConventionsSlugHistoryGet(ctx context.Context, slug string, params *ListHistoryApiV1ConventionsSlugHistoryGetParams, reqEditors ...RequestEditorFn) (*http.Response, error)
 
+	// DisableCollectionEndpointApiV1DocCollectionsCollectionKeyDisablePost request
+	DisableCollectionEndpointApiV1DocCollectionsCollectionKeyDisablePost(ctx context.Context, collectionKey string, params *DisableCollectionEndpointApiV1DocCollectionsCollectionKeyDisablePostParams, reqEditors ...RequestEditorFn) (*http.Response, error)
+
+	// EnableCollectionEndpointApiV1DocCollectionsCollectionKeyEnablePost request
+	EnableCollectionEndpointApiV1DocCollectionsCollectionKeyEnablePost(ctx context.Context, collectionKey string, params *EnableCollectionEndpointApiV1DocCollectionsCollectionKeyEnablePostParams, reqEditors ...RequestEditorFn) (*http.Response, error)
+
+	// ProbeCollectionEndpointApiV1DocCollectionsCollectionKeyProbePost request
+	ProbeCollectionEndpointApiV1DocCollectionsCollectionKeyProbePost(ctx context.Context, collectionKey string, params *ProbeCollectionEndpointApiV1DocCollectionsCollectionKeyProbePostParams, reqEditors ...RequestEditorFn) (*http.Response, error)
+
 	// FeedEndpointApiV1FeedGet request
 	FeedEndpointApiV1FeedGet(ctx context.Context, params *FeedEndpointApiV1FeedGetParams, reqEditors ...RequestEditorFn) (*http.Response, error)
 
@@ -8048,6 +8099,42 @@ func (c *Client) UpdateConventionApiV1ConventionsSlugPatch(ctx context.Context, 
 
 func (c *Client) ListHistoryApiV1ConventionsSlugHistoryGet(ctx context.Context, slug string, params *ListHistoryApiV1ConventionsSlugHistoryGetParams, reqEditors ...RequestEditorFn) (*http.Response, error) {
 	req, err := NewListHistoryApiV1ConventionsSlugHistoryGetRequest(c.Server, slug, params)
+	if err != nil {
+		return nil, err
+	}
+	req = req.WithContext(ctx)
+	if err := c.applyEditors(ctx, req, reqEditors); err != nil {
+		return nil, err
+	}
+	return c.Client.Do(req)
+}
+
+func (c *Client) DisableCollectionEndpointApiV1DocCollectionsCollectionKeyDisablePost(ctx context.Context, collectionKey string, params *DisableCollectionEndpointApiV1DocCollectionsCollectionKeyDisablePostParams, reqEditors ...RequestEditorFn) (*http.Response, error) {
+	req, err := NewDisableCollectionEndpointApiV1DocCollectionsCollectionKeyDisablePostRequest(c.Server, collectionKey, params)
+	if err != nil {
+		return nil, err
+	}
+	req = req.WithContext(ctx)
+	if err := c.applyEditors(ctx, req, reqEditors); err != nil {
+		return nil, err
+	}
+	return c.Client.Do(req)
+}
+
+func (c *Client) EnableCollectionEndpointApiV1DocCollectionsCollectionKeyEnablePost(ctx context.Context, collectionKey string, params *EnableCollectionEndpointApiV1DocCollectionsCollectionKeyEnablePostParams, reqEditors ...RequestEditorFn) (*http.Response, error) {
+	req, err := NewEnableCollectionEndpointApiV1DocCollectionsCollectionKeyEnablePostRequest(c.Server, collectionKey, params)
+	if err != nil {
+		return nil, err
+	}
+	req = req.WithContext(ctx)
+	if err := c.applyEditors(ctx, req, reqEditors); err != nil {
+		return nil, err
+	}
+	return c.Client.Do(req)
+}
+
+func (c *Client) ProbeCollectionEndpointApiV1DocCollectionsCollectionKeyProbePost(ctx context.Context, collectionKey string, params *ProbeCollectionEndpointApiV1DocCollectionsCollectionKeyProbePostParams, reqEditors ...RequestEditorFn) (*http.Response, error) {
+	req, err := NewProbeCollectionEndpointApiV1DocCollectionsCollectionKeyProbePostRequest(c.Server, collectionKey, params)
 	if err != nil {
 		return nil, err
 	}
@@ -12760,6 +12847,153 @@ func NewListHistoryApiV1ConventionsSlugHistoryGetRequest(server string, slug str
 	}
 
 	req, err := http.NewRequest("GET", queryURL.String(), nil)
+	if err != nil {
+		return nil, err
+	}
+
+	if params != nil {
+
+		if params.Authorization != nil {
+			var headerParam0 string
+
+			headerParam0, err = runtime.StyleParamWithLocation("simple", false, "authorization", runtime.ParamLocationHeader, *params.Authorization)
+			if err != nil {
+				return nil, err
+			}
+
+			req.Header.Set("authorization", headerParam0)
+		}
+
+	}
+
+	return req, nil
+}
+
+// NewDisableCollectionEndpointApiV1DocCollectionsCollectionKeyDisablePostRequest generates requests for DisableCollectionEndpointApiV1DocCollectionsCollectionKeyDisablePost
+func NewDisableCollectionEndpointApiV1DocCollectionsCollectionKeyDisablePostRequest(server string, collectionKey string, params *DisableCollectionEndpointApiV1DocCollectionsCollectionKeyDisablePostParams) (*http.Request, error) {
+	var err error
+
+	var pathParam0 string
+
+	pathParam0, err = runtime.StyleParamWithLocation("simple", false, "collection_key", runtime.ParamLocationPath, collectionKey)
+	if err != nil {
+		return nil, err
+	}
+
+	serverURL, err := url.Parse(server)
+	if err != nil {
+		return nil, err
+	}
+
+	operationPath := fmt.Sprintf("/api/v1/doc_collections/%s/disable", pathParam0)
+	if operationPath[0] == '/' {
+		operationPath = "." + operationPath
+	}
+
+	queryURL, err := serverURL.Parse(operationPath)
+	if err != nil {
+		return nil, err
+	}
+
+	req, err := http.NewRequest("POST", queryURL.String(), nil)
+	if err != nil {
+		return nil, err
+	}
+
+	if params != nil {
+
+		if params.Authorization != nil {
+			var headerParam0 string
+
+			headerParam0, err = runtime.StyleParamWithLocation("simple", false, "authorization", runtime.ParamLocationHeader, *params.Authorization)
+			if err != nil {
+				return nil, err
+			}
+
+			req.Header.Set("authorization", headerParam0)
+		}
+
+	}
+
+	return req, nil
+}
+
+// NewEnableCollectionEndpointApiV1DocCollectionsCollectionKeyEnablePostRequest generates requests for EnableCollectionEndpointApiV1DocCollectionsCollectionKeyEnablePost
+func NewEnableCollectionEndpointApiV1DocCollectionsCollectionKeyEnablePostRequest(server string, collectionKey string, params *EnableCollectionEndpointApiV1DocCollectionsCollectionKeyEnablePostParams) (*http.Request, error) {
+	var err error
+
+	var pathParam0 string
+
+	pathParam0, err = runtime.StyleParamWithLocation("simple", false, "collection_key", runtime.ParamLocationPath, collectionKey)
+	if err != nil {
+		return nil, err
+	}
+
+	serverURL, err := url.Parse(server)
+	if err != nil {
+		return nil, err
+	}
+
+	operationPath := fmt.Sprintf("/api/v1/doc_collections/%s/enable", pathParam0)
+	if operationPath[0] == '/' {
+		operationPath = "." + operationPath
+	}
+
+	queryURL, err := serverURL.Parse(operationPath)
+	if err != nil {
+		return nil, err
+	}
+
+	req, err := http.NewRequest("POST", queryURL.String(), nil)
+	if err != nil {
+		return nil, err
+	}
+
+	if params != nil {
+
+		if params.Authorization != nil {
+			var headerParam0 string
+
+			headerParam0, err = runtime.StyleParamWithLocation("simple", false, "authorization", runtime.ParamLocationHeader, *params.Authorization)
+			if err != nil {
+				return nil, err
+			}
+
+			req.Header.Set("authorization", headerParam0)
+		}
+
+	}
+
+	return req, nil
+}
+
+// NewProbeCollectionEndpointApiV1DocCollectionsCollectionKeyProbePostRequest generates requests for ProbeCollectionEndpointApiV1DocCollectionsCollectionKeyProbePost
+func NewProbeCollectionEndpointApiV1DocCollectionsCollectionKeyProbePostRequest(server string, collectionKey string, params *ProbeCollectionEndpointApiV1DocCollectionsCollectionKeyProbePostParams) (*http.Request, error) {
+	var err error
+
+	var pathParam0 string
+
+	pathParam0, err = runtime.StyleParamWithLocation("simple", false, "collection_key", runtime.ParamLocationPath, collectionKey)
+	if err != nil {
+		return nil, err
+	}
+
+	serverURL, err := url.Parse(server)
+	if err != nil {
+		return nil, err
+	}
+
+	operationPath := fmt.Sprintf("/api/v1/doc_collections/%s/probe", pathParam0)
+	if operationPath[0] == '/' {
+		operationPath = "." + operationPath
+	}
+
+	queryURL, err := serverURL.Parse(operationPath)
+	if err != nil {
+		return nil, err
+	}
+
+	req, err := http.NewRequest("POST", queryURL.String(), nil)
 	if err != nil {
 		return nil, err
 	}
@@ -20087,6 +20321,15 @@ type ClientWithResponsesInterface interface {
 	// ListHistoryApiV1ConventionsSlugHistoryGetWithResponse request
 	ListHistoryApiV1ConventionsSlugHistoryGetWithResponse(ctx context.Context, slug string, params *ListHistoryApiV1ConventionsSlugHistoryGetParams, reqEditors ...RequestEditorFn) (*ListHistoryApiV1ConventionsSlugHistoryGetResponse, error)
 
+	// DisableCollectionEndpointApiV1DocCollectionsCollectionKeyDisablePostWithResponse request
+	DisableCollectionEndpointApiV1DocCollectionsCollectionKeyDisablePostWithResponse(ctx context.Context, collectionKey string, params *DisableCollectionEndpointApiV1DocCollectionsCollectionKeyDisablePostParams, reqEditors ...RequestEditorFn) (*DisableCollectionEndpointApiV1DocCollectionsCollectionKeyDisablePostResponse, error)
+
+	// EnableCollectionEndpointApiV1DocCollectionsCollectionKeyEnablePostWithResponse request
+	EnableCollectionEndpointApiV1DocCollectionsCollectionKeyEnablePostWithResponse(ctx context.Context, collectionKey string, params *EnableCollectionEndpointApiV1DocCollectionsCollectionKeyEnablePostParams, reqEditors ...RequestEditorFn) (*EnableCollectionEndpointApiV1DocCollectionsCollectionKeyEnablePostResponse, error)
+
+	// ProbeCollectionEndpointApiV1DocCollectionsCollectionKeyProbePostWithResponse request
+	ProbeCollectionEndpointApiV1DocCollectionsCollectionKeyProbePostWithResponse(ctx context.Context, collectionKey string, params *ProbeCollectionEndpointApiV1DocCollectionsCollectionKeyProbePostParams, reqEditors ...RequestEditorFn) (*ProbeCollectionEndpointApiV1DocCollectionsCollectionKeyProbePostResponse, error)
+
 	// FeedEndpointApiV1FeedGetWithResponse request
 	FeedEndpointApiV1FeedGetWithResponse(ctx context.Context, params *FeedEndpointApiV1FeedGetParams, reqEditors ...RequestEditorFn) (*FeedEndpointApiV1FeedGetResponse, error)
 
@@ -21614,6 +21857,73 @@ func (r ListHistoryApiV1ConventionsSlugHistoryGetResponse) Status() string {
 
 // StatusCode returns HTTPResponse.StatusCode
 func (r ListHistoryApiV1ConventionsSlugHistoryGetResponse) StatusCode() int {
+	if r.HTTPResponse != nil {
+		return r.HTTPResponse.StatusCode
+	}
+	return 0
+}
+
+type DisableCollectionEndpointApiV1DocCollectionsCollectionKeyDisablePostResponse struct {
+	Body         []byte
+	HTTPResponse *http.Response
+	JSON422      *HTTPValidationError
+}
+
+// Status returns HTTPResponse.Status
+func (r DisableCollectionEndpointApiV1DocCollectionsCollectionKeyDisablePostResponse) Status() string {
+	if r.HTTPResponse != nil {
+		return r.HTTPResponse.Status
+	}
+	return http.StatusText(0)
+}
+
+// StatusCode returns HTTPResponse.StatusCode
+func (r DisableCollectionEndpointApiV1DocCollectionsCollectionKeyDisablePostResponse) StatusCode() int {
+	if r.HTTPResponse != nil {
+		return r.HTTPResponse.StatusCode
+	}
+	return 0
+}
+
+type EnableCollectionEndpointApiV1DocCollectionsCollectionKeyEnablePostResponse struct {
+	Body         []byte
+	HTTPResponse *http.Response
+	JSON422      *HTTPValidationError
+}
+
+// Status returns HTTPResponse.Status
+func (r EnableCollectionEndpointApiV1DocCollectionsCollectionKeyEnablePostResponse) Status() string {
+	if r.HTTPResponse != nil {
+		return r.HTTPResponse.Status
+	}
+	return http.StatusText(0)
+}
+
+// StatusCode returns HTTPResponse.StatusCode
+func (r EnableCollectionEndpointApiV1DocCollectionsCollectionKeyEnablePostResponse) StatusCode() int {
+	if r.HTTPResponse != nil {
+		return r.HTTPResponse.StatusCode
+	}
+	return 0
+}
+
+type ProbeCollectionEndpointApiV1DocCollectionsCollectionKeyProbePostResponse struct {
+	Body         []byte
+	HTTPResponse *http.Response
+	JSON200      *BackendReadiness
+	JSON422      *HTTPValidationError
+}
+
+// Status returns HTTPResponse.Status
+func (r ProbeCollectionEndpointApiV1DocCollectionsCollectionKeyProbePostResponse) Status() string {
+	if r.HTTPResponse != nil {
+		return r.HTTPResponse.Status
+	}
+	return http.StatusText(0)
+}
+
+// StatusCode returns HTTPResponse.StatusCode
+func (r ProbeCollectionEndpointApiV1DocCollectionsCollectionKeyProbePostResponse) StatusCode() int {
 	if r.HTTPResponse != nil {
 		return r.HTTPResponse.StatusCode
 	}
@@ -24773,6 +25083,33 @@ func (c *ClientWithResponses) ListHistoryApiV1ConventionsSlugHistoryGetWithRespo
 	return ParseListHistoryApiV1ConventionsSlugHistoryGetResponse(rsp)
 }
 
+// DisableCollectionEndpointApiV1DocCollectionsCollectionKeyDisablePostWithResponse request returning *DisableCollectionEndpointApiV1DocCollectionsCollectionKeyDisablePostResponse
+func (c *ClientWithResponses) DisableCollectionEndpointApiV1DocCollectionsCollectionKeyDisablePostWithResponse(ctx context.Context, collectionKey string, params *DisableCollectionEndpointApiV1DocCollectionsCollectionKeyDisablePostParams, reqEditors ...RequestEditorFn) (*DisableCollectionEndpointApiV1DocCollectionsCollectionKeyDisablePostResponse, error) {
+	rsp, err := c.DisableCollectionEndpointApiV1DocCollectionsCollectionKeyDisablePost(ctx, collectionKey, params, reqEditors...)
+	if err != nil {
+		return nil, err
+	}
+	return ParseDisableCollectionEndpointApiV1DocCollectionsCollectionKeyDisablePostResponse(rsp)
+}
+
+// EnableCollectionEndpointApiV1DocCollectionsCollectionKeyEnablePostWithResponse request returning *EnableCollectionEndpointApiV1DocCollectionsCollectionKeyEnablePostResponse
+func (c *ClientWithResponses) EnableCollectionEndpointApiV1DocCollectionsCollectionKeyEnablePostWithResponse(ctx context.Context, collectionKey string, params *EnableCollectionEndpointApiV1DocCollectionsCollectionKeyEnablePostParams, reqEditors ...RequestEditorFn) (*EnableCollectionEndpointApiV1DocCollectionsCollectionKeyEnablePostResponse, error) {
+	rsp, err := c.EnableCollectionEndpointApiV1DocCollectionsCollectionKeyEnablePost(ctx, collectionKey, params, reqEditors...)
+	if err != nil {
+		return nil, err
+	}
+	return ParseEnableCollectionEndpointApiV1DocCollectionsCollectionKeyEnablePostResponse(rsp)
+}
+
+// ProbeCollectionEndpointApiV1DocCollectionsCollectionKeyProbePostWithResponse request returning *ProbeCollectionEndpointApiV1DocCollectionsCollectionKeyProbePostResponse
+func (c *ClientWithResponses) ProbeCollectionEndpointApiV1DocCollectionsCollectionKeyProbePostWithResponse(ctx context.Context, collectionKey string, params *ProbeCollectionEndpointApiV1DocCollectionsCollectionKeyProbePostParams, reqEditors ...RequestEditorFn) (*ProbeCollectionEndpointApiV1DocCollectionsCollectionKeyProbePostResponse, error) {
+	rsp, err := c.ProbeCollectionEndpointApiV1DocCollectionsCollectionKeyProbePost(ctx, collectionKey, params, reqEditors...)
+	if err != nil {
+		return nil, err
+	}
+	return ParseProbeCollectionEndpointApiV1DocCollectionsCollectionKeyProbePostResponse(rsp)
+}
+
 // FeedEndpointApiV1FeedGetWithResponse request returning *FeedEndpointApiV1FeedGetResponse
 func (c *ClientWithResponses) FeedEndpointApiV1FeedGetWithResponse(ctx context.Context, params *FeedEndpointApiV1FeedGetParams, reqEditors ...RequestEditorFn) (*FeedEndpointApiV1FeedGetResponse, error) {
 	rsp, err := c.FeedEndpointApiV1FeedGet(ctx, params, reqEditors...)
@@ -27672,6 +28009,91 @@ func ParseListHistoryApiV1ConventionsSlugHistoryGetResponse(rsp *http.Response) 
 	switch {
 	case strings.Contains(rsp.Header.Get("Content-Type"), "json") && rsp.StatusCode == 200:
 		var dest []ConventionHistoryEntry
+		if err := json.Unmarshal(bodyBytes, &dest); err != nil {
+			return nil, err
+		}
+		response.JSON200 = &dest
+
+	case strings.Contains(rsp.Header.Get("Content-Type"), "json") && rsp.StatusCode == 422:
+		var dest HTTPValidationError
+		if err := json.Unmarshal(bodyBytes, &dest); err != nil {
+			return nil, err
+		}
+		response.JSON422 = &dest
+
+	}
+
+	return response, nil
+}
+
+// ParseDisableCollectionEndpointApiV1DocCollectionsCollectionKeyDisablePostResponse parses an HTTP response from a DisableCollectionEndpointApiV1DocCollectionsCollectionKeyDisablePostWithResponse call
+func ParseDisableCollectionEndpointApiV1DocCollectionsCollectionKeyDisablePostResponse(rsp *http.Response) (*DisableCollectionEndpointApiV1DocCollectionsCollectionKeyDisablePostResponse, error) {
+	bodyBytes, err := io.ReadAll(rsp.Body)
+	defer func() { _ = rsp.Body.Close() }()
+	if err != nil {
+		return nil, err
+	}
+
+	response := &DisableCollectionEndpointApiV1DocCollectionsCollectionKeyDisablePostResponse{
+		Body:         bodyBytes,
+		HTTPResponse: rsp,
+	}
+
+	switch {
+	case strings.Contains(rsp.Header.Get("Content-Type"), "json") && rsp.StatusCode == 422:
+		var dest HTTPValidationError
+		if err := json.Unmarshal(bodyBytes, &dest); err != nil {
+			return nil, err
+		}
+		response.JSON422 = &dest
+
+	}
+
+	return response, nil
+}
+
+// ParseEnableCollectionEndpointApiV1DocCollectionsCollectionKeyEnablePostResponse parses an HTTP response from a EnableCollectionEndpointApiV1DocCollectionsCollectionKeyEnablePostWithResponse call
+func ParseEnableCollectionEndpointApiV1DocCollectionsCollectionKeyEnablePostResponse(rsp *http.Response) (*EnableCollectionEndpointApiV1DocCollectionsCollectionKeyEnablePostResponse, error) {
+	bodyBytes, err := io.ReadAll(rsp.Body)
+	defer func() { _ = rsp.Body.Close() }()
+	if err != nil {
+		return nil, err
+	}
+
+	response := &EnableCollectionEndpointApiV1DocCollectionsCollectionKeyEnablePostResponse{
+		Body:         bodyBytes,
+		HTTPResponse: rsp,
+	}
+
+	switch {
+	case strings.Contains(rsp.Header.Get("Content-Type"), "json") && rsp.StatusCode == 422:
+		var dest HTTPValidationError
+		if err := json.Unmarshal(bodyBytes, &dest); err != nil {
+			return nil, err
+		}
+		response.JSON422 = &dest
+
+	}
+
+	return response, nil
+}
+
+// ParseProbeCollectionEndpointApiV1DocCollectionsCollectionKeyProbePostResponse parses an HTTP response from a ProbeCollectionEndpointApiV1DocCollectionsCollectionKeyProbePostWithResponse call
+func ParseProbeCollectionEndpointApiV1DocCollectionsCollectionKeyProbePostResponse(rsp *http.Response) (*ProbeCollectionEndpointApiV1DocCollectionsCollectionKeyProbePostResponse, error) {
+	bodyBytes, err := io.ReadAll(rsp.Body)
+	defer func() { _ = rsp.Body.Close() }()
+	if err != nil {
+		return nil, err
+	}
+
+	response := &ProbeCollectionEndpointApiV1DocCollectionsCollectionKeyProbePostResponse{
+		Body:         bodyBytes,
+		HTTPResponse: rsp,
+	}
+
+	switch {
+	case strings.Contains(rsp.Header.Get("Content-Type"), "json") && rsp.StatusCode == 200:
+		var dest BackendReadiness
 		if err := json.Unmarshal(bodyBytes, &dest); err != nil {
 			return nil, err
 		}

--- a/cli/internal/cmd/docs/collections.go
+++ b/cli/internal/cmd/docs/collections.go
@@ -1,0 +1,362 @@
+// SPDX-License-Identifier: Apache-2.0
+// Copyright (c) 2026 evoila Group
+
+package docs
+
+import (
+	"context"
+	"fmt"
+	"io"
+	"net/http"
+	"time"
+
+	"github.com/spf13/cobra"
+
+	"github.com/evoila/meho/cli/internal/api"
+	"github.com/evoila/meho/cli/internal/backplane"
+	"github.com/evoila/meho/cli/internal/output"
+)
+
+// newCollectionsCmd returns the `meho docs collections` command tree.
+//
+// G4.6-T6 (#1555). The lifecycle/readiness face of the doc-collection
+// catalogue: probe a collection's backend to refresh its cached liveness
+// and toggle a collection in / out of search service. The catalogue
+// `list` verb is a sibling Task (T4 #1553) that adds to this same parent;
+// T6 ships the lifecycle verbs that mutate registry state.
+//
+// Role: tenant_admin on every verb (they mutate the doc_collections row),
+// matching the connector enable/disable gate. `provisioned` carries the
+// meho-docs capability resolved at command-tree-build time; an
+// unprovisioned tenant gets the typed `addon_not_provisioned` refusal
+// before any network call, the same gate `meho docs search` enforces.
+func newCollectionsCmd(provisioned bool) *cobra.Command {
+	cmd := &cobra.Command{
+		Use:   "collections",
+		Short: "Probe and toggle doc-collection backends (tenant_admin)",
+		Long: "collections operates the readiness + lifecycle of the " +
+			"doc-collection catalogue. `probe` refreshes a collection's " +
+			"cached liveness (doc count, last ingest, readiness) from its " +
+			"backend and transitions its status; `enable` / `disable` move " +
+			"a collection in / out of search service. A managed-RAG index " +
+			"answers searches only once it is built, and rebuilds serialize " +
+			"per project — `probe` surfaces that as the collection's status " +
+			"rather than hiding it behind a silent empty search result.",
+		Hidden:       !provisioned,
+		SilenceUsage: true,
+	}
+	cmd.AddCommand(newCollectionsProbeCmd(provisioned))
+	cmd.AddCommand(newCollectionsEnableCmd(provisioned))
+	cmd.AddCommand(newCollectionsDisableCmd(provisioned))
+	return cmd
+}
+
+// lifecycleOptions is the shared flag/arg set for the collections verbs.
+type lifecycleOptions struct {
+	CollectionKey     string
+	JSONOut           bool
+	BackplaneOverride string
+	// Provisioned carries the meho-docs capability gate. When false the
+	// verb refuses with the typed addon_not_provisioned error before
+	// touching the network.
+	Provisioned bool
+}
+
+func newCollectionsProbeCmd(provisioned bool) *cobra.Command {
+	var (
+		jsonOut           bool
+		backplaneOverride string
+	)
+	cmd := &cobra.Command{
+		Use:   "probe <collection-key>",
+		Short: "Probe a collection's backend and refresh its cached liveness",
+		Long: "probe calls POST /api/v1/doc_collections/<key>/probe: it " +
+			"queries the collection's backend for index readiness, doc " +
+			"count, and last-ingest time, persists them onto the " +
+			"doc_collections row on success only (a failed probe leaves the " +
+			"cached liveness untouched), and transitions the collection's " +
+			"status (provisioning/rebuilding → ready once the index is " +
+			"built). Renders the BackendReadiness result as a text table; " +
+			"--json emits the raw payload. A 503 means the backend is " +
+			"unavailable; the row is unchanged.",
+		Args:          cobra.ExactArgs(1),
+		SilenceUsage:  true,
+		SilenceErrors: true,
+		RunE: func(cmd *cobra.Command, args []string) error {
+			return runCollectionProbe(cmd, lifecycleOptions{
+				CollectionKey:     args[0],
+				JSONOut:           jsonOut,
+				BackplaneOverride: backplaneOverride,
+				Provisioned:       provisioned,
+			})
+		},
+	}
+	cmd.Flags().BoolVar(&jsonOut, "json", false,
+		"emit raw BackendReadiness JSON")
+	cmd.Flags().StringVar(&backplaneOverride, "backplane", "",
+		"backplane URL to query (defaults to the URL recorded by the most recent `meho login`)")
+	return cmd
+}
+
+func newCollectionsEnableCmd(provisioned bool) *cobra.Command {
+	var (
+		jsonOut           bool
+		backplaneOverride string
+	)
+	cmd := &cobra.Command{
+		Use:   "enable <collection-key>",
+		Short: "Return a disabled collection to search service",
+		Long: "enable calls POST /api/v1/doc_collections/<key>/enable, " +
+			"moving a disabled collection back to provisioning (a follow-up " +
+			"`probe` promotes it to ready once its index confirms). " +
+			"Idempotent: re-enabling a live collection is a no-op. A 409 " +
+			"means the move is forbidden from the collection's current state.",
+		Args:          cobra.ExactArgs(1),
+		SilenceUsage:  true,
+		SilenceErrors: true,
+		RunE: func(cmd *cobra.Command, args []string) error {
+			return runCollectionEnable(cmd, lifecycleOptions{
+				CollectionKey:     args[0],
+				JSONOut:           jsonOut,
+				BackplaneOverride: backplaneOverride,
+				Provisioned:       provisioned,
+			})
+		},
+	}
+	cmd.Flags().BoolVar(&jsonOut, "json", false, "emit a JSON status envelope")
+	cmd.Flags().StringVar(&backplaneOverride, "backplane", "",
+		"backplane URL to query (defaults to the URL recorded by the most recent `meho login`)")
+	return cmd
+}
+
+func newCollectionsDisableCmd(provisioned bool) *cobra.Command {
+	var (
+		jsonOut           bool
+		backplaneOverride string
+	)
+	cmd := &cobra.Command{
+		Use:   "disable <collection-key>",
+		Short: "Hide a collection from search service",
+		Long: "disable calls POST /api/v1/doc_collections/<key>/disable, " +
+			"moving the collection to disabled so search_docs fails typed " +
+			"(403) against it rather than returning an empty result. " +
+			"Idempotent: re-disabling an already-disabled collection is a " +
+			"no-op.",
+		Args:          cobra.ExactArgs(1),
+		SilenceUsage:  true,
+		SilenceErrors: true,
+		RunE: func(cmd *cobra.Command, args []string) error {
+			return runCollectionDisable(cmd, lifecycleOptions{
+				CollectionKey:     args[0],
+				JSONOut:           jsonOut,
+				BackplaneOverride: backplaneOverride,
+				Provisioned:       provisioned,
+			})
+		},
+	}
+	cmd.Flags().BoolVar(&jsonOut, "json", false, "emit a JSON status envelope")
+	cmd.Flags().StringVar(&backplaneOverride, "backplane", "",
+		"backplane URL to query (defaults to the URL recorded by the most recent `meho login`)")
+	return cmd
+}
+
+// gateLifecycle runs the shared pre-flight every collections verb needs:
+// the capability gate, a non-empty key, and backplane resolution. Returns
+// the resolved URL or a rendered error the caller returns directly.
+func gateLifecycle(cmd *cobra.Command, opts lifecycleOptions) (string, error) {
+	if !opts.Provisioned {
+		return "", errNotProvisioned(cmd, opts.JSONOut)
+	}
+	if opts.CollectionKey == "" {
+		return "", output.RenderError(
+			cmd.ErrOrStderr(),
+			output.Unexpected("a non-empty <collection-key> argument is required"),
+			opts.JSONOut,
+		)
+	}
+	backplaneURL, err := backplane.Resolve(opts.BackplaneOverride)
+	if err != nil {
+		return "", output.RenderError(cmd.ErrOrStderr(), backplane.ClassifyError(err), opts.JSONOut)
+	}
+	return backplaneURL, nil
+}
+
+func runCollectionProbe(cmd *cobra.Command, opts lifecycleOptions) error {
+	backplaneURL, gateErr := gateLifecycle(cmd, opts)
+	if gateErr != nil {
+		return gateErr
+	}
+	resp, err := probeCollection(cmd.Context(), backplaneURL, opts)
+	if err != nil {
+		return renderRequestError(cmd, backplaneURL, err, opts.JSONOut)
+	}
+	if resp.StatusCode() != http.StatusOK {
+		return renderHTTPStatus(cmd, backplaneURL, resp.StatusCode(), resp.Body, opts.JSONOut)
+	}
+	if resp.JSON200 == nil {
+		return output.RenderError(
+			cmd.ErrOrStderr(),
+			output.Unexpected(fmt.Sprintf(
+				"call %s: HTTP 200 without a BackendReadiness payload",
+				backplaneURL,
+			)),
+			opts.JSONOut,
+		)
+	}
+	if opts.JSONOut {
+		return output.PrintJSON(cmd.OutOrStdout(), resp.JSON200)
+	}
+	printReadiness(cmd.OutOrStdout(), opts.CollectionKey, resp.JSON200)
+	return nil
+}
+
+func runCollectionEnable(cmd *cobra.Command, opts lifecycleOptions) error {
+	backplaneURL, gateErr := gateLifecycle(cmd, opts)
+	if gateErr != nil {
+		return gateErr
+	}
+	resp, err := enableCollection(cmd.Context(), backplaneURL, opts)
+	if err != nil {
+		return renderRequestError(cmd, backplaneURL, err, opts.JSONOut)
+	}
+	return renderLifecycleResult(cmd, backplaneURL, opts, resp.StatusCode(), resp.Body, "enabled")
+}
+
+func runCollectionDisable(cmd *cobra.Command, opts lifecycleOptions) error {
+	backplaneURL, gateErr := gateLifecycle(cmd, opts)
+	if gateErr != nil {
+		return gateErr
+	}
+	resp, err := disableCollection(cmd.Context(), backplaneURL, opts)
+	if err != nil {
+		return renderRequestError(cmd, backplaneURL, err, opts.JSONOut)
+	}
+	return renderLifecycleResult(cmd, backplaneURL, opts, resp.StatusCode(), resp.Body, "disabled")
+}
+
+// renderLifecycleResult maps the 204 success of an enable/disable call to
+// the verb's confirmation output, deferring every non-204 status to the
+// shared HTTP-status renderer (404 / 409 / 403 / 401). The route returns
+// 204 on both the transition and the idempotent no-op, so the
+// confirmation reads "is now <action>" without claiming a write happened.
+func renderLifecycleResult(
+	cmd *cobra.Command,
+	backplaneURL string,
+	opts lifecycleOptions,
+	statusCode int,
+	body []byte,
+	action string,
+) error {
+	if statusCode != http.StatusNoContent {
+		return renderHTTPStatus(cmd, backplaneURL, statusCode, body, opts.JSONOut)
+	}
+	if opts.JSONOut {
+		return output.PrintJSON(cmd.OutOrStdout(), map[string]string{
+			"collection_key": opts.CollectionKey,
+			"status":         action,
+		})
+	}
+	fmt.Fprintf(cmd.OutOrStdout(), "collection %q is now %s\n", opts.CollectionKey, action)
+	return nil
+}
+
+func probeCollection(
+	ctx context.Context,
+	backplaneURL string,
+	opts lifecycleOptions,
+) (*api.ProbeCollectionEndpointApiV1DocCollectionsCollectionKeyProbePostResponse, error) {
+	authed, err := newAuthedClient(ctx, backplaneURL)
+	if err != nil {
+		return nil, err
+	}
+	return retryOn401(ctx, authed,
+		func(ctx context.Context) (*api.ProbeCollectionEndpointApiV1DocCollectionsCollectionKeyProbePostResponse, error) {
+			return authed.ProbeCollectionEndpointApiV1DocCollectionsCollectionKeyProbePostWithResponse(
+				ctx,
+				opts.CollectionKey,
+				&api.ProbeCollectionEndpointApiV1DocCollectionsCollectionKeyProbePostParams{},
+			)
+		},
+		func(r *api.ProbeCollectionEndpointApiV1DocCollectionsCollectionKeyProbePostResponse) int {
+			return r.StatusCode()
+		},
+	)
+}
+
+func enableCollection(
+	ctx context.Context,
+	backplaneURL string,
+	opts lifecycleOptions,
+) (*api.EnableCollectionEndpointApiV1DocCollectionsCollectionKeyEnablePostResponse, error) {
+	authed, err := newAuthedClient(ctx, backplaneURL)
+	if err != nil {
+		return nil, err
+	}
+	return retryOn401(ctx, authed,
+		func(ctx context.Context) (*api.EnableCollectionEndpointApiV1DocCollectionsCollectionKeyEnablePostResponse, error) {
+			return authed.EnableCollectionEndpointApiV1DocCollectionsCollectionKeyEnablePostWithResponse(
+				ctx,
+				opts.CollectionKey,
+				&api.EnableCollectionEndpointApiV1DocCollectionsCollectionKeyEnablePostParams{},
+			)
+		},
+		func(r *api.EnableCollectionEndpointApiV1DocCollectionsCollectionKeyEnablePostResponse) int {
+			return r.StatusCode()
+		},
+	)
+}
+
+func disableCollection(
+	ctx context.Context,
+	backplaneURL string,
+	opts lifecycleOptions,
+) (*api.DisableCollectionEndpointApiV1DocCollectionsCollectionKeyDisablePostResponse, error) {
+	authed, err := newAuthedClient(ctx, backplaneURL)
+	if err != nil {
+		return nil, err
+	}
+	return retryOn401(ctx, authed,
+		func(ctx context.Context) (*api.DisableCollectionEndpointApiV1DocCollectionsCollectionKeyDisablePostResponse, error) {
+			return authed.DisableCollectionEndpointApiV1DocCollectionsCollectionKeyDisablePostWithResponse(
+				ctx,
+				opts.CollectionKey,
+				&api.DisableCollectionEndpointApiV1DocCollectionsCollectionKeyDisablePostParams{},
+			)
+		},
+		func(r *api.DisableCollectionEndpointApiV1DocCollectionsCollectionKeyDisablePostResponse) int {
+			return r.StatusCode()
+		},
+	)
+}
+
+// printReadiness renders a BackendReadiness as a compact key/value block.
+// REACHABLE and INDEX BUILT are the two booleans that decide whether a
+// search will answer; DOC COUNT and LAST INGEST are the liveness an
+// operator reads to confirm an ingest landed. A nil doc count / last
+// ingest renders as "-" so an absent value is not misread as zero.
+func printReadiness(w io.Writer, collectionKey string, r *api.BackendReadiness) {
+	fmt.Fprintf(w, "collection:   %s\n", collectionKey)
+	fmt.Fprintf(w, "reachable:    %t\n", r.Reachable)
+	fmt.Fprintf(w, "index built:  %t\n", r.IndexBuilt)
+	fmt.Fprintf(w, "doc count:    %s\n", formatDocCount(r.DocCount))
+	fmt.Fprintf(w, "last ingest:  %s\n", formatLastIngest(r.LastIngestedAt))
+}
+
+// formatDocCount renders the optional doc count, which is *int on the
+// wire (a backend that does not expose a count sends null). A nil count
+// renders as "-" so it isn't misread as 0.
+func formatDocCount(count *int) string {
+	if count == nil {
+		return "-"
+	}
+	return fmt.Sprintf("%d", *count)
+}
+
+// formatLastIngest renders the optional last-ingest timestamp in RFC 3339,
+// or "-" when the backend did not report one.
+func formatLastIngest(ts *time.Time) string {
+	if ts == nil {
+		return "-"
+	}
+	return ts.UTC().Format(time.RFC3339)
+}

--- a/cli/internal/cmd/docs/collections_test.go
+++ b/cli/internal/cmd/docs/collections_test.go
@@ -1,0 +1,189 @@
+// SPDX-License-Identifier: Apache-2.0
+// Copyright (c) 2026 evoila Group
+
+package docs
+
+import (
+	"encoding/json"
+	"net/http"
+	"net/http/httptest"
+	"strings"
+	"testing"
+
+	"github.com/evoila/meho/cli/internal/api"
+)
+
+func TestCollectionsCmdHiddenWhenUnprovisioned(t *testing.T) {
+	cmd := newCollectionsCmd(false)
+	if !cmd.Hidden {
+		t.Errorf("expected collections parent Hidden when unprovisioned")
+	}
+}
+
+func TestRunCollectionProbeRefusesWhenUnprovisioned(t *testing.T) {
+	cmd, _, stderr := newRunCmd(t)
+	err := runCollectionProbe(cmd, lifecycleOptions{
+		CollectionKey: "vmware",
+		Provisioned:   false,
+	})
+	if exitCodeOf(t, err) != 5 {
+		t.Errorf("expected exit 5 (insufficient_role family); got %d", exitCodeOf(t, err))
+	}
+	if !strings.Contains(stderr.String(), "addon_not_provisioned") {
+		t.Errorf("expected addon_not_provisioned code; got %q", stderr.String())
+	}
+}
+
+func TestRunCollectionProbeRefusalIsBeforeNetwork(t *testing.T) {
+	// An unprovisioned refusal must short-circuit before any HTTP call.
+	hit := false
+	srv := httptest.NewServer(http.HandlerFunc(func(http.ResponseWriter, *http.Request) {
+		hit = true
+	}))
+	defer srv.Close()
+
+	cmd, _, _ := newRunCmd(t)
+	_ = runCollectionProbe(cmd, lifecycleOptions{
+		CollectionKey:     "vmware",
+		Provisioned:       false,
+		BackplaneOverride: srv.URL,
+	})
+	if hit {
+		t.Errorf("expected no HTTP call for an unprovisioned refusal")
+	}
+}
+
+func TestRunCollectionProbeRejectsEmptyKey(t *testing.T) {
+	cmd, _, _ := newRunCmd(t)
+	err := runCollectionProbe(cmd, lifecycleOptions{
+		CollectionKey: "",
+		Provisioned:   true,
+	})
+	if exitCodeOf(t, err) != 4 {
+		t.Errorf("expected exit 4 (unexpected_response) for empty key; got %d", exitCodeOf(t, err))
+	}
+}
+
+func TestRunCollectionProbeHappyPath(t *testing.T) {
+	mux := http.NewServeMux()
+	mux.HandleFunc(
+		"/api/v1/doc_collections/vmware/probe",
+		func(w http.ResponseWriter, r *http.Request) {
+			if r.Method != http.MethodPost {
+				t.Errorf("expected POST; got %s", r.Method)
+			}
+			docCount := 17000
+			w.Header().Set("Content-Type", "application/json")
+			_ = json.NewEncoder(w).Encode(api.BackendReadiness{
+				Reachable:  true,
+				IndexBuilt: true,
+				DocCount:   &docCount,
+			})
+		},
+	)
+	srv := httptest.NewServer(mux)
+	defer srv.Close()
+	seedXDGAndToken(t, srv.URL, "eyJ.test.token")
+
+	cmd, stdout, stderr := newRunCmd(t)
+	err := runCollectionProbe(cmd, lifecycleOptions{
+		CollectionKey:     "vmware",
+		Provisioned:       true,
+		BackplaneOverride: srv.URL,
+	})
+	if err != nil {
+		t.Fatalf("runCollectionProbe: %v; stderr=%s", err, stderr.String())
+	}
+	for _, want := range []string{"vmware", "reachable:", "index built:", "17000"} {
+		if !strings.Contains(stdout.String(), want) {
+			t.Errorf("stdout missing %q in %q", want, stdout.String())
+		}
+	}
+}
+
+func TestRunCollectionDisableHappyPath(t *testing.T) {
+	mux := http.NewServeMux()
+	mux.HandleFunc(
+		"/api/v1/doc_collections/vmware/disable",
+		func(w http.ResponseWriter, r *http.Request) {
+			if r.Method != http.MethodPost {
+				t.Errorf("expected POST; got %s", r.Method)
+			}
+			w.WriteHeader(http.StatusNoContent)
+		},
+	)
+	srv := httptest.NewServer(mux)
+	defer srv.Close()
+	seedXDGAndToken(t, srv.URL, "eyJ.test.token")
+
+	cmd, stdout, stderr := newRunCmd(t)
+	err := runCollectionDisable(cmd, lifecycleOptions{
+		CollectionKey:     "vmware",
+		Provisioned:       true,
+		BackplaneOverride: srv.URL,
+	})
+	if err != nil {
+		t.Fatalf("runCollectionDisable: %v; stderr=%s", err, stderr.String())
+	}
+	if !strings.Contains(stdout.String(), "is now disabled") {
+		t.Errorf("expected confirmation; got %q", stdout.String())
+	}
+}
+
+func TestRunCollectionEnableForbiddenTransition409(t *testing.T) {
+	// A 409 from the route surfaces as the default unexpected_response
+	// mapping (exit 4) — the forbidden-transition path.
+	mux := http.NewServeMux()
+	mux.HandleFunc(
+		"/api/v1/doc_collections/vmware/enable",
+		func(w http.ResponseWriter, _ *http.Request) {
+			w.Header().Set("Content-Type", "application/json")
+			w.WriteHeader(http.StatusConflict)
+			_ = json.NewEncoder(w).Encode(map[string]any{
+				"detail": map[string]any{
+					"error":       "invalid_collection_transition",
+					"from_status": "ready",
+					"to_status":   "provisioning",
+				},
+			})
+		},
+	)
+	srv := httptest.NewServer(mux)
+	defer srv.Close()
+	seedXDGAndToken(t, srv.URL, "eyJ.test.token")
+
+	cmd, _, _ := newRunCmd(t)
+	err := runCollectionEnable(cmd, lifecycleOptions{
+		CollectionKey:     "vmware",
+		Provisioned:       true,
+		BackplaneOverride: srv.URL,
+	})
+	if exitCodeOf(t, err) != 4 {
+		t.Errorf("expected exit 4 for a 409 conflict; got %d", exitCodeOf(t, err))
+	}
+}
+
+func TestRunCollectionProbeForbiddenRole403(t *testing.T) {
+	mux := http.NewServeMux()
+	mux.HandleFunc(
+		"/api/v1/doc_collections/vmware/probe",
+		func(w http.ResponseWriter, _ *http.Request) {
+			w.Header().Set("Content-Type", "application/json")
+			w.WriteHeader(http.StatusForbidden)
+			_ = json.NewEncoder(w).Encode(map[string]any{"detail": "tenant_admin required"})
+		},
+	)
+	srv := httptest.NewServer(mux)
+	defer srv.Close()
+	seedXDGAndToken(t, srv.URL, "eyJ.test.token")
+
+	cmd, _, _ := newRunCmd(t)
+	err := runCollectionProbe(cmd, lifecycleOptions{
+		CollectionKey:     "vmware",
+		Provisioned:       true,
+		BackplaneOverride: srv.URL,
+	})
+	if exitCodeOf(t, err) != 5 {
+		t.Errorf("expected exit 5 (insufficient_role) for a 403; got %d", exitCodeOf(t, err))
+	}
+}

--- a/cli/internal/cmd/docs/docs.go
+++ b/cli/internal/cmd/docs/docs.go
@@ -120,6 +120,7 @@ func newRootCmdWithGate(provisioned bool) *cobra.Command {
 		SilenceUsage: true,
 	}
 	cmd.AddCommand(newSearchCmd(provisioned))
+	cmd.AddCommand(newCollectionsCmd(provisioned))
 	return cmd
 }
 

--- a/docs/codebase/doc-collections.md
+++ b/docs/codebase/doc-collections.md
@@ -19,14 +19,14 @@ The registry deliberately splits two kinds of field by who writes them
   in v1; operator-managed seed only).
 - **Probe-written liveness** — `status`, `last_ingested_at`,
   `doc_count`, and `readiness`. The backend is the source of truth for
-  liveness; a later probe (G4.6-T6, #1555) writes these from the
-  backend. This task ships the columns; nothing writes them yet.
+  liveness; the readiness probe (G4.6-T6, #1555) writes these from the
+  backend on a successful probe. See [Readiness probe + lifecycle](#readiness-probe--lifecycle-g46-t6-1555).
 
-This is registry substrate only. The backend-agnostic search router
-(T2, #1551), collection-scoped `search_docs` / `ask_docs` (T3, #1552),
-the `list_doc_collections` catalogue tool and CLI (T4, #1553), and the
-readiness probe (T6, #1555) all build on this surface but are out of
-scope here. There is no agent-facing surface yet.
+This is registry substrate plus the readiness/lifecycle layer. The
+backend-agnostic search router (T2, #1551), collection-scoped
+`search_docs` / `ask_docs` (T3, #1552), and the `list_doc_collections`
+catalogue tool and CLI (T4, #1553) build on this surface but are out of
+scope here.
 
 ## Key types
 
@@ -114,6 +114,98 @@ suggestions without a second query.
 4. An unknown key raises `DocCollectionNotFoundError` with the visible
    keys for a "did you mean…?" diagnostic.
 
+## Readiness probe + lifecycle (G4.6-T6 #1555)
+
+The liveness layer that makes the catalogue carry **backend readiness**
+so the router hides managed-RAG operational footguns from the agent. A
+managed-RAG ANN index answers searches only once it has been explicitly
+(re)built, and rebuilds serialize per project; the probe reflects that
+state onto the row so the search path can fail typed instead of returning
+a silent empty result.
+
+### The `probe()` seam (`meho_backplane.docs_search.backends`)
+
+`SearchBackend.probe(operator, *, backend_ref=None) -> BackendReadiness`
+is the readiness sibling of `search()`. The row's `backend{type, ref}` is
+resolved to `backend_ref` by the router before the call, so the adapter
+depends only on the backend routing detail, never on the ORM shape. The
+base method raises `NotImplementedError` (an adapter without a liveness
+check fails loud rather than claiming "ready").
+
+`BackendReadiness` (frozen Pydantic) carries `reachable`, `index_built`,
+`doc_count`, `last_ingested_at`, and a free-form `detail` mapping the
+`readiness` column stores verbatim. `index_built=False` is the
+managed-RAG footgun: reachable but the index is not yet answerable.
+
+`CorpusHttpBackend.probe` reads the corpus's readiness via
+`corpus_status` (a GET to the corpus `/status` endpoint derived from the
+search URL by `derive_status_url`, forwarding the operator JWT, bounded
+by `corpus_timeout_seconds`, failing closed to one `CorpusUnavailable`).
+The **per-project rebuild serialization** lives inside the adapter: a
+`defaultdict[str, asyncio.Lock]` keyed on the resolved corpus endpoint,
+held across the corpus round-trip, so two concurrent probes against the
+same project's backend serialize while different projects run
+concurrently. This is in-adapter, not a substrate scheduler (substrate
+minimalism, #1177); the serialized state surfaces via `status='rebuilding'`.
+
+### The lifecycle state machine (`meho_backplane.docs_collections.lifecycle`)
+
+The `status` column's four states form a guarded machine:
+
+- **Probe transitions** (`PROBE_TRANSITIONS`): `provisioning` →
+  `{ready, rebuilding}`, `ready` → `rebuilding`, `rebuilding` → `ready`.
+  A probe never touches a `disabled` row — operator intent outranks a
+  liveness signal. `status_for_readiness` maps a `BackendReadiness` to
+  the target status (index built → `ready`, else `rebuilding`).
+- **Operator transitions** (`OPERATOR_TRANSITIONS`): `disable` from any
+  live state; `enable` from `disabled` back to `provisioning` (a probe
+  then promotes it). A same-state re-call is the idempotent no-op.
+
+A forbidden move raises `DocCollectionStateError` (HTTP 409). The
+search-time guard `ensure_collection_searchable(collection_key, status)`
+is the **mechanism T3 (#1552) wires into the search path**: `ready`
+passes, `provisioning` / `rebuilding` → `DocCollectionNotReadyError`
+(409, retryable), `disabled` → `DocCollectionDisabledError` (403); an
+unknown status fails closed as not-ready. T6 ships the guard; T3 calls it.
+
+### The probe write-back service (`meho_backplane.docs_collections.service`)
+
+`probe_collection(session, operator, collection)` resolves the backend,
+reads `BackendReadiness`, and — **on success only** — writes `readiness`
+/ `doc_count` / `last_ingested_at` and transitions `status`. A raising
+probe leaves the row untouched (the route's `session.begin()` rolls back,
+the `probe_target` / `Target.fingerprint` write-back split).
+`set_collection_enabled(session, collection, enabled)` is the
+guarded, idempotent enable/disable transition.
+
+### REST routes (`meho_backplane.api.v1.doc_collections`)
+
+Three **tenant_admin-gated** routes (mirroring the connector
+enable/disable gate):
+
+- `POST /api/v1/doc_collections/{key}/probe` → 200 `BackendReadiness`
+  (row written back), 404 unknown key, 409 forbidden transition, 503
+  backend unavailable (row untouched).
+- `POST /api/v1/doc_collections/{key}/enable` / `.../disable` → 204,
+  idempotent, 409 on a forbidden move.
+
+### `/ready` backend reachability (`meho_backplane.docs_search.readiness_probe`)
+
+`docs_backends_readiness_probe` is a coarse, synchronous, credential-free
+`/ready` check registered in the lifespan: it reports `ok` only when
+every registered adapter's `is_configured()` is true (for `corpus-http`,
+`settings.corpus_url` set), naming the unconfigured ones. It deliberately
+does **not** issue a live round-trip — that is the explicit per-collection
+probe route's job.
+
+### CLI (`cli/internal/cmd/docs/collections.go`)
+
+`meho docs collections probe|enable|disable <key>` — the lifecycle face
+of the catalogue, tenant_admin-gated and capability-gated like
+`meho docs search`. `probe` renders the `BackendReadiness` block;
+`enable` / `disable` confirm the transition. The catalogue `list` verb is
+a sibling Task (T4 #1553) that adds to this same parent command.
+
 ## Dependencies
 
 - SQLAlchemy 2.0 typed ORM (`Mapped[...]` / `mapped_column`), the
@@ -129,11 +221,21 @@ suggestions without a second query.
 
 ## Known issues / boundaries
 
-- **No liveness writer yet.** `status` defaults to `provisioning` and
-  the probe-written fields are NULL until G4.6-T6 (#1555) lands the
-  readiness probe. A consumer must not assume a collection is
-  answerable from registry presence alone — that is what `status` /
-  `readiness` are for.
+- **Liveness is probe-written, not auto-refreshed.** The probe route
+  (G4.6-T6 #1555) writes `status` / `last_ingested_at` / `doc_count` /
+  `readiness`, but only when an operator (or ops automation) calls it —
+  there is no background poller. A consumer must not assume a collection
+  is answerable from registry presence alone; the cached `status` /
+  `readiness` reflect the *last* probe.
+- **Ingest / rebuild is not triggered here.** The probe reflects the
+  backend's state; the heavy ingest / index rebuild is the backend / ops
+  side (out of scope per #1555). `enable` returns a collection to
+  `provisioning`, not to `ready` — a probe confirms the index before
+  `ready`.
+- **The search-time status check is wired by T3.** T6 ships
+  `ensure_collection_searchable`; the call site in the `search_docs`
+  route is T3's (#1552). Until T3 lands, the search path does not yet
+  fail typed on a not-ready collection.
 - **No write API.** Collections are operator-managed seed for v1. An
   `import` verb (mirroring `meho targets import`) is a later add if a
   collection needs one.
@@ -149,5 +251,11 @@ suggestions without a second query.
 - Migration precedent: `0004_create_targets_and_audit_target_id.py`
   (dialect-portable create_table) and `0005_create_endpoint_descriptor.py`
   (partial-unique-index emission).
-- Initiative #1548; this task #1550. Predecessor add-on:
-  [docs-search.md](docs-search.md) (G4.5 single-corpus `meho-docs`).
+- Initiative #1548; registry task #1550; readiness/lifecycle task #1555.
+  Predecessor add-on: [docs-search.md](docs-search.md) (G4.5
+  single-corpus `meho-docs`).
+- Probe write-back precedent: `probe_target` + `Target.fingerprint`
+  (`backend/src/meho_backplane/api/v1/targets.py`); lifecycle / 409
+  transition precedent: connector enable/disable
+  (`api/v1/connectors_ingest.py`, `InvalidStateTransitionError`);
+  `/ready` probe registry: `backend/src/meho_backplane/health.py`.


### PR DESCRIPTION
## Summary

- Make the doc-collection catalogue carry **backend readiness** so the router hides managed-RAG operational footguns from the agent (G4.6-T6).
- Fill in the reserved `SearchBackend.probe()` seam → `probe(operator, *, backend_ref) -> BackendReadiness` (typed reachable/index-built/doc-count/last-ingest). The `corpus-http` adapter reads it from the corpus `/status` endpoint and **serializes concurrent rebuilds per project inside the adapter** (an `asyncio.Lock` keyed on the corpus endpoint — not a substrate scheduler, #1177); the serialized state surfaces via `status='rebuilding'`.
- Add the lifecycle state machine + tenant_admin-gated routes `POST /api/v1/doc_collections/{key}/probe|enable|disable`. The probe **writes liveness back onto the row on success only** (a failed probe leaves it untouched — the `probe_target`/`Target.fingerprint` split, via the route's `session.begin()` rollback) and transitions `status`; enable/disable are idempotent and 409 on a forbidden move. A coarse `/ready` check reports each configured search backend reachable. New `meho docs collections probe|enable|disable` CLI verbs.

No migration: the `status` CHECK and liveness columns already shipped with the registry (#1550); this task only writes them.

## Test plan

- [x] `ruff check` / `ruff format --check` (src + tests) — clean
- [x] `mypy src/meho_backplane --ignore-missing-imports` — clean (453 files)
- [x] `code-quality.py --diff` — 0 blockers (6 pre-existing/docstring-size warnings)
- [x] `pytest test_doc_collections_readiness.py test_corpus_client.py test_docs_backends_router.py` — 63 passed
- [x] app/lifespan/startup suite (`-k "openapi or main or lifespan"`) — 212 passed, 2 skipped
- [x] CLI: `go build ./...`, `go vet`, `go test ./internal/...` — green
- [x] **CLI snapshot freshness:** `make snapshot-openapi && make generate` committed (`cli/api/openapi.json` + `cli/internal/api/client.gen.go`); regen is idempotent
- **Acceptance criteria:**
  - [x] Probing writes `readiness`/`doc_count`/`last_ingested_at` + transitions `status`; a failed probe leaves the row unchanged (success-only) — `test_probe_writes_liveness_and_promotes_to_ready`, `test_failed_probe_leaves_row_unchanged`, `test_probe_route_backend_unavailable_503_row_untouched`
  - [x] `search_docs` against a not-ready collection → typed 409 (rebuilding/provisioning), disabled → 403 — `ensure_collection_searchable` guard shipped + tested (wiring into the route is #1552, see Out of scope)
  - [x] Forbidden transitions → 409; enable/disable tenant_admin-gated + idempotent — `test_apply_*_transition`, `test_*_route_requires_tenant_admin`, `test_set_collection_enabled_is_idempotent`
  - [x] Per-project rebuild serialization proven (two concurrent rebuilds serialize; different projects don't) — `test_concurrent_probes_same_project_serialize`, `test_concurrent_probes_different_projects_run_concurrently`
  - [x] `/ready` reports each configured backend's reachability — `test_ready_probe_*`

## Out of scope

- **Wiring the search-time status check into the `search_docs` route/service + the MCP tools** — that is **#1552/T3** ("T3 only fails typed when `status != 'ready'`"). This PR ships the reusable `ensure_collection_searchable` mechanism; #1552 calls it. `docs_search/service.py`, `search_docs.py`, and the MCP tools are deliberately untouched (sibling-task territory).
- The `list_doc_collections` MCP/CLI surface (#1553/T4) — this PR adds only the lifecycle verbs under the `collections` CLI parent; `list` lands in #1553.
- Triggering ingest/rebuild jobs (the heavy ingest is the backend/ops side) and cross-collection fan-out (#1554/T5).

<!-- auto-implement-issue: fresh, iteration 1 -->

Closes #1555


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added document collection lifecycle management: probe backend readiness status, enable/disable collections via REST API
  * Added CLI commands (`meho docs collections probe|enable|disable`) for collection management
  * Added backend readiness probing to verify collection availability and index status
  * New REST endpoints for tenant administrators to manage collection lifecycle

* **Documentation**
  * Updated architecture documentation for doc-collections layer

<!-- end of auto-generated comment: release notes by coderabbit.ai -->