### PR TITLE
fix(broadcast): restore mypy strict against redis-py 8 stub changes

### DIFF
--- a/backend/src/meho_backplane/broadcast/probe.py
+++ b/backend/src/meho_backplane/broadcast/probe.py
@@ -25,8 +25,6 @@ misconfigured tenants.
 from __future__ import annotations
 
 import logging
-from collections.abc import Awaitable
-from typing import cast
 
 from redis import exceptions as redis_exceptions
 
@@ -69,12 +67,11 @@ async def broadcast_readiness_probe() -> ProbeResult:
     """
     client = get_broadcast_client()
     try:
-        # redis-py's ``Redis.ping`` declares ``Awaitable[bool] | bool`` so
-        # the same class can serve both the sync and asyncio backends.
-        # Under :mod:`redis.asyncio` the runtime value is always the
-        # awaitable branch; the cast keeps strict mypy happy without
-        # widening the public surface.
-        await cast(Awaitable[bool], client.ping())
+        # redis-py 8's ``redis.asyncio`` stub types ``Redis.ping`` as a
+        # plain ``Awaitable[bool]`` (no longer the ``Awaitable[bool] | bool``
+        # union), so awaiting it directly type-checks under strict mypy --
+        # the earlier ``cast`` is now redundant.
+        await client.ping()
     except redis_exceptions.TimeoutError:
         return ProbeResult(name="broadcast", ok=False, detail="timeout")
     except redis_exceptions.ConnectionError as exc:

--- a/backend/src/meho_backplane/ui/routes/broadcast/stream.py
+++ b/backend/src/meho_backplane/ui/routes/broadcast/stream.py
@@ -109,6 +109,7 @@ def _stream_key(tenant_id: object) -> str:
     return f"meho:feed:{tenant_id}"
 
 
+# code-quality-allow: pre-existing SSE generator size/complexity; type-only redis-8 XREAD fix
 async def _ui_feed_generator(
     *,
     tenant_id: object,
@@ -196,8 +197,12 @@ async def _ui_feed_generator(
             if entries:
                 # redis-py returns ``[[stream_key, [(entry_id, fields), ...]], ...]``;
                 # we query exactly one stream, so ``entries[0][1]`` is
-                # this tenant's ``(entry_id, fields_dict)`` list.
-                _key, items = entries[0]
+                # this tenant's ``(entry_id, fields_dict)`` list. redis 8's
+                # stub widens the XREAD return type beyond an int-indexable
+                # outer list, so launder it to the known RESP2 shape here --
+                # exactly as ``_consume_xread_batch`` does for the API route.
+                typed_entries: list[tuple[str, list[tuple[str, dict[str, str]]]]] = entries  # type: ignore[assignment]
+                _key, items = typed_entries[0]
                 if items:
                     # Advance past EVERY consumed entry before the yield
                     # loop so a fully-filtered batch still moves the


### PR DESCRIPTION
## Why

The redis 7.4.0 → 8.0.0 bump (#1467) landed on `main` and turned the **`Python (ruff + mypy + pytest)`** check red — `Mypy (strict)` reports **7 errors in 2 files**. redis-py 8.0 reshaped its `redis.asyncio` type stubs:

- `Redis.ping` is now typed as a plain `Awaitable[bool]` (no longer the `Awaitable[bool] | bool` union), so the `cast(Awaitable[bool], …)` in `broadcast/probe.py` is now a **redundant-cast** error.
- `xread` widens its return type beyond an int-indexable outer list, so the inline `entries[0]` unpack in the UI broadcast SSE generator (`stream.py`) no longer type-checks (`index` / `assignment` / `arg-type` errors at lines 200–207).

This is a **type-only** breakage — the runtime contract is unchanged (redis-py still returns the RESP2 `[[stream_key, [(entry_id, fields), …]], …]` list at runtime); only the stubs moved.

## What

- **`broadcast/probe.py`** — drop the now-redundant `ping()` cast and its two unused imports (`cast`, `Awaitable`); await `client.ping()` directly.
- **`ui/routes/broadcast/stream.py`** — launder the `xread` result to its known RESP2 shape with the same annotated `# type: ignore[assignment]` pattern that `api/v1/feed.py`'s `_consume_xread_batch` already uses (the inline block was a copy of that logic — its own comment says it "mirrors the API route's M2 fix"). No behavior change: the cast is a no-op and `typed_entries` is a rebinding.

A `# code-quality-allow` marker is added on `_ui_feed_generator` because the function was **already** over the repo's local size/complexity hook limit (117 lines on `main`); this PR intentionally does not refactor a load-bearing SSE hot-path for a type-only fix.

## Verification (local, mirrors CI)

- `uv run ruff check src/…` → **All checks passed**
- `uv run ruff format` → unchanged
- `uv run mypy src/` (strict) → **Success: no issues found in 457 source files**
- `uv run pytest -k "broadcast or stream or probe"` → **53 passed, 1 skipped**

Restores green CI on `main`, which is currently blocking every other open PR.

🤖 Generated with [Claude Code](https://claude.com/claude-code)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Refactor**
  * Improved type compatibility and code clarity in broadcast streaming components by removing type-checking workarounds and simplifying return value handling.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->