### PR TITLE
feat(vault): startup advisory + layout doc for unenforced tenant-scope guard (#1673)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -176,6 +176,19 @@ connector-related release-notes line.
   ingested, only a fraction enabled). The `meho.connector.list` MCP
   tool returns the same rows. Additive — existing `operation_count`
   consumers are unaffected. (#1636)
+- The backplane now emits a single structured startup advisory
+  (`vault_tenant_scope_unenforced`) when the opt-in Vault `vault.kv.*`
+  tenant-scope guard (#1643) is left default-off
+  (`VAULT_KV_TENANT_SCOPE_PREFIX` unset), so an operator running a
+  tenant-partitioned Vault has a signal that cross-tenant `vault.kv.*`
+  isolation is unenforced at the app layer instead of the guard silently
+  no-op'ing. The advisory names the enabling env var and the doc; it is
+  observability-only — dispatch behaviour and the empty default are
+  unchanged (flipping the guard on is an explicit infra decision). A new
+  "Choosing a layout" section in
+  `docs/codebase/connectors-vault-tenant-scope.md` documents the
+  per-`sub` vs tenant-partitioned choice and what enabling the prefix
+  requires (#1673).
 
 ### Fixed
 

--- a/backend/src/meho_backplane/main.py
+++ b/backend/src/meho_backplane/main.py
@@ -223,6 +223,40 @@ def _assert_mcp_resource_uri_configured() -> None:
         raise RuntimeError(AUDIENCE_NOT_CONFIGURED_REMEDIATION)
 
 
+def _advise_vault_tenant_scope_unenforced() -> None:
+    """Emit a one-time startup advisory when the Vault tenant-scope guard is off.
+
+    The application-layer ``vault.kv.*`` tenant-scope guard (#1643) is
+    **opt-in** and **default-off** (``VAULT_KV_TENANT_SCOPE_PREFIX=""``),
+    because the shipped Vault layout scopes secrets per operator ``sub``
+    rather than per tenant, so a hard tenant prefix would deny every
+    existing call. The consequence is silent: an operator running a
+    **tenant-partitioned** Vault gets no signal that the guard is a no-op
+    and cross-tenant ``vault.kv.*`` isolation is therefore unenforced at
+    the app layer (the empty-prefix branch of
+    :func:`~meho_backplane.connectors.vault.tenant_scope.enforce_tenant_scope`).
+
+    This logs **one** structured advisory at startup naming the env var
+    that enables the guard. It is purely observability — it does **not**
+    change dispatch behaviour or flip the default; whether to enable the
+    prefix (and migrate the Vault layout) is an explicit human/infra
+    decision, documented under "Choosing a layout" in
+    ``docs/codebase/connectors-vault-tenant-scope.md``. A deploy that
+    relies solely on the per-``sub`` Vault policy can ignore the line; a
+    tenant-partitioned deploy treats it as the cue to set the prefix.
+
+    Mirrors the loud-but-non-fatal advisory shape the rest of the
+    lifespan uses (e.g. :func:`_preload_embedding_model`): a single
+    ``structlog`` event, no f-strings, no raise.
+    """
+    if not get_settings().vault_kv_tenant_scope_prefix:
+        structlog.get_logger().warning(
+            "vault_tenant_scope_unenforced",
+            enable_via="VAULT_KV_TENANT_SCOPE_PREFIX",
+            doc="docs/codebase/connectors-vault-tenant-scope.md",
+        )
+
+
 async def _run_lifespan_shutdown() -> None:
     """Dispose every long-lived resource the lifespan opened.
 
@@ -269,9 +303,9 @@ async def _run_lifespan_startup() -> None:
        ``register_*`` calls run before the first request arrives.
     5. Typed-op registrars run **after** connector discovery (the
        registrars are appended during the import pass).
-    6. MCP audience guard last — the eager-init failures above raise
-       before this, so the guard's CrashLoopBackOff carries the
-       MCP-audience message, not a stale earlier failure.
+    6. MCP audience guard after the eager-init steps, so a failure there
+       carries the MCP-audience message, not a stale earlier one; the
+       Vault tenant-scope advisory (operability-only) follows it.
     """
     configure_logging()
     register_probe("keycloak", keycloak_readiness_probe)
@@ -335,12 +369,12 @@ async def _run_lifespan_startup() -> None:
     # as connector auto-discovery: top-level register_mcp_tool /
     # register_mcp_resource calls run at module import.
     eager_import_mcp_modules()
-    # MCP audience guard (G0.8-T4 #633). The /mcp router is mounted
-    # unconditionally; a deploy with neither MCP_RESOURCE_URI nor
-    # BACKPLANE_URL leaves the audience empty and every /mcp request
-    # 401s with no signal. Crash loudly here with the remediation
-    # instead of serving a dark, silent surface.
+    # Startup guards (each self-documented in its own docstring): MCP
+    # audience guard crashes loudly on an unresolvable /mcp audience
+    # (G0.8-T4 #633); the Vault tenant-scope advisory is operability-only
+    # (#1673).
     _assert_mcp_resource_uri_configured()
+    _advise_vault_tenant_scope_unenforced()
     # G10.0-T5 (#866) — ensure ``ui/static/dist/`` exists so the
     # StaticFiles mount does not crash on a fresh clone where
     # ``tailwindcss --watch`` has not yet materialised the compiled

--- a/backend/tests/test_vault_tenant_scope_advisory.py
+++ b/backend/tests/test_vault_tenant_scope_advisory.py
@@ -1,0 +1,99 @@
+# SPDX-License-Identifier: Apache-2.0
+# Copyright (c) 2026 evoila Group
+
+"""Startup advisory for an unenforced Vault tenant-scope guard (#1673).
+
+The application-layer ``vault.kv.*`` tenant-scope guard (#1643) is opt-in
+and default-off (``VAULT_KV_TENANT_SCOPE_PREFIX=""``). On a deploy whose
+Vault layout *is* tenant-partitioned, leaving the prefix empty silently
+turns the guard into a no-op, so cross-tenant ``vault.kv.*`` isolation is
+unenforced at the app layer with no signal.
+
+:func:`meho_backplane.main._advise_vault_tenant_scope_unenforced` runs in
+the FastAPI lifespan and emits exactly one structured
+``vault_tenant_scope_unenforced`` advisory when the prefix is unset. These
+tests assert it fires when unset, stays silent when set, and does not
+change boot behaviour either way (it is observability-only — no raise).
+"""
+
+from __future__ import annotations
+
+from collections.abc import Iterator
+
+import pytest
+from fastapi.testclient import TestClient
+from structlog.testing import capture_logs
+
+from meho_backplane.main import _advise_vault_tenant_scope_unenforced, app
+from meho_backplane.settings import get_settings
+
+_ADVISORY_EVENT = "vault_tenant_scope_unenforced"
+
+
+@pytest.fixture(autouse=True)
+def _required_settings_env(monkeypatch: pytest.MonkeyPatch) -> Iterator[None]:
+    """Pin the required env the lifespan / ``Settings`` construction needs.
+
+    ``get_settings()`` reads ``KEYCLOAK_ISSUER_URL`` / ``KEYCLOAK_AUDIENCE``
+    / ``VAULT_ADDR`` as hard ``os.environ[...]`` lookups, and the lifespan's
+    MCP-audience guard needs a resolvable ``BACKPLANE_URL``. The conftest
+    autouse fixtures pin only ``DATABASE_URL`` / ``RETRIEVAL_MODEL_CACHE_DIR``
+    / ``BACKPLANE_URL``; this module owns the rest so each test drives only
+    ``VAULT_KV_TENANT_SCOPE_PREFIX``.
+    """
+    monkeypatch.setenv("KEYCLOAK_ISSUER_URL", "https://keycloak.test/realms/meho")
+    monkeypatch.setenv("KEYCLOAK_AUDIENCE", "meho-backplane")
+    monkeypatch.setenv("VAULT_ADDR", "https://vault.test")
+    monkeypatch.setenv("BACKPLANE_URL", "https://meho.test")
+    get_settings.cache_clear()
+    yield
+    get_settings.cache_clear()
+
+
+def test_advisory_fires_once_when_prefix_unset(monkeypatch: pytest.MonkeyPatch) -> None:
+    """Empty prefix → exactly one structured advisory naming the env var."""
+    monkeypatch.setenv("VAULT_KV_TENANT_SCOPE_PREFIX", "")
+    get_settings.cache_clear()
+    try:
+        with capture_logs() as captured:
+            _advise_vault_tenant_scope_unenforced()
+    finally:
+        get_settings.cache_clear()
+
+    advisories = [e for e in captured if e.get("event") == _ADVISORY_EVENT]
+    assert len(advisories) == 1
+    event = advisories[0]
+    assert event["log_level"] == "warning"
+    assert event["enable_via"] == "VAULT_KV_TENANT_SCOPE_PREFIX"
+    assert event["doc"] == "docs/codebase/connectors-vault-tenant-scope.md"
+
+
+def test_advisory_silent_when_prefix_set(monkeypatch: pytest.MonkeyPatch) -> None:
+    """A configured prefix → the guard is enforced, so no advisory is logged."""
+    monkeypatch.setenv("VAULT_KV_TENANT_SCOPE_PREFIX", "tenant-{tenant_id}/")
+    get_settings.cache_clear()
+    try:
+        with capture_logs() as captured:
+            _advise_vault_tenant_scope_unenforced()
+    finally:
+        get_settings.cache_clear()
+
+    advisories = [e for e in captured if e.get("event") == _ADVISORY_EVENT]
+    assert advisories == []
+
+
+def test_advisory_does_not_block_boot(monkeypatch: pytest.MonkeyPatch) -> None:
+    """The advisory is observability-only: the lifespan still boots to serving.
+
+    Running the full lifespan with the prefix unset exercises the advisory
+    on the real startup path and asserts it does not raise — the app
+    reaches a serving state and ``GET /`` returns its identity payload.
+    """
+    monkeypatch.setenv("VAULT_KV_TENANT_SCOPE_PREFIX", "")
+    get_settings.cache_clear()
+    try:
+        with TestClient(app) as client:
+            response = client.get("/")
+        assert response.status_code == 200
+    finally:
+        get_settings.cache_clear()

--- a/docs/codebase/connectors-vault-tenant-scope.md
+++ b/docs/codebase/connectors-vault-tenant-scope.md
@@ -88,6 +88,68 @@ guard is enabled: its only callers run the unauthenticated
 `vault.sys.health` op and forward no token to Vault, so there is no tenant
 identity to bind against.
 
+## Startup advisory (unenforced state is visible)
+
+Because the guard is default-off, a deploy whose Vault layout *is*
+tenant-partitioned could leave the prefix empty and never know the guard
+is silently a no-op. To make that state visible,
+[`main._advise_vault_tenant_scope_unenforced`](../../backend/src/meho_backplane/main.py)
+runs in the FastAPI lifespan and emits **exactly one** structured advisory
+at startup when `vault_kv_tenant_scope_prefix` is empty:
+
+```
+vault_tenant_scope_unenforced  enable_via=VAULT_KV_TENANT_SCOPE_PREFIX  doc=docs/codebase/connectors-vault-tenant-scope.md
+```
+
+It is **observability-only** — loud-but-non-fatal, like the embedding
+preload advisory: no dispatch change, no raise, the default is not flipped.
+A deploy that relies solely on the per-`sub` Vault policy can ignore the
+line; a tenant-partitioned deploy treats it as the cue to set the prefix
+(see "Choosing a layout"). Once the prefix is set the advisory is silent.
+The behaviour is covered by
+[`backend/tests/test_vault_tenant_scope_advisory.py`](../../backend/tests/test_vault_tenant_scope_advisory.py)
+(fires unset, silent when set, never blocks boot).
+
+## Choosing a layout
+
+Which Vault KV layout you run determines whether this guard does anything.
+It is a deploy/infra decision, **not** a backplane default — the backplane
+ships the prefix empty (#1673 only surfaces and documents the choice; it
+does not make it):
+
+- **Per-`sub` layout (the shipped default).** Secrets live under
+  `secret/data/targets/<sub>/*` and isolation is enforced entirely by the
+  templated `meho-mcp` Vault policy (`connector-vault-policy.md` §2). There
+  is no `tenant-<id>/` partition to bind against, so the prefix stays
+  **empty** and the app-layer guard is intentionally a no-op. The startup
+  advisory fires; for this layout it is expected and can be ignored. Keep
+  the policy template correct — it is the primary (and only) gate here.
+
+- **Tenant-partitioned layout (opt-in).** Secrets are physically
+  partitioned by tenant — e.g. mount `secret/tenant-<tenant_id>/...` or a
+  path prefix `tenant-<tenant_id>/...`. Here the app-layer guard becomes a
+  real backstop for a mis-provisioned policy, so you **enable** it.
+
+**Enabling the prefix requires all of:**
+
+1. A Vault KV layout actually partitioned by `tenant_id` (mount or path) —
+   the prefix only denies; it never relocates secrets.
+2. Setting `VAULT_KV_TENANT_SCOPE_PREFIX` to the matching `str.format`
+   template with a single `{tenant_id}` placeholder, e.g.
+   `tenant-{tenant_id}/` (path prefix) or `secret/tenant-{tenant_id}/`
+   (mount-pinned). The rendered `tenant_id` is the canonical dashed
+   lowercase UUID (see "The namespace convention").
+3. Confirming every legitimate `vault.kv.*` caller's secrets already live
+   **under** that prefix — once set, any in-namespace mismatch is denied
+   with `exception_class=VaultTenantScopeError` *before* the hvac call.
+   The system/shim operator (Nil-UUID tenant, `vault.sys.health` only) is
+   exempt, so enabling the prefix does not break the health probe.
+
+Because step 3 denies every per-`sub` call that is *not* under a
+`tenant-<id>/` prefix, flipping this on against the shipped per-`sub`
+layout would break dispatch — which is exactly why the default is empty
+and the switch is left to the operator.
+
 ## Scope notes
 
 - This is **defense-in-depth, not the primary gate.** The guard never


### PR DESCRIPTION
## What

Follow-up to #1643. The opt-in, default-off Vault `vault.kv.*` tenant-scope guard (`VAULT_KV_TENANT_SCOPE_PREFIX`, empty = no-op) gives an operator running a **tenant-partitioned** Vault no signal that cross-tenant isolation is unenforced at the app layer. This surfaces and documents that state. It does **not** change dispatch behaviour or flip the default — that's an explicit human/infra decision, out of scope (per the issue).

## Changes

- **Startup advisory** — `main._advise_vault_tenant_scope_unenforced` runs in the FastAPI lifespan (right after the MCP audience guard) and emits **exactly one** structured `vault_tenant_scope_unenforced` advisory when `vault_kv_tenant_scope_prefix` is empty, with fields `enable_via=VAULT_KV_TENANT_SCOPE_PREFIX` and `doc=docs/codebase/connectors-vault-tenant-scope.md`. Loud-but-non-fatal, mirroring the existing `_preload_embedding_model` advisory idiom (single `structlog` event, no f-strings, no raise).
- **Docs** — new **"Choosing a layout"** + **"Startup advisory"** sections in `docs/codebase/connectors-vault-tenant-scope.md`: per-`sub` default vs tenant-partitioned layout, and the three prerequisites for enabling the prefix.
- **Test** — `backend/tests/test_vault_tenant_scope_advisory.py` (mirrors `test_mcp_startup_guard.py`): asserts the advisory fires exactly once (warning level, correct fields) when unset via `structlog.testing.capture_logs`, stays silent when the prefix is set, and never blocks lifespan boot.
- **CHANGELOG** `[Unreleased]` bullet under **Added** (operability, not a vuln fix).

## Scope / safety

- No change to dispatch behaviour or to the guard itself; the existing `test_connectors_vault_tenant_scope.py` suite passes unchanged (20 passed).
- No FastAPI route/schema change → no OpenAPI regen (nothing under `backend/src/meho_backplane/api/` touched).

## Verification

- `ruff check` / `ruff format --check` — pass
- `mypy src/meho_backplane/main.py src/meho_backplane/settings.py` — pass
- `pytest tests/test_vault_tenant_scope_advisory.py` — **3 passed**
- `pytest tests/test_connectors_vault_tenant_scope.py` — **20 passed** (unchanged)
- code-quality gate (`--diff`) — exit 0 (remaining items are pre-existing file-size warning + a function-size WARN at 100 lines, no blockers)

Closes #1673

🤖 Generated with [Claude Code](https://claude.com/claude-code)