### PR TITLE
fix(audit): shield SSE disconnect-path audit write against double cancellation (#1599)

### DIFF
--- a/backend/src/meho_backplane/audit.py
+++ b/backend/src/meho_backplane/audit.py
@@ -757,7 +757,9 @@ class AuditMiddleware:
         # out of the inner app; the audit row for the now-closed session
         # is still written (the ``result`` holder is fully populated by
         # then) before the cancellation propagates to unwind the task
-        # tree per asyncio's contract.
+        # tree per asyncio's contract. That disconnect-path write is
+        # shielded (#1599) so a second cancellation mid-INSERT cannot
+        # silently drop the row — see the ``except`` arm below.
         buffered: list[Message] = []
         result = _InnerAppResult()
         try:
@@ -775,13 +777,56 @@ class AuditMiddleware:
             # sent on the first yield; write the audit row for the closed
             # session, then re-raise to unwind the task tree (Sonar
             # S7497 / asyncio cancellation contract).
-            await self._finalize(
-                scope=scope,
-                send=send,
-                buffered=buffered,
-                result=result,
-                duration_ms=round((time.monotonic() - start) * 1000, 2),
+            #
+            # The write is run as a shielded task (#1599): a *second*
+            # ``CancelledError`` delivered while ``_finalize`` is awaiting
+            # the audit INSERT (task-tree teardown, server shutdown, an
+            # enclosing ``timeout()`` or anyio cancel scope) would
+            # otherwise propagate straight out of a bare ``await`` —
+            # ``CancelledError`` is a ``BaseException``, so ``_finalize``'s
+            # ``except Exception`` arm never sees it and the row is dropped
+            # with no log line at all.
+            #
+            # ``ensure_future`` schedules the write on the loop and we keep
+            # a strong reference (the loop holds only a weak one). We then
+            # drain it to completion under ``asyncio.shield``. The drain is
+            # a loop, not a single ``await``: cancellation can be delivered
+            # repeatedly (an ASGI server re-cancelling the task on a
+            # half-closed disconnect, an enclosing anyio cancel scope that
+            # is *level-triggered* and re-raises at every checkpoint while
+            # it stays cancelled), so a single ``await shield(write)`` may
+            # be interrupted before the shielded task finishes. Re-awaiting
+            # under a fresh shield each iteration lets the write run to
+            # completion regardless of how many cancellations are
+            # redelivered. The shielded task itself is never cancelled by
+            # these (that is what ``shield`` guarantees); only our wait is.
+            # Once the write is done we re-raise the original ``cancelled``
+            # so the disconnect is honored, without suppressing it (no
+            # ``Task.uncancel()``).
+            write = asyncio.ensure_future(
+                self._finalize(
+                    scope=scope,
+                    send=send,
+                    buffered=buffered,
+                    result=result,
+                    duration_ms=round((time.monotonic() - start) * 1000, 2),
+                ),
             )
+            while not write.done():
+                try:
+                    await asyncio.shield(write)
+                except asyncio.CancelledError:
+                    # A redelivered cancellation interrupted the wait, not
+                    # the shielded write. Loop to finish draining it; the
+                    # original ``cancelled`` is re-raised below to honor the
+                    # disconnect.
+                    continue
+            # Surface a ``_finalize`` failure (the handler itself raised);
+            # ``write.result()`` re-raises it. An SSE disconnect never
+            # populates ``handler_exc`` (the inner app only catches
+            # ``Exception``), so a cleanly-closed stream's write returns
+            # ``None`` here.
+            write.result()
             raise cancelled
 
         duration_ms = round((time.monotonic() - start) * 1000, 2)

--- a/backend/tests/test_api_v1_feed.py
+++ b/backend/tests/test_api_v1_feed.py
@@ -697,6 +697,197 @@ class TestSseStreamsThroughMiddleware:
         assert rows[0].method == "GET"
         assert rows[0].status_code == 200
 
+    async def test_double_cancelled_disconnect_still_writes_audit_row(
+        self,
+        _feed_env: None,
+        monkeypatch: pytest.MonkeyPatch,
+    ) -> None:
+        """A second cancellation mid-INSERT does not drop the disconnect-path row (#1599).
+
+        Drives ``RequestContextMiddleware(AuditMiddleware(app))`` as a raw
+        ASGI callable (the same seam as
+        ``test_first_chunk_forwarded_before_inner_generator_completes``)
+        and reproduces a production SSE disconnect by **cancelling the ASGI
+        task** while the feed generator is suspended — which is how a real
+        ASGI server (uvicorn, ``asgi.spec_version >= 2.4``) signals a
+        client disconnect: it cancels the task running the app. That
+        cancellation raises out of the suspended generator, past
+        ``_run_inner_app_buffered``'s ``except Exception`` (``CancelledError``
+        is a ``BaseException``), and into ``AuditMiddleware.__call__``'s
+        ``except asyncio.CancelledError`` arm — the disconnect-path audit
+        write under test.
+
+        The ``http.disconnect`` / ``receive``-listener route is *not* used:
+        under Starlette's ``spec_version < 2.4`` task-group branch the
+        disconnect listener cancels the stream inside the response's own
+        anyio cancel scope, which absorbs the ``CancelledError`` so the
+        response returns normally and the row is written on the *normal*
+        path — never exercising the ``except`` arm. Pinning
+        ``spec_version="2.4"`` selects the branch that streams directly, so
+        a task-level cancel propagates the way a real disconnect does.
+
+        While the disconnect-path INSERT is in flight, the instrumented
+        write delivers a **second** ``task.cancel()`` — the task-tree
+        teardown / server-shutdown / enclosing-``timeout()`` interleaving
+        the issue describes. With the shielded write the row still commits:
+        the cancellation hits ``await asyncio.shield(write)`` (not the write
+        task), the fix drains the write to completion, then re-raises so
+        cancellation is honored. The post-run ``audit_log`` table carries
+        exactly one row for ``GET /api/v1/feed``.
+
+        This test *discriminates*: against a variant where the
+        disconnect-path ``_finalize`` is awaited unshielded, the second
+        cancellation interrupts the in-flight ``_write_audit_row`` await
+        (``CancelledError`` bypasses ``_finalize``'s ``except Exception``
+        arm) and zero rows are written → ``write_committed`` stays False and
+        ``len(rows) == 1`` fails. Adversarially verified against that
+        broken variant during implementation.
+        """
+        from sqlalchemy import select
+
+        import meho_backplane.audit as audit_module
+        from meho_backplane.db.engine import get_sessionmaker
+        from meho_backplane.db.models import AuditLog
+        from tests._vault_fakes import install_fake_vault
+
+        first_frame = _sse_frame(_make_event(), "1715600000000-0")
+        first_body_seen = asyncio.Event()
+        # Set only in cleanup. The generator must NOT return on its own —
+        # the *only* way out of its post-yield suspension is the disconnect
+        # cancellation that drives ``__call__``'s ``except`` arm. A
+        # generator that could return would race the normal stream-end path
+        # and the test would no longer isolate the disconnect branch.
+        teardown = asyncio.Event()
+
+        async def _one_then_block(*_args: object, **_kwargs: object) -> AsyncIterator[str]:
+            yield first_frame
+            await teardown.wait()
+
+        import meho_backplane.api.v1.feed as feed_module
+
+        monkeypatch.setattr(feed_module, "_feed_generator", _one_then_block)
+
+        # The ASGI task is bound below; the in-flight write closes over it.
+        task_holder: dict[str, asyncio.Task[None]] = {}
+        write_committed = False
+
+        # Wrap the audit INSERT so the SECOND cancellation is delivered
+        # *while the disconnect-path write is in flight*. By the time this
+        # runs we are provably inside ``__call__``'s ``except CancelledError``
+        # arm — it is the only caller of ``_finalize`` for a generator that
+        # never returns — so cancelling the task here is the "second cancel
+        # mid-INSERT" the issue describes, with no race against the normal
+        # path.
+        real_write_audit_row = audit_module._write_audit_row
+
+        async def _instrumented_write(**kwargs: object) -> None:
+            nonlocal write_committed
+            # Deliver the second cancellation, then yield so it is raised at
+            # the parent's ``await asyncio.shield(write)`` before this
+            # shielded write proceeds. ``shield`` keeps the cancel off this
+            # (the write) task; the fix drains us to completion here.
+            task_holder["task"].cancel()
+            await asyncio.sleep(0)
+            await real_write_audit_row(**kwargs)  # type: ignore[arg-type]
+            write_committed = True
+
+        monkeypatch.setattr(audit_module, "_write_audit_row", _instrumented_write)
+
+        install_fake_vault(monkeypatch)
+        key = make_rsa_keypair("kid-sse-dbl-cancel")
+        token = mint_token(
+            key,
+            sub="op-sse-dbl-cancel",
+            tenant_id=str(_TENANT_A),
+            tenant_role=TenantRole.OPERATOR.value,
+        )
+
+        inner = FastAPI()
+        inner.include_router(feed_router)
+        asgi_app = RequestContextMiddleware(AuditMiddleware(inner))
+
+        scope = {
+            "type": "http",
+            # ``spec_version="2.4"`` selects Starlette's direct-stream
+            # branch (no disconnect-listener cancel scope), so a task-level
+            # cancel propagates the way a real server-signalled disconnect
+            # does — into the middleware's ``except`` arm.
+            "asgi": {"version": "3.0", "spec_version": "2.4"},
+            "http_version": "1.1",
+            "method": "GET",
+            "path": "/api/v1/feed",
+            "raw_path": b"/api/v1/feed",
+            "query_string": b"",
+            "root_path": "",
+            "scheme": "https",
+            "server": ("testserver", 443),
+            "client": ("testclient", 50000),
+            "headers": [(b"authorization", f"Bearer {token}".encode())],
+        }
+
+        request_drained = False
+
+        async def receive() -> dict[str, object]:
+            # Drain the (empty) request body once, then behave like a
+            # still-connected client (block). The disconnect is signalled by
+            # cancelling the ASGI task, not via this channel.
+            nonlocal request_drained
+            if not request_drained:
+                request_drained = True
+                return {"type": "http.request", "body": b"", "more_body": False}
+            await teardown.wait()
+            return {"type": "http.disconnect"}
+
+        captured_status: dict[str, int] = {}
+
+        async def send(message: dict[str, object]) -> None:
+            if message["type"] == "http.response.start":
+                captured_status["status"] = int(message["status"])  # type: ignore[arg-type]
+            elif message["type"] == "http.response.body" and message.get("body"):
+                first_body_seen.set()
+
+        with respx.mock as mock_router:
+            mock_discovery_and_jwks(mock_router, public_jwks(key))
+            task = asyncio.ensure_future(asgi_app(scope, receive, send))
+            task_holder["task"] = task
+            try:
+                # 1. Let the first SSE frame reach the wire (response has
+                #    started; the generator is now suspended on ``teardown``).
+                async with asyncio.timeout(5.0):
+                    await first_body_seen.wait()
+                assert captured_status["status"] == 200
+
+                # 2. Signal the client disconnect by cancelling the task
+                #    (FIRST cancel). This raises out of the suspended
+                #    generator into the middleware's ``except`` arm, which
+                #    schedules the shielded write; the instrumented INSERT
+                #    then delivers the SECOND cancel mid-write.
+                task.cancel()
+
+                # 3. The task must end cancelled (cancellation honored, not
+                #    suppressed).
+                with pytest.raises(asyncio.CancelledError):
+                    async with asyncio.timeout(5.0):
+                        await task
+            finally:
+                teardown.set()
+
+        # The shielded write committed the row despite the double cancel.
+        assert write_committed, "disconnect-path audit write did not run to completion"
+
+        # Exactly one audit row for the disconnected feed request — no
+        # silent drop.
+        sessionmaker = get_sessionmaker()
+        async with sessionmaker() as session:
+            rows = list(
+                (await session.execute(select(AuditLog).where(AuditLog.path == "/api/v1/feed")))
+                .scalars()
+                .all()
+            )
+        assert len(rows) == 1
+        assert rows[0].operator_sub == "op-sse-dbl-cancel"
+        assert rows[0].method == "GET"
+
 
 # ---------------------------------------------------------------------------
 # Generator — every body-shaping AC


### PR DESCRIPTION
## Summary

- On an SSE client disconnect, `AuditMiddleware.__call__` catches `CancelledError` and writes the audit row via `_finalize` before re-raising (#1389). That await was **unshielded**: a *second* `CancelledError` arriving while the audit INSERT was in flight (task-tree teardown, server shutdown, an enclosing `timeout()`/anyio cancel scope) propagated straight out of the bare `await`, bypassed `_finalize`'s `except Exception` arm (`CancelledError` is a `BaseException`), and dropped the row **with no log line** — a silent hole in the "every authenticated action gets exactly one row" fail-closed contract.
- Fix: schedule the disconnect-path write as a task (strong reference kept) and drain it to completion under `asyncio.shield` in a loop, so redelivered/level-triggered cancellations interrupt only the *wait*, never the shielded write. The original `CancelledError` is re-raised once the row commits — cancellation is honored, enclosing `TaskGroup`/`timeout()` semantics unchanged (no `Task.uncancel()` suppression).
- Shielding applies **only** to the `CancelledError` arm; the normal (non-disconnect) return path is byte-for-byte unchanged. No FastAPI route/schema touched → no OpenAPI regen.

## Test plan

- [x] New `test_double_cancelled_disconnect_still_writes_audit_row` in `TestSseStreamsThroughMiddleware` drives the middleware as a raw ASGI app, reproduces a production disconnect by cancelling the ASGI task while the feed generator is suspended (how uvicorn signals a disconnect under `asgi.spec_version >= 2.4`), and delivers a **second** cancellation while the INSERT is in flight — asserts exactly one `audit_log` row for the disconnected `GET /api/v1/feed`, and that cancellation is still re-raised.
- [x] **Discriminating** (AC#4): adversarially verified — against an unshielded variant the second cancel drops the row and the test FAILS (`disconnect-path audit write did not run to completion`); restored, it passes.
- [x] `uv run ruff check src/ tests/` — clean (the one pre-existing RUF034 lives in `alembic/`, outside the `src/ tests/` CI scope, and is unchanged on `main`).
- [x] `uv run ruff format --check src/ tests/` — clean.
- [x] `uv run mypy src/` (CI gate, strict) — `Success: no issues found in 464 source files`.
- [x] `uv run pytest tests/test_api_v1_feed.py tests/test_audit_middleware.py` — 43 passed, 1 skipped (Docker-gated integration). Confirms AC#3: non-streaming JSON routes + the normal stream-end path retain exact current behavior.

## Acceptance criteria

- [x] On an SSE disconnect, the audit row is written even under a second cancellation mid-INSERT; never dropped without at least one structured log line.
- [x] `CancelledError` re-raised after the write (no suppression without `uncancel()`); `TaskGroup`/`timeout()` semantics unchanged.
- [x] Non-streaming JSON routes + normal stream-end path retain exact current behavior (existing tests green).
- [x] New `TestSseStreamsThroughMiddleware` test drives the disconnect/cancellation branch, asserts exactly one row, and fails against the skipped/dropped-write variant.
- [x] ruff check + ruff format --check + mypy + the two pytest files all green (scoped to the CI gate; see Test plan note on the pre-existing alembic-only RUF034).

## Out of scope

- Non-streaming JSON route buffering / the fail-closed-500 swap — untouched.
- Broadcast/publish-on-write (`_publish_broadcast_event`) — unchanged.
- The buffered-vs-streamed split from #1585 — not re-architected.

### Adjacent findings (deferred, not in scope)

- Pre-existing `RUF034` in `backend/alembic/versions/0023_create_approval_request.py:228` (`sa.text("'{}'") if is_postgres else sa.text("'{}'")`) — present on `main`, outside the `src/ tests/` CI lint scope.
- `backend/tests/test_api_v1_feed.py` carries pre-existing strict-mypy noise (`call-overload`/`unused-ignore` on the raw-ASGI `send`/`int(message["status"])` pattern, line 605). The new test mirrors that established in-file pattern; the test tree is intentionally outside the `mypy src/` CI gate.

<!-- auto-implement-issue: fresh, iteration 1 -->

Closes #1599


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved reliability of audit logging when SSE streams disconnect unexpectedly. Audit records are now guaranteed to be written even if cancellation errors occur during the write operation.

* **Tests**
  * Added regression test to verify proper audit logging behavior during stream disconnections under various cancellation scenarios.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->