### PR TITLE
fix(api): authorize cross-tenant scope via platform-admin (close tenant IDOR)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -90,6 +90,20 @@ connector-related release-notes line.
 
 ## [Unreleased]
 
+### Security
+
+- Closed a cross-tenant IDOR on the scheduler
+  (`GET`/`POST`/`DELETE /api/v1/scheduler/triggers`) and retrieval
+  (`GET /api/v1/retrieve/usage`, `POST /api/v1/retrieve/retire-checklist`)
+  routes: a caller-supplied `tenant_id` / `tenant_filter` was authorized on
+  `tenant_admin` **rank** alone, so a tenant-admin of tenant A could
+  read/act on tenant B. A new shared `authorize_tenant_scope` helper now
+  requires the cross-tenant `platform_admin` capability (#1638) to target
+  another tenant; requesting one's own tenant (or omitting the filter) is
+  unchanged. The 403 detail token changes from
+  `tenant_filter_requires_tenant_admin` to
+  `cross_tenant_requires_platform_admin` (#1640).
+
 ### Breaking changes
 
 - `meho connector edit-op --enable` no longer reports a silent

--- a/backend/src/meho_backplane/api/v1/retrieve_retire.py
+++ b/backend/src/meho_backplane/api/v1/retrieve_retire.py
@@ -72,7 +72,7 @@ from fastapi import APIRouter, Depends, HTTPException, Query
 from pydantic import BaseModel, ConfigDict, Field
 
 from meho_backplane.auth.operator import Operator, TenantRole
-from meho_backplane.auth.rbac import require_role
+from meho_backplane.auth.rbac import authorize_tenant_scope, require_role
 from meho_backplane.db.engine import get_sessionmaker
 from meho_backplane.retrieval.retire import (
     SURFACE_VERDICT_ORDER,
@@ -181,9 +181,10 @@ async def retire_checklist_endpoint(
     """Return the five-criterion retire-decision checklist per surface.
 
     Tenant scoping mirrors the sibling usage route:
-    ``operator`` / ``read_only`` callers are scoped to
-    ``operator.tenant_id``; passing a non-null ``tenant_filter`` query
-    parameter returns 403. Only ``tenant_admin`` may cross tenants.
+    Callers are scoped to ``operator.tenant_id``; a ``tenant_filter``
+    query parameter naming a different tenant returns 403
+    ``cross_tenant_requires_platform_admin`` unless the caller holds the
+    ``platform_admin`` cross-tenant capability (#1638).
     The request body's ``surface=all`` (default) walks every supported
     surface in the order :data:`SURFACE_VERDICT_ORDER` pins.
 
@@ -211,13 +212,7 @@ async def retire_checklist_endpoint(
         operator_tenant_id=operator.tenant_id,
     )
 
-    if tenant_filter is not None and operator.tenant_role != TenantRole.TENANT_ADMIN:
-        raise HTTPException(
-            status_code=403,
-            detail="tenant_filter_requires_tenant_admin",
-        )
-
-    target_tenant = tenant_filter if tenant_filter is not None else operator.tenant_id
+    target_tenant = authorize_tenant_scope(operator, tenant_filter)
 
     # ``blocker_counts`` may carry keys that aren't part of the
     # currently-requested surface scope; Pydantic has already pinned

--- a/backend/src/meho_backplane/api/v1/retrieve_usage.py
+++ b/backend/src/meho_backplane/api/v1/retrieve_usage.py
@@ -60,7 +60,7 @@ import structlog
 from fastapi import APIRouter, Depends, HTTPException, Query
 
 from meho_backplane.auth.operator import Operator, TenantRole
-from meho_backplane.auth.rbac import require_role
+from meho_backplane.auth.rbac import authorize_tenant_scope, require_role
 from meho_backplane.db.engine import get_sessionmaker
 from meho_backplane.retrieval.usage import (
     DEFAULT_SINCE,
@@ -129,9 +129,10 @@ async def usage_endpoint(
 ) -> UsageReport:
     """Return audit-backed retrieval usage aggregates for *operator*.
 
-    Tenant scoping: ``operator`` / ``read_only`` callers are scoped
-    to ``operator.tenant_id``; passing a non-null ``tenant_filter``
-    returns 403. Only ``tenant_admin`` may cross tenants. *since*
+    Tenant scoping: callers are scoped to ``operator.tenant_id``; a
+    ``tenant_filter`` naming a different tenant returns 403
+    ``cross_tenant_requires_platform_admin`` unless the caller holds the
+    ``platform_admin`` cross-tenant capability (#1638). *since*
     accepts ``<N>d`` / ``<N>h`` (relative) or an ISO-8601 date;
     malformed → 400. ``surface=all`` (default) covers all three;
     ``surface=<one>`` narrows. Empty result is a structured zero
@@ -139,11 +140,7 @@ async def usage_endpoint(
     bound before :func:`compute_usage` runs so a handler exception
     still produces an audit row with partial payload.
     """
-    if tenant_filter is not None and operator.tenant_role != TenantRole.TENANT_ADMIN:
-        raise HTTPException(
-            status_code=403,
-            detail="tenant_filter_requires_tenant_admin",
-        )
+    target_tenant = authorize_tenant_scope(operator, tenant_filter)
 
     surfaces = _resolve_surfaces(surface)
     now = datetime.now(UTC)
@@ -152,7 +149,6 @@ async def usage_endpoint(
     except SinceValueError as exc:
         raise HTTPException(status_code=400, detail=str(exc)) from exc
 
-    target_tenant = tenant_filter if tenant_filter is not None else operator.tenant_id
     _bind_request_audit_context(
         surfaces=surfaces,
         since=since,

--- a/backend/src/meho_backplane/api/v1/scheduler.py
+++ b/backend/src/meho_backplane/api/v1/scheduler.py
@@ -27,13 +27,14 @@ Route inventory
 Tenant scoping + cross-tenant admin
 -----------------------------------
 
-``operator`` / ``read_only`` callers are scoped to their JWT's
-``tenant_id`` claim and any attempt to pass ``tenant_id`` in the
-create body or ``tenant_filter`` in the query string surfaces as 403
-``tenant_filter_requires_tenant_admin`` (mirrors the
-``retrieve_usage`` precedent). ``tenant_admin`` callers may target
-another tenant by setting ``tenant_id`` in the body (create) or
-``tenant_filter`` in the query (list). A cross-tenant probe by id
+Callers are scoped to their JWT's ``tenant_id`` claim; passing a
+*different* ``tenant_id`` in the create body or ``tenant_filter`` in the
+query string surfaces as 403 ``cross_tenant_requires_platform_admin``
+(mirrors the ``retrieve_usage`` precedent) unless the caller holds the
+``platform_admin`` cross-tenant capability (#1638). Only a
+``platform_admin`` may target another tenant by setting ``tenant_id`` in
+the body (create) or ``tenant_filter`` in the query (list); tenant role
+alone no longer crosses the boundary. A cross-tenant probe by id
 surfaces as 404 ``trigger_not_found`` (never 403) -- the conflation
 prevents enumerating another tenant's triggers via a status-code
 differential.
@@ -62,7 +63,7 @@ from fastapi import status as http_status
 from fastapi.responses import Response
 
 from meho_backplane.auth.operator import Operator, TenantRole
-from meho_backplane.auth.rbac import require_role
+from meho_backplane.auth.rbac import authorize_tenant_scope, require_role
 from meho_backplane.scheduler.schemas import (
     KindFilter,
     ScheduledTriggerCreate,
@@ -124,16 +125,13 @@ async def list_triggers(
 ) -> ScheduledTriggerListResponse:
     """List scheduled triggers for the operator's tenant, newest-first.
 
-    Tenant scoping: ``operator`` / ``read_only`` callers are scoped to
-    ``operator.tenant_id`` and any non-null ``tenant_filter`` returns
-    403. Only ``tenant_admin`` may cross tenants.
+    Tenant scoping: callers are scoped to ``operator.tenant_id``; a
+    ``tenant_filter`` naming a *different* tenant returns 403
+    ``cross_tenant_requires_platform_admin`` unless the caller holds the
+    ``platform_admin`` cross-tenant capability. Passing one's own tenant
+    id (or omitting the filter) is always allowed.
     """
-    if tenant_filter is not None and operator.tenant_role != TenantRole.TENANT_ADMIN:
-        raise HTTPException(
-            status_code=http_status.HTTP_403_FORBIDDEN,
-            detail="tenant_filter_requires_tenant_admin",
-        )
-    target_tenant = tenant_filter if tenant_filter is not None else operator.tenant_id
+    target_tenant = authorize_tenant_scope(operator, tenant_filter)
     structlog.contextvars.bind_contextvars(
         audit_op_id=_SCHEDULER_OP_IDS["list"],
         audit_op_class="read",
@@ -172,7 +170,7 @@ async def create_trigger(
     of ``cron_expr`` / ``fire_at`` / ``event_filter`` is set; the
     service runs the FK pre-flight.
     """
-    target_tenant = body.tenant_id if body.tenant_id is not None else operator.tenant_id
+    target_tenant = authorize_tenant_scope(operator, body.tenant_id)
     structlog.contextvars.bind_contextvars(
         audit_op_id=_SCHEDULER_OP_IDS["create"],
         audit_op_class="write",
@@ -226,12 +224,7 @@ async def cancel_trigger(
     ``tenant_admin``-gated, for forward-compat in case the role gate
     relaxes in a future release.
     """
-    if tenant_filter is not None and operator.tenant_role != TenantRole.TENANT_ADMIN:
-        raise HTTPException(
-            status_code=http_status.HTTP_403_FORBIDDEN,
-            detail="tenant_filter_requires_tenant_admin",
-        )
-    target_tenant = tenant_filter if tenant_filter is not None else operator.tenant_id
+    target_tenant = authorize_tenant_scope(operator, tenant_filter)
     structlog.contextvars.bind_contextvars(
         audit_op_id=_SCHEDULER_OP_IDS["cancel"],
         audit_op_class="write",

--- a/backend/src/meho_backplane/auth/rbac.py
+++ b/backend/src/meho_backplane/auth/rbac.py
@@ -40,6 +40,7 @@ from __future__ import annotations
 
 from collections.abc import Callable
 from typing import Final
+from uuid import UUID
 
 import structlog
 from fastapi import Depends, HTTPException, status
@@ -47,7 +48,7 @@ from fastapi import Depends, HTTPException, status
 from meho_backplane.auth.operator import Operator, TenantRole
 from meho_backplane.middleware import verify_jwt_and_bind
 
-__all__ = ["require_role"]
+__all__ = ["authorize_tenant_scope", "require_role"]
 
 #: Linear role ordering. Index = rank; ``read_only`` is rank 0,
 #: ``tenant_admin`` is rank 2. The dependency compares the actual
@@ -160,3 +161,35 @@ def require_role(min_role: TenantRole) -> Callable[[Operator], Operator]:
         return operator
 
     return _checker
+
+
+def authorize_tenant_scope(operator: Operator, requested: UUID | None) -> UUID:
+    """Resolve the effective tenant for a request, authorizing a cross-tenant claim.
+
+    Returns ``operator.tenant_id`` when *requested* is ``None`` or equals
+    the operator's own tenant — the common, same-tenant path. A request
+    naming a *different* tenant is the cross-tenant case: it is allowed
+    **only** for a platform-admin (``operator.platform_admin``, the
+    cross-tenant capability primitive #1638) and otherwise raises HTTP 403
+    ``cross_tenant_requires_platform_admin``.
+
+    This replaces the prior per-route gate that allowed the claim on
+    ``tenant_admin`` *rank* alone — a tenant-admin of tenant A could pass
+    tenant B's id and read/act on B (a cross-tenant IDOR). Tenant role
+    governs *what* an operator may do within their tenant; crossing the
+    tenant boundary is a separate, platform-level capability.
+    """
+    if requested is None or requested == operator.tenant_id:
+        return operator.tenant_id
+    if operator.platform_admin:
+        return requested
+    structlog.get_logger(__name__).warning(
+        "cross_tenant_denied",
+        operator_sub=operator.sub,
+        operator_tenant_id=str(operator.tenant_id),
+        requested_tenant_id=str(requested),
+    )
+    raise HTTPException(
+        status_code=status.HTTP_403_FORBIDDEN,
+        detail="cross_tenant_requires_platform_admin",
+    )

--- a/backend/tests/_oidc_jwt_helpers.py
+++ b/backend/tests/_oidc_jwt_helpers.py
@@ -74,6 +74,7 @@ def mint_token(
     tenant_role: str = DEFAULT_TENANT_ROLE,
     audience: str | None = None,
     capabilities: list[str] | None = None,
+    platform_admin: bool | None = None,
 ) -> str:
     """Mint a happy-path JWT signed by *private_key*.
 
@@ -112,6 +113,8 @@ def mint_token(
             payload["email"] = email
         if capabilities is not None:
             payload["capabilities"] = capabilities
+        if platform_admin is not None:
+            payload["platform_admin"] = platform_admin
         header = {"alg": "RS256", "kid": private_key.as_dict()["kid"], "typ": "JWT"}
         token: bytes | str = jwt.encode(header, payload, private_key)
         return token.decode("ascii") if isinstance(token, bytes) else token

--- a/backend/tests/test_auth_rbac.py
+++ b/backend/tests/test_auth_rbac.py
@@ -54,13 +54,13 @@ from uuid import UUID
 import pytest
 import respx
 import structlog
-from fastapi import FastAPI
+from fastapi import FastAPI, HTTPException
 from fastapi.testclient import TestClient
 
 from meho_backplane.api.v1.rbac_test import router as rbac_test_router
 from meho_backplane.auth.jwt import clear_jwks_cache
 from meho_backplane.auth.operator import Operator, TenantRole
-from meho_backplane.auth.rbac import require_role
+from meho_backplane.auth.rbac import authorize_tenant_scope, require_role
 from meho_backplane.middleware import RequestContextMiddleware
 from meho_backplane.settings import get_settings
 
@@ -472,3 +472,57 @@ def test_settings_enable_rbac_test_route_falsy_values(
     monkeypatch.setenv("MEHO_ENABLE_RBAC_TEST_ROUTE", value)
     get_settings.cache_clear()
     assert get_settings().enable_rbac_test_route is False
+
+
+# ---------------------------------------------------------------------------
+# authorize_tenant_scope — cross-tenant authorization (#1640)
+# ---------------------------------------------------------------------------
+
+_TENANT_SELF = UUID("11111111-1111-1111-1111-111111111111")
+_TENANT_OTHER = UUID("22222222-2222-2222-2222-222222222222")
+
+
+def _scope_op(
+    *,
+    role: TenantRole = TenantRole.TENANT_ADMIN,
+    platform_admin: bool = False,
+) -> Operator:
+    return Operator(
+        sub="op",
+        raw_jwt="t",
+        tenant_id=_TENANT_SELF,
+        tenant_role=role,
+        platform_admin=platform_admin,
+    )
+
+
+def test_authorize_tenant_scope_none_returns_own() -> None:
+    """No requested tenant → the operator's own tenant."""
+    assert authorize_tenant_scope(_scope_op(), None) == _TENANT_SELF
+
+
+def test_authorize_tenant_scope_own_returns_own() -> None:
+    """Explicitly requesting one's own tenant is always allowed."""
+    assert authorize_tenant_scope(_scope_op(), _TENANT_SELF) == _TENANT_SELF
+
+
+def test_authorize_tenant_scope_foreign_tenant_admin_denied() -> None:
+    """A tenant-admin without platform_admin cannot cross tenants (the IDOR fix)."""
+    with pytest.raises(HTTPException) as exc:
+        authorize_tenant_scope(
+            _scope_op(role=TenantRole.TENANT_ADMIN, platform_admin=False),
+            _TENANT_OTHER,
+        )
+    assert exc.value.status_code == 403
+    assert exc.value.detail == "cross_tenant_requires_platform_admin"
+
+
+def test_authorize_tenant_scope_foreign_platform_admin_allowed() -> None:
+    """A platform-admin may target another tenant even with a sub-admin role."""
+    assert (
+        authorize_tenant_scope(
+            _scope_op(role=TenantRole.OPERATOR, platform_admin=True),
+            _TENANT_OTHER,
+        )
+        == _TENANT_OTHER
+    )

--- a/backend/tests/test_retrieval_retire.py
+++ b/backend/tests/test_retrieval_retire.py
@@ -913,14 +913,20 @@ def test_route_operator_with_tenant_filter_returns_403(
             headers={"Authorization": f"Bearer {token}"},
         )
     assert response.status_code == 403
-    assert response.json() == {"detail": "tenant_filter_requires_tenant_admin"}
+    assert response.json() == {"detail": "cross_tenant_requires_platform_admin"}
 
 
-def test_route_tenant_admin_with_tenant_filter_returns_200(
+def test_route_platform_admin_with_tenant_filter_returns_200(
     retire_client: TestClient,
 ) -> None:
+    """Cross-tenant retire requires platform-admin (#1638); tenant-admin alone is denied."""
     key = _make_rsa_keypair("kid-A")
-    token = _mint_token(key, sub="op-admin", tenant_role=TenantRole.TENANT_ADMIN.value)
+    token = _mint_token(
+        key,
+        sub="op-admin",
+        tenant_role=TenantRole.TENANT_ADMIN.value,
+        platform_admin=True,
+    )
     fake_eval = AsyncMock(return_value=_stub_eval_result())
     with (
         respx.mock as mock_router,
@@ -1064,7 +1070,12 @@ async def test_route_audit_tenant_scope_other_for_cross_tenant_admin(
     retire_client: TestClient,
 ) -> None:
     key = _make_rsa_keypair("kid-A")
-    token = _mint_token(key, sub="op-admin", tenant_role=TenantRole.TENANT_ADMIN.value)
+    token = _mint_token(
+        key,
+        sub="op-admin",
+        tenant_role=TenantRole.TENANT_ADMIN.value,
+        platform_admin=True,
+    )
     fake_eval = AsyncMock(return_value=_stub_eval_result())
     with (
         respx.mock as mock_router,

--- a/backend/tests/test_retrieval_usage.py
+++ b/backend/tests/test_retrieval_usage.py
@@ -878,18 +878,23 @@ def test_route_operator_with_tenant_filter_returns_403(
             headers={"Authorization": f"Bearer {token}"},
         )
     assert response.status_code == 403
-    assert response.json() == {"detail": "tenant_filter_requires_tenant_admin"}
+    assert response.json() == {"detail": "cross_tenant_requires_platform_admin"}
 
 
-def test_route_tenant_admin_with_tenant_filter_returns_200(
+def test_route_platform_admin_with_tenant_filter_returns_200(
     usage_client: TestClient,
 ) -> None:
-    """``tenant_admin`` + ``tenant_filter`` → 200 with the filtered scope."""
+    """A ``platform_admin`` + ``tenant_filter`` → 200 with the filtered scope.
+
+    Cross-tenant access requires the platform-admin capability (#1638); a
+    plain ``tenant_admin`` is now denied (see the operator-403 sibling test).
+    """
     key = _make_rsa_keypair("kid-A")
     token = _mint_token(
         key,
         sub="op-admin",
         tenant_role=TenantRole.TENANT_ADMIN.value,
+        platform_admin=True,
     )
     with respx.mock as mock_router:
         _mock_discovery_and_jwks(mock_router, _public_jwks(key))
@@ -1003,16 +1008,17 @@ async def test_route_audit_payload_carries_canonical_op_id(
 async def test_route_audit_tenant_scope_other_for_cross_tenant_admin(
     usage_client: TestClient,
 ) -> None:
-    """``tenant_admin`` + cross-tenant filter → ``tenant_scope="other"``.
+    """``platform_admin`` + cross-tenant filter → ``tenant_scope="other"``.
 
     Lets G8 audit-trail queries distinguish operators inspecting
-    their own tenant from tenant_admins genuinely cross-cutting.
+    their own tenant from platform-admins genuinely cross-cutting.
     """
     key = _make_rsa_keypair("kid-A")
     token = _mint_token(
         key,
         sub="op-admin",
         tenant_role=TenantRole.TENANT_ADMIN.value,
+        platform_admin=True,
     )
     with respx.mock as mock_router:
         _mock_discovery_and_jwks(mock_router, _public_jwks(key))

--- a/backend/tests/test_scheduler_admin.py
+++ b/backend/tests/test_scheduler_admin.py
@@ -108,8 +108,15 @@ def _token(
     sub: str = "op-admin",
     role: TenantRole = TenantRole.TENANT_ADMIN,
     tenant_id: UUID = _TENANT_A,
+    platform_admin: bool = False,
 ) -> str:
-    return mint_token(key, sub=sub, tenant_role=role.value, tenant_id=str(tenant_id))
+    return mint_token(
+        key,
+        sub=sub,
+        tenant_role=role.value,
+        tenant_id=str(tenant_id),
+        platform_admin=platform_admin if platform_admin else None,
+    )
 
 
 @pytest.fixture
@@ -703,7 +710,62 @@ async def test_rest_operator_blocked_from_tenant_filter(client: TestClient) -> N
             params={"tenant_filter": str(_TENANT_B)},
         )
         assert rejected.status_code == 403
-        assert rejected.json()["detail"] == "tenant_filter_requires_tenant_admin"
+        assert rejected.json()["detail"] == "cross_tenant_requires_platform_admin"
+
+
+@pytest.mark.asyncio
+async def test_rest_tenant_admin_blocked_from_foreign_tenant_filter(
+    client: TestClient,
+) -> None:
+    """A tenant-admin of A passing tenant B's id is now 403 (the cross-tenant IDOR fix).
+
+    Pre-#1640 the route gated ``tenant_filter`` on ``tenant_admin`` *rank*
+    alone, so any tenant-admin could read another tenant's triggers. Only a
+    platform-admin may now cross the boundary.
+    """
+    await _seed_tenant(_TENANT_A, "tenant-a")
+    await _seed_tenant(_TENANT_B, "tenant-b")
+    admin_key = make_rsa_keypair("kid-admin-foreign")
+    with respx.mock as r:
+        mock_discovery_and_jwks(r, public_jwks(admin_key))
+        token = _token(
+            admin_key,
+            sub="a-admin",
+            role=TenantRole.TENANT_ADMIN,
+            tenant_id=_TENANT_A,
+        )
+        headers = {"Authorization": f"Bearer {token}"}
+        rejected = client.get(
+            "/api/v1/scheduler/triggers",
+            headers=headers,
+            params={"tenant_filter": str(_TENANT_B)},
+        )
+        assert rejected.status_code == 403
+        assert rejected.json()["detail"] == "cross_tenant_requires_platform_admin"
+
+
+@pytest.mark.asyncio
+async def test_rest_platform_admin_allowed_cross_tenant(client: TestClient) -> None:
+    """A platform-admin may list another tenant's triggers."""
+    await _seed_tenant(_TENANT_A, "tenant-a")
+    await _seed_tenant(_TENANT_B, "tenant-b")
+    pa_key = make_rsa_keypair("kid-platform-admin")
+    with respx.mock as r:
+        mock_discovery_and_jwks(r, public_jwks(pa_key))
+        token = _token(
+            pa_key,
+            sub="platform-op",
+            role=TenantRole.TENANT_ADMIN,
+            tenant_id=_TENANT_A,
+            platform_admin=True,
+        )
+        headers = {"Authorization": f"Bearer {token}"}
+        ok = client.get(
+            "/api/v1/scheduler/triggers",
+            headers=headers,
+            params={"tenant_filter": str(_TENANT_B)},
+        )
+        assert ok.status_code == 200, ok.text
 
 
 @pytest.mark.asyncio

--- a/cli/api/openapi.json
+++ b/cli/api/openapi.json
@@ -205,7 +205,7 @@
           "retrieval"
         ],
         "summary": "Usage Endpoint",
-        "description": "Return audit-backed retrieval usage aggregates for *operator*.\n\nTenant scoping: ``operator`` / ``read_only`` callers are scoped\nto ``operator.tenant_id``; passing a non-null ``tenant_filter``\nreturns 403. Only ``tenant_admin`` may cross tenants. *since*\naccepts ``<N>d`` / ``<N>h`` (relative) or an ISO-8601 date;\nmalformed \u2192 400. ``surface=all`` (default) covers all three;\n``surface=<one>`` narrows. Empty result is a structured zero\nreport, not 404. Audit overrides + enrichment contextvars are\nbound before :func:`compute_usage` runs so a handler exception\nstill produces an audit row with partial payload.",
+        "description": "Return audit-backed retrieval usage aggregates for *operator*.\n\nTenant scoping: callers are scoped to ``operator.tenant_id``; a\n``tenant_filter`` naming a different tenant returns 403\n``cross_tenant_requires_platform_admin`` unless the caller holds the\n``platform_admin`` cross-tenant capability (#1638). *since*\naccepts ``<N>d`` / ``<N>h`` (relative) or an ISO-8601 date;\nmalformed \u2192 400. ``surface=all`` (default) covers all three;\n``surface=<one>`` narrows. Empty result is a structured zero\nreport, not 404. Audit overrides + enrichment contextvars are\nbound before :func:`compute_usage` runs so a handler exception\nstill produces an audit row with partial payload.",
         "operationId": "usage_endpoint_api_v1_retrieve_usage_get",
         "parameters": [
           {
@@ -344,7 +344,7 @@
           "retrieval"
         ],
         "summary": "Retire Checklist Endpoint",
-        "description": "Return the five-criterion retire-decision checklist per surface.\n\nTenant scoping mirrors the sibling usage route:\n``operator`` / ``read_only`` callers are scoped to\n``operator.tenant_id``; passing a non-null ``tenant_filter`` query\nparameter returns 403. Only ``tenant_admin`` may cross tenants.\nThe request body's ``surface=all`` (default) walks every supported\nsurface in the order :data:`SURFACE_VERDICT_ORDER` pins.\n\nAudit overrides + enrichment contextvars are bound **before** the\ntenant-filter 403 path so the denied request still produces an\naudit row with the canonical ``op_id`` /\n``op_class`` / ``tenant_scope`` payload (the \"audit row per call\"\ncontract from the issue body holds on every status code). The\nsame overrides also protect the happy-path handler-exception case:\na partial payload is itself a useful incident-postmortem signal.\n``audit_row_count`` is bound after the service returns so the\nbroadcast event's ``row_count`` field reflects the number of\nsurfaces evaluated, not the underlying audit_log scan size.",
+        "description": "Return the five-criterion retire-decision checklist per surface.\n\nTenant scoping mirrors the sibling usage route:\nCallers are scoped to ``operator.tenant_id``; a ``tenant_filter``\nquery parameter naming a different tenant returns 403\n``cross_tenant_requires_platform_admin`` unless the caller holds the\n``platform_admin`` cross-tenant capability (#1638).\nThe request body's ``surface=all`` (default) walks every supported\nsurface in the order :data:`SURFACE_VERDICT_ORDER` pins.\n\nAudit overrides + enrichment contextvars are bound **before** the\ntenant-filter 403 path so the denied request still produces an\naudit row with the canonical ``op_id`` /\n``op_class`` / ``tenant_scope`` payload (the \"audit row per call\"\ncontract from the issue body holds on every status code). The\nsame overrides also protect the happy-path handler-exception case:\na partial payload is itself a useful incident-postmortem signal.\n``audit_row_count`` is bound after the service returns so the\nbroadcast event's ``row_count`` field reflects the number of\nsurfaces evaluated, not the underlying audit_log scan size.",
         "operationId": "retire_checklist_endpoint_api_v1_retrieve_retire_checklist_post",
         "parameters": [
           {
@@ -6214,7 +6214,7 @@
           "scheduler"
         ],
         "summary": "List Triggers",
-        "description": "List scheduled triggers for the operator's tenant, newest-first.\n\nTenant scoping: ``operator`` / ``read_only`` callers are scoped to\n``operator.tenant_id`` and any non-null ``tenant_filter`` returns\n403. Only ``tenant_admin`` may cross tenants.",
+        "description": "List scheduled triggers for the operator's tenant, newest-first.\n\nTenant scoping: callers are scoped to ``operator.tenant_id``; a\n``tenant_filter`` naming a *different* tenant returns 403\n``cross_tenant_requires_platform_admin`` unless the caller holds the\n``platform_admin`` cross-tenant capability. Passing one's own tenant\nid (or omitting the filter) is always allowed.",
         "operationId": "list_triggers_api_v1_scheduler_triggers_get",
         "parameters": [
           {


### PR DESCRIPTION
## Summary

- Closes a **cross-tenant IDOR**: the scheduler (`/api/v1/scheduler/triggers` list/create/cancel) and retrieval (`/api/v1/retrieve/usage`, `/retire-checklist`) routes authorized a caller-supplied `tenant_id`/`tenant_filter` on `tenant_admin` **rank** alone — so a tenant-admin of tenant A could read/act on tenant B.
- New shared `authorize_tenant_scope(operator, requested)` helper in `auth.rbac`: a different-tenant request is allowed only for a `platform_admin` (the cross-tenant capability from #1638), else 403 `cross_tenant_requires_platform_admin`. Same-tenant / omitted filter unchanged. All 5 sites route through it.
- **Behaviour change:** a plain `tenant_admin` can no longer cross tenants (now needs `platform_admin`); 403 detail token changes from `tenant_filter_requires_tenant_admin` → `cross_tenant_requires_platform_admin`.

## Test plan

- [x] `ruff check` / `format --check` — clean
- [x] `mypy` (src) — clean
- [x] `pytest` rbac + scheduler + retrieval (usage/retire) — 154 passed
- [x] Helper unit test — 4 branches incl. tenant-admin-denied + platform-admin-allowed (`test_auth_rbac.py`)
- [x] Route tests: tenant-admin→foreign = 403 (IDOR fix), platform-admin→foreign = 200 (scheduler); cross-tenant retrieval tests migrated to platform-admin tokens
- [x] code-quality `--diff` — 0 blockers
- [x] No OpenAPI surface change (route signatures unchanged; 403 detail not in schema)

## Out of scope

- Builds on #1638 (`platform_admin`). Sibling tasks: #1641 (MCP `list_targets`), #1642 (cred caches), #1643 (Vault paths).

<!-- auto-implement-issue: fresh, iteration 1 -->

Closes #1640