### PR TITLE
fix(connectors): key shared connection pools by tenant-unique identity

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -139,6 +139,20 @@ connector-related release-notes line.
   entry, closing the same cross-tenant credential/session bleed in these
   connectors. The shared `HttpConnector._clients` connection pool stays keyed
   on `target.name` (a pooling concern, tracked separately) (#1672).
+- Re-keyed the shared connection pools — `HttpConnector._clients`
+  (every HTTP connector) and `SshConnector._connections` (bind9, pfSense,
+  Holodeck) — on the tenant-unique `(tenant_id, target.id)` tuple
+  (`target_cache_key`) instead of `target.name`, closing the pooling
+  concern deferred in #1642/#1672. Each pooled `httpx.AsyncClient` is
+  host-bound via `base_url` (and each SSH connection is bound to a live
+  host session), so when two tenants legitimately owned same-named targets
+  pointing at different hosts, the name-keyed pool served tenant B's
+  request through tenant A's host-bound client — a cross-tenant request
+  **misroute** and credential leak below the authz layer. The vmware-rest
+  `aclose()` session-revoke path and the NSX cookie-jar invalidation, which
+  reached the pool directly by name, now resolve clients by the same
+  tenant-unique key (the vmware-rest `_session_names` name reverse-map is
+  removed as redundant). Same-tenant pooling behaviour is unchanged (#1682).
 
 ### Breaking changes
 

--- a/backend/src/meho_backplane/connectors/adapters/http.py
+++ b/backend/src/meho_backplane/connectors/adapters/http.py
@@ -14,8 +14,15 @@ carries the retry decorator; non-idempotent callers must bypass it.
 4xx responses represent caller/auth errors that retrying would not fix.
 
 **Client pooling:** Each :class:`HttpConnector` instance owns a dict of
-``httpx.AsyncClient`` keyed by ``target.name``. The client is created lazily
-on first use and reused across all operations against the same target.
+``httpx.AsyncClient`` keyed by the tenant-unique
+:func:`~meho_backplane.connectors._shared.cache_key.target_cache_key`
+(``(tenant_id, id)``). The client is created lazily on first use and reused
+across all operations against the same target. Keying on ``target.name``
+alone would collide two same-named targets in different tenants — target
+names are unique only per ``(tenant_id, name)`` — and since each pooled
+client is host-bound via ``base_url``, the collision would route one
+tenant's request to the other tenant's host and leak credentials across
+the tenant boundary (evoila/meho#1682).
 
 **Cert-bundle support:** httpx honours ``SSL_CERT_FILE`` natively; no extra
 cert logic is needed here beyond not overriding the default ``verify`` flag.
@@ -30,6 +37,7 @@ import httpx
 from tenacity import retry, retry_if_exception, stop_after_attempt, wait_exponential
 
 from meho_backplane.auth.operator import Operator
+from meho_backplane.connectors._shared.cache_key import target_cache_key
 from meho_backplane.connectors.base import Connector
 
 # Forward declaration — replaced with `from meho_backplane.targets import Target`
@@ -56,14 +64,21 @@ class HttpConnector(Connector):
     """
 
     def __init__(self) -> None:
-        self._clients: dict[str, httpx.AsyncClient] = {}
+        # Keyed on the tenant-unique ``(tenant_id, id)`` tuple
+        # (``target_cache_key``), not ``target.name``: each pooled client
+        # is host-bound via ``base_url``, and two tenants may legitimately
+        # own same-named targets pointing at different hosts. Name-keying
+        # would route the second tenant's request to the first tenant's
+        # host and leak credentials across the boundary (evoila/meho#1682).
+        self._clients: dict[tuple[str, str], httpx.AsyncClient] = {}
         self._lock = asyncio.Lock()
 
     async def _http_client(self, target: Target) -> httpx.AsyncClient:
         """Return the per-target pooled client, creating it on first use."""
+        cache_key = target_cache_key(target)
         async with self._lock:
-            if target.name not in self._clients:
-                self._clients[target.name] = httpx.AsyncClient(
+            if cache_key not in self._clients:
+                self._clients[cache_key] = httpx.AsyncClient(
                     base_url=self._base_url(target),
                     timeout=httpx.Timeout(connect=5.0, read=30.0, write=30.0, pool=5.0),
                     # Follow 301/302/307/308. Vendor REST surfaces
@@ -78,7 +93,7 @@ class HttpConnector(Connector):
                     # don't 301 mid-write.
                     follow_redirects=True,
                 )
-            return self._clients[target.name]
+            return self._clients[cache_key]
 
     async def mount_op_path(self, target: Target, path: str, operator: Operator) -> str:
         """Map an ingested-descriptor *path* onto the wire path for *target*.

--- a/backend/src/meho_backplane/connectors/adapters/ssh.py
+++ b/backend/src/meho_backplane/connectors/adapters/ssh.py
@@ -43,6 +43,7 @@ from typing import Any
 import asyncssh
 import structlog
 
+from meho_backplane.connectors._shared.cache_key import target_cache_key
 from meho_backplane.connectors.base import Connector
 from meho_backplane.connectors.schemas import FingerprintResult
 
@@ -78,12 +79,20 @@ class SshConnector(Connector):
     """
 
     def __init__(self) -> None:
-        # Maps target.name → (SSHClientConnection, last_used monotonic timestamp).
-        self._connections: dict[str, tuple[asyncssh.SSHClientConnection, float]] = {}
+        # Maps the tenant-unique ``(tenant_id, id)`` cache key
+        # (``target_cache_key``) → (SSHClientConnection, last_used monotonic
+        # timestamp). Keyed on the tuple rather than ``target.name``: two
+        # tenants may legitimately own same-named targets on different
+        # hosts (names are unique only per ``(tenant_id, name)``), and a
+        # name-keyed pool would hand tenant B the live connection tenant A
+        # opened to A's host — a cross-tenant misroute and credential leak
+        # (evoila/meho#1682).
+        self._connections: dict[tuple[str, str], tuple[asyncssh.SSHClientConnection, float]] = {}
         # Short-lived lock protecting only _connections and _connect_locks dicts.
         self._pool_lock = asyncio.Lock()
-        # Per-target connect locks — SSH handshakes for distinct targets run in parallel.
-        self._connect_locks: dict[str, asyncio.Lock] = {}
+        # Per-target connect locks — SSH handshakes for distinct targets run
+        # in parallel. Keyed on the same tenant-unique tuple as the pool.
+        self._connect_locks: dict[tuple[str, str], asyncio.Lock] = {}
 
     async def _auth_config(self, target: Target) -> dict[str, Any]:
         """Extract auth kwargs from ``target.secret_ref``.
@@ -115,35 +124,36 @@ class SshConnector(Connector):
         and within the idle TTL. Slow path: acquires the per-target connect
         lock, evicts stale/closed entries, and opens a fresh connection.
         """
+        cache_key = target_cache_key(target)
         # Fast path: check without acquiring any lock.
-        entry = self._connections.get(target.name)
+        entry = self._connections.get(cache_key)
         if entry is not None:
             conn, last_used = entry
             now = time.monotonic()
             if not conn.is_closed() and (now - last_used) <= _POOL_TTL_S:
-                self._connections[target.name] = (conn, now)
+                self._connections[cache_key] = (conn, now)
                 return conn
 
         # Get or create the per-target connect lock.
         async with self._pool_lock:
-            if target.name not in self._connect_locks:
-                self._connect_locks[target.name] = asyncio.Lock()
-            t_lock = self._connect_locks[target.name]
+            if cache_key not in self._connect_locks:
+                self._connect_locks[cache_key] = asyncio.Lock()
+            t_lock = self._connect_locks[cache_key]
 
         async with t_lock:
             # Double-check under per-target lock.
             now = time.monotonic()
-            entry = self._connections.get(target.name)
+            entry = self._connections.get(cache_key)
             if entry is not None:
                 conn, last_used = entry
                 if not conn.is_closed() and (now - last_used) <= _POOL_TTL_S:
-                    self._connections[target.name] = (conn, now)
+                    self._connections[cache_key] = (conn, now)
                     return conn
                 # Evict closed or idle-expired entry.
                 if not conn.is_closed():
                     conn.close()
                     await conn.wait_closed()
-                del self._connections[target.name]
+                del self._connections[cache_key]
 
             auth_kwargs = await self._auth_config(target)
             conn = await asyncssh.connect(
@@ -154,7 +164,7 @@ class SshConnector(Connector):
                 password=auth_kwargs.get("password"),
                 known_hosts=None,
             )
-            self._connections[target.name] = (conn, time.monotonic())
+            self._connections[cache_key] = (conn, time.monotonic())
             logger.info("ssh_connected", target=target.name, host=target.host)
             return conn
 

--- a/backend/src/meho_backplane/connectors/nsx/connector.py
+++ b/backend/src/meho_backplane/connectors/nsx/connector.py
@@ -329,11 +329,14 @@ class NsxConnector(HttpConnector):
         Holds the lock so a concurrent re-establish doesn't race with
         the invalidation.
         """
+        cache_key = target_cache_key(target)
         async with self._session_lock:
-            self._session_tokens.pop(target_cache_key(target), None)
-            # ``_clients`` (the shared HttpConnector pool) is keyed on
-            # ``target.name``; only the session-token cache is tenant-keyed.
-            client = self._clients.get(target.name)
+            self._session_tokens.pop(cache_key, None)
+            # The shared ``HttpConnector._clients`` pool is keyed on the
+            # same tenant-unique ``(tenant_id, id)`` tuple as the
+            # session-token cache (evoila/meho#1682), so the cookie jar we
+            # clear here belongs to exactly this tenant's host-bound client.
+            client = self._clients.get(cache_key)
             if client is not None:
                 client.cookies.clear()
 

--- a/backend/src/meho_backplane/connectors/vmware_rest/connector.py
+++ b/backend/src/meho_backplane/connectors/vmware_rest/connector.py
@@ -259,11 +259,6 @@ class VmwareRestConnector(HttpConnector):
         # for the rationale and source citations. Keyed on the same
         # tenant-unique tuple as ``_session_tokens``.
         self._session_paths: dict[tuple[str, str], str] = {}
-        # Maps each tenant-unique cache key back to its ``target.name`` so
-        # :meth:`aclose` can locate the per-target client in the shared
-        # ``HttpConnector._clients`` pool (which is keyed on ``target.name``
-        # and is explicitly out of scope for the #1672 re-keying).
-        self._session_names: dict[tuple[str, str], str] = {}
         self._session_lock = asyncio.Lock()
         self._session_loader: VsphereSessionLoader = (
             session_loader if session_loader is not None else load_session_credentials_from_vault
@@ -396,9 +391,11 @@ class VmwareRestConnector(HttpConnector):
         Called by :meth:`_session_token` under ``self._session_lock`` on a
         cold cache. Resolves credentials via the loader, POSTs to the modern
         session endpoint (falling back to the legacy path on a 404 only),
-        and records the token, the endpoint that minted it, and the target's
-        ``name`` (so :meth:`aclose` can find the per-target client in the
-        ``target.name``-keyed pool) against the tenant-unique *cache_key*.
+        and records the token and the endpoint that minted it against the
+        tenant-unique *cache_key* — the same key the shared
+        ``HttpConnector._clients`` pool now uses (evoila/meho#1682), so
+        :meth:`aclose` can locate the per-target client directly by
+        *cache_key* without a name reverse-map.
         """
         creds = await self._session_loader(target, operator)
         client = await self._http_client(target)
@@ -442,7 +439,6 @@ class VmwareRestConnector(HttpConnector):
         token = _extract_session_token(resp.json(), target.name)
         self._session_tokens[cache_key] = token
         self._session_paths[cache_key] = established_path
-        self._session_names[cache_key] = target.name
         _log.info(
             "vsphere_session_established",
             target=target.name,
@@ -620,18 +616,15 @@ class VmwareRestConnector(HttpConnector):
         async with self._session_lock:
             tokens = dict(self._session_tokens)
             paths = dict(self._session_paths)
-            names = dict(self._session_names)
             self._session_tokens.clear()
             self._session_paths.clear()
-            self._session_names.clear()
         for cache_key, token in tokens.items():
-            # ``_session_tokens`` is keyed on the tenant-unique
-            # ``(tenant_id, target.id)`` tuple (#1672), but the shared
-            # ``HttpConnector._clients`` pool is keyed on ``target.name``
-            # (explicitly out of scope). ``_session_names`` maps each
-            # cache key back to its name so we can locate the client.
-            target_name = names.get(cache_key)
-            client = self._clients.get(target_name) if target_name is not None else None
+            # ``_session_tokens`` and the shared ``HttpConnector._clients``
+            # pool are now keyed on the same tenant-unique
+            # ``(tenant_id, target.id)`` tuple (evoila/meho#1682), so the
+            # cached token's key indexes its host-bound client directly —
+            # no name reverse-map needed.
+            client = self._clients.get(cache_key)
             if client is None:
                 # Theoretically unreachable — every cached token was
                 # established against a per-target client that was
@@ -654,14 +647,14 @@ class VmwareRestConnector(HttpConnector):
                 if resp.status_code >= 400:
                     _log.warning(
                         "vsphere_session_revoke_non_2xx",
-                        target=target_name,
+                        target=cache_key,
                         status_code=resp.status_code,
                         session_path=revoke_path,
                     )
             except (httpx.HTTPError, OSError) as exc:
                 _log.warning(
                     "vsphere_session_revoke_failed",
-                    target=target_name,
+                    target=cache_key,
                     error=f"{type(exc).__name__}: {exc}",
                     session_path=revoke_path,
                 )

--- a/backend/tests/integration/test_connectors_bind9_container.py
+++ b/backend/tests/integration/test_connectors_bind9_container.py
@@ -77,6 +77,17 @@ class _Bind9Target:
     host: str
     port: int | None
     secret_ref: dict[str, Any]
+    # The SSH connection pool keys on ``target_cache_key`` (``(tenant_id,
+    # id)``); a double missing either field raises ``AttributeError`` the
+    # moment it reaches the pool. This testcontainers lane is the only one
+    # that exercises the real SSH pool, so the missing fields surface only
+    # here (the #1642 lesson — evoila/meho#1682).
+    id: str = ""
+    tenant_id: str = "00000000-0000-0000-0000-000000000000"
+
+    def __post_init__(self) -> None:
+        if not self.id:
+            self.id = f"id-{self.name}"
 
 
 # ---------------------------------------------------------------------------

--- a/backend/tests/integration/test_g3_4_bind9_e2e.py
+++ b/backend/tests/integration/test_g3_4_bind9_e2e.py
@@ -179,6 +179,10 @@ class _Bind9Target:
 
     def __post_init__(self) -> None:
         self.id: UUID = uuid4()
+        # The SSH connection pool keys on ``target_cache_key`` (``(tenant_id,
+        # id)``); without ``tenant_id`` the real SSH pool raises
+        # ``AttributeError`` in this testcontainers lane (evoila/meho#1682).
+        self.tenant_id: UUID = UUID(int=0)
         self.preferred_impl_id: str | None = None
 
         class _FP:

--- a/backend/tests/test_connectors_holodeck_auth.py
+++ b/backend/tests/test_connectors_holodeck_auth.py
@@ -88,6 +88,16 @@ class _StubTarget:
     host: str
     port: int | None
     secret_ref: dict[str, Any]
+    # The SSH connection pool keys on ``target_cache_key`` (``(tenant_id,
+    # id)``); a double missing either field hits ``AttributeError`` at the
+    # pool (evoila/meho#1682). ``id`` defaults off ``name`` so distinct
+    # targets in one tenant land on distinct pool keys.
+    id: str = ""
+    tenant_id: str = "00000000-0000-0000-0000-000000000000"
+
+    def __post_init__(self) -> None:
+        if not self.id:
+            self.id = f"id-{self.name}"
 
 
 # Canary credentials the secret-leak assertions key on. The fake
@@ -274,15 +284,17 @@ async def test_per_target_connection_isolation() -> None:
     conn_a.is_closed.return_value = False
     conn_b = MagicMock(name="conn-B")
     conn_b.is_closed.return_value = False
+    target_a = _password_target("holorouter-a")
+    target_b = _password_target("holorouter-b")
     with patch("asyncssh.connect", new=AsyncMock(side_effect=[conn_a, conn_b])):
-        a = await connector._connect(_password_target("holorouter-a"), raw_jwt="")
-        b = await connector._connect(_password_target("holorouter-b"), raw_jwt="")
+        a = await connector._connect(target_a, raw_jwt="")
+        b = await connector._connect(target_b, raw_jwt="")
     assert a is conn_a
     assert b is conn_b
     assert a is not b
-    # Pool keyed by target.name; both entries present.
-    assert "holorouter-a" in connector._connections
-    assert "holorouter-b" in connector._connections
+    # Pool keyed by the tenant-unique ``(tenant_id, id)`` tuple; both present.
+    assert (target_a.tenant_id, target_a.id) in connector._connections
+    assert (target_b.tenant_id, target_b.id) in connector._connections
 
 
 # ---------------------------------------------------------------------------

--- a/backend/tests/test_connectors_http_adapter.py
+++ b/backend/tests/test_connectors_http_adapter.py
@@ -15,8 +15,11 @@ Coverage matrix (per Task #242 acceptance criteria):
   :exc:`httpx.HTTPStatusError`.
 * 4xx response (e.g. 404) does NOT retry — exactly 1 call, then re-raise.
 * :exc:`httpx.ConnectError` retries exactly 3 times (4 total calls).
-* Per-target client pool: same ``target.name`` reuses the same
-  :class:`httpx.AsyncClient`; different names get distinct clients.
+* Per-target client pool: the same target reuses the same
+  :class:`httpx.AsyncClient`; distinct targets get distinct clients.
+* Cross-tenant isolation (evoila/meho#1682): two same-named targets in
+  different tenants with different hosts get distinct host-bound clients,
+  and a dispatch for one tenant never reaches the other tenant's host.
 * ``aclose()`` closes all pooled clients and empties the pool dict.
 """
 
@@ -58,11 +61,28 @@ def _make_operator(raw_jwt: str = "") -> Operator:
 
 
 def _make_target(
-    name: str = "test-target", host: str = "vcenter.example.com", port: int = 443
+    name: str = "test-target",
+    host: str = "vcenter.example.com",
+    port: int = 443,
+    *,
+    target_id: str = "11111111-1111-1111-1111-111111111111",
+    tenant_id: str = "00000000-0000-0000-0000-000000000000",
 ) -> Any:
-    """Return a minimal duck-typed Target stub."""
-    t = types.SimpleNamespace(name=name, host=host, port=port, auth_model="impersonation")
-    return t
+    """Return a minimal duck-typed Target stub.
+
+    Carries ``id`` and ``tenant_id`` because the pooled-client cache is
+    keyed on ``target_cache_key`` (``(tenant_id, id)``); a double missing
+    either field raises ``AttributeError`` the moment it reaches the pool
+    (evoila/meho#1682).
+    """
+    return types.SimpleNamespace(
+        name=name,
+        host=host,
+        port=port,
+        id=target_id,
+        tenant_id=tenant_id,
+        auth_model="impersonation",
+    )
 
 
 class _ConcreteHttpConnector(HttpConnector):
@@ -292,17 +312,61 @@ async def test_same_target_reuses_client() -> None:
 
 @pytest.mark.asyncio
 async def test_different_targets_get_different_clients() -> None:
-    """Each distinct target.name gets its own httpx.AsyncClient."""
+    """Each distinct target gets its own httpx.AsyncClient."""
     conn = _ConcreteHttpConnector()
-    target_a = _make_target(name="vc-01", host="vc01.example.com")
-    target_b = _make_target(name="vc-02", host="vc02.example.com")
+    target_a = _make_target(name="vc-01", host="vc01.example.com", target_id="aaaa")
+    target_b = _make_target(name="vc-02", host="vc02.example.com", target_id="bbbb")
 
     client_a = await conn._http_client(target_a)
     client_b = await conn._http_client(target_b)
 
     assert client_a is not client_b
-    assert "vc-01" in conn._clients
-    assert "vc-02" in conn._clients
+    # Pool is keyed on the tenant-unique ``(tenant_id, id)`` tuple.
+    assert (target_a.tenant_id, target_a.id) in conn._clients
+    assert (target_b.tenant_id, target_b.id) in conn._clients
+    await conn.aclose()
+
+
+@pytest.mark.asyncio
+async def test_same_name_different_tenant_get_distinct_host_bound_clients() -> None:
+    """Cross-tenant misrouting regression (evoila/meho#1682).
+
+    Two targets both named ``prod-vcenter`` but owned by different
+    tenants and pointing at different hosts must get *distinct* pooled
+    clients, and a dispatch issued for tenant B must reach B's host —
+    never tenant A's host-bound client. We assert on the resolved
+    ``base_url`` of each pooled client (the host the request would be
+    routed to), not merely dict identity, because the bug is a wrong
+    *route*, not a shared object per se.
+    """
+    conn = _ConcreteHttpConnector()
+    target_a = _make_target(
+        name="prod-vcenter",
+        host="vc-tenant-a.example.com",
+        target_id="a-id",
+        tenant_id="tenant-a",
+    )
+    target_b = _make_target(
+        name="prod-vcenter",
+        host="vc-tenant-b.example.com",
+        target_id="b-id",
+        tenant_id="tenant-b",
+    )
+
+    # Tenant A dispatches first — first-writer-wins would have bound the
+    # name-keyed pool to A's host.
+    client_a = await conn._http_client(target_a)
+    # Tenant B's dispatch against its *own* same-named target.
+    client_b = await conn._http_client(target_b)
+
+    assert client_a is not client_b
+    # The load-bearing assertion: B's client routes to B's host, A's to
+    # A's host. Under the old name-keyed pool, client_b would be
+    # client_a and this would resolve to vc-tenant-a.example.com.
+    assert str(client_a.base_url) == "https://vc-tenant-a.example.com"
+    assert str(client_b.base_url) == "https://vc-tenant-b.example.com"
+    # Re-fetching B's client returns B's, not A's (no first-writer bleed).
+    assert await conn._http_client(target_b) is client_b
     await conn.aclose()
 
 
@@ -316,8 +380,8 @@ async def test_aclose_closes_all_clients_and_empties_pool() -> None:
     """aclose() calls .aclose() on every pooled client and clears the dict."""
     conn = _ConcreteHttpConnector()
 
-    target_a = _make_target(name="t-a", host="a.example.com")
-    target_b = _make_target(name="t-b", host="b.example.com")
+    target_a = _make_target(name="t-a", host="a.example.com", target_id="id-a")
+    target_b = _make_target(name="t-b", host="b.example.com", target_id="id-b")
 
     client_a = await conn._http_client(target_a)
     client_b = await conn._http_client(target_b)

--- a/backend/tests/test_connectors_pfsense_auth.py
+++ b/backend/tests/test_connectors_pfsense_auth.py
@@ -83,6 +83,16 @@ class _StubTarget:
     host: str
     port: int | None
     secret_ref: dict[str, Any]
+    # The SSH connection pool keys on ``target_cache_key`` (``(tenant_id,
+    # id)``); a double missing either field hits ``AttributeError`` at the
+    # pool (evoila/meho#1682). ``id`` defaults off ``name`` so distinct
+    # targets in one tenant land on distinct pool keys.
+    id: str = ""
+    tenant_id: str = "00000000-0000-0000-0000-000000000000"
+
+    def __post_init__(self) -> None:
+        if not self.id:
+            self.id = f"id-{self.name}"
 
 
 _KEY_TARGET = _StubTarget(
@@ -586,7 +596,7 @@ async def test_execute_about_unreachable_returns_connector_error_not_ok() -> Non
 
 
 async def test_per_target_connection_isolation() -> None:
-    """Distinct targets get distinct connections -- pool is keyed by target.name."""
+    """Distinct targets get distinct connections -- pool keyed by ``(tenant_id, id)``."""
     private_key = asyncssh.generate_private_key("ssh-ed25519")
     pem = private_key.export_private_key().decode()
 

--- a/backend/tests/test_connectors_ssh_adapter.py
+++ b/backend/tests/test_connectors_ssh_adapter.py
@@ -121,11 +121,20 @@ def _password_target(
     host: str = "127.0.0.1",
     port: int = 22,
     username: str = "test",
+    target_id: str | None = None,
+    tenant_id: str = "00000000-0000-0000-0000-000000000000",
 ) -> Any:
+    # Carries ``id`` and ``tenant_id`` because the connection pool keys on
+    # ``target_cache_key`` (``(tenant_id, id)``); a double missing either
+    # field hits ``AttributeError`` at the pool (evoila/meho#1682). Derive
+    # a distinct ``id`` from ``name`` so distinct-name targets in the same
+    # tenant land on distinct pool keys by default.
     return types.SimpleNamespace(
         name=name,
         host=host,
         port=port,
+        id=target_id if target_id is not None else f"id-{name}",
+        tenant_id=tenant_id,
         secret_ref={"username": username, "password": _PASSWORD},
     )
 
@@ -136,12 +145,16 @@ def _key_target(
     host: str = "127.0.0.1",
     port: int = 22,
     username: str = "test",
+    target_id: str | None = None,
+    tenant_id: str = "00000000-0000-0000-0000-000000000000",
 ) -> Any:
     private_key_pem = _CLIENT_KEY.export_private_key("pkcs8-pem").decode()
     return types.SimpleNamespace(
         name=name,
         host=host,
         port=port,
+        id=target_id if target_id is not None else f"id-{name}",
+        tenant_id=tenant_id,
         secret_ref={"username": username, "ssh_private_key": private_key_pem},
     )
 
@@ -257,7 +270,7 @@ async def test_same_target_reuses_connection(ssh_server: Any) -> None:
 
 @pytest.mark.asyncio
 async def test_different_targets_get_different_connections(ssh_server: Any) -> None:
-    """Each distinct target.name gets its own SSHClientConnection."""
+    """Each distinct target gets its own SSHClientConnection."""
     conn = _ConcreteSshConnector()
     target_a = _password_target(name="srv-a", host=ssh_server.host, port=ssh_server.port)
     target_b = _password_target(name="srv-b", host=ssh_server.host, port=ssh_server.port)
@@ -266,8 +279,38 @@ async def test_different_targets_get_different_connections(ssh_server: Any) -> N
     ssh_b = await conn._connect(target_b, "jwt")
 
     assert ssh_a is not ssh_b
-    assert "srv-a" in conn._connections
-    assert "srv-b" in conn._connections
+    # Pool is keyed on the tenant-unique ``(tenant_id, id)`` tuple.
+    assert (target_a.tenant_id, target_a.id) in conn._connections
+    assert (target_b.tenant_id, target_b.id) in conn._connections
+    await conn.aclose()
+
+
+@pytest.mark.asyncio
+async def test_same_name_different_tenant_get_distinct_connections(ssh_server: Any) -> None:
+    """Cross-tenant misrouting regression for the SSH pool (evoila/meho#1682).
+
+    Two targets both named ``edge-router`` owned by different tenants
+    must get *distinct* pooled SSH connections — a name-keyed pool would
+    hand tenant B the live connection tenant A opened, routing B's
+    commands onto A's session.
+    """
+    conn = _ConcreteSshConnector()
+    target_a = _password_target(
+        name="edge-router", host=ssh_server.host, port=ssh_server.port, tenant_id="tenant-a"
+    )
+    target_b = _password_target(
+        name="edge-router", host=ssh_server.host, port=ssh_server.port, tenant_id="tenant-b"
+    )
+
+    ssh_a = await conn._connect(target_a, "jwt")
+    ssh_b = await conn._connect(target_b, "jwt")
+
+    assert ssh_a is not ssh_b
+    assert len(conn._connections) == 2
+    assert (target_a.tenant_id, target_a.id) in conn._connections
+    assert (target_b.tenant_id, target_b.id) in conn._connections
+    # Re-fetching B's connection returns B's, not A's (no first-writer bleed).
+    assert await conn._connect(target_b, "jwt") is ssh_b
     await conn.aclose()
 
 
@@ -302,6 +345,8 @@ async def test_connect_failure_raises_at_connect_time() -> None:
         name="bad-host",
         host="unreachable.internal",
         port=22,
+        id="id-bad-host",
+        tenant_id="00000000-0000-0000-0000-000000000000",
         secret_ref={"username": "u", "password": "p"},  # NOSONAR
     )
 
@@ -340,9 +385,11 @@ async def test_run_command_timeout_raises_asyncio_timeout_error() -> None:
         name="timeout-target",
         host="127.0.0.1",
         port=22,
+        id="id-timeout-target",
+        tenant_id="00000000-0000-0000-0000-000000000000",
         secret_ref={"username": "u", "password": "p"},  # NOSONAR
     )
-    conn._connections["timeout-target"] = (mock_conn, time.monotonic())
+    conn._connections[(target.tenant_id, target.id)] = (mock_conn, time.monotonic())
 
     with pytest.raises(asyncio.TimeoutError):
         await conn._run_command(target, "sleep 60", raw_jwt="jwt", timeout=0.05)
@@ -481,7 +528,10 @@ async def test_idle_ttl_evicts_stale_connection(ssh_server: Any) -> None:
     ssh_first = await conn._connect(target, "jwt")
 
     # Backdate last_used to simulate idle expiry.
-    conn._connections["ttl-test"] = (ssh_first, time.monotonic() - _POOL_TTL_S - 1.0)
+    conn._connections[(target.tenant_id, target.id)] = (
+        ssh_first,
+        time.monotonic() - _POOL_TTL_S - 1.0,
+    )
 
     ssh_second = await conn._connect(target, "jwt")
 

--- a/backend/tests/test_connectors_vmware_rest_auth.py
+++ b/backend/tests/test_connectors_vmware_rest_auth.py
@@ -265,7 +265,6 @@ def _patch_no_revoke_aclose(connector: VmwareRestConnector) -> None:
     async def _aclose() -> None:
         connector._session_tokens.clear()
         connector._session_paths.clear()
-        connector._session_names.clear()
         for client in connector._clients.values():
             await client.aclose()
         connector._clients.clear()

--- a/backend/tests/test_connectors_vmware_rest_fingerprint.py
+++ b/backend/tests/test_connectors_vmware_rest_fingerprint.py
@@ -77,7 +77,6 @@ def _make_connector() -> VmwareRestConnector:
 def _patch_no_revoke_aclose(connector: VmwareRestConnector) -> None:
     async def _aclose() -> None:
         connector._session_tokens.clear()
-        connector._session_names.clear()
         for client in connector._clients.values():
             await client.aclose()
         connector._clients.clear()

--- a/backend/tests/test_operations_connector_unsupported.py
+++ b/backend/tests/test_operations_connector_unsupported.py
@@ -161,6 +161,10 @@ class _FakeTarget:
         self.fingerprint = _FakeFingerprint(version=version)
         self.preferred_impl_id: str | None = None
         self.id: UUID = uuid.uuid4()
+        # The shared HTTP client pool keys on ``target_cache_key``
+        # (``(tenant_id, id)``); without ``tenant_id`` any double that
+        # reaches the pool hits ``AttributeError`` (evoila/meho#1682).
+        self.tenant_id: UUID = UUID("00000000-0000-0000-0000-00000000a0a0")
         self.name = name
         self.host = host
         self.port = port

--- a/backend/tests/test_operations_dispatcher.py
+++ b/backend/tests/test_operations_dispatcher.py
@@ -177,6 +177,7 @@ class _FakeTarget:
         product: str = "test-product",
         version: str | None = None,
         target_id: UUID | None = None,
+        tenant_id: UUID | None = None,
         name: str = "test-target",
         host: str = "test.example.com",
         port: int = 443,
@@ -186,6 +187,10 @@ class _FakeTarget:
         self.fingerprint = _FakeFingerprint(version=version)
         self.preferred_impl_id: str | None = None
         self.id: UUID = target_id or uuid.uuid4()
+        # The shared HTTP client pool keys on ``target_cache_key``
+        # (``(tenant_id, id)``); without ``tenant_id`` any double that
+        # reaches the pool hits ``AttributeError`` (evoila/meho#1682).
+        self.tenant_id: UUID = tenant_id or UUID("00000000-0000-0000-0000-00000000a0a0")
         self.name = name
         self.host = host
         self.port = port


### PR DESCRIPTION
## Summary

- Re-keys the shared connection pools — `HttpConnector._clients` (every HTTP connector) and `SshConnector._connections` (bind9, pfSense, Holodeck) — on the tenant-unique `target_cache_key(target)` (`(tenant_id, id)`) instead of `target.name`, closing the cross-tenant pooling concern explicitly deferred in #1642/#1672.
- **The bug:** each pooled `httpx.AsyncClient` is host-bound via `base_url` (each SSH connection is bound to a live host session). Target names are unique only per `(tenant_id, name)`, so two tenants can each own a `prod-vcenter` pointing at different hosts. First-writer-wins meant tenant B's request was routed through tenant A's host-bound client — a cross-tenant request **misroute** and credential leak, below the authz layer.
- The two callers that reached the pool directly by name are migrated to the tenant-unique key: NSX `_invalidate_session` (cookie-jar clear) resolves by `cache_key`; vmware-rest `aclose()` indexes `_clients` by the `_session_tokens` cache key directly, and its `_session_names` name reverse-map (added in #1672 for exactly this) is **removed as redundant** now that the pool shares the session-cache key.
- Same-tenant pooling behaviour is unchanged.

## Test plan

- [x] `ruff check` (connectors + tests) — clean
- [x] `ruff format --check` — clean
- [x] `mypy src/meho_backplane/connectors/ --ignore-missing-imports` — 143 files, no issues
- [x] **Misrouting regression (the core of this fix):** new HTTP and SSH adapter tests assert two same-named targets in different tenants with different hosts get **distinct** pooled clients, that tenant B's client routes to B's host (asserting resolved `base_url`, not just dict identity), and that re-fetching B's client never returns A's (no first-writer bleed).
- [x] `aclose()` / drain still closes every pooled client and empties the pool (existing tests, updated for tuple keys).
- [x] Broad connector + operations suite (`-k "connectors or adapters or operations"`) — 3096 passed (vs 3094 on main; the +2 are the new regressions). The only 2 remaining failures are a **pre-existing test-ordering flake** in `test_operations_register_ingested.py` that reproduces identically on clean `origin/main` with the same `-k` selection and passes in isolation — unrelated to this change.
- [x] Targeted `-k` connector selection (http/ssh/vmware_rest/nsx/harbor/argocd/github/keycloak/gcloud/vcf/sddc/hetzner/adapters/holodeck/pfsense/bind9/dispatcher) — 1912 passed, 0 failed.
- [x] **Integration-double sweep (the #1642 lesson):** every `tests/integration/` target double that reaches the HTTP/SSH pool now carries both `id` and `tenant_id`. Found and fixed the two `_Bind9Target` doubles (testcontainers SSH lanes) that lacked the fields — exactly the AttributeError only the testcontainers CI lane catches. Harbor / vcsim / lab-smoke already carried both.
- [x] Code-quality gate (`code-quality.py --diff`) — 0 blockers (warnings are pre-existing legacy file/function sizes; `vmware_rest/connector.py` net shrank).
- [x] No FastAPI route / schema touched → no OpenAPI regen needed (verified nothing under `backend/src/meho_backplane/api/` changed).

## Out of scope

- The credential/session caches themselves (done in #1642/#1672).
- Kubernetes connector pools (`_api_clients`/`_ws_api_clients`) — separate `Connector`, keyed on `secret_ref` (already tenant-safe), not the shared HTTP/SSH base.
- Pre-existing `test_operations_register_ingested.py` ordering flake (reproduces on main).

Closes #1682


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Security**
  * Fixed a vulnerability where connection pools could potentially leak credentials across tenants by implementing tenant-scoped connection isolation for HTTP and SSH connectors. Same-tenant pooling behavior remains unchanged.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->