### PR TITLE
chore(mcp): defer flat runbook_* alias removal to v0.15.0 — explicit erratum, deadline re-pin (#1702)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -109,10 +109,11 @@ connector-related release-notes line.
   v0.14.0 shipped with all 11 aliases still registered and callable and
   its release notes carried no removal or deferral line, so the
   deadline is moved explicitly rather than slipping silently: the
-  per-call deprecation warnings (`mcp_tool_name_deprecated`,
-  `runbook_template_slug_field_deprecated`) and the DEPRECATED wire
-  descriptions now name v0.15.0, a `### Deprecated` erratum was added
-  to the v0.14.0 section below, and the removal itself stays tracked in
+  `runbook_template_slug_field_deprecated` warning and the DEPRECATED
+  wire descriptions now name v0.15.0 (the per-call
+  `mcp_tool_name_deprecated` breadcrumb stays unversioned — it logs
+  tool + replacement only), a `### Deprecated` erratum was added to
+  the v0.14.0 section below, and the removal itself stays tracked in
   #1625 (re-scheduled to the v0.15.0 cycle). Nothing else changes:
   consumers already on `meho.runbook.<verb>` + `template_slug` are
   unaffected, and the migration recipe is unchanged — replace

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -102,6 +102,23 @@ connector-related release-notes line.
   the registered-row `next_step` rationale now name the right surface
   per scope (#1699).
 
+### Deprecated
+
+- Deferred the removal of the 11 flat `runbook_*` MCP tool-name aliases
+  and the `slug` template-id input alias from v0.14.0 to **v0.15.0**.
+  v0.14.0 shipped with all 11 aliases still registered and callable and
+  its release notes carried no removal or deferral line, so the
+  deadline is moved explicitly rather than slipping silently: the
+  per-call deprecation warnings (`mcp_tool_name_deprecated`,
+  `runbook_template_slug_field_deprecated`) and the DEPRECATED wire
+  descriptions now name v0.15.0, a `### Deprecated` erratum was added
+  to the v0.14.0 section below, and the removal itself stays tracked in
+  #1625 (re-scheduled to the v0.15.0 cycle). Nothing else changes:
+  consumers already on `meho.runbook.<verb>` + `template_slug` are
+  unaffected, and the migration recipe is unchanged — replace
+  `runbook_<verb>` with `meho.runbook.<verb>` and rename `slug` →
+  `template_slug` in template-verb arguments (#1612, #1702).
+
 ### Fixed
 
 - Operator console: broadcast feed/wall and the connectors recent-ops
@@ -272,6 +289,19 @@ connector-related release-notes line.
   spec/label cross-check; omitting the band keeps the strict check, and
   a non-pattern token (a bare `v2`) is rejected at request validation.
   (#1646; consumer signal claude-rdc-hetzner-dc#1136)
+
+### Deprecated
+
+- *Erratum — added 2026-06-12, after the v0.14.0 tag (#1702).* Deferral
+  of flat `runbook_*` alias removal to v0.15.0 (originally scheduled
+  per the #1612 migration recipe announced in v0.13.0; execution
+  deferred to the next release). v0.14.0 ships with the 11 flat
+  `runbook_*` MCP tool names and the `slug` template-id input alias
+  still callable as deprecated aliases; they are removed in v0.15.0,
+  tracked in #1625 (re-scheduled to the v0.15.0 cycle). Consumers who
+  already migrated to `meho.runbook.<verb>` + `template_slug` are
+  unaffected; consumers still on the flat names keep working through
+  v0.14.x and must migrate before v0.15.0.
 
 ### Fixed
 

--- a/backend/src/meho_backplane/mcp/tools/runbook_runs.py
+++ b/backend/src/meho_backplane/mcp/tools/runbook_runs.py
@@ -21,8 +21,9 @@ place (T3, #1308).
 Naming canonicalisation (#1612): the dotted names above are canonical,
 matching the ``meho.<noun>.<verb>`` grammar of every other multi-verb
 family; the original flat ``runbook_*`` names remain registered as
-deprecated aliases (same handler object) for one release and are
-removed in v0.14.0. The run-side wire fields already used the canonical
+deprecated aliases (same handler object) and are removed in v0.15.0 —
+deferred from the original one-release v0.14.0 window by #1702. The
+run-side wire fields already used the canonical
 ``template_slug`` name, so only the template-side module needed the
 field shim.
 
@@ -154,10 +155,12 @@ _DEFAULT_LIST_LIMIT: Final[int] = 100
 _MAX_LIST_LIMIT: Final[int] = 500
 
 #: Release that drops the deprecated flat ``runbook_*`` tool-name
-#: aliases (#1612). Must stay in lockstep with the template-side
-#: constant in :mod:`meho_backplane.mcp.tools.runbooks` — the 11 aliases
-#: are announced and removed as one set.
-_ALIAS_REMOVAL_VERSION: Final[str] = "0.14.0"
+#: aliases (#1612); deferred from the original v0.14.0 window by #1702
+#: after v0.14.0 was tagged with the aliases still registered. Must
+#: stay in lockstep with the template-side constant in
+#: :mod:`meho_backplane.mcp.tools.runbooks` — the 11 aliases are
+#: announced and removed as one set.
+_ALIAS_REMOVAL_VERSION: Final[str] = "0.15.0"
 
 
 def _to_invalid_params(tool: str, exc: Exception) -> McpInvalidParamsError:
@@ -691,8 +694,9 @@ register_mcp_tool(
 
 
 # ---------------------------------------------------------------------------
-# Deprecated flat-name aliases (#1612) — one release, removed in
-# v0.14.0 (`_ALIAS_REMOVAL_VERSION`). Registered strictly after their
+# Deprecated flat-name aliases (#1612) — removed in v0.15.0
+# (`_ALIAS_REMOVAL_VERSION`; deferred from the original one-release
+# v0.14.0 window by #1702). Registered strictly after their
 # canonical targets; each shares the canonical handler object and
 # schema, differing only in name + DEPRECATED pointer description.
 # ---------------------------------------------------------------------------

--- a/backend/src/meho_backplane/mcp/tools/runbooks.py
+++ b/backend/src/meho_backplane/mcp/tools/runbooks.py
@@ -17,9 +17,9 @@ The canonical tool names are dotted — ``meho.runbook.draft_template``,
 ``meho.runbook.show_template``, … — matching the ``meho.<noun>.<verb>``
 grammar every other multi-verb family on the surface uses. The original
 flat ``runbook_*`` names remain registered as deprecated aliases (same
-handler object, same schema) for one release and are removed in
-v0.14.0; calling one emits the dispatcher's ``mcp_tool_name_deprecated``
-warning.
+handler object, same schema) and are removed in v0.15.0 — deferred from
+the original one-release v0.14.0 window by #1702; calling one emits the
+dispatcher's ``mcp_tool_name_deprecated`` warning.
 
 The template identifier is canonically ``template_slug`` on every wire
 input (matching ``meho.runbook.start`` / ``meho.runbook.list_runs`` on
@@ -124,10 +124,16 @@ _OP_CLASS_READ: Final[str] = "read"
 _OP_CLASS_WRITE: Final[str] = "write"
 
 #: Release that drops the deprecated flat ``runbook_*`` tool-name
-#: aliases and the ``slug`` input-field alias (#1612). One release after
-#: the canonicalisation ships (announced in the CHANGELOG ``Deprecated``
-#: section), mirroring the v0.6.x ``content``→``body`` one-cycle shim.
-_ALIAS_REMOVAL_VERSION: Final[str] = "0.14.0"
+#: aliases and the ``slug`` input-field alias (#1612). Originally one
+#: release after the canonicalisation shipped (v0.14.0, mirroring the
+#: v0.6.x ``content``→``body`` one-cycle shim), but v0.14.0 was tagged
+#: with the aliases still registered and no release-notes line, so
+#: #1702 re-pinned the deadline to v0.15.0 with a public deferral
+#: erratum on the v0.14.0 CHANGELOG section. The value is description/
+#: warning text only — removal is executed by the scheduled task
+#: (#1625, re-scheduled to the v0.15.0 cycle), not by a runtime
+#: version gate (``__version__`` is build-metadata-dependent; #1698).
+_ALIAS_REMOVAL_VERSION: Final[str] = "0.15.0"
 
 #: The caller-actionable service exceptions that map to JSON-RPC
 #: ``-32602``. Bad input or a missing / wrong-state entity is the
@@ -169,8 +175,8 @@ def _resolve_template_slug(tool: str, arguments: dict[str, Any]) -> str:
     on ``add_to_memory``: exactly one of the two names must be supplied
     (both → ``-32602``), and the deprecated name emits a structured
     ``runbook_template_slug_field_deprecated`` warning so operators can
-    watch consumers migrate before the alias is dropped in
-    v0.14.0 (:data:`_ALIAS_REMOVAL_VERSION`).
+    watch consumers migrate before the alias is dropped in v0.15.0
+    (:data:`_ALIAS_REMOVAL_VERSION`; deferred from v0.14.0 by #1702).
 
     The dispatcher's JSON-Schema gate (:data:`_TEMPLATE_SLUG_ANYOF`)
     guarantees at least one name is present; the neither-supplied branch
@@ -206,8 +212,8 @@ def _mirror_template_slug(payload: dict[str, Any]) -> dict[str, Any]:
     REST surface is out of #1612's scope), so the MCP handlers mirror it
     at the wire boundary: every template-verb response carries
     ``template_slug`` (canonical, what ``meho.runbook.start`` accepts
-    verbatim) *and* ``slug`` (kept for the same one-release window as
-    the input alias, dropped with it in v0.14.0). Top-level only — the
+    verbatim) *and* ``slug`` (kept for the same alias window as the
+    input alias, dropped with it in v0.15.0 per #1702). Top-level only — the
     nested ``forked_from.slug`` names the fork *source* and is not a
     round-trip input.
     """
@@ -836,8 +842,9 @@ register_mcp_tool(
 
 
 # ---------------------------------------------------------------------------
-# Deprecated flat-name aliases (#1612) — one release, removed in
-# v0.14.0 (`_ALIAS_REMOVAL_VERSION`). Registered strictly after their
+# Deprecated flat-name aliases (#1612) — removed in v0.15.0
+# (`_ALIAS_REMOVAL_VERSION`; deferred from the original one-release
+# v0.14.0 window by #1702). Registered strictly after their
 # canonical targets; each shares the canonical handler object and
 # schema, differing only in name + DEPRECATED pointer description.
 # ---------------------------------------------------------------------------

--- a/backend/tests/test_mcp_tools_list_shape_conventions.py
+++ b/backend/tests/test_mcp_tools_list_shape_conventions.py
@@ -429,8 +429,9 @@ def test_runbook_tools_dotted_canonical_with_flat_deprecated_alias(
 
     The runbook family was the last flat multi-verb family on the
     surface (#1612). The dotted name is canonical; the flat name stays
-    registered as a deprecated alias routed to the same handler for one
-    release (removed in v0.14.0).
+    registered as a deprecated alias routed to the same handler
+    (removed in v0.15.0 — deferred from the original one-release
+    v0.14.0 window by #1702).
     """
     dotted_entry = mcp_registry.get_tool(dotted_name)
     flat_entry = mcp_registry.get_tool(flat_name)

--- a/docs/architecture/runbooks.md
+++ b/docs/architecture/runbooks.md
@@ -29,7 +29,7 @@ meho.runbook.reassign(run_id, new_assignee) -> {run_id, assigned_to, reassigned_
 
 The six template-lifecycle tools (`meho.runbook.draft_template` / `.edit_template` / `.publish_template` / `.deprecate_template` / `.list_templates` / `.show_template`) live on the same MCP surface from G12.2 and are documented in the authoring counterpart.
 
-The dotted names are canonical as of #1612; the original flat `runbook_*` names remain callable as deprecated aliases for one release (removed in v0.14.0), and the template id is `template_slug` on every tool (`slug` accepted as a deprecated alias on the template verbs for the same window). See [`docs/codebase/mcp.md`](../codebase/mcp.md) §Tool naming grammar.
+The dotted names are canonical as of #1612; the original flat `runbook_*` names remain callable as deprecated aliases (removed in v0.15.0, deferred from the original one-release v0.14.0 window by #1702), and the template id is `template_slug` on every tool (`slug` accepted as a deprecated alias on the template verbs for the same window). See [`docs/codebase/mcp.md`](../codebase/mcp.md) §Tool naming grammar.
 
 ## The three entities
 

--- a/docs/codebase/api-shape-conventions.md
+++ b/docs/codebase/api-shape-conventions.md
@@ -1024,8 +1024,10 @@ hold-out (`runbook_start`, `runbook_show_template`, …) until #1612
 canonicalised the 11 tools as `meho.runbook.<verb>`. The flat names
 stay registered as deprecated aliases — same handler object, same
 schema, DEPRECATED pointer description, per-call
-`mcp_tool_name_deprecated` warning log — for one release (removed in
-v0.14.0). The same change unified the template identifier on
+`mcp_tool_name_deprecated` warning log — until removal in v0.15.0
+(the original one-release v0.14.0 deadline slipped past the v0.14.0
+tag and was re-pinned, with a public CHANGELOG erratum, by #1702).
+The same change unified the template identifier on
 `template_slug` across all 11 tools (the template verbs previously
 took `slug` while the run verbs took `template_slug`); `slug` is
 accepted as a deprecated input alias on the template verbs for the

--- a/docs/codebase/mcp.md
+++ b/docs/codebase/mcp.md
@@ -167,7 +167,14 @@ in #1612:
 Renames on an agent-facing wire surface always ship with a one-release
 alias window (the `content`→`body`, `since`→`cursor`, and
 `id`→`approval_request_id` precedents). For #1612 the window covers
-two alias kinds, both **removed in v0.14.0**:
+two alias kinds, both **removed in v0.15.0** (originally pinned to
+v0.14.0, but v0.14.0 was tagged with the aliases still registered and
+no release-notes line, so #1702 re-pinned the deadline to v0.15.0 and
+published a `### Deprecated` erratum on the v0.14.0 CHANGELOG section;
+removal executes as the scheduled task #1625, re-scheduled to the
+v0.15.0 cycle, and `removal_version` is warning/description text only
+— deliberately not a runtime version gate, because `__version__` is
+build-metadata-dependent; see #1698):
 
 * **Tool-name aliases.** The flat `runbook_*` names stay registered
   via `register_deprecated_mcp_tool_alias`
@@ -276,7 +283,8 @@ resource.
 * G0.14-T13 (#1202) — protocol-version mismatch observability
   (this section).
 * G0.22-T7 (#1612) — runbook tool-name + `template_slug`
-  canonicalisation; deprecated flat aliases removed in v0.14.0.
+  canonicalisation; deprecated flat aliases removed in v0.15.0
+  (deferred from v0.14.0 by #1702).
 * MCP spec (2025-06-18) §Tools (Tool object shape — no first-class
   deprecation field):
   https://modelcontextprotocol.io/specification/2025-06-18/server/tools

--- a/docs/runbooks/authoring.md
+++ b/docs/runbooks/authoring.md
@@ -62,7 +62,8 @@ session re-reads it with `meho.runbook.show_template`.
 
 > **Naming note (#1612).** The dotted `meho.runbook.<verb>` names are
 > canonical; the original flat `runbook_*` names remain callable as
-> deprecated aliases for one release (removed in v0.14.0). The template
+> deprecated aliases (removed in v0.15.0, deferred from the original
+> one-release v0.14.0 window by #1702). The template
 > id field is `template_slug` everywhere — `slug` is accepted as a
 > deprecated alias on the template verbs for the same window, and
 > responses carry both keys until the window closes.


### PR DESCRIPTION
## Summary

- **Decision (Path B of #1702): deferral, made public.** The v0.13.0-announced removal of the 11 flat `runbook_*` MCP tool aliases + the `slug` template-id input alias was pinned to v0.14.0, but v0.14.0 was tagged with all 11 aliases still registered and its release notes silent. This PR moves the deadline explicitly instead of leaving it silently slipped: `_ALIAS_REMOVAL_VERSION = "0.15.0"` in both tools modules (the `runbook_template_slug_field_deprecated` warning + DEPRECATED wire descriptions now name v0.15.0; the per-call `mcp_tool_name_deprecated` breadcrumb stays unversioned — tool + replacement only), a `### Deprecated` **erratum on the released v0.14.0 CHANGELOG section** (sanctioned by Keep a Changelog 1.1.0's corrective-amendment guidance), a matching `[Unreleased]` bullet (publishes with v0.15.0's notes), and doc updates (`docs/codebase/mcp.md`, `docs/codebase/api-shape-conventions.md` §14.9, and — iteration 1, B1 — `docs/runbooks/authoring.md`, `docs/architecture/runbooks.md`) so no surface still claims "removed in v0.14.0".
- **Why Path B over Path A (remove now):** v0.14.0 is already tagged, so "enforce the v0.14.0 deadline" is unmeetable as stated — any removal commit now ships in v0.15.0 regardless. Removing here would duplicate **open #1625**, which carries the complete removal scope (incl. the two prose cleanups deferred from PR #1619's review and the flat-name occurrences flowing into `cli/api/openapi.json`) that #1702's Path A AC doesn't cover. And consumers got no final warning in v0.14.0's notes — removing in the very next release with only a retroactive erratum would break the announced-window discipline of the repo's own `content`→`body` precedent (#1612). Deferral + a public statement is the truthful minimal fix for the actual SEV-2 defect, which is the *silence* (Area: process). The initiative DoD (#1691) explicitly admits this branch: "OR the deadline moved + a release-notes line added — decided, not silent."
- **No runtime version gate, deliberately:** `register_deprecated_mcp_tool_alias()` keeps using `removal_version` as warning/description text only. A `__version__` comparison gate could not fire correctly on real deploys until #1698 lands (runtime version reads `0.1.0-dev` without build metadata). Removal stays a scheduled-task obligation — #1625, re-scheduled to the v0.15.0 cycle. The decision is recorded in `mcp.md` and both constants' comments.

## Orchestrator action required (1 item)

Path B AC #3 ("New task filed for v0.15.0 with reference to #1625 + rationale documented") could not be executed from this worker: `gh issue create` was denied twice by the sandbox write-policy classifier. The complete task body is staged below — filing it is one `gh issue create --repo evoila/meho --label task --title "Task: v0.15.0 — remove the deprecated flat runbook_* tool aliases + slug field alias (deferred from v0.14.0 by #1702)" --body-file <staged>` away. Until then **#1625 remains the live tracker**, and every reference in this diff deliberately points at "#1625, re-scheduled to the v0.15.0 cycle" — wording that stays correct whether #1625 is retargeted in place or superseded by the new task.

<details>
<summary>Staged body for the v0.15.0 removal task</summary>

```markdown
Parent goal: #221
Parent initiative: #1605

> **Execution gate:** execute during the **v0.15.0 cycle** — any time after the v0.14.0 tag (already cut, 2026-06-12) and **before the v0.15.0 release-cutting PR**. This is the re-scheduled other half of #1612's one-release deprecation contract. It must not slip past a second tag: if v0.15.0 ships with the aliases still registered, the release-cutting PR must carry another explicit deferral note (silence is not an option — see the #1702 post-mortem).

## Why

#1612 (PR #1619) made dotted `meho.runbook.<verb>` canonical for all 11 runbook MCP tools and unified the template id on `template_slug`, keeping the flat `runbook_*` names and the `slug` input field as deprecated aliases with removal pinned to **v0.14.0**. That deadline slipped silently: v0.14.0 (2026-06-12) shipped with all 11 aliases still registered and no release-notes line.

#1702 (G0.25 cycle-10, SEV-2 process) resolved the slip by **deferral**: `_ALIAS_REMOVAL_VERSION` is re-pinned to `"0.15.0"` in both tools modules, a `### Deprecated` erratum was added to the v0.14.0 CHANGELOG section, and this task is the tracked executor of the new deadline.

This task supersedes the **schedule** of #1625 (the original v0.14.0 removal task). The technical scope is identical to #1625 — see its body for the full grounding (alias machinery, registration sites, the `slug` XOR shim, the two prose cleanups deferred from PR #1619's review, and the flat-name occurrences flowing into `cli/api/openapi.json`). Re-ground all line numbers against main at execution time; #1625's refs predate the v0.14.0 and v0.15.0 cycles.

## Scope (by reference to #1625 — deltas only)

Everything in #1625's Desired state / acceptance criteria, with these deltas:

- All deadline references now read **v0.15.0** (re-pinned by #1702): `_ALIAS_REMOVAL_VERSION` in `backend/src/meho_backplane/mcp/tools/runbooks.py` and `runbook_runs.py`, plus `docs/codebase/mcp.md` §"Tool naming grammar" and `docs/codebase/api-shape-conventions.md` §14.9.
- The CHANGELOG `Removed` bullet lands under `[Unreleased]` during the v0.15.0 cycle and must reference both the #1612 migration recipe and the #1702 deferral.
- `docs/codebase/mcp.md` + `api-shape-conventions.md` §14.9 flip from "removed in v0.15.0 (deferred from v0.14.0 by #1702)" to "removed as of v0.15.0".
- The §14.9 structural pin tests (`backend/tests/test_mcp_tools_list_shape_conventions.py`) flip from "flat alias registered + DEPRECATED description + same handler object" to "exactly 11 dotted `meho.runbook.*` tools, zero flat `runbook_*` names, flat call → standard unknown-tool error".

## Why no runtime version gate

`register_deprecated_mcp_tool_alias()` (`backend/src/meho_backplane/mcp/registry.py`) deliberately uses `removal_version` for description/warning text only — there is no version-comparison gate, and #1702 decided not to add one: the runtime `__version__` is `0.1.0-dev` unless build metadata binds it (#1698), so a runtime gate would never fire on real deploys. Removal is a scheduled-task obligation enforced by this task and the release checklist, not by runtime logic.

## Acceptance criteria

- [ ] All of #1625's acceptance criteria, re-grounded against main at execution time, with "v0.14.0" read as "v0.15.0"
- [ ] CHANGELOG `[Unreleased]` `### Removed` bullet referencing the #1612 migration recipe and the #1702 deferral
- [ ] No `runbook_*` flat tool name and no `register_deprecated_mcp_tool_alias` call remains under `backend/src/meho_backplane/mcp/tools/`

## References

- #1625 — original v0.14.0 removal task (full technical scope + grounding; superseded in schedule by this task)
- #1702 — the deferral decision, v0.14.0 CHANGELOG erratum, and process post-mortem (G0.25, claude-rdc-hetzner-dc v0.14.0 cycle-10)
- #1612 / PR #1619 — canonicalisation + one-release deprecation window (v0.13.0)
- CHANGELOG: v0.13.0 `### Deprecated` announcement; v0.14.0 `### Deprecated` erratum (added by #1702)
```

</details>

## Test plan

- [x] `uv run ruff check src/ tests/` — All checks passed
- [x] `uv run ruff format --check src/ tests/` — 950 files already formatted
- [x] `uv run mypy src/` — Success: no issues found in 468 source files
- [x] Targeted: `pytest tests/test_mcp_tools_list_shape_conventions.py tests/test_mcp_tools_runbooks_templates.py tests/test_mcp_tools_runbook_runs.py` — 98 passed
- [x] Full unit sweep `pytest -n 6 --dist loadscope --maxfail=1 --ignore=tests/integration` — green on re-run (first run hit the documented structlog/xdist flake in `test_corpus_client.py::test_forwarded_jwt_never_logged`, unrelated subsystem, passes in isolation)
- [x] **AC-B1**: `_ALIAS_REMOVAL_VERSION: Final[str] = "0.15.0"` in `runbooks.py:136` and `runbook_runs.py:163`
- [x] **AC-B2**: v0.14.0 CHANGELOG `### Deprecated` erratum present with the prescribed wording ("Deferral of flat `runbook_*` alias removal to v0.15.0 (originally scheduled per the #1612 migration recipe announced in v0.13.0; execution deferred to the next release)")
- [ ] **AC-B3**: new v0.15.0 task — **staged above; orchestrator files it** (sandbox write denial)
- [x] No stale deadline claims — **repo-wide, all tracked files** (widened in iteration 1 per B1): `git grep -inE 'remov(ed|al)[^.]{0,30}in v0\.14|dropped[^.]{0,30}in v0\.14' -- .` → 1 hit: the v0.13.0 `### Deprecated` announcement in `CHANGELOG.md` (deliberately kept historical record — see Out of scope); `docs/runbooks/authoring.md` + `docs/architecture/runbooks.md` fixed in 5e3780eb
- [x] `code-quality.py --diff` — 0 blockers (1 pre-existing warning: `runbooks.py` 866 lines > 600, pre-dates this PR)
- [x] CLI snapshot freshness: `cd cli && make snapshot-openapi` re-run → **zero diff** on `cli/api/openapi.json` (the deprecation version string never flows into REST OpenAPI; MCP-only surface)

## Out of scope

- The actual alias removal — #1625 (re-scheduled to the v0.15.0 cycle; its scope additionally covers PR #1619's two deferred prose cleanups and the CLI-snapshot flat-name occurrences).
- The v0.13.0 CHANGELOG `### Deprecated` announcement still says "removed in v0.14.0" — kept deliberately: it is the historical record of what was announced at v0.13.0 release time. The v0.14.0 erratum + `[Unreleased]` bullet carry the correction.
- The published v0.14.0 **GitHub Release body** still shows the pre-erratum notes (cli-release.yml extracts the section at tag time). Mirroring the erratum into the release body has precedent (v0.6.0 amendment, PR #1159) — left as a maintainer follow-up, recorded as an adjacent finding.

<!-- auto-implement-issue: fresh, iteration 1 -->

Closes #1702


---

## Follow-up (auto-implement-issue, iteration 1, 2026-06-12)

Addressed both findings from review iteration 1 (inline comments on the [review summary](https://github.com/evoila/meho/pull/1703#issuecomment-4694902808)):

- **B1** 5e3780eb — `docs/runbooks/authoring.md:65` + `docs/architecture/runbooks.md:32` reworded from “removed in v0.14.0” to the deferred truth (“removed in v0.15.0, deferred from the original one-release v0.14.0 window by #1702”), consistent with the `docs/codebase/mcp.md` section the latter links to. Staleness grep re-run **repo-wide over all tracked files** — only remaining hit is the v0.13.0 `### Deprecated` announcement in `CHANGELOG.md`, the deliberately kept historical record (see Out of scope), corrected forward by the v0.14.0 erratum.
- **M1** b02bd075 — `[Unreleased]` bullet now attaches the v0.15.0-naming claim only to the `runbook_template_slug_field_deprecated` warning and the DEPRECATED wire descriptions, and explicitly notes the per-call `mcp_tool_name_deprecated` breadcrumb stays unversioned (logs tool + replacement only; `handlers.py` untouched — that surface belongs to #1625). Same correction mirrored in the first summary bullet above.

<!-- auto-implement-issue: continue, iteration 1 -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Extended deprecation timeline for `runbook_*` tool-name aliases and `slug` input alias from v0.14.0 to v0.15.0, providing additional migration time before removal.

* **Chores**
  * Updated internal deprecation version markers and configuration across the codebase to reflect the revised timeline.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->
