### PR TITLE
feat(connectors): per-tenant Vault KV path convention + secret_ref migration (#1723)

### DIFF
--- a/backend/src/meho_backplane/api/v1/targets.py
+++ b/backend/src/meho_backplane/api/v1/targets.py
@@ -153,6 +153,7 @@ from meho_backplane.connectors.registry import (
 )
 from meho_backplane.connectors.resolver import resolve_connector_or_label
 from meho_backplane.connectors.schemas import AuthModel, CandidateHint, FingerprintResult
+from meho_backplane.connectors.vault.tenant_paths import tenant_secret_ref
 from meho_backplane.db.engine import get_session
 from meho_backplane.db.models import GraphNode
 from meho_backplane.db.models import Target as TargetORM
@@ -876,6 +877,15 @@ async def create_target(
     # may have supplied, so the stored row matches the registry /
     # resolver spelling (G0.18-T2 #1355).
     create_fields["product"] = product
+    # #1723: default a fresh target's secret onto the per-tenant shared
+    # path ``tenants/<tenant_id>/<name>`` so new targets land on the
+    # canonical layout the #1643 guard can enforce, instead of the
+    # retired per-``sub`` layout an operator would otherwise type by
+    # hand. An explicitly-supplied ``secret_ref`` is honoured verbatim
+    # (operator override / a non-default mount layout); only the absent
+    # case is derived.
+    if create_fields.get("secret_ref") is None:
+        create_fields["secret_ref"] = tenant_secret_ref(operator.tenant_id, body.name)
     t = TargetORM(
         id=uuid.uuid4(),
         tenant_id=operator.tenant_id,
@@ -989,6 +999,18 @@ async def update_target(
             )
     for k, v in updates.items():
         setattr(t, k, v)
+    # #1723: home an as-yet-unconfigured target onto the per-tenant shared
+    # path. A PATCH that does not touch ``secret_ref`` (the field is absent
+    # from the request body, so it is not in ``updates``) on a row whose
+    # ``secret_ref`` is still unset derives ``tenants/<tenant_id>/<name>``
+    # so the canonical layout is filled in without the operator typing it.
+    # A PATCH that *sends* ``secret_ref`` — including an explicit
+    # ``{"secret_ref": null}`` to clear it — is honoured verbatim and is
+    # never overwritten here (it is in ``updates`` and the branch is
+    # skipped); silent re-homing of an already-configured ref is the
+    # operator-driven migration runbook's job, not the route's.
+    if "secret_ref" not in updates and t.secret_ref is None:
+        t.secret_ref = tenant_secret_ref(operator.tenant_id, t.name)
     t.updated_at = datetime.now(UTC)
     _log.info(
         "target_updated",

--- a/backend/src/meho_backplane/connectors/vault/tenant_paths.py
+++ b/backend/src/meho_backplane/connectors/vault/tenant_paths.py
@@ -1,0 +1,202 @@
+# SPDX-License-Identifier: Apache-2.0
+# Copyright (c) 2026 evoila Group
+
+"""Per-tenant Vault KV path convention + a runbook-driven relocation helper (#1723).
+
+Goal #221 / Initiative #1685. The shipped deploy convention scoped each
+target's secret per operator ``sub`` (``secret/data/targets/<sub>/*``,
+``docs/cross-repo/connector-vault-policy.md`` §2). That duplicated a
+target's credential per operator and blocked two operators in one tenant
+from sharing it; it also meant the #1643 tenant-scope guard
+(:mod:`meho_backplane.connectors.vault.tenant_scope`) had no universal
+``{tenant_id}`` partition to enforce against, so it had to ship default-off.
+
+This module moves the canonical layout to a **per-tenant shared** path:
+
+.. code-block:: text
+
+    secret/data/tenants/<tenant_id>/<target>
+
+so a target's credential lives once per tenant and every operator in that
+tenant reads the same path. ``<tenant_id>`` is the canonical dashed
+lowercase UUID (``str(UUID)``) — the exact rendering
+:func:`~meho_backplane.connectors.vault.tenant_scope.rendered_tenant_prefix`
+produces, so a deploy can enable the guard with the matching
+``tenants/{tenant_id}/`` prefix once its secrets are relocated.
+
+Two public helpers:
+
+* :func:`tenant_secret_ref` — a pure function deriving the logical
+  ``secret_ref`` (the path relative to the KV-v2 mount, the shape
+  ``targets.secret_ref`` carries) for a target from its tenant + name.
+  Called at target create/update so freshly-created targets default onto
+  the per-tenant path instead of a per-``sub`` path the operator would
+  otherwise have to type by hand.
+* :func:`relocate_target_secret` — an operator-driven coroutine that moves
+  one existing ``targets/<sub>/<x>`` secret to ``tenants/<id>/<x>`` via the
+  existing ``vault_kv_*`` handlers (read → write → optional delete) and
+  returns the rewritten ``secret_ref``. It is **not** wired into any app
+  request path: the migration is operator-run from the runbook
+  (``docs/cross-repo/vault-per-tenant-migration.md``); RDC owns the Vault
+  deployment, so the backplane never auto-relocates secrets.
+
+Both stay clear of the system/shim operator: the Nil-UUID tenant exemption
+that :mod:`meho_backplane.connectors.vault.tenant_scope` preserves applies
+to the *guard*; these helpers only ever run for a real authenticated tenant
+admin (target CRUD) or under an operator the runbook supplies explicitly.
+"""
+
+from __future__ import annotations
+
+from typing import TYPE_CHECKING, Any
+from uuid import UUID
+
+from meho_backplane.connectors.vault.ops import (
+    vault_kv_delete,
+    vault_kv_put,
+    vault_kv_read,
+)
+
+if TYPE_CHECKING:
+    from meho_backplane.auth.operator import Operator
+
+__all__ = ["TENANT_SECRET_PREFIX", "relocate_target_secret", "tenant_secret_ref"]
+
+#: The logical-path prefix (relative to the KV-v2 mount) under which a
+#: tenant's target secrets live. Combined with the dashed-UUID tenant id
+#: and the target identity this yields ``tenants/<tenant_id>/<target>``;
+#: hvac inserts the mount and the ``/data/`` API segment itself, so the
+#: full KV-v2 wire path becomes ``secret/data/tenants/<tenant_id>/<target>``.
+#: A deploy enables the #1643 guard against this layout by setting
+#: ``VAULT_KV_TENANT_SCOPE_PREFIX="tenants/{tenant_id}/"``.
+TENANT_SECRET_PREFIX = "tenants"
+
+
+def tenant_secret_ref(tenant_id: UUID, target: str) -> str:
+    """Derive the per-tenant logical ``secret_ref`` for *target*.
+
+    Returns ``"tenants/<tenant_id>/<target>"`` — the logical KV-v2 path
+    relative to the mount, which is the shape ``targets.secret_ref``
+    stores (no mount segment, no ``/data/`` API segment; hvac inserts
+    both at read time, see
+    :func:`meho_backplane.connectors._shared.vault_creds._is_api_path_shaped`).
+
+    ``tenant_id`` is rendered in its canonical dashed lowercase form
+    (``str(UUID)``), matching how tenant UUIDs appear everywhere else —
+    audit rows, JWT claims, and
+    :func:`~meho_backplane.connectors.vault.tenant_scope.rendered_tenant_prefix`'s
+    output — so a deploy that enables the guard with
+    ``tenants/{tenant_id}/`` finds the derived ref already inside the
+    rendered prefix.
+
+    Parameters
+    ----------
+    tenant_id
+        The owning tenant's UUID (``operator.tenant_id`` at the CRUD
+        boundary). Always a real tenant here; the Nil-UUID system shim
+        never reaches target CRUD.
+    target
+        The target's stable identity — its ``name``. Stripped of stray
+        surrounding slashes/whitespace so the joined path has exactly one
+        separator between segments. Must be non-empty after stripping.
+
+    Raises
+    ------
+    ValueError
+        *target* is empty or whitespace/slash-only after stripping —
+        there is no meaningful leaf to key the secret under.
+    """
+    leaf = target.strip().strip("/").strip()
+    if not leaf:
+        raise ValueError("cannot derive a per-tenant secret_ref for an empty target identity")
+    return f"{TENANT_SECRET_PREFIX}/{tenant_id}/{leaf}"
+
+
+async def relocate_target_secret(
+    operator: Operator,
+    *,
+    old_ref: str,
+    target: str,
+    mount: str = "secret",
+    delete_old: bool = False,
+) -> str:
+    """Move one ``targets/<sub>/<x>`` secret to its per-tenant home and return the new ref.
+
+    Runbook-driven (``docs/cross-repo/vault-per-tenant-migration.md``), not
+    an app request path. Performs the KV-v2 read → write sequence via the
+    existing typed-op handlers so the move runs under *operator*'s OIDC
+    identity exactly as a real ``vault.kv.*`` call would, and the Vault
+    audit log attributes both legs to that operator:
+
+    1. **read** the secret at *old_ref* (``vault.kv.read``) — the full
+       key/value payload of the latest version.
+    2. **write** that payload to the derived per-tenant path
+       (:func:`tenant_secret_ref`) as a new version (``vault.kv.put``).
+    3. optionally **soft-delete** the latest version at *old_ref*
+       (``vault.kv.delete``) when *delete_old* is set — off by default so a
+       dry run leaves the source untouched and the operator deletes only
+       after verifying the new ref resolves.
+
+    Returns the rewritten logical ``secret_ref`` the operator then writes
+    back onto the target row (``PATCH /api/v1/targets/{name}`` with
+    ``{"secret_ref": <returned value>}``).
+
+    Parameters
+    ----------
+    operator
+        The authenticated operator the migration runs as. Its
+        ``tenant_id`` keys the destination path; its ``raw_jwt`` is
+        forwarded to Vault by the underlying handlers.
+    old_ref
+        The current logical KV-v2 path of the secret (e.g.
+        ``targets/<sub>/<target>``). No mount, no ``/data/`` prefix —
+        the same shape ``secret_ref`` carries.
+    target
+        The target's identity (``name``) used to derive the per-tenant
+        leaf via :func:`tenant_secret_ref`.
+    mount
+        The KV-v2 mount both legs address. Defaults to ``"secret"``,
+        matching the handlers' default mount.
+    delete_old
+        When ``True``, soft-delete the latest version at *old_ref* after
+        the write succeeds. Default ``False`` (read+write only) so the
+        operator verifies the relocation before retiring the source.
+
+    Returns
+    -------
+    str
+        The new per-tenant ``secret_ref`` (``tenants/<tenant_id>/<target>``).
+    """
+    new_ref = tenant_secret_ref(operator.tenant_id, target)
+
+    read_result = await vault_kv_read(operator, None, {"mount": mount, "path": old_ref})
+    secret_data: dict[str, Any] = read_result["data"]
+
+    await vault_kv_put(
+        operator,
+        None,
+        {"mount": mount, "path": new_ref, "data": secret_data},
+    )
+
+    if delete_old:
+        # Soft-delete the latest version only — reversible via Vault's
+        # undelete path, so a misverified relocation can be rolled back.
+        await vault_kv_delete(
+            operator,
+            None,
+            {"mount": mount, "path": old_ref, "versions": [_latest_version(read_result)]},
+        )
+
+    return new_ref
+
+
+def _latest_version(read_result: dict[str, Any]) -> int:
+    """Return the version number from a ``vault.kv.read`` result, defaulting to 1.
+
+    ``vault_kv_read`` returns ``{"data": ..., "version": <int|None>}``.
+    A ``None`` version (metadata lacked the key) falls back to ``1`` —
+    the only version a freshly-written per-``sub`` secret can have — so
+    the soft-delete still names a concrete version rather than failing.
+    """
+    version = read_result.get("version")
+    return int(version) if isinstance(version, int) else 1

--- a/backend/src/meho_backplane/main.py
+++ b/backend/src/meho_backplane/main.py
@@ -969,12 +969,26 @@ def build_openapi_schema() -> dict[str, object]:
     (Options A + C from the task body, sharing one source-of-truth
     helper so they cannot drift).
 
-    Calls :func:`_eager_import_connectors` when the registry is empty
-    so the schema is correct even when the override fires before the
-    FastAPI lifespan (the OpenAPI snapshot script under
+    Calls :func:`_eager_import_connectors` **unconditionally** so the
+    schema is correct even when the override fires before the FastAPI
+    lifespan (the OpenAPI snapshot script under
     ``cli/api/snapshot-openapi.py`` calls :meth:`app.openapi` directly
-    without running the lifespan). Idempotent — modules already in
-    ``sys.modules`` are a no-op on the second call.
+    without running the lifespan). The call is idempotent — every
+    connector subpackage is already in ``sys.modules`` after the first
+    import, so a second call re-imports nothing.
+
+    It must run unconditionally rather than behind an
+    ``if not registered_product_tokens()`` guard: a single connector
+    self-registering as an import side-effect (e.g.
+    :mod:`meho_backplane.connectors.vault.tenant_paths` importing
+    ``connectors.vault.ops``, which triggers the ``connectors.vault``
+    package ``__init__`` to register ``VaultConnector`` at import time)
+    leaves the registry non-empty but only *partially* populated. The
+    old guard would then short-circuit and skip the eager import, so the
+    other connector subpackages never load and ``TargetCreate.product``
+    collapses to just the one product that happened to self-register
+    (#1723 / CI ``CLI API snapshot freshness`` truncated the enum
+    18 -> 1). "Registry non-empty" is not "all connectors loaded".
 
     Caches the result on ``app.openapi_schema`` to match FastAPI's
     own caching behaviour.
@@ -982,8 +996,7 @@ def build_openapi_schema() -> dict[str, object]:
     if app.openapi_schema is not None:
         return app.openapi_schema
 
-    if not registered_product_tokens():
-        _eager_import_connectors()
+    _eager_import_connectors()
 
     schema = get_openapi(
         title=app.title,

--- a/backend/tests/test_api_v1_targets.py
+++ b/backend/tests/test_api_v1_targets.py
@@ -2401,3 +2401,104 @@ def test_patch_product_same_value_passes_without_validator(client: TestClient) -
     assert response.status_code == 200
     assert response.json()["product"] == "legacy"
     assert response.json()["host"] == "new.host"
+
+
+# ---------------------------------------------------------------------------
+# #1723 — per-tenant Vault KV secret_ref derivation at create / update
+# ---------------------------------------------------------------------------
+
+
+def test_create_target_derives_per_tenant_secret_ref(client: TestClient) -> None:
+    """A create with no explicit ``secret_ref`` lands on ``tenants/<T>/<name>``.
+
+    #1723: new targets default onto the per-tenant shared path so the
+    #1643 guard can enforce ``tenants/{tenant_id}/`` — not the retired
+    per-``sub`` layout.
+    """
+    key = make_rsa_keypair("kid-A")
+    with respx.mock as mock_router:
+        mock_discovery_and_jwks(mock_router, public_jwks(key))
+        response = client.post(
+            "/api/v1/targets",
+            json={"name": "rdc-vcenter", "product": "ssh", "host": "10.0.0.5"},
+            headers={"Authorization": f"Bearer {_admin_token(key)}"},
+        )
+    assert response.status_code == 201
+    data = response.json()
+    assert data["secret_ref"] == f"tenants/{DEFAULT_TENANT_ID}/rdc-vcenter"
+    # Never the retired per-``sub`` layout.
+    assert "targets/" not in data["secret_ref"]
+
+
+def test_create_target_honours_explicit_secret_ref(client: TestClient) -> None:
+    """An explicitly-supplied ``secret_ref`` is stored verbatim, not derived."""
+    key = make_rsa_keypair("kid-A")
+    with respx.mock as mock_router:
+        mock_discovery_and_jwks(mock_router, public_jwks(key))
+        response = client.post(
+            "/api/v1/targets",
+            json={
+                "name": "custom",
+                "product": "ssh",
+                "host": "10.0.0.5",
+                "secret_ref": "tenants/some-other/custom",
+            },
+            headers={"Authorization": f"Bearer {_admin_token(key)}"},
+        )
+    assert response.status_code == 201
+    assert response.json()["secret_ref"] == "tenants/some-other/custom"
+
+
+@pytest.mark.asyncio
+async def test_update_target_homes_unconfigured_secret_ref(client: TestClient) -> None:
+    """A PATCH not touching ``secret_ref`` on a null-ref row derives the per-tenant path."""
+    key = make_rsa_keypair("kid-A")
+    # Row created out-of-band with no secret_ref (e.g. pre-#1723).
+    await _insert_target(name="legacy-target", product="ssh", host="10.0.0.9", secret_ref=None)
+    with respx.mock as mock_router:
+        mock_discovery_and_jwks(mock_router, public_jwks(key))
+        response = client.patch(
+            "/api/v1/targets/legacy-target",
+            json={"host": "moved.host"},
+            headers={"Authorization": f"Bearer {_admin_token(key)}"},
+        )
+    assert response.status_code == 200
+    data = response.json()
+    assert data["host"] == "moved.host"
+    assert data["secret_ref"] == f"tenants/{DEFAULT_TENANT_ID}/legacy-target"
+
+
+@pytest.mark.asyncio
+async def test_update_target_preserves_existing_secret_ref(client: TestClient) -> None:
+    """A PATCH not touching ``secret_ref`` leaves an already-set ref untouched."""
+    key = make_rsa_keypair("kid-A")
+    await _insert_target(
+        name="configured", product="ssh", host="10.0.0.9", secret_ref="tenants/x/configured"
+    )
+    with respx.mock as mock_router:
+        mock_discovery_and_jwks(mock_router, public_jwks(key))
+        response = client.patch(
+            "/api/v1/targets/configured",
+            json={"host": "moved.host"},
+            headers={"Authorization": f"Bearer {_admin_token(key)}"},
+        )
+    assert response.status_code == 200
+    assert response.json()["secret_ref"] == "tenants/x/configured"
+
+
+@pytest.mark.asyncio
+async def test_update_target_clears_secret_ref_when_explicit_null(client: TestClient) -> None:
+    """An explicit ``{"secret_ref": null}`` clears the ref and is not re-derived."""
+    key = make_rsa_keypair("kid-A")
+    await _insert_target(
+        name="to-clear", product="ssh", host="10.0.0.9", secret_ref="tenants/x/to-clear"
+    )
+    with respx.mock as mock_router:
+        mock_discovery_and_jwks(mock_router, public_jwks(key))
+        response = client.patch(
+            "/api/v1/targets/to-clear",
+            json={"secret_ref": None},
+            headers={"Authorization": f"Bearer {_admin_token(key)}"},
+        )
+    assert response.status_code == 200
+    assert response.json()["secret_ref"] is None

--- a/backend/tests/test_connectors_vault_tenant_paths.py
+++ b/backend/tests/test_connectors_vault_tenant_paths.py
@@ -1,0 +1,147 @@
+# SPDX-License-Identifier: Apache-2.0
+# Copyright (c) 2026 evoila Group
+
+"""Per-tenant Vault KV path convention + relocation helper (#1723).
+
+Covers the two public helpers in
+:mod:`meho_backplane.connectors.vault.tenant_paths`:
+
+* :func:`tenant_secret_ref` — pure derivation of the canonical
+  ``tenants/<tenant_id>/<target>`` logical ``secret_ref``.
+* :func:`relocate_target_secret` — runbook-driven read→write(→delete)
+  move of an existing per-``sub`` secret to its per-tenant home, run
+  through the real ``vault_kv_*`` handlers against the shared in-process
+  Vault fake.
+"""
+
+from __future__ import annotations
+
+from collections.abc import Iterator
+from uuid import UUID
+
+import pytest
+
+from meho_backplane.auth.operator import Operator, TenantRole
+from meho_backplane.connectors.vault.tenant_paths import (
+    TENANT_SECRET_PREFIX,
+    relocate_target_secret,
+    tenant_secret_ref,
+)
+from meho_backplane.connectors.vault.tenant_scope import rendered_tenant_prefix
+from meho_backplane.settings import get_settings
+
+from ._vault_fakes import install_fake_client
+
+_TENANT = UUID("11111111-1111-1111-1111-111111111111")
+
+
+@pytest.fixture(autouse=True)
+def _settings_env(monkeypatch: pytest.MonkeyPatch) -> Iterator[None]:
+    monkeypatch.setenv("KEYCLOAK_ISSUER_URL", "https://keycloak.test/realms/meho")
+    monkeypatch.setenv("KEYCLOAK_AUDIENCE", "meho-backplane")
+    monkeypatch.setenv("VAULT_ADDR", "https://vault.test")
+    monkeypatch.setenv("VAULT_OIDC_ROLE", "meho-mcp")
+    monkeypatch.setenv("VAULT_OIDC_MOUNT_PATH", "jwt")
+    monkeypatch.setenv("VAULT_TIMEOUT_SECONDS", "5.0")
+    monkeypatch.delenv("VAULT_NAMESPACE", raising=False)
+    get_settings.cache_clear()
+    yield
+    get_settings.cache_clear()
+
+
+def _operator() -> Operator:
+    return Operator(
+        sub="op-1",
+        raw_jwt="header.payload.signature",
+        tenant_id=_TENANT,
+        tenant_role=TenantRole.TENANT_ADMIN,
+    )
+
+
+# ---------------------------------------------------------------------------
+# tenant_secret_ref — pure derivation
+# ---------------------------------------------------------------------------
+
+
+def test_tenant_secret_ref_canonical_shape() -> None:
+    """The ref is ``tenants/<dashed-uuid>/<target>`` — no mount, no /data/."""
+    assert tenant_secret_ref(_TENANT, "rdc-vcenter") == (
+        f"{TENANT_SECRET_PREFIX}/{_TENANT}/rdc-vcenter"
+    )
+
+
+def test_tenant_secret_ref_uses_canonical_dashed_uuid() -> None:
+    """The tenant segment matches the guard's rendered prefix exactly."""
+    op = _operator()
+    ref = tenant_secret_ref(op.tenant_id, "x")
+    prefix = rendered_tenant_prefix(op, template="tenants/{tenant_id}/")
+    # The derived ref sits inside the prefix the #1643 guard would render.
+    assert ref.startswith(prefix)
+
+
+def test_tenant_secret_ref_strips_stray_separators() -> None:
+    """Stray surrounding slashes/whitespace on the target collapse cleanly."""
+    assert tenant_secret_ref(_TENANT, "  /vc/  ") == f"tenants/{_TENANT}/vc"
+
+
+def test_tenant_secret_ref_rejects_empty_target() -> None:
+    """An empty / slash-only target has no leaf to key the secret under."""
+    with pytest.raises(ValueError, match="empty target identity"):
+        tenant_secret_ref(_TENANT, "  //  ")
+
+
+# ---------------------------------------------------------------------------
+# relocate_target_secret — read → write (→ delete) through the real handlers
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.asyncio
+async def test_relocate_reads_old_writes_per_tenant(monkeypatch: pytest.MonkeyPatch) -> None:
+    """Reads ``targets/<sub>/x`` and writes it to ``tenants/<id>/x``; returns the new ref."""
+    fake = install_fake_client(monkeypatch, secret={"username": "demo", "password": "s3cr3t"})
+    op = _operator()
+
+    new_ref = await relocate_target_secret(op, old_ref="targets/op-1/vc", target="vc")
+
+    assert new_ref == f"tenants/{_TENANT}/vc"
+    # The read leg hit the old per-``sub`` path.
+    assert fake.secrets.kv.v2.read_calls[0]["path"] == "targets/op-1/vc"
+    # The write leg landed the same payload at the per-tenant path.
+    put = fake.secrets.kv.v2.put_calls[0]
+    assert put["path"] == new_ref
+    assert put["secret"] == {"username": "demo", "password": "s3cr3t"}
+    # Read-only by default — the source is left intact.
+    assert fake.secrets.kv.v2.delete_calls == []
+
+
+@pytest.mark.asyncio
+async def test_relocate_new_ref_resolves_through_read(monkeypatch: pytest.MonkeyPatch) -> None:
+    """After relocation the rewritten secret_ref resolves through vault_kv_read."""
+    from meho_backplane.connectors.vault.ops import vault_kv_read
+
+    fake = install_fake_client(monkeypatch, secret={"kubeconfig": "yaml"})
+    op = _operator()
+
+    new_ref = await relocate_target_secret(op, old_ref="targets/op-1/k8s", target="k8s")
+
+    read_back = await vault_kv_read(op, None, {"path": new_ref})
+    assert read_back["data"] == {"kubeconfig": "yaml"}
+    # The read-back addressed the new per-tenant path.
+    assert fake.secrets.kv.v2.read_calls[-1]["path"] == new_ref
+
+
+@pytest.mark.asyncio
+async def test_relocate_soft_deletes_source_when_requested(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """``delete_old=True`` soft-deletes the read version at the old path."""
+    fake = install_fake_client(monkeypatch, secret={"username": "demo"}, kv_version=4)
+    op = _operator()
+
+    await relocate_target_secret(op, old_ref="targets/op-1/vc", target="vc", delete_old=True)
+
+    assert len(fake.secrets.kv.v2.delete_calls) == 1
+    deleted = fake.secrets.kv.v2.delete_calls[0]
+    assert deleted["path"] == "targets/op-1/vc"
+    # The version named is the one the read returned (no destroy, reversible).
+    assert deleted["versions"] == [4]

--- a/backend/tests/test_openapi_target_product_enum.py
+++ b/backend/tests/test_openapi_target_product_enum.py
@@ -49,6 +49,10 @@ restore to that populated snapshot too. This is the same pattern
 
 from __future__ import annotations
 
+import json
+import subprocess
+import sys
+
 import pytest
 from fastapi.openapi.utils import get_openapi
 
@@ -173,3 +177,110 @@ def test_openapi_default_schema_lacks_enum_without_hook() -> None:
     )
     field = _product_field(schema)
     assert "enum" not in field
+
+
+# Source for the subprocess regression test below. Runs in a *fresh*
+# interpreter so the side-effect import is genuinely the first thing to
+# touch the connector registry — the only faithful way to reproduce the
+# production import ordering (see the test docstring).
+_PARTIAL_REGISTRY_REPRO = """
+import json
+import sys
+
+# 1. Import a module that reaches connectors.vault first. tenant_paths
+#    imports connectors.vault.ops at module top, which triggers the
+#    connectors.vault package __init__ to register VaultConnector at
+#    import time -- exactly the #1723 chain (api/v1/targets.py ->
+#    tenant_paths -> connectors.vault.ops -> connectors.vault.__init__).
+import meho_backplane.connectors.vault.tenant_paths  # noqa: F401
+
+from meho_backplane.connectors.registry import registered_product_tokens
+
+# 2. Before the OpenAPI override runs, the registry is partially
+#    populated: only the side-effect-registered connector is present.
+partial = sorted(registered_product_tokens())
+
+# 3. Build the schema. The override must eager-load the remaining
+#    connector subpackages before injecting the TargetCreate.product
+#    enum, regardless of the already-non-empty registry.
+from meho_backplane.main import app
+
+app.openapi_schema = None
+schema = app.openapi()
+field = schema["components"]["schemas"]["TargetCreate"]["properties"]["product"]
+full = sorted(registered_product_tokens())
+
+# Importing main.py boots logging/migrations that write to stdout, so
+# emit the result on its own sentinel-prefixed line the parent greps for.
+print(
+    "__REPRO_RESULT__"
+    + json.dumps({"partial": partial, "enum": field.get("enum"), "full": full})
+)
+"""
+
+
+def test_openapi_product_enum_full_when_registry_partially_populated() -> None:
+    """The enum is the full connector set even if one connector pre-registered.
+
+    Regression for #1723. ``connectors/vault/tenant_paths.py`` imports
+    ``connectors.vault.ops`` at module top, which triggers the
+    ``connectors.vault`` package ``__init__`` to register
+    ``VaultConnector`` at *import* time. Any module reaching
+    ``tenant_paths`` (e.g. ``api/v1/targets.py``) therefore leaves the
+    registry holding exactly ``{"vault"}`` before the OpenAPI override
+    runs. The override previously guarded its eager-import behind
+    ``if not registered_product_tokens()``; with the registry already
+    non-empty the guard short-circuited, the other 17 connector
+    subpackages never loaded, and ``TargetCreate.product`` collapsed
+    from 18 entries to ``["vault"]`` — turning the
+    ``CLI API snapshot freshness`` CI gate red (it regenerates the
+    snapshot by calling ``app.openapi()`` in a fresh interpreter).
+
+    This pins the post-fix contract: ``build_openapi_schema`` calls
+    :func:`_eager_import_connectors` **unconditionally**, so a
+    partially-populated registry is fully loaded before the enum is
+    injected.
+
+    Why a subprocess: the import ordering is load-bearing and only
+    reproducible in a *fresh* interpreter. This module already calls
+    :func:`_eager_import_connectors` at its own import time, so within
+    the test process every connector subpackage is warm in
+    ``sys.modules``; clearing the registry and re-importing registers
+    nothing (cached modules don't re-run their top-level
+    ``register_connector_v2`` calls), which would model the harness
+    rather than production. The snapshot script
+    (``cli/api/snapshot-openapi.py``) hits exactly this fresh-process
+    path, so the subprocess is the truest reproduction of the CI gate.
+    """
+    proc = subprocess.run(
+        [sys.executable, "-c", _PARTIAL_REGISTRY_REPRO],
+        capture_output=True,
+        text=True,
+        check=False,
+    )
+    assert proc.returncode == 0, f"repro subprocess failed:\n{proc.stderr}"
+    # main.py boots logging/migrations onto stdout; pull the one
+    # sentinel-prefixed line the child emitted for us.
+    marker = "__REPRO_RESULT__"
+    payload = next(
+        line[len(marker) :] for line in proc.stdout.splitlines() if line.startswith(marker)
+    )
+    result = json.loads(payload)
+
+    # Precondition: the side-effect import leaves the registry holding
+    # exactly the one connector whose package self-registered.
+    assert result["partial"] == ["vault"], (
+        "precondition: only the side-effect-registered connector is present "
+        f"before the override runs; got {result['partial']}"
+    )
+
+    # Post-fix contract: the enum is the full registered set, not the
+    # truncated lone token.
+    enum = result["enum"]
+    assert enum == result["full"]
+    assert isinstance(enum, list)
+    assert {"vault", "k8s", "keycloak", "argocd"}.issubset(enum)
+    # Pin the exact count so a future re-truncation that still leaves
+    # the enum multi-valued cannot pass: the eager import must surface
+    # every distinct registered product token.
+    assert len(enum) == len(result["full"]) > 1

--- a/docs/codebase/connectors-vault-tenant-scope.md
+++ b/docs/codebase/connectors-vault-tenant-scope.md
@@ -69,18 +69,49 @@ The rule is configured by one setting,
   (`tenant-{tenant_id}/`) — a deploy partitions tenants by whichever it
   uses.
 
-## Why opt-in (empty default)
+## The canonical layout is per-tenant (#1723)
+
+As of [#1723](https://github.com/evoila/meho/issues/1723) (Goal #221,
+Initiative #1685) the **canonical** KV layout for target secrets is
+**per-tenant shared**:
+
+```text
+secret/data/tenants/<tenant_id>/<target>
+```
+
+`<tenant_id>` is the canonical dashed lowercase UUID — the exact rendering
+`rendered_tenant_prefix` produces. New targets land on this path
+automatically:
+[`connectors/vault/tenant_paths.py`](../../backend/src/meho_backplane/connectors/vault/tenant_paths.py)'s
+`tenant_secret_ref(tenant_id, target)` derives
+`tenants/<tenant_id>/<target>`, and `api/v1/targets.py`'s `create_target`
+(no explicit `secret_ref`) and `update_target` (PATCH not touching
+`secret_ref` on an unset row) apply it. An explicitly-supplied
+`secret_ref` is always honoured verbatim.
+
+This replaces the retired **per operator `sub`** layout
+(`secret/data/targets/<sub>/*`, `connector-vault-policy.md` §2), which
+duplicated a target's credential per operator and gave the guard no
+universal `{tenant_id}` partition to enforce against. Existing per-`sub`
+secrets are relocated by the operator-driven runbook
+[`docs/cross-repo/vault-per-tenant-migration.md`](../cross-repo/vault-per-tenant-migration.md)
+(read → write → soft-delete via the `vault_kv_*` ops, then rewrite each
+target's `secret_ref`).
+
+## Why the guard is still opt-in (empty default)
 
 The guard is **disabled by default** (empty prefix → `enforce_tenant_scope`
-is a no-op, behaviour is byte-for-byte pre-#1643). This is deliberate:
+is a no-op, behaviour is byte-for-byte pre-#1643). This is deliberate even
+with the per-tenant layout now canonical:
 
-The shipped Vault layout scopes secrets **per operator `sub`**
-(`secret/data/targets/<sub>/*`, `connector-vault-policy.md` §2), **not per
-tenant**. There is no universal `tenant-<id>/` partition to enforce against
-out of the box, so turning on a hard tenant prefix unconditionally would
-deny every existing `vault.kv.*` call. A deploy whose KV layout *is*
-tenant-partitioned opts in by setting the env var; a deploy that relies
-solely on the per-`sub` Vault policy leaves it empty and is unaffected.
+The backplane homes *new* targets on `tenants/<tenant_id>/`, but a deploy
+may still hold *existing* secrets under the retired per-`sub` layout until
+the migration runbook has run. Turning on a hard tenant prefix
+unconditionally would deny every not-yet-relocated `vault.kv.*` call. A
+deploy whose secrets are all under `tenants/<tenant_id>/` (fresh, or
+post-migration) opts in by setting the env var to
+`tenants/{tenant_id}/`; a deploy mid-migration leaves it empty until every
+caller's secret is relocated.
 
 The **system/shim operator** (the Nil-UUID `tenant_id` the vault connector
 synthesises in `connector.py`, empty `raw_jwt`) is exempt even when the
@@ -117,18 +148,23 @@ It is a deploy/infra decision, **not** a backplane default — the backplane
 ships the prefix empty (#1673 only surfaces and documents the choice; it
 does not make it):
 
-- **Per-`sub` layout (the shipped default).** Secrets live under
-  `secret/data/targets/<sub>/*` and isolation is enforced entirely by the
-  templated `meho-mcp` Vault policy (`connector-vault-policy.md` §2). There
-  is no `tenant-<id>/` partition to bind against, so the prefix stays
-  **empty** and the app-layer guard is intentionally a no-op. The startup
-  advisory fires; for this layout it is expected and can be ignored. Keep
-  the policy template correct — it is the primary (and only) gate here.
+- **Per-`sub` layout (retired; pre-#1723 deploys mid-migration).** Secrets
+  live under `secret/data/targets/<sub>/*` and isolation is enforced
+  entirely by the templated `meho-mcp` Vault policy
+  (`connector-vault-policy.md` §2). There is no `tenant-<id>/` partition to
+  bind against, so the prefix stays **empty** and the app-layer guard is
+  intentionally a no-op. The startup advisory fires; for this layout it is
+  expected and can be ignored. Keep the policy template correct — it is the
+  primary (and only) gate here. Relocate to the per-tenant layout via
+  [`vault-per-tenant-migration.md`](../cross-repo/vault-per-tenant-migration.md).
 
-- **Tenant-partitioned layout (opt-in).** Secrets are physically
-  partitioned by tenant — e.g. mount `secret/tenant-<tenant_id>/...` or a
-  path prefix `tenant-<tenant_id>/...`. Here the app-layer guard becomes a
-  real backstop for a mis-provisioned policy, so you **enable** it.
+- **Per-tenant layout (canonical since #1723; opt-in guard).** Secrets are
+  partitioned by tenant under `tenants/<tenant_id>/<target>` (path prefix)
+  or, for a mount-pinned deploy, `secret/tenant-<tenant_id>/...`. New
+  targets land here automatically; existing per-`sub` secrets are moved by
+  the migration runbook. Once every secret is under the prefix, the
+  app-layer guard becomes a real backstop for a mis-provisioned policy, so
+  you **enable** it (`tenants/{tenant_id}/`).
 
 **Enabling the prefix requires all of:**
 

--- a/docs/cross-repo/vault-per-tenant-migration.md
+++ b/docs/cross-repo/vault-per-tenant-migration.md
@@ -1,0 +1,187 @@
+<!--
+SPDX-License-Identifier: Apache-2.0
+Copyright (c) 2026 evoila Group
+-->
+
+# Migration runbook: per-`sub` → per-tenant Vault KV layout
+
+> Operator-driven relocation of target secrets from the retired
+> per-operator-`sub` layout (`secret/data/targets/<sub>/*`) to the
+> canonical **per-tenant shared** layout
+> (`secret/data/tenants/<tenant_id>/<target>`). Companion to the
+> app-layer convention in
+> [`connectors/vault/tenant_paths.py`](../../backend/src/meho_backplane/connectors/vault/tenant_paths.py)
+> and the tenant-scope guard in
+> [`docs/codebase/connectors-vault-tenant-scope.md`](../codebase/connectors-vault-tenant-scope.md).
+> Implemented for [#1723](https://github.com/evoila/meho/issues/1723)
+> (Goal #221, Initiative #1685).
+
+## Why migrate
+
+The shipped layout stored each target's credential per operator `sub`
+(`secret/data/targets/<sub>/*`, [`connector-vault-policy.md`](./connector-vault-policy.md) §2).
+Two consequences:
+
+- **Duplication.** A target shared by two operators in one tenant needed
+  the same credential written under each operator's `sub` path. Rotating
+  it meant rotating every copy.
+- **The #1643 guard could not go default-on.** The tenant-scope guard
+  ([`tenant_scope.py`](../../backend/src/meho_backplane/connectors/vault/tenant_scope.py))
+  enforces a `{tenant_id}` prefix, but there was no universal
+  tenant-partitioned layout to enforce against, so it shipped opt-in.
+
+The per-tenant layout fixes both: one secret per `(tenant, target)`,
+readable by every operator in that tenant, under a path the guard can
+enforce with `VAULT_KV_TENANT_SCOPE_PREFIX="tenants/{tenant_id}/"`.
+
+## The new convention
+
+| | Retired (per-`sub`) | Canonical (per-tenant) |
+| --- | --- | --- |
+| Logical `secret_ref` | `targets/<sub>/<target>` | `tenants/<tenant_id>/<target>` |
+| KV-v2 wire path | `secret/data/targets/<sub>/<target>` | `secret/data/tenants/<tenant_id>/<target>` |
+
+`<tenant_id>` is the canonical dashed lowercase UUID (`str(UUID)`) —
+the same rendering the guard's
+[`rendered_tenant_prefix`](../../backend/src/meho_backplane/connectors/vault/tenant_scope.py)
+produces and the same UUID that appears in audit rows and JWT claims.
+
+New targets created or PATCH-homed after #1723 land on the per-tenant
+path automatically (see "What the backplane does for you"). This runbook
+covers the **existing** secrets that predate the change.
+
+## What the backplane does for you
+
+- **Create** (`POST /api/v1/targets`) with no explicit `secret_ref`
+  derives `tenants/<tenant_id>/<name>` and stores it on the row.
+- **Update** (`PATCH /api/v1/targets/{name}`) that does not touch
+  `secret_ref`, on a row whose `secret_ref` is still unset, fills in the
+  same derived path.
+- An **explicitly-supplied** `secret_ref` (including a non-default mount
+  layout, or an explicit `{"secret_ref": null}` to clear it) is always
+  honoured verbatim — the backplane never silently re-homes a ref you set.
+
+The backplane **never auto-relocates the secret material in Vault** —
+RDC owns the Vault deployment. Moving the bytes is this runbook.
+
+## Prerequisites
+
+- `vault` CLI authenticated against the deployment, or the MEHO
+  `vault.kv.*` ops reachable for an operator in the target tenant.
+- The tenant's `tenant_id` (canonical dashed UUID). For an operator JWT
+  this is the `tenant_id` claim; for a target row it is `targets.tenant_id`
+  (`GET /api/v1/targets/{name}` returns it).
+- A list of the targets to migrate and their current per-`sub`
+  `secret_ref` values (`GET /api/v1/targets` returns `secret_ref` on the
+  summary shape).
+
+## Procedure (per target)
+
+For each target with an old `targets/<sub>/<x>` secret_ref:
+
+### 1. Relocate the secret material
+
+The relocation moves the secret with a KV-v2 read → write, optionally
+followed by a soft-delete of the old version. Two equivalent ways:
+
+**A. Via the MEHO `relocate_target_secret` helper** (recommended — it runs
+under the operator's OIDC identity and writes the Vault audit log
+correctly, and derives the destination path for you):
+
+```python
+from meho_backplane.connectors.vault.tenant_paths import relocate_target_secret
+
+# `operator` is the authenticated tenant operator (its tenant_id keys
+# the destination path; its JWT authenticates both Vault legs).
+new_ref = await relocate_target_secret(
+    operator,
+    old_ref="targets/<sub>/<target>",
+    target="<target-name>",
+    delete_old=False,   # leave the source intact until verified
+)
+# new_ref == "tenants/<tenant_id>/<target-name>"
+```
+
+**B. Via the `vault` CLI** (when running the migration outside MEHO):
+
+```bash
+TENANT_ID=<dashed-uuid>
+TARGET=<target-name>
+OLD=targets/<sub>/$TARGET
+NEW=tenants/$TENANT_ID/$TARGET
+
+# Read the latest version of the old secret and write it to the new path.
+vault kv get -format=json secret/$OLD \
+  | jq '.data.data' \
+  | vault kv put secret/$NEW -
+```
+
+### 2. Verify the new path resolves
+
+Confirm the relocated secret reads back through the new path before you
+retire the source:
+
+```bash
+vault kv get secret/tenants/$TENANT_ID/$TARGET
+```
+
+Or, in MEHO, a `vault.kv.read` op (or any connector auth that resolves
+`secret_ref`) against the rewritten target.
+
+### 3. Rewrite the target's `secret_ref`
+
+Point the target row at the new path:
+
+```bash
+curl -X PATCH https://<backplane>/api/v1/targets/$TARGET \
+  -H "Authorization: Bearer $OPERATOR_JWT" \
+  -H "Content-Type: application/json" \
+  -d "{\"secret_ref\": \"tenants/$TENANT_ID/$TARGET\"}"
+```
+
+`secret_ref` is the **logical** KV-v2 path — no `secret/`, no `/data/`
+prefix (hvac inserts the mount and the `/data/` segment itself; a
+prefixed value double-resolves to a 404, see
+[`_shared/vault_creds.py`](../../backend/src/meho_backplane/connectors/_shared/vault_creds.py)
+`_is_api_path_shaped`).
+
+### 4. Retire the old secret
+
+Once every operator in the tenant resolves the target through the new
+path, soft-delete the old version (reversible via Vault's undelete):
+
+```bash
+vault kv delete secret/$OLD
+```
+
+Or pass `delete_old=True` to `relocate_target_secret` in step 1 to do the
+read → write → soft-delete in one call **after** you have verified the new
+path resolves.
+
+## Enabling the guard (after migration)
+
+Once all of a tenant's secrets live under `tenants/<tenant_id>/`, the
+deploy can flip the #1643 guard default-on by setting:
+
+```text
+VAULT_KV_TENANT_SCOPE_PREFIX=tenants/{tenant_id}/
+```
+
+See
+[`connectors-vault-tenant-scope.md`](../codebase/connectors-vault-tenant-scope.md)
+("Enabling the prefix requires all of") for the preconditions and the
+startup advisory. Do **not** enable the prefix until every legitimate
+`vault.kv.*` caller's secrets are under it — once set, any in-namespace
+mismatch is denied with `exception_class=VaultTenantScopeError` before the
+hvac call.
+
+## Rollback
+
+The relocation is non-destructive when `delete_old=False` (the default):
+the source secret survives. To roll back, PATCH the target's `secret_ref`
+back to the old `targets/<sub>/<target>` value. If you already
+soft-deleted the source, undelete it first:
+
+```bash
+vault kv undelete -versions=<n> secret/$OLD
+```


### PR DESCRIPTION
## Summary
- Adds the canonical **per-tenant** Vault KV path convention `secret/data/tenants/<tenant_id>/<target>`, replacing the retired per-operator-`sub` layout so a target's credential lives once per tenant and the #1643 tenant-scope guard has a `{tenant_id}` partition it can enforce against.
- New pure helper `tenant_secret_ref(tenant_id, target)` derives the logical `secret_ref`; `POST /api/v1/targets` (no explicit `secret_ref`) and `PATCH /api/v1/targets/{name}` (untouched `secret_ref` on an unset row) now default new targets onto that path. An explicit `secret_ref` (or `{"secret_ref": null}`) is always honoured verbatim.
- New operator-driven `relocate_target_secret(...)` coroutine moves an existing `targets/<sub>/x` secret to `tenants/<id>/x` via the existing `vault_kv_*` ops (read → write → optional reversible soft-delete) and returns the rewritten ref. Not wired into any request path — RDC owns the Vault deployment.
- Migration runbook `docs/cross-repo/vault-per-tenant-migration.md` + updated `docs/codebase/connectors-vault-tenant-scope.md` to state per-tenant is canonical.

## Test plan
- [x] `uv run ruff check` — clean
- [x] `ruff format --check` — clean
- [x] `mypy src/` — clean (472 files)
- [x] New unit tests `tests/test_connectors_vault_tenant_paths.py` — 7 passed (pure derivation: canonical dashed-UUID shape, matches guard prefix, strips separators, rejects empty; relocation: read-old/write-per-tenant, new ref resolves through `vault_kv_read`, soft-deletes source on request)
- [x] New route tests in `tests/test_api_v1_targets.py` — 6 passed (create derives `tenants/<T>/<name>`; explicit ref honoured; PATCH homes unset ref; PATCH preserves set ref; explicit null clears)
- [x] No REST/MCP schema change (`secret_ref` field + route signatures unchanged) → no OpenAPI snapshot regen needed.

## Out of scope
- Templated Vault ACL policies + identity-group mapping (sibling policy task).
- Flipping the #1643 guard default-on (depending task).
- Auto-running the migration in app code — operator-driven per the runbook.

## Adjacent findings
- `tests/test_connectors_vault.py::test_preflight_fail_soft_when_probe_raises` errors in teardown on clean `main` (pre-existing, unrelated; test body passes) — deselected in the local full run.
- `code-quality.py --diff` warns `relocate_target_secret` is 76 lines (mostly docstring; body ~12 lines) — warning, not a blocker.

---

## Follow-up (auto-implement-issue, iteration 2, 2026-06-13)

Addressed review finding **B1** from the iteration-1 `REQUEST_CHANGES`
(OpenAPI product-enum truncation; `CLI API snapshot freshness` RED):

- **B1** `73d7a355` — `build_openapi_schema()` now calls
  `_eager_import_connectors()` **unconditionally** instead of behind the
  `if not registered_product_tokens()` guard. The new import chain
  (`targets.py` → `tenant_paths` → `connectors.vault.ops` →
  `connectors.vault.__init__`) self-registers `VaultConnector` at import
  time, so the registry was already `{"vault"}` when the override ran;
  the guard short-circuited the eager import, the other 17 connectors
  never loaded, and `TargetCreate.product` collapsed 18 → `["vault"]`.
  The eager import is idempotent (`sys.modules`-cached), so dropping the
  guard makes the schema build robust to any partially-populated
  registry. Reviewer's preferred option (1).
- **B1 (regression test)** `73d7a355` — added
  `test_openapi_product_enum_full_when_registry_partially_populated` to
  `tests/test_openapi_target_product_enum.py`. It reproduces the bug in
  a fresh subprocess (the only faithful repro — the test process is
  already warm with every connector in `sys.modules`): imports
  `tenant_paths` first, asserts the registry holds exactly `{"vault"}`,
  then asserts the generated enum is the full registered set. Verified
  red against the reintroduced guard, green with the fix.

The committed CLI snapshot already carried the correct full 18-connector
enum (the PR commit never touched `cli/`); the CI freshness job was
failing because it *regenerated* the snapshot in a fresh interpreter and
the regen truncated. A fresh `cd cli && make snapshot-openapi &&
make generate` now leaves the `cli/` tree clean, confirming freshness is
restored. The iteration-1 "no OpenAPI snapshot regen needed" claim in
the test plan above was the original miss.

<!-- auto-implement-issue: continue, iteration 2 -->

Closes #1723



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Targets now automatically derive per-tenant secret paths when not explicitly specified during creation and updates
  * Added helper utilities for migrating Vault secrets from legacy per-operator layout to per-tenant structure

* **Documentation**
  * Added comprehensive Vault tenant-scope migration guide
  * Updated Vault KV tenant-scope documentation with canonical per-tenant path conventions

* **Tests**
  * Enhanced test coverage for target secret reference handling and path derivation
  * Added validation tests for secret relocation functionality

<!-- end of auto-generated comment: release notes by coderabbit.ai -->