### PR TITLE
fix(ui): surface deployed image version in the footer instead of package __version__ (#1698)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -164,6 +164,13 @@ connector-related release-notes line.
   inheritance); the datalist now pins `hx-target="this"` so the
   `<option>` fragment lands in the datalist and the cards stay intact
   (#1695)
+- Operator console: the sidebar footer (and the dashboard Deploy card)
+  showed `v0.1.0-dev` on every deployed instance because the
+  `app_version` Jinja global bound the static package `__version__`;
+  it now binds the deployed-build label read from the same
+  `CHART_VERSION` / `GIT_SHA` env metadata `GET /version` reports —
+  `v0.14.0`-style on chart deploys, a 12-char commit id on bare-image
+  runs, `unknown` on local runs without build metadata (#1698)
 
 ## [0.14.0] - 2026-06-12
 

--- a/backend/src/meho_backplane/ui/routes/dashboard.py
+++ b/backend/src/meho_backplane/ui/routes/dashboard.py
@@ -19,11 +19,15 @@ renders three components per the Initiative work-item #6:
   is the auth boundary that gates ``/ui/``). Trimming the rendered
   tray to the last N events is G10.1 (#338) client-side surface work;
   the underlying feed endpoint streams the live tail unbounded.
-* A version + readiness card sourced from
-  :data:`meho_backplane.__version__` (always rendered) and the chassis
-  readiness probe registry (``meho_backplane.health.run_probes_async``)
-  -- the same data ``/ready`` returns, surfaced as a single
-  ready/starting pill.
+* A version + readiness card sourced from the deployed-build label the
+  chassis Jinja env binds as the ``app_version`` global -- the same
+  ``CHART_VERSION`` / ``GIT_SHA`` env metadata ``GET /version`` reads
+  (#1698; the handler must NOT pass its own ``app_version`` context
+  key: render context shadows env globals, which is exactly how the
+  static package ``__version__`` used to leak into this page) -- and
+  the chassis readiness probe registry
+  (``meho_backplane.health.run_probes_async``) -- the same data
+  ``/ready`` returns, surfaced as a single ready/starting pill.
 
 The handler also sets the ``meho_csrf`` cookie on the response. Per
 the OWASP signed double-submit cookie pattern, the cookie is
@@ -59,7 +63,6 @@ from typing import Final
 from fastapi import APIRouter, Depends, Request
 from fastapi.responses import HTMLResponse
 
-from meho_backplane import __version__
 from meho_backplane.health import run_probes_async
 from meho_backplane.ui.auth.middleware import UISessionContext, require_ui_session
 from meho_backplane.ui.csrf import CSRF_COOKIE_NAME, mint_csrf_token
@@ -150,7 +153,6 @@ async def _render_dashboard(
     csrf_token = mint_csrf_token(str(session.session_id))
     context = {
         "page_title": "Dashboard",
-        "app_version": __version__,
         "ready": readiness["ready"],
         "readiness_checks": readiness["checks"],
         "surface_tiles": _SURFACE_TILES,

--- a/backend/src/meho_backplane/ui/templates/base.html
+++ b/backend/src/meho_backplane/ui/templates/base.html
@@ -250,16 +250,21 @@
                 </button>
               </div>
 
-              {# Status line #}
+              {# Status line. ``app_version`` is the deployed-build
+                 label (chart version, short git sha, or "unknown") the
+                 chassis env binds from the same CHART_VERSION/GIT_SHA
+                 env vars GET /version reads -- it carries its own
+                 ``v`` prefix when it is a release version, so none is
+                 hardcoded here (#1698). #}
               <div
                 class="flex items-center gap-2 px-0.5 font-mono text-[0.68rem] text-base-content/50"
-                title="MEHO backplane v{{ app_version }}"
+                title="MEHO backplane {{ app_version }}"
               >
                 <span
                   class="inline-block h-1.5 w-1.5 rounded-full {% if ready %}bg-success{% else %}bg-warning{% endif %}"
                   aria-hidden="true"
                 ></span>
-                <span>v{{ app_version }}</span>
+                <span>{{ app_version }}</span>
                 <span aria-hidden="true">&middot;</span>
                 <span>{% if ready %}ready{% else %}starting{% endif %}</span>
               </div>

--- a/backend/src/meho_backplane/ui/templates/dashboard.html
+++ b/backend/src/meho_backplane/ui/templates/dashboard.html
@@ -111,8 +111,8 @@
           <h2 class="text-base font-semibold">Deploy</h2>
           <dl class="mt-2 space-y-1 text-sm text-base-content/65">
             <div class="flex items-center justify-between gap-4">
-              <dt>Backplane version</dt>
-              <dd><code class="font-mono text-xs text-base-content/80">v{{ app_version }}</code></dd>
+              <dt>Deployed version</dt>
+              <dd><code class="font-mono text-xs text-base-content/80">{{ app_version }}</code></dd>
             </div>
           </dl>
         </div>

--- a/backend/src/meho_backplane/ui/templating.py
+++ b/backend/src/meho_backplane/ui/templating.py
@@ -30,10 +30,18 @@ Configuration decisions:
   500 into a structlog event the operator sees in CI / kubectl logs.
 
 The environment exposes one extra global, ``app_version``, bound from
-:data:`meho_backplane.__version__` so every template can show the
-backplane version in the footer without each route having to pass it
-explicitly. Tenant / operator-identity globals will be wired by T4
-(#865) once the session middleware lands.
+:func:`meho_backplane.version.deployed_version_label` so every template
+can show the *deployed* build identity in the footer without each route
+having to pass it explicitly. The label reads the same ``CHART_VERSION``
+/ ``GIT_SHA`` environment variables ``GET /version`` reports (#1698 —
+the global used to bind the static package ``__version__``, which is
+pinned to ``0.1.0-dev`` by design and never tracks the deployed image).
+Binding once at environment construction is equivalent to reading
+per-request: the env vars are injected at image build / Pod start and
+cannot change for the life of the process. Tests that monkeypatch them
+rebuild the singleton via :func:`reset_templating_for_testing`. Tenant /
+operator-identity globals will be wired by T4 (#865) once the session
+middleware lands.
 
 This module deliberately does **not** wire FastAPI dependencies or
 ``Request`` objects. T5 (#866) builds the ``TemplateResponse`` helper
@@ -50,8 +58,8 @@ from fastapi.templating import Jinja2Templates
 from jinja2 import Environment, FileSystemLoader, StrictUndefined, select_autoescape
 from starlette.requests import Request
 
-from meho_backplane import __version__
 from meho_backplane.ui.paths import templates_dir
+from meho_backplane.version import deployed_version_label
 
 # Cached environment singleton. Module-level cache rather than
 # functools.lru_cache so the type checker sees the concrete return
@@ -97,7 +105,7 @@ def get_jinja_env() -> Environment:
             # cleanly.
             keep_trailing_newline=True,
         )
-        _ENV.globals["app_version"] = __version__
+        _ENV.globals["app_version"] = deployed_version_label()
     return _ENV
 
 

--- a/backend/src/meho_backplane/version.py
+++ b/backend/src/meho_backplane/version.py
@@ -28,11 +28,48 @@ import os
 
 from fastapi import APIRouter
 
-__all__ = ["router"]
+__all__ = ["deployed_version_label", "router"]
 
 _UNKNOWN: str = "unknown"
 
+#: Display length for a bare commit hash in the UI label. Twelve hex
+#: chars matches the container-ecosystem short-id convention (docker /
+#: kubelet imageID truncation) and stays collision-safe at this repo's
+#: scale; the full 40-char value remains available via ``GET /version``.
+_SHA_LABEL_LEN: int = 12
+
 router = APIRouter(tags=["version"])
+
+
+def deployed_version_label() -> str:
+    """Return the operator-facing label for the running build.
+
+    Single source of truth with :func:`version` below: both read the
+    same ``CHART_VERSION`` / ``GIT_SHA`` environment variables, so the
+    UI footer and ``GET /version`` can never disagree about which
+    image is live (#1698 — the footer used to render the static
+    package ``__version__``, which is pinned to ``0.1.0-dev`` by
+    design and never tracks the deployed release).
+
+    Precedence mirrors how meaningful each value is to an operator:
+
+    * ``CHART_VERSION`` — the helm release identity (``0.14.0`` on a
+      tag deploy, ``0.1.<date>-<sha>`` calver on main deploys),
+      rendered with a ``v`` prefix when not already carrying one.
+    * ``GIT_SHA`` — bare-image runs (``docker run`` without the
+      chart): the first 12 hash chars. The Dockerfile defaults the
+      build arg to the literal ``unknown``, which intentionally falls
+      through to the fallback below.
+    * ``"unknown"`` — local ``uvicorn`` runs with no build metadata;
+      the same never-pretend posture ``GET /version`` takes.
+    """
+    chart_version = os.environ.get("CHART_VERSION")
+    if chart_version:
+        return chart_version if chart_version.startswith("v") else f"v{chart_version}"
+    git_sha = os.environ.get("GIT_SHA")
+    if git_sha and git_sha != _UNKNOWN:
+        return git_sha[:_SHA_LABEL_LEN]
+    return _UNKNOWN
 
 
 @router.get("/version")

--- a/backend/tests/test_health.py
+++ b/backend/tests/test_health.py
@@ -15,6 +15,11 @@ Coverage matrix (per Task #19 acceptance criteria):
   200 once a passing probe is registered, and 503 again with one
   failing probe registered alongside a passing one (so the failure
   detail is visible in the payload).
+* :func:`~meho_backplane.version.deployed_version_label` (#1698 — the
+  UI footer's source string) prefers ``CHART_VERSION`` (``v``-prefixed)
+  over a 12-char ``GIT_SHA`` truncation over the literal ``"unknown"``,
+  reading the same env vars as ``/version`` so the two surfaces cannot
+  disagree.
 """
 
 from collections.abc import Iterator
@@ -30,6 +35,7 @@ from meho_backplane.health import (
 )
 from meho_backplane.main import app
 from meho_backplane.settings import get_settings
+from meho_backplane.version import deployed_version_label
 
 
 @pytest.fixture(autouse=True)
@@ -182,6 +188,67 @@ def test_version_chart_version_unset_is_null(
 
     assert response.status_code == 200
     assert response.json()["chart_version"] is None
+
+
+# ---------------------------------------------------------------------------
+# deployed_version_label (#1698 — the UI footer's build-identity string)
+# ---------------------------------------------------------------------------
+
+
+def test_label_prefers_chart_version_with_v_prefix(monkeypatch: pytest.MonkeyPatch) -> None:
+    """A chart deploy shows the release identity, ``v``-prefixed.
+
+    ``chart.yml`` stamps plain semver on tag pushes (Helm rejects a
+    leading ``v`` in ``Chart.yaml``), so the label adds the prefix for
+    the operator-facing rendering: ``CHART_VERSION=0.14.0`` →
+    ``v0.14.0``. ``GIT_SHA`` being set too must not matter.
+    """
+    monkeypatch.setenv("CHART_VERSION", "0.14.0")
+    monkeypatch.setenv("GIT_SHA", "deadbeefcafe0123456789aa")
+
+    assert deployed_version_label() == "v0.14.0"
+
+
+def test_label_does_not_double_v_prefix(monkeypatch: pytest.MonkeyPatch) -> None:
+    """A ``CHART_VERSION`` already carrying ``v`` is passed through."""
+    monkeypatch.setenv("CHART_VERSION", "v0.15.0-rc1")
+
+    assert deployed_version_label() == "v0.15.0-rc1"
+
+
+def test_label_falls_back_to_short_git_sha(monkeypatch: pytest.MonkeyPatch) -> None:
+    """Bare-image runs (no chart) show the first 12 hash chars, unprefixed."""
+    monkeypatch.delenv("CHART_VERSION", raising=False)
+    monkeypatch.setenv("GIT_SHA", "2bbea9ad00112233445566778899aabbccddeeff")
+
+    assert deployed_version_label() == "2bbea9ad0011"
+
+
+def test_label_unknown_when_no_build_metadata(monkeypatch: pytest.MonkeyPatch) -> None:
+    """Local ``uvicorn`` runs degrade to ``unknown`` — never ``0.1.0-dev``."""
+    monkeypatch.delenv("CHART_VERSION", raising=False)
+    monkeypatch.delenv("GIT_SHA", raising=False)
+
+    assert deployed_version_label() == "unknown"
+
+
+def test_label_treats_dockerfile_default_sha_as_unknown(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """``ARG GIT_SHA=unknown`` (Dockerfile default) is not a real hash.
+
+    A locally-built image without ``--build-arg GIT_SHA=...`` carries
+    the literal ``unknown`` in the env; the label must not render it as
+    if it were a 7-char commit id. Empty strings degrade the same way
+    (mirrors ``/version``'s ``or "unknown"`` coercion).
+    """
+    monkeypatch.delenv("CHART_VERSION", raising=False)
+    monkeypatch.setenv("GIT_SHA", "unknown")
+    assert deployed_version_label() == "unknown"
+
+    monkeypatch.setenv("GIT_SHA", "")
+    monkeypatch.setenv("CHART_VERSION", "")
+    assert deployed_version_label() == "unknown"
 
 
 # ---------------------------------------------------------------------------

--- a/backend/tests/test_ui_chassis_smoke.py
+++ b/backend/tests/test_ui_chassis_smoke.py
@@ -50,6 +50,7 @@ from fastapi import Depends, FastAPI
 from fastapi.staticfiles import StaticFiles
 from fastapi.testclient import TestClient
 
+from meho_backplane import __version__
 from meho_backplane.auth.jwt import clear_jwks_cache
 from meho_backplane.auth.operator import Operator
 from meho_backplane.db.engine import get_sessionmaker, reset_engine_for_testing
@@ -392,8 +393,14 @@ def test_dashboard_authenticated_renders_console_html() -> None:
     # to-last-N is G10.1 (#338) client-side surface work.
     assert 'sse-connect="/api/v1/feed"' in body
     assert 'sse-swap="broadcast"' in body
-    # Version footer renders the chassis version global.
-    assert "MEHO backplane v" in body
+    # Version footer renders the deployed-build label the chassis env
+    # binds from CHART_VERSION / GIT_SHA (#1698). No hardcoded ``v``
+    # prefix anymore -- the label carries its own when it is a release
+    # version -- and the static package ``__version__`` (0.1.0-dev by
+    # design) must never leak into a rendered page, whatever the
+    # ambient env vars say.
+    assert "MEHO backplane " in body
+    assert __version__ not in body
     # CSRF cookie set on the response so subsequent state-changing
     # requests can echo it back.
     assert CSRF_COOKIE_NAME in response.cookies

--- a/backend/tests/test_ui_templates.py
+++ b/backend/tests/test_ui_templates.py
@@ -13,8 +13,11 @@ shape:
 * Sidebar links to every one of the five G10.x surfaces.
 * Alpine.js ``x-data`` wiring for the sidebar collapse + user menu.
 * A ``{% block content %}`` slot the surface templates can override.
-* A footer rendering the backplane version (``app_version`` global)
-  and the readiness pill.
+* A footer rendering the deployed-build label (``app_version`` global,
+  bound from the same ``CHART_VERSION`` / ``GIT_SHA`` env metadata
+  ``GET /version`` reads — #1698) and the readiness pill. The static
+  package ``__version__`` (``0.1.0-dev`` by design) must never leak
+  into the rendered HTML.
 * :class:`jinja2.StrictUndefined` propagates so a typo in a template
   variable fails the render rather than producing an empty string.
 """
@@ -29,7 +32,7 @@ from jinja2 import Environment, UndefinedError
 
 from meho_backplane import __version__
 from meho_backplane.ui.paths import static_src_dir, templates_dir
-from meho_backplane.ui.templating import get_jinja_env
+from meho_backplane.ui.templating import get_jinja_env, reset_templating_for_testing
 
 # The five surface routes the chassis sidebar links to. Sourced from
 # Initiative #337 work-item 5 + Goal #336 done-when (broadcast / kb /
@@ -101,16 +104,56 @@ def test_static_src_carries_vendored_assets() -> None:
     assert (vendor / "VENDOR.md").is_file()
 
 
-def test_base_template_renders_with_app_version_global(ui_env: Environment) -> None:
-    """``base.html`` resolves the ``app_version`` global from the env.
+@pytest.fixture(name="fresh_templating_singleton")
+def fixture_fresh_templating_singleton() -> Iterator[None]:
+    """Rebuild the templating singleton around a test that patches env vars.
 
-    The environment factory binds ``__version__`` as a Jinja global so
-    every surface template can show the backplane version in the
-    footer without each route having to pass it explicitly.
+    The ``app_version`` global is read from ``CHART_VERSION`` /
+    ``GIT_SHA`` once, at environment construction (the values are
+    process-immutable in deployment, so once-per-process is the correct
+    cadence). Tests that monkeypatch those vars must drop the cached
+    env before *and* after, so they see their own values and don't
+    leak a patched label into later modules on the same xdist worker.
     """
-    template = ui_env.get_template("base.html")
-    html = template.render(ready=True)
-    assert __version__ in html
+    reset_templating_for_testing()
+    yield
+    reset_templating_for_testing()
+
+
+def test_base_template_renders_chart_version_label(
+    fresh_templating_singleton: None, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    """``base.html`` shows the deployed release, not the package version.
+
+    #1698 — the footer used to render ``meho_backplane.__version__``
+    (``0.1.0-dev`` by design, never tracking the deployed image). The
+    ``app_version`` global now binds the deployed-build label from the
+    same ``CHART_VERSION`` / ``GIT_SHA`` env vars ``GET /version``
+    reads. On a chart deploy the label is the ``v``-prefixed release,
+    so the template no longer hardcodes a ``v`` of its own.
+    """
+    monkeypatch.setenv("CHART_VERSION", "0.14.0")
+    monkeypatch.setenv("GIT_SHA", "2bbea9ad00112233445566778899aabbccddeeff")
+    html = get_jinja_env().get_template("base.html").render(ready=True)
+    assert "v0.14.0" in html
+    assert "vv0.14.0" not in html
+    assert __version__ not in html
+
+
+def test_base_template_version_label_degrades_to_unknown(
+    fresh_templating_singleton: None, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    """No build metadata (local dev) → ``unknown``, still never ``0.1.0-dev``.
+
+    The global resolves without any route passing ``app_version``
+    explicitly, so a bare-env render (this test) and every surface
+    route get the same label for free.
+    """
+    monkeypatch.delenv("CHART_VERSION", raising=False)
+    monkeypatch.delenv("GIT_SHA", raising=False)
+    html = get_jinja_env().get_template("base.html").render(ready=True)
+    assert "unknown" in html
+    assert __version__ not in html
 
 
 def test_base_template_renders_navbar_and_drawer(ui_env: Environment) -> None:

--- a/docs/codebase/ui.md
+++ b/docs/codebase/ui.md
@@ -43,7 +43,7 @@ Locked decisions:
 | Module | Purpose |
 | ------ | ------- |
 | `meho_backplane.ui.paths` | Resolves `templates/`, `static/src/`, `static/dist/` directories at runtime. Source-tree dev and image deploy both work via `Path(__file__).resolve().parent`. |
-| `meho_backplane.ui.templating` | Jinja2 `Environment` factory with `FileSystemLoader`, `select_autoescape`, `StrictUndefined`, and the `app_version` global pre-bound from `meho_backplane.__version__`. `get_templates()` registers `_ui_session_context_processor` so every render sees a `session_tenant` dict ({id, slug, name}, or None on unauthenticated auth surfaces) -- G0.15-T9 #1217. |
+| `meho_backplane.ui.templating` | Jinja2 `Environment` factory with `FileSystemLoader`, `select_autoescape`, `StrictUndefined`, and the `app_version` global pre-bound from `meho_backplane.version.deployed_version_label()` -- the deployed-build label (`v<CHART_VERSION>`, else 12-char `GIT_SHA` truncation, else `unknown`) read from the same env vars `GET /version` reports, bound once at env construction because the values are process-immutable (#1698; the global used to bind the static package `__version__`, so every deploy's footer said `0.1.0-dev`). Routes must not pass their own `app_version` context key -- render context shadows env globals. `get_templates()` registers `_ui_session_context_processor` so every render sees a `session_tenant` dict ({id, slug, name}, or None on unauthenticated auth surfaces) -- G0.15-T9 #1217. |
 | `meho_backplane.ui.routes` | Aggregate `APIRouter`. `build_router()` aggregates the dashboard (`GET /ui/`), the real broadcast routes (`GET /ui/broadcast` + `/ui/broadcast/stream`, G10.1-T1 #867), the real topology routes (`GET /ui/topology` + node detail, G10.5-T1 #880), the real KB routes (`GET /ui/kb` + search + detail + preview, G10.2-T1 #870), and the remaining surface stubs (`GET /ui/{connectors,memory}`, `_stub.html` placeholders). Real routers are included **before** the stubs so their concrete paths win the first-match-wins lookup. G10.3-G10.4 replace the remaining stubs the same way. |
 | `meho_backplane.ui.csrf` | T5 (#866) double-submit-cookie CSRF middleware on state-changing `/ui/*` requests (POST/PATCH/PUT/DELETE). Signed-double-submit per OWASP -- the token is `hmac_sha256(session_secret, session_id || random) + "." + random`; the cookie is JS-readable (`meho_csrf`) so HTMX can echo it in `X-CSRF-Token`. Mismatch / missing token / forged signature -> 403. Read-only methods + out-of-prefix paths pass through. |
 | `meho_backplane.ui.auth` | BFF auth subpackage. T3 (#864) landed `session_store` (encrypted token custody + RFC 9700 refresh-token rotation); T4 (#865) lands `/ui/auth/{login,callback,logout}` + session middleware. |
@@ -273,7 +273,7 @@ backplane Python base image already follows).
       <div class="drawer-content">
         <header class="navbar">…tenant select…user menu…</header>
         <main>{% block content %}{% endblock %}</main>
-        <footer>v{{ app_version }} · ready/starting pill</footer>
+        <footer>{{ app_version }} · ready/starting pill</footer>  <!-- deployed-build label, self-prefixed (#1698) -->
       </div>
       <aside class="drawer-side">
         <nav>…sidebar with 5 surface links…</nav>


### PR DESCRIPTION
## Summary

- The operator-console footer (and the dashboard Deploy card) rendered `v0.1.0-dev` on every deployed instance because the `app_version` Jinja global bound the static package `__version__` — pinned to `0.1.0-dev` by design (the real version ships as a git tag + image label, see #1703's deferral notes in `docs/codebase/mcp.md`).
- New `meho_backplane.version.deployed_version_label()` is the single source of truth shared with `GET /version`: it reads the same `CHART_VERSION` / `GIT_SHA` env vars and renders `v0.14.0`-style on chart deploys, a 12-char commit id on bare-image runs, and `unknown` on local runs without build metadata. The `/version` endpoint itself is untouched (per the task's out-of-scope).
- The chassis env binds the label once at environment construction (env vars are process-immutable; tests rebuild via `reset_templating_for_testing()`), and the dashboard route's explicit `app_version: __version__` context entry is removed — render context shadows env globals (verified against installed jinja2 3.1.6), so leaving it would have kept `0.1.0-dev` on `GET /ui/` specifically.
- Templates drop their hardcoded `v` prefix; the label carries its own when it is a release version, so a bare short-sha never renders as `v2bbea9ad…`.

## Test plan

- [x] `uv run ruff check src/ tests/` — clean
- [x] `uv run ruff format --check src/ tests/` — 950 files already formatted
- [x] `uv run mypy src/` — no issues in 468 source files
- [x] `uv run pytest tests/test_health.py tests/test_ui_templates.py tests/test_ui_chassis_smoke.py` — 44 passed, 1 skipped (pre-existing skip)
- [x] Full unit sweep `pytest -n 6 --dist loadscope --maxfail=1 --ignore=tests/integration` — green (see PR checks)
- [x] AC: footer renders env-derived build metadata instead of `__version__` — `test_base_template_renders_chart_version_label` (CHART_VERSION=0.14.0 → `v0.14.0` in HTML, `0.1.0-dev` absent)
- [x] AC: rendered HTML on a deployed image shows a deployed version string — local proxy: route-level `test_dashboard_authenticated_renders_console_html` now asserts `__version__ not in body` on a real `GET /ui/` response; live k8s re-verification lands with the next RDC dogfood cycle per Initiative #1691 DoD
- [x] AC: graceful local-dev fallback — `test_base_template_version_label_degrades_to_unknown` + `test_label_unknown_when_no_build_metadata` (label `unknown`, mirroring `/version`'s never-pretend posture)
- [x] AC: footer and `/version` share a single source of truth — both read `CHART_VERSION` / `GIT_SHA`; `deployed_version_label()` lives in `version.py` next to the endpoint; 5 new unit tests pin the precedence chain (chart > sha[:12] > unknown, Dockerfile `GIT_SHA=unknown` default treated as absent)

## Out of scope

- `__version__` / pyproject stay `0.1.0-dev` (intentional design per the task; `docs/codebase/mcp.md`'s #1698-keyed wording — "`__version__` is build-metadata-dependent" / no runtime version gate — remains factually true).
- `GET /version` endpoint behavior unchanged; no OpenAPI surface touched, so the CLI snapshot stays zero-diff.
- OpenAPI `info.version` and the `GET /` root payload also bind `__version__` (`main.py:521` / `main.py:996`) — same root, REST surface, deliberately untouched here (adjacent finding).

<!-- auto-implement-issue: fresh, iteration 1 -->

Closes #1698


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Fixed UI version display in sidebar footer and Deploy card to accurately reflect deployed build metadata instead of showing the same development version on all instances. Version now displays correctly based on deployment information, with a fallback to "unknown" for local development runs.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->