### PR TITLE
feat(operations): read-only dispatch request preview (method/path/redacted body) (#1683)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -179,6 +179,29 @@ connector-related release-notes line.
 
 ### Added
 
+- A read-only **dispatch request preview** — `POST
+  /api/v1/operations/preview`, the MCP `preview_operation` tool, and the
+  regenerated CLI client — resolves an ingested op + params to the literal
+  would-be HTTP request (`method` + substituted `path` + `query` +
+  **redacted** `body`) and **returns** it instead of dispatching. It makes
+  a write failure self-diagnosable from the inside: an operator who hit a
+  gh-rest write `422` / `403` re-issues the same arguments against
+  `/preview` to read back exactly what would be put on the wire, rather
+  than bisecting payload shapes from the outside — the operation audit
+  persists only a hashed `params_hash`, so the request shape is otherwise
+  unrecoverable. The body is redacted through the **same**
+  connector-boundary pipeline the response path uses (a bearer token in a
+  body value is masked just as in a response), so it is request-time
+  observability, **not** a new persisted-secret surface: nothing is
+  written to the audit row and the `params_hash` privacy choice is
+  untouched. The literal request is resolved through the **same** code
+  path `dispatch_ingested` sends through (path substitution, `mount_op_path`
+  prefix, requestBody unwrap), so the preview can never drift from the real
+  request. `typed` / `composite` ops return `status="unavailable"` (no
+  single literal HTTP request to preview); inspection only — it never sends
+  the request and never re-dispatches a past one (replay is out of scope).
+  The observability counterpart to #1656 (requestBody unwrap) and #1649
+  (structured `403`/`422` shape) (`claude-rdc-hetzner-dc#1138`) (#1683).
 - `Operator` now carries a `platform_admin: bool` flag, parsed from a
   configurable JWT claim (`JWT_PLATFORM_ADMIN_CLAIM_NAME`, default
   `platform_admin`) and defaulting to `False` when the claim is absent or

--- a/backend/src/meho_backplane/api/v1/operations.py
+++ b/backend/src/meho_backplane/api/v1/operations.py
@@ -43,10 +43,12 @@ from meho_backplane.operations.meta_tools import (
     CallOperationBody,
     ConnectorNotIngestedError,
     OperationDescriptor,
+    PreviewOperationBody,
     UnknownConnectorError,
     call_operation,
     describe_descriptor,
     list_operation_groups,
+    preview_operation,
     search_operations,
 )
 
@@ -227,6 +229,37 @@ async def post_call(
     """
     try:
         return await call_operation(operator, body.model_dump())
+    except ValueError as exc:
+        # Missing `target.name` is the only ValueError the meta-tool raises.
+        raise HTTPException(status_code=400, detail=str(exc)) from exc
+
+
+@router.post("/preview")
+async def post_preview(
+    body: PreviewOperationBody,
+    operator: Operator = _require_operator,
+) -> dict[str, Any]:
+    """Resolve an op + params to the literal would-be HTTP request, without sending.
+
+    Delegates to :func:`preview_operation` (#1683). The read-only diagnosis
+    sibling of ``POST /api/v1/operations/call``: it resolves the same op +
+    target + params and returns the literal request
+    (``{method, resolved_path, query, redacted_body}``) for an
+    ``source_kind='ingested'`` op **instead of dispatching it**. Use it to
+    diagnose a write 4xx from the inside -- the audit row persists only a
+    hashed ``params_hash``, so the wire shape is otherwise unrecoverable.
+
+    Returns ``200`` with the structured envelope; operator-input faults
+    (unknown op, invalid params, unresolvable connector) land inside the
+    envelope (``status="error"`` / ``status="unavailable"`` +
+    ``extras.error_code``) rather than as HTTP 4xx, the same contract as
+    ``/call``. The one HTTP-side gate is target resolution: a missing-target
+    name (``{"target": {}}`` without ``"name"``) surfaces as a ``400``. The
+    body is redacted through the same connector-boundary pipeline the
+    response path uses; nothing is written to the audit row.
+    """
+    try:
+        return await preview_operation(operator, body.model_dump())
     except ValueError as exc:
         # Missing `target.name` is the only ValueError the meta-tool raises.
         raise HTTPException(status_code=400, detail=str(exc)) from exc

--- a/backend/src/meho_backplane/mcp/tools/operations.py
+++ b/backend/src/meho_backplane/mcp/tools/operations.py
@@ -61,6 +61,7 @@ from meho_backplane.operations.meta_tools import (
     UnknownConnectorError,
     call_operation,
     list_operation_groups,
+    preview_operation,
     search_operations,
 )
 
@@ -142,6 +143,14 @@ async def _call_operation_handler(
 ) -> dict[str, Any]:
     """Thin shim over :func:`call_operation`."""
     return await call_operation(operator, arguments)
+
+
+async def _preview_operation_handler(
+    operator: Operator,
+    arguments: dict[str, Any],
+) -> dict[str, Any]:
+    """Thin shim over :func:`preview_operation` (#1683)."""
+    return await preview_operation(operator, arguments)
 
 
 # ---------------------------------------------------------------------------
@@ -509,4 +518,128 @@ register_mcp_tool(
         op_class="tool_call",
     ),
     handler=_call_operation_handler,
+)
+
+
+register_mcp_tool(
+    definition=ToolDefinition(
+        name="preview_operation",
+        description=(
+            "Preview an operation WITHOUT running it. Resolves the same "
+            "op + target + params `call_operation` would and returns the "
+            "literal would-be HTTP request -- `method`, `resolved_path` "
+            "(path placeholders substituted + connector mount prefix "
+            "applied), `query`, and a REDACTED `redacted_body` -- instead "
+            "of dispatching. Use this to diagnose a write failure: when a "
+            "`call_operation` write returned a 4xx (e.g. a gh-rest 422 / "
+            "403), re-issue the SAME arguments here to read back exactly "
+            "what would be put on the wire (the operation audit persists "
+            "only a hashed params_hash, so the request shape is otherwise "
+            "unrecoverable). Inspection only -- it never sends the request "
+            "and never re-dispatches a past one. Covers ingested HTTP ops "
+            "(`source_kind='ingested'`); for a typed/composite op it "
+            'returns `status="unavailable"` (no single literal HTTP '
+            "request to preview). Arguments mirror `call_operation`: "
+            "`connector_id` (required), `op_id` (required), `target` "
+            '(optional; bare string `"rdc-vcenter"` or dict '
+            '`{"name": "rdc-vcenter"}`), `params` (operation-specific).'
+        ),
+        inputSchema={
+            "type": "object",
+            "properties": {
+                "connector_id": {"type": "string", "minLength": 1},
+                "op_id": {
+                    "type": "string",
+                    "minLength": 1,
+                    "description": (
+                        "Operation id as returned by `search_operations`. "
+                        'Examples: "POST:/repos/{owner}/{repo}/issues", '
+                        '"GET:/api/vcenter/cluster".'
+                    ),
+                },
+                "target": {
+                    "type": ["string", "object", "null"],
+                    "description": (
+                        "Target reference. Same two shapes as "
+                        '`call_operation`: a bare string `"rdc-vcenter"` '
+                        'or a dict `{"name": "rdc-vcenter"}` (with an '
+                        "optional `fqdn` override). Pass null for ops that "
+                        "do not act on a target. Resolving the target lets "
+                        "the preview reflect the same connector + mount "
+                        "prefix the real dispatch would hit."
+                    ),
+                    "minLength": 1,
+                    "properties": {
+                        "name": {"type": "string", "minLength": 1},
+                        "fqdn": {
+                            "type": "string",
+                            "minLength": 1,
+                            "description": (
+                                "Per-call override for the resolved "
+                                "target's `fqdn` column; threaded into the "
+                                "connector for vhost routing. Dict-shape "
+                                "only."
+                            ),
+                        },
+                    },
+                },
+                "params": {
+                    "type": "object",
+                    "description": (
+                        "Operation-specific parameters. Validated against "
+                        "the operation's parameter_schema before the "
+                        "request is resolved; an invalid shape returns "
+                        '`status="error"` + `extras.validation_errors` '
+                        "(the same shape `call_operation` rejects with)."
+                    ),
+                },
+            },
+            "required": ["connector_id", "op_id"],
+            "additionalProperties": False,
+        },
+        outputSchema={
+            "type": "object",
+            "properties": {
+                "status": {
+                    "type": "string",
+                    "enum": ["ok", "error", "unavailable"],
+                },
+                "op_id": {"type": "string"},
+                "connector_id": {"type": "string"},
+                "source_kind": {"type": "string"},
+                "method": {
+                    "type": "string",
+                    "description": "Resolved HTTP verb (present on status=ok).",
+                },
+                "resolved_path": {
+                    "type": "string",
+                    "description": (
+                        "Fully resolved request path -- placeholders "
+                        "substituted, mount prefix applied (status=ok)."
+                    ),
+                },
+                "query": {
+                    "type": ["object", "null"],
+                    "description": "Query-string params, or null (status=ok).",
+                },
+                "redacted_body": {
+                    "description": (
+                        "The would-be JSON request body after the "
+                        "connector-boundary redaction pipeline; null when "
+                        "the op declares no body (status=ok)."
+                    ),
+                },
+                "error": {"type": ["string", "null"]},
+                "extras": {"type": "object"},
+            },
+            "required": ["status", "op_id", "connector_id"],
+        },
+        required_role=TenantRole.OPERATOR,
+        # A read-only request-shape inspection. No dispatch, no audit row,
+        # no mutation -- ``"read"`` matches the actual op-class (unlike
+        # ``call_operation``'s ``"tool_call"`` envelope, which wraps a
+        # dispatch whose true class lives on the inner DISPATCH row).
+        op_class="read",
+    ),
+    handler=_preview_operation_handler,
 )

--- a/backend/src/meho_backplane/operations/_branches.py
+++ b/backend/src/meho_backplane/operations/_branches.py
@@ -33,6 +33,7 @@ from __future__ import annotations
 import inspect
 import re
 from collections.abc import Awaitable, Callable
+from dataclasses import dataclass
 from typing import Any
 from urllib.parse import quote
 
@@ -41,9 +42,11 @@ from meho_backplane.connectors.base import Connector
 from meho_backplane.db.models import EndpointDescriptor
 
 __all__ = [
+    "IngestedRequest",
     "dispatch_composite",
     "dispatch_ingested",
     "dispatch_typed",
+    "resolve_ingested_request",
 ]
 
 
@@ -146,33 +149,62 @@ def _substitute_path(path_template: str, path_params: dict[str, Any]) -> str:
     return _PATH_VAR_RE.sub(_replace, path_template)
 
 
-async def dispatch_ingested(
+@dataclass(frozen=True)
+class IngestedRequest:
+    """The literal HTTP request an ingested-op dispatch would put on the wire.
+
+    G0.24 follow-up (#1683). The same four artefacts
+    :func:`dispatch_ingested` hands to the connector's HTTP transport,
+    captured as data so they can be *returned* (the read-only dispatch
+    preview) instead of only being sent. The body here is the **raw**
+    unwrapped request body -- redaction is the dispatcher's
+    connector-boundary concern (it owns the policy resolution), so this
+    layer stays free of a redaction import and the preview path runs the
+    raw body through the exact same
+    :func:`~meho_backplane.redaction.middleware.apply_connector_boundary_redaction`
+    pipeline the response path uses.
+
+    Attributes:
+        method: The upper-cased HTTP verb (``GET`` / ``POST`` / ...).
+        path: The fully resolved request path -- ``{var}`` placeholders
+            substituted *and* the connector's ``mount_op_path`` prefix
+            applied, exactly as the wire call receives it.
+        query: The query-string params bucket (``loc=="query"``), or
+            ``None`` when empty -- the same value passed as httpx's
+            ``params=`` on the GET path.
+        body: The raw, unwrapped JSON request body (``loc=="body"``), or
+            ``None`` when the op declares no body param -- the same value
+            passed as httpx's ``json=``.
+    """
+
+    method: str
+    path: str
+    query: dict[str, Any] | None
+    body: Any
+
+
+async def resolve_ingested_request(
     *,
     connector: Connector,
     descriptor: EndpointDescriptor,
     operator: Operator,
     target: Any,
     params: dict[str, Any],
-) -> Any:
-    """Execute an ``source_kind='ingested'`` op via the connector's HTTP transport.
+) -> IngestedRequest:
+    """Resolve an ingested op + params to the literal HTTP request, without sending.
 
-    v0.2 routes through :meth:`HttpConnector._request_json` for idempotent
-    verbs (GET / HEAD / OPTIONS) -- the only verbs the ingest pipeline
-    declares as safe-to-retry. POST / PUT / DELETE / PATCH route through
-    :meth:`HttpConnector._post_json` (the same client pool, no retry).
-    The connector instance MUST be an :class:`HttpConnector` -- the
-    dispatcher type-checks via ``hasattr(connector, "_request_json")``
-    rather than an :func:`isinstance` import to avoid a circular
-    dependency on the adapters package.
+    The single source of truth for "what method / path / query / body
+    does an ``source_kind='ingested'`` dispatch put on the wire" -- shared
+    verbatim by :func:`dispatch_ingested` (which then *sends* it) and the
+    read-only dispatch preview (#1683, which *returns* it). Keeping the
+    resolution in one place means the preview can never drift from the
+    real request: the path substitution, the ``mount_op_path`` prefix
+    application, the requestBody unwrap (#1656) all run identically.
 
-    The v0.2 ingest pipeline (G0.7, not yet shipped) does not exist;
-    consequently no ``source_kind='ingested'`` rows live in the DB
-    today. The branch ships anyway so:
-
-    * G0.7 can land a single ingested descriptor and the dispatcher
-      routes it without code change.
-    * The mock-based test asserting "GET /api/test/{id} -> the right
-      httpx call" can pin the contract before G0.7 lands.
+    Raises the same :class:`RuntimeError` (missing method/path) and
+    :class:`KeyError` (unsubstituted path var) the dispatch path raised
+    inline, so both the execute and the preview surface them through the
+    dispatcher's structured-error mapping unchanged.
     """
     method = (descriptor.method or "").upper()
     path_template = descriptor.path or ""
@@ -194,11 +226,59 @@ async def dispatch_ingested(
     mount_op_path = getattr(connector, "mount_op_path", None)
     if mount_op_path is not None:
         substituted = await mount_op_path(target, substituted, operator)
+    return IngestedRequest(
+        method=method,
+        path=substituted,
+        query=query_params or None,
+        body=_unwrap_body(body_params),
+    )
+
+
+async def dispatch_ingested(
+    *,
+    connector: Connector,
+    descriptor: EndpointDescriptor,
+    operator: Operator,
+    target: Any,
+    params: dict[str, Any],
+) -> Any:
+    """Execute an ``source_kind='ingested'`` op via the connector's HTTP transport.
+
+    v0.2 routes through :meth:`HttpConnector._request_json` for idempotent
+    verbs (GET / HEAD / OPTIONS) -- the only verbs the ingest pipeline
+    declares as safe-to-retry. POST / PUT / DELETE / PATCH route through
+    :meth:`HttpConnector._post_json` (the same client pool, no retry).
+    The connector instance MUST be an :class:`HttpConnector` -- the
+    dispatcher type-checks via ``hasattr(connector, "_request_json")``
+    rather than an :func:`isinstance` import to avoid a circular
+    dependency on the adapters package.
+
+    The literal method / path / query / body are resolved by
+    :func:`resolve_ingested_request` -- the same resolver the read-only
+    dispatch preview (#1683) calls, so the previewed request can never
+    drift from what this branch actually sends.
+
+    The v0.2 ingest pipeline (G0.7, not yet shipped) does not exist;
+    consequently no ``source_kind='ingested'`` rows live in the DB
+    today. The branch ships anyway so:
+
+    * G0.7 can land a single ingested descriptor and the dispatcher
+      routes it without code change.
+    * The mock-based test asserting "GET /api/test/{id} -> the right
+      httpx call" can pin the contract before G0.7 lands.
+    """
+    request = await resolve_ingested_request(
+        connector=connector,
+        descriptor=descriptor,
+        operator=operator,
+        target=target,
+        params=params,
+    )
     # Thread the full Operator (not just operator.raw_jwt) to the HTTP
     # transport: the connector's credential loader resolves the per-target
     # secret under the operator's identity (operator-context Vault read).
     # See docs/architecture/connector-auth.md.
-    if method in ("GET", "HEAD", "OPTIONS"):
+    if request.method in ("GET", "HEAD", "OPTIONS"):
         request_json = getattr(connector, "_request_json", None)
         if request_json is None:
             raise RuntimeError(
@@ -207,11 +287,11 @@ async def dispatch_ingested(
             )
         return await request_json(
             target,
-            method,
-            substituted,
+            request.method,
+            request.path,
             operator=operator,
-            params=query_params or None,
-            json=_unwrap_body(body_params),
+            params=request.query,
+            json=request.body,
         )
     # Non-idempotent verb -- POST / PUT / PATCH / DELETE. v0.2 routes
     # through ``_post_json``-shaped httpx call (no retry). The connector
@@ -224,9 +304,9 @@ async def dispatch_ingested(
         )
     return await post_json(
         target,
-        substituted,
+        request.path,
         operator=operator,
-        json=_unwrap_body(body_params),
+        json=request.body,
     )
 
 

--- a/backend/src/meho_backplane/operations/_request_preview.py
+++ b/backend/src/meho_backplane/operations/_request_preview.py
@@ -1,0 +1,323 @@
+# SPDX-License-Identifier: Apache-2.0
+# Copyright (c) 2026 evoila Group
+
+"""Read-only dispatch preview -- the literal would-be HTTP request (#1683).
+
+G0.24 follow-up (#1683), the observability counterpart to T5 #1656
+(requestBody unwrap) and T4 #1649 (structured 4xx error shape). When an
+ingested-L2 **write** dispatch fails upstream, an operator could not read
+back *what meho actually put on the wire*: the operation audit persists
+only a **hashed** ``params_hash`` (an intentional privacy + row-size
+choice -- full args may carry secrets), not the resolved method / path /
+body. During the #1656 dogfood the consumer had to "bisect payload
+shapes from the outside" to discover the body was being sent wrapped,
+because nothing inside meho exposed the constructed request
+(``claude-rdc-hetzner-dc#1138``).
+
+This module is the lowest-friction fix consistent with the dumb-substrate
+posture: a **read-only preview** that resolves an op + params to the
+literal request and *returns* it -- ``{method, resolved_path, query,
+redacted_body}`` -- instead of sending it. It is request-time
+observability, **not** a new persisted-secret surface: nothing is written
+to the audit row, the ``params_hash`` design is untouched, and the body
+is run through the **same** connector-boundary redaction pipeline the
+response path uses (:func:`apply_connector_boundary_redaction`), so a
+field the redactor masks in a real response is masked in the preview too.
+
+Scope (honouring #1683's out-of-scope dispositions):
+
+* **No dispatch.** The connector's HTTP transport is never called; no
+  network egress, no audit row, no broadcast event, no policy-gate park.
+* **No replay.** Inspecting a *would-be* request only; re-dispatching a
+  past audited request is a separate governance concern (Goal #1651).
+* **Ingested ops only.** A "would-be HTTP request" exists only for
+  ``source_kind='ingested'`` ops (they construct a literal method/path/
+  body). ``typed`` / ``composite`` ops invoke Python handlers and have no
+  single HTTP request to preview -- the preview says so explicitly rather
+  than fabricating one.
+
+The resolution itself is shared verbatim with the execute path via
+:func:`~meho_backplane.operations._branches.resolve_ingested_request`, so
+the previewed request can never drift from what
+:func:`~meho_backplane.operations._branches.dispatch_ingested` actually
+sends (the path substitution, the ``mount_op_path`` prefix, the
+requestBody unwrap all run identically).
+"""
+
+from __future__ import annotations
+
+from typing import Any
+
+import structlog
+
+from meho_backplane.auth.operator import Operator
+from meho_backplane.connectors import resolve_connector_or_label
+from meho_backplane.db.models import EndpointDescriptor
+from meho_backplane.operations._branches import resolve_ingested_request
+from meho_backplane.operations._handler_resolve import get_or_create_connector_instance
+from meho_backplane.operations._lookup import (
+    count_known_ops,
+    lookup_descriptor,
+    parse_connector_id,
+)
+from meho_backplane.operations._validate import validate_params
+from meho_backplane.redaction import apply_connector_boundary_redaction
+
+__all__ = ["preview_dispatch"]
+
+_log = structlog.get_logger(__name__)
+
+
+async def _resolve_previewable_descriptor(
+    *,
+    operator: Operator,
+    connector_id: str,
+    op_id: str,
+    params: dict[str, Any],
+) -> EndpointDescriptor | dict[str, Any]:
+    """Run dispatch Steps 2-3 + the previewability gate; return descriptor or error.
+
+    Returns the validated :class:`EndpointDescriptor` when the op resolves,
+    is an ``source_kind='ingested'`` op, and its params pass the schema.
+    Otherwise returns the structured envelope the caller propagates verbatim:
+
+    * ``unknown_op`` -- the natural key resolved no descriptor.
+    * ``preview_unavailable`` (status ``"unavailable"``) -- a ``typed`` /
+      ``composite`` op has no single literal HTTP request to preview.
+    * ``invalid_params`` -- params failed the descriptor's
+      ``parameter_schema`` (same validation ``dispatch`` runs).
+    """
+    product, version, impl_id = parse_connector_id(connector_id)
+
+    # --- Step 2: descriptor lookup (mirrors dispatch) ---------------------
+    descriptor = await lookup_descriptor(
+        tenant_id=operator.tenant_id,
+        product=product,
+        version=version,
+        impl_id=impl_id,
+        op_id=op_id,
+    )
+    if descriptor is None:
+        known_op_count = await count_known_ops(
+            product=product,
+            version=version,
+            impl_id=impl_id,
+        )
+        return {
+            "status": "error",
+            "op_id": op_id,
+            "connector_id": connector_id,
+            "error": (
+                f"unknown_op: no operation {op_id!r} for connector "
+                f"{connector_id!r} ({known_op_count} known op(s) for the "
+                "connector). Discover op ids via search_operations."
+            ),
+            "extras": {"error_code": "unknown_op", "known_op_count": known_op_count},
+        }
+
+    # --- Non-ingested ops have no single literal HTTP request -------------
+    # A ``typed`` / ``composite`` op invokes a Python handler (which may
+    # itself make zero or many HTTP calls, or none); there is no one
+    # method/path/body to preview. Say so explicitly rather than fabricate.
+    if descriptor.source_kind != "ingested":
+        return {
+            "status": "unavailable",
+            "op_id": op_id,
+            "connector_id": connector_id,
+            "source_kind": descriptor.source_kind,
+            "error": (
+                f"preview_unavailable: op {op_id!r} is source_kind="
+                f"{descriptor.source_kind!r}, not an HTTP-ingested op -- it "
+                "runs a typed/composite handler with no single literal HTTP "
+                "request to preview. The dispatch-request preview covers "
+                "source_kind='ingested' ops only."
+            ),
+            "extras": {
+                "error_code": "preview_unavailable",
+                "reason": "not_ingested",
+                "source_kind": descriptor.source_kind,
+            },
+        }
+
+    # --- Step 3: parameter_schema validation (mirrors dispatch) -----------
+    validation_errors = validate_params(descriptor.parameter_schema, params)
+    if validation_errors:
+        return {
+            "status": "error",
+            "op_id": op_id,
+            "connector_id": connector_id,
+            "source_kind": descriptor.source_kind,
+            "error": (
+                "invalid_params: params failed the operation's parameter_schema; "
+                "fix the params shape (see extras.validation_errors) before "
+                "previewing."
+            ),
+            "extras": {
+                "error_code": "invalid_params",
+                "validation_errors": validation_errors,
+            },
+        }
+
+    return descriptor
+
+
+def _redact_request_body(
+    body: Any,
+    *,
+    connector_id: str,
+    operator: Operator,
+    op_id: str,
+) -> Any:
+    """Redact a would-be request body through the connector-boundary pipeline.
+
+    The exact pipeline the response path uses
+    (``dispatcher._apply_redaction_middleware`` →
+    :func:`apply_connector_boundary_redaction`): resolve the
+    per-(connector_id, tenant, op) ``RedactionPolicy`` and run the engine.
+    A body field the redactor masks in a real response is masked here too --
+    no new raw-secret surface. A ``None`` body (no requestBody) round-trips
+    to ``None`` without touching the engine.
+    """
+    if body is None:
+        return None
+    tenant = str(operator.tenant_id) if operator.tenant_id is not None else None
+    redaction = apply_connector_boundary_redaction(
+        body,
+        connector_id=connector_id,
+        tenant=tenant,
+        op=op_id,
+    )
+    return redaction.redacted
+
+
+async def _build_ingested_preview(
+    *,
+    operator: Operator,
+    connector_id: str,
+    op_id: str,
+    descriptor: EndpointDescriptor,
+    target: Any,
+    params: dict[str, Any],
+) -> dict[str, Any]:
+    """Resolve the connector + literal request for a validated ingested op.
+
+    Dispatch Step 5 (connector resolution) followed by the literal-request
+    resolve (shared with :func:`dispatch_ingested`) and body redaction.
+    Returns the ``status="ok"`` envelope, or a structured ``no_connector`` /
+    ``ambiguous_connector`` error envelope when the target resolves no
+    connector. Never sends the request.
+    """
+    cls, label, exc_message = resolve_connector_or_label(target)
+    if label is not None:
+        return {
+            "status": "error",
+            "op_id": op_id,
+            "connector_id": connector_id,
+            "source_kind": descriptor.source_kind,
+            "error": f"{label}: {exc_message or 'connector could not be resolved for the target'}",
+            "extras": {"error_code": label, "exception_message": exc_message},
+        }
+    # ``label is None`` ⇔ ``cls`` is set (resolver contract).
+    assert cls is not None
+    connector_instance = get_or_create_connector_instance(cls)
+
+    # The literal request, resolved through the SAME code path
+    # ``dispatch_ingested`` sends through -- no drift.
+    request = await resolve_ingested_request(
+        connector=connector_instance,
+        descriptor=descriptor,
+        operator=operator,
+        target=target,
+        params=params,
+    )
+    redacted_body = _redact_request_body(
+        request.body, connector_id=connector_id, operator=operator, op_id=op_id
+    )
+
+    _log.info(
+        "preview_dispatch",
+        connector_id=connector_id,
+        op_id=op_id,
+        method=request.method,
+        source_kind=descriptor.source_kind,
+        has_body=request.body is not None,
+        tenant_id=str(operator.tenant_id),
+    )
+
+    return {
+        "status": "ok",
+        "op_id": op_id,
+        "connector_id": connector_id,
+        "source_kind": descriptor.source_kind,
+        "method": request.method,
+        "resolved_path": request.path,
+        "query": request.query,
+        "redacted_body": redacted_body,
+    }
+
+
+async def preview_dispatch(
+    *,
+    operator: Operator,
+    connector_id: str,
+    op_id: str,
+    target: Any,
+    params: dict[str, Any],
+) -> dict[str, Any]:
+    """Resolve an op + params to the literal would-be HTTP request, redacted.
+
+    The read-only sibling of :func:`~meho_backplane.operations.dispatcher.dispatch`.
+    Runs the same Steps 1-3 (parse connector id, look up the descriptor,
+    validate params against ``parameter_schema`` -- via
+    :func:`_resolve_previewable_descriptor`) and Step 5 (resolve the
+    connector instance), then -- instead of executing -- resolves the
+    literal request via
+    :func:`~meho_backplane.operations._branches.resolve_ingested_request`
+    and returns it with the body redacted through the connector-boundary
+    pipeline (:func:`_redact_request_body`).
+
+    Never sends the request, never writes an audit row, never parks. The
+    policy gate (Step 4) is deliberately skipped: a preview reveals only
+    what *would* be sent (and the body is redacted), so it carries no
+    side effect to authorize -- the same posture as ``search_operations``
+    over the same descriptors. (Both surfaces are still ``OPERATOR``-gated
+    at the route / tool layer.)
+
+    Returns a JSON-shaped envelope:
+
+    * ``status`` -- ``"ok"`` when the request resolved; ``"error"`` on a
+      structured failure (``unknown_op`` / ``invalid_params`` /
+      ``no_connector`` / ``ambiguous_connector``); ``"unavailable"`` when
+      the op is not previewable (a ``typed`` / ``composite`` op has no
+      literal HTTP request).
+    * ``op_id`` / ``connector_id`` -- echoed for correlation.
+    * ``source_kind`` -- the descriptor's source kind (present whenever a
+      descriptor resolved).
+    * On ``status == "ok"``: ``method``, ``resolved_path``, ``query``
+      (object or ``null``), and ``redacted_body`` (the raw body after the
+      redaction pipeline; ``null`` when the op declares no body).
+    * On a non-ok status: ``error`` (``"<code>: <human-readable>"``) and,
+      for structured failures, an ``extras`` object carrying the
+      machine-readable ``error_code`` and any per-code detail.
+
+    The function does not raise for operator-input faults (unknown op,
+    invalid params, unresolvable connector) -- they come back as the
+    structured ``error`` envelope, mirroring the dispatcher's never-raises
+    contract so the REST route and MCP tool keep one uniform shape.
+    """
+    resolved = await _resolve_previewable_descriptor(
+        operator=operator,
+        connector_id=connector_id,
+        op_id=op_id,
+        params=params,
+    )
+    if isinstance(resolved, dict):
+        return resolved  # structured unknown_op / unavailable / invalid_params
+    return await _build_ingested_preview(
+        operator=operator,
+        connector_id=connector_id,
+        op_id=op_id,
+        descriptor=resolved,
+        target=target,
+        params=params,
+    )

--- a/backend/src/meho_backplane/operations/meta_tools.py
+++ b/backend/src/meho_backplane/operations/meta_tools.py
@@ -93,6 +93,7 @@ from meho_backplane.operations._lookup import (
     connector_exists,
     parse_connector_id,
 )
+from meho_backplane.operations._request_preview import preview_dispatch
 from meho_backplane.operations._search import hybrid_search, resolve_group_id
 from meho_backplane.operations.dispatcher import dispatch
 from meho_backplane.operations.ingest.list_connectors import next_step_for_registered_connector
@@ -105,11 +106,13 @@ __all__ = [
     "OperationDescriptor",
     "OperationGroupSummary",
     "OperationSearchHit",
+    "PreviewOperationBody",
     "UnknownConnectorError",
     "call_operation",
     "call_operation_with_approval",
     "describe_descriptor",
     "list_operation_groups",
+    "preview_operation",
     "search_operations",
 ]
 
@@ -356,6 +359,32 @@ class CallOperationBody(BaseModel):
     free-form ``dict`` because per-op parameter shape is enforced by
     the descriptor's ``parameter_schema`` further down the dispatch
     path; only the meta-tool body's own fields are constrained here.
+    """
+
+    model_config = ConfigDict(extra="forbid")
+
+    connector_id: str = Field(min_length=1)
+    op_id: str = Field(min_length=1)
+    target: str | dict[str, Any] | None = None
+    params: dict[str, Any] = Field(default_factory=dict)
+
+
+class PreviewOperationBody(BaseModel):
+    """Request body for the ``POST /api/v1/operations/preview`` route.
+
+    Same field shape as :class:`CallOperationBody` (#1683) -- a preview
+    resolves the *same* op + target + params a real ``call_operation``
+    would, then returns the literal would-be HTTP request instead of
+    sending it. Keeping the body identical means an operator who hit a
+    write 4xx can re-issue the exact arguments against ``/preview`` to see
+    what was put on the wire (the audit row persists only a hashed
+    ``params_hash``, so the request shape is otherwise unrecoverable).
+
+    ``target`` accepts the same three shapes as ``call_operation`` (bare
+    string, dict ``{"name": ...}``, or ``None``); see
+    :class:`CallOperationBody` for the convention. ``extra="forbid"`` keeps
+    a typo in ``connector_id`` failing loud rather than silently previewing
+    nothing.
     """
 
     model_config = ConfigDict(extra="forbid")
@@ -922,6 +951,77 @@ async def call_operation_with_approval(
     split documented in #1117).
     """
     return await _call_operation_impl(operator, arguments, approved=True)
+
+
+async def preview_operation(
+    operator: Operator,
+    arguments: dict[str, Any],
+) -> dict[str, Any]:
+    """Resolve an op + params to the literal would-be HTTP request, without sending.
+
+    The read-only diagnosis sibling of :func:`call_operation` (#1683). Takes
+    the same ``arguments`` shape -- ``{"connector_id": str, "op_id": str,
+    "target": str | dict | None, "params": dict}`` -- resolves the target the
+    same way, then delegates to
+    :func:`~meho_backplane.operations._request_preview.preview_dispatch`,
+    which returns ``{method, resolved_path, query, redacted_body}`` for an
+    ``source_kind='ingested'`` op **instead of dispatching it**. The body is
+    redacted through the same connector-boundary pipeline the response path
+    uses, so the preview is not a new raw-secret surface; nothing is written
+    to the audit row (the ``params_hash`` privacy design is untouched).
+
+    Use this to diagnose a write 4xx (the gh-rest 422 of #1656, a 403 of
+    #1649) from the inside -- re-issue the exact arguments here to read back
+    what meho would put on the wire, rather than bisecting payload shapes
+    from outside. Inspection only: it never sends the request and never
+    re-dispatches a past one (replay is a separate concern, Goal #1651).
+
+    Returns the structured envelope verbatim (``status`` of ``"ok"`` /
+    ``"error"`` / ``"unavailable"``); operator-input faults (unknown op,
+    invalid params, unresolvable connector) come back inside the envelope
+    rather than as exceptions, mirroring ``call_operation``. The one
+    exception the handler may raise is the missing-``target.name``
+    ``ValueError`` from :func:`_normalize_target_arg`, which the route maps
+    to a ``400``.
+    """
+    connector_id = arguments["connector_id"]
+    op_id = arguments["op_id"]
+    target_arg = _normalize_target_arg(arguments.get("target"))
+    params: dict[str, Any] = arguments.get("params") or {}
+
+    resolved_target: Any = None
+    if target_arg is not None:
+        # ``name`` is guaranteed present + non-empty by
+        # ``_normalize_target_arg``. Resolve the target so the preview
+        # reflects the same connector + ``mount_op_path`` the real dispatch
+        # would hit -- but do NOT bind the ``audit_target_id`` contextvar:
+        # a preview writes no audit row, so there is nothing to enrich.
+        name = target_arg["name"]
+        sessionmaker = get_sessionmaker()
+        async with sessionmaker() as session:
+            resolved_target = await resolve_target(session, operator.tenant_id, name)
+        # Per-call ``fqdn`` override -- applied in memory only, same as
+        # ``call_operation``; the resolved path the connector's
+        # ``mount_op_path`` produces can depend on it (vhost routing).
+        fqdn_override = target_arg.get("fqdn")
+        if isinstance(fqdn_override, str) and fqdn_override:
+            resolved_target.fqdn = fqdn_override
+
+    envelope = await preview_dispatch(
+        operator=operator,
+        connector_id=connector_id,
+        op_id=op_id,
+        target=resolved_target,
+        params=params,
+    )
+    _log.info(
+        "preview_operation",
+        connector_id=connector_id,
+        op_id=op_id,
+        status=envelope.get("status"),
+        tenant_id=str(operator.tenant_id),
+    )
+    return envelope
 
 
 async def describe_descriptor(

--- a/backend/tests/test_operations_request_preview.py
+++ b/backend/tests/test_operations_request_preview.py
@@ -1,0 +1,833 @@
+# SPDX-License-Identifier: Apache-2.0
+# Copyright (c) 2026 evoila Group
+
+"""Behavioural tests for the read-only dispatch request preview (#1683).
+
+G0.24 follow-up (#1683) -- the observability counterpart to T5 #1656
+(requestBody unwrap) and T4 #1649 (structured 4xx error shape). When an
+ingested-L2 **write** dispatch fails upstream, an operator could not read
+back what meho put on the wire: the audit row persists only a hashed
+``params_hash``. This surface returns the literal would-be HTTP request
+(``{method, resolved_path, query, redacted_body}``) WITHOUT dispatching.
+
+Acceptance criteria covered:
+
+* **AC1** -- a read-only preview path resolves an op + params to the
+  literal request (method + substituted path + query + redacted body) and
+  returns it WITHOUT dispatching. A gh-rest issue-create preview shows
+  ``POST`` + ``/repos/{owner}/{repo}/issues`` + body ``{"title": "…"}``.
+  Proven the connector's HTTP transport is never called.
+* **AC2** -- redaction reuses the existing connector-boundary pipeline: a
+  body field the redactor masks (a labelled credential under the
+  default-safe policy; a UUID under a registered override) is masked in
+  the preview. No new raw-secret surface.
+* **AC3** -- the persisted audit row is unchanged: a preview writes **no**
+  ``AuditLog`` row and publishes **no** broadcast event (regression).
+* **AC4** -- the error-echo option is **deferred** (see the module-level
+  note in :mod:`meho_backplane.operations._request_preview` and the PR
+  body): the dedicated read-only preview is the diagnosis surface; the
+  4xx error's ``extras`` is not extended in this change.
+
+Plus scope boundaries: a ``typed`` / ``composite`` op (no single literal
+HTTP request) returns ``status="unavailable"``; ``invalid_params`` /
+``unknown_op`` come back as structured envelopes; the previewed request
+matches what ``dispatch_ingested`` actually sends (shared-resolver
+regression); REST + MCP parity over the shared meta-tool funnel.
+
+Mirrors the sibling #1649 ``test_operations_connector_http_403`` fixtures
+(in-memory SQLite via the autouse-migrated engine, connector registry +
+dispatcher-cache reset, deterministic embedding stub).
+"""
+
+from __future__ import annotations
+
+import textwrap
+import uuid
+from collections.abc import AsyncIterator, Iterator
+from datetime import UTC, datetime
+from typing import Any
+from unittest.mock import AsyncMock
+from uuid import UUID
+
+import pytest
+from sqlalchemy import select
+from sqlalchemy.ext.asyncio import AsyncSession
+
+import meho_backplane.operations._audit as audit_module
+from meho_backplane.auth.operator import Operator, TenantRole
+from meho_backplane.broadcast import BroadcastEvent
+from meho_backplane.connectors.adapters import HttpConnector
+from meho_backplane.connectors.registry import clear_registry, register_connector_v2
+from meho_backplane.connectors.schemas import FingerprintResult, ProbeResult
+from meho_backplane.db.engine import get_sessionmaker
+from meho_backplane.db.models import AuditLog, EndpointDescriptor
+from meho_backplane.db.models import Target as TargetORM
+from meho_backplane.operations import register_typed_operation, reset_dispatcher_caches
+from meho_backplane.operations._handler_resolve import get_or_create_connector_instance
+from meho_backplane.operations._request_preview import preview_dispatch
+from meho_backplane.operations.meta_tools import preview_operation
+from meho_backplane.redaction import clear_overrides, parse_policy, register_policy
+from meho_backplane.settings import get_settings
+
+_TENANT: UUID = UUID("00000000-0000-0000-0000-0000000016b3")
+
+
+# ---------------------------------------------------------------------------
+# Fixtures (the sibling dispatcher-test pattern)
+# ---------------------------------------------------------------------------
+
+
+@pytest.fixture(autouse=True)
+def _required_settings_env(monkeypatch: pytest.MonkeyPatch) -> Iterator[None]:
+    """Pin every env var :class:`Settings` requires for this module."""
+    monkeypatch.setenv("KEYCLOAK_ISSUER_URL", "https://keycloak.test/realms/meho")
+    monkeypatch.setenv("KEYCLOAK_AUDIENCE", "meho-backplane")
+    monkeypatch.setenv("VAULT_ADDR", "https://vault.test")
+    get_settings.cache_clear()
+    yield
+    get_settings.cache_clear()
+
+
+@pytest.fixture(autouse=True)
+def _reset_module_state() -> Iterator[None]:
+    """Reset dispatcher caches + connector registry + redaction overrides."""
+    reset_dispatcher_caches()
+    clear_registry()
+    clear_overrides()
+    yield
+    reset_dispatcher_caches()
+    clear_registry()
+    clear_overrides()
+
+
+@pytest.fixture
+def stub_embedding_service() -> AsyncMock:
+    """Deterministic embedding stub so descriptor inserts don't pull ONNX."""
+    service = AsyncMock()
+    service.encode_one.return_value = [0.1] * 384
+    service.encode.return_value = [[0.1] * 384]
+    service.dimension = 384
+    return service
+
+
+@pytest.fixture
+def captured_events(monkeypatch: pytest.MonkeyPatch) -> list[BroadcastEvent]:
+    """Replace :func:`publish_event` with a recording stub.
+
+    Lets each test assert the preview path publishes **zero** broadcast
+    events (it never dispatches), the broadcast-side half of AC3.
+    """
+    events: list[BroadcastEvent] = []
+
+    async def _capture(event: BroadcastEvent) -> None:
+        events.append(event)
+
+    monkeypatch.setattr(audit_module, "publish_event", _capture)
+    return events
+
+
+@pytest.fixture
+async def session() -> AsyncIterator[AsyncSession]:
+    """Yield an :class:`AsyncSession` against the autouse-migrated engine."""
+    sessionmaker = get_sessionmaker()
+    async with sessionmaker() as s:
+        yield s
+
+
+def _make_operator(*, sub: str = "op-preview") -> Operator:
+    """Construct an :class:`Operator` directly -- no JWT round-trip."""
+    return Operator(
+        sub=sub,
+        name="Request-Preview Test Operator",
+        email=None,
+        raw_jwt="<test-raw-jwt>",
+        tenant_id=_TENANT,
+        tenant_role=TenantRole.OPERATOR,
+    )
+
+
+class _FakeFingerprint:
+    """Duck-typed fingerprint for resolver lookups."""
+
+    def __init__(self, version: str | None = None) -> None:
+        self.version = version
+
+
+class _FakeTarget:
+    """Minimal target shape the resolver / dispatcher / connectors read."""
+
+    def __init__(
+        self,
+        *,
+        product: str = "gh",
+        version: str | None = "3",
+        name: str = "gh-target",
+        host: str = "api.github.com",
+        port: int = 443,
+        auth_model: str | None = "shared_service_account",
+    ) -> None:
+        self.product = product
+        self.fingerprint = _FakeFingerprint(version=version)
+        self.preferred_impl_id: str | None = None
+        self.id: UUID = uuid.uuid4()
+        self.name = name
+        self.host = host
+        self.port = port
+        self.auth_model = auth_model
+        self.secret_ref: str | None = None
+        self.fqdn: str | None = None
+
+
+class _RecordingHttpConnector(HttpConnector):
+    """Connector whose write/read transport records calls instead of sending.
+
+    The preview path must resolve the request WITHOUT touching the HTTP
+    transport. These ``_post_json`` / ``_request_json`` overrides append to
+    :attr:`calls` and would return a sentinel if ever reached -- a non-empty
+    ``calls`` list after a preview is the AC1 failure signal (the preview
+    dispatched).
+    """
+
+    product = "gh"
+    version = "3"
+    impl_id = "gh-rest"
+    supported_version_range = ">=3,<4"
+    priority = 1
+
+    def __init__(self) -> None:
+        super().__init__()
+        self.calls: list[dict[str, Any]] = []
+
+    async def _post_json(
+        self,
+        target: Any,
+        path: str,
+        *,
+        operator: Operator,
+        json: dict[str, Any] | None = None,
+    ) -> dict[str, Any]:
+        self.calls.append({"verb": "POST", "path": path, "json": json})
+        return {"sent": True}
+
+    async def _request_json(
+        self,
+        target: Any,
+        method: str,
+        path: str,
+        *,
+        operator: Operator,
+        params: dict[str, Any] | None = None,
+        json: dict[str, Any] | None = None,
+    ) -> dict[str, Any]:
+        self.calls.append({"verb": method, "path": path, "params": params, "json": json})
+        return {"sent": True}
+
+    async def fingerprint(  # type: ignore[override]
+        self,
+        target: Any,
+        operator: Operator | None = None,
+    ) -> FingerprintResult:
+        raise NotImplementedError
+
+    async def probe(self, target: Any) -> ProbeResult:  # type: ignore[override]
+        raise NotImplementedError
+
+    async def execute(  # type: ignore[override]
+        self,
+        target: Any,
+        op_id: str,
+        params: dict[str, Any],
+    ) -> dict[str, Any]:
+        raise NotImplementedError
+
+
+def _register_recording_gh_connector() -> _RecordingHttpConnector:
+    """Register :class:`_RecordingHttpConnector` under ``gh-rest-3`` + return the singleton.
+
+    The v2 registry stores the **class**; the dispatcher / preview resolve
+    the **cached instance** via :func:`get_or_create_connector_instance`.
+    Returning that same singleton lets a test assert on its ``calls`` list
+    -- a non-empty ``calls`` after a preview is the AC1 "it dispatched"
+    failure signal.
+    """
+    register_connector_v2(
+        product="gh",
+        version="3",
+        impl_id="gh-rest",
+        cls=_RecordingHttpConnector,
+    )
+    connector = get_or_create_connector_instance(_RecordingHttpConnector)
+    assert isinstance(connector, _RecordingHttpConnector)
+    return connector
+
+
+async def _insert_ingested_descriptor(
+    *,
+    session: AsyncSession,
+    product: str,
+    version: str,
+    impl_id: str,
+    op_id: str,
+    embedding: list[float],
+    method: str = "POST",
+    path: str = "/repos/{owner}/{repo}/issues",
+    parameter_schema: dict[str, Any] | None = None,
+) -> None:
+    """Seed one enabled ``source_kind='ingested'`` descriptor row.
+
+    Default ``parameter_schema`` models a gh-rest issue-create: ``owner`` /
+    ``repo`` as ``x-meho-param-loc: path`` and ``body`` as
+    ``x-meho-param-loc: body`` (the single requestBody container param
+    #1656 unwraps), so the preview substitutes the path and unwraps the
+    body exactly as the real dispatch would.
+    """
+    if parameter_schema is None:
+        parameter_schema = {
+            "type": "object",
+            "properties": {
+                "owner": {"type": "string", "x-meho-param-loc": "path"},
+                "repo": {"type": "string", "x-meho-param-loc": "path"},
+                "body": {"type": "object", "x-meho-param-loc": "body"},
+            },
+        }
+    descriptor = EndpointDescriptor(
+        id=uuid.uuid4(),
+        tenant_id=None,
+        product=product,
+        version=version,
+        impl_id=impl_id,
+        op_id=op_id,
+        source_kind="ingested",
+        method=method,
+        path=path,
+        handler_ref=None,
+        summary="Create issue.",
+        description="Ingested write test op.",
+        tags=[],
+        parameter_schema=parameter_schema,
+        response_schema=None,
+        llm_instructions=None,
+        safety_level="safe",
+        requires_approval=False,
+        is_enabled=True,
+        embedding=embedding,
+        custom_description=None,
+        custom_notes=None,
+        created_at=datetime.now(UTC),
+        updated_at=datetime.now(UTC),
+    )
+    session.add(descriptor)
+    await session.commit()
+
+
+async def _assert_no_audit_rows(path: str) -> None:
+    """AC3 regression: the preview wrote no ``AuditLog`` row for *path*."""
+    sessionmaker = get_sessionmaker()
+    async with sessionmaker() as fresh:
+        rows = (await fresh.execute(select(AuditLog).where(AuditLog.path == path))).scalars().all()
+    assert rows == [], f"preview must not persist an audit row; found {len(rows)}"
+
+
+# ---------------------------------------------------------------------------
+# AC1 -- the literal request, without dispatching
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.asyncio
+async def test_preview_gh_issue_create_returns_literal_request_without_dispatching(
+    stub_embedding_service: AsyncMock,
+    session: AsyncSession,
+    captured_events: list[BroadcastEvent],
+) -> None:
+    """AC1: gh-rest issue-create preview -> POST + substituted path + unwrapped body.
+
+    The keystone acceptance criterion: a preview of the gh-rest
+    issue-create op resolves to ``POST`` + ``/repos/{owner}/{repo}/issues``
+    (placeholders substituted) + body ``{"title": "…"}`` (the requestBody
+    container unwrapped, #1656) and returns it WITHOUT calling the
+    connector's HTTP transport.
+    """
+    connector = _register_recording_gh_connector()
+    await _insert_ingested_descriptor(
+        session=session,
+        product="gh",
+        version="3",
+        impl_id="gh-rest",
+        op_id="POST:/repos/{owner}/{repo}/issues",
+        embedding=stub_embedding_service.encode_one.return_value,
+    )
+
+    envelope = await preview_dispatch(
+        operator=_make_operator(),
+        connector_id="gh-rest-3",
+        op_id="POST:/repos/{owner}/{repo}/issues",
+        target=_FakeTarget(name="gh-prod"),
+        params={
+            "owner": "evoila",
+            "repo": "meho",
+            "body": {"title": "diagnose me"},
+        },
+    )
+
+    assert envelope["status"] == "ok"
+    assert envelope["op_id"] == "POST:/repos/{owner}/{repo}/issues"
+    assert envelope["connector_id"] == "gh-rest-3"
+    assert envelope["source_kind"] == "ingested"
+    assert envelope["method"] == "POST"
+    # Placeholders substituted to the literal path.
+    assert envelope["resolved_path"] == "/repos/evoila/meho/issues"
+    # requestBody container unwrapped (#1656) -- NOT {"body": {"title": ...}}.
+    assert envelope["redacted_body"] == {"title": "diagnose me"}
+    assert envelope["query"] is None
+
+    # AC1: nothing was dispatched -- the HTTP transport was never reached.
+    assert connector.calls == []
+    # AC3: no broadcast event, no audit row.
+    assert captured_events == []
+    await _assert_no_audit_rows("POST:/repos/{owner}/{repo}/issues")
+
+
+@pytest.mark.asyncio
+async def test_preview_get_op_splits_query_and_path(
+    stub_embedding_service: AsyncMock,
+    session: AsyncSession,
+    captured_events: list[BroadcastEvent],
+) -> None:
+    """A GET op previews its substituted path + query bucket, no body.
+
+    Pins the read-verb branch: ``x-meho-param-loc: query`` params land in
+    ``query`` (the httpx ``params=`` value), a path placeholder is
+    substituted, and there is no body. Still no dispatch.
+    """
+    connector = _register_recording_gh_connector()
+    await _insert_ingested_descriptor(
+        session=session,
+        product="gh",
+        version="3",
+        impl_id="gh-rest",
+        op_id="GET:/repos/{owner}/{repo}/issues",
+        embedding=stub_embedding_service.encode_one.return_value,
+        method="GET",
+        path="/repos/{owner}/{repo}/issues",
+        parameter_schema={
+            "type": "object",
+            "properties": {
+                "owner": {"type": "string", "x-meho-param-loc": "path"},
+                "repo": {"type": "string", "x-meho-param-loc": "path"},
+                "state": {"type": "string", "x-meho-param-loc": "query"},
+            },
+        },
+    )
+
+    envelope = await preview_dispatch(
+        operator=_make_operator(),
+        connector_id="gh-rest-3",
+        op_id="GET:/repos/{owner}/{repo}/issues",
+        target=_FakeTarget(name="gh-prod"),
+        params={"owner": "evoila", "repo": "meho", "state": "open"},
+    )
+
+    assert envelope["status"] == "ok"
+    assert envelope["method"] == "GET"
+    assert envelope["resolved_path"] == "/repos/evoila/meho/issues"
+    assert envelope["query"] == {"state": "open"}
+    assert envelope["redacted_body"] is None
+    assert connector.calls == []
+
+
+@pytest.mark.asyncio
+async def test_preview_matches_what_dispatch_ingested_sends(
+    stub_embedding_service: AsyncMock,
+    session: AsyncSession,
+    captured_events: list[BroadcastEvent],
+) -> None:
+    """Shared-resolver regression: the previewed request == the sent request.
+
+    Both :func:`dispatch_ingested` and the preview resolve the literal
+    request through :func:`resolve_ingested_request`, so the previewed
+    method/path/body must equal what a real dispatch puts on the wire. This
+    guards against drift -- the whole point of factoring the resolver.
+    """
+    from meho_backplane.operations.dispatcher import dispatch
+
+    connector = _register_recording_gh_connector()
+    await _insert_ingested_descriptor(
+        session=session,
+        product="gh",
+        version="3",
+        impl_id="gh-rest",
+        op_id="POST:/repos/{owner}/{repo}/issues",
+        embedding=stub_embedding_service.encode_one.return_value,
+    )
+
+    args: dict[str, Any] = {
+        "owner": "evoila",
+        "repo": "meho",
+        "body": {"title": "parity"},
+    }
+    preview = await preview_dispatch(
+        operator=_make_operator(),
+        connector_id="gh-rest-3",
+        op_id="POST:/repos/{owner}/{repo}/issues",
+        target=_FakeTarget(name="gh-prod"),
+        params=args,
+    )
+    assert connector.calls == []  # preview did not send
+
+    # Now actually dispatch the same args and compare the recorded wire call.
+    await dispatch(
+        operator=_make_operator(),
+        connector_id="gh-rest-3",
+        op_id="POST:/repos/{owner}/{repo}/issues",
+        target=_FakeTarget(name="gh-prod"),
+        params=args,
+    )
+    assert len(connector.calls) == 1
+    sent = connector.calls[0]
+    assert sent["verb"] == "POST"
+    assert sent["path"] == preview["resolved_path"]
+    # The body the connector received equals the previewed (pre-redaction)
+    # body -- here nothing is masked, so redacted_body == the sent body.
+    assert sent["json"] == preview["redacted_body"] == {"title": "parity"}
+
+
+# ---------------------------------------------------------------------------
+# AC2 -- redaction reuses the existing connector-boundary pipeline
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.asyncio
+async def test_preview_masks_credential_body_field_default_policy(
+    stub_embedding_service: AsyncMock,
+    session: AsyncSession,
+    captured_events: list[BroadcastEvent],
+) -> None:
+    """AC2: a credential-shaped body value is masked by the default-safe policy.
+
+    No override registered -> the conservative default policy fires. The
+    Tier-1 engine matches on the **string value shape** (not the dict key
+    name), so a bearer token carried in a request-body value is redacted in
+    the preview exactly as it would be at the connector response boundary --
+    proving the preview is not a new raw-secret surface and reuses the same
+    named-pattern library.
+    """
+    connector = _register_recording_gh_connector()
+    await _insert_ingested_descriptor(
+        session=session,
+        product="gh",
+        version="3",
+        impl_id="gh-rest",
+        op_id="POST:/repos/{owner}/{repo}/secrets",
+        embedding=stub_embedding_service.encode_one.return_value,
+        path="/repos/{owner}/{repo}/secrets",
+    )
+
+    secret = "Bearer eyJhbGciOiJIUzI1NiIsInR5cCI6IkpXVCJ9.eyJzdWIiOiIxIn0.sig"
+    envelope = await preview_dispatch(
+        operator=_make_operator(),
+        connector_id="gh-rest-3",
+        op_id="POST:/repos/{owner}/{repo}/secrets",
+        target=_FakeTarget(name="gh-prod"),
+        params={
+            "owner": "evoila",
+            "repo": "meho",
+            "body": {"title": "visible", "upstream_auth": secret},
+        },
+    )
+
+    assert envelope["status"] == "ok"
+    body = envelope["redacted_body"]
+    assert isinstance(body, dict)
+    # The non-secret field is preserved verbatim...
+    assert body["title"] == "visible"
+    # ...the bearer token in the body value is redacted (default-safe policy).
+    assert "[REDACTED:bearer_token]" in body["upstream_auth"]
+    assert secret not in str(body)
+    assert connector.calls == []
+
+
+@pytest.mark.asyncio
+async def test_preview_redaction_honours_registered_override(
+    stub_embedding_service: AsyncMock,
+    session: AsyncSession,
+    captured_events: list[BroadcastEvent],
+) -> None:
+    """AC2: the preview resolves the per-(connector_id) policy override.
+
+    A UUID-only override registered for ``gh-rest-3`` masks a UUID in the
+    body while leaving a bearer token (no rule) untouched -- proving the
+    preview routes through the same
+    :func:`resolve_policy`-backed pipeline the dispatcher uses, not a
+    hard-coded default.
+    """
+    uuid_only = parse_policy(
+        textwrap.dedent(
+            """
+            id: preview-uuid-only-test
+            version: 1
+            rules:
+              - name: redact-uuid
+                pattern: uuid
+                action: redact
+                reason: "test override"
+            """
+        ).strip()
+    )
+    register_policy(uuid_only, connector_id="gh-rest-3")
+
+    _register_recording_gh_connector()
+    await _insert_ingested_descriptor(
+        session=session,
+        product="gh",
+        version="3",
+        impl_id="gh-rest",
+        op_id="POST:/repos/{owner}/{repo}/issues",
+        embedding=stub_embedding_service.encode_one.return_value,
+    )
+
+    a_uuid = "123e4567-e89b-12d3-a456-426614174000"
+    envelope = await preview_dispatch(
+        operator=_make_operator(),
+        connector_id="gh-rest-3",
+        op_id="POST:/repos/{owner}/{repo}/issues",
+        target=_FakeTarget(name="gh-prod"),
+        params={
+            "owner": "evoila",
+            "repo": "meho",
+            "body": {"ref_id": a_uuid, "token": "Bearer eyJhbGciOi"},
+        },
+    )
+
+    assert envelope["status"] == "ok"
+    serialised = str(envelope["redacted_body"])
+    # UUID redacted by the override...
+    assert "[REDACTED:uuid]" in serialised
+    assert a_uuid not in serialised
+    # ...bearer survived (override has no bearer rule -> proves the default
+    # was NOT applied; the override fired).
+    assert "Bearer eyJhbGciOi" in serialised
+
+
+# ---------------------------------------------------------------------------
+# Scope boundaries / structured envelopes
+# ---------------------------------------------------------------------------
+
+
+async def _handler_returning_ok(
+    *, operator: Operator, target: Any, params: dict[str, Any]
+) -> dict[str, Any]:
+    """A trivial typed handler (never invoked by the preview path)."""
+    return {"ok": True}
+
+
+@pytest.mark.asyncio
+async def test_preview_typed_op_is_unavailable(
+    stub_embedding_service: AsyncMock,
+    session: AsyncSession,
+    captured_events: list[BroadcastEvent],
+) -> None:
+    """A typed op has no single literal HTTP request -> status=unavailable.
+
+    Scope boundary: ``typed`` / ``composite`` ops run Python handlers
+    (which may make zero or many HTTP calls). The preview says so
+    explicitly rather than fabricating a request.
+    """
+    register_connector_v2(
+        product="demo",
+        version="",
+        impl_id="",
+        cls=_RecordingHttpConnector,
+    )
+    await register_typed_operation(
+        product="demo",
+        version="1.x",
+        impl_id="demo",
+        op_id="demo.typed.read",
+        handler=_handler_returning_ok,
+        summary="A typed op.",
+        description="Typed.",
+        parameter_schema={"type": "object"},
+        safety_level="safe",
+        when_to_use=None,
+        embedding_service=stub_embedding_service,
+    )
+
+    envelope = await preview_dispatch(
+        operator=_make_operator(),
+        connector_id="demo-1.x",
+        op_id="demo.typed.read",
+        target=_FakeTarget(product="demo", version="1.x", name="demo-prod"),
+        params={},
+    )
+
+    assert envelope["status"] == "unavailable"
+    assert envelope["source_kind"] == "typed"
+    assert envelope["extras"]["error_code"] == "preview_unavailable"
+    assert envelope["extras"]["reason"] == "not_ingested"
+    assert "method" not in envelope
+    assert "resolved_path" not in envelope
+
+
+@pytest.mark.asyncio
+async def test_preview_invalid_params_returns_structured_error(
+    stub_embedding_service: AsyncMock,
+    session: AsyncSession,
+    captured_events: list[BroadcastEvent],
+) -> None:
+    """Params failing parameter_schema -> structured invalid_params envelope.
+
+    The preview validates params the same way ``dispatch`` does, so an
+    agent that previews a bad shape gets ``extras.validation_errors`` to
+    self-correct from -- without ever resolving a request.
+    """
+    connector = _register_recording_gh_connector()
+    await _insert_ingested_descriptor(
+        session=session,
+        product="gh",
+        version="3",
+        impl_id="gh-rest",
+        op_id="POST:/repos/{owner}/{repo}/issues",
+        embedding=stub_embedding_service.encode_one.return_value,
+        parameter_schema={
+            "type": "object",
+            "properties": {"owner": {"type": "string", "x-meho-param-loc": "path"}},
+            "required": ["owner"],
+            "additionalProperties": False,
+        },
+    )
+
+    envelope = await preview_dispatch(
+        operator=_make_operator(),
+        connector_id="gh-rest-3",
+        op_id="POST:/repos/{owner}/{repo}/issues",
+        target=_FakeTarget(name="gh-prod"),
+        params={"unexpected": "field"},  # missing required owner + extra
+    )
+
+    assert envelope["status"] == "error"
+    assert envelope["error"].startswith("invalid_params:")
+    assert envelope["extras"]["error_code"] == "invalid_params"
+    assert isinstance(envelope["extras"]["validation_errors"], list)
+    assert envelope["extras"]["validation_errors"]
+    assert connector.calls == []
+
+
+@pytest.mark.asyncio
+async def test_preview_unknown_op_returns_structured_error(
+    stub_embedding_service: AsyncMock,
+    session: AsyncSession,
+    captured_events: list[BroadcastEvent],
+) -> None:
+    """An op id that resolves no descriptor -> structured unknown_op envelope."""
+    register_connector_v2(
+        product="gh",
+        version="3",
+        impl_id="gh-rest",
+        cls=_RecordingHttpConnector,
+    )
+    envelope = await preview_dispatch(
+        operator=_make_operator(),
+        connector_id="gh-rest-3",
+        op_id="POST:/does/not/exist",
+        target=_FakeTarget(name="gh-prod"),
+        params={},
+    )
+    assert envelope["status"] == "error"
+    assert envelope["error"].startswith("unknown_op:")
+    assert envelope["extras"]["error_code"] == "unknown_op"
+
+
+# ---------------------------------------------------------------------------
+# REST / MCP parity over the shared meta-tool funnel
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.asyncio
+async def test_preview_operation_meta_tool_resolves_target_by_name(
+    stub_embedding_service: AsyncMock,
+    session: AsyncSession,
+    captured_events: list[BroadcastEvent],
+) -> None:
+    """The shared ``preview_operation`` funnel both surfaces call resolves the target.
+
+    ``POST /api/v1/operations/preview`` returns ``await
+    preview_operation(...)`` verbatim and the MCP ``preview_operation``
+    tool is a thin shim over the same function, so asserting on the
+    envelope here covers both surfaces -- the same parity argument the
+    ``call_operation`` envelope relies on. Also re-confirms the
+    no-dispatch / no-audit contract end-to-end through the funnel.
+    """
+    connector = _register_recording_gh_connector()
+    await _insert_ingested_descriptor(
+        session=session,
+        product="gh",
+        version="3",
+        impl_id="gh-rest",
+        op_id="POST:/repos/{owner}/{repo}/issues",
+        embedding=stub_embedding_service.encode_one.return_value,
+    )
+    # Seed a target row resolve_target() can find by name.
+    target_id = uuid.uuid4()
+    sessionmaker = get_sessionmaker()
+    async with sessionmaker() as s, s.begin():
+        s.add(
+            TargetORM(
+                id=target_id,
+                tenant_id=_TENANT,
+                name="gh-prod",
+                aliases=[],
+                product="gh",
+                version="3",
+                host="api.github.com",
+                port=443,
+                fqdn=None,
+                secret_ref=None,
+                auth_model="shared_service_account",
+                vpn_required=False,
+                extras={},
+                notes=None,
+                created_at=datetime.now(UTC),
+                updated_at=datetime.now(UTC),
+            )
+        )
+
+    envelope = await preview_operation(
+        _make_operator(),
+        {
+            "connector_id": "gh-rest-3",
+            "op_id": "POST:/repos/{owner}/{repo}/issues",
+            "target": "gh-prod",  # bare-string shape
+            "params": {
+                "owner": "evoila",
+                "repo": "meho",
+                "body": {"title": "via-funnel"},
+            },
+        },
+    )
+
+    assert envelope["status"] == "ok"
+    assert envelope["method"] == "POST"
+    assert envelope["resolved_path"] == "/repos/evoila/meho/issues"
+    assert envelope["redacted_body"] == {"title": "via-funnel"}
+    assert connector.calls == []
+    assert captured_events == []
+    await _assert_no_audit_rows("POST:/repos/{owner}/{repo}/issues")
+
+
+@pytest.mark.asyncio
+async def test_preview_operation_missing_target_name_raises_valueerror() -> None:
+    """A dict target without ``name`` raises ValueError (route maps to 400).
+
+    Mirrors ``call_operation``'s sole ValueError surface so the
+    ``/preview`` route's 400 mapping is the same contract as ``/call``.
+    """
+    with pytest.raises(ValueError, match="must include a 'name' field"):
+        await preview_operation(
+            _make_operator(),
+            {
+                "connector_id": "gh-rest-3",
+                "op_id": "POST:/repos/{owner}/{repo}/issues",
+                "target": {"fqdn": "no-name-here"},
+                "params": {},
+            },
+        )

--- a/cli/api/openapi.json
+++ b/cli/api/openapi.json
@@ -2731,6 +2731,62 @@
         }
       }
     },
+    "/api/v1/operations/preview": {
+      "post": {
+        "tags": [
+          "operations"
+        ],
+        "summary": "Post Preview",
+        "description": "Resolve an op + params to the literal would-be HTTP request, without sending.\n\nDelegates to :func:`preview_operation` (#1683). The read-only diagnosis\nsibling of ``POST /api/v1/operations/call``: it resolves the same op +\ntarget + params and returns the literal request\n(``{method, resolved_path, query, redacted_body}``) for an\n``source_kind='ingested'`` op **instead of dispatching it**. Use it to\ndiagnose a write 4xx from the inside -- the audit row persists only a\nhashed ``params_hash``, so the wire shape is otherwise unrecoverable.\n\nReturns ``200`` with the structured envelope; operator-input faults\n(unknown op, invalid params, unresolvable connector) land inside the\nenvelope (``status=\"error\"`` / ``status=\"unavailable\"`` +\n``extras.error_code``) rather than as HTTP 4xx, the same contract as\n``/call``. The one HTTP-side gate is target resolution: a missing-target\nname (``{\"target\": {}}`` without ``\"name\"``) surfaces as a ``400``. The\nbody is redacted through the same connector-boundary pipeline the\nresponse path uses; nothing is written to the audit row.",
+        "operationId": "post_preview_api_v1_operations_preview_post",
+        "parameters": [
+          {
+            "name": "authorization",
+            "in": "header",
+            "required": false,
+            "schema": {
+              "type": "string",
+              "nullable": true,
+              "title": "Authorization"
+            }
+          }
+        ],
+        "requestBody": {
+          "required": true,
+          "content": {
+            "application/json": {
+              "schema": {
+                "$ref": "#/components/schemas/PreviewOperationBody"
+              }
+            }
+          }
+        },
+        "responses": {
+          "200": {
+            "description": "Successful Response",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "type": "object",
+                  "additionalProperties": true,
+                  "title": "Response Post Preview Api V1 Operations Preview Post"
+                }
+              }
+            }
+          },
+          "422": {
+            "description": "Validation Error",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/HTTPValidationError"
+                }
+              }
+            }
+          }
+        }
+      }
+    },
     "/api/v1/operations/{descriptor_id}": {
       "get": {
         "tags": [
@@ -14146,6 +14202,46 @@
         ],
         "title": "PreambleInclusion",
         "description": "Whether a just-written convention reaches the session preamble.\n\nG0.14-T8 (#1149, signal 18) -- the post-write feedback shape\n``POST /api/v1/conventions`` and ``PATCH /api/v1/conventions/{slug}``\nattach to the response when the convention is ``kind='operational'``.\nWithout it, the operator gets a ``201`` (or ``200`` on PATCH), assumes\nthe rule is in effect, and the agent silently never sees it because\nthe preamble packer dropped it on budget overflow.\n\nFields:\n\n* ``included`` -- ``True`` when the slug landed in the assembled\n  preamble (after the priority-ranked pack against\n  :data:`DEFAULT_MAX_PREAMBLE_TOKENS`). ``False`` when the packer\n  dropped it whole on overflow.\n* ``position`` -- 1-based index of the convention in the assembled\n  preamble's packed order (the packer iterates ``priority DESC,\n  created_at ASC``; ``position=1`` means highest-priority slot in\n  the operator's tenant). ``None`` when ``included=False``.\n* ``token_count`` -- the convention body's own estimated token\n  cost via :func:`estimate_tokens`. Useful for the operator to\n  see why a near-budget body got dropped (it weighed more than\n  the remaining headroom).\n* ``would_drop_slugs`` -- the full ``dropped_slugs`` list the\n  packer produced on this assembly. When ``included=True`` this\n  names *other* slugs that fell out of the preamble (the just-\n  written convention may have pushed a lower-priority neighbour\n  out); when ``included=False`` the list contains *this* slug\n  plus any others dropped under the same pack. The shape lets\n  a single ``meho conventions create ...`` round-trip surface\n  both the personal outcome (did mine land?) and the collateral\n  damage (did mine push someone else out?).\n\nWhy a separate model instead of inlining fields on\n:class:`Convention`: the response shape ``Convention`` is used\nby ``GET /{slug}`` too, where ``preamble_status`` would be\nredundant (operators inspecting a row already have the\n``GET /api/v1/conventions``'s ``budget_status`` envelope for\naggregate budget signal). Keeping the inclusion shape on a\nsub-model means GET-single can drop the field cleanly while\nPOST/PATCH attach it."
+      },
+      "PreviewOperationBody": {
+        "properties": {
+          "connector_id": {
+            "type": "string",
+            "minLength": 1,
+            "title": "Connector Id"
+          },
+          "op_id": {
+            "type": "string",
+            "minLength": 1,
+            "title": "Op Id"
+          },
+          "target": {
+            "anyOf": [
+              {
+                "type": "string"
+              },
+              {
+                "additionalProperties": true,
+                "type": "object"
+              }
+            ],
+            "nullable": true,
+            "title": "Target"
+          },
+          "params": {
+            "additionalProperties": true,
+            "type": "object",
+            "title": "Params"
+          }
+        },
+        "additionalProperties": false,
+        "type": "object",
+        "required": [
+          "connector_id",
+          "op_id"
+        ],
+        "title": "PreviewOperationBody",
+        "description": "Request body for the ``POST /api/v1/operations/preview`` route.\n\nSame field shape as :class:`CallOperationBody` (#1683) -- a preview\nresolves the *same* op + target + params a real ``call_operation``\nwould, then returns the literal would-be HTTP request instead of\nsending it. Keeping the body identical means an operator who hit a\nwrite 4xx can re-issue the exact arguments against ``/preview`` to see\nwhat was put on the wire (the audit row persists only a hashed\n``params_hash``, so the request shape is otherwise unrecoverable).\n\n``target`` accepts the same three shapes as ``call_operation`` (bare\nstring, dict ``{\"name\": ...}``, or ``None``); see\n:class:`CallOperationBody` for the convention. ``extra=\"forbid\"`` keeps\na typo in ``connector_id`` failing loud rather than silently previewing\nnothing."
       },
       "PromoteBody": {
         "properties": {

--- a/cli/internal/api/client.gen.go
+++ b/cli/internal/api/client.gen.go
@@ -3118,6 +3118,39 @@ type PreambleInclusion struct {
 	WouldDropSlugs []string `json:"would_drop_slugs"`
 }
 
+// PreviewOperationBody Request body for the “POST /api/v1/operations/preview“ route.
+//
+// Same field shape as :class:`CallOperationBody` (#1683) -- a preview
+// resolves the *same* op + target + params a real “call_operation“
+// would, then returns the literal would-be HTTP request instead of
+// sending it. Keeping the body identical means an operator who hit a
+// write 4xx can re-issue the exact arguments against “/preview“ to see
+// what was put on the wire (the audit row persists only a hashed
+// “params_hash“, so the request shape is otherwise unrecoverable).
+//
+// “target“ accepts the same three shapes as “call_operation“ (bare
+// string, dict “{"name": ...}“, or “None“); see
+// :class:`CallOperationBody` for the convention. “extra="forbid"“ keeps
+// a typo in “connector_id“ failing loud rather than silently previewing
+// nothing.
+type PreviewOperationBody struct {
+	ConnectorId string                       `json:"connector_id"`
+	OpId        string                       `json:"op_id"`
+	Params      *map[string]interface{}      `json:"params,omitempty"`
+	Target      *PreviewOperationBody_Target `json:"target"`
+}
+
+// PreviewOperationBodyTarget0 defines model for .
+type PreviewOperationBodyTarget0 = string
+
+// PreviewOperationBodyTarget1 defines model for .
+type PreviewOperationBodyTarget1 map[string]interface{}
+
+// PreviewOperationBody_Target defines model for PreviewOperationBody.Target.
+type PreviewOperationBody_Target struct {
+	union json.RawMessage
+}
+
 // PromoteBody POST body for “/api/v1/memory/{scope}/{slug}/promote“.
 //
 // G5.2-T4 (#626) of Initiative #374. Two required-ish fields plus a
@@ -5435,6 +5468,11 @@ type GetGroupsApiV1OperationsGroupsGetParams struct {
 	Authorization *string `json:"authorization,omitempty"`
 }
 
+// PostPreviewApiV1OperationsPreviewPostParams defines parameters for PostPreviewApiV1OperationsPreviewPost.
+type PostPreviewApiV1OperationsPreviewPostParams struct {
+	Authorization *string `json:"authorization,omitempty"`
+}
+
 // GetSearchApiV1OperationsSearchGetParams defines parameters for GetSearchApiV1OperationsSearchGet.
 type GetSearchApiV1OperationsSearchGetParams struct {
 	// ConnectorId Connector implementation id in `<impl_id>-<version>` form — e.g. `vmware-rest-9.0`, `vault-1.x`, `k8s-1.x`. NOT the bare product name (`vault`, `vmware`): a bare product slug names no connector and returns 404. Discover valid ids via `GET /api/v1/connectors`.
@@ -5914,6 +5952,9 @@ type PromoteApiV1MemoryScopeSlugPromotePostJSONRequestBody = PromoteBody
 
 // PostCallApiV1OperationsCallPostJSONRequestBody defines body for PostCallApiV1OperationsCallPost for application/json ContentType.
 type PostCallApiV1OperationsCallPostJSONRequestBody = CallOperationBody
+
+// PostPreviewApiV1OperationsPreviewPostJSONRequestBody defines body for PostPreviewApiV1OperationsPreviewPost for application/json ContentType.
+type PostPreviewApiV1OperationsPreviewPostJSONRequestBody = PreviewOperationBody
 
 // RetrieveEndpointApiV1RetrievePostJSONRequestBody defines body for RetrieveEndpointApiV1RetrievePost for application/json ContentType.
 type RetrieveEndpointApiV1RetrievePostJSONRequestBody = RetrieveRequest
@@ -6512,6 +6553,68 @@ func (t *OperationCallStep_Verify) UnmarshalJSON(b []byte) error {
 	return err
 }
 
+// AsPreviewOperationBodyTarget0 returns the union data inside the PreviewOperationBody_Target as a PreviewOperationBodyTarget0
+func (t PreviewOperationBody_Target) AsPreviewOperationBodyTarget0() (PreviewOperationBodyTarget0, error) {
+	var body PreviewOperationBodyTarget0
+	err := json.Unmarshal(t.union, &body)
+	return body, err
+}
+
+// FromPreviewOperationBodyTarget0 overwrites any union data inside the PreviewOperationBody_Target as the provided PreviewOperationBodyTarget0
+func (t *PreviewOperationBody_Target) FromPreviewOperationBodyTarget0(v PreviewOperationBodyTarget0) error {
+	b, err := json.Marshal(v)
+	t.union = b
+	return err
+}
+
+// MergePreviewOperationBodyTarget0 performs a merge with any union data inside the PreviewOperationBody_Target, using the provided PreviewOperationBodyTarget0
+func (t *PreviewOperationBody_Target) MergePreviewOperationBodyTarget0(v PreviewOperationBodyTarget0) error {
+	b, err := json.Marshal(v)
+	if err != nil {
+		return err
+	}
+
+	merged, err := runtime.JSONMerge(t.union, b)
+	t.union = merged
+	return err
+}
+
+// AsPreviewOperationBodyTarget1 returns the union data inside the PreviewOperationBody_Target as a PreviewOperationBodyTarget1
+func (t PreviewOperationBody_Target) AsPreviewOperationBodyTarget1() (PreviewOperationBodyTarget1, error) {
+	var body PreviewOperationBodyTarget1
+	err := json.Unmarshal(t.union, &body)
+	return body, err
+}
+
+// FromPreviewOperationBodyTarget1 overwrites any union data inside the PreviewOperationBody_Target as the provided PreviewOperationBodyTarget1
+func (t *PreviewOperationBody_Target) FromPreviewOperationBodyTarget1(v PreviewOperationBodyTarget1) error {
+	b, err := json.Marshal(v)
+	t.union = b
+	return err
+}
+
+// MergePreviewOperationBodyTarget1 performs a merge with any union data inside the PreviewOperationBody_Target, using the provided PreviewOperationBodyTarget1
+func (t *PreviewOperationBody_Target) MergePreviewOperationBodyTarget1(v PreviewOperationBodyTarget1) error {
+	b, err := json.Marshal(v)
+	if err != nil {
+		return err
+	}
+
+	merged, err := runtime.JSONMerge(t.union, b)
+	t.union = merged
+	return err
+}
+
+func (t PreviewOperationBody_Target) MarshalJSON() ([]byte, error) {
+	b, err := t.union.MarshalJSON()
+	return b, err
+}
+
+func (t *PreviewOperationBody_Target) UnmarshalJSON(b []byte) error {
+	err := t.union.UnmarshalJSON(b)
+	return err
+}
+
 // AsOperationCallStep returns the union data inside the RunbookTemplateBody_Steps_Item as a OperationCallStep
 func (t RunbookTemplateBody_Steps_Item) AsOperationCallStep() (OperationCallStep, error) {
 	var body OperationCallStep
@@ -7066,6 +7169,11 @@ type ClientInterface interface {
 
 	// GetGroupsApiV1OperationsGroupsGet request
 	GetGroupsApiV1OperationsGroupsGet(ctx context.Context, params *GetGroupsApiV1OperationsGroupsGetParams, reqEditors ...RequestEditorFn) (*http.Response, error)
+
+	// PostPreviewApiV1OperationsPreviewPostWithBody request with any body
+	PostPreviewApiV1OperationsPreviewPostWithBody(ctx context.Context, params *PostPreviewApiV1OperationsPreviewPostParams, contentType string, body io.Reader, reqEditors ...RequestEditorFn) (*http.Response, error)
+
+	PostPreviewApiV1OperationsPreviewPost(ctx context.Context, params *PostPreviewApiV1OperationsPreviewPostParams, body PostPreviewApiV1OperationsPreviewPostJSONRequestBody, reqEditors ...RequestEditorFn) (*http.Response, error)
 
 	// GetSearchApiV1OperationsSearchGet request
 	GetSearchApiV1OperationsSearchGet(ctx context.Context, params *GetSearchApiV1OperationsSearchGetParams, reqEditors ...RequestEditorFn) (*http.Response, error)
@@ -8496,6 +8604,30 @@ func (c *Client) PostCallApiV1OperationsCallPost(ctx context.Context, params *Po
 
 func (c *Client) GetGroupsApiV1OperationsGroupsGet(ctx context.Context, params *GetGroupsApiV1OperationsGroupsGetParams, reqEditors ...RequestEditorFn) (*http.Response, error) {
 	req, err := NewGetGroupsApiV1OperationsGroupsGetRequest(c.Server, params)
+	if err != nil {
+		return nil, err
+	}
+	req = req.WithContext(ctx)
+	if err := c.applyEditors(ctx, req, reqEditors); err != nil {
+		return nil, err
+	}
+	return c.Client.Do(req)
+}
+
+func (c *Client) PostPreviewApiV1OperationsPreviewPostWithBody(ctx context.Context, params *PostPreviewApiV1OperationsPreviewPostParams, contentType string, body io.Reader, reqEditors ...RequestEditorFn) (*http.Response, error) {
+	req, err := NewPostPreviewApiV1OperationsPreviewPostRequestWithBody(c.Server, params, contentType, body)
+	if err != nil {
+		return nil, err
+	}
+	req = req.WithContext(ctx)
+	if err := c.applyEditors(ctx, req, reqEditors); err != nil {
+		return nil, err
+	}
+	return c.Client.Do(req)
+}
+
+func (c *Client) PostPreviewApiV1OperationsPreviewPost(ctx context.Context, params *PostPreviewApiV1OperationsPreviewPostParams, body PostPreviewApiV1OperationsPreviewPostJSONRequestBody, reqEditors ...RequestEditorFn) (*http.Response, error) {
+	req, err := NewPostPreviewApiV1OperationsPreviewPostRequest(c.Server, params, body)
 	if err != nil {
 		return nil, err
 	}
@@ -14239,6 +14371,61 @@ func NewGetGroupsApiV1OperationsGroupsGetRequest(server string, params *GetGroup
 	if err != nil {
 		return nil, err
 	}
+
+	if params != nil {
+
+		if params.Authorization != nil {
+			var headerParam0 string
+
+			headerParam0, err = runtime.StyleParamWithLocation("simple", false, "authorization", runtime.ParamLocationHeader, *params.Authorization)
+			if err != nil {
+				return nil, err
+			}
+
+			req.Header.Set("authorization", headerParam0)
+		}
+
+	}
+
+	return req, nil
+}
+
+// NewPostPreviewApiV1OperationsPreviewPostRequest calls the generic PostPreviewApiV1OperationsPreviewPost builder with application/json body
+func NewPostPreviewApiV1OperationsPreviewPostRequest(server string, params *PostPreviewApiV1OperationsPreviewPostParams, body PostPreviewApiV1OperationsPreviewPostJSONRequestBody) (*http.Request, error) {
+	var bodyReader io.Reader
+	buf, err := json.Marshal(body)
+	if err != nil {
+		return nil, err
+	}
+	bodyReader = bytes.NewReader(buf)
+	return NewPostPreviewApiV1OperationsPreviewPostRequestWithBody(server, params, "application/json", bodyReader)
+}
+
+// NewPostPreviewApiV1OperationsPreviewPostRequestWithBody generates requests for PostPreviewApiV1OperationsPreviewPost with any type of body
+func NewPostPreviewApiV1OperationsPreviewPostRequestWithBody(server string, params *PostPreviewApiV1OperationsPreviewPostParams, contentType string, body io.Reader) (*http.Request, error) {
+	var err error
+
+	serverURL, err := url.Parse(server)
+	if err != nil {
+		return nil, err
+	}
+
+	operationPath := fmt.Sprintf("/api/v1/operations/preview")
+	if operationPath[0] == '/' {
+		operationPath = "." + operationPath
+	}
+
+	queryURL, err := serverURL.Parse(operationPath)
+	if err != nil {
+		return nil, err
+	}
+
+	req, err := http.NewRequest("POST", queryURL.String(), body)
+	if err != nil {
+		return nil, err
+	}
+
+	req.Header.Add("Content-Type", contentType)
 
 	if params != nil {
 
@@ -20646,6 +20833,11 @@ type ClientWithResponsesInterface interface {
 	// GetGroupsApiV1OperationsGroupsGetWithResponse request
 	GetGroupsApiV1OperationsGroupsGetWithResponse(ctx context.Context, params *GetGroupsApiV1OperationsGroupsGetParams, reqEditors ...RequestEditorFn) (*GetGroupsApiV1OperationsGroupsGetResponse, error)
 
+	// PostPreviewApiV1OperationsPreviewPostWithBodyWithResponse request with any body
+	PostPreviewApiV1OperationsPreviewPostWithBodyWithResponse(ctx context.Context, params *PostPreviewApiV1OperationsPreviewPostParams, contentType string, body io.Reader, reqEditors ...RequestEditorFn) (*PostPreviewApiV1OperationsPreviewPostResponse, error)
+
+	PostPreviewApiV1OperationsPreviewPostWithResponse(ctx context.Context, params *PostPreviewApiV1OperationsPreviewPostParams, body PostPreviewApiV1OperationsPreviewPostJSONRequestBody, reqEditors ...RequestEditorFn) (*PostPreviewApiV1OperationsPreviewPostResponse, error)
+
 	// GetSearchApiV1OperationsSearchGetWithResponse request
 	GetSearchApiV1OperationsSearchGetWithResponse(ctx context.Context, params *GetSearchApiV1OperationsSearchGetParams, reqEditors ...RequestEditorFn) (*GetSearchApiV1OperationsSearchGetResponse, error)
 
@@ -22532,6 +22724,29 @@ func (r GetGroupsApiV1OperationsGroupsGetResponse) Status() string {
 
 // StatusCode returns HTTPResponse.StatusCode
 func (r GetGroupsApiV1OperationsGroupsGetResponse) StatusCode() int {
+	if r.HTTPResponse != nil {
+		return r.HTTPResponse.StatusCode
+	}
+	return 0
+}
+
+type PostPreviewApiV1OperationsPreviewPostResponse struct {
+	Body         []byte
+	HTTPResponse *http.Response
+	JSON200      *map[string]interface{}
+	JSON422      *HTTPValidationError
+}
+
+// Status returns HTTPResponse.Status
+func (r PostPreviewApiV1OperationsPreviewPostResponse) Status() string {
+	if r.HTTPResponse != nil {
+		return r.HTTPResponse.Status
+	}
+	return http.StatusText(0)
+}
+
+// StatusCode returns HTTPResponse.StatusCode
+func (r PostPreviewApiV1OperationsPreviewPostResponse) StatusCode() int {
 	if r.HTTPResponse != nil {
 		return r.HTTPResponse.StatusCode
 	}
@@ -25571,6 +25786,23 @@ func (c *ClientWithResponses) GetGroupsApiV1OperationsGroupsGetWithResponse(ctx 
 		return nil, err
 	}
 	return ParseGetGroupsApiV1OperationsGroupsGetResponse(rsp)
+}
+
+// PostPreviewApiV1OperationsPreviewPostWithBodyWithResponse request with arbitrary body returning *PostPreviewApiV1OperationsPreviewPostResponse
+func (c *ClientWithResponses) PostPreviewApiV1OperationsPreviewPostWithBodyWithResponse(ctx context.Context, params *PostPreviewApiV1OperationsPreviewPostParams, contentType string, body io.Reader, reqEditors ...RequestEditorFn) (*PostPreviewApiV1OperationsPreviewPostResponse, error) {
+	rsp, err := c.PostPreviewApiV1OperationsPreviewPostWithBody(ctx, params, contentType, body, reqEditors...)
+	if err != nil {
+		return nil, err
+	}
+	return ParsePostPreviewApiV1OperationsPreviewPostResponse(rsp)
+}
+
+func (c *ClientWithResponses) PostPreviewApiV1OperationsPreviewPostWithResponse(ctx context.Context, params *PostPreviewApiV1OperationsPreviewPostParams, body PostPreviewApiV1OperationsPreviewPostJSONRequestBody, reqEditors ...RequestEditorFn) (*PostPreviewApiV1OperationsPreviewPostResponse, error) {
+	rsp, err := c.PostPreviewApiV1OperationsPreviewPost(ctx, params, body, reqEditors...)
+	if err != nil {
+		return nil, err
+	}
+	return ParsePostPreviewApiV1OperationsPreviewPostResponse(rsp)
 }
 
 // GetSearchApiV1OperationsSearchGetWithResponse request returning *GetSearchApiV1OperationsSearchGetResponse
@@ -28872,6 +29104,39 @@ func ParseGetGroupsApiV1OperationsGroupsGetResponse(rsp *http.Response) (*GetGro
 	}
 
 	response := &GetGroupsApiV1OperationsGroupsGetResponse{
+		Body:         bodyBytes,
+		HTTPResponse: rsp,
+	}
+
+	switch {
+	case strings.Contains(rsp.Header.Get("Content-Type"), "json") && rsp.StatusCode == 200:
+		var dest map[string]interface{}
+		if err := json.Unmarshal(bodyBytes, &dest); err != nil {
+			return nil, err
+		}
+		response.JSON200 = &dest
+
+	case strings.Contains(rsp.Header.Get("Content-Type"), "json") && rsp.StatusCode == 422:
+		var dest HTTPValidationError
+		if err := json.Unmarshal(bodyBytes, &dest); err != nil {
+			return nil, err
+		}
+		response.JSON422 = &dest
+
+	}
+
+	return response, nil
+}
+
+// ParsePostPreviewApiV1OperationsPreviewPostResponse parses an HTTP response from a PostPreviewApiV1OperationsPreviewPostWithResponse call
+func ParsePostPreviewApiV1OperationsPreviewPostResponse(rsp *http.Response) (*PostPreviewApiV1OperationsPreviewPostResponse, error) {
+	bodyBytes, err := io.ReadAll(rsp.Body)
+	defer func() { _ = rsp.Body.Close() }()
+	if err != nil {
+		return nil, err
+	}
+
+	response := &PostPreviewApiV1OperationsPreviewPostResponse{
 		Body:         bodyBytes,
 		HTTPResponse: rsp,
 	}

--- a/docs/codebase/dispatch-request-preview.md
+++ b/docs/codebase/dispatch-request-preview.md
@@ -1,0 +1,191 @@
+# Dispatch request preview (read-only would-be HTTP request)
+
+**Initiative:** #1666 — G0.24 v0.13.0 log-sentry extended dogfood hardening
+**Task:** #1683 — expose the literal would-be HTTP request for a dispatch
+**Consumer signal:** `claude-rdc-hetzner-dc#1138`
+
+## Overview
+
+When an ingested-L2 **write** dispatch fails upstream (a gh-rest `422`
+validation failure, a `403` scope rejection), an operator needs to read
+back *what meho actually put on the wire* to diagnose it. They cannot get
+that from the audit trail: the operation audit persists only a **hashed**
+`params_hash`, never the resolved method / path / body. The hash is an
+intentional privacy + row-size choice — full args may carry secrets, and
+the read-broadcast safety note in `mcp/tools/docs.py` depends on the raw
+query never reaching the feed. During the #1656 dogfood the consumer had
+to "bisect payload shapes from the outside" to discover the request body
+was being sent wrapped (`{"body": {...}}`), because nothing inside meho
+exposed the constructed request.
+
+The **dispatch request preview** closes that gap with the lowest-friction
+shape consistent with the dumb-substrate posture: a read-only path that
+resolves an op + params to the literal request and **returns** it —
+`{method, resolved_path, query, redacted_body}` — instead of sending it.
+It is the observability counterpart to the two functional siblings in the
+same Initiative:
+
+- **#1656** (T5) — unwrap the ingested requestBody container on the wire
+  (the bug whose payload shape this surface now makes visible).
+- **#1649** (T4) — map upstream `403` / `422` to a structured connector
+  error with actionable detail.
+
+This surface is **request-time observability, not a new persisted-secret
+surface**: nothing is written to the audit row, the `params_hash` design
+is untouched, and the body is redacted through the **same**
+connector-boundary pipeline the response path uses.
+
+## Scope
+
+In scope: the literal would-be request for an `source_kind='ingested'`
+op, redacted, returned without sending.
+
+Out of scope (honouring #1683's dispositions):
+
+- **No persisting the raw body.** `params_hash` stays the audit field.
+- **No replay.** Inspecting a *would-be* request only; re-dispatching a
+  past audited request is a separate governance concern (Goal #1651).
+- **Non-ingested ops.** A `typed` / `composite` op runs a Python handler
+  (which may make zero or many HTTP calls) and has no single literal HTTP
+  request — the preview returns `status="unavailable"` rather than
+  fabricating one.
+- **Error-echo on the dispatch path** is deferred (see Known issues).
+
+## Key types
+
+- `meho_backplane.operations._branches.IngestedRequest` — a frozen
+  dataclass holding the four artefacts a `source_kind='ingested'`
+  dispatch puts on the wire: `method`, `path` (placeholders substituted
+  *and* the connector's `mount_op_path` prefix applied), `query`
+  (the httpx `params=` value, or `None`), and `body` (the **raw**,
+  unwrapped JSON request body, or `None`).
+- `meho_backplane.operations._branches.resolve_ingested_request(...)` —
+  the single source of truth for "what method/path/query/body does an
+  ingested dispatch send". Shared verbatim by `dispatch_ingested` (which
+  then *sends* it) and the preview (which *returns* it), so the previewed
+  request can never drift from the real one.
+- `meho_backplane.operations._request_preview.preview_dispatch(...)` —
+  the read-only orchestration. Mirrors `dispatch`'s Steps 1–3 (parse
+  connector id, look up descriptor, validate params) and Step 5 (resolve
+  connector instance), then resolves the literal request and redacts the
+  body. Returns a structured envelope; never sends, never audits, never
+  parks.
+- `meho_backplane.operations.meta_tools.preview_operation(...)` /
+  `PreviewOperationBody` — the shared meta-tool funnel both transports
+  call. Same `{connector_id, op_id, target, params}` argument shape as
+  `call_operation` (so an operator re-issues the exact failed arguments).
+
+## Control flow
+
+```text
+preview_operation(operator, {connector_id, op_id, target, params})
+        │  (REST POST /api/v1/operations/preview, MCP preview_operation)
+        ▼
+resolve target by name (resolve_target) — in-memory fqdn override only;
+        │  NO audit_target_id contextvar bind (no audit row to enrich)
+        ▼
+preview_dispatch(operator, connector_id, op_id, target, params)
+        │
+        ├─ parse_connector_id → (product, version, impl_id)
+        ├─ lookup_descriptor → None ? → status=error error_code=unknown_op
+        ├─ source_kind != 'ingested' ? → status=unavailable (not_ingested)
+        ├─ validate_params → errors ? → status=error error_code=invalid_params
+        ├─ resolve_connector_or_label → label ? → status=error (no_connector /
+        │       ambiguous_connector)
+        ├─ get_or_create_connector_instance(cls)   (cached singleton)
+        ├─ resolve_ingested_request(...)   ◄── SAME resolver dispatch_ingested uses
+        │       → IngestedRequest{method, path, query, body}
+        └─ body is not None ?
+               → apply_connector_boundary_redaction(body, connector_id,
+                     tenant, op).redacted   ◄── SAME pipeline the response path uses
+        ▼
+{status: ok, op_id, connector_id, source_kind, method,
+ resolved_path, query, redacted_body}
+```
+
+The HTTP transport (`HttpConnector._post_json` / `_request_json`) is
+**never** called: there is no network egress, no audit row, no broadcast
+event, no policy-gate park. The policy gate (dispatch Step 4) is
+deliberately skipped — a preview reveals only what *would* be sent (and
+the body is redacted), so it carries no side effect to authorize, the
+same posture as `search_operations` over the same descriptors. Both
+surfaces stay `OPERATOR`-gated at the route / tool layer.
+
+## Envelope shape
+
+| `status` | meaning | extra fields |
+|---|---|---|
+| `ok` | request resolved | `method`, `resolved_path`, `query` (object/null), `redacted_body` (object/null), `source_kind` |
+| `error` | structured failure | `error` (`"<code>: …"`), `extras.error_code` (`unknown_op` / `invalid_params` / `no_connector` / `ambiguous_connector`) + per-code detail |
+| `unavailable` | not an HTTP-ingested op | `source_kind`, `extras.error_code=preview_unavailable`, `extras.reason=not_ingested` |
+
+Operator-input faults come back **inside** the envelope (not as
+exceptions), mirroring the dispatcher's never-raises contract so the REST
+route and MCP tool keep one uniform shape. The only exception the
+meta-tool raises is the missing-`target.name` `ValueError`, which the
+route maps to a `400` (identical to `/call`).
+
+## Redaction
+
+The body is redacted through `apply_connector_boundary_redaction(body,
+connector_id=..., tenant=..., op=...)` — the exact seam
+`dispatcher._apply_redaction_middleware` calls on the connector response.
+It resolves the per-`(connector_id, tenant, op)` `RedactionPolicy`
+(falling through to the conservative default) and runs the Tier-1 engine
+(plus Tier-2 Presidio when the policy carries a `tier2` block). A body
+value the redactor masks in a real response is masked identically in the
+preview — no new raw-secret surface.
+
+Note the engine matches on the **string value shape** (a bearer token /
+JWT / labelled-credential string in a leaf value), not on the dict key
+name: a bare `{"password": "…"}` field is not masked by the default
+policy unless its *value* matches a named pattern; a `{"upstream_auth":
+"Bearer eyJ…"}` value is. See `docs/codebase/redaction.md` for the
+named-pattern catalogue and policy resolution.
+
+## Surfaces
+
+- **REST:** `POST /api/v1/operations/preview` (`OPERATOR`), body
+  `PreviewOperationBody` (same fields as `CallOperationBody`).
+- **MCP:** the `preview_operation` tool (`op_class="read"` — a read-only
+  inspection, unlike `call_operation`'s `"tool_call"` envelope).
+- **CLI:** regenerated from the OpenAPI snapshot (`cd cli && make
+  snapshot-openapi && make generate`).
+
+## Dependencies
+
+- `operations._branches` — the shared request resolver.
+- `operations._lookup` — `parse_connector_id`, `lookup_descriptor`,
+  `count_known_ops`.
+- `operations._validate` — `validate_params`.
+- `operations._handler_resolve` — `get_or_create_connector_instance`.
+- `connectors.resolve_connector_or_label` — the same yes/no/ambiguous
+  connector resolution the dispatcher and the target-probe route use.
+- `redaction.apply_connector_boundary_redaction` — the connector-boundary
+  pipeline.
+
+## Known issues / deferred
+
+- **Error-echo on the dispatch error path is deferred.** #1683's AC4 made
+  attaching the redacted request to a 4xx dispatch error's `extras`
+  optional ("otherwise explicitly note it deferred"). The dedicated
+  read-only preview is the keystone diagnosis surface and is sufficient
+  to recover the wire shape; threading the constructed request out of
+  `dispatch_ingested` through the exception unwind into the error result
+  is a larger, riskier change for marginal benefit (an operator who hit a
+  4xx re-issues the same args against `/preview`). It is recorded here as
+  a possible follow-up rather than shipped in this change.
+- The preview covers `source_kind='ingested'` only; previewing the
+  *effective* request a composite handler would synthesize per sub-op is
+  out of scope (composites already carry the park-time `proposed_effect`
+  semantic preview, #1608 / #1628).
+
+## References
+
+- Task #1683; Initiative #1666 (G0.24); Goal #221.
+- Siblings: #1656 (requestBody unwrap), #1649 (structured `403`/`422`).
+- Prior art: the park-time `proposed_effect` preview
+  (`operations/_preview.py`, #1437 / #1504 / #1628).
+- `docs/codebase/redaction.md` — the redaction pipeline this reuses.
+- `docs/codebase/error-message-shape.md` — the structured-error
+  convention the `error` strings follow.


### PR DESCRIPTION
## Summary

- Adds a **read-only dispatch request preview** that resolves an ingested op + params to the literal would-be HTTP request — `{method, resolved_path, query, redacted_body}` — and **returns** it instead of dispatching. It makes an ingested-L2 write failure self-diagnosable from the inside: the operation audit persists only a hashed `params_hash` (an intentional privacy choice), so until now an operator who hit a gh-rest write `422`/`403` had to "bisect payload shapes from the outside" (`claude-rdc-hetzner-dc#1138`). The observability counterpart to #1656 (requestBody unwrap) and #1649 (structured 4xx error shape) under Initiative #1666.
- The literal request is resolved through the **same** code path `dispatch_ingested` sends through — extracted `resolve_ingested_request()` in `_branches.py` (path substitution, `mount_op_path` prefix, requestBody unwrap), used verbatim by both the real dispatch and the preview, so the previewed request can never drift from the wire.
- The body is redacted through the **same** connector-boundary pipeline (`apply_connector_boundary_redaction`) the response path uses, so this is request-time observability, **not** a new persisted-secret surface: nothing is written to the audit row, and the `params_hash` design is untouched.
- Surfaces: `POST /api/v1/operations/preview` (REST, `OPERATOR`), the `preview_operation` MCP tool (`op_class="read"`), and the regenerated CLI client — all sharing the `preview_operation` meta-tool funnel (same `{connector_id, op_id, target, params}` shape as `call_operation`, so an operator re-issues the exact failed arguments).

## Acceptance criteria

- [x] **Read-only preview resolves op + params → literal request without dispatching.** `preview_dispatch` returns `{method, resolved_path, query, redacted_body}`; the HTTP transport is never called. Unit test `test_preview_gh_issue_create_returns_literal_request_without_dispatching` asserts a gh-rest issue-create preview shows `POST` + `/repos/evoila/meho/issues` + body `{"title": "diagnose me"}` and that the connector's `_post_json` was never reached.
- [x] **Redaction reuses the existing pipeline; a masked field is masked in the preview.** `test_preview_masks_credential_body_field_default_policy` (a bearer token in a body value → `[REDACTED:bearer_token]` under the default-safe policy) + `test_preview_redaction_honours_registered_override` (a per-`connector_id` UUID-only override masks a body UUID while the bearer survives — proving it routes through the same `resolve_policy`-backed engine, not a hard-coded default). Grounding note: the Tier-1 engine matches on the **string value shape**, not the dict key name, so a bare `{"password": …}` field is not masked by the default policy unless its value matches a named pattern; the test uses a bearer-token value accordingly.
- [x] **Persisted audit row unchanged — no raw body stored (regression).** The preview writes **no** `AuditLog` row and publishes **no** broadcast event; asserted in `test_preview_gh_issue_create_…` and `test_preview_operation_meta_tool_resolves_target_by_name` (both check zero audit rows + zero captured events).
- [x] **Error-echo option — explicitly deferred.** AC4 made attaching the redacted request to a 4xx dispatch error's `extras` optional ("otherwise explicitly note it deferred"). The dedicated read-only preview is the keystone diagnosis surface and is sufficient to recover the wire shape; threading the constructed request out of `dispatch_ingested` through the exception unwind is a larger, riskier change for marginal benefit (re-issue the same args against `/preview`). Recorded as a possible follow-up in `docs/codebase/dispatch-request-preview.md` and the test module's AC4 note.
- [x] **OpenAPI snapshot + CLI client regenerated** (a REST surface was added): `cd cli && make snapshot-openapi && make generate` — `cli/api/openapi.json` carries `/api/v1/operations/preview`; `cli/internal/api/client.gen.go` carries `PreviewOperationBody` + `PostPreviewApiV1OperationsPreviewPost`; the CLI builds clean (`go build ./...`).
- [x] **CHANGELOG `[Unreleased]` bullet citing `claude-rdc-hetzner-dc#1138`** added under `### Added`.

## Test plan

- [x] `ruff check src/ tests/` — clean (CI scope; the one pre-existing `alembic/versions/0023` SIM finding is outside the lint scope and untouched here)
- [x] `ruff format --check src/ tests/` — clean
- [x] `mypy src/` — clean (468 files)
- [x] `code-quality.py --diff` — 0 blockers (`preview_dispatch` factored into `_resolve_previewable_descriptor` + `_build_ingested_preview` + `_redact_request_body` to stay under the 100-line cap)
- [x] `pytest tests/test_operations_request_preview.py` — 10 passed (all ACs + scope boundaries: typed-op `unavailable`, `invalid_params`, `unknown_op`, REST/MCP parity, missing-`target.name` → 400, previewed-request-equals-sent-request regression)
- [x] Adjacent regression: `test_operations_connector_http_403` (sibling #1649), `test_operations_dispatcher`, `test_dispatcher_redaction_integration`, `test_operations_meta_tools`, `test_operations_composite`, + a sweep of ingested-dispatch connector tests (vmware-rest / vcf-logs / sddc / argocd / harbor / github-composite) — all green (the `_branches.py` shared-resolver refactor is behaviour-preserving)

## Out of scope

- **Persisting the raw request body** in the audit — `params_hash` stays the audit field (issue Out-of-scope).
- **Replay / re-dispatch** of a past audited request — inspection only; replay is a separate governance concern (Goal #1651).
- **The error-echo on the dispatch error path** — deferred (AC4 above).
- Non-ingested (`typed` / `composite`) ops return `status="unavailable"` rather than fabricating a request; composites already carry the park-time `proposed_effect` semantic preview (#1608 / #1628).

## Adjacent findings (not addressed here)

- `backend/alembic/versions/0023_create_approval_request.py:228` has a pre-existing ruff SIM finding (a `sa.text("'{}'") if is_postgres else sa.text("'{}'")` redundant-branch ternary) — present on `origin/main`, outside CI's `ruff check src/ tests/` scope, untouched.
- `backend/src/meho_backplane/mcp/tools/operations.py` is 646 lines (pre-existing file-size warning; a 4th tool registration nudges it further over the 600 warn — a module split is its own refactor, out of scope here).

<!-- auto-implement-issue: fresh, iteration 1 -->

Closes #1683


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added read-only dispatch request preview capability via `POST /api/v1/operations/preview` REST endpoint and `preview_operation` MCP tool.
  * Users can now preview the literal HTTP request (method, path, query, redacted body) that would be dispatched without actually sending it.
  * Preview unavailable for typed and composite operations.

* **Documentation**
  * Added release notes and codebase documentation for the preview feature.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->