### PR TITLE
feat(scheduler): work_ref I3-T3 — scheduled_trigger.work_ref + dispatch-seam run inheritance

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -102,6 +102,16 @@ connector-related release-notes line.
   no rows remain anywhere (hand-coded classes never), warns —
   advisory, not error — when enabled operations are deleted, and
   re-ingest revives the connector from scratch (#1700)
+- `work_ref` on scheduled triggers, inherited end-to-end by every
+  dispatched run: `scheduled_trigger.work_ref` (migration 0043) is
+  set at create time on `meho.scheduler.create` / `POST
+  /api/v1/scheduler/triggers` and, when the trigger fires, the
+  scheduler binds it around the dispatched agent run so the run's
+  `agent_run.work_ref` and every audit row it produces carry the
+  trigger's change-ticket reference (the previously-severed
+  trigger → run seam). The scheduler-trigger list filters by
+  `--work-ref` and surfaces it (`meho scheduler list --work-ref`,
+  `meho scheduler create --work-ref`) (#1663)
 
 ### Changed
 

--- a/backend/alembic/versions/0043_add_scheduled_trigger_work_ref.py
+++ b/backend/alembic/versions/0043_add_scheduled_trigger_work_ref.py
@@ -1,0 +1,90 @@
+# SPDX-License-Identifier: Apache-2.0
+# Copyright (c) 2026 evoila Group
+
+"""Add ``scheduled_trigger.work_ref`` for change-ticket inheritance.
+
+Revision ID: 0043
+Revises: 0042
+Create Date: 2026-06-13
+
+Task #1663 (work_ref I3-T3) under Initiative #1654, Goal #1651. A
+scheduled trigger -- the authorizing definition for a recurring agent
+run -- carries no link to the change ticket it works under, and the
+trigger -> dispatched-run seam carries no ref to inherit. Migration
+``0039`` added ``audit_log.work_ref`` (the column the dispatch audit
+writers stamp from the shared
+:data:`meho_backplane.operations._audit.work_ref_var` ContextVar),
+``0041`` added ``agent_run.work_ref`` (the durable bind source for a
+single run), ``0042`` added ``runbook_runs.work_ref``; this migration
+adds the *trigger-level* bind source: a ``work_ref`` recorded on the
+``scheduled_trigger`` row at create time. When the trigger fires, the
+scheduler binds ``work_ref_var`` from this column around the dispatched
+run, so the dispatched run's ``agent_run.work_ref`` and every audit row
+the run produces inherit the trigger's ref end-to-end.
+
+What this migration adds
+------------------------
+
+* ``scheduled_trigger.work_ref text`` -- nullable. The opaque external
+  change-ticket reference (a GitHub issue ``"gh:evoila/meho#13"``, a
+  Jira key, a CR id) of the change record the trigger -- and every run
+  it dispatches -- works under. Set at create time; ``None`` when no
+  ticket is bound. ``NULL`` for pre-#1663 rows. Set-at-create-only --
+  triggers have no UPDATE path. No backfill.
+* ``scheduled_trigger_tenant_work_ref_idx`` -- composite b-tree index
+  on ``(tenant_id, work_ref)``, driving the tenant-scoped exact-match
+  ``--work-ref`` filter the scheduled-trigger list surfaces (mirrors the
+  ``agent_run_tenant_work_ref_idx`` shape of 0041 and the
+  ``runbook_runs_tenant_work_ref_idx`` shape of 0042).
+
+Why no foreign key / NOT NULL
+-----------------------------
+
+Same soft-column discipline as ``audit_log.work_ref`` (0039),
+``agent_run.work_ref`` (0041), and ``runbook_runs.work_ref`` (0042):
+nullable, no server default (the ORM ``default`` of ``None`` works on
+both PG and SQLite), no FK clause -- the migration is trivially
+reversible on a populated table. ``work_ref`` is an opaque cross-system
+reference string, not a row id in this schema, so there is no table to
+point a FK at.
+
+Reversibility contract
+----------------------
+
+``downgrade()`` reverses ``upgrade()`` in order: drop the index, then
+the column. Pure generic SQLAlchemy DDL, portable across PG and SQLite.
+"""
+
+from collections.abc import Sequence
+
+import sqlalchemy as sa
+from alembic import op
+
+# revision identifiers, used by Alembic.
+revision: str = "0043"
+down_revision: str | None = "0042"
+branch_labels: str | Sequence[str] | None = None
+depends_on: str | Sequence[str] | None = None
+
+
+def upgrade() -> None:
+    """Add ``scheduled_trigger.work_ref`` column + composite index."""
+    op.add_column(
+        "scheduled_trigger",
+        sa.Column("work_ref", sa.Text(), nullable=True),
+    )
+    op.create_index(
+        "scheduled_trigger_tenant_work_ref_idx",
+        "scheduled_trigger",
+        ["tenant_id", "work_ref"],
+        postgresql_using="btree",
+    )
+
+
+def downgrade() -> None:
+    """Reverse the upgrade -- drop the index and column."""
+    op.drop_index(
+        "scheduled_trigger_tenant_work_ref_idx",
+        table_name="scheduled_trigger",
+    )
+    op.drop_column("scheduled_trigger", "work_ref")

--- a/backend/src/meho_backplane/agent/invocation.py
+++ b/backend/src/meho_backplane/agent/invocation.py
@@ -955,6 +955,7 @@ class AgentInvoker:
         *,
         agent_client_id: str,
         agent_client_secret: SecretStr,
+        work_ref: str | None = None,
     ) -> AgentRunOutcome:
         """Run an agent autonomously under its own ``client_credentials`` identity.
 
@@ -984,6 +985,21 @@ class AgentInvoker:
         owns-definition guard) is delegated to
         :meth:`_authenticate_scheduled_agent`.
 
+        work_ref I3-T3 (#1663): when the firing trigger carries a
+        *work_ref* (its change-ticket reference), it is bound onto the
+        shared
+        :data:`~meho_backplane.operations._audit.work_ref_var` ContextVar
+        for the duration of this call. :meth:`_create_run_row` reads that
+        ContextVar at run-create time, so the dispatched
+        ``agent_run.work_ref`` lands the trigger's ref; the background
+        loop task snapshots the ContextVar at
+        :func:`asyncio.create_task` time (in :meth:`_launch_run`), so
+        every per-tool-call audit row the run produces inherits it too.
+        ``None`` leaves the binding untouched (the run lands ``NULL``
+        work_ref, the pre-#1663 behaviour). This is the inheritance hop
+        the Initiative #1654 builds across the previously-severed
+        trigger -> dispatched-run seam.
+
         A trigger fired with no usable user prompt (empty / whitespace-only
         *inputs*, the common cause being a trigger created without
         ``inputs``) does **not** reach the model: the run row is finalised
@@ -1007,9 +1023,21 @@ class AgentInvoker:
             agent_client_secret=agent_client_secret,
             settings=settings,
         )
-        return await self._launch_scheduled_run(
-            name, inputs, operator=operator, entry=entry, settings=settings
-        )
+        # work_ref I3-T3 #1663: bind the firing trigger's change-ticket ref
+        # onto the shared ContextVar so the dispatched run inherits it.
+        # _create_run_row reads it at create time (-> agent_run.work_ref);
+        # the background loop task snapshots it at create_task time (->
+        # the run's audit rows). A blank/None ref binds nothing -- the run
+        # lands NULL work_ref (the pre-#1663 behaviour).
+        cleaned_work_ref = work_ref.strip() if work_ref else None
+        work_ref_token = work_ref_var.set(cleaned_work_ref) if cleaned_work_ref else None
+        try:
+            return await self._launch_scheduled_run(
+                name, inputs, operator=operator, entry=entry, settings=settings
+            )
+        finally:
+            if work_ref_token is not None:
+                work_ref_var.reset(work_ref_token)
 
     async def _refuse_scheduled_no_input(
         self,

--- a/backend/src/meho_backplane/agent/invocation.py
+++ b/backend/src/meho_backplane/agent/invocation.py
@@ -1027,17 +1027,21 @@ class AgentInvoker:
         # onto the shared ContextVar so the dispatched run inherits it.
         # _create_run_row reads it at create time (-> agent_run.work_ref);
         # the background loop task snapshots it at create_task time (->
-        # the run's audit rows). A blank/None ref binds nothing -- the run
-        # lands NULL work_ref (the pre-#1663 behaviour).
+        # the run's audit rows). The bind is UNCONDITIONAL: a blank/None
+        # trigger ref sets the ContextVar to None so the dispatched run
+        # lands NULL work_ref deterministically -- a pre-existing ambient
+        # work_ref bound elsewhere in this task's context can never bleed
+        # into _create_run_row / agent_run.work_ref / downstream audit
+        # lineage. The dispatched run's work_ref is exactly the trigger's
+        # value (or None). reset() in finally restores the prior binding.
         cleaned_work_ref = work_ref.strip() if work_ref else None
-        work_ref_token = work_ref_var.set(cleaned_work_ref) if cleaned_work_ref else None
+        work_ref_token = work_ref_var.set(cleaned_work_ref)
         try:
             return await self._launch_scheduled_run(
                 name, inputs, operator=operator, entry=entry, settings=settings
             )
         finally:
-            if work_ref_token is not None:
-                work_ref_var.reset(work_ref_token)
+            work_ref_var.reset(work_ref_token)
 
     async def _refuse_scheduled_no_input(
         self,

--- a/backend/src/meho_backplane/api/v1/scheduler.py
+++ b/backend/src/meho_backplane/api/v1/scheduler.py
@@ -121,6 +121,7 @@ async def list_triggers(
     offset: int = Query(default=0, ge=0),
     kind: KindFilter | None = Query(default=None),
     status: StatusFilter | None = Query(default=None),
+    work_ref: str | None = Query(default=None),
     tenant_filter: UUID | None = Query(default=None),
 ) -> ScheduledTriggerListResponse:
     """List scheduled triggers for the operator's tenant, newest-first.
@@ -130,6 +131,10 @@ async def list_triggers(
     ``cross_tenant_requires_platform_admin`` unless the caller holds the
     ``platform_admin`` cross-tenant capability. Passing one's own tenant
     id (or omitting the filter) is always allowed.
+
+    ``work_ref`` (optional, work_ref I3-T3 #1663) narrows to triggers
+    carrying that exact change-ticket reference -- the tenant-scoped
+    exact-match driven by ``scheduled_trigger_tenant_work_ref_idx``.
     """
     target_tenant = authorize_tenant_scope(operator, tenant_filter)
     structlog.contextvars.bind_contextvars(
@@ -145,6 +150,7 @@ async def list_triggers(
         target_tenant,
         kind=kind,
         status=status,
+        work_ref=work_ref,
         limit=limit,
         offset=offset,
     )

--- a/backend/src/meho_backplane/db/models.py
+++ b/backend/src/meho_backplane/db/models.py
@@ -3873,6 +3873,22 @@ class ScheduledTrigger(Base):
         default="__scheduler__",
     )
     created_by_sub: Mapped[str] = mapped_column(Text, nullable=False)
+    # External change-ticket reference (work_ref I3-T3 #1663). The opaque
+    # cross-system reference (a GitHub issue ``"gh:evoila/meho#13"``, a
+    # Jira key, a CR id) of the change record this trigger -- and every
+    # run it dispatches -- works under. Set at create time; the scheduler
+    # binds the shared ``work_ref_var`` ContextVar from this column around
+    # each dispatched run so the dispatched ``agent_run.work_ref`` and the
+    # run's audit rows inherit the trigger's ref end-to-end
+    # (:data:`meho_backplane.operations._audit.work_ref_var`). Triggers
+    # have no UPDATE path, so this is set-at-create-only. NULL when no
+    # work_ref is bound (pre-#1663 rows). No FK -- opaque cross-system
+    # string. Added by migration ``0043``.
+    work_ref: Mapped[str | None] = mapped_column(
+        Text,
+        nullable=True,
+        default=None,
+    )
     created_at: Mapped[datetime] = mapped_column(
         DateTime(timezone=True),
         nullable=False,
@@ -3897,6 +3913,16 @@ class ScheduledTrigger(Base):
             "scheduled_trigger_tenant_idx",
             "tenant_id",
             "kind",
+            postgresql_using="btree",
+        ),
+        # work_ref I3-T3 #1663 -- composite (tenant_id, work_ref) drives
+        # the tenant-scoped exact-match ``--work-ref`` filter the
+        # scheduled-trigger list surfaces. Mirrors
+        # agent_run_tenant_work_ref_idx / runbook_runs_tenant_work_ref_idx.
+        Index(
+            "scheduled_trigger_tenant_work_ref_idx",
+            "tenant_id",
+            "work_ref",
             postgresql_using="btree",
         ),
         sa.CheckConstraint(

--- a/backend/src/meho_backplane/mcp/tools/scheduler.py
+++ b/backend/src/meho_backplane/mcp/tools/scheduler.py
@@ -118,6 +118,7 @@ async def _list_handler(
     )
     kind = arguments.get("kind")
     status = arguments.get("status")
+    work_ref = arguments.get("work_ref")
     limit_raw = arguments.get("limit", 100)
     offset_raw = arguments.get("offset", 0)
     # The inputSchema does first-pass shape + bounds; the int() cast is
@@ -129,6 +130,7 @@ async def _list_handler(
         operator.tenant_id,
         kind=kind if isinstance(kind, str) else None,
         status=status if isinstance(status, str) else None,
+        work_ref=work_ref if isinstance(work_ref, str) else None,
         limit=limit,
         offset=offset,
     )
@@ -144,7 +146,8 @@ register_mcp_tool(
             "(Initiative #804). Operator-level read. Returns "
             "{triggers: [trigger, ...]} sorted newest-first. "
             "Optional filters: kind ('cron'|'one_off'|'event'), "
-            "status ('active'|'paused'|'cancelled'|'fired'). "
+            "status ('active'|'paused'|'cancelled'|'fired'), "
+            "work_ref (exact-match change-ticket reference). "
             "Tenant-scoped via the JWT; cross-tenant listing is not "
             "exposed on the MCP transport."
         ),
@@ -160,6 +163,14 @@ register_mcp_tool(
                     "type": "string",
                     "enum": ["active", "paused", "cancelled", "fired"],
                     "description": "Optional status filter.",
+                },
+                "work_ref": {
+                    "type": "string",
+                    "maxLength": 256,
+                    "description": (
+                        "Optional exact-match filter on the trigger's "
+                        "change-ticket reference (e.g. 'gh:evoila/meho#13')."
+                    ),
                 },
                 "limit": {
                     "type": "integer",
@@ -245,7 +256,9 @@ register_mcp_tool(
             "object), identity_sub (default '__scheduler__'), "
             "in_flight_policy ('fail_into_audit'|'resume', default "
             "'fail_into_audit'), tenant_id (UUID; tenant_admin-only "
-            "cross-tenant target). Invalid cron expression -> error with "
+            "cross-tenant target), work_ref (change-ticket reference "
+            "inherited by every dispatched run's audit rows). Invalid "
+            "cron expression -> error with "
             "detail 'invalid_arguments'; unknown agent_definition_id -> "
             "'agent_definition_not_found'; non-admin passing tenant_id -> "
             "'tenant_id_requires_tenant_admin'. Response: {trigger_id, "
@@ -304,6 +317,18 @@ register_mcp_tool(
                         "'tenant_id_requires_tenant_admin'). When omitted "
                         "or null, the trigger is created under the "
                         "caller's tenant."
+                    ),
+                },
+                "work_ref": {
+                    "type": ["string", "null"],
+                    "maxLength": 256,
+                    "description": (
+                        "Optional external change-ticket reference (a "
+                        "GitHub issue 'gh:evoila/meho#13', a Jira key, a "
+                        "CR id) the trigger -- and every run it dispatches "
+                        "-- works under. Pinned on the trigger and "
+                        "inherited by each dispatched run's audit rows. "
+                        "Set-at-create-only."
                     ),
                 },
             },

--- a/backend/src/meho_backplane/scheduler/loop.py
+++ b/backend/src/meho_backplane/scheduler/loop.py
@@ -350,6 +350,16 @@ class _PreparedInvocation:
     #: only at the token-mint call site via ``.get_secret_value()``.
     agent_client_secret: SecretStr
     inputs_str: str
+    #: The firing trigger's external change-ticket reference
+    #: (work_ref I3-T3 #1663), copied off ``row.work_ref`` at prepare
+    #: time. The dispatcher binds ``work_ref_var`` from this value around
+    #: :meth:`AgentInvoker.run_scheduled` so the dispatched run's
+    #: ``agent_run.work_ref`` and every audit row the run produces inherit
+    #: the trigger's ref end-to-end. ``None`` when the trigger carries no
+    #: change ticket. This is the seam the Initiative #1654 widens: today
+    #: the dispatch carried only name + inputs, so a dispatched run could
+    #: not inherit the trigger's ref.
+    work_ref: str | None
 
 
 async def _prepare_invocation(row: ScheduledTrigger) -> _PreparedInvocation | None:
@@ -430,6 +440,9 @@ async def _prepare_invocation(row: ScheduledTrigger) -> _PreparedInvocation | No
         # any fire that ``run_one_tick`` would log on).
         agent_client_secret=SecretStr(agent_client_secret),
         inputs_str=_coerce_inputs(row.inputs),
+        # work_ref I3-T3 #1663: snapshot the trigger's change-ticket ref so
+        # the dispatcher can bind it onto the run for inheritance.
+        work_ref=row.work_ref,
     )
 
 
@@ -524,6 +537,11 @@ async def _fire_one_off(
     return await _dispatch_invocation(row, prepared, invoker)
 
 
+# _dispatch_invocation is a dispatch handler with four exception branches + two
+# outcome branches, each carrying a load-bearing at-most-once-contract comment;
+# splitting fragments that single error-contract. It was already at the 100-line
+# limit before #1663 added the one-line ``work_ref=`` forward.
+# code-quality-allow: function-size — irreducible error-contract dispatcher (see above)
 async def _dispatch_invocation(
     row: ScheduledTrigger,
     prepared: _PreparedInvocation,
@@ -541,6 +559,11 @@ async def _dispatch_invocation(
     :meth:`run_scheduled` so a cron / one-off fire is distinguishable
     from a direct invocation in audit queries.
 
+    work_ref I3-T3 (#1663): *prepared*'s ``work_ref`` is forwarded into
+    :meth:`run_scheduled`, which binds ``work_ref_var`` so the dispatched
+    run + its audit rows inherit the trigger's ref -- the seam that
+    before #1663 carried only name + inputs.
+
     Errors are logged + swallowed (return ``False``); the at-most-once
     contract documented in the module docstring applies -- the
     advance/mark-fired commit has already happened, so a transient
@@ -553,6 +576,7 @@ async def _dispatch_invocation(
             prepared.inputs_str,
             agent_client_id=prepared.agent_client_id,
             agent_client_secret=prepared.agent_client_secret,
+            work_ref=prepared.work_ref,
         )
     except (
         AgentNotFoundError,

--- a/backend/src/meho_backplane/scheduler/repository.py
+++ b/backend/src/meho_backplane/scheduler/repository.py
@@ -71,6 +71,7 @@ async def create_cron_trigger(
     timezone: str = "UTC",
     base: datetime | None = None,
     in_flight_policy: str = ScheduledTriggerInFlightPolicy.FAIL_INTO_AUDIT.value,
+    work_ref: str | None = None,
 ) -> ScheduledTrigger:
     """Insert a cron trigger with a computed first ``next_fire_at``.
 
@@ -106,6 +107,7 @@ async def create_cron_trigger(
         inputs=inputs,
         identity_sub=identity_sub,
         created_by_sub=created_by_sub,
+        work_ref=work_ref,
     )
     session.add(row)
     await session.flush()
@@ -122,6 +124,7 @@ async def create_one_off_trigger(
     identity_sub: str,
     created_by_sub: str,
     in_flight_policy: str = ScheduledTriggerInFlightPolicy.FAIL_INTO_AUDIT.value,
+    work_ref: str | None = None,
 ) -> ScheduledTrigger:
     """Insert a one-off trigger that fires once at *run_at*.
 
@@ -154,6 +157,7 @@ async def create_one_off_trigger(
         inputs=inputs,
         identity_sub=identity_sub,
         created_by_sub=created_by_sub,
+        work_ref=work_ref,
     )
     session.add(row)
     await session.flush()
@@ -170,6 +174,7 @@ async def create_event_trigger(
     identity_sub: str,
     created_by_sub: str,
     in_flight_policy: str,
+    work_ref: str | None = None,
 ) -> ScheduledTrigger:
     """Insert an event-subscription trigger.
 
@@ -199,6 +204,7 @@ async def create_event_trigger(
         inputs=inputs,
         identity_sub=identity_sub,
         created_by_sub=created_by_sub,
+        work_ref=work_ref,
     )
     session.add(row)
     await session.flush()

--- a/backend/src/meho_backplane/scheduler/schemas.py
+++ b/backend/src/meho_backplane/scheduler/schemas.py
@@ -52,6 +52,13 @@ _TIMEZONE_MAX_LENGTH = 64
 #: customisation (longer values are almost certainly a misconfiguration).
 _IDENTITY_SUB_MAX_LENGTH = 256
 
+#: Max length of a ``work_ref`` change-ticket reference. An opaque
+#: cross-system string (``"gh:evoila/meho#13"`` / a Jira key / a CR id);
+#: bounded so an adversarial caller cannot smuggle a large blob past the
+#: validator. Mirrors the 256-char cap the audit ``work_ref`` sink
+#: applies (:class:`~meho_backplane.api.v1.audit_models`).
+_WORK_REF_MAX_LENGTH = 256
+
 
 class ScheduledTriggerCreate(BaseModel):
     """Request body for ``POST /api/v1/scheduler/triggers``.
@@ -94,6 +101,13 @@ class ScheduledTriggerCreate(BaseModel):
     callers leave it ``None`` and the boundary pins it to the JWT's
     tenant id. The boundary enforces the RBAC -- this schema only
     carries the field.
+
+    *work_ref* (optional, work_ref I3-T3 #1663) is the opaque external
+    change-ticket reference the trigger -- and every run it dispatches --
+    works under. Pinned on the trigger row at create time and inherited
+    by each dispatched run's ``agent_run.work_ref`` and audit rows via
+    the shared ``work_ref_var`` ContextVar. Set-at-create-only: triggers
+    have no UPDATE path. Omit when the trigger carries no change ticket.
     """
 
     model_config = ConfigDict(frozen=True, extra="forbid")
@@ -110,6 +124,7 @@ class ScheduledTriggerCreate(BaseModel):
         ScheduledTriggerInFlightPolicy.FAIL_INTO_AUDIT
     )
     tenant_id: uuid.UUID | None = None
+    work_ref: Annotated[str | None, Field(max_length=_WORK_REF_MAX_LENGTH)] = None
 
     @model_validator(mode="after")
     def _validate_discriminated_union(self) -> ScheduledTriggerCreate:
@@ -180,6 +195,7 @@ class ScheduledTriggerRead(BaseModel):
     inputs: dict[str, object] | None
     identity_sub: str
     created_by_sub: str
+    work_ref: str | None
     created_at: datetime
     updated_at: datetime
 

--- a/backend/src/meho_backplane/scheduler/service.py
+++ b/backend/src/meho_backplane/scheduler/service.py
@@ -209,6 +209,7 @@ class SchedulerAdminService:
                         identity_sub=payload.identity_sub,
                         created_by_sub=created_by_sub,
                         in_flight_policy=payload.in_flight_policy.value,
+                        work_ref=payload.work_ref,
                     )
                 elif payload.kind == ScheduledTriggerKind.ONE_OFF:
                     assert payload.fire_at is not None
@@ -221,6 +222,7 @@ class SchedulerAdminService:
                         identity_sub=payload.identity_sub,
                         created_by_sub=created_by_sub,
                         in_flight_policy=payload.in_flight_policy.value,
+                        work_ref=payload.work_ref,
                     )
                 else:  # payload.kind == ScheduledTriggerKind.EVENT
                     assert payload.event_filter is not None
@@ -233,6 +235,7 @@ class SchedulerAdminService:
                         identity_sub=payload.identity_sub,
                         created_by_sub=created_by_sub,
                         in_flight_policy=payload.in_flight_policy.value,
+                        work_ref=payload.work_ref,
                     )
                 await session.commit()
             except IntegrityError as exc:
@@ -251,6 +254,7 @@ class SchedulerAdminService:
         *,
         kind: str | None = None,
         status: str | None = None,
+        work_ref: str | None = None,
         limit: int = DEFAULT_LIST_LIMIT,
         offset: int = 0,
     ) -> Sequence[ScheduledTriggerRead]:
@@ -262,6 +266,12 @@ class SchedulerAdminService:
         :data:`KindFilter` / :data:`StatusFilter` literals); this
         method accepts the raw string so a future widening doesn't
         require lock-step changes.
+
+        Optional *work_ref* narrows to triggers carrying that exact
+        change-ticket reference (work_ref I3-T3 #1663) -- the
+        tenant-scoped exact-match driven by
+        ``scheduled_trigger_tenant_work_ref_idx``. ``None`` (the
+        default) applies no work_ref filter.
 
         Ordering is ``created_at DESC`` so the operator sees the most
         recent trigger first -- matching the precedent
@@ -282,6 +292,8 @@ class SchedulerAdminService:
                 stmt = stmt.where(ScheduledTrigger.kind == kind)
             if status is not None:
                 stmt = stmt.where(ScheduledTrigger.status == status)
+            if work_ref is not None:
+                stmt = stmt.where(ScheduledTrigger.work_ref == work_ref)
             result = await session.execute(stmt)
             rows = list(result.scalars().all())
             return [_row_to_read(r) for r in rows]

--- a/backend/tests/test_scheduler.py
+++ b/backend/tests/test_scheduler.py
@@ -738,6 +738,44 @@ async def test_dispatched_run_inherits_trigger_work_ref() -> None:
 
 
 @pytest.mark.asyncio
+async def test_dispatched_run_ignores_ambient_work_ref_when_trigger_has_none() -> None:
+    """A no-work_ref trigger lands ``NULL`` even with an ambient ref bound.
+
+    Determinism contract for the dispatch seam: the dispatched run's
+    ``work_ref`` is exactly the firing trigger's value (or ``None``), never
+    whatever ``work_ref_var`` happened to be bound to in the surrounding
+    context. ``run_scheduled`` binds the ContextVar UNCONDITIONALLY -- here
+    to ``None`` -- so a pre-existing ambient ref cannot bleed into
+    ``_create_run_row`` / ``agent_run.work_ref``. Before the unconditional
+    bind (conditional ``set(...) if cleaned_work_ref``), a None trigger ref
+    left the ambient binding in place and the dispatched run would have
+    inherited it.
+    """
+    agent_id = await _seed_tenant_and_agent()
+    base = datetime(2026, 5, 25, 12, 0, 0, tzinfo=UTC)
+    # Trigger has NO work_ref.
+    trigger = await _create_cron(agent_definition_id=agent_id, base=base)
+    await _force_due(trigger.id, datetime(2026, 1, 1, tzinfo=UTC))
+
+    # Bind an ambient ref in the surrounding context that, absent the
+    # unconditional bind, would bleed into the dispatched run.
+    ambient_token = work_ref_var.set("gh:evoila/meho#9999")
+    try:
+        fires = await run_one_tick(invoker=_make_invoker())
+        assert fires == 1
+        # The dispatch reset() restored the ambient binding it found, rather
+        # than leaving its own None binding in place.
+        assert work_ref_var.get() == "gh:evoila/meho#9999"
+    finally:
+        work_ref_var.reset(ambient_token)
+
+    runs = await _wait_for_agent_runs(1, trigger=AgentRunTrigger.SCHEDULED)
+    assert len(runs) == 1
+    # The ambient ref did NOT bleed in -- the run lands NULL work_ref.
+    assert runs[0].work_ref is None
+
+
+@pytest.mark.asyncio
 async def test_dispatched_run_audit_rows_inherit_trigger_work_ref(
     _reset_connector_state: None,
     _stub_embedding_service: AsyncMock,

--- a/backend/tests/test_scheduler.py
+++ b/backend/tests/test_scheduler.py
@@ -42,11 +42,18 @@ import uuid
 from collections.abc import Iterator
 from datetime import UTC, datetime, timedelta
 from types import ModuleType
+from typing import Any
 from unittest.mock import AsyncMock
 
 import pytest
 import structlog
-from pydantic_ai.messages import ModelMessage, ModelResponse, TextPart
+from pydantic_ai.messages import (
+    ModelMessage,
+    ModelRequest,
+    ModelResponse,
+    TextPart,
+    ToolCallPart,
+)
 from pydantic_ai.models.function import AgentInfo, FunctionModel
 from sqlalchemy import select
 
@@ -59,17 +66,34 @@ from meho_backplane.agent.run import (
 from meho_backplane.agents.schemas import AgentDefinitionCreate, AgentModelTier
 from meho_backplane.agents.service import AgentDefinitionService
 from meho_backplane.auth.operator import Operator, TenantRole
+from meho_backplane.connectors.base import Connector
+from meho_backplane.connectors.registry import (
+    clear_registry,
+    register_connector_v2,
+)
+from meho_backplane.connectors.schemas import (
+    FingerprintResult,
+    OperationResult,
+    ProbeResult,
+)
 from meho_backplane.db.engine import get_sessionmaker
 from meho_backplane.db.models import (
     AgentPrincipal,
     AgentRun,
     AgentRunStatus,
     AgentRunTrigger,
+    AuditLog,
     ScheduledTrigger,
     ScheduledTriggerKind,
     ScheduledTriggerStatus,
     Tenant,
 )
+from meho_backplane.operations import (
+    register_typed_operation,
+    reset_dispatcher_caches,
+)
+from meho_backplane.operations._audit import work_ref_var
+from meho_backplane.retrieval.embedding import EMBEDDING_DIMENSION
 from meho_backplane.scheduler import start_scheduler, stop_scheduler
 from meho_backplane.scheduler.cron import (
     InvalidCronExpressionError,
@@ -143,6 +167,87 @@ def _stub_autonomous_auth(monkeypatch: pytest.MonkeyPatch) -> Iterator[None]:
     yield
 
 
+@pytest.fixture
+def _reset_connector_state() -> Iterator[None]:
+    """Clear the connector registry + dispatcher caches around a test.
+
+    Only the work_ref audit-inheritance test seeds a typed operation, so
+    this fixture is opt-in (not autouse) to keep the rest of the module's
+    fires off the dispatcher's global registry entirely.
+    """
+    clear_registry()
+    reset_dispatcher_caches()
+    yield
+    clear_registry()
+    reset_dispatcher_caches()
+
+
+@pytest.fixture
+def _stub_embedding_service() -> AsyncMock:
+    """A stub embedding service returning a fixed-dimension vector.
+
+    ``register_typed_operation`` embeds the op's ``when_to_use`` text; the
+    stub keeps that off a real model so the op-seeding stays hermetic.
+    """
+    service = AsyncMock()
+    service.encode_one.return_value = [0.1] * EMBEDDING_DIMENSION
+    service.encode.return_value = [[0.1] * EMBEDDING_DIMENSION]
+    service.dimension = EMBEDDING_DIMENSION
+    return service
+
+
+class _NoOpVaultConnector(Connector):
+    """Connector class registered so resolver/dispatch lookups succeed."""
+
+    product = "vault"
+    version = "1.x"
+    impl_id = "vault"
+
+    async def fingerprint(self, target: Any, operator: Any = None) -> FingerprintResult:  # type: ignore[override]
+        raise NotImplementedError
+
+    async def probe(self, target: Any) -> ProbeResult:  # type: ignore[override]
+        raise NotImplementedError
+
+    async def execute(  # type: ignore[override]
+        self,
+        target: Any,
+        op_id: str,
+        params: dict[str, Any],
+    ) -> OperationResult:
+        raise NotImplementedError
+
+
+async def _echo_handler(
+    operator: Operator,
+    target: Any,
+    params: dict[str, Any],
+) -> dict[str, Any]:
+    """Typed handler echoing its params — proves the dispatch path runs."""
+    return {"echo": params, "operator_sub": operator.sub}
+
+
+async def _seed_echo_op(stub_embedding_service: AsyncMock) -> None:
+    """Register the ``vault.kv.read`` typed op the agent tool will dispatch.
+
+    The op emits a per-tool-call ``audit_log`` row when the agent calls
+    it, which is the row the work_ref-inheritance assertion checks.
+    """
+    register_connector_v2(product="vault", version="", impl_id="", cls=_NoOpVaultConnector)
+    await register_typed_operation(
+        product="vault",
+        version="1.x",
+        impl_id="vault",
+        op_id="vault.kv.read",
+        handler=_echo_handler,
+        summary="Read a secret.",
+        description="reads.",
+        parameter_schema={"type": "object"},
+        when_to_use=None,
+        embedding_service=stub_embedding_service,
+    )
+
+
 def _final_text(text: str) -> FunctionModel:
     """A deterministic model that answers immediately with *text*."""
 
@@ -150,6 +255,46 @@ def _final_text(text: str) -> FunctionModel:
         return ModelResponse(parts=[TextPart(text)])
 
     return FunctionModel(fn)
+
+
+def _call_op_then_text(text: str) -> FunctionModel:
+    """A model that calls ``call_operation`` once, then answers with *text*.
+
+    The single tool call drives a per-tool-call ``audit_log`` row so the
+    dispatched run's audit trail is non-empty — the row whose ``work_ref``
+    the inheritance assertion checks.
+    """
+
+    def fn(messages: list[ModelMessage], info: AgentInfo) -> ModelResponse:
+        has_return = any(
+            getattr(part, "part_kind", "") == "tool-return"
+            for message in messages
+            if isinstance(message, ModelRequest)
+            for part in message.parts
+        )
+        if not has_return:
+            return ModelResponse(
+                parts=[
+                    ToolCallPart(
+                        "call_operation",
+                        {
+                            "connector_id": "vault-1.x",
+                            "op_id": "vault.kv.read",
+                            "params": {"path": "secret/foo"},
+                        },
+                    )
+                ]
+            )
+        return ModelResponse(parts=[TextPart(text)])
+
+    return FunctionModel(fn)
+
+
+def _make_tool_calling_invoker() -> AgentInvoker:
+    """An invoker whose model makes one audited ``call_operation`` tool call."""
+    return AgentInvoker(
+        runtime=PydanticAgentRun(model_factory=lambda: _call_op_then_text("done")),
+    )
 
 
 def _make_invoker() -> AgentInvoker:
@@ -180,7 +325,11 @@ def _make_no_call_invoker() -> AgentInvoker:
     )
 
 
-async def _seed_tenant_and_agent(name: str = "reporter") -> uuid.UUID:
+async def _seed_tenant_and_agent(
+    name: str = "reporter",
+    *,
+    toolset: dict[str, Any] | None = None,
+) -> uuid.UUID:
     """Insert one Tenant + AgentPrincipal + enabled AgentDefinition; return def id.
 
     The ``AgentPrincipal`` seed exists to satisfy
@@ -231,7 +380,7 @@ async def _seed_tenant_and_agent(name: str = "reporter") -> uuid.UUID:
             identity_ref=f"agent:{name}",
             model_tier=AgentModelTier.STANDARD,
             system_prompt="You report status.",
-            toolset={},
+            toolset=toolset or {},
             turn_budget=2,
             enabled=True,
         ),
@@ -244,6 +393,7 @@ async def _create_cron(
     agent_definition_id: uuid.UUID,
     cron_expr: str = "*/5 * * * *",
     base: datetime,
+    work_ref: str | None = None,
 ) -> ScheduledTrigger:
     sessionmaker = get_sessionmaker()
     async with sessionmaker() as session:
@@ -256,6 +406,7 @@ async def _create_cron(
             identity_sub="op-scheduler",
             created_by_sub="seed-admin",
             base=base,
+            work_ref=work_ref,
         )
         await session.commit()
         return row
@@ -265,6 +416,7 @@ async def _create_one_off(
     *,
     agent_definition_id: uuid.UUID,
     run_at: datetime,
+    work_ref: str | None = None,
 ) -> ScheduledTrigger:
     sessionmaker = get_sessionmaker()
     async with sessionmaker() as session:
@@ -276,6 +428,7 @@ async def _create_one_off(
             inputs={"prompt": "one-shot"},
             identity_sub="op-scheduler",
             created_by_sub="seed-admin",
+            work_ref=work_ref,
         )
         await session.commit()
         return row
@@ -382,6 +535,35 @@ async def _wait_for_agent_runs(
     pytest.fail(f"expected {expected} agent_run rows, found {len(rows)}")
 
 
+async def _wait_for_run_audit_rows(
+    run_id: uuid.UUID,
+    *,
+    expected: int,
+    timeout: float = 3.0,
+) -> list[AuditLog]:
+    """Poll for *expected* ``audit_log`` rows correlated to *run_id*.
+
+    Audit rows are written from the background loop task (which finalises
+    after :func:`run_one_tick` returns), so the assertion polls rather
+    than reading once. Correlation is via ``agent_session_id`` -- the
+    lineage key every per-tool-call audit row the run produces shares
+    with the ``agent_run.id``.
+    """
+    deadline = asyncio.get_event_loop().time() + timeout
+    sessionmaker = get_sessionmaker()
+    while asyncio.get_event_loop().time() < deadline:
+        async with sessionmaker() as session:
+            rows = list(
+                (await session.execute(select(AuditLog).where(AuditLog.agent_session_id == run_id)))
+                .scalars()
+                .all()
+            )
+            if len(rows) >= expected:
+                return rows
+        await asyncio.sleep(0.05)
+    pytest.fail(f"expected {expected} audit_log rows for run {run_id}, found {len(rows)}")
+
+
 # ---------------------------------------------------------------------------
 # Cron arithmetic
 # ---------------------------------------------------------------------------
@@ -486,6 +668,110 @@ async def test_cron_trigger_fires_when_due_and_advances() -> None:
     assert next_fire is not None
     assert next_fire > datetime(2026, 1, 1, tzinfo=UTC)
     assert advanced.last_fired_at is not None
+
+
+# ---------------------------------------------------------------------------
+# work_ref I3-T3 (#1663): trigger.work_ref + dispatch-seam inheritance
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.asyncio
+async def test_create_cron_trigger_persists_work_ref() -> None:
+    """A trigger created with ``work_ref`` writes a row whose work_ref matches.
+
+    Acceptance criterion 1: creating a trigger with
+    ``work_ref="gh:evoila/meho#13"`` persists that exact ref on the
+    ``scheduled_trigger`` row.
+    """
+    agent_id = await _seed_tenant_and_agent()
+    base = datetime(2026, 5, 25, 12, 0, 0, tzinfo=UTC)
+    trigger = await _create_cron(
+        agent_definition_id=agent_id,
+        base=base,
+        work_ref="gh:evoila/meho#13",
+    )
+    persisted = await _get_trigger(trigger.id)
+    assert persisted.work_ref == "gh:evoila/meho#13"
+
+
+@pytest.mark.asyncio
+async def test_create_trigger_without_work_ref_leaves_it_null() -> None:
+    """A trigger created without ``work_ref`` lands ``NULL`` (set-at-create-only)."""
+    agent_id = await _seed_tenant_and_agent()
+    base = datetime(2026, 5, 25, 12, 0, 0, tzinfo=UTC)
+    trigger = await _create_cron(agent_definition_id=agent_id, base=base)
+    persisted = await _get_trigger(trigger.id)
+    assert persisted.work_ref is None
+
+
+@pytest.mark.asyncio
+async def test_dispatched_run_inherits_trigger_work_ref() -> None:
+    """A fired trigger's dispatched run inherits the trigger's ``work_ref``.
+
+    Acceptance criterion 2 (the severed seam): a cron trigger carrying a
+    ``work_ref`` fires through the real :func:`run_one_tick` loop; the
+    dispatched ``agent_run`` row lands the trigger's ref, proving the
+    inheritance flows through the widened ``_PreparedInvocation`` ->
+    ``run_scheduled`` -> ``work_ref_var`` -> ``_create_run_row`` seam.
+    Before #1663 the dispatch carried only name + inputs and a dispatched
+    run could not inherit the trigger's ref.
+    """
+    work_ref = "gh:evoila/meho#13"
+    agent_id = await _seed_tenant_and_agent()
+    base = datetime(2026, 5, 25, 12, 0, 0, tzinfo=UTC)
+    trigger = await _create_cron(
+        agent_definition_id=agent_id,
+        base=base,
+        work_ref=work_ref,
+    )
+    await _force_due(trigger.id, datetime(2026, 1, 1, tzinfo=UTC))
+
+    fires = await run_one_tick(invoker=_make_invoker())
+    assert fires == 1
+
+    runs = await _wait_for_agent_runs(1, trigger=AgentRunTrigger.SCHEDULED)
+    assert len(runs) == 1
+    # The dispatched run carries the firing trigger's work_ref.
+    assert runs[0].work_ref == work_ref
+    # The binding does not leak past the dispatch (the loop reset the var).
+    assert work_ref_var.get() is None
+
+
+@pytest.mark.asyncio
+async def test_dispatched_run_audit_rows_inherit_trigger_work_ref(
+    _reset_connector_state: None,
+    _stub_embedding_service: AsyncMock,
+) -> None:
+    """A fired trigger's dispatched-run audit rows carry the trigger's ``work_ref``.
+
+    Acceptance criterion 2, end-to-end through the audit trail: the
+    dispatched run makes one audited ``call_operation`` tool call; the
+    resulting ``audit_log`` row (correlated by the run's
+    ``agent_session_id``) carries the firing trigger's ``work_ref``,
+    inherited via the ``work_ref_var`` ContextVar the dispatch seam binds
+    (snapshotted into the background loop task at ``create_task`` time).
+    """
+    work_ref = "gh:evoila/meho#13"
+    await _seed_echo_op(_stub_embedding_service)
+    agent_id = await _seed_tenant_and_agent(toolset={"meta_tools": ["call_operation"]})
+    base = datetime(2026, 5, 25, 12, 0, 0, tzinfo=UTC)
+    trigger = await _create_cron(
+        agent_definition_id=agent_id,
+        base=base,
+        work_ref=work_ref,
+    )
+    await _force_due(trigger.id, datetime(2026, 1, 1, tzinfo=UTC))
+
+    fires = await run_one_tick(invoker=_make_tool_calling_invoker())
+    assert fires == 1
+
+    runs = await _wait_for_agent_runs(1, trigger=AgentRunTrigger.SCHEDULED)
+    assert len(runs) == 1
+    run_id = runs[0].id
+    # The dispatched run's tool-call audit rows inherit the trigger's ref.
+    audit_rows = await _wait_for_run_audit_rows(run_id, expected=1)
+    assert audit_rows, "expected at least one audit_log row for the dispatched run"
+    assert all(row.work_ref == work_ref for row in audit_rows)
 
 
 # ---------------------------------------------------------------------------

--- a/backend/tests/test_scheduler_admin.py
+++ b/backend/tests/test_scheduler_admin.py
@@ -390,6 +390,58 @@ async def test_service_list_filters_kind_and_status() -> None:
 
 
 @pytest.mark.asyncio
+async def test_service_create_persists_work_ref() -> None:
+    """The create path threads ``work_ref`` from the payload onto the row."""
+    def_id = await _seed_agent_definition(tenant_id=_TENANT_A, name="ref-bot")
+    service = SchedulerAdminService()
+    entry = await service.create(
+        tenant_id=_TENANT_A,
+        created_by_sub="op-admin",
+        payload=ScheduledTriggerCreate(
+            kind=ScheduledTriggerKind.CRON,
+            agent_definition_id=def_id,
+            cron_expr="*/5 * * * *",
+            work_ref="gh:evoila/meho#13",
+        ),
+    )
+    assert entry.work_ref == "gh:evoila/meho#13"
+
+
+@pytest.mark.asyncio
+async def test_service_list_filters_work_ref() -> None:
+    """``list_(work_ref=...)`` narrows to triggers carrying that exact ref."""
+    def_id = await _seed_agent_definition(tenant_id=_TENANT_A, name="ref-filter")
+    service = SchedulerAdminService()
+    tagged = await service.create(
+        tenant_id=_TENANT_A,
+        created_by_sub="op-admin",
+        payload=ScheduledTriggerCreate(
+            kind=ScheduledTriggerKind.CRON,
+            agent_definition_id=def_id,
+            cron_expr="*/5 * * * *",
+            work_ref="gh:evoila/meho#13",
+        ),
+    )
+    untagged = await service.create(
+        tenant_id=_TENANT_A,
+        created_by_sub="op-admin",
+        payload=ScheduledTriggerCreate(
+            kind=ScheduledTriggerKind.ONE_OFF,
+            agent_definition_id=def_id,
+            fire_at=datetime.now(UTC) + timedelta(hours=1),
+        ),
+    )
+    matched = await service.list_(_TENANT_A, work_ref="gh:evoila/meho#13")
+    assert [t.id for t in matched] == [tagged.id]
+    # A non-matching ref filters everything out.
+    none_match = await service.list_(_TENANT_A, work_ref="gh:evoila/meho#99")
+    assert none_match == []
+    # No filter still returns both.
+    all_rows = await service.list_(_TENANT_A)
+    assert {t.id for t in all_rows} == {tagged.id, untagged.id}
+
+
+@pytest.mark.asyncio
 async def test_service_cancel_active_trigger() -> None:
     def_id = await _seed_agent_definition(tenant_id=_TENANT_A, name="cancellable")
     service = SchedulerAdminService()
@@ -984,6 +1036,7 @@ async def test_durability_trigger_survives_scheduler_restart(
         agent_client_id="dummy",
         agent_client_secret=SecretStr("dummy"),
         inputs_str="",
+        work_ref=None,
     )
 
     async def _stub_prepare(row: ScheduledTrigger) -> Any:

--- a/backend/tests/test_secret_leak_checks.py
+++ b/backend/tests/test_secret_leak_checks.py
@@ -725,6 +725,7 @@ def _raise_dispatch_through_scheduler_log(buf: io.StringIO, exc: Exception) -> N
         # The canary lives only inside the SecretStr from here on.
         agent_client_secret=SecretStr(_AGENT_SECRET_CANARY),
         inputs_str="ping",
+        work_ref=None,
     )
     row = SimpleNamespace(id="11111111-1111-1111-1111-111111111111", kind="cron")
     log = structlog.get_logger("meho_backplane.scheduler.loop")

--- a/cli/api/openapi.json
+++ b/cli/api/openapi.json
@@ -6521,7 +6521,7 @@
           "scheduler"
         ],
         "summary": "List Triggers",
-        "description": "List scheduled triggers for the operator's tenant, newest-first.\n\nTenant scoping: callers are scoped to ``operator.tenant_id``; a\n``tenant_filter`` naming a *different* tenant returns 403\n``cross_tenant_requires_platform_admin`` unless the caller holds the\n``platform_admin`` cross-tenant capability. Passing one's own tenant\nid (or omitting the filter) is always allowed.",
+        "description": "List scheduled triggers for the operator's tenant, newest-first.\n\nTenant scoping: callers are scoped to ``operator.tenant_id``; a\n``tenant_filter`` naming a *different* tenant returns 403\n``cross_tenant_requires_platform_admin`` unless the caller holds the\n``platform_admin`` cross-tenant capability. Passing one's own tenant\nid (or omitting the filter) is always allowed.\n\n``work_ref`` (optional, work_ref I3-T3 #1663) narrows to triggers\ncarrying that exact change-ticket reference -- the tenant-scoped\nexact-match driven by ``scheduled_trigger_tenant_work_ref_idx``.",
         "operationId": "list_triggers_api_v1_scheduler_triggers_get",
         "parameters": [
           {
@@ -6576,6 +6576,16 @@
               "type": "string",
               "nullable": true,
               "title": "Status"
+            }
+          },
+          {
+            "name": "work_ref",
+            "in": "query",
+            "required": false,
+            "schema": {
+              "type": "string",
+              "nullable": true,
+              "title": "Work Ref"
             }
           },
           {
@@ -15555,6 +15565,12 @@
             "format": "uuid",
             "nullable": true,
             "title": "Tenant Id"
+          },
+          "work_ref": {
+            "type": "string",
+            "maxLength": 256,
+            "nullable": true,
+            "title": "Work Ref"
           }
         },
         "additionalProperties": false,
@@ -15564,7 +15580,7 @@
           "agent_definition_id"
         ],
         "title": "ScheduledTriggerCreate",
-        "description": "Request body for ``POST /api/v1/scheduler/triggers``.\n\nDiscriminated by *kind*: exactly one of ``cron_expr`` / ``fire_at``\n/ ``event_filter`` must be set, matching the DB-side\n``ck_scheduled_trigger_kind_fields`` invariant. The\n:meth:`_validate_discriminated_union` validator enforces this at\nthe wire so a malformed body surfaces as 422 rather than as a\nflush-time :class:`IntegrityError`.\n\n*agent_definition_id* is the existing-definition reference -- the\nrepository's FK check rejects an orphan id with 422 at insert; no\nvalidation is duplicated here.\n\n*identity_sub* is the OIDC ``sub`` the scheduler impersonates when\nfiring the trigger (distinct from *created_by_sub* which the\nboundary derives from the operator). Defaulted to\n``\"__scheduler__\"`` to match the migration-time backstop the\nORM-level default sets, so a minimal create body still validates.\n\n*inputs* is optional and unvalidated here **by design**. Whether a\ntrigger needs a user prompt depends on the referenced agent\ndefinition, which this pure wire-shape validator does not (and must\nnot) load -- the definition FK is checked one layer down in the\nservice. A no-inputs trigger is therefore *accepted* at create and the\nno-usable-prompt case is handled at fire time: the scheduled-run seam\nfinalises the run ``failed`` with a typed\n:data:`~meho_backplane.agent.run.SCHEDULED_RUN_NO_INPUT_CLASS` error\nrather than letting it reach the provider as an empty-``messages`` 400\n(#1505). This keeps a definition that legitimately needs no user turn\nfrom being over-rejected at create while still surfacing the doomed\nno-prompt fire as a typed, greppable failure.\n\n*in_flight_policy* defaults to ``fail_into_audit`` per the consumer\ndoc; operators wanting at-least-once semantics opt into ``resume``.\n\n*tenant_id* (optional) lets a tenant-admin caller create triggers in\nanother tenant for cross-tenant admin operations; ``operator`` role\ncallers leave it ``None`` and the boundary pins it to the JWT's\ntenant id. The boundary enforces the RBAC -- this schema only\ncarries the field."
+        "description": "Request body for ``POST /api/v1/scheduler/triggers``.\n\nDiscriminated by *kind*: exactly one of ``cron_expr`` / ``fire_at``\n/ ``event_filter`` must be set, matching the DB-side\n``ck_scheduled_trigger_kind_fields`` invariant. The\n:meth:`_validate_discriminated_union` validator enforces this at\nthe wire so a malformed body surfaces as 422 rather than as a\nflush-time :class:`IntegrityError`.\n\n*agent_definition_id* is the existing-definition reference -- the\nrepository's FK check rejects an orphan id with 422 at insert; no\nvalidation is duplicated here.\n\n*identity_sub* is the OIDC ``sub`` the scheduler impersonates when\nfiring the trigger (distinct from *created_by_sub* which the\nboundary derives from the operator). Defaulted to\n``\"__scheduler__\"`` to match the migration-time backstop the\nORM-level default sets, so a minimal create body still validates.\n\n*inputs* is optional and unvalidated here **by design**. Whether a\ntrigger needs a user prompt depends on the referenced agent\ndefinition, which this pure wire-shape validator does not (and must\nnot) load -- the definition FK is checked one layer down in the\nservice. A no-inputs trigger is therefore *accepted* at create and the\nno-usable-prompt case is handled at fire time: the scheduled-run seam\nfinalises the run ``failed`` with a typed\n:data:`~meho_backplane.agent.run.SCHEDULED_RUN_NO_INPUT_CLASS` error\nrather than letting it reach the provider as an empty-``messages`` 400\n(#1505). This keeps a definition that legitimately needs no user turn\nfrom being over-rejected at create while still surfacing the doomed\nno-prompt fire as a typed, greppable failure.\n\n*in_flight_policy* defaults to ``fail_into_audit`` per the consumer\ndoc; operators wanting at-least-once semantics opt into ``resume``.\n\n*tenant_id* (optional) lets a tenant-admin caller create triggers in\nanother tenant for cross-tenant admin operations; ``operator`` role\ncallers leave it ``None`` and the boundary pins it to the JWT's\ntenant id. The boundary enforces the RBAC -- this schema only\ncarries the field.\n\n*work_ref* (optional, work_ref I3-T3 #1663) is the opaque external\nchange-ticket reference the trigger -- and every run it dispatches --\nworks under. Pinned on the trigger row at create time and inherited\nby each dispatched run's ``agent_run.work_ref`` and audit rows via\nthe shared ``work_ref_var`` ContextVar. Set-at-create-only: triggers\nhave no UPDATE path. Omit when the trigger carries no change ticket."
       },
       "ScheduledTriggerInFlightPolicy": {
         "type": "string",
@@ -15675,6 +15691,11 @@
             "type": "string",
             "title": "Created By Sub"
           },
+          "work_ref": {
+            "type": "string",
+            "nullable": true,
+            "title": "Work Ref"
+          },
           "created_at": {
             "type": "string",
             "format": "date-time",
@@ -15703,6 +15724,7 @@
           "inputs",
           "identity_sub",
           "created_by_sub",
+          "work_ref",
           "created_at",
           "updated_at"
         ],

--- a/cli/internal/api/client.gen.go
+++ b/cli/internal/api/client.gen.go
@@ -3713,6 +3713,13 @@ type RunbookTemplateListResponse struct {
 // callers leave it “None“ and the boundary pins it to the JWT's
 // tenant id. The boundary enforces the RBAC -- this schema only
 // carries the field.
+//
+// *work_ref* (optional, work_ref I3-T3 #1663) is the opaque external
+// change-ticket reference the trigger -- and every run it dispatches --
+// works under. Pinned on the trigger row at create time and inherited
+// by each dispatched run's “agent_run.work_ref“ and audit rows via
+// the shared “work_ref_var“ ContextVar. Set-at-create-only: triggers
+// have no UPDATE path. Omit when the trigger carries no change ticket.
 type ScheduledTriggerCreate struct {
 	AgentDefinitionId openapi_types.UUID      `json:"agent_definition_id"`
 	CronExpr          *string                 `json:"cron_expr"`
@@ -3777,6 +3784,7 @@ type ScheduledTriggerCreate struct {
 	Kind     ScheduledTriggerKind `json:"kind"`
 	TenantId *openapi_types.UUID  `json:"tenant_id"`
 	Timezone *string              `json:"timezone,omitempty"`
+	WorkRef  *string              `json:"work_ref"`
 }
 
 // ScheduledTriggerInFlightPolicy Closed policy of what happens to a fired run that gets killed mid-flight.
@@ -3943,6 +3951,7 @@ type ScheduledTriggerRead struct {
 	TenantId  openapi_types.UUID     `json:"tenant_id"`
 	Timezone  string                 `json:"timezone"`
 	UpdatedAt time.Time              `json:"updated_at"`
+	WorkRef   *string                `json:"work_ref"`
 }
 
 // ScheduledTriggerStatus Closed lifecycle status of a :class:`ScheduledTrigger`.
@@ -5724,6 +5733,7 @@ type ListTriggersApiV1SchedulerTriggersGetParams struct {
 	Offset        *int                                               `form:"offset,omitempty" json:"offset,omitempty"`
 	Kind          *ListTriggersApiV1SchedulerTriggersGetParamsKind   `form:"kind,omitempty" json:"kind,omitempty"`
 	Status        *ListTriggersApiV1SchedulerTriggersGetParamsStatus `form:"status,omitempty" json:"status,omitempty"`
+	WorkRef       *string                                            `form:"work_ref,omitempty" json:"work_ref,omitempty"`
 	TenantFilter  *openapi_types.UUID                                `form:"tenant_filter,omitempty" json:"tenant_filter,omitempty"`
 	Authorization *string                                            `json:"authorization,omitempty"`
 }
@@ -16222,6 +16232,22 @@ func NewListTriggersApiV1SchedulerTriggersGetRequest(server string, params *List
 		if params.Status != nil {
 
 			if queryFrag, err := runtime.StyleParamWithLocation("form", true, "status", runtime.ParamLocationQuery, *params.Status); err != nil {
+				return nil, err
+			} else if parsed, err := url.ParseQuery(queryFrag); err != nil {
+				return nil, err
+			} else {
+				for k, v := range parsed {
+					for _, v2 := range v {
+						queryValues.Add(k, v2)
+					}
+				}
+			}
+
+		}
+
+		if params.WorkRef != nil {
+
+			if queryFrag, err := runtime.StyleParamWithLocation("form", true, "work_ref", runtime.ParamLocationQuery, *params.WorkRef); err != nil {
 				return nil, err
 			} else if parsed, err := url.ParseQuery(queryFrag); err != nil {
 				return nil, err

--- a/cli/internal/cmd/scheduler/create.go
+++ b/cli/internal/cmd/scheduler/create.go
@@ -38,6 +38,7 @@ func newCreateCmd() *cobra.Command {
 		identitySub       string
 		inFlightPolicy    string
 		tenant            string
+		workRef           string
 		jsonOut           bool
 		backplaneOverride string
 	)
@@ -59,6 +60,9 @@ func newCreateCmd() *cobra.Command {
 			"the default scheduler identity. --in-flight-policy is one of " +
 			"fail_into_audit|resume (default fail_into_audit). --tenant " +
 			"targets another tenant (tenant_admin can act cross-tenant). " +
+			"--work-ref pins an external change-ticket reference (e.g. " +
+			"gh:evoila/meho#13) on the trigger; every run it dispatches " +
+			"inherits it on the run row and its audit trail. " +
 			"\n\nAn unknown --agent-definition returns 422 " +
 			"agent_definition_not_found; an invalid cron expression " +
 			"or timezone returns 422 invalid_arguments.",
@@ -77,6 +81,7 @@ func newCreateCmd() *cobra.Command {
 				IdentitySub:       identitySub,
 				InFlightPolicy:    inFlightPolicy,
 				Tenant:            tenant,
+				WorkRef:           workRef,
 				JSONOut:           jsonOut,
 				BackplaneOverride: backplaneOverride,
 			})
@@ -102,6 +107,8 @@ func newCreateCmd() *cobra.Command {
 		"killed-mid-flight policy: fail_into_audit | resume (default fail_into_audit)")
 	cmd.Flags().StringVar(&tenant, "tenant", "",
 		"target tenant UUID (tenant_admin cross-tenant create)")
+	cmd.Flags().StringVar(&workRef, "work-ref", "",
+		"external change-ticket reference inherited by every dispatched run (e.g. gh:evoila/meho#13)")
 	cmd.Flags().BoolVar(&jsonOut, "json", false,
 		"emit raw Trigger JSON instead of the human summary")
 	cmd.Flags().StringVar(&backplaneOverride, "backplane", "",
@@ -122,6 +129,7 @@ type createOptions struct {
 	IdentitySub       string
 	InFlightPolicy    string
 	Tenant            string
+	WorkRef           string
 	JSONOut           bool
 	BackplaneOverride string
 }
@@ -318,6 +326,10 @@ func buildCreateBody(
 	}
 	if tenantID != nil {
 		body.TenantId = tenantID
+	}
+	if opts.WorkRef != "" {
+		wr := opts.WorkRef
+		body.WorkRef = &wr
 	}
 	return body
 }

--- a/cli/internal/cmd/scheduler/list.go
+++ b/cli/internal/cmd/scheduler/list.go
@@ -29,6 +29,7 @@ func newListCmd() *cobra.Command {
 	var (
 		kind              string
 		status            string
+		workRef           string
 		tenant            string
 		limit             int
 		offset            int
@@ -41,7 +42,9 @@ func newListCmd() *cobra.Command {
 		Long: "list calls GET /api/v1/scheduler/triggers and renders " +
 			"the triggers in the operator's tenant, newest-first. " +
 			"--kind narrows to cron|one_off|event; --status narrows to " +
-			"active|paused|cancelled|fired. --tenant is a tenant_admin-" +
+			"active|paused|cancelled|fired. --work-ref narrows to triggers " +
+			"carrying that exact change-ticket reference (e.g. " +
+			"gh:evoila/meho#13). --tenant is a tenant_admin-" +
 			"only filter that targets another tenant; operator role " +
 			"calling with --tenant lands as 403 insufficient_role. " +
 			"--limit caps the page size (1..500, server default 100). " +
@@ -54,6 +57,7 @@ func newListCmd() *cobra.Command {
 			return runList(cmd, listOptions{
 				Kind:              kind,
 				Status:            status,
+				WorkRef:           workRef,
 				Tenant:            tenant,
 				Limit:             limit,
 				Offset:            offset,
@@ -66,6 +70,8 @@ func newListCmd() *cobra.Command {
 		"filter by trigger kind: cron | one_off | event")
 	cmd.Flags().StringVar(&status, "status", "",
 		"filter by trigger status: active | paused | cancelled | fired")
+	cmd.Flags().StringVar(&workRef, "work-ref", "",
+		"filter by external change-ticket reference (exact match, e.g. gh:evoila/meho#13)")
 	cmd.Flags().StringVar(&tenant, "tenant", "",
 		"target tenant UUID (tenant_admin only; operator role is locked to its own tenant)")
 	cmd.Flags().IntVar(&limit, "limit", 0,
@@ -82,6 +88,7 @@ func newListCmd() *cobra.Command {
 type listOptions struct {
 	Kind              string
 	Status            string
+	WorkRef           string
 	Tenant            string
 	Limit             int
 	Offset            int
@@ -178,6 +185,10 @@ func listQueryParams(opts listOptions, tenantFilter *openapi_types.UUID) *api.Li
 		s := api.ListTriggersApiV1SchedulerTriggersGetParamsStatus(opts.Status)
 		params.Status = &s
 	}
+	if opts.WorkRef != "" {
+		wr := opts.WorkRef
+		params.WorkRef = &wr
+	}
 	if tenantFilter != nil {
 		params.TenantFilter = tenantFilter
 	}
@@ -229,8 +240,8 @@ func printListTable(w io.Writer, r *api.ScheduledTriggerListResponse) {
 		fmt.Fprintln(w, "no scheduled triggers in this tenant")
 		return
 	}
-	fmt.Fprintf(w, "%-36s %-8s %-10s %-30s %s\n",
-		"ID", "KIND", "STATUS", "SCHEDULE", "NEXT_FIRE_AT")
+	fmt.Fprintf(w, "%-36s %-8s %-10s %-30s %-24s %s\n",
+		"ID", "KIND", "STATUS", "SCHEDULE", "NEXT_FIRE_AT", "WORK_REF")
 	for _, t := range r.Triggers {
 		schedule := ""
 		switch string(t.Kind) {
@@ -252,7 +263,11 @@ func printListTable(w io.Writer, r *api.ScheduledTriggerListResponse) {
 		if t.NextFireAt != nil {
 			next = formatTime(t.NextFireAt)
 		}
-		fmt.Fprintf(w, "%-36s %-8s %-10s %-30s %s\n",
-			t.Id.String(), string(t.Kind), string(t.Status), schedule, next)
+		workRef := "-"
+		if t.WorkRef != nil && *t.WorkRef != "" {
+			workRef = *t.WorkRef
+		}
+		fmt.Fprintf(w, "%-36s %-8s %-10s %-30s %-24s %s\n",
+			t.Id.String(), string(t.Kind), string(t.Status), schedule, next, workRef)
 	}
 }

--- a/cli/internal/cmd/scheduler/scheduler.go
+++ b/cli/internal/cmd/scheduler/scheduler.go
@@ -498,6 +498,9 @@ func printTriggerSummary(w io.Writer, t *api.ScheduledTriggerRead) {
 		fmt.Fprintf(w, "%-22s %s\n", "last_fired_at:", formatTime(t.LastFiredAt))
 	}
 	fmt.Fprintf(w, "%-22s %s\n", "identity_sub:", t.IdentitySub)
+	if t.WorkRef != nil && *t.WorkRef != "" {
+		fmt.Fprintf(w, "%-22s %s\n", "work_ref:", *t.WorkRef)
+	}
 	fmt.Fprintf(w, "%-22s %s\n", "created_by:", t.CreatedBySub)
 	fmt.Fprintf(w, "%-22s %s\n", "created_at:", formatTime(&t.CreatedAt))
 }

--- a/docs/codebase/scheduler.md
+++ b/docs/codebase/scheduler.md
@@ -49,6 +49,12 @@ DBOS rebase swaps only the loop module.
     run's user-prompt input string — `"prompt"` key when present, else the
     dict as JSON, else `""` for a `NULL`/no-`inputs` trigger). A `""`
     result is refused typed at fire time, see the no-input guard below.
+  - `work_ref` (nullable Text, migration `0043`, #1663) — the opaque
+    external change-ticket reference (`"gh:evoila/meho#13"`, a Jira key,
+    a CR id) the trigger works under. Set at create time (triggers have
+    no UPDATE path); inherited end-to-end by every dispatched run — see
+    "work_ref inheritance" under Dispatch. Indexed
+    `(tenant_id, work_ref)` for the list `--work-ref` exact-match filter.
 - `ScheduledTriggerKind`, `ScheduledTriggerStatus` — closed StrEnums
   kept in lock-step with the DB-layer `CHECK (... IN (...))` constraints
   via migrations `0020` (T1 substrate) and `0025` (T2 dispatcher
@@ -202,6 +208,29 @@ at-most-once contract honest for invoke-time failures (where it was
 always the right behaviour) without dropping work for the
 precondition cases (where it was always recoverable by the
 operator).
+
+### work_ref inheritance (#1663)
+
+A scheduled trigger's `work_ref` is inherited by every run it
+dispatches, end-to-end:
+
+1. `_prepare_invocation` copies `row.work_ref` onto
+   `_PreparedInvocation.work_ref`.
+2. `_dispatch_invocation` forwards it as the `work_ref=` argument to
+   `AgentInvoker.run_scheduled`.
+3. `run_scheduled` binds the value onto the shared `work_ref_var`
+   ContextVar for the duration of the call. `_create_run_row` reads
+   that ContextVar at run-create time, so the dispatched
+   `agent_run.work_ref` lands the trigger's ref; the background loop
+   task snapshots the ContextVar at `asyncio.create_task` time (in
+   `_launch_run`), so every per-tool-call `audit_log` row the run
+   produces inherits it too.
+
+This is the trigger → dispatched-run seam the work_ref Initiative
+(#1654) widened: before #1663 the dispatch carried only name + inputs
+and `agent_run` had no trigger linkage, so a dispatched run could not
+inherit the trigger's ref. `work_ref` is set-at-create-only and binds
+nothing when the trigger carries no ticket (the run lands `NULL`).
 
 ### Cron fire path (`_fire_cron`)
 


### PR DESCRIPTION
## Summary
- Add `scheduled_trigger.work_ref` (migration `0043`, `down_revision="0042"`) — nullable Text + `(tenant_id, work_ref)` index, mirroring the audit `0039` / agent_run `0041` / runbook `0042` soft-column discipline. Set-at-create-only (triggers have no UPDATE path).
- **Widen the severed dispatch seam (the crux):** `_PreparedInvocation` now carries the trigger's `work_ref`; `_dispatch_invocation` forwards it into `run_scheduled`, which binds the shared `work_ref_var` ContextVar around the run. `_create_run_row` reads it at create time (→ `agent_run.work_ref`) and the background loop task snapshots it at `create_task` time (→ the run's `audit_log` rows), so the dispatched run **and its audit trail** inherit the trigger's ref end-to-end. Reuses I3-T2's `create_run(work_ref=)` + `work_ref_var` — nothing reinvented.
- Thread `work_ref` through `create_{cron,one_off,event}_trigger` + `SchedulerAdminService.create` + the request/response schemas.
- List surfacing: `--work-ref` exact-match filter on the service `list_`, REST `GET /api/v1/scheduler/triggers`, MCP `meho.scheduler.list`, and `meho scheduler list`; `--work-ref` on create across REST/MCP/CLI; surfaced in the CLI list table + create summary.
- CLI client + OpenAPI snapshot regenerated (`make snapshot-openapi && make generate`).

## Test plan
- [x] `ruff check` / `ruff format --check` — clean
- [x] `mypy src/` — clean (471 files)
- [x] `python3 .claude/hooks/code-quality.py --diff` — 0 blockers (one justified `code-quality-allow: function-size` on `_dispatch_invocation`, already at the 100-line limit pre-#1663; the body is an irreducible error-contract dispatcher)
- [x] Full backend `pytest` — **7434 passed, 416 skipped** (known-pre-existing `test_route_audit_row_count_matches_total_searches` deselected per task)
- [x] **Acceptance 1** — `test_create_cron_trigger_persists_work_ref`: trigger created with `work_ref="gh:evoila/meho#13"` writes a row whose `work_ref` matches
- [x] **Acceptance 2 (the seam)** — `test_dispatched_run_inherits_trigger_work_ref` (dispatched `agent_run.work_ref` via the real `run_one_tick` loop) **and** `test_dispatched_run_audit_rows_inherit_trigger_work_ref` (the run's tool-call `audit_log` rows carry the trigger's ref)
- [x] **Acceptance 3** — `test_service_list_filters_work_ref` + CLI `--work-ref` wired
- [x] CLI: `go build ./...`, `go test ./...`, `golangci-lint run ./...` (v2.12.2, CI-pinned) — all green
- [x] Integration doubles swept — no `tests/integration/` double constructs `ScheduledTrigger` / `_PreparedInvocation` / `run_scheduled` positionally; unit-test `_PreparedInvocation(...)` constructions updated with `work_ref=None`

## Out of scope
- Trigger UPDATE path (none exists — `work_ref` is set-at-create-only)
- runbook-run / agent-run column definitions (I3-T1 #1661 / I3-T2 #1662, already merged; this task consumes I3-T2's plumbing)

<!-- auto-implement-issue: fresh, iteration 1 -->

Closes #1663


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **New Features**
  * Scheduled triggers now support an optional `work_ref` field to track external change-ticket references. Set it via `meho scheduler create --work-ref` or the API; the reference automatically inherits to dispatched runs and audit logs for end-to-end traceability.
  * `meho scheduler list` now supports filtering triggers by `--work-ref` for exact-match lookups.
  * API endpoints updated to accept and return `work_ref` on trigger operations.

* **Documentation**
  * Added scheduler documentation covering `work_ref` inheritance and usage.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->