### PR TITLE
fix(docs): apply list_doc_collections vendor filter after tenant-first dedupe (#1568)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -116,6 +116,22 @@ connector-related release-notes line.
   terminal/retryable signal is a genuine client value and the mechanism was
   already shipped and tested by #1555.)
 
+### list_doc_collections vendor scoping (#1568)
+
+- Fix the optional `vendor` filter on `list_doc_collections` (MCP tool +
+  `GET /api/v1/doc_collections` REST route) to run **after** the
+  tenant-first dedupe instead of before it. Previously the filter was a
+  pre-dedupe SQL `WHERE`, so when a tenant-curated row shadowed a global
+  `collection_key` under a *different* vendor, filtering by the shadowed
+  global row's vendor surfaced that global row's metadata
+  (vendor/products/`when_to_use`/status) — violating the catalogue's
+  documented "tenant row wins" invariant. The filter now applies in Python
+  over the post-dedupe tenant-wins rows, so `vendor` only ever keeps or
+  drops the row the principal would actually search; the keyset cursor
+  (`collection_key > cursor`) stays in SQL and pagination is unaffected.
+  Not an entitlement leak — the returned `collection_key` set and
+  entitlement filtering are unchanged.
+
 ### Doc-collection docs + runbook (#1556)
 
 - Update the operator provisioning runbook

--- a/backend/src/meho_backplane/api/v1/doc_collections.py
+++ b/backend/src/meho_backplane/api/v1/doc_collections.py
@@ -163,8 +163,6 @@ async def list_doc_collections_endpoint(
     stmt = select(DocCollectionORM).where(
         (DocCollectionORM.tenant_id == operator.tenant_id) | (DocCollectionORM.tenant_id.is_(None)),
     )
-    if vendor is not None:
-        stmt = stmt.where(DocCollectionORM.vendor == vendor)
     if cursor is not None:
         stmt = stmt.where(DocCollectionORM.collection_key > cursor)
     stmt = stmt.order_by(
@@ -174,6 +172,14 @@ async def list_doc_collections_endpoint(
 
     result = await session.execute(stmt)
     rows = _dedupe_tenant_first(list(result.scalars().all()))
+    # Apply ``vendor`` AFTER the tenant-first dedupe (Python-side, over the
+    # post-dedupe tenant-wins rows), never in the pre-dedupe SQL WHERE: a
+    # tenant row may shadow a global key under a *different* vendor, and
+    # filtering in SQL would drop the tenant row before it could win and
+    # surface the shadowed global row's vendor. Mirrors the identical reorder
+    # in the ``list_doc_collections`` MCP tool so the two faces agree.
+    if vendor is not None:
+        rows = [row for row in rows if row.vendor == vendor]
     entitled = [
         row
         for row in rows

--- a/backend/src/meho_backplane/mcp/tools/doc_collections.py
+++ b/backend/src/meho_backplane/mcp/tools/doc_collections.py
@@ -266,8 +266,6 @@ async def _list_doc_collections_handler(
     stmt = select(DocCollectionORM).where(
         (DocCollectionORM.tenant_id == operator.tenant_id) | (DocCollectionORM.tenant_id.is_(None)),
     )
-    if vendor is not None:
-        stmt = stmt.where(DocCollectionORM.vendor == vendor)
     if cursor is not None:
         stmt = stmt.where(DocCollectionORM.collection_key > cursor)
     # Order by ``collection_key`` (the cursor + dedupe key) so the keyset
@@ -287,6 +285,15 @@ async def _list_doc_collections_handler(
         rows = list(result.scalars().all())
 
     deduped = _dedupe_tenant_first(rows)
+    # Apply ``vendor`` AFTER the tenant-first dedupe, over the post-dedupe
+    # tenant-wins rows — never in the pre-dedupe SQL WHERE. A tenant row may
+    # shadow a global key under a *different* vendor; filtering in SQL would
+    # drop the tenant row before it could win and surface the shadowed global
+    # row's vendor instead, so ``vendor`` must filter the rows the principal
+    # actually sees (the tenant-wins projection), matching the resolver's
+    # tenant-then-global preference the docstring promises.
+    if vendor is not None:
+        deduped = [row for row in deduped if row.vendor == vendor]
     entitled = [
         row
         for row in deduped

--- a/backend/tests/test_doc_collections_list_route.py
+++ b/backend/tests/test_doc_collections_list_route.py
@@ -222,6 +222,29 @@ def test_vendor_filter_narrows(client: TestClient) -> None:
     assert [r["collection_key"] for r in rows] == ["netapp"]
 
 
+def test_vendor_filter_runs_after_dedupe_for_a_shadowed_key(client: TestClient) -> None:
+    """``vendor`` filters the tenant-wins row, never the shadowed global one.
+
+    A global key ``vmware`` (vendor ``A``) is shadowed by a tenant-curated
+    row for the same key under a different vendor ``B`` (the tenant row
+    wins). With the filter applied after the tenant-first dedupe,
+    ``vendor=B`` returns the tenant row for ``vmware`` while ``vendor=A``
+    does NOT — the shadowed global vendor is not searchable. The old
+    SQL-side filter leaked the global row's metadata under ``vendor=A``.
+    """
+    _seed_sync(collection_key="vmware", vendor="A")
+    _seed_sync(collection_key="vmware", vendor="B", tenant_id=_TENANT_ID)
+    caps = ["meho-docs", "meho-docs:vmware"]
+
+    by_tenant_vendor = _get(client, capabilities=caps, params={"vendor": "B"})
+    tenant_rows = by_tenant_vendor.json()  # type: ignore[attr-defined]
+    assert [r["collection_key"] for r in tenant_rows] == ["vmware"]
+    assert tenant_rows[0]["vendor"] == "B"
+
+    by_global_vendor = _get(client, capabilities=caps, params={"vendor": "A"})
+    assert by_global_vendor.json() == []  # type: ignore[attr-defined]
+
+
 def test_keyset_pagination(client: TestClient) -> None:
     """``cursor`` resumes after the last key seen."""
     for key in ("alpha", "bravo", "charlie"):
@@ -232,6 +255,28 @@ def test_keyset_pagination(client: TestClient) -> None:
     assert [r["collection_key"] for r in first.json()] == ["alpha", "bravo"]  # type: ignore[attr-defined]
 
     second = _get(client, capabilities=caps, params={"limit": 2, "cursor": "bravo"})
+    assert [r["collection_key"] for r in second.json()] == ["charlie"]  # type: ignore[attr-defined]
+
+
+def test_keyset_pagination_with_vendor_filter_after_dedupe(client: TestClient) -> None:
+    """The cursor still windows by ``collection_key`` with ``vendor`` set.
+
+    ``alpha`` and ``charlie`` share vendor ``Acme``; ``bravo`` is a
+    different vendor. A ``limit=1`` walk filtered to ``Acme`` yields
+    ``alpha`` then resumes after it — skipping the filtered-out ``bravo``
+    in SQL — to ``charlie``, terminating on the empty page.
+    """
+    _seed_sync(collection_key="alpha", vendor="Acme")
+    _seed_sync(collection_key="bravo", vendor="Other")
+    _seed_sync(collection_key="charlie", vendor="Acme")
+    caps = ["meho-docs", "meho-docs:alpha", "meho-docs:bravo", "meho-docs:charlie"]
+
+    first = _get(client, capabilities=caps, params={"vendor": "Acme", "limit": 1})
+    assert [r["collection_key"] for r in first.json()] == ["alpha"]  # type: ignore[attr-defined]
+
+    second = _get(
+        client, capabilities=caps, params={"vendor": "Acme", "limit": 1, "cursor": "alpha"}
+    )
     assert [r["collection_key"] for r in second.json()] == ["charlie"]  # type: ignore[attr-defined]
 
 

--- a/backend/tests/test_mcp_tools_doc_collections.py
+++ b/backend/tests/test_mcp_tools_doc_collections.py
@@ -361,6 +361,41 @@ def test_vendor_filter_narrows_the_catalogue(
     assert keys == ["netapp"]
 
 
+@pytest.mark.parametrize(
+    "catalogue_client",
+    [frozenset({_DOCS_CAPABILITY, "meho-docs:vmware"})],
+    indirect=True,
+)
+def test_vendor_filter_runs_after_dedupe_for_a_shadowed_key(
+    catalogue_client: tuple[TestClient, Operator],
+) -> None:
+    """``vendor`` filters the tenant-wins row, never the shadowed global one.
+
+    A global key ``vmware`` (vendor ``A``) is shadowed by a tenant-curated
+    row for the same key under a *different* vendor ``B`` (the tenant row
+    wins). Because the filter runs after the tenant-first dedupe:
+
+    * ``vendor="B"`` returns the tenant row for ``vmware`` — the scope the
+      principal actually sees.
+    * ``vendor="A"`` does NOT return ``vmware`` — the shadowed global
+      vendor is not searchable; the old SQL-side filter would have leaked
+      the global row's metadata here.
+    """
+    client, op = catalogue_client
+    _seed_sync(collection_key="vmware", vendor="A")
+    _seed_sync(collection_key="vmware", vendor="B", tenant_id=op.tenant_id)
+
+    # vendor=B → the tenant-wins row for the shadowed key.
+    by_tenant_vendor = _payload(_call_list(client, {"vendor": "B"}))
+    assert [c["collection_key"] for c in by_tenant_vendor["collections"]] == ["vmware"]
+    assert by_tenant_vendor["collections"][0]["vendor"] == "B"
+
+    # vendor=A → the shadowed global vendor is not searchable.
+    by_global_vendor = _payload(_call_list(client, {"vendor": "A"}))
+    assert by_global_vendor["collections"] == []
+    assert by_global_vendor["next_cursor"] is None
+
+
 # ---------------------------------------------------------------------------
 # tools/call — keyset pagination
 # ---------------------------------------------------------------------------
@@ -386,6 +421,47 @@ def test_keyset_pagination_walks_by_collection_key(
     second = _payload(_call_list(client, {"limit": 2, "cursor": "bravo"}))
     assert [c["collection_key"] for c in second["collections"]] == ["charlie"]
     assert second["next_cursor"] is None
+
+
+@pytest.mark.parametrize(
+    "catalogue_client",
+    [frozenset({_DOCS_CAPABILITY, "meho-docs:alpha", "meho-docs:bravo", "meho-docs:charlie"})],
+    indirect=True,
+)
+def test_keyset_pagination_with_vendor_filter_after_dedupe(
+    catalogue_client: tuple[TestClient, Operator],
+) -> None:
+    """The cursor still advances by ``collection_key`` with ``vendor`` set.
+
+    With the ``vendor`` filter moved after the dedupe, the keyset cursor
+    must keep windowing by ``collection_key``: ``alpha`` and ``charlie``
+    share vendor ``Acme`` while ``bravo`` is a different vendor. A
+    ``limit=1`` walk filtered to ``Acme`` yields ``alpha`` then resumes
+    after it to ``charlie`` — skipping the filtered-out ``bravo`` without
+    the cursor stalling on it. ``next_cursor`` follows the existing
+    full-page convention (set whenever a page is full, even if it is the
+    last filtered row), so a final empty page terminates the walk.
+    """
+    client, _op = catalogue_client
+    _seed_sync(collection_key="alpha", vendor="Acme")
+    _seed_sync(collection_key="bravo", vendor="Other")
+    _seed_sync(collection_key="charlie", vendor="Acme")
+
+    first = _payload(_call_list(client, {"vendor": "Acme", "limit": 1}))
+    assert [c["collection_key"] for c in first["collections"]] == ["alpha"]
+    assert first["next_cursor"] == "alpha"
+
+    # The cursor windows by ``collection_key`` in SQL, so the next page
+    # skips the filtered-out ``bravo`` and resumes at ``charlie``.
+    second = _payload(_call_list(client, {"vendor": "Acme", "limit": 1, "cursor": "alpha"}))
+    assert [c["collection_key"] for c in second["collections"]] == ["charlie"]
+    assert second["next_cursor"] == "charlie"
+
+    # A full page always advertises a cursor; the terminal empty page is
+    # how the walk ends.
+    third = _payload(_call_list(client, {"vendor": "Acme", "limit": 1, "cursor": "charlie"}))
+    assert third["collections"] == []
+    assert third["next_cursor"] is None
 
 
 # ---------------------------------------------------------------------------

--- a/docs/codebase/doc-collections.md
+++ b/docs/codebase/doc-collections.md
@@ -235,6 +235,16 @@ set, and returns `{collections: [...], next_cursor}` keyset-paginated by
 `meho.docs.*` family #1549 established). The summary omits the `backend`
 record by design (#1548 backend-agnostic contract).
 
+The optional `vendor` filter is applied **after** the tenant-first dedupe
+(in Python, over the post-dedupe tenant-wins rows), never in the
+pre-dedupe SQL `WHERE` (#1568). A tenant row may shadow a global key under
+a *different* vendor; filtering in SQL would drop the tenant row before it
+could win and surface the shadowed global row's metadata, so `vendor`
+filters the rows the principal actually sees. The keyset cursor
+(`collection_key > cursor`) stays in SQL — dedupe and the vendor filter
+both preserve `collection_key` ordering, so pagination is unaffected by
+the reorder.
+
 ### REST `GET /api/v1/doc_collections` (`meho_backplane.api.v1.doc_collections`)
 
 The REST sibling — OPERATOR-gated, same tenant-scope + dedupe +


### PR DESCRIPTION
## Summary
- `list_doc_collections` (MCP tool + `GET /api/v1/doc_collections` REST list route) applied the optional `vendor` filter as a **pre-dedupe SQL `WHERE`**, before the tenant-first dedupe runs in Python. When a tenant-curated row shadowed a global `collection_key` under a *different* vendor, filtering by the shadowed global row's vendor dropped the tenant row at SQL level and surfaced the **global (shadowed) row's metadata** — violating the catalogue's documented "tenant row wins" invariant.
- Move the `vendor` predicate to Python, applied **after** `_dedupe_tenant_first`, over the post-dedupe tenant-wins rows, on **both** surfaces. `vendor` now only keeps or drops the row the principal would actually search — never a shadowed global row.
- The keyset cursor (`collection_key > cursor`) stays in SQL; dedupe and the vendor filter both preserve `collection_key` ordering, so **pagination is unaffected** by the reorder.
- Not an entitlement leak — the returned `collection_key` set and entitlement filtering are unchanged; only which rows the vendor filter keeps and whose metadata is shown.

## Test plan
- [x] `ruff check` / `ruff format --check` — clean (changed source + tests)
- [x] `mypy src/.../mcp/tools/doc_collections.py src/.../api/v1/doc_collections.py` — clean
- [x] `pytest tests/test_mcp_tools_doc_collections.py tests/test_doc_collections_list_route.py` — 27 passed (4 new)
- [x] **Shadow-key test (both surfaces):** global `K` vendor `A` shadowed by tenant `K` vendor `B`; `vendor=B` returns the tenant row for `K`, `vendor=A` does NOT return `K`. Verified to fail on the old SQL-side filter and pass with the fix (regression guard validated).
- [x] **Keyset pagination after the reorder (both surfaces):** a `limit=1` walk filtered to one vendor advances by `collection_key`, skipping a filtered-out interleaved key in SQL, terminating on the empty page.
- [x] `code-quality.py --diff` — 0 blockers (1 pre-existing function-size warn on `_list_doc_collections_handler`, well under the 100-line hard cap)
- [x] No OpenAPI/CLI surface change — `git status` shows no generated/`cli/` files touched (internal query-ordering fix only).

## Out of scope
- The readiness-guard / disabled-search 409-vs-403 contract — separate follow-up (#1567), which edits the **disable** endpoint + search path in the same REST file. This PR confines its REST edits to the **list** endpoint.
- Any change to the dedupe rule itself (tenant-wins is correct) or to entitlement filtering.

## Adjacent findings
- `_list_doc_collections_handler` is 75 lines (code-quality warn >60; hard cap 100) — pre-existing, not introduced here; could be split if it grows.

<!-- auto-implement-issue: fresh, iteration 1 -->

Closes #1568


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Fixed vendor filtering in document collections to correctly apply after tenant-first deduplication, ensuring tenant-scoped collections are properly prioritized.

* **Tests**
  * Added coverage for vendor filtering with shadowed keys and keyset pagination combined with vendor filters.

* **Documentation**
  * Clarified vendor filter behavior and timing in document collection discovery documentation.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->