### PR TITLE
docs(changelog): cut v0.13.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -90,6 +90,8 @@ connector-related release-notes line.
 
 ## [Unreleased]
 
+## [0.13.0] - 2026-06-11
+
 ### Added
 
 - Parked `vmware.composite.*` write approvals now carry a
@@ -213,6 +215,22 @@ connector-related release-notes line.
   `detail.message`, so REST/SDK callers branch on the stable classifier
   instead of re-parsing prose; the human-readable message is carried
   verbatim inside the envelope (#1610).
+- SSE disconnect-path audit writes are no longer dropped silently under
+  a second cancellation. On a client disconnect `AuditMiddleware`
+  catches `CancelledError` and writes the audit row before re-raising
+  (#1389), but that write was **unshielded** — a second `CancelledError`
+  arriving mid-INSERT (task-tree teardown, server shutdown, an enclosing
+  `timeout()`/anyio cancel scope) propagated out of the bare `await`,
+  bypassed `_finalize`'s `except Exception` arm (`CancelledError` is a
+  `BaseException`), and dropped the row with no log line — a silent hole
+  in the "every authenticated action gets exactly one row" fail-closed
+  contract. The disconnect-path write is now scheduled as a task and
+  drained to completion under `asyncio.shield`, so redelivered
+  cancellations interrupt only the wait, never the shielded write; the
+  original `CancelledError` is re-raised once the row commits, leaving
+  enclosing `TaskGroup`/`timeout()` semantics unchanged. Only the
+  `CancelledError` arm is shielded; the normal return path is unchanged
+  (#1600).
 
 ## [0.12.0] - 2026-06-08
 


### PR DESCRIPTION
## Summary

Rolls the `[Unreleased]` CHANGELOG section into **`## [0.13.0] - 2026-06-11`** ahead of tagging `v0.13.0`. Leaves a fresh empty `[Unreleased]`.

This is the release-cutting PR for `v0.13.0` (per `docs/RELEASING.md` / `/release`). The tag is **not** pushed until this merges.

### Scope of v0.13.0 (minor — new features + a deprecation)

**Added**
- vmware `composite.*` write approvals carry connector-rendered park-time previews (#1608)
- runbook list endpoints honour `?envelope=v2` (#1611)

**Deprecated**
- flat `runbook_*` MCP tool names → dotted `meho.runbook.*`; `slug` → `template_slug` (removed in v0.14.0) (#1612)

**Fixed**
- `/ready` skips unconfigured optional docs backends (#1606)
- disabled-vs-absent L2 sub-op distinction in vmware composite pre-flight (#1601)
- `portgroup.audit` composite L2 op_id reconciliation + build-time guard (#1602/#1603)
- db-ahead `/ready` tolerance so `helm --atomic` auto-rollback survives a migration (#1607)
- CLI treats async `202` ingest-job envelope as success + polls to completion (#1609)
- structured `SpecError` 400 envelopes on REST ingest (#1610)
- SSE disconnect-path audit write shielded against double cancellation (#1600)

### Completeness audit

`git log v0.12.0..main` PR/issue numbers vs `[0.13.0]` citations: every shipped PR is covered. The audit-only backfill this cut was **#1600** (had no bullet); the other uncited numbers (#1604, #1613–#1619) are PR-wrappers of already-cited issue numbers.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Fixed an issue where audit records were silently lost during server-sent events and client disconnections, ensuring all audit data is now properly preserved.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->