### PR TITLE
fix(connectors): key VCF/Harbor/NSX/SDDC credential & session caches by (tenant_id, target.id)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -123,6 +123,12 @@ connector-related release-notes line.
   naming one's own tenant (by slug or UUID) or omitting the argument is
   unchanged, and an unauthorized cross-tenant request surfaces as the
   MCP `-32602` (INVALID_PARAMS) error (#1641).
+- Re-keyed the VCF (vROps / vRLI / Fleet), Harbor, NSX, and SDDC-Manager
+  connectors' per-target credential and session-token caches on the
+  tenant-unique `(tenant_id, target.id)` tuple instead of `target.name`.
+  Two same-named targets in different tenants previously collapsed onto one
+  cache entry, so one tenant could be served another tenant's cached
+  service-account credential or session token (#1642).
 
 ### Breaking changes
 

--- a/backend/src/meho_backplane/connectors/_shared/__init__.py
+++ b/backend/src/meho_backplane/connectors/_shared/__init__.py
@@ -17,6 +17,10 @@ Exports:
   reusable operator-context Vault KV-v2 basic-credentials reader
   (G3.9-T2 #941). Every REST connector loader resolves a target's
   ``secret_ref`` to vendor credentials through it.
+* :mod:`meho_backplane.connectors._shared.cache_key` — the canonical
+  tenant-unique ``(tenant_id, id)`` per-target cache key (#1642). Every
+  connector credential / session / client cache derives its key here so
+  same-named targets in different tenants never collapse to one entry.
 
 New cross-connector shared modules land alongside these — keep each
 module focused on a single concern (auth, retries, pagination, etc.)
@@ -24,9 +28,10 @@ rather than growing this package into a god-module.
 """
 
 from meho_backplane.connectors._shared import (
+    cache_key,
     system_operator,
     vault_creds,
     vcf_auth,
 )
 
-__all__ = ["system_operator", "vault_creds", "vcf_auth"]
+__all__ = ["cache_key", "system_operator", "vault_creds", "vcf_auth"]

--- a/backend/src/meho_backplane/connectors/_shared/cache_key.py
+++ b/backend/src/meho_backplane/connectors/_shared/cache_key.py
@@ -1,0 +1,53 @@
+# SPDX-License-Identifier: Apache-2.0
+# Copyright (c) 2026 evoila Group
+
+"""Tenant-unique per-target cache key.
+
+Connector credential / session / client caches are process-global and
+shared across tenants. Keying them on ``target.name`` alone is a
+cross-tenant isolation bug: two same-named targets in different tenants
+collapse to one entry, so one tenant can be served another tenant's
+cached session or credential (evoila/meho#1642).
+
+The targets table enforces uniqueness only on ``(tenant_id, name)`` and
+``id`` is the table's primary key, so ``(tenant_id, id)`` is the stable,
+tenant-unique identity of a target row. This module exposes the single
+canonical key so every connector cache derives the same value and no
+two-cache-keying-skew bugs can creep in (e.g. NSX's session-token cache
+and the shared HTTP-client pool keying differently).
+"""
+
+from __future__ import annotations
+
+from typing import Protocol, runtime_checkable
+
+
+@runtime_checkable
+class TenantScopedTargetLike(Protocol):
+    """Minimum identity shape needed to derive a tenant-unique cache key.
+
+    The concrete ``Target`` model
+    (:class:`meho_backplane.targets.Target`) and ORM row both carry a
+    UUID ``id`` (primary key) and a NOT-NULL UUID ``tenant_id``, so they
+    satisfy this Protocol unchanged. The connector ``*TargetLike``
+    Protocols extend this one so the structural-typing contract the
+    connectors already rely on keeps mypy honest about the two fields
+    the cache key reads.
+    """
+
+    id: object
+    tenant_id: object
+
+
+def target_cache_key(target: TenantScopedTargetLike) -> tuple[str, str]:
+    """Return the tenant-unique ``(tenant_id, id)`` cache key for *target*.
+
+    Both components are stringified so the key is hashable and stable
+    regardless of whether the caller passes ``uuid.UUID`` objects (the
+    live model) or plain strings (test doubles). ``id`` is the targets
+    table primary key and ``(tenant_id, name)`` is its only uniqueness
+    constraint, so ``(tenant_id, id)`` uniquely identifies one target row
+    across all tenants — unlike ``name`` alone, which collides across
+    tenants (evoila/meho#1642).
+    """
+    return (str(target.tenant_id), str(target.id))

--- a/backend/src/meho_backplane/connectors/_shared/vcf_auth.py
+++ b/backend/src/meho_backplane/connectors/_shared/vcf_auth.py
@@ -72,6 +72,7 @@ import httpx
 import structlog
 
 from meho_backplane.auth.operator import Operator
+from meho_backplane.connectors._shared.cache_key import target_cache_key
 from meho_backplane.connectors._shared.vault_creds import (
     VaultCredentialsReadError,
     load_basic_credentials,
@@ -150,7 +151,12 @@ class VcfTargetLike(Protocol):
 
     Fields:
 
-    * ``name`` — per-target cache key (credentials + session token).
+    * ``id`` / ``tenant_id`` — the tenant-unique cache key
+      (:func:`~meho_backplane.connectors._shared.cache_key.target_cache_key`).
+      Keying the credential / session cache on ``(tenant_id, id)`` instead
+      of ``name`` keeps two same-named targets in different tenants from
+      collapsing onto one cached credential (#1642).
+    * ``name`` — used in audit-log / error messages (no longer a cache key).
     * ``host`` / ``port`` — forwarded to
       :meth:`meho_backplane.connectors.adapters.http.HttpConnector._base_url`.
     * ``secret_ref`` — Vault path the loader resolves to a
@@ -163,6 +169,8 @@ class VcfTargetLike(Protocol):
       :func:`is_acceptable_auth_model`.
     """
 
+    id: object
+    tenant_id: object
     name: str
     host: str
     port: int | None
@@ -255,10 +263,13 @@ class CredentialsCache:
     path (a typo in a production loader otherwise surfaces as a confusing
     ``KeyError`` deep inside the consuming code).
 
-    The cache is keyed on ``target.name``. Production deploys with multiple
-    connector instances each get their own cache — there is no
-    process-global cache by design, so connector-instance teardown
-    (``aclose``) clears credentials immediately.
+    The cache is keyed on the tenant-unique ``(tenant_id, target.id)``
+    tuple (:func:`~meho_backplane.connectors._shared.cache_key.target_cache_key`,
+    #1642) so two same-named targets in different tenants never share a
+    cached credential. Production deploys with multiple connector instances
+    each get their own cache — there is no process-global cache by design,
+    so connector-instance teardown (``aclose``) clears credentials
+    immediately.
     """
 
     def __init__(
@@ -277,7 +288,7 @@ class CredentialsCache:
         """
         self._loader = loader
         self._product_label = product_label
-        self._cache: dict[str, dict[str, str]] = {}
+        self._cache: dict[tuple[str, str], dict[str, str]] = {}
         self._lock = asyncio.Lock()
 
     async def get(self, target: VcfTargetLike, operator: Operator) -> dict[str, str]:
@@ -287,8 +298,9 @@ class CredentialsCache:
         (:func:`load_credentials_from_vault`) performs the Vault read
         under the operator's Identity entity via
         :func:`~meho_backplane.auth.vault.vault_client_for_operator`. The
-        cache is keyed on ``target.name`` only — a single per-target
-        credential pair is shared across operators because the
+        cache is keyed on the tenant-unique ``(tenant_id, target.id)``
+        tuple (#1642) — a single per-target credential pair is shared
+        across operators of the same tenant because the
         ``shared_service_account`` auth model authenticates the connector
         with a Vault-sourced service account, not the operator's OIDC
         token. ``per_user`` / ``impersonation`` are explicitly out of
@@ -324,8 +336,9 @@ class CredentialsCache:
                 f"target={target.name!r} has no operator JWT (system-initiated calls "
                 "cannot read per-target vendor credentials)"
             )
+        cache_key = target_cache_key(target)
         async with self._lock:
-            cached = self._cache.get(target.name)
+            cached = self._cache.get(cache_key)
             if cached is not None:
                 return cached
             raw = await self._loader(target, operator)
@@ -337,7 +350,7 @@ class CredentialsCache:
                         f"{required!r}; need "
                         "{'username': str, 'password': str}"
                     )
-            self._cache[target.name] = raw
+            self._cache[cache_key] = raw
             _log.info(
                 "vcf_credentials_loaded",
                 connector=self._product_label,
@@ -357,7 +370,7 @@ class CredentialsCache:
         surfaced via a future admin endpoint).
         """
         async with self._lock:
-            self._cache.pop(target.name, None)
+            self._cache.pop(target_cache_key(target), None)
 
     async def clear(self) -> None:
         """Drop all cached credentials.
@@ -378,8 +391,8 @@ class CredentialsCache:
             self._cache.clear()
 
     @property
-    def cached_targets(self) -> frozenset[str]:
-        """Frozen view of the cached target names (read-only, for tests/audit)."""
+    def cached_targets(self) -> frozenset[tuple[str, str]]:
+        """Frozen view of the cached ``(tenant_id, id)`` keys (read-only, for tests/audit)."""
         return frozenset(self._cache)
 
 

--- a/backend/src/meho_backplane/connectors/harbor/connector.py
+++ b/backend/src/meho_backplane/connectors/harbor/connector.py
@@ -88,6 +88,7 @@ import httpx
 import structlog
 
 from meho_backplane.auth.operator import Operator
+from meho_backplane.connectors._shared.cache_key import target_cache_key
 from meho_backplane.connectors._shared.system_operator import (
     is_system_operator,
     synthesise_system_operator,
@@ -176,7 +177,7 @@ class HarborConnector(HttpConnector):
         credentials_loader: HarborCredentialsLoader | None = None,
     ) -> None:
         super().__init__()
-        self._creds_cache: dict[str, dict[str, str]] = {}
+        self._creds_cache: dict[tuple[str, str], dict[str, str]] = {}
         self._creds_lock = asyncio.Lock()
         self._credentials_loader: HarborCredentialsLoader = (
             credentials_loader if credentials_loader is not None else load_credentials_from_vault
@@ -256,8 +257,9 @@ class HarborConnector(HttpConnector):
         resolve itself (#1008). Real-operator behaviour is unchanged —
         cold load → cache → reuse.
         """
+        cache_key = target_cache_key(target)
         async with self._creds_lock:
-            cached = self._creds_cache.get(target.name)
+            cached = self._creds_cache.get(cache_key)
             if cached is not None and not is_system_operator(operator):
                 return cached
             raw = await self._credentials_loader(target, operator)
@@ -270,7 +272,7 @@ class HarborConnector(HttpConnector):
                     f"a dict missing required key {exc.args[0]!r}; need "
                     "{'username': str, 'password': str}"
                 ) from exc
-            self._creds_cache[target.name] = raw
+            self._creds_cache[cache_key] = raw
             _log.info(
                 "harbor_credentials_loaded",
                 target=target.name,

--- a/backend/src/meho_backplane/connectors/harbor/session.py
+++ b/backend/src/meho_backplane/connectors/harbor/session.py
@@ -96,8 +96,15 @@ class HarborTargetLike(Protocol):
 
     No ``sso_realm`` field — Harbor sends ``username:password`` as-is;
     no realm suffix is appended.
+
+    ``id`` / ``tenant_id`` form the tenant-unique ``(tenant_id, id)``
+    cache key (:func:`~meho_backplane.connectors._shared.cache_key.target_cache_key`)
+    the credential + HTTP-client caches use, so two same-named targets in
+    different tenants never share a cached credential (#1642).
     """
 
+    id: object
+    tenant_id: object
     name: str
     host: str
     port: int | None

--- a/backend/src/meho_backplane/connectors/nsx/connector.py
+++ b/backend/src/meho_backplane/connectors/nsx/connector.py
@@ -49,8 +49,9 @@ consumer wrapper repo). The flow:
    subsequent requests through the same per-target client carry the
    cookie without manual plumbing.
 3. The response's ``X-XSRF-TOKEN`` header is captured into
-   :attr:`_session_tokens` keyed on ``target.name`` (mirrors
-   :class:`VmwareRestConnector._session_tokens` per-target isolation).
+   :attr:`_session_tokens` keyed on the tenant-unique
+   ``(tenant_id, target.id)`` tuple (#1642), so two same-named targets in
+   different tenants never share a cached session.
 4. :meth:`auth_headers` returns ``{"X-XSRF-TOKEN": <cached>}`` on
    subsequent calls; the cookie travels via the client jar.
 5. On HTTP 401 from a downstream call, :meth:`_get_json_with_session_retry`
@@ -114,6 +115,7 @@ import httpx
 import structlog
 
 from meho_backplane.auth.operator import Operator
+from meho_backplane.connectors._shared.cache_key import target_cache_key
 from meho_backplane.connectors._shared.system_operator import synthesise_system_operator
 from meho_backplane.connectors.adapters.http import HttpConnector
 from meho_backplane.connectors.nsx.session import (
@@ -203,7 +205,7 @@ class NsxConnector(HttpConnector):
         session_loader: NsxSessionLoader | None = None,
     ) -> None:
         super().__init__()
-        self._session_tokens: dict[str, str] = {}
+        self._session_tokens: dict[tuple[str, str], str] = {}
         self._session_lock = asyncio.Lock()
         self._session_loader: NsxSessionLoader = (
             session_loader if session_loader is not None else load_session_credentials_from_vault
@@ -264,8 +266,9 @@ class NsxConnector(HttpConnector):
         read; injected test loaders accept the same
         ``(target, operator)`` pair.
         """
+        cache_key = target_cache_key(target)
         async with self._session_lock:
-            cached = self._session_tokens.get(target.name)
+            cached = self._session_tokens.get(cache_key)
             if cached is not None:
                 return cached
             creds = await self._session_loader(target, operator)
@@ -309,7 +312,7 @@ class NsxConnector(HttpConnector):
                     f"POST {_SESSION_CREATE_PATH} returned 2xx with no "
                     f"{_XSRF_HEADER} response header"
                 )
-            self._session_tokens[target.name] = xsrf
+            self._session_tokens[cache_key] = xsrf
             _log.info(
                 "nsx_session_established",
                 target=target.name,
@@ -327,7 +330,9 @@ class NsxConnector(HttpConnector):
         the invalidation.
         """
         async with self._session_lock:
-            self._session_tokens.pop(target.name, None)
+            self._session_tokens.pop(target_cache_key(target), None)
+            # ``_clients`` (the shared HttpConnector pool) is keyed on
+            # ``target.name``; only the session-token cache is tenant-keyed.
             client = self._clients.get(target.name)
             if client is not None:
                 client.cookies.clear()

--- a/backend/src/meho_backplane/connectors/nsx/session.py
+++ b/backend/src/meho_backplane/connectors/nsx/session.py
@@ -83,8 +83,15 @@ class NsxTargetLike(Protocol):
     bare ``KeyError``. ``port`` is optional -- NSX manager defaults to
     443 and :meth:`HttpConnector._base_url` already handles the
     ``port is None or 443`` case correctly.
+
+    ``id`` / ``tenant_id`` form the tenant-unique ``(tenant_id, id)``
+    cache key (:func:`~meho_backplane.connectors._shared.cache_key.target_cache_key`)
+    the session-token + HTTP-client caches use, so two same-named targets
+    in different tenants never share a cached session (#1642).
     """
 
+    id: object
+    tenant_id: object
     name: str
     host: str
     port: int | None

--- a/backend/src/meho_backplane/connectors/sddc_manager/connector.py
+++ b/backend/src/meho_backplane/connectors/sddc_manager/connector.py
@@ -75,6 +75,7 @@ import httpx
 import structlog
 
 from meho_backplane.auth.operator import Operator
+from meho_backplane.connectors._shared.cache_key import target_cache_key
 from meho_backplane.connectors._shared.system_operator import (
     is_system_operator,
     synthesise_system_operator,
@@ -149,7 +150,7 @@ class SddcManagerConnector(HttpConnector):
         credentials_loader: SddcCredentialsLoader | None = None,
     ) -> None:
         super().__init__()
-        self._creds_cache: dict[str, dict[str, str]] = {}
+        self._creds_cache: dict[tuple[str, str], dict[str, str]] = {}
         self._creds_lock = asyncio.Lock()
         self._credentials_loader: SddcCredentialsLoader = (
             credentials_loader if credentials_loader is not None else load_credentials_from_vault
@@ -211,8 +212,9 @@ class SddcManagerConnector(HttpConnector):
         resolve itself (#1008). Real-operator behaviour is unchanged —
         cold load → cache → reuse.
         """
+        cache_key = target_cache_key(target)
         async with self._creds_lock:
-            cached = self._creds_cache.get(target.name)
+            cached = self._creds_cache.get(cache_key)
             if cached is not None and not is_system_operator(operator):
                 return cached
             raw = await self._credentials_loader(target, operator)
@@ -225,7 +227,7 @@ class SddcManagerConnector(HttpConnector):
                     f"a dict missing required key {exc.args[0]!r}; need "
                     "{'username': str, 'password': str}"
                 ) from exc
-            self._creds_cache[target.name] = raw
+            self._creds_cache[cache_key] = raw
             _log.info(
                 "sddc_manager_credentials_loaded",
                 target=target.name,

--- a/backend/src/meho_backplane/connectors/sddc_manager/session.py
+++ b/backend/src/meho_backplane/connectors/sddc_manager/session.py
@@ -90,8 +90,15 @@ class SddcTargetLike(Protocol):
     constructing the Basic auth header (``username@sso_realm``). Defaults
     to ``"vsphere.local"`` per the consumer wrapper contract; operators
     managing a custom domain override this at the target level.
+
+    ``id`` / ``tenant_id`` form the tenant-unique ``(tenant_id, id)``
+    cache key (:func:`~meho_backplane.connectors._shared.cache_key.target_cache_key`)
+    the credential + HTTP-client caches use, so two same-named targets in
+    different tenants never share a cached credential (#1642).
     """
 
+    id: object
+    tenant_id: object
     name: str
     host: str
     port: int | None

--- a/backend/src/meho_backplane/connectors/vcf_fleet/session.py
+++ b/backend/src/meho_backplane/connectors/vcf_fleet/session.py
@@ -93,8 +93,14 @@ class VcfFleetTargetLike(Protocol):
     No ``sso_realm`` field — Fleet's local user store accepts
     ``admin@local`` as the literal Basic-auth username; no realm suffix
     is appended by the connector.
+
+    ``id`` / ``tenant_id`` form the tenant-unique ``(tenant_id, id)`` cache
+    key the shared :class:`CredentialsCache` uses, so two same-named targets
+    in different tenants never share a cached credential (#1642).
     """
 
+    id: object
+    tenant_id: object
     name: str
     host: str
     port: int | None

--- a/backend/src/meho_backplane/connectors/vcf_logs/connector.py
+++ b/backend/src/meho_backplane/connectors/vcf_logs/connector.py
@@ -93,6 +93,7 @@ import httpx
 import structlog
 
 from meho_backplane.auth.operator import Operator
+from meho_backplane.connectors._shared.cache_key import target_cache_key
 from meho_backplane.connectors._shared.vault_creds import VaultCredentialsReadError
 from meho_backplane.connectors._shared.vcf_auth import (
     CredentialsCache,
@@ -233,7 +234,7 @@ class VcfLogsConnector(HttpConnector):
         credentials_loader: VcfCredentialsLoader | None = None,
     ) -> None:
         super().__init__()
-        self._session_tokens: dict[str, str] = {}
+        self._session_tokens: dict[tuple[str, str], str] = {}
         self._session_lock = asyncio.Lock()
         self._credentials = CredentialsCache(
             credentials_loader if credentials_loader is not None else load_credentials_from_vault,
@@ -317,8 +318,9 @@ class VcfLogsConnector(HttpConnector):
                 f"target={target.name!r} has no operator JWT (system-initiated calls "
                 "cannot read per-target vendor credentials)"
             )
+        cache_key = target_cache_key(target)
         async with self._session_lock:
-            cached = self._session_tokens.get(target.name)
+            cached = self._session_tokens.get(cache_key)
             if cached is not None:
                 return cached
             creds = await self._credentials.get(target, operator)
@@ -337,7 +339,7 @@ class VcfLogsConnector(HttpConnector):
                     "Accept": "application/json",
                 },
             )
-            self._session_tokens[target.name] = token
+            self._session_tokens[cache_key] = token
             _log.info(
                 "vrli_session_established",
                 target=target.name,
@@ -358,7 +360,7 @@ class VcfLogsConnector(HttpConnector):
         wrong.
         """
         async with self._session_lock:
-            self._session_tokens.pop(target.name, None)
+            self._session_tokens.pop(target_cache_key(target), None)
 
     async def _get_json_with_session_retry(
         self,

--- a/backend/src/meho_backplane/connectors/vcf_logs/session.py
+++ b/backend/src/meho_backplane/connectors/vcf_logs/session.py
@@ -65,7 +65,12 @@ class VcfLogsTargetLike(Protocol):
 
     Fields:
 
-    * ``name`` -- per-target cache key (credentials + session token).
+    * ``id`` / ``tenant_id`` -- the tenant-unique ``(tenant_id, id)``
+      cache key
+      (:func:`~meho_backplane.connectors._shared.cache_key.target_cache_key`)
+      the credential + session-token caches use, so two same-named targets
+      in different tenants never share a cached session (#1642).
+    * ``name`` -- used in audit-log / error messages (no longer a cache key).
     * ``host`` / ``port`` -- forwarded to
       :meth:`HttpConnector._base_url`.
     * ``secret_ref`` -- Vault path the loader resolves to a
@@ -79,6 +84,8 @@ class VcfLogsTargetLike(Protocol):
       wrapper's posture.
     """
 
+    id: object
+    tenant_id: object
     name: str
     host: str
     port: int | None

--- a/backend/src/meho_backplane/connectors/vcf_operations/session.py
+++ b/backend/src/meho_backplane/connectors/vcf_operations/session.py
@@ -69,11 +69,15 @@ class VcfOperationsTargetLike(Protocol):
       realm name, etc.) are operator-configured per vROps deployment; the
       connector passes the string through verbatim.
 
-    The base shared fields (``name``, ``host``, ``port``, ``secret_ref``,
-    ``auth_model``) are gated and consumed identically to the other G3.6
-    skeletons (see :class:`VcfTargetLike`).
+    The base shared fields (``id``, ``tenant_id``, ``name``, ``host``,
+    ``port``, ``secret_ref``, ``auth_model``) are gated and consumed
+    identically to the other G3.6 skeletons (see :class:`VcfTargetLike`).
+    ``id`` / ``tenant_id`` form the tenant-unique ``(tenant_id, id)`` cache
+    key the shared :class:`CredentialsCache` uses (#1642).
     """
 
+    id: object
+    tenant_id: object
     name: str
     host: str
     port: int | None

--- a/backend/tests/integration/test_connectors_harbor_container.py
+++ b/backend/tests/integration/test_connectors_harbor_container.py
@@ -305,6 +305,7 @@ class _HarborTarget:
 
     def __post_init__(self) -> None:
         self.id = uuid.uuid4()
+        self.tenant_id = uuid.uuid4()
         self.preferred_impl_id: str | None = None
 
         class _FP:

--- a/backend/tests/test_connectors_harbor_auth.py
+++ b/backend/tests/test_connectors_harbor_auth.py
@@ -17,13 +17,14 @@ from __future__ import annotations
 
 import base64
 from collections.abc import Iterator
-from dataclasses import dataclass
-from uuid import UUID
+from dataclasses import dataclass, field
+from uuid import UUID, uuid4
 
 import pytest
 import respx
 
 from meho_backplane.auth.operator import Operator, TenantRole
+from meho_backplane.connectors._shared.cache_key import target_cache_key
 from meho_backplane.connectors._shared.system_operator import (
     SYSTEM_OPERATOR_SUB,
     synthesise_system_operator,
@@ -86,6 +87,10 @@ class _StubTarget:
     port: int | None
     secret_ref: str
     auth_model: str | None = AuthModel.SHARED_SERVICE_ACCOUNT.value
+    # Tenant-unique cache key components (#1642). Distinct ``id`` per
+    # instance so two stub targets never collapse onto one cache entry.
+    id: UUID = field(default_factory=uuid4)
+    tenant_id: UUID = field(default_factory=lambda: UUID(int=0))
 
 
 _TARGET_A = _StubTarget(
@@ -337,6 +342,63 @@ async def test_per_target_isolation_keeps_credentials_separate() -> None:
     await connector.aclose()
 
 
+@pytest.mark.asyncio
+async def test_same_name_targets_in_different_tenants_get_distinct_credentials() -> None:
+    """Same-named targets in DIFFERENT tenants never share a cached credential.
+
+    Regression guard for #1642: the credential cache used to key on
+    ``target.name`` alone, so two same-named targets in different tenants
+    collapsed onto one entry and one tenant could be served another
+    tenant's cached credential. The cache keys on the tenant-unique
+    ``(tenant_id, id)`` tuple instead.
+    """
+    load_count = 0
+
+    async def _counting_loader(target: HarborTargetLike, _operator: Operator) -> dict[str, str]:
+        nonlocal load_count
+        load_count += 1
+        return {"username": f"svc-{target.tenant_id}", "password": "pass"}
+
+    tenant_one = _StubTarget(
+        name="harbor-shared",
+        host="harbor-shared.test.invalid",
+        port=443,
+        secret_ref="harbor/harbor-shared",
+        id=UUID(int=0x1),
+        tenant_id=UUID(int=0x100),
+    )
+    tenant_two = _StubTarget(
+        name="harbor-shared",
+        host="harbor-shared.test.invalid",
+        port=443,
+        secret_ref="harbor/harbor-shared",
+        id=UUID(int=0x2),
+        tenant_id=UUID(int=0x200),
+    )
+
+    connector = HarborConnector(credentials_loader=_counting_loader)
+    h_one = await connector.auth_headers(tenant_one, operator=_make_operator())
+    h_two = await connector.auth_headers(tenant_two, operator=_make_operator())
+
+    user_one, _ = _decode_basic_auth(h_one["Authorization"])
+    user_two, _ = _decode_basic_auth(h_two["Authorization"])
+    # Each tenant triggered its own load -- no cross-tenant cache hit.
+    assert load_count == 2
+    assert user_one == f"svc-{tenant_one.tenant_id}"
+    assert user_two == f"svc-{tenant_two.tenant_id}"
+    assert user_one != user_two
+    assert connector._creds_cache.keys() == {
+        target_cache_key(tenant_one),
+        target_cache_key(tenant_two),
+    }
+
+    # Same-tenant re-fetch is a cache HIT -- behaviour unchanged.
+    h_one_again = await connector.auth_headers(tenant_one, operator=_make_operator())
+    assert h_one_again == h_one
+    assert load_count == 2
+    await connector.aclose()
+
+
 # ---------------------------------------------------------------------------
 # Credential loading failure modes
 # ---------------------------------------------------------------------------
@@ -582,7 +644,7 @@ async def test_aclose_clears_credential_cache_and_pool() -> None:
     """aclose() clears the in-memory credential cache and tears down the httpx pool."""
     connector = _make_connector()
     await connector.auth_headers(_TARGET_A, operator=_make_operator())
-    assert "harbor-a" in connector._creds_cache
+    assert target_cache_key(_TARGET_A) in connector._creds_cache
     await connector.aclose()
     assert connector._creds_cache == {}
     assert connector._clients == {}

--- a/backend/tests/test_connectors_harbor_credread.py
+++ b/backend/tests/test_connectors_harbor_credread.py
@@ -170,6 +170,7 @@ class _CredReadTarget:
         self.fingerprint = type("_FP", (), {"version": "2.11.0"})()
         self.preferred_impl_id: str | None = None
         self.id: UUID = uuid.uuid4()
+        self.tenant_id: UUID = UUID("00000000-0000-0000-0000-00000000a0a2")
         self.name = "harbor-credread"
         self.host = _HARBOR_HOST
         self.port = 443

--- a/backend/tests/test_connectors_harbor_robot.py
+++ b/backend/tests/test_connectors_harbor_robot.py
@@ -27,8 +27,8 @@ credentials_loader stub masks the read.
 
 from __future__ import annotations
 
-from dataclasses import dataclass
-from uuid import UUID
+from dataclasses import dataclass, field
+from uuid import UUID, uuid4
 
 import httpx
 import pytest
@@ -112,6 +112,10 @@ class _StubTarget:
     port: int | None
     secret_ref: str
     auth_model: str | None = AuthModel.SHARED_SERVICE_ACCOUNT.value
+    # Tenant-unique cache key components (#1642). Distinct ``id`` per
+    # instance so two stub targets never collapse onto one cache entry.
+    id: UUID = field(default_factory=uuid4)
+    tenant_id: UUID = field(default_factory=lambda: UUID(int=0))
 
 
 _TARGET = _StubTarget(

--- a/backend/tests/test_connectors_nsx_auth.py
+++ b/backend/tests/test_connectors_nsx_auth.py
@@ -15,15 +15,16 @@ response (not JSON-string token), and the connector-level 401 retry
 from __future__ import annotations
 
 from collections.abc import Iterator
-from dataclasses import dataclass
+from dataclasses import dataclass, field
 from urllib.parse import parse_qsl
-from uuid import UUID
+from uuid import UUID, uuid4
 
 import httpx
 import pytest
 import respx
 
 from meho_backplane.auth.operator import Operator, TenantRole
+from meho_backplane.connectors._shared.cache_key import target_cache_key
 from meho_backplane.connectors.adapters.http import HttpConnector
 from meho_backplane.connectors.nsx import (
     NsxConnector,
@@ -83,6 +84,10 @@ class _StubTarget:
     port: int | None
     secret_ref: str
     auth_model: str | None = AuthModel.SHARED_SERVICE_ACCOUNT.value
+    # Tenant-unique cache key components (#1642). Distinct ``id`` per
+    # instance so two stub targets never collapse onto one cache entry.
+    id: UUID = field(default_factory=uuid4)
+    tenant_id: UUID = field(default_factory=lambda: UUID(int=0))
 
 
 _TARGET_A = _StubTarget(
@@ -266,14 +271,72 @@ async def test_per_target_isolation_keeps_session_tokens_separate() -> None:
     assert h_a == {"X-XSRF-TOKEN": "xsrf-a"}
     assert h_b == {"X-XSRF-TOKEN": "xsrf-b"}
     assert connector._session_tokens == {
-        "nsx-a": "xsrf-a",
-        "nsx-b": "xsrf-b",
+        target_cache_key(_TARGET_A): "xsrf-a",
+        target_cache_key(_TARGET_B): "xsrf-b",
     }
     # Cookie jars are also isolated -- one client per target.
     client_a = await connector._http_client(_TARGET_A)
     client_b = await connector._http_client(_TARGET_B)
     assert client_a.cookies.get("JSESSIONID") == "jsess-a"
     assert client_b.cookies.get("JSESSIONID") == "jsess-b"
+
+    await connector.aclose()
+
+
+@pytest.mark.asyncio
+async def test_same_name_targets_in_different_tenants_get_distinct_sessions() -> None:
+    """Same-named targets in DIFFERENT tenants never share a cached session.
+
+    Regression guard for #1642: the session-token cache used to key on
+    ``target.name`` alone, so two same-named targets in different tenants
+    collapsed onto one entry and one tenant could be served another
+    tenant's session. The cache keys on the tenant-unique
+    ``(tenant_id, id)`` tuple instead. Both stub targets share one host
+    (same appliance) so the established session token, not the HTTP-client
+    pool, is the variable under test.
+    """
+    connector = _make_connector()
+    host = "https://nsx-shared.test.invalid"
+    tenant_one = _StubTarget(
+        name="nsx-shared",
+        host="nsx-shared.test.invalid",
+        port=443,
+        secret_ref="nsx/nsx-shared",
+        id=UUID(int=0x1),
+        tenant_id=UUID(int=0x100),
+    )
+    tenant_two = _StubTarget(
+        name="nsx-shared",
+        host="nsx-shared.test.invalid",
+        port=443,
+        secret_ref="nsx/nsx-shared",
+        id=UUID(int=0x2),
+        tenant_id=UUID(int=0x200),
+    )
+
+    async with respx.mock() as mock:
+        route = mock.post(f"{host}/api/session/create").mock(
+            side_effect=[
+                httpx.Response(200, headers={"X-XSRF-TOKEN": "xsrf-tenant-one"}),
+                httpx.Response(200, headers={"X-XSRF-TOKEN": "xsrf-tenant-two"}),
+            ]
+        )
+        h_one = await connector.auth_headers(tenant_one, operator=_make_operator())
+        h_two = await connector.auth_headers(tenant_two, operator=_make_operator())
+
+    # Each tenant established its own session -- no cross-tenant cache hit.
+    assert route.call_count == 2
+    assert h_one == {"X-XSRF-TOKEN": "xsrf-tenant-one"}
+    assert h_two == {"X-XSRF-TOKEN": "xsrf-tenant-two"}
+    assert connector._session_tokens == {
+        target_cache_key(tenant_one): "xsrf-tenant-one",
+        target_cache_key(tenant_two): "xsrf-tenant-two",
+    }
+
+    # Same-tenant re-fetch is a cache HIT -- behaviour unchanged.
+    h_one_again = await connector.auth_headers(tenant_one, operator=_make_operator())
+    assert h_one_again == {"X-XSRF-TOKEN": "xsrf-tenant-one"}
+    assert route.call_count == 2
 
     await connector.aclose()
 
@@ -451,7 +514,7 @@ async def test_downstream_401_triggers_relogin_and_retry_once() -> None:
     # Downstream GET fired twice -- the original 401 + the post-relogin retry.
     assert node_route.call_count == 2
     # The post-relogin XSRF replaced the stale one.
-    assert connector._session_tokens == {"nsx-a": "xsrf-second"}
+    assert connector._session_tokens == {target_cache_key(_TARGET_A): "xsrf-second"}
     await connector.aclose()
 
 
@@ -636,7 +699,7 @@ async def test_aclose_clears_session_token_cache_and_pool() -> None:
         )
         await connector.auth_headers(_TARGET_A, operator=_make_operator())
 
-    assert connector._session_tokens == {"nsx-a": "xsrf"}
+    assert connector._session_tokens == {target_cache_key(_TARGET_A): "xsrf"}
     await connector.aclose()
     assert connector._session_tokens == {}
     assert connector._clients == {}

--- a/backend/tests/test_connectors_nsx_credread.py
+++ b/backend/tests/test_connectors_nsx_credread.py
@@ -183,6 +183,7 @@ class _CredReadTarget:
         self.fingerprint = type("_FP", (), {"version": _VERSION})()
         self.preferred_impl_id: str | None = None
         self.id: UUID = uuid.uuid4()
+        self.tenant_id: UUID = UUID("00000000-0000-0000-0000-00000000a0a1")
         self.name = "nsx-credread"
         self.host = _NSX_HOST
         self.port = 443

--- a/backend/tests/test_connectors_nsx_e2e.py
+++ b/backend/tests/test_connectors_nsx_e2e.py
@@ -42,6 +42,7 @@ from sqlalchemy import select
 
 import meho_backplane.operations._audit as audit_module
 from meho_backplane.auth.operator import Operator, TenantRole
+from meho_backplane.connectors._shared.cache_key import target_cache_key
 from meho_backplane.connectors.nsx import (
     NSX_CONNECTOR_ID,
     NSX_CORE_OPS,
@@ -195,6 +196,7 @@ def _resolve_connector() -> NsxConnector:
 class _NsxE2EBundle:
     target_name: str
     connector_instance: NsxConnector
+    db_target: Any
 
 
 @pytest.fixture
@@ -212,7 +214,7 @@ async def nsx_e2e_canary(captured_events: list[Any]) -> AsyncIterator[_NsxE2EBun
        register the 9 read-op routes + session-create.
     """
     await _insert_nsx_descriptors()
-    await _seed_target()
+    seeded_target = await _seed_target()
     instance = _resolve_connector()
 
     async with respx.mock(
@@ -225,6 +227,7 @@ async def nsx_e2e_canary(captured_events: list[Any]) -> AsyncIterator[_NsxE2EBun
             yield _NsxE2EBundle(
                 target_name=_E2E_TARGET_NAME,
                 connector_instance=instance,
+                db_target=seeded_target,
             )
         finally:
             await instance.aclose()
@@ -361,8 +364,11 @@ async def test_nsx_e2e_session_establishes_on_first_dispatch(
     """
     instance = nsx_e2e_canary.connector_instance
     target_name = nsx_e2e_canary.target_name
+    # The session-token cache is keyed on the tenant-unique (tenant_id, id)
+    # tuple (#1642), not the bare name.
+    cache_key = target_cache_key(nsx_e2e_canary.db_target)
 
-    assert target_name not in instance._session_tokens, (
+    assert cache_key not in instance._session_tokens, (
         "Expected empty token cache before first dispatch; "
         f"got _session_tokens={instance._session_tokens!r}"
     )
@@ -377,7 +383,7 @@ async def test_nsx_e2e_session_establishes_on_first_dispatch(
         },
     )
     assert result["status"] == "ok"
-    assert instance._session_tokens.get(target_name) == "canary-xsrf-token", (
+    assert instance._session_tokens.get(cache_key) == "canary-xsrf-token", (
         f"Expected XSRF token cached after first dispatch; "
         f"got _session_tokens={instance._session_tokens!r}"
     )
@@ -425,7 +431,8 @@ async def test_nsx_e2e_401_retry_via_connector_method(
         f"Expected GET /api/v1/node called twice (401 + retry); "
         f"got call_count={bundle.node_route.call_count}"
     )
-    assert bundle.connector_instance._session_tokens.get(_E2E_TARGET_NAME) == "xsrf-second", (
+    cache_key = target_cache_key(bundle.db_target)
+    assert bundle.connector_instance._session_tokens.get(cache_key) == "xsrf-second", (
         f"Expected post-retry XSRF token to be 'xsrf-second'; "
         f"got _session_tokens={bundle.connector_instance._session_tokens!r}"
     )

--- a/backend/tests/test_connectors_sddc_manager_auth.py
+++ b/backend/tests/test_connectors_sddc_manager_auth.py
@@ -19,12 +19,13 @@ from __future__ import annotations
 import base64
 from collections.abc import Iterator
 from dataclasses import dataclass, field
-from uuid import UUID
+from uuid import UUID, uuid4
 
 import pytest
 import respx
 
 from meho_backplane.auth.operator import Operator, TenantRole
+from meho_backplane.connectors._shared.cache_key import target_cache_key
 from meho_backplane.connectors._shared.system_operator import (
     SYSTEM_OPERATOR_SUB,
     synthesise_system_operator,
@@ -88,6 +89,10 @@ class _StubTarget:
     secret_ref: str
     auth_model: str | None = AuthModel.SHARED_SERVICE_ACCOUNT.value
     sso_realm: str = field(default="vsphere.local")
+    # Tenant-unique cache key components (#1642). Distinct ``id`` per
+    # instance so two stub targets never collapse onto one cache entry.
+    id: UUID = field(default_factory=uuid4)
+    tenant_id: UUID = field(default_factory=lambda: UUID(int=0))
 
 
 _TARGET_A = _StubTarget(
@@ -336,6 +341,63 @@ async def test_per_target_isolation_keeps_credentials_separate() -> None:
     await connector.aclose()
 
 
+@pytest.mark.asyncio
+async def test_same_name_targets_in_different_tenants_get_distinct_credentials() -> None:
+    """Same-named targets in DIFFERENT tenants never share a cached credential.
+
+    Regression guard for #1642: the credential cache used to key on
+    ``target.name`` alone, so two same-named targets in different tenants
+    collapsed onto one entry and one tenant could be served another
+    tenant's cached credential. The cache keys on the tenant-unique
+    ``(tenant_id, id)`` tuple instead.
+    """
+    load_count = 0
+
+    async def _counting_loader(target: SddcTargetLike, _operator: Operator) -> dict[str, str]:
+        nonlocal load_count
+        load_count += 1
+        return {"username": f"svc-{target.tenant_id}", "password": "pass"}
+
+    tenant_one = _StubTarget(
+        name="sddc-shared",
+        host="sddc-shared.test.invalid",
+        port=443,
+        secret_ref="sddc/sddc-shared",
+        id=UUID(int=0x1),
+        tenant_id=UUID(int=0x100),
+    )
+    tenant_two = _StubTarget(
+        name="sddc-shared",
+        host="sddc-shared.test.invalid",
+        port=443,
+        secret_ref="sddc/sddc-shared",
+        id=UUID(int=0x2),
+        tenant_id=UUID(int=0x200),
+    )
+
+    connector = SddcManagerConnector(credentials_loader=_counting_loader)
+    h_one = await connector.auth_headers(tenant_one, operator=_make_operator())
+    h_two = await connector.auth_headers(tenant_two, operator=_make_operator())
+
+    user_one, _ = _decode_basic_auth(h_one["Authorization"])
+    user_two, _ = _decode_basic_auth(h_two["Authorization"])
+    # Each tenant triggered its own load -- no cross-tenant cache hit.
+    assert load_count == 2
+    assert user_one == f"svc-{tenant_one.tenant_id}@vsphere.local"
+    assert user_two == f"svc-{tenant_two.tenant_id}@vsphere.local"
+    assert user_one != user_two
+    assert connector._creds_cache.keys() == {
+        target_cache_key(tenant_one),
+        target_cache_key(tenant_two),
+    }
+
+    # Same-tenant re-fetch is a cache HIT -- behaviour unchanged.
+    h_one_again = await connector.auth_headers(tenant_one, operator=_make_operator())
+    assert h_one_again == h_one
+    assert load_count == 2
+    await connector.aclose()
+
+
 # ---------------------------------------------------------------------------
 # Credential loading failure modes
 # ---------------------------------------------------------------------------
@@ -559,7 +621,7 @@ async def test_aclose_clears_credential_cache_and_pool() -> None:
     """aclose() clears the in-memory credential cache and tears down the httpx pool."""
     connector = _make_connector()
     await connector.auth_headers(_TARGET_A, operator=_make_operator())
-    assert "sddc-a" in connector._creds_cache
+    assert target_cache_key(_TARGET_A) in connector._creds_cache
     await connector.aclose()
     assert connector._creds_cache == {}
     assert connector._clients == {}

--- a/backend/tests/test_connectors_sddc_manager_credread.py
+++ b/backend/tests/test_connectors_sddc_manager_credread.py
@@ -183,6 +183,7 @@ class _CredReadTarget:
         self.fingerprint = type("_FP", (), {"version": _VERSION})()
         self.preferred_impl_id: str | None = None
         self.id: UUID = uuid.uuid4()
+        self.tenant_id: UUID = UUID("00000000-0000-0000-0000-00000000a0a3")
         self.name = "sddc-credread"
         self.host = _SDDC_HOST
         self.port = 443

--- a/backend/tests/test_connectors_sddc_manager_e2e.py
+++ b/backend/tests/test_connectors_sddc_manager_e2e.py
@@ -38,6 +38,7 @@ from sqlalchemy import select
 
 import meho_backplane.operations._audit as audit_module
 from meho_backplane.auth.operator import Operator, TenantRole
+from meho_backplane.connectors._shared.cache_key import target_cache_key
 from meho_backplane.connectors.registry import all_connectors_v2
 from meho_backplane.connectors.sddc_manager import (
     SDDC_CONNECTOR_ID,
@@ -176,6 +177,7 @@ def _resolve_connector() -> SddcManagerConnector:
 class _SddcE2EBundle:
     target_name: str
     connector_instance: SddcManagerConnector
+    db_target: Any
 
 
 @pytest.fixture
@@ -193,7 +195,7 @@ async def sddc_e2e_canary(captured_events: list[Any]) -> AsyncIterator[_SddcE2EB
        register the 9 read-op routes.
     """
     await _insert_sddc_descriptors()
-    await _seed_target()
+    seeded_target = await _seed_target()
     instance = _resolve_connector()
 
     async with respx.mock(
@@ -206,6 +208,7 @@ async def sddc_e2e_canary(captured_events: list[Any]) -> AsyncIterator[_SddcE2EB
             yield _SddcE2EBundle(
                 target_name=_E2E_TARGET_NAME,
                 connector_instance=instance,
+                db_target=seeded_target,
             )
         finally:
             await instance.aclose()
@@ -259,8 +262,11 @@ async def test_sddc_e2e_credentials_cached_after_first_dispatch(
     """
     instance = sddc_e2e_canary.connector_instance
     target_name = sddc_e2e_canary.target_name
+    # The credential cache is keyed on the tenant-unique (tenant_id, id)
+    # tuple (#1642), not the bare name.
+    cache_key = target_cache_key(sddc_e2e_canary.db_target)
 
-    assert target_name not in instance._creds_cache, (
+    assert cache_key not in instance._creds_cache, (
         "Expected empty credential cache before first dispatch; "
         f"got _creds_cache={list(instance._creds_cache.keys())!r}"
     )
@@ -275,7 +281,7 @@ async def test_sddc_e2e_credentials_cached_after_first_dispatch(
         },
     )
     assert result["status"] == "ok"
-    assert target_name in instance._creds_cache, (
+    assert cache_key in instance._creds_cache, (
         "Expected credentials cached after first dispatch; "
         f"got _creds_cache={list(instance._creds_cache.keys())!r}"
     )

--- a/backend/tests/test_connectors_vcf_fleet_auth.py
+++ b/backend/tests/test_connectors_vcf_fleet_auth.py
@@ -26,8 +26,8 @@ from __future__ import annotations
 
 import base64
 from collections.abc import Iterator
-from dataclasses import dataclass
-from uuid import UUID
+from dataclasses import dataclass, field
+from uuid import UUID, uuid4
 
 import httpx
 import pytest
@@ -99,6 +99,10 @@ class _StubTarget:
     port: int | None
     secret_ref: str
     auth_model: str | None = AuthModel.SHARED_SERVICE_ACCOUNT.value
+    # Tenant-unique cache key components (#1642). Distinct ``id`` per
+    # instance so two stub targets never collapse onto one cache entry.
+    id: UUID = field(default_factory=uuid4)
+    tenant_id: UUID = field(default_factory=lambda: UUID(int=0))
 
 
 _TARGET_A = _StubTarget(

--- a/backend/tests/test_connectors_vcf_fleet_credread.py
+++ b/backend/tests/test_connectors_vcf_fleet_credread.py
@@ -158,6 +158,7 @@ class _CredReadTarget:
         self.fingerprint = type("_FP", (), {"version": _VERSION})()
         self.preferred_impl_id: str | None = None
         self.id: UUID = uuid.uuid4()
+        self.tenant_id: UUID = UUID("00000000-0000-0000-0000-00000000a0a3")
         self.name = "fleet-credread"
         self.host = _FLEET_HOST
         self.port = 443

--- a/backend/tests/test_connectors_vcf_fleet_e2e.py
+++ b/backend/tests/test_connectors_vcf_fleet_e2e.py
@@ -50,6 +50,7 @@ from sqlalchemy import select
 
 import meho_backplane.operations._audit as audit_module
 from meho_backplane.auth.operator import Operator, TenantRole
+from meho_backplane.connectors._shared.cache_key import target_cache_key
 from meho_backplane.connectors.registry import all_connectors_v2
 from meho_backplane.connectors.vcf_fleet import (
     FLEET_CONNECTOR_ID,
@@ -210,6 +211,7 @@ def _resolve_connector() -> VcfFleetConnector:
 class _FleetE2EBundle:
     target_name: str
     connector_instance: VcfFleetConnector
+    db_target: Any
 
 
 @pytest.fixture
@@ -228,7 +230,7 @@ async def fleet_e2e_canary(captured_events: list[Any]) -> AsyncIterator[_FleetE2
        register the 8 read-op routes.
     """
     await _insert_fleet_descriptors()
-    await _seed_target()
+    seeded_target = await _seed_target()
     instance = _resolve_connector()
 
     async with respx.mock(
@@ -241,6 +243,7 @@ async def fleet_e2e_canary(captured_events: list[Any]) -> AsyncIterator[_FleetE2
             yield _FleetE2EBundle(
                 target_name=FLEET_TARGET_NAME,
                 connector_instance=instance,
+                db_target=seeded_target,
             )
         finally:
             await instance.aclose()
@@ -298,13 +301,13 @@ async def test_fleet_e2e_credentials_cached_after_first_dispatch(
     """
     instance = fleet_e2e_canary.connector_instance
     target_name = fleet_e2e_canary.target_name
-
     # The CredentialsCache exposes the underlying dict via ``_cache``; the
     # SDDC Manager precedent uses ``_creds_cache`` because its connector
-    # caches the dict directly. The cache key is the target name (set by
-    # ``CredentialsCache.get(target)``).
+    # caches the dict directly. The cache key is the tenant-unique
+    # (tenant_id, id) tuple (#1642), set by ``CredentialsCache.get(target)``.
+    cache_key = target_cache_key(fleet_e2e_canary.db_target)
     initial_keys = list(instance._creds._cache.keys())  # type: ignore[attr-defined]
-    assert target_name not in initial_keys, (
+    assert cache_key not in initial_keys, (
         f"Expected empty credential cache before first dispatch; got keys={initial_keys!r}"
     )
 
@@ -319,7 +322,7 @@ async def test_fleet_e2e_credentials_cached_after_first_dispatch(
     )
     assert result["status"] == "ok"
     after_first_keys = list(instance._creds._cache.keys())  # type: ignore[attr-defined]
-    assert target_name in after_first_keys, (
+    assert cache_key in after_first_keys, (
         f"Expected credentials cached after first dispatch; got keys={after_first_keys!r}"
     )
 

--- a/backend/tests/test_connectors_vcf_logs_auth.py
+++ b/backend/tests/test_connectors_vcf_logs_auth.py
@@ -32,14 +32,15 @@ divergence: JSON body (not form), provider field, sessionId in body
 from __future__ import annotations
 
 from collections.abc import Iterator
-from dataclasses import dataclass
-from uuid import UUID
+from dataclasses import dataclass, field
+from uuid import UUID, uuid4
 
 import httpx
 import pytest
 import respx
 
 from meho_backplane.auth.operator import Operator, TenantRole
+from meho_backplane.connectors._shared.cache_key import target_cache_key
 from meho_backplane.connectors._shared.vcf_auth import VcfTargetLike
 from meho_backplane.connectors.adapters.http import HttpConnector
 from meho_backplane.connectors.registry import (
@@ -106,6 +107,10 @@ class _StubTarget:
     secret_ref: str
     auth_model: str | None = AuthModel.SHARED_SERVICE_ACCOUNT.value
     provider: str | None = None
+    # Tenant-unique cache key components (#1642). Distinct ``id`` per
+    # instance so two stub targets never collapse onto one cache entry.
+    id: UUID = field(default_factory=uuid4)
+    tenant_id: UUID = field(default_factory=lambda: UUID(int=0))
 
 
 _TARGET_A = _StubTarget(
@@ -307,8 +312,8 @@ async def test_per_target_isolation_keeps_session_tokens_separate() -> None:
     assert h_a == {"Authorization": "Bearer token-a"}
     assert h_b == {"Authorization": "Bearer token-b"}
     assert connector._session_tokens == {
-        "vrli-a": "token-a",
-        "vrli-b": "token-b",
+        target_cache_key(_TARGET_A): "token-a",
+        target_cache_key(_TARGET_B): "token-b",
     }
     await connector.aclose()
 
@@ -500,7 +505,7 @@ async def test_downstream_401_triggers_relogin_and_retry_once() -> None:
     # Downstream GET fired twice -- the original 401 + the post-relogin retry.
     assert events_route.call_count == 2
     # The post-relogin token replaced the stale one.
-    assert connector._session_tokens == {"vrli-a": "token-second"}
+    assert connector._session_tokens == {target_cache_key(_TARGET_A): "token-second"}
     # Both downstream GETs carried Bearer headers (first the stale
     # token, second the refreshed one).
     requests = events_route.calls
@@ -684,9 +689,9 @@ async def test_aclose_clears_session_token_cache_and_credentials_and_pool() -> N
         mock.post("/api/v2/sessions").respond(200, json={"sessionId": "token", "ttl": 1800})
         await connector.auth_headers(_TARGET_A, operator=_make_operator())
 
-    assert connector._session_tokens == {"vrli-a": "token"}
+    assert connector._session_tokens == {target_cache_key(_TARGET_A): "token"}
     # Credentials cache should also be populated after the first call.
-    assert "vrli-a" in connector._credentials.cached_targets
+    assert target_cache_key(_TARGET_A) in connector._credentials.cached_targets
     await connector.aclose()
     assert connector._session_tokens == {}
     assert connector._credentials.cached_targets == frozenset()

--- a/backend/tests/test_connectors_vcf_logs_credread.py
+++ b/backend/tests/test_connectors_vcf_logs_credread.py
@@ -57,6 +57,7 @@ from structlog.testing import capture_logs
 import meho_backplane.operations._audit as audit_module
 from meho_backplane.auth.operator import Operator, TenantRole
 from meho_backplane.broadcast import BroadcastEvent
+from meho_backplane.connectors._shared.cache_key import target_cache_key
 from meho_backplane.connectors._shared.vault_creds import VaultCredentialsReadError
 from meho_backplane.connectors.registry import clear_registry, register_connector_v2
 from meho_backplane.connectors.vcf_logs import VcfLogsConnector
@@ -170,6 +171,7 @@ class _CredReadTarget:
         self.fingerprint = type("_FP", (), {"version": _VERSION})()
         self.preferred_impl_id: str | None = None
         self.id: UUID = uuid.uuid4()
+        self.tenant_id: UUID = UUID("00000000-0000-0000-0000-00000000a0a2")
         self.name = "vrli-credread"
         self.host = _VRLI_HOST
         self.port = 443
@@ -427,7 +429,7 @@ async def test_session_token_fast_path_fails_closed_on_empty_raw_jwt() -> None:
         mock.post(_SESSION_PATH).respond(200, json={"sessionId": _SESSION_TOKEN, "ttl": 1800})
         primed = await connector._session_token(target, _make_operator())
     assert primed == _SESSION_TOKEN
-    assert connector._session_tokens[target.name] == _SESSION_TOKEN
+    assert connector._session_tokens[target_cache_key(target)] == _SESSION_TOKEN
 
     system_operator = Operator(
         sub="system",
@@ -444,6 +446,6 @@ async def test_session_token_fast_path_fails_closed_on_empty_raw_jwt() -> None:
     assert "operator" in str(exc_info.value).lower()
     # The cache still holds the primed token; the guard ran ahead of
     # any cache mutation.
-    assert connector._session_tokens[target.name] == _SESSION_TOKEN
+    assert connector._session_tokens[target_cache_key(target)] == _SESSION_TOKEN
 
     await connector.aclose()

--- a/backend/tests/test_connectors_vcf_logs_e2e.py
+++ b/backend/tests/test_connectors_vcf_logs_e2e.py
@@ -68,6 +68,7 @@ from sqlalchemy import select
 
 import meho_backplane.operations._audit as audit_module
 from meho_backplane.auth.operator import Operator, TenantRole
+from meho_backplane.connectors._shared.cache_key import target_cache_key
 from meho_backplane.connectors.registry import all_connectors_v2
 from meho_backplane.connectors.vcf_logs import (
     VRLI_CONNECTOR_ID,
@@ -234,6 +235,7 @@ def _resolve_connector() -> VcfLogsConnector:
 class _VrliE2EBundle:
     target_name: str
     connector_instance: VcfLogsConnector
+    db_target: Any
 
 
 @pytest.fixture
@@ -242,7 +244,7 @@ async def vrli_e2e_canary(captured_events: list[Any]) -> AsyncIterator[_VrliE2EB
     del captured_events  # the fixture's side-effect is the patched publisher
 
     await _insert_vrli_descriptors()
-    await _seed_target()
+    seeded_target = await _seed_target()
     instance = _resolve_connector()
 
     async with respx.mock(
@@ -255,6 +257,7 @@ async def vrli_e2e_canary(captured_events: list[Any]) -> AsyncIterator[_VrliE2EB
             yield _VrliE2EBundle(
                 target_name=_E2E_TARGET_NAME,
                 connector_instance=instance,
+                db_target=seeded_target,
             )
         finally:
             await instance.aclose()
@@ -430,8 +433,11 @@ async def test_vrli_e2e_session_establishes_on_first_dispatch(
     """
     instance = vrli_e2e_canary.connector_instance
     target_name = vrli_e2e_canary.target_name
+    # The session-token cache is keyed on the tenant-unique (tenant_id, id)
+    # tuple (#1642), not the bare name.
+    cache_key = target_cache_key(vrli_e2e_canary.db_target)
 
-    assert target_name not in instance._session_tokens, (
+    assert cache_key not in instance._session_tokens, (
         "Expected empty token cache before first dispatch; "
         f"got _session_tokens={instance._session_tokens!r}"
     )
@@ -446,7 +452,7 @@ async def test_vrli_e2e_session_establishes_on_first_dispatch(
         },
     )
     assert result["status"] == "ok"
-    assert instance._session_tokens.get(target_name) == VRLI_CANARY_SESSION_ID, (
+    assert instance._session_tokens.get(cache_key) == VRLI_CANARY_SESSION_ID, (
         f"Expected vRLI session token cached after first dispatch; "
         f"got _session_tokens={instance._session_tokens!r}"
     )
@@ -500,7 +506,7 @@ async def test_vrli_e2e_401_recovery_via_connector_method(
         f"Expected GET /api/v2/version called twice (401 + retry); "
         f"got call_count={bundle.version_route.call_count}"
     )
-    cached = bundle.connector_instance._session_tokens.get(_E2E_TARGET_NAME)
+    cached = bundle.connector_instance._session_tokens.get(target_cache_key(bundle.db_target))
     assert cached == VRLI_CANARY_SESSION_REFRESH_ID, (
         f"Expected post-retry token to be the refreshed id {VRLI_CANARY_SESSION_REFRESH_ID!r}; "
         f"got cached token {cached!r}"

--- a/backend/tests/test_connectors_vcf_operations_auth.py
+++ b/backend/tests/test_connectors_vcf_operations_auth.py
@@ -18,13 +18,14 @@ from __future__ import annotations
 import asyncio
 import base64
 from collections.abc import Iterator
-from dataclasses import dataclass
-from uuid import UUID
+from dataclasses import dataclass, field
+from uuid import UUID, uuid4
 
 import pytest
 import respx
 
 from meho_backplane.auth.operator import Operator, TenantRole
+from meho_backplane.connectors._shared.cache_key import target_cache_key
 from meho_backplane.connectors._shared.vcf_auth import VcfTargetLike
 from meho_backplane.connectors.adapters.http import HttpConnector
 from meho_backplane.connectors.registry import (
@@ -91,6 +92,10 @@ class _StubTarget:
     secret_ref: str
     auth_model: str | None = AuthModel.SHARED_SERVICE_ACCOUNT.value
     auth_source: str | None = None
+    # Tenant-unique cache key components (#1642). Distinct ``id`` per
+    # instance so two stub targets never collapse onto one cache entry.
+    id: UUID = field(default_factory=uuid4)
+    tenant_id: UUID = field(default_factory=lambda: UUID(int=0))
 
 
 _TARGET_A = _StubTarget(
@@ -539,7 +544,7 @@ async def test_aclose_clears_credential_cache_and_pool() -> None:
     """aclose() clears the in-memory credential cache and tears down the httpx pool."""
     connector = _make_connector()
     await connector.auth_headers(_TARGET_A, operator=_make_operator())
-    assert "vrops-a" in connector._creds.cached_targets
+    assert target_cache_key(_TARGET_A) in connector._creds.cached_targets
     await connector.aclose()
     assert connector._creds.cached_targets == frozenset()
     assert connector._clients == {}

--- a/backend/tests/test_connectors_vcf_operations_credread.py
+++ b/backend/tests/test_connectors_vcf_operations_credread.py
@@ -194,6 +194,7 @@ class _CredReadTarget:
         self.fingerprint = type("_FP", (), {"version": _VERSION})()
         self.preferred_impl_id: str | None = None
         self.id: UUID = uuid.uuid4()
+        self.tenant_id: UUID = UUID("00000000-0000-0000-0000-00000000a0a1")
         self.name = "vrops-credread"
         self.host = _VROPS_HOST
         self.port = 443

--- a/backend/tests/test_connectors_vcf_operations_e2e.py
+++ b/backend/tests/test_connectors_vcf_operations_e2e.py
@@ -57,6 +57,7 @@ from sqlalchemy import select
 
 import meho_backplane.operations._audit as audit_module
 from meho_backplane.auth.operator import Operator, TenantRole
+from meho_backplane.connectors._shared.cache_key import target_cache_key
 from meho_backplane.connectors.registry import all_connectors_v2
 from meho_backplane.connectors.vcf_operations import (
     VROPS_CONNECTOR_ID,
@@ -211,6 +212,7 @@ def _resolve_connector() -> VcfOperationsConnector:
 class _VropsE2EBundle:
     target_name: str
     connector_instance: VcfOperationsConnector
+    db_target: Any
 
 
 @pytest.fixture
@@ -231,7 +233,7 @@ async def vcf_operations_e2e_canary(captured_events: list[Any]) -> AsyncIterator
        payloads.
     """
     await _insert_vrops_descriptors()
-    await _seed_target()
+    seeded_target = await _seed_target()
     instance = _resolve_connector()
 
     async with respx.mock(
@@ -244,6 +246,7 @@ async def vcf_operations_e2e_canary(captured_events: list[Any]) -> AsyncIterator
             yield _VropsE2EBundle(
                 target_name=_E2E_TARGET_NAME,
                 connector_instance=instance,
+                db_target=seeded_target,
             )
         finally:
             await instance.aclose()
@@ -306,9 +309,11 @@ async def test_vcf_operations_e2e_credentials_cached_after_first_dispatch(
     """
     instance = vcf_operations_e2e_canary.connector_instance
     target_name = vcf_operations_e2e_canary.target_name
+    # The shared CredentialsCache holds entries keyed by the tenant-unique
+    # (tenant_id, id) tuple (#1642), not the bare name.
+    cache_key = target_cache_key(vcf_operations_e2e_canary.db_target)
 
-    # The shared CredentialsCache holds entries keyed by target name.
-    assert target_name not in instance._creds._cache, (
+    assert cache_key not in instance._creds._cache, (
         "Expected empty credential cache before first dispatch; "
         f"got _creds._cache={list(instance._creds._cache.keys())!r}"
     )
@@ -323,7 +328,7 @@ async def test_vcf_operations_e2e_credentials_cached_after_first_dispatch(
         },
     )
     assert result["status"] == "ok"
-    assert target_name in instance._creds._cache, (
+    assert cache_key in instance._creds._cache, (
         "Expected credentials cached after first dispatch; "
         f"got _creds._cache={list(instance._creds._cache.keys())!r}"
     )

--- a/backend/tests/test_connectors_vcf_shared_auth.py
+++ b/backend/tests/test_connectors_vcf_shared_auth.py
@@ -23,7 +23,7 @@ from __future__ import annotations
 import base64
 import json
 from collections.abc import AsyncIterator
-from dataclasses import dataclass
+from dataclasses import dataclass, field
 from uuid import UUID
 
 import httpx
@@ -31,6 +31,7 @@ import pytest
 import respx
 
 from meho_backplane.auth.operator import Operator, TenantRole
+from meho_backplane.connectors._shared.cache_key import target_cache_key
 from meho_backplane.connectors._shared.vault_creds import VaultCredentialsReadError
 from meho_backplane.connectors._shared.vcf_auth import (
     CredentialsCache,
@@ -55,6 +56,8 @@ class _StubTarget:
     port: int | None
     secret_ref: str | None
     auth_model: str | None = AuthModel.SHARED_SERVICE_ACCOUNT.value
+    id: UUID = field(default_factory=lambda: UUID(int=1))
+    tenant_id: UUID = field(default_factory=lambda: UUID(int=0))
 
 
 def _make_operator(raw_jwt: str = "op.test.jwt") -> Operator:
@@ -74,12 +77,16 @@ _TARGET_A = _StubTarget(
     host="vrops-a.test.invalid",
     port=443,
     secret_ref="vcf-operations/vrops-a",
+    id=UUID(int=0xA),
+    tenant_id=UUID(int=0),
 )
 _TARGET_B = _StubTarget(
     name="vrops-b",
     host="vrops-b.test.invalid",
     port=443,
     secret_ref="vcf-operations/vrops-b",
+    id=UUID(int=0xB),
+    tenant_id=UUID(int=0),
 )
 
 
@@ -298,7 +305,64 @@ async def test_credentials_cache_isolates_per_target() -> None:
     assert a["username"] == "svc-vrops-a"
     assert b["username"] == "svc-vrops-b"
     assert call_log == ["vrops-a", "vrops-b"]
-    assert cache.cached_targets == frozenset({"vrops-a", "vrops-b"})
+    assert cache.cached_targets == frozenset(
+        {target_cache_key(_TARGET_A), target_cache_key(_TARGET_B)}
+    )
+
+
+@pytest.mark.asyncio
+async def test_credentials_cache_isolates_same_name_across_tenants() -> None:
+    """Two same-named targets in DIFFERENT tenants get distinct cache entries.
+
+    Regression guard for #1642: keying the cache on ``target.name`` alone
+    collapsed same-named targets across tenants onto one entry, so one
+    tenant could be served another tenant's cached credential. The cache
+    is keyed on the tenant-unique ``(tenant_id, id)`` tuple instead.
+    """
+    load_count = 0
+
+    async def _counting_loader(target: VcfTargetLike, _operator: Operator) -> dict[str, str]:
+        nonlocal load_count
+        load_count += 1
+        # Username encodes the tenant so a cross-tenant cache hit is
+        # observable in the returned credential, not just the load count.
+        return {"username": f"svc-{target.tenant_id}", "password": "pass"}
+
+    # Same NAME, same id-shape, but two different tenants.
+    tenant_one = _StubTarget(
+        name="shared-name",
+        host="appliance-one.test.invalid",
+        port=443,
+        secret_ref="vcf/shared-name",
+        id=UUID(int=0x1),
+        tenant_id=UUID(int=0x100),
+    )
+    tenant_two = _StubTarget(
+        name="shared-name",
+        host="appliance-two.test.invalid",
+        port=443,
+        secret_ref="vcf/shared-name",
+        id=UUID(int=0x2),
+        tenant_id=UUID(int=0x200),
+    )
+
+    cache = CredentialsCache(_counting_loader, product_label="vrops")
+    creds_one = await cache.get(tenant_one, _make_operator())
+    creds_two = await cache.get(tenant_two, _make_operator())
+
+    # Each tenant triggered its own load — no cross-tenant cache hit.
+    assert load_count == 2
+    assert creds_one["username"] == f"svc-{tenant_one.tenant_id}"
+    assert creds_two["username"] == f"svc-{tenant_two.tenant_id}"
+    assert creds_one != creds_two
+    assert cache.cached_targets == frozenset(
+        {target_cache_key(tenant_one), target_cache_key(tenant_two)}
+    )
+
+    # Same-tenant re-fetch is a cache HIT — behaviour unchanged.
+    creds_one_again = await cache.get(tenant_one, _make_operator())
+    assert load_count == 2
+    assert creds_one_again == creds_one
 
 
 @pytest.mark.asyncio
@@ -307,7 +371,7 @@ async def test_credentials_cache_invalidate_drops_only_that_target() -> None:
     await cache.get(_TARGET_A, _make_operator())
     await cache.get(_TARGET_B, _make_operator())
     await cache.invalidate(_TARGET_A)
-    assert cache.cached_targets == frozenset({"vrops-b"})
+    assert cache.cached_targets == frozenset({target_cache_key(_TARGET_B)})
 
 
 @pytest.mark.asyncio


### PR DESCRIPTION
## Summary

Task **T3** of the cross-tenant isolation hardening batch (Goal #214).

The VCF (vROps / vRLI / Fleet), Harbor, NSX, and SDDC-Manager connectors keyed their per-target **credential** and **session-token** caches on `target.name`. Targets are unique only on `(tenant_id, name)`, so two same-named targets in **different tenants collapsed onto one cache entry** — one tenant could be served another tenant's cached service-account credential or session token. This is a cross-tenant isolation break.

### What changed

- New shared helper `connectors/_shared/cache_key.py` → `target_cache_key(target)` returns the tenant-unique `(str(tenant_id), str(id))` tuple. `id` is the targets-table PK and `(tenant_id, name)` its only uniqueness constraint, so `(tenant_id, id)` uniquely identifies a target row across all tenants.
- Re-keyed every affected cache on it:
  - `CredentialsCache` (shared by vROps / vRLI / Fleet) — `_cache`
  - Harbor / SDDC-Manager — `_creds_cache`
  - NSX / vRLI — `_session_tokens`
- Widened the `*TargetLike` protocols (`VcfTargetLike` + vROps/vRLI/Fleet siblings, `HarborTargetLike`, `NsxTargetLike`, `SddcTargetLike`) with `id` + `tenant_id` so mypy stays honest. The concrete `Target` model (UUID `id` PK + NOT-NULL UUID `tenant_id`) satisfies them unchanged.
- The widened key is strictly more specific → **same-tenant hit/miss behaviour is unchanged**.

### Deliberately out of scope

The shared `HttpConnector._clients` pool keeps its `target.name` key. Re-keying it reaches **every** HTTP connector (incl. out-of-scope `vmware_rest`, which reads the pool directly) and is a connection-pooling concern, not the credential/session isolation this task targets. NSX's cookie-jar invalidation reads that pool by name accordingly. (The other name-keyed token caches — vcf_automation, argocd, gcloud, ssh, keycloak, vmware_rest, github, hetzner_robot — are separate connectors outside this task's four-family scope.)

No FastAPI route/schema touched → no OpenAPI snapshot regen needed.

## Test plan

- **New regression tests** (one per cache flavour) prove two same-named targets in **different tenants get distinct cache entries**, and that a same-tenant re-fetch is still a cache hit:
  - `test_credentials_cache_isolates_same_name_across_tenants` (shared `CredentialsCache`)
  - `test_same_name_targets_in_different_tenants_get_distinct_sessions` (NSX session token)
  - `test_same_name_targets_in_different_tenants_get_distinct_credentials` (Harbor + SDDC)
- Existing connector test fixtures gained `id`/`tenant_id`; cache-key assertions moved to `target_cache_key(...)` (incl. the e2e bundles, which now expose the seeded DB target).
- Gates (all green):
  - `ruff check` / `ruff format --check` — clean on all 32 changed files
  - `mypy src/meho_backplane/connectors/ --ignore-missing-imports` — **Success, no issues** (widened protocols)
  - Full connector test surface: **2642 passed, 0 failed** (`pytest -k "connector or vcf or nsx or harbor or sddc or fleet or vrli or vrops"`)
  - code-quality `--diff` hook — exit 0 (0 blockers)

Closes #1642