### PR TITLE
test(broadcast): pin empty VAULT_KV_TENANT_SCOPE_PREFIX in credential-dispatch fixtures (#1741)

### DIFF
--- a/backend/tests/test_broadcast_credential_read_dispatch.py
+++ b/backend/tests/test_broadcast_credential_read_dispatch.py
@@ -72,7 +72,8 @@ import pytest
 import meho_backplane.operations._audit as audit_module
 from meho_backplane.auth.operator import Operator, TenantRole
 from meho_backplane.broadcast import BroadcastEvent
-from meho_backplane.connectors.registry import clear_registry
+from meho_backplane.connectors.registry import clear_registry, register_connector_v2
+from meho_backplane.connectors.vault import VaultConnector
 from meho_backplane.connectors.vault.ops import register_vault_typed_operations
 from meho_backplane.connectors.vault.ops_sys import (
     register_vault_sys_typed_operations,
@@ -154,6 +155,16 @@ def _required_settings_env(monkeypatch: pytest.MonkeyPatch) -> Iterator[None]:
     monkeypatch.setenv("KEYCLOAK_ISSUER_URL", "https://keycloak.test/realms/meho")
     monkeypatch.setenv("KEYCLOAK_AUDIENCE", "meho-backplane")
     monkeypatch.setenv("VAULT_ADDR", "https://vault.test")
+    # The default-on tenant-scope guard (#1725) pins KV calls under
+    # ``secret/tenants/{tenant_id}/``. These tests dispatch against the
+    # ``_SENTINEL_MOUNT`` sentinel mount under a real operator tenant to
+    # exercise the credential-classifier path, not tenant isolation
+    # (covered by ``test_connectors_vault_tenant_scope.py``). The sentinel
+    # path is not under ``secret/tenants/<id>/``, so the guard would deny
+    # it with VaultTenantScopeError once Redis is present. Disable the
+    # guard explicitly — matching the empty-prefix pin the #1725 PR used
+    # for its e2e fixtures.
+    monkeypatch.setenv("VAULT_KV_TENANT_SCOPE_PREFIX", "")
     get_settings.cache_clear()
     yield
     get_settings.cache_clear()
@@ -161,9 +172,20 @@ def _required_settings_env(monkeypatch: pytest.MonkeyPatch) -> Iterator[None]:
 
 @pytest.fixture(autouse=True)
 def _reset_module_state() -> Iterator[None]:
-    """Reset dispatcher caches + connector registry around every test."""
+    """Reset dispatcher caches + connector registry around every test.
+
+    Registers the v2 ``vault`` connector entry after the setup clear so
+    the dispatcher's natural-key resolution finds an implementation for
+    ``connector_id="vault-1.x"`` — the per-test
+    ``register_vault_typed_operations`` call only upserts the typed-op
+    *descriptor* rows, not the connector *class*, and connector
+    resolution is a hard gate before the handler runs (``no_connector``
+    otherwise). Mirrors the ``_registered_vault_substrate`` fixture in
+    ``test_api_v1_health.py``.
+    """
     reset_dispatcher_caches()
     clear_registry()
+    register_connector_v2(product="vault", version="1.x", impl_id="vault", cls=VaultConnector)
     yield
     reset_dispatcher_caches()
     clear_registry()

--- a/backend/tests/test_broadcast_credential_write_dispatch.py
+++ b/backend/tests/test_broadcast_credential_write_dispatch.py
@@ -64,6 +64,16 @@ def _required_settings_env(monkeypatch: pytest.MonkeyPatch) -> Iterator[None]:
     monkeypatch.setenv("KEYCLOAK_ISSUER_URL", "https://keycloak.test/realms/meho")
     monkeypatch.setenv("KEYCLOAK_AUDIENCE", "meho-backplane")
     monkeypatch.setenv("VAULT_ADDR", "https://vault.test")
+    # The default-on tenant-scope guard (#1725) pins KV calls under
+    # ``secret/tenants/{tenant_id}/``. This test dispatches a
+    # ``vault.kv.write`` against a sentinel mount under a real operator
+    # tenant to exercise the credential-classifier redaction path, not
+    # tenant isolation (covered by ``test_connectors_vault_tenant_scope.py``).
+    # The sentinel path is not under ``secret/tenants/<id>/``, so the guard
+    # would deny it with VaultTenantScopeError once Redis is present.
+    # Disable the guard explicitly — matching the empty-prefix pin the
+    # #1725 PR used for its e2e fixtures.
+    monkeypatch.setenv("VAULT_KV_TENANT_SCOPE_PREFIX", "")
     get_settings.cache_clear()
     yield
     get_settings.cache_clear()


### PR DESCRIPTION
## Summary
- Pin `VAULT_KV_TENANT_SCOPE_PREFIX=""` in the autouse `_required_settings_env` fixtures of both broadcast credential-dispatch tests so the now-default-on Vault tenant-scope guard (#1725) does not deny their sentinel-mount dispatch when Redis is present.
- These tests exercise the broadcast credential-classifier / redaction path, not tenant isolation (covered by `test_connectors_vault_tenant_scope.py`); they deliberately dispatch against a sentinel mount under a real operator tenant, so the empty-prefix pin is the minimal, intent-preserving fix — matching the precedent the #1725 PR used for its e2e fixtures.
- Also registers the `vault` v2 connector entry in the read test's `_reset_module_state` fixture: a separate latent setup gap (masked by the same `BROADCAST_REDIS_URL` skip) meant dispatch failed `no_connector` before ever reaching the guard. Mirrors the `_registered_vault_substrate` fixture in `test_api_v1_health.py`. Without it AC2 ("confirm `result_status == "ok"` with Redis present") cannot be proven.

## Test plan
- [x] `uv run ruff check src/ tests/` — clean (the 8 pre-existing `dev/seed_demo.py` findings are out of CI scope — CI runs `ruff check src/ tests/`)
- [x] `uv run ruff format --check src/ tests/` — clean
- [x] `uv run mypy src/` — Success, no issues in 473 files
- [x] `BROADCAST_REDIS_URL=… uv run pytest tests/test_broadcast_credential_read_dispatch.py` — 4 passed (publisher is stubbed; no real Valkey connection opens)
- [x] `BROADCAST_REDIS_URL=… uv run pytest tests/test_broadcast_credential_write_dispatch.py` — 4 passed
- [x] Guard proven load-bearing: removing the prefix pin makes the read test fail with `connector_error: VaultTenantScopeError`; restoring it passes.
- [x] Grep: no other top-level (non-`tests/integration/`) test dispatches the real `vault.kv.*` handler on a non-`tenants/` `secret`-mount path under a real (non-Nil) operator without pinning the empty prefix.
- [x] Full backend unit suite (`pytest --dist loadscope --ignore=tests/integration`) green.
- No FastAPI route/schema change → CLI OpenAPI snapshot unaffected (only two test files touched).

## Out of scope
- The guard, the default prefix, and `PLATFORM_EXEMPT_PATHS` — all correct as shipped in #1725, unchanged.
- Relocating the sentinel mount onto a `tenants/<id>/` layout — the tests deliberately use a sentinel mount to exercise the classifier.

<!-- auto-implement-issue: fresh, iteration 1 -->

Closes #1741
