### PR TITLE
fix(docs): reconcile disabled-collection search contract — terminal 403 vs retryable 409 (#1567)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -90,6 +90,32 @@ connector-related release-notes line.
 
 ## [Unreleased]
 
+### Disabled-collection search contract (#1567)
+
+- Reconcile the disabled-collection `search_docs` contract so code, the
+  OpenAPI response descriptions, the `disable` endpoint docstring, and the
+  CLI `disable` help all agree, and restore the operationally load-bearing
+  **terminal/retryable** split the design intended (the shipped code had
+  collapsed every non-`ready` status to a single 409, while two docstrings
+  and the CLI help still claimed a 403). Searching a **`disabled`**
+  collection now returns a **terminal** rejection — HTTP **403** with a
+  structured `detail.error="collection_disabled"` (MCP **`-32602`** with
+  `error.data.reason="collection_disabled"`) — distinct from a
+  **transient** `provisioning`/`rebuilding` collection, which stays a
+  **retryable** HTTP **409** (MCP **`-32603`**), so a client knows to back
+  off and retry a rebuild but not a deliberately-disabled collection. The
+  decision is made in **exactly one** readiness gate
+  (`resolve_entitled_ready_collection`, shared by the REST route, the
+  `search_docs`/`ask_docs` MCP tools, and the docs-chunk resource); the
+  unwired duplicate guard (`ensure_collection_searchable` +
+  `DocCollectionDisabledError`/`DocCollectionNotReadyError` in
+  `docs_collections.lifecycle`) is removed. The `meho docs search` CLI
+  renders the disabled 403 as a distinct "collection is disabled" error
+  rather than the misleading `insufficient_role`. (Option A of the issue —
+  honor the designed split — chosen over Option B's 409-for-all because the
+  terminal/retryable signal is a genuine client value and the mechanism was
+  already shipped and tested by #1555.)
+
 ### Doc-collection docs + runbook (#1556)
 
 - Update the operator provisioning runbook
@@ -104,7 +130,9 @@ connector-related release-notes line.
   record (`corpus-http` adapter + the legacy `corpus_url` fallback) and
   bringing it to readiness through the **probe → enable** lifecycle
   (`provisioning`/`rebuilding` → `ready`; `disable` → not-ready, so
-  search returns 409 like any other non-`ready` status);
+  search fails typed — a terminal 403 for `disabled`, a retryable 409
+  for `provisioning`/`rebuilding`, see the contract reconciliation in
+  #1567);
   **discovery** (`list_doc_collections` / `GET /api/v1/doc_collections` /
   `meho docs collections list` + the `initialize.instructions`
   `<<DOC_COLLECTIONS_AVAILABLE>>` band); the **search contract**

--- a/backend/src/meho_backplane/api/v1/doc_collections.py
+++ b/backend/src/meho_backplane/api/v1/doc_collections.py
@@ -37,11 +37,13 @@ Why a probe **route** rather than an implicit probe-on-search: a probe
 talks to the managed-RAG backend (latency + serialized rebuilds), so it
 is an explicit operator/ops action that refreshes the cached liveness the
 search path then reads cheaply — exactly the ``probe_target`` →
-``Target.fingerprint`` → dispatch split. Collection-scoped search wiring
-(the ``status != 'ready'`` typed failure) lives in T3 (#1552), which
-calls the
-:func:`~meho_backplane.docs_collections.lifecycle.ensure_collection_searchable`
-guard this Task ships.
+``Target.fingerprint`` → dispatch split. The collection-scoped search path
+reads that cached ``status`` in its shared resolve + entitle + readiness
+gate (:func:`~meho_backplane.docs_search.resolve_entitled_ready_collection`),
+which fails typed against a not-``ready`` collection — branching a terminal
+``disabled`` collection (403) from the transient ``provisioning`` /
+``rebuilding`` states (409). The readiness rejection lives there, not on
+these write routes.
 
 RBAC + tenancy
 --------------
@@ -280,8 +282,12 @@ async def disable_collection_endpoint(
     """Hide a collection from search (→ ``disabled``).
 
     Idempotent and lifecycle-guarded — same shape as the enable handler.
-    A disabled collection fails ``search_docs`` typed (403) via the T3
-    search-time guard rather than returning an empty result.
+    A disabled collection fails ``search_docs`` typed with a **terminal**
+    rejection (REST 403 ``detail.error='collection_disabled'`` / MCP
+    ``-32602``), distinct from the retryable 409 a ``provisioning`` /
+    ``rebuilding`` collection returns, via the shared
+    :func:`~meho_backplane.docs_search.resolve_entitled_ready_collection`
+    gate — never an empty result.
     """
     collection = await resolve_doc_collection(session, collection_key, operator.tenant_id)
     await set_collection_enabled(session, collection, enabled=False)

--- a/backend/src/meho_backplane/api/v1/search_docs.py
+++ b/backend/src/meho_backplane/api/v1/search_docs.py
@@ -34,8 +34,12 @@ After the scope parses, :func:`~meho_backplane.docs_search.resolve_entitled_read
 runs the shared gate: it resolves ``collection`` to its registry row
 (tenant-first), enforces the ``meho-docs:<collection>`` capability
 (403 on a miss -- the collection exists but the tenant is not entitled),
-and checks the registry ``status`` (409 when the collection is not
-``ready``). An unknown collection is 422 (an invalid argument).
+and checks the registry ``status``. The readiness rejection branches on
+the kind of not-ready: a ``disabled`` collection is a terminal **403**
+(``detail.error='collection_disabled'`` -- an operator hid it, distinct
+from the entitlement-miss 403 and not retryable), while a transient
+``provisioning`` / ``rebuilding`` collection is a retryable **409**. An
+unknown collection is 422 (an invalid argument).
 
 RBAC + tenant scoping
 ---------------------
@@ -109,6 +113,7 @@ from meho_backplane.auth.rbac import require_role
 from meho_backplane.db.engine import get_session
 from meho_backplane.docs_collections import DocCollection
 from meho_backplane.docs_search import (
+    CollectionDisabledError,
     CollectionForbiddenError,
     CollectionNotReadyError,
     CollectionScope,
@@ -207,8 +212,12 @@ async def _resolve_collection_or_http_error(
     Each typed access failure maps to its own status: an unknown collection
     → 422 (an invalid ``collection`` argument, carrying the catalogue of
     visible keys), not entitled → 403 (the collection exists; the tenant
-    lacks ``meho-docs:<collection>``), not ready → 409 (the backend is not
-    answerable yet).
+    lacks ``meho-docs:<collection>``), disabled → 403 (an operator hid the
+    collection from service — terminal, *not* retryable), and transiently
+    not ready (``provisioning`` / ``rebuilding``) → 409 (retryable once the
+    rebuild finishes). The disabled 403 carries a structured
+    ``{"error": "collection_disabled"}`` detail so a client (and the CLI's
+    status renderer) can tell it apart from the entitlement-miss 403.
     """
     try:
         return await resolve_entitled_ready_collection(session, operator, collection_key)
@@ -225,6 +234,15 @@ async def _resolve_collection_or_http_error(
         raise HTTPException(
             status_code=status.HTTP_403_FORBIDDEN,
             detail=str(exc),
+        ) from exc
+    except CollectionDisabledError as exc:
+        raise HTTPException(
+            status_code=status.HTTP_403_FORBIDDEN,
+            detail={
+                "error": "collection_disabled",
+                "collection": exc.collection_key,
+                "retryable": False,
+            },
         ) from exc
     except CollectionNotReadyError as exc:
         raise HTTPException(
@@ -293,17 +311,24 @@ async def _run_fanout_or_http_error(
     responses={
         403: {
             "description": (
-                "The tenant is not entitled to the named collection -- it "
-                "lacks the ``meho-docs:<collection>`` capability even "
-                "though it can see the add-on. The collection exists; the "
-                "principal just cannot search it."
+                "Terminal rejection of an otherwise-resolvable collection, "
+                "in one of two forms (both 403, distinguished by the "
+                "``detail.error`` field): the tenant is not entitled to the "
+                "named collection -- it lacks the ``meho-docs:<collection>`` "
+                "capability even though it can see the add-on -- or the "
+                "collection has been ``disabled`` by an operator "
+                "(``detail.error='collection_disabled'``). Neither is "
+                "retryable: the collection exists but the principal cannot "
+                "search it, or an operator switched it off."
             ),
         },
         409: {
             "description": (
-                "The named collection is known and entitled but not "
-                "``ready`` (provisioning / rebuilding / disabled) -- its "
-                "backend is not answerable yet."
+                "The named collection is known and entitled but transiently "
+                "not ``ready`` (provisioning / rebuilding) -- its backend is "
+                "not answerable yet. Retryable once the rebuild finishes. A "
+                "``disabled`` collection is the terminal 403 above, not a "
+                "409."
             ),
         },
         422: {
@@ -336,7 +361,9 @@ async def search_docs_endpoint(
 
     * **Single** (``collection``) -- the T3 path: resolve to one backend,
       enforce the per-collection ``meho-docs:<collection>`` entitlement (403)
-      and readiness (409), and search that one collection.
+      and readiness (terminal ``disabled`` → 403, transient
+      ``provisioning`` / ``rebuilding`` → 409), and search that one
+      collection.
     * **Fan-out** (``collections=[…]`` or ``collection="all"``, G4.6-T5
       #1554) -- query every entitled, ready collection in scope on its own
       backend and RRF-merge the ranked lists. Non-entitled / not-ready

--- a/backend/src/meho_backplane/docs_collections/__init__.py
+++ b/backend/src/meho_backplane/docs_collections/__init__.py
@@ -9,15 +9,14 @@ downstream tasks can import from ``meho_backplane.docs_collections``
 without knowing the internal module split. The backend-agnostic search
 router (T2 #1551), collection-scoped search (T3 #1552), and the catalogue
 tool / CLI (T4 #1553) all build on this surface; the probe / enable /
-disable routes and the search-time readiness guard build on the
-``lifecycle`` + ``service`` modules (T6 #1555).
+disable routes build on the ``lifecycle`` + ``service`` modules (T6
+#1555). The search-time readiness rejection is the access gate's
+(:func:`~meho_backplane.docs_search.resolve_entitled_ready_collection`),
+not this package's — ``lifecycle`` owns only the write-side status machine.
 """
 
 from meho_backplane.docs_collections.lifecycle import (
-    DocCollectionDisabledError,
-    DocCollectionNotReadyError,
     DocCollectionStateError,
-    ensure_collection_searchable,
 )
 from meho_backplane.docs_collections.resolver import (
     DocCollectionNotFoundError,
@@ -35,12 +34,9 @@ from meho_backplane.docs_collections.service import (
 
 __all__ = [
     "DocCollection",
-    "DocCollectionDisabledError",
     "DocCollectionNotFoundError",
-    "DocCollectionNotReadyError",
     "DocCollectionStateError",
     "DocCollectionSummary",
-    "ensure_collection_searchable",
     "probe_collection",
     "project_doc_collection_to_summary",
     "resolve_doc_collection",

--- a/backend/src/meho_backplane/docs_collections/lifecycle.py
+++ b/backend/src/meho_backplane/docs_collections/lifecycle.py
@@ -38,16 +38,20 @@ idempotency the acceptance criteria require), not an error — re-enabling
 an enabled collection or re-probing a steady-state ``ready`` collection
 returns without a spurious 409.
 
-Search-time guard
------------------
+Search-time readiness
+---------------------
 
-:func:`ensure_collection_searchable` is the typed guard the
-collection-scoped search path (T3 #1552) calls to fail typed against a
-not-``ready`` collection: ``rebuilding`` / ``provisioning`` →
-:class:`DocCollectionNotReadyError` (409, retryable), ``disabled`` →
-:class:`DocCollectionDisabledError` (403). T6 ships the guard; T3 wires
-it into the ``search_docs`` route — the mechanism here, the call site
-there.
+The search path does **not** re-derive readiness here. The single
+readiness gate lives in
+:func:`~meho_backplane.docs_search.resolve_entitled_ready_collection` —
+the same gate that resolves the ``collection`` key and enforces the
+per-collection entitlement — which branches a terminal ``disabled``
+collection (:class:`~meho_backplane.docs_search.CollectionDisabledError`
+→ 403 / ``-32602``) from the transient ``provisioning`` / ``rebuilding``
+states (:class:`~meho_backplane.docs_search.CollectionNotReadyError` →
+409 / ``-32603``). This module owns the *write-side* status machine
+(transitions + probe mapping); the read-side readiness rejection is the
+access gate's, so the decision is made exactly once.
 """
 
 from __future__ import annotations
@@ -68,12 +72,9 @@ __all__ = [
     "STATUS_PROVISIONING",
     "STATUS_READY",
     "STATUS_REBUILDING",
-    "DocCollectionDisabledError",
-    "DocCollectionNotReadyError",
     "DocCollectionStateError",
     "apply_operator_transition",
     "apply_probe_transition",
-    "ensure_collection_searchable",
     "status_for_readiness",
 ]
 
@@ -137,50 +138,6 @@ class DocCollectionStateError(HTTPException):
                 "collection_key": collection_key,
                 "from_status": from_status,
                 "to_status": to_status,
-            },
-        )
-
-
-class DocCollectionNotReadyError(HTTPException):
-    """A collection cannot serve search because its index is not ready.
-
-    The typed search-time failure for a ``provisioning`` / ``rebuilding``
-    collection — HTTP **409** (a conflict with the collection's current
-    lifecycle state, retryable once the rebuild finishes), never a silent
-    empty 200. The search path (T3 #1552) raises this via
-    :func:`ensure_collection_searchable`. ``retryable=True`` distinguishes
-    it from the disabled 403 so a client can back off rather than treat it
-    as terminal.
-    """
-
-    def __init__(self, *, collection_key: str, status: str) -> None:
-        self.status = status
-        super().__init__(
-            status_code=409,
-            detail={
-                "error": "collection_not_ready",
-                "collection_key": collection_key,
-                "status": status,
-                "retryable": True,
-            },
-        )
-
-
-class DocCollectionDisabledError(HTTPException):
-    """A disabled collection cannot serve search.
-
-    The typed search-time failure for a ``disabled`` collection — HTTP
-    **403** (the collection is hidden from service by operator action, not
-    a transient state), distinct from the retryable 409 a rebuild yields.
-    """
-
-    def __init__(self, *, collection_key: str) -> None:
-        super().__init__(
-            status_code=403,
-            detail={
-                "error": "collection_disabled",
-                "collection_key": collection_key,
-                "retryable": False,
             },
         )
 
@@ -269,25 +226,3 @@ def _resolve_transition(
             to_status=to_status,
         )
     return to_status
-
-
-def ensure_collection_searchable(*, collection_key: str, status: str) -> None:
-    """Raise the typed failure when *status* cannot serve search (T6 mechanism).
-
-    The guard the collection-scoped search path (T3 #1552) calls before
-    federating a query. ``ready`` returns silently; every other state
-    raises so the route fails typed rather than returning an empty 200:
-
-    * ``provisioning`` / ``rebuilding`` → :class:`DocCollectionNotReadyError`
-      (409, retryable).
-    * ``disabled`` → :class:`DocCollectionDisabledError` (403).
-
-    T6 ships this guard; T3 wires the call into the ``search_docs`` route.
-    A status outside the known enum is treated as not-ready (fail-closed)
-    rather than waved through.
-    """
-    if status == STATUS_READY:
-        return
-    if status == STATUS_DISABLED:
-        raise DocCollectionDisabledError(collection_key=collection_key)
-    raise DocCollectionNotReadyError(collection_key=collection_key, status=status)

--- a/backend/src/meho_backplane/docs_search/__init__.py
+++ b/backend/src/meho_backplane/docs_search/__init__.py
@@ -19,12 +19,16 @@ enforced here: :func:`build_docs_scope` rejects a missing/blank
 ``collection`` with :class:`MissingDocsFilterError`, which the route
 renders as HTTP 422 (fail-closed) and the MCP face as ``-32602``.
 ``product`` / ``version`` are optional refinements within the chosen
-collection. :func:`resolve_entitled_ready_collection` is the shared gate
-that turns the ``collection`` key into its registry row, enforces the
-per-collection ``meho-docs:<key>`` entitlement, and checks readiness; the
-central audit binding (``op_id="meho.docs.search"`` + ``audit_collection``)
-stays in each surface, next to the ``audit_*`` contextvars the chassis
-middleware lifts into the row.
+collection. :func:`resolve_entitled_ready_collection` is the **single**
+shared gate that turns the ``collection`` key into its registry row,
+enforces the per-collection ``meho-docs:<key>`` entitlement, and checks
+readiness — branching a terminal ``disabled`` collection
+(:class:`CollectionDisabledError` → 403 / ``-32602``) from the transient
+``provisioning`` / ``rebuilding`` states (:class:`CollectionNotReadyError`
+→ 409 / ``-32603``) so a client can tell "do not retry" from "retry
+later". The central audit binding (``op_id="meho.docs.search"`` +
+``audit_collection``) stays in each surface, next to the ``audit_*``
+contextvars the chassis middleware lifts into the row.
 """
 
 from __future__ import annotations
@@ -36,6 +40,7 @@ from meho_backplane.docs_search.backends import (
 )
 from meho_backplane.docs_search.collection_access import (
     CollectionAccessError,
+    CollectionDisabledError,
     CollectionForbiddenError,
     CollectionNotReadyError,
     NoEntitledReadyCollectionError,
@@ -69,6 +74,7 @@ from meho_backplane.docs_search.synthesis import (
 __all__ = [
     "NO_GROUNDED_ANSWER",
     "CollectionAccessError",
+    "CollectionDisabledError",
     "CollectionForbiddenError",
     "CollectionNotReadyError",
     "CollectionScope",

--- a/backend/src/meho_backplane/docs_search/collection_access.py
+++ b/backend/src/meho_backplane/docs_search/collection_access.py
@@ -24,10 +24,17 @@ readiness) are defined once and cannot drift per surface:
    actually query. A miss is the typed :exc:`CollectionForbiddenError`.
 
 3. **Readiness** — a collection whose lifecycle ``status`` is not
-   ``"ready"`` (``provisioning`` / ``rebuilding`` / ``disabled``) is not
-   answerable yet; this is the typed :exc:`CollectionNotReadyError`. The
-   richer reachability *probe* is T6 (#1555); T3 reads only the registry
-   ``status`` column the T1 substrate already carries.
+   ``"ready"`` is not answerable yet, but the rejection branches on *why*:
+   a ``provisioning`` / ``rebuilding`` collection is **transiently** not
+   ready (:exc:`CollectionNotReadyError`, retryable once the rebuild
+   finishes), whereas a ``disabled`` collection is **terminally** hidden by
+   operator action (:exc:`CollectionDisabledError`, not retryable). The
+   split is operationally load-bearing — a client should back off and retry
+   a rebuilding collection but must not retry a disabled one — so the two
+   carry distinct transport shapes (409 vs 403 at REST; ``-32603`` vs
+   ``-32602`` at the MCP face). The richer reachability *probe* is T6
+   (#1555); this gate reads only the registry ``status`` column the T1
+   substrate already carries.
 
 Each surface translates these typed errors into its own transport shape
 (HTTP status at the REST route, JSON-RPC ``-32xxx`` at the MCP face) so
@@ -56,6 +63,7 @@ if TYPE_CHECKING:
 
 __all__ = [
     "CollectionAccessError",
+    "CollectionDisabledError",
     "CollectionForbiddenError",
     "CollectionNotReadyError",
     "NoEntitledReadyCollectionError",
@@ -72,6 +80,15 @@ _log = structlog.get_logger(__name__)
 #: not-ready: the catalogue knows the collection but the backend is not
 #: serving it yet.
 _READY_STATUS = "ready"
+
+#: The terminal not-ready status: an operator has hidden the collection
+#: from service. Distinct from the transient ``provisioning`` /
+#: ``rebuilding`` states because a disabled collection will not become
+#: answerable on its own — a client must not retry it. Kept as a literal
+#: (rather than imported from ``docs_collections.lifecycle``) so this
+#: transport-neutral access module stays free of a lifecycle import; the
+#: string is the same ``ck_doc_collections_status`` CHECK-constraint value.
+_DISABLED_STATUS = "disabled"
 
 #: The capability-key prefix the per-collection entitlement gate keys on.
 #: ``meho-docs:<collection_key>`` reuses the G4.5-T1 capability substrate
@@ -132,10 +149,14 @@ class CollectionForbiddenError(CollectionAccessError):
 class CollectionNotReadyError(CollectionAccessError):
     """The collection is known + entitled but its backend is not serving yet.
 
-    The registry ``status`` is not ``"ready"`` (``provisioning`` /
-    ``rebuilding`` / ``disabled``). Surfaces map this to a 409/503-class
-    rejection — the request was well-formed and authorised; the collection
-    is simply not answerable at this moment.
+    The registry ``status`` is ``provisioning`` or ``rebuilding`` — a
+    **transient** not-ready state. Surfaces map this to a retryable
+    409-class rejection (REST 409, MCP ``-32603``): the request was
+    well-formed and authorised; the collection is simply not answerable at
+    *this* moment and will become so once provisioning / the rebuild
+    finishes. A ``disabled`` collection is the sibling :exc:`CollectionDisabledError`
+    (terminal) instead, so a client can tell "retry later" from "do not
+    retry".
     """
 
     def __init__(self, collection_key: str, status: str) -> None:
@@ -144,6 +165,28 @@ class CollectionNotReadyError(CollectionAccessError):
             collection_key=collection_key,
         )
         self.status = status
+
+
+class CollectionDisabledError(CollectionAccessError):
+    """The collection is known + entitled but an operator has disabled it.
+
+    The registry ``status`` is ``disabled`` — a **terminal** not-ready
+    state: the collection is hidden from service by deliberate operator
+    action, not a transient rebuild, so it will not become answerable on
+    its own. Surfaces map this to a terminal rejection distinct from the
+    retryable :exc:`CollectionNotReadyError` (REST 403, MCP ``-32602``) so a
+    client backs off permanently rather than polling a collection that an
+    operator chose to take out of service. It is *not* the entitlement-miss
+    :exc:`CollectionForbiddenError` — the tenant holds
+    ``meho-docs:<collection_key>``; the collection itself is switched off.
+    """
+
+    def __init__(self, collection_key: str) -> None:
+        super().__init__(
+            f"doc collection {collection_key!r} is disabled",
+            collection_key=collection_key,
+        )
+        self.status = _DISABLED_STATUS
 
 
 class NoEntitledReadyCollectionError(CollectionAccessError):
@@ -201,8 +244,14 @@ async def resolve_entitled_ready_collection(
     The checks run resolve → entitle → readiness in that order so the
     rejection is the most specific true one: a tenant gets
     ``not found`` for a key it cannot see at all, ``forbidden`` for a
-    key it can see but is not entitled to, and ``not ready`` only once
-    both of those pass.
+    key it can see but is not entitled to, and a readiness rejection only
+    once both of those pass. The readiness arm itself branches on the
+    *kind* of not-ready: a ``disabled`` collection is the terminal
+    :exc:`CollectionDisabledError`; ``provisioning`` / ``rebuilding`` (or
+    any other non-``ready`` value, fail-closed) is the retryable
+    :exc:`CollectionNotReadyError`. This is the **single** readiness gate
+    every collection-scoped search surface runs — there is no second
+    duplicate check downstream.
 
     Args:
         session: Active async DB session.
@@ -220,8 +269,11 @@ async def resolve_entitled_ready_collection(
             visible to the operator's tenant.
         CollectionForbiddenError: The tenant lacks the
             ``meho-docs:<collection_key>`` capability.
+        CollectionDisabledError: The collection's registry ``status`` is
+            ``disabled`` (terminal — an operator hid it from service).
         CollectionNotReadyError: The collection's registry ``status`` is
-            not ``"ready"``.
+            ``provisioning`` / ``rebuilding`` (or any other non-``ready``
+            value), i.e. transiently not answerable.
     """
     try:
         row = await resolve_doc_collection(session, collection_key, operator.tenant_id)
@@ -250,6 +302,10 @@ async def resolve_entitled_ready_collection(
             collection_key=row.collection_key,
             status=row.status,
         )
+        # Branch the not-ready rejection so the terminal disabled state is
+        # distinguishable from the transient rebuild states downstream.
+        if row.status == _DISABLED_STATUS:
+            raise CollectionDisabledError(row.collection_key)
         raise CollectionNotReadyError(row.collection_key, row.status)
 
     return DocCollection.model_validate(row, from_attributes=True)

--- a/backend/src/meho_backplane/mcp/resources/docs.py
+++ b/backend/src/meho_backplane/mcp/resources/docs.py
@@ -48,22 +48,28 @@ taken from the returned chunks.
 Rejection arms
 ==============
 
-* **Blank scope segment / unknown / not-entitled collection** (all
-  ``-32602`` INVALID_PARAMS) —
+* **Blank scope segment / unknown / not-entitled / disabled collection**
+  (all ``-32602`` INVALID_PARAMS) —
   :class:`~meho_backplane.docs_search.MissingDocsFilterError`,
-  :class:`~meho_backplane.docs_search.UnknownCollectionError`, and
-  :class:`~meho_backplane.docs_search.CollectionForbiddenError` map to
-  :class:`McpInvalidParamsError`.
+  :class:`~meho_backplane.docs_search.UnknownCollectionError`,
+  :class:`~meho_backplane.docs_search.CollectionForbiddenError`, and
+  :class:`~meho_backplane.docs_search.CollectionDisabledError` map to
+  :class:`McpInvalidParamsError`. A disabled collection is a terminal,
+  client-actionable rejection (an operator hid it), so it joins the
+  ``-32602`` lane rather than bubbling to the retryable ``-32603`` a
+  transiently not-ready collection lands on.
 * **Chunk not found in the scope** (``-32602``) — the re-search returned no
   chunk whose ``chunk_id`` matches. Collapses to "docs chunk not found"
   without revealing whether the scope is empty or the id is simply absent,
   so the resource is not a probe oracle for the collection contents.
 
-A not-ready collection (:class:`~meho_backplane.docs_search.CollectionNotReadyError`)
-or an unavailable backend (:class:`~meho_backplane.auth.corpus.CorpusUnavailable`)
-is *not* caught here: it bubbles to the dispatcher's generic catch and
-surfaces as ``-32603`` Internal Error — the read was well-formed; the
-backend is down / not serving.
+A *transiently* not-ready collection
+(:class:`~meho_backplane.docs_search.CollectionNotReadyError` —
+``provisioning`` / ``rebuilding``) or an unavailable backend
+(:class:`~meho_backplane.auth.corpus.CorpusUnavailable`) is *not* caught
+here: it bubbles to the dispatcher's generic catch and surfaces as
+``-32603`` Internal Error — the read was well-formed; the backend is down /
+not serving yet (retryable).
 
 Response shape
 ==============
@@ -85,6 +91,7 @@ import structlog
 from meho_backplane.auth.operator import Operator, TenantRole
 from meho_backplane.db.engine import get_sessionmaker
 from meho_backplane.docs_search import (
+    CollectionDisabledError,
     CollectionForbiddenError,
     MissingDocsFilterError,
     UnknownCollectionError,
@@ -134,8 +141,9 @@ async def _docs_chunk_handler(
     structlog.contextvars.bind_contextvars(audit_collection=scope.collection_key)
 
     # Resolve + entitle + readiness gate (the same shared gate the tools
-    # run). Unknown / not-entitled collections map to -32602; a not-ready
-    # collection bubbles to -32603 via the dispatcher's generic catch.
+    # run). Unknown / not-entitled / disabled collections map to -32602
+    # (terminal, client-actionable); a transiently not-ready collection
+    # bubbles to -32603 via the dispatcher's generic catch (retryable).
     sessionmaker = get_sessionmaker()
     async with sessionmaker() as session:
         try:
@@ -149,6 +157,11 @@ async def _docs_chunk_handler(
             ) from exc
         except CollectionForbiddenError as exc:
             raise McpInvalidParamsError(f"docs chunk: {exc}") from exc
+        except CollectionDisabledError as exc:
+            raise McpInvalidParamsError(
+                f"docs chunk: {exc}",
+                data={"reason": "collection_disabled"},
+            ) from exc
 
     # The transport is search-only, so recover the chunk by re-searching
     # the bound scope and matching on the exact id. The chunk_id doubles

--- a/backend/src/meho_backplane/mcp/tools/docs.py
+++ b/backend/src/meho_backplane/mcp/tools/docs.py
@@ -97,6 +97,7 @@ from meho_backplane.auth.operator import Operator, TenantRole
 from meho_backplane.db.engine import get_sessionmaker
 from meho_backplane.docs_collections import DocCollection
 from meho_backplane.docs_search import (
+    CollectionDisabledError,
     CollectionForbiddenError,
     CollectionScope,
     ConflictingCollectionScopeError,
@@ -190,11 +191,17 @@ async def _resolve_collection_or_error(
       projected to the 403-class audit status by the dispatcher): the same
       403-projected path the static capability gate uses. The collection
       exists; the tenant lacks ``meho-docs:<collection>``.
+    * **Disabled** — :class:`~meho_backplane.docs_search.CollectionDisabledError`
+      → :class:`McpInvalidParamsError` (``-32602``): an operator hid the
+      collection from service. This is a **terminal**, client-actionable
+      rejection (the agent must not retry), so it maps to the spec's
+      "invalid params" lane like the entitlement miss — distinct from the
+      retryable not-ready ``-32603`` below.
     * **Not ready** — :class:`~meho_backplane.docs_search.CollectionNotReadyError`
-      is *not* caught here: a known + entitled collection whose backend is
-      not yet serving is a server-side condition (the MCP analogue of the
-      route's 409/503), so it bubbles to the dispatcher's generic catch as
-      ``-32603``.
+      is *not* caught here: a known + entitled collection that is
+      transiently ``provisioning`` / ``rebuilding`` is a server-side,
+      **retryable** condition (the MCP analogue of the route's 409/503), so
+      it bubbles to the dispatcher's generic catch as ``-32603``.
     """
     sessionmaker = get_sessionmaker()
     async with sessionmaker() as session:
@@ -207,6 +214,11 @@ async def _resolve_collection_or_error(
             ) from exc
         except CollectionForbiddenError as exc:
             raise McpInvalidParamsError(f"{tool}: {exc}") from exc
+        except CollectionDisabledError as exc:
+            raise McpInvalidParamsError(
+                f"{tool}: {exc}",
+                data={"reason": "collection_disabled"},
+            ) from exc
 
 
 def _parse_scope_or_invalid_params(tool: str, arguments: dict[str, Any]) -> CollectionScope:
@@ -262,12 +274,14 @@ async def _search_docs_handler(
     call as the operator.
 
     Error arms: a conflicting (both single + fan-out) scope, a missing/blank
-    or unknown / not-entitled single ``collection``, or a fan-out that
-    resolves to no entitled, ready collection → ``-32602``; a not-ready
-    single collection or an unavailable
+    or unknown / not-entitled / ``disabled`` single ``collection``, or a
+    fan-out that resolves to no entitled, ready collection → ``-32602``
+    (all client-actionable, terminal — a disabled collection carries
+    ``error.data.reason='collection_disabled'``); a *transiently* not-ready
+    single collection (``provisioning`` / ``rebuilding``) or an unavailable
     :class:`~meho_backplane.auth.corpus.CorpusUnavailable` backend bubbles to
     ``-32603`` (a well-formed request against a backend that is down / not
-    serving is a server-side fault, not invalid params).
+    serving yet is a server-side, retryable fault, not invalid params).
     """
     # Bind the canonical op_id so the persisted audit row is filterable by
     # ``op_id="meho.docs.search"`` the same way the REST + CLI faces are
@@ -473,17 +487,21 @@ async def _ask_docs_handler(
     * **Fan-out attempt** (``collections`` / ``collection="all"``) — mapped
       to :class:`McpInvalidParamsError` (``-32602``): ``ask_docs`` is
       single-collection only.
-    * **Missing/blank or unknown / not-entitled ``collection``** — mapped to
-      :class:`McpInvalidParamsError` (``-32602``) by
+    * **Missing/blank or unknown / not-entitled / disabled ``collection``**
+      — mapped to :class:`McpInvalidParamsError` (``-32602``) by
       :func:`_build_scope_or_invalid_params` /
       :func:`_resolve_collection_or_error` (the MCP analogue of the route's
-      422 / 403). The inputSchema's ``required`` list catches the missing
-      case first for a schema-validating client.
-    * **Not-ready collection / corpus unavailable** —
-      :class:`~meho_backplane.docs_search.CollectionNotReadyError` and
+      422 / 403). A disabled collection carries
+      ``error.data.reason='collection_disabled'`` — a terminal,
+      client-actionable rejection distinct from the retryable not-ready
+      ``-32603`` below. The inputSchema's ``required`` list catches the
+      missing case first for a schema-validating client.
+    * **Transiently not-ready collection / corpus unavailable** —
+      :class:`~meho_backplane.docs_search.CollectionNotReadyError`
+      (``provisioning`` / ``rebuilding``) and
       :class:`~meho_backplane.auth.corpus.CorpusUnavailable` are *not*
-      caught; they bubble to ``-32603`` (a down / not-serving backend is a
-      server fault).
+      caught; they bubble to ``-32603`` (a down / not-serving-yet backend is
+      a server fault the agent can retry).
     * **Synthesis model unconfigured / unreachable** —
       :class:`~meho_backplane.operations.ingest.LlmClientUnavailable` (and
       :class:`~meho_backplane.docs_search.DocsSynthesisError` for a model

--- a/backend/tests/test_doc_collections_readiness.py
+++ b/backend/tests/test_doc_collections_readiness.py
@@ -15,10 +15,12 @@ Coverage matrix (Task #1555 acceptance criteria):
   ``ready`` → ``rebuilding`` when it is not; a forbidden move (a probe
   against a ``disabled`` row) raises ``DocCollectionStateError`` (409).
   Enable / disable are idempotent and guarded.
-* **Search-time guard** — ``ensure_collection_searchable`` (the T6
-  mechanism T3 #1552 wires into the route): ``ready`` passes,
-  ``rebuilding`` / ``provisioning`` → 409 (retryable), ``disabled`` →
-  403; never an empty pass-through.
+* **Search-time readiness** — no longer a guard in this module; the
+  single ``resolve_entitled_ready_collection`` gate (#1567) makes the
+  rejection (``ready`` passes, ``rebuilding`` / ``provisioning`` → 409
+  retryable, ``disabled`` → 403 terminal; never an empty pass-through).
+  Its route- / tool-level outcomes are asserted in
+  ``test_search_docs_route`` and ``test_mcp_tools_docs``.
 * **Per-project rebuild serialization** — two concurrent probes against
   the same backend endpoint serialize inside the adapter (the lock is
   held across the corpus round-trip); probes against different endpoints
@@ -55,10 +57,7 @@ from meho_backplane.auth.operator import Operator, PrincipalKind, TenantRole
 from meho_backplane.db.engine import get_sessionmaker, reset_engine_for_testing
 from meho_backplane.db.models import DocCollection
 from meho_backplane.docs_collections import (
-    DocCollectionDisabledError,
-    DocCollectionNotReadyError,
     DocCollectionStateError,
-    ensure_collection_searchable,
     probe_collection,
     set_collection_enabled,
 )
@@ -230,35 +229,12 @@ def test_apply_operator_transition_enable_only_from_disabled() -> None:
         )
 
 
-# ---------------------------------------------------------------------------
-# Search-time guard (the T6 mechanism T3 #1552 wires in)
-# ---------------------------------------------------------------------------
-
-
-def test_ensure_searchable_passes_for_ready() -> None:
-    ensure_collection_searchable(collection_key="vmware", status=STATUS_READY)  # no raise
-
-
-@pytest.mark.parametrize("status", [STATUS_REBUILDING, STATUS_PROVISIONING])
-def test_ensure_searchable_409_for_not_ready(status: str) -> None:
-    with pytest.raises(DocCollectionNotReadyError) as exc:
-        ensure_collection_searchable(collection_key="vmware", status=status)
-    assert exc.value.status_code == 409
-    assert exc.value.detail["retryable"] is True
-    assert exc.value.detail["status"] == status
-
-
-def test_ensure_searchable_403_for_disabled() -> None:
-    with pytest.raises(DocCollectionDisabledError) as exc:
-        ensure_collection_searchable(collection_key="vmware", status=STATUS_DISABLED)
-    assert exc.value.status_code == 403
-    assert exc.value.detail["retryable"] is False
-
-
-def test_ensure_searchable_fails_closed_on_unknown_status() -> None:
-    """A status outside the enum is treated as not-ready, never waved through."""
-    with pytest.raises(DocCollectionNotReadyError):
-        ensure_collection_searchable(collection_key="vmware", status="bogus")
+# NOTE: the search-time readiness rejection (``ready`` passes,
+# ``provisioning`` / ``rebuilding`` → retryable, ``disabled`` → terminal)
+# is no longer a separate guard in this module — it is the single
+# ``resolve_entitled_ready_collection`` gate (G4.6 #1567). Its distinguishable
+# 403-vs-409 (REST) and -32602-vs--32603 (MCP) outcomes are asserted at the
+# route / tool level: see ``test_search_docs_route`` and ``test_mcp_tools_docs``.
 
 
 # ---------------------------------------------------------------------------

--- a/backend/tests/test_mcp_resources_docs.py
+++ b/backend/tests/test_mcp_resources_docs.py
@@ -340,3 +340,36 @@ def test_resources_read_docs_backend_unavailable_is_internal_error(
         )
     assert response.status_code == 200
     assert response.json()["error"]["code"] == INTERNAL_ERROR
+
+
+@pytest.mark.parametrize("docs_client", [_ENTITLED], indirect=True)
+def test_resources_read_docs_disabled_collection_is_invalid_params(
+    docs_client: tuple[TestClient, Operator],
+) -> None:
+    """A ``disabled`` collection → -32602 terminal (the shared gate's #1567 split).
+
+    The resource reuses ``resolve_entitled_ready_collection``, so a disabled
+    collection is the same terminal ``-32602`` (``collection_disabled``) the
+    ``search_docs`` tool surfaces — distinct from the retryable ``-32603`` a
+    ``provisioning`` / ``rebuilding`` collection bubbles to.
+    """
+    client, _op = docs_client
+    _seed_collection_sync(status="disabled")
+
+    fake = _fake_corpus(
+        CorpusChunk(chunk_id="nsx-9.0-maximums-0007", document_id="d", content="x"),
+    )
+    with patch(_CORPUS_SEAM, new=fake):
+        response = post_mcp(
+            client,
+            {
+                "jsonrpc": "2.0",
+                "id": 6,
+                "method": "resources/read",
+                "params": {"uri": _DOCS_URI},
+            },
+        )
+    assert response.status_code == 200
+    error = response.json()["error"]
+    assert error["code"] == INVALID_PARAMS
+    assert error["data"]["reason"] == "collection_disabled"

--- a/backend/tests/test_mcp_tools_docs.py
+++ b/backend/tests/test_mcp_tools_docs.py
@@ -19,7 +19,10 @@ Covers the collection-scoped contract layered on the G4.5-T4 capability gate:
   query routes to the collection's backend.
 * **Collection scope routing:** the query reaches the resolved backend
   with the optional product/version refinements as ``metadata_filters``;
-  an unknown collection → ``-32602``, a not-ready collection → ``-32603``.
+  an unknown collection → ``-32602``, a *transiently* not-ready
+  (``provisioning`` / ``rebuilding``) collection → ``-32603`` (retryable),
+  a ``disabled`` collection → ``-32602`` (terminal,
+  ``error.data.reason='collection_disabled'``) (#1567).
 * The audit row carries the canonical ``op_id="meho.docs.search"`` plus
   ``audit_collection``; the raw query is recorded only as a hash.
 
@@ -463,12 +466,14 @@ def test_tools_call_search_docs_unknown_collection_is_invalid_params(
 
 
 @pytest.mark.parametrize("docs_client", [_ENTITLED], indirect=True)
-def test_tools_call_search_docs_not_ready_collection_is_internal_error(
+@pytest.mark.parametrize("status", ["provisioning", "rebuilding"])
+def test_tools_call_search_docs_transiently_not_ready_is_internal_error(
     docs_client: tuple[TestClient, Operator],
+    status: str,
 ) -> None:
-    """A known + entitled but not-``ready`` collection → -32603 (server-side condition)."""
+    """A transiently not-ready collection → -32603 (retryable server-side condition)."""
     client, _op = docs_client
-    _seed_collection_sync(status="rebuilding")
+    _seed_collection_sync(status=status)
     fake = _fake_corpus(_SAMPLE_CHUNK)
     with patch(_CORPUS_SEAM, new=fake):
         response = post_mcp(
@@ -485,6 +490,41 @@ def test_tools_call_search_docs_not_ready_collection_is_internal_error(
         )
     assert response.status_code == 200
     assert response.json()["error"]["code"] == INTERNAL_ERROR
+    assert "query" not in fake.captured  # type: ignore[attr-defined]
+
+
+@pytest.mark.parametrize("docs_client", [_ENTITLED], indirect=True)
+def test_tools_call_search_docs_disabled_collection_is_invalid_params(
+    docs_client: tuple[TestClient, Operator],
+) -> None:
+    """A ``disabled`` collection → -32602 terminal, distinct from the -32603 a rebuild yields.
+
+    The MCP analogue of the route's terminal/retryable split (#1567): a
+    disabled collection is a client-actionable terminal rejection
+    (``-32602`` carrying ``error.data.reason='collection_disabled'``), so the
+    agent does not retry — whereas a ``provisioning`` / ``rebuilding``
+    collection bubbles to the retryable ``-32603``.
+    """
+    client, _op = docs_client
+    _seed_collection_sync(status="disabled")
+    fake = _fake_corpus(_SAMPLE_CHUNK)
+    with patch(_CORPUS_SEAM, new=fake):
+        response = post_mcp(
+            client,
+            {
+                "jsonrpc": "2.0",
+                "id": 8,
+                "method": "tools/call",
+                "params": {
+                    "name": "search_docs",
+                    "arguments": {"query": "x", "collection": "vmware"},
+                },
+            },
+        )
+    assert response.status_code == 200
+    error = response.json()["error"]
+    assert error["code"] == INVALID_PARAMS
+    assert error["data"]["reason"] == "collection_disabled"
     assert "query" not in fake.captured  # type: ignore[attr-defined]
 
 

--- a/backend/tests/test_search_docs_route.py
+++ b/backend/tests/test_search_docs_route.py
@@ -16,7 +16,11 @@ Coverage matrix (Task #1552 acceptance criteria):
 * **Per-collection entitlement** -- a tenant lacking
   ``meho-docs:<collection>`` gets **403** on a known collection even though
   it can authenticate; a tenant with it succeeds.
-* **Readiness** -- a not-``ready`` collection → **409**.
+* **Readiness** -- a *transiently* not-ready collection
+  (``provisioning`` / ``rebuilding``) → **409** (retryable); a
+  ``disabled`` collection → **403** with a structured
+  ``detail.error='collection_disabled'`` (terminal), distinguishable from
+  the 409 and from the entitlement-miss 403 (#1567).
 * **RBAC** -- ``read_only`` → 403; unauthenticated → 401.
 * **Central audit** -- one audit row per query, ``op_id="meho.docs.search"``,
   ``op_class="read"``, the raw query stored only as a SHA-256 hash, plus
@@ -418,9 +422,10 @@ def test_not_entitled_to_collection_returns_403(client: TestClient) -> None:
     fake_corpus.assert_not_awaited()
 
 
-def test_not_ready_collection_returns_409(client: TestClient) -> None:
-    """A known + entitled but not-``ready`` collection → 409 (not answerable yet)."""
-    _seed_collection_sync(status="rebuilding")
+@pytest.mark.parametrize("status", ["provisioning", "rebuilding"])
+def test_transiently_not_ready_collection_returns_409(client: TestClient, status: str) -> None:
+    """A known + entitled but transiently not-ready collection → 409 (retryable)."""
+    _seed_collection_sync(status=status)
     key = _make_rsa_keypair("kid-A")
     token = _mint_token(
         key, sub="op-nr", tenant_role=TenantRole.OPERATOR.value, capabilities=_ENTITLED_CAPS
@@ -438,6 +443,38 @@ def test_not_ready_collection_returns_409(client: TestClient) -> None:
         )
     assert response.status_code == 409
     assert "not ready" in json.dumps(response.json()["detail"])
+    fake_corpus.assert_not_awaited()
+
+
+def test_disabled_collection_returns_terminal_403(client: TestClient) -> None:
+    """A ``disabled`` collection → 403 (terminal), distinct from the 409 a rebuild yields.
+
+    Asserts the operationally load-bearing terminal/retryable split (#1567):
+    a disabled collection is a permanent "do not retry" 403 carrying the
+    structured ``detail.error='collection_disabled'`` marker, distinguishable
+    both from the retryable 409 a ``provisioning`` / ``rebuilding`` collection
+    returns and from the plain-string entitlement-miss 403.
+    """
+    _seed_collection_sync(status="disabled")
+    key = _make_rsa_keypair("kid-A")
+    token = _mint_token(
+        key, sub="op-dis", tenant_role=TenantRole.OPERATOR.value, capabilities=_ENTITLED_CAPS
+    )
+    fake_corpus = _mock_corpus(_make_chunk())
+    with (
+        respx.mock as mock_router,
+        patch(_CORPUS_SEAM, new=fake_corpus),
+    ):
+        _mock_discovery_and_jwks(mock_router, _public_jwks(key))
+        response = client.post(
+            "/api/v1/search_docs",
+            json={"query": "q", "collection": "vmware"},
+            headers={"Authorization": f"Bearer {token}"},
+        )
+    assert response.status_code == 403
+    detail = response.json()["detail"]
+    assert detail["error"] == "collection_disabled"
+    assert detail["retryable"] is False
     fake_corpus.assert_not_awaited()
 
 

--- a/cli/api/openapi.json
+++ b/cli/api/openapi.json
@@ -409,7 +409,7 @@
           "docs"
         ],
         "summary": "Search Docs Endpoint",
-        "description": "Route a vendor-document query to one or more collections, returning cited chunks.\n\nTwo scopes, mutually exclusive (a 422 when both are supplied):\n\n* **Single** (``collection``) -- the T3 path: resolve to one backend,\n  enforce the per-collection ``meho-docs:<collection>`` entitlement (403)\n  and readiness (409), and search that one collection.\n* **Fan-out** (``collections=[\u2026]`` or ``collection=\"all\"``, G4.6-T5\n  #1554) -- query every entitled, ready collection in scope on its own\n  backend and RRF-merge the ranked lists. Non-entitled / not-ready\n  collections are dropped (logged); an empty resolved set is a 403.\n\nBoth bind the central ``meho.docs.search`` audit row, with\n``audit_collection`` carrying the queried collection (single) or the\nsorted, comma-joined queried set (fan-out) so who-touched attributes the\nquery either way. ``read_only`` operators get 403 via\n:func:`require_role` before reaching this handler. The raw query is never\nbound -- only its SHA-256 hash.",
+        "description": "Route a vendor-document query to one or more collections, returning cited chunks.\n\nTwo scopes, mutually exclusive (a 422 when both are supplied):\n\n* **Single** (``collection``) -- the T3 path: resolve to one backend,\n  enforce the per-collection ``meho-docs:<collection>`` entitlement (403)\n  and readiness (terminal ``disabled`` \u2192 403, transient\n  ``provisioning`` / ``rebuilding`` \u2192 409), and search that one\n  collection.\n* **Fan-out** (``collections=[\u2026]`` or ``collection=\"all\"``, G4.6-T5\n  #1554) -- query every entitled, ready collection in scope on its own\n  backend and RRF-merge the ranked lists. Non-entitled / not-ready\n  collections are dropped (logged); an empty resolved set is a 403.\n\nBoth bind the central ``meho.docs.search`` audit row, with\n``audit_collection`` carrying the queried collection (single) or the\nsorted, comma-joined queried set (fan-out) so who-touched attributes the\nquery either way. ``read_only`` operators get 403 via\n:func:`require_role` before reaching this handler. The raw query is never\nbound -- only its SHA-256 hash.",
         "operationId": "search_docs_endpoint_api_v1_search_docs_post",
         "parameters": [
           {
@@ -445,10 +445,10 @@
             }
           },
           "403": {
-            "description": "The tenant is not entitled to the named collection -- it lacks the ``meho-docs:<collection>`` capability even though it can see the add-on. The collection exists; the principal just cannot search it."
+            "description": "Terminal rejection of an otherwise-resolvable collection, in one of two forms (both 403, distinguished by the ``detail.error`` field): the tenant is not entitled to the named collection -- it lacks the ``meho-docs:<collection>`` capability even though it can see the add-on -- or the collection has been ``disabled`` by an operator (``detail.error='collection_disabled'``). Neither is retryable: the collection exists but the principal cannot search it, or an operator switched it off."
           },
           "409": {
-            "description": "The named collection is known and entitled but not ``ready`` (provisioning / rebuilding / disabled) -- its backend is not answerable yet."
+            "description": "The named collection is known and entitled but transiently not ``ready`` (provisioning / rebuilding) -- its backend is not answerable yet. Retryable once the rebuild finishes. A ``disabled`` collection is the terminal 403 above, not a 409."
           },
           "422": {
             "description": "The mandatory ``collection`` scope is absent / blank, names no collection visible to the tenant, or both a single ``collection`` and a fan-out ``collections`` / ``collection='all'`` scope were supplied (they are mutually exclusive). A docs query without a routable collection is rejected rather than forwarded as an unscoped query."
@@ -659,7 +659,7 @@
           "docs"
         ],
         "summary": "Disable Collection Endpoint",
-        "description": "Hide a collection from search (\u2192 ``disabled``).\n\nIdempotent and lifecycle-guarded \u2014 same shape as the enable handler.\nA disabled collection fails ``search_docs`` typed (403) via the T3\nsearch-time guard rather than returning an empty result.",
+        "description": "Hide a collection from search (\u2192 ``disabled``).\n\nIdempotent and lifecycle-guarded \u2014 same shape as the enable handler.\nA disabled collection fails ``search_docs`` typed with a **terminal**\nrejection (REST 403 ``detail.error='collection_disabled'`` / MCP\n``-32602``), distinct from the retryable 409 a ``provisioning`` /\n``rebuilding`` collection returns, via the shared\n:func:`~meho_backplane.docs_search.resolve_entitled_ready_collection`\ngate \u2014 never an empty result.",
         "operationId": "disable_collection_endpoint_api_v1_doc_collections__collection_key__disable_post",
         "parameters": [
           {

--- a/cli/internal/cmd/docs/collections.go
+++ b/cli/internal/cmd/docs/collections.go
@@ -142,9 +142,11 @@ func newCollectionsDisableCmd(provisioned bool) *cobra.Command {
 		Short: "Hide a collection from search service",
 		Long: "disable calls POST /api/v1/doc_collections/<key>/disable, " +
 			"moving the collection to disabled so search_docs fails typed " +
-			"(403) against it rather than returning an empty result. " +
-			"Idempotent: re-disabling an already-disabled collection is a " +
-			"no-op.",
+			"with a terminal rejection (HTTP 403, `collection_disabled`) " +
+			"against it rather than returning an empty result — distinct " +
+			"from the retryable 409 a provisioning/rebuilding collection " +
+			"returns, so a client knows not to retry. Idempotent: " +
+			"re-disabling an already-disabled collection is a no-op.",
 		Args:          cobra.ExactArgs(1),
 		SilenceUsage:  true,
 		SilenceErrors: true,

--- a/cli/internal/cmd/docs/docs.go
+++ b/cli/internal/cmd/docs/docs.go
@@ -344,10 +344,14 @@ func renderRequestError(
 //   - 401 → auth_expired (token rejected / refresh impossible).
 //   - 403 → insufficient_role (read_only operator, OR the tenant is not
 //     entitled to the named collection — it lacks the
-//     `meho-docs:<collection>` capability).
+//     `meho-docs:<collection>` capability), UNLESS the body carries the
+//     structured `detail.error == "collection_disabled"` marker, in which
+//     case it is unexpected wrapping a "collection is disabled" detail (an
+//     operator hid the collection — a terminal readiness rejection, not a
+//     role/entitlement miss).
 //   - 409 → unexpected wrapping the not-ready detail (the collection is
-//     known + entitled but its backend is provisioning / rebuilding /
-//     disabled).
+//     known + entitled but transiently provisioning / rebuilding — a
+//     disabled collection is the terminal 403 above, not a 409).
 //   - 422 → unexpected wrapping the collection-scope detail (missing
 //     --collection — the CLI fails fast before the call, so a 422 here
 //     means an unknown collection or a contract drift worth surfacing)
@@ -373,6 +377,15 @@ func renderHTTPStatus(
 			jsonOut,
 		)
 	case http.StatusForbidden:
+		if isDisabledCollection(bodyStr) {
+			return output.RenderError(cmd.ErrOrStderr(),
+				output.Unexpected(fmt.Sprintf(
+					"the doc collection is disabled: %s",
+					decodeDetailString(bodyStr),
+				)),
+				jsonOut,
+			)
+		}
 		return output.RenderError(cmd.ErrOrStderr(),
 			output.InsufficientRole(decodeDetailString(bodyStr)),
 			jsonOut,
@@ -426,6 +439,26 @@ func decodeDetailString(body string) string {
 		}
 	}
 	return strings.TrimSpace(body)
+}
+
+// isDisabledCollection reports whether a 403 body carries the structured
+// `detail.error == "collection_disabled"` marker the search route attaches
+// when an operator has disabled the collection. A disabled collection is a
+// terminal readiness rejection (not an entitlement/role miss), so the 403
+// renderer surfaces it distinctly rather than as `insufficient_role`. The
+// entitlement-miss 403 carries a plain-string `detail`, so it never matches.
+func isDisabledCollection(body string) bool {
+	var outer detailEnvelope
+	if err := json.Unmarshal([]byte(body), &outer); err != nil {
+		return false
+	}
+	var inner struct {
+		Error string `json:"error"`
+	}
+	if err := json.Unmarshal(outer.Detail, &inner); err != nil {
+		return false
+	}
+	return inner.Error == "collection_disabled"
 }
 
 // truncate cuts s to maxLen runes, appending an ellipsis when

--- a/cli/internal/cmd/docs/search_test.go
+++ b/cli/internal/cmd/docs/search_test.go
@@ -516,9 +516,20 @@ func firstChunkRow(t *testing.T, table string) string {
 // --- HTTP status mapping ---------------------------------------------
 
 func TestRunSearchMaps403(t *testing.T) {
+	// A plain-string 403 detail is a role / entitlement miss → insufficient_role.
 	assertStatusMapping(t, http.StatusForbidden,
 		`{"detail":"operator role required"}`,
 		output.ExitInsufficientRole, "operator role required")
+}
+
+func TestRunSearchMaps403DisabledCollection(t *testing.T) {
+	// A 403 carrying the structured `collection_disabled` marker is a
+	// terminal readiness rejection (an operator hid the collection), not a
+	// role/entitlement miss — surfaced as unexpected (#1567), distinct from
+	// the insufficient_role path above.
+	assertStatusMapping(t, http.StatusForbidden,
+		`{"detail":{"error":"collection_disabled","collection":"vmware","retryable":false}}`,
+		output.ExitUnexpected, "collection is disabled")
 }
 
 func TestRunSearchMaps422(t *testing.T) {
@@ -528,6 +539,8 @@ func TestRunSearchMaps422(t *testing.T) {
 }
 
 func TestRunSearchMaps409NotReady(t *testing.T) {
+	// A 409 is the transient (provisioning / rebuilding) not-ready state —
+	// retryable, distinct from the terminal disabled 403 above (#1567).
 	assertStatusMapping(t, http.StatusConflict,
 		`{"detail":"doc collection 'vmware' is not ready (status='rebuilding')"}`,
 		output.ExitUnexpected, "not ready")

--- a/docs/codebase/doc-collections.md
+++ b/docs/codebase/doc-collections.md
@@ -164,11 +164,14 @@ The `status` column's four states form a guarded machine:
   then promotes it). A same-state re-call is the idempotent no-op.
 
 A forbidden move raises `DocCollectionStateError` (HTTP 409). The
-search-time guard `ensure_collection_searchable(collection_key, status)`
-is the **mechanism T3 (#1552) wires into the search path**: `ready`
-passes, `provisioning` / `rebuilding` → `DocCollectionNotReadyError`
-(409, retryable), `disabled` → `DocCollectionDisabledError` (403); an
-unknown status fails closed as not-ready. T6 ships the guard; T3 calls it.
+search-time readiness rejection is **not** in this module — it lives in
+the single `resolve_entitled_ready_collection` access gate (#1567), which
+branches on the *kind* of not-ready: `ready` passes, `provisioning` /
+`rebuilding` → `CollectionNotReadyError` (409 / `-32603`, retryable),
+`disabled` → `CollectionDisabledError` (403 / `-32602`, terminal); any
+other value fails closed as not-ready. This `lifecycle` module owns only
+the write-side status machine (transitions + probe mapping); the read-side
+decision is the access gate's, made exactly once.
 
 ### The probe write-back service (`meho_backplane.docs_collections.service`)
 
@@ -292,10 +295,13 @@ malicious `when_to_use` carrying the terminator cannot escape the block.
   side (out of scope per #1555). `enable` returns a collection to
   `provisioning`, not to `ready` — a probe confirms the index before
   `ready`.
-- **The search-time status check is wired by T3.** T6 ships
-  `ensure_collection_searchable`; the call site in the `search_docs`
-  route is T3's (#1552). Until T3 lands, the search path does not yet
-  fail typed on a not-ready collection.
+- **The search-time status check is the access gate's, not a separate
+  guard.** `resolve_entitled_ready_collection` (#1552, #1567) is the single
+  place readiness is decided on the search path — it resolves the key,
+  enforces entitlement, and rejects a not-ready collection, branching the
+  terminal `disabled` (403 / `-32602`) from the transient `provisioning` /
+  `rebuilding` (409 / `-32603`). There is no second `ensure_collection_searchable`
+  duplicate.
 - **No write API.** Collections are operator-managed seed for v1. An
   `import` verb (mirroring `meho targets import`) is a later add if a
   collection needs one.

--- a/docs/cross-repo/meho-docs-addon.md
+++ b/docs/cross-repo/meho-docs-addon.md
@@ -350,11 +350,16 @@ entitled to** (`meho-docs:<key>`), so every key shown is one
 - **Entitlement** — searching a collection the tenant is not entitled to
   (`meho-docs:<key>` missing) → **403** / `-32602`, even though the tool
   stays visible via the base `meho-docs` gate.
-- **Readiness** — a collection whose `status` is not `ready`
-  (`provisioning` / `rebuilding` / `disabled`) → **409** / `-32603`
-  (CLI exit 4, "not ready"). The wired search path treats every
-  non-`ready` status uniformly: `disabled` is not a 403 — an operator
-  hiding a collection is a readiness state, not an entitlement miss.
+- **Readiness** — a collection whose `status` is not `ready` is rejected,
+  branching on the *kind* of not-ready (#1567): a *transient*
+  `provisioning` / `rebuilding` collection → **409** / `-32603` (CLI exit
+  4, "not ready") — retryable once the rebuild finishes; a `disabled`
+  collection → **403** (`detail.error='collection_disabled'`) / `-32602`
+  (CLI exit 4, "collection is disabled") — terminal, an operator hid it,
+  so a client must not retry. The split is deliberate: a disabled
+  collection is *not* an entitlement miss (the entitlement-miss 403 carries
+  a plain-string detail), it is a terminal readiness state distinct from
+  the retryable rebuild.
 
 ```bash
 # Single collection — the common path. --collection is mandatory.


### PR DESCRIPTION
## Summary

- Reconcile the **disabled-collection `search_docs` contract** across all five surfaces (REST code + OpenAPI descriptions, the MCP tools/resource, the `disable` endpoint docstring, and the CLI `disable` help), which previously disagreed: the shipped code collapsed every non-`ready` status to a single **409**, while the design intent, an unwired guard, two docstrings, and the CLI help asserted `disabled` → **403** (terminal).
- **Chose Option A** (honor the designed retryable/terminal split) over Option B (409-for-all). Rationale: the terminal/retryable signal is genuine client value — a client should retry a `rebuilding` collection but must **not** retry a deliberately-`disabled` one — and the mechanism was already shipped + tested by #1555. Option B would have thrown that away to "make docs match code".
- Searching a **`disabled`** collection now returns a **terminal** rejection — REST **403** `detail.error="collection_disabled"` / MCP **`-32602`** `error.data.reason="collection_disabled"` — distinct from a **transient** `provisioning`/`rebuilding` collection, which stays a **retryable** REST **409** / MCP **`-32603`**.
- The readiness decision is made in **exactly one** gate (`resolve_entitled_ready_collection`, shared by the REST route, the `search_docs`/`ask_docs` MCP tools, and the docs-chunk resource); the unwired duplicate (`ensure_collection_searchable` + `DocCollectionDisabledError`/`DocCollectionNotReadyError`) is **removed**. The `meho docs search` CLI now renders the disabled 403 as a distinct "collection is disabled" error instead of the misleading `insufficient_role`.

## Decision: Option A (explicit)

Honor the designed split — `disabled` = terminal, `provisioning`/`rebuilding` = retryable — rather than accepting 409-for-all. The genuine entitlement-miss 403 (`CollectionForbiddenError`, capability not held) is untouched and stays correct; the disabled 403 is distinguished by its structured `detail.error` so the CLI can tell them apart.

## Test plan

- [x] `ruff check` / `ruff format --check` — clean (25 files)
- [x] `mypy src/meho_backplane/` — clean (457 source files)
- [x] `code-quality.py --diff` — 0 blockers (8 pre-existing size warnings, diff-only)
- [x] **REST**: `disabled` → 403 `collection_disabled` (terminal); `provisioning`/`rebuilding` → 409 (retryable) — both asserted distinguishable (`test_search_docs_route.py`)
- [x] **MCP tool**: `disabled` → `-32602` `collection_disabled`; transient → `-32603` (`test_mcp_tools_docs.py`)
- [x] **MCP resource**: `disabled` → `-32602` `collection_disabled` (`test_mcp_resources_docs.py`)
- [x] **CLI**: disabled 403 → "collection is disabled" (exit 4), plain-string 403 stays `insufficient_role` (exit 5), 409 stays "not ready" (`search_test.go`) — `go test ./internal/cmd/docs/...` ok
- [x] Backend collection/docs sweep — 275 passed, 2 skipped (env-guarded)
- [x] `grep` confirms no remaining `ensure_collection_searchable` / removed-class references in code
- [x] **CLI snapshot** regenerated (`make snapshot-openapi && make generate`) — `cli/api/openapi.json` updated (403/409 + disable docstrings); `client.gen.go` unchanged (descriptions aren't emitted to Go comments)

## Out of scope

- The `list` endpoint's vendor filter (~lines 132-165 of `doc_collections.py`) is **sibling task #1568's** territory — confined my edits in that file to the module docstring + `disable_collection_endpoint` docstring only.
- The genuine entitlement-miss 403 (`CollectionForbiddenError`) — correct, untouched.

### Adjacent findings (recorded, not edited)

- `mcp/tools/docs.py` is 645 lines (pre-existing, > 600 block limit, flagged pre-existing by the diff-only quality gate); `_ask_docs_handler` / `_handle_single` / the resolver functions are slightly over the 60-line warn threshold (dominated by docstrings). Not introduced here.

<!-- auto-implement-issue: fresh, iteration 1 -->

Closes #1567
