### PR TITLE
feat(mcp): wrap retrieve helper as meho://retrieve/{query} resource (G0.5-T9)

### DIFF
--- a/backend/src/meho_backplane/mcp/handlers.py
+++ b/backend/src/meho_backplane/mcp/handlers.py
@@ -94,6 +94,7 @@ from meho_backplane.mcp.registry import (
     capability_satisfied,
     get_resource_for_uri,
     get_tool,
+    redacted_audit_uri,
     role_at_least,
 )
 from meho_backplane.mcp.server import McpInvalidParamsError, register_method
@@ -617,6 +618,18 @@ async def handle_resources_read(
             status_code = 404
             raise McpInvalidParamsError(f"resource not found: {uri!r}")
         defn, handler, bound_params = match
+
+        # G0.5-T9: query-bearing resources (``meho://retrieve/{query}``)
+        # opt out of persisting the concrete URI — its variable portion is
+        # a free-form query that leaks operator intent. Replace the audit
+        # path + payload URI with a query-stripped sentinel; the resource
+        # handler binds a privacy-preserving ``audit_query_hash``
+        # contextvar so the row stays correlatable without the raw query.
+        # Only applied once the template matched, so a 404 (unmatched URI)
+        # still records the attempted URI for forensic visibility.
+        if defn.audit_redact_uri:
+            audit_uri = redacted_audit_uri(defn.uriTemplate)
+            audit_payload["uri"] = audit_uri
 
         # RBAC: same call-time re-check as tools.
         if not _operator_meets_required_role(operator, defn):

--- a/backend/src/meho_backplane/mcp/registry.py
+++ b/backend/src/meho_backplane/mcp/registry.py
@@ -273,6 +273,22 @@ class ResourceTemplateDefinition(BaseModel):
     operator lacking the key. ``None`` (the default) means no capability
     gate. T4's companion ``meho://docs/{...}`` resource is the first
     consumer.
+
+    ``audit_redact_uri`` (G0.5-T9) opts the template out of persisting
+    its concrete URI in the audit trail. Most resources encode opaque
+    identifiers (slugs, chunk ids, tenant UUIDs) whose presence in
+    ``audit_log.path`` / ``payload.uri`` is harmless or useful. The
+    ``meho://retrieve/{query}`` resource is different: its variable is a
+    free-form retrieval query that leaks operator intent, so the row must
+    not carry it. When ``True``,
+    :func:`~meho_backplane.mcp.handlers.handle_resources_read` substitutes
+    a query-stripped sentinel (the template prefix up to the first
+    variable, plus ``<redacted>``) for both the audit ``path`` and
+    ``payload.uri``; the resource handler is expected to bind a
+    privacy-preserving identity (e.g. ``audit_query_hash``) via the
+    ``audit_*`` contextvar convention so the row stays correlatable.
+    ``False`` (the default) preserves the per-URI forensic path every
+    other resource relies on.
     """
 
     model_config = ConfigDict(frozen=True)
@@ -284,6 +300,7 @@ class ResourceTemplateDefinition(BaseModel):
     title: str | None = None
     required_role: TenantRole = TenantRole.OPERATOR
     required_capability: str | None = None
+    audit_redact_uri: bool = False
 
     def to_wire(self) -> dict[str, Any]:
         """Serialise to the MCP wire shape, dropping MEHO-internal fields."""
@@ -469,6 +486,26 @@ def _canonical_template_shape(template: str) -> str:
     at boot) rather than silent (the second handler never fires).
     """
     return _TEMPLATE_VAR_RE.sub("{}", template)
+
+
+def redacted_audit_uri(template: str) -> str:
+    """Return a query-stripped sentinel for an ``audit_redact_uri`` template.
+
+    Takes the literal prefix of *template* up to its first ``{var}``
+    placeholder and appends ``<redacted>``, so ``meho://retrieve/{query}``
+    collapses to ``meho://retrieve/<redacted>``. Used by
+    :func:`~meho_backplane.mcp.handlers.handle_resources_read` to keep the
+    free-form variable portion (a retrieval query that leaks operator
+    intent) out of ``audit_log.path`` / ``payload.uri`` while preserving a
+    stable, greppable prefix that identifies *which* resource was read.
+
+    Templates with no placeholder (none exist in v0.2 — every registered
+    resource is templated) fall back to the template verbatim plus the
+    sentinel suffix, which is the harmless degenerate case.
+    """
+    first = _TEMPLATE_VAR_RE.search(template)
+    prefix = template[: first.start()] if first is not None else template
+    return f"{prefix}<redacted>"
 
 
 def _match_uri_template(uri: str, template: str) -> dict[str, str] | None:

--- a/backend/src/meho_backplane/mcp/resources/retrieve.py
+++ b/backend/src/meho_backplane/mcp/resources/retrieve.py
@@ -1,0 +1,190 @@
+# SPDX-License-Identifier: Apache-2.0
+# Copyright (c) 2026 evoila Group
+
+"""``meho://retrieve/{query}`` — hybrid-retrieval MCP resource (G0.5-T9).
+
+The MCP-resource face of the G0.4 retrieval substrate. The in-process
+:func:`~meho_backplane.retrieval.retriever.retrieve` helper (G0.4-T4,
+#261) and its HTTP surface ``POST /api/v1/retrieve`` (G0.4-T5, #262) are
+already in place; this resource exposes the same hybrid BM25 + cosine
+retrieval through the MCP resource registry so an agent can pull ranked
+hits with a plain ``resources/read`` instead of a tool call.
+
+URI template + variable binding
+================================
+
+``meho://retrieve/{query}`` follows the v0.2 simple-expansion subset of
+RFC 6570 (one named variable, no operators). The MCP registry's URI
+matcher binds ``{query}`` from the concrete URI as a single path segment
+(``[^/]+``) and forwards it to the handler. The client percent-encodes
+the free-form query into that segment; the handler
+:func:`~urllib.parse.unquote`\\ s it back before retrieval, so a query
+carrying spaces (``kubernetes%20ingress``) or a literal slash
+(``a%2Fb``) round-trips losslessly. The tenant is **not** in the URI —
+it comes purely from the operator's JWT (see "Tenant scoping").
+
+Tenant scoping
+==============
+
+The handler reads :attr:`Operator.tenant_id` from the validated MCP-auth
+operator and threads it into :func:`retrieve`; there is no URI variable
+or any other surface that accepts a tenant id, so cross-tenant retrieval
+is impossible by construction. The substrate filters every candidate
+query by ``tenant_id``, so a query issued under tenant A can never
+surface tenant B's documents — the same guarantee the HTTP route relies
+on.
+
+RBAC
+====
+
+``operator`` role minimum — identical to ``POST /api/v1/retrieve``.
+``read_only`` operators are filtered out of
+``resources/templates/list`` and rejected at ``resources/read`` time by
+the dispatcher's call-time role re-check
+(:func:`~meho_backplane.mcp.handlers.handle_resources_read`). Diagnostic
+retrieval is an operator-level action; ``read_only`` agents use the
+higher-level kb / memory search tools.
+
+Audit privacy contract
+======================
+
+Retrieval queries leak operator intent, so — exactly like the HTTP
+route — the audit trail must record *that* a retrieval happened and a
+correlatable identity for the query, never the raw query text. The
+handler binds the four ``audit_*`` contextvars the HTTP route introduced
+(``audit_query_hash`` / ``audit_source`` / ``audit_kind`` /
+``audit_hit_count``); :func:`~meho_backplane.mcp.audit.write_mcp_audit_row`
+merges them into the ``audit_log.payload`` so the persisted row carries
+``{query_hash, source, kind, hit_count}``.
+
+Because the query is a *URI path segment* (not a JSON body field), the
+generic ``resources/read`` audit path would otherwise persist the raw
+query inside ``audit_log.path`` and ``payload.uri``. The resource
+therefore opts into ``audit_redact_uri=True`` on its
+:class:`~meho_backplane.mcp.registry.ResourceTemplateDefinition`, which
+makes the dispatcher substitute a query-stripped sentinel
+(``meho://retrieve/<redacted>``) for both the audit ``path`` and
+``payload.uri``. The result is a row that is fully attributable (tenant,
+operator, ``query_hash``, ``hit_count``) yet carries no recoverable
+query string — matching the HTTP route's privacy posture.
+
+Response shape
+==============
+
+The MCP ``resources/read`` response is a ``contents[]`` array. The
+dispatcher wraps this handler's return value in a single text block
+whose ``mimeType`` is the template's ``application/json`` and whose
+``text`` is the JSON-serialised handler return. The handler returns
+``{"hits": [...]}`` where each hit is a
+:class:`~meho_backplane.retrieval.retriever.RetrievalHit` serialised via
+``model_dump(mode="json")`` — the identical hit shape the HTTP route
+returns under ``RetrieveResponse.hits``.
+"""
+
+from __future__ import annotations
+
+import hashlib
+from typing import Any, Final
+from urllib.parse import unquote
+
+import structlog
+
+from meho_backplane.auth.operator import Operator, TenantRole
+from meho_backplane.mcp.registry import (
+    ResourceTemplateDefinition,
+    register_mcp_resource,
+)
+from meho_backplane.mcp.server import McpInvalidParamsError
+from meho_backplane.retrieval.retriever import retrieve
+
+#: Default hit ceiling for the resource read. The URI template carries no
+#: ``limit`` variable (a resource read is a fixed-shape fetch, not a
+#: parameterised query), so the resource pins the same default the HTTP
+#: route's ``RetrieveRequest.limit`` uses (10). An agent that needs a
+#: different ceiling uses the ``search_knowledge`` / ``search_memory``
+#: meta-tools, which take an explicit ``limit`` argument.
+_DEFAULT_LIMIT: Final[int] = 10
+
+
+def _compute_query_hash(query: str) -> str:
+    """SHA-256 hex digest of *query* (UTF-8 encoded).
+
+    Matches :func:`meho_backplane.api.v1.retrieve._compute_query_hash`
+    byte-for-byte so an analyst correlating a known query against an
+    ``audit_log.payload.query_hash`` gets the same digest whether the
+    retrieval came through the HTTP route or this resource.
+    """
+    return hashlib.sha256(query.encode("utf-8")).hexdigest()
+
+
+async def _retrieve_handler(
+    operator: Operator,
+    bound: dict[str, str],
+) -> dict[str, Any]:
+    """Run hybrid retrieval for the URI-bound query, tenant-scoped to the JWT.
+
+    The ``{query}`` segment is percent-decoded before retrieval. The four
+    ``audit_*`` contextvars are bound **before** the retrieval call so a
+    handler exception still leaves an audit row carrying the query
+    identity (``audit_hit_count`` absent in that case — the partial
+    signal is itself useful for postmortem), mirroring the HTTP route.
+
+    One rejection arm: a ``{query}`` that decodes to an empty/whitespace
+    string surfaces as :class:`McpInvalidParamsError` (``-32602``) before
+    the embedding pipeline runs — the same gate the HTTP route's
+    ``Field(min_length=1)`` enforces, kept here because the resource has
+    no Pydantic request body to lean on.
+    """
+    query = unquote(bound["query"])
+    if not query.strip():
+        raise McpInvalidParamsError(
+            "retrieve: empty query — the URI's {query} segment must decode to a non-empty string",
+        )
+
+    log = structlog.get_logger()
+    # Bind the privacy-preserving query identity up front so a handler
+    # exception still produces an audit row with the query hash. Only the
+    # SHA-256 hash is ever bound — never the raw query. ``source`` / ``kind``
+    # are None for the resource (it retrieves across every source); the
+    # audit-payload resolver drops None-valued contextvars.
+    structlog.contextvars.bind_contextvars(
+        audit_query_hash=_compute_query_hash(query),
+        audit_source=None,
+        audit_kind=None,
+    )
+
+    hits = await retrieve(
+        tenant_id=operator.tenant_id,
+        query=query,
+        limit=_DEFAULT_LIMIT,
+    )
+
+    structlog.contextvars.bind_contextvars(audit_hit_count=len(hits))
+    log.info(
+        "mcp_retrieve_resource_completed",
+        operator_sub=operator.sub,
+        tenant_id=str(operator.tenant_id),
+        hit_count=len(hits),
+    )
+    return {"hits": [hit.model_dump(mode="json") for hit in hits]}
+
+
+register_mcp_resource(
+    definition=ResourceTemplateDefinition(
+        uriTemplate="meho://retrieve/{query}",
+        name="Hybrid retrieval",
+        description=(
+            "Hybrid BM25 + cosine retrieval over the operator's tenant "
+            "corpus, ranked by Reciprocal Rank Fusion. Percent-encode the "
+            "free-form query into the {query} segment; the result is the "
+            "same ranked RetrievalHit list `POST /api/v1/retrieve` returns "
+            "(per-signal scores + ranks carried for observability). The "
+            "tenant is taken from the JWT — there is no cross-tenant "
+            "retrieval surface. Requires the `operator` role."
+        ),
+        mimeType="application/json",
+        required_role=TenantRole.OPERATOR,
+        audit_redact_uri=True,
+    ),
+    handler=_retrieve_handler,
+)

--- a/backend/tests/mcp_test_fixtures.py
+++ b/backend/tests/mcp_test_fixtures.py
@@ -177,6 +177,7 @@ def isolated_registry() -> Iterator[None]:
     from meho_backplane.mcp.resources import docs as docs_resource
     from meho_backplane.mcp.resources import kb as kb_resource
     from meho_backplane.mcp.resources import memory as memory_resource
+    from meho_backplane.mcp.resources import retrieve as retrieve_resource
     from meho_backplane.mcp.resources import (
         tenant_conventions as tenant_conventions_resource,
     )
@@ -288,6 +289,13 @@ def isolated_registry() -> Iterator[None]:
     importlib.reload(kb_resource)
     importlib.reload(docs_resource)
     importlib.reload(memory_resource)
+    # G0.5-T9 (#348): the hybrid-retrieval resource
+    # (``meho://retrieve/{query}``) joins the reload list for the same
+    # reason every other resource module does -- the autouse
+    # clear_registries() above would otherwise leave it unregistered in
+    # any test file that imports this fixture after the first one runs in
+    # the process.
+    importlib.reload(retrieve_resource)
     # G7.1-T4 (#316): the tenant-conventions per-slug resource
     # (``meho://tenant/{tenant_id}/conventions/{slug}``) joins the
     # reload list for the same reason every other resource module

--- a/backend/tests/test_mcp_resources_retrieve.py
+++ b/backend/tests/test_mcp_resources_retrieve.py
@@ -1,0 +1,414 @@
+# SPDX-License-Identifier: Apache-2.0
+# Copyright (c) 2026 evoila Group
+
+"""Tests for the ``meho://retrieve/{query}`` resource (G0.5-T9, #348).
+
+Covers the acceptance criteria:
+
+* ``meho://retrieve/{query}`` is registered via ``register_mcp_resource``
+  and appears in ``resources/templates/list`` for an operator-role JWT.
+* The resource handler returns the same ``RetrievalHit`` shape the HTTP
+  route (``POST /api/v1/retrieve``) does — ``{"hits": [...]}`` where each
+  hit is a ``RetrievalHit.model_dump(mode="json")``.
+* **RBAC:** ``read_only`` → 403-class read (the handler / retrieve never
+  run); ``operator`` / ``tenant_admin`` → hits.
+* **Tenant scoping:** the handler threads the JWT's ``tenant_id`` into
+  ``retrieve`` (never a URI value); a fake substrate keyed on tenant_id
+  shows a tenant-A query returns no tenant-B document.
+* **Audit privacy:** the persisted ``audit_log`` row carries
+  ``query_hash`` (+ ``hit_count``) but **no raw query string** anywhere —
+  the query-bearing URI is redacted in both ``path`` and ``payload.uri``.
+
+The PG-only ``@@`` / ``<=>`` ranking is exercised in the integration
+suite; here ``retrieve`` is mocked at the resource's import site so the
+MCP wire-shape + audit plumbing is exercised without spinning up
+Postgres + fastembed.
+"""
+
+from __future__ import annotations
+
+import json
+import uuid
+from collections.abc import Iterator
+from datetime import UTC, datetime
+from typing import Any
+from unittest.mock import AsyncMock, patch
+from urllib.parse import quote
+
+import pytest
+from fastapi.testclient import TestClient
+from sqlalchemy import select
+
+from meho_backplane.auth.operator import Operator, TenantRole
+from meho_backplane.db.engine import get_sessionmaker
+from meho_backplane.db.models import AuditLog
+from meho_backplane.main import app
+from meho_backplane.mcp.auth import verify_mcp_jwt_and_bind
+from meho_backplane.mcp.resources.retrieve import _compute_query_hash
+from meho_backplane.mcp.schemas import INVALID_PARAMS
+from meho_backplane.retrieval.retriever import RetrievalHit
+from tests.mcp_test_fixtures import (
+    OPERATOR_TENANT_ID,
+    isolated_registry,  # noqa: F401 — pytest-discovered autouse fixture
+    post_mcp,
+    required_settings_env,  # noqa: F401 — pytest-discovered autouse fixture
+)
+
+_RETRIEVE_TEMPLATE = "meho://retrieve/{query}"
+#: The seam the resource patches: ``retrieve`` is imported into the
+#: resource module's namespace, so patching it there stubs the call the
+#: handler makes (same pattern the HTTP-route tests use).
+_RETRIEVE_SEAM = "meho_backplane.mcp.resources.retrieve.retrieve"
+
+#: A query carrying a space + punctuation so the percent-encoding round
+#: trip and the "raw query must not appear in the audit row" negative
+#: assertion are both meaningful.
+_RAW_QUERY = "kubernetes ingress timeout"
+_RETRIEVE_URI = f"meho://retrieve/{quote(_RAW_QUERY, safe='')}"
+
+
+def _operator(
+    *,
+    role: TenantRole = TenantRole.OPERATOR,
+    tenant_id: uuid.UUID = OPERATOR_TENANT_ID,
+) -> Operator:
+    return Operator(
+        sub="op-test",
+        name="Test",
+        email=None,
+        raw_jwt="fixture-jwt-not-real",
+        tenant_id=tenant_id,
+        tenant_role=role,
+    )
+
+
+@pytest.fixture
+def retrieve_client(
+    request: pytest.FixtureRequest,
+) -> Iterator[tuple[TestClient, Operator]]:
+    """``TestClient`` with a role-parametrised operator (default: operator)."""
+    role: TenantRole = getattr(request, "param", TenantRole.OPERATOR)
+    op = _operator(role=role)
+
+    async def _fake_verify() -> Operator:
+        return op
+
+    app.dependency_overrides[verify_mcp_jwt_and_bind] = _fake_verify
+    try:
+        with TestClient(app) as client:
+            yield client, op
+    finally:
+        app.dependency_overrides.pop(verify_mcp_jwt_and_bind, None)
+
+
+def _make_hit(*, tenant_id: uuid.UUID, body: str = "doc body") -> RetrievalHit:
+    """Build a :class:`RetrievalHit` stub scoped to *tenant_id*."""
+    ts = datetime(2026, 5, 21, 10, 16, 12, tzinfo=UTC)
+    return RetrievalHit(
+        document_id=uuid.uuid4(),
+        tenant_id=tenant_id,
+        source="kb",
+        source_id="kb-entry:ingress-timeouts",
+        kind="kb-entry",
+        body=body,
+        doc_metadata={"product": "k8s"},
+        created_at=ts,
+        updated_at=ts,
+        fused_score=0.7,
+        bm25_score=0.4,
+        cosine_score=0.85,
+        bm25_rank=1,
+        cosine_rank=1,
+    )
+
+
+# ---------------------------------------------------------------------------
+# Registration + resources/templates/list
+# ---------------------------------------------------------------------------
+
+
+def test_retrieve_resource_in_templates_list(
+    retrieve_client: tuple[TestClient, Operator],
+) -> None:
+    """AC: the template is registered and visible to an operator-role JWT."""
+    client, _op = retrieve_client
+    response = post_mcp(
+        client,
+        {"jsonrpc": "2.0", "id": 1, "method": "resources/templates/list"},
+    )
+    assert response.status_code == 200
+    templates = {t["uriTemplate"]: t for t in response.json()["result"]["resourceTemplates"]}
+    template = templates.get(_RETRIEVE_TEMPLATE)
+    assert template is not None
+    assert template["mimeType"] == "application/json"
+    # MEHO-internal RBAC fields are dropped from the wire shape.
+    assert "required_role" not in template
+    assert "audit_redact_uri" not in template
+
+
+@pytest.mark.parametrize("retrieve_client", [TenantRole.READ_ONLY], indirect=True)
+def test_retrieve_resource_absent_for_read_only_in_templates_list(
+    retrieve_client: tuple[TestClient, Operator],
+) -> None:
+    """A ``read_only`` operator never sees the operator-gated template."""
+    client, _op = retrieve_client
+    response = post_mcp(
+        client,
+        {"jsonrpc": "2.0", "id": 1, "method": "resources/templates/list"},
+    )
+    assert response.status_code == 200
+    templates = {t["uriTemplate"] for t in response.json()["result"]["resourceTemplates"]}
+    assert _RETRIEVE_TEMPLATE not in templates
+
+
+# ---------------------------------------------------------------------------
+# resources/read — happy path + hit shape + tenant binding
+# ---------------------------------------------------------------------------
+
+
+def test_resources_read_returns_retrieval_hit_shape(
+    retrieve_client: tuple[TestClient, Operator],
+) -> None:
+    """AC: the read returns the same ``RetrievalHit`` shape the HTTP route does.
+
+    Also asserts the handler decoded the percent-encoded query and passed
+    the operator's JWT ``tenant_id`` (not a URI value) into ``retrieve``.
+    """
+    client, op = retrieve_client
+    fake = AsyncMock(
+        return_value=[
+            _make_hit(tenant_id=op.tenant_id, body="body-A"),
+            _make_hit(tenant_id=op.tenant_id, body="body-B"),
+        ],
+    )
+    with patch(_RETRIEVE_SEAM, new=fake):
+        response = post_mcp(
+            client,
+            {
+                "jsonrpc": "2.0",
+                "id": 2,
+                "method": "resources/read",
+                "params": {"uri": _RETRIEVE_URI},
+            },
+        )
+    assert response.status_code == 200
+    body = response.json()
+    contents = body["result"]["contents"]
+    assert contents[0]["uri"] == _RETRIEVE_URI
+    assert contents[0]["mimeType"] == "application/json"
+    payload = json.loads(contents[0]["text"])
+    assert list(payload.keys()) == ["hits"]
+    assert len(payload["hits"]) == 2
+    hit = payload["hits"][0]
+    # The hit carries the full RetrievalHit projection (same keys the
+    # HTTP route's RetrieveResponse.hits entries carry).
+    assert set(hit) == {
+        "document_id",
+        "tenant_id",
+        "source",
+        "source_id",
+        "kind",
+        "body",
+        "doc_metadata",
+        "created_at",
+        "updated_at",
+        "fused_score",
+        "bm25_score",
+        "cosine_score",
+        "bm25_rank",
+        "cosine_rank",
+    }
+    assert hit["body"] == "body-A"
+    assert hit["fused_score"] == pytest.approx(0.7)
+
+    # Tenant from JWT, query decoded from the URI.
+    fake.assert_awaited_once()
+    call_kwargs = fake.await_args.kwargs
+    assert call_kwargs["tenant_id"] == op.tenant_id
+    assert call_kwargs["query"] == _RAW_QUERY
+
+
+def test_resources_read_empty_query_is_invalid_params(
+    retrieve_client: tuple[TestClient, Operator],
+) -> None:
+    """A ``{query}`` decoding to whitespace rejects before retrieval runs."""
+    client, _op = retrieve_client
+    fake = AsyncMock(return_value=[])
+    with patch(_RETRIEVE_SEAM, new=fake):
+        response = post_mcp(
+            client,
+            {
+                "jsonrpc": "2.0",
+                "id": 3,
+                "method": "resources/read",
+                "params": {"uri": f"meho://retrieve/{quote('   ', safe='')}"},
+            },
+        )
+    assert response.status_code == 200
+    error = response.json()["error"]
+    assert error["code"] == INVALID_PARAMS
+    assert "empty query" in error["message"].lower()
+    fake.assert_not_awaited()
+
+
+# ---------------------------------------------------------------------------
+# RBAC
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.parametrize("retrieve_client", [TenantRole.READ_ONLY], indirect=True)
+def test_resources_read_read_only_is_forbidden(
+    retrieve_client: tuple[TestClient, Operator],
+) -> None:
+    """AC: a ``read_only`` operator is rejected; the handler must not run."""
+    client, _op = retrieve_client
+    fake = AsyncMock(return_value=[_make_hit(tenant_id=OPERATOR_TENANT_ID)])
+    with patch(_RETRIEVE_SEAM, new=fake):
+        response = post_mcp(
+            client,
+            {
+                "jsonrpc": "2.0",
+                "id": 4,
+                "method": "resources/read",
+                "params": {"uri": _RETRIEVE_URI},
+            },
+        )
+    assert response.status_code == 200
+    error = response.json()["error"]
+    assert error["code"] == INVALID_PARAMS
+    assert "forbidden" in error["message"].lower()
+    # The retrieve substrate must never be reached for a denied read.
+    fake.assert_not_awaited()
+
+
+@pytest.mark.parametrize(
+    "retrieve_client",
+    [TenantRole.OPERATOR, TenantRole.TENANT_ADMIN],
+    indirect=True,
+)
+def test_resources_read_operator_and_tenant_admin_get_hits(
+    retrieve_client: tuple[TestClient, Operator],
+) -> None:
+    """AC: both ``operator`` and ``tenant_admin`` roles get hits back."""
+    client, op = retrieve_client
+    fake = AsyncMock(return_value=[_make_hit(tenant_id=op.tenant_id, body="ok")])
+    with patch(_RETRIEVE_SEAM, new=fake):
+        response = post_mcp(
+            client,
+            {
+                "jsonrpc": "2.0",
+                "id": 5,
+                "method": "resources/read",
+                "params": {"uri": _RETRIEVE_URI},
+            },
+        )
+    assert response.status_code == 200
+    payload = json.loads(response.json()["result"]["contents"][0]["text"])
+    assert len(payload["hits"]) == 1
+    assert payload["hits"][0]["body"] == "ok"
+
+
+# ---------------------------------------------------------------------------
+# Tenant scoping (JWT, not URI)
+# ---------------------------------------------------------------------------
+
+
+def test_resources_read_tenant_scoped_to_jwt_excludes_other_tenant(
+    retrieve_client: tuple[TestClient, Operator],
+) -> None:
+    """AC: a query under tenant A returns no tenant-B documents.
+
+    The fake substrate models the real helper's tenant filter — it only
+    returns documents whose tenant matches the ``tenant_id`` it was
+    called with. Since the handler sources ``tenant_id`` purely from the
+    JWT, a tenant-B document seeded into the fake is structurally
+    invisible to tenant A's read.
+    """
+    client, op = retrieve_client
+    other_tenant = uuid.uuid4()
+    corpus = [
+        _make_hit(tenant_id=op.tenant_id, body="tenant-A doc"),
+        _make_hit(tenant_id=other_tenant, body="tenant-B doc"),
+    ]
+
+    async def _tenant_filtered(**kwargs: Any) -> list[RetrievalHit]:
+        return [h for h in corpus if h.tenant_id == kwargs["tenant_id"]]
+
+    with patch(_RETRIEVE_SEAM, side_effect=_tenant_filtered):
+        response = post_mcp(
+            client,
+            {
+                "jsonrpc": "2.0",
+                "id": 6,
+                "method": "resources/read",
+                "params": {"uri": _RETRIEVE_URI},
+            },
+        )
+    assert response.status_code == 200
+    payload = json.loads(response.json()["result"]["contents"][0]["text"])
+    bodies = [h["body"] for h in payload["hits"]]
+    assert bodies == ["tenant-A doc"]
+    assert "tenant-B doc" not in bodies
+
+
+# ---------------------------------------------------------------------------
+# Audit privacy contract
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.asyncio
+async def test_audit_row_carries_query_hash_not_raw_query(
+    retrieve_client: tuple[TestClient, Operator],
+) -> None:
+    """AC: the persisted audit row carries ``query_hash`` + ``hit_count``, no raw query.
+
+    The query is a URI path segment, so without redaction it would leak
+    into ``audit_log.path`` / ``payload.uri``. The resource opts into
+    ``audit_redact_uri`` so the row records a query-stripped sentinel and
+    the correlatable ``query_hash`` the handler binds — never the query.
+    """
+    client, op = retrieve_client
+    fake = AsyncMock(
+        return_value=[
+            _make_hit(tenant_id=op.tenant_id, body="a"),
+            _make_hit(tenant_id=op.tenant_id, body="b"),
+        ],
+    )
+    with patch(_RETRIEVE_SEAM, new=fake):
+        response = post_mcp(
+            client,
+            {
+                "jsonrpc": "2.0",
+                "id": 7,
+                "method": "resources/read",
+                "params": {"uri": _RETRIEVE_URI},
+            },
+        )
+    assert response.status_code == 200
+
+    sessionmaker = get_sessionmaker()
+    async with sessionmaker() as session:
+        rows = (
+            (await session.execute(select(AuditLog).where(AuditLog.method == "MCP")))
+            .scalars()
+            .all()
+        )
+    assert len(rows) == 1
+    row = rows[0]
+
+    # Positive: privacy-preserving identity present, mirroring the HTTP route.
+    assert row.payload["query_hash"] == _compute_query_hash(_RAW_QUERY)
+    assert len(row.payload["query_hash"]) == 64
+    assert row.payload["hit_count"] == 2
+
+    # The URI was redacted in both the path and the payload.
+    assert row.payload["uri"] == "meho://retrieve/<redacted>"
+    assert row.path == "/mcp/resources/read/meho://retrieve/<redacted>"
+
+    # Negative: the raw query (and its percent-encoded form) must not
+    # appear anywhere in the serialised row.
+    serialised = json.dumps(row.payload) + row.path
+    assert _RAW_QUERY not in serialised
+    assert quote(_RAW_QUERY, safe="") not in serialised
+    for token in _RAW_QUERY.split():
+        assert token not in serialised

--- a/docs/codebase/mcp.md
+++ b/docs/codebase/mcp.md
@@ -133,6 +133,41 @@ client identity should file a follow-up Task on
 [`evoila/meho`](https://github.com/evoila/meho) describing the
 mismatch pattern and what behaviour change would unblock them.
 
+## Audit URI redaction for query-bearing resources
+
+The `resources/read` dispatcher
+(`handle_resources_read` in `mcp/handlers.py`) records the concrete
+read URI in the audit row's `path` (`/mcp/resources/read/<uri>`) and
+`payload.uri`. For most resources the URI variable is an opaque
+identifier (a kb slug, a docs chunk id, a tenant UUID), so persisting
+it is harmless and useful for forensic queries.
+
+`meho://retrieve/{query}` is the exception: its variable is a
+free-form retrieval query that leaks operator intent, so the raw query
+must not land in the audit trail. The resource template opts into
+`audit_redact_uri=True` (a field on
+`ResourceTemplateDefinition`); when set, the dispatcher substitutes a
+query-stripped sentinel — the template prefix up to the first `{var}`
+plus `<redacted>`, i.e. `meho://retrieve/<redacted>` — for both the
+audit `path` and `payload.uri`. The substitution runs only after the
+URI matches a registered template, so an unmatched URI (404) still
+records the attempted value.
+
+Correlatability is preserved through the `audit_*` contextvar
+convention: the retrieve handler binds `audit_query_hash` (the
+SHA-256 of the decoded query, byte-for-byte identical to the
+`POST /api/v1/retrieve` hash) plus `audit_hit_count` before/after the
+retrieval call. `write_mcp_audit_row` merges those into the row's
+`payload`, so the persisted row is fully attributable (tenant,
+operator, `query_hash`, `hit_count`) without carrying the query text.
+This mirrors the HTTP route's privacy posture documented in
+[`retrieval.md`](retrieval.md).
+
+The redaction helper is `redacted_audit_uri(template)` in
+`mcp/registry.py`. New query-bearing resources reuse the same flag +
+contextvar pattern rather than special-casing the dispatcher per
+resource.
+
 ## Dependencies
 
 * `structlog` — every MCP log line goes through


### PR DESCRIPTION
## Summary
- Wrap the G0.4 hybrid-retrieval substrate as the MCP resource `meho://retrieve/{query}` (G0.5-T9), registered via `register_mcp_resource`, mirroring the reference `tenant_info` / `kb` resources.
- The handler percent-decodes the URI `{query}` segment, sources `tenant_id` purely from the JWT (no tenant in the URI → cross-tenant retrieval impossible by construction), reuses the `retrieve` helper, and returns the same `RetrievalHit` shape `POST /api/v1/retrieve` returns. RBAC is `operator` minimum, matching the HTTP route.
- Reuses the G0.4-T5 audit contextvar pattern (`audit_query_hash` / `audit_hit_count`) so the persisted `audit_log` row stays privacy-preserving — the raw query is never stored.
- **Audit-URI redaction (cross-cutting):** because the query is a URI path segment, the generic `resources/read` audit path would otherwise persist the raw query in `audit_log.path` and `payload.uri`. Added a generic, opt-in `audit_redact_uri` flag on `ResourceTemplateDefinition`; when set, the dispatcher substitutes a query-stripped `meho://retrieve/<redacted>` sentinel for both. New query-bearing resources reuse the flag rather than special-casing the dispatcher.

## Scope note (beyond the issue's named files)
The issue body named only the new resource module + tests. Satisfying the AC "the persisted `audit_log` row contains no raw query string" was **not possible** without a small shared-dispatcher change, because `handle_resources_read` persists the full read URI (which carries the query) independently of the handler. Rather than push back on a satisfiable task, this PR adds a minimal, generic redaction hook:
- `backend/src/meho_backplane/mcp/registry.py` — new `audit_redact_uri` field + `redacted_audit_uri()` helper.
- `backend/src/meho_backplane/mcp/handlers.py` — apply the sentinel for `audit_redact_uri` templates (post-match, so 404s still log the attempted URI).

## Test plan
- [x] `ruff check` + `ruff format --check` — clean on all touched files
- [x] `mypy` (resources/retrieve.py, registry.py, handlers.py) — clean
- [x] `pytest tests/test_mcp_resources_retrieve.py` — 9 passed
- [x] MCP + retrieve regression (`-k "mcp or retrieve"`) — 755 passed, 23 skipped, 0 failed
- [x] `code-quality.py --diff` — 0 blockers (4 pre-existing warnings on handlers.py/registry.py)

Acceptance criteria → evidence:
- [x] `meho://retrieve/{query}` registered + appears in `resources/templates/list` — `test_retrieve_resource_in_templates_list`
- [x] Handler returns the HTTP route's `RetrievalHit` shape — `test_resources_read_returns_retrieval_hit_shape` (asserts the full hit key set)
- [x] RBAC: `read_only` → 403; `operator` / `tenant_admin` → hits — `test_resources_read_read_only_is_forbidden`, `test_resources_read_operator_and_tenant_admin_get_hits`
- [x] Tenant-scoping: tenant-A query returns no tenant-B doc (tenant from JWT) — `test_resources_read_tenant_scoped_to_jwt_excludes_other_tenant`
- [x] Audit payload mirrors `{query_hash, source, kind, hit_count}`; no raw query persisted — `test_audit_row_carries_query_hash_not_raw_query` (asserts `query_hash` + `hit_count` present, redacted `uri`/`path`, and the raw query, its percent-encoded form, and each query token are all absent from the serialised row)
- [x] `backend/tests/test_mcp_resources_retrieve.py` passes
- [x] CI green: ruff + mypy + pytest (run locally; CI to confirm)

## Out of scope
- The `retrieve` helper and `POST /api/v1/retrieve` route — unchanged.
- Reranking / streaming / multilingual retrieval — inherited out-of-scope from #225.
- MCP meta-tools (#226 T7) — this is a *resource*, not a tool.

## Adjacent findings (recorded, not edited)
- `handlers.py` is 848 lines and `registry.py` is 598 lines (pre-existing; both flagged as warnings by the code-quality gate, neither caused by this change).
- `handle_resources_read` still maps "resource not found" to `-32602` rather than the spec-correct `-32002` (pre-existing deferral documented in its docstring).

<!-- auto-implement-issue: fresh, iteration 1 -->

Closes #348


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **New Features**
  * Introduced a new retrieval resource accessible through the MCP interface supporting hybrid search queries.
  * Added audit URI redaction for query-bearing resources, preserving query correlation through hash tracking in audit logs.

* **Documentation**
  * Added documentation on audit privacy features and URI redaction behavior for query-based resources.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->