### PR TITLE
fix(ci): pre-seed fastembed cache so helm-test build stops 429-flaking on HuggingFace

### DIFF
--- a/.github/workflows/chart.yml
+++ b/.github/workflows/chart.yml
@@ -366,6 +366,46 @@ jobs:
         # two lanes converge on a single buildx version.
         uses: docker/setup-buildx-action@d7f5e7f509e45cec5c76c4d5afdd7de93d0b3df5  # v4.1.0
 
+      - name: Restore fastembed model cache (#1623)
+        # Restore-only: the unit lane (ci.yml "Cache fastembed model") owns the
+        # SAVE on every main push, so this lane reuses its entry and never has
+        # to populate it. SAME key + restore-keys as ci.yml so the entries line
+        # up; GitHub's cache scoping lets a PR/main run restore main-created
+        # entries, so this is effectively never cold. A miss (bumped uv.lock
+        # hash with no restore-key hit, or a fresh repo) leaves the dir absent
+        # and the cold path below kicks in -- the build downloads once, as today.
+        uses: actions/cache/restore@27d5ce7f107fe9357f9df03efb73ab90386fccae  # v5.0.5
+        with:
+          path: ${{ github.workspace }}/.fastembed-cache
+          key: fastembed-model-${{ runner.os }}-${{ hashFiles('backend/uv.lock') }}
+          restore-keys: |
+            fastembed-model-${{ runner.os }}-
+
+      - name: Pre-seed fastembed snapshot into the build context (#1623)
+        # Stage the restored snapshot into backend/.model-preseed/ so the
+        # Dockerfile's `COPY .model-preseed/ /opt/meho/model-cache/` lands it
+        # ahead of the warm RUN. fastembed probes the cache_dir local-first
+        # (snapshot_download local_files_only=True), so a present snapshot ->
+        # ZERO HuggingFace requests during the bake. The unit lane caches the
+        # fastembed cache_dir root (`.fastembed-cache`), whose layout
+        # (`models--<org>--<repo>/...` HF snapshot) is identical to the bake's
+        # cache_dir -- they run the same `meho_backplane.retrieval.warm`
+        # module -- so the tree copies in verbatim. On a cache miss the dir
+        # stays empty (only the tracked `.gitkeep`) and the warm RUN downloads
+        # once (cold path). `cp -a` preserves the HF blob<->snapshot symlinks
+        # fastembed relies on. The COPY in the Dockerfile keeps working either
+        # way (it always has at least `.gitkeep`).
+        run: |
+          if [ -d "${{ github.workspace }}/.fastembed-cache" ] \
+             && [ -n "$(ls -A "${{ github.workspace }}/.fastembed-cache" 2>/dev/null)" ]; then
+            echo ">> fastembed cache restored; staging into backend/.model-preseed/"
+            cp -a "${{ github.workspace }}/.fastembed-cache/." backend/.model-preseed/
+            echo ">> staged contents:"
+            ls -la backend/.model-preseed/
+          else
+            echo ">> fastembed cache MISS (cold path); warm RUN will download once"
+          fi
+
       - name: Build backplane image locally (load into Docker, not push)
         # ``load: true`` (= ``--output=type=docker``) leaves the image
         # in the local Docker daemon so the next step can ``kind load``

--- a/.gitignore
+++ b/.gitignore
@@ -50,6 +50,15 @@ htmlcov/
 .venv/
 venv/
 
+# fastembed model snapshot pre-seeded into the backend Docker build context by
+# the chart.yml ``helm-test`` lane (restored from the unit lane's actions/cache
+# entry) so the model-bake layer skips the HuggingFace download (#1623). Only
+# the ``.gitkeep`` sentinel is tracked — it keeps the directory present for a
+# cold/local ``docker build backend/`` (empty dir -> fastembed downloads as
+# before); CI writes the restored snapshot here and the Dockerfile COPYs it in.
+backend/.model-preseed/*
+!backend/.model-preseed/.gitkeep
+
 # =============================================================================
 # JavaScript / Frontend
 # =============================================================================

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -214,6 +214,21 @@ connector-related release-notes line.
 
 ### Fixed
 
+- The chart CI lane's `helm-test` job no longer intermittently fails its local
+  backplane image build on HuggingFace's anonymous per-IP `429 Too Many
+  Requests`. The model-bake layer (`RUN python -m meho_backplane.retrieval.warm`)
+  re-downloaded the default embedding model on effectively every run — the
+  BuildKit layer cache misses because per-build `BUILD_DATE`/`GIT_SHA` args and
+  per-commit venv content invalidate the warm layer — and GitHub-hosted runners
+  share egress IPs, so the anonymous HF quota tripped at random. The job now
+  restores the unit lane's existing fastembed `actions/cache` entry (same key),
+  stages the snapshot into the gitignored `backend/.model-preseed/`, and the
+  Dockerfile `COPY`s it into `/opt/meho/model-cache` ahead of the warm `RUN`;
+  fastembed's local-first probe then finds the snapshot and performs zero
+  HuggingFace requests on a warm build. A cold cache (or a local
+  `docker build backend/` with no pre-seed) downloads exactly once, as before,
+  and the warm step still runs the #574 drift-guard assertion (real embed +
+  `EMBEDDING_DIMENSION` check) in every path (#1623).
 - An async `--spec` ingest no longer false-succeeds when nothing became
   dispatchable, and the `--product` the catalog's `next_step` verb prints
   now round-trips. Two tangled defects: (1) ingesting under a VCF-family

--- a/backend/Dockerfile
+++ b/backend/Dockerfile
@@ -204,10 +204,29 @@ COPY --from=builder --chown=meho:0 /app/.venv /app/.venv
 #     of CrashLooping in production — the exact failure green ci.yml on a
 #     runtime-fetched model cannot catch.
 #
+# Pre-seed the fastembed snapshot from the build context BEFORE the warm RUN
+# (#1623). `.model-preseed/` is tracked as an empty dir (only a `.gitkeep`
+# sentinel) and is populated by the chart.yml ``helm-test`` lane, which
+# restores it from the unit lane's actions/cache entry (same cache key) and
+# stages the `models--qdrant--bge-small-en-v1.5-onnx-q` HF snapshot into it.
+# fastembed's bake (`download_model`) probes the cache_dir local-first
+# (`snapshot_download(..., local_files_only=True)`); a present snapshot is a
+# hit, so the warm RUN below performs ZERO HuggingFace requests on a warm
+# helm-test build — killing the per-IP 429 flake on GitHub-hosted runners even
+# when the BuildKit layer cache misses (per-build BUILD_DATE/GIT_SHA args +
+# per-commit venv content invalidate it). Cold/local `docker build backend/`
+# with no pre-seed: the dir holds only `.gitkeep`, the local probe misses, and
+# the warm RUN downloads exactly once as before. The COPY is a no-op layer in
+# the cold path (sentinel only), so the published image is unchanged. The warm
+# RUN still instantiates the model + runs one real embed (the #574 drift guard)
+# in BOTH paths — pre-seeding never short-circuits that assertion.
+COPY .model-preseed/ /opt/meho/model-cache/
+
 # No uv build-cache mount here: the download must land in the image layer,
 # not in a discarded BuildKit cache. Runs while still root so it can create
 # /opt/meho; chowned to the runtime uid (1001, gid 0) afterwards so the
-# non-root USER below can read it. `chmod -R g=u` keeps it group-readable
+# non-root USER below can read it (including any pre-seeded snapshot files and
+# the `.gitkeep` sentinel COPYed above). `chmod -R g=u` keeps it group-readable
 # for the arbitrary-uid / restricted-PSA case (gid is always 0).
 RUN python -m meho_backplane.retrieval.warm \
  && chown -R 1001:0 /opt/meho \


### PR DESCRIPTION
## Summary
- The chart workflow's `helm-test` job builds the backplane image on `ubuntu-latest`, re-running the model-bake layer (`RUN python -m meho_backplane.retrieval.warm`) on effectively every run — the BuildKit layer cache misses (per-build `BUILD_DATE`/`GIT_SHA` args + per-commit venv content invalidate the warm layer), so it re-downloads the embedding model from HuggingFace anonymously and intermittently dies on HF's per-IP `429`.
- Pre-seed the model into the build context instead of fighting the layer cache: restore the unit lane's existing fastembed `actions/cache` entry (restore-only, same key as `ci.yml`), stage the snapshot into the gitignored `backend/.model-preseed/`, and `COPY` it into `/opt/meho/model-cache` ahead of the warm `RUN`. fastembed's bake probes local-first, so a present snapshot is a hit and the warm `RUN` makes zero HF requests — even when the layer cache misses.
- Cold cache (or local `docker build backend/` with no pre-seed): only the `.gitkeep` sentinel is present, the local probe misses, and the warm `RUN` downloads exactly once as before. The #574 drift guard (real embed + `EMBEDDING_DIMENSION` check) still runs in both paths.

## Test plan
Verified with real `docker build backend/` runs on both paths (full multi-stage build, `--no-cache`):
- [x] **Warm path (AC1, AC5)** — pre-seeded snapshot staged into `.model-preseed/`: warm `RUN` went `[warm] baking` → `[warm] OK ... dim=384` in 0.1s with **zero** `huggingface.co` / `Fetching N files` / `429` / `download_model` retries anywhere in the build log. `dim=384` proves the drift guard executed.
- [x] **Backend-source-only change (AC2)** — the fix removes the model download from the warm `RUN` whenever the snapshot is pre-seeded; the bake no longer depends on the venv-COPY layer digest, so a source-only change can't re-trigger a download on a warm cache.
- [x] **Cold path (AC3)** — `.model-preseed/` reset to `.gitkeep`-only: warm `RUN` shows `Fetching 5 files` (one download), `[warm] OK ... dim=384`, build exits 0.
- [x] **Local build + ownership (AC4)** — both baked images contain the model at `/opt/meho/model-cache` (incl. `model_optimized.onnx`), all files `uid=1001 gid=0`, perms `g=u`, zero ownership violations under `/opt/meho`.
- [x] **Unit lane untouched (AC6)** — `ci.yml` "Cache fastembed model" step (and its drift guard) unchanged; the new step uses `actions/cache/restore` (restore-only) at the same pinned digest, so the unit lane still owns the save.
- [x] **CHANGELOG (AC7)** — one `[Unreleased] > Fixed` bullet added (#1623).
- [x] `pre-commit run` on the changed files — all hygiene + gitleaks hooks pass; `chart.yml` is valid YAML; `code-quality.py --diff` exit 0.

## Out of scope
- Removing `continue-on-error: true` from `helm-test` (#349 — this unblocks its "10 green runs" criterion but doesn't flip the switch).
- image.yml's own per-build warm re-download (multi-arch publish path; succeeds on self-hosted egress) — alternative (b) in the issue covers it if wanted later.
- Re-pinning / switching the embedding model (`DEFAULT_EMBEDDING_MODEL` stays `BAAI/bge-small-en-v1.5`).
- No `docs/codebase/*` change: no existing doc documents the helm-test model-bake mechanics, and the inline Dockerfile/chart.yml comments + the CHANGELOG bullet are the operator-facing record. Docs verified — unchanged.

<!-- auto-implement-issue: fresh, iteration 1 -->

Closes #1623
