### PR TITLE
feat(migrations): Alembic 0038 backfill — reconcile pre-v0.14.0 product-split orphans to dispatch spelling (#1701)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -134,6 +134,17 @@ connector-related release-notes line.
   `X-CSRF-Token`; the create form now declares its own `hx-headers`
   echo of the token minted with the modal, so the double-submit pair
   always matches and the create round-trips to 204 + redirect (#1693)
+- Alembic data backfill (`0038`) reconciles pre-v0.14.0 ingested rows
+  persisted under the long VCF-family / SDDC / Hetzner-Robot product
+  spellings (`vcf-logs`, `vcf-automation`, `vcf-fleet`,
+  `vcf-operations`, `sddc-manager`, `hetzner-robot`) to the
+  dispatch-canonical short spellings (`vrli`, `vcfa`, `fleet`,
+  `vrops`, `sddc`, `hetzner`) that v0.14.0's register-time
+  reconciliation (#1647) writes for new ingests — the connectors'
+  pre-existing operations become dispatchable again after upgrade
+  instead of reporting `registered, 0 ops`. Built-in rows only
+  (`tenant_id IS NULL`); idempotent; rows whose short-spelling twin
+  already exists (post-upgrade re-ingest) are left untouched (#1701)
 
 ## [0.14.0] - 2026-06-12
 

--- a/backend/alembic/versions/0038_backfill_endpoint_descriptor_product_splits.py
+++ b/backend/alembic/versions/0038_backfill_endpoint_descriptor_product_splits.py
@@ -1,0 +1,277 @@
+# SPDX-License-Identifier: Apache-2.0
+# Copyright (c) 2026 evoila Group
+
+"""Backfill pre-v0.14.0 product-split orphans to the dispatch-canonical spelling.
+
+Revision ID: 0038
+Revises: 0037
+Create Date: 2026-06-12
+
+Initiative #1691 (G0.25 v0.14.0 cycle-10 dogfood hardening), Task
+#1701 (CI-3). PR #1677 (#1647) made ``register_ingested_operations``
+reconcile the operator-supplied *registry* product to the
+dispatch-canonical spelling at write time
+(:func:`~meho_backplane.operations.ingest.register_ingested._reconciled_row_product`
+-> :func:`~meho_backplane.operations._lookup.dispatch_product`), so
+new ingests of the VCF-family / SDDC / Hetzner-Robot connectors land
+under the product the dispatcher derives from the connector_id
+(``vcf-logs`` -> ``vrli``, etc.). That fix is forward-only: rows
+ingested on v0.13.0 and earlier still carry the long registry
+spelling, and every dispatch probe (``connector_exists``,
+``search_operations``, ``list_operation_groups``) keys on the short,
+parser-derived product -- the pre-existing rows are invisible, the
+catalog reports ``registered, 0 ops``, and the operations are
+non-dispatchable (claude-rdc-hetzner-dc v0.14.0 cycle-10 finding
+CI-3). This migration is the one-shot data backfill that reconciles
+those orphaned rows.
+
+Fix shape -- Alembic data migration
+-----------------------------------
+
+Same self-contained shape as migration ``0011`` (the v0.3.2
+``when_to_use`` backfill precedent): lightweight :func:`sa.table` /
+:func:`sa.column` shims mirror only the columns the migration
+touches, no ORM imports (importing the live models would pin the
+migration to one moment in the schema's history and break replay),
+statements execute synchronously via ``op.get_bind()``.
+
+Mapping table
+-------------
+
+The six long<->short splits, snapshotted from the fixture
+``_VCF_PRODUCT_SPLITS`` in ``tests/test_operations_register_ingested.py``
+(which mirrors the connector registrations PR #1677 reconciled):
+
+==================  ================  ================
+registry product    impl_id           dispatch product
+==================  ================  ================
+``vcf-logs``        ``vrli-rest``     ``vrli``
+``vcf-automation``  ``vcfa-rest``     ``vcfa``
+``vcf-fleet``       ``fleet-rest``    ``fleet``
+``vcf-operations``  ``vrops-rest``    ``vrops``
+``sddc-manager``    ``sddc-rest``     ``sddc``
+``hetzner-robot``   ``hetzner-rest``  ``hetzner``
+==================  ================  ================
+
+The values are inlined rather than imported because migrations must
+stay self-contained; the runtime mapping source of truth remains
+:func:`~meho_backplane.operations._lookup.dispatch_product`.
+
+Row-narrowing predicate
+-----------------------
+
+A row is rewritten only when **all** of the following hold:
+
+* ``tenant_id IS NULL`` -- built-in / global rows only. Tenant-scoped
+  rows are operator-owned (the #1699 contract documents the NULL/UUID
+  namespaces as deliberately distinct shadow copies); operators
+  re-ingest under their tenant to update those. Same boundary
+  migration ``0011`` drew.
+* ``product = '<long>'`` -- the row still carries the pre-#1677
+  registry spelling. This is also what makes the UPDATE idempotent:
+  after the rewrite the row carries the short spelling and no longer
+  matches, so a re-run (or the stamp-back replay the test suite
+  exercises) is a no-op.
+* ``impl_id = '<short>' OR impl_id LIKE '<short>-%'`` -- the
+  dispatcher derives the product from the first hyphen-segment of
+  ``impl_id`` (:func:`~meho_backplane.operations._lookup.parse_connector_id`);
+  this clause is that rule expressed in portable SQL. It scopes the
+  rewrite to rows the dispatcher would actually resolve under the
+  short spelling -- a hypothetical ``product='vcf-logs'`` row whose
+  ``impl_id`` derives some *other* product is left alone rather than
+  corrupted into a triple the dispatcher still couldn't reach.
+* ``NOT EXISTS (<short twin>)`` -- collision guard, see below.
+
+Collision guard
+---------------
+
+The partial unique indexes from migration ``0005``
+(``endpoint_descriptor_global_idx`` on ``(product, version, impl_id,
+op_id)`` and ``operation_group_global_idx`` on ``(product, version,
+impl_id, group_key)``, both ``WHERE tenant_id IS NULL``) mean the
+product rewrite can collide: an operator who upgraded to v0.14.0 and
+*re-ingested* a connector already has fresh rows under the short
+spelling, and rewriting the stale long-spelling row onto the same
+natural key would raise ``IntegrityError`` and fail the helm
+pre-upgrade migration Job mid-deploy. Each UPDATE therefore carries a
+correlated ``NOT EXISTS`` self-join that skips long rows whose short
+twin already exists. Skipped rows stay exactly as they were --
+invisible to dispatch, which is the pre-migration status quo (the
+catalog's round-trip integrity gate already drops them from
+listings); the re-ingested short rows are the live ones. Deleting the
+stale twins is deliberately out of scope for a backfill -- destructive
+cleanup stays with the operator (see Task #1700's DELETE surface).
+
+``group_id`` linkage needs no touch-up: ``endpoint_descriptor`` rows
+reference their group by UUID FK, which the product rewrite does not
+change, and both tables are rewritten under the same predicate so a
+connector's descriptors and groups move together.
+
+Reversibility contract
+----------------------
+
+``downgrade()`` is a documented no-op, same rationale as migration
+``0011``: the long spellings carry no operator value (they were never
+dispatchable -- that is the bug), production rollback is image-revert
+plus forward-compatible schema (the additive-only contract in
+``docs/codebase/migrations.md``), and restoring them would
+re-orphan the rows. No DDL runs in ``upgrade()``, so there is nothing
+to undo at the schema layer either.
+
+Cross-references
+----------------
+
+* Task #1701 / Initiative #1691 (G0.25) -- this backfill.
+* Issue #1647 / PR #1677 -- the forward-only register-time
+  reconciliation this migration completes.
+* :func:`~meho_backplane.operations._lookup.dispatch_product` -- the
+  runtime mapping rule this migration mirrors in SQL.
+* Migration ``0011`` -- the self-contained data-backfill precedent
+  (shims, idempotent predicate, documented no-op downgrade).
+* :mod:`tests.test_migration_0038_backfill_product_splits` -- the
+  behavioural contract: rewrite, tenant boundary, collision skip,
+  idempotency, and post-migration dispatch-probe resolution.
+"""
+
+from __future__ import annotations
+
+from collections.abc import Sequence
+from datetime import UTC, datetime
+
+import sqlalchemy as sa
+from alembic import op
+
+# revision identifiers, used by Alembic.
+revision: str = "0038"
+down_revision: str | None = "0037"
+branch_labels: str | Sequence[str] | None = None
+depends_on: str | Sequence[str] | None = None
+
+
+#: Every known long->short product split, as ``(registry_product,
+#: dispatch_product)``. Snapshot of ``_VCF_PRODUCT_SPLITS`` in
+#: ``tests/test_operations_register_ingested.py`` (minus the per-split
+#: impl_id column: the impl_id predicate is *derived* from the short
+#: product below, mirroring how
+#: :func:`~meho_backplane.operations._lookup.dispatch_product` derives
+#: the product from the first hyphen-segment of ``impl_id`` rather
+#: than from a lookup table).
+_PRODUCT_SPLITS: tuple[tuple[str, str], ...] = (
+    ("hetzner-robot", "hetzner"),
+    ("sddc-manager", "sddc"),
+    ("vcf-automation", "vcfa"),
+    ("vcf-fleet", "fleet"),
+    ("vcf-logs", "vrli"),
+    ("vcf-operations", "vrops"),
+)
+
+
+def _backfill_table(
+    *,
+    table_name: str,
+    op_discriminator: str,
+    now: datetime,
+) -> None:
+    """Issue one guarded UPDATE per product split against *table_name*.
+
+    ``op_discriminator`` names the per-operation natural-key column
+    that completes the global unique index alongside ``(product,
+    version, impl_id)`` -- ``op_id`` on ``endpoint_descriptor``,
+    ``group_key`` on ``operation_group``. It participates only in the
+    collision guard's twin correlation; the rewrite predicate itself
+    is per-connector, not per-operation.
+
+    One statement per split (12 total across both tables) rather than
+    a single CASE-expression bulk UPDATE -- same auditability call as
+    migration ``0011``: the row volume is small (hundreds of rows per
+    affected connector at most) and per-split statements keep the SQL
+    log attributable.
+    """
+    shim = sa.table(
+        table_name,
+        sa.column("tenant_id", sa.Uuid()),
+        sa.column("product", sa.Text()),
+        sa.column("version", sa.Text()),
+        sa.column("impl_id", sa.Text()),
+        sa.column(op_discriminator, sa.Text()),
+        sa.column("updated_at", sa.DateTime(timezone=True)),
+    )
+    twin = shim.alias("twin")
+    bind = op.get_bind()
+
+    for long_product, short_product in _PRODUCT_SPLITS:
+        # Correlated existence probe for a row already persisted under
+        # the short spelling on the same global natural key (a
+        # post-upgrade re-ingest). The outer UPDATE target correlates
+        # automatically; only ``twin`` is selected from.
+        short_twin_exists = (
+            sa.select(sa.literal(1))
+            .select_from(twin)
+            .where(
+                twin.c.tenant_id.is_(None),
+                twin.c.product == short_product,
+                twin.c.version == shim.c.version,
+                twin.c.impl_id == shim.c.impl_id,
+                twin.c[op_discriminator] == shim.c[op_discriminator],
+            )
+            .exists()
+        )
+        stmt = (
+            sa.update(shim)
+            .where(
+                shim.c.tenant_id.is_(None),
+                shim.c.product == long_product,
+                # First-hyphen-segment rule from ``parse_connector_id``:
+                # the dispatcher resolves this row under ``short_product``
+                # exactly when ``impl_id`` is the short product itself or
+                # starts with ``"<short>-"``.
+                sa.or_(
+                    shim.c.impl_id == short_product,
+                    shim.c.impl_id.like(f"{short_product}-%"),
+                ),
+                ~short_twin_exists,
+            )
+            .values(product=short_product, updated_at=now)
+        )
+        bind.execute(stmt)
+
+
+def upgrade() -> None:
+    """Reconcile orphaned long-product rows to the dispatch-canonical spelling.
+
+    Both row surfaces the dispatch/query layer reads --
+    ``endpoint_descriptor`` and ``operation_group`` -- are rewritten
+    under the same predicate so a connector's operations and groups
+    stay aligned. ``updated_at`` is bumped (single ``now`` per run,
+    same discipline as migration ``0011``) so operator tooling driven
+    off the column sees the change.
+    """
+    now = datetime.now(UTC)
+    _backfill_table(
+        table_name="endpoint_descriptor",
+        op_discriminator="op_id",
+        now=now,
+    )
+    _backfill_table(
+        table_name="operation_group",
+        op_discriminator="group_key",
+        now=now,
+    )
+
+
+def downgrade() -> None:
+    """No-op by design.
+
+    Restoring the long registry spellings would re-orphan the rows --
+    the long form was never dispatchable (that is the defect this
+    migration fixes), so the pre-upgrade state carries no operator
+    value to recover. Production rollback is image-revert plus the
+    additive-only forward-compat contract (``docs/codebase/migrations.md``);
+    a v0.13.x image reading short-spelling rows simply serves them,
+    because the short spelling is what the dispatch surface keyed on
+    in every release. No DDL runs in ``upgrade()``, so there is
+    nothing to undo at the column / index / constraint layer. Same
+    documented-no-op shape as migration ``0011``.
+    """
+    # Intentionally empty -- see docstring. The function stays defined
+    # so ``alembic downgrade -1`` resolves the symbol cleanly.

--- a/backend/tests/test_doc_collections_registry.py
+++ b/backend/tests/test_doc_collections_registry.py
@@ -635,12 +635,20 @@ def test_migration_0037_downgrade_drops_table(
     monkeypatch: pytest.MonkeyPatch,
     tmp_path: Path,
 ) -> None:
-    """``upgrade head`` → ``downgrade -1`` is clean: the table is gone."""
+    """``upgrade 0037`` → ``downgrade -1`` is clean: the table is gone.
+
+    The upgrade target is pinned to ``0037`` (not ``head``) so the
+    relative ``-1`` always exercises *this* migration's
+    ``downgrade()`` -- with later revisions present (``0038``'s data
+    backfill ships a documented-no-op downgrade), ``head`` → ``-1``
+    would walk the newest migration instead and the table would
+    survive. Same pin-the-target discipline as the 0011 replay test.
+    """
     from alembic import command
 
     cfg, sync_url = _alembic_cfg(monkeypatch, tmp_path)
     try:
-        command.upgrade(cfg, "head")
+        command.upgrade(cfg, "0037")
         assert "doc_collections" in _table_names(sync_url)
 
         command.downgrade(cfg, "-1")

--- a/backend/tests/test_migration_0038_backfill_product_splits.py
+++ b/backend/tests/test_migration_0038_backfill_product_splits.py
@@ -1,0 +1,554 @@
+# SPDX-License-Identifier: Apache-2.0
+# Copyright (c) 2026 evoila Group
+
+"""Behavioural tests for ``0038_backfill_endpoint_descriptor_product_splits``.
+
+Initiative #1691 (G0.25 v0.14.0 cycle-10 dogfood hardening), Task
+#1701 (CI-3). The migration reconciles pre-v0.14.0 built-in rows
+persisted under the long registry product spellings (``vcf-logs``
+etc.) to the short dispatch-canonical spellings (``vrli`` etc.) that
+PR #1677 (#1647) made the register-time path write -- the data half
+of a fix that was otherwise forward-only.
+
+Test matrix
+-----------
+
+* **Long rows -> reconciled.** Descriptor + group rows seeded under
+  ``(vcf-logs, 9.0, vrli-rest)`` carry ``product='vrli'`` (and a
+  bumped ``updated_at``) after ``upgrade head``.
+* **All six splits, SQL-level counts.** One descriptor + one group
+  per split; post-migration each long-product count is 0 and each
+  short-product count is 1, on both tables.
+* **Tenant-scoped rows -> preserved.** ``tenant_id IS NOT NULL`` rows
+  are operator-owned (#1699 scoping contract) and never rewritten.
+* **Short twin -> long row skipped, no crash.** When a post-upgrade
+  re-ingest already created the short-spelling row on the same
+  global natural key, the long row is left untouched instead of
+  colliding with the partial unique indexes from migration ``0005``.
+* **Foreign impl_id -> preserved.** A ``product='vcf-logs'`` row
+  whose ``impl_id`` derives some other product is not rewritten (the
+  predicate mirrors ``parse_connector_id``'s first-hyphen-segment
+  rule, not a blanket product rename); unmapped products are
+  untouched.
+* **Idempotency.** Re-running the migration's ``upgrade()`` against
+  an already-reconciled DB (stamp back + re-upgrade, the same replay
+  shape :mod:`tests.test_migration_0011_backfill_when_to_use`
+  established) changes nothing, including ``updated_at``.
+* **Dispatch probes resolve post-migration.** The acceptance gate
+  from #1701: ``connector_exists`` / ``count_known_ops`` keyed on the
+  ``parse_connector_id``-derived triple miss the orphaned rows before
+  the migration and resolve them after.
+
+Sync-test constraint: ``alembic.command.upgrade`` drives env.py's
+async cookbook through ``asyncio.run``, so test functions stay sync
+and the dispatch-probe test wraps its async probe in its own
+``asyncio.run`` with an engine-cache reset on each side.
+"""
+
+from __future__ import annotations
+
+import asyncio
+from collections.abc import Iterator
+from pathlib import Path
+from typing import Final
+from uuid import UUID, uuid4
+
+import pytest
+from alembic import command
+from alembic.config import Config
+from sqlalchemy import create_engine as sa_create_engine
+from sqlalchemy import text
+
+from meho_backplane.db.engine import dispose_engine, reset_engine_for_testing
+from meho_backplane.db.migrations import alembic_config
+from meho_backplane.operations._lookup import (
+    connector_exists,
+    count_known_ops,
+    parse_connector_id,
+)
+from meho_backplane.settings import get_settings
+
+#: The six long->short splits the migration reconciles, as
+#: ``(registry_product, impl_id, dispatch_product)``. Mirrors
+#: ``_VCF_PRODUCT_SPLITS`` in :mod:`tests.test_operations_register_ingested`
+#: (the register-time fixture) and the snapshot inside migration 0038.
+_SPLITS: Final[list[tuple[str, str, str]]] = [
+    ("hetzner-robot", "hetzner-rest", "hetzner"),
+    ("sddc-manager", "sddc-rest", "sddc"),
+    ("vcf-automation", "vcfa-rest", "vcfa"),
+    ("vcf-fleet", "fleet-rest", "fleet"),
+    ("vcf-logs", "vrli-rest", "vrli"),
+    ("vcf-operations", "vrops-rest", "vrops"),
+]
+
+_VERSION: Final[str] = "9.0"
+
+#: Deliberately old seed timestamp -- lets assertions tell "migration
+#: bumped updated_at" apart from "row untouched" without sleeping.
+_SEED_TS: Final[str] = "2026-01-01T00:00:00+00:00"
+
+
+@pytest.fixture
+def alembic_cfg(
+    monkeypatch: pytest.MonkeyPatch,
+    tmp_path: Path,
+) -> Iterator[tuple[Config, str]]:
+    """Pin env, reset caches, return an Alembic config + sync URL.
+
+    Same harness as :mod:`tests.test_migration_0011_backfill_when_to_use`:
+    sync fixture (``alembic.command`` calls ``asyncio.run`` internally),
+    per-test SQLite file under ``tmp_path``, settings + engine caches
+    reset on both sides so the alembic env and the dispatch probes read
+    *this* ``DATABASE_URL``.
+    """
+    db_path = tmp_path / "migration_0038.db"
+    async_url = f"sqlite+aiosqlite:///{db_path}"
+    sync_url = f"sqlite:///{db_path}"
+    monkeypatch.setenv("DATABASE_URL", async_url)
+    monkeypatch.setenv("KEYCLOAK_ISSUER_URL", "https://keycloak.test/realms/meho")
+    monkeypatch.setenv("KEYCLOAK_AUDIENCE", "meho-backplane")
+    monkeypatch.setenv("VAULT_ADDR", "https://vault.test")
+    get_settings.cache_clear()
+    reset_engine_for_testing()
+
+    cfg = alembic_config()
+    cfg.set_main_option("sqlalchemy.url", async_url)
+    try:
+        yield cfg, sync_url
+    finally:
+        get_settings.cache_clear()
+        reset_engine_for_testing()
+
+
+def _insert_descriptor_row(
+    sync_url: str,
+    *,
+    tenant_id: UUID | None,
+    product: str,
+    impl_id: str,
+    op_id: str,
+    version: str = _VERSION,
+) -> UUID:
+    """Insert one minimal ``endpoint_descriptor`` row at revision 0037.
+
+    Raw SQL (not the ORM) keeps the seed pinned to the schema the
+    migration actually runs against. Columns with SQLite server
+    defaults from migration 0005 (``tags``, ``parameter_schema``,
+    ``safety_level``, ``requires_approval``, ``is_enabled``) are
+    omitted; ``is_enabled`` therefore defaults to 1, which the
+    ``count_known_ops`` probe relies on. UUID binds use ``.hex`` per
+    the convention in ``docs/codebase/migrations.md``.
+    """
+    row_id = uuid4()
+    sync_eng = sa_create_engine(sync_url)
+    try:
+        with sync_eng.begin() as conn:
+            conn.execute(
+                text(
+                    """
+                    INSERT INTO endpoint_descriptor (
+                        id, tenant_id, product, version, impl_id, op_id,
+                        source_kind, created_at, updated_at
+                    ) VALUES (
+                        :id, :tenant_id, :product, :version, :impl_id, :op_id,
+                        'ingested', :ts, :ts
+                    )
+                    """,
+                ),
+                {
+                    "id": row_id.hex,
+                    "tenant_id": tenant_id.hex if tenant_id is not None else None,
+                    "product": product,
+                    "version": version,
+                    "impl_id": impl_id,
+                    "op_id": op_id,
+                    "ts": _SEED_TS,
+                },
+            )
+    finally:
+        sync_eng.dispose()
+    return row_id
+
+
+def _insert_group_row(
+    sync_url: str,
+    *,
+    tenant_id: UUID | None,
+    product: str,
+    impl_id: str,
+    group_key: str,
+    version: str = _VERSION,
+) -> UUID:
+    """Insert one minimal ``operation_group`` row at revision 0037."""
+    row_id = uuid4()
+    sync_eng = sa_create_engine(sync_url)
+    try:
+        with sync_eng.begin() as conn:
+            conn.execute(
+                text(
+                    """
+                    INSERT INTO operation_group (
+                        id, tenant_id, product, version, impl_id, group_key,
+                        name, when_to_use, review_status, created_at, updated_at
+                    ) VALUES (
+                        :id, :tenant_id, :product, :version, :impl_id, :group_key,
+                        :name, 'seeded for 0038 backfill test', 'enabled', :ts, :ts
+                    )
+                    """,
+                ),
+                {
+                    "id": row_id.hex,
+                    "tenant_id": tenant_id.hex if tenant_id is not None else None,
+                    "product": product,
+                    "version": version,
+                    "impl_id": impl_id,
+                    "group_key": group_key,
+                    "name": group_key.title(),
+                    "ts": _SEED_TS,
+                },
+            )
+    finally:
+        sync_eng.dispose()
+    return row_id
+
+
+def _read_row(sync_url: str, table: str, row_id: UUID) -> tuple[str, str]:
+    """Return ``(product, updated_at)`` for one row, as strings."""
+    sync_eng = sa_create_engine(sync_url)
+    try:
+        with sync_eng.connect() as conn:
+            row = conn.execute(
+                text(f"SELECT product, updated_at FROM {table} WHERE id = :id"),
+                {"id": row_id.hex},
+            ).one()
+            return (str(row.product), str(row.updated_at))
+    finally:
+        sync_eng.dispose()
+
+
+def _count_by_product(sync_url: str, table: str, product: str) -> int:
+    """Return ``COUNT(*)`` for one product on one table."""
+    sync_eng = sa_create_engine(sync_url)
+    try:
+        with sync_eng.connect() as conn:
+            count = conn.execute(
+                text(f"SELECT COUNT(*) FROM {table} WHERE product = :product"),
+                {"product": product},
+            ).scalar_one()
+            return int(count)
+    finally:
+        sync_eng.dispose()
+
+
+def test_long_product_rows_reconciled_to_dispatch_spelling(
+    alembic_cfg: tuple[Config, str],
+) -> None:
+    """Built-in long-spelling rows carry the short product after upgrade.
+
+    Both row surfaces move together -- the descriptor and its group
+    are rewritten under the same predicate -- and ``updated_at`` is
+    bumped so operator tooling driven off the column sees the change.
+    """
+    cfg, sync_url = alembic_cfg
+    command.upgrade(cfg, "0037")
+
+    descriptor_id = _insert_descriptor_row(
+        sync_url,
+        tenant_id=None,
+        product="vcf-logs",
+        impl_id="vrli-rest",
+        op_id="GET:/api/v2/version",
+    )
+    group_id = _insert_group_row(
+        sync_url,
+        tenant_id=None,
+        product="vcf-logs",
+        impl_id="vrli-rest",
+        group_key="system",
+    )
+
+    command.upgrade(cfg, "head")
+
+    for table, row_id in (
+        ("endpoint_descriptor", descriptor_id),
+        ("operation_group", group_id),
+    ):
+        product, updated_at = _read_row(sync_url, table, row_id)
+        assert product == "vrli", f"{table} row must carry the dispatch product"
+        assert updated_at != _SEED_TS, f"{table}.updated_at must be bumped by the rewrite"
+
+
+def test_all_six_splits_reconcile_to_expected_counts(
+    alembic_cfg: tuple[Config, str],
+) -> None:
+    """SQL-level validation: post-migration counts match the reconciled state.
+
+    One descriptor + one group seeded per split under the long
+    spelling; after the upgrade every long-product count is 0 and
+    every short-product count is 1, on both tables (#1701 acceptance
+    criterion).
+    """
+    cfg, sync_url = alembic_cfg
+    command.upgrade(cfg, "0037")
+
+    for long_product, impl_id, _ in _SPLITS:
+        _insert_descriptor_row(
+            sync_url,
+            tenant_id=None,
+            product=long_product,
+            impl_id=impl_id,
+            op_id="GET:/api/v2/version",
+        )
+        _insert_group_row(
+            sync_url,
+            tenant_id=None,
+            product=long_product,
+            impl_id=impl_id,
+            group_key="system",
+        )
+
+    command.upgrade(cfg, "head")
+
+    for long_product, _, short_product in _SPLITS:
+        for table in ("endpoint_descriptor", "operation_group"):
+            assert _count_by_product(sync_url, table, long_product) == 0, (
+                f"no {table} row may remain under {long_product!r} after the backfill"
+            )
+            assert _count_by_product(sync_url, table, short_product) == 1, (
+                f"exactly the seeded {table} row must surface under {short_product!r}"
+            )
+
+
+def test_tenant_scoped_rows_preserved(
+    alembic_cfg: tuple[Config, str],
+) -> None:
+    """``tenant_id IS NOT NULL`` rows are operator-owned and never rewritten.
+
+    The #1699 scoping contract keeps the NULL and per-tenant
+    namespaces as deliberately distinct shadow copies; operators
+    re-ingest under their tenant to update theirs (#1701 out-of-scope
+    note).
+    """
+    cfg, sync_url = alembic_cfg
+    command.upgrade(cfg, "0037")
+
+    tenant_id = uuid4()
+    descriptor_id = _insert_descriptor_row(
+        sync_url,
+        tenant_id=tenant_id,
+        product="vcf-logs",
+        impl_id="vrli-rest",
+        op_id="GET:/api/v2/version",
+    )
+    group_id = _insert_group_row(
+        sync_url,
+        tenant_id=tenant_id,
+        product="vcf-logs",
+        impl_id="vrli-rest",
+        group_key="system",
+    )
+
+    command.upgrade(cfg, "head")
+
+    for table, row_id in (
+        ("endpoint_descriptor", descriptor_id),
+        ("operation_group", group_id),
+    ):
+        product, updated_at = _read_row(sync_url, table, row_id)
+        assert product == "vcf-logs", f"tenant-scoped {table} row must keep its product"
+        assert updated_at == _SEED_TS, f"tenant-scoped {table} row must not be touched"
+
+
+def test_short_twin_collision_is_skipped_not_crashed(
+    alembic_cfg: tuple[Config, str],
+) -> None:
+    """A pre-existing short-spelling twin parks the long row instead of crashing.
+
+    The re-ingested-after-upgrade scenario: rewriting the long row
+    would collide with ``endpoint_descriptor_global_idx`` /
+    ``operation_group_global_idx`` (migration 0005) on the short
+    twin's natural key. The ``NOT EXISTS`` guard skips it so the helm
+    pre-upgrade migration Job cannot fail with ``IntegrityError``; the
+    skipped row stays exactly as orphaned as it already was.
+    """
+    cfg, sync_url = alembic_cfg
+    command.upgrade(cfg, "0037")
+
+    long_descriptor = _insert_descriptor_row(
+        sync_url,
+        tenant_id=None,
+        product="vcf-logs",
+        impl_id="vrli-rest",
+        op_id="GET:/api/v2/version",
+    )
+    short_descriptor = _insert_descriptor_row(
+        sync_url,
+        tenant_id=None,
+        product="vrli",
+        impl_id="vrli-rest",
+        op_id="GET:/api/v2/version",
+    )
+    long_group = _insert_group_row(
+        sync_url,
+        tenant_id=None,
+        product="vcf-logs",
+        impl_id="vrli-rest",
+        group_key="system",
+    )
+    short_group = _insert_group_row(
+        sync_url,
+        tenant_id=None,
+        product="vrli",
+        impl_id="vrli-rest",
+        group_key="system",
+    )
+
+    # Must not raise -- the guard, not the unique index, decides.
+    command.upgrade(cfg, "head")
+
+    for table, long_id, short_id in (
+        ("endpoint_descriptor", long_descriptor, short_descriptor),
+        ("operation_group", long_group, short_group),
+    ):
+        long_product, long_updated = _read_row(sync_url, table, long_id)
+        assert long_product == "vcf-logs", f"collided {table} row must be skipped"
+        assert long_updated == _SEED_TS, f"collided {table} row must not be touched"
+        short_product, short_updated = _read_row(sync_url, table, short_id)
+        assert short_product == "vrli", f"re-ingested {table} twin must stay live"
+        assert short_updated == _SEED_TS, f"re-ingested {table} twin must not be touched"
+
+
+def test_foreign_impl_id_rows_preserved(
+    alembic_cfg: tuple[Config, str],
+) -> None:
+    """The rewrite follows ``parse_connector_id``, not a blanket product rename.
+
+    A ``product='vcf-logs'`` row whose ``impl_id`` first-hyphen-segment
+    is not ``vrli`` would still be unreachable under ``vrli`` after a
+    rewrite, so the migration leaves it alone. Aligned connectors
+    (``vmware`` / ``vmware-rest``) are not in the mapping and are
+    untouched.
+    """
+    cfg, sync_url = alembic_cfg
+    command.upgrade(cfg, "0037")
+
+    foreign_impl = _insert_descriptor_row(
+        sync_url,
+        tenant_id=None,
+        product="vcf-logs",
+        impl_id="custom-rest",
+        op_id="GET:/api/v2/version",
+    )
+    aligned = _insert_descriptor_row(
+        sync_url,
+        tenant_id=None,
+        product="vmware",
+        impl_id="vmware-rest",
+        op_id="GET:/api/vcenter/cluster",
+    )
+
+    command.upgrade(cfg, "head")
+
+    product, updated_at = _read_row(sync_url, "endpoint_descriptor", foreign_impl)
+    assert (product, updated_at) == ("vcf-logs", _SEED_TS), (
+        "a long-product row whose impl_id derives another product must not be rewritten"
+    )
+    product, updated_at = _read_row(sync_url, "endpoint_descriptor", aligned)
+    assert (product, updated_at) == ("vmware", _SEED_TS), (
+        "aligned connectors are outside the mapping and must not move"
+    )
+
+
+def test_re_running_migration_is_idempotent(
+    alembic_cfg: tuple[Config, str],
+) -> None:
+    """Replaying ``upgrade()`` on a reconciled DB changes nothing.
+
+    Same stamp-back replay shape as the 0011 test: after the first
+    pass the rows no longer match ``product = '<long>'``, so a second
+    execution of the migration body is filter-shaped no-op --
+    ``updated_at`` must not move either. Both passes pin the target
+    to ``0038`` so future non-idempotent schema migrations cannot
+    leak into the replay.
+    """
+    cfg, sync_url = alembic_cfg
+    command.upgrade(cfg, "0037")
+
+    descriptor_id = _insert_descriptor_row(
+        sync_url,
+        tenant_id=None,
+        product="vcf-logs",
+        impl_id="vrli-rest",
+        op_id="GET:/api/v2/version",
+    )
+
+    command.upgrade(cfg, "0038")
+    first_product, first_updated = _read_row(sync_url, "endpoint_descriptor", descriptor_id)
+    assert first_product == "vrli"  # sanity: first pass landed
+
+    command.stamp(cfg, "0037")
+    command.upgrade(cfg, "0038")
+
+    second_product, second_updated = _read_row(sync_url, "endpoint_descriptor", descriptor_id)
+    assert second_product == first_product
+    assert second_updated == first_updated, (
+        "second invocation must not bump updated_at -- the product predicate "
+        "filters reconciled rows out before the UPDATE runs"
+    )
+
+
+def test_dispatch_probes_resolve_reconciled_connector(
+    alembic_cfg: tuple[Config, str],
+) -> None:
+    """``connector_exists`` / ``count_known_ops`` flip from miss to hit.
+
+    The #1701 acceptance gate, end to end: the dispatch surface keys
+    on the triple ``parse_connector_id`` derives from the
+    connector_id. Before the migration the orphaned long rows are
+    invisible to it (the CI-3 symptom); after the migration the
+    probes resolve the connector and count its enabled ops.
+    """
+    cfg, sync_url = alembic_cfg
+    command.upgrade(cfg, "0037")
+
+    for op_id in ("GET:/api/v2/version", "GET:/api/v2/events"):
+        _insert_descriptor_row(
+            sync_url,
+            tenant_id=None,
+            product="vcf-logs",
+            impl_id="vrli-rest",
+            op_id=op_id,
+        )
+
+    product, version, impl_id = parse_connector_id("vrli-rest-9.0")
+    assert (product, version, impl_id) == ("vrli", "9.0", "vrli-rest")
+
+    async def _probe() -> tuple[bool, int]:
+        # Fresh engine on this event loop; disposed before the loop
+        # closes so no aiosqlite connection outlives its loop.
+        reset_engine_for_testing()
+        try:
+            exists = await connector_exists(
+                tenant_id=uuid4(),
+                product=product,
+                version=version,
+                impl_id=impl_id,
+            )
+            known = await count_known_ops(
+                product=product,
+                version=version,
+                impl_id=impl_id,
+            )
+            return exists, known
+        finally:
+            await dispose_engine()
+
+    exists_before, known_before = asyncio.run(_probe())
+    assert exists_before is False, "orphaned long rows must be invisible pre-migration"
+    assert known_before == 0
+
+    command.upgrade(cfg, "head")
+
+    exists_after, known_after = asyncio.run(_probe())
+    assert exists_after is True, "reconciled rows must resolve through the dispatch probe"
+    assert known_after == 2, "both enabled ops must count under the short product"

--- a/docs/codebase/migrations.md
+++ b/docs/codebase/migrations.md
@@ -132,9 +132,21 @@ Migrations that INSERT, UPDATE, or DELETE rows. Rules:
    `datetime.now(UTC).isoformat()` string as a bind parameter.
 5. **Idempotent.** `ON CONFLICT DO NOTHING` / `ON CONFLICT DO UPDATE` so a
    re-run on an already-migrated DB is a no-op.
-6. **Reversible.** `downgrade()` must undo the data (delete seeded rows by a
-   stable discriminant such as `actor_sub` or slug) without touching rows the
-   operator authored independently.
+6. **Reversible — or a documented no-op.** Seed migrations undo their data in
+   `downgrade()` (delete seeded rows by a stable discriminant such as
+   `actor_sub` or slug) without touching rows the operator authored
+   independently. Backfill-rewrite migrations (`0011`, `0038`) instead ship a
+   **documented no-op** `downgrade()` when the pre-upgrade value carries no
+   operator-recoverable state (restoring it would need a copy column, and the
+   restored value serves no one). The no-op must say *why* in its docstring —
+   explicit refusal beats silent partial recovery.
+7. **Guard natural-key rewrites against collisions.** An UPDATE that rewrites
+   part of a unique key (e.g. `0038` rewriting `product`) must carry a
+   correlated `NOT EXISTS` twin check on the target key, or a row inserted
+   under the new spelling after the fix-forward release will make the
+   migration Job die with `IntegrityError` mid-deploy. Skip-and-leave beats
+   delete: the skipped row stays in its pre-migration state, and destructive
+   cleanup remains operator-driven.
 
 ## Additive-only constraint
 
@@ -232,6 +244,9 @@ avoid "event loop already running" errors.
 - `backend/alembic/versions/0018_seed_rdc_internal_conventions.py`: the
   canonical data-migration reference implementation with `_uuid_param` and
   `_coerce_uuid` helpers.
+- `backend/alembic/versions/0038_backfill_endpoint_descriptor_product_splits.py`:
+  the canonical collision-guarded backfill-rewrite (correlated `NOT EXISTS`
+  twin check on a partial-unique natural key, documented no-op downgrade).
 - `backend/tests/test_alembic_uuid_param_consistency.py`: drift-guard test.
 - `backend/tests/test_alembic_seed_rdc_conventions.py`: 0018 behavioural tests.
 - `backend/tests/test_migration_compat.py`: additive-only CI guard tests.


### PR DESCRIPTION
## Summary

- Adds Alembic data migration `0038_backfill_endpoint_descriptor_product_splits` — the data half of #1647/#1677's forward-only register-time product reconciliation. Pre-v0.14.0 built-in rows persisted under the six long registry spellings (`vcf-logs`, `vcf-automation`, `vcf-fleet`, `vcf-operations`, `sddc-manager`, `hetzner-robot`) are rewritten to the dispatch-canonical short spellings (`vrli`, `vcfa`, `fleet`, `vrops`, `sddc`, `hetzner`) on both `endpoint_descriptor` and `operation_group`, so dispatch probes (`connector_exists`, `search_operations`, `list_operation_groups`) resolve them after upgrade instead of reporting `registered, 0 ops` (RDC v0.14.0 cycle-10 finding CI-3).
- Predicate mirrors `dispatch_product` exactly: `tenant_id IS NULL` (the #1699 contract keeps tenant namespaces operator-owned) AND `product = '<long>'` AND impl_id's first hyphen-segment equals the short product (`impl_id = '<short>' OR impl_id LIKE '<short>-%'`). Idempotent by construction — rewritten rows no longer match `product = '<long>'`.
- **Collision guard beyond the issue's AC list:** an operator who upgraded to v0.14.0 and re-ingested a connector already has rows under the short spelling; an unguarded UPDATE would hit the partial unique indexes from migration `0005` and fail the helm pre-upgrade migration Job with `IntegrityError` mid-deploy. Each UPDATE carries a correlated `NOT EXISTS` twin check; collided long rows are skipped (they stay exactly as dispatch-invisible as before — no regression, no destructive delete).
- `downgrade()` is a documented no-op (0011 precedent; the long spelling was never dispatchable, so there is no operator state to restore). `docs/codebase/migrations.md` rule 6 now names both data-migration reversibility shapes and a new rule 7 records the collision-guard discipline.

## Test plan

- [x] `uv run ruff check src/ tests/ alembic/versions/0038_...py` — clean
- [x] `uv run ruff format --check` — clean (952 files)
- [x] `uv run mypy src/` — clean (468 files)
- [x] `python3 scripts/ci/check_migration_compat.py` — pass (UPDATE-only data migration; no destructive DDL)
- [x] `uv run pytest tests/test_migration_0038_backfill_product_splits.py` — 7 passed:
  - AC "UPDATEs both tables" + "mapping matches dispatch_product" — `test_long_product_rows_reconciled_to_dispatch_spelling`, `test_foreign_impl_id_rows_preserved`
  - AC "SQL-level validation: query counts match expected reconciled state" — `test_all_six_splits_reconcile_to_expected_counts`
  - AC "only `tenant_id IS NULL`" — `test_tenant_scoped_rows_preserved`
  - AC "idempotent" — `test_re_running_migration_is_idempotent` (stamp-back replay, `updated_at` stable)
  - AC "integration test: dispatch probes resolve after migration" — `test_dispatch_probes_resolve_reconciled_connector` (`connector_exists` False→True, `count_known_ops` 0→2 across the upgrade, keyed via `parse_connector_id`)
  - collision guard — `test_short_twin_collision_is_skipped_not_crashed`
- [x] `uv run pytest tests/test_alembic_uuid_param_consistency.py tests/test_migration_compat.py` — 60 passed (drift guards now scan 0038; no UUID bind params in the migration)
- [x] Full unit sweep `pytest -n 6 --dist loadscope --ignore=tests/integration` — 7303 passed, 195 skipped, 1 failed: `test_migration_0037_downgrade_drops_table` coupled `upgrade head` with `downgrade -1` (now walks 0038's no-op instead of 0037's table drop) — fixed by pinning the upgrade target to `0037`; file re-run green (22 passed incl. the new 0038 suite). A first sweep pass also tripped the known structlog/xdist capture flake (`test_forwarded_jwt_never_logged`) — passes in isolation, unrelated to this diff
- [x] `alembic upgrade head` + `alembic downgrade -1` CLI smoke against a scratch SQLite — full chain 0001→0038 applies, no-op downgrade resolves cleanly (the helm migration Job path)
- [ ] PG-side replay (`alembic upgrade head` on pgvector testcontainers) — no Docker in this sandbox; runs in the required `Python (integration testcontainers)` CI lane

## Revision-graph note for the merge queue

`down_revision = "0037"` was the Alembic head at branch time (base `2c57eae5`). No sibling task in this wave adds a migration, but if an unrelated migration lands on `main` before this merges, the rebase will surface a multiple-heads conflict that needs a one-line re-parent of `0038`'s `down_revision` (and the test's `command.upgrade(cfg, "0037")` pin) — don't resolve it blind.

## Out of scope

- Tenant-scoped rows (`tenant_id IS NOT NULL`) — operator-owned per the #1699 scoping contract; re-ingest under the tenant is the documented path (issue out-of-scope note).
- Deleting collided long-spelling twins — destructive cleanup stays operator-driven (#1700 adds the DELETE surface).

<!-- auto-implement-issue: fresh, iteration 1 -->

Closes #1701


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Reconciled pre-v0.14.0 ingested operations that used legacy product name spellings, converting them to dispatch-canonical format to restore dispatchability after upgrade.

* **Documentation**
  * Updated migration guidelines to document collision-guarding and no-op downgrade patterns for backfill-rewrite migrations.

* **Tests**
  * Added comprehensive test coverage for the product spelling reconciliation migration.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->