### PR TITLE
fix(ui): register Alpine component scripts ahead of alpine.min.js (#1692)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -90,6 +90,15 @@ connector-related release-notes line.
 
 ## [Unreleased]
 
+### Fixed
+
+- Operator console: broadcast feed/wall and the connectors recent-ops
+  card rendered dead (empty state despite a healthy stream, console
+  errors on every SSE frame) because their Alpine component scripts
+  loaded after Alpine had already started; component registration now
+  loads from a head-level `component_scripts` block that precedes
+  `alpine.min.js` (#1692)
+
 ## [0.14.0] - 2026-06-12
 
 ### Security

--- a/backend/src/meho_backplane/ui/static/src/app/broadcast-feed.js
+++ b/backend/src/meho_backplane/ui/static/src/app/broadcast-feed.js
@@ -6,10 +6,15 @@
 // click-to-open drawer + the PII 🔒 marker helper).
 //
 // Registered on ``alpine:init`` so the ``x-data="broadcastFeed(...)"``
-// wrapper in ``broadcast/_feed.html`` resolves to this component. Kept in
-// a static file (loaded via ``<script src=... defer>`` from the page's
-// ``{% block scripts %}``) rather than an inline ``<script>`` block so a
-// future nonce-based CSP needs no inline-script exception -- matching the
+// wrapper in ``broadcast/_feed.html`` resolves to this component. Loaded
+// via ``<script src=... defer>`` from the page's HEAD-level
+// ``component_scripts`` block (wall.html: directly in its head), which
+// renders BEFORE ``vendor/alpine.min.js`` -- deferred scripts execute in
+// document order, and Alpine's CDN bundle auto-starts in a microtask at
+// the end of its own script task, so this listener must already be
+// registered by then or the component never registers (#1692). Kept in
+// a static file rather than an inline ``<script>`` block so a future
+// nonce-based CSP needs no inline-script exception -- matching the
 // chassis ``base.html`` "zero inline script" posture.
 //
 // Responsibilities:

--- a/backend/src/meho_backplane/ui/static/src/app/connectors-feed.js
+++ b/backend/src/meho_backplane/ui/static/src/app/connectors-feed.js
@@ -4,11 +4,16 @@
 // Connectors recent-ops Alpine controller (Initiative #340; Task #873
 // G10.3-T1). Registers on ``alpine:init`` so the
 // ``x-data="connectorsRecentOps(...)"`` wrapper in
-// ``connectors/_recent_ops.html`` resolves to this component. Kept
-// in a static file (loaded via ``<script src=... defer>``) rather
-// than an inline ``<script>`` block so a future nonce-based CSP
-// needs no inline-script exception -- matching the chassis
-// ``base.html`` "zero inline script" posture.
+// ``connectors/_recent_ops.html`` resolves to this component. Loaded
+// via ``<script src=... defer>`` from the detail page's HEAD-level
+// ``component_scripts`` block, which renders BEFORE
+// ``vendor/alpine.min.js`` -- deferred scripts execute in document
+// order, and Alpine's CDN bundle auto-starts in a microtask at the
+// end of its own script task, so this listener must already be
+// registered by then or the component never registers (#1692). Kept
+// in a static file rather than an inline ``<script>`` block so a
+// future nonce-based CSP needs no inline-script exception --
+// matching the chassis ``base.html`` "zero inline script" posture.
 //
 // Responsibilities:
 //   * Seed ``events`` from the server-rendered payload passed in

--- a/backend/src/meho_backplane/ui/templates/_head_assets.html
+++ b/backend/src/meho_backplane/ui/templates/_head_assets.html
@@ -10,7 +10,12 @@
   vendored HTMX 2 + SSE extension + Alpine 3. Script order is
   load-bearing: ``sse.min.js`` calls ``htmx.defineExtension`` at load,
   so it must execute after ``htmx.min.js``; ``defer`` preserves
-  document order across all three. Zero inline script — CSP-ready.
+  document order across all three. Equally load-bearing: any surface
+  script that registers Alpine components on ``alpine:init`` must be
+  injected BEFORE this include (base.html's ``component_scripts``
+  block / wall.html's head) — ``alpine.min.js`` auto-starts in a
+  microtask at the end of its own script task, before any later
+  deferred script runs (#1692). Zero inline script — CSP-ready.
 -#}
 {# Theme bootstrap — synchronous on purpose (NO defer): it must set
    <html data-theme> from localStorage / OS preference BEFORE first

--- a/backend/src/meho_backplane/ui/templates/base.html
+++ b/backend/src/meho_backplane/ui/templates/base.html
@@ -56,6 +56,23 @@
     <meta charset="utf-8" />
     <meta name="viewport" content="width=device-width, initial-scale=1" />
     <title>{% block page_title %}MEHO Operator Console{% endblock %}</title>
+    {#- Alpine component-registration scripts. This block MUST render
+       BEFORE the _head_assets.html include: every script here and in
+       the include is ``defer``red, and deferred scripts execute in
+       document order, so a script injected here runs before
+       ``vendor/alpine.min.js`` evaluates. The vendored Alpine CDN
+       bundle auto-starts via ``queueMicrotask(() => Alpine.start())``
+       at the end of its own script task -- the microtask drains
+       BEFORE the next deferred script runs -- so an ``alpine:init``
+       listener registered from the body-end ``scripts`` block is too
+       late: the event has already fired and the ``Alpine.data()``
+       component never registers, leaving its ``x-data`` element dead
+       (#1692). Surfaces whose JS registers components on
+       ``alpine:init`` (broadcast feed, connectors recent-ops) inject
+       their ``<script src=... defer>`` here; plain-JS page scripts
+       and vendor bundles (Cytoscape, CodeMirror) stay in the
+       body-end ``scripts`` block so they don't delay Alpine boot. -#}
+    {% block component_scripts %}{% endblock %}
     {% include "_head_assets.html" %}
   </head>
   <body class="min-h-full text-base-content antialiased">
@@ -251,10 +268,15 @@
         </nav>
       </aside>
     </div>
-    {# Per-surface deferred JS. Surfaces that ship a static app script
-       (e.g. the broadcast feed's Alpine controller) inject a
-       ``<script src=... defer>`` here -- external src, not inline, so a
-       future nonce-based CSP needs no special-casing. Empty by default. #}
+    {# Per-surface deferred JS that does NOT register Alpine
+       components -- plain-JS page scripts (topology) and heavy vendor
+       bundles (Cytoscape, CodeMirror). External src, not inline, so a
+       future nonce-based CSP needs no special-casing. Empty by
+       default. Scripts that call ``Alpine.data()`` inside an
+       ``alpine:init`` listener belong in the head-level
+       ``component_scripts`` block instead -- from here they execute
+       after Alpine has already started and the registration is lost
+       (#1692). #}
     {% block scripts %}{% endblock %}
   </body>
 </html>

--- a/backend/src/meho_backplane/ui/templates/broadcast/feed.html
+++ b/backend/src/meho_backplane/ui/templates/broadcast/feed.html
@@ -157,10 +157,15 @@
 </section>
 {% endblock %}
 
-{# Surface JS -- the ``broadcastFeed`` Alpine controller. Loaded as an
-   external deferred script (not inline) so a future nonce-based CSP
-   needs no special-casing. Registers on ``alpine:init`` before Alpine
-   processes the ``x-data`` in the feed fragment. #}
-{% block scripts %}
+{# Surface JS -- the ``broadcastFeed`` Alpine controller. Injected into
+   the head-level ``component_scripts`` block so it executes BEFORE
+   ``vendor/alpine.min.js`` (deferred scripts run in document order):
+   the controller registers on ``alpine:init``, and Alpine's CDN bundle
+   fires that event from a microtask at the end of its own script task
+   -- a body-end script registers the listener too late and the
+   ``x-data="broadcastFeed(...)"`` wrapper stays dead (#1692). External
+   src, not inline, so a future nonce-based CSP needs no
+   special-casing. #}
+{% block component_scripts %}
   <script src="/ui/static/src/app/broadcast-feed.js" defer></script>
 {% endblock %}

--- a/backend/src/meho_backplane/ui/templates/broadcast/wall.html
+++ b/backend/src/meho_backplane/ui/templates/broadcast/wall.html
@@ -47,6 +47,14 @@
     <meta charset="utf-8" />
     <meta name="viewport" content="width=device-width, initial-scale=1" />
     <title>Broadcast wall &middot; MEHO Operator Console</title>
+    {# Surface JS -- the shared ``broadcastFeed`` Alpine controller.
+       MUST precede the _head_assets.html include (the standalone-
+       document equivalent of base.html's ``component_scripts``
+       block): deferred scripts execute in document order, and the
+       controller's ``alpine:init`` listener has to be registered
+       before ``vendor/alpine.min.js`` auto-starts Alpine from its
+       end-of-task microtask (#1692). #}
+    <script src="/ui/static/src/app/broadcast-feed.js" defer></script>
     {# Shared asset block — same CSS/fonts/JS + load order as base.html
        (the include is what keeps the two heads from drifting). #}
     {% include "_head_assets.html" %}
@@ -88,8 +96,5 @@
         aria-label="Event detail drawer"
       ></aside>
     </section>
-
-    {# Surface JS -- the shared ``broadcastFeed`` Alpine controller. #}
-    <script src="/ui/static/src/app/broadcast-feed.js" defer></script>
   </body>
 </html>

--- a/backend/src/meho_backplane/ui/templates/connectors/detail.html
+++ b/backend/src/meho_backplane/ui/templates/connectors/detail.html
@@ -156,6 +156,14 @@
 </section>
 {% endblock %}
 
-{% block scripts %}
+{# Surface JS -- the ``connectorsRecentOps`` Alpine controller.
+   Injected into the head-level ``component_scripts`` block so it
+   executes BEFORE ``vendor/alpine.min.js`` (deferred scripts run in
+   document order): the controller registers on ``alpine:init``, and
+   Alpine's CDN bundle fires that event from a microtask at the end of
+   its own script task -- a body-end script registers the listener too
+   late and the ``x-data="connectorsRecentOps(...)"`` wrapper stays
+   dead (#1692). #}
+{% block component_scripts %}
   <script src="/ui/static/src/app/connectors-feed.js" defer></script>
 {% endblock %}

--- a/backend/tests/test_ui_broadcast_feed.py
+++ b/backend/tests/test_ui_broadcast_feed.py
@@ -362,6 +362,28 @@ def test_feed_page_wires_sse_extension_to_ui_bridge() -> None:
     assert "/ui/static/src/vendor/sse.min.js" in body
 
 
+def test_feed_page_loads_controller_before_alpine() -> None:
+    """The controller script tag precedes the Alpine bundle (#1692).
+
+    Both tags are ``defer``red, and deferred scripts execute in
+    document order -- the only ordering that lets the controller's
+    ``alpine:init`` listener register before the Alpine CDN bundle
+    auto-starts (it fires ``alpine:init`` from a microtask at the end
+    of its own script task, before any later deferred script runs). A
+    regression here makes Alpine process ``x-data="broadcastFeed(...)"``
+    with the component unregistered: both broadcast tabs render dead
+    and every SSE frame throws in the console.
+    """
+    session_id = _seed_session_sync(tenant_id=_TENANT_A)
+    with respx.mock(assert_all_called=False):
+        client = _authenticated_client(session_id)
+        response = client.get("/ui/broadcast")
+    body = response.text
+    controller_pos = body.index("/ui/static/src/app/broadcast-feed.js")
+    alpine_pos = body.index("/ui/static/src/vendor/alpine.min.js")
+    assert controller_pos < alpine_pos
+
+
 def test_feed_page_renders_empty_state() -> None:
     """The empty-state copy renders (shown until the first event lands)."""
     session_id = _seed_session_sync(tenant_id=_TENANT_A)

--- a/backend/tests/test_ui_broadcast_wall_replay.py
+++ b/backend/tests/test_ui_broadcast_wall_replay.py
@@ -281,6 +281,28 @@ class TestWallMode:
         # The shared controller script is loaded.
         assert "/ui/static/src/app/broadcast-feed.js" in body
 
+    def test_wall_view_loads_controller_before_alpine(self) -> None:
+        """The controller script tag precedes the Alpine bundle (#1692).
+
+        The wall page is a standalone document, so it places the
+        controller ``<script>`` in its own head, before the
+        ``_head_assets.html`` include that loads ``alpine.min.js`` --
+        the same document-order contract base.html's
+        ``component_scripts`` block gives the in-chrome view. Deferred
+        scripts execute in document order, and the Alpine CDN bundle
+        fires ``alpine:init`` from a microtask at the end of its own
+        script task; a body-end controller registers too late and the
+        wall renders permanently empty with no auto-scroll.
+        """
+        session_id = _seed_session_sync(tenant_id=_TENANT_A)
+        with respx.mock(assert_all_called=False):
+            client = _authenticated_client(session_id)
+            response = client.get("/ui/broadcast?wall=1")
+        body = response.text
+        controller_pos = body.index("/ui/static/src/app/broadcast-feed.js")
+        alpine_pos = body.index("/ui/static/src/vendor/alpine.min.js")
+        assert controller_pos < alpine_pos
+
     def test_in_chrome_view_keeps_chrome_and_no_autoscroll(self) -> None:
         """The default (non-wall) view still renders base.html chrome."""
         session_id = _seed_session_sync(tenant_id=_TENANT_A)

--- a/backend/tests/test_ui_connectors_view.py
+++ b/backend/tests/test_ui_connectors_view.py
@@ -744,6 +744,33 @@ def test_detail_renders_recent_ops_for_target() -> None:
     assert "/api/v1/operations/call" in body
 
 
+def test_detail_loads_recent_ops_controller_before_alpine() -> None:
+    """The recent-ops controller script precedes the Alpine bundle (#1692).
+
+    Both tags are ``defer``red, and deferred scripts execute in
+    document order -- the only ordering that lets the controller's
+    ``alpine:init`` listener register before the Alpine CDN bundle
+    auto-starts (it fires ``alpine:init`` from a microtask at the end
+    of its own script task, before any later deferred script runs). A
+    regression here makes Alpine process
+    ``x-data="connectorsRecentOps(...)"`` with the component
+    unregistered: the recent-ops card renders dead, with no seeded
+    rows and no live SSE updates.
+    """
+    _seed_tenant(_TENANT_A, "tenant-a")
+    _seed_target(tenant_id=_TENANT_A, name="ordered-target", product="ssh")
+
+    session_id = _seed_session_sync(tenant_id=_TENANT_A)
+    with respx.mock(assert_all_called=False):
+        client = _authenticated_client(session_id)
+        response = client.get("/ui/connectors/ordered-target")
+    assert response.status_code == 200, response.text
+    body = response.text
+    controller_pos = body.index("/ui/static/src/app/connectors-feed.js")
+    alpine_pos = body.index("/ui/static/src/vendor/alpine.min.js")
+    assert controller_pos < alpine_pos
+
+
 def test_detail_isolates_recent_ops_from_other_tenants() -> None:
     """Audit rows under another tenant's target id never seed into the card."""
     _seed_tenant(_TENANT_A, "tenant-a")

--- a/backend/tests/test_ui_templates.py
+++ b/backend/tests/test_ui_templates.py
@@ -164,6 +164,27 @@ def test_base_template_exposes_content_block(ui_env: Environment) -> None:
     assert "{% endblock %}" in template_source
 
 
+def test_base_template_orders_component_scripts_before_alpine() -> None:
+    """``component_scripts`` renders before the Alpine-loading include.
+
+    The vendored Alpine CDN bundle auto-starts via
+    ``queueMicrotask(() => Alpine.start())`` at the end of its own
+    script task, and the microtask queue drains before the next
+    deferred script executes -- so an ``alpine:init`` listener
+    registered by a script that renders AFTER ``alpine.min.js`` in
+    document order never sees the event, and its ``Alpine.data()``
+    component silently never registers (#1692). Deferred scripts
+    execute in document order, so the chassis must place the
+    ``component_scripts`` block (where surfaces inject their
+    controller-registration scripts) before the ``_head_assets.html``
+    include that loads ``alpine.min.js``.
+    """
+    template_source = (templates_dir() / "base.html").read_text(encoding="utf-8")
+    block_pos = template_source.index("{% block component_scripts %}")
+    include_pos = template_source.index('{% include "_head_assets.html" %}')
+    assert block_pos < include_pos
+
+
 def test_base_template_footer_shows_readiness_pill(ui_env: Environment) -> None:
     """Footer flips between 'ready' and 'starting' on the ``ready`` flag."""
     ready_html = ui_env.get_template("base.html").render(ready=True)

--- a/docs/codebase/ui.md
+++ b/docs/codebase/ui.md
@@ -223,11 +223,30 @@ Current as of Task #863 (refresh procedure documented in
 | Cytoscape.js | 3.33.4 |
 
 `htmx-ext-sse` (`sse.min.js`) is the SSE extension HTMX 2 split out of
-core (HTMX 1 bundled it). It is loaded in `base.html` right after
-`htmx.min.js` (script order matters — the extension calls
+core (HTMX 1 bundled it). It is loaded in `_head_assets.html` right
+after `htmx.min.js` (script order matters — the extension calls
 `htmx.defineExtension` at load) and is required by both the dashboard
 recent-activity snippet (G10.0) and the broadcast live feed (G10.1):
 without it every `hx-ext="sse"` wrapper is inert.
+
+**Alpine component-registration ordering (#1692).** The vendored
+Alpine CDN bundle auto-starts via `queueMicrotask(() =>
+Alpine.start())` at the end of its own script task; the microtask
+queue drains before the next deferred script executes, so any surface
+script that registers components on `alpine:init` must appear BEFORE
+`alpine.min.js` in document order (deferred scripts execute in
+document order — the [Alpine extension
+contract](https://alpinejs.dev/advanced/extending)). `base.html`
+exposes a head-level `{% block component_scripts %}` rendered before
+the `_head_assets.html` include for exactly this: the broadcast feed
+and connectors detail pages inject their controller scripts there
+(the standalone `wall.html` places the tag directly in its head). A
+controller loaded from the body-end `{% block scripts %}` instead
+registers its `alpine:init` listener after the event has fired —
+`Alpine.data()` never runs and every `x-data` element referencing the
+component renders dead (the v0.14.0 cycle-10 broadcast outage).
+Plain-JS page scripts and heavy vendor bundles (Cytoscape, CodeMirror)
+stay in the body-end block so they don't delay Alpine boot.
 
 Every bump lands on its own `chore(ui): bump <library> to <version>`
 PR so the supply-chain trail records each move (same discipline the
@@ -238,10 +257,14 @@ backplane Python base image already follows).
 `base.html` is the only template Task #863 ships. Its structure:
 
 ```html
-<html data-theme="corporate">
+<html data-theme="meho-dark">
   <head>
+    {% block component_scripts %}{% endblock %}   <!-- Alpine.data() registrations; MUST precede alpine.min.js (#1692) -->
+    <!-- _head_assets.html include (shared with wall.html): -->
+    <script src="/ui/static/src/app/theme.js">    <!-- sync: pre-paint theme -->
     <link href="/ui/static/dist/tailwind.css">
     <script src="/ui/static/src/vendor/htmx.min.js" defer>
+    <script src="/ui/static/src/vendor/sse.min.js" defer>
     <script src="/ui/static/src/vendor/alpine.min.js" defer>
   </head>
   <body>
@@ -623,7 +646,7 @@ the colour policy stays one auditable map.
 
 | File | Purpose |
 | ---- | ------- |
-| `broadcast/feed.html` | Full-page view: header, filter bar include, feed-fragment include, drawer slot, `<script src>` for the controller. |
+| `broadcast/feed.html` | Full-page view: header, filter bar include, feed-fragment include, drawer slot. Injects the controller `<script src>` into the head-level `{% block component_scripts %}` so it executes before `alpine.min.js` (#1692). |
 | `broadcast/_filter_bar.html` | The op_class / principal / target / op_id controls. The three server filters `hx-get` to `/ui/broadcast/feed`; op_id dispatches a `broadcast-op-id-changed` window event for the client-side filter. |
 | `broadcast/_feed.html` | The swappable feed fragment: the SSE sink (with the filtered `sse-connect` URL), status bar, column header, empty state, `<template x-for>`. Wraps the `broadcastFeed` Alpine controller so a filter re-render resets the event list and re-subscribes. |
 | `broadcast/_event_row.html` | Server-authored row markup (timestamp · principal badge · op_id · op_class badge · result_status icon · target · payload summary). Click opens the drawer; aggregate-only events render the 🔒 marker + placeholder. |
@@ -631,7 +654,7 @@ the colour policy stays one auditable map.
 | `broadcast/_event_drawer_not_found.html` | The 404 drawer fragment for a missing / cross-tenant audit id. |
 | `broadcast/wall.html` | The no-chrome wall-monitor view (Task #869): a standalone document (not `extends base.html`) that drops the sidebar / navbar / filter bar and embeds `_feed.html` with `wall=True` (taller rows + auto-scroll). |
 | `broadcast/_history.html` | The Last-24h replay fragment (Task #869): seeds the shared `broadcastFeed` controller with the historical events the `/ui/broadcast/history` route pulled via `XRANGE`, so the rows render through `_event_row.html` and open the same drawer as the live feed. |
-| `static/src/app/broadcast-feed.js` | The `broadcastFeed` Alpine component (registered on `alpine:init`). External deferred script, not inline, to stay CSP-ready. Holds the parse + prepend + 1000-row trim, the `visibleEvents` op_id client filter, the `init` re-read of the live op_id input (so the filter survives a server-side fragment swap, gated to `#broadcast-feed` only), the `openDrawer` helper, the badge/timestamp/payload/aggregate-only helpers, the `opts.seedFrom` data-island seed (for the history replay pane — reads + `JSON.parse`s a `<script type="application/json">` block rather than receiving events through the `x-data` attribute, closing B1's stored-XSS hole), and the `opts.autoScroll` wall-monitor behaviour. |
+| `static/src/app/broadcast-feed.js` | The `broadcastFeed` Alpine component (registered on `alpine:init`; loaded from the head-level `component_scripts` block — before `alpine.min.js`, or the registration is lost, #1692). External deferred script, not inline, to stay CSP-ready. Holds the parse + prepend + 1000-row trim, the `visibleEvents` op_id client filter, the `init` re-read of the live op_id input (so the filter survives a server-side fragment swap, gated to `#broadcast-feed` only), the `openDrawer` helper, the badge/timestamp/payload/aggregate-only helpers, the `opts.seedFrom` data-island seed (for the history replay pane — reads + `JSON.parse`s a `<script type="application/json">` block rather than receiving events through the `x-data` attribute, closing B1's stored-XSS hole), and the `opts.autoScroll` wall-monitor behaviour. |
 
 ### Performance + empty state
 


### PR DESCRIPTION
## Summary

- Fixes the SEV-1 `alpine:init` race that left the broadcast feed/wall and the connectors recent-ops card dead in the v0.14.0 cycle-10 dogfood: the `broadcastFeed` / `connectorsRecentOps` controllers were loaded from the body-end `{% block scripts %}`, but the vendored Alpine CDN bundle auto-starts via `queueMicrotask(() => Alpine.start())` at the end of its own script task — the microtask drains before any later deferred script runs, so the controllers' `alpine:init` listeners registered after the event had fired and `Alpine.data()` never ran, leaving every `x-data` wrapper undefined.
- Adds a head-level `{% block component_scripts %}` to `base.html`, rendered before the `_head_assets.html` include that loads `alpine.min.js`. Deferred scripts execute in document order, so registration scripts injected there are guaranteed to run before Alpine boots — the load-order contract Alpine's own extension docs prescribe (`https://alpinejs.dev/advanced/extending`: the extension file's `<script>` tag goes BEFORE Alpine's).
- Moves `broadcast-feed.js` (feed page + standalone wall document) and `connectors-feed.js` (connectors detail page) into that head position. No JS logic changes; the body-end `{% block scripts %}` stays for plain-JS page scripts and heavy vendor bundles (Cytoscape, CodeMirror) so they keep loading without delaying Alpine boot.
- Pins the contract with four regression tests (chassis source order + rendered-HTML order on `/ui/broadcast`, `/ui/broadcast?wall=1`, `/ui/connectors/<name>`) and documents the ordering rule in `docs/codebase/ui.md`, `_head_assets.html`, and both controller headers.

## Test plan

- [x] `uv run ruff check src/ tests/` — clean
- [x] `uv run ruff format --check src/ tests/` — clean
- [x] `uv run mypy src/` — clean (468 files)
- [x] `python3 .claude/hooks/code-quality.py --diff` — pass
- [x] `uv run pytest tests/test_ui_templates.py tests/test_ui_broadcast_feed.py tests/test_ui_broadcast_wall_replay.py tests/test_ui_connectors_view.py -q` — 78 passed (includes the 4 new ordering tests)
- [x] AC: `broadcast-feed.js` executes before `alpine:init` — `test_feed_page_loads_controller_before_alpine` + `test_wall_view_loads_controller_before_alpine` assert the controller tag precedes `alpine.min.js` in the rendered HTML; with all tags `defer`red, document order is execution order, and the bundle only starts (and fires `alpine:init`) at the end of its own script task
- [x] AC: `connectors-feed.js` executes before `alpine:init` — `test_detail_loads_recent_ops_controller_before_alpine`, same contract
- [x] AC: chassis guarantees the ordering for future surfaces — `test_base_template_orders_component_scripts_before_alpine` pins `{% block component_scripts %}` before the `_head_assets.html` include
- [x] Full unit sweep (`pytest -n 6 --dist loadscope --maxfail=1 --ignore=tests/integration tests/`) — green locally
- [ ] Browser-level ACs (live tab renders rows, wall auto-scrolls, SSE events processed, no console errors) — deterministically implied by the registration-order fix; re-verified live by the next RDC dogfood cycle per Initiative #1691's DoD

## Out of scope

- Re-architecting the controllers to inline `x-data` (explicitly excluded by #1692 / Initiative #1691)
- Dashboard widget badge updates (#1696) and the other cycle-10 FE seams (#1693–#1698) — sibling tasks
- Topology/kb/runbooks page scripts — plain JS on `DOMContentLoaded` / vendor bundles, correctly unaffected by Alpine start timing

<!-- auto-implement-issue: fresh, iteration 1 -->

Closes #1692
