### PR TITLE
feat(connectors): secret.move broker op + SecretEndpoint adapter protocol (#1577)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -90,6 +90,18 @@ connector-related release-notes line.
 
 ## [Unreleased]
 
+### Secret broker `secret.move` op + `SecretEndpoint` adapter protocol (#1577)
+
+- Add the server-side `secret.move` broker op (synthetic
+  `secret-broker-1.x` identity, `requires_approval=True` +
+  `safety_level="dangerous"`) and the `SecretEndpoint` adapter protocol
+  with a kind-keyed registry, plus the first vault-kv↔vault-kv pair. A
+  move copies one credential field between stores entirely inside the
+  backplane; the value never enters the op params, response, logs, or the
+  audit row — only the move status, the value SHA-256, and its length.
+  The keycloak sink, approval-queue gating, CLI verb, and docs page are
+  separate sibling tasks reusing this contract.
+
 ### Retire the stale `meho targets create` verb tree-wide (#1559)
 
 - Remove the last references to the nonexistent `meho targets create`

--- a/backend/src/meho_backplane/connectors/secret/__init__.py
+++ b/backend/src/meho_backplane/connectors/secret/__init__.py
@@ -1,0 +1,46 @@
+# SPDX-License-Identifier: Apache-2.0
+# Copyright (c) 2026 evoila Group
+
+"""meho_backplane.connectors.secret — the secret broker (Initiative #581).
+
+The first **synthetic** connector subpackage: no vendor connector backs
+it. Importing the package (the lifespan's
+:func:`~meho_backplane.connectors.registry._eager_import_connectors` pass
+walks ``connectors/<product>/`` and imports each subpackage) wires the
+secret broker in two import-time steps:
+
+* **Adapter registration** — importing
+  :mod:`~meho_backplane.connectors.secret.vault_endpoint` runs its
+  module-level :func:`~meho_backplane.connectors.secret.endpoints.register_secret_endpoint`
+  call, populating :data:`~meho_backplane.connectors.secret.endpoints.SECRET_ENDPOINT_REGISTRY`
+  with the vault-kv pair under kind ``"vault"``. Sibling tasks add
+  further kinds (#1578 keycloak sink) by importing their adapter module
+  the same way.
+* **Op registrar queueing** — the
+  :func:`~meho_backplane.operations.typed_register.register_typed_op_registrar`
+  call below appends
+  :func:`~meho_backplane.connectors.secret.ops.register_secret_broker_operations`
+  to the lifespan-driven registrar list, so the ``secret.move``
+  ``endpoint_descriptor`` row lands before the first dispatch.
+
+Unlike every other connector subpackage, this one calls neither
+``register_connector`` nor ``register_connector_v2``: the synthetic
+``secret-broker-1.x`` identity has no connector class. The ``secret.move``
+handler is a module-level function the dispatcher routes to with
+``connector_instance=None`` / ``target=None``.
+"""
+
+# Importing the adapter module runs its module-level
+# ``register_secret_endpoint("vault", ...)`` call so the registry is
+# populated before any move dispatches. Imported for the side effect.
+from meho_backplane.connectors.secret import vault_endpoint as _vault_endpoint  # noqa: F401
+from meho_backplane.connectors.secret.ops import register_secret_broker_operations
+from meho_backplane.operations.typed_register import register_typed_op_registrar
+
+# Queue the secret.move typed-op upsert onto the lifespan-driven
+# registrar list (run after the connector eager-import pass).
+register_typed_op_registrar(register_secret_broker_operations)
+
+__all__ = [
+    "register_secret_broker_operations",
+]

--- a/backend/src/meho_backplane/connectors/secret/endpoints.py
+++ b/backend/src/meho_backplane/connectors/secret/endpoints.py
@@ -1,0 +1,254 @@
+# SPDX-License-Identifier: Apache-2.0
+# Copyright (c) 2026 evoila Group
+
+"""Secret-broker adapter protocol + kind-keyed endpoint registry.
+
+The secret broker (Initiative #581) moves credential material from one
+store to another **server-side**, so the value never enters the agent's
+op params, the op response, a log event, or an audit row. This module
+owns the abstraction the move handler dispatches through:
+
+* :class:`SecretMaterial` — an in-memory wrapper over the moved value.
+  Its ``__repr__`` / ``__str__`` redact the value; it exposes only the
+  value's SHA-256 digest and byte length to the response path. The
+  wrapped value is read back exactly once by a sink's
+  :meth:`SecretEndpoint.write_secret` and is otherwise inert.
+* :class:`SecretEndpoint` — a structural :class:`typing.Protocol` every
+  store adapter satisfies. A source adapter implements
+  :meth:`~SecretEndpoint.read_secret`; a sink adapter implements
+  :meth:`~SecretEndpoint.write_secret`. A vault-kv adapter (the first
+  pair, #1577) implements both. Sibling tasks add further kinds (e.g. a
+  keycloak sink, #1578) under the **same** contract.
+* :data:`SECRET_ENDPOINT_REGISTRY` + :func:`register_secret_endpoint` —
+  a kind-string → endpoint-factory registry. The move handler resolves
+  each side's ``kind`` (``vault``, …) to a factory and constructs the
+  per-move endpoint from the parsed ``ref``. This is the extension seam
+  sibling adapter tasks register into; they import this module, never
+  the handler.
+* :func:`parse_secret_ref` — splits a ``"<kind>:<ref>"`` intent string
+  into its kind and store-specific reference.
+
+No secret in logs / responses / audit
+======================================
+
+The broker's core invariant (Initiative #581): the value never appears
+in op args, the transcript, logs, the op response, a broadcast payload,
+or the audit row — only the move's status, the value's SHA-256, and its
+length. :class:`SecretMaterial` enforces the representation half of that
+invariant (a stray ``logger.info("...", material=m)`` or f-string renders
+the redacted form, not the value); the handler enforces the response
+half by returning only ``status`` + ``value_sha256`` + ``length`` and
+never threading the value into params. Adapters keep only field *names*
+(never values) in their structlog events, mirroring the discipline in
+:mod:`meho_backplane.connectors._shared.vault_creds`.
+"""
+
+from __future__ import annotations
+
+import hashlib
+from collections.abc import Callable
+from typing import TYPE_CHECKING, Protocol, runtime_checkable
+
+if TYPE_CHECKING:
+    from meho_backplane.auth.operator import Operator
+
+__all__ = [
+    "SECRET_ENDPOINT_REGISTRY",
+    "SecretEndpoint",
+    "SecretEndpointFactory",
+    "SecretMaterial",
+    "SecretRef",
+    "UnknownSecretKindError",
+    "parse_secret_ref",
+    "register_secret_endpoint",
+]
+
+
+class SecretMaterial:
+    """An in-memory carrier for a moved secret value.
+
+    The broker reads a value out of a source store and writes it into a
+    sink store entirely server-side; this wrapper is the only thing that
+    ever holds the value in the move handler's address space. It is
+    deliberately **not** a dataclass / pydantic model and overrides
+    ``__repr__`` / ``__str__`` so the value cannot leak through the
+    string-coercion paths that secret leaks usually travel:
+
+    * a structlog event whose JSON renderer calls ``repr()`` on a bound
+      non-primitive value,
+    * an f-string / ``str()`` in an exception message,
+    * a ``print`` left in during debugging.
+
+    The wrapped value is stored as ``bytes`` (a ``str`` value is encoded
+    UTF-8 on construction) so the SHA-256 digest and the length are over
+    the exact byte sequence that will be written to the sink. The plain
+    value is reachable only through :attr:`value` — the single accessor a
+    sink adapter calls inside :meth:`SecretEndpoint.write_secret`. No
+    callers outside an adapter's write path should touch it.
+    """
+
+    __slots__ = ("_value",)
+
+    def __init__(self, value: str | bytes) -> None:
+        self._value: bytes = value.encode("utf-8") if isinstance(value, str) else value
+
+    @property
+    def value(self) -> bytes:
+        """The raw secret bytes. Read only by a sink's ``write_secret``."""
+        return self._value
+
+    @property
+    def length(self) -> int:
+        """Byte length of the wrapped value — safe to surface in the response."""
+        return len(self._value)
+
+    @property
+    def value_sha256(self) -> str:
+        """Hex SHA-256 of the wrapped value — the provenance hash for the response/audit."""
+        return hashlib.sha256(self._value).hexdigest()
+
+    def __repr__(self) -> str:
+        # Redacted: length + digest only, never the value. The digest is
+        # the provenance signal an auditor reading a log line wants; the
+        # value never appears.
+        return f"<SecretMaterial len={self.length} sha256={self.value_sha256}>"
+
+    __str__ = __repr__
+
+
+class SecretRef:
+    """A parsed ``"<kind>:<ref>"`` secret-move intent reference.
+
+    ``kind`` selects the adapter in :data:`SECRET_ENDPOINT_REGISTRY`
+    (``vault`` → the vault-kv adapter); ``ref`` is the store-specific
+    address the adapter interprets (for vault-kv: a KV-v2 path with an
+    optional ``#<field>`` fragment selecting one field).
+    """
+
+    __slots__ = ("kind", "ref")
+
+    def __init__(self, kind: str, ref: str) -> None:
+        self.kind = kind
+        self.ref = ref
+
+    def __repr__(self) -> str:
+        return f"SecretRef(kind={self.kind!r}, ref={self.ref!r})"
+
+    def __eq__(self, other: object) -> bool:
+        if not isinstance(other, SecretRef):
+            return NotImplemented
+        return self.kind == other.kind and self.ref == other.ref
+
+    def __hash__(self) -> int:
+        return hash((self.kind, self.ref))
+
+
+def parse_secret_ref(raw: str) -> SecretRef:
+    """Split a ``"<kind>:<ref>"`` intent string into a :class:`SecretRef`.
+
+    The split is on the **first** colon only, so the store-specific
+    reference may itself contain colons (a port, a nested path):
+
+    * ``"vault:secret/db/prod#password"`` → kind ``"vault"``, ref
+      ``"secret/db/prod#password"``.
+
+    Both halves must be non-empty after the split. A string with no
+    colon, an empty kind (``":ref"``), or an empty ref (``"vault:"``)
+    raises :class:`ValueError` — the move intent is malformed and there
+    is no defaulting that would be safe for a credential move.
+    """
+    kind, sep, ref = raw.partition(":")
+    if not sep or not kind or not ref:
+        raise ValueError(
+            f"malformed secret ref {raw!r}: expected '<kind>:<ref>' with a "
+            "non-empty kind and ref (e.g. 'vault:secret/db/prod#password')"
+        )
+    return SecretRef(kind=kind, ref=ref)
+
+
+@runtime_checkable
+class SecretEndpoint(Protocol):
+    """Structural contract for a secret store the broker reads from / writes to.
+
+    A concrete adapter is constructed by a
+    :data:`SecretEndpointFactory` from the parsed store-specific
+    ``ref``. A **source** endpoint implements :meth:`read_secret`; a
+    **sink** endpoint implements :meth:`write_secret`. An adapter that is
+    both (the vault-kv pair, #1577) implements both. Because this is a
+    :func:`~typing.runtime_checkable` :class:`~typing.Protocol`, an
+    adapter need only define the methods — no base class, no
+    registration ceremony beyond :func:`register_secret_endpoint`.
+
+    Both methods take the request-scoped :class:`Operator` so the
+    adapter performs its store access under the operator's own
+    credentials (e.g. a Vault JWT/OIDC login via
+    :func:`~meho_backplane.auth.vault.vault_client_for_operator`),
+    keeping the move inside the operator's existing authorization
+    envelope. Neither method accepts or returns the raw value as a bare
+    string: the read produces a :class:`SecretMaterial`, the write
+    consumes one.
+    """
+
+    async def read_secret(self, operator: Operator) -> SecretMaterial:
+        """Read the addressed value from the store and wrap it.
+
+        Raises a store-specific error (subclass of :class:`Exception`)
+        when the address is missing, malformed, or unreadable; the
+        dispatcher maps the exception to a structured ``connector_error``
+        result. The error message names the field/path, never the value.
+        """
+        ...
+
+    async def write_secret(self, operator: Operator, material: SecretMaterial) -> None:
+        """Write *material* into the store at the addressed location.
+
+        Reads ``material.value`` exactly once to obtain the bytes to
+        store. Raises a store-specific error on a write failure.
+        """
+        ...
+
+
+#: Builds a per-move endpoint from the store-specific ``ref`` string an
+#: adapter is registered for. A PEP 695 ``type`` alias, whose value is
+#: lazily evaluated, so the ``Callable`` / :class:`SecretEndpoint`
+#: references resolve at type-check time without a runtime cost.
+type SecretEndpointFactory = Callable[[str], SecretEndpoint]
+
+
+class UnknownSecretKindError(KeyError):
+    """No adapter is registered for a move's ``<kind>``.
+
+    Raised by the move handler when :func:`parse_secret_ref` yields a
+    kind absent from :data:`SECRET_ENDPOINT_REGISTRY`. A
+    :class:`KeyError` subclass so the dispatcher's ``connector_error``
+    branch reports ``exception_class="UnknownSecretKindError"``; the
+    message names the unknown kind and the registered kinds, never a
+    ref value.
+    """
+
+
+#: Kind-string → endpoint-factory registry. Populated at connector
+#: import time: each adapter module calls :func:`register_secret_endpoint`
+#: for the kind(s) it serves. The move handler reads it to resolve a
+#: parsed ``<kind>`` to the factory that builds the per-move endpoint
+#: from the ``ref``. Sibling adapter tasks (#1578 keycloak sink, …)
+#: register additional kinds here under the same contract; no handler
+#: change is needed to add a kind.
+SECRET_ENDPOINT_REGISTRY: dict[str, SecretEndpointFactory] = {}
+
+
+def register_secret_endpoint(kind: str, factory: SecretEndpointFactory) -> None:
+    """Register *factory* as the endpoint builder for move ``kind``.
+
+    Called once per adapter at import time. Re-registering the same
+    kind raises :class:`ValueError` — two adapters claiming one kind is
+    a wiring bug that should fail the import (and therefore the lifespan
+    eager-import pass) loudly rather than silently shadowing one with
+    the other.
+    """
+    if kind in SECRET_ENDPOINT_REGISTRY:
+        raise ValueError(
+            f"secret endpoint kind {kind!r} is already registered "
+            f"(by {SECRET_ENDPOINT_REGISTRY[kind]!r}); kinds must be unique"
+        )
+    SECRET_ENDPOINT_REGISTRY[kind] = factory

--- a/backend/src/meho_backplane/connectors/secret/ops.py
+++ b/backend/src/meho_backplane/connectors/secret/ops.py
@@ -1,0 +1,263 @@
+# SPDX-License-Identifier: Apache-2.0
+# Copyright (c) 2026 evoila Group
+
+"""Secret-broker typed op ``secret.move`` + its registrar.
+
+This is the first **synthetic** typed-op product in the codebase: no
+vendor connector backs it. The op is registered under the natural key
+``(product="secret", version="1.x", impl_id="secret-broker")``, so the
+wire ``connector_id`` is ``secret-broker-1.x`` — which round-trips
+through :func:`~meho_backplane.operations._lookup.parse_connector_id`
+back to ``("secret", "1.x", "secret-broker")`` (the version segment is
+digit-led and the product is the head's first hyphen segment, both
+required by the parser). A colon form or a non-digit-led version would
+make the descriptor unreachable.
+
+``secret.move`` copies a single credential field from a source store to
+a sink store **server-side**. The agent submits only declarative
+``<kind>:<ref>`` references; the value is read inside the backplane,
+held in an in-memory :class:`~.endpoints.SecretMaterial`, written to the
+sink, and never returned. The response carries only the move status, the
+value's SHA-256, and its byte length. ``requires_approval=True`` +
+``safety_level="dangerous"`` route the move through the existing
+approval gate (the gate parks an unapproved move at ``awaiting_approval``
+and the handler never runs); the scoped/time-boxed grant wiring is the
+policy task (#1579), not this mechanism.
+
+The handler is a **module-level** function (not a connector-bound
+method), so the dispatcher resolves it with ``connector_instance=None``
+and ``target=None`` — the synthetic product has no connector instance to
+bind to. Adapters are resolved per move from
+:data:`~.endpoints.SECRET_ENDPOINT_REGISTRY`.
+"""
+
+from __future__ import annotations
+
+from typing import TYPE_CHECKING, Any
+
+import structlog
+
+from meho_backplane.connectors.secret.endpoints import (
+    SECRET_ENDPOINT_REGISTRY,
+    UnknownSecretKindError,
+    parse_secret_ref,
+)
+from meho_backplane.operations.typed_register import register_typed_operation
+
+if TYPE_CHECKING:
+    from meho_backplane.auth.operator import Operator
+    from meho_backplane.connectors.secret.endpoints import (
+        SecretEndpoint,
+        SecretRef,
+    )
+    from meho_backplane.retrieval.embedding import EmbeddingService
+
+__all__ = [
+    "SECRET_MOVE_PARAMETER_SCHEMA",
+    "register_secret_broker_operations",
+    "secret_move",
+]
+
+_log = structlog.get_logger(__name__)
+
+#: A ``<kind>:<ref>`` move endpoint reference. A non-empty string; the
+#: kind/ref split (and the per-kind ref grammar) is validated in the
+#: handler — JSON Schema cannot express "a registered kind" — so the
+#: schema only guards against an empty/whitespace value here. The
+#: ``pattern`` requires at least one non-whitespace char on each side of
+#: a colon so an obviously malformed intent (``":x"``, ``"x:"``, no
+#: colon) fails at param validation rather than inside the handler.
+_SECRET_REF_PROPERTY: dict[str, Any] = {
+    "type": "string",
+    "minLength": 3,
+    "pattern": r"^\S+:\S+$",
+    "description": (
+        "A '<kind>:<ref>' secret reference. 'kind' selects the store "
+        "adapter (e.g. 'vault'); 'ref' is the store-specific address "
+        "(for vault: a KV-v2 path with a '#<field>' fragment, e.g. "
+        "'vault:secret/db/prod#password'). References only — never the "
+        "secret value."
+    ),
+}
+
+#: ``secret.move`` parameter schema (JSON Schema 2020-12). Carries the
+#: source/sink references and an operator-supplied reason for the audit
+#: trail — never the value. ``additionalProperties: false`` keeps a
+#: caller from smuggling a value field past the schema into the handler.
+SECRET_MOVE_PARAMETER_SCHEMA: dict[str, Any] = {
+    "type": "object",
+    "properties": {
+        "from": _SECRET_REF_PROPERTY,
+        "to": _SECRET_REF_PROPERTY,
+        "reason": {
+            "type": "string",
+            "minLength": 1,
+            "description": (
+                "Why the move is being performed. Recorded for the "
+                "operator/approver; must not contain a secret value."
+            ),
+        },
+    },
+    "required": ["from", "to"],
+    "additionalProperties": False,
+}
+
+_SECRET_MOVE_RESPONSE_SCHEMA: dict[str, Any] = {
+    "type": "object",
+    "properties": {
+        "status": {"type": "string", "const": "moved"},
+        "value_sha256": {
+            "type": "string",
+            "description": "Hex SHA-256 of the moved value — provenance, never the value.",
+        },
+        "length": {
+            "type": "integer",
+            "description": "Byte length of the moved value.",
+        },
+    },
+    "required": ["status", "value_sha256", "length"],
+    "additionalProperties": False,
+}
+
+_SECRET_MOVE_LLM_INSTRUCTIONS: dict[str, Any] = {
+    "when_to_use": (
+        "Move a single credential field from one store to another "
+        "server-side WITHOUT ever reading the value into your context. "
+        "Use when an operational flow needs a secret copied from A to B "
+        "(e.g. provisioning a downstream system with a credential that "
+        "lives in Vault) and observing the value would force a rotation. "
+        "Submit references, never values: --from/--to are '<kind>:<ref>' "
+        "strings. The move is change-class: it requires approval before "
+        "it executes, and the response returns only the move status, the "
+        "value's SHA-256, and its length — never the value."
+    ),
+    "parameter_hints": {
+        "from": "Required. Source '<kind>:<ref>' (e.g. 'vault:secret/db/prod#password').",
+        "to": "Required. Sink '<kind>:<ref>'.",
+        "reason": "Optional. Human-readable justification for the approver/audit trail.",
+    },
+    "output_shape": (
+        "On success: {'status': 'moved', 'value_sha256': <hex>, "
+        "'length': <int>}. The value never appears."
+    ),
+}
+
+_SECRET_MOVE_WHEN_TO_USE = (
+    "Use to move a credential from one store to another server-side, "
+    "with the backplane as the credential-bearing intermediary so the "
+    "agent never observes the value. The right op when the question is "
+    "'copy this secret from A to B' rather than 'read this secret' "
+    "(which would land the value in the transcript)."
+)
+
+
+def _resolve_endpoint(spec: SecretRef) -> SecretEndpoint:
+    """Resolve a parsed ``<kind>:<ref>`` to a constructed endpoint.
+
+    Raises :class:`UnknownSecretKindError` when no adapter is registered
+    for the kind — the dispatcher maps it to a ``connector_error`` with
+    the class name in ``extras['exception_class']``. The error names the
+    unknown kind and the registered kinds, never the ref's value side.
+    """
+    factory = SECRET_ENDPOINT_REGISTRY.get(spec.kind)
+    if factory is None:
+        known = ", ".join(sorted(SECRET_ENDPOINT_REGISTRY)) or "(none)"
+        raise UnknownSecretKindError(
+            f"no secret endpoint adapter for kind {spec.kind!r}; registered kinds: {known}"
+        )
+    return factory(spec.ref)
+
+
+async def secret_move(operator: Operator, target: Any, params: dict[str, Any]) -> dict[str, Any]:
+    """Move a credential field from a source store to a sink store.
+
+    Op-id: ``secret.move``. Synthetic typed op (no vendor connector).
+    The handler:
+
+    1. parses ``params['from']`` / ``params['to']`` into
+       ``<kind>:<ref>`` references (the dispatcher has already validated
+       the param schema, so both are present and colon-shaped);
+    2. resolves each kind to a :class:`~.endpoints.SecretEndpoint` via
+       the registry;
+    3. ``read_secret`` from the source (the value enters memory only as
+       a :class:`~.endpoints.SecretMaterial`);
+    4. ``write_secret`` to the sink — entirely server-side.
+
+    Returns ONLY ``{'status': 'moved', 'value_sha256': <hex>, 'length':
+    <int>}``. The value is never in the params, the return value, a log
+    event, or (therefore) the audit row — only its hash + length. The
+    ``reason`` param (when supplied) is operator-facing justification and
+    is intentionally not read here; it is recorded by the dispatcher's
+    audit row via the validated params hash and is surfaced to the
+    approver by the approval-queue task (#1579).
+    """
+    source_ref = parse_secret_ref(str(params["from"]))
+    sink_ref = parse_secret_ref(str(params["to"]))
+    source = _resolve_endpoint(source_ref)
+    sink = _resolve_endpoint(sink_ref)
+
+    # Server-side read → write. The value lives only inside ``material``
+    # for the duration of this call; it never crosses back to the caller.
+    material = await source.read_secret(operator)
+    await sink.write_secret(operator, material)
+
+    _log.info(
+        "secret_broker.move",
+        from_kind=source_ref.kind,
+        to_kind=sink_ref.kind,
+        value_sha256=material.value_sha256,
+        length=material.length,
+    )
+    return {
+        "status": "moved",
+        "value_sha256": material.value_sha256,
+        "length": material.length,
+    }
+
+
+async def register_secret_broker_operations(
+    *,
+    embedding_service: EmbeddingService | None = None,
+) -> None:
+    """Upsert the ``secret.move`` typed op into ``endpoint_descriptor``.
+
+    Queued onto the lifespan-driven registrar list by the package
+    ``__init__`` (via ``register_typed_op_registrar``) and run by
+    :func:`~meho_backplane.operations.typed_register.run_typed_op_registrars`
+    after the connector eager-import pass. Idempotent: a re-run against
+    unchanged text is a no-op for the embedding pipeline.
+
+    ``requires_approval=True`` + ``safety_level="dangerous"`` make the
+    move change-class: the existing policy gate parks an unapproved
+    dispatch at ``awaiting_approval`` (G11.7-T1 #1401) and the handler
+    never runs. The ``embedding_service`` kwarg is the test seam, the
+    same shape every connector registrar carries.
+    """
+    await register_typed_operation(
+        product="secret",
+        version="1.x",
+        impl_id="secret-broker",
+        op_id="secret.move",
+        handler=secret_move,
+        group_key="broker",
+        when_to_use=_SECRET_MOVE_WHEN_TO_USE,
+        summary="Move a credential from one store to another, value never returned.",
+        description=(
+            "Copies a single credential field from a source store to a "
+            "sink store server-side via the SecretEndpoint adapter "
+            "registry (vault-kv is the first pair). The agent submits "
+            "only '<kind>:<ref>' references; the value is read, hashed, "
+            "and written entirely inside the backplane and never enters "
+            "the op params, the response, a log event, or the audit row "
+            "— the response carries only status + value SHA-256 + length. "
+            "Change-class: requires_approval=True + safety_level=dangerous "
+            "route the move through the approval gate before it executes."
+        ),
+        parameter_schema=SECRET_MOVE_PARAMETER_SCHEMA,
+        response_schema=_SECRET_MOVE_RESPONSE_SCHEMA,
+        tags=["secret-broker", "write", "change-class"],
+        safety_level="dangerous",
+        requires_approval=True,
+        llm_instructions=_SECRET_MOVE_LLM_INSTRUCTIONS,
+        embedding_service=embedding_service,
+    )

--- a/backend/src/meho_backplane/connectors/secret/vault_endpoint.py
+++ b/backend/src/meho_backplane/connectors/secret/vault_endpoint.py
@@ -1,0 +1,186 @@
+# SPDX-License-Identifier: Apache-2.0
+# Copyright (c) 2026 evoila Group
+
+"""Vault KV-v2 :class:`SecretEndpoint` adapter — the first broker pair.
+
+Registered under kind ``"vault"`` (see :func:`register_secret_endpoint`
+at module import), this adapter is both a **source** (``read_secret``)
+and a **sink** (``write_secret``) so the broker's first move pair is
+vault-kv → vault-kv. Sibling tasks add further sink kinds (e.g. keycloak,
+#1578) under the same :class:`SecretEndpoint` contract.
+
+Ref grammar
+===========
+
+The store-specific ``ref`` addresses a KV-v2 secret as::
+
+    [<mount>/]<path>#<field>
+
+* ``<path>`` is the KV-v2 logical path (relative to the mount, the same
+  shape hvac's ``read_secret_version`` / ``create_or_update_secret``
+  ``path=`` expects — Vault inserts the ``/data/`` segment itself).
+* ``#<field>`` (required) selects which field of the secret's data dict
+  carries the value to move. The broker moves a single field, not a
+  whole secret body, because the move is value-oriented (a password, a
+  token) — naming the field is what keeps the SHA-256 / length in the
+  response meaningful.
+* A leading mount segment is **not** parsed out of the path here: the
+  ``ref`` is forwarded to hvac's ``path=`` and the mount defaults to
+  ``"secret"`` (the deployment KV-v2 mount, mirroring
+  :data:`meho_backplane.connectors._shared.vault_creds.DEFAULT_KV_MOUNT`).
+  A non-default mount is a per-adapter concern a sibling task can add via
+  a richer ref grammar without touching the broker handler.
+
+No secret in logs
+=================
+
+The adapter's structlog events carry only the ``path`` and the ``field``
+*name* — never the field's value, and never the bytes carried by the
+:class:`SecretMaterial`. The value lives only inside the
+:class:`SecretMaterial` between the source read and the sink write.
+"""
+
+from __future__ import annotations
+
+import asyncio
+from typing import TYPE_CHECKING, Any
+
+import structlog
+
+import meho_backplane.auth.vault as _auth_vault
+from meho_backplane.connectors._shared.vault_creds import (
+    DEFAULT_KV_MOUNT,
+    strip_credential_value,
+)
+from meho_backplane.connectors.secret.endpoints import (
+    SecretMaterial,
+    register_secret_endpoint,
+)
+
+if TYPE_CHECKING:
+    from meho_backplane.auth.operator import Operator
+
+__all__ = [
+    "VaultKvSecretEndpoint",
+    "VaultSecretRefError",
+]
+
+_log = structlog.get_logger(__name__)
+
+
+class VaultSecretRefError(ValueError):
+    """A vault-kv ``ref`` is malformed or addresses a missing field.
+
+    Raised for a ref without the required ``#<field>`` fragment, an
+    empty path/field, a KV-v2 read whose data dict lacks the named
+    field, or a malformed hvac payload. A :class:`ValueError` so the
+    dispatcher's ``connector_error`` branch surfaces
+    ``exception_class="VaultSecretRefError"``. The message names the
+    path and field, never the value.
+    """
+
+
+def _parse_vault_ref(ref: str) -> tuple[str, str]:
+    """Split ``"<path>#<field>"`` into ``(path, field)``.
+
+    The split is on the **last** ``#`` so a path may itself contain a
+    ``#`` (uncommon but legal in a KV-v2 key). Both halves must be
+    non-empty after the split.
+    """
+    path, sep, field = ref.rpartition("#")
+    if not sep or not path or not field:
+        raise VaultSecretRefError(
+            f"malformed vault secret ref {ref!r}: expected '<path>#<field>' "
+            "selecting one KV-v2 field (e.g. 'secret/db/prod#password')"
+        )
+    return path.strip(), field.strip()
+
+
+class VaultKvSecretEndpoint:
+    """A vault-kv source+sink endpoint addressing one KV-v2 field.
+
+    Constructed per move from the parsed ``ref``. Both methods open an
+    operator-scoped Vault client via
+    :func:`~meho_backplane.auth.vault.vault_client_for_operator` (JWT/OIDC
+    login under the operator's own token, revoked on exit), so the move
+    runs inside the operator's authorization envelope.
+    """
+
+    def __init__(self, ref: str, *, mount: str = DEFAULT_KV_MOUNT) -> None:
+        self._path, self._field = _parse_vault_ref(ref)
+        self._mount = mount
+
+    async def read_secret(self, operator: Operator) -> SecretMaterial:
+        """Read the addressed field and wrap its value in a :class:`SecretMaterial`.
+
+        Reads via ``client.secrets.kv.v2.read_secret_version``, performs
+        the KV-v2 ``data.data`` double-unwrap (the same shape
+        ``vault/ops.py`` and ``vault_creds._structural_unwrap`` use), and
+        selects the named field. The value is coerced + whitespace-
+        stripped by :func:`strip_credential_value` (a trailing newline is
+        the single most common secret-storage artifact) before it is
+        hashed and forwarded, so source and sink agree byte-for-byte.
+        """
+        _log.debug("secret_broker.vault.read", path=self._path, field=self._field)
+        async with _auth_vault.vault_client_for_operator(operator) as client:
+            payload = await asyncio.to_thread(
+                client.secrets.kv.v2.read_secret_version,
+                path=self._path,
+                mount_point=self._mount,
+                raise_on_deleted_version=False,
+            )
+        secret_data = _structural_unwrap(payload, path=self._path)
+        if self._field not in secret_data:
+            raise VaultSecretRefError(
+                f"vault KV-v2 secret at {self._path!r} has no field {self._field!r}"
+            )
+        return SecretMaterial(strip_credential_value(secret_data[self._field]))
+
+    async def write_secret(self, operator: Operator, material: SecretMaterial) -> None:
+        """Write *material* into the addressed field as a new KV-v2 version.
+
+        KV-v2 replaces the latest version wholesale (no server-side
+        merge), so the write sends a single-field secret body
+        ``{<field>: <value>}``. The value is decoded back to ``str`` from
+        the material's bytes — KV-v2 stores JSON string values, and the
+        source read coerced via :func:`strip_credential_value`, so the
+        round-trip is lossless for the credential strings the broker
+        moves. ``cas`` is omitted (unconditional write); a check-and-set
+        guard is a policy-task concern (#1579), not the mechanism.
+        """
+        _log.debug("secret_broker.vault.write", path=self._path, field=self._field)
+        body: dict[str, str] = {self._field: material.value.decode("utf-8")}
+        async with _auth_vault.vault_client_for_operator(operator) as client:
+            await asyncio.to_thread(
+                client.secrets.kv.v2.create_or_update_secret,
+                path=self._path,
+                secret=body,
+                cas=None,
+                mount_point=self._mount,
+            )
+
+
+def _structural_unwrap(payload: object, *, path: str) -> dict[str, Any]:
+    """Unwrap hvac's ``read_secret_version`` payload to the secret data dict.
+
+    KV-v2's GET returns ``{"data": {"data": {<secret kv>}, "metadata":
+    {...}}}``; the secret content is the nested ``data["data"]``. A
+    malformed payload (missing either level) raises
+    :class:`VaultSecretRefError` naming the path rather than a bare
+    ``KeyError`` deep inside hvac's response — mirroring
+    ``vault_creds._structural_unwrap``.
+    """
+    outer = payload.get("data") if isinstance(payload, dict) else None
+    secret_data = outer.get("data") if isinstance(outer, dict) else None
+    if not isinstance(secret_data, dict):
+        raise VaultSecretRefError(
+            f"vault KV-v2 read for {path!r} returned a malformed payload: "
+            "expected a nested 'data.data' object holding the secret fields"
+        )
+    return secret_data
+
+
+# Register the vault-kv adapter under kind ``"vault"`` at import time. The
+# package ``__init__`` imports this module so the registration lands
+# before the lifespan runs the move op's registrar.
+register_secret_endpoint("vault", VaultKvSecretEndpoint)

--- a/backend/tests/test_connectors_secret_broker.py
+++ b/backend/tests/test_connectors_secret_broker.py
@@ -1,0 +1,489 @@
+# SPDX-License-Identifier: Apache-2.0
+# Copyright (c) 2026 evoila Group
+
+"""Tests for the secret broker — G0.22-T1 (#1577).
+
+Covers the mechanism this task establishes:
+
+* The ``SecretMaterial`` wrapper redacts its value in ``repr``/``str``
+  and exposes only ``value_sha256`` / ``length``.
+* ``parse_secret_ref`` splits ``"<kind>:<ref>"`` (first-colon split) and
+  rejects malformed intents.
+* The synthetic ``secret-broker-1.x`` connector_id round-trips through
+  the dispatcher's parser back to ``("secret", "1.x", "secret-broker")``
+  — the descriptor is reachable.
+* ``secret.move`` is registered with the exact synthetic identity +
+  change-class posture (``safety_level="dangerous"``,
+  ``requires_approval=True``).
+* End-to-end vault-kv → vault-kv move through ``dispatch(...,
+  _approved=True)``: the sink receives the value, the response carries
+  ONLY ``status`` + ``value_sha256`` + ``length``, and the secret
+  substring is absent from the response, the params, and the persisted
+  audit row's ``payload`` AND ``raw_payload``.
+* The existing approval gate parks an unapproved move at
+  ``awaiting_approval`` and the sink write never runs.
+
+Test isolation mirrors ``test_connectors_vault.py``: the operator-scoped
+Vault client is built through the single ``_build_client`` seam, which
+``install_fake_client`` monkeypatches to a controllable
+``_FakeKVv2`` — no real HTTP, no Vault container. The autouse
+``_default_database_url`` conftest fixture migrates the SQLite DB to head
+so the ``endpoint_descriptor`` / ``operation_group`` / ``audit_log``
+tables exist before the registrar runs.
+"""
+
+from __future__ import annotations
+
+import hashlib
+import json
+from collections.abc import AsyncIterator, Iterator
+from typing import Any
+from unittest.mock import AsyncMock
+from uuid import UUID
+
+import pytest
+from sqlalchemy import select
+
+from meho_backplane.auth.operator import Operator, TenantRole
+from meho_backplane.connectors.schemas import OperationResult
+from meho_backplane.connectors.secret.endpoints import (
+    SECRET_ENDPOINT_REGISTRY,
+    SecretEndpoint,
+    SecretMaterial,
+    parse_secret_ref,
+    register_secret_endpoint,
+)
+from meho_backplane.connectors.secret.ops import (
+    register_secret_broker_operations,
+    secret_move,
+)
+from meho_backplane.connectors.secret.vault_endpoint import VaultKvSecretEndpoint
+from meho_backplane.db.engine import get_sessionmaker
+from meho_backplane.db.models import AuditLog, EndpointDescriptor
+from meho_backplane.operations import dispatch, reset_dispatcher_caches
+from meho_backplane.operations._lookup import parse_connector_id
+from meho_backplane.settings import get_settings
+
+from ._vault_fakes import install_fake_client
+
+_SECRET_VALUE = "hunter2"
+_SECRET_SHA256 = hashlib.sha256(_SECRET_VALUE.encode()).hexdigest()
+
+
+# ---------------------------------------------------------------------------
+# Settings env + dispatcher isolation
+# ---------------------------------------------------------------------------
+
+
+@pytest.fixture(autouse=True)
+def _settings_env(monkeypatch: pytest.MonkeyPatch) -> Iterator[None]:
+    """Pin env vars Settings / the operator-scoped Vault client need."""
+    monkeypatch.setenv("KEYCLOAK_ISSUER_URL", "https://keycloak.test/realms/meho")
+    monkeypatch.setenv("KEYCLOAK_AUDIENCE", "meho-backplane")
+    monkeypatch.setenv("VAULT_ADDR", "https://vault.test")
+    monkeypatch.setenv("VAULT_OIDC_ROLE", "meho-mcp")
+    monkeypatch.setenv("VAULT_OIDC_MOUNT_PATH", "jwt")
+    monkeypatch.setenv("VAULT_TIMEOUT_SECONDS", "5.0")
+    monkeypatch.delenv("VAULT_NAMESPACE", raising=False)
+    get_settings.cache_clear()
+    reset_dispatcher_caches()
+    yield
+    get_settings.cache_clear()
+    reset_dispatcher_caches()
+
+
+@pytest.fixture
+def stub_embedding_service() -> AsyncMock:
+    """Deterministic embedding stub so registration doesn't pull ONNX."""
+    service = AsyncMock()
+    service.encode_one.return_value = [0.1] * 384
+    service.encode.return_value = [[0.1] * 384]
+    service.dimension = 384
+    return service
+
+
+@pytest.fixture
+async def _registered_secret_broker_op(
+    stub_embedding_service: AsyncMock,
+) -> AsyncIterator[None]:
+    """Upsert the ``secret.move`` descriptor row for dispatch-driving tests."""
+    await register_secret_broker_operations(embedding_service=stub_embedding_service)
+    yield
+
+
+def _make_operator(jwt: str = "fake.jwt.value") -> Operator:
+    """A request-scoped operator carrying the JWT the vault adapter forwards."""
+    return Operator(
+        sub="test-operator",
+        name=None,
+        email=None,
+        raw_jwt=jwt,
+        tenant_id=UUID(int=0),
+        tenant_role=TenantRole.OPERATOR,
+    )
+
+
+async def _dispatch_move(
+    params: dict[str, Any],
+    *,
+    jwt: str = "fake.jwt.value",
+    approved: bool = True,
+) -> OperationResult:
+    """Dispatch ``secret.move`` through the real operator-aware path.
+
+    ``target`` is ``None`` (the synthetic product has no connector
+    instance); the handler is module-level, so the dispatcher resolves
+    it with ``connector_instance=None``. ``approved`` threads the
+    ``_approved`` resume flag — the op registers ``requires_approval=True``
+    so an unapproved dispatch parks at ``awaiting_approval``.
+    """
+    return await dispatch(
+        operator=_make_operator(jwt),
+        connector_id="secret-broker-1.x",
+        op_id="secret.move",
+        target=None,
+        params=params,
+        _approved=approved,
+    )
+
+
+async def _fetch_audit_rows() -> list[AuditLog]:
+    sessionmaker = get_sessionmaker()
+    async with sessionmaker() as session:
+        result = await session.execute(select(AuditLog).order_by(AuditLog.occurred_at))
+        return list(result.scalars().all())
+
+
+# ---------------------------------------------------------------------------
+# SecretMaterial — value never leaks through repr/str; hash + length exposed
+# ---------------------------------------------------------------------------
+
+
+def test_secret_material_repr_and_str_redact_the_value() -> None:
+    material = SecretMaterial(_SECRET_VALUE)
+    assert _SECRET_VALUE not in repr(material)
+    assert _SECRET_VALUE not in str(material)
+    # The redacted form carries the provenance signal an auditor wants.
+    assert _SECRET_SHA256 in repr(material)
+    assert f"len={len(_SECRET_VALUE.encode())}" in repr(material)
+
+
+def test_secret_material_exposes_sha256_and_length() -> None:
+    material = SecretMaterial(_SECRET_VALUE)
+    assert material.value_sha256 == _SECRET_SHA256
+    assert material.length == len(_SECRET_VALUE.encode())
+    # bytes and str of the same content hash identically.
+    assert SecretMaterial(_SECRET_VALUE.encode()).value_sha256 == _SECRET_SHA256
+
+
+# ---------------------------------------------------------------------------
+# parse_secret_ref — first-colon split + malformed rejection
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.parametrize(
+    "raw,kind,ref",
+    [
+        ("vault:secret/db/prod#password", "vault", "secret/db/prod#password"),
+        # First-colon split: the ref may itself contain colons.
+        ("vault:secret/a:b#field", "vault", "secret/a:b#field"),
+        ("keycloak:realm/clients/web#secret", "keycloak", "realm/clients/web#secret"),
+    ],
+    ids=["vault", "ref-with-colon", "keycloak-kind"],
+)
+def test_parse_secret_ref_splits_kind_and_ref(raw: str, kind: str, ref: str) -> None:
+    parsed = parse_secret_ref(raw)
+    assert parsed.kind == kind
+    assert parsed.ref == ref
+
+
+@pytest.mark.parametrize(
+    "raw",
+    ["no-colon", ":ref-only", "kind-only:", ""],
+    ids=["missing-colon", "empty-kind", "empty-ref", "empty"],
+)
+def test_parse_secret_ref_rejects_malformed(raw: str) -> None:
+    with pytest.raises(ValueError, match="malformed secret ref"):
+        parse_secret_ref(raw)
+
+
+# ---------------------------------------------------------------------------
+# Reachability + registration identity
+# ---------------------------------------------------------------------------
+
+
+def test_secret_broker_connector_id_round_trips() -> None:
+    """The wire connector_id resolves to the registered natural key.
+
+    Guards the unreachable-identity trap: a non-digit-led version or a
+    colon form would silently never match the descriptor.
+    """
+    assert parse_connector_id("secret-broker-1.x") == ("secret", "1.x", "secret-broker")
+
+
+def test_vault_endpoint_registered_under_kind_vault() -> None:
+    assert SECRET_ENDPOINT_REGISTRY.get("vault") is VaultKvSecretEndpoint
+
+
+def test_vault_endpoint_satisfies_secret_endpoint_protocol() -> None:
+    endpoint = VaultKvSecretEndpoint("secret/db/prod#password")
+    assert isinstance(endpoint, SecretEndpoint)
+
+
+def test_register_secret_endpoint_rejects_duplicate_kind() -> None:
+    with pytest.raises(ValueError, match="already registered"):
+        register_secret_endpoint("vault", VaultKvSecretEndpoint)
+
+
+async def test_secret_move_registered_with_synthetic_identity(
+    _registered_secret_broker_op: None,
+) -> None:
+    """The descriptor row carries the exact synthetic identity + posture."""
+    sessionmaker = get_sessionmaker()
+    async with sessionmaker() as session:
+        result = await session.execute(
+            select(EndpointDescriptor).where(
+                EndpointDescriptor.product == "secret",
+                EndpointDescriptor.version == "1.x",
+                EndpointDescriptor.impl_id == "secret-broker",
+                EndpointDescriptor.op_id == "secret.move",
+            )
+        )
+        row = result.scalar_one()
+    assert row.source_kind == "typed"
+    assert row.safety_level == "dangerous"
+    assert row.requires_approval is True
+
+
+# ---------------------------------------------------------------------------
+# End-to-end move — value reaches the sink, never the response/params/audit
+# ---------------------------------------------------------------------------
+
+
+async def test_secret_move_vault_to_vault_round_trips_value_server_side(
+    monkeypatch: pytest.MonkeyPatch,
+    _registered_secret_broker_op: None,
+) -> None:
+    """A vault-kv → vault-kv move writes the value to the sink path.
+
+    The single fake Vault client serves both endpoints (same operator,
+    same Vault): the source read returns the seeded secret; the sink
+    write records to ``put_calls``. The handler returns only status +
+    hash + length.
+    """
+    fake = install_fake_client(monkeypatch, secret={"password": _SECRET_VALUE})
+
+    result = await _dispatch_move(
+        {
+            "from": "vault:secret/db/prod#password",
+            "to": "vault:secret/db/replica#password",
+            "reason": "promote replica credential",
+        }
+    )
+
+    assert result.status == "ok", result.error
+    # (a) the sink received the value at the 'to' path.
+    put_calls = fake.secrets.kv.v2.put_calls
+    assert put_calls == [
+        {
+            "path": "secret/db/replica",
+            "secret": {"password": _SECRET_VALUE},
+            "cas": None,
+            "mount_point": "secret",
+        }
+    ]
+
+
+async def test_secret_move_response_carries_only_status_hash_length(
+    monkeypatch: pytest.MonkeyPatch,
+    _registered_secret_broker_op: None,
+) -> None:
+    """(b) The result payload is exactly {status, value_sha256, length}.
+
+    And the secret substring is absent from the JSON-serialised result.
+    """
+    install_fake_client(monkeypatch, secret={"password": _SECRET_VALUE})
+
+    result = await _dispatch_move(
+        {
+            "from": "vault:secret/db/prod#password",
+            "to": "vault:secret/db/replica#password",
+        }
+    )
+
+    assert result.status == "ok", result.error
+    assert result.result == {
+        "status": "moved",
+        "value_sha256": _SECRET_SHA256,
+        "length": len(_SECRET_VALUE.encode()),
+    }
+    # The value never appears anywhere in the serialised OperationResult.
+    assert _SECRET_VALUE not in json.dumps(result.result)
+    assert _SECRET_VALUE not in result.model_dump_json()
+
+
+async def test_secret_move_audit_row_omits_value(
+    monkeypatch: pytest.MonkeyPatch,
+    _registered_secret_broker_op: None,
+) -> None:
+    """(c) The persisted audit row's payload AND raw_payload omit the value.
+
+    The dispatcher stores ``params_hash`` (not the params) in ``payload``
+    and the handler's return dict (hash + length only) in ``raw_payload``,
+    so the value is absent from both by construction.
+    """
+    install_fake_client(monkeypatch, secret={"password": _SECRET_VALUE})
+
+    result = await _dispatch_move(
+        {
+            "from": "vault:secret/db/prod#password",
+            "to": "vault:secret/db/replica#password",
+        }
+    )
+    assert result.status == "ok", result.error
+
+    rows = await _fetch_audit_rows()
+    move_rows = [r for r in rows if r.path == "secret.move"]
+    assert len(move_rows) == 1
+    row = move_rows[0]
+    assert row.status_code == 200
+    assert _SECRET_VALUE not in json.dumps(row.payload)
+    assert _SECRET_VALUE not in json.dumps(row.raw_payload)
+    # The raw payload is the handler's return dict — hash + length only.
+    assert row.raw_payload == {
+        "status": "moved",
+        "value_sha256": _SECRET_SHA256,
+        "length": len(_SECRET_VALUE.encode()),
+    }
+
+
+def test_secret_move_params_never_carry_the_value() -> None:
+    """The dispatched params dict carries only the '<kind>:<ref>' strings."""
+    params = {
+        "from": "vault:secret/db/prod#password",
+        "to": "vault:secret/db/replica#password",
+        "reason": "promote replica credential",
+    }
+    assert _SECRET_VALUE not in json.dumps(params)
+
+
+async def test_secret_move_handler_does_not_read_value_from_params(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """The handler resolves the value from the source store, not params.
+
+    A params dict carrying a (would-be-malicious) value field is rejected
+    by the schema's ``additionalProperties: false``; calling the handler
+    directly with only refs proves the value comes from the source read.
+    """
+    fake = install_fake_client(monkeypatch, secret={"password": _SECRET_VALUE})
+    operator = _make_operator()
+
+    result = await secret_move(
+        operator,
+        None,
+        {
+            "from": "vault:secret/db/prod#password",
+            "to": "vault:secret/db/replica#password",
+        },
+    )
+
+    assert result == {
+        "status": "moved",
+        "value_sha256": _SECRET_SHA256,
+        "length": len(_SECRET_VALUE.encode()),
+    }
+    # The value the sink wrote came from the source read, not params.
+    assert fake.secrets.kv.v2.put_calls[0]["secret"] == {"password": _SECRET_VALUE}
+
+
+# ---------------------------------------------------------------------------
+# Approval gate — an unapproved move is parked, the sink write never runs
+# ---------------------------------------------------------------------------
+
+
+async def test_secret_move_parks_without_approval(
+    monkeypatch: pytest.MonkeyPatch,
+    _registered_secret_broker_op: None,
+) -> None:
+    """``requires_approval=True`` parks the move; the handler never runs.
+
+    Dispatching without the approval-resume flag routes the call to the
+    approval queue (``awaiting_approval``) per G11.7-T1 (#1401) rather
+    than reaching the source read / sink write — the sink ``put_calls``
+    log stays empty.
+    """
+    fake = install_fake_client(monkeypatch, secret={"password": _SECRET_VALUE})
+
+    result = await _dispatch_move(
+        {
+            "from": "vault:secret/db/prod#password",
+            "to": "vault:secret/db/replica#password",
+        },
+        approved=False,
+    )
+
+    assert result.status == "awaiting_approval", result.error
+    assert fake.secrets.kv.v2.put_calls == []
+    assert fake.secrets.kv.v2.read_calls == []
+
+
+# ---------------------------------------------------------------------------
+# Error mapping — unknown kind / missing field surface as connector_error
+# ---------------------------------------------------------------------------
+
+
+async def test_secret_move_unknown_kind_is_connector_error(
+    monkeypatch: pytest.MonkeyPatch,
+    _registered_secret_broker_op: None,
+) -> None:
+    install_fake_client(monkeypatch, secret={"password": _SECRET_VALUE})
+
+    result = await _dispatch_move(
+        {
+            "from": "nope:whatever#field",
+            "to": "vault:secret/db/replica#password",
+        }
+    )
+
+    assert result.status == "error"
+    assert result.extras.get("exception_class") == "UnknownSecretKindError"
+
+
+async def test_secret_move_missing_field_is_connector_error(
+    monkeypatch: pytest.MonkeyPatch,
+    _registered_secret_broker_op: None,
+) -> None:
+    install_fake_client(monkeypatch, secret={"username": "demo"})
+
+    result = await _dispatch_move(
+        {
+            "from": "vault:secret/db/prod#password",
+            "to": "vault:secret/db/replica#password",
+        }
+    )
+
+    assert result.status == "error"
+    assert result.extras.get("exception_class") == "VaultSecretRefError"
+
+
+@pytest.mark.parametrize(
+    "params",
+    [
+        {"to": "vault:secret/db/replica#password"},
+        {"from": "vault:secret/db/prod#password"},
+        {"from": "no-colon", "to": "vault:secret/db/replica#password"},
+    ],
+    ids=["missing-from", "missing-to", "malformed-from"],
+)
+async def test_secret_move_invalid_params_returns_dispatcher_error(
+    monkeypatch: pytest.MonkeyPatch,
+    params: dict[str, Any],
+    _registered_secret_broker_op: None,
+) -> None:
+    """The param schema rejects missing/malformed refs before the handler."""
+    install_fake_client(monkeypatch, secret={"password": _SECRET_VALUE})
+    result = await _dispatch_move(params)
+
+    assert result.status == "error"
+    assert result.extras.get("error_code") == "invalid_params"

--- a/docs/codebase/connectors-secret-broker.md
+++ b/docs/codebase/connectors-secret-broker.md
@@ -1,0 +1,161 @@
+# Secret broker (`connectors/secret`)
+
+## Overview
+
+The secret broker moves a single credential field from one store to
+another **server-side**, so the agent driving the move never observes
+the value. It exists because an autonomous agent can orchestrate almost
+every operational step except moving a secret from system A to system B:
+reading the value into the agent's context lands it in the model/API
+transcript (forcing a rotation), and bouncing to a human terminal breaks
+unattended operation. The broker is the safe primitive for "take the
+value at A, put it at B, agent never observes it, with provenance."
+
+This task (#1577, Initiative #581 T1) establishes the **mechanism**: the
+adapter protocol, the kind-keyed registry, the synthetic `secret.move`
+typed op + handler, and the first adapter pair (vault-kv source AND
+vault-kv sink). Sibling tasks add further adapter kinds (#1578 keycloak
+sink), the approval-queue gating (#1579), the CLI verb (#1580), and the
+docs page (#1581). Those reuse the names established here.
+
+## Core invariant
+
+The secret value must **never** appear in:
+
+- the op params / the agent's args / the transcript,
+- a log event,
+- the op response or a broadcast payload,
+- the audit row.
+
+Only the move **status**, the value's **SHA-256**, and its **byte
+length** are surfaced. This holds **by construction**, not by relying on
+boundary redaction:
+
+- The agent submits only declarative `<kind>:<ref>` references. The
+  value is read inside the backplane, never passed in params.
+- `SecretMaterial` (the in-memory carrier) redacts its value in
+  `__repr__` / `__str__`, so a stray log-bind or f-string renders
+  `<SecretMaterial len=N sha256=…>`, not the value.
+- The handler returns only `{status, value_sha256, length}`. The
+  dispatcher stores `params_hash` (not the params) in the audit row's
+  `payload`, and the handler's return dict in `raw_payload` — so neither
+  audit column carries the value.
+
+## Key types
+
+- **`SecretMaterial`** (`endpoints.py`) — wraps the moved value as
+  `bytes`. Exposes `value` (read once by a sink's `write_secret`),
+  `length`, and `value_sha256`. `__repr__`/`__str__` redact.
+- **`SecretEndpoint`** (`endpoints.py`) — a `runtime_checkable`
+  `typing.Protocol`. A source adapter implements
+  `async read_secret(operator) -> SecretMaterial`; a sink adapter
+  implements `async write_secret(operator, material) -> None`. Both take
+  the request-scoped `Operator` so the store access runs under the
+  operator's own credentials. An adapter that is both (vault-kv)
+  implements both methods.
+- **`SecretRef`** + **`parse_secret_ref`** (`endpoints.py`) — parse a
+  `"<kind>:<ref>"` intent string on the **first** colon (so the ref may
+  contain colons). Both halves must be non-empty.
+- **`SECRET_ENDPOINT_REGISTRY`** + **`register_secret_endpoint`**
+  (`endpoints.py`) — kind-string → endpoint-factory registry. Each
+  adapter registers its kind(s) at import time. The move handler resolves
+  a parsed `<kind>` to the factory that builds the per-move endpoint from
+  the `ref`. This is the extension seam sibling adapter tasks register
+  into; duplicate-kind registration raises.
+- **`VaultKvSecretEndpoint`** (`vault_endpoint.py`) — the first adapter,
+  registered under kind `"vault"`. Addresses a KV-v2 secret as
+  `<path>#<field>` (the `#<field>` fragment is required and selects one
+  field). Reads via `read_secret_version` + the KV-v2 `data.data`
+  double-unwrap + `strip_credential_value`; writes via
+  `create_or_update_secret` (a single-field body, `cas=None`). Both
+  through `vault_client_for_operator`.
+- **`secret_move`** + **`register_secret_broker_operations`**
+  (`ops.py`) — the module-level handler and its lifespan registrar.
+
+## Control flow
+
+A move dispatches through the standard typed-op path:
+
+1. A caller dispatches `connector_id="secret-broker-1.x"`,
+   `op_id="secret.move"`, `target=None`, params
+   `{"from": "<kind>:<ref>", "to": "<kind>:<ref>", "reason": ...}`.
+2. `parse_connector_id("secret-broker-1.x")` →
+   `("secret", "1.x", "secret-broker")` (the natural key the descriptor
+   is registered under). The version segment is digit-led (`1.x`) and the
+   product is the head's first hyphen segment, both required for the id
+   to round-trip — a colon form or a non-digit-led version would make the
+   descriptor unreachable.
+3. The dispatcher validates params against the op's
+   `parameter_schema`, then runs the policy gate. Because the op is
+   `requires_approval=True`, an ordinary dispatch is parked at
+   `awaiting_approval` and the handler never runs; the approval-resume
+   path (`_approved=True`) skips the gate and runs the handler.
+4. The handler is **module-level** (no `self`), so
+   `_resolve_connector_instance` returns `(None, None, None)` and the op
+   dispatches with `connector_instance=None`. The synthetic `secret`
+   product has no connector class.
+5. `secret_move` parses both refs, resolves each kind to a
+   `SecretEndpoint` via the registry, `read_secret` from the source
+   (value enters memory only as a `SecretMaterial`), `write_secret` to
+   the sink — entirely server-side. It returns
+   `{status, value_sha256, length}`.
+6. The dispatcher redacts → reduces → audits the return dict. Since the
+   return carries no value, the audit row's `raw_payload` and `payload`
+   carry no value.
+
+## The synthetic identity
+
+`secret-broker-1.x` is the first **synthetic** connector identity in the
+codebase: no vendor connector backs it. The package `__init__` calls
+neither `register_connector` nor `register_connector_v2` (every other
+connector subpackage registers a connector class). It only:
+
+- imports `vault_endpoint` for its module-level
+  `register_secret_endpoint("vault", …)` side effect, and
+- queues `register_secret_broker_operations` onto the lifespan registrar
+  list via `register_typed_op_registrar`.
+
+The lifespan's `_eager_import_connectors` pass imports the
+`connectors/secret/` subpackage (it walks every subpackage), so both
+import-time effects land before `run_typed_op_registrars` runs.
+
+## Change-class posture
+
+The op registers `safety_level="dangerous"` + `requires_approval=True`,
+so the **existing** approval gate parks an unapproved move. This task
+sets the posture and relies on the existing gate; wiring the scoped,
+time-boxed grant (the approval's `expires_at` + an `AgentPermission`
+`op_pattern`) and the ref-only `proposed_effect` shaping is the policy
+task (#1579), not the mechanism.
+
+## Dependencies
+
+- `meho_backplane.operations.typed_register` — `register_typed_operation`
+  (op upsert), `register_typed_op_registrar` (lifespan wiring).
+- `meho_backplane.operations.dispatcher` — the dispatch path, the policy
+  gate, the redact→reduce→audit sequence (value-free for this op).
+- `meho_backplane.operations._lookup.parse_connector_id` — the
+  connector-id round-trip the synthetic identity is built to satisfy.
+- `meho_backplane.auth.vault.vault_client_for_operator` — the
+  operator-scoped Vault client (JWT/OIDC login, token revoked on exit).
+- `meho_backplane.connectors._shared.vault_creds` — `strip_credential_value`
+  + the `data.data` double-unwrap shape, mirrored by the vault adapter.
+
+## Known issues / scope boundaries
+
+- vault-kv is the only adapter kind in this task; further kinds are
+  separate tasks reusing the `SecretEndpoint` contract.
+- The vault adapter forwards the `ref` to hvac's `path=` and defaults the
+  mount to `"secret"`; a non-default mount is a richer-ref-grammar
+  follow-up, not wired here.
+- The `reason` param is recorded for the approver/audit trail but is not
+  read by the handler; surfacing it to the approver is the #1579 task.
+
+## References
+
+- `backend/src/meho_backplane/connectors/secret/endpoints.py`
+- `backend/src/meho_backplane/connectors/secret/vault_endpoint.py`
+- `backend/src/meho_backplane/connectors/secret/ops.py`
+- `backend/src/meho_backplane/connectors/secret/__init__.py`
+- `backend/tests/test_connectors_secret_broker.py`
+- Initiative #581 (G0.22 Secret broker), Goal #221.


### PR DESCRIPTION
## Summary

- Add the secret-broker `secret.move` typed op and the `SecretEndpoint`
  adapter protocol + kind-keyed registry, with the first vault-kv↔vault-kv
  source/sink pair. A move copies one credential field between stores
  **server-side**; the agent submits only declarative `<kind>:<ref>`
  references and never observes the value.
- Establishes the first **synthetic** connector identity in the codebase:
  `secret-broker-1.x` (`product=secret`, `version=1.x`,
  `impl_id=secret-broker`), which round-trips through the dispatcher's
  `parse_connector_id` so the descriptor is reachable. No vendor connector
  backs it; the handler is module-level and dispatches with
  `connector_instance=None` / `target=None`.
- Honors the Initiative's core invariant **by construction**: the value
  never enters the op params, the response, a log event, or the audit row
  — only `status` + value SHA-256 + length. `SecretMaterial` redacts in
  `repr`/`str`; the handler returns hash+length only; the dispatcher
  stores `params_hash` (not params) and the value-free return dict in the
  audit row.
- Change-class posture: `requires_approval=True` + `safety_level=dangerous`
  so the **existing** approval gate parks an unapproved move at
  `awaiting_approval` (the handler never runs).

Clean extension seams left for the sibling tasks (not built here):
`register_secret_endpoint(kind, factory)` for #1578's keycloak sink, the
change-class posture for #1579's approval gating, the dispatch-reachable
op for #1580's CLI verb.

## Test plan

- [x] `uv run ruff check src/ tests/` — clean
- [x] `uv run ruff format --check src/ tests/` — clean
- [x] `uv run mypy src/` — clean (strict; the Protocol + registry type-check)
- [x] `uv run pytest tests/test_connectors_secret_broker.py` — 25 passed
- [x] Full `uv run pytest` sweep — green
- [x] `code-quality.py --diff` — clean
- [x] `secret-broker-1.x` round-trips to `("secret","1.x","secret-broker")` (pytest)
- [x] `SecretMaterial` repr/str omit the value; `value_sha256`/`length` correct (pytest)
- [x] `parse_secret_ref` table incl. missing-colon error case (pytest)
- [x] e2e vault-kv→vault-kv move: sink receives value; response/params/audit
      `payload`+`raw_payload` omit the secret (pytest)
- [x] unapproved move parks; sink write never runs (pytest)

## Out of scope

- Keycloak sink adapter (#1578), approval-queue gating (#1579), CLI verb
  (#1580), docs page (#1581) — separate sibling tasks reusing this contract.
- Backend-only: no new/changed REST route, so the CLI OpenAPI snapshot is
  unaffected.

<!-- auto-implement-issue: fresh, iteration 1 -->

Closes #1577


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added a secure credential movement operation that transfers secrets between storage backends. Secret values never appear in logs, audit records, or operation responses—only metadata (SHA-256 hash and byte length) is exposed. Initial support for Vault KV-v2 storage. Requires approval before execution.

* **Documentation**
  * Added connector documentation describing the credential movement operation's security guarantees and storage adapter details.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->