### PR TITLE
feat(docs): collection-scoped search_docs/ask_docs + per-collection entitlement + audit (#1552)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -90,6 +90,28 @@ connector-related release-notes line.
 
 ## [Unreleased]
 
+### Collection-scoped doc search (#1552)
+
+- Make `collection` the mandatory binary scope on `search_docs` /
+  `ask_docs` across all three surfaces (REST `POST /api/v1/search_docs`,
+  the MCP tools + the `meho://docs/{collection}/{product}/{version}/{chunk_id}`
+  resource, and `meho docs search --collection`). The query routes to the
+  named collection's backend via the T2 router; `product` / `version`
+  demote to optional metadata refinements within the collection (omitting
+  them still succeeds). A missing/blank `collection` → 422 / `-32602`; an
+  unknown collection → 422 / `-32602`. Add **per-collection entitlement**
+  (reusing the `meho-docs` capability substrate, zero new tables): a
+  principal may search a collection only when its tenant holds the
+  `meho-docs:<collection>` capability — a miss → 403 / `-32602` even
+  though the tool stays visible via the base `meho-docs` gate. A
+  not-`ready` collection → 409 / `-32603`. Each call's audit row carries
+  `audit_collection` alongside the canonical `meho.docs.search` /
+  `meho.docs.ask` op_id (#1549), so rows are filterable by both op_id and
+  collection; the raw query stays hashed. The shared resolve + entitle +
+  readiness gate lives in `docs_search/collection_access.py` so all
+  surfaces enforce one policy. CLI client regenerated for the new
+  `collection` request field.
+
 ### Backend-agnostic search router (#1551)
 
 - Add a `collection → backend{type, ref}` search router so one doc

--- a/backend/src/meho_backplane/api/v1/search_docs.py
+++ b/backend/src/meho_backplane/api/v1/search_docs.py
@@ -1,29 +1,41 @@
 # SPDX-License-Identifier: Apache-2.0
 # Copyright (c) 2026 evoila Group
 
-"""``POST /api/v1/search_docs`` -- federated vendor-document retrieval.
+"""``POST /api/v1/search_docs`` -- collection-scoped vendor-document retrieval.
 
-G4.5-T3 (#1521) of Initiative #1518 (the ``meho-docs`` add-on). The
-route is the REST face of the shared
-:func:`~meho_backplane.docs_search.search_docs` service: it federates a
-free-text query through the backplane to the external vendor-document
-corpus the ops team runs (T2, :mod:`meho_backplane.auth.corpus`) rather
-than hitting the corpus directly. Routing through the backplane is what
+G4.6-T3 (#1552) of Initiative #1548 (the doc-collection catalogue),
+building on G4.5-T3 (#1521). The route is the REST face of the shared
+:func:`~meho_backplane.docs_search.search_docs` service: it routes a
+free-text query to the named collection's backend (T2 #1551) rather than
+hitting any one corpus directly. Routing through the backplane is what
 lands every query in the audit trail, forwards the operator JWT once,
-and enforces the mandatory product/version posture centrally.
+enforces per-collection entitlement, and records the collection scope
+centrally.
 
-REQUIRE_FILTERS (the binary scope)
-----------------------------------
+Collection scope (the binary scope)
+-----------------------------------
 
-``product`` AND ``version`` are **mandatory** -- a request missing
-either is rejected **422** (fail-closed) by
+``collection`` is **mandatory** -- a request missing or blanking it is
+rejected **422** (fail-closed) by
 :func:`~meho_backplane.docs_search.build_docs_scope` rather than
-forwarded as an unfiltered corpus query. The filter is a **binary
-scope** passed verbatim to the corpus (the #1178 / #1177 decision:
-containment, not RRF weighting) -- it is never expressed as a ranking
-weight. Enforcement is gated by ``settings.corpus_require_filters``
-(default on); with the gate off the filter degrades to optional and the
-corpus owns the policy.
+forwarded as an unscoped query. ``collection`` is the binary scope: it
+routes the query to a backend and gates entitlement, but it is a
+router / entitlement key, NOT a metadata filter (it never reaches the
+backend's per-chunk ``metadata`` containment query). ``product`` /
+``version`` demote to **optional refinements** within the chosen
+collection -- present, they ride ``metadata_filters`` (binary
+containment, the #1178 / #1177 decision, never a ranking weight); absent,
+the collection alone scopes the query.
+
+Per-collection entitlement + readiness
+--------------------------------------
+
+After the scope parses, :func:`~meho_backplane.docs_search.resolve_entitled_ready_collection`
+runs the shared gate: it resolves ``collection`` to its registry row
+(tenant-first), enforces the ``meho-docs:<collection>`` capability
+(403 on a miss -- the collection exists but the tenant is not entitled),
+and checks the registry ``status`` (409 when the collection is not
+``ready``). An unknown collection is 422 (an invalid argument).
 
 RBAC + tenant scoping
 ---------------------
@@ -46,15 +58,18 @@ payload:
   filter on ``payload->>'op_id' = 'meho.docs.search'``.
 * ``audit_op_class = "read"`` -- this is a read operation. The broadcast
   payload for ``read`` is full-detail, which is safe here because the
-  bound payload is *only* the hash + binary scope + hit count -- the
-  **raw query is never bound** (only its SHA-256 digest), so nothing
-  operator-sensitive can leak through the feed.
+  bound payload is *only* the hash + scope + hit count -- the **raw query
+  is never bound** (only its SHA-256 digest), so nothing operator-sensitive
+  can leak through the feed.
 * ``audit_query_hash`` -- SHA-256 hex of the UTF-8 query; the raw query
   is never stored.
-* ``audit_product`` / ``audit_version`` -- the binary scope (these are
-  the operator-chosen product/version, not tenant-shaped identifiers, so
-  they are recorded in the clear for who-touched attribution).
-* ``audit_hit_count`` -- bound after the corpus returns.
+* ``audit_collection`` -- the collection scope (the operator-chosen
+  collection key, the binary router / entitlement scope, recorded in the
+  clear for who-touched attribution; builds on #1549 so a row is
+  filterable by both op_id and collection).
+* ``audit_product`` / ``audit_version`` -- the optional refinements, when
+  present (operator-chosen, not tenant-shaped identifiers).
+* ``audit_hit_count`` -- bound after the backend returns.
 
 Corpus-unavailable contract
 ---------------------------
@@ -81,18 +96,26 @@ Out of scope (per the Initiative body)
 from __future__ import annotations
 
 import hashlib
+from typing import Annotated
 
 import structlog
 from fastapi import APIRouter, Depends, HTTPException, status
 from pydantic import BaseModel, ConfigDict, Field
+from sqlalchemy.ext.asyncio import AsyncSession
 
 from meho_backplane.auth.corpus import CorpusUnavailable
 from meho_backplane.auth.operator import Operator, TenantRole
 from meho_backplane.auth.rbac import require_role
+from meho_backplane.db.engine import get_session
+from meho_backplane.docs_collections import DocCollection
 from meho_backplane.docs_search import (
+    CollectionForbiddenError,
+    CollectionNotReadyError,
     DocsChunk,
     MissingDocsFilterError,
+    UnknownCollectionError,
     build_docs_scope,
+    resolve_entitled_ready_collection,
     search_docs,
 )
 
@@ -111,12 +134,12 @@ _require_operator = Depends(require_role(TenantRole.OPERATOR))
 class SearchDocsRequest(BaseModel):
     """POST body for ``/api/v1/search_docs``.
 
-    ``product`` / ``version`` are the **mandatory binary scope** under
-    the REQUIRE_FILTERS posture -- they are typed optional here so a
-    missing value is rejected by the service with a route-shaped 422
-    naming the absent key(s), rather than Pydantic's generic
-    ``field_required`` (which would not say *why* the scope is mandatory
-    or honour the ``corpus_require_filters`` gate-off path).
+    ``collection`` is the **mandatory binary scope** (G4.6-T3 #1552) -- it
+    is typed optional here so a missing value is rejected by the service
+    with a route-shaped 422 naming the absent key (carrying *why* the
+    collection is mandatory), rather than Pydantic's generic
+    ``field_required``. ``product`` / ``version`` are **optional
+    refinements** within the chosen collection.
 
     ``extra="forbid"`` rejects unknown fields at 422 so a client sending
     a pre-rename key fails loud rather than running with the defaults --
@@ -126,6 +149,7 @@ class SearchDocsRequest(BaseModel):
     model_config = ConfigDict(frozen=True, extra="forbid")
 
     query: str = Field(min_length=1, max_length=2000)
+    collection: str | None = Field(default=None, max_length=128)
     product: str | None = Field(default=None, max_length=128)
     version: str | None = Field(default=None, max_length=128)
     limit: int = Field(default=10, ge=1, le=50)
@@ -157,21 +181,72 @@ def _compute_query_hash(query: str) -> str:
     return hashlib.sha256(query.encode("utf-8")).hexdigest()
 
 
+async def _resolve_collection_or_http_error(
+    session: AsyncSession,
+    operator: Operator,
+    collection_key: str,
+) -> DocCollection:
+    """Run the shared resolve + entitle + readiness gate, mapping to HTTP.
+
+    Each typed access failure maps to its own status: an unknown collection
+    → 422 (an invalid ``collection`` argument, carrying the catalogue of
+    visible keys), not entitled → 403 (the collection exists; the tenant
+    lacks ``meho-docs:<collection>``), not ready → 409 (the backend is not
+    answerable yet).
+    """
+    try:
+        return await resolve_entitled_ready_collection(session, operator, collection_key)
+    except UnknownCollectionError as exc:
+        raise HTTPException(
+            status_code=status.HTTP_422_UNPROCESSABLE_CONTENT,
+            detail={
+                "error": "unknown_collection",
+                "collection": exc.collection_key,
+                "known_collections": exc.known_keys,
+            },
+        ) from exc
+    except CollectionForbiddenError as exc:
+        raise HTTPException(
+            status_code=status.HTTP_403_FORBIDDEN,
+            detail=str(exc),
+        ) from exc
+    except CollectionNotReadyError as exc:
+        raise HTTPException(
+            status_code=status.HTTP_409_CONFLICT,
+            detail=str(exc),
+        ) from exc
+
+
 @router.post(
     "/search_docs",
     response_model=SearchDocsResponse,
     responses={
+        403: {
+            "description": (
+                "The tenant is not entitled to the named collection -- it "
+                "lacks the ``meho-docs:<collection>`` capability even "
+                "though it can see the add-on. The collection exists; the "
+                "principal just cannot search it."
+            ),
+        },
+        409: {
+            "description": (
+                "The named collection is known and entitled but not "
+                "``ready`` (provisioning / rebuilding / disabled) -- its "
+                "backend is not answerable yet."
+            ),
+        },
         422: {
             "description": (
-                "The mandatory binary product+version scope is absent "
-                "(REQUIRE_FILTERS). A docs query without both filters is "
-                "rejected rather than forwarded as an unfiltered corpus "
-                "query."
+                "The mandatory ``collection`` scope is absent / blank, or "
+                "names no collection visible to the tenant. A docs query "
+                "without a routable collection is rejected rather than "
+                "forwarded as an unscoped query."
             ),
         },
         503: {
             "description": (
-                "The external corpus is unavailable -- unconfigured, "
+                "The collection's backend is unavailable -- unconfigured, "
                 "unreachable, or returned a non-2xx / malformed response. "
                 "Fail-closed; never an empty 200."
             ),
@@ -180,28 +255,29 @@ def _compute_query_hash(query: str) -> str:
 )
 async def search_docs_endpoint(
     body: SearchDocsRequest,
-    operator: Operator = _require_operator,
+    operator: Annotated[Operator, _require_operator],
+    session: Annotated[AsyncSession, Depends(get_session)],
 ) -> SearchDocsResponse:
-    """Federate a vendor-document query to the corpus, returning cited chunks.
+    """Route a vendor-document query to a collection's backend, returning cited chunks.
 
-    Enforces the mandatory binary product+version scope (422 when the
-    REQUIRE_FILTERS gate is on and either is absent), forwards the
-    operator JWT to the corpus via the shared
-    :func:`~meho_backplane.docs_search.search_docs` service, and binds
-    the central ``meho.docs.search`` audit row. ``read_only`` operators
-    get 403 via :func:`require_role` before reaching this handler.
+    Enforces the mandatory ``collection`` binary scope (422 when absent),
+    resolves it to its backend via the shared
+    :func:`~meho_backplane.docs_search.search_docs` service, enforces the
+    per-collection ``meho-docs:<collection>`` entitlement (403) and
+    readiness (409), and binds the central ``meho.docs.search`` audit row.
+    ``read_only`` operators get 403 via :func:`require_role` before
+    reaching this handler.
 
-    The audit contextvars are bound **before** the corpus call so a
-    handler exception (including the :class:`CorpusUnavailable` → 503
-    branch) still produces an audit row with the query identity + binary
-    scope preserved. The raw query is never bound -- only its SHA-256
-    hash.
+    The audit contextvars are bound **before** the entitlement / backend
+    call so a handler exception (the entitlement 403, readiness 409, or
+    :class:`CorpusUnavailable` 503 branch) still produces an audit row
+    with the query identity + collection scope preserved. The raw query is
+    never bound -- only its SHA-256 hash.
     """
     # Validate the binary scope first; a 422 here must NOT bind an audit
-    # row implying a corpus call happened. The scope build is the
-    # REQUIRE_FILTERS gate.
+    # row implying a backend call happened. ``collection`` is mandatory.
     try:
-        scope = build_docs_scope(body.product, body.version)
+        scope = build_docs_scope(body.collection, body.product, body.version)
     except MissingDocsFilterError as exc:
         raise HTTPException(
             status_code=status.HTTP_422_UNPROCESSABLE_CONTENT,
@@ -210,33 +286,41 @@ async def search_docs_endpoint(
 
     log = structlog.get_logger()
     # Pre-bind everything the audit middleware lifts into
-    # ``audit_log.payload``. ``hit_count`` is bound after the corpus
-    # returns; the rest are known up-front so a handler exception (e.g.
-    # the corpus 503 branch) still records the query identity + scope.
-    # The raw query is never bound -- only its SHA-256 hash.
+    # ``audit_log.payload``. ``hit_count`` is bound after the backend
+    # returns; the rest are known up-front so a handler exception (the
+    # entitlement / readiness / backend branches) still records the query
+    # identity + scope. The raw query is never bound -- only its SHA-256
+    # hash.
     structlog.contextvars.bind_contextvars(
         audit_op_id="meho.docs.search",
         audit_op_class="read",
         audit_query_hash=_compute_query_hash(body.query),
+        audit_collection=scope.collection_key,
         audit_product=scope.product,
         audit_version=scope.version,
     )
+
+    # Resolve + entitle + readiness gate (each typed failure → its own HTTP
+    # status; see :func:`_resolve_collection_or_http_error`).
+    collection = await _resolve_collection_or_http_error(session, operator, scope.collection_key)
 
     try:
         result = await search_docs(
             operator,
             body.query,
             scope=scope,
+            collection=collection,
             limit=body.limit,
         )
     except CorpusUnavailable as exc:
-        # Fail-closed: an unconfigured / unreachable / non-2xx corpus is
-        # 503, never an empty 200. The transport guarantees the corpus
+        # Fail-closed: an unconfigured / unreachable / non-2xx backend is
+        # 503, never an empty 200. The transport guarantees the backend
         # response body is never on the exception, so nothing leaks
-        # through the detail.
+        # through the detail (and the backend id stays server-side).
         log.warning(
-            "search_docs_corpus_unavailable",
+            "search_docs_backend_unavailable",
             operator_sub=operator.sub,
+            collection=scope.collection_key,
             product=scope.product,
             version=scope.version,
             corpus_status=exc.status,
@@ -251,6 +335,7 @@ async def search_docs_endpoint(
         "search_docs_endpoint_completed",
         operator_sub=operator.sub,
         tenant_id=str(operator.tenant_id),
+        collection=scope.collection_key,
         product=scope.product,
         version=scope.version,
         hit_count=len(result.chunks),

--- a/backend/src/meho_backplane/docs_search/__init__.py
+++ b/backend/src/meho_backplane/docs_search/__init__.py
@@ -1,26 +1,30 @@
 # SPDX-License-Identifier: Apache-2.0
 # Copyright (c) 2026 evoila Group
 
-"""Shared ``search_docs`` retrieval service (G4.5-T3 #1521).
+"""Shared ``search_docs`` retrieval service (G4.5-T3 #1521, G4.6-T3 #1552).
 
 The ``meho-docs`` add-on (Initiative #1518) federates vendor-document
 queries through the backplane to the external corpus the ops team runs
 (T2, :mod:`meho_backplane.auth.corpus`). This package is the **one**
-shared entrypoint that surface — :func:`search_docs` — used by both the
-REST route (``POST /api/v1/search_docs``, T3) and the future MCP tool
-(T4, #1523) / CLI verb (T5, #1524). Keeping the scope-validation,
-corpus call, and cited-chunk projection in a service module (rather than
-inline in the route) is what lets T4/T5 reuse the exact same posture
-without re-implementing the REQUIRE_FILTERS gate or the citation shape.
+shared entrypoint that surface — :func:`search_docs` — used by the REST
+route (``POST /api/v1/search_docs``), the MCP ``search_docs`` / ``ask_docs``
+tools, and the CLI verb. Keeping the scope-validation, backend call, and
+cited-chunk projection in a service module (rather than inline in the
+route) is what lets every surface reuse the exact same posture without
+re-implementing the binary-scope gate or the citation shape.
 
-The mandatory product+version filter — a **binary scope**, never a
-ranking weight (the #1178 / #1177 decision) — is enforced here:
-:func:`build_docs_scope` rejects a missing/blank ``product`` or
-``version`` with :class:`MissingDocsFilterError`, which the route renders as
-HTTP 422 (fail-closed). Enforcement is gated by
-``settings.corpus_require_filters`` (default on); the central audit
-binding (``op_id="meho.docs.search"``) stays in the route, next to the
-``audit_*`` contextvars the chassis middleware lifts into the row.
+The mandatory ``collection`` scope — the binary router / entitlement key
+(G4.6-T3 #1552), never a ranking weight (the #1178 / #1177 decision) — is
+enforced here: :func:`build_docs_scope` rejects a missing/blank
+``collection`` with :class:`MissingDocsFilterError`, which the route
+renders as HTTP 422 (fail-closed) and the MCP face as ``-32602``.
+``product`` / ``version`` are optional refinements within the chosen
+collection. :func:`resolve_entitled_ready_collection` is the shared gate
+that turns the ``collection`` key into its registry row, enforces the
+per-collection ``meho-docs:<key>`` entitlement, and checks readiness; the
+central audit binding (``op_id="meho.docs.search"`` + ``audit_collection``)
+stays in each surface, next to the ``audit_*`` contextvars the chassis
+middleware lifts into the row.
 """
 
 from __future__ import annotations
@@ -29,6 +33,14 @@ from meho_backplane.docs_search.backends import (
     SearchBackend,
     resolve_backend,
     resolve_backend_or_label,
+)
+from meho_backplane.docs_search.collection_access import (
+    CollectionAccessError,
+    CollectionForbiddenError,
+    CollectionNotReadyError,
+    UnknownCollectionError,
+    collection_capability_key,
+    resolve_entitled_ready_collection,
 )
 from meho_backplane.docs_search.service import (
     DocsChunk,
@@ -47,6 +59,9 @@ from meho_backplane.docs_search.synthesis import (
 
 __all__ = [
     "NO_GROUNDED_ANSWER",
+    "CollectionAccessError",
+    "CollectionForbiddenError",
+    "CollectionNotReadyError",
     "DocsAnswer",
     "DocsChunk",
     "DocsScope",
@@ -54,9 +69,12 @@ __all__ = [
     "DocsSynthesisError",
     "MissingDocsFilterError",
     "SearchBackend",
+    "UnknownCollectionError",
     "build_docs_scope",
+    "collection_capability_key",
     "resolve_backend",
     "resolve_backend_or_label",
+    "resolve_entitled_ready_collection",
     "search_docs",
     "synthesize_docs_answer",
 ]

--- a/backend/src/meho_backplane/docs_search/collection_access.py
+++ b/backend/src/meho_backplane/docs_search/collection_access.py
@@ -1,0 +1,223 @@
+# SPDX-License-Identifier: Apache-2.0
+# Copyright (c) 2026 evoila Group
+
+"""Collection resolution + per-collection entitlement + readiness (T3 #1552).
+
+The single shared gate every collection-scoped surface — the REST route,
+the ``search_docs`` / ``ask_docs`` MCP tools, and the docs-chunk resource —
+runs *after* parsing the operator-supplied ``collection`` key and *before*
+calling :func:`~meho_backplane.docs_search.search_docs`. Centralising it
+here means the three policies (catalogue membership, entitlement, and
+readiness) are defined once and cannot drift per surface:
+
+1. **Resolution** — turn the ``collection`` key into its registry row via
+   the tenant-first-then-global resolver
+   (:func:`~meho_backplane.docs_collections.resolve_doc_collection`). An
+   unknown key is the typed :exc:`UnknownCollectionError`.
+
+2. **Per-collection entitlement** (reuses the G4.5-T1 capability
+   substrate, zero new tables) — a principal may search a collection only
+   when its operator carries the ``meho-docs:<collection_key>`` capability.
+   The static ``required_capability="meho-docs"`` gate on the tool still
+   governs *visibility* (a tenant without the add-on never sees the tool);
+   this finer gate governs *which collections* an entitled tenant may
+   actually query. A miss is the typed :exc:`CollectionForbiddenError`.
+
+3. **Readiness** — a collection whose lifecycle ``status`` is not
+   ``"ready"`` (``provisioning`` / ``rebuilding`` / ``disabled``) is not
+   answerable yet; this is the typed :exc:`CollectionNotReadyError`. The
+   richer reachability *probe* is T6 (#1555); T3 reads only the registry
+   ``status`` column the T1 substrate already carries.
+
+Each surface translates these typed errors into its own transport shape
+(HTTP status at the REST route, JSON-RPC ``-32xxx`` at the MCP face) so
+the policy stays transport-independent and this module imports nothing
+transport-specific.
+"""
+
+from __future__ import annotations
+
+from typing import TYPE_CHECKING, Any
+
+import structlog
+
+from meho_backplane.docs_collections import (
+    DocCollection,
+    DocCollectionNotFoundError,
+    resolve_doc_collection,
+)
+
+if TYPE_CHECKING:
+    from sqlalchemy.ext.asyncio import AsyncSession
+
+    from meho_backplane.auth.operator import Operator
+
+__all__ = [
+    "CollectionAccessError",
+    "CollectionForbiddenError",
+    "CollectionNotReadyError",
+    "UnknownCollectionError",
+    "collection_capability_key",
+    "resolve_entitled_ready_collection",
+]
+
+_log = structlog.get_logger(__name__)
+
+#: The lifecycle status a collection must carry to be answerable. The
+#: other states (``provisioning`` / ``rebuilding`` / ``disabled``) are
+#: not-ready: the catalogue knows the collection but the backend is not
+#: serving it yet.
+_READY_STATUS = "ready"
+
+#: The capability-key prefix the per-collection entitlement gate keys on.
+#: ``meho-docs:<collection_key>`` reuses the G4.5-T1 capability substrate
+#: (``Operator.capabilities`` accepts arbitrary keys), so the finer gate
+#: needs no new table.
+_CAPABILITY_PREFIX = "meho-docs:"
+
+
+class CollectionAccessError(Exception):
+    """Base for the typed collection-access failures.
+
+    Surfaces translate each subclass into a transport-specific shape; the
+    base lets a caller that does not care which arm fired catch the whole
+    family. ``known_keys`` is populated only for
+    :class:`UnknownCollectionError` (it has the resolver's catalogue
+    diagnostics); the other arms leave it ``None``.
+    """
+
+    def __init__(self, message: str, *, collection_key: str) -> None:
+        super().__init__(message)
+        self.collection_key = collection_key
+
+
+class UnknownCollectionError(CollectionAccessError):
+    """The ``collection`` key names no collection visible to the tenant.
+
+    Carries the catalogue of keys the tenant *can* see (global + its own)
+    so a surface can render a "did you mean…?" hint without a second query.
+    Surfaces map this to 422 (REST) / ``-32602`` (MCP) — an invalid
+    ``collection`` argument, not a server fault.
+    """
+
+    def __init__(self, collection_key: str, known_keys: list[str]) -> None:
+        super().__init__(
+            f"unknown doc collection {collection_key!r}",
+            collection_key=collection_key,
+        )
+        self.known_keys = known_keys
+
+
+class CollectionForbiddenError(CollectionAccessError):
+    """The tenant is not entitled to the (otherwise-resolvable) collection.
+
+    The operator passed the static ``meho-docs`` visibility gate (the tool
+    is callable) but lacks the finer ``meho-docs:<collection_key>``
+    capability for *this* collection. Surfaces map this to a 403-class
+    rejection so it reads as "denied", not "not found" — the collection
+    exists; the principal just cannot search it.
+    """
+
+    def __init__(self, collection_key: str) -> None:
+        super().__init__(
+            f"not entitled to doc collection {collection_key!r}",
+            collection_key=collection_key,
+        )
+
+
+class CollectionNotReadyError(CollectionAccessError):
+    """The collection is known + entitled but its backend is not serving yet.
+
+    The registry ``status`` is not ``"ready"`` (``provisioning`` /
+    ``rebuilding`` / ``disabled``). Surfaces map this to a 409/503-class
+    rejection — the request was well-formed and authorised; the collection
+    is simply not answerable at this moment.
+    """
+
+    def __init__(self, collection_key: str, status: str) -> None:
+        super().__init__(
+            f"doc collection {collection_key!r} is not ready (status={status!r})",
+            collection_key=collection_key,
+        )
+        self.status = status
+
+
+def collection_capability_key(collection_key: str) -> str:
+    """Return the per-collection entitlement capability key.
+
+    ``meho-docs:<collection_key>`` — the key an operator's
+    :attr:`~meho_backplane.auth.operator.Operator.capabilities` must carry
+    to search *collection_key*. Single source of truth so the gate and any
+    provisioning tooling agree on the string.
+    """
+    return f"{_CAPABILITY_PREFIX}{collection_key}"
+
+
+async def resolve_entitled_ready_collection(
+    session: AsyncSession,
+    operator: Operator,
+    collection_key: str,
+) -> DocCollection:
+    """Resolve, entitlement-check, and readiness-check *collection_key*.
+
+    The one gate every collection-scoped surface runs after parsing the
+    ``collection`` argument. Returns the frozen :class:`DocCollection` read
+    shape (not the ORM row) so the caller can pass it to
+    :func:`~meho_backplane.docs_search.search_docs` and stash it in logs
+    without an open-session lifetime concern.
+
+    The checks run resolve → entitle → readiness in that order so the
+    rejection is the most specific true one: a tenant gets
+    ``not found`` for a key it cannot see at all, ``forbidden`` for a
+    key it can see but is not entitled to, and ``not ready`` only once
+    both of those pass.
+
+    Args:
+        session: Active async DB session.
+        operator: The verified operator (carries ``tenant_id`` for the
+            tenant-scoped resolve and ``capabilities`` for the entitlement
+            check).
+        collection_key: The operator-supplied collection key (already
+            stripped / non-blank by :func:`build_docs_scope`).
+
+    Returns:
+        The resolved, entitled, ready :class:`DocCollection`.
+
+    Raises:
+        UnknownCollectionError: No collection with *collection_key* is
+            visible to the operator's tenant.
+        CollectionForbiddenError: The tenant lacks the
+            ``meho-docs:<collection_key>`` capability.
+        CollectionNotReadyError: The collection's registry ``status`` is
+            not ``"ready"``.
+    """
+    try:
+        row = await resolve_doc_collection(session, collection_key, operator.tenant_id)
+    except DocCollectionNotFoundError as exc:
+        # Re-shape the resolver's 404-flavoured HTTPException into the
+        # transport-neutral typed error this module owns, preserving the
+        # catalogue hint the resolver assembled.
+        detail: dict[str, Any] = exc.detail if isinstance(exc.detail, dict) else {}
+        known_keys = detail.get("known_keys", [])
+        raise UnknownCollectionError(collection_key, list(known_keys)) from exc
+
+    capability = collection_capability_key(row.collection_key)
+    if capability not in operator.capabilities:
+        _log.warning(
+            "doc_collection_entitlement_denied",
+            tenant_id=str(operator.tenant_id),
+            collection_key=row.collection_key,
+            required_capability=capability,
+        )
+        raise CollectionForbiddenError(row.collection_key)
+
+    if row.status != _READY_STATUS:
+        _log.info(
+            "doc_collection_not_ready",
+            tenant_id=str(operator.tenant_id),
+            collection_key=row.collection_key,
+            status=row.status,
+        )
+        raise CollectionNotReadyError(row.collection_key, row.status)
+
+    return DocCollection.model_validate(row, from_attributes=True)

--- a/backend/src/meho_backplane/docs_search/service.py
+++ b/backend/src/meho_backplane/docs_search/service.py
@@ -6,14 +6,18 @@
 Two responsibilities, both shared across the REST route (T3), the MCP
 tool (T4), and the CLI verb (T5):
 
-1. :func:`build_docs_scope` — enforce the **mandatory** product+version
-   filter as a binary scope. When ``settings.corpus_require_filters`` is
-   on (the default), a missing or blank ``product`` / ``version`` raises
-   :class:`MissingDocsFilterError`, which the route renders HTTP 422
-   (fail-closed). The filter is a scope passed verbatim to the corpus —
-   never a ranking weight (#1178 / #1177). With the gate **off**, the
-   filter degrades to optional: present keys still scope, absent keys
-   simply widen the search (the corpus is the policy owner in that mode).
+1. :func:`build_docs_scope` — enforce the **mandatory** ``collection``
+   binary scope (T3 #1552). ``collection`` is the single hard-required
+   scope: a missing or blank value raises :class:`MissingDocsFilterError`,
+   which the route renders HTTP 422 (fail-closed) and the MCP face renders
+   ``-32602``. ``product`` / ``version`` demote to **optional refinements**
+   within the chosen collection — present, they ride
+   :meth:`DocsScope.as_filters` as ``metadata_filters``; absent, the
+   collection alone scopes the query. The filters are scopes passed
+   verbatim to the backend, never ranking weights (#1178 / #1177). The
+   ``collection`` key is a **router / entitlement key**, not a metadata
+   filter — it is kept out of :meth:`DocsScope.as_filters` so it never
+   leaks into the backend's per-chunk ``metadata`` containment query.
 
 2. :func:`search_docs` — call T2's :func:`~meho_backplane.auth.corpus.search_corpus`
    with the operator's forwarded JWT and the binary scope, then project
@@ -36,10 +40,9 @@ from typing import TYPE_CHECKING
 import structlog
 from pydantic import BaseModel, ConfigDict, Field
 
-from meho_backplane.auth.corpus import CorpusChunk, search_corpus
+from meho_backplane.auth.corpus import CorpusChunk
 from meho_backplane.auth.operator import Operator
 from meho_backplane.docs_search.backends import resolve_backend
-from meho_backplane.settings import get_settings
 
 if TYPE_CHECKING:
     from meho_backplane.docs_collections import DocCollection
@@ -55,53 +58,68 @@ __all__ = [
 
 _log = structlog.get_logger(__name__)
 
-#: The two binary-scope keys forwarded to the corpus as
-#: ``metadata_filters``. Both are mandatory under the REQUIRE_FILTERS
-#: posture; the corpus keys its per-chunk ``metadata`` off these names.
+#: The optional refinement keys forwarded to the backend as
+#: ``metadata_filters`` within the chosen collection. Both are optional
+#: under the collection-scoped posture (T3 #1552); the backend keys its
+#: per-chunk ``metadata`` off these names.
 _PRODUCT_KEY = "product"
 _VERSION_KEY = "version"
 
+#: The mandatory binary-scope key. ``collection`` is the router /
+#: entitlement key (T3 #1552) — required on every query, but **not** a
+#: metadata filter (it never reaches :meth:`DocsScope.as_filters`).
+_COLLECTION_KEY = "collection"
+
 
 class MissingDocsFilterError(ValueError):
-    """Raised when a mandatory ``product`` / ``version`` filter is absent.
+    """Raised when the mandatory ``collection`` scope is absent or blank.
 
-    The REQUIRE_FILTERS posture is fail-closed: a docs query without a
-    binary product+version scope is rejected rather than forwarded as an
-    unfiltered corpus query (which would scan the whole vendor corpus and
-    defeat the per-product/version scoping the add-on exists to enforce).
-    The route maps this to HTTP 422. ``missing`` lists which key(s) were
-    absent or blank so the caller's error detail can name them without
-    re-deriving the gap.
+    The collection-scoped posture is fail-closed: a docs query without a
+    ``collection`` is rejected rather than forwarded as an unscoped query
+    (which would have no backend to route to and defeat the per-collection
+    entitlement the catalogue exists to enforce). The route maps this to
+    HTTP 422; the MCP face maps it to ``-32602``. ``missing`` lists which
+    key(s) were absent or blank so the caller's error detail can name them
+    without re-deriving the gap.
     """
 
     def __init__(self, missing: list[str]) -> None:
         self.missing = missing
         joined = ", ".join(missing)
         super().__init__(
-            f"search_docs requires a binary {joined} filter "
-            "(product and version are mandatory scopes, not ranking weights)"
+            f"search_docs requires a {joined} scope "
+            "(collection is the mandatory binary scope, not a ranking weight)"
         )
 
 
 class DocsScope(BaseModel):
-    """The validated binary product+version scope for a docs query.
+    """The validated binary scope for a docs query.
 
-    Frozen value object built by :func:`build_docs_scope`. :meth:`as_filters`
-    renders it into the ``{key: scalar}`` ``metadata_filters`` shape the
-    corpus federation client (T2) forwards verbatim — the same containment
-    contract the local retrieval substrate uses (PG ``metadata @>`` ),
-    mirrored on the corpus side. Only positively-set keys are emitted, so
-    the gate-off path can carry a partial scope without injecting ``None``
-    values the corpus would have to special-case.
+    Frozen value object built by :func:`build_docs_scope`. ``collection_key``
+    is the mandatory router / entitlement key; ``product`` / ``version`` are
+    the optional refinements within that collection. :meth:`as_filters`
+    renders **only** the optional refinements into the ``{key: scalar}``
+    ``metadata_filters`` shape the backend forwards verbatim — the same
+    containment contract the local retrieval substrate uses (PG
+    ``metadata @>`` ), mirrored on the backend side. ``collection_key`` is
+    deliberately **excluded** from :meth:`as_filters`: it routes and gates
+    the query, it is not a per-chunk metadata field. Only positively-set
+    refinement keys are emitted, so a query with no product/version carries
+    no spurious ``None`` values the backend would have to special-case.
     """
 
     model_config = ConfigDict(frozen=True)
 
+    collection_key: str
     product: str | None = Field(default=None)
     version: str | None = Field(default=None)
 
     def as_filters(self) -> dict[str, str]:
-        """Render the scope as a ``{key: scalar}`` corpus filter dict."""
+        """Render the optional refinements as a ``{key: scalar}`` filter dict.
+
+        ``collection_key`` is intentionally not included — it is a router /
+        entitlement key, not a metadata filter.
+        """
         filters: dict[str, str] = {}
         if self.product is not None:
             filters[_PRODUCT_KEY] = self.product
@@ -143,41 +161,49 @@ class DocsSearchResult(BaseModel):
     chunks: list[DocsChunk] = Field(default_factory=list)
 
 
-def build_docs_scope(product: str | None, version: str | None) -> DocsScope:
-    """Validate the binary product+version scope, fail-closed under the gate.
+def build_docs_scope(
+    collection: str | None,
+    product: str | None = None,
+    version: str | None = None,
+) -> DocsScope:
+    """Validate the binary ``collection`` scope, fail-closed.
 
-    When ``settings.corpus_require_filters`` is on (the default), **both**
-    ``product`` and ``version`` must be non-blank; either missing raises
-    :class:`MissingDocsFilterError` (HTTP 422 at the route). With the gate off,
-    the scope degrades to optional — whatever is provided still scopes the
-    corpus query, whatever is absent simply widens it. Blank-after-strip
-    values are treated as absent so a ``product=" "`` cannot smuggle past
-    the mandatory gate.
+    ``collection`` is the **mandatory** binary scope (T3 #1552): a missing
+    or blank value raises :class:`MissingDocsFilterError` (HTTP 422 at the
+    route, ``-32602`` at the MCP face), unconditionally — this is not gated
+    by ``settings.corpus_require_filters`` (the legacy product+version gate),
+    because every collection-scoped query *must* name a collection to route
+    and entitle on. ``product`` / ``version`` are **optional refinements**
+    within the chosen collection: whatever is provided rides
+    :meth:`DocsScope.as_filters` as ``metadata_filters``, whatever is absent
+    simply widens the search inside the collection. Blank-after-strip values
+    are treated as absent so a ``collection=" "`` cannot smuggle past the
+    mandatory gate.
 
     Args:
-        product: The vendor product to scope to (e.g. ``"vmware"``).
-        version: The product version to scope to (e.g. ``"9.0"``).
+        collection: The mandatory collection key to route + entitle on
+            (e.g. ``"vmware"``).
+        product: The optional vendor product refinement (e.g. ``"vsphere"``).
+        version: The optional product version refinement (e.g. ``"9.0"``).
 
     Returns:
         A :class:`DocsScope` carrying the normalised (stripped) values.
 
     Raises:
-        MissingDocsFilterError: when the REQUIRE_FILTERS gate is on and either
-            ``product`` or ``version`` is missing or blank.
+        MissingDocsFilterError: when ``collection`` is missing or blank.
     """
+    norm_collection = collection.strip() if collection and collection.strip() else None
     norm_product = product.strip() if product and product.strip() else None
     norm_version = version.strip() if version and version.strip() else None
 
-    if get_settings().corpus_require_filters:
-        missing: list[str] = []
-        if norm_product is None:
-            missing.append(_PRODUCT_KEY)
-        if norm_version is None:
-            missing.append(_VERSION_KEY)
-        if missing:
-            raise MissingDocsFilterError(missing)
+    if norm_collection is None:
+        raise MissingDocsFilterError([_COLLECTION_KEY])
 
-    return DocsScope(product=norm_product, version=norm_version)
+    return DocsScope(
+        collection_key=norm_collection,
+        product=norm_product,
+        version=norm_version,
+    )
 
 
 def _project_chunk(chunk: CorpusChunk) -> DocsChunk:
@@ -196,10 +222,10 @@ async def search_docs(
     query: str,
     *,
     scope: DocsScope,
+    collection: DocCollection,
     limit: int = 10,
-    collection: DocCollection | None = None,
 ) -> DocsSearchResult:
-    """Search a doc collection's backend for *operator* within *scope*.
+    """Search *collection*'s backend for *operator* within *scope*.
 
     Resolves *collection* to its concrete search backend via the
     backend-agnostic router
@@ -208,28 +234,29 @@ async def search_docs(
     managed RAG and another on the JWT-forward corpus behind this one
     entrypoint, and the agent never sees which backend answered. The
     operator JWT is forwarded by the adapter (for the JWT-forward corpus
-    backend), the search is scoped to the binary product+version filter,
-    and the cited chunks are projected into MEHO's surface. The query
-    itself is never logged here — only its presence is implied; the route
-    binds the SHA-256 hash to the audit row.
+    backend), the search is scoped by the collection (and the optional
+    product/version refinements), and the cited chunks are projected into
+    MEHO's surface. The query itself is never logged here — only its
+    presence is implied; the route binds the SHA-256 hash to the audit
+    row.
 
-    ``collection=None`` is the **legacy single-collection** path: a
-    deploy that has not yet adopted the ``doc_collections`` registry
-    federates every query to the one global ``corpus_url`` via the
-    re-homed :func:`~meho_backplane.auth.corpus.search_corpus` transport.
-    The collection-scoped request param that makes *collection* mandatory
-    is T3 (#1552); T2 ships the router with this additive, non-breaking
-    seam so the legacy path keeps working unchanged.
+    *collection* is the **required** binary scope (T3 #1552): the caller
+    (the REST route / MCP handler) has already resolved the
+    operator-supplied ``collection`` key to its registry row via
+    :func:`~meho_backplane.docs_collections.resolve_doc_collection`,
+    enforced per-collection entitlement, and checked readiness — so by the
+    time the query reaches here, the backend binding is authoritative.
 
     Args:
         operator: The verified operator whose JWT is forwarded to the
             backend.
         query: The free-text search query.
-        scope: The validated binary product+version scope from
-            :func:`build_docs_scope`.
+        scope: The validated binary scope from :func:`build_docs_scope`
+            (carries ``collection_key`` plus the optional product/version
+            refinements).
+        collection: The resolved doc collection whose ``backend`` record
+            the router selects the search backend from.
         limit: Maximum number of chunks to request.
-        collection: The resolved doc collection to search, or ``None`` for
-            the legacy single-collection corpus path.
 
     Returns:
         A :class:`DocsSearchResult` carrying the backend's ranked cited
@@ -242,34 +269,21 @@ async def search_docs(
             to HTTP 503 (the backend id never appears in the 503).
     """
     filters = scope.as_filters()
-    if collection is None:
-        # Legacy single-collection deploy: federate to the one global
-        # corpus through the module-level transport seam. Kept distinct
-        # from the routed path so the pre-registry behaviour (and the
-        # callers patching ``service.search_corpus``) is untouched until
-        # T3 makes ``collection`` mandatory.
-        response = await search_corpus(
-            operator,
-            query,
-            metadata_filters=filters or None,
-            limit=limit,
-        )
-    else:
-        resolved = resolve_backend(collection)
-        response = await resolved.backend.search(
-            operator,
-            query,
-            backend_ref=resolved.ref,
-            metadata_filters=filters or None,
-            limit=limit,
-        )
+    resolved = resolve_backend(collection)
+    response = await resolved.backend.search(
+        operator,
+        query,
+        backend_ref=resolved.ref,
+        metadata_filters=filters or None,
+        limit=limit,
+    )
     chunks = [_project_chunk(c) for c in response.chunks]
     _log.info(
         "docs_search_completed",
         operator_sub=operator.sub,
+        collection_key=scope.collection_key,
         product=scope.product,
         version=scope.version,
-        collection_key=collection.collection_key if collection is not None else None,
         hit_count=len(chunks),
     )
     return DocsSearchResult(chunks=chunks)

--- a/backend/src/meho_backplane/mcp/resources/docs.py
+++ b/backend/src/meho_backplane/mcp/resources/docs.py
@@ -1,63 +1,69 @@
 # SPDX-License-Identifier: Apache-2.0
 # Copyright (c) 2026 evoila Group
 
-"""``meho://docs/{product}/{version}/{chunk_id}`` — docs chunk resource (G4.5-T4).
+"""``meho://docs/{collection}/{product}/{version}/{chunk_id}`` — docs chunk resource.
 
-The fetch-by-citation companion to the :mod:`search_docs` meta-tool. An
-agent that kept only a hit's citation (``product`` / ``version`` /
-``chunk_id``) from an earlier ``search_docs`` call — but not the full
-chunk text — reads this resource on a later turn to recover the text
-without re-running and re-scanning the whole search.
+G4.6-T3 (#1552), building on G4.5-T4. The fetch-by-citation companion to
+the :mod:`search_docs` meta-tool. An agent that kept only a hit's citation
+(``collection`` / ``product`` / ``version`` / ``chunk_id``) from an earlier
+``search_docs`` call — but not the full chunk text — reads this resource on
+a later turn to recover the text without re-running and re-scanning the
+whole search.
 
-Gated identically to the tool
-=============================
+Gated identically to the tool, per-collection
+=============================================
 
 The template carries the same ``required_capability="meho-docs"`` gate as
 ``search_docs`` (G4.5-T1, #1519): a tenant without the ``meho-docs``
 add-on never sees it in ``resources/templates/list`` and a
 ``resources/read`` on a known URI is rejected with a 403-class error
-before the handler runs. The gate is enforced at list time
-(:func:`~meho_backplane.mcp.registry.all_resource_templates_for`) and
-again at read time
-(:func:`~meho_backplane.mcp.handlers.handle_resources_read`).
+before the handler runs (enforced at list time by
+:func:`~meho_backplane.mcp.registry.all_resource_templates_for` and again
+at read time by :func:`~meho_backplane.mcp.handlers.handle_resources_read`).
+On top of that visibility gate, the handler enforces the **per-collection**
+``meho-docs:<collection>`` entitlement (G4.6-T3 #1552) — so reading a chunk
+from a collection the tenant is not entitled to is rejected even when the
+add-on is provisioned.
 
 Why the URI carries the scope (and how the fetch works)
 =======================================================
 
 The corpus federation client (T2, :mod:`meho_backplane.auth.corpus`)
 exposes search-by-query only — there is no fetch-chunk-by-id endpoint to
-proxy. So this resource recovers a chunk by **re-issuing a scoped corpus
-search** through the same shared
+proxy. So this resource recovers a chunk by **re-issuing a scoped search**
+through the same shared
 :func:`~meho_backplane.docs_search.search_docs` service the tool uses,
 then selecting the hit whose ``chunk_id`` matches the URI. That is why the
-``product`` and ``version`` are in the URI rather than just a bare
-``chunk_id``: they are the mandatory binary scope the re-search needs, and
-encoding them lets :func:`~meho_backplane.docs_search.build_docs_scope`
-enforce the same REQUIRE_FILTERS posture the tool enforces (a blank
-segment can't physically match the ``[^/]+`` template, so the gate is
-belt-and-suspenders here). The ``chunk_id`` is used as the re-search query
-text — chunk ids are document-derived tokens, so the corpus's own ranking
-surfaces the matching chunk near the top of a bounded re-search — and the
-exact-id match is then taken from the returned chunks.
+``collection`` (plus the optional ``product`` / ``version``) is in the URI:
+``collection`` is the mandatory binary scope the re-search needs to route +
+entitle, and encoding it lets
+:func:`~meho_backplane.docs_search.build_docs_scope` enforce the same
+collection-scoped posture the tool enforces (a blank segment can't
+physically match the ``[^/]+`` template, so the gate is belt-and-suspenders
+here). The ``chunk_id`` is used as the re-search query text — chunk ids are
+document-derived tokens, so the backend's own ranking surfaces the matching
+chunk near the top of a bounded re-search — and the exact-id match is then
+taken from the returned chunks.
 
-Rejection arms (all ``-32602`` INVALID_PARAMS)
-==============================================
+Rejection arms
+==============
 
-* **Blank scope segment** —
-  :class:`~meho_backplane.docs_search.MissingDocsFilterError` from
-  :func:`build_docs_scope` (only reachable with the gate on and a
-  segment that survived the template but is blank-after-strip) maps to
+* **Blank scope segment / unknown / not-entitled collection** (all
+  ``-32602`` INVALID_PARAMS) —
+  :class:`~meho_backplane.docs_search.MissingDocsFilterError`,
+  :class:`~meho_backplane.docs_search.UnknownCollectionError`, and
+  :class:`~meho_backplane.docs_search.CollectionForbiddenError` map to
   :class:`McpInvalidParamsError`.
-* **Chunk not found in the scope** — the re-search returned no chunk
-  whose ``chunk_id`` matches. Collapses to "docs chunk not found"
-  without revealing whether the scope is empty or the id is simply
-  absent, so the resource is not a probe oracle for the corpus contents.
+* **Chunk not found in the scope** (``-32602``) — the re-search returned no
+  chunk whose ``chunk_id`` matches. Collapses to "docs chunk not found"
+  without revealing whether the scope is empty or the id is simply absent,
+  so the resource is not a probe oracle for the collection contents.
 
-A corpus that is unavailable raises the typed
-:class:`~meho_backplane.auth.corpus.CorpusUnavailable`, which is *not*
-caught here: it bubbles to the dispatcher's generic catch and surfaces as
-``-32603`` Internal Error — the read was well-formed; the upstream is
-down.
+A not-ready collection (:class:`~meho_backplane.docs_search.CollectionNotReadyError`)
+or an unavailable backend (:class:`~meho_backplane.auth.corpus.CorpusUnavailable`)
+is *not* caught here: it bubbles to the dispatcher's generic catch and
+surfaces as ``-32603`` Internal Error — the read was well-formed; the
+backend is down / not serving.
 
 Response shape
 ==============
@@ -74,10 +80,16 @@ from __future__ import annotations
 
 from typing import Any, Final
 
+import structlog
+
 from meho_backplane.auth.operator import Operator, TenantRole
+from meho_backplane.db.engine import get_sessionmaker
 from meho_backplane.docs_search import (
+    CollectionForbiddenError,
     MissingDocsFilterError,
+    UnknownCollectionError,
     build_docs_scope,
+    resolve_entitled_ready_collection,
     search_docs,
 )
 from meho_backplane.mcp.registry import (
@@ -102,29 +114,51 @@ async def _docs_chunk_handler(
 ) -> dict[str, Any]:
     """Return the cited :class:`~meho_backplane.docs_search.DocsChunk` for the URI.
 
-    Rebuilds the binary product+version scope from the URI segments,
-    re-issues a scoped corpus search (the transport has no
-    fetch-by-id endpoint), and returns the chunk whose ``chunk_id``
-    matches the URI's ``{chunk_id}``. See the module docstring for why
-    the fetch is a re-search and for the rejection-arm contract.
+    Rebuilds the binary collection scope (plus the optional product /
+    version refinements) from the URI segments, resolves + entitles +
+    readiness-checks the collection, re-issues a scoped search (the
+    transport has no fetch-by-id endpoint), and returns the chunk whose
+    ``chunk_id`` matches the URI's ``{chunk_id}``. See the module docstring
+    for why the fetch is a re-search and for the rejection-arm contract.
     """
+    collection_arg = bound["collection"]
     product = bound["product"]
     version = bound["version"]
     chunk_id = bound["chunk_id"]
 
     try:
-        scope = build_docs_scope(product, version)
+        scope = build_docs_scope(collection_arg, product, version)
     except MissingDocsFilterError as exc:
         raise McpInvalidParamsError(f"docs chunk: {exc}") from exc
 
+    structlog.contextvars.bind_contextvars(audit_collection=scope.collection_key)
+
+    # Resolve + entitle + readiness gate (the same shared gate the tools
+    # run). Unknown / not-entitled collections map to -32602; a not-ready
+    # collection bubbles to -32603 via the dispatcher's generic catch.
+    sessionmaker = get_sessionmaker()
+    async with sessionmaker() as session:
+        try:
+            collection = await resolve_entitled_ready_collection(
+                session, operator, scope.collection_key
+            )
+        except UnknownCollectionError as exc:
+            raise McpInvalidParamsError(
+                f"docs chunk: unknown collection {exc.collection_key!r}",
+                data={"known_collections": exc.known_keys},
+            ) from exc
+        except CollectionForbiddenError as exc:
+            raise McpInvalidParamsError(f"docs chunk: {exc}") from exc
+
     # The transport is search-only, so recover the chunk by re-searching
     # the bound scope and matching on the exact id. The chunk_id doubles
-    # as the query text — chunk ids are document-derived, so the corpus
+    # as the query text — chunk ids are document-derived, so the backend
     # ranks the matching chunk highly within the bounded window.
     result = await search_docs(
         operator,
         chunk_id,
         scope=scope,
+        collection=collection,
         limit=_FETCH_SEARCH_LIMIT,
     )
     for chunk in result.chunks:
@@ -132,26 +166,28 @@ async def _docs_chunk_handler(
             return chunk.model_dump(mode="json")
 
     # Not-found collapse: never distinguish "empty scope" from "no such
-    # chunk" so the resource can't be used as a corpus-contents oracle.
+    # chunk" so the resource can't be used as a collection-contents oracle.
     raise McpInvalidParamsError(
-        f"docs chunk not found: product={product!r}, version={version!r}, chunk_id={chunk_id!r}",
+        f"docs chunk not found: collection={collection_arg!r}, "
+        f"product={product!r}, version={version!r}, chunk_id={chunk_id!r}",
     )
 
 
 register_mcp_resource(
     definition=ResourceTemplateDefinition(
-        uriTemplate="meho://docs/{product}/{version}/{chunk_id}",
+        uriTemplate="meho://docs/{collection}/{product}/{version}/{chunk_id}",
         name="Vendor-document chunk",
         description=(
             "Full text and citation of one vendor-document chunk, "
-            "identified by the product + version scope and the chunk id "
-            "from a `search_docs` hit. Use after `search_docs` has "
-            "returned a citation whose chunk text you no longer have in "
-            "context — this resource recovers the chunk's content plus "
-            "its `source_url` without re-running the whole search. "
-            "Returns INVALID_PARAMS for a blank scope segment or for a "
-            "(product, version, chunk_id) that doesn't resolve to a "
-            "chunk under the operator's federated corpus access."
+            "identified by the collection scope (plus the product / version "
+            "refinements) and the chunk id from a `search_docs` hit. Use "
+            "after `search_docs` has returned a citation whose chunk text "
+            "you no longer have in context — this resource recovers the "
+            "chunk's content plus its `source_url` without re-running the "
+            "whole search. Returns INVALID_PARAMS for a blank / unknown / "
+            "not-entitled collection segment or for a (collection, product, "
+            "version, chunk_id) that doesn't resolve to a chunk under the "
+            "operator's collection access."
         ),
         mimeType="text/markdown",
         required_role=TenantRole.OPERATOR,

--- a/backend/src/meho_backplane/mcp/tools/docs.py
+++ b/backend/src/meho_backplane/mcp/tools/docs.py
@@ -94,9 +94,15 @@ from typing import Any, Final
 import structlog
 
 from meho_backplane.auth.operator import Operator, TenantRole
+from meho_backplane.db.engine import get_sessionmaker
+from meho_backplane.docs_collections import DocCollection
 from meho_backplane.docs_search import (
+    CollectionForbiddenError,
+    DocsScope,
     MissingDocsFilterError,
+    UnknownCollectionError,
     build_docs_scope,
+    resolve_entitled_ready_collection,
     search_docs,
     synthesize_docs_answer,
 )
@@ -135,53 +141,100 @@ _SEARCH_OP_ID: Final[str] = "meho.docs.search"
 _ASK_OP_ID: Final[str] = "meho.docs.ask"
 
 
+def _build_scope_or_invalid_params(tool: str, arguments: dict[str, Any]) -> DocsScope:
+    """Build the binary scope from *arguments* or raise ``-32602``.
+
+    ``collection`` is the mandatory binary scope (T3 #1552); ``product`` /
+    ``version`` are optional refinements. A missing/blank ``collection``
+    raises :class:`MissingDocsFilterError`, re-raised here as
+    :class:`McpInvalidParamsError` so the dispatcher emits the spec-correct
+    ``-32602`` (the MCP analogue of the route's 422). The inputSchema's
+    ``required`` list catches this first for a schema-validating client;
+    this arm covers a non-validating client.
+    """
+    collection: str = arguments["collection"]
+    product: str | None = arguments.get("product")
+    version: str | None = arguments.get("version")
+    try:
+        return build_docs_scope(collection, product, version)
+    except MissingDocsFilterError as exc:
+        raise McpInvalidParamsError(f"{tool}: {exc}") from exc
+
+
+async def _resolve_collection_or_error(
+    operator: Operator,
+    scope: DocsScope,
+    *,
+    tool: str,
+) -> DocCollection:
+    """Resolve + entitle + readiness-check the scoped collection.
+
+    Opens its own DB session (the MCP dispatcher does not thread one), runs
+    the shared :func:`~meho_backplane.docs_search.resolve_entitled_ready_collection`
+    gate, and maps the typed access errors onto the MCP wire:
+
+    * **Unknown collection** → :class:`McpInvalidParamsError` (``-32602``):
+      a ``collection`` argument naming no visible collection is invalid
+      params, not a server fault. The catalogue of visible keys rides
+      ``error.data`` so the agent can self-correct.
+    * **Not entitled** → :class:`McpInvalidParamsError` (``-32602``,
+      projected to the 403-class audit status by the dispatcher): the same
+      403-projected path the static capability gate uses. The collection
+      exists; the tenant lacks ``meho-docs:<collection>``.
+    * **Not ready** — :class:`~meho_backplane.docs_search.CollectionNotReadyError`
+      is *not* caught here: a known + entitled collection whose backend is
+      not yet serving is a server-side condition (the MCP analogue of the
+      route's 409/503), so it bubbles to the dispatcher's generic catch as
+      ``-32603``.
+    """
+    sessionmaker = get_sessionmaker()
+    async with sessionmaker() as session:
+        try:
+            return await resolve_entitled_ready_collection(session, operator, scope.collection_key)
+        except UnknownCollectionError as exc:
+            raise McpInvalidParamsError(
+                f"{tool}: unknown collection {exc.collection_key!r}",
+                data={"known_collections": exc.known_keys},
+            ) from exc
+        except CollectionForbiddenError as exc:
+            raise McpInvalidParamsError(f"{tool}: {exc}") from exc
+
+
 async def _search_docs_handler(
     operator: Operator,
     arguments: dict[str, Any],
 ) -> dict[str, Any]:
-    """Federate a vendor-document query through the shared docs-search service.
+    """Route a vendor-document query through the shared docs-search service.
 
-    Validates the mandatory product+version binary scope, then delegates
-    to :func:`~meho_backplane.docs_search.search_docs` — the same service
-    the REST route fronts — forwarding the operator's JWT so the corpus
+    Validates the mandatory ``collection`` binary scope, resolves +
+    entitles + readiness-checks the collection, then delegates to
+    :func:`~meho_backplane.docs_search.search_docs` — the same service the
+    REST route fronts — forwarding the operator's JWT so the backend
     authenticates and audits the call as the operator.
 
-    Two error arms:
-
-    * **Missing/blank product or version** —
-      :class:`~meho_backplane.docs_search.MissingDocsFilterError` from
-      :func:`build_docs_scope` (when REQUIRE_FILTERS is on) is re-raised
-      as :class:`McpInvalidParamsError` so the dispatcher emits the
-      spec-correct ``-32602`` (the MCP analogue of the route's 422). The
-      inputSchema's ``required`` list catches this first for a
-      schema-validating client; this arm covers the gate-off → gate-on
-      flip and non-validating clients.
-    * **Corpus unavailable** — the typed
-      :class:`~meho_backplane.auth.corpus.CorpusUnavailable` is *not*
-      caught here. It bubbles to the dispatcher's generic catch and
-      surfaces as ``-32603`` Internal Error (the MCP analogue of the
-      route's 503): a well-formed request against a down upstream is a
-      server-side fault, not invalid params.
+    Error arms (see :func:`_build_scope_or_invalid_params` /
+    :func:`_resolve_collection_or_error`): a missing/blank or unknown /
+    not-entitled ``collection`` → ``-32602``; a not-ready collection or an
+    unavailable :class:`~meho_backplane.auth.corpus.CorpusUnavailable`
+    backend bubbles to ``-32603`` (a well-formed request against a backend
+    that is down / not serving is a server-side fault, not invalid params).
     """
-    # Bind the canonical op_id so the persisted audit row is filterable by
-    # ``op_id="meho.docs.search"`` the same way the REST + CLI faces are
-    # (G4.5-T8 #1549). The dispatcher lifts ``audit_op_id`` into the row's
-    # payload op_id; ``op_class="read"`` (declared on the ToolDefinition)
-    # and the broadcast / ``classify_op`` op_id (the bare tool name) are
-    # unchanged. Bound up-front so a handler exception still records the
-    # canonical identity on the row.
+    # Bind the canonical op_id + collection scope so the persisted audit row
+    # is filterable by ``op_id="meho.docs.search"`` and ``collection`` the
+    # same way the REST + CLI faces are (G4.5-T8 #1549, G4.6-T3 #1552). The
+    # dispatcher lifts the ``audit_*`` contextvars into the row's payload;
+    # ``op_class="read"`` (declared on the ToolDefinition) and the broadcast
+    # / ``classify_op`` op_id (the bare tool name) are unchanged. Bound
+    # up-front so a handler exception still records the canonical identity.
     structlog.contextvars.bind_contextvars(audit_op_id=_SEARCH_OP_ID)
     query: str = arguments["query"]
-    product: str = arguments["product"]
-    version: str = arguments["version"]
     limit: int = int(arguments.get("limit", _DEFAULT_SEARCH_LIMIT))
 
-    try:
-        scope = build_docs_scope(product, version)
-    except MissingDocsFilterError as exc:
-        raise McpInvalidParamsError(f"search_docs: {exc}") from exc
+    scope = _build_scope_or_invalid_params("search_docs", arguments)
+    structlog.contextvars.bind_contextvars(audit_collection=scope.collection_key)
+    collection = await _resolve_collection_or_error(operator, scope, tool="search_docs")
 
-    result = await search_docs(operator, query, scope=scope, limit=limit)
+    result = await search_docs(operator, query, scope=scope, collection=collection, limit=limit)
     return {
         "chunks": [chunk.model_dump(mode="json") for chunk in result.chunks],
     }
@@ -191,13 +244,15 @@ register_mcp_tool(
     definition=ToolDefinition(
         name="search_docs",
         description=(
-            "Search the vendor-document corpus (product manuals, KB "
+            "Search a vendor-document collection (product manuals, KB "
             "articles, design / reference guides) for an authoritative "
             "vendor fact — e.g. 'NSX config maximums for 9.0' or "
             "'vCenter 8.0 supported snapshot depth'. "
-            "REQUIRES `product` AND `version`: they are a hard binary "
-            "scope (the query is rejected without both), NOT a ranking "
-            "hint. "
+            "REQUIRES `collection`: it is the hard binary scope (the query "
+            "is rejected without it), naming WHICH corpus to search and "
+            "gating entitlement — pick it from `list_doc_collections`. "
+            "`product` and `version` are OPTIONAL refinements within that "
+            "collection, not a ranking hint. "
             "Use this for VENDOR REFERENCE — what the documentation says. "
             "Use `search_knowledge` instead for how THIS team does "
             "something (lab conventions, known-good runbooks, "
@@ -207,8 +262,8 @@ register_mcp_tool(
             "Returns ranked cited chunks: each carries the chunk text, a "
             "`source_url` citation, a `chunk_id`, and a `document_id`. "
             "For the full text of a hit on a later turn (when you kept "
-            "only the citation), read `meho://docs/{product}/{version}/"
-            "{chunk_id}` via `resources/read`. "
+            "only the citation), read `meho://docs/{collection}/{product}/"
+            "{version}/{chunk_id}` via `resources/read`. "
             "Limit defaults to 10; cap is 50."
         ),
         inputSchema={
@@ -220,8 +275,20 @@ register_mcp_tool(
                     "maxLength": 2000,
                     "description": (
                         "Free-form vendor-reference query. Forwarded to the "
-                        "corpus verbatim; never logged in the clear (the "
-                        "audit row stores only its SHA-256 hash)."
+                        "collection's backend verbatim; never logged in the "
+                        "clear (the audit row stores only its SHA-256 hash)."
+                    ),
+                },
+                "collection": {
+                    "type": "string",
+                    "minLength": 1,
+                    "maxLength": 128,
+                    "description": (
+                        "Collection key to search (e.g. 'vmware'). MANDATORY "
+                        "binary scope — it routes the query to a backend and "
+                        "gates per-collection entitlement; a query without "
+                        "it is rejected with INVALID_PARAMS. Pick it from "
+                        "`list_doc_collections`."
                     ),
                 },
                 "product": {
@@ -229,10 +296,9 @@ register_mcp_tool(
                     "minLength": 1,
                     "maxLength": 128,
                     "description": (
-                        "Vendor product to scope to (e.g. 'nsx', 'vcenter'). "
-                        "MANDATORY binary scope, not a hint — a query "
-                        "without it is rejected with INVALID_PARAMS while "
-                        "the REQUIRE_FILTERS posture is on."
+                        "OPTIONAL vendor-product refinement within the "
+                        "collection (e.g. 'nsx', 'vcenter'). Narrows the "
+                        "search; omit it to search the whole collection."
                     ),
                 },
                 "version": {
@@ -240,10 +306,9 @@ register_mcp_tool(
                     "minLength": 1,
                     "maxLength": 128,
                     "description": (
-                        "Product version to scope to (e.g. '9.0'). "
-                        "MANDATORY binary scope alongside `product` — "
-                        "both are required to bound the search to one "
-                        "product / version slice."
+                        "OPTIONAL product-version refinement (e.g. '9.0'). "
+                        "Narrows the search alongside `product`; omit it to "
+                        "search the whole collection."
                     ),
                 },
                 "limit": {
@@ -254,7 +319,7 @@ register_mcp_tool(
                     "description": "Maximum number of ranked cited chunks to return.",
                 },
             },
-            "required": ["query", "product", "version"],
+            "required": ["query", "collection"],
             "additionalProperties": False,
         },
         required_role=TenantRole.OPERATOR,
@@ -272,23 +337,27 @@ async def _ask_docs_handler(
     """Answer a vendor-document question with a grounded, cited answer.
 
     The synthesis fast-follow to ``search_docs``: it runs the **same**
-    shared retrieval (so the REQUIRE_FILTERS gate, corpus federation, and
-    forwarded-JWT audit are enforced in exactly one place), then composes a
-    single answer grounded strictly in the retrieved chunks via
+    shared retrieval (so the collection scope gate, per-collection
+    entitlement, backend routing, and forwarded-JWT audit are enforced in
+    exactly one place), then composes a single answer grounded strictly in
+    the retrieved chunks via
     :func:`~meho_backplane.docs_search.synthesize_docs_answer`. Returns
     ``{answer, citations[]}`` where every citation is a chunk the retrieval
     returned and the model relied on — no claim without a citation.
 
     Error arms mirror ``search_docs`` exactly, plus the synthesis arm:
 
-    * **Missing/blank product or version** —
-      :class:`~meho_backplane.docs_search.MissingDocsFilterError` from
-      :func:`build_docs_scope` re-raised as :class:`McpInvalidParamsError`
-      (``-32602``, the MCP analogue of the route's 422). The inputSchema's
-      ``required`` list catches this first for a schema-validating client.
-    * **Corpus unavailable** —
-      :class:`~meho_backplane.auth.corpus.CorpusUnavailable` is *not*
-      caught; it bubbles to ``-32603`` (a down upstream is a server fault).
+    * **Missing/blank or unknown / not-entitled ``collection``** — mapped to
+      :class:`McpInvalidParamsError` (``-32602``) by
+      :func:`_build_scope_or_invalid_params` /
+      :func:`_resolve_collection_or_error` (the MCP analogue of the route's
+      422 / 403). The inputSchema's ``required`` list catches the missing
+      case first for a schema-validating client.
+    * **Not-ready collection / corpus unavailable** —
+      :class:`~meho_backplane.docs_search.CollectionNotReadyError` and
+      :class:`~meho_backplane.auth.corpus.CorpusUnavailable` are *not*
+      caught; they bubble to ``-32603`` (a down / not-serving backend is a
+      server fault).
     * **Synthesis model unconfigured / unreachable** —
       :class:`~meho_backplane.operations.ingest.LlmClientUnavailable` (and
       :class:`~meho_backplane.docs_search.DocsSynthesisError` for a model
@@ -299,22 +368,20 @@ async def _ask_docs_handler(
       helper, which returns a deterministic "no grounded answer" *without*
       calling the model.
     """
-    # Same canonical-op_id binding as ``search_docs`` — ``ask_docs`` audit
-    # rows are filterable by ``op_id="meho.docs.ask"`` across all three
-    # faces (G4.5-T8 #1549). ``op_class`` stays ``read``; ask is a
-    # read-class compose over retrieved chunks.
+    # Same canonical-op_id + collection binding as ``search_docs`` —
+    # ``ask_docs`` audit rows are filterable by ``op_id="meho.docs.ask"``
+    # and ``collection`` across all faces (G4.5-T8 #1549, G4.6-T3 #1552).
+    # ``op_class`` stays ``read``; ask is a read-class compose over
+    # retrieved chunks.
     structlog.contextvars.bind_contextvars(audit_op_id=_ASK_OP_ID)
     query: str = arguments["query"]
-    product: str = arguments["product"]
-    version: str = arguments["version"]
     limit: int = int(arguments.get("limit", _DEFAULT_SEARCH_LIMIT))
 
-    try:
-        scope = build_docs_scope(product, version)
-    except MissingDocsFilterError as exc:
-        raise McpInvalidParamsError(f"ask_docs: {exc}") from exc
+    scope = _build_scope_or_invalid_params("ask_docs", arguments)
+    structlog.contextvars.bind_contextvars(audit_collection=scope.collection_key)
+    collection = await _resolve_collection_or_error(operator, scope, tool="ask_docs")
 
-    retrieval = await search_docs(operator, query, scope=scope, limit=limit)
+    retrieval = await search_docs(operator, query, scope=scope, collection=collection, limit=limit)
     answer = await synthesize_docs_answer(query, retrieval)
     return {
         "answer": answer.answer,
@@ -327,16 +394,18 @@ register_mcp_tool(
         name="ask_docs",
         description=(
             "Answer a vendor-reference question with a SYNTHESIZED, CITED "
-            "answer composed over the vendor-document corpus (product "
+            "answer composed over a vendor-document collection (product "
             "manuals, KB articles, design / reference guides) — e.g. 'What "
             "are the NSX 9.0 config maximums for logical switches?'. "
             "This is the answer-shaped sibling of `search_docs`: "
             "`search_docs` returns the raw ranked chunks; `ask_docs` "
             "composes them into one grounded answer and returns the chunks "
             "it cited. "
-            "REQUIRES `product` AND `version`: they are a hard binary "
-            "scope (the question is rejected without both), NOT a ranking "
-            "hint. "
+            "REQUIRES `collection`: it is the hard binary scope (the "
+            "question is rejected without it), naming WHICH corpus to "
+            "search and gating entitlement — pick it from "
+            "`list_doc_collections`. `product` and `version` are OPTIONAL "
+            "refinements within that collection, not a ranking hint. "
             "Use this for VENDOR REFERENCE when you want a composed answer "
             "rather than chunks to read yourself; use `search_docs` for the "
             "raw chunks, `search_knowledge` for how THIS team does "
@@ -344,9 +413,9 @@ register_mcp_tool(
             "post-incident learnings), and `search_memory` for "
             "cross-session state. "
             "Returns `{answer, citations[]}`: the answer is grounded "
-            "STRICTLY in the corpus (no claim without a citation), and "
+            "STRICTLY in the collection (no claim without a citation), and "
             "every citation is one of the cited chunks (chunk text, "
-            "`source_url`, `chunk_id`, `document_id`). If the corpus has "
+            "`source_url`, `chunk_id`, `document_id`). If the collection has "
             "nothing in scope, the answer is 'no grounded answer' — never "
             "a guess. "
             "Limit (chunks retrieved to ground on) defaults to 10; cap is 50."
@@ -360,9 +429,21 @@ register_mcp_tool(
                     "maxLength": 2000,
                     "description": (
                         "Free-form vendor-reference question. Forwarded to "
-                        "the corpus verbatim for retrieval and to the "
-                        "synthesis model; never logged in the clear (the "
-                        "audit row stores only its SHA-256 hash)."
+                        "the collection's backend verbatim for retrieval and "
+                        "to the synthesis model; never logged in the clear "
+                        "(the audit row stores only its SHA-256 hash)."
+                    ),
+                },
+                "collection": {
+                    "type": "string",
+                    "minLength": 1,
+                    "maxLength": 128,
+                    "description": (
+                        "Collection key to ground the answer on (e.g. "
+                        "'vmware'). MANDATORY binary scope — it routes "
+                        "retrieval to a backend and gates per-collection "
+                        "entitlement; a question without it is rejected with "
+                        "INVALID_PARAMS. Pick it from `list_doc_collections`."
                     ),
                 },
                 "product": {
@@ -370,10 +451,9 @@ register_mcp_tool(
                     "minLength": 1,
                     "maxLength": 128,
                     "description": (
-                        "Vendor product to scope to (e.g. 'nsx', 'vcenter'). "
-                        "MANDATORY binary scope, not a hint — a question "
-                        "without it is rejected with INVALID_PARAMS while "
-                        "the REQUIRE_FILTERS posture is on."
+                        "OPTIONAL vendor-product refinement within the "
+                        "collection (e.g. 'nsx', 'vcenter'). Narrows "
+                        "retrieval; omit it to ground on the whole collection."
                     ),
                 },
                 "version": {
@@ -381,10 +461,9 @@ register_mcp_tool(
                     "minLength": 1,
                     "maxLength": 128,
                     "description": (
-                        "Product version to scope to (e.g. '9.0'). "
-                        "MANDATORY binary scope alongside `product` — "
-                        "both are required to bound the search to one "
-                        "product / version slice."
+                        "OPTIONAL product-version refinement (e.g. '9.0'). "
+                        "Narrows retrieval alongside `product`; omit it to "
+                        "ground on the whole collection."
                     ),
                 },
                 "limit": {
@@ -398,7 +477,7 @@ register_mcp_tool(
                     ),
                 },
             },
-            "required": ["query", "product", "version"],
+            "required": ["query", "collection"],
             "additionalProperties": False,
         },
         required_role=TenantRole.OPERATOR,

--- a/backend/tests/_oidc_jwt_helpers.py
+++ b/backend/tests/_oidc_jwt_helpers.py
@@ -73,6 +73,7 @@ def mint_token(
     tenant_id: str = DEFAULT_TENANT_ID,
     tenant_role: str = DEFAULT_TENANT_ROLE,
     audience: str | None = None,
+    capabilities: list[str] | None = None,
 ) -> str:
     """Mint a happy-path JWT signed by *private_key*.
 
@@ -85,6 +86,11 @@ def mint_token(
     don't change. The MCP acceptance suite passes the canonical MCP
     resource URI here so the same minter can produce tokens for both
     audiences without forking a parallel helper.
+
+    ``capabilities`` populates the ``capabilities`` JWT claim the backend's
+    ``_extract_capabilities`` reads onto ``Operator.capabilities`` (G4.5-T1
+    add-on / G4.6-T3 per-collection entitlement). ``None`` omits the claim
+    entirely so pre-capability call sites are unchanged.
     """
     with warnings.catch_warnings():
         warnings.simplefilter("ignore")
@@ -104,6 +110,8 @@ def mint_token(
             payload["name"] = name
         if email is not None:
             payload["email"] = email
+        if capabilities is not None:
+            payload["capabilities"] = capabilities
         header = {"alg": "RS256", "kid": private_key.as_dict()["kid"], "typ": "JWT"}
         token: bytes | str = jwt.encode(header, payload, private_key)
         return token.decode("ascii") if isinstance(token, bytes) else token

--- a/backend/tests/mcp_test_fixtures.py
+++ b/backend/tests/mcp_test_fixtures.py
@@ -50,7 +50,7 @@ from fastapi.testclient import TestClient
 
 from meho_backplane.auth.operator import Operator, TenantRole
 from meho_backplane.db.engine import get_sessionmaker
-from meho_backplane.db.models import Tenant
+from meho_backplane.db.models import DocCollection, Tenant
 from meho_backplane.main import app
 from meho_backplane.mcp.auth import verify_mcp_jwt_and_bind
 from meho_backplane.mcp.registry import clear_registries
@@ -63,8 +63,41 @@ __all__ = [
     "isolated_registry",
     "post_mcp",
     "required_settings_env",
+    "seed_doc_collection",
     "seeded_operator_tenant",
 ]
+
+
+async def seed_doc_collection(
+    *,
+    collection_key: str = "vmware",
+    status: str = "ready",
+    backend: dict[str, Any] | None = None,
+    tenant_id: UUID | None = None,
+) -> None:
+    """Insert a global :class:`DocCollection` row for collection-scoped tests.
+
+    Defaults to a ``ready`` ``vmware`` collection bound to the
+    ``corpus-http`` backend (no ``ref`` → the legacy global corpus URL the
+    transport mock stands in for). Pass ``status="rebuilding"`` to exercise
+    the not-ready arm, or a ``tenant_id`` to make it tenant-curated. The
+    ``backend`` record is NOT NULL with no default, so a valid ``{type}``
+    is always supplied.
+    """
+    sessionmaker = get_sessionmaker()
+    async with sessionmaker() as session, session.begin():
+        session.add(
+            DocCollection(
+                tenant_id=tenant_id,
+                collection_key=collection_key,
+                vendor="VMware by Broadcom",
+                products=["vsphere", "nsx"],
+                description="VMware vendor docs.",
+                when_to_use="VMware product questions.",
+                backend=backend if backend is not None else {"type": "corpus-http"},
+                status=status,
+            ),
+        )
 
 
 #: UUID pinned for the fixture operator's ``tenant_id``. Used by every

--- a/backend/tests/test_docs_backends_router.py
+++ b/backend/tests/test_docs_backends_router.py
@@ -413,7 +413,7 @@ async def test_search_docs_routes_through_resolved_backend(_restore_registry: No
     result = await search_docs(
         _make_operator(),
         "how do I configure NSX",
-        scope=DocsScope(product="vmware", version="9.0"),
+        scope=DocsScope(collection_key="vmware", product="vmware", version="9.0"),
         limit=7,
         collection=collection,
     )
@@ -450,6 +450,6 @@ async def test_search_docs_unroutable_collection_raises(_restore_registry: None)
         await search_docs(
             _make_operator(),
             "q",
-            scope=DocsScope(product="vmware", version="9.0"),
+            scope=DocsScope(collection_key="vmware", product="vmware", version="9.0"),
             collection=collection,
         )

--- a/backend/tests/test_mcp_resources_docs.py
+++ b/backend/tests/test_mcp_resources_docs.py
@@ -1,29 +1,34 @@
 # SPDX-License-Identifier: Apache-2.0
 # Copyright (c) 2026 evoila Group
 
-"""Tests for the ``meho://docs/{...}`` companion resource (G4.5-T4, #1523).
+"""Tests for the ``meho://docs/{...}`` companion resource (G4.6-T3, #1552).
 
-Covers the resource-side acceptance criteria:
+Covers the collection-scoped resource acceptance criteria:
 
-* ``meho://docs/{product}/{version}/{chunk_id}`` is registered, gated by
-  the SAME ``required_capability="meho-docs"`` as the ``search_docs`` tool:
-  absent from ``resources/templates/list`` and 403-on-read for a tenant
-  without the capability; present + readable for one with it.
-* ``resources/read`` recovers the cited chunk's text (the corpus transport
-  has no fetch-by-id endpoint, so the handler re-issues a scoped search
-  and matches on ``chunk_id``).
-* A ``(product, version, chunk_id)`` that doesn't resolve collapses to
-  INVALID_PARAMS "not found" without leaking corpus contents.
-* The MEHO-internal RBAC + capability fields are stripped from the wire.
+* ``meho://docs/{collection}/{product}/{version}/{chunk_id}`` is
+  registered, gated by the SAME ``required_capability="meho-docs"`` as the
+  ``search_docs`` tool: absent from ``resources/templates/list`` and
+  403-on-read for a tenant without the base capability; present for one
+  with it.
+* **Per-collection entitlement (#1552):** a tenant with base ``meho-docs``
+  but not ``meho-docs:<collection>`` → 403-class read even though the
+  template is visible.
+* ``resources/read`` recovers the cited chunk's text (the backend has no
+  fetch-by-id endpoint, so the handler re-issues a scoped search and
+  matches on ``chunk_id``).
+* A ``(collection, product, version, chunk_id)`` that doesn't resolve
+  collapses to INVALID_PARAMS "not found" without leaking collection
+  contents.
 
-The shared docs-search service federates to an external corpus; these
-unit tests mock
-:func:`meho_backplane.docs_search.service.search_corpus` so the read
-plumbing is exercised without a live corpus.
+The ``corpus-http`` backend wraps the JWT-forward transport; these unit
+tests mock
+:func:`meho_backplane.docs_search.backends.corpus_http.search_corpus` so
+the read plumbing is exercised without a live corpus.
 """
 
 from __future__ import annotations
 
+import asyncio
 import json
 from collections.abc import Iterator
 from typing import Any
@@ -42,10 +47,25 @@ from tests.mcp_test_fixtures import (
     isolated_registry,  # noqa: F401 — pytest-discovered autouse fixture
     post_mcp,
     required_settings_env,  # noqa: F401 — pytest-discovered autouse fixture
+    seed_doc_collection,
 )
 
 _DOCS_CAPABILITY = "meho-docs"
-_DOCS_URI = "meho://docs/nsx/9.0/nsx-9.0-maximums-0007"
+#: Per-collection entitlement key for the seeded ``vmware`` collection.
+_VMWARE_CAP = "meho-docs:vmware"
+#: A provisioned + vmware-entitled capability set.
+_ENTITLED = frozenset({_DOCS_CAPABILITY, _VMWARE_CAP})
+#: URI now carries the leading ``{collection}`` segment.
+_DOCS_URI = "meho://docs/vmware/nsx/9.0/nsx-9.0-maximums-0007"
+_DOCS_TEMPLATE = "meho://docs/{collection}/{product}/{version}/{chunk_id}"
+
+#: The corpus-http backend's transport seam.
+_CORPUS_SEAM = "meho_backplane.docs_search.backends.corpus_http.search_corpus"
+
+
+def _seed_collection_sync(**kwargs: Any) -> None:
+    """Run :func:`seed_doc_collection` to completion from a sync test."""
+    asyncio.run(seed_doc_collection(**kwargs))
 
 
 def _operator(
@@ -122,14 +142,18 @@ def test_docs_resource_absent_from_templates_list_when_unprovisioned(
     )
     assert response.status_code == 200
     templates = {t["uriTemplate"] for t in response.json()["result"]["resourceTemplates"]}
-    assert "meho://docs/{product}/{version}/{chunk_id}" not in templates
+    assert _DOCS_TEMPLATE not in templates
 
 
 @pytest.mark.parametrize("docs_client", [frozenset({_DOCS_CAPABILITY})], indirect=True)
 def test_docs_resource_present_with_stripped_wire_fields_when_provisioned(
     docs_client: tuple[TestClient, Operator],
 ) -> None:
-    """The template appears once provisioned; wire shape drops the gating fields."""
+    """The template appears once provisioned; wire shape drops the gating fields.
+
+    Visibility rides only the base ``meho-docs`` capability — the
+    per-collection entitlement is enforced at read time, not list time.
+    """
     client, _op = docs_client
     response = post_mcp(
         client,
@@ -137,7 +161,7 @@ def test_docs_resource_present_with_stripped_wire_fields_when_provisioned(
     )
     assert response.status_code == 200
     templates = {t["uriTemplate"]: t for t in response.json()["result"]["resourceTemplates"]}
-    template = templates.get("meho://docs/{product}/{version}/{chunk_id}")
+    template = templates.get(_DOCS_TEMPLATE)
     assert template is not None
     assert template["mimeType"] == "text/markdown"
     assert "required_role" not in template
@@ -159,7 +183,7 @@ def test_resources_read_docs_403_when_unprovisioned(
     """
     client, _op = docs_client
     fake = _fake_corpus(_SAMPLE_CHUNK)
-    with patch("meho_backplane.docs_search.service.search_corpus", new=fake):
+    with patch(_CORPUS_SEAM, new=fake):
         response = post_mcp(
             client,
             {
@@ -182,24 +206,26 @@ def test_resources_read_docs_403_when_unprovisioned(
 # ---------------------------------------------------------------------------
 
 
-@pytest.mark.parametrize("docs_client", [frozenset({_DOCS_CAPABILITY})], indirect=True)
+@pytest.mark.parametrize("docs_client", [_ENTITLED], indirect=True)
 def test_resources_read_docs_returns_matching_chunk_text(
     docs_client: tuple[TestClient, Operator],
 ) -> None:
-    """A provisioned read recovers the chunk whose id matches the URI.
+    """An entitled read recovers the chunk whose id matches the URI.
 
-    The handler rebuilds the binary scope from the URI segments,
-    re-issues a scoped corpus search, and returns the exact-id match —
-    even when the corpus returns sibling chunks alongside it.
+    The handler rebuilds the binary scope from the URI segments, runs the
+    resolve + entitle + readiness gate, re-issues a scoped search on the
+    collection's backend, and returns the exact-id match — even when the
+    backend returns sibling chunks alongside it.
     """
     client, op = docs_client
+    _seed_collection_sync()
     other = CorpusChunk(
         chunk_id="nsx-9.0-maximums-0008",
         document_id="nsx-9.0-config-maximums",
         content="An unrelated sibling chunk.",
     )
     fake = _fake_corpus(other, _SAMPLE_CHUNK)
-    with patch("meho_backplane.docs_search.service.search_corpus", new=fake):
+    with patch(_CORPUS_SEAM, new=fake):
         response = post_mcp(
             client,
             {
@@ -219,32 +245,63 @@ def test_resources_read_docs_returns_matching_chunk_text(
     assert chunk["content"].startswith("NSX 9.0 supports")
     assert chunk["source_url"].endswith("/maximums")
 
-    # The binary scope reached the corpus and the operator identity was forwarded.
+    # The optional product/version refinements reached the backend and the
+    # operator identity was forwarded.
     captured = fake.captured  # type: ignore[attr-defined]
     assert captured["metadata_filters"] == {"product": "nsx", "version": "9.0"}
     assert captured["operator"].tenant_id == op.tenant_id
 
 
-# ---------------------------------------------------------------------------
-# resources/read — not-found collapse + corpus-down internal error
-# ---------------------------------------------------------------------------
-
-
 @pytest.mark.parametrize("docs_client", [frozenset({_DOCS_CAPABILITY})], indirect=True)
+def test_resources_read_docs_403_when_not_entitled_to_collection(
+    docs_client: tuple[TestClient, Operator],
+) -> None:
+    """A tenant with base ``meho-docs`` but not ``meho-docs:vmware`` → 403-class read.
+
+    The template is visible (base capability), but the per-collection
+    entitlement gate rejects the read before the backend re-search.
+    """
+    client, _op = docs_client
+    _seed_collection_sync()
+    fake = _fake_corpus(_SAMPLE_CHUNK)
+    with patch(_CORPUS_SEAM, new=fake):
+        response = post_mcp(
+            client,
+            {
+                "jsonrpc": "2.0",
+                "id": 6,
+                "method": "resources/read",
+                "params": {"uri": _DOCS_URI},
+            },
+        )
+    assert response.status_code == 200
+    body = response.json()
+    assert body["error"]["code"] == INVALID_PARAMS
+    assert "entitled" in body["error"]["message"].lower()
+    assert "query" not in fake.captured  # type: ignore[attr-defined]
+
+
+# ---------------------------------------------------------------------------
+# resources/read — not-found collapse + backend-down internal error
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.parametrize("docs_client", [_ENTITLED], indirect=True)
 def test_resources_read_docs_unknown_chunk_collapses_to_not_found(
     docs_client: tuple[TestClient, Operator],
 ) -> None:
     """A chunk id absent from the re-search collapses to INVALID_PARAMS not-found.
 
     The message never distinguishes "empty scope" from "no such id" so
-    the resource can't be used as a corpus-contents oracle.
+    the resource can't be used as a collection-contents oracle.
     """
     client, _op = docs_client
-    # The corpus returns only a non-matching chunk.
+    _seed_collection_sync()
+    # The backend returns only a non-matching chunk.
     fake = _fake_corpus(
         CorpusChunk(chunk_id="some-other-id", document_id="d", content="x"),
     )
-    with patch("meho_backplane.docs_search.service.search_corpus", new=fake):
+    with patch(_CORPUS_SEAM, new=fake):
         response = post_mcp(
             client,
             {
@@ -260,17 +317,18 @@ def test_resources_read_docs_unknown_chunk_collapses_to_not_found(
     assert "not found" in body["error"]["message"].lower()
 
 
-@pytest.mark.parametrize("docs_client", [frozenset({_DOCS_CAPABILITY})], indirect=True)
-def test_resources_read_docs_corpus_unavailable_is_internal_error(
+@pytest.mark.parametrize("docs_client", [_ENTITLED], indirect=True)
+def test_resources_read_docs_backend_unavailable_is_internal_error(
     docs_client: tuple[TestClient, Operator],
 ) -> None:
-    """A down corpus surfaces as ``-32603`` Internal Error, not invalid params."""
+    """A down backend surfaces as ``-32603`` Internal Error, not invalid params."""
     client, _op = docs_client
+    _seed_collection_sync()
 
     async def _down(_op: Operator, _query: str, **_kwargs: Any) -> CorpusSearchResponse:
         raise CorpusUnavailable("corpus unreachable: ConnectError")
 
-    with patch("meho_backplane.docs_search.service.search_corpus", new=_down):
+    with patch(_CORPUS_SEAM, new=_down):
         response = post_mcp(
             client,
             {

--- a/backend/tests/test_mcp_tools_docs.py
+++ b/backend/tests/test_mcp_tools_docs.py
@@ -1,34 +1,37 @@
 # SPDX-License-Identifier: Apache-2.0
 # Copyright (c) 2026 evoila Group
 
-"""Tests for the capability-gated ``search_docs`` MCP tool (G4.5-T4, #1523).
+"""Tests for the collection-scoped ``search_docs`` MCP tool (G4.6-T3, #1552).
 
-Covers every acceptance criterion in the task body:
+Covers the collection-scoped contract layered on the G4.5-T4 capability gate:
 
 * ``search_docs`` is registered with ``required_capability="meho-docs"``;
-  it is **absent** from ``tools/list`` for a tenant without the
+  it is **absent** from ``tools/list`` for a tenant without the base
   capability and **present** for one with it (T1's gate, #1519).
-* ``tools/call search_docs`` from an unprovisioned tenant → 403-class
-  error (the handler never runs); from a provisioned tenant with
-  product+version → cited chunks; missing/blank product or version →
-  the T3 422 surfaced as an MCP ``-32602`` error.
 * ``inputSchema`` is strict (``additionalProperties: false``, required
-  ``[query, product, version]``); the MEHO-internal RBAC + capability
-  fields are stripped from the wire shape.
-* The handler calls the shared docs-search service with the operator's
-  forwarded identity and the validated binary scope.
-* The description names the sibling tools (``search_knowledge`` /
-  ``search_memory``) and points to the companion resource.
+  ``[query, collection]``, product/version demoted to optional).
+* ``tools/call search_docs`` from a tenant lacking the base ``meho-docs``
+  capability → 403-class error (the handler never runs); a missing
+  ``collection`` → ``-32602``.
+* **Per-collection entitlement (#1552):** a tenant with the base
+  ``meho-docs`` capability but lacking ``meho-docs:<collection>`` → a
+  403-class ``-32602`` even though the tool is visible; with it → the
+  query routes to the collection's backend.
+* **Collection scope routing:** the query reaches the resolved backend
+  with the optional product/version refinements as ``metadata_filters``;
+  an unknown collection → ``-32602``, a not-ready collection → ``-32603``.
+* The audit row carries the canonical ``op_id="meho.docs.search"`` plus
+  ``audit_collection``; the raw query is recorded only as a hash.
 
-The shared docs-search service (T3, #1521) federates to an **external**
-corpus; these unit tests mock
-:func:`meho_backplane.docs_search.service.search_corpus` so the wire
-shape + scope plumbing are exercised without a live corpus. PG-real /
-live-corpus coverage is out of scope for the unit suite.
+The ``corpus-http`` backend wraps the JWT-forward transport; these unit
+tests mock
+:func:`meho_backplane.docs_search.backends.corpus_http.search_corpus` so
+the wire shape + scope plumbing are exercised without a live corpus.
 """
 
 from __future__ import annotations
 
+import asyncio
 import json
 from collections.abc import Iterator
 from typing import Any
@@ -45,16 +48,25 @@ from meho_backplane.db.models import AuditLog
 from meho_backplane.main import app
 from meho_backplane.mcp.auth import verify_mcp_jwt_and_bind
 from meho_backplane.mcp.schemas import INTERNAL_ERROR, INVALID_PARAMS
-from meho_backplane.settings import get_settings
 from tests.mcp_test_fixtures import (
     OPERATOR_TENANT_ID,
     isolated_registry,  # noqa: F401 — pytest-discovered autouse fixture
     post_mcp,
     required_settings_env,  # noqa: F401 — pytest-discovered autouse fixture
+    seed_doc_collection,
     seeded_operator_tenant,  # noqa: F401 — pytest-discovered fixture
 )
 
 _DOCS_CAPABILITY = "meho-docs"
+#: Per-collection entitlement key for the seeded ``vmware`` collection.
+_VMWARE_CAP = "meho-docs:vmware"
+#: A provisioned + vmware-entitled capability set.
+_ENTITLED = frozenset({_DOCS_CAPABILITY, _VMWARE_CAP})
+
+#: The corpus-http backend's transport seam — the function the
+#: ``corpus-http`` adapter actually calls. Patching here exercises the
+#: full router → backend → transport path.
+_CORPUS_SEAM = "meho_backplane.docs_search.backends.corpus_http.search_corpus"
 
 
 async def _mcp_audit_rows() -> list[AuditLog]:
@@ -63,6 +75,17 @@ async def _mcp_audit_rows() -> list[AuditLog]:
     async with sessionmaker() as session:
         result = await session.execute(select(AuditLog).order_by(AuditLog.occurred_at))
         return [row for row in result.scalars().all() if row.method == "MCP"]
+
+
+def _seed_collection_sync(**kwargs: Any) -> None:
+    """Run :func:`seed_doc_collection` to completion from a sync test.
+
+    ``asyncio.run`` spins a fresh loop for the one-shot DB write; the
+    file-backed SQLite engine the autouse ``_default_database_url`` fixture
+    pins works across loops, so the row is visible to the subsequent
+    ``TestClient`` request (which runs its own loop).
+    """
+    asyncio.run(seed_doc_collection(**kwargs))
 
 
 def _operator(
@@ -88,10 +111,8 @@ def docs_client(
 ) -> Iterator[tuple[TestClient, Operator]]:
     """``TestClient`` whose operator's capability set is parametrised.
 
-    The production ``search_docs`` tool is registered by the lifespan's
-    eager import (it lives in ``mcp/tools/docs.py``); this fixture only
-    pins the operator. Provision the ``meho-docs`` capability with
-    ``@pytest.mark.parametrize("docs_client", [frozenset({"meho-docs"})], indirect=True)``;
+    Provision the capability set with
+    ``@pytest.mark.parametrize("docs_client", [_ENTITLED], indirect=True)``;
     default is the empty set (unprovisioned).
     """
     capabilities: frozenset[str] = getattr(request, "param", frozenset())
@@ -134,14 +155,14 @@ _SAMPLE_CHUNK = CorpusChunk(
 
 
 # ---------------------------------------------------------------------------
-# tools/list shape + capability gate (AC1, AC3)
+# tools/list shape + capability gate (visibility)
 # ---------------------------------------------------------------------------
 
 
 def test_search_docs_absent_from_tools_list_for_unprovisioned_tenant(
     docs_client: tuple[TestClient, Operator],
 ) -> None:
-    """AC1: an operator without ``meho-docs`` never sees the tool (true absence)."""
+    """An operator without the base ``meho-docs`` never sees the tool."""
     client, _op = docs_client
     response = post_mcp(client, {"jsonrpc": "2.0", "id": 1, "method": "tools/list"})
     assert response.status_code == 200
@@ -150,14 +171,16 @@ def test_search_docs_absent_from_tools_list_for_unprovisioned_tenant(
 
 
 @pytest.mark.parametrize("docs_client", [frozenset({_DOCS_CAPABILITY})], indirect=True)
-def test_search_docs_present_with_strict_schema_for_provisioned_tenant(
+def test_search_docs_present_with_strict_collection_schema(
     docs_client: tuple[TestClient, Operator],
 ) -> None:
-    """AC1 + AC3: the tool appears once provisioned, with a strict 2020-12 schema.
+    """The tool appears once provisioned, with a strict collection-scoped schema.
 
-    Required ``[query, product, version]``, ``additionalProperties:
-    false``, and the MEHO-internal RBAC + capability fields stripped by
-    :meth:`ToolDefinition.to_wire`.
+    Required ``[query, collection]``, ``additionalProperties: false``,
+    product/version demoted to optional, and the MEHO-internal RBAC +
+    capability fields stripped by :meth:`ToolDefinition.to_wire`. Tool
+    visibility rides only the base ``meho-docs`` capability — the
+    per-collection entitlement is enforced at call time, not at list time.
     """
     client, _op = docs_client
     response = post_mcp(client, {"jsonrpc": "2.0", "id": 1, "method": "tools/list"})
@@ -168,9 +191,9 @@ def test_search_docs_present_with_strict_schema_for_provisioned_tenant(
     tool = tools_by_name["search_docs"]
     schema = tool["inputSchema"]
     assert schema["type"] == "object"
-    assert schema["required"] == ["query", "product", "version"]
+    assert schema["required"] == ["query", "collection"]
     assert schema["additionalProperties"] is False
-    assert set(schema["properties"]) == {"query", "product", "version", "limit"}
+    assert set(schema["properties"]) == {"query", "collection", "product", "version", "limit"}
     assert schema["properties"]["limit"]["default"] == 10
     assert schema["properties"]["limit"]["maximum"] == 50
     # Wire shape never leaks the server-side gating fields.
@@ -180,35 +203,27 @@ def test_search_docs_present_with_strict_schema_for_provisioned_tenant(
 
 
 @pytest.mark.parametrize("docs_client", [frozenset({_DOCS_CAPABILITY})], indirect=True)
-def test_search_docs_description_names_siblings_and_companion_resource(
+def test_search_docs_description_names_collection_and_siblings(
     docs_client: tuple[TestClient, Operator],
 ) -> None:
-    """AC: the description names what / when / when-NOT and the sibling tools.
-
-    Loose substring assertions so prose can evolve without churn; the
-    load-bearing routing hints (vendor reference vs. how-we-do-X vs.
-    cross-session state) and the companion-resource pointer must stay.
-    """
+    """The description names the collection scope, the sibling tools, and the resource."""
     client, _op = docs_client
     response = post_mcp(client, {"jsonrpc": "2.0", "id": 1, "method": "tools/list"})
     tools_by_name = {t["name"]: t for t in response.json()["result"]["tools"]}
     desc = tools_by_name["search_docs"]["description"]
 
-    # What: vendor-document corpus search.
-    assert "vendor-document corpus" in desc or "vendor document" in desc.lower()
-    # When-NOT: routes to the sibling tools.
+    assert "collection" in desc.lower()
+    assert "list_doc_collections" in desc
     assert "search_knowledge" in desc
     assert "search_memory" in desc
-    # Mandatory binary scope is called out, not a hint.
-    assert "product" in desc and "version" in desc
-    # Companion resource pointer for the full text on a later turn.
-    assert "meho://docs/" in desc
+    # Companion resource pointer now carries the collection segment.
+    assert "meho://docs/{collection}/" in desc
     assert "resources/read" in desc
 
 
 def test_search_docs_hidden_from_provisioned_read_only_operator() -> None:
     """The capability does not relax the role gate: read_only never sees it."""
-    op = _operator(role=TenantRole.READ_ONLY, capabilities=frozenset({_DOCS_CAPABILITY}))
+    op = _operator(role=TenantRole.READ_ONLY, capabilities=_ENTITLED)
 
     async def _fake_verify() -> Operator:
         return op
@@ -224,25 +239,16 @@ def test_search_docs_hidden_from_provisioned_read_only_operator() -> None:
 
 
 # ---------------------------------------------------------------------------
-# tools/call — capability gate (AC2)
+# tools/call — base capability gate (visibility re-check)
 # ---------------------------------------------------------------------------
 
 
 def test_tools_call_search_docs_403_when_unprovisioned(
     docs_client: tuple[TestClient, Operator],
 ) -> None:
-    """AC2: naming the tool directly still 403s when the capability is absent.
-
-    The capability re-check in the dispatcher fires before the handler,
-    so an unprovisioned tenant that learned the name cannot reach the
-    corpus. Surfaces as INVALID_PARAMS with a ``forbidden`` / ``capability``
-    message (the JSON-RPC projection of a 403).
-    """
+    """Naming the tool directly still 403s when the base capability is absent."""
     client, _op = docs_client
-    with patch(
-        "meho_backplane.docs_search.service.search_corpus",
-        new=_fake_corpus(_SAMPLE_CHUNK),
-    ) as spy:
+    with patch(_CORPUS_SEAM, new=_fake_corpus(_SAMPLE_CHUNK)) as spy:
         response = post_mcp(
             client,
             {
@@ -251,7 +257,7 @@ def test_tools_call_search_docs_403_when_unprovisioned(
                 "method": "tools/call",
                 "params": {
                     "name": "search_docs",
-                    "arguments": {"query": "nsx maximums", "product": "nsx", "version": "9.0"},
+                    "arguments": {"query": "nsx maximums", "collection": "vmware"},
                 },
             },
         )
@@ -260,29 +266,26 @@ def test_tools_call_search_docs_403_when_unprovisioned(
     assert body["error"]["code"] == INVALID_PARAMS
     assert "forbidden" in body["error"]["message"].lower()
     assert "capability" in body["error"]["message"].lower()
-    # The handler never reached the corpus.
     assert "query" not in spy.captured  # type: ignore[attr-defined]
 
 
 # ---------------------------------------------------------------------------
-# tools/call — provisioned happy path (AC2 positive)
+# tools/call — per-collection entitlement (#1552)
 # ---------------------------------------------------------------------------
 
 
 @pytest.mark.parametrize("docs_client", [frozenset({_DOCS_CAPABILITY})], indirect=True)
-def test_tools_call_search_docs_returns_cited_chunks(
+def test_tools_call_search_docs_403_when_not_entitled_to_collection(
     docs_client: tuple[TestClient, Operator],
 ) -> None:
-    """AC2: a provisioned operator with product+version gets cited chunks.
+    """A tenant with base ``meho-docs`` but not ``meho-docs:vmware`` → 403-class.
 
-    Pins the wire round-trip: the handler projects the corpus chunk into
-    MEHO's ``DocsChunk`` surface, the dispatcher JSON-encodes it into
-    ``content[0].text``, and the binary scope reaches the corpus as
-    ``metadata_filters``.
+    The tool is visible (base capability present), but the per-collection
+    entitlement gate rejects the query before it reaches the backend.
     """
-    client, op = docs_client
-    fake = _fake_corpus(_SAMPLE_CHUNK)
-    with patch("meho_backplane.docs_search.service.search_corpus", new=fake):
+    client, _op = docs_client
+    _seed_collection_sync()
+    with patch(_CORPUS_SEAM, new=_fake_corpus(_SAMPLE_CHUNK)) as spy:
         response = post_mcp(
             client,
             {
@@ -291,8 +294,48 @@ def test_tools_call_search_docs_returns_cited_chunks(
                 "method": "tools/call",
                 "params": {
                     "name": "search_docs",
+                    "arguments": {"query": "config maximums", "collection": "vmware"},
+                },
+            },
+        )
+    assert response.status_code == 200
+    body = response.json()
+    assert body["error"]["code"] == INVALID_PARAMS
+    assert "entitled" in body["error"]["message"].lower()
+    assert "query" not in spy.captured  # type: ignore[attr-defined]
+
+
+# ---------------------------------------------------------------------------
+# tools/call — entitled happy path
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.parametrize("docs_client", [_ENTITLED], indirect=True)
+def test_tools_call_search_docs_routes_to_collection_backend(
+    docs_client: tuple[TestClient, Operator],
+) -> None:
+    """An entitled operator's query routes to the collection's backend with refinements.
+
+    The handler resolves the ``vmware`` collection, routes through the
+    ``corpus-http`` backend, and the optional product/version refinements
+    reach the transport as ``metadata_filters``. The backend id is absent
+    from the response.
+    """
+    client, op = docs_client
+    _seed_collection_sync()
+    fake = _fake_corpus(_SAMPLE_CHUNK)
+    with patch(_CORPUS_SEAM, new=fake):
+        response = post_mcp(
+            client,
+            {
+                "jsonrpc": "2.0",
+                "id": 4,
+                "method": "tools/call",
+                "params": {
+                    "name": "search_docs",
                     "arguments": {
                         "query": "config maximums",
+                        "collection": "vmware",
                         "product": "nsx",
                         "version": "9.0",
                         "limit": 5,
@@ -304,15 +347,12 @@ def test_tools_call_search_docs_returns_cited_chunks(
     body = response.json()
     assert body["result"]["isError"] is False
     payload = json.loads(body["result"]["content"][0]["text"])
-    assert "chunks" in payload
     assert len(payload["chunks"]) == 1
     chunk = payload["chunks"][0]
     assert chunk["chunk_id"] == "nsx-9.0-maximums-0007"
-    assert chunk["content"].startswith("NSX 9.0 supports")
-    assert chunk["source_url"].endswith("/maximums")
+    # The backend id never appears in the response.
+    assert "backend" not in json.dumps(payload)
 
-    # The binary product+version scope reached the corpus as filters, and
-    # the operator's identity was forwarded (never a caller-supplied one).
     captured = fake.captured  # type: ignore[attr-defined]
     assert captured["query"] == "config maximums"
     assert captured["limit"] == 5
@@ -320,26 +360,53 @@ def test_tools_call_search_docs_returns_cited_chunks(
     assert captured["operator"].tenant_id == op.tenant_id
 
 
-# ---------------------------------------------------------------------------
-# tools/call — REQUIRE_FILTERS surfaces as an MCP error (AC2)
-# ---------------------------------------------------------------------------
-
-
-@pytest.mark.parametrize("docs_client", [frozenset({_DOCS_CAPABILITY})], indirect=True)
-def test_tools_call_search_docs_missing_version_rejected_by_schema(
+@pytest.mark.parametrize("docs_client", [_ENTITLED], indirect=True)
+def test_tools_call_search_docs_collection_only_omits_refinements(
     docs_client: tuple[TestClient, Operator],
 ) -> None:
-    """A missing required ``version`` fails inputSchema validation → -32602.
+    """Product/version are optional: a collection-only query still succeeds.
 
-    The strict schema catches the missing mandatory scope before the
-    handler runs — the first line of the REQUIRE_FILTERS defence.
+    With no product/version, no ``metadata_filters`` reach the backend
+    (the collection alone scopes the query).
     """
+    client, _op = docs_client
+    _seed_collection_sync()
+    fake = _fake_corpus(_SAMPLE_CHUNK)
+    with patch(_CORPUS_SEAM, new=fake):
+        response = post_mcp(
+            client,
+            {
+                "jsonrpc": "2.0",
+                "id": 5,
+                "method": "tools/call",
+                "params": {
+                    "name": "search_docs",
+                    "arguments": {"query": "anything", "collection": "vmware"},
+                },
+            },
+        )
+    assert response.status_code == 200
+    assert response.json()["result"]["isError"] is False
+    # No product/version → no metadata_filters forwarded.
+    assert fake.captured["metadata_filters"] is None  # type: ignore[attr-defined]
+
+
+# ---------------------------------------------------------------------------
+# tools/call — collection-scope rejection arms
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.parametrize("docs_client", [_ENTITLED], indirect=True)
+def test_tools_call_search_docs_missing_collection_rejected_by_schema(
+    docs_client: tuple[TestClient, Operator],
+) -> None:
+    """A missing required ``collection`` fails inputSchema validation → -32602."""
     client, _op = docs_client
     response = post_mcp(
         client,
         {
             "jsonrpc": "2.0",
-            "id": 4,
+            "id": 6,
             "method": "tools/call",
             "params": {
                 "name": "search_docs",
@@ -351,41 +418,61 @@ def test_tools_call_search_docs_missing_version_rejected_by_schema(
     assert response.json()["error"]["code"] == INVALID_PARAMS
 
 
-@pytest.mark.parametrize("docs_client", [frozenset({_DOCS_CAPABILITY})], indirect=True)
-def test_tools_call_search_docs_blank_version_surfaces_service_422_as_mcp_error(
+@pytest.mark.parametrize("docs_client", [_ENTITLED], indirect=True)
+def test_tools_call_search_docs_unknown_collection_is_invalid_params(
     docs_client: tuple[TestClient, Operator],
 ) -> None:
-    """A blank-after-strip ``version`` passes the schema but the service rejects it.
-
-    ``minLength: 1`` admits a single space; the shared
-    ``build_docs_scope`` treats blank-after-strip as absent and raises
-    ``MissingDocsFilterError`` (the route's 422), which the handler maps
-    to ``-32602`` — the MCP analogue. The corpus is never called.
-    """
+    """An unknown collection key → -32602 (invalid argument, not a server fault)."""
     client, _op = docs_client
+    # No collection seeded → resolve fails.
     fake = _fake_corpus(_SAMPLE_CHUNK)
-    with patch("meho_backplane.docs_search.service.search_corpus", new=fake):
+    with patch(_CORPUS_SEAM, new=fake):
         response = post_mcp(
             client,
             {
                 "jsonrpc": "2.0",
-                "id": 5,
+                "id": 7,
                 "method": "tools/call",
                 "params": {
                     "name": "search_docs",
-                    "arguments": {"query": "x", "product": "nsx", "version": " "},
+                    "arguments": {"query": "x", "collection": "nope"},
                 },
             },
         )
     assert response.status_code == 200
     body = response.json()
     assert body["error"]["code"] == INVALID_PARAMS
-    assert "version" in body["error"]["message"].lower()
-    # The REQUIRE_FILTERS rejection short-circuits before the corpus call.
+    assert "unknown collection" in body["error"]["message"].lower()
     assert "query" not in fake.captured  # type: ignore[attr-defined]
 
 
-@pytest.mark.parametrize("docs_client", [frozenset({_DOCS_CAPABILITY})], indirect=True)
+@pytest.mark.parametrize("docs_client", [_ENTITLED], indirect=True)
+def test_tools_call_search_docs_not_ready_collection_is_internal_error(
+    docs_client: tuple[TestClient, Operator],
+) -> None:
+    """A known + entitled but not-``ready`` collection → -32603 (server-side condition)."""
+    client, _op = docs_client
+    _seed_collection_sync(status="rebuilding")
+    fake = _fake_corpus(_SAMPLE_CHUNK)
+    with patch(_CORPUS_SEAM, new=fake):
+        response = post_mcp(
+            client,
+            {
+                "jsonrpc": "2.0",
+                "id": 8,
+                "method": "tools/call",
+                "params": {
+                    "name": "search_docs",
+                    "arguments": {"query": "x", "collection": "vmware"},
+                },
+            },
+        )
+    assert response.status_code == 200
+    assert response.json()["error"]["code"] == INTERNAL_ERROR
+    assert "query" not in fake.captured  # type: ignore[attr-defined]
+
+
+@pytest.mark.parametrize("docs_client", [_ENTITLED], indirect=True)
 def test_tools_call_search_docs_rejects_extra_arguments(
     docs_client: tuple[TestClient, Operator],
 ) -> None:
@@ -395,14 +482,13 @@ def test_tools_call_search_docs_rejects_extra_arguments(
         client,
         {
             "jsonrpc": "2.0",
-            "id": 6,
+            "id": 9,
             "method": "tools/call",
             "params": {
                 "name": "search_docs",
                 "arguments": {
                     "query": "x",
-                    "product": "nsx",
-                    "version": "9.0",
+                    "collection": "vmware",
                     "tenant_id": "smuggled",
                 },
             },
@@ -413,35 +499,31 @@ def test_tools_call_search_docs_rejects_extra_arguments(
 
 
 # ---------------------------------------------------------------------------
-# tools/call — corpus unavailable surfaces as INTERNAL_ERROR (not -32602)
+# tools/call — backend unavailable surfaces as INTERNAL_ERROR (not -32602)
 # ---------------------------------------------------------------------------
 
 
-@pytest.mark.parametrize("docs_client", [frozenset({_DOCS_CAPABILITY})], indirect=True)
-def test_tools_call_search_docs_corpus_unavailable_is_internal_error(
+@pytest.mark.parametrize("docs_client", [_ENTITLED], indirect=True)
+def test_tools_call_search_docs_backend_unavailable_is_internal_error(
     docs_client: tuple[TestClient, Operator],
 ) -> None:
-    """A down corpus is a server fault → ``-32603``, not invalid params.
-
-    The well-formed request is not the client's fault; the typed
-    ``CorpusUnavailable`` is not caught in the handler and bubbles to the
-    dispatcher's generic catch (the MCP analogue of the route's 503).
-    """
+    """A down backend is a server fault → ``-32603``, not invalid params."""
     client, _op = docs_client
+    _seed_collection_sync()
 
     async def _down(_op: Operator, _query: str, **_kwargs: Any) -> CorpusSearchResponse:
         raise CorpusUnavailable("corpus_url is not configured")
 
-    with patch("meho_backplane.docs_search.service.search_corpus", new=_down):
+    with patch(_CORPUS_SEAM, new=_down):
         response = post_mcp(
             client,
             {
                 "jsonrpc": "2.0",
-                "id": 7,
+                "id": 10,
                 "method": "tools/call",
                 "params": {
                     "name": "search_docs",
-                    "arguments": {"query": "x", "product": "nsx", "version": "9.0"},
+                    "arguments": {"query": "x", "collection": "vmware"},
                 },
             },
         )
@@ -450,79 +532,35 @@ def test_tools_call_search_docs_corpus_unavailable_is_internal_error(
 
 
 # ---------------------------------------------------------------------------
-# Settings hygiene — the gate-off path keeps the corpus reachable
-# ---------------------------------------------------------------------------
-
-
-@pytest.mark.parametrize("docs_client", [frozenset({_DOCS_CAPABILITY})], indirect=True)
-def test_tools_call_search_docs_gate_off_allows_partial_scope(
-    docs_client: tuple[TestClient, Operator],
-    monkeypatch: pytest.MonkeyPatch,
-) -> None:
-    """With ``corpus_require_filters`` off, a blank version degrades to optional.
-
-    The schema's ``minLength: 1`` still requires the key be present and
-    non-empty per the wire contract, but a blank-after-strip value no
-    longer trips REQUIRE_FILTERS — it simply widens the corpus query
-    (only ``product`` reaches ``metadata_filters``).
-    """
-    monkeypatch.setenv("CORPUS_REQUIRE_FILTERS", "false")
-    get_settings.cache_clear()
-    client, _op = docs_client
-    fake = _fake_corpus()
-    try:
-        with patch("meho_backplane.docs_search.service.search_corpus", new=fake):
-            response = post_mcp(
-                client,
-                {
-                    "jsonrpc": "2.0",
-                    "id": 8,
-                    "method": "tools/call",
-                    "params": {
-                        "name": "search_docs",
-                        "arguments": {"query": "x", "product": "nsx", "version": " "},
-                    },
-                },
-            )
-    finally:
-        get_settings.cache_clear()
-    assert response.status_code == 200
-    assert response.json()["result"]["isError"] is False
-    # Only the non-blank product survived into the corpus filter.
-    assert fake.captured["metadata_filters"] == {"product": "nsx"}  # type: ignore[attr-defined]
-
-
-# ---------------------------------------------------------------------------
-# Uniform audit op_id across faces (G4.5-T8 #1549)
+# Uniform audit op_id + collection across faces (#1549 / #1552)
 # ---------------------------------------------------------------------------
 
 
 @pytest.mark.asyncio
-@pytest.mark.parametrize("docs_client", [frozenset({_DOCS_CAPABILITY})], indirect=True)
-async def test_tools_call_search_docs_audit_row_carries_canonical_op_id(
+@pytest.mark.parametrize("docs_client", [_ENTITLED], indirect=True)
+async def test_tools_call_search_docs_audit_row_carries_op_id_and_collection(
     docs_client: tuple[TestClient, Operator],
     seeded_operator_tenant: None,  # noqa: F811
 ) -> None:
-    """G4.5-T8: the MCP audit row's ``op_id`` is the canonical ``meho.docs.search``.
+    """The MCP audit row's ``op_id`` is canonical and carries ``collection``.
 
-    The DoD requires every ``search_docs`` audit row — REST, CLI, *and*
-    MCP — be filterable by ``op_id="meho.docs.search"``. The handler binds
-    the ``audit_op_id`` contextvar; the dispatcher lifts it into the
-    persisted row, overriding the bare tool name. ``op_class`` stays
-    ``read`` (declared on the ToolDefinition) and the raw query is recorded
-    only as ``params_hash``, never in the clear.
+    The handler binds the ``audit_op_id`` and ``audit_collection``
+    contextvars; the dispatcher lifts them into the persisted row.
+    ``op_class`` stays ``read`` and the raw query is recorded only as a
+    hash, never in the clear.
     """
     client, _op = docs_client
-    with patch("meho_backplane.docs_search.service.search_corpus", new=_fake_corpus(_SAMPLE_CHUNK)):
+    await seed_doc_collection()
+    with patch(_CORPUS_SEAM, new=_fake_corpus(_SAMPLE_CHUNK)):
         response = post_mcp(
             client,
             {
                 "jsonrpc": "2.0",
-                "id": 9,
+                "id": 11,
                 "method": "tools/call",
                 "params": {
                     "name": "search_docs",
-                    "arguments": {"query": "config maximums", "product": "nsx", "version": "9.0"},
+                    "arguments": {"query": "config maximums", "collection": "vmware"},
                 },
             },
         )
@@ -534,38 +572,32 @@ async def test_tools_call_search_docs_audit_row_carries_canonical_op_id(
     payload = rows[0].payload
     assert payload["op_id"] == "meho.docs.search"
     assert payload["op_class"] == "read"
-    # The raw query is hashed, never recorded in the clear.
+    assert payload["collection"] == "vmware"
     assert "config maximums" not in json.dumps(payload)
     assert payload["params_hash"]
 
 
 @pytest.mark.asyncio
-@pytest.mark.parametrize("docs_client", [frozenset({_DOCS_CAPABILITY})], indirect=True)
+@pytest.mark.parametrize("docs_client", [_ENTITLED], indirect=True)
 async def test_query_audit_op_id_filter_catches_mcp_search_docs(
     docs_client: tuple[TestClient, Operator],
     seeded_operator_tenant: None,  # noqa: F811
 ) -> None:
-    """G4.5-T8 AC2: a ``query_audit`` ``op_id`` filter returns the MCP call.
-
-    Before the fix the MCP row landed under the bare tool name
-    ``search_docs``, so a who-touched / ``query_audit`` filter on
-    ``op_id="meho.docs.search"`` caught REST + CLI but missed every MCP
-    call — the primary agent surface. This pins that the MCP face is now in
-    the trail under the canonical op_id.
-    """
+    """A ``query_audit`` ``op_id`` filter returns the MCP collection-scoped call."""
     from meho_backplane.audit_query import AuditQueryFilters, query_audit
 
     client, _op = docs_client
-    with patch("meho_backplane.docs_search.service.search_corpus", new=_fake_corpus(_SAMPLE_CHUNK)):
+    await seed_doc_collection()
+    with patch(_CORPUS_SEAM, new=_fake_corpus(_SAMPLE_CHUNK)):
         response = post_mcp(
             client,
             {
                 "jsonrpc": "2.0",
-                "id": 10,
+                "id": 12,
                 "method": "tools/call",
                 "params": {
                     "name": "search_docs",
-                    "arguments": {"query": "nsx maximums", "product": "nsx", "version": "9.0"},
+                    "arguments": {"query": "nsx maximums", "collection": "vmware"},
                 },
             },
         )

--- a/backend/tests/test_mcp_tools_docs_ask.py
+++ b/backend/tests/test_mcp_tools_docs_ask.py
@@ -1,34 +1,35 @@
 # SPDX-License-Identifier: Apache-2.0
 # Copyright (c) 2026 evoila Group
 
-"""Tests for the capability-gated ``ask_docs`` MCP tool (G4.5-T7, #1526).
+"""Tests for the collection-scoped ``ask_docs`` MCP tool (G4.6-T3, #1552).
 
 ``ask_docs`` is the synthesis fast-follow to ``search_docs``: it runs the
-same T3 retrieval, then composes a grounded, cited answer over the
-retrieved chunks. These tests cover every acceptance criterion in the
-task body:
+same retrieval, then composes a grounded, cited answer over the retrieved
+chunks. These tests cover the collection-scoped contract on top of the
+synthesis invariants:
 
 * ``ask_docs`` carries ``required_capability="meho-docs"`` — **absent**
-  from ``tools/list`` and **403** on ``tools/call`` for an unprovisioned
-  tenant (the same T1 gate, #1519, as ``search_docs``).
-* Missing/blank ``product`` or ``version`` → ``-32602`` (REQUIRE_FILTERS,
-  via T3).
+  from ``tools/list`` and **403** on ``tools/call`` for a tenant without
+  the base capability (the same gate as ``search_docs``).
+* Strict schema: required ``[query, collection]``, product/version optional.
+* Missing ``collection`` → ``-32602``; a tenant lacking
+  ``meho-docs:<collection>`` → 403-class ``-32602`` (per-collection
+  entitlement, #1552).
 * Returns ``{answer, citations[]}`` where every citation resolves to a
   chunk the underlying retrieval returned; an answer with **zero**
   retrieved chunks returns "no grounded answer", never a hallucinated one.
 * Synthesis model unconfigured / unreachable → ``-32603`` (fail-closed,
   the MCP analogue of 503), never an ungrounded answer.
 
-Two seams are mocked so no network is touched: the corpus
-(``meho_backplane.docs_search.service.search_corpus``, the retrieval side)
-and the synthesis client (``build_anthropic_ingest_llm_client``, the LLM
-side). The audit row is written by the dispatcher with ``op_class="read"``
-from the tool definition and the raw query hashed — the same path
-``search_docs`` exercises, verified by its own suite.
+Two seams are mocked so no network is touched: the corpus transport
+(``meho_backplane.docs_search.backends.corpus_http.search_corpus``, the
+retrieval side, reached via the collection's resolved backend) and the
+synthesis client (``build_anthropic_ingest_llm_client``, the LLM side).
 """
 
 from __future__ import annotations
 
+import asyncio
 import json
 from collections.abc import Iterator
 from typing import Any
@@ -52,15 +53,29 @@ from tests.mcp_test_fixtures import (
     isolated_registry,  # noqa: F401 — pytest-discovered autouse fixture
     post_mcp,
     required_settings_env,  # noqa: F401 — pytest-discovered autouse fixture
+    seed_doc_collection,
     seeded_operator_tenant,  # noqa: F401 — pytest-discovered fixture
 )
 
 _DOCS_CAPABILITY = "meho-docs"
+#: Per-collection entitlement key for the seeded ``vmware`` collection.
+_VMWARE_CAP = "meho-docs:vmware"
+#: A provisioned + vmware-entitled capability set.
+_ENTITLED = frozenset({_DOCS_CAPABILITY, _VMWARE_CAP})
 
 #: Where the synthesis helper resolves its default LLM client. Patching
 #: here lets a test pin a deterministic stub or assert the fail-closed
 #: factory propagates.
 _BUILD_LLM_CLIENT = "meho_backplane.docs_search.synthesis.build_anthropic_ingest_llm_client"
+
+#: The corpus-http backend's transport seam — the function the
+#: ``corpus-http`` adapter actually calls.
+_CORPUS_SEAM = "meho_backplane.docs_search.backends.corpus_http.search_corpus"
+
+
+def _seed_collection_sync(**kwargs: Any) -> None:
+    """Run :func:`seed_doc_collection` to completion from a sync test."""
+    asyncio.run(seed_doc_collection(**kwargs))
 
 
 def _operator(
@@ -190,10 +205,10 @@ def test_ask_docs_absent_from_tools_list_for_unprovisioned_tenant(
 
 
 @pytest.mark.parametrize("docs_client", [frozenset({_DOCS_CAPABILITY})], indirect=True)
-def test_ask_docs_present_with_strict_schema_for_provisioned_tenant(
+def test_ask_docs_present_with_strict_collection_schema(
     docs_client: tuple[TestClient, Operator],
 ) -> None:
-    """AC1: the tool appears once provisioned, with a strict 2020-12 schema."""
+    """The tool appears once provisioned, with a strict collection-scoped schema."""
     client, _op = docs_client
     response = post_mcp(client, {"jsonrpc": "2.0", "id": 1, "method": "tools/list"})
     assert response.status_code == 200
@@ -203,9 +218,9 @@ def test_ask_docs_present_with_strict_schema_for_provisioned_tenant(
     tool = tools_by_name["ask_docs"]
     schema = tool["inputSchema"]
     assert schema["type"] == "object"
-    assert schema["required"] == ["query", "product", "version"]
+    assert schema["required"] == ["query", "collection"]
     assert schema["additionalProperties"] is False
-    assert set(schema["properties"]) == {"query", "product", "version", "limit"}
+    assert set(schema["properties"]) == {"query", "collection", "product", "version", "limit"}
     assert schema["properties"]["limit"]["default"] == 10
     assert schema["properties"]["limit"]["maximum"] == 50
     # Wire shape never leaks the server-side gating fields.
@@ -215,7 +230,7 @@ def test_ask_docs_present_with_strict_schema_for_provisioned_tenant(
 
 
 @pytest.mark.parametrize("docs_client", [frozenset({_DOCS_CAPABILITY})], indirect=True)
-def test_ask_docs_description_names_search_docs_sibling(
+def test_ask_docs_description_names_collection_and_sibling(
     docs_client: tuple[TestClient, Operator],
 ) -> None:
     """The description routes between the answer tool and the chunks tool."""
@@ -228,14 +243,15 @@ def test_ask_docs_description_names_search_docs_sibling(
     assert "search_docs" in desc
     assert "search_knowledge" in desc
     assert "search_memory" in desc
-    # The mandatory binary scope and the no-guess posture are called out.
-    assert "product" in desc and "version" in desc
+    # The mandatory collection scope and the no-guess posture are called out.
+    assert "collection" in desc.lower()
+    assert "list_doc_collections" in desc
     assert "no grounded answer" in desc.lower() or "no claim without a citation" in desc.lower()
 
 
 def test_ask_docs_hidden_from_provisioned_read_only_operator() -> None:
     """The capability does not relax the role gate: read_only never sees it."""
-    op = _operator(role=TenantRole.READ_ONLY, capabilities=frozenset({_DOCS_CAPABILITY}))
+    op = _operator(role=TenantRole.READ_ONLY, capabilities=_ENTITLED)
 
     async def _fake_verify() -> Operator:
         return op
@@ -267,12 +283,12 @@ def test_tools_call_ask_docs_403_when_unprovisioned(
     corpus = _fake_corpus(_SAMPLE_CHUNK)
     stub = _StubLlmClient('{"answer": "x", "cited_chunk_ids": []}')
     with (
-        patch("meho_backplane.docs_search.service.search_corpus", new=corpus),
+        patch(_CORPUS_SEAM, new=corpus),
         patch(_BUILD_LLM_CLIENT, return_value=stub),
     ):
         response = post_mcp(
             client,
-            _ask_call({"query": "nsx maximums", "product": "nsx", "version": "9.0"}, call_id=2),
+            _ask_call({"query": "nsx maximums", "collection": "vmware"}, call_id=2),
         )
     assert response.status_code == 200
     body = response.json()
@@ -285,15 +301,15 @@ def test_tools_call_ask_docs_403_when_unprovisioned(
 
 
 # ---------------------------------------------------------------------------
-# tools/call — REQUIRE_FILTERS (AC2)
+# tools/call — collection-scope rejection arms (#1552)
 # ---------------------------------------------------------------------------
 
 
-@pytest.mark.parametrize("docs_client", [frozenset({_DOCS_CAPABILITY})], indirect=True)
-def test_tools_call_ask_docs_missing_version_rejected_by_schema(
+@pytest.mark.parametrize("docs_client", [_ENTITLED], indirect=True)
+def test_tools_call_ask_docs_missing_collection_rejected_by_schema(
     docs_client: tuple[TestClient, Operator],
 ) -> None:
-    """AC2: a missing required ``version`` fails inputSchema validation → -32602."""
+    """A missing required ``collection`` fails inputSchema validation → -32602."""
     client, _op = docs_client
     response = post_mcp(client, _ask_call({"query": "x", "product": "nsx"}, call_id=3))
     assert response.status_code == 200
@@ -301,31 +317,30 @@ def test_tools_call_ask_docs_missing_version_rejected_by_schema(
 
 
 @pytest.mark.parametrize("docs_client", [frozenset({_DOCS_CAPABILITY})], indirect=True)
-def test_tools_call_ask_docs_blank_version_surfaces_service_422_as_mcp_error(
+def test_tools_call_ask_docs_403_when_not_entitled_to_collection(
     docs_client: tuple[TestClient, Operator],
 ) -> None:
-    """AC2: a blank-after-strip ``version`` trips REQUIRE_FILTERS in T3 → -32602.
+    """A tenant with base ``meho-docs`` but not ``meho-docs:vmware`` → 403-class.
 
-    ``minLength: 1`` admits a single space; the shared ``build_docs_scope``
-    treats blank-after-strip as absent and raises ``MissingDocsFilterError``
-    (the route's 422), which the handler maps to ``-32602``. Neither the
-    corpus nor the synthesis model is called.
+    The per-collection entitlement gate rejects the question before either
+    retrieval or synthesis runs.
     """
     client, _op = docs_client
+    _seed_collection_sync()
     corpus = _fake_corpus(_SAMPLE_CHUNK)
     stub = _StubLlmClient('{"answer": "x", "cited_chunk_ids": []}')
     with (
-        patch("meho_backplane.docs_search.service.search_corpus", new=corpus),
+        patch(_CORPUS_SEAM, new=corpus),
         patch(_BUILD_LLM_CLIENT, return_value=stub),
     ):
         response = post_mcp(
             client,
-            _ask_call({"query": "x", "product": "nsx", "version": " "}, call_id=4),
+            _ask_call({"query": "x", "collection": "vmware"}, call_id=4),
         )
     assert response.status_code == 200
     body = response.json()
     assert body["error"]["code"] == INVALID_PARAMS
-    assert "version" in body["error"]["message"].lower()
+    assert "entitled" in body["error"]["message"].lower()
     assert "query" not in corpus.captured  # type: ignore[attr-defined]
     assert stub.captured == {}
 
@@ -335,18 +350,20 @@ def test_tools_call_ask_docs_blank_version_surfaces_service_422_as_mcp_error(
 # ---------------------------------------------------------------------------
 
 
-@pytest.mark.parametrize("docs_client", [frozenset({_DOCS_CAPABILITY})], indirect=True)
+@pytest.mark.parametrize("docs_client", [_ENTITLED], indirect=True)
 def test_tools_call_ask_docs_returns_grounded_cited_answer(
     docs_client: tuple[TestClient, Operator],
 ) -> None:
-    """AC3: a provisioned operator gets ``{answer, citations[]}`` over retrieved chunks.
+    """An entitled operator gets ``{answer, citations[]}`` over retrieved chunks.
 
-    Pins the full round-trip: retrieval forwards the binary scope to the
-    corpus, the synthesis model composes an answer citing one of the two
-    retrieved chunks, and every returned citation resolves to a retrieved
-    chunk. The retrieved evidence reached the synthesis prompt.
+    Pins the full round-trip: retrieval routes to the ``vmware``
+    collection's backend with the optional refinements as
+    ``metadata_filters``, the synthesis model composes an answer citing one
+    of the two retrieved chunks, and every returned citation resolves to a
+    retrieved chunk. The retrieved evidence reached the synthesis prompt.
     """
     client, op = docs_client
+    _seed_collection_sync()
     corpus = _fake_corpus(_SAMPLE_CHUNK, _SECOND_CHUNK)
     stub = _StubLlmClient(
         json.dumps(
@@ -357,7 +374,7 @@ def test_tools_call_ask_docs_returns_grounded_cited_answer(
         )
     )
     with (
-        patch("meho_backplane.docs_search.service.search_corpus", new=corpus),
+        patch(_CORPUS_SEAM, new=corpus),
         patch(_BUILD_LLM_CLIENT, return_value=stub),
     ):
         response = post_mcp(
@@ -365,6 +382,7 @@ def test_tools_call_ask_docs_returns_grounded_cited_answer(
             _ask_call(
                 {
                     "query": "How many logical switches does NSX 9.0 support?",
+                    "collection": "vmware",
                     "product": "nsx",
                     "version": "9.0",
                     "limit": 5,
@@ -384,7 +402,8 @@ def test_tools_call_ask_docs_returns_grounded_cited_answer(
     assert citation["chunk_id"] == "nsx-9.0-maximums-0007"
     assert citation["source_url"].endswith("/maximums")
 
-    # The binary scope reached the corpus and the operator identity was forwarded.
+    # The optional refinements reached the backend and the operator identity
+    # was forwarded.
     assert corpus.captured["metadata_filters"] == {"product": "nsx", "version": "9.0"}  # type: ignore[attr-defined]
     assert corpus.captured["limit"] == 5  # type: ignore[attr-defined]
     assert corpus.captured["operator"].tenant_id == op.tenant_id  # type: ignore[attr-defined]
@@ -398,27 +417,28 @@ def test_tools_call_ask_docs_returns_grounded_cited_answer(
 # ---------------------------------------------------------------------------
 
 
-@pytest.mark.parametrize("docs_client", [frozenset({_DOCS_CAPABILITY})], indirect=True)
+@pytest.mark.parametrize("docs_client", [_ENTITLED], indirect=True)
 def test_tools_call_ask_docs_zero_chunks_returns_no_grounded_answer(
     docs_client: tuple[TestClient, Operator],
 ) -> None:
-    """AC3: an empty retrieval returns "no grounded answer" without calling the model.
+    """An empty retrieval returns "no grounded answer" without calling the model.
 
     The empty-evidence path is the one answer path that must NOT invoke the
     synthesis model — there is nothing to ground on, so a model call could
     only hallucinate. Citations are empty.
     """
     client, _op = docs_client
+    _seed_collection_sync()
     corpus = _fake_corpus()  # zero chunks
     stub = _StubLlmClient('{"answer": "should never be used", "cited_chunk_ids": []}')
     with (
-        patch("meho_backplane.docs_search.service.search_corpus", new=corpus),
+        patch(_CORPUS_SEAM, new=corpus),
         patch(_BUILD_LLM_CLIENT, return_value=stub),
     ):
         response = post_mcp(
             client,
             _ask_call(
-                {"query": "obscure unanswerable thing", "product": "nsx", "version": "9.0"},
+                {"query": "obscure unanswerable thing", "collection": "vmware"},
                 call_id=6,
             ),
         )
@@ -438,7 +458,7 @@ def test_tools_call_ask_docs_zero_chunks_returns_no_grounded_answer(
 # ---------------------------------------------------------------------------
 
 
-@pytest.mark.parametrize("docs_client", [frozenset({_DOCS_CAPABILITY})], indirect=True)
+@pytest.mark.parametrize("docs_client", [_ENTITLED], indirect=True)
 def test_tools_call_ask_docs_unconfigured_model_is_internal_error(
     docs_client: tuple[TestClient, Operator],
 ) -> None:
@@ -451,18 +471,19 @@ def test_tools_call_ask_docs_unconfigured_model_is_internal_error(
     return an ungrounded answer when the model is missing.
     """
     client, _op = docs_client
+    _seed_collection_sync()
     corpus = _fake_corpus(_SAMPLE_CHUNK)
 
     def _fail_closed() -> Any:
         raise LlmClientUnavailable("no ANTHROPIC_API_KEY configured")
 
     with (
-        patch("meho_backplane.docs_search.service.search_corpus", new=corpus),
+        patch(_CORPUS_SEAM, new=corpus),
         patch(_BUILD_LLM_CLIENT, side_effect=_fail_closed),
     ):
         response = post_mcp(
             client,
-            _ask_call({"query": "x", "product": "nsx", "version": "9.0"}, call_id=7),
+            _ask_call({"query": "x", "collection": "vmware"}, call_id=7),
         )
     assert response.status_code == 200
     assert response.json()["error"]["code"] == INTERNAL_ERROR
@@ -473,28 +494,29 @@ def test_tools_call_ask_docs_unconfigured_model_is_internal_error(
 # ---------------------------------------------------------------------------
 
 
-@pytest.mark.parametrize("docs_client", [frozenset({_DOCS_CAPABILITY})], indirect=True)
+@pytest.mark.parametrize("docs_client", [_ENTITLED], indirect=True)
 def test_tools_call_ask_docs_fabricated_citation_is_internal_error(
     docs_client: tuple[TestClient, Operator],
 ) -> None:
-    """AC3: a model citing a chunk_id outside the retrieved set fails closed.
+    """A model citing a chunk_id outside the retrieved set fails closed.
 
     An unverifiable citation breaks the no-claim-without-a-REAL-citation
     contract, so the synthesis raises ``DocsSynthesisError`` rather than
     returning an answer with a fabricated reference. Surfaces as ``-32603``.
     """
     client, _op = docs_client
+    _seed_collection_sync()
     corpus = _fake_corpus(_SAMPLE_CHUNK)
     stub = _StubLlmClient(
         json.dumps({"answer": "Fabricated.", "cited_chunk_ids": ["does-not-exist-9999"]})
     )
     with (
-        patch("meho_backplane.docs_search.service.search_corpus", new=corpus),
+        patch(_CORPUS_SEAM, new=corpus),
         patch(_BUILD_LLM_CLIENT, return_value=stub),
     ):
         response = post_mcp(
             client,
-            _ask_call({"query": "x", "product": "nsx", "version": "9.0"}, call_id=8),
+            _ask_call({"query": "x", "collection": "vmware"}, call_id=8),
         )
     assert response.status_code == 200
     assert response.json()["error"]["code"] == INTERNAL_ERROR
@@ -505,24 +527,25 @@ def test_tools_call_ask_docs_fabricated_citation_is_internal_error(
 # ---------------------------------------------------------------------------
 
 
-@pytest.mark.parametrize("docs_client", [frozenset({_DOCS_CAPABILITY})], indirect=True)
-def test_tools_call_ask_docs_corpus_unavailable_is_internal_error(
+@pytest.mark.parametrize("docs_client", [_ENTITLED], indirect=True)
+def test_tools_call_ask_docs_backend_unavailable_is_internal_error(
     docs_client: tuple[TestClient, Operator],
 ) -> None:
-    """A down corpus is a server fault → ``-32603``, mirroring ``search_docs``."""
+    """A down backend is a server fault → ``-32603``, mirroring ``search_docs``."""
     client, _op = docs_client
+    _seed_collection_sync()
 
     async def _down(_op: Operator, _query: str, **_kwargs: Any) -> CorpusSearchResponse:
         raise CorpusUnavailable("corpus_url is not configured")
 
     stub = _StubLlmClient('{"answer": "x", "cited_chunk_ids": []}')
     with (
-        patch("meho_backplane.docs_search.service.search_corpus", new=_down),
+        patch(_CORPUS_SEAM, new=_down),
         patch(_BUILD_LLM_CLIENT, return_value=stub),
     ):
         response = post_mcp(
             client,
-            _ask_call({"query": "x", "product": "nsx", "version": "9.0"}, call_id=9),
+            _ask_call({"query": "x", "collection": "vmware"}, call_id=9),
         )
     assert response.status_code == 200
     assert response.json()["error"]["code"] == INTERNAL_ERROR
@@ -535,7 +558,7 @@ def test_tools_call_ask_docs_corpus_unavailable_is_internal_error(
 # ---------------------------------------------------------------------------
 
 
-@pytest.mark.parametrize("docs_client", [frozenset({_DOCS_CAPABILITY})], indirect=True)
+@pytest.mark.parametrize("docs_client", [_ENTITLED], indirect=True)
 def test_tools_call_ask_docs_rejects_extra_arguments(
     docs_client: tuple[TestClient, Operator],
 ) -> None:
@@ -544,7 +567,7 @@ def test_tools_call_ask_docs_rejects_extra_arguments(
     response = post_mcp(
         client,
         _ask_call(
-            {"query": "x", "product": "nsx", "version": "9.0", "tenant_id": "smuggled"},
+            {"query": "x", "collection": "vmware", "tenant_id": "smuggled"},
             call_id=10,
         ),
     )
@@ -558,20 +581,21 @@ def test_tools_call_ask_docs_rejects_extra_arguments(
 
 
 @pytest.mark.asyncio
-@pytest.mark.parametrize("docs_client", [frozenset({_DOCS_CAPABILITY})], indirect=True)
-async def test_tools_call_ask_docs_audit_row_carries_canonical_op_id(
+@pytest.mark.parametrize("docs_client", [_ENTITLED], indirect=True)
+async def test_tools_call_ask_docs_audit_row_carries_op_id_and_collection(
     docs_client: tuple[TestClient, Operator],
     seeded_operator_tenant: None,  # noqa: F811
 ) -> None:
-    """G4.5-T8: the MCP ``ask_docs`` audit row's ``op_id`` is ``meho.docs.ask``.
+    """The MCP ``ask_docs`` audit row's ``op_id`` is ``meho.docs.ask`` + carries ``collection``.
 
-    Mirrors ``search_docs``: the handler binds the ``audit_op_id``
-    contextvar so the persisted row is filterable by the canonical, uniform
-    op_id across REST / CLI / MCP. ``op_class`` stays ``read`` (ask is a
-    read-class compose over retrieved chunks) and the raw query is recorded
-    only as ``params_hash``.
+    Mirrors ``search_docs``: the handler binds the ``audit_op_id`` and
+    ``audit_collection`` contextvars so the persisted row is filterable by
+    the canonical, uniform op_id and the collection across REST / CLI / MCP.
+    ``op_class`` stays ``read`` (ask is a read-class compose over retrieved
+    chunks) and the raw query is recorded only as ``params_hash``.
     """
     client, _op = docs_client
+    await seed_doc_collection()
     corpus = _fake_corpus(_SAMPLE_CHUNK)
     stub = _StubLlmClient(
         json.dumps(
@@ -582,13 +606,13 @@ async def test_tools_call_ask_docs_audit_row_carries_canonical_op_id(
         )
     )
     with (
-        patch("meho_backplane.docs_search.service.search_corpus", new=corpus),
+        patch(_CORPUS_SEAM, new=corpus),
         patch(_BUILD_LLM_CLIENT, return_value=stub),
     ):
         response = post_mcp(
             client,
             _ask_call(
-                {"query": "logical switch maximums", "product": "nsx", "version": "9.0"},
+                {"query": "logical switch maximums", "collection": "vmware"},
                 call_id=11,
             ),
         )
@@ -603,5 +627,6 @@ async def test_tools_call_ask_docs_audit_row_carries_canonical_op_id(
     payload = mcp_rows[0].payload
     assert payload["op_id"] == "meho.docs.ask"
     assert payload["op_class"] == "read"
+    assert payload["collection"] == "vmware"
     assert "logical switch maximums" not in json.dumps(payload)
     assert payload["params_hash"]

--- a/backend/tests/test_search_docs_route.py
+++ b/backend/tests/test_search_docs_route.py
@@ -1,38 +1,40 @@
 # SPDX-License-Identifier: Apache-2.0
 # Copyright (c) 2026 evoila Group
 
-"""Behavioural tests for :mod:`meho_backplane.api.v1.search_docs` (G4.5-T3 #1521).
+"""Behavioural tests for :mod:`meho_backplane.api.v1.search_docs` (G4.6-T3 #1552).
 
-Coverage matrix (Task #1521 acceptance criteria):
+Coverage matrix (Task #1552 acceptance criteria):
 
-* **REQUIRE_FILTERS** -- a request missing ``product`` or ``version`` (or
-  carrying a blank one) is rejected **422** when the
-  ``corpus_require_filters`` gate is on; with both present the corpus is
-  called and cited chunks are returned. With the gate off, a partial /
-  absent scope is accepted and forwarded as-is.
-* **Binary scope, not a weight** -- the product+version scope reaches the
-  T2 federation client as ``metadata_filters`` (a binary containment
-  scope), verified via the mock; it is never expressed as a ranking
-  weight.
-* **RBAC + tenant** -- ``read_only`` → 403; ``operator`` → 200; the
-  forwarded operator carries the JWT's ``tenant_id`` (tenant-scoped by
-  construction). Unauthenticated → 401.
+* **Collection scope** -- a request missing / blanking ``collection`` is
+  rejected **422** (fail-closed); ``product`` / ``version`` are now optional
+  refinements (omitting them still succeeds). An unknown collection key is
+  **422**.
+* **Collection routing** -- the query reaches the resolved collection's
+  backend; the optional product/version refinements arrive as
+  ``metadata_filters`` (binary containment, never a weight). The backend id
+  is absent from request + response.
+* **Per-collection entitlement** -- a tenant lacking
+  ``meho-docs:<collection>`` gets **403** on a known collection even though
+  it can authenticate; a tenant with it succeeds.
+* **Readiness** -- a not-``ready`` collection → **409**.
+* **RBAC** -- ``read_only`` → 403; unauthenticated → 401.
 * **Central audit** -- one audit row per query, ``op_id="meho.docs.search"``,
   ``op_class="read"``, the raw query stored only as a SHA-256 hash, plus
-  ``product`` / ``version`` / ``hit_count``; the row is returned by
-  :func:`~meho_backplane.audit_query.query.query_audit` filtered on that
-  ``op_id``.
-* **Corpus-unavailable** -- a :class:`CorpusUnavailable` from the
-  federation client → 503 (fail-closed), never an empty 200.
+  ``collection`` / ``product`` / ``version`` / ``hit_count``; the row is
+  returned by ``query_audit`` filtered on that ``op_id``.
+* **Backend-unavailable** -- a :class:`CorpusUnavailable` from the backend
+  → 503 (fail-closed), never an empty 200.
 
-The corpus call is mocked at :func:`meho_backplane.docs_search.service.search_corpus`
-(the service's import site) so the route tests don't depend on a live
-corpus; the audit read-back uses the autouse SQLite engine the chassis
-audit tests share.
+The corpus call is mocked at the ``corpus-http`` backend's transport seam
+(``meho_backplane.docs_search.backends.corpus_http.search_corpus``) so the
+route tests don't depend on a live corpus; the DB-backed resolve uses the
+autouse SQLite engine the chassis tests share, seeded with a global
+``vmware`` collection.
 """
 
 from __future__ import annotations
 
+import asyncio
 import json
 from collections.abc import Iterator
 from unittest.mock import AsyncMock, patch
@@ -53,7 +55,7 @@ from meho_backplane.auth.corpus import CorpusChunk, CorpusSearchResponse, Corpus
 from meho_backplane.auth.jwt import clear_jwks_cache
 from meho_backplane.auth.operator import TenantRole
 from meho_backplane.db.engine import get_sessionmaker
-from meho_backplane.db.models import AuditLog
+from meho_backplane.db.models import AuditLog, DocCollection
 from meho_backplane.middleware import RequestContextMiddleware
 from meho_backplane.settings import get_settings
 
@@ -64,6 +66,15 @@ from ._oidc_jwt_helpers import mint_token as _mint_token
 from ._oidc_jwt_helpers import mock_discovery_and_jwks as _mock_discovery_and_jwks
 from ._oidc_jwt_helpers import public_jwks as _public_jwks
 
+#: The corpus-http backend's transport seam — the function the
+#: ``corpus-http`` adapter actually calls.
+_CORPUS_SEAM = "meho_backplane.docs_search.backends.corpus_http.search_corpus"
+
+#: The capabilities a token carries to search the seeded ``vmware``
+#: collection: the base add-on key + the per-collection entitlement.
+_ENTITLED_CAPS = ["meho-docs", "meho-docs:vmware"]
+
+
 # ---------------------------------------------------------------------------
 # Settings + JWKS cache fixtures
 # ---------------------------------------------------------------------------
@@ -71,14 +82,7 @@ from ._oidc_jwt_helpers import public_jwks as _public_jwks
 
 @pytest.fixture(autouse=True)
 def _settings_env(monkeypatch: pytest.MonkeyPatch) -> Iterator[None]:
-    """Pin every env var :class:`Settings` reads, around every test.
-
-    ``CORPUS_URL`` is set so the corpus is "configured" (the federation
-    client is mocked at the service import site regardless, so the URL is
-    never dialled); ``CORPUS_REQUIRE_FILTERS`` defaults on. Tests that
-    exercise the gate-off path override it via :func:`_settings_env`'s
-    monkeypatch + ``cache_clear``.
-    """
+    """Pin every env var :class:`Settings` reads, around every test."""
     monkeypatch.setenv("KEYCLOAK_ISSUER_URL", _ISSUER)
     monkeypatch.setenv("KEYCLOAK_AUDIENCE", _AUDIENCE)
     monkeypatch.setenv("KEYCLOAK_JWKS_CACHE_TTL_SECONDS", "300")
@@ -89,7 +93,6 @@ def _settings_env(monkeypatch: pytest.MonkeyPatch) -> Iterator[None]:
     monkeypatch.setenv("VAULT_TIMEOUT_SECONDS", "5.0")
     monkeypatch.delenv("VAULT_NAMESPACE", raising=False)
     monkeypatch.setenv("CORPUS_URL", "https://corpus.test/search")
-    monkeypatch.setenv("CORPUS_REQUIRE_FILTERS", "true")
     get_settings.cache_clear()
     yield
     get_settings.cache_clear()
@@ -104,17 +107,40 @@ def _isolated_jwks_cache() -> Iterator[None]:
 
 
 # ---------------------------------------------------------------------------
+# Doc-collection seeding
+# ---------------------------------------------------------------------------
+
+
+async def _seed_global_collection(*, collection_key: str = "vmware", status: str = "ready") -> None:
+    """Insert a global (``tenant_id IS NULL``) collection for the route tests."""
+    sessionmaker = get_sessionmaker()
+    async with sessionmaker() as session, session.begin():
+        session.add(
+            DocCollection(
+                tenant_id=None,
+                collection_key=collection_key,
+                vendor="VMware by Broadcom",
+                products=["vsphere", "nsx"],
+                description="VMware vendor docs.",
+                when_to_use="VMware product questions.",
+                backend={"type": "corpus-http"},
+                status=status,
+            ),
+        )
+
+
+def _seed_collection_sync(**kwargs: str) -> None:
+    """Seed a global collection from a sync test via a one-shot loop."""
+    asyncio.run(_seed_global_collection(**kwargs))
+
+
+# ---------------------------------------------------------------------------
 # App construction with the search_docs route + audit middleware
 # ---------------------------------------------------------------------------
 
 
 def _build_app() -> FastAPI:
-    """Return a :class:`FastAPI` mirroring prod with the route mounted.
-
-    Includes the production middleware stack so the audit-payload tests
-    see the same contextvar-binding flow production uses. The corpus
-    client is patched at the service import site per-test.
-    """
+    """Return a :class:`FastAPI` mirroring prod with the route mounted."""
     app = FastAPI()
     app.add_middleware(AuditMiddleware)
     app.add_middleware(RequestContextMiddleware)
@@ -146,7 +172,7 @@ def _make_chunk(chunk_id: str = "c1", content: str = "vSAN disk groups...") -> C
 
 
 def _mock_corpus(*chunks: CorpusChunk) -> AsyncMock:
-    """An ``AsyncMock`` standing in for ``search_corpus`` returning *chunks*."""
+    """An ``AsyncMock`` standing in for the backend transport returning *chunks*."""
     return AsyncMock(return_value=CorpusSearchResponse(chunks=list(chunks)))
 
 
@@ -164,12 +190,13 @@ def test_compute_query_hash_is_deterministic_sha256() -> None:
 
 
 # ---------------------------------------------------------------------------
-# Happy path + binary scope forwarding
+# Happy path + collection routing
 # ---------------------------------------------------------------------------
 
 
 def test_search_docs_returns_200_with_cited_chunks(client: TestClient) -> None:
-    """``operator`` JWT + product+version → 200 with cited chunks."""
+    """``operator`` JWT + entitled collection → 200 with cited chunks."""
+    _seed_collection_sync()
     key = _make_rsa_keypair("kid-A")
     tenant_id = UUID("33333333-3333-3333-3333-333333333333")
     token = _mint_token(
@@ -177,17 +204,18 @@ def test_search_docs_returns_200_with_cited_chunks(client: TestClient) -> None:
         sub="op-1",
         tenant_role=TenantRole.OPERATOR.value,
         tenant_id=str(tenant_id),
+        capabilities=_ENTITLED_CAPS,
     )
 
     fake_corpus = _mock_corpus(_make_chunk("c1"), _make_chunk("c2", "another"))
     with (
         respx.mock as mock_router,
-        patch("meho_backplane.docs_search.service.search_corpus", new=fake_corpus),
+        patch(_CORPUS_SEAM, new=fake_corpus),
     ):
         _mock_discovery_and_jwks(mock_router, _public_jwks(key))
         response = client.post(
             "/api/v1/search_docs",
-            json={"query": "vsan disk groups", "product": "vmware", "version": "9.0", "limit": 5},
+            json={"query": "vsan disk groups", "collection": "vmware", "limit": 5},
             headers={"Authorization": f"Bearer {token}"},
         )
 
@@ -196,11 +224,9 @@ def test_search_docs_returns_200_with_cited_chunks(client: TestClient) -> None:
     assert len(body["chunks"]) == 2
     assert body["chunks"][0]["chunk_id"] == "c1"
     assert body["chunks"][0]["content"] == "vSAN disk groups..."
-    assert body["chunks"][0]["source_url"] == "https://docs.vendor.test/vsan#disk-groups"
-    assert body["chunks"][0]["score"] == 0.91
+    # The backend id never appears in the response.
+    assert "backend" not in json.dumps(body)
 
-    # The corpus client was called as the operator (forwarded JWT) with
-    # the query + limit; the operator object carries the JWT tenant_id.
     fake_corpus.assert_awaited_once()
     call_args = fake_corpus.await_args
     operator_arg = call_args.args[0]
@@ -209,67 +235,101 @@ def test_search_docs_returns_200_with_cited_chunks(client: TestClient) -> None:
     assert call_args.kwargs["limit"] == 5
 
 
-def test_product_version_forwarded_as_binary_filter_not_weight(client: TestClient) -> None:
-    """The product+version scope reaches the corpus as ``metadata_filters``.
+def test_optional_refinements_forwarded_as_binary_filter_not_weight(
+    client: TestClient,
+) -> None:
+    """Optional product+version reach the backend as ``metadata_filters``.
 
-    The scope is a binary containment filter (#1178 / #1177), so it must
-    arrive on the T2 client's ``metadata_filters`` kwarg verbatim -- never
-    as a ``weight`` / boost parameter.
+    The refinements are a binary containment filter (#1178 / #1177), so they
+    must arrive on the backend's ``metadata_filters`` kwarg verbatim -- never
+    as a ``weight`` / boost parameter. ``collection`` is the router key and
+    must NOT appear in the metadata filters.
     """
+    _seed_collection_sync()
     key = _make_rsa_keypair("kid-A")
-    token = _mint_token(key, sub="op-2", tenant_role=TenantRole.OPERATOR.value)
+    token = _mint_token(
+        key, sub="op-2", tenant_role=TenantRole.OPERATOR.value, capabilities=_ENTITLED_CAPS
+    )
 
     fake_corpus = _mock_corpus()
     with (
         respx.mock as mock_router,
-        patch("meho_backplane.docs_search.service.search_corpus", new=fake_corpus),
+        patch(_CORPUS_SEAM, new=fake_corpus),
     ):
         _mock_discovery_and_jwks(mock_router, _public_jwks(key))
         response = client.post(
             "/api/v1/search_docs",
-            json={"query": "esxi upgrade", "product": "vmware", "version": "8.0"},
+            json={
+                "query": "esxi upgrade",
+                "collection": "vmware",
+                "product": "vmware",
+                "version": "8.0",
+            },
             headers={"Authorization": f"Bearer {token}"},
         )
 
     assert response.status_code == 200
     call_kwargs = fake_corpus.await_args.kwargs
     assert call_kwargs["metadata_filters"] == {"product": "vmware", "version": "8.0"}
-    # The scope is a filter, not a weight: no weighting kwarg is passed.
+    # The collection routes/entitles; it is not a metadata filter.
+    assert "collection" not in call_kwargs["metadata_filters"]
     assert "weight" not in call_kwargs
-    assert "weights" not in call_kwargs
     assert "boost" not in call_kwargs
 
 
+def test_collection_only_omits_metadata_filters(client: TestClient) -> None:
+    """Product/version are optional: a collection-only query still succeeds.
+
+    With no product/version, ``metadata_filters`` is ``None`` (the collection
+    alone scopes the query).
+    """
+    _seed_collection_sync()
+    key = _make_rsa_keypair("kid-A")
+    token = _mint_token(
+        key, sub="op-co", tenant_role=TenantRole.OPERATOR.value, capabilities=_ENTITLED_CAPS
+    )
+    fake_corpus = _mock_corpus(_make_chunk())
+    with (
+        respx.mock as mock_router,
+        patch(_CORPUS_SEAM, new=fake_corpus),
+    ):
+        _mock_discovery_and_jwks(mock_router, _public_jwks(key))
+        response = client.post(
+            "/api/v1/search_docs",
+            json={"query": "q", "collection": "vmware"},  # no product/version
+            headers={"Authorization": f"Bearer {token}"},
+        )
+
+    assert response.status_code == 200
+    assert fake_corpus.await_args.kwargs["metadata_filters"] is None
+
+
 # ---------------------------------------------------------------------------
-# REQUIRE_FILTERS (422 fail-closed)
+# Collection scope (422 fail-closed)
 # ---------------------------------------------------------------------------
 
 
 @pytest.mark.parametrize(
-    ("body", "missing"),
+    "body",
     [
-        ({"query": "q", "version": "9.0"}, "product"),
-        ({"query": "q", "product": "vmware"}, "version"),
-        ({"query": "q"}, "product"),
-        ({"query": "q", "product": "  ", "version": "9.0"}, "product"),
-        ({"query": "q", "product": "vmware", "version": ""}, "version"),
+        {"query": "q"},  # no collection
+        {"query": "q", "collection": ""},  # blank collection
+        {"query": "q", "collection": "  "},  # blank-after-strip
+        {"query": "q", "product": "vmware", "version": "9.0"},  # refinements, no collection
     ],
 )
-def test_missing_or_blank_filter_rejects_with_422(
-    client: TestClient, body: dict[str, str], missing: str
+def test_missing_or_blank_collection_rejects_with_422(
+    client: TestClient, body: dict[str, str]
 ) -> None:
-    """A missing / blank product or version → 422 (REQUIRE_FILTERS).
-
-    The corpus client must NOT be called when the mandatory scope is
-    absent -- an unfiltered corpus query is exactly what fail-closed
-    prevents.
-    """
+    """A missing / blank collection → 422. The backend must NOT be called."""
     key = _make_rsa_keypair("kid-A")
-    token = _mint_token(key, sub="op-rf", tenant_role=TenantRole.OPERATOR.value)
+    token = _mint_token(
+        key, sub="op-rf", tenant_role=TenantRole.OPERATOR.value, capabilities=_ENTITLED_CAPS
+    )
     fake_corpus = _mock_corpus()
     with (
         respx.mock as mock_router,
-        patch("meho_backplane.docs_search.service.search_corpus", new=fake_corpus),
+        patch(_CORPUS_SEAM, new=fake_corpus),
     ):
         _mock_discovery_and_jwks(mock_router, _public_jwks(key))
         response = client.post(
@@ -278,101 +338,134 @@ def test_missing_or_blank_filter_rejects_with_422(
             headers={"Authorization": f"Bearer {token}"},
         )
     assert response.status_code == 422
-    assert missing in json.dumps(response.json()["detail"])
+    assert "collection" in json.dumps(response.json()["detail"])
     fake_corpus.assert_not_awaited()
 
 
-def test_gate_off_accepts_partial_scope_and_forwards_present_keys(
-    client: TestClient, monkeypatch: pytest.MonkeyPatch
-) -> None:
-    """With ``corpus_require_filters`` off, a partial scope is accepted.
-
-    Whatever filter is present still scopes the corpus query; absent
-    keys simply widen it (the corpus owns the policy in this mode). The
-    enforcement is gated, per the Initiative -- not hard-wired.
-    """
-    monkeypatch.setenv("CORPUS_REQUIRE_FILTERS", "false")
-    get_settings.cache_clear()
-
+def test_unknown_collection_rejects_with_422(client: TestClient) -> None:
+    """A collection key naming no visible collection → 422 (invalid argument)."""
+    # No collection seeded.
     key = _make_rsa_keypair("kid-A")
-    token = _mint_token(key, sub="op-gate-off", tenant_role=TenantRole.OPERATOR.value)
-    fake_corpus = _mock_corpus(_make_chunk())
+    token = _mint_token(
+        key, sub="op-unk", tenant_role=TenantRole.OPERATOR.value, capabilities=_ENTITLED_CAPS
+    )
+    fake_corpus = _mock_corpus()
     with (
         respx.mock as mock_router,
-        patch("meho_backplane.docs_search.service.search_corpus", new=fake_corpus),
+        patch(_CORPUS_SEAM, new=fake_corpus),
     ):
         _mock_discovery_and_jwks(mock_router, _public_jwks(key))
         response = client.post(
             "/api/v1/search_docs",
-            json={"query": "q", "product": "vmware"},  # no version
+            json={"query": "q", "collection": "nope"},
             headers={"Authorization": f"Bearer {token}"},
         )
-
-    assert response.status_code == 200
-    # Only the present key is forwarded; no `version: None` is injected.
-    assert fake_corpus.await_args.kwargs["metadata_filters"] == {"product": "vmware"}
+    assert response.status_code == 422
+    detail = response.json()["detail"]
+    assert detail["error"] == "unknown_collection"
+    fake_corpus.assert_not_awaited()
 
 
 def test_empty_query_rejects_with_422(client: TestClient) -> None:
     """``query=""`` fails Pydantic min_length validation."""
     key = _make_rsa_keypair("kid-A")
-    token = _mint_token(key, sub="op-eq", tenant_role=TenantRole.OPERATOR.value)
+    token = _mint_token(
+        key, sub="op-eq", tenant_role=TenantRole.OPERATOR.value, capabilities=_ENTITLED_CAPS
+    )
     with respx.mock as mock_router:
         _mock_discovery_and_jwks(mock_router, _public_jwks(key))
         response = client.post(
             "/api/v1/search_docs",
-            json={"query": "", "product": "vmware", "version": "9.0"},
+            json={"query": "", "collection": "vmware"},
             headers={"Authorization": f"Bearer {token}"},
         )
     assert response.status_code == 422
 
 
 # ---------------------------------------------------------------------------
-# Corpus unavailable (503 fail-closed)
+# Per-collection entitlement (403) + readiness (409)
 # ---------------------------------------------------------------------------
 
 
-def test_corpus_unavailable_maps_to_503_not_empty_200(client: TestClient) -> None:
-    """A :class:`CorpusUnavailable` from the client → 503, never empty 200."""
+def test_not_entitled_to_collection_returns_403(client: TestClient) -> None:
+    """A tenant lacking ``meho-docs:vmware`` → 403 on a known collection.
+
+    The base ``meho-docs`` capability authenticates the add-on; the
+    per-collection entitlement is the finer gate that rejects the query.
+    The backend is never called.
+    """
+    _seed_collection_sync()
     key = _make_rsa_keypair("kid-A")
-    token = _mint_token(key, sub="op-503", tenant_role=TenantRole.OPERATOR.value)
-    fake_corpus = AsyncMock(side_effect=CorpusUnavailable("corpus unreachable: ConnectError"))
+    token = _mint_token(
+        key,
+        sub="op-nopriv",
+        tenant_role=TenantRole.OPERATOR.value,
+        capabilities=["meho-docs"],  # base only, no per-collection key
+    )
+    fake_corpus = _mock_corpus(_make_chunk())
     with (
         respx.mock as mock_router,
-        patch("meho_backplane.docs_search.service.search_corpus", new=fake_corpus),
+        patch(_CORPUS_SEAM, new=fake_corpus),
     ):
         _mock_discovery_and_jwks(mock_router, _public_jwks(key))
         response = client.post(
             "/api/v1/search_docs",
-            json={"query": "q", "product": "vmware", "version": "9.0"},
+            json={"query": "q", "collection": "vmware"},
+            headers={"Authorization": f"Bearer {token}"},
+        )
+    assert response.status_code == 403
+    assert "entitled" in json.dumps(response.json()["detail"])
+    fake_corpus.assert_not_awaited()
+
+
+def test_not_ready_collection_returns_409(client: TestClient) -> None:
+    """A known + entitled but not-``ready`` collection → 409 (not answerable yet)."""
+    _seed_collection_sync(status="rebuilding")
+    key = _make_rsa_keypair("kid-A")
+    token = _mint_token(
+        key, sub="op-nr", tenant_role=TenantRole.OPERATOR.value, capabilities=_ENTITLED_CAPS
+    )
+    fake_corpus = _mock_corpus(_make_chunk())
+    with (
+        respx.mock as mock_router,
+        patch(_CORPUS_SEAM, new=fake_corpus),
+    ):
+        _mock_discovery_and_jwks(mock_router, _public_jwks(key))
+        response = client.post(
+            "/api/v1/search_docs",
+            json={"query": "q", "collection": "vmware"},
+            headers={"Authorization": f"Bearer {token}"},
+        )
+    assert response.status_code == 409
+    assert "not ready" in json.dumps(response.json()["detail"])
+    fake_corpus.assert_not_awaited()
+
+
+# ---------------------------------------------------------------------------
+# Backend unavailable (503 fail-closed)
+# ---------------------------------------------------------------------------
+
+
+def test_backend_unavailable_maps_to_503_not_empty_200(client: TestClient) -> None:
+    """A :class:`CorpusUnavailable` from the backend → 503, never empty 200."""
+    _seed_collection_sync()
+    key = _make_rsa_keypair("kid-A")
+    token = _mint_token(
+        key, sub="op-503", tenant_role=TenantRole.OPERATOR.value, capabilities=_ENTITLED_CAPS
+    )
+    fake_corpus = AsyncMock(side_effect=CorpusUnavailable("corpus unreachable: ConnectError"))
+    with (
+        respx.mock as mock_router,
+        patch(_CORPUS_SEAM, new=fake_corpus),
+    ):
+        _mock_discovery_and_jwks(mock_router, _public_jwks(key))
+        response = client.post(
+            "/api/v1/search_docs",
+            json={"query": "q", "collection": "vmware"},
             headers={"Authorization": f"Bearer {token}"},
         )
     assert response.status_code == 503
     assert "chunks" not in response.json()
-
-
-def test_unconfigured_corpus_maps_to_503(
-    client: TestClient, monkeypatch: pytest.MonkeyPatch
-) -> None:
-    """An unset ``CORPUS_URL`` → the real client raises → 503.
-
-    Uses the *real* :func:`search_corpus` (no patch) with ``CORPUS_URL``
-    cleared, proving the unconfigured branch fails closed end-to-end
-    rather than via the mock.
-    """
-    monkeypatch.delenv("CORPUS_URL", raising=False)
-    get_settings.cache_clear()
-
-    key = _make_rsa_keypair("kid-A")
-    token = _mint_token(key, sub="op-unconfig", tenant_role=TenantRole.OPERATOR.value)
-    with respx.mock as mock_router:
-        _mock_discovery_and_jwks(mock_router, _public_jwks(key))
-        response = client.post(
-            "/api/v1/search_docs",
-            json={"query": "q", "product": "vmware", "version": "9.0"},
-            headers={"Authorization": f"Bearer {token}"},
-        )
-    assert response.status_code == 503
 
 
 # ---------------------------------------------------------------------------
@@ -384,7 +477,7 @@ def test_unauthenticated_request_returns_401(client: TestClient) -> None:
     """No Authorization header → 401."""
     response = client.post(
         "/api/v1/search_docs",
-        json={"query": "q", "product": "vmware", "version": "9.0"},
+        json={"query": "q", "collection": "vmware"},
     )
     assert response.status_code == 401
 
@@ -392,12 +485,14 @@ def test_unauthenticated_request_returns_401(client: TestClient) -> None:
 def test_read_only_role_returns_403(client: TestClient) -> None:
     """``read_only`` JWT → 403 (route gated on OPERATOR)."""
     key = _make_rsa_keypair("kid-A")
-    token = _mint_token(key, sub="op-ro", tenant_role=TenantRole.READ_ONLY.value)
+    token = _mint_token(
+        key, sub="op-ro", tenant_role=TenantRole.READ_ONLY.value, capabilities=_ENTITLED_CAPS
+    )
     with respx.mock as mock_router, structlog.testing.capture_logs() as cap_logs:
         _mock_discovery_and_jwks(mock_router, _public_jwks(key))
         response = client.post(
             "/api/v1/search_docs",
-            json={"query": "q", "product": "vmware", "version": "9.0"},
+            json={"query": "q", "collection": "vmware"},
             headers={"Authorization": f"Bearer {token}"},
         )
     assert response.status_code == 403
@@ -409,17 +504,23 @@ def test_read_only_role_returns_403(client: TestClient) -> None:
 
 def test_admin_role_returns_200(client: TestClient) -> None:
     """``tenant_admin`` JWT passes the operator gate (admin >= operator)."""
+    _seed_collection_sync()
     key = _make_rsa_keypair("kid-A")
-    token = _mint_token(key, sub="op-admin", tenant_role=TenantRole.TENANT_ADMIN.value)
+    token = _mint_token(
+        key,
+        sub="op-admin",
+        tenant_role=TenantRole.TENANT_ADMIN.value,
+        capabilities=_ENTITLED_CAPS,
+    )
     fake_corpus = _mock_corpus()
     with (
         respx.mock as mock_router,
-        patch("meho_backplane.docs_search.service.search_corpus", new=fake_corpus),
+        patch(_CORPUS_SEAM, new=fake_corpus),
     ):
         _mock_discovery_and_jwks(mock_router, _public_jwks(key))
         response = client.post(
             "/api/v1/search_docs",
-            json={"query": "q", "product": "vmware", "version": "9.0"},
+            json={"query": "q", "collection": "vmware"},
             headers={"Authorization": f"Bearer {token}"},
         )
     assert response.status_code == 200
@@ -431,25 +532,35 @@ def test_admin_role_returns_200(client: TestClient) -> None:
 
 
 @pytest.mark.asyncio
-async def test_audit_row_carries_op_id_hash_and_scope_not_raw_query(client: TestClient) -> None:
-    """One audit row: ``op_id=meho.docs.search``, ``op_class=read``, hash + scope.
+async def test_audit_row_carries_op_id_hash_and_collection_not_raw_query(
+    client: TestClient,
+) -> None:
+    """One audit row: ``op_id=meho.docs.search``, ``op_class=read``, hash + collection.
 
     The raw query MUST NOT appear anywhere in the payload -- only its
-    SHA-256 digest. ``product`` / ``version`` (operator-chosen scopes,
-    not tenant-shaped identifiers) and ``hit_count`` are recorded.
+    SHA-256 digest. ``collection`` / ``product`` / ``version`` and
+    ``hit_count`` are recorded.
     """
+    await _seed_global_collection()
     key = _make_rsa_keypair("kid-A")
     raw_query = "how do I expand a vsan disk group"
-    token = _mint_token(key, sub="op-audit", tenant_role=TenantRole.OPERATOR.value)
+    token = _mint_token(
+        key, sub="op-audit", tenant_role=TenantRole.OPERATOR.value, capabilities=_ENTITLED_CAPS
+    )
     fake_corpus = _mock_corpus(_make_chunk("c1"), _make_chunk("c2"))
     with (
         respx.mock as mock_router,
-        patch("meho_backplane.docs_search.service.search_corpus", new=fake_corpus),
+        patch(_CORPUS_SEAM, new=fake_corpus),
     ):
         _mock_discovery_and_jwks(mock_router, _public_jwks(key))
         response = client.post(
             "/api/v1/search_docs",
-            json={"query": raw_query, "product": "vmware", "version": "9.0"},
+            json={
+                "query": raw_query,
+                "collection": "vmware",
+                "product": "vmware",
+                "version": "9.0",
+            },
             headers={"Authorization": f"Bearer {token}"},
         )
     assert response.status_code == 200
@@ -466,6 +577,7 @@ async def test_audit_row_carries_op_id_hash_and_scope_not_raw_query(client: Test
     assert payload["op_id"] == "meho.docs.search"
     assert payload["op_class"] == "read"
     assert payload["query_hash"] == _compute_query_hash(raw_query)
+    assert payload["collection"] == "vmware"
     assert payload["product"] == "vmware"
     assert payload["version"] == "9.0"
     assert payload["hit_count"] == 2
@@ -477,12 +589,8 @@ async def test_audit_row_carries_op_id_hash_and_scope_not_raw_query(client: Test
 
 @pytest.mark.asyncio
 async def test_query_audit_finds_row_by_op_id(client: TestClient) -> None:
-    """The audit row is returned by ``query_audit`` filtered on the op_id.
-
-    Closes the loop that who-touched / ``query_audit`` surface every
-    docs query under the named op -- the reason the route binds a canonical
-    ``op_id`` rather than the path-derived default.
-    """
+    """The audit row is returned by ``query_audit`` filtered on the op_id."""
+    await _seed_global_collection()
     key = _make_rsa_keypair("kid-A")
     tenant_id = UUID("44444444-4444-4444-4444-444444444444")
     token = _mint_token(
@@ -490,16 +598,17 @@ async def test_query_audit_finds_row_by_op_id(client: TestClient) -> None:
         sub="op-qa",
         tenant_role=TenantRole.OPERATOR.value,
         tenant_id=str(tenant_id),
+        capabilities=_ENTITLED_CAPS,
     )
     fake_corpus = _mock_corpus(_make_chunk())
     with (
         respx.mock as mock_router,
-        patch("meho_backplane.docs_search.service.search_corpus", new=fake_corpus),
+        patch(_CORPUS_SEAM, new=fake_corpus),
     ):
         _mock_discovery_and_jwks(mock_router, _public_jwks(key))
         response = client.post(
             "/api/v1/search_docs",
-            json={"query": "vsan", "product": "vmware", "version": "9.0"},
+            json={"query": "vsan", "collection": "vmware"},
             headers={"Authorization": f"Bearer {token}"},
         )
     assert response.status_code == 200
@@ -518,26 +627,33 @@ async def test_query_audit_finds_row_by_op_id(client: TestClient) -> None:
 
 
 @pytest.mark.asyncio
-async def test_audit_row_written_on_corpus_503(client: TestClient) -> None:
-    """A 503 still produces an audit row with the query identity + scope.
+async def test_audit_row_written_on_backend_503(client: TestClient) -> None:
+    """A 503 still produces an audit row with the query identity + collection scope.
 
-    The contextvars are bound *before* the corpus call, so the
-    fail-closed path is still attributable: who searched for what
-    (hashed), scoped to which product/version, even though it failed.
-    ``hit_count`` is absent (bound only after a successful return).
+    The contextvars are bound *before* the backend call, so the fail-closed
+    path is still attributable. ``hit_count`` is absent (bound only after a
+    successful return).
     """
+    await _seed_global_collection()
     key = _make_rsa_keypair("kid-A")
     raw_query = "esxi boot loop"
-    token = _mint_token(key, sub="op-503-audit", tenant_role=TenantRole.OPERATOR.value)
+    token = _mint_token(
+        key, sub="op-503-audit", tenant_role=TenantRole.OPERATOR.value, capabilities=_ENTITLED_CAPS
+    )
     fake_corpus = AsyncMock(side_effect=CorpusUnavailable("corpus returned HTTP 502", status=502))
     with (
         respx.mock as mock_router,
-        patch("meho_backplane.docs_search.service.search_corpus", new=fake_corpus),
+        patch(_CORPUS_SEAM, new=fake_corpus),
     ):
         _mock_discovery_and_jwks(mock_router, _public_jwks(key))
         response = client.post(
             "/api/v1/search_docs",
-            json={"query": raw_query, "product": "vmware", "version": "8.0"},
+            json={
+                "query": raw_query,
+                "collection": "vmware",
+                "product": "vmware",
+                "version": "8.0",
+            },
             headers={"Authorization": f"Bearer {token}"},
         )
     assert response.status_code == 503
@@ -553,6 +669,7 @@ async def test_audit_row_written_on_corpus_503(client: TestClient) -> None:
     payload = rows[0].payload
     assert payload["op_id"] == "meho.docs.search"
     assert payload["query_hash"] == _compute_query_hash(raw_query)
+    assert payload["collection"] == "vmware"
     assert payload["product"] == "vmware"
     assert payload["version"] == "8.0"
     assert "hit_count" not in payload

--- a/cli/api/openapi.json
+++ b/cli/api/openapi.json
@@ -409,7 +409,7 @@
           "docs"
         ],
         "summary": "Search Docs Endpoint",
-        "description": "Federate a vendor-document query to the corpus, returning cited chunks.\n\nEnforces the mandatory binary product+version scope (422 when the\nREQUIRE_FILTERS gate is on and either is absent), forwards the\noperator JWT to the corpus via the shared\n:func:`~meho_backplane.docs_search.search_docs` service, and binds\nthe central ``meho.docs.search`` audit row. ``read_only`` operators\nget 403 via :func:`require_role` before reaching this handler.\n\nThe audit contextvars are bound **before** the corpus call so a\nhandler exception (including the :class:`CorpusUnavailable` \u2192 503\nbranch) still produces an audit row with the query identity + binary\nscope preserved. The raw query is never bound -- only its SHA-256\nhash.",
+        "description": "Route a vendor-document query to a collection's backend, returning cited chunks.\n\nEnforces the mandatory ``collection`` binary scope (422 when absent),\nresolves it to its backend via the shared\n:func:`~meho_backplane.docs_search.search_docs` service, enforces the\nper-collection ``meho-docs:<collection>`` entitlement (403) and\nreadiness (409), and binds the central ``meho.docs.search`` audit row.\n``read_only`` operators get 403 via :func:`require_role` before\nreaching this handler.\n\nThe audit contextvars are bound **before** the entitlement / backend\ncall so a handler exception (the entitlement 403, readiness 409, or\n:class:`CorpusUnavailable` 503 branch) still produces an audit row\nwith the query identity + collection scope preserved. The raw query is\nnever bound -- only its SHA-256 hash.",
         "operationId": "search_docs_endpoint_api_v1_search_docs_post",
         "parameters": [
           {
@@ -444,11 +444,17 @@
               }
             }
           },
+          "403": {
+            "description": "The tenant is not entitled to the named collection -- it lacks the ``meho-docs:<collection>`` capability even though it can see the add-on. The collection exists; the principal just cannot search it."
+          },
+          "409": {
+            "description": "The named collection is known and entitled but not ``ready`` (provisioning / rebuilding / disabled) -- its backend is not answerable yet."
+          },
           "422": {
-            "description": "The mandatory binary product+version scope is absent (REQUIRE_FILTERS). A docs query without both filters is rejected rather than forwarded as an unfiltered corpus query."
+            "description": "The mandatory ``collection`` scope is absent / blank, or names no collection visible to the tenant. A docs query without a routable collection is rejected rather than forwarded as an unscoped query."
           },
           "503": {
-            "description": "The external corpus is unavailable -- unconfigured, unreachable, or returned a non-2xx / malformed response. Fail-closed; never an empty 200."
+            "description": "The collection's backend is unavailable -- unconfigured, unreachable, or returned a non-2xx / malformed response. Fail-closed; never an empty 200."
           }
         }
       }
@@ -14789,6 +14795,12 @@
             "minLength": 1,
             "title": "Query"
           },
+          "collection": {
+            "type": "string",
+            "maxLength": 128,
+            "nullable": true,
+            "title": "Collection"
+          },
           "product": {
             "type": "string",
             "maxLength": 128,
@@ -14815,7 +14827,7 @@
           "query"
         ],
         "title": "SearchDocsRequest",
-        "description": "POST body for ``/api/v1/search_docs``.\n\n``product`` / ``version`` are the **mandatory binary scope** under\nthe REQUIRE_FILTERS posture -- they are typed optional here so a\nmissing value is rejected by the service with a route-shaped 422\nnaming the absent key(s), rather than Pydantic's generic\n``field_required`` (which would not say *why* the scope is mandatory\nor honour the ``corpus_require_filters`` gate-off path).\n\n``extra=\"forbid\"`` rejects unknown fields at 422 so a client sending\na pre-rename key fails loud rather than running with the defaults --\nthe same posture every public v1 request schema ships under."
+        "description": "POST body for ``/api/v1/search_docs``.\n\n``collection`` is the **mandatory binary scope** (G4.6-T3 #1552) -- it\nis typed optional here so a missing value is rejected by the service\nwith a route-shaped 422 naming the absent key (carrying *why* the\ncollection is mandatory), rather than Pydantic's generic\n``field_required``. ``product`` / ``version`` are **optional\nrefinements** within the chosen collection.\n\n``extra=\"forbid\"`` rejects unknown fields at 422 so a client sending\na pre-rename key fails loud rather than running with the defaults --\nthe same posture every public v1 request schema ships under."
       },
       "SearchDocsResponse": {
         "properties": {

--- a/cli/internal/api/client.gen.go
+++ b/cli/internal/api/client.gen.go
@@ -3731,21 +3731,22 @@ type ScheduledTriggerStatus string
 
 // SearchDocsRequest POST body for “/api/v1/search_docs“.
 //
-// “product“ / “version“ are the **mandatory binary scope** under
-// the REQUIRE_FILTERS posture -- they are typed optional here so a
-// missing value is rejected by the service with a route-shaped 422
-// naming the absent key(s), rather than Pydantic's generic
-// “field_required“ (which would not say *why* the scope is mandatory
-// or honour the “corpus_require_filters“ gate-off path).
+// “collection“ is the **mandatory binary scope** (G4.6-T3 #1552) -- it
+// is typed optional here so a missing value is rejected by the service
+// with a route-shaped 422 naming the absent key (carrying *why* the
+// collection is mandatory), rather than Pydantic's generic
+// “field_required“. “product“ / “version“ are **optional
+// refinements** within the chosen collection.
 //
 // “extra="forbid"“ rejects unknown fields at 422 so a client sending
 // a pre-rename key fails loud rather than running with the defaults --
 // the same posture every public v1 request schema ships under.
 type SearchDocsRequest struct {
-	Limit   *int    `json:"limit,omitempty"`
-	Product *string `json:"product"`
-	Query   string  `json:"query"`
-	Version *string `json:"version"`
+	Collection *string `json:"collection"`
+	Limit      *int    `json:"limit,omitempty"`
+	Product    *string `json:"product"`
+	Query      string  `json:"query"`
+	Version    *string `json:"version"`
 }
 
 // SearchDocsResponse Successful response shape for “/api/v1/search_docs“.

--- a/cli/internal/cmd/docs/docs.go
+++ b/cli/internal/cmd/docs/docs.go
@@ -2,16 +2,18 @@
 // Copyright (c) 2026 evoila Group
 
 // Package docs hosts the cobra commands under `meho docs ...` for
-// G4.5-T5 (#1524) of Initiative #1518 (the meho-docs add-on). v0.11
-// ships one operator-facing verb that mirrors the `search_docs` MCP
-// tool (T4, #1523):
+// G4.5-T5 (#1524) of Initiative #1518 (the meho-docs add-on), extended
+// for collection-scoped search by G4.6-T3 (#1552). It ships one
+// operator-facing verb that mirrors the `search_docs` MCP tool:
 //
-//   - `meho docs search <query> --product <p> --version <v>
-//     [--limit N] [--json]` — federated vendor-document retrieval via
-//     POST /api/v1/search_docs (T3, #1521). Role: operator. The
-//     product+version filter is the mandatory binary scope under the
-//     backend's REQUIRE_FILTERS posture; the CLI fails fast on a
-//     missing filter before the round-trip.
+//   - `meho docs search <query> --collection <c> [--product <p>]
+//     [--version <v>] [--limit N] [--json]` — collection-scoped
+//     vendor-document retrieval via POST /api/v1/search_docs (T3,
+//     #1552). Role: operator. --collection is the mandatory binary
+//     scope (it routes to a backend and gates per-collection
+//     entitlement); the CLI fails fast on a missing --collection
+//     before the round-trip. --product / --version are optional
+//     refinements within the collection.
 //
 // Gating — true-absence-when-unprovisioned (option B, the
 // compiled-in fallback). The `meho docs` tree compiles into every
@@ -108,7 +110,8 @@ func newRootCmdWithGate(provisioned bool) *cobra.Command {
 			"`meho --help` and every verb refuses with a typed " +
 			"`addon_not_provisioned` error. Search routes through the " +
 			"backplane so every query is audited and the mandatory " +
-			"product+version scope is enforced centrally.",
+			"collection scope + per-collection entitlement are enforced " +
+			"centrally.",
 		// Hidden mirrors the absence the Initiative asks for: an
 		// unprovisioned tenant should not see the command in --help.
 		// The verb-level refusal (below) closes the "hidden but still
@@ -338,13 +341,18 @@ func renderRequestError(
 // the T3 route contract):
 //
 //   - 401 → auth_expired (token rejected / refresh impossible).
-//   - 403 → insufficient_role (read_only operator).
-//   - 422 → unexpected wrapping the REQUIRE_FILTERS detail (missing
-//     product/version — the CLI fails fast before the call, so a 422
-//     here means a contract drift worth surfacing rather than
-//     swallowing) or a too-long query / out-of-range limit.
-//   - 503 → unexpected with the corpus-unavailable detail (the
-//     external corpus is unconfigured / unreachable / non-2xx).
+//   - 403 → insufficient_role (read_only operator, OR the tenant is not
+//     entitled to the named collection — it lacks the
+//     `meho-docs:<collection>` capability).
+//   - 409 → unexpected wrapping the not-ready detail (the collection is
+//     known + entitled but its backend is provisioning / rebuilding /
+//     disabled).
+//   - 422 → unexpected wrapping the collection-scope detail (missing
+//     --collection — the CLI fails fast before the call, so a 422 here
+//     means an unknown collection or a contract drift worth surfacing)
+//     or a too-long query / out-of-range limit.
+//   - 503 → unexpected with the backend-unavailable detail (the
+//     collection's backend is unconfigured / unreachable / non-2xx).
 //   - Other non-2xx → unexpected with the raw body.
 func renderHTTPStatus(
 	cmd *cobra.Command,
@@ -373,10 +381,18 @@ func renderHTTPStatus(
 			output.Unexpected(fmt.Sprintf("invalid request: %s", decodeDetailString(bodyStr))),
 			jsonOut,
 		)
+	case http.StatusConflict:
+		return output.RenderError(cmd.ErrOrStderr(),
+			output.Unexpected(fmt.Sprintf(
+				"the doc collection is not ready: %s",
+				decodeDetailString(bodyStr),
+			)),
+			jsonOut,
+		)
 	case http.StatusServiceUnavailable:
 		return output.RenderError(cmd.ErrOrStderr(),
 			output.Unexpected(fmt.Sprintf(
-				"the vendor-document corpus is unavailable: %s",
+				"the collection's backend is unavailable: %s",
 				decodeDetailString(bodyStr),
 			)),
 			jsonOut,

--- a/cli/internal/cmd/docs/search.go
+++ b/cli/internal/cmd/docs/search.go
@@ -18,31 +18,33 @@ import (
 
 // newSearchCmd returns the `meho docs search` command.
 //
-// CLI shape (per issue #1524):
+// CLI shape (per issue #1552):
 //
-//	meho docs search <query> --product <p> --version <v> \
-//	  [--limit N] [--json] [--backplane <url>]
+//	meho docs search <query> --collection <c> \
+//	  [--product <p>] [--version <v>] [--limit N] [--json] [--backplane <url>]
 //
-// Role: operator. Calls POST /api/v1/search_docs (T3, #1521) via the
+// Role: operator. Calls POST /api/v1/search_docs (T3, #1552) via the
 // shared authed client (bearer + 401-refresh). `provisioned` carries
 // the meho-docs capability gate resolved at command-tree-build time;
 // when false the verb refuses with a typed `addon_not_provisioned`
 // error before any flag validation or network call.
 //
-// product/version are the mandatory binary scope under the backend's
-// REQUIRE_FILTERS posture. The CLI fails fast on a missing filter
-// (exit 4) before the round-trip, mirroring the route's 422 rather
-// than incurring it.
+// --collection is the mandatory binary scope: it routes the query to a
+// backend and gates per-collection entitlement. The CLI fails fast on a
+// missing --collection (exit 4) before the round-trip, mirroring the
+// route's 422 rather than incurring it. --product / --version are
+// optional refinements within the collection.
 //
 // Exit codes:
 //   - 0   search returned cleanly (incl. zero-hit result)
 //   - 2   auth_expired
 //   - 3   unreachable
-//   - 4   unexpected_response (missing --product/--version,
-//     out-of-range --limit, a 422/503 from the route)
+//   - 4   unexpected_response (missing --collection, out-of-range
+//     --limit, a 422/503 from the route)
 //   - 5   insufficient_role / addon_not_provisioned
 func newSearchCmd(provisioned bool) *cobra.Command {
 	var (
+		collection        string
 		product           string
 		version           string
 		limit             int
@@ -51,13 +53,14 @@ func newSearchCmd(provisioned bool) *cobra.Command {
 	)
 	cmd := &cobra.Command{
 		Use:   "search <query>",
-		Short: "Search the vendor-document corpus (mandatory --product + --version)",
+		Short: "Search a vendor-document collection (mandatory --collection)",
 		Long: "search calls POST /api/v1/search_docs and renders the " +
-			"ranked cited chunks as a text table. --product and " +
-			"--version are mandatory: they are the binary scope the " +
-			"backend's REQUIRE_FILTERS posture enforces (a docs query " +
-			"without both is rejected rather than run as an unfiltered " +
-			"corpus query). The query routes through the backplane so it " +
+			"ranked cited chunks as a text table. --collection is " +
+			"mandatory: it is the binary scope that routes the query to a " +
+			"collection's backend and gates per-collection entitlement (a " +
+			"docs query without it is rejected rather than run unscoped). " +
+			"--product and --version are optional refinements within the " +
+			"collection. The query routes through the backplane so it " +
 			"is audited centrally; the raw query is never logged (only " +
 			"its hash). --json emits the raw SearchDocsResponse with the " +
 			"full DocsChunk shape (chunk id, document id, score, source " +
@@ -68,6 +71,7 @@ func newSearchCmd(provisioned bool) *cobra.Command {
 		RunE: func(cmd *cobra.Command, args []string) error {
 			return runSearch(cmd, searchOptions{
 				Query:             args[0],
+				Collection:        collection,
 				Product:           product,
 				Version:           version,
 				Limit:             limit,
@@ -78,10 +82,12 @@ func newSearchCmd(provisioned bool) *cobra.Command {
 			})
 		},
 	}
+	cmd.Flags().StringVar(&collection, "collection", "",
+		"collection key to search (required; e.g. vmware)")
 	cmd.Flags().StringVar(&product, "product", "",
-		"vendor product to scope the search to (required)")
+		"optional vendor-product refinement within the collection")
 	cmd.Flags().StringVar(&version, "version", "",
-		"product version to scope the search to (required)")
+		"optional product-version refinement within the collection")
 	cmd.Flags().IntVar(&limit, "limit", 0,
 		"max chunks to return (1..50, server default 10 when omitted)")
 	cmd.Flags().BoolVar(&jsonOut, "json", false,
@@ -92,10 +98,11 @@ func newSearchCmd(provisioned bool) *cobra.Command {
 }
 
 type searchOptions struct {
-	Query   string
-	Product string
-	Version string
-	Limit   int
+	Query      string
+	Collection string
+	Product    string
+	Version    string
+	Limit      int
 	// Changed mirrors `cobra.Command.Flags().Changed("limit")` for the
 	// "operator-supplied 0 is an error; default-0 means 'use the
 	// server default'" gate. Threaded as a field rather than re-read
@@ -126,13 +133,14 @@ func runSearch(cmd *cobra.Command, opts searchOptions) error {
 			opts.JSONOut,
 		)
 	}
-	// REQUIRE_FILTERS, client-side: both product and version are
-	// mandatory. Fail fast with the same constraint the route would
+	// Collection scope, client-side: --collection is the mandatory
+	// binary scope. Fail fast with the same constraint the route would
 	// 422 on, so operators see it locally without a round-trip.
-	if opts.Product == "" || opts.Version == "" {
+	// --product / --version are optional refinements (no client gate).
+	if opts.Collection == "" {
 		return output.RenderError(
 			cmd.ErrOrStderr(),
-			output.Unexpected("search requires both --product and --version (the mandatory binary scope)"),
+			output.Unexpected("search requires --collection (the mandatory binary scope)"),
 			opts.JSONOut,
 		)
 	}
@@ -180,18 +188,26 @@ func runSearch(cmd *cobra.Command, opts searchOptions) error {
 }
 
 // buildSearchBody assembles the typed POST body for /api/v1/search_docs.
-// product/version flow as the binary scope (typed as *string on the
-// wire; non-empty by the time this is reached). Limit only lands on
-// the wire when the operator passed a positive --limit — the generated
-// field tag is `omitempty`, so a nil pointer keeps the JSON key absent
-// and the backend's Field(ge=1, le=50, default=10) applies.
+// collection is the mandatory binary scope (non-empty by the time this is
+// reached); product/version are optional refinements and only land on the
+// wire when the operator supplied them (the generated field tags are
+// `omitempty`, so a nil pointer keeps the JSON key absent and the backend
+// treats the refinement as unset). Limit only lands when the operator
+// passed a positive --limit — same omitempty contract, so the backend's
+// Field(ge=1, le=50, default=10) applies on absence.
 func buildSearchBody(opts searchOptions) api.SearchDocsRequest {
-	product := opts.Product
-	version := opts.Version
+	collection := opts.Collection
 	body := api.SearchDocsRequest{
-		Query:   opts.Query,
-		Product: &product,
-		Version: &version,
+		Query:      opts.Query,
+		Collection: &collection,
+	}
+	if opts.Product != "" {
+		product := opts.Product
+		body.Product = &product
+	}
+	if opts.Version != "" {
+		version := opts.Version
+		body.Version = &version
 	}
 	if opts.Limit > 0 {
 		limit := opts.Limit

--- a/cli/internal/cmd/docs/search_test.go
+++ b/cli/internal/cmd/docs/search_test.go
@@ -211,8 +211,7 @@ func TestRunSearchRefusesWhenUnprovisioned(t *testing.T) {
 	cmd, _, stderr := newRunCmd(t)
 	err := runSearch(cmd, searchOptions{
 		Query:       "x",
-		Product:     "vmware",
-		Version:     "9.0",
+		Collection:  "vmware",
 		Provisioned: false,
 	})
 	if err == nil {
@@ -234,8 +233,7 @@ func TestRunSearchRefusalIsBeforeNetwork(t *testing.T) {
 	cmd, _, stderr := newRunCmd(t)
 	err := runSearch(cmd, searchOptions{
 		Query:             "x",
-		Product:           "vmware",
-		Version:           "9.0",
+		Collection:        "vmware",
 		Provisioned:       false,
 		BackplaneOverride: "http://127.0.0.1:0",
 	})
@@ -251,7 +249,7 @@ func TestRunSearchRefusalIsBeforeNetwork(t *testing.T) {
 
 func TestRunSearchRejectsEmptyQuery(t *testing.T) {
 	cmd, _, stderr := newRunCmd(t)
-	err := runSearch(cmd, searchOptions{Query: "", Product: "vmware", Version: "9.0", Provisioned: true})
+	err := runSearch(cmd, searchOptions{Query: "", Collection: "vmware", Provisioned: true})
 	if err == nil {
 		t.Fatalf("expected error for empty query")
 	}
@@ -260,34 +258,23 @@ func TestRunSearchRejectsEmptyQuery(t *testing.T) {
 	}
 }
 
-func TestRunSearchRejectsMissingProduct(t *testing.T) {
+func TestRunSearchRejectsMissingCollection(t *testing.T) {
 	cmd, _, stderr := newRunCmd(t)
-	err := runSearch(cmd, searchOptions{Query: "x", Version: "9.0", Provisioned: true})
+	err := runSearch(cmd, searchOptions{Query: "x", Provisioned: true})
 	if err == nil {
-		t.Fatalf("expected error for missing --product")
+		t.Fatalf("expected error for missing --collection")
 	}
 	if got := exitCodeOf(t, err); got != output.ExitUnexpected {
 		t.Errorf("expected exit %d; got %d", output.ExitUnexpected, got)
 	}
-	if !strings.Contains(stderr.String(), "--product and --version") {
-		t.Errorf("expected filter hint; got %q", stderr.String())
-	}
-}
-
-func TestRunSearchRejectsMissingVersion(t *testing.T) {
-	cmd, _, stderr := newRunCmd(t)
-	err := runSearch(cmd, searchOptions{Query: "x", Product: "vmware", Provisioned: true})
-	if err == nil {
-		t.Fatalf("expected error for missing --version")
-	}
-	if !strings.Contains(stderr.String(), "--product and --version") {
-		t.Errorf("expected filter hint; got %q", stderr.String())
+	if !strings.Contains(stderr.String(), "--collection") {
+		t.Errorf("expected collection hint; got %q", stderr.String())
 	}
 }
 
 func TestRunSearchRejectsOutOfRangeLimit(t *testing.T) {
 	cmd, _, stderr := newRunCmd(t)
-	err := runSearch(cmd, searchOptions{Query: "x", Product: "vmware", Version: "9.0", Limit: 51, Provisioned: true})
+	err := runSearch(cmd, searchOptions{Query: "x", Collection: "vmware", Limit: 51, Provisioned: true})
 	if err == nil {
 		t.Fatalf("expected error for over-budget limit")
 	}
@@ -299,7 +286,7 @@ func TestRunSearchRejectsOutOfRangeLimit(t *testing.T) {
 func TestRunSearchRejectsExplicitZeroLimit(t *testing.T) {
 	cmd, _, stderr := newRunCmd(t)
 	err := runSearch(cmd, searchOptions{
-		Query: "x", Product: "vmware", Version: "9.0",
+		Query: "x", Collection: "vmware",
 		Limit: 0, Changed: true, Provisioned: true,
 	})
 	if err == nil {
@@ -340,14 +327,17 @@ func TestRunSearchHappyPath(t *testing.T) {
 
 	cmd, stdout, stderr := newRunCmd(t)
 	err := runSearch(cmd, searchOptions{
-		Query: "nsx config maximums", Product: "vmware", Version: "9.0",
+		Query: "nsx config maximums", Collection: "vmware", Product: "nsx", Version: "9.0",
 		Provisioned: true, BackplaneOverride: srv.URL,
 	})
 	if err != nil {
 		t.Fatalf("runSearch: %v; stderr=%s", err, stderr.String())
 	}
-	if bodyOnWire.Product == nil || *bodyOnWire.Product != "vmware" {
-		t.Errorf("expected product=vmware on wire; got %+v", bodyOnWire)
+	if bodyOnWire.Collection == nil || *bodyOnWire.Collection != "vmware" {
+		t.Errorf("expected collection=vmware on wire; got %+v", bodyOnWire)
+	}
+	if bodyOnWire.Product == nil || *bodyOnWire.Product != "nsx" {
+		t.Errorf("expected product=nsx on wire; got %+v", bodyOnWire)
 	}
 	if bodyOnWire.Version == nil || *bodyOnWire.Version != "9.0" {
 		t.Errorf("expected version=9.0 on wire; got %+v", bodyOnWire)
@@ -362,6 +352,41 @@ func TestRunSearchHappyPath(t *testing.T) {
 		if !strings.Contains(stdout.String(), want) {
 			t.Errorf("stdout missing %q in %q", want, stdout.String())
 		}
+	}
+}
+
+// TestRunSearchOmitsAbsentRefinements proves --product / --version are
+// optional refinements: with --collection set but neither refinement
+// supplied, the wire body carries collection only (the omitempty pointer
+// tags keep product/version absent so the backend treats them as unset).
+func TestRunSearchOmitsAbsentRefinements(t *testing.T) {
+	var bodyOnWire api.SearchDocsRequest
+	mux := http.NewServeMux()
+	mux.HandleFunc("/api/v1/search_docs", func(w http.ResponseWriter, r *http.Request) {
+		raw, _ := io.ReadAll(r.Body)
+		readJSONBodyOf(t, raw, &bodyOnWire)
+		w.Header().Set("Content-Type", "application/json")
+		_ = json.NewEncoder(w).Encode(api.SearchDocsResponse{Chunks: nil})
+	})
+	srv := httptest.NewServer(mux)
+	defer srv.Close()
+	seedXDGAndToken(t, srv.URL, "eyJ.test.token")
+
+	cmd, _, stderr := newRunCmd(t)
+	if err := runSearch(cmd, searchOptions{
+		Query: "x", Collection: "vmware",
+		Provisioned: true, BackplaneOverride: srv.URL,
+	}); err != nil {
+		t.Fatalf("runSearch: %v; stderr=%s", err, stderr.String())
+	}
+	if bodyOnWire.Collection == nil || *bodyOnWire.Collection != "vmware" {
+		t.Errorf("expected collection=vmware on wire; got %+v", bodyOnWire)
+	}
+	if bodyOnWire.Product != nil {
+		t.Errorf("expected product absent on wire; got %q", *bodyOnWire.Product)
+	}
+	if bodyOnWire.Version != nil {
+		t.Errorf("expected version absent on wire; got %q", *bodyOnWire.Version)
 	}
 }
 
@@ -380,7 +405,7 @@ func TestRunSearchSendsLimitWhenSet(t *testing.T) {
 
 	cmd, _, _ := newRunCmd(t)
 	if err := runSearch(cmd, searchOptions{
-		Query: "x", Product: "vmware", Version: "9.0",
+		Query: "x", Collection: "vmware",
 		Limit: 25, Provisioned: true, BackplaneOverride: srv.URL,
 	}); err != nil {
 		t.Fatalf("runSearch: %v", err)
@@ -402,7 +427,7 @@ func TestRunSearchZeroHits(t *testing.T) {
 
 	cmd, stdout, _ := newRunCmd(t)
 	if err := runSearch(cmd, searchOptions{
-		Query: "obscure", Product: "vmware", Version: "9.0",
+		Query: "obscure", Collection: "vmware",
 		Provisioned: true, BackplaneOverride: srv.URL,
 	}); err != nil {
 		t.Fatalf("runSearch: %v", err)
@@ -434,7 +459,7 @@ func TestRunSearchJSONHappyPath(t *testing.T) {
 
 	cmd, stdout, _ := newRunCmd(t)
 	if err := runSearch(cmd, searchOptions{
-		Query: "x", Product: "vmware", Version: "9.0",
+		Query: "x", Collection: "vmware",
 		JSONOut: true, Provisioned: true, BackplaneOverride: srv.URL,
 	}); err != nil {
 		t.Fatalf("runSearch: %v", err)
@@ -466,7 +491,7 @@ func TestRunSearchRendersAbsentScoreAsDash(t *testing.T) {
 
 	cmd, stdout, _ := newRunCmd(t)
 	if err := runSearch(cmd, searchOptions{
-		Query: "x", Product: "vmware", Version: "9.0",
+		Query: "x", Collection: "vmware",
 		Provisioned: true, BackplaneOverride: srv.URL,
 	}); err != nil {
 		t.Fatalf("runSearch: %v", err)
@@ -498,14 +523,20 @@ func TestRunSearchMaps403(t *testing.T) {
 
 func TestRunSearchMaps422(t *testing.T) {
 	assertStatusMapping(t, http.StatusUnprocessableEntity,
-		`{"detail":"missing required filters: product, version"}`,
-		output.ExitUnexpected, "missing required filters")
+		`{"detail":"unknown doc collection 'nope'"}`,
+		output.ExitUnexpected, "unknown doc collection")
+}
+
+func TestRunSearchMaps409NotReady(t *testing.T) {
+	assertStatusMapping(t, http.StatusConflict,
+		`{"detail":"doc collection 'vmware' is not ready (status='rebuilding')"}`,
+		output.ExitUnexpected, "not ready")
 }
 
 func TestRunSearchMaps503(t *testing.T) {
 	assertStatusMapping(t, http.StatusServiceUnavailable,
-		`{"detail":"corpus unreachable"}`,
-		output.ExitUnexpected, "corpus is unavailable")
+		`{"detail":"backend unreachable"}`,
+		output.ExitUnexpected, "backend is unavailable")
 }
 
 func assertStatusMapping(t *testing.T, status int, body string, wantExit int, wantSubstr string) {
@@ -522,7 +553,7 @@ func assertStatusMapping(t *testing.T, status int, body string, wantExit int, wa
 
 	cmd, _, stderr := newRunCmd(t)
 	err := runSearch(cmd, searchOptions{
-		Query: "x", Product: "vmware", Version: "9.0",
+		Query: "x", Collection: "vmware",
 		Provisioned: true, BackplaneOverride: srv.URL,
 	})
 	if err == nil {

--- a/docs/codebase/docs-search.md
+++ b/docs/codebase/docs-search.md
@@ -18,9 +18,12 @@ corpus directly) is what buys three properties in one place:
   it (the raw query is hashed, never stored).
 - **JWT federation handled once.** The operator JWT forwarding lives in
   the T2 client, not in every consumer.
-- **Mandatory product/version posture enforced centrally.** A docs query
-  without a binary product+version scope is rejected — fail-closed — so
-  no caller can accidentally run an unfiltered corpus-wide query.
+- **Mandatory collection scope + per-collection entitlement enforced
+  centrally.** A docs query without a `collection` is rejected —
+  fail-closed — and a tenant may only search collections it holds the
+  `meho-docs:<collection>` capability for, so no caller can run an
+  unscoped query or reach a collection it isn't entitled to. `product` /
+  `version` are optional refinements within the chosen collection.
 
 The same `search_docs` service backs four consumers: the REST route
 (T3), the MCP tool `search_docs` (T4, #1523), the CLI verb
@@ -98,32 +101,62 @@ registry (`connectors/registry.py`) **minus the version tie-break ladder**
   fan-out and T6 readiness probe branch on. `collection=None` routes to
   `corpus-http` with no ref — the legacy single-collection path.
 
-### `build_docs_scope(product, version)` (`meho_backplane.docs_search.service`)
+### `build_docs_scope(collection, product=None, version=None)` (`meho_backplane.docs_search.service`)
 
-The REQUIRE_FILTERS gate. When `settings.corpus_require_filters` is on
-(the default), both `product` and `version` must be non-blank; either
-missing raises `MissingDocsFilter` (HTTP 422 at the route). With the
-gate off, the scope degrades to optional — present keys still scope the
-query, absent keys widen it (the corpus owns the policy in that mode).
-Blank-after-strip values are treated as absent so `product=" "` cannot
-smuggle past the gate. Returns a frozen `DocsScope` whose `as_filters()`
-renders the `{key: scalar}` `metadata_filters` shape — a **binary
-containment scope**, never a ranking weight (the #1178 / #1177
-decision).
+The binary-scope gate (G4.6-T3 #1552, the **scope inversion**).
+`collection` is the **mandatory** binary scope — a missing or blank value
+raises `MissingDocsFilterError` (HTTP 422 at the route, `-32602` at the
+MCP face), **unconditionally** (it is no longer gated by
+`settings.corpus_require_filters`, which governed the old product+version
+gate). `product` / `version` demote to **optional refinements** within
+the chosen collection: present, they ride `as_filters()`; absent, the
+collection alone scopes the query. Blank-after-strip values are treated
+as absent so `collection=" "` cannot smuggle past the gate. Returns a
+frozen `DocsScope` carrying `collection_key` plus the optional
+refinements; `as_filters()` renders **only** the refinements into the
+`{key: scalar}` `metadata_filters` shape — a **binary containment
+scope**, never a ranking weight (the #1178 / #1177 decision).
+`collection_key` is deliberately **excluded** from `as_filters()`: it is
+a router / entitlement key, not a per-chunk metadata field.
 
-### `search_docs(operator, query, *, scope, limit, collection=None)` (`meho_backplane.docs_search.service`)
+### `resolve_entitled_ready_collection(session, operator, collection_key)` (`meho_backplane.docs_search.collection_access`)
 
-The shared service and the **router seam**. With a `collection`, it
-resolves the backend via `resolve_backend(collection)` and calls
-`backend.search(...)`; without one (`collection=None`, the legacy
-single-collection deploy) it federates to the global corpus via
-`search_corpus` directly. Either way it projects the backend's
-`CorpusChunk`s into MEHO's own `DocsChunk` surface (chunk text + source
-citation + score), decoupling the public response from the wire contract,
-and propagates `CorpusUnavailable` unchanged. The `collection` kwarg is
-additive and optional in T2 — T3 (#1552) threads the request param and
-makes it mandatory; the backend id never appears in the request or the
-projected response.
+The **shared gate** every collection-scoped surface (the REST route, the
+`search_docs` / `ask_docs` tools, the docs-chunk resource) runs after
+parsing the `collection` key and before calling `search_docs`. Three
+policies, defined once so they cannot drift per surface:
+
+- **Resolution** — `resolve_doc_collection` (T1 #1550, tenant-first) turns
+  the key into its registry row. An unknown key → `UnknownCollectionError`
+  (carrying the catalogue of visible keys for a "did you mean…?" hint),
+  mapped to 422 / `-32602`.
+- **Per-collection entitlement** (reuses the G4.5-T1 capability substrate,
+  zero new tables) — the operator must carry the
+  `meho-docs:<collection_key>` capability key (built by
+  `collection_capability_key`). The static `required_capability="meho-docs"`
+  gate still governs *visibility* (tool / template absence when the add-on
+  isn't provisioned); this finer gate governs *which collections* an
+  entitled tenant may query. A miss → `CollectionForbiddenError`, mapped to
+  403 / `-32602` (the 403-projected dispatcher path).
+- **Readiness** — a collection whose registry `status` is not `"ready"`
+  → `CollectionNotReadyError`, mapped to 409 (REST) / `-32603` (MCP,
+  server-side condition). The richer reachability *probe* is T6 (#1555);
+  T3 reads only the `status` column.
+
+The checks run resolve → entitle → readiness so the rejection is the most
+specific true one. Returns the frozen `DocCollection` read shape.
+
+### `search_docs(operator, query, *, scope, collection, limit=10)` (`meho_backplane.docs_search.service`)
+
+The shared service and the **router seam**. `collection` is now
+**required**: the caller (route / handler) has already resolved + entitled
++ readiness-checked it via `resolve_entitled_ready_collection`. It
+resolves the backend via `resolve_backend(collection)`, calls
+`backend.search(...)` with the optional product/version refinements as
+`metadata_filters`, projects the backend's `CorpusChunk`s into MEHO's own
+`DocsChunk` surface (chunk text + source citation + score), and propagates
+`CorpusUnavailable` unchanged. The backend id never appears in the request
+or the projected response (the backend-agnostic contract).
 
 ### `synthesize_docs_answer(query, retrieval, *, llm_client=None)` (`meho_backplane.docs_search.synthesis`, T7 #1526)
 
@@ -155,19 +188,24 @@ The client is injectable so tests pin a deterministic stub; production
 reuses the spec-ingestion grouping pass's Anthropic key + model, so no new
 settings are introduced.
 
-### `POST /api/v1/search_docs` (`meho_backplane.api.v1.search_docs`, T3 #1521)
+### `POST /api/v1/search_docs` (`meho_backplane.api.v1.search_docs`, T3 #1552)
 
 The REST face. `operator` role minimum (`read_only` → 403). Validates
-the scope first (422 before any audit binding), then binds the audit
-contextvars and calls the service.
+the `collection` scope first (422 before any audit binding), binds the
+audit contextvars (including `audit_collection`), runs the shared
+`resolve_entitled_ready_collection` gate (unknown → 422, not entitled →
+403, not ready → 409), then calls the service. Takes a
+`Depends(get_session)` DB session for the resolve.
 
-### `meho docs search` (`cli/internal/cmd/docs`, T5 #1524)
+### `meho docs search` (`cli/internal/cmd/docs`, T5 / T3 #1552)
 
-The operator-facing CLI verb. `meho docs search <query> --product <p>
---version <v> [--limit N] [--json]` POSTs to `/api/v1/search_docs` via
-the shared generated authed client (bearer + lazy 401-refresh), mirrors
-the route's REQUIRE_FILTERS gate client-side (a missing `--product` or
-`--version` is rejected before the round-trip), and renders the cited
+The operator-facing CLI verb. `meho docs search <query> --collection <c>
+[--product <p>] [--version <v>] [--limit N] [--json]` POSTs to
+`/api/v1/search_docs` via the shared generated authed client (bearer +
+lazy 401-refresh), mirrors the route's collection gate client-side (a
+missing `--collection` is rejected before the round-trip; `--product` /
+`--version` are optional refinements), maps the 403 (not entitled) / 409
+(not ready) / 422 (unknown collection) statuses, and renders the cited
 chunks as a text table or raw JSON. It consumes the generated
 `api.SearchDocsRequest` / `api.SearchDocsResponse` / `api.DocsChunk`
 types directly — no hand-typed copies of the backend schemas.
@@ -218,12 +256,16 @@ provisioned the `meho-docs` add-on never sees the tool in `tools/list`
 (`all_tools_for`) and again at call time (`handle_tools_call`).
 
 The `inputSchema` is strict JSON Schema 2020-12: `additionalProperties:
-false`, required `[query, product, version]`. That `required` list is the
-**first** line of the REQUIRE_FILTERS defence — a schema-validating
-client never reaches the service-side `build_docs_scope` check. When the
-gate-off → gate-on settings flip or a non-validating client does reach
-it, `MissingDocsFilterError` (the route's 422) maps to
-`McpInvalidParamsError` → JSON-RPC `-32602` (the MCP analogue of a 422).
+false`, required `[query, collection]` (product/version demoted to
+optional). That `required` list is the **first** line of the
+collection-scope defence — a schema-validating client never reaches the
+service-side `build_docs_scope` check. When a non-validating client does
+reach it, `MissingDocsFilterError` maps to `McpInvalidParamsError` →
+JSON-RPC `-32602` (the MCP analogue of a 422). The handler then runs the
+shared `resolve_entitled_ready_collection` gate: an unknown / not-entitled
+collection maps to `-32602` (the per-collection entitlement is enforced at
+**call** time, since the collection key is a tool argument, not known at
+list time), and a not-ready collection bubbles to `-32603`.
 A `CorpusUnavailable` is **not** caught — a well-formed request against a
 down upstream is a server fault, so it bubbles to the dispatcher's
 generic catch as `-32603` Internal Error (the MCP analogue of the route's
@@ -245,14 +287,17 @@ resource for the full text of a hit on a later turn.
 
 The synthesis sibling, registered alongside `search_docs` in the **same**
 module and carrying the **same** `required_capability="meho-docs"` gate,
-the same `operator` role minimum, and the same strict `inputSchema`
-(`additionalProperties: false`, required `[query, product, version]`,
-`limit` default 10 / cap 50). It is absent from `tools/list` and 403-class
-on `tools/call` for an unprovisioned tenant exactly like `search_docs`.
+the same `operator` role minimum, the same per-collection entitlement, and
+the same strict `inputSchema` (`additionalProperties: false`, required
+`[query, collection]`, product/version optional, `limit` default 10 / cap
+50). It is absent from `tools/list` and 403-class on `tools/call` for an
+unprovisioned tenant exactly like `search_docs`.
 
 The handler mirrors `search_docs`'s error arms and adds the synthesis arm:
-`build_docs_scope` enforces REQUIRE_FILTERS (`MissingDocsFilterError` →
-`-32602`); `CorpusUnavailable` from retrieval bubbles to `-32603`; and the
+`build_docs_scope` + the shared gate enforce the collection scope
+(`MissingDocsFilterError` / unknown / not-entitled → `-32602`);
+`CorpusUnavailable` from retrieval and a not-ready collection bubble to
+`-32603`; and the
 synthesis failures (`LlmClientUnavailable` for an unconfigured model,
 `DocsSynthesisError` for a broken grounding contract) also bubble to
 `-32603` — never an ungrounded 200. It stays `op_class="read"`: it
@@ -269,39 +314,45 @@ chunks-shaped one: `ask_docs` for a composed grounded answer, `search_docs`
 for the raw chunks to read itself, `search_knowledge` / `search_memory`
 for the non-vendor corpora.
 
-### `meho://docs/{product}/{version}/{chunk_id}` resource (`meho_backplane.mcp.resources.docs`, T4 #1523)
+### `meho://docs/{collection}/{product}/{version}/{chunk_id}` resource (`meho_backplane.mcp.resources.docs`, T3 #1552)
 
 The fetch-by-citation companion, gated by the **same**
-`required_capability="meho-docs"`. The corpus transport (T2) is
-search-only — there is no fetch-chunk-by-id endpoint — so the handler
-recovers a chunk by **re-issuing a scoped corpus search** through the
-shared service and selecting the hit whose `chunk_id` matches the URI.
-That is why the URI carries `product` + `version`: they are the mandatory
-binary scope the re-search needs, and encoding them lets
-`build_docs_scope` enforce the same REQUIRE_FILTERS posture (belt-and-
-suspenders, since a blank segment can't match the `[^/]+` template). A
-`chunk_id` absent from the re-search collapses to `-32602` "not found"
-without distinguishing "empty scope" from "no such id", so the resource
-is not a corpus-contents oracle.
+`required_capability="meho-docs"` plus the **per-collection**
+`meho-docs:<collection>` entitlement (enforced in the handler via the
+shared gate). The backend (T2) is search-only — there is no
+fetch-chunk-by-id endpoint — so the handler recovers a chunk by
+**re-issuing a scoped search** through the shared service and selecting
+the hit whose `chunk_id` matches the URI. That is why the URI carries the
+leading `collection` segment (plus the optional `product` / `version`):
+`collection` is the mandatory binary scope the re-search needs to route +
+entitle, and encoding it lets `build_docs_scope` enforce the same
+collection posture (belt-and-suspenders, since a blank segment can't match
+the `[^/]+` template). A blank / unknown / not-entitled collection →
+`-32602`; a `chunk_id` absent from the re-search collapses to `-32602`
+"not found" without distinguishing "empty scope" from "no such id", so the
+resource is not a collection-contents oracle.
 
 ## Control flow (the REST route)
 
 1. `require_role(TenantRole.OPERATOR)` gates the request (`read_only` →
    403, unauthenticated → 401) before the handler runs.
-2. `build_docs_scope(product, version)` enforces REQUIRE_FILTERS. A
-   `MissingDocsFilter` → HTTP 422; the corpus is never called. (A 422
-   here binds no audit context — it does not imply a corpus call
-   happened.)
-3. The handler binds the `audit_*` contextvars **before** the corpus
-   call: `audit_op_id="meho.docs.search"`, `audit_op_class="read"`,
+2. `build_docs_scope(collection, product, version)` enforces the
+   mandatory `collection` scope. A `MissingDocsFilterError` → HTTP 422;
+   no backend is called. (A 422 here binds no audit context.)
+3. The handler binds the `audit_*` contextvars **before** the gate /
+   backend call: `audit_op_id="meho.docs.search"`, `audit_op_class="read"`,
    `audit_query_hash` (SHA-256 of the UTF-8 query — the raw query is
-   never bound), `audit_product`, `audit_version`. `AuditMiddleware`
-   strips the `audit_` prefix and merges these into `audit_log.payload`,
-   so a handler exception still produces an attributable row.
-4. `search_docs(...)` forwards the operator JWT to the corpus and
-   returns the cited chunks. `CorpusUnavailable` → HTTP 503
+   never bound), `audit_collection`, `audit_product`, `audit_version`.
+   `AuditMiddleware` strips the `audit_` prefix and merges these into
+   `audit_log.payload`, so an entitlement / readiness / backend exception
+   still produces an attributable row.
+4. `resolve_entitled_ready_collection(session, operator, collection_key)`
+   resolves + entitles + readiness-checks the collection: unknown → 422,
+   not entitled → 403, not ready → 409.
+5. `search_docs(..., collection=...)` routes to the collection's backend
+   and returns the cited chunks. `CorpusUnavailable` → HTTP 503
    (fail-closed; never an empty 200).
-5. On success, `audit_hit_count` is bound and the cited chunks are
+6. On success, `audit_hit_count` is bound and the cited chunks are
    returned as `SearchDocsResponse`.
 
 ### Why `op_class="read"` is safe for the broadcast feed
@@ -347,6 +398,10 @@ just makes the op name canonical for `query_audit` filtering.
 
 - Route: `backend/src/meho_backplane/api/v1/search_docs.py`.
 - Service (router seam): `backend/src/meho_backplane/docs_search/service.py`.
+- Collection-access gate (resolve + entitle + readiness, T3 #1552):
+  `backend/src/meho_backplane/docs_search/collection_access.py`.
+- Doc-collections registry + resolver (T1 #1550):
+  `backend/src/meho_backplane/docs_collections/`.
 - Backend router (T2 #1551): `backend/src/meho_backplane/docs_search/backends/`
   (`base.py` ABC, `corpus_http.py` first adapter, `registry.py`,
   `resolver.py`). Registry/ABC/resolver precedent:


### PR DESCRIPTION
## Summary

- Make `collection` the **mandatory binary scope** on `search_docs` / `ask_docs` across all three surfaces (REST `POST /api/v1/search_docs`, the MCP tools + the `meho://docs/{collection}/{product}/{version}/{chunk_id}` resource, and `meho docs search --collection`). Each query routes to the named collection's backend via the T2 router (#1551); `product` / `version` demote to **optional** metadata refinements within the collection.
- Add **per-collection entitlement** (reuses the `meho-docs` capability substrate, zero new tables): a principal may search a collection only when its tenant holds the `meho-docs:<collection>` capability. A miss → 403 / `-32602` even though the tool stays visible via the base `meho-docs` gate.
- Add a single shared gate — `docs_search/collection_access.py::resolve_entitled_ready_collection` — that resolves the key (tenant-first, #1550), enforces entitlement, and checks readiness (not-`ready` → 409 / `-32603`), so every surface enforces one policy.
- Each call's audit row carries `audit_collection` alongside the canonical `meho.docs.search` / `meho.docs.ask` op_id (#1549); the raw query stays hashed. CLI OpenAPI snapshot + generated client regenerated for the new `collection` field.

## Test plan

- [x] `ruff check` / `ruff format --check` — clean
- [x] `mypy` — clean (12 source files)
- [x] `python3 .claude/hooks/code-quality.py --diff` — 0 blockers
- [x] `pytest` docs + MCP suites — 154 passed (`test_search_docs_route`, `test_mcp_tools_docs`, `test_mcp_tools_docs_ask`, `test_mcp_resources_docs`, `test_docs_backends_router`, `test_docs_search_synthesis`, `test_doc_collections_registry`, `test_mcp_capability_gating`, `test_mcp_initialize_instructions`, `test_mcp_tools_list_shape_conventions`); plus `test_app_starts` / `test_mcp_server` / `test_mcp_audit` / `test_mcp_registry` / `test_settings` / `test_corpus_client` green
- [x] `go test ./...` (CLI) — pass; `go vet` + `gofmt` clean
- [x] Acceptance criteria verified:
  - no/blank `collection` → 422; unknown collection → 422; product/version omitted → still succeeds
  - tenant lacking `meho-docs:<collection>` → 403 (REST) / `-32602` (MCP) while the tool stays visible; entitled tenant succeeds
  - query routes to `collection.backend`; backend id absent from request + response
  - audit row carries `audit_collection` + `op_id="meho.docs.search"`/`"meho.docs.ask"`; raw query hashed
  - `meho://docs/{collection}/{product}/{version}/{chunk_id}` resolves and is per-collection entitlement-gated
  - CLI `meho docs search "<q>" --collection vmware` works; `--collection` required, `--product`/`--version` optional; client regen committed

## Out of scope

- Cross-collection fan-out `collections/all` (#1554), `list_doc_collections` (#1553), the readiness probe (#1555 — owns `backends/base.py` + `corpus_http.py`, deliberately untouched here), and docs (#1556).

<!-- auto-implement-issue: fresh, iteration 1 -->

Closes #1552
