### PR TITLE
fix(knowledge): map corpus-http adapter to MEHO.Knowledge /search contract (#1732)

### DIFF
--- a/backend/src/meho_backplane/auth/corpus.py
+++ b/backend/src/meho_backplane/auth/corpus.py
@@ -49,7 +49,7 @@ from urllib.parse import urlsplit, urlunsplit
 
 import httpx
 import structlog
-from pydantic import BaseModel, ConfigDict, Field
+from pydantic import AliasChoices, BaseModel, ConfigDict, Field
 
 from meho_backplane.auth.operator import Operator
 from meho_backplane.settings import get_settings
@@ -85,6 +85,36 @@ class CorpusUnavailable(RuntimeError):  # noqa: N818 -- "Unavailable" reads bett
         super().__init__(message)
 
 
+def _parse_2xx_body[ModelT: BaseModel](
+    response: httpx.Response,
+    model: type[ModelT],
+    *,
+    event_prefix: str,
+) -> ModelT:
+    """Decode a 2xx corpus response body and validate it against *model*.
+
+    Both fail-closed branches map to one :class:`CorpusUnavailable` so the
+    consuming route renders a single 503: a non-JSON body and a body that
+    does not match the model (a dropped/renamed consumed field, or — for
+    :class:`CorpusSearchResponse` — an unrecognised envelope that names
+    neither ``chunks`` nor ``results``, #1732). Neither the raw body nor
+    the validation error detail is echoed, so a corpus error page or a
+    leaky field value cannot ride out through the 503. *event_prefix*
+    namespaces the structlog event (``corpus`` vs ``corpus_status``).
+    """
+    try:
+        body: Any = response.json()
+    except ValueError as exc:
+        _log.warning(f"{event_prefix}_response_not_json")
+        raise CorpusUnavailable("corpus returned a non-JSON body") from exc
+
+    try:
+        return model.model_validate(body)
+    except ValueError as exc:
+        _log.warning(f"{event_prefix}_response_invalid_schema")
+        raise CorpusUnavailable("corpus response did not match the expected schema") from exc
+
+
 class CorpusChunk(BaseModel):
     """One cited chunk returned by the external corpus.
 
@@ -97,14 +127,26 @@ class CorpusChunk(BaseModel):
     result. ``metadata`` keeps the corpus's per-chunk attributes (e.g.
     ``product`` / ``version`` the T3 filters key off) without MEHO
     having to model every one.
+
+    The text and source-link fields each accept **two** wire names via a
+    validation alias (#1732): MEHO.Knowledge's ``/search`` returns
+    ``text`` / ``source_uri`` while an earlier corpus shape (and MEHO's
+    own internal projection) uses ``content`` / ``source_url``. Accepting
+    both keeps the one consumed name (``content`` / ``source_url``) stable
+    for downstream callers regardless of which wire dialect the corpus
+    speaks. ``populate_by_name=True`` keeps the internal name usable when
+    constructing the model directly in tests.
     """
 
-    model_config = ConfigDict(frozen=True, extra="ignore")
+    model_config = ConfigDict(frozen=True, extra="ignore", populate_by_name=True)
 
     chunk_id: str
     document_id: str
-    content: str
-    source_url: str | None = None
+    content: str = Field(validation_alias=AliasChoices("content", "text"))
+    source_url: str | None = Field(
+        default=None,
+        validation_alias=AliasChoices("source_url", "source_uri"),
+    )
     score: float | None = None
     metadata: dict[str, Any] = Field(default_factory=dict)
 
@@ -115,11 +157,22 @@ class CorpusSearchResponse(BaseModel):
     Frozen adapter; ``chunks`` is the ordered hit list (best first, as
     the corpus ranks them). The consuming route (T3) projects these into
     MEHO's own cited-chunk surface and binds the central audit row.
+
+    The hit list accepts **two** envelope names via a validation alias
+    (#1732): MEHO.Knowledge's ``/search`` returns ``{"results": [...]}``
+    while an earlier corpus shape (and MEHO's own internal projection)
+    uses ``{"chunks": [...]}``. The field is **required** — it carries no
+    default — so a 2xx body that names *neither* envelope fails parse
+    loudly (surfaced as :class:`CorpusUnavailable`) rather than silently
+    validating to an empty hit list. That fail-loud posture is the whole
+    point of #1732: a populated corpus returning an unrecognised envelope
+    must not read back as "zero hits". ``populate_by_name=True`` keeps the
+    internal ``chunks`` name usable when constructing the model directly.
     """
 
-    model_config = ConfigDict(frozen=True, extra="ignore")
+    model_config = ConfigDict(frozen=True, extra="ignore", populate_by_name=True)
 
-    chunks: list[CorpusChunk] = Field(default_factory=list)
+    chunks: list[CorpusChunk] = Field(validation_alias=AliasChoices("chunks", "results"))
 
 
 async def search_corpus(
@@ -175,7 +228,11 @@ async def search_corpus(
         raise CorpusUnavailable("corpus_url is not configured")
     resolved_audience = audience if audience is not None else settings.corpus_audience
 
-    payload: dict[str, Any] = {"query": query, "limit": limit}
+    # MEHO.Knowledge's ``/search`` reads ``top_k`` for the hit cap and
+    # silently ignores ``limit`` (#1732) — sending ``limit`` let the
+    # corpus fall back to its server-side default. Send the key the corpus
+    # actually honours so ``limit`` reaches it.
+    payload: dict[str, Any] = {"query": query, "top_k": limit}
     if metadata_filters:
         payload["metadata_filters"] = metadata_filters
     if resolved_audience:
@@ -204,43 +261,46 @@ async def search_corpus(
             status=response.status_code,
         )
 
-    try:
-        body: Any = response.json()
-    except ValueError as exc:
-        # A 2xx with a non-JSON body is a broken corpus contract —
-        # fail closed rather than leaking a raw JSONDecodeError.
-        _log.warning("corpus_response_not_json")
-        raise CorpusUnavailable("corpus returned a non-JSON body") from exc
-
-    try:
-        return CorpusSearchResponse.model_validate(body)
-    except ValueError as exc:
-        # Schema drift (a consumed field dropped / wrong type) is also a
-        # broken contract; fail closed without echoing the payload.
-        _log.warning("corpus_response_invalid_schema")
-        raise CorpusUnavailable("corpus response did not match the expected schema") from exc
+    return _parse_2xx_body(response, CorpusSearchResponse, event_prefix="corpus")
 
 
 class CorpusStatusResponse(BaseModel):
     """Parsed corpus readiness response — the liveness the probe reads back.
 
-    The consumer-side adapter over the corpus's ``/status`` contract (the
-    readiness sibling of :class:`CorpusSearchResponse`). The probe Task
-    (T6 #1555) reads ``index_built`` / ``doc_count`` / ``last_ingested_at``
-    here and the collection-probe route persists them onto the
-    ``doc_collections`` row on success. ``extra="ignore"`` absorbs corpus
-    fields MEHO does not consume; a dropped consumed field fails parse
-    rather than silently degrading — surfaced as :class:`CorpusUnavailable`.
+    The consumer-side adapter over the corpus's readiness endpoint. The
+    probe Task (T6 #1555) reads ``index_built`` / ``doc_count`` /
+    ``last_ingested_at`` here and the collection-probe route persists them
+    onto the ``doc_collections`` row on success. ``extra="ignore"`` absorbs
+    corpus fields MEHO does not consume.
 
     ``index_built`` is the managed-RAG footgun: ``False`` means the corpus
     is reachable but its ANN index is not yet answerable (a rebuild is in
     flight, or the corpus was registered but never ingested), so the
     search path can fail typed instead of returning an empty 200. Frozen.
+
+    Readiness wire shape (#1732). MEHO.Knowledge has **no** ``/status``
+    route; it exposes ``GET /readyz`` returning a ``HealthResponse`` whose
+    200 *is* the "ready" signal — it need not carry an ``index_built``
+    field. So this adapter:
+
+    * accepts ``index_built`` under any of ``index_built`` / ``ready`` /
+      ``index_ready`` (the names a health body may use), and
+    * **defaults it to ``True``** — a corpus that answers its readiness
+      probe with a 2xx and no explicit readiness flag is treated as
+      answerable. A corpus that wants to advertise an in-flight rebuild
+      still can, by returning the flag set ``False``.
+
+    ``doc_count`` / ``last_ingested_at`` stay optional liveness, populated
+    only when the health body carries them. ``populate_by_name=True`` keeps
+    the canonical names usable when constructing the model directly.
     """
 
-    model_config = ConfigDict(frozen=True, extra="ignore")
+    model_config = ConfigDict(frozen=True, extra="ignore", populate_by_name=True)
 
-    index_built: bool
+    index_built: bool = Field(
+        default=True,
+        validation_alias=AliasChoices("index_built", "ready", "index_ready"),
+    )
     doc_count: int | None = None
     last_ingested_at: datetime | None = None
 
@@ -248,21 +308,17 @@ class CorpusStatusResponse(BaseModel):
 def derive_status_url(search_url: str) -> str:
     """Derive the corpus readiness URL from its *search_url*.
 
-    The corpus exposes its readiness check as a sibling of the search
-    endpoint: the final path segment ``search`` is swapped for ``status``
-    (``https://corpus/v1/search`` → ``https://corpus/v1/status``). A URL
-    whose final segment is not ``search`` gets ``status`` appended as a
-    child segment so an unconventional layout still resolves to a single
-    deterministic readiness URL. Query string and fragment are dropped —
-    they are search-request shape, never part of the status endpoint.
+    MEHO.Knowledge exposes its readiness as ``GET /readyz`` at the service
+    root (no ``/status`` route, #1732), so the readiness URL is the search
+    URL's **host root** plus ``/readyz``
+    (``https://corpus/v1/search`` → ``https://corpus/readyz``). Anchoring
+    at the root rather than swapping the final path segment matches a
+    health endpoint that lives beside the API version prefix, not inside
+    it. Query string and fragment are dropped — they are search-request
+    shape, never part of the readiness endpoint.
     """
     parts = urlsplit(search_url)
-    path = parts.path.rstrip("/")
-    if path.rsplit("/", 1)[-1] == "search":
-        new_path = path[: -len("search")] + "status"
-    else:
-        new_path = f"{path}/status"
-    return urlunsplit((parts.scheme, parts.netloc, new_path, "", ""))
+    return urlunsplit((parts.scheme, parts.netloc, "/readyz", "", ""))
 
 
 async def corpus_status(
@@ -326,14 +382,4 @@ async def corpus_status(
             status=response.status_code,
         )
 
-    try:
-        body: Any = response.json()
-    except ValueError as exc:
-        _log.warning("corpus_status_response_not_json")
-        raise CorpusUnavailable("corpus returned a non-JSON body") from exc
-
-    try:
-        return CorpusStatusResponse.model_validate(body)
-    except ValueError as exc:
-        _log.warning("corpus_status_response_invalid_schema")
-        raise CorpusUnavailable("corpus status response did not match the expected schema") from exc
+    return _parse_2xx_body(response, CorpusStatusResponse, event_prefix="corpus_status")

--- a/backend/tests/test_corpus_client.py
+++ b/backend/tests/test_corpus_client.py
@@ -114,19 +114,25 @@ async def test_forwards_bearer_jwt_and_posts_query(monkeypatch: pytest.MonkeyPat
     """The client POSTs to corpus_url with Authorization: Bearer <raw_jwt>."""
     _pin_settings(monkeypatch, corpus_url=_CORPUS_URL)
     captured: list[httpx.Request] = []
+    # MEHO.Knowledge's actual /search wire shape (#1732): a ``results``
+    # envelope of chunks whose text/source-link fields are ``text`` /
+    # ``source_uri``. The adapter must read real hits from this body.
     response = httpx.Response(
         200,
         json={
-            "chunks": [
+            "query": "supervisor cluster",
+            "results": [
                 {
                     "chunk_id": "c1",
                     "document_id": "d1",
-                    "content": "vSphere 9.0 supervisor cluster setup.",
-                    "source_url": "https://docs.example/vsphere",
+                    "text": "vSphere 9.0 supervisor cluster setup.",
+                    "source_uri": "https://docs.example/vsphere",
                     "score": 0.91,
                     "metadata": {"product": "vmware", "version": "9.0"},
                 }
-            ]
+            ],
+            "took_ms": 12,
+            "score_kind": "cosine",
         },
     )
     transport = _transport_capturing(captured, response)
@@ -137,6 +143,10 @@ async def test_forwards_bearer_jwt_and_posts_query(monkeypatch: pytest.MonkeyPat
     assert isinstance(result, CorpusSearchResponse)
     assert len(result.chunks) == 1
     assert result.chunks[0].chunk_id == "c1"
+    # The corpus's ``text`` / ``source_uri`` map onto the consumed
+    # ``content`` / ``source_url`` names downstream callers read.
+    assert result.chunks[0].content == "vSphere 9.0 supervisor cluster setup."
+    assert result.chunks[0].source_url == "https://docs.example/vsphere"
     assert result.chunks[0].metadata == {"product": "vmware", "version": "9.0"}
 
     sent = captured[0]
@@ -147,7 +157,9 @@ async def test_forwards_bearer_jwt_and_posts_query(monkeypatch: pytest.MonkeyPat
 
     body = json.loads(sent.content.decode())
     assert body["query"] == "supervisor cluster"
-    assert body["limit"] == 5
+    # The corpus reads ``top_k``, not ``limit`` (#1732).
+    assert body["top_k"] == 5
+    assert "limit" not in body
 
 
 @pytest.mark.asyncio
@@ -269,6 +281,70 @@ async def test_schema_drift_fails_closed(monkeypatch: pytest.MonkeyPatch) -> Non
 
 
 @pytest.mark.asyncio
+async def test_results_envelope_with_text_fields_returns_real_hits(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """A populated {results:[…]} 200 returns real hits, not zero (#1732).
+
+    The regression for the original SEV-2: a healthy corpus returning five
+    hits under the ``results`` envelope (with ``text`` / ``source_uri``
+    fields) was parsed to an empty hit list, so the consumer saw "no docs
+    hits" for a populated corpus. The hits must come through with their
+    text and source link mapped onto the consumed names.
+    """
+    _pin_settings(monkeypatch, corpus_url=_CORPUS_URL)
+    response = httpx.Response(
+        200,
+        json={
+            "query": "NSX edge node sizing",
+            "results": [
+                {
+                    "chunk_id": f"c{i}",
+                    "document_id": f"d{i}",
+                    "text": f"hit {i} body",
+                    "source_uri": f"https://docs.example/{i}",
+                    "score": 1.0 - i / 10,
+                }
+                for i in range(5)
+            ],
+            "took_ms": 9,
+            "score_kind": "cosine",
+        },
+    )
+    _patch_async_client(monkeypatch, _transport_capturing([], response), [])
+
+    result = await search_corpus(_make_operator(), "NSX edge node sizing", limit=3)
+
+    assert len(result.chunks) == 5
+    assert result.chunks[0].content == "hit 0 body"
+    assert result.chunks[0].source_url == "https://docs.example/0"
+
+
+@pytest.mark.asyncio
+async def test_unrecognized_envelope_fails_loud_not_zero(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """A 2xx whose body names neither ``chunks`` nor ``results`` fails loud (#1732).
+
+    The dangerous silent-zero the old ``chunks: [] = default`` shape
+    produced: a successful response carrying an unrecognised envelope must
+    raise :class:`CorpusUnavailable` (→ 503), never parse to an empty hit
+    list that reads as "no docs hits" from a healthy corpus.
+    """
+    _pin_settings(monkeypatch, corpus_url=_CORPUS_URL)
+    transport = _transport_capturing(
+        [],
+        # A 200 with hits under an unrecognised key — the exact silent-zero
+        # shape #1732 is about.
+        httpx.Response(200, json={"query": "q", "hits": [{"chunk_id": "c"}], "took_ms": 3}),
+    )
+    _patch_async_client(monkeypatch, transport, [])
+
+    with pytest.raises(CorpusUnavailable):
+        await search_corpus(_make_operator(), "q")
+
+
+@pytest.mark.asyncio
 async def test_forwarded_jwt_never_logged(monkeypatch: pytest.MonkeyPatch) -> None:
     """The forwarded operator JWT must not appear in any structlog event."""
     _pin_settings(monkeypatch, corpus_url=_CORPUS_URL)
@@ -292,14 +368,16 @@ async def test_forwarded_jwt_never_logged(monkeypatch: pytest.MonkeyPatch) -> No
 @pytest.mark.parametrize(
     ("search_url", "expected"),
     [
-        ("https://corpus.test/v1/search", "https://corpus.test/v1/status"),
-        ("https://corpus.test/v1/search/", "https://corpus.test/v1/status"),
-        ("https://corpus.test/corpus", "https://corpus.test/corpus/status"),
-        ("https://corpus.test/search?x=1", "https://corpus.test/status"),
+        # The readiness URL is the search URL's host root + /readyz (#1732):
+        # MEHO.Knowledge exposes /readyz, not a /status sibling.
+        ("https://corpus.test/v1/search", "https://corpus.test/readyz"),
+        ("https://corpus.test/v1/search/", "https://corpus.test/readyz"),
+        ("https://corpus.test/corpus", "https://corpus.test/readyz"),
+        ("https://corpus.test/search?x=1", "https://corpus.test/readyz"),
     ],
 )
 def test_derive_status_url(search_url: str, expected: str) -> None:
-    """The readiness URL is the search URL with its tail swapped to status."""
+    """The readiness URL is the search URL's host root plus /readyz."""
     assert derive_status_url(search_url) == expected
 
 
@@ -307,7 +385,7 @@ def test_derive_status_url(search_url: str, expected: str) -> None:
 async def test_corpus_status_gets_status_url_with_bearer(
     monkeypatch: pytest.MonkeyPatch,
 ) -> None:
-    """corpus_status GETs the derived status URL forwarding the operator JWT."""
+    """corpus_status GETs the derived /readyz URL forwarding the operator JWT."""
     _pin_settings(monkeypatch, corpus_url=_CORPUS_URL)
     captured: list[httpx.Request] = []
     response = httpx.Response(
@@ -330,6 +408,40 @@ async def test_corpus_status_gets_status_url_with_bearer(
     assert captured[0].method == "GET"
     assert str(captured[0].url) == derive_status_url(_CORPUS_URL)
     assert captured[0].headers["Authorization"] == f"Bearer {_JWT}"
+
+
+@pytest.mark.asyncio
+async def test_corpus_status_readyz_200_without_flag_is_ready(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """A bare /readyz 200 (no readiness flag) reads as index_built=True (#1732).
+
+    MEHO.Knowledge's /readyz returns a HealthResponse whose 200 *is* the
+    ready signal; it need not carry an ``index_built`` field. The adapter
+    must treat such a body as answerable rather than failing parse.
+    """
+    _pin_settings(monkeypatch, corpus_url=_CORPUS_URL)
+    transport = _transport_capturing([], httpx.Response(200, json={"status": "ok"}))
+    _patch_async_client(monkeypatch, transport, [])
+
+    result = await corpus_status(_make_operator())
+
+    assert result.index_built is True
+    assert result.doc_count is None
+
+
+@pytest.mark.asyncio
+async def test_corpus_status_readyz_ready_alias_false_is_not_built(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """A /readyz body advertising ``ready: false`` maps to index_built=False."""
+    _pin_settings(monkeypatch, corpus_url=_CORPUS_URL)
+    transport = _transport_capturing([], httpx.Response(200, json={"ready": False}))
+    _patch_async_client(monkeypatch, transport, [])
+
+    result = await corpus_status(_make_operator())
+
+    assert result.index_built is False
 
 
 @pytest.mark.asyncio
@@ -356,9 +468,11 @@ async def test_corpus_status_non_2xx_fails_closed(monkeypatch: pytest.MonkeyPatc
 
 @pytest.mark.asyncio
 async def test_corpus_status_malformed_body_fails_closed(monkeypatch: pytest.MonkeyPatch) -> None:
-    """A 2xx body missing the required index_built fails parse → unavailable."""
+    """A 2xx body with a wrong-typed consumed field fails parse → unavailable."""
     _pin_settings(monkeypatch, corpus_url=_CORPUS_URL)
-    transport = _transport_capturing([], httpx.Response(200, json={"doc_count": 5}))
+    # ``doc_count`` is an optional int; a non-numeric string violates the
+    # contract and must fail closed rather than silently degrade.
+    transport = _transport_capturing([], httpx.Response(200, json={"doc_count": "lots"}))
     _patch_async_client(monkeypatch, transport, [])
 
     with pytest.raises(CorpusUnavailable):

--- a/backend/tests/test_docs_backends_router.py
+++ b/backend/tests/test_docs_backends_router.py
@@ -320,7 +320,8 @@ async def test_adapter_forwards_jwt_and_uses_backend_ref_endpoint(
 
     body = json.loads(sent.content.decode())
     assert body["query"] == "supervisor cluster"
-    assert body["limit"] == 5
+    # The corpus reads ``top_k``, not ``limit`` (#1732).
+    assert body["top_k"] == 5
     assert body["metadata_filters"] == {"product": "vmware", "version": "9.0"}
     assert body["audience"] == "meho-corpus"
 

--- a/docs/codebase/doc-collections.md
+++ b/docs/codebase/doc-collections.md
@@ -140,9 +140,14 @@ check fails loud rather than claiming "ready").
 managed-RAG footgun: reachable but the index is not yet answerable.
 
 `CorpusHttpBackend.probe` reads the corpus's readiness via
-`corpus_status` (a GET to the corpus `/status` endpoint derived from the
-search URL by `derive_status_url`, forwarding the operator JWT, bounded
-by `corpus_timeout_seconds`, failing closed to one `CorpusUnavailable`).
+`corpus_status` (a GET to the corpus `/readyz` endpoint — the search
+URL's host root plus `/readyz`, derived by `derive_status_url`;
+MEHO.Knowledge exposes `/readyz`, not a `/status` sibling, #1732 —
+forwarding the operator JWT, bounded by `corpus_timeout_seconds`, failing
+closed to one `CorpusUnavailable`). A `/readyz` 200 with no explicit
+readiness flag reads as `index_built=True` (the 200 *is* the ready
+signal); a body advertising `index_built`/`ready`/`index_ready` `false`
+maps to `index_built=False`.
 The **per-project rebuild serialization** lives inside the adapter: a
 `defaultdict[str, asyncio.Lock]` keyed on the resolved corpus endpoint,
 held across the corpus round-trip, so two concurrent probes against the

--- a/docs/codebase/docs-search.md
+++ b/docs/codebase/docs-search.md
@@ -50,10 +50,22 @@ by `settings.corpus_timeout_seconds`. The URL and RFC 8707 audience are
 optional overrides (`corpus_url=` / `audience=`); `None` falls back to
 the global `settings.corpus_url` / `settings.corpus_audience` — the
 seam the `corpus-http` backend uses to pass a per-collection endpoint
-(see the router below). Models the corpus's response behind a small
-frozen Pydantic adapter (`CorpusChunk` / `CorpusSearchResponse`,
-`extra="ignore"` so additive corpus fields are absorbed silently while a
-dropped consumed field fails loudly).
+(see the router below). The request sends `top_k` for the hit cap (the
+key MEHO.Knowledge's `/search` reads — `limit` was silently ignored,
+#1732). Models the corpus's response behind a small frozen Pydantic
+adapter (`CorpusChunk` / `CorpusSearchResponse`, `extra="ignore"` so
+additive corpus fields are absorbed silently while a dropped consumed
+field fails loudly).
+
+The adapter speaks **two wire dialects** via validation aliases (#1732):
+the hit list is read from `results` (MEHO.Knowledge) **or** `chunks`, and
+each chunk's text/source-link from `text`/`source_uri` (MEHO.Knowledge)
+**or** `content`/`source_url`. The consumed names downstream callers read
+stay `chunks` / `content` / `source_url` regardless of dialect. Crucially
+the hit list is **required** (no default) so a 2xx body that names
+*neither* envelope raises `CorpusUnavailable` (→ 503) rather than parsing
+to a silent empty list — the original SEV-2 was a `{results:[…5 hits…]}`
+200 reading back as zero hits.
 
 Fail-closed by construction: an unconfigured (no URL), unreachable,
 non-2xx, or malformed-response corpus all collapse to one typed


### PR DESCRIPTION
## Summary

- The first real end-to-end `search_docs` round-trip against a co-located MEHO.Knowledge corpus surfaced a total contract mismatch between the `corpus-http` adapter and MEHO.Knowledge's `/search`: the request key, the response envelope, the per-chunk field names, and the readiness path all disagreed. The 200 round-trip parsed to **zero hits** because `extra="ignore"` + `chunks` defaulting to `[]` let a `{results:[…5 hits…]}` body validate as an empty list — a healthy populated corpus read back as "no docs hits".
- Maps the adapter to MEHO.Knowledge's actual wire contract via Pydantic **validation aliases**, keeping the consumed names (`chunks` / `content` / `source_url`) stable for downstream callers: request sends `top_k` (was `limit`, silently ignored); the hit list reads from `results` **or** `chunks`; each chunk's text/source-link from `text`/`source_uri` **or** `content`/`source_url`.
- **Fails loud, not zero:** the hit list is now **required** (no default), so a 2xx body that names *neither* envelope raises `CorpusUnavailable` (→ 503) instead of silently parsing to an empty list. That fail-loud posture is the core of the SEV-2.
- **Readiness path:** `derive_status_url` now targets the host root + `/readyz` (MEHO.Knowledge exposes `/readyz`, not a `/status` sibling). A `/readyz` 200 with no explicit flag reads `index_built=True` (the 200 *is* the ready signal); a body advertising `ready`/`index_built`/`index_ready` `false` maps to `index_built=False`.
- Extracts the shared 2xx-body decode+validate tail into `_parse_2xx_body` so both transports fail closed identically without echoing the body.

## Test plan

- [x] `ruff check` / `ruff format --check` — clean on changed files
- [x] `mypy src/meho_backplane/auth/corpus.py src/meho_backplane/docs_search/` — no issues
- [x] `pytest tests/test_corpus_client.py` — 22 passed (incl. new regression tests)
- [x] `pytest -k "corpus or docs_backends or doc_collections or search_docs or docs_ask or resources_docs or tools_docs"` — 235 passed, 2 skipped
- [x] Regression: a populated `{results:[…]}` 200 returns real hits with `text`/`source_uri` mapped onto `content`/`source_url`
- [x] Regression: a 2xx body naming neither `chunks` nor `results` raises `CorpusUnavailable` (fail-loud, not zero)
- [x] `top_k` is sent (not `limit`); `derive_status_url` → `/readyz`
- [x] `cd cli && make snapshot-openapi` — OpenAPI snapshot unchanged (internal adapters, not route schemas)
- [x] `code-quality.py --diff` — 0 blockers (pre-existing size/arg warnings only)

## Out of scope

- Documenting the corpus `/search` + readiness **wire contract** in `meho-docs-addon.md` — that's sibling task #1737 (F2). This PR updates only the `docs/codebase/` walkthroughs the code change invalidated (`docs-search.md`, `doc-collections.md`).
- The corpus implementation itself (MEHO.Knowledge / ECP) — consumer/operator-owned.

Closes #1732
