### PR TITLE
feat(connectors): default-on Vault tenant-scope guard (mount-pinned prefix) (#1725)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -285,7 +285,12 @@ connector-related release-notes line.
   silent on the default, firing only when an operator explicitly sets the
   prefix back to empty. The platform's own federation-proof health read
   (`secret/meho/test/federation`, `GET /api/v1/health`) is exempt via a
-  closed allow-list so the default-on guard does not deny it. A deploy still
+  closed allow-list so the default-on guard does not deny it; the exemption
+  is scoped to **read-only** verbs, so a `put`/`patch`/`delete` to that
+  shared platform path under a non-owning operator stays tenant-scoped. A
+  malformed `VAULT_KV_TENANT_SCOPE_PREFIX` (missing the `{tenant_id}`
+  placeholder, unbalanced braces, or an extra placeholder) is now rejected
+  at startup rather than failing at first `vault.kv.*` call. A deploy still
   holding secrets under the retired per-`sub` layout disables the guard with
   `VAULT_KV_TENANT_SCOPE_PREFIX=""` until the migration runbook
   (`docs/cross-repo/vault-per-tenant-migration.md`) has run (#1725)

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -271,6 +271,25 @@ connector-related release-notes line.
   closes the last bare-string arm in the ingest route's typed-exception
   table, completing the #1610 400-family parity (#1624)
 
+### Security
+
+- The #1643 Vault tenant-scope guard is now **default-on**: agent-supplied
+  `vault.kv.*` calls are confined to the calling operator's tenant
+  namespace out of the box, no per-deploy opt-in. The default
+  `VAULT_KV_TENANT_SCOPE_PREFIX` is the **mount-pinned**
+  `secret/tenants/{tenant_id}/` — the mount segment is required because the
+  guard matches a normalised `<mount>/<path>` candidate on the default
+  `secret` KV mount, so a path-only `tenants/{tenant_id}/` would deny every
+  legitimate per-tenant call. Builds on the per-tenant layout (#1723) and
+  templated policies (#1724). The startup advisory inverts accordingly:
+  silent on the default, firing only when an operator explicitly sets the
+  prefix back to empty. The platform's own federation-proof health read
+  (`secret/meho/test/federation`, `GET /api/v1/health`) is exempt via a
+  closed allow-list so the default-on guard does not deny it. A deploy still
+  holding secrets under the retired per-`sub` layout disables the guard with
+  `VAULT_KV_TENANT_SCOPE_PREFIX=""` until the migration runbook
+  (`docs/cross-repo/vault-per-tenant-migration.md`) has run (#1725)
+
 ## [0.14.0] - 2026-06-12
 
 ### Security

--- a/backend/src/meho_backplane/connectors/vault/ops.py
+++ b/backend/src/meho_backplane/connectors/vault/ops.py
@@ -298,8 +298,9 @@ async def vault_kv_read(operator: Operator, target: Any, params: dict[str, Any])
     # Defense-in-depth tenant-scope check (#1643): deny a path outside the
     # operator's tenant namespace BEFORE the hvac call. No-op unless
     # ``vault_kv_tenant_scope_prefix`` is configured. Behind the Vault
-    # ``meho-mcp`` ACL policy, never a replacement for it.
-    enforce_tenant_scope(operator, mount=mount, path=path)
+    # ``meho-mcp`` ACL policy, never a replacement for it. ``read_only``
+    # so the platform-path allow-list (health read) applies.
+    enforce_tenant_scope(operator, mount=mount, path=path, read_only=True)
 
     # vault_client_for_operator is accessed via the module reference so
     # test monkeypatches on vault_module._build_client propagate through
@@ -398,8 +399,8 @@ async def vault_kv_list(operator: Operator, target: Any, params: dict[str, Any])
     mount: str = str(params.get("mount", _DEFAULT_KV_MOUNT)).strip()
     path: str = str(params["path"]).strip()
 
-    # Tenant-scope guard (#1643) — see vault_kv_read.
-    enforce_tenant_scope(operator, mount=mount, path=path)
+    # Tenant-scope guard (#1643) — see vault_kv_read. Read-only op.
+    enforce_tenant_scope(operator, mount=mount, path=path, read_only=True)
 
     async with _auth_vault.vault_client_for_operator(operator) as client:
         list_payload = await asyncio.to_thread(
@@ -505,8 +506,9 @@ async def vault_kv_put(operator: Operator, target: Any, params: dict[str, Any]) 
     secret: dict[str, Any] = params["data"]
     cas = params.get("cas")
 
-    # Tenant-scope guard (#1643) — see vault_kv_read.
-    enforce_tenant_scope(operator, mount=mount, path=path)
+    # Tenant-scope guard (#1643) — see vault_kv_read. Mutating put: the
+    # platform-path allow-list does NOT apply (read-only only, #1725 M1).
+    enforce_tenant_scope(operator, mount=mount, path=path, read_only=False)
 
     async with _auth_vault.vault_client_for_operator(operator) as client:
         write_payload = await asyncio.to_thread(
@@ -668,8 +670,9 @@ async def vault_kv_patch(operator: Operator, target: Any, params: dict[str, Any]
     path: str = str(params["path"]).strip()
     secret: dict[str, Any] = params["data"]
 
-    # Tenant-scope guard (#1643) — see vault_kv_read.
-    enforce_tenant_scope(operator, mount=mount, path=path)
+    # Tenant-scope guard (#1643) — see vault_kv_read. Mutating patch: the
+    # platform-path allow-list does NOT apply (read-only only, #1725 M1).
+    enforce_tenant_scope(operator, mount=mount, path=path, read_only=False)
 
     async with _auth_vault.vault_client_for_operator(operator) as client:
         patch_payload = await asyncio.to_thread(
@@ -745,8 +748,8 @@ async def vault_kv_versions(
     mount: str = str(params.get("mount", _DEFAULT_KV_MOUNT)).strip()
     path: str = str(params["path"]).strip()
 
-    # Tenant-scope guard (#1643) — see vault_kv_read.
-    enforce_tenant_scope(operator, mount=mount, path=path)
+    # Tenant-scope guard (#1643) — see vault_kv_read. Read-only op.
+    enforce_tenant_scope(operator, mount=mount, path=path, read_only=True)
 
     async with _auth_vault.vault_client_for_operator(operator) as client:
         meta_payload = await asyncio.to_thread(
@@ -840,8 +843,9 @@ async def vault_kv_delete(
     path: str = str(params["path"]).strip()
     versions: list[int] = list(params["versions"])
 
-    # Tenant-scope guard (#1643) — see vault_kv_read.
-    enforce_tenant_scope(operator, mount=mount, path=path)
+    # Tenant-scope guard (#1643) — see vault_kv_read. Mutating delete: the
+    # platform-path allow-list does NOT apply (read-only only, #1725 M1).
+    enforce_tenant_scope(operator, mount=mount, path=path, read_only=False)
 
     async with _auth_vault.vault_client_for_operator(operator) as client:
         await asyncio.to_thread(

--- a/backend/src/meho_backplane/connectors/vault/tenant_paths.py
+++ b/backend/src/meho_backplane/connectors/vault/tenant_paths.py
@@ -21,8 +21,11 @@ so a target's credential lives once per tenant and every operator in that
 tenant reads the same path. ``<tenant_id>`` is the canonical dashed
 lowercase UUID (``str(UUID)``) — the exact rendering
 :func:`~meho_backplane.connectors.vault.tenant_scope.rendered_tenant_prefix`
-produces, so a deploy can enable the guard with the matching
-``tenants/{tenant_id}/`` prefix once its secrets are relocated.
+produces. The #1643 guard enforces this layout by default (#1725) with the
+mount-pinned ``secret/tenants/{tenant_id}/`` prefix (the guard matches a
+``<mount>/<path>`` candidate and these secrets sit on the default ``secret``
+mount); a deploy mid-migration disables it with
+``VAULT_KV_TENANT_SCOPE_PREFIX=""`` until its secrets are relocated.
 
 Two public helpers:
 
@@ -67,8 +70,11 @@ __all__ = ["TENANT_SECRET_PREFIX", "relocate_target_secret", "tenant_secret_ref"
 #: and the target identity this yields ``tenants/<tenant_id>/<target>``;
 #: hvac inserts the mount and the ``/data/`` API segment itself, so the
 #: full KV-v2 wire path becomes ``secret/data/tenants/<tenant_id>/<target>``.
-#: A deploy enables the #1643 guard against this layout by setting
-#: ``VAULT_KV_TENANT_SCOPE_PREFIX="tenants/{tenant_id}/"``.
+#: The #1643 guard enforces this layout **by default** (#1725) via the
+#: mount-pinned ``VAULT_KV_TENANT_SCOPE_PREFIX="secret/tenants/{tenant_id}/"``
+#: — the mount segment is required because the guard matches a
+#: ``<mount>/<path>`` candidate and these secrets sit on the default
+#: ``secret`` mount.
 TENANT_SECRET_PREFIX = "tenants"
 
 
@@ -85,9 +91,9 @@ def tenant_secret_ref(tenant_id: UUID, target: str) -> str:
     (``str(UUID)``), matching how tenant UUIDs appear everywhere else —
     audit rows, JWT claims, and
     :func:`~meho_backplane.connectors.vault.tenant_scope.rendered_tenant_prefix`'s
-    output — so a deploy that enables the guard with
-    ``tenants/{tenant_id}/`` finds the derived ref already inside the
-    rendered prefix.
+    output — so the default-on guard
+    (``secret/tenants/{tenant_id}/``) finds the derived ref already inside
+    the rendered prefix.
 
     Parameters
     ----------

--- a/backend/src/meho_backplane/connectors/vault/tenant_scope.py
+++ b/backend/src/meho_backplane/connectors/vault/tenant_scope.py
@@ -19,25 +19,40 @@ It is deliberately *additive*: the Vault policy stays the primary gate
 earlier). See ``docs/codebase/connectors-vault-tenant-scope.md`` for the
 namespace convention, the rationale, and the failure mode.
 
-Opt-in by design
-----------------
-The shipped deploy convention scopes secrets per operator ``sub``
-(``secret/data/targets/<sub>/*``), **not** per tenant, so there is no
-universal ``tenant-<id>/`` layout to enforce against out of the box.
-Enforcing a hard tenant prefix unconditionally would deny every existing
-call. The guard is therefore controlled by
+Default-on as of #1725
+----------------------
+The canonical KV layout is now per-tenant
+(``secret/data/tenants/<tenant_id>/<target>``, #1723), so the guard ships
+**enforcing** by default. The guard is controlled by
 :attr:`~meho_backplane.settings.Settings.vault_kv_tenant_scope_prefix`:
 
-* **empty (default)** → :func:`enforce_tenant_scope` is a no-op; behaviour
-  is byte-for-byte what it was before #1643.
-* **a ``str.format`` template** with a single ``{tenant_id}`` placeholder
-  (e.g. ``"tenant-{tenant_id}/"``) → the requested logical path must begin
-  with the rendered prefix, or :class:`VaultTenantScopeError` is raised
-  before any Vault round-trip.
+* **the mount-pinned default** ``"secret/tenants/{tenant_id}/"`` → the
+  requested logical path must begin with the rendered prefix, or
+  :class:`VaultTenantScopeError` is raised before any Vault round-trip. The
+  mount segment is part of the default because the match candidate is the
+  normalised ``<mount>/<path>`` (see :func:`_normalised_logical_path`) and
+  the KV-v2 handlers default ``mount="secret"`` — a *path-only*
+  ``"tenants/{tenant_id}/"`` would render to ``tenants/<id>/`` and never
+  match the ``secret/tenants/<id>/...`` candidate, denying every legitimate
+  per-tenant call.
+* **empty** (``VAULT_KV_TENANT_SCOPE_PREFIX=""``) → :func:`enforce_tenant_scope`
+  is a no-op; behaviour is byte-for-byte what it was before #1643. A deploy
+  still mid-migration (secrets under the retired per-``sub`` layout) opts out
+  this way until its secrets are relocated.
 
 The system/shim operator (Nil-UUID tenant, empty ``raw_jwt``) is exempt:
 its only callers exercise the unauthenticated ``vault.sys.health`` op and
 forward no token to Vault, so there is no tenant identity to bind against.
+
+A small set of **platform paths** is also exempt regardless of operator —
+fixed, shared, non-tenant secrets the platform itself reads under any
+authenticated operator's identity. The only such path today is the
+federation-proof health-check secret (``secret/meho/test/federation``,
+read by ``GET /api/v1/health`` to prove the JWT→OIDC→Vault chain). It is
+provisioned shared per the Goal #11 cross-repo contract and carries no
+tenant data, so the per-tenant guard must not deny it once enforced by
+default (#1725). The exemption is deliberately a closed allow-list, not a
+pattern, so it cannot be widened by a caller-supplied path.
 """
 
 from __future__ import annotations
@@ -47,7 +62,12 @@ from uuid import UUID
 from meho_backplane.auth.operator import Operator
 from meho_backplane.settings import get_settings
 
-__all__ = ["VaultTenantScopeError", "enforce_tenant_scope", "rendered_tenant_prefix"]
+__all__ = [
+    "PLATFORM_EXEMPT_PATHS",
+    "VaultTenantScopeError",
+    "enforce_tenant_scope",
+    "rendered_tenant_prefix",
+]
 
 #: The Nil UUID the vault-connector shim synthesises as the system
 #: operator's ``tenant_id`` (mirrors
@@ -56,6 +76,17 @@ __all__ = ["VaultTenantScopeError", "enforce_tenant_scope", "rendered_tenant_pre
 #: is skipped for it. Duplicated here rather than imported to avoid a
 #: connector ↔ ops import cycle; a regression test pins the two equal.
 _SYSTEM_TENANT_ID: UUID = UUID(int=0)
+
+#: Closed allow-list of normalised ``<mount>/<path>`` candidates the guard
+#: never denies, regardless of operator tenant. These are fixed, shared,
+#: non-tenant platform secrets the backplane reads on its own behalf under
+#: the request operator's identity (the audit trail keeps the real
+#: operator). Currently only the federation-proof health secret
+#: ``GET /api/v1/health`` reads. Kept as an explicit set — never a prefix or
+#: glob — so a caller cannot smuggle a tenant escape through it. A
+#: regression test pins this equal to the health route's
+#: ``_FEDERATION_PROOF_PATH`` rendered onto the default ``secret`` mount.
+PLATFORM_EXEMPT_PATHS: frozenset[str] = frozenset({"secret/meho/test/federation"})
 
 
 class VaultTenantScopeError(Exception):
@@ -107,12 +138,15 @@ def _normalised_logical_path(mount: str, path: str) -> str:
 def enforce_tenant_scope(operator: Operator, *, mount: str, path: str) -> None:
     """Deny a ``vault.kv.*`` call whose path escapes the operator's tenant namespace.
 
-    No-op when
-    :attr:`~meho_backplane.settings.Settings.vault_kv_tenant_scope_prefix`
-    is empty (the default) or when *operator* is the Nil-tenant system
-    shim. Otherwise renders the operator's tenant prefix from the template
-    and raises :class:`VaultTenantScopeError` unless the normalised
-    ``<mount>/<path>`` begins with it.
+    Enforced by default
+    (``vault_kv_tenant_scope_prefix="secret/tenants/{tenant_id}/"``). No-op
+    only when the prefix is explicitly emptied
+    (``VAULT_KV_TENANT_SCOPE_PREFIX=""``), when *operator* is the Nil-tenant
+    system shim, or when the normalised ``<mount>/<path>`` is one of the
+    fixed :data:`PLATFORM_EXEMPT_PATHS` (shared non-tenant platform secrets,
+    e.g. the federation-proof health read). Otherwise renders the operator's
+    tenant prefix from the template and raises :class:`VaultTenantScopeError`
+    unless the normalised ``<mount>/<path>`` begins with it.
 
     Parameters
     ----------
@@ -139,9 +173,15 @@ def enforce_tenant_scope(operator: Operator, *, mount: str, path: str) -> None:
         # callers run the unauthenticated sys.health op.
         return
 
+    candidate = _normalised_logical_path(mount, path)
+    if candidate in PLATFORM_EXEMPT_PATHS:
+        # A fixed, shared, non-tenant platform secret (e.g. the
+        # federation-proof health read) — exempt by closed allow-list so
+        # default-on enforcement does not deny the platform's own probes.
+        return
+
     prefix = rendered_tenant_prefix(operator, template=template)
     normalised_prefix = prefix.strip().strip("/")
-    candidate = _normalised_logical_path(mount, path)
 
     # Match on a path-segment boundary so a "tenant-1" prefix cannot be
     # satisfied by a "tenant-12/..." path. The candidate is normalised to

--- a/backend/src/meho_backplane/connectors/vault/tenant_scope.py
+++ b/backend/src/meho_backplane/connectors/vault/tenant_scope.py
@@ -44,15 +44,20 @@ The system/shim operator (Nil-UUID tenant, empty ``raw_jwt``) is exempt:
 its only callers exercise the unauthenticated ``vault.sys.health`` op and
 forward no token to Vault, so there is no tenant identity to bind against.
 
-A small set of **platform paths** is also exempt regardless of operator —
-fixed, shared, non-tenant secrets the platform itself reads under any
-authenticated operator's identity. The only such path today is the
-federation-proof health-check secret (``secret/meho/test/federation``,
-read by ``GET /api/v1/health`` to prove the JWT→OIDC→Vault chain). It is
-provisioned shared per the Goal #11 cross-repo contract and carries no
-tenant data, so the per-tenant guard must not deny it once enforced by
-default (#1725). The exemption is deliberately a closed allow-list, not a
-pattern, so it cannot be widened by a caller-supplied path.
+A small set of **platform paths** is also exempt — but only for
+**read-only** ops — fixed, shared, non-tenant secrets the platform itself
+reads under any authenticated operator's identity. The only such path
+today is the federation-proof health-check secret
+(``secret/meho/test/federation``, read by ``GET /api/v1/health`` to prove
+the JWT→OIDC→Vault chain). It is provisioned shared per the Goal #11
+cross-repo contract and carries no tenant data, so the per-tenant guard
+must not deny that read once enforced by default (#1725). The exemption is
+deliberately a closed allow-list, not a pattern, so it cannot be widened
+by a caller-supplied path; and it is scoped to read-only verbs
+(``vault.kv.read`` / ``vault.kv.list`` / ``vault.kv.versions``) so a
+``put`` / ``patch`` / ``delete`` to the shared platform path under a
+non-owning operator is still tenant-scoped (#1725 M1) — the health route
+only ever reads it.
 """
 
 from __future__ import annotations
@@ -135,18 +140,19 @@ def _normalised_logical_path(mount: str, path: str) -> str:
     return f"{clean_mount}/{clean_path}"
 
 
-def enforce_tenant_scope(operator: Operator, *, mount: str, path: str) -> None:
+def enforce_tenant_scope(operator: Operator, *, mount: str, path: str, read_only: bool) -> None:
     """Deny a ``vault.kv.*`` call whose path escapes the operator's tenant namespace.
 
     Enforced by default
     (``vault_kv_tenant_scope_prefix="secret/tenants/{tenant_id}/"``). No-op
     only when the prefix is explicitly emptied
     (``VAULT_KV_TENANT_SCOPE_PREFIX=""``), when *operator* is the Nil-tenant
-    system shim, or when the normalised ``<mount>/<path>`` is one of the
-    fixed :data:`PLATFORM_EXEMPT_PATHS` (shared non-tenant platform secrets,
-    e.g. the federation-proof health read). Otherwise renders the operator's
-    tenant prefix from the template and raises :class:`VaultTenantScopeError`
-    unless the normalised ``<mount>/<path>`` begins with it.
+    system shim, or — for **read-only** ops only — when the normalised
+    ``<mount>/<path>`` is one of the fixed :data:`PLATFORM_EXEMPT_PATHS`
+    (shared non-tenant platform secrets, e.g. the federation-proof health
+    read). Otherwise renders the operator's tenant prefix from the template
+    and raises :class:`VaultTenantScopeError` unless the normalised
+    ``<mount>/<path>`` begins with it.
 
     Parameters
     ----------
@@ -158,6 +164,16 @@ def enforce_tenant_scope(operator: Operator, *, mount: str, path: str) -> None:
     mount, path
         The mount handle and logical path the handler is about to forward
         to hvac, already ``.strip()``-ed by the handler.
+    read_only
+        Whether the calling op only reads/lists (``vault.kv.read`` /
+        ``vault.kv.list`` / ``vault.kv.versions``) or mutates
+        (``vault.kv.put`` / ``vault.kv.patch`` / ``vault.kv.delete``). The
+        :data:`PLATFORM_EXEMPT_PATHS` allow-list is honoured **only** for
+        read-only ops: the sole exempt path is the federation-proof health
+        secret which the health route only ever reads, so a write/delete to
+        it under a non-owning operator must still be tenant-scoped (#1725
+        M1). Required (no default) so every callsite makes its verb class
+        explicit rather than silently inheriting an exemption.
 
     Raises
     ------
@@ -174,10 +190,12 @@ def enforce_tenant_scope(operator: Operator, *, mount: str, path: str) -> None:
         return
 
     candidate = _normalised_logical_path(mount, path)
-    if candidate in PLATFORM_EXEMPT_PATHS:
+    if read_only and candidate in PLATFORM_EXEMPT_PATHS:
         # A fixed, shared, non-tenant platform secret (e.g. the
         # federation-proof health read) — exempt by closed allow-list so
         # default-on enforcement does not deny the platform's own probes.
+        # Scoped to read-only ops: the health route only reads this path,
+        # so a put/patch/delete to it stays tenant-scoped (#1725 M1).
         return
 
     prefix = rendered_tenant_prefix(operator, template=template)

--- a/backend/src/meho_backplane/main.py
+++ b/backend/src/meho_backplane/main.py
@@ -231,23 +231,25 @@ def _advise_vault_tenant_scope_unenforced() -> None:
     """Emit a one-time startup advisory when the Vault tenant-scope guard is off.
 
     The application-layer ``vault.kv.*`` tenant-scope guard (#1643) is
-    **opt-in** and **default-off** (``VAULT_KV_TENANT_SCOPE_PREFIX=""``),
-    because the shipped Vault layout scopes secrets per operator ``sub``
-    rather than per tenant, so a hard tenant prefix would deny every
-    existing call. The consequence is silent: an operator running a
-    **tenant-partitioned** Vault gets no signal that the guard is a no-op
-    and cross-tenant ``vault.kv.*`` isolation is therefore unenforced at
-    the app layer (the empty-prefix branch of
-    :func:`~meho_backplane.connectors.vault.tenant_scope.enforce_tenant_scope`).
+    **default-on** as of #1725
+    (``VAULT_KV_TENANT_SCOPE_PREFIX="secret/tenants/{tenant_id}/"``), so the
+    common deploy is silent here. An operator only reaches this advisory by
+    **explicitly disabling** the guard (setting the prefix back to ``""``) —
+    e.g. while still mid-migration with secrets under the retired per-``sub``
+    layout. The consequence of running unenforced is silent otherwise: with
+    the empty prefix
+    :func:`~meho_backplane.connectors.vault.tenant_scope.enforce_tenant_scope`
+    is a no-op and cross-tenant ``vault.kv.*`` isolation is unenforced at the
+    app layer, with no other signal.
 
-    This logs **one** structured advisory at startup naming the env var
-    that enables the guard. It is purely observability — it does **not**
-    change dispatch behaviour or flip the default; whether to enable the
-    prefix (and migrate the Vault layout) is an explicit human/infra
-    decision, documented under "Choosing a layout" in
-    ``docs/codebase/connectors-vault-tenant-scope.md``. A deploy that
-    relies solely on the per-``sub`` Vault policy can ignore the line; a
-    tenant-partitioned deploy treats it as the cue to set the prefix.
+    This logs **one** structured advisory at startup naming the env var that
+    re-enables the guard. It is purely observability — it does **not** change
+    dispatch behaviour or flip the default; whether to keep the guard
+    disabled (and finish migrating the Vault layout) is an explicit
+    human/infra decision, documented under "Choosing a layout" in
+    ``docs/codebase/connectors-vault-tenant-scope.md``. A deploy that has
+    deliberately opted out can ignore the line; otherwise it is the cue that
+    tenant isolation is not being enforced at the app layer.
 
     Mirrors the loud-but-non-fatal advisory shape the rest of the
     lifespan uses (e.g. :func:`_preload_embedding_model`): a single

--- a/backend/src/meho_backplane/settings.py
+++ b/backend/src/meho_backplane/settings.py
@@ -1107,6 +1107,56 @@ class Settings(BaseModel):
     #: Set via ``VAULT_KV_TENANT_SCOPE_PREFIX``.
     vault_kv_tenant_scope_prefix: str = "secret/tenants/{tenant_id}/"
 
+    @field_validator("vault_kv_tenant_scope_prefix")
+    @classmethod
+    def _vault_tenant_prefix_must_template_tenant_id(cls, value: str) -> str:
+        """Reject a tenant-scope prefix that isn't a clean ``{tenant_id}`` template.
+
+        The guard renders this prefix per-operator via
+        ``value.format(tenant_id=...)``
+        (:func:`~meho_backplane.connectors.vault.tenant_scope.rendered_tenant_prefix`).
+        Pulled up to :class:`Settings` construction so two otherwise-silent
+        misconfigurations of ``VAULT_KV_TENANT_SCOPE_PREFIX`` surface at pod
+        startup rather than at first ``vault.kv.*`` call:
+
+        * **Missing ``{tenant_id}`` placeholder**: ``str.format`` returns the
+          literal prefix, so every operator shares one rendered prefix and
+          tenant isolation silently collapses to a single shared namespace.
+        * **Malformed template** — unbalanced braces, a positional ``{0}``,
+          or an extra named placeholder (``{tenant_id}/{region}``): the
+          render raises :class:`KeyError` / :class:`IndexError` /
+          :class:`ValueError` at request time, denying every legitimate
+          per-tenant call.
+
+        The empty string is the **explicit-disable** sentinel
+        (``VAULT_KV_TENANT_SCOPE_PREFIX=""`` opts a mid-migration deploy
+        out of the guard) and is accepted verbatim. Same fail-closed-at-
+        startup discipline as
+        :meth:`_scheduler_secret_pattern_must_substitute_client_id`.
+        """
+        if not value.strip():
+            # Explicit-disable sentinel — guard is a no-op; nothing to render.
+            return value
+        if "{tenant_id}" not in value:
+            raise ValueError(
+                f"VAULT_KV_TENANT_SCOPE_PREFIX must include '{{tenant_id}}' so "
+                f"each operator's KV calls are scoped to their own tenant "
+                f"namespace; got: {value!r}. Set it to the empty string to "
+                f"disable the tenant-scope guard."
+            )
+        try:
+            # A clean template renders with ONLY tenant_id; an extra named
+            # placeholder raises KeyError, a positional {0} raises IndexError,
+            # unbalanced braces raise ValueError.
+            value.format(tenant_id="00000000-0000-0000-0000-000000000000")
+        except (IndexError, KeyError, ValueError) as exc:
+            raise ValueError(
+                f"VAULT_KV_TENANT_SCOPE_PREFIX must be a valid str.format "
+                f"template whose only placeholder is '{{tenant_id}}'; got: "
+                f"{value!r}"
+            ) from exc
+        return value
+
     @field_validator("broadcast_redis_url")
     @classmethod
     def _broadcast_url_must_use_supported_scheme(cls, value: str) -> str:

--- a/backend/src/meho_backplane/settings.py
+++ b/backend/src/meho_backplane/settings.py
@@ -1092,14 +1092,20 @@ class Settings(BaseModel):
     #: (``docs/codebase/connectors-vault-tenant-scope.md``). When a caller
     #: requests a ``path`` outside their rendered prefix the handler raises
     #: :class:`~meho_backplane.connectors.vault.tenant_scope.VaultTenantScopeError`
-    #: *before* the hvac call. **Empty (the default) disables the guard** —
-    #: the shipped deploy convention scopes per operator ``sub``
-    #: (``secret/data/targets/<sub>/*``, ``connector-vault-policy.md`` §2),
-    #: not per tenant, so enforcing a hard tenant prefix unconditionally
-    #: would break every existing call; a deploy whose KV layout *is*
-    #: tenant-partitioned opts in by setting e.g. ``"tenant-{tenant_id}/"``.
+    #: *before* the hvac call. **Default-on** as of this release: the
+    #: canonical KV layout is now per-tenant
+    #: (``secret/data/tenants/<tenant_id>/<target>``, #1723), so the guard
+    #: ships enforcing the mount-pinned ``"secret/tenants/{tenant_id}/"``
+    #: prefix. The mount segment is required because the guard matches a
+    #: normalised ``<mount>/<path>`` candidate and the KV-v2 handlers default
+    #: ``mount="secret"`` (``connectors/vault/ops.py`` ``_DEFAULT_KV_MOUNT``);
+    #: a path-only ``"tenants/{tenant_id}/"`` would never match that
+    #: candidate and would deny every legitimate per-tenant call. A deploy
+    #: still mid-migration (secrets under the retired per-``sub`` layout)
+    #: opts **out** by setting ``VAULT_KV_TENANT_SCOPE_PREFIX=""`` until its
+    #: secrets are relocated. Pre-#1725 this defaulted empty (guard off).
     #: Set via ``VAULT_KV_TENANT_SCOPE_PREFIX``.
-    vault_kv_tenant_scope_prefix: str = ""
+    vault_kv_tenant_scope_prefix: str = "secret/tenants/{tenant_id}/"
 
     @field_validator("broadcast_redis_url")
     @classmethod
@@ -1452,5 +1458,7 @@ def get_settings() -> Settings:
         corpus_require_filters=parse_bool_env(
             os.environ.get("CORPUS_REQUIRE_FILTERS", "true"),
         ),
-        vault_kv_tenant_scope_prefix=os.environ.get("VAULT_KV_TENANT_SCOPE_PREFIX", "").strip(),
+        vault_kv_tenant_scope_prefix=os.environ.get(
+            "VAULT_KV_TENANT_SCOPE_PREFIX", "secret/tenants/{tenant_id}/"
+        ).strip(),
     )

--- a/backend/tests/acceptance/test_g08_operations_call_vault_e2e.py
+++ b/backend/tests/acceptance/test_g08_operations_call_vault_e2e.py
@@ -95,6 +95,7 @@ from meho_backplane.db.models import AuditLog, Tenant
 from meho_backplane.operations import reset_dispatcher_caches
 from meho_backplane.operations.dispatcher import set_default_reducer
 from meho_backplane.operations.reducer import PassThroughReducer
+from meho_backplane.settings import get_settings
 from tests._oidc_jwt_helpers import (
     make_rsa_keypair,
     mint_token,
@@ -282,6 +283,17 @@ async def vault_operations_app(
         yield _root_client(vault_dev_addr)
 
     monkeypatch.setattr(_auth_vault, "vault_client_for_operator", _root_client_cm)
+
+    # The default-on tenant-scope guard (#1725) pins KV calls under
+    # ``secret/tenants/{tenant_id}/``. This e2e exercises the
+    # JWT-bind → Vault-read path against a fixed legacy seed path
+    # (``g08-t8/federation`` on the default ``secret`` mount), not the
+    # per-tenant layout, so the guard would deny it with
+    # VaultTenantScopeError. Disable the guard explicitly for this test
+    # (the scope under test is the federated read path, not tenant
+    # scoping — covered by ``test_connectors_vault_tenant_scope.py``).
+    monkeypatch.setenv("VAULT_KV_TENANT_SCOPE_PREFIX", "")
+    get_settings.cache_clear()
 
     app = build_integration_app()
     app.include_router(operations_router)

--- a/backend/tests/integration/test_connectors_vault_dev_e2e.py
+++ b/backend/tests/integration/test_connectors_vault_dev_e2e.py
@@ -396,6 +396,14 @@ async def vault_e2e(
     # container so the sys.health / sys.seal_status path (which does
     # not go through vault_client_for_operator) hits the dev Vault.
     monkeypatch.setenv("VAULT_ADDR", vault_dev_addr)
+    # The default-on tenant-scope guard (#1725) would deny the seeded
+    # legacy paths exercised here (``app/config``, ``app/written`` … on
+    # the default ``secret`` mount) under the test operator's real
+    # tenant. This suite proves the connector → hvac → dispatch → audit
+    # path, not tenant scoping (covered by
+    # ``test_connectors_vault_tenant_scope.py``); disable the guard
+    # explicitly so the legacy KV layout under test stays reachable.
+    monkeypatch.setenv("VAULT_KV_TENANT_SCOPE_PREFIX", "")
     from meho_backplane.settings import get_settings
 
     get_settings.cache_clear()

--- a/backend/tests/test_api_v1_targets.py
+++ b/backend/tests/test_api_v1_targets.py
@@ -2412,8 +2412,8 @@ def test_create_target_derives_per_tenant_secret_ref(client: TestClient) -> None
     """A create with no explicit ``secret_ref`` lands on ``tenants/<T>/<name>``.
 
     #1723: new targets default onto the per-tenant shared path so the
-    #1643 guard can enforce ``tenants/{tenant_id}/`` — not the retired
-    per-``sub`` layout.
+    default-on #1643 guard (``secret/tenants/{tenant_id}/``, #1725) enforces
+    against it — not the retired per-``sub`` layout.
     """
     key = make_rsa_keypair("kid-A")
     with respx.mock as mock_router:

--- a/backend/tests/test_connectors_vault_tenant_paths.py
+++ b/backend/tests/test_connectors_vault_tenant_paths.py
@@ -44,6 +44,13 @@ def _settings_env(monkeypatch: pytest.MonkeyPatch) -> Iterator[None]:
     monkeypatch.setenv("VAULT_OIDC_MOUNT_PATH", "jwt")
     monkeypatch.setenv("VAULT_TIMEOUT_SECONDS", "5.0")
     monkeypatch.delenv("VAULT_NAMESPACE", raising=False)
+    # The relocation helper reads the *retired* per-`sub` path
+    # (``targets/<sub>/...``) to move it to the per-tenant home. That source
+    # path is outside the now-default-on tenant-scope guard
+    # (``secret/tenants/{tenant_id}/``, #1725), so the migration runs with
+    # the guard explicitly disabled — exactly as the operator runbook
+    # (``vault-per-tenant-migration.md``) prescribes for the migration window.
+    monkeypatch.setenv("VAULT_KV_TENANT_SCOPE_PREFIX", "")
     get_settings.cache_clear()
     yield
     get_settings.cache_clear()
@@ -74,8 +81,11 @@ def test_tenant_secret_ref_uses_canonical_dashed_uuid() -> None:
     """The tenant segment matches the guard's rendered prefix exactly."""
     op = _operator()
     ref = tenant_secret_ref(op.tenant_id, "x")
+    # The mount-less ``secret_ref`` carries only the path portion; the
+    # default-on guard pins the mount too (``secret/tenants/{tenant_id}/``),
+    # so the path-relative prefix here is the path tail of that template.
     prefix = rendered_tenant_prefix(op, template="tenants/{tenant_id}/")
-    # The derived ref sits inside the prefix the #1643 guard would render.
+    # The derived ref sits inside the path tail of the prefix the guard renders.
     assert ref.startswith(prefix)
 
 

--- a/backend/tests/test_connectors_vault_tenant_scope.py
+++ b/backend/tests/test_connectors_vault_tenant_scope.py
@@ -30,6 +30,7 @@ from meho_backplane.connectors.vault import VaultConnector
 from meho_backplane.connectors.vault.connector import _SYSTEM_TENANT_ID
 from meho_backplane.connectors.vault.ops import register_vault_typed_operations
 from meho_backplane.connectors.vault.tenant_scope import (
+    PLATFORM_EXEMPT_PATHS,
     VaultTenantScopeError,
     enforce_tenant_scope,
     rendered_tenant_prefix,
@@ -180,6 +181,84 @@ def test_empty_template_disables_the_guard(monkeypatch: pytest.MonkeyPatch) -> N
     op = _operator(_TENANT_A)
     # Any path, including a cross-tenant one, is allowed when disabled.
     enforce_tenant_scope(op, mount="secret", path=f"tenant-{_TENANT_B}/db")
+
+
+def test_default_prefix_is_mount_pinned_per_tenant(monkeypatch: pytest.MonkeyPatch) -> None:
+    """No env override → the guard ships enforced with ``secret/tenants/{tenant_id}/`` (#1725).
+
+    The default-on value must be **mount-pinned**: the guard matches a
+    normalised ``<mount>/<path>`` candidate and the KV-v2 handlers default
+    ``mount="secret"``, so a path-only ``tenants/{tenant_id}/`` would never
+    match the ``secret/tenants/<id>/...`` candidate and would deny every
+    legitimate per-tenant call.
+    """
+    monkeypatch.delenv("VAULT_KV_TENANT_SCOPE_PREFIX", raising=False)
+    get_settings.cache_clear()
+    assert get_settings().vault_kv_tenant_scope_prefix == "secret/tenants/{tenant_id}/"
+
+
+def test_default_config_allows_canonical_per_tenant_call(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """Under the default prefix, the canonical #1723 layout call is ALLOWED.
+
+    mount=``secret`` (the handler default) + path=``tenants/<id>/<target>``
+    → candidate ``secret/tenants/<id>/<target>`` is inside the rendered
+    default prefix, so no raise.
+    """
+    monkeypatch.delenv("VAULT_KV_TENANT_SCOPE_PREFIX", raising=False)
+    get_settings.cache_clear()
+    op = _operator(_TENANT_A)
+    enforce_tenant_scope(op, mount="secret", path=f"tenants/{_TENANT_A}/rdc-vcenter")
+
+
+def test_default_config_denies_cross_tenant_call(monkeypatch: pytest.MonkeyPatch) -> None:
+    """Under the default prefix, a cross-tenant path is DENIED."""
+    monkeypatch.delenv("VAULT_KV_TENANT_SCOPE_PREFIX", raising=False)
+    get_settings.cache_clear()
+    op = _operator(_TENANT_A)
+    with pytest.raises(VaultTenantScopeError):
+        enforce_tenant_scope(op, mount="secret", path=f"tenants/{_TENANT_B}/rdc-vcenter")
+
+
+def test_default_config_exempts_system_tenant(monkeypatch: pytest.MonkeyPatch) -> None:
+    """Under the default prefix, the Nil-UUID system operator stays exempt."""
+    monkeypatch.delenv("VAULT_KV_TENANT_SCOPE_PREFIX", raising=False)
+    get_settings.cache_clear()
+    op = _operator(_SYSTEM_TENANT_ID)
+    enforce_tenant_scope(op, mount="secret", path="anything/at/all")
+
+
+def test_platform_exempt_path_is_allowed_for_real_tenant() -> None:
+    """A shared platform secret (federation-proof health) bypasses the guard.
+
+    The path is read by ``GET /api/v1/health`` under the *real* request
+    operator's identity (not the system shim), so the per-tenant guard would
+    otherwise deny it once enforced by default. The closed allow-list exempts
+    it.
+    """
+    op = _operator(_TENANT_A)
+    # mount "secret" (the handler default) + path "meho/test/federation".
+    enforce_tenant_scope(op, mount="secret", path="meho/test/federation")
+
+
+def test_platform_exemption_does_not_widen_to_sibling_paths() -> None:
+    """The exemption is an exact-match allow-list, not a prefix."""
+    op = _operator(_TENANT_A)
+    with pytest.raises(VaultTenantScopeError):
+        enforce_tenant_scope(op, mount="secret", path="meho/test/federation/escape")
+
+
+def test_platform_exempt_paths_match_health_route() -> None:
+    """The exempt set stays equal to the health route's federation-proof path.
+
+    Mirrors the ``_SYSTEM_TENANT_ID`` duplication pattern: the value is
+    pinned by a test rather than imported, so a drift in the health route's
+    ``_FEDERATION_PROOF_PATH`` (or its mount) trips here.
+    """
+    from meho_backplane.api.v1.health import _FEDERATION_PROOF_PATH
+
+    assert frozenset({f"secret/{_FEDERATION_PROOF_PATH}"}) == PLATFORM_EXEMPT_PATHS
 
 
 def test_system_tenant_is_exempt() -> None:

--- a/backend/tests/test_connectors_vault_tenant_scope.py
+++ b/backend/tests/test_connectors_vault_tenant_scope.py
@@ -143,13 +143,15 @@ def test_in_namespace_path_passes() -> None:
     """A path under the operator's rendered prefix is allowed (no raise)."""
     op = _operator(_TENANT_A)
     # mount "secret", path "tenant-<A>/db/creds" → "secret/tenant-<A>/db/creds"
-    enforce_tenant_scope(op, mount="secret", path=f"tenant-{_TENANT_A}/db/creds")
+    enforce_tenant_scope(op, mount="secret", path=f"tenant-{_TENANT_A}/db/creds", read_only=True)
 
 
 def test_out_of_namespace_path_is_denied() -> None:
     op = _operator(_TENANT_A)
     with pytest.raises(VaultTenantScopeError) as exc:
-        enforce_tenant_scope(op, mount="secret", path=f"tenant-{_TENANT_B}/db/creds")
+        enforce_tenant_scope(
+            op, mount="secret", path=f"tenant-{_TENANT_B}/db/creds", read_only=True
+        )
     # The message names the offending path + tenant, never a secret value.
     assert f"tenant-{_TENANT_B}/db/creds" in str(exc.value)
     assert str(_TENANT_A) in str(exc.value)
@@ -164,14 +166,14 @@ def test_sibling_prefix_does_not_satisfy_the_guard() -> None:
     """
     op = _operator(_TENANT_A)
     with pytest.raises(VaultTenantScopeError):
-        enforce_tenant_scope(op, mount="secret", path=f"tenant-{_TENANT_A}extra/x")
+        enforce_tenant_scope(op, mount="secret", path=f"tenant-{_TENANT_A}extra/x", read_only=True)
 
 
 def test_cross_mount_request_is_denied() -> None:
     """The prefix pins the mount segment too — a different mount is denied."""
     op = _operator(_TENANT_A)
     with pytest.raises(VaultTenantScopeError):
-        enforce_tenant_scope(op, mount="other", path=f"tenant-{_TENANT_A}/db")
+        enforce_tenant_scope(op, mount="other", path=f"tenant-{_TENANT_A}/db", read_only=True)
 
 
 def test_empty_template_disables_the_guard(monkeypatch: pytest.MonkeyPatch) -> None:
@@ -180,7 +182,7 @@ def test_empty_template_disables_the_guard(monkeypatch: pytest.MonkeyPatch) -> N
     get_settings.cache_clear()
     op = _operator(_TENANT_A)
     # Any path, including a cross-tenant one, is allowed when disabled.
-    enforce_tenant_scope(op, mount="secret", path=f"tenant-{_TENANT_B}/db")
+    enforce_tenant_scope(op, mount="secret", path=f"tenant-{_TENANT_B}/db", read_only=False)
 
 
 def test_default_prefix_is_mount_pinned_per_tenant(monkeypatch: pytest.MonkeyPatch) -> None:
@@ -209,7 +211,9 @@ def test_default_config_allows_canonical_per_tenant_call(
     monkeypatch.delenv("VAULT_KV_TENANT_SCOPE_PREFIX", raising=False)
     get_settings.cache_clear()
     op = _operator(_TENANT_A)
-    enforce_tenant_scope(op, mount="secret", path=f"tenants/{_TENANT_A}/rdc-vcenter")
+    enforce_tenant_scope(
+        op, mount="secret", path=f"tenants/{_TENANT_A}/rdc-vcenter", read_only=True
+    )
 
 
 def test_default_config_denies_cross_tenant_call(monkeypatch: pytest.MonkeyPatch) -> None:
@@ -218,7 +222,9 @@ def test_default_config_denies_cross_tenant_call(monkeypatch: pytest.MonkeyPatch
     get_settings.cache_clear()
     op = _operator(_TENANT_A)
     with pytest.raises(VaultTenantScopeError):
-        enforce_tenant_scope(op, mount="secret", path=f"tenants/{_TENANT_B}/rdc-vcenter")
+        enforce_tenant_scope(
+            op, mount="secret", path=f"tenants/{_TENANT_B}/rdc-vcenter", read_only=True
+        )
 
 
 def test_default_config_exempts_system_tenant(monkeypatch: pytest.MonkeyPatch) -> None:
@@ -226,7 +232,7 @@ def test_default_config_exempts_system_tenant(monkeypatch: pytest.MonkeyPatch) -
     monkeypatch.delenv("VAULT_KV_TENANT_SCOPE_PREFIX", raising=False)
     get_settings.cache_clear()
     op = _operator(_SYSTEM_TENANT_ID)
-    enforce_tenant_scope(op, mount="secret", path="anything/at/all")
+    enforce_tenant_scope(op, mount="secret", path="anything/at/all", read_only=True)
 
 
 def test_platform_exempt_path_is_allowed_for_real_tenant() -> None:
@@ -239,14 +245,42 @@ def test_platform_exempt_path_is_allowed_for_real_tenant() -> None:
     """
     op = _operator(_TENANT_A)
     # mount "secret" (the handler default) + path "meho/test/federation".
-    enforce_tenant_scope(op, mount="secret", path="meho/test/federation")
+    # Read-only — the health route only reads this path.
+    enforce_tenant_scope(op, mount="secret", path="meho/test/federation", read_only=True)
 
 
 def test_platform_exemption_does_not_widen_to_sibling_paths() -> None:
     """The exemption is an exact-match allow-list, not a prefix."""
     op = _operator(_TENANT_A)
     with pytest.raises(VaultTenantScopeError):
-        enforce_tenant_scope(op, mount="secret", path="meho/test/federation/escape")
+        enforce_tenant_scope(op, mount="secret", path="meho/test/federation/escape", read_only=True)
+
+
+def test_platform_exemption_is_read_only_write_is_denied() -> None:
+    """A WRITE to the exempt platform path is denied — the exemption is read-only (#1725 M1).
+
+    The health route only ever READS ``secret/meho/test/federation``. The
+    closed allow-list must not bypass the guard for a mutating verb, so a
+    ``put`` / ``patch`` / ``delete`` to the shared platform path under a
+    non-owning operator stays tenant-scoped.
+    """
+    op = _operator(_TENANT_A)
+    with pytest.raises(VaultTenantScopeError):
+        enforce_tenant_scope(op, mount="secret", path="meho/test/federation", read_only=False)
+
+
+def test_platform_exemption_read_allowed_write_denied_same_path() -> None:
+    """The same exact exempt path: read passes, write is denied (#1725 M1).
+
+    Pins the read/write asymmetry on one path so a future refactor that
+    drops the ``read_only`` gate (re-widening to all verbs) trips here.
+    """
+    op = _operator(_TENANT_A)
+    # Read is exempt.
+    enforce_tenant_scope(op, mount="secret", path="meho/test/federation", read_only=True)
+    # Write to the very same path is not.
+    with pytest.raises(VaultTenantScopeError):
+        enforce_tenant_scope(op, mount="secret", path="meho/test/federation", read_only=False)
 
 
 def test_platform_exempt_paths_match_health_route() -> None:
@@ -264,7 +298,7 @@ def test_platform_exempt_paths_match_health_route() -> None:
 def test_system_tenant_is_exempt() -> None:
     """The Nil-UUID system/shim operator bypasses the guard."""
     op = _operator(_SYSTEM_TENANT_ID)
-    enforce_tenant_scope(op, mount="secret", path="anything/at/all")
+    enforce_tenant_scope(op, mount="secret", path="anything/at/all", read_only=True)
 
 
 def test_system_tenant_constant_matches_connector() -> None:
@@ -363,3 +397,57 @@ async def test_handler_allows_in_namespace_path(
     assert result.status == "ok", result.error
     # The guard did not short-circuit: the handler logged in to Vault.
     assert fake.auth.jwt.login_calls != []
+
+
+# ---------------------------------------------------------------------------
+# Dispatch-level — the platform-path exemption is read-only (#1725 M1)
+# ---------------------------------------------------------------------------
+
+#: The shared platform secret the health route reads. Outside this suite's
+#: ``secret/tenant-{tenant_id}/`` prefix, so it only passes the guard via
+#: the read-only platform-path allow-list.
+_PLATFORM_PATH = "meho/test/federation"
+
+
+async def test_handler_allows_read_of_exempt_platform_path(
+    monkeypatch: pytest.MonkeyPatch,
+    _registered_vault_typed_ops: None,
+) -> None:
+    """``vault.kv.read`` of the exempt platform path is allowed for a real tenant."""
+    fake = install_fake_client(monkeypatch, secret={"k": "v"}, kv_version=3)
+    result = await _dispatch("vault.kv.read", {"path": _PLATFORM_PATH}, tenant_id=_TENANT_A)
+
+    assert result.status == "ok", result.error
+    # The read reached Vault — the read-only platform exemption applied.
+    assert fake.auth.jwt.login_calls != []
+
+
+@pytest.mark.parametrize(
+    "op_id,params",
+    [
+        ("vault.kv.put", {"path": _PLATFORM_PATH, "data": {"k": "v"}}),
+        ("vault.kv.patch", {"path": _PLATFORM_PATH, "data": {"k": "v"}}),
+        ("vault.kv.delete", {"path": _PLATFORM_PATH, "versions": [1]}),
+    ],
+    ids=["put", "patch", "delete"],
+)
+async def test_handler_denies_write_to_exempt_platform_path(
+    monkeypatch: pytest.MonkeyPatch,
+    op_id: str,
+    params: dict[str, Any],
+    _registered_vault_typed_ops: None,
+) -> None:
+    """A WRITE to the exempt platform path is denied — read-only exemption (#1725 M1).
+
+    The platform-path allow-list bypasses the guard only for read-only ops.
+    A mutating ``put`` / ``patch`` / ``delete`` to the shared platform path
+    under a non-owning operator must still be tenant-scoped, so the guard
+    short-circuits before any Vault round-trip.
+    """
+    fake = install_fake_client(monkeypatch, secret={"k": "v"})
+    result = await _dispatch(op_id, params, tenant_id=_TENANT_A)
+
+    assert result.status == "error"
+    assert result.extras.get("exception_class") == "VaultTenantScopeError"
+    # Defense-in-depth: no Vault round-trip — the guard denied before login.
+    assert fake.auth.jwt.login_calls == []

--- a/backend/tests/test_settings.py
+++ b/backend/tests/test_settings.py
@@ -318,3 +318,65 @@ def test_agent_runs_disabled_tenants_rejects_non_uuid(raw: str) -> None:
             agent_runs_disabled_tenants=raw,
         )
     assert "AGENT_RUNS_DISABLED_TENANTS" in str(exc_info.value)
+
+
+# ---------------------------------------------------------------------------
+# #1725 M2 — vault_kv_tenant_scope_prefix template validation at construction
+# ---------------------------------------------------------------------------
+
+
+def test_vault_tenant_scope_prefix_default_is_valid() -> None:
+    """The shipped default-on prefix constructs without raising.
+
+    The mount-pinned ``secret/tenants/{tenant_id}/`` default carries the
+    required ``{tenant_id}`` placeholder and no other, so it passes the
+    construction-time template check.
+    """
+    settings = Settings(**_settings_kwargs("sqlite+aiosqlite:///:memory:"))  # type: ignore[arg-type]
+    assert settings.vault_kv_tenant_scope_prefix == "secret/tenants/{tenant_id}/"
+
+
+@pytest.mark.parametrize(
+    "raw",
+    [
+        "",  # explicit-disable sentinel
+        "   ",  # whitespace-only → disabled
+        "secret/tenants/{tenant_id}/",  # the default
+        "kv-prod/{tenant_id}/",  # custom mount, single placeholder
+        "{tenant_id}/",  # path-only single placeholder
+    ],
+)
+def test_vault_tenant_scope_prefix_accepts_valid_templates(raw: str) -> None:
+    """The empty sentinel and any clean single-``{tenant_id}`` template construct."""
+    settings = Settings(
+        **_settings_kwargs("sqlite+aiosqlite:///:memory:"),  # type: ignore[arg-type]
+        vault_kv_tenant_scope_prefix=raw,
+    )
+    assert settings.vault_kv_tenant_scope_prefix == raw
+
+
+@pytest.mark.parametrize(
+    "raw",
+    [
+        "secret/tenants/",  # missing the {tenant_id} placeholder
+        "secret/tenants/{tenant_id",  # unbalanced brace
+        "secret/tenants/{0}/",  # positional placeholder, not named
+        "secret/tenants/{tenant_id}/{region}/",  # extra placeholder
+        "secret/{sub}/{tenant_id}/",  # extra named placeholder
+    ],
+)
+def test_vault_tenant_scope_prefix_rejects_malformed_templates(raw: str) -> None:
+    """A non-empty prefix that isn't a clean ``{tenant_id}`` template fails construction.
+
+    #1725 M2 — a malformed override would otherwise fail at first
+    ``vault.kv.*`` call (and a placeholder-less one silently collapses
+    every operator to one shared namespace). Eager validation at
+    construction surfaces the misconfig at pod startup with the offending
+    value quoted.
+    """
+    with pytest.raises(ValidationError) as exc_info:
+        Settings(
+            **_settings_kwargs("sqlite+aiosqlite:///:memory:"),  # type: ignore[arg-type]
+            vault_kv_tenant_scope_prefix=raw,
+        )
+    assert "VAULT_KV_TENANT_SCOPE_PREFIX" in str(exc_info.value)

--- a/backend/tests/test_vault_tenant_scope_advisory.py
+++ b/backend/tests/test_vault_tenant_scope_advisory.py
@@ -3,17 +3,19 @@
 
 """Startup advisory for an unenforced Vault tenant-scope guard (#1673).
 
-The application-layer ``vault.kv.*`` tenant-scope guard (#1643) is opt-in
-and default-off (``VAULT_KV_TENANT_SCOPE_PREFIX=""``). On a deploy whose
-Vault layout *is* tenant-partitioned, leaving the prefix empty silently
-turns the guard into a no-op, so cross-tenant ``vault.kv.*`` isolation is
-unenforced at the app layer with no signal.
+The application-layer ``vault.kv.*`` tenant-scope guard (#1643) is default-on
+as of #1725 (``VAULT_KV_TENANT_SCOPE_PREFIX="secret/tenants/{tenant_id}/"``).
+The advisory therefore stays silent on the common deploy; it fires only when
+an operator has *explicitly disabled* the guard (set the prefix back to
+``""``) — e.g. while still mid-migration — so that running unenforced is
+never silent.
 
 :func:`meho_backplane.main._advise_vault_tenant_scope_unenforced` runs in
 the FastAPI lifespan and emits exactly one structured
-``vault_tenant_scope_unenforced`` advisory when the prefix is unset. These
-tests assert it fires when unset, stays silent when set, and does not
-change boot behaviour either way (it is observability-only — no raise).
+``vault_tenant_scope_unenforced`` advisory when the prefix is empty. These
+tests assert it stays silent on the default config and when a prefix is set,
+fires when the prefix is explicitly emptied, and does not change boot
+behaviour either way (it is observability-only — no raise).
 """
 
 from __future__ import annotations
@@ -50,8 +52,24 @@ def _required_settings_env(monkeypatch: pytest.MonkeyPatch) -> Iterator[None]:
     get_settings.cache_clear()
 
 
-def test_advisory_fires_once_when_prefix_unset(monkeypatch: pytest.MonkeyPatch) -> None:
-    """Empty prefix → exactly one structured advisory naming the env var."""
+def test_advisory_silent_on_default_config(monkeypatch: pytest.MonkeyPatch) -> None:
+    """No env override → guard is default-on (#1725), so no advisory fires."""
+    monkeypatch.delenv("VAULT_KV_TENANT_SCOPE_PREFIX", raising=False)
+    get_settings.cache_clear()
+    try:
+        with capture_logs() as captured:
+            _advise_vault_tenant_scope_unenforced()
+    finally:
+        get_settings.cache_clear()
+
+    advisories = [e for e in captured if e.get("event") == _ADVISORY_EVENT]
+    assert advisories == []
+
+
+def test_advisory_fires_once_when_prefix_explicitly_emptied(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """Explicitly emptied prefix → exactly one structured advisory naming the env var."""
     monkeypatch.setenv("VAULT_KV_TENANT_SCOPE_PREFIX", "")
     get_settings.cache_clear()
     try:

--- a/docs/codebase/connectors-vault-tenant-scope.md
+++ b/docs/codebase/connectors-vault-tenant-scope.md
@@ -33,10 +33,13 @@ straight through.
 ## The guard
 
 [`connectors/vault/tenant_scope.py`](../../backend/src/meho_backplane/connectors/vault/tenant_scope.py)
-adds `enforce_tenant_scope(operator, mount=..., path=...)`, called by
-**every** KV-v2 handler (`read`, `list`, `versions`, `put`, `patch`,
-`delete`) immediately after it extracts `mount`/`path` and **before** the
-`vault_client_for_operator(...)` login. On a violation it raises
+adds `enforce_tenant_scope(operator, mount=..., path=..., read_only=...)`,
+called by **every** KV-v2 handler (`read`, `list`, `versions`, `put`,
+`patch`, `delete`) immediately after it extracts `mount`/`path` and
+**before** the `vault_client_for_operator(...)` login. `read_only` is
+`True` for the read/list/versions handlers and `False` for
+put/patch/delete; it gates the platform-path exemption (below) to
+read-only verbs. On a violation it raises
 `VaultTenantScopeError`; the dispatcher's `connector_error` branch wraps
 it into a structured `OperationResult` with
 `extras["exception_class"] == "VaultTenantScopeError"` — distinct from the
@@ -136,7 +139,20 @@ provisioned shared per the Goal #11 cross-repo contract, so the default-on
 guard must not deny the platform's own probe. The exemption is an
 **exact-match** set, never a prefix or glob, so a caller cannot smuggle a
 tenant escape through it; a regression test pins it equal to the health
-route's path.
+route's path. It is also scoped to **read-only** verbs (gated on the
+`read_only` argument): the health route only ever reads this path, so a
+`put`/`patch`/`delete` to it under a non-owning operator is still
+tenant-scoped and denied.
+
+**Prefix template validation.** `vault_kv_tenant_scope_prefix` is validated
+at `Settings` construction (a pydantic `@field_validator`): a non-empty
+value must contain the `{tenant_id}` placeholder and be a clean
+`str.format` template (no unbalanced braces, no positional `{0}`, no extra
+named placeholder). The empty string (explicit-disable) is accepted
+verbatim. A malformed override therefore fails the pod start with an
+actionable message rather than failing at first `vault.kv.*` call (or, for
+a placeholder-less value, silently collapsing every operator to one shared
+namespace).
 
 The **system/shim operator** (the Nil-UUID `tenant_id` the vault connector
 synthesises in `connector.py`, empty `raw_jwt`) is exempt even when the

--- a/docs/codebase/connectors-vault-tenant-scope.md
+++ b/docs/codebase/connectors-vault-tenant-scope.md
@@ -98,20 +98,45 @@ secrets are relocated by the operator-driven runbook
 (read → write → soft-delete via the `vault_kv_*` ops, then rewrite each
 target's `secret_ref`).
 
-## Why the guard is still opt-in (empty default)
+## The guard is default-on (as of #1725)
 
-The guard is **disabled by default** (empty prefix → `enforce_tenant_scope`
-is a no-op, behaviour is byte-for-byte pre-#1643). This is deliberate even
-with the per-tenant layout now canonical:
+The guard ships **enforced by default** with the mount-pinned prefix
+`secret/tenants/{tenant_id}/`. With the per-tenant layout now canonical
+(#1723), tenant isolation is enforced at the app layer out of the box — no
+per-deploy opt-in.
 
-The backplane homes *new* targets on `tenants/<tenant_id>/`, but a deploy
-may still hold *existing* secrets under the retired per-`sub` layout until
-the migration runbook has run. Turning on a hard tenant prefix
-unconditionally would deny every not-yet-relocated `vault.kv.*` call. A
-deploy whose secrets are all under `tenants/<tenant_id>/` (fresh, or
-post-migration) opts in by setting the env var to
-`tenants/{tenant_id}/`; a deploy mid-migration leaves it empty until every
-caller's secret is relocated.
+**Why the mount segment is in the default.** The guard matches a normalised
+`<mount>/<path>` candidate (see "The namespace convention"), and the KV-v2
+handlers default `mount="secret"` (`ops.py` `_DEFAULT_KV_MOUNT`). The
+canonical layout addresses secrets as mount `secret`, path
+`tenants/<tenant_id>/<target>`, so the candidate is
+`secret/tenants/<tenant_id>/<target>`. A *path-only* prefix
+`tenants/{tenant_id}/` would render to `tenants/<id>/` and never match that
+candidate — it would deny **every** legitimate per-tenant call. The default
+is therefore the mount-pinned `secret/tenants/{tenant_id}/`.
+
+**Migration prerequisite.** The backplane homes *new* targets on
+`tenants/<tenant_id>/`, but a deploy upgrading from a pre-#1723 release may
+still hold *existing* secrets under the retired per-`sub` layout. Until
+those are relocated by the migration runbook
+([`vault-per-tenant-migration.md`](../cross-repo/vault-per-tenant-migration.md)),
+the default-on guard would deny every not-yet-relocated `vault.kv.*` call.
+Such a deploy must **explicitly disable** the guard
+(`VAULT_KV_TENANT_SCOPE_PREFIX=""`) until the migration completes, then drop
+the override to let the default enforce. A fresh deploy (all secrets under
+`tenants/<tenant_id>/`) needs no action — the default already enforces.
+
+**Platform-path exemption.** A closed allow-list of fixed, shared,
+non-tenant platform secrets (`PLATFORM_EXEMPT_PATHS` in `tenant_scope.py`)
+is exempt regardless of operator. The only entry today is the
+federation-proof health secret `secret/meho/test/federation` that
+`GET /api/v1/health` reads under the *real* request operator's identity to
+prove the JWT→OIDC→Vault chain — it carries no tenant data and is
+provisioned shared per the Goal #11 cross-repo contract, so the default-on
+guard must not deny the platform's own probe. The exemption is an
+**exact-match** set, never a prefix or glob, so a caller cannot smuggle a
+tenant escape through it; a regression test pins it equal to the health
+route's path.
 
 The **system/shim operator** (the Nil-UUID `tenant_id` the vault connector
 synthesises in `connector.py`, empty `raw_jwt`) is exempt even when the
@@ -121,9 +146,11 @@ identity to bind against.
 
 ## Startup advisory (unenforced state is visible)
 
-Because the guard is default-off, a deploy whose Vault layout *is*
-tenant-partitioned could leave the prefix empty and never know the guard
-is silently a no-op. To make that state visible,
+Because the guard is now default-on, the advisory is **silent on the common
+deploy**. It fires only when an operator has *explicitly disabled* the guard
+(`VAULT_KV_TENANT_SCOPE_PREFIX=""`) — e.g. while still mid-migration with
+secrets under the retired per-`sub` layout — so that running unenforced is
+never silent.
 [`main._advise_vault_tenant_scope_unenforced`](../../backend/src/meho_backplane/main.py)
 runs in the FastAPI lifespan and emits **exactly one** structured advisory
 at startup when `vault_kv_tenant_scope_prefix` is empty:
@@ -133,58 +160,63 @@ vault_tenant_scope_unenforced  enable_via=VAULT_KV_TENANT_SCOPE_PREFIX  doc=docs
 ```
 
 It is **observability-only** — loud-but-non-fatal, like the embedding
-preload advisory: no dispatch change, no raise, the default is not flipped.
-A deploy that relies solely on the per-`sub` Vault policy can ignore the
-line; a tenant-partitioned deploy treats it as the cue to set the prefix
-(see "Choosing a layout"). Once the prefix is set the advisory is silent.
-The behaviour is covered by
+preload advisory: no dispatch change, no raise. A deploy that has
+deliberately opted out (mid-migration) can ignore the line; otherwise it is
+the cue that tenant isolation is not being enforced at the app layer. Once
+the prefix is restored to a non-empty value (or left at the default) the
+advisory is silent. The behaviour is covered by
 [`backend/tests/test_vault_tenant_scope_advisory.py`](../../backend/tests/test_vault_tenant_scope_advisory.py)
-(fires unset, silent when set, never blocks boot).
+(silent on default, silent when set, fires when explicitly emptied, never
+blocks boot).
 
 ## Choosing a layout
 
-Which Vault KV layout you run determines whether this guard does anything.
-It is a deploy/infra decision, **not** a backplane default — the backplane
-ships the prefix empty (#1673 only surfaces and documents the choice; it
-does not make it):
+The guard is default-on (`secret/tenants/{tenant_id}/`), matching the
+canonical per-tenant layout. The only deploy that needs to touch the prefix
+is one still holding secrets under the retired per-`sub` layout:
+
+- **Per-tenant layout (canonical since #1723; guard default-on).** Secrets
+  are partitioned by tenant under `tenants/<tenant_id>/<target>` on the
+  default `secret` mount. New targets land here automatically; existing
+  per-`sub` secrets are moved by the migration runbook. The default-on guard
+  is a real backstop for a mis-provisioned Vault policy — **no action
+  required** (leave `VAULT_KV_TENANT_SCOPE_PREFIX` unset).
 
 - **Per-`sub` layout (retired; pre-#1723 deploys mid-migration).** Secrets
   live under `secret/data/targets/<sub>/*` and isolation is enforced
   entirely by the templated `meho-mcp` Vault policy
   (`connector-vault-policy.md` §2). There is no `tenant-<id>/` partition to
-  bind against, so the prefix stays **empty** and the app-layer guard is
-  intentionally a no-op. The startup advisory fires; for this layout it is
-  expected and can be ignored. Keep the policy template correct — it is the
-  primary (and only) gate here. Relocate to the per-tenant layout via
-  [`vault-per-tenant-migration.md`](../cross-repo/vault-per-tenant-migration.md).
+  bind against, so the default-on guard would deny every not-yet-relocated
+  call. **Explicitly disable** the guard with
+  `VAULT_KV_TENANT_SCOPE_PREFIX=""` until the migration runbook has run; the
+  startup advisory fires to keep that unenforced state visible. Keep the
+  policy template correct — it is the primary (and only) gate while the
+  guard is disabled. Relocate to the per-tenant layout via
+  [`vault-per-tenant-migration.md`](../cross-repo/vault-per-tenant-migration.md),
+  then drop the override.
 
-- **Per-tenant layout (canonical since #1723; opt-in guard).** Secrets are
-  partitioned by tenant under `tenants/<tenant_id>/<target>` (path prefix)
-  or, for a mount-pinned deploy, `secret/tenant-<tenant_id>/...`. New
-  targets land here automatically; existing per-`sub` secrets are moved by
-  the migration runbook. Once every secret is under the prefix, the
-  app-layer guard becomes a real backstop for a mis-provisioned policy, so
-  you **enable** it (`tenants/{tenant_id}/`).
+**The active (default) prefix and its preconditions:**
 
-**Enabling the prefix requires all of:**
-
-1. A Vault KV layout actually partitioned by `tenant_id` (mount or path) —
-   the prefix only denies; it never relocates secrets.
-2. Setting `VAULT_KV_TENANT_SCOPE_PREFIX` to the matching `str.format`
-   template with a single `{tenant_id}` placeholder, e.g.
-   `tenant-{tenant_id}/` (path prefix) or `secret/tenant-{tenant_id}/`
-   (mount-pinned). The rendered `tenant_id` is the canonical dashed
-   lowercase UUID (see "The namespace convention").
-3. Confirming every legitimate `vault.kv.*` caller's secrets already live
-   **under** that prefix — once set, any in-namespace mismatch is denied
-   with `exception_class=VaultTenantScopeError` *before* the hvac call.
-   The system/shim operator (Nil-UUID tenant, `vault.sys.health` only) is
-   exempt, so enabling the prefix does not break the health probe.
+1. The canonical Vault KV layout is per-tenant: mount `secret`, path
+   `tenants/<tenant_id>/<target>`. The prefix only denies; it never
+   relocates secrets.
+2. The default `VAULT_KV_TENANT_SCOPE_PREFIX` is the mount-pinned
+   `secret/tenants/{tenant_id}/` — a `str.format` template with a single
+   `{tenant_id}` placeholder. The mount segment is required because the
+   guard matches a normalised `<mount>/<path>` candidate on the default
+   `secret` mount; a path-only `tenants/{tenant_id}/` would never match and
+   would deny every legitimate call. The rendered `tenant_id` is the
+   canonical dashed lowercase UUID (see "The namespace convention").
+3. Every legitimate `vault.kv.*` caller's secrets must already live
+   **under** that prefix — any in-namespace mismatch is denied with
+   `exception_class=VaultTenantScopeError` *before* the hvac call. The
+   system/shim operator (Nil-UUID tenant, `vault.sys.health` only) is
+   exempt, so the default does not break the health probe.
 
 Because step 3 denies every per-`sub` call that is *not* under a
-`tenant-<id>/` prefix, flipping this on against the shipped per-`sub`
-layout would break dispatch — which is exactly why the default is empty
-and the switch is left to the operator.
+`tenants/<id>/` prefix, a deploy still on the retired per-`sub` layout must
+disable the guard until its secrets are relocated — which is exactly what
+the `VAULT_KV_TENANT_SCOPE_PREFIX=""` opt-out is for.
 
 ## Scope notes
 

--- a/docs/cross-repo/vault-per-tenant-migration.md
+++ b/docs/cross-repo/vault-per-tenant-migration.md
@@ -31,8 +31,9 @@ Two consequences:
   tenant-partitioned layout to enforce against, so it shipped opt-in.
 
 The per-tenant layout fixes both: one secret per `(tenant, target)`,
-readable by every operator in that tenant, under a path the guard can
-enforce with `VAULT_KV_TENANT_SCOPE_PREFIX="tenants/{tenant_id}/"`.
+readable by every operator in that tenant, under a path the guard now
+enforces **by default** (#1725) with the mount-pinned
+`VAULT_KV_TENANT_SCOPE_PREFIX="secret/tenants/{tenant_id}/"`.
 
 ## The new convention
 
@@ -158,14 +159,28 @@ Or pass `delete_old=True` to `relocate_target_secret` in step 1 to do the
 read → write → soft-delete in one call **after** you have verified the new
 path resolves.
 
-## Enabling the guard (after migration)
+## The guard is default-on (disable while mid-migration)
 
-Once all of a tenant's secrets live under `tenants/<tenant_id>/`, the
-deploy can flip the #1643 guard default-on by setting:
+As of #1725 the #1643 guard is **enforced by default** with the
+mount-pinned prefix:
 
 ```text
-VAULT_KV_TENANT_SCOPE_PREFIX=tenants/{tenant_id}/
+VAULT_KV_TENANT_SCOPE_PREFIX=secret/tenants/{tenant_id}/
 ```
+
+The mount segment is required: the guard matches a normalised
+`<mount>/<path>` candidate and these secrets sit on the default `secret`
+mount, so a path-only `tenants/{tenant_id}/` would deny every legitimate
+per-tenant call. While a deploy still holds secrets under the retired
+per-`sub` layout, **disable** the guard until the migration completes:
+
+```text
+VAULT_KV_TENANT_SCOPE_PREFIX=
+```
+
+Once every legitimate `vault.kv.*` caller's secrets are under
+`tenants/<tenant_id>/`, drop the override and let the default-on guard
+enforce.
 
 See
 [`connectors-vault-tenant-scope.md`](../codebase/connectors-vault-tenant-scope.md)


### PR DESCRIPTION
## Summary

- Flips the #1643 Vault tenant-scope guard to **default-on**: agent-supplied `vault.kv.*` calls are confined to the calling operator's tenant namespace out of the box (no per-deploy opt-in), now that the per-tenant layout (#1723) and templated policies (#1724) are merged.
- Default `VAULT_KV_TENANT_SCOPE_PREFIX` is the **mount-pinned** `secret/tenants/{tenant_id}/` (set in both the `Settings` field default and the `get_settings()` env-parse fallback).
- Inverts the startup advisory framing: `vault_tenant_scope_unenforced` is silent on the default config and fires only when an operator explicitly empties the prefix (the runtime guard `if not prefix` was already correct; the docstring + tests now match).
- Corrects stale path-only references left by #1723 (`tenant_paths.py`, the tenant-scope doc, and the migration runbook) to the mount-pinned value; doc now states the guard is "default-on as of this release" with the migration prerequisite called out.
- Adds a **platform-path exemption** (`PLATFORM_EXEMPT_PATHS`, closed exact-match allow-list) so the federation-proof health read (`secret/meho/test/federation`, `GET /api/v1/health`) — a shared non-tenant secret read under the real operator identity — is not denied once the guard enforces by default. Without it, default-on would 200-with-`read_failed` every `/api/v1/health` call. A regression test pins the set equal to the health route's path.

## Deviation from the ticket (important)

Deviates from the ticket's literal default `tenants/{tenant_id}/` — that path-only value would deny all per-tenant calls; using the mount-pinned `secret/tenants/{tenant_id}/` (verified against the `<mount>/<path>` guard + default `secret` mount). Also corrects stale path-only references introduced by #1723.

The guard (`tenant_scope.py::_normalised_logical_path`) builds its match candidate as `<mount>/<path>`, and the KV-v2 handlers default `mount="secret"` (`ops.py` `_DEFAULT_KV_MOUNT`). The canonical #1723 layout addresses secrets as mount `secret`, path `tenants/<id>/<target>`, so the candidate is `secret/tenants/<id>/<target>`. A path-only prefix renders to `tenants/<id>/` and never matches that candidate — it would DENY every legitimate per-tenant call. Verified empirically (see Test plan). This deviation was raised as a Phase-4 pushback on attempt 1, independently verified by the orchestrator, and is the corrected spec implemented here.

## Test plan

- [x] Empirical allow/deny with the new default (no env override): default prefix is `secret/tenants/{tenant_id}/`; a call (mount=`secret`, path=`tenants/<A>/foo`) is **ALLOWED**; a cross-tenant path (`tenants/<B>/foo`) is **DENIED**; the system Nil-UUID tenant remains **exempt**.
- [x] `uv run ruff check src/ tests/` — clean
- [x] `uv run ruff format --check src/ tests/` — clean (967 files)
- [x] `uv run mypy src/` — Success: no issues in 473 files
- [x] `pytest tests/test_connectors_vault_tenant_scope.py tests/test_vault_tenant_scope_advisory.py tests/test_connectors_vault_tenant_paths.py` — 35 passed (new default-config allow/deny/exempt tests; advisory silent-on-default + fires-when-emptied; relocation fixture now sets `VAULT_KV_TENANT_SCOPE_PREFIX=""` to exercise the documented migration window)
- [x] Full backend `pytest` — green (the one pre-existing teardown-only ERROR in `test_preflight_fail_soft_when_probe_raises` reproduces unchanged on clean `origin/main`; the topology depth-16 perf integration test is a known CI flake)
- [x] OpenAPI snapshot unchanged — a settings-default change touches no FastAPI route/schema and the setting is not an OpenAPI field; no `make snapshot-openapi` regen needed.

## Out of scope

- Path migration (#1723) and policy authoring (#1724) — prerequisites, already merged.
- Release-notify ops (#1685 T4) — already done.

<!-- auto-implement-issue: fresh, iteration 1 -->

Closes #1725


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **Security**
  * Vault tenant-scope guard for KV secret calls is now enabled by default, enforcing per-tenant isolation with the `secret/tenants/{tenant_id}/` path structure.
  * Operators can disable during migration by setting `VAULT_KV_TENANT_SCOPE_PREFIX=""`.
  * Health checks and platform paths remain exempt.

* **Documentation**
  * Updated migration runbook and internal documentation to reflect new default-on behavior.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->

---

## Follow-up (auto-implement-issue, iteration 2, 2026-06-13)

Addressed the iteration-1 review punch list (`a360d886`):

- **B1** `a360d886` — fixed the default-on regression on the G0.8 vault e2e
  acceptance read (`VAULT_KV_TENANT_SCOPE_PREFIX=""` in the fixture); swept
  the suite and applied the same fix to the `test_connectors_vault_dev_e2e`
  integration suite (also reads/writes legacy `secret`-mount paths under a
  real tenant). Full backend pytest green (7482 passed, 416 skipped).
- **M1** `a360d886` — scoped `PLATFORM_EXEMPT_PATHS` to read-only verbs via
  a required `read_only` arg on `enforce_tenant_scope`; write/delete to the
  shared platform path under a non-owning operator is now denied. Unit +
  dispatch-level regression tests added.
- **M2** `a360d886` — added a pydantic field validator on
  `vault_kv_tenant_scope_prefix` rejecting malformed/placeholder-less
  templates at construction; tests cover the valid default + malformed cases.

<!-- auto-implement-issue: continue, iteration 2 -->