### PR TITLE
feat(connectors): keycloak-credential SecretEndpoint sink — broker's second kind (#1578)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -102,6 +102,18 @@ connector-related release-notes line.
   The keycloak sink, approval-queue gating, CLI verb, and docs page are
   separate sibling tasks reusing this contract.
 
+### Keycloak-credential `SecretEndpoint` sink — broker's second kind (#1578)
+
+- Add a `keycloak`-kind `SecretEndpoint` sink so a `secret.move` can land
+  a credential in a Keycloak user's password, proving the broker's
+  cross-kind ("≥2 kinds") move surface (`vault:secret/...#password` →
+  `keycloak:<target>/<realm>/<user>#password`). The sink reuses the
+  existing Keycloak admin write path (username→UUID + `PUT
+  .../reset-password`) and writes the value server-side from the
+  in-memory `SecretMaterial`; the value never enters op params, the
+  response, logs, or the audit row. Keycloak is write-only here, so the
+  source side raises a clear unsupported error.
+
 ### Retire the stale `meho targets create` verb tree-wide (#1559)
 
 - Remove the last references to the nonexistent `meho targets create`

--- a/backend/src/meho_backplane/connectors/keycloak/secret_endpoint.py
+++ b/backend/src/meho_backplane/connectors/keycloak/secret_endpoint.py
@@ -1,0 +1,250 @@
+# SPDX-License-Identifier: Apache-2.0
+# Copyright (c) 2026 evoila Group
+
+"""Keycloak-credential :class:`SecretEndpoint` sink — the broker's second kind.
+
+Registered under kind ``"keycloak"`` (see :func:`register_secret_endpoint`
+at module import), this adapter is a **sink only**: it sets a Keycloak
+user's password credential from a :class:`SecretMaterial` the broker
+already holds. It is the second connector kind the secret broker
+(Initiative #581) gains after the vault-kv pair (#1577), so a cross-kind
+move ``vault:secret/db/prod#password`` → ``keycloak:<target>/<realm>/<user>#password``
+can be proven end to end — the broker's "≥2 kinds" definition of done.
+
+Why sink-only
+=============
+
+Keycloak never serves a stored password back over the Admin REST API
+(credentials are write-only by design — Keycloak hashes them and the
+plaintext is unrecoverable), so a keycloak **source** has nothing to
+read. :meth:`~KeycloakCredentialSecretEndpoint.read_secret` therefore
+raises :class:`NotImplementedError`; the dispatcher maps it to a
+``connector_error`` naming the kind, never a value.
+
+Reuse, not reimplementation
+===========================
+
+The sink does **not** open its own HTTP client. It resolves the
+:class:`KeycloakConnector` instance from the dispatcher's instance cache
+(:func:`~meho_backplane.operations._handler_resolve.get_or_create_connector_instance`)
+and drives the *existing* admin-write path —
+:meth:`KeycloakConnector._find_user_uuid` (username→UUID) +
+:meth:`KeycloakConnector._write_admin` (``PUT
+.../users/{id}/reset-password`` with a CredentialRepresentation
+``{type:"password", value, temporary}``) — exactly as
+:func:`~meho_backplane.connectors.keycloak.ops_write.keycloak_user_reset_password`
+does. The admin Bearer is minted under the connector's own admin
+credential; the operator's JWT authorises only the per-operator target
+resolution and never reaches Keycloak.
+
+Ref grammar
+===========
+
+The store-specific ``ref`` (the part after ``keycloak:``) addresses one
+user credential as::
+
+    <target>/<realm>/<username>#<field>
+
+* ``<target>`` — the MEHO target *name* (or alias) the Keycloak admin
+  connection is configured under; resolved tenant-scoped via
+  :func:`~meho_backplane.targets.resolver.resolve_target`.
+* ``<realm>`` — the Keycloak realm the user lives in. Taken from the ref
+  (the operator addresses it explicitly), not from the target's
+  ``extras["managed_realm"]`` default.
+* ``<username>`` — the human username; resolved to the internal UUID via
+  the Admin REST ``?username=&exact=true`` lookup.
+* ``#<field>`` (required) — must be ``password``; keycloak credentials
+  are the only writable field here. Any other field is rejected so a
+  malformed move fails before the admin write.
+
+No secret in logs / response / audit
+====================================
+
+The value lives only inside the :class:`SecretMaterial` between the
+source read and this sink write. It is read **once**, whitespace-stripped
+by :func:`strip_credential_value` (so a trailing newline never rides into
+the Keycloak password — the same artifact the credential loaders strip),
+placed into the Admin REST PUT body, and never returned. The adapter's
+structlog events carry only the target name, realm, and username — never
+the value, and never the bytes the :class:`SecretMaterial` wraps. The
+``secret.move`` handler returns only ``status`` + ``value_sha256`` +
+``length``; the audit row stores a ``params_hash`` of the (value-free)
+references, so the value reaches neither the response nor the audit row.
+"""
+
+from __future__ import annotations
+
+from typing import TYPE_CHECKING, cast
+
+import structlog
+
+from meho_backplane.connectors._shared.vault_creds import strip_credential_value
+from meho_backplane.connectors.keycloak.connector import KeycloakConnector
+from meho_backplane.connectors.keycloak.ops_write import KeycloakUserNotFoundError
+from meho_backplane.connectors.keycloak.session import KeycloakTargetLike, quote_segment
+from meho_backplane.connectors.secret.endpoints import register_secret_endpoint
+from meho_backplane.db.engine import get_sessionmaker
+from meho_backplane.operations._handler_resolve import get_or_create_connector_instance
+from meho_backplane.targets.resolver import resolve_target
+
+if TYPE_CHECKING:
+    from meho_backplane.auth.operator import Operator
+    from meho_backplane.connectors.secret.endpoints import SecretMaterial
+
+__all__ = [
+    "KeycloakCredentialSecretEndpoint",
+    "KeycloakSecretRefError",
+]
+
+_log = structlog.get_logger(__name__)
+
+#: The only credential field this sink writes. Keycloak's CredentialRepresentation
+#: distinguishes credential types; the broker moves a password, so the ref's
+#: ``#<field>`` fragment must name it. A non-password field is rejected rather
+#: than silently coerced.
+_SUPPORTED_FIELD = "password"
+
+
+class KeycloakSecretRefError(ValueError):
+    """A keycloak ``ref`` is malformed or names an unsupported field.
+
+    Raised for a ref missing the required ``#<field>`` fragment, a ref
+    without the ``<target>/<realm>/<username>`` triple, an empty segment,
+    or a ``#<field>`` other than ``password``. A :class:`ValueError` so
+    the dispatcher's ``connector_error`` branch surfaces
+    ``exception_class="KeycloakSecretRefError"``. The message names the
+    ref's address parts, never the value.
+    """
+
+
+def _parse_keycloak_ref(ref: str) -> tuple[str, str, str]:
+    """Split ``"<target>/<realm>/<username>#<field>"`` into ``(target, realm, username)``.
+
+    The ``#<field>`` fragment is split off first (on the **last** ``#``,
+    so a username may contain a ``#``) and validated to be ``password``.
+    The remaining address is split into exactly three ``/``-separated
+    segments. Every segment must be non-empty after stripping.
+    """
+    address, sep, field = ref.rpartition("#")
+    if not sep or not address:
+        raise KeycloakSecretRefError(
+            f"malformed keycloak secret ref {ref!r}: expected "
+            "'<target>/<realm>/<username>#password' "
+            "(e.g. 'keycloak:rdc-keycloak/evba/operator-a#password')"
+        )
+    field = field.strip()
+    if field != _SUPPORTED_FIELD:
+        raise KeycloakSecretRefError(
+            f"keycloak secret ref {ref!r} names unsupported field {field!r}: "
+            f"only {_SUPPORTED_FIELD!r} credentials are writable here"
+        )
+    segments = [seg.strip() for seg in address.split("/")]
+    if len(segments) != 3 or not all(segments):
+        raise KeycloakSecretRefError(
+            f"malformed keycloak secret ref {ref!r}: expected a "
+            "'<target>/<realm>/<username>' address before '#password'"
+        )
+    target_name, realm, username = segments
+    return target_name, realm, username
+
+
+class KeycloakCredentialSecretEndpoint:
+    """A keycloak credential **sink** addressing one user's password.
+
+    Constructed per move from the parsed ``ref``. Sink-only:
+    :meth:`read_secret` raises; :meth:`write_secret` sets the addressed
+    user's password by reusing the connector's admin-write path.
+    """
+
+    def __init__(self, ref: str) -> None:
+        self._target_name, self._realm, self._username = _parse_keycloak_ref(ref)
+
+    async def _resolve_target(self, operator: Operator) -> KeycloakTargetLike:
+        """Resolve the ref's ``<target>`` to a ``KeycloakTargetLike``, tenant-scoped.
+
+        The ORM row structurally satisfies ``KeycloakTargetLike`` (name,
+        host, port, secret_ref, auth_model, extras) — the same row the
+        dispatcher hands the keycloak write ops at runtime. mypy can't
+        confirm the structural match across the ORM's mutable column types
+        (the ``AuthModel`` enum vs the Protocol's ``str | None``), so the
+        narrow is made explicit at this single reuse site.
+        """
+        sessionmaker = get_sessionmaker()
+        async with sessionmaker() as session:
+            row = await resolve_target(session, operator.tenant_id, self._target_name)
+        return cast(KeycloakTargetLike, row)
+
+    async def read_secret(self, operator: Operator) -> SecretMaterial:
+        """Unsupported — keycloak credentials are write-only.
+
+        Keycloak hashes credentials and never serves the plaintext back,
+        so there is nothing for a source read to return. Raised here (not
+        at construction) so the kind can still be a move **sink**; the
+        dispatcher maps it to a ``connector_error`` naming the kind.
+        """
+        raise NotImplementedError(
+            "keycloak is a write-only secret sink: credentials cannot be read "
+            "back from the Keycloak Admin REST API, so it cannot be a move source"
+        )
+
+    async def write_secret(self, operator: Operator, material: SecretMaterial) -> None:
+        """Set the addressed user's password from *material* server-side.
+
+        Resolves the target (tenant-scoped, by name) and the user's UUID,
+        then PUTs ``.../users/{id}/reset-password`` with a permanent
+        password CredentialRepresentation. The value is read once from the
+        :class:`SecretMaterial`, decoded, and whitespace-stripped via
+        :func:`strip_credential_value` (matching the existing
+        reset-password path so source and sink agree byte-for-byte); it
+        never enters op params, the response, a log event, or the audit
+        row. ``idempotent_conflict=False`` mirrors
+        :func:`~meho_backplane.connectors.keycloak.ops_write.keycloak_user_reset_password`
+        — a credential set is not a create, so a 409 should surface rather
+        than be swallowed.
+        """
+        connector = get_or_create_connector_instance(KeycloakConnector)
+        if not isinstance(connector, KeycloakConnector):  # pragma: no cover -- registry invariant
+            raise TypeError(
+                "secret broker keycloak sink resolved a non-KeycloakConnector instance; "
+                "the connector instance cache is misconfigured"
+            )
+
+        target = await self._resolve_target(operator)
+        uuid = await connector._find_user_uuid(
+            target, self._realm, self._username, operator=operator
+        )
+        if uuid is None:
+            raise KeycloakUserNotFoundError(
+                f"keycloak secret sink: no user with username={self._username!r} "
+                f"in realm {self._realm!r} on target {self._target_name!r}"
+            )
+
+        # Read the value exactly once, here, on the write path; strip the
+        # trailing-newline artifact as the existing reset-password path does.
+        credential = {
+            "type": "password",
+            "value": strip_credential_value(material.value.decode("utf-8")),
+            "temporary": False,
+        }
+        _log.debug(
+            "secret_broker.keycloak.write",
+            target=self._target_name,
+            realm=self._realm,
+            username=self._username,
+        )
+        await connector._write_admin(
+            target,
+            "PUT",
+            f"/admin/realms/{quote_segment(self._realm)}/users/"
+            f"{quote_segment(uuid)}/reset-password",
+            operator=operator,
+            json=credential,
+            idempotent_conflict=False,
+        )
+
+
+# Register the keycloak credential sink under kind ``"keycloak"`` at import
+# time. The ``connectors/secret`` package ``__init__`` imports this module so
+# the registration lands before the lifespan runs the move op's registrar —
+# mirroring how ``vault_endpoint`` registers the ``"vault"`` kind.
+register_secret_endpoint("keycloak", KeycloakCredentialSecretEndpoint)

--- a/backend/src/meho_backplane/connectors/secret/__init__.py
+++ b/backend/src/meho_backplane/connectors/secret/__init__.py
@@ -30,9 +30,12 @@ handler is a module-level function the dispatcher routes to with
 ``connector_instance=None`` / ``target=None``.
 """
 
-# Importing the adapter module runs its module-level
-# ``register_secret_endpoint("vault", ...)`` call so the registry is
+# Importing each adapter module runs its module-level
+# ``register_secret_endpoint(<kind>, ...)`` call so the registry is
 # populated before any move dispatches. Imported for the side effect.
+# The keycloak sink (#1578) lives under ``connectors/keycloak`` but
+# registers here so the broker's second kind lands on the same seam.
+from meho_backplane.connectors.keycloak import secret_endpoint as _keycloak_endpoint  # noqa: F401
 from meho_backplane.connectors.secret import vault_endpoint as _vault_endpoint  # noqa: F401
 from meho_backplane.connectors.secret.ops import register_secret_broker_operations
 from meho_backplane.operations.typed_register import register_typed_op_registrar

--- a/backend/tests/test_secret_broker_keycloak_sink.py
+++ b/backend/tests/test_secret_broker_keycloak_sink.py
@@ -1,0 +1,294 @@
+# SPDX-License-Identifier: Apache-2.0
+# Copyright (c) 2026 evoila Group
+
+"""Cross-kind secret move — vault source → keycloak sink (G0.22-T2 #1578).
+
+Proves the broker's "≥2 connector kinds" definition of done: a single
+``secret.move`` reads a credential from a ``vault:`` source and writes it
+into a ``keycloak:`` user credential, server-side, with the value never
+crossing back to the caller.
+
+The source uses the shared in-process Vault fake (``install_fake_client``
+— same seam ``test_connectors_secret_broker.py`` drives the vault→vault
+move through). The sink uses a respx-mocked Keycloak Admin REST host plus
+a seeded ``KeycloakConnector`` instance with a stub admin-credential
+loader (the pattern from ``test_connectors_keycloak_write_e2e.py``), so
+no live Keycloak / Vault is needed.
+
+The load-bearing security assertion mirrors the keycloak write E2E
+(``test_connectors_keycloak_write_e2e.py`` ``_PASSWORD_SENTINEL`` /
+asserts at :452-453): the sentinel value appears in the mocked Admin REST
+``reset-password`` PUT body and **nowhere else** — not in the
+``secret.move`` op params, the op response JSON, the captured log
+records, or the persisted audit row.
+"""
+
+from __future__ import annotations
+
+import hashlib
+import json
+import logging
+import uuid
+from collections.abc import AsyncIterator, Iterator
+from typing import Any
+
+import pytest
+import respx
+from sqlalchemy import select
+
+import meho_backplane.connectors.secret  # noqa: F401 -- registers the keycloak + vault kinds
+from meho_backplane.auth.operator import Operator, TenantRole
+from meho_backplane.connectors.keycloak import KeycloakConnector
+from meho_backplane.connectors.keycloak.secret_endpoint import (
+    KeycloakCredentialSecretEndpoint,
+    KeycloakSecretRefError,
+)
+from meho_backplane.connectors.keycloak.session import (
+    KeycloakAdminCredentials,
+    KeycloakClientCredentials,
+    KeycloakTargetLike,
+)
+from meho_backplane.connectors.schemas import OperationResult
+from meho_backplane.connectors.secret.endpoints import SECRET_ENDPOINT_REGISTRY
+from meho_backplane.connectors.secret.ops import register_secret_broker_operations
+from meho_backplane.db.engine import get_sessionmaker
+from meho_backplane.db.models import AuditLog
+from meho_backplane.db.models import Target as TargetORM
+from meho_backplane.operations import dispatch, reset_dispatcher_caches
+from meho_backplane.operations._handler_resolve import _CONNECTOR_INSTANCE_CACHE
+from meho_backplane.operations.dispatcher import set_default_reducer
+from meho_backplane.operations.reducer import PassThroughReducer
+from meho_backplane.settings import get_settings
+
+from ._vault_fakes import install_fake_client
+
+#: The secret the Vault source serves. The whole point of this suite is
+#: that it appears ONLY in the mocked Keycloak Admin PUT body.
+_SENTINEL = "vault-sourced-password-DO-NOT-LEAK-keycloak-sink"
+
+_KC_HOST = "keycloak-secret-sink.test.invalid"
+_KC_BASE_URL = f"https://{_KC_HOST}"
+_ADMIN_TOKEN = "kc-admin-token-secret-sink"
+_TARGET_NAME = "rdc-keycloak-secret-sink"
+_REALM = "evba"
+_USERNAME = "operator-a"
+_USER_UUID = "44444444-4444-4444-4444-444444444444"
+
+_OPERATOR_TENANT_ID = uuid.UUID("00000000-0000-0000-0000-0000000000ae")
+_OPERATOR = Operator(
+    sub="secret-sink-test",
+    name=None,
+    email=None,
+    raw_jwt="<secret-sink-raw-jwt>",
+    tenant_id=_OPERATOR_TENANT_ID,
+    tenant_role=TenantRole.TENANT_ADMIN,
+)
+
+_EXISTING_USER = {"id": _USER_UUID, "username": _USERNAME, "enabled": True}
+
+
+# ---------------------------------------------------------------------------
+# Fixtures — settings env, dispatcher isolation, seeded target + connector
+# ---------------------------------------------------------------------------
+
+
+@pytest.fixture(autouse=True)
+def _settings_env(monkeypatch: pytest.MonkeyPatch) -> Iterator[None]:
+    monkeypatch.setenv("KEYCLOAK_ISSUER_URL", "https://keycloak.test/realms/meho")
+    monkeypatch.setenv("KEYCLOAK_AUDIENCE", "meho-backplane")
+    monkeypatch.setenv("VAULT_ADDR", "https://vault.test")
+    monkeypatch.setenv("VAULT_OIDC_ROLE", "meho-mcp")
+    monkeypatch.setenv("VAULT_OIDC_MOUNT_PATH", "jwt")
+    monkeypatch.setenv("VAULT_TIMEOUT_SECONDS", "5.0")
+    monkeypatch.delenv("VAULT_NAMESPACE", raising=False)
+    get_settings.cache_clear()
+    reset_dispatcher_caches()
+    yield
+    get_settings.cache_clear()
+    reset_dispatcher_caches()
+
+
+@pytest.fixture
+def stub_embedding_service() -> Any:
+    from unittest.mock import AsyncMock
+
+    service = AsyncMock()
+    service.encode_one.return_value = [0.1] * 384
+    service.encode.return_value = [[0.1] * 384]
+    service.dimension = 384
+    return service
+
+
+def _stub_loader(_target: KeycloakTargetLike, _operator: Operator) -> Any:
+    async def _load() -> KeycloakAdminCredentials:
+        return KeycloakClientCredentials(client_id="meho-admin", client_secret="stub-secret")
+
+    return _load()
+
+
+async def _seed_keycloak_target() -> None:
+    sessionmaker = get_sessionmaker()
+    async with sessionmaker() as session:
+        target = TargetORM(
+            tenant_id=_OPERATOR_TENANT_ID,
+            name=_TARGET_NAME,
+            aliases=[],
+            product="keycloak",
+            host=_KC_HOST,
+            port=443,
+            fqdn=None,
+            secret_ref="rdc-hetzner-dc/keycloak/admin",
+            auth_model="shared_service_account",
+            vpn_required=False,
+            extras={},
+            fingerprint={"version": "26.0.5"},
+            notes="seeded by test_secret_broker_keycloak_sink",
+        )
+        session.add(target)
+        await session.commit()
+
+
+@pytest.fixture
+async def keycloak_sink_env(
+    stub_embedding_service: Any,
+) -> AsyncIterator[KeycloakConnector]:
+    """Seed the move op, the keycloak target, and a stubbed connector instance."""
+    set_default_reducer(PassThroughReducer())
+    await register_secret_broker_operations(embedding_service=stub_embedding_service)
+    await _seed_keycloak_target()
+    connector = KeycloakConnector(credentials_loader=_stub_loader)
+    _CONNECTOR_INSTANCE_CACHE[KeycloakConnector] = connector
+    yield connector
+    await connector.aclose()
+
+
+def _mount_admin_token(mock: respx.MockRouter) -> None:
+    mock.post("/realms/master/protocol/openid-connect/token").respond(
+        200, json={"access_token": _ADMIN_TOKEN, "expires_in": 300}
+    )
+
+
+async def _dispatch_move(params: dict[str, Any]) -> OperationResult:
+    return await dispatch(
+        operator=_OPERATOR,
+        connector_id="secret-broker-1.x",
+        op_id="secret.move",
+        target=None,
+        params=params,
+        _approved=True,
+    )
+
+
+async def _fetch_move_audit_rows() -> list[AuditLog]:
+    sessionmaker = get_sessionmaker()
+    async with sessionmaker() as session:
+        result = await session.execute(select(AuditLog).order_by(AuditLog.occurred_at))
+        return [r for r in result.scalars().all() if r.path == "secret.move"]
+
+
+# ---------------------------------------------------------------------------
+# Registration — the keycloak kind is on the T1 registry
+# ---------------------------------------------------------------------------
+
+
+def test_keycloak_kind_registered_in_secret_registry() -> None:
+    """The keycloak sink registers under kind ``"keycloak"`` at import time."""
+    assert SECRET_ENDPOINT_REGISTRY.get("keycloak") is KeycloakCredentialSecretEndpoint
+
+
+# ---------------------------------------------------------------------------
+# Sink-only — keycloak credentials cannot be read back
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.asyncio
+async def test_keycloak_source_read_is_unsupported() -> None:
+    """``read_secret`` on the keycloak kind raises — it is a write-only sink."""
+    endpoint = SECRET_ENDPOINT_REGISTRY["keycloak"](f"{_TARGET_NAME}/{_REALM}/{_USERNAME}#password")
+    with pytest.raises(NotImplementedError, match="write-only"):
+        await endpoint.read_secret(_OPERATOR)
+
+
+# ---------------------------------------------------------------------------
+# Ref grammar — malformed / unsupported-field rejection
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.parametrize(
+    "ref",
+    [
+        "target/realm/user",  # missing #field
+        "target/realm/user#secret",  # unsupported field
+        "target/realm#password",  # too few segments
+        "target/realm/user/extra#password",  # too many segments
+        "target//user#password",  # empty segment
+    ],
+    ids=["no-field", "bad-field", "too-few", "too-many", "empty-segment"],
+)
+def test_keycloak_ref_rejects_malformed(ref: str) -> None:
+    with pytest.raises(KeycloakSecretRefError):
+        KeycloakCredentialSecretEndpoint(ref)
+
+
+# ---------------------------------------------------------------------------
+# Cross-kind move — value reaches Keycloak, never the caller/audit/logs
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.asyncio
+async def test_vault_to_keycloak_move_writes_credential_server_side(
+    monkeypatch: pytest.MonkeyPatch,
+    caplog: pytest.LogCaptureFixture,
+    keycloak_sink_env: KeycloakConnector,
+) -> None:
+    """A vault: → keycloak: move sets the user password; value stays server-side.
+
+    Asserts the sentinel appears ONLY in the mocked Admin REST
+    reset-password PUT body — not in the op response, the op params, the
+    captured logs, or the persisted audit row.
+    """
+    install_fake_client(monkeypatch, secret={"password": _SENTINEL})
+
+    params = {
+        "from": "vault:secret/db/prod#password",
+        "to": f"keycloak:{_TARGET_NAME}/{_REALM}/{_USERNAME}#password",
+        "reason": "provision keycloak operator credential",
+    }
+
+    with (
+        caplog.at_level(logging.DEBUG),
+        respx.mock(base_url=_KC_BASE_URL, assert_all_called=False) as mock,
+    ):
+        _mount_admin_token(mock)
+        list_route = mock.get(f"/admin/realms/{_REALM}/users").respond(200, json=[_EXISTING_USER])
+        put_route = mock.put(f"/admin/realms/{_REALM}/users/{_USER_UUID}/reset-password").respond(
+            204
+        )
+        result = await _dispatch_move(params)
+
+    assert result.status == "ok", result.error
+
+    # (a) The sink resolved username→UUID and PUT the credential.
+    assert list_route.called, "should have looked up the username → UUID"
+    assert put_route.called, "should have PUT the reset-password credential"
+
+    # (b) The sentinel value rode into the Admin REST PUT body...
+    put_body = json.loads(put_route.calls.last.request.content)
+    assert put_body == {"type": "password", "value": _SENTINEL, "temporary": False}
+
+    # (c) ...and NOWHERE else: response, params, logs.
+    assert result.result == {
+        "status": "moved",
+        "value_sha256": hashlib.sha256(_SENTINEL.encode()).hexdigest(),
+        "length": len(_SENTINEL.encode()),
+    }
+    assert _SENTINEL not in result.model_dump_json()
+    assert _SENTINEL not in json.dumps(params)
+    assert _SENTINEL not in caplog.text
+
+    # (d) ...and not in the persisted audit row (payload + raw_payload).
+    move_rows = await _fetch_move_audit_rows()
+    assert len(move_rows) == 1
+    row = move_rows[0]
+    assert _SENTINEL not in json.dumps(row.payload)
+    assert _SENTINEL not in json.dumps(row.raw_payload)

--- a/docs/codebase/connectors-secret-broker.md
+++ b/docs/codebase/connectors-secret-broker.md
@@ -69,6 +69,20 @@ boundary redaction:
   double-unwrap + `strip_credential_value`; writes via
   `create_or_update_secret` (a single-field body, `cas=None`). Both
   through `vault_client_for_operator`.
+- **`KeycloakCredentialSecretEndpoint`**
+  (`connectors/keycloak/secret_endpoint.py`) — the second adapter (#1578),
+  registered under kind `"keycloak"`. **Sink-only**: keycloak credentials
+  are write-only (Keycloak hashes them; the plaintext is unrecoverable),
+  so `read_secret` raises `NotImplementedError`. Addresses one user
+  credential as `<target>/<realm>/<username>#password` (the `#password`
+  field is the only writable one). `write_secret` resolves the target by
+  name (tenant-scoped `resolve_target`), gets the `KeycloakConnector`
+  instance from the dispatcher's instance cache, resolves username→UUID
+  via `_find_user_uuid`, and PUTs `.../users/{id}/reset-password` with a
+  permanent password CredentialRepresentation via `_write_admin` — it
+  opens no HTTP client of its own. The value is `strip_credential_value`-d
+  before the PUT. This is the broker's **second kind**, so a cross-kind
+  `vault:` → `keycloak:` move proves the initiative's "≥2 kinds" DoD.
 - **`secret_move`** + **`register_secret_broker_operations`**
   (`ops.py`) — the module-level handler and its lifespan registrar.
 
@@ -143,8 +157,9 @@ task (#1579), not the mechanism.
 
 ## Known issues / scope boundaries
 
-- vault-kv is the only adapter kind in this task; further kinds are
-  separate tasks reusing the `SecretEndpoint` contract.
+- vault-kv (source+sink) and keycloak (sink-only, #1578) are the
+  registered adapter kinds; further kinds are separate tasks reusing the
+  `SecretEndpoint` contract.
 - The vault adapter forwards the `ref` to hvac's `path=` and defaults the
   mount to `"secret"`; a non-default mount is a richer-ref-grammar
   follow-up, not wired here.


### PR DESCRIPTION
## Summary

- Adds a `keycloak`-kind `SecretEndpoint` **sink** so a `secret.move` can land a credential in a Keycloak user's password — the broker's **second** connector kind, which proves the G0.22 "≥2 kinds" cross-kind move surface (`vault:secret/...#password` → `keycloak:<target>/<realm>/<user>#password`).
- The sink reuses the existing Keycloak admin-write path unchanged: it resolves the `KeycloakConnector` from the dispatcher's instance cache and drives `_find_user_uuid` (username→UUID) + `_write_admin` (`PUT .../users/{id}/reset-password` with a permanent password CredentialRepresentation). It opens no HTTP client of its own.
- Honors the Initiative invariant by construction: the value is read once from the in-memory `SecretMaterial` on the write path, `strip_credential_value`-d (matching the existing reset-password path), and PUT to Keycloak — it never enters op params, the response, a log event, or the audit row.
- Keycloak credentials are write-only (Keycloak hashes them; the plaintext is unrecoverable), so the source side raises a clear `NotImplementedError`.

## Test plan

- [x] `uv run ruff check src/ tests/` — clean
- [x] `uv run ruff format --check src/ tests/` — clean
- [x] `uv run mypy src/` — clean (463 source files)
- [x] `python3 .claude/hooks/code-quality.py --diff` — 0 blockers, 0 warnings
- [x] New cross-kind pytest `tests/test_secret_broker_keycloak_sink.py` — 8 passed. Drives a `vault:` source → `keycloak:` sink move with a sentinel value and asserts the sentinel appears in the mocked Keycloak Admin `reset-password` PUT body and **nowhere else** — not in the `secret.move` op params, the op response JSON, the captured log records, or the persisted audit row (`payload` + `raw_payload`).
- [x] `read_secret` on the keycloak kind raises `NotImplementedError` (write-only sink) — asserted.
- [x] Ref-grammar rejection (`#field != password`, wrong segment count, empty segment) — asserted.
- [x] `git status cli/internal/api/client.gen.go` shows no change — no new REST route, no OpenAPI/CLI regen.

## Out of scope

- Approval-queue gating of `secret.move` (#1579), the `meho secret move` CLI verb + OpenAPI regen (#1580), and the docs page (#1581) — separate sibling tasks reusing this contract.
- A keycloak **source** (read) adapter beyond the unsupported-error — keycloak is write-only here.

<!-- auto-implement-issue: fresh, iteration 1 -->

Closes #1578
