### PR TITLE
feat(secret): add `meho secret move` references-not-values CLI verb (#1580)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -126,6 +126,19 @@ connector-related release-notes line.
   longer decidable. Reuses the shipped approval substrate — no new
   capability/token system.
 
+### `meho secret move` CLI verb (#1580)
+
+- Add the operator-facing `meho secret move --from <kind>:<ref> --to
+  <kind>:<ref> --reason …` verb over the `secret-broker-1.x` connector
+  (#1577). It is references-not-values: only the `<kind>:<ref>` source /
+  sink references and the audit reason cross the wire — the secret value
+  is never a flag, argument, or prompt, so it never lands in argv, shell
+  history, or the op params. The change-class move requires approval, so
+  the verb surfaces `status=awaiting_approval` verbatim (rendered, not
+  treated as an error) and otherwise prints only the move status, the
+  value SHA-256, and its byte length. Reuses the generic
+  `/api/v1/operations/call` route, so the OpenAPI snapshot is unchanged.
+
 ### Retire the stale `meho targets create` verb tree-wide (#1559)
 
 - Remove the last references to the nonexistent `meho targets create`

--- a/cli/internal/cmd/root.go
+++ b/cli/internal/cmd/root.go
@@ -41,6 +41,7 @@ import (
 	"github.com/evoila/meho/cli/internal/cmd/runbook"
 	"github.com/evoila/meho/cli/internal/cmd/scheduler"
 	sddcmanager "github.com/evoila/meho/cli/internal/cmd/sddc-manager"
+	"github.com/evoila/meho/cli/internal/cmd/secret"
 	"github.com/evoila/meho/cli/internal/cmd/targets"
 	"github.com/evoila/meho/cli/internal/cmd/topology"
 	"github.com/evoila/meho/cli/internal/cmd/vault"
@@ -430,6 +431,17 @@ func newRootCmd() *cobra.Command {
 	// before registerDynamicSubcommands so the backplane manifest cannot
 	// shadow the built-in `keycloak` parent.
 	root.AddCommand(keycloak.NewRootCmd())
+
+	// G0.22-T4 (#1580) -- secret-broker-1.x operator alias verb for
+	// Initiative #581. `meho secret move` pre-bakes connector_id=
+	// "secret-broker-1.x" on top of the existing /api/v1/operations/call
+	// dispatcher route and dispatches the synthetic secret.move broker op
+	// (#1577). The move is references-not-values: the operator names
+	// --from / --to '<kind>:<ref>' references and a --reason; the value is
+	// read, transferred, and re-written entirely server-side and never
+	// crosses the command line or the op params. The verb is change-class
+	// (requires approval) and surfaces status=awaiting_approval verbatim.
+	root.AddCommand(secret.NewRootCmd())
 
 	// G3.12-T3 (#1392) -- argocd-api-3.x operator alias verbs for
 	// Initiative #1387. The verb tree pre-bakes connector_id=

--- a/cli/internal/cmd/secret/move.go
+++ b/cli/internal/cmd/secret/move.go
@@ -1,0 +1,195 @@
+// SPDX-License-Identifier: Apache-2.0
+// Copyright (c) 2026 evoila Group
+
+package secret
+
+import (
+	"encoding/json"
+	"fmt"
+	"io"
+
+	"github.com/spf13/cobra"
+
+	"github.com/evoila/meho/cli/internal/dispatch"
+	"github.com/evoila/meho/cli/internal/output"
+)
+
+// opMove is the canonical op_id `meho secret move` dispatches.
+const opMove = "secret.move"
+
+// statusAwaitingApproval is the change-class park status the policy gate
+// returns for an unapproved move. The shared dispatch.Render rejects any
+// status outside ok/error/denied as an exit-4 "invalid OperationResult
+// status", so this verb intercepts awaiting_approval BEFORE delegating to
+// conn.Render (option (b) of #1580 — a package-local render path, leaving
+// the shared status enum and every other vendor verb untouched).
+const statusAwaitingApproval = "awaiting_approval"
+
+// newMoveCmd returns the `meho secret move` command (secret.move —
+// change-class, approval-gated). It dispatches secret.move with the
+// source/sink references and the audit reason as opaque params; the
+// secret value is never passed inline.
+func newMoveCmd() *cobra.Command {
+	var (
+		from      string
+		to        string
+		reason    string
+		jsonOut   bool
+		backplane string
+	)
+	cmd := &cobra.Command{
+		Use:   "move",
+		Short: "Move a credential between stores server-side (references only, approval-gated)",
+		Long: "move dispatches secret.move: the backplane reads the credential\n" +
+			"named by --from, transfers it, and re-writes it to --to entirely\n" +
+			"server-side. --from and --to are '<kind>:<ref>' references (e.g.\n" +
+			"'vault:secret/db/prod#password'); 'kind' selects the store adapter\n" +
+			"and 'ref' is the store-specific address. --reason is recorded for\n" +
+			"the approver and the audit trail.\n\n" +
+			"References, not values: there is NO inline-secret flag of any kind.\n" +
+			"The value is never passed on the command line, so it never lands in\n" +
+			"shell history, ps output, or the op params. The response returns\n" +
+			"only the move status, the value's SHA-256, and its byte length —\n" +
+			"never the value.\n\n" +
+			"Change-class: the move requires approval. An unapproved dispatch\n" +
+			"returns status=awaiting_approval (parked for a human to approve\n" +
+			"through the approval queue); re-dispatch after approval.\n\n" +
+			"Exit codes: 0=ok/awaiting_approval, 1=error/denied,\n" +
+			"2=auth_expired, 3=unreachable, 4=unexpected.",
+		Example: "  meho secret move --from vault:secret/db/prod#password " +
+			"--to vault:secret/db/standby#password --reason 'provision standby DB'",
+		Args:          cobra.NoArgs,
+		SilenceUsage:  true,
+		SilenceErrors: true,
+		RunE: func(cmd *cobra.Command, _ []string) error {
+			return runMove(cmd, from, to, reason, jsonOut, backplane)
+		},
+	}
+	// References-not-values: --from / --to carry only opaque '<kind>:<ref>'
+	// strings, --reason an audit justification. There is deliberately NO
+	// --value / --secret / --password flag.
+	cmd.Flags().StringVar(&from, "from", "",
+		"source '<kind>:<ref>' reference the credential is read from (required)")
+	cmd.Flags().StringVar(&to, "to", "",
+		"sink '<kind>:<ref>' reference the credential is written to (required)")
+	cmd.Flags().StringVar(&reason, "reason", "",
+		"justification recorded for the approver and the audit trail (required)")
+	cmd.Flags().BoolVar(&jsonOut, "json", false,
+		"emit the full OperationResult envelope as JSON")
+	cmd.Flags().StringVar(&backplane, "backplane", "",
+		"backplane URL (defaults to the URL from the most recent `meho login`)")
+	for _, name := range []string{"from", "to", "reason"} {
+		if err := cmd.MarkFlagRequired(name); err != nil {
+			panic(err) // programmer error: the flag is defined directly above
+		}
+	}
+	return cmd
+}
+
+// runMove resolves the backplane, dispatches secret.move with the
+// reference/reason params, and renders the value-free result.
+func runMove(
+	cmd *cobra.Command,
+	from, to, reason string,
+	jsonOut bool,
+	backplaneOverride string,
+) error {
+	backplaneURL, err := resolveBackplane(backplaneOverride)
+	if err != nil {
+		return output.RenderError(cmd.ErrOrStderr(), classifyBackplaneError(err), jsonOut)
+	}
+	// Only references and the reason ever cross the wire — never a value.
+	params := map[string]any{
+		"from":   from,
+		"to":     to,
+		"reason": reason,
+	}
+	r, err := conn.Call(cmd.Context(), backplaneURL, opMove, "", params)
+	if err != nil {
+		return renderRequestError(cmd, backplaneURL, err, jsonOut)
+	}
+	return renderMoveResult(cmd, r, jsonOut)
+}
+
+// renderMoveResult surfaces the secret.move result. awaiting_approval is
+// handled package-locally (the shared conn.Render would exit-4 it as an
+// invalid status); every other status delegates to conn.Render so the
+// ok→exit-0 / error|denied→exit-1 classification and the JSON envelope
+// path are reused unchanged.
+func renderMoveResult(cmd *cobra.Command, r *dispatch.CallResult, jsonOut bool) error {
+	if r.Status == statusAwaitingApproval {
+		if jsonOut {
+			return output.PrintJSON(cmd.OutOrStdout(), r)
+		}
+		printMoveResult(cmd.OutOrStdout(), r)
+		return nil // parked, not failed — exit 0.
+	}
+	return conn.Render(cmd, opMove, r, jsonOut, printMoveResult)
+}
+
+// printMoveResult renders the value-free move confirmation: the op header
+// then, on success, only the move status / value SHA-256 / byte length.
+// It never renders a secret value because the response never carries one.
+func printMoveResult(w io.Writer, r *dispatch.CallResult) {
+	fmt.Fprintf(w, "%s %s — status=%s (%.0fms)\n", ConnectorID, opMove, r.Status, r.DurationMs)
+	if r.Status == statusAwaitingApproval {
+		fmt.Fprintln(w, "  parked for human approval — approve via the approval queue, then re-dispatch")
+		return
+	}
+	if r.Status != "ok" {
+		printErrorTrailer(w, r)
+		return
+	}
+	obj, err := decodeMoveResult(r.Result)
+	if err != nil || obj == nil {
+		// Fall back to the raw result envelope (still value-free — the op
+		// response schema carries only status / value_sha256 / length).
+		if len(r.Result) > 0 && string(r.Result) != "null" {
+			if pretty, perr := dispatch.PrettyJSON(r.Result); perr == nil {
+				fmt.Fprintln(w, pretty)
+			}
+		}
+		return
+	}
+	for _, key := range moveResultKeyOrder {
+		if v, ok := obj[key]; ok && v != nil {
+			fmt.Fprintf(w, "  %-13s %v\n", key+":", v)
+		}
+	}
+}
+
+// moveResultKeyOrder pins a stable render order for the move
+// confirmation's scalar fields so the output is diff-stable. These are
+// the only fields secret.move returns; none carries the value.
+var moveResultKeyOrder = []string{"status", "value_sha256", "length"}
+
+// decodeMoveResult decodes the move confirmation envelope — a flat JSON
+// object of scalar fields ({status, value_sha256, length}) — into a map.
+func decodeMoveResult(raw json.RawMessage) (map[string]any, error) {
+	if len(raw) == 0 || string(raw) == "null" {
+		return nil, nil
+	}
+	var obj map[string]any
+	if err := json.Unmarshal(raw, &obj); err != nil {
+		return nil, fmt.Errorf("decode move result: %w", err)
+	}
+	return obj, nil
+}
+
+// printErrorTrailer surfaces the dispatcher error + extras envelope on the
+// non-ok branch. Mirrors the keycloak sibling helper.
+func printErrorTrailer(w io.Writer, r *dispatch.CallResult) {
+	if r.Error != nil && *r.Error != "" {
+		fmt.Fprintf(w, "meho: connector error: %s\n", *r.Error)
+	} else {
+		fmt.Fprintf(w, "meho: connector status=%s\n", r.Status)
+	}
+	if len(r.Extras) > 0 && string(r.Extras) != "null" {
+		fmt.Fprintln(w, "extras:")
+		if pretty, err := dispatch.PrettyJSON(r.Extras); err == nil {
+			fmt.Fprintln(w, pretty)
+		} else {
+			fmt.Fprintln(w, string(r.Extras))
+		}
+	}
+}

--- a/cli/internal/cmd/secret/secret.go
+++ b/cli/internal/cmd/secret/secret.go
@@ -1,0 +1,194 @@
+// SPDX-License-Identifier: Apache-2.0
+// Copyright (c) 2026 evoila Group
+
+// Package secret hosts the cobra commands under `meho secret ...` for
+// G0.22-T4 (#1580) of Initiative #581 (the secret broker). The verb
+// tree is a thin Cobra layer over `POST /api/v1/operations/call`,
+// pre-baking the synthetic broker connector_id so operators don't type
+// it on every dispatch:
+//
+//   - `meho secret move --from <kind>:<ref> --to <kind>:<ref> --reason R`
+//     → secret.move
+//
+// The move is references-not-values: the operator names a `--from` and a
+// `--to` `<kind>:<ref>` reference and a `--reason`; the backplane reads
+// the credential, transfers it, and re-writes it entirely server-side.
+// The secret value is never a CLI argument, flag, env var, or prompt —
+// it never lands in argv, shell history, ps output, or the op params.
+// The response carries only the move status, the value's SHA-256, and
+// its byte length, which is all this verb renders.
+//
+// `secret.move` is change-class (requires_approval=True +
+// safety_level="dangerous"), so a dispatch parks at
+// status=awaiting_approval until a human approves through the queue
+// (G11.7-T1 #1401); the verb surfaces that status verbatim rather than
+// treating it as an error (see move.go's renderMoveResult).
+//
+// Per CLAUDE.md postulate 5 this alias verb is operator-only — it is not
+// mirrored on the MCP surface. Agents reach `secret.move` through the
+// narrow-waist search_operations / call_operation meta-tools.
+package secret
+
+import (
+	"errors"
+	"fmt"
+	"net/url"
+	"strings"
+
+	"github.com/spf13/cobra"
+
+	"github.com/evoila/meho/cli/internal/api"
+	"github.com/evoila/meho/cli/internal/auth"
+	"github.com/evoila/meho/cli/internal/dispatch"
+	"github.com/evoila/meho/cli/internal/output"
+)
+
+// ConnectorID is the pre-baked connector_id `meho secret move` dispatches
+// against. It encodes the synthetic broker's registry-v2 natural key
+// triple `(product="secret", version="1.x", impl_id="secret-broker")` per
+// the connector_id parser convention in
+// `backend/src/meho_backplane/operations/_lookup.py::parse_connector_id`:
+// the trailing `-1.x` segment is the version (digit-led, as the parser
+// requires); everything before is the impl_id (`secret-broker`); the
+// product is the first hyphen segment of the impl_id (`secret`). T1
+// (#1577) registers this exact triple, so `secret-broker-1.x`
+// round-trips through parse_connector_id back to
+// `("secret", "1.x", "secret-broker")`.
+const ConnectorID = "secret-broker-1.x"
+
+// conn binds this package's pre-baked connector_id to the shared
+// dispatch core (cli/internal/dispatch), mirroring the keycloak / vault
+// verb trees.
+var conn = dispatch.New(ConnectorID)
+
+// NewRootCmd returns the `meho secret` parent command. cmd/root.go grafts
+// this onto the top-level command tree alongside the other built-in verb
+// trees. The parent itself takes no args and prints its own help; the
+// behaviour lives in the `move` sub-command's RunE closure.
+func NewRootCmd() *cobra.Command {
+	cmd := &cobra.Command{
+		Use:   "secret",
+		Short: "Secret-broker verbs for the secret-broker-1.x connector",
+		Long: "secret is the operator-facing verb tree for the synthetic\n" +
+			"secret-broker-1.x connector (registry triple\n" +
+			"(product=\"secret\", version=\"1.x\", impl_id=\"secret-broker\")).\n" +
+			"It dispatches through POST /api/v1/operations/call with\n" +
+			"connector_id=\"secret-broker-1.x\" pre-baked.\n\n" +
+			"The single verb today is `move`, which copies a credential from\n" +
+			"one store to another server-side. The move is\n" +
+			"references-not-values: you name a --from and --to '<kind>:<ref>'\n" +
+			"reference and a --reason; the backplane reads, transfers, and\n" +
+			"re-writes the material. The secret value is NEVER passed on the\n" +
+			"command line, so it never lands in shell history, ps output, or\n" +
+			"the op params; the response returns only the move status, the\n" +
+			"value's SHA-256, and its byte length.\n\n" +
+			"move is change-class (it requires approval): an unapproved\n" +
+			"dispatch parks at status=awaiting_approval until a human approves\n" +
+			"through the approval queue.\n\n" +
+			"Per CLAUDE.md postulate 5 these alias verbs are operator-only —\n" +
+			"agents reach secret.move via search_operations / call_operation.",
+		SilenceUsage: true,
+	}
+	cmd.AddCommand(newMoveCmd())
+	return cmd
+}
+
+// errNoBackplaneConfigured wraps auth.ErrConfigNotFound so callers can
+// distinguish "operator never logged in" (→ auth_expired exit code 2 —
+// the right fix is `meho login`) from URL-parse failures (→ unexpected
+// exit code 4 — the right fix is correcting argv). Mirrors the keycloak /
+// vault sibling helper (the cmd/* packages can't import one another
+// without an import cycle, so the helper is duplicated per dir).
+type errNoBackplaneConfigured struct{ inner error }
+
+func (e *errNoBackplaneConfigured) Error() string {
+	return "no backplane URL configured; run `meho login <url>` first or pass --backplane <url>"
+}
+func (e *errNoBackplaneConfigured) Unwrap() error { return e.inner }
+
+// resolveBackplane mirrors the keycloak / vault sibling helpers:
+// --backplane override flag wins; otherwise read the URL the most recent
+// `meho login` wrote to config.json.
+func resolveBackplane(override string) (string, error) {
+	if override != "" {
+		return normaliseURL(override)
+	}
+	cfg, err := auth.LoadConfig()
+	if err != nil {
+		if errors.Is(err, auth.ErrConfigNotFound) {
+			return "", &errNoBackplaneConfigured{inner: err}
+		}
+		return "", err
+	}
+	return normaliseURL(cfg.BackplaneURL)
+}
+
+// classifyBackplaneError maps a resolveBackplane error to the right
+// output.StructuredError category: missing-config → auth_expired;
+// everything else → unexpected.
+func classifyBackplaneError(err error) *output.StructuredError {
+	if errors.Is(err, auth.ErrConfigNotFound) {
+		return output.AuthExpired(err.Error())
+	}
+	return output.Unexpected(err.Error())
+}
+
+// normaliseURL strips trailing slashes + parses the URL to fail fast on
+// garbage input. Mirrors the keycloak / vault siblings.
+func normaliseURL(s string) (string, error) {
+	trimmed := strings.TrimRight(strings.TrimSpace(s), "/")
+	if trimmed == "" {
+		return "", errors.New("backplane URL is empty")
+	}
+	u, err := url.ParseRequestURI(trimmed)
+	if err != nil {
+		return "", fmt.Errorf("invalid backplane URL %q: %w", s, err)
+	}
+	if u.Host == "" {
+		return "", fmt.Errorf("backplane URL %q has no host", s)
+	}
+	u.Path = strings.TrimRight(u.Path, "/")
+	return u.String(), nil
+}
+
+// renderRequestError translates an error from the dispatch core into the
+// right output.RenderError category: token-not-found / no-refresh-token →
+// auth_expired; HTTP-error → unexpected; transport → unreachable. Same
+// classification ladder as the keycloak / vault siblings.
+func renderRequestError(
+	cmd *cobra.Command,
+	backplaneURL string,
+	err error,
+	jsonOut bool,
+) error {
+	if api.IsTokenNotFound(err) {
+		return output.RenderError(cmd.ErrOrStderr(),
+			output.AuthExpired(fmt.Sprintf(
+				"no stored credentials for %s; run `meho login %s`",
+				backplaneURL, backplaneURL,
+			)),
+			jsonOut,
+		)
+	}
+	if api.IsNoRefreshToken(err) {
+		return output.RenderError(cmd.ErrOrStderr(),
+			output.AuthExpired(fmt.Sprintf(
+				"stored token rejected and no refresh_token present; run `meho login %s`",
+				backplaneURL,
+			)),
+			jsonOut,
+		)
+	}
+	var apiErr *dispatch.APIResponseError
+	if errors.As(err, &apiErr) {
+		return output.RenderError(cmd.ErrOrStderr(),
+			output.Unexpected(fmt.Sprintf("call %s: HTTP %d: %s",
+				backplaneURL, apiErr.StatusCode, apiErr.Body)),
+			jsonOut,
+		)
+	}
+	return output.RenderError(cmd.ErrOrStderr(),
+		output.Unreachable(fmt.Sprintf("call %s: %v", backplaneURL, err)),
+		jsonOut,
+	)
+}

--- a/cli/internal/cmd/secret/secret_test.go
+++ b/cli/internal/cmd/secret/secret_test.go
@@ -141,11 +141,11 @@ func TestMoveHelpListsFlags(t *testing.T) {
 // security invariant of #1580 (mirrors keycloak's
 // TestUserCreatePassesSecretRefNotPassword).
 func TestSecretMovePassesRefsNotValues(t *testing.T) {
-	var captured map[string]any
+	var body callRequestBody
 	srv := mockBackplane(t, map[string]mockHandler{
 		"POST /api/v1/operations/call": func(w http.ResponseWriter, r *http.Request) {
-			if err := json.NewDecoder(r.Body).Decode(&captured); err != nil {
-				t.Errorf("decode: %v", err)
+			if err := json.NewDecoder(r.Body).Decode(&body); err != nil {
+				t.Errorf("decode body: %v", err)
 				w.WriteHeader(400)
 				return
 			}
@@ -171,15 +171,20 @@ func TestSecretMovePassesRefsNotValues(t *testing.T) {
 		t.Fatalf("execute: %v", err)
 	}
 
-	if captured["connector_id"] != "secret-broker-1.x" {
-		t.Errorf("connector_id: got %v want secret-broker-1.x", captured["connector_id"])
+	if body.ConnectorID != "secret-broker-1.x" {
+		t.Errorf("connector_id: got %q want secret-broker-1.x", body.ConnectorID)
 	}
-	if captured["op_id"] != opMove {
-		t.Errorf("op_id: got %v want %s", captured["op_id"], opMove)
+	if body.OpID != opMove {
+		t.Errorf("op_id: got %q want %s", body.OpID, opMove)
 	}
-	params, _ := captured["params"].(map[string]any)
+	// The broker op acts on no target — only the source/sink refs and the
+	// reason carry it. A non-nil target would signal a wire-shape drift.
+	if body.Target != nil {
+		t.Errorf("target should be nil for the broker op; got %v", body.Target)
+	}
+	params := body.Params
 	if params == nil {
-		t.Fatalf("no params captured: %v", captured)
+		t.Fatalf("no params captured: %+v", body)
 	}
 	if params["from"] != "vault:secret/db/prod#password" {
 		t.Errorf("from not forwarded: %v", params["from"])
@@ -196,7 +201,7 @@ func TestSecretMovePassesRefsNotValues(t *testing.T) {
 			t.Errorf("params must NEVER carry an inline %q field; got %v", leaked, params)
 		}
 	}
-	blob, _ := json.Marshal(captured)
+	blob, _ := json.Marshal(body)
 	for _, leaked := range []string{`"value"`, `"secret"`, `"password"`} {
 		if strings.Contains(string(blob), leaked) {
 			t.Errorf("request body carries an inline %s field: %s", leaked, blob)

--- a/cli/internal/cmd/secret/secret_test.go
+++ b/cli/internal/cmd/secret/secret_test.go
@@ -1,0 +1,329 @@
+// SPDX-License-Identifier: Apache-2.0
+// Copyright (c) 2026 evoila Group
+
+package secret
+
+import (
+	"bytes"
+	"encoding/json"
+	"net/http"
+	"net/http/httptest"
+	"os"
+	"path/filepath"
+	"strings"
+	"testing"
+
+	"github.com/evoila/meho/cli/internal/auth"
+	"github.com/evoila/meho/cli/internal/dispatch"
+)
+
+// callRequestBody mirrors the on-the-wire OperationCall body so the
+// wire-shape tests can decode and assert it.
+type callRequestBody = dispatch.CallRequestBody
+
+// cobraRequiredAnnotation is the pflag annotation key cobra sets via
+// MarkFlagRequired. Pinned here so the required-flag tests don't import
+// cobra internals.
+const cobraRequiredAnnotation = "cobra_annotation_bash_completion_one_required_flag"
+
+// ---------- mock backplane harness (mirrors cmd/keycloak) ----------
+
+type mockHandler = http.HandlerFunc
+
+func mockBackplane(t *testing.T, routes map[string]mockHandler) *httptest.Server {
+	t.Helper()
+	return httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		key := r.Method + " " + r.URL.Path
+		if h, ok := routes[key]; ok {
+			h(w, r)
+			return
+		}
+		if h, ok := routes[""]; ok {
+			h(w, r)
+			return
+		}
+		t.Errorf("mockBackplane: unhandled route %s", key)
+		w.WriteHeader(404)
+	}))
+}
+
+func writeJSON(t *testing.T, w http.ResponseWriter, status int, body any) {
+	t.Helper()
+	raw, err := json.Marshal(body)
+	if err != nil {
+		t.Errorf("writeJSON marshal: %v", err)
+		w.WriteHeader(500)
+		return
+	}
+	w.Header().Set("Content-Type", "application/json")
+	w.WriteHeader(status)
+	if _, err := w.Write(raw); err != nil {
+		t.Errorf("writeJSON write: %v", err)
+	}
+}
+
+func primeToken(t *testing.T, backplaneURL string) {
+	t.Helper()
+	dir := t.TempDir()
+	t.Setenv("XDG_CONFIG_HOME", dir)
+	cfg := filepath.Join(dir, "meho", "config.json")
+	if err := os.MkdirAll(filepath.Dir(cfg), 0o700); err != nil {
+		t.Fatalf("mkdir config: %v", err)
+	}
+	cfgBlob, _ := json.Marshal(map[string]string{"backplane_url": backplaneURL})
+	if err := os.WriteFile(cfg, cfgBlob, 0o600); err != nil {
+		t.Fatalf("write config: %v", err)
+	}
+	service, user := auth.KeyForBackplane(backplaneURL)
+	store, err := auth.NewTokenStore()
+	if err != nil {
+		t.Fatalf("NewTokenStore: %v", err)
+	}
+	if err := store.Save(service, user, auth.StoredToken{
+		AccessToken:  "test-bearer",
+		BackplaneURL: backplaneURL,
+	}); err != nil {
+		t.Fatalf("store.Save: %v", err)
+	}
+}
+
+// ---------- connector_id is the synthetic broker triple ----------
+
+// TestConnectorIDIsFrozen pins the pre-baked connector_id. It must match
+// T1's (#1577) registered synthetic triple
+// `(product="secret", version="1.x", impl_id="secret-broker")`, whose
+// wire form `secret-broker-1.x` round-trips through parse_connector_id.
+func TestConnectorIDIsFrozen(t *testing.T) {
+	if ConnectorID != "secret-broker-1.x" {
+		t.Fatalf("ConnectorID drifted: got %q want %q", ConnectorID, "secret-broker-1.x")
+	}
+}
+
+// ---------- command-tree shape ----------
+
+// TestNewRootCmdHasMove — the root command must expose the `move` verb so
+// `meho secret --help` lists it.
+func TestNewRootCmdHasMove(t *testing.T) {
+	root := NewRootCmd()
+	got := map[string]bool{}
+	for _, sub := range root.Commands() {
+		got[sub.Name()] = true
+	}
+	if !got["move"] {
+		t.Errorf("secret root is missing the move sub-verb; has %v", got)
+	}
+}
+
+// TestMoveHelpListsFlags — `meho secret move --help` must surface
+// --from / --to / --reason (acceptance criterion (c)).
+func TestMoveHelpListsFlags(t *testing.T) {
+	cmd := newMoveCmd()
+	var buf bytes.Buffer
+	cmd.SetOut(&buf)
+	cmd.SetErr(&buf)
+	cmd.SetArgs([]string{"--help"})
+	if err := cmd.Execute(); err != nil {
+		t.Fatalf("--help execute: %v", err)
+	}
+	out := buf.String()
+	for _, want := range []string{"--from", "--to", "--reason"} {
+		if !strings.Contains(out, want) {
+			t.Errorf("move --help output missing %q\n%s", want, out)
+		}
+	}
+}
+
+// ---------- params contract + references-not-values invariant ----------
+
+// TestSecretMovePassesRefsNotValues — the move verb must forward
+// from / to / reason as opaque references AND must never carry an inline
+// secret value anywhere in the request body. This is the load-bearing
+// security invariant of #1580 (mirrors keycloak's
+// TestUserCreatePassesSecretRefNotPassword).
+func TestSecretMovePassesRefsNotValues(t *testing.T) {
+	var captured map[string]any
+	srv := mockBackplane(t, map[string]mockHandler{
+		"POST /api/v1/operations/call": func(w http.ResponseWriter, r *http.Request) {
+			if err := json.NewDecoder(r.Body).Decode(&captured); err != nil {
+				t.Errorf("decode: %v", err)
+				w.WriteHeader(400)
+				return
+			}
+			writeJSON(t, w, 200, dispatch.CallResult{
+				Status: "ok", OpID: opMove,
+				Result: json.RawMessage(`{"status":"moved","value_sha256":"abc123","length":24}`),
+			})
+		},
+	})
+	defer srv.Close()
+	primeToken(t, srv.URL)
+
+	cmd := newMoveCmd()
+	cmd.SetOut(&bytes.Buffer{})
+	cmd.SetErr(&bytes.Buffer{})
+	cmd.SetArgs([]string{
+		"--from", "vault:secret/db/prod#password",
+		"--to", "vault:secret/db/standby#password",
+		"--reason", "provision standby DB",
+		"--backplane", srv.URL,
+	})
+	if err := cmd.Execute(); err != nil {
+		t.Fatalf("execute: %v", err)
+	}
+
+	if captured["connector_id"] != "secret-broker-1.x" {
+		t.Errorf("connector_id: got %v want secret-broker-1.x", captured["connector_id"])
+	}
+	if captured["op_id"] != opMove {
+		t.Errorf("op_id: got %v want %s", captured["op_id"], opMove)
+	}
+	params, _ := captured["params"].(map[string]any)
+	if params == nil {
+		t.Fatalf("no params captured: %v", captured)
+	}
+	if params["from"] != "vault:secret/db/prod#password" {
+		t.Errorf("from not forwarded: %v", params["from"])
+	}
+	if params["to"] != "vault:secret/db/standby#password" {
+		t.Errorf("to not forwarded: %v", params["to"])
+	}
+	if params["reason"] != "provision standby DB" {
+		t.Errorf("reason not forwarded: %v", params["reason"])
+	}
+	// References-not-values: no inline-secret field may reach the wire.
+	for _, leaked := range []string{"value", "secret", "password"} {
+		if _, ok := params[leaked]; ok {
+			t.Errorf("params must NEVER carry an inline %q field; got %v", leaked, params)
+		}
+	}
+	blob, _ := json.Marshal(captured)
+	for _, leaked := range []string{`"value"`, `"secret"`, `"password"`} {
+		if strings.Contains(string(blob), leaked) {
+			t.Errorf("request body carries an inline %s field: %s", leaked, blob)
+		}
+	}
+}
+
+// TestSecretMoveRequiresRefsAndReason — --from / --to / --reason are
+// required, and the command exposes NO flag whose name implies a literal
+// secret value (mirrors keycloak's TestUserResetPasswordRequiresSecretRef).
+func TestSecretMoveRequiresRefsAndReason(t *testing.T) {
+	cmd := newMoveCmd()
+	for _, name := range []string{"from", "to", "reason"} {
+		flag := cmd.Flags().Lookup(name)
+		if flag == nil {
+			t.Fatalf("move is missing the --%s flag", name)
+		}
+		if ann := flag.Annotations[cobraRequiredAnnotation]; len(ann) == 0 || ann[0] != "true" {
+			t.Errorf("--%s should be marked required; annotations=%v", name, flag.Annotations)
+		}
+	}
+	for _, banned := range []string{"value", "secret", "password"} {
+		if cmd.Flags().Lookup(banned) != nil {
+			t.Errorf("move must NOT expose an inline --%s flag", banned)
+		}
+	}
+}
+
+// TestSecretMoveRendersValueFreeResult — a successful move renders only
+// the status / value SHA-256 / length, never a value (which the response
+// never carries anyway).
+func TestSecretMoveRendersValueFreeResult(t *testing.T) {
+	srv := mockBackplane(t, map[string]mockHandler{
+		"POST /api/v1/operations/call": func(w http.ResponseWriter, r *http.Request) {
+			writeJSON(t, w, 200, dispatch.CallResult{
+				Status: "ok", OpID: opMove, DurationMs: 12,
+				Result: json.RawMessage(`{"status":"moved","value_sha256":"deadbeef","length":24}`),
+			})
+		},
+	})
+	defer srv.Close()
+	primeToken(t, srv.URL)
+
+	cmd := newMoveCmd()
+	var out bytes.Buffer
+	cmd.SetOut(&out)
+	cmd.SetErr(&bytes.Buffer{})
+	cmd.SetArgs([]string{
+		"--from", "vault:a#k", "--to", "vault:b#k", "--reason", "r",
+		"--backplane", srv.URL,
+	})
+	if err := cmd.Execute(); err != nil {
+		t.Fatalf("execute: %v", err)
+	}
+	got := out.String()
+	for _, want := range []string{"deadbeef", "24", "moved"} {
+		if !strings.Contains(got, want) {
+			t.Errorf("rendered output missing %q\n%s", want, got)
+		}
+	}
+}
+
+// TestSecretMoveAwaitingApproval — secret.move is requires_approval=True,
+// so an unapproved dispatch returns status=awaiting_approval. The verb
+// must render it (NOT classify it as an exit-4 invalid status, which the
+// shared dispatch.Render would do) and exit 0 (parked, not failed).
+func TestSecretMoveAwaitingApproval(t *testing.T) {
+	srv := mockBackplane(t, map[string]mockHandler{
+		"POST /api/v1/operations/call": func(w http.ResponseWriter, r *http.Request) {
+			writeJSON(t, w, 200, dispatch.CallResult{
+				Status: statusAwaitingApproval, OpID: opMove, DurationMs: 3,
+			})
+		},
+	})
+	defer srv.Close()
+	primeToken(t, srv.URL)
+
+	cmd := newMoveCmd()
+	var out bytes.Buffer
+	var errBuf bytes.Buffer
+	cmd.SetOut(&out)
+	cmd.SetErr(&errBuf)
+	cmd.SetArgs([]string{
+		"--from", "vault:a#k", "--to", "vault:b#k", "--reason", "r",
+		"--backplane", srv.URL,
+	})
+	if err := cmd.Execute(); err != nil {
+		t.Fatalf("awaiting_approval must not be an error (parked, exit 0); got %v", err)
+	}
+	got := out.String()
+	if !strings.Contains(got, statusAwaitingApproval) {
+		t.Errorf("output should surface awaiting_approval verbatim\n%s", got)
+	}
+	if strings.Contains(errBuf.String(), "invalid OperationResult") {
+		t.Errorf("awaiting_approval was wrongly rejected as an invalid status: %s", errBuf.String())
+	}
+}
+
+// TestSecretMoveAwaitingApprovalJSON — with --json the awaiting_approval
+// envelope round-trips as the full OperationResult JSON.
+func TestSecretMoveAwaitingApprovalJSON(t *testing.T) {
+	srv := mockBackplane(t, map[string]mockHandler{
+		"POST /api/v1/operations/call": func(w http.ResponseWriter, r *http.Request) {
+			writeJSON(t, w, 200, dispatch.CallResult{
+				Status: statusAwaitingApproval, OpID: opMove,
+			})
+		},
+	})
+	defer srv.Close()
+	primeToken(t, srv.URL)
+
+	cmd := newMoveCmd()
+	var out bytes.Buffer
+	cmd.SetOut(&out)
+	cmd.SetErr(&bytes.Buffer{})
+	cmd.SetArgs([]string{
+		"--from", "vault:a#k", "--to", "vault:b#k", "--reason", "r",
+		"--json", "--backplane", srv.URL,
+	})
+	if err := cmd.Execute(); err != nil {
+		t.Fatalf("execute: %v", err)
+	}
+	var decoded map[string]any
+	if err := json.Unmarshal(out.Bytes(), &decoded); err != nil {
+		t.Fatalf("--json output is not valid JSON: %v\n%s", err, out.String())
+	}
+	if decoded["status"] != statusAwaitingApproval {
+		t.Errorf("json envelope status: got %v want %s", decoded["status"], statusAwaitingApproval)
+	}
+}


### PR DESCRIPTION
## Summary

- Add the operator-facing `meho secret move --from <kind>:<ref> --to <kind>:<ref> --reason …` verb over the synthetic `secret-broker-1.x` connector shipped by #1577. Thin Cobra layer over `POST /api/v1/operations/call` that pre-bakes the connector_id and dispatches op_id `secret.move`.
- **References-not-values (the load-bearing invariant):** `--from` / `--to` carry only opaque `<kind>:<ref>` strings, `--reason` an audit justification. There is deliberately NO `--value` / `--secret` / `--password` flag, so the secret value never enters argv, shell history, ps output, or the op params. The backplane reads/transfers/re-writes server-side and returns only the move status, the value's SHA-256, and its byte length — the only fields the verb renders.
- **`awaiting_approval` handling:** `secret.move` is change-class (`requires_approval=True`). The shared `dispatch.Render` rejects any status outside `ok`/`error`/`denied` as an exit-4 invalid status, so the verb intercepts `awaiting_approval` in a **package-local render path** (option **(b)** of the issue) and renders it verbatim as a parked, exit-0 outcome — leaving the shared status enum and every other vendor verb untouched. `ok`/`error`/`denied` delegate to `dispatch.Render`, reusing the exit-code classification and `--json` envelope path unchanged.

### Connector-id verification

T1 (#1577) registers `(product="secret", version="1.x", impl_id="secret-broker")`. The wire `connector_id` bound here is **`secret-broker-1.x`**, which round-trips through `parse_connector_id` back to `("secret", "1.x", "secret-broker")` (version is digit-led `1.x`; product is the impl_id's first hyphen segment). Confirmed against the merged T1 registration in `backend/src/meho_backplane/connectors/secret/ops.py`. Param keys (`from` / `to` / `reason`) match T1's `SECRET_MOVE_PARAMETER_SCHEMA`.

### OpenAPI snapshot

The generic `operations/call` route is reused **unchanged** — #1577 added no dedicated REST route. `make -C cli snapshot-openapi && make -C cli generate` leaves `cli/api/openapi.json` and `cli/internal/api/client.gen.go` **byte-identical** (verified by md5 + clean `git status`). The "CLI API snapshot freshness" check therefore passes with no regen artifacts in the diff. **Acceptance (g): no-route-change case applies.**

## Test plan

- [x] `make -C cli build` — green.
- [x] `go test -race ./...` (CLI) — all 44 packages pass, zero FAIL/panic. (`make -C cli test` itself exits non-zero only on a sandbox toolchain quirk — the auto-fetched go SDK is missing the `covdata` coverage-merge tool; the test run itself is green and CI's pinned toolchain runs it cleanly.)
- [x] `meho secret move --help` (via `go run ./cmd/meho`) exits 0 and lists `--from`, `--to`, `--reason`.
- [x] `go test ./internal/cmd/secret/... -run 'TestSecretMove' -race` — passes (params contract: `from`/`to`/`reason` forwarded; no `value`/`secret`/`password` key or literal anywhere in the request body).
- [x] required-flag test — `--from`/`--to`/`--reason` are `required`; `Lookup("value")`/`Lookup("secret")`/`Lookup("password")` all return nil.
- [x] `go test ./internal/cmd/secret/... -run 'TestSecretMoveAwaitingApproval' -race` — passes (rendered verbatim, exit 0, not exit-4; `--json` envelope round-trips).
- [x] `gofmt` clean, `go vet` clean, code-quality gate exit 0.

## Out of scope

- The keycloak sink adapter (#1578), approval-queue / policy-gate wiring (#1579), and the dedicated `secret.move` docs page (#1581) — separate sibling tasks.
- The backend op handler / `SecretEndpoint` protocol / connector registration — T1 (#1577), already merged.

<!-- auto-implement-issue: fresh, iteration 1 -->

Closes #1580


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **New Features**
  * Added `meho secret move` command for migrating secrets with approval workflows. Accepts `--from`, `--to`, and `--reason` reference-based parameters. Displays `status=awaiting_approval` when approval is required; otherwise outputs operation status, value SHA-256 hash, and byte length. Secret values never exposed in CLI flags, prompts, or shell history.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->