### PR TITLE
fix(audit): stream text/event-stream through AuditMiddleware (#1389)

### DIFF
--- a/backend/src/meho_backplane/audit.py
+++ b/backend/src/meho_backplane/audit.py
@@ -76,11 +76,19 @@ are forwarded verbatim. On audit failure the buffer is discarded and
 a fresh 500 ``{"detail": "audit_write_failed"}`` response is sent.
 
 The buffer is bounded by the response itself (typical FastAPI JSON
-responses are kilobytes); v0.1 does not need streaming-response
-support on audited routes and the audit middleware would degrade
-streaming semantics regardless. When v0.2 adds streaming routes, the
-audit row must be written *after* the response body has streamed —
-a change tracked as a follow-up rather than landing here.
+responses are kilobytes). Streaming routes are the deliberate
+exception: a ``text/event-stream`` response (the SSE feeds at
+``/api/v1/feed`` and ``/ui/broadcast/stream``) is **not** buffered —
+buffering an open-ended SSE generator until the inner app returns
+delivers zero bytes to the client for the life of the connection
+(#1389). Such responses are forwarded chunk-by-chunk as the generator
+yields, and the audit row is written when the stream ends (normal
+completion or a client-disconnect ``CancelledError``). The fail-closed
+500 swap cannot apply once a stream's ``http.response.start`` is on the
+wire; the audit-write failure is still logged loudly, and the SSE
+handler surfaces transport faults to the subscriber as an
+``event: feed_error`` frame. Non-streaming JSON routes keep the
+buffered fail-closed-500 contract verbatim.
 
 References
 ----------
@@ -90,6 +98,7 @@ References
 
 from __future__ import annotations
 
+import asyncio
 import json
 import time
 import uuid
@@ -119,6 +128,35 @@ _AUDIT_FAILURE_BODY: Final[bytes] = json.dumps({"detail": "audit_write_failed"})
 
 _RESPONSE_START: Final[str] = "http.response.start"
 _RESPONSE_BODY: Final[str] = "http.response.body"
+
+#: Content-type the middleware treats as a live stream that must NOT be
+#: buffered. Matched as a prefix against the lowercased ``content-type``
+#: header value on ``http.response.start`` so the ``; charset=utf-8``
+#: suffix Starlette's :class:`~starlette.responses.StreamingResponse`
+#: appends still matches. Both SSE surfaces — ``GET /api/v1/feed``
+#: (G6.1-T4) and ``GET /ui/broadcast/stream`` (G10.1) — set this media
+#: type; an open-ended SSE generator never completes, so buffering its
+#: send messages until the inner app returns delivers zero bytes to the
+#: client for the life of the connection (#1389).
+_EVENT_STREAM_MEDIA_TYPE: Final[bytes] = b"text/event-stream"
+
+
+def _is_event_stream_start(message: Message) -> bool:
+    """Return ``True`` when *message* is an ``http.response.start`` for an SSE body.
+
+    Inspects the ``content-type`` header on the start message. ASGI
+    header names are byte strings and case-insensitive per RFC 9110;
+    the value carries the ``; charset=...`` suffix Starlette appends,
+    so the comparison is a lowercased prefix match against
+    :data:`_EVENT_STREAM_MEDIA_TYPE`.
+    """
+    if message.get("type") != _RESPONSE_START:
+        return False
+    headers: list[tuple[bytes, bytes]] = message.get("headers") or []
+    for name, value in headers:
+        if name.lower() == b"content-type":
+            return bool(value.lower().startswith(_EVENT_STREAM_MEDIA_TYPE))
+    return False
 
 
 def _coerce_request_id(raw: object) -> uuid.UUID | None:
@@ -464,36 +502,88 @@ async def _publish_broadcast_event(
     await publish_event(event)
 
 
+class _InnerAppResult:
+    """Mutable view of the inner app's response, observable on exception.
+
+    ``status_code`` and ``streamed`` are written as the inner app emits
+    its first ``http.response.start`` message, so the audit-write code
+    can read them even when the inner app later raises
+    :class:`asyncio.CancelledError` (an SSE client disconnect, which
+    must still produce an audit row for the closed session — #1389).
+    ``handler_exc`` holds a non-cancellation :class:`Exception` the
+    inner app raised, mapped to the fail-closed 500 path.
+    """
+
+    __slots__ = ("handler_exc", "status_code", "streamed")
+
+    def __init__(self) -> None:
+        self.status_code: int = 0
+        self.handler_exc: BaseException | None = None
+        #: True once an ``http.response.start`` for ``text/event-stream``
+        #: was seen — its messages were forwarded live, not buffered.
+        self.streamed: bool = False
+
+
 async def _run_inner_app_buffered(
     app: ASGIApp,
     scope: Scope,
     receive: Receive,
+    send: Send,
     buffered: list[Message],
-) -> tuple[int, BaseException | None]:
-    """Invoke the inner app capturing its send messages.
+    result: _InnerAppResult,
+) -> None:
+    """Invoke the inner app, buffering its send messages — except SSE streams.
 
-    Returns ``(status_code, handler_exc)``. When the inner app raises a
-    non-cancellation :class:`Exception`, the buffered messages are
-    cleared (a partially-emitted response cannot be safely forwarded)
-    and ``status_code`` is synthesised to 500 so the audit row reflects
-    Starlette's :class:`~starlette.middleware.errors.ServerErrorMiddleware`
+    Populates the caller-owned *result* in place. The default contract
+    is unchanged: ``http.response.start`` + ``http.response.body``
+    messages are appended to *buffered* and the caller forwards them only
+    after the audit insert decides whether to keep them or replace them
+    with a fail-closed 500.
+
+    The exception is a ``text/event-stream`` response
+    (:func:`_is_event_stream_start`): an open-ended SSE generator never
+    completes, so buffering its messages until the inner app returns
+    delivers zero bytes to the client for the life of the connection
+    (#1389). Once the start message is recognised as a stream, that
+    message and every subsequent body chunk are forwarded through *send*
+    immediately, and :attr:`_InnerAppResult.streamed` is set so the
+    caller skips the post-audit re-forward and the fail-closed-500
+    replacement (the response headers are already on the wire — the SSE
+    feed handler surfaces a transport failure as an ``event: feed_error``
+    frame instead, see :mod:`meho_backplane.api.v1.feed`).
+
+    When the inner app raises a non-cancellation :class:`Exception`,
+    non-streamed buffered messages are cleared (a partially-emitted
+    response cannot be safely forwarded) and the status is synthesised
+    to 500 so the audit row reflects
+    :class:`~starlette.middleware.errors.ServerErrorMiddleware`'s
     eventual verdict. ``CancelledError`` is intentionally *not* caught
-    so client disconnects still cancel the task tree cleanly.
+    so client disconnects still cancel the task tree cleanly — and
+    because *result* is caller-owned, it is fully populated by the time
+    the cancellation propagates, so the caller's ``except`` arm still
+    writes the audit row for a streamed session that ended on disconnect.
     """
-    status_code: int = 0
 
     async def buffered_send(message: Message) -> None:
-        nonlocal status_code
         if message["type"] == _RESPONSE_START:
-            status_code = int(message.get("status", 0))
+            result.status_code = int(message.get("status", 0))
+            if _is_event_stream_start(message):
+                result.streamed = True
+        if result.streamed:
+            # SSE: forward live so each chunk reaches the client as the
+            # generator yields it, rather than after the (never-ending)
+            # stream closes.
+            await send(message)
+            return
         buffered.append(message)
 
     try:
         await app(scope, receive, buffered_send)
     except Exception as exc:
-        buffered.clear()
-        return 500, exc
-    return status_code, None
+        if not result.streamed:
+            buffered.clear()
+            result.status_code = 500
+        result.handler_exc = exc
 
 
 def _resolve_request_metadata(
@@ -634,7 +724,6 @@ class AuditMiddleware:
     def __init__(self, app: ASGIApp) -> None:
         self.app = app
 
-    # code-quality-allow: pre-existing legacy __call__; G7.1-T2 only added audit_id pre-allocation
     async def __call__(self, scope: Scope, receive: Receive, send: Send) -> None:
         if scope["type"] != "http":
             await self.app(scope, receive, send)
@@ -656,20 +745,77 @@ class AuditMiddleware:
 
         # Buffer the inner app's send messages so we can decide, after
         # the audit insert, whether to forward them or replace with a
-        # fresh 500. v0.1 routes return single-shot JSON responses; the
-        # buffer is small. The inner-app invocation is wrapped so a
-        # handler exception still produces an audit row for the failed
-        # action (the audit row is the operator-facing trace of "this
-        # action was attempted"); see :func:`_run_inner_app_buffered`.
+        # fresh 500. Single-shot JSON responses keep the buffer small.
+        # The exception is a ``text/event-stream`` response: its messages
+        # are forwarded live by :func:`_run_inner_app_buffered` (an
+        # open-ended SSE generator never returns, so buffering would
+        # deliver zero bytes — #1389). The inner-app invocation is
+        # wrapped so a handler exception still produces an audit row for
+        # the failed action.
+        #
+        # An SSE client disconnect raises :class:`asyncio.CancelledError`
+        # out of the inner app; the audit row for the now-closed session
+        # is still written (the ``result`` holder is fully populated by
+        # then) before the cancellation propagates to unwind the task
+        # tree per asyncio's contract.
         buffered: list[Message] = []
-        status_code, handler_exc = await _run_inner_app_buffered(
-            self.app,
-            scope,
-            receive,
-            buffered,
-        )
+        result = _InnerAppResult()
+        try:
+            await _run_inner_app_buffered(
+                self.app,
+                scope,
+                receive,
+                send,
+                buffered,
+                result,
+            )
+        except asyncio.CancelledError as cancelled:
+            # SSE client disconnect. ``result`` is caller-owned, so its
+            # ``streamed`` / ``status_code`` reflect the headers already
+            # sent on the first yield; write the audit row for the closed
+            # session, then re-raise to unwind the task tree (Sonar
+            # S7497 / asyncio cancellation contract).
+            await self._finalize(
+                scope=scope,
+                send=send,
+                buffered=buffered,
+                result=result,
+                duration_ms=round((time.monotonic() - start) * 1000, 2),
+            )
+            raise cancelled
 
         duration_ms = round((time.monotonic() - start) * 1000, 2)
+        await self._finalize(
+            scope=scope,
+            send=send,
+            buffered=buffered,
+            result=result,
+            duration_ms=duration_ms,
+        )
+
+    # code-quality-allow: relocated legacy __call__ body (audit-write +
+    # broadcast publish + forward control flow); #1389 only extracted it
+    # so the normal-return and SSE-disconnect paths share one finalizer.
+    async def _finalize(
+        self,
+        *,
+        scope: Scope,
+        send: Send,
+        buffered: list[Message],
+        result: _InnerAppResult,
+        duration_ms: float,
+    ) -> None:
+        """Write the audit row and forward / replace / re-raise the response.
+
+        Shared by the normal-return path and the SSE-disconnect
+        (``CancelledError``) path. ``result.streamed`` selects between
+        the buffered fail-closed-500 contract (non-streaming JSON routes,
+        unchanged) and the already-streamed contract (SSE: bytes are on
+        the wire, so the audit row is recorded but the response can no
+        longer be replaced or re-forwarded — #1389).
+        """
+        status_code = result.status_code
+        handler_exc = result.handler_exc
         operator_sub = structlog.contextvars.get_contextvars().get("operator_sub")
 
         if not isinstance(operator_sub, str) or not operator_sub:
@@ -677,11 +823,13 @@ class AuditMiddleware:
             # (public surfaces, 401s, and any other unauthenticated
             # path land here); forward the buffered response unchanged
             # — or, if the handler raised, re-raise so the outer
-            # ServerErrorMiddleware builds the 500.
-            if handler_exc is not None:
+            # ServerErrorMiddleware builds the 500. Streamed responses
+            # were already forwarded live, so there is nothing to flush.
+            if handler_exc is not None and not result.streamed:
                 raise handler_exc
-            for message in buffered:
-                await send(message)
+            if not result.streamed:
+                for message in buffered:
+                    await send(message)
             return
 
         method, path, request_id = _resolve_request_metadata(scope)
@@ -764,6 +912,18 @@ class AuditMiddleware:
                 status_code=status_code,
                 duration_ms=duration_ms,
             )
+            # Streamed (SSE) responses already sent ``http.response.start``
+            # live, so the fail-closed 500 swap is impossible — the bytes
+            # are on the wire. The audit-write failure is still logged
+            # loudly above; the SSE handler surfaces transport faults to
+            # the subscriber as an ``event: feed_error`` frame. Re-raise
+            # only when the handler itself faulted (the task is already
+            # unwinding); otherwise return so the live stream closes
+            # cleanly rather than being torn down by a synthesised 500.
+            if result.streamed:
+                if handler_exc is not None:
+                    raise handler_exc from None
+                return
             # If the handler itself also raised, the audit-failure
             # response cannot be sent (the outer ServerErrorMiddleware
             # is about to take over); prefer surfacing the original
@@ -809,11 +969,18 @@ class AuditMiddleware:
         # ServerErrorMiddleware builds the canonical 500; the audit
         # row attributing the failed action is already persisted,
         # satisfying the "every authenticated action gets exactly one
-        # row" contract for the 5xx path.
+        # row" contract for the 5xx path. An SSE client disconnect
+        # surfaces as ``CancelledError`` re-raised by ``__call__`` after
+        # this method returns — it is never recorded in ``handler_exc``
+        # (``_run_inner_app_buffered`` only catches ``Exception``), so a
+        # cleanly-closed stream falls through to the no-op return below.
         if handler_exc is not None:
             raise handler_exc
 
-        # Audit committed and handler succeeded — forward the buffered
-        # response verbatim.
+        # Audit committed and handler succeeded. A streamed response was
+        # already forwarded chunk-by-chunk; only buffered (non-streaming)
+        # responses are flushed here.
+        if result.streamed:
+            return
         for message in buffered:
             await send(message)

--- a/backend/tests/test_api_v1_feed.py
+++ b/backend/tests/test_api_v1_feed.py
@@ -48,6 +48,7 @@ Two surfaces, each tested at the layer that fits:
 from __future__ import annotations
 
 import asyncio
+import contextlib
 import json
 import os
 from collections.abc import AsyncIterator, Iterator
@@ -467,6 +468,234 @@ class TestFeedEndpoint:
         with pytest.raises(HTTPException) as exc_info:
             _validate_cursor_or_400("2026-05-25")
         assert exc_info.value.status_code == 400
+
+
+# ---------------------------------------------------------------------------
+# ASGI-transport e2e — SSE streams incrementally through the full
+# middleware stack (regression coverage for #1389)
+# ---------------------------------------------------------------------------
+
+
+def _sse_frame(event: BroadcastEvent, entry_id: str) -> str:
+    """Render *event* as the on-wire ``event: broadcast`` SSE frame."""
+    return f"event: broadcast\ndata: {event.model_dump_json()}\nid: {entry_id}\n\n"
+
+
+class TestSseStreamsThroughMiddleware:
+    """The audit middleware forwards ``text/event-stream`` chunks live (#1389).
+
+    Before #1389 :class:`~meho_backplane.audit.AuditMiddleware` buffered
+    the entire ASGI response before forwarding it. For an open-ended SSE
+    generator the inner-app call never returns, so the buffer is never
+    flushed and the client receives **zero bytes** for the life of the
+    connection — ``/api/v1/feed`` and ``/ui/broadcast/stream`` are dark
+    on a real deploy even though the generator is yielding frames.
+
+    ``httpx.ASGITransport`` cannot prove incremental delivery: it runs
+    the inner app **to completion** before exposing the body
+    (``handle_async_request`` collects every ``http.response.body`` into
+    a list, then wraps it in a stream), so an open-ended generator would
+    just hang the transport regardless of whether the middleware buffers
+    or streams. The first test therefore drives the production middleware
+    stack (``AuditMiddleware`` inside ``RequestContextMiddleware``, the
+    ordering :func:`meho_backplane.main` wires) as a **raw ASGI app**
+    with an instrumented ``send`` — the only seam that observes a body
+    chunk reaching the transport *while the inner generator is still
+    suspended*. With the old buffering middleware the handshake below
+    deadlocks (no body chunk is forwarded until the generator returns,
+    which it never does) → ``asyncio.timeout`` fires → the test fails.
+
+    The second test asserts the audit row is still written for the
+    streaming request (fail-closed preserved). It uses a finite generator
+    so the assertion rides the normal stream-completion path rather than
+    ASGI's racy disconnect-cancellation handshake; ``ASGITransport`` is
+    fine here because a finite stream completes on its own.
+    """
+
+    async def test_first_chunk_forwarded_before_inner_generator_completes(
+        self,
+        _feed_env: None,
+        monkeypatch: pytest.MonkeyPatch,
+    ) -> None:
+        """A body chunk reaches ``send`` while the SSE generator is still open.
+
+        Drives ``RequestContextMiddleware(AuditMiddleware(app))`` directly
+        as an ASGI callable. The patched generator yields one
+        ``event: broadcast`` frame and then ``await``\\ s an event that is
+        only set *after* the instrumented ``send`` observes the first
+        ``http.response.body`` — i.e. the test asserts the body left the
+        middleware before the generator could move past its first yield.
+
+        Against the pre-#1389 buffering middleware no body chunk is
+        forwarded until the inner app returns, so ``first_body_seen`` is
+        never set, the generator blocks on ``release.wait()`` forever, and
+        the ``asyncio.timeout`` guard fires → the test fails. The
+        streaming fix forwards the chunk live, the handshake completes,
+        and the generator is released to finish cleanly.
+        """
+        from tests._vault_fakes import install_fake_vault
+
+        first_frame = _sse_frame(_make_event(), "1715600000000-0")
+        first_body_seen = asyncio.Event()
+        release = asyncio.Event()
+
+        async def _one_then_wait(*_args: object, **_kwargs: object) -> AsyncIterator[str]:
+            yield first_frame
+            # Suspend until the test confirms the first chunk was
+            # forwarded — stands in for the never-returning XREAD BLOCK
+            # loop. A buffering middleware never sets ``first_body_seen``,
+            # so this wait (and thus the whole request) hangs.
+            await release.wait()
+
+        import meho_backplane.api.v1.feed as feed_module
+
+        monkeypatch.setattr(feed_module, "_feed_generator", _one_then_wait)
+
+        install_fake_vault(monkeypatch)
+        key = make_rsa_keypair("kid-sse-live")
+        token = mint_token(
+            key,
+            sub="op-sse-live",
+            tenant_id=str(_TENANT_A),
+            tenant_role=TenantRole.OPERATOR.value,
+        )
+
+        # Build the production middleware stack around the feed router.
+        inner = FastAPI()
+        inner.include_router(feed_router)
+        asgi_app = RequestContextMiddleware(AuditMiddleware(inner))
+
+        scope = {
+            "type": "http",
+            "asgi": {"version": "3.0"},
+            "http_version": "1.1",
+            "method": "GET",
+            "path": "/api/v1/feed",
+            "raw_path": b"/api/v1/feed",
+            "query_string": b"",
+            "root_path": "",
+            "scheme": "https",
+            "server": ("testserver", 443),
+            "client": ("testclient", 50000),
+            "headers": [(b"authorization", f"Bearer {token}".encode())],
+        }
+
+        request_drained = False
+
+        async def receive() -> dict[str, object]:
+            # Deliver the (empty) request body exactly once, then behave
+            # like a still-connected client: block until the test releases
+            # the request, then report ``http.disconnect``. A real ASGI
+            # server's ``receive`` blocks here too — Starlette's
+            # ``StreamingResponse`` spawns a disconnect-listener task that
+            # polls ``receive``; returning ``http.request`` on every call
+            # would busy-loop that task at 100% CPU.
+            nonlocal request_drained
+            if not request_drained:
+                request_drained = True
+                return {"type": "http.request", "body": b"", "more_body": False}
+            await release.wait()
+            return {"type": "http.disconnect"}
+
+        captured_status: dict[str, int] = {}
+        body_chunks: list[bytes] = []
+
+        async def send(message: dict[str, object]) -> None:
+            if message["type"] == "http.response.start":
+                captured_status["status"] = int(message["status"])  # type: ignore[arg-type]
+            elif message["type"] == "http.response.body":
+                body = message.get("body", b"")
+                if body:
+                    body_chunks.append(body)  # type: ignore[arg-type]
+                    first_body_seen.set()
+
+        with respx.mock as mock_router:
+            mock_discovery_and_jwks(mock_router, public_jwks(key))
+            task = asyncio.ensure_future(asgi_app(scope, receive, send))
+            try:
+                # Streaming fix: the first body chunk is forwarded live,
+                # so this resolves immediately. Buffering: never resolves.
+                async with asyncio.timeout(5.0):
+                    await first_body_seen.wait()
+                assert captured_status["status"] == 200
+                assert body_chunks, "no body chunk forwarded before generator suspended"
+                assert b"event: broadcast" in b"".join(body_chunks)
+            finally:
+                # Release the suspended generator so the request task can
+                # complete and we don't leak a pending task.
+                release.set()
+                with contextlib.suppress(TimeoutError):
+                    async with asyncio.timeout(5.0):
+                        await task
+
+    async def test_streaming_request_writes_audit_row(
+        self,
+        _feed_env: None,
+        monkeypatch: pytest.MonkeyPatch,
+    ) -> None:
+        """An audit row is written for a streaming request (fail-closed preserved).
+
+        Uses a *finite* generator (two frames, then the stream ends) so
+        the middleware's audit-write runs on normal stream completion
+        rather than depending on ASGI's racy disconnect-cancellation
+        handshake. After the body is fully drained the ``audit_log``
+        table carries exactly one row for ``GET /api/v1/feed`` with
+        ``status_code=200`` — proving the SSE path keeps the
+        every-authenticated-action-gets-a-row contract.
+        """
+        from sqlalchemy import select
+
+        from meho_backplane.db.engine import get_sessionmaker
+        from meho_backplane.db.models import AuditLog
+
+        frames = [
+            _sse_frame(_make_event(op_id="vsphere.vm.list"), "1715600000000-0"),
+            _sse_frame(_make_event(op_id="vsphere.vm.get"), "1715600000001-0"),
+        ]
+
+        async def _finite_stream(*_args: object, **_kwargs: object) -> AsyncIterator[str]:
+            for frame in frames:
+                yield frame
+
+        import meho_backplane.api.v1.feed as feed_module
+
+        monkeypatch.setattr(feed_module, "_feed_generator", _finite_stream)
+
+        app = _build_app()
+        with respx.mock as mock_router:
+            from tests._vault_fakes import install_fake_vault
+
+            install_fake_vault(monkeypatch)
+            key = make_rsa_keypair("kid-sse-audit")
+            mock_discovery_and_jwks(mock_router, public_jwks(key))
+            token = mint_token(
+                key,
+                sub="op-sse-audit",
+                tenant_id=str(_TENANT_A),
+                tenant_role=TenantRole.OPERATOR.value,
+            )
+            async with _make_client(app) as client:
+                response = await client.get(
+                    "/api/v1/feed",
+                    headers={"Authorization": f"Bearer {token}"},
+                )
+                assert response.status_code == 200
+                assert response.headers["content-type"].startswith("text/event-stream")
+                # Both frames must be present in the streamed body — the
+                # middleware forwarded them, it did not drop the stream.
+                assert response.text.count("event: broadcast") == 2
+
+        sessionmaker = get_sessionmaker()
+        async with sessionmaker() as session:
+            rows = list(
+                (await session.execute(select(AuditLog).where(AuditLog.path == "/api/v1/feed")))
+                .scalars()
+                .all()
+            )
+        assert len(rows) == 1
+        assert rows[0].operator_sub == "op-sse-audit"
+        assert rows[0].method == "GET"
+        assert rows[0].status_code == 200
 
 
 # ---------------------------------------------------------------------------

--- a/docs/codebase/broadcast.md
+++ b/docs/codebase/broadcast.md
@@ -306,6 +306,52 @@ assert the published events show up in the first batch of frames
 within bounded latency. A second test asserts that an explicit
 `since=` cursor skips the prelude.
 
+### SSE feed delivers zero bytes on deploy — `AuditMiddleware` buffered the stream (FIXED, #1389)
+
+**Symptom.** On a real deploy `GET /api/v1/feed` (Bearer JWT) and
+`/ui/broadcast/stream` (session cookie) delivered **zero bytes** for
+the life of the connection even though the generator was yielding
+`event: broadcast` frames — the live-activity UI and
+`meho status --watch` stayed dark.
+
+**Root cause (middleware side, distinct from #1305/#771).** The
+chassis `AuditMiddleware` (`backend/src/meho_backplane/audit.py`) ran
+the inner app through `_run_inner_app_buffered`, which appended every
+`http.response.start` + `http.response.body` message to a list and
+forwarded them only **after** the audit insert completed — i.e. after
+`await app(...)` returned. An SSE generator's `await app(...)` never
+returns (the BLOCK loop runs for the life of the connection), so the
+buffer was never flushed. The handlers were correct (#1305 fixed the
+backlog prelude / `$`-cursor blackout; #1354 fixed the 5 s
+`socket_timeout` teardown); the bytes simply never left the
+middleware. #1354 *unmasked* this defect by removing the periodic
+spurious teardown that had been flushing the buffer with an error
+frame.
+
+**Fix.** `_run_inner_app_buffered` now recognises a
+`text/event-stream` response (`_is_event_stream_start`, matched on the
+`content-type` header of `http.response.start`) and forwards the start
+message + every body chunk **immediately** through the real `send`
+instead of buffering. The audit row is written when the stream ends —
+normal completion or a client-disconnect `CancelledError` — so the
+fail-closed "every authenticated action gets a row" contract holds.
+The fail-closed-500 swap cannot apply once a stream's
+`http.response.start` is on the wire; an audit-write failure is logged
+loudly, and the feed handler surfaces transport faults to the
+subscriber as an `event: feed_error` frame. Non-streaming JSON routes
+keep the buffered fail-closed-500 contract verbatim.
+
+**Acceptance test** lives in `backend/tests/test_api_v1_feed.py` under
+`TestSseStreamsThroughMiddleware`. One test drives
+`RequestContextMiddleware(AuditMiddleware(app))` as a raw ASGI
+callable with an instrumented `send` and asserts a body chunk reaches
+the transport *while the generator is still suspended* — it deadlocks
+(and times out) against the old buffering behaviour. A second test
+asserts the streaming request still writes one `audit_log` row.
+(`httpx.ASGITransport` cannot prove incremental delivery — it runs the
+inner app to completion before exposing the body — so the raw-ASGI
+seam is the one that observes live forwarding.)
+
 ### Earlier issue: empty broadcast feed in v0.7.0 (#755)
 
 The v0.7.0 cycle (`claude-rdc-hetzner-dc#753`) surfaced "I see empty


### PR DESCRIPTION
## Summary

- `AuditMiddleware` buffered the **entire** ASGI response before forwarding it, so `text/event-stream` responses (`/api/v1/feed`, `/ui/broadcast/stream`) delivered **zero bytes** until the stream closed — which for an open-ended SSE feed is never. The live-activity UI and `meho status --watch` were dark on a real deploy. #1354 unmasked this by removing the periodic teardown that had been flushing the buffer with a spurious error frame.
- `_run_inner_app_buffered` now recognises a `text/event-stream` response (`content-type` on `http.response.start`) and forwards the start message + every body chunk **live** through the real `send` instead of buffering. The audit row is still written — at stream end (normal completion) or on a client-disconnect `CancelledError` — so the fail-closed "every authenticated action gets a row" contract holds for the streaming path.
- The fail-closed-500 swap cannot apply once a stream's `http.response.start` is on the wire; an audit-write failure is still logged loudly, and the feed handler surfaces transport faults to the subscriber as an `event: feed_error` frame. **Non-streaming JSON routes keep the buffered fail-closed-500 contract verbatim.**
- The post-inner-app audit/forward control flow was extracted from `__call__` into `_finalize` so the normal-return and SSE-disconnect paths share one finalizer.

## Test plan

- [x] `ruff check` / `ruff format --check` — clean
- [x] `mypy src/meho_backplane/audit.py` — clean
- [x] New ASGI-transport e2e coverage in `backend/tests/test_api_v1_feed.py::TestSseStreamsThroughMiddleware`:
  - `test_first_chunk_forwarded_before_inner_generator_completes` — drives `RequestContextMiddleware(AuditMiddleware(app))` as a raw ASGI callable with an instrumented `send`; asserts a body chunk reaches the transport **while the SSE generator is still suspended**. Deadlocks (times out → fails) against the old buffering behaviour. *(Note: `httpx.ASGITransport` runs the inner app to completion before exposing the body, so it cannot prove incremental delivery — the raw-ASGI seam is the discriminating one.)*
  - `test_streaming_request_writes_audit_row` — finite generator; asserts exactly one `audit_log` row for `GET /api/v1/feed` with `status_code=200` (fail-closed preserved on the streaming path).
- [x] Existing `test_audit_middleware.py` (non-streaming JSON + fail-closed-500 + handler-exception) and `test_api_v1_feed.py` suites — green (no regression).
- [x] `docs/codebase/broadcast.md` — added a "Known issues" entry for #1389 (the middleware-buffering root cause that #1305/#1354 masked) + updated the module docstring's stale "Fail-closed buffering" section.

## Out of scope

- The Valkey-backed generator behaviour (cursor/prelude/heartbeat/filter) is unchanged and already covered by `TestFeedGenerator` / `TestFeedBacklogPrelude`.

<!-- auto-implement-issue: fresh, iteration 1 -->

Closes #1389
