### PR TITLE
fix(ui): dashboard feed tray subscribes to the session-gated SSE bridge (#1696)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -189,6 +189,16 @@ connector-related release-notes line.
   `/ui/auth/login?return_to=<page>` with the dead cookie cleared
   instead of a JSON error page. Session and CSRF cookies are never
   rotated by a refresh, so already-open pages keep working (#1694)
+- Operator console: the dashboard's "Recent activity" tray streamed
+  nothing (permanent "Connecting to live feed…" placeholder) because it
+  subscribed to the Bearer-only `/api/v1/feed`, which the browser's
+  `EventSource` can never authenticate against (no `Authorization`
+  header support — each attempt 401'd and reconnect-looped); the tray
+  now subscribes to the session-gated `/ui/broadcast/stream` bridge the
+  broadcast surface already uses (same cookie boundary as the page
+  itself) and renders the live `BroadcastEvent` frames as
+  time/principal/op/status rows through the XSS-safe Alpine sink
+  pattern, capped at 50 in-DOM rows (#1696)
 
 ## [0.14.0] - 2026-06-12
 

--- a/backend/src/meho_backplane/ui/routes/broadcast/stream.py
+++ b/backend/src/meho_backplane/ui/routes/broadcast/stream.py
@@ -22,11 +22,12 @@ browser pointing ``sse-connect`` at ``/api/v1/feed`` would be answered
 with a 401 and the SSE state machine would tighten into a reconnect
 loop.
 
-The chassis dashboard's recent-activity snippet (#866) wired
-``sse-connect="/api/v1/feed"`` directly; that wiring is inert for the
-same reason (and the snippet only renders a "Connecting..." placeholder
-today). G10.1's live feed is the first surface that must *actually*
-stream, so it routes through this UI-owned bridge instead.
+The chassis dashboard's recent-activity snippet (#866) originally
+wired ``sse-connect="/api/v1/feed"`` directly; that wiring was inert
+for the same reason and the snippet never left its "Connecting..."
+placeholder. G10.1's live feed was the first surface to route through
+this UI-owned bridge instead; G0.25 (#1696) re-pointed the dashboard
+tray here too, so every browser-side subscriber now rides this route.
 
 This route lives under ``/ui/`` so the existing
 :class:`~meho_backplane.ui.auth.middleware.UISessionMiddleware` gates it
@@ -235,10 +236,10 @@ def build_stream_router() -> APIRouter:
     """Construct the broadcast SSE-bridge :class:`APIRouter`.
 
     Registers ``GET /ui/broadcast/stream`` -- the session-gated SSE
-    source the live feed subscribes to. The route name
-    (``ui_broadcast_stream``) is referenced by the feed template's
-    ``sse-connect`` URL; a rename here must update the template in
-    lockstep.
+    source the live feed, the connectors recent-ops card, and the
+    dashboard recent-activity tray (#1696) subscribe to. The path is
+    referenced by those templates' ``sse-connect`` URLs; a rename here
+    must update them in lockstep.
     """
     router = APIRouter(tags=["ui-broadcast"])
 

--- a/backend/src/meho_backplane/ui/routes/dashboard.py
+++ b/backend/src/meho_backplane/ui/routes/dashboard.py
@@ -10,15 +10,21 @@ renders three components per the Initiative work-item #6:
   routes G10.1-G10.5 fill in. The sixth tile is a static
   "deploy details" card so the grid layout is balanced without a
   trailing empty slot.
-* A live recent-activity snippet wired to ``/api/v1/feed`` via the
-  HTMX 2 SSE extension (``hx-ext="sse"`` + ``sse-connect="..."`` +
-  ``sse-swap="broadcast"``). The feed endpoint validates the JWT via
-  the Bearer header on ``/api/v1/feed``; the dashboard surface only
-  renders the HTMX wiring -- the actual subscription happens
-  browser-side once the page loads (and the operator's session cookie
-  is the auth boundary that gates ``/ui/``). Trimming the rendered
-  tray to the last N events is G10.1 (#338) client-side surface work;
-  the underlying feed endpoint streams the live tail unbounded.
+* A live recent-activity snippet wired to the session-gated SSE
+  bridge ``/ui/broadcast/stream`` (G0.25 #1696). The chassis
+  originally pointed ``sse-connect`` at the Bearer-authenticated
+  ``/api/v1/feed``, but the browser's ``EventSource`` cannot send an
+  ``Authorization`` header (the WHATWG constructor exposes only
+  ``withCredentials``), so that wiring 401-looped and the tray never
+  left its "Connecting..." placeholder. The bridge lives under
+  ``/ui/`` where the operator's session cookie -- the same boundary
+  that gated this page render -- authenticates the stream. Frames are
+  consumed through the hidden-sink + Alpine pattern the broadcast and
+  connectors surfaces established (``dashboardFeedTray`` in
+  ``static/src/app/dashboard-feed.js``): the controller cancels the
+  extension's raw swap and renders each ``BroadcastEvent`` JSON frame
+  through ``x-text`` bindings, which keeps markup-bearing event
+  fields inert instead of letting the swap parse them into live DOM.
 * A version + readiness card sourced from the deployed-build label the
   chassis Jinja env binds as the ``app_version`` global -- the same
   ``CHART_VERSION`` / ``GIT_SHA`` env metadata ``GET /version`` reads
@@ -52,7 +58,10 @@ References
   https://htmx.org/extensions/sse/
 * Chassis ``base.html`` reference (sidebar links, version footer):
   ``backend/src/meho_backplane/ui/templates/base.html``
-* Per-tenant SSE feed endpoint (G6.1-T4, #310):
+* Session-gated SSE bridge (G10.1-T1, #867) the tray subscribes to:
+  ``backend/src/meho_backplane/ui/routes/broadcast/stream.py``
+* Canonical per-tenant SSE feed the bridge stays byte-compatible
+  with (G6.1-T4, #310):
   ``backend/src/meho_backplane/api/v1/feed.py``
 """
 
@@ -118,6 +127,28 @@ _SURFACE_TILES: Final[tuple[dict[str, str], ...]] = (
 )
 
 
+#: The session-gated SSE bridge the recent-activity tray subscribes to
+#: (G0.25 #1696). NOT ``/api/v1/feed`` -- the browser ``EventSource``
+#: cannot send the Bearer header that endpoint requires, so the
+#: original wiring 401-looped forever; see the rationale in
+#: :mod:`meho_backplane.ui.routes.broadcast.stream` and the matching
+#: ``_STREAM_ENDPOINT`` constant in
+#: :mod:`meho_backplane.ui.routes.broadcast.feed`. The dashboard
+#: subscribes to the unfiltered live tail (no query parameters) --
+#: filtering is the broadcast surface's affordance.
+_FEED_STREAM_ENDPOINT: Final[str] = "/ui/broadcast/stream"
+
+#: Hard cap on the number of event rows the tray keeps in the DOM at
+#: once, passed to the ``dashboardFeedTray`` Alpine controller. The
+#: tray is a glance surface (~12 visible rows under its ``max-h-72``
+#: scroll box), so the connectors recent-ops default (50) is the right
+#: order of magnitude -- enough scroll-back to be useful, bounded so an
+#: all-day dashboard tab can't grow the DOM unboundedly. The richer
+#: bounded-tray UX (row counters, trim affordances) is G10.1 (#338)
+#: surface work per #1696's out-of-scope.
+_FEED_TRAY_DOM_CAP: Final[int] = 50
+
+
 async def _readiness_snapshot() -> dict[str, object]:
     """Project the chassis readiness-probe results into the dashboard shape.
 
@@ -159,16 +190,15 @@ async def _render_dashboard(
         "operator_sub": session.operator_sub,
         "tenant_id": str(session.tenant_id),
         "csrf_token": csrf_token,
-        # Endpoint the HTMX SSE snippet subscribes to. Lifted out so a
+        # Endpoint the HTMX SSE sink subscribes to. Lifted out so a
         # future deploy can swap to a CDN-hosted edge proxy without
-        # editing the template. ``/api/v1/feed`` is the canonical
-        # tenant-scoped SSE stream from G6.1-T4 (#310); the route does
-        # not accept a ``limit`` query parameter (FastAPI silently
-        # ignores unknown query params, so a hardcoded ``?limit=5``
-        # would be a no-op surface promise), so the dashboard subscribes
-        # to the full live stream. Trimming the tray to the last N
-        # events client-side is G10.1 (#338) surface work.
-        "feed_endpoint": "/api/v1/feed",
+        # editing the template. The session-gated bridge streams the
+        # tenant's live tail scoped by the validated session -- no
+        # tenant or limit query parameters exist on the route, so the
+        # tray subscribes bare and bounds itself client-side via
+        # ``feed_tray_cap``.
+        "feed_endpoint": _FEED_STREAM_ENDPOINT,
+        "feed_tray_cap": _FEED_TRAY_DOM_CAP,
     }
     response = get_templates().TemplateResponse(request, "dashboard.html", context)
     # Mirror the SameSite + Secure posture of the session cookie. The

--- a/backend/src/meho_backplane/ui/static/src/app/dashboard-feed.js
+++ b/backend/src/meho_backplane/ui/static/src/app/dashboard-feed.js
@@ -1,0 +1,88 @@
+// SPDX-License-Identifier: Apache-2.0
+// Copyright (c) 2026 evoila Group
+//
+// Dashboard recent-activity tray Alpine controller (G0.25 #1696).
+// Registers on ``alpine:init`` so the ``x-data="dashboardFeedTray(...)"``
+// wrapper in ``dashboard.html`` resolves to this component. Loaded via
+// ``<script src=... defer>`` from the page's HEAD-level
+// ``component_scripts`` block, which renders BEFORE
+// ``vendor/alpine.min.js`` -- deferred scripts execute in document
+// order, and Alpine's CDN bundle auto-starts in a microtask at the end
+// of its own script task, so this listener must already be registered
+// by then or the component never registers (#1692). Kept in a static
+// file rather than an inline ``<script>`` block so a future nonce-based
+// CSP needs no inline-script exception -- matching the chassis
+// ``base.html`` "zero inline script" posture.
+//
+// Responsibilities:
+//   * Subscribe (indirectly) to the session-gated SSE bridge: the HTMX
+//     ``sse`` extension owns the EventSource pointed at
+//     ``/ui/broadcast/stream``; this controller hooks
+//     ``htmx:sseBeforeMessage`` to parse each ``event: broadcast``
+//     frame and route it into the ``events`` array instead of letting
+//     the extension swap the raw JSON text into the DOM. The
+//     ``preventDefault()`` is load-bearing twice over: the raw frame
+//     is unreadable as tray content, and an event field containing
+//     markup would otherwise be parsed into live DOM by the swap
+//     (the same injection class the broadcast surface closed in
+//     PR #1044) -- ``x-text`` bindings render every field inert.
+//   * Prepend newest-first and trim to the in-DOM cap so an all-day
+//     dashboard tab doesn't grow the tray unboundedly -- same hygiene
+//     as ``connectors-feed.js`` (cap 50) and ``broadcast-feed.js``
+//     (cap 1000). The richer bounded-tray surface work (row counters,
+//     filters) stays with G10.1 follow-ups per #1696's out-of-scope.
+//
+// Wire-shape note
+//   The bridge validates every stream entry as a ``BroadcastEvent``
+//   (G6.1) before emitting, so each frame's JSON carries:
+//     { kind, event_id, ts, tenant_id, principal_sub, principal_name,
+//       target_name, op_id, op_class, result_status, audit_id,
+//       payload }
+//   The tray renders the compact subset (ts / principal_sub / op_id /
+//   result_status) directly -- no projection step like the connectors
+//   recent-ops card needs, because the tray's row shape is the wire
+//   shape.
+
+document.addEventListener("alpine:init", () => {
+  Alpine.data("dashboardFeedTray", (opts) => ({
+    // Fills from the SSE stream only -- the dashboard tray has no
+    // server-seeded rows (the bridge's backlog prelude replays recent
+    // history into a fresh connection, so a quiet-but-nonempty tenant
+    // still paints rows immediately).
+    events: [],
+    connected: false,
+    cap: typeof opts.cap === "number" && opts.cap > 0 ? opts.cap : 50,
+
+    // Parse one SSE ``event: broadcast`` frame and prepend it, trimming
+    // to the in-DOM cap. Mirrors ``connectors-feed.js``: bad JSON (a
+    // mid-stream truncation, an upstream serialisation glitch) is
+    // dropped silently rather than thrown into the user-visible
+    // surface -- a single bad frame must not break the live tray.
+    onSseMessage($event) {
+      const raw = $event && $event.detail && $event.detail.data;
+      if (!raw) {
+        return;
+      }
+      $event.preventDefault();
+      let frame;
+      try {
+        frame = JSON.parse(raw);
+      } catch {
+        return;
+      }
+      this.events.unshift(frame);
+      if (this.events.length > this.cap) {
+        this.events.length = this.cap;
+      }
+    },
+
+    // Locale time string for the row timestamp; falls back to the raw
+    // ISO value if it can't be parsed. Same helper shape as
+    // ``broadcast-feed.js`` -- the tray is a same-day glance surface,
+    // so the time alone is the right density.
+    formatTs(ts) {
+      const d = new Date(ts);
+      return isNaN(d.getTime()) ? ts : d.toLocaleTimeString();
+    },
+  }));
+});

--- a/backend/src/meho_backplane/ui/templates/dashboard.html
+++ b/backend/src/meho_backplane/ui/templates/dashboard.html
@@ -17,31 +17,46 @@
       (5 cols). Below: live-feed tray (8) + readiness checks (4).
       Cards stagger in via the CSS-only ``meho-reveal`` animation.
     * The live recent-activity snippet -- HTMX SSE extension
-      subscribes to /api/v1/feed and swaps events into the
-      ``#meho-feed-tray`` container as they arrive. Pre-render
-      placeholder text covers the SSE-not-yet-connected window.
-      (Trim-to-last-N is G10.1 client-side surface work; the feed
-      endpoint streams the live tail.)
+      subscribes to the session-gated /ui/broadcast/stream bridge
+      (#1696; the Bearer-only /api/v1/feed is unreachable for
+      EventSource, which cannot send an Authorization header). A
+      hidden sink + the ``dashboardFeedTray`` Alpine controller
+      consume the BroadcastEvent JSON frames and render them as
+      x-text-bound rows in ``#meho-feed-tray`` -- the same
+      raw-swap-cancelling pattern as the broadcast + connectors
+      surfaces, so markup-bearing event fields stay inert text.
+      Pre-render placeholder copy covers the SSE-not-yet-connected
+      window; the controller trims the tray to ``feed_tray_cap``
+      rows (richer bounded-tray UX is G10.1 surface work).
 -#}
 {% extends "base.html" %}
 {% from "_icons.html" import icon %}
+
+{#-
+  Registers the ``dashboardFeedTray`` Alpine component. Injected into
+  the head-level ``component_scripts`` block so it executes BEFORE
+  ``vendor/alpine.min.js`` (deferred scripts run in document order):
+  the controller registers on ``alpine:init``, and Alpine's CDN bundle
+  fires that event from a microtask at the end of its own script task
+  -- a body-end script registers the listener too late and the
+  ``x-data="dashboardFeedTray(...)"`` wrapper stays dead (#1692).
+-#}
+{% block component_scripts %}
+  <script src="/ui/static/src/app/dashboard-feed.js" defer></script>
+{% endblock %}
 
 {% block page_title %}MEHO Operator Console{% endblock %}
 
 {% block content %}
 {#-
-  HTMX 2 SSE extension wiring (https://htmx.org/extensions/sse/) --
-  ``hx-ext="sse"`` activates the extension on the wrapper element;
-  ``sse-connect`` points at the SSE endpoint;
-  ``sse-swap="broadcast"`` listens for ``event: broadcast`` frames the
-  feed emits per G6.1-T4 (#310) and swaps the data payload into
-  ``#meho-feed-tray``. The ``hx-headers`` on the wrapper forwards
-  the CSRF token on any state-changing HTMX request anywhere in this
-  page subtree.
+  The ``hx-headers`` on the wrapper forwards the CSRF token on any
+  state-changing HTMX request anywhere in this page subtree. The SSE
+  wiring lives on the recent-activity tray's hidden sink below --
+  ``hx-ext="sse"`` + ``sse-connect`` belong on the same element per
+  https://htmx.org/extensions/sse/.
 -#}
 <section
   class="space-y-8"
-  hx-ext="sse"
   hx-headers='{"X-CSRF-Token": "{{ csrf_token }}"}'
 >
 
@@ -123,10 +138,21 @@
   {# -------- Live feed tray + readiness, side by side -------- #}
   <div class="grid grid-cols-1 gap-4 lg:grid-cols-12">
 
-    {# Live feed snippet (HTMX SSE). #}
+    {# Live feed snippet (HTMX SSE via the session-gated bridge, #1696).
+       The section is the ``dashboardFeedTray`` component root: the
+       htmx:sse-* events dispatched on the hidden sink bubble up to the
+       Alpine listeners here. ``onSseMessage`` cancels the extension's
+       raw swap (BroadcastEvent JSON must never be parsed into DOM) and
+       prepends the frame to ``events``; rows render through ``x-text``
+       bindings only, so operator-influenced event fields stay inert
+       text -- mirrors broadcast/_feed.html + connectors/_recent_ops.html. #}
     <section
       class="meho-card meho-reveal col-span-1 lg:col-span-8"
       aria-label="Recent broadcast events (live)"
+      x-data='dashboardFeedTray({ cap: {{ feed_tray_cap }} })'
+      x-on:htmx:sse-before-message="onSseMessage($event)"
+      x-on:htmx:sse-open="connected = true"
+      x-on:htmx:sse-error="connected = false"
     >
       <div class="flex h-full flex-col p-5">
         <div class="flex items-baseline justify-between gap-4">
@@ -138,16 +164,45 @@
             Open broadcast surface {{ icon("arrow-right", class="size-3") }}
           </a>
         </div>
+
+        {# SSE sink -- the extension binds the EventSource here and owns
+           reconnect/backoff (Last-Event-Id replay rides on the bridge's
+           ``id:`` lines exactly as on the broadcast surface). #}
+        <div
+          hx-ext="sse"
+          sse-connect="{{ feed_endpoint }}"
+          sse-swap="broadcast"
+          class="hidden"
+          aria-hidden="true"
+        ></div>
+
         <ul
           id="meho-feed-tray"
           class="mt-3 max-h-72 divide-y divide-base-content/6 overflow-y-auto overflow-x-hidden font-mono text-xs leading-6 text-base-content/70 [overflow-wrap:anywhere]"
-          sse-connect="{{ feed_endpoint }}"
-          sse-swap="broadcast"
-          hx-swap="afterbegin"
+          aria-live="polite"
         >
-          <li class="py-2 text-base-content/50">
+          {# Server-rendered copy covers the pre-Alpine window; once the
+             controller mounts, x-text keeps the copy in step with the
+             connection state until the first frame hides the row. #}
+          <li
+            x-show="events.length === 0"
+            class="py-2 text-base-content/50"
+            x-text="connected ? 'Connected — waiting for activity…' : 'Connecting to live feed…'"
+          >
             Connecting to live feed&hellip;
           </li>
+          <template x-for="ev in events" :key="ev.event_id">
+            <li class="flex items-center gap-2 py-1.5">
+              <time
+                class="shrink-0 text-base-content/50"
+                x-bind:datetime="ev.ts"
+                x-text="formatTs(ev.ts)"
+              ></time>
+              <span class="max-w-40 shrink-0 truncate text-base-content/50" x-text="ev.principal_sub"></span>
+              <span class="min-w-0 truncate" x-text="ev.op_id"></span>
+              <span class="ml-auto shrink-0 text-base-content/50" x-text="ev.result_status"></span>
+            </li>
+          </template>
         </ul>
       </div>
     </section>

--- a/backend/tests/test_ui_chassis_smoke.py
+++ b/backend/tests/test_ui_chassis_smoke.py
@@ -385,14 +385,23 @@ def test_dashboard_authenticated_renders_console_html() -> None:
     # rebrand replaced DaisyUI's ``card``/``card-body`` shell).
     # Five surface cards + one deploy card = 6 card blocks.
     assert body.count("meho-card") >= 6
-    # HTMX SSE wiring on the recent-activity tray. The dashboard
-    # subscribes to ``/api/v1/feed`` with no query parameters; the
-    # feed endpoint (G6.1-T4 #310) does not accept a ``limit`` knob
-    # and FastAPI silently drops unknown query params, so any
-    # ``?limit=N`` here would only be a no-op surface promise. Trim-
-    # to-last-N is G10.1 (#338) client-side surface work.
-    assert 'sse-connect="/api/v1/feed"' in body
+    # HTMX SSE wiring on the recent-activity tray (G0.25 #1696). The
+    # tray subscribes to the session-gated bridge -- NOT the
+    # Bearer-only ``/api/v1/feed``, which a browser ``EventSource``
+    # can never authenticate against (no Authorization header
+    # support), so the old wiring 401-looped behind its
+    # "Connecting..." placeholder forever.
+    assert 'sse-connect="/ui/broadcast/stream"' in body
     assert 'sse-swap="broadcast"' in body
+    assert 'sse-connect="/api/v1/feed"' not in body
+    # Frames are consumed via the hidden-sink + Alpine pattern (raw
+    # BroadcastEvent JSON must never be swapped into the DOM): the
+    # component wrapper, its head-level controller script (#1692
+    # ordering seam), and the pre-render placeholder all render
+    # server-side.
+    assert "dashboardFeedTray({" in body
+    assert '<script src="/ui/static/src/app/dashboard-feed.js" defer></script>' in body
+    assert "Connecting to live feed" in body
     # Version footer renders the deployed-build label the chassis env
     # binds from CHART_VERSION / GIT_SHA (#1698). No hardcoded ``v``
     # prefix anymore -- the label carries its own when it is a release

--- a/docs/codebase/ui.md
+++ b/docs/codebase/ui.md
@@ -51,7 +51,7 @@ Locked decisions:
 | `meho_backplane.ui.auth.flow` | OAuth 2.1 + PKCE client primitives layered on authlib's `AsyncOAuth2Client`. `build_authorization_request` mints the Keycloak redirect URL (S256 PKCE + RFC 8707 `resource` parameter) and registers the per-flow verifier in a server-side `PKCEVerifierStore`. `exchange_code_for_tokens` pops the verifier and exchanges code+verifier at the token endpoint. `resolve_oidc_endpoints` caches the discovery doc on the same TTL the JWKS cache uses. |
 | `meho_backplane.ui.auth.routes` | FastAPI `APIRouter` for `/ui/auth/{login,callback,logout}`. `build_router()` returns the router for T5 to mount. Callback verifies the access token through the chassis JWT chain (`verify_jwt_for_audience`) so the BFF inherits issuer / audience / sub / tenant_id / tenant_role checks. Sets `meho_session` cookie with `HttpOnly; Secure; SameSite=Strict; Path=/`. Logout revokes the session, clears the cookie, and 302s to Keycloak's `end_session_endpoint` (best-effort -- a missing endpoint falls back to a local `/ui/auth/login` redirect). |
 | `meho_backplane.ui.auth.middleware` | Pure-ASGI `UISessionMiddleware` for `/ui/*`. Loads operator identity from the session cookie on every request; 302s to login on missing/expired session. Bypasses `/ui/static/*` (chassis assets) and `/ui/auth/*` (the BFF surfaces themselves). Per-request `UISessionContext` (frozen dataclass: `session_id`, `operator_sub`, `tenant_id`, plus `tenant_slug` + `tenant_name` populated from a same-transaction `tenant` PK lookup added by G0.15-T9 #1217) lands on `request.state.ui_session`; route handlers read it via `Depends(require_ui_session)`. `require_ui_admin` (the write-route RBAC gate) loads + verifies the stored access token through `meho_backplane.ui.auth.refresh`, so expired tokens silently refresh instead of 401ing (G0.25 #1694). |
-| `meho_backplane.ui.auth.refresh` | Inline token-refresh lifecycle (G0.25 #1694). `load_fresh_session` (proactive: refresh when the row is within 60 s of `expires_at`), `verify_access_token_with_refresh` (reactive: refresh once on the JWT chain's `token_expired`, re-verify), both funnelling into `refresh_session_tokens` -- the `SELECT ... FOR UPDATE`-serialised chokepoint that POSTs the RFC 6749 § 6 refresh grant (single attempt, 5 s timeout) and rotates the row via `rotate_refresh` (RFC 9700 § 4.14). Concurrent refreshes: first wins; the loser observes the rotated pair under the lock and skips its network call. Failures log `ui_auth_token_refresh_failed` (reason: `invalid_grant` / `network_error` / `timeout` / `malformed_response`) and raise `401 session_expired`; successes log `ui_auth_token_refresh_succeeded` (session_id, old/new expires_at, time_cost_ms). No token material in logs. The refresh performs zero `Set-Cookie` operations -- `meho_session` and `meho_csrf` stay byte-identical, so in-flight pages and their CSRF tokens survive a rotation (no #1706-class cookie desync). This is the session seam the dashboard-feed proxy (#1696) builds on. |
+| `meho_backplane.ui.auth.refresh` | Inline token-refresh lifecycle (G0.25 #1694). `load_fresh_session` (proactive: refresh when the row is within 60 s of `expires_at`), `verify_access_token_with_refresh` (reactive: refresh once on the JWT chain's `token_expired`, re-verify), both funnelling into `refresh_session_tokens` -- the `SELECT ... FOR UPDATE`-serialised chokepoint that POSTs the RFC 6749 § 6 refresh grant (single attempt, 5 s timeout) and rotates the row via `rotate_refresh` (RFC 9700 § 4.14). Concurrent refreshes: first wins; the loser observes the rotated pair under the lock and skips its network call. Failures log `ui_auth_token_refresh_failed` (reason: `invalid_grant` / `network_error` / `timeout` / `malformed_response`) and raise `401 session_expired`; successes log `ui_auth_token_refresh_succeeded` (session_id, old/new expires_at, time_cost_ms). No token material in logs. The refresh performs zero `Set-Cookie` operations -- `meho_session` and `meho_csrf` stay byte-identical, so in-flight pages and their CSRF tokens survive a rotation (no #1706-class cookie desync). The seam serves **token-presenting** dependencies (`require_ui_admin` today); the dashboard-feed fix (#1696) needed no new caller here — it re-pointed the tray at the existing session-gated `/ui/broadcast/stream` bridge, which reads Valkey directly under `require_ui_session` and never presents the access token. |
 | `meho_backplane.ui.auth.errors` | App-level `HTTPException` handler registered in `main.py` for the whole app (G0.25 #1694). Intercepts exactly `401 session_expired` on `/ui/*`: HTML requests (`Accept: text/html`) get `302 /ui/auth/login?return_to=<path>` + `meho_session` cookie clear; non-HTML callers keep the JSON body (cookie cleared too). Every other HTTPException delegates byte-for-byte to FastAPI's stock `http_exception_handler`, so `/api/*` 401 codes are untouched. |
 
 The Jinja2 `Environment` is a module-level singleton (constructed on
@@ -424,16 +424,21 @@ Initiative #337 work-item #6:
 * A 3x2 grid of DaisyUI `card` tiles linking to the five surface
   routes. The sixth tile shows the backplane version + readiness
   badge sourced from `meho_backplane.health.run_probes_async`.
-* A live "recent activity" snippet wired to `/api/v1/feed` via the
-  HTMX 2 SSE extension (`hx-ext="sse"` + `sse-connect="..."` +
-  `sse-swap="broadcast"`). The feed endpoint itself runs the chassis
-  JWT dependency, but the browser carries the session cookie and the
-  same operator's JWT will be issued by Keycloak; G10.1 (`#338`)
-  wires the live-token round-trip and the client-side
-  trim-to-last-N rendering (the feed endpoint streams the live tail
-  unbounded -- it does not accept a `limit` query parameter, so a
-  hardcoded `?limit=N` would be a silent no-op given FastAPI's
-  unknown-query-param drop semantics).
+* A live "recent activity" snippet wired to the session-gated SSE
+  bridge `/ui/broadcast/stream` (G0.25 `#1696`; the chassis
+  originally pointed at the Bearer-only `/api/v1/feed`, which a
+  browser `EventSource` can never authenticate against — no
+  `Authorization` header support — so that wiring 401-looped behind
+  its "Connecting…" placeholder). Frames are consumed through the
+  same hidden-sink + Alpine pattern as the broadcast and connectors
+  surfaces: `hx-ext="sse"` + `sse-connect` + `sse-swap="broadcast"`
+  sit on a hidden sink, and the `dashboardFeedTray` controller
+  (`static/src/app/dashboard-feed.js`, registered on `alpine:init`
+  from the head-level `component_scripts` block per #1692) cancels
+  the raw swap on `htmx:sse-before-message`, parses the
+  `BroadcastEvent` JSON, and renders time / principal / op_id /
+  result_status rows via `x-text` bindings (markup-bearing event
+  fields stay inert), trimmed to a 50-row in-DOM cap.
 * A "readiness checks" panel listing every registered probe with a
   green/orange pill matching `/ready`'s shape.
 
@@ -634,9 +639,10 @@ constructor exposes only `withCredentials`); it sends cookies, not a
 Bearer token. So pointing `sse-connect` at `/api/v1/feed` from a
 logged-in operator's browser would be answered with a 401 and the SSE
 state machine would tighten into a reconnect loop. (The chassis
-dashboard's recent-activity snippet wired `sse-connect="/api/v1/feed"`
-directly for the same reason it only shows a "Connecting…" placeholder —
-that snippet is inert today; fixing it is tracked separately.)
+dashboard's recent-activity snippet originally wired
+`sse-connect="/api/v1/feed"` directly and was inert for exactly this
+reason — it never left its "Connecting…" placeholder until G0.25
+`#1696` re-pointed it at this bridge.)
 
 The broadcast view instead subscribes to `/ui/broadcast/stream`, a
 UI-owned route under `/ui/` so the existing `UISessionMiddleware` gates


### PR DESCRIPTION
## Summary

- Re-points the dashboard's "Recent activity" tray from the Bearer-only `/api/v1/feed` to the session-gated `/ui/broadcast/stream` bridge (RDC v0.14.0 cycle-10 Finding FE-5). A browser `EventSource` cannot send an `Authorization` header (WHATWG constructor exposes only `withCredentials`), so the old wiring 401-looped forever behind its "Connecting to live feed…" placeholder; the bridge sits behind the same `meho_session` cookie boundary that authenticated the page render, so the subscription now succeeds with zero extra auth round-trips.
- Consumes the frames through the codebase's established hidden-sink + Alpine pattern (new `dashboardFeedTray` controller in `static/src/app/dashboard-feed.js`, mirroring `connectors-feed.js`): the controller cancels the extension's raw swap on `htmx:sse-before-message` and renders each `BroadcastEvent` JSON frame as a compact time / principal / op_id / result_status row via `x-text` bindings. This is load-bearing, not cosmetic — a bare endpoint repoint would have the htmx SSE extension parse raw JSON frames into the DOM as HTML (`hx-swap="afterbegin"` on the old tray), which both renders as unreadable JSON soup and revives the PR #1044-class injection vector for markup-bearing event fields. `x-text` keeps every field inert by construction.
- The controller script loads from the head-level `component_scripts` block (#1692 ordering seam, registered on `alpine:init`), and the tray bounds itself at 50 in-DOM rows — the same defensive hygiene both existing consumers of this pattern carry (`connectors-feed.js` cap 50, `broadcast-feed.js` cap 1000).
- Updates the now-stale "dashboard wiring is inert" notes in `broadcast/stream.py` + `docs/codebase/ui.md`, and corrects ui.md's "#1696 builds on the refresh seam" sentence: no token-presenting proxy was needed — the bridge reads Valkey directly under `require_ui_session` and never presents the access token, so the #1711 refresh-seam constraints (`load_fresh_session` / `verify_access_token_with_refresh` / `SESSION_EXPIRED_DETAIL` / zero-`Set-Cookie`) are not triggered by this change.

## Constraints from PR #1711 (`constraints_for_1696`)

| Constraint | Disposition |
| --- | --- |
| `load_fresh_session` + `verify_access_token_with_refresh` for token-presenting proxy routes | n/a — no new route; the existing bridge presents no token upstream (direct Valkey read scoped by the validated session) |
| Import `SESSION_EXPIRED_DETAIL`, never re-spell | n/a — no code path in this diff touches the 401 shape |
| Zero `Set-Cookie` on refresh success | unaffected — refresh module untouched |
| Terminal refresh failure = JSON 401 + cookie clear, not 302 | unaffected — the tray's failure mode on an expired session matches the broadcast surface exactly (EventSource fails on the login redirect's non-`text/event-stream` response; extension backs off; any page navigation re-auths via the middleware) |
| Single refresh attempt per request | n/a — no refresh caller added |
| New `expires_at` pre-checking callers must thread `now=` | n/a — no new `rotate_refresh` caller |

## Test plan

- [x] `ruff check` + `ruff format --check` — clean (src + tests)
- [x] `mypy src/` — strict, 471 files, 0 issues
- [x] Targeted UI suites: `test_ui_chassis_smoke.py` + `test_ui_broadcast_feed.py` + `test_ui_broadcast_filters.py` + `test_ui_broadcast_wall_replay.py` + `test_ui_connectors_view.py` + `test_ui_tenant_chip.py` — 108 passed, 1 skipped
- [x] Full backend unit sweep (`pytest tests/ -n 6 --dist loadscope --ignore=tests/integration`) — green (see CI)
- [x] `python3 .claude/hooks/code-quality.py --diff` — 0 blockers (1 pre-existing PLR0913 warning in `stream.py`, untouched function)
- [x] OpenAPI surface unchanged — regenerated via `cli/api/snapshot-openapi.py` and byte-diffed against the committed `cli/api/openapi.json`: identical (no CLI snapshot regen needed)
- [x] AC1 `feed_endpoint` → `/ui/broadcast/stream`: `_FEED_STREAM_ENDPOINT` constant + smoke-test assertion `sse-connect="/ui/broadcast/stream"` (and a regression pin that `/api/v1/feed` no longer appears)
- [x] AC2 widget renders live events: sink + controller + `x-for` row path asserted server-side (`dashboardFeedTray({`, controller `<script>` tag, placeholder copy); the render path is byte-identical in mechanism to the dogfood-verified broadcast + connectors consumers — browser-level confirmation lands with the next RDC cycle per the initiative DoD
- [x] AC3 no EventSource 401s: the subscription targets the cookie-gated route; the existing `test_ui_broadcast_feed.py` suite covers session-cookie connect (200 + `text/event-stream`) and the unauthenticated 302 boundary
- [x] AC4 `/ui/broadcast` unaffected: only docstrings changed in `broadcast/stream.py`; all broadcast suites green
- [x] AC5 reconnect / `Last-Event-Id` replay identical: bridge mechanics untouched; the sink pattern leaves EventSource ownership (and its reconnect/backoff + `id:` cursor replay) with the htmx SSE extension, exactly as on the broadcast surface

## Out of scope

- G10.1-style surface work on the tray (richer bounded-tray UX, filter bar, wall-monitor layout) — per the issue's out-of-scope list. The 50-row in-DOM cap is not that work item: it is the standing hygiene of the sink-controller pattern this fix had to adopt anyway (both existing controllers carry one), preventing unbounded DOM growth on the landing page.
- A "navigate to login on terminal stream failure" client affordance: the dashboard tray inherits the broadcast surface's behavior (stream goes quiet; the next navigation or htmx request re-auths via the middleware). Changing that contract belongs to a follow-up that would touch all three stream consumers together.
- Known shared trait (pre-existing, all three consumers): an extension-level reconnect that replaces the EventSource loses the `Last-Event-Id` cursor and replays the backlog prelude, which can transiently produce duplicate `event_id` keys in the Alpine `x-for`. Identical on `/ui/broadcast` and the connectors card today; if it ever bites, dedup-on-unshift in the shared controllers is the one-line fix.

<!-- auto-implement-issue: fresh, iteration 1 -->

Closes #1696
