### PR TITLE
feat(connectors): enabled-vs-total operation counts on the connector listing (#1636)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -113,6 +113,19 @@ connector-related release-notes line.
   `cli/api/openapi.json` regenerate against the refreshed snapshot —
   the bundled `meho` CLI in this release already is. (#1630)
 
+### Added
+
+- `GET /api/v1/connectors` rows now split the operation rollup
+  enabled-vs-total: `enabled_operation_count` (ops whose per-op
+  `is_enabled` dispatchability flag is set) lands next to the
+  existing `operation_count` total, mirroring the `*_group_count`
+  family's naming, so an operator (or an LLM browsing the catalog)
+  can tell how many of a connector's operations are actually
+  dispatchable vs ingested-but-disabled (`vmware-rest-9.0`: ~2,211
+  ingested, only a fraction enabled). The `meho.connector.list` MCP
+  tool returns the same rows. Additive — existing `operation_count`
+  consumers are unaffected. (#1636)
+
 ### Fixed
 
 - A failed park-time `proposed_effect` preview no longer degrades

--- a/backend/src/meho_backplane/mcp/tools/connector_admin.py
+++ b/backend/src/meho_backplane/mcp/tools/connector_admin.py
@@ -268,13 +268,18 @@ register_mcp_tool(
         name="meho.connector.list",
         description=(
             "List ingested connectors visible to the operator's tenant "
-            "(plus built-in / global). Returns per-connector counts and "
-            "the aggregate review status (staged / enabled / disabled). "
-            "Use as the entry point when an operator needs to find a "
-            "connector to review or to see what's already in place. "
-            "Filter via status=staged to surface only connectors that "
-            "need review. Pair with meho.connector.review to drill into "
-            "an individual connector. Read-only; visible to operator and "
+            "(plus built-in / global). Returns per-connector counts — "
+            "group counts split by review status, plus the operation "
+            "rollup split enabled-vs-total (enabled_operation_count = "
+            "ops whose per-op is_enabled flag is set, i.e. actually "
+            "dispatchable; operation_count = every ingested/typed/"
+            "composite op) — and the aggregate review status (staged / "
+            "enabled / disabled). Use as the entry point when an "
+            "operator needs to find a connector to review or to see "
+            "what's already in place. Filter via status=staged to "
+            "surface only connectors that need review. Pair with "
+            "meho.connector.review to drill into an individual "
+            "connector. Read-only; visible to operator and "
             "tenant_admin roles."
         ),
         inputSchema={

--- a/backend/src/meho_backplane/operations/ingest/api_schemas.py
+++ b/backend/src/meho_backplane/operations/ingest/api_schemas.py
@@ -404,8 +404,26 @@ class ConnectorListItem(BaseModel):
     review-queue backlog at a glance.
 
     ``operation_count`` is the sum of operations across all groups
-    in scope. Useful for the CLI's
-    ``meho connector list --status staged`` summary view.
+    in scope; ``enabled_operation_count`` (G0.23-T5 / #1636) is the
+    subset of those rows whose per-op ``is_enabled`` flag is set --
+    the operations the dispatcher will actually resolve
+    (dispatchable), vs ingested-but-disabled rows that only surface
+    in review. The naming mirrors the ``*_group_count`` family above:
+    the unprefixed field is the total, the ``enabled_``-prefixed
+    field is the subset. Kept additive (rather than renaming the
+    total to ``total_operation_count``) so existing consumers of
+    ``operation_count`` -- the CLI's ``listEntry`` decode shape and
+    every ``meho.connector.list`` client -- keep working unchanged.
+    Mind the axis difference between the two ``enabled_*`` fields:
+    ``enabled_group_count`` buckets groups by *review_status*, while
+    ``enabled_operation_count`` counts the per-op ``is_enabled`` bit
+    (the dispatchability flag that survives connector-level
+    enable/disable cycles via operator overrides). Useful for the
+    CLI's ``meho connector list --status staged`` summary view and
+    for an LLM browsing the catalog: ``vmware-rest-9.0`` ingests
+    ~2,211 ops of which only a fraction are enabled, and before the
+    split nothing on the row said which of the two numbers
+    ``operation_count`` was.
 
     ``state`` (G0.9.1-T1 / #773) distinguishes *dispatchable* rows
     (``"ingested"`` — DB-backed, resolves through the dispatcher) from
@@ -448,6 +466,7 @@ class ConnectorListItem(BaseModel):
     enabled_group_count: int
     disabled_group_count: int
     operation_count: int
+    enabled_operation_count: int
     state: ConnectorState = "ingested"
     next_step: NextStep | None = None
 

--- a/backend/src/meho_backplane/operations/ingest/list_connectors.py
+++ b/backend/src/meho_backplane/operations/ingest/list_connectors.py
@@ -22,8 +22,9 @@ Class-side registrations from the v2 connector registry (entries
 registered via
 :func:`~meho_backplane.connectors.registry.register_connector_v2`
 that have no rows in ``endpoint_descriptor`` / ``operation_group``
-yet) are unioned into the response with ``group_count: 0,
-operation_count: 0``. This surfaces "State 0.5" connectors
+yet) are unioned into the response with every count zeroed
+(``group_count: 0, operation_count: 0, enabled_operation_count:
+0``). This surfaces "State 0.5" connectors
 (harbor, sddc-manager during pre-G3.5 windows) so operators see
 ``connector registered ⇒ visible in list`` rather than silent
 invisibility until the first op lands. v1-compat shim entries
@@ -326,8 +327,16 @@ async def _operation_count_by_connector(
     session: AsyncSession,
     *,
     operator_tenant_id: UUID,
-) -> dict[tuple[UUID | None, str, str, str], int]:
+) -> dict[tuple[UUID | None, str, str, str], dict[str, int]]:
     """Aggregate :class:`EndpointDescriptor` rows by connector triple.
+
+    Returns a dict keyed on ``(tenant_id, product, version,
+    impl_id)`` whose values are ``{total, enabled}`` op counts.
+    ``enabled`` counts the rows whose per-op ``is_enabled`` flag is
+    set -- the dispatchable subset -- via the same portable ``CASE
+    WHEN`` SUM technique as :func:`_aggregate_groups_by_connector`,
+    so an operator can tell how many of a connector's ops are
+    actually callable vs ingested-but-disabled (G0.23-T5 / #1636).
 
     Counts every ``source_kind`` -- ``"ingested"`` (G0.7 spec-driven),
     ``"typed"`` (G3.x hand-coded via :func:`register_typed_operation`),
@@ -343,15 +352,23 @@ async def _operation_count_by_connector(
     ``operation_count: 0`` -- the asymmetry between the two paired
     queries was the bug (Signal #4 in the v0.3.0 RDC dogfood), fixed
     by dropping the filter so both queries count the same universe
-    of rows.
+    of rows. The ``enabled`` split rides on the same unfiltered
+    universe: both numbers count the same rows, one of them narrowed
+    by ``is_enabled`` only.
     """
+    enabled_case = func.sum(
+        case((EndpointDescriptor.is_enabled.is_(True), 1), else_=0),
+    ).label("enabled")
+    total = func.count(EndpointDescriptor.id).label("total")
+
     stmt = (
         select(
             EndpointDescriptor.tenant_id,
             EndpointDescriptor.product,
             EndpointDescriptor.version,
             EndpointDescriptor.impl_id,
-            func.count(EndpointDescriptor.id).label("op_count"),
+            total,
+            enabled_case,
         )
         .where(
             (EndpointDescriptor.tenant_id.is_(None))
@@ -365,10 +382,13 @@ async def _operation_count_by_connector(
         )
     )
     result = await session.execute(stmt)
-    counts: dict[tuple[UUID | None, str, str, str], int] = {}
+    counts: dict[tuple[UUID | None, str, str, str], dict[str, int]] = {}
     for row in result.all():
-        tenant_uuid, product, version, impl_id, count = row
-        counts[(tenant_uuid, product, version, impl_id)] = int(count or 0)
+        tenant_uuid, product, version, impl_id, total_v, enabled_v = row
+        counts[(tenant_uuid, product, version, impl_id)] = {
+            "total": int(total_v or 0),
+            "enabled": int(enabled_v or 0),
+        }
     return counts
 
 
@@ -402,8 +422,8 @@ async def list_ingested_connectors(
       through) the review pipeline. These sort first and carry
       ``state="ingested"``.
     * Class-side registrations from the v2 connector registry that
-      have no DB rows yet ("State 0.5"). These append with
-      ``group_count: 0, operation_count: 0`` and ``state="registered"``
+      have no DB rows yet ("State 0.5"). These append with every
+      count zeroed and ``state="registered"``
       so an operator sees every registered connector but knows the
       dispatcher won't resolve a call against it until ingestion /
       typed-op registration lands rows. Class-only entries are always
@@ -462,7 +482,7 @@ async def _emit_db_backed_rows(
     *,
     operator: Operator,
     groups_by_connector: dict[tuple[UUID | None, str, str, str], dict[str, int]],
-    op_counts_by_connector: dict[tuple[UUID | None, str, str, str], int],
+    op_counts_by_connector: dict[tuple[UUID | None, str, str, str], dict[str, int]],
     status: ConnectorStatusFilter | None,
 ) -> list[ConnectorListItem]:
     """Emit one ``state="ingested"`` :class:`ConnectorListItem` per DB-backed connector.
@@ -496,6 +516,7 @@ async def _emit_db_backed_rows(
             source="db",
         ):
             continue
+        op_counts = op_counts_by_connector.get(key, {})
         items.append(
             ConnectorListItem(
                 connector_id=connector_id,
@@ -507,7 +528,8 @@ async def _emit_db_backed_rows(
                 staged_group_count=row["staged"],
                 enabled_group_count=row["enabled"],
                 disabled_group_count=row["disabled"],
-                operation_count=op_counts_by_connector.get(key, 0),
+                operation_count=op_counts.get("total", 0),
+                enabled_operation_count=op_counts.get("enabled", 0),
                 state="ingested",
             ),
         )
@@ -653,6 +675,7 @@ def _maybe_build_class_only_item(
         enabled_group_count=0,
         disabled_group_count=0,
         operation_count=0,
+        enabled_operation_count=0,
         state="registered",
         next_step=_next_step_for_registered(
             catalog=catalog,

--- a/backend/tests/test_api_v1_connectors_ingest.py
+++ b/backend/tests/test_api_v1_connectors_ingest.py
@@ -674,6 +674,10 @@ async def test_list_status_enabled_requires_uniform_state(
     assert item["connector_id"] == "vmware-rest-9.0"
     assert item["enabled_group_count"] == item["group_count"]
     assert item["operation_count"] == 6  # 2 groups x 3 ops
+    # The op rollup reads the per-op ``is_enabled`` bit, not the
+    # group review_status: every group is enabled here but the
+    # seeded ops carry ``is_enabled=False`` (G0.23-T5 / #1636).
+    assert item["enabled_operation_count"] == 0
 
 
 @pytest.mark.asyncio
@@ -729,6 +733,58 @@ async def test_list_operation_count_includes_typed_and_composite(
     assert by_id["vmware-rest-9.0"]["operation_count"] == 3
     assert by_id["bind9-ssh-9.0"]["operation_count"] == 4
     assert by_id["vmware-composite-9.0"]["operation_count"] == 2
+
+
+@pytest.mark.asyncio
+async def test_list_splits_enabled_vs_total_operation_count(
+    client: TestClient,
+) -> None:
+    """``enabled_operation_count`` counts ``is_enabled`` rows; ``operation_count`` counts all.
+
+    G0.23-T5 (#1636): the v0.12.0 vmware campaign observed
+    ``vmware-rest-9.0`` listing ~2,211 ingested ops of which only a
+    small fraction were enabled (dispatchable), and nothing on the
+    listing row said which of the two numbers ``operation_count``
+    was. Seeds the same connector with 6 ops all disabled, flips 2
+    to ``is_enabled=True``, and asserts the row splits 6-total /
+    2-enabled -- the two numbers differing is the point of the test.
+    """
+    tenant_a = uuid.uuid4()
+    await _seed_connector(
+        tenant_id=tenant_a,
+        product="vmware",
+        impl_id="vmware-rest",
+        group_count=2,
+        ops_per_group=3,
+        op_is_enabled=False,
+    )
+    # Flip two ops to enabled so the two rollups must differ;
+    # deterministic pick via op_id ordering.
+    sessionmaker = get_sessionmaker()
+    async with sessionmaker() as session:
+        result = await session.execute(
+            select(EndpointDescriptor)
+            .where(EndpointDescriptor.tenant_id == tenant_a)
+            .order_by(EndpointDescriptor.op_id)
+            .limit(2),
+        )
+        for descriptor in result.scalars().all():
+            descriptor.is_enabled = True
+        await session.commit()
+
+    key, token = _operator_token(tenant_id=tenant_a)
+    with respx.mock as mock_router:
+        _mock_discovery_and_jwks(mock_router, _public_jwks(key))
+        response = client.get("/api/v1/connectors", headers=_authed(token))
+    assert response.status_code == 200
+    # The unfiltered listing unions class-side "registered" rows for
+    # every v2-registered connector; key on connector_id like the
+    # sibling rollup tests instead of expecting a single row.
+    by_id = {c["connector_id"]: c for c in response.json()["connectors"]}
+    item = by_id["vmware-rest-9.0"]
+    assert item["state"] == "ingested"
+    assert item["operation_count"] == 6
+    assert item["enabled_operation_count"] == 2
 
 
 @pytest.fixture
@@ -843,6 +899,7 @@ async def test_list_surfaces_register_connector_v2_only_entries(
     assert harbor["enabled_group_count"] == 0
     assert harbor["disabled_group_count"] == 0
     assert harbor["operation_count"] == 0
+    assert harbor["enabled_operation_count"] == 0
     assert harbor["state"] == "registered"
 
     assert "sddc-rest-9.0" in by_id
@@ -858,6 +915,7 @@ async def test_list_surfaces_register_connector_v2_only_entries(
     assert sddc["impl_id"] == "sddc-rest"
     assert sddc["version"] == "9.0"
     assert sddc["operation_count"] == 0
+    assert sddc["enabled_operation_count"] == 0
     assert sddc["group_count"] == 0
     assert sddc["state"] == "registered"
 

--- a/backend/tests/test_mcp_tools_connector_admin.py
+++ b/backend/tests/test_mcp_tools_connector_admin.py
@@ -173,6 +173,7 @@ def stubbed_services(monkeypatch: pytest.MonkeyPatch) -> Iterator[dict[str, Any]
                 enabled_group_count=0,
                 disabled_group_count=0,
                 operation_count=42,
+                enabled_operation_count=7,
             ),
         ]
 
@@ -390,6 +391,9 @@ def test_call_meho_connector_list_dispatches_to_list_ingested_connectors(
     assert payload["connectors"][0]["connector_id"] == "vmware-rest-9.0"
     assert payload["connectors"][0]["staged_group_count"] == 3
     assert payload["connectors"][0]["operation_count"] == 42
+    # MCP rows ride the same ConnectorListItem model_dump as REST, so
+    # the enabled-vs-total op split lands here too (G0.23-T5 / #1636).
+    assert payload["connectors"][0]["enabled_operation_count"] == 7
 
     # The stubbed query helper recorded the status filter + operator.
     [call_kwargs] = stubbed_services["list_calls"]

--- a/docs/codebase/connector-release-readiness.md
+++ b/docs/codebase/connector-release-readiness.md
@@ -163,8 +163,9 @@ flow is the only auth_model; loader is live; consumer confirmed
 
 State 0.5 = `register_connector_v2` called but no ops registered yet.
 Since [T5 #733](https://github.com/evoila/meho/issues/733), these
-connectors surface in `GET /api/v1/connectors` with
-`group_count: 0, operation_count: 0` (built-in, `tenant_id: null`)
+connectors surface in `GET /api/v1/connectors` with every count
+zeroed (`group_count: 0, operation_count: 0,
+enabled_operation_count: 0`; built-in, `tenant_id: null`)
 so operators see `connector registered ⇒ visible in list` rather
 than waiting for the first ingested or typed op to land.
 

--- a/docs/codebase/spec-ingestion.md
+++ b/docs/codebase/spec-ingestion.md
@@ -600,11 +600,24 @@ The renamer "list_*ingested*_connectors" is now misleading and is a
 follow-up cleanup; the function lists every connector with at least
 one visible :class:`OperationGroup` row.
 
+Since G0.23-T5 (#1636) the op rollup also splits enabled-vs-total,
+mirroring the group rollup's `CASE WHEN` technique:
+`enabled_operation_count` counts the rows whose per-op `is_enabled`
+flag is set (the dispatchable subset) while `operation_count` stays
+the total over the same unfiltered `source_kind` universe. The two
+`enabled_*` fields count different axes — `enabled_group_count`
+buckets groups by `review_status`; `enabled_operation_count` reads
+the per-op dispatchability bit — so an operator (or an LLM browsing
+the catalog) can tell "~2,211 ops ingested" from "the fraction
+actually callable" on a `vmware-rest-9.0` row without drilling into
+`/review`.
+
 Class-side registrations from the v2 connector registry that have
 no DB-side state yet (T5 #733 — "State 0.5" connectors registered
 via `register_connector_v2` but without any rows in
 `operation_group` / `endpoint_descriptor`) are unioned into the
-response with `group_count: 0, operation_count: 0` and
+response with every count zeroed (`group_count: 0,
+operation_count: 0, enabled_operation_count: 0`) and
 `state: "registered"` so operators see `connector registered ⇒
 visible in list` but the agent knows the dispatcher won't resolve
 calls against them yet. Class-only rows are always built-in
@@ -745,6 +758,11 @@ consume so the wire contract is defined once:
   completion hint: a `NextStep` object (verb + rationale) on
   `state="registered"` rows, `null` on `state="ingested"` rows — see
   the next-step hint section above.
+  `ConnectorListItem.enabled_operation_count` (G0.23-T5 / #1636)
+  splits the op rollup enabled-vs-total next to the existing
+  `operation_count` — naming mirrors the `*_group_count` family
+  (unprefixed = total, `enabled_`-prefixed = subset), kept additive
+  so existing `operation_count` consumers don't break.
 * `NextStep` (G0.13-T3 / #1133) — `{verb, rationale}` pair surfaced
   on `state="registered"` rows. `verb` is a copy/pasteable
   `meho connector ingest ...` invocation; `rationale` is one


### PR DESCRIPTION
## Summary

- `GET /api/v1/connectors` rows now split the operation rollup enabled-vs-total: new `enabled_operation_count` (ops whose per-op `is_enabled` dispatchability flag is set) lands next to the existing `operation_count` total — closing the G0.23-T5 gap where `vmware-rest-9.0` listed ~2,211 ingested ops with nothing on the row saying how many are actually dispatchable.
- `_operation_count_by_connector` grows the same portable `CASE WHEN ... THEN 1 ELSE 0 END` SUM split `_aggregate_groups_by_connector` already uses (keyed on `EndpointDescriptor.is_enabled`), riding the same unfiltered `source_kind` universe — the v0.3.0 Signal #4 fix (no `source_kind` filter) stays intact; both numbers count the same rows.
- Naming follows the `*_group_count` family (unprefixed = total, `enabled_`-prefixed = subset) and is justified in the `ConnectorListItem` field docstring per the AC, including the axis difference vs `enabled_group_count` (groups bucket by `review_status`; ops count the per-op `is_enabled` bit). Additive — no rename, so existing `operation_count` consumers (CLI `listEntry` decode, MCP clients) are unaffected.
- MCP parity: `meho.connector.list` returns the same rows via the shared `ConnectorListItem.model_dump(mode="json")`; its tool description now advertises the split. Note: the issue's `mcp/tools/operations.py:225-240` anchor resolves to the **per-group** `operation_count` in `list_operation_groups`' outputSchema — that count is explicitly out of scope per the issue's own out-of-scope list; the actual MCP connectors listing is `meho.connector.list` (`connector_admin.py`), which declares no outputSchema and inherits the row shape from the shared model, so the description is its advertising surface.

## Test plan

- [x] `uv run ruff check src/ tests/` — clean
- [x] `uv run ruff format --check src/ tests/` — clean
- [x] `uv run mypy src/` — clean (465 files, strict)
- [x] AC: enabled-vs-total split returned by `GET /api/v1/connectors` — new `test_list_splits_enabled_vs_total_operation_count` seeds `vmware-rest-9.0` with 6 ops, enables 2, asserts `operation_count == 6` / `enabled_operation_count == 2` (the two numbers differing is the point, per the AC)
- [x] AC: `case()` split keyed on `EndpointDescriptor.is_enabled` mirroring `_aggregate_groups_by_connector` — see the `_operation_count_by_connector` diff
- [x] AC: MCP parity — `meho.connector.list` test pins `enabled_operation_count` riding through `model_dump`; tool description updated
- [x] Extended existing tests: uniform-group-state test pins the axis difference (all groups `review_status="enabled"`, ops `is_enabled=False` → `enabled_operation_count == 0`); class-only registered rows pin `enabled_operation_count: 0`
- [x] AC: `cd cli && make snapshot-openapi && make generate` — ran clean with **zero diff**: the list route deliberately returns an untyped dict (no `response_model`), so `ConnectorListItem` is not part of the OpenAPI document and the committed snapshot/client are already current (the `cli-api-snapshot-freshness` job regenerates and diffs the same two artifacts)
- [x] AC: CHANGELOG `[Unreleased]` carries one bullet under `### Added`
- [x] Full unit sweep `uv run pytest -n 6 --dist loadscope --ignore=tests/integration` — passed
- [x] `.claude/hooks/code-quality.py --diff` — 0 blockers (11 warnings, all pre-existing debt in touched files)

## Out of scope

- Per-group enabled/total op counts (`list_operation_groups`' per-group `operation_count` in `meta_tools.OperationGroupSummary` / its MCP outputSchema) — untouched per the issue.
- `source_kind` filter semantics — unchanged; both rollup numbers count the same universe of rows.
- CLI surfacing of the new field: `cli/internal/cmd/connector/list.go`'s `listEntry` decode struct already omits `state` / `next_step`, and `--json` mode re-serialises the decoded struct (lossy today). Additive backend fields are ignored harmlessly by `encoding/json`. Recorded as an adjacent finding for a possible follow-up (surface `enabled_operation_count` — and the already-missing `state` / `next_step` — in the CLI listing).

<!-- auto-implement-issue: fresh, iteration 1 -->

Closes #1636


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * The connector listing endpoint now splits operation metrics into an enabled-versus-total breakdown, exposing the count of enabled operations alongside the total operation count. This provides better visibility into which operations are available for use.

* **Documentation**
  * Updated documentation to clarify the new operation count metrics and their relationship to existing group-level breakdowns.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->