### PR TITLE
feat(agents): work_ref I3-T2 — agent_run.work_ref column + filterable run list

### DIFF
--- a/backend/alembic/versions/0041_add_agent_run_work_ref.py
+++ b/backend/alembic/versions/0041_add_agent_run_work_ref.py
@@ -1,0 +1,89 @@
+# SPDX-License-Identifier: Apache-2.0
+# Copyright (c) 2026 evoila Group
+
+"""Add ``agent_run.work_ref`` for change-ticket correlation of agent runs.
+
+Revision ID: 0041
+Revises: 0040
+Create Date: 2026-06-13
+
+Task #1662 (work_ref I3-T2) under Initiative #1654, Goal #1651. An agent
+run carries no link to the change ticket it works under, and the
+agent-run list cannot be narrowed to "what did change ticket X run?".
+Migration ``0039`` added ``audit_log.work_ref`` (the column the dispatcher
+audit writers stamp from the shared
+:data:`meho_backplane.operations._audit.work_ref_var` ContextVar); this
+migration adds the *durable bind source* for agent runs: a ``work_ref``
+recorded on the ``agent_run`` row at create time, filterable on the
+agent-run list and surfaced on the run's terminal ``agent_run.completed``
+event.
+
+This ``work_ref`` is a genuinely new column -- it must not be conflated
+with ``agent_run.id`` (which doubles as the ``agent_session_id`` lineage
+key, a UUID generated for *this* run). ``work_ref`` is an opaque external
+reference set from outside the run; ``id`` is the run's own identity.
+
+What this migration adds
+------------------------
+
+* ``agent_run.work_ref text`` -- nullable. The opaque external
+  change-ticket reference (a GitHub issue ``"gh:evoila/meho#11"``, a Jira
+  key, a CR id) of the change record the run works under. Set at create
+  time from the request-time ``work_ref_var`` binding (the same ContextVar
+  mechanism that carries the value onto ``audit_log.work_ref``, 0039), or
+  ``None`` when no ticket is bound. ``NULL`` for pre-#1662 rows and direct
+  runs without a ticket. Set-at-create-only -- no later mutation. No
+  backfill.
+* ``agent_run_tenant_work_ref_idx`` -- composite b-tree index on
+  ``(tenant_id, work_ref)``, driving the tenant-scoped exact-match
+  ``--work-ref`` filter the agent-run list surfaces (mirrors the
+  ``runbook_runs_tenant_work_ref_idx`` shape of 0040).
+
+Why no foreign key / NOT NULL
+-----------------------------
+
+Same soft-column discipline as ``audit_log.work_ref`` (0039),
+``agent_definition_id`` / ``parent_run_id`` (the existing ``agent_run``
+soft-FK columns), and ``tenant_id`` (0002): nullable, no server default
+(the ORM ``default`` of ``None`` works on both PG and SQLite), no FK
+clause -- the migration is trivially reversible on a populated table.
+``work_ref`` is an opaque cross-system reference string, not a row id in
+this schema, so there is no table to point a FK at.
+
+Reversibility contract
+----------------------
+
+``downgrade()`` reverses ``upgrade()`` in order: drop the index, then
+the column. Pure generic SQLAlchemy DDL, portable across PG and SQLite.
+"""
+
+from collections.abc import Sequence
+
+import sqlalchemy as sa
+from alembic import op
+
+# revision identifiers, used by Alembic.
+revision: str = "0041"
+down_revision: str | None = "0040"
+branch_labels: str | Sequence[str] | None = None
+depends_on: str | Sequence[str] | None = None
+
+
+def upgrade() -> None:
+    """Add ``agent_run.work_ref`` column + composite index."""
+    op.add_column(
+        "agent_run",
+        sa.Column("work_ref", sa.Text(), nullable=True),
+    )
+    op.create_index(
+        "agent_run_tenant_work_ref_idx",
+        "agent_run",
+        ["tenant_id", "work_ref"],
+        postgresql_using="btree",
+    )
+
+
+def downgrade() -> None:
+    """Reverse the upgrade -- drop the index and column."""
+    op.drop_index("agent_run_tenant_work_ref_idx", table_name="agent_run")
+    op.drop_column("agent_run", "work_ref")

--- a/backend/src/meho_backplane/agent/invocation.py
+++ b/backend/src/meho_backplane/agent/invocation.py
@@ -78,6 +78,7 @@ import socket
 import uuid
 from collections.abc import AsyncIterator
 from dataclasses import dataclass
+from datetime import datetime
 from decimal import Decimal
 from typing import Final
 
@@ -111,6 +112,7 @@ from meho_backplane.operations._audit import (
     AgentRunAuditMeta,
     agent_run_audit_meta_var,
     agent_session_id_var,
+    work_ref_var,
 )
 from meho_backplane.operations.budget_enforcement import (
     BudgetDecision,
@@ -129,6 +131,7 @@ __all__ = [
     "AgentRunNotFoundError",
     "AgentRunOutcome",
     "AgentRunStatusView",
+    "AgentRunSummary",
     "BudgetExceededError",
     "ScheduledRunNoInputError",
     "get_agent_invoker",
@@ -197,6 +200,31 @@ class AgentRunStatusView:
     model: str | None
     output: dict[str, object] | None
     error: str | None
+
+
+@dataclass(frozen=True, slots=True)
+class AgentRunSummary:
+    """A list-row view of a run, read from the durable ``agent_run`` row.
+
+    The projection the agent-run list surface (work_ref I3-T2 #1662)
+    returns per row: identity, lifecycle state, the resolved model
+    coordinates, timestamps, and the ``work_ref`` change-ticket
+    reference the list filters on. The full ``output`` blob is *not*
+    carried -- the list is a scannable index; a caller wanting the
+    result polls :meth:`AgentInvoker.poll` for the specific run.
+    """
+
+    run_id: uuid.UUID
+    status: AgentRunStatus
+    trigger: str
+    model_tier: str
+    provider: str | None
+    model: str | None
+    turns: int
+    work_ref: str | None
+    created_at: datetime
+    started_at: datetime | None
+    ended_at: datetime | None
 
 
 @dataclass(frozen=True, slots=True)
@@ -568,6 +596,15 @@ class AgentInvoker:
         scheduled run has no firing-trigger row to snapshot, and
         ``fail_into_audit`` is the conservative reclaim outcome the
         reaper applies.
+
+        work_ref I3-T2 (#1662): the run's external change-ticket
+        reference is read here off the shared
+        :data:`~meho_backplane.operations._audit.work_ref_var` ContextVar
+        -- the same boundary every transport (REST / MCP / scheduler)
+        binds it on, so all three call sites (:meth:`run`,
+        :meth:`stream_events`, :meth:`_launch_scheduled_run`) inherit it
+        without per-caller plumbing. ``None`` when no ticket is bound;
+        set-at-create-only on the row.
         """
         owner = _lease_owner()
         sessionmaker = get_sessionmaker()
@@ -579,6 +616,7 @@ class AgentInvoker:
                 trigger=trigger,
                 model_tier=entry.model_tier,
                 agent_definition_id=entry.id,
+                work_ref=work_ref_var.get(),
             )
             await run_lifecycle.start_run(session, row, provider=provider, model=model)
             await run_lifecycle.claim_lease(
@@ -1153,6 +1191,36 @@ class AgentInvoker:
                 raise AgentRunNotFoundError(run_id)
             return _row_to_view(row)
 
+    async def list_runs(
+        self,
+        operator: Operator,
+        *,
+        work_ref: str | None = None,
+        status: AgentRunStatus | None = None,
+        limit: int = 100,
+        offset: int = 0,
+    ) -> list[AgentRunSummary]:
+        """List the operator's tenant's runs, newest first (work_ref I3-T2).
+
+        Reads the durable ``agent_run`` rows, tenant-isolated to the
+        operator's tenant. ``work_ref`` (when not ``None``) narrows to
+        runs whose external change-ticket reference matches exactly;
+        ``status`` (when not ``None``) narrows to one lifecycle state.
+        The slice is bounded server-side -- the operation clamps the page
+        size -- so a single call never scans an unbounded table.
+        """
+        sessionmaker = get_sessionmaker()
+        async with sessionmaker() as session:
+            rows = await run_lifecycle.list_runs(
+                session,
+                tenant_id=operator.tenant_id,
+                work_ref=work_ref,
+                status=status,
+                limit=limit,
+                offset=offset,
+            )
+            return [_row_to_summary(r) for r in rows]
+
     async def stream_events(
         self,
         operator: Operator,
@@ -1350,6 +1418,23 @@ def _row_to_view(row: AgentRunRow) -> AgentRunStatusView:
         model=row.model,
         output=row.output,
         error=row.error,
+    )
+
+
+def _row_to_summary(row: AgentRunRow) -> AgentRunSummary:
+    """Project an ``agent_run`` row onto the list-row summary (no output blob)."""
+    return AgentRunSummary(
+        run_id=row.id,
+        status=AgentRunStatus(row.status),
+        trigger=row.trigger,
+        model_tier=row.model_tier,
+        provider=row.provider,
+        model=row.model,
+        turns=row.turns,
+        work_ref=row.work_ref,
+        created_at=row.created_at,
+        started_at=row.started_at,
+        ended_at=row.ended_at,
     )
 
 

--- a/backend/src/meho_backplane/agent/invocation.py
+++ b/backend/src/meho_backplane/agent/invocation.py
@@ -1343,6 +1343,15 @@ async def _record_child_run(
     the ``invoke_agent`` tool can heartbeat the child for its loop's lifetime
     and the reaper can reclaim a child whose worker died mid-flight.
 
+    work_ref I3-T2 (#1662): the child run inherits the parent's external
+    change-ticket reference off the shared
+    :data:`~meho_backplane.operations._audit.work_ref_var` ContextVar -- the
+    same boundary the top-level path reads in
+    :meth:`AgentInvoker._create_run_row`. Children are recorded inside the
+    parent's ``invoker.run`` call, so the var is still bound at child-creation
+    time and the child lands the same ``work_ref`` as its parent instead of
+    ``None``.
+
     The row's *terminal* state is closed by the companion
     :func:`_finalize_child_run` (G11.1-T8 #1087) after the child loop returns,
     so the child reaches ``succeeded`` / ``failed``. A definition deleted
@@ -1367,6 +1376,7 @@ async def _record_child_run(
             model_tier=entry.model_tier,
             agent_definition_id=entry.id,
             parent_run_id=parent_run_id,
+            work_ref=work_ref_var.get(),
         )
         await run_lifecycle.start_run(session, row, provider=provider, model=model)
         await run_lifecycle.claim_lease(

--- a/backend/src/meho_backplane/api/v1/agent_runs.py
+++ b/backend/src/meho_backplane/api/v1/agent_runs.py
@@ -47,13 +47,15 @@ errors this module maps.
 
 from __future__ import annotations
 
+import contextlib
 import json
 import uuid
-from collections.abc import AsyncIterator
+from collections.abc import AsyncIterator, Iterator
+from datetime import datetime
 from typing import Annotated, Final
 
 import structlog
-from fastapi import APIRouter, Depends, HTTPException, Path
+from fastapi import APIRouter, Depends, Header, HTTPException, Path, Query
 from fastapi import status as http_status
 from fastapi.responses import JSONResponse, StreamingResponse
 from pydantic import BaseModel, ConfigDict, Field
@@ -63,6 +65,7 @@ from meho_backplane.agent.invocation import (
     AgentNotFoundError,
     AgentRunNotFoundError,
     AgentRunOutcome,
+    AgentRunSummary,
     BudgetExceededError,
     get_agent_invoker,
 )
@@ -70,6 +73,7 @@ from meho_backplane.agent.run import AgentRunEvent
 from meho_backplane.auth.operator import Operator, TenantRole
 from meho_backplane.auth.rbac import require_role
 from meho_backplane.db.models import AgentRunStatus
+from meho_backplane.operations._audit import work_ref_var
 
 __all__ = ["router"]
 
@@ -149,6 +153,31 @@ class AgentRunStatusResponse(BaseModel):
     error: str | None
 
 
+class AgentRunSummaryResponse(BaseModel):
+    """One row of the agent-run list (``GET /agents/runs``).
+
+    A scannable index row: identity, lifecycle state, resolved model
+    coordinates, timestamps, and the ``work_ref`` change-ticket
+    reference the list filters on (work_ref I3-T2 #1662). The full
+    ``output`` blob is omitted — a caller wanting a run's result polls
+    ``GET /agents/runs/{handle}``.
+    """
+
+    model_config = ConfigDict(frozen=True)
+
+    run_id: uuid.UUID
+    status: AgentRunStatus
+    trigger: str
+    model_tier: str
+    provider: str | None
+    model: str | None
+    turns: int
+    work_ref: str | None
+    created_at: datetime
+    started_at: datetime | None
+    ended_at: datetime | None
+
+
 def _outcome_response(outcome: AgentRunOutcome) -> JSONResponse:
     """Render an :class:`AgentRunOutcome` as the right JSON response.
 
@@ -182,11 +211,52 @@ def _outcome_response(outcome: AgentRunOutcome) -> JSONResponse:
     )
 
 
+@contextlib.contextmanager
+def _bound_work_ref(raw: str | None) -> Iterator[None]:
+    """Bind the inbound ``Meho-Work-Ref`` header onto ``work_ref_var``.
+
+    work_ref I3-T2 (#1662): the agent runner reads ``work_ref_var`` when it
+    creates the durable run row, but the chassis audit middleware only binds
+    the header around its *post-response* audit write (so the binding is not
+    live during the route handler). This binds the same header value for the
+    duration of the invoker call so the run row inherits it, mirroring the
+    set/reset discipline the approval-queue boundary uses. A missing /
+    blank header binds nothing — the run's ``work_ref`` lands ``NULL``.
+    """
+    cleaned = raw.strip() if raw is not None else None
+    if not cleaned:
+        yield
+        return
+    token = work_ref_var.set(cleaned)
+    try:
+        yield
+    finally:
+        work_ref_var.reset(token)
+
+
+def _summary_response(summary: AgentRunSummary) -> AgentRunSummaryResponse:
+    """Project an :class:`AgentRunSummary` onto the list-row wire model."""
+    return AgentRunSummaryResponse(
+        run_id=summary.run_id,
+        status=summary.status,
+        trigger=summary.trigger,
+        model_tier=summary.model_tier,
+        provider=summary.provider,
+        model=summary.model,
+        turns=summary.turns,
+        work_ref=summary.work_ref,
+        created_at=summary.created_at,
+        started_at=summary.started_at,
+        ended_at=summary.ended_at,
+    )
+
+
 @router.post("/{name}/run")
 async def run_agent(
     name: Annotated[str, Path(max_length=_NAME_MAX_LENGTH)],
     body: AgentRunRequest,
     operator: Operator = _require_operator,
+    meho_work_ref: Annotated[str | None, Header()] = None,
 ) -> JSONResponse:
     """Run the named agent for the operator's tenant.
 
@@ -197,6 +267,10 @@ async def run_agent(
     budget-refused run (per-identity cap reached, per-tenant or global
     kill switch on — G11.5-T6 #1080) is 429 with the reason in the
     ``detail`` body so the operator sees which gate fired.
+
+    The optional ``Meho-Work-Ref`` header binds the run to an external
+    change ticket (work_ref I3-T2 #1662); it is stamped on the durable run
+    row at create time and filterable on ``GET /agents/runs``.
     """
     structlog.contextvars.bind_contextvars(
         audit_op_id=_RUN_OP_IDS["run"],
@@ -205,7 +279,8 @@ async def run_agent(
     )
     invoker = get_agent_invoker()
     try:
-        outcome = await invoker.run(operator, name, body.input, async_mode=body.async_)
+        with _bound_work_ref(meho_work_ref):
+            outcome = await invoker.run(operator, name, body.input, async_mode=body.async_)
     except AgentNotFoundError as exc:
         raise HTTPException(
             status_code=http_status.HTTP_404_NOT_FOUND,
@@ -222,6 +297,58 @@ async def run_agent(
             detail={"error": "budget_exceeded", "reason": exc.reason},
         ) from exc
     return _outcome_response(outcome)
+
+
+@router.get("/runs", response_model=list[AgentRunSummaryResponse])
+async def list_runs(
+    work_ref: str | None = Query(
+        default=None,
+        description=(
+            "Filter by external change-ticket reference (exact match), e.g. "
+            "'gh:evoila/meho#11' — the runs that worked under change ticket X "
+            "(work_ref I3-T2 #1662). Omit for no work_ref filter."
+        ),
+    ),
+    status: AgentRunStatus | None = Query(
+        default=None,
+        description=(
+            "Filter by lifecycle status (pending / running / awaiting_approval / "
+            "succeeded / failed / cancelled). Omit for every state."
+        ),
+    ),
+    limit: int = Query(
+        default=100,
+        ge=1,
+        le=500,
+        description="Max runs per page (1..500, default 100).",
+    ),
+    offset: int = Query(
+        default=0,
+        ge=0,
+        description="Rows to skip for paging.",
+    ),
+    operator: Operator = _require_operator,
+) -> list[AgentRunSummaryResponse]:
+    """List the operator's tenant's agent runs, newest first.
+
+    Tenant-isolated server-side via the JWT — cross-tenant runs are
+    invisible. ``?work_ref=gh:evoila/meho#11`` narrows to runs under one
+    change ticket (exact match); ``?status=running`` narrows to one
+    lifecycle state. Returns ``created_at DESC``.
+    """
+    structlog.contextvars.bind_contextvars(
+        audit_op_id="agent.list_runs",
+        audit_op_class="read",
+    )
+    invoker = get_agent_invoker()
+    summaries = await invoker.list_runs(
+        operator,
+        work_ref=work_ref,
+        status=status,
+        limit=limit,
+        offset=offset,
+    )
+    return [_summary_response(s) for s in summaries]
 
 
 @router.get("/runs/{handle}", response_model=AgentRunStatusResponse)
@@ -274,6 +401,7 @@ async def _events_generator(
     operator: Operator,
     name: str,
     inputs: str,
+    work_ref: str | None,
 ) -> AsyncIterator[str]:
     """SSE generator: drive a fresh run inline, yield one frame per event.
 
@@ -281,10 +409,15 @@ async def _events_generator(
     the pending iteration; the underlying loop's ``async with agent.iter``
     cleanup cancels the run, and the cancellation re-raises so the task tree
     unwinds per asyncio's contract (Sonar S7497).
+
+    The work_ref binding (#1662) is held for the whole stream so the run row
+    the stream creates inherits the change ticket; it resets when the
+    generator finalises (stream end, client disconnect, cancel).
     """
     invoker = get_agent_invoker()
-    async for run_id, event in invoker.stream_events(operator, name, inputs):
-        yield _format_event(run_id, event)
+    with _bound_work_ref(work_ref):
+        async for run_id, event in invoker.stream_events(operator, name, inputs):
+            yield _format_event(run_id, event)
 
 
 @router.post("/{name}/run/events")
@@ -292,6 +425,7 @@ async def run_agent_events(
     name: Annotated[str, Path(max_length=_NAME_MAX_LENGTH)],
     body: AgentRunRequest,
     operator: Operator = _require_operator,
+    meho_work_ref: Annotated[str | None, Header()] = None,
 ) -> StreamingResponse:
     """Stream a fresh run's events for the named agent as Server-Sent Events.
 
@@ -331,7 +465,7 @@ async def run_agent_events(
             detail={"error": "budget_exceeded", "reason": exc.reason},
         ) from exc
     return StreamingResponse(
-        _events_generator(operator, name, body.input),
+        _events_generator(operator, name, body.input, meho_work_ref),
         media_type="text/event-stream",
         headers={
             "Cache-Control": "no-cache, no-store, must-revalidate",

--- a/backend/src/meho_backplane/db/models.py
+++ b/backend/src/meho_backplane/db/models.py
@@ -3056,6 +3056,9 @@ class AgentRun(Base):
       ``lease_expires_at`` (PG ``WHERE status='running'``). Drives
       the reaper's "what leases have expired" query without
       scanning the table. T4 #825.
+    * ``agent_run_tenant_work_ref_idx`` -- composite b-tree on
+      ``(tenant_id, work_ref)``. Drives the tenant-scoped exact-match
+      ``--work-ref`` filter on the agent-run list (work_ref I3-T2 #1662).
     """
 
     __tablename__ = "agent_run"
@@ -3153,12 +3156,37 @@ class AgentRun(Base):
         nullable=False,
         default=_AGENT_RUN_IN_FLIGHT_POLICY_DEFAULT,
     )
+    # External change-ticket reference (work_ref I3-T2 #1662). The opaque
+    # cross-system reference (a GitHub issue ``"gh:evoila/meho#11"``, a
+    # Jira key, a CR id) of the change record this run works under. Set at
+    # create time from the request-time ``work_ref_var`` binding (same
+    # ContextVar mechanism as run_id / audit_log.work_ref); set-at-create-
+    # only -- never re-mutated. Distinct from ``id`` / the
+    # ``agent_session_id`` lineage key: ``id`` is the run's own identity,
+    # ``work_ref`` is an external reference set from outside the run. NULL
+    # when no work_ref is bound (pre-#1662 rows, direct runs without a
+    # ticket). No FK -- opaque cross-system string. Added by migration
+    # ``0041``.
+    work_ref: Mapped[str | None] = mapped_column(
+        Text,
+        nullable=True,
+        default=None,
+    )
 
     __table_args__ = (
         Index(
             "agent_run_tenant_created_at_idx",
             "tenant_id",
             "created_at",
+            postgresql_using="btree",
+        ),
+        # work_ref I3-T2 #1662 -- composite (tenant_id, work_ref) drives
+        # the tenant-scoped exact-match ``--work-ref`` filter the
+        # agent-run list surfaces. Mirrors runbook_runs_tenant_work_ref_idx.
+        Index(
+            "agent_run_tenant_work_ref_idx",
+            "tenant_id",
+            "work_ref",
             postgresql_using="btree",
         ),
         Index(

--- a/backend/src/meho_backplane/main.py
+++ b/backend/src/meho_backplane/main.py
@@ -790,6 +790,21 @@ app.include_router(api_v1_broadcast_overrides_router)
 # ``show_agent`` because the grants router only matches paths under
 # its own ``/api/v1/agents/grants`` prefix.
 app.include_router(api_v1_agent_grants_router)
+# G11.1-T4 (#811) -- agent invocation surface. POST /agents/{name}/run
+# (sync block-and-return, or async handle on the timeout / async flag),
+# GET /agents/runs (list the tenant's runs, --work-ref filter; work_ref
+# I3-T2 #1662), GET /agents/runs/{handle} (poll the durable run state),
+# and POST /agents/{name}/run/events (SSE stream of a fresh run's turn /
+# tool-call / final events). Operator-level; tenant-scoped via the JWT;
+# runs only an enabled definition in the operator's tenant.
+#
+# Registered BEFORE ``api_v1_agents_router`` for the same reason the
+# grants router is (G11.2 follow-up #1168): FastAPI dispatches routes in
+# include order, so the agents-router's ``GET /{name}`` would otherwise
+# shadow the one-segment ``GET /api/v1/agents/runs`` (matching
+# ``name="runs"``). Specific ``/runs`` route first → the list resolves;
+# every other name still falls through to ``show_agent``.
+app.include_router(api_v1_agent_runs_router)
 # G11.1-T2 (#809) -- agent-definition CRUD verbs (list / show / create
 # / edit / delete) over the AgentDefinition ORM model. Reads gated to
 # operator-level, writes to tenant_admin. Tenant-scoped via the JWT's
@@ -803,13 +818,6 @@ app.include_router(api_v1_agents_router)
 # Reads gated to operator+; writes gated to tenant_admin.
 # Tenant-scoped via the JWT; cross-tenant probes return 404.
 app.include_router(api_v1_agent_principals_router)
-# G11.1-T4 (#811) -- agent invocation surface. POST /agents/{name}/run
-# (sync block-and-return, or async handle on the timeout / async flag),
-# GET /agents/runs/{handle} (poll the durable run state), and POST
-# /agents/{name}/run/events (SSE stream of a fresh run's turn / tool-call
-# / final events). Operator-level; tenant-scoped via the JWT; runs only an
-# enabled definition in the operator's tenant.
-app.include_router(api_v1_agent_runs_router)
 # G11.3-T5 (#826) -- scheduler-admin surface. GET /scheduler/triggers
 # (list, paginated, operator-level), POST /scheduler/triggers (create,
 # tenant_admin), DELETE /scheduler/triggers/{id} (cancel, tenant_admin).

--- a/backend/src/meho_backplane/mcp/tools/agent_runs.py
+++ b/backend/src/meho_backplane/mcp/tools/agent_runs.py
@@ -47,8 +47,10 @@ from meho_backplane.agent.invocation import (
     get_agent_invoker,
 )
 from meho_backplane.auth.operator import Operator, TenantRole
+from meho_backplane.db.models import AgentRunStatus
 from meho_backplane.mcp.registry import ToolDefinition, register_mcp_tool
 from meho_backplane.mcp.server import McpInvalidParamsError
+from meho_backplane.operations._audit import work_ref_var
 
 _log = structlog.get_logger(__name__)
 
@@ -57,6 +59,7 @@ _log = structlog.get_logger(__name__)
 _RUN_OP_IDS: Final[dict[str, str]] = {
     "run": "agent.run",
     "status": "agent.run_status",
+    "list": "agent.list_runs",
 }
 
 
@@ -88,12 +91,19 @@ async def _run_handler(
     name = _require_name(arguments)
     user_input = _require_input(arguments)
     async_mode = bool(arguments.get("async", False))
+    work_ref = arguments.get("work_ref")
+    if work_ref is not None and not isinstance(work_ref, str):
+        raise McpInvalidParamsError("work_ref must be a string when supplied")
     structlog.contextvars.bind_contextvars(
         audit_op_id=_RUN_OP_IDS["run"],
         audit_op_class="write",
         audit_agent_name=name,
     )
     invoker = get_agent_invoker()
+    # work_ref I3-T2 (#1662): bind the change-ticket ref onto work_ref_var
+    # for the run-create boundary so the durable run row inherits it.
+    cleaned_work_ref = work_ref.strip() if isinstance(work_ref, str) else None
+    work_ref_token = work_ref_var.set(cleaned_work_ref) if cleaned_work_ref else None
     try:
         outcome = await invoker.run(operator, name, user_input, async_mode=async_mode)
     except AgentNotFoundError as exc:
@@ -108,6 +118,9 @@ async def _run_handler(
         # use here. The reason string carries which gate fired (cap /
         # kill switch / per-identity zero limit).
         raise McpInvalidParamsError(f"budget_exceeded: {exc.reason}") from exc
+    finally:
+        if work_ref_token is not None:
+            work_ref_var.reset(work_ref_token)
     return {
         "run_id": str(outcome.run_id),
         "status": outcome.status.value,
@@ -147,6 +160,15 @@ register_mcp_tool(
                 "async": {
                     "type": "boolean",
                     "description": "Return a run handle immediately instead of blocking.",
+                },
+                "work_ref": {
+                    "type": "string",
+                    "description": (
+                        "Optional external change-ticket reference to bind the run "
+                        "to (work_ref I3-T2 #1662), e.g. 'gh:evoila/meho#11'. "
+                        "Stamped on the run row and filterable via "
+                        "meho.agents.list_runs."
+                    ),
                 },
             },
             "required": ["name", "input"],
@@ -222,4 +244,114 @@ register_mcp_tool(
         op_class="read",
     ),
     handler=_run_status_handler,
+)
+
+
+# ---------------------------------------------------------------------------
+# meho.agents.list_runs
+# ---------------------------------------------------------------------------
+
+
+async def _list_runs_handler(
+    operator: Operator,
+    arguments: dict[str, Any],
+) -> dict[str, Any]:
+    work_ref = arguments.get("work_ref")
+    if work_ref is not None and not isinstance(work_ref, str):
+        raise McpInvalidParamsError("work_ref must be a string when supplied")
+    status_arg = arguments.get("status")
+    status: AgentRunStatus | None = None
+    if status_arg is not None:
+        if not isinstance(status_arg, str):
+            raise McpInvalidParamsError("status must be a string when supplied")
+        try:
+            status = AgentRunStatus(status_arg)
+        except ValueError as exc:
+            raise McpInvalidParamsError(f"unknown status {status_arg!r}") from exc
+    limit = arguments.get("limit", 100)
+    if not isinstance(limit, int) or isinstance(limit, bool) or not 1 <= limit <= 500:
+        raise McpInvalidParamsError("limit must be an integer in 1..500")
+    offset = arguments.get("offset", 0)
+    if not isinstance(offset, int) or isinstance(offset, bool) or offset < 0:
+        raise McpInvalidParamsError("offset must be a non-negative integer")
+    structlog.contextvars.bind_contextvars(
+        audit_op_id=_RUN_OP_IDS["list"],
+        audit_op_class="read",
+    )
+    invoker = get_agent_invoker()
+    summaries = await invoker.list_runs(
+        operator,
+        work_ref=work_ref,
+        status=status,
+        limit=limit,
+        offset=offset,
+    )
+    return {
+        "runs": [
+            {
+                "run_id": str(s.run_id),
+                "status": s.status.value,
+                "trigger": s.trigger,
+                "model_tier": s.model_tier,
+                "provider": s.provider,
+                "model": s.model,
+                "turns": s.turns,
+                "work_ref": s.work_ref,
+                "created_at": s.created_at.isoformat(),
+                "started_at": s.started_at.isoformat() if s.started_at is not None else None,
+                "ended_at": s.ended_at.isoformat() if s.ended_at is not None else None,
+            }
+            for s in summaries
+        ],
+    }
+
+
+register_mcp_tool(
+    definition=ToolDefinition(
+        name="meho.agents.list_runs",
+        description=(
+            "List the operator's tenant's agent runs, newest first "
+            "(Initiative #802; work_ref I3-T2 #1662). Operator-level. "
+            "Returns {runs: [{run_id, status, trigger, model_tier, "
+            "provider, model, turns, work_ref, created_at, started_at, "
+            "ended_at}]}. Filter by work_ref (exact-match external "
+            "change-ticket reference, e.g. 'gh:evoila/meho#11') and/or "
+            "status; page with limit (1..500, default 100) + offset. "
+            "Tenant-isolated server-side — only your tenant's runs are "
+            "visible."
+        ),
+        inputSchema={
+            "type": "object",
+            "properties": {
+                "work_ref": {
+                    "type": "string",
+                    "description": (
+                        "Exact-match external change-ticket reference filter, "
+                        "e.g. 'gh:evoila/meho#11'."
+                    ),
+                },
+                "status": {
+                    "type": "string",
+                    "enum": [s.value for s in AgentRunStatus],
+                    "description": "Filter by lifecycle status.",
+                },
+                "limit": {
+                    "type": "integer",
+                    "minimum": 1,
+                    "maximum": 500,
+                    "description": "Max runs per page (default 100).",
+                },
+                "offset": {
+                    "type": "integer",
+                    "minimum": 0,
+                    "description": "Rows to skip for paging.",
+                },
+            },
+            "required": [],
+            "additionalProperties": False,
+        },
+        required_role=TenantRole.OPERATOR,
+        op_class="read",
+    ),
+    handler=_list_runs_handler,
 )

--- a/backend/src/meho_backplane/operations/agent_run.py
+++ b/backend/src/meho_backplane/operations/agent_run.py
@@ -66,7 +66,7 @@ from datetime import UTC, datetime, timedelta
 from decimal import Decimal
 from typing import Any, Final, cast
 
-from sqlalchemy import update
+from sqlalchemy import select, update
 from sqlalchemy.engine.cursor import CursorResult
 from sqlalchemy.ext.asyncio import AsyncSession
 
@@ -102,6 +102,7 @@ __all__ = [
     "get_run",
     "heartbeat",
     "increment_turns",
+    "list_runs",
     "release_lease",
     "snapshot_in_flight_policy",
     "start_run",
@@ -283,6 +284,7 @@ async def create_run(
     identity_act: str | None = None,
     agent_definition_id: uuid.UUID | None = None,
     parent_run_id: uuid.UUID | None = None,
+    work_ref: str | None = None,
 ) -> AgentRun:
     """Insert a fresh ``agent_run`` row in the ``pending`` state.
 
@@ -308,6 +310,14 @@ async def create_run(
             executes (soft-FK; ``None`` for an ad-hoc run).
         parent_run_id: The parent run's id when this is an
             agent-invoked child (G11.1-T5); ``None`` otherwise.
+        work_ref: The external change-ticket reference the run works
+            under (work_ref I3-T2 #1662) -- an opaque cross-system
+            string (``"gh:evoila/meho#11"`` / a Jira key / a CR id),
+            normally the request-time
+            :data:`meho_backplane.operations._audit.work_ref_var`
+            binding. ``None`` (the default) when no ticket is bound.
+            Set-at-create-only -- the lifecycle never re-writes it.
+            Distinct from the run's own ``id``.
 
     Returns:
         The inserted :class:`AgentRun`, flushed so its server / ORM
@@ -324,6 +334,7 @@ async def create_run(
         status=AgentRunStatus.PENDING.value,
         turns=0,
         parent_run_id=parent_run_id,
+        work_ref=work_ref,
         created_at=datetime.now(UTC),
     )
     session.add(row)
@@ -342,6 +353,60 @@ async def get_run(session: AsyncSession, run_id: uuid.UUID) -> AgentRun | None:
     surface.
     """
     return await session.get(AgentRun, run_id)
+
+
+#: Server-side cap on the agent-run list page size -- mirrors the bounded
+#: paging discipline of the runbook-run / approval list surfaces so a
+#: single request can never scan an unbounded slice of the table.
+_LIST_RUNS_MAX_LIMIT: Final[int] = 500
+_LIST_RUNS_DEFAULT_LIMIT: Final[int] = 100
+
+
+async def list_runs(
+    session: AsyncSession,
+    *,
+    tenant_id: uuid.UUID,
+    work_ref: str | None = None,
+    status: AgentRunStatus | None = None,
+    limit: int = _LIST_RUNS_DEFAULT_LIMIT,
+    offset: int = 0,
+) -> list[AgentRun]:
+    """Page through agent runs in *tenant_id*, newest first.
+
+    The read substrate for the agent-run list surface (work_ref I3-T2
+    #1662) -- ``GET /api/v1/agents/runs``, ``meho.agents.list_runs``, and
+    ``meho agent run-list``. Tenant-isolated by the WHERE clause:
+    cross-tenant rows are invisible, so the list cannot leak another
+    tenant's runs.
+
+    Args:
+        session: Open :class:`AsyncSession` (read-only; no commit).
+        tenant_id: The tenant whose runs to list.
+        work_ref: When supplied, narrows to runs whose ``work_ref``
+            matches this external change ticket exactly
+            (``"gh:evoila/meho#11"``). ``None`` applies no work_ref
+            filter (runs with and without a ticket are returned). An
+            empty string is a legitimate exact-match value, distinct
+            from ``None`` -- so the filter is applied whenever the
+            argument is not ``None``.
+        status: When supplied, narrows to runs in this lifecycle state.
+            ``None`` returns every state.
+        limit: Max rows per page. Clamped to ``[1, 500]``.
+        offset: Rows to skip (paging). Negative offsets are clamped to 0.
+
+    Returns:
+        The matching :class:`AgentRun` rows ordered ``created_at DESC``.
+    """
+    bounded_limit = max(1, min(limit, _LIST_RUNS_MAX_LIMIT))
+    bounded_offset = max(0, offset)
+    stmt = select(AgentRun).where(AgentRun.tenant_id == tenant_id)
+    if work_ref is not None:
+        stmt = stmt.where(AgentRun.work_ref == work_ref)
+    if status is not None:
+        stmt = stmt.where(AgentRun.status == status.value)
+    stmt = stmt.order_by(AgentRun.created_at.desc()).limit(bounded_limit).offset(bounded_offset)
+    result = await session.execute(stmt)
+    return list(result.scalars().all())
 
 
 async def transition(
@@ -427,6 +492,11 @@ async def transition(
                 "agent_definition_id": (
                     str(row.agent_definition_id) if row.agent_definition_id is not None else None
                 ),
+                # work_ref I3-T2 #1662: the change ticket the run worked
+                # under, so a subscriber's JSONB filter can route the
+                # follow-up against runs of a specific change record.
+                # NULL when the run carried no ticket.
+                "work_ref": row.work_ref,
             },
         )
 

--- a/backend/tests/test_agent_invocation.py
+++ b/backend/tests/test_agent_invocation.py
@@ -74,6 +74,7 @@ from meho_backplane.db.models import (
 from meho_backplane.db.models import AgentRun as AgentRunRow
 from meho_backplane.operations import agent_run as run_lifecycle
 from meho_backplane.operations import register_typed_operation, reset_dispatcher_caches
+from meho_backplane.operations._audit import work_ref_var
 from meho_backplane.retrieval.embedding import EMBEDDING_DIMENSION
 from meho_backplane.settings import get_settings
 
@@ -852,6 +853,59 @@ async def test_finalize_child_run_swallows_illegal_transition() -> None:
         # The cancel's terminal state stands; the finalizer did not overwrite it.
         assert row.status == AgentRunStatus.CANCELLED.value
         assert row.output is None
+
+
+# ---------------------------------------------------------------------------
+# work_ref I3-T2 (#1662): an agent-invoked child run inherits the parent's
+# external change-ticket reference off the shared ``work_ref_var`` ContextVar —
+# children are recorded inside the parent's invoker.run call while the var is
+# still bound, so the child must land the same work_ref, not NULL.
+# ---------------------------------------------------------------------------
+
+
+async def test_record_child_run_inherits_bound_work_ref() -> None:
+    """A child run recorded while ``work_ref_var`` is bound persists that
+    work_ref — mirroring the top-level ``_create_run_row`` path. The defect this
+    guards: child runs landing NULL even when the parent's ticket is bound."""
+    await _seed_definition(name="child", toolset={"meta_tools": []})
+    op = _make_operator()
+    child_def = await _resolve_child_definition(op, "child")
+    assert child_def is not None
+
+    token = work_ref_var.set("gh:evoila/meho#1662")
+    try:
+        child_run_id, _lease_owner = await _record_child_run(
+            operator=op, definition=child_def, parent_run_id=None
+        )
+    finally:
+        work_ref_var.reset(token)
+
+    sessionmaker = get_sessionmaker()
+    async with sessionmaker() as session:
+        row = await run_lifecycle.get_run(session, child_run_id)
+        assert row is not None
+        assert row.work_ref == "gh:evoila/meho#1662"
+
+
+async def test_record_child_run_leaves_work_ref_null_when_unbound() -> None:
+    """With no ticket bound on ``work_ref_var``, a child run records work_ref as
+    NULL — inheritance is opt-in via the ContextVar, never fabricated."""
+    await _seed_definition(name="child", toolset={"meta_tools": []})
+    op = _make_operator()
+    child_def = await _resolve_child_definition(op, "child")
+    assert child_def is not None
+
+    # work_ref_var defaults to None; assert that to make the precondition explicit.
+    assert work_ref_var.get() is None
+    child_run_id, _lease_owner = await _record_child_run(
+        operator=op, definition=child_def, parent_run_id=None
+    )
+
+    sessionmaker = get_sessionmaker()
+    async with sessionmaker() as session:
+        row = await run_lifecycle.get_run(session, child_run_id)
+        assert row is not None
+        assert row.work_ref is None
 
 
 # ---------------------------------------------------------------------------

--- a/backend/tests/test_agent_run_lifecycle.py
+++ b/backend/tests/test_agent_run_lifecycle.py
@@ -60,6 +60,7 @@ from meho_backplane.operations.agent_run import (
     get_run,
     heartbeat,
     increment_turns,
+    list_runs,
     release_lease,
     snapshot_in_flight_policy,
     start_run,
@@ -154,6 +155,186 @@ async def test_get_run_returns_none_for_absent_id() -> None:
     async with sessionmaker() as session:
         result = await get_run(session, uuid.uuid4())
     assert result is None
+
+
+# ---------------------------------------------------------------------------
+# work_ref column (I3-T2 #1662): set-at-create, distinct from id, NULL absent
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.asyncio
+async def test_create_run_persists_work_ref() -> None:
+    """``create_run(work_ref=...)`` writes the change-ticket ref on the row."""
+    sessionmaker = get_sessionmaker()
+    async with sessionmaker() as session:
+        tenant_id = await _seed_tenant(session, slug=f"t-{uuid.uuid4().hex[:8]}")
+        run = await create_run(
+            session,
+            tenant_id=tenant_id,
+            identity_sub="user-7",
+            trigger=AgentRunTrigger.DIRECT,
+            model_tier="cheap",
+            work_ref="gh:evoila/meho#11",
+        )
+        await session.commit()
+        run_id = run.id
+
+    async with sessionmaker() as session:
+        loaded = await get_run(session, run_id)
+    assert loaded is not None
+    assert loaded.work_ref == "gh:evoila/meho#11"
+    # work_ref is a genuinely distinct column -- it must not be conflated
+    # with the run's own id / agent_session_id lineage key.
+    assert str(loaded.id) != loaded.work_ref
+
+
+@pytest.mark.asyncio
+async def test_create_run_work_ref_defaults_to_null() -> None:
+    """A run created without a work_ref has ``work_ref = NULL``."""
+    sessionmaker = get_sessionmaker()
+    async with sessionmaker() as session:
+        tenant_id = await _seed_tenant(session, slug=f"t-{uuid.uuid4().hex[:8]}")
+        run = await create_run(
+            session,
+            tenant_id=tenant_id,
+            identity_sub="user-7",
+            trigger=AgentRunTrigger.DIRECT,
+            model_tier="cheap",
+        )
+        await session.commit()
+        run_id = run.id
+
+    async with sessionmaker() as session:
+        loaded = await get_run(session, run_id)
+    assert loaded is not None
+    assert loaded.work_ref is None
+
+
+# ---------------------------------------------------------------------------
+# list_runs (I3-T2 #1662): tenant isolation + work_ref filter + paging
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.asyncio
+async def test_list_runs_returns_tenant_runs_newest_first() -> None:
+    """``list_runs`` returns the tenant's runs ordered ``created_at DESC``."""
+    sessionmaker = get_sessionmaker()
+    async with sessionmaker() as session:
+        tenant_id = await _seed_tenant(session, slug=f"t-{uuid.uuid4().hex[:8]}")
+        for sub in ("a", "b", "c"):
+            await create_run(
+                session,
+                tenant_id=tenant_id,
+                identity_sub=sub,
+                trigger=AgentRunTrigger.DIRECT,
+                model_tier="cheap",
+            )
+        await session.commit()
+
+    async with sessionmaker() as session:
+        runs = await list_runs(session, tenant_id=tenant_id)
+    assert len(runs) == 3
+    # Newest-first: created_at is non-increasing across the page.
+    created = [r.created_at for r in runs]
+    assert created == sorted(created, reverse=True)
+
+
+@pytest.mark.asyncio
+async def test_list_runs_filters_by_work_ref_exact_match() -> None:
+    """``work_ref`` narrows to the runs under that exact change ticket."""
+    sessionmaker = get_sessionmaker()
+    async with sessionmaker() as session:
+        tenant_id = await _seed_tenant(session, slug=f"t-{uuid.uuid4().hex[:8]}")
+        match = await create_run(
+            session,
+            tenant_id=tenant_id,
+            identity_sub="a",
+            trigger=AgentRunTrigger.DIRECT,
+            model_tier="cheap",
+            work_ref="gh:evoila/meho#11",
+        )
+        await create_run(
+            session,
+            tenant_id=tenant_id,
+            identity_sub="b",
+            trigger=AgentRunTrigger.DIRECT,
+            model_tier="cheap",
+            work_ref="gh:evoila/meho#22",
+        )
+        await create_run(
+            session,
+            tenant_id=tenant_id,
+            identity_sub="c",
+            trigger=AgentRunTrigger.DIRECT,
+            model_tier="cheap",
+        )
+        await session.commit()
+        match_id = match.id
+
+    async with sessionmaker() as session:
+        filtered = await list_runs(session, tenant_id=tenant_id, work_ref="gh:evoila/meho#11")
+    assert [r.id for r in filtered] == [match_id]
+
+
+@pytest.mark.asyncio
+async def test_list_runs_no_filter_returns_runs_with_and_without_work_ref() -> None:
+    """``work_ref=None`` applies no filter -- ticketed + un-ticketed runs return."""
+    sessionmaker = get_sessionmaker()
+    async with sessionmaker() as session:
+        tenant_id = await _seed_tenant(session, slug=f"t-{uuid.uuid4().hex[:8]}")
+        await create_run(
+            session,
+            tenant_id=tenant_id,
+            identity_sub="a",
+            trigger=AgentRunTrigger.DIRECT,
+            model_tier="cheap",
+            work_ref="gh:evoila/meho#11",
+        )
+        await create_run(
+            session,
+            tenant_id=tenant_id,
+            identity_sub="b",
+            trigger=AgentRunTrigger.DIRECT,
+            model_tier="cheap",
+        )
+        await session.commit()
+
+    async with sessionmaker() as session:
+        all_runs = await list_runs(session, tenant_id=tenant_id, work_ref=None)
+    assert len(all_runs) == 2
+
+
+@pytest.mark.asyncio
+async def test_list_runs_is_tenant_isolated() -> None:
+    """``list_runs`` never returns another tenant's runs."""
+    sessionmaker = get_sessionmaker()
+    async with sessionmaker() as session:
+        tenant_a = await _seed_tenant(session, slug=f"t-{uuid.uuid4().hex[:8]}")
+        tenant_b = await _seed_tenant(session, slug=f"t-{uuid.uuid4().hex[:8]}")
+        await create_run(
+            session,
+            tenant_id=tenant_a,
+            identity_sub="a",
+            trigger=AgentRunTrigger.DIRECT,
+            model_tier="cheap",
+            work_ref="gh:evoila/meho#11",
+        )
+        await create_run(
+            session,
+            tenant_id=tenant_b,
+            identity_sub="b",
+            trigger=AgentRunTrigger.DIRECT,
+            model_tier="cheap",
+            work_ref="gh:evoila/meho#11",
+        )
+        await session.commit()
+
+    async with sessionmaker() as session:
+        # Tenant B has a run with the same work_ref, but tenant A's list
+        # must not see it.
+        a_runs = await list_runs(session, tenant_id=tenant_a, work_ref="gh:evoila/meho#11")
+    assert len(a_runs) == 1
+    assert all(r.tenant_id == tenant_a for r in a_runs)
 
 
 # ---------------------------------------------------------------------------

--- a/backend/tests/test_api_v1_agent_runs.py
+++ b/backend/tests/test_api_v1_agent_runs.py
@@ -234,6 +234,84 @@ async def test_sync_run_converts_to_async_on_timeout(
 
 
 @pytest.mark.asyncio
+async def test_list_runs_filters_by_work_ref_from_header(client: TestClient) -> None:
+    """A run launched with the Meho-Work-Ref header is findable via ?work_ref.
+
+    Exercises the full boundary: the chassis binds ``work_ref_var`` from the
+    inbound header, ``_create_run_row`` stamps it onto the ``agent_run`` row,
+    and ``GET /agents/runs?work_ref=`` returns only the matching run
+    (work_ref I3-T2 #1662).
+    """
+    await _seed_definition()
+    _install_invoker("triaged: ok")
+    key = make_rsa_keypair("kid-list")
+    headers = {"Authorization": f"Bearer {_token(key)}"}
+    with respx.mock as r:
+        mock_discovery_and_jwks(r, public_jwks(key))
+        # One run tagged with a change ticket, one without.
+        tagged = client.post(
+            "/api/v1/agents/triage/run",
+            json={"input": "go"},
+            headers={**headers, "Meho-Work-Ref": "gh:evoila/meho#11"},
+        )
+        assert tagged.status_code == 200, tagged.text
+        tagged_run_id = tagged.json()["run_id"]
+        untagged = client.post(
+            "/api/v1/agents/triage/run",
+            json={"input": "go"},
+            headers=headers,
+        )
+        assert untagged.status_code == 200, untagged.text
+
+        filtered = client.get(
+            "/api/v1/agents/runs",
+            params={"work_ref": "gh:evoila/meho#11"},
+            headers=headers,
+        )
+        assert filtered.status_code == 200, filtered.text
+        rows = filtered.json()
+        assert [row["run_id"] for row in rows] == [tagged_run_id]
+        assert rows[0]["work_ref"] == "gh:evoila/meho#11"
+
+        # No filter returns both runs.
+        unfiltered = client.get("/api/v1/agents/runs", headers=headers)
+        assert unfiltered.status_code == 200, unfiltered.text
+        assert len(unfiltered.json()) == 2
+
+
+@pytest.mark.asyncio
+async def test_list_runs_is_tenant_isolated(client: TestClient) -> None:
+    """The agent-run list never returns another tenant's runs."""
+    await _seed_definition(name="triage", tenant_id=_TENANT_A)
+    await _seed_definition(name="triage", tenant_id=_TENANT_B)
+    _install_invoker("triaged: ok")
+    key = make_rsa_keypair("kid-iso")
+    with respx.mock as r:
+        mock_discovery_and_jwks(r, public_jwks(key))
+        # Tenant B runs an agent under the same work_ref.
+        b_headers = {
+            "Authorization": f"Bearer {_token(key, sub='op-b', tenant_id=_TENANT_B)}",
+            "Meho-Work-Ref": "gh:evoila/meho#11",
+        }
+        b_run = client.post(
+            "/api/v1/agents/triage/run",
+            json={"input": "go"},
+            headers=b_headers,
+        )
+        assert b_run.status_code == 200, b_run.text
+
+        # Tenant A lists with the same work_ref filter -- must see nothing.
+        a_headers = {"Authorization": f"Bearer {_token(key, sub='op-a', tenant_id=_TENANT_A)}"}
+        a_list = client.get(
+            "/api/v1/agents/runs",
+            params={"work_ref": "gh:evoila/meho#11"},
+            headers=a_headers,
+        )
+        assert a_list.status_code == 200, a_list.text
+        assert a_list.json() == []
+
+
+@pytest.mark.asyncio
 async def test_run_events_streams_sse(client: TestClient) -> None:
     """The SSE events route returns text/event-stream with turn + final frames."""
     await _seed_definition()

--- a/backend/tests/test_event_outbox.py
+++ b/backend/tests/test_event_outbox.py
@@ -344,6 +344,53 @@ async def test_fail_run_publishes_outbox_event() -> None:
     assert completed[0].payload["status"] == AgentRunStatus.FAILED.value
 
 
+async def test_completed_event_surfaces_work_ref() -> None:
+    """The ``agent_run.completed`` payload carries the run's ``work_ref`` (#1662)."""
+    await _seed_tenant()
+    sessionmaker = get_sessionmaker()
+    async with sessionmaker() as session:
+        row = await create_run(
+            session,
+            tenant_id=_TENANT_A,
+            identity_sub="seed-user",
+            trigger=AgentRunTrigger.DIRECT,
+            model_tier="standard",
+            work_ref="gh:evoila/meho#11",
+        )
+        await transition(session, row, AgentRunStatus.RUNNING)
+        run_id = row.id
+        await session.commit()
+
+    async with sessionmaker() as session:
+        attached = await session.get(AgentRun, run_id)
+        assert attached is not None
+        await succeed_run(session, attached, output={"result": "ok"})
+        await session.commit()
+
+    rows = await _all_outbox_rows()
+    completed = [r for r in rows if r.event_kind == AGENT_RUN_COMPLETED_EVENT_KIND]
+    assert len(completed) == 1
+    assert completed[0].payload["work_ref"] == "gh:evoila/meho#11"
+
+
+async def test_completed_event_work_ref_is_null_when_unset() -> None:
+    """A run with no work_ref surfaces ``work_ref=None`` on the completed event."""
+    await _seed_tenant()
+    run = await _make_agent_run(status=AgentRunStatus.RUNNING)
+
+    sessionmaker = get_sessionmaker()
+    async with sessionmaker() as session:
+        attached = await session.get(AgentRun, run.id)
+        assert attached is not None
+        await succeed_run(session, attached, output={"result": "ok"})
+        await session.commit()
+
+    rows = await _all_outbox_rows()
+    completed = [r for r in rows if r.event_kind == AGENT_RUN_COMPLETED_EVENT_KIND]
+    assert len(completed) == 1
+    assert completed[0].payload["work_ref"] is None
+
+
 async def test_terminal_event_rolls_back_with_run_transition() -> None:
     """If the run transition rolls back, the outbox event rolls back too.
 

--- a/backend/tests/test_mcp_tools_agent_runs.py
+++ b/backend/tests/test_mcp_tools_agent_runs.py
@@ -122,6 +122,7 @@ def test_operator_sees_run_tools(
     names = {t["name"] for t in resp.json()["result"]["tools"]}
     assert "meho.agents.run" in names
     assert "meho.agents.run_status" in names
+    assert "meho.agents.list_runs" in names
 
 
 @pytest.mark.parametrize("client_with_operator", [TenantRole.OPERATOR], indirect=True)
@@ -145,6 +146,27 @@ async def test_run_then_poll_round_trip(
     assert status_body["run_id"] == handle
     assert status_body["status"] == "succeeded"
     assert status_body["output"] == {"text": "triaged via mcp"}
+
+
+@pytest.mark.parametrize("client_with_operator", [TenantRole.OPERATOR], indirect=True)
+@pytest.mark.asyncio
+async def test_list_runs_returns_tenant_runs(
+    client_with_operator: tuple[TestClient, Operator],  # noqa: F811
+) -> None:
+    """meho.agents.list_runs returns the operator's tenant's runs (#1662)."""
+    client, op = client_with_operator
+    await _seed_definition(tenant_id=op.tenant_id)
+    _install_invoker("triaged via mcp")
+
+    run = _call(client, "meho.agents.run", {"name": "triage", "input": "go"})
+    handle = _result_dict(run)["run_id"]
+
+    listed = _call(client, "meho.agents.list_runs", {}, rpc_id=2)
+    body = _result_dict(listed)
+    assert [r["run_id"] for r in body["runs"]] == [handle]
+    # work_ref is surfaced on the list row (None here -- no header bound).
+    assert body["runs"][0]["work_ref"] is None
+    assert body["runs"][0]["status"] == "succeeded"
 
 
 @pytest.mark.parametrize("client_with_operator", [TenantRole.OPERATOR], indirect=True)

--- a/backend/tests/test_migration_0041_agent_run_work_ref.py
+++ b/backend/tests/test_migration_0041_agent_run_work_ref.py
@@ -1,0 +1,123 @@
+# SPDX-License-Identifier: Apache-2.0
+# Copyright (c) 2026 evoila Group
+
+"""Behavioural tests for Alembic migration ``0041_add_agent_run_work_ref``.
+
+Initiative #1654, Task #1662 (work_ref I3-T2). Adds the nullable
+``agent_run.work_ref`` column + its composite ``(tenant_id, work_ref)``
+b-tree index -- the durable change-ticket reference an agent run works
+under, set at create time and filterable on the agent-run list. Soft-column
+discipline mirrors 0039 / 0040: nullable, no server default (Python-side
+``None``), reversible.
+
+SQLite is the test driver and the migration uses only generic DDL, so PG
+parity holds.
+"""
+
+from __future__ import annotations
+
+from collections.abc import Iterator
+from pathlib import Path
+
+import pytest
+from alembic import command
+from alembic.config import Config
+from sqlalchemy import create_engine as sa_create_engine
+from sqlalchemy import text
+
+from meho_backplane.db.engine import reset_engine_for_testing
+from meho_backplane.db.migrations import alembic_config
+from meho_backplane.settings import get_settings
+
+
+@pytest.fixture
+def alembic_cfg(
+    monkeypatch: pytest.MonkeyPatch,
+    tmp_path: Path,
+) -> Iterator[tuple[Config, str]]:
+    """Pin env, reset caches, return an Alembic config + sync URL (sync fixture)."""
+    db_path = tmp_path / "migration_0041.db"
+    async_url = f"sqlite+aiosqlite:///{db_path}"
+    sync_url = f"sqlite:///{db_path}"
+    monkeypatch.setenv("DATABASE_URL", async_url)
+    monkeypatch.setenv("KEYCLOAK_ISSUER_URL", "https://keycloak.test/realms/meho")
+    monkeypatch.setenv("KEYCLOAK_AUDIENCE", "meho-backplane")
+    monkeypatch.setenv("VAULT_ADDR", "https://vault.test")
+    get_settings.cache_clear()
+    reset_engine_for_testing()
+
+    cfg = alembic_config()
+    cfg.set_main_option("sqlalchemy.url", async_url)
+    try:
+        yield cfg, sync_url
+    finally:
+        get_settings.cache_clear()
+        reset_engine_for_testing()
+
+
+def _agent_run_columns(sync_url: str) -> set[str]:
+    sync_eng = sa_create_engine(sync_url)
+    try:
+        with sync_eng.connect() as conn:
+            rows = conn.execute(text("PRAGMA table_info(agent_run)")).all()
+    finally:
+        sync_eng.dispose()
+    return {str(row[1]) for row in rows}
+
+
+def _agent_run_column_is_nullable(sync_url: str, column: str) -> bool:
+    sync_eng = sa_create_engine(sync_url)
+    try:
+        with sync_eng.connect() as conn:
+            rows = conn.execute(text("PRAGMA table_info(agent_run)")).all()
+    finally:
+        sync_eng.dispose()
+    for row in rows:
+        if str(row[1]) == column:
+            # PRAGMA table_info column 3 is ``notnull`` (0 == nullable).
+            return int(row[3]) == 0
+    raise AssertionError(f"column {column!r} not present on agent_run")
+
+
+def _agent_run_indexes(sync_url: str) -> set[str]:
+    sync_eng = sa_create_engine(sync_url)
+    try:
+        with sync_eng.connect() as conn:
+            rows = conn.execute(text("PRAGMA index_list(agent_run)")).all()
+    finally:
+        sync_eng.dispose()
+    return {str(row[1]) for row in rows}
+
+
+def test_upgrade_adds_work_ref_column_and_index(alembic_cfg: tuple[Config, str]) -> None:
+    """``upgrade head`` lands the nullable column + its composite index."""
+    cfg, sync_url = alembic_cfg
+    command.upgrade(cfg, "head")
+
+    assert "work_ref" in _agent_run_columns(sync_url), (
+        "migration 0041 must add agent_run.work_ref on upgrade head"
+    )
+    assert _agent_run_column_is_nullable(sync_url, "work_ref"), (
+        "work_ref must be nullable -- NULL when the run carries no change ticket"
+    )
+    assert "agent_run_tenant_work_ref_idx" in _agent_run_indexes(sync_url), (
+        "migration 0041 must create agent_run_tenant_work_ref_idx on upgrade head"
+    )
+
+
+def test_downgrade_then_upgrade_round_trips(alembic_cfg: tuple[Config, str]) -> None:
+    """``downgrade "0040"`` drops column + index; ``upgrade head`` restores them."""
+    cfg, sync_url = alembic_cfg
+    command.upgrade(cfg, "head")
+    assert "work_ref" in _agent_run_columns(sync_url)
+    assert "agent_run_tenant_work_ref_idx" in _agent_run_indexes(sync_url)
+
+    command.downgrade(cfg, "0040")
+    assert "work_ref" not in _agent_run_columns(sync_url), "downgrade must drop agent_run.work_ref"
+    assert "agent_run_tenant_work_ref_idx" not in _agent_run_indexes(sync_url), (
+        "downgrade must drop agent_run_tenant_work_ref_idx"
+    )
+
+    command.upgrade(cfg, "head")
+    assert "work_ref" in _agent_run_columns(sync_url)
+    assert "agent_run_tenant_work_ref_idx" in _agent_run_indexes(sync_url)

--- a/cli/api/openapi.json
+++ b/cli/api/openapi.json
@@ -5691,6 +5691,303 @@
         }
       }
     },
+    "/api/v1/agents/{name}/run": {
+      "post": {
+        "tags": [
+          "agents"
+        ],
+        "summary": "Run Agent",
+        "description": "Run the named agent for the operator's tenant.\n\nSync (default) blocks up to ``agent_sync_timeout_seconds`` and returns\nthe final output at 200; a longer run converts to async and returns a\nhandle at 202. ``async=true`` returns the handle immediately. A\ncross-tenant / absent name is 404; a disabled definition is 409; a\nbudget-refused run (per-identity cap reached, per-tenant or global\nkill switch on \u2014 G11.5-T6 #1080) is 429 with the reason in the\n``detail`` body so the operator sees which gate fired.\n\nThe optional ``Meho-Work-Ref`` header binds the run to an external\nchange ticket (work_ref I3-T2 #1662); it is stamped on the durable run\nrow at create time and filterable on ``GET /agents/runs``.",
+        "operationId": "run_agent_api_v1_agents__name__run_post",
+        "parameters": [
+          {
+            "name": "name",
+            "in": "path",
+            "required": true,
+            "schema": {
+              "type": "string",
+              "maxLength": 128,
+              "title": "Name"
+            }
+          },
+          {
+            "name": "meho-work-ref",
+            "in": "header",
+            "required": false,
+            "schema": {
+              "type": "string",
+              "nullable": true,
+              "title": "Meho-Work-Ref"
+            }
+          },
+          {
+            "name": "authorization",
+            "in": "header",
+            "required": false,
+            "schema": {
+              "type": "string",
+              "nullable": true,
+              "title": "Authorization"
+            }
+          }
+        ],
+        "requestBody": {
+          "required": true,
+          "content": {
+            "application/json": {
+              "schema": {
+                "$ref": "#/components/schemas/AgentRunRequest"
+              }
+            }
+          }
+        },
+        "responses": {
+          "200": {
+            "description": "Successful Response",
+            "content": {
+              "application/json": {
+                "schema": {}
+              }
+            }
+          },
+          "422": {
+            "description": "Validation Error",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/HTTPValidationError"
+                }
+              }
+            }
+          }
+        }
+      }
+    },
+    "/api/v1/agents/runs": {
+      "get": {
+        "tags": [
+          "agents"
+        ],
+        "summary": "List Runs",
+        "description": "List the operator's tenant's agent runs, newest first.\n\nTenant-isolated server-side via the JWT \u2014 cross-tenant runs are\ninvisible. ``?work_ref=gh:evoila/meho#11`` narrows to runs under one\nchange ticket (exact match); ``?status=running`` narrows to one\nlifecycle state. Returns ``created_at DESC``.",
+        "operationId": "list_runs_api_v1_agents_runs_get",
+        "parameters": [
+          {
+            "name": "work_ref",
+            "in": "query",
+            "required": false,
+            "schema": {
+              "type": "string",
+              "nullable": true,
+              "description": "Filter by external change-ticket reference (exact match), e.g. 'gh:evoila/meho#11' \u2014 the runs that worked under change ticket X (work_ref I3-T2 #1662). Omit for no work_ref filter.",
+              "title": "Work Ref"
+            },
+            "description": "Filter by external change-ticket reference (exact match), e.g. 'gh:evoila/meho#11' \u2014 the runs that worked under change ticket X (work_ref I3-T2 #1662). Omit for no work_ref filter."
+          },
+          {
+            "name": "status",
+            "in": "query",
+            "required": false,
+            "schema": {
+              "$ref": "#/components/schemas/AgentRunStatus",
+              "nullable": true,
+              "description": "Filter by lifecycle status (pending / running / awaiting_approval / succeeded / failed / cancelled). Omit for every state.",
+              "title": "Status"
+            },
+            "description": "Filter by lifecycle status (pending / running / awaiting_approval / succeeded / failed / cancelled). Omit for every state."
+          },
+          {
+            "name": "limit",
+            "in": "query",
+            "required": false,
+            "schema": {
+              "type": "integer",
+              "maximum": 500,
+              "minimum": 1,
+              "description": "Max runs per page (1..500, default 100).",
+              "default": 100,
+              "title": "Limit"
+            },
+            "description": "Max runs per page (1..500, default 100)."
+          },
+          {
+            "name": "offset",
+            "in": "query",
+            "required": false,
+            "schema": {
+              "type": "integer",
+              "minimum": 0,
+              "description": "Rows to skip for paging.",
+              "default": 0,
+              "title": "Offset"
+            },
+            "description": "Rows to skip for paging."
+          },
+          {
+            "name": "authorization",
+            "in": "header",
+            "required": false,
+            "schema": {
+              "type": "string",
+              "nullable": true,
+              "title": "Authorization"
+            }
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "Successful Response",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "type": "array",
+                  "items": {
+                    "$ref": "#/components/schemas/AgentRunSummaryResponse"
+                  },
+                  "title": "Response List Runs Api V1 Agents Runs Get"
+                }
+              }
+            }
+          },
+          "422": {
+            "description": "Validation Error",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/HTTPValidationError"
+                }
+              }
+            }
+          }
+        }
+      }
+    },
+    "/api/v1/agents/runs/{handle}": {
+      "get": {
+        "tags": [
+          "agents"
+        ],
+        "summary": "Get Run Status",
+        "description": "Poll a run's durable status by handle (the run id).\n\nReads the durable ``agent_run`` row, so it works after the request that\nstarted the run has returned. An unknown / cross-tenant handle is 404.",
+        "operationId": "get_run_status_api_v1_agents_runs__handle__get",
+        "parameters": [
+          {
+            "name": "handle",
+            "in": "path",
+            "required": true,
+            "schema": {
+              "type": "string",
+              "format": "uuid",
+              "title": "Handle"
+            }
+          },
+          {
+            "name": "authorization",
+            "in": "header",
+            "required": false,
+            "schema": {
+              "type": "string",
+              "nullable": true,
+              "title": "Authorization"
+            }
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "Successful Response",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/AgentRunStatusResponse"
+                }
+              }
+            }
+          },
+          "422": {
+            "description": "Validation Error",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/HTTPValidationError"
+                }
+              }
+            }
+          }
+        }
+      }
+    },
+    "/api/v1/agents/{name}/run/events": {
+      "post": {
+        "tags": [
+          "agents"
+        ],
+        "summary": "Run Agent Events",
+        "description": "Stream a fresh run's events for the named agent as Server-Sent Events.\n\nDrives a new run inline and emits ``turn`` / ``tool_call`` /\n``tool_result`` / ``final`` / ``error`` events as they happen. The run\nis recorded on a durable ``agent_run`` row, so a consumer can poll the\nrun's recorded outcome after the stream ends (the ``data:`` field of\nevery frame carries the ``run_id``). A cross-tenant / absent name is\n404; a disabled definition is 409 \u2014 resolved before the stream opens so\nthe error is a normal HTTP status, not a torn stream.",
+        "operationId": "run_agent_events_api_v1_agents__name__run_events_post",
+        "parameters": [
+          {
+            "name": "name",
+            "in": "path",
+            "required": true,
+            "schema": {
+              "type": "string",
+              "maxLength": 128,
+              "title": "Name"
+            }
+          },
+          {
+            "name": "meho-work-ref",
+            "in": "header",
+            "required": false,
+            "schema": {
+              "type": "string",
+              "nullable": true,
+              "title": "Meho-Work-Ref"
+            }
+          },
+          {
+            "name": "authorization",
+            "in": "header",
+            "required": false,
+            "schema": {
+              "type": "string",
+              "nullable": true,
+              "title": "Authorization"
+            }
+          }
+        ],
+        "requestBody": {
+          "required": true,
+          "content": {
+            "application/json": {
+              "schema": {
+                "$ref": "#/components/schemas/AgentRunRequest"
+              }
+            }
+          }
+        },
+        "responses": {
+          "200": {
+            "description": "Successful Response",
+            "content": {
+              "application/json": {
+                "schema": {}
+              }
+            }
+          },
+          "422": {
+            "description": "Validation Error",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/HTTPValidationError"
+                }
+              }
+            }
+          }
+        }
+      }
+    },
     "/api/v1/agents": {
       "get": {
         "tags": [
@@ -6192,184 +6489,6 @@
                 "schema": {
                   "$ref": "#/components/schemas/AgentPrincipalRead"
                 }
-              }
-            }
-          },
-          "422": {
-            "description": "Validation Error",
-            "content": {
-              "application/json": {
-                "schema": {
-                  "$ref": "#/components/schemas/HTTPValidationError"
-                }
-              }
-            }
-          }
-        }
-      }
-    },
-    "/api/v1/agents/{name}/run": {
-      "post": {
-        "tags": [
-          "agents"
-        ],
-        "summary": "Run Agent",
-        "description": "Run the named agent for the operator's tenant.\n\nSync (default) blocks up to ``agent_sync_timeout_seconds`` and returns\nthe final output at 200; a longer run converts to async and returns a\nhandle at 202. ``async=true`` returns the handle immediately. A\ncross-tenant / absent name is 404; a disabled definition is 409; a\nbudget-refused run (per-identity cap reached, per-tenant or global\nkill switch on \u2014 G11.5-T6 #1080) is 429 with the reason in the\n``detail`` body so the operator sees which gate fired.",
-        "operationId": "run_agent_api_v1_agents__name__run_post",
-        "parameters": [
-          {
-            "name": "name",
-            "in": "path",
-            "required": true,
-            "schema": {
-              "type": "string",
-              "maxLength": 128,
-              "title": "Name"
-            }
-          },
-          {
-            "name": "authorization",
-            "in": "header",
-            "required": false,
-            "schema": {
-              "type": "string",
-              "nullable": true,
-              "title": "Authorization"
-            }
-          }
-        ],
-        "requestBody": {
-          "required": true,
-          "content": {
-            "application/json": {
-              "schema": {
-                "$ref": "#/components/schemas/AgentRunRequest"
-              }
-            }
-          }
-        },
-        "responses": {
-          "200": {
-            "description": "Successful Response",
-            "content": {
-              "application/json": {
-                "schema": {}
-              }
-            }
-          },
-          "422": {
-            "description": "Validation Error",
-            "content": {
-              "application/json": {
-                "schema": {
-                  "$ref": "#/components/schemas/HTTPValidationError"
-                }
-              }
-            }
-          }
-        }
-      }
-    },
-    "/api/v1/agents/runs/{handle}": {
-      "get": {
-        "tags": [
-          "agents"
-        ],
-        "summary": "Get Run Status",
-        "description": "Poll a run's durable status by handle (the run id).\n\nReads the durable ``agent_run`` row, so it works after the request that\nstarted the run has returned. An unknown / cross-tenant handle is 404.",
-        "operationId": "get_run_status_api_v1_agents_runs__handle__get",
-        "parameters": [
-          {
-            "name": "handle",
-            "in": "path",
-            "required": true,
-            "schema": {
-              "type": "string",
-              "format": "uuid",
-              "title": "Handle"
-            }
-          },
-          {
-            "name": "authorization",
-            "in": "header",
-            "required": false,
-            "schema": {
-              "type": "string",
-              "nullable": true,
-              "title": "Authorization"
-            }
-          }
-        ],
-        "responses": {
-          "200": {
-            "description": "Successful Response",
-            "content": {
-              "application/json": {
-                "schema": {
-                  "$ref": "#/components/schemas/AgentRunStatusResponse"
-                }
-              }
-            }
-          },
-          "422": {
-            "description": "Validation Error",
-            "content": {
-              "application/json": {
-                "schema": {
-                  "$ref": "#/components/schemas/HTTPValidationError"
-                }
-              }
-            }
-          }
-        }
-      }
-    },
-    "/api/v1/agents/{name}/run/events": {
-      "post": {
-        "tags": [
-          "agents"
-        ],
-        "summary": "Run Agent Events",
-        "description": "Stream a fresh run's events for the named agent as Server-Sent Events.\n\nDrives a new run inline and emits ``turn`` / ``tool_call`` /\n``tool_result`` / ``final`` / ``error`` events as they happen. The run\nis recorded on a durable ``agent_run`` row, so a consumer can poll the\nrun's recorded outcome after the stream ends (the ``data:`` field of\nevery frame carries the ``run_id``). A cross-tenant / absent name is\n404; a disabled definition is 409 \u2014 resolved before the stream opens so\nthe error is a normal HTTP status, not a torn stream.",
-        "operationId": "run_agent_events_api_v1_agents__name__run_events_post",
-        "parameters": [
-          {
-            "name": "name",
-            "in": "path",
-            "required": true,
-            "schema": {
-              "type": "string",
-              "maxLength": 128,
-              "title": "Name"
-            }
-          },
-          {
-            "name": "authorization",
-            "in": "header",
-            "required": false,
-            "schema": {
-              "type": "string",
-              "nullable": true,
-              "title": "Authorization"
-            }
-          }
-        ],
-        "requestBody": {
-          "required": true,
-          "content": {
-            "application/json": {
-              "schema": {
-                "$ref": "#/components/schemas/AgentRunRequest"
-              }
-            }
-          }
-        },
-        "responses": {
-          "200": {
-            "description": "Successful Response",
-            "content": {
-              "application/json": {
-                "schema": {}
               }
             }
           },
@@ -10793,6 +10912,78 @@
         ],
         "title": "AgentRunStatusResponse",
         "description": "Poll response for ``GET /agents/runs/{handle}``."
+      },
+      "AgentRunSummaryResponse": {
+        "properties": {
+          "run_id": {
+            "type": "string",
+            "format": "uuid",
+            "title": "Run Id"
+          },
+          "status": {
+            "$ref": "#/components/schemas/AgentRunStatus"
+          },
+          "trigger": {
+            "type": "string",
+            "title": "Trigger"
+          },
+          "model_tier": {
+            "type": "string",
+            "title": "Model Tier"
+          },
+          "provider": {
+            "type": "string",
+            "nullable": true,
+            "title": "Provider"
+          },
+          "model": {
+            "type": "string",
+            "nullable": true,
+            "title": "Model"
+          },
+          "turns": {
+            "type": "integer",
+            "title": "Turns"
+          },
+          "work_ref": {
+            "type": "string",
+            "nullable": true,
+            "title": "Work Ref"
+          },
+          "created_at": {
+            "type": "string",
+            "format": "date-time",
+            "title": "Created At"
+          },
+          "started_at": {
+            "type": "string",
+            "format": "date-time",
+            "nullable": true,
+            "title": "Started At"
+          },
+          "ended_at": {
+            "type": "string",
+            "format": "date-time",
+            "nullable": true,
+            "title": "Ended At"
+          }
+        },
+        "type": "object",
+        "required": [
+          "run_id",
+          "status",
+          "trigger",
+          "model_tier",
+          "provider",
+          "model",
+          "turns",
+          "work_ref",
+          "created_at",
+          "started_at",
+          "ended_at"
+        ],
+        "title": "AgentRunSummaryResponse",
+        "description": "One row of the agent-run list (``GET /agents/runs``).\n\nA scannable index row: identity, lifecycle state, resolved model\ncoordinates, timestamps, and the ``work_ref`` change-ticket\nreference the list filters on (work_ref I3-T2 #1662). The full\n``output`` blob is omitted \u2014 a caller wanting a run's result polls\n``GET /agents/runs/{handle}``."
       },
       "ApprovalRequestStatus": {
         "type": "string",

--- a/cli/internal/api/client.gen.go
+++ b/cli/internal/api/client.gen.go
@@ -767,6 +767,62 @@ type AgentRunStatusResponse struct {
 	Turns  int            `json:"turns"`
 }
 
+// AgentRunSummaryResponse One row of the agent-run list (“GET /agents/runs“).
+//
+// A scannable index row: identity, lifecycle state, resolved model
+// coordinates, timestamps, and the “work_ref“ change-ticket
+// reference the list filters on (work_ref I3-T2 #1662). The full
+// “output“ blob is omitted — a caller wanting a run's result polls
+// “GET /agents/runs/{handle}“.
+type AgentRunSummaryResponse struct {
+	CreatedAt time.Time          `json:"created_at"`
+	EndedAt   *time.Time         `json:"ended_at"`
+	Model     *string            `json:"model"`
+	ModelTier string             `json:"model_tier"`
+	Provider  *string            `json:"provider"`
+	RunId     openapi_types.UUID `json:"run_id"`
+	StartedAt *time.Time         `json:"started_at"`
+
+	// Status Closed lifecycle status of an :class:`AgentRun`.
+	//
+	// Initiative #802 (G11.1 Agent runtime), Task #813 (T6). The runtime
+	// hosts an LLM tool-use loop in MEHO's process; every invocation is
+	// one ``agent_run`` row whose ``status`` walks an explicit, enforced
+	// state machine. The legal transitions live in
+	// :data:`meho_backplane.operations.agent_run.ALLOWED_TRANSITIONS`; the
+	// service rejects any edge not on that map so an illegal jump (e.g.
+	// ``succeeded`` -> ``running``) cannot land in the DB.
+	//
+	// Members:
+	//
+	// * :attr:`PENDING` -- the row was created but the loop has not
+	//   started executing yet (initial state on insert).
+	// * :attr:`RUNNING` -- the loop is executing tool-use turns.
+	// * :attr:`AWAITING_APPROVAL` -- the loop is paused on a
+	//   policy-gated tool call whose verdict is ``needs-approval``
+	//   (G11.2 resolves the verdict; the runtime parks the run here in
+	//   the meantime). Resumable back to ``running``.
+	// * :attr:`SUCCEEDED` -- the loop completed and produced ``output``
+	//   (terminal).
+	// * :attr:`FAILED` -- the loop errored or exhausted its turn budget
+	//   without producing a usable result (terminal).
+	// * :attr:`CANCELLED` -- an authorized operator cancelled a
+	//   non-terminal run (terminal). The cancellation path is the
+	//   ``running`` / ``pending`` / ``awaiting_approval`` ->
+	//   ``cancelled`` edge.
+	//
+	// Mirrors the closed-enum + DB ``CHECK`` discipline
+	// :class:`GraphEdgeKind` / :class:`GraphHistoryChangeKind` set: the
+	// enum and the ``CHECK (status IN (...))`` constraint move in
+	// lock-step via migration ``0015``; the drift guard
+	// :func:`tests.test_db_agent_run.test_status_check_matches_enum`
+	// enforces the equality at unit-test time.
+	Status  AgentRunStatus `json:"status"`
+	Trigger string         `json:"trigger"`
+	Turns   int            `json:"turns"`
+	WorkRef *string        `json:"work_ref"`
+}
+
 // ApprovalRequestStatus Closed lifecycle status of an :class:`ApprovalRequest`.
 //
 // Initiative #803 (G11.2 Agent permission model), Task #817 (T4). The
@@ -5174,6 +5230,22 @@ type ShowGrantApiV1AgentsGrantsGrantIdGetParams struct {
 	Authorization *string `json:"authorization,omitempty"`
 }
 
+// ListRunsApiV1AgentsRunsGetParams defines parameters for ListRunsApiV1AgentsRunsGet.
+type ListRunsApiV1AgentsRunsGetParams struct {
+	// WorkRef Filter by external change-ticket reference (exact match), e.g. 'gh:evoila/meho#11' — the runs that worked under change ticket X (work_ref I3-T2 #1662). Omit for no work_ref filter.
+	WorkRef *string `form:"work_ref,omitempty" json:"work_ref,omitempty"`
+
+	// Status Filter by lifecycle status (pending / running / awaiting_approval / succeeded / failed / cancelled). Omit for every state.
+	Status *AgentRunStatus `form:"status,omitempty" json:"status,omitempty"`
+
+	// Limit Max runs per page (1..500, default 100).
+	Limit *int `form:"limit,omitempty" json:"limit,omitempty"`
+
+	// Offset Rows to skip for paging.
+	Offset        *int    `form:"offset,omitempty" json:"offset,omitempty"`
+	Authorization *string `json:"authorization,omitempty"`
+}
+
 // GetRunStatusApiV1AgentsRunsHandleGetParams defines parameters for GetRunStatusApiV1AgentsRunsHandleGet.
 type GetRunStatusApiV1AgentsRunsHandleGetParams struct {
 	Authorization *string `json:"authorization,omitempty"`
@@ -5196,11 +5268,13 @@ type EditAgentApiV1AgentsNamePatchParams struct {
 
 // RunAgentApiV1AgentsNameRunPostParams defines parameters for RunAgentApiV1AgentsNameRunPost.
 type RunAgentApiV1AgentsNameRunPostParams struct {
+	MehoWorkRef   *string `json:"meho-work-ref,omitempty"`
 	Authorization *string `json:"authorization,omitempty"`
 }
 
 // RunAgentEventsApiV1AgentsNameRunEventsPostParams defines parameters for RunAgentEventsApiV1AgentsNameRunEventsPost.
 type RunAgentEventsApiV1AgentsNameRunEventsPostParams struct {
+	MehoWorkRef   *string `json:"meho-work-ref,omitempty"`
 	Authorization *string `json:"authorization,omitempty"`
 }
 
@@ -7014,6 +7088,9 @@ type ClientInterface interface {
 	// ShowGrantApiV1AgentsGrantsGrantIdGet request
 	ShowGrantApiV1AgentsGrantsGrantIdGet(ctx context.Context, grantId openapi_types.UUID, params *ShowGrantApiV1AgentsGrantsGrantIdGetParams, reqEditors ...RequestEditorFn) (*http.Response, error)
 
+	// ListRunsApiV1AgentsRunsGet request
+	ListRunsApiV1AgentsRunsGet(ctx context.Context, params *ListRunsApiV1AgentsRunsGetParams, reqEditors ...RequestEditorFn) (*http.Response, error)
+
 	// GetRunStatusApiV1AgentsRunsHandleGet request
 	GetRunStatusApiV1AgentsRunsHandleGet(ctx context.Context, handle openapi_types.UUID, params *GetRunStatusApiV1AgentsRunsHandleGetParams, reqEditors ...RequestEditorFn) (*http.Response, error)
 
@@ -7797,6 +7874,18 @@ func (c *Client) RevokeGrantApiV1AgentsGrantsGrantIdDelete(ctx context.Context, 
 
 func (c *Client) ShowGrantApiV1AgentsGrantsGrantIdGet(ctx context.Context, grantId openapi_types.UUID, params *ShowGrantApiV1AgentsGrantsGrantIdGetParams, reqEditors ...RequestEditorFn) (*http.Response, error) {
 	req, err := NewShowGrantApiV1AgentsGrantsGrantIdGetRequest(c.Server, grantId, params)
+	if err != nil {
+		return nil, err
+	}
+	req = req.WithContext(ctx)
+	if err := c.applyEditors(ctx, req, reqEditors); err != nil {
+		return nil, err
+	}
+	return c.Client.Do(req)
+}
+
+func (c *Client) ListRunsApiV1AgentsRunsGet(ctx context.Context, params *ListRunsApiV1AgentsRunsGetParams, reqEditors ...RequestEditorFn) (*http.Response, error) {
+	req, err := NewListRunsApiV1AgentsRunsGetRequest(c.Server, params)
 	if err != nil {
 		return nil, err
 	}
@@ -11169,6 +11258,118 @@ func NewShowGrantApiV1AgentsGrantsGrantIdGetRequest(server string, grantId opena
 	return req, nil
 }
 
+// NewListRunsApiV1AgentsRunsGetRequest generates requests for ListRunsApiV1AgentsRunsGet
+func NewListRunsApiV1AgentsRunsGetRequest(server string, params *ListRunsApiV1AgentsRunsGetParams) (*http.Request, error) {
+	var err error
+
+	serverURL, err := url.Parse(server)
+	if err != nil {
+		return nil, err
+	}
+
+	operationPath := fmt.Sprintf("/api/v1/agents/runs")
+	if operationPath[0] == '/' {
+		operationPath = "." + operationPath
+	}
+
+	queryURL, err := serverURL.Parse(operationPath)
+	if err != nil {
+		return nil, err
+	}
+
+	if params != nil {
+		queryValues := queryURL.Query()
+
+		if params.WorkRef != nil {
+
+			if queryFrag, err := runtime.StyleParamWithLocation("form", true, "work_ref", runtime.ParamLocationQuery, *params.WorkRef); err != nil {
+				return nil, err
+			} else if parsed, err := url.ParseQuery(queryFrag); err != nil {
+				return nil, err
+			} else {
+				for k, v := range parsed {
+					for _, v2 := range v {
+						queryValues.Add(k, v2)
+					}
+				}
+			}
+
+		}
+
+		if params.Status != nil {
+
+			if queryFrag, err := runtime.StyleParamWithLocation("form", true, "status", runtime.ParamLocationQuery, *params.Status); err != nil {
+				return nil, err
+			} else if parsed, err := url.ParseQuery(queryFrag); err != nil {
+				return nil, err
+			} else {
+				for k, v := range parsed {
+					for _, v2 := range v {
+						queryValues.Add(k, v2)
+					}
+				}
+			}
+
+		}
+
+		if params.Limit != nil {
+
+			if queryFrag, err := runtime.StyleParamWithLocation("form", true, "limit", runtime.ParamLocationQuery, *params.Limit); err != nil {
+				return nil, err
+			} else if parsed, err := url.ParseQuery(queryFrag); err != nil {
+				return nil, err
+			} else {
+				for k, v := range parsed {
+					for _, v2 := range v {
+						queryValues.Add(k, v2)
+					}
+				}
+			}
+
+		}
+
+		if params.Offset != nil {
+
+			if queryFrag, err := runtime.StyleParamWithLocation("form", true, "offset", runtime.ParamLocationQuery, *params.Offset); err != nil {
+				return nil, err
+			} else if parsed, err := url.ParseQuery(queryFrag); err != nil {
+				return nil, err
+			} else {
+				for k, v := range parsed {
+					for _, v2 := range v {
+						queryValues.Add(k, v2)
+					}
+				}
+			}
+
+		}
+
+		queryURL.RawQuery = queryValues.Encode()
+	}
+
+	req, err := http.NewRequest("GET", queryURL.String(), nil)
+	if err != nil {
+		return nil, err
+	}
+
+	if params != nil {
+
+		if params.Authorization != nil {
+			var headerParam0 string
+
+			headerParam0, err = runtime.StyleParamWithLocation("simple", false, "authorization", runtime.ParamLocationHeader, *params.Authorization)
+			if err != nil {
+				return nil, err
+			}
+
+			req.Header.Set("authorization", headerParam0)
+		}
+
+	}
+
+	return req, nil
+}
+
 // NewGetRunStatusApiV1AgentsRunsHandleGetRequest generates requests for GetRunStatusApiV1AgentsRunsHandleGet
 func NewGetRunStatusApiV1AgentsRunsHandleGetRequest(server string, handle openapi_types.UUID, params *GetRunStatusApiV1AgentsRunsHandleGetParams) (*http.Request, error) {
 	var err error
@@ -11424,15 +11625,26 @@ func NewRunAgentApiV1AgentsNameRunPostRequestWithBody(server string, name string
 
 	if params != nil {
 
-		if params.Authorization != nil {
+		if params.MehoWorkRef != nil {
 			var headerParam0 string
 
-			headerParam0, err = runtime.StyleParamWithLocation("simple", false, "authorization", runtime.ParamLocationHeader, *params.Authorization)
+			headerParam0, err = runtime.StyleParamWithLocation("simple", false, "meho-work-ref", runtime.ParamLocationHeader, *params.MehoWorkRef)
 			if err != nil {
 				return nil, err
 			}
 
-			req.Header.Set("authorization", headerParam0)
+			req.Header.Set("meho-work-ref", headerParam0)
+		}
+
+		if params.Authorization != nil {
+			var headerParam1 string
+
+			headerParam1, err = runtime.StyleParamWithLocation("simple", false, "authorization", runtime.ParamLocationHeader, *params.Authorization)
+			if err != nil {
+				return nil, err
+			}
+
+			req.Header.Set("authorization", headerParam1)
 		}
 
 	}
@@ -11486,15 +11698,26 @@ func NewRunAgentEventsApiV1AgentsNameRunEventsPostRequestWithBody(server string,
 
 	if params != nil {
 
-		if params.Authorization != nil {
+		if params.MehoWorkRef != nil {
 			var headerParam0 string
 
-			headerParam0, err = runtime.StyleParamWithLocation("simple", false, "authorization", runtime.ParamLocationHeader, *params.Authorization)
+			headerParam0, err = runtime.StyleParamWithLocation("simple", false, "meho-work-ref", runtime.ParamLocationHeader, *params.MehoWorkRef)
 			if err != nil {
 				return nil, err
 			}
 
-			req.Header.Set("authorization", headerParam0)
+			req.Header.Set("meho-work-ref", headerParam0)
+		}
+
+		if params.Authorization != nil {
+			var headerParam1 string
+
+			headerParam1, err = runtime.StyleParamWithLocation("simple", false, "authorization", runtime.ParamLocationHeader, *params.Authorization)
+			if err != nil {
+				return nil, err
+			}
+
+			req.Header.Set("authorization", headerParam1)
 		}
 
 	}
@@ -20859,6 +21082,9 @@ type ClientWithResponsesInterface interface {
 	// ShowGrantApiV1AgentsGrantsGrantIdGetWithResponse request
 	ShowGrantApiV1AgentsGrantsGrantIdGetWithResponse(ctx context.Context, grantId openapi_types.UUID, params *ShowGrantApiV1AgentsGrantsGrantIdGetParams, reqEditors ...RequestEditorFn) (*ShowGrantApiV1AgentsGrantsGrantIdGetResponse, error)
 
+	// ListRunsApiV1AgentsRunsGetWithResponse request
+	ListRunsApiV1AgentsRunsGetWithResponse(ctx context.Context, params *ListRunsApiV1AgentsRunsGetParams, reqEditors ...RequestEditorFn) (*ListRunsApiV1AgentsRunsGetResponse, error)
+
 	// GetRunStatusApiV1AgentsRunsHandleGetWithResponse request
 	GetRunStatusApiV1AgentsRunsHandleGetWithResponse(ctx context.Context, handle openapi_types.UUID, params *GetRunStatusApiV1AgentsRunsHandleGetParams, reqEditors ...RequestEditorFn) (*GetRunStatusApiV1AgentsRunsHandleGetResponse, error)
 
@@ -21738,6 +21964,29 @@ func (r ShowGrantApiV1AgentsGrantsGrantIdGetResponse) Status() string {
 
 // StatusCode returns HTTPResponse.StatusCode
 func (r ShowGrantApiV1AgentsGrantsGrantIdGetResponse) StatusCode() int {
+	if r.HTTPResponse != nil {
+		return r.HTTPResponse.StatusCode
+	}
+	return 0
+}
+
+type ListRunsApiV1AgentsRunsGetResponse struct {
+	Body         []byte
+	HTTPResponse *http.Response
+	JSON200      *[]AgentRunSummaryResponse
+	JSON422      *HTTPValidationError
+}
+
+// Status returns HTTPResponse.Status
+func (r ListRunsApiV1AgentsRunsGetResponse) Status() string {
+	if r.HTTPResponse != nil {
+		return r.HTTPResponse.Status
+	}
+	return http.StatusText(0)
+}
+
+// StatusCode returns HTTPResponse.StatusCode
+func (r ListRunsApiV1AgentsRunsGetResponse) StatusCode() int {
 	if r.HTTPResponse != nil {
 		return r.HTTPResponse.StatusCode
 	}
@@ -25439,6 +25688,15 @@ func (c *ClientWithResponses) ShowGrantApiV1AgentsGrantsGrantIdGetWithResponse(c
 	return ParseShowGrantApiV1AgentsGrantsGrantIdGetResponse(rsp)
 }
 
+// ListRunsApiV1AgentsRunsGetWithResponse request returning *ListRunsApiV1AgentsRunsGetResponse
+func (c *ClientWithResponses) ListRunsApiV1AgentsRunsGetWithResponse(ctx context.Context, params *ListRunsApiV1AgentsRunsGetParams, reqEditors ...RequestEditorFn) (*ListRunsApiV1AgentsRunsGetResponse, error) {
+	rsp, err := c.ListRunsApiV1AgentsRunsGet(ctx, params, reqEditors...)
+	if err != nil {
+		return nil, err
+	}
+	return ParseListRunsApiV1AgentsRunsGetResponse(rsp)
+}
+
 // GetRunStatusApiV1AgentsRunsHandleGetWithResponse request returning *GetRunStatusApiV1AgentsRunsHandleGetResponse
 func (c *ClientWithResponses) GetRunStatusApiV1AgentsRunsHandleGetWithResponse(ctx context.Context, handle openapi_types.UUID, params *GetRunStatusApiV1AgentsRunsHandleGetParams, reqEditors ...RequestEditorFn) (*GetRunStatusApiV1AgentsRunsHandleGetResponse, error) {
 	rsp, err := c.GetRunStatusApiV1AgentsRunsHandleGet(ctx, handle, params, reqEditors...)
@@ -27720,6 +27978,39 @@ func ParseShowGrantApiV1AgentsGrantsGrantIdGetResponse(rsp *http.Response) (*Sho
 	switch {
 	case strings.Contains(rsp.Header.Get("Content-Type"), "json") && rsp.StatusCode == 200:
 		var dest AgentGrantRead
+		if err := json.Unmarshal(bodyBytes, &dest); err != nil {
+			return nil, err
+		}
+		response.JSON200 = &dest
+
+	case strings.Contains(rsp.Header.Get("Content-Type"), "json") && rsp.StatusCode == 422:
+		var dest HTTPValidationError
+		if err := json.Unmarshal(bodyBytes, &dest); err != nil {
+			return nil, err
+		}
+		response.JSON422 = &dest
+
+	}
+
+	return response, nil
+}
+
+// ParseListRunsApiV1AgentsRunsGetResponse parses an HTTP response from a ListRunsApiV1AgentsRunsGetWithResponse call
+func ParseListRunsApiV1AgentsRunsGetResponse(rsp *http.Response) (*ListRunsApiV1AgentsRunsGetResponse, error) {
+	bodyBytes, err := io.ReadAll(rsp.Body)
+	defer func() { _ = rsp.Body.Close() }()
+	if err != nil {
+		return nil, err
+	}
+
+	response := &ListRunsApiV1AgentsRunsGetResponse{
+		Body:         bodyBytes,
+		HTTPResponse: rsp,
+	}
+
+	switch {
+	case strings.Contains(rsp.Header.Get("Content-Type"), "json") && rsp.StatusCode == 200:
+		var dest []AgentRunSummaryResponse
 		if err := json.Unmarshal(bodyBytes, &dest); err != nil {
 			return nil, err
 		}

--- a/cli/internal/cmd/agent/agent.go
+++ b/cli/internal/cmd/agent/agent.go
@@ -96,6 +96,7 @@ func NewRootCmd() *cobra.Command {
 	// (poll), run-events (SSE stream of a fresh run).
 	cmd.AddCommand(newRunCmd())
 	cmd.AddCommand(newRunStatusCmd())
+	cmd.AddCommand(newRunListCmd())
 	cmd.AddCommand(newRunEventsCmd())
 	// G11.2-T6 (#819): permission grant management sub-tree — grant list /
 	// show / create / elevate / revoke. All verbs require tenant_admin.

--- a/cli/internal/cmd/agent/agent_test.go
+++ b/cli/internal/cmd/agent/agent_test.go
@@ -75,6 +75,7 @@ func TestNewRootCmdRegistersAllVerbs(t *testing.T) {
 		"delete":     false,
 		"run":        false,
 		"run-status": false,
+		"run-list":   false,
 		"run-events": false,
 	}
 	for _, sub := range root.Commands() {

--- a/cli/internal/cmd/agent/run.go
+++ b/cli/internal/cmd/agent/run.go
@@ -57,6 +57,7 @@ func newRunCmd() *cobra.Command {
 	var (
 		input             string
 		asyncRun          bool
+		workRef           string
 		jsonOut           bool
 		backplaneOverride string
 	)
@@ -78,6 +79,7 @@ func newRunCmd() *cobra.Command {
 				Name:              args[0],
 				Input:             input,
 				Async:             asyncRun,
+				WorkRef:           workRef,
 				JSONOut:           jsonOut,
 				BackplaneOverride: backplaneOverride,
 			})
@@ -87,6 +89,9 @@ func newRunCmd() *cobra.Command {
 		"the user prompt to run the agent on (required)")
 	cmd.Flags().BoolVar(&asyncRun, "async", false,
 		"return a run handle immediately instead of blocking for the result")
+	cmd.Flags().StringVar(&workRef, "work-ref", "",
+		"external change-ticket reference to bind the run to (e.g. gh:evoila/meho#11); "+
+			"filterable via `meho agent run-list --work-ref`")
 	cmd.Flags().BoolVar(&jsonOut, "json", false,
 		"emit the raw run response JSON instead of the human summary")
 	cmd.Flags().StringVar(&backplaneOverride, "backplane", "",
@@ -98,6 +103,7 @@ type runOptions struct {
 	Name              string
 	Input             string
 	Async             bool
+	WorkRef           string
 	JSONOut           bool
 	BackplaneOverride string
 }
@@ -147,9 +153,14 @@ func postRun(ctx context.Context, backplaneURL string, opts runOptions) (*api.Ru
 		Input: opts.Input,
 		Async: &asyncFlag,
 	}
+	params := &api.RunAgentApiV1AgentsNameRunPostParams{}
+	if opts.WorkRef != "" {
+		wr := opts.WorkRef
+		params.MehoWorkRef = &wr
+	}
 	return retryOn401(ctx, authed,
 		func(ctx context.Context) (*api.RunAgentApiV1AgentsNameRunPostResponse, error) {
-			return authed.RunAgentApiV1AgentsNameRunPostWithResponse(ctx, opts.Name, nil, body)
+			return authed.RunAgentApiV1AgentsNameRunPostWithResponse(ctx, opts.Name, params, body)
 		},
 		func(r *api.RunAgentApiV1AgentsNameRunPostResponse) int { return r.StatusCode() },
 	)

--- a/cli/internal/cmd/agent/run_list.go
+++ b/cli/internal/cmd/agent/run_list.go
@@ -18,7 +18,7 @@ import (
 
 // newRunListCmd returns the `meho agent run-list` command.
 //
-//	meho agent run-list [--work-ref REF] [--status S] [--limit N] [--json] [--backplane <url>]
+//	meho agent run-list [--work-ref REF] [--status S] [--limit N] [--offset N] [--json] [--backplane <url>]
 //
 // Role: operator. Lists the tenant's agent runs via GET /api/v1/agents/runs,
 // newest first. Filters: --work-ref (exact-match external change-ticket
@@ -29,6 +29,7 @@ func newRunListCmd() *cobra.Command {
 		workRef           string
 		statusFilter      string
 		limit             int
+		offset            int
 		jsonOut           bool
 		backplaneOverride string
 	)
@@ -40,7 +41,8 @@ func newRunListCmd() *cobra.Command {
 			"--work-ref (exact-match change-ticket reference, e.g. " +
 			"gh:evoila/meho#11), --status (pending / running / " +
 			"awaiting_approval / succeeded / failed / cancelled), " +
-			"--limit (1..500, server default 100). Runs are " +
+			"--limit (1..500, server default 100), --offset (rows to " +
+			"skip for paging, default 0). Runs are " +
 			"tenant-isolated server-side — only your tenant's runs " +
 			"appear. --json emits the raw list for scripting.",
 		Args:          cobra.NoArgs,
@@ -51,6 +53,7 @@ func newRunListCmd() *cobra.Command {
 				WorkRef:           workRef,
 				Status:            statusFilter,
 				Limit:             limit,
+				Offset:            offset,
 				JSONOut:           jsonOut,
 				BackplaneOverride: backplaneOverride,
 			})
@@ -62,6 +65,8 @@ func newRunListCmd() *cobra.Command {
 		"filter by lifecycle status: pending, running, awaiting_approval, succeeded, failed, or cancelled")
 	cmd.Flags().IntVar(&limit, "limit", 0,
 		"max runs per page (1..500, server default 100 when omitted)")
+	cmd.Flags().IntVar(&offset, "offset", 0,
+		"rows to skip for paging into the result set (default 0)")
 	cmd.Flags().BoolVar(&jsonOut, "json", false,
 		"emit the raw []AgentRunSummaryResponse JSON instead of the table")
 	cmd.Flags().StringVar(&backplaneOverride, "backplane", "",
@@ -73,6 +78,7 @@ type runListOptions struct {
 	WorkRef           string
 	Status            string
 	Limit             int
+	Offset            int
 	JSONOut           bool
 	BackplaneOverride string
 }
@@ -112,6 +118,10 @@ func listRunsParams(opts runListOptions) *api.ListRunsApiV1AgentsRunsGetParams {
 	if opts.Limit > 0 {
 		l := opts.Limit
 		params.Limit = &l
+	}
+	if opts.Offset > 0 {
+		o := opts.Offset
+		params.Offset = &o
 	}
 	return params
 }

--- a/cli/internal/cmd/agent/run_list.go
+++ b/cli/internal/cmd/agent/run_list.go
@@ -1,0 +1,155 @@
+// SPDX-License-Identifier: Apache-2.0
+// Copyright (c) 2026 evoila Group
+
+package agent
+
+import (
+	"context"
+	"fmt"
+	"io"
+	"net/http"
+
+	"github.com/spf13/cobra"
+
+	"github.com/evoila/meho/cli/internal/api"
+	"github.com/evoila/meho/cli/internal/backplane"
+	"github.com/evoila/meho/cli/internal/output"
+)
+
+// newRunListCmd returns the `meho agent run-list` command.
+//
+//	meho agent run-list [--work-ref REF] [--status S] [--limit N] [--json] [--backplane <url>]
+//
+// Role: operator. Lists the tenant's agent runs via GET /api/v1/agents/runs,
+// newest first. Filters: --work-ref (exact-match external change-ticket
+// reference, work_ref I3-T2 #1662) and --status. Tenant-isolated
+// server-side via the JWT — only the caller's tenant's runs are visible.
+func newRunListCmd() *cobra.Command {
+	var (
+		workRef           string
+		statusFilter      string
+		limit             int
+		jsonOut           bool
+		backplaneOverride string
+	)
+	cmd := &cobra.Command{
+		Use:   "run-list",
+		Short: "List agent runs (filter by --work-ref / --status)",
+		Long: "run-list calls GET /api/v1/agents/runs and renders the " +
+			"tenant's runs as a compact table, newest first. Filters: " +
+			"--work-ref (exact-match change-ticket reference, e.g. " +
+			"gh:evoila/meho#11), --status (pending / running / " +
+			"awaiting_approval / succeeded / failed / cancelled), " +
+			"--limit (1..500, server default 100). Runs are " +
+			"tenant-isolated server-side — only your tenant's runs " +
+			"appear. --json emits the raw list for scripting.",
+		Args:          cobra.NoArgs,
+		SilenceUsage:  true,
+		SilenceErrors: true,
+		RunE: func(cmd *cobra.Command, args []string) error {
+			return runRunList(cmd, runListOptions{
+				WorkRef:           workRef,
+				Status:            statusFilter,
+				Limit:             limit,
+				JSONOut:           jsonOut,
+				BackplaneOverride: backplaneOverride,
+			})
+		},
+	}
+	cmd.Flags().StringVar(&workRef, "work-ref", "",
+		"filter by external change-ticket reference (exact match, e.g. gh:evoila/meho#11)")
+	cmd.Flags().StringVar(&statusFilter, "status", "",
+		"filter by lifecycle status: pending, running, awaiting_approval, succeeded, failed, or cancelled")
+	cmd.Flags().IntVar(&limit, "limit", 0,
+		"max runs per page (1..500, server default 100 when omitted)")
+	cmd.Flags().BoolVar(&jsonOut, "json", false,
+		"emit the raw []AgentRunSummaryResponse JSON instead of the table")
+	cmd.Flags().StringVar(&backplaneOverride, "backplane", "",
+		"backplane URL to query (defaults to the URL recorded by the most recent `meho login`)")
+	return cmd
+}
+
+type runListOptions struct {
+	WorkRef           string
+	Status            string
+	Limit             int
+	JSONOut           bool
+	BackplaneOverride string
+}
+
+func runRunList(cmd *cobra.Command, opts runListOptions) error {
+	backplaneURL, err := backplane.Resolve(opts.BackplaneOverride)
+	if err != nil {
+		return output.RenderError(cmd.ErrOrStderr(), backplane.ClassifyError(err), opts.JSONOut)
+	}
+	resp, err := listRuns(cmd.Context(), backplaneURL, opts)
+	if err != nil {
+		return renderRequestError(cmd, backplaneURL, err, opts.JSONOut)
+	}
+	if resp.StatusCode() != http.StatusOK {
+		return renderHTTPStatus(cmd, backplaneURL, resp.StatusCode(), resp.Body, opts.JSONOut)
+	}
+	if opts.JSONOut {
+		return output.PrintJSON(cmd.OutOrStdout(), resp.JSON200)
+	}
+	printRunList(cmd.OutOrStdout(), resp.JSON200)
+	return nil
+}
+
+// listRunsParams maps the CLI options onto the generated query-param struct.
+// Empty filters are left nil so the server applies its defaults (no filter,
+// server-side page size).
+func listRunsParams(opts runListOptions) *api.ListRunsApiV1AgentsRunsGetParams {
+	params := &api.ListRunsApiV1AgentsRunsGetParams{}
+	if opts.WorkRef != "" {
+		wr := opts.WorkRef
+		params.WorkRef = &wr
+	}
+	if opts.Status != "" {
+		s := api.AgentRunStatus(opts.Status)
+		params.Status = &s
+	}
+	if opts.Limit > 0 {
+		l := opts.Limit
+		params.Limit = &l
+	}
+	return params
+}
+
+func listRuns(ctx context.Context, backplaneURL string, opts runListOptions) (*api.ListRunsApiV1AgentsRunsGetResponse, error) {
+	authed, err := newAuthedClient(ctx, backplaneURL)
+	if err != nil {
+		return nil, err
+	}
+	params := listRunsParams(opts)
+	return retryOn401(ctx, authed,
+		func(ctx context.Context) (*api.ListRunsApiV1AgentsRunsGetResponse, error) {
+			return authed.ListRunsApiV1AgentsRunsGetWithResponse(ctx, params)
+		},
+		func(r *api.ListRunsApiV1AgentsRunsGetResponse) int { return r.StatusCode() },
+	)
+}
+
+// printRunList renders the run list as a compact table. An empty list
+// prints a single "no runs" line so a scripted caller sees a clear signal.
+func printRunList(w io.Writer, runs *[]api.AgentRunSummaryResponse) {
+	if runs == nil || len(*runs) == 0 {
+		fmt.Fprintln(w, "no agent runs")
+		return
+	}
+	fmt.Fprintf(w, "%-36s  %-18s  %-12s  %-24s  %s\n",
+		"RUN ID", "STATUS", "TRIGGER", "CREATED", "WORK_REF")
+	for _, r := range *runs {
+		workRef := "-"
+		if r.WorkRef != nil && *r.WorkRef != "" {
+			workRef = *r.WorkRef
+		}
+		fmt.Fprintf(w, "%-36s  %-18s  %-12s  %-24s  %s\n",
+			r.RunId.String(),
+			string(r.Status),
+			r.Trigger,
+			r.CreatedAt.UTC().Format("2006-01-02T15:04:05Z"),
+			workRef,
+		)
+	}
+}

--- a/cli/internal/cmd/agent/run_list.go
+++ b/cli/internal/cmd/agent/run_list.go
@@ -46,7 +46,7 @@ func newRunListCmd() *cobra.Command {
 		Args:          cobra.NoArgs,
 		SilenceUsage:  true,
 		SilenceErrors: true,
-		RunE: func(cmd *cobra.Command, args []string) error {
+		RunE: func(cmd *cobra.Command, _ []string) error {
 			return runRunList(cmd, runListOptions{
 				WorkRef:           workRef,
 				Status:            statusFilter,

--- a/cli/internal/cmd/agent/run_test.go
+++ b/cli/internal/cmd/agent/run_test.go
@@ -249,3 +249,75 @@ func TestRunEvents403SingleErrorLine(t *testing.T) {
 		t.Errorf("403 must not surface as 'unreachable' (B1 regression); got %q", got)
 	}
 }
+
+// --- run-list ---
+
+func TestRunListHappyPathRendersTable(t *testing.T) {
+	workRef := "gh:evoila/meho#11"
+	mux := http.NewServeMux()
+	mux.HandleFunc("/api/v1/agents/runs", func(w http.ResponseWriter, _ *http.Request) {
+		w.Header().Set("Content-Type", "application/json")
+		_ = json.NewEncoder(w).Encode([]api.AgentRunSummaryResponse{
+			{
+				RunId:     uuid.MustParse("11111111-1111-1111-1111-111111111111"),
+				Status:    api.AgentRunStatusSucceeded,
+				Trigger:   "direct",
+				ModelTier: "standard",
+				Turns:     2,
+				WorkRef:   &workRef,
+			},
+		})
+	})
+	srv := httptest.NewServer(mux)
+	defer srv.Close()
+	seedXDGAndToken(t, srv.URL)
+
+	cmd, stdout, stderr := newTestCmd(t)
+	if err := runRunList(cmd, runListOptions{BackplaneOverride: srv.URL}); err != nil {
+		t.Fatalf("runRunList: %v; stderr=%s", err, stderr.String())
+	}
+	for _, want := range []string{"succeeded", "direct", workRef} {
+		if !strings.Contains(stdout.String(), want) {
+			t.Errorf("stdout missing %q in %q", want, stdout.String())
+		}
+	}
+}
+
+func TestRunListPassesWorkRefFilter(t *testing.T) {
+	var gotQuery string
+	mux := http.NewServeMux()
+	mux.HandleFunc("/api/v1/agents/runs", func(w http.ResponseWriter, r *http.Request) {
+		gotQuery = r.URL.RawQuery
+		w.Header().Set("Content-Type", "application/json")
+		_ = json.NewEncoder(w).Encode([]api.AgentRunSummaryResponse{})
+	})
+	srv := httptest.NewServer(mux)
+	defer srv.Close()
+	seedXDGAndToken(t, srv.URL)
+
+	cmd, stdout, stderr := newTestCmd(t)
+	err := runRunList(cmd, runListOptions{
+		WorkRef:           "gh:evoila/meho#11",
+		Status:            "succeeded",
+		BackplaneOverride: srv.URL,
+	})
+	if err != nil {
+		t.Fatalf("runRunList: %v; stderr=%s", err, stderr.String())
+	}
+	if !strings.Contains(gotQuery, "work_ref=gh") {
+		t.Errorf("request must carry the work_ref filter; got query %q", gotQuery)
+	}
+	if !strings.Contains(gotQuery, "status=succeeded") {
+		t.Errorf("request must carry the status filter; got query %q", gotQuery)
+	}
+	if !strings.Contains(stdout.String(), "no agent runs") {
+		t.Errorf("empty list should print 'no agent runs'; got %q", stdout.String())
+	}
+}
+
+func TestListRunsParamsOmitsEmptyFilters(t *testing.T) {
+	params := listRunsParams(runListOptions{})
+	if params.WorkRef != nil || params.Status != nil || params.Limit != nil {
+		t.Errorf("empty options must leave filters nil; got %+v", params)
+	}
+}

--- a/cli/internal/cmd/agent/run_test.go
+++ b/cli/internal/cmd/agent/run_test.go
@@ -8,6 +8,7 @@ import (
 	"fmt"
 	"net/http"
 	"net/http/httptest"
+	"net/url"
 	"strings"
 	"testing"
 
@@ -299,16 +300,28 @@ func TestRunListPassesWorkRefFilter(t *testing.T) {
 	err := runRunList(cmd, runListOptions{
 		WorkRef:           "gh:evoila/meho#11",
 		Status:            "succeeded",
+		Limit:             25,
+		Offset:            50,
 		BackplaneOverride: srv.URL,
 	})
 	if err != nil {
 		t.Fatalf("runRunList: %v; stderr=%s", err, stderr.String())
 	}
-	if !strings.Contains(gotQuery, "work_ref=gh") {
-		t.Errorf("request must carry the work_ref filter; got query %q", gotQuery)
+	q, perr := url.ParseQuery(gotQuery)
+	if perr != nil {
+		t.Fatalf("parse query %q: %v", gotQuery, perr)
 	}
-	if !strings.Contains(gotQuery, "status=succeeded") {
-		t.Errorf("request must carry the status filter; got query %q", gotQuery)
+	if got := q.Get("work_ref"); got != "gh:evoila/meho#11" {
+		t.Errorf("work_ref filter: got %q, want %q", got, "gh:evoila/meho#11")
+	}
+	if got := q.Get("status"); got != "succeeded" {
+		t.Errorf("status filter: got %q, want %q", got, "succeeded")
+	}
+	if got := q.Get("limit"); got != "25" {
+		t.Errorf("limit filter: got %q, want %q", got, "25")
+	}
+	if got := q.Get("offset"); got != "50" {
+		t.Errorf("offset filter: got %q, want %q", got, "50")
 	}
 	if !strings.Contains(stdout.String(), "no agent runs") {
 		t.Errorf("empty list should print 'no agent runs'; got %q", stdout.String())
@@ -317,7 +330,7 @@ func TestRunListPassesWorkRefFilter(t *testing.T) {
 
 func TestListRunsParamsOmitsEmptyFilters(t *testing.T) {
 	params := listRunsParams(runListOptions{})
-	if params.WorkRef != nil || params.Status != nil || params.Limit != nil {
+	if params.WorkRef != nil || params.Status != nil || params.Limit != nil || params.Offset != nil {
 		t.Errorf("empty options must leave filters nil; got %+v", params)
 	}
 }

--- a/docs/codebase/agent-run.md
+++ b/docs/codebase/agent-run.md
@@ -102,8 +102,10 @@ What is **not** in T6 or T4 (other tasks own these):
   resolver maps it to a concrete pair), `provider` / `model` (resolved,
   nullable until `start`), `status`, `turns`, `cost` (stub until C3),
   `output`, `error`, `parent_run_id` (self-referential soft-FK for
-  agent-invoked child runs, G11.1-T5), `created_at`, `started_at`,
-  `ended_at`.
+  agent-invoked child runs, G11.1-T5), `work_ref` (nullable Text — the
+  external change-ticket reference the run works under, work_ref I3-T2
+  #1662, migration `0041`; set at create time, distinct from `id`),
+  `created_at`, `started_at`, `ended_at`.
 - `AgentRunStatus` — closed `StrEnum`: `pending`, `running`,
   `awaiting_approval`, `succeeded`, `failed`, `cancelled`.
 - `AgentRunTrigger` — closed `StrEnum`: `direct`, `scheduled`, `event`,
@@ -173,10 +175,22 @@ and leave the commit to the caller — the same transaction contract
 one transaction):
 
 - `create_run(session, *, tenant_id, identity_sub, trigger, model_tier,
-  identity_act=None, agent_definition_id=None, parent_run_id=None)
-  -> AgentRun` — inserts a `pending` row; `run.id` is the lineage key.
+  identity_act=None, agent_definition_id=None, parent_run_id=None,
+  work_ref=None) -> AgentRun` — inserts a `pending` row; `run.id` is the
+  lineage key. `work_ref` (work_ref I3-T2 #1662) stamps the external
+  change-ticket reference on the row at create time; the invoker passes
+  it off the shared `work_ref_var` ContextVar so the REST `Meho-Work-Ref`
+  header / MCP `work_ref` arg flows through to the row. Set-at-create-only.
 - `get_run(session, run_id) -> AgentRun | None` — read side; returns
   `None` for a missing id (the caller shapes the 404).
+- `list_runs(session, *, tenant_id, work_ref=None, status=None,
+  limit=100, offset=0) -> list[AgentRun]` — the agent-run list read
+  substrate (work_ref I3-T2 #1662), newest-first, tenant-isolated.
+  `work_ref` narrows to one exact change ticket (composite
+  `(tenant_id, work_ref)` index); `status` narrows to one lifecycle
+  state; the page size is clamped server-side to `[1, 500]`. Surfaced as
+  `GET /api/v1/agents/runs`, the `meho.agents.list_runs` MCP tool, and
+  `meho agent run-list --work-ref`.
 - `transition(session, row, to_status) -> AgentRun` — the single
   status-mutation point. Stamps `started_at` on the first entry into
   `running` (the `awaiting_approval` -> `running` resume does not reset


### PR DESCRIPTION
## Summary

- Adds `agent_run.work_ref` (migration `0041`, nullable Text + composite `(tenant_id, work_ref)` btree index) — the external change-ticket reference an agent run works under. A genuinely distinct column from `id` / the `agent_session_id` lineage key; set-at-create-only.
- `create_run` gains a `work_ref` kwarg; the invoker's `_create_run_row` reads it off the shared `work_ref_var` ContextVar at the run-create boundary, so the REST `Meho-Work-Ref` header and the MCP `work_ref` arg flow onto the row for the sync, async, and SSE-stream paths. `work_ref` is surfaced on the `agent_run.completed` outbox payload.
- New agent-run **list surface** (modelled on the runbook-run list #1661): `list_runs` op (tenant-isolated, newest-first, exact-match `work_ref` + `status` filters, server-clamped paging), `GET /api/v1/agents/runs`, the `meho.agents.list_runs` MCP tool, and `meho agent run-list --work-ref`. `meho agent run --work-ref` tags a run at launch.
- The agent-runs router is now included **before** the agents-definition router so the one-segment `GET /agents/runs` resolves ahead of `GET /agents/{name}` (the same shadow-avoidance ordering the grants router uses).

## Test plan

- [x] `ruff check` / `ruff format --check` — clean (backend `src/` + `tests/`)
- [x] `mypy src/` — clean (471 files)
- [x] `code-quality.py --diff` — 0 blockers (warnings pre-existing)
- [x] Migration round-trip: `test_migration_0041_agent_run_work_ref.py` (upgrade adds nullable column + composite index; downgrade→upgrade round-trips)
- [x] Create-kwarg propagation + work_ref distinct-from-id + NULL-when-absent: `test_agent_run_lifecycle.py`
- [x] `list_runs` filter (exact-match), no-filter (ticketed + un-ticketed), tenant isolation: `test_agent_run_lifecycle.py`
- [x] Completed-event surfacing (set + NULL): `test_event_outbox.py`
- [x] REST list endpoint + `work_ref` filter via `Meho-Work-Ref` header + tenant isolation: `test_api_v1_agent_runs.py`
- [x] MCP `meho.agents.list_runs` + tool registration: `test_mcp_tools_agent_runs.py`
- [x] CLI `run-list` happy path / work-ref+status filter / empty list, verb registration: `internal/cmd/agent` (`go test`, `go vet`, `gofmt`)
- [x] CLI regenerated: `make snapshot-openapi && make generate` (cli/api/openapi.json, cli/internal/api/client.gen.go committed)
- [x] `docs/codebase/agent-run.md` updated (work_ref column, `create_run` kwarg, `list_runs`)

## Out of scope

- Runbook-run / scheduler binding (I3-T1 #1661, I3-T3).
- Reusing `agent_session_id` for the ref (explicitly rejected by the issue — different identity).

<!-- auto-implement-issue: fresh, iteration 1 -->

Closes #1662


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **New Features**
  * List agent runs with pagination and filtering by work reference and execution status.
  * Associate runs with external work or change references for cross-system correlation.
  * New `GET /api/v1/agents/runs` endpoint and `meho agent run-list` CLI command.
  * Optional `Meho-Work-Ref` header support for tagging runs with external references.

* **Documentation**
  * Updated agent run documentation with new listing and work reference capabilities.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->