### PR TITLE
fix(connectors): park failed proposed_effect previews with an explicit preview_unavailable marker (#1628)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -90,6 +90,18 @@ connector-related release-notes line.
 
 ## [Unreleased]
 
+### Fixed
+
+- A failed park-time `proposed_effect` preview no longer degrades
+  silently to the identifier-only default: the parked approval now
+  carries `preview_unavailable: true` plus a `preview_error` reason
+  alongside the identifier fields (visible on REST
+  `GET /api/v1/approvals`, `meho.approvals.list` / `.get`, and `meho
+  approvals show`), so a four-eyes reviewer can tell "blast-radius
+  unknown" from a genuinely small action when a `vmware.composite.*`
+  preview's listing read cannot execute. The park itself still always
+  proceeds; successful previews are unchanged. (#1628)
+
 ## [0.13.0] - 2026-06-11
 
 ### Added

--- a/backend/src/meho_backplane/connectors/vmware_rest/composites/_write_preview.py
+++ b/backend/src/meho_backplane/connectors/vmware_rest/composites/_write_preview.py
@@ -76,7 +76,10 @@ dispatch params — infrastructure topology, never credential material.
 
 Fail-soft: every builder either declines (``None`` → identifier-only
 default) on malformed params or lets resolution faults propagate into
-``build_proposed_effect``'s catch — the park always proceeds.
+``build_proposed_effect``'s catch, which parks with the identifier
+fields plus an explicit ``preview_unavailable`` marker + reason (#1628)
+— the park always proceeds, and a reviewer can tell "blast-radius
+unknown" from a genuinely small action.
 """
 
 from __future__ import annotations

--- a/backend/src/meho_backplane/operations/_preview.py
+++ b/backend/src/meho_backplane/operations/_preview.py
@@ -25,12 +25,18 @@ Design contract
 * **Opt-in per op.** A builder is registered against an ``op_id``; ops
   without a registered builder fall through to the identifier-only
   default exactly as before -- no extra work, no new failure mode.
-* **Fail-soft.** A builder that raises (a dry-run that hits the API
-  server and errors, a transient connector fault) must never block the
-  park: :func:`build_proposed_effect` swallows the exception, logs it,
-  and returns ``None`` so the caller uses the default. Parking an
-  approval is the durable, safety-relevant action; a missing preview is
-  a degraded-but-acceptable outcome, an exception is not.
+* **Fail-soft, never silent.** A builder that raises (a dry-run that
+  hits the API server and errors, a transient connector fault) must
+  never block the park: :func:`build_proposed_effect` swallows the
+  exception and logs it. Parking an approval is the durable,
+  safety-relevant action; a missing preview is a
+  degraded-but-acceptable outcome, an exception is not. But the
+  degradation is **visible** (#1628): the hook returns an explicit
+  ``{op_class, preview_unavailable: True, preview_error}`` marker
+  rather than ``None``, so the reviewer can tell "blast-radius
+  unknown" from a genuinely small action. Only a *declined* preview
+  (no builder registered, builder returns ``None``, credential-class
+  suppression) yields ``None`` → the identifier-only default.
 * **Redaction-safe.** The preview lands in a durable row surfaced over
   REST / MCP / CLI, so it must not carry secret material. The hook
   reuses the single-sourced sensitivity classification from
@@ -80,6 +86,26 @@ _SENSITIVE_CLASSES: frozenset[str] = frozenset(
     {"credential_read", "credential_mint", "credential_write"}
 )
 
+#: Truncation bound for the reviewer-facing ``preview_error`` reason. A
+#: builder fault is normally a one-line message; the cap keeps a
+#: pathological exception repr (an HTTP error echoing a response body)
+#: from ballooning the durable approval row.
+_PREVIEW_ERROR_MAX_LEN: int = 500
+
+
+def _preview_failure_reason(exc: Exception) -> str:
+    """Render a builder fault as the short reviewer-facing reason string.
+
+    Keeps the exception *message* front and centre (the type name alone
+    is opaque -- the lesson of the ``connector_error`` flattening,
+    sibling #1627) while staying robust for message-less exceptions.
+    """
+    message = str(exc)
+    reason = f"{type(exc).__name__}: {message}" if message else type(exc).__name__
+    if len(reason) > _PREVIEW_ERROR_MAX_LEN:
+        reason = reason[:_PREVIEW_ERROR_MAX_LEN] + " [truncated]"
+    return reason
+
 
 @dataclass(frozen=True)
 class PreviewContext:
@@ -113,7 +139,8 @@ class PreviewBuilder(Protocol):
     :attr:`~meho_backplane.db.models.ApprovalRequest.proposed_effect`, or
     ``None`` to decline (caller falls back to the identifier-only
     default). May raise -- :func:`build_proposed_effect` treats a raise
-    as "no preview" rather than failing the park.
+    as "preview unavailable" (an explicit marker on the parked row,
+    #1628) rather than failing the park.
     """
 
     async def __call__(self, ctx: PreviewContext) -> dict[str, Any] | None: ...
@@ -174,9 +201,16 @@ async def build_proposed_effect(ctx: PreviewContext) -> dict[str, Any] | None:
     Looks up a builder for ``ctx.descriptor.op_id``; returns ``None``
     (caller uses the identifier-only default) when no builder is
     registered, when the op classifies as a credential class (the
-    preview is suppressed to stay redaction-safe), when the builder
-    declines, or when the builder raises (fail-soft -- the park proceeds
-    regardless).
+    preview is suppressed to stay redaction-safe), or when the builder
+    declines.
+
+    A builder that **raises** is still fail-soft -- the park proceeds
+    regardless -- but no longer silent (#1628): the hook returns an
+    explicit ``{"op_class", "preview_unavailable": True,
+    "preview_error"}`` marker so the reviewer-facing row can say
+    "blast-radius unknown" instead of degrading to a bare identifier
+    default indistinguishable from a small action. The dispatcher
+    merges the marker onto the identifier fields before parking.
 
     On success the returned dict is wrapped with a ``"preview"`` envelope
     key + the op's sensitivity ``"op_class"`` so the approval surface can
@@ -204,16 +238,26 @@ async def build_proposed_effect(ctx: PreviewContext) -> dict[str, Any] | None:
 
     try:
         preview = await builder(ctx)
-    except Exception:
+    except Exception as exc:
         # Fail-soft: a preview is a convenience, the park is the
         # safety-relevant action. Never let a dry-run fault block it.
+        # But never silently (#1628): a registered builder that raised
+        # means the blast radius is UNKNOWN, and the reviewer must be
+        # able to distinguish that from a genuinely small action -- so
+        # the row carries an explicit marker + reason instead of the
+        # bare identifier-only default a server-side log line can't
+        # substitute for.
         _log.warning(
             "proposed_effect_preview_failed",
             op_id=op_id,
             operator_sub=getattr(ctx.operator, "sub", None),
             exc_info=True,
         )
-        return None
+        return {
+            "op_class": op_class,
+            "preview_unavailable": True,
+            "preview_error": _preview_failure_reason(exc),
+        }
 
     if preview is None:
         return None

--- a/backend/src/meho_backplane/operations/dispatcher.py
+++ b/backend/src/meho_backplane/operations/dispatcher.py
@@ -957,8 +957,9 @@ def _identifier_default_effect(
     Mirrors the default
     :func:`~meho_backplane.operations.approval_queue.create_pending_request`
     constructs when no preview is supplied, so a permission-preflight-only
-    park keeps the op identity on the row (``{op_id, connector_id,
-    target_id}``) and merely appends the preflight banner to it.
+    park — and a failed-preview park (#1628) — keeps the op identity on
+    the row (``{op_id, connector_id, target_id}``) and merely appends the
+    preflight banner / unavailability marker to it.
     """
     effect: dict[str, Any] = {"op_id": op_id, "connector_id": connector_id}
     raw_tid = getattr(target, "id", None) if target is not None else None
@@ -997,6 +998,11 @@ async def _build_proposed_effect(
     anything (the caller then stores the identifier-only default). When
     only the preflight fired, its result is merged onto the identifier
     default-shaped base so the reviewer still sees the denial banner.
+    A *failed* preview (the hook's ``preview_unavailable`` marker,
+    #1628) is likewise merged onto the identifier base — the reviewer
+    keeps the op identity and additionally sees that the blast radius
+    could not be resolved, instead of a bare identifier default
+    indistinguishable from a small action.
     Never raises: connector-resolution faults degrade to "no preview" so
     the park always proceeds.
     """
@@ -1014,6 +1020,15 @@ async def _build_proposed_effect(
             params=params,
         )
         preview = await build_proposed_effect(ctx)
+        if preview is not None and preview.get("preview_unavailable") is True:
+            # The registered builder *failed* (vs. declined) — keep the
+            # identifier fields the default would have carried and ride
+            # the marker + reason alongside them (#1628).
+            marked = _identifier_default_effect(
+                op_id=op_id, connector_id=connector_id, target=target
+            )
+            marked.update(preview)
+            preview = marked
         preflight = await build_permission_preflight(ctx)
         if preflight is None:
             # No permission preflight ran -- preserve the prior contract
@@ -1080,8 +1095,11 @@ async def _handle_needs_approval(
     # side-effect-free preview (notably ``k8s.apply``'s server-dry-run) a
     # chance to populate ``proposed_effect`` so the reviewer sees the diff
     # in the approval queue. Opt-in per op + fail-soft: ops without a
-    # registered builder (and any builder that raises) yield ``None`` and
-    # the queue stores the identifier-only default exactly as before.
+    # registered builder (or whose builder declines) yield ``None`` and
+    # the queue stores the identifier-only default exactly as before. A
+    # builder that *raises* parks with the identifier fields plus an
+    # explicit ``preview_unavailable`` marker + reason (#1628), so the
+    # reviewer can tell "blast-radius unknown" from a small action.
     #
     # G0.20-T4 (#1504): the same hook also runs the op's park-time
     # permission preflight (the Vault KV-write ops probe

--- a/backend/tests/test_connectors_vmware_rest_composites_write_preview.py
+++ b/backend/tests/test_connectors_vmware_rest_composites_write_preview.py
@@ -20,6 +20,11 @@ G0.22-T3 (#1608) acceptance criteria:
 4. All 8 write composites register a builder (4 live-read + 4 param
    echo); the wiring test pins the full set.
 
+Plus the #1628 follow-up: a *failed* live-read preview parks with the
+identifier fields **and** an explicit ``preview_unavailable`` marker +
+reason (visible through the REST / MCP serialisation helpers), so the
+reviewer can tell "blast-radius unknown" from a genuinely small action.
+
 Harness: mirrors :mod:`tests.test_connectors_vmware_rest_composites_write_e2e`
 (recording leaf typed-ops + in-process SQLite dispatcher), trimmed to the
 two listing leaves the park-time previews actually read — at park time
@@ -498,10 +503,19 @@ async def test_power_bulk_resolved_list_is_capped_with_true_total(
     assert preview["resolved"][0] == {"vm": "vm-0", "name": "node-0"}
 
 
-async def test_power_bulk_preview_failure_fails_soft_to_identifier_default(
+async def test_power_bulk_preview_failure_parks_with_unavailable_marker(
     stub_embedding_service: AsyncMock,
 ) -> None:
-    """A failing listing read degrades to the identifier-only default; the park proceeds."""
+    """A failing listing read parks with identifiers + an explicit marker (#1628).
+
+    Pre-#1628 the row degraded silently to the bare identifier-only
+    default — indistinguishable from a genuinely small action, defeating
+    the four-eyes purpose of the preview on any deploy where the L2 read
+    can't execute. The park (the safety-relevant action) still proceeds
+    — ``_park`` asserts ``awaiting_approval`` + a PENDING row — but the
+    reviewer now sees "blast-radius unknown" plus the read's failure
+    reason alongside the identifier fields.
+    """
     await _bootstrap_registry(stub_embedding_service)
     _FAILURES["GET:/vcenter/vm"] = "vCenter listing unavailable"
 
@@ -512,11 +526,52 @@ async def test_power_bulk_preview_failure_fails_soft_to_identifier_default(
         target=target,
     )
 
-    assert row.proposed_effect == {
-        "op_id": "vmware.composite.vm.power.bulk",
-        "connector_id": _CONNECTOR_ID,
-        "target_id": str(target.id),
-    }
+    effect = row.proposed_effect
+    # The identifier fields stay — the marker rides alongside them.
+    assert effect["op_id"] == "vmware.composite.vm.power.bulk"
+    assert effect["connector_id"] == _CONNECTOR_ID
+    assert effect["target_id"] == str(target.id)
+    assert effect["op_class"] == "other"
+    assert effect["preview_unavailable"] is True
+    # The reason names the failed listing read and its error, not just
+    # "failed" — the reviewer learns *what* could not be resolved.
+    assert "GET:/vcenter/vm" in effect["preview_error"]
+    assert "vCenter listing unavailable" in effect["preview_error"]
+    # No "preview" envelope key: a failed preview is structurally
+    # distinct from a successful one.
+    assert "preview" not in effect
+
+
+async def test_preview_unavailable_marker_reaches_reviewer_surfaces(
+    stub_embedding_service: AsyncMock,
+) -> None:
+    """The marker is reviewer-visible on the REST view and the MCP row dict (#1628).
+
+    ``GET /api/v1/approvals[/{id}]`` serialises the row through
+    :func:`meho_backplane.api.v1.approvals._view` and
+    ``meho.approvals.list`` / ``.get`` through
+    :func:`meho_backplane.mcp.tools.approvals._row_to_dict`; both pass
+    ``proposed_effect`` through verbatim. Pinning the passthrough for
+    the marker keeps a future field projection from silently hiding a
+    failed preview from the approval queue.
+    """
+    from meho_backplane.api.v1.approvals import _view
+    from meho_backplane.mcp.tools.approvals import _row_to_dict
+
+    await _bootstrap_registry(stub_embedding_service)
+    _FAILURES["GET:/vcenter/vm"] = "vCenter listing unavailable"
+
+    _, row = await _park("vmware.composite.vm.power.bulk", {"action": "reset"})
+
+    rest_effect = _view(row).proposed_effect
+    mcp_effect = _row_to_dict(row)["proposed_effect"]
+    assert rest_effect["preview_unavailable"] is True
+    assert mcp_effect["preview_unavailable"] is True
+    assert (
+        rest_effect["preview_error"]
+        == mcp_effect["preview_error"]
+        == row.proposed_effect["preview_error"]
+    )
 
 
 # ===========================================================================

--- a/backend/tests/test_operations_preview.py
+++ b/backend/tests/test_operations_preview.py
@@ -14,8 +14,11 @@ Coverage matrix (per Issue #1437 acceptance criteria):
   ``dry_run`` -- the preview never persists.
 * An op with no registered builder yields ``None`` (caller falls back to
   the identifier-only default).
-* A builder that raises is fail-soft: the hook returns ``None`` rather
-  than propagating, so the park always proceeds.
+* A builder that raises is fail-soft but not silent (#1628): the hook
+  returns an explicit ``preview_unavailable`` marker + reason rather
+  than propagating (the park always proceeds) or degrading to ``None``
+  (the reviewer must be able to tell "blast-radius unknown" from a
+  genuinely small action).
 * A credential-class op is suppressed (no raw preview in the durable
   row), reusing the :func:`classify_op` sensitivity classification.
 
@@ -165,8 +168,15 @@ async def test_no_builder_op_yields_none() -> None:
 
 
 @pytest.mark.asyncio
-async def test_builder_that_raises_is_fail_soft() -> None:
-    """A builder exception degrades to no-preview, never propagates."""
+async def test_builder_that_raises_yields_preview_unavailable_marker() -> None:
+    """A builder exception degrades to an explicit unavailability marker (#1628).
+
+    The raise never propagates -- the park (the safety-relevant action)
+    always proceeds -- but the degradation is no longer silent: pre-#1628
+    the hook returned ``None``, which collapsed to the identifier-only
+    default indistinguishable from a genuinely small action. The marker
+    + reason let the reviewer see "blast-radius unknown".
+    """
 
     async def _boom(_ctx: PreviewContext) -> dict[str, Any] | None:
         raise RuntimeError("dry-run hit the API and failed")
@@ -179,8 +189,54 @@ async def test_builder_that_raises_is_fail_soft() -> None:
         target=_FakeTarget(),
         params={},
     )
-    # No exception escapes; the park proceeds with the identifier-only default.
-    assert await build_proposed_effect(ctx) is None
+    # No exception escapes; the marker names the failure for the reviewer.
+    assert await build_proposed_effect(ctx) == {
+        "op_class": "other",
+        "preview_unavailable": True,
+        "preview_error": "RuntimeError: dry-run hit the API and failed",
+    }
+
+
+@pytest.mark.asyncio
+async def test_builder_failure_reason_is_truncated_and_message_less_safe() -> None:
+    """The reviewer-facing reason is bounded and survives message-less raises.
+
+    A pathological exception repr (an HTTP error echoing a response
+    body) must not balloon the durable approval row; a bare
+    ``ValueError()`` must still produce a usable type name.
+    """
+
+    async def _boom_long(_ctx: PreviewContext) -> dict[str, Any] | None:
+        raise RuntimeError("x" * 2000)
+
+    register_preview_builder("test.preview.boomlong", _boom_long)
+    ctx = PreviewContext(
+        descriptor=_FakeDescriptor(op_id="test.preview.boomlong"),  # type: ignore[arg-type]
+        connector_instance=None,
+        operator=_operator(),
+        target=_FakeTarget(),
+        params={},
+    )
+    effect = await build_proposed_effect(ctx)
+    assert effect is not None
+    assert effect["preview_unavailable"] is True
+    assert effect["preview_error"].endswith(" [truncated]")
+    assert len(effect["preview_error"]) == 500 + len(" [truncated]")
+
+    async def _boom_bare(_ctx: PreviewContext) -> dict[str, Any] | None:
+        raise ValueError
+
+    register_preview_builder("test.preview.boombare", _boom_bare)
+    ctx_bare = PreviewContext(
+        descriptor=_FakeDescriptor(op_id="test.preview.boombare"),  # type: ignore[arg-type]
+        connector_instance=None,
+        operator=_operator(),
+        target=_FakeTarget(),
+        params={},
+    )
+    effect_bare = await build_proposed_effect(ctx_bare)
+    assert effect_bare is not None
+    assert effect_bare["preview_error"] == "ValueError"
 
 
 @pytest.mark.asyncio

--- a/docs/codebase/approvals.md
+++ b/docs/codebase/approvals.md
@@ -221,9 +221,19 @@ Three invariants make the hook safe to wire on the park path:
 
 1. **Opt-in / no regression.** An op with no registered builder yields
    `None` and parks exactly as before.
-2. **Fail-soft.** A builder that raises (a dry-run that hits the API and
-   errors) degrades to `None`; the park — the safety-relevant action —
-   always proceeds. Connector-resolution faults degrade the same way.
+2. **Fail-soft, never silent.** A builder that raises (a dry-run that
+   hits the API and errors, a preview listing read that can't execute)
+   never blocks the park — the safety-relevant action always proceeds.
+   But the failure is visible (#1628): the hook returns
+   `{op_class, preview_unavailable: true, preview_error}` and the
+   dispatcher merges that marker onto the identifier fields, so the
+   parked row reads "blast-radius unknown: <reason>" instead of a bare
+   identifier default a reviewer can't tell from a small action. The
+   reason string is the exception's type + message, truncated at 500
+   chars. A builder that *declines* (returns `None` — op not
+   previewable from these params) still collapses to the identifier-only
+   default with no marker, as do connector-resolution faults outside
+   the hook.
 3. **Redaction-safe.** `build_proposed_effect` classifies the op via
    `classify_op` (the same single-sourced sensitivity classification used
    for broadcast/audit redaction, #1401) and **suppresses** the preview

--- a/docs/codebase/connectors-vmware-rest.md
+++ b/docs/codebase/connectors-vmware-rest.md
@@ -408,10 +408,18 @@ never mutate vSphere state. This mirrors how the k8s.apply dry-run
 (#1437), the argocd snapshot reads (#1452), and the vault capability
 probe (#1504) run their preview I/O — connector-level, un-dispatched.
 
-Everything is fail-soft: a builder that declines or raises (vCenter
-unreachable, listing op not ingested yet) degrades the row to the
-identifier-only default and the park always proceeds. The 5 read
-composites register no builder — they never park.
+Everything is fail-soft — the park always proceeds — but a decline and
+a failure degrade differently (#1628): a builder that *declines*
+(malformed params) parks with the identifier-only default, while a
+builder that *raises* (vCenter unreachable, listing op not ingested
+yet, the L2 read can't execute on this deploy) parks with the
+identifier fields **plus** `preview_unavailable: true` and a
+`preview_error` reason naming the failed read. The marker rides through
+every reviewer surface that renders `proposed_effect` verbatim (REST
+`GET /api/v1/approvals`, `meho.approvals.list` / `.get`, `meho
+approvals show`), so "blast-radius unknown" is distinguishable from a
+genuinely small action. The 5 read composites register no builder —
+they never park.
 
 ## Dependencies
 


### PR DESCRIPTION
## Summary

- A parked `vmware.composite.*` write whose park-time preview **fails** (the L2 listing read can't execute — RDC cycle-8, `vmware-l2-dispatch-notimplemented`) no longer degrades silently to the bare identifier-only `{op_id, connector_id, target_id}` default. The generic preview hook (`operations/_preview.py`) now returns an explicit `{op_class, preview_unavailable: true, preview_error}` marker on a builder raise, and the dispatcher merges it onto the identifier fields — so the reviewer can distinguish "blast-radius UNKNOWN" from a genuinely small action.
- The park (the safety-relevant action) still always proceeds, and the fix point is the generic fail-soft seam, so the marker naturally applies to every registered preview builder (k8s.apply / argocd / secret.move) without touching them. A builder that *declines* (returns `None`) and ops with no builder still park with the identifier-only default — unchanged.
- The marker reaches every reviewer surface without schema changes: REST `GET /api/v1/approvals[/{id}]`, `meho.approvals.list` / `.get`, and `meho approvals show` all serialise `proposed_effect` verbatim (`dict[str, Any]` / `map[string]interface{}`); a test pins the REST + MCP passthrough. The `preview_error` reason is the exception type + message (the listing-read failure detail), truncated at 500 chars to keep the durable row bounded.

## Test plan

- [x] `uv run ruff check src/ tests/` — clean
- [x] `uv run ruff format --check src/ tests/` — 940 files already formatted
- [x] `uv run mypy src/` — Success: no issues found in 465 source files
- [x] `uv run pytest -n 6 --dist loadscope --maxfail=1 --ignore=tests/integration` — full unit sweep green
- [x] AC1 (failed preview → marker + park succeeds): `test_power_bulk_preview_failure_parks_with_unavailable_marker` extends the prior fails-soft pin — parked row carries `op_id`/`connector_id`/`target_id` + `preview_unavailable: true` + a `preview_error` naming `GET:/vcenter/vm` and the failure; `_park` asserts `awaiting_approval` + PENDING row. Hook-level contract pinned in `test_builder_that_raises_yields_preview_unavailable_marker` (+ truncation / message-less-raise coverage).
- [x] AC2 (successful preview unchanged): the exact-shape equality asserts in `test_power_bulk_park_carries_action_filter_and_resolved_set`, `test_host_evacuate_park_resolves_vm_set_on_host`, `test_host_detach_from_vds_park_resolves_vm_set_on_host`, `test_cluster_patch_park_resolves_host_set`, and `test_vm_create_park_carries_echo_preview_without_any_read` would fail on any added key — all green, no marker.
- [x] AC3 (marker surfaced where the reviewer reads the approval): `test_preview_unavailable_marker_reaches_reviewer_surfaces` pins the marker through the REST `_view` and MCP `_row_to_dict` serialisation helpers (the exact seams `GET /api/v1/approvals` and `meho.approvals.*` render).
- [x] AC4 (OpenAPI/CLI regen if schema changes): no pydantic model changed — regenerated the snapshot to a temp file and diffed: byte-identical to `cli/api/openapi.json`, so no regen needed.
- [x] AC5: CHANGELOG `[Unreleased]` carries one `Fixed` bullet.
- [x] `python3 .claude/hooks/code-quality.py --diff` — 0 blockers (6 pre-existing function-size warnings in touched legacy functions).

## Out of scope

- Making the L2 reads succeed / the structured dispatch error surface — sibling #1627 (same Initiative #1626, T1).
- New previews or marker parity work for k8s.apply / argocd / secret.move beyond the generic seam they already share (verified not regressed: their decline/no-builder paths are untouched and their suites pass).
- The MCP tool *description* strings for `meho.approvals.*` still describe `proposed_effect` generically; the marker is data inside the passthrough field, so no tool-schema change is needed.

<!-- auto-implement-issue: fresh, iteration 1 -->

Closes #1628


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * When an approval preview fails to load, the system now explicitly marks it as unavailable with a failure reason instead of silently degrading to identifier-only data. This information is exposed across REST API and CLI approval views, helping reviewers understand when blast radius is unknown.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->