### PR TITLE
feat(approvals): work_ref I2-T2 — optional reason on approve for parity with reject

### DIFF
--- a/backend/src/meho_backplane/api/v1/approvals.py
+++ b/backend/src/meho_backplane/api/v1/approvals.py
@@ -16,8 +16,8 @@ Route inventory
   ``operator``.
 * ``POST /api/v1/approvals/{request_id}/approve`` — approve a pending
   request and re-dispatch the original call with the original params.
-  Body: :class:`ApproveRequestBody` (``params`` dict). Role:
-  ``operator``.
+  Body: :class:`ApproveRequestBody` (``params`` dict + optional
+  ``reason`` string). Role: ``operator``.
 * ``POST /api/v1/approvals/{request_id}/reject`` — reject a pending
   request; the original dispatch is not executed. Body:
   :class:`RejectRequestBody` (optional ``reason`` string). Role:
@@ -128,6 +128,10 @@ class ApproveRequestBody(BaseModel):
             "the stored params_hash on the approval request."
         ),
     )
+    reason: str = Field(
+        default="",
+        description="Optional human-readable approval reason (recorded in the audit row).",
+    )
 
 
 class RejectRequestBody(BaseModel):
@@ -232,7 +236,9 @@ async def _capture_operator_decision(
     try:
         async with sessionmaker() as session:
             if decision == "approved":
-                request = await approve_request(session, request_id, operator=operator, params=None)
+                request = await approve_request(
+                    session, request_id, operator=operator, params=None, reason=reason
+                )
             else:
                 request = await reject_request(
                     session, request_id, operator=operator, reason=reason
@@ -386,6 +392,7 @@ async def approve_approval_request(
                 request_id,
                 operator=operator,
                 params=body.params,
+                reason=body.reason,
             )
             await session.commit()
         # Publish AFTER commit (G11.2-T5): a phantom event cannot

--- a/backend/src/meho_backplane/mcp/tools/approvals.py
+++ b/backend/src/meho_backplane/mcp/tools/approvals.py
@@ -341,6 +341,8 @@ async def _approve_handler(
     arguments: dict[str, Any],
 ) -> dict[str, Any]:
     request_id = _require_id(arguments)
+    reason = arguments.get("reason")
+    reason_str = str(reason) if reason is not None else ""
     structlog.contextvars.bind_contextvars(
         audit_op_id=_OP_IDS["approve"],
         audit_op_class="write",
@@ -358,6 +360,7 @@ async def _approve_handler(
                 request_id,
                 operator=operator,
                 params=None,
+                reason=reason_str,
             )
             await session.commit()
         except ApprovalNotFoundError as exc:
@@ -440,6 +443,10 @@ register_mcp_tool(
             "properties": {
                 "approval_request_id": _APPROVAL_REQUEST_ID_PROPERTY,
                 "id": _APPROVAL_LEGACY_ID_PROPERTY,
+                "reason": {
+                    "type": "string",
+                    "description": "Optional rationale recorded on the decision audit row.",
+                },
             },
             "anyOf": _APPROVAL_ID_ANYOF,
             "additionalProperties": False,

--- a/backend/src/meho_backplane/operations/approval_queue.py
+++ b/backend/src/meho_backplane/operations/approval_queue.py
@@ -365,12 +365,16 @@ async def create_pending_request(
     return request
 
 
+# code-quality-allow: 101 lines but ~70 are the Args/Raises docstring documenting
+# the four preconditions + the params/reason contract; the executable body is ~15
+# lines. Splitting it would scatter one linear approve flow for a line-count win.
 async def approve_request(
     session: AsyncSession,
     request_id: uuid.UUID,
     *,
     operator: Operator,
     params: dict[str, Any] | None = None,
+    reason: str = "",
 ) -> ApprovalRequest:
     """Approve a pending request.
 
@@ -415,6 +419,8 @@ async def approve_request(
         params: The **original** dispatch params (un-modified). Required
             on the REST path so the hash check applies; ``None`` on the
             MCP/CLI operator-decision path.
+        reason: Optional human-readable approval reason (recorded in the
+            audit payload). Mirrors :func:`reject_request`.
 
     Returns:
         The updated, flushed :class:`ApprovalRequest`.
@@ -438,6 +444,10 @@ async def approve_request(
     request.decided_at = now
     await session.flush()
 
+    extra: dict[str, Any] = {"decision": "approved", "reviewed_by": operator.sub}
+    if reason:
+        extra["reason"] = reason
+
     approve_audit_id = uuid.uuid4()
     await _write_audit_row(
         session,
@@ -447,7 +457,7 @@ async def approve_request(
         path="approval.decision",
         status_code=_DECISION_STATUS_CODE_APPROVED,
         duration_ms=0.0,
-        extra_payload={"decision": "approved", "reviewed_by": operator.sub},
+        extra_payload=extra,
     )
 
     _log.info(

--- a/backend/tests/test_approval_queue.py
+++ b/backend/tests/test_approval_queue.py
@@ -388,6 +388,117 @@ async def test_approve_request_writes_decision_audit_row(session: AsyncSession) 
 
 
 @pytest.mark.asyncio
+async def test_approve_request_records_reason_in_decision_payload(
+    session: AsyncSession,
+) -> None:
+    """A non-empty approve ``reason`` lands in the decision audit payload;
+    omitting it leaves the payload free of a ``reason`` key — mirroring reject.
+    """
+    requester = _make_operator(sub="requester-sub")
+    reviewer = _make_operator(sub="reviewer-sub")
+    params = {}
+    params_hash = compute_params_hash(params)
+
+    with_reason = await create_pending_request(
+        session,
+        operator=requester,
+        connector_id="vault-1.x",
+        op_id="vault.kv.write",
+        target=None,
+        params=params,
+        params_hash=params_hash,
+    )
+    without_reason = await create_pending_request(
+        session,
+        operator=requester,
+        connector_id="vault-1.x",
+        op_id="vault.kv.write",
+        target=None,
+        params=params,
+        params_hash=params_hash,
+    )
+    await session.commit()
+
+    async with get_sessionmaker()() as s2:
+        await approve_request(
+            s2, with_reason.id, operator=reviewer, params=params, reason="rollback window approved"
+        )
+        await approve_request(s2, without_reason.id, operator=reviewer, params=params)
+        await s2.commit()
+
+    sessionmaker = get_sessionmaker()
+    async with sessionmaker() as fresh:
+        decision_rows = (
+            (await fresh.execute(select(AuditLog).where(AuditLog.path == "approval.decision")))
+            .scalars()
+            .all()
+        )
+    by_request = {row.payload["approval_request_id"]: row.payload for row in decision_rows}
+    assert by_request[str(with_reason.id)]["decision"] == "approved"
+    assert by_request[str(with_reason.id)]["reason"] == "rollback window approved"
+    # Omitting the reason leaves the payload unchanged from today (no key).
+    assert "reason" not in by_request[str(without_reason.id)]
+
+
+@pytest.mark.asyncio
+async def test_approve_and_reject_reason_payloads_are_symmetric(
+    session: AsyncSession,
+) -> None:
+    """approve and reject decision-row payloads carry the ``reason`` field
+    in the same structural shape (side-by-side assertion)."""
+    requester = _make_operator(sub="requester-sub")
+    reviewer = _make_operator(sub="reviewer-sub")
+    params = {}
+    params_hash = compute_params_hash(params)
+
+    to_approve = await create_pending_request(
+        session,
+        operator=requester,
+        connector_id="vault-1.x",
+        op_id="vault.kv.write",
+        target=None,
+        params=params,
+        params_hash=params_hash,
+    )
+    to_reject = await create_pending_request(
+        session,
+        operator=requester,
+        connector_id="vault-1.x",
+        op_id="vault.kv.delete",
+        target=None,
+        params=params,
+        params_hash=params_hash,
+    )
+    await session.commit()
+
+    async with get_sessionmaker()() as s2:
+        await approve_request(
+            s2, to_approve.id, operator=reviewer, params=params, reason="why-approve"
+        )
+        await reject_request(s2, to_reject.id, operator=reviewer, reason="why-reject")
+        await s2.commit()
+
+    sessionmaker = get_sessionmaker()
+    async with sessionmaker() as fresh:
+        rows = {
+            row.payload["approval_request_id"]: row.payload
+            for row in (
+                await fresh.execute(select(AuditLog).where(AuditLog.path == "approval.decision"))
+            )
+            .scalars()
+            .all()
+        }
+    approve_payload = rows[str(to_approve.id)]
+    reject_payload = rows[str(to_reject.id)]
+    assert approve_payload["decision"] == "approved"
+    assert reject_payload["decision"] == "rejected"
+    assert approve_payload["reason"] == "why-approve"
+    assert reject_payload["reason"] == "why-reject"
+    # Same key set up to the decision-specific value.
+    assert set(approve_payload) == set(reject_payload)
+
+
+@pytest.mark.asyncio
 async def test_approve_request_raises_on_hash_mismatch(session: AsyncSession) -> None:
     """Supplying different params raises ParamsMismatchError."""
     requester = _make_operator(sub="requester-sub")

--- a/cli/api/openapi.json
+++ b/cli/api/openapi.json
@@ -10894,6 +10894,12 @@
             "type": "object",
             "title": "Params",
             "description": "The original dispatch params, unchanged. The hash must match the stored params_hash on the approval request."
+          },
+          "reason": {
+            "type": "string",
+            "title": "Reason",
+            "description": "Optional human-readable approval reason (recorded in the audit row).",
+            "default": ""
           }
         },
         "additionalProperties": false,

--- a/cli/internal/api/client.gen.go
+++ b/cli/internal/api/client.gen.go
@@ -841,6 +841,9 @@ type ApprovalRequestView struct {
 type ApproveRequestBody struct {
 	// Params The original dispatch params, unchanged. The hash must match the stored params_hash on the approval request.
 	Params *map[string]interface{} `json:"params,omitempty"`
+
+	// Reason Optional human-readable approval reason (recorded in the audit row).
+	Reason *string `json:"reason,omitempty"`
 }
 
 // ApproveResponseBody Response for a successful approve + re-dispatch.


### PR DESCRIPTION
## Summary
- `approvals.reject` records a free-text `reason` on its decision audit row, but `approvals.approve` accepted only the request id — an approve decision had no durable "why". This adds the parity nicety (it is **not** the `work_ref` structured fix, I2-T1).
- Threads an optional `reason: str = ''` through `approve_request` into the decision audit row's `extra_payload['reason']`, mirroring the reject path exactly: when non-empty the key is written, otherwise the payload is byte-for-byte what it is today.
- Symmetric surface updates: approve MCP tool `inputSchema` gains an optional `reason` string (same description as reject), REST `ApproveRequestBody` gains an optional `reason`, and the REST `/decide` approve branch threads its already-present `reason`.
- **No new `approval_request` column / no migration** — the reason lives in the audit payload, exactly where reject keeps it. Symmetric, not a schema change.

## Test plan
- [x] `uv run ruff check` (touched files) — clean
- [x] `uv run ruff format --check` (touched files) — clean
- [x] `uv run mypy src/` — Success, no issues in 471 source files
- [x] `uv run pytest` (full backend unit suite) — 7395 passed, 416 skipped
- [x] `python3 .claude/hooks/code-quality.py --diff` — 0 blockers (pre-existing size warnings only)
- [x] `cd cli && make snapshot-openapi && make generate` — regenerated `cli/api/openapi.json` + `cli/internal/api/client.gen.go` (committed)
- [x] AC1 — `test_approve_request_records_reason_in_decision_payload`: approving with `reason="rollback window approved"` writes that reason into the decision payload; approving without a reason leaves the payload free of the `reason` key (unchanged from today)
- [x] AC2 — `test_approve_and_reject_reason_payloads_are_symmetric`: approve and reject decision-row payloads carry `reason` in the same structural shape, asserted side by side (equal key sets)

## Notes
- `approve_request` crossed the 100-line code-quality block limit purely because of its long Args/Raises docstring (~70 lines of docs, ~15 lines of body). Added a `# code-quality-allow:` comment with that rationale rather than artificially splitting one linear approve flow.

## Out of scope
- A `reason` column on `approval_request` (kept in the audit payload, like reject).
- `work_ref` (I2-T1) — the structured, filterable fix this complements.

<!-- auto-implement-issue: fresh, iteration 1 -->

Closes #1660
