### PR TITLE
feat(api): runbook list endpoints honour ?envelope=v2 — unified {items, next_cursor} shape (#1611)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -106,6 +106,13 @@ connector-related release-notes line.
   `vm.snapshot.revert`, `vm.migrate`) echo their blast-radius-naming
   params. Preview reads are GET-only by construction and fail-soft —
   the park always proceeds (#1608).
+- `GET /api/v1/runbooks/templates` and `GET /api/v1/runbooks/runs` now
+  honour the `?envelope=v2` opt-in and return the unified
+  `{items, next_cursor}` list shape (api-shape-conventions §2), joining
+  the seven sibling list endpoints widened in #1312/#1356. Both listings
+  are unpaged, so `next_cursor` is always `null`; omitting the param
+  keeps the keyed `{"templates": [...]}` / `{"runs": [...]}` defaults
+  unchanged (#1611).
 
 ### Fixed
 

--- a/backend/src/meho_backplane/api/v1/_envelope.py
+++ b/backend/src/meho_backplane/api/v1/_envelope.py
@@ -43,16 +43,19 @@ endpoint.
 
 Code reference: see :func:`meho_backplane.api.v1.targets.list_targets`
 for the reference adoption (the first endpoint widened to honour the
-opt-in). All five §2 list endpoints now accept the opt-in: the
+opt-in). All five §2 list endpoints accept the opt-in: the
 ``targets`` reference and the topology ``dependents`` /
 ``dependencies`` endpoints (G0.16-T6 Finding A #1312), plus the four
 sister endpoints
 (``conventions`` / ``audit/my-recent`` / ``broadcast/overrides``
 / ``connectors``) widened by G0.18-T3 (#1356), completing #1312
-acceptance A. The MCP sister tools are v2-native (they call the
-service layer in-process and return their own list shapes, with no
-HTTP ``?envelope=`` param to forward); the CLI typed clients consume
-the v0.8.0 default shape, so neither forwards the param.
+acceptance A. The two runbook list endpoints
+(``runbooks/templates`` / ``runbooks/runs``) shipped after the §2
+sweep and joined the opt-in in G0.22-T6 (#1611). The MCP sister
+tools are v2-native (they call the service layer in-process and
+return their own list shapes, with no HTTP ``?envelope=`` param to
+forward); the CLI typed clients consume the v0.8.0 default shape,
+so neither forwards the param.
 """
 
 from __future__ import annotations

--- a/backend/src/meho_backplane/api/v1/runbook_runs.py
+++ b/backend/src/meho_backplane/api/v1/runbook_runs.py
@@ -44,13 +44,15 @@ Route inventory
   load-bearing escalation knob (per #1198, ``runbook_reassign`` is the
   *only* way for a senior to take over a junior's stuck run).
 * ``GET /api/v1/runbooks/runs`` -- list runs the caller can see. Query
-  params: ``assignee``, ``status``, ``template_slug``, ``limit``.
-  Returns a :class:`RunbookListRunsResponse` envelope wrapping
-  ``list[RunSummary]``. Role: ``operator`` at the gate; the service
-  branches on the handler-computed ``caller_is_admin`` flag so an
-  ``OPERATOR`` only ever sees their own runs (filter ``assignee`` is
-  ignored) while a ``TENANT_ADMIN`` sees all tenant runs (filter
-  honoured as-is).
+  params: ``assignee``, ``status``, ``template_slug``, ``limit``,
+  ``envelope``. Returns a :class:`RunbookListRunsResponse` envelope
+  wrapping ``list[RunSummary]`` by default; ``?envelope=v2`` returns
+  the unified ``{"items": [...], "next_cursor": null}`` shape per
+  ``docs/codebase/api-shape-conventions.md`` §2 (G0.22-T6 #1611).
+  Role: ``operator`` at the gate; the service branches on the
+  handler-computed ``caller_is_admin`` flag so an ``OPERATOR`` only
+  ever sees their own runs (filter ``assignee`` is ignored) while a
+  ``TENANT_ADMIN`` sees all tenant runs (filter honoured as-is).
 
 Tenant scoping
 --------------
@@ -175,8 +177,14 @@ from typing import Final, Literal
 import structlog
 from fastapi import APIRouter, Depends, Query
 from fastapi import status as http_status
+from fastapi.responses import JSONResponse
 from pydantic import BaseModel, ConfigDict
 
+from meho_backplane.api.v1._envelope import (
+    ENVELOPE_QUERY,
+    EnvelopeVersion,
+    wrap_v2_envelope,
+)
 from meho_backplane.api.v1._errors import http_for, register_error
 from meho_backplane.auth.operator import Operator, TenantRole
 from meho_backplane.auth.rbac import require_role
@@ -514,7 +522,8 @@ async def list_runs(
     limit: int = Query(default=100, ge=1, le=500),
     operator: Operator = _require_operator,
     service: RunbookRunService = _RUNBOOK_RUN_SERVICE,
-) -> RunbookListRunsResponse:
+    envelope: EnvelopeVersion | None = ENVELOPE_QUERY,
+) -> RunbookListRunsResponse | JSONResponse:
     """List runs for the operator's tenant, scoped by role.
 
     Role floor: ``operator``. The handler computes
@@ -540,6 +549,22 @@ async def list_runs(
     :class:`~meho_backplane.runbooks.runs_schemas.ListRunsFilter`
     internally.
 
+    The default response is the v0.8.0 keyed
+    :class:`RunbookListRunsResponse` shape (``{"runs": [...]}``).
+    Passing ``?envelope=v2`` returns the unified ``{"items": [...],
+    "next_cursor": null}`` shape per
+    ``docs/codebase/api-shape-conventions.md`` §2 -- the listing is
+    not cursor-paginated (``limit`` truncates), so ``next_cursor`` is
+    always ``null`` under the opt-in, matching the sibling unpaged
+    adopters. Omitting the param keeps the keyed default so no client
+    breaks (G0.22-T6 #1611, joining the shape unified in #1356/#1366).
+
+    The v2 envelope is emitted via a raw :class:`JSONResponse` rather
+    than a union return type: that keeps ``response_model`` (and so
+    the documented OpenAPI 200 schema, and the typed CLI client
+    generated from it) as the named :class:`RunbookListRunsResponse`
+    while still letting the opt-in branch return the unified shape.
+
     Binds ``audit_op_id="runbook.list_runs"`` + ``audit_op_class=
     "read"`` before the service call. ``runbook.list_runs`` matches
     no ``.list`` / ``.get`` suffix the broadcast classifier
@@ -561,4 +586,11 @@ async def list_runs(
         filter_=filter_,
         limit=limit,
     )
+    if envelope == "v2":
+        return JSONResponse(
+            wrap_v2_envelope(
+                [summary.model_dump(mode="json") for summary in summaries],
+                next_cursor=None,
+            )
+        )
     return RunbookListRunsResponse(runs=summaries)

--- a/backend/src/meho_backplane/api/v1/runbook_templates.py
+++ b/backend/src/meho_backplane/api/v1/runbook_templates.py
@@ -19,8 +19,11 @@ Route inventory
   HTTP 201. Role: ``tenant_admin``.
 * ``GET /api/v1/runbooks/templates`` -- list the latest version of each
   slug for the operator's tenant. Query params: ``status``,
-  ``target_kind``, ``limit``. Returns
-  :class:`RunbookTemplateListResponse`. Role: ``operator``.
+  ``target_kind``, ``limit``, ``envelope``. Returns
+  :class:`RunbookTemplateListResponse` by default; ``?envelope=v2``
+  returns the unified ``{"items": [...], "next_cursor": null}`` shape
+  per ``docs/codebase/api-shape-conventions.md`` §2 (G0.22-T6 #1611).
+  Role: ``operator``.
 * ``GET /api/v1/runbooks/templates/{slug}`` -- fetch the full body of one
   template. Query param: ``version`` (optional -> latest). Returns
   :class:`~meho_backplane.runbooks.schemas.ShowTemplateResponse`. 404 when
@@ -130,8 +133,14 @@ from typing import Final, Literal
 import structlog
 from fastapi import APIRouter, Depends, HTTPException, Query
 from fastapi import status as http_status
+from fastapi.responses import JSONResponse
 from pydantic import BaseModel, ConfigDict
 
+from meho_backplane.api.v1._envelope import (
+    ENVELOPE_QUERY,
+    EnvelopeVersion,
+    wrap_v2_envelope,
+)
 from meho_backplane.api.v1._errors import http_for, register_error
 from meho_backplane.auth.operator import Operator, TenantRole
 from meho_backplane.auth.rbac import require_role
@@ -277,7 +286,8 @@ async def list_templates(
     target_kind: str | None = Query(default=None),
     limit: int = Query(default=100, ge=1, le=500),
     operator: Operator = _require_operator,
-) -> RunbookTemplateListResponse:
+    envelope: EnvelopeVersion | None = ENVELOPE_QUERY,
+) -> RunbookTemplateListResponse | JSONResponse:
     """List the latest version of each template slug for the operator's tenant.
 
     Tenant-scoped to ``operator.tenant_id`` -- no surface accepts a tenant
@@ -294,6 +304,22 @@ async def list_templates(
     :class:`~meho_backplane.runbooks.schemas.ListTemplatesFilter`
     internally.
 
+    The default response is the v0.8.0 keyed
+    :class:`RunbookTemplateListResponse` shape (``{"templates": [...]}``).
+    Passing ``?envelope=v2`` returns the unified ``{"items": [...],
+    "next_cursor": null}`` shape per
+    ``docs/codebase/api-shape-conventions.md`` §2 -- the listing is not
+    cursor-paginated (``limit`` truncates), so ``next_cursor`` is always
+    ``null`` under the opt-in, matching the sibling unpaged adopters.
+    Omitting the param keeps the keyed default so no client breaks
+    (G0.22-T6 #1611, joining the shape unified in #1356/#1366).
+
+    The v2 envelope is emitted via a raw :class:`JSONResponse` rather
+    than a union return type: that keeps ``response_model`` (and so the
+    documented OpenAPI 200 schema, and the typed CLI client generated
+    from it) as the named :class:`RunbookTemplateListResponse` while
+    still letting the opt-in branch return the unified shape.
+
     Binds ``audit_op_id="runbook.list_templates"`` + ``audit_op_class=
     "read"`` before the service call.
     """
@@ -308,6 +334,13 @@ async def list_templates(
         template_filter,
         limit=limit,
     )
+    if envelope == "v2":
+        return JSONResponse(
+            wrap_v2_envelope(
+                [summary.model_dump(mode="json") for summary in summaries],
+                next_cursor=None,
+            )
+        )
     return RunbookTemplateListResponse(templates=summaries)
 
 

--- a/backend/tests/test_api_v1_list_envelope_v2.py
+++ b/backend/tests/test_api_v1_list_envelope_v2.py
@@ -9,12 +9,14 @@ passing ``?envelope=v2`` returns ``{items, next_cursor?, ...sidecars}``;
 omitting it keeps the v0.8.0 default shape so no client breaks.
 
 This module asserts the shape contract uniformly across the four sister
-list endpoints widened in this Task (``conventions``, ``audit/my-recent``,
-``broadcast/overrides``, ``connectors``) in one place. The two endpoints
-that adopted the opt-in in #1312 (``targets`` and the topology
-``dependents`` / ``dependencies`` endpoints) keep their own envelope
-tests in ``test_api_v1_targets.py`` / ``test_api_v1_topology.py``, so all
-five §2 surfaces are covered. The per-endpoint behavioural suites own the
+list endpoints widened in that Task (``conventions``, ``audit/my-recent``,
+``broadcast/overrides``, ``connectors``) plus the two runbook list
+endpoints (``runbooks/templates`` / ``runbooks/runs``) that shipped after
+the §2 sweep and joined the opt-in in G0.22-T6 (#1611), in one place. The
+two endpoints that adopted the opt-in in #1312 (``targets`` and the
+topology ``dependents`` / ``dependencies`` endpoints) keep their own
+envelope tests in ``test_api_v1_targets.py`` / ``test_api_v1_topology.py``,
+so every §2 surface is covered. The per-endpoint behavioural suites own the
 data-bearing pagination / sidecar assertions; this file pins the envelope
 *contract* — that every endpoint honours the param, returns the unified
 shape with the param, and is byte-shape-unchanged without it.
@@ -106,12 +108,15 @@ async def _seed_tenant() -> None:
 #: shape wraps its list under, or ``None`` when the default is a bare
 #: JSON array. The topology node-scoped endpoints + ``targets`` keep
 #: their envelope tests in their own suites; here we cover the four
-#: sister endpoints widened by this Task.
+#: sister endpoints widened by #1356 plus the two runbook list
+#: endpoints widened by #1611.
 _CASES = [
     pytest.param("/api/v1/conventions", "entries", id="conventions"),
     pytest.param("/api/v1/audit/my-recent", "rows", id="audit-my-recent"),
     pytest.param("/api/v1/broadcast/overrides", None, id="broadcast-overrides"),
     pytest.param("/api/v1/connectors", "connectors", id="connectors"),
+    pytest.param("/api/v1/runbooks/templates", "templates", id="runbook-templates"),
+    pytest.param("/api/v1/runbooks/runs", "runs", id="runbook-runs"),
 ]
 
 

--- a/backend/tests/test_runbook_runs_api.py
+++ b/backend/tests/test_runbook_runs_api.py
@@ -971,6 +971,36 @@ def test_list_runs_invalid_status_422(client: TestClient) -> None:
     assert response.status_code == 422
 
 
+def test_list_runs_envelope_v2_unified_shape(client: TestClient) -> None:
+    """``?envelope=v2`` returns ``{items, next_cursor}``; the keyed field is absent.
+
+    G0.22-T6 (#1611): the same rows the default ``{"runs": [...]}`` shape
+    carries ride under ``items``; the listing is unpaged so ``next_cursor``
+    is always ``null``. The cross-endpoint contract pin lives in
+    ``test_api_v1_list_envelope_v2.py``; this test owns the data-bearing
+    assertion that the v2 items match the keyed payload.
+    """
+    run_id = uuid.uuid4()
+    key, token = _operator_token(sub="op-operator")
+    fake_list = AsyncMock(return_value=[_run_summary(run_id=run_id, assigned_to="op-operator")])
+    with (
+        respx.mock as mock_router,
+        patch(f"{_SERVICE_ROUTE}.list_runs", fake_list),
+    ):
+        _mock_discovery_and_jwks(mock_router, _public_jwks(key))
+        response = client.get(
+            "/api/v1/runbooks/runs?envelope=v2",
+            headers=_authed(token),
+        )
+
+    assert response.status_code == 200
+    body = response.json()
+    assert [item["run_id"] for item in body["items"]] == [str(run_id)]
+    assert body["items"][0]["started_at"] == "2026-05-01T11:00:00Z"
+    assert body["next_cursor"] is None
+    assert "runs" not in body
+
+
 def test_list_runs_cross_tenant_isolation(client: TestClient) -> None:
     """Operator's tenant_id is the *only* tenant id the service ever sees.
 

--- a/backend/tests/test_runbook_templates_api.py
+++ b/backend/tests/test_runbook_templates_api.py
@@ -473,6 +473,43 @@ def test_list_invalid_status_422(client: TestClient) -> None:
     assert response.status_code == 422
 
 
+def test_list_envelope_v2_unified_shape(client: TestClient) -> None:
+    """``?envelope=v2`` returns ``{items, next_cursor}``; the keyed field is absent.
+
+    G0.22-T6 (#1611): the same rows the default ``{"templates": [...]}``
+    shape carries ride under ``items``; the listing is unpaged so
+    ``next_cursor`` is always ``null``. The cross-endpoint contract pin
+    lives in ``test_api_v1_list_envelope_v2.py``; this test owns the
+    data-bearing assertion that the v2 items match the keyed payload.
+    """
+    key, token = _operator_token()
+    summary = TemplateSummary(
+        slug="rotate-cert",
+        version=1,
+        title="Rotate certificate",
+        status="draft",
+        target_kind="host",
+        edited_at=datetime(2026, 1, 2, tzinfo=UTC),
+    )
+    fake_list = AsyncMock(return_value=[summary])
+    with (
+        respx.mock as mock_router,
+        patch(f"{_ROUTE}.list_templates", fake_list),
+    ):
+        _mock_discovery_and_jwks(mock_router, _public_jwks(key))
+        response = client.get(
+            "/api/v1/runbooks/templates?envelope=v2",
+            headers=_authed(token),
+        )
+
+    assert response.status_code == 200
+    body = response.json()
+    assert [item["slug"] for item in body["items"]] == ["rotate-cert"]
+    assert body["items"][0]["edited_at"] == "2026-01-02T00:00:00Z"
+    assert body["next_cursor"] is None
+    assert "templates" not in body
+
+
 # ---------------------------------------------------------------------------
 # GET /{slug} -- show
 # ---------------------------------------------------------------------------

--- a/cli/api/openapi.json
+++ b/cli/api/openapi.json
@@ -3650,7 +3650,7 @@
           "runbooks"
         ],
         "summary": "List Templates",
-        "description": "List the latest version of each template slug for the operator's tenant.\n\nTenant-scoped to ``operator.tenant_id`` -- no surface accepts a tenant\nid from the query string. ``read_only`` operators get 403 via\n:func:`require_role` before reaching this handler; ``operator`` and\n``tenant_admin`` both pass.\n\nThe optional ``status`` / ``target_kind`` filters narrow the rows\nconsidered before the latest-per-slug projection; ``limit`` is capped\nat 500. ``status`` is typed as the closed ``draft`` / ``published`` /\n``deprecated`` vocabulary, so an out-of-vocabulary value trips a clean\n422 at FastAPI's query-parameter validation boundary (before the\nhandler body runs) rather than a 500 from constructing the\n:class:`~meho_backplane.runbooks.schemas.ListTemplatesFilter`\ninternally.\n\nBinds ``audit_op_id=\"runbook.list_templates\"`` + ``audit_op_class=\n\"read\"`` before the service call.",
+        "description": "List the latest version of each template slug for the operator's tenant.\n\nTenant-scoped to ``operator.tenant_id`` -- no surface accepts a tenant\nid from the query string. ``read_only`` operators get 403 via\n:func:`require_role` before reaching this handler; ``operator`` and\n``tenant_admin`` both pass.\n\nThe optional ``status`` / ``target_kind`` filters narrow the rows\nconsidered before the latest-per-slug projection; ``limit`` is capped\nat 500. ``status`` is typed as the closed ``draft`` / ``published`` /\n``deprecated`` vocabulary, so an out-of-vocabulary value trips a clean\n422 at FastAPI's query-parameter validation boundary (before the\nhandler body runs) rather than a 500 from constructing the\n:class:`~meho_backplane.runbooks.schemas.ListTemplatesFilter`\ninternally.\n\nThe default response is the v0.8.0 keyed\n:class:`RunbookTemplateListResponse` shape (``{\"templates\": [...]}``).\nPassing ``?envelope=v2`` returns the unified ``{\"items\": [...],\n\"next_cursor\": null}`` shape per\n``docs/codebase/api-shape-conventions.md`` \u00a72 -- the listing is not\ncursor-paginated (``limit`` truncates), so ``next_cursor`` is always\n``null`` under the opt-in, matching the sibling unpaged adopters.\nOmitting the param keeps the keyed default so no client breaks\n(G0.22-T6 #1611, joining the shape unified in #1356/#1366).\n\nThe v2 envelope is emitted via a raw :class:`JSONResponse` rather\nthan a union return type: that keeps ``response_model`` (and so the\ndocumented OpenAPI 200 schema, and the typed CLI client generated\nfrom it) as the named :class:`RunbookTemplateListResponse` while\nstill letting the opt-in branch return the unified shape.\n\nBinds ``audit_op_id=\"runbook.list_templates\"`` + ``audit_op_class=\n\"read\"`` before the service call.",
         "operationId": "list_templates_api_v1_runbooks_templates_get",
         "parameters": [
           {
@@ -3689,6 +3689,19 @@
               "default": 100,
               "title": "Limit"
             }
+          },
+          {
+            "name": "envelope",
+            "in": "query",
+            "required": false,
+            "schema": {
+              "const": "v2",
+              "type": "string",
+              "nullable": true,
+              "description": "Opt into the unified list-envelope shape per docs/codebase/api-shape-conventions.md \u00a72. Pass `v2` to receive `{items, next_cursor?, ...sidecars}`; omit to keep the v0.8.0 bare/keyed default. The opt-in is non-breaking across release cycles \u2014 the default flips after two cycles and the legacy shape is removed three cycles after that (G0.16-T6 Finding A #1312).",
+              "title": "Envelope"
+            },
+            "description": "Opt into the unified list-envelope shape per docs/codebase/api-shape-conventions.md \u00a72. Pass `v2` to receive `{items, next_cursor?, ...sidecars}`; omit to keep the v0.8.0 bare/keyed default. The opt-in is non-breaking across release cycles \u2014 the default flips after two cycles and the legacy shape is removed three cycles after that (G0.16-T6 Finding A #1312)."
           },
           {
             "name": "authorization",
@@ -4049,7 +4062,7 @@
           "runbooks"
         ],
         "summary": "List Runs",
-        "description": "List runs for the operator's tenant, scoped by role.\n\nRole floor: ``operator``. The handler computes\n``caller_is_admin`` from ``operator.tenant_role`` and passes it\nto the service:\n\n* ``caller_is_admin=False`` (operator path) -- the service forces\n  ``assignee=operator.sub`` regardless of what the query string\n  says, so an ``OPERATOR`` only ever sees their own runs even if\n  they try to filter to another assignee. The filter is a\n  *narrow* surface for their own view, never an *escape* into\n  another operator's.\n* ``caller_is_admin=True`` (admin path) -- the filter is honoured\n  as-is, so a ``TENANT_ADMIN`` can pass ``?assignee=<other-sub>``\n  to inspect a junior's runs.\n\nTenant-scoped to ``operator.tenant_id`` -- no surface accepts a\ntenant id from the query string. ``status`` is typed as the\nclosed ``in_progress`` / ``completed`` / ``abandoned`` vocabulary,\nso an out-of-vocabulary value trips a clean 422 at FastAPI's\nquery-parameter validation boundary (before the handler body\nruns) rather than a 500 from constructing the\n:class:`~meho_backplane.runbooks.runs_schemas.ListRunsFilter`\ninternally.\n\nBinds ``audit_op_id=\"runbook.list_runs\"`` + ``audit_op_class=\n\"read\"`` before the service call. ``runbook.list_runs`` matches\nno ``.list`` / ``.get`` suffix the broadcast classifier\nrecognises, so the explicit override is load-bearing to keep\nclassification from defaulting to ``op_class=\"other\"`` (same\ngotcha :mod:`meho_backplane.api.v1.runbook_templates`'s\n``list_templates`` documents).",
+        "description": "List runs for the operator's tenant, scoped by role.\n\nRole floor: ``operator``. The handler computes\n``caller_is_admin`` from ``operator.tenant_role`` and passes it\nto the service:\n\n* ``caller_is_admin=False`` (operator path) -- the service forces\n  ``assignee=operator.sub`` regardless of what the query string\n  says, so an ``OPERATOR`` only ever sees their own runs even if\n  they try to filter to another assignee. The filter is a\n  *narrow* surface for their own view, never an *escape* into\n  another operator's.\n* ``caller_is_admin=True`` (admin path) -- the filter is honoured\n  as-is, so a ``TENANT_ADMIN`` can pass ``?assignee=<other-sub>``\n  to inspect a junior's runs.\n\nTenant-scoped to ``operator.tenant_id`` -- no surface accepts a\ntenant id from the query string. ``status`` is typed as the\nclosed ``in_progress`` / ``completed`` / ``abandoned`` vocabulary,\nso an out-of-vocabulary value trips a clean 422 at FastAPI's\nquery-parameter validation boundary (before the handler body\nruns) rather than a 500 from constructing the\n:class:`~meho_backplane.runbooks.runs_schemas.ListRunsFilter`\ninternally.\n\nThe default response is the v0.8.0 keyed\n:class:`RunbookListRunsResponse` shape (``{\"runs\": [...]}``).\nPassing ``?envelope=v2`` returns the unified ``{\"items\": [...],\n\"next_cursor\": null}`` shape per\n``docs/codebase/api-shape-conventions.md`` \u00a72 -- the listing is\nnot cursor-paginated (``limit`` truncates), so ``next_cursor`` is\nalways ``null`` under the opt-in, matching the sibling unpaged\nadopters. Omitting the param keeps the keyed default so no client\nbreaks (G0.22-T6 #1611, joining the shape unified in #1356/#1366).\n\nThe v2 envelope is emitted via a raw :class:`JSONResponse` rather\nthan a union return type: that keeps ``response_model`` (and so\nthe documented OpenAPI 200 schema, and the typed CLI client\ngenerated from it) as the named :class:`RunbookListRunsResponse`\nwhile still letting the opt-in branch return the unified shape.\n\nBinds ``audit_op_id=\"runbook.list_runs\"`` + ``audit_op_class=\n\"read\"`` before the service call. ``runbook.list_runs`` matches\nno ``.list`` / ``.get`` suffix the broadcast classifier\nrecognises, so the explicit override is load-bearing to keep\nclassification from defaulting to ``op_class=\"other\"`` (same\ngotcha :mod:`meho_backplane.api.v1.runbook_templates`'s\n``list_templates`` documents).",
         "operationId": "list_runs_api_v1_runbooks_runs_get",
         "parameters": [
           {
@@ -4098,6 +4111,19 @@
               "default": 100,
               "title": "Limit"
             }
+          },
+          {
+            "name": "envelope",
+            "in": "query",
+            "required": false,
+            "schema": {
+              "const": "v2",
+              "type": "string",
+              "nullable": true,
+              "description": "Opt into the unified list-envelope shape per docs/codebase/api-shape-conventions.md \u00a72. Pass `v2` to receive `{items, next_cursor?, ...sidecars}`; omit to keep the v0.8.0 bare/keyed default. The opt-in is non-breaking across release cycles \u2014 the default flips after two cycles and the legacy shape is removed three cycles after that (G0.16-T6 Finding A #1312).",
+              "title": "Envelope"
+            },
+            "description": "Opt into the unified list-envelope shape per docs/codebase/api-shape-conventions.md \u00a72. Pass `v2` to receive `{items, next_cursor?, ...sidecars}`; omit to keep the v0.8.0 bare/keyed default. The opt-in is non-breaking across release cycles \u2014 the default flips after two cycles and the legacy shape is removed three cycles after that (G0.16-T6 Finding A #1312)."
           },
           {
             "name": "authorization",

--- a/cli/internal/api/client.gen.go
+++ b/cli/internal/api/client.gen.go
@@ -5419,11 +5419,14 @@ type UsageEndpointApiV1RetrieveUsageGetParamsSurface string
 
 // ListRunsApiV1RunbooksRunsGetParams defines parameters for ListRunsApiV1RunbooksRunsGet.
 type ListRunsApiV1RunbooksRunsGetParams struct {
-	Assignee      *string                                   `form:"assignee,omitempty" json:"assignee,omitempty"`
-	Status        *ListRunsApiV1RunbooksRunsGetParamsStatus `form:"status,omitempty" json:"status,omitempty"`
-	TemplateSlug  *string                                   `form:"template_slug,omitempty" json:"template_slug,omitempty"`
-	Limit         *int                                      `form:"limit,omitempty" json:"limit,omitempty"`
-	Authorization *string                                   `json:"authorization,omitempty"`
+	Assignee     *string                                   `form:"assignee,omitempty" json:"assignee,omitempty"`
+	Status       *ListRunsApiV1RunbooksRunsGetParamsStatus `form:"status,omitempty" json:"status,omitempty"`
+	TemplateSlug *string                                   `form:"template_slug,omitempty" json:"template_slug,omitempty"`
+	Limit        *int                                      `form:"limit,omitempty" json:"limit,omitempty"`
+
+	// Envelope Opt into the unified list-envelope shape per docs/codebase/api-shape-conventions.md §2. Pass `v2` to receive `{items, next_cursor?, ...sidecars}`; omit to keep the v0.8.0 bare/keyed default. The opt-in is non-breaking across release cycles — the default flips after two cycles and the legacy shape is removed three cycles after that (G0.16-T6 Finding A #1312).
+	Envelope      *string `form:"envelope,omitempty" json:"envelope,omitempty"`
+	Authorization *string `json:"authorization,omitempty"`
 }
 
 // ListRunsApiV1RunbooksRunsGetParamsStatus defines parameters for ListRunsApiV1RunbooksRunsGet.
@@ -5451,10 +5454,13 @@ type ReassignRunApiV1RunbooksRunsRunIdReassignPostParams struct {
 
 // ListTemplatesApiV1RunbooksTemplatesGetParams defines parameters for ListTemplatesApiV1RunbooksTemplatesGet.
 type ListTemplatesApiV1RunbooksTemplatesGetParams struct {
-	Status        *ListTemplatesApiV1RunbooksTemplatesGetParamsStatus `form:"status,omitempty" json:"status,omitempty"`
-	TargetKind    *string                                             `form:"target_kind,omitempty" json:"target_kind,omitempty"`
-	Limit         *int                                                `form:"limit,omitempty" json:"limit,omitempty"`
-	Authorization *string                                             `json:"authorization,omitempty"`
+	Status     *ListTemplatesApiV1RunbooksTemplatesGetParamsStatus `form:"status,omitempty" json:"status,omitempty"`
+	TargetKind *string                                             `form:"target_kind,omitempty" json:"target_kind,omitempty"`
+	Limit      *int                                                `form:"limit,omitempty" json:"limit,omitempty"`
+
+	// Envelope Opt into the unified list-envelope shape per docs/codebase/api-shape-conventions.md §2. Pass `v2` to receive `{items, next_cursor?, ...sidecars}`; omit to keep the v0.8.0 bare/keyed default. The opt-in is non-breaking across release cycles — the default flips after two cycles and the legacy shape is removed three cycles after that (G0.16-T6 Finding A #1312).
+	Envelope      *string `form:"envelope,omitempty" json:"envelope,omitempty"`
+	Authorization *string `json:"authorization,omitempty"`
 }
 
 // ListTemplatesApiV1RunbooksTemplatesGetParamsStatus defines parameters for ListTemplatesApiV1RunbooksTemplatesGet.
@@ -14714,6 +14720,22 @@ func NewListRunsApiV1RunbooksRunsGetRequest(server string, params *ListRunsApiV1
 
 		}
 
+		if params.Envelope != nil {
+
+			if queryFrag, err := runtime.StyleParamWithLocation("form", true, "envelope", runtime.ParamLocationQuery, *params.Envelope); err != nil {
+				return nil, err
+			} else if parsed, err := url.ParseQuery(queryFrag); err != nil {
+				return nil, err
+			} else {
+				for k, v := range parsed {
+					for _, v2 := range v {
+						queryValues.Add(k, v2)
+					}
+				}
+			}
+
+		}
+
 		queryURL.RawQuery = queryValues.Encode()
 	}
 
@@ -15038,6 +15060,22 @@ func NewListTemplatesApiV1RunbooksTemplatesGetRequest(server string, params *Lis
 		if params.Limit != nil {
 
 			if queryFrag, err := runtime.StyleParamWithLocation("form", true, "limit", runtime.ParamLocationQuery, *params.Limit); err != nil {
+				return nil, err
+			} else if parsed, err := url.ParseQuery(queryFrag); err != nil {
+				return nil, err
+			} else {
+				for k, v := range parsed {
+					for _, v2 := range v {
+						queryValues.Add(k, v2)
+					}
+				}
+			}
+
+		}
+
+		if params.Envelope != nil {
+
+			if queryFrag, err := runtime.StyleParamWithLocation("form", true, "envelope", runtime.ParamLocationQuery, *params.Envelope); err != nil {
 				return nil, err
 			} else if parsed, err := url.ParseQuery(queryFrag); err != nil {
 				return nil, err

--- a/docs/codebase/api-shape-conventions.md
+++ b/docs/codebase/api-shape-conventions.md
@@ -207,20 +207,26 @@ adoption on
 via the shared helper
 [`backend/src/meho_backplane/api/v1/_envelope.py`](../../backend/src/meho_backplane/api/v1/_envelope.py)
 (``EnvelopeVersion`` type, ``ENVELOPE_QUERY`` declaration,
-``wrap_v2_envelope`` builder). All five list endpoints now accept
+``wrap_v2_envelope`` builder). All five list endpoints accept
 the opt-in: `targets` (the reference) and the topology
 `dependents`/`dependencies` reads in #1312, plus the four sister
 endpoints (``conventions`` / ``audit/my-recent`` /
 ``broadcast/overrides`` / ``connectors``) in G0.18-T3 (#1356),
-completing #1312 acceptance A. The ``connectors``, ``conventions``,
-and ``broadcast/overrides`` lists are unpaginated, so their
-``next_cursor`` is always ``null`` under the opt-in; ``conventions``
-carries ``budget_status`` as a top-level sidecar.
+completing #1312 acceptance A. The two runbook list endpoints
+(``GET /api/v1/runbooks/templates`` / ``GET /api/v1/runbooks/runs``)
+shipped after that sweep with product-specific keyed shapes
+(``{"templates": [...]}`` / ``{"runs": [...]}``) and joined the
+opt-in in G0.22-T6 (#1611). The ``connectors``, ``conventions``,
+``broadcast/overrides``, and both runbook lists are unpaginated, so
+their ``next_cursor`` is always ``null`` under the opt-in;
+``conventions`` carries ``budget_status`` as a top-level sidecar.
 
-The three sister endpoints with a named/typed v0.8.0 response model
+The sister endpoints with a named/typed v0.8.0 response model
 (``conventions`` → ``ConventionListResponse``, ``audit/my-recent``
 → ``AuditQueryResult``, ``broadcast/overrides`` →
-``[BroadcastOverrideRead]``) keep ``response_model`` on the route and
+``[BroadcastOverrideRead]``, ``runbooks/templates`` →
+``RunbookTemplateListResponse``, ``runbooks/runs`` →
+``RunbookListRunsResponse``) keep ``response_model`` on the route and
 emit the v2 envelope via a raw ``JSONResponse`` in the opt-in branch.
 That preserves the named OpenAPI 200 schema — and the typed CLI
 client generated from it — while still returning the unified shape


### PR DESCRIPTION
## Summary
- `GET /api/v1/runbooks/templates` and `GET /api/v1/runbooks/runs` now honour the `?envelope=v2` opt-in and return the unified `{items, next_cursor}` list shape (api-shape-conventions §2), joining the seven sibling list endpoints widened in #1312/#1356. Both listings are unpaged, so `next_cursor` is always `null` under the opt-in — matching the sibling unpaged adopters.
- The default keyed shapes (`{"templates": [...]}` / `{"runs": [...]}`) are byte-shape-unchanged. Both routes keep `response_model` and emit the v2 envelope via a raw `JSONResponse`, so the named OpenAPI 200 schema — and the typed Go CLI client generated from it — is untouched apart from the new optional `envelope` query parameter (same rationale §2 documents for the #1356 adopters).
- The cross-endpoint conformance suite (`test_api_v1_list_envelope_v2.py`) now pins both runbook routes; the per-endpoint suites gain data-bearing v2 tests; the committed CLI OpenAPI snapshot + generated client are refreshed; the adopter inventories in `_envelope.py` and the §2 convention doc are updated.

## Test plan
- [x] `ruff check src/ tests/` — clean
- [x] `ruff format --check src/ tests/` — clean
- [x] `mypy src/` — clean (465 files)
- [x] `pytest tests/test_api_v1_list_envelope_v2.py tests/test_runbook_templates_api.py tests/test_runbook_runs_api.py` — 84 passed
- [x] Full unit suite (`pytest -n 6 --dist loadscope --ignore=tests/integration`) — green
- [x] `GET /api/v1/runbooks/templates?envelope=v2` returns `{"items": [...], "next_cursor": null}`; without the param it still returns `{"templates": [...]}` — `test_list_envelope_v2_unified_shape` + conformance ids `runbook-templates`
- [x] Same for `GET /api/v1/runbooks/runs` (`{"runs": [...]}` default; `{items, next_cursor}` on v2) — `test_list_runs_envelope_v2_unified_shape` + conformance id `runbook-runs`
- [x] Both handlers use the shared `ENVELOPE_QUERY` + `wrap_v2_envelope` helpers — `grep -n "ENVELOPE_QUERY\|wrap_v2_envelope" backend/src/meho_backplane/api/v1/runbook_*.py` is non-empty (4 hits per file)
- [x] OpenAPI snapshot + CLI client regenerated (`cd cli && make snapshot-openapi && make generate`); `go build` + `go test ./...` green
- [x] CHANGELOG `[Unreleased]` carries one bullet

## Out of scope
- Real cursor pagination semantics for runbooks — `next_cursor` is emitted as `null`, per the issue's out-of-scope note (matches how the sibling unpaged endpoints handle it).
- The runbook MCP tool surface grammar (dotted `meho.runbook.*` aliases, template-id field naming) — sibling task #1612.

<!-- auto-implement-issue: fresh, iteration 1 -->

Closes #1611


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Runbook list endpoints now support an optional `?envelope=v2` query parameter to return responses in a unified envelope format with `items` and `next_cursor` fields; default response format remains unchanged for backward compatibility.

* **Documentation**
  * Updated API documentation and OpenAPI specification to document the new envelope parameter support.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->