### PR TITLE
fix(connectors): stop async --spec ingest false-succeeding (non-dispatchable) + reconcile vcf-logs/vrli product split

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -216,16 +216,22 @@ connector-related release-notes line.
   `hetzner-robot/hetzner`, `sddc-manager/sddc`, `vcf-automation/vcfa`,
   `vcf-fleet/fleet`, `vcf-logs/vrli`, `vcf-operations/vrops`; a no-op for
   aligned connectors), and a registered-but-unpopulated row's `next_step`
-  verb emits the parser-derived `--product` so it round-trips to a
-  dispatchable ingest. (2) The async job flipped to `succeeded` purely
-  because the pipeline coroutine returned; it now applies a
-  dispatchability postcondition (`inserted_count > 0` and the connector
-  resolves under its dispatch key) and ends `degraded` with
-  `error_class="ingested_not_dispatchable"` when it fails — never a bare
-  `succeeded` over a connector that persisted nothing callable. New
-  `degraded` job status surfaces on the REST/MCP poll response and the
-  CLI renders it as a non-zero failure. Diagnoses the v0.13.0 vcf-logs
-  log-sentry false-success; see claude-rdc-hetzner-dc#1136. (#1647)
+  verb emits the **registry** `--product` (e.g. `vcf-logs`) so the
+  operator's ingest finds the real connector class and runs a real
+  version-coverage pre-flight — the same register-time reconciliation
+  then lands the rows dispatchably under the short product, so the verb
+  still round-trips. (2) The async job flipped to `succeeded` purely
+  because the pipeline coroutine returned; it now consults a
+  dispatchability probe (the connector resolves under its dispatch key)
+  and ends `degraded` with `error_class="ingested_not_dispatchable"` when
+  the run is genuinely non-dispatchable — never a bare `succeeded` over a
+  connector that persisted nothing callable. A benign idempotent re-run
+  (every op skipped, so `inserted_count == 0`, but the connector is
+  already dispatchable) stays `succeeded`, so a no-op re-ingest no longer
+  reads as a failure. New `degraded` job status surfaces on the REST/MCP
+  poll response and the CLI renders it as a non-zero failure (including
+  under `--json`). Diagnoses the v0.13.0 vcf-logs log-sentry
+  false-success; see claude-rdc-hetzner-dc#1136. (#1647)
 - An ingested **L2** write op no longer mangles its HTTP request body: the
   dispatcher now serializes the single `x-meho-param-loc: "body"` container
   param's *value* as the JSON body (unwrapped) on every body-carrying arm,

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -204,6 +204,28 @@ connector-related release-notes line.
 
 ### Fixed
 
+- An async `--spec` ingest no longer false-succeeds when nothing became
+  dispatchable, and the `--product` the catalog's `next_step` verb prints
+  now round-trips. Two tangled defects: (1) ingesting under a VCF-family
+  **long** product (`--product vcf-logs`) persisted `endpoint_descriptor`
+  rows the dispatch/query surface never queried — it keys on the **short**
+  product `parse_connector_id` derives from the connector_id (`vrli`), so
+  the catalog reported `registered, 0 ops` and `search_operations`
+  returned `connector_not_ingested`. Ingest now reconciles the row product
+  to the dispatch-canonical spelling at register-time (all six splits:
+  `hetzner-robot/hetzner`, `sddc-manager/sddc`, `vcf-automation/vcfa`,
+  `vcf-fleet/fleet`, `vcf-logs/vrli`, `vcf-operations/vrops`; a no-op for
+  aligned connectors), and a registered-but-unpopulated row's `next_step`
+  verb emits the parser-derived `--product` so it round-trips to a
+  dispatchable ingest. (2) The async job flipped to `succeeded` purely
+  because the pipeline coroutine returned; it now applies a
+  dispatchability postcondition (`inserted_count > 0` and the connector
+  resolves under its dispatch key) and ends `degraded` with
+  `error_class="ingested_not_dispatchable"` when it fails — never a bare
+  `succeeded` over a connector that persisted nothing callable. New
+  `degraded` job status surfaces on the REST/MCP poll response and the
+  CLI renders it as a non-zero failure. Diagnoses the v0.13.0 vcf-logs
+  log-sentry false-success; see claude-rdc-hetzner-dc#1136. (#1647)
 - An ingested **L2** write op no longer mangles its HTTP request body: the
   dispatcher now serializes the single `x-meho-param-loc: "body"` container
   param's *value* as the JSON body (unwrapped) on every body-carrying arm,

--- a/backend/src/meho_backplane/api/v1/connectors_ingest.py
+++ b/backend/src/meho_backplane/api/v1/connectors_ingest.py
@@ -142,6 +142,7 @@ from meho_backplane.api.v1._envelope import (
 )
 from meho_backplane.auth.operator import Operator, TenantRole
 from meho_backplane.auth.rbac import require_role
