### PR TITLE
feat(connectors): honour spec_info_versions_compatible on the manual --spec ingest path (#1646)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -170,6 +170,18 @@ connector-related release-notes line.
   ingested, only a fraction enabled). The `meho.connector.list` MCP
   tool returns the same rows. Additive — existing `operation_count`
   consumers are unaffected. (#1636)
+- The manual `--spec` connector-ingest path now accepts an
+  operator-supplied `spec_info_versions_compatible` band (REST body
+  field + `meho connector ingest --spec-info-versions-compatible`,
+  repeatable or comma-separated), mirroring the catalog opt-in (#1307).
+  A vendor spec that self-versions independently of the connector's
+  product-line label — e.g. the version-stable vRLI `/api/v2` surface
+  reporting `info.version="v2"` while the seeded `VcfLogsConnector`
+  label is `9.0` — now ingests under `--version 9.0
+  --spec-info-versions-compatible 2.x` instead of failing the
+  spec/label cross-check; omitting the band keeps the strict check, and
+  a non-pattern token (a bare `v2`) is rejected at request validation.
+  (#1646; consumer signal claude-rdc-hetzner-dc#1136)
 
 ### Fixed
 

--- a/backend/src/meho_backplane/api/v1/connectors_ingest.py
+++ b/backend/src/meho_backplane/api/v1/connectors_ingest.py
@@ -368,7 +368,18 @@ async def ingest_endpoint(
     # quadruple body with ``catalog_entry=None``, so we have to snapshot
     # before resolution.
     catalog_entry = body.catalog_entry
-    resolved, spec_info_versions_compatible = _resolve_catalog_entry_if_set(body)
+    resolved, catalog_compatible = _resolve_catalog_entry_if_set(body)
+    # The catalog-driven shape resolves its opt-in band from the catalog
+    # row (``catalog_compatible``); the explicit-quadruple shape carries
+    # the operator-supplied band on the body itself (T1 #1646). The two
+    # shapes are mutually exclusive (the ``IngestRequest`` validator
+    # rejects a body that sets both), so exactly one of these is ever
+    # non-None — fold them into one value the pipeline cross-check honours.
+    spec_info_versions_compatible = catalog_compatible or (
+        tuple(resolved.spec_info_versions_compatible)
+        if resolved.spec_info_versions_compatible is not None
+        else None
+    )
     service = IngestionPipelineService(
         operator=operator,
         llm_client_factory=llm_client_factory,

--- a/backend/src/meho_backplane/operations/ingest/api_schemas.py
+++ b/backend/src/meho_backplane/operations/ingest/api_schemas.py
@@ -58,7 +58,9 @@ from __future__ import annotations
 from typing import Literal
 from uuid import UUID
 
-from pydantic import BaseModel, ConfigDict, Field, model_validator
+from pydantic import BaseModel, ConfigDict, Field, field_validator, model_validator
+
+from meho_backplane.operations.ingest.catalog import _compatibility_pattern_to_specifier
 
 __all__ = [
     "ConnectorListItem",
@@ -181,6 +183,32 @@ class IngestRequest(BaseModel):
     specs: list[SpecSource] = Field(default_factory=list, max_length=16)
     catalog_entry: str | None = Field(default=None, min_length=1, max_length=128)
     base_url: str | None = Field(default=None, max_length=2048)
+    #: Explicit-quadruple counterpart to the catalog row's
+    #: :attr:`ConnectorSpecEntry.spec_info_versions_compatible` opt-in
+    #: (G0.16-T5 #1307). Lets an operator running the manual ``--spec``
+    #: path declare that a self-versioning vendor spec — whose
+    #: ``info.version`` is orthogonal to the connector's product-line
+    #: ``version`` label — is compatible with that label, so the
+    #: spec-vs-label cross-check in ``_validate_spec_versions`` widens
+    #: against the declared band instead of raising
+    #: :exc:`VersionMismatchError`. Each entry is a glob (``"2.x"`` /
+    #: ``"9.0.x"``) or a PEP 440 specifier set (``">=2,<3"``); the
+    #: field validator below rejects any other shape at request-
+    #: validation time. ``None`` (the default) keeps the historical
+    #: strict check. The route forwards a populated value to
+    #: :meth:`IngestionPipelineService.ingest`; it is mutually
+    #: exclusive with ``catalog_entry`` (the catalog row carries its
+    #: own band) — see the ``catalog_entry_conflict`` validator below.
+    #:
+    #: T1 (#1646) — the vRLI catch-22 (claude-rdc-hetzner-dc#1136):
+    #: the version-stable ``/api/v2`` surface self-identifies as
+    #: ``info.version="v2"`` while the seeded ``VcfLogsConnector``
+    #: label is ``9.0``; no label ingested the canonical artifact
+    #: until the manual path gained this catalog-parity opt-in.
+    spec_info_versions_compatible: list[str] | None = Field(
+        default=None,
+        max_length=16,
+    )
     dry_run: bool = False
     #: Background-mode opt-out. ``True`` (default) fires the
     #: pipeline off the request thread and returns
@@ -238,6 +266,18 @@ class IngestRequest(BaseModel):
                 "supply only one request shape. "
                 "See docs/codebase/error-message-shape.md.",
             )
+        if catalog_set and self.spec_info_versions_compatible is not None:
+            # The catalog row carries its own
+            # ``spec_info_versions_compatible`` band (#1307); an
+            # explicit one on a catalog-driven body would be silently
+            # discarded during resolution, so reject it loudly rather
+            # than let the operator believe their override took effect.
+            raise ValueError(
+                "catalog_entry_conflict: 'spec_info_versions_compatible' is "
+                "the explicit-quadruple counterpart of the catalog row's own "
+                "compatibility band; drop it when using 'catalog_entry'. "
+                "See docs/codebase/error-message-shape.md.",
+            )
         if not catalog_set and not quadruple_set:
             raise ValueError(
                 "ingest_request_underspecified: supply either "
@@ -270,6 +310,35 @@ class IngestRequest(BaseModel):
                     "See docs/codebase/error-message-shape.md.",
                 )
         return self
+
+    @field_validator("spec_info_versions_compatible")
+    @classmethod
+    def _compatibility_patterns_are_parseable(cls, value: list[str] | None) -> list[str] | None:
+        """Reject malformed compat patterns at request-validation time.
+
+        Mirrors the catalog field's
+        :meth:`ConnectorSpecEntry._compatibility_patterns_are_parseable`
+        so the manual ``--spec`` opt-in fails the same way the catalog
+        opt-in does: a glob (``"2.x"`` / ``"9.0.x"``) or a PEP 440
+        specifier set (``">=2,<3"``) passes; anything else (a bare
+        product-line token like ``"v2"``, a typo, a blank) raises a
+        ``ValueError`` the route surfaces as 422 ``extra``-class
+        validation. Compiling here — rather than only inside
+        ``_validate_spec_versions`` mid-pipeline — gives the operator
+        the diagnostic before any spec is fetched or parsed.
+        """
+        if value is None:
+            return value
+        if not value:
+            raise ValueError(
+                "spec_info_versions_compatible must be null (no opt-in) or a non-empty list"
+            )
+        normalized: list[str] = []
+        for raw_pattern in value:
+            pattern = raw_pattern.strip()
+            _compatibility_pattern_to_specifier(pattern)
+            normalized.append(pattern)
+        return normalized
 
 
 class IngestionResultModel(BaseModel):

--- a/backend/tests/test_api_v1_connectors_ingest.py
+++ b/backend/tests/test_api_v1_connectors_ingest.py
@@ -2318,6 +2318,174 @@ paths:
 
 
 # ---------------------------------------------------------------------------
+# T1 (#1646) — manual --spec spec_info_versions_compatible opt-in
+#
+# The vRLI catch-22 (claude-rdc-hetzner-dc#1136): the version-stable
+# vRLI ``/api/v2`` surface self-identifies as ``info.version="v2"``
+# while the seeded ``VcfLogsConnector`` label is ``9.0``
+# (supported_version_range ``>=9.0,<10.0``). Ingesting under ``9.0``
+# clears the class-range check (9.0 ∈ the range), so the only gate is
+# the spec-vs-label cross-check — which the explicit-quadruple
+# ``spec_info_versions_compatible`` band now decouples, exactly as the
+# catalog opt-in (#1307) does on the catalog path.
+# ---------------------------------------------------------------------------
+
+
+def _vrli_v2_spec_yaml() -> str:
+    """A minimal vRLI-shaped spec that self-versions as ``info.version=v2``.
+
+    Stands in for the pinned 136-op vRLI artifact: the cross-check only
+    reads ``info.version`` (via the lightweight ``read_spec_info_version``
+    helper), so a single-op spec exercises the same label-vs-spec gate
+    the real spec trips. ``packaging`` normalizes ``v2`` to ``2``, which
+    is why a ``2.x`` band (→ ``>=2,<3``) covers it while a bare ``v2``
+    token is not a valid pattern.
+    """
+    return """openapi: 3.0.3
+info:
+  title: VMware Aria Operations for Logs
+  version: 'v2'
+paths:
+  /api/v2/events:
+    get:
+      summary: query events
+      responses:
+        '200':
+          description: ok
+"""
+
+
+def test_ingest_manual_spec_info_versions_compatible_accepts_self_versioned_spec(
+    client: TestClient,
+    tmp_path: Any,
+    stub_embedding_service: AsyncMock,
+) -> None:
+    """vRLI ``info.version=v2`` under ``--version 9.0`` + compat ``["2.x"]`` ingests.
+
+    The manual ``--spec`` opt-in (T1 #1646) carries an operator-declared
+    compatibility band to ``_validate_spec_versions``, which widens the
+    label-vs-spec cross-check against it: ``v2`` normalizes to ``2``,
+    inside the ``2.x`` (→ ``>=2,<3``) band, so the otherwise-fatal
+    spec/label major mismatch is decoupled and the pipeline runs to
+    completion (ops inserted). The seeded ``VcfLogsConnector``
+    (``supported_version_range='>=9.0,<10.0'``) covers ``9.0``, so the
+    class-range pre-flight stays green — only the cross-check needed the
+    opt-in.
+    """
+    spec_path = tmp_path / "vrli.yaml"
+    spec_path.write_text(_vrli_v2_spec_yaml())
+    propose_json = (
+        '[{"group_key": "events", "name": "Events", '
+        '"when_to_use": "Use these operations to query log events."}]'
+    )
+    assign_json = '{"GET:/api/v2/events": "events"}'
+    set_llm_client_factory(
+        lambda: _StubLlmClient(
+            propose_response=propose_json,
+            assign_response=assign_json,
+        ),
+    )
+
+    key, token = _admin_token()
+    with (
+        respx.mock as mock_router,
+        patch(
+            "meho_backplane.operations.ingest._upsert.encode_endpoint_text",
+            AsyncMock(return_value=[0.25] * 384),
+        ),
+    ):
+        _mock_discovery_and_jwks(mock_router, _public_jwks(key))
+        spec_url = _register_spec_at_https(mock_router, spec_path, path="vrli-v2.yaml")
+        response = client.post(
+            "/api/v1/connectors/ingest",
+            json={
+                "product": "vcf-logs",
+                "version": "9.0",
+                "impl_id": "vrli-rest",
+                "specs": [{"uri": spec_url}],
+                "spec_info_versions_compatible": ["2.x"],
+                "async": False,
+            },
+            headers=_authed(token),
+        )
+    assert response.status_code == 200, response.text
+    body = response.json()
+    # The cross-check did not raise: the single op was parsed + inserted.
+    assert body["ingestion"]["inserted_count"] == 1
+
+
+def test_ingest_manual_self_versioned_spec_without_opt_in_returns_422(
+    client: TestClient, tmp_path: Any
+) -> None:
+    """Same ingest **without** the opt-in still raises the spec/label mismatch.
+
+    Regression guard: the opt-in is explicit and never default. Omitting
+    ``spec_info_versions_compatible`` leaves the historical strict
+    cross-check in force, so ``info.version=v2`` under ``--version 9.0``
+    is a cross-major mismatch → 422 ``spec_label_mismatch`` naming both
+    versions, exactly as it did before T1.
+    """
+    spec_path = tmp_path / "vrli.yaml"
+    spec_path.write_text(_vrli_v2_spec_yaml())
+    key, token = _admin_token()
+    with respx.mock as mock_router:
+        _mock_discovery_and_jwks(mock_router, _public_jwks(key))
+        spec_url = _register_spec_at_https(mock_router, spec_path, path="vrli-v2-noopt.yaml")
+        response = client.post(
+            "/api/v1/connectors/ingest",
+            json={
+                "product": "vcf-logs",
+                "version": "9.0",
+                "impl_id": "vrli-rest",
+                "specs": [{"uri": spec_url}],
+                "async": False,
+            },
+            headers=_authed(token),
+        )
+    assert response.status_code == 422, response.text
+    detail = response.json()["detail"]
+    assert detail["kind"] == "spec_label_mismatch"
+    assert detail["requested_version"] == "9.0"
+    assert detail["spec_info_versions"] == [{"spec_uri": spec_url, "info_version": "v2"}]
+    assert "v2" in detail["message"]
+    assert "9.0" in detail["message"]
+
+
+def test_ingest_manual_invalid_compat_pattern_returns_422(
+    client: TestClient, tmp_path: Any
+) -> None:
+    """A bare ``["v2"]`` compat token is rejected at request validation.
+
+    ``v2`` is neither a glob nor a PEP 440 specifier set, so the
+    ``IngestRequest`` field validator (mirroring the catalog row's)
+    rejects it before any spec is fetched — the operator hears about the
+    bad band immediately rather than mid-pipeline. FastAPI surfaces the
+    ``ValueError`` as a 422 whose body names the offending field.
+    """
+    spec_path = tmp_path / "vrli.yaml"
+    spec_path.write_text(_vrli_v2_spec_yaml())
+    key, token = _admin_token()
+    with respx.mock as mock_router:
+        _mock_discovery_and_jwks(mock_router, _public_jwks(key))
+        spec_url = _register_spec_at_https(mock_router, spec_path, path="vrli-v2-badpat.yaml")
+        response = client.post(
+            "/api/v1/connectors/ingest",
+            json={
+                "product": "vcf-logs",
+                "version": "9.0",
+                "impl_id": "vrli-rest",
+                "specs": [{"uri": spec_url}],
+                "spec_info_versions_compatible": ["v2"],
+                "async": False,
+            },
+            headers=_authed(token),
+        )
+    assert response.status_code == 422, response.text
+    messages = [err.get("msg", "") for err in response.json()["detail"]]
+    assert any("spec_info_versions_compatible" in m for m in messages), messages
+
+
+# ---------------------------------------------------------------------------
 # set_llm_client_factory contract
 # ---------------------------------------------------------------------------
 

--- a/cli/api/openapi.json
+++ b/cli/api/openapi.json
@@ -13374,6 +13374,15 @@
             "nullable": true,
             "title": "Base Url"
           },
+          "spec_info_versions_compatible": {
+            "items": {
+              "type": "string"
+            },
+            "type": "array",
+            "maxItems": 16,
+            "nullable": true,
+            "title": "Spec Info Versions Compatible"
+          },
           "dry_run": {
             "type": "boolean",
             "title": "Dry Run",

--- a/cli/internal/api/client.gen.go
+++ b/cli/internal/api/client.gen.go
@@ -2682,14 +2682,15 @@ type IngestKbRequest struct {
 // and the operator only finds out at review-time.
 type IngestRequest struct {
 	// Async Run the pipeline off the request thread (202 + job handle); set to false for the legacy blocking response. Ignored when dry_run=true.
-	Async        *bool         `json:"async,omitempty"`
-	BaseUrl      *string       `json:"base_url"`
-	CatalogEntry *string       `json:"catalog_entry"`
-	DryRun       *bool         `json:"dry_run,omitempty"`
-	ImplId       *string       `json:"impl_id"`
-	Product      *string       `json:"product"`
-	Specs        *[]SpecSource `json:"specs,omitempty"`
-	Version      *string       `json:"version"`
+	Async                      *bool         `json:"async,omitempty"`
+	BaseUrl                    *string       `json:"base_url"`
+	CatalogEntry               *string       `json:"catalog_entry"`
+	DryRun                     *bool         `json:"dry_run,omitempty"`
+	ImplId                     *string       `json:"impl_id"`
+	Product                    *string       `json:"product"`
+	SpecInfoVersionsCompatible *[]string     `json:"spec_info_versions_compatible"`
+	Specs                      *[]SpecSource `json:"specs,omitempty"`
+	Version                    *string       `json:"version"`
 }
 
 // IngestResponse Response shape for “POST /api/v1/connectors/ingest“.

--- a/cli/internal/cmd/connector/connector_test.go
+++ b/cli/internal/cmd/connector/connector_test.go
@@ -403,6 +403,65 @@ func TestValidateIngestModeTable(t *testing.T) {
 	}
 }
 
+// TestBuildIngestRequestSpecInfoVersionsCompatible — the manual-mode
+// --spec-info-versions-compatible flag (T1 #1646) threads onto the
+// request body so the backend's spec-vs-label cross-check can widen
+// against the operator-declared band; catalog mode and an unset flag
+// both leave the field nil.
+func TestBuildIngestRequestSpecInfoVersionsCompatible(t *testing.T) {
+	t.Run("manual sets the band", func(t *testing.T) {
+		body, err := buildIngestRequest(ingestOptions{
+			Product:    "vcf-logs",
+			Version:    "9.0",
+			ImplID:     "vrli-rest",
+			Specs:      []string{"https://specs.example.test/vrli.yaml"},
+			Compatible: []string{"2.x", ">=2,<3"},
+		})
+		if err != nil {
+			t.Fatalf("buildIngestRequest: %v", err)
+		}
+		if body.SpecInfoVersionsCompatible == nil {
+			t.Fatal("SpecInfoVersionsCompatible: want populated, got nil")
+		}
+		got := *body.SpecInfoVersionsCompatible
+		if len(got) != 2 || got[0] != "2.x" || got[1] != ">=2,<3" {
+			t.Errorf("SpecInfoVersionsCompatible = %v, want [2.x >=2,<3]", got)
+		}
+	})
+
+	t.Run("unset leaves the field nil", func(t *testing.T) {
+		body, err := buildIngestRequest(ingestOptions{
+			Product: "vcf-logs",
+			Version: "9.0",
+			ImplID:  "vrli-rest",
+			Specs:   []string{"https://specs.example.test/vrli.yaml"},
+		})
+		if err != nil {
+			t.Fatalf("buildIngestRequest: %v", err)
+		}
+		if body.SpecInfoVersionsCompatible != nil {
+			t.Errorf("SpecInfoVersionsCompatible = %v, want nil", *body.SpecInfoVersionsCompatible)
+		}
+	})
+
+	t.Run("catalog mode never carries the band", func(t *testing.T) {
+		// Catalog mode returns before the manual-mode tail, so a
+		// stray --spec-info-versions-compatible value is dropped on
+		// the wire; the backend validator rejects the combination
+		// up front anyway (catalog_entry_conflict).
+		body, err := buildIngestRequest(ingestOptions{
+			Catalog:    "vmware/9.0",
+			Compatible: []string{"2.x"},
+		})
+		if err != nil {
+			t.Fatalf("buildIngestRequest: %v", err)
+		}
+		if body.SpecInfoVersionsCompatible != nil {
+			t.Errorf("SpecInfoVersionsCompatible = %v, want nil", *body.SpecInfoVersionsCompatible)
+		}
+	})
+}
+
 // ---------- renderers ----------
 
 // TestPrintIngestSummaryDryRun — dry-run header + counts; no

--- a/cli/internal/cmd/connector/ingest.go
+++ b/cli/internal/cmd/connector/ingest.go
@@ -51,6 +51,7 @@ func newIngestCmd() *cobra.Command {
 		versionFlag       string
 		implID            string
 		specs             []string
+		compatible        []string
 		catalog           string
 		dryRun            bool
 		noWait            bool
@@ -79,6 +80,13 @@ func newIngestCmd() *cobra.Command {
 			"      $CLAUDE_RDC_DOCS; read + uploaded by the CLI like file://)\n" +
 			"  Repeat --spec to merge multiple specs under one connector_id\n" +
 			"  (vSphere is the canonical case: vcenter.yaml + vi-json.yaml).\n\n" +
+			"  When a vendor spec self-versions independently of the product\n" +
+			"  line (e.g. a version-stable /api/v2 surface reports\n" +
+			"  info.version=v2 while the connector label is 9.0), pass\n" +
+			"  --spec-info-versions-compatible with a glob (2.x, 9.0.x) or a\n" +
+			"  PEP 440 specifier set (>=2,<3) to declare the band; the backplane\n" +
+			"  then accepts the spec under --version instead of rejecting the\n" +
+			"  major mismatch.\n\n" +
 			"v0.12+ backplanes run the pipeline off the request thread and\n" +
 			"answer 202 Accepted + a job handle. The CLI polls the job to a\n" +
 			"terminal status and renders the usual summary on success; pass\n" +
@@ -98,6 +106,7 @@ func newIngestCmd() *cobra.Command {
 				Version:           versionFlag,
 				ImplID:            implID,
 				Specs:             specs,
+				Compatible:        compatible,
 				Catalog:           catalog,
 				DryRun:            dryRun,
 				NoWait:            noWait,
@@ -114,6 +123,12 @@ func newIngestCmd() *cobra.Command {
 		"impl identifier (e.g. vmware-rest, k8s-go); manual mode")
 	cmd.Flags().StringArrayVar(&specs, "spec", nil,
 		"spec URI; repeat for multi-spec merge under one connector_id; manual mode")
+	cmd.Flags().StringSliceVar(&compatible, "spec-info-versions-compatible", nil,
+		"manual mode: declare that the spec's info.version is compatible with --version even when "+
+			"they differ (e.g. a vendor /api/v2 surface self-versioning as info.version=v2 ingested "+
+			"under --version 9.0). Each entry is a glob (2.x, 9.0.x) or a PEP 440 specifier set "+
+			"(>=2,<3); repeatable or comma-separated. Without it, a spec/label major mismatch is "+
+			"rejected; mutually exclusive with --catalog (the catalog row carries its own band)")
 	cmd.Flags().StringVar(&catalog, "catalog", "",
 		"catalog mode: ingest the curated entry for <product>/<version> (e.g. vmware/9.0); "+
 			"mutually exclusive with --product/--version/--impl/--spec")
@@ -134,6 +149,7 @@ type ingestOptions struct {
 	Version           string
 	ImplID            string
 	Specs             []string
+	Compatible        []string
 	Catalog           string
 	DryRun            bool
 	NoWait            bool
@@ -228,6 +244,16 @@ func buildIngestRequest(opts ingestOptions) (api.IngestRequest, error) {
 	body.Version = &version
 	body.ImplId = &implID
 	body.Specs = &specs
+	if len(opts.Compatible) > 0 {
+		// Explicit-quadruple opt-in (T1 #1646): the operator declares a
+		// spec-info-version compatibility band so the backplane's
+		// spec-vs-label cross-check widens against it instead of rejecting
+		// a self-versioning vendor spec. Catalog mode returns above, so
+		// this only ever rides the manual shape — the backend validator
+		// rejects the field alongside catalog_entry.
+		compatible := append([]string(nil), opts.Compatible...)
+		body.SpecInfoVersionsCompatible = &compatible
+	}
 	return body, nil
 }
 

--- a/docs/codebase/spec-ingestion.md
+++ b/docs/codebase/spec-ingestion.md
@@ -500,11 +500,32 @@ which forwards it to `_validate_spec_versions`. Per-spec
 classification then bypasses the verbatim/major-band check for any
 spec whose `info.version` matches a pattern in the range, emitting
 `connector_ingest_version_label_decoupled` so the audit trail still
-records the decision. The explicit-quadruple shape doesn't carry
-the catalog row and therefore can't opt in — operators using it
-implicitly accept the historical strict check. See
+records the decision. See
 [`docs/cross-repo/connector-catalog.md`](../cross-repo/connector-catalog.md#label-vs-spec-decoupling-spec_info_versions_compatible)
 for the field definition and pattern syntax.
+
+**Manual `--spec` opt-in: `IngestRequest.spec_info_versions_compatible`
+(T1 #1646).** The explicit-quadruple shape carries the same opt-in as
+an optional body field (`meho connector ingest
+--spec-info-versions-compatible <band>`, repeatable or comma-separated)
+so a self-versioning vendor spec ingests on the manual path too — no
+catalog row required. The motivating case
+(claude-rdc-hetzner-dc#1136): the version-stable vRLI `/api/v2`
+surface reports `info.version="v2"` while the seeded `VcfLogsConnector`
+label is `9.0`; ingesting under `--version 9.0
+--spec-info-versions-compatible 2.x` decouples the cross-check (`v2`
+normalizes to `2`, inside the `2.x` → `>=2,<3` band) while the
+class-range pre-flight stays green (`9.0` ∈ `>=9.0,<10.0`). The route
+folds the body field together with the catalog-resolved band into the
+single value it hands `IngestionPipelineService.ingest` — the two are
+mutually exclusive (`IngestRequest` rejects a body that sets both
+`catalog_entry` and `spec_info_versions_compatible` with
+`catalog_entry_conflict`). Each entry is a glob (`2.x` / `9.0.x`) or a
+PEP 440 specifier set (`>=2,<3`); the field validator rejects any other
+shape (a bare `v2`, a typo) at request-validation time, so the operator
+gets the diagnostic before any spec is fetched. Omitting the field
+keeps the historical strict check — the opt-in is explicit, never
+default.
 
 ### Shared error-envelope builders (`ingest/error_envelopes.py`)
 


### PR DESCRIPTION
## Summary

- The manual `--spec` connector-ingest path now accepts an operator-supplied `spec_info_versions_compatible` band, extending the catalog-path opt-in (#1307) to the explicit-quadruple shape. This unblocks ingesting a vendor spec that self-versions independently of the connector's product-line label.
- Motivating case (claude-rdc-hetzner-dc#1136): the version-stable vRLI `/api/v2` surface reports `info.version="v2"` while the seeded `VcfLogsConnector` label is `9.0`, so the spec-vs-label cross-check rejected every label that the class-range check accepted. Ingesting under `--version 9.0 --spec-info-versions-compatible 2.x` decouples the cross-check (`v2` → `2`, inside the `2.x` → `>=2,<3` band) while the class-range pre-flight stays green (`9.0` ∈ `>=9.0,<10.0`).
- **Plumbing only — no validator-logic change.** `IngestRequest` gains an optional `spec_info_versions_compatible: list[str] | None`; `meho connector ingest` gains a matching `--spec-info-versions-compatible` flag (repeatable / CSV); the route folds the body value together with the catalog-resolved band into the single value handed to `service.ingest(...)`. The validator already honours it at `pipeline.py:538-553`.
- The field validator mirrors the catalog row's: a non-pattern token (a bare `v2`) is rejected at request-validation time, before any spec fetch; the field is mutually exclusive with `catalog_entry` (`catalog_entry_conflict`). Omitting it keeps the historical strict check — the opt-in is explicit, never default.

## Test plan

- [x] `ruff check` / `ruff format --check` — clean
- [x] `mypy` — clean (`api_schemas.py`, `connectors_ingest.py`)
- [x] `python3 .claude/hooks/code-quality.py --files …` — exit 0
- [x] `pytest tests/test_api_v1_connectors_ingest.py` — 70 passed (3 new)
  - [x] **AC2:** vRLI `info.version=v2` under `--version 9.0` + `spec_info_versions_compatible=["2.x"]` ingests without `VersionMismatchError` (op inserted)
  - [x] **AC3 (regression):** same ingest **without** the opt-in still raises `spec_label_mismatch` (422)
  - [x] bare `["v2"]` → 422 at request validation (not a valid glob / `SpecifierSet`)
- [x] `pytest tests/test_operations_ingest_pipeline_version_check.py tests/test_operations_ingest_catalog.py` — 80 passed (validator untouched)
- [x] `go test ./internal/cmd/connector/...` — pass (3 new `buildIngestRequest` sub-tests: manual sets the band / unset is nil / catalog never carries it)
- [x] `go build ./...` + `go vet` + `gofmt -l` — clean
- [x] OpenAPI snapshot + CLI client regenerated (`make snapshot-openapi && make generate`); generated diff scoped to the one new field
- [x] Docs: `docs/codebase/spec-ingestion.md` updated (manual `--spec` opt-in section; corrected the prior "explicit-quadruple shape can't opt in" claim)
- [x] CHANGELOG `[Unreleased]` bullet citing claude-rdc-hetzner-dc#1136

## Out of scope

- The `UncoveredVersionLabel` class-range check — untouched (ingesting under `9.0` clears it; `9.0` ∈ `>=9.0,<10.0`).
- Product-slug dispatch-key reconciliation that makes the ingested connector dispatchable under `--product vcf-logs` — T2 (#1647).
- Auto-inferring the band from the spec — kept an explicit operator declaration (dumb substrate, smart agent).

<!-- auto-implement-issue: fresh, iteration 1 -->

Closes #1646
