### PR TITLE
fix(operations): no-spill drill-in carries a machine-readable reason — k8s.logs tail=300 diagnosis + hardening (#1629)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -101,6 +101,15 @@ connector-related release-notes line.
   unknown" from a genuinely small action when a `vmware.composite.*`
   preview's listing read cannot execute. The park itself still always
   proceeds; successful previews are unchanged. (#1628)
+- A reduced result whose rows exceed the inline sample but could not be
+  spilled to the read-back store no longer fails silently: the handle's
+  `fetch_more.drill_in` now carries a machine-readable `reason`
+  (`no_tenant_context` / `result_store_unavailable`) next to a
+  reason-specific rationale, and every skipped spill logs a structured
+  `jsonflux_spill_skipped` warning. Diagnoses the RDC cycle-8
+  `k8s.logs tail=300` 5-of-300-sample finding — not a #1507 regression
+  and not a k8s.logs-shape gap (pinned by repro tests); see
+  `docs/codebase/result-spill.md` for the triage runbook. (#1629)
 
 ## [0.13.0] - 2026-06-11
 

--- a/backend/src/meho_backplane/connectors/schemas.py
+++ b/backend/src/meho_backplane/connectors/schemas.py
@@ -39,6 +39,7 @@ from pydantic import BaseModel, ConfigDict, Field, field_serializer, model_valid
 __all__ = [
     "AuthModel",
     "CandidateHint",
+    "DrillInUnavailableReason",
     "EdgeHint",
     "EdgeKind",
     "FetchMore",
@@ -53,6 +54,17 @@ __all__ = [
     "ResultHandle",
     "TopologyHints",
 ]
+
+
+#: Machine-readable cause for ``FetchMoreDrillIn.available=False`` (#1629).
+#: ``no_tenant_context`` -- the reduce ran without a usable
+#: ``tenant_id`` / ``operator_sub`` pair in the reducer context, so the
+#: spill could not be keyed to a tenant (a non-dispatch reduce; never a
+#: real authenticated dispatch, where ``Operator.tenant_id`` is a
+#: required field). ``result_store_unavailable`` -- tenant context was
+#: present but the Valkey-backed read-back store did not persist the
+#: rows (unreachable, rejected the write, or disabled by configuration).
+DrillInUnavailableReason = Literal["no_tenant_context", "result_store_unavailable"]
 
 
 NodeKind = Literal[
@@ -154,6 +166,16 @@ class FetchMoreDrillIn(BaseModel):
     names the tool + the handle id to call it with. The ``mcp_tool`` /
     ``mcp_resource_uri`` / ``example_call`` / ``expires_at`` fields are
     populated only on the ``available=True`` branch.
+
+    ``reason`` (#1629) is the machine-readable counterpart of the
+    ``available=False`` rationale: one of
+    :data:`DrillInUnavailableReason`, naming *which* no-spill branch
+    fired (``no_tenant_context`` vs ``result_store_unavailable``) so a
+    reduced-but-unspilled result is self-explanatory instead of a
+    silent N-of-M sample. ``None`` on the ``available=True`` branch.
+    Hardens the RDC cycle-8 ``k8s.logs tail=300`` finding where the
+    operator saw a 5-of-300 sample with no way to page and no stated
+    cause.
     """
 
     model_config = ConfigDict(frozen=True)
@@ -165,6 +187,16 @@ class FetchMoreDrillIn(BaseModel):
             "For ``available=False`` this names the workaround (typically "
             "re-call with native pagination); for ``available=True`` it "
             "names the read-back tool + the handle id to call it with."
+        ),
+    )
+    reason: DrillInUnavailableReason | None = Field(
+        default=None,
+        description=(
+            "Machine-readable cause when ``available=False``: "
+            "``no_tenant_context`` (the reduce ran outside a "
+            "tenant-scoped dispatch, so the spill could not be keyed) or "
+            "``result_store_unavailable`` (the read-back store did not "
+            "persist the rows). ``None`` when ``available=True``."
         ),
     )
     mcp_tool: str | None = Field(

--- a/backend/src/meho_backplane/operations/jsonflux_reducer.py
+++ b/backend/src/meho_backplane/operations/jsonflux_reducer.py
@@ -59,6 +59,7 @@ from meho_backplane.connectors.result_handle_store import (
     get_result_handle_store,
 )
 from meho_backplane.connectors.schemas import (
+    DrillInUnavailableReason,
     FetchMore,
     FetchMoreDrillIn,
     FetchMoreNativePagination,
@@ -82,13 +83,32 @@ _log = structlog.get_logger(__name__)
 #: prose every time) and so the tests can assert against a stable anchor.
 _RESULT_QUERY_TOOL = "result_query"
 
-_DRILL_IN_UNAVAILABLE_RATIONALE: str = (
-    "The full result set was not spilled to the read-back store for this "
-    "handle (the spill backend was unreachable, or this op did not run "
-    "through a tenant-scoped dispatch). To act on more than the sample, "
-    "re-call the operation with narrower params (see ``native_pagination`` "
-    "below)."
+#: Shared workaround tail for every no-spill rationale: whatever the
+#: cause, the recovery the agent can act on is the same.
+_DRILL_IN_WORKAROUND = (
+    "To act on more than the sample, re-call the operation with narrower "
+    "params (see ``native_pagination`` below)."
 )
+
+#: Per-reason rationale for the ``available=False`` drill-in branch
+#: (#1629). Keyed by the machine-readable
+#: :data:`~meho_backplane.connectors.schemas.DrillInUnavailableReason`
+#: that ships alongside it, so the prose and the ``reason`` field can
+#: never drift apart. Before #1629 a single ambiguous string named both
+#: causes at once and the operator could not tell which one fired.
+_DRILL_IN_UNAVAILABLE_RATIONALES: dict[DrillInUnavailableReason, str] = {
+    "no_tenant_context": (
+        "The full result set was not spilled to the read-back store for "
+        "this handle: the reduce ran without a usable tenant context "
+        "(``tenant_id`` / ``operator_sub``), so the rows could not be "
+        f"keyed to a tenant. {_DRILL_IN_WORKAROUND}"
+    ),
+    "result_store_unavailable": (
+        "The full result set was not spilled to the read-back store for "
+        "this handle: the result store did not persist the rows (backend "
+        f"unreachable, write rejected, or disabled). {_DRILL_IN_WORKAROUND}"
+    ),
+}
 
 
 def _drill_in_available_rationale(handle_id: UUID, stored_rows: int, total_rows: int) -> str:
@@ -215,6 +235,22 @@ class _MaterializedSet:
     full_rows: list[dict[str, Any]]
 
 
+@dataclass(frozen=True, slots=True)
+class _SpillOutcome:
+    """What :meth:`JsonFluxReducer._spill` reports back to the assembler.
+
+    Exactly one of the two fields is set: ``stored_rows`` (the spill
+    succeeded; how many rows are retrievable via ``result_query``) or
+    ``skip_reason`` (the spill was skipped or failed; the
+    machine-readable cause the drill-in branch surfaces, #1629). The
+    pre-#1629 shape was a bare ``int | None`` whose ``None`` collapsed
+    every distinct skip cause into one indistinguishable state.
+    """
+
+    stored_rows: int | None = None
+    skip_reason: DrillInUnavailableReason | None = None
+
+
 class JsonFluxReducer:
     """Materialize large set-shaped payloads; pass small ones through.
 
@@ -275,7 +311,9 @@ class JsonFluxReducer:
         the ``result_query`` MCP tool an agent can call to page beyond the
         inline sample. A spill that is skipped or fails (no tenant in
         context, store unreachable) leaves ``drill_in.available=False`` --
-        the inline sample still ships, exactly as before this Task.
+        the inline sample still ships, and (#1629) the branch carries a
+        machine-readable ``reason`` naming which skip fired so the
+        reduced-but-unspilled response is self-explanatory.
         """
         del schema  # schema is inferred from the registered table
 
@@ -289,8 +327,8 @@ class JsonFluxReducer:
             return payload, None
 
         materialized = self._materialize(rows, context)
-        spilled_rows = await self._spill(materialized, context)
-        return self._assemble(materialized, envelope_key, context, spilled_rows)
+        spill_outcome = await self._spill(materialized, context)
+        return self._assemble(materialized, envelope_key, context, spill_outcome)
 
     def _over_threshold(self, rows: list[Any], payload: Any) -> bool:
         """True when *rows* exceeds the row OR byte threshold.
@@ -353,27 +391,41 @@ class JsonFluxReducer:
         self,
         materialized: _MaterializedSet,
         context: dict[str, Any] | None,
-    ) -> int | None:
+    ) -> _SpillOutcome:
         """Persist the full materialized rows to the read-back store.
 
-        Returns the number of rows actually stored (so :meth:`_assemble`
-        can build the drill-in rationale and flag a capped tail), or
-        ``None`` when the spill was skipped or failed: no ``tenant_id`` /
-        ``operator_sub`` in context (e.g. a non-dispatch reduce), or the
-        store rejected/could-not-store the rows. The reducer never raises
+        Returns a :class:`_SpillOutcome`: ``stored_rows`` when the rows
+        were persisted (so :meth:`_assemble` can build the drill-in
+        rationale and flag a capped tail), or ``skip_reason`` when the
+        spill was skipped or failed -- ``no_tenant_context`` for a reduce
+        without a usable ``tenant_id`` / ``operator_sub`` pair (e.g. a
+        non-dispatch reduce), ``result_store_unavailable`` when the store
+        rejected or could not persist the rows. The reducer never raises
         from here -- the store itself is fail-open, and a missing tenant
-        is a skip, not an error.
+        is a skip, not an error. Every skip logs a structured
+        ``jsonflux_spill_skipped`` warning (#1629): the tenant-context
+        skip used to be fully silent, which left the RDC cycle-8
+        ``k8s.logs tail=300`` diagnosis with nothing to grep for.
         """
-        if not context:
-            return None
-        tenant_raw = context.get("tenant_id")
-        operator_sub = context.get("operator_sub")
+        tenant_raw = context.get("tenant_id") if context else None
+        operator_sub = context.get("operator_sub") if context else None
         if not tenant_raw or not operator_sub:
-            return None
+            return self._skip(
+                "no_tenant_context",
+                materialized,
+                context,
+                has_tenant_id=bool(tenant_raw),
+                has_operator_sub=bool(operator_sub),
+            )
         try:
             tenant_id = UUID(str(tenant_raw))
         except (ValueError, TypeError):
-            return None
+            return self._skip(
+                "no_tenant_context",
+                materialized,
+                context,
+                tenant_id_malformed=True,
+            )
 
         store = self._store if self._store is not None else get_result_handle_store()
         max_rows = (
@@ -385,36 +437,62 @@ class JsonFluxReducer:
             tenant_id=tenant_id,
             operator_sub=str(operator_sub),
             handle_id=materialized.handle_id,
-            op_id=context.get("op_id"),
+            op_id=context.get("op_id") if context else None,
             rows=materialized.full_rows,
             total_rows=materialized.total_rows,
             ttl_seconds=self._ttl_seconds,
             max_rows=max_rows,
         )
         if not stored:
-            return None
-        return min(materialized.total_rows, max_rows)
+            return self._skip("result_store_unavailable", materialized, context)
+        return _SpillOutcome(stored_rows=min(materialized.total_rows, max_rows))
+
+    @staticmethod
+    def _skip(
+        reason: DrillInUnavailableReason,
+        materialized: _MaterializedSet,
+        context: dict[str, Any] | None,
+        **detail: bool,
+    ) -> _SpillOutcome:
+        """Log a structured skip and return the no-spill outcome.
+
+        One event name (``jsonflux_spill_skipped``) for every branch so
+        operators triaging a reduced-but-unspilled response have a single
+        thing to grep; ``reason`` carries the same machine-readable value
+        the response's ``drill_in.reason`` ships, and *detail* adds
+        boolean breadcrumbs (which context key was absent / malformed)
+        without leaking identity values into logs.
+        """
+        _log.warning(
+            "jsonflux_spill_skipped",
+            reason=reason,
+            op_id=context.get("op_id") if context else None,
+            handle_id=str(materialized.handle_id),
+            total_rows=materialized.total_rows,
+            **detail,
+        )
+        return _SpillOutcome(skip_reason=reason)
 
     def _assemble(
         self,
         materialized: _MaterializedSet,
         envelope_key: str | None,
         context: dict[str, Any] | None,
-        spilled_rows: int | None,
+        spill_outcome: _SpillOutcome,
     ) -> tuple[dict[str, Any], ResultHandle]:
         """Build the inline summary + the :class:`ResultHandle`.
 
-        ``spilled_rows`` is the count :meth:`_spill` persisted (``None``
-        when nothing was spilled); it decides whether the handle's
-        drill-in branch is ``available=True`` (pointing at
-        ``result_query``) or stays on the unavailable workaround branch.
+        ``spill_outcome`` carries either the count :meth:`_spill`
+        persisted -- the handle's drill-in branch flips to
+        ``available=True`` pointing at ``result_query`` -- or the skip
+        reason the unavailable branch surfaces verbatim (#1629).
         """
         total_rows = materialized.total_rows
         fetch_more = _build_fetch_more(
             context,
             handle_id=materialized.handle_id,
             total_rows=total_rows,
-            spilled_rows=spilled_rows,
+            spill_outcome=spill_outcome,
             ttl_seconds=self._ttl_seconds,
         )
         sample_rows = materialized.sample_rows
@@ -595,7 +673,7 @@ def _build_fetch_more(
     *,
     handle_id: UUID,
     total_rows: int,
-    spilled_rows: int | None,
+    spill_outcome: _SpillOutcome,
     ttl_seconds: int,
 ) -> FetchMore:
     """Build the :class:`FetchMore` envelope from the reducer's *context*.
@@ -606,13 +684,14 @@ def _build_fetch_more(
     branches:
 
     * ``drill_in`` reflects whether the full set was spilled to the
-      read-back store. When ``spilled_rows`` is not ``None`` (the spill
-      succeeded), ``available=True`` and the envelope names the
-      ``result_query`` MCP tool, a ready-to-adapt ``example_call``, and
-      the handle's ``expires_at`` so an agent can page beyond the inline
-      sample without a discovery dance. When the spill was skipped or
-      failed, ``available=False`` and the rationale surfaces the
-      narrower-params workaround verbatim.
+      read-back store. When ``spill_outcome.stored_rows`` is not ``None``
+      (the spill succeeded), ``available=True`` and the envelope names
+      the ``result_query`` MCP tool, a ready-to-adapt ``example_call``,
+      and the handle's ``expires_at`` so an agent can page beyond the
+      inline sample without a discovery dance. When the spill was skipped
+      or failed, ``available=False`` and the branch carries the
+      machine-readable ``reason`` plus a reason-specific rationale ending
+      in the narrower-params workaround (#1629).
     * ``native_pagination`` is populated from the op's
       :class:`PaginationHint` (registered under
       ``llm_instructions.pagination_hint`` and threaded through the
@@ -636,7 +715,7 @@ def _build_fetch_more(
     drill_in = _build_drill_in(
         handle_id=handle_id,
         total_rows=total_rows,
-        spilled_rows=spilled_rows,
+        spill_outcome=spill_outcome,
         ttl_seconds=ttl_seconds,
     )
     native = _native_pagination_from_context(context)
@@ -647,25 +726,33 @@ def _build_drill_in(
     *,
     handle_id: UUID,
     total_rows: int,
-    spilled_rows: int | None,
+    spill_outcome: _SpillOutcome,
     ttl_seconds: int,
 ) -> FetchMoreDrillIn:
     """Build the drill-in branch: available when the set was spilled.
 
-    ``spilled_rows is None`` -> the spill was skipped or failed, so the
-    branch is ``available=False`` with the narrower-params workaround.
-    Otherwise the branch names the ``result_query`` tool, a first-page
-    ``example_call``, and the handle's ``expires_at`` (now + the spill
-    TTL).
+    ``spill_outcome.stored_rows is None`` -> the spill was skipped or
+    failed, so the branch is ``available=False`` carrying the outcome's
+    machine-readable ``skip_reason`` and the matching reason-specific
+    rationale (#1629) -- a reduced result whose rows exceed the inline
+    sample now states *why* it cannot be paged instead of silently
+    returning an N-of-M sample. Otherwise the branch names the
+    ``result_query`` tool, a first-page ``example_call``, and the
+    handle's ``expires_at`` (now + the spill TTL).
     """
-    if spilled_rows is None:
+    if spill_outcome.stored_rows is None:
+        # ``_spill`` always sets ``skip_reason`` on the no-spill path; the
+        # fallback covers a hand-built outcome and picks the value that
+        # stays factually true in that state (nothing is retrievable).
+        reason: DrillInUnavailableReason = spill_outcome.skip_reason or "result_store_unavailable"
         return FetchMoreDrillIn(
             available=False,
-            rationale=_DRILL_IN_UNAVAILABLE_RATIONALE,
+            rationale=_DRILL_IN_UNAVAILABLE_RATIONALES[reason],
+            reason=reason,
         )
     return FetchMoreDrillIn(
         available=True,
-        rationale=_drill_in_available_rationale(handle_id, spilled_rows, total_rows),
+        rationale=_drill_in_available_rationale(handle_id, spill_outcome.stored_rows, total_rows),
         mcp_tool=_RESULT_QUERY_TOOL,
         example_call={
             "tool": _RESULT_QUERY_TOOL,

--- a/backend/tests/test_operations_jsonflux_reducer.py
+++ b/backend/tests/test_operations_jsonflux_reducer.py
@@ -599,8 +599,10 @@ async def test_handle_carries_fetch_more_unavailable_branches_without_context() 
     )
     # The unavailable branch names the narrower-params workaround (G0.20-T7
     # #1507: no spill happened because there is no tenant in the bare
-    # reduce context), and leaves the available-only fields empty.
+    # reduce context), carries the machine-readable reason (#1629), and
+    # leaves the available-only fields empty.
     assert "narrower" in handle.fetch_more.drill_in.rationale.lower()
+    assert handle.fetch_more.drill_in.reason == "no_tenant_context"
     assert handle.fetch_more.drill_in.mcp_tool is None
     assert handle.fetch_more.drill_in.example_call is None
     assert handle.fetch_more.drill_in.expires_at is None
@@ -767,6 +769,7 @@ async def test_reduce_spills_full_rows_and_flips_drill_in_available() -> None:
 
     drill_in = handle.fetch_more.drill_in
     assert drill_in.available is True
+    assert drill_in.reason is None, "#1629: the reason field is no-spill-only"
     assert drill_in.mcp_tool == "result_query"
     assert drill_in.example_call is not None
     assert drill_in.example_call["tool"] == "result_query"
@@ -780,7 +783,8 @@ async def test_reduce_without_tenant_skips_spill_and_stays_unavailable() -> None
 
     A non-dispatch reduce (or an operator with no tenant) cannot key the
     spill, so the store is untouched and the handle keeps the
-    narrower-params workaround branch — exactly the pre-#1507 behaviour.
+    narrower-params workaround branch — exactly the pre-#1507 behaviour,
+    now with the explicit ``no_tenant_context`` reason (#1629).
     """
     store = _FakeStore()
     reducer = JsonFluxReducer(sample_size=5, store=store, max_spill_rows=10000)
@@ -793,7 +797,66 @@ async def test_reduce_without_tenant_skips_spill_and_stays_unavailable() -> None
     assert handle is not None
     assert store.spills == []
     assert handle.fetch_more.drill_in.available is False
+    assert handle.fetch_more.drill_in.reason == "no_tenant_context"
     assert handle.fetch_more.drill_in.mcp_tool is None
+
+
+async def test_reduce_with_malformed_tenant_id_reports_no_tenant_context() -> None:
+    """A tenant_id that does not parse as a UUID is unusable context (#1629).
+
+    The spill cannot be keyed, so the store stays untouched and the
+    drill-in branch carries the same ``no_tenant_context`` reason as the
+    absent-tenant case — the operator-facing taxonomy stays two-valued.
+    """
+    store = _FakeStore()
+    reducer = JsonFluxReducer(sample_size=5, store=store, max_spill_rows=10000)
+    rows = [{"id": f"seg-{i}"} for i in range(60)]
+    context = {"op_id": "x", "operator_sub": "op-a", "tenant_id": "not-a-uuid"}
+
+    _reduced, handle = await reducer.reduce({"results": rows}, None, context)
+
+    assert handle is not None
+    assert store.spills == []
+    drill_in = handle.fetch_more.drill_in
+    assert drill_in.available is False
+    assert drill_in.reason == "no_tenant_context"
+
+
+async def test_reduce_store_rejection_reports_result_store_unavailable() -> None:
+    """A store that cannot persist the rows yields the store reason (#1629).
+
+    The Valkey-backed store is fail-open: ``spill`` returns ``False`` on
+    an unreachable backend / rejected write instead of raising. The
+    reduce must still ship the inline sample, and the drill-in branch
+    must say *why* paging is unavailable — ``result_store_unavailable``,
+    not the ambiguous catch-all the RDC cycle-8 ``k8s.logs tail=300``
+    operators hit.
+    """
+
+    class _DownStore:
+        async def spill(self, **_kwargs: Any) -> bool:
+            return False
+
+    reducer = JsonFluxReducer(sample_size=5, store=_DownStore(), max_spill_rows=10000)
+    rows = [{"id": f"seg-{i}"} for i in range(60)]
+    context = {
+        "op_id": "k8s.logs",
+        "operator_sub": "op-a",
+        "tenant_id": "00000000-0000-0000-0000-00000000a0a0",
+    }
+
+    reduced, handle = await reducer.reduce({"results": rows}, None, context)
+
+    assert handle is not None
+    assert reduced["row_count"] == 60
+    assert len(reduced["sample"]) == 5, "the inline sample must still ship"
+    drill_in = handle.fetch_more.drill_in
+    assert drill_in.available is False
+    assert drill_in.reason == "result_store_unavailable"
+    assert "store" in drill_in.rationale.lower()
+    assert "narrower" in drill_in.rationale.lower()
+    assert drill_in.mcp_tool is None
+    assert drill_in.example_call is None
 
 
 async def test_reduce_spill_capped_reports_truncated_tail() -> None:
@@ -816,6 +879,103 @@ async def test_reduce_spill_capped_reports_truncated_tail() -> None:
     # The rationale flags that only the first 40 of 60 rows are retrievable.
     assert "40" in drill_in.rationale
     assert "60" in drill_in.rationale
+
+
+# ---------------------------------------------------------------------------
+# #1629 — k8s.logs tail=300 diagnosis repro (RDC cycle-8, reported as a
+# #1507 regression; attribution disproved here)
+# ---------------------------------------------------------------------------
+
+
+def _k8s_logs_payload(line_count: int) -> dict[str, Any]:
+    """The exact response shape ``k8s_logs`` returns for ``tail=N``.
+
+    A flat dict whose ``lines`` list sits NEXT TO scalar keys — none of
+    the reducer's priority envelope keys (``value`` / ``results`` / ...)
+    match, so collection detection must fall through to the
+    largest-list branch and report ``source_key="lines"``, exactly what
+    the RDC cycle-8 consumer saw.
+    """
+    return {
+        "pod": "argocd-server-7d8f9c-x2x9z",
+        "namespace": "argocd",
+        "container": "argocd-server",
+        "lines": [f"2026-05-31T10:00:{i % 60:02d} log line {i}" for i in range(line_count)],
+        "truncated": False,
+    }
+
+
+async def test_k8s_logs_shape_with_tenant_context_spills_and_pages() -> None:
+    """The consumer's ``tail=300`` repro against a healthy store: NO shape gap.
+
+    Diagnosis evidence for #1629 acceptance criterion 1: the full
+    ``k8s.logs`` response shape (scalar siblings + a 300-element
+    ``lines`` list + the tail ordering hint) reduces, spills, and flips
+    drill-in available under a tenant-scoped context. The #1507 spill
+    infrastructure handles the k8s.logs shape correctly — the RDC
+    cycle-8 ``handle: null`` cannot be a k8s.logs-shape gap, leaving a
+    runtime skip (store or context) as the only candidates, both of
+    which now self-identify via ``drill_in.reason``.
+    """
+    store = _FakeStore()
+    reducer = JsonFluxReducer(sample_size=5, store=store, max_spill_rows=10000)
+    context = {
+        "op_id": "k8s.logs",
+        "operator_sub": "rdc-operator",
+        "tenant_id": "00000000-0000-0000-0000-00000000a0a0",
+        "result_ordering": {"sample": "tail"},
+    }
+
+    reduced, handle = await reducer.reduce(_k8s_logs_payload(300), None, context)
+
+    assert handle is not None, "a reducing k8s.logs response always mints a handle"
+    assert reduced["row_count"] == 300
+    assert reduced["total"] == 300
+    assert reduced["source_key"] == "lines"
+    assert len(reduced["sample"]) == 5
+    # Tail ordering: the sample is the five most-recent lines.
+    assert reduced["sample"][-1]["value"].endswith("log line 299")
+    # The full 300 rows were spilled and the drill-in teaches the page-back.
+    assert len(store.spills) == 1
+    assert store.spills[0]["stored_rows"] == 300
+    drill_in = handle.fetch_more.drill_in
+    assert drill_in.available is True
+    assert drill_in.reason is None
+    assert drill_in.mcp_tool == "result_query"
+
+
+async def test_k8s_logs_shape_store_down_states_the_reason() -> None:
+    """The hardened #1629 envelope for the consumer's actual failure mode.
+
+    Same ``tail=300`` payload, but the spill store cannot persist —
+    the only no-spill branch reachable on a real authenticated dispatch
+    (``Operator.tenant_id`` / ``sub`` are required fields, so the
+    tenant-context branch cannot fire there). The 5-of-300 sample still
+    ships, and the response now says *why* it cannot be paged instead
+    of silently omitting the read-back route.
+    """
+
+    class _DownStore:
+        async def spill(self, **_kwargs: Any) -> bool:
+            return False
+
+    reducer = JsonFluxReducer(sample_size=5, store=_DownStore(), max_spill_rows=10000)
+    context = {
+        "op_id": "k8s.logs",
+        "operator_sub": "rdc-operator",
+        "tenant_id": "00000000-0000-0000-0000-00000000a0a0",
+        "result_ordering": {"sample": "tail"},
+    }
+
+    reduced, handle = await reducer.reduce(_k8s_logs_payload(300), None, context)
+
+    assert handle is not None
+    assert reduced["row_count"] == 300
+    assert len(reduced["sample"]) == 5
+    drill_in = handle.fetch_more.drill_in
+    assert drill_in.available is False
+    assert drill_in.reason == "result_store_unavailable"
+    assert "store" in drill_in.rationale.lower()
 
 
 async def _set_shaped_handler(

--- a/docs/architecture/jsonflux.md
+++ b/docs/architecture/jsonflux.md
@@ -250,7 +250,18 @@ ready-to-adapt `example_call` carrying the handle id + a first-page
 `{offset, limit}`, and the handle's `expires_at` (the spill TTL). When
 the spill was skipped — the reduce ran outside a tenant-scoped dispatch
 — or the store was unreachable, `available=False` and `rationale`
-points at the narrower-params / native-pagination workaround. The spill
+points at the narrower-params / native-pagination workaround; since
+#1629 the branch additionally carries a machine-readable `reason`
+naming which no-spill branch fired — `no_tenant_context` (no usable
+`tenant_id` / `operator_sub` pair in the reducer context, so the spill
+could not be keyed) or `result_store_unavailable` (the Valkey-backed
+store did not persist the rows: unreachable, write rejected, or
+disabled). `reason` is `None` on the `available=True` branch, and every
+skip also logs a structured `jsonflux_spill_skipped` warning carrying
+the same reason plus `op_id` / `handle_id`, so a reduced-but-unspilled
+response is diagnosable from logs as well as from the envelope (see
+[`docs/codebase/result-spill.md`](../codebase/result-spill.md) for the
+triage runbook). The spill
 + read-back are described under *"Read-back: the `ResultHandleStore`"*
 below; the `mcp_resource_uri` field stays `None` in the current
 tool-only surface. `rationale` always carries the operator/agent-facing
@@ -333,7 +344,11 @@ learns when the tail was capped. The dispatcher threads `tenant_id` +
 `operator_sub` into `reducer_context`; a reduce with neither (a
 non-dispatch call) skips the spill, and a Valkey error is swallowed
 (`spill` returns `False`) — a read never fails because the spill backend
-is unreachable.
+is unreachable. Both skip shapes surface in the response as
+`drill_in.available=false` with the matching `reason`
+(`no_tenant_context` / `result_store_unavailable`, #1629) and log a
+`jsonflux_spill_skipped` warning; the store-level failure additionally
+logs `result_handle_spill_failed` with the underlying error.
 
 The `result_query` MCP meta-tool
 ([`mcp/tools/result_query.py`](../../backend/src/meho_backplane/mcp/tools/result_query.py))

--- a/docs/codebase/result-spill.md
+++ b/docs/codebase/result-spill.md
@@ -1,0 +1,150 @@
+# Result spill + drill-in read-back (JSONFlux handles)
+
+How a reduced (over-threshold) operation response becomes pageable —
+and how to diagnose one that is not. Companion to the broader
+[`docs/architecture/jsonflux.md`](../architecture/jsonflux.md) (engine
+provenance, reduction thresholds, sample ordering); this doc covers the
+**spill / read-back slice** and the no-spill diagnosis runbook added for
+#1629.
+
+## Overview
+
+When `JsonFluxReducer.reduce()` materializes a set-shaped payload above
+threshold (>50 rows or >4 KB by default), the caller gets back:
+
+- an inline summary `{row_count, total, sample, source_key?}` (the
+  `sample` is bounded at 5 rows by default), and
+- a `ResultHandle` on `OperationResult.handle` carrying `summary_md`,
+  `schema_`, `total_rows`, `sample_rows`, and the self-documenting
+  `fetch_more` envelope.
+
+The **full** normalized row list is spilled to the Valkey-backed
+`ResultHandleStore` keyed by `(tenant_id, handle_id)`; the
+`result_query` MCP meta-tool pages it back. Whether that spill happened
+is reported on `handle.fetch_more.drill_in`:
+
+| State | `available` | `reason` | What the agent can do |
+|---|---|---|---|
+| Spilled | `true` | `null` | Call `result_query(handle_id, offset, limit)` until `expires_at` |
+| No usable tenant context | `false` | `no_tenant_context` | Re-call with narrower params / native pagination |
+| Store did not persist | `false` | `result_store_unavailable` | Re-call with narrower params / native pagination; operator checks the Valkey backend |
+
+The handle itself is minted **unconditionally** on every reduce — a
+skipped spill never suppresses the handle, it only flips the drill-in
+branch to `available=false`.
+
+## Key types
+
+| Symbol | Where | Role |
+|---|---|---|
+| `JsonFluxReducer._spill` / `_SpillOutcome` | `backend/src/meho_backplane/operations/jsonflux_reducer.py` | Persists the materialized rows; reports `stored_rows` **or** a machine-readable `skip_reason` |
+| `FetchMoreDrillIn.reason` / `DrillInUnavailableReason` | `backend/src/meho_backplane/connectors/schemas.py` | The two-valued no-spill cause on the wire (#1629) |
+| `ResultHandleStore.spill` / `fetch_window` | `backend/src/meho_backplane/connectors/result_handle_store.py` | Fail-open Valkey persistence + operator/tenant-scoped read-back |
+| `result_query` | `backend/src/meho_backplane/mcp/tools/result_query.py` | MCP read surface; misses surface as recoverable `handle_not_found` |
+| `_reduce_or_error` | `backend/src/meho_backplane/operations/dispatcher.py` | Builds `reducer_context` (`tenant_id`, `operator_sub`, `op_id`, hints) from the authenticated `Operator` |
+
+## Control flow (dispatch path)
+
+1. `dispatch()` runs the op, redacts, and calls the reducer with
+   `reducer_context` — `operator.sub` always, `str(operator.tenant_id)`
+   whenever the operator has a tenant. `Operator.tenant_id` and
+   `Operator.sub` are **required** fields on the auth model, so an
+   authenticated MCP/REST dispatch always carries both.
+2. The reducer materializes (DuckDB), then `_spill()`:
+   - no usable `tenant_id`/`operator_sub` (absent or non-UUID) →
+     skip, reason `no_tenant_context`;
+   - `ResultHandleStore.spill()` returns `False` (Valkey unreachable,
+     write rejected, or the guard `ttl/max_rows <= 0` / empty rows) →
+     skip, reason `result_store_unavailable`;
+   - otherwise → `stored_rows = min(total_rows,
+     RESULT_HANDLE_MAX_SPILL_ROWS)`.
+3. `_assemble()` builds the inline summary + handle; the drill-in
+   branch carries the outcome (`available` + `reason` + rationale).
+4. Every skip logs a structured `jsonflux_spill_skipped` warning with
+   `reason`, `op_id`, `handle_id`, `total_rows` (plus boolean
+   breadcrumbs for which context key was absent/malformed). A
+   store-level exception additionally logs
+   `result_handle_spill_failed` with the underlying error string.
+
+## Diagnosis: the RDC cycle-8 `k8s.logs tail=300` finding (#1629)
+
+The consumer reported `k8s.logs tail=300` returning `row_count=300,
+total=300`, a 5-row `sample`, `source_key="lines"`, and "`handle:
+null`" — filed as a regression of the #1507 spill infrastructure. The
+code-level diagnosis at `v0.13.0` (`f6ee330`):
+
+- **Not a #1507 regression and not a k8s.logs-shape gap.** The spill /
+  `result_query` / drill-in infrastructure is fully present, and the
+  exact handler response shape (`lines` list next to scalar `pod` /
+  `namespace` / `container` / `truncated` keys, 300 rows, tail
+  ordering) reduces, spills, and flips drill-in available under a
+  tenant-scoped context — pinned by
+  `test_k8s_logs_shape_with_tenant_context_spills_and_pages` in
+  `backend/tests/test_operations_jsonflux_reducer.py`.
+- **A literal envelope-level `handle: null` is not producible by this
+  reduce path.** `wrap_ok_result` attaches the minted handle whenever
+  the summary shape (`row_count`/`total`/`sample`) is present, and the
+  MCP `call_operation` tool serializes `OperationResult` verbatim. A
+  null handle next to a reduced summary therefore points at the
+  *reading surface* (e.g. an audit/broadcast projection, which carry
+  only handle metadata by design, or client-side rendering), or at
+  operator shorthand for "no usable read-back route".
+- **The reachable no-spill branch on a real deploy is the store one.**
+  `Operator.tenant_id`/`sub` are required on every authenticated
+  dispatch, so `no_tenant_context` cannot fire there (it covers
+  non-dispatch reduces and malformed context only). A 5-of-300 sample
+  with no working `result_query` route on a live deploy means
+  `ResultHandleStore.spill()` returned `False` — Valkey (the broadcast
+  service the store piggybacks on, `BROADCAST_REDIS_URL`) unreachable
+  from the backplane pod, or the write rejected.
+- **What was actually wrong user-side:** before #1629 both skip causes
+  collapsed into one ambiguous rationale with no machine-readable
+  `reason`, and the tenant-context skip was fully silent in logs — the
+  operator saw a truncated sample with no way to page and no stated
+  cause. That explainability gap is what #1629 fixes; the deploy-side
+  store reachability is verified with the triage below.
+
+### Triage runbook
+
+1. Reproduce the reduce (any over-threshold read works) and inspect
+   `handle.fetch_more.drill_in` in the response: `reason` now names the
+   branch.
+2. `result_store_unavailable` → check backplane logs for
+   `result_handle_spill_failed` (carries the Valkey error) and the
+   broadcast service health (`BROADCAST_REDIS_URL`; the store reuses
+   the broadcast client's pool, so a broken broadcast feed and a
+   broken spill store fail together).
+3. `no_tenant_context` → the reduce ran outside an authenticated
+   dispatch; check the `jsonflux_spill_skipped` warning's
+   `has_tenant_id` / `has_operator_sub` / `tenant_id_malformed`
+   breadcrumbs for which key was missing.
+4. A drill-in `available=true` handle whose `result_query` still
+   misses → the handle expired (TTL default 3600 s) or the read ran as
+   a different operator (`sub` mismatch is an intentional
+   `handle_not_found`).
+
+## Dependencies
+
+- Valkey via the broadcast fast client
+  (`meho_backplane.broadcast.client.get_broadcast_client`,
+  `BROADCAST_REDIS_URL`) — shared pool, 5 s socket timeouts, fail-fast.
+- `RESULT_HANDLE_MAX_SPILL_ROWS` (default 10000, validated `> 0`) caps
+  the per-key value size; `ttl_seconds` (reducer default 3600) bounds
+  lifetime server-side.
+
+## Known issues
+
+- The spill TTL and sample size are reducer-constructor defaults, not
+  per-op tunables.
+- `no_tenant_context` folds the malformed-UUID case into the
+  absent-context case on the wire; the log breadcrumb
+  (`tenant_id_malformed=true`) is the only place they differ.
+
+## References
+
+- #1507 — spill store + `result_query` + drill-in (G0.20-T7).
+- #1629 — no-spill `reason` surfacing + skip logging + this diagnosis
+  (G0.23-T3, RDC cycle-8 signal `k8s-logs-mcp-five-row-sample-cap`).
+- #1479 — tail sample ordering for log-shaped ops (G0.19-T1).
+- `docs/architecture/jsonflux.md` — engine provenance + full reducer
+  contract.


### PR DESCRIPTION
## Summary

- **Diagnosis (AC 1):** the RDC cycle-8 `k8s.logs tail=300` finding is **not a #1507 regression and not a k8s.logs-shape gap**. The exact handler response shape (300-line `lines` list next to scalar `pod`/`namespace`/`container`/`truncated` keys, tail ordering hint) reduces, spills, and flips drill-in `available=true` under a tenant-scoped context — pinned by the new `test_k8s_logs_shape_with_tenant_context_spills_and_pages` repro. A literal envelope-level `handle: null` is not producible by the v0.13.0 reduce path (`wrap_ok_result` attaches the minted handle whenever the reduced summary ships); and since `Operator.tenant_id`/`sub` are **required** fields on every authenticated dispatch, the only reachable no-spill branch on a real deploy is the store one (`ResultHandleStore.spill()` → `False`: Valkey unreachable / write rejected). Full written diagnosis + triage runbook: `docs/codebase/result-spill.md` (new).
- **Hardening (AC 2):** `FetchMoreDrillIn` gains a machine-readable `reason` (`no_tenant_context` | `result_store_unavailable`) on the `available=false` branch, the reducer's `_spill()` now reports a structured `_SpillOutcome` instead of a bare `int | None`, each reason gets its own rationale (both keep the narrower-params workaround), and every skipped spill logs a structured `jsonflux_spill_skipped` warning — the tenant-context skip used to be fully silent.
- Docs: `docs/architecture/jsonflux.md` drill-in + spill sections updated; new `docs/codebase/result-spill.md` area doc records the diagnosis (AC 3); CHANGELOG `[Unreleased]` bullet (AC 4).

## Test plan

- [x] `uv run ruff check src/ tests/` — clean
- [x] `uv run ruff format --check src/ tests/` — clean (940 files)
- [x] `uv run mypy src/` — clean (465 source files)
- [x] `uv run pytest tests/test_operations_jsonflux_reducer.py` — 23 passed (19 existing + 4 new)
- [x] Full unit sweep `pytest -n 6 --dist loadscope --maxfail=1 --ignore=tests/integration` — green (see CI)
- [x] AC 1 — root cause recorded: repro tests prove no shape gap; reachable-branch analysis in `docs/codebase/result-spill.md`
- [x] AC 2 — `drill_in.available=false` carries an explicit `reason`; unit test per no-spill branch (`no_tenant_context` absent / malformed, `result_store_unavailable`)
- [x] AC 3 — diagnosis + triage runbook documented in `docs/codebase/result-spill.md`; reason-surfacing lands regardless of deploy-side cause
- [x] AC 4 — CHANGELOG `[Unreleased]` carries one bullet

## Out of scope

- Re-implementing #1507 (present and correct — confirmed by the repro tests).
- The 5-row sample cap / tail ordering (#1485, #1479) — unchanged.
- Sibling cycle-8 tasks: vmware dispatch error surface (#1627), preview visibility (#1628), edit-op auto-shim guard (#1630).
- No REST/OpenAPI surface change: `FetchMoreDrillIn` does not appear in the API schema (verified against `cli/api/openapi.json`), so no CLI snapshot regen is needed.

<!-- auto-implement-issue: fresh, iteration 1 -->

Closes #1629
