### PR TITLE
feat(connectors): park-time proposed_effect previews for the 8 vmware write composites (#1608)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -90,6 +90,23 @@ connector-related release-notes line.
 
 ## [Unreleased]
 
+### Added
+
+- Parked `vmware.composite.*` write approvals now carry a
+  connector-rendered preview in `proposed_effect` instead of the
+  identifier-only `{op_id, connector_id, target_id}` default, extending
+  the #1504/#1437 park-time preview pattern to all 8 vmware write
+  composites. The fan-out composites (`vm.power.bulk`, `host.evacuate`,
+  `host.detach_from_vds`, `cluster.patch`) resolve the entity set the
+  approved dispatch would act on — via the same read-only listing
+  helpers the handlers use — and store the requested action/filter plus
+  a capped `resolved` list with `total_resolved`, so a four-eyes
+  reviewer can tell a one-VM power cycle from a 1000-VM outage; the
+  single-entity composites (`vm.create`, `vm.clone`,
+  `vm.snapshot.revert`, `vm.migrate`) echo their blast-radius-naming
+  params. Preview reads are GET-only by construction and fail-soft —
+  the park always proceeds (#1608).
+
 ### Fixed
 
 - Distinguish ingested-but-**disabled** L2 sub-ops from truly-absent ones

--- a/backend/src/meho_backplane/connectors/vmware_rest/composites/__init__.py
+++ b/backend/src/meho_backplane/connectors/vmware_rest/composites/__init__.py
@@ -67,6 +67,12 @@ from meho_backplane.operations.typed_register import register_typed_op_registrar
 # registered by the time the runner iterates.
 register_typed_op_registrar(register_vmware_composite_operations)
 
+# Side-effect import: registers the 8 write composites' park-time
+# ``proposed_effect`` preview builders (#1608) onto the per-op hook in
+# :mod:`meho_backplane.operations._preview` — mirrors how
+# ``connectors/argocd/__init__`` wires ``ops_write_preview``.
+from meho_backplane.connectors.vmware_rest.composites import _write_preview  # noqa: E402,F401
+
 __all__ = [
     "cluster_drs_recommendations_composite",
     "cluster_patch_composite",

--- a/backend/src/meho_backplane/connectors/vmware_rest/composites/_write.py
+++ b/backend/src/meho_backplane/connectors/vmware_rest/composites/_write.py
@@ -236,6 +236,72 @@ def _rolled_back(
     }
 
 
+async def _resolve_vm_list(
+    *,
+    dispatch_child: DispatchChild,
+    filter_dict: dict[str, Any],
+) -> list[dict[str, Any]]:
+    """Resolve a VM filter to its listing rows via ``GET:/vcenter/vm``.
+
+    Read-only: issues exactly one listing GET, never a mutation. Filter
+    keys are forwarded as ``filter.<key>`` query params per the vCenter
+    listing contract.
+
+    Shared seam (#1608): the write handlers that fan out over a filtered
+    VM set (:func:`vm_power_bulk_composite`, :func:`host_evacuate_composite`,
+    :func:`host_detach_from_vds_composite`) call this at dispatch time,
+    and their park-time preview builders (:mod:`._write_preview`) call the
+    same function at approval-park time — so the entity set the reviewer
+    sees in ``proposed_effect`` is resolved by the same code path the
+    approved dispatch will use.
+
+    Raises :class:`RuntimeError` when the listing sub-op fails or returns
+    a non-list payload. Non-dict rows are dropped (the listing contract
+    yields summary objects); per-row key validation stays with callers.
+    """
+    listing = _require_ok(
+        await dispatch_child(
+            connector_id=_CONNECTOR_ID,
+            op_id=_OP_LIST_VMS,
+            params={f"filter.{k}": v for k, v in filter_dict.items()},
+        )
+    )
+    vms = _unwrap_value(listing)
+    if not isinstance(vms, list):
+        raise RuntimeError(f"expected list from {_OP_LIST_VMS!r}, got {type(vms).__name__}")
+    return [entry for entry in vms if isinstance(entry, dict)]
+
+
+async def _resolve_cluster_hosts(
+    *,
+    dispatch_child: DispatchChild,
+    cluster_moid: str,
+) -> list[dict[str, Any]]:
+    """Resolve a cluster's host listing rows via ``GET:/vcenter/cluster/{cluster}/host``.
+
+    Read-only single GET. Shared between :func:`cluster_patch_composite`
+    (dispatch time) and its park-time preview builder in
+    :mod:`._write_preview` (#1608) — same rationale as
+    :func:`_resolve_vm_list`.
+
+    Raises :class:`RuntimeError` when the listing sub-op fails or returns
+    a non-list payload. Non-dict rows are dropped.
+    """
+    listing = _require_ok(
+        await dispatch_child(
+            connector_id=_CONNECTOR_ID,
+            op_id=_OP_LIST_CLUSTER_HOSTS,
+            params={"cluster": cluster_moid},
+        )
+    )
+    entries = _unwrap_value(listing)
+    if not isinstance(entries, list):
+        raise RuntimeError(
+            f"expected list from {_OP_LIST_CLUSTER_HOSTS!r}, got {type(entries).__name__}"
+        )
+    return [entry for entry in entries if isinstance(entry, dict)]
+
+
 # ===========================================================================
 # vm.create
 # ===========================================================================
@@ -760,26 +826,13 @@ async def vm_power_bulk_composite(
     # every per-VM dispatch must target the matching one.
     power_op_id = _power_vm_op_id(action)
 
-    listing = _require_ok(
-        await dispatch_child(
-            connector_id=_CONNECTOR_ID,
-            op_id=_OP_LIST_VMS,
-            params={f"filter.{k}": v for k, v in filter_dict.items()},
-        )
-    )
-    vms = _unwrap_value(listing)
-    if not isinstance(vms, list):
-        raise RuntimeError(
-            f"vm.power.bulk: expected list from {_OP_LIST_VMS!r}, got {type(vms).__name__}"
-        )
+    vms = await _resolve_vm_list(dispatch_child=dispatch_child, filter_dict=filter_dict)
 
     results: list[dict[str, Any]] = []
     ok_count = 0
     err_count = 0
     aborted = False
     for vm_entry in vms:
-        if not isinstance(vm_entry, dict):
-            continue
         vm_moid = vm_entry.get("vm")
         if not isinstance(vm_moid, str):
             continue
@@ -849,24 +902,11 @@ async def host_evacuate_composite(
     host_moid = params["host"]
     tolerate_partial = bool(params.get("tolerate_partial_failure", False))
 
-    listing = _require_ok(
-        await dispatch_child(
-            connector_id=_CONNECTOR_ID,
-            op_id=_OP_LIST_VMS,
-            params={"filter.hosts": [host_moid]},
-        )
-    )
-    vms = _unwrap_value(listing)
-    if not isinstance(vms, list):
-        raise RuntimeError(
-            f"host.evacuate: expected list from {_OP_LIST_VMS!r}, got {type(vms).__name__}"
-        )
+    vms = await _resolve_vm_list(dispatch_child=dispatch_child, filter_dict={"hosts": [host_moid]})
 
     migrated: list[str] = []
     failed: list[dict[str, str]] = []
     for vm_entry in vms:
-        if not isinstance(vm_entry, dict):
-            continue
         vm_moid = vm_entry.get("vm")
         if not isinstance(vm_moid, str):
             continue
@@ -960,24 +1000,11 @@ async def host_detach_from_vds_composite(
             params={"filter.hosts": [host_moid]},
         )
     )
-    vm_listing = _require_ok(
-        await dispatch_child(
-            connector_id=_CONNECTOR_ID,
-            op_id=_OP_LIST_VMS,
-            params={"filter.hosts": [host_moid]},
-        )
-    )
-    vms = _unwrap_value(vm_listing)
-    if not isinstance(vms, list):
-        raise RuntimeError(
-            f"host.detach_from_vds: expected list from {_OP_LIST_VMS!r}, got {type(vms).__name__}"
-        )
+    vms = await _resolve_vm_list(dispatch_child=dispatch_child, filter_dict={"hosts": [host_moid]})
 
     vms_migrated: list[str] = []
     migration_failures: list[dict[str, str]] = []
     for vm_entry in vms:
-        if not isinstance(vm_entry, dict):
-            continue
         vm_moid = vm_entry.get("vm")
         if not isinstance(vm_moid, str):
             continue
@@ -1091,25 +1118,12 @@ async def cluster_patch_composite(
     cluster_moid = params["cluster"]
     patch_method = params.get("patch_method", "default")
 
-    listing = _require_ok(
-        await dispatch_child(
-            connector_id=_CONNECTOR_ID,
-            op_id=_OP_LIST_CLUSTER_HOSTS,
-            params={"cluster": cluster_moid},
-        )
-    )
-    entries = _unwrap_value(listing)
-    if not isinstance(entries, list):
-        raise RuntimeError(
-            f"cluster.patch: expected list from {_OP_LIST_CLUSTER_HOSTS!r}, "
-            f"got {type(entries).__name__}"
-        )
+    entries = await _resolve_cluster_hosts(dispatch_child=dispatch_child, cluster_moid=cluster_moid)
     host_moids: list[str] = []
     for entry in entries:
-        if isinstance(entry, dict):
-            host_moid = entry.get("host")
-            if isinstance(host_moid, str):
-                host_moids.append(host_moid)
+        host_moid = entry.get("host")
+        if isinstance(host_moid, str):
+            host_moids.append(host_moid)
 
     patched: list[str] = []
     for i, host_moid in enumerate(host_moids):

--- a/backend/src/meho_backplane/connectors/vmware_rest/composites/_write_preview.py
+++ b/backend/src/meho_backplane/connectors/vmware_rest/composites/_write_preview.py
@@ -1,0 +1,464 @@
+# SPDX-License-Identifier: Apache-2.0
+# Copyright (c) 2026 evoila Group
+
+"""Park-time ``proposed_effect`` preview builders for the 8 vmware write composites.
+
+G0.22-T3 (#1608). Before this module, a parked ``vmware.composite.*``
+write stored only the identifier default ``{op_id, connector_id,
+target_id}`` in :attr:`~meho_backplane.db.models.ApprovalRequest.proposed_effect`
+— and because the original dispatch ``params`` are deliberately never
+serialised onto a reviewer-facing surface (#1503), the four-eyes
+approver could not tell a one-VM power cycle from a 1000-VM outage.
+This wires all 8 write composites onto the per-op preview hook shipped
+by #1437 (:mod:`meho_backplane.operations._preview`), following the
+argocd pattern (#1452): reuse the handlers' own read-only resolution
+helpers, never the mutating sub-ops.
+
+========================  ====================================================
+``vmware.composite.*``    preview stored in ``proposed_effect["preview"]``
+========================  ====================================================
+``vm.power.bulk``         ``{action, filter, resolved, total_resolved}``
+``host.evacuate``         ``{host, tolerate_partial_failure, resolved,
+                          total_resolved}``
+``host.detach_from_vds``  ``{host, dvs, fallback_network, resolved,
+                          total_resolved}``
+``cluster.patch``         ``{cluster, patch_method, resolved, total_resolved}``
+``vm.create``             echo: name, guest_os, sizing, networks, power-on
+``vm.clone``              echo: source_vm, target_name, library_item, wait flag
+``vm.snapshot.revert``    echo: vm, snapshot_name
+``vm.migrate``            echo: vm, cluster, target_host + resolution source
+========================  ====================================================
+
+Two preview depths, chosen per composite
+========================================
+
+* **Live-read resolution** for the four fan-out composites whose blast
+  radius is *not* derivable from params — a filter / host / cluster
+  resolves to N entities only at vCenter. These call the same shared
+  read-only helpers the handlers use at dispatch time
+  (:func:`._write._resolve_vm_list` / :func:`._write._resolve_cluster_hosts`),
+  so the reviewer sees the resolved entity list (capped at
+  :data:`_PREVIEW_RESOLVED_CAP`, with ``total_resolved`` carrying the
+  uncapped count).
+* **Param echo** (no I/O — the ``secret.move`` precedent, #1580) for the
+  four single-entity composites whose params fully name the blast
+  radius. ``vm.migrate`` deliberately does **not** pre-resolve a DRS
+  recommendation: DRS output is point-in-time and the approved dispatch
+  re-consults it, so echoing a predicted host could mislead the reviewer
+  — the preview says ``target_host_source="drs_at_execution"`` instead.
+
+How preview reads execute
+=========================
+
+The handlers receive their ``dispatch_child`` from the dispatcher's
+composite branch; at park time the composite never runs, so the live-read
+builders construct :func:`_read_only_dispatch_child` — an adapter
+satisfying the same :class:`~meho_backplane.operations.composite.DispatchChild`
+protocol (which is what lets the resolution helpers be shared verbatim)
+but executing the sub-op **directly against the resolved connector**
+rather than through :func:`~meho_backplane.operations.dispatcher.dispatch`.
+See the adapter docstring for the three reasons (no policy-gate
+re-entry, no unparented audit rows, GET-only fail-closed guard); the
+k8s.apply dry-run (#1437), the argocd snapshot reads (#1452), and the
+vault capability probe (#1504) all run their preview I/O the same way —
+connector-level, un-dispatched.
+
+Redaction posture
+=================
+
+The whole-builder ``classify_op`` gate runs in
+:func:`~meho_backplane.operations._preview.build_proposed_effect` before
+any builder fires: the 8 op_ids classify as ``write`` (``.create`` /
+``.patch`` suffixes) or ``other`` — none is a credential class, so none
+is suppressed. The previews themselves carry only vSphere inventory
+identity (moids, display names, power states) and the operator's own
+dispatch params — infrastructure topology, never credential material.
+
+Fail-soft: every builder either declines (``None`` → identifier-only
+default) on malformed params or lets resolution faults propagate into
+``build_proposed_effect``'s catch — the park always proceeds.
+"""
+
+from __future__ import annotations
+
+import time
+from collections.abc import Callable
+from typing import Any
+
+from meho_backplane.connectors import OperationResult
+from meho_backplane.connectors.vmware_rest.composites._write import (
+    _resolve_cluster_hosts,
+    _resolve_vm_list,
+)
+from meho_backplane.operations._preview import (
+    PreviewBuilder,
+    PreviewContext,
+    register_preview_builder,
+)
+from meho_backplane.operations.composite import DispatchChild
+
+#: Cap on the ``resolved`` entity list stored in the durable
+#: ``proposed_effect`` row. ``total_resolved`` always carries the uncapped
+#: count, so a reviewer of a 1000-VM bulk op sees the first 20 entities
+#: *and* the true blast-radius number without the row ballooning.
+_PREVIEW_RESOLVED_CAP = 20
+
+#: HTTP-verb prefix every preview sub-op must carry. Canonical L2 op_ids
+#: encode the method (``METHOD:/path``), so the prefix check is a
+#: structural read-only guard that holds for both ``ingested`` and
+#: ``typed`` descriptor rows.
+_READ_OP_ID_PREFIX = "GET:"
+
+
+async def _execute_leaf_read(
+    ctx: PreviewContext,
+    *,
+    connector_id: str,
+    op_id: str,
+    params: dict[str, Any],
+    effective_target: Any,
+) -> Any:
+    """Resolve + execute one leaf read directly via its source-kind branch.
+
+    Mirrors the dispatcher's own steps — resolve the enabled descriptor
+    row for ``(connector_id, op_id)``, then route by ``source_kind``:
+    ``ingested`` rows execute over the connector's HTTP transport,
+    ``typed`` rows import + invoke their module-level handler. Anything
+    else (composite sub-ops, unknown kinds) raises — a preview read must
+    be a leaf. Raises on every fault; the adapter wraps raises into
+    error-shaped :class:`OperationResult` values.
+    """
+    # Local imports keep the connector→operations import graph as thin
+    # as the established preview builders' (mirrors _k8s_apply_preview
+    # and get_dispatch_child's deferred resolution).
+    from meho_backplane.operations._branches import dispatch_ingested, dispatch_typed
+    from meho_backplane.operations._handler_resolve import import_handler
+    from meho_backplane.operations._lookup import lookup_descriptor, parse_connector_id
+
+    product, version, impl_id = parse_connector_id(connector_id)
+    descriptor = await lookup_descriptor(
+        tenant_id=ctx.operator.tenant_id,
+        product=product,
+        version=version,
+        impl_id=impl_id,
+        op_id=op_id,
+    )
+    if descriptor is None:
+        raise RuntimeError(f"unknown_op at preview time: {op_id}")
+
+    if descriptor.source_kind == "ingested":
+        if ctx.connector_instance is None:
+            raise RuntimeError("no connector instance resolved for ingested preview read")
+        return await dispatch_ingested(
+            connector=ctx.connector_instance,
+            descriptor=descriptor,
+            operator=ctx.operator,
+            target=effective_target,
+            params=params,
+        )
+    if descriptor.source_kind == "typed":
+        handler = import_handler(descriptor.handler_ref or "")
+        return await dispatch_typed(
+            handler=handler,
+            operator=ctx.operator,
+            target=effective_target,
+            params=params,
+        )
+    raise RuntimeError(f"preview cannot execute source_kind={descriptor.source_kind!r} sub-op")
+
+
+def _read_only_dispatch_child(ctx: PreviewContext) -> DispatchChild:
+    """Build a read-only ``DispatchChild`` for park-time preview resolution.
+
+    Satisfies the :class:`DispatchChild` protocol so the shared resolution
+    helpers in :mod:`._write` run unchanged, but executes the sub-op
+    directly against the connector resolved into *ctx* (via
+    :func:`_execute_leaf_read`) instead of routing through
+    :func:`~meho_backplane.operations.dispatcher.dispatch`:
+
+    * **No policy-gate re-entry.** A tenant policy that gates *reads*
+      could otherwise park (or deny) the preview's own sub-op from inside
+      the park of its parent — creating approval rows as a side effect of
+      creating an approval row. Direct execution cannot re-enter the gate.
+    * **No unparented audit rows.** At park time the ``approval.request``
+      audit row does not exist yet (it is written after the preview), so
+      a dispatched sub-op would land as a top-level row with no parent
+      linkage and distort the audit tree. The park's own request row
+      remains the audit anchor, exactly as for the k8s/argocd/vault
+      preview I/O.
+    * **Reads only, fail-closed.** Any op_id not carrying the ``GET:``
+      method prefix is refused with an error result before any lookup or
+      I/O — the approval park must never mutate vSphere state, even if a
+      future helper drifts.
+
+    Never raises: every fault returns an error-shaped
+    :class:`OperationResult` (the ``DispatchChild`` contract), which the
+    calling resolution helper surfaces as a raise and
+    :func:`~meho_backplane.operations._preview.build_proposed_effect`
+    swallows fail-soft.
+    """
+
+    async def _dispatch_read(
+        *,
+        connector_id: str,
+        op_id: str,
+        params: dict[str, Any],
+        target: Any = None,
+    ) -> OperationResult:
+        started = time.monotonic()
+
+        def _error(reason: str) -> OperationResult:
+            return OperationResult(
+                status="error",
+                op_id=op_id,
+                error=reason,
+                duration_ms=(time.monotonic() - started) * 1000.0,
+            )
+
+        if not op_id.startswith(_READ_OP_ID_PREFIX):
+            return _error(f"preview refuses non-read sub-op {op_id!r} (GET-only)")
+        try:
+            raw = await _execute_leaf_read(
+                ctx,
+                connector_id=connector_id,
+                op_id=op_id,
+                params=params,
+                effective_target=ctx.target if target is None else target,
+            )
+            return OperationResult(
+                status="ok",
+                op_id=op_id,
+                result=raw,
+                duration_ms=(time.monotonic() - started) * 1000.0,
+            )
+        except Exception as exc:
+            return _error(f"preview read failed: {exc}")
+
+    return _dispatch_read
+
+
+def _vm_identity(row: dict[str, Any]) -> dict[str, Any]:
+    """Identity-only projection of a VM listing row for the durable preview.
+
+    Keeps moid + display name + power state and drops the rest (cpu /
+    memory sizing) — the approval row needs to *name* the blast radius,
+    not snapshot the inventory.
+    """
+    return {key: row[key] for key in ("vm", "name", "power_state") if row.get(key) is not None}
+
+
+def _host_identity(row: dict[str, Any]) -> dict[str, Any]:
+    """Identity-only projection of a cluster-host listing row."""
+    return {key: row[key] for key in ("host", "name") if row.get(key) is not None}
+
+
+def _capped_resolution(
+    rows: list[dict[str, Any]],
+    project: Callable[[dict[str, Any]], dict[str, Any]],
+) -> dict[str, Any]:
+    """Render ``{resolved, total_resolved}`` with :data:`_PREVIEW_RESOLVED_CAP` applied."""
+    return {
+        "resolved": [project(row) for row in rows[:_PREVIEW_RESOLVED_CAP]],
+        "total_resolved": len(rows),
+    }
+
+
+async def _vm_power_bulk_preview(ctx: PreviewContext) -> dict[str, Any] | None:
+    """Preview ``vm.power.bulk`` — echo action + filter, resolve the matched VM set.
+
+    Resolves the same filtered listing the handler's fan-out would act on
+    via the shared :func:`._write._resolve_vm_list` (one read-only GET),
+    so the reviewer sees how many — and which — VMs the approved power
+    action would hit. The per-VM power sub-ops never fire here.
+    """
+    action = ctx.params.get("action")
+    if not isinstance(action, str):
+        return None
+    filter_dict: dict[str, Any] = dict(ctx.params.get("filter") or {})
+    rows = await _resolve_vm_list(
+        dispatch_child=_read_only_dispatch_child(ctx),
+        filter_dict=filter_dict,
+    )
+    return {
+        "action": action,
+        "filter": filter_dict,
+        **_capped_resolution(rows, _vm_identity),
+    }
+
+
+async def _host_evacuate_preview(ctx: PreviewContext) -> dict[str, Any] | None:
+    """Preview ``host.evacuate`` — resolve the VM set the evacuation would migrate.
+
+    Same ``{"hosts": [host]}`` filter the handler uses; the recursive
+    ``vm.migrate`` calls and the maintenance-enter never fire here.
+    """
+    host = ctx.params.get("host")
+    if not isinstance(host, str):
+        return None
+    rows = await _resolve_vm_list(
+        dispatch_child=_read_only_dispatch_child(ctx),
+        filter_dict={"hosts": [host]},
+    )
+    return {
+        "host": host,
+        "tolerate_partial_failure": bool(ctx.params.get("tolerate_partial_failure", False)),
+        **_capped_resolution(rows, _vm_identity),
+    }
+
+
+async def _host_detach_from_vds_preview(ctx: PreviewContext) -> dict[str, Any] | None:
+    """Preview ``host.detach_from_vds`` — resolve the VMs whose NICs would migrate.
+
+    Echoes the detach coordinates and resolves the host's VM set (the
+    entities whose NICs move to ``fallback_network`` before the DVS
+    detach). The NIC PATCHes and the DVS remove_host never fire here.
+    """
+    host = ctx.params.get("host")
+    dvs = ctx.params.get("dvs")
+    fallback_network = ctx.params.get("fallback_network")
+    if not isinstance(host, str) or not isinstance(dvs, str):
+        return None
+    rows = await _resolve_vm_list(
+        dispatch_child=_read_only_dispatch_child(ctx),
+        filter_dict={"hosts": [host]},
+    )
+    return {
+        "host": host,
+        "dvs": dvs,
+        "fallback_network": fallback_network,
+        **_capped_resolution(rows, _vm_identity),
+    }
+
+
+async def _cluster_patch_preview(ctx: PreviewContext) -> dict[str, Any] | None:
+    """Preview ``cluster.patch`` — resolve the host set the rolling patch would walk.
+
+    Uses the shared :func:`._write._resolve_cluster_hosts` listing; the
+    per-host maintenance / patch sub-ops never fire here.
+    """
+    cluster = ctx.params.get("cluster")
+    if not isinstance(cluster, str):
+        return None
+    rows = await _resolve_cluster_hosts(
+        dispatch_child=_read_only_dispatch_child(ctx),
+        cluster_moid=cluster,
+    )
+    return {
+        "cluster": cluster,
+        "patch_method": ctx.params.get("patch_method", "default"),
+        **_capped_resolution(rows, _host_identity),
+    }
+
+
+async def _vm_create_preview(ctx: PreviewContext) -> dict[str, Any] | None:
+    """Preview ``vm.create`` — echo the creation spec (no I/O).
+
+    The params fully name what gets created; mirroring the handler's
+    defaults makes the echoed sizing the sizing the approved dispatch
+    will use.
+    """
+    name = ctx.params.get("name")
+    guest_os = ctx.params.get("guest_os")
+    if not isinstance(name, str) or not isinstance(guest_os, str):
+        return None
+    nics = ctx.params.get("nics") or []
+    networks = [nic.get("network") for nic in nics if isinstance(nic, dict) and nic.get("network")]
+    return {
+        "name": name,
+        "guest_os": guest_os,
+        "folder_name": ctx.params.get("folder_name"),
+        "cpu_count": int(ctx.params.get("cpu_count", 1)),
+        "memory_mib": int(ctx.params.get("memory_mib", 1024)),
+        "networks": networks,
+        "power_on_after_create": bool(ctx.params.get("power_on_after_create", False)),
+    }
+
+
+async def _vm_clone_preview(ctx: PreviewContext) -> dict[str, Any] | None:
+    """Preview ``vm.clone`` — echo the clone coordinates (no I/O)."""
+    source_vm = ctx.params.get("source_vm")
+    target_name = ctx.params.get("target_name")
+    library_item = ctx.params.get("library_item")
+    if (
+        not isinstance(source_vm, str)
+        or not isinstance(target_name, str)
+        or not isinstance(library_item, str)
+    ):
+        return None
+    return {
+        "source_vm": source_vm,
+        "target_name": target_name,
+        "library_item": library_item,
+        "wait_for_completion": bool(ctx.params.get("wait_for_completion", True)),
+    }
+
+
+async def _vm_snapshot_revert_preview(ctx: PreviewContext) -> dict[str, Any] | None:
+    """Preview ``vm.snapshot.revert`` — echo the revert coordinates (no I/O).
+
+    The destructive scope is "this VM reverts to the snapshot named X",
+    which the params fully convey; match/ambiguity resolution stays the
+    handler's job (it refuses ambiguous or missing names safely).
+    """
+    vm = ctx.params.get("vm")
+    snapshot_name = ctx.params.get("snapshot_name")
+    if not isinstance(vm, str) or not isinstance(snapshot_name, str):
+        return None
+    return {"vm": vm, "snapshot_name": snapshot_name}
+
+
+async def _vm_migrate_preview(ctx: PreviewContext) -> dict[str, Any] | None:
+    """Preview ``vm.migrate`` — echo coordinates + how the target host resolves.
+
+    Deliberately no DRS read: a recommendation fetched at park time is
+    point-in-time and the approved dispatch re-consults DRS, so echoing a
+    predicted host could mislead the reviewer. ``target_host_source``
+    says whether the host is operator-pinned or DRS-resolved at
+    execution.
+    """
+    vm = ctx.params.get("vm")
+    cluster = ctx.params.get("cluster")
+    if not isinstance(vm, str) or not isinstance(cluster, str):
+        return None
+    explicit_target = ctx.params.get("target_host")
+    if isinstance(explicit_target, str):
+        return {
+            "vm": vm,
+            "cluster": cluster,
+            "target_host": explicit_target,
+            "target_host_source": "operator",
+        }
+    return {
+        "vm": vm,
+        "cluster": cluster,
+        "target_host": None,
+        "target_host_source": "drs_at_execution",
+    }
+
+
+#: op_id → builder for the 8 write composites. Module-level so the
+#: registration below and the wiring tests share one source of truth.
+_WRITE_PREVIEW_BUILDERS: dict[str, PreviewBuilder] = {
+    "vmware.composite.vm.create": _vm_create_preview,
+    "vmware.composite.vm.clone": _vm_clone_preview,
+    "vmware.composite.vm.snapshot.revert": _vm_snapshot_revert_preview,
+    "vmware.composite.vm.migrate": _vm_migrate_preview,
+    "vmware.composite.vm.power.bulk": _vm_power_bulk_preview,
+    "vmware.composite.host.evacuate": _host_evacuate_preview,
+    "vmware.composite.host.detach_from_vds": _host_detach_from_vds_preview,
+    "vmware.composite.cluster.patch": _cluster_patch_preview,
+}
+
+
+def _register_vmware_write_preview_builders() -> None:
+    """Wire the 8 write-composite park-time preview builders. Import-time.
+
+    The 5 read composites register no builder — they are
+    ``requires_approval=False`` and never park, so a preview would be
+    dead code.
+    """
+    for op_id, builder in _WRITE_PREVIEW_BUILDERS.items():
+        register_preview_builder(op_id, builder)
+
+
+_register_vmware_write_preview_builders()

--- a/backend/tests/test_connectors_vmware_rest_composites_write_preview.py
+++ b/backend/tests/test_connectors_vmware_rest_composites_write_preview.py
@@ -1,0 +1,631 @@
+# SPDX-License-Identifier: Apache-2.0
+# Copyright (c) 2026 evoila Group
+
+"""Park-time ``proposed_effect`` previews for the 8 vmware write composites.
+
+G0.22-T3 (#1608) acceptance criteria:
+
+1. A parked ``vmware.composite.vm.power.bulk`` request's
+   ``proposed_effect`` carries the requested ``action``, the ``filter``
+   echoed, and the ``resolved`` (capped) entity list + ``total_resolved``
+   — asserted against the durable :class:`ApprovalRequest` row through
+   the production :func:`~meho_backplane.operations.dispatch` park path.
+2. The preview path issues **only reads**: the park records exactly one
+   ``GET:/vcenter/vm`` leaf call and no power sub-op; the read-only
+   adapter additionally refuses any non-``GET:`` op_id structurally.
+3. The resolution logic is shared, not duplicated — the builders call
+   the same :func:`._write._resolve_vm_list` /
+   :func:`._write._resolve_cluster_hosts` helpers the handlers use
+   (asserted via the wiring test + the helpers' single definition site).
+4. All 8 write composites register a builder (4 live-read + 4 param
+   echo); the wiring test pins the full set.
+
+Harness: mirrors :mod:`tests.test_connectors_vmware_rest_composites_write_e2e`
+(recording leaf typed-ops + in-process SQLite dispatcher), trimmed to the
+two listing leaves the park-time previews actually read — at park time
+the composite handler never runs, so no other leaf descriptor is needed.
+"""
+
+from __future__ import annotations
+
+import uuid
+from collections.abc import Iterator
+from typing import Any
+from unittest.mock import AsyncMock
+from uuid import UUID
+
+import pytest
+
+import meho_backplane.operations._audit as audit_module
+from meho_backplane.auth.operator import Operator, PrincipalKind, TenantRole
+from meho_backplane.broadcast import BroadcastEvent
+from meho_backplane.connectors import OperationResult
+from meho_backplane.connectors.base import Connector
+from meho_backplane.connectors.registry import clear_registry, register_connector_v2
+from meho_backplane.connectors.schemas import FingerprintResult, ProbeResult
+from meho_backplane.connectors.vmware_rest.composites import (
+    _write_preview,
+    register_vmware_composite_operations,
+)
+from meho_backplane.db.engine import get_sessionmaker
+from meho_backplane.db.models import ApprovalRequest, ApprovalRequestStatus
+from meho_backplane.operations import (
+    dispatch,
+    register_typed_operation,
+    reset_dispatcher_caches,
+)
+from meho_backplane.operations._preview import _PREVIEW_BUILDERS, PreviewContext
+from meho_backplane.settings import get_settings
+
+_CONNECTOR_ID = "vmware-rest-9.0"
+_TENANT_ID = UUID("00000000-0000-0000-0000-00000000a0a8")
+
+_WRITE_COMPOSITE_OP_IDS: frozenset[str] = frozenset(
+    {
+        "vmware.composite.vm.create",
+        "vmware.composite.vm.clone",
+        "vmware.composite.vm.snapshot.revert",
+        "vmware.composite.vm.migrate",
+        "vmware.composite.vm.power.bulk",
+        "vmware.composite.host.evacuate",
+        "vmware.composite.host.detach_from_vds",
+        "vmware.composite.cluster.patch",
+    }
+)
+
+
+# ---------------------------------------------------------------------------
+# Fixtures (mirror tests.test_connectors_vmware_rest_composites_write_e2e)
+# ---------------------------------------------------------------------------
+
+
+@pytest.fixture(autouse=True)
+def _required_settings_env(monkeypatch: pytest.MonkeyPatch) -> Iterator[None]:
+    """Pin every env var :class:`Settings` requires for this module."""
+    monkeypatch.setenv("KEYCLOAK_ISSUER_URL", "https://keycloak.test/realms/meho")
+    monkeypatch.setenv("KEYCLOAK_AUDIENCE", "meho-backplane")
+    monkeypatch.setenv("VAULT_ADDR", "https://vault.test")
+    get_settings.cache_clear()
+    yield
+    get_settings.cache_clear()
+
+
+@pytest.fixture(autouse=True)
+def _reset_module_state() -> Iterator[None]:
+    """Reset dispatcher caches + connector registry around each test."""
+    reset_dispatcher_caches()
+    clear_registry()
+    yield
+    reset_dispatcher_caches()
+    clear_registry()
+
+
+@pytest.fixture
+def stub_embedding_service() -> AsyncMock:
+    """Deterministic embedding stub so registrations skip ONNX."""
+    service = AsyncMock()
+    service.encode_one.return_value = [0.1] * 384
+    service.encode.return_value = [[0.1] * 384]
+    service.dimension = 384
+    return service
+
+
+@pytest.fixture(autouse=True)
+def captured_events(monkeypatch: pytest.MonkeyPatch) -> list[BroadcastEvent]:
+    """Replace the audit path's :func:`publish_event` with a recording stub."""
+    events: list[BroadcastEvent] = []
+
+    async def _capture(event: BroadcastEvent) -> None:
+        events.append(event)
+
+    monkeypatch.setattr(audit_module, "publish_event", _capture)
+    return events
+
+
+def _make_operator(*, sub: str = "op-vmware-write-preview") -> Operator:
+    """Synthetic USER operator — the principal kind the approval park routes."""
+    return Operator(
+        sub=sub,
+        name="VMware Write Preview Test",
+        email=None,
+        raw_jwt="<test-raw-jwt>",
+        tenant_id=_TENANT_ID,
+        tenant_role=TenantRole.OPERATOR,
+        principal_kind=PrincipalKind.USER,
+    )
+
+
+class _FakeFingerprint:
+    """Duck-typed fingerprint for the resolver."""
+
+    def __init__(self, version: str | None = "9.0") -> None:
+        self.version = version
+
+
+class _FakeVmwareTarget:
+    """Minimal target the resolver / dispatcher reads from."""
+
+    def __init__(self, target_id: UUID | None = None) -> None:
+        self.product = "vmware"
+        self.fingerprint = _FakeFingerprint(version="9.0")
+        self.preferred_impl_id: str | None = "vmware-rest"
+        self.id: UUID = target_id or uuid.uuid4()
+        self.name = "test-vcenter"
+        self.host = "vcenter.test"
+        self.port = 443
+        self.auth_model = "shared_service_account"
+
+
+class _NoOpVmwareConnector(Connector):
+    """Resolver-satisfying connector — the typed leaf path never invokes it."""
+
+    product = "vmware"
+    version = "9.0"
+    impl_id = "vmware-rest"
+
+    async def fingerprint(self, target: Any, operator: Any = None) -> FingerprintResult:  # type: ignore[override]
+        raise NotImplementedError
+
+    async def probe(self, target: Any) -> ProbeResult:  # type: ignore[override]
+        raise NotImplementedError
+
+    async def execute(  # type: ignore[override]
+        self,
+        target: Any,
+        op_id: str,
+        params: dict[str, Any],
+    ) -> OperationResult:
+        raise NotImplementedError
+
+
+# ---------------------------------------------------------------------------
+# Recording leaf stubs — only the two listing reads the previews issue
+# ---------------------------------------------------------------------------
+
+#: Ordered record of every leaf op_id dispatched in the current test.
+_CALLS: list[tuple[str, dict[str, Any]]] = []
+
+#: Per-op canned response payload (vSphere REST envelope shape).
+_RESPONSES: dict[str, Any] = {}
+
+#: op_ids whose stub should raise (drives the fail-soft branch).
+_FAILURES: dict[str, str] = {}
+
+
+def _record(op_id: str, params: dict[str, Any]) -> dict[str, Any]:
+    """Append a leaf call and resolve its canned payload, raising on failure."""
+    _CALLS.append((op_id, dict(params)))
+    if op_id in _FAILURES:
+        raise RuntimeError(_FAILURES[op_id])
+    return _RESPONSES.get(op_id, {"value": []})
+
+
+async def _h_list_vms(target: Any, params: dict[str, Any]) -> dict[str, Any]:
+    return _record("GET:/vcenter/vm", params)
+
+
+async def _h_list_cluster_hosts(target: Any, params: dict[str, Any]) -> dict[str, Any]:
+    return _record("GET:/vcenter/cluster/{cluster}/host", params)
+
+
+_LEAF_HANDLERS: dict[str, Any] = {
+    "GET:/vcenter/vm": _h_list_vms,
+    "GET:/vcenter/cluster/{cluster}/host": _h_list_cluster_hosts,
+}
+
+
+def _reset_recorder() -> None:
+    _CALLS.clear()
+    _RESPONSES.clear()
+    _FAILURES.clear()
+
+
+async def _bootstrap_registry(stub_embedding_service: AsyncMock) -> None:
+    """Register the connector, the 13 composites, and the listing leaves."""
+    register_connector_v2(
+        product="vmware",
+        version="9.0",
+        impl_id="vmware-rest",
+        cls=_NoOpVmwareConnector,
+    )
+    await register_vmware_composite_operations(embedding_service=stub_embedding_service)
+    permissive_schema = {"type": "object", "additionalProperties": True}
+    for op_id, handler in _LEAF_HANDLERS.items():
+        await register_typed_operation(
+            product="vmware",
+            version="9.0",
+            impl_id="vmware-rest",
+            op_id=op_id,
+            handler=handler,
+            summary=f"Stub leaf op {op_id} for the write-preview tests.",
+            description=f"Stub leaf op {op_id} for the write-preview tests.",
+            parameter_schema=permissive_schema,
+            when_to_use=None,
+            embedding_service=stub_embedding_service,
+        )
+    _reset_recorder()
+
+
+def _ops_in_calls() -> list[str]:
+    return [op_id for op_id, _ in _CALLS]
+
+
+async def _park(
+    op_id: str,
+    params: dict[str, Any],
+    *,
+    target: _FakeVmwareTarget | None = None,
+) -> tuple[OperationResult, ApprovalRequest]:
+    """Dispatch *op_id* as a USER (no grant) and return (result, parked row)."""
+    result = await dispatch(
+        operator=_make_operator(),
+        connector_id=_CONNECTOR_ID,
+        op_id=op_id,
+        target=target or _FakeVmwareTarget(),
+        params=params,
+    )
+    assert result.status == "awaiting_approval", result.error
+    request_id = UUID(result.extras["approval_request_id"])
+    async with get_sessionmaker()() as session:
+        row = await session.get(ApprovalRequest, request_id)
+    assert row is not None
+    assert row.status == ApprovalRequestStatus.PENDING.value
+    return result, row
+
+
+# ===========================================================================
+# Wiring — all 8 write composites register a builder (criterion 4)
+# ===========================================================================
+
+
+def test_all_eight_write_composites_register_a_preview_builder() -> None:
+    """Importing the composites package wires a builder per write composite.
+
+    The side-effect import in ``composites/__init__`` must register every
+    ``requires_approval=True`` composite; a rename or dropped entry would
+    silently regress that op to the identifier-only default.
+    """
+    assert set(_write_preview._WRITE_PREVIEW_BUILDERS) == set(_WRITE_COMPOSITE_OP_IDS)
+    for op_id, builder in _write_preview._WRITE_PREVIEW_BUILDERS.items():
+        assert _PREVIEW_BUILDERS.get(op_id) is builder, op_id
+
+
+# ===========================================================================
+# Read-only adapter — structural GET-only guard (criterion 2, belt)
+# ===========================================================================
+
+
+def _make_preview_ctx(params: dict[str, Any]) -> PreviewContext:
+    """A :class:`PreviewContext` for builder-direct unit tests."""
+    return PreviewContext(
+        descriptor=object(),  # type: ignore[arg-type]  # echo builders ignore it
+        connector_instance=None,
+        operator=_make_operator(),
+        target=_FakeVmwareTarget(),
+        params=params,
+    )
+
+
+async def test_read_only_adapter_refuses_non_get_op_ids() -> None:
+    """The adapter rejects any mutating op_id before lookup or I/O fires."""
+    adapter = _write_preview._read_only_dispatch_child(_make_preview_ctx({}))
+    for op_id in (
+        "POST:/vcenter/vm/{vm}/power?action=start",
+        "DELETE:/vcenter/vm/{vm}",
+        "PATCH:/vcenter/vm/{vm}/network",
+    ):
+        result = await adapter(connector_id=_CONNECTOR_ID, op_id=op_id, params={})
+        assert result.status == "error"
+        assert "GET-only" in (result.error or "")
+
+
+# ===========================================================================
+# Echo builders — params fully name the blast radius (no I/O)
+# ===========================================================================
+
+
+async def test_vm_create_preview_echoes_creation_spec() -> None:
+    preview = await _write_preview._vm_create_preview(
+        _make_preview_ctx(
+            {
+                "folder_name": "prod",
+                "name": "vm-new",
+                "guest_os": "UBUNTU_64",
+                "cpu_count": 4,
+                "memory_mib": 8192,
+                "nics": [{"network": "net-1"}, {"network": "net-2"}],
+                "power_on_after_create": True,
+            }
+        )
+    )
+    assert preview == {
+        "name": "vm-new",
+        "guest_os": "UBUNTU_64",
+        "folder_name": "prod",
+        "cpu_count": 4,
+        "memory_mib": 8192,
+        "networks": ["net-1", "net-2"],
+        "power_on_after_create": True,
+    }
+
+
+async def test_vm_create_preview_mirrors_handler_defaults() -> None:
+    preview = await _write_preview._vm_create_preview(
+        _make_preview_ctx({"folder_name": "prod", "name": "vm-new", "guest_os": "UBUNTU_64"})
+    )
+    assert preview is not None
+    assert preview["cpu_count"] == 1
+    assert preview["memory_mib"] == 1024
+    assert preview["networks"] == []
+    assert preview["power_on_after_create"] is False
+
+
+async def test_vm_clone_preview_echoes_clone_coordinates() -> None:
+    preview = await _write_preview._vm_clone_preview(
+        _make_preview_ctx(
+            {
+                "source_vm": "vm-1",
+                "target_name": "vm-clone",
+                "library_item": "lib-1",
+                "wait_for_completion": False,
+            }
+        )
+    )
+    assert preview == {
+        "source_vm": "vm-1",
+        "target_name": "vm-clone",
+        "library_item": "lib-1",
+        "wait_for_completion": False,
+    }
+
+
+async def test_vm_snapshot_revert_preview_echoes_revert_coordinates() -> None:
+    preview = await _write_preview._vm_snapshot_revert_preview(
+        _make_preview_ctx({"vm": "vm-1", "snapshot_name": "pre-upgrade"})
+    )
+    assert preview == {"vm": "vm-1", "snapshot_name": "pre-upgrade"}
+
+
+async def test_vm_migrate_preview_names_target_host_resolution() -> None:
+    """Operator-pinned host echoes verbatim; DRS path is honest about runtime resolution."""
+    pinned = await _write_preview._vm_migrate_preview(
+        _make_preview_ctx({"vm": "vm-1", "cluster": "domain-c1", "target_host": "host-9"})
+    )
+    assert pinned == {
+        "vm": "vm-1",
+        "cluster": "domain-c1",
+        "target_host": "host-9",
+        "target_host_source": "operator",
+    }
+    drs = await _write_preview._vm_migrate_preview(
+        _make_preview_ctx({"vm": "vm-1", "cluster": "domain-c1"})
+    )
+    assert drs == {
+        "vm": "vm-1",
+        "cluster": "domain-c1",
+        "target_host": None,
+        "target_host_source": "drs_at_execution",
+    }
+
+
+async def test_echo_builders_decline_on_malformed_params() -> None:
+    """Missing required params decline (→ identifier-only default), never raise."""
+    assert await _write_preview._vm_create_preview(_make_preview_ctx({})) is None
+    assert await _write_preview._vm_clone_preview(_make_preview_ctx({})) is None
+    assert await _write_preview._vm_snapshot_revert_preview(_make_preview_ctx({})) is None
+    assert await _write_preview._vm_migrate_preview(_make_preview_ctx({})) is None
+    assert await _write_preview._vm_power_bulk_preview(_make_preview_ctx({})) is None
+    assert await _write_preview._host_evacuate_preview(_make_preview_ctx({})) is None
+    assert await _write_preview._host_detach_from_vds_preview(_make_preview_ctx({})) is None
+    assert await _write_preview._cluster_patch_preview(_make_preview_ctx({})) is None
+
+
+# ===========================================================================
+# vm.power.bulk — the parked row carries action + filter + resolved set
+# (criteria 1 + 2, through the production dispatch park path)
+# ===========================================================================
+
+
+async def test_power_bulk_park_carries_action_filter_and_resolved_set(
+    stub_embedding_service: AsyncMock,
+) -> None:
+    """The parked row's ``proposed_effect`` names the blast radius (criterion 1).
+
+    The reviewer sees the requested ``action``, the ``filter`` echoed, and
+    the resolved VM identities with the uncapped count — not just
+    ``{op_id, connector_id, target_id}``.
+    """
+    await _bootstrap_registry(stub_embedding_service)
+    _RESPONSES["GET:/vcenter/vm"] = {
+        "value": [
+            {"vm": "vm-a", "name": "web-a", "power_state": "POWERED_ON", "cpu_count": 2},
+            {"vm": "vm-b", "name": "web-b", "power_state": "POWERED_OFF", "cpu_count": 4},
+        ]
+    }
+
+    _, row = await _park(
+        "vmware.composite.vm.power.bulk",
+        {"action": "stop", "filter": {"names": ["web-*"]}},
+    )
+
+    assert row.proposed_effect == {
+        "op_class": "other",
+        "preview": {
+            "action": "stop",
+            "filter": {"names": ["web-*"]},
+            "resolved": [
+                {"vm": "vm-a", "name": "web-a", "power_state": "POWERED_ON"},
+                {"vm": "vm-b", "name": "web-b", "power_state": "POWERED_OFF"},
+            ],
+            "total_resolved": 2,
+        },
+    }
+    # The filter reached the listing read in the handler's wire shape.
+    assert _CALLS == [("GET:/vcenter/vm", {"filter.names": ["web-*"]})]
+
+
+async def test_power_bulk_park_issues_only_the_listing_read(
+    stub_embedding_service: AsyncMock,
+) -> None:
+    """No power mutation fires on the park path (criterion 2).
+
+    The recorded leaf calls contain exactly the one listing GET — no
+    ``POST:/vcenter/vm/{vm}/power?action=...`` — even though the listing
+    resolved VMs the approved dispatch would act on.
+    """
+    await _bootstrap_registry(stub_embedding_service)
+    _RESPONSES["GET:/vcenter/vm"] = {"value": [{"vm": "vm-a"}, {"vm": "vm-b"}]}
+
+    await _park("vmware.composite.vm.power.bulk", {"action": "start"})
+
+    assert _ops_in_calls() == ["GET:/vcenter/vm"]
+
+
+async def test_power_bulk_resolved_list_is_capped_with_true_total(
+    stub_embedding_service: AsyncMock,
+) -> None:
+    """A wide filter caps ``resolved`` at the preview cap; ``total_resolved`` is uncapped."""
+    await _bootstrap_registry(stub_embedding_service)
+    _RESPONSES["GET:/vcenter/vm"] = {
+        "value": [{"vm": f"vm-{i}", "name": f"node-{i}"} for i in range(25)]
+    }
+
+    _, row = await _park("vmware.composite.vm.power.bulk", {"action": "suspend"})
+
+    preview = row.proposed_effect["preview"]
+    assert len(preview["resolved"]) == _write_preview._PREVIEW_RESOLVED_CAP
+    assert preview["total_resolved"] == 25
+    assert preview["resolved"][0] == {"vm": "vm-0", "name": "node-0"}
+
+
+async def test_power_bulk_preview_failure_fails_soft_to_identifier_default(
+    stub_embedding_service: AsyncMock,
+) -> None:
+    """A failing listing read degrades to the identifier-only default; the park proceeds."""
+    await _bootstrap_registry(stub_embedding_service)
+    _FAILURES["GET:/vcenter/vm"] = "vCenter listing unavailable"
+
+    target = _FakeVmwareTarget()
+    _, row = await _park(
+        "vmware.composite.vm.power.bulk",
+        {"action": "reset"},
+        target=target,
+    )
+
+    assert row.proposed_effect == {
+        "op_id": "vmware.composite.vm.power.bulk",
+        "connector_id": _CONNECTOR_ID,
+        "target_id": str(target.id),
+    }
+
+
+# ===========================================================================
+# The other live-read previews — host.evacuate / host.detach / cluster.patch
+# ===========================================================================
+
+
+async def test_host_evacuate_park_resolves_vm_set_on_host(
+    stub_embedding_service: AsyncMock,
+) -> None:
+    await _bootstrap_registry(stub_embedding_service)
+    _RESPONSES["GET:/vcenter/vm"] = {
+        "value": [{"vm": "vm-a", "name": "app-a", "cluster": "domain-c1"}]
+    }
+
+    _, row = await _park("vmware.composite.host.evacuate", {"host": "host-1"})
+
+    assert row.proposed_effect == {
+        "op_class": "other",
+        "preview": {
+            "host": "host-1",
+            "tolerate_partial_failure": False,
+            "resolved": [{"vm": "vm-a", "name": "app-a"}],
+            "total_resolved": 1,
+        },
+    }
+    # Only the listing read fired — no recursive migrate, no maintenance.
+    assert _CALLS == [("GET:/vcenter/vm", {"filter.hosts": ["host-1"]})]
+
+
+async def test_host_detach_from_vds_park_resolves_vm_set_on_host(
+    stub_embedding_service: AsyncMock,
+) -> None:
+    await _bootstrap_registry(stub_embedding_service)
+    _RESPONSES["GET:/vcenter/vm"] = {"value": [{"vm": "vm-a", "name": "app-a"}]}
+
+    _, row = await _park(
+        "vmware.composite.host.detach_from_vds",
+        {"host": "host-1", "dvs": "dvs-1", "fallback_network": "net-fallback"},
+    )
+
+    assert row.proposed_effect == {
+        "op_class": "other",
+        "preview": {
+            "host": "host-1",
+            "dvs": "dvs-1",
+            "fallback_network": "net-fallback",
+            "resolved": [{"vm": "vm-a", "name": "app-a"}],
+            "total_resolved": 1,
+        },
+    }
+    assert _ops_in_calls() == ["GET:/vcenter/vm"]
+
+
+async def test_cluster_patch_park_resolves_host_set(
+    stub_embedding_service: AsyncMock,
+) -> None:
+    await _bootstrap_registry(stub_embedding_service)
+    _RESPONSES["GET:/vcenter/cluster/{cluster}/host"] = {
+        "value": [
+            {"host": "host-1", "name": "esx-1"},
+            {"host": "host-2", "name": "esx-2"},
+        ]
+    }
+
+    _, row = await _park("vmware.composite.cluster.patch", {"cluster": "domain-c1"})
+
+    assert row.proposed_effect == {
+        "op_class": "write",
+        "preview": {
+            "cluster": "domain-c1",
+            "patch_method": "default",
+            "resolved": [
+                {"host": "host-1", "name": "esx-1"},
+                {"host": "host-2", "name": "esx-2"},
+            ],
+            "total_resolved": 2,
+        },
+    }
+    # Only the host listing fired — no maintenance / patch sub-ops.
+    assert _ops_in_calls() == ["GET:/vcenter/cluster/{cluster}/host"]
+
+
+# ===========================================================================
+# Echo preview through the production park path — zero leaf reads
+# ===========================================================================
+
+
+async def test_vm_create_park_carries_echo_preview_without_any_read(
+    stub_embedding_service: AsyncMock,
+) -> None:
+    """The echo previews enrich the parked row with zero connector I/O."""
+    await _bootstrap_registry(stub_embedding_service)
+
+    _, row = await _park(
+        "vmware.composite.vm.create",
+        {"folder_name": "prod", "name": "vm-new", "guest_os": "UBUNTU_64"},
+    )
+
+    assert row.proposed_effect == {
+        "op_class": "write",
+        "preview": {
+            "name": "vm-new",
+            "guest_os": "UBUNTU_64",
+            "folder_name": "prod",
+            "cpu_count": 1,
+            "memory_mib": 1024,
+            "networks": [],
+            "power_on_after_create": False,
+        },
+    }
+    assert _CALLS == []

--- a/docs/codebase/approvals.md
+++ b/docs/codebase/approvals.md
@@ -241,8 +241,19 @@ way (#1452): `argocd.app.set` / `argocd.appproject.update` populate
 `{before_spec, after_spec}` and `argocd.app.delete` populates
 `{cascade_resources}` from read-only GETs against the live
 Application / AppProject — wired in
-`connectors/argocd/ops_write_preview.py`. Further connectors register
-their own builders as needed.
+`connectors/argocd/ops_write_preview.py`. The `secret.move` broker op
+populates a ref-only `{action, source, sink}` summary with no store I/O
+(#1580, `connectors/secret/move_preview.py`). The 8 vmware write
+composites register builders in
+`connectors/vmware_rest/composites/_write_preview.py` (#1608): the
+fan-out composites (`vm.power.bulk`, `host.evacuate`,
+`host.detach_from_vds`, `cluster.patch`) resolve their entity set via
+the same read-only listing helpers the handlers use — `{..., resolved,
+total_resolved}` with the list capped — and the single-entity
+composites echo their params; see
+[`connectors-vmware-rest.md`](connectors-vmware-rest.md) "Park-time
+approval previews". Further connectors register their own builders as
+needed.
 
 ## Permission preflight hook (#1504)
 

--- a/docs/codebase/connectors-vmware-rest.md
+++ b/docs/codebase/connectors-vmware-rest.md
@@ -355,6 +355,64 @@ write composites prefer "stop and report" semantics over silent
 rollback -- the operator decides whether to manually finish or
 revert.
 
+### Park-time approval previews (#1608)
+
+All 8 write composites ship `requires_approval=True`, so a human/agent
+dispatch parks as a durable `ApprovalRequest` row. Pre-#1608 that row's
+`proposed_effect` was the identifier-only default `{op_id, connector_id,
+target_id}` — and since the dispatch `params` are deliberately never
+serialised onto a reviewer-facing surface (#1503), the four-eyes
+approver could not tell a one-VM power cycle from a 1000-VM outage.
+
+`composites/_write_preview.py` registers one preview builder per write
+composite on the generic per-op hook (`register_preview_builder`,
+`operations/_preview.py`, #1437). The builder result lands under
+`proposed_effect["preview"]`, wrapped with the op's sensitivity
+`op_class` (see [`approvals.md`](approvals.md)). Two depths:
+
+| Composite | Preview | Depth |
+| --- | --- | --- |
+| `vm.power.bulk` | `{action, filter, resolved, total_resolved}` | live read (`GET:/vcenter/vm`) |
+| `host.evacuate` | `{host, tolerate_partial_failure, resolved, total_resolved}` | live read (`GET:/vcenter/vm`) |
+| `host.detach_from_vds` | `{host, dvs, fallback_network, resolved, total_resolved}` | live read (`GET:/vcenter/vm`) |
+| `cluster.patch` | `{cluster, patch_method, resolved, total_resolved}` | live read (`GET:/vcenter/cluster/{cluster}/host`) |
+| `vm.create` | creation-spec echo (name, guest_os, sizing, networks, power-on) | param echo, no I/O |
+| `vm.clone` | clone-coordinates echo | param echo, no I/O |
+| `vm.snapshot.revert` | `{vm, snapshot_name}` echo | param echo, no I/O |
+| `vm.migrate` | `{vm, cluster, target_host, target_host_source}` | param echo, no I/O |
+
+The live-read previews resolve the same entity set the approved
+dispatch would act on, through the **same shared helpers** the handlers
+use at dispatch time (`_write._resolve_vm_list` /
+`_write._resolve_cluster_hosts`) — one resolution code path, two call
+sites. The `resolved` list is capped at 20 entries
+(`_PREVIEW_RESOLVED_CAP`), identity-only per row (`vm`/`host`, `name`,
+`power_state`); `total_resolved` always carries the uncapped count. The
+four param-echo composites name their full blast radius in params, so
+no read can change what the preview says; `vm.migrate` deliberately
+does **not** pre-resolve a DRS recommendation (point-in-time output
+would mislead the reviewer — the preview says
+`target_host_source="drs_at_execution"` instead).
+
+At park time the composite handler never runs, so the builders cannot
+receive the dispatcher's `dispatch_child`. They construct a **read-only
+adapter** (`_read_only_dispatch_child`) that satisfies the same
+`DispatchChild` protocol but executes the sub-op directly against the
+resolved connector (descriptor lookup → `dispatch_ingested` /
+`dispatch_typed`), never through `dispatch()`: no policy-gate re-entry
+(a read-gating policy could otherwise park the preview's own sub-op
+from inside the parent's park), no unparented audit rows (the
+`approval.request` row — the audit anchor — is written *after* the
+preview), and a fail-closed `GET:`-prefix guard so the park path can
+never mutate vSphere state. This mirrors how the k8s.apply dry-run
+(#1437), the argocd snapshot reads (#1452), and the vault capability
+probe (#1504) run their preview I/O — connector-level, un-dispatched.
+
+Everything is fail-soft: a builder that declines or raises (vCenter
+unreachable, listing op not ingested yet) degrades the row to the
+identifier-only default and the park always proceeds. The 5 read
+composites register no builder — they never park.
+
 ## Dependencies
 
 - `meho_backplane.connectors.adapters.http.HttpConnector` (G0.2-T3


### PR DESCRIPTION
## Summary

- A parked `vmware.composite.*` write approval previously stored only the identifier default `{op_id, connector_id, target_id}` in `proposed_effect` — and since dispatch `params` are deliberately never reviewer-facing (#1503), a four-eyes approver could not tell a one-VM power cycle from a 1000-VM outage. This registers a park-time preview builder for **all 8 write composites** on the generic `register_preview_builder` hook (#1437), extending the #1504/#1454/#1580 pattern to the vmware connector.
- **Fan-out composites resolve their blast radius live**: `vm.power.bulk` stores `{action, filter, resolved, total_resolved}`; `host.evacuate` / `host.detach_from_vds` / `cluster.patch` store their coordinates + the resolved VM/host set. The `resolved` list is capped at 20 identity-only rows (`vm`/`host`, `name`, `power_state`); `total_resolved` carries the uncapped count. Resolution is **shared, not duplicated** — the dispatch-time listing logic is factored into `_resolve_vm_list` / `_resolve_cluster_hosts` in `composites/_write.py`, called by both the handlers and the builders.
- **Single-entity composites echo their params** (`vm.create`, `vm.clone`, `vm.snapshot.revert`, `vm.migrate` — the secret.move precedent, #1580): params fully name their blast radius, so no read can change what the preview says. `vm.migrate` deliberately does not pre-resolve a DRS recommendation (point-in-time output would mislead the reviewer); it reports `target_host_source="drs_at_execution"` instead.
- **Preview reads are read-only by construction**: at park time the composite handler never runs, so the builders construct a `DispatchChild`-conformant adapter that executes the listing read directly against the resolved connector (descriptor lookup → `dispatch_ingested`/`dispatch_typed`) with a fail-closed `GET:`-prefix guard — never through `dispatch()`. This avoids policy-gate re-entry (a read-gating policy could otherwise create approval rows from inside a park) and unparented audit rows (the `approval.request` audit anchor is written *after* the preview), mirroring how the k8s.apply dry-run (#1437), argocd snapshot reads (#1452), and vault capability probe (#1504) run their preview I/O. Everything stays fail-soft: any builder fault degrades to the identifier-only default and the park proceeds.

## Test plan

- [x] `ruff check src/ tests/` — clean
- [x] `ruff format --check src/ tests/` — clean
- [x] `mypy src/` (strict) — clean, 465 files
- [x] Full backend unit lane `pytest tests/ --ignore=tests/integration` — all passed
- [x] **AC: parked `vm.power.bulk` `proposed_effect` carries `action` + `filter` + `resolved` (capped) + `total_resolved`** — `test_power_bulk_park_carries_action_filter_and_resolved_set` parks through the production `dispatch()` gate and asserts the durable `ApprovalRequest` row's exact payload; `test_power_bulk_resolved_list_is_capped_with_true_total` proves the 20-row cap with `total_resolved=25`.
- [x] **AC: the preview path issues only reads** — `test_power_bulk_park_issues_only_the_listing_read` parks the op against recording leaf stubs (the same deterministic harness `test_connectors_vmware_rest_composites_write_e2e.py` uses in place of respx/vcsim) and asserts the recorded leaf calls are exactly `["GET:/vcenter/vm"]` — no power sub-op fired; `test_read_only_adapter_refuses_non_get_op_ids` proves the structural GET-only guard.
- [x] **AC: resolution shared, not duplicated** — `grep -rn _resolve_vm_list src/` shows one definition (`composites/_write.py`) called by the handlers (`_write.py:829,905,1003`) and the builders (`_write_preview.py`); same for `_resolve_cluster_hosts`.
- [x] **AC: all 8 composites covered** — every write composite registers a builder (4 live-read + 4 param-echo; the wiring test pins the full set), exceeding the "at least `vm.power.bulk` + rationale" minimum. Per-builder unit tests cover the echo shapes, defaults, and malformed-param declines; `test_power_bulk_preview_failure_fails_soft_to_identifier_default` proves the park survives a failing listing read.
- [x] **AC: docs + CHANGELOG** — `docs/codebase/connectors-vmware-rest.md` gains a "Park-time approval previews" section (preview contract, cap, adapter rationale); `docs/codebase/approvals.md`'s builder-registry section now names the secret.move and vmware builders; one CHANGELOG `[Unreleased]` bullet.

## Out of scope

- A generic auto-preview for **all** spec-ingested writes (noted in the task as a separate follow-up if the gap recurs); this PR covers the vmware composites.
- The composite L2 preflight classification work tracked under #1601/#1602 (adjacent; both merged).
- Adjacent finding (pre-existing, recorded not fixed): the code-quality checker warns on `host_detach_from_vds_composite` (71 lines) and the `_write.py` module size — legacy debt predating this change.

<!-- auto-implement-issue: fresh, iteration 1 -->

Closes #1608