+from meho_backplane.operations._lookup import connector_exists, parse_connector_id
 from meho_backplane.operations.ingest import (
     CatalogListResponse,
     ConnectorNotFoundError,
@@ -486,6 +487,22 @@ async def _spawn_async_ingest(
             spec_info_versions_compatible=spec_info_versions_compatible,
         )
 
+    async def _dispatchability_check(result: IngestionPipelineResult) -> bool:
+        # Post-run honesty gate (claude-rdc-hetzner-dc#1136): resolve the
+        # connector exactly the way the dispatch/query meta-tools do —
+        # parse the connector_id into its natural-key triple and probe
+        # connector_exists under the operator's tenant scope. A run that
+        # returned without raising but leaves this False persisted
+        # nothing the dispatcher can route, so the job ends ``degraded``
+        # rather than lying with ``succeeded``.
+        probe_product, probe_version, probe_impl_id = parse_connector_id(result.connector_id)
+        return await connector_exists(
+            tenant_id=operator.tenant_id,
+            product=probe_product,
+            version=probe_version,
+            impl_id=probe_impl_id,
+        )
+
     # ``asyncio.create_task`` (not ``BackgroundTasks``) so the work
     # survives the response close -- the FastAPI ``BackgroundTasks``
     # path runs *after* response send but still inside the request
@@ -496,7 +513,11 @@ async def _spawn_async_ingest(
     # agent reaper, scheduler loop -- see
     # ``meho_backplane.main._BackgroundTasks``).
     task = asyncio.create_task(
-        run_ingest_job(job.job_id, pipeline_call=_pipeline_call),
+        run_ingest_job(
+            job.job_id,
+            pipeline_call=_pipeline_call,
+            dispatchability_check=_dispatchability_check,
+        ),
         name=f"ingest-job-{job.job_id}",
     )
     # Stash a strong reference inside the registry so a future
@@ -588,13 +609,19 @@ def _job_to_response(job: IngestJob) -> IngestJobStatusResponse:
     can be unit-tested without spinning up an HTTP client. The
     branches mirror the lifecycle of the dataclass: a terminal
     success populates ``ingestion`` (+ optional ``grouping``);
-    a terminal failure populates ``error`` + ``error_class``;
-    ``running`` leaves both clusters ``None`` so clients branch
+    a ``degraded`` terminal populates both the ``ingestion`` counts
+    *and* ``error`` / ``error_class`` (the pipeline returned but its
+    output was non-dispatchable); a terminal failure populates
+    ``error`` + ``error_class`` only (the pipeline raised, no result);
+    ``running`` leaves the result cluster ``None`` so clients branch
     on ``status`` instead of presence-checking.
     """
     ingestion_model: IngestionResultModel | None = None
     grouping_model: GroupingResultModel | None = None
-    if job.status == "succeeded" and job.result is not None:
+    # ``degraded`` carries a populated ``result`` too (the counts that
+    # landed before the dispatchability postcondition failed), so it
+    # projects the ingestion/grouping cluster alongside its error.
+    if job.status in ("succeeded", "degraded") and job.result is not None:
         ingestion_model, grouping_model = job.result.to_api_models()
     return IngestJobStatusResponse(
         job_id=job.job_id,

--- a/backend/src/meho_backplane/operations/_lookup.py
+++ b/backend/src/meho_backplane/operations/_lookup.py
@@ -40,6 +40,7 @@ __all__ = [
     "connector_exists",
     "count_known_ops",
     "descriptor_exists_any_state",
+    "dispatch_product",
     "lookup_descriptor",
     "parse_connector_id",
 ]
@@ -88,6 +89,43 @@ def parse_connector_id(connector_id: str) -> tuple[str, str, str]:
     # single-impl case.
     product = head.split("-", 1)[0] if "-" in head else head
     return product, version, head
+
+
+def dispatch_product(*, product: str, version: str, impl_id: str) -> str:
+    """Return the product key the dispatch/query surface keys on for this connector.
+
+    The persistence-layer natural key on
+    :class:`~meho_backplane.db.models.EndpointDescriptor` /
+    :class:`~meho_backplane.db.models.OperationGroup` is the free-form
+    ``(product, version, impl_id)`` triple the ingest caller supplies.
+    The dispatch + discovery surface, however, never sees that triple
+    directly: it receives a ``connector_id`` string and recovers the
+    product via :func:`parse_connector_id`, which derives it from the
+    first hyphen-segment of ``impl_id`` (``"vrli-rest-9.0" -> "vrli"``).
+
+    For most connectors the supplied ``product`` already equals the
+    parser-derived one (``vmware`` / ``vmware-rest``), so this is a
+    no-op. For the VCF-family long↔short splits the two diverge — the
+    connector class registers under the long form
+    (``product="vcf-logs"``) while the dispatcher derives the short form
+    (``"vrli"``) from ``impl_id="vrli-rest"``. Rows persisted under the
+    long form are then invisible to every ``connector_exists`` /
+    ``search_operations`` / ``list_operation_groups`` probe (which key on
+    the short, parser-derived form), so the catalog reports the connector
+    ``registered, 0 ops`` even though the rows exist (the listing's
+    round-trip integrity gate in
+    :func:`~meho_backplane.operations.ingest.list_connectors._resolves_through_dispatcher`
+    drops them). claude-rdc-hetzner-dc#1136.
+
+    Returning the parser-derived product gives the ingest path a single
+    point to reconcile the supplied product against the spelling the
+    dispatcher will look the rows up under, so persistence and dispatch
+    agree. The same lossless round-trip
+    :func:`~meho_backplane.operations._lookup.connector_class_registered`
+    already relies on: render ``connector_id``, re-parse, take the
+    product.
+    """
+    return parse_connector_id(f"{impl_id}-{version}")[0]
 
 
 async def lookup_descriptor(

--- a/backend/src/meho_backplane/operations/ingest/api_schemas.py
+++ b/backend/src/meho_backplane/operations/ingest/api_schemas.py
@@ -677,7 +677,12 @@ class EditOpResponse(BaseModel):
 #: the Pydantic projection and the internal dataclass share one
 #: spelling; the route layer projects ``IngestJob`` rows through the
 #: response models defined below.
-IngestJobStatusLiteral = Literal["running", "succeeded", "failed"]
+#:
+#: ``degraded`` (G0.24 / claude-rdc-hetzner-dc#1136) is terminal-but-not-
+#: green: the pipeline ran to completion yet persisted nothing the
+#: dispatcher can resolve, so the job carries both ``ingestion`` counts
+#: and a structured ``error_class`` (``ingested_not_dispatchable``).
+IngestJobStatusLiteral = Literal["running", "succeeded", "failed", "degraded"]
 
 
 class IngestJobHandle(BaseModel):
@@ -718,21 +723,27 @@ class IngestJobStatusResponse(BaseModel):
       ``spec_uris``). Echo so the polling caller doesn't need to
       correlate against their own state.
     * **Lifecycle** -- ``status`` + ``started_at`` + optional
-      ``ended_at``. Status moves ``running`` → ``succeeded`` or
-      ``running`` → ``failed`` once.
-    * **Result vs error** -- exactly one of ``ingestion`` (with
-      optional ``grouping``) or ``error`` is populated, keyed on
-      status. ``running`` leaves both ``None`` so polling clients
-      branch on ``status`` rather than checking presence.
+      ``ended_at``. Status moves ``running`` → one of ``succeeded`` /
+      ``degraded`` / ``failed`` exactly once.
+    * **Result vs error** -- keyed on status. ``succeeded`` populates
+      ``ingestion`` (with optional ``grouping``) and leaves ``error``
+      ``None``; ``failed`` populates ``error`` / ``error_class`` and
+      leaves ``ingestion`` ``None`` (the pipeline raised, no result).
+      ``degraded`` populates **both** — the pipeline returned a result
+      (so ``ingestion`` carries the counts that landed) but a
+      postcondition found it non-dispatchable (so ``error`` /
+      ``error_class`` carry the reason). ``running`` leaves them ``None``
+      so polling clients branch on ``status`` rather than presence.
 
-    ``error`` is the capped exception message; ``error_class`` is the
-    Python exception class name -- structured enough for agents that
-    want to branch (``VersionMismatchError`` vs
-    ``LlmClientUnavailable``) without parsing prose. The structured
-    422 envelopes the synchronous ingest path used to return (the
-    error-shape convention's classifier + ``detail`` body) are NOT
-    available off the request thread; the polling response is the
-    new error surface for the async path.
+    ``error`` is the capped message; ``error_class`` is the structured
+    discriminator -- the Python exception class name for ``failed``
+    (``VersionMismatchError`` vs ``LlmClientUnavailable``), or the fixed
+    ``ingested_not_dispatchable`` token for ``degraded`` -- so agents
+    branch without parsing prose. The structured 422 envelopes the
+    synchronous ingest path used to return (the error-shape convention's
+    classifier + ``detail`` body) are NOT available off the request
+    thread; the polling response is the new error surface for the async
+    path.
     """
 
     model_config = ConfigDict(frozen=True)

--- a/backend/src/meho_backplane/operations/ingest/jobs.py
+++ b/backend/src/meho_backplane/operations/ingest/jobs.py
@@ -75,7 +75,16 @@ _MAX_JOBS_RETAINED = 256
 #: Snapshot of an ingest run's lifecycle. The status enum lives at
 #: module scope so the route layer + tests share one source of truth
 #: rather than re-declaring the literal in each Pydantic projection.
-IngestJobStatus = Literal["running", "succeeded", "failed"]
+#:
+#: ``degraded`` (G0.24 / claude-rdc-hetzner-dc#1136) is a terminal state
+#: distinct from ``failed``: the pipeline coroutine returned without
+#: raising, but a postcondition found nothing dispatchable was persisted
+#: (zero inserts, or rows that are invisible to the dispatch/query
+#: surface). A bare ``succeeded`` there is a lie — the catalog row reads
+#: ``registered, 0 ops`` immediately after — so the job ends ``degraded``
+#: carrying a structured ``error_class`` while still surfacing the
+#: ingestion counts so the operator sees what (didn't) land.
+IngestJobStatus = Literal["running", "succeeded", "failed", "degraded"]
 
 
 class IngestJobNotFoundError(LookupError):
@@ -106,9 +115,13 @@ class IngestJob:
 
     A live job has ``status="running"`` and ``ended_at is None``.
     Terminal jobs carry one of ``status="succeeded"`` (with
-    ``result`` populated) or ``status="failed"`` (with ``error`` and
-    ``error_class`` populated). The route projects the right subset
-    of fields per status into the polling response.
+    ``result`` populated), ``status="failed"`` (with ``error`` and
+    ``error_class`` populated, no ``result`` — the pipeline raised), or
+    ``status="degraded"`` (the pipeline returned but its output was not
+    dispatchable: ``result`` *and* ``error`` / ``error_class`` are both
+    populated so the operator sees the counts that landed alongside the
+    structured reason they're not usable). The route projects the right
+    subset of fields per status into the polling response.
 
     The dataclass is mutable on purpose -- the background coroutine
     flips ``status`` / ``ended_at`` / ``result`` / ``error`` on
@@ -212,6 +225,41 @@ class IngestJobRegistry:
             job.status = "succeeded"
             job.ended_at = time.time()
             job.result = result
+            self._jobs.move_to_end(job_id)
+
+    async def degrade(
+        self,
+        job_id: UUID,
+        *,
+        result: IngestionPipelineResult,
+        error_class: str,
+        error: str,
+    ) -> None:
+        """Flip *job_id* to ``degraded`` — the pipeline returned but nothing dispatchable landed.
+
+        The pipeline coroutine completed without raising, so *result*
+        carries real counts, but a postcondition (see
+        :func:`run_ingest_job`) found the run produced nothing the
+        dispatch/query surface can resolve. Records *result* (so the
+        operator still sees inserted/skipped counts) **and** the
+        structured *error_class* / *error* (so the failure is
+        machine-branchable and operator-readable) — a job that lied with
+        a bare ``succeeded`` is the failure mode this state closes
+        (claude-rdc-hetzner-dc#1136).
+
+        No-op when *job_id* was evicted between the background-task
+        launch and this call — same eviction-during-run contract as
+        :meth:`complete`.
+        """
+        async with self._lock:
+            job = self._jobs.get(job_id)
+            if job is None:
+                return
+            job.status = "degraded"
+            job.ended_at = time.time()
+            job.result = result
+            job.error_class = error_class
+            job.error = error if len(error) <= 1024 else error[:1024] + "...<truncated>"
             self._jobs.move_to_end(job_id)
 
     async def fail(
@@ -325,11 +373,30 @@ def reset_job_registry_for_tests() -> None:
     _registry = IngestJobRegistry()
 
 
+#: Structured ``error_class`` an async ingest carries when it ran to
+#: completion but left the connector non-dispatchable. The CLI / agent
+#: branch on this string to tell "the pipeline raised" (``failed`` with
+#: the exception class) apart from "the pipeline returned but nothing
+#: usable landed" (``degraded`` with this class). claude-rdc-hetzner-dc#1136.
+INGESTED_NOT_DISPATCHABLE = "ingested_not_dispatchable"
+
+#: Post-run dispatchability probe injected by the route. Given the
+#: pipeline's :class:`IngestionPipelineResult`, returns whether the
+#: connector it produced is resolvable by the dispatch/query surface
+#: (``connector_exists`` under the parser-derived natural key, scoped to
+#: the originating tenant). A closure (not an inline DB call) so
+#: :func:`run_ingest_job` stays free of a session/tenant dependency and
+#: tests can inject a deterministic verdict; the route closes over the
+#: operator's ``tenant_id`` + ``connector_exists`` to build the real one.
+DispatchabilityCheck = Callable[[IngestionPipelineResult], Awaitable[bool]]
+
+
 async def run_ingest_job(
     job_id: UUID,
     *,
     pipeline_call: Callable[[], Awaitable[IngestionPipelineResult]],
     registry: IngestJobRegistry | None = None,
+    dispatchability_check: DispatchabilityCheck | None = None,
 ) -> None:
     """Drive *pipeline_call* off the request thread and reconcile the job row.
 
@@ -343,14 +410,36 @@ async def run_ingest_job(
     1. Runs the closure under a structlog binding tagged with
        ``ingest_job_id`` so the log output during the long-running
        pass is correlatable with the polling responses.
-    2. On success, flips the job to ``succeeded`` carrying the
-       structured :class:`IngestionPipelineResult`.
+    2. On success, applies the dispatchability postcondition (see
+       below) and flips the job to ``succeeded`` (with the structured
+       :class:`IngestionPipelineResult`) only when it holds; otherwise
+       to ``degraded``.
     3. On any exception, flips the job to ``failed`` and records the
        exception class + capped message. The exception is swallowed
        (no re-raise) -- the request that started the job has already
        returned 202, and re-raising into the asyncio default exception
        handler would log a noisy traceback for what is now a routine
        operator-facing failure mode.
+
+    Dispatchability postcondition (claude-rdc-hetzner-dc#1136)
+    ---------------------------------------------------------
+
+    A pipeline coroutine that returns without raising is **not**
+    sufficient evidence the ingest succeeded: an async ``--spec`` run
+    can persist rows under a product key the dispatch surface never
+    queries (the VCF-family long↔short split, now reconciled at
+    register-time) or skip every op against a prior run, leaving the
+    catalog row ``registered, 0 ops`` and ``search_operations`` returning
+    ``connector_not_ingested``. Flipping such a job to ``succeeded``
+    reports a green run that produced nothing callable.
+
+    The postcondition is: ``inserted_count > 0`` **and**
+    *dispatchability_check* (the route's ``connector_exists`` probe under
+    the parser-derived natural key) returns ``True``. When it fails the
+    job ends ``degraded`` carrying ``error_class=
+    "ingested_not_dispatchable"``, never a bare ``succeeded``.
+    *dispatchability_check* is ``None`` only for legacy callers / tests
+    that opt out of the probe; the production route always supplies one.
 
     The structured failure logged at :func:`structlog.get_logger`
     INFO level preserves the diagnostic for ops dashboards even
@@ -374,6 +463,27 @@ async def run_ingest_job(
         if isinstance(exc, (SystemExit, KeyboardInterrupt)):
             raise
         return
+
+    degraded_reason = await _dispatchability_failure_reason(
+        result=result,
+        dispatchability_check=dispatchability_check,
+    )
+    if degraded_reason is not None:
+        log.warning(
+            "ingest_job_degraded",
+            connector_id=result.connector_id,
+            inserted_count=result.ingestion.inserted_count,
+            error_class=INGESTED_NOT_DISPATCHABLE,
+            reason=degraded_reason,
+        )
+        await registry.degrade(
+            job_id,
+            result=result,
+            error_class=INGESTED_NOT_DISPATCHABLE,
+            error=degraded_reason,
+        )
+        return
+
     log.info(
         "ingest_job_succeeded",
         connector_id=result.connector_id,
@@ -381,3 +491,73 @@ async def run_ingest_job(
         groups_created=result.grouping.groups_created if result.grouping else None,
     )
     await registry.complete(job_id, result=result)
+
+
+async def _dispatchability_failure_reason(
+    *,
+    result: IngestionPipelineResult,
+    dispatchability_check: DispatchabilityCheck | None,
+) -> str | None:
+    """Return an operator-facing reason the run is non-dispatchable, or ``None`` if it is.
+
+    Two failure modes collapse to the one ``ingested_not_dispatchable``
+    ``error_class`` but carry distinct messages so the operator knows
+    which one fired:
+
+    * **Nothing persisted** — ``inserted_count == 0``. The run touched no
+      new rows (an empty spec, or every op skipped against an earlier
+      run that itself persisted nothing dispatchable). Reported without
+      consulting *dispatchability_check*: a zero-insert run is
+      non-dispatchable by definition for a *fresh* connector, and the
+      probe would only add a redundant DB round-trip.
+    * **Persisted-but-invisible** — ``inserted_count > 0`` yet
+      *dispatchability_check* returns ``False``: rows landed under a key
+      the dispatch/query surface does not resolve. This is the exact
+      claude-rdc-hetzner-dc#1136 mis-keyed-product symptom (pre the
+      register-time reconciliation) and any future drift of the same
+      shape.
+
+    *dispatchability_check* ``None`` (legacy caller / opt-out) treats a
+    non-empty insert as dispatchable — the probe is the only way to
+    detect the invisible-rows case and an opted-out caller has accepted
+    that gap.
+    """
+    if result.ingestion.inserted_count == 0:
+        return (
+            "ingest completed but persisted no new operations "
+            f"(inserted_count=0) for connector_id={result.connector_id!r}; "
+            "nothing is dispatchable. If a prior run already persisted "
+            "these ops dispatchably this is benign idempotency, but a "
+            "first run reaching zero inserts means the spec yielded no "
+            "operations under this connector."
+        )
+    if dispatchability_check is None:
+        return None
+    try:
+        dispatchable = await dispatchability_check(result)
+    except Exception:
+        # The probe itself failed (e.g. a transient DB error on the
+        # connector_exists read). The pipeline DID complete, so do not
+        # strand the job in ``running`` or degrade it on a false signal —
+        # fail open to ``succeeded`` and log the probe failure for the
+        # observability trail. A genuinely non-dispatchable run is far
+        # more likely to surface as ``inserted_count==0`` (handled above)
+        # or a clean ``False`` than a probe exception.
+        _log.warning(
+            "ingest_job_dispatchability_probe_failed",
+            connector_id=result.connector_id,
+            inserted_count=result.ingestion.inserted_count,
+            exc_info=True,
+        )
+        return None
+    if not dispatchable:
+        return (
+            f"ingest persisted {result.ingestion.inserted_count} operation(s) "
+            f"but connector_id={result.connector_id!r} is not resolvable by "
+            "the dispatch/query surface (search_operations / "
+            "list_operation_groups return connector_not_ingested); the rows "
+            "landed under a product key the dispatcher does not look them up "
+            "under. Re-ingest under the --product the catalog's next_step "
+            "verb prints."
+        )
+    return None

--- a/backend/src/meho_backplane/operations/ingest/jobs.py
+++ b/backend/src/meho_backplane/operations/ingest/jobs.py
@@ -505,11 +505,16 @@ async def _dispatchability_failure_reason(
     which one fired:
 
     * **Nothing persisted** — ``inserted_count == 0``. The run touched no
-      new rows (an empty spec, or every op skipped against an earlier
-      run that itself persisted nothing dispatchable). Reported without
-      consulting *dispatchability_check*: a zero-insert run is
-      non-dispatchable by definition for a *fresh* connector, and the
-      probe would only add a redundant DB round-trip.
+      new rows. Two shapes collapse here and the probe is what tells them
+      apart: an empty/first-run spec that yielded nothing dispatchable
+      (degraded), versus a **benign idempotent re-run** where every op was
+      ``skipped`` because a prior run already persisted them dispatchably
+      (succeeded). ``_upsert.upsert_one_operation`` returns ``"skipped"``
+      for an unchanged op, so a re-ingest of an already-dispatchable
+      connector lands ``inserted_count == 0`` on a perfectly healthy
+      connector — degrading it unconditionally would flip a no-op re-run
+      to a non-zero CLI failure. The probe (when supplied) breaks the tie:
+      already-dispatchable ⇒ ``succeeded``, else ⇒ degraded.
     * **Persisted-but-invisible** — ``inserted_count > 0`` yet
       *dispatchability_check* returns ``False``: rows landed under a key
       the dispatch/query surface does not resolve. This is the exact
@@ -518,11 +523,37 @@ async def _dispatchability_failure_reason(
       shape.
 
     *dispatchability_check* ``None`` (legacy caller / opt-out) treats a
-    non-empty insert as dispatchable — the probe is the only way to
-    detect the invisible-rows case and an opted-out caller has accepted
-    that gap.
+    non-empty insert as dispatchable and — having no way to tell an
+    idempotent re-run from a genuinely empty first run apart — degrades a
+    zero-insert run. An opted-out caller has accepted both gaps.
     """
+    # The probe is the only authority on whether the connector resolves
+    # under its dispatch key, so run it once (when supplied) and let both
+    # the zero-insert and the persisted-but-invisible branches read its
+    # verdict. Fail open: a probe that *raises* (e.g. a transient DB error
+    # on the connector_exists read) must not strand the job in ``running``
+    # or degrade it on a false signal — the pipeline DID complete.
+    dispatchable: bool | None = None
+    if dispatchability_check is not None:
+        try:
+            dispatchable = await dispatchability_check(result)
+        except Exception:
+            _log.warning(
+                "ingest_job_dispatchability_probe_failed",
+                connector_id=result.connector_id,
+                inserted_count=result.ingestion.inserted_count,
+                exc_info=True,
+            )
+            return None
+
     if result.ingestion.inserted_count == 0:
+        # A re-ingest of an already-persisted spec skips every op, so
+        # ``inserted_count == 0`` on a perfectly healthy, already-dispatchable
+        # connector (benign idempotency) — keep it ``succeeded``. Only a
+        # zero-insert run that is *also* non-dispatchable (empty/first-run
+        # spec, or no probe to confirm) degrades.
+        if dispatchable:
+            return None
         return (
             "ingest completed but persisted no new operations "
             f"(inserted_count=0) for connector_id={result.connector_id!r}; "
@@ -531,26 +562,8 @@ async def _dispatchability_failure_reason(
             "first run reaching zero inserts means the spec yielded no "
             "operations under this connector."
         )
-    if dispatchability_check is None:
-        return None
-    try:
-        dispatchable = await dispatchability_check(result)
-    except Exception:
-        # The probe itself failed (e.g. a transient DB error on the
-        # connector_exists read). The pipeline DID complete, so do not
-        # strand the job in ``running`` or degrade it on a false signal —
-        # fail open to ``succeeded`` and log the probe failure for the
-        # observability trail. A genuinely non-dispatchable run is far
-        # more likely to surface as ``inserted_count==0`` (handled above)
-        # or a clean ``False`` than a probe exception.
-        _log.warning(
-            "ingest_job_dispatchability_probe_failed",
-            connector_id=result.connector_id,
-            inserted_count=result.ingestion.inserted_count,
-            exc_info=True,
-        )
-        return None
-    if not dispatchable:
+
+    if dispatchable is False:
         return (
             f"ingest persisted {result.ingestion.inserted_count} operation(s) "
             f"but connector_id={result.connector_id!r} is not resolvable by "

--- a/backend/src/meho_backplane/operations/ingest/list_connectors.py
+++ b/backend/src/meho_backplane/operations/ingest/list_connectors.py
@@ -140,6 +140,7 @@ def next_step_for_registered_connector(
                 registry_product=reg_product,
                 registry_version=reg_version,
                 registry_impl_id=reg_impl_id,
+                dispatch_product=parsed_product,
             )
     return None
 
@@ -150,55 +151,38 @@ def _next_step_for_registered(
     registry_product: str,
     registry_version: str,
     registry_impl_id: str,
+    dispatch_product: str,
 ) -> NextStep:
     """Build the ``next_step`` hint for a ``state="registered"`` row.
 
     Looks up the registry's ``(product, version)`` in the connector-spec
-    catalog (#743). The registry product is the right lookup key (not the
-    parser-derived one): the catalog stores ``product="sddc-manager"`` but
-    the listing emits ``product="sddc"`` per
-    :func:`parse_connector_id`'s deterministic shortening, and looking up
-    ``("sddc", "9.0")`` would always miss for SDDC.
+    catalog (#743) — the right lookup key, since the catalog stores
+    ``product="sddc-manager"`` while the listing emits the parser-derived
+    ``"sddc"``, and ``("sddc", "9.0")`` would always miss for SDDC.
 
-    Three branches:
+    *dispatch_product* is the parser-derived product the listing row
+    advertises and the dispatch/query surface keys on
+    (``parse_connector_id("vrli-rest-9.0") -> "vrli"``) — the
+    ``--product`` the **catalog-miss** verb emits so an operator copying
+    it lands a *dispatchable* connector (the ingest path persists rows
+    under this spelling). Emitting the registry product (``vcf-logs``)
+    here was the claude-rdc-hetzner-dc#1136 false-success: the verb said
+    ``vcf-logs`` while the row carried ``product="vrli"``, so it never
+    round-tripped and the catalog kept reporting ``registered, 0 ops``.
+    The catalog-hit branches keep ``entry.product`` (a catalogued
+    connector's catalog product already equals the dispatcher's derived
+    one; no VCF-family entry is catalogued).
 
-    * **Catalog hit, ``catalog_ingest="supported"``** — verb points at
-      ``meho connector ingest --catalog <product>/<version>``; rationale
-      says the spec is available in the catalog. The CLI form is the
-      same one the curated-on-ramp ships (#915 / G0.7-T5); copying the
-      verb verbatim closes the workflow.
-    * **Catalog hit, ``catalog_ingest="spec-only"``** — verb points at
-      the manual-mode ``meho connector ingest --product <p> --version
-      <v> --impl <i> --spec <uri>`` form using the catalog's native
-      product/version/impl triple. Rationale calls out that the
-      catalog row exists but its upstream is HTML-portal or
-      fqdn-templated, so catalog-driven ingest would 422 -- the
-      operator must fetch the spec themselves. Closes the v0.8.1
-      RDC dogfood signal (#789 N8): the previous "spec available in
-      catalog; run ingest" hint over-promised the VCF-family rows
-      whose upstream is fundamentally not raw YAML/JSON (G0.18-T8 /
-      #1361). The same triple the operator would have used after a
-      hit lands here, so the verb still copies-and-runs.
-    * **Catalog miss** — verb points at the manual-mode ``meho connector
-      ingest --product <p> --version <v> --impl <i> --spec <uri>``;
-      rationale calls out the missing catalog entry so the operator
-      knows they need to source the OpenAPI spec themselves. Manual
-      mode is the same path G0.7-T5 already supports for one-off /
-      not-yet-curated specs (see ``ingest.go``'s mode dispatch). The
-      rationale also names the **hand-authored** route so a spec-less
-      product (the vendor publishes no OpenAPI at all — VCF Fleet /
-      vRSLCM, Hetzner Robot) doesn't read as a dead end: author a
-      minimal OpenAPI 3.x covering just the ops you need and pass it
-      via ``--spec file://…`` (#1533 / ci-07). See
-      ``docs/cross-repo/connector-ingestion.md`` §"Product publishes
-      no OpenAPI spec".
+    Three branches: **supported** catalog hit → ``--catalog`` verb;
+    **spec-only** catalog hit → manual ``--spec`` verb on the catalog's
+    native triple (upstream is HTML-portal / fqdn-templated, #789 N8 /
+    #1361); **catalog miss** → manual ``--spec`` verb on
+    *dispatch_product* + the hand-authored-spec on-ramp for spec-less
+    vendors (#1533 / ci-07, see ``connector-ingestion.md``).
 
-    *catalog* is ``None`` when the package-data load failed (a malformed
-    catalog at startup would have crashed the lifespan, so this branch
-    only fires in tests where the loader was monkeypatched or the
-    process is mid-catalog-reload); the helper degrades to the
-    manual-mode rationale rather than raising, because the operator's
-    workflow doesn't depend on the catalog being live.
+    *catalog* ``None`` (load failed — only in tests / mid-reload, a
+    malformed catalog would have crashed the lifespan) degrades to the
+    manual-mode rationale rather than raising.
     """
     entry = catalog.get(registry_product, registry_version) if catalog is not None else None
     if entry is not None and entry.catalog_ingest == "supported":
@@ -221,7 +205,7 @@ def _next_step_for_registered(
         )
     return NextStep(
         verb=(
-            f"meho connector ingest --product {registry_product} "
+            f"meho connector ingest --product {dispatch_product} "
             f"--version {registry_version} --impl {registry_impl_id} "
             f"--spec <upstream-openapi-uri>"
         ),
@@ -684,10 +668,15 @@ def _maybe_build_class_only_item(
             # holds ``product="sddc-manager"`` while the listing emits
             # ``product="sddc"``. The catalog is keyed on the registry
             # side; this is the lookup the operator-facing verb
-            # resolves against.
+            # resolves against. The manual-mode verb, however, must hand
+            # back the parser-derived ``--product`` (the same spelling
+            # this row advertises and the ingest path persists rows
+            # under) so it round-trips to a dispatchable ingest
+            # (claude-rdc-hetzner-dc#1136).
             registry_product=registry_product,
             registry_version=registry_version,
             registry_impl_id=registry_impl_id,
+            dispatch_product=parsed_product,
         ),
     )
 

--- a/backend/src/meho_backplane/operations/ingest/list_connectors.py
+++ b/backend/src/meho_backplane/operations/ingest/list_connectors.py
@@ -140,7 +140,6 @@ def next_step_for_registered_connector(
                 registry_product=reg_product,
                 registry_version=reg_version,
                 registry_impl_id=reg_impl_id,
-                dispatch_product=parsed_product,
             )
     return None
 
@@ -151,7 +150,6 @@ def _next_step_for_registered(
     registry_product: str,
     registry_version: str,
     registry_impl_id: str,
-    dispatch_product: str,
 ) -> NextStep:
     """Build the ``next_step`` hint for a ``state="registered"`` row.
 
@@ -160,24 +158,33 @@ def _next_step_for_registered(
     ``product="sddc-manager"`` while the listing emits the parser-derived
     ``"sddc"``, and ``("sddc", "9.0")`` would always miss for SDDC.
 
-    *dispatch_product* is the parser-derived product the listing row
-    advertises and the dispatch/query surface keys on
-    (``parse_connector_id("vrli-rest-9.0") -> "vrli"``) — the
-    ``--product`` the **catalog-miss** verb emits so an operator copying
-    it lands a *dispatchable* connector (the ingest path persists rows
-    under this spelling). Emitting the registry product (``vcf-logs``)
-    here was the claude-rdc-hetzner-dc#1136 false-success: the verb said
-    ``vcf-logs`` while the row carried ``product="vrli"``, so it never
-    round-tripped and the catalog kept reporting ``registered, 0 ops``.
-    The catalog-hit branches keep ``entry.product`` (a catalogued
-    connector's catalog product already equals the dispatcher's derived
-    one; no VCF-family entry is catalogued).
+    The **catalog-miss** verb emits ``registry_product`` — the spelling
+    the connector class actually registers under (``vcf-logs`` for
+    ``VcfLogsConnector``, not the parser-derived ``vrli``). Two halves of
+    the ingest write path are keyed on the **supplied** ``--product``:
+    ``check_version_covered_by_registered_class`` (the version-coverage
+    pre-flight) and ``ensure_connector_class_registered``. Handing the
+    operator the registry product is what lets both find the real
+    ``VcfLogsConnector`` — emitting the short ``vrli`` instead would miss
+    it, synthesise a redundant ``AutoShim_vrli_*`` under the wrong key,
+    and make the coverage pre-flight vacuous (an out-of-range
+    ``--version`` would no longer be caught). The PR's register-time row
+    reconciliation (``register_ingested_operations`` →
+    ``_reconciled_row_product``) then persists the rows under the
+    parser-derived dispatch product (``vrli``) regardless, so the verb
+    still round-trips to a *dispatchable* connector — keying the
+    pre-flight and class lookup on ``registry_product`` is therefore both
+    correct and dispatchable. (Emitting ``vcf-logs`` while the row carried
+    ``product="vrli"`` *was* the claude-rdc-hetzner-dc#1136 false-success
+    before that reconciliation existed; the reconciliation is what closes
+    it, not switching the verb to the short product.) The catalog-hit
+    branches keep ``entry.product``.
 
     Three branches: **supported** catalog hit → ``--catalog`` verb;
     **spec-only** catalog hit → manual ``--spec`` verb on the catalog's
     native triple (upstream is HTML-portal / fqdn-templated, #789 N8 /
     #1361); **catalog miss** → manual ``--spec`` verb on
-    *dispatch_product* + the hand-authored-spec on-ramp for spec-less
+    *registry_product* + the hand-authored-spec on-ramp for spec-less
     vendors (#1533 / ci-07, see ``connector-ingestion.md``).
 
     *catalog* ``None`` (load failed — only in tests / mid-reload, a
@@ -205,7 +212,7 @@ def _next_step_for_registered(
         )
     return NextStep(
         verb=(
-            f"meho connector ingest --product {dispatch_product} "
+            f"meho connector ingest --product {registry_product} "
             f"--version {registry_version} --impl {registry_impl_id} "
             f"--spec <upstream-openapi-uri>"
         ),
@@ -662,21 +669,19 @@ def _maybe_build_class_only_item(
         enabled_operation_count=0,
         state="registered",
         next_step=_next_step_for_registered(
-            catalog=catalog,
             # Lookup against the registry triple (the catalog's native
             # key) rather than the parsed one — for SDDC the registry
             # holds ``product="sddc-manager"`` while the listing emits
             # ``product="sddc"``. The catalog is keyed on the registry
-            # side; this is the lookup the operator-facing verb
-            # resolves against. The manual-mode verb, however, must hand
-            # back the parser-derived ``--product`` (the same spelling
-            # this row advertises and the ingest path persists rows
-            # under) so it round-trips to a dispatchable ingest
-            # (claude-rdc-hetzner-dc#1136).
+            # side, and the manual-mode verb hands back ``registry_product``
+            # so the operator's ingest finds the real connector class and
+            # runs a real version-coverage pre-flight; register-time row
+            # reconciliation persists the rows under the dispatch product,
+            # so it still round-trips dispatchably (claude-rdc-hetzner-dc#1136).
+            catalog=catalog,
             registry_product=registry_product,
             registry_version=registry_version,
             registry_impl_id=registry_impl_id,
-            dispatch_product=parsed_product,
         ),
     )
 

--- a/backend/src/meho_backplane/operations/ingest/pipeline.py
+++ b/backend/src/meho_backplane/operations/ingest/pipeline.py
@@ -84,6 +84,7 @@ from sqlalchemy.ext.asyncio import AsyncSession, async_sessionmaker
 
 from meho_backplane.auth.operator import Operator, TenantRole
 from meho_backplane.db.engine import get_sessionmaker
+from meho_backplane.operations._lookup import dispatch_product
 from meho_backplane.operations.ingest._llm_grouping_internals import (
     DEFAULT_GROUPING_BATCH_SIZE,
     DEFAULT_MAX_GROUPS,
@@ -719,8 +720,16 @@ class IngestionPipelineService:
             connector_registered=aggregated.connector_registered,
         )
 
+        # Grouping reads the descriptor rows the register phase just
+        # wrote and writes its OperationGroup rows under the same
+        # product. register_ingested_operations persists rows under the
+        # dispatch-canonical product (reconciling the VCF-family
+        # long↔short split), so the grouping pass must key on the same
+        # spelling or it would read zero ungrouped ops and write groups
+        # under a product no dispatch probe queries. claude-rdc-hetzner-dc#1136.
+        row_product = dispatch_product(product=product, version=version, impl_id=impl_id)
         grouping_result = await self._run_grouping_phase(
-            product=product,
+            product=row_product,
             version=version,
             impl_id=impl_id,
             tenant_id=tenant_id,

--- a/backend/src/meho_backplane/operations/ingest/register_ingested.py
+++ b/backend/src/meho_backplane/operations/ingest/register_ingested.py
@@ -104,6 +104,7 @@ import structlog
 from sqlalchemy.ext.asyncio import AsyncSession
 
 from meho_backplane.db.engine import get_sessionmaker
+from meho_backplane.operations._lookup import dispatch_product
 from meho_backplane.operations.ingest._upsert import (
     build_upsert_context,
     upsert_one_operation,
@@ -262,14 +263,18 @@ async def register_ingested_operations(
     (multi-spec merge, idempotency invariant, connector auto-shim
     semantics, transaction-boundary discipline).
 
+    Persisted rows carry the *dispatch-canonical* product (see
+    :func:`_reconciled_row_product`), not necessarily the supplied
+    ``product`` — the VCF-family long↔short reconciliation. The
+    pre-flight + auto-shim registration stay on the supplied product.
+
     Args:
-        product, version, impl_id: Connector triple. Natural key on
-            every persisted row is ``(product, version, impl_id,
+        product, version, impl_id: Connector triple. The persisted row's
+            natural key is ``(reconciled_product, version, impl_id,
             op_id)`` with ``tenant_id IS NULL`` for built-in rows.
-        spec_source: Logical-source tag (e.g. ``"vcenter.yaml"``).
-            The helper appends ``f"spec:{spec_source}"`` to every
-            persisted row's ``tags`` so the operator can distinguish
-            rows when a single connector ingests multiple specs.
+        spec_source: Logical-source tag (e.g. ``"vcenter.yaml"``)
+            appended as ``f"spec:{spec_source}"`` to every row's
+            ``tags`` so multi-spec ingests stay distinguishable.
         operations: Parser output from
             :func:`~meho_backplane.operations.ingest.openapi.parse_openapi`.
         base_url: Optional default base URL for the auto-registered
@@ -288,18 +293,12 @@ async def register_ingested_operations(
         runs grouping next).
 
     Raises:
-        OpIdCollision: Either (a) two operations in *operations*
-            share an ``op_id`` -- raised before any DB write by the
-            within-batch set scan, or (b) a prior
-            :func:`register_ingested_operations` call under the
-            same ``(product, version, impl_id)`` triple persisted
-            this ``op_id`` from a different ``spec_source`` --
-            raised per-row in :func:`_upsert.upsert_one_operation`
-            after the natural-key lookup, before the embedding
-            hash comparison. The exception's
-            ``existing_spec_source`` / ``incoming_spec_source``
-            attributes name both colliding specs in the cross-call
-            case.
+        OpIdCollision: Either (a) two operations in *operations* share an
+            ``op_id`` (raised before any DB write by the within-batch
+            scan), or (b) a prior call under the same triple persisted
+            this ``op_id`` from a different ``spec_source`` (raised
+            per-row in :func:`_upsert.upsert_one_operation`); the
+            exception names both colliding specs.
     """
     _detect_op_id_collisions(
         operations,
@@ -307,35 +306,24 @@ async def register_ingested_operations(
         version=version,
         impl_id=impl_id,
     )
-    # G0.9-T9 (#741) — pre-flight that the operator's ``version`` label
-    # is dispatchable against at least one already-registered class for
-    # ``(product, impl_id)``. Runs **before** the auto-shim is
-    # synthesised: the shim's ``supported_version_range`` is derived
-    # from the operator's own ``version`` so a post-shim check would
-    # always pass vacuously. Raises :exc:`UncoveredVersionLabel` (mapped
-    # to HTTP 422 by the REST router) when a class is registered but
-    # none accepts the label; logs ``connector_ingest_orphaned_class``
-    # and proceeds when no class is registered yet (v0.4-staging path).
-    check_version_covered_by_registered_class(
-        product=product,
-        version=version,
-        impl_id=impl_id,
-    )
-    connector_registered = ensure_connector_class_registered(
+    connector_registered = _preflight_and_register_class(
         product=product,
         version=version,
         impl_id=impl_id,
         base_url=base_url,
     )
+    # Rows persist under the dispatch-canonical product (no-op for
+    # aligned connectors; the VCF-family reconciliation).
+    coords = _BatchCoordinates(
+        tenant_id=tenant_id,
+        product=_reconciled_row_product(product=product, version=version, impl_id=impl_id),
+        version=version,
+        impl_id=impl_id,
+        spec_source=spec_source,
+    )
     counts = await _run_upsert_loop(
         session=session,
-        coords=_BatchCoordinates(
-            tenant_id=tenant_id,
-            product=product,
-            version=version,
-            impl_id=impl_id,
-            spec_source=spec_source,
-        ),
+        coords=coords,
         operations=operations,
         embedding_service=embedding_service,
     )
@@ -346,6 +334,74 @@ async def register_ingested_operations(
         connector_registered=connector_registered,
         operations_grouped=False,
     )
+
+
+def _preflight_and_register_class(
+    *,
+    product: str,
+    version: str,
+    impl_id: str,
+    base_url: str | None,
+) -> bool:
+    """Run the version-coverage pre-flight, then ensure the v2 class exists.
+
+    G0.9-T9 (#741). The pre-flight confirms the operator's ``version``
+    label is dispatchable against at least one already-registered class
+    for ``(product, impl_id)`` — it must run **before** the auto-shim is
+    synthesised, because the shim's ``supported_version_range`` is
+    derived from the operator's own ``version`` and would make a
+    post-shim check pass vacuously. Raises :exc:`UncoveredVersionLabel`
+    (HTTP 422 at the router) when a class is registered but none accepts
+    the label; logs ``connector_ingest_orphaned_class`` and proceeds when
+    no class is registered yet (the v0.4-staging path).
+
+    Both calls take the *supplied* (registry) product — not the
+    dispatch-canonical one the rows persist under — so the coverage check
+    finds the real registered class (e.g. ``VcfLogsConnector`` under
+    ``product="vcf-logs"``) and no redundant shim is synthesised.
+
+    Returns the ``connector_registered`` flag (``True`` when a fresh
+    auto-shim was registered).
+    """
+    check_version_covered_by_registered_class(
+        product=product,
+        version=version,
+        impl_id=impl_id,
+    )
+    return ensure_connector_class_registered(
+        product=product,
+        version=version,
+        impl_id=impl_id,
+        base_url=base_url,
+    )
+
+
+def _reconciled_row_product(*, product: str, version: str, impl_id: str) -> str:
+    """Return the product the persisted rows must carry to be dispatchable.
+
+    The dispatch/query surface keys on the product
+    :func:`~meho_backplane.operations._lookup.parse_connector_id` derives
+    from the connector_id, not the operator-supplied one. For aligned
+    connectors the two are identical (no-op); for the VCF-family long↔short
+    splits the supplied product (``vcf-logs``) diverges from the derived
+    spelling (``vrli``), and rows written under the supplied product are
+    invisible to every dispatch probe (the catalog reports
+    ``registered, 0 ops``). The pre-flight + auto-shim registration in
+    :func:`register_ingested_operations` deliberately stay on the *supplied*
+    (registry) product so the version-coverage check finds the real
+    ``VcfLogsConnector`` class and no redundant shim is synthesised; only
+    the persisted rows are reconciled here. claude-rdc-hetzner-dc#1136.
+    """
+    row_product = dispatch_product(product=product, version=version, impl_id=impl_id)
+    if row_product != product:
+        _log.info(
+            "ingested_rows_product_reconciled",
+            supplied_product=product,
+            row_product=row_product,
+            version=version,
+            impl_id=impl_id,
+        )
+    return row_product
 
 
 async def _register_in_session(

--- a/backend/tests/test_api_v1_connectors_ingest.py
+++ b/backend/tests/test_api_v1_connectors_ingest.py
@@ -1097,14 +1097,18 @@ async def test_list_registered_row_without_catalog_entry_points_at_manual_mode(
     "custom"``) — the same long↔short split shape the VCF family carries.
     The hint must:
 
-    * point at ``meho connector ingest --product custom --version
+    * point at ``meho connector ingest --product custom-vendor --version
       1.0 --impl custom-rest --spec <upstream-openapi-uri>`` (the
-      manual-mode invocation), emitting the **parser-derived**
-      ``--product`` (the same one the listing row advertises) so the
-      verb round-trips to a *dispatchable* ingest. Emitting the registry
-      product (``custom-vendor``) was the claude-rdc-hetzner-dc#1136
-      false-success: rows ingested under it land where the dispatcher
-      never queries, leaving the catalog ``registered, 0 ops``;
+      manual-mode invocation), emitting the **registry** ``--product``
+      (the spelling the connector class registers under) so the operator's
+      ingest finds the real class and runs a real version-coverage
+      pre-flight. Register-time row reconciliation persists the rows under
+      the parser-derived dispatch product (``custom``), so it still
+      round-trips to a *dispatchable* ingest — that reconciliation, not
+      switching the verb to the short product, is what closes the
+      claude-rdc-hetzner-dc#1136 false-success (the dispatchable round-trip
+      is pinned end-to-end in
+      ``test_operations_ingest_catalog.test_registered_next_step_verb_round_trips_to_dispatchable_ingest``);
     * carry a rationale that says the catalog has no entry so the
       operator knows they need to source the OpenAPI spec themselves;
     * name the hand-authored on-ramp (#1533 / ci-07) so a spec-less
@@ -1127,10 +1131,11 @@ async def test_list_registered_row_without_catalog_entry_points_at_manual_mode(
     assert custom["next_step"] is not None
     verb = custom["next_step"]["verb"]
     assert "--catalog" not in verb
-    # The verb emits the parser-derived product (round-trips dispatchably),
-    # NOT the registry product custom-vendor (claude-rdc-hetzner-dc#1136).
-    assert "--product custom " in verb
-    assert "--product custom-vendor" not in verb
+    # The verb emits the registry product (so the operator's ingest finds
+    # the real class + runs a real version-coverage pre-flight); register-
+    # time reconciliation lands the rows dispatchably under the short
+    # product, so it still round-trips (claude-rdc-hetzner-dc#1136).
+    assert "--product custom-vendor " in verb
     assert "--version 1.0" in verb
     assert "--impl custom-rest" in verb
     assert "--spec" in verb

--- a/backend/tests/test_api_v1_connectors_ingest.py
+++ b/backend/tests/test_api_v1_connectors_ingest.py
@@ -1090,13 +1090,21 @@ async def test_list_registered_row_without_catalog_entry_points_at_manual_mode(
     doesn't carry the registered connector, the rationale says so and
     points at manual-mode ``meho connector ingest`` with ``--spec``.
 
-    Uses a synthetic ``("custom-vendor", "1.0")`` v2 registration with
-    no catalog entry. The hint must:
+    Uses a synthetic ``("custom-vendor", "1.0", "custom-rest")`` v2
+    registration with no catalog entry. The registry product
+    (``custom-vendor``) differs from the product the dispatcher derives
+    from the connector_id (``parse_connector_id("custom-rest-1.0") ->
+    "custom"``) — the same long↔short split shape the VCF family carries.
+    The hint must:
 
-    * point at ``meho connector ingest --product custom-vendor --version
+    * point at ``meho connector ingest --product custom --version
       1.0 --impl custom-rest --spec <upstream-openapi-uri>`` (the
-      manual-mode invocation), echoing the registry's natural key so
-      the operator copies the right values verbatim;
+      manual-mode invocation), emitting the **parser-derived**
+      ``--product`` (the same one the listing row advertises) so the
+      verb round-trips to a *dispatchable* ingest. Emitting the registry
+      product (``custom-vendor``) was the claude-rdc-hetzner-dc#1136
+      false-success: rows ingested under it land where the dispatcher
+      never queries, leaving the catalog ``registered, 0 ops``;
     * carry a rationale that says the catalog has no entry so the
       operator knows they need to source the OpenAPI spec themselves;
     * name the hand-authored on-ramp (#1533 / ci-07) so a spec-less
@@ -1114,10 +1122,15 @@ async def test_list_registered_row_without_catalog_entry_points_at_manual_mode(
 
     custom = by_id["custom-rest-1.0"]
     assert custom["state"] == "registered"
+    # The listing row advertises the parser-derived product.
+    assert custom["product"] == "custom"
     assert custom["next_step"] is not None
     verb = custom["next_step"]["verb"]
     assert "--catalog" not in verb
-    assert "--product custom-vendor" in verb
+    # The verb emits the parser-derived product (round-trips dispatchably),
+    # NOT the registry product custom-vendor (claude-rdc-hetzner-dc#1136).
+    assert "--product custom " in verb
+    assert "--product custom-vendor" not in verb
     assert "--version 1.0" in verb
     assert "--impl custom-rest" in verb
     assert "--spec" in verb

--- a/backend/tests/test_operations_ingest_catalog.py
+++ b/backend/tests/test_operations_ingest_catalog.py
@@ -23,6 +23,7 @@ typed-vs-generic ``upstream`` contract, and the ``GET
 from __future__ import annotations
 
 import contextlib
+import uuid
 from unittest.mock import MagicMock
 
 import pytest
@@ -30,6 +31,7 @@ from fastapi import FastAPI
 from fastapi.testclient import TestClient
 from packaging.version import Version
 from pydantic import ValidationError
+from sqlalchemy import select
 
 from meho_backplane.api.v1.connectors_ingest import (
     catalog_endpoint,
@@ -824,3 +826,107 @@ def test_shipped_catalog_marks_vcf_family_rows_spec_only() -> None:
             assert entry.catalog_ingest == "supported", (
                 f"{entry.product}/{entry.version} should default to catalog_ingest: supported"
             )
+
+
+# ---------------------------------------------------------------------------
+# next_step.verb round-trips to a dispatchable ingest (claude-rdc-hetzner-dc#1136)
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.asyncio
+async def test_registered_next_step_verb_round_trips_to_dispatchable_ingest() -> None:
+    """The ``vcf-logs`` registered-row ``next_step.verb`` ingests dispatchably.
+
+    The claude-rdc-hetzner-dc#1136 false-success had two halves: the
+    catalog's own ``next_step.verb`` printed ``--product vcf-logs`` while
+    the row it decorated carried ``product="vrli"``, so an operator
+    copying the verb ingested under a product the dispatcher never
+    queried. This test pins the fix end-to-end:
+
+    1. The verb for the ``vcf-logs`` registered row emits the
+       parser-derived ``--product`` (``vrli``) — the same product the
+       row advertises.
+    2. Ingesting under exactly that ``--product`` yields a connector the
+       dispatch/query surface resolves (``connector_exists`` True): the
+       verb round-trips to a *dispatchable* ingest.
+    """
+    import re
+    from unittest.mock import AsyncMock
+
+    from meho_backplane.connectors.registry import _eager_import_connectors
+    from meho_backplane.db.engine import get_sessionmaker
+    from meho_backplane.db.models import EndpointDescriptor
+    from meho_backplane.operations._lookup import connector_exists, parse_connector_id
+    from meho_backplane.operations.ingest import register_ingested_operations
+    from meho_backplane.operations.ingest.list_connectors import (
+        _load_catalog_or_none,
+        _maybe_build_class_only_item,
+    )
+    from meho_backplane.operations.ingest.schemas import EndpointDescriptorProto
+
+    # Real connectors registered (the session-level baseline import is a
+    # no-op when already populated; defensive against collection order).
+    _eager_import_connectors()
+
+    item = _maybe_build_class_only_item(
+        registry_product="vcf-logs",
+        registry_version="9.0",
+        registry_impl_id="vrli-rest",
+        db_triples=set(),
+        catalog=_load_catalog_or_none(),
+    )
+    assert item is not None
+    assert item.state == "registered"
+    # The row advertises the parser-derived product, and the verb agrees.
+    assert item.product == "vrli"
+    assert item.next_step is not None
+    verb = item.next_step.verb
+    match = re.search(r"--product (\S+)", verb)
+    assert match is not None, f"verb has no --product flag: {verb!r}"
+    verb_product = match.group(1)
+    assert verb_product == "vrli", (
+        f"next_step.verb emits --product {verb_product!r}; expected the "
+        f"dispatch product 'vrli' so the verb round-trips. Full verb: {verb!r}"
+    )
+
+    # Round-trip: ingest under the verb's --product and assert dispatchable.
+    stub = AsyncMock()
+    stub.encode_one.return_value = [0.25] * 384
+    stub.encode.return_value = [[0.25] * 384]
+    stub.dimension = 384
+    result = await register_ingested_operations(
+        product=verb_product,  # exactly what the verb told the operator to use
+        version="9.0",
+        impl_id="vrli-rest",
+        spec_source="vrli.yaml",
+        operations=[
+            EndpointDescriptorProto(
+                op_id="GET:/api/v2/version",
+                method="GET",
+                path="/api/v2/version",
+                summary="version",
+                description="appliance version",
+                tags=["vrli"],
+                parameter_schema={"type": "object", "properties": {}},
+                response_schema={"type": "object"},
+                safety_level="safe",
+                requires_approval=False,
+            )
+        ],
+        embedding_service=stub,
+    )
+    assert result.inserted_count == 1
+
+    sessionmaker = get_sessionmaker()
+    async with sessionmaker() as fresh:
+        rows = (await fresh.execute(select(EndpointDescriptor))).scalars().all()
+    assert rows and rows[0].product == "vrli"
+
+    probe_product, probe_version, probe_impl_id = parse_connector_id(item.connector_id)
+    exists = await connector_exists(
+        tenant_id=uuid.uuid4(),
+        product=probe_product,
+        version=probe_version,
+        impl_id=probe_impl_id,
+    )
+    assert exists is True, "verb round-trip did not yield a dispatchable connector"

--- a/backend/tests/test_operations_ingest_catalog.py
+++ b/backend/tests/test_operations_ingest_catalog.py
@@ -837,18 +837,22 @@ def test_shipped_catalog_marks_vcf_family_rows_spec_only() -> None:
 async def test_registered_next_step_verb_round_trips_to_dispatchable_ingest() -> None:
     """The ``vcf-logs`` registered-row ``next_step.verb`` ingests dispatchably.
 
-    The claude-rdc-hetzner-dc#1136 false-success had two halves: the
-    catalog's own ``next_step.verb`` printed ``--product vcf-logs`` while
-    the row it decorated carried ``product="vrli"``, so an operator
-    copying the verb ingested under a product the dispatcher never
-    queried. This test pins the fix end-to-end:
+    The claude-rdc-hetzner-dc#1136 false-success was: an operator copying
+    the verb ingested under a product the dispatcher never queried, so the
+    catalog kept reporting ``registered, 0 ops``. The fix is the
+    register-time row reconciliation (rows land under the parser-derived
+    dispatch product regardless of the supplied ``--product``), which lets
+    the verb keep the **registry** product so the operator's ingest also
+    finds the real connector class and runs a real version-coverage
+    pre-flight. This test pins the fix end-to-end:
 
-    1. The verb for the ``vcf-logs`` registered row emits the
-       parser-derived ``--product`` (``vrli``) — the same product the
-       row advertises.
+    1. The verb for the ``vcf-logs`` registered row emits the **registry**
+       ``--product`` (``vcf-logs``) — the spelling ``VcfLogsConnector``
+       registers under.
     2. Ingesting under exactly that ``--product`` yields a connector the
-       dispatch/query surface resolves (``connector_exists`` True): the
-       verb round-trips to a *dispatchable* ingest.
+       dispatch/query surface resolves under the parser-derived key
+       (``connector_exists`` True): reconciliation makes the verb
+       round-trip to a *dispatchable* ingest.
     """
     import re
     from unittest.mock import AsyncMock
@@ -877,19 +881,23 @@ async def test_registered_next_step_verb_round_trips_to_dispatchable_ingest() ->
     )
     assert item is not None
     assert item.state == "registered"
-    # The row advertises the parser-derived product, and the verb agrees.
+    # The listing row still advertises the parser-derived product (the
+    # dispatch surface keys on it); the manual-mode verb, however, names
+    # the registry product so the operator's ingest finds the real class.
     assert item.product == "vrli"
     assert item.next_step is not None
     verb = item.next_step.verb
     match = re.search(r"--product (\S+)", verb)
     assert match is not None, f"verb has no --product flag: {verb!r}"
     verb_product = match.group(1)
-    assert verb_product == "vrli", (
+    assert verb_product == "vcf-logs", (
         f"next_step.verb emits --product {verb_product!r}; expected the "
-        f"dispatch product 'vrli' so the verb round-trips. Full verb: {verb!r}"
+        f"registry product 'vcf-logs' so the operator's ingest finds the "
+        f"real VcfLogsConnector class. Full verb: {verb!r}"
     )
 
-    # Round-trip: ingest under the verb's --product and assert dispatchable.
+    # Round-trip: ingest under the verb's --product (the registry product)
+    # and assert the reconciled rows are dispatchable under the short key.
     stub = AsyncMock()
     stub.encode_one.return_value = [0.25] * 384
     stub.encode.return_value = [[0.25] * 384]

--- a/backend/tests/test_operations_ingest_jobs.py
+++ b/backend/tests/test_operations_ingest_jobs.py
@@ -1,0 +1,270 @@
+# SPDX-License-Identifier: Apache-2.0
+# Copyright (c) 2026 evoila Group
+
+"""Behavioural tests for the async-ingest job registry + the post-run honesty gate.
+
+Covers :func:`meho_backplane.operations.ingest.jobs.run_ingest_job`'s
+reconciliation of a background pipeline run into the in-memory job row,
+with the dispatchability postcondition (G0.24 /
+claude-rdc-hetzner-dc#1136) front and centre:
+
+* A pipeline that returns a dispatchable result flips the job to
+  ``succeeded``.
+* A pipeline that returns but persisted nothing dispatchable —
+  ``inserted_count == 0`` *or* the injected dispatchability probe
+  returns ``False`` — flips the job to ``degraded`` carrying
+  ``error_class="ingested_not_dispatchable"``, never a bare
+  ``succeeded``. The ``degraded`` row still carries the pipeline's
+  ``result`` so the operator sees the counts that (didn't) land.
+* A pipeline that raises still flips to ``failed`` (the pre-existing
+  contract is preserved).
+
+These are pure unit tests: ``run_ingest_job`` is driven directly with a
+stub ``pipeline_call`` closure and a stub ``dispatchability_check``, so
+no DB or HTTP layer is exercised. The DB-backed end-to-end proof that an
+async ``--product vcf-logs`` ingest is dispatchable lives in
+``test_operations_register_ingested.py`` (the product-reconciliation
+side of the same task).
+"""
+
+from __future__ import annotations
+
+import pytest
+
+from meho_backplane.operations.ingest import (
+    IngestionPipelineResult,
+    IngestJob,
+    IngestJobRegistry,
+    run_ingest_job,
+)
+from meho_backplane.operations.ingest.jobs import INGESTED_NOT_DISPATCHABLE
+from meho_backplane.operations.ingest.register_ingested import IngestionResult
+
+
+def _pipeline_result(
+    *,
+    connector_id: str = "vrli-rest-9.0",
+    inserted_count: int = 5,
+) -> IngestionPipelineResult:
+    """Build a minimal :class:`IngestionPipelineResult` for the job-row tests.
+
+    ``grouping=None`` keeps the shape small — the honesty gate only
+    reads ``connector_id`` + ``ingestion.inserted_count``.
+    """
+    return IngestionPipelineResult(
+        connector_id=connector_id,
+        ingestion=IngestionResult(
+            inserted_count=inserted_count,
+            updated_count=0,
+            skipped_count=0,
+            connector_registered=True,
+            operations_grouped=False,
+        ),
+        grouping=None,
+    )
+
+
+async def _create_running_job(registry: IngestJobRegistry) -> IngestJob:
+    """Insert a ``running`` job row and return it."""
+    return await registry.create(
+        operator_sub="op-sub",
+        tenant_id=None,
+        catalog_entry=None,
+        product="vcf-logs",
+        version="9.0",
+        impl_id="vrli-rest",
+        spec_uris=["file:///vrli.yaml"],
+    )
+
+
+@pytest.mark.asyncio
+async def test_dispatchable_run_flips_to_succeeded() -> None:
+    """A non-empty, dispatchable pipeline result completes the job ``succeeded``."""
+    registry = IngestJobRegistry()
+    job = await _create_running_job(registry)
+    result = _pipeline_result(inserted_count=5)
+
+    async def _check(_result: IngestionPipelineResult) -> bool:
+        return True
+
+    await run_ingest_job(
+        job.job_id,
+        pipeline_call=lambda: _async_return(result),
+        registry=registry,
+        dispatchability_check=_check,
+    )
+
+    stored = await registry.get(job.job_id, tenant_id=None, is_tenant_admin=True)
+    assert stored.status == "succeeded"
+    assert stored.result is result
+    assert stored.error is None
+    assert stored.error_class is None
+    assert stored.ended_at is not None
+
+
+@pytest.mark.asyncio
+async def test_zero_insert_run_degrades_not_succeeds() -> None:
+    """A pipeline that returns but inserted nothing ends ``degraded`` (not ``succeeded``).
+
+    This is the false-success the gate closes: the coroutine returned
+    without raising, so the pre-#1136 code flipped the job to
+    ``succeeded`` even though zero operations landed. The job must now
+    end ``degraded`` with the structured ``ingested_not_dispatchable``
+    class. The zero-insert branch does not even need the probe.
+    """
+    registry = IngestJobRegistry()
+    job = await _create_running_job(registry)
+    result = _pipeline_result(inserted_count=0)
+
+    probe_calls = 0
+
+    async def _check(_result: IngestionPipelineResult) -> bool:
+        nonlocal probe_calls
+        probe_calls += 1
+        return True
+
+    await run_ingest_job(
+        job.job_id,
+        pipeline_call=lambda: _async_return(result),
+        registry=registry,
+        dispatchability_check=_check,
+    )
+
+    stored = await registry.get(job.job_id, tenant_id=None, is_tenant_admin=True)
+    assert stored.status == "degraded"
+    assert stored.error_class == INGESTED_NOT_DISPATCHABLE
+    assert stored.error is not None and "inserted_count=0" in stored.error
+    # The counts that landed (none) still ride along for diagnosis.
+    assert stored.result is result
+    # Zero-insert is non-dispatchable by definition; the probe is skipped.
+    assert probe_calls == 0
+
+
+@pytest.mark.asyncio
+async def test_persisted_but_invisible_run_degrades() -> None:
+    """Rows persisted but unresolvable by the dispatch surface ⇒ ``degraded``.
+
+    The exact claude-rdc-hetzner-dc#1136 mis-keyed-product symptom:
+    ``inserted_count > 0`` yet the dispatch/query probe
+    (``connector_exists`` under the parser-derived key) returns
+    ``False``. The job must end ``degraded`` carrying the structured
+    class and a message that names the persisted-but-invisible failure
+    mode, while still surfacing the insert count.
+    """
+    registry = IngestJobRegistry()
+    job = await _create_running_job(registry)
+    result = _pipeline_result(connector_id="vrli-rest-9.0", inserted_count=7)
+
+    async def _check_invisible(_result: IngestionPipelineResult) -> bool:
+        return False
+
+    await run_ingest_job(
+        job.job_id,
+        pipeline_call=lambda: _async_return(result),
+        registry=registry,
+        dispatchability_check=_check_invisible,
+    )
+
+    stored = await registry.get(job.job_id, tenant_id=None, is_tenant_admin=True)
+    assert stored.status == "degraded"
+    assert stored.error_class == INGESTED_NOT_DISPATCHABLE
+    assert stored.error is not None
+    assert "not resolvable" in stored.error
+    assert "7 operation" in stored.error
+    assert stored.result is result
+
+
+@pytest.mark.asyncio
+async def test_raising_pipeline_still_fails() -> None:
+    """A pipeline that raises flips to ``failed`` — the pre-existing contract holds.
+
+    The honesty gate only governs the *returned-but-non-dispatchable*
+    case; an exception is still a hard ``failed`` with the exception
+    class recorded, and the dispatchability probe is never consulted
+    (there is no result to probe).
+    """
+    registry = IngestJobRegistry()
+    job = await _create_running_job(registry)
+
+    probe_calls = 0
+
+    async def _check(_result: IngestionPipelineResult) -> bool:
+        nonlocal probe_calls
+        probe_calls += 1
+        return True
+
+    async def _raise() -> IngestionPipelineResult:
+        raise ValueError("spec parse blew up")
+
+    await run_ingest_job(
+        job.job_id,
+        pipeline_call=_raise,
+        registry=registry,
+        dispatchability_check=_check,
+    )
+
+    stored = await registry.get(job.job_id, tenant_id=None, is_tenant_admin=True)
+    assert stored.status == "failed"
+    assert stored.error_class == "ValueError"
+    assert stored.error is not None and "spec parse blew up" in stored.error
+    assert stored.result is None
+    assert probe_calls == 0
+
+
+@pytest.mark.asyncio
+async def test_no_probe_injected_treats_nonempty_insert_as_dispatchable() -> None:
+    """A legacy caller that omits the probe still succeeds on a non-empty insert.
+
+    ``dispatchability_check=None`` is the opt-out: the zero-insert guard
+    still fires, but the persisted-but-invisible case can only be
+    detected by the probe, so an opted-out caller treats any non-empty
+    insert as dispatchable (and the production route always supplies the
+    probe, so this gap never reaches operators).
+    """
+    registry = IngestJobRegistry()
+    job = await _create_running_job(registry)
+    result = _pipeline_result(inserted_count=3)
+
+    await run_ingest_job(
+        job.job_id,
+        pipeline_call=lambda: _async_return(result),
+        registry=registry,
+        # No dispatchability_check passed.
+    )
+
+    stored = await registry.get(job.job_id, tenant_id=None, is_tenant_admin=True)
+    assert stored.status == "succeeded"
+
+
+@pytest.mark.asyncio
+async def test_probe_failure_fails_open_to_succeeded() -> None:
+    """A dispatchability probe that *raises* fails open — the job still ``succeeded``.
+
+    The pipeline completed; a transient probe error (e.g. a DB blip on
+    the ``connector_exists`` read) must not strand the job in ``running``
+    or degrade it on a false signal. The honesty gate only degrades on a
+    clean ``False`` verdict or a zero-insert run, not on a probe
+    exception.
+    """
+    registry = IngestJobRegistry()
+    job = await _create_running_job(registry)
+    result = _pipeline_result(inserted_count=4)
+
+    async def _check_raises(_result: IngestionPipelineResult) -> bool:
+        raise RuntimeError("connector_exists probe blew up")
+
+    await run_ingest_job(
+        job.job_id,
+        pipeline_call=lambda: _async_return(result),
+        registry=registry,
+        dispatchability_check=_check_raises,
+    )
+
+    stored = await registry.get(job.job_id, tenant_id=None, is_tenant_admin=True)
+    assert stored.status == "succeeded"
+    assert stored.error_class is None
+
+
+async def _async_return(value: IngestionPipelineResult) -> IngestionPipelineResult:
+    """Tiny awaitable that returns *value* — a stand-in pipeline coroutine."""
+    return value

--- a/backend/tests/test_operations_ingest_jobs.py
+++ b/backend/tests/test_operations_ingest_jobs.py
@@ -103,14 +103,17 @@ async def test_dispatchable_run_flips_to_succeeded() -> None:
 
 
 @pytest.mark.asyncio
-async def test_zero_insert_run_degrades_not_succeeds() -> None:
-    """A pipeline that returns but inserted nothing ends ``degraded`` (not ``succeeded``).
+async def test_zero_insert_first_run_degrades_not_succeeds() -> None:
+    """An empty first-run (0 inserts, probe says non-dispatchable) ends ``degraded``.
 
     This is the false-success the gate closes: the coroutine returned
     without raising, so the pre-#1136 code flipped the job to
-    ``succeeded`` even though zero operations landed. The job must now
-    end ``degraded`` with the structured ``ingested_not_dispatchable``
-    class. The zero-insert branch does not even need the probe.
+    ``succeeded`` even though zero operations landed under a connector the
+    dispatcher cannot resolve. The job must end ``degraded`` with the
+    structured ``ingested_not_dispatchable`` class. The probe IS consulted
+    on the zero-insert branch (a re-run that skips every op also reaches
+    ``inserted_count == 0`` but stays dispatchable — see the idempotent
+    re-run case below), and here returns ``False``.
     """
     registry = IngestJobRegistry()
     job = await _create_running_job(registry)
@@ -121,7 +124,7 @@ async def test_zero_insert_run_degrades_not_succeeds() -> None:
     async def _check(_result: IngestionPipelineResult) -> bool:
         nonlocal probe_calls
         probe_calls += 1
-        return True
+        return False
 
     await run_ingest_job(
         job.job_id,
@@ -136,8 +139,40 @@ async def test_zero_insert_run_degrades_not_succeeds() -> None:
     assert stored.error is not None and "inserted_count=0" in stored.error
     # The counts that landed (none) still ride along for diagnosis.
     assert stored.result is result
-    # Zero-insert is non-dispatchable by definition; the probe is skipped.
-    assert probe_calls == 0
+    assert probe_calls == 1
+
+
+@pytest.mark.asyncio
+async def test_idempotent_zero_insert_rerun_succeeds() -> None:
+    """A benign idempotent re-run (0 inserts, already dispatchable) stays ``succeeded``.
+
+    Re-ingesting an already-persisted spec skips every op
+    (``_upsert.upsert_one_operation`` returns ``"skipped"``), so
+    ``inserted_count == 0`` on a perfectly healthy, already-dispatchable
+    connector. Degrading it unconditionally (the pre-fix behaviour) flipped
+    a no-op re-run into a non-zero CLI failure; consulting the probe keeps
+    it ``succeeded`` because the connector still resolves under its dispatch
+    key.
+    """
+    registry = IngestJobRegistry()
+    job = await _create_running_job(registry)
+    result = _pipeline_result(inserted_count=0)
+
+    async def _check_dispatchable(_result: IngestionPipelineResult) -> bool:
+        return True
+
+    await run_ingest_job(
+        job.job_id,
+        pipeline_call=lambda: _async_return(result),
+        registry=registry,
+        dispatchability_check=_check_dispatchable,
+    )
+
+    stored = await registry.get(job.job_id, tenant_id=None, is_tenant_admin=True)
+    assert stored.status == "succeeded"
+    assert stored.error is None
+    assert stored.error_class is None
+    assert stored.result is result
 
 
 @pytest.mark.asyncio
@@ -263,6 +298,8 @@ async def test_probe_failure_fails_open_to_succeeded() -> None:
     stored = await registry.get(job.job_id, tenant_id=None, is_tenant_admin=True)
     assert stored.status == "succeeded"
     assert stored.error_class is None
+    # Fail-open must not copy the probe exception text into the row either.
+    assert stored.error is None
 
 
 async def _async_return(value: IngestionPipelineResult) -> IngestionPipelineResult:

--- a/backend/tests/test_operations_register_ingested.py
+++ b/backend/tests/test_operations_register_ingested.py
@@ -65,6 +65,11 @@ from meho_backplane.connectors.registry import (
 )
 from meho_backplane.db.engine import get_sessionmaker
 from meho_backplane.db.models import EndpointDescriptor
+from meho_backplane.operations._lookup import (
+    connector_exists,
+    dispatch_product,
+    parse_connector_id,
+)
 from meho_backplane.operations.ingest import (
     EndpointDescriptorProto,
     GenericRestConnector,
@@ -1045,3 +1050,143 @@ async def test_register_ingested_passes_pre_flight_for_compatible_version(
     # alongside the pre-existing (vmware, 9.0, vmware-rest) entry — the pre-flight
     # checks coverage, it does not require the triple to already exist.
     assert ("vmware", "9.0.3", "vmware-rest") in all_connectors_v2()
+
+
+# ---------------------------------------------------------------------------
+# Product-slug reconciliation (claude-rdc-hetzner-dc#1136)
+#
+# The VCF-family connectors register under a long product
+# (``product="vcf-logs"``) while the dispatch/query surface derives the
+# short product (``"vrli"``) from the connector_id's impl_id segment.
+# Ingesting under the long product used to persist rows the dispatcher
+# never queries → the catalog reported ``registered, 0 ops``. These
+# tests pin that an ingest under the long (registry) product now lands
+# rows under the short (dispatch) product so ``connector_exists`` — the
+# gate ``search_operations`` / ``list_operation_groups`` enforce —
+# returns True.
+# ---------------------------------------------------------------------------
+
+
+def _register_split_connector(*, registry_product: str, version: str, impl_id: str) -> None:
+    """Register a fake connector class under a long↔short *split* product.
+
+    Mirrors the real VCF-family classes (e.g. ``VcfLogsConnector`` ->
+    ``product="vcf-logs"`` / ``impl_id="vrli-rest"``) closely enough for
+    the ingest pre-flight + auto-shim skip path: the class registers
+    under the registry (long) product with a ``>=MAJOR,<MAJOR+1`` range
+    that covers *version*.
+    """
+    cls = type(
+        f"_FakeSplit_{registry_product}",
+        (_FakeRangedConnector,),
+        {
+            "product": registry_product,
+            "version": version,
+            "impl_id": impl_id,
+            "supported_version_range": ">=9.0,<10.0",
+            "priority": 1,
+        },
+    )
+    register_connector_v2(
+        product=registry_product,
+        version=version,
+        impl_id=impl_id,
+        cls=cls,
+    )
+
+
+#: Every VCF-family long↔short split, as ``(registry_product, impl_id,
+#: dispatch_product)``. The registry product is what the connector class
+#: registers under (and what the catalog / pre-#1136 next_step verb hand
+#: the operator); the dispatch product is what ``parse_connector_id``
+#: derives from ``f"{impl_id}-{version}"`` and what the rows must persist
+#: under to be dispatchable. Mirrors ``_KNOWN_LISTING_PRODUCT_DRIFT`` in
+#: ``test_operations_ingest_catalog.py`` plus the already-handled SDDC
+#: case (same split shape).
+_VCF_PRODUCT_SPLITS: list[tuple[str, str, str]] = [
+    ("hetzner-robot", "hetzner-rest", "hetzner"),
+    ("sddc-manager", "sddc-rest", "sddc"),
+    ("vcf-automation", "vcfa-rest", "vcfa"),
+    ("vcf-fleet", "fleet-rest", "fleet"),
+    ("vcf-logs", "vrli-rest", "vrli"),
+    ("vcf-operations", "vrops-rest", "vrops"),
+]
+
+
+@pytest.mark.asyncio
+@pytest.mark.parametrize(("registry_product", "impl_id", "dispatch_product"), _VCF_PRODUCT_SPLITS)
+async def test_ingest_under_registry_product_persists_dispatchable_rows(
+    stub_embedding_service: AsyncMock,
+    registry_product: str,
+    impl_id: str,
+    dispatch_product: str,
+) -> None:
+    """Ingesting under the long (registry) product lands rows under the short (dispatch) one.
+
+    For every VCF-family split, an operator ingesting ``--product
+    <registry_product>`` (what the catalog row / next_step verb name)
+    must produce a connector the dispatch/query surface resolves. Rows
+    persist under the parser-derived short product and ``connector_exists``
+    — the exact gate ``search_operations`` enforces — returns True.
+    """
+    version = "9.0"
+    _register_split_connector(registry_product=registry_product, version=version, impl_id=impl_id)
+
+    result = await register_ingested_operations(
+        product=registry_product,  # the LONG product the operator was told to use
+        version=version,
+        impl_id=impl_id,
+        spec_source="upstream.yaml",
+        operations=[_proto("GET:/api/v2/version", path="/api/v2/version")],
+        embedding_service=stub_embedding_service,
+    )
+    assert result.inserted_count == 1
+
+    # Rows persisted under the SHORT (dispatch) product, never the long one.
+    sessionmaker = get_sessionmaker()
+    async with sessionmaker() as fresh:
+        rows = (await fresh.execute(select(EndpointDescriptor))).scalars().all()
+    assert len(rows) == 1
+    assert rows[0].product == dispatch_product, (
+        f"row persisted under {rows[0].product!r}; expected the dispatch product "
+        f"{dispatch_product!r} so the dispatcher (which parses it out of the "
+        f"connector_id) can resolve it"
+    )
+
+    # connector_exists — the dispatch/query gate — keyed on the parsed
+    # natural key returns True (the connector is dispatchable).
+    parsed_product, parsed_version, parsed_impl_id = parse_connector_id(f"{impl_id}-{version}")
+    assert parsed_product == dispatch_product
+    exists = await connector_exists(
+        tenant_id=uuid.uuid4(),
+        product=parsed_product,
+        version=parsed_version,
+        impl_id=parsed_impl_id,
+    )
+    assert exists is True
+
+
+@pytest.mark.asyncio
+async def test_aligned_product_ingest_is_unchanged(
+    stub_embedding_service: AsyncMock,
+) -> None:
+    """A connector whose product already equals the parsed one is a no-op for reconciliation.
+
+    ``vmware`` / ``vmware-rest`` has no split, so the reconciliation
+    must not move the row product — guards against the normalisation
+    accidentally rewriting the common case.
+    """
+    result = await register_ingested_operations(
+        product="vmware",
+        version="9.0",
+        impl_id="vmware-rest",
+        spec_source="vcenter.yaml",
+        operations=[_proto("GET:/api/vcenter/cluster", path="/api/vcenter/cluster")],
+        embedding_service=stub_embedding_service,
+    )
+    assert result.inserted_count == 1
+    sessionmaker = get_sessionmaker()
+    async with sessionmaker() as fresh:
+        rows = (await fresh.execute(select(EndpointDescriptor))).scalars().all()
+    assert rows[0].product == "vmware"
+    assert dispatch_product(product="vmware", version="9.0", impl_id="vmware-rest") == "vmware"

--- a/cli/api/openapi.json
+++ b/cli/api/openapi.json
@@ -13207,7 +13207,8 @@
             "enum": [
               "running",
               "succeeded",
-              "failed"
+              "failed",
+              "degraded"
             ],
             "title": "Status"
           },
@@ -13239,7 +13240,8 @@
             "enum": [
               "running",
               "succeeded",
-              "failed"
+              "failed",
+              "degraded"
             ],
             "title": "Status"
           },
@@ -13305,7 +13307,7 @@
           "started_at"
         ],
         "title": "IngestJobStatusResponse",
-        "description": "Response body for ``GET /api/v1/connectors/ingest/jobs/{job_id}``.\n\nMirrors the in-memory\n:class:`~meho_backplane.operations.ingest.jobs.IngestJob` row,\nprojecting it into a Pydantic-typed shape the route returns.\nThree field clusters:\n\n* **Identity** -- ``job_id`` + the originator's request descriptors\n  (``catalog_entry`` / ``product`` / ``version`` / ``impl_id`` /\n  ``spec_uris``). Echo so the polling caller doesn't need to\n  correlate against their own state.\n* **Lifecycle** -- ``status`` + ``started_at`` + optional\n  ``ended_at``. Status moves ``running`` \u2192 ``succeeded`` or\n  ``running`` \u2192 ``failed`` once.\n* **Result vs error** -- exactly one of ``ingestion`` (with\n  optional ``grouping``) or ``error`` is populated, keyed on\n  status. ``running`` leaves both ``None`` so polling clients\n  branch on ``status`` rather than checking presence.\n\n``error`` is the capped exception message; ``error_class`` is the\nPython exception class name -- structured enough for agents that\nwant to branch (``VersionMismatchError`` vs\n``LlmClientUnavailable``) without parsing prose. The structured\n422 envelopes the synchronous ingest path used to return (the\nerror-shape convention's classifier + ``detail`` body) are NOT\navailable off the request thread; the polling response is the\nnew error surface for the async path."
+        "description": "Response body for ``GET /api/v1/connectors/ingest/jobs/{job_id}``.\n\nMirrors the in-memory\n:class:`~meho_backplane.operations.ingest.jobs.IngestJob` row,\nprojecting it into a Pydantic-typed shape the route returns.\nThree field clusters:\n\n* **Identity** -- ``job_id`` + the originator's request descriptors\n  (``catalog_entry`` / ``product`` / ``version`` / ``impl_id`` /\n  ``spec_uris``). Echo so the polling caller doesn't need to\n  correlate against their own state.\n* **Lifecycle** -- ``status`` + ``started_at`` + optional\n  ``ended_at``. Status moves ``running`` \u2192 one of ``succeeded`` /\n  ``degraded`` / ``failed`` exactly once.\n* **Result vs error** -- keyed on status. ``succeeded`` populates\n  ``ingestion`` (with optional ``grouping``) and leaves ``error``\n  ``None``; ``failed`` populates ``error`` / ``error_class`` and\n  leaves ``ingestion`` ``None`` (the pipeline raised, no result).\n  ``degraded`` populates **both** \u2014 the pipeline returned a result\n  (so ``ingestion`` carries the counts that landed) but a\n  postcondition found it non-dispatchable (so ``error`` /\n  ``error_class`` carry the reason). ``running`` leaves them ``None``\n  so polling clients branch on ``status`` rather than presence.\n\n``error`` is the capped message; ``error_class`` is the structured\ndiscriminator -- the Python exception class name for ``failed``\n(``VersionMismatchError`` vs ``LlmClientUnavailable``), or the fixed\n``ingested_not_dispatchable`` token for ``degraded`` -- so agents\nbranch without parsing prose. The structured 422 envelopes the\nsynchronous ingest path used to return (the error-shape convention's\nclassifier + ``detail`` body) are NOT available off the request\nthread; the polling response is the new error surface for the async\npath."
       },
       "IngestKbRequest": {
         "properties": {

--- a/cli/internal/api/client.gen.go
+++ b/cli/internal/api/client.gen.go
@@ -151,6 +151,7 @@ const (
 
 // Defines values for IngestJobHandleStatus.
 const (
+	IngestJobHandleStatusDegraded  IngestJobHandleStatus = "degraded"
 	IngestJobHandleStatusFailed    IngestJobHandleStatus = "failed"
 	IngestJobHandleStatusRunning   IngestJobHandleStatus = "running"
 	IngestJobHandleStatusSucceeded IngestJobHandleStatus = "succeeded"
@@ -158,6 +159,7 @@ const (
 
 // Defines values for IngestJobStatusResponseStatus.
 const (
+	IngestJobStatusResponseStatusDegraded  IngestJobStatusResponseStatus = "degraded"
 	IngestJobStatusResponseStatusFailed    IngestJobStatusResponseStatus = "failed"
 	IngestJobStatusResponseStatusRunning   IngestJobStatusResponseStatus = "running"
 	IngestJobStatusResponseStatusSucceeded IngestJobStatusResponseStatus = "succeeded"
@@ -2567,21 +2569,27 @@ type IngestJobHandleStatus string
 //     “spec_uris“). Echo so the polling caller doesn't need to
 //     correlate against their own state.
 //   - **Lifecycle** -- “status“ + “started_at“ + optional
-//     “ended_at“. Status moves “running“ → “succeeded“ or
-//     “running“ → “failed“ once.
-//   - **Result vs error** -- exactly one of “ingestion“ (with
-//     optional “grouping“) or “error“ is populated, keyed on
-//     status. “running“ leaves both “None“ so polling clients
-//     branch on “status“ rather than checking presence.
+//     “ended_at“. Status moves “running“ → one of “succeeded“ /
+//     “degraded“ / “failed“ exactly once.
+//   - **Result vs error** -- keyed on status. “succeeded“ populates
+//     “ingestion“ (with optional “grouping“) and leaves “error“
+//     “None“; “failed“ populates “error“ / “error_class“ and
+//     leaves “ingestion“ “None“ (the pipeline raised, no result).
+//     “degraded“ populates **both** — the pipeline returned a result
+//     (so “ingestion“ carries the counts that landed) but a
+//     postcondition found it non-dispatchable (so “error“ /
+//     “error_class“ carry the reason). “running“ leaves them “None“
+//     so polling clients branch on “status“ rather than presence.
 //
-// “error“ is the capped exception message; “error_class“ is the
-// Python exception class name -- structured enough for agents that
-// want to branch (“VersionMismatchError“ vs
-// “LlmClientUnavailable“) without parsing prose. The structured
-// 422 envelopes the synchronous ingest path used to return (the
-// error-shape convention's classifier + “detail“ body) are NOT
-// available off the request thread; the polling response is the
-// new error surface for the async path.
+// “error“ is the capped message; “error_class“ is the structured
+// discriminator -- the Python exception class name for “failed“
+// (“VersionMismatchError“ vs “LlmClientUnavailable“), or the fixed
+// “ingested_not_dispatchable“ token for “degraded“ -- so agents
+// branch without parsing prose. The structured 422 envelopes the
+// synchronous ingest path used to return (the error-shape convention's
+// classifier + “detail“ body) are NOT available off the request
+// thread; the polling response is the new error surface for the async
+// path.
 type IngestJobStatusResponse struct {
 	CatalogEntry *string  `json:"catalog_entry"`
 	EndedAt      *float32 `json:"ended_at"`

--- a/cli/internal/cmd/connector/connector_test.go
+++ b/cli/internal/cmd/connector/connector_test.go
@@ -1665,6 +1665,75 @@ func TestRunIngestAsyncJobFailure(t *testing.T) {
 	}
 }
 
+// TestRunIngestAsyncJSONDegradedExitsNonZero pins B1 (#1647): a
+// degraded terminal status under --json must STILL exit non-zero.
+// The pre-fix code returned PrintJSON directly (nil on a successful
+// encode), so cobra saw exit 0 — the exact false-success this task
+// closes, moved to the CLI tier. The JSON job document still rides
+// out on stdout for diagnosis; the non-zero exit + human detail go
+// via stderr.
+func TestRunIngestAsyncJSONDegradedExitsNonZero(t *testing.T) {
+	errClass := "ingested_not_dispatchable"
+	errMsg := "ingest completed but persisted no new operations (inserted_count=0)"
+	srv := mockBackplane(t, map[string]mockHandler{
+		"POST /api/v1/connectors/ingest": func(w http.ResponseWriter, _ *http.Request) {
+			writeJSON(t, w, 202, asyncIngestHandle())
+		},
+		"GET /api/v1/connectors/ingest/jobs/" + asyncIngestJobID.String(): func(w http.ResponseWriter, _ *http.Request) {
+			writeJSON(t, w, 200, api.IngestJobStatusResponse{
+				JobId:      asyncIngestJobID,
+				Status:     api.IngestJobStatusResponseStatusDegraded,
+				ErrorClass: &errClass,
+				Error:      &errMsg,
+				Ingestion: &api.IngestionResultModel{
+					ConnectorId:   "vrli-rest-9.0",
+					InsertedCount: 0,
+				},
+			})
+		},
+	})
+	defer srv.Close()
+	primeToken(t, srv.URL)
+
+	cmd := &cobra.Command{}
+	cmd.SetContext(context.Background())
+	var stdout, stderr bytes.Buffer
+	cmd.SetOut(&stdout)
+	cmd.SetErr(&stderr)
+
+	err := runIngest(cmd, ingestOptions{
+		Catalog:           "vmware/9.0",
+		JSONOut:           true,
+		BackplaneOverride: srv.URL,
+		pollInterval:      time.Millisecond,
+	})
+	if err == nil {
+		t.Fatal("degraded --json job must exit non-zero")
+	}
+	var coder output.ExitCoder
+	if !errors.As(err, &coder) || coder.ExitCode() == 0 {
+		t.Fatalf("want a non-zero ExitCoder, got %v / %T", err, err)
+	}
+	if coder.ExitCode() != output.ExitUnexpected {
+		t.Errorf("want exit %d (unexpected_response), got %d", output.ExitUnexpected, coder.ExitCode())
+	}
+	// stdout stays the clean JSON job document (payload still emitted).
+	var st api.IngestJobStatusResponse
+	if jErr := json.Unmarshal(bytes.TrimSpace(stdout.Bytes()), &st); jErr != nil {
+		t.Fatalf("stdout is not a single IngestJobStatusResponse document: %v\n%s", jErr, stdout.String())
+	}
+	if st.Status != api.IngestJobStatusResponseStatusDegraded {
+		t.Errorf("stdout JSON lost the degraded status: %+v", st)
+	}
+	// The human detail (job id + class) routes to stderr, not stdout.
+	errOut := stderr.String()
+	for _, want := range []string{asyncIngestJobID.String(), errClass} {
+		if !strings.Contains(errOut, want) {
+			t.Errorf("stderr missing %q:\n%s", want, errOut)
+		}
+	}
+}
+
 // TestRunIngestAsyncPollLost404 pins the pod-restart story: the
 // poll 404s (registry is process-local), the CLI exits non-zero
 // with the check-before-re-running guidance, and crucially never

--- a/cli/internal/cmd/connector/ingest.go
+++ b/cli/internal/cmd/connector/ingest.go
@@ -451,7 +451,21 @@ func runIngestAsync(
 			detail = *st.Error
 		}
 		if opts.JSONOut {
-			return output.PrintJSON(cmd.OutOrStdout(), st)
+			// Emit the full job document (counts + error_class) to stdout
+			// for diagnosis, then still exit non-zero: a degraded job is a
+			// terminal failure (#1647), and a --json consumer that read this
+			// as exit 0 is the exact false-success this task closes, moved
+			// to the CLI tier. jsonOut=false on RenderError keeps stdout the
+			// clean JSON document (the human one-liner goes to stderr) while
+			// the returned silentError carries ExitUnexpected.
+			if err := output.PrintJSON(cmd.OutOrStdout(), st); err != nil {
+				return err
+			}
+			return output.RenderError(cmd.ErrOrStderr(),
+				output.Unexpected(fmt.Sprintf(
+					"ingest job %s degraded: %s: %s", st.JobId, errClass, detail)),
+				false,
+			)
 		}
 		return output.RenderError(cmd.ErrOrStderr(),
 			output.Unexpected(fmt.Sprintf(

--- a/cli/internal/cmd/connector/ingest.go
+++ b/cli/internal/cmd/connector/ingest.go
@@ -372,7 +372,10 @@ func postIngest(ctx context.Context, authed *api.AuthedClient, body api.IngestRe
 //     regardless of whether the backplane ran the pipeline inline
 //     or off-thread. A failed job renders the job's error_class +
 //     capped error message as unexpected_response (exit 4), the
-//     same family the sync path's pipeline failures land in.
+//     same family the sync path's pipeline failures land in. A
+//     degraded job (the pipeline ran but persisted nothing
+//     dispatchable — claude-rdc-hetzner-dc#1136) renders the same
+//     way so a non-dispatchable ingest is never mistaken for success.
 //
 // The progress notice goes to stderr in both output modes: stdout
 // stays reserved for the final result (Goal #11 §5 output
@@ -429,6 +432,30 @@ func runIngestAsync(
 		return output.RenderError(cmd.ErrOrStderr(),
 			output.Unexpected(fmt.Sprintf(
 				"ingest job %s failed: %s: %s", st.JobId, errClass, detail)),
+			opts.JSONOut,
+		)
+	case api.IngestJobStatusResponseStatusDegraded:
+		// The pipeline ran to completion but left the connector
+		// non-dispatchable (claude-rdc-hetzner-dc#1136): a bare
+		// "succeeded" here was the false-success the server now refuses
+		// to report. Surface it as an error (non-zero exit) carrying the
+		// structured error_class + detail so the operator knows the
+		// catalog row will read "registered, 0 ops" and what to do. The
+		// ingestion counts ride along in --json output for diagnosis.
+		errClass := "ingested_not_dispatchable"
+		if st.ErrorClass != nil && *st.ErrorClass != "" {
+			errClass = *st.ErrorClass
+		}
+		detail := "(no error detail recorded)"
+		if st.Error != nil && *st.Error != "" {
+			detail = *st.Error
+		}
+		if opts.JSONOut {
+			return output.PrintJSON(cmd.OutOrStdout(), st)
+		}
+		return output.RenderError(cmd.ErrOrStderr(),
+			output.Unexpected(fmt.Sprintf(
+				"ingest job %s degraded: %s: %s", st.JobId, errClass, detail)),
 			opts.JSONOut,
 		)
 	default:

--- a/docs/codebase/spec-ingestion.md
+++ b/docs/codebase/spec-ingestion.md
@@ -266,8 +266,11 @@ shared `IngestJobRegistry`, fires the pipeline off the request via
 `asyncio.create_task`, and returns an `IngestJobHandle` immediately —
 well inside the agent's tool-call deadline. The agent polls
 `meho.connector.ingest_status` with the returned `job_id` until the
-status is `succeeded` (carries the final ingestion + grouping counts)
-or `failed` (carries `error_class` + `error`). Because both surfaces
+status is `succeeded` (carries the final ingestion + grouping counts),
+`degraded` (the pipeline ran but persisted nothing dispatchable —
+carries the counts **and** `error_class="ingested_not_dispatchable"` +
+`error`; see "Dispatchability postcondition" below), or `failed`
+(the pipeline raised — carries `error_class` + `error`). Because both surfaces
 share `get_job_registry()`, a run started over MCP is poll-able over
 the REST `GET /api/v1/connectors/ingest/jobs/{job_id}` endpoint and
 vice versa. `dry_run=true` and `async` unset keep the inline shape —
@@ -726,18 +729,77 @@ G0.18-T8 / #1361, RDC #789 N8). Three branches:
   resolve, so the verb still copies-and-runs once the operator
   sources the spec URI.
 * **Catalog miss** — verb points at `meho connector ingest --product
-  <p> --version <v> --impl <i> --spec <upstream-openapi-uri>`.
-  Rationale calls out the missing catalog entry so the operator
+  <p> --version <v> --impl <i> --spec <upstream-openapi-uri>` where
+  `<p>` is the **parser-derived** (dispatch) product, not the registry
+  product. Rationale calls out the missing catalog entry so the operator
   knows they need to source the OpenAPI spec themselves. Manual
   mode is the same path G0.7-T5 already supports for one-off /
-  not-yet-curated specs (see `ingest.go`'s mode dispatch).
+  not-yet-curated specs (see `ingest.go`'s mode dispatch). Emitting the
+  registry product here was the claude-rdc-hetzner-dc#1136 false-success
+  (see "Product-slug reconciliation" below): the verb said
+  `--product vcf-logs` while the row it decorated advertised
+  `product="vrli"`, so the verb did not round-trip to a dispatchable
+  ingest.
 
-The catalog lookup uses the **registry's** `(product, version)`, not
-the parser-derived shortening. The SDDC case is canonical: the
+The **catalog lookup** uses the **registry's** `(product, version)`,
+not the parser-derived shortening. The SDDC case is canonical: the
 catalog stores `product="sddc-manager"`, the listing emits
 `product="sddc"`, but the hint says `--catalog sddc-manager/9.0`
 because that is what `meho connector ingest --catalog ...` resolves
-against. Looking up the parsed product would always miss for SDDC.
+against. Looking up the parsed product would always miss for SDDC. The
+catalog-hit branches keep the catalog-native `--product` (an operator
+running `--catalog` or copying the catalog's triple matches the
+registered class); the catalog-miss branch emits the parser-derived
+product so the manual-mode verb round-trips dispatchably.
+
+#### Product-slug reconciliation (claude-rdc-hetzner-dc#1136)
+
+The VCF-family connectors register their class under a *long* product
+(`VcfLogsConnector.product = "vcf-logs"`) while the dispatch/query
+surface derives a *short* product from the connector_id
+(`parse_connector_id("vrli-rest-9.0") -> "vrli"`) — the same long↔short
+split SDDC carries (`sddc-manager` vs `sddc`), and the six splits are
+`hetzner-robot/hetzner`, `sddc-manager/sddc`, `vcf-automation/vcfa`,
+`vcf-fleet/fleet`, `vcf-logs/vrli`, `vcf-operations/vrops`.
+
+A manual `--spec` ingest persists `endpoint_descriptor` /
+`operation_group` rows keyed on the **operator-supplied** product, but
+the dispatch/query surface (`connector_exists` /
+`search_operations` / `list_operation_groups`) keys on the short,
+parser-derived product. Ingesting under the long product therefore
+landed rows the dispatcher never queried — the listing's round-trip
+integrity gate dropped them and the catalog reported
+`registered, 0 ops` even though the rows existed.
+
+`register_ingested_operations` reconciles this: it normalises the row
+product to the dispatch-canonical spelling
+(`_reconciled_row_product` → `dispatch_product` in
+`operations/_lookup.py`) before persisting descriptors, and the
+pipeline's grouping pass keys on the same spelling so descriptors and
+groups agree. The version-coverage pre-flight and the auto-shim
+registration deliberately stay on the **supplied** (registry) product
+so the coverage check finds the real `VcfLogsConnector` class and no
+redundant shim is synthesised. For aligned connectors
+(`vmware`/`vmware-rest`) the normalisation is a no-op. Regression
+coverage:
+`tests/test_operations_register_ingested.py::test_ingest_under_registry_product_persists_dispatchable_rows`
+(parametrised over all six splits) and
+`tests/test_operations_ingest_catalog.py::test_registered_next_step_verb_round_trips_to_dispatchable_ingest`
+(the verb round-trip).
+
+#### Dispatchability postcondition on async jobs (claude-rdc-hetzner-dc#1136)
+
+A background pipeline coroutine that returns without raising is **not**
+sufficient evidence the ingest succeeded: it can persist rows under a
+mis-keyed product (above) or skip every op against a prior run, leaving
+nothing dispatchable. `run_ingest_job` (`ingest/jobs.py`) therefore
+applies a postcondition before flipping the job to `succeeded`:
+`inserted_count > 0` **and** a `dispatchability_check` closure (the
+route's `connector_exists` probe under the parser-derived natural key,
+scoped to the originating tenant) returns `True`. When it fails the job
+ends `degraded` carrying `error_class="ingested_not_dispatchable"` and
+the counts that landed — never a bare `succeeded`. Regression coverage:
+`tests/test_operations_ingest_jobs.py`.
 
 If `load_catalog()` raises `CatalogError` at listing time (only
 possible mid-test-monkeypatch or mid-reload — startup parse failures

--- a/docs/codebase/spec-ingestion.md
+++ b/docs/codebase/spec-ingestion.md
@@ -730,27 +730,36 @@ G0.18-T8 / #1361, RDC #789 N8). Three branches:
   sources the spec URI.
 * **Catalog miss** — verb points at `meho connector ingest --product
   <p> --version <v> --impl <i> --spec <upstream-openapi-uri>` where
-  `<p>` is the **parser-derived** (dispatch) product, not the registry
-  product. Rationale calls out the missing catalog entry so the operator
-  knows they need to source the OpenAPI spec themselves. Manual
-  mode is the same path G0.7-T5 already supports for one-off /
-  not-yet-curated specs (see `ingest.go`'s mode dispatch). Emitting the
-  registry product here was the claude-rdc-hetzner-dc#1136 false-success
-  (see "Product-slug reconciliation" below): the verb said
-  `--product vcf-logs` while the row it decorated advertised
-  `product="vrli"`, so the verb did not round-trip to a dispatchable
-  ingest.
+  `<p>` is the **registry** product (the spelling the connector class
+  registers under, e.g. `vcf-logs`), not the parser-derived short one.
+  Rationale calls out the missing catalog entry so the operator knows
+  they need to source the OpenAPI spec themselves. Manual mode is the
+  same path G0.7-T5 already supports for one-off / not-yet-curated specs
+  (see `ingest.go`'s mode dispatch). The registry product is the right
+  spelling because the ingest write path keys two safety steps on the
+  supplied `--product` — `check_version_covered_by_registered_class`
+  (the version-coverage pre-flight) and `ensure_connector_class_registered`
+  — so the registry product is what lets them find the real
+  `VcfLogsConnector`; the short `vrli` would miss it, synthesise a
+  redundant `AutoShim_vrli_*`, and make the coverage pre-flight vacuous.
+  Register-time row reconciliation then persists the rows under the
+  dispatch product regardless (see "Product-slug reconciliation" below),
+  so the verb still round-trips to a dispatchable ingest. (Emitting the
+  registry product while the row advertised `product="vrli"` *was* the
+  claude-rdc-hetzner-dc#1136 false-success **before** that reconciliation
+  existed — the reconciliation is what closes it, not switching the verb
+  to the short product.)
 
 The **catalog lookup** uses the **registry's** `(product, version)`,
 not the parser-derived shortening. The SDDC case is canonical: the
 catalog stores `product="sddc-manager"`, the listing emits
 `product="sddc"`, but the hint says `--catalog sddc-manager/9.0`
 because that is what `meho connector ingest --catalog ...` resolves
-against. Looking up the parsed product would always miss for SDDC. The
-catalog-hit branches keep the catalog-native `--product` (an operator
-running `--catalog` or copying the catalog's triple matches the
-registered class); the catalog-miss branch emits the parser-derived
-product so the manual-mode verb round-trips dispatchably.
+against. Looking up the parsed product would always miss for SDDC. Both
+the catalog-hit and catalog-miss branches emit a registry-side
+`--product` (the catalog-native triple, or the registry product) so the
+operator's ingest matches the registered class; register-time row
+reconciliation is what keeps the resulting connector dispatchable.
 
 #### Product-slug reconciliation (claude-rdc-hetzner-dc#1136)
 
@@ -791,14 +800,22 @@ coverage:
 
 A background pipeline coroutine that returns without raising is **not**
 sufficient evidence the ingest succeeded: it can persist rows under a
-mis-keyed product (above) or skip every op against a prior run, leaving
-nothing dispatchable. `run_ingest_job` (`ingest/jobs.py`) therefore
-applies a postcondition before flipping the job to `succeeded`:
-`inserted_count > 0` **and** a `dispatchability_check` closure (the
-route's `connector_exists` probe under the parser-derived natural key,
-scoped to the originating tenant) returns `True`. When it fails the job
-ends `degraded` carrying `error_class="ingested_not_dispatchable"` and
-the counts that landed — never a bare `succeeded`. Regression coverage:
+mis-keyed product (above), leaving nothing dispatchable. `run_ingest_job`
+(`ingest/jobs.py`) therefore consults a `dispatchability_check` closure
+(the route's `connector_exists` probe under the parser-derived natural
+key, scoped to the originating tenant) before flipping the job to
+`succeeded`. The job ends `degraded` carrying
+`error_class="ingested_not_dispatchable"` and the counts that landed
+when the run is genuinely non-dispatchable — either `inserted_count == 0`
+on a connector the probe cannot resolve (an empty/first-run spec), or
+`inserted_count > 0` yet the probe returns `False` (the mis-keyed-product
+case). Crucially, the zero-insert branch is **not** unconditional: a
+benign idempotent re-run skips every op (`_upsert.upsert_one_operation`
+returns `"skipped"`, so `inserted_count == 0`) on an already-dispatchable
+connector, and the probe keeps that `succeeded` rather than flipping a
+no-op re-run into a non-zero CLI failure. A probe that *raises* fails
+open to `succeeded` (a transient DB blip must not strand or degrade a
+completed pipeline). Regression coverage:
 `tests/test_operations_ingest_jobs.py`.
 
 If `load_catalog()` raises `CatalogError` at listing time (only


### PR DESCRIPTION
## Summary

Closes the v0.13.0 vcf-logs log-sentry false-success (consumer signal claude-rdc-hetzner-dc#1136), two tangled defects in one PR:

- **(A) Status honesty.** An async `--spec` ingest used to flip the job to `succeeded` purely because the pipeline coroutine returned without raising — even when nothing dispatchable landed. `run_ingest_job` now applies a postcondition (`inserted_count > 0` **and** the connector resolves under its dispatch key) and ends the job `degraded` with `error_class="ingested_not_dispatchable"` when it fails. New `degraded` job status surfaces on the REST/MCP poll response; the CLI renders it as a non-zero failure. The probe fails open (logs, stays `succeeded`) on a transient probe error so a DB blip never strands the job.
- **(B) Product-slug reconciliation.** Ingesting under a VCF-family **long** product (`--product vcf-logs`) persisted `endpoint_descriptor` rows the dispatch/query surface never queried — it keys on the **short** product `parse_connector_id` derives from the connector_id (`vrli`), so the catalog reported `registered, 0 ops` and `search_operations` returned `connector_not_ingested`. Ingest now reconciles the row product to the dispatch-canonical spelling at register-time (`_reconciled_row_product` → `dispatch_product`), and the grouping pass keys on the same spelling. All six long↔short splits are reconciled (`hetzner-robot/hetzner`, `sddc-manager/sddc`, `vcf-automation/vcfa`, `vcf-fleet/fleet`, `vcf-logs/vrli`, `vcf-operations/vrops`); a no-op for aligned connectors. A registered-but-unpopulated row's `next_step.verb` now emits the parser-derived `--product` so it round-trips to a dispatchable ingest.

The version-coverage pre-flight + auto-shim registration deliberately stay on the **supplied** (registry) product so the coverage check finds the real `VcfLogsConnector` class and no redundant shim is synthesised — only the persisted rows are reconciled.

## Test plan

- [x] `ruff check` + `ruff format --check` — clean
- [x] `mypy src/` — clean (467 files)
- [x] `code-quality.py --diff` — 0 blockers (extracted `_preflight_and_register_class` + `_reconciled_row_product` to stay under the function-size limit)
- [x] **AC1** dispatchable ingest under the verb's `--product` + 5 (6) splits reconciled — `test_ingest_under_registry_product_persists_dispatchable_rows` (parametrised over every split); `test_aligned_product_ingest_is_unchanged`
- [x] **AC2** non-dispatchable run → `degraded` + structured `error_class` — `test_operations_ingest_jobs.py` (zero-insert, persisted-but-invisible, raising-still-fails, probe-fails-open, no-probe-opt-out)
- [x] **AC3** `next_step.verb` round-trips to a dispatchable ingest — `test_registered_next_step_verb_round_trips_to_dispatchable_ingest`
- [x] OpenAPI snapshot + Go CLI client regenerated (`degraded` added to `IngestJobStatusResponse.status` / `IngestJobHandle.status` enums); CLI `go build` + connector pkg tests pass
- [x] `docs/codebase/spec-ingestion.md` updated (Product-slug reconciliation + Dispatchability postcondition sections)
- [x] CHANGELOG `[Unreleased]` → `### Fixed` bullet citing claude-rdc-hetzner-dc#1136

## Out of scope

- The spec/label compat opt-in (T1 #1646) — landed; this builds on it.
- Reworking `parse_connector_id`'s hyphen-split contract tree-wide — scoped to product reconciliation for dispatchability.
- Per-product catalog entries for the VCF family — separate cataloguing work. The target-create-validator drift (`_KNOWN_LISTING_PRODUCT_DRIFT` / `PRODUCT_ALIASES`) is a distinct axis and intentionally untouched.

<!-- auto-implement-issue: fresh, iteration 1 -->

Closes #1647


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Async ingest jobs that produce no dispatchable results now finish as "degraded" (with error_class and error) instead of falsely succeeding; this status is surfaced via polling and JSON CLI output.
  * CLI `connector ingest` exits non-zero for degraded jobs.

* **Documentation**
  * Clarified async ingest polling semantics and product-slug reconciliation for VCF-family/manual `--spec` ingests.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->