### PR TITLE
feat(connectors): add connector DELETE surface for zero-op ingest stubs (#1700)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -90,6 +90,19 @@ connector-related release-notes line.
 
 ## [Unreleased]
 
+### Added
+
+- Connector DELETE surface for the zero-op registry stubs aborted
+  ingests leave behind: `DELETE /api/v1/connectors/{connector_id}`
+  (204, tenant_admin, always operator-tenant-scoped) and the
+  `meho.connector.delete` MCP tool (optional `tenant_id`, omitted =
+  built-in / global scope). Removes the scoped `operation_group` +
+  `endpoint_descriptor` rows with one `meho.connector.delete` audit
+  row, deregisters the triple's `GenericRestConnector` auto-shim when
+  no rows remain anywhere (hand-coded classes never), warns —
+  advisory, not error — when enabled operations are deleted, and
+  re-ingest revives the connector from scratch (#1700)
+
 ### Changed
 
 - Document and pin the ingest tenant-scope contract across surfaces:

--- a/backend/src/meho_backplane/api/v1/connectors_ingest.py
+++ b/backend/src/meho_backplane/api/v1/connectors_ingest.py
@@ -3,8 +3,8 @@
 
 """``/api/v1/connectors*`` -- REST surface for spec-ingestion + review.
 
-G0.7-T6 (#406) of Initiative #389. Seven routes mounted under
-``/api/v1/connectors*`` that drive the spec-ingestion pipeline (T1
+G0.7-T6 (#406) of Initiative #389. The routes mounted under
+``/api/v1/connectors*`` drive the spec-ingestion pipeline (T1
 parser + T2 register_ingested + T3 LLM grouping) and the
 review-queue state machine (T4 :class:`ReviewService`).
 
@@ -34,6 +34,10 @@ Route inventory
 * ``POST /api/v1/connectors/{connector_id}/disable`` — transition all
   groups to ``disabled``; cascade. Returns 204. Idempotent. Role:
   ``tenant_admin``.
+* ``DELETE /api/v1/connectors/{connector_id}`` — delete the connector:
+  remove its rows under the operator's tenant scope and, when no rows
+  remain for the triple anywhere, deregister the auto-registered
+  ingest shim (G0.25-T2 #1700). Returns 204. Role: ``tenant_admin``.
 
 Tenant scoping
 --------------
@@ -1218,6 +1222,62 @@ async def disable_endpoint(
     except InvalidStateTransitionError as exc:
         raise HTTPException(
             status_code=http_status.HTTP_409_CONFLICT,
+            detail=str(exc),
+        ) from exc
+    return Response(status_code=http_status.HTTP_204_NO_CONTENT)
+
+
+@router.delete(
+    "/{connector_id}",
+    status_code=http_status.HTTP_204_NO_CONTENT,
+    response_class=Response,
+)
+async def delete_endpoint(
+    connector_id: str,
+    operator: Operator = _require_admin,
+) -> Response:
+    """Delete *connector_id* — rows under the operator's tenant + the ingest shim.
+
+    G0.25-T2 (#1700): clean-up surface for the zero-op registry stubs
+    aborted ingests leave behind, and for removing an unwanted
+    ingested connector outright. Removes the connector's
+    ``endpoint_descriptor`` + ``operation_group`` rows and writes one
+    ``meho.connector.delete`` audit row in the same transaction; when
+    no rows remain for the triple under any scope, the
+    auto-registered ``GenericRestConnector`` shim is also popped from
+    the v2 registry (hand-coded connector classes are never
+    deregistered). A zero-op stub — registered class, no rows — is
+    deletable here too: that delete is registry-only.
+
+    Tenant scoping (#1699 contract): this route exposes **no**
+    ``tenant_id`` parameter — the delete scope is always the calling
+    operator's tenant from the JWT. Built-in / global connectors
+    (``tenant_id IS NULL`` rows) are deleted via the MCP sibling
+    ``meho.connector.delete`` with ``tenant_id`` omitted
+    (tenant_admin only). Unknown ids, cross-tenant probes, and rows
+    visible only under a scope this route cannot name all collapse
+    into the same 404 the other connector routes use; a repeat
+    DELETE therefore returns 404 once the first one landed.
+
+    A connector that still has enabled operations is deleted anyway —
+    the advisory is deliberate, not an error: it surfaces as the
+    ``connector_delete_enabled_ops`` structured log event plus the
+    audit payload's ``enabled_operations_deleted`` count. The wire
+    response stays ``204 No Content`` per the task contract, so the
+    structured warning body lives on the MCP sibling (the
+    ``edit_op`` 200-promotion precedent from #1630 remains available
+    if a REST wire home is ever needed). Re-ingesting the same triple
+    afterwards re-registers the connector from scratch.
+    """
+    service = ReviewService(operator)
+    try:
+        await service.delete_connector(
+            connector_id,
+            tenant_id=operator.tenant_id,
+        )
+    except ConnectorNotFoundError as exc:
+        raise HTTPException(
+            status_code=http_status.HTTP_404_NOT_FOUND,
             detail=str(exc),
         ) from exc
     return Response(status_code=http_status.HTTP_204_NO_CONTENT)

--- a/backend/src/meho_backplane/connectors/registry.py
+++ b/backend/src/meho_backplane/connectors/registry.py
@@ -46,6 +46,7 @@ __all__ = [
     "all_connectors_v2",
     "canonical_product_token",
     "clear_registry",
+    "deregister_connector_v2",
     "get_connector",
     "list_connector_impls",
     "register_connector",
@@ -176,6 +177,59 @@ def register_connector_v2(
         impl_id=impl_id,
         cls=cls.__name__,
     )
+
+
+def deregister_connector_v2(
+    *,
+    product: str,
+    version: str,
+    impl_id: str,
+) -> bool:
+    """Remove one v2 three-tuple registration. Returns whether a key was removed.
+
+    Counterpart to :func:`register_connector_v2`, added for the
+    connector DELETE surface (G0.25 #1700): operators can remove the
+    :class:`~meho_backplane.operations.ingest.connector_registration.GenericRestConnector`
+    auto-shims that aborted ingests leave behind. The function itself
+    is mechanism-only — it pops exactly the ``(product, version,
+    impl_id)`` key it is given and never inspects the class. Policy
+    (only auto-shims are ever deregistered; hand-coded classes stay)
+    lives with the caller in
+    :mod:`meho_backplane.operations.ingest.delete_connector`, because
+    this module cannot import the shim base class without creating an
+    import cycle.
+
+    The v1 table is deliberately untouched: v1 entries are written at
+    module import time by shipped connector packages and re-appear on
+    every process start, so removing them here would only manufacture
+    a restart-inconsistent half-state. The v1-compat padding rows the
+    v1 path writes into the v2 table (``(product, "", "")``) are
+    likewise never passed in by the production caller — parsed
+    connector triples always carry a non-empty version.
+
+    Removing an absent key returns ``False`` and is not an error —
+    the v2 registry is process-local, so a delete replayed against a
+    freshly-restarted pod (where the shim was never re-registered)
+    must stay a no-op rather than a crash.
+    """
+    key = (product, version, impl_id)
+    cls = _REGISTRY_V2.pop(key, None)
+    if cls is None:
+        _log.info(
+            "connector_deregister_v2_missed",
+            product=product,
+            version=version,
+            impl_id=impl_id,
+        )
+        return False
+    _log.info(
+        "connector_deregistered_v2",
+        product=product,
+        version=version,
+        impl_id=impl_id,
+        cls=cls.__name__,
+    )
+    return True
 
 
 def get_connector(product: str) -> type[Connector] | None:

--- a/backend/src/meho_backplane/mcp/tools/connector_admin.py
+++ b/backend/src/meho_backplane/mcp/tools/connector_admin.py
@@ -3,7 +3,7 @@
 
 """Admin MCP tools for the connector review + state-machine surface (G0.7-T7).
 
-Six tools under the ``meho.connector.*`` namespace, deliberately
+Seven tools under the ``meho.connector.*`` namespace, deliberately
 separate from the agent-surface meta-tools
 (:mod:`~meho_backplane.mcp.tools.operations`):
 
@@ -13,6 +13,8 @@ separate from the agent-surface meta-tools
 * ``meho.connector.edit_op`` — edit one op override. **tenant_admin**.
 * ``meho.connector.enable`` — flip the connector to enabled. **tenant_admin**.
 * ``meho.connector.disable`` — flip the connector to disabled. **tenant_admin**.
+* ``meho.connector.delete`` — delete the connector's rows + auto-shim
+  registration (G0.25-T2 #1700). **tenant_admin**.
 
 The ingest-pipeline tools (``meho.connector.ingest`` +
 ``meho.connector.ingest_status``) live in the sibling
@@ -256,6 +258,48 @@ async def _disable_handler(
     service = ReviewService(operator)
     await service.disable_connector(connector_id, tenant_id=tenant_id)
     return {"connector_id": connector_id, "status": "disabled", "ok": True}
+
+
+async def _delete_handler(
+    operator: Operator,
+    arguments: dict[str, Any],
+) -> dict[str, Any]:
+    """Delete one connector's rows + its auto-registered ingest shim.
+
+    Delegates to :meth:`ReviewService.delete_connector` — the same
+    service path ``DELETE /api/v1/connectors/{connector_id}`` drives.
+    ``warnings`` mirrors the ``edit_op`` advisory discipline
+    (G0.23-T4 #1630): a connector deleted while it still had enabled
+    operations completes the delete and reports the advisory here
+    (this tool is the structured wire home; the REST sibling stays
+    ``204 No Content`` and logs/audits instead). The ``deleted``
+    block carries the row counts plus the ``registry_only`` /
+    ``class_deregistered`` flags so an operator can tell a zero-op
+    stub clean-up apart from a full row delete.
+    """
+    connector_id: str = arguments["connector_id"]
+    tenant_id = _coerce_tenant_id(arguments.get("tenant_id"))
+    service = ReviewService(operator)
+    result = await service.delete_connector(connector_id, tenant_id=tenant_id)
+    return {
+        "connector_id": connector_id,
+        "ok": True,
+        "deleted": {
+            "groups_deleted": result.groups_deleted,
+            "operations_deleted": result.operations_deleted,
+            "enabled_operations_deleted": result.enabled_operations_deleted,
+            "class_deregistered": result.class_deregistered,
+            "registry_only": result.registry_only,
+        },
+        "warnings": [
+            {
+                "code": warning.code,
+                "enabled_op_count": warning.enabled_op_count,
+                "message": warning.message,
+            }
+            for warning in result.warnings
+        ],
+    }
 
 
 # ---------------------------------------------------------------------------
@@ -502,4 +546,56 @@ register_mcp_tool(
         op_class=_OP_CLASS_WRITE,
     ),
     handler=_disable_handler,
+)
+
+
+register_mcp_tool(
+    definition=ToolDefinition(
+        name="meho.connector.delete",
+        description=(
+            "Delete one connector (tenant_admin only): remove its "
+            "operation_group + endpoint_descriptor rows under the "
+            "target scope and, when no rows remain for the triple "
+            "anywhere, deregister the auto-registered ingest shim "
+            "from the v2 registry. Use to clean up the zero-op stubs "
+            "an aborted ingest leaves behind (spec parsed to zero "
+            "operations, batch failed mid-way) or to remove an "
+            "unwanted ingested connector outright. The tenant_id "
+            "parameter controls the scope: omit it or pass null for "
+            "built-in / global connectors; pass the operator's own "
+            "tenant UUID for tenant-curated rows. The REST sibling "
+            "DELETE /api/v1/connectors/{connector_id} does NOT expose "
+            "this parameter and always scopes to the calling "
+            "operator's tenant — for global rows use this tool. "
+            "Deleting a connector that still has enabled operations "
+            "completes and returns an enabled_operations_deleted "
+            "warning (advisory, never blocks). One "
+            "meho.connector.delete audit row is written. Do NOT use "
+            "this for a temporary roll-back — pair with "
+            "meho.connector.disable for reversible state instead; "
+            "delete is permanent (no undo), though re-running ingest "
+            "for the same product/version/impl re-registers the "
+            "connector from scratch. Hand-coded connector classes "
+            "(Vault, K8s, bind9, …) are never deregistered — for "
+            "those only the rows under the named scope are removed. "
+            "Unknown or cross-tenant connector ids fail with the "
+            "same not-found error every other connector tool uses."
+        ),
+        inputSchema={
+            "type": "object",
+            "properties": {
+                "connector_id": {
+                    "type": "string",
+                    "minLength": 1,
+                    "description": _CONNECTOR_ID_DESCRIPTION,
+                },
+                "tenant_id": _TENANT_ID_PROPERTY,
+            },
+            "required": ["connector_id"],
+            "additionalProperties": False,
+        },
+        required_role=TenantRole.TENANT_ADMIN,
+        op_class=_OP_CLASS_WRITE,
+    ),
+    handler=_delete_handler,
 )

--- a/backend/src/meho_backplane/operations/ingest/__init__.py
+++ b/backend/src/meho_backplane/operations/ingest/__init__.py
@@ -50,6 +50,10 @@ from meho_backplane.operations.ingest.connector_registration import (
     check_version_covered_by_registered_class,
     ensure_connector_class_registered,
 )
+from meho_backplane.operations.ingest.delete_connector import (
+    DeleteConnectorResult,
+    DeleteConnectorWarning,
+)
 from meho_backplane.operations.ingest.error_envelopes import (
     build_catalog_entry_malformed_detail,
     build_catalog_entry_not_found_detail,
@@ -137,6 +141,8 @@ __all__ = [
     "ConnectorSpecCatalog",
     "ConnectorSpecEntry",
     "ConnectorStatusFilter",
+    "DeleteConnectorResult",
+    "DeleteConnectorWarning",
     "EditGroupBody",
     "EditOpBody",
     "EditOpResponse",

--- a/backend/src/meho_backplane/operations/ingest/_internals.py
+++ b/backend/src/meho_backplane/operations/ingest/_internals.py
@@ -41,6 +41,7 @@ _log = structlog.get_logger(__name__)
 
 __all__ = [
     "AUDIT_METHOD",
+    "OP_DELETE_CONNECTOR",
     "OP_DISABLE_CONNECTOR",
     "OP_EDIT_GROUP",
     "OP_EDIT_OP",
@@ -67,12 +68,13 @@ __all__ = [
 #: the three surfaces cleanly.
 AUDIT_METHOD: Final[str] = "SERVICE"
 
-#: Op-ids (audit-row ``path`` column) for the five mutating actions.
+#: Op-ids (audit-row ``path`` column) for the mutating actions.
 OP_ENABLE_CONNECTOR: Final[str] = "meho.connector.enable"
 OP_DISABLE_CONNECTOR: Final[str] = "meho.connector.disable"
 OP_ENABLE_GROUP: Final[str] = "meho.connector.enable_group"
 OP_EDIT_GROUP: Final[str] = "meho.connector.edit_group"
 OP_EDIT_OP: Final[str] = "meho.connector.edit_op"
+OP_DELETE_CONNECTOR: Final[str] = "meho.connector.delete"
 OP_LLM_GROUPING: Final[str] = "meho.connector.llm_grouping"
 
 #: Allowed values for :attr:`EndpointDescriptor.safety_level`. The

--- a/backend/src/meho_backplane/operations/ingest/delete_connector.py
+++ b/backend/src/meho_backplane/operations/ingest/delete_connector.py
@@ -1,0 +1,459 @@
+# SPDX-License-Identifier: Apache-2.0
+# Copyright (c) 2026 evoila Group
+
+"""Connector DELETE engine — row removal + auto-shim deregistration.
+
+G0.25-T2 (#1700). The ingest pipeline auto-registers a
+:class:`~meho_backplane.operations.ingest.connector_registration.GenericRestConnector`
+shim on the first ingest of a ``(product, version, impl_id)`` triple
+(`register_ingested.py`), and an aborted ingest — a spec that parses
+to zero operations, a multi-spec batch that fails mid-way — leaves
+that shim registered forever with no surface to remove it. This
+module is the engine behind the two removal surfaces
+(``DELETE /api/v1/connectors/{connector_id}`` and the
+``meho.connector.delete`` MCP tool, both delegating through
+:meth:`~meho_backplane.operations.ingest.service.ReviewService.delete_connector`).
+
+Mechanism note (recorded on #1700): the task body sketched
+``review_status='deleted'`` soft-deletion, but
+``ck_operation_group_review_status`` (migration ``0005``) pins the
+column to ``('staged', 'enabled', 'disabled')`` and the wave assigns
+Alembic migrations to the sibling backfill task (#1701). The shipped
+mechanism is therefore **row removal**: the scoped
+``endpoint_descriptor`` + ``operation_group`` rows are deleted in one
+transaction (DML only, no schema change; the single inbound FK is
+``endpoint_descriptor.group_id → operation_group.id ON DELETE SET
+NULL``), one ``meho.connector.delete`` audit row preserves the
+forensic trail, and re-ingest revives the connector from scratch —
+the exact revival path the task scoped in ("once deleted, the
+operator re-ingests to bring the connector back").
+
+Registry policy
+---------------
+
+Only :class:`GenericRestConnector` subclasses (the ``AutoShim_*``
+classes the ingest pipeline synthesises) are ever deregistered, and
+only when **no** rows remain for the triple under *any* tenant scope
+— the v2 registry is process-global, so popping a class while
+another tenant still has rows would break that tenant's dispatch
+resolution. Hand-coded classes (``VaultConnector``,
+``VmwareRestConnector``, …) are never deregistered: they re-register
+at every process start, so removal here would only manufacture a
+restart-inconsistent half-state. A connector whose hand-coded class
+survives the row delete simply reverts to the truthful
+``state="registered"`` listing row ("known class, awaiting ingest").
+
+The registry walk matches by the *parsed* natural key (the same
+round-trip ``list_connectors`` uses), so the VCF-family long↔short
+product splits resolve correctly: rows persist under the
+dispatch-canonical product (``vrli``) while the shim may be
+registered under the supplied product (``vcf-logs``), and both spell
+the same ``connector_id``.
+
+Transaction shape
+-----------------
+
+:func:`stage_connector_delete` runs inside the caller's session and
+performs the row deletes + decides the shim keys; the caller
+(:class:`ReviewService`) writes the audit row, commits, and only then
+applies :func:`deregister_staged_auto_shims`. Ordering is deliberate:
+a failed commit must leave the process-local registry untouched, and
+the pop itself is idempotent (a replay against a freshly-restarted
+pod, where no shim was ever re-registered, is a logged no-op).
+"""
+
+from __future__ import annotations
+
+from dataclasses import dataclass
+from typing import Any
+
+import structlog
+from sqlalchemy import CursorResult, case, delete, func, select
+from sqlalchemy.ext.asyncio import AsyncSession
+
+from meho_backplane.connectors.registry import all_connectors_v2, deregister_connector_v2
+from meho_backplane.db.models import EndpointDescriptor, OperationGroup
+from meho_backplane.operations.ingest._internals import ConnectorScope
+from meho_backplane.operations.ingest._llm_grouping_internals import build_connector_id
+from meho_backplane.operations.ingest.connector_registration import GenericRestConnector
+from meho_backplane.operations.ingest.exceptions import ConnectorNotFoundError
+from meho_backplane.operations.ingest.parser import parse_connector_id
+
+__all__ = [
+    "DeleteConnectorResult",
+    "DeleteConnectorWarning",
+    "StagedConnectorDelete",
+    "deregister_staged_auto_shims",
+    "stage_connector_delete",
+]
+
+_log = structlog.get_logger(__name__)
+
+
+@dataclass(frozen=True, slots=True)
+class DeleteConnectorWarning:
+    """One advisory attached to a completed connector delete.
+
+    Mirrors the :class:`~meho_backplane.operations.ingest.api_schemas.EditOpWarning`
+    discipline (G0.23-T4 #1630): the delete **was applied**; the
+    warning tells the operator it had a sharp edge. The only producer
+    today is the enabled-operations probe — the connector still had
+    dispatchable ops when it was deleted. The REST route stays
+    ``204 No Content`` per the task contract, so the structured wire
+    home for this advisory is the MCP tool response; the REST path
+    surfaces it via the ``connector_delete_enabled_ops`` log event
+    and the audit payload's ``enabled_operations_deleted`` count.
+    """
+
+    code: str
+    enabled_op_count: int
+    message: str
+
+
+@dataclass(frozen=True, slots=True)
+class DeleteConnectorResult:
+    """Outcome of one connector delete, as returned by the service layer.
+
+    ``registry_only`` distinguishes the zero-op-stub path (no DB rows
+    existed anywhere; only the auto-shim class was removed — the
+    primary #1700 consumer scenario) from the row-bearing path.
+    ``class_deregistered`` reports whether the delete removed the
+    triple's auto-shim from the process-local v2 registry; it stays
+    ``False`` when rows survive under another tenant scope or when
+    the resolved class is hand-coded.
+    """
+
+    connector_id: str
+    groups_deleted: int
+    operations_deleted: int
+    enabled_operations_deleted: int
+    class_deregistered: bool
+    registry_only: bool
+    warnings: tuple[DeleteConnectorWarning, ...]
+
+
+@dataclass(frozen=True, slots=True)
+class StagedConnectorDelete:
+    """A delete staged inside an open session, awaiting commit.
+
+    ``shim_keys`` carries the v2-registry keys (registry spelling,
+    not the parsed one) to pop **after** the caller's commit
+    succeeds; ``audit_payload`` is the JSON-safe dict for the
+    ``meho.connector.delete`` audit row the caller writes into the
+    same transaction.
+    """
+
+    result: DeleteConnectorResult
+    audit_payload: dict[str, Any]
+    shim_keys: tuple[tuple[str, str, str], ...]
+
+
+def _auto_shim_keys_for_triple(
+    product: str,
+    version: str,
+    impl_id: str,
+) -> tuple[tuple[str, str, str], ...]:
+    """Return v2-registry keys whose auto-shim resolves to the parsed triple.
+
+    Walks :func:`all_connectors_v2` and keeps the keys that (a) are
+    not v1-compat padding rows (empty ``version`` / ``impl_id``),
+    (b) round-trip through :func:`parse_connector_id` to exactly
+    *(product, version, impl_id)* — the same lossless-round-trip rule
+    ``list_connectors._resolve_class_only_natural_key`` applies, which
+    is what makes the VCF long↔short product split match — and
+    (c) hold a :class:`GenericRestConnector` subclass. Hand-coded
+    classes are intentionally excluded; see the module docstring's
+    registry policy.
+    """
+    keys: list[tuple[str, str, str]] = []
+    for (reg_product, reg_version, reg_impl_id), cls in sorted(all_connectors_v2().items()):
+        if not reg_version or not reg_impl_id:
+            continue
+        connector_id = build_connector_id(reg_product, reg_version, reg_impl_id)
+        if parse_connector_id(connector_id) != (product, version, impl_id):
+            continue
+        if not issubclass(cls, GenericRestConnector):
+            continue
+        keys.append((reg_product, reg_version, reg_impl_id))
+    return tuple(keys)
+
+
+async def _rows_exist_any_scope(
+    session: AsyncSession,
+    product: str,
+    version: str,
+    impl_id: str,
+) -> bool:
+    """Return whether any row exists for the triple under **any** tenant scope.
+
+    Internal-only, deliberately unscoped — the decision it feeds
+    ("may the process-global auto-shim be deregistered?") is about
+    the registry, which has no tenant axis. The probe never widens
+    what the caller's *response* exposes: the 204/404 outcome is
+    fully determined by the caller-scoped rows before this runs, so
+    no cross-tenant information leaks through the wire contract.
+    Two ``LIMIT 1`` probes, descriptors first — same shape as
+    :func:`~meho_backplane.operations._lookup.connector_exists`.
+    """
+    descriptor_hit = await session.execute(
+        select(EndpointDescriptor.id)
+        .where(
+            EndpointDescriptor.product == product,
+            EndpointDescriptor.version == version,
+            EndpointDescriptor.impl_id == impl_id,
+        )
+        .limit(1)
+    )
+    if descriptor_hit.first() is not None:
+        return True
+    group_hit = await session.execute(
+        select(OperationGroup.id)
+        .where(
+            OperationGroup.product == product,
+            OperationGroup.version == version,
+            OperationGroup.impl_id == impl_id,
+        )
+        .limit(1)
+    )
+    return group_hit.first() is not None
+
+
+async def _scoped_groups(
+    session: AsyncSession,
+    scope: ConnectorScope,
+) -> list[OperationGroup]:
+    """Return the scope's group rows sorted by ``group_key`` (empty list OK).
+
+    Unlike :func:`~meho_backplane.operations.ingest._internals.load_groups`
+    this does **not** raise on an empty result — the zero-op-stub
+    path (no rows anywhere, only a registered shim) is a legitimate
+    delete target here, and the not-found decision needs more
+    context than "no groups" (stray ungrouped descriptors must be
+    found too).
+    """
+    stmt = select(OperationGroup).where(
+        OperationGroup.product == scope.product,
+        OperationGroup.version == scope.version,
+        OperationGroup.impl_id == scope.impl_id,
+    )
+    if scope.tenant_id is None:
+        stmt = stmt.where(OperationGroup.tenant_id.is_(None))
+    else:
+        stmt = stmt.where(OperationGroup.tenant_id == scope.tenant_id)
+    result = await session.execute(stmt.order_by(OperationGroup.group_key))
+    return list(result.scalars().all())
+
+
+async def _scoped_descriptor_counts(
+    session: AsyncSession,
+    scope: ConnectorScope,
+) -> tuple[int, int]:
+    """Return ``(total, enabled)`` descriptor counts for the scope.
+
+    Counts by the natural-key triple + tenant scope rather than by
+    ``group_id`` so descriptors the T2 upsert landed but the T3
+    grouping pass never assigned (``group_id IS NULL`` — the
+    mid-pipeline-abort shape this task exists for) are counted and
+    later deleted too. Portable ``CASE WHEN`` sum, same dialect
+    rationale as ``list_connectors._operation_count_by_connector``.
+    """
+    enabled_case = func.sum(
+        case((EndpointDescriptor.is_enabled.is_(True), 1), else_=0),
+    )
+    stmt = select(func.count(EndpointDescriptor.id), enabled_case).where(
+        EndpointDescriptor.product == scope.product,
+        EndpointDescriptor.version == scope.version,
+        EndpointDescriptor.impl_id == scope.impl_id,
+    )
+    if scope.tenant_id is None:
+        stmt = stmt.where(EndpointDescriptor.tenant_id.is_(None))
+    else:
+        stmt = stmt.where(EndpointDescriptor.tenant_id == scope.tenant_id)
+    total_raw, enabled_raw = (await session.execute(stmt)).one()
+    return int(total_raw or 0), int(enabled_raw or 0)
+
+
+async def _delete_scoped_rows(
+    session: AsyncSession,
+    scope: ConnectorScope,
+) -> tuple[int, int]:
+    """Bulk-delete the scope's descriptor + group rows; return rowcounts.
+
+    Descriptors first: their ``group_id`` FK is ``ON DELETE SET
+    NULL`` so the reverse order would also be referentially safe,
+    but deleting children first avoids a pointless wave of NULL
+    re-writes. Both statements filter by the natural-key triple +
+    tenant scope (never by ``group_id``), so ungrouped stray
+    descriptors are removed with the rest.
+    """
+    descriptor_stmt = delete(EndpointDescriptor).where(
+        EndpointDescriptor.product == scope.product,
+        EndpointDescriptor.version == scope.version,
+        EndpointDescriptor.impl_id == scope.impl_id,
+    )
+    group_stmt = delete(OperationGroup).where(
+        OperationGroup.product == scope.product,
+        OperationGroup.version == scope.version,
+        OperationGroup.impl_id == scope.impl_id,
+    )
+    if scope.tenant_id is None:
+        descriptor_stmt = descriptor_stmt.where(EndpointDescriptor.tenant_id.is_(None))
+        group_stmt = group_stmt.where(OperationGroup.tenant_id.is_(None))
+    else:
+        descriptor_stmt = descriptor_stmt.where(EndpointDescriptor.tenant_id == scope.tenant_id)
+        group_stmt = group_stmt.where(OperationGroup.tenant_id == scope.tenant_id)
+    # Cast rationale matches _internals.cascade_is_enabled: DML
+    # statements produce a CursorResult whose rowcount mypy cannot
+    # see through AsyncSession.execute's Result annotation.
+    descriptor_result: CursorResult[Any] = await session.execute(descriptor_stmt)  # type: ignore[assignment]
+    group_result: CursorResult[Any] = await session.execute(group_stmt)  # type: ignore[assignment]
+    return (
+        max(descriptor_result.rowcount or 0, 0),
+        max(group_result.rowcount or 0, 0),
+    )
+
+
+def _build_warnings(
+    connector_id: str,
+    enabled_count: int,
+) -> tuple[DeleteConnectorWarning, ...]:
+    """Return the enabled-operations advisory when *enabled_count* > 0."""
+    if enabled_count <= 0:
+        return ()
+    message = (
+        f"connector {connector_id!r} still had {enabled_count} enabled "
+        f"operation(s) at delete time; the delete completed and those "
+        f"operations are no longer dispatchable. Re-ingest the spec and "
+        f"re-enable the connector to restore them."
+    )
+    return (
+        DeleteConnectorWarning(
+            code="enabled_operations_deleted",
+            enabled_op_count=enabled_count,
+            message=message,
+        ),
+    )
+
+
+def _registry_only_stage(
+    scope: ConnectorScope,
+    connector_id: str,
+) -> StagedConnectorDelete:
+    """Stage the zero-op-stub delete (no rows anywhere; pop the shim only).
+
+    Raises :class:`ConnectorNotFoundError` when no auto-shim matches
+    the triple either — nothing exists to delete, and the unified
+    404 keeps the probe surface identical to every other connector
+    route. A registered *hand-coded* class without rows also 404s
+    here: its registration is a deploy artefact, not deletable
+    operator state.
+    """
+    shim_keys = _auto_shim_keys_for_triple(scope.product, scope.version, scope.impl_id)
+    if not shim_keys:
+        raise ConnectorNotFoundError(connector_id=connector_id, tenant_id=scope.tenant_id)
+    result = DeleteConnectorResult(
+        connector_id=connector_id,
+        groups_deleted=0,
+        operations_deleted=0,
+        enabled_operations_deleted=0,
+        class_deregistered=True,
+        registry_only=True,
+        warnings=(),
+    )
+    return StagedConnectorDelete(
+        result=result,
+        audit_payload=_audit_payload(scope, result, deleted_group_keys=[]),
+        shim_keys=shim_keys,
+    )
+
+
+def _audit_payload(
+    scope: ConnectorScope,
+    result: DeleteConnectorResult,
+    *,
+    deleted_group_keys: list[str],
+) -> dict[str, Any]:
+    """Build the JSON-safe ``meho.connector.delete`` audit payload."""
+    return {
+        "connector_id": result.connector_id,
+        "tenant_scope": str(scope.tenant_id) if scope.tenant_id is not None else None,
+        "deleted_group_keys": sorted(deleted_group_keys),
+        "groups_deleted": result.groups_deleted,
+        "operations_deleted": result.operations_deleted,
+        "enabled_operations_deleted": result.enabled_operations_deleted,
+        "class_deregistered": result.class_deregistered,
+        "registry_only": result.registry_only,
+    }
+
+
+async def stage_connector_delete(
+    session: AsyncSession,
+    scope: ConnectorScope,
+    connector_id: str,
+) -> StagedConnectorDelete:
+    """Delete the scope's rows in *session* and stage the registry follow-up.
+
+    Two paths:
+
+    * **Zero rows under the caller's scope.** If rows exist for the
+      triple under *another* scope, raise
+      :class:`ConnectorNotFoundError` — the caller cannot delete rows
+      their scope cannot see (the same 404 conflation every connector
+      route uses; a tenant-scoped REST call must not be able to nuke
+      a built-in connector, and vice versa). If no rows exist
+      anywhere, this is the zero-op stub: stage the auto-shim pop, or
+      404 when no auto-shim matches either.
+    * **Rows present.** Count + bulk-delete the scoped descriptor and
+      group rows, then re-probe the triple unscoped *inside the same
+      transaction* (the session sees its own deletes): only when
+      nothing remains anywhere is the auto-shim staged for
+      deregistration.
+
+    The caller writes the audit row from ``audit_payload``, commits,
+    and then applies :func:`deregister_staged_auto_shims`.
+    """
+    groups = await _scoped_groups(session, scope)
+    op_total, op_enabled = await _scoped_descriptor_counts(session, scope)
+
+    if not groups and op_total == 0:
+        if await _rows_exist_any_scope(session, scope.product, scope.version, scope.impl_id):
+            raise ConnectorNotFoundError(connector_id=connector_id, tenant_id=scope.tenant_id)
+        return _registry_only_stage(scope, connector_id)
+
+    group_keys = [group.group_key for group in groups]
+    ops_deleted, groups_deleted = await _delete_scoped_rows(session, scope)
+    residual = await _rows_exist_any_scope(session, scope.product, scope.version, scope.impl_id)
+    shim_keys: tuple[tuple[str, str, str], ...] = ()
+    if not residual:
+        shim_keys = _auto_shim_keys_for_triple(scope.product, scope.version, scope.impl_id)
+
+    result = DeleteConnectorResult(
+        connector_id=connector_id,
+        groups_deleted=groups_deleted,
+        operations_deleted=ops_deleted,
+        enabled_operations_deleted=op_enabled,
+        class_deregistered=bool(shim_keys),
+        registry_only=False,
+        warnings=_build_warnings(connector_id, op_enabled),
+    )
+    return StagedConnectorDelete(
+        result=result,
+        audit_payload=_audit_payload(scope, result, deleted_group_keys=group_keys),
+        shim_keys=shim_keys,
+    )
+
+
+def deregister_staged_auto_shims(
+    staged: StagedConnectorDelete,
+) -> None:
+    """Pop every staged auto-shim key from the v2 registry (post-commit).
+
+    Process-local and idempotent — a key already absent (another
+    worker raced, or the pod restarted between commit and pop on a
+    retry) logs ``connector_deregister_v2_missed`` inside
+    :func:`deregister_connector_v2` and moves on. Runs strictly after
+    the row-delete transaction commits so a failed commit never
+    leaves the registry ahead of the database.
+    """
+    for product, version, impl_id in staged.shim_keys:
+        deregister_connector_v2(product=product, version=version, impl_id=impl_id)

--- a/backend/src/meho_backplane/operations/ingest/service.py
+++ b/backend/src/meho_backplane/operations/ingest/service.py
@@ -82,6 +82,7 @@ from sqlalchemy.ext.asyncio import AsyncSession, async_sessionmaker
 from meho_backplane.auth.operator import Operator, TenantRole
 from meho_backplane.db.engine import get_sessionmaker
 from meho_backplane.operations.ingest._internals import (
+    OP_DELETE_CONNECTOR,
     OP_DISABLE_CONNECTOR,
     OP_EDIT_GROUP,
     OP_EDIT_OP,
@@ -100,6 +101,11 @@ from meho_backplane.operations.ingest._internals import (
     write_audit_row,
 )
 from meho_backplane.operations.ingest.api_schemas import EditOpWarning
+from meho_backplane.operations.ingest.delete_connector import (
+    DeleteConnectorResult,
+    deregister_staged_auto_shims,
+    stage_connector_delete,
+)
 from meho_backplane.operations.ingest.exceptions import (
     ConnectorNotFoundError,
     InvalidStateTransitionError,
@@ -577,6 +583,59 @@ class ReviewService:
                 },
             )
             await session.commit()
+
+    async def delete_connector(
+        self,
+        connector_id: str,
+        *,
+        tenant_id: UUID | None,
+    ) -> DeleteConnectorResult:
+        """Delete *connector_id* in *tenant_id*'s scope (G0.25-T2 #1700).
+
+        Removes the scope's ``endpoint_descriptor`` + ``operation_group``
+        rows and, when no rows remain for the triple under any scope,
+        pops the triple's auto-registered
+        :class:`~meho_backplane.operations.ingest.connector_registration.GenericRestConnector`
+        shim from the v2 registry — the zero-op stubs aborted ingests
+        leave behind are the primary target, and for those (no rows
+        anywhere) the delete is registry-only. Hand-coded connector
+        classes are never deregistered.
+
+        Unknown connector, cross-tenant probe, and a triple whose rows
+        live only under a scope the caller did not name all raise
+        :class:`ConnectorNotFoundError` — the same 404 conflation every
+        other connector route uses. Exactly one
+        ``meho.connector.delete`` audit row commits atomically with the
+        row deletes; the registry pop runs strictly after the commit so
+        a failed transaction never leaves the process-local registry
+        ahead of the database. A connector that still had enabled
+        operations is deleted anyway and the returned
+        :attr:`DeleteConnectorResult.warnings` carries the advisory
+        (warnings never block the write — the
+        :meth:`edit_op` discipline). Re-ingesting the same triple
+        afterwards re-registers the connector from scratch.
+        """
+        scope = self._resolve_scope(connector_id, tenant_id)
+        sessionmaker = self._sessionmaker()
+        async with sessionmaker() as session:
+            staged = await stage_connector_delete(session, scope, connector_id)
+            await write_audit_row(
+                session,
+                operator_sub=self._operator.sub,
+                operator_tenant_id=self._operator.tenant_id,
+                op_id=OP_DELETE_CONNECTOR,
+                payload=staged.audit_payload,
+            )
+            await session.commit()
+        deregister_staged_auto_shims(staged)
+        for warning in staged.result.warnings:
+            _log.warning(
+                "connector_delete_enabled_ops",
+                connector_id=connector_id,
+                enabled_op_count=warning.enabled_op_count,
+                code=warning.code,
+            )
+        return staged.result
 
     # -- internal connector-wide transition --------------------------------
 

--- a/backend/tests/test_api_v1_connectors_delete.py
+++ b/backend/tests/test_api_v1_connectors_delete.py
@@ -1,0 +1,416 @@
+# SPDX-License-Identifier: Apache-2.0
+# Copyright (c) 2026 evoila Group
+
+"""Route tests for ``DELETE /api/v1/connectors/{connector_id}`` (G0.25-T2 #1700).
+
+The service-layer behaviour matrix lives in
+:mod:`tests.test_operations_ingest_delete`; this module pins the REST
+surface on top of it:
+
+* 204 on success; the response carries no body (the enabled-ops
+  advisory's structured wire home is the MCP sibling — the REST path
+  logs + audits instead).
+* ``tenant_admin`` role required — an ``operator``-role JWT gets 403
+  before the service layer runs.
+* The route always scopes to the calling operator's tenant (#1699
+  contract: no ``tenant_id`` parameter), so another tenant's rows
+  404 and survive.
+* Repeat DELETE collapses to 404 once the first one landed.
+* End-to-end consumer scenario (the task's AC 8): ingest a zero-op
+  spec through ``POST /api/v1/connectors/ingest``, watch the stub
+  appear as a ``state="registered"`` row in ``GET
+  /api/v1/connectors``, DELETE it, and verify it is gone from the
+  listing, the v2 registry, and that the ``meho.connector.delete``
+  audit row landed.
+
+Self-contained rather than appended to
+``test_api_v1_connectors_ingest.py``: the DELETE surface needs only a
+sliver of that module's machinery (JWT mint + discovery/JWKS mocks +
+one spec mock), and the sibling #1699 PR is appending to that file in
+the same wave.
+"""
+
+from __future__ import annotations
+
+import socket
+import uuid
+from collections.abc import Iterator
+from typing import Any
+from unittest.mock import patch
+
+import httpx
+import pytest
+import respx
+from fastapi import FastAPI
+from fastapi.testclient import TestClient
+from sqlalchemy import select
+
+from meho_backplane.api.v1.connectors_ingest import (
+    router as connectors_ingest_router,
+)
+from meho_backplane.api.v1.connectors_ingest import (
+    set_llm_client_factory,
+)
+from meho_backplane.audit import AuditMiddleware
+from meho_backplane.auth.jwt import clear_jwks_cache
+from meho_backplane.connectors.registry import all_connectors_v2
+from meho_backplane.db.engine import get_sessionmaker
+from meho_backplane.db.models import AuditLog, EndpointDescriptor, OperationGroup
+from meho_backplane.middleware import RequestContextMiddleware
+from meho_backplane.operations.ingest import (
+    default_llm_client_factory,
+    ensure_connector_class_registered,
+)
+from meho_backplane.settings import get_settings
+
+from ._oidc_jwt_helpers import AUDIENCE as _AUDIENCE
+from ._oidc_jwt_helpers import ISSUER as _ISSUER
+from ._oidc_jwt_helpers import make_rsa_keypair as _make_rsa_keypair
+from ._oidc_jwt_helpers import mint_token as _mint_token
+from ._oidc_jwt_helpers import mock_discovery_and_jwks as _mock_discovery_and_jwks
+from ._oidc_jwt_helpers import public_jwks as _public_jwks
+
+_PRODUCT = "ghostspec"
+_VERSION = "1.0"
+_IMPL_ID = "ghostspec-rest"
+_CONNECTOR_ID = f"{_IMPL_ID}-{_VERSION}"
+
+# Public IP for the SSRF destination guard (IANA example.com assignment)
+# + the hostnames this module's mocks serve. Mirrors
+# test_api_v1_connectors_ingest.py.
+_PUBLIC_IP = "93.184.216.34"
+_SPEC_HOST = "specs.example.test"
+_TEST_HOSTS = frozenset({_SPEC_HOST, "keycloak.test", "vault.test"})
+
+
+@pytest.fixture(autouse=True)
+def _settings_env(monkeypatch: pytest.MonkeyPatch) -> Iterator[None]:
+    """Pin every env var :class:`Settings` reads."""
+    monkeypatch.setenv("KEYCLOAK_ISSUER_URL", _ISSUER)
+    monkeypatch.setenv("KEYCLOAK_AUDIENCE", _AUDIENCE)
+    monkeypatch.setenv("KEYCLOAK_JWKS_CACHE_TTL_SECONDS", "300")
+    monkeypatch.setenv("KEYCLOAK_JWT_LEEWAY_SECONDS", "30")
+    monkeypatch.setenv("VAULT_ADDR", "https://vault.test")
+    get_settings.cache_clear()
+    yield
+    get_settings.cache_clear()
+
+
+@pytest.fixture(autouse=True)
+def _isolated_jwks_cache() -> Iterator[None]:
+    """Empty the module-level JWKS cache around every test."""
+    clear_jwks_cache()
+    yield
+    clear_jwks_cache()
+
+
+def _getaddrinfo(
+    host: str, port: object, **kwargs: object
+) -> list[tuple[int, int, int, str, tuple[str, int]]]:
+    if host in _TEST_HOSTS:
+        return [(socket.AF_INET, socket.SOCK_STREAM, 0, "", (_PUBLIC_IP, 443))]
+    return socket.getaddrinfo(host, port, **kwargs)  # type: ignore[arg-type]
+
+
+@pytest.fixture(autouse=True)
+def _mock_ssrf_getaddrinfo() -> Iterator[None]:
+    """Resolve the mock spec host to a public IP for the SSRF guard."""
+    with patch(
+        "meho_backplane.operations.ingest.openapi.socket.getaddrinfo",
+        side_effect=_getaddrinfo,
+    ):
+        yield
+
+
+def _build_app() -> FastAPI:
+    app = FastAPI()
+    app.add_middleware(AuditMiddleware)
+    app.add_middleware(RequestContextMiddleware)
+    app.include_router(connectors_ingest_router)
+    return app
+
+
+@pytest.fixture
+def client() -> Iterator[TestClient]:
+    yield TestClient(_build_app())
+
+
+def _token(*, tenant_id: uuid.UUID, role: str = "tenant_admin") -> tuple[Any, str]:
+    """Mint a (private_key, JWT) pair for *tenant_id* with *role*."""
+    key = _make_rsa_keypair("kid-delete")
+    token = _mint_token(
+        key,
+        sub=f"op-{role}",
+        tenant_id=str(tenant_id),
+        tenant_role=role,
+    )
+    return key, token
+
+
+def _authed(token: str) -> dict[str, str]:
+    return {"Authorization": f"Bearer {token}"}
+
+
+async def _seed_rows(*, tenant_id: uuid.UUID, op_is_enabled: bool = False) -> None:
+    """Seed one group + two child ops for the test triple under *tenant_id*."""
+    sessionmaker = get_sessionmaker()
+    async with sessionmaker() as session:
+        group_id = uuid.uuid4()
+        session.add(
+            OperationGroup(
+                id=group_id,
+                tenant_id=tenant_id,
+                product=_PRODUCT,
+                version=_VERSION,
+                impl_id=_IMPL_ID,
+                group_key="things",
+                name="Things",
+                when_to_use="Use for thing management.",
+                review_status="staged",
+            ),
+        )
+        for index in range(2):
+            session.add(
+                EndpointDescriptor(
+                    tenant_id=tenant_id,
+                    product=_PRODUCT,
+                    version=_VERSION,
+                    impl_id=_IMPL_ID,
+                    op_id=f"GET:/things/{index}",
+                    source_kind="ingested",
+                    method="GET",
+                    path=f"/things/{index}",
+                    summary="Summary",
+                    description="Description",
+                    group_id=group_id,
+                    tags=["test"],
+                    parameter_schema={"type": "object"},
+                    safety_level="safe",
+                    requires_approval=False,
+                    is_enabled=op_is_enabled,
+                ),
+            )
+        await session.commit()
+
+
+async def _row_counts(tenant_id: uuid.UUID | None) -> tuple[int, int]:
+    sessionmaker = get_sessionmaker()
+    async with sessionmaker() as session:
+        group_stmt = select(OperationGroup).where(
+            OperationGroup.product == _PRODUCT,
+            OperationGroup.version == _VERSION,
+            OperationGroup.impl_id == _IMPL_ID,
+        )
+        op_stmt = select(EndpointDescriptor).where(
+            EndpointDescriptor.product == _PRODUCT,
+            EndpointDescriptor.version == _VERSION,
+            EndpointDescriptor.impl_id == _IMPL_ID,
+        )
+        if tenant_id is None:
+            group_stmt = group_stmt.where(OperationGroup.tenant_id.is_(None))
+            op_stmt = op_stmt.where(EndpointDescriptor.tenant_id.is_(None))
+        else:
+            group_stmt = group_stmt.where(OperationGroup.tenant_id == tenant_id)
+            op_stmt = op_stmt.where(EndpointDescriptor.tenant_id == tenant_id)
+        groups = len((await session.execute(group_stmt)).scalars().all())
+        ops = len((await session.execute(op_stmt)).scalars().all())
+        return groups, ops
+
+
+async def _service_delete_audit_count() -> int:
+    sessionmaker = get_sessionmaker()
+    async with sessionmaker() as session:
+        result = await session.execute(
+            select(AuditLog).where(
+                AuditLog.method == "SERVICE",
+                AuditLog.path == "meho.connector.delete",
+            ),
+        )
+        return len(list(result.scalars().all()))
+
+
+# ---------------------------------------------------------------------------
+# Route behaviour
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.asyncio
+async def test_delete_returns_204_then_404_on_repeat(client: TestClient) -> None:
+    """Happy path: 204 + rows gone + shim gone; the second DELETE 404s."""
+    tenant = uuid.uuid4()
+    key, token = _token(tenant_id=tenant)
+    ensure_connector_class_registered(
+        product=_PRODUCT,
+        version=_VERSION,
+        impl_id=_IMPL_ID,
+        base_url=None,
+    )
+    await _seed_rows(tenant_id=tenant)
+
+    with respx.mock as mock_router:
+        _mock_discovery_and_jwks(mock_router, _public_jwks(key))
+        response = client.delete(f"/api/v1/connectors/{_CONNECTOR_ID}", headers=_authed(token))
+        assert response.status_code == 204, response.text
+        assert response.content == b""
+
+        repeat = client.delete(f"/api/v1/connectors/{_CONNECTOR_ID}", headers=_authed(token))
+        assert repeat.status_code == 404
+
+    assert await _row_counts(tenant) == (0, 0)
+    assert (_PRODUCT, _VERSION, _IMPL_ID) not in all_connectors_v2()
+    assert await _service_delete_audit_count() == 1
+
+
+@pytest.mark.asyncio
+async def test_delete_requires_tenant_admin_role(client: TestClient) -> None:
+    """An operator-role JWT is rejected with 403 before the service runs."""
+    tenant = uuid.uuid4()
+    key, token = _token(tenant_id=tenant, role="operator")
+    await _seed_rows(tenant_id=tenant)
+
+    with respx.mock as mock_router:
+        _mock_discovery_and_jwks(mock_router, _public_jwks(key))
+        response = client.delete(f"/api/v1/connectors/{_CONNECTOR_ID}", headers=_authed(token))
+
+    assert response.status_code == 403
+    assert await _row_counts(tenant) == (1, 2)
+
+
+@pytest.mark.asyncio
+async def test_delete_is_tenant_scoped_cross_tenant_404(client: TestClient) -> None:
+    """Another tenant's rows are invisible: 404, nothing deleted (#1699 contract)."""
+    tenant_a = uuid.uuid4()
+    tenant_b = uuid.uuid4()
+    key, token = _token(tenant_id=tenant_a)
+    await _seed_rows(tenant_id=tenant_b)
+
+    with respx.mock as mock_router:
+        _mock_discovery_and_jwks(mock_router, _public_jwks(key))
+        response = client.delete(f"/api/v1/connectors/{_CONNECTOR_ID}", headers=_authed(token))
+
+    assert response.status_code == 404
+    assert await _row_counts(tenant_b) == (1, 2)
+
+
+@pytest.mark.asyncio
+async def test_delete_with_enabled_ops_completes_with_204(client: TestClient) -> None:
+    """Enabled ops do not block the REST delete — advisory is log/audit-side."""
+    tenant = uuid.uuid4()
+    key, token = _token(tenant_id=tenant)
+    await _seed_rows(tenant_id=tenant, op_is_enabled=True)
+
+    with respx.mock as mock_router:
+        _mock_discovery_and_jwks(mock_router, _public_jwks(key))
+        response = client.delete(f"/api/v1/connectors/{_CONNECTOR_ID}", headers=_authed(token))
+
+    assert response.status_code == 204
+    assert await _row_counts(tenant) == (0, 0)
+
+
+# ---------------------------------------------------------------------------
+# End-to-end consumer scenario (task AC 8)
+# ---------------------------------------------------------------------------
+
+_ZERO_OP_SPEC = """openapi: 3.0.3
+info:
+  title: ghost
+  version: '1'
+paths: {}
+"""
+
+
+class _NeverCalledLlmClient:
+    """LLM stub that fails the test if the grouping pass ever invokes it.
+
+    The pipeline resolves the LLM-client factory before it discovers
+    there is nothing to group, so a zero-op ingest still needs a
+    factory installed — but the client itself must never run (zero
+    unassigned ops short-circuits ``run_llm_grouping``).
+    """
+
+    async def generate_json(
+        self,
+        *,
+        system_prompt: str,
+        user_prompt: str,
+        max_output_tokens: int,
+    ) -> str:
+        raise AssertionError("zero-op ingest must not invoke the grouping LLM")
+
+
+@pytest.fixture
+def _stub_llm_factory() -> Iterator[None]:
+    """Install the never-called stub; restore the fail-closed default after."""
+    set_llm_client_factory(lambda: _NeverCalledLlmClient())
+    yield
+    set_llm_client_factory(default_llm_client_factory)
+
+
+def _connector_ids(list_response: httpx.Response) -> set[str]:
+    assert list_response.status_code == 200, list_response.text
+    return {item["connector_id"] for item in list_response.json()["connectors"]}
+
+
+@pytest.mark.asyncio
+@pytest.mark.usefixtures("_stub_llm_factory")
+async def test_e2e_zero_op_ingest_then_delete_clears_catalog(client: TestClient) -> None:
+    """Ingest a zero-op spec, DELETE the stub, verify it left every surface.
+
+    The exact claude-rdc-hetzner-dc v0.14.0 cycle-10 sequence: a spec
+    whose ``paths`` is empty parses cleanly, registers the auto-shim
+    (pre-flight + registration run before the upsert loop), and lands
+    zero rows — leaving a ``state="registered"`` stub in the catalog
+    that nothing could remove. ``run_llm_grouping`` no-ops on zero
+    unassigned ops, so the installed LLM stub asserts it is never
+    actually invoked.
+    """
+    tenant = uuid.uuid4()
+    key, token = _token(tenant_id=tenant)
+
+    with respx.mock as mock_router:
+        _mock_discovery_and_jwks(mock_router, _public_jwks(key))
+        spec_url = f"https://{_SPEC_HOST}/ghost.yaml"
+        mock_router.get(spec_url).mock(
+            return_value=httpx.Response(
+                200,
+                content=_ZERO_OP_SPEC.encode(),
+                headers={"content-type": "application/yaml"},
+            ),
+        )
+
+        ingest = client.post(
+            "/api/v1/connectors/ingest",
+            json={
+                "product": _PRODUCT,
+                "version": _VERSION,
+                "impl_id": _IMPL_ID,
+                "specs": [{"uri": spec_url}],
+                "async": False,
+            },
+            headers=_authed(token),
+        )
+        assert ingest.status_code == 200, ingest.text
+        ingestion = ingest.json()["ingestion"]
+        assert ingestion["inserted_count"] == 0
+        assert ingestion["connector_registered"] is True
+        assert (_PRODUCT, _VERSION, _IMPL_ID) in all_connectors_v2()
+
+        # The stub is now visible in the catalog as a class-side row.
+        before = client.get("/api/v1/connectors", headers=_authed(token))
+        assert _CONNECTOR_ID in _connector_ids(before)
+
+        # DELETE the stub — registry-only (no rows ever landed).
+        deleted = client.delete(
+            f"/api/v1/connectors/{_CONNECTOR_ID}",
+            headers=_authed(token),
+        )
+        assert deleted.status_code == 204, deleted.text
+
+        # Gone from the catalog, gone from the registry.
+        after = client.get("/api/v1/connectors", headers=_authed(token))
+        assert _CONNECTOR_ID not in _connector_ids(after)
+
+    assert (_PRODUCT, _VERSION, _IMPL_ID) not in all_connectors_v2()
+    assert await _row_counts(tenant) == (0, 0)
+    assert await _row_counts(None) == (0, 0)
+    assert await _service_delete_audit_count() == 1

--- a/backend/tests/test_mcp_tools_connector_admin.py
+++ b/backend/tests/test_mcp_tools_connector_admin.py
@@ -3,10 +3,10 @@
 
 """Tests for the connector review / state-machine admin MCP tools (G0.7-T7 #407).
 
-Covers the six ``meho.connector.*`` review / edit / enable / disable
-tools. The ingest-pipeline tools (``meho.connector.ingest`` +
-``meho.connector.ingest_status``) split out into their own handler
-module (#1531) and are tested in
+Covers the seven ``meho.connector.*`` review / edit / enable /
+disable / delete tools. The ingest-pipeline tools
+(``meho.connector.ingest`` + ``meho.connector.ingest_status``) split
+out into their own handler module (#1531) and are tested in
 ``test_mcp_tools_connector_ingest.py``.
 
 Coverage matrix:
@@ -50,6 +50,8 @@ from meho_backplane.operations.ingest import (
     ConnectorListItem,
     ConnectorReviewGroup,
     ConnectorReviewPayload,
+    DeleteConnectorResult,
+    DeleteConnectorWarning,
     EditOpWarning,
 )
 from tests.mcp_test_fixtures import (
@@ -77,6 +79,20 @@ class _FakeReviewService:
 
     edit_op_warnings: ClassVar[list[EditOpWarning]] = []
 
+    #: Canned :meth:`delete_connector` result — class attribute for the
+    #: same lazy-construction reason as ``edit_op_warnings``. Default
+    #: mirrors the clean row-bearing path: rows deleted, shim popped,
+    #: no advisory.
+    delete_result: ClassVar[DeleteConnectorResult] = DeleteConnectorResult(
+        connector_id="vmware-rest-9.0",
+        groups_deleted=2,
+        operations_deleted=8,
+        enabled_operations_deleted=0,
+        class_deregistered=True,
+        registry_only=False,
+        warnings=(),
+    )
+
     def __init__(self, operator: Operator) -> None:
         self.operator = operator
         self.review_calls: list[tuple[str, Any]] = []
@@ -84,6 +100,7 @@ class _FakeReviewService:
         self.edit_op_calls: list[dict[str, Any]] = []
         self.enable_calls: list[str] = []
         self.disable_calls: list[str] = []
+        self.delete_calls: list[dict[str, Any]] = []
 
     async def get_review_payload(
         self,
@@ -136,6 +153,14 @@ class _FakeReviewService:
 
     async def disable_connector(self, connector_id: str, **_kwargs: Any) -> None:
         self.disable_calls.append(connector_id)
+
+    async def delete_connector(
+        self,
+        connector_id: str,
+        **kwargs: Any,
+    ) -> DeleteConnectorResult:
+        self.delete_calls.append({"connector_id": connector_id, **kwargs})
+        return self.delete_result
 
 
 @pytest.fixture
@@ -205,6 +230,7 @@ _ADMIN_TOOL_NAMES = {
     "meho.connector.edit_op",
     "meho.connector.enable",
     "meho.connector.disable",
+    "meho.connector.delete",
 }
 
 _READ_ADMIN_TOOL_NAMES = {
@@ -694,6 +720,126 @@ def test_call_meho_connector_enable_dispatches(
 
     [review] = stubbed_services["review"]
     assert review.enable_calls == ["vmware-rest-9.0"]
+
+
+@pytest.mark.parametrize(
+    "client_with_operator",
+    [TenantRole.TENANT_ADMIN],
+    indirect=True,
+)
+def test_call_meho_connector_delete_defaults_to_global_scope(
+    client_with_operator: tuple[TestClient, Operator],  # noqa: F811
+    stubbed_services: dict[str, Any],
+) -> None:
+    """``delete`` with ``tenant_id`` omitted targets the built-in scope.
+
+    Pins the #1699 tenant-scope contract on the delete tool: an
+    omitted ``tenant_id`` forwards ``None`` (global / built-in) to
+    :meth:`ReviewService.delete_connector` — the mirror of the REST
+    route, which always forwards the operator's own tenant.
+    """
+    client, _op = client_with_operator
+    response = post_mcp(
+        client,
+        {
+            "jsonrpc": "2.0",
+            "id": 1,
+            "method": "tools/call",
+            "params": {
+                "name": "meho.connector.delete",
+                "arguments": {"connector_id": "vmware-rest-9.0"},
+            },
+        },
+    )
+    assert response.status_code == 200
+    payload = _unwrap_text_content(response.json())
+    assert payload == {
+        "connector_id": "vmware-rest-9.0",
+        "ok": True,
+        "deleted": {
+            "groups_deleted": 2,
+            "operations_deleted": 8,
+            "enabled_operations_deleted": 0,
+            "class_deregistered": True,
+            "registry_only": False,
+        },
+        "warnings": [],
+    }
+
+    [review] = stubbed_services["review"]
+    assert review.delete_calls == [
+        {"connector_id": "vmware-rest-9.0", "tenant_id": None},
+    ]
+
+
+@pytest.mark.parametrize(
+    "client_with_operator",
+    [TenantRole.TENANT_ADMIN],
+    indirect=True,
+)
+def test_call_meho_connector_delete_surfaces_enabled_ops_warning(
+    client_with_operator: tuple[TestClient, Operator],  # noqa: F811
+    stubbed_services: dict[str, Any],
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """The enabled-operations advisory rides the MCP response body.
+
+    The REST sibling stays ``204 No Content`` per the task contract,
+    so this tool is the structured wire home for the advisory — the
+    same MCP↔REST split the ``edit_op`` warnings established
+    (G0.23-T4 #1630). The explicit tenant UUID also pins the
+    tenant-scoped call shape.
+    """
+    client, op = client_with_operator
+    warning = DeleteConnectorWarning(
+        code="enabled_operations_deleted",
+        enabled_op_count=3,
+        message="connector 'vmware-rest-9.0' still had 3 enabled operation(s).",
+    )
+    monkeypatch.setattr(
+        _FakeReviewService,
+        "delete_result",
+        DeleteConnectorResult(
+            connector_id="vmware-rest-9.0",
+            groups_deleted=1,
+            operations_deleted=3,
+            enabled_operations_deleted=3,
+            class_deregistered=False,
+            registry_only=False,
+            warnings=(warning,),
+        ),
+    )
+    response = post_mcp(
+        client,
+        {
+            "jsonrpc": "2.0",
+            "id": 1,
+            "method": "tools/call",
+            "params": {
+                "name": "meho.connector.delete",
+                "arguments": {
+                    "connector_id": "vmware-rest-9.0",
+                    "tenant_id": str(op.tenant_id),
+                },
+            },
+        },
+    )
+    assert response.status_code == 200
+    payload = _unwrap_text_content(response.json())
+    assert payload["ok"] is True
+    assert payload["deleted"]["enabled_operations_deleted"] == 3
+    assert payload["warnings"] == [
+        {
+            "code": "enabled_operations_deleted",
+            "enabled_op_count": 3,
+            "message": "connector 'vmware-rest-9.0' still had 3 enabled operation(s).",
+        },
+    ]
+
+    [review] = stubbed_services["review"]
+    assert review.delete_calls == [
+        {"connector_id": "vmware-rest-9.0", "tenant_id": op.tenant_id},
+    ]
 
 
 # ---------------------------------------------------------------------------

--- a/backend/tests/test_operations_ingest_delete.py
+++ b/backend/tests/test_operations_ingest_delete.py
@@ -1,0 +1,558 @@
+# SPDX-License-Identifier: Apache-2.0
+# Copyright (c) 2026 evoila Group
+
+"""Behavioural tests for the connector DELETE surface (G0.25-T2 #1700).
+
+Coverage matrix against the task's acceptance criteria, at the
+service layer (:meth:`ReviewService.delete_connector` — the single
+path both the REST route and the MCP tool drive):
+
+* Row-bearing delete removes every ``operation_group`` +
+  ``endpoint_descriptor`` row under the caller's scope (including
+  ``group_id IS NULL`` strays the mid-pipeline-abort shape leaves),
+  pops the triple's auto-shim from the v2 registry, writes exactly
+  one ``meho.connector.delete`` audit row, and drops the connector
+  from ``list_ingested_connectors``.
+* Zero-op stub delete (the primary #1700 consumer scenario): no rows
+  anywhere, only the auto-registered shim — registry-only delete.
+* 404 conflation: unknown id, cross-tenant probe, built-in scope
+  without tenant_admin, and rows that live only under a scope the
+  caller did not name.
+* Enabled-operations advisory: the delete completes, the result
+  carries the ``enabled_operations_deleted`` warning.
+* Registry policy: hand-coded classes are never deregistered; the
+  shim survives while another tenant still has rows for the triple.
+* Re-ingest revival: a fresh ``register_ingested_operations`` run on
+  the deleted triple re-registers the shim and re-lands rows.
+* Post-delete discovery: ``search_operations`` classifies the
+  connector as unknown (no hits possible) once rows + shim are gone.
+
+Runs against ``sqlite+aiosqlite`` via the autouse
+``_default_database_url`` conftest fixture (schema pre-migrated to
+head). Registry state is snapshot/restored per test by the conftest
+global-registry isolation fixture (#585).
+"""
+
+from __future__ import annotations
+
+import uuid
+from collections.abc import Iterator
+from typing import Any
+from unittest.mock import AsyncMock
+
+import pytest
+from sqlalchemy import select
+
+from meho_backplane.auth.operator import Operator, TenantRole
+from meho_backplane.connectors.base import Connector
+from meho_backplane.connectors.registry import all_connectors_v2, register_connector_v2
+from meho_backplane.connectors.schemas import (
+    FingerprintResult,
+    OperationResult,
+    ProbeResult,
+)
+from meho_backplane.db.engine import get_sessionmaker
+from meho_backplane.db.models import AuditLog, EndpointDescriptor, OperationGroup
+from meho_backplane.operations.ingest import (
+    ConnectorNotFoundError,
+    ReviewService,
+    ensure_connector_class_registered,
+    list_ingested_connectors,
+    register_ingested_operations,
+)
+from meho_backplane.operations.ingest.schemas import EndpointDescriptorProto
+from meho_backplane.operations.meta_tools import UnknownConnectorError, search_operations
+from meho_backplane.settings import get_settings
+
+_PRODUCT = "stubprobe"
+_VERSION = "1.0"
+_IMPL_ID = "stubprobe-rest"
+_CONNECTOR_ID = f"{_IMPL_ID}-{_VERSION}"
+
+
+class _HandCodedConnector(Connector):
+    """A non-shim stand-in for a hand-rolled per-product connector class.
+
+    Local fake (same shape :mod:`tests.test_connectors_registry_v2`
+    uses) rather than a real shipped class — importing a shipped
+    connector package would fire its module-import-time registration
+    side effects inside this test module.
+    """
+
+    product = _PRODUCT
+    version = _VERSION
+    impl_id = _IMPL_ID
+    supported_version_range = ">=1.0,<2.0"
+
+    async def fingerprint(self, target: Any, operator: Any = None) -> FingerprintResult:  # type: ignore[override]
+        raise NotImplementedError
+
+    async def probe(self, target: Any) -> ProbeResult:  # type: ignore[override]
+        raise NotImplementedError
+
+    async def execute(self, target: Any, op_id: str, params: dict[str, Any]) -> OperationResult:  # type: ignore[override]
+        raise NotImplementedError
+
+
+@pytest.fixture(autouse=True)
+def _required_settings_env(monkeypatch: pytest.MonkeyPatch) -> Iterator[None]:
+    """Pin the Settings env vars Operator construction depends on.
+
+    Same shape as :mod:`tests.test_operations_ingest_review` — the
+    autouse conftest fixture pins ``DATABASE_URL``; Keycloak/Vault
+    env come from the test file.
+    """
+    monkeypatch.setenv("KEYCLOAK_ISSUER_URL", "https://keycloak.test/realms/meho")
+    monkeypatch.setenv("KEYCLOAK_AUDIENCE", "meho-backplane")
+    monkeypatch.setenv("VAULT_ADDR", "https://vault.test")
+    get_settings.cache_clear()
+    yield
+    get_settings.cache_clear()
+
+
+_FAKE_JWT = "header.payload.signature"
+
+
+def _make_operator(
+    *,
+    tenant_id: uuid.UUID,
+    role: TenantRole = TenantRole.TENANT_ADMIN,
+) -> Operator:
+    return Operator(
+        sub=f"test-operator-{uuid.uuid4()}",
+        name="Test Operator",
+        email=None,
+        raw_jwt=_FAKE_JWT,
+        tenant_id=tenant_id,
+        tenant_role=role,
+    )
+
+
+async def _seed_rows(
+    *,
+    tenant_id: uuid.UUID | None,
+    group_count: int = 2,
+    ops_per_group: int = 3,
+    op_is_enabled: bool = False,
+    stray_ungrouped_ops: int = 0,
+) -> None:
+    """Seed groups + child ops (and optional ``group_id IS NULL`` strays)."""
+    sessionmaker = get_sessionmaker()
+    async with sessionmaker() as session:
+        for g_index in range(group_count):
+            group_id = uuid.uuid4()
+            group_key = f"group-{g_index}"
+            session.add(
+                OperationGroup(
+                    id=group_id,
+                    tenant_id=tenant_id,
+                    product=_PRODUCT,
+                    version=_VERSION,
+                    impl_id=_IMPL_ID,
+                    group_key=group_key,
+                    name=f"Group {g_index}",
+                    when_to_use=f"Use group {g_index} for things.",
+                    review_status="staged",
+                ),
+            )
+            for o_index in range(ops_per_group):
+                session.add(
+                    EndpointDescriptor(
+                        tenant_id=tenant_id,
+                        product=_PRODUCT,
+                        version=_VERSION,
+                        impl_id=_IMPL_ID,
+                        op_id=f"GET:/api/v1/{group_key}/{o_index}",
+                        source_kind="ingested",
+                        method="GET",
+                        path=f"/api/v1/{group_key}/{o_index}",
+                        summary="Summary",
+                        description="Description",
+                        group_id=group_id,
+                        tags=["test"],
+                        parameter_schema={"type": "object"},
+                        safety_level="safe",
+                        requires_approval=False,
+                        is_enabled=op_is_enabled,
+                    ),
+                )
+        for s_index in range(stray_ungrouped_ops):
+            session.add(
+                EndpointDescriptor(
+                    tenant_id=tenant_id,
+                    product=_PRODUCT,
+                    version=_VERSION,
+                    impl_id=_IMPL_ID,
+                    op_id=f"GET:/api/v1/stray/{s_index}",
+                    source_kind="ingested",
+                    method="GET",
+                    path=f"/api/v1/stray/{s_index}",
+                    summary="Stray",
+                    description="Upserted by T2 but never grouped by T3.",
+                    group_id=None,
+                    tags=["test"],
+                    parameter_schema={"type": "object"},
+                    safety_level="safe",
+                    requires_approval=False,
+                    is_enabled=False,
+                ),
+            )
+        await session.commit()
+
+
+def _register_shim() -> None:
+    assert ensure_connector_class_registered(
+        product=_PRODUCT,
+        version=_VERSION,
+        impl_id=_IMPL_ID,
+        base_url=None,
+    )
+
+
+async def _count_rows(tenant_id: uuid.UUID | None) -> tuple[int, int]:
+    """Return ``(group_rows, descriptor_rows)`` for the test triple in scope."""
+    sessionmaker = get_sessionmaker()
+    async with sessionmaker() as session:
+        group_stmt = select(OperationGroup).where(
+            OperationGroup.product == _PRODUCT,
+            OperationGroup.version == _VERSION,
+            OperationGroup.impl_id == _IMPL_ID,
+        )
+        op_stmt = select(EndpointDescriptor).where(
+            EndpointDescriptor.product == _PRODUCT,
+            EndpointDescriptor.version == _VERSION,
+            EndpointDescriptor.impl_id == _IMPL_ID,
+        )
+        if tenant_id is None:
+            group_stmt = group_stmt.where(OperationGroup.tenant_id.is_(None))
+            op_stmt = op_stmt.where(EndpointDescriptor.tenant_id.is_(None))
+        else:
+            group_stmt = group_stmt.where(OperationGroup.tenant_id == tenant_id)
+            op_stmt = op_stmt.where(EndpointDescriptor.tenant_id == tenant_id)
+        groups = len((await session.execute(group_stmt)).scalars().all())
+        ops = len((await session.execute(op_stmt)).scalars().all())
+        return groups, ops
+
+
+async def _delete_audit_rows() -> list[AuditLog]:
+    sessionmaker = get_sessionmaker()
+    async with sessionmaker() as session:
+        result = await session.execute(
+            select(AuditLog).where(
+                AuditLog.method == "SERVICE",
+                AuditLog.path == "meho.connector.delete",
+            ),
+        )
+        return list(result.scalars().all())
+
+
+# ---------------------------------------------------------------------------
+# Row-bearing delete
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.asyncio
+async def test_delete_removes_rows_shim_listing_and_audits() -> None:
+    """Full delete: rows gone (incl. strays), shim gone, listing clean, one audit row."""
+    tenant = uuid.uuid4()
+    operator = _make_operator(tenant_id=tenant)
+    _register_shim()
+    await _seed_rows(tenant_id=tenant, stray_ungrouped_ops=2)
+
+    result = await ReviewService(operator).delete_connector(
+        _CONNECTOR_ID,
+        tenant_id=tenant,
+    )
+
+    assert result.groups_deleted == 2
+    assert result.operations_deleted == 8  # 2 groups x 3 ops + 2 strays
+    assert result.enabled_operations_deleted == 0
+    assert result.warnings == ()
+    assert result.class_deregistered is True
+    assert result.registry_only is False
+    assert await _count_rows(tenant) == (0, 0)
+    assert (_PRODUCT, _VERSION, _IMPL_ID) not in all_connectors_v2()
+
+    listed = await list_ingested_connectors(operator=operator)
+    assert all(item.connector_id != _CONNECTOR_ID for item in listed)
+
+    audit_rows = await _delete_audit_rows()
+    assert len(audit_rows) == 1
+    payload = audit_rows[0].payload
+    assert payload["connector_id"] == _CONNECTOR_ID
+    assert payload["tenant_scope"] == str(tenant)
+    assert payload["deleted_group_keys"] == ["group-0", "group-1"]
+    assert payload["groups_deleted"] == 2
+    assert payload["operations_deleted"] == 8
+    assert payload["class_deregistered"] is True
+    assert payload["registry_only"] is False
+
+
+@pytest.mark.asyncio
+async def test_delete_warns_on_enabled_ops_but_completes() -> None:
+    """A connector with enabled ops deletes anyway; the advisory names the count."""
+    tenant = uuid.uuid4()
+    operator = _make_operator(tenant_id=tenant)
+    _register_shim()
+    await _seed_rows(tenant_id=tenant, op_is_enabled=True)
+
+    result = await ReviewService(operator).delete_connector(
+        _CONNECTOR_ID,
+        tenant_id=tenant,
+    )
+
+    assert result.enabled_operations_deleted == 6
+    assert len(result.warnings) == 1
+    warning = result.warnings[0]
+    assert warning.code == "enabled_operations_deleted"
+    assert warning.enabled_op_count == 6
+    assert _CONNECTOR_ID in warning.message
+    assert await _count_rows(tenant) == (0, 0)
+
+
+@pytest.mark.asyncio
+async def test_delete_preserves_other_scope_rows_and_shim() -> None:
+    """Deleting one tenant's copy leaves the other scope's rows + the shim intact."""
+    tenant = uuid.uuid4()
+    operator = _make_operator(tenant_id=tenant)
+    _register_shim()
+    await _seed_rows(tenant_id=tenant)
+    await _seed_rows(tenant_id=None, group_count=1, ops_per_group=1)
+
+    result = await ReviewService(operator).delete_connector(
+        _CONNECTOR_ID,
+        tenant_id=tenant,
+    )
+
+    assert result.class_deregistered is False
+    assert await _count_rows(tenant) == (0, 0)
+    assert await _count_rows(None) == (1, 1)
+    assert (_PRODUCT, _VERSION, _IMPL_ID) in all_connectors_v2()
+
+
+@pytest.mark.asyncio
+async def test_delete_never_deregisters_hand_coded_class() -> None:
+    """Rows of a hand-coded connector delete; the class registration survives."""
+    tenant = uuid.uuid4()
+    operator = _make_operator(tenant_id=tenant)
+    register_connector_v2(
+        product=_PRODUCT,
+        version=_VERSION,
+        impl_id=_IMPL_ID,
+        cls=_HandCodedConnector,
+    )
+    await _seed_rows(tenant_id=tenant)
+
+    result = await ReviewService(operator).delete_connector(
+        _CONNECTOR_ID,
+        tenant_id=tenant,
+    )
+
+    assert result.class_deregistered is False
+    assert await _count_rows(tenant) == (0, 0)
+    assert (_PRODUCT, _VERSION, _IMPL_ID) in all_connectors_v2()
+
+
+# ---------------------------------------------------------------------------
+# Zero-op stub (the primary #1700 scenario)
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.asyncio
+async def test_delete_zero_op_stub_is_registry_only() -> None:
+    """No rows anywhere + registered shim: the delete pops the shim and audits."""
+    tenant = uuid.uuid4()
+    operator = _make_operator(tenant_id=tenant)
+    _register_shim()
+    assert (_PRODUCT, _VERSION, _IMPL_ID) in all_connectors_v2()
+
+    result = await ReviewService(operator).delete_connector(
+        _CONNECTOR_ID,
+        tenant_id=tenant,
+    )
+
+    assert result.registry_only is True
+    assert result.class_deregistered is True
+    assert result.groups_deleted == 0
+    assert result.operations_deleted == 0
+    assert result.warnings == ()
+    assert (_PRODUCT, _VERSION, _IMPL_ID) not in all_connectors_v2()
+
+    audit_rows = await _delete_audit_rows()
+    assert len(audit_rows) == 1
+    assert audit_rows[0].payload["registry_only"] is True
+
+    listed = await list_ingested_connectors(operator=operator)
+    assert all(item.connector_id != _CONNECTOR_ID for item in listed)
+
+
+@pytest.mark.asyncio
+async def test_delete_zero_op_stub_repeat_returns_not_found() -> None:
+    """The second delete of a stub 404s — nothing is left to remove."""
+    tenant = uuid.uuid4()
+    operator = _make_operator(tenant_id=tenant)
+    _register_shim()
+    service = ReviewService(operator)
+    await service.delete_connector(_CONNECTOR_ID, tenant_id=tenant)
+
+    with pytest.raises(ConnectorNotFoundError):
+        await service.delete_connector(_CONNECTOR_ID, tenant_id=tenant)
+
+
+# ---------------------------------------------------------------------------
+# 404 conflation
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.asyncio
+async def test_delete_unknown_connector_raises_not_found() -> None:
+    operator = _make_operator(tenant_id=uuid.uuid4())
+    with pytest.raises(ConnectorNotFoundError):
+        await ReviewService(operator).delete_connector(
+            "missing-rest-9.9",
+            tenant_id=operator.tenant_id,
+        )
+
+
+@pytest.mark.asyncio
+async def test_delete_cross_tenant_scope_raises_not_found() -> None:
+    """Naming another tenant's scope conflates into the same not-found error."""
+    tenant_a = uuid.uuid4()
+    tenant_b = uuid.uuid4()
+    operator = _make_operator(tenant_id=tenant_a)
+    _register_shim()
+    await _seed_rows(tenant_id=tenant_b)
+
+    with pytest.raises(ConnectorNotFoundError):
+        await ReviewService(operator).delete_connector(
+            _CONNECTOR_ID,
+            tenant_id=tenant_b,
+        )
+    assert await _count_rows(tenant_b) == (2, 6)
+
+
+@pytest.mark.asyncio
+async def test_delete_rows_only_under_other_scope_raises_not_found() -> None:
+    """Built-in rows are invisible to a tenant-scoped delete: 404, nothing changes.
+
+    Pins the write-scope discipline the #1699 contract documents: the
+    REST route always passes the operator's tenant, so a built-in
+    connector must be deleted via the MCP tool's global scope — the
+    tenant-scoped call cannot see (or take down) the NULL-scope rows,
+    and the shim stays registered because rows still exist.
+    """
+    tenant = uuid.uuid4()
+    operator = _make_operator(tenant_id=tenant)
+    _register_shim()
+    await _seed_rows(tenant_id=None)
+
+    with pytest.raises(ConnectorNotFoundError):
+        await ReviewService(operator).delete_connector(
+            _CONNECTOR_ID,
+            tenant_id=tenant,
+        )
+    assert await _count_rows(None) == (2, 6)
+    assert (_PRODUCT, _VERSION, _IMPL_ID) in all_connectors_v2()
+
+
+@pytest.mark.asyncio
+async def test_delete_built_in_scope_requires_tenant_admin() -> None:
+    """``tenant_id=None`` without tenant_admin conflates to not-found."""
+    operator = _make_operator(tenant_id=uuid.uuid4(), role=TenantRole.OPERATOR)
+    _register_shim()
+    await _seed_rows(tenant_id=None)
+
+    with pytest.raises(ConnectorNotFoundError):
+        await ReviewService(operator).delete_connector(
+            _CONNECTOR_ID,
+            tenant_id=None,
+        )
+    assert await _count_rows(None) == (2, 6)
+
+
+@pytest.mark.asyncio
+async def test_delete_built_in_scope_with_tenant_admin_succeeds() -> None:
+    """The MCP-shaped global-scope delete (tenant_id=None) removes built-in rows."""
+    operator = _make_operator(tenant_id=uuid.uuid4())
+    _register_shim()
+    await _seed_rows(tenant_id=None)
+
+    result = await ReviewService(operator).delete_connector(
+        _CONNECTOR_ID,
+        tenant_id=None,
+    )
+
+    assert result.class_deregistered is True
+    assert await _count_rows(None) == (0, 0)
+    audit_rows = await _delete_audit_rows()
+    assert len(audit_rows) == 1
+    assert audit_rows[0].payload["tenant_scope"] is None
+
+
+# ---------------------------------------------------------------------------
+# Post-delete discovery + revival
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.asyncio
+async def test_deleted_connector_is_unknown_to_search_operations() -> None:
+    """Once rows + shim are gone, search classifies the connector as unknown.
+
+    ``search_operations`` resolves the connector before touching the
+    query embedding, so the post-delete probe raises
+    :class:`UnknownConnectorError` without any hits — the strongest
+    form of "deleted operations do not appear in search results".
+    """
+    tenant = uuid.uuid4()
+    operator = _make_operator(tenant_id=tenant)
+    _register_shim()
+    await _seed_rows(tenant_id=tenant)
+    await ReviewService(operator).delete_connector(_CONNECTOR_ID, tenant_id=tenant)
+
+    with pytest.raises(UnknownConnectorError):
+        await search_operations(
+            operator,
+            {"connector_id": _CONNECTOR_ID, "query": "anything"},
+        )
+
+
+@pytest.mark.asyncio
+async def test_reingest_after_delete_re_registers_connector() -> None:
+    """AC: an ingest on a deleted connector re-registers it from scratch."""
+    tenant = uuid.uuid4()
+    operator = _make_operator(tenant_id=tenant)
+    _register_shim()
+    await _seed_rows(tenant_id=tenant)
+    await ReviewService(operator).delete_connector(_CONNECTOR_ID, tenant_id=tenant)
+    assert (_PRODUCT, _VERSION, _IMPL_ID) not in all_connectors_v2()
+
+    stub_embedding: Any = AsyncMock()
+    stub_embedding.encode_one.return_value = [0.25] * 384
+    stub_embedding.dimension = 384
+    result = await register_ingested_operations(
+        product=_PRODUCT,
+        version=_VERSION,
+        impl_id=_IMPL_ID,
+        operations=[
+            EndpointDescriptorProto(
+                op_id="GET:/pets",
+                method="GET",
+                path="/pets",
+                summary="List pets",
+                description="List the pets.",
+                tags=["pets"],
+                parameter_schema={"type": "object", "properties": {}},
+                response_schema={"type": "object"},
+                safety_level="safe",
+                requires_approval=False,
+            ),
+        ],
+        spec_source="https://specs.example.test/reingest.yaml",
+        tenant_id=tenant,
+        embedding_service=stub_embedding,
+    )
+
+    assert result.connector_registered is True  # fresh shim, not a reuse
+    assert result.inserted_count == 1
+    assert (_PRODUCT, _VERSION, _IMPL_ID) in all_connectors_v2()
+    assert await _count_rows(tenant) == (0, 1)

--- a/cli/api/openapi.json
+++ b/cli/api/openapi.json
@@ -3374,6 +3374,52 @@
         }
       }
     },
+    "/api/v1/connectors/{connector_id}": {
+      "delete": {
+        "tags": [
+          "connectors"
+        ],
+        "summary": "Delete Endpoint",
+        "description": "Delete *connector_id* \u2014 rows under the operator's tenant + the ingest shim.\n\nG0.25-T2 (#1700): clean-up surface for the zero-op registry stubs\naborted ingests leave behind, and for removing an unwanted\ningested connector outright. Removes the connector's\n``endpoint_descriptor`` + ``operation_group`` rows and writes one\n``meho.connector.delete`` audit row in the same transaction; when\nno rows remain for the triple under any scope, the\nauto-registered ``GenericRestConnector`` shim is also popped from\nthe v2 registry (hand-coded connector classes are never\nderegistered). A zero-op stub \u2014 registered class, no rows \u2014 is\ndeletable here too: that delete is registry-only.\n\nTenant scoping (#1699 contract): this route exposes **no**\n``tenant_id`` parameter \u2014 the delete scope is always the calling\noperator's tenant from the JWT. Built-in / global connectors\n(``tenant_id IS NULL`` rows) are deleted via the MCP sibling\n``meho.connector.delete`` with ``tenant_id`` omitted\n(tenant_admin only). Unknown ids, cross-tenant probes, and rows\nvisible only under a scope this route cannot name all collapse\ninto the same 404 the other connector routes use; a repeat\nDELETE therefore returns 404 once the first one landed.\n\nA connector that still has enabled operations is deleted anyway \u2014\nthe advisory is deliberate, not an error: it surfaces as the\n``connector_delete_enabled_ops`` structured log event plus the\naudit payload's ``enabled_operations_deleted`` count. The wire\nresponse stays ``204 No Content`` per the task contract, so the\nstructured warning body lives on the MCP sibling (the\n``edit_op`` 200-promotion precedent from #1630 remains available\nif a REST wire home is ever needed). Re-ingesting the same triple\nafterwards re-registers the connector from scratch.",
+        "operationId": "delete_endpoint_api_v1_connectors__connector_id__delete",
+        "parameters": [
+          {
+            "name": "connector_id",
+            "in": "path",
+            "required": true,
+            "schema": {
+              "type": "string",
+              "title": "Connector Id"
+            }
+          },
+          {
+            "name": "authorization",
+            "in": "header",
+            "required": false,
+            "schema": {
+              "type": "string",
+              "nullable": true,
+              "title": "Authorization"
+            }
+          }
+        ],
+        "responses": {
+          "204": {
+            "description": "Successful Response"
+          },
+          "422": {
+            "description": "Validation Error",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/HTTPValidationError"
+                }
+              }
+            }
+          }
+        }
+      }
+    },
     "/api/v1/kb": {
       "get": {
         "tags": [

--- a/cli/internal/api/client.gen.go
+++ b/cli/internal/api/client.gen.go
@@ -5286,6 +5286,11 @@ type GetIngestJobEndpointApiV1ConnectorsIngestJobsJobIdGetParams struct {
 	Authorization *string `json:"authorization,omitempty"`
 }
 
+// DeleteEndpointApiV1ConnectorsConnectorIdDeleteParams defines parameters for DeleteEndpointApiV1ConnectorsConnectorIdDelete.
+type DeleteEndpointApiV1ConnectorsConnectorIdDeleteParams struct {
+	Authorization *string `json:"authorization,omitempty"`
+}
+
 // DisableEndpointApiV1ConnectorsConnectorIdDisablePostParams defines parameters for DisableEndpointApiV1ConnectorsConnectorIdDisablePost.
 type DisableEndpointApiV1ConnectorsConnectorIdDisablePostParams struct {
 	Authorization *string `json:"authorization,omitempty"`
@@ -7065,6 +7070,9 @@ type ClientInterface interface {
 	// GetIngestJobEndpointApiV1ConnectorsIngestJobsJobIdGet request
 	GetIngestJobEndpointApiV1ConnectorsIngestJobsJobIdGet(ctx context.Context, jobId openapi_types.UUID, params *GetIngestJobEndpointApiV1ConnectorsIngestJobsJobIdGetParams, reqEditors ...RequestEditorFn) (*http.Response, error)
 
+	// DeleteEndpointApiV1ConnectorsConnectorIdDelete request
+	DeleteEndpointApiV1ConnectorsConnectorIdDelete(ctx context.Context, connectorId string, params *DeleteEndpointApiV1ConnectorsConnectorIdDeleteParams, reqEditors ...RequestEditorFn) (*http.Response, error)
+
 	// DisableEndpointApiV1ConnectorsConnectorIdDisablePost request
 	DisableEndpointApiV1ConnectorsConnectorIdDisablePost(ctx context.Context, connectorId string, params *DisableEndpointApiV1ConnectorsConnectorIdDisablePostParams, reqEditors ...RequestEditorFn) (*http.Response, error)
 
@@ -8148,6 +8156,18 @@ func (c *Client) IngestEndpointApiV1ConnectorsIngestPost(ctx context.Context, pa
 
 func (c *Client) GetIngestJobEndpointApiV1ConnectorsIngestJobsJobIdGet(ctx context.Context, jobId openapi_types.UUID, params *GetIngestJobEndpointApiV1ConnectorsIngestJobsJobIdGetParams, reqEditors ...RequestEditorFn) (*http.Response, error) {
 	req, err := NewGetIngestJobEndpointApiV1ConnectorsIngestJobsJobIdGetRequest(c.Server, jobId, params)
+	if err != nil {
+		return nil, err
+	}
+	req = req.WithContext(ctx)
+	if err := c.applyEditors(ctx, req, reqEditors); err != nil {
+		return nil, err
+	}
+	return c.Client.Do(req)
+}
+
+func (c *Client) DeleteEndpointApiV1ConnectorsConnectorIdDelete(ctx context.Context, connectorId string, params *DeleteEndpointApiV1ConnectorsConnectorIdDeleteParams, reqEditors ...RequestEditorFn) (*http.Response, error) {
+	req, err := NewDeleteEndpointApiV1ConnectorsConnectorIdDeleteRequest(c.Server, connectorId, params)
 	if err != nil {
 		return nil, err
 	}
@@ -12483,6 +12503,55 @@ func NewGetIngestJobEndpointApiV1ConnectorsIngestJobsJobIdGetRequest(server stri
 	}
 
 	req, err := http.NewRequest("GET", queryURL.String(), nil)
+	if err != nil {
+		return nil, err
+	}
+
+	if params != nil {
+
+		if params.Authorization != nil {
+			var headerParam0 string
+
+			headerParam0, err = runtime.StyleParamWithLocation("simple", false, "authorization", runtime.ParamLocationHeader, *params.Authorization)
+			if err != nil {
+				return nil, err
+			}
+
+			req.Header.Set("authorization", headerParam0)
+		}
+
+	}
+
+	return req, nil
+}
+
+// NewDeleteEndpointApiV1ConnectorsConnectorIdDeleteRequest generates requests for DeleteEndpointApiV1ConnectorsConnectorIdDelete
+func NewDeleteEndpointApiV1ConnectorsConnectorIdDeleteRequest(server string, connectorId string, params *DeleteEndpointApiV1ConnectorsConnectorIdDeleteParams) (*http.Request, error) {
+	var err error
+
+	var pathParam0 string
+
+	pathParam0, err = runtime.StyleParamWithLocation("simple", false, "connector_id", runtime.ParamLocationPath, connectorId)
+	if err != nil {
+		return nil, err
+	}
+
+	serverURL, err := url.Parse(server)
+	if err != nil {
+		return nil, err
+	}
+
+	operationPath := fmt.Sprintf("/api/v1/connectors/%s", pathParam0)
+	if operationPath[0] == '/' {
+		operationPath = "." + operationPath
+	}
+
+	queryURL, err := serverURL.Parse(operationPath)
+	if err != nil {
+		return nil, err
+	}
+
+	req, err := http.NewRequest("DELETE", queryURL.String(), nil)
 	if err != nil {
 		return nil, err
 	}
@@ -20728,6 +20797,9 @@ type ClientWithResponsesInterface interface {
 	// GetIngestJobEndpointApiV1ConnectorsIngestJobsJobIdGetWithResponse request
 	GetIngestJobEndpointApiV1ConnectorsIngestJobsJobIdGetWithResponse(ctx context.Context, jobId openapi_types.UUID, params *GetIngestJobEndpointApiV1ConnectorsIngestJobsJobIdGetParams, reqEditors ...RequestEditorFn) (*GetIngestJobEndpointApiV1ConnectorsIngestJobsJobIdGetResponse, error)
 
+	// DeleteEndpointApiV1ConnectorsConnectorIdDeleteWithResponse request
+	DeleteEndpointApiV1ConnectorsConnectorIdDeleteWithResponse(ctx context.Context, connectorId string, params *DeleteEndpointApiV1ConnectorsConnectorIdDeleteParams, reqEditors ...RequestEditorFn) (*DeleteEndpointApiV1ConnectorsConnectorIdDeleteResponse, error)
+
 	// DisableEndpointApiV1ConnectorsConnectorIdDisablePostWithResponse request
 	DisableEndpointApiV1ConnectorsConnectorIdDisablePostWithResponse(ctx context.Context, connectorId string, params *DisableEndpointApiV1ConnectorsConnectorIdDisablePostParams, reqEditors ...RequestEditorFn) (*DisableEndpointApiV1ConnectorsConnectorIdDisablePostResponse, error)
 
@@ -22065,6 +22137,28 @@ func (r GetIngestJobEndpointApiV1ConnectorsIngestJobsJobIdGetResponse) Status() 
 
 // StatusCode returns HTTPResponse.StatusCode
 func (r GetIngestJobEndpointApiV1ConnectorsIngestJobsJobIdGetResponse) StatusCode() int {
+	if r.HTTPResponse != nil {
+		return r.HTTPResponse.StatusCode
+	}
+	return 0
+}
+
+type DeleteEndpointApiV1ConnectorsConnectorIdDeleteResponse struct {
+	Body         []byte
+	HTTPResponse *http.Response
+	JSON422      *HTTPValidationError
+}
+
+// Status returns HTTPResponse.Status
+func (r DeleteEndpointApiV1ConnectorsConnectorIdDeleteResponse) Status() string {
+	if r.HTTPResponse != nil {
+		return r.HTTPResponse.Status
+	}
+	return http.StatusText(0)
+}
+
+// StatusCode returns HTTPResponse.StatusCode
+func (r DeleteEndpointApiV1ConnectorsConnectorIdDeleteResponse) StatusCode() int {
 	if r.HTTPResponse != nil {
 		return r.HTTPResponse.StatusCode
 	}
@@ -25455,6 +25549,15 @@ func (c *ClientWithResponses) GetIngestJobEndpointApiV1ConnectorsIngestJobsJobId
 	return ParseGetIngestJobEndpointApiV1ConnectorsIngestJobsJobIdGetResponse(rsp)
 }
 
+// DeleteEndpointApiV1ConnectorsConnectorIdDeleteWithResponse request returning *DeleteEndpointApiV1ConnectorsConnectorIdDeleteResponse
+func (c *ClientWithResponses) DeleteEndpointApiV1ConnectorsConnectorIdDeleteWithResponse(ctx context.Context, connectorId string, params *DeleteEndpointApiV1ConnectorsConnectorIdDeleteParams, reqEditors ...RequestEditorFn) (*DeleteEndpointApiV1ConnectorsConnectorIdDeleteResponse, error) {
+	rsp, err := c.DeleteEndpointApiV1ConnectorsConnectorIdDelete(ctx, connectorId, params, reqEditors...)
+	if err != nil {
+		return nil, err
+	}
+	return ParseDeleteEndpointApiV1ConnectorsConnectorIdDeleteResponse(rsp)
+}
+
 // DisableEndpointApiV1ConnectorsConnectorIdDisablePostWithResponse request returning *DisableEndpointApiV1ConnectorsConnectorIdDisablePostResponse
 func (c *ClientWithResponses) DisableEndpointApiV1ConnectorsConnectorIdDisablePostWithResponse(ctx context.Context, connectorId string, params *DisableEndpointApiV1ConnectorsConnectorIdDisablePostParams, reqEditors ...RequestEditorFn) (*DisableEndpointApiV1ConnectorsConnectorIdDisablePostResponse, error) {
 	rsp, err := c.DisableEndpointApiV1ConnectorsConnectorIdDisablePost(ctx, connectorId, params, reqEditors...)
@@ -28215,6 +28318,32 @@ func ParseGetIngestJobEndpointApiV1ConnectorsIngestJobsJobIdGetResponse(rsp *htt
 		}
 		response.JSON200 = &dest
 
+	case strings.Contains(rsp.Header.Get("Content-Type"), "json") && rsp.StatusCode == 422:
+		var dest HTTPValidationError
+		if err := json.Unmarshal(bodyBytes, &dest); err != nil {
+			return nil, err
+		}
+		response.JSON422 = &dest
+
+	}
+
+	return response, nil
+}
+
+// ParseDeleteEndpointApiV1ConnectorsConnectorIdDeleteResponse parses an HTTP response from a DeleteEndpointApiV1ConnectorsConnectorIdDeleteWithResponse call
+func ParseDeleteEndpointApiV1ConnectorsConnectorIdDeleteResponse(rsp *http.Response) (*DeleteEndpointApiV1ConnectorsConnectorIdDeleteResponse, error) {
+	bodyBytes, err := io.ReadAll(rsp.Body)
+	defer func() { _ = rsp.Body.Close() }()
+	if err != nil {
+		return nil, err
+	}
+
+	response := &DeleteEndpointApiV1ConnectorsConnectorIdDeleteResponse{
+		Body:         bodyBytes,
+		HTTPResponse: rsp,
+	}
+
+	switch {
 	case strings.Contains(rsp.Header.Get("Content-Type"), "json") && rsp.StatusCode == 422:
 		var dest HTTPValidationError
 		if err := json.Unmarshal(bodyBytes, &dest); err != nil {

--- a/docs/codebase/spec-ingestion.md
+++ b/docs/codebase/spec-ingestion.md
@@ -1287,6 +1287,64 @@ through it is a separate, larger change. A keyless air-gapped deploy
 (agent runtime on an on-prem backend, no Anthropic key) therefore still
 gets the 503 on `--catalog` grouping until that work lands.
 
+## Connector deletion (G0.25-T2 #1700)
+
+Aborted ingests leave junk behind: a spec that parses to zero
+operations (or a batch that fails mid-way) has already registered its
+`GenericRestConnector` auto-shim before the upsert loop ran, so the
+catalog shows a permanent `state="registered"` stub with nothing to
+dispatch. The DELETE surface removes it:
+
+* **REST** — `DELETE /api/v1/connectors/{connector_id}` → `204 No
+  Content`. `tenant_admin` role. Always scoped to the calling
+  operator's tenant (the #1699 contract: the route exposes no
+  `tenant_id` parameter).
+* **MCP** — `meho.connector.delete(connector_id, tenant_id=None)` →
+  `{ok: true, deleted: {...}, warnings: [...]}`. `tenant_id` omitted
+  targets the built-in / global scope (the only path that can remove
+  `tenant_id IS NULL` rows), mirroring `meho.connector.ingest`.
+
+Both delegate to `ReviewService.delete_connector`
+(`operations/ingest/delete_connector.py` is the engine). Semantics:
+
+* **Row removal, not a status flag.** The scoped
+  `endpoint_descriptor` + `operation_group` rows are deleted in one
+  transaction together with one `meho.connector.delete` audit row
+  (group keys, op counts, enabled-op count, deregistration flag — the
+  forensic trail). The task's original `review_status='deleted'`
+  sketch would have required widening the
+  `ck_operation_group_review_status` CHECK (an Alembic migration) and
+  an "exclude deleted" filter on every reader; row removal needs
+  neither, and the scoped-out undo path was already "re-ingest brings
+  it back" (deviation recorded on #1700).
+* **Auto-shims only, and only when nothing remains.** The v2-registry
+  class is popped only when (a) it is a `GenericRestConnector`
+  subclass and (b) no rows remain for the triple under *any* tenant
+  scope after the delete (the registry is process-global; popping it
+  while another tenant still has rows would break that tenant's
+  dispatch). Hand-coded classes are never deregistered — they
+  re-register at every boot, so the connector reverts to the truthful
+  `state="registered"` listing row instead.
+* **Zero-op stubs are registry-only deletes.** No rows anywhere + a
+  matching auto-shim → pop + audit + 204. The registry match uses the
+  parsed-natural-key round-trip, so the VCF-family long↔short product
+  splits resolve (`vrli` rows ↔ `vcf-logs`-registered shim).
+* **404 conflation.** Unknown id, cross-tenant probe, rows visible
+  only under a scope the caller did not name, and repeat deletes all
+  return the same 404 the other connector routes use.
+* **Enabled ops warn, never block.** The delete completes; the
+  advisory rides the MCP response body (`warnings[]`, the `edit_op`
+  #1630 discipline), the `connector_delete_enabled_ops` log event,
+  and the audit payload. The REST response stays a body-less 204.
+* **Re-ingest revives.** A later ingest of the same triple
+  re-registers the shim (`connector_registered=True`) and re-lands
+  rows from scratch.
+* **Process-local deregistration.** The registry pop applies to the
+  serving pod; sibling replicas keep the class until their next
+  restart (no startup path re-registers ingest shims, so restarts
+  converge every pod on the post-delete state). The DB rows are the
+  durable truth and are gone everywhere immediately.
+
 ## Known issues
 
 * **`--catalog` ingest grouping requires `ANTHROPIC_API_KEY`.** The


### PR DESCRIPTION
## Summary

- Adds the connector DELETE surface the v0.14.0 cycle-10 dogfood asked for: aborted ingests (zero-op spec, mid-batch failure) register a `GenericRestConnector` auto-shim before the upsert loop runs and nothing could ever remove it, so operators accumulate undeletable `state="registered"` stubs in the catalog.
- **REST**: `DELETE /api/v1/connectors/{connector_id}` → 204, `tenant_admin`, always scoped to the calling operator's tenant (no `tenant_id` param — consistent with the #1699 scope contract), same 404 conflation as the sibling routes. **MCP**: `meho.connector.delete` with optional `tenant_id` (omitted = built-in/global scope, mirroring `meho.connector.ingest`), carrying structured `deleted{}` counts + `warnings[]`.
- Engine (`operations/ingest/delete_connector.py` + `ReviewService.delete_connector`): deletes the scoped `endpoint_descriptor` + `operation_group` rows in one transaction with one `meho.connector.delete` audit row; pops the triple's auto-shim from the v2 registry (new `deregister_connector_v2`) only when it is a `GenericRestConnector` subclass **and** no rows remain under any tenant scope (post-commit, so a failed transaction never leaves the registry ahead of the DB). Hand-coded classes are never deregistered. Zero-op stubs (no rows anywhere) delete registry-only. Enabled ops warn — advisory, never blocks. Re-ingest revives the connector from scratch.
- CLI OpenAPI snapshot + generated Go client regenerated for the new route (additive); `docs/codebase/spec-ingestion.md` gains a "Connector deletion" section; CHANGELOG bullet under [Unreleased].

## Mechanism deviation (recorded on #1700 before implementation)

The task body sketched `review_status='deleted'` soft-deletion, but the deployed `ck_operation_group_review_status` CHECK (migration `0005`) pins the column to `('staged','enabled','disabled')` — the sketch is unimplementable without an Alembic migration, and this wave assigns migrations exclusively to sibling #1701 (concurrent, avoids a two-head revision conflict). Row removal satisfies every observable acceptance criterion with no schema change and no "exclude deleted" tax on the ~10 existing readers; the task had already scoped out undo ("the operator re-ingests to bring the connector back"), and the audit row keeps the forensic trail. Full rationale + alternatives: [issue comment](https://github.com/evoila/meho/issues/1700#issuecomment-4695168692).

## Test plan

- [x] `ruff check src/ tests/` + `ruff format --check` — clean
- [x] `mypy src/` (strict) — clean
- [x] Full backend sweep `pytest tests/ -n 6 --dist loadscope` — **7335 passed, 0 failed**, 416 pre-existing secret-guarded skips
- [x] `python3 .claude/hooks/code-quality.py --diff` — 0 blockers
- [x] `cd cli && go build ./...` — clean with the regenerated client
- [x] AC: DELETE endpoint exists, tenant_admin, 204 → `test_api_v1_connectors_delete.py::test_delete_returns_204_then_404_on_repeat`, `::test_delete_requires_tenant_admin_role`
- [x] AC: cross-tenant DELETE 404s → `::test_delete_is_tenant_scoped_cross_tenant_404` + service-level `test_operations_ingest_delete.py::test_delete_cross_tenant_scope_raises_not_found`
- [x] AC: gone from `all_connectors_v2()` + `list_ingested_connectors()` → `test_delete_removes_rows_shim_listing_and_audits`, `test_delete_zero_op_stub_is_registry_only`
- [x] AC: descriptors absent from `search_operations` → `test_deleted_connector_is_unknown_to_search_operations` (post-delete the connector classifies as unknown before any hit can exist; row-removal mechanism deviation noted above)
- [x] AC: `meho.connector.delete` MCP tool, REST-parity inputs → `test_mcp_tools_connector_admin.py` (visibility/RBAC/schema/description gates auto-extend via `_ADMIN_TOOL_NAMES` + 2 dispatch tests pinning the #1699 scope default)
- [x] AC: warns (advisory, not error) on enabled ops but completes → `test_delete_warns_on_enabled_ops_but_completes` (service) + `test_call_meho_connector_delete_surfaces_enabled_ops_warning` (MCP wire) + REST 204 path
- [x] AC: re-ingest re-registers → `test_reingest_after_delete_re_registers_connector`
- [x] AC E2E: ingest zero-op spec → DELETE → gone from catalog → `test_e2e_zero_op_ingest_then_delete_clears_catalog` (full JWT + SSRF-mocked REST round-trip)

## Out of scope

- Hard schema work (`review_status='deleted'` CHECK widening / `deleted_at` columns) — possible follow-up after #1701's migration lands if restorable deletes are ever wanted; the wire contract here (204/404/warning) is mechanism-agnostic.
- Cascading target deletion and audit-log undo — per the task's out-of-scope list.
- A `meho connector delete` CLI verb — not in the ACs; the regenerated client already exposes the typed route for a follow-up.
- Sibling #1699/#1705 (scope-contract docs) and #1701 (product-split backfill migration) — untouched; this PR only cites the landed contract language.

Adjacent findings (recorded, not changed): `service.py` is pre-existing over the 600-line budget (now 724 — the new method is deliberately thin with the engine split into `delete_connector.py`); `test_api_v1_connectors_ingest.py` at 3591 lines is why the DELETE route tests live in a new focused file; registry deregistration is process-local by design — sibling replicas converge on restart since no startup path re-registers ingest shims (pre-existing platform behaviour, now documented).

<!-- auto-implement-issue: fresh, iteration 1 -->

Closes #1700
