### PR TITLE
feat(connectors): https-only spec guard + CLI content-upload on-ramp (#95 + #102)

### DIFF
--- a/backend/src/meho_backplane/operations/ingest/api_schemas.py
+++ b/backend/src/meho_backplane/operations/ingest/api_schemas.py
@@ -90,19 +90,20 @@ ConnectorStatusFilter = Literal["staged", "enabled", "disabled", "all"]
 class SpecSource(BaseModel):
     """One spec to ingest under a connector triple.
 
-    ``uri`` carries the operator's spec identifier. Two forms are
-    resolved by the underlying :func:`parse_openapi` resolver:
+    ``uri`` is the operator's spec identifier and audit label. When the
+    spec is *fetched* by the backend, only an ``https://`` URL is
+    accepted -- the G0.16-T8 (#95) SSRF / local-file guard rejects
+    ``http``, ``file://``, and bare paths so a spec URI cannot become a
+    network-topology or filesystem oracle.
 
-    * Absolute local path — ``/abs/path/to/spec.yaml`` (or its
-      ``file://`` URI form).
-    * HTTP(S) URL — ``https://api.example.com/openapi.yaml``.
-
-    The ``meho`` CLI additionally accepts a ``docs:<connector-id>/<file>``
-    shorthand, which it expands **CLI-side** to a ``file://`` URI against
-    ``$CLAUDE_RDC_DOCS`` before sending the request. The backend has no
-    docs root of its own, so a bare ``docs:`` URI that reaches the parser
-    unexpanded is rejected with :exc:`UnsupportedSpecError` naming the
-    scheme — the backend does not resolve ``docs:`` natively (#1535).
+    ``content`` carries the spec text inline. The ``meho`` CLI reads
+    ``docs:<connector-id>/<file>`` and ``file://`` sources **CLI-side**
+    and uploads the bytes here, leaving ``uri`` as the audit label, so
+    no local path or non-https scheme reaches the backend. When
+    ``content`` is set the backend uses it verbatim (size-capped) and
+    skips the fetch; when absent, ``uri`` is fetched under the https
+    guard. A bare ``docs:`` URI that reaches the backend with no
+    ``content`` is rejected with :exc:`UnsupportedSpecError` (#1535).
 
     Wrapped in its own model so future per-spec knobs (auth headers,
     dialect pinning, content-type override) can land without
@@ -115,6 +116,10 @@ class SpecSource(BaseModel):
     model_config = ConfigDict(frozen=True, extra="forbid")
 
     uri: str = Field(min_length=1, max_length=2048)
+    # Inline spec text uploaded by the CLI for docs:/file:// sources.
+    # ~20 MiB coarse char guard; the authoritative byte cap lives in
+    # openapi._load_spec_bytes.
+    content: str | None = Field(default=None, max_length=20 * 1024 * 1024)
 
 
 class IngestRequest(BaseModel):

--- a/backend/src/meho_backplane/operations/ingest/openapi.py
+++ b/backend/src/meho_backplane/operations/ingest/openapi.py
@@ -465,33 +465,39 @@ def _load_spec_bytes(spec_path_or_uri: str) -> bytes:
     current_url = spec_path_or_uri
     with httpx.Client(timeout=_HTTP_TIMEOUT, follow_redirects=False) as client:
         for _ in range(_MAX_REDIRECTS + 1):
-            response = client.get(current_url)
-            if response.has_redirect_location:
-                next_url = str(response.headers["location"])
-                # Re-validate the redirect target before following it so a
-                # 30x from a public host to a private IP is rejected here,
-                # before any socket is opened to the redirect target.
-                _assert_fetchable_remote_url(next_url)
-                current_url = next_url
-                continue
-            response.raise_for_status()
-            _reject_non_spec_content_type(
-                upstream_url=spec_path_or_uri,
-                content_type=response.headers.get("content-type"),
-            )
-            # Cap response size to guard against redirects to large
-            # internal endpoints exhausting pod memory.
-            chunks: list[bytes] = []
-            total = 0
-            for chunk in response.iter_bytes(chunk_size=65536):
-                total += len(chunk)
-                if total > _MAX_SPEC_BYTES:
-                    raise InvalidSpecError(
-                        f"spec response exceeds the {_MAX_SPEC_BYTES // (1024 * 1024)} MiB"
-                        " size limit"
-                    )
-                chunks.append(chunk)
-            return b"".join(chunks)
+            # Stream rather than buffer: ``client.get`` reads the whole
+            # body into memory before the size cap below can fire, which
+            # defeats the memory-exhaustion guard. ``stream`` lets the cap
+            # abort the read mid-flight; the ``with`` block closes the
+            # socket on the redirect ``continue``, the over-cap ``raise``,
+            # and the success ``return`` alike.
+            with client.stream("GET", current_url) as response:
+                if response.has_redirect_location:
+                    next_url = str(response.headers["location"])
+                    # Re-validate the redirect target before following it
+                    # so a 30x from a public host to a private IP is
+                    # rejected here, before a socket opens to the target.
+                    _assert_fetchable_remote_url(next_url)
+                    current_url = next_url
+                    continue
+                response.raise_for_status()
+                _reject_non_spec_content_type(
+                    upstream_url=spec_path_or_uri,
+                    content_type=response.headers.get("content-type"),
+                )
+                # Cap the body size as it streams in, so a redirect to a
+                # large internal endpoint can't exhaust pod memory.
+                chunks: list[bytes] = []
+                total = 0
+                for chunk in response.iter_bytes(chunk_size=65536):
+                    total += len(chunk)
+                    if total > _MAX_SPEC_BYTES:
+                        raise InvalidSpecError(
+                            f"spec response exceeds the {_MAX_SPEC_BYTES // (1024 * 1024)} MiB"
+                            " size limit"
+                        )
+                    chunks.append(chunk)
+                return b"".join(chunks)
         raise InvalidSpecError(f"spec URI followed more than {_MAX_REDIRECTS} redirects")
 
 

--- a/backend/src/meho_backplane/operations/ingest/openapi.py
+++ b/backend/src/meho_backplane/operations/ingest/openapi.py
@@ -198,6 +198,7 @@ def parse_openapi(
     spec_path_or_uri: str,
     *,
     spec_source: str | None = None,
+    content: str | None = None,
 ) -> list[EndpointDescriptorProto]:
     """Parse an OpenAPI 3.0 or 3.1 spec into a list of
     :class:`EndpointDescriptorProto` rows.
@@ -216,6 +217,10 @@ def parse_openapi(
             ``tags`` so operators can distinguish rows when a single
             connector ingests multiple specs (vCenter merges
             ``vcenter.yaml`` and ``vi-json.yaml``).
+        content: Optional inline spec text. When the CLI uploads it
+            for a ``docs:`` / ``file://`` source, it is used verbatim
+            instead of fetching *spec_path_or_uri*; the https-only SSRF
+            guard then applies only to the no-content (URL) path.
 
     Returns:
         A list of :class:`EndpointDescriptorProto`. One entry per
@@ -242,8 +247,8 @@ def parse_openapi(
         json.JSONDecodeError: Malformed JSON — bubbles up.
         httpx.HTTPError: HTTP fetch failure for URL inputs.
     """
-    content = _load_spec_bytes(spec_path_or_uri)
-    spec = _decode_spec(content)
+    spec_bytes = _load_spec_bytes(spec_path_or_uri, content=content)
+    spec = _decode_spec(spec_bytes)
     _validate_openapi_version(spec)
 
     paths = spec.get("paths")
@@ -289,7 +294,7 @@ def parse_openapi(
     )
 
 
-def read_spec_info_version(spec_path_or_uri: str) -> str | None:
+def read_spec_info_version(spec_path_or_uri: str, *, content: str | None = None) -> str | None:
     """Return the spec's ``info.version`` string, or ``None`` if absent.
 
     Lightweight companion to :func:`parse_openapi` for the ingest
@@ -307,6 +312,9 @@ def read_spec_info_version(spec_path_or_uri: str) -> str | None:
         spec_path_or_uri: ``https://`` URL — same scheme constraint
             as :func:`parse_openapi`. The SSRF/destination guard in
             :func:`_assert_fetchable_remote_url` fires here too.
+        content: Optional inline spec text, used verbatim when the CLI
+            uploaded it for a ``docs:`` / ``file://`` source -- same
+            semantics as :func:`parse_openapi`'s ``content``.
 
     Returns:
         The ``info.version`` string when present; ``None`` when
@@ -331,8 +339,8 @@ def read_spec_info_version(spec_path_or_uri: str) -> str | None:
         json.JSONDecodeError: Malformed JSON — bubbles up.
         httpx.HTTPError: HTTP fetch failure for URL inputs.
     """
-    content = _load_spec_bytes(spec_path_or_uri)
-    spec = _decode_spec(content)
+    spec_bytes = _load_spec_bytes(spec_path_or_uri, content=content)
+    spec = _decode_spec(spec_bytes)
     _validate_openapi_version(spec)
     info = spec.get("info")
     if not isinstance(info, dict):
@@ -410,40 +418,39 @@ def _assert_fetchable_remote_url(url: str) -> None:
             )
 
 
-def _load_spec_bytes(spec_path_or_uri: str) -> bytes:
-    """Resolve ``spec_path_or_uri`` to raw spec bytes.
+def _load_spec_bytes(spec_path_or_uri: str, content: str | None = None) -> bytes:
+    """Resolve a spec source to raw bytes: uploaded content, or an https fetch.
 
-    Only ``https://`` URIs are accepted. The destination is validated
-    via :func:`_assert_fetchable_remote_url` before any socket opens,
-    and again after every redirect hop, so a 30x chain cannot escape
-    the public-IP constraint by routing through a benign-looking host.
+    When *content* is provided, it is the inline spec text the CLI
+    uploaded for a ``docs:`` / ``file://`` source (so no local path or
+    non-https scheme reaches the backend). It is used verbatim -- capped
+    at :data:`_MAX_SPEC_BYTES`, no fetch, no scheme guard -- and
+    *spec_path_or_uri* serves only as the audit label.
 
-    Non-``https`` schemes (``http``, ``file://``, ``docs:``, bare paths)
-    raise an error with a terse, path-free message so the response is
-    not a filesystem or network-topology oracle. A bare ``docs:`` URI
-    (the CLI-side shorthand, normally expanded before the request
-    reaches the backend) is rejected with :exc:`UnsupportedSpecError`
-    naming the remedy rather than the generic scheme error.
-
-    After a 2xx response the ``Content-Type`` is inspected against the
-    spec allow-list; a non-spec media type raises
-    :exc:`UpstreamNotSpecError` so the operator sees a structured 422
-    rather than an opaque YAML parse error.
-
-    The response body is capped at :data:`_MAX_SPEC_BYTES` (20 MiB) so
-    a redirect to a large internal endpoint cannot exhaust pod memory.
+    Without *content*, *spec_path_or_uri* must be an ``https://`` URL: a
+    bare ``docs:`` shorthand (normally expanded CLI-side) is rejected
+    with :exc:`UnsupportedSpecError`, and the fetch + every other scheme
+    check is delegated to :func:`_fetch_spec_bytes`.
 
     Raises:
-        InvalidSpecError: Scheme is not ``https``, destination guard
-            fires (private/loopback/link-local/reserved IP), or the
-            response body exceeds the size cap.
+        InvalidSpecError: Non-https scheme, destination guard fires, or
+            the uploaded content / fetched body exceeds the size cap.
         UnsupportedSpecError: Bare ``docs:`` shorthand reached the
             backend unexpanded.
-        UpstreamNotSpecError: 2xx response with a non-spec
-            ``Content-Type``.
-        httpx.HTTPStatusError: Non-2xx HTTP response.
+        UpstreamNotSpecError: 2xx fetch with a non-spec ``Content-Type``.
         httpx.HTTPError: Network-level fetch failure.
     """
+    if content is not None:
+        # The CLI uploads the resolved bytes for ``docs:`` / ``file://``
+        # sources so no local path or non-https scheme reaches the
+        # backend; use them verbatim (still size-capped) and skip the
+        # fetch + scheme guard.
+        raw = content.encode("utf-8")
+        if len(raw) > _MAX_SPEC_BYTES:
+            raise InvalidSpecError(
+                f"spec content exceeds the {_MAX_SPEC_BYTES // (1024 * 1024)} MiB size limit"
+            )
+        return raw
     if urlparse(spec_path_or_uri).scheme == "docs":
         # The ``docs:<connector-id>/<file>`` shorthand is a CLI-side
         # convenience the CLI expands to a real URI against
@@ -460,6 +467,31 @@ def _load_spec_bytes(spec_path_or_uri: str) -> bytes:
             f"the request reaches the backend. Set $CLAUDE_RDC_DOCS so "
             f"the CLI resolves it, or pass an 'https://' spec URI.",
         )
+    return _fetch_spec_bytes(spec_path_or_uri)
+
+
+def _fetch_spec_bytes(spec_path_or_uri: str) -> bytes:
+    """Fetch + size-cap the spec body from an ``https://`` URL.
+
+    Only ``https://`` is accepted: the destination is validated via
+    :func:`_assert_fetchable_remote_url` before any socket opens, and
+    again after every redirect hop, so a 30x chain cannot escape the
+    public-IP constraint by routing through a benign-looking host.
+
+    After a 2xx response the ``Content-Type`` is inspected against the
+    spec allow-list; a non-spec media type raises
+    :exc:`UpstreamNotSpecError`. The body is streamed and capped at
+    :data:`_MAX_SPEC_BYTES` (20 MiB) so a redirect to a large internal
+    endpoint cannot exhaust pod memory.
+
+    Raises:
+        InvalidSpecError: Scheme is not ``https``, destination guard
+            fires (private/loopback/link-local/reserved IP), or the
+            response body exceeds the size cap.
+        UpstreamNotSpecError: 2xx response with a non-spec ``Content-Type``.
+        httpx.HTTPStatusError: Non-2xx HTTP response.
+        httpx.HTTPError: Network-level fetch failure.
+    """
     _assert_fetchable_remote_url(spec_path_or_uri)
 
     current_url = spec_path_or_uri

--- a/backend/src/meho_backplane/operations/ingest/openapi.py
+++ b/backend/src/meho_backplane/operations/ingest/openapi.py
@@ -51,10 +51,11 @@ collision; T1 produces what the spec literally says.
 from __future__ import annotations
 
 import io
+import ipaddress
 import json
 import re
+import socket
 from collections.abc import Iterable
-from pathlib import Path
 from typing import Any, cast
 from urllib.parse import urlparse
 
@@ -141,6 +142,17 @@ _DANGEROUS_VERBS = frozenset({"DELETE"})
 # pathological cases from hanging an ingest.
 _HTTP_TIMEOUT = httpx.Timeout(30.0, connect=10.0)
 
+# Maximum number of redirect hops the spec fetcher will follow. Each hop
+# is re-validated against the destination guard before the next request
+# fires, so a chain longer than this cap is rejected with InvalidSpecError.
+_MAX_REDIRECTS = 5
+
+# Hard cap on spec response body size. OpenAPI specs for the largest VMware
+# suites (vi-json.yaml) run to ~10 MB; 20 MB gives comfortable headroom
+# while preventing a redirect to a large internal endpoint from exhausting
+# pod memory.
+_MAX_SPEC_BYTES = 20 * 1024 * 1024  # 20 MiB
+
 
 # Content-Type prefixes the upstream-fetch path accepts as spec-shaped.
 # OpenAPI specs are served as ``application/json`` (the modern default),
@@ -191,7 +203,14 @@ def parse_openapi(
     :class:`EndpointDescriptorProto` rows.
 
     Args:
-        spec_path_or_uri: Local file path or ``http(s)://`` URL.
+        spec_path_or_uri: ``https://`` URL pointing at the spec.
+            Only the ``https`` scheme is accepted on the
+            network-facing ingest path; non-``https`` URIs
+            (including ``http://``, ``file://``, and bare paths)
+            raise :exc:`InvalidSpecError`. The destination is
+            validated against the SSRF guard in
+            :func:`_assert_fetchable_remote_url` before any
+            network connection is opened.
         spec_source: Optional logical-source tag (e.g.
             ``"spec:vcenter.yaml"``) injected into each row's
             ``tags`` so operators can distinguish rows when a single
@@ -206,12 +225,9 @@ def parse_openapi(
 
     Raises:
         InvalidSpecError: Document is not a mapping, lacks ``paths``,
-            or the local file referenced by ``spec_path_or_uri`` cannot
-            be read (missing / not a regular file / permission denied).
-            Local-file OS errors are re-raised as ``InvalidSpecError``
-            so callers see one parser-shaped error type; HTTP fetch
-            failures still bubble as ``httpx.HTTPError`` because those
-            are a transport concern.
+            the URI scheme is not ``https``, or the resolved
+            destination is a private/loopback/link-local/reserved
+            address.
         UnsupportedSpecError: Spec version is not 3.0.x / 3.1.x, or the
             document references a cross-document ``$ref``.
         UpstreamNotSpecError: HTTP fetch succeeded (2xx) but the
@@ -288,8 +304,9 @@ def read_spec_info_version(spec_path_or_uri: str) -> str | None:
     classification ladder against the operator-supplied label.
 
     Args:
-        spec_path_or_uri: Local file path or ``http(s)://`` URL —
-            same shapes accepted by :func:`parse_openapi`.
+        spec_path_or_uri: ``https://`` URL — same scheme constraint
+            as :func:`parse_openapi`. The SSRF/destination guard in
+            :func:`_assert_fetchable_remote_url` fires here too.
 
     Returns:
         The ``info.version`` string when present; ``None`` when
@@ -300,9 +317,9 @@ def read_spec_info_version(spec_path_or_uri: str) -> str | None:
         operator label.
 
     Raises:
-        InvalidSpecError: Document is not a mapping, or the file
-            referenced by ``spec_path_or_uri`` cannot be read. Same
-            shape :func:`parse_openapi` raises.
+        InvalidSpecError: Document is not a mapping, URI scheme is not
+            ``https``, or destination guard fires. Same shape
+            :func:`parse_openapi` raises.
         UnsupportedSpecError: Spec version is not 3.0.x / 3.1.x — the
             same gate the parser enforces; surfaced here so callers
             can fail fast before touching ``info.version``.
@@ -326,79 +343,156 @@ def read_spec_info_version(spec_path_or_uri: str) -> str | None:
     return version
 
 
+def _assert_fetchable_remote_url(url: str) -> None:
+    """Validate that ``url`` is safe to fetch from the backplane's network position.
+
+    Enforces two invariants before any socket is opened:
+
+    1. **Scheme allowlist** — only ``https`` is permitted on the
+       network-facing ingest path. ``http`` is rejected because it
+       cannot protect the transport and is indistinguishable from a
+       redirect-bypass target after a single 30x hop. ``file://``,
+       bare paths, and every other scheme are rejected because no
+       local-file read is reachable from the API/MCP-driven
+       ``IngestRequest.uri``.
+
+    2. **Destination guard** — the hostname is resolved via
+       ``socket.getaddrinfo`` and every returned address is checked
+       with :mod:`ipaddress`. Any candidate that is private,
+       loopback, link-local, ULA, unspecified, multicast, or
+       otherwise reserved triggers immediate rejection. This covers
+       at minimum ``127.0.0.0/8``, ``10.0.0.0/8``,
+       ``172.16.0.0/12``, ``192.168.0.0/16``, ``169.254.0.0/16``
+       (cloud metadata), ``::1``, ``fc00::/7``, ``fe80::/10``.
+
+    The same check is called for every redirect hop in
+    :func:`_load_spec_bytes` so a benign-looking initial host cannot
+    30x-redirect the fetcher into an internal address.
+
+    Args:
+        url: The full URL to validate (scheme + host + path).
+
+    Raises:
+        InvalidSpecError: Scheme is not ``https``, the hostname is
+            absent or unresolvable, or any resolved address is
+            non-public. The message is intentionally terse and
+            path-free so the response is not a network-topology
+            oracle for the caller.
+    """
+    parsed = urlparse(url)
+    if parsed.scheme != "https":
+        raise InvalidSpecError(f"spec URI must use the https scheme; got {parsed.scheme!r}")
+    hostname = parsed.hostname
+    if not hostname:
+        raise InvalidSpecError("spec URI must include a hostname")
+    try:
+        addr_infos = socket.getaddrinfo(hostname, None, type=socket.SOCK_STREAM)
+    except socket.gaierror as exc:
+        raise InvalidSpecError("spec URI hostname could not be resolved") from exc
+    if not addr_infos:
+        raise InvalidSpecError("spec URI hostname resolved to no addresses")
+    for _family, _type, _proto, _canonname, sockaddr in addr_infos:
+        raw_ip = sockaddr[0]
+        try:
+            addr = ipaddress.ip_address(raw_ip)
+        except ValueError as exc:
+            raise InvalidSpecError("spec URI resolved to an unrecognised address format") from exc
+        if (
+            addr.is_private
+            or addr.is_loopback
+            or addr.is_link_local
+            or addr.is_reserved
+            or addr.is_multicast
+            or addr.is_unspecified
+        ):
+            raise InvalidSpecError(
+                "spec URI resolves to a non-public address; remote fetch refused"
+            )
+
+
 def _load_spec_bytes(spec_path_or_uri: str) -> bytes:
     """Resolve ``spec_path_or_uri`` to raw spec bytes.
 
-    Local-file inputs are read in binary mode so YAML's BOM handling
-    + UTF-8 decoding stay inside the loader; missing files /
-    permission errors raise :exc:`InvalidSpecError` with the original
-    OS error chained via ``from`` so callers see a single
-    parser-shaped error type. HTTP(S) inputs are fetched with httpx
-    and a 30 s timeout; non-2xx responses raise
-    :exc:`httpx.HTTPStatusError` (an :exc:`httpx.HTTPError` subclass)
-    unwrapped — fetch failures are a transport concern, not a spec
-    concern.
+    Only ``https://`` URIs are accepted. The destination is validated
+    via :func:`_assert_fetchable_remote_url` before any socket opens,
+    and again after every redirect hop, so a 30x chain cannot escape
+    the public-IP constraint by routing through a benign-looking host.
 
-    After a 2xx HTTP fetch we additionally inspect ``Content-Type``: a
-    non-spec media type (HTML developer portal, generic
-    ``application/octet-stream``, etc.) raises
-    :exc:`UpstreamNotSpecError` instead of falling through to YAML
-    decoding. Local files are not gated on content-type — the operator
-    chose the path and a stray ``.html`` next to ``.yaml`` is on them
-    to notice; the YAML / JSON decoder still produces a usable error
-    in that case. The HTTP gate exists because catalog-driven ingest
-    against the Broadcom Developer Portal (vmware/9.0, sddc-manager/9.0)
-    returned HTML and surfaced as a useless YAML parse error at line 33.
+    Non-``https`` schemes (``http``, ``file://``, ``docs:``, bare paths)
+    raise an error with a terse, path-free message so the response is
+    not a filesystem or network-topology oracle. A bare ``docs:`` URI
+    (the CLI-side shorthand, normally expanded before the request
+    reaches the backend) is rejected with :exc:`UnsupportedSpecError`
+    naming the remedy rather than the generic scheme error.
 
-    The ``docs:<connector-id>/<file>`` shorthand is rejected with
-    :exc:`UnsupportedSpecError` naming the scheme: it is a CLI-side
-    convenience expanded to ``file://`` against ``$CLAUDE_RDC_DOCS``
-    before the request reaches the backend, which has no docs root of
-    its own. Rejecting it explicitly stops a bare ``docs:`` URI from
-    falling through to ``Path("docs:…")`` and surfacing as an opaque
-    ``InvalidSpecError`` that reads like a missing local file.
+    After a 2xx response the ``Content-Type`` is inspected against the
+    spec allow-list; a non-spec media type raises
+    :exc:`UpstreamNotSpecError` so the operator sees a structured 422
+    rather than an opaque YAML parse error.
+
+    The response body is capped at :data:`_MAX_SPEC_BYTES` (20 MiB) so
+    a redirect to a large internal endpoint cannot exhaust pod memory.
+
+    Raises:
+        InvalidSpecError: Scheme is not ``https``, destination guard
+            fires (private/loopback/link-local/reserved IP), or the
+            response body exceeds the size cap.
+        UnsupportedSpecError: Bare ``docs:`` shorthand reached the
+            backend unexpanded.
+        UpstreamNotSpecError: 2xx response with a non-spec
+            ``Content-Type``.
+        httpx.HTTPStatusError: Non-2xx HTTP response.
+        httpx.HTTPError: Network-level fetch failure.
     """
-    parsed = urlparse(spec_path_or_uri)
-    if parsed.scheme in {"http", "https"}:
-        response = httpx.get(spec_path_or_uri, timeout=_HTTP_TIMEOUT, follow_redirects=True)
-        response.raise_for_status()
-        _reject_non_spec_content_type(
-            upstream_url=spec_path_or_uri,
-            content_type=response.headers.get("content-type"),
-        )
-        return response.content
-    if parsed.scheme == "docs":
-        # The ``docs:<connector-id>/<file>`` shorthand is a *CLI-side*
-        # convenience: the CLI expands it to a ``file://`` URI against
-        # ``$CLAUDE_RDC_DOCS`` before the request reaches the backend.
-        # The backend has no docs root of its own, so a bare ``docs:``
-        # URI that survives to here was never expandable. Reject it as
-        # an unsupported scheme that names itself + the remedy, rather
-        # than letting it fall through to ``Path("docs:…")`` and surface
-        # as an opaque ``InvalidSpecError`` that reads like a missing
-        # file. ``UnsupportedSpecError`` (not ``InvalidSpecError``) keeps
-        # this on the "known shape the resolver doesn't ingest" ladder
-        # alongside Swagger 2.0 / cross-document ``$ref``.
+    if urlparse(spec_path_or_uri).scheme == "docs":
+        # The ``docs:<connector-id>/<file>`` shorthand is a CLI-side
+        # convenience the CLI expands to a real URI against
+        # ``$CLAUDE_RDC_DOCS`` before the request reaches the backend,
+        # which has no docs root of its own. A bare ``docs:`` URI that
+        # survives to here was never expandable; reject it as an
+        # unsupported scheme that names the remedy rather than letting
+        # it fall through to the https guard and surface as a generic
+        # scheme error.
         raise UnsupportedSpecError(
             f"the 'docs:' spec-source scheme is not resolvable by the "
             f"backplane (got {spec_path_or_uri!r}); it is a CLI-side "
-            f"shorthand that the CLI expands to a 'file://' URI against "
-            f"$CLAUDE_RDC_DOCS. Set $CLAUDE_RDC_DOCS so the CLI resolves "
-            f"it, or pass an absolute 'file://' / 'https://' spec URI.",
+            f"shorthand the CLI expands against $CLAUDE_RDC_DOCS before "
+            f"the request reaches the backend. Set $CLAUDE_RDC_DOCS so "
+            f"the CLI resolves it, or pass an 'https://' spec URI.",
         )
-    # Treat everything else as a local file path. ``Path`` handles
-    # both relative and absolute paths cleanly; ``file://`` URIs go
-    # through ``url2pathname`` for cross-platform correctness.
-    if parsed.scheme == "file":
-        from urllib.request import url2pathname
+    _assert_fetchable_remote_url(spec_path_or_uri)
 
-        path = Path(url2pathname(parsed.path))
-    else:
-        path = Path(spec_path_or_uri)
-    try:
-        return path.read_bytes()
-    except (FileNotFoundError, IsADirectoryError, PermissionError, OSError) as exc:
-        raise InvalidSpecError(f"could not read spec from {spec_path_or_uri!r}: {exc}") from exc
+    current_url = spec_path_or_uri
+    with httpx.Client(timeout=_HTTP_TIMEOUT, follow_redirects=False) as client:
+        for _ in range(_MAX_REDIRECTS + 1):
+            response = client.get(current_url)
+            if response.has_redirect_location:
+                next_url = str(response.headers["location"])
+                # Re-validate the redirect target before following it so a
+                # 30x from a public host to a private IP is rejected here,
+                # before any socket is opened to the redirect target.
+                _assert_fetchable_remote_url(next_url)
+                current_url = next_url
+                continue
+            response.raise_for_status()
+            _reject_non_spec_content_type(
+                upstream_url=spec_path_or_uri,
+                content_type=response.headers.get("content-type"),
+            )
+            # Cap response size to guard against redirects to large
+            # internal endpoints exhausting pod memory.
+            chunks: list[bytes] = []
+            total = 0
+            for chunk in response.iter_bytes(chunk_size=65536):
+                total += len(chunk)
+                if total > _MAX_SPEC_BYTES:
+                    raise InvalidSpecError(
+                        f"spec response exceeds the {_MAX_SPEC_BYTES // (1024 * 1024)} MiB"
+                        " size limit"
+                    )
+                chunks.append(chunk)
+            return b"".join(chunks)
+        raise InvalidSpecError(f"spec URI followed more than {_MAX_REDIRECTS} redirects")
 
 
 def _reject_non_spec_content_type(

--- a/backend/src/meho_backplane/operations/ingest/openapi.py
+++ b/backend/src/meho_backplane/operations/ingest/openapi.py
@@ -57,7 +57,7 @@ import re
 import socket
 from collections.abc import Iterable
 from typing import Any, cast
-from urllib.parse import urlparse
+from urllib.parse import urljoin, urlparse
 
 import httpx
 import yaml
@@ -505,10 +505,13 @@ def _fetch_spec_bytes(spec_path_or_uri: str) -> bytes:
             # and the success ``return`` alike.
             with client.stream("GET", current_url) as response:
                 if response.has_redirect_location:
-                    next_url = str(response.headers["location"])
-                    # Re-validate the redirect target before following it
-                    # so a 30x from a public host to a private IP is
-                    # rejected here, before a socket opens to the target.
+                    # Resolve relative / protocol-relative Location headers
+                    # against the current URL so a valid 30x to a relative
+                    # path isn't rejected by the https-only guard.
+                    next_url = urljoin(current_url, str(response.headers["location"]))
+                    # Re-validate the (now absolute) redirect target before
+                    # following it so a 30x to a private IP is rejected here,
+                    # before a socket opens to it.
                     _assert_fetchable_remote_url(next_url)
                     current_url = next_url
                     continue

--- a/backend/src/meho_backplane/operations/ingest/pipeline.py
+++ b/backend/src/meho_backplane/operations/ingest/pipeline.py
@@ -522,7 +522,7 @@ class IngestionPipelineService:
         per_spec: list[tuple[str, str | None]] = []
         mismatches: list[tuple[str, str | None]] = []
         for spec in specs:
-            info_version = read_spec_info_version(spec.uri)
+            info_version = read_spec_info_version(spec.uri, content=spec.content)
             per_spec.append((spec.uri, info_version))
             if info_version is None:
                 # No info.version → no cross-check possible. Operators
@@ -765,7 +765,9 @@ class IngestionPipelineService:
             # extra synchronisation. Yielding the loop between specs
             # lets the request handler return its 202 + handle inside
             # the kubelet liveness-probe budget.
-            parsed = await asyncio.to_thread(parse_openapi, spec.uri, spec_source=spec.uri)
+            parsed = await asyncio.to_thread(
+                parse_openapi, spec.uri, spec_source=spec.uri, content=spec.content
+            )
             total_ops += len(parsed)
         ingestion = IngestionResult(
             inserted_count=total_ops,
@@ -819,7 +821,9 @@ class IngestionPipelineService:
             # this hop). ``register_ingested_operations`` is already
             # an async coroutine that yields on every DB write so
             # it doesn't need the same treatment.
-            protos = await asyncio.to_thread(parse_openapi, spec.uri, spec_source=spec.uri)
+            protos = await asyncio.to_thread(
+                parse_openapi, spec.uri, spec_source=spec.uri, content=spec.content
+            )
             partial = await register_ingested_operations(
                 product=product,
                 version=version,

--- a/backend/tests/integration/test_operations_ingest_vcenter.py
+++ b/backend/tests/integration/test_operations_ingest_vcenter.py
@@ -20,6 +20,13 @@ predate T8's provisioning stay green. The unit-test fixtures cover
 contract behaviour; this test only asserts the parser scales to the
 real spec corpus per the Initiative's acceptance criterion ("≥95% of
 paths produce a row with non-null parameter_schema").
+
+G0.16-T8 (#95): the fetcher now accepts only ``https://`` URIs. When the
+resolver returns a local filesystem path the test wraps the file content
+in a respx-mocked HTTPS endpoint so the guard is exercised on real spec
+bytes without requiring an outbound network connection. HTTPS URLs
+(including ``http://`` env-var values) are rejected — set MEHO_VCENTER_OPENAPI
+to an ``https://`` URL or a local path; ``http://`` is no longer accepted.
 """
 
 from __future__ import annotations
@@ -27,7 +34,9 @@ from __future__ import annotations
 import os
 from pathlib import Path
 
+import httpx
 import pytest
+import respx
 
 from meho_backplane.operations.ingest import parse_openapi
 
@@ -35,14 +44,18 @@ from meho_backplane.operations.ingest import parse_openapi
 def _resolve_vcenter_spec() -> str | None:
     """Resolve the vCenter spec from env vars.
 
-    Returns either an ``http(s)://`` URL or a local filesystem path,
-    both of which ``parse_openapi`` accepts. ``None`` when no source
-    is configured — the integration test skips in that case.
+    Returns an ``https://`` URL or a local filesystem path.
+    ``None`` when no source is configured — the integration test skips
+    in that case. ``http://`` URLs are no longer accepted (the fetcher
+    requires ``https``).
     """
     explicit = os.getenv("MEHO_VCENTER_OPENAPI")
     if explicit:
-        if explicit.startswith(("http://", "https://")):
+        if explicit.startswith("https://"):
             return explicit
+        if explicit.startswith("http://"):
+            # http:// no longer accepted — skip gracefully.
+            return None
         candidate = Path(explicit)
         if candidate.exists():
             return str(candidate)
@@ -57,15 +70,32 @@ def _resolve_vcenter_spec() -> str | None:
 @pytest.mark.skipif(
     _resolve_vcenter_spec() is None,
     reason=(
-        "vcenter.yaml unavailable — set MEHO_VCENTER_OPENAPI or MEHO_CONSUMER_DOCS_ROOT. "
+        "vcenter.yaml unavailable — set MEHO_VCENTER_OPENAPI (https:// URL or local path) "
+        "or MEHO_CONSUMER_DOCS_ROOT. "
         "The unit-test fixtures cover the parser contract; this integration test only "
         "verifies the parser scales to the real spec corpus."
     ),
 )
 def test_parse_vcenter_meets_path_coverage_threshold() -> None:
-    spec_path = _resolve_vcenter_spec()
-    assert spec_path is not None  # guarded by skipif above
-    rows = parse_openapi(spec_path, spec_source="spec:vcenter.yaml")
+    spec_source = _resolve_vcenter_spec()
+    assert spec_source is not None  # guarded by skipif above
+
+    if spec_source.startswith("https://"):
+        rows = parse_openapi(spec_source, spec_source="spec:vcenter.yaml")
+    else:
+        # Local filesystem path — serve via respx mock to satisfy the https guard.
+        spec_bytes = Path(spec_source).read_bytes()
+        spec_url = "https://specs.example.test/vcenter.yaml"
+        with respx.mock(assert_all_called=False) as router:
+            router.get(spec_url).mock(
+                return_value=httpx.Response(
+                    200,
+                    content=spec_bytes,
+                    headers={"content-type": "application/yaml"},
+                )
+            )
+            rows = parse_openapi(spec_url, spec_source="spec:vcenter.yaml")
+
     distinct_paths = {row.path for row in rows}
     assert len(rows) >= 950, f"got {len(rows)} rows; acceptance threshold is 950"
     assert len(distinct_paths) >= 950, (

--- a/backend/tests/integration/test_operations_ingest_vcenter.py
+++ b/backend/tests/integration/test_operations_ingest_vcenter.py
@@ -34,9 +34,7 @@ from __future__ import annotations
 import os
 from pathlib import Path
 
-import httpx
 import pytest
-import respx
 
 from meho_backplane.operations.ingest import parse_openapi
 
@@ -83,18 +81,11 @@ def test_parse_vcenter_meets_path_coverage_threshold() -> None:
     if spec_source.startswith("https://"):
         rows = parse_openapi(spec_source, spec_source="spec:vcenter.yaml")
     else:
-        # Local filesystem path — serve via respx mock to satisfy the https guard.
-        spec_bytes = Path(spec_source).read_bytes()
-        spec_url = "https://specs.example.test/vcenter.yaml"
-        with respx.mock(assert_all_called=False) as router:
-            router.get(spec_url).mock(
-                return_value=httpx.Response(
-                    200,
-                    content=spec_bytes,
-                    headers={"content-type": "application/yaml"},
-                )
-            )
-            rows = parse_openapi(spec_url, spec_source="spec:vcenter.yaml")
+        # Local filesystem path — upload the bytes via the content channel
+        # (mirrors how the CLI uploads docs:/file:// specs), so the https
+        # guard + DNS lookup are skipped without a respx mock.
+        spec_text = Path(spec_source).read_text()
+        rows = parse_openapi(spec_source, spec_source="spec:vcenter.yaml", content=spec_text)
 
     distinct_paths = {row.path for row in rows}
     assert len(rows) >= 950, f"got {len(rows)} rows; acceptance threshold is 950"

--- a/backend/tests/integration/test_operations_ingest_vi_json.py
+++ b/backend/tests/integration/test_operations_ingest_vi_json.py
@@ -29,9 +29,7 @@ from __future__ import annotations
 
 from pathlib import Path
 
-import httpx
 import pytest
-import respx
 
 from meho_backplane.operations.ingest import parse_openapi
 from tests.acceptance._vcenter_spec import VCENTER_SPEC_REASON, resolve_vi_json_yaml
@@ -50,19 +48,11 @@ def test_parse_vi_json_does_not_raise() -> None:
         # Already a public HTTPS URL — fetch directly; no mock needed.
         rows = parse_openapi(spec_source_raw, spec_source="spec:vi-json.yaml")
     else:
-        # Local filesystem path — serve the file bytes through a respx mock so
-        # the SSRF guard's scheme check passes (guard requires https://).
-        spec_bytes = Path(spec_source_raw).read_bytes()
-        spec_url = "https://specs.example.test/vi-json.yaml"
-        with respx.mock(assert_all_called=False) as router:
-            router.get(spec_url).mock(
-                return_value=httpx.Response(
-                    200,
-                    content=spec_bytes,
-                    headers={"content-type": "application/yaml"},
-                )
-            )
-            rows = parse_openapi(spec_url, spec_source="spec:vi-json.yaml")
+        # Local filesystem path — upload the bytes via the content channel
+        # (mirrors how the CLI uploads docs:/file:// specs), so the https
+        # guard + DNS lookup are skipped without a respx mock.
+        spec_text = Path(spec_source_raw).read_text()
+        rows = parse_openapi(spec_source_raw, spec_source="spec:vi-json.yaml", content=spec_text)
 
     assert len(rows) >= 2000, f"got {len(rows)} rows; acceptance threshold is 2000"
     # Spot-check the parameter-ref resolution path: every row that

--- a/backend/tests/integration/test_operations_ingest_vi_json.py
+++ b/backend/tests/integration/test_operations_ingest_vi_json.py
@@ -18,11 +18,20 @@ Skipped when no spec source is configured, mirroring the
 ``vcenter.yaml`` integration test next door. Storage + grouping +
 retrieval are downstream Tasks (T3 under #227 G3.1); this test only
 asserts the parser does not raise.
+
+G0.16-T8 (#95): the fetcher now accepts only ``https://`` URIs. When the
+resolver returns a local filesystem path the test wraps the file content
+in a respx-mocked HTTPS endpoint so the guard is exercised on real spec
+bytes without requiring an outbound network connection.
 """
 
 from __future__ import annotations
 
+from pathlib import Path
+
+import httpx
 import pytest
+import respx
 
 from meho_backplane.operations.ingest import parse_openapi
 from tests.acceptance._vcenter_spec import VCENTER_SPEC_REASON, resolve_vi_json_yaml
@@ -34,9 +43,27 @@ from tests.acceptance._vcenter_spec import VCENTER_SPEC_REASON, resolve_vi_json_
 )
 def test_parse_vi_json_does_not_raise() -> None:
     """vi-json.yaml parses end-to-end after T11's parameter-ref resolver landed."""
-    spec_path = resolve_vi_json_yaml()
-    assert spec_path is not None  # guarded by skipif above
-    rows = parse_openapi(str(spec_path), spec_source="spec:vi-json.yaml")
+    spec_source_raw = resolve_vi_json_yaml()
+    assert spec_source_raw is not None  # guarded by skipif above
+
+    if spec_source_raw.startswith("https://"):
+        # Already a public HTTPS URL — fetch directly; no mock needed.
+        rows = parse_openapi(spec_source_raw, spec_source="spec:vi-json.yaml")
+    else:
+        # Local filesystem path — serve the file bytes through a respx mock so
+        # the SSRF guard's scheme check passes (guard requires https://).
+        spec_bytes = Path(spec_source_raw).read_bytes()
+        spec_url = "https://specs.example.test/vi-json.yaml"
+        with respx.mock(assert_all_called=False) as router:
+            router.get(spec_url).mock(
+                return_value=httpx.Response(
+                    200,
+                    content=spec_bytes,
+                    headers={"content-type": "application/yaml"},
+                )
+            )
+            rows = parse_openapi(spec_url, spec_source="spec:vi-json.yaml")
+
     assert len(rows) >= 2000, f"got {len(rows)} rows; acceptance threshold is 2000"
     # Spot-check the parameter-ref resolution path: every row that
     # carries an ``moId`` property must have ``x-meho-param-loc="path"``

--- a/backend/tests/test_api_v1_connectors_ingest.py
+++ b/backend/tests/test_api_v1_connectors_ingest.py
@@ -33,8 +33,10 @@ stub so the ingest test paths don't need a real Anthropic key.
 
 from __future__ import annotations
 
+import socket
 import uuid
 from collections.abc import Iterator
+from pathlib import Path
 from typing import Any
 from unittest.mock import AsyncMock, patch
 from uuid import UUID
@@ -138,6 +140,85 @@ def _reset_ingest_job_registry() -> Iterator[None]:
     reset_job_registry_for_tests()
     yield
     reset_job_registry_for_tests()
+
+
+# ---------------------------------------------------------------------------
+# SSRF guard helpers (G0.16-T8, #95)
+# ---------------------------------------------------------------------------
+
+# A public IP used for mock getaddrinfo responses — ``93.184.216.34`` is
+# IANA's example.com assignment; it is globally routable and non-special
+# per the ipaddress module so the SSRF destination guard passes.
+_INGEST_TEST_PUBLIC_IP = "93.184.216.34"
+
+# Hostname for all spec mock endpoints in this module.
+_SPEC_HOST = "specs.example.test"
+_SPEC_BASE = f"https://{_SPEC_HOST}"
+
+# All test hostnames that must resolve to a public IP via the mock.
+_INGEST_TEST_HOSTS = frozenset(
+    {
+        "specs.example.test",
+        "example.lab",
+        "developer.broadcom.com",
+        "keycloak.test",
+        "vault.test",
+    }
+)
+
+
+def _ingest_getaddrinfo(
+    host: str, port: object, **kwargs: object
+) -> list[tuple[int, int, int, str, tuple[str, int]]]:
+    """Mock for ``socket.getaddrinfo`` in the SSRF guard.
+
+    Returns a public IP for test hostnames so the destination guard
+    accepts them; delegates to the real function for everything else so
+    that the discovery/JWKS mock routes wired by respx still resolve.
+    """
+    if host in _INGEST_TEST_HOSTS:
+        return [(socket.AF_INET, socket.SOCK_STREAM, 0, "", (_INGEST_TEST_PUBLIC_IP, 443))]
+    return socket.getaddrinfo(host, port, **kwargs)  # type: ignore[arg-type]
+
+
+@pytest.fixture(autouse=True)
+def _mock_ssrf_getaddrinfo() -> Iterator[None]:
+    """Patch the SSRF guard's getaddrinfo for the duration of every test.
+
+    Since G0.16-T8 (#95) the spec fetcher resolves the hostname before
+    opening any socket. Tests that pass ``https://specs.example.test/…``
+    URIs would fail DNS resolution without this patch.
+    """
+    with patch(
+        "meho_backplane.operations.ingest.openapi.socket.getaddrinfo",
+        side_effect=_ingest_getaddrinfo,
+    ):
+        yield
+
+
+def _register_spec_at_https(
+    router: respx.MockRouter,
+    spec_path: Path,
+    *,
+    path: str = "spec.yaml",
+    content_type: str = "application/yaml",
+) -> str:
+    """Register spec file content at an HTTPS mock URL and return the URL.
+
+    Reads ``spec_path`` from disk, registers the bytes at
+    ``https://specs.example.test/<path>`` on ``router``, and returns
+    the URL. All ingest tests that formerly passed a local file path to
+    the ``uri`` field now call this helper instead.
+    """
+    url = f"{_SPEC_BASE}/{path}"
+    router.get(url).mock(
+        return_value=httpx.Response(
+            200,
+            content=spec_path.read_bytes(),
+            headers={"content-type": content_type},
+        )
+    )
+    return url
 
 
 @pytest.fixture
@@ -1666,13 +1747,14 @@ paths:
         ),
     ):
         _mock_discovery_and_jwks(mock_router, _public_jwks(key))
+        spec_url = _register_spec_at_https(mock_router, spec_path, path="spec-503.yaml")
         response = client.post(
             "/api/v1/connectors/ingest",
             json={
                 "product": "test",
                 "version": "1.0",
                 "impl_id": "test-impl",
-                "specs": [{"uri": str(spec_path)}],
+                "specs": [{"uri": spec_url}],
                 "async": False,
             },
             headers=_authed(token),
@@ -1715,13 +1797,14 @@ paths:
     key, token = _admin_token()
     with respx.mock as mock_router:
         _mock_discovery_and_jwks(mock_router, _public_jwks(key))
+        spec_url = _register_spec_at_https(mock_router, spec_path, path="spec-dryrun.yaml")
         response = client.post(
             "/api/v1/connectors/ingest",
             json={
                 "product": "test",
                 "version": "1.0",
                 "impl_id": "test-impl",
-                "specs": [{"uri": str(spec_path)}],
+                "specs": [{"uri": spec_url}],
                 "dry_run": True,
             },
             headers=_authed(token),
@@ -1795,13 +1878,14 @@ paths:
         ),
     ):
         _mock_discovery_and_jwks(mock_router, _public_jwks(key))
+        spec_url = _register_spec_at_https(mock_router, spec_path, path="spec-happy.yaml")
         response = client.post(
             "/api/v1/connectors/ingest",
             json={
                 "product": "test",
                 "version": "1.0",
                 "impl_id": "test-impl",
-                "specs": [{"uri": str(spec_path)}],
+                "specs": [{"uri": spec_url}],
                 "async": False,
             },
             headers=_authed(token),
@@ -1827,13 +1911,14 @@ def test_ingest_bad_spec_returns_400(client: TestClient, tmp_path: Any) -> None:
     key, token = _admin_token()
     with respx.mock as mock_router:
         _mock_discovery_and_jwks(mock_router, _public_jwks(key))
+        spec_url = _register_spec_at_https(mock_router, spec_path, path="bad-spec.yaml")
         response = client.post(
             "/api/v1/connectors/ingest",
             json={
                 "product": "test",
                 "version": "1.0",
                 "impl_id": "test-impl",
-                "specs": [{"uri": str(spec_path)}],
+                "specs": [{"uri": spec_url}],
                 "async": False,
             },
             headers=_authed(token),
@@ -1869,13 +1954,14 @@ paths:
     key, token = _admin_token()
     with respx.mock as mock_router:
         _mock_discovery_and_jwks(mock_router, _public_jwks(key))
+        spec_url = _register_spec_at_https(mock_router, spec_path, path="vcenter-9.yaml")
         response = client.post(
             "/api/v1/connectors/ingest",
             json={
                 "product": "vmware",
                 "version": "8.0",
                 "impl_id": "vmware-rest",
-                "specs": [{"uri": str(spec_path)}],
+                "specs": [{"uri": spec_url}],
                 "async": False,
             },
             headers=_authed(token),
@@ -1884,7 +1970,7 @@ paths:
     detail = response.json()["detail"]
     assert detail["kind"] == "spec_label_mismatch"
     assert detail["requested_version"] == "8.0"
-    assert detail["spec_info_versions"] == [{"spec_uri": str(spec_path), "info_version": "9.0.3"}]
+    assert detail["spec_info_versions"] == [{"spec_uri": spec_url, "info_version": "9.0.3"}]
     # The operator-facing message must mention both versions.
     assert "9.0.3" in detail["message"]
     assert "8.0" in detail["message"]
@@ -1937,13 +2023,14 @@ paths:
         ),
     ):
         _mock_discovery_and_jwks(mock_router, _public_jwks(key))
+        spec_url = _register_spec_at_https(mock_router, spec_path, path="spec-drift.yaml")
         response = client.post(
             "/api/v1/connectors/ingest",
             json={
                 "product": "drift-test",
                 "version": "9.1",
                 "impl_id": "drift-impl",
-                "specs": [{"uri": str(spec_path)}],
+                "specs": [{"uri": spec_url}],
                 "async": False,
             },
             headers=_authed(token),
@@ -2055,13 +2142,14 @@ paths:
     key, token = _admin_token()
     with respx.mock as mock_router:
         _mock_discovery_and_jwks(mock_router, _public_jwks(key))
+        spec_url = _register_spec_at_https(mock_router, spec_path, path="vcenter-7.yaml")
         response = client.post(
             "/api/v1/connectors/ingest",
             json={
                 "product": "t9-vmware",
                 "version": "7.0",
                 "impl_id": "t9-vmware-rest",
-                "specs": [{"uri": str(spec_path)}],
+                "specs": [{"uri": spec_url}],
                 "async": False,
             },
             headers=_authed(token),
@@ -2102,13 +2190,14 @@ paths:
     key, token = _admin_token()
     with respx.mock as mock_router:
         _mock_discovery_and_jwks(mock_router, _public_jwks(key))
+        spec_url = _register_spec_at_https(mock_router, spec_path, path="vcenter-7-dryrun.yaml")
         response = client.post(
             "/api/v1/connectors/ingest",
             json={
                 "product": "t9-vmware",
                 "version": "7.0",
                 "impl_id": "t9-vmware-rest",
-                "specs": [{"uri": str(spec_path)}],
+                "specs": [{"uri": spec_url}],
                 "dry_run": True,
             },
             headers=_authed(token),
@@ -2181,6 +2270,7 @@ paths:
           description: ok
 """,
     )
+    catalog_spec_url = f"{_SPEC_BASE}/catalog-spec.yaml"
     _patch_catalog(
         monkeypatch,
         entries=[
@@ -2189,13 +2279,20 @@ paths:
                 "version": "9.0",
                 "impl_id": "vmware-rest-t9",
                 "requires_connector_class": "VmwareRestConnector",
-                "upstream": (str(spec_path),),
+                "upstream": (catalog_spec_url,),
             },
         ],
     )
     key, token = _admin_token()
     with respx.mock as mock_router:
         _mock_discovery_and_jwks(mock_router, _public_jwks(key))
+        mock_router.get(catalog_spec_url).mock(
+            return_value=httpx.Response(
+                200,
+                content=spec_path.read_bytes(),
+                headers={"content-type": "application/yaml"},
+            )
+        )
         response = client.post(
             "/api/v1/connectors/ingest",
             json={"catalog_entry": "vmware-t9/9.0", "dry_run": True},
@@ -2655,13 +2752,14 @@ paths:
     key, token = _admin_token()
     with respx.mock as mock_router:
         _mock_discovery_and_jwks(mock_router, _public_jwks(key))
+        spec_url = _register_spec_at_https(mock_router, spec_path, path="spec-quadruple.yaml")
         response = client.post(
             "/api/v1/connectors/ingest",
             json={
                 "product": "test-quadruple",
                 "version": "1.0",
                 "impl_id": "test-impl",
-                "specs": [{"uri": str(spec_path)}],
+                "specs": [{"uri": spec_url}],
                 "dry_run": True,
             },
             headers=_authed(token),
@@ -2852,6 +2950,7 @@ async def test_ingest_async_default_returns_202_with_job_handle(
         ),
     ):
         _mock_discovery_and_jwks(mock_router, _public_jwks(key))
+        spec_url = _register_spec_at_https(mock_router, spec_path, path="stress-spec.yaml")
         async with httpx.AsyncClient(
             transport=ASGITransport(app=app),
             base_url="https://testserver",
@@ -2863,7 +2962,7 @@ async def test_ingest_async_default_returns_202_with_job_handle(
                     "product": "stress-vmware",
                     "version": "9.0.0.0",
                     "impl_id": "stress-vmware-rest",
-                    "specs": [{"uri": str(spec_path)}],
+                    "specs": [{"uri": spec_url}],
                     # Default is ``async=true``; the assertion below
                     # is what the issue's "must not crash the pod"
                     # framing protects against. No need to set it
@@ -2997,6 +3096,7 @@ paths:
         # JWKS and 401-ing the POST on the very signature it
         # produced.
         _mock_discovery_and_jwks(mock_router, _public_jwks(key_a, key_b))
+        spec_url = _register_spec_at_https(mock_router, spec_path, path="spec-tenant-iso.yaml")
         async with httpx.AsyncClient(
             transport=ASGITransport(app=app),
             base_url="https://testserver",
@@ -3007,7 +3107,7 @@ paths:
                     "product": "tenant-iso",
                     "version": "1.0",
                     "impl_id": "tenant-iso-impl",
-                    "specs": [{"uri": str(spec_path)}],
+                    "specs": [{"uri": spec_url}],
                 },
                 headers=_authed(token_a),
             )

--- a/backend/tests/test_connectors_vmware_rest_composites_l2_ingest_reconcile.py
+++ b/backend/tests/test_connectors_vmware_rest_composites_l2_ingest_reconcile.py
@@ -47,11 +47,26 @@ the ingest pipeline cannot emit, this test goes red.
 from __future__ import annotations
 
 import json
-from pathlib import Path
+import socket
 from typing import Any
+from unittest.mock import patch
+
+import httpx
+import respx
 
 from meho_backplane.connectors.vmware_rest.composites import _write
 from meho_backplane.operations.ingest import parse_openapi
+
+# Public IP returned by the mock getaddrinfo for specs.example.test.
+_PUBLIC_TEST_IP = "93.184.216.34"
+
+# Patch used by both reconciliation tests to satisfy the SSRF guard without
+# real DNS lookups. The guard is a correctness property, not a test concern;
+# this fixture keeps the mock in one place.
+_GETADDRINFO_PATCH = patch(
+    "meho_backplane.operations.ingest.openapi.socket.getaddrinfo",
+    return_value=[(socket.AF_INET, socket.SOCK_STREAM, 0, "", (_PUBLIC_TEST_IP, 443))],
+)
 
 # ---------------------------------------------------------------------------
 # Derive the composites' required L2 sub-op_ids from the live constants.
@@ -136,9 +151,7 @@ def _build_vcenter_fixture(required_op_ids: set[str]) -> dict[str, Any]:
     }
 
 
-def test_every_write_composite_sub_op_resolves_to_an_ingested_op_id(
-    tmp_path: Path,
-) -> None:
+def test_every_write_composite_sub_op_resolves_to_an_ingested_op_id() -> None:
     """The ingest pipeline emits an op_id for every composite sub-op.
 
     This is the in-code proxy for #1414 acceptance criterion 2 ("every
@@ -152,10 +165,18 @@ def test_every_write_composite_sub_op_resolves_to_an_ingested_op_id(
     assert required, "introspection found no raw sub-op_ids -- wiring broke"
 
     spec = _build_vcenter_fixture(required)
-    spec_path = tmp_path / "vcenter.yaml"
-    spec_path.write_text(json.dumps(spec), encoding="utf-8")
+    spec_bytes = json.dumps(spec).encode()
+    spec_url = "https://specs.example.test/vcenter.yaml"
 
-    rows = parse_openapi(str(spec_path), spec_source="spec:vcenter.yaml")
+    with _GETADDRINFO_PATCH, respx.mock(assert_all_called=False) as router:
+        router.get(spec_url).mock(
+            return_value=httpx.Response(
+                200,
+                content=spec_bytes,
+                headers={"content-type": "application/json"},
+            )
+        )
+        rows = parse_openapi(spec_url, spec_source="spec:vcenter.yaml")
     ingested_op_ids = {row.op_id for row in rows}
 
     missing = required - ingested_op_ids
@@ -167,9 +188,7 @@ def test_every_write_composite_sub_op_resolves_to_an_ingested_op_id(
     )
 
 
-def test_action_discriminated_sub_ops_keep_query_suffix_through_ingest(
-    tmp_path: Path,
-) -> None:
+def test_action_discriminated_sub_ops_keep_query_suffix_through_ingest() -> None:
     """Action verbs in the path key survive ``op_id = f'{method}:{path}'``.
 
     The reconciliation hinge: ``?action=<verb>`` is part of the path key
@@ -189,10 +208,18 @@ def test_action_discriminated_sub_ops_keep_query_suffix_through_ingest(
     } <= action_op_ids
 
     spec = _build_vcenter_fixture(action_op_ids)
-    spec_path = tmp_path / "vcenter.yaml"
-    spec_path.write_text(json.dumps(spec), encoding="utf-8")
+    spec_bytes = json.dumps(spec).encode()
+    spec_url = "https://specs.example.test/vcenter-action.yaml"
 
-    rows = parse_openapi(str(spec_path), spec_source="spec:vcenter.yaml")
+    with _GETADDRINFO_PATCH, respx.mock(assert_all_called=False) as router:
+        router.get(spec_url).mock(
+            return_value=httpx.Response(
+                200,
+                content=spec_bytes,
+                headers={"content-type": "application/json"},
+            )
+        )
+        rows = parse_openapi(spec_url, spec_source="spec:vcenter.yaml")
     ingested_op_ids = {row.op_id for row in rows}
 
     # Every action op_id round-trips with its ``?action=`` suffix intact.

--- a/backend/tests/test_operations_ingest_openapi.py
+++ b/backend/tests/test_operations_ingest_openapi.py
@@ -481,6 +481,30 @@ def test_uploaded_content_over_size_cap_raises(
         parse_openapi("file:///x.yaml", content="x" * 64)
 
 
+def test_relative_redirect_location_resolved_and_followed() -> None:
+    """A 30x with a relative ``Location`` is resolved against the current URL
+    (``urljoin``) so the https-only guard does not wrongly reject a valid
+    relative redirect (M1).
+    """
+    spec = (
+        b"openapi: 3.0.3\n"
+        b"info: {title: t, version: '1'}\n"
+        b"paths:\n  /x:\n    get:\n      responses:\n"
+        b"        '200':\n          description: ok\n"
+    )
+    with respx.mock(assert_all_called=False) as router:
+        router.get(f"{_FIXTURE_HOST}/redir.yaml").mock(
+            return_value=httpx.Response(302, headers={"location": "/real.yaml"})
+        )
+        router.get(f"{_FIXTURE_HOST}/real.yaml").mock(
+            return_value=httpx.Response(
+                200, content=spec, headers={"content-type": "application/yaml"}
+            )
+        )
+        rows = parse_openapi(f"{_FIXTURE_HOST}/redir.yaml")
+    assert rows, "relative redirect should be resolved and followed"
+
+
 def test_malformed_yaml_bubbles_up() -> None:
     content = b"openapi: '3.0.3'\npaths:\n  /x:\n   get:\n   summary: oops\n  : bad\n"
     with respx.mock(assert_all_called=False) as router:

--- a/backend/tests/test_operations_ingest_openapi.py
+++ b/backend/tests/test_operations_ingest_openapi.py
@@ -37,7 +37,7 @@ from meho_backplane.operations.ingest import (
     parse_openapi,
     read_spec_info_version,
 )
-from meho_backplane.operations.ingest.openapi import _assert_fetchable_remote_url
+from meho_backplane.operations.ingest.openapi import _MAX_REDIRECTS, _assert_fetchable_remote_url
 
 FIXTURES = Path(__file__).parent / "fixtures" / "openapi"
 PETSTORE_30 = FIXTURES / "petstore_30.yaml"
@@ -308,28 +308,27 @@ def test_parse_petstore_31_json_route() -> None:
 # -- hand-authored minimal spec (#1533 / ci-07 on-ramp) --------------------
 
 
-def test_parse_handauthored_minimal_spec_via_file_uri() -> None:
-    """A hand-authored minimal OpenAPI 3.x ingests via a ``file://`` URI.
+def test_parse_handauthored_minimal_spec_via_https() -> None:
+    """A hand-authored minimal OpenAPI 3.x ingests via an ``https://`` URL.
 
     #1533 / ci-07: for a product whose vendor publishes no OpenAPI doc
     at all (VCF Fleet / vRSLCM, Hetzner Robot), the supported on-ramp is
     to author a minimal OpenAPI 3.x covering just the needed ops and
-    pass it to ``meho connector ingest … --spec file://…``. A
-    hand-authored spec is identical to a downloaded one once it reaches
-    the parser; this test is the worked example proving the end-to-end
-    parse from a ``file://`` URI, matching the workflow documented in
+    serve it over https to ``meho connector ingest``. A hand-authored
+    spec is identical to a downloaded one once it reaches the parser;
+    this test is the worked example proving the end-to-end parse,
+    matching the workflow documented in
     ``docs/cross-repo/connector-ingestion.md`` §"Product publishes no
     OpenAPI spec".
 
-    ``Path.as_uri()`` is the cross-platform ``file://`` form the
-    operator types after ``meho connector ingest`` resolves their local
-    path; the parser's ``file`` scheme branch round-trips it through
-    ``url2pathname`` back to the on-disk file.
+    The G0.16-T8 (#95) SSRF guard makes the backend https-only, so the
+    hand-authored spec reaches the parser over the same vetted transport
+    a downloaded one does.
     """
-    file_uri = HANDAUTHORED_MINIMAL_30.as_uri()
-    assert file_uri.startswith("file://")
-
-    rows = parse_openapi(file_uri, spec_source="spec:hetzner-robot.yaml")
+    content = HANDAUTHORED_MINIMAL_30.read_bytes()
+    with respx.mock(assert_all_called=False) as router:
+        url = _mock_yaml_spec(router, "handauthored_minimal.yaml", content)
+        rows = parse_openapi(url, spec_source="spec:hetzner-robot.yaml")
     ops = _by_op_id(rows)
 
     assert set(ops) == {"GET:/server", "POST:/reset/{server_ip}"}
@@ -419,6 +418,42 @@ def test_non_https_scheme_raises_invalid_spec() -> None:
     """
     with pytest.raises(InvalidSpecError, match="https"):
         parse_openapi("http://example.test/spec.yaml")
+
+
+def test_spec_response_over_size_cap_streams_and_raises(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """A 2xx body larger than ``_MAX_SPEC_BYTES`` raises ``InvalidSpecError``
+    naming the size limit.
+
+    Regression guard for the M1 streaming fix: the cap is enforced while the
+    body streams in (``client.stream`` + ``iter_bytes``), so an oversized
+    response aborts the read instead of being fully buffered into pod memory
+    first.
+    """
+    monkeypatch.setattr("meho_backplane.operations.ingest.openapi._MAX_SPEC_BYTES", 1024)
+    oversized = b"x" * 4096
+    with respx.mock(assert_all_called=False) as router:
+        url = _mock_yaml_spec(router, "oversized.yaml", oversized)
+        with pytest.raises(InvalidSpecError, match="size limit"):
+            parse_openapi(url)
+
+
+def test_redirect_chain_over_cap_raises_invalid_spec() -> None:
+    """A redirect chain longer than ``_MAX_REDIRECTS`` raises
+    ``InvalidSpecError`` naming the redirect cap.
+
+    Each hop's destination is re-validated by the SSRF guard (the autouse
+    ``getaddrinfo`` patch keeps the test hosts public); the loop exhausts its
+    hop budget before any 2xx body is served.
+    """
+    with respx.mock(assert_all_called=False) as router:
+        for i in range(_MAX_REDIRECTS + 1):
+            router.get(f"{_FIXTURE_HOST}/r{i}").mock(
+                return_value=httpx.Response(302, headers={"location": f"{_FIXTURE_HOST}/r{i + 1}"})
+            )
+        with pytest.raises(InvalidSpecError, match="followed more than"):
+            parse_openapi(f"{_FIXTURE_HOST}/r0")
 
 
 def test_malformed_yaml_bubbles_up() -> None:

--- a/backend/tests/test_operations_ingest_openapi.py
+++ b/backend/tests/test_operations_ingest_openapi.py
@@ -456,6 +456,31 @@ def test_redirect_chain_over_cap_raises_invalid_spec() -> None:
             parse_openapi(f"{_FIXTURE_HOST}/r0")
 
 
+def test_uploaded_content_skips_fetch_and_scheme_guard() -> None:
+    """When the CLI uploads inline spec content for a docs:/file:// source,
+    ``parse_openapi`` uses it verbatim -- no fetch, no scheme guard -- so a
+    ``docs:`` / ``file://`` uri label parses without the https-only guard
+    firing (#102: this is what keeps the local-spec on-ramp working under
+    the #95 guard).
+    """
+    spec_text = HANDAUTHORED_MINIMAL_30.read_text()
+    rows = parse_openapi("docs:hetzner-robot/spec.yaml", content=spec_text)
+    assert rows, "uploaded content should parse to operations"
+    assert read_spec_info_version("file:///irrelevant.yaml", content=spec_text) == "1.0"
+
+
+def test_uploaded_content_over_size_cap_raises(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """Uploaded content larger than ``_MAX_SPEC_BYTES`` raises
+    ``InvalidSpecError`` naming the size limit -- the cap applies to the
+    content channel exactly as it does to a fetched body.
+    """
+    monkeypatch.setattr("meho_backplane.operations.ingest.openapi._MAX_SPEC_BYTES", 16)
+    with pytest.raises(InvalidSpecError, match="size limit"):
+        parse_openapi("file:///x.yaml", content="x" * 64)
+
+
 def test_malformed_yaml_bubbles_up() -> None:
     content = b"openapi: '3.0.3'\npaths:\n  /x:\n   get:\n   summary: oops\n  : bad\n"
     with respx.mock(assert_all_called=False) as router:

--- a/backend/tests/test_operations_ingest_openapi.py
+++ b/backend/tests/test_operations_ingest_openapi.py
@@ -6,12 +6,20 @@
 Fixture specs live next to this file at ``tests/fixtures/openapi/``.
 Each fixture exercises one or two parser concerns so the failures
 point at a specific contract violation rather than a soup of issues.
+
+Since G0.16-T8 (#95) the spec fetcher only accepts ``https://`` URIs
+on the network-facing path. Tests that formerly exercised the parser
+via local file paths now serve fixture content through respx-mocked
+HTTPS endpoints so the same parsing assertions remain valid.
 """
 
 from __future__ import annotations
 
 import json
+import socket
+from collections.abc import Generator
 from pathlib import Path
+from unittest.mock import patch
 
 import httpx
 import pytest
@@ -29,6 +37,7 @@ from meho_backplane.operations.ingest import (
     parse_openapi,
     read_spec_info_version,
 )
+from meho_backplane.operations.ingest.openapi import _assert_fetchable_remote_url
 
 FIXTURES = Path(__file__).parent / "fixtures" / "openapi"
 PETSTORE_30 = FIXTURES / "petstore_30.yaml"
@@ -39,9 +48,96 @@ RESPONSE_REFS_30 = FIXTURES / "response_refs_30.yaml"
 REQUEST_BODY_REFS_30 = FIXTURES / "request_body_refs_30.yaml"
 HANDAUTHORED_MINIMAL_30 = FIXTURES / "handauthored_minimal_30.yaml"
 
+# Stable HTTPS URL prefix used by tests that serve fixture content through
+# respx. Using a dedicated subdomain makes it easy to route all fixture
+# fetches in a single mock block when tests need multiple specs.
+_FIXTURE_HOST = "https://specs.example.test"
+
+# A stable public IP returned by the ``getaddrinfo`` patch for every test
+# domain used in this module. ``93.184.216.34`` is IANA's example.com
+# address — public and non-special per RFC 5737 / the ipaddress module.
+_PUBLIC_TEST_IP = "93.184.216.34"
+
+# Hostnames that appear in test HTTPS URLs and need a mocked getaddrinfo
+# response so the SSRF destination guard passes without real DNS lookups.
+_TEST_HOSTS = frozenset(
+    {
+        "specs.example.test",
+        "example.test",
+        "developer.broadcom.com",
+        "public.example.test",
+        "cdn.example.test",
+        "public-looking.example.test",
+    }
+)
+
+
+def _getaddrinfo_for_tests(
+    host: str, port: object, **kwargs: object
+) -> list[tuple[int, int, int, str, tuple[str, int]]]:
+    """Mock ``socket.getaddrinfo`` for the SSRF guard used in test calls.
+
+    Returns a public IP for all known test hostnames so the destination
+    guard passes; delegates to the real ``getaddrinfo`` for everything
+    else (private/metadata IPs tested via their own per-test patches).
+    """
+    if host in _TEST_HOSTS:
+        return [(socket.AF_INET, socket.SOCK_STREAM, 0, "", (_PUBLIC_TEST_IP, 443))]
+    return socket.getaddrinfo(host, port, **kwargs)  # type: ignore[arg-type]
+
+
+@pytest.fixture(autouse=True)
+def _mock_getaddrinfo_for_test_hosts() -> Generator[None, None, None]:
+    """Patch ``socket.getaddrinfo`` for the SSRF guard so test HTTPS URLs
+    resolve to a public IP without real DNS, and the guard passes.
+
+    Tests that need specific IP outcomes (private/metadata ranges) apply
+    their own ``patch`` context inside the test body, which overrides
+    this fixture's patch for that block.
+    """
+    with patch(
+        "meho_backplane.operations.ingest.openapi.socket.getaddrinfo",
+        side_effect=_getaddrinfo_for_tests,
+    ):
+        yield
+
 
 def _by_op_id(rows: list[EndpointDescriptorProto]) -> dict[str, EndpointDescriptorProto]:
     return {r.op_id: r for r in rows}
+
+
+def _mock_yaml_spec(
+    router: respx.MockRouter,
+    path: str,
+    content: bytes,
+) -> str:
+    """Register ``content`` at ``_FIXTURE_HOST/<path>`` and return the URL."""
+    url = f"{_FIXTURE_HOST}/{path}"
+    router.get(url).mock(
+        return_value=httpx.Response(
+            200,
+            content=content,
+            headers={"content-type": "application/yaml"},
+        )
+    )
+    return url
+
+
+def _mock_json_spec(
+    router: respx.MockRouter,
+    path: str,
+    content: bytes,
+) -> str:
+    """Register ``content`` at ``_FIXTURE_HOST/<path>`` and return the URL."""
+    url = f"{_FIXTURE_HOST}/{path}"
+    router.get(url).mock(
+        return_value=httpx.Response(
+            200,
+            content=content,
+            headers={"content-type": "application/json"},
+        )
+    )
+    return url
 
 
 # -- detect_spec_format -----------------------------------------------------
@@ -68,7 +164,9 @@ def test_detect_spec_format(content: bytes, expected: str) -> None:
 
 
 def test_parse_petstore_30_yields_expected_ops() -> None:
-    rows = parse_openapi(str(PETSTORE_30), spec_source="spec:petstore_30.yaml")
+    with respx.mock(assert_all_called=False) as router:
+        url = _mock_yaml_spec(router, "petstore_30.yaml", PETSTORE_30.read_bytes())
+        rows = parse_openapi(url, spec_source="spec:petstore_30.yaml")
     ops = _by_op_id(rows)
     expected_ids = {
         "GET:/pets",
@@ -82,7 +180,9 @@ def test_parse_petstore_30_yields_expected_ops() -> None:
 
 
 def test_parse_petstore_30_safety_heuristic() -> None:
-    rows = parse_openapi(str(PETSTORE_30))
+    with respx.mock(assert_all_called=False) as router:
+        url = _mock_yaml_spec(router, "petstore_30.yaml", PETSTORE_30.read_bytes())
+        rows = parse_openapi(url)
     ops = _by_op_id(rows)
     assert ops["GET:/pets"].safety_level == "safe"
     assert ops["POST:/pets"].safety_level == "caution"
@@ -92,7 +192,9 @@ def test_parse_petstore_30_safety_heuristic() -> None:
 
 
 def test_parse_petstore_30_path_and_query_param_locations() -> None:
-    rows = parse_openapi(str(PETSTORE_30))
+    with respx.mock(assert_all_called=False) as router:
+        url = _mock_yaml_spec(router, "petstore_30.yaml", PETSTORE_30.read_bytes())
+        rows = parse_openapi(url)
     list_pets = _by_op_id(rows)["GET:/pets"]
     props = list_pets.parameter_schema["properties"]
     assert isinstance(props, dict)
@@ -109,7 +211,9 @@ def test_parse_petstore_30_path_and_query_param_locations() -> None:
 
 
 def test_parse_petstore_30_path_param_is_required() -> None:
-    rows = parse_openapi(str(PETSTORE_30))
+    with respx.mock(assert_all_called=False) as router:
+        url = _mock_yaml_spec(router, "petstore_30.yaml", PETSTORE_30.read_bytes())
+        rows = parse_openapi(url)
     get_pet = _by_op_id(rows)["GET:/pets/{petId}"]
     props = get_pet.parameter_schema["properties"]
     assert props["petId"]["x-meho-param-loc"] == "path"
@@ -117,7 +221,9 @@ def test_parse_petstore_30_path_param_is_required() -> None:
 
 
 def test_parse_petstore_30_request_body_inlined_with_param_loc() -> None:
-    rows = parse_openapi(str(PETSTORE_30))
+    with respx.mock(assert_all_called=False) as router:
+        url = _mock_yaml_spec(router, "petstore_30.yaml", PETSTORE_30.read_bytes())
+        rows = parse_openapi(url)
     post = _by_op_id(rows)["POST:/pets"]
     props = post.parameter_schema["properties"]
     body = props["body"]
@@ -132,7 +238,9 @@ def test_parse_petstore_30_request_body_inlined_with_param_loc() -> None:
 
 
 def test_parse_petstore_30_optional_body_not_required() -> None:
-    rows = parse_openapi(str(PETSTORE_30))
+    with respx.mock(assert_all_called=False) as router:
+        url = _mock_yaml_spec(router, "petstore_30.yaml", PETSTORE_30.read_bytes())
+        rows = parse_openapi(url)
     put = _by_op_id(rows)["PUT:/pets/{petId}/photos"]
     assert put.parameter_schema["properties"]["body"]["x-meho-param-loc"] == "body"
     # requestBody.required omitted → not required.
@@ -140,7 +248,9 @@ def test_parse_petstore_30_optional_body_not_required() -> None:
 
 
 def test_parse_petstore_30_response_schema_extracted() -> None:
-    rows = parse_openapi(str(PETSTORE_30))
+    with respx.mock(assert_all_called=False) as router:
+        url = _mock_yaml_spec(router, "petstore_30.yaml", PETSTORE_30.read_bytes())
+        rows = parse_openapi(url)
     list_pets = _by_op_id(rows)["GET:/pets"]
     # PetPage was inlined; nested $ref to Pet preserved.
     assert list_pets.response_schema is not None
@@ -150,20 +260,26 @@ def test_parse_petstore_30_response_schema_extracted() -> None:
 
 
 def test_parse_petstore_30_204_response_yields_none() -> None:
-    rows = parse_openapi(str(PETSTORE_30))
+    with respx.mock(assert_all_called=False) as router:
+        url = _mock_yaml_spec(router, "petstore_30.yaml", PETSTORE_30.read_bytes())
+        rows = parse_openapi(url)
     delete = _by_op_id(rows)["DELETE:/pets/{petId}"]
     assert delete.response_schema is None
 
 
 def test_parse_petstore_30_tags_include_spec_source() -> None:
-    rows = parse_openapi(str(PETSTORE_30), spec_source="spec:petstore_30.yaml")
+    with respx.mock(assert_all_called=False) as router:
+        url = _mock_yaml_spec(router, "petstore_30.yaml", PETSTORE_30.read_bytes())
+        rows = parse_openapi(url, spec_source="spec:petstore_30.yaml")
     list_pets = _by_op_id(rows)["GET:/pets"]
     assert "pets" in list_pets.tags
     assert "spec:petstore_30.yaml" in list_pets.tags
 
 
 def test_parse_petstore_30_without_spec_source_omits_tag() -> None:
-    rows = parse_openapi(str(PETSTORE_30))
+    with respx.mock(assert_all_called=False) as router:
+        url = _mock_yaml_spec(router, "petstore_30.yaml", PETSTORE_30.read_bytes())
+        rows = parse_openapi(url)
     list_pets = _by_op_id(rows)["GET:/pets"]
     assert list_pets.tags == ["pets"]
     # No accidental injection of an empty string or None.
@@ -171,7 +287,9 @@ def test_parse_petstore_30_without_spec_source_omits_tag() -> None:
 
 
 def test_parse_petstore_31_yaml_wildcard_2xx_response() -> None:
-    rows = parse_openapi(str(PETSTORE_31_YAML))
+    with respx.mock(assert_all_called=False) as router:
+        url = _mock_yaml_spec(router, "petstore_31.yaml", PETSTORE_31_YAML.read_bytes())
+        rows = parse_openapi(url)
     ops = _by_op_id(rows)
     list_vets = ops["GET:/vets"]
     assert list_vets.response_schema is not None
@@ -180,7 +298,9 @@ def test_parse_petstore_31_yaml_wildcard_2xx_response() -> None:
 
 
 def test_parse_petstore_31_json_route() -> None:
-    rows = parse_openapi(str(PETSTORE_31_JSON))
+    with respx.mock(assert_all_called=False) as router:
+        url = _mock_json_spec(router, "petstore_31.json", PETSTORE_31_JSON.read_bytes())
+        rows = parse_openapi(url)
     assert {r.op_id for r in rows} == {"GET:/zoos"}
     assert rows[0].response_schema == {"type": "array", "items": {"type": "string"}}
 
@@ -232,11 +352,14 @@ def test_parse_handauthored_minimal_spec_via_file_uri() -> None:
 # -- spec_source merging ---------------------------------------------------
 
 
-def test_spec_source_threads_distinctly_across_two_specs(tmp_path: Path) -> None:
+def test_spec_source_threads_distinctly_across_two_specs() -> None:
     """vCenter ingests vcenter.yaml + vi-json.yaml under one connector;
     rows from each spec must carry distinguishable ``spec:<source>`` tags."""
-    rows_a = parse_openapi(str(PETSTORE_30), spec_source="spec:vcenter.yaml")
-    rows_b = parse_openapi(str(PETSTORE_31_YAML), spec_source="spec:vi-json.yaml")
+    with respx.mock(assert_all_called=False) as router:
+        url_a = _mock_yaml_spec(router, "vcenter.yaml", PETSTORE_30.read_bytes())
+        url_b = _mock_yaml_spec(router, "vi-json.yaml", PETSTORE_31_YAML.read_bytes())
+        rows_a = parse_openapi(url_a, spec_source="spec:vcenter.yaml")
+        rows_b = parse_openapi(url_b, spec_source="spec:vi-json.yaml")
     all_tags_a = {tag for row in rows_a for tag in row.tags}
     all_tags_b = {tag for row in rows_b for tag in row.tags}
     assert "spec:vcenter.yaml" in all_tags_a
@@ -247,51 +370,63 @@ def test_spec_source_threads_distinctly_across_two_specs(tmp_path: Path) -> None
 # -- failure modes ---------------------------------------------------------
 
 
-def test_unsupported_swagger_2_raises(tmp_path: Path) -> None:
-    spec = tmp_path / "swagger.yaml"
-    spec.write_text("swagger: '2.0'\ninfo: {title: x, version: '1'}\npaths: {}\n")
-    with pytest.raises(UnsupportedSpecError, match=r"Swagger 2\.0") as excinfo:
-        parse_openapi(str(spec))
-    # The rejection must be *actionable* — it names the conversion path
-    # (swagger2openapi / converter.swagger.io) so a 2.0-only surface
-    # such as Harbor 2.x can be onboarded without an opaque dead end
-    # (#1532). The detected version is echoed back verbatim.
+def test_unsupported_swagger_2_raises() -> None:
+    content = b"swagger: '2.0'\ninfo: {title: x, version: '1'}\npaths: {}\n"
+    with respx.mock(assert_all_called=False) as router:
+        url = _mock_yaml_spec(router, "swagger.yaml", content)
+        with pytest.raises(UnsupportedSpecError, match=r"Swagger 2\.0") as excinfo:
+            parse_openapi(url)
+    # The rejection must be *actionable* -- it names the conversion path
+    # (swagger2openapi / converter.swagger.io) so a 2.0-only surface such
+    # as Harbor 2.x can be onboarded without an opaque dead end (#1532).
     message = str(excinfo.value)
     assert "swagger2openapi" in message
     assert "converter.swagger.io" in message
     assert "'2.0'" in message
 
 
-def test_unsupported_openapi_4_raises(tmp_path: Path) -> None:
-    spec = tmp_path / "v4.yaml"
-    spec.write_text("openapi: '4.0.0'\ninfo: {title: x, version: '1'}\npaths: {}\n")
-    with pytest.raises(UnsupportedSpecError, match=r"4\.0\.0"):
-        parse_openapi(str(spec))
+def test_unsupported_openapi_4_raises() -> None:
+    content = b"openapi: '4.0.0'\ninfo: {title: x, version: '1'}\npaths: {}\n"
+    with respx.mock(assert_all_called=False) as router:
+        url = _mock_yaml_spec(router, "v4.yaml", content)
+        with pytest.raises(UnsupportedSpecError, match=r"4\.0\.0"):
+            parse_openapi(url)
 
 
-def test_invalid_spec_missing_paths_raises(tmp_path: Path) -> None:
-    spec = tmp_path / "broken.yaml"
-    spec.write_text("openapi: '3.1.0'\ninfo: {title: x, version: '1'}\n")
-    with pytest.raises(InvalidSpecError, match="no 'paths' key"):
-        parse_openapi(str(spec))
+def test_invalid_spec_missing_paths_raises() -> None:
+    content = b"openapi: '3.1.0'\ninfo: {title: x, version: '1'}\n"
+    with respx.mock(assert_all_called=False) as router:
+        url = _mock_yaml_spec(router, "broken.yaml", content)
+        with pytest.raises(InvalidSpecError, match="no 'paths' key"):
+            parse_openapi(url)
 
 
-def test_invalid_spec_non_mapping_root_raises(tmp_path: Path) -> None:
-    spec = tmp_path / "list.yaml"
-    spec.write_text("- not\n- a\n- mapping\n")
-    with pytest.raises(InvalidSpecError, match="must parse to a mapping"):
-        parse_openapi(str(spec))
+def test_invalid_spec_non_mapping_root_raises() -> None:
+    content = b"- not\n- a\n- mapping\n"
+    with respx.mock(assert_all_called=False) as router:
+        url = _mock_yaml_spec(router, "list.yaml", content)
+        with pytest.raises(InvalidSpecError, match="must parse to a mapping"):
+            parse_openapi(url)
 
 
-def test_missing_local_file_raises_invalid_spec(tmp_path: Path) -> None:
-    missing = tmp_path / "nope.yaml"
-    with pytest.raises(InvalidSpecError, match="could not read spec"):
-        parse_openapi(str(missing))
+def test_non_https_scheme_raises_invalid_spec() -> None:
+    """Any non-https scheme (http, file://, bare path) raises InvalidSpecError.
+
+    This is the top-level smoke test for the G0.16-T8 (#95) SSRF guard:
+    even a scheme that looks harmless (``http``) is rejected because the
+    guard cannot protect the transport and ``http`` is indistinguishable
+    from a redirect-bypass target after a single 30x hop.
+    """
+    with pytest.raises(InvalidSpecError, match="https"):
+        parse_openapi("http://example.test/spec.yaml")
 
 
-def test_directory_path_raises_invalid_spec(tmp_path: Path) -> None:
-    with pytest.raises(InvalidSpecError, match="could not read spec"):
-        parse_openapi(str(tmp_path))
+def test_malformed_yaml_bubbles_up() -> None:
+    content = b"openapi: '3.0.3'\npaths:\n  /x:\n   get:\n   summary: oops\n  : bad\n"
+    with respx.mock(assert_all_called=False) as router:
+        url = _mock_yaml_spec(router, "bad.yaml", content)
+        with pytest.raises(yaml.YAMLError):
+            parse_openapi(url)
 
 
 def test_docs_scheme_rejected_unsupported_naming_scheme() -> None:
@@ -314,36 +449,16 @@ def test_docs_scheme_rejected_unsupported_naming_scheme() -> None:
     assert "could not read spec" not in str(excinfo.value)
 
 
-def test_file_uri_unaffected_regression(tmp_path: Path) -> None:
-    """Regression check for #1535: adding the ``docs:`` branch must not
-    perturb the ``file://`` path. An absolute ``file://`` URI to a valid
-    spec still parses end-to-end.
-    """
-    spec = tmp_path / "spec.yaml"
-    spec.write_text(PETSTORE_30.read_text())
-    protos = parse_openapi(spec.resolve().as_uri())
-    assert protos, "file:// spec should yield at least one operation proto"
+def test_malformed_json_bubbles_up() -> None:
+    content = b'{"openapi": "3.0.3", broken'
+    with respx.mock(assert_all_called=False) as router:
+        url = _mock_json_spec(router, "bad.json", content)
+        with pytest.raises(json.JSONDecodeError):
+            parse_openapi(url)
 
 
-def test_malformed_yaml_bubbles_up(tmp_path: Path) -> None:
-    spec = tmp_path / "bad.yaml"
-    spec.write_text("openapi: '3.0.3'\npaths:\n  /x:\n   get:\n   summary: oops\n  : bad\n")
-    with pytest.raises(yaml.YAMLError):
-        parse_openapi(str(spec))
-
-
-def test_malformed_json_bubbles_up(tmp_path: Path) -> None:
-    spec = tmp_path / "bad.json"
-    spec.write_text('{"openapi": "3.0.3", broken')
-    with pytest.raises(json.JSONDecodeError):
-        parse_openapi(str(spec))
-
-
-def test_external_ref_raises(tmp_path: Path) -> None:
-    spec = tmp_path / "ext.yaml"
-    spec.write_text(
-        """
-openapi: '3.0.3'
+def test_external_ref_raises() -> None:
+    content = b"""openapi: '3.0.3'
 info: {title: x, version: '1'}
 paths:
   /x:
@@ -353,13 +468,14 @@ paths:
       responses:
         "200":
           description: ok
-        """.lstrip()
-    )
-    with pytest.raises(UnsupportedSpecError, match="cross-document"):
-        parse_openapi(str(spec))
+"""
+    with respx.mock(assert_all_called=False) as router:
+        url = _mock_yaml_spec(router, "ext.yaml", content)
+        with pytest.raises(UnsupportedSpecError, match="cross-document"):
+            parse_openapi(url)
 
 
-def test_component_parameter_ref_resolves(tmp_path: Path) -> None:
+def test_component_parameter_ref_resolves() -> None:
     """``$ref: '#/components/parameters/<name>'`` resolves to the shared parameter.
 
     The pre-T11 contract rejected this with ``UnsupportedSpecError`` —
@@ -367,10 +483,7 @@ def test_component_parameter_ref_resolves(tmp_path: Path) -> None:
     blocked the entire ~2,195-op spec. The new contract inlines the
     referenced parameter the same way it inlines schema refs.
     """
-    spec = tmp_path / "param_ref.yaml"
-    spec.write_text(
-        """
-openapi: '3.0.3'
+    content = b"""openapi: '3.0.3'
 info: {title: x, version: '1'}
 paths:
   /x:
@@ -388,9 +501,10 @@ components:
       required: true
       schema:
         type: string
-        """.lstrip()
-    )
-    rows = parse_openapi(str(spec))
+"""
+    with respx.mock(assert_all_called=False) as router:
+        url = _mock_yaml_spec(router, "param_ref.yaml", content)
+        rows = parse_openapi(url)
     assert len(rows) == 1
     properties = rows[0].parameter_schema["properties"]
     assert isinstance(properties, dict)
@@ -400,17 +514,14 @@ components:
     assert rows[0].parameter_schema["required"] == ["shared"]
 
 
-def test_component_parameter_ref_missing_name_raises(tmp_path: Path) -> None:
+def test_component_parameter_ref_missing_name_raises() -> None:
     """A ref to an unknown parameter component raises ``InvalidSchemaError``.
 
     Mirrors the existing schema-bucket missing-component behaviour;
     the symmetry keeps the parser failure mode predictable across
     both component kinds.
     """
-    spec = tmp_path / "param_ref_dangling.yaml"
-    spec.write_text(
-        """
-openapi: '3.0.3'
+    content = b"""openapi: '3.0.3'
 info: {title: x, version: '1'}
 paths:
   /x:
@@ -427,22 +538,20 @@ components:
       in: query
       schema:
         type: string
-        """.lstrip()
-    )
-    with pytest.raises(InvalidSchemaError, match="missing component"):
-        parse_openapi(str(spec))
+"""
+    with respx.mock(assert_all_called=False) as router:
+        url = _mock_yaml_spec(router, "param_ref_dangling.yaml", content)
+        with pytest.raises(InvalidSchemaError, match="missing component"):
+            parse_openapi(url)
 
 
-def test_component_parameter_ref_drilldown_raises(tmp_path: Path) -> None:
+def test_component_parameter_ref_drilldown_raises() -> None:
     """A ref into a parameter component's subpath raises ``InvalidSchemaError``.
 
     Symmetric with the schema-bucket drill-down rejection. The
     OpenAPI spec only declares fragment refs to *named* components.
     """
-    spec = tmp_path / "param_ref_drilldown.yaml"
-    spec.write_text(
-        """
-openapi: '3.0.3'
+    content = b"""openapi: '3.0.3'
 info: {title: x, version: '1'}
 paths:
   /x:
@@ -459,13 +568,14 @@ components:
       in: query
       schema:
         type: string
-        """.lstrip()
-    )
-    with pytest.raises(InvalidSchemaError, match="drill-down"):
-        parse_openapi(str(spec))
+"""
+    with respx.mock(assert_all_called=False) as router:
+        url = _mock_yaml_spec(router, "param_ref_drilldown.yaml", content)
+        with pytest.raises(InvalidSchemaError, match="drill-down"):
+            parse_openapi(url)
 
 
-def test_unsupported_component_bucket_ref_raises(tmp_path: Path) -> None:
+def test_unsupported_component_bucket_ref_raises() -> None:
     """Refs to component buckets the parser doesn't inline stay rejected.
 
     Headers refs are the canonical example: OpenAPI 3.x defines them
@@ -479,10 +589,7 @@ def test_unsupported_component_bucket_ref_raises(tmp_path: Path) -> None:
     residual ``UnsupportedSpecError`` envelope. The envelope shape is
     asserted here so future bucket gaps stay diagnosable.
     """
-    spec = tmp_path / "headers_ref.yaml"
-    spec.write_text(
-        """
-openapi: '3.0.3'
+    content = b"""openapi: '3.0.3'
 info: {title: x, version: '1'}
 paths:
   /x:
@@ -495,10 +602,11 @@ components:
     X-Rate-Limit:
       schema:
         type: integer
-        """.lstrip()
-    )
-    with pytest.raises(UnsupportedSpecError, match="unsupported component bucket"):
-        parse_openapi(str(spec))
+"""
+    with respx.mock(assert_all_called=False) as router:
+        url = _mock_yaml_spec(router, "headers_ref.yaml", content)
+        with pytest.raises(UnsupportedSpecError, match="unsupported component bucket"):
+            parse_openapi(url)
 
 
 def test_resolve_shallow_ref_parameter_ref_opt_in() -> None:
@@ -531,7 +639,9 @@ def test_parse_parameter_refs_30_fixture() -> None:
     time, including ``x-meho-param-loc="path"`` and required-by-default
     path-parameter semantics.
     """
-    rows = parse_openapi(str(PARAMETER_REFS_30))
+    with respx.mock(assert_all_called=False) as router:
+        url = _mock_yaml_spec(router, "parameter_refs_30.yaml", PARAMETER_REFS_30.read_bytes())
+        rows = parse_openapi(url)
     op_ids = {row.op_id for row in rows}
     assert op_ids == {
         "POST:/vm/{moId}/PowerOn_Task",
@@ -609,7 +719,9 @@ def test_parse_response_refs_30_fixture() -> None:
     transparently, the rest of the parser sees the resolved
     Response Object.
     """
-    rows = parse_openapi(str(RESPONSE_REFS_30))
+    with respx.mock(assert_all_called=False) as router:
+        url = _mock_yaml_spec(router, "response_refs_30.yaml", RESPONSE_REFS_30.read_bytes())
+        rows = parse_openapi(url)
     by_op = _by_op_id(rows)
     assert set(by_op) == {"GET:/widgets", "GET:/widgets/{id}"}
 
@@ -644,7 +756,11 @@ def test_parse_request_body_refs_30_fixture() -> None:
     ``required=True`` because the resolved Request Body Object's
     ``required`` field is ``True``.
     """
-    rows = parse_openapi(str(REQUEST_BODY_REFS_30))
+    with respx.mock(assert_all_called=False) as router:
+        url = _mock_yaml_spec(
+            router, "request_body_refs_30.yaml", REQUEST_BODY_REFS_30.read_bytes()
+        )
+        rows = parse_openapi(url)
     by_op = _by_op_id(rows)
     assert set(by_op) == {"POST:/widgets", "PUT:/widgets/{id}"}
 
@@ -662,7 +778,7 @@ def test_parse_request_body_refs_30_fixture() -> None:
         assert "body" in required, f"{op_id}: body must be required (requestBody.required=True)"
 
 
-def test_parse_github_shaped_response_ref_with_inline_schema(tmp_path: Path) -> None:
+def test_parse_github_shaped_response_ref_with_inline_schema() -> None:
     """Tightest reproduction of the GitHub spec's `responses/accepted` shape.
 
     GitHub's spec defines ``components.responses.accepted`` with a
@@ -670,10 +786,7 @@ def test_parse_github_shaped_response_ref_with_inline_schema(tmp_path: Path) -> 
     — no nested ``$ref``. Locks the simplest case so future
     refactors don't lose it.
     """
-    spec = tmp_path / "gh_accepted.yaml"
-    spec.write_text(
-        """
-openapi: '3.0.3'
+    content = b"""openapi: '3.0.3'
 info: {title: x, version: '1'}
 paths:
   /op:
@@ -690,19 +803,17 @@ components:
         application/json:
           schema:
             type: object
-        """.lstrip()
-    )
-    rows = parse_openapi(str(spec))
+"""
+    with respx.mock(assert_all_called=False) as router:
+        url = _mock_yaml_spec(router, "gh_accepted.yaml", content)
+        rows = parse_openapi(url)
     assert len(rows) == 1
     assert rows[0].response_schema == {"type": "object"}
 
 
-def test_missing_response_ref_raises(tmp_path: Path) -> None:
+def test_missing_response_ref_raises() -> None:
     """A ref to an unknown response component raises ``InvalidSchemaError``."""
-    spec = tmp_path / "dangling_response.yaml"
-    spec.write_text(
-        """
-openapi: '3.0.3'
+    content = b"""openapi: '3.0.3'
 info: {title: x, version: '1'}
 paths:
   /x:
@@ -718,18 +829,16 @@ components:
         application/json:
           schema:
             type: string
-        """.lstrip()
-    )
-    with pytest.raises(InvalidSchemaError, match="missing component"):
-        parse_openapi(str(spec))
+"""
+    with respx.mock(assert_all_called=False) as router:
+        url = _mock_yaml_spec(router, "dangling_response.yaml", content)
+        with pytest.raises(InvalidSchemaError, match="missing component"):
+            parse_openapi(url)
 
 
-def test_missing_request_body_ref_raises(tmp_path: Path) -> None:
+def test_missing_request_body_ref_raises() -> None:
     """A ref to an unknown requestBody component raises ``InvalidSchemaError``."""
-    spec = tmp_path / "dangling_requestbody.yaml"
-    spec.write_text(
-        """
-openapi: '3.0.3'
+    content = b"""openapi: '3.0.3'
 info: {title: x, version: '1'}
 paths:
   /x:
@@ -746,17 +855,15 @@ components:
         application/json:
           schema:
             type: string
-        """.lstrip()
-    )
-    with pytest.raises(InvalidSchemaError, match="missing component"):
-        parse_openapi(str(spec))
+"""
+    with respx.mock(assert_all_called=False) as router:
+        url = _mock_yaml_spec(router, "dangling_requestbody.yaml", content)
+        with pytest.raises(InvalidSchemaError, match="missing component"):
+            parse_openapi(url)
 
 
-def test_missing_schema_ref_raises(tmp_path: Path) -> None:
-    spec = tmp_path / "dangling.yaml"
-    spec.write_text(
-        """
-openapi: '3.0.3'
+def test_missing_schema_ref_raises() -> None:
+    content = b"""openapi: '3.0.3'
 info: {title: x, version: '1'}
 paths:
   /x:
@@ -769,18 +876,16 @@ paths:
       responses:
         "200":
           description: ok
-        """.lstrip()
-    )
-    with pytest.raises(InvalidSchemaError, match="missing component"):
-        parse_openapi(str(spec))
+"""
+    with respx.mock(assert_all_called=False) as router:
+        url = _mock_yaml_spec(router, "dangling.yaml", content)
+        with pytest.raises(InvalidSchemaError, match="missing component"):
+            parse_openapi(url)
 
 
-def test_non_list_tags_raises(tmp_path: Path) -> None:
+def test_non_list_tags_raises() -> None:
     """A spec with ``tags: "admin"`` would otherwise iterate as characters."""
-    spec = tmp_path / "bad_tags.yaml"
-    spec.write_text(
-        """
-openapi: '3.0.3'
+    content = b"""openapi: '3.0.3'
 info: {title: x, version: '1'}
 paths:
   /x:
@@ -789,18 +894,16 @@ paths:
       responses:
         "200":
           description: ok
-        """.lstrip()
-    )
-    with pytest.raises(InvalidSchemaError, match=r"tags must be a list"):
-        parse_openapi(str(spec))
+"""
+    with respx.mock(assert_all_called=False) as router:
+        url = _mock_yaml_spec(router, "bad_tags.yaml", content)
+        with pytest.raises(InvalidSchemaError, match=r"tags must be a list"):
+            parse_openapi(url)
 
 
-def test_openapi_31_boolean_parameter_schema(tmp_path: Path) -> None:
+def test_openapi_31_boolean_parameter_schema() -> None:
     """OpenAPI 3.1 allows ``schema: true`` / ``schema: false`` on parameters."""
-    spec = tmp_path / "bool_param.yaml"
-    spec.write_text(
-        """
-openapi: '3.1.0'
+    content = b"""openapi: '3.1.0'
 info: {title: x, version: '1'}
 paths:
   /any:
@@ -811,9 +914,10 @@ paths:
       responses:
         "200":
           description: ok
-        """.lstrip()
-    )
-    rows = parse_openapi(str(spec))
+"""
+    with respx.mock(assert_all_called=False) as router:
+        url = _mock_yaml_spec(router, "bool_param.yaml", content)
+        rows = parse_openapi(url)
     props = rows[0].parameter_schema["properties"]
     assert isinstance(props, dict)
     # true → {} (matches anything)
@@ -822,12 +926,9 @@ paths:
     assert props["nothing"] == {"not": {}, "x-meho-param-loc": "query"}
 
 
-def test_openapi_31_boolean_body_and_response_schema(tmp_path: Path) -> None:
+def test_openapi_31_boolean_body_and_response_schema() -> None:
     """Boolean body / response schemas survive the parser pipeline."""
-    spec = tmp_path / "bool_body.yaml"
-    spec.write_text(
-        """
-openapi: '3.1.0'
+    content = b"""openapi: '3.1.0'
 info: {title: x, version: '1'}
 paths:
   /any:
@@ -843,19 +944,17 @@ paths:
           content:
             application/json:
               schema: false
-        """.lstrip()
-    )
-    rows = parse_openapi(str(spec))
+"""
+    with respx.mock(assert_all_called=False) as router:
+        url = _mock_yaml_spec(router, "bool_body.yaml", content)
+        rows = parse_openapi(url)
     body = rows[0].parameter_schema["properties"]["body"]
     assert body == {"x-meho-param-loc": "body"}  # true → {} merged with loc keyword
     assert rows[0].response_schema == {"not": {}}  # false → {"not": {}}
 
 
-def test_drilldown_schema_ref_raises(tmp_path: Path) -> None:
-    spec = tmp_path / "drilldown.yaml"
-    spec.write_text(
-        """
-openapi: '3.0.3'
+def test_drilldown_schema_ref_raises() -> None:
+    content = b"""openapi: '3.0.3'
 info: {title: x, version: '1'}
 paths:
   /x:
@@ -874,10 +973,11 @@ components:
       type: object
       properties:
         y: {type: string}
-        """.lstrip()
-    )
-    with pytest.raises(InvalidSchemaError, match="drill-down"):
-        parse_openapi(str(spec))
+"""
+    with respx.mock(assert_all_called=False) as router:
+        url = _mock_yaml_spec(router, "drilldown.yaml", content)
+        with pytest.raises(InvalidSchemaError, match="drill-down"):
+            parse_openapi(url)
 
 
 # -- model behaviour -------------------------------------------------------
@@ -903,7 +1003,7 @@ def test_proto_safety_level_literal_rejects_garbage() -> None:
 
 
 def test_http_fetch_round_trip() -> None:
-    """``http(s)://`` URLs are fetched via httpx."""
+    """``https://`` URLs are fetched via httpx."""
     with respx.mock(assert_all_called=False) as mock_router:
         mock_router.get("https://example.test/spec.yaml").mock(
             return_value=httpx.Response(
@@ -973,9 +1073,7 @@ def test_http_fetch_missing_content_type_raises_upstream_not_spec() -> None:
     assert exc_info.value.content_type is None
 
 
-def test_http_fetch_application_yaml_content_type_accepted(
-    tmp_path: Path,
-) -> None:
+def test_http_fetch_application_yaml_content_type_accepted() -> None:
     """G0.15-T2 (#1211): a 2xx response with ``application/yaml`` proceeds
     through the parser unchanged.
 
@@ -1032,59 +1130,293 @@ def test_http_fetch_accepted_content_types_proceed(content_type: str) -> None:
     assert rows
 
 
+# -- SSRF / local-file guard (G0.16-T8, #95) --------------------------------
+
+
+def test_ssrf_file_uri_rejected_before_any_read() -> None:
+    """AC-3: ``file:///etc/passwd`` raises ``InvalidSpecError`` before any file read.
+
+    The guard fires at the scheme check in ``_assert_fetchable_remote_url``
+    before any network or filesystem activity. The exception message must
+    not contain the path string so the response is not a filesystem oracle.
+    """
+    with pytest.raises(InvalidSpecError) as exc_info:
+        parse_openapi("file:///etc/passwd")
+    msg = str(exc_info.value)
+    assert "/etc/passwd" not in msg
+    assert "OSError" not in msg and "FileNotFoundError" not in msg
+
+
+def test_ssrf_file_uri_rejected_via_read_spec_info_version() -> None:
+    """AC-3 end-to-end: same guard fires through ``read_spec_info_version``."""
+    with pytest.raises(InvalidSpecError) as exc_info:
+        read_spec_info_version("file:///etc/passwd")
+    msg = str(exc_info.value)
+    assert "/etc/passwd" not in msg
+
+
+def test_ssrf_bare_path_rejected() -> None:
+    """A bare filesystem path (no scheme) is rejected as non-https."""
+    with pytest.raises(InvalidSpecError, match="https"):
+        parse_openapi("/etc/passwd")
+
+
+def test_ssrf_http_scheme_rejected() -> None:
+    """``http://`` is rejected; only ``https://`` is permitted on the ingest path."""
+    with pytest.raises(InvalidSpecError, match="https"):
+        parse_openapi("http://example.com/spec.yaml")
+
+
+def test_ssrf_metadata_ip_rejected_before_connect() -> None:
+    """AC-4: ``http://169.254.169.254/...`` is rejected before any socket connect.
+
+    The guard resolves the hostname and checks every returned address
+    against the private/link-local/reserved ranges before opening a
+    connection. With the scheme check firing first (``http`` is not
+    ``https``), the rejection happens even before DNS is attempted.
+    This test also exercises the HTTPS variant by patching ``getaddrinfo``
+    to return the metadata IP directly, proving the IP check fires.
+    """
+    # Scheme check fires first for ``http``.
+    with pytest.raises(InvalidSpecError, match="https"):
+        parse_openapi("http://169.254.169.254/latest/meta-data/")
+
+    # For the HTTPS variant, mock getaddrinfo to return the metadata IP
+    # so the IP-range check fires without a real DNS lookup.
+    import socket
+
+    with (
+        patch(
+            "meho_backplane.operations.ingest.openapi.socket.getaddrinfo",
+            return_value=[(socket.AF_INET, socket.SOCK_STREAM, 0, "", ("169.254.169.254", 443))],
+        ),
+        respx.mock(assert_all_called=False) as router,
+    ):
+        # Register a route but assert it is never called — the guard
+        # must fire before the transport opens a connection.
+        router.get("https://169.254.169.254/latest/meta-data/").mock(
+            return_value=httpx.Response(200, content=b"", headers={"content-type": "text/plain"})
+        )
+        with pytest.raises(InvalidSpecError, match="non-public"):
+            parse_openapi("https://169.254.169.254/latest/meta-data/")
+        assert router.calls.call_count == 0
+
+
+def test_ssrf_private_ip_rejected_before_connect() -> None:
+    """AC-4 variant: RFC-1918 private IPs are rejected before any socket connect.
+
+    Patches ``getaddrinfo`` to return a 10.x.x.x address so the IP
+    check fires even for a hostname that looks public in the URL.
+    """
+    import socket
+
+    with (
+        patch(
+            "meho_backplane.operations.ingest.openapi.socket.getaddrinfo",
+            return_value=[(socket.AF_INET, socket.SOCK_STREAM, 0, "", ("10.0.0.5", 443))],
+        ),
+        respx.mock(assert_all_called=False) as router,
+    ):
+        router.get("https://public-looking.example.test/spec.yaml").mock(
+            return_value=httpx.Response(200, content=b"", headers={"content-type": "text/plain"})
+        )
+        with pytest.raises(InvalidSpecError, match="non-public"):
+            parse_openapi("https://public-looking.example.test/spec.yaml")
+        assert router.calls.call_count == 0
+
+
+def test_ssrf_redirect_to_private_ip_rejected() -> None:
+    """AC-5: a 30x redirect from an allowlisted public host to a private IP is rejected.
+
+    The guard re-validates every redirect hop before following it.
+    The private-target route must never be called.
+    """
+    import socket
+
+    public_url = "https://public.example.test/spec.yaml"
+    private_redirect_url = "https://10.0.0.5/spec.yaml"
+
+    # First call (public host) resolves to a real public IP.
+    public_addrs = [(socket.AF_INET, socket.SOCK_STREAM, 0, "", ("93.184.216.34", 443))]
+    # Second call (private redirect target) returns a private IP.
+    private_addrs = [(socket.AF_INET, socket.SOCK_STREAM, 0, "", ("10.0.0.5", 443))]
+
+    call_count = 0
+
+    def _mock_getaddrinfo(hostname: str, port: object, **kwargs: object) -> list:
+        nonlocal call_count
+        call_count += 1
+        if hostname == "public.example.test":
+            return public_addrs
+        return private_addrs
+
+    with (
+        patch(
+            "meho_backplane.operations.ingest.openapi.socket.getaddrinfo",
+            side_effect=_mock_getaddrinfo,
+        ),
+        respx.mock(assert_all_called=False) as router,
+    ):
+        router.get(public_url).mock(
+            return_value=httpx.Response(302, headers={"location": private_redirect_url})
+        )
+        private_route = router.get(private_redirect_url).mock(
+            return_value=httpx.Response(
+                200,
+                content=PETSTORE_31_YAML.read_bytes(),
+                headers={"content-type": "application/yaml"},
+            )
+        )
+        with pytest.raises(InvalidSpecError, match="non-public"):
+            parse_openapi(public_url)
+        # The private-target route must not have been called.
+        assert not private_route.called
+
+
+def test_ssrf_public_https_spec_fetch_succeeds() -> None:
+    """AC-6: a ``https`` URL resolving to a public IP returns spec bytes unchanged.
+
+    Proves the guard does not block legitimate catalog/CDN fetches.
+    Patches ``getaddrinfo`` to return a stable public IP so the test
+    is not sensitive to external DNS.
+    """
+    import socket
+
+    url = "https://cdn.example.test/spec.yaml"
+    with (
+        patch(
+            "meho_backplane.operations.ingest.openapi.socket.getaddrinfo",
+            return_value=[(socket.AF_INET, socket.SOCK_STREAM, 0, "", ("93.184.216.34", 443))],
+        ),
+        respx.mock(assert_all_called=False) as router,
+    ):
+        router.get(url).mock(
+            return_value=httpx.Response(
+                200,
+                content=PETSTORE_31_YAML.read_bytes(),
+                headers={"content-type": "application/yaml"},
+            )
+        )
+        rows = parse_openapi(url)
+    assert rows  # guard did not block; parsing succeeded
+
+
+# -- _assert_fetchable_remote_url unit tests --------------------------------
+
+
+def test_assert_fetchable_remote_url_rejects_http_scheme() -> None:
+    with pytest.raises(InvalidSpecError, match="https"):
+        _assert_fetchable_remote_url("http://example.com/spec.yaml")
+
+
+def test_assert_fetchable_remote_url_rejects_file_scheme() -> None:
+    with pytest.raises(InvalidSpecError, match="https"):
+        _assert_fetchable_remote_url("file:///etc/passwd")
+
+
+def test_assert_fetchable_remote_url_rejects_missing_hostname() -> None:
+    with pytest.raises(InvalidSpecError, match="hostname"):
+        _assert_fetchable_remote_url("https:///no-host/spec.yaml")
+
+
+@pytest.mark.parametrize(
+    "private_ip",
+    [
+        "127.0.0.1",  # loopback
+        "10.0.0.1",  # RFC-1918
+        "172.16.0.1",  # RFC-1918
+        "192.168.1.1",  # RFC-1918
+        "169.254.169.254",  # cloud metadata (link-local)
+        "::1",  # IPv6 loopback
+        "fc00::1",  # ULA (unique local)
+        "fe80::1",  # IPv6 link-local
+    ],
+)
+def test_assert_fetchable_remote_url_rejects_private_ips(private_ip: str) -> None:
+    """Every address family in the private/reserved ranges is blocked."""
+    import socket
+
+    with (
+        patch(
+            "meho_backplane.operations.ingest.openapi.socket.getaddrinfo",
+            return_value=[(socket.AF_INET, socket.SOCK_STREAM, 0, "", (private_ip, 443))],
+        ),
+        pytest.raises(InvalidSpecError, match="non-public"),
+    ):
+        _assert_fetchable_remote_url("https://any.example.test/spec.yaml")
+
+
+def test_assert_fetchable_remote_url_accepts_public_ip() -> None:
+    """A hostname resolving to a public IP passes the guard without error."""
+    import socket
+
+    with patch(
+        "meho_backplane.operations.ingest.openapi.socket.getaddrinfo",
+        return_value=[(socket.AF_INET, socket.SOCK_STREAM, 0, "", ("93.184.216.34", 443))],
+    ):
+        # Should not raise.
+        _assert_fetchable_remote_url("https://example.com/spec.yaml")
+
+
 # -- read_spec_info_version ------------------------------------------------
 
 
-def test_read_spec_info_version_returns_string(tmp_path: Path) -> None:
+def test_read_spec_info_version_returns_string() -> None:
     """Happy path — the spec's ``info.version`` is returned verbatim."""
-    spec = tmp_path / "spec.yaml"
-    spec.write_text("openapi: '3.0.3'\ninfo: {title: t, version: '9.0.3'}\npaths: {}\n")
-    assert read_spec_info_version(str(spec)) == "9.0.3"
+    content = b"openapi: '3.0.3'\ninfo: {title: t, version: '9.0.3'}\npaths: {}\n"
+    with respx.mock(assert_all_called=False) as router:
+        url = _mock_yaml_spec(router, "spec.yaml", content)
+        assert read_spec_info_version(url) == "9.0.3"
 
 
-def test_read_spec_info_version_missing_info_returns_none(tmp_path: Path) -> None:
+def test_read_spec_info_version_missing_info_returns_none() -> None:
     """Specs without an ``info`` block return ``None`` — the cross-check skips."""
-    spec = tmp_path / "spec.yaml"
-    spec.write_text("openapi: '3.0.3'\npaths: {}\n")
-    assert read_spec_info_version(str(spec)) is None
+    content = b"openapi: '3.0.3'\npaths: {}\n"
+    with respx.mock(assert_all_called=False) as router:
+        url = _mock_yaml_spec(router, "spec.yaml", content)
+        assert read_spec_info_version(url) is None
 
 
-def test_read_spec_info_version_missing_version_field_returns_none(tmp_path: Path) -> None:
+def test_read_spec_info_version_missing_version_field_returns_none() -> None:
     """``info`` present but no ``version`` field → ``None``."""
-    spec = tmp_path / "spec.yaml"
-    spec.write_text("openapi: '3.0.3'\ninfo: {title: t}\npaths: {}\n")
-    assert read_spec_info_version(str(spec)) is None
+    content = b"openapi: '3.0.3'\ninfo: {title: t}\npaths: {}\n"
+    with respx.mock(assert_all_called=False) as router:
+        url = _mock_yaml_spec(router, "spec.yaml", content)
+        assert read_spec_info_version(url) is None
 
 
-def test_read_spec_info_version_non_string_version_returns_none(tmp_path: Path) -> None:
+def test_read_spec_info_version_non_string_version_returns_none() -> None:
     """A non-string ``info.version`` (e.g. an integer) → ``None``."""
-    spec = tmp_path / "spec.yaml"
-    spec.write_text("openapi: '3.0.3'\ninfo: {title: t, version: 1}\npaths: {}\n")
-    assert read_spec_info_version(str(spec)) is None
+    content = b"openapi: '3.0.3'\ninfo: {title: t, version: 1}\npaths: {}\n"
+    with respx.mock(assert_all_called=False) as router:
+        url = _mock_yaml_spec(router, "spec.yaml", content)
+        assert read_spec_info_version(url) is None
 
 
-def test_read_spec_info_version_empty_version_returns_none(tmp_path: Path) -> None:
+def test_read_spec_info_version_empty_version_returns_none() -> None:
     """An empty ``info.version`` string is treated as missing."""
-    spec = tmp_path / "spec.yaml"
-    spec.write_text("openapi: '3.0.3'\ninfo: {title: t, version: ''}\npaths: {}\n")
-    assert read_spec_info_version(str(spec)) is None
+    content = b"openapi: '3.0.3'\ninfo: {title: t, version: ''}\npaths: {}\n"
+    with respx.mock(assert_all_called=False) as router:
+        url = _mock_yaml_spec(router, "spec.yaml", content)
+        assert read_spec_info_version(url) is None
 
 
-def test_read_spec_info_version_rejects_swagger_2(tmp_path: Path) -> None:
+def test_read_spec_info_version_rejects_swagger_2() -> None:
     """Swagger 2.0 specs surface the same gate :func:`parse_openapi` enforces.
 
     The cross-check helper shares ``_validate_openapi_version`` with the
     parser, so the same actionable conversion-path remedy reaches the
     operator on the spec-vs-label fast path (#1532).
     """
-    spec = tmp_path / "spec.yaml"
-    spec.write_text("swagger: '2.0'\ninfo: {title: t, version: '9.0.3'}\npaths: {}\n")
-    with pytest.raises(UnsupportedSpecError, match=r"Swagger 2\.0") as excinfo:
-        read_spec_info_version(str(spec))
+    content = b"swagger: '2.0'\ninfo: {title: t, version: '9.0.3'}\npaths: {}\n"
+    with respx.mock(assert_all_called=False) as router:
+        url = _mock_yaml_spec(router, "spec.yaml", content)
+        with pytest.raises(UnsupportedSpecError, match=r"Swagger 2\.0") as excinfo:
+            read_spec_info_version(url)
     assert "swagger2openapi" in str(excinfo.value)
 
 
-def test_read_spec_info_version_missing_file_raises_invalid_spec(tmp_path: Path) -> None:
-    missing = tmp_path / "nope.yaml"
-    with pytest.raises(InvalidSpecError, match="could not read spec"):
-        read_spec_info_version(str(missing))
+def test_read_spec_info_version_non_https_scheme_raises_invalid_spec() -> None:
+    """Non-https schemes raise ``InvalidSpecError`` from read_spec_info_version too."""
+    with pytest.raises(InvalidSpecError, match="https"):
+        read_spec_info_version("file:///tmp/nope.yaml")

--- a/backend/tests/test_operations_ingest_pipeline_version_check.py
+++ b/backend/tests/test_operations_ingest_pipeline_version_check.py
@@ -65,7 +65,7 @@ def _bound_log() -> structlog.stdlib.BoundLogger:
     return structlog.get_logger(__name__).bind(test=True)
 
 
-def _read_spec_info_version_local(uri: str) -> str | None:
+def _read_spec_info_version_local(uri: str, *, content: str | None = None) -> str | None:
     """Read ``info.version`` from a local file path URI, bypassing the SSRF guard.
 
     Autouse fixture :func:`_patch_read_spec_info_version` swaps
@@ -75,12 +75,15 @@ def _read_spec_info_version_local(uri: str) -> str | None:
     (#95). The SSRF guard's own correctness is covered by
     ``tests/test_operations_ingest_openapi.py``.
     """
+    if content is not None:
+        raw = content.encode("utf-8")
+    else:
+        try:
+            raw = Path(uri).read_bytes()
+        except OSError:
+            return None
     try:
-        content = Path(uri).read_bytes()
-    except OSError:
-        return None
-    try:
-        spec = yaml.safe_load(io.BytesIO(content))
+        spec = yaml.safe_load(io.BytesIO(raw))
     except yaml.YAMLError:
         return None
     if not isinstance(spec, dict):

--- a/backend/tests/test_operations_ingest_pipeline_version_check.py
+++ b/backend/tests/test_operations_ingest_pipeline_version_check.py
@@ -28,11 +28,13 @@ covered by ``tests/test_api_v1_connectors_ingest.py``.
 
 from __future__ import annotations
 
+import io
 import uuid
 from pathlib import Path
 
 import pytest
 import structlog
+import yaml
 
 from meho_backplane.auth.operator import Operator, TenantRole
 from meho_backplane.operations.ingest import (
@@ -61,6 +63,53 @@ def _operator() -> Operator:
 def _bound_log() -> structlog.stdlib.BoundLogger:
     """Return a bound logger of the shape ``_validate_spec_versions`` expects."""
     return structlog.get_logger(__name__).bind(test=True)
+
+
+def _read_spec_info_version_local(uri: str) -> str | None:
+    """Read ``info.version`` from a local file path URI, bypassing the SSRF guard.
+
+    Autouse fixture :func:`_patch_read_spec_info_version` swaps
+    the pipeline's ``read_spec_info_version`` for this function so
+    these service-layer unit tests can pass local file paths without
+    triggering the network-facing guard that was added in G0.16-T8
+    (#95). The SSRF guard's own correctness is covered by
+    ``tests/test_operations_ingest_openapi.py``.
+    """
+    try:
+        content = Path(uri).read_bytes()
+    except OSError:
+        return None
+    try:
+        spec = yaml.safe_load(io.BytesIO(content))
+    except yaml.YAMLError:
+        return None
+    if not isinstance(spec, dict):
+        return None
+    info = spec.get("info")
+    if not isinstance(info, dict):
+        return None
+    version = info.get("version")
+    if not isinstance(version, str) or not version:
+        return None
+    return version
+
+
+@pytest.fixture(autouse=True)
+def _patch_read_spec_info_version(monkeypatch: pytest.MonkeyPatch) -> None:
+    """Replace the pipeline's ``read_spec_info_version`` with a local-file reader.
+
+    These tests exercise ``_validate_spec_versions`` (the service-layer
+    cross-check logic) not the HTTP fetch path. G0.16-T8 (#95) moved
+    the network-facing guard into ``_load_spec_bytes``, so all tests
+    that pass local file paths as ``spec.uri`` would fail the scheme
+    check without this patch. Swapping the imported name in the pipeline
+    module is the narrowest possible seam — only ``_validate_spec_versions``
+    is affected; the real ``read_spec_info_version`` (and its SSRF guard)
+    stays in place for every other caller.
+    """
+    import meho_backplane.operations.ingest.pipeline as _pipeline_mod
+
+    monkeypatch.setattr(_pipeline_mod, "read_spec_info_version", _read_spec_info_version_local)
 
 
 def _spec_yaml(path: Path, *, openapi: str = "3.0.3", info_version: str | None) -> SpecSource:

--- a/backend/tests/test_operations_register_ingested.py
+++ b/backend/tests/test_operations_register_ingested.py
@@ -46,10 +46,13 @@ from __future__ import annotations
 
 import uuid
 from collections.abc import AsyncIterator, Iterator
+from pathlib import Path
 from typing import Any
 from unittest.mock import AsyncMock
 
+import httpx
 import pytest
+import respx
 import structlog.testing
 from sqlalchemy import select
 from sqlalchemy.ext.asyncio import AsyncSession
@@ -692,7 +695,29 @@ async def test_end_to_end_with_real_parsed_spec(
     :func:`parse_openapi` without any shape massaging at the call
     site.
     """
-    operations = parse_openapi("tests/fixtures/openapi/petstore_30.yaml")
+    import socket
+    from unittest.mock import patch
+
+    _fixtures = Path(__file__).parent / "fixtures" / "openapi"
+    _petstore_30_bytes = (_fixtures / "petstore_30.yaml").read_bytes()
+    _petstore_url = "https://specs.example.test/petstore_30.yaml"
+    # Patch getaddrinfo so the SSRF guard resolves specs.example.test to a
+    # public IP without a real DNS lookup; then mock the HTTP fetch via respx.
+    with (
+        patch(
+            "meho_backplane.operations.ingest.openapi.socket.getaddrinfo",
+            return_value=[(socket.AF_INET, socket.SOCK_STREAM, 0, "", ("93.184.216.34", 443))],
+        ),
+        respx.mock(assert_all_called=False) as _router,
+    ):
+        _router.get(_petstore_url).mock(
+            return_value=httpx.Response(
+                200,
+                content=_petstore_30_bytes,
+                headers={"content-type": "application/yaml"},
+            )
+        )
+        operations = parse_openapi(_petstore_url)
 
     result = await register_ingested_operations(
         product="petstore",

--- a/cli/api/openapi.json
+++ b/cli/api/openapi.json
@@ -15345,6 +15345,12 @@
             "maxLength": 2048,
             "minLength": 1,
             "title": "Uri"
+          },
+          "content": {
+            "type": "string",
+            "maxLength": 20971520,
+            "nullable": true,
+            "title": "Content"
           }
         },
         "additionalProperties": false,
@@ -15353,7 +15359,7 @@
           "uri"
         ],
         "title": "SpecSource",
-        "description": "One spec to ingest under a connector triple.\n\n``uri`` carries the operator's spec identifier. Two forms are\nresolved by the underlying :func:`parse_openapi` resolver:\n\n* Absolute local path \u2014 ``/abs/path/to/spec.yaml`` (or its\n  ``file://`` URI form).\n* HTTP(S) URL \u2014 ``https://api.example.com/openapi.yaml``.\n\nThe ``meho`` CLI additionally accepts a ``docs:<connector-id>/<file>``\nshorthand, which it expands **CLI-side** to a ``file://`` URI against\n``$CLAUDE_RDC_DOCS`` before sending the request. The backend has no\ndocs root of its own, so a bare ``docs:`` URI that reaches the parser\nunexpanded is rejected with :exc:`UnsupportedSpecError` naming the\nscheme \u2014 the backend does not resolve ``docs:`` natively (#1535).\n\nWrapped in its own model so future per-spec knobs (auth headers,\ndialect pinning, content-type override) can land without\nreshaping :class:`IngestRequest`. ``extra=\"forbid\"`` rejects\nunknown fields (per the request-schema-strictness rule) so a\ntypo in a nested ``specs[*]`` entry fails 422 at the body parse\ninstead of being silently dropped."
+        "description": "One spec to ingest under a connector triple.\n\n``uri`` is the operator's spec identifier and audit label. When the\nspec is *fetched* by the backend, only an ``https://`` URL is\naccepted -- the G0.16-T8 (#95) SSRF / local-file guard rejects\n``http``, ``file://``, and bare paths so a spec URI cannot become a\nnetwork-topology or filesystem oracle.\n\n``content`` carries the spec text inline. The ``meho`` CLI reads\n``docs:<connector-id>/<file>`` and ``file://`` sources **CLI-side**\nand uploads the bytes here, leaving ``uri`` as the audit label, so\nno local path or non-https scheme reaches the backend. When\n``content`` is set the backend uses it verbatim (size-capped) and\nskips the fetch; when absent, ``uri`` is fetched under the https\nguard. A bare ``docs:`` URI that reaches the backend with no\n``content`` is rejected with :exc:`UnsupportedSpecError` (#1535).\n\nWrapped in its own model so future per-spec knobs (auth headers,\ndialect pinning, content-type override) can land without\nreshaping :class:`IngestRequest`. ``extra=\"forbid\"`` rejects\nunknown fields (per the request-schema-strictness rule) so a\ntypo in a nested ``specs[*]`` entry fails 422 at the body parse\ninstead of being silently dropped."
       },
       "StartRunRequest": {
         "properties": {

--- a/cli/internal/api/client.gen.go
+++ b/cli/internal/api/client.gen.go
@@ -3872,19 +3872,20 @@ type SkippedConnector struct {
 
 // SpecSource One spec to ingest under a connector triple.
 //
-// “uri“ carries the operator's spec identifier. Two forms are
-// resolved by the underlying :func:`parse_openapi` resolver:
+// “uri“ is the operator's spec identifier and audit label. When the
+// spec is *fetched* by the backend, only an “https://“ URL is
+// accepted -- the G0.16-T8 (#95) SSRF / local-file guard rejects
+// “http“, “file://“, and bare paths so a spec URI cannot become a
+// network-topology or filesystem oracle.
 //
-//   - Absolute local path — “/abs/path/to/spec.yaml“ (or its
-//     “file://“ URI form).
-//   - HTTP(S) URL — “https://api.example.com/openapi.yaml“.
-//
-// The “meho“ CLI additionally accepts a “docs:<connector-id>/<file>“
-// shorthand, which it expands **CLI-side** to a “file://“ URI against
-// “$CLAUDE_RDC_DOCS“ before sending the request. The backend has no
-// docs root of its own, so a bare “docs:“ URI that reaches the parser
-// unexpanded is rejected with :exc:`UnsupportedSpecError` naming the
-// scheme — the backend does not resolve “docs:“ natively (#1535).
+// “content“ carries the spec text inline. The “meho“ CLI reads
+// “docs:<connector-id>/<file>“ and “file://“ sources **CLI-side**
+// and uploads the bytes here, leaving “uri“ as the audit label, so
+// no local path or non-https scheme reaches the backend. When
+// “content“ is set the backend uses it verbatim (size-capped) and
+// skips the fetch; when absent, “uri“ is fetched under the https
+// guard. A bare “docs:“ URI that reaches the backend with no
+// “content“ is rejected with :exc:`UnsupportedSpecError` (#1535).
 //
 // Wrapped in its own model so future per-spec knobs (auth headers,
 // dialect pinning, content-type override) can land without
@@ -3893,7 +3894,8 @@ type SkippedConnector struct {
 // typo in a nested “specs[*]“ entry fails 422 at the body parse
 // instead of being silently dropped.
 type SpecSource struct {
-	Uri string `json:"uri"`
+	Content *string `json:"content"`
+	Uri     string  `json:"uri"`
 }
 
 // StartRunRequest Request body for “runbook_start“ -- begin a new run on a template.

--- a/cli/internal/cmd/connector/connector.go
+++ b/cli/internal/cmd/connector/connector.go
@@ -405,93 +405,92 @@ func truncate(s string, maxLen int) string {
 	return string(runes[:maxLen-1]) + "…"
 }
 
-// resolveSpecURI normalises a --spec flag value into the canonical
-// URI the backplane's IngestRequest accepts. Three input shapes are
+// resolveSpecURI normalises a --spec flag value into the (uri, content)
+// pair the backplane's IngestRequest accepts. Three input shapes are
 // supported:
 //
-//   - `file://<absolute path>`    — passes through after path validation.
-//   - `https://<url>` / `http://` — passes through.
-//   - `docs:<product-version>/<spec>` — shorthand resolving against
-//     the consumer's checked-in docs/ directory. The base directory
-//     comes from the CLAUDE_RDC_DOCS env var (operator workstation
-//     convention — points at a checkout of
-//     `claude-rdc-hetzner-dc/docs/meho-coordination/`). The resolved
-//     form is `file://<absolute path>` so the backplane sees a uniform
-//     scheme. Resolution is CLI-side only: the backplane has no docs
-//     root and does not resolve a bare `docs:` URI, so when
-//     CLAUDE_RDC_DOCS is unset the shorthand is rejected here with a
-//     hint naming the env var rather than passed through to surface as
-//     an opaque backplane ingest error (#1535).
+//   - `https://<url>` -- passed through as the uri; the backplane fetches
+//     it under the https-only SSRF / local-file guard (#95). content is
+//     empty. (`http://` is passed through too, but the https-only guard
+//     rejects it backplane-side.)
+//   - `file://<absolute path>` -- the CLI reads the file and uploads its
+//     bytes as content; uri is kept as the audit label. No local path
+//     reaches the backplane.
+//   - `docs:<product-version>/<spec>` -- resolved CLI-side against the
+//     consumer's checked-in docs/ directory ($CLAUDE_RDC_DOCS, e.g. a
+//     checkout of `claude-rdc-hetzner-dc/docs/meho-coordination/`), then
+//     read + uploaded as content with the `docs:` label kept as uri.
+//     When CLAUDE_RDC_DOCS is unset the shorthand is rejected here with a
+//     hint naming the env var (#1535).
 //
-// Anything else returns an error — the operator gets a clear "use
-// one of file:// / https:// / docs:<...>" hint rather than a 422
-// from the backplane.
-func resolveSpecURI(raw string) (string, error) {
+// Reading docs:/file:// CLI-side and uploading the bytes is what keeps
+// the #95 https-only backend from breaking the local-spec on-ramp: the
+// backplane never sees a local path or a non-https scheme (#102).
+//
+// Anything else returns an error -- the operator gets a clear "use one of
+// file:// / https:// / docs:<...>" hint rather than a 422 from the
+// backplane.
+func resolveSpecURI(raw string) (uri string, content string, err error) {
 	raw = strings.TrimSpace(raw)
 	if raw == "" {
-		return "", errors.New("--spec value is empty")
+		return "", "", errors.New("--spec value is empty")
 	}
 	if strings.HasPrefix(raw, "file://") {
-		// Validate locally so operators see a fast CLI error rather
-		// than a backplane 4xx. The contract is `file://<absolute
-		// path>` — relative or scheme-less file URIs are rejected.
-		u, err := url.Parse(raw)
-		if err != nil || u.Scheme != "file" {
-			return "", fmt.Errorf("--spec %q: invalid file URI", raw)
+		// Validate locally so operators see a fast CLI error rather than a
+		// backplane 4xx. The contract is `file://<absolute path>`.
+		u, perr := url.Parse(raw)
+		if perr != nil || u.Scheme != "file" {
+			return "", "", fmt.Errorf("--spec %q: invalid file URI", raw)
 		}
-		// Per RFC 8089, file URIs have either an empty authority
-		// or `localhost`. A bare `file://relative/path` would
-		// parse `relative` as the host, which is what RFC 3986
-		// says but not what an operator typing the URL means. Reject
-		// any other host so the typo surfaces here instead of as
-		// a confused on-disk lookup.
+		// Per RFC 8089, file URIs have either an empty authority or
+		// `localhost`. Reject any other host so a `file://relative/path`
+		// typo surfaces here instead of as a confused on-disk lookup.
 		if u.Host != "" && u.Host != "localhost" {
-			return "", fmt.Errorf("--spec %q: file URI host must be empty or \"localhost\"", raw)
+			return "", "", fmt.Errorf("--spec %q: file URI host must be empty or \"localhost\"", raw)
 		}
-		// u.Path is the on-disk path with the `file://` (and optional
-		// host) prefix stripped. `path.IsAbs` covers POSIX absolute
-		// paths; the Windows drive-letter form (`/C:/...`) also
-		// satisfies path.IsAbs after url.Parse normalises the leading
-		// slash, so one check covers both.
-		//
-		// Root-only (`file:///`) is rejected too — there's no spec
-		// file name to ingest. `len(u.Path) <= 1` covers both the
-		// empty case and the bare-slash case.
+		// Root-only (`file:///`) is rejected too -- no spec file to read.
 		if len(u.Path) <= 1 || !path.IsAbs(u.Path) {
-			return "", fmt.Errorf("--spec %q: file URI must be an absolute path to a spec", raw)
+			return "", "", fmt.Errorf("--spec %q: file URI must be an absolute path to a spec", raw)
 		}
-		return raw, nil
+		b, rerr := os.ReadFile(u.Path) // #nosec G304 -- operator-supplied spec path, operator-only CLI
+		if rerr != nil {
+			return "", "", fmt.Errorf("--spec %q: %w", raw, rerr)
+		}
+		return raw, string(b), nil
 	}
 	if strings.HasPrefix(raw, "https://") || strings.HasPrefix(raw, "http://") {
-		return raw, nil
+		return raw, "", nil
 	}
 	if strings.HasPrefix(raw, "docs:") {
 		shorthand := strings.TrimPrefix(raw, "docs:")
 		if shorthand == "" {
-			return "", errors.New("--spec docs: shorthand has no path")
+			return "", "", errors.New("--spec docs: shorthand has no path")
 		}
 		root := os.Getenv("CLAUDE_RDC_DOCS")
 		if root == "" {
-			// The `docs:` shorthand is resolved CLI-side only. The
-			// backplane has no docs root and does not resolve a bare
-			// `docs:` URI — passing one through would surface as an
-			// opaque ingest error (#1535). Fail here with a clear hint
-			// naming the env var the operator must set.
-			return "", errors.New(
+			// The `docs:` shorthand is resolved CLI-side only. The backplane
+			// has no docs root and is https-only, so it cannot resolve a bare
+			// `docs:` URI. Fail here with a clear hint naming the env var
+			// the operator must set (#1535).
+			return "", "", errors.New(
 				"--spec docs: shorthand requires $CLAUDE_RDC_DOCS to be set " +
 					"(the backplane does not resolve docs: URIs); set it to a " +
-					"docs checkout, or pass an absolute file:// / https:// spec URI",
+					"docs checkout, or pass a file:// / https:// spec URI",
 			)
 		}
 		abs := filepath.Join(root, shorthand)
 		if !filepath.IsAbs(abs) {
-			// filepath.Join keeps relative roots relative; reject
-			// rather than ship a half-resolved URI.
-			return "", fmt.Errorf("CLAUDE_RDC_DOCS=%q produced non-absolute spec path %q", root, abs)
+			// filepath.Join keeps relative roots relative; reject rather
+			// than read from a half-resolved path.
+			return "", "", fmt.Errorf("CLAUDE_RDC_DOCS=%q produced non-absolute spec path %q", root, abs)
 		}
-		return "file://" + abs, nil
+		b, rerr := os.ReadFile(abs) // #nosec G304 -- operator-supplied docs path, operator-only CLI
+		if rerr != nil {
+			return "", "", fmt.Errorf("--spec %q (resolved to %q): %w", raw, abs, rerr)
+		}
+		return raw, string(b), nil
 	}
-	return "", fmt.Errorf(
+	return "", "", fmt.Errorf(
 		"--spec %q: unknown URI scheme; expected file:// / https:// / docs:<product-version>/<spec>",
 		raw,
 	)

--- a/cli/internal/cmd/connector/connector_test.go
+++ b/cli/internal/cmd/connector/connector_test.go
@@ -111,101 +111,132 @@ func TestClassifyBackplaneErrorRoutesByCause(t *testing.T) {
 
 // ---------- resolveSpecURI ----------
 
-// TestResolveSpecURIFile — file:// passes through verbatim once
-// validated (scheme=file, path absolute).
+const sampleSpecYAML = "openapi: 3.0.3\ninfo: {title: t, version: '1'}\npaths: {}\n"
+
+// TestResolveSpecURIFile -- file:// is read CLI-side; the uri is kept as
+// the audit label and the file bytes are returned as content so no local
+// path reaches the backplane.
 func TestResolveSpecURIFile(t *testing.T) {
-	got, err := resolveSpecURI("file:///abs/path/spec.yaml")
+	specPath := filepath.Join(t.TempDir(), "spec.yaml")
+	if err := os.WriteFile(specPath, []byte(sampleSpecYAML), 0o600); err != nil {
+		t.Fatal(err)
+	}
+	uri := "file://" + specPath
+	gotURI, content, err := resolveSpecURI(uri)
 	if err != nil {
 		t.Fatalf("file scheme: %v", err)
 	}
-	if got != "file:///abs/path/spec.yaml" {
-		t.Fatalf("file scheme passthrough; got %q", got)
+	if gotURI != uri {
+		t.Fatalf("file uri label; got %q want %q", gotURI, uri)
+	}
+	if content != sampleSpecYAML {
+		t.Fatalf("file content; got %q", content)
 	}
 }
 
-// TestResolveSpecURIFileRejectsRelative — a `file://relative/path`
-// URI (no leading slash, so url.Parse reads `relative` as a host)
-// or an empty path is rejected client-side so operators see a fast
-// hint rather than a backplane 4xx.
+// TestResolveSpecURIFileMissing -- a file:// to a nonexistent path is
+// rejected client-side with the read error.
+func TestResolveSpecURIFileMissing(t *testing.T) {
+	_, _, err := resolveSpecURI("file:///no/such/spec.yaml")
+	if err == nil {
+		t.Fatalf("missing file should reject; got nil error")
+	}
+}
+
+// TestResolveSpecURIFileRejectsRelative -- a `file://relative/path` URI
+// (no leading slash, so url.Parse reads `relative` as a host) or an
+// empty/root path is rejected client-side.
 func TestResolveSpecURIFileRejectsRelative(t *testing.T) {
 	cases := []string{
-		"file://relative/path/spec.yaml", // host=relative, not empty
-		"file://",                        // empty path
-		"file:///",                       // root only — no spec name
+		"file://relative/path/spec.yaml",
+		"file://",
+		"file:///",
 	}
 	for _, in := range cases {
-		_, err := resolveSpecURI(in)
+		_, _, err := resolveSpecURI(in)
 		if err == nil || !strings.Contains(err.Error(), "file URI") {
 			t.Errorf("resolveSpecURI(%q): want rejection; got %v", in, err)
 		}
 	}
 }
 
-// TestResolveSpecURIFileAcceptsLocalhostHost — `file://localhost/abs`
-// is the RFC 8089 equivalent of `file:///abs` and must pass.
+// TestResolveSpecURIFileAcceptsLocalhostHost -- `file://localhost/abs` is
+// the RFC 8089 equivalent of `file:///abs` and is read the same way.
 func TestResolveSpecURIFileAcceptsLocalhostHost(t *testing.T) {
-	got, err := resolveSpecURI("file://localhost/abs/spec.yaml")
+	specPath := filepath.Join(t.TempDir(), "spec.yaml")
+	if err := os.WriteFile(specPath, []byte(sampleSpecYAML), 0o600); err != nil {
+		t.Fatal(err)
+	}
+	uri := "file://localhost" + specPath
+	gotURI, content, err := resolveSpecURI(uri)
 	if err != nil {
 		t.Fatalf("file://localhost: %v", err)
 	}
-	if got != "file://localhost/abs/spec.yaml" {
-		t.Fatalf("file://localhost passthrough; got %q", got)
+	if gotURI != uri || content != sampleSpecYAML {
+		t.Fatalf("file://localhost; got uri=%q content=%q", gotURI, content)
 	}
 }
 
-// TestResolveSpecURIHTTPS — http(s) passes through verbatim.
+// TestResolveSpecURIHTTPS -- https passes through as the uri; no content
+// (the backplane fetches it under the https-only guard).
 func TestResolveSpecURIHTTPS(t *testing.T) {
-	got, err := resolveSpecURI("https://example.com/spec.yaml")
+	gotURI, content, err := resolveSpecURI("https://example.com/spec.yaml")
 	if err != nil {
 		t.Fatalf("https scheme: %v", err)
 	}
-	if got != "https://example.com/spec.yaml" {
-		t.Fatalf("https passthrough; got %q", got)
+	if gotURI != "https://example.com/spec.yaml" || content != "" {
+		t.Fatalf("https passthrough; got uri=%q content=%q", gotURI, content)
 	}
 }
 
-// TestResolveSpecURIDocsWithEnv — `docs:` shorthand resolves to a
-// file:// path when CLAUDE_RDC_DOCS is set.
+// TestResolveSpecURIDocsWithEnv -- `docs:` resolves against
+// CLAUDE_RDC_DOCS, is read CLI-side, and uploads the bytes as content
+// while keeping the `docs:` label as the uri.
 func TestResolveSpecURIDocsWithEnv(t *testing.T) {
-	t.Setenv("CLAUDE_RDC_DOCS", "/opt/rdc/docs")
-	got, err := resolveSpecURI("docs:vcenter-9.0/vcenter.yaml")
+	root := t.TempDir()
+	if err := os.MkdirAll(filepath.Join(root, "vcenter-9.0"), 0o700); err != nil {
+		t.Fatal(err)
+	}
+	if err := os.WriteFile(filepath.Join(root, "vcenter-9.0", "vcenter.yaml"), []byte(sampleSpecYAML), 0o600); err != nil {
+		t.Fatal(err)
+	}
+	t.Setenv("CLAUDE_RDC_DOCS", root)
+	gotURI, content, err := resolveSpecURI("docs:vcenter-9.0/vcenter.yaml")
 	if err != nil {
 		t.Fatalf("docs shorthand: %v", err)
 	}
-	want := "file:///opt/rdc/docs/vcenter-9.0/vcenter.yaml"
-	if got != want {
-		t.Fatalf("docs shorthand: got %q want %q", got, want)
+	if gotURI != "docs:vcenter-9.0/vcenter.yaml" {
+		t.Fatalf("docs uri label; got %q", gotURI)
+	}
+	if content != sampleSpecYAML {
+		t.Fatalf("docs content; got %q", content)
 	}
 }
 
-// TestResolveSpecURIDocsNoEnv — `docs:` is resolved CLI-side only.
-// When CLAUDE_RDC_DOCS is unset the shorthand is rejected here with a
-// hint naming the env var, rather than passed through to the backplane
-// (which does not resolve docs: URIs and would surface an opaque ingest
-// error — #1535).
+// TestResolveSpecURIDocsNoEnv -- `docs:` with no CLAUDE_RDC_DOCS is
+// rejected client-side with a hint naming the env var (#1535).
 func TestResolveSpecURIDocsNoEnv(t *testing.T) {
 	t.Setenv("CLAUDE_RDC_DOCS", "")
-	_, err := resolveSpecURI("docs:vcenter-9.0/vcenter.yaml")
+	_, _, err := resolveSpecURI("docs:vcenter-9.0/vcenter.yaml")
 	if err == nil {
 		t.Fatalf("docs shorthand with no env should reject; got nil error")
 	}
 	if !strings.Contains(err.Error(), "CLAUDE_RDC_DOCS") {
-		t.Fatalf("docs shorthand rejection should name CLAUDE_RDC_DOCS; got %v", err)
+		t.Fatalf("docs rejection should name CLAUDE_RDC_DOCS; got %v", err)
 	}
 }
 
-// TestResolveSpecURIUnknownScheme — anything not file/http(s)/docs
-// rejects with a clear message.
+// TestResolveSpecURIUnknownScheme -- anything not file/http(s)/docs rejects.
 func TestResolveSpecURIUnknownScheme(t *testing.T) {
-	_, err := resolveSpecURI("ftp://example.com/spec.yaml")
+	_, _, err := resolveSpecURI("ftp://example.com/spec.yaml")
 	if err == nil || !strings.Contains(err.Error(), "unknown URI scheme") {
 		t.Fatalf("unknown scheme should reject; got %v", err)
 	}
 }
 
-// TestResolveSpecURIEmpty — empty input rejects.
+// TestResolveSpecURIEmpty -- empty input rejects.
 func TestResolveSpecURIEmpty(t *testing.T) {
-	_, err := resolveSpecURI("   ")
+	_, _, err := resolveSpecURI("   ")
 	if err == nil || !strings.Contains(err.Error(), "empty") {
 		t.Fatalf("empty spec should reject; got %v", err)
 	}

--- a/cli/internal/cmd/connector/ingest.go
+++ b/cli/internal/cmd/connector/ingest.go
@@ -57,11 +57,10 @@ func newIngestCmd() *cobra.Command {
 			"  fqdn-templated entries are refused with a hint.\n\n" +
 			"  Manual mode: --product + --version + --impl + one-or-more --spec.\n" +
 			"  --spec accepts three URI shapes:\n" +
-			"    - file:///abs/path/to/spec.yaml          (local file)\n" +
-			"    - https://example.com/spec.yaml           (HTTP fetch)\n" +
-			"    - docs:<product-version>/<spec.yaml>      (CLI-side shorthand;\n" +
-			"      requires $CLAUDE_RDC_DOCS — expanded to a file:// URI. The\n" +
-			"      backplane does not resolve docs: URIs itself)\n" +
+			"    - https://example.com/spec.yaml           (fetched by the backplane; https only)\n" +
+			"    - file:///abs/path/to/spec.yaml          (read + uploaded by the CLI)\n" +
+			"    - docs:<product-version>/<spec.yaml>      (CLI-side shorthand against\n" +
+			"      $CLAUDE_RDC_DOCS; read + uploaded by the CLI like file://)\n" +
 			"  Repeat --spec to merge multiple specs under one connector_id\n" +
 			"  (vSphere is the canonical case: vcenter.yaml + vi-json.yaml).\n\n" +
 			"--dry-run parses + plans without writing to the DB; useful for\n" +
@@ -170,11 +169,15 @@ func buildIngestRequest(opts ingestOptions) (api.IngestRequest, error) {
 	}
 	specs := make([]api.SpecSource, 0, len(opts.Specs))
 	for _, raw := range opts.Specs {
-		uri, uerr := resolveSpecURI(raw)
+		uri, content, uerr := resolveSpecURI(raw)
 		if uerr != nil {
 			return api.IngestRequest{}, uerr
 		}
-		specs = append(specs, api.SpecSource{Uri: uri})
+		src := api.SpecSource{Uri: uri}
+		if content != "" {
+			src.Content = &content
+		}
+		specs = append(specs, src)
 	}
 	product := opts.Product
 	version := opts.Version

--- a/docs/architecture/spec-ingestion.md
+++ b/docs/architecture/spec-ingestion.md
@@ -48,11 +48,12 @@ Operator-facing surfaces — CLI (T5, [#405](https://github.com/evoila/meho/issu
 
 ## T1 — the parser
 
-[`parse_openapi(spec_path_or_uri, *, spec_source=None) -> list[EndpointDescriptorProto]`](../../backend/src/meho_backplane/operations/ingest/openapi.py) is the only public entry point. The function is synchronous because callers are CLI / one-shot ingestion endpoints with no event-loop concern, and the surface stays trivially testable.
+[`parse_openapi(spec_path_or_uri, *, spec_source=None, content=None) -> list[EndpointDescriptorProto]`](../../backend/src/meho_backplane/operations/ingest/openapi.py) is the only public entry point. The function is synchronous because callers are CLI / one-shot ingestion endpoints with no event-loop concern, and the surface stays trivially testable.
 
 ### Inputs
 
-- `spec_path_or_uri` — a `file://` path or an `http(s)://` URL. Local files read with stdlib; remote files fetched via [`httpx`](https://www.python-httpx.org/) with a 30 s timeout. YAML decoded via PyYAML's `CSafeLoader` (with a pure-Python `SafeLoader` fallback for platforms lacking LibYAML); JSON decoded via stdlib.
+- `spec_path_or_uri` — an `https://` URL the backend fetches under the SSRF / local-file guard (`_assert_fetchable_remote_url`; non-`https` schemes are rejected). Remote fetch uses [`httpx`](https://www.python-httpx.org/) streaming with a 30 s timeout and a 20 MiB cap. YAML decoded via PyYAML's `CSafeLoader` (pure-Python `SafeLoader` fallback); JSON via stdlib.
+- `content` — optional inline spec text. The `meho` CLI reads `docs:` / `file://` sources client-side and uploads the bytes here, so no local path or non-`https` scheme reaches the backend; when set it is used verbatim (capped) and `spec_path_or_uri` is just the audit label.
 - `spec_source` — optional tag string (e.g. `"vcenter.yaml"`) the parser stamps onto every row as a `spec:<source>` entry in `tags`. The downstream T2 merge path keys collision detection off this tag.
 
 ### Per-operation output

--- a/docs/codebase/spec-ingestion.md
+++ b/docs/codebase/spec-ingestion.md
@@ -804,9 +804,11 @@ activity:
    `169.254.0.0/16` (cloud metadata), `::1`, `fc00::/7`, or `fe80::/10` is
    rejected before the transport opens a connection.
 
-3. **Per-hop redirect re-validation.** `_load_spec_bytes` uses
-   `follow_redirects=False` and manually follows each 30x hop, calling
-   `_assert_fetchable_remote_url` on the redirect target before issuing the
+3. **Per-hop redirect re-validation.** `_fetch_spec_bytes` (invoked by
+   `_load_spec_bytes` when no content is uploaded) uses
+   `follow_redirects=False`, resolves each `Location` against the current
+   URL (`urljoin`, so relative hops aren't wrongly rejected), and calls
+   `_assert_fetchable_remote_url` on the resolved target before issuing the
    next request. A redirect from a public host to a private IP is rejected
    at the hop — the private-target socket is never opened.
 

--- a/docs/codebase/spec-ingestion.md
+++ b/docs/codebase/spec-ingestion.md
@@ -784,13 +784,52 @@ version-gate steps but returns the spec's `info.version` string
 pipeline can fail the spec-vs-label check in milliseconds rather
 than after spending CPU on a 2,000-op spec walk.
 
+## Security: SSRF and local-file guard (G0.16-T8, #95)
+
+`_load_spec_bytes` (the fetch sink shared by `parse_openapi` and
+`read_spec_info_version`) enforces two invariants before any network
+activity:
+
+1. **Scheme allowlist.** Only `https://` is accepted on the
+   network-facing ingest path. `http://`, `file://`, and bare filesystem
+   paths are rejected with `InvalidSpecError`. The restriction covers both
+   the REST `POST /api/v1/connectors/ingest` and the MCP
+   `meho.connector.ingest` tool, both of which are `TENANT_ADMIN`-gated.
+
+2. **Pre-connect destination guard (`_assert_fetchable_remote_url`).** Before
+   opening any socket, the hostname is resolved with `socket.getaddrinfo`
+   and every returned address is checked against the private / loopback /
+   link-local / ULA / reserved ranges using `ipaddress`. Any candidate IP in
+   `127.0.0.0/8`, `10.0.0.0/8`, `172.16.0.0/12`, `192.168.0.0/16`,
+   `169.254.0.0/16` (cloud metadata), `::1`, `fc00::/7`, or `fe80::/10` is
+   rejected before the transport opens a connection.
+
+3. **Per-hop redirect re-validation.** `_load_spec_bytes` uses
+   `follow_redirects=False` and manually follows each 30x hop, calling
+   `_assert_fetchable_remote_url` on the redirect target before issuing the
+   next request. A redirect from a public host to a private IP is rejected
+   at the hop — the private-target socket is never opened.
+
+4. **Response size cap.** The response body is streamed and rejected if it
+   exceeds 20 MiB (`_MAX_SPEC_BYTES`), preventing a redirect to a large
+   internal endpoint from exhausting pod memory.
+
+5. **Oracle-free error messages.** Error messages never echo the
+   operator-supplied URI or OS-level error text. Error text is
+   intentionally terse and path-free.
+
+Pre-#95: `http`/`https` URIs were fetched with `follow_redirects=True` and
+no IP check; `file://` URIs and bare paths were read via `Path(...).read_bytes()`;
+OS errors were echoed verbatim. The fix removes the filesystem branch from this
+network-facing function entirely.
+
 ## Control flow
 
 ```text
 parse_openapi
-├─ _load_spec_bytes        # file:// or http(s)://; httpx with a 30s timeout
-│                          # docs:<...> rejected with UnsupportedSpecError
-│                          # (CLI-side shorthand; backend has no docs root, #1535)
+├─ _load_spec_bytes        # https:// only; SSRF guard + redirect re-validation
+│  ├─ docs:<...> rejected with UnsupportedSpecError (CLI-side shorthand, #1535)
+│  └─ _assert_fetchable_remote_url  # scheme check, DNS resolve, IP allowlist
 ├─ _decode_spec            # CSafeLoader-preferred YAML, stdlib JSON
 ├─ _validate_openapi_version
 └─ _iter_operations

--- a/docs/codebase/spec-ingestion.md
+++ b/docs/codebase/spec-ingestion.md
@@ -827,9 +827,10 @@ network-facing function entirely.
 
 ```text
 parse_openapi
-├─ _load_spec_bytes        # https:// only; SSRF guard + redirect re-validation
-│  ├─ docs:<...> rejected with UnsupportedSpecError (CLI-side shorthand, #1535)
-│  └─ _assert_fetchable_remote_url  # scheme check, DNS resolve, IP allowlist
+├─ _load_spec_bytes        # CLI-uploaded content (capped) OR https:// fetch
+│  ├─ content present       # docs:/file:// bytes uploaded by CLI; no fetch, no guard (#102)
+│  ├─ docs:<...> + no content rejected with UnsupportedSpecError (#1535)
+│  └─ _assert_fetchable_remote_url  # https-only SSRF guard; DNS resolve, IP allowlist
 ├─ _decode_spec            # CSafeLoader-preferred YAML, stdlib JSON
 ├─ _validate_openapi_version
 └─ _iter_operations


### PR DESCRIPTION
## Summary

Folds the **#95 SSRF / local-file guard** (kr3s0's #1477) and the **#102 content-upload on-ramp fix** into one coherent change, so `main` never sits with the guard landed but the `docs:` / `file://` on-ramps broken.

- **Guard (#95, kr3s0):** `_load_spec_bytes` → `_fetch_spec_bytes` fetches **https-only** with a pre-connect SSRF destination guard, per-hop redirect re-validation, and a streamed 20 MiB cap (the cap aborts mid-download, not after buffering).
- **Content upload (#102):** `SpecSource` gains an optional `content` field. The CLI reads `docs:` / `file://` sources **client-side** and uploads the bytes as `content` (keeping the URI as the audit label); the backend uses content verbatim (size-capped) and never sees a local path or non-https scheme. `https://` is still fetched server-side under the guard.

Net: the SSRF / arbitrary-local-file-read vector is closed **and** the `docs:` corpus + `file://` on-ramps keep working — no incoherent intermediate state.

## Test plan

- [x] `uv run ruff check` / `ruff format --check` — clean
- [x] `uv run mypy src/` (strict) — 457 files, no issues
- [x] `uv run pytest -k ingest` — **407 passed** (incl. new content-upload tests + the streaming / size-cap / redirect-exhaustion regression tests)
- [x] `go build ./... && go vet ./... && go test ./...` — all pass (`resolveSpecURI` tests rewritten for the 3-value `(uri, content, err)` contract + real temp-file reads)
- [x] CLI OpenAPI snapshot regenerated + Go client synced; deterministic re-snapshot is diff-clean
- [x] code-quality gate — **0 blockers** (`_load_spec_bytes` split into `_fetch_spec_bytes` to stay under the size limit)

## Supersedes / closes

- **Supersedes #1477** (kr3s0's guard PR) — its guard commit + the M1 streaming fix are the first two commits here, co-authored.
- Closes evoila-bosnia/meho-internal#102
- Refs evoila-bosnia/meho-internal#95

🤖 Generated with [Claude Code](https://claude.com/claude-code)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **New Features**
  * Added support for inline spec uploads via a new `content` field in the API, allowing users to provide OpenAPI specifications directly without requiring a remote URL.

* **Security Improvements**
  * Enforced HTTPS-only requirements for remote spec fetches; the backend now rejects HTTP, file://, and local filesystem paths for enhanced security.
  * CLI now reads spec files locally and uploads their content, reducing exposure of local file paths.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->