### PR TITLE
fix(operations): unwrap ingested L2 requestBody container param on the wire (#1656)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -173,6 +173,18 @@ connector-related release-notes line.
 
 ### Fixed
 
+- An ingested **L2** write op no longer mangles its HTTP request body: the
+  dispatcher now serializes the single `x-meho-param-loc: "body"` container
+  param's *value* as the JSON body (unwrapped) on every body-carrying arm,
+  instead of wrapping it under the param name (`{"body": {…}}`). Every
+  ingested-L2 REST write (gh-rest issue-create / issue-comment / add-labels /
+  create-PR, …) previously 422'd because the upstream saw the requestBody
+  schema nested one level too deep; a gh-rest issue-create with
+  `body: {"title": "X"}` now sends exactly `{"title": "X"}` on the wire.
+  Generic to all ingested-L2 connectors with a requestBody; reads (no body)
+  and path/query/header routing are unchanged. Diagnoses the RDC log-sentry
+  issue-filing finding (`gh api` 201 vs meho 422 on identical `{title}`);
+  see claude-rdc-hetzner-dc#1138. (#1656)
 - A failed park-time `proposed_effect` preview no longer degrades
   silently to the identifier-only default: the parked approval now
   carries `preview_unavailable: true` plus a `preview_error` reason

--- a/backend/src/meho_backplane/operations/_branches.py
+++ b/backend/src/meho_backplane/operations/_branches.py
@@ -96,6 +96,36 @@ def _split_ingested_params(
     return path_params, query_params, header_params, body_params
 
 
+def _unwrap_body(body_params: dict[str, Any]) -> Any:
+    """Return the request body to send for the ``loc=="body"`` bucket.
+
+    An ingested op models its OpenAPI ``requestBody`` as a *single*
+    parameter (named ``body``, tagged ``x-meho-param-loc: "body"`` by the
+    G0.7 ingester -- see ``ingest.openapi``'s parameter-schema builder).
+    :func:`_split_ingested_params` collects it into ``body_params`` keyed
+    by that parameter name. The HTTP request body is that param's
+    **value** -- not a ``{name: value}`` wrapper. Returning the wrapper
+    would serialize ``{"body": {"title": "X"}}`` onto the wire, so an
+    upstream that expects the requestBody schema at the top level (GitHub's
+    issue-create wants ``{"title": "X"}``) rejects it as malformed (422).
+
+    Empty bucket -> ``None`` (no body; httpx omits the request body).
+    Exactly one entry -> its value, unwrapped. The single-entry shape is
+    an ingest invariant; should a malformed descriptor ever carry more
+    than one ``loc=="body"`` property, fail loudly rather than silently
+    pick one and send a body the caller never asked for.
+    """
+    if not body_params:
+        return None
+    if len(body_params) > 1:
+        raise RuntimeError(
+            "ingested op declares multiple 'body' params "
+            f"{sorted(body_params)!r}; requestBody must be a single container "
+            "param (x-meho-param-loc='body'). This is an ingest-modelling fault."
+        )
+    return next(iter(body_params.values()))
+
+
 def _substitute_path(path_template: str, path_params: dict[str, Any]) -> str:
     """Substitute ``{var}`` placeholders in *path_template* from *path_params*.
 
@@ -181,7 +211,7 @@ async def dispatch_ingested(
             substituted,
             operator=operator,
             params=query_params or None,
-            json=body_params or None,
+            json=_unwrap_body(body_params),
         )
     # Non-idempotent verb -- POST / PUT / PATCH / DELETE. v0.2 routes
     # through ``_post_json``-shaped httpx call (no retry). The connector
@@ -196,7 +226,7 @@ async def dispatch_ingested(
         target,
         substituted,
         operator=operator,
-        json=body_params or None,
+        json=_unwrap_body(body_params),
     )
 
 

--- a/backend/tests/test_operations_dispatcher.py
+++ b/backend/tests/test_operations_dispatcher.py
@@ -1151,6 +1151,197 @@ async def test_dispatch_ingested_builds_request_via_request_json(
 
 
 # ---------------------------------------------------------------------------
+# Ingested write-body round-trip (#1656): the ``loc=="body"`` container
+# param's *value* must go on the wire unwrapped. Drives the REAL
+# ``HttpConnector._post_json`` httpx transport and captures the outbound
+# request with respx, so the assertion is on the actual bytes a vendor API
+# (here gh-rest issue-create) would receive — not a mocked transport seam.
+# ---------------------------------------------------------------------------
+
+
+class _RoundTripHttpConnector(HttpConnector):
+    """Ingested-dispatch fixture exercising the real httpx ``_post_json``.
+
+    Unlike :class:`_FakeHttpConnector` (which records ``_request_json``
+    calls), this connector keeps :class:`HttpConnector`'s real transport so
+    the request is genuinely serialized and sent — respx intercepts it at
+    the wire. Only ``auth_headers`` and the three ABC methods are
+    overridden; ``_base_url`` derives ``https://{target.host}`` from the
+    target, which the test mocks via ``respx.mock(base_url=...)``.
+    """
+
+    product = "gh"
+    version = "3.0"
+    impl_id = "gh-rest"
+    supported_version_range = ">=3.0,<4.0"
+
+    async def fingerprint(self, target: Any, operator: Any = None) -> FingerprintResult:  # type: ignore[override]
+        raise NotImplementedError
+
+    async def probe(self, target: Any) -> ProbeResult:  # type: ignore[override]
+        raise NotImplementedError
+
+    async def execute(  # type: ignore[override]
+        self,
+        target: Any,
+        op_id: str,
+        params: dict[str, Any],
+    ) -> OperationResult:
+        raise NotImplementedError
+
+    async def auth_headers(  # type: ignore[override]
+        self,
+        target: Any,
+        operator: Operator,
+    ) -> dict[str, str]:
+        return {"authorization": "Bearer test-token"}
+
+
+def _gh_issue_create_descriptor(embedding: Any) -> Any:
+    """Build a gh-rest ``POST:/repos/{owner}/{repo}/issues`` ingested descriptor.
+
+    Mirrors the G0.7 ingester's output shape: ``owner``/``repo`` are
+    ``x-meho-param-loc='path'`` and the requestBody is a single ``body``
+    property tagged ``x-meho-param-loc='body'`` (see ``ingest.openapi``).
+    """
+    from datetime import UTC, datetime
+
+    from meho_backplane.db.models import EndpointDescriptor
+
+    return EndpointDescriptor(
+        id=uuid.uuid4(),
+        tenant_id=None,
+        product="gh",
+        version="3.0",
+        impl_id="gh-rest",
+        op_id="POST:/repos/{owner}/{repo}/issues",
+        source_kind="ingested",
+        method="POST",
+        path="/repos/{owner}/{repo}/issues",
+        handler_ref=None,
+        summary="Create an issue",
+        description="Create an issue on a repository.",
+        tags=[],
+        parameter_schema={
+            "type": "object",
+            "properties": {
+                "owner": {"type": "string", "x-meho-param-loc": "path"},
+                "repo": {"type": "string", "x-meho-param-loc": "path"},
+                "body": {"type": "object", "x-meho-param-loc": "body"},
+            },
+            "required": ["owner", "repo", "body"],
+        },
+        response_schema=None,
+        llm_instructions=None,
+        safety_level="caution",
+        requires_approval=False,
+        is_enabled=True,
+        embedding=embedding,
+        custom_description=None,
+        custom_notes=None,
+        created_at=datetime.now(UTC),
+        updated_at=datetime.now(UTC),
+    )
+
+
+@pytest.mark.asyncio
+@pytest.mark.parametrize(
+    "issue_body",
+    [
+        pytest.param({"title": "X"}, id="title-only"),
+        pytest.param({"title": "X", "body": "Y"}, id="title-and-body"),
+    ],
+)
+async def test_dispatch_ingested_post_sends_unwrapped_request_body(
+    issue_body: dict[str, Any],
+    stub_embedding_service: AsyncMock,
+    session: AsyncSession,
+    captured_events: list[BroadcastEvent],
+) -> None:
+    """gh-rest issue-create sends the body param's *value* (unwrapped) on the wire.
+
+    Regression for #1656: the dispatcher previously serialized
+    ``{"body": {"title": "X"}}`` (the ``{name: value}`` bucket) instead of
+    ``{"title": "X"}`` (the value), which GitHub 422s. Asserts the captured
+    outbound body is exactly the requestBody value and that a recorded 201
+    round-trips to ``status='ok'``.
+    """
+    import json as _json
+
+    import respx
+
+    register_connector_v2(
+        product="gh",
+        version="3.0",
+        impl_id="gh-rest",
+        cls=_RoundTripHttpConnector,
+    )
+
+    session.add(_gh_issue_create_descriptor(stub_embedding_service.encode_one.return_value))
+    await session.commit()
+
+    operator = _make_operator()
+    target = _FakeTarget(product="gh", version="3.0", host="api.github.test", port=443)
+
+    with respx.mock(base_url="https://api.github.test", assert_all_called=True) as mock:
+        route = mock.post("/repos/octocat/hello/issues").respond(
+            201, json={"number": 7, "title": issue_body["title"]}
+        )
+        result = await dispatch(
+            operator=operator,
+            connector_id="gh-rest-3.0",
+            op_id="POST:/repos/{owner}/{repo}/issues",
+            target=target,
+            params={"owner": "octocat", "repo": "hello", "body": issue_body},
+        )
+
+    assert route.called
+    sent = route.calls.last.request
+    # The path params substitute into the URL; the body param's *value* is
+    # the wire body — never wrapped under the ``"body"`` key.
+    assert sent.url.path == "/repos/octocat/hello/issues"
+    # Exact-equality is the load-bearing check: a wire body equal to the
+    # requestBody value proves the dispatcher did NOT wrap it under "body".
+    assert _json.loads(sent.content) == issue_body
+
+    assert result.status == "ok", result.error
+    assert isinstance(result.result, dict)
+    assert result.result["number"] == 7
+    assert len(captured_events) == 1
+
+
+def test_unwrap_body_returns_value_not_wrapper() -> None:
+    """`_unwrap_body` yields the body param's value (unwrapped), or None when empty.
+
+    Locks the serialization contract shared by both body-carrying dispatch
+    arms (POST/PUT/PATCH/DELETE *and* GET-with-body): the single
+    `x-meho-param-loc='body'` param's value is the request body, never a
+    `{name: value}` wrapper (#1656).
+    """
+    from meho_backplane.operations._branches import _unwrap_body
+
+    # Empty bucket -> no body (httpx omits the request body).
+    assert _unwrap_body({}) is None
+    # Single body param -> its value, unwrapped (the GitHub issue-create shape).
+    assert _unwrap_body({"body": {"title": "X"}}) == {"title": "X"}
+    # The param name is irrelevant — the *value* is returned regardless.
+    assert _unwrap_body({"payload": [1, 2, 3]}) == [1, 2, 3]
+
+
+def test_unwrap_body_rejects_multiple_body_params() -> None:
+    """More than one `loc=='body'` param is an ingest-modelling fault -> raise.
+
+    A descriptor must carry exactly one requestBody container param. Failing
+    loud beats silently picking one and sending a body the caller never
+    asked for.
+    """
+    from meho_backplane.operations._branches import _unwrap_body
+
+    with pytest.raises(RuntimeError, match="multiple 'body' params"):
+        _unwrap_body({"body": {"title": "X"}, "extra": {"k": "v"}})
+
+
+# ---------------------------------------------------------------------------
 # Composite dispatch + audit-tree linkage
 # ---------------------------------------------------------------------------
 


### PR DESCRIPTION
## Summary

- An ingested **L2** write op mis-serialized its HTTP request body: `_split_ingested_params` stored the single `x-meho-param-loc: "body"` container param under its **name** (`body_params["body"] = value` → `{"body": {…}}`), and both body-carrying dispatch arms passed that whole dict as the JSON body — so httpx sent `{"body": {"title": "X"}}` instead of `{"title": "X"}`. Upstreams that expect the requestBody schema at the top level (GitHub issue-create wants top-level `title`) saw it nested one level too deep and **422'd**, breaking *every* ingested-L2 REST write (gh-rest issue-create / issue-comment / add-labels / create-PR, …).
- Fix: extract `_unwrap_body`, which returns the single body param's **value** (unwrapped) — `None` when the bucket is empty, and a loud `RuntimeError` if a malformed descriptor ever declares more than one `loc=="body"` param. Wired into **both** the POST/PUT/PATCH/DELETE arm and the GET-with-body arm. Generic to all ingested-L2 connectors with a requestBody; reads and path/query/header routing are untouched.
- Wire-serialization only — no FastAPI route/schema surfaced, so no OpenAPI snapshot / CLI client regen (no-op, confirmed).

## Test plan

- [x] `ruff check` + `ruff format --check` — clean on changed files
- [x] `mypy src/ --ignore-missing-imports` — clean (466 files)
- [x] `pytest tests/test_operations_dispatcher.py` — 39 passed (35 existing + 4 new)
- [x] **AC: unwrapped body on the wire** — new dispatch round-trip test drives the *real* `HttpConnector._post_json` httpx transport and captures the outbound request with `respx`: gh-rest `POST:/repos/{owner}/{repo}/issues` with `body: {"title": "X"}` sends exactly `{"title": "X"}` (title-only) and `{"title": "X", "body": "Y"}` (title+body); a recorded 201 round-trips to `status='ok'`.
- [x] **Negative control** — reverting either arm to the buggy `json=body_params or None` makes both round-trip tests FAIL, confirming they genuinely guard the regression.
- [x] **AC: both arms** — `_unwrap_body` unit tests lock the empty→`None` / single→value / multi→raise contract shared by the POST arm and the GET-with-body arm.
- [x] **AC: routing unchanged** — `owner`/`repo` substitute into the URL path (asserted); 35 pre-existing dispatcher tests green.
- [x] **AC: reads unaffected** — GET ingested + composite tests green; empty body bucket → `json=None` exactly as before.
- [x] Regression slice — `test_operations_register_ingested` + keycloak/vmware write-e2e: 100 passed.
- [x] `code-quality.py --diff` — 0 blockers (1 pre-existing `dispatch_ingested` size warning, not introduced here).

## Out of scope

- The opaque 422/403 error shape that hid GitHub's `errors[]` detail — sibling T4 #1649.
- Auditing the actual request body (`audit_log` stores only `params_hash`) — separate observability task.
- Re-modelling requestBody as flattened top-level params — the `body` container shape is fine; only its wire serialization was wrong.

## Adjacent findings

- `dispatch_ingested` is 82 lines (code-quality warn >60, pre-existing). Not refactored — out of scope for a SEV-1 wire fix.

<!-- auto-implement-issue: fresh, iteration 1 -->

Closes #1656


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Fixed request body serialization for L2 write operations. Body parameters are now correctly serialized as direct JSON content instead of being nested, resolving HTTP 422 schema mismatch errors that occurred during ingested connector requests.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->