### PR TITLE
docs(changelog): de-stale the #1672 shared-pool note (re-keyed in #1682)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -137,8 +137,9 @@ connector-related release-notes line.
   Hetzner Robot, and vmware-rest (session token + endpoint paths). Two
   same-named targets in different tenants no longer collapse onto one cache
   entry, closing the same cross-tenant credential/session bleed in these
-  connectors. The shared `HttpConnector._clients` connection pool stays keyed
-  on `target.name` (a pooling concern, tracked separately) (#1672).
+  connectors. (The shared `HttpConnector._clients` connection pool was the
+  one remaining `target.name`-keyed cache; it is re-keyed in the following
+  bullet, #1682.) (#1672).
 - Re-keyed the shared connection pools — `HttpConnector._clients`
   (every HTTP connector) and `SshConnector._connections` (bind9, pfSense,
   Holodeck) — on the tenant-unique `(tenant_id, target.id)` tuple


### PR DESCRIPTION
## Summary

Release-prep CHANGELOG cleanup ahead of `v0.14.0`. The `[Unreleased]`
**Security** bullet for the seven-connector cache re-key (#1672) still closed
with:

> The shared `HttpConnector._clients` connection pool stays keyed on
> `target.name` (a pooling concern, tracked separately).

That sentence is now stale: the very next bullet (#1682) re-keyed exactly that
shared pool on the tenant-unique `(tenant_id, target.id)`. Left as-is, the
v0.14.0 release notes would contradict themselves one bullet apart. Reworded to
forward-reference #1682.

Docs-only — no code, no API surface, no behaviour change.

## Note

The two larger items flagged during release triage — #1682 (shared connection
pool re-key) and #1683 (read-only dispatch-request preview) — **already carry
their own complete `[Unreleased]` bullets** on `main`. This PR only fixes the
single stale cross-reference #1682 left behind in the #1672 bullet.

🤖 Generated with [Claude Code](https://claude.com/claude-code)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Clarified changelog entry regarding connector cache behavior.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->