### PR TITLE
docs(changelog): roll [Unreleased] into v0.14.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -90,6 +90,8 @@ connector-related release-notes line.
 
 ## [Unreleased]
 
+## [0.14.0] - 2026-06-12
+
 ### Security
 
 - Closed a cross-tenant IDOR on the scheduler


### PR DESCRIPTION
## Summary

Release-cutting PR for **v0.14.0**. Rolls the `[Unreleased]` CHANGELOG section
under `## [0.14.0] - 2026-06-12` and leaves a fresh empty `[Unreleased]`.
**No bullet content changed** — this is a pure roll (`+2` lines: the version
header).

## Completeness audit (`v0.13.0..main`)

Every PR merged since `v0.13.0` was audited against the `[Unreleased]` bullets:

- **20 substantive PRs — all covered.** The CHANGELOG cites planning-issue
  anchors, so the PR numbers map through their issues (e.g. #1639→#1638,
  #1644→#1640, #1650→#1641, #1665→#1643, #1684→#1682, #1686→#1683).
- **11 routine dependabot bumps** (#1589–1598, #1635) — **intentionally
  omitted**, matching every prior release section (no released version bullets
  dependency bumps). Flagging the decision explicitly rather than skipping
  silently.
- **Nothing post-tag** — every rolled bullet's commit is an ancestor of the
  intended tag commit.

## What ships in v0.14.0 (20 bullets)

- **Security (4)** — the tenant-isolation campaign: cross-tenant IDOR closure
  (#1640), `list_targets` enumeration gate (#1641), the opt-in Vault
  `vault.kv.*` tenant-scope guard (#1643), and credential/session/**connection-pool**
  cross-tenant re-keying (#1642 / #1672 / #1682).
- **Breaking changes (1)** — `PATCH /api/v1/connectors/{id}/operations/{op_id}`
  now returns `200 EditOpResponse` instead of `204` (carries the
  `unreplaced_auto_shim` advisory); migration recipe in the bullet (#1630).
- **Added (5)** — `platform_admin` principal flag, enabled-vs-total operation
  counts, the Vault-unenforced startup advisory, manual-`--spec`
  `spec_info_versions_compatible`, and the read-only dispatch-request preview.
- **Fixed (9)** — the G0.24 log-sentry dogfood seams (#1646/#1647/#1648/#1649/#1656)
  plus connector-error and CLI-shape hardening.

## After merge (release mechanics)

This is the load-bearing step before the tag. Once merged, `v0.14.0` is tagged
on **this PR's merge commit** (explicit SHA, not `HEAD`), which fans out to
`cli-release.yml` / `image.yml` / `chart.yml`.

Two operational notes for the cut (neither blocks it):

- The `image` workflow's red is the **expired `RDC_TOKEN`** post-build
  *repository_dispatch* notify step — **not** the image build (which pushes
  fine). Expect the tag's image run to show the same red; rotate the secret
  separately.
- v0.14.0 ships the **opt-in Vault tenant-scope guard** (#1643/#1673); RDC ops
  to be notified of the guard + recommended per-tenant layout (Initiative
  #1685).

🤖 Generated with [Claude Code](https://claude.com/claude-code)
