### PR TITLE
fix(cli): complete the listEntry mirror — connector list --json keeps state, next_step and enabled_operation_count (#1645)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -192,6 +192,17 @@ connector-related release-notes line.
   reference in the message. Reaches both the REST dispatch response
   and the MCP `call_operation` tool, matching the `composite_l2_*`
   envelope parity (#1627).
+- `meho connector list --json` no longer silently drops the `state`,
+  `next_step` and `enabled_operation_count` fields the backend ships on
+  every `GET /api/v1/connectors` row — the machine surface was
+  advertising an incomplete row shape, so scripts and LLM consumers
+  could not tell a dispatchable (`ingested`) connector from a
+  registered-but-empty one, see the self-describing remediation verb
+  for half-registered connectors, or read the enabled-vs-total
+  operation split. The CLI's decode shape now mirrors all 13
+  `ConnectorListItem` fields and the canonical wire-shape test rejects
+  unknown fixture keys so the mirror cannot silently regress. The
+  human table is unchanged. (#1645)
 
 ## [0.13.0] - 2026-06-11
 

--- a/cli/internal/cmd/connector/connector_test.go
+++ b/cli/internal/cmd/connector/connector_test.go
@@ -731,12 +731,17 @@ func TestDeriveRollupLabelTable(t *testing.T) {
 }
 
 // TestListEntryDecodesCanonical pins the wire shape: the canonical
-// ConnectorListItem (PR #488 api_schemas.py) ships per-status group
-// counts and no top-level review_status. The list endpoint
-// deliberately returns `dict[str, list[dict[str, object]]]` (no
-// `response_model`), so we keep a package-private listEntry struct
-// for the decode; drift here surfaces as a Major-class wire-contract
-// failure on the next list round-trip.
+// ConnectorListItem (operations/ingest/api_schemas.py) ships the
+// per-status group counts, the enabled-vs-total op split (#1636),
+// the dispatchability state (#773), the next_step hint (#1133) and
+// no top-level review_status. The list endpoint deliberately returns
+// `dict[str, list[dict[str, object]]]` (no `response_model`), so we
+// keep a package-private listEntry struct for the decode. The strict
+// decoder makes the fixture⇄struct direction fail loudly: a canonical
+// key without a matching listEntry field is exactly the drift class
+// that silently dropped three backend fields from `--json` (#1645) —
+// plain json.Unmarshal ignores unknown keys, so three backend
+// additions sailed past the previous shape of this test.
 func TestListEntryDecodesCanonical(t *testing.T) {
 	raw := []byte(`{
 		"connector_id": "vmware-rest-9.0",
@@ -748,10 +753,15 @@ func TestListEntryDecodesCanonical(t *testing.T) {
 		"staged_group_count": 5,
 		"enabled_group_count": 3,
 		"disabled_group_count": 1,
-		"operation_count": 961
+		"operation_count": 961,
+		"enabled_operation_count": 14,
+		"state": "ingested",
+		"next_step": null
 	}`)
+	dec := json.NewDecoder(bytes.NewReader(raw))
+	dec.DisallowUnknownFields()
 	var got listEntry
-	if err := json.Unmarshal(raw, &got); err != nil {
+	if err := dec.Decode(&got); err != nil {
 		t.Fatalf("decode listEntry: %v", err)
 	}
 	if got.ConnectorID != "vmware-rest-9.0" {
@@ -763,6 +773,111 @@ func TestListEntryDecodesCanonical(t *testing.T) {
 	if got.StagedGroupCount != 5 || got.EnabledGroupCount != 3 || got.DisabledGroupCount != 1 {
 		t.Errorf("per-status counts: got %+v", got)
 	}
+	if got.OperationCount != 961 || got.EnabledOperationCount != 14 {
+		t.Errorf("op rollup: want 961 total / 14 enabled; got %+v", got)
+	}
+	if got.State != "ingested" {
+		t.Errorf("state: got %q", got.State)
+	}
+	if got.NextStep != nil {
+		t.Errorf("next_step must decode JSON null to nil on an ingested row; got %+v", got.NextStep)
+	}
+}
+
+// TestListEntryJSONRoundTrip pins the machine surface end to end:
+// decode a canonical row, re-marshal through output.PrintJSON — the
+// exact `--json` emit path (`runList` marshals the decoded envelope,
+// not the raw response body) — and assert the fields #773 / #1133 /
+// #1636 added survive the round trip. This is the regression class
+// #1645 closes: any ConnectorListItem field the struct doesn't
+// mirror silently vanishes from machine-readable output.
+func TestListEntryJSONRoundTrip(t *testing.T) {
+	t.Run("registered row carries next_step", func(t *testing.T) {
+		raw := []byte(`{
+			"connector_id": "nsx-rest-4.2",
+			"product": "nsx",
+			"version": "4.2",
+			"impl_id": "nsx-rest",
+			"tenant_id": null,
+			"group_count": 0,
+			"staged_group_count": 0,
+			"enabled_group_count": 0,
+			"disabled_group_count": 0,
+			"operation_count": 0,
+			"enabled_operation_count": 0,
+			"state": "registered",
+			"next_step": {
+				"verb": "meho connector ingest --catalog nsx/4.2",
+				"rationale": "registered without descriptor rows; ingest the catalog spec to make it dispatchable"
+			}
+		}`)
+		var got listEntry
+		if err := json.Unmarshal(raw, &got); err != nil {
+			t.Fatalf("decode listEntry: %v", err)
+		}
+		if got.State != "registered" {
+			t.Errorf("state: got %q", got.State)
+		}
+		if got.NextStep == nil {
+			t.Fatal("next_step must decode to a non-nil pointer on a registered row")
+		}
+		if got.NextStep.Verb != "meho connector ingest --catalog nsx/4.2" {
+			t.Errorf("next_step.verb: got %q", got.NextStep.Verb)
+		}
+		if got.NextStep.Rationale == "" {
+			t.Error("next_step.rationale must survive decode")
+		}
+		var buf bytes.Buffer
+		if err := output.PrintJSON(&buf, &connectorListEnvelope{Connectors: []listEntry{got}}); err != nil {
+			t.Fatalf("PrintJSON: %v", err)
+		}
+		out := buf.String()
+		for _, want := range []string{
+			`"state": "registered"`,
+			`"verb": "meho connector ingest --catalog nsx/4.2"`,
+			`"rationale": "registered without descriptor rows; ingest the catalog spec to make it dispatchable"`,
+			`"enabled_operation_count": 0`,
+		} {
+			if !strings.Contains(out, want) {
+				t.Errorf("--json re-marshal missing %s in:\n%s", want, out)
+			}
+		}
+	})
+	t.Run("ingested row re-marshals next_step as null", func(t *testing.T) {
+		raw := []byte(`{
+			"connector_id": "vault-1.x",
+			"product": "vault",
+			"version": "1.x",
+			"impl_id": "vault",
+			"tenant_id": null,
+			"group_count": 2,
+			"staged_group_count": 0,
+			"enabled_group_count": 2,
+			"disabled_group_count": 0,
+			"operation_count": 7,
+			"enabled_operation_count": 7,
+			"state": "ingested",
+			"next_step": null
+		}`)
+		var got listEntry
+		if err := json.Unmarshal(raw, &got); err != nil {
+			t.Fatalf("decode listEntry: %v", err)
+		}
+		if got.NextStep != nil {
+			t.Fatalf("next_step must be nil on an ingested row; got %+v", got.NextStep)
+		}
+		var buf bytes.Buffer
+		if err := output.PrintJSON(&buf, &connectorListEnvelope{Connectors: []listEntry{got}}); err != nil {
+			t.Fatalf("PrintJSON: %v", err)
+		}
+		out := buf.String()
+		if !strings.Contains(out, `"next_step": null`) {
+			t.Errorf("nil next_step must re-marshal as JSON null, not be dropped or rendered as {}; got:\n%s", out)
+		}
+		if !strings.Contains(out, `"state": "ingested"`) {
+			t.Errorf("state must survive the --json round trip; got:\n%s", out)
+		}
+	})
 }
 
 // TestPrintReviewTableHappyPath — review render shows groups + ops

--- a/cli/internal/cmd/connector/list.go
+++ b/cli/internal/cmd/connector/list.go
@@ -17,11 +17,21 @@ import (
 	"github.com/evoila/meho/cli/internal/output"
 )
 
-// listEntry mirrors the backend ConnectorListItem Pydantic model
-// (operations/ingest/api_schemas.py) verbatim: one row per ingested
-// connector with parsed coordinates + tenant scope + per-status group
-// counts + bulk op count for the operator's overview table. The full
-// per-op detail comes from `meho connector review <id>`.
+// listEntry mirrors all 13 fields of the backend ConnectorListItem
+// Pydantic model (operations/ingest/api_schemas.py): one row per
+// listed connector with parsed coordinates + tenant scope +
+// per-status group counts + the operation rollup — `operation_count`
+// total vs `enabled_operation_count` dispatchable subset (#1636) —
+// plus the dispatchability `state` ("ingested" = DB-backed, resolves
+// through the dispatcher; "registered" = v2-registry entry without
+// descriptor rows yet, #773) and the `next_step` remediation hint
+// shipped on registered rows (#1133). The full per-op detail comes
+// from `meho connector review <id>`. Keep the field set complete:
+// the `--json` path re-marshals this struct (not the raw response
+// body), so any ConnectorListItem field missing here silently
+// vanishes from machine-readable output — `encoding/json.Unmarshal`
+// ignores unknown keys. TestListEntryDecodesCanonical pins the
+// fixture⇄struct direction with DisallowUnknownFields.
 //
 // Kept as a package-private decode shape (not surfaced through the
 // generated `api.*` types) because the FastAPI list endpoint
@@ -48,16 +58,32 @@ import (
 // for built-in connectors. Pointer-to-string so we can distinguish
 // "field absent" from "empty string" in the rendered table.
 type listEntry struct {
-	ConnectorID        string  `json:"connector_id"`
-	Product            string  `json:"product"`
-	Version            string  `json:"version"`
-	ImplID             string  `json:"impl_id"`
-	TenantID           *string `json:"tenant_id"`
-	GroupCount         int     `json:"group_count"`
-	StagedGroupCount   int     `json:"staged_group_count"`
-	EnabledGroupCount  int     `json:"enabled_group_count"`
-	DisabledGroupCount int     `json:"disabled_group_count"`
-	OperationCount     int     `json:"operation_count"`
+	ConnectorID           string    `json:"connector_id"`
+	Product               string    `json:"product"`
+	Version               string    `json:"version"`
+	ImplID                string    `json:"impl_id"`
+	TenantID              *string   `json:"tenant_id"`
+	GroupCount            int       `json:"group_count"`
+	StagedGroupCount      int       `json:"staged_group_count"`
+	EnabledGroupCount     int       `json:"enabled_group_count"`
+	DisabledGroupCount    int       `json:"disabled_group_count"`
+	OperationCount        int       `json:"operation_count"`
+	EnabledOperationCount int       `json:"enabled_operation_count"`
+	State                 string    `json:"state"`
+	NextStep              *nextStep `json:"next_step"`
+}
+
+// nextStep mirrors the backend NextStep Pydantic model (same module):
+// the self-describing hint shipped on `state="registered"` rows —
+// the `meho connector ingest ...` verb that closes the workflow plus
+// the rationale for why that verb applies. The listEntry field is
+// pointer-typed because the backend ships JSON `null` on every
+// `state="ingested"` row (nothing left for the operator to do), and
+// `null` must decode to nil — same null-vs-absent discipline as
+// `TenantID` above.
+type nextStep struct {
+	Verb      string `json:"verb"`
+	Rationale string `json:"rationale"`
 }
 
 // connectorListEnvelope is the package-private decode shape for the


### PR DESCRIPTION
## Summary
- `meho connector list --json` was silently dropping three fields the backend ships on every `GET /api/v1/connectors` row — `state` (#773), `next_step` (#1133) and `enabled_operation_count` (#1636) — because the `--json` path re-marshals the package-private `listEntry` decode struct (not the raw body) and `encoding/json.Unmarshal` ignores unknown keys. Machine consumers could not tell a dispatchable (`ingested`) connector from a registered-but-empty one or see the remediation verb.
- Completes the mirror: `listEntry` now carries all 13 `ConnectorListItem` fields, with `next_step` as a pointer to a new package-private `nextStep` struct (`verb`, `rationale`) so the JSON `null` on every `state="ingested"` row decodes to `nil` — same null-vs-absent discipline as `TenantID`.
- Hardens the wire-shape guard: `TestListEntryDecodesCanonical` now pins the full 13-field canonical payload and decodes via `json.Decoder.DisallowUnknownFields()`, so a fixture key without a matching struct field fails loudly (the direction `encoding/json` can enforce; this is exactly the drift class that let three backend additions sail past the old test). New `TestListEntryJSONRoundTrip` covers both row shapes through the real `output.PrintJSON` emit path, asserting a nil `next_step` re-marshals as JSON `null` (not `{}`).
- Fixes the `listEntry` doc comment, which claimed a "verbatim" mirror it had not kept since #773 — it now names the three additions with their provenance and explains why the field set must stay complete.

## Test plan
- [x] `cd cli && go build ./...` — clean
- [x] `cd cli && CGO_ENABLED=1 go test -race ./...` — exit 0, 44 packages ok (CI-parity flags minus `-covermode`/`-coverprofile`: the sandbox's module-form Go 1.25.8 toolchain ships a pruned `pkg/tool` without `covdata`, which breaks coverage-profile synthesis for the three no-test packages; CI's `actions/setup-go` toolchain has it)
- [x] `golangci-lint run` (v2.12.2, the exact CI version, with `cli/.golangci.yml`) — 0 issues
- [x] `gofmt -l .` — clean
- [x] AC: 13-field decode — `TestListEntryDecodesCanonical` PASS with `DisallowUnknownFields`
- [x] AC: round-trip both row shapes — `TestListEntryJSONRoundTrip/{registered_row_carries_next_step,ingested_row_re-marshals_next_step_as_null}` PASS
- [x] AC: doc-comment honesty — `grep -n enabled_operation_count cli/internal/cmd/connector/list.go` hits the comment (L24) and the field tag (L71)
- [x] AC: human table untouched — `TestPrintListTableHappyPath` unmodified and PASS
- [x] CHANGELOG bullet under `[Unreleased]` / `### Fixed`
- [x] `python3 .claude/hooks/code-quality.py --diff` — pass

## Out of scope (per the issue)
- Rendering `state` / `next_step` / the enabled-vs-total split in the human table (separate UX decision; the derived rollup label already answers the status question there).
- Switching `--json` to raw-response passthrough — the CLI convention is structured, CLI-owned envelopes via `output.PrintJSON`.
- Typing the route in OpenAPI backend-side (#1265 dispositioned the generated-client question for this route).
- Note: `DisallowUnknownFields` is deliberately applied to the **test** decoder only, never the runtime `getList` decode — a strict runtime decode would make older CLIs fail closed against every future backend field addition.

<!-- auto-implement-issue: fresh, iteration 1 -->

Closes #1645

🤖 Generated with [Claude Code](https://claude.com/claude-code)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Bug Fixes
* Fixed `meho connector list --json` to output complete connector details. The JSON response now includes `state`, `next_step`, and `enabled_operation_count` fields that were previously omitted. Human-readable table format output remains unchanged.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->