### PR TITLE
fix(mcp): gate list_targets cross-tenant args on platform-admin (close tenant enumeration hole)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -103,6 +103,14 @@ connector-related release-notes line.
   unchanged. The 403 detail token changes from
   `tenant_filter_requires_tenant_admin` to
   `cross_tenant_requires_platform_admin` (#1640).
+- Closed a cross-tenant enumeration hole on the MCP `list_targets` tool:
+  the caller-supplied `tenant_id` / `tenant` argument was resolved with
+  no equality check and gated on `tenant_admin` **rank** alone, so a
+  tenant-admin of tenant A could enumerate tenant B's targets. Cross-
+  tenant listing now requires the `platform_admin` capability (#1638);
+  naming one's own tenant (by slug or UUID) or omitting the argument is
+  unchanged, and an unauthorized cross-tenant request surfaces as the
+  MCP `-32602` (INVALID_PARAMS) error (#1641).
 
 ### Breaking changes
 

--- a/backend/src/meho_backplane/mcp/tools/topology.py
+++ b/backend/src/meho_backplane/mcp/tools/topology.py
@@ -1133,10 +1133,12 @@ _LIST_TARGETS_INPUT_SCHEMA: Final[dict[str, Any]] = {
             "type": ["string", "null"],
             "description": (
                 "Cross-tenant scope. Omit / null → the operator's own "
-                "tenant (the only choice for the `operator` role). A "
-                "tenant slug OR UUID selects another tenant's targets "
-                "and REQUIRES the `tenant_admin` role; an `operator`-"
-                "role caller passing this gets -32602. Canonical name "
+                "tenant. A tenant slug OR UUID naming a DIFFERENT tenant "
+                "selects that tenant's targets and REQUIRES the "
+                "`platform_admin` capability (#1641); a caller who is "
+                "not a platform-admin passing a foreign tenant gets "
+                "-32602 (naming your own tenant explicitly is always "
+                "allowed). Canonical name "
                 "(G0.18-T5 #1358); matches `tenant_id` on "
                 "`meho.connector.*` / `meho.scheduler.create`. "
                 "NOTE: `list_targets.tenant_id` accepts a slug OR a "
@@ -1190,7 +1192,7 @@ _LIST_TARGETS_DESCRIPTION: Final[str] = (
     "WHEN TO CALL: the operator asks 'what can I act on?', or you need a "
     "concrete target name and only have a product in mind ('list the "
     "vCenters' → `connector_id=vmware-rest-9.0`). Tenant scope is the "
-    "operator's own tenant unless a `tenant_admin` passes `tenant`.\n\n"
+    "operator's own tenant unless a `platform_admin` passes `tenant`.\n\n"
     "Returns `{targets: [{id, name, aliases, product, host}, ...], "
     "next_cursor: <name|null>}` ordered by name; `next_cursor` is the "
     "last name on the page when more rows may exist, else null."
@@ -1198,49 +1200,59 @@ _LIST_TARGETS_DESCRIPTION: Final[str] = (
 
 
 async def _resolve_tenant_scope(operator: Operator, tenant_arg: str | None) -> Any:
-    """Resolve the tenant id to scope the listing to.
+    """Resolve the tenant id to scope the listing to, authorizing a cross-tenant claim.
 
-    No ``tenant_id`` argument → the operator's own tenant (the only
-    path open to an ``operator``-role caller). A ``tenant_id``
-    argument is a cross-tenant request: it requires ``tenant_admin``
-    and is resolved by slug first then UUID. An unknown tenant, or a
-    non-admin passing ``tenant_id``, surfaces as ``-32602``
-    (operator-actionable input problem) rather than silently falling
-    back to the own-tenant scope — a silent fallback would make a
-    typo'd cross-tenant query look like an empty tenant.
+    No ``tenant_id`` argument → the operator's own tenant (the common,
+    same-tenant path open to any role). A ``tenant_id`` argument is
+    resolved by slug first then UUID; an unknown tenant surfaces as
+    ``-32602`` (operator-actionable input problem) rather than silently
+    falling back to the own-tenant scope — a silent fallback would make
+    a typo'd cross-tenant query look like an empty tenant.
+
+    Authorization mirrors the REST ``authorize_tenant_scope`` helper
+    (#1640): resolving to the operator's *own* tenant is always allowed
+    (a caller may name their own tenant explicitly by slug or UUID);
+    resolving to a *different* tenant is the cross-tenant case and is
+    permitted **only** for a ``platform_admin`` (#1638). A non-platform-
+    admin naming a foreign tenant is denied with ``-32602``.
+
+    The gate moved off ``tenant_admin`` *rank*: tenant role governs what
+    an operator may do *within* their tenant, while crossing the tenant
+    boundary is a separate, platform-level capability — gating cross-
+    tenant enumeration on ``tenant_admin`` alone let a tenant-admin of A
+    enumerate B's targets (a cross-tenant IDOR, #1641).
     """
     if tenant_arg is None:
         return operator.tenant_id
-    if operator.tenant_role != TenantRole.TENANT_ADMIN:
-        raise McpInvalidParamsError(
-            "list_targets: the `tenant_id` argument (cross-tenant scope) "
-            "requires the tenant_admin role",
-        )
     sessionmaker = get_sessionmaker()
     async with sessionmaker() as session:
         by_slug = await session.execute(
             select(Tenant.id).where(Tenant.slug == tenant_arg),
         )
-        tenant_id = by_slug.scalar_one_or_none()
-        if tenant_id is not None:
-            return tenant_id
-        # Slug miss — try the argument as a tenant UUID.
-        try:
-            from uuid import UUID
-
-            candidate = UUID(tenant_arg)
-        except ValueError:
-            candidate = None
-        if candidate is not None:
-            by_id = await session.execute(
-                select(Tenant.id).where(Tenant.id == candidate),
-            )
-            tenant_id = by_id.scalar_one_or_none()
-            if tenant_id is not None:
-                return tenant_id
-    raise McpInvalidParamsError(
-        f"list_targets: no tenant matches {tenant_arg!r} (tried slug then UUID)",
-    )
+        resolved = by_slug.scalar_one_or_none()
+        if resolved is None:
+            # Slug miss — try the argument as a tenant UUID.
+            try:
+                candidate = uuid.UUID(tenant_arg)
+            except ValueError:
+                candidate = None
+            if candidate is not None:
+                by_id = await session.execute(
+                    select(Tenant.id).where(Tenant.id == candidate),
+                )
+                resolved = by_id.scalar_one_or_none()
+    if resolved is None:
+        raise McpInvalidParamsError(
+            f"list_targets: no tenant matches {tenant_arg!r} (tried slug then UUID)",
+        )
+    if resolved == operator.tenant_id:
+        return resolved
+    if not operator.platform_admin:
+        raise McpInvalidParamsError(
+            "list_targets: the `tenant_id` argument (cross-tenant scope) "
+            "requires the platform_admin capability",
+        )
+    return resolved
 
 
 async def _list_targets_handler(

--- a/backend/tests/mcp_test_fixtures.py
+++ b/backend/tests/mcp_test_fixtures.py
@@ -106,8 +106,17 @@ async def seed_doc_collection(
 OPERATOR_TENANT_ID: UUID = UUID("00000000-0000-0000-0000-00000000a0a0")
 
 
-def build_operator(role: TenantRole = TenantRole.READ_ONLY) -> Operator:
-    """Build a fixture :class:`Operator` pinned to :data:`OPERATOR_TENANT_ID`."""
+def build_operator(
+    role: TenantRole = TenantRole.READ_ONLY,
+    *,
+    platform_admin: bool = False,
+) -> Operator:
+    """Build a fixture :class:`Operator` pinned to :data:`OPERATOR_TENANT_ID`.
+
+    ``platform_admin`` sets the cross-tenant capability primitive (#1638)
+    so tests can exercise the platform-admin-gated cross-tenant paths
+    (e.g. ``list_targets`` with a foreign ``tenant`` arg, #1641).
+    """
     return Operator(
         sub="op-test",
         name="Test",
@@ -115,6 +124,7 @@ def build_operator(role: TenantRole = TenantRole.READ_ONLY) -> Operator:
         raw_jwt="fixture-jwt-not-real",
         tenant_id=OPERATOR_TENANT_ID,
         tenant_role=role,
+        platform_admin=platform_admin,
     )
 
 
@@ -324,9 +334,18 @@ def client_with_operator(
     Operator role parameterisation: tests can request a non-default
     role via ``@pytest.mark.parametrize("client_with_operator", [TenantRole.X], indirect=True)``.
     Default is :class:`~meho_backplane.auth.operator.TenantRole.READ_ONLY`.
+
+    The param may also be a ``(role, platform_admin)`` tuple to set the
+    cross-tenant capability primitive (#1638) — e.g.
+    ``[(TenantRole.TENANT_ADMIN, True)]`` for a platform-admin operator
+    exercising the cross-tenant ``list_targets`` path (#1641).
     """
-    role: TenantRole = getattr(request, "param", TenantRole.READ_ONLY)
-    op = build_operator(role)
+    param = getattr(request, "param", TenantRole.READ_ONLY)
+    if isinstance(param, tuple):
+        role, platform_admin = param
+    else:
+        role, platform_admin = param, False
+    op = build_operator(role, platform_admin=platform_admin)
 
     async def _fake_verify() -> Operator:
         return op

--- a/backend/tests/test_mcp_tools_topology.py
+++ b/backend/tests/test_mcp_tools_topology.py
@@ -16,8 +16,9 @@ Two tools, exactly two — ``query_topology`` (parametric) and
 * ``tools/call query_topology {kind: dependents, target: <node>}``
   dispatches through the T4 service and returns the dependents list.
 * ``list_targets`` returns the operator's tenant's targets;
-  ``tenant_admin`` + ``tenant`` works cross-tenant; an ``operator``
-  passing ``tenant`` is rejected.
+  a ``platform_admin`` + ``tenant`` works cross-tenant (#1641); a
+  non-platform-admin (any rank, incl. ``tenant_admin``) passing a
+  foreign ``tenant`` is rejected — naming one's own tenant is allowed.
 * Tool descriptions name the blast-radius use-case verbatim ("call
   this *before* recommending a destructive op").
 * Tenant scope comes from the operator JWT, never the arguments dict.
@@ -699,21 +700,44 @@ async def test_list_targets_connector_id_filters_by_product(
 async def test_list_targets_operator_cannot_cross_tenant(
     client_with_operator: tuple[TestClient, Operator],  # noqa: F811
 ) -> None:
-    """An operator passing `tenant` is rejected (-32602), not silently scoped."""
+    """A non-platform-admin operator naming a foreign tenant is rejected (-32602)."""
     client, _op = client_with_operator
     await _seed_tenant(OPERATOR_TENANT_ID, "op-tenant")
+    await _seed_tenant(_OTHER_TENANT_ID, "other-tenant")
+    await _seed_target(_OTHER_TENANT_ID, "other-vc", "vmware", "ovc.example")
 
     response = _list_targets_call(client, 22, {"tenant": "other-tenant"})
     body = response.json()
     assert body["error"]["code"] == INVALID_PARAMS
-    assert "tenant_admin" in body["error"]["message"]
+    assert "platform_admin" in body["error"]["message"]
 
 
 @pytest.mark.parametrize("client_with_operator", [TenantRole.TENANT_ADMIN], indirect=True)
-async def test_list_targets_tenant_admin_cross_tenant_by_slug(
+async def test_list_targets_tenant_admin_cannot_cross_tenant(
     client_with_operator: tuple[TestClient, Operator],  # noqa: F811
 ) -> None:
-    """tenant_admin + `tenant` slug lists the other tenant's targets."""
+    """A `tenant_admin` (not platform-admin) naming a foreign tenant is denied (#1641).
+
+    Cross-tenant enumeration moved off `tenant_admin` rank onto the
+    `platform_admin` capability — a tenant-admin of A must not be able
+    to enumerate B's targets (the cross-tenant IDOR this task closes).
+    """
+    client, _op = client_with_operator
+    await _seed_tenant(OPERATOR_TENANT_ID, "op-tenant")
+    await _seed_tenant(_OTHER_TENANT_ID, "other-tenant")
+    await _seed_target(_OTHER_TENANT_ID, "other-vc", "vmware", "ovc.example")
+
+    response = _list_targets_call(client, 23, {"tenant": "other-tenant"})
+    body = response.json()
+    assert body["error"]["code"] == INVALID_PARAMS
+    assert "platform_admin" in body["error"]["message"]
+
+
+@pytest.mark.parametrize("client_with_operator", [(TenantRole.TENANT_ADMIN, True)], indirect=True)
+async def test_list_targets_platform_admin_cross_tenant_by_slug(
+    client_with_operator: tuple[TestClient, Operator],  # noqa: F811
+) -> None:
+    """A `platform_admin` + `tenant` slug lists the other tenant's targets (#1641)."""
     client, _op = client_with_operator
     await _seed_tenant(OPERATOR_TENANT_ID, "op-tenant")
     await _seed_tenant(_OTHER_TENANT_ID, "other-tenant")
@@ -722,6 +746,22 @@ async def test_list_targets_tenant_admin_cross_tenant_by_slug(
     response = _list_targets_call(client, 23, {"tenant": "other-tenant"})
     payload = json.loads(response.json()["result"]["content"][0]["text"])
     assert [t["name"] for t in payload["targets"]] == ["other-vc"]
+
+
+@pytest.mark.parametrize("client_with_operator", [TenantRole.OPERATOR], indirect=True)
+async def test_list_targets_own_tenant_slug_is_allowed(
+    client_with_operator: tuple[TestClient, Operator],  # noqa: F811
+) -> None:
+    """Naming one's OWN tenant explicitly (slug) is allowed for any role (#1641)."""
+    client, _op = client_with_operator
+    await _seed_tenant(OPERATOR_TENANT_ID, "op-tenant")
+    await _seed_target(OPERATOR_TENANT_ID, "rdc-vcenter", "vmware", "vc.example")
+
+    response = _list_targets_call(client, 25, {"tenant": "op-tenant"})
+    body = response.json()
+    assert "error" not in body, body
+    payload = json.loads(body["result"]["content"][0]["text"])
+    assert [t["name"] for t in payload["targets"]] == ["rdc-vcenter"]
 
 
 @pytest.mark.parametrize("client_with_operator", [TenantRole.TENANT_ADMIN], indirect=True)


### PR DESCRIPTION
## Summary

The MCP `list_targets` tool resolved its caller-supplied `tenant_id` / `tenant` argument (slug or UUID) against the global tenant table with **no equality check** against the operator's own tenant, gating only on `tenant_admin` **rank** — so a tenant-admin of tenant A could enumerate tenant B's targets (a cross-tenant enumeration / IDOR hole). This is the MCP-side sibling of the REST fix in #1644 (helper #1640).

`_resolve_tenant_scope` now mirrors the REST `authorize_tenant_scope` helper logic (#1640):

- omit / `null` → the operator's own tenant (unchanged);
- resolve the argument to a tenant id, then **allow the operator's own tenant unconditionally** (a caller may name their own tenant explicitly by slug or UUID);
- a **different** tenant is permitted **only** for a `platform_admin` (#1638); a non-platform-admin naming a foreign tenant is denied;
- an unknown tenant still surfaces as `-32602` (no silent own-tenant fallback).

### MCP error model

MCP tools use the structured JSON-RPC error model, not the REST `HTTPException`. The 403-raising REST helper `authorize_tenant_scope` therefore could **not** be reused directly inside the MCP path; the gate replicates its logic and raises `McpInvalidParamsError` (mapped to JSON-RPC `-32602` / `INVALID_PARAMS`), consistent with the other validation/authz raises already in this tool.

### Docs

The `tenant_id` input-schema description and the tool description now state the platform-admin gate (was `tenant_admin`).

## Test plan

Migrated the prior `tenant_admin`-can-cross assertions onto the platform-admin gate and added coverage:

- `test_list_targets_operator_cannot_cross_tenant` — non-platform-admin operator naming a foreign tenant → `-32602`, message names `platform_admin`.
- `test_list_targets_tenant_admin_cannot_cross_tenant` (**new**) — a `tenant_admin` (not platform-admin) naming a foreign tenant is now **denied** (the IDOR this closes).
- `test_list_targets_platform_admin_cross_tenant_by_slug` (**new**) — a `platform_admin` + `tenant` slug lists the other tenant's targets.
- `test_list_targets_own_tenant_slug_is_allowed` (**new**) — naming one's OWN tenant explicitly by slug is allowed for any role.

Shared fixtures (`build_operator` / `client_with_operator`) grow a `platform_admin` knob to mint the capability.

Verification (in the worktree, `backend/`):

- `ruff check` + `ruff format --check`: pass
- `mypy src/meho_backplane/mcp/ --ignore-missing-imports`: pass (40 files)
- `pytest tests/test_mcp_tools_topology.py tests/test_mcp_tools_list_shape_conventions.py`: 74 passed
- broader MCP sweep (`-k "mcp_tools or mcp_resources or mcp_server"`): 378 passed, 1 skipped
- code-quality `--diff`: 0 blockers (pre-existing function-size warnings only)
- no `backend/src/meho_backplane/api/` change → no OpenAPI snapshot regen

Closes #1641

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Fixed cross-tenant enumeration vulnerability in target listing. Cross-tenant enumeration now requires platform administrator privileges; unauthorized requests return an error.

* **Documentation**
  * Updated changelog to document cross-tenant access control improvements.

* **Tests**
  * Updated authorization tests to reflect revised cross-tenant access controls.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->