### PR TITLE
fix(ui): pin hx-target="this" on the memory tag datalist (#1695)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -158,6 +158,12 @@ connector-related release-notes line.
   instead of reporting `registered, 0 ops`. Built-in rows only
   (`tenant_id IS NULL`); idempotent; rows whose short-spelling twin
   already exists (post-upgrade re-ingest) are left untouched (#1701)
+- Operator console: the memory list's tag-autocomplete fetch wiped the
+  card grid on page load because the `<datalist>` inherited the filter
+  form's `hx-target="#memory-cards"` (htmx closest-wins attribute
+  inheritance); the datalist now pins `hx-target="this"` so the
+  `<option>` fragment lands in the datalist and the cards stay intact
+  (#1695)
 
 ## [0.14.0] - 2026-06-12
 

--- a/backend/src/meho_backplane/ui/templates/memory/index.html
+++ b/backend/src/meho_backplane/ui/templates/memory/index.html
@@ -22,6 +22,11 @@
       ``hx-swap="outerHTML"``, ``hx-push-url="true"`` so the browser
       URL stays in sync with the active scope (copy/paste reproduces).
     * Tag filter: same target, debounced 300ms.
+    * Tag datalist: ``hx-target="this"`` pins the load-time options
+      fetch to the datalist itself. htmx resolves ``hx-target`` by
+      walking ancestors (closest wins), so without the local override
+      the datalist inherits the filter form's ``#memory-cards`` target
+      and the ``<option>`` fragment replaces the card grid (#1695).
     * The page-level ``hx-headers`` directive echoes the CSRF token
       for any state-changing request triggered from this page
       (delete-from-detail, for example).
@@ -122,6 +127,7 @@
           id="memory-tag-options"
           hx-get="/ui/memory/tags"
           hx-trigger="load"
+          hx-target="this"
           hx-swap="innerHTML"
         ></datalist>
       </label>

--- a/backend/tests/test_ui_memory_list.py
+++ b/backend/tests/test_ui_memory_list.py
@@ -522,6 +522,31 @@ def test_tags_endpoint_returns_distinct_sorted_tag_options() -> None:
     assert body.count("<option ") == 3
 
 
+def test_list_datalist_overrides_inherited_hx_target() -> None:
+    """The tag datalist pins ``hx-target="this"`` against form inheritance.
+
+    Regression for #1695: htmx resolves ``hx-target`` closest-wins up
+    the ancestor chain, so without a local override the datalist
+    inherits the filter form's ``hx-target="#memory-cards"`` and the
+    ``hx-trigger="load"`` options fetch replaces the card grid with
+    bare ``<option>`` elements on every page load.
+    """
+    _seed_tenant(_TENANT_A, "tenant-a")
+    _, jwks = _make_keypair_and_jwks()
+    session_id = _seed_session_sync(tenant_id=_TENANT_A, access_token="unused", operator_sub=_OP_A)
+    client, mock, _csrf = _authenticated_client(session_id=session_id, jwks=jwks)
+    try:
+        response = client.get("/ui/memory")
+    finally:
+        mock.stop()
+    assert response.status_code == 200
+    body = response.text
+    start = body.index("<datalist")
+    datalist_tag = body[start : body.index(">", start)]
+    assert 'id="memory-tag-options"' in datalist_tag
+    assert 'hx-target="this"' in datalist_tag
+
+
 # ---------------------------------------------------------------------------
 # Detail view -- 200 + Markdown render + 404 + cross-user
 # ---------------------------------------------------------------------------

--- a/docs/codebase/ui.md
+++ b/docs/codebase/ui.md
@@ -1402,6 +1402,12 @@ silent no-op that audits worse).
 ### HTMX conventions
 
 * `hx-get` for scope tabs + tag filter (idempotent reads).
+* The tag datalist (`#memory-tag-options`) pins `hx-target="this"`
+  on its `hx-trigger="load"` options fetch. htmx resolves
+  `hx-target` closest-wins up the ancestor chain, so without the
+  local override the datalist inherits the filter form's
+  `hx-target="#memory-cards"` and the `<option>` fragment replaces
+  the card grid on page load (#1695).
 * `hx-patch` for the edit-in-place save; the form's
   `id="memory-body"` is the swap target so Save replaces the form
   with the rendered body view in place.


### PR DESCRIPTION
## Summary
- The memory list's tag-autocomplete `<datalist>` issues a `hx-trigger="load"` GET to `/ui/memory/tags` but carried no own `hx-target`; htmx 2.0.9 resolves `hx-target` closest-wins up the ancestor chain (verified in the vendored `htmx.min.js`: `getTarget` → `getClosestAttributeValue` ancestor walk), so the fetch inherited the filter form's `hx-target="#memory-cards"` and swapped the `<option>` fragment into the card grid, wiping the memory list on every page load (RDC v0.14.0 cycle-10 finding FE-4).
- Fix pins `hx-target="this"` on the datalist — `getTarget`'s `"this"` branch resolves via `findThisElement` to the declaring element, so the options land in the datalist and the grid stays intact. Same local-override idiom as #1706's form-level `hx-headers`.
- Adds a rendered-page regression test pinning the datalist's self-target, a `docs/codebase/ui.md` HTMX-conventions bullet recording the why, and the CHANGELOG bullet.

## Test plan
- [x] `ruff check src/ tests/` — All checks passed
- [x] `ruff format --check src/ tests/` — 950 files already formatted
- [x] `mypy src/` — no issues in 468 source files
- [x] `pytest tests/test_ui_memory_list.py` — 27 passed (incl. new `test_list_datalist_overrides_inherited_hx_target`)
- [x] `.claude/hooks/code-quality.py --diff` — clean
- [x] AC: grep confirms the datalist in `memory/index.html` now carries `hx-target="this"` (line 130)
- [x] AC (cards intact / swap into `#memory-tag-options` / suggestions / filter): server-rendered contract pinned by the regression test; client swap-location behavior verified against the vendored htmx 2.0.9 source (`Ee`/`Se` = `getTarget`/`findThisElement`); existing `test_list_tag_filter_narrows_results` + `test_tags_endpoint_returns_distinct_sorted_tag_options` cover the filter round-trip. Live-browser confirmation lands with the next RDC dogfood cycle per Initiative #1691 DoD.

## Out of scope
- Tag-filter styling/UX (T1 #877 shipped the MVP), bulk tag management, tag-collection performance — per issue Out of scope.
- Sibling wave-3 tasks #1694 (BFF token refresh) and #1698 (footer version) touch different files.

<!-- auto-implement-issue: fresh, iteration 1 -->

Closes #1695
