### PR TITLE
feat(approvals): work_ref I2-T1 — approval_request.work_ref column + filter + re-dispatch inheritance

### DIFF
--- a/backend/alembic/versions/0040_add_approval_request_work_ref.py
+++ b/backend/alembic/versions/0040_add_approval_request_work_ref.py
@@ -1,0 +1,79 @@
+# SPDX-License-Identifier: Apache-2.0
+# Copyright (c) 2026 evoila Group
+
+"""Add ``approval_request.work_ref`` for external change-ticket correlation.
+
+Revision ID: 0040
+Revises: 0039
+Create Date: 2026-06-13
+
+Task #1659 (work_ref I2-T1) under Initiative #1653, Goal #1651. A parked
+approval -- the durable change-authorisation record -- carried no link to
+the out-of-band ticket that authorised the change. Migration ``0039``
+added ``audit_log.work_ref`` (I1-T1 #1655); this migration extends the
+same opaque reference onto the ``approval_request`` row so the parked
+request, its decision audit row, and the re-dispatched op's audit rows
+all share one change-ticket ref.
+
+What this migration adds
+------------------------
+
+* ``approval_request.work_ref text`` -- nullable. The external
+  change-ticket reference for the dispatch that parked the request --
+  a GitHub issue (``"gh:evoila/meho#1"``), a Jira key, a CR id. Set at
+  creation from the request-time
+  :data:`meho_backplane.operations._audit.work_ref_var` binding (the same
+  ContextVar mechanism that carries ``run_id``), re-bound on re-dispatch
+  so the approved op's audit rows inherit the ref. ``NULL`` when no
+  work_ref was bound -- pre-#1659 rows and direct operator dispatches
+  without a ticket stay ``NULL``. No backfill.
+* ``approval_request_work_ref_idx`` -- b-tree index on the new column,
+  for the ``meho approvals list --work-ref gh:evoila/meho#N`` filter.
+
+Why no foreign key / NOT NULL
+-----------------------------
+
+Same soft-column discipline as ``audit_log.work_ref`` (0039),
+``run_id`` (0017 mirror), and ``target_id`` (0004): nullable, no server
+default (the ORM ``default`` of ``None`` works on both PG and SQLite),
+no FK clause -- the migration is trivially reversible on a populated
+table. ``work_ref`` is an opaque cross-system reference string, not a
+row id in this schema, so there is no table to point a FK at.
+
+Reversibility contract
+----------------------
+
+``downgrade()`` reverses ``upgrade()`` in order: drop the index, then
+the column. Pure generic SQLAlchemy DDL, portable across PG and SQLite.
+"""
+
+from collections.abc import Sequence
+
+import sqlalchemy as sa
+from alembic import op
+
+# revision identifiers, used by Alembic.
+revision: str = "0040"
+down_revision: str | None = "0039"
+branch_labels: str | Sequence[str] | None = None
+depends_on: str | Sequence[str] | None = None
+
+
+def upgrade() -> None:
+    """Add ``approval_request.work_ref`` column + named index."""
+    op.add_column(
+        "approval_request",
+        sa.Column("work_ref", sa.Text(), nullable=True),
+    )
+    op.create_index(
+        "approval_request_work_ref_idx",
+        "approval_request",
+        ["work_ref"],
+        postgresql_using="btree",
+    )
+
+
+def downgrade() -> None:
+    """Reverse the upgrade -- drop the index and column."""
+    op.drop_index("approval_request_work_ref_idx", table_name="approval_request")
+    op.drop_column("approval_request", "work_ref")

--- a/backend/src/meho_backplane/api/v1/approvals.py
+++ b/backend/src/meho_backplane/api/v1/approvals.py
@@ -114,6 +114,7 @@ class ApprovalRequestView(BaseModel):
     decided_at: str | None
     created_at: str
     expires_at: str | None
+    work_ref: str | None
 
 
 class ApproveRequestBody(BaseModel):
@@ -187,6 +188,7 @@ def _view(row: ApprovalRequest) -> ApprovalRequestView:
         decided_at=row.decided_at.isoformat() if row.decided_at else None,
         created_at=row.created_at.isoformat(),
         expires_at=row.expires_at.isoformat() if row.expires_at else None,
+        work_ref=row.work_ref,
     )
 
 
@@ -285,13 +287,23 @@ async def list_approvals(
             "Filter by status. One of: pending, approved, rejected, expired. Defaults to 'pending'."
         ),
     ),
+    work_ref: str | None = Query(
+        default=None,
+        description=(
+            "Filter by external change-ticket reference (exact match), e.g. "
+            "'gh:evoila/meho#1' — the requests authorised by change ticket X "
+            "(work_ref I2-T1 #1659). Omit for no work_ref filter."
+        ),
+    ),
     operator: Operator = _require_operator,
 ) -> list[ApprovalRequestView]:
     """List approval requests for the operator's tenant.
 
     Defaults to listing only ``pending`` requests. Supports filtering
     by status via ``?status=approved`` / ``?status=rejected`` /
-    ``?status=expired``. Returns newest-first (``created_at DESC``).
+    ``?status=expired`` and by change ticket via
+    ``?work_ref=gh:evoila/meho#1`` (exact match). Returns newest-first
+    (``created_at DESC``).
     """
     structlog.contextvars.bind_contextvars(
         audit_op_id="approval.list",
@@ -312,8 +324,10 @@ async def list_approvals(
             select(ApprovalRequest)
             .where(ApprovalRequest.tenant_id == operator.tenant_id)
             .where(ApprovalRequest.status == status_filter.value)
-            .order_by(ApprovalRequest.created_at.desc())
         )
+        if work_ref is not None:
+            stmt = stmt.where(ApprovalRequest.work_ref == work_ref)
+        stmt = stmt.order_by(ApprovalRequest.created_at.desc())
         result = await session.execute(stmt)
         rows = list(result.scalars().all())
 

--- a/backend/src/meho_backplane/db/models.py
+++ b/backend/src/meho_backplane/db/models.py
@@ -4026,12 +4026,23 @@ class ApprovalRequest(Base):
     * ``expires_at`` -- ``timestamptz`` nullable. Expiry deadline; NULL
       means no deadline.
 
+    * ``work_ref`` -- Text nullable. The external change-ticket reference
+      that authorised the dispatch (work_ref I2-T1 #1659) -- an opaque
+      string such as ``"gh:evoila/meho#1"``, captured at creation from
+      :data:`meho_backplane.operations._audit.work_ref_var` (the same
+      ContextVar that carries the value onto ``audit_log.work_ref``, 0039
+      / #1655). Re-bound from this row on re-dispatch so the approved
+      op's audit rows inherit the ref. NULL when no work_ref was bound.
+      No FK -- same soft-reference discipline as ``run_id`` / ``target_id``.
+      Added by migration ``0040``.
+
     Indexes
     -------
 
     * ``approval_request_tenant_created_at_idx`` -- ``(tenant_id, created_at)``.
     * ``approval_request_status_idx`` -- ``status``.
     * ``approval_request_run_id_idx`` -- ``run_id``.
+    * ``approval_request_work_ref_idx`` -- ``work_ref``.
     """
 
     __tablename__ = "approval_request"
@@ -4103,6 +4114,17 @@ class ApprovalRequest(Base):
         nullable=True,
         default=None,
     )
+    # External change-ticket reference (work_ref I2-T1 #1659). Set at
+    # creation from the request-time work_ref_var binding (same ContextVar
+    # mechanism as run_id / audit_log.work_ref); re-bound from this row on
+    # re-dispatch so the approved op's audit rows inherit the ref. NULL
+    # when no work_ref is bound. No FK -- opaque cross-system string.
+    # Added by migration 0040.
+    work_ref: Mapped[str | None] = mapped_column(
+        Text,
+        nullable=True,
+        default=None,
+    )
 
     __table_args__ = (
         Index(
@@ -4119,6 +4141,11 @@ class ApprovalRequest(Base):
         Index(
             "approval_request_run_id_idx",
             "run_id",
+            postgresql_using="btree",
+        ),
+        Index(
+            "approval_request_work_ref_idx",
+            "work_ref",
             postgresql_using="btree",
         ),
         sa.CheckConstraint(

--- a/backend/src/meho_backplane/mcp/tools/approvals.py
+++ b/backend/src/meho_backplane/mcp/tools/approvals.py
@@ -157,6 +157,7 @@ def _row_to_dict(row: ApprovalRequest) -> dict[str, Any]:
         "decided_at": row.decided_at.isoformat() if row.decided_at else None,
         "expires_at": row.expires_at.isoformat() if row.expires_at else None,
         "created_at": row.created_at.isoformat() if row.created_at else None,
+        "work_ref": row.work_ref,
     }
 
 
@@ -213,6 +214,12 @@ async def _list_handler(
             ) from exc
     limit = int(arguments.get("limit", 50))
     offset = int(arguments.get("offset", 0))
+    work_ref_raw = arguments.get("work_ref")
+    work_ref_filter: str | None = None
+    if work_ref_raw is not None:
+        if not isinstance(work_ref_raw, str) or not work_ref_raw:
+            raise McpInvalidParamsError("work_ref must be a non-empty string when supplied")
+        work_ref_filter = work_ref_raw
 
     sessionmaker = get_sessionmaker()
     async with sessionmaker() as session:
@@ -220,6 +227,7 @@ async def _list_handler(
             session,
             tenant_id=operator.tenant_id,
             status=status_filter,
+            work_ref=work_ref_filter,
             limit=limit,
             offset=offset,
         )
@@ -266,6 +274,15 @@ register_mcp_tool(
                     "minimum": 0,
                     "default": 0,
                     "description": "Rows to skip before the first returned row. Default 0.",
+                },
+                "work_ref": {
+                    "type": "string",
+                    "description": (
+                        "Filter by external change-ticket reference (exact "
+                        "match), e.g. 'gh:evoila/meho#1' — the requests "
+                        "authorised by change ticket X (work_ref I2-T1 "
+                        "#1659). Omit for no work_ref filter."
+                    ),
                 },
             },
             "additionalProperties": False,

--- a/backend/src/meho_backplane/operations/approval_queue.py
+++ b/backend/src/meho_backplane/operations/approval_queue.py
@@ -73,6 +73,7 @@ from meho_backplane.db.models import (
     ApprovalRequestStatus,
     AuditLog,
 )
+from meho_backplane.operations._audit import work_ref_var
 from meho_backplane.operations._errors import result_denied
 from meho_backplane.operations._validate import compute_params_hash
 
@@ -241,6 +242,14 @@ async def _write_audit_row(
         request_id=None,
         duration_ms=Decimal(str(round(duration_ms, 2))),
         payload=payload,
+        # work_ref I2-T1 (#1659): stamp the authorising change-ticket ref
+        # straight off the request row rather than re-reading work_ref_var.
+        # The approval-request and decision audit rows are written from the
+        # request's own lifecycle (create, then a later approve/reject on a
+        # different operator's task whose var is unset), so the row is the
+        # durable source of truth -- it keeps both audit rows aligned with
+        # the value the request was parked under.
+        work_ref=request.work_ref,
     )
     session.add(row)
     await session.flush()
@@ -317,6 +326,11 @@ async def create_pending_request(
     # dead code — ``Operator`` has no such field, so it was always ``None``.
     principal_act: str | None = resolve_actor_sub()
 
+    # External change-ticket ref (work_ref I2-T1 #1659): read from the
+    # same request-time ContextVar the audit writers read (bound at the
+    # transport/agent boundary, #1657), so the parked request, its
+    # decision audit row, and the re-dispatched op all carry one ref.
+    # NULL when nothing bound it.
     request = ApprovalRequest(
         id=uuid.uuid4(),
         tenant_id=operator.tenant_id,
@@ -332,6 +346,7 @@ async def create_pending_request(
         status=ApprovalRequestStatus.PENDING.value,
         created_at=_now(),
         expires_at=expires_at,
+        work_ref=work_ref_var.get(),
     )
     session.add(request)
     await session.flush()
@@ -606,14 +621,27 @@ async def resume_dispatch_after_approval(
 
     from meho_backplane.operations.dispatcher import dispatch
 
-    return await dispatch(
-        operator=operator,
-        connector_id=request.connector_id,
-        op_id=request.op_id,
-        target=resolved_target,
-        params=effective_params,
-        _approved=True,
-    )
+    # Re-bind the request's stored work_ref onto the ContextVar for the
+    # re-dispatch (work_ref I2-T1 #1659). The operator decision surfaces
+    # (REST /approve, /decide, MCP by-id) run on a fresh task whose
+    # work_ref_var is unset, so the re-dispatched op's audit rows would
+    # otherwise lose the authorising ticket the parked request carried.
+    # The in-process agent-run resume path keeps its own bound var and
+    # does not call this helper, so it inherits the ref unchanged. Reset
+    # the token afterward to avoid leaking the ref onto unrelated work on
+    # the same task.
+    token = work_ref_var.set(request.work_ref)
+    try:
+        return await dispatch(
+            operator=operator,
+            connector_id=request.connector_id,
+            op_id=request.op_id,
+            target=resolved_target,
+            params=effective_params,
+            _approved=True,
+        )
+    finally:
+        work_ref_var.reset(token)
 
 
 async def _rehydrate_resume_target(
@@ -848,6 +876,7 @@ async def list_pending(
     *,
     tenant_id: uuid.UUID,
     status: str | None = "pending",
+    work_ref: str | None = None,
     limit: int = 50,
     offset: int = 0,
 ) -> list[ApprovalRequest]:
@@ -855,14 +884,19 @@ async def list_pending(
 
     G11.2-T5 (#818) read substrate. ``status=None`` returns every state;
     ``status="pending"`` (the default for the operator UX) returns only
-    requests awaiting a decision. Tenant-isolated by the WHERE clause —
-    cross-tenant ids are invisible.
+    requests awaiting a decision. ``work_ref`` (work_ref I2-T1 #1659),
+    when supplied, narrows to requests authorised by that exact external
+    change ticket (``"gh:evoila/meho#1"``); ``None`` applies no work_ref
+    filter. Tenant-isolated by the WHERE clause — cross-tenant ids are
+    invisible.
     """
     from sqlalchemy import select
 
     stmt = select(ApprovalRequest).where(ApprovalRequest.tenant_id == tenant_id)
     if status is not None:
         stmt = stmt.where(ApprovalRequest.status == status)
+    if work_ref is not None:
+        stmt = stmt.where(ApprovalRequest.work_ref == work_ref)
     stmt = stmt.order_by(ApprovalRequest.created_at.desc()).limit(limit).offset(offset)
     result = await session.execute(stmt)
     return list(result.scalars().all())

--- a/backend/tests/test_api_v1_approvals.py
+++ b/backend/tests/test_api_v1_approvals.py
@@ -195,13 +195,14 @@ async def test_resume_refuses_when_pinned_target_no_longer_resolves(
         principal_kind=PrincipalKind.USER,
     )
     # Minimal stand-in for the ApprovalRequest ORM row: the resume helper
-    # reads id / target_id / op_id / connector_id / params off it.
+    # reads id / target_id / op_id / connector_id / params / work_ref off it.
     request = SimpleNamespace(
         id=uuid.uuid4(),
         target_id=target_id,
         op_id="vault.kv.put",
         connector_id="vault-1.x",
         params={"path": "secret/x", "value": "s3cr3t"},
+        work_ref=None,
     )
 
     # The pinned target no longer resolves (soft-deleted between request
@@ -266,6 +267,7 @@ async def test_resume_dispatches_when_no_target_was_pinned(
         op_id="some.tenant_wide.op",
         connector_id="some-1.x",
         params={"k": "v"},
+        work_ref=None,
     )
 
     seen: dict[str, Any] = {}

--- a/backend/tests/test_approval_queue.py
+++ b/backend/tests/test_approval_queue.py
@@ -49,6 +49,7 @@ from meho_backplane.auth.delegation import actor_delegation
 from meho_backplane.auth.operator import Operator, PrincipalKind, TenantRole
 from meho_backplane.db.engine import get_sessionmaker
 from meho_backplane.db.models import ApprovalRequest, ApprovalRequestStatus, AuditLog
+from meho_backplane.operations._audit import work_ref_var
 from meho_backplane.operations._validate import compute_params_hash
 from meho_backplane.operations.approval_queue import (
     ApprovalNotFoundError,
@@ -59,6 +60,7 @@ from meho_backplane.operations.approval_queue import (
     approve_request,
     create_pending_request,
     expire_stale_requests,
+    list_pending,
     reject_request,
 )
 from meho_backplane.settings import get_settings
@@ -308,6 +310,117 @@ async def test_create_pending_request_sets_run_id(session: AsyncSession) -> None
     )
     await session.commit()
     assert request.run_id == run_id
+
+
+# ---------------------------------------------------------------------------
+# work_ref (I2-T1 #1659)
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.asyncio
+async def test_create_pending_request_captures_bound_work_ref(
+    session: AsyncSession,
+) -> None:
+    """A parked request captures the bound ``work_ref_var`` value.
+
+    work_ref I2-T1 #1659 AC1: a USER principal with no standing grant
+    dispatched under a bound work_ref parks an :class:`ApprovalRequest`
+    carrying the matching ``work_ref``, surfaced on the read view and the
+    MCP dict.
+    """
+    from meho_backplane.api.v1.approvals import _view
+    from meho_backplane.mcp.tools.approvals import _row_to_dict
+
+    operator = _make_operator(sub="human-sub", principal_kind=PrincipalKind.USER)
+    token = work_ref_var.set("gh:evoila/meho#1659")
+    try:
+        request = await create_pending_request(
+            session,
+            operator=operator,
+            connector_id="vault-1.x",
+            op_id="vault.kv.write",
+            target=None,
+            params={"k": "v"},
+            params_hash=compute_params_hash({"k": "v"}),
+        )
+        await session.commit()
+    finally:
+        work_ref_var.reset(token)
+
+    assert request.work_ref == "gh:evoila/meho#1659"
+    assert _view(request).work_ref == "gh:evoila/meho#1659"
+    assert _row_to_dict(request)["work_ref"] == "gh:evoila/meho#1659"
+
+
+@pytest.mark.asyncio
+async def test_create_pending_request_work_ref_null_when_unbound(
+    session: AsyncSession,
+) -> None:
+    """No bound work_ref → the parked row's ``work_ref`` is NULL."""
+    operator = _make_operator()
+    request = await create_pending_request(
+        session,
+        operator=operator,
+        connector_id="vault-1.x",
+        op_id="vault.kv.write",
+        target=None,
+        params={},
+        params_hash=compute_params_hash({}),
+    )
+    await session.commit()
+    assert request.work_ref is None
+
+
+@pytest.mark.asyncio
+async def test_list_pending_filters_by_work_ref(session: AsyncSession) -> None:
+    """``list_pending(work_ref=...)`` returns only exact-match requests.
+
+    work_ref I2-T1 #1659 AC2 (service layer behind ``meho approvals list
+    --work-ref``): an exact ``work_ref`` filter narrows to the matching
+    requests; an unrelated ref returns none.
+    """
+    operator = _make_operator()
+
+    async def _park(ref: str | None) -> None:
+        token = work_ref_var.set(ref) if ref is not None else None
+        try:
+            await create_pending_request(
+                session,
+                operator=operator,
+                connector_id="vault-1.x",
+                op_id="vault.kv.write",
+                target=None,
+                params={"r": ref},
+                params_hash=compute_params_hash({"r": ref}),
+            )
+        finally:
+            if token is not None:
+                work_ref_var.reset(token)
+
+    await _park("gh:evoila/meho#10")
+    await _park("gh:evoila/meho#20")
+    await _park(None)
+    await session.commit()
+
+    matched = await list_pending(
+        session,
+        tenant_id=_TENANT_ID,
+        status=None,
+        work_ref="gh:evoila/meho#10",
+    )
+    assert len(matched) == 1
+    assert matched[0].work_ref == "gh:evoila/meho#10"
+
+    none_matched = await list_pending(
+        session,
+        tenant_id=_TENANT_ID,
+        status=None,
+        work_ref="gh:evoila/meho#999",
+    )
+    assert none_matched == []
+
+    all_rows = await list_pending(session, tenant_id=_TENANT_ID, status=None)
+    assert len(all_rows) == 3
 
 
 # ---------------------------------------------------------------------------
@@ -1183,6 +1296,144 @@ async def test_pause_approve_resume_execute(
         _approved=True,
     )
     assert result2.status == "ok"
+
+    reset_dispatcher_caches()
+    clear_registry()
+
+
+@pytest.mark.asyncio
+async def test_work_ref_inherited_through_park_approve_redispatch(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """work_ref survives park → decide → re-dispatch onto every audit row.
+
+    work_ref I2-T1 #1659 AC3: a USER op parked under a bound work_ref,
+    approved by a different operator and re-dispatched via the shared
+    :func:`resume_dispatch_after_approval` helper, stamps the same
+    ``work_ref`` onto the decision audit row AND the re-dispatched op's
+    DISPATCH audit row — even though the approving / resuming task has no
+    work_ref bound on its own ContextVar.
+    """
+    from unittest.mock import AsyncMock
+
+    import meho_backplane.operations._audit as audit_module
+    from meho_backplane.connectors.base import Connector
+    from meho_backplane.connectors.registry import clear_registry, register_connector_v2
+    from meho_backplane.connectors.schemas import FingerprintResult, ProbeResult
+    from meho_backplane.operations import (
+        dispatch,
+        register_typed_operation,
+        reset_dispatcher_caches,
+    )
+    from meho_backplane.operations.approval_queue import resume_dispatch_after_approval
+
+    monkeypatch.setenv("KEYCLOAK_ISSUER_URL", "https://keycloak.test/realms/meho")
+    monkeypatch.setenv("KEYCLOAK_AUDIENCE", "meho-backplane")
+    monkeypatch.setenv("VAULT_ADDR", "https://vault.test")
+    get_settings.cache_clear()
+
+    async def _capture(event: Any) -> None:
+        pass
+
+    monkeypatch.setattr(audit_module, "publish_event", _capture)
+
+    reset_dispatcher_caches()
+    clear_registry()
+
+    class _OkConnector(Connector):
+        product = "reftest"
+        version = "1.x"
+        impl_id = "reftest"
+        priority = 10
+
+        async def fingerprint(self, host: str, port: int | None) -> FingerprintResult:
+            return FingerprintResult(
+                probe=ProbeResult(reachable=True, probe_method="none"),
+                product="reftest",
+                version="1.x",
+            )
+
+        async def probe(self, target: Any) -> ProbeResult:  # type: ignore[override]
+            raise NotImplementedError
+
+        async def execute(  # type: ignore[override]
+            self, target: Any, op_id: str, params: dict[str, Any]
+        ) -> Any:
+            raise NotImplementedError
+
+    register_connector_v2(product="reftest", version="", impl_id="", cls=_OkConnector)
+
+    stub_emb = AsyncMock()
+    stub_emb.encode_one.return_value = [0.1] * 384
+    stub_emb.encode.return_value = [[0.1] * 384]
+    stub_emb.dimension = 384
+
+    await register_typed_operation(
+        product="reftest",
+        version="1.x",
+        impl_id="reftest",
+        op_id="reftest.op",
+        handler=_approval_test_ok_handler,
+        summary="Test op requiring approval.",
+        description="Test.",
+        parameter_schema={"type": "object"},
+        requires_approval=True,
+        when_to_use=None,
+        embedding_service=stub_emb,
+    )
+
+    work_ref = "gh:evoila/meho#1659"
+    requester = _make_operator(sub="human-requester", principal_kind=PrincipalKind.USER)
+    params = {"x": 7}
+
+    # Step 1: park the op under a bound work_ref.
+    token = work_ref_var.set(work_ref)
+    try:
+        result1 = await dispatch(
+            operator=requester,
+            connector_id="reftest-1.x",
+            op_id="reftest.op",
+            target=None,
+            params=params,
+        )
+    finally:
+        work_ref_var.reset(token)
+    assert result1.status == "awaiting_approval"
+    approval_request_id = uuid.UUID(result1.extras["approval_request_id"])
+
+    # Step 2: a different operator approves — its task has no work_ref
+    # bound, so the decision audit row must source the ref from the row.
+    reviewer = _make_operator(sub="human-reviewer", principal_kind=PrincipalKind.USER)
+    assert work_ref_var.get() is None
+    async with get_sessionmaker()() as s:
+        approved = await approve_request(s, approval_request_id, operator=reviewer)
+        await s.commit()
+    assert approved.work_ref == work_ref
+
+    # Step 3: re-dispatch via the shared resume helper (var still unset on
+    # this task). The helper re-binds the row's work_ref around dispatch.
+    assert work_ref_var.get() is None
+    result2 = await resume_dispatch_after_approval(operator=reviewer, request=approved)
+    assert result2.status == "ok"
+    # The re-bind is scoped: the var is reset after the re-dispatch.
+    assert work_ref_var.get() is None
+
+    # Assert: the decision audit row AND the re-dispatched DISPATCH audit
+    # row both carry the work_ref.
+    async with get_sessionmaker()() as fresh:
+        decision_row = (
+            (await fresh.execute(select(AuditLog).where(AuditLog.path == "approval.decision")))
+            .scalars()
+            .one()
+        )
+        dispatch_rows = (
+            (await fresh.execute(select(AuditLog).where(AuditLog.method != "APPROVAL")))
+            .scalars()
+            .all()
+        )
+    assert decision_row.work_ref == work_ref
+    assert dispatch_rows, "expected a re-dispatched DISPATCH audit row"
+    assert all(r.work_ref == work_ref for r in dispatch_rows)
 
     reset_dispatcher_caches()
     clear_registry()

--- a/backend/tests/test_migration_0040_approval_request_work_ref.py
+++ b/backend/tests/test_migration_0040_approval_request_work_ref.py
@@ -1,0 +1,157 @@
+# SPDX-License-Identifier: Apache-2.0
+# Copyright (c) 2026 evoila Group
+
+"""Behavioural tests for Alembic migration ``0040_add_approval_request_work_ref``.
+
+Initiative #1653, Task #1659 (work_ref I2-T1). Adds the nullable
+``approval_request.work_ref`` column + its b-tree index -- the external
+change-ticket reference recorded on a parked approval. Soft-column
+discipline mirrors 0039 / 0017: nullable, no server default (Python-side
+``None``), reversible.
+
+Mirrors :mod:`tests.test_migration_0039_work_ref`; SQLite is the test
+driver and the migration uses only generic DDL, so PG parity holds.
+"""
+
+from __future__ import annotations
+
+from collections.abc import Iterator
+from pathlib import Path
+
+import pytest
+from alembic import command
+from alembic.config import Config
+from sqlalchemy import create_engine as sa_create_engine
+from sqlalchemy import text
+
+from meho_backplane.db.engine import reset_engine_for_testing
+from meho_backplane.db.migrations import alembic_config
+from meho_backplane.settings import get_settings
+
+
+@pytest.fixture
+def alembic_cfg(
+    monkeypatch: pytest.MonkeyPatch,
+    tmp_path: Path,
+) -> Iterator[tuple[Config, str]]:
+    """Pin env, reset caches, return an Alembic config + sync URL (sync fixture)."""
+    db_path = tmp_path / "migration_0040.db"
+    async_url = f"sqlite+aiosqlite:///{db_path}"
+    sync_url = f"sqlite:///{db_path}"
+    monkeypatch.setenv("DATABASE_URL", async_url)
+    monkeypatch.setenv("KEYCLOAK_ISSUER_URL", "https://keycloak.test/realms/meho")
+    monkeypatch.setenv("KEYCLOAK_AUDIENCE", "meho-backplane")
+    monkeypatch.setenv("VAULT_ADDR", "https://vault.test")
+    get_settings.cache_clear()
+    reset_engine_for_testing()
+
+    cfg = alembic_config()
+    cfg.set_main_option("sqlalchemy.url", async_url)
+    try:
+        yield cfg, sync_url
+    finally:
+        get_settings.cache_clear()
+        reset_engine_for_testing()
+
+
+def _approval_request_columns(sync_url: str) -> set[str]:
+    sync_eng = sa_create_engine(sync_url)
+    try:
+        with sync_eng.connect() as conn:
+            rows = conn.execute(text("PRAGMA table_info(approval_request)")).all()
+    finally:
+        sync_eng.dispose()
+    return {str(row[1]) for row in rows}
+
+
+def _approval_request_column_is_nullable(sync_url: str, column: str) -> bool:
+    sync_eng = sa_create_engine(sync_url)
+    try:
+        with sync_eng.connect() as conn:
+            rows = conn.execute(text("PRAGMA table_info(approval_request)")).all()
+    finally:
+        sync_eng.dispose()
+    for row in rows:
+        if str(row[1]) == column:
+            return int(row[3]) == 0
+    raise AssertionError(f"column {column!r} not present on approval_request")
+
+
+def _approval_request_indexes(sync_url: str) -> set[str]:
+    sync_eng = sa_create_engine(sync_url)
+    try:
+        with sync_eng.connect() as conn:
+            rows = conn.execute(text("PRAGMA index_list(approval_request)")).all()
+    finally:
+        sync_eng.dispose()
+    return {str(row[1]) for row in rows}
+
+
+def test_upgrade_adds_work_ref_column_and_index(alembic_cfg: tuple[Config, str]) -> None:
+    """``upgrade head`` lands the nullable column + its named index."""
+    cfg, sync_url = alembic_cfg
+    command.upgrade(cfg, "head")
+
+    assert "work_ref" in _approval_request_columns(sync_url), (
+        "migration 0040 must add approval_request.work_ref on upgrade head"
+    )
+    assert _approval_request_column_is_nullable(sync_url, "work_ref"), (
+        "work_ref must be nullable -- NULL when no change ticket authorised the request"
+    )
+    assert "approval_request_work_ref_idx" in _approval_request_indexes(sync_url), (
+        "migration 0040 must create approval_request_work_ref_idx on upgrade head"
+    )
+
+
+def test_downgrade_then_upgrade_round_trips(alembic_cfg: tuple[Config, str]) -> None:
+    """``downgrade "0039"`` drops column + index; ``upgrade head`` restores them."""
+    cfg, sync_url = alembic_cfg
+    command.upgrade(cfg, "head")
+    assert "work_ref" in _approval_request_columns(sync_url)
+    assert "approval_request_work_ref_idx" in _approval_request_indexes(sync_url)
+
+    command.downgrade(cfg, "0039")
+    assert "work_ref" not in _approval_request_columns(sync_url), "downgrade must drop work_ref"
+    assert "approval_request_work_ref_idx" not in _approval_request_indexes(sync_url), (
+        "downgrade must drop approval_request_work_ref_idx"
+    )
+
+    command.upgrade(cfg, "head")
+    assert "work_ref" in _approval_request_columns(sync_url)
+    assert "approval_request_work_ref_idx" in _approval_request_indexes(sync_url)
+
+
+def test_prior_approval_request_columns_untouched(alembic_cfg: tuple[Config, str]) -> None:
+    """The pre-existing columns + indexes survive 0040."""
+    cfg, sync_url = alembic_cfg
+    command.upgrade(cfg, "head")
+
+    columns = _approval_request_columns(sync_url)
+    assert "run_id" in columns, "the run_id soft-FK must survive 0040"
+    assert "params" in columns, "0036's params column must survive 0040"
+    assert "params_hash" in columns
+    assert "work_ref" in columns
+
+    indexes = _approval_request_indexes(sync_url)
+    assert "approval_request_status_idx" in indexes
+    assert "approval_request_run_id_idx" in indexes
+    assert "approval_request_work_ref_idx" in indexes
+
+
+def test_orm_field_resolves_and_defaults_none() -> None:
+    """:attr:`ApprovalRequest.work_ref` resolves and defaults to ``None``."""
+    import uuid
+
+    from meho_backplane.db.models import ApprovalRequest
+
+    assert hasattr(ApprovalRequest, "work_ref")
+    row = ApprovalRequest(
+        tenant_id=uuid.uuid4(),
+        principal_sub="op-smoke",
+        op_id="vault.kv.write",
+        connector_id="vault-1.x",
+        params_hash="deadbeef",
+        proposed_effect={},
+        status="pending",
+    )
+    assert row.work_ref is None, "an ApprovalRequest built without work_ref must default it to None"

--- a/cli/api/openapi.json
+++ b/cli/api/openapi.json
@@ -6611,7 +6611,7 @@
           "approvals"
         ],
         "summary": "List Approvals",
-        "description": "List approval requests for the operator's tenant.\n\nDefaults to listing only ``pending`` requests. Supports filtering\nby status via ``?status=approved`` / ``?status=rejected`` /\n``?status=expired``. Returns newest-first (``created_at DESC``).",
+        "description": "List approval requests for the operator's tenant.\n\nDefaults to listing only ``pending`` requests. Supports filtering\nby status via ``?status=approved`` / ``?status=rejected`` /\n``?status=expired`` and by change ticket via\n``?work_ref=gh:evoila/meho#1`` (exact match). Returns newest-first\n(``created_at DESC``).",
         "operationId": "list_approvals_api_v1_approvals_get",
         "parameters": [
           {
@@ -6625,6 +6625,18 @@
               "title": "Status"
             },
             "description": "Filter by status. One of: pending, approved, rejected, expired. Defaults to 'pending'."
+          },
+          {
+            "name": "work_ref",
+            "in": "query",
+            "required": false,
+            "schema": {
+              "type": "string",
+              "nullable": true,
+              "description": "Filter by external change-ticket reference (exact match), e.g. 'gh:evoila/meho#1' \u2014 the requests authorised by change ticket X (work_ref I2-T1 #1659). Omit for no work_ref filter.",
+              "title": "Work Ref"
+            },
+            "description": "Filter by external change-ticket reference (exact match), e.g. 'gh:evoila/meho#1' \u2014 the requests authorised by change ticket X (work_ref I2-T1 #1659). Omit for no work_ref filter."
           },
           {
             "name": "authorization",
@@ -10864,6 +10876,11 @@
             "type": "string",
             "nullable": true,
             "title": "Expires At"
+          },
+          "work_ref": {
+            "type": "string",
+            "nullable": true,
+            "title": "Work Ref"
           }
         },
         "type": "object",
@@ -10882,7 +10899,8 @@
           "reviewed_by",
           "decided_at",
           "created_at",
-          "expires_at"
+          "expires_at",
+          "work_ref"
         ],
         "title": "ApprovalRequestView",
         "description": "Read-only view of an :class:`~meho_backplane.db.models.ApprovalRequest`."

--- a/cli/internal/api/client.gen.go
+++ b/cli/internal/api/client.gen.go
@@ -835,6 +835,7 @@ type ApprovalRequestView struct {
 	Status   ApprovalRequestStatus `json:"status"`
 	TargetId *openapi_types.UUID   `json:"target_id"`
 	TenantId openapi_types.UUID    `json:"tenant_id"`
+	WorkRef  *string               `json:"work_ref"`
 }
 
 // ApproveRequestBody POST body for “…/approve“.
@@ -5203,7 +5204,10 @@ type RunAgentEventsApiV1AgentsNameRunEventsPostParams struct {
 // ListApprovalsApiV1ApprovalsGetParams defines parameters for ListApprovalsApiV1ApprovalsGet.
 type ListApprovalsApiV1ApprovalsGetParams struct {
 	// Status Filter by status. One of: pending, approved, rejected, expired. Defaults to 'pending'.
-	Status        *string `form:"status,omitempty" json:"status,omitempty"`
+	Status *string `form:"status,omitempty" json:"status,omitempty"`
+
+	// WorkRef Filter by external change-ticket reference (exact match), e.g. 'gh:evoila/meho#1' — the requests authorised by change ticket X (work_ref I2-T1 #1659). Omit for no work_ref filter.
+	WorkRef       *string `form:"work_ref,omitempty" json:"work_ref,omitempty"`
 	Authorization *string `json:"authorization,omitempty"`
 }
 
@@ -11520,6 +11524,22 @@ func NewListApprovalsApiV1ApprovalsGetRequest(server string, params *ListApprova
 		if params.Status != nil {
 
 			if queryFrag, err := runtime.StyleParamWithLocation("form", true, "status", runtime.ParamLocationQuery, *params.Status); err != nil {
+				return nil, err
+			} else if parsed, err := url.ParseQuery(queryFrag); err != nil {
+				return nil, err
+			} else {
+				for k, v := range parsed {
+					for _, v2 := range v {
+						queryValues.Add(k, v2)
+					}
+				}
+			}
+
+		}
+
+		if params.WorkRef != nil {
+
+			if queryFrag, err := runtime.StyleParamWithLocation("form", true, "work_ref", runtime.ParamLocationQuery, *params.WorkRef); err != nil {
 				return nil, err
 			} else if parsed, err := url.ParseQuery(queryFrag); err != nil {
 				return nil, err

--- a/cli/internal/cmd/approvals/list.go
+++ b/cli/internal/cmd/approvals/list.go
@@ -24,6 +24,7 @@ import (
 func newListCmd() *cobra.Command {
 	var (
 		statusFilter      string
+		workRef           string
 		limit             int
 		offset            int
 		jsonOut           bool
@@ -35,7 +36,9 @@ func newListCmd() *cobra.Command {
 		Long: "list calls GET /api/v1/approvals and renders approval " +
 			"requests in the operator's tenant, newest first. Use " +
 			"--status pending for the most common query: requests " +
-			"awaiting a decision. --limit caps the page size " +
+			"awaiting a decision. --work-ref filters to the requests " +
+			"authorised by an external change ticket (exact match, " +
+			"e.g. gh:evoila/meho#1). --limit caps the page size " +
 			"(1..500, server default 50). --offset advances the page " +
 			"window. --json emits the raw JSON array for " +
 			"jq pipelines.",
@@ -45,6 +48,7 @@ func newListCmd() *cobra.Command {
 		RunE: func(cmd *cobra.Command, _ []string) error {
 			return runList(cmd, listOpts{
 				StatusFilter:      statusFilter,
+				WorkRef:           workRef,
 				Limit:             limit,
 				Offset:            offset,
 				JSONOut:           jsonOut,
@@ -54,6 +58,8 @@ func newListCmd() *cobra.Command {
 	}
 	cmd.Flags().StringVar(&statusFilter, "status", "",
 		"filter by status: pending, approved, rejected, expired (default: all)")
+	cmd.Flags().StringVar(&workRef, "work-ref", "",
+		"filter by external change-ticket reference, exact match (e.g. gh:evoila/meho#1)")
 	// --limit and --offset are preserved for CLI-signature compatibility
 	// (operator scripts may pass them). The backend's
 	// /api/v1/approvals route doesn't accept either parameter today
@@ -75,6 +81,7 @@ func newListCmd() *cobra.Command {
 
 type listOpts struct {
 	StatusFilter      string
+	WorkRef           string
 	Limit             int
 	Offset            int
 	JSONOut           bool
@@ -154,6 +161,10 @@ func fetchList(
 	if opts.StatusFilter != "" {
 		s := opts.StatusFilter
 		params.Status = &s
+	}
+	if opts.WorkRef != "" {
+		w := opts.WorkRef
+		params.WorkRef = &w
 	}
 	resp, err := client.ListApprovalsApiV1ApprovalsGetWithResponse(ctx, params)
 	if err != nil {


### PR DESCRIPTION
## Summary
- Adds `approval_request.work_ref` (migration `0040`, nullable `Text` + btree index) — the external change ticket that authorised a parked approval, captured at create from the request-time `work_ref_var` ContextVar (the same mechanism that stamps `audit_log.work_ref`, `0039`/#1655).
- The decision audit row sources the ref straight off the request row; `resume_dispatch_after_approval` re-binds `work_ref_var` from the row around the re-dispatch so the approved op's audit rows inherit the ref on the operator-decision surfaces (REST `/approve`, `/decide`, MCP by-id) whose tasks carry no bound var. The in-process agent-run resume path keeps its own bound var unchanged.
- Surfaced on `ApprovalRequestView` + MCP `_row_to_dict`; new exact-match filter on `list_pending(work_ref=...)`, the REST `?work_ref` query arm, the MCP `meho.approvals.list` `work_ref` arg, and the regenerated CLI `meho approvals list --work-ref`.

## Test plan
- [x] `uv run ruff check src/ tests/` — clean
- [x] `ruff format --check` — clean (test files reformatted)
- [x] `mypy src/` — clean (471 files)
- [x] `pytest tests/test_approval_queue.py tests/test_migration_0040_approval_request_work_ref.py` — 39 passed
- [x] `pytest tests/test_api_v1_approvals.py tests/test_mcp_tool_approvals.py` — 15 passed
- [x] AC1 — parked op under a bound `work_ref` writes the matching `work_ref`, visible on `ApprovalRequestView` + `_row_to_dict` (`test_create_pending_request_captures_bound_work_ref`)
- [x] AC2 (service layer) — `list_pending(work_ref=...)` exact-match filter (`test_list_pending_filters_by_work_ref`); CLI `meho approvals list --work-ref` wired against the regenerated client + help smoke-tested
- [x] AC3 — after approve (different operator) → re-dispatch, the decision audit row AND the re-dispatched op's DISPATCH audit row both carry the ref (`test_work_ref_inherited_through_park_approve_redispatch`)
- [x] `cd cli && make snapshot-openapi && make generate` committed; `go build` / `go vet` / `go test ./internal/cmd/approvals/...` pass
- [x] migration round-trips (`upgrade head` / `downgrade 0039` / re-`upgrade`), single alembic head `0040`
- [x] code-quality gate `--diff`: 0 blockers (warnings all pre-existing file/function-size)

## Out of scope
- The `0036 params` column (verbatim re-dispatch input) — not the home for `work_ref`.
- Enforcement; the approve-`reason` parity nicety (I2-T2); the `audit_log` column (I1, landed).

## Adjacent finding (pre-existing, not introduced here)
- `tests/test_retrieval_usage.py::test_route_audit_row_count_matches_total_searches` fails identically on clean `origin/main` (asserts `total_searches == 2`, gets `1`) — unrelated to approvals/work_ref.

<!-- auto-implement-issue: fresh, iteration 1 -->

Closes #1659


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

**New Features**
- Added external change-ticket reference (`work_ref`) tracking to approval requests for enhanced correlation with external systems
- Support filtering approval requests by `work_ref` in the approvals API endpoint
- Added `--work-ref` flag to CLI approvals list command for exact-match filtering
- The `work_ref` is preserved through the approval workflow lifecycle when requests are approved and re-dispatched

<!-- end of auto-generated comment: release notes by coderabbit.ai -->