### PR TITLE
feat(audit): work_ref I1-T3 — query_audit work_ref filter + AuditEntry surfacing + /by-work-ref route + CLI

### DIFF
--- a/backend/src/meho_backplane/api/v1/audit.py
+++ b/backend/src/meho_backplane/api/v1/audit.py
@@ -3,8 +3,8 @@
 
 """``/api/v1/audit/*`` — REST surface for the audit-query substrate (G8.1-T2).
 
-Mounts five routes. Four dispatch through the T1
-:func:`~meho_backplane.audit_query.query_audit` handler; the fifth
+Mounts six routes. Five dispatch through the T1
+:func:`~meho_backplane.audit_query.query_audit` handler; the sixth
 (replay, G8.2-T4) dispatches through
 :func:`~meho_backplane.audit_query.replay_session`:
 
@@ -12,6 +12,9 @@ Mounts five routes. Four dispatch through the T1
   :class:`~meho_backplane.api.v1.audit_models.AuditQueryRequest`.
 * ``GET /api/v1/audit/who-touched/{target}`` — pre-canned shortcut
   bound to ``target=<path>``.
+* ``GET /api/v1/audit/by-work-ref/{ref}`` — pre-canned shortcut bound
+  to ``work_ref=<path>`` (exact match); the "show every write
+  authorised by change-ticket X" lookup (work_ref I1-T1 #1655).
 * ``GET /api/v1/audit/my-recent`` — pre-canned shortcut bound to
   ``principal=<operator.sub>``.
 * ``GET /api/v1/audit/show/{audit_id}`` — single-row fetch. 404 (not
@@ -243,6 +246,7 @@ async def query(
         audit_id=body.audit_id,
         parent_audit_id=body.parent_audit_id,
         agent_session_id=body.agent_session_id,
+        work_ref=body.work_ref,
         limit=body.limit,
         cursor=body.cursor,
     )
@@ -270,6 +274,45 @@ async def who_touched(
     except DurationParseError as exc:
         raise HTTPException(status_code=400, detail=str(exc)) from exc
     filters = AuditQueryFilters(target=target, since=since_dt, limit=limit)
+    return await _dispatch(filters, tenant_id=operator.tenant_id)
+
+
+@router.get("/by-work-ref/{ref:path}", response_model=AuditQueryResult)
+async def by_work_ref(
+    ref: str,
+    since: str | None = Query(default=None, max_length=32),
+    limit: int = Query(default=100, ge=1, le=1000),
+    operator: Operator = _require_operator,
+) -> AuditQueryResult:
+    """Audit rows authorised by the external change-ticket reference *ref*.
+
+    Pre-canned shortcut over :func:`query_audit` with the ``work_ref``
+    filter bound to the path param (work_ref I1-T1 #1655) — the headline
+    "show every write authorised by ticket X" lookup. The match is
+    **exact**: ``ref`` is an opaque identifier (e.g. ``gh:evoila/meho#1``),
+    not a search term, so a non-matching value returns an empty result,
+    never an error.
+
+    Unlike :func:`who_touched` / :func:`my_recent`, ``since`` has **no**
+    default window: a change-ticket lookup wants the whole governed history
+    of that ref, not just the last 24h. Passing ``?since=`` narrows it when
+    a window is wanted.
+
+    The path converter is ``{ref:path}`` (not the default ``{ref}``) because a
+    work_ref carries embedded slashes — ``gh:evoila/meho#1`` — that the default
+    converter would refuse to match (404). The ``#`` is passed percent-encoded
+    (``%23``); FastAPI decodes it. The OpenAPI path string is still
+    ``/api/v1/audit/by-work-ref/{ref}``.
+    """
+    _bind_audit_overrides()
+    since_dt = None
+    if since is not None:
+        now = datetime.now(UTC)
+        try:
+            since_dt = parse_duration(since, now=now)
+        except DurationParseError as exc:
+            raise HTTPException(status_code=400, detail=str(exc)) from exc
+    filters = AuditQueryFilters(work_ref=ref, since=since_dt, limit=limit)
     return await _dispatch(filters, tenant_id=operator.tenant_id)
 
 

--- a/backend/src/meho_backplane/api/v1/audit_models.py
+++ b/backend/src/meho_backplane/api/v1/audit_models.py
@@ -80,6 +80,7 @@ class AuditQueryRequest(BaseModel):
     audit_id: uuid.UUID | None = None
     parent_audit_id: uuid.UUID | None = None
     agent_session_id: uuid.UUID | None = None
+    work_ref: str | None = Field(default=None, max_length=256)
     limit: int = Field(default=100, ge=1, le=1000)
     cursor: str | None = Field(default=None, max_length=512)
 

--- a/backend/src/meho_backplane/audit_query/query.py
+++ b/backend/src/meho_backplane/audit_query/query.py
@@ -44,6 +44,13 @@ Filter coverage
   the column is also surfaced on every returned ``AuditEntry`` and drives the
   per-session replay query
   (:func:`~meho_backplane.audit_query.replay.replay_session`).
+* ``work_ref`` is a real column (work_ref I1-T1 #1655, migration ``0039``).
+  The filter narrows to ``audit_log.work_ref = :work_ref`` — exact match (an
+  opaque change-ticket reference such as ``"gh:evoila/meho#1"`` is an
+  identifier, not a search term, so the predicate is deterministic equality
+  per #1177, not ``ILIKE``); the column is also surfaced on every returned
+  ``AuditEntry``. NULL on rows with no bound work_ref, so a ``work_ref``
+  filter excludes them.
 * ``parent_audit_id`` is a real column too (G0.6-T7 #398, migration ``0006``)
   and is surfaced on every returned ``AuditEntry``, but the *flat filter* on
   it still raises :class:`UnsupportedFilterError` — un-gating that filter is
@@ -194,6 +201,9 @@ def _apply_filters(
     if filters.agent_session_id is not None:
         stmt = stmt.where(AuditLog.agent_session_id == filters.agent_session_id)
 
+    if filters.work_ref is not None:
+        stmt = stmt.where(AuditLog.work_ref == filters.work_ref)
+
     if filters.principal is not None:
         escaped = _escape_like_literal(filters.principal)
         stmt = stmt.where(
@@ -330,6 +340,7 @@ def _build_audit_entry(row: AuditLog, target_name: str | None) -> AuditEntry:
         result_status=_derive_result_status(row.status_code),
         parent_audit_id=row.parent_audit_id,
         agent_session_id=row.agent_session_id,
+        work_ref=row.work_ref,
         broadcast_event_id=None,
     )
 

--- a/backend/src/meho_backplane/audit_query/schemas.py
+++ b/backend/src/meho_backplane/audit_query/schemas.py
@@ -99,6 +99,7 @@ class AuditQueryFilters(BaseModel):
     audit_id: uuid.UUID | None = None
     parent_audit_id: uuid.UUID | None = None
     agent_session_id: uuid.UUID | None = None
+    work_ref: str | None = None
     limit: int = Field(default=100, ge=1, le=1000)
     cursor: str | None = None
 
@@ -120,6 +121,9 @@ class AuditEntry(BaseModel):
     * ``op_id`` / ``op_class`` / ``result_status`` — computed at query time
     * ``parent_audit_id`` ← ``audit_log.parent_audit_id`` (lineage; #398)
     * ``agent_session_id`` ← ``audit_log.agent_session_id`` (MCP session; #1009)
+    * ``work_ref`` ← ``audit_log.work_ref`` (external change-ticket reference;
+      work_ref I1-T1 #1655). NULL until a bind source lands (I1-T2); the flat
+      ``work_ref`` filter on :class:`AuditQueryFilters` is exact-match.
     * ``principal_name`` ← ``payload['principal_name']`` when set. The MCP
       audit-write helper (``write_mcp_audit_row``) populates it from
       ``Operator.name`` since G0.15-T3 #1212; HTTP-chassis rows remain
@@ -149,6 +153,7 @@ class AuditEntry(BaseModel):
     result_status: str
     parent_audit_id: uuid.UUID | None
     agent_session_id: uuid.UUID | None
+    work_ref: str | None
     broadcast_event_id: uuid.UUID | None
 
 

--- a/backend/tests/test_api_audit_routes.py
+++ b/backend/tests/test_api_audit_routes.py
@@ -209,6 +209,7 @@ def _make_entry(
         result_status="ok",
         parent_audit_id=None,
         agent_session_id=None,
+        work_ref=None,
         broadcast_event_id=None,
     )
 
@@ -415,6 +416,37 @@ def test_who_touched_builds_target_filter(client: TestClient) -> None:
 
 
 # ---------------------------------------------------------------------------
+# GET /api/v1/audit/by-work-ref/{ref}
+# ---------------------------------------------------------------------------
+
+
+def test_by_work_ref_builds_exact_work_ref_filter(client: TestClient) -> None:
+    """work_ref I1-T3 #1658: the path param becomes the substrate ``work_ref`` filter.
+
+    Unlike ``who-touched``, the route binds **no** default ``since`` window — a
+    change-ticket lookup wants the whole governed history of the ref, not just
+    the last 24h — so ``since`` stays None unless the caller passes one.
+    """
+    key = make_rsa_keypair("kid-A")
+    token = _token(key)
+    mock_query = AsyncMock(return_value=_empty_result())
+    with (
+        respx.mock as r,
+        patch("meho_backplane.api.v1.audit.query_audit", new=mock_query),
+    ):
+        mock_discovery_and_jwks(r, public_jwks(key))
+        resp = client.get(
+            "/api/v1/audit/by-work-ref/gh:evoila/meho%231",
+            headers={"Authorization": f"Bearer {token}"},
+        )
+    assert resp.status_code == 200
+    filters = mock_query.await_args.args[0]
+    assert filters.work_ref == "gh:evoila/meho#1"
+    assert filters.since is None  # no default window for a change-ticket lookup
+    assert filters.limit == 100
+
+
+# ---------------------------------------------------------------------------
 # GET /api/v1/audit/my-recent
 # ---------------------------------------------------------------------------
 
@@ -592,6 +624,7 @@ def test_openapi_schema_lists_all_routes(client: TestClient) -> None:
     paths = schema["paths"]
     assert "/api/v1/audit/query" in paths
     assert "/api/v1/audit/who-touched/{target}" in paths
+    assert "/api/v1/audit/by-work-ref/{ref}" in paths
     assert "/api/v1/audit/my-recent" in paths
     assert "/api/v1/audit/show/{audit_id}" in paths
     assert "/api/v1/audit/sessions/{session_id}/replay" in paths
@@ -600,6 +633,7 @@ def test_openapi_schema_lists_all_routes(client: TestClient) -> None:
     assert "post" in paths["/api/v1/audit/query"]
     assert "audit" in paths["/api/v1/audit/query"]["post"]["tags"]
     assert "audit" in paths["/api/v1/audit/who-touched/{target}"]["get"]["tags"]
+    assert "audit" in paths["/api/v1/audit/by-work-ref/{ref}"]["get"]["tags"]
     assert "audit" in paths["/api/v1/audit/my-recent"]["get"]["tags"]
     assert "audit" in paths["/api/v1/audit/show/{audit_id}"]["get"]["tags"]
     assert "audit" in paths["/api/v1/audit/sessions/{session_id}/replay"]["get"]["tags"]

--- a/backend/tests/test_audit_query_handler.py
+++ b/backend/tests/test_audit_query_handler.py
@@ -22,6 +22,9 @@ Coverage matrix (G8.1-T1 acceptance criteria):
   (the flat filter stays gated; ``agent_session_id`` is un-gated by G8.2-T3).
 * G8.2-T3 — ``agent_session_id`` filter narrows rows; ``parent_audit_id`` /
   ``agent_session_id`` populate on the returned ``AuditEntry``.
+* work_ref I1-T3 #1658 — ``work_ref`` exact-match filter narrows to rows whose
+  ``work_ref`` matches (excluding different / NULL); ``work_ref`` populates on
+  every returned ``AuditEntry``.
 * :class:`InvalidCursorError` propagates when a tampered cursor is passed.
 * ``target_name`` denormalization via LEFT JOIN works (and is None when the
   audit row has no ``target_id``).
@@ -87,6 +90,7 @@ async def _seed_audit_row(
     payload: dict[str, object] | None = None,
     agent_session_id: uuid.UUID | None = None,
     parent_audit_id: uuid.UUID | None = None,
+    work_ref: str | None = None,
 ) -> uuid.UUID:
     """Insert one :class:`AuditLog` row and return its ``id``."""
     row_id = uuid.uuid4()
@@ -104,6 +108,7 @@ async def _seed_audit_row(
             target_id=target_id,
             agent_session_id=agent_session_id,
             parent_audit_id=parent_audit_id,
+            work_ref=work_ref,
         ),
     )
     return row_id
@@ -530,6 +535,95 @@ async def test_agent_session_id_filter_narrows_rows(
 
     assert len(result.rows) == 1
     assert result.rows[0].agent_session_id == session_a
+
+
+# ---------------------------------------------------------------------------
+# work_ref filter + surfacing (work_ref I1-T3 #1658)
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.asyncio
+async def test_work_ref_filter_exact_match_excludes_others_and_null(
+    session: AsyncSession,
+) -> None:
+    """``work_ref`` is an exact-match filter (work_ref I1-T3 #1658).
+
+    The column landed with work_ref I1-T1 (#1655, migration ``0039``); this
+    task adds the ``WHERE work_ref = :work_ref`` clause. The match is exact —
+    a change-ticket reference is an opaque identifier, not a search term — so a
+    row carrying a *different* work_ref, and a row whose ``work_ref`` is NULL
+    (the system-internal / not-yet-bound case), are both excluded. The
+    headline "show every write authorised by ticket X" use case.
+    """
+    tenant_id = uuid.uuid4()
+    ref = "gh:evoila/meho#1"
+    other_ref = "gh:evoila/meho#2"
+    matching_id = await _seed_audit_row(
+        session,
+        tenant_id=tenant_id,
+        occurred_at=datetime(2026, 5, 14, 0, 0, 1, tzinfo=UTC),
+        work_ref=ref,
+    )
+    await _seed_audit_row(
+        session,
+        tenant_id=tenant_id,
+        occurred_at=datetime(2026, 5, 14, 0, 0, 2, tzinfo=UTC),
+        work_ref=other_ref,
+    )
+    await _seed_audit_row(
+        session,
+        tenant_id=tenant_id,
+        occurred_at=datetime(2026, 5, 14, 0, 0, 3, tzinfo=UTC),
+        work_ref=None,
+    )
+    await session.commit()
+
+    result = await query_audit(
+        AuditQueryFilters(work_ref=ref),
+        tenant_id=tenant_id,
+        session=session,
+    )
+
+    assert [entry.id for entry in result.rows] == [matching_id]
+    assert result.rows[0].work_ref == ref
+
+
+@pytest.mark.asyncio
+async def test_work_ref_surfaced_on_every_returned_entry(
+    session: AsyncSession,
+) -> None:
+    """Every returned ``AuditEntry`` carries its row's ``work_ref`` value.
+
+    Guards the half-wired failure mode the task exists to prevent: a column
+    that is filterable but never surfaced on the row (the ``actor_sub`` /
+    ``run_id`` / ``step_id`` trap). A no-filter query over rows with mixed
+    work_ref values must echo each row's ``work_ref`` verbatim — the bound
+    string on bound rows, ``None`` on unbound rows.
+    """
+    tenant_id = uuid.uuid4()
+    bound_id = await _seed_audit_row(
+        session,
+        tenant_id=tenant_id,
+        occurred_at=datetime(2026, 5, 14, 0, 0, 1, tzinfo=UTC),
+        work_ref="jira:OPS-42",
+    )
+    unbound_id = await _seed_audit_row(
+        session,
+        tenant_id=tenant_id,
+        occurred_at=datetime(2026, 5, 14, 0, 0, 2, tzinfo=UTC),
+        work_ref=None,
+    )
+    await session.commit()
+
+    result = await query_audit(
+        AuditQueryFilters(),
+        tenant_id=tenant_id,
+        session=session,
+    )
+
+    by_id = {entry.id: entry.work_ref for entry in result.rows}
+    assert by_id[bound_id] == "jira:OPS-42"
+    assert by_id[unbound_id] is None
 
 
 # ---------------------------------------------------------------------------

--- a/backend/tests/test_audit_query_schemas.py
+++ b/backend/tests/test_audit_query_schemas.py
@@ -47,6 +47,7 @@ def test_filters_empty_construction_uses_defaults() -> None:
     assert f.audit_id is None
     assert f.parent_audit_id is None
     assert f.agent_session_id is None
+    assert f.work_ref is None
 
 
 def test_filters_limit_lower_bound_rejected() -> None:
@@ -86,8 +87,10 @@ def _make_entry(**overrides: object) -> AuditEntry:
     so the helper spells out all of them — including ``broadcast_event_id``
     (still unconditionally None in v0.2; FK direction is reversed),
     ``principal_name`` (conditionally populated since G0.15-T3 #1212 — None
-    here unless overridden), and the two lineage columns the handler now
-    populates from the row (``parent_audit_id`` / ``agent_session_id``).
+    here unless overridden), the two lineage columns the handler now
+    populates from the row (``parent_audit_id`` / ``agent_session_id``), and
+    ``work_ref`` (external change-ticket reference; work_ref I1-T1 #1655 —
+    None here unless overridden).
     """
     defaults: dict[str, object] = {
         "id": uuid.uuid4(),
@@ -108,6 +111,7 @@ def _make_entry(**overrides: object) -> AuditEntry:
         "result_status": "ok",
         "parent_audit_id": None,
         "agent_session_id": None,
+        "work_ref": None,
         "broadcast_event_id": None,
     }
     defaults.update(overrides)

--- a/backend/tests/test_audit_replay.py
+++ b/backend/tests/test_audit_replay.py
@@ -441,6 +441,7 @@ def test_replay_node_is_frozen() -> None:
         result_status="ok",
         parent_audit_id=None,
         agent_session_id=None,
+        work_ref=None,
         broadcast_event_id=None,
         depth=0,
         children=[],

--- a/backend/tests/test_mcp_tool_audit_replay.py
+++ b/backend/tests/test_mcp_tool_audit_replay.py
@@ -70,6 +70,7 @@ def _node(node_id: str, *, depth: int, children: list[ReplayNode] | None = None)
         result_status="ok",
         parent_audit_id=None,
         agent_session_id=uuid.UUID(_SESSION_ID),
+        work_ref=None,
         broadcast_event_id=None,
         depth=depth,
         children=children or [],

--- a/backend/tests/test_mcp_tool_query_audit.py
+++ b/backend/tests/test_mcp_tool_query_audit.py
@@ -329,6 +329,7 @@ def test_tools_call_handler_returns_result_model_dump(
         result_status="ok",
         parent_audit_id=None,
         agent_session_id=None,
+        work_ref=None,
         broadcast_event_id=None,
     )
     mock_query = AsyncMock(

--- a/cli/api/openapi.json
+++ b/cli/api/openapi.json
@@ -4962,6 +4962,82 @@
         }
       }
     },
+    "/api/v1/audit/by-work-ref/{ref}": {
+      "get": {
+        "tags": [
+          "audit"
+        ],
+        "summary": "By Work Ref",
+        "description": "Audit rows authorised by the external change-ticket reference *ref*.\n\nPre-canned shortcut over :func:`query_audit` with the ``work_ref``\nfilter bound to the path param (work_ref I1-T1 #1655) \u2014 the headline\n\"show every write authorised by ticket X\" lookup. The match is\n**exact**: ``ref`` is an opaque identifier (e.g. ``gh:evoila/meho#1``),\nnot a search term, so a non-matching value returns an empty result,\nnever an error.\n\nUnlike :func:`who_touched` / :func:`my_recent`, ``since`` has **no**\ndefault window: a change-ticket lookup wants the whole governed history\nof that ref, not just the last 24h. Passing ``?since=`` narrows it when\na window is wanted.\n\nThe path converter is ``{ref:path}`` (not the default ``{ref}``) because a\nwork_ref carries embedded slashes \u2014 ``gh:evoila/meho#1`` \u2014 that the default\nconverter would refuse to match (404). The ``#`` is passed percent-encoded\n(``%23``); FastAPI decodes it. The OpenAPI path string is still\n``/api/v1/audit/by-work-ref/{ref}``.",
+        "operationId": "by_work_ref_api_v1_audit_by_work_ref__ref__get",
+        "parameters": [
+          {
+            "name": "ref",
+            "in": "path",
+            "required": true,
+            "schema": {
+              "type": "string",
+              "title": "Ref"
+            }
+          },
+          {
+            "name": "since",
+            "in": "query",
+            "required": false,
+            "schema": {
+              "type": "string",
+              "maxLength": 32,
+              "nullable": true,
+              "title": "Since"
+            }
+          },
+          {
+            "name": "limit",
+            "in": "query",
+            "required": false,
+            "schema": {
+              "type": "integer",
+              "maximum": 1000,
+              "minimum": 1,
+              "default": 100,
+              "title": "Limit"
+            }
+          },
+          {
+            "name": "authorization",
+            "in": "header",
+            "required": false,
+            "schema": {
+              "type": "string",
+              "nullable": true,
+              "title": "Authorization"
+            }
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "Successful Response",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/AuditQueryResult"
+                }
+              }
+            }
+          },
+          "422": {
+            "description": "Validation Error",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/HTTPValidationError"
+                }
+              }
+            }
+          }
+        }
+      }
+    },
     "/api/v1/audit/my-recent": {
       "get": {
         "tags": [
@@ -10967,6 +11043,11 @@
             "nullable": true,
             "title": "Agent Session Id"
           },
+          "work_ref": {
+            "type": "string",
+            "nullable": true,
+            "title": "Work Ref"
+          },
           "broadcast_event_id": {
             "type": "string",
             "format": "uuid",
@@ -10994,10 +11075,11 @@
           "result_status",
           "parent_audit_id",
           "agent_session_id",
+          "work_ref",
           "broadcast_event_id"
         ],
         "title": "AuditEntry",
-        "description": "One row of the audit query result.\n\nField-to-column mapping (see module docstring for the substrate\nreconciliation):\n\n* ``id`` \u2190 ``audit_log.id``\n* ``ts`` \u2190 ``audit_log.occurred_at``\n* ``tenant_id`` \u2190 ``audit_log.tenant_id``\n* ``principal_sub`` \u2190 ``audit_log.operator_sub``\n* ``target_id`` \u2190 ``audit_log.target_id``\n* ``target_name`` \u2190 LEFT JOIN ``targets.name`` ON ``audit_log.target_id``\n* ``method`` / ``path`` / ``status_code`` / ``request_id`` / ``duration_ms``\n  / ``payload`` \u2190 columns of the same name\n* ``op_id`` / ``op_class`` / ``result_status`` \u2014 computed at query time\n* ``parent_audit_id`` \u2190 ``audit_log.parent_audit_id`` (lineage; #398)\n* ``agent_session_id`` \u2190 ``audit_log.agent_session_id`` (MCP session; #1009)\n* ``principal_name`` \u2190 ``payload['principal_name']`` when set. The MCP\n  audit-write helper (``write_mcp_audit_row``) populates it from\n  ``Operator.name`` since G0.15-T3 #1212; HTTP-chassis rows remain\n  None pending a separate fix to bind ``name`` to contextvars in\n  ``verify_jwt_and_bind``.\n* ``broadcast_event_id`` \u2014 v0.2 placeholder, always None (FK direction\n  is reversed: ``BroadcastEvent.audit_id`` points at the audit row)."
+        "description": "One row of the audit query result.\n\nField-to-column mapping (see module docstring for the substrate\nreconciliation):\n\n* ``id`` \u2190 ``audit_log.id``\n* ``ts`` \u2190 ``audit_log.occurred_at``\n* ``tenant_id`` \u2190 ``audit_log.tenant_id``\n* ``principal_sub`` \u2190 ``audit_log.operator_sub``\n* ``target_id`` \u2190 ``audit_log.target_id``\n* ``target_name`` \u2190 LEFT JOIN ``targets.name`` ON ``audit_log.target_id``\n* ``method`` / ``path`` / ``status_code`` / ``request_id`` / ``duration_ms``\n  / ``payload`` \u2190 columns of the same name\n* ``op_id`` / ``op_class`` / ``result_status`` \u2014 computed at query time\n* ``parent_audit_id`` \u2190 ``audit_log.parent_audit_id`` (lineage; #398)\n* ``agent_session_id`` \u2190 ``audit_log.agent_session_id`` (MCP session; #1009)\n* ``work_ref`` \u2190 ``audit_log.work_ref`` (external change-ticket reference;\n  work_ref I1-T1 #1655). NULL until a bind source lands (I1-T2); the flat\n  ``work_ref`` filter on :class:`AuditQueryFilters` is exact-match.\n* ``principal_name`` \u2190 ``payload['principal_name']`` when set. The MCP\n  audit-write helper (``write_mcp_audit_row``) populates it from\n  ``Operator.name`` since G0.15-T3 #1212; HTTP-chassis rows remain\n  None pending a separate fix to bind ``name`` to contextvars in\n  ``verify_jwt_and_bind``.\n* ``broadcast_event_id`` \u2014 v0.2 placeholder, always None (FK direction\n  is reversed: ``BroadcastEvent.audit_id`` points at the audit row)."
       },
       "AuditQueryRequest": {
         "properties": {
@@ -11060,6 +11142,12 @@
             "format": "uuid",
             "nullable": true,
             "title": "Agent Session Id"
+          },
+          "work_ref": {
+            "type": "string",
+            "maxLength": 256,
+            "nullable": true,
+            "title": "Work Ref"
           },
           "limit": {
             "type": "integer",
@@ -14673,6 +14761,11 @@
             "nullable": true,
             "title": "Agent Session Id"
           },
+          "work_ref": {
+            "type": "string",
+            "nullable": true,
+            "title": "Work Ref"
+          },
           "broadcast_event_id": {
             "type": "string",
             "format": "uuid",
@@ -14711,6 +14804,7 @@
           "result_status",
           "parent_audit_id",
           "agent_session_id",
+          "work_ref",
           "broadcast_event_id",
           "depth"
         ],

--- a/cli/internal/api/client.gen.go
+++ b/cli/internal/api/client.gen.go
@@ -880,6 +880,9 @@ type ApproveResponseBody_DispatchResult struct {
 //   - “op_id“ / “op_class“ / “result_status“ — computed at query time
 //   - “parent_audit_id“ ← “audit_log.parent_audit_id“ (lineage; #398)
 //   - “agent_session_id“ ← “audit_log.agent_session_id“ (MCP session; #1009)
+//   - “work_ref“ ← “audit_log.work_ref“ (external change-ticket reference;
+//     work_ref I1-T1 #1655). NULL until a bind source lands (I1-T2); the flat
+//     “work_ref“ filter on :class:`AuditQueryFilters` is exact-match.
 //   - “principal_name“ ← “payload['principal_name']“ when set. The MCP
 //     audit-write helper (“write_mcp_audit_row“) populates it from
 //     “Operator.name“ since G0.15-T3 #1212; HTTP-chassis rows remain
@@ -907,6 +910,7 @@ type AuditEntry struct {
 	TargetName       *string                `json:"target_name"`
 	TenantId         *openapi_types.UUID    `json:"tenant_id"`
 	Ts               time.Time              `json:"ts"`
+	WorkRef          *string                `json:"work_ref"`
 }
 
 // AuditQueryRequest POST body for “/api/v1/audit/query“.
@@ -935,6 +939,7 @@ type AuditQueryRequest struct {
 	Since          *string             `json:"since"`
 	Target         *string             `json:"target"`
 	Until          *string             `json:"until"`
+	WorkRef        *string             `json:"work_ref"`
 }
 
 // AuditQueryResult Page of audit rows plus the forward-only continuation cursor.
@@ -3345,6 +3350,7 @@ type ReplayNode struct {
 	TargetName       *string                `json:"target_name"`
 	TenantId         *openapi_types.UUID    `json:"tenant_id"`
 	Ts               time.Time              `json:"ts"`
+	WorkRef          *string                `json:"work_ref"`
 }
 
 // RetireChecklistReport Top-level shape returned by :func:`compute_retire_checklist`.
@@ -5207,6 +5213,13 @@ type RejectApprovalRequestApiV1ApprovalsRequestIdRejectPostParams struct {
 	Authorization *string `json:"authorization,omitempty"`
 }
 
+// ByWorkRefApiV1AuditByWorkRefRefGetParams defines parameters for ByWorkRefApiV1AuditByWorkRefRefGet.
+type ByWorkRefApiV1AuditByWorkRefRefGetParams struct {
+	Since         *string `form:"since,omitempty" json:"since,omitempty"`
+	Limit         *int    `form:"limit,omitempty" json:"limit,omitempty"`
+	Authorization *string `json:"authorization,omitempty"`
+}
+
 // MyRecentApiV1AuditMyRecentGetParams defines parameters for MyRecentApiV1AuditMyRecentGet.
 type MyRecentApiV1AuditMyRecentGetParams struct {
 	Since *string `form:"since,omitempty" json:"since,omitempty"`
@@ -7025,6 +7038,9 @@ type ClientInterface interface {
 
 	RejectApprovalRequestApiV1ApprovalsRequestIdRejectPost(ctx context.Context, requestId openapi_types.UUID, params *RejectApprovalRequestApiV1ApprovalsRequestIdRejectPostParams, body RejectApprovalRequestApiV1ApprovalsRequestIdRejectPostJSONRequestBody, reqEditors ...RequestEditorFn) (*http.Response, error)
 
+	// ByWorkRefApiV1AuditByWorkRefRefGet request
+	ByWorkRefApiV1AuditByWorkRefRefGet(ctx context.Context, ref string, params *ByWorkRefApiV1AuditByWorkRefRefGetParams, reqEditors ...RequestEditorFn) (*http.Response, error)
+
 	// MyRecentApiV1AuditMyRecentGet request
 	MyRecentApiV1AuditMyRecentGet(ctx context.Context, params *MyRecentApiV1AuditMyRecentGetParams, reqEditors ...RequestEditorFn) (*http.Response, error)
 
@@ -7964,6 +7980,18 @@ func (c *Client) RejectApprovalRequestApiV1ApprovalsRequestIdRejectPostWithBody(
 
 func (c *Client) RejectApprovalRequestApiV1ApprovalsRequestIdRejectPost(ctx context.Context, requestId openapi_types.UUID, params *RejectApprovalRequestApiV1ApprovalsRequestIdRejectPostParams, body RejectApprovalRequestApiV1ApprovalsRequestIdRejectPostJSONRequestBody, reqEditors ...RequestEditorFn) (*http.Response, error) {
 	req, err := NewRejectApprovalRequestApiV1ApprovalsRequestIdRejectPostRequest(c.Server, requestId, params, body)
+	if err != nil {
+		return nil, err
+	}
+	req = req.WithContext(ctx)
+	if err := c.applyEditors(ctx, req, reqEditors); err != nil {
+		return nil, err
+	}
+	return c.Client.Do(req)
+}
+
+func (c *Client) ByWorkRefApiV1AuditByWorkRefRefGet(ctx context.Context, ref string, params *ByWorkRefApiV1AuditByWorkRefRefGetParams, reqEditors ...RequestEditorFn) (*http.Response, error) {
+	req, err := NewByWorkRefApiV1AuditByWorkRefRefGetRequest(c.Server, ref, params)
 	if err != nil {
 		return nil, err
 	}
@@ -11733,6 +11761,93 @@ func NewRejectApprovalRequestApiV1ApprovalsRequestIdRejectPostRequestWithBody(se
 	}
 
 	req.Header.Add("Content-Type", contentType)
+
+	if params != nil {
+
+		if params.Authorization != nil {
+			var headerParam0 string
+
+			headerParam0, err = runtime.StyleParamWithLocation("simple", false, "authorization", runtime.ParamLocationHeader, *params.Authorization)
+			if err != nil {
+				return nil, err
+			}
+
+			req.Header.Set("authorization", headerParam0)
+		}
+
+	}
+
+	return req, nil
+}
+
+// NewByWorkRefApiV1AuditByWorkRefRefGetRequest generates requests for ByWorkRefApiV1AuditByWorkRefRefGet
+func NewByWorkRefApiV1AuditByWorkRefRefGetRequest(server string, ref string, params *ByWorkRefApiV1AuditByWorkRefRefGetParams) (*http.Request, error) {
+	var err error
+
+	var pathParam0 string
+
+	pathParam0, err = runtime.StyleParamWithLocation("simple", false, "ref", runtime.ParamLocationPath, ref)
+	if err != nil {
+		return nil, err
+	}
+
+	serverURL, err := url.Parse(server)
+	if err != nil {
+		return nil, err
+	}
+
+	operationPath := fmt.Sprintf("/api/v1/audit/by-work-ref/%s", pathParam0)
+	if operationPath[0] == '/' {
+		operationPath = "." + operationPath
+	}
+
+	queryURL, err := serverURL.Parse(operationPath)
+	if err != nil {
+		return nil, err
+	}
+
+	if params != nil {
+		queryValues := queryURL.Query()
+
+		if params.Since != nil {
+
+			if queryFrag, err := runtime.StyleParamWithLocation("form", true, "since", runtime.ParamLocationQuery, *params.Since); err != nil {
+				return nil, err
+			} else if parsed, err := url.ParseQuery(queryFrag); err != nil {
+				return nil, err
+			} else {
+				for k, v := range parsed {
+					for _, v2 := range v {
+						queryValues.Add(k, v2)
+					}
+				}
+			}
+
+		}
+
+		if params.Limit != nil {
+
+			if queryFrag, err := runtime.StyleParamWithLocation("form", true, "limit", runtime.ParamLocationQuery, *params.Limit); err != nil {
+				return nil, err
+			} else if parsed, err := url.ParseQuery(queryFrag); err != nil {
+				return nil, err
+			} else {
+				for k, v := range parsed {
+					for _, v2 := range v {
+						queryValues.Add(k, v2)
+					}
+				}
+			}
+
+		}
+
+		queryURL.RawQuery = queryValues.Encode()
+	}
+
+	req, err := http.NewRequest("GET", queryURL.String(), nil)
+	if err != nil {
+		return nil, err
+	}
 
 	if params != nil {
 
@@ -20752,6 +20867,9 @@ type ClientWithResponsesInterface interface {
 
 	RejectApprovalRequestApiV1ApprovalsRequestIdRejectPostWithResponse(ctx context.Context, requestId openapi_types.UUID, params *RejectApprovalRequestApiV1ApprovalsRequestIdRejectPostParams, body RejectApprovalRequestApiV1ApprovalsRequestIdRejectPostJSONRequestBody, reqEditors ...RequestEditorFn) (*RejectApprovalRequestApiV1ApprovalsRequestIdRejectPostResponse, error)
 
+	// ByWorkRefApiV1AuditByWorkRefRefGetWithResponse request
+	ByWorkRefApiV1AuditByWorkRefRefGetWithResponse(ctx context.Context, ref string, params *ByWorkRefApiV1AuditByWorkRefRefGetParams, reqEditors ...RequestEditorFn) (*ByWorkRefApiV1AuditByWorkRefRefGetResponse, error)
+
 	// MyRecentApiV1AuditMyRecentGetWithResponse request
 	MyRecentApiV1AuditMyRecentGetWithResponse(ctx context.Context, params *MyRecentApiV1AuditMyRecentGetParams, reqEditors ...RequestEditorFn) (*MyRecentApiV1AuditMyRecentGetResponse, error)
 
@@ -21835,6 +21953,29 @@ func (r RejectApprovalRequestApiV1ApprovalsRequestIdRejectPostResponse) Status()
 
 // StatusCode returns HTTPResponse.StatusCode
 func (r RejectApprovalRequestApiV1ApprovalsRequestIdRejectPostResponse) StatusCode() int {
+	if r.HTTPResponse != nil {
+		return r.HTTPResponse.StatusCode
+	}
+	return 0
+}
+
+type ByWorkRefApiV1AuditByWorkRefRefGetResponse struct {
+	Body         []byte
+	HTTPResponse *http.Response
+	JSON200      *AuditQueryResult
+	JSON422      *HTTPValidationError
+}
+
+// Status returns HTTPResponse.Status
+func (r ByWorkRefApiV1AuditByWorkRefRefGetResponse) Status() string {
+	if r.HTTPResponse != nil {
+		return r.HTTPResponse.Status
+	}
+	return http.StatusText(0)
+}
+
+// StatusCode returns HTTPResponse.StatusCode
+func (r ByWorkRefApiV1AuditByWorkRefRefGetResponse) StatusCode() int {
 	if r.HTTPResponse != nil {
 		return r.HTTPResponse.StatusCode
 	}
@@ -25408,6 +25549,15 @@ func (c *ClientWithResponses) RejectApprovalRequestApiV1ApprovalsRequestIdReject
 	return ParseRejectApprovalRequestApiV1ApprovalsRequestIdRejectPostResponse(rsp)
 }
 
+// ByWorkRefApiV1AuditByWorkRefRefGetWithResponse request returning *ByWorkRefApiV1AuditByWorkRefRefGetResponse
+func (c *ClientWithResponses) ByWorkRefApiV1AuditByWorkRefRefGetWithResponse(ctx context.Context, ref string, params *ByWorkRefApiV1AuditByWorkRefRefGetParams, reqEditors ...RequestEditorFn) (*ByWorkRefApiV1AuditByWorkRefRefGetResponse, error) {
+	rsp, err := c.ByWorkRefApiV1AuditByWorkRefRefGet(ctx, ref, params, reqEditors...)
+	if err != nil {
+		return nil, err
+	}
+	return ParseByWorkRefApiV1AuditByWorkRefRefGetResponse(rsp)
+}
+
 // MyRecentApiV1AuditMyRecentGetWithResponse request returning *MyRecentApiV1AuditMyRecentGetResponse
 func (c *ClientWithResponses) MyRecentApiV1AuditMyRecentGetWithResponse(ctx context.Context, params *MyRecentApiV1AuditMyRecentGetParams, reqEditors ...RequestEditorFn) (*MyRecentApiV1AuditMyRecentGetResponse, error) {
 	rsp, err := c.MyRecentApiV1AuditMyRecentGet(ctx, params, reqEditors...)
@@ -27889,6 +28039,39 @@ func ParseRejectApprovalRequestApiV1ApprovalsRequestIdRejectPostResponse(rsp *ht
 	switch {
 	case strings.Contains(rsp.Header.Get("Content-Type"), "json") && rsp.StatusCode == 200:
 		var dest RejectResponseBody
+		if err := json.Unmarshal(bodyBytes, &dest); err != nil {
+			return nil, err
+		}
+		response.JSON200 = &dest
+
+	case strings.Contains(rsp.Header.Get("Content-Type"), "json") && rsp.StatusCode == 422:
+		var dest HTTPValidationError
+		if err := json.Unmarshal(bodyBytes, &dest); err != nil {
+			return nil, err
+		}
+		response.JSON422 = &dest
+
+	}
+
+	return response, nil
+}
+
+// ParseByWorkRefApiV1AuditByWorkRefRefGetResponse parses an HTTP response from a ByWorkRefApiV1AuditByWorkRefRefGetWithResponse call
+func ParseByWorkRefApiV1AuditByWorkRefRefGetResponse(rsp *http.Response) (*ByWorkRefApiV1AuditByWorkRefRefGetResponse, error) {
+	bodyBytes, err := io.ReadAll(rsp.Body)
+	defer func() { _ = rsp.Body.Close() }()
+	if err != nil {
+		return nil, err
+	}
+
+	response := &ByWorkRefApiV1AuditByWorkRefRefGetResponse{
+		Body:         bodyBytes,
+		HTTPResponse: rsp,
+	}
+
+	switch {
+	case strings.Contains(rsp.Header.Get("Content-Type"), "json") && rsp.StatusCode == 200:
+		var dest AuditQueryResult
 		if err := json.Unmarshal(bodyBytes, &dest); err != nil {
 			return nil, err
 		}

--- a/cli/internal/cmd/audit/query.go
+++ b/cli/internal/cmd/audit/query.go
@@ -35,6 +35,7 @@ import (
 //	  [--audit-id ID]              # exact-id lookup
 //	  [--parent-audit-id ID]       # v0.2 substrate rejects (400)
 //	  [--session-id ID]            # narrow to one agent session (UUID)
+//	  [--work-ref REF]             # exact change-ticket ref: gh:evoila/meho#1
 //	  [--json]                     # raw AuditQueryResult JSON
 //	  [--backplane <url>]          # override the configured backplane
 //
@@ -59,6 +60,7 @@ func newQueryCmd() *cobra.Command {
 		auditID           string
 		parentAuditID     string
 		sessionID         string
+		workRef           string
 		jsonOut           bool
 		backplaneOverride string
 	)
@@ -90,6 +92,7 @@ func newQueryCmd() *cobra.Command {
 				AuditID:           auditID,
 				ParentAuditID:     parentAuditID,
 				SessionID:         sessionID,
+				WorkRef:           workRef,
 				JSONOut:           jsonOut,
 				BackplaneOverride: backplaneOverride,
 			})
@@ -120,6 +123,9 @@ func newQueryCmd() *cobra.Command {
 			"(v0.2 substrate rejects with 400; column lands with G0.6-T7 #398)")
 	cmd.Flags().StringVar(&sessionID, "session-id", "",
 		"narrow to one agent session (UUID); the flat companion to `meho audit replay`")
+	cmd.Flags().StringVar(&workRef, "work-ref", "",
+		"narrow to one external change-ticket reference (exact match; "+
+			"e.g. gh:evoila/meho#1) — \"show every write authorised by ticket X\"")
 	cmd.Flags().BoolVar(&jsonOut, "json", false,
 		"emit raw AuditQueryResult JSON instead of the human table")
 	cmd.Flags().StringVar(&backplaneOverride, "backplane", "",
@@ -140,6 +146,7 @@ type queryOptions struct {
 	AuditID           string
 	ParentAuditID     string
 	SessionID         string
+	WorkRef           string
 	JSONOut           bool
 	BackplaneOverride string
 }
@@ -264,6 +271,10 @@ func buildAuditQueryRequest(opts queryOptions) (api.AuditQueryRequest, error) {
 		}
 		uu := openapi_types.UUID(u)
 		body.AgentSessionId = &uu
+	}
+	if opts.WorkRef != "" {
+		v := opts.WorkRef
+		body.WorkRef = &v
 	}
 	if opts.Limit > 0 {
 		l := opts.Limit

--- a/cli/internal/cmd/audit/query_test.go
+++ b/cli/internal/cmd/audit/query_test.go
@@ -110,6 +110,7 @@ func TestBuildAuditQueryRequestEveryFlagLandsOnWire(t *testing.T) {
 		AuditID:       "00000000-0000-0000-0000-000000000001",
 		ParentAuditID: "00000000-0000-0000-0000-000000000002",
 		SessionID:     "00000000-0000-0000-0000-000000000003",
+		WorkRef:       "gh:evoila/meho#1",
 		Limit:         50,
 		Cursor:        "opaque-cursor-bytes",
 	}
@@ -133,6 +134,7 @@ func TestBuildAuditQueryRequestEveryFlagLandsOnWire(t *testing.T) {
 		`"audit_id":"00000000-0000-0000-0000-000000000001"`,
 		`"parent_audit_id":"00000000-0000-0000-0000-000000000002"`,
 		`"agent_session_id":"00000000-0000-0000-0000-000000000003"`,
+		`"work_ref":"gh:evoila/meho#1"`,
 		`"limit":50`,
 		`"cursor":"opaque-cursor-bytes"`,
 	} {

--- a/docs/codebase/audit_query.md
+++ b/docs/codebase/audit_query.md
@@ -28,6 +28,7 @@ this package never inserts, updates, or deletes.
 | `audit_id` | `UUID \| None` | Exact-id lookup. |
 | `parent_audit_id` | `UUID \| None` | **Raises `UnsupportedFilterError`** — the flat filter stays gated (un-gating is out of scope for #377). The column itself (#398) *is* read onto the returned row and is walked by the replay CTE. |
 | `agent_session_id` | `UUID \| None` | `audit_log.agent_session_id = :value`. Un-gated by G8.2-T3 (#1011); the column landed with G8.2-T1 (#1009). |
+| `work_ref` | `str \| None` | `audit_log.work_ref = :value` — **exact match** (a change-ticket reference is an opaque identifier, not a search term, so deterministic equality per #1177, not `ILIKE`). Filterable + surfaced since work_ref I1-T3 (#1658); the column landed with work_ref I1-T1 (#1655, migration `0039`). NULL rows are excluded. |
 | `limit` | `int` (1-1000) | Default 100. |
 | `cursor` | `str \| None` | Opaque forward-only cursor produced by a prior page. |
 
@@ -55,6 +56,7 @@ Field-to-source mapping:
 | `principal_name` | `payload['principal_name']` when present (MCP rows since G0.15-T3 #1212; `write_mcp_audit_row` merges `Operator.name` from the validated JWT). HTTP-chassis rows remain `None` — the `verify_jwt_and_bind` middleware does not bind `name` to contextvars, so the audit middleware sees no source for it. |
 | `parent_audit_id` | `audit_log.parent_audit_id` — composite-operation lineage column (G0.6-T7 #398, migration `0006`). Surfaced on the row since G8.2-T3 (#1011); the flat *filter* on it stays gated. |
 | `agent_session_id` | `audit_log.agent_session_id` — MCP-session correlation column (G8.2-T1 #1009, migration `0014`). Surfaced + filterable since G8.2-T3 (#1011). |
+| `work_ref` | `audit_log.work_ref` — external change-ticket reference (work_ref I1-T1 #1655, migration `0039`). An opaque string (e.g. `"gh:evoila/meho#1"`) correlating a governed operation to the out-of-band change record that authorised it. Surfaced + exact-match-filterable since work_ref I1-T3 (#1658). NULL until a bind source lands (I1-T2); system-internal writers leave it NULL by design. |
 | `broadcast_event_id` | **None in v0.2** — FK direction is reversed: `BroadcastEvent.audit_id` points at the audit row. |
 
 The three computed fields use exactly the same rules
@@ -83,6 +85,7 @@ query_audit(filters, tenant_id, session)
   │     WHERE audit_log.tenant_id = :tenant_id      ← always first
   │       [+ audit_id = :audit_id]
   │       [+ agent_session_id = :agent_session_id]
+  │       [+ work_ref = :work_ref]                              ← exact match
   │       [+ operator_sub ILIKE :principal]
   │       [+ occurred_at >= :since]
   │       [+ occurred_at <= :until]
@@ -109,6 +112,7 @@ query_audit(filters, tenant_id, session)
   │   └─ AuditEntry(... real cols ..., op_id, op_class, result_status,
   │                 parent_audit_id=row.parent_audit_id,
   │                 agent_session_id=row.agent_session_id,
+  │                 work_ref=row.work_ref,
   │                 principal_name=principal_name, broadcast_event_id=None)
   │
   └─ next_cursor = encode_cursor(CursorPosition(ts=last.ts, id=last.id))
@@ -163,9 +167,9 @@ node and a `query_audit` row for the same audit id agree field-for-field.
 
 ## REST surface (G8.1-T2 #466, G8.2-T4 #1012)
 
-The five routes under `backend/src/meho_backplane/api/v1/audit.py` are the
-operator-facing entry into the substrate. The first four dispatch through
-`query_audit`; the fifth (replay) dispatches through `replay_session`. All
+The six routes under `backend/src/meho_backplane/api/v1/audit.py` are the
+operator-facing entry into the substrate. The first five dispatch through
+`query_audit`; the sixth (replay) dispatches through `replay_session`. All
 pass `tenant_id=operator.tenant_id` (from the JWT) — the substrate's
 tenant-scoping invariant is enforced one layer up.
 
@@ -173,6 +177,7 @@ tenant-scoping invariant is enforced one layer up.
 |---|---|---|
 | `POST /api/v1/audit/query` | Body is `AuditQueryRequest`; `since` / `until` are strings parsed at the router via `parse_duration` (`"24h"` / `"7d"` / ISO-8601). Client-supplied `tenant_id` (or any other unknown field) is rejected with 422 `extra_forbidden` (`AuditQueryRequest.model_config` sets `extra="forbid"`, G0.9-T2 / #729); the route never reads tenant from the body — it always passes `operator.tenant_id` from the JWT to the substrate. | Full-filter surface. |
 | `GET /api/v1/audit/who-touched/{target}` | Path param becomes `filters.target`; `since` query defaults to `"24h"`. | Pre-canned shortcut. |
+| `GET /api/v1/audit/by-work-ref/{ref}` | Path param (`{ref:path}` converter — a work_ref carries embedded slashes, `#` is percent-encoded) becomes `filters.work_ref` (exact match); `since` query has **no** default window (a change-ticket lookup wants the whole governed history of the ref, not just the last 24h). The "show every write authorised by ticket X" lookup (work_ref I1-T3 #1658). | Pre-canned shortcut. |
 | `GET /api/v1/audit/my-recent` | `filters.principal = operator.sub`; `since` query defaults to `"24h"`. | Pre-canned shortcut. |
 | `GET /api/v1/audit/show/{audit_id}` | `filters.audit_id = <path>`, `limit=1`. Substrate returns 0 rows for cross-tenant lookups → router raises **404** (not 403) so existence never leaks. | Single-row fetch. |
 | `GET /api/v1/audit/sessions/{session_id}/replay` | Dispatches `replay_session(session_id, tenant_id=operator.tenant_id, ...)`. 200 body is `AuditReplayResult` (`{root: [ReplayNode], session_id, tenant_id, row_count}`). Unknown / foreign session → `root=[]` / `row_count=0` (**not** 404 — same non-leakage as `show`). `row_count > 10_000` → **413** `{"detail": "session_too_large", "row_count": n}` from a count-first guard run *before* the recursive tree build. | Per-session replay (G8.2-T4). |


### PR DESCRIPTION
## Summary

- Completes the **read surface** for the `audit_log.work_ref` column landed by work_ref I1-T1 (#1655): `query_audit` can now both **filter** by `work_ref` and **surface** it on every returned row — the headline "show every write authorised by ticket X" use case. Deliberately not left half-wired like `actor_sub` / `run_id` / `step_id` (indexed columns that are neither flat-filterable nor surfaced on `AuditEntry`).
- Adds `work_ref: str | None` to `AuditQueryFilters` + `AuditQueryRequest`; an exact-match `WHERE work_ref = :value` arm in `_apply_filters` (mirroring `agent_session_id` — a change-ticket ref is an opaque identifier, not a search term, so deterministic equality per #1177, not `ILIKE`; NULL rows excluded); `work_ref` on `AuditEntry`, populated in `_build_audit_entry`. `ReplayNode` inherits it via its `model_dump()` splat — no `replay.py` change.
- Adds the optional `GET /api/v1/audit/by-work-ref/{ref}` convenience route (per the issue's Desired state), mirroring `who_touched`. Uses the `{ref:path}` converter because a work_ref carries embedded slashes (`gh:evoila/meho#1`); no default `since` window — a ticket lookup wants the whole governed history.
- CLI: `meho audit query --work-ref <ref>` (hand-written flag → generated request body). OpenAPI snapshot re-generated (`make snapshot-openapi && make generate`); the typed Go client now carries `WorkRef` + the `ByWorkRef*` operation.

## Test plan

- [x] `ruff check` / `ruff format --check` (changed files) — clean
- [x] `mypy src/` — clean (469 source files)
- [x] **New** `test_work_ref_filter_exact_match_excludes_others_and_null` — `query_audit(work_ref="gh:evoila/meho#1")` returns only the exact-matching row, excludes a different `work_ref` and a NULL `work_ref`
- [x] **New** `test_work_ref_surfaced_on_every_returned_entry` — every returned `AuditEntry` carries its row's `work_ref` verbatim (the surfacing guard against the half-wired failure mode)
- [x] **New** `test_by_work_ref_builds_exact_work_ref_filter` — the route binds `filters.work_ref` from the path param, with no default `since` window
- [x] **New** CLI assertion — `--work-ref` round-trips onto the wire as `"work_ref":"gh:evoila/meho#1"`
- [x] `meho audit query --help` shows `--work-ref`; CLI builds + full `go test ./...` green
- [x] Full backend unit suite (`pytest --ignore=tests/integration`) green; 3 `AuditEntry` + 2 `ReplayNode` test doubles updated for the new required field
- [x] OpenAPI snapshot regen committed — `CLI API snapshot freshness` lane will be clean
- [x] `docs/codebase/audit_query.md` updated (filters table, AuditEntry table, control-flow, REST routes table)

## Out of scope

- The bind sources (work_ref I1-T2); approval/run-object filters (I2 / I3) — each owns its own list-surface filter.
- Enforcement; ranking/scoring (the filter is deterministic exact-match, per #1177).

<!-- auto-implement-issue: fresh, iteration 1 -->

Closes #1658
