### PR TITLE
fix(db): tolerate DB-ahead /ready so helm auto-rollback survives pre-upgrade migrations (#1607)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -117,6 +117,26 @@ connector-related release-notes line.
   unavailable. A build-time guard test asserts every declared composite
   `op_id` resolves against the ingested spec so a future drift fails CI
   rather than at runtime (#1602 / #1603).
+- Defuse the pre-upgrade-migration ↔ auto-rollback trap that made
+  `helm --atomic` dead on arrival for any release carrying a migration
+  (live ~2.5h outage, 2026-06-08): the `db` readiness probe demanded
+  strict `current == head` revision equality, so once the
+  `pre-install,pre-upgrade` Job committed the new migration — a side
+  effect `helm rollback` never reverts — both the still-running prior
+  pods and any rolled-back pods failed `/ready` forever
+  (`current=0037 head=0036`). The probe now tolerates a database
+  **ahead** of the image's head (revision unknown to the image's
+  `versions/` directory ⇒ stamped by a newer release), reporting
+  `ok=true` with `db_ahead=true` in the detail; this leans on the
+  CI-enforced additive-only `upgrade()` contract that already
+  guarantees older code reads newer schemas. A DB *behind* head (missed
+  migration) still fails readiness, as does a missing pgvector
+  extension. The migration ↔ rollback contract, the rejected
+  `pre-rollback` `alembic downgrade` alternative (Helm renders rollback
+  hooks from the *previous* release's manifests — the old image lacks
+  the newer migration scripts), and a failure-injection rollback drill
+  are documented in `docs/codebase/migrations.md` and
+  `docs/RELEASING.md` § 6b (#1607).
 
 ## [0.12.0] - 2026-06-08
 

--- a/backend/src/meho_backplane/db/migrations.py
+++ b/backend/src/meho_backplane/db/migrations.py
@@ -3,15 +3,28 @@
 
 """DB-migration-state readiness probe + Alembic configuration helpers.
 
-The probe answers a single operational question: *is the database
-schema at the revision this code expects?* Three failure modes — DB
+The probe answers a single operational question: *can this code run
+against the database's current schema?* Three failure modes — DB
 unreachable, ``alembic_version`` table missing, current revision
-diverges from the code's head — collapse into a single
+**behind** the code's head — collapse into a single
 :class:`~meho_backplane.health.ProbeResult` with ``ok=False`` and a
 short structured detail string. The probe is registered against the
 shared readiness registry from :mod:`meho_backplane.main`'s lifespan
 hook so ``/ready`` returns 503 (and the kubelet keeps the pod out of
-service traffic) until the schema matches.
+service traffic) until the schema is compatible.
+
+The comparison is deliberately **not** strict equality: a database
+*ahead* of the code's head (a revision this image's ``versions/``
+directory cannot resolve) reports ``ok=True``. That is the schema
+state every ``helm rollback`` / ``--atomic`` auto-rollback produces —
+the ``pre-upgrade`` migration Job's commit survives the manifest
+rollback (Helm reverts manifests only, never hook side effects), so
+the rolled-back image must tolerate the newer schema or the rollback
+is dead on arrival (#1607, 2026-06-08 outage). The additive-only
+``upgrade()`` contract enforced by
+``scripts/ci/check_migration_compat.py`` is what makes the newer
+schema safe to run against. See
+``docs/codebase/migrations.md`` § "Rollback contract".
 
 The helper :func:`alembic_config` resolves and caches the on-disk
 ``alembic.ini``; both the probe and the migration runner (T29) share
@@ -34,6 +47,7 @@ from pathlib import Path
 from alembic.config import Config
 from alembic.runtime.migration import MigrationContext
 from alembic.script import ScriptDirectory
+from alembic.util.exc import CommandError
 from sqlalchemy import text
 from sqlalchemy.engine import Connection
 
@@ -173,6 +187,26 @@ def _read_current_revision(connection: Connection) -> str | None:
     return context.get_current_revision()
 
 
+def _revision_known(script: ScriptDirectory, revision: str) -> bool:
+    """Return ``True`` iff *revision* resolves in this image's ``versions/``.
+
+    ``alembic_version`` has a single writer — ``alembic upgrade head``
+    run by the chart's pre-upgrade migration Job — so a revision the
+    on-disk :class:`~alembic.script.ScriptDirectory` cannot resolve
+    was stamped by a *newer* image: the database is ahead of this
+    code, not diverged from it. Alembic signals the unknown id with
+    :class:`alembic.util.exc.CommandError` ("Can't locate revision
+    identified by ..."); only that error is treated as "unknown".
+    Anything else propagates to the probe's catch-all so the probe
+    stays fail-closed (``check_failed: <ExcClass>``).
+    """
+    try:
+        script.get_revision(revision)
+    except CommandError:
+        return False
+    return True
+
+
 def _check_pgvector_extension(connection: Connection) -> bool:
     """Return ``True`` iff the ``vector`` extension is enabled.
 
@@ -207,17 +241,30 @@ def _check_pgvector_extension(connection: Connection) -> bool:
 async def db_migration_probe() -> ProbeResult:
     """Compare the DB's Alembic revision to the code's head.
 
-    Three observable outcomes:
+    Four observable outcomes:
 
     * **healthy** — database reachable, ``alembic_version`` table
       readable, current revision matches the head defined by the
       ``versions/`` directory on disk. Detail carries
       ``revision=<sha>``.
-    * **unhealthy (revision diverged)** — current and head both
-      resolved but they differ. Detail carries
-      ``current=<sha> head=<sha>``. Operators see this when a
-      forward-deploy missed an ``alembic upgrade head`` or when a
-      rollback returned the image but not the schema.
+    * **healthy (DB ahead)** — current is a revision this image's
+      ``versions/`` directory cannot resolve, i.e. it was stamped by
+      a newer release. This is the expected state after a
+      ``helm rollback`` / ``--atomic`` auto-rollback: Helm reverts
+      manifests only, never the pre-upgrade migration Job's commit,
+      and the additive-only ``upgrade()`` contract
+      (``scripts/ci/check_migration_compat.py``) guarantees the
+      newer schema is readable by this code. Detail carries
+      ``current=<sha> head=<sha> db_ahead=true`` so the tolerated
+      mismatch stays visible on ``/ready``. Trade-off (#1607): a
+      corrupted / foreign ``alembic_version`` value is
+      indistinguishable from "newer release" and now passes
+      readiness — accepted, because the dangerous direction (DB
+      *behind* the code, schema objects missing) still fails.
+    * **unhealthy (DB behind)** — current resolves in this image's
+      ``versions/`` but differs from head: a forward-deploy missed
+      its ``alembic upgrade head``. Detail carries
+      ``current=<sha> head=<sha>``.
     * **unhealthy (DB / config error)** — DB unreachable, table
       missing, ini missing, etc. Detail carries
       ``check_failed: <ExcClass>`` — the class name only, not the
@@ -233,9 +280,9 @@ async def db_migration_probe() -> ProbeResult:
     drift where an operator manually dropped the extension or a
     backup restore brought back the schema without the catalog
     entry. The detail in that case is ``revision=<sha>
-    pgvector=missing`` (revision still matches head — only the
-    extension is gone). SQLite skips this check; the dialect has no
-    ``pg_extension`` catalog.
+    pgvector=missing`` — ``<sha>`` is the DB's current revision
+    (equal to head except on the db-ahead path). SQLite skips this
+    check; the dialect has no ``pg_extension`` catalog.
 
     The function is ``async`` because the canonical SQLAlchemy 2.x
     pattern reads the version through an ``AsyncEngine.connect()`` /
@@ -245,12 +292,18 @@ async def db_migration_probe() -> ProbeResult:
     pgvector_ok = True  # default for non-PG dialects; PG branch overrides below
     try:
         cfg = alembic_config()
-        head = ScriptDirectory.from_config(cfg).get_current_head()
+        script = ScriptDirectory.from_config(cfg)
+        head = script.get_current_head()
         engine = get_engine()
         async with engine.connect() as conn:
             current = await conn.run_sync(_read_current_revision)
             if engine.dialect.name == "postgresql":
                 pgvector_ok = await conn.run_sync(_check_pgvector_extension)
+        # The verdict stays inside the try: its db-ahead branch walks
+        # the script directory again (``_revision_known``), and an
+        # unexpected error there must fold into ``check_failed`` —
+        # the probe never raises (Task #27 AC #3).
+        return _revision_verdict(script, current, head, pgvector_ok)
     except Exception as exc:
         _log.warning(
             "db_migration_probe_failed",
@@ -261,6 +314,21 @@ async def db_migration_probe() -> ProbeResult:
             ok=False,
             detail=f"check_failed: {type(exc).__name__}",
         )
+
+
+def _revision_verdict(
+    script: ScriptDirectory,
+    current: str | None,
+    head: str | None,
+    pgvector_ok: bool,
+) -> ProbeResult:
+    """Fold the fetched migration state into a single :class:`ProbeResult`.
+
+    Pure decision logic, split from :func:`db_migration_probe` so the
+    async I/O shell stays small. Outcome matrix in the probe's
+    docstring; rollback rationale in the module docstring and
+    ``docs/codebase/migrations.md`` § "Rollback contract".
+    """
     if head is None and current is None:
         # No migrations on disk and none applied. Treat as not-ready
         # rather than vacuously-ready: the chassis ships with an
@@ -271,24 +339,45 @@ async def db_migration_probe() -> ProbeResult:
             ok=False,
             detail="no_migrations: head and current are both unset",
         )
+    db_ahead = False
     if current != head:
-        return ProbeResult(
-            name="db",
-            ok=False,
-            detail=f"current={current} head={head}",
-        )
+        # A current revision this image's script directory cannot
+        # resolve was stamped by a newer release — the DB is *ahead*,
+        # the post-auto-rollback state (#1607). Tolerated: the
+        # additive-only upgrade() contract means this code still runs
+        # against the newer schema. ``current is None`` (fresh DB,
+        # migrations never ran) and a *resolvable* mismatch (DB
+        # behind head) keep failing. ``head is None`` with a stamped
+        # DB (image shipped without its ``versions/``) is a packaging
+        # defect, not a rollback — also keeps failing.
+        db_ahead = current is not None and head is not None and not _revision_known(script, current)
+        if not db_ahead:
+            return ProbeResult(
+                name="db",
+                ok=False,
+                detail=f"current={current} head={head}",
+            )
     if not pgvector_ok:
-        # Revision matches head but the pgvector extension is gone.
-        # G0.4-T6 (#263) failure mode: operator dropped the extension
-        # post-deploy or a backup restore brought back the schema
-        # without the catalog entry. Surfaced loudly on ``/ready`` so
-        # the kubelet pulls the pod out of service traffic; retrieval
-        # writes / reads against the ``vector(384)`` column would
-        # silently degrade otherwise.
+        # Schema revision is compatible but the pgvector extension is
+        # gone. G0.4-T6 (#263) failure mode: operator dropped the
+        # extension post-deploy or a backup restore brought back the
+        # schema without the catalog entry. Surfaced loudly on
+        # ``/ready`` so the kubelet pulls the pod out of service
+        # traffic; retrieval writes / reads against the
+        # ``vector(384)`` column would silently degrade otherwise.
+        # ``current`` (== head except on the db-ahead path, where it
+        # is the DB's actual revision) keeps the detail truthful in
+        # both cases.
         return ProbeResult(
             name="db",
             ok=False,
-            detail=f"revision={head} pgvector=missing",
+            detail=f"revision={current} pgvector=missing",
+        )
+    if db_ahead:
+        return ProbeResult(
+            name="db",
+            ok=True,
+            detail=f"current={current} head={head} db_ahead=true",
         )
     return ProbeResult(
         name="db",

--- a/backend/tests/test_alembic_probe.py
+++ b/backend/tests/test_alembic_probe.py
@@ -13,6 +13,12 @@ Coverage matrix (Task #27 acceptance criteria #3, #4):
 * ``/api/v1/health.db.migrated`` reflects the probe outcome — the
   response field is no longer hardcoded ``None``.
 
+Plus the #1607 rollback-tolerance matrix: the DB *ahead* of the
+image's head (the post-``helm rollback`` state — the pre-upgrade
+migration Job's commit survives a manifest-only rollback) is healthy,
+while the DB *behind* head stays unhealthy, and the pgvector gate
+still applies on the ahead path.
+
 The aiosqlite tests stay always-on; they exercise the probe's
 revision comparison machinery without needing Docker. The probe's
 async-engine code path is the same one a PG deployment hits — the
@@ -28,6 +34,7 @@ from unittest.mock import patch
 
 import pytest
 from alembic.script import ScriptDirectory
+from alembic.util.exc import CommandError
 from fastapi.testclient import TestClient
 from sqlalchemy import text
 from sqlalchemy.ext.asyncio import AsyncEngine
@@ -234,6 +241,140 @@ async def test_probe_registers_with_async_runner(
     assert len(results) == 1
     assert results[0].name == "db"
     assert isinstance(results[0], ProbeResult)
+
+
+# ---------------------------------------------------------------------------
+# #1607 rollback tolerance — DB ahead of the image's head
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.asyncio
+async def test_probe_healthy_when_db_ahead_of_head(
+    sqlite_engine: AsyncEngine,
+) -> None:
+    """DB stamped with a revision this image doesn't ship → ``ok=True``.
+
+    The post-auto-rollback state (#1607): the ``pre-upgrade``
+    migration Job committed ``0037``, the new release failed
+    readiness, and Helm rolled the Deployment back to the prior image
+    whose ``versions/`` ends at ``0036``. Helm reverts manifests only
+    — the schema stays at ``0037``. The additive-only ``upgrade()``
+    contract (``scripts/ci/check_migration_compat.py``) makes the
+    newer schema readable by the older code, so the rolled-back pod
+    must report Ready; the strict ``current == head`` equality this
+    test replaces is what made the 2026-06-08 auto-rollback dead on
+    arrival. ``get_revision`` raising ``CommandError`` mirrors
+    Alembic's real unknown-revision behaviour (verified on 1.18.4).
+    """
+    await _create_alembic_version_table(sqlite_engine, "0037")
+
+    with patch(
+        "meho_backplane.db.migrations.ScriptDirectory.from_config",
+    ) as fake_from_config:
+        fake_script = fake_from_config.return_value
+        fake_script.get_current_head.return_value = "0036"
+        fake_script.get_revision.side_effect = CommandError(
+            "Can't locate revision identified by '0037'",
+        )
+        result = await db_migration_probe()
+
+    assert result.ok is True
+    assert result.detail == "current=0037 head=0036 db_ahead=true"
+    fake_script.get_revision.assert_called_once_with("0037")
+
+
+@pytest.mark.asyncio
+async def test_probe_unhealthy_when_db_behind_head(
+    sqlite_engine: AsyncEngine,
+) -> None:
+    """DB stamped with an *older* revision this image knows → ``ok=False``.
+
+    The dangerous direction: the code expects schema objects migration
+    ``0036`` creates and the DB is still at ``0035`` (a forward-deploy
+    missed its ``alembic upgrade head``). ``0035`` resolves in this
+    image's script directory, so this is not the db-ahead rollback
+    state — the fail-closed contract is preserved.
+    """
+    await _create_alembic_version_table(sqlite_engine, "0035")
+
+    with patch(
+        "meho_backplane.db.migrations.ScriptDirectory.from_config",
+    ) as fake_from_config:
+        fake_script = fake_from_config.return_value
+        fake_script.get_current_head.return_value = "0036"
+        # Default Mock behaviour: ``get_revision("0035")`` returns a
+        # Mock Script — the revision is *known* to this image.
+        result = await db_migration_probe()
+
+    assert result.ok is False
+    assert result.detail == "current=0035 head=0036"
+    fake_script.get_revision.assert_called_once_with("0035")
+
+
+@pytest.mark.asyncio
+async def test_probe_db_ahead_still_fails_when_pgvector_missing(
+    sqlite_engine: AsyncEngine,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """The db-ahead tolerance must not bypass the pgvector gate.
+
+    A rolled-back pod on PostgreSQL with the ``vector`` extension
+    dropped out-of-band is still unready — the revision tolerance and
+    the extension check are orthogonal, and the ahead path joins the
+    pgvector gate rather than short-circuiting around it. The detail
+    reports the DB's actual revision (``0037``), not the image head.
+    """
+    await _create_alembic_version_table(sqlite_engine, "0037")
+
+    with patch(
+        "meho_backplane.db.migrations.ScriptDirectory.from_config",
+    ) as fake_from_config:
+        fake_script = fake_from_config.return_value
+        fake_script.get_current_head.return_value = "0036"
+        fake_script.get_revision.side_effect = CommandError(
+            "Can't locate revision identified by '0037'",
+        )
+        monkeypatch.setattr(sqlite_engine.dialect, "name", "postgresql", raising=False)
+        with patch(
+            "meho_backplane.db.migrations._check_pgvector_extension",
+            return_value=False,
+        ):
+            result = await db_migration_probe()
+
+    assert result.ok is False
+    assert result.detail == "revision=0037 pgvector=missing"
+
+
+@pytest.mark.asyncio
+async def test_probe_db_ahead_healthy_on_postgres_with_pgvector(
+    sqlite_engine: AsyncEngine,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """Rolled-back pod on PostgreSQL with pgvector intact → ``ok=True``.
+
+    The full production rollback shape: PG dialect, schema ahead,
+    extension present. Pins that the ahead path emits the
+    ``db_ahead=true`` detail after the pgvector gate passes.
+    """
+    await _create_alembic_version_table(sqlite_engine, "0037")
+
+    with patch(
+        "meho_backplane.db.migrations.ScriptDirectory.from_config",
+    ) as fake_from_config:
+        fake_script = fake_from_config.return_value
+        fake_script.get_current_head.return_value = "0036"
+        fake_script.get_revision.side_effect = CommandError(
+            "Can't locate revision identified by '0037'",
+        )
+        monkeypatch.setattr(sqlite_engine.dialect, "name", "postgresql", raising=False)
+        with patch(
+            "meho_backplane.db.migrations._check_pgvector_extension",
+            return_value=True,
+        ):
+            result = await db_migration_probe()
+
+    assert result.ok is True
+    assert result.detail == "current=0037 head=0036 db_ahead=true"
 
 
 # ---------------------------------------------------------------------------

--- a/deploy/charts/meho/templates/migration-job.yaml
+++ b/deploy/charts/meho/templates/migration-job.yaml
@@ -26,6 +26,18 @@ metadata:
     # hook resources resolve). The negative weight is documentary — even
     # at weight 0 the migration Job would precede the Deployment because
     # only hooks weighted in this Job render at the pre-install phase.
+    # ROLLBACK CONTRACT (#1607): this hook's schema commit is a side
+    # effect Helm does NOT revert — `helm rollback` / `--atomic`
+    # restores manifests only, so after any rollback across a
+    # migration the DB stays at the *newer* revision. That is safe
+    # (not an outage) only because (a) upgrade() is additive-only
+    # (CI: scripts/ci/check_migration_compat.py) and (b) the backend's
+    # `db` readiness probe tolerates a DB ahead of the image's head.
+    # Do NOT add a pre-rollback `alembic downgrade` hook: rollback
+    # hooks render from the *previous* release's manifests (old image,
+    # which lacks the newer migration scripts) and would brick the
+    # rollback itself. See docs/codebase/migrations.md § "Rollback
+    # contract" and docs/RELEASING.md § 6b.
     helm.sh/hook: pre-install,pre-upgrade
     helm.sh/hook-weight: "-10"
     # `before-hook-creation` lets a fresh `helm upgrade` retry overwrite

--- a/docs/RELEASING.md
+++ b/docs/RELEASING.md
@@ -336,6 +336,62 @@ enabled. Any `"configured": false` with a non-empty `missing_env`
 list is an unfinished provisioning step — name the listed env vars
 into the pod's environment and re-deploy.
 
+### 6b. Rollback drill — the migration ↔ rollback contract
+
+**Contract** (#1607, hardened after the 2026-06-08 outage):
+`helm rollback` / `--atomic` reverts **manifests only** — the
+`pre-install,pre-upgrade` migration Job's schema commit survives the
+rollback (Helm does not track hook side effects). Pods rolled back
+across a migration therefore run against a *newer* schema than their
+code expects. Two enforced invariants make that safe:
+
+1. **Additive-only `upgrade()`** — `scripts/ci/check_migration_compat.py`
+   (CI: `migration-compat.yml`) rejects destructive DDL, so an older
+   image can always read a newer schema.
+2. **DB-ahead-tolerant readiness** — the `db` probe
+   (`backend/src/meho_backplane/db/migrations.py`) reports `ok=true`
+   with detail `current=<newer> head=<older> db_ahead=true` when the
+   DB revision is unknown to the image. DB *behind* head still fails
+   readiness. Full rationale (including why a `pre-rollback`
+   `alembic downgrade` hook cannot work):
+   [`docs/codebase/migrations.md`](codebase/migrations.md) § "Rollback
+   contract".
+
+Never run `alembic downgrade` as part of a deploy or rollback;
+`downgrade()` bodies are the manual escape hatch only. **Caveat:** the
+tolerance lives in the image being rolled back **to** — rolling back
+to a pre-tolerance release (strict `current == head` probe) across a
+migration still bricks readiness; recover those by rolling forward.
+
+**Failure-injection drill** — run on a sandbox (kind/minikube or the
+staging namespace, never prod) when the release carries a migration,
+and whenever the migration Job or the `db` probe changes:
+
+- [ ] 1. Install the prior release `v(n)` (DB at migration `00NN`);
+  wait Ready. Per the caveat above, `v(n)` must already carry the
+  db-ahead-tolerant probe (#1607) — the drill proves the safety net
+  of the release being rolled back *to*.
+- [ ] 2. Upgrade to the candidate `v(n+1)` (carrying `00NN+1`) with
+  readiness deliberately broken, so the rollout must fail and
+  auto-roll-back:
+
+  ```bash
+  helm upgrade meho oci://ghcr.io/evoila/meho-chart \
+    --version <candidate> --reuse-values --atomic --timeout 5m \
+    --set probes.readiness.httpGet.path=/definitely-404
+  ```
+
+- [ ] 3. Confirm the upgrade fails and Helm auto-rolls-back:
+  `helm history meho` shows a rollback revision; pods run the `v(n)`
+  image again.
+- [ ] 4. Assert the rolled-back pods reach `READY 1/1` **without any
+  manual `alembic` command**, and `GET /ready` returns 200 with the
+  `db` check `ok=true`, detail `current=00NN+1 head=00NN
+  db_ahead=true`.
+- [ ] 5. Clean up by rolling **forward**: re-run the upgrade with
+  readiness intact. The DB is already at `00NN+1`; the migration Job
+  re-runs as a no-op (`alembic upgrade head` is idempotent).
+
 ### 7. Post-release
 
 - [ ] Close the release Initiative; update the board / MVP roadmap.
@@ -359,6 +415,9 @@ into the pod's environment and re-deploy.
         configure the env vars per the cited Vault doc; verify gate
         flips to configured (or capture_mode=always for audit_replay
         post-T6)
+[ ] 6b. Rollback drill (releases carrying a migration): broken-readiness
+        upgrade auto-rolls-back; rolled-back pods reach Ready with
+        db_ahead=true and no manual alembic (#1607)
 [ ] 7. Initiative closed; board/roadmap updated; consumers notified
 ```
 
@@ -370,6 +429,15 @@ into the pod's environment and re-deploy.
 - **Empty release notes:** `cli-release.yml` falls back to `[Unreleased]`
   when no `## [X.Y.Z]` section exists at tag time. Always roll (step 2)
   *before* tagging (step 4).
+- **Strict `current == head` readiness vs pre-upgrade migrations
+  (v0.12.0, 2026-06-08, ~2.5h outage):** the migration Job committed
+  `0037` before the Deployment rolled; the new release failed
+  readiness; `--atomic` rolled the manifests back but not the schema,
+  and the restored `v0.11.0` pods failed their own strict `db` probe
+  (`current=0037 head=0036`) forever — recovery required rolling
+  *forward*. Closed by #1607 (db-ahead-tolerant probe + section 6b's
+  drill). Remember: the tolerance must exist in the image being
+  rolled back **to**.
 - **Tagging off a red / cancelled `main` (v0.5.0):** the publish
   workflows have no green-main gate — the `v*` tag publishes whatever
   `main` is. During the v0.5.0 cut, merge-storm concurrency cancellation

--- a/docs/codebase/migrations.md
+++ b/docs/codebase/migrations.md
@@ -144,9 +144,73 @@ Migrations in `upgrade()` must be additive: `create_table`, `add_column`,
 raw `DROP …` / `RENAME …` / `SET NOT NULL` SQL) is forbidden in `upgrade()`.
 
 The CI script `scripts/ci/check_migration_compat.py` enforces this at the AST
-level. Running `alembic downgrade` in production is the rollback path; the
-schema must survive a rollback without manual DB intervention (`helm rollback`
-contract, Goal #11 DoD).
+level. Production **never** runs `alembic downgrade` — rollback is
+image-revert plus forward-compatible schema discipline (`helm rollback`
+contract, Goal #11 DoD). The additive-only rule is what makes that safe: any
+older image can read any newer schema. See the rollback contract below.
+
+## Rollback contract (readiness ↔ migrations, #1607)
+
+The chart applies migrations from a `helm.sh/hook: pre-install,pre-upgrade`
+Job (`deploy/charts/meho/templates/migration-job.yaml`), so the schema moves
+**before** the Deployment rolls. Helm's `helm rollback` / `--atomic` reverts
+**manifests only** — hook side effects such as a committed migration survive
+(documented Helm limitation; hook resources are not tracked as part of the
+release). After any rollback across a migration the database is therefore
+*ahead* of the running image, by design.
+
+Two enforced invariants make that state safe instead of an outage:
+
+1. **Additive-only `upgrade()`** (above, CI-gated by
+   `scripts/ci/check_migration_compat.py` via `migration-compat.yml`) — the
+   older code never depends on schema objects the newer migration removed,
+   because nothing is removed.
+2. **DB-ahead-tolerant readiness** — `db_migration_probe`
+   (`backend/src/meho_backplane/db/migrations.py`) reports `ok=True` with
+   detail `current=<newer> head=<older> db_ahead=true` when the DB's
+   revision does not resolve in the image's `versions/` directory (only a
+   newer release's migration Job can have stamped it). A revision the image
+   *does* know that differs from head means the DB is **behind** — that
+   still fails readiness, as does a fresh unmigrated DB.
+
+Before #1607 the probe demanded strict `current == head` equality, which
+poisoned the deploy lifecycle twice over (live 2026-06-08, v0.12.0): the
+moment the pre-upgrade Job committed `0037`, the *still-running* prior pods
+flipped NotReady (their head was `0036`), and after `--atomic` rolled the
+failed release back, the restored pods could never become Ready either —
+the service could move neither forward nor back without manual `alembic`.
+
+**Why not a `pre-rollback` downgrade hook** (the textbook Helm answer):
+Helm renders rollback hooks from the *previous* release's stored manifests
+(`pkg/action/rollback.go` builds the target release with
+`Hooks: previousRelease.Hooks`), i.e. the **old image** — which does not
+ship the newer migration scripts. `alembic downgrade` must load the script
+of every revision it walks down through, so it dies with `Can't locate
+revision identified by '0037'` (verified against Alembic 1.18.4) and the
+failed hook would block the rollback outright. Even if the scripts were
+available, an unattended downgrade is destructive: `0037`'s `downgrade()`
+drops `doc_collections`, destroying anything written during the
+failed-release window. Automatic downgrades stay banned.
+
+**Trade-offs, accepted in #1607:**
+
+- The probe no longer flags "DB at a revision this image does not know" as
+  a failure, so a corrupted or foreign `alembic_version` value passes
+  readiness. The dangerous direction (DB behind the code — expected tables
+  or columns missing) still fails closed, and the tolerated state stays
+  visible on `/ready` as `db_ahead=true`.
+- The tolerance ships *in the image being rolled back to*. Rolling back to
+  a pre-tolerance image (strict-equality probe) across a migration still
+  bricks readiness — recover by rolling forward.
+
+`downgrade()` bodies remain **mandatory and real** (see `0037`): they are
+the development-time symmetry check and the *manual*, operator-driven
+escape hatch — never part of the automated deploy lifecycle.
+
+What re-arms the trap: a migration that smuggles destructive DDL past the
+compat gate, or a readiness check that reintroduces strict revision
+equality. Both are CI/test-pinned (`test_migration_compat.py`,
+`test_alembic_probe.py`).
 
 ## Async and sync engine interaction
 
@@ -157,6 +221,12 @@ avoid "event loop already running" errors.
 
 ## References
 
+- Task #1607: pre-upgrade hook ↔ auto-rollback trap; db-ahead-tolerant
+  readiness probe (G0.22, 2026-06-08 outage).
+- Helm chart hooks (hook resources unmanaged by the release):
+  <https://helm.sh/docs/topics/charts_hooks/>; `--atomic` rolls back
+  manifests only, not hook side effects:
+  <https://github.com/helm/helm/issues/7158>.
 - PR #1045: the UUID `str()` vs `.hex` incident (G7.1-T5).
 - Task #1095: UUID audit + drift-guard (G0.11 CI hardening).
 - `backend/alembic/versions/0018_seed_rdc_internal_conventions.py`: the


### PR DESCRIPTION
## Summary

- Defuses the SEV-1 deploy-lifecycle trap from the 2026-06-08 outage: the `pre-install,pre-upgrade` alembic Job commits the schema **before** the Deployment rolls, and `helm rollback` / `--atomic` reverts manifests only — so after any rollback across a migration the DB is *ahead* of the running image, and the `db` readiness probe's strict `current == head` equality kept both the rolled-back pods **and** the still-running prior pods out of `/ready` forever.
- Implements **mechanism (2)** from #1607: `db_migration_probe` now treats a DB revision *unknown to the image's `versions/` directory* as "DB ahead" and reports `ok=True` with detail `current=<newer> head=<older> db_ahead=true` (state stays visible on `/ready`). A revision the image *does* know that differs from head — DB **behind**, the genuinely dangerous direction — still fails, as do fresh-unmigrated DBs, packaging defects (`head=None` with a stamped DB), and a missing pgvector extension (the gate is not bypassed on the ahead path).
- Why not the issue's lead candidate, a `pre-rollback` `alembic downgrade` hook — it is mechanically broken and contradicts the repo's own contract:
  - Helm renders rollback hooks from the **previous** release's stored manifests (`pkg/action/rollback.go` builds the target release with `Hooks: previousRelease.Hooks`) — i.e. the old image, which does not ship the newer migration scripts. `alembic downgrade` must load the script of the DB's current revision, so it dies with `Can't locate revision identified by '0037'` (verified against installed Alembic 1.18.4) and the failed hook would block the rollback outright.
  - `scripts/ci/check_migration_compat.py` already pins the design: "Production never invokes `alembic downgrade` — rollback is image-revert + forward-compat schema discipline", and its additive-only `upgrade()` gate is exactly what makes the DB-ahead state safe for older code. The probe was the only piece not honoring that contract.
  - An unattended downgrade is destructive (`0037`'s `downgrade()` drops `doc_collections`, destroying data written during the failed-release window).
- Documents the migration ↔ rollback contract so future migrations don't re-arm the trap: `docs/codebase/migrations.md` § "Rollback contract" (trade-off: a corrupted/foreign `alembic_version` value now passes readiness; accepted because DB-behind still fails closed), `docs/RELEASING.md` § 6b (failure-injection rollback drill + checklist entry + 2026-06-08 failure-mode entry), and a pointer comment on the chart's migration Job hook annotations.
- Known limitation (documented): the tolerance lives in the image being rolled back **to** — rolling back to a pre-tolerance release across a migration still bricks readiness; recover those by rolling forward.

## Test plan

- [x] `uv run ruff check src/ tests/` — clean
- [x] `uv run ruff format --check src/ tests/` — clean
- [x] `uv run mypy src/` — clean (strict, 464 files)
- [x] `uv run pytest -n 6 --dist loadscope --maxfail=1 --ignore=tests/integration` — full unit sweep green
- [x] AC "probe accepts DB ahead": `test_probe_healthy_when_db_ahead_of_head` pins `current=0037, head=0036 → ok=True` with detail `current=0037 head=0036 db_ahead=true`
- [x] AC "DB behind still fails": `test_probe_unhealthy_when_db_behind_head` pins `current=0035, head=0036 → ok=False`
- [x] Gate ordering: `test_probe_db_ahead_still_fails_when_pgvector_missing` and `test_probe_db_ahead_healthy_on_postgres_with_pgvector` pin that the ahead path joins (not bypasses) the pgvector gate
- [x] All 9 pre-existing probe tests unchanged and green (strict-equality failure modes other than db-ahead are preserved)
- [x] AC "failure-injection test documented": `docs/RELEASING.md` § 6b runbook drill (sandbox `helm upgrade --atomic` with readiness deliberately broken → auto-rollback → rolled-back pods Ready with `db_ahead=true`, no manual alembic)
- [x] AC "migration↔rollback contract documented": `docs/codebase/migrations.md` § "Rollback contract" + `docs/RELEASING.md` § 6b
- [x] AC "CHANGELOG": one `[Unreleased]` bullet
- [x] `helm lint` + `helm template` with the chart CI's override set — render unchanged apart from the comment block; migration Job present

## Out of scope

- #1606 (sibling T1) — the `docs_search` readiness probe's unconfigured-backend fail-close; different probe, different file.
- Backfilling `downgrade()` bodies for pre-`0037` migrations (issue's explicit out-of-scope; `downgrade()` stays the manual escape hatch).
- An automated kind/minikube e2e for the rollback drill — the issue accepts a documented runbook step (`CI or docs/RELEASING.md runbook step`); the drill is now a release-checklist item for migration-carrying releases.

<!-- auto-implement-issue: fresh, iteration 1 -->

Closes #1607


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Fixed Helm upgrade/rollback readiness failures by allowing the database readiness check to tolerate database schema being ahead of the currently running image version.

* **Documentation**
  * Updated release and migration documentation to describe rollback safety contracts and readiness probe behavior during schema updates.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->