### PR TITLE
feat(audit): work_ref I1-T1 — audit_log.work_ref column + work_ref_var ContextVar (#1655)

### DIFF
--- a/backend/alembic/versions/0038_add_audit_log_work_ref.py
+++ b/backend/alembic/versions/0038_add_audit_log_work_ref.py
@@ -1,0 +1,83 @@
+# SPDX-License-Identifier: Apache-2.0
+# Copyright (c) 2026 evoila Group
+
+"""Add ``audit_log.work_ref`` for external change-ticket correlation.
+
+Revision ID: 0038
+Revises: 0037
+Create Date: 2026-06-12
+
+Schema keystone of Task #1655 (work_ref I1-T1) under Initiative #1652,
+Goal #1651. No governed MEHO object can currently be correlated to an
+external change ticket. This migration adds the column that lets the
+audit trail carry an opaque reference to the out-of-band change record
+that authorised an operation -- a GitHub issue (``"gh:evoila/meho#1"``),
+a Jira key, a CR id -- threaded by the same ContextVar mechanism that
+already carries ``run_id`` / ``agent_session_id`` / ``parent_audit_id``.
+
+What this migration adds
+------------------------
+
+* ``audit_log.work_ref text`` -- nullable. The external change-ticket
+  reference for the operation that produced the row. Populated only when
+  a ``work_ref`` is bound on the request / agent-loop ContextVar
+  (:data:`meho_backplane.operations._audit.work_ref_var`), read by the
+  three primary audit writers (chassis HTTP, dispatcher DISPATCH, MCP).
+  The bind *source* is a separate task (I1-T2), so on this task's own
+  the column stays ``NULL`` except where a caller binds the var
+  directly. ``NULL`` is also the correct value for the system-internal
+  writers (memory / topology / reaper / ui-session) that legitimately
+  act without an external ticket. No backfill -- pre-#1655 rows stay
+  ``NULL``.
+* ``audit_log_work_ref_idx`` -- b-tree index on the new column, for the
+  "what did change ticket X authorise?" audit query the I1-T3 filter
+  surfaces.
+
+Why no foreign key / NOT NULL
+-----------------------------
+
+Same soft-column discipline as ``actor_sub`` (0021), ``parent_audit_id``
+(0006), ``agent_session_id`` (0014), ``tenant_id`` (0002), and
+``target_id`` (0004): nullable, no server default (the ORM ``default``
+of ``None`` works on both PG and SQLite), no FK clause -- so the
+migration is trivially reversible on a populated table. ``work_ref`` is
+an opaque cross-system reference string (``"gh:evoila/meho#1"``), not a
+row id in this schema, so there is no table to point a FK at.
+
+Reversibility contract
+----------------------
+
+``downgrade()`` reverses ``upgrade()`` in order: drop the index, then
+the column. Pure generic SQLAlchemy DDL, portable across PG and SQLite.
+"""
+
+from collections.abc import Sequence
+
+import sqlalchemy as sa
+from alembic import op
+
+# revision identifiers, used by Alembic.
+revision: str = "0038"
+down_revision: str | None = "0037"
+branch_labels: str | Sequence[str] | None = None
+depends_on: str | Sequence[str] | None = None
+
+
+def upgrade() -> None:
+    """Add ``audit_log.work_ref`` column + named index."""
+    op.add_column(
+        "audit_log",
+        sa.Column("work_ref", sa.Text(), nullable=True),
+    )
+    op.create_index(
+        "audit_log_work_ref_idx",
+        "audit_log",
+        ["work_ref"],
+        postgresql_using="btree",
+    )
+
+
+def downgrade() -> None:
+    """Reverse the upgrade -- drop the index and column."""
+    op.drop_index("audit_log_work_ref_idx", table_name="audit_log")
+    op.drop_column("audit_log", "work_ref")

--- a/backend/src/meho_backplane/audit.py
+++ b/backend/src/meho_backplane/audit.py
@@ -119,6 +119,7 @@ from meho_backplane.broadcast import (
 )
 from meho_backplane.db.engine import get_sessionmaker
 from meho_backplane.db.models import AuditLog
+from meho_backplane.operations._audit import work_ref_var
 
 __all__ = ["AuditMiddleware", "bind_preallocated_audit_id"]
 
@@ -370,6 +371,15 @@ async def _write_audit_row(
     after the audit commit succeeds.
     """
     sessionmaker = get_sessionmaker()
+    # work_ref I1-T1 #1655 -- read the external change-ticket reference
+    # off the contextvar. The ``work_ref`` column is added by migration
+    # ``0038``; guard on the attribute so the writer stays
+    # forward-compatible if the model predates the migration (the same
+    # discipline the dispatcher writer uses for the runbook columns).
+    # ``None`` until the bind source (I1-T2) lands.
+    soft_fk_kwargs: dict[str, Any] = {}
+    if hasattr(AuditLog, "work_ref"):
+        soft_fk_kwargs["work_ref"] = work_ref_var.get()
     async with sessionmaker() as session:
         row = AuditLog(
             id=audit_id,
@@ -384,6 +394,7 @@ async def _write_audit_row(
             request_id=request_id,
             duration_ms=Decimal(str(duration_ms)),
             payload=payload,
+            **soft_fk_kwargs,
         )
         session.add(row)
         await session.commit()

--- a/backend/src/meho_backplane/db/models.py
+++ b/backend/src/meho_backplane/db/models.py
@@ -502,6 +502,23 @@ class AuditLog(Base):
         nullable=True,
         default=None,
     )
+    # External change-ticket reference (work_ref I1-T1 #1655). Correlates
+    # a governed MEHO operation to the out-of-band change record that
+    # authorised it (a GitHub issue, a Jira ticket, a CR id) -- an opaque
+    # string such as ``"gh:evoila/meho#1"`` carried on the same ContextVar
+    # mechanism as ``run_id`` / ``agent_session_id`` / ``parent_audit_id``
+    # (:data:`meho_backplane.operations._audit.work_ref_var`). NULL when no
+    # work_ref is bound: the bind source is a separate task (I1-T2), so
+    # today only a direct contextvar bind populates it, and the
+    # system-internal writers (memory/topology/reaper/ui-session) leave it
+    # NULL by design. No FK -- same soft-reference discipline as
+    # ``tenant_id`` / ``target_id`` / ``parent_audit_id``. Added by
+    # migration ``0038``.
+    work_ref: Mapped[str | None] = mapped_column(
+        Text,
+        nullable=True,
+        default=None,
+    )
 
     __table_args__ = (
         Index(
@@ -542,6 +559,11 @@ class AuditLog(Base):
         Index(
             "audit_log_run_id_idx",
             "run_id",
+            postgresql_using="btree",
+        ),
+        Index(
+            "audit_log_work_ref_idx",
+            "work_ref",
             postgresql_using="btree",
         ),
     )

--- a/backend/src/meho_backplane/mcp/audit.py
+++ b/backend/src/meho_backplane/mcp/audit.py
@@ -64,6 +64,7 @@ from meho_backplane.auth.delegation import resolve_actor_sub
 from meho_backplane.auth.operator import Operator
 from meho_backplane.db.engine import get_sessionmaker
 from meho_backplane.db.models import AuditLog
+from meho_backplane.operations._audit import work_ref_var
 
 __all__ = ["compute_params_hash", "write_mcp_audit_row"]
 
@@ -266,6 +267,16 @@ async def write_mcp_audit_row(
     agent_session_id = _resolve_uuid_contextvar("mcp_session_id")
     parent_audit_id = _resolve_uuid_contextvar("parent_audit_id")
     target_id = _resolve_uuid_contextvar("target_id")
+    # work_ref I1-T1 #1655 -- external change-ticket reference. Read from
+    # the shared :data:`work_ref_var` ContextVar (not the structlog
+    # ``audit_*`` payload-merge convention the graph columns above use),
+    # so all three primary writers source it from one place. The
+    # ``work_ref`` column is added by migration ``0038``; guard on the
+    # attribute for forward-compat. ``None`` until the bind source
+    # (I1-T2) lands.
+    soft_fk_kwargs: dict[str, Any] = {}
+    if hasattr(AuditLog, "work_ref"):
+        soft_fk_kwargs["work_ref"] = work_ref_var.get()
 
     log = structlog.get_logger(__name__)
     if audit_id is None:
@@ -294,6 +305,7 @@ async def write_mcp_audit_row(
             # conversion artifacts ``Decimal(float)`` would introduce.
             duration_ms=Decimal(str(duration_ms)),
             payload=payload,
+            **soft_fk_kwargs,
         )
         session.add(row)
         await session.commit()

--- a/backend/src/meho_backplane/operations/_audit.py
+++ b/backend/src/meho_backplane/operations/_audit.py
@@ -54,6 +54,7 @@ __all__ = [
     "publish_broadcast",
     "run_id_var",
     "step_id_var",
+    "work_ref_var",
     "write_audit_row",
 ]
 
@@ -134,6 +135,32 @@ run_id_var: ContextVar[uuid.UUID | None] = ContextVar(
 #: runbook step execution.
 step_id_var: ContextVar[str | None] = ContextVar(
     "step_id",
+    default=None,
+)
+
+
+#: ContextVar carrying the external change-ticket reference for the
+#: operation in flight (work_ref I1-T1 #1655). An opaque string -- a
+#: GitHub issue (``"gh:evoila/meho#1"``), a Jira key, a CR id -- that
+#: correlates the governed MEHO operation to the out-of-band change
+#: record that authorised it. Read by the three primary audit writers
+#: (the chassis HTTP middleware's
+#: :func:`meho_backplane.audit._write_audit_row`, this module's
+#: :func:`write_audit_row` dispatcher path, and the MCP
+#: :func:`meho_backplane.mcp.audit.write_mcp_audit_row`) into the real
+#: ``audit_log.work_ref`` column added by migration ``0038``.
+#:
+#: Same source-of-truth-contextvar mechanism as
+#: :data:`parent_audit_id_var` / :data:`agent_session_id_var` /
+#: :data:`run_id_var`: one var bound at a boundary, read at every
+#: audit-write call site that lives inside the same async task
+#: (``asyncio.create_task`` snapshots the contextvars, so spawned
+#: helpers inherit the binding for their whole life). ``None`` is the
+#: correct default -- where the work_ref is bound FROM (the request
+#: transport / agent loop) is a separate task (I1-T2); until then the
+#: column stays NULL except where a caller binds the var directly.
+work_ref_var: ContextVar[str | None] = ContextVar(
+    "work_ref",
     default=None,
 )
 
@@ -401,6 +428,13 @@ async def write_audit_row(
         runbook_kwargs["run_id"] = run_id
     if hasattr(AuditLog, "step_id"):
         runbook_kwargs["step_id"] = step_id
+    # work_ref I1-T1 #1655 -- read the external change-ticket reference
+    # off the contextvar. Same hasattr forward-compat guard as the
+    # runbook columns: the ``work_ref`` column is added by migration
+    # ``0038`` and the bind source is a separate task (I1-T2), so this
+    # is ``None`` until a caller binds the var.
+    if hasattr(AuditLog, "work_ref"):
+        runbook_kwargs["work_ref"] = work_ref_var.get()
     async with sessionmaker() as session:
         row = AuditLog(
             id=audit_id,

--- a/backend/tests/test_audit_work_ref.py
+++ b/backend/tests/test_audit_work_ref.py
@@ -1,0 +1,306 @@
+# SPDX-License-Identifier: Apache-2.0
+# Copyright (c) 2026 evoila Group
+
+"""Audit ``work_ref`` persistence tests (work_ref I1-T1 #1655).
+
+Proves the three primary audit writers stamp ``audit_log.work_ref`` from
+the shared :data:`meho_backplane.operations._audit.work_ref_var`
+ContextVar: present when a ``work_ref`` is bound in scope, ``NULL``
+otherwise. The bind *source* (request transport / agent loop) is a
+separate task (I1-T2), so these tests bind the var directly -- the same
+shape the eventual binder will use.
+
+The three primary writers (mirroring the ``actor_sub`` #816 coverage):
+
+* chassis HTTP -- :func:`meho_backplane.audit._write_audit_row`
+* dispatcher DISPATCH -- ``meho_backplane.operations.dispatch`` →
+  :func:`meho_backplane.operations._audit.write_audit_row`
+* MCP -- :func:`meho_backplane.mcp.audit.write_mcp_audit_row`
+
+The ~8 system-internal writers (memory / topology / reaper / ui-session)
+legitimately leave the column ``NULL`` and are explicitly out of scope.
+"""
+
+from __future__ import annotations
+
+import uuid
+from collections.abc import AsyncIterator, Iterator
+from typing import Any
+from unittest.mock import AsyncMock
+
+import pytest
+from sqlalchemy import select
+from sqlalchemy.ext.asyncio import AsyncSession
+
+from meho_backplane.audit import _write_audit_row
+from meho_backplane.auth.operator import Operator, TenantRole
+from meho_backplane.connectors.base import Connector
+from meho_backplane.connectors.registry import clear_registry, register_connector_v2
+from meho_backplane.connectors.schemas import FingerprintResult, OperationResult, ProbeResult
+from meho_backplane.db.engine import get_sessionmaker
+from meho_backplane.db.models import AuditLog
+from meho_backplane.mcp.audit import write_mcp_audit_row
+from meho_backplane.operations import (
+    dispatch,
+    register_typed_operation,
+    reset_dispatcher_caches,
+)
+from meho_backplane.operations._audit import work_ref_var
+from meho_backplane.retrieval.embedding import EMBEDDING_DIMENSION
+from meho_backplane.settings import get_settings
+
+_TENANT_A = uuid.UUID("11111111-1111-1111-1111-111111111111")
+_WORK_REF = "gh:evoila/meho#1"
+
+
+@pytest.fixture(autouse=True)
+def _required_settings_env(monkeypatch: pytest.MonkeyPatch) -> Iterator[None]:
+    """Pin the env vars :class:`Settings` requires (conftest provides the DB)."""
+    monkeypatch.setenv("KEYCLOAK_ISSUER_URL", "https://keycloak.test/realms/meho")
+    monkeypatch.setenv("KEYCLOAK_AUDIENCE", "meho-backplane")
+    monkeypatch.setenv("VAULT_ADDR", "https://vault.test")
+    get_settings.cache_clear()
+    yield
+    get_settings.cache_clear()
+
+
+@pytest.fixture(autouse=True)
+def _reset_state() -> Iterator[None]:
+    """Clear connector + dispatcher caches around each test."""
+    clear_registry()
+    reset_dispatcher_caches()
+    yield
+    clear_registry()
+    reset_dispatcher_caches()
+
+
+@pytest.fixture
+async def db_session() -> AsyncIterator[AsyncSession]:
+    """One :class:`AsyncSession` per test for direct row inspection."""
+    sessionmaker = get_sessionmaker()
+    async with sessionmaker() as s:
+        yield s
+
+
+@pytest.fixture
+def stub_embedding_service() -> AsyncMock:
+    """Embedding stub for the typed-op descriptor's embedding column."""
+    service = AsyncMock()
+    service.encode_one.return_value = [0.0] * EMBEDDING_DIMENSION
+    service.encode.return_value = [[0.0] * EMBEDDING_DIMENSION]
+    service.dimension = EMBEDDING_DIMENSION
+    return service
+
+
+def _operator() -> Operator:
+    """Test operator in tenant A."""
+    return Operator(
+        sub="alice@example.com",
+        name="Alice",
+        email=None,
+        raw_jwt="<test-raw-jwt>",
+        tenant_id=_TENANT_A,
+        tenant_role=TenantRole.OPERATOR,
+    )
+
+
+def _chassis_kwargs(audit_id: uuid.UUID) -> dict[str, object]:
+    """Minimal kwargs for the chassis writer :func:`_write_audit_row`."""
+    return {
+        "audit_id": audit_id,
+        "operator_sub": "alice@example.com",
+        "tenant_id": _TENANT_A,
+        "target_id": None,
+        "method": "POST",
+        "path": "/api/v1/targets",
+        "status_code": 200,
+        "request_id": None,
+        "duration_ms": 1.0,
+        "payload": {},
+    }
+
+
+class _StubConnector(Connector):
+    """Minimal connector so the dispatcher resolver finds a class for the triple."""
+
+    product = "stub"
+    version = "1.x"
+    impl_id = "stub"
+
+    async def fingerprint(self, target: Any, operator: Any = None) -> FingerprintResult:  # type: ignore[override]
+        raise NotImplementedError
+
+    async def probe(self, target: Any) -> ProbeResult:  # type: ignore[override]
+        raise NotImplementedError
+
+    async def execute(  # type: ignore[override]
+        self,
+        target: Any,
+        op_id: str,
+        params: dict[str, Any],
+    ) -> OperationResult:
+        raise NotImplementedError
+
+
+async def _echo_handler(
+    operator: Operator,
+    target: Any,
+    params: dict[str, Any],
+) -> dict[str, Any]:
+    """Typed handler: return a trivial result."""
+    return {"ok": True}
+
+
+async def _seed_typed_op(stub_embedding_service: AsyncMock) -> None:
+    """Register the stub connector + typed op the dispatcher can find."""
+    register_connector_v2(product="stub", version="", impl_id="", cls=_StubConnector)
+    await register_typed_operation(
+        product="stub",
+        version="1.x",
+        impl_id="stub",
+        op_id="stub.op_call",
+        handler=_echo_handler,
+        summary="Stub op for work_ref tests.",
+        description="Echo a result; used to assert the audit row's work_ref.",
+        parameter_schema={"type": "object"},
+        when_to_use=None,
+        embedding_service=stub_embedding_service,
+    )
+
+
+async def _read_row(db_session: AsyncSession, audit_id: uuid.UUID) -> AuditLog:
+    """Fetch one audit row by id."""
+    result = await db_session.execute(select(AuditLog).where(AuditLog.id == audit_id))
+    return result.scalar_one()
+
+
+# ---------------------------------------------------------------------------
+# work_ref bound → every primary writer stamps the column
+# ---------------------------------------------------------------------------
+
+
+async def test_work_ref_var_stamped(
+    db_session: AsyncSession,
+    stub_embedding_service: AsyncMock,
+) -> None:
+    """With ``work_ref_var`` bound, all 3 primary writers stamp ``work_ref``.
+
+    Drives the chassis HTTP writer, the dispatcher DISPATCH writer (via
+    ``dispatch``), and the MCP writer in turn under one binding, then
+    asserts each produced ``audit_log`` row carries
+    ``work_ref == "gh:evoila/meho#1"``.
+    """
+    await _seed_typed_op(stub_embedding_service)
+    operator = _operator()
+
+    chassis_id = uuid.uuid4()
+    token = work_ref_var.set(_WORK_REF)
+    try:
+        # 1. chassis HTTP writer.
+        await _write_audit_row(**_chassis_kwargs(chassis_id))  # type: ignore[arg-type]
+
+        # 2. dispatcher DISPATCH writer (one row per dispatch).
+        await dispatch(
+            operator=operator,
+            connector_id="stub-1.x",
+            op_id="stub.op_call",
+            target=None,
+            params={},
+        )
+
+        # 3. MCP writer (returns the audit id it used).
+        mcp_id = await write_mcp_audit_row(
+            operator=operator,
+            method="MCP",
+            path="/mcp/tools/call/stub.op_call",
+            status_code=200,
+            duration_ms=1.0,
+            payload={"op_id": "stub.op_call"},
+        )
+    finally:
+        work_ref_var.reset(token)
+
+    chassis_row = await _read_row(db_session, chassis_id)
+    assert chassis_row.work_ref == _WORK_REF  # type: ignore[attr-defined]
+
+    mcp_row = await _read_row(db_session, mcp_id)
+    assert mcp_row.work_ref == _WORK_REF  # type: ignore[attr-defined]
+
+    dispatch_rows = (
+        await db_session.scalars(select(AuditLog).where(AuditLog.method == "DISPATCH"))
+    ).all()
+    assert len(dispatch_rows) == 1
+    assert dispatch_rows[0].work_ref == _WORK_REF  # type: ignore[attr-defined]
+
+
+# ---------------------------------------------------------------------------
+# work_ref unset → every primary writer leaves the column NULL
+# ---------------------------------------------------------------------------
+
+
+async def test_work_ref_null_when_unset(
+    db_session: AsyncSession,
+    stub_embedding_service: AsyncMock,
+) -> None:
+    """With no ``work_ref_var`` binding, all 3 primary writers leave it NULL.
+
+    Regression guard: operations outside a change-ticket scope (and the
+    system-internal writers) must not gain a spurious ``work_ref``.
+    """
+    await _seed_typed_op(stub_embedding_service)
+    operator = _operator()
+
+    # No work_ref binding in scope.
+    assert work_ref_var.get() is None
+
+    chassis_id = uuid.uuid4()
+    await _write_audit_row(**_chassis_kwargs(chassis_id))  # type: ignore[arg-type]
+
+    await dispatch(
+        operator=operator,
+        connector_id="stub-1.x",
+        op_id="stub.op_call",
+        target=None,
+        params={},
+    )
+
+    mcp_id = await write_mcp_audit_row(
+        operator=operator,
+        method="MCP",
+        path="/mcp/tools/call/stub.op_call",
+        status_code=200,
+        duration_ms=1.0,
+        payload={"op_id": "stub.op_call"},
+    )
+
+    chassis_row = await _read_row(db_session, chassis_id)
+    assert chassis_row.work_ref is None  # type: ignore[attr-defined]
+
+    mcp_row = await _read_row(db_session, mcp_id)
+    assert mcp_row.work_ref is None  # type: ignore[attr-defined]
+
+    dispatch_rows = (
+        await db_session.scalars(select(AuditLog).where(AuditLog.method == "DISPATCH"))
+    ).all()
+    assert len(dispatch_rows) == 1
+    assert dispatch_rows[0].work_ref is None  # type: ignore[attr-defined]
+
+
+# ---------------------------------------------------------------------------
+# Pure unit test -- the contextvar set/reset contract
+# ---------------------------------------------------------------------------
+
+
+def test_work_ref_var_resets_cleanly() -> None:
+    """set → non-None → reset → None; no dispatch, no DB.
+
+    Validates the set/reset token contract so the I1-T2 binder's
+    bind-around-request pattern is sound.
+    """
+    assert work_ref_var.get() is None
+
+    token = work_ref_var.set(_WORK_REF)
+    assert work_ref_var.get() == _WORK_REF
+
+    work_ref_var.reset(token)
+    assert work_ref_var.get() is None

--- a/backend/tests/test_doc_collections_registry.py
+++ b/backend/tests/test_doc_collections_registry.py
@@ -635,7 +635,15 @@ def test_migration_0037_downgrade_drops_table(
     monkeypatch: pytest.MonkeyPatch,
     tmp_path: Path,
 ) -> None:
-    """``upgrade head`` → ``downgrade -1`` is clean: the table is gone."""
+    """``upgrade head`` → ``downgrade "0036"`` is clean: the table is gone.
+
+    Targets the explicit predecessor revision (``0036``) rather than the
+    relative ``"-1"``: ``0037`` is no longer the migration head (later
+    audit-column migrations chain past it), so ``"-1"`` from head would
+    undo the wrong revision and leave ``doc_collections`` standing. The
+    explicit-revision form matches every other migration downgrade test
+    and stays correct as the head advances.
+    """
     from alembic import command
 
     cfg, sync_url = _alembic_cfg(monkeypatch, tmp_path)
@@ -643,7 +651,7 @@ def test_migration_0037_downgrade_drops_table(
         command.upgrade(cfg, "head")
         assert "doc_collections" in _table_names(sync_url)
 
-        command.downgrade(cfg, "-1")
+        command.downgrade(cfg, "0036")
         assert "doc_collections" not in _table_names(sync_url)
     finally:
         get_settings.cache_clear()

--- a/backend/tests/test_migration_0038_work_ref.py
+++ b/backend/tests/test_migration_0038_work_ref.py
@@ -1,0 +1,153 @@
+# SPDX-License-Identifier: Apache-2.0
+# Copyright (c) 2026 evoila Group
+
+"""Behavioural tests for Alembic migration ``0038_add_audit_log_work_ref``.
+
+Initiative #1652, Task #1655 (work_ref I1-T1). Adds the nullable
+``audit_log.work_ref`` column + its b-tree index -- the external
+change-ticket reference recorded on an operation's audit row. Soft-column
+discipline mirrors 0021 / 0014: nullable, no server default (Python-side
+``None``), reversible.
+
+Mirrors :mod:`tests.test_migration_0021_actor_sub`; SQLite is the test
+driver and the migration uses only generic DDL, so PG parity holds.
+"""
+
+from __future__ import annotations
+
+from collections.abc import Iterator
+from pathlib import Path
+
+import pytest
+from alembic import command
+from alembic.config import Config
+from sqlalchemy import create_engine as sa_create_engine
+from sqlalchemy import text
+
+from meho_backplane.db.engine import reset_engine_for_testing
+from meho_backplane.db.migrations import alembic_config
+from meho_backplane.settings import get_settings
+
+
+@pytest.fixture
+def alembic_cfg(
+    monkeypatch: pytest.MonkeyPatch,
+    tmp_path: Path,
+) -> Iterator[tuple[Config, str]]:
+    """Pin env, reset caches, return an Alembic config + sync URL (sync fixture)."""
+    db_path = tmp_path / "migration_0038.db"
+    async_url = f"sqlite+aiosqlite:///{db_path}"
+    sync_url = f"sqlite:///{db_path}"
+    monkeypatch.setenv("DATABASE_URL", async_url)
+    monkeypatch.setenv("KEYCLOAK_ISSUER_URL", "https://keycloak.test/realms/meho")
+    monkeypatch.setenv("KEYCLOAK_AUDIENCE", "meho-backplane")
+    monkeypatch.setenv("VAULT_ADDR", "https://vault.test")
+    get_settings.cache_clear()
+    reset_engine_for_testing()
+
+    cfg = alembic_config()
+    cfg.set_main_option("sqlalchemy.url", async_url)
+    try:
+        yield cfg, sync_url
+    finally:
+        get_settings.cache_clear()
+        reset_engine_for_testing()
+
+
+def _audit_log_columns(sync_url: str) -> set[str]:
+    sync_eng = sa_create_engine(sync_url)
+    try:
+        with sync_eng.connect() as conn:
+            rows = conn.execute(text("PRAGMA table_info(audit_log)")).all()
+    finally:
+        sync_eng.dispose()
+    return {str(row[1]) for row in rows}
+
+
+def _audit_log_column_is_nullable(sync_url: str, column: str) -> bool:
+    sync_eng = sa_create_engine(sync_url)
+    try:
+        with sync_eng.connect() as conn:
+            rows = conn.execute(text("PRAGMA table_info(audit_log)")).all()
+    finally:
+        sync_eng.dispose()
+    for row in rows:
+        if str(row[1]) == column:
+            return int(row[3]) == 0
+    raise AssertionError(f"column {column!r} not present on audit_log")
+
+
+def _audit_log_indexes(sync_url: str) -> set[str]:
+    sync_eng = sa_create_engine(sync_url)
+    try:
+        with sync_eng.connect() as conn:
+            rows = conn.execute(text("PRAGMA index_list(audit_log)")).all()
+    finally:
+        sync_eng.dispose()
+    return {str(row[1]) for row in rows}
+
+
+def test_upgrade_adds_work_ref_column_and_index(alembic_cfg: tuple[Config, str]) -> None:
+    """``upgrade head`` lands the nullable column + its named index."""
+    cfg, sync_url = alembic_cfg
+    command.upgrade(cfg, "head")
+
+    assert "work_ref" in _audit_log_columns(sync_url), (
+        "migration 0038 must add audit_log.work_ref on upgrade head"
+    )
+    assert _audit_log_column_is_nullable(sync_url, "work_ref"), (
+        "work_ref must be nullable -- NULL when no change ticket is in scope"
+    )
+    assert "audit_log_work_ref_idx" in _audit_log_indexes(sync_url), (
+        "migration 0038 must create audit_log_work_ref_idx on upgrade head"
+    )
+
+
+def test_downgrade_then_upgrade_round_trips(alembic_cfg: tuple[Config, str]) -> None:
+    """``downgrade "0037"`` drops column + index; ``upgrade head`` restores them."""
+    cfg, sync_url = alembic_cfg
+    command.upgrade(cfg, "head")
+    assert "work_ref" in _audit_log_columns(sync_url)
+    assert "audit_log_work_ref_idx" in _audit_log_indexes(sync_url)
+
+    command.downgrade(cfg, "0037")
+    assert "work_ref" not in _audit_log_columns(sync_url), "downgrade must drop work_ref"
+    assert "audit_log_work_ref_idx" not in _audit_log_indexes(sync_url), (
+        "downgrade must drop audit_log_work_ref_idx"
+    )
+
+    command.upgrade(cfg, "head")
+    assert "work_ref" in _audit_log_columns(sync_url)
+    assert "audit_log_work_ref_idx" in _audit_log_indexes(sync_url)
+
+
+def test_prior_audit_columns_untouched(alembic_cfg: tuple[Config, str]) -> None:
+    """The pre-existing soft-FK columns + indexes survive 0038."""
+    cfg, sync_url = alembic_cfg
+    command.upgrade(cfg, "head")
+
+    columns = _audit_log_columns(sync_url)
+    # A representative slice of the prior soft-FK columns 0038 sits beside.
+    assert "actor_sub" in columns, "0021's actor_sub must survive 0038"
+    assert "run_id" in columns, "0034's run_id must survive 0038"
+    assert "agent_session_id" in columns, "0014's agent_session_id must survive 0038"
+    assert "work_ref" in columns
+
+    indexes = _audit_log_indexes(sync_url)
+    assert "audit_log_actor_sub_idx" in indexes
+    assert "audit_log_run_id_idx" in indexes
+    assert "audit_log_work_ref_idx" in indexes
+
+
+def test_orm_field_resolves_and_defaults_none() -> None:
+    """:attr:`AuditLog.work_ref` resolves and defaults to ``None``."""
+    from meho_backplane.db.models import AuditLog
+
+    assert hasattr(AuditLog, "work_ref")
+    row = AuditLog(
+        operator_sub="op-smoke",
+        method="POST",
+        path="/api/v1/targets",
+        status_code=200,
+    )
+    assert row.work_ref is None, "an AuditLog built without work_ref must default it to None"

--- a/backend/tests/test_operations_register_ingested.py
+++ b/backend/tests/test_operations_register_ingested.py
@@ -925,7 +925,9 @@ def test_check_version_covered_logs_orphan_when_no_class_registered(
     assert events[0]["impl_id"] == "brand-new-impl"
 
 
-def test_check_version_covered_ignores_other_impls_of_same_product() -> None:
+def test_check_version_covered_ignores_other_impls_of_same_product(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
     """Class for ``(product, impl_id_A)`` does not constrain ingest under ``impl_id_B``.
 
     The pre-flight filters by the full ``(product, impl_id)`` pair, so
@@ -933,21 +935,43 @@ def test_check_version_covered_ignores_other_impls_of_same_product() -> None:
     (``vmware-pyvmomi`` vs ``vmware-rest``) leaves the ``impl_id_B``
     pre-flight in the no-class-registered branch and proceeds with
     the orphan warning.
+
+    Capture surface (#1254): binds a private
+    :class:`structlog.testing.LogCapture` + monkeypatches the subject
+    module's ``_log`` rather than using
+    :func:`structlog.testing.capture_logs`, whose global
+    processor-list swap can return an empty list when a concurrent
+    :func:`structlog.configure` (lifespan boot / observability
+    fixtures) races it -- the same flake #1258 fixed for the sibling
+    orphan test. Process-local, contextvar-free, auto-restored on
+    teardown.
     """
+    from meho_backplane.operations.ingest import connector_registration
+
     register_connector_v2(
         product="vmware",
         version="9.0",
         impl_id="vmware-rest",
         cls=_FakeRangedConnector,
     )
-    with structlog.testing.capture_logs() as captured:
-        check_version_covered_by_registered_class(
-            product="vmware",
-            version="7.0",
-            impl_id="vmware-pyvmomi",
-        )
+
+    capture = structlog.testing.LogCapture()
+    private_log = structlog.wrap_logger(
+        structlog.PrintLogger(),
+        processors=[capture],
+    )
+    monkeypatch.setattr(connector_registration, "_log", private_log)
+
+    check_version_covered_by_registered_class(
+        product="vmware",
+        version="7.0",
+        impl_id="vmware-pyvmomi",
+    )
+
     orphan_events = [
-        entry for entry in captured if entry.get("event") == "connector_ingest_orphaned_class"
+        entry
+        for entry in capture.entries
+        if entry.get("event") == "connector_ingest_orphaned_class"
     ]
     assert len(orphan_events) == 1
     assert orphan_events[0]["impl_id"] == "vmware-pyvmomi"
@@ -996,24 +1020,42 @@ async def test_register_ingested_blocks_when_version_outside_existing_class_rang
 @pytest.mark.asyncio
 async def test_register_ingested_warns_and_proceeds_when_no_class_registered(
     stub_embedding_service: AsyncMock,
+    monkeypatch: pytest.MonkeyPatch,
 ) -> None:
     """No class for ``(product, impl_id)`` → ingest proceeds and emits
     ``connector_ingest_orphaned_class``.
+
+    Capture surface (#1254): same private-``LogCapture`` +
+    monkeypatched-``_log`` pattern as the sibling orphan tests; the
+    orphan event is emitted from ``connector_registration._log`` even
+    on the ``register_ingested_operations`` path, so patching that
+    module's logger captures it without the
+    :func:`structlog.testing.capture_logs` global-swap flake.
     """
+    from meho_backplane.operations.ingest import connector_registration
+
+    capture = structlog.testing.LogCapture()
+    private_log = structlog.wrap_logger(
+        structlog.PrintLogger(),
+        processors=[capture],
+    )
+    monkeypatch.setattr(connector_registration, "_log", private_log)
+
     # Registry empty for ``(unknown-vendor, brand-new-impl)``.
-    with structlog.testing.capture_logs() as captured:
-        result = await register_ingested_operations(
-            product="unknown-vendor",
-            version="1.0",
-            impl_id="brand-new-impl",
-            spec_source="vendor.yaml",
-            operations=[_proto("GET:/things", path="/things")],
-            embedding_service=stub_embedding_service,
-        )
+    result = await register_ingested_operations(
+        product="unknown-vendor",
+        version="1.0",
+        impl_id="brand-new-impl",
+        spec_source="vendor.yaml",
+        operations=[_proto("GET:/things", path="/things")],
+        embedding_service=stub_embedding_service,
+    )
     assert result.inserted_count == 1
     # The orphan event is logged with the full triple.
     orphan_events = [
-        entry for entry in captured if entry.get("event") == "connector_ingest_orphaned_class"
+        entry
+        for entry in capture.entries
+        if entry.get("event") == "connector_ingest_orphaned_class"
     ]
     assert len(orphan_events) == 1
     event = orphan_events[0]


### PR DESCRIPTION
## Summary

- Adds the `audit_log.work_ref` keystone (work_ref I1-T1): a nullable `Text` column + btree index `audit_log_work_ref_idx` that correlates a governed MEHO operation to the external change ticket that authorised it (a GitHub issue, a Jira key, a CR id), e.g. `"gh:evoila/meho#1"`.
- Threads the value on a new `work_ref_var: ContextVar[str | None]` defined beside the existing `parent_audit_id_var` / `agent_session_id_var` / `run_id_var` / `step_id_var` in `operations/_audit.py` — there is no single audit-write chokepoint, so the value rides a ContextVar read by the writers.
- Stamps `work_ref` from the **3 primary** audit writers only — chassis HTTP (`audit._write_audit_row`), dispatcher DISPATCH (`operations/_audit.write_audit_row`), and MCP (`mcp/audit.write_mcp_audit_row`) — each hasattr-guarded for forward-compat. The ~8 system-internal writers (memory / topology / reaper / ui-session) legitimately leave the column NULL and are untouched.
- Where the var is bound FROM (request transport / agent loop) is the next task (I1-T2); on its own this task leaves the column NULL except where a caller binds the var directly.

## Test plan

- [x] `uv run alembic upgrade head` then `uv run alembic downgrade -1` round-trip clean (0038 is the single head, chained off the true head 0037).
- [x] `uv run ruff check src/ tests/` — clean
- [x] `uv run ruff format --check src/ tests/` — clean
- [x] `uv run mypy src/` — clean (468 files, strict)
- [x] `uv run pytest -x` — full backend suite green
- [x] **AC** `grep -n work_ref backend/.../db/models.py` shows the typed `Mapped[str | None]` column + the `audit_log_work_ref_idx` btree index in `__table_args__`.
- [x] **AC** new `tests/test_audit_work_ref.py::test_work_ref_var_stamped` — binds `work_ref_var.set("gh:evoila/meho#1")`, drives all 3 primary writers, asserts each row carries the work_ref; unset → NULL.
- [x] new `tests/test_migration_0038_work_ref.py` — upgrade adds the nullable column + index; downgrade→upgrade round-trips; prior audit columns survive.

## Out of scope

- The bind source / transport (I1-T2); the query filter + `AuditEntry` surfacing (I1-T3).
- The other entity columns (I2, I3); enforcement; the ~8 system-internal writers.

## Adjacent fix (in-scope, caused by this change)

- `tests/test_doc_collections_registry.py::test_migration_0037_downgrade_drops_table` used a brittle `downgrade("-1")` that assumed 0037 was the head. Adding 0038 as the new head made `-1` undo the wrong revision. Re-pinned to the explicit predecessor `downgrade("0036")`, matching the explicit-revision convention every other migration downgrade test already uses.

<!-- auto-implement-issue: fresh, iteration 1 -->

Closes #1655


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Audit logs now support storing external change-ticket references, enabling operators to correlate system audit entries with external work items and change-tracking systems. This improves visibility into change management decisions, accountability, and end-to-end operational traceability.

* **Tests**
  * Added comprehensive test coverage for the new audit work reference feature.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->