### PR TITLE
feat(mcp)!: remove deprecated flat runbook_* tool aliases + slug field alias (#1625)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -133,6 +133,26 @@ connector-related release-notes line.
   `runbook_<verb>` with `meho.runbook.<verb>` and rename `slug` →
   `template_slug` in template-verb arguments (#1612, #1702).
 
+### Removed
+
+- Removed the 11 deprecated flat `runbook_*` MCP tool-name aliases and
+  the `slug` template-id input alias, completing the one-release
+  deprecation contract opened in #1612 (v0.13.0) and deferred once from
+  v0.14.0 to v0.15.0 by #1702. The runbook MCP family now serves exactly
+  the 11 dotted `meho.runbook.<verb>` tools; a removed flat name returns
+  the registry's standard unknown-tool error, and the template verbs
+  accept `template_slug` only (`slug` is now rejected). The unused
+  alias machinery (`register_deprecated_mcp_tool_alias`, the
+  `deprecated_alias_for` marker, and the `mcp_tool_name_deprecated` /
+  `runbook_template_slug_field_deprecated` warnings) was deleted with
+  it. Migration (unchanged from #1612): replace `runbook_<verb>` with
+  `meho.runbook.<verb>` and rename `slug` → `template_slug` in
+  template-verb arguments. Template-verb responses still carry
+  `template_slug`, so ids round-trip into `meho.runbook.start`
+  unchanged. The database tables `runbook_templates` / `runbook_runs` /
+  `runbook_run_step_states` are not tool names and are unaffected
+  (#1612, #1702, #1625).
+
 ### Fixed
 
 - Operator console: broadcast feed/wall and the connectors recent-ops

--- a/backend/src/meho_backplane/mcp/handlers.py
+++ b/backend/src/meho_backplane/mcp/handlers.py
@@ -1,5 +1,12 @@
 # SPDX-License-Identifier: Apache-2.0
 # Copyright (c) 2026 evoila Group
+#
+# code-quality-allow: file-size — the JSON-RPC envelope dispatcher for the
+# whole MCP surface (tools/call, resources/read, audit, event publish). It
+# was already well over the 600-line limit on main (two oversized handlers
+# inside carry their own per-function allows); #1625 only removed the
+# now-dead deprecated-alias breadcrumb. Splitting the dispatcher is a
+# behaviour-preserving refactor out of scope for an alias-removal task.
 
 """JSON-RPC method handlers for the registry-backed MCP surface (G0.5-T3).
 
@@ -273,19 +280,6 @@ async def handle_tools_call(
             raise McpInvalidParamsError(f"unknown tool: {name!r}")
         defn, handler = entry
         audit_payload["op_class"] = defn.op_class
-
-        # Deprecated-alias breadcrumb (#1612). A call arriving under a
-        # deprecated tool name still dispatches normally (the alias
-        # shares the canonical handler), but the structured warning
-        # gives operators a migration signal to watch before the alias
-        # is removed — same posture as the field-level
-        # ``add_to_memory_field_deprecated`` shim log.
-        if defn.deprecated_alias_for is not None:
-            _log.warning(
-                "mcp_tool_name_deprecated",
-                tool=name,
-                replacement=defn.deprecated_alias_for,
-            )
 
         # RBAC: the tool's required_role gates *invocation*, not just listing.
         # The list filter already hides tools the operator can't call, but

--- a/backend/src/meho_backplane/mcp/registry.py
+++ b/backend/src/meho_backplane/mcp/registry.py
@@ -1,5 +1,12 @@
 # SPDX-License-Identifier: Apache-2.0
 # Copyright (c) 2026 evoila Group
+#
+# code-quality-allow: file-size — this module is the single coherent MCP
+# registry substrate (tool + resource registration, RBAC/capability
+# filtering, wire serialisation). It was already over the 600-line limit
+# on main; #1625's removal of the deprecated-alias machinery shrank it.
+# Splitting the two registries into separate modules is a behaviour-
+# preserving refactor out of scope for an alias-removal task.
 
 """MCP tool + resource registries — the substrate G3-G9 verbs register against.
 
@@ -80,7 +87,6 @@ __all__ = [
     "eager_import_mcp_modules",
     "get_resource_for_uri",
     "get_tool",
-    "register_deprecated_mcp_tool_alias",
     "register_mcp_resource",
     "register_mcp_tool",
     "role_at_least",
@@ -225,16 +231,6 @@ class ToolDefinition(BaseModel):
     required_role: TenantRole = TenantRole.OPERATOR
     op_class: str = "read"
     required_capability: str | None = None
-    #: MEHO-internal deprecation marker (#1612). When set, this
-    #: definition is a deprecated alias for the named canonical tool:
-    #: same handler, same schema, kept resolvable for one release so
-    #: pinned callers keep working. The dispatcher emits a structured
-    #: ``mcp_tool_name_deprecated`` warning per call so operators can
-    #: watch consumers migrate before the alias is removed. Never
-    #: serialised to the wire (the MCP 2025-06-18 ``Tool`` object has
-    #: no deprecation field; the alias's *description* carries the
-    #: agent-visible DEPRECATED marker instead).
-    deprecated_alias_for: str | None = None
 
     def to_wire(self) -> dict[str, Any]:
         """Serialise to the MCP wire shape, dropping MEHO-internal fields.
@@ -353,48 +349,6 @@ def register_mcp_tool(definition: ToolDefinition, handler: ToolHandler) -> None:
         raise RuntimeError(f"MCP tool already registered: {definition.name!r}")
     _TOOLS[definition.name] = (definition, handler)
     _log.info("mcp_tool_registered", name=definition.name)
-
-
-def register_deprecated_mcp_tool_alias(
-    *,
-    alias: str,
-    canonical: str,
-    removal_version: str,
-) -> None:
-    """Register *alias* as a deprecated second name for the *canonical* tool.
-
-    The alias shares the canonical tool's handler **object** (callers can
-    assert identity), ``inputSchema``, role gate, op class, and capability
-    gate — only ``name`` and ``description`` differ, plus the
-    MEHO-internal :attr:`ToolDefinition.deprecated_alias_for` marker the
-    dispatcher keys its ``mcp_tool_name_deprecated`` warning on. The
-    description is generated here so every alias on the surface carries
-    the same DEPRECATED phrasing (the one-cycle alias convention from the
-    ``content``→``body`` / ``id``→``approval_request_id`` field shims,
-    lifted to whole tool names for #1612).
-
-    The canonical tool must already be registered — alias registration is
-    a strict follow-on so the pair is always created together at module
-    import and the alias can never outlive (or predate) its target.
-    """
-    entry = _TOOLS.get(canonical)
-    if entry is None:
-        raise RuntimeError(
-            f"cannot register alias {alias!r}: canonical MCP tool {canonical!r} is not registered",
-        )
-    definition, handler = entry
-    alias_definition = definition.model_copy(
-        update={
-            "name": alias,
-            "description": (
-                f"DEPRECATED alias for `{canonical}`; removed in "
-                f"v{removal_version}. Identical arguments and behaviour — "
-                f"new callers MUST use `{canonical}`."
-            ),
-            "deprecated_alias_for": canonical,
-        }
-    )
-    register_mcp_tool(alias_definition, handler)
 
 
 def register_mcp_resource(

--- a/backend/src/meho_backplane/mcp/tools/runbook_runs.py
+++ b/backend/src/meho_backplane/mcp/tools/runbook_runs.py
@@ -86,7 +86,6 @@ from pydantic import ValidationError
 from meho_backplane.auth.operator import Operator, TenantRole
 from meho_backplane.mcp.registry import (
     ToolDefinition,
-    register_deprecated_mcp_tool_alias,
     register_mcp_tool,
 )
 from meho_backplane.mcp.server import McpInvalidParamsError
@@ -153,14 +152,6 @@ _INVALID_PARAMS_ERRORS = (
 #: default (100).
 _DEFAULT_LIST_LIMIT: Final[int] = 100
 _MAX_LIST_LIMIT: Final[int] = 500
-
-#: Release that drops the deprecated flat ``runbook_*`` tool-name
-#: aliases (#1612); deferred from the original v0.14.0 window by #1702
-#: after v0.14.0 was tagged with the aliases still registered. Must
-#: stay in lockstep with the template-side constant in
-#: :mod:`meho_backplane.mcp.tools.runbooks` — the 11 aliases are
-#: announced and removed as one set.
-_ALIAS_REMOVAL_VERSION: Final[str] = "0.15.0"
 
 
 def _to_invalid_params(tool: str, exc: Exception) -> McpInvalidParamsError:
@@ -691,26 +682,3 @@ register_mcp_tool(
     ),
     handler=_list_runs_handler,
 )
-
-
-# ---------------------------------------------------------------------------
-# Deprecated flat-name aliases (#1612) — removed in v0.15.0
-# (`_ALIAS_REMOVAL_VERSION`; deferred from the original one-release
-# v0.14.0 window by #1702). Registered strictly after their
-# canonical targets; each shares the canonical handler object and
-# schema, differing only in name + DEPRECATED pointer description.
-# ---------------------------------------------------------------------------
-
-
-for _flat_alias, _canonical in (
-    ("runbook_start", "meho.runbook.start"),
-    ("runbook_next", "meho.runbook.next"),
-    ("runbook_abort", "meho.runbook.abort"),
-    ("runbook_reassign", "meho.runbook.reassign"),
-    ("runbook_list_runs", "meho.runbook.list_runs"),
-):
-    register_deprecated_mcp_tool_alias(
-        alias=_flat_alias,
-        canonical=_canonical,
-        removal_version=_ALIAS_REMOVAL_VERSION,
-    )

--- a/backend/src/meho_backplane/mcp/tools/runbooks.py
+++ b/backend/src/meho_backplane/mcp/tools/runbooks.py
@@ -1,5 +1,12 @@
 # SPDX-License-Identifier: Apache-2.0
 # Copyright (c) 2026 evoila Group
+# code-quality-allow: load-bearing tool descriptions per issue #1298; the
+# six template-verb descriptions teach the multi-session drafting pattern,
+# fork-on-edit semantics, and the opacity-floor carve-out, and are
+# regression-tested verbatim. The file was already over the 600-line limit
+# on main; #1625's removal of the deprecated-alias machinery shrank it.
+# Splitting would obscure the contract. Same structural choice as the
+# sibling mcp/tools/runbook_runs.py (run-side).
 
 """``meho.runbook.*`` template-lifecycle MCP tools (G12.2-T4).
 
@@ -13,21 +20,20 @@ and the ``in_flight_run_count`` query all live in one place (T2, #1296).
 Naming + field canonicalisation (#1612)
 =======================================
 
-The canonical tool names are dotted — ``meho.runbook.draft_template``,
+The tool names are dotted — ``meho.runbook.draft_template``,
 ``meho.runbook.show_template``, … — matching the ``meho.<noun>.<verb>``
 grammar every other multi-verb family on the surface uses. The original
-flat ``runbook_*`` names remain registered as deprecated aliases (same
-handler object, same schema) and are removed in v0.15.0 — deferred from
-the original one-release v0.14.0 window by #1702; calling one emits the
-dispatcher's ``mcp_tool_name_deprecated`` warning.
+flat ``runbook_*`` names were kept as deprecated aliases for one window
+after #1612 and were removed in v0.15.0 (#1625; the deadline was
+deferred once from the original v0.14.0 window by #1702).
 
-The template identifier is canonically ``template_slug`` on every wire
-input (matching ``meho.runbook.start`` / ``meho.runbook.list_runs`` on
-the run side), with the pre-#1612 ``slug`` accepted as a deprecated
-input alias for the same window via :func:`_resolve_template_slug`.
-Responses mirror the model's ``slug`` key as ``template_slug`` (see
-:func:`_mirror_template_slug`) so an id read from any template verb
-round-trips verbatim into ``meho.runbook.start`` with no field rename.
+The template identifier is ``template_slug`` on every wire input
+(matching ``meho.runbook.start`` / ``meho.runbook.list_runs`` on the run
+side); the pre-#1612 ``slug`` input alias was removed alongside the flat
+names. Responses still mirror the model's ``slug`` key as
+``template_slug`` (see :func:`_mirror_template_slug`) so an id read from
+any template verb round-trips verbatim into ``meho.runbook.start`` with
+no field rename.
 
 Why the descriptions are long
 =============================
@@ -91,7 +97,6 @@ from meho_backplane.auth.operator import Operator, TenantRole
 from meho_backplane.kb.schemas import InvalidKbSlugError
 from meho_backplane.mcp.registry import (
     ToolDefinition,
-    register_deprecated_mcp_tool_alias,
     register_mcp_tool,
 )
 from meho_backplane.mcp.server import McpInvalidParamsError
@@ -122,18 +127,6 @@ _log = structlog.get_logger(__name__)
 #: flips are ``write``; list + show are ``read``.
 _OP_CLASS_READ: Final[str] = "read"
 _OP_CLASS_WRITE: Final[str] = "write"
-
-#: Release that drops the deprecated flat ``runbook_*`` tool-name
-#: aliases and the ``slug`` input-field alias (#1612). Originally one
-#: release after the canonicalisation shipped (v0.14.0, mirroring the
-#: v0.6.x ``content``→``body`` one-cycle shim), but v0.14.0 was tagged
-#: with the aliases still registered and no release-notes line, so
-#: #1702 re-pinned the deadline to v0.15.0 with a public deferral
-#: erratum on the v0.14.0 CHANGELOG section. The value is description/
-#: warning text only — removal is executed by the scheduled task
-#: (#1625, re-scheduled to the v0.15.0 cycle), not by a runtime
-#: version gate (``__version__`` is build-metadata-dependent; #1698).
-_ALIAS_REMOVAL_VERSION: Final[str] = "0.15.0"
 
 #: The caller-actionable service exceptions that map to JSON-RPC
 #: ``-32602``. Bad input or a missing / wrong-state entity is the
@@ -168,40 +161,17 @@ def _to_invalid_params(tool: str, exc: Exception) -> McpInvalidParamsError:
 
 
 def _resolve_template_slug(tool: str, arguments: dict[str, Any]) -> str:
-    """Resolve the template id from ``template_slug`` (canonical) or ``slug``.
+    """Read the required ``template_slug`` template id from *arguments*.
 
-    One-cycle deprecation shim for the #1612 ``slug`` → ``template_slug``
-    field unification, mirroring the v0.6.x ``content`` → ``body`` shim
-    on ``add_to_memory``: exactly one of the two names must be supplied
-    (both → ``-32602``), and the deprecated name emits a structured
-    ``runbook_template_slug_field_deprecated`` warning so operators can
-    watch consumers migrate before the alias is dropped in v0.15.0
-    (:data:`_ALIAS_REMOVAL_VERSION`; deferred from v0.14.0 by #1702).
-
-    The dispatcher's JSON-Schema gate (:data:`_TEMPLATE_SLUG_ANYOF`)
-    guarantees at least one name is present; the neither-supplied branch
-    is the fail-closed answer to a schema regression, not a real
-    run-time path.
+    ``template_slug`` is the single canonical field name across all 11
+    runbook tools (#1612). The dispatcher's JSON-Schema gate marks it
+    ``required`` on every template verb, so the absent branch is the
+    fail-closed answer to a schema regression, not a real run-time path
+    (the deprecated ``slug`` input alias and its XOR guard were removed
+    in v0.15.0 per #1625).
     """
-    has_canonical = "template_slug" in arguments
-    has_alias = "slug" in arguments
-    if has_canonical and has_alias:
-        raise McpInvalidParamsError(
-            f"{tool}: pass either `template_slug` (canonical) or `slug` "
-            "(deprecated alias), not both",
-        )
-    if has_alias:
-        _log.warning(
-            "runbook_template_slug_field_deprecated",
-            tool=tool,
-            replacement="template_slug",
-            removal_version=_ALIAS_REMOVAL_VERSION,
-        )
-        return str(arguments["slug"])
-    if not has_canonical:
-        raise McpInvalidParamsError(
-            f"{tool}: one of `template_slug` or `slug` must be supplied",
-        )
+    if "template_slug" not in arguments:
+        raise McpInvalidParamsError(f"{tool}: `template_slug` is required")
     return str(arguments["template_slug"])
 
 
@@ -211,11 +181,10 @@ def _mirror_template_slug(payload: dict[str, Any]) -> dict[str, Any]:
     The shared Pydantic response models keep their ``slug`` field (the
     REST surface is out of #1612's scope), so the MCP handlers mirror it
     at the wire boundary: every template-verb response carries
-    ``template_slug`` (canonical, what ``meho.runbook.start`` accepts
-    verbatim) *and* ``slug`` (kept for the same alias window as the
-    input alias, dropped with it in v0.15.0 per #1702). Top-level only — the
-    nested ``forked_from.slug`` names the fork *source* and is not a
-    round-trip input.
+    ``template_slug`` (canonical, the field name ``meho.runbook.start``
+    accepts verbatim) alongside the model's native ``slug``. Top-level
+    only — the nested ``forked_from.slug`` names the fork *source* and is
+    not a round-trip input.
     """
     if "slug" in payload:
         payload["template_slug"] = payload["slug"]
@@ -321,8 +290,9 @@ _LIST_DESCRIPTION: Final[str] = (
     "List runbook templates in the operator's tenant. Returns "
     "template_slugs + titles + status\n"
     "+ target_kind + edited_at. Does NOT return step bodies — use\n"
-    "`meho.runbook.show_template` (TENANT_ADMIN-only) to read full "
-    "content.\n\n"
+    "`meho.runbook.show_template` to read full content (TENANT_ADMIN "
+    "unconditionally; OPERATOR only for a template they hold a "
+    "completed or abandoned run against).\n\n"
     "Operators see this surface to discover available procedures before\n"
     "`meho.runbook.start` — each summary's `template_slug` is accepted "
     "verbatim by `meho.runbook.start`. TENANT_ADMINs see the same to "
@@ -377,43 +347,11 @@ _TEMPLATE_SLUG_PROPERTY: Final[dict[str, Any]] = {
         "Template identifier in kebab-case (the same slug shape as kb "
         "entries): must start with a lowercase letter and contain only "
         "lowercase letters, digits, hyphens, or dots. Example: "
-        "'vcenter-9.0-cert-rotation'. REQUIRED (unless the deprecated "
-        "`slug` alias is supplied instead). Canonical field name across "
-        "all 11 runbook tools (#1612) — the same name "
+        "'vcenter-9.0-cert-rotation'. REQUIRED. Canonical field name "
+        "across all 11 runbook tools (#1612) — the same name "
         "`meho.runbook.start` takes and every template response returns."
     ),
 }
-
-#: Deprecated ``slug`` input alias kept for the pre-#1612 wire shape.
-#: Same constraints as :data:`_TEMPLATE_SLUG_PROPERTY`; the handler
-#: enforces the XOR and emits the migration warning (see
-#: :func:`_resolve_template_slug`).
-_SLUG_ALIAS_PROPERTY: Final[dict[str, Any]] = {
-    "type": "string",
-    "minLength": 1,
-    "description": (
-        "DEPRECATED alias for `template_slug` (pre-#1612 wire shape); "
-        f"removed in v{_ALIAS_REMOVAL_VERSION}. Accepted for backward "
-        "compatibility; new callers MUST use `template_slug`. Mutually "
-        "exclusive with `template_slug`; passing both rejects with "
-        "-32602. Supplying `slug` emits a structured "
-        "`runbook_template_slug_field_deprecated` warning log."
-    ),
-    "deprecated": True,
-}
-
-#: Either field name satisfies the "template id required" constraint;
-#: the handler enforces the XOR. Top-level ``anyOf`` is stripped from
-#: the *wire* copy of the schema by ``_wire_safe_input_schema`` (the
-#: Anthropic Messages API rejects top-level combinators), so the wire
-#: ``required`` omits the template id and the property descriptions
-#: carry the contract; server-side ``jsonschema.validate`` still
-#: enforces it before the handler runs. Same shape as the
-#: ``approval_request_id``/``id`` and ``body``/``content`` shims.
-_TEMPLATE_SLUG_ANYOF: Final[list[dict[str, Any]]] = [
-    {"required": ["template_slug"]},
-    {"required": ["slug"]},
-]
 
 #: The author-facing template body shape. Mirrors
 #: :class:`~meho_backplane.runbooks.schemas.RunbookTemplateBody`; the
@@ -675,11 +613,7 @@ def _opacity_floor_denial() -> McpInvalidParamsError:
     Centralised so every operator-path denial uses the same message --
     anti-enumeration relies on the response being identical regardless of
     which leg of the predicate failed (slug missing, version missing, no
-    completed run). The message names the canonical tool even when the
-    call arrived via the deprecated ``runbook_show_template`` alias --
-    deriving it from the called name would cost the single-message
-    property nothing, but pinning it keeps the denial byte-identical
-    across both names for the deprecation window.
+    completed run).
     """
     return McpInvalidParamsError("meho.runbook.show_template: opacity_floor")
 
@@ -697,11 +631,9 @@ register_mcp_tool(
             "type": "object",
             "properties": {
                 "template_slug": _TEMPLATE_SLUG_PROPERTY,
-                "slug": _SLUG_ALIAS_PROPERTY,
                 "body": _BODY_PROPERTY,
             },
-            "required": ["body"],
-            "anyOf": _TEMPLATE_SLUG_ANYOF,
+            "required": ["template_slug", "body"],
             "additionalProperties": False,
         },
         required_role=TenantRole.TENANT_ADMIN,
@@ -719,11 +651,9 @@ register_mcp_tool(
             "type": "object",
             "properties": {
                 "template_slug": _TEMPLATE_SLUG_PROPERTY,
-                "slug": _SLUG_ALIAS_PROPERTY,
                 "body": _BODY_PROPERTY,
             },
-            "required": ["body"],
-            "anyOf": _TEMPLATE_SLUG_ANYOF,
+            "required": ["template_slug", "body"],
             "additionalProperties": False,
         },
         required_role=TenantRole.TENANT_ADMIN,
@@ -741,11 +671,9 @@ register_mcp_tool(
             "type": "object",
             "properties": {
                 "template_slug": _TEMPLATE_SLUG_PROPERTY,
-                "slug": _SLUG_ALIAS_PROPERTY,
                 "version": _VERSION_PROPERTY,
             },
-            "required": ["version"],
-            "anyOf": _TEMPLATE_SLUG_ANYOF,
+            "required": ["template_slug", "version"],
             "additionalProperties": False,
         },
         required_role=TenantRole.TENANT_ADMIN,
@@ -763,11 +691,9 @@ register_mcp_tool(
             "type": "object",
             "properties": {
                 "template_slug": _TEMPLATE_SLUG_PROPERTY,
-                "slug": _SLUG_ALIAS_PROPERTY,
                 "version": _VERSION_PROPERTY,
             },
-            "required": ["version"],
-            "anyOf": _TEMPLATE_SLUG_ANYOF,
+            "required": ["template_slug", "version"],
             "additionalProperties": False,
         },
         required_role=TenantRole.TENANT_ADMIN,
@@ -819,7 +745,6 @@ register_mcp_tool(
             "type": "object",
             "properties": {
                 "template_slug": _TEMPLATE_SLUG_PROPERTY,
-                "slug": _SLUG_ALIAS_PROPERTY,
                 "version": {
                     **_VERSION_PROPERTY,
                     "description": (
@@ -827,11 +752,7 @@ register_mcp_tool(
                     ),
                 },
             },
-            # No `required` array — the template id is the only required
-            # input and it is accepted under either alias name, so the
-            # `anyOf` is the only required-shape declaration (the
-            # broadcast.watch cursor/since_cursor precedent, §14.2).
-            "anyOf": _TEMPLATE_SLUG_ANYOF,
+            "required": ["template_slug"],
             "additionalProperties": False,
         },
         required_role=TenantRole.OPERATOR,
@@ -839,27 +760,3 @@ register_mcp_tool(
     ),
     handler=_show_template_handler,
 )
-
-
-# ---------------------------------------------------------------------------
-# Deprecated flat-name aliases (#1612) — removed in v0.15.0
-# (`_ALIAS_REMOVAL_VERSION`; deferred from the original one-release
-# v0.14.0 window by #1702). Registered strictly after their
-# canonical targets; each shares the canonical handler object and
-# schema, differing only in name + DEPRECATED pointer description.
-# ---------------------------------------------------------------------------
-
-
-for _flat_alias, _canonical in (
-    ("runbook_draft_template", "meho.runbook.draft_template"),
-    ("runbook_edit_template", "meho.runbook.edit_template"),
-    ("runbook_publish_template", "meho.runbook.publish_template"),
-    ("runbook_deprecate_template", "meho.runbook.deprecate_template"),
-    ("runbook_list_templates", "meho.runbook.list_templates"),
-    ("runbook_show_template", "meho.runbook.show_template"),
-):
-    register_deprecated_mcp_tool_alias(
-        alias=_flat_alias,
-        canonical=_canonical,
-        removal_version=_ALIAS_REMOVAL_VERSION,
-    )

--- a/backend/src/meho_backplane/runbooks/engine.py
+++ b/backend/src/meho_backplane/runbooks/engine.py
@@ -151,7 +151,7 @@ class AdvanceOutcome:
       ``no``/``escalate``, or the ``operation_call`` verify's ``actual``
       did not match ``expect``). T3 writes the current step's state to
       ``failed``; the run as a whole remains ``in_progress`` and the
-      operator either retries (by re-issuing ``runbook_next`` with a
+      operator either retries (by re-issuing ``meho.runbook.next`` with a
       corrected response) or aborts.
 
     :attr:`verify_response_persisted` is the canonical response shape T3

--- a/backend/src/meho_backplane/runbooks/runs_schemas.py
+++ b/backend/src/meho_backplane/runbooks/runs_schemas.py
@@ -13,7 +13,7 @@ scrolling past authoring types.
 
 The load-bearing data structure here is :class:`StepBody` -- the
 *opaque-by-construction* single-step shape returned by the
-``runbook_next`` tool. The structural property that makes the entire
+``meho.runbook.next`` tool. The structural property that makes the entire
 Initiative #1198 adherence floor real is that this shape carries
 **exactly one step body** (the one the operator is currently on, with
 ``${run.target}`` / ``${run.params.X}`` substitutions resolved) and no
@@ -31,7 +31,7 @@ module established:
   (``"confirm"`` / ``"operation_call"``); the operator/engine's answer to
   the current step's verify gate.
 * :data:`NextStepResponse` -- discriminated on ``kind``
-  (``"current_step"`` / ``"completed"``); the ``runbook_next`` tool's
+  (``"current_step"`` / ``"completed"``); the ``meho.runbook.next`` tool's
   reply shape. The explicit ``kind`` tag is chosen deliberately over a
   field-presence-based callable discriminator because (a) it is more
   debuggable at the wire boundary, and (b) it matches the existing
@@ -115,7 +115,7 @@ class OperationCallVerifyResponse(BaseModel):
 
 
 #: The verify-response surface a caller (operator) sends back to
-#: ``runbook_next`` or the engine populates from a dispatched call.
+#: ``meho.runbook.next`` or the engine populates from a dispatched call.
 #: Discriminated on ``type`` -- the same tag the template-side
 #: :class:`~meho_backplane.runbooks.schemas.Verify` union uses, so the
 #: response shape mirrors the gate shape one-for-one. An unknown ``type``
@@ -159,7 +159,7 @@ class StepBodyVerify(BaseModel):
 
 
 class StepBody(BaseModel):
-    """The opaque-by-construction single-step shape returned by ``runbook_next``.
+    """The opaque-by-construction single-step shape returned by ``meho.runbook.next``.
 
     All ``${run.target}`` and ``${run.params.X}`` substitutions are
     already resolved by the engine (G12.3-T2, #1301); the strings here
@@ -175,7 +175,7 @@ class StepBody(BaseModel):
     * :attr:`op_id` / :attr:`params` -- populated only for
       ``operation_call`` steps; the substituted call shape.
     * :attr:`verify` -- the substituted-and-frozen verify gate the
-      caller must respond to on the next ``runbook_next`` call.
+      caller must respond to on the next ``meho.runbook.next`` call.
 
     What this shape **must not** carry, by structural construction
     (regression-tested in ``test_step_body_omits_future_step_fields``):
@@ -236,7 +236,7 @@ class StepPosition(BaseModel):
 
 
 class StartRunRequest(BaseModel):
-    """Request body for ``runbook_start`` -- begin a new run on a template.
+    """Request body for ``meho.runbook.start`` -- begin a new run on a template.
 
     :attr:`template_slug` references a *published* runbook template; the
     service layer (G12.3-T3) resolves it to a pinned ``(slug, version)``
@@ -255,7 +255,7 @@ class StartRunRequest(BaseModel):
 
 
 class CurrentStepResponse(BaseModel):
-    """Returned by ``runbook_start`` and the non-completion path of ``runbook_next``.
+    """Returned by ``meho.runbook.start`` and the non-completion path of ``meho.runbook.next``.
 
     Carries the run coordinates (``run_id`` / ``template_slug`` /
     ``template_version``), the structural position hint
@@ -282,7 +282,7 @@ class CurrentStepResponse(BaseModel):
 
 
 class RunCompletedResponse(BaseModel):
-    """Returned by ``runbook_next`` when the previous step was the last.
+    """Returned by ``meho.runbook.next`` when the previous step was the last.
 
     The terminal-state shape: no step body, just the run coordinates
     and the transition timestamp. The companion abort-side shape is
@@ -304,7 +304,7 @@ class RunCompletedResponse(BaseModel):
     completed_at: datetime
 
 
-#: Reply shape of ``runbook_next`` -- discriminated on ``kind``. The
+#: Reply shape of ``meho.runbook.next`` -- discriminated on ``kind``. The
 #: non-completion path returns a :class:`CurrentStepResponse` (one step
 #: body, no future-step leakage); the completion path returns a
 #: :class:`RunCompletedResponse` (terminal-state marker, no step
@@ -317,7 +317,7 @@ NextStepResponse = Annotated[
 
 
 class NextStepRequest(BaseModel):
-    """Request body for ``runbook_next`` -- advance the run.
+    """Request body for ``meho.runbook.next`` -- advance the run.
 
     :attr:`last_verified` is the caller's *claim* that the previous
     step's verify gate was satisfied. It is **informational only**:
@@ -332,7 +332,7 @@ class NextStepRequest(BaseModel):
     :attr:`verify_response` carries the operator's answer for a
     ``confirm`` step or the engine's captured result for an
     ``operation_call`` step. ``None`` is valid only on the very first
-    ``runbook_next`` call (when no prior step exists to verify).
+    ``meho.runbook.next`` call (when no prior step exists to verify).
     """
 
     model_config = ConfigDict(frozen=True)
@@ -342,7 +342,7 @@ class NextStepRequest(BaseModel):
 
 
 class AbortRunRequest(BaseModel):
-    """Request body for ``runbook_abort`` -- terminate the run mid-flight.
+    """Request body for ``meho.runbook.abort`` -- terminate the run mid-flight.
 
     :attr:`reason` is required and non-empty (``Field(min_length=1)``)
     because it is persisted to ``audit_log.payload`` for the abort
@@ -356,7 +356,7 @@ class AbortRunRequest(BaseModel):
 
 
 class AbortRunResponse(BaseModel):
-    """Returned by ``runbook_abort`` -- the terminal-state coordinates."""
+    """Returned by ``meho.runbook.abort`` -- the terminal-state coordinates."""
 
     model_config = ConfigDict(frozen=True)
 
@@ -366,13 +366,13 @@ class AbortRunResponse(BaseModel):
 
 
 class ReassignRunRequest(BaseModel):
-    """Request body for ``runbook_reassign`` -- transfer ownership of a run.
+    """Request body for ``meho.runbook.reassign`` -- transfer ownership of a run.
 
     :attr:`new_assignee` is the operator subject identifier of the
     new owner. Non-empty (``Field(min_length=1)``) because the
     reassign path writes to ``runbook_runs.assigned_to`` which is
     ``NOT NULL`` at the storage layer and is the predicate for
-    every subsequent ``runbook_next`` ownership check.
+    every subsequent ``meho.runbook.next`` ownership check.
     """
 
     model_config = ConfigDict(frozen=True)
@@ -381,7 +381,7 @@ class ReassignRunRequest(BaseModel):
 
 
 class ReassignRunResponse(BaseModel):
-    """Returned by ``runbook_reassign`` -- the new ownership coordinates."""
+    """Returned by ``meho.runbook.reassign`` -- the new ownership coordinates."""
 
     model_config = ConfigDict(frozen=True)
 
@@ -391,7 +391,7 @@ class ReassignRunResponse(BaseModel):
 
 
 class ListRunsFilter(BaseModel):
-    """Optional filters for ``runbook_list_runs``.
+    """Optional filters for ``meho.runbook.list_runs``.
 
     All three fields default to ``None`` (no filter applied). A bare
     :class:`ListRunsFilter` -- equivalent to passing no filter at all
@@ -414,11 +414,11 @@ class ListRunsFilter(BaseModel):
 
 
 class RunSummary(BaseModel):
-    """List-view projection returned by ``runbook_list_runs``.
+    """List-view projection returned by ``meho.runbook.list_runs``.
 
     Run-level state only: no step contents are exposed. The
     step-by-step content is opaque-by-construction (only
-    ``runbook_next`` ever returns a step body, and only one step at a
+    ``meho.runbook.next`` ever returns a step body, and only one step at a
     time), so :attr:`current_step_id` is the *id* of the step the
     run is currently on -- enough for a UI to render "step 3:
     drain-node" -- but not the body.

--- a/backend/src/meho_backplane/runbooks/schemas.py
+++ b/backend/src/meho_backplane/runbooks/schemas.py
@@ -290,7 +290,7 @@ class RunbookTemplateBody(BaseModel):
 
 
 class ForkInfo(BaseModel):
-    """Surfaced by ``runbook_edit_template`` when editing a published template forks.
+    """Surfaced by ``meho.runbook.edit_template`` when editing a published template forks.
 
     Editing a *published* template cannot mutate it in place (published
     templates are immutable); the edit forks a new draft instead. This
@@ -307,7 +307,7 @@ class ForkInfo(BaseModel):
 
 
 class DraftTemplateRequest(BaseModel):
-    """Request body for ``runbook_draft_template`` -- create a new draft.
+    """Request body for ``meho.runbook.draft_template`` -- create a new draft.
 
     :attr:`slug` is validated against :data:`SLUG_PATTERN` (the kb slug
     contract, reused verbatim).
@@ -320,7 +320,7 @@ class DraftTemplateRequest(BaseModel):
 
 
 class DraftTemplateResponse(BaseModel):
-    """Response for ``runbook_draft_template`` -- the created draft's coordinates."""
+    """Response for ``meho.runbook.draft_template`` -- the created draft's coordinates."""
 
     model_config = ConfigDict(frozen=True)
 
@@ -330,7 +330,7 @@ class DraftTemplateResponse(BaseModel):
 
 
 class EditTemplateRequest(BaseModel):
-    """Request body for ``runbook_edit_template`` -- edit a draft or fork a publish."""
+    """Request body for ``meho.runbook.edit_template`` -- edit a draft or fork a publish."""
 
     model_config = ConfigDict(frozen=True)
 
@@ -339,7 +339,7 @@ class EditTemplateRequest(BaseModel):
 
 
 class EditTemplateResponse(BaseModel):
-    """Response for ``runbook_edit_template``.
+    """Response for ``meho.runbook.edit_template``.
 
     :attr:`version` equals the input version when editing a draft in
     place; it is a new version when forking from a published template, in
@@ -357,7 +357,7 @@ class EditTemplateResponse(BaseModel):
 
 
 class PublishTemplateRequest(BaseModel):
-    """Request body for ``runbook_publish_template`` -- promote a draft to published."""
+    """Request body for ``meho.runbook.publish_template`` -- promote a draft to published."""
 
     model_config = ConfigDict(frozen=True)
 
@@ -366,7 +366,7 @@ class PublishTemplateRequest(BaseModel):
 
 
 class PublishTemplateResponse(BaseModel):
-    """Response for ``runbook_publish_template`` -- the now-published coordinates."""
+    """Response for ``meho.runbook.publish_template`` -- the now-published coordinates."""
 
     model_config = ConfigDict(frozen=True)
 
@@ -376,7 +376,7 @@ class PublishTemplateResponse(BaseModel):
 
 
 class DeprecateTemplateRequest(BaseModel):
-    """Request body for ``runbook_deprecate_template`` -- retire a published version."""
+    """Request body for ``meho.runbook.deprecate_template`` -- retire a published version."""
 
     model_config = ConfigDict(frozen=True)
 
@@ -385,7 +385,7 @@ class DeprecateTemplateRequest(BaseModel):
 
 
 class DeprecateTemplateResponse(BaseModel):
-    """Response for ``runbook_deprecate_template`` -- the now-deprecated coordinates."""
+    """Response for ``meho.runbook.deprecate_template`` -- the now-deprecated coordinates."""
 
     model_config = ConfigDict(frozen=True)
 
@@ -395,7 +395,7 @@ class DeprecateTemplateResponse(BaseModel):
 
 
 class ListTemplatesFilter(BaseModel):
-    """Optional filters for ``runbook_list_templates``.
+    """Optional filters for ``meho.runbook.list_templates``.
 
     Both fields default to ``None`` (no filter). A bare
     :class:`ListTemplatesFilter` lists every template the caller can see.
@@ -408,7 +408,7 @@ class ListTemplatesFilter(BaseModel):
 
 
 class TemplateSummary(BaseModel):
-    """Operator-readable summary row surfaced by ``runbook_list_templates``.
+    """Operator-readable summary row surfaced by ``meho.runbook.list_templates``.
 
     The list-view projection -- enough to identify a template and its
     lifecycle state without loading the full step list (which
@@ -426,7 +426,7 @@ class TemplateSummary(BaseModel):
 
 
 class ShowTemplateResponse(BaseModel):
-    """Full template surface returned by ``runbook_show_template``.
+    """Full template surface returned by ``meho.runbook.show_template``.
 
     The complete template including the ordered :attr:`steps` and the
     authorship / timestamp provenance. Mirrors the

--- a/backend/src/meho_backplane/runbooks/substitution.py
+++ b/backend/src/meho_backplane/runbooks/substitution.py
@@ -13,7 +13,7 @@ current position.
 Two patterns are allowlisted by Initiative #1198, both single-flat-level:
 
 * ``${run.target}`` -- the run's subject (the host, cluster, cert
-  thumbprint) supplied at ``runbook_start`` time.
+  thumbprint) supplied at ``meho.runbook.start`` time.
 * ``${run.params.X}`` -- one of the named run parameters, where ``X``
   matches ``[a-z_][a-z0-9_]*``. Nested paths (``${run.params.X.Y}``) are
   not allowed and are rejected at publish time -- this module assumes the

--- a/backend/tests/mcp_test_fixtures.py
+++ b/backend/tests/mcp_test_fixtures.py
@@ -260,17 +260,17 @@ def isolated_registry() -> Iterator[None]:
     importlib.reload(topology)
     importlib.reload(topology_create_node)
     # G12.2-T4 (#1298): the runbook template MCP tools
-    # (``runbook_*_template`` x 6) join the reload list for the same
+    # (``meho.runbook.*_template`` x 6) join the reload list for the same
     # reason every other tool module does -- the autouse
     # ``clear_registries()`` above would otherwise leave them
     # unregistered in any test file that imports this fixture after
     # the first one runs in the process.
     importlib.reload(runbooks)
-    # G12.3-T6 (#1313): the runbook *run* MCP tools (``runbook_start``
-    # / ``runbook_next`` / ``runbook_abort`` / ``runbook_reassign`` /
-    # ``runbook_list_runs``) join the reload list for the same reason
-    # as the template-side module above. The five tools are imported
-    # but unused here -- pytest collects them via the side-effect
+    # G12.3-T6 (#1313): the runbook *run* MCP tools
+    # (``meho.runbook.start`` / ``.next`` / ``.abort`` / ``.reassign`` /
+    # ``.list_runs``) join the reload list for the same reason as the
+    # template-side module above. The five tools are imported but unused
+    # here -- pytest collects them via the side-effect
     # ``register_mcp_tool`` calls in the module body, not by name.
     importlib.reload(runbook_runs)
     importlib.reload(memory_tools)

--- a/backend/tests/test_mcp_tools_list_shape_conventions.py
+++ b/backend/tests/test_mcp_tools_list_shape_conventions.py
@@ -401,92 +401,101 @@ def test_list_operation_groups_paginates_keyset_on_group_key() -> None:
 
 
 # ---------------------------------------------------------------------------
-# §14.9 — runbook family: dotted canonical names + template_slug field
+# §14.9 — runbook family: dotted names only + template_slug field
 # ---------------------------------------------------------------------------
 
-#: The 11 runbook pairs (#1612): flat v0.12 name → canonical dotted name.
-_RUNBOOK_NAME_PAIRS = (
-    ("runbook_draft_template", "meho.runbook.draft_template"),
-    ("runbook_edit_template", "meho.runbook.edit_template"),
-    ("runbook_publish_template", "meho.runbook.publish_template"),
-    ("runbook_deprecate_template", "meho.runbook.deprecate_template"),
-    ("runbook_list_templates", "meho.runbook.list_templates"),
-    ("runbook_show_template", "meho.runbook.show_template"),
-    ("runbook_start", "meho.runbook.start"),
-    ("runbook_next", "meho.runbook.next"),
-    ("runbook_abort", "meho.runbook.abort"),
-    ("runbook_reassign", "meho.runbook.reassign"),
-    ("runbook_list_runs", "meho.runbook.list_runs"),
+#: The 11 canonical dotted runbook tool names (#1612). After #1625 these
+#: are the *only* runbook tools on the surface — the flat ``runbook_*``
+#: aliases that bridged the one-release migration window were removed.
+_DOTTED_RUNBOOK_TOOLS = (
+    "meho.runbook.draft_template",
+    "meho.runbook.edit_template",
+    "meho.runbook.publish_template",
+    "meho.runbook.deprecate_template",
+    "meho.runbook.list_templates",
+    "meho.runbook.show_template",
+    "meho.runbook.start",
+    "meho.runbook.next",
+    "meho.runbook.abort",
+    "meho.runbook.reassign",
+    "meho.runbook.list_runs",
+)
+
+#: The flat names removed by #1625 — each must now resolve to nothing.
+_REMOVED_FLAT_RUNBOOK_TOOLS = (
+    "runbook_draft_template",
+    "runbook_edit_template",
+    "runbook_publish_template",
+    "runbook_deprecate_template",
+    "runbook_list_templates",
+    "runbook_show_template",
+    "runbook_start",
+    "runbook_next",
+    "runbook_abort",
+    "runbook_reassign",
+    "runbook_list_runs",
 )
 
 
-@pytest.mark.parametrize(("flat_name", "dotted_name"), _RUNBOOK_NAME_PAIRS)
-def test_runbook_tools_dotted_canonical_with_flat_deprecated_alias(
-    flat_name: str,
-    dotted_name: str,
-) -> None:
-    """Convention §14.9: runbooks follow the dotted `meho.<noun>.<verb>` grammar.
+def test_runbook_family_is_exactly_eleven_dotted_tools() -> None:
+    """Convention §14.9: the runbook family is exactly 11 dotted tools, zero flat.
 
-    The runbook family was the last flat multi-verb family on the
-    surface (#1612). The dotted name is canonical; the flat name stays
-    registered as a deprecated alias routed to the same handler
-    (removed in v0.15.0 — deferred from the original one-release
-    v0.14.0 window by #1702).
+    The runbook family was the last flat multi-verb family on the surface
+    (#1612). #1612 made the dotted ``meho.runbook.<verb>`` names canonical
+    and kept the flat ``runbook_*`` names as deprecated aliases for one
+    release; #1625 removed them. The wire surface now serves exactly the
+    11 dotted tools and no flat aliases.
     """
-    dotted_entry = mcp_registry.get_tool(dotted_name)
-    flat_entry = mcp_registry.get_tool(flat_name)
-    assert dotted_entry is not None, dotted_name
-    assert flat_entry is not None, flat_name
-    # Canonical carries no deprecation marker; the alias points home.
-    assert dotted_entry[0].deprecated_alias_for is None
-    assert flat_entry[0].deprecated_alias_for == dotted_name
-    assert flat_entry[0].description.startswith(f"DEPRECATED alias for `{dotted_name}`")
-    # Same handler object — alias, not fork.
-    assert flat_entry[1] is dotted_entry[1]
+    # Enumerate the live tool registry (the same private map the
+    # dispatcher resolves against). The structural pin is total: the set
+    # of runbook-family tools equals the 11 dotted names, with no flat
+    # ``runbook_*`` survivor anywhere on the surface.
+    registered = set(mcp_registry._TOOLS)
+    runbook_family = {name for name in registered if "runbook" in name.lower()}
+    assert runbook_family == set(_DOTTED_RUNBOOK_TOOLS)
+    assert not [name for name in registered if name.startswith("runbook_")]
+
+
+@pytest.mark.parametrize("flat_name", _REMOVED_FLAT_RUNBOOK_TOOLS)
+def test_removed_flat_runbook_alias_does_not_resolve(flat_name: str) -> None:
+    """Convention §14.9: a removed flat name falls through to unknown-tool.
+
+    A consumer pinned to the pre-#1612 flat name no longer finds a
+    registration; the dispatcher returns its standard unknown-tool error
+    (exercised end-to-end in the template/run tool test modules).
+    """
+    assert mcp_registry.get_tool(flat_name) is None
 
 
 @pytest.mark.parametrize(
-    ("tool_name", "other_required"),
+    ("tool_name", "required"),
     (
-        ("meho.runbook.draft_template", ["body"]),
-        ("meho.runbook.edit_template", ["body"]),
-        ("meho.runbook.publish_template", ["version"]),
-        ("meho.runbook.deprecate_template", ["version"]),
-        ("meho.runbook.show_template", None),
+        ("meho.runbook.draft_template", ["template_slug", "body"]),
+        ("meho.runbook.edit_template", ["template_slug", "body"]),
+        ("meho.runbook.publish_template", ["template_slug", "version"]),
+        ("meho.runbook.deprecate_template", ["template_slug", "version"]),
+        ("meho.runbook.show_template", ["template_slug"]),
     ),
 )
-def test_runbook_template_tools_expose_template_slug_canonical_name(
+def test_runbook_template_tools_require_template_slug_only(
     tool_name: str,
-    other_required: list[str] | None,
+    required: list[str],
 ) -> None:
-    """Convention §14.9: the template id is `template_slug` on every input.
+    """Convention §14.9: the template id is plain required `template_slug`.
 
-    The v0.12 wire split the same identifier across `slug` (template
-    verbs) and `template_slug` (run verbs); #1612 unifies on the more
-    specific `template_slug` everywhere, keeping `slug` as a deprecated
-    alias for one cycle — the `cursor`/`since` and
-    `approval_request_id`/`id` migration shape applied to the runbook
-    family.
+    #1612 unified the identifier on the more specific `template_slug` and
+    kept `slug` as a deprecated input alias for one cycle; #1625 removed
+    the alias. The field is now an ordinary required property — no `slug`
+    sibling, no top-level `anyOf` selector.
     """
     properties = _properties(tool_name)
     assert "template_slug" in properties, (
         f"{tool_name}: missing canonical `template_slug` (properties={sorted(properties)})"
     )
-    assert "deprecated" not in properties["template_slug"]
-    assert properties["slug"].get("deprecated") is True
-    # Either alias name satisfies the schema-level required check; the
-    # handler enforces the XOR.
+    assert "slug" not in properties
     schema = _input_schema(tool_name)
-    assert schema["anyOf"] == [
-        {"required": ["template_slug"]},
-        {"required": ["slug"]},
-    ]
-    if other_required is None:
-        # The template id is the only required input — the anyOf is the
-        # only required-shape declaration (broadcast.watch precedent).
-        assert "required" not in schema
-    else:
-        assert schema["required"] == other_required
+    assert "anyOf" not in schema
+    assert schema["required"] == required
 
 
 @pytest.mark.parametrize(

--- a/backend/tests/test_mcp_tools_runbook_runs.py
+++ b/backend/tests/test_mcp_tools_runbook_runs.py
@@ -14,9 +14,10 @@ on the MCP transport:
 * RBAC: four tools (``meho.runbook.start`` / ``.next`` / ``.abort`` /
   ``.list_runs``) are ``OPERATOR``-callable; ``meho.runbook.reassign``
   is ``TENANT_ADMIN``-only.
-* #1612 naming canonicalisation: the dotted names are canonical; the
-  flat ``runbook_*`` names resolve as deprecated aliases routed to the
-  same handler objects, including end-to-end through the dispatcher.
+* #1612 naming canonicalisation + #1625 removal: the dotted names are
+  the only registered names; the flat ``runbook_*`` aliases kept for one
+  release by #1612 were removed, so a flat-name call now falls through to
+  the dispatcher's unknown-tool error.
 * Typed-exception -> ``-32602`` mapping for the ten operator-actionable
   service + engine errors.
 * The load-bearing ``meho.runbook.next`` description carries the verbatim
@@ -60,7 +61,6 @@ from meho_backplane.connectors.schemas import (
 )
 from meho_backplane.db.engine import get_sessionmaker
 from meho_backplane.db.models import AuditLog, Target
-from meho_backplane.mcp.registry import get_tool
 from meho_backplane.mcp.schemas import INVALID_PARAMS
 from meho_backplane.operations import (
     register_typed_operation,
@@ -87,15 +87,16 @@ _OPERATOR_TOOLS = {
 _ADMIN_TOOLS = {"meho.runbook.reassign"}
 _ALL_TOOLS = _OPERATOR_TOOLS | _ADMIN_TOOLS
 
-#: Deprecated flat aliases (#1612) — kept resolvable for one release;
-#: each maps to its canonical dotted name.
-_FLAT_ALIASES = {
-    "runbook_start": "meho.runbook.start",
-    "runbook_next": "meho.runbook.next",
-    "runbook_abort": "meho.runbook.abort",
-    "runbook_reassign": "meho.runbook.reassign",
-    "runbook_list_runs": "meho.runbook.list_runs",
-}
+#: Flat run-verb aliases removed by #1625 (kept as deprecated aliases
+#: for one release by #1612). Each must now fall through to the
+#: dispatcher's unknown-tool error.
+_REMOVED_FLAT_ALIASES = (
+    "runbook_start",
+    "runbook_next",
+    "runbook_abort",
+    "runbook_reassign",
+    "runbook_list_runs",
+)
 
 
 def _template_body(
@@ -1014,58 +1015,34 @@ async def test_next_operation_call_match_advances(
 
 
 # ---------------------------------------------------------------------------
-# #1612 — deprecated flat-name aliases + template_slug round-trip
+# #1625 — removal of the deprecated flat-name aliases + template_slug round-trip
 # ---------------------------------------------------------------------------
 
 
 @pytest.mark.parametrize("client_with_operator", [TenantRole.TENANT_ADMIN], indirect=True)
-def test_flat_aliases_listed_deprecated_and_route_to_same_handler(
+def test_removed_flat_run_aliases_return_unknown_tool(
     client_with_operator: tuple[TestClient, Operator],  # noqa: F811
 ) -> None:
-    """AC #1612: every flat alias resolves, is DEPRECATED-marked, shares the handler.
+    """AC #1625: the flat run-verb names no longer resolve.
 
-    Mirrors the template-side assertion for the five run-lifecycle pairs:
-    both names listed for an admin, the alias's wire description is the
-    standard DEPRECATED pointer, and the registry routes both names to
-    the same handler object.
+    #1612 kept the flat names as deprecated aliases for one release;
+    #1625 removed them. The flat names are absent from ``tools/list`` and
+    calling one returns the dispatcher's standard unknown-tool error
+    (``-32602``, ``unknown tool: …``).
     """
     client, _op = client_with_operator
-    response = post_mcp(client, {"jsonrpc": "2.0", "id": 1, "method": "tools/list"})
-    tools_by_name = {t["name"]: t for t in response.json()["result"]["tools"]}
+    listed = {
+        t["name"]
+        for t in post_mcp(client, {"jsonrpc": "2.0", "id": 1, "method": "tools/list"}).json()[
+            "result"
+        ]["tools"]
+    }
+    assert not [name for name in listed if name.startswith("runbook_")]
 
-    for alias, canonical in _FLAT_ALIASES.items():
-        assert canonical in tools_by_name, canonical
-        assert alias in tools_by_name, alias
-        alias_desc = tools_by_name[alias]["description"]
-        assert alias_desc.startswith(f"DEPRECATED alias for `{canonical}`"), alias_desc
-        assert tools_by_name[alias]["inputSchema"] == tools_by_name[canonical]["inputSchema"]
-
-        canonical_entry = get_tool(canonical)
-        alias_entry = get_tool(alias)
-        assert canonical_entry is not None and alias_entry is not None
-        assert alias_entry[1] is canonical_entry[1], alias
-        assert alias_entry[0].deprecated_alias_for == canonical
-
-
-@pytest.mark.parametrize("client_with_operator", [TenantRole.OPERATOR], indirect=True)
-@pytest.mark.asyncio
-async def test_flat_alias_call_behaves_identically(
-    client_with_operator: tuple[TestClient, Operator],  # noqa: F811
-) -> None:
-    """AC #1612: calling the flat ``runbook_start`` alias behaves like the dotted name.
-
-    Same arguments, same dispatcher path, same response shape — the
-    pre-#1612 wire contract holds verbatim for the deprecation window.
-    """
-    client, op = client_with_operator
-    await _seed_published_template(tenant_id=op.tenant_id, operator_sub=op.sub, slug="r1")
-
-    payload = _result_payload(
-        _call(client, "runbook_start", {"template_slug": "r1", "target": "host-1"})
-    )
-    assert payload["kind"] == "current_step"
-    assert payload["template_slug"] == "r1"
-    assert payload["current_step"]["id"] == "step-1"
+    for flat in _REMOVED_FLAT_ALIASES:
+        body = _call(client, flat, {"template_slug": "r1", "target": "host-1"})
+        assert body["error"]["code"] == INVALID_PARAMS, flat
+        assert "unknown tool" in body["error"]["message"], flat
 
 
 @pytest.mark.parametrize("client_with_operator", [TenantRole.TENANT_ADMIN], indirect=True)

--- a/backend/tests/test_mcp_tools_runbooks_templates.py
+++ b/backend/tests/test_mcp_tools_runbooks_templates.py
@@ -12,11 +12,12 @@ on the MCP transport:
   wire shape.
 * RBAC: five tools are ``TENANT_ADMIN``-only; ``meho.runbook.list_templates``
   is ``OPERATOR``-readable.
-* #1612 naming + field canonicalisation: the dotted names are canonical;
-  the flat ``runbook_*`` names resolve as deprecated aliases routed to
-  the same handler objects; ``template_slug`` is the canonical input
-  field with ``slug`` as a deprecated XOR-guarded alias; responses
-  mirror ``slug`` as ``template_slug``.
+* #1612 naming + field canonicalisation, #1625 removal: the dotted names
+  are the only registered names; the flat ``runbook_*`` aliases and the
+  ``slug`` input alias were removed after their one-release window, so a
+  flat-name call falls through to unknown-tool and ``slug`` is rejected.
+  ``template_slug`` is the sole input field; responses still mirror
+  ``slug`` as ``template_slug``.
 * The edit tool's draft-in-place vs fork-from-published paths round-trip
   through the dispatcher (``forked_from`` present iff a published version
   exists).
@@ -47,7 +48,6 @@ from fastapi.testclient import TestClient
 from meho_backplane.auth.operator import Operator, TenantRole
 from meho_backplane.db.engine import get_sessionmaker
 from meho_backplane.db.models import RunbookRun
-from meho_backplane.mcp.registry import get_tool
 from meho_backplane.mcp.schemas import INVALID_PARAMS
 from meho_backplane.runbooks.schemas import DraftTemplateRequest, PublishTemplateRequest
 from meho_backplane.runbooks.service import RunbookTemplateService
@@ -72,16 +72,17 @@ _ADMIN_TOOLS = {
 # ``-32602`` and the ``opacity_floor`` reason.
 _OPERATOR_TOOLS = {"meho.runbook.list_templates", "meho.runbook.show_template"}
 
-#: Deprecated flat aliases (#1612) — kept resolvable for one release;
-#: each maps to its canonical dotted name.
-_FLAT_ALIASES = {
-    "runbook_draft_template": "meho.runbook.draft_template",
-    "runbook_edit_template": "meho.runbook.edit_template",
-    "runbook_publish_template": "meho.runbook.publish_template",
-    "runbook_deprecate_template": "meho.runbook.deprecate_template",
-    "runbook_list_templates": "meho.runbook.list_templates",
-    "runbook_show_template": "meho.runbook.show_template",
-}
+#: Flat template-verb aliases removed by #1625 (kept as deprecated
+#: aliases for one release by #1612). Each must now fall through to the
+#: dispatcher's unknown-tool error.
+_REMOVED_FLAT_ALIASES = (
+    "runbook_draft_template",
+    "runbook_edit_template",
+    "runbook_publish_template",
+    "runbook_deprecate_template",
+    "runbook_list_templates",
+    "runbook_show_template",
+)
 
 
 def _body(title: str = "Rotate cert", *, step_body: str = "Rotate the cert.") -> dict[str, Any]:
@@ -593,86 +594,67 @@ def test_show_template_missing_error(
 
 
 # ---------------------------------------------------------------------------
-# #1612 — deprecated flat-name aliases + slug/template_slug field shim
+# #1625 — removal of the deprecated flat-name aliases + slug input alias
 # ---------------------------------------------------------------------------
 
 
 @pytest.mark.parametrize("client_with_operator", [TenantRole.TENANT_ADMIN], indirect=True)
-def test_flat_aliases_listed_deprecated_and_route_to_same_handler(
+def test_removed_flat_template_aliases_return_unknown_tool(
     client_with_operator: tuple[TestClient, Operator],  # noqa: F811
 ) -> None:
-    """AC #1612: every flat alias resolves, is DEPRECATED-marked, shares the handler.
+    """AC #1625: the flat ``runbook_*_template`` names no longer resolve.
 
-    Three properties per template-side pair: (1) both names appear in
-    ``tools/list`` for an admin; (2) the alias's wire description is the
-    standard DEPRECATED pointer at its canonical name; (3) the registry
-    routes both names to the *same handler object* — the alias is a
-    second name, never a fork.
+    #1612 kept the flat names as deprecated aliases for one release;
+    #1625 removed them. A consumer that never migrated and calls a flat
+    name gets the dispatcher's standard unknown-tool error (``-32602``,
+    ``unknown tool: …``) — the same fall-through any unregistered name
+    hits — and the flat names are absent from ``tools/list``.
     """
     client, _op = client_with_operator
-    response = post_mcp(client, {"jsonrpc": "2.0", "id": 1, "method": "tools/list"})
-    tools_by_name = {t["name"]: t for t in response.json()["result"]["tools"]}
-
-    for alias, canonical in _FLAT_ALIASES.items():
-        assert canonical in tools_by_name, canonical
-        assert alias in tools_by_name, alias
-        alias_desc = tools_by_name[alias]["description"]
-        assert alias_desc.startswith(f"DEPRECATED alias for `{canonical}`"), alias_desc
-        # Identical schema on the wire — the alias accepts exactly what
-        # the canonical accepts.
-        assert tools_by_name[alias]["inputSchema"] == tools_by_name[canonical]["inputSchema"]
-
-        canonical_entry = get_tool(canonical)
-        alias_entry = get_tool(alias)
-        assert canonical_entry is not None and alias_entry is not None
-        assert alias_entry[1] is canonical_entry[1], alias
-        assert alias_entry[0].deprecated_alias_for == canonical
-
-
-@pytest.mark.parametrize("client_with_operator", [TenantRole.TENANT_ADMIN], indirect=True)
-def test_flat_alias_call_with_legacy_slug_field_still_works(
-    client_with_operator: tuple[TestClient, Operator],  # noqa: F811
-) -> None:
-    """AC #1612: the full pre-#1612 wire shape (flat name + ``slug``) still works.
-
-    A v0.12 caller pinned to ``runbook_draft_template`` + ``slug`` must
-    keep working unchanged for the deprecation window, and the response
-    now additionally mirrors ``template_slug``.
-    """
-    client, _op = client_with_operator
-    payload = _result_payload(
-        _call(client, "runbook_draft_template", {"slug": "cert-rotate", "body": _body()})
-    )
-    assert payload == {
-        "slug": "cert-rotate",
-        "template_slug": "cert-rotate",
-        "version": 1,
-        "status": "draft",
+    listed = {
+        t["name"]
+        for t in post_mcp(client, {"jsonrpc": "2.0", "id": 1, "method": "tools/list"}).json()[
+            "result"
+        ]["tools"]
     }
+    assert not [name for name in listed if name.startswith("runbook_")]
 
-    shown = _result_payload(_call(client, "runbook_show_template", {"slug": "cert-rotate"}))
-    assert shown["template_slug"] == "cert-rotate"
-    assert shown["slug"] == "cert-rotate"
+    for flat in _REMOVED_FLAT_ALIASES:
+        body = _call(client, flat, {"template_slug": "cert-rotate", "body": _body()})
+        assert body["error"]["code"] == INVALID_PARAMS, flat
+        assert "unknown tool" in body["error"]["message"], flat
 
 
 @pytest.mark.parametrize("client_with_operator", [TenantRole.TENANT_ADMIN], indirect=True)
-def test_template_slug_and_slug_are_mutually_exclusive(
+def test_slug_input_field_rejected_template_slug_required(
     client_with_operator: tuple[TestClient, Operator],  # noqa: F811
 ) -> None:
-    """AC #1612: supplying both names → -32602; supplying neither → -32602."""
-    client, _op = client_with_operator
-    both = _call(
-        client,
-        "meho.runbook.draft_template",
-        {"template_slug": "cert-rotate", "slug": "cert-rotate", "body": _body()},
-    )
-    assert both["error"]["code"] == INVALID_PARAMS
-    assert "not both" in both["error"]["message"]
+    """AC #1625: template verbs accept ``template_slug`` only; ``slug`` is rejected.
 
-    # Neither name supplied — rejected by the server-side anyOf gate
-    # before the handler runs.
-    neither = _call(client, "meho.runbook.draft_template", {"body": _body()})
-    assert neither["error"]["code"] == INVALID_PARAMS
+    The deprecated ``slug`` input alias and its XOR guard are gone. The
+    canonical ``template_slug`` works; supplying the removed ``slug``
+    field is an unknown property under the schema's
+    ``additionalProperties: false`` gate and surfaces as a clean
+    ``-32602`` validation error before the handler runs.
+    """
+    client, _op = client_with_operator
+
+    ok = _result_payload(
+        _call(
+            client,
+            "meho.runbook.draft_template",
+            {"template_slug": "cert-rotate", "body": _body()},
+        )
+    )
+    assert ok["template_slug"] == "cert-rotate"
+
+    rejected = _call(
+        client, "meho.runbook.draft_template", {"slug": "cert-rotate", "body": _body()}
+    )
+    assert rejected["error"]["code"] == INVALID_PARAMS
+    # The handler never runs — the schema gate rejects the now-unknown
+    # ``slug`` property (and the absent required ``template_slug``).
+    assert "inputSchema" in rejected["error"]["message"]
 
 
 @pytest.mark.parametrize("client_with_operator", [TenantRole.TENANT_ADMIN], indirect=True)

--- a/backend/tests/test_runbooks_runs_schemas.py
+++ b/backend/tests/test_runbooks_runs_schemas.py
@@ -115,7 +115,7 @@ def test_step_body_round_trip() -> None:
 def test_step_body_omits_future_step_fields() -> None:
     """Locks the Initiative #1198 opacity floor at the schema layer.
 
-    ``CurrentStepResponse`` is the wire surface that ``runbook_next``
+    ``CurrentStepResponse`` is the wire surface that ``meho.runbook.next``
     returns on the non-completion path. The acceptance bar of the
     parent Initiative is that an agent / operator who parses this
     response cannot deduce the contents of any step other than the

--- a/cli/api/openapi.json
+++ b/cli/api/openapi.json
@@ -10194,7 +10194,7 @@
           "reason"
         ],
         "title": "AbortRunRequest",
-        "description": "Request body for ``runbook_abort`` -- terminate the run mid-flight.\n\n:attr:`reason` is required and non-empty (``Field(min_length=1)``)\nbecause it is persisted to ``audit_log.payload`` for the abort\nevent -- an empty reason would defeat the audit trail that\nInitiative #1198's \"abort-with-audit\" guarantee rests on."
+        "description": "Request body for ``meho.runbook.abort`` -- terminate the run mid-flight.\n\n:attr:`reason` is required and non-empty (``Field(min_length=1)``)\nbecause it is persisted to ``audit_log.payload`` for the abort\nevent -- an empty reason would defeat the audit trail that\nInitiative #1198's \"abort-with-audit\" guarantee rests on."
       },
       "AbortRunResponse": {
         "properties": {
@@ -10221,7 +10221,7 @@
           "abandoned_at"
         ],
         "title": "AbortRunResponse",
-        "description": "Returned by ``runbook_abort`` -- the terminal-state coordinates."
+        "description": "Returned by ``meho.runbook.abort`` -- the terminal-state coordinates."
       },
       "AgentDefinitionCreate": {
         "properties": {
@@ -12717,7 +12717,7 @@
           "current_step"
         ],
         "title": "CurrentStepResponse",
-        "description": "Returned by ``runbook_start`` and the non-completion path of ``runbook_next``.\n\nCarries the run coordinates (``run_id`` / ``template_slug`` /\n``template_version``), the structural position hint\n(:class:`StepPosition`), and -- crucially -- exactly one\n:class:`StepBody`: the step the run is *currently on*. No previous\nsteps (already executed), no following steps (the opacity property\nthis Initiative is built around).\n\nTagged with ``kind: Literal[\"current_step\"]`` so the parent\n:data:`NextStepResponse` discriminated union routes payloads on a\nvisible field rather than a callable shape-sniffing discriminator\n(option 1 of the design decision documented at the module docstring\nand the #1300 issue body)."
+        "description": "Returned by ``meho.runbook.start`` and the non-completion path of ``meho.runbook.next``.\n\nCarries the run coordinates (``run_id`` / ``template_slug`` /\n``template_version``), the structural position hint\n(:class:`StepPosition`), and -- crucially -- exactly one\n:class:`StepBody`: the step the run is *currently on*. No previous\nsteps (already executed), no following steps (the opacity property\nthis Initiative is built around).\n\nTagged with ``kind: Literal[\"current_step\"]`` so the parent\n:data:`NextStepResponse` discriminated union routes payloads on a\nvisible field rather than a callable shape-sniffing discriminator\n(option 1 of the design decision documented at the module docstring\nand the #1300 issue body)."
       },
       "DailyUsageBucket": {
         "properties": {
@@ -12873,7 +12873,7 @@
           "status"
         ],
         "title": "DeprecateTemplateResponse",
-        "description": "Response for ``runbook_deprecate_template`` -- the now-deprecated coordinates."
+        "description": "Response for ``meho.runbook.deprecate_template`` -- the now-deprecated coordinates."
       },
       "DocCollectionSummary": {
         "properties": {
@@ -13020,7 +13020,7 @@
           "body"
         ],
         "title": "DraftTemplateRequest",
-        "description": "Request body for ``runbook_draft_template`` -- create a new draft.\n\n:attr:`slug` is validated against :data:`SLUG_PATTERN` (the kb slug\ncontract, reused verbatim)."
+        "description": "Request body for ``meho.runbook.draft_template`` -- create a new draft.\n\n:attr:`slug` is validated against :data:`SLUG_PATTERN` (the kb slug\ncontract, reused verbatim)."
       },
       "DraftTemplateResponse": {
         "properties": {
@@ -13045,7 +13045,7 @@
           "status"
         ],
         "title": "DraftTemplateResponse",
-        "description": "Response for ``runbook_draft_template`` -- the created draft's coordinates."
+        "description": "Response for ``meho.runbook.draft_template`` -- the created draft's coordinates."
       },
       "EditGroupBody": {
         "properties": {
@@ -13173,7 +13173,7 @@
           "status"
         ],
         "title": "EditTemplateResponse",
-        "description": "Response for ``runbook_edit_template``.\n\n:attr:`version` equals the input version when editing a draft in\nplace; it is a new version when forking from a published template, in\nwhich case :attr:`forked_from` is populated with the source's\n:class:`ForkInfo`. On the draft-edit path :attr:`forked_from` is\n``None``."
+        "description": "Response for ``meho.runbook.edit_template``.\n\n:attr:`version` equals the input version when editing a draft in\nplace; it is a new version when forking from a published template, in\nwhich case :attr:`forked_from` is populated with the source's\n:class:`ForkInfo`. On the draft-edit path :attr:`forked_from` is\n``None``."
       },
       "EvalRequest": {
         "properties": {
@@ -13313,7 +13313,7 @@
           "in_flight_run_count"
         ],
         "title": "ForkInfo",
-        "description": "Surfaced by ``runbook_edit_template`` when editing a published template forks.\n\nEditing a *published* template cannot mutate it in place (published\ntemplates are immutable); the edit forks a new draft instead. This\nshape tells the senior what they are forking from -- the source\nversion and how many runs are still pinned to it -- so they can decide\nwhether the fork is the right move."
+        "description": "Surfaced by ``meho.runbook.edit_template`` when editing a published template forks.\n\nEditing a *published* template cannot mutate it in place (published\ntemplates are immutable); the edit forks a new draft instead. This\nshape tells the senior what they are forking from -- the source\nversion and how many runs are still pinned to it -- so they can decide\nwhether the fork is the right move."
       },
       "GraphEdgeKind": {
         "type": "string",
@@ -14031,7 +14031,7 @@
           "last_verified"
         ],
         "title": "NextStepRequest",
-        "description": "Request body for ``runbook_next`` -- advance the run.\n\n:attr:`last_verified` is the caller's *claim* that the previous\nstep's verify gate was satisfied. It is **informational only**:\nthe substrate (engine, G12.3-T2) is the verify oracle, and a\nrequest from a caller whose previous-step state is not\n``verified`` returns 400 *regardless* of what\n:attr:`last_verified` says. The field exists so the wire log\ncaptures the caller's belief alongside the substrate's decision\n-- useful for diagnosing a client that thinks it advanced when\nthe substrate did not.\n\n:attr:`verify_response` carries the operator's answer for a\n``confirm`` step or the engine's captured result for an\n``operation_call`` step. ``None`` is valid only on the very first\n``runbook_next`` call (when no prior step exists to verify)."
+        "description": "Request body for ``meho.runbook.next`` -- advance the run.\n\n:attr:`last_verified` is the caller's *claim* that the previous\nstep's verify gate was satisfied. It is **informational only**:\nthe substrate (engine, G12.3-T2) is the verify oracle, and a\nrequest from a caller whose previous-step state is not\n``verified`` returns 400 *regardless* of what\n:attr:`last_verified` says. The field exists so the wire log\ncaptures the caller's belief alongside the substrate's decision\n-- useful for diagnosing a client that thinks it advanced when\nthe substrate did not.\n\n:attr:`verify_response` carries the operator's answer for a\n``confirm`` step or the engine's captured result for an\n``operation_call`` step. ``None`` is valid only on the very first\n``meho.runbook.next`` call (when no prior step exists to verify)."
       },
       "OperationCallStep": {
         "properties": {
@@ -14455,7 +14455,7 @@
           "status"
         ],
         "title": "PublishTemplateResponse",
-        "description": "Response for ``runbook_publish_template`` -- the now-published coordinates."
+        "description": "Response for ``meho.runbook.publish_template`` -- the now-published coordinates."
       },
       "QueryResult": {
         "properties": {
@@ -14538,7 +14538,7 @@
           "new_assignee"
         ],
         "title": "ReassignRunRequest",
-        "description": "Request body for ``runbook_reassign`` -- transfer ownership of a run.\n\n:attr:`new_assignee` is the operator subject identifier of the\nnew owner. Non-empty (``Field(min_length=1)``) because the\nreassign path writes to ``runbook_runs.assigned_to`` which is\n``NOT NULL`` at the storage layer and is the predicate for\nevery subsequent ``runbook_next`` ownership check."
+        "description": "Request body for ``meho.runbook.reassign`` -- transfer ownership of a run.\n\n:attr:`new_assignee` is the operator subject identifier of the\nnew owner. Non-empty (``Field(min_length=1)``) because the\nreassign path writes to ``runbook_runs.assigned_to`` which is\n``NOT NULL`` at the storage layer and is the predicate for\nevery subsequent ``meho.runbook.next`` ownership check."
       },
       "ReassignRunResponse": {
         "properties": {
@@ -14564,7 +14564,7 @@
           "reassigned_at"
         ],
         "title": "ReassignRunResponse",
-        "description": "Returned by ``runbook_reassign`` -- the new ownership coordinates."
+        "description": "Returned by ``meho.runbook.reassign`` -- the new ownership coordinates."
       },
       "RefreshResult": {
         "properties": {
@@ -15140,7 +15140,7 @@
           "completed_at"
         ],
         "title": "RunCompletedResponse",
-        "description": "Returned by ``runbook_next`` when the previous step was the last.\n\nThe terminal-state shape: no step body, just the run coordinates\nand the transition timestamp. The companion abort-side shape is\n:class:`AbortRunResponse`.\n\nThe :attr:`state` and :attr:`kind` literals both carry ``\"completed\"``\nby design: :attr:`kind` is the parent-union discriminator (per the\nexplicit-tag decision documented at the module docstring), while\n:attr:`state` matches the run's storage-level state column\n(``runbook_runs.state``) so the response shape mirrors the row\none-for-one."
+        "description": "Returned by ``meho.runbook.next`` when the previous step was the last.\n\nThe terminal-state shape: no step body, just the run coordinates\nand the transition timestamp. The companion abort-side shape is\n:class:`AbortRunResponse`.\n\nThe :attr:`state` and :attr:`kind` literals both carry ``\"completed\"``\nby design: :attr:`kind` is the parent-union discriminator (per the\nexplicit-tag decision documented at the module docstring), while\n:attr:`state` matches the run's storage-level state column\n(``runbook_runs.state``) so the response shape mirrors the row\none-for-one."
       },
       "RunSummary": {
         "properties": {
@@ -15212,7 +15212,7 @@
           "started_at"
         ],
         "title": "RunSummary",
-        "description": "List-view projection returned by ``runbook_list_runs``.\n\nRun-level state only: no step contents are exposed. The\nstep-by-step content is opaque-by-construction (only\n``runbook_next`` ever returns a step body, and only one step at a\ntime), so :attr:`current_step_id` is the *id* of the step the\nrun is currently on -- enough for a UI to render \"step 3:\ndrain-node\" -- but not the body.\n\n:attr:`current_step_id` and :attr:`position` are ``None`` for\nruns in terminal state (``completed`` / ``abandoned``); a\nterminal-state run has no \"current\" step.\n\n:attr:`completed_at` and :attr:`abandoned_at` are mutually\nexclusive (and both ``None`` for ``in_progress`` runs); the\ntransition that fired sets the corresponding column on\n``runbook_runs``."
+        "description": "List-view projection returned by ``meho.runbook.list_runs``.\n\nRun-level state only: no step contents are exposed. The\nstep-by-step content is opaque-by-construction (only\n``meho.runbook.next`` ever returns a step body, and only one step at a\ntime), so :attr:`current_step_id` is the *id* of the step the\nrun is currently on -- enough for a UI to render \"step 3:\ndrain-node\" -- but not the body.\n\n:attr:`current_step_id` and :attr:`position` are ``None`` for\nruns in terminal state (``completed`` / ``abandoned``); a\nterminal-state run has no \"current\" step.\n\n:attr:`completed_at` and :attr:`abandoned_at` are mutually\nexclusive (and both ``None`` for ``in_progress`` runs); the\ntransition that fired sets the corresponding column on\n``runbook_runs``."
       },
       "RunbookListRunsResponse": {
         "properties": {
@@ -15669,7 +15669,7 @@
           "edited_at"
         ],
         "title": "ShowTemplateResponse",
-        "description": "Full template surface returned by ``runbook_show_template``.\n\nThe complete template including the ordered :attr:`steps` and the\nauthorship / timestamp provenance. Mirrors the\n:class:`~meho_backplane.db.models.RunbookTemplate` column set projected\nto wire types."
+        "description": "Full template surface returned by ``meho.runbook.show_template``.\n\nThe complete template including the ordered :attr:`steps` and the\nauthorship / timestamp provenance. Mirrors the\n:class:`~meho_backplane.db.models.RunbookTemplate` column set projected\nto wire types."
       },
       "SkippedConnector": {
         "properties": {
@@ -15735,7 +15735,7 @@
           "target"
         ],
         "title": "StartRunRequest",
-        "description": "Request body for ``runbook_start`` -- begin a new run on a template.\n\n:attr:`template_slug` references a *published* runbook template; the\nservice layer (G12.3-T3) resolves it to a pinned ``(slug, version)``\nat start time so later template edits cannot alter this run's step\nlist (per Initiative #1198 deprecation interplay rules).\n:attr:`target` is the run's subject (the host, the cluster, the\ncert thumbprint); :attr:`params` is the substitution context for\n``${run.params.X}`` and may be empty."
+        "description": "Request body for ``meho.runbook.start`` -- begin a new run on a template.\n\n:attr:`template_slug` references a *published* runbook template; the\nservice layer (G12.3-T3) resolves it to a pinned ``(slug, version)``\nat start time so later template edits cannot alter this run's step\nlist (per Initiative #1198 deprecation interplay rules).\n:attr:`target` is the run's subject (the host, the cluster, the\ncert thumbprint); :attr:`params` is the substitution context for\n``${run.params.X}`` and may be empty."
       },
       "StepBody": {
         "properties": {
@@ -15783,7 +15783,7 @@
           "verify"
         ],
         "title": "StepBody",
-        "description": "The opaque-by-construction single-step shape returned by ``runbook_next``.\n\nAll ``${run.target}`` and ``${run.params.X}`` substitutions are\nalready resolved by the engine (G12.3-T2, #1301); the strings here\nare post-substitution and final. This is what the operator / agent\nsees -- *and the only step they see* at this position in the run.\n\nWhat this shape carries:\n\n* :attr:`id` -- the step's id (matches ``runbook_run_step_states.step_id``).\n* :attr:`title` / :attr:`body` -- substituted authoring text.\n* :attr:`type` -- ``\"operation_call\"`` (MEHO dispatches the action) or\n  ``\"manual\"`` (operator performs the step off-MEHO).\n* :attr:`op_id` / :attr:`params` -- populated only for\n  ``operation_call`` steps; the substituted call shape.\n* :attr:`verify` -- the substituted-and-frozen verify gate the\n  caller must respond to on the next ``runbook_next`` call.\n\nWhat this shape **must not** carry, by structural construction\n(regression-tested in ``test_step_body_omits_future_step_fields``):\n\n* The full template's step list.\n* Any reference to step ids other than the current one.\n* The unsubstituted (template) body.\n\nNo discriminated union split between operation-call and manual\nvariants is used here -- ``op_id`` / ``params`` are simply nullable\nby ``type``. The split would buy stronger typing at the cost of an\nextra adapter layer for callers that just want to render the\nbody; the issue spec explicitly chose the flat shape (#1300)."
+        "description": "The opaque-by-construction single-step shape returned by ``meho.runbook.next``.\n\nAll ``${run.target}`` and ``${run.params.X}`` substitutions are\nalready resolved by the engine (G12.3-T2, #1301); the strings here\nare post-substitution and final. This is what the operator / agent\nsees -- *and the only step they see* at this position in the run.\n\nWhat this shape carries:\n\n* :attr:`id` -- the step's id (matches ``runbook_run_step_states.step_id``).\n* :attr:`title` / :attr:`body` -- substituted authoring text.\n* :attr:`type` -- ``\"operation_call\"`` (MEHO dispatches the action) or\n  ``\"manual\"`` (operator performs the step off-MEHO).\n* :attr:`op_id` / :attr:`params` -- populated only for\n  ``operation_call`` steps; the substituted call shape.\n* :attr:`verify` -- the substituted-and-frozen verify gate the\n  caller must respond to on the next ``meho.runbook.next`` call.\n\nWhat this shape **must not** carry, by structural construction\n(regression-tested in ``test_step_body_omits_future_step_fields``):\n\n* The full template's step list.\n* Any reference to step ids other than the current one.\n* The unsubstituted (template) body.\n\nNo discriminated union split between operation-call and manual\nvariants is used here -- ``op_id`` / ``params`` are simply nullable\nby ``type``. The split would buy stronger typing at the cost of an\nextra adapter layer for callers that just want to render the\nbody; the issue spec explicitly chose the flat shape (#1300)."
       },
       "StepBodyVerify": {
         "properties": {
@@ -16451,7 +16451,7 @@
           "edited_at"
         ],
         "title": "TemplateSummary",
-        "description": "Operator-readable summary row surfaced by ``runbook_list_templates``.\n\nThe list-view projection -- enough to identify a template and its\nlifecycle state without loading the full step list (which\n:class:`ShowTemplateResponse` carries)."
+        "description": "Operator-readable summary row surfaced by ``meho.runbook.list_templates``.\n\nThe list-view projection -- enough to identify a template and its\nlifecycle state without loading the full step list (which\n:class:`ShowTemplateResponse` carries)."
       },
       "Thresholds": {
         "properties": {

--- a/cli/internal/api/client.gen.go
+++ b/cli/internal/api/client.gen.go
@@ -408,7 +408,7 @@ const (
 	Published  RunbooksListUiRunbooksListGetParamsStatus = "published"
 )
 
-// AbortRunRequest Request body for “runbook_abort“ -- terminate the run mid-flight.
+// AbortRunRequest Request body for “meho.runbook.abort“ -- terminate the run mid-flight.
 //
 // :attr:`reason` is required and non-empty (“Field(min_length=1)“)
 // because it is persisted to “audit_log.payload“ for the abort
@@ -418,7 +418,7 @@ type AbortRunRequest struct {
 	Reason string `json:"reason"`
 }
 
-// AbortRunResponse Returned by “runbook_abort“ -- the terminal-state coordinates.
+// AbortRunResponse Returned by “meho.runbook.abort“ -- the terminal-state coordinates.
 type AbortRunResponse struct {
 	AbandonedAt time.Time          `json:"abandoned_at"`
 	RunId       openapi_types.UUID `json:"run_id"`
@@ -1990,7 +1990,7 @@ type CriterionResultName string
 // CriterionResultVerdict defines model for CriterionResult.Verdict.
 type CriterionResultVerdict string
 
-// CurrentStepResponse Returned by “runbook_start“ and the non-completion path of “runbook_next“.
+// CurrentStepResponse Returned by “meho.runbook.start“ and the non-completion path of “meho.runbook.next“.
 //
 // Carries the run coordinates (“run_id“ / “template_slug“ /
 // “template_version“), the structural position hint
@@ -2005,7 +2005,7 @@ type CriterionResultVerdict string
 // (option 1 of the design decision documented at the module docstring
 // and the #1300 issue body).
 type CurrentStepResponse struct {
-	// CurrentStep The opaque-by-construction single-step shape returned by ``runbook_next``.
+	// CurrentStep The opaque-by-construction single-step shape returned by ``meho.runbook.next``.
 	//
 	// All ``${run.target}`` and ``${run.params.X}`` substitutions are
 	// already resolved by the engine (G12.3-T2, #1301); the strings here
@@ -2021,7 +2021,7 @@ type CurrentStepResponse struct {
 	// * :attr:`op_id` / :attr:`params` -- populated only for
 	//   ``operation_call`` steps; the substituted call shape.
 	// * :attr:`verify` -- the substituted-and-frozen verify gate the
-	//   caller must respond to on the next ``runbook_next`` call.
+	//   caller must respond to on the next ``meho.runbook.next`` call.
 	//
 	// What this shape **must not** carry, by structural construction
 	// (regression-tested in ``test_step_body_omits_future_step_fields``):
@@ -2139,7 +2139,7 @@ type DecideResponseBody_DispatchResult struct {
 	union json.RawMessage
 }
 
-// DeprecateTemplateResponse Response for “runbook_deprecate_template“ -- the now-deprecated coordinates.
+// DeprecateTemplateResponse Response for “meho.runbook.deprecate_template“ -- the now-deprecated coordinates.
 type DeprecateTemplateResponse struct {
 	Slug    string `json:"slug"`
 	Status  string `json:"status"`
@@ -2195,7 +2195,7 @@ type DocsChunk struct {
 	SourceUrl  *string  `json:"source_url"`
 }
 
-// DraftTemplateRequest Request body for “runbook_draft_template“ -- create a new draft.
+// DraftTemplateRequest Request body for “meho.runbook.draft_template“ -- create a new draft.
 //
 // :attr:`slug` is validated against :data:`SLUG_PATTERN` (the kb slug
 // contract, reused verbatim).
@@ -2217,7 +2217,7 @@ type DraftTemplateRequest struct {
 	Slug string              `json:"slug"`
 }
 
-// DraftTemplateResponse Response for “runbook_draft_template“ -- the created draft's coordinates.
+// DraftTemplateResponse Response for “meho.runbook.draft_template“ -- the created draft's coordinates.
 type DraftTemplateResponse struct {
 	Slug    string `json:"slug"`
 	Status  string `json:"status"`
@@ -2332,7 +2332,7 @@ type EditOpWarning struct {
 	Message        string `json:"message"`
 }
 
-// EditTemplateResponse Response for “runbook_edit_template“.
+// EditTemplateResponse Response for “meho.runbook.edit_template“.
 //
 // :attr:`version` equals the input version when editing a draft in
 // place; it is a new version when forking from a published template, in
@@ -2340,7 +2340,7 @@ type EditOpWarning struct {
 // :class:`ForkInfo`. On the draft-edit path :attr:`forked_from` is
 // “None“.
 type EditTemplateResponse struct {
-	// ForkedFrom Surfaced by ``runbook_edit_template`` when editing a published template forks.
+	// ForkedFrom Surfaced by ``meho.runbook.edit_template`` when editing a published template forks.
 	//
 	// Editing a *published* template cannot mutate it in place (published
 	// templates are immutable); the edit forks a new draft instead. This
@@ -2411,7 +2411,7 @@ type FingerprintResult struct {
 	Version     *string                 `json:"version"`
 }
 
-// ForkInfo Surfaced by “runbook_edit_template“ when editing a published template forks.
+// ForkInfo Surfaced by “meho.runbook.edit_template“ when editing a published template forks.
 //
 // Editing a *published* template cannot mutate it in place (published
 // templates are immutable); the edit forks a new draft instead. This
@@ -2956,7 +2956,7 @@ type MemoryListResponse struct {
 // the :class:`~meho_backplane.auth.operator.TenantRole` convention.
 type MemoryScope string
 
-// NextStepRequest Request body for “runbook_next“ -- advance the run.
+// NextStepRequest Request body for “meho.runbook.next“ -- advance the run.
 //
 // :attr:`last_verified` is the caller's *claim* that the previous
 // step's verify gate was satisfied. It is **informational only**:
@@ -2971,7 +2971,7 @@ type MemoryScope string
 // :attr:`verify_response` carries the operator's answer for a
 // “confirm“ step or the engine's captured result for an
 // “operation_call“ step. “None“ is valid only on the very first
-// “runbook_next“ call (when no prior step exists to verify).
+// “meho.runbook.next“ call (when no prior step exists to verify).
 type NextStepRequest struct {
 	LastVerified   bool                            `json:"last_verified"`
 	VerifyResponse *NextStepRequest_VerifyResponse `json:"verify_response"`
@@ -3214,7 +3214,7 @@ type PromoteBody struct {
 	To MemoryScope `json:"to"`
 }
 
-// PublishTemplateResponse Response for “runbook_publish_template“ -- the now-published coordinates.
+// PublishTemplateResponse Response for “meho.runbook.publish_template“ -- the now-published coordinates.
 type PublishTemplateResponse struct {
 	Slug    string `json:"slug"`
 	Status  string `json:"status"`
@@ -3243,18 +3243,18 @@ type QueryResult struct {
 	ReciprocalRank         float32   `json:"reciprocal_rank"`
 }
 
-// ReassignRunRequest Request body for “runbook_reassign“ -- transfer ownership of a run.
+// ReassignRunRequest Request body for “meho.runbook.reassign“ -- transfer ownership of a run.
 //
 // :attr:`new_assignee` is the operator subject identifier of the
 // new owner. Non-empty (“Field(min_length=1)“) because the
 // reassign path writes to “runbook_runs.assigned_to“ which is
 // “NOT NULL“ at the storage layer and is the predicate for
-// every subsequent “runbook_next“ ownership check.
+// every subsequent “meho.runbook.next“ ownership check.
 type ReassignRunRequest struct {
 	NewAssignee string `json:"new_assignee"`
 }
 
-// ReassignRunResponse Returned by “runbook_reassign“ -- the new ownership coordinates.
+// ReassignRunResponse Returned by “meho.runbook.reassign“ -- the new ownership coordinates.
 type ReassignRunResponse struct {
 	AssignedTo   string             `json:"assigned_to"`
 	ReassignedAt time.Time          `json:"reassigned_at"`
@@ -3494,7 +3494,7 @@ type RetrieveResponse struct {
 	QueryDurationMs float32        `json:"query_duration_ms"`
 }
 
-// RunCompletedResponse Returned by “runbook_next“ when the previous step was the last.
+// RunCompletedResponse Returned by “meho.runbook.next“ when the previous step was the last.
 //
 // The terminal-state shape: no step body, just the run coordinates
 // and the transition timestamp. The companion abort-side shape is
@@ -3513,11 +3513,11 @@ type RunCompletedResponse struct {
 	State       *string            `json:"state,omitempty"`
 }
 
-// RunSummary List-view projection returned by “runbook_list_runs“.
+// RunSummary List-view projection returned by “meho.runbook.list_runs“.
 //
 // Run-level state only: no step contents are exposed. The
 // step-by-step content is opaque-by-construction (only
-// “runbook_next“ ever returns a step body, and only one step at a
+// “meho.runbook.next“ ever returns a step body, and only one step at a
 // time), so :attr:`current_step_id` is the *id* of the step the
 // run is currently on -- enough for a UI to render "step 3:
 // drain-node" -- but not the body.
@@ -3946,7 +3946,7 @@ type SearchDocsResponse struct {
 	Chunks []DocsChunk `json:"chunks"`
 }
 
-// ShowTemplateResponse Full template surface returned by “runbook_show_template“.
+// ShowTemplateResponse Full template surface returned by “meho.runbook.show_template“.
 //
 // The complete template including the ordered :attr:`steps` and the
 // authorship / timestamp provenance. Mirrors the
@@ -4015,7 +4015,7 @@ type SpecSource struct {
 	Uri     string  `json:"uri"`
 }
 
-// StartRunRequest Request body for “runbook_start“ -- begin a new run on a template.
+// StartRunRequest Request body for “meho.runbook.start“ -- begin a new run on a template.
 //
 // :attr:`template_slug` references a *published* runbook template; the
 // service layer (G12.3-T3) resolves it to a pinned “(slug, version)“
@@ -4030,7 +4030,7 @@ type StartRunRequest struct {
 	TemplateSlug string                  `json:"template_slug"`
 }
 
-// StepBody The opaque-by-construction single-step shape returned by “runbook_next“.
+// StepBody The opaque-by-construction single-step shape returned by “meho.runbook.next“.
 //
 // All “${run.target}“ and “${run.params.X}“ substitutions are
 // already resolved by the engine (G12.3-T2, #1301); the strings here
@@ -4046,7 +4046,7 @@ type StartRunRequest struct {
 //   - :attr:`op_id` / :attr:`params` -- populated only for
 //     “operation_call“ steps; the substituted call shape.
 //   - :attr:`verify` -- the substituted-and-frozen verify gate the
-//     caller must respond to on the next “runbook_next“ call.
+//     caller must respond to on the next “meho.runbook.next“ call.
 //
 // What this shape **must not** carry, by structural construction
 // (regression-tested in “test_step_body_omits_future_step_fields“):
@@ -4408,7 +4408,7 @@ type TargetsDiscoverResult struct {
 	Skipped    []SkippedConnector `json:"skipped"`
 }
 
-// TemplateSummary Operator-readable summary row surfaced by “runbook_list_templates“.
+// TemplateSummary Operator-readable summary row surfaced by “meho.runbook.list_templates“.
 //
 // The list-view projection -- enough to identify a template and its
 // lifecycle state without loading the full step list (which

--- a/docs/architecture/runbooks.md
+++ b/docs/architecture/runbooks.md
@@ -29,7 +29,7 @@ meho.runbook.reassign(run_id, new_assignee) -> {run_id, assigned_to, reassigned_
 
 The six template-lifecycle tools (`meho.runbook.draft_template` / `.edit_template` / `.publish_template` / `.deprecate_template` / `.list_templates` / `.show_template`) live on the same MCP surface from G12.2 and are documented in the authoring counterpart.
 
-The dotted names are canonical as of #1612; the original flat `runbook_*` names remain callable as deprecated aliases (removed in v0.15.0, deferred from the original one-release v0.14.0 window by #1702), and the template id is `template_slug` on every tool (`slug` accepted as a deprecated alias on the template verbs for the same window). See [`docs/codebase/mcp.md`](../codebase/mcp.md) §Tool naming grammar.
+The dotted names are canonical as of #1612; the original flat `runbook_*` names were kept as deprecated aliases for one release and removed in v0.15.0 (#1625; the deadline was deferred once from the original v0.14.0 window by #1702). The template id is `template_slug` on every tool — the deprecated `slug` input alias on the template verbs was removed alongside the flat names. See [`docs/codebase/mcp.md`](../codebase/mcp.md) §Tool naming grammar.
 
 ## The three entities
 

--- a/docs/codebase/api-shape-conventions.md
+++ b/docs/codebase/api-shape-conventions.md
@@ -1022,21 +1022,21 @@ Every multi-verb domain family on the MCP surface uses the dotted
 `meho.agent_principals.*`). The runbook family was the lone flat
 hold-out (`runbook_start`, `runbook_show_template`, …) until #1612
 canonicalised the 11 tools as `meho.runbook.<verb>`. The flat names
-stay registered as deprecated aliases — same handler object, same
-schema, DEPRECATED pointer description, per-call
-`mcp_tool_name_deprecated` warning log — until removal in v0.15.0
-(the original one-release v0.14.0 deadline slipped past the v0.14.0
-tag and was re-pinned, with a public CHANGELOG erratum, by #1702).
-The same change unified the template identifier on
-`template_slug` across all 11 tools (the template verbs previously
-took `slug` while the run verbs took `template_slug`); `slug` is
-accepted as a deprecated input alias on the template verbs for the
-same window, and template-verb responses mirror the id as
+were kept as deprecated aliases for one release and **removed in
+v0.15.0** by #1625 (the original one-release v0.14.0 deadline slipped
+past the v0.14.0 tag and was re-pinned, with a public CHANGELOG
+erratum, by #1702). The runbook family now serves exactly the 11
+dotted tools; a flat name falls through to the dispatcher's standard
+unknown-tool error. The same #1612 change unified the template
+identifier on `template_slug` across all 11 tools (the template verbs
+previously took `slug` while the run verbs took `template_slug`);
+`slug` was accepted as a deprecated input alias on the template verbs
+for the same window and was removed alongside the flat names, so
+`template_slug` is now a plain required field (no `anyOf`, no `slug`
+sibling). Template-verb responses still mirror the id as
 `template_slug` so a value read from `show_template` /
-`list_templates` round-trips into `meho.runbook.start` verbatim.
-Alias mechanics live in `register_deprecated_mcp_tool_alias`
-(`backend/src/meho_backplane/mcp/registry.py`); see also
-[`mcp.md`](mcp.md) §Tool naming grammar.
+`list_templates` round-trips into `meho.runbook.start` verbatim. See
+also [`mcp.md`](mcp.md) §Tool naming grammar.
 
 ### Code reference
 

--- a/docs/codebase/mcp.md
+++ b/docs/codebase/mcp.md
@@ -162,44 +162,41 @@ in #1612:
   `meho.runbook.show_template` or a `list_templates` summary is
   accepted by `meho.runbook.start` verbatim, no rename.
 
-### Deprecation-window mechanics
+### Alias window (closed — removed in v0.15.0, #1625)
 
 Renames on an agent-facing wire surface always ship with a one-release
 alias window (the `content`→`body`, `since`→`cursor`, and
-`id`→`approval_request_id` precedents). For #1612 the window covers
-two alias kinds, both **removed in v0.15.0** (originally pinned to
-v0.14.0, but v0.14.0 was tagged with the aliases still registered and
-no release-notes line, so #1702 re-pinned the deadline to v0.15.0 and
-published a `### Deprecated` erratum on the v0.14.0 CHANGELOG section;
-removal executes as the scheduled task #1625, re-scheduled to the
-v0.15.0 cycle, and `removal_version` is warning/description text only
-— deliberately not a runtime version gate, because `__version__` is
-build-metadata-dependent; see #1698):
+`id`→`approval_request_id` precedents). #1612 added two alias kinds for
+the runbook family; both have now been **removed in v0.15.0** by #1625.
+The removal was originally pinned to v0.14.0, but v0.14.0 was tagged
+with the aliases still registered and no release-notes line, so #1702
+re-pinned the deadline to v0.15.0 and published a `### Deprecated`
+erratum on the v0.14.0 CHANGELOG section. (There was never a runtime
+version gate — `removal_version` was warning/description text only,
+because `__version__` is build-metadata-dependent; see #1698 — so the
+removal is enforced by #1625 and the release checklist, not by dispatch
+logic.)
 
-* **Tool-name aliases.** The flat `runbook_*` names stay registered
-  via `register_deprecated_mcp_tool_alias`
-  (`backend/src/meho_backplane/mcp/registry.py`): the alias shares the
-  canonical tool's handler *object*, `inputSchema`, role gate, and
-  capability gate, differing only in name + a generated
-  `DEPRECATED alias for …` description. The MCP 2025-06-18 `Tool`
-  object has no first-class deprecation field, so the description is
-  the agent-visible marker; the MEHO-internal
-  `ToolDefinition.deprecated_alias_for` field (never serialised to the
-  wire) is the machine-readable one. `handle_tools_call` emits a
-  structured `mcp_tool_name_deprecated` warning (with `replacement=`)
-  per alias call, so operators can grep logs to confirm consumers have
-  migrated before the removal release. Audit rows keep recording the
-  *called* name — migration forensics stay queryable.
-* **Field aliases.** The five template verbs accept `slug` as a
-  deprecated alias for `template_slug` (schema-level: both properties
-  declared, the alias flagged `"deprecated": true`, a top-level
-  `anyOf` requiring exactly one of the two — stripped from the wire
-  copy per the Anthropic top-level-combinator restriction but enforced
-  server-side). The handler-level resolver enforces the XOR (`-32602`
-  when both are supplied) and logs
-  `runbook_template_slug_field_deprecated` on alias use. The mirrored
-  `slug` key in template-verb responses is part of the same window and
-  is dropped with the aliases.
+* **Tool-name aliases (removed).** The flat `runbook_*` names were
+  registered alongside their dotted canonical tools via a
+  `register_deprecated_mcp_tool_alias` helper that shared the canonical
+  handler object and schema and marked the alias with a MEHO-internal
+  `ToolDefinition.deprecated_alias_for` field; `handle_tools_call`
+  emitted a per-call `mcp_tool_name_deprecated` warning so operators
+  could watch consumers migrate. #1625 deleted the registrations, the
+  helper, the field, and the warning — a flat name now falls through to
+  the dispatcher's standard unknown-tool error. The runbook family was
+  the only adopter of the alias machinery, so it was removed wholesale.
+* **Field alias (removed).** The five template verbs accepted `slug` as
+  a deprecated alias for `template_slug`, guarded by a top-level `anyOf`
+  and a handler-level XOR resolver that logged
+  `runbook_template_slug_field_deprecated`. #1625 removed the `slug`
+  property and the `anyOf`; `template_slug` is now an ordinary required
+  field, and supplying `slug` is an unknown property rejected by the
+  schema's `additionalProperties: false` gate. The response mirror —
+  template-verb responses carry `template_slug` alongside the model's
+  native `slug` — stays: it is canonical post-#1612 behaviour, not part
+  of the alias window.
 
 The conventions are structurally pinned in
 [`backend/tests/test_mcp_tools_list_shape_conventions.py`](../../backend/tests/test_mcp_tools_list_shape_conventions.py)
@@ -283,8 +280,9 @@ resource.
 * G0.14-T13 (#1202) — protocol-version mismatch observability
   (this section).
 * G0.22-T7 (#1612) — runbook tool-name + `template_slug`
-  canonicalisation; deprecated flat aliases removed in v0.15.0
-  (deferred from v0.14.0 by #1702).
+  canonicalisation; deprecated flat aliases + `slug` input alias
+  removed in v0.15.0 by #1625 (deadline deferred once from v0.14.0 by
+  #1702).
 * MCP spec (2025-06-18) §Tools (Tool object shape — no first-class
   deprecation field):
   https://modelcontextprotocol.io/specification/2025-06-18/server/tools

--- a/docs/runbooks/authoring.md
+++ b/docs/runbooks/authoring.md
@@ -61,12 +61,13 @@ each `meho.runbook.edit_template` call persists the whole body, and a new
 session re-reads it with `meho.runbook.show_template`.
 
 > **Naming note (#1612).** The dotted `meho.runbook.<verb>` names are
-> canonical; the original flat `runbook_*` names remain callable as
-> deprecated aliases (removed in v0.15.0, deferred from the original
-> one-release v0.14.0 window by #1702). The template
-> id field is `template_slug` everywhere — `slug` is accepted as a
-> deprecated alias on the template verbs for the same window, and
-> responses carry both keys until the window closes.
+> canonical; the original flat `runbook_*` names were kept as deprecated
+> aliases for one release and removed in v0.15.0 (#1625; the deadline was
+> deferred once from the original v0.14.0 window by #1702). The template
+> id field is `template_slug` everywhere — the deprecated `slug` input
+> alias on the template verbs was removed alongside the flat names,
+> though template-verb responses still carry both `template_slug` and the
+> model's `slug` key.
 
 The load-bearing property: **drafts are mutable, and editing a draft does not
 bump the version.** A published version is pinned and immutable; a draft is a


### PR DESCRIPTION
## Summary

- Removes the 11 deprecated flat `runbook_*` MCP tool-name aliases and the `slug` template-id input alias, completing the one-release deprecation contract opened in #1612 (v0.13.0) and deferred once from v0.14.0 to v0.15.0 by #1702. The runbook MCP family now serves exactly the 11 dotted `meho.runbook.<verb>` tools.
- A removed flat name now falls through to the registry's standard unknown-tool error; template verbs accept `template_slug` only (plain required field, no `anyOf`), and supplying the removed `slug` field is rejected by the schema's `additionalProperties: false` gate before the handler runs.
- Deletes the now-unused alias machinery wholesale — `register_deprecated_mcp_tool_alias`, `ToolDefinition.deprecated_alias_for`, and the `mcp_tool_name_deprecated` / `runbook_template_slug_field_deprecated` warnings. The runbook family was the **only** adopter (grep evidence below).
- Updates docstring tool-name prose to dotted names and regenerates the CLI snapshot, so no flat tool name survives in `cli/api/openapi.json`; fixes the stale `_LIST_DESCRIPTION` `(TENANT_ADMIN-only)` permission text; flips both convention docs + the §14.9 structural-pin tests from "removed in v0.15.0 (deferred)" to completed-removal.

## Execution-gate / consumer-migration evidence (Phase 4)

- v0.14.0 is tagged (2026-06-12); no v0.15.0 tag and no v0.15.0 release-cutting PR is open — the execution gate (after v0.14.0, before the v0.15.0 cut) is satisfied.
- The RDC consumer (claude-rdc-hetzner-dc) ran a full v0.14.0 cycle-10 dogfood (#1691) that exercised the runbook MCP surface and filed 11 grounded findings. The **only** runbook-alias finding (#1702) was a process/release-engineering miss — "the removal deadline lapsed without a release note" — explicitly **requesting** the removal (or a formal deferral), not protection against it. No finding reported continued dependence on the flat names. #1702's claim that "consumers already on `meho.runbook.<verb>` + `template_slug` are unaffected" is corroborated by its own source (the consumer asking for removal).
- In-repo, every flat-name occurrence was docstring prose (now dotted), the alias machinery itself, tests pinning that machinery, or DB-table names (out of scope). Zero live callers of the flat tool names.

## Grep evidence (AC3 — whole-machinery removal)

```
$ grep -rn "register_deprecated_mcp_tool_alias" backend/src/meho_backplane/mcp/tools/   → (nothing)
$ grep -rn "deprecated_alias_for" backend/src/                                          → (nothing)
```
Only the runbook family used the alias helper/field/warnings, so they were removed entirely (no non-runbook adopter).

## Test plan

- [x] `ruff check src/ tests/` — clean
- [x] `ruff format --check src/ tests/` — clean (961 files)
- [x] `mypy src/ --ignore-missing-imports` — clean (471 files)
- [x] MCP blast-radius pytest sweep (registry, audit/dispatch, capability gating, runbook template+run tools, §14.9 pins, REST runbook API, topology/knowledge/memory/approvals/broadcast MCP) — **379 passed, 2 skipped**
- [x] `code-quality.py --diff` — 0 blockers (7 pre-existing warnings on touched-but-unmodified files)
- [x] **AC1** import smoke: `list_tools` exposes exactly 11 dotted `meho.runbook.*`, zero flat names; flat call → `-32602` `unknown tool` (test pinned)
- [x] **AC2** `slug` rejected with clean `-32602` validation error (no `anyOf`, `_resolve_template_slug` is a direct read); `_mirror_template_slug` round-trip still green
- [x] **AC3** alias machinery removed (grep above); registry helper + `deprecated_alias_for` + both warnings gone
- [x] **AC4** `grep -oE "runbook_[a-z_]*" cli/api/openapi.json` yields only `runbook_runs` / `runbook_templates` / `runbook_run_step_states` (DB tables); CLI snapshot + Go client regenerated via `make snapshot-openapi && make generate`
- [x] **AC5** CHANGELOG `[Unreleased]` `### Removed` bullet (references #1612 recipe + #1702 deferral); `docs/codebase/mcp.md` §Tool naming grammar + `docs/codebase/api-shape-conventions.md` §14.9 updated to completed-removal

## Out of scope

- Single-purpose flat reference tools outside the runbook family (deliberately left flat by #1612).
- REST runbook routes / `?envelope=v2` (#1611) — MCP-only task.
- DB table names + migrations; no new deprecation/alias machinery.

<!-- auto-implement-issue: fresh, iteration 1 -->

Closes #1625
