### PR TITLE
fix(vault): tenant-scope guard on agent-supplied KV mount/path (defense-in-depth)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -103,6 +103,18 @@ connector-related release-notes line.
   unchanged. The 403 detail token changes from
   `tenant_filter_requires_tenant_admin` to
   `cross_tenant_requires_platform_admin` (#1640).
+- Added a defense-in-depth tenant-scope guard on the agent-supplied
+  `vault.kv.*` ops (`read` / `list` / `versions` / `put` / `patch` /
+  `delete`): the requested `mount`/`path` is now checked against the
+  operator's tenant namespace **before** the hvac call, so a tenant-A
+  caller reaching for a tenant-B path is denied with a structured
+  `connector_error` (`exception_class=VaultTenantScopeError`) even if the
+  shared Vault `meho-mcp` policy is mis-provisioned too broadly. The guard
+  is **opt-in** via `VAULT_KV_TENANT_SCOPE_PREFIX` (a `{tenant_id}`
+  format template, e.g. `tenant-{tenant_id}/`); empty (the default) leaves
+  behaviour unchanged because the shipped Vault layout scopes per operator
+  `sub`, not per tenant. The convention is documented in
+  `docs/codebase/connectors-vault-tenant-scope.md` (#1643).
 
 ### Breaking changes
 

--- a/backend/src/meho_backplane/connectors/vault/ops.py
+++ b/backend/src/meho_backplane/connectors/vault/ops.py
@@ -72,6 +72,7 @@ import meho_backplane.auth.vault as _auth_vault
 from meho_backplane.auth.operator import Operator
 from meho_backplane.connectors.vault.ops_auth import register_vault_auth_operations
 from meho_backplane.connectors.vault.ops_auth_write import register_vault_auth_write_operations
+from meho_backplane.connectors.vault.tenant_scope import enforce_tenant_scope
 from meho_backplane.operations.typed_register import register_typed_operation
 from meho_backplane.retrieval.embedding import EmbeddingService
 
@@ -294,6 +295,12 @@ async def vault_kv_read(operator: Operator, target: Any, params: dict[str, Any])
     mount: str = str(params.get("mount", _DEFAULT_KV_MOUNT)).strip()
     path: str = str(params["path"]).strip()
 
+    # Defense-in-depth tenant-scope check (#1643): deny a path outside the
+    # operator's tenant namespace BEFORE the hvac call. No-op unless
+    # ``vault_kv_tenant_scope_prefix`` is configured. Behind the Vault
+    # ``meho-mcp`` ACL policy, never a replacement for it.
+    enforce_tenant_scope(operator, mount=mount, path=path)
+
     # vault_client_for_operator is accessed via the module reference so
     # test monkeypatches on vault_module._build_client propagate through
     # the call chain. It reads operator.raw_jwt for the JWT/OIDC login.
@@ -390,6 +397,9 @@ async def vault_kv_list(operator: Operator, target: Any, params: dict[str, Any])
     """
     mount: str = str(params.get("mount", _DEFAULT_KV_MOUNT)).strip()
     path: str = str(params["path"]).strip()
+
+    # Tenant-scope guard (#1643) — see vault_kv_read.
+    enforce_tenant_scope(operator, mount=mount, path=path)
 
     async with _auth_vault.vault_client_for_operator(operator) as client:
         list_payload = await asyncio.to_thread(
@@ -494,6 +504,9 @@ async def vault_kv_put(operator: Operator, target: Any, params: dict[str, Any]) 
     path: str = str(params["path"]).strip()
     secret: dict[str, Any] = params["data"]
     cas = params.get("cas")
+
+    # Tenant-scope guard (#1643) — see vault_kv_read.
+    enforce_tenant_scope(operator, mount=mount, path=path)
 
     async with _auth_vault.vault_client_for_operator(operator) as client:
         write_payload = await asyncio.to_thread(
@@ -655,6 +668,9 @@ async def vault_kv_patch(operator: Operator, target: Any, params: dict[str, Any]
     path: str = str(params["path"]).strip()
     secret: dict[str, Any] = params["data"]
 
+    # Tenant-scope guard (#1643) — see vault_kv_read.
+    enforce_tenant_scope(operator, mount=mount, path=path)
+
     async with _auth_vault.vault_client_for_operator(operator) as client:
         patch_payload = await asyncio.to_thread(
             client.secrets.kv.v2.patch,
@@ -728,6 +744,9 @@ async def vault_kv_versions(
     """
     mount: str = str(params.get("mount", _DEFAULT_KV_MOUNT)).strip()
     path: str = str(params["path"]).strip()
+
+    # Tenant-scope guard (#1643) — see vault_kv_read.
+    enforce_tenant_scope(operator, mount=mount, path=path)
 
     async with _auth_vault.vault_client_for_operator(operator) as client:
         meta_payload = await asyncio.to_thread(
@@ -820,6 +839,9 @@ async def vault_kv_delete(
     mount: str = str(params.get("mount", _DEFAULT_KV_MOUNT)).strip()
     path: str = str(params["path"]).strip()
     versions: list[int] = list(params["versions"])
+
+    # Tenant-scope guard (#1643) — see vault_kv_read.
+    enforce_tenant_scope(operator, mount=mount, path=path)
 
     async with _auth_vault.vault_client_for_operator(operator) as client:
         await asyncio.to_thread(

--- a/backend/src/meho_backplane/connectors/vault/tenant_scope.py
+++ b/backend/src/meho_backplane/connectors/vault/tenant_scope.py
@@ -1,0 +1,157 @@
+# SPDX-License-Identifier: Apache-2.0
+# Copyright (c) 2026 evoila Group
+
+"""Application-layer tenant-scope guard for the agent-supplied ``vault.kv.*`` ops.
+
+#1643 (cross-tenant isolation hardening, Goal #221). The KV-v2 handlers in
+:mod:`meho_backplane.connectors.vault.ops` forward the agent-supplied
+``mount`` / ``path`` to hvac **verbatim**. The intended access boundary is
+the Vault ``meho-mcp`` role's ACL policy (per-operator templating,
+``docs/cross-repo/connector-vault-policy.md`` §2). If that policy is
+mis-provisioned *too broadly* — e.g. the templated identity segment is
+dropped, or a wildcard leaks into the rendered output — a tenant-A caller
+could read ``tenant-b/...`` secrets. This module adds a **defense-in-depth**
+check *in front of* the hvac call so a broken Vault policy is not the only
+thing standing between two tenants.
+
+It is deliberately *additive*: the Vault policy stays the primary gate
+(this guard never grants access the policy denies — it only ever denies
+earlier). See ``docs/codebase/connectors-vault-tenant-scope.md`` for the
+namespace convention, the rationale, and the failure mode.
+
+Opt-in by design
+----------------
+The shipped deploy convention scopes secrets per operator ``sub``
+(``secret/data/targets/<sub>/*``), **not** per tenant, so there is no
+universal ``tenant-<id>/`` layout to enforce against out of the box.
+Enforcing a hard tenant prefix unconditionally would deny every existing
+call. The guard is therefore controlled by
+:attr:`~meho_backplane.settings.Settings.vault_kv_tenant_scope_prefix`:
+
+* **empty (default)** → :func:`enforce_tenant_scope` is a no-op; behaviour
+  is byte-for-byte what it was before #1643.
+* **a ``str.format`` template** with a single ``{tenant_id}`` placeholder
+  (e.g. ``"tenant-{tenant_id}/"``) → the requested logical path must begin
+  with the rendered prefix, or :class:`VaultTenantScopeError` is raised
+  before any Vault round-trip.
+
+The system/shim operator (Nil-UUID tenant, empty ``raw_jwt``) is exempt:
+its only callers exercise the unauthenticated ``vault.sys.health`` op and
+forward no token to Vault, so there is no tenant identity to bind against.
+"""
+
+from __future__ import annotations
+
+from uuid import UUID
+
+from meho_backplane.auth.operator import Operator
+from meho_backplane.settings import get_settings
+
+__all__ = ["VaultTenantScopeError", "enforce_tenant_scope", "rendered_tenant_prefix"]
+
+#: The Nil UUID the vault-connector shim synthesises as the system
+#: operator's ``tenant_id`` (mirrors
+#: :data:`meho_backplane.connectors.vault.connector._SYSTEM_TENANT_ID`).
+#: A caller carrying this tenant has no real tenant identity, so the guard
+#: is skipped for it. Duplicated here rather than imported to avoid a
+#: connector ↔ ops import cycle; a regression test pins the two equal.
+_SYSTEM_TENANT_ID: UUID = UUID(int=0)
+
+
+class VaultTenantScopeError(Exception):
+    """A ``vault.kv.*`` call requested a path outside the operator's tenant namespace.
+
+    Raised by :func:`enforce_tenant_scope` **before** the hvac call when
+    :attr:`~meho_backplane.settings.Settings.vault_kv_tenant_scope_prefix`
+    is configured and the requested logical path does not begin with the
+    operator's rendered tenant prefix. The dispatcher's ``connector_error``
+    branch wraps the raised exception into a structured
+    :class:`~meho_backplane.connectors.schemas.OperationResult` with
+    ``extras["exception_class"] == "VaultTenantScopeError"`` — distinct
+    from the ``VaultClientError`` family (login-phase) and from generic
+    read-phase errors, so a caller can tell a *local policy denial* apart
+    from a Vault-side 403.
+
+    The message names the rendered prefix but **never** echoes secret
+    material — only the (non-secret) mount/path the caller already supplied.
+    """
+
+
+def rendered_tenant_prefix(operator: Operator, *, template: str) -> str:
+    """Render the per-tenant logical-path prefix for *operator*.
+
+    *template* is a ``str.format`` string carrying a single ``{tenant_id}``
+    placeholder (validated non-empty by the caller). The operator's
+    ``tenant_id`` UUID is rendered in its canonical dashed lowercase form
+    (``str(UUID)``), matching how tenant UUIDs appear everywhere else in
+    the codebase (audit rows, JWT claims).
+    """
+    return template.format(tenant_id=operator.tenant_id)
+
+
+def _normalised_logical_path(mount: str, path: str) -> str:
+    """Build the ``<mount>/<path>`` string the guard matches the prefix against.
+
+    The KV handlers split the address into hvac's ``(mount_point, path)``
+    pair; we recombine them into one logical string so a tenant prefix can
+    constrain either the mount segment or the path segment (a deploy may
+    partition tenants by mount *or* by a path prefix). Leading/trailing
+    slashes are normalised away so ``"tenant-x/"`` matches ``"tenant-x/a"``
+    regardless of stray slashes the caller typed.
+    """
+    clean_mount = mount.strip().strip("/")
+    clean_path = path.strip().strip("/")
+    return f"{clean_mount}/{clean_path}"
+
+
+def enforce_tenant_scope(operator: Operator, *, mount: str, path: str) -> None:
+    """Deny a ``vault.kv.*`` call whose path escapes the operator's tenant namespace.
+
+    No-op when
+    :attr:`~meho_backplane.settings.Settings.vault_kv_tenant_scope_prefix`
+    is empty (the default) or when *operator* is the Nil-tenant system
+    shim. Otherwise renders the operator's tenant prefix from the template
+    and raises :class:`VaultTenantScopeError` unless the normalised
+    ``<mount>/<path>`` begins with it.
+
+    Parameters
+    ----------
+    operator
+        The request-scoped operator. ``operator.tenant_id`` supplies the
+        binding identity; it is already populated on every authenticated
+        handler call (the dispatcher threads the real
+        :class:`~meho_backplane.auth.operator.Operator`).
+    mount, path
+        The mount handle and logical path the handler is about to forward
+        to hvac, already ``.strip()``-ed by the handler.
+
+    Raises
+    ------
+    VaultTenantScopeError
+        The requested path falls outside the operator's tenant prefix.
+    """
+    template = get_settings().vault_kv_tenant_scope_prefix.strip()
+    if not template:
+        # Guard disabled — preserve pre-#1643 behaviour exactly.
+        return
+    if operator.tenant_id == _SYSTEM_TENANT_ID:
+        # System/shim operator: no real tenant to bind against; its only
+        # callers run the unauthenticated sys.health op.
+        return
+
+    prefix = rendered_tenant_prefix(operator, template=template)
+    normalised_prefix = prefix.strip().strip("/")
+    candidate = _normalised_logical_path(mount, path)
+
+    # Match on a path-segment boundary so a "tenant-1" prefix cannot be
+    # satisfied by a "tenant-12/..." path. The candidate is normalised to
+    # "<mount>/<path>"; an in-namespace request is the prefix itself or the
+    # prefix followed by "/".
+    if candidate == normalised_prefix or candidate.startswith(normalised_prefix + "/"):
+        return
+
+    raise VaultTenantScopeError(
+        "vault.kv request outside tenant namespace: "
+        f"requested {candidate!r} is not within tenant prefix "
+        f"{normalised_prefix!r} (tenant_id={operator.tenant_id})"
+    )

--- a/backend/src/meho_backplane/settings.py
+++ b/backend/src/meho_backplane/settings.py
@@ -1084,6 +1084,22 @@ class Settings(BaseModel):
     #: ``True`` — fail-closed scope discipline. Consumed by T3, not by the
     #: transport in this Task.
     corpus_require_filters: bool = True
+    #: Application-layer tenant-scope guard for the agent-supplied
+    #: ``vault.kv.*`` ops (#1643). A Python ``str.format`` template with a
+    #: single ``{tenant_id}`` placeholder rendering the logical-path prefix
+    #: an operator's KV calls must stay within — defense-in-depth *behind*
+    #: the Vault ``meho-mcp`` policy, not a replacement for it
+    #: (``docs/codebase/connectors-vault-tenant-scope.md``). When a caller
+    #: requests a ``path`` outside their rendered prefix the handler raises
+    #: :class:`~meho_backplane.connectors.vault.tenant_scope.VaultTenantScopeError`
+    #: *before* the hvac call. **Empty (the default) disables the guard** —
+    #: the shipped deploy convention scopes per operator ``sub``
+    #: (``secret/data/targets/<sub>/*``, ``connector-vault-policy.md`` §2),
+    #: not per tenant, so enforcing a hard tenant prefix unconditionally
+    #: would break every existing call; a deploy whose KV layout *is*
+    #: tenant-partitioned opts in by setting e.g. ``"tenant-{tenant_id}/"``.
+    #: Set via ``VAULT_KV_TENANT_SCOPE_PREFIX``.
+    vault_kv_tenant_scope_prefix: str = ""
 
     @field_validator("broadcast_redis_url")
     @classmethod
@@ -1436,4 +1452,5 @@ def get_settings() -> Settings:
         corpus_require_filters=parse_bool_env(
             os.environ.get("CORPUS_REQUIRE_FILTERS", "true"),
         ),
+        vault_kv_tenant_scope_prefix=os.environ.get("VAULT_KV_TENANT_SCOPE_PREFIX", "").strip(),
     )

--- a/backend/tests/test_connectors_vault_tenant_scope.py
+++ b/backend/tests/test_connectors_vault_tenant_scope.py
@@ -1,0 +1,286 @@
+# SPDX-License-Identifier: Apache-2.0
+# Copyright (c) 2026 evoila Group
+
+"""Tenant-scope guard for the agent-supplied ``vault.kv.*`` ops (#1643).
+
+Defense-in-depth: a caller requesting a path outside their tenant
+namespace is denied **before** the hvac call. These tests cover the
+:func:`~meho_backplane.connectors.vault.tenant_scope.enforce_tenant_scope`
+helper directly (boundary cases) and every KV-v2 handler end-to-end
+through the real dispatcher (the AC: all handlers deny out-of-namespace
+requests; in-namespace requests are unchanged).
+"""
+
+from __future__ import annotations
+
+from collections.abc import Iterator
+from typing import Any
+from unittest.mock import AsyncMock
+from uuid import UUID
+
+import pytest
+
+from meho_backplane.auth.operator import Operator, TenantRole
+from meho_backplane.connectors.registry import (
+    clear_registry,
+    register_connector_v2,
+)
+from meho_backplane.connectors.schemas import OperationResult
+from meho_backplane.connectors.vault import VaultConnector
+from meho_backplane.connectors.vault.connector import _SYSTEM_TENANT_ID
+from meho_backplane.connectors.vault.ops import register_vault_typed_operations
+from meho_backplane.connectors.vault.tenant_scope import (
+    VaultTenantScopeError,
+    enforce_tenant_scope,
+    rendered_tenant_prefix,
+)
+from meho_backplane.operations import dispatch, reset_dispatcher_caches
+from meho_backplane.settings import get_settings
+
+from ._vault_fakes import install_fake_client
+
+# A concrete, non-system tenant so the guard does not short-circuit on the
+# Nil-UUID system-operator exemption.
+_TENANT_A = UUID("11111111-1111-1111-1111-111111111111")
+_TENANT_B = UUID("22222222-2222-2222-2222-222222222222")
+
+# The opt-in convention these tests enforce: each tenant's KV calls must
+# live under ``tenant-<tenant_id>/`` on the (default) ``secret`` mount.
+_SCOPE_TEMPLATE = "secret/tenant-{tenant_id}/"
+
+
+# ---------------------------------------------------------------------------
+# Fixtures — register the vault connector + typed ops, pin env
+# ---------------------------------------------------------------------------
+
+
+@pytest.fixture(autouse=True)
+def _registered_connector() -> Iterator[None]:
+    clear_registry()
+    register_connector_v2(
+        product="vault",
+        version="1.x",
+        impl_id="vault",
+        cls=VaultConnector,
+    )
+    reset_dispatcher_caches()
+    yield
+    reset_dispatcher_caches()
+    clear_registry()
+
+
+@pytest.fixture(autouse=True)
+def _settings_env(monkeypatch: pytest.MonkeyPatch) -> Iterator[None]:
+    monkeypatch.setenv("KEYCLOAK_ISSUER_URL", "https://keycloak.test/realms/meho")
+    monkeypatch.setenv("KEYCLOAK_AUDIENCE", "meho-backplane")
+    monkeypatch.setenv("VAULT_ADDR", "https://vault.test")
+    monkeypatch.setenv("VAULT_OIDC_ROLE", "meho-mcp")
+    monkeypatch.setenv("VAULT_OIDC_MOUNT_PATH", "jwt")
+    monkeypatch.setenv("VAULT_TIMEOUT_SECONDS", "5.0")
+    monkeypatch.delenv("VAULT_NAMESPACE", raising=False)
+    # Guard enabled for this suite — the per-tenant prefix convention.
+    monkeypatch.setenv("VAULT_KV_TENANT_SCOPE_PREFIX", _SCOPE_TEMPLATE)
+    get_settings.cache_clear()
+    yield
+    get_settings.cache_clear()
+
+
+@pytest.fixture
+def stub_embedding_service() -> AsyncMock:
+    service = AsyncMock()
+    service.encode_one.return_value = [0.1] * 384
+    service.encode.return_value = [[0.1] * 384]
+    service.dimension = 384
+    return service
+
+
+@pytest.fixture
+async def _registered_vault_typed_ops(
+    stub_embedding_service: AsyncMock,
+) -> None:
+    await register_vault_typed_operations(embedding_service=stub_embedding_service)
+
+
+def _operator(tenant_id: UUID, *, jwt: str = "fake.jwt.value") -> Operator:
+    return Operator(
+        sub="test-operator",
+        name=None,
+        email=None,
+        raw_jwt=jwt,
+        tenant_id=tenant_id,
+        tenant_role=TenantRole.OPERATOR,
+    )
+
+
+async def _dispatch(
+    op_id: str,
+    params: dict[str, Any],
+    *,
+    tenant_id: UUID,
+) -> OperationResult:
+    return await dispatch(
+        operator=_operator(tenant_id),
+        connector_id="vault-1.x",
+        op_id=op_id,
+        target=None,
+        params=params,
+        _approved=True,
+    )
+
+
+# ---------------------------------------------------------------------------
+# Unit — enforce_tenant_scope boundary behaviour
+# ---------------------------------------------------------------------------
+
+
+def test_rendered_prefix_uses_canonical_uuid() -> None:
+    op = _operator(_TENANT_A)
+    assert rendered_tenant_prefix(op, template=_SCOPE_TEMPLATE) == f"secret/tenant-{_TENANT_A}/"
+
+
+def test_in_namespace_path_passes() -> None:
+    """A path under the operator's rendered prefix is allowed (no raise)."""
+    op = _operator(_TENANT_A)
+    # mount "secret", path "tenant-<A>/db/creds" → "secret/tenant-<A>/db/creds"
+    enforce_tenant_scope(op, mount="secret", path=f"tenant-{_TENANT_A}/db/creds")
+
+
+def test_out_of_namespace_path_is_denied() -> None:
+    op = _operator(_TENANT_A)
+    with pytest.raises(VaultTenantScopeError) as exc:
+        enforce_tenant_scope(op, mount="secret", path=f"tenant-{_TENANT_B}/db/creds")
+    # The message names the offending path + tenant, never a secret value.
+    assert f"tenant-{_TENANT_B}/db/creds" in str(exc.value)
+    assert str(_TENANT_A) in str(exc.value)
+
+
+def test_sibling_prefix_does_not_satisfy_the_guard() -> None:
+    """A look-alike tenant segment (no path-boundary) must not pass.
+
+    ``secret/tenant-<A>extra/...`` shares a leading string with the
+    prefix but is a different namespace — the segment-boundary match
+    rejects it.
+    """
+    op = _operator(_TENANT_A)
+    with pytest.raises(VaultTenantScopeError):
+        enforce_tenant_scope(op, mount="secret", path=f"tenant-{_TENANT_A}extra/x")
+
+
+def test_cross_mount_request_is_denied() -> None:
+    """The prefix pins the mount segment too — a different mount is denied."""
+    op = _operator(_TENANT_A)
+    with pytest.raises(VaultTenantScopeError):
+        enforce_tenant_scope(op, mount="other", path=f"tenant-{_TENANT_A}/db")
+
+
+def test_empty_template_disables_the_guard(monkeypatch: pytest.MonkeyPatch) -> None:
+    """The default (empty prefix) is a no-op — pre-#1643 behaviour."""
+    monkeypatch.setenv("VAULT_KV_TENANT_SCOPE_PREFIX", "")
+    get_settings.cache_clear()
+    op = _operator(_TENANT_A)
+    # Any path, including a cross-tenant one, is allowed when disabled.
+    enforce_tenant_scope(op, mount="secret", path=f"tenant-{_TENANT_B}/db")
+
+
+def test_system_tenant_is_exempt() -> None:
+    """The Nil-UUID system/shim operator bypasses the guard."""
+    op = _operator(_SYSTEM_TENANT_ID)
+    enforce_tenant_scope(op, mount="secret", path="anything/at/all")
+
+
+def test_system_tenant_constant_matches_connector() -> None:
+    """The duplicated Nil-UUID sentinel stays equal to the connector's."""
+    assert UUID(int=0) == _SYSTEM_TENANT_ID
+
+
+# ---------------------------------------------------------------------------
+# Dispatch-level — every KV-v2 handler denies an out-of-namespace request
+# ---------------------------------------------------------------------------
+
+#: (op_id, params) for a request that targets tenant B's namespace. The
+#: acting operator (tenant A) must be denied on every one. Each carries the
+#: schema-required params for its op so the request reaches the handler
+#: guard rather than failing param validation first.
+_OUT_OF_NAMESPACE_CALLS: list[tuple[str, dict[str, Any]]] = [
+    ("vault.kv.read", {"path": f"tenant-{_TENANT_B}/db/creds"}),
+    ("vault.kv.list", {"path": f"tenant-{_TENANT_B}/db"}),
+    ("vault.kv.versions", {"path": f"tenant-{_TENANT_B}/db/creds"}),
+    ("vault.kv.put", {"path": f"tenant-{_TENANT_B}/db/creds", "data": {"k": "v"}}),
+    ("vault.kv.patch", {"path": f"tenant-{_TENANT_B}/db/creds", "data": {"k": "v"}}),
+    (
+        "vault.kv.delete",
+        {"path": f"tenant-{_TENANT_B}/db/creds", "versions": [1]},
+    ),
+]
+
+
+@pytest.mark.parametrize(
+    "op_id,params",
+    _OUT_OF_NAMESPACE_CALLS,
+    ids=[c[0] for c in _OUT_OF_NAMESPACE_CALLS],
+)
+async def test_handler_denies_cross_tenant_path(
+    monkeypatch: pytest.MonkeyPatch,
+    op_id: str,
+    params: dict[str, Any],
+    _registered_vault_typed_ops: None,
+) -> None:
+    """Tenant A requesting tenant B's path is denied on every KV-v2 handler.
+
+    The guard raises :class:`VaultTenantScopeError` before the hvac call;
+    the dispatcher wraps it into a structured ``connector_error`` whose
+    ``extras.exception_class`` names the guard, distinct from a Vault-side
+    403 (``VaultRoleDeniedError``) or a read-phase error.
+    """
+    fake = install_fake_client(monkeypatch, secret={"k": "v"})
+    result = await _dispatch(op_id, params, tenant_id=_TENANT_A)
+
+    assert result.status == "error"
+    assert result.extras.get("error_code") == "connector_error"
+    assert result.extras.get("exception_class") == "VaultTenantScopeError"
+    # Defense-in-depth means *no* Vault round-trip happened: the guard
+    # short-circuits before login.
+    assert fake.auth.jwt.login_calls == []
+
+
+@pytest.mark.parametrize(
+    "op_id,params",
+    [
+        ("vault.kv.read", {"path": f"tenant-{_TENANT_A}/db/creds"}),
+        ("vault.kv.list", {"path": f"tenant-{_TENANT_A}/db"}),
+        ("vault.kv.versions", {"path": f"tenant-{_TENANT_A}/db/creds"}),
+        (
+            "vault.kv.put",
+            {"path": f"tenant-{_TENANT_A}/db/creds", "data": {"k": "v"}},
+        ),
+        (
+            "vault.kv.patch",
+            {"path": f"tenant-{_TENANT_A}/db/creds", "data": {"k": "v"}},
+        ),
+        (
+            "vault.kv.delete",
+            {"path": f"tenant-{_TENANT_A}/db/creds", "versions": [1]},
+        ),
+    ],
+    ids=[
+        "read",
+        "list",
+        "versions",
+        "put",
+        "patch",
+        "delete",
+    ],
+)
+async def test_handler_allows_in_namespace_path(
+    monkeypatch: pytest.MonkeyPatch,
+    op_id: str,
+    params: dict[str, Any],
+    _registered_vault_typed_ops: None,
+) -> None:
+    """An in-namespace request is unchanged — it reaches Vault and succeeds."""
+    fake = install_fake_client(monkeypatch, secret={"k": "v"}, kv_version=3)
+    result = await _dispatch(op_id, params, tenant_id=_TENANT_A)
+
+    assert result.status == "ok", result.error
+    # The guard did not short-circuit: the handler logged in to Vault.
+    assert fake.auth.jwt.login_calls != []

--- a/docs/codebase/connectors-vault-tenant-scope.md
+++ b/docs/codebase/connectors-vault-tenant-scope.md
@@ -1,0 +1,111 @@
+<!--
+SPDX-License-Identifier: Apache-2.0
+Copyright (c) 2026 evoila Group
+-->
+
+# Vault KV tenant-scope guard (defense-in-depth)
+
+> Application-layer tenant binding on the agent-supplied `vault.kv.*`
+> mount/path, in front of the hvac call. Companion to the deploy-side
+> contract in
+> [`docs/cross-repo/connector-vault-policy.md`](../cross-repo/connector-vault-policy.md).
+> Implemented for [#1643](https://github.com/evoila/meho/issues/1643)
+> (cross-tenant isolation hardening, Goal #221).
+
+## The problem
+
+The KV-v2 handlers in
+[`connectors/vault/ops.py`](../../backend/src/meho_backplane/connectors/vault/ops.py)
+forward the agent-supplied `mount` / `path` to hvac **verbatim**. The
+intended access boundary is the Vault `meho-mcp` role's ACL policy, which
+scopes each operator to their own identity segment via policy templating
+(`connector-vault-policy.md` §2). That is the *primary* gate and it is
+sound — **as long as the policy is provisioned correctly.**
+
+The failure mode this guard defends against is an **over-broad Vault
+policy**: if a deploy drops the templated identity segment, or a wildcard
+leaks into the rendered output (`connector-vault-policy.md` §2's "no glob
+inside the rendered segment" constraint is violated), the single shared
+`meho-mcp` role would let a tenant-A caller read `tenant-b/...` secrets.
+Nothing in the backplane would have stopped it — the path was passed
+straight through.
+
+## The guard
+
+[`connectors/vault/tenant_scope.py`](../../backend/src/meho_backplane/connectors/vault/tenant_scope.py)
+adds `enforce_tenant_scope(operator, mount=..., path=...)`, called by
+**every** KV-v2 handler (`read`, `list`, `versions`, `put`, `patch`,
+`delete`) immediately after it extracts `mount`/`path` and **before** the
+`vault_client_for_operator(...)` login. On a violation it raises
+`VaultTenantScopeError`; the dispatcher's `connector_error` branch wraps
+it into a structured `OperationResult` with
+`extras["exception_class"] == "VaultTenantScopeError"` — distinct from the
+`VaultClientError` family (a real Vault-side 403) so callers can tell a
+*local* tenant denial apart from a Vault denial. No Vault round-trip
+happens on a denied call.
+
+`operator.tenant_id` (a `UUID`) is already threaded into every handler —
+the dispatcher passes the real `Operator` to typed handlers
+(`operations/_branches.py` `dispatch_typed`). **No operator-threading
+refactor was needed.**
+
+## The namespace convention
+
+The rule is configured by one setting,
+[`vault_kv_tenant_scope_prefix`](../../backend/src/meho_backplane/settings.py)
+(env `VAULT_KV_TENANT_SCOPE_PREFIX`):
+
+- It is a Python `str.format` template carrying a single `{tenant_id}`
+  placeholder, e.g. `tenant-{tenant_id}/` or `secret/tenant-{tenant_id}/`.
+- At call time the operator's `tenant_id` UUID is rendered into the
+  template (canonical dashed lowercase form, matching audit rows and JWT
+  claims).
+- The requested address is normalised to `<mount>/<path>` (stray slashes
+  trimmed) and must **equal the rendered prefix or begin with
+  `<prefix>/`** — a path-segment-boundary match, so a `tenant-1` prefix is
+  *not* satisfied by a `tenant-12/...` path or a `tenant-1extra/...` path.
+- Because the candidate includes the mount segment, the prefix can pin the
+  **mount** (`secret/tenant-{tenant_id}/`) or just a **path** prefix
+  (`tenant-{tenant_id}/`) — a deploy partitions tenants by whichever it
+  uses.
+
+## Why opt-in (empty default)
+
+The guard is **disabled by default** (empty prefix → `enforce_tenant_scope`
+is a no-op, behaviour is byte-for-byte pre-#1643). This is deliberate:
+
+The shipped Vault layout scopes secrets **per operator `sub`**
+(`secret/data/targets/<sub>/*`, `connector-vault-policy.md` §2), **not per
+tenant**. There is no universal `tenant-<id>/` partition to enforce against
+out of the box, so turning on a hard tenant prefix unconditionally would
+deny every existing `vault.kv.*` call. A deploy whose KV layout *is*
+tenant-partitioned opts in by setting the env var; a deploy that relies
+solely on the per-`sub` Vault policy leaves it empty and is unaffected.
+
+The **system/shim operator** (the Nil-UUID `tenant_id` the vault connector
+synthesises in `connector.py`, empty `raw_jwt`) is exempt even when the
+guard is enabled: its only callers run the unauthenticated
+`vault.sys.health` op and forward no token to Vault, so there is no tenant
+identity to bind against.
+
+## Scope notes
+
+- This is **defense-in-depth, not the primary gate.** The guard never
+  grants access the Vault policy denies — it only ever denies *earlier*.
+  Keep the `meho-mcp` policy correct (`connector-vault-policy.md` §2/§6);
+  this guard is the backstop for the day it is mis-provisioned.
+- The **park-time write-capability preflight**
+  (`vault_kv_write_capability_preflight`, #1504) is intentionally *not*
+  guarded here: it is a non-authoritative early signal that probes
+  capability *names* (no secret material) and already fails soft. The
+  authoritative tenant check lives in the write handlers (`put`/`patch`/
+  `delete`), which a parked write re-dispatches through on approval.
+
+## Tests
+
+[`backend/tests/test_connectors_vault_tenant_scope.py`](../../backend/tests/test_connectors_vault_tenant_scope.py):
+unit boundary cases on `enforce_tenant_scope` (in-namespace pass,
+out-of-namespace deny, look-alike sibling prefix, cross-mount, disabled
+default, system-tenant exemption) plus dispatch-level coverage that **every**
+KV-v2 handler denies a cross-tenant path (`exception_class=VaultTenantScopeError`,
+no Vault login) and allows an in-namespace path unchanged.


### PR DESCRIPTION
## Summary

The `vault.kv.*` handlers forwarded the agent-supplied `mount`/`path` to hvac **verbatim** with no application-layer tenant binding. If the shared Vault `meho-mcp` role's policy is over-broad (the templated identity segment is dropped, or a glob leaks into the rendered output per `connector-vault-policy.md` §2's constraint), a tenant-A caller could read `tenant-b/...` secrets and nothing in the backplane would stop it.

This adds a **defense-in-depth** tenant-scope check in front of the hvac call.

- New `connectors/vault/tenant_scope.py` → `enforce_tenant_scope(operator, mount=, path=)`, called by **every** KV-v2 handler (`read` / `list` / `versions` / `put` / `patch` / `delete`) immediately after it extracts `mount`/`path` and **before** the Vault login.
- `operator.tenant_id` (a `UUID`) is **already threaded** into the typed-handler signature by the dispatcher — **no operator-threading refactor was needed.** Surfaced as a key finding below.
- On a violation the guard raises `VaultTenantScopeError`; the dispatcher wraps it into a structured `connector_error` `OperationResult` with `extras.exception_class == "VaultTenantScopeError"` — distinct from a Vault-side 403 (`VaultClientError` family). No Vault round-trip happens on a denied call.

### Convention chosen + why opt-in

The guard is configured by one setting, `VAULT_KV_TENANT_SCOPE_PREFIX` (env): a `str.format` template with a single `{tenant_id}` placeholder, e.g. `tenant-{tenant_id}/` or `secret/tenant-{tenant_id}/`. The requested `<mount>/<path>` (slash-normalised) must equal the rendered prefix or begin with `<prefix>/` — a **path-segment-boundary** match, so `tenant-1` is not satisfied by `tenant-12/...` or `tenant-1extra/...`.

**Empty (the default) disables the guard.** The shipped Vault layout scopes secrets **per operator `sub`** (`secret/data/targets/<sub>/*`, `connector-vault-policy.md` §2), **not per tenant** — so enforcing a hard tenant prefix unconditionally would deny every existing call. A deploy whose KV layout *is* tenant-partitioned opts in by setting the env var. The Nil-UUID system/shim operator (unauthenticated `sys.health` only) is exempt.

Convention, rationale, and failure mode documented in `docs/codebase/connectors-vault-tenant-scope.md`.

Connector-only change — no FastAPI route or OpenAPI snapshot touched (verified nothing under `api/` changed).

## Test plan

`backend/tests/test_connectors_vault_tenant_scope.py` (20 tests, all pass):

- **Unit** on `enforce_tenant_scope`: in-namespace pass; out-of-namespace deny; look-alike sibling prefix denied; cross-mount denied; empty-template no-op; system-tenant exemption; sentinel-equals-connector pin.
- **Dispatch-level** across **all six** KV-v2 handlers: a tenant-A operator requesting a tenant-B path is denied (`exception_class=VaultTenantScopeError`, **no Vault login**); an in-namespace request succeeds unchanged (reaches Vault).

Gates (in `backend/`, via `uv run`):
- `ruff check` + `ruff format --check` on all changed files — pass
- `mypy src/meho_backplane/connectors/vault/ --ignore-missing-imports` — `Success: no issues found in 16 source files`
- `pytest tests/test_connectors_vault_tenant_scope.py` — 20 passed
- full vault suite — 294 passed (1 pre-existing teardown flake in `test_preflight_fail_soft_when_probe_raises`, reproduced on clean `origin/main`, unrelated)
- code-quality `--diff` gate — exit 0, 0 blockers

Closes #1643