### PR TITLE
fix(docs): /ready skips unconfigured optional docs backends — a deploy without CORPUS_URL becomes Ready (#1606)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -92,6 +92,15 @@ connector-related release-notes line.
 
 ### Fixed
 
+- `/ready` no longer fail-closes on the self-registered `corpus-http`
+  docs backend when `CORPUS_URL` is unset. The docs add-on is optional:
+  the coarse `docs_backends` readiness check now skips unconfigured
+  backends (registered ≠ configured), so a deploy with no docs backend
+  configured becomes Ready instead of returning 503 forever (which made
+  `helm --wait` time out and the rollout never complete). Call-time
+  behaviour is unchanged — `search_docs` still fails closed with 503
+  `CorpusUnavailable` when the corpus is unconfigured or unreachable
+  (#1606).
 - Distinguish ingested-but-**disabled** L2 sub-ops from truly-absent ones
   in the `vmware-rest` composite pre-flight. A composite that depends on
   an L2 op whose descriptor row exists but is `is_enabled=false` now

--- a/backend/src/meho_backplane/docs_search/readiness_probe.py
+++ b/backend/src/meho_backplane/docs_search/readiness_probe.py
@@ -1,12 +1,12 @@
 # SPDX-License-Identifier: Apache-2.0
 # Copyright (c) 2026 evoila Group
 
-"""Coarse ``/ready`` probe: each configured search backend is reachable (T6 #1555).
+"""Coarse ``/ready`` probe over the *configured* search backends (T6 #1555).
 
 Registered with :mod:`meho_backplane.health` from the FastAPI lifespan
 (:mod:`meho_backplane.main`), beside the Keycloak / Vault / DB / broadcast
-probes. It answers the deploy-level question "are the doc-search backends
-wired?" — a coarse liveness gate, not the per-collection round-trip
+probes. It answers the deploy-level question "which doc-search backends
+are wired?" — a coarse config read, not the per-collection round-trip
 :meth:`~meho_backplane.docs_search.backends.base.SearchBackend.probe`
 performs.
 
@@ -23,19 +23,28 @@ business minting and (b) hammer the external corpus on every poll. The
 per-collection liveness round-trip is the explicit
 ``POST /api/v1/doc_collections/{key}/probe`` operator action instead.
 
-Empty-registry note
--------------------
+Registered ≠ configured (#1606)
+-------------------------------
 
-With no registered backends the probe reports ``ok=True`` with
-``detail="no backends registered"`` — the doc-search add-on being absent
-is not a backplane-unready signal (the four core probes gate readiness).
-The shipped ``corpus-http`` adapter self-registers at import, so a deploy
-that imported the docs package always has at least that one to report on.
+The shipped ``corpus-http`` adapter self-registers at import, so every
+deploy that imported the docs package has it in the registry — including
+deploys that never set ``CORPUS_URL`` because the optional docs add-on is
+simply not in use. An **unconfigured backend is therefore skipped, never
+failed**: the docs add-on's absence is not a backplane-unready signal
+(the four core probes gate readiness), and gating ``/ready`` on it
+bricked a real deploy (503 forever, ``helm --wait`` timeout). The probe
+reports ``ok=True`` unconditionally and is observability-only: ``detail``
+says how many backends are configured so an operator's single
+``GET /ready`` answers "is the docs add-on wired?".
+
+Fail-closed is preserved where the backend actually dials: an
+unconfigured or unreachable corpus raises
+:class:`~meho_backplane.auth.corpus.CorpusUnavailable` at call time
+(``search_docs`` → HTTP 503) and fails the explicit per-collection probe
+route — readiness of the *collection*, not of the backplane.
 """
 
 from __future__ import annotations
-
-import structlog
 
 from meho_backplane.docs_search.backends import all_backends
 from meho_backplane.health import ProbeResult
@@ -46,35 +55,26 @@ __all__ = ["PROBE_NAME", "docs_backends_readiness_probe"]
 #: surfaces in the ``/ready`` payload).
 PROBE_NAME = "docs_backends"
 
-_log = structlog.get_logger(__name__)
-
 
 def docs_backends_readiness_probe() -> ProbeResult:
-    """Report whether every configured search backend is reachable.
+    """Report which search backends are configured — never failing readiness.
 
     Synchronous (no I/O — :meth:`is_configured` is a config read), so the
-    health registry calls it inline. ``ok`` is the AND across every
-    registered adapter's :meth:`is_configured`; ``detail`` names the
-    unconfigured backend types so an operator's single ``GET /ready``
-    answers *which* backend is unwired without a second query. An empty
-    registry is ``ok=True`` (the docs add-on is optional; its absence does
-    not fail the backplane's readiness gate).
+    health registry calls it inline. Registered ≠ configured (#1606): the
+    registry holds every backend that self-registered at import, while
+    only the subset whose :meth:`is_configured` is true is actually wired
+    on this deploy. Unconfigured backends are **skipped** — the docs
+    add-on is optional, so ``ok`` is always ``True`` and ``detail``
+    carries the configured count (or the no-backends note). A configured
+    backend's actual reachability is asserted where the call dials: the
+    search path and the per-collection probe route fail closed with
+    :class:`~meho_backplane.auth.corpus.CorpusUnavailable`.
     """
     backends = all_backends()
     if not backends:
         return ProbeResult(name=PROBE_NAME, ok=True, detail="no backends registered")
 
-    unconfigured = sorted(
-        backend_type for backend_type, impl in backends.items() if not impl.is_configured()
-    )
-    if unconfigured:
-        # Coarse fail: at least one registered backend is not wired. Name
-        # the offending types (backend type strings are deploy config, not
-        # tenant data, so they are safe to surface on /ready).
-        _log.warning("docs_backends_unconfigured", unconfigured=unconfigured)
-        return ProbeResult(
-            name=PROBE_NAME,
-            ok=False,
-            detail=f"unconfigured: {', '.join(unconfigured)}",
-        )
-    return ProbeResult(name=PROBE_NAME, ok=True, detail=f"{len(backends)} backend(s) configured")
+    configured = [impl for impl in backends.values() if impl.is_configured()]
+    if not configured:
+        return ProbeResult(name=PROBE_NAME, ok=True, detail="no backends configured")
+    return ProbeResult(name=PROBE_NAME, ok=True, detail=f"{len(configured)} backend(s) configured")

--- a/backend/src/meho_backplane/main.py
+++ b/backend/src/meho_backplane/main.py
@@ -278,9 +278,9 @@ async def _run_lifespan_startup() -> None:
     register_probe("vault", vault_readiness_probe)
     register_probe("db", db_migration_probe)
     register_probe("broadcast", broadcast_readiness_probe)
-    # G4.6-T6 (#1555) — coarse "each configured search backend reachable"
-    # gate. Synchronous config read (no live round-trip); the
-    # per-collection liveness round-trip is the explicit probe route.
+    # G4.6-T6 (#1555) — coarse "which search backends are configured"
+    # check; observability-only since #1606 (unconfigured optional
+    # backends are skipped, never failed — no live round-trip).
     register_probe("docs_backends", docs_backends_readiness_probe)
     # Eager engine construction (G2.3-T2 #258); validates ``DATABASE_URL``
     # at startup so first-request latency doesn't absorb the pool build.

--- a/backend/tests/test_doc_collections_readiness.py
+++ b/backend/tests/test_doc_collections_readiness.py
@@ -25,9 +25,13 @@ Coverage matrix (Task #1555 acceptance criteria):
   the same backend endpoint serialize inside the adapter (the lock is
   held across the corpus round-trip); probes against different endpoints
   run concurrently.
-* **/ready backend reachability** — the coarse probe reports ``ok`` only
-  when every registered backend is configured, naming the unconfigured
-  ones.
+* **/ready backend configuredness** — registered ≠ configured (#1606):
+  the coarse probe *skips* unconfigured (optional) backends rather than
+  failing them, so a deploy with no docs backend configured is Ready
+  (``GET /ready`` → 200), while a configured-but-unreachable backend
+  still fails closed at call time — never at the readiness gate (the
+  coarse probe does no I/O, so a corpus outage cannot flap the
+  backplane out of rotation).
 * **REST routes** — probe / enable / disable are tenant_admin-gated
   (operator → 403), 404 on an unknown key, and the probe maps a backend
   failure to 503 with the row untouched.
@@ -45,6 +49,7 @@ from collections.abc import Iterator
 from datetime import UTC, datetime
 from typing import Any
 
+import httpx
 import pytest
 import respx
 from fastapi import FastAPI
@@ -73,6 +78,8 @@ from meho_backplane.docs_collections.lifecycle import (
 from meho_backplane.docs_search.backends import BackendReadiness, CorpusHttpBackend
 from meho_backplane.docs_search.backends.base import SearchBackend
 from meho_backplane.docs_search.readiness_probe import docs_backends_readiness_probe
+from meho_backplane.health import clear_probes, register_probe
+from meho_backplane.health import router as health_router
 from meho_backplane.middleware import RequestContextMiddleware
 from meho_backplane.settings import get_settings
 
@@ -433,7 +440,7 @@ async def test_concurrent_probes_different_projects_run_concurrently(
 
 
 # ---------------------------------------------------------------------------
-# /ready backend reachability probe
+# /ready backend configuredness probe
 # ---------------------------------------------------------------------------
 
 
@@ -441,14 +448,71 @@ def test_ready_probe_ok_when_corpus_configured() -> None:
     result = docs_backends_readiness_probe()
     assert result.name == "docs_backends"
     assert result.ok is True
+    assert result.detail == "1 backend(s) configured"
 
 
-def test_ready_probe_fails_when_backend_unconfigured(monkeypatch: pytest.MonkeyPatch) -> None:
+def test_ready_probe_skips_unconfigured_backend(monkeypatch: pytest.MonkeyPatch) -> None:
+    """Registered ≠ configured (#1606): an unconfigured optional backend is skipped.
+
+    The ``corpus-http`` adapter self-registers at import, so a deploy
+    that never set ``CORPUS_URL`` still has it in the registry. That must
+    not fail readiness — the docs add-on is optional — and the detail
+    must not name any backend as unconfigured.
+    """
     monkeypatch.setenv("CORPUS_URL", "")
     get_settings.cache_clear()
     result = docs_backends_readiness_probe()
-    assert result.ok is False
-    assert "corpus-http" in (result.detail or "")
+    assert result.ok is True
+    assert result.detail == "no backends configured"
+    assert "corpus-http" not in (result.detail or "")
+
+
+@pytest.mark.asyncio
+async def test_configured_but_unreachable_backend_fails_closed_at_call_time() -> None:
+    """A *configured* backend that is unreachable still fails closed — at call time.
+
+    The coarse ``/ready`` probe is a credential-free config read and
+    never dials the corpus, so an outage of the (optional) docs backend
+    cannot flap the whole backplane out of rotation. The fail-closed
+    property for real config lives where the call actually dials: the
+    search round-trip maps the dead endpoint to ``CorpusUnavailable``
+    (→ HTTP 503 at the route / per-collection probe).
+    """
+    with respx.mock as mock_router:
+        # Only the search POST is mocked (as unreachable); the readiness
+        # probe running inside this strict context proves it issues no
+        # HTTP I/O at all (an unmocked request would raise).
+        mock_router.post(_CORPUS_URL).mock(side_effect=httpx.ConnectError("connection refused"))
+        result = docs_backends_readiness_probe()
+        assert result.ok is True
+        assert result.detail == "1 backend(s) configured"
+        with pytest.raises(CorpusUnavailable):
+            await CorpusHttpBackend().search(_make_operator(), "q", backend_ref=None)
+
+
+@pytest.mark.asyncio
+async def test_ready_endpoint_200_when_no_backend_configured(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """End-to-end over ASGI transport: a deploy without ``CORPUS_URL`` is Ready."""
+    monkeypatch.setenv("CORPUS_URL", "")
+    get_settings.cache_clear()
+    app = FastAPI()
+    app.include_router(health_router)
+    clear_probes()
+    try:
+        register_probe("docs_backends", docs_backends_readiness_probe)
+        transport = httpx.ASGITransport(app=app)
+        async with httpx.AsyncClient(transport=transport, base_url="http://test") as http_client:
+            resp = await http_client.get("/ready")
+    finally:
+        clear_probes()
+    assert resp.status_code == 200
+    body = resp.json()
+    assert body["status"] == "ready"
+    docs_check = next(c for c in body["checks"] if c["name"] == "docs_backends")
+    assert docs_check["ok"] is True
+    assert docs_check["detail"] == "no backends configured"
 
 
 # ---------------------------------------------------------------------------

--- a/docs/codebase/doc-collections.md
+++ b/docs/codebase/doc-collections.md
@@ -194,14 +194,21 @@ enable/disable gate):
 - `POST /api/v1/doc_collections/{key}/enable` / `.../disable` → 204,
   idempotent, 409 on a forbidden move.
 
-### `/ready` backend reachability (`meho_backplane.docs_search.readiness_probe`)
+### `/ready` backend configuredness (`meho_backplane.docs_search.readiness_probe`)
 
 `docs_backends_readiness_probe` is a coarse, synchronous, credential-free
-`/ready` check registered in the lifespan: it reports `ok` only when
-every registered adapter's `is_configured()` is true (for `corpus-http`,
-`settings.corpus_url` set), naming the unconfigured ones. It deliberately
-does **not** issue a live round-trip — that is the explicit per-collection
-probe route's job.
+`/ready` check registered in the lifespan. Registered ≠ configured
+(#1606): the shipped `corpus-http` adapter self-registers at import even
+on deploys that never set `CORPUS_URL`, so the probe filters to the
+adapters whose `is_configured()` is true (for `corpus-http`,
+`settings.corpus_url` set) and reports `ok=True` unconditionally — the
+docs add-on is optional, and a deploy with no docs backend configured
+must still become Ready. `detail` carries the configured count (the
+observability value of the check). It deliberately does **not** issue a
+live round-trip — a corpus outage must not flap the backplane out of
+rotation; an unconfigured or unreachable backend instead fails closed at
+call time (`CorpusUnavailable` → 503) and at the explicit per-collection
+probe route.
 
 ### CLI (`cli/internal/cmd/docs/collections.go`)
 


### PR DESCRIPTION
## Summary

- `/ready` no longer fail-closes on the self-registered `corpus-http` docs backend: the coarse `docs_backends` check now filters to the **configured** subset of registered backends (registered ≠ configured), so a deploy that never set `CORPUS_URL` becomes Ready instead of returning 503 forever (`helm --wait` timeout — the live v0.12.0 RDC outage, 2026-06-08).
- The probe is now explicitly observability-only (`ok=True` always; `detail` carries the configured count, or `no backends configured`). It stays a credential-free config read with zero I/O — a corpus outage can never flap the backplane out of rotation, which is the Kubernetes contract for an optional dependency.
- Call-time fail-closed is untouched: an unconfigured or unreachable corpus still raises `CorpusUnavailable` → HTTP 503 at `search_docs` and at the per-collection probe route (`POST /api/v1/doc_collections/{key}/probe`).
- Docs updated (`docs/codebase/doc-collections.md` `/ready` section), stale lifespan comment in `main.py` refreshed, one CHANGELOG `[Unreleased]` bullet.

## Acceptance-criterion note (criterion 2)

The issue's criterion 2 letter reads "`CORPUS_URL` set to an unreachable endpoint → the probe still reports `ok=False`". The coarse probe deliberately performs **no I/O** (no operator JWT on the readiness path; kubelet-interval polling must not hammer the external corpus — the module's documented design, which the issue's chosen lowest-friction shape keeps), so endpoint *unreachability* is undetectable at `/ready` — and gating `/ready` on a live corpus round-trip would reintroduce the exact outage class this fix removes (an optional dependency's outage flapping backplane readiness, against the Kubernetes guidance the issue itself cites). The criterion's parenthetical intent — "the fail-closed property for real config is preserved" — is pinned instead at the surfaces that actually dial: the new `test_configured_but_unreachable_backend_fails_closed_at_call_time` proves, inside one strict respx context, that the readiness probe issues zero HTTP I/O and stays green while the real `CorpusHttpBackend.search()` against the same configured-but-dead endpoint raises `CorpusUnavailable` (→ 503 at the route).

## Test plan

- [x] `uv run ruff check src/ tests/` — clean
- [x] `uv run ruff format --check src/ tests/` — clean
- [x] `uv run mypy src/` — clean (strict)
- [x] Full unit sweep `uv run pytest -n 4 --dist loadscope --maxfail=1 --ignore=tests/integration tests/` — all green
- [x] AC1 — `CORPUS_URL` unset → `docs_backends_readiness_probe()` returns `ok=True` and the detail names no unconfigured backend (`test_ready_probe_skips_unconfigured_backend`); `GET /ready` → **200** end-to-end over httpx `ASGITransport` (`test_ready_endpoint_200_when_no_backend_configured`)
- [x] AC2 — configured-but-unreachable: fail-closed preserved where the call dials, `/ready` provably I/O-free and green (`test_configured_but_unreachable_backend_fails_closed_at_call_time`; see note above), plus existing `test_connect_error_fails_closed` and `test_probe_route_backend_unavailable_503_row_untouched`
- [x] AC3 — call-time fail-closed unchanged (no code on that path touched): existing `test_unconfigured_corpus_url_fails_closed`, `test_adapter_unconfigured_fails_closed`, `test_backend_unavailable_maps_to_503_not_empty_200` all green
- [x] AC4 — pinned test `test_ready_probe_fails_when_backend_unconfigured` replaced by the skip-when-unconfigured contract (`test_ready_probe_skips_unconfigured_backend`); new configured-but-unreachable test added
- [x] AC5 — one CHANGELOG `[Unreleased]` bullet
- [x] OpenAPI surface unchanged — regenerated `cli/api/openapi.json` via `make snapshot-openapi`: zero diff

## Out of scope

- A general backend-`optional`/`enabled` registration flag (issue's explicit out-of-scope; the configured-subset filter suffices for today's single optional backend).
- Any change to `search_corpus`' call-time fail-closed behaviour.
- Sibling dogfood findings (#1607–#1612) are separate tasks of Initiative #1605.

<!-- auto-implement-issue: fresh, iteration 1 -->

Closes #1606


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Fixed the deployment readiness check to skip unconfigured optional documentation backends, preventing helm deployments from timing out during rollouts.

* **Documentation**
  * Clarified that the readiness check verifies which backends are configured, not their live reachability.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->