### PR TITLE
fix(cli): connector ingest treats the async-202 job envelope as success — poll to completion or --no-wait (#1609)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -163,6 +163,20 @@ connector-related release-notes line.
   the newer migration scripts), and a failure-injection rollback drill
   are documented in `docs/codebase/migrations.md` and
   `docs/RELEASING.md` § 6b (#1607).
+- `meho connector ingest` no longer dies with a fatal
+  `unexpected_response` when a v0.12+ backplane answers the default
+  async shape (`202 Accepted` + ingest-job handle) — an error that hid
+  a successfully started job and baited operators into retrying, i.e.
+  double-ingesting. The CLI now treats 202 as success: it polls
+  `GET /api/v1/connectors/ingest/jobs/{job_id}` to a terminal status by
+  default (rendering the same summary / `--json` shape as the
+  synchronous path, with token refresh kept alive across long waits)
+  and a new `--no-wait` flag exits 0 with the job handle instead. A
+  failed job surfaces its `error_class` + message (exit 4), and a job
+  lost to a backplane restart tells the operator to check
+  `meho connector list` before re-running. Legacy synchronous `200`
+  responses (and `--dry-run`, which always runs inline) are unchanged
+  (#1609).
 
 ## [0.12.0] - 2026-06-08
 

--- a/cli/internal/cmd/connector/connector_test.go
+++ b/cli/internal/cmd/connector/connector_test.go
@@ -15,12 +15,16 @@ import (
 	"os"
 	"path/filepath"
 	"strings"
+	"sync/atomic"
 	"testing"
+	"time"
 
+	"github.com/google/uuid"
 	"github.com/spf13/cobra"
 
 	"github.com/evoila/meho/cli/internal/api"
 	"github.com/evoila/meho/cli/internal/auth"
+	"github.com/evoila/meho/cli/internal/output"
 )
 
 // ---------- helper tests (pure-function) ----------
@@ -378,6 +382,12 @@ func TestValidateIngestModeTable(t *testing.T) {
 		{"manual missing impl+spec", ingestOptions{
 			Product: "vmware", Version: "9.0",
 		}, "manual ingest requires --impl, --spec"},
+		{"no-wait + dry-run", ingestOptions{
+			Catalog: "vmware/9.0", DryRun: true, NoWait: true,
+		}, "--no-wait cannot be combined with --dry-run"},
+		{"no-wait alone is fine", ingestOptions{
+			Catalog: "vmware/9.0", NoWait: true,
+		}, ""},
 	}
 	for _, c := range cases {
 		err := validateIngestMode(c.opts)
@@ -982,18 +992,28 @@ func TestPostIngestRoundTripWithMockServer(t *testing.T) {
 	version := "9.0"
 	implID := "vmware-rest"
 	specs := []api.SpecSource{{Uri: "file:///abs/vcenter.yaml"}}
-	got, err := postIngest(context.Background(), srv.URL, api.IngestRequest{
+	authed, err := newAuthedClient(context.Background(), srv.URL)
+	if err != nil {
+		t.Fatalf("newAuthedClient: %v", err)
+	}
+	got, err := postIngest(context.Background(), authed, api.IngestRequest{
 		Product: &product, Version: &version, ImplId: &implID,
 		Specs: &specs,
 	})
 	if err != nil {
 		t.Fatalf("postIngest: %v", err)
 	}
-	if got.Ingestion.ConnectorId != "vmware-rest-9.0" || got.Ingestion.InsertedCount != 961 {
-		t.Fatalf("unexpected ingest result: %+v", got)
+	if got.job != nil {
+		t.Fatalf("sync 200 answer must not produce a job handle: %+v", got.job)
 	}
-	if got.Grouping == nil || got.Grouping.GroupsCreated != 9 {
-		t.Fatalf("unexpected grouping: %+v", got.Grouping)
+	if got.sync == nil {
+		t.Fatal("sync 200 answer must populate the IngestResponse")
+	}
+	if got.sync.Ingestion.ConnectorId != "vmware-rest-9.0" || got.sync.Ingestion.InsertedCount != 961 {
+		t.Fatalf("unexpected ingest result: %+v", got.sync)
+	}
+	if got.sync.Grouping == nil || got.sync.Grouping.GroupsCreated != 9 {
+		t.Fatalf("unexpected grouping: %+v", got.sync.Grouping)
 	}
 }
 
@@ -1143,6 +1163,415 @@ func TestRunIngestManualModePostsQuadruple(t *testing.T) {
 	}
 	if posted["product"] != "test" || posted["version"] != "1.0" || posted["impl_id"] != "test-impl" {
 		t.Errorf("manual mode posted quadruple wrong: %+v", posted)
+	}
+}
+
+// ---------- async-202 ingest (G0.22-T4 #1609) ----------
+
+// asyncIngestJobID is the fixed job id the async-202 mock fixtures
+// use; the GET-route key embeds it because mockBackplane routes on
+// the literal path.
+var asyncIngestJobID = uuid.MustParse("0c4b7e8f-1111-2222-3333-444455556666")
+
+// asyncIngestHandle builds the 202 envelope the #1303 backplane
+// returns for a default (async) ingest.
+func asyncIngestHandle() api.IngestJobHandle {
+	return api.IngestJobHandle{
+		JobId:   asyncIngestJobID,
+		Status:  api.IngestJobHandleStatusRunning,
+		PollUrl: "/api/v1/connectors/ingest/jobs/" + asyncIngestJobID.String(),
+	}
+}
+
+// TestPostIngest202ReturnsJobHandle pins the half of the #1609 fix
+// that used to be the bug: a 202 + IngestJobHandle is a *success*
+// shape on the postIngest surface, never an *httpResponseError
+// (the pre-fix code rendered it as a fatal unexpected_response
+// after the pipeline had already started server-side).
+func TestPostIngest202ReturnsJobHandle(t *testing.T) {
+	srv := mockBackplane(t, map[string]mockHandler{
+		"POST /api/v1/connectors/ingest": func(w http.ResponseWriter, _ *http.Request) {
+			writeJSON(t, w, 202, asyncIngestHandle())
+		},
+	})
+	defer srv.Close()
+	primeToken(t, srv.URL)
+
+	authed, err := newAuthedClient(context.Background(), srv.URL)
+	if err != nil {
+		t.Fatalf("newAuthedClient: %v", err)
+	}
+	catalog := "vmware/9.0"
+	got, err := postIngest(context.Background(), authed, api.IngestRequest{CatalogEntry: &catalog})
+	if err != nil {
+		t.Fatalf("postIngest on a 202 must not error (double-ingest bait): %v", err)
+	}
+	if got.sync != nil {
+		t.Fatalf("202 answer must not populate the sync IngestResponse: %+v", got.sync)
+	}
+	if got.job == nil {
+		t.Fatal("202 answer must populate the job handle")
+	}
+	if got.job.JobId != asyncIngestJobID || got.job.PollUrl != asyncIngestHandle().PollUrl {
+		t.Fatalf("unexpected handle: %+v", got.job)
+	}
+}
+
+// TestPostIngest202WithoutBodyErrors covers the decode guard: a 202
+// whose body didn't decode against IngestJobHandle (wrong content
+// type) is a contract violation, not a silent success.
+func TestPostIngest202WithoutBodyErrors(t *testing.T) {
+	srv := mockBackplane(t, map[string]mockHandler{
+		"POST /api/v1/connectors/ingest": func(w http.ResponseWriter, _ *http.Request) {
+			w.Header().Set("Content-Type", "text/plain")
+			w.WriteHeader(202)
+			_, _ = w.Write([]byte("accepted"))
+		},
+	})
+	defer srv.Close()
+	primeToken(t, srv.URL)
+
+	authed, err := newAuthedClient(context.Background(), srv.URL)
+	if err != nil {
+		t.Fatalf("newAuthedClient: %v", err)
+	}
+	catalog := "vmware/9.0"
+	_, err = postIngest(context.Background(), authed, api.IngestRequest{CatalogEntry: &catalog})
+	if err == nil || !strings.Contains(err.Error(), "202 Accepted but no JSON body") {
+		t.Fatalf("want decode-guard error, got %v", err)
+	}
+}
+
+// TestRunIngestAsyncPollsToSuccess pins the default async flow
+// end-to-end: POST → 202 + handle, poll → running, poll →
+// succeeded, then the CLI renders the exact summary the sync path
+// renders (assembled from the job's ingestion + grouping clusters)
+// and exits 0. Also pins single-submission: exactly one POST ever
+// leaves the CLI (the double-ingest regression guard).
+func TestRunIngestAsyncPollsToSuccess(t *testing.T) {
+	var postCalls, pollCalls atomic.Int32
+	srv := mockBackplane(t, map[string]mockHandler{
+		"POST /api/v1/connectors/ingest": func(w http.ResponseWriter, _ *http.Request) {
+			postCalls.Add(1)
+			writeJSON(t, w, 202, asyncIngestHandle())
+		},
+		"GET /api/v1/connectors/ingest/jobs/" + asyncIngestJobID.String(): func(w http.ResponseWriter, _ *http.Request) {
+			if pollCalls.Add(1) == 1 {
+				writeJSON(t, w, 200, api.IngestJobStatusResponse{
+					JobId:  asyncIngestJobID,
+					Status: api.IngestJobStatusResponseStatusRunning,
+				})
+				return
+			}
+			writeJSON(t, w, 200, api.IngestJobStatusResponse{
+				JobId:  asyncIngestJobID,
+				Status: api.IngestJobStatusResponseStatusSucceeded,
+				Ingestion: &api.IngestionResultModel{
+					ConnectorId:         "vmware-rest-9.0",
+					InsertedCount:       961,
+					ConnectorRegistered: true,
+					OperationsGrouped:   true,
+				},
+				Grouping: &api.GroupingResultModel{
+					ConnectorId:        "vmware-rest-9.0",
+					GroupsCreated:      9,
+					OperationsAssigned: 961,
+				},
+			})
+		},
+	})
+	defer srv.Close()
+	primeToken(t, srv.URL)
+
+	cmd := &cobra.Command{}
+	cmd.SetContext(context.Background())
+	var stdout, stderr bytes.Buffer
+	cmd.SetOut(&stdout)
+	cmd.SetErr(&stderr)
+
+	if err := runIngest(cmd, ingestOptions{
+		Catalog:           "vmware/9.0",
+		BackplaneOverride: srv.URL,
+		pollInterval:      time.Millisecond,
+	}); err != nil {
+		t.Fatalf("runIngest async: %v", err)
+	}
+	if got := postCalls.Load(); got != 1 {
+		t.Errorf("expected exactly 1 ingest POST (re-submitting double-ingests), got %d", got)
+	}
+	if got := pollCalls.Load(); got != 2 {
+		t.Errorf("expected 2 job polls (running, then succeeded), got %d", got)
+	}
+	out := stdout.String()
+	for _, want := range []string{
+		"ingest vmware/9.0/vmware-rest — connector_id=vmware-rest-9.0",
+		"operations: 961 total (961 inserted / 0 updated / 0 skipped)",
+		"grouping: 9 groups, 961 ops assigned",
+		"meho connector review vmware-rest-9.0",
+	} {
+		if !strings.Contains(out, want) {
+			t.Errorf("stdout missing %q:\n%s", want, out)
+		}
+	}
+	errOut := stderr.String()
+	if !strings.Contains(errOut, "ingest accepted (HTTP 202)") ||
+		!strings.Contains(errOut, asyncIngestJobID.String()) {
+		t.Errorf("stderr missing the 202 progress notice:\n%s", errOut)
+	}
+	if strings.Contains(out, "202") {
+		t.Errorf("stdout must stay reserved for the result (progress goes to stderr):\n%s", out)
+	}
+}
+
+// TestRunIngestAsyncNoWaitPrintsHandle pins the detached mode: a
+// 202 + --no-wait exits 0 with the handle and never polls (the
+// mock registers no GET route, so any poll fails the test via the
+// unhandled-route check in mockBackplane).
+func TestRunIngestAsyncNoWaitPrintsHandle(t *testing.T) {
+	srv := mockBackplane(t, map[string]mockHandler{
+		"POST /api/v1/connectors/ingest": func(w http.ResponseWriter, _ *http.Request) {
+			writeJSON(t, w, 202, asyncIngestHandle())
+		},
+	})
+	defer srv.Close()
+	primeToken(t, srv.URL)
+
+	cmd := &cobra.Command{}
+	cmd.SetContext(context.Background())
+	var stdout bytes.Buffer
+	cmd.SetOut(&stdout)
+	cmd.SetErr(&bytes.Buffer{})
+
+	if err := runIngest(cmd, ingestOptions{
+		Catalog:           "vmware/9.0",
+		NoWait:            true,
+		BackplaneOverride: srv.URL,
+	}); err != nil {
+		t.Fatalf("runIngest --no-wait on 202 must exit clean: %v", err)
+	}
+	out := stdout.String()
+	for _, want := range []string{
+		"job_id=" + asyncIngestJobID.String(),
+		"poll: GET /api/v1/connectors/ingest/jobs/" + asyncIngestJobID.String(),
+		"re-running ingest would start a second job",
+	} {
+		if !strings.Contains(out, want) {
+			t.Errorf("stdout missing %q:\n%s", want, out)
+		}
+	}
+}
+
+// TestRunIngestAsyncNoWaitJSONEmitsHandle pins the machine shape of
+// the detached mode: stdout is exactly the IngestJobHandle document.
+func TestRunIngestAsyncNoWaitJSONEmitsHandle(t *testing.T) {
+	srv := mockBackplane(t, map[string]mockHandler{
+		"POST /api/v1/connectors/ingest": func(w http.ResponseWriter, _ *http.Request) {
+			writeJSON(t, w, 202, asyncIngestHandle())
+		},
+	})
+	defer srv.Close()
+	primeToken(t, srv.URL)
+
+	cmd := &cobra.Command{}
+	cmd.SetContext(context.Background())
+	var stdout bytes.Buffer
+	cmd.SetOut(&stdout)
+	cmd.SetErr(&bytes.Buffer{})
+
+	if err := runIngest(cmd, ingestOptions{
+		Catalog:           "vmware/9.0",
+		NoWait:            true,
+		JSONOut:           true,
+		BackplaneOverride: srv.URL,
+	}); err != nil {
+		t.Fatalf("runIngest --no-wait --json: %v", err)
+	}
+	var handle api.IngestJobHandle
+	if err := json.Unmarshal(bytes.TrimSpace(stdout.Bytes()), &handle); err != nil {
+		t.Fatalf("stdout is not a single IngestJobHandle document: %v\n%s", err, stdout.String())
+	}
+	if handle.JobId != asyncIngestJobID {
+		t.Errorf("handle round-trip lost the job id: %+v", handle)
+	}
+}
+
+// TestRunIngestAsyncJSONStableSuccessShape pins the script contract:
+// `--json` (wait mode) emits the same IngestResponse shape on the
+// async path that the legacy sync path emits, so jq consumers see
+// one stable success document regardless of how the backplane ran
+// the pipeline.
+func TestRunIngestAsyncJSONStableSuccessShape(t *testing.T) {
+	srv := mockBackplane(t, map[string]mockHandler{
+		"POST /api/v1/connectors/ingest": func(w http.ResponseWriter, _ *http.Request) {
+			writeJSON(t, w, 202, asyncIngestHandle())
+		},
+		"GET /api/v1/connectors/ingest/jobs/" + asyncIngestJobID.String(): func(w http.ResponseWriter, _ *http.Request) {
+			writeJSON(t, w, 200, api.IngestJobStatusResponse{
+				JobId:  asyncIngestJobID,
+				Status: api.IngestJobStatusResponseStatusSucceeded,
+				Ingestion: &api.IngestionResultModel{
+					ConnectorId:   "vmware-rest-9.0",
+					InsertedCount: 961,
+				},
+			})
+		},
+	})
+	defer srv.Close()
+	primeToken(t, srv.URL)
+
+	cmd := &cobra.Command{}
+	cmd.SetContext(context.Background())
+	var stdout bytes.Buffer
+	cmd.SetOut(&stdout)
+	cmd.SetErr(&bytes.Buffer{})
+
+	if err := runIngest(cmd, ingestOptions{
+		Catalog:           "vmware/9.0",
+		JSONOut:           true,
+		BackplaneOverride: srv.URL,
+		pollInterval:      time.Millisecond,
+	}); err != nil {
+		t.Fatalf("runIngest async --json: %v", err)
+	}
+	var resp api.IngestResponse
+	if err := json.Unmarshal(bytes.TrimSpace(stdout.Bytes()), &resp); err != nil {
+		t.Fatalf("stdout is not a single IngestResponse document: %v\n%s", err, stdout.String())
+	}
+	if resp.Ingestion.ConnectorId != "vmware-rest-9.0" || resp.Ingestion.InsertedCount != 961 {
+		t.Errorf("IngestResponse round-trip wrong: %+v", resp)
+	}
+}
+
+// TestRunIngestAsyncJobFailure pins the failed-terminal contract:
+// the job's error_class + capped error render as
+// unexpected_response (exit 4) with the job id, mirroring where the
+// sync path's pipeline failures land.
+func TestRunIngestAsyncJobFailure(t *testing.T) {
+	errClass := "VersionMismatchError"
+	errMsg := "spec info.version 8.0 does not match requested 9.0"
+	srv := mockBackplane(t, map[string]mockHandler{
+		"POST /api/v1/connectors/ingest": func(w http.ResponseWriter, _ *http.Request) {
+			writeJSON(t, w, 202, asyncIngestHandle())
+		},
+		"GET /api/v1/connectors/ingest/jobs/" + asyncIngestJobID.String(): func(w http.ResponseWriter, _ *http.Request) {
+			writeJSON(t, w, 200, api.IngestJobStatusResponse{
+				JobId:      asyncIngestJobID,
+				Status:     api.IngestJobStatusResponseStatusFailed,
+				ErrorClass: &errClass,
+				Error:      &errMsg,
+			})
+		},
+	})
+	defer srv.Close()
+	primeToken(t, srv.URL)
+
+	cmd := &cobra.Command{}
+	cmd.SetContext(context.Background())
+	var stderr bytes.Buffer
+	cmd.SetOut(&bytes.Buffer{})
+	cmd.SetErr(&stderr)
+
+	err := runIngest(cmd, ingestOptions{
+		Catalog:           "vmware/9.0",
+		BackplaneOverride: srv.URL,
+		pollInterval:      time.Millisecond,
+	})
+	if err == nil {
+		t.Fatal("failed job must exit non-zero")
+	}
+	var coder output.ExitCoder
+	if !errors.As(err, &coder) || coder.ExitCode() != output.ExitUnexpected {
+		t.Fatalf("want exit %d (unexpected_response), got %v / %T", output.ExitUnexpected, err, err)
+	}
+	errOut := stderr.String()
+	for _, want := range []string{asyncIngestJobID.String(), errClass, errMsg} {
+		if !strings.Contains(errOut, want) {
+			t.Errorf("stderr missing %q:\n%s", want, errOut)
+		}
+	}
+}
+
+// TestRunIngestAsyncPollLost404 pins the pod-restart story: the
+// poll 404s (registry is process-local), the CLI exits non-zero
+// with the check-before-re-running guidance, and crucially never
+// re-POSTs the ingest.
+func TestRunIngestAsyncPollLost404(t *testing.T) {
+	var postCalls atomic.Int32
+	srv := mockBackplane(t, map[string]mockHandler{
+		"POST /api/v1/connectors/ingest": func(w http.ResponseWriter, _ *http.Request) {
+			postCalls.Add(1)
+			writeJSON(t, w, 202, asyncIngestHandle())
+		},
+		"GET /api/v1/connectors/ingest/jobs/" + asyncIngestJobID.String(): func(w http.ResponseWriter, _ *http.Request) {
+			writeJSON(t, w, 404, map[string]string{"detail": "ingest_job_not_found"})
+		},
+	})
+	defer srv.Close()
+	primeToken(t, srv.URL)
+
+	cmd := &cobra.Command{}
+	cmd.SetContext(context.Background())
+	var stderr bytes.Buffer
+	cmd.SetOut(&bytes.Buffer{})
+	cmd.SetErr(&stderr)
+
+	err := runIngest(cmd, ingestOptions{
+		Catalog:           "vmware/9.0",
+		BackplaneOverride: srv.URL,
+		pollInterval:      time.Millisecond,
+	})
+	if err == nil {
+		t.Fatal("lost job must exit non-zero")
+	}
+	var coder output.ExitCoder
+	if !errors.As(err, &coder) || coder.ExitCode() != output.ExitUnexpected {
+		t.Fatalf("want exit %d (unexpected_response), got %v", output.ExitUnexpected, err)
+	}
+	if got := postCalls.Load(); got != 1 {
+		t.Errorf("expected exactly 1 ingest POST even when the poll dies, got %d", got)
+	}
+	errOut := stderr.String()
+	for _, want := range []string{"no longer tracked", "meho connector list", "before re-running ingest"} {
+		if !strings.Contains(errOut, want) {
+			t.Errorf("stderr missing %q:\n%s", want, errOut)
+		}
+	}
+}
+
+// TestRunIngestAsyncUndocumentedStatus pins forward-compat
+// fail-loud: a terminal status outside running/succeeded/failed is
+// an error, never a silent success.
+func TestRunIngestAsyncUndocumentedStatus(t *testing.T) {
+	srv := mockBackplane(t, map[string]mockHandler{
+		"POST /api/v1/connectors/ingest": func(w http.ResponseWriter, _ *http.Request) {
+			writeJSON(t, w, 202, asyncIngestHandle())
+		},
+		"GET /api/v1/connectors/ingest/jobs/" + asyncIngestJobID.String(): func(w http.ResponseWriter, _ *http.Request) {
+			writeJSON(t, w, 200, api.IngestJobStatusResponse{
+				JobId:  asyncIngestJobID,
+				Status: api.IngestJobStatusResponseStatus("paused"),
+			})
+		},
+	})
+	defer srv.Close()
+	primeToken(t, srv.URL)
+
+	cmd := &cobra.Command{}
+	cmd.SetContext(context.Background())
+	var stderr bytes.Buffer
+	cmd.SetOut(&bytes.Buffer{})
+	cmd.SetErr(&stderr)
+
+	err := runIngest(cmd, ingestOptions{
+		Catalog:           "vmware/9.0",
+		BackplaneOverride: srv.URL,
+		pollInterval:      time.Millisecond,
+	})
+	if err == nil {
+		t.Fatal("undocumented job status must exit non-zero")
+	}
+	if !strings.Contains(stderr.String(), `undocumented status "paused"`) {
+		t.Errorf("stderr missing the undocumented-status detail:\n%s", stderr.String())
 	}
 }
 
@@ -1501,7 +1930,11 @@ func TestHTTPErrorClassification403(t *testing.T) {
 	version := "y"
 	implID := "z"
 	specs := []api.SpecSource{{Uri: "file:///a.yaml"}}
-	_, err := postIngest(context.Background(), srv.URL, api.IngestRequest{
+	authed, err := newAuthedClient(context.Background(), srv.URL)
+	if err != nil {
+		t.Fatalf("newAuthedClient: %v", err)
+	}
+	_, err = postIngest(context.Background(), authed, api.IngestRequest{
 		Product: &product, Version: &version, ImplId: &implID,
 		Specs: &specs,
 	})

--- a/cli/internal/cmd/connector/ingest.go
+++ b/cli/internal/cmd/connector/ingest.go
@@ -10,12 +10,22 @@ import (
 	"io"
 	"net/http"
 	"strings"
+	"time"
 
+	"github.com/google/uuid"
 	"github.com/spf13/cobra"
 
 	"github.com/evoila/meho/cli/internal/api"
 	"github.com/evoila/meho/cli/internal/output"
 )
+
+// defaultIngestPollInterval is the steady-state delay between
+// GET /api/v1/connectors/ingest/jobs/{job_id} polls while waiting
+// for an async ingest job to reach a terminal status. The job-status
+// read is an in-memory registry lookup backplane-side, so a 2s
+// cadence is cheap; real vendor specs spend ~30s+ in the register +
+// LLM-grouping phases, so anything much faster only burns requests.
+const defaultIngestPollInterval = 2 * time.Second
 
 // newIngestCmd returns the `meho connector ingest` command.
 //
@@ -24,11 +34,16 @@ import (
 //	meho connector ingest \
 //	  --product <p> --version <v> --impl <i> \
 //	  --spec <uri> [--spec <uri> ...] \
-//	  [--dry-run] [--json] [--backplane <url>]
+//	  [--dry-run] [--no-wait] [--json] [--backplane <url>]
 //
 // The verb hits POST /api/v1/connectors/ingest with an IngestRequest
 // body; the backplane runs T1 parser → T2 register_ingested → T3
-// LLM grouping and returns an IngestResponse envelope. tenant_admin
+// LLM grouping. Since #1303 the route defaults to the async shape:
+// it fires the pipeline off the request thread and answers
+// 202 Accepted + an IngestJobHandle. The CLI polls the handle to a
+// terminal status by default (`--no-wait` exits 0 with the handle
+// instead); a legacy 200 + IngestResponse (sync backplane, or
+// --dry-run which always runs inline) renders directly. tenant_admin
 // role required (HTTP 403 → exit 5).
 func newIngestCmd() *cobra.Command {
 	var (
@@ -38,6 +53,7 @@ func newIngestCmd() *cobra.Command {
 		specs             []string
 		catalog           string
 		dryRun            bool
+		noWait            bool
 		jsonOut           bool
 		backplaneOverride string
 	)
@@ -63,8 +79,16 @@ func newIngestCmd() *cobra.Command {
 			"      $CLAUDE_RDC_DOCS; read + uploaded by the CLI like file://)\n" +
 			"  Repeat --spec to merge multiple specs under one connector_id\n" +
 			"  (vSphere is the canonical case: vcenter.yaml + vi-json.yaml).\n\n" +
+			"v0.12+ backplanes run the pipeline off the request thread and\n" +
+			"answer 202 Accepted + a job handle. The CLI polls the job to a\n" +
+			"terminal status and renders the usual summary on success; pass\n" +
+			"--no-wait to exit 0 with the handle (job_id + poll URL) as soon\n" +
+			"as the backplane accepts the work. Either way the job keeps\n" +
+			"running server-side — re-running ingest after a 202 starts a\n" +
+			"SECOND job, so poll the handle instead of retrying.\n\n" +
 			"--dry-run parses + plans without writing to the DB; useful for\n" +
-			"validating a spec before committing. Role: tenant_admin.",
+			"validating a spec before committing. Dry runs always execute\n" +
+			"synchronously (200 + inline result). Role: tenant_admin.",
 		Args:          cobra.NoArgs,
 		SilenceUsage:  true,
 		SilenceErrors: true,
@@ -76,6 +100,7 @@ func newIngestCmd() *cobra.Command {
 				Specs:             specs,
 				Catalog:           catalog,
 				DryRun:            dryRun,
+				NoWait:            noWait,
 				JSONOut:           jsonOut,
 				BackplaneOverride: backplaneOverride,
 			})
@@ -94,6 +119,9 @@ func newIngestCmd() *cobra.Command {
 			"mutually exclusive with --product/--version/--impl/--spec")
 	cmd.Flags().BoolVar(&dryRun, "dry-run", false,
 		"parse and plan without writing to the DB; the response carries an IngestionResult with counts but no GroupingResult")
+	cmd.Flags().BoolVar(&noWait, "no-wait", false,
+		"on an async 202 answer, exit 0 with the job handle (job_id + poll URL) instead of polling the job to completion; "+
+			"no effect when the backplane answers synchronously (HTTP 200)")
 	cmd.Flags().BoolVar(&jsonOut, "json", false,
 		"emit machine-readable JSON to stdout instead of the human summary")
 	cmd.Flags().StringVar(&backplaneOverride, "backplane", "",
@@ -108,8 +136,14 @@ type ingestOptions struct {
 	Specs             []string
 	Catalog           string
 	DryRun            bool
+	NoWait            bool
 	JSONOut           bool
 	BackplaneOverride string
+
+	// pollInterval overrides defaultIngestPollInterval; zero means
+	// "use the default". Unexported test seam so the async-poll
+	// tests don't sleep wall-clock seconds per iteration.
+	pollInterval time.Duration
 }
 
 func runIngest(cmd *cobra.Command, opts ingestOptions) error {
@@ -127,7 +161,12 @@ func runIngest(cmd *cobra.Command, opts ingestOptions) error {
 		return output.RenderError(cmd.ErrOrStderr(), output.Unexpected(err.Error()), opts.JSONOut)
 	}
 
-	result, err := postIngest(cmd.Context(), backplaneURL, body)
+	authed, err := newAuthedClient(cmd.Context(), backplaneURL)
+	if err != nil {
+		return renderRequestError(cmd, backplaneURL, err, opts.JSONOut)
+	}
+
+	start, err := postIngest(cmd.Context(), authed, body)
 	if err != nil {
 		var he *httpResponseError
 		if errors.As(err, &he) {
@@ -135,10 +174,13 @@ func runIngest(cmd *cobra.Command, opts ingestOptions) error {
 		}
 		return renderRequestError(cmd, backplaneURL, err, opts.JSONOut)
 	}
-	if opts.JSONOut {
-		return output.PrintJSON(cmd.OutOrStdout(), result)
+	if start.job != nil {
+		return runIngestAsync(cmd, authed, backplaneURL, start.job, opts)
 	}
-	printIngestSummary(cmd.OutOrStdout(), opts, result)
+	if opts.JSONOut {
+		return output.PrintJSON(cmd.OutOrStdout(), start.sync)
+	}
+	printIngestSummary(cmd.OutOrStdout(), opts, start.sync)
 	return nil
 }
 
@@ -194,6 +236,15 @@ func buildIngestRequest(opts ingestOptions) (api.IngestRequest, error) {
 // Replaces the per-flag MarkFlagRequired wiring (which can't express
 // "required unless --catalog").
 func validateIngestMode(opts ingestOptions) error {
+	if opts.NoWait && opts.DryRun {
+		// Dry runs always execute synchronously backplane-side (the
+		// parse-only leg returns 200 + the inline plan; there is no
+		// job to detach from), so a combined flag set signals a
+		// misunderstanding worth correcting rather than ignoring.
+		return errors.New(
+			"--no-wait cannot be combined with --dry-run: dry runs always execute " +
+				"synchronously (the backplane returns the parse plan inline)")
+	}
 	manualSet := opts.Product != "" || opts.Version != "" || opts.ImplID != "" || len(opts.Specs) > 0
 	if opts.Catalog != "" {
 		if manualSet {
@@ -228,15 +279,31 @@ func validateIngestMode(opts ingestOptions) error {
 	return nil
 }
 
+// ingestStart carries the two mutually-exclusive success shapes of
+// POST /api/v1/connectors/ingest. Exactly one field is non-nil:
+//
+//   - sync — HTTP 200, the legacy blocking IngestResponse
+//     (async=false backplanes, and every --dry-run regardless of
+//     backplane version).
+//   - job — HTTP 202, the #1303 async default: the pipeline runs
+//     off the request thread and the handle names the job to poll.
+//
+// Callers branch on `job != nil` rather than re-reading the status
+// code so the "202 is a success, not an error" contract lives in
+// one place (this is the envelope the pre-#1609 CLI rendered as a
+// fatal unexpected_response — after the work had already started
+// server-side, which is what made retrying double-ingest).
+type ingestStart struct {
+	sync *api.IngestResponse
+	job  *api.IngestJobHandle
+}
+
 // postIngest drives the typed-client ingest endpoint with a one-shot
-// 401-retry. The route declares `response_model=IngestResponse` so
-// JSON200 carries the typed envelope; non-2xx surfaces as
-// *httpResponseError for the caller to route through renderHTTPStatus.
-func postIngest(ctx context.Context, backplaneURL string, body api.IngestRequest) (*api.IngestResponse, error) {
-	authed, err := newAuthedClient(ctx, backplaneURL)
-	if err != nil {
-		return nil, err
-	}
+// 401-retry. The route declares both success shapes (200 sync legacy,
+// 202 async job handle) so JSON200 / JSON202 carry the typed
+// envelopes; any other status surfaces as *httpResponseError for the
+// caller to route through renderHTTPStatus.
+func postIngest(ctx context.Context, authed *api.AuthedClient, body api.IngestRequest) (*ingestStart, error) {
 	resp, err := retryOn401(ctx, authed,
 		func(ctx context.Context) (*api.IngestEndpointApiV1ConnectorsIngestPostResponse, error) {
 			return authed.IngestEndpointApiV1ConnectorsIngestPostWithResponse(
@@ -250,13 +317,246 @@ func postIngest(ctx context.Context, backplaneURL string, body api.IngestRequest
 	if err != nil {
 		return nil, err
 	}
-	if resp.StatusCode() != http.StatusOK {
+	switch resp.StatusCode() {
+	case http.StatusOK:
+		if resp.JSON200 == nil {
+			return nil, fmt.Errorf("backplane returned 200 OK but no JSON body decoded against IngestResponse")
+		}
+		return &ingestStart{sync: resp.JSON200}, nil
+	case http.StatusAccepted:
+		if resp.JSON202 == nil {
+			return nil, fmt.Errorf("backplane returned 202 Accepted but no JSON body decoded against IngestJobHandle")
+		}
+		return &ingestStart{job: resp.JSON202}, nil
+	default:
 		return nil, &httpResponseError{statusCode: resp.StatusCode(), body: resp.Body}
 	}
-	if resp.JSON200 == nil {
-		return nil, fmt.Errorf("backplane returned 200 OK but no JSON body decoded against IngestResponse")
+}
+
+// runIngestAsync finishes an ingest the backplane accepted with
+// 202 + an IngestJobHandle. Two modes:
+//
+//   - --no-wait: render the handle (human key/value or the raw
+//     IngestJobHandle JSON) and exit 0 — the job keeps running
+//     server-side and the operator polls poll_url themselves.
+//   - default: poll GET /api/v1/connectors/ingest/jobs/{job_id}
+//     until the job leaves "running", then render exactly what the
+//     sync path would have rendered (the assembled IngestResponse) —
+//     so scripts parsing `--json` see one stable success shape
+//     regardless of whether the backplane ran the pipeline inline
+//     or off-thread. A failed job renders the job's error_class +
+//     capped error message as unexpected_response (exit 4), the
+//     same family the sync path's pipeline failures land in.
+//
+// The progress notice goes to stderr in both output modes: stdout
+// stays reserved for the final result (Goal #11 §5 output
+// discipline — `--json` consumers must see a single JSON document).
+func runIngestAsync(
+	cmd *cobra.Command,
+	authed *api.AuthedClient,
+	backplaneURL string,
+	handle *api.IngestJobHandle,
+	opts ingestOptions,
+) error {
+	if opts.NoWait {
+		if opts.JSONOut {
+			return output.PrintJSON(cmd.OutOrStdout(), handle)
+		}
+		printIngestJobHandle(cmd.OutOrStdout(), handle)
+		return nil
 	}
-	return resp.JSON200, nil
+	interval := opts.pollInterval
+	if interval <= 0 {
+		interval = defaultIngestPollInterval
+	}
+	fmt.Fprintf(cmd.ErrOrStderr(),
+		"ingest accepted (HTTP 202) — job_id=%s; polling %s every %s until the job completes\n",
+		handle.JobId, handle.PollUrl, interval)
+	st, err := pollIngestJob(cmd.Context(), authed, handle.JobId, interval)
+	if err != nil {
+		return renderIngestWaitError(cmd, backplaneURL, handle, err, opts.JSONOut)
+	}
+	switch st.Status {
+	case api.IngestJobStatusResponseStatusSucceeded:
+		if st.Ingestion == nil {
+			return output.RenderError(cmd.ErrOrStderr(),
+				output.Unexpected(fmt.Sprintf(
+					"ingest job %s reports succeeded but carries no ingestion result", st.JobId)),
+				opts.JSONOut,
+			)
+		}
+		result := &api.IngestResponse{Ingestion: *st.Ingestion, Grouping: st.Grouping}
+		if opts.JSONOut {
+			return output.PrintJSON(cmd.OutOrStdout(), result)
+		}
+		printIngestSummary(cmd.OutOrStdout(), opts, result)
+		return nil
+	case api.IngestJobStatusResponseStatusFailed:
+		errClass := "IngestJobFailed"
+		if st.ErrorClass != nil && *st.ErrorClass != "" {
+			errClass = *st.ErrorClass
+		}
+		detail := "(no error detail recorded)"
+		if st.Error != nil && *st.Error != "" {
+			detail = *st.Error
+		}
+		return output.RenderError(cmd.ErrOrStderr(),
+			output.Unexpected(fmt.Sprintf(
+				"ingest job %s failed: %s: %s", st.JobId, errClass, detail)),
+			opts.JSONOut,
+		)
+	default:
+		// Forward-compat: a status outside the documented
+		// running/succeeded/failed lifecycle fails loudly instead of
+		// being treated as success (or spinning forever in the poll
+		// loop, which only continues on "running").
+		return output.RenderError(cmd.ErrOrStderr(),
+			output.Unexpected(fmt.Sprintf(
+				"ingest job %s returned undocumented status %q", st.JobId, st.Status)),
+			opts.JSONOut,
+		)
+	}
+}
+
+// pollIngestJob reads the job row until it leaves "running", with
+// the same one-shot 401-refresh contract every connector verb uses
+// (a token can expire mid-wait on a long LLM-grouping pass; the
+// refresh keeps the poll alive without operator action). Errors are
+// returned raw — renderIngestWaitError owns the job-aware
+// classification, because every poll-phase failure message must
+// carry the "job keeps running server-side, don't re-run ingest"
+// guidance.
+func pollIngestJob(
+	ctx context.Context,
+	authed *api.AuthedClient,
+	jobID uuid.UUID,
+	interval time.Duration,
+) (*api.IngestJobStatusResponse, error) {
+	for {
+		resp, err := retryOn401(ctx, authed,
+			func(ctx context.Context) (*api.GetIngestJobEndpointApiV1ConnectorsIngestJobsJobIdGetResponse, error) {
+				return authed.GetIngestJobEndpointApiV1ConnectorsIngestJobsJobIdGetWithResponse(
+					ctx,
+					jobID,
+					&api.GetIngestJobEndpointApiV1ConnectorsIngestJobsJobIdGetParams{},
+				)
+			},
+			func(r *api.GetIngestJobEndpointApiV1ConnectorsIngestJobsJobIdGetResponse) int { return r.StatusCode() },
+		)
+		if err != nil {
+			return nil, err
+		}
+		if resp.StatusCode() != http.StatusOK {
+			return nil, &httpResponseError{statusCode: resp.StatusCode(), body: resp.Body}
+		}
+		if resp.JSON200 == nil {
+			return nil, fmt.Errorf("backplane returned 200 OK on the job poll but no JSON body decoded against IngestJobStatusResponse")
+		}
+		if resp.JSON200.Status != api.IngestJobStatusResponseStatusRunning {
+			return resp.JSON200, nil
+		}
+		if serr := sleepCtx(ctx, interval); serr != nil {
+			return nil, serr
+		}
+	}
+}
+
+// renderIngestWaitError classifies a poll-phase failure. Unlike the
+// pre-submit failure paths (renderHTTPStatus / renderRequestError),
+// every message here must orient the operator around one fact: the
+// ingest job already started server-side, so the safe reaction to a
+// broken wait is to re-check the job (poll_url or `meho connector
+// list`), never to re-run `meho connector ingest` — a re-run starts
+// a second job (the double-ingest failure mode this verb's 202
+// handling exists to prevent).
+func renderIngestWaitError(
+	cmd *cobra.Command,
+	backplaneURL string,
+	handle *api.IngestJobHandle,
+	err error,
+	jsonOut bool,
+) error {
+	recheck := fmt.Sprintf(
+		"the job keeps running server-side — re-check GET %s (or `meho connector list`) before re-running ingest, "+
+			"a re-run would start a second job", handle.PollUrl)
+	var he *httpResponseError
+	if errors.As(err, &he) {
+		switch he.statusCode {
+		case http.StatusUnauthorized:
+			return output.RenderError(cmd.ErrOrStderr(),
+				output.AuthExpired(fmt.Sprintf(
+					"backplane rejected the stored token while polling ingest job %s; run `meho login %s`; %s",
+					handle.JobId, backplaneURL, recheck)),
+				jsonOut,
+			)
+		case http.StatusForbidden:
+			return output.RenderError(cmd.ErrOrStderr(),
+				output.InsufficientRole(fmt.Sprintf(
+					"polling ingest job %s: HTTP 403 (the job poll requires tenant_admin role); %s",
+					handle.JobId, recheck)),
+				jsonOut,
+			)
+		case http.StatusNotFound:
+			return output.RenderError(cmd.ErrOrStderr(),
+				output.Unexpected(fmt.Sprintf(
+					"ingest job %s is no longer tracked by the backplane (pod restart or registry eviction); "+
+						"the pipeline may have completed or died with the pod — check `meho connector list` "+
+						"for the connector before re-running ingest", handle.JobId)),
+				jsonOut,
+			)
+		default:
+			return output.RenderError(cmd.ErrOrStderr(),
+				output.Unexpected(fmt.Sprintf(
+					"polling ingest job %s: HTTP %d: %s; %s",
+					handle.JobId, he.statusCode, strings.TrimSpace(string(he.body)), recheck)),
+				jsonOut,
+			)
+		}
+	}
+	if errors.Is(err, context.Canceled) || errors.Is(err, context.DeadlineExceeded) {
+		return output.RenderError(cmd.ErrOrStderr(),
+			output.Unexpected(fmt.Sprintf(
+				"wait for ingest job %s cancelled: %v; %s", handle.JobId, err, recheck)),
+			jsonOut,
+		)
+	}
+	return output.RenderError(cmd.ErrOrStderr(),
+		output.Unreachable(fmt.Sprintf(
+			"polling ingest job %s on %s: %v; %s", handle.JobId, backplaneURL, err, recheck)),
+		jsonOut,
+	)
+}
+
+// printIngestJobHandle renders the --no-wait handle for human eyes:
+// the job_id first (the thing the operator copies), the poll URL,
+// and the workflow reminder that makes the detached mode safe —
+// the next action is polling, not re-running ingest.
+func printIngestJobHandle(w io.Writer, handle *api.IngestJobHandle) {
+	fmt.Fprintf(w, "ingest accepted — job_id=%s (status=%s)\n", handle.JobId, handle.Status)
+	fmt.Fprintf(w, "  poll: GET %s\n", handle.PollUrl)
+	fmt.Fprintf(w,
+		"\nThe pipeline keeps running server-side; re-running ingest would start a second job.\n"+
+			"Poll the URL above (or watch `meho connector list`) until the connector lands in\n"+
+			"review_status=staged, then:\n"+
+			"  meho connector review <connector_id>\n"+
+			"  meho connector enable <connector_id> --confirm\n")
+}
+
+// sleepCtx waits d or until ctx is cancelled, whichever comes first.
+// Returns ctx.Err() on cancellation, nil on timer fire. Same shape
+// as the status --watch retry loop's helper (internal/cmd/
+// status_watch.go) — duplicated because cmd/connector can't import
+// the root cmd package without a cycle (cmd/root.go grafts this
+// package onto the tree).
+func sleepCtx(ctx context.Context, d time.Duration) error {
+	timer := time.NewTimer(d)
+	defer timer.Stop()
+	select {
+	case <-timer.C:
+		return nil
+	case <-ctx.Done():
+		return ctx.Err()
+	}
 }
 
 // printIngestSummary renders an IngestResponse for human eyes. The

--- a/docs/codebase/cli.md
+++ b/docs/codebase/cli.md
@@ -225,7 +225,7 @@ cli/
     │   │   └── memory_test.go    # parseScope/parseTTL/parseScopeSlugArg + verb-happy-path + 403/404/422 + decline + JSON envelope tests.
     │   ├── connector/         # G0.7-T5 #405 — `meho connector …` verb tree. G0.12-T7 #1265 migrated every verb onto the generated typed client (api.ClientWithResponses via api.AuthedClient + retryOn401); api.CatalogListResponse / api.ConnectorReviewPayload / api.IngestRequest / api.IngestResponse / api.EditGroupBody / api.EditOpBody are the single source of truth, no consumer-side struct duplicates.
     │   │   ├── connector.go      # NewRootCmd + newAuthedClient / retryOn401 / renderRequestError / renderHTTPStatus helpers.
-    │   │   ├── ingest.go         # `meho connector ingest` (POST /api/v1/connectors/ingest).
+    │   │   ├── ingest.go         # `meho connector ingest` (POST /api/v1/connectors/ingest). 202-aware since G0.22-T4 #1609: polls GET /ingest/jobs/{job_id} to a terminal status by default, `--no-wait` exits 0 with the job handle; 200 stays the legacy sync render.
     │   │   ├── list.go           # `meho connector list` (GET  /api/v1/connectors). List endpoint returns dict[str, list[dict]] (no response_model on the backend; per-row UUID serialisation), so a package-private listEntry decode lives here.
     │   │   ├── review.go         # `meho connector review <id>` (GET  /api/v1/connectors/{id}/review).
     │   │   ├── edit_group.go     # `meho connector edit-group <id> <key>` (PATCH groups/{key}).

--- a/docs/codebase/spec-ingestion.md
+++ b/docs/codebase/spec-ingestion.md
@@ -1031,6 +1031,22 @@ whose pod died was never going to finish. Durable cross-restart
 jobs are a v0.9 follow-up (the same migration that lands
 operator-cancellable jobs).
 
+**The Go CLI consumes the handle (G0.22-T4 / #1609).** `meho
+connector ingest` (`cli/internal/cmd/connector/ingest.go`) treats
+202 as a first-class success: by default it polls the job to a
+terminal status every 2s and renders the same summary / `--json`
+`IngestResponse` shape the sync 200 path renders, so script
+consumers see one stable success document regardless of how the
+backplane ran the pipeline; `--no-wait` exits 0 with the handle
+instead. A failed job renders `error_class` + the capped `error`
+as `unexpected_response` (exit 4); a 404 on the poll (pod restart /
+eviction) tells the operator to check `meho connector list`
+**before** re-running ingest. Pre-#1609 CLIs rendered the 202
+itself as a fatal `unexpected_response`, which baited operators
+into retrying and double-ingesting. `--dry-run` is unaffected
+(always sync, see above), and `--no-wait --dry-run` is rejected
+client-side.
+
 **The MCP surface shares the offload (G3.5-T2 / #1531).** The
 `meho.connector.ingest` admin MCP tool carries the same async shape:
 `async=true` (with `dry_run=false`) creates a job in the **same**


### PR DESCRIPTION
## Summary
- `meho connector ingest` against a v0.12+ backplane (async-202 default since #1303) no longer dies with a fatal `unexpected_response` after the job already started server-side — the failure mode that baited operators into retrying and double-ingesting (SEV-2, RDC signal `cli-ingest-async-202-unexpected-response`).
- `postIngest` now branches on the route's two declared success shapes: `200` keeps the legacy synchronous render unchanged; `202` returns the typed `IngestJobHandle` and the CLI polls `GET /api/v1/connectors/ingest/jobs/{job_id}` (2s cadence, ctx-aware sleep, one-shot 401-refresh per poll) to a terminal status, then renders the exact summary / `--json` `IngestResponse` document the sync path emits — one stable success shape for scripts regardless of how the backplane ran the pipeline.
- New `--no-wait` flag exits 0 with the job handle (human key/value or raw `IngestJobHandle` JSON) without polling; rejected in combination with `--dry-run` (dry runs always execute synchronously). Every poll-phase failure message (404 after pod restart/eviction, auth expiry, transport drop, failed job) carries the "job keeps running server-side — re-check before re-running ingest" guidance.
- Docs: `docs/codebase/spec-ingestion.md` async section gains the CLI-counterpart paragraph; `docs/codebase/cli.md` tree annotation updated.

## Test plan
- [x] `go build ./...` — clean
- [x] `go test -race ./...` — full module green (coverage profiling left to CI: the local module-cache Go toolchain ships without the `covdata` tool)
- [x] `golangci-lint run` (v2.12.2, project config) — 0 issues in touched packages; the 27 staticcheck findings the local toolchain reports elsewhere reproduce identically on origin/main (environment-only, CI green there)
- [x] `python3 .claude/hooks/code-quality.py --diff` — pass
- [x] 202 → exit 0, prints job_id, polls to terminal status: `TestRunIngestAsyncPollsToSuccess` (mock 202 + running→succeeded; pins exactly 1 POST + 2 polls + stdout summary + stderr progress notice), `TestPostIngest202ReturnsJobHandle`, `TestPostIngest202WithoutBodyErrors`
- [x] 200 legacy synchronous unchanged: `TestPostIngestRoundTripWithMockServer`, `TestRunIngestCatalogModePostsCatalogEntry`, `TestRunIngestCatalogModeRendersResolvedTriple`, `TestRunIngestManualModePostsQuadruple` (pre-existing tests, still green)
- [x] No path treats 202 as `unexpected_response`: `grep -n "StatusOK\|StatusAccepted\|unexpected_response" cli/internal/cmd/connector/ingest.go` → explicit `http.StatusAccepted` success branch; the string appears only in comments
- [x] `--no-wait` exits 0 with the handle, never polls: `TestRunIngestAsyncNoWaitPrintsHandle`, `TestRunIngestAsyncNoWaitJSONEmitsHandle` (mock registers no GET route — any poll fails the test)
- [x] Failed / lost / undocumented job statuses exit non-zero with actionable guidance: `TestRunIngestAsyncJobFailure` (error_class + message, exit 4), `TestRunIngestAsyncPollLost404` (pins single POST — no re-submit), `TestRunIngestAsyncUndocumentedStatus`
- [x] CLI API snapshot: no-op verified — the change touches neither the backend OpenAPI surface nor the generated client (`git diff -- cli/api/openapi.json cli/internal/api/client.gen.go` empty)
- [x] CHANGELOG `[Unreleased]` carries one bullet (#1609)

## Out of scope
- Optional version-skew warning (CLI minor < backplane minor) from the issue body — deliberately not included: it needs a reliable backplane-version source on every invocation (extra `/health` round-trip) and belongs in a shared client seam rather than buried in one verb; the core 202 handling already removes the silent-skew failure mode for this envelope. Recorded as an adjacent finding for a follow-up decision.
- No `meho connector ingest-status <job-id>` verb exists for post-`--no-wait` polling — operators get the poll URL + `meho connector list` hint; a dedicated verb is a possible follow-up.
- Backend / MCP surfaces (#1303, #1531) — already shipped; untouched here.

<!-- auto-implement-issue: fresh, iteration 1 -->

Closes #1609
