### PR TITLE
fix(connectors): key cred/session caches by (tenant_id, target.id) in 7 more connectors (#1672)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -129,6 +129,16 @@ connector-related release-notes line.
   Two same-named targets in different tenants previously collapsed onto one
   cache entry, so one tenant could be served another tenant's cached
   service-account credential or session token (#1642).
+- Extended the same `(tenant_id, target.id)` cache re-keying (via the shared
+  `target_cache_key` helper) to the remaining seven connectors that still
+  keyed credential/session/token caches on `target.name`: VCF Automation
+  (both per-plane token caches), ArgoCD, gcloud (token + impersonated-creds +
+  per-target lock), Keycloak (admin token), GitHub (installation token + PAT),
+  Hetzner Robot, and vmware-rest (session token + endpoint paths). Two
+  same-named targets in different tenants no longer collapse onto one cache
+  entry, closing the same cross-tenant credential/session bleed in these
+  connectors. The shared `HttpConnector._clients` connection pool stays keyed
+  on `target.name` (a pooling concern, tracked separately) (#1672).
 
 ### Breaking changes
 

--- a/backend/src/meho_backplane/connectors/argocd/connector.py
+++ b/backend/src/meho_backplane/connectors/argocd/connector.py
@@ -87,6 +87,7 @@ import structlog
 from tenacity import retry, retry_if_exception, stop_after_attempt, wait_exponential
 
 from meho_backplane.auth.operator import Operator
+from meho_backplane.connectors._shared.cache_key import target_cache_key
 from meho_backplane.connectors._shared.system_operator import is_system_operator
 from meho_backplane.connectors.adapters.http import HttpConnector
 from meho_backplane.connectors.argocd.session import (
@@ -147,8 +148,10 @@ def _is_acceptable_auth_model(value: Any) -> bool:
 class ArgoCdConnector(HttpConnector):
     """ArgoCD 3.x REST connector with bearer-token auth.
 
-    Per-target token cached in :attr:`_creds_cache` (loaded once via the
-    injectable :class:`ArgoCdCredentialsLoader`). The bearer token is sent
+    Per-target token cached in :attr:`_creds_cache` keyed on the
+    tenant-unique ``(tenant_id, target.id)`` tuple (#1642/#1672), loaded
+    once via the injectable :class:`ArgoCdCredentialsLoader`. The bearer
+    token is sent
     on every request via ``Authorization: Bearer <token>`` — no session is
     established and no 401-driven re-login is needed.
 
@@ -172,7 +175,10 @@ class ArgoCdConnector(HttpConnector):
         credentials_loader: ArgoCdCredentialsLoader | None = None,
     ) -> None:
         super().__init__()
-        self._creds_cache: dict[str, dict[str, str]] = {}
+        # Keyed on the tenant-unique ``(tenant_id, target.id)`` tuple
+        # (``target_cache_key``) so two same-named targets in different
+        # tenants never share a cached token (#1642/#1672).
+        self._creds_cache: dict[tuple[str, str], dict[str, str]] = {}
         self._creds_lock = asyncio.Lock()
         self._credentials_loader: ArgoCdCredentialsLoader = (
             credentials_loader if credentials_loader is not None else load_credentials_from_vault
@@ -228,8 +234,9 @@ class ArgoCdConnector(HttpConnector):
         itself (#1008). Real-operator behaviour is unchanged — cold load →
         cache → reuse.
         """
+        cache_key = target_cache_key(target)
         async with self._creds_lock:
-            cached = self._creds_cache.get(target.name)
+            cached = self._creds_cache.get(cache_key)
             if cached is not None and not is_system_operator(operator):
                 return cached
             raw = await self._credentials_loader(target, operator)
@@ -239,7 +246,7 @@ class ArgoCdConnector(HttpConnector):
                     f"dict missing required key {ARGOCD_TOKEN_FIELD!r}; need "
                     "{'token': str}"
                 )
-            self._creds_cache[target.name] = raw
+            self._creds_cache[cache_key] = raw
             _log.info(
                 "argocd_credentials_loaded",
                 target=target.name,

--- a/backend/src/meho_backplane/connectors/argocd/session.py
+++ b/backend/src/meho_backplane/connectors/argocd/session.py
@@ -77,8 +77,15 @@ class ArgoCdTargetLike(Protocol):
     ``KeyError``. ``port`` is optional — ``argocd-server`` defaults to 443
     and :meth:`HttpConnector._base_url` already handles the
     ``port is None or 443`` case correctly.
+
+    ``id`` / ``tenant_id`` form the tenant-unique ``(tenant_id, id)``
+    cache key (:func:`~meho_backplane.connectors._shared.cache_key.target_cache_key`)
+    the credential cache uses, so two same-named targets in different
+    tenants never share a cached token (#1642/#1672).
     """
 
+    id: object
+    tenant_id: object
     name: str
     host: str
     port: int | None

--- a/backend/src/meho_backplane/connectors/gcloud/connector.py
+++ b/backend/src/meho_backplane/connectors/gcloud/connector.py
@@ -28,7 +28,8 @@ Impersonation** per decision #12 (transport = B). There are two layers:
    ``https://www.googleapis.com/auth/cloud-platform`` scope and
    ``lifetime=3600`` (the GCP maximum for impersonated tokens).
 
-The bearer token is cached per ``target.name``. On a 401 response,
+The bearer token is cached per tenant-unique ``(tenant_id, target.id)``
+tuple (#1642/#1672). On a 401 response,
 :meth:`_refresh_token` re-calls ``creds.refresh()`` to get a new token and
 retries the original request once.
 
@@ -94,6 +95,7 @@ import httpx
 import structlog
 
 from meho_backplane.auth.operator import Operator
+from meho_backplane.connectors._shared.cache_key import target_cache_key
 from meho_backplane.connectors._shared.system_operator import synthesise_system_operator
 from meho_backplane.connectors.adapters.http import HttpConnector
 from meho_backplane.connectors.gcloud.session import (
@@ -227,7 +229,9 @@ class GcloudConnector(HttpConnector):
     Auth: ``google.auth.default()`` for ADC source credentials, wrapped
     by ``google.auth.impersonated_credentials.Credentials`` targeting the
     SA in ``target.gcp_impersonate_sa``. Bearer token is cached per
-    ``target.name``; auto-refreshed on 401 via ``_ensure_token(target)``.
+    tenant-unique ``(tenant_id, target.id)`` tuple (#1642/#1672) so two
+    same-named targets in different tenants never share a cached token;
+    auto-refreshed on 401 via ``_ensure_token(target)``.
 
     SA-JSON-key material in the Vault ``secret_ref`` payload is refused
     before any token is built. The refusal is unconditional — org policy
@@ -273,10 +277,14 @@ class GcloudConnector(HttpConnector):
         self._adc_loader = adc_loader
         # Per-target cache: token string + impersonated Credentials object.
         # Per-target locks allow concurrent fetch/refresh for different targets
-        # without serialising across all targets (M1 fix).
-        self._token_cache: dict[str, str] = {}
-        self._creds_cache: dict[str, Any] = {}  # google.auth.impersonated_credentials.Credentials
-        self._token_locks: dict[str, asyncio.Lock] = {}
+        # without serialising across all targets (M1 fix). All three are keyed
+        # on the tenant-unique ``(tenant_id, target.id)`` tuple
+        # (``target_cache_key``) so two same-named targets in different tenants
+        # never share a cached token / credential / lock (#1642/#1672).
+        self._token_cache: dict[tuple[str, str], str] = {}
+        # google.auth.impersonated_credentials.Credentials
+        self._creds_cache: dict[tuple[str, str], Any] = {}
+        self._token_locks: dict[tuple[str, str], asyncio.Lock] = {}
 
     # ------------------------------------------------------------------
     # HttpConnector overrides
@@ -387,7 +395,8 @@ class GcloudConnector(HttpConnector):
         ``google.auth.default()`` + ``google.auth.impersonated_credentials.Credentials``.
         Caches the token string and the Credentials object.
 
-        A per-target lock (keyed by ``target.name``) serialises concurrent
+        A per-target lock (keyed by the tenant-unique ``(tenant_id, id)``
+        tuple) serialises concurrent
         first-use callers for the same target without blocking callers for
         different targets (M1 fix). Subsequent calls take the fast path
         (cached token still valid) without acquiring any lock.
@@ -404,19 +413,20 @@ class GcloudConnector(HttpConnector):
         """
         await self._gate_sa_key_refusal(target, operator)
 
+        cache_key = target_cache_key(target)
         # Fast path: cached and valid
-        cached_token = self._token_cache.get(target.name)
+        cached_token = self._token_cache.get(cache_key)
         if cached_token is not None:
-            creds = self._creds_cache.get(target.name)
+            creds = self._creds_cache.get(cache_key)
             if creds is not None and getattr(creds, "valid", False):
                 return cached_token
 
-        lock = self._token_locks.setdefault(target.name, asyncio.Lock())
+        lock = self._token_locks.setdefault(cache_key, asyncio.Lock())
         async with lock:
             # Re-check under lock in case another coroutine fetched first.
-            cached_token = self._token_cache.get(target.name)
+            cached_token = self._token_cache.get(cache_key)
             if cached_token is not None:
-                creds = self._creds_cache.get(target.name)
+                creds = self._creds_cache.get(cache_key)
                 if creds is not None and getattr(creds, "valid", False):
                     return cached_token
 
@@ -431,8 +441,9 @@ class GcloudConnector(HttpConnector):
         """
         loop = asyncio.get_running_loop()
         token, creds = await loop.run_in_executor(None, self._fetch_token_sync, target)
-        self._token_cache[target.name] = token
-        self._creds_cache[target.name] = creds
+        cache_key = target_cache_key(target)
+        self._token_cache[cache_key] = token
+        self._creds_cache[cache_key] = creds
         _log.info(
             "gcloud_token_fetched",
             target=target.name,
@@ -478,9 +489,10 @@ class GcloudConnector(HttpConnector):
         updates the cache, and returns the new token.
         """
         loop = asyncio.get_running_loop()
-        lock = self._token_locks.setdefault(target.name, asyncio.Lock())
+        cache_key = target_cache_key(target)
+        lock = self._token_locks.setdefault(cache_key, asyncio.Lock())
         async with lock:
-            creds = self._creds_cache.get(target.name)
+            creds = self._creds_cache.get(cache_key)
             if creds is None:
                 return await self._fetch_token(target)
 
@@ -492,7 +504,7 @@ class GcloudConnector(HttpConnector):
                 return str(creds.token)
 
             new_token = await loop.run_in_executor(None, _refresh_sync)
-            self._token_cache[target.name] = new_token
+            self._token_cache[cache_key] = new_token
             _log.info(
                 "gcloud_token_refreshed",
                 target=target.name,

--- a/backend/src/meho_backplane/connectors/gcloud/session.py
+++ b/backend/src/meho_backplane/connectors/gcloud/session.py
@@ -81,8 +81,15 @@ class GcloudTargetLike(Protocol):
     ``auth_model`` is checked at the boundary: only ``IMPERSONATION`` or
     ``None`` (pre-G0.3 sentinel) are accepted. Any other value raises a
     clear :exc:`NotImplementedError`.
+
+    ``id`` / ``tenant_id`` form the tenant-unique ``(tenant_id, id)``
+    cache key (:func:`~meho_backplane.connectors._shared.cache_key.target_cache_key`)
+    the token / credential / lock caches use, so two same-named targets in
+    different tenants never share a cached token (#1642/#1672).
     """
 
+    id: object
+    tenant_id: object
     name: str
     gcp_project: str
     gcp_impersonate_sa: str

--- a/backend/src/meho_backplane/connectors/github/connector.py
+++ b/backend/src/meho_backplane/connectors/github/connector.py
@@ -47,7 +47,9 @@ violation.
   passes through as the bearer credential. Documented but not
   first-class.
 
-Per-target cache scoping mirrors vmware-rest: keyed on ``target.name``,
+Per-target cache scoping mirrors vmware-rest: keyed on the tenant-unique
+``(tenant_id, target.id)`` tuple (#1642/#1672) so two same-named targets
+in different tenants never share a cached token,
 serialised under a single :class:`asyncio.Lock` so two concurrent
 first-use callers don't double-mint. The cache fast-path additionally
 rejects an empty operator JWT (defense-in-depth — the loader's
@@ -98,6 +100,7 @@ import httpx
 import structlog
 
 from meho_backplane.auth.operator import Operator
+from meho_backplane.connectors._shared.cache_key import target_cache_key
 from meho_backplane.connectors._shared.system_operator import synthesise_system_operator
 from meho_backplane.connectors._shared.vault_creds import VaultCredentialsReadError
 from meho_backplane.connectors.adapters.http import HttpConnector
@@ -185,13 +188,16 @@ class GitHubRestConnector(HttpConnector):
         passing ``None`` is the production shape.
         """
         super().__init__()
-        # Per-target installation-token cache. Keyed on target.name; the
-        # value's ``expires_at_monotonic`` drives cache-validity checks.
-        self._installation_tokens: dict[str, InstallationToken] = {}
-        # Per-target PAT cache — same shape but the token never expires
-        # from MEHO's side (the PAT carries its own GitHub-set TTL).
-        # Caching keeps the Vault read off the hot path.
-        self._pat_tokens: dict[str, str] = {}
+        # Per-target installation-token cache. Keyed on the tenant-unique
+        # ``(tenant_id, target.id)`` tuple (``target_cache_key``, #1642/#1672)
+        # so two same-named targets in different tenants never share a
+        # cached token; the value's ``expires_at_monotonic`` drives
+        # cache-validity checks.
+        self._installation_tokens: dict[tuple[str, str], InstallationToken] = {}
+        # Per-target PAT cache — same shape and tenant-unique key but the
+        # token never expires from MEHO's side (the PAT carries its own
+        # GitHub-set TTL). Caching keeps the Vault read off the hot path.
+        self._pat_tokens: dict[tuple[str, str], str] = {}
         self._token_lock = asyncio.Lock()
         # The injected http client is reserved for a future bring-your-
         # own-client test path; production uses the inherited per-target
@@ -289,12 +295,13 @@ class GitHubRestConnector(HttpConnector):
         / ``GitHubRateLimitedError``) when the App-mint round-trip
         itself fails.
         """
+        cache_key = target_cache_key(target)
         async with self._token_lock:
             now = time.monotonic()
-            cached_app = self._installation_tokens.get(target.name)
+            cached_app = self._installation_tokens.get(cache_key)
             if cached_app is not None and cached_app.expires_at_monotonic > now:
                 return cached_app.token
-            cached_pat = self._pat_tokens.get(target.name)
+            cached_pat = self._pat_tokens.get(cache_key)
             if cached_pat is not None:
                 return cached_pat
 
@@ -302,7 +309,7 @@ class GitHubRestConnector(HttpConnector):
             if isinstance(creds, GitHubAppCredentials):
                 return await self._mint_and_cache_installation_token(target, creds)
             if isinstance(creds, GitHubPATCredentials):
-                self._pat_tokens[target.name] = creds.token
+                self._pat_tokens[cache_key] = creds.token
                 _log.info(
                     "github_pat_token_loaded",
                     target=target.name,
@@ -344,7 +351,7 @@ class GitHubRestConnector(HttpConnector):
             installation_id=creds.installation_id,
             api_base_url=self._BASE_URL,
         )
-        self._installation_tokens[target.name] = installation
+        self._installation_tokens[target_cache_key(target)] = installation
         _log.info(
             "github_installation_token_minted",
             target=target.name,

--- a/backend/src/meho_backplane/connectors/github/session.py
+++ b/backend/src/meho_backplane/connectors/github/session.py
@@ -177,8 +177,15 @@ class GitHubTargetLike(Protocol):
     splits ``host`` at the first ``/`` so the bare API URL drives the
     httpx base URL and the trailing path (if any) drives the
     fingerprint endpoint selection.
+
+    ``id`` / ``tenant_id`` form the tenant-unique ``(tenant_id, id)``
+    cache key (:func:`~meho_backplane.connectors._shared.cache_key.target_cache_key`)
+    the installation-token + PAT caches use, so two same-named targets in
+    different tenants never share a cached token (#1642/#1672).
     """
 
+    id: object
+    tenant_id: object
     name: str
     host: str
     port: int | None

--- a/backend/src/meho_backplane/connectors/hetzner_robot/connector.py
+++ b/backend/src/meho_backplane/connectors/hetzner_robot/connector.py
@@ -79,6 +79,7 @@ import httpx
 import structlog
 
 from meho_backplane.auth.operator import Operator
+from meho_backplane.connectors._shared.cache_key import target_cache_key
 from meho_backplane.connectors._shared.system_operator import synthesise_system_operator
 from meho_backplane.connectors.adapters.http import HttpConnector
 from meho_backplane.connectors.hetzner_robot.session import (
@@ -127,8 +128,10 @@ def _basic_auth_header(username: str, password: str) -> str:
 class HetznerRobotConnector(HttpConnector):
     """Hetzner Robot Webservice connector with HTTP Basic auth.
 
-    Per-target credentials cached in :attr:`_creds_cache` (loaded once via
-    the injectable :class:`HetznerRobotCredentialsLoader`). HTTP Basic auth
+    Per-target credentials cached in :attr:`_creds_cache` keyed on the
+    tenant-unique ``(tenant_id, target.id)`` tuple (#1642/#1672), loaded
+    once via the injectable :class:`HetznerRobotCredentialsLoader`. HTTP
+    Basic auth
     is sent on every request via ``Authorization: Basic <base64>`` — no
     session token is established.
 
@@ -154,7 +157,10 @@ class HetznerRobotConnector(HttpConnector):
         credentials_loader: HetznerRobotCredentialsLoader | None = None,
     ) -> None:
         super().__init__()
-        self._creds_cache: dict[str, dict[str, str]] = {}
+        # Keyed on the tenant-unique ``(tenant_id, target.id)`` tuple
+        # (``target_cache_key``) so two same-named targets in different
+        # tenants never share cached credentials (#1642/#1672).
+        self._creds_cache: dict[tuple[str, str], dict[str, str]] = {}
         self._creds_lock = asyncio.Lock()
         self._credentials_loader: HetznerRobotCredentialsLoader = (
             credentials_loader if credentials_loader is not None else load_credentials_from_vault
@@ -195,8 +201,9 @@ class HetznerRobotConnector(HttpConnector):
         missing keys raise :exc:`RuntimeError` naming the target and the missing
         key so operators can identify a misconfigured Vault path.
         """
+        cache_key = target_cache_key(target)
         async with self._creds_lock:
-            cached = self._creds_cache.get(target.name)
+            cached = self._creds_cache.get(cache_key)
             if cached is not None:
                 return cached
             raw = await self._credentials_loader(target)
@@ -209,7 +216,7 @@ class HetznerRobotConnector(HttpConnector):
                     f"a dict missing required key {exc.args[0]!r}; need "
                     "{'username': str, 'password': str}"
                 ) from exc
-            self._creds_cache[target.name] = raw
+            self._creds_cache[cache_key] = raw
             _log.info(
                 "hetzner_robot_credentials_loaded",
                 target=target.name,

--- a/backend/src/meho_backplane/connectors/hetzner_robot/session.py
+++ b/backend/src/meho_backplane/connectors/hetzner_robot/session.py
@@ -66,8 +66,15 @@ class HetznerRobotTargetLike(Protocol):
     ``port`` is optional — the Robot API is HTTPS/443 and
     :meth:`HttpConnector._base_url` already handles the ``port is None or
     443`` case correctly.
+
+    ``id`` / ``tenant_id`` form the tenant-unique ``(tenant_id, id)``
+    cache key (:func:`~meho_backplane.connectors._shared.cache_key.target_cache_key`)
+    the credential cache uses, so two same-named targets in different
+    tenants never share cached credentials (#1642/#1672).
     """
 
+    id: object
+    tenant_id: object
     name: str
     host: str
     port: int | None

--- a/backend/src/meho_backplane/connectors/keycloak/connector.py
+++ b/backend/src/meho_backplane/connectors/keycloak/connector.py
@@ -92,6 +92,7 @@ import structlog
 from tenacity import retry, retry_if_exception, stop_after_attempt, wait_exponential
 
 from meho_backplane.auth.operator import Operator
+from meho_backplane.connectors._shared.cache_key import target_cache_key
 from meho_backplane.connectors._shared.vault_creds import VaultCredentialsReadError
 from meho_backplane.connectors._shared.vcf_auth import is_acceptable_auth_model
 from meho_backplane.connectors.adapters.http import HttpConnector, _retryable
@@ -310,7 +311,8 @@ class KeycloakConnector(HttpConnector):
     ``("keycloak", "27.x", ...)`` entry can ship alongside without
     disturbing 26.x targets.
 
-    Per-target admin token cached in :attr:`_admin_tokens` with a
+    Per-target admin token cached in :attr:`_admin_tokens` keyed on the
+    tenant-unique ``(tenant_id, target.id)`` tuple (#1642/#1672) with a
     TTL-driven refresh; per-target admin credentials are loaded fresh on
     each token mint (the secret read is cheap relative to the token
     round-trip and avoids holding the credential in memory between
@@ -334,7 +336,10 @@ class KeycloakConnector(HttpConnector):
         credentials_loader: KeycloakAdminCredentialsLoader | None = None,
     ) -> None:
         super().__init__()
-        self._admin_tokens: dict[str, _CachedToken] = {}
+        # Keyed on the tenant-unique ``(tenant_id, target.id)`` tuple
+        # (``target_cache_key``) so two same-named targets in different
+        # tenants never share a cached admin token (#1642/#1672).
+        self._admin_tokens: dict[tuple[str, str], _CachedToken] = {}
         self._token_lock = asyncio.Lock()
         self._credentials_loader: KeycloakAdminCredentialsLoader = (
             credentials_loader
@@ -391,13 +396,14 @@ class KeycloakConnector(HttpConnector):
                 f"target={target.name!r} has no operator JWT (system-initiated calls "
                 "cannot read the Keycloak admin credential)"
             )
+        cache_key = target_cache_key(target)
         async with self._token_lock:
             now = time.monotonic()
-            cached = self._admin_tokens.get(target.name)
+            cached = self._admin_tokens.get(cache_key)
             if cached is not None and cached.is_fresh(now):
                 return cached.token
             token, ttl = await self._mint_admin_token(target, operator)
-            self._admin_tokens[target.name] = _CachedToken(token, now + ttl)
+            self._admin_tokens[cache_key] = _CachedToken(token, now + ttl)
             return token
 
     async def _mint_admin_token(

--- a/backend/src/meho_backplane/connectors/keycloak/session.py
+++ b/backend/src/meho_backplane/connectors/keycloak/session.py
@@ -157,8 +157,14 @@ class KeycloakTargetLike(Protocol):
       only ``"shared_service_account"`` / ``None`` accepted.
     * ``extras`` — free-form mapping carrying the optional
       ``admin_realm`` / ``managed_realm`` overrides.
+    * ``id`` / ``tenant_id`` — the tenant-unique ``(tenant_id, id)``
+      cache key (:func:`~meho_backplane.connectors._shared.cache_key.target_cache_key`)
+      the admin-token cache uses, so two same-named targets in different
+      tenants never share a cached token (#1642/#1672).
     """
 
+    id: object
+    tenant_id: object
     name: str
     host: str
     port: int | None

--- a/backend/src/meho_backplane/connectors/vcf_automation/connector.py
+++ b/backend/src/meho_backplane/connectors/vcf_automation/connector.py
@@ -43,8 +43,10 @@ comment + login blocks, 2026-05-21):
   application/json``. Tokens are bespoke per plane; the provider
   JWT does NOT authenticate the tenant plane and vice versa.
 
-Both per-plane token caches are keyed on ``target.name`` and
-established lazily on first request that resolves to that plane.
+Both per-plane token caches are keyed on the tenant-unique
+``(tenant_id, target.id)`` tuple (``target_cache_key``, #1642/#1672) --
+so two same-named targets in different tenants never share a cached
+token -- and established lazily on first request that resolves to that plane.
 On HTTP 401 from a downstream call, the relevant plane's cache is
 invalidated and the call retries once -- consumer wrapper posture:
 re-login once on session-expiry, not a retry loop.
@@ -93,6 +95,7 @@ import httpx
 import structlog
 
 from meho_backplane.auth.operator import Operator
+from meho_backplane.connectors._shared.cache_key import target_cache_key
 from meho_backplane.connectors._shared.vault_creds import VaultCredentialsReadError
 from meho_backplane.connectors.adapters.http import HttpConnector
 from meho_backplane.connectors.schemas import (
@@ -161,10 +164,12 @@ class VcfAutomationConnector(HttpConnector):
         credentials_loader: VcfAutomationCredentialsLoader | None = None,
     ) -> None:
         super().__init__()
-        # Per-target, per-plane token caches. Keyed on target.name; same
-        # isolation invariant the NSX precedent established.
-        self._provider_tokens: dict[str, str] = {}
-        self._tenant_tokens: dict[str, str] = {}
+        # Per-target, per-plane token caches. Keyed on the tenant-unique
+        # ``(tenant_id, target.id)`` tuple (``target_cache_key``, #1642/#1672)
+        # so two same-named targets in different tenants never share a
+        # cached token; same isolation invariant the NSX precedent established.
+        self._provider_tokens: dict[tuple[str, str], str] = {}
+        self._tenant_tokens: dict[tuple[str, str], str] = {}
         # One lock per plane -- provider and tenant first-uses are
         # independent and shouldn't block each other.
         self._provider_lock = asyncio.Lock()
@@ -290,8 +295,9 @@ class VcfAutomationConnector(HttpConnector):
                 f"target={target.name!r} has no operator JWT (system-initiated calls "
                 "cannot read per-target vendor credentials)"
             )
+        cache_key = target_cache_key(target)
         async with self._provider_lock:
-            cached = self._provider_tokens.get(target.name)
+            cached = self._provider_tokens.get(cache_key)
             if cached is not None:
                 return cached
             override_ref = getattr(target, "provider_secret_ref", None)
@@ -300,7 +306,7 @@ class VcfAutomationConnector(HttpConnector):
             )
             client = await self._http_client(target)
             jwt = await vcfa_provider_login(client, creds, target)
-            self._provider_tokens[target.name] = jwt
+            self._provider_tokens[cache_key] = jwt
             return jwt
 
     async def _tenant_session_token(
@@ -339,8 +345,9 @@ class VcfAutomationConnector(HttpConnector):
                 f"target={target.name!r} has no operator JWT (system-initiated calls "
                 "cannot read per-target vendor credentials)"
             )
+        cache_key = target_cache_key(target)
         async with self._tenant_lock:
-            cached = self._tenant_tokens.get(target.name)
+            cached = self._tenant_tokens.get(cache_key)
             if cached is not None:
                 return cached
             creds = await load_credentials_with_override(
@@ -348,7 +355,7 @@ class VcfAutomationConnector(HttpConnector):
             )
             client = await self._http_client(target)
             token = await tenant_login(client, creds, target)
-            self._tenant_tokens[target.name] = token
+            self._tenant_tokens[cache_key] = token
             return token
 
     async def _invalidate_plane(self, target: VcfAutomationTargetLike, plane: Plane) -> None:
@@ -356,7 +363,7 @@ class VcfAutomationConnector(HttpConnector):
         lock = self._provider_lock if plane == "provider" else self._tenant_lock
         cache = self._provider_tokens if plane == "provider" else self._tenant_tokens
         async with lock:
-            cache.pop(target.name, None)
+            cache.pop(target_cache_key(target), None)
 
     # ------------------------------------------------------------------
     # Transport overrides -- thread path into auth_headers + 401 retry-once

--- a/backend/src/meho_backplane/connectors/vcf_automation/session.py
+++ b/backend/src/meho_backplane/connectors/vcf_automation/session.py
@@ -120,8 +120,15 @@ class VcfAutomationTargetLike(Protocol):
     password differs from the SSO secret -- the connector reads the
     provider plane via the override loader when set, the default loader
     otherwise.
+
+    ``id`` / ``tenant_id`` form the tenant-unique ``(tenant_id, id)``
+    cache key (:func:`~meho_backplane.connectors._shared.cache_key.target_cache_key`)
+    the per-plane token caches use, so two same-named targets in different
+    tenants never share a cached token (#1642/#1672).
     """
 
+    id: object
+    tenant_id: object
     name: str
     host: str
     port: int | None

--- a/backend/src/meho_backplane/connectors/vmware_rest/connector.py
+++ b/backend/src/meho_backplane/connectors/vmware_rest/connector.py
@@ -35,8 +35,10 @@ JSON-string-body response (or legacy ``{"value": "<token>"}`` shape) is
 the session token; subsequent calls reuse the cached value. Per-target
 isolation is the load-bearing invariant: two targets must never share a
 session token even if their names collide across tenants — the cache is
-keyed on ``target.name`` because that's the operator-supplied identifier
-the connector receives at the boundary.
+keyed on the tenant-unique ``(tenant_id, target.id)`` tuple via the
+shared :func:`~meho_backplane.connectors._shared.cache_key.target_cache_key`
+helper (#1642/#1672), so two same-named targets in different tenants
+never collapse onto one cached session.
 
 The session-establish flow runs under an :class:`asyncio.Lock` so two
 concurrent first-use callers against the same target don't both POST to
@@ -87,6 +89,7 @@ import httpx
 import structlog
 
 from meho_backplane.auth.operator import Operator
+from meho_backplane.connectors._shared.cache_key import target_cache_key
 from meho_backplane.connectors._shared.system_operator import synthesise_system_operator
 from meho_backplane.connectors._shared.vault_creds import VaultCredentialsReadError
 from meho_backplane.connectors.adapters.http import HttpConnector
@@ -210,7 +213,8 @@ def _is_acceptable_auth_model(value: Any) -> bool:
 class VmwareRestConnector(HttpConnector):
     """vSphere REST connector for vCenter 8.5+ / ESXi 8.5+ targets.
 
-    Per-target session cached in ``self._session_tokens``; token
+    Per-target session cached in ``self._session_tokens`` keyed on the
+    tenant-unique ``(tenant_id, target.id)`` tuple (#1642/#1672); token
     established on first call to :meth:`auth_headers` via
     ``POST /api/session`` with HTTP basic (service-account creds from
     the injectable :class:`VsphereSessionLoader`); revoked on
@@ -243,14 +247,23 @@ class VmwareRestConnector(HttpConnector):
         session_loader: VsphereSessionLoader | None = None,
     ) -> None:
         super().__init__()
-        self._session_tokens: dict[str, str] = {}
+        # Keyed on the tenant-unique ``(tenant_id, target.id)`` tuple
+        # (``target_cache_key``) so two same-named targets in different
+        # tenants never share a cached session (#1642/#1672).
+        self._session_tokens: dict[tuple[str, str], str] = {}
         # Tracks which session endpoint minted each cached token so
         # :meth:`aclose` can DELETE against the same path. Production
         # vCenter serves both ``/api/session`` and the legacy
         # ``/rest/com/vmware/cis/session``; vcsim serves only the legacy
         # path. See ``SESSION_PATH_MODERN`` / ``SESSION_PATH_LEGACY``
-        # for the rationale and source citations.
-        self._session_paths: dict[str, str] = {}
+        # for the rationale and source citations. Keyed on the same
+        # tenant-unique tuple as ``_session_tokens``.
+        self._session_paths: dict[tuple[str, str], str] = {}
+        # Maps each tenant-unique cache key back to its ``target.name`` so
+        # :meth:`aclose` can locate the per-target client in the shared
+        # ``HttpConnector._clients`` pool (which is keyed on ``target.name``
+        # and is explicitly out of scope for the #1672 re-keying).
+        self._session_names: dict[tuple[str, str], str] = {}
         self._session_lock = asyncio.Lock()
         self._session_loader: VsphereSessionLoader = (
             session_loader if session_loader is not None else load_session_credentials_from_vault
@@ -313,7 +326,7 @@ class VmwareRestConnector(HttpConnector):
         and force a spurious session establish on the pre-auth probe.
         """
         await self._session_token(target, operator)
-        session_path = self._session_paths.get(target.name, SESSION_PATH_MODERN)
+        session_path = self._session_paths.get(target_cache_key(target), SESSION_PATH_MODERN)
         return mounted_path(session_path, path)
 
     async def _session_token(self, target: VsphereTargetLike, operator: Operator) -> str:
@@ -365,59 +378,78 @@ class VmwareRestConnector(HttpConnector):
                 f"target={target.name!r} has no operator JWT (system-initiated calls "
                 "cannot read per-target vendor credentials)"
             )
+        cache_key = target_cache_key(target)
         async with self._session_lock:
-            cached = self._session_tokens.get(target.name)
+            cached = self._session_tokens.get(cache_key)
             if cached is not None:
                 return cached
-            creds = await self._session_loader(target, operator)
-            client = await self._http_client(target)
-            try:
-                username = creds["username"]
-                password = creds["password"]
-            except KeyError as exc:
-                # Surface a clear error if the loader returned a dict
-                # missing one of the two required keys — a typo in a
-                # production loader implementation otherwise surfaces
-                # as a confusing TypeError deep inside httpx's auth
-                # builder.
-                raise RuntimeError(
-                    f"vsphere session loader for target {target.name!r} returned "
-                    f"a dict missing required key {exc.args[0]!r}; need "
-                    "{'username': str, 'password': str}"
-                ) from exc
-            auth = (username, password)
-            resp = await client.post(SESSION_PATH_MODERN, auth=auth)
-            established_path = SESSION_PATH_MODERN
-            if resp.status_code == 404:
-                # Modern endpoint not served (vcsim, very old vCenter,
-                # or a reverse-proxy that hasn't been updated). Try the
-                # legacy path before declaring failure.
-                resp = await client.post(SESSION_PATH_LEGACY, auth=auth)
-                established_path = SESSION_PATH_LEGACY
-            try:
-                resp.raise_for_status()
-            except httpx.HTTPStatusError as exc:
-                # Wrap so the operator-facing message names the target;
-                # httpx's default str() shows only the URL/status, which
-                # loses the per-target identification the dispatcher's
-                # audit row needs. The path in the message is the last
-                # one attempted, which distinguishes a real 404 (legacy
-                # also missing) from auth/server failure on the modern
-                # path.
-                raise RuntimeError(
-                    f"vsphere session establish failed for target {target.name!r}: "
-                    f"POST {established_path} returned HTTP {exc.response.status_code}"
-                ) from exc
-            token = _extract_session_token(resp.json(), target.name)
-            self._session_tokens[target.name] = token
-            self._session_paths[target.name] = established_path
-            _log.info(
-                "vsphere_session_established",
-                target=target.name,
-                host=target.host,
-                session_path=established_path,
-            )
-            return token
+            return await self._establish_and_cache_session(target, operator, cache_key)
+
+    async def _establish_and_cache_session(
+        self,
+        target: VsphereTargetLike,
+        operator: Operator,
+        cache_key: tuple[str, str],
+    ) -> str:
+        """Establish a fresh vSphere session for *target* and cache it.
+
+        Called by :meth:`_session_token` under ``self._session_lock`` on a
+        cold cache. Resolves credentials via the loader, POSTs to the modern
+        session endpoint (falling back to the legacy path on a 404 only),
+        and records the token, the endpoint that minted it, and the target's
+        ``name`` (so :meth:`aclose` can find the per-target client in the
+        ``target.name``-keyed pool) against the tenant-unique *cache_key*.
+        """
+        creds = await self._session_loader(target, operator)
+        client = await self._http_client(target)
+        try:
+            username = creds["username"]
+            password = creds["password"]
+        except KeyError as exc:
+            # Surface a clear error if the loader returned a dict
+            # missing one of the two required keys — a typo in a
+            # production loader implementation otherwise surfaces
+            # as a confusing TypeError deep inside httpx's auth
+            # builder.
+            raise RuntimeError(
+                f"vsphere session loader for target {target.name!r} returned "
+                f"a dict missing required key {exc.args[0]!r}; need "
+                "{'username': str, 'password': str}"
+            ) from exc
+        auth = (username, password)
+        resp = await client.post(SESSION_PATH_MODERN, auth=auth)
+        established_path = SESSION_PATH_MODERN
+        if resp.status_code == 404:
+            # Modern endpoint not served (vcsim, very old vCenter,
+            # or a reverse-proxy that hasn't been updated). Try the
+            # legacy path before declaring failure.
+            resp = await client.post(SESSION_PATH_LEGACY, auth=auth)
+            established_path = SESSION_PATH_LEGACY
+        try:
+            resp.raise_for_status()
+        except httpx.HTTPStatusError as exc:
+            # Wrap so the operator-facing message names the target;
+            # httpx's default str() shows only the URL/status, which
+            # loses the per-target identification the dispatcher's
+            # audit row needs. The path in the message is the last
+            # one attempted, which distinguishes a real 404 (legacy
+            # also missing) from auth/server failure on the modern
+            # path.
+            raise RuntimeError(
+                f"vsphere session establish failed for target {target.name!r}: "
+                f"POST {established_path} returned HTTP {exc.response.status_code}"
+            ) from exc
+        token = _extract_session_token(resp.json(), target.name)
+        self._session_tokens[cache_key] = token
+        self._session_paths[cache_key] = established_path
+        self._session_names[cache_key] = target.name
+        _log.info(
+            "vsphere_session_established",
+            target=target.name,
+            host=target.host,
+            session_path=established_path,
+        )
+        return token
 
     async def fingerprint(
         self,
@@ -588,10 +620,18 @@ class VmwareRestConnector(HttpConnector):
         async with self._session_lock:
             tokens = dict(self._session_tokens)
             paths = dict(self._session_paths)
+            names = dict(self._session_names)
             self._session_tokens.clear()
             self._session_paths.clear()
-        for target_name, token in tokens.items():
-            client = self._clients.get(target_name)
+            self._session_names.clear()
+        for cache_key, token in tokens.items():
+            # ``_session_tokens`` is keyed on the tenant-unique
+            # ``(tenant_id, target.id)`` tuple (#1672), but the shared
+            # ``HttpConnector._clients`` pool is keyed on ``target.name``
+            # (explicitly out of scope). ``_session_names`` maps each
+            # cache key back to its name so we can locate the client.
+            target_name = names.get(cache_key)
+            client = self._clients.get(target_name) if target_name is not None else None
             if client is None:
                 # Theoretically unreachable — every cached token was
                 # established against a per-target client that was
@@ -603,7 +643,7 @@ class VmwareRestConnector(HttpConnector):
             # ``_session_token``; the default keeps shutdown safe if
             # a future code path ever caches a token without recording
             # its endpoint.
-            revoke_path = paths.get(target_name, SESSION_PATH_MODERN)
+            revoke_path = paths.get(cache_key, SESSION_PATH_MODERN)
             try:
                 resp = await client.request(
                     "DELETE",

--- a/backend/src/meho_backplane/connectors/vmware_rest/session.py
+++ b/backend/src/meho_backplane/connectors/vmware_rest/session.py
@@ -83,8 +83,15 @@ class VsphereTargetLike(Protocol):
     ``KeyError``. ``port`` is optional — vCenter defaults to 443 and
     :meth:`HttpConnector._base_url` already handles the
     ``port is None or 443`` case correctly.
+
+    ``id`` / ``tenant_id`` form the tenant-unique ``(tenant_id, id)``
+    cache key (:func:`~meho_backplane.connectors._shared.cache_key.target_cache_key`)
+    the session-token cache uses, so two same-named targets in different
+    tenants never share a cached session (#1642/#1672).
     """
 
+    id: object
+    tenant_id: object
     name: str
     host: str
     port: int | None

--- a/backend/tests/integration/test_connectors_vmware_rest_lab_smoke.py
+++ b/backend/tests/integration/test_connectors_vmware_rest_lab_smoke.py
@@ -85,6 +85,10 @@ class _LabTarget:
     """A lab vCenter target satisfying ``VsphereTargetLike``."""
 
     def __init__(self) -> None:
+        # Tenant-unique cache key components (#1642/#1672); without them
+        # ``target_cache_key`` raises AttributeError at runtime.
+        self.id: UUID = UUID(int=0x5A)
+        self.tenant_id: UUID = UUID(int=0)
         self.name = "vcenter-lab-smoke"
         # Strip any scheme an operator may have included in the env var.
         self.host = (_LAB_VCENTER or "").removeprefix("https://").removeprefix("http://")

--- a/backend/tests/integration/test_connectors_vmware_rest_vcsim.py
+++ b/backend/tests/integration/test_connectors_vmware_rest_vcsim.py
@@ -32,13 +32,15 @@ dependency — respx runs in-process.
 from __future__ import annotations
 
 from collections.abc import AsyncIterator
-from dataclasses import dataclass
+from dataclasses import dataclass, field
 from typing import Any
+from uuid import UUID, uuid4
 
 import pytest
 import respx
 
 from meho_backplane.auth.operator import Operator
+from meho_backplane.connectors._shared.cache_key import target_cache_key
 from meho_backplane.connectors.schemas import AuthModel
 from meho_backplane.connectors.vmware_rest import (
     VmwareRestConnector,
@@ -102,6 +104,12 @@ class _VcsimTarget:
     port: int | None
     secret_ref: str
     auth_model: str | None = AuthModel.SHARED_SERVICE_ACCOUNT.value
+    # Tenant-unique cache key components (#1642/#1672); without them
+    # ``target_cache_key`` raises AttributeError at runtime — the exact
+    # gap the Harbor integration double had that only the testcontainers
+    # lane caught in #1642.
+    id: UUID = field(default_factory=uuid4)
+    tenant_id: UUID = field(default_factory=lambda: UUID(int=0))
 
 
 @pytest.fixture
@@ -182,11 +190,12 @@ async def test_session_reused_across_consecutive_fingerprint_calls(
 ) -> None:
     """Two consecutive fingerprint calls share the same cached session token."""
     connector, target = vcsim_connector
+    cache_key = target_cache_key(target)
     await connector.fingerprint(target)
-    token_after_first = connector._session_tokens.get(target.name)
+    token_after_first = connector._session_tokens.get(cache_key)
     assert token_after_first is not None
     await connector.fingerprint(target)
-    token_after_second = connector._session_tokens.get(target.name)
+    token_after_second = connector._session_tokens.get(cache_key)
     # Load-bearing: the cached token is byte-identical across calls
     # (no re-establish).
     assert token_after_first == token_after_second
@@ -200,7 +209,7 @@ async def test_aclose_revokes_session_against_vcsim(
     connector, target = vcsim_connector
 
     await connector.fingerprint(target)
-    assert target.name in connector._session_tokens
+    assert target_cache_key(target) in connector._session_tokens
 
     await connector.aclose()
     # Post-aclose: token cache + client pool both emptied. (The fixture

--- a/backend/tests/test_connectors_argocd_auth.py
+++ b/backend/tests/test_connectors_argocd_auth.py
@@ -16,13 +16,14 @@ no username component; the stored token is sent verbatim.
 from __future__ import annotations
 
 from collections.abc import Iterator
-from dataclasses import dataclass
-from uuid import UUID
+from dataclasses import dataclass, field
+from uuid import UUID, uuid4
 
 import pytest
 import respx
 
 from meho_backplane.auth.operator import Operator, TenantRole
+from meho_backplane.connectors._shared.cache_key import target_cache_key
 from meho_backplane.connectors._shared.system_operator import (
     SYSTEM_OPERATOR_SUB,
     synthesise_system_operator,
@@ -85,6 +86,9 @@ class _StubTarget:
     port: int | None
     secret_ref: str
     auth_model: str | None = AuthModel.SHARED_SERVICE_ACCOUNT.value
+    # Tenant-unique cache key components (#1642/#1672).
+    id: UUID = field(default_factory=uuid4)
+    tenant_id: UUID = field(default_factory=lambda: UUID(int=0))
 
 
 _TARGET_A = _StubTarget(
@@ -212,6 +216,56 @@ async def test_per_target_isolation_keeps_tokens_separate() -> None:
     assert h_a == {"Authorization": "Bearer token-argocd-infra"}
     assert h_b == {"Authorization": "Bearer token-argocd-ci"}
     assert call_log == ["argocd-infra", "argocd-ci"]
+    await connector.aclose()
+
+
+@pytest.mark.asyncio
+async def test_same_name_targets_in_different_tenants_get_distinct_tokens() -> None:
+    """Same-named targets in DIFFERENT tenants never share a cached token.
+
+    Regression guard for #1642/#1672: the credential cache used to key on
+    ``target.name`` alone, so two same-named targets in different tenants
+    collapsed onto one entry and one tenant could be served another
+    tenant's token. The cache keys on the tenant-unique ``(tenant_id, id)``
+    tuple instead.
+    """
+    tenant_one = _StubTarget(
+        name="argocd-shared",
+        host="argocd-shared.test.invalid",
+        port=443,
+        secret_ref="targets/argocd-shared",
+        id=UUID(int=0x1),
+        tenant_id=UUID(int=0x100),
+    )
+    tenant_two = _StubTarget(
+        name="argocd-shared",
+        host="argocd-shared.test.invalid",
+        port=443,
+        secret_ref="targets/argocd-shared",
+        id=UUID(int=0x2),
+        tenant_id=UUID(int=0x200),
+    )
+    call_log: list[tuple[str, str]] = []
+
+    async def _tracking_loader(target: ArgoCdTargetLike, _operator: Operator) -> dict[str, str]:
+        call_log.append((str(target.tenant_id), str(target.id)))
+        return {"token": f"token-{target.tenant_id}"}
+
+    connector = ArgoCdConnector(credentials_loader=_tracking_loader)
+    h_one = await connector.auth_headers(tenant_one, operator=_make_operator())
+    h_two = await connector.auth_headers(tenant_two, operator=_make_operator())
+
+    # Each tenant loaded its own token — no cross-tenant cache hit.
+    assert h_one != h_two
+    assert len(call_log) == 2
+    assert connector._creds_cache == {
+        target_cache_key(tenant_one): {"token": f"token-{tenant_one.tenant_id}"},
+        target_cache_key(tenant_two): {"token": f"token-{tenant_two.tenant_id}"},
+    }
+
+    # Same-tenant re-fetch is a cache HIT — loader not re-invoked.
+    await connector.auth_headers(tenant_one, operator=_make_operator())
+    assert len(call_log) == 2
     await connector.aclose()
 
 
@@ -452,7 +506,7 @@ async def test_aclose_clears_token_cache_and_pool() -> None:
     """aclose() clears the in-memory token cache and tears down the httpx pool."""
     connector = _make_connector()
     await connector.auth_headers(_TARGET_A, operator=_make_operator())
-    assert "argocd-infra" in connector._creds_cache
+    assert target_cache_key(_TARGET_A) in connector._creds_cache
     await connector.aclose()
     assert connector._creds_cache == {}
     assert connector._clients == {}

--- a/backend/tests/test_connectors_argocd_credread.py
+++ b/backend/tests/test_connectors_argocd_credread.py
@@ -162,6 +162,9 @@ class _CredReadTarget:
         self.fingerprint = type("_FP", (), {"version": "3.3.9"})()
         self.preferred_impl_id: str | None = None
         self.id: UUID = uuid.uuid4()
+        # Tenant-unique cache key component (#1642/#1672); without it
+        # ``target_cache_key`` raises AttributeError at runtime.
+        self.tenant_id: UUID = uuid.UUID("00000000-0000-0000-0000-0000000000a1")
         self.name = "argocd-credread"
         self.host = _ARGOCD_HOST
         self.port = 443

--- a/backend/tests/test_connectors_argocd_reads.py
+++ b/backend/tests/test_connectors_argocd_reads.py
@@ -144,6 +144,9 @@ class _ReadTarget:
         self.fingerprint = type("_FP", (), {"version": "3.3.9"})()
         self.preferred_impl_id: str | None = None
         self.id: UUID = uuid.uuid4()
+        # Tenant-unique cache key component (#1642/#1672); without it
+        # ``target_cache_key`` raises AttributeError at runtime.
+        self.tenant_id: UUID = uuid.UUID("00000000-0000-0000-0000-0000000000a0")
         self.name = "argocd-reads"
         self.host = _ARGOCD_HOST
         self.port = 443

--- a/backend/tests/test_connectors_gcloud_auth.py
+++ b/backend/tests/test_connectors_gcloud_auth.py
@@ -23,15 +23,17 @@ from __future__ import annotations
 import asyncio
 import contextlib
 from collections.abc import Iterator
-from dataclasses import dataclass
+from dataclasses import dataclass, field
 from typing import Any
 from unittest.mock import MagicMock, patch
+from uuid import UUID, uuid4
 
 import httpx
 import pytest
 import respx
 
 from meho_backplane.auth.operator import Operator
+from meho_backplane.connectors._shared.cache_key import target_cache_key
 from meho_backplane.connectors._shared.system_operator import synthesise_system_operator
 from meho_backplane.connectors.adapters.http import HttpConnector
 from meho_backplane.connectors.gcloud import GcloudConnector, GcloudTargetLike
@@ -76,6 +78,9 @@ class _StubTarget:
     auth_model: str | None = AuthModel.IMPERSONATION.value
     host: str = "gcp.invalid"
     port: int | None = None
+    # Tenant-unique cache key components (#1642/#1672).
+    id: UUID = field(default_factory=uuid4)
+    tenant_id: UUID = field(default_factory=lambda: UUID(int=0))
 
 
 _TARGET_A = _StubTarget(
@@ -336,7 +341,7 @@ async def test_auth_headers_refuses_sa_json_key_in_secret_ref() -> None:
     assert "private_key" in msg
     assert "disableServiceAccountKeyCreation" in msg
     # No token should have been built
-    assert _TARGET_A.name not in connector._token_cache
+    assert target_cache_key(_TARGET_A) not in connector._token_cache
     await connector.aclose()
 
 
@@ -446,6 +451,69 @@ async def test_per_target_token_isolation() -> None:
     await connector.aclose()
 
 
+@pytest.mark.asyncio
+async def test_same_name_targets_in_different_tenants_get_distinct_tokens() -> None:
+    """Same-named targets in DIFFERENT tenants never share a cached token.
+
+    Regression guard for #1642/#1672: the token / creds / lock caches used
+    to key on ``target.name`` alone, so two same-named targets in different
+    tenants collapsed onto one entry and one tenant could be served
+    another tenant's token. The caches key on the tenant-unique
+    ``(tenant_id, id)`` tuple instead.
+    """
+    tenant_one = _StubTarget(
+        name="gcloud-shared",
+        gcp_project="proj-one",
+        gcp_impersonate_sa="svc@proj-one.iam.gserviceaccount.com",
+        secret_ref="gcloud/gcloud-shared",
+        id=UUID(int=0x1),
+        tenant_id=UUID(int=0x100),
+    )
+    tenant_two = _StubTarget(
+        name="gcloud-shared",
+        gcp_project="proj-two",
+        gcp_impersonate_sa="svc@proj-two.iam.gserviceaccount.com",
+        secret_ref="gcloud/gcloud-shared",
+        id=UUID(int=0x2),
+        tenant_id=UUID(int=0x200),
+    )
+
+    def _adc(scopes: list[str] | None = None) -> tuple[Any, str | None]:
+        return _make_mock_source_creds(), "p"
+
+    creds_seq = [_make_mock_creds("token-one"), _make_mock_creds("token-two")]
+    call_idx = 0
+
+    def _patch_impersonated(
+        source_credentials: Any,
+        target_principal: str,
+        target_scopes: list[str],
+        lifetime: int = 3600,
+    ) -> Any:
+        nonlocal call_idx
+        c = creds_seq[call_idx]
+        call_idx += 1
+        return c
+
+    connector = GcloudConnector(credentials_loader=_empty_loader, adc_loader=_adc)
+    with patch(
+        "google.auth.impersonated_credentials.Credentials",
+        side_effect=_patch_impersonated,
+    ):
+        h_one = await connector.auth_headers(tenant_one, operator=_OPERATOR)
+        h_two = await connector.auth_headers(tenant_two, operator=_OPERATOR)
+
+    # Each tenant minted its own token — no cross-tenant cache hit.
+    assert h_one["Authorization"] == "Bearer token-one"
+    assert h_two["Authorization"] == "Bearer token-two"
+    assert call_idx == 2
+    assert set(connector._token_cache) == {
+        target_cache_key(tenant_one),
+        target_cache_key(tenant_two),
+    }
+    await connector.aclose()
+
+
 # ---------------------------------------------------------------------------
 # 401 → token refresh → retry
 # ---------------------------------------------------------------------------
@@ -477,7 +545,7 @@ async def test_401_triggers_token_refresh_and_retry() -> None:
     ):
         # Pre-populate the token cache so the first call uses "initial-token"
         await connector.auth_headers(_TARGET_A, operator=_OPERATOR)
-        assert connector._token_cache.get("gcloud-a") == "initial-token"
+        assert connector._token_cache.get(target_cache_key(_TARGET_A)) == "initial-token"
 
         # First call: 401; second call: 200 (after token refresh)
         call_count = 0
@@ -699,7 +767,7 @@ async def test_aclose_clears_token_and_creds_cache() -> None:
     ):
         await connector.auth_headers(_TARGET_A, operator=_OPERATOR)
 
-    assert "gcloud-a" in connector._token_cache
+    assert target_cache_key(_TARGET_A) in connector._token_cache
     await connector.aclose()
     assert connector._token_cache == {}
     assert connector._creds_cache == {}
@@ -743,7 +811,7 @@ async def test_op_handler_get_path_refuses_sa_json_key() -> None:
     assert "gcloud-a" in msg
     assert "private_key" in msg
     assert "disableServiceAccountKeyCreation" in msg
-    assert _TARGET_A.name not in connector._token_cache
+    assert target_cache_key(_TARGET_A) not in connector._token_cache
     assert not connector._creds_cache
     await connector.aclose()
 
@@ -761,7 +829,7 @@ async def test_op_handler_post_path_refuses_sa_json_key() -> None:
     msg = str(exc_info.value)
     assert "gcloud-a" in msg
     assert "private_key" in msg
-    assert _TARGET_A.name not in connector._token_cache
+    assert target_cache_key(_TARGET_A) not in connector._token_cache
     await connector.aclose()
 
 
@@ -795,7 +863,7 @@ async def test_op_handler_compliant_secret_does_not_refuse() -> None:
     assert result["project_id"] == "my-project-123"
     assert result["project_number"] == "987654321"
     assert result["organization"] == "112233445566"
-    assert connector._token_cache.get("gcloud-a") == "tok"
+    assert connector._token_cache.get(target_cache_key(_TARGET_A)) == "tok"
     await connector.aclose()
 
 
@@ -814,7 +882,7 @@ async def test_fingerprint_refuses_sa_json_key_returns_unreachable() -> None:
     assert "error" in fp.extras
     assert "ValueError" in fp.extras["error"]
     assert "private_key" in fp.extras["error"]
-    assert _TARGET_A.name not in connector._token_cache
+    assert target_cache_key(_TARGET_A) not in connector._token_cache
     await connector.aclose()
 
 
@@ -828,7 +896,7 @@ async def test_probe_refuses_sa_json_key_returns_ok_false() -> None:
     assert result.reason is not None
     assert "ValueError" in result.reason
     assert "private_key" in result.reason
-    assert _TARGET_A.name not in connector._token_cache
+    assert target_cache_key(_TARGET_A) not in connector._token_cache
     await connector.aclose()
 
 

--- a/backend/tests/test_connectors_gcloud_e2e.py
+++ b/backend/tests/test_connectors_gcloud_e2e.py
@@ -38,9 +38,10 @@ when the env var is absent — they do not count as passing gates.
 from __future__ import annotations
 
 import os
-from dataclasses import dataclass
+from dataclasses import dataclass, field
 from typing import Any
 from unittest.mock import MagicMock, patch
+from uuid import UUID, uuid4
 
 import pytest
 import respx
@@ -98,6 +99,9 @@ class _StubTarget:
     auth_model: str | None = AuthModel.IMPERSONATION.value
     host: str = "gcp.invalid"
     port: int | None = None
+    # Tenant-unique cache key components (#1642/#1672).
+    id: UUID = field(default_factory=uuid4)
+    tenant_id: UUID = field(default_factory=lambda: UUID(int=0))
 
 
 _E2E_TARGET = _StubTarget(

--- a/backend/tests/test_connectors_gcloud_ops.py
+++ b/backend/tests/test_connectors_gcloud_ops.py
@@ -24,9 +24,10 @@ established in ``test_connectors_gcloud_auth.py``.
 
 from __future__ import annotations
 
-from dataclasses import dataclass
+from dataclasses import dataclass, field
 from typing import Any
 from unittest.mock import AsyncMock, MagicMock, patch
+from uuid import UUID, uuid4
 
 import pytest
 import respx
@@ -58,6 +59,9 @@ class _StubTarget:
     auth_model: str | None = AuthModel.IMPERSONATION.value
     host: str = "gcp.invalid"
     port: int | None = None
+    # Tenant-unique cache key components (#1642/#1672).
+    id: UUID = field(default_factory=uuid4)
+    tenant_id: UUID = field(default_factory=lambda: UUID(int=0))
 
 
 _TARGET = _StubTarget(

--- a/backend/tests/test_connectors_github_connector.py
+++ b/backend/tests/test_connectors_github_connector.py
@@ -33,8 +33,8 @@ use.
 from __future__ import annotations
 
 from collections.abc import Iterator
-from dataclasses import dataclass
-from uuid import UUID
+from dataclasses import dataclass, field
+from uuid import UUID, uuid4
 
 import httpx
 import pytest
@@ -94,6 +94,9 @@ class _FakeTarget:
     port: int | None = None
     secret_ref: str | None = "targets/github/test"
     auth_model: str | None = AuthModel.SHARED_SERVICE_ACCOUNT.value
+    # Tenant-unique cache key components (#1642/#1672).
+    id: UUID = field(default_factory=uuid4)
+    tenant_id: UUID = field(default_factory=lambda: UUID(int=0))
 
 
 @pytest.fixture

--- a/backend/tests/test_connectors_hetzner_robot_auth.py
+++ b/backend/tests/test_connectors_hetzner_robot_auth.py
@@ -19,13 +19,14 @@ from __future__ import annotations
 
 import base64
 from collections.abc import Iterator
-from dataclasses import dataclass
-from uuid import UUID
+from dataclasses import dataclass, field
+from uuid import UUID, uuid4
 
 import pytest
 import respx
 
 from meho_backplane.auth.operator import Operator, TenantRole
+from meho_backplane.connectors._shared.cache_key import target_cache_key
 from meho_backplane.connectors.adapters.http import HttpConnector
 from meho_backplane.connectors.hetzner_robot import (
     HetznerRobotConnector,
@@ -82,6 +83,9 @@ class _StubTarget:
     port: int | None
     secret_ref: str
     auth_model: str | None = AuthModel.SHARED_SERVICE_ACCOUNT.value
+    # Tenant-unique cache key components (#1642/#1672).
+    id: UUID = field(default_factory=uuid4)
+    tenant_id: UUID = field(default_factory=lambda: UUID(int=0))
 
 
 _TARGET_A = _StubTarget(
@@ -313,6 +317,58 @@ async def test_per_target_isolation_keeps_credentials_separate() -> None:
     assert username_a == "svc-robot-a"
     assert username_b == "svc-robot-b"
     assert call_log == ["robot-a", "robot-b"]
+    await connector.aclose()
+
+
+@pytest.mark.asyncio
+async def test_same_name_targets_in_different_tenants_get_distinct_credentials() -> None:
+    """Same-named targets in DIFFERENT tenants never share cached credentials.
+
+    Regression guard for #1642/#1672: the credential cache used to key on
+    ``target.name`` alone, so two same-named targets in different tenants
+    collapsed onto one entry. The cache keys on the tenant-unique
+    ``(tenant_id, id)`` tuple instead.
+    """
+    tenant_one = _StubTarget(
+        name="robot-shared",
+        host="robot.your-server.de",
+        port=443,
+        secret_ref="hetzner/robot-shared",
+        id=UUID(int=0x1),
+        tenant_id=UUID(int=0x100),
+    )
+    tenant_two = _StubTarget(
+        name="robot-shared",
+        host="robot.your-server.de",
+        port=443,
+        secret_ref="hetzner/robot-shared",
+        id=UUID(int=0x2),
+        tenant_id=UUID(int=0x200),
+    )
+    call_log: list[str] = []
+
+    async def _tracking_loader(target: HetznerRobotTargetLike) -> dict[str, str]:
+        call_log.append(str(target.tenant_id))
+        return {"username": f"svc-{target.tenant_id}", "password": "pass"}
+
+    connector = HetznerRobotConnector(credentials_loader=_tracking_loader)
+    h_one = await connector.auth_headers(tenant_one, operator=_make_operator())
+    h_two = await connector.auth_headers(tenant_two, operator=_make_operator())
+
+    user_one, _ = _decode_basic_auth(h_one["Authorization"])
+    user_two, _ = _decode_basic_auth(h_two["Authorization"])
+    # Each tenant loaded its own credential — no cross-tenant cache hit.
+    assert user_one == f"svc-{tenant_one.tenant_id}"
+    assert user_two == f"svc-{tenant_two.tenant_id}"
+    assert len(call_log) == 2
+    assert set(connector._creds_cache) == {
+        target_cache_key(tenant_one),
+        target_cache_key(tenant_two),
+    }
+
+    # Same-tenant re-fetch is a cache HIT — loader not re-invoked.
+    await connector.auth_headers(tenant_one, operator=_make_operator())
+    assert len(call_log) == 2
     await connector.aclose()
 
 
@@ -552,7 +608,7 @@ async def test_aclose_clears_credential_cache_and_pool() -> None:
     """aclose() clears the in-memory credential cache and tears down the httpx pool."""
     connector = _make_connector()
     await connector.auth_headers(_TARGET_A, operator=_make_operator())
-    assert "robot-a" in connector._creds_cache
+    assert target_cache_key(_TARGET_A) in connector._creds_cache
     await connector.aclose()
     assert connector._creds_cache == {}
     assert connector._clients == {}

--- a/backend/tests/test_connectors_keycloak_auth.py
+++ b/backend/tests/test_connectors_keycloak_auth.py
@@ -34,12 +34,13 @@ from __future__ import annotations
 from collections.abc import Iterator
 from dataclasses import dataclass, field
 from typing import Any
-from uuid import UUID
+from uuid import UUID, uuid4
 
 import pytest
 import respx
 
 from meho_backplane.auth.operator import Operator, TenantRole
+from meho_backplane.connectors._shared.cache_key import target_cache_key
 from meho_backplane.connectors._shared.vault_creds import VaultCredentialsReadError
 from meho_backplane.connectors.adapters.http import HttpConnector
 from meho_backplane.connectors.keycloak import KeycloakConnector
@@ -111,6 +112,9 @@ class _StubTarget:
     secret_ref: str | None = "rdc-hetzner-dc/keycloak/admin"
     auth_model: str | None = AuthModel.SHARED_SERVICE_ACCOUNT.value
     extras: dict[str, Any] = field(default_factory=dict)
+    # Tenant-unique cache key components (#1642/#1672).
+    id: UUID = field(default_factory=uuid4)
+    tenant_id: UUID = field(default_factory=lambda: UUID(int=0))
 
 
 _TARGET = _StubTarget(name="keycloak-a", host="keycloak-a.test.invalid")
@@ -287,6 +291,58 @@ async def test_admin_token_cached_across_calls() -> None:
 
     assert h1 == h2 == {"Authorization": f"Bearer {_ADMIN_TOKEN}"}
     assert token_route.call_count == 1
+
+    await connector.aclose()
+
+
+@pytest.mark.asyncio
+async def test_same_name_targets_in_different_tenants_get_distinct_tokens() -> None:
+    """Same-named targets in DIFFERENT tenants never share a cached admin token.
+
+    Regression guard for #1642/#1672: the admin-token cache used to key on
+    ``target.name`` alone, so two same-named targets in different tenants
+    collapsed onto one entry and one tenant could be served another
+    tenant's token. The cache keys on the tenant-unique ``(tenant_id, id)``
+    tuple instead. Both stub targets share one host so the established
+    admin token, not the per-target HTTP-client pool, is under test.
+    """
+    connector = _make_connector()
+    tenant_one = _StubTarget(
+        name="keycloak-shared",
+        host="keycloak-shared.test.invalid",
+        id=UUID(int=0x1),
+        tenant_id=UUID(int=0x100),
+    )
+    tenant_two = _StubTarget(
+        name="keycloak-shared",
+        host="keycloak-shared.test.invalid",
+        id=UUID(int=0x2),
+        tenant_id=UUID(int=0x200),
+    )
+
+    async with respx.mock(base_url="https://keycloak-shared.test.invalid") as mock:
+        token_route = mock.post("/realms/master/protocol/openid-connect/token").respond(
+            200, json={"access_token": _ADMIN_TOKEN, "expires_in": 3600}
+        )
+        await connector.auth_headers(tenant_one, operator=_make_operator())
+        await connector.auth_headers(tenant_two, operator=_make_operator())
+
+    # Each tenant minted its own token — no cross-tenant cache hit.
+    assert token_route.call_count == 2
+    assert set(connector._admin_tokens) == {
+        target_cache_key(tenant_one),
+        target_cache_key(tenant_two),
+    }
+
+    # Same-tenant re-fetch is a cache HIT — token endpoint not re-hit.
+    async with respx.mock(
+        base_url="https://keycloak-shared.test.invalid", assert_all_called=False
+    ) as mock:
+        again = mock.post("/realms/master/protocol/openid-connect/token").respond(
+            200, json={"access_token": "different", "expires_in": 3600}
+        )
+        await connector.auth_headers(tenant_one, operator=_make_operator())
+        assert again.call_count == 0
 
     await connector.aclose()
 

--- a/backend/tests/test_connectors_keycloak_path_encoding.py
+++ b/backend/tests/test_connectors_keycloak_path_encoding.py
@@ -158,6 +158,11 @@ async def test_client_get_encodes_traversal_id_in_request_path() -> None:
     target_stub.secret_ref = "stub/secret"
     target_stub.auth_model = "shared_service_account"
     target_stub.extras = {}
+    # Tenant-unique cache key components (#1642/#1672); a MagicMock with a
+    # Protocol spec does not auto-expose annotation-only attributes, so set
+    # them explicitly or target_cache_key raises AttributeError.
+    target_stub.id = uuid.UUID(int=0xCE)
+    target_stub.tenant_id = uuid.UUID(int=0)
 
     # Patch the connector to use our mock transport via respx.
     with respx.mock(base_url=_KC_BASE_URL, assert_all_called=False) as mock:
@@ -198,6 +203,11 @@ async def test_role_mapping_get_encodes_traversal_id_in_request_path() -> None:
     target_stub.secret_ref = "stub/secret"
     target_stub.auth_model = "shared_service_account"
     target_stub.extras = {}
+    # Tenant-unique cache key components (#1642/#1672); a MagicMock with a
+    # Protocol spec does not auto-expose annotation-only attributes, so set
+    # them explicitly or target_cache_key raises AttributeError.
+    target_stub.id = uuid.UUID(int=0xCE)
+    target_stub.tenant_id = uuid.UUID(int=0)
 
     with respx.mock(base_url=_KC_BASE_URL, assert_all_called=False) as mock:
         mock.post("/realms/master/protocol/openid-connect/token").respond(

--- a/backend/tests/test_connectors_vcf_automation_auth.py
+++ b/backend/tests/test_connectors_vcf_automation_auth.py
@@ -31,14 +31,15 @@ from __future__ import annotations
 
 import base64
 from collections.abc import Iterator
-from dataclasses import dataclass
-from uuid import UUID
+from dataclasses import dataclass, field
+from uuid import UUID, uuid4
 
 import httpx
 import pytest
 import respx
 
 from meho_backplane.auth.operator import Operator, TenantRole
+from meho_backplane.connectors._shared.cache_key import target_cache_key
 from meho_backplane.connectors.adapters.http import HttpConnector
 from meho_backplane.connectors.registry import (
     clear_registry,
@@ -109,6 +110,9 @@ class _StubTarget:
     domain: str | None = None
     provider_username: str | None = None
     provider_secret_ref: str | None = None
+    # Tenant-unique cache key components (#1642/#1672).
+    id: UUID = field(default_factory=uuid4)
+    tenant_id: UUID = field(default_factory=lambda: UUID(int=0))
 
 
 _TARGET_A = _StubTarget(
@@ -443,8 +447,8 @@ async def test_provider_and_tenant_caches_are_independent_per_target() -> None:
             _TARGET_A, operator=_make_operator(), path="/iaas/api/projects"
         )
 
-    assert connector._provider_tokens == {"vcfa-a": "p-jwt-1"}
-    assert connector._tenant_tokens == {"vcfa-a": "t-tok-1"}
+    assert connector._provider_tokens == {target_cache_key(_TARGET_A): "p-jwt-1"}
+    assert connector._tenant_tokens == {target_cache_key(_TARGET_A): "t-tok-1"}
     await connector.aclose()
 
 
@@ -476,8 +480,80 @@ async def test_per_target_isolation_keeps_both_plane_caches_separate() -> None:
             _TARGET_B, operator=_make_operator(), path="/iaas/api/projects"
         )
 
-    assert connector._provider_tokens == {"vcfa-a": "p-a", "vcfa-b": "p-b"}
-    assert connector._tenant_tokens == {"vcfa-a": "t-a", "vcfa-b": "t-b"}
+    assert connector._provider_tokens == {
+        target_cache_key(_TARGET_A): "p-a",
+        target_cache_key(_TARGET_B): "p-b",
+    }
+    assert connector._tenant_tokens == {
+        target_cache_key(_TARGET_A): "t-a",
+        target_cache_key(_TARGET_B): "t-b",
+    }
+    await connector.aclose()
+
+
+@pytest.mark.asyncio
+async def test_same_name_targets_in_different_tenants_get_distinct_tokens() -> None:
+    """Same-named targets in DIFFERENT tenants never share cached plane tokens.
+
+    Regression guard for #1642/#1672: both per-plane token caches used to
+    key on ``target.name`` alone, so two same-named targets in different
+    tenants collapsed onto one entry. The caches key on the tenant-unique
+    ``(tenant_id, id)`` tuple instead. Both stub targets share one host so
+    the established tokens, not the per-target HTTP-client pool, are under
+    test.
+    """
+    connector = _make_connector()
+    tenant_one = _StubTarget(
+        name="vcfa-shared",
+        host="vcfa-shared.test.invalid",
+        port=443,
+        secret_ref="vcfa/vcfa-shared",
+        id=UUID(int=0x1),
+        tenant_id=UUID(int=0x100),
+    )
+    tenant_two = _StubTarget(
+        name="vcfa-shared",
+        host="vcfa-shared.test.invalid",
+        port=443,
+        secret_ref="vcfa/vcfa-shared",
+        id=UUID(int=0x2),
+        tenant_id=UUID(int=0x200),
+    )
+
+    async with respx.mock(base_url="https://vcfa-shared.test.invalid") as mock:
+        mock.post("/cloudapi/1.0.0/sessions/provider").mock(
+            side_effect=[
+                httpx.Response(200, headers={"X-VMWARE-VCLOUD-ACCESS-TOKEN": "p-one"}),
+                httpx.Response(200, headers={"X-VMWARE-VCLOUD-ACCESS-TOKEN": "p-two"}),
+            ]
+        )
+        mock.post("/iaas/api/login").mock(
+            side_effect=[
+                httpx.Response(200, json={"token": "t-one"}),
+                httpx.Response(200, json={"token": "t-two"}),
+            ]
+        )
+        await connector.auth_headers(
+            tenant_one, operator=_make_operator(), path="/cloudapi/1.0.0/orgs"
+        )
+        await connector.auth_headers(
+            tenant_two, operator=_make_operator(), path="/cloudapi/1.0.0/orgs"
+        )
+        await connector.auth_headers(
+            tenant_one, operator=_make_operator(), path="/iaas/api/projects"
+        )
+        await connector.auth_headers(
+            tenant_two, operator=_make_operator(), path="/iaas/api/projects"
+        )
+
+    assert connector._provider_tokens == {
+        target_cache_key(tenant_one): "p-one",
+        target_cache_key(tenant_two): "p-two",
+    }
+    assert connector._tenant_tokens == {
+        target_cache_key(tenant_one): "t-one",
+        target_cache_key(tenant_two): "t-two",
+    }
     await connector.aclose()
 
 
@@ -742,7 +818,7 @@ async def test_provider_plane_401_triggers_relogin_and_retry_once() -> None:
     assert login.call_count == 2
     assert orgs.call_count == 2
     # Cache holds the refreshed token; tenant cache untouched.
-    assert connector._provider_tokens == {"vcfa-a": "p-jwt-second"}
+    assert connector._provider_tokens == {target_cache_key(_TARGET_A): "p-jwt-second"}
     assert connector._tenant_tokens == {}
     await connector.aclose()
 
@@ -803,8 +879,8 @@ async def test_tenant_plane_401_triggers_independent_relogin_and_retry_once() ->
     assert tenant_login.call_count == 2
     assert projects.call_count == 2
     # The provider cache survived the tenant-plane re-login.
-    assert connector._provider_tokens == {"vcfa-a": "p-jwt-stable"}
-    assert connector._tenant_tokens == {"vcfa-a": "t-second"}
+    assert connector._provider_tokens == {target_cache_key(_TARGET_A): "p-jwt-stable"}
+    assert connector._tenant_tokens == {target_cache_key(_TARGET_A): "t-second"}
     await connector.aclose()
 
 
@@ -958,8 +1034,8 @@ async def test_aclose_clears_both_plane_caches_and_pool() -> None:
             _TARGET_A, operator=_make_operator(), path="/iaas/api/projects"
         )
 
-    assert connector._provider_tokens == {"vcfa-a": "p-jwt"}
-    assert connector._tenant_tokens == {"vcfa-a": "t-tok"}
+    assert connector._provider_tokens == {target_cache_key(_TARGET_A): "p-jwt"}
+    assert connector._tenant_tokens == {target_cache_key(_TARGET_A): "t-tok"}
     await connector.aclose()
     assert connector._provider_tokens == {}
     assert connector._tenant_tokens == {}

--- a/backend/tests/test_connectors_vcf_automation_credread.py
+++ b/backend/tests/test_connectors_vcf_automation_credread.py
@@ -61,6 +61,7 @@ from structlog.testing import capture_logs
 import meho_backplane.operations._audit as audit_module
 from meho_backplane.auth.operator import Operator, TenantRole
 from meho_backplane.broadcast import BroadcastEvent
+from meho_backplane.connectors._shared.cache_key import target_cache_key
 from meho_backplane.connectors._shared.vault_creds import VaultCredentialsReadError
 from meho_backplane.connectors.registry import clear_registry, register_connector_v2
 from meho_backplane.connectors.vcf_automation import VcfAutomationConnector
@@ -204,6 +205,9 @@ class _CredReadTarget:
         self.fingerprint = type("_FP", (), {"version": _VERSION})()
         self.preferred_impl_id: str | None = None
         self.id: UUID = uuid.uuid4()
+        # Tenant-unique cache key component (#1642/#1672); without it
+        # ``target_cache_key`` would raise AttributeError at runtime.
+        self.tenant_id: UUID = UUID("00000000-0000-0000-0000-00000000a0fa")
         self.name = "vcfa-credread-target"
         self.host = _VCFA_FQDN
         self.port = 443
@@ -496,8 +500,9 @@ async def test_session_token_fast_paths_fail_closed_on_empty_raw_jwt() -> None:
 
     assert primed_provider == _CANARY_PROVIDER_JWT
     assert primed_tenant == _CANARY_TENANT_TOKEN
-    assert connector._provider_tokens[target.name] == _CANARY_PROVIDER_JWT
-    assert connector._tenant_tokens[target.name] == _CANARY_TENANT_TOKEN
+    cache_key = target_cache_key(target)
+    assert connector._provider_tokens[cache_key] == _CANARY_PROVIDER_JWT
+    assert connector._tenant_tokens[cache_key] == _CANARY_TENANT_TOKEN
 
     system_operator = Operator(
         sub="system",
@@ -520,7 +525,7 @@ async def test_session_token_fast_paths_fail_closed_on_empty_raw_jwt() -> None:
 
     # Both caches still hold the primed tokens; the guards ran ahead
     # of any cache mutation.
-    assert connector._provider_tokens[target.name] == _CANARY_PROVIDER_JWT
-    assert connector._tenant_tokens[target.name] == _CANARY_TENANT_TOKEN
+    assert connector._provider_tokens[cache_key] == _CANARY_PROVIDER_JWT
+    assert connector._tenant_tokens[cache_key] == _CANARY_TENANT_TOKEN
 
     await connector.aclose()

--- a/backend/tests/test_connectors_vcf_automation_e2e.py
+++ b/backend/tests/test_connectors_vcf_automation_e2e.py
@@ -68,6 +68,7 @@ from sqlalchemy import select
 
 import meho_backplane.operations._audit as audit_module
 from meho_backplane.auth.operator import Operator, TenantRole
+from meho_backplane.connectors._shared.cache_key import target_cache_key
 from meho_backplane.connectors.registry import all_connectors_v2
 from meho_backplane.connectors.schemas import FingerprintResult
 from meho_backplane.connectors.vcf_automation import (
@@ -549,6 +550,7 @@ def _register_vcfa_routes(mock: respx.MockRouter) -> None:
 class _VcfaE2EBundle:
     target_name: str
     connector_instance: VcfAutomationConnector
+    db_target: Any
 
 
 @pytest.fixture
@@ -573,7 +575,7 @@ async def vcfa_e2e_canary(captured_events: list[Any]) -> AsyncIterator[_VcfaE2EB
        register the dual-plane login + 11 read-op routes.
     """
     await _insert_vcfa_descriptors()
-    await _seed_target(host="10.10.10.5", fqdn=VCFA_E2E_FQDN)
+    seeded_target = await _seed_target(host="10.10.10.5", fqdn=VCFA_E2E_FQDN)
     instance = _resolve_connector()
 
     async with respx.mock(
@@ -586,6 +588,7 @@ async def vcfa_e2e_canary(captured_events: list[Any]) -> AsyncIterator[_VcfaE2EB
             yield _VcfaE2EBundle(
                 target_name=VCFA_E2E_TARGET_NAME,
                 connector_instance=instance,
+                db_target=seeded_target,
             )
         finally:
             await instance.aclose()
@@ -641,8 +644,11 @@ async def test_vcfa_e2e_provider_login_fires_once_per_target(
     """
     instance = vcfa_e2e_canary.connector_instance
     target_name = vcfa_e2e_canary.target_name
+    # The token caches key on the tenant-unique (tenant_id, id) tuple
+    # (#1642/#1672), not the bare name.
+    cache_key = target_cache_key(vcfa_e2e_canary.db_target)
 
-    assert target_name not in instance._provider_tokens, (
+    assert cache_key not in instance._provider_tokens, (
         f"Expected empty provider cache before first dispatch; got {instance._provider_tokens!r}"
     )
     result = await call_operation(
@@ -655,13 +661,13 @@ async def test_vcfa_e2e_provider_login_fires_once_per_target(
         },
     )
     assert result["status"] == "ok"
-    assert instance._provider_tokens.get(target_name) == _PROVIDER_JWT, (
+    assert instance._provider_tokens.get(cache_key) == _PROVIDER_JWT, (
         "Expected provider JWT cached after first provider-plane dispatch; "
         f"got _provider_tokens={instance._provider_tokens!r}"
     )
     # Tenant cache must remain untouched: provider dispatch only
     # establishes the provider session.
-    assert instance._tenant_tokens.get(target_name) is None, (
+    assert instance._tenant_tokens.get(cache_key) is None, (
         f"Tenant cache should be empty after provider-only dispatch; "
         f"got _tenant_tokens={instance._tenant_tokens!r}"
     )
@@ -673,6 +679,7 @@ async def test_vcfa_e2e_tenant_login_fires_once_per_target(
     """Tenant session-establish runs on first tenant dispatch and the token caches."""
     instance = vcfa_e2e_canary.connector_instance
     target_name = vcfa_e2e_canary.target_name
+    cache_key = target_cache_key(vcfa_e2e_canary.db_target)
 
     result = await call_operation(
         _OPERATOR,
@@ -684,7 +691,7 @@ async def test_vcfa_e2e_tenant_login_fires_once_per_target(
         },
     )
     assert result["status"] == "ok"
-    assert instance._tenant_tokens.get(target_name) == _TENANT_TOKEN, (
+    assert instance._tenant_tokens.get(cache_key) == _TENANT_TOKEN, (
         "Expected tenant token cached after first tenant-plane dispatch; "
         f"got _tenant_tokens={instance._tenant_tokens!r}"
     )

--- a/backend/tests/test_connectors_vmware_rest_auth.py
+++ b/backend/tests/test_connectors_vmware_rest_auth.py
@@ -33,14 +33,15 @@ Coverage matrix (per #498 acceptance criteria):
 from __future__ import annotations
 
 from collections.abc import Iterator
-from dataclasses import dataclass
-from uuid import UUID
+from dataclasses import dataclass, field
+from uuid import UUID, uuid4
 
 import httpx
 import pytest
 import respx
 
 from meho_backplane.auth.operator import Operator, TenantRole
+from meho_backplane.connectors._shared.cache_key import target_cache_key
 from meho_backplane.connectors.adapters.http import HttpConnector
 from meho_backplane.connectors.registry import (
     clear_registry,
@@ -134,6 +135,10 @@ class _StubTarget:
     port: int | None
     secret_ref: str
     auth_model: str | None = AuthModel.SHARED_SERVICE_ACCOUNT.value
+    # Tenant-unique cache key components (#1642/#1672). Distinct ``id`` per
+    # instance so two stub targets never collapse onto one cache entry.
+    id: UUID = field(default_factory=uuid4)
+    tenant_id: UUID = field(default_factory=lambda: UUID(int=0))
 
 
 _TARGET_A = _StubTarget(
@@ -260,6 +265,7 @@ def _patch_no_revoke_aclose(connector: VmwareRestConnector) -> None:
     async def _aclose() -> None:
         connector._session_tokens.clear()
         connector._session_paths.clear()
+        connector._session_names.clear()
         for client in connector._clients.values():
             await client.aclose()
         connector._clients.clear()
@@ -329,9 +335,66 @@ async def test_per_target_isolation_keeps_session_tokens_separate() -> None:
     assert h_b == {"vmware-api-session-id": "token-for-b"}
     # Both tokens cached.
     assert connector._session_tokens == {
-        "vcenter-a": "token-for-a",
-        "vcenter-b": "token-for-b",
+        target_cache_key(_TARGET_A): "token-for-a",
+        target_cache_key(_TARGET_B): "token-for-b",
     }
+    await connector.aclose()
+
+
+@pytest.mark.asyncio
+async def test_same_name_targets_in_different_tenants_get_distinct_sessions() -> None:
+    """Same-named targets in DIFFERENT tenants never share a cached session.
+
+    Regression guard for #1642/#1672: the session-token cache used to key
+    on ``target.name`` alone, so two same-named targets in different
+    tenants collapsed onto one entry and one tenant could be served
+    another tenant's session. The cache keys on the tenant-unique
+    ``(tenant_id, id)`` tuple instead. Both stub targets share one host
+    so the established session token, not the per-target HTTP-client pool,
+    is the variable under test.
+    """
+    connector = _make_connector()
+    _patch_no_revoke_aclose(connector)
+    tenant_one = _StubTarget(
+        name="vcenter-shared",
+        host="vcenter-shared.test.invalid",
+        port=443,
+        secret_ref="vsphere/vcenter-shared",
+        id=UUID(int=0x1),
+        tenant_id=UUID(int=0x100),
+    )
+    tenant_two = _StubTarget(
+        name="vcenter-shared",
+        host="vcenter-shared.test.invalid",
+        port=443,
+        secret_ref="vsphere/vcenter-shared",
+        id=UUID(int=0x2),
+        tenant_id=UUID(int=0x200),
+    )
+
+    async with respx.mock(base_url="https://vcenter-shared.test.invalid") as mock:
+        route = mock.post("/api/session").mock(
+            side_effect=[
+                httpx.Response(200, json="token-tenant-one"),
+                httpx.Response(200, json="token-tenant-two"),
+            ]
+        )
+        h_one = await connector.auth_headers(tenant_one, _make_operator())
+        h_two = await connector.auth_headers(tenant_two, _make_operator())
+
+    # Each tenant established its own session — no cross-tenant cache hit.
+    assert route.call_count == 2
+    assert h_one == {"vmware-api-session-id": "token-tenant-one"}
+    assert h_two == {"vmware-api-session-id": "token-tenant-two"}
+    assert connector._session_tokens == {
+        target_cache_key(tenant_one): "token-tenant-one",
+        target_cache_key(tenant_two): "token-tenant-two",
+    }
+
+    # Same-tenant re-fetch is a cache HIT — behaviour unchanged.
+    h_one_again = await connector.auth_headers(tenant_one, _make_operator())
+    assert h_one_again == {"vmware-api-session-id": "token-tenant-one"}
+    assert route.call_count == 2
     await connector.aclose()
 
 
@@ -428,7 +491,7 @@ async def test_modern_session_endpoint_is_tried_first_no_fallback_on_200() -> No
     assert headers == {"vmware-api-session-id": "modern-path-token"}
     assert modern.called and modern.call_count == 1
     # The cached path records the modern endpoint so aclose targets it.
-    assert connector._session_paths == {"vcenter-a": "/api/session"}
+    assert connector._session_paths == {target_cache_key(_TARGET_A): "/api/session"}
     await connector.aclose()
 
 
@@ -454,7 +517,7 @@ async def test_session_falls_back_to_legacy_path_on_modern_404() -> None:
     assert legacy.called and legacy.call_count == 1
     assert headers == {"vmware-api-session-id": "legacy-path-token"}
     # The legacy path is recorded so aclose DELETEs against it.
-    assert connector._session_paths == {"vcenter-a": "/rest/com/vmware/cis/session"}
+    assert connector._session_paths == {target_cache_key(_TARGET_A): "/rest/com/vmware/cis/session"}
     await connector.aclose()
 
 

--- a/backend/tests/test_connectors_vmware_rest_composites_recursive_e2e.py
+++ b/backend/tests/test_connectors_vmware_rest_composites_recursive_e2e.py
@@ -175,6 +175,9 @@ class _FakeVmwareTarget:
         self.fingerprint = _FakeFingerprint(version="9.0")
         self.preferred_impl_id: str | None = "vmware-rest"
         self.id: UUID = uuid.uuid4()
+        # Tenant-unique cache key component (#1642/#1672); without it
+        # ``target_cache_key`` raises AttributeError at runtime.
+        self.tenant_id: UUID = uuid.UUID("00000000-0000-0000-0000-0000000000a2")
         self.name = "test-vcenter"
         self.host = "vcenter.test"
         self.port = 443

--- a/backend/tests/test_connectors_vmware_rest_composites_write_e2e.py
+++ b/backend/tests/test_connectors_vmware_rest_composites_write_e2e.py
@@ -193,6 +193,9 @@ class _FakeVmwareTarget:
         self.fingerprint = _FakeFingerprint(version="9.0")
         self.preferred_impl_id: str | None = "vmware-rest"
         self.id: UUID = target_id or uuid.uuid4()
+        # Tenant-unique cache key component (#1642/#1672); without it
+        # ``target_cache_key`` raises AttributeError at runtime.
+        self.tenant_id: UUID = _TENANT_ID
         self.name = "test-vcenter"
         self.host = "vcenter.test"
         self.port = 443

--- a/backend/tests/test_connectors_vmware_rest_composites_write_preview.py
+++ b/backend/tests/test_connectors_vmware_rest_composites_write_preview.py
@@ -155,6 +155,9 @@ class _FakeVmwareTarget:
         self.fingerprint = _FakeFingerprint(version="9.0")
         self.preferred_impl_id: str | None = "vmware-rest"
         self.id: UUID = target_id or uuid.uuid4()
+        # Tenant-unique cache key component (#1642/#1672); without it
+        # ``target_cache_key`` raises AttributeError at runtime.
+        self.tenant_id: UUID = _TENANT_ID
         self.name = "test-vcenter"
         self.host = "vcenter.test"
         self.port = 443

--- a/backend/tests/test_connectors_vmware_rest_credread.py
+++ b/backend/tests/test_connectors_vmware_rest_credread.py
@@ -66,6 +66,7 @@ from structlog.testing import capture_logs
 import meho_backplane.operations._audit as audit_module
 from meho_backplane.auth.operator import Operator, TenantRole
 from meho_backplane.broadcast import BroadcastEvent
+from meho_backplane.connectors._shared.cache_key import target_cache_key
 from meho_backplane.connectors._shared.vault_creds import VaultCredentialsReadError
 from meho_backplane.connectors.registry import clear_registry, register_connector_v2
 from meho_backplane.connectors.vmware_rest import VmwareRestConnector
@@ -192,6 +193,9 @@ class _CredReadTarget:
         self.fingerprint = type("_FP", (), {"version": _VERSION})()
         self.preferred_impl_id: str | None = None
         self.id: UUID = uuid.uuid4()
+        # Tenant-unique cache key component (#1642/#1672); without it
+        # ``target_cache_key`` would raise AttributeError at runtime.
+        self.tenant_id: UUID = UUID("00000000-0000-0000-0000-00000000a0a0")
         self.name = "vcenter-credread"
         self.host = _VCENTER_HOST
         self.port = 443
@@ -382,7 +386,7 @@ async def test_session_token_fast_path_fails_closed_on_empty_raw_jwt() -> None:
         mock.delete("/api/session").respond(204)
         primed = await connector._session_token(target, _make_operator())
         assert primed == _SESSION_TOKEN
-        assert connector._session_tokens[target.name] == _SESSION_TOKEN
+        assert connector._session_tokens[target_cache_key(target)] == _SESSION_TOKEN
 
         system_operator = Operator(
             sub="system",
@@ -399,7 +403,7 @@ async def test_session_token_fast_path_fails_closed_on_empty_raw_jwt() -> None:
         assert "operator" in str(exc_info.value).lower()
         # The cache still holds the primed token; the guard ran ahead of
         # any cache mutation.
-        assert connector._session_tokens[target.name] == _SESSION_TOKEN
+        assert connector._session_tokens[target_cache_key(target)] == _SESSION_TOKEN
 
         # aclose() inside the respx.mock context so the DELETE /api/session
         # cleanup is mocked and never leaks to live network.

--- a/backend/tests/test_connectors_vmware_rest_fingerprint.py
+++ b/backend/tests/test_connectors_vmware_rest_fingerprint.py
@@ -21,8 +21,9 @@ Coverage matrix (per #498 acceptance criteria):
 
 from __future__ import annotations
 
-from dataclasses import dataclass
+from dataclasses import dataclass, field
 from typing import Any
+from uuid import UUID, uuid4
 
 import httpx
 import pytest
@@ -52,6 +53,9 @@ class _StubTarget:
     port: int | None
     secret_ref: str
     auth_model: str | None = AuthModel.SHARED_SERVICE_ACCOUNT.value
+    # Tenant-unique cache key components (#1642/#1672).
+    id: UUID = field(default_factory=uuid4)
+    tenant_id: UUID = field(default_factory=lambda: UUID(int=0))
 
 
 _TARGET = _StubTarget(
@@ -73,6 +77,7 @@ def _make_connector() -> VmwareRestConnector:
 def _patch_no_revoke_aclose(connector: VmwareRestConnector) -> None:
     async def _aclose() -> None:
         connector._session_tokens.clear()
+        connector._session_names.clear()
         for client in connector._clients.values():
             await client.aclose()
         connector._clients.clear()


### PR DESCRIPTION
## What

Extends the #1642 cross-tenant credential/session cache fix (landed as PR #1669) to the **seven remaining connectors** that still keyed credential / session / token caches on `target.name` alone. Two same-named targets in different tenants collapsed onto one cache entry, so one tenant could be served another tenant's cached token or credential.

Every affected cache now keys on the tenant-unique `(tenant_id, target.id)` tuple via the shared `meho_backplane.connectors._shared.cache_key.target_cache_key` helper (already on main from #1669).

## Connectors re-keyed

| Connector | Cache(s) re-keyed |
|---|---|
| `vcf_automation` | `_provider_tokens` + `_tenant_tokens` (both per-plane token caches) |
| `argocd` | `_creds_cache` |
| `gcloud` | `_token_cache` + `_creds_cache` + `_token_locks` |
| `keycloak` | `_admin_tokens` |
| `github` | `_installation_tokens` + `_pat_tokens` |
| `hetzner_robot` | `_creds_cache` |
| `vmware_rest` | `_session_tokens` + `_session_paths` (own caches only) |

Each connector's `*TargetLike` protocol is widened with `id`/`tenant_id` (mirrors how #1642 wired `vcf_auth`/`harbor`/`nsx`/`sddc`).

## vmware_rest specifics

- Only vmware_rest's **own** `_session_tokens`/`_session_paths` caches are re-keyed. The shared `HttpConnector._clients` connection pool stays keyed on `target.name` (out of scope per the issue — re-keying it breaks vmware_rest + ~14 tests).
- `aclose()` revokes sessions per-target and needs `target.name` to find the pooled client; since the token cache is now tuple-keyed, a new `_session_names` map (tenant-unique key → `target.name`) is populated in lock-step so `aclose` can still locate the client.
- The session-establish block was extracted into `_establish_and_cache_session` (behaviour-preserving) to keep `_session_token` under the code-quality function-size limit.

## Out of scope

- `HttpConnector._clients` connection pool (pooling concern, tracked separately).
- `adapters/ssh.py` `_connections` — a live-connection pool (SSHClientConnection objects), not a credential/session cache; the SSH equivalent of `_clients`.

## Tests

- Per-connector cross-tenant regression tests added: two same-named targets in different tenants get **distinct** cache entries; same-tenant re-fetch is still a cache **hit**.
- Per the #1642 lesson (the Harbor integration double missed `tenant_id` and only the testcontainers lane caught it): every duck-typed target double under `tests/integration/` and every unit-test target stub for these connectors now carries **both** `id` and `tenant_id`, so `target_cache_key` never raises `AttributeError` at runtime.

## Verification

- `ruff check` / `ruff format --check` — clean
- `mypy src/meho_backplane/connectors/ --ignore-missing-imports` — clean (143 files)
- code-quality `--diff` gate — exit 0 (0 blockers)
- `pytest -k "vcf_automation or argocd or gcloud or keycloak or github or hetzner or vmware_rest"` — 673 passed
- No `backend/src/meho_backplane/api/` changes → no OpenAPI regen needed

Closes #1672

🤖 Generated with [Claude Code](https://claude.com/claude-code)
