### PR TITLE
fix(ui): echo the modal-minted CSRF token from the memory create form (#1693)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -98,6 +98,12 @@ connector-related release-notes line.
   loaded after Alpine had already started; component registration now
   loads from a head-level `component_scripts` block that precedes
   `alpine.min.js` (#1692)
+- Operator console: every Memory create-modal submit silently 403'd
+  (`csrf_token_invalid`) because the modal render rotates the
+  `meho_csrf` cookie while the form still echoed the stale page-level
+  `X-CSRF-Token`; the create form now declares its own `hx-headers`
+  echo of the token minted with the modal, so the double-submit pair
+  always matches and the create round-trips to 204 + redirect (#1693)
 
 ## [0.14.0] - 2026-06-12
 

--- a/backend/src/meho_backplane/ui/routes/memory/create.py
+++ b/backend/src/meho_backplane/ui/routes/memory/create.py
@@ -83,10 +83,12 @@ async def render_create_modal(
 
     Scope selector is filtered via :func:`writable_scopes_for` so the
     operator never sees a scope they can't write to (defence-in-depth:
-    the service-layer matrix re-checks on submit). The modal carries
-    its own CSRF token via the page-level ``hx-headers`` directive on
-    the form -- the route also sets the cookie so the chassis
-    double-submit pair lines up.
+    the service-layer matrix re-checks on submit). The form carries
+    its own ``hx-headers`` echo of the token minted here, and the
+    route sets the matching ``meho_csrf`` cookie on the same response,
+    so the chassis double-submit pair lines up (#1693 -- the
+    page-level directive's inherited token goes stale the moment this
+    render rotates the cookie).
     """
     writable = writable_scopes_for(operator)
     csrf_token = mint_csrf_token(str(session_ctx.session_id))

--- a/backend/src/meho_backplane/ui/templates/memory/_create_modal.html
+++ b/backend/src/meho_backplane/ui/templates/memory/_create_modal.html
@@ -13,11 +13,19 @@
   ``HX-Redirect: /ui/memory`` -- HTMX then reloads the full list
   page so the new row appears.
 
-  CSRF posture: the page-level ``hx-headers`` directive on
-  ``index.html`` echoes the CSRF token; HTMX inherits the header
-  through the inserted form, so the modal form does not need its own
-  ``hx-headers`` override. The route also sets the cookie on every
-  modal render so a freshly-issued token lines up with the cookie.
+  CSRF posture: the form declares its own ``hx-headers`` echo of the
+  token THIS render minted -- the route sets the matching
+  ``meho_csrf`` cookie on the same response, so the double-submit
+  pair always lines up (#1693). Relying on the page-level
+  ``hx-headers`` on ``index.html`` is not enough: htmx 2 *does*
+  inherit the attribute (child declarations override parent ones,
+  https://htmx.org/attributes/hx-headers/), but the modal render
+  rotates the cookie, so the inherited header still carried the
+  stale list-render token while the cookie carried the fresh one and
+  the chassis middleware 403'd every create POST (the same
+  cookie/header desync class the runbooks list fragment fixed). The
+  form-level declaration also covers the body textarea's debounced
+  preview ``hx-post``, which inherits it from the form.
 
   RBAC posture: the scope selector is server-filtered via
   :func:`writable_scopes_for` so the operator only sees scopes they
@@ -56,6 +64,7 @@
       <form
         id="memory-create-form"
         hx-post="/ui/memory/create"
+        hx-headers='{"X-CSRF-Token": "{{ csrf_token }}"}'
         hx-target="this"
         hx-swap="none"
         hx-disabled-elt="find button[type=submit]"

--- a/backend/tests/test_ui_memory_create_promote.py
+++ b/backend/tests/test_ui_memory_create_promote.py
@@ -38,6 +38,7 @@ token; ``_authenticated_client`` returns a TestClient + a respx mock
 from __future__ import annotations
 
 import asyncio
+import re
 import uuid
 import warnings
 from collections.abc import Iterator
@@ -622,6 +623,75 @@ def test_create_submit_missing_csrf_token_returns_403() -> None:
     finally:
         mock.stop()
     assert response.status_code == 403, response.text
+
+
+#: Pull the ``meho_csrf`` value out of the raw ``Set-Cookie`` header. Read the
+#: raw header (not the TestClient cookie jar): ``set_csrf_cookie`` marks the
+#: cookie ``Secure``, which the http-scheme TestClient jar refuses to store.
+_CSRF_SETCOOKIE_RE = re.compile(rf"{CSRF_COOKIE_NAME}=([^;]+)")
+
+#: Pull the ``X-CSRF-Token`` the create form echoes via its ``hx-headers``
+#: attribute out of the rendered modal fragment -- the header half of the
+#: double-submit pair the create POST will present.
+_FORM_HX_HEADERS_RE = re.compile(r'hx-headers=\'\{"X-CSRF-Token": "([^"]+)"\}\'')
+
+
+def test_create_submit_real_modal_cookie_header_pair_returns_204() -> None:
+    """Create POST through the REAL modal cookie/header CSRF pair -> 204.
+
+    Regression for #1693: the create form used to rely on the page-level
+    ``hx-headers`` directive on ``index.html``, but ``GET /ui/memory/create``
+    re-mints + re-sets the ``meho_csrf`` cookie, so the inherited header
+    still carried the stale list-render token and the chassis middleware
+    403'd every modal create. The sibling submit tests hand-mint one token
+    into both cookie and header, which is exactly why they missed the
+    desync. This test drives the genuine flow instead: GET the modal,
+    capture the ``Set-Cookie`` token AND the token the form echoes via its
+    own ``hx-headers`` attribute, assert they are the same minted value,
+    then POST presenting that captured pair verbatim.
+    """
+    _seed_tenant(_TENANT_A, "tenant-a")
+    keypair, jwks = _make_keypair_and_jwks()
+    access_token = _mint_token(
+        keypair,
+        sub=_OP_A,
+        tenant_id=str(_TENANT_A),
+        tenant_role=TenantRole.OPERATOR.value,
+    )
+    session_id = _seed_session_sync(
+        tenant_id=_TENANT_A, access_token=access_token, operator_sub=_OP_A
+    )
+    client, mock, _csrf = _authenticated_client(session_id=session_id, jwks=jwks)
+    try:
+        modal = client.get("/ui/memory/create", headers={"HX-Request": "true"})
+        assert modal.status_code == 200, modal.text
+
+        cookie_match = _CSRF_SETCOOKIE_RE.search(modal.headers.get("set-cookie", ""))
+        assert cookie_match, "modal render set no meho_csrf cookie"
+        cookie_token = cookie_match.group(1)
+
+        header_tokens = _FORM_HX_HEADERS_RE.findall(modal.text)
+        assert len(header_tokens) == 1, (
+            "expected exactly one hx-headers X-CSRF-Token echo in the create "
+            f"modal (the form's own), found {len(header_tokens)}"
+        )
+        assert cookie_token == header_tokens[0], (
+            "modal CSRF cookie does not match the form's hx-headers token -- the #1693 desync"
+        )
+
+        # Echo the captured pair back verbatim -- the browser round-trip.
+        client.cookies.set(CSRF_COOKIE_NAME, cookie_token)
+        with _stub_embedding_service():
+            response = client.post(
+                "/ui/memory/create",
+                data={"scope": "user", "body": "# pair test\n\nbody text"},
+                headers=_csrf_headers(header_tokens[0]),
+            )
+    finally:
+        mock.stop()
+    assert response.status_code == 204, response.text
+    assert response.headers.get("HX-Redirect") == "/ui/memory"
+    assert _count_documents(_TENANT_A, MemoryScope.USER) == 1
 
 
 # ---------------------------------------------------------------------------

--- a/docs/codebase/ui.md
+++ b/docs/codebase/ui.md
@@ -1531,8 +1531,15 @@ before calling the service.
   rendered fragment. Same convention T1's delete-confirm modal uses.
 * Form encoding is `application/x-www-form-urlencoded`. The chassis
   `CSRFMiddleware` accepts the double-submit token from either the
-  `X-CSRF-Token` header (HTMX inherits it from the page-level
-  `hx-headers` directive) or the `csrf_token` form field.
+  `X-CSRF-Token` header or the `csrf_token` form field. The create
+  form declares its own `hx-headers` echo of the token its render
+  minted (#1693): each modal GET re-mints + re-sets the `meho_csrf`
+  cookie, so the token inherited from the page-level directive is
+  stale by the time the operator submits. htmx 2 does inherit
+  `hx-headers`, and a child declaration overrides a parent one
+  (https://htmx.org/attributes/hx-headers/), so the form-level echo
+  keeps the double-submit pair aligned — and the body textarea's
+  debounced preview `hx-post` inherits the fresh token from the form.
 * `hx-trigger="keyup changed delay:300ms"` on the create modal's
   body textarea drives the debounced server-side preview — see
   https://htmx.org/attributes/hx-trigger/. `delay:300ms` matches
@@ -1579,7 +1586,8 @@ The full suite lives in
 * the create submit (persists the row + HX-Redirects to the list,
   blank slug auto-generates, tenant scope as operator 403s, empty
   body 422s, target-scoped without `target_name` 422s, missing CSRF
-  cookie 403s),
+  cookie 403s, and the real modal cookie/header pair round-trips to
+  204 — the #1693 desync regression),
 * the Markdown preview (renders Markdown to HTML, empty body returns
   the placeholder, raw `<script>` escapes),
 * the promote-modal render (USER source lists USER_TENANT +


### PR DESCRIPTION
## Summary
- Every Memory create-modal POST 403'd (`csrf_token_invalid`) in the v0.14.0 cycle-10 dogfood, invisibly to the operator (`hx-swap="none"` discards the error response). The form now declares `hx-headers='{"X-CSRF-Token": "{{ csrf_token }}"}'` on `<form id="memory-create-form">`, echoing the token minted by the same `GET /ui/memory/create` render that sets the `meho_csrf` cookie — the double-submit pair can no longer drift apart.
- Root-cause note (refines the issue text): htmx 2.0.9 **does** inherit `hx-headers` from ancestors (verified against the vendored `htmx.min.js` and https://htmx.org/attributes/hx-headers/ — "a child declaration of a header overrides a parent declaration"). The actual desync: the modal GET re-mints + re-sets the cookie (`create.py` / `set_csrf_cookie`), so the token inherited from `index.html`'s page-level directive was the stale list-render token. The prescribed fix is correct under either mechanism — the form-level child declaration wins and is minted token-for-token with the cookie. Same desync class previously fixed for the runbooks list fragment ("B1") and the KB editor modal.
- Bonus from the same attribute: the body textarea's debounced preview `hx-post` (a child of the form) now inherits the fresh token from the form instead of the stale page-level one.
- Stale comments that claimed the page-level directive covers the modal are rewritten (`_create_modal.html` header comment, `render_create_modal` docstring, `docs/codebase/ui.md` modal-conventions + tests bullets).

## Test plan
- [x] `uv run ruff check src/ tests/` — clean
- [x] `uv run ruff format --check src/ tests/` — 950 files already formatted
- [x] `uv run mypy src/` — no issues in 468 files
- [x] `uv run pytest tests/test_ui_memory_create_promote.py tests/test_ui_memory_list.py` — 53 passed
- [x] AC1 — `hx-headers` present on `<form id="memory-create-form">`: template diff + new test asserts exactly one `X-CSRF-Token` echo in the rendered modal fragment
- [x] AC2 — POST succeeds with 204 when the header is sent: new `test_create_submit_real_modal_cookie_header_pair_returns_204` drives the REAL flow (GET modal → capture `Set-Cookie` token + the form's `hx-headers` token → assert identical → POST that pair → 204 + `HX-Redirect: /ui/memory` + row persisted). Unlike the sibling tests it does not hand-mint a matching pair — which is exactly why those missed the desync.
- [x] AC3 — existing create-endpoint tests keep passing: full `test_ui_memory_list.py` + `test_ui_memory_create_promote.py` files green (53 passed)
- [x] AC4 — no duplicate CSRF headers on other forms: diff touches no other template (edit detail `memory/detail.html`, KB upload `kb/upload.html`, connector import `connectors/import.html` untouched, each retains its single existing wiring); the new test pins exactly one echo in the create modal
- [x] `.claude/hooks/code-quality.py --diff` — 0 blockers (2 pre-existing PLR0913 warnings in `create.py`, untouched logic)

## Out of scope
- #1697 (wave 4) owns default-TTL/`expires_at` on this same form — deliberately untouched.
- Global HTMX header injection (`htmx:configRequest`) and 403 UX feedback — explicitly out of scope per the issue.
- Adjacent findings (recorded, not edited): `memory/_body_edit.html` and `connectors/_delete_modal.html` comments still claim page-level inheritance covers their fragments — same desync class is plausible on the memory PATCH path and the connectors delete path (relevant to #1700's new DELETE surface); `docs/codebase/ui.md` connectors-detail CSRF paragraph carries the same claim.

<!-- auto-implement-issue: fresh, iteration 1 -->

Closes #1693
