### PR TITLE
fix(cli): treat awaiting_approval as a parked exit-0 outcome on every dispatch path (#1740)

### DIFF
--- a/backend/src/meho_backplane/mcp/tools/operations.py
+++ b/backend/src/meho_backplane/mcp/tools/operations.py
@@ -506,7 +506,16 @@ register_mcp_tool(
             "properties": {
                 "status": {
                     "type": "string",
-                    "enum": ["ok", "error", "denied"],
+                    # ``awaiting_approval`` is the parked outcome the
+                    # dispatcher returns for an approval-gated op that has
+                    # not yet been approved (G11.7-T1 #1401). It is a
+                    # first-class non-error result, so a spec-compliant MCP
+                    # client validating the structured result against this
+                    # outputSchema (MCP 2025-06-18: "Clients SHOULD
+                    # validate structured results against this schema")
+                    # must accept it. The enum lists only statuses the
+                    # dispatcher actually emits (no ``pending``).
+                    "enum": ["ok", "error", "denied", "awaiting_approval"],
                 },
                 "op_id": {"type": "string"},
                 "result": {

--- a/backend/tests/test_operations_meta_tools.py
+++ b/backend/tests/test_operations_meta_tools.py
@@ -1639,3 +1639,21 @@ async def test_real_descriptor_embedding_path(
     hits = result["hits"]
     assert hits, "expected at least one hit"
     assert hits[0]["op_id"] == "vault.kv.read"
+
+
+def test_call_operation_output_schema_status_enum_includes_awaiting_approval() -> None:
+    """The ``call_operation`` outputSchema ``status`` enum lists the parked
+    outcome so a spec-compliant MCP client validating the structured result
+    accepts ``awaiting_approval`` (G11.7-T1 #1401 / MCP 2025-06-18 server
+    output contract). The enum stays bounded to statuses the dispatcher
+    actually emits — no ``pending``.
+    """
+    import meho_backplane.mcp.tools.operations  # noqa: F401  (registers the tool)
+    from meho_backplane.mcp.registry import get_tool
+
+    entry = get_tool("call_operation")
+    assert entry is not None, "call_operation must be registered"
+    defn, _ = entry
+    assert defn.outputSchema is not None
+    enum = defn.outputSchema["properties"]["status"]["enum"]
+    assert set(enum) == {"ok", "error", "denied", "awaiting_approval"}, enum

--- a/cli/internal/cmd/argocd/write.go
+++ b/cli/internal/cmd/argocd/write.go
@@ -59,16 +59,14 @@ var writeResultKeyOrder = []string{
 }
 
 // printWriteResult is the shared pretty-printer for the write confirmations.
-// It renders the op header, the awaiting_approval hint when parked, then the
-// flat result object's scalar fields (proposed_effect / before-after blocks
-// are nested and only shown under --json).
+// It renders the op header then the flat result object's scalar fields
+// (proposed_effect / before-after blocks are nested and only shown under
+// --json). The awaiting_approval (parked) status never reaches this
+// printer: the shared dispatch.Render intercepts it ahead of the
+// pretty-printer and renders the parked hint itself (exit 0).
 func printWriteResult(opID string) func(w io.Writer, r *CallResult) {
 	return func(w io.Writer, r *CallResult) {
 		fmt.Fprintf(w, "%s %s — status=%s (%.0fms)\n", ConnectorID, opID, r.Status, r.DurationMs)
-		if r.Status == "awaiting_approval" {
-			fmt.Fprintln(w, "  parked for human approval — approve via the approval queue, then re-dispatch")
-			return
-		}
 		if r.Status != "ok" {
 			printErrorTrailer(w, r)
 			return

--- a/cli/internal/cmd/argocd/write_test.go
+++ b/cli/internal/cmd/argocd/write_test.go
@@ -119,21 +119,75 @@ func TestSyncForwardsSyncParams(t *testing.T) {
 	}
 }
 
-// TestPrintWriteResultAwaitingApproval — the awaiting_approval status renders
-// the human-approve hint, never an error trailer.
-func TestPrintWriteResultAwaitingApproval(t *testing.T) {
-	var buf bytes.Buffer
-	r := &CallResult{Status: "awaiting_approval", OpID: "argocd.app.sync", DurationMs: 5}
-	printWriteResult("argocd.app.sync")(&buf, r)
-	out := buf.String()
-	if !strings.Contains(out, "awaiting_approval") {
-		t.Errorf("expected status line; got %q", out)
+// TestAppSyncAwaitingApprovalRealPath — drives the REAL end-to-end path
+// (fake backplane returns status=awaiting_approval → dispatchWrite →
+// renderCallResult → conn.Render), not printWriteResult directly. The
+// dispatch must NOT classify the park as an exit-4 invalid status: the
+// command exits 0 (parked, not failed), stdout carries the parked hint,
+// and stderr never carries the invalid-status diagnostic. Replaces the
+// pre-#1740 test that called printWriteResult directly and so never
+// exercised the conn.Render allowlist that actually rejected the park.
+func TestAppSyncAwaitingApprovalRealPath(t *testing.T) {
+	srv := mockBackplane(t, map[string]mockHandler{
+		"POST /api/v1/operations/call": func(w http.ResponseWriter, _ *http.Request) {
+			writeJSON(t, w, 200, CallResult{
+				Status: "awaiting_approval", OpID: "argocd.app.sync", DurationMs: 5,
+				Extras: json.RawMessage(`{"approval_request_id":"ar-123"}`),
+			})
+		},
+	})
+	defer srv.Close()
+	primeToken(t, srv.URL)
+
+	cmd := newAppSyncCmd()
+	var out, errBuf bytes.Buffer
+	cmd.SetOut(&out)
+	cmd.SetErr(&errBuf)
+	cmd.SetArgs([]string{"--target", "rdc-argocd", "--name", "guestbook", "--backplane", srv.URL})
+	if err := cmd.Execute(); err != nil {
+		t.Fatalf("awaiting_approval must not be an error (parked, exit 0); got %v", err)
 	}
-	if !strings.Contains(out, "parked for human approval") {
-		t.Errorf("expected approval hint; got %q", out)
+	if !strings.Contains(out.String(), "parked for human approval") {
+		t.Errorf("expected parked hint on stdout; got %q", out.String())
 	}
-	if strings.Contains(out, "connector error") {
-		t.Errorf("awaiting_approval must not render an error trailer; got %q", out)
+	if strings.Contains(errBuf.String(), "invalid OperationResult") {
+		t.Errorf("awaiting_approval was wrongly rejected as invalid status: %s", errBuf.String())
+	}
+}
+
+// TestAppSyncAwaitingApprovalJSON — with --json the parked envelope
+// round-trips as the full OperationResult JSON (incl.
+// extras.approval_request_id) and the command exits 0.
+func TestAppSyncAwaitingApprovalJSON(t *testing.T) {
+	srv := mockBackplane(t, map[string]mockHandler{
+		"POST /api/v1/operations/call": func(w http.ResponseWriter, _ *http.Request) {
+			writeJSON(t, w, 200, CallResult{
+				Status: "awaiting_approval", OpID: "argocd.app.sync",
+				Extras: json.RawMessage(`{"approval_request_id":"ar-123"}`),
+			})
+		},
+	})
+	defer srv.Close()
+	primeToken(t, srv.URL)
+
+	cmd := newAppSyncCmd()
+	var out bytes.Buffer
+	cmd.SetOut(&out)
+	cmd.SetErr(&bytes.Buffer{})
+	cmd.SetArgs([]string{"--target", "rdc-argocd", "--name", "guestbook", "--json", "--backplane", srv.URL})
+	if err := cmd.Execute(); err != nil {
+		t.Fatalf("execute: %v", err)
+	}
+	var decoded map[string]any
+	if err := json.Unmarshal(out.Bytes(), &decoded); err != nil {
+		t.Fatalf("--json output is not valid JSON: %v\n%s", err, out.String())
+	}
+	if decoded["status"] != "awaiting_approval" {
+		t.Errorf("json status: got %v want awaiting_approval", decoded["status"])
+	}
+	extras, ok := decoded["extras"].(map[string]any)
+	if !ok || extras["approval_request_id"] != "ar-123" {
+		t.Errorf("json envelope must carry extras.approval_request_id; got %v", decoded["extras"])
 	}
 }
 

--- a/cli/internal/cmd/keycloak/write.go
+++ b/cli/internal/cmd/keycloak/write.go
@@ -59,14 +59,12 @@ func loadRepresentation(path string) (map[string]any, *output.StructuredError) {
 // confirmations every write op returns. It renders the op header then the
 // flat result object's scalar fields (id / created / conflict / updated /
 // password_reset / assigned_roles …) — none of which ever carry secret
-// material.
+// material. The awaiting_approval (parked) status never reaches this
+// printer: the shared dispatch.Render intercepts it ahead of the
+// pretty-printer and renders the parked hint itself (exit 0).
 func printWriteResult(opID string) func(w io.Writer, r *CallResult) {
 	return func(w io.Writer, r *CallResult) {
 		fmt.Fprintf(w, "%s %s — status=%s (%.0fms)\n", ConnectorID, opID, r.Status, r.DurationMs)
-		if r.Status == "awaiting_approval" {
-			fmt.Fprintln(w, "  parked for human approval — approve via the approval queue, then re-dispatch")
-			return
-		}
 		if r.Status != "ok" {
 			printErrorTrailer(w, r)
 			return

--- a/cli/internal/cmd/keycloak/write_test.go
+++ b/cli/internal/cmd/keycloak/write_test.go
@@ -270,3 +270,40 @@ func TestRoleMappingAssignForwardsRoles(t *testing.T) {
 		t.Errorf("username not forwarded: %v", params["username"])
 	}
 }
+
+// TestRoleMappingAssignAwaitingApprovalRealPath — drives the REAL
+// end-to-end path (fake backplane returns status=awaiting_approval →
+// dispatchWrite → renderCallResult → conn.Render). The shared
+// dispatch.Render intercepts the park as a non-error outcome: the
+// command exits 0, stdout carries the parked hint, and stderr never
+// carries the invalid-status diagnostic.
+func TestRoleMappingAssignAwaitingApprovalRealPath(t *testing.T) {
+	srv := mockBackplane(t, map[string]mockHandler{
+		"POST /api/v1/operations/call": func(w http.ResponseWriter, _ *http.Request) {
+			writeJSON(t, w, 200, CallResult{
+				Status: "awaiting_approval", OpID: "keycloak.role_mapping.assign", DurationMs: 4,
+				Extras: json.RawMessage(`{"approval_request_id":"ar-kc-1"}`),
+			})
+		},
+	})
+	defer srv.Close()
+	primeToken(t, srv.URL)
+
+	cmd := newRoleMappingAssignCmd()
+	var out, errBuf bytes.Buffer
+	cmd.SetOut(&out)
+	cmd.SetErr(&errBuf)
+	cmd.SetArgs([]string{
+		"--target", "rdc-keycloak", "--username", "operator-a",
+		"--role", "tenant_admin", "--backplane", srv.URL,
+	})
+	if err := cmd.Execute(); err != nil {
+		t.Fatalf("awaiting_approval must not be an error (parked, exit 0); got %v", err)
+	}
+	if !strings.Contains(out.String(), "parked for human approval") {
+		t.Errorf("expected parked hint on stdout; got %q", out.String())
+	}
+	if strings.Contains(errBuf.String(), "invalid OperationResult") {
+		t.Errorf("awaiting_approval was wrongly rejected as invalid status: %s", errBuf.String())
+	}
+}

--- a/cli/internal/cmd/operation/call.go
+++ b/cli/internal/cmd/operation/call.go
@@ -15,6 +15,7 @@ import (
 
 	"github.com/evoila/meho/cli/internal/api"
 	"github.com/evoila/meho/cli/internal/backplane"
+	"github.com/evoila/meho/cli/internal/dispatch"
 	"github.com/evoila/meho/cli/internal/output"
 )
 
@@ -139,6 +140,24 @@ func runCall(cmd *cobra.Command, opts callOptions) error {
 	if err != nil {
 		return renderRequestError(cmd, backplaneURL, err, opts.JSONOut)
 	}
+	// awaiting_approval (parked) is a first-class non-error outcome:
+	// the dispatcher has durably written an ApprovalRequest row and
+	// parked the call (G11.7-T1 #1401). Intercept it ahead of the
+	// status switch — mirroring the shared dispatch.Render path the
+	// vendor verbs go through — so the generic `operation call` verb
+	// renders the parked hint (or the full envelope, incl.
+	// extras.approval_request_id, under --json) and exits 0 instead of
+	// rejecting it as an invalid status (exit 4).
+	if result.Status == dispatch.StatusAwaitingApproval {
+		if opts.JSONOut {
+			return output.PrintJSON(cmd.OutOrStdout(), result)
+		}
+		w := cmd.OutOrStdout()
+		fmt.Fprintf(w, "%s %s — status=%s (%.0fms)\n",
+			opts.ConnectorID, opts.OpID, result.Status, result.DurationMs)
+		fmt.Fprintf(w, "  %s\n", dispatch.ParkedHint)
+		return nil // parked, not failed — exit 0.
+	}
 	// Classify status BEFORE rendering. The backend
 	// `Connector.execute` contract (see
 	// `backend/src/meho_backplane/connectors/schemas.py`) defines three
@@ -156,7 +175,7 @@ func runCall(cmd *cobra.Command, opts callOptions) error {
 		return output.RenderError(
 			cmd.ErrOrStderr(),
 			output.Unexpected(fmt.Sprintf(
-				"backplane returned invalid OperationResult.status %q (expected one of: ok / error / denied)",
+				"backplane returned invalid OperationResult.status %q (expected one of: ok / error / denied / awaiting_approval)",
 				result.Status,
 			)),
 			opts.JSONOut,

--- a/cli/internal/cmd/operation/client_test.go
+++ b/cli/internal/cmd/operation/client_test.go
@@ -9,6 +9,7 @@ import (
 	"encoding/json"
 	"errors"
 	"net/http"
+	"strings"
 	"testing"
 
 	"github.com/evoila/meho/cli/internal/api"
@@ -487,5 +488,84 @@ func TestPostCallNon2xxAfterRefreshClassifiesAsApiResponseError(t *testing.T) {
 	var apiErr *apiResponseError
 	if !errors.As(err, &apiErr) || apiErr.StatusCode != 500 {
 		t.Fatalf("expected *apiResponseError{StatusCode:500}; got %+v", err)
+	}
+}
+
+// withFakeClient swaps newAuthedClient for a factory returning f and
+// restores the original on cleanup, so a full runCall path can be
+// exercised without a live backplane or token store.
+func withFakeClient(t *testing.T, f operationsAPI) {
+	t.Helper()
+	orig := newAuthedClient
+	newAuthedClient = func(_ context.Context, _ string) (operationsAPI, error) { return f, nil }
+	t.Cleanup(func() { newAuthedClient = orig })
+}
+
+// TestRunCallAwaitingApprovalRealPath — the generic `operation call`
+// verb treats status=awaiting_approval as a parked, non-error,
+// exit-0 outcome on the REAL runCall path (not just printCallResult):
+// stdout carries the parked hint and stderr never carries the
+// invalid-status diagnostic.
+func TestRunCallAwaitingApprovalRealPath(t *testing.T) {
+	cr, _ := json.Marshal(CallResult{
+		Status: "awaiting_approval", OpID: "argocd.app.sync", DurationMs: 7,
+		Extras: json.RawMessage(`{"approval_request_id":"ar-op-1"}`),
+	})
+	f := &fakeOperationsClient{
+		callResponses: []*api.PostCallApiV1OperationsCallPostResponse{
+			{HTTPResponse: makeHTTPResp(200), Body: cr},
+		},
+	}
+	withFakeClient(t, f)
+
+	cmd := newCallCmd()
+	var out, errBuf bytes.Buffer
+	cmd.SetOut(&out)
+	cmd.SetErr(&errBuf)
+	cmd.SetArgs([]string{"argocd-api-3.x", "argocd.app.sync", "--target", "rdc-argocd", "--backplane", "http://x"})
+	if err := cmd.Execute(); err != nil {
+		t.Fatalf("awaiting_approval must not be an error (parked, exit 0); got %v", err)
+	}
+	if !strings.Contains(out.String(), "parked for human approval") {
+		t.Errorf("expected parked hint on stdout; got %q", out.String())
+	}
+	if strings.Contains(errBuf.String(), "invalid OperationResult") {
+		t.Errorf("awaiting_approval was wrongly rejected as invalid status: %s", errBuf.String())
+	}
+}
+
+// TestRunCallAwaitingApprovalJSON — with --json the parked envelope
+// round-trips as the full OperationResult JSON (incl.
+// extras.approval_request_id) and the command exits 0.
+func TestRunCallAwaitingApprovalJSON(t *testing.T) {
+	cr, _ := json.Marshal(CallResult{
+		Status: "awaiting_approval", OpID: "argocd.app.sync",
+		Extras: json.RawMessage(`{"approval_request_id":"ar-op-1"}`),
+	})
+	f := &fakeOperationsClient{
+		callResponses: []*api.PostCallApiV1OperationsCallPostResponse{
+			{HTTPResponse: makeHTTPResp(200), Body: cr},
+		},
+	}
+	withFakeClient(t, f)
+
+	cmd := newCallCmd()
+	var out bytes.Buffer
+	cmd.SetOut(&out)
+	cmd.SetErr(&bytes.Buffer{})
+	cmd.SetArgs([]string{"argocd-api-3.x", "argocd.app.sync", "--target", "rdc-argocd", "--json", "--backplane", "http://x"})
+	if err := cmd.Execute(); err != nil {
+		t.Fatalf("execute: %v", err)
+	}
+	var decoded map[string]any
+	if err := json.Unmarshal(out.Bytes(), &decoded); err != nil {
+		t.Fatalf("--json output is not valid JSON: %v\n%s", err, out.String())
+	}
+	if decoded["status"] != "awaiting_approval" {
+		t.Errorf("json status: got %v want awaiting_approval", decoded["status"])
+	}
+	extras, ok := decoded["extras"].(map[string]any)
+	if !ok || extras["approval_request_id"] != "ar-op-1" {
+		t.Errorf("json envelope must carry extras.approval_request_id; got %v", decoded["extras"])
 	}
 }

--- a/cli/internal/cmd/secret/move.go
+++ b/cli/internal/cmd/secret/move.go
@@ -17,14 +17,6 @@ import (
 // opMove is the canonical op_id `meho secret move` dispatches.
 const opMove = "secret.move"
 
-// statusAwaitingApproval is the change-class park status the policy gate
-// returns for an unapproved move. The shared dispatch.Render rejects any
-// status outside ok/error/denied as an exit-4 "invalid OperationResult
-// status", so this verb intercepts awaiting_approval BEFORE delegating to
-// conn.Render (option (b) of #1580 — a package-local render path, leaving
-// the shared status enum and every other vendor verb untouched).
-const statusAwaitingApproval = "awaiting_approval"
-
 // newMoveCmd returns the `meho secret move` command (secret.move —
 // change-class, approval-gated). It dispatches secret.move with the
 // source/sink references and the audit reason as opaque params; the
@@ -108,22 +100,10 @@ func runMove(
 	if err != nil {
 		return renderRequestError(cmd, backplaneURL, err, jsonOut)
 	}
-	return renderMoveResult(cmd, r, jsonOut)
-}
-
-// renderMoveResult surfaces the secret.move result. awaiting_approval is
-// handled package-locally (the shared conn.Render would exit-4 it as an
-// invalid status); every other status delegates to conn.Render so the
-// ok→exit-0 / error|denied→exit-1 classification and the JSON envelope
-// path are reused unchanged.
-func renderMoveResult(cmd *cobra.Command, r *dispatch.CallResult, jsonOut bool) error {
-	if r.Status == statusAwaitingApproval {
-		if jsonOut {
-			return output.PrintJSON(cmd.OutOrStdout(), r)
-		}
-		printMoveResult(cmd.OutOrStdout(), r)
-		return nil // parked, not failed — exit 0.
-	}
+	// awaiting_approval (the parked, unapproved move) is intercepted by
+	// the shared conn.Render ahead of this pretty-printer (exit 0); the
+	// ok→exit-0 / error|denied→exit-1 classification and the JSON
+	// envelope path are reused unchanged.
 	return conn.Render(cmd, opMove, r, jsonOut, printMoveResult)
 }
 
@@ -132,10 +112,6 @@ func renderMoveResult(cmd *cobra.Command, r *dispatch.CallResult, jsonOut bool) 
 // It never renders a secret value because the response never carries one.
 func printMoveResult(w io.Writer, r *dispatch.CallResult) {
 	fmt.Fprintf(w, "%s %s — status=%s (%.0fms)\n", ConnectorID, opMove, r.Status, r.DurationMs)
-	if r.Status == statusAwaitingApproval {
-		fmt.Fprintln(w, "  parked for human approval — approve via the approval queue, then re-dispatch")
-		return
-	}
 	if r.Status != "ok" {
 		printErrorTrailer(w, r)
 		return

--- a/cli/internal/cmd/secret/secret_test.go
+++ b/cli/internal/cmd/secret/secret_test.go
@@ -272,7 +272,7 @@ func TestSecretMoveAwaitingApproval(t *testing.T) {
 	srv := mockBackplane(t, map[string]mockHandler{
 		"POST /api/v1/operations/call": func(w http.ResponseWriter, r *http.Request) {
 			writeJSON(t, w, 200, dispatch.CallResult{
-				Status: statusAwaitingApproval, OpID: opMove, DurationMs: 3,
+				Status: dispatch.StatusAwaitingApproval, OpID: opMove, DurationMs: 3,
 			})
 		},
 	})
@@ -292,7 +292,7 @@ func TestSecretMoveAwaitingApproval(t *testing.T) {
 		t.Fatalf("awaiting_approval must not be an error (parked, exit 0); got %v", err)
 	}
 	got := out.String()
-	if !strings.Contains(got, statusAwaitingApproval) {
+	if !strings.Contains(got, dispatch.StatusAwaitingApproval) {
 		t.Errorf("output should surface awaiting_approval verbatim\n%s", got)
 	}
 	if strings.Contains(errBuf.String(), "invalid OperationResult") {
@@ -306,7 +306,7 @@ func TestSecretMoveAwaitingApprovalJSON(t *testing.T) {
 	srv := mockBackplane(t, map[string]mockHandler{
 		"POST /api/v1/operations/call": func(w http.ResponseWriter, r *http.Request) {
 			writeJSON(t, w, 200, dispatch.CallResult{
-				Status: statusAwaitingApproval, OpID: opMove,
+				Status: dispatch.StatusAwaitingApproval, OpID: opMove,
 			})
 		},
 	})
@@ -328,7 +328,7 @@ func TestSecretMoveAwaitingApprovalJSON(t *testing.T) {
 	if err := json.Unmarshal(out.Bytes(), &decoded); err != nil {
 		t.Fatalf("--json output is not valid JSON: %v\n%s", err, out.String())
 	}
-	if decoded["status"] != statusAwaitingApproval {
-		t.Errorf("json envelope status: got %v want %s", decoded["status"], statusAwaitingApproval)
+	if decoded["status"] != dispatch.StatusAwaitingApproval {
+		t.Errorf("json envelope status: got %v want %s", decoded["status"], dispatch.StatusAwaitingApproval)
 	}
 }

--- a/cli/internal/dispatch/dispatch.go
+++ b/cli/internal/dispatch/dispatch.go
@@ -111,6 +111,19 @@ type SearchResponse struct {
 // each command keeps cobra from double-printing the error string.
 var ErrOpError = errors.New("operation status not ok")
 
+// StatusAwaitingApproval is the change-class park status the dispatcher
+// returns for an approval-gated op that has not yet been approved
+// (G11.7-T1 #1401). The backplane has durably written an ApprovalRequest
+// row and parked the call; it is a first-class non-error outcome that
+// Render surfaces as a parked dispatch and maps to exit 0.
+const StatusAwaitingApproval = "awaiting_approval"
+
+// ParkedHint is the operator-facing one-liner Render prints under the
+// status header when a dispatch parks. Exported so the parallel
+// operation/call.go render path (a separate package that can't share
+// Render) emits the byte-identical hint.
+const ParkedHint = "parked for human approval — approve via the approval queue, then re-dispatch"
+
 // APIResponseError wraps a non-2xx response from the backplane so
 // per-vendor renderRequestError can pick the right output category
 // (401 → AuthExpired, 403 → InsufficientRole, other non-2xx →
@@ -369,6 +382,15 @@ func isSpace(b byte) bool {
 // the status enum, render the envelope (JSON or human), then map
 // "error" / "denied" to ErrOpError. When prettyPrinter is nil the
 // generic envelope is used.
+//
+// awaiting_approval (parked) is intercepted here — ahead of the
+// per-verb prettyPrinter — so the park is a first-class non-error
+// outcome on every dispatch render path (the generic verb, every
+// argocd/keycloak approval-gated write verb, secret move, and any
+// future requires_approval verb) without each verb re-implementing
+// it. A parked dispatch renders the status header plus the ParkedHint
+// (or the full envelope under --json, incl. extras.approval_request_id)
+// and returns nil → exit 0.
 func (c Connector) Render(
 	cmd *cobra.Command,
 	opID string,
@@ -376,6 +398,15 @@ func (c Connector) Render(
 	jsonOut bool,
 	prettyPrinter func(w io.Writer, r *CallResult),
 ) error {
+	if r.Status == StatusAwaitingApproval {
+		if jsonOut {
+			return output.PrintJSON(cmd.OutOrStdout(), r)
+		}
+		w := cmd.OutOrStdout()
+		fmt.Fprintf(w, "%s %s — status=%s (%.0fms)\n", c.ID, opID, r.Status, r.DurationMs)
+		fmt.Fprintf(w, "  %s\n", ParkedHint)
+		return nil // parked, not failed — exit 0.
+	}
 	switch r.Status {
 	case "ok", "error", "denied":
 		// fall through.
@@ -383,7 +414,7 @@ func (c Connector) Render(
 		return output.RenderError(
 			cmd.ErrOrStderr(),
 			output.Unexpected(fmt.Sprintf(
-				"backplane returned invalid OperationResult.status %q (expected one of: ok / error / denied)",
+				"backplane returned invalid OperationResult.status %q (expected one of: ok / error / denied / awaiting_approval)",
 				r.Status,
 			)),
 			jsonOut,

--- a/cli/internal/dispatch/dispatch_test.go
+++ b/cli/internal/dispatch/dispatch_test.go
@@ -431,6 +431,61 @@ func TestRenderStatusMapping(t *testing.T) {
 	}
 }
 
+// TestRenderAwaitingApprovalParkedExitZero — the shared Render owns the
+// parked outcome: status=awaiting_approval renders the status header plus
+// the ParkedHint, returns nil (exit 0), and never writes the
+// invalid-status diagnostic to stderr. This is the single shared
+// interception every vendor verb (argocd/keycloak/secret move) inherits.
+func TestRenderAwaitingApprovalParkedExitZero(t *testing.T) {
+	c := New("argocd-api-3.x")
+	cmd := &cobra.Command{}
+	var out, errBuf bytes.Buffer
+	cmd.SetOut(&out)
+	cmd.SetErr(&errBuf)
+	r := &CallResult{Status: StatusAwaitingApproval, OpID: "argocd.app.sync", DurationMs: 5}
+	if err := c.Render(cmd, "argocd.app.sync", r, false, nil); err != nil {
+		t.Fatalf("parked dispatch must return nil (exit 0); got %v", err)
+	}
+	if !strings.Contains(out.String(), StatusAwaitingApproval) {
+		t.Errorf("expected status line; got %q", out.String())
+	}
+	if !strings.Contains(out.String(), ParkedHint) {
+		t.Errorf("expected parked hint; got %q", out.String())
+	}
+	if strings.Contains(errBuf.String(), "invalid OperationResult") {
+		t.Errorf("park must not be rejected as invalid status; stderr=%q", errBuf.String())
+	}
+}
+
+// TestRenderAwaitingApprovalJSON — under --json the parked envelope
+// round-trips verbatim (incl. extras.approval_request_id) and Render
+// returns nil.
+func TestRenderAwaitingApprovalJSON(t *testing.T) {
+	c := New("argocd-api-3.x")
+	cmd := &cobra.Command{}
+	var out bytes.Buffer
+	cmd.SetOut(&out)
+	cmd.SetErr(&bytes.Buffer{})
+	r := &CallResult{
+		Status: StatusAwaitingApproval, OpID: "argocd.app.sync",
+		Extras: json.RawMessage(`{"approval_request_id":"ar-9"}`),
+	}
+	if err := c.Render(cmd, "argocd.app.sync", r, true, nil); err != nil {
+		t.Fatalf("parked --json must return nil; got %v", err)
+	}
+	var decoded map[string]any
+	if err := json.Unmarshal(out.Bytes(), &decoded); err != nil {
+		t.Fatalf("--json output is not valid JSON: %v\n%s", err, out.String())
+	}
+	if decoded["status"] != StatusAwaitingApproval {
+		t.Errorf("json status: got %v", decoded["status"])
+	}
+	extras, ok := decoded["extras"].(map[string]any)
+	if !ok || extras["approval_request_id"] != "ar-9" {
+		t.Errorf("json envelope must carry extras.approval_request_id; got %v", decoded["extras"])
+	}
+}
+
 func TestRenderInvalidStatusReturnsRenderError(t *testing.T) {
 	c := New("c")
 	cmd := &cobra.Command{}


### PR DESCRIPTION
## Summary
- A `requires_approval` op dispatched through the CLI is correctly **parked** by the backplane (durable `ApprovalRequest` row + `OperationResult` with `status=awaiting_approval`), but the CLI render path rejected the park as a hard error: both `dispatch.Render` and `operation/call.go` carried a hardcoded 3-value status allowlist (`ok`/`error`/`denied`) whose `default` branch emitted `invalid OperationResult.status` and exited 4 (the exact ops-reported symptom).
- The argocd/keycloak write verbs' `printWriteResult` `awaiting_approval` branch was **dead code** — `Render` rejected the status before ever invoking the pretty-printer — so only `secret move` (which intercepted ahead of `Render`) handled parking correctly.
- **Fix (shared, not per-verb):** hoist the interception into `dispatch.Render`, so every verb (generic `operation call`, every argocd/keycloak approval-gated write verb, `secret move`, and any future `requires_approval` verb) inherits it. A parked dispatch renders `status=awaiting_approval` + the hint `parked for human approval — approve via the approval queue, then re-dispatch` and **exits 0**; `--json` emits the full envelope (incl. `extras.approval_request_id`) and exits 0. The parallel `operation/call.go` path gets the same interception ahead of its status switch, sharing the `StatusAwaitingApproval`/`ParkedHint` constants. `secret move`'s package-local interception collapses onto the shared path; the now-dead per-verb branches are removed.
- Aligned the MCP `call_operation` `outputSchema` `status` enum to include `awaiting_approval` (MCP 2025-06-18 server-output contract). The enum stays bounded to statuses the dispatcher emits (no `pending`).

## Test plan
- [x] `go build ./...` — clean
- [x] `go test ./...` (CLI) — all packages pass
- [x] `gofmt -l` / `go vet` — clean (golangci-lint skipped locally: env has go1.24 < targeted 1.25; runs in CI)
- [x] New real-path regression tests assert a parked op **exits 0** through the actual `dispatchWrite`/`runCall` → `Render` path (not `printWriteResult` directly) and on `--json`, for the generic `operation call`, an argocd write verb, and a keycloak write verb; plus shared `dispatch.Render` unit tests (human + JSON). stdout carries the parked hint; stderr never carries `invalid OperationResult.status`.
- [x] `grep -n '"awaiting_approval"' cli/internal/dispatch/dispatch.go` — accepted in `Render` (renders hint, returns nil)
- [x] `grep -n 'awaiting_approval' cli/internal/cmd/operation/call.go` — generic verb treats it exit-0 parked
- [x] `grep -n awaiting_approval backend/src/meho_backplane/mcp/tools/operations.py` — enum now lists it
- [x] `cd cli && make snapshot-openapi && make generate && git diff --exit-code` — clean (REST route is untyped → snapshot does not churn)
- [x] `cd backend && uv run pytest tests/test_operations_meta_tools.py` — 34 passed (incl. new enum-lock test); broader `-k "mcp or call_operation or output_schema"` — 742 passed, 20 skipped
- [x] `ruff check` / `ruff format --check` / `mypy` on the touched backend file — clean

## Out of scope
- Post-approval re-dispatch / execute-after-approve (closed #1503).
- Server-side `outputSchema` result validation in `mcp/handlers.py` (separate hardening).
- Adding a `pending` status.

## Adjacent findings (out of scope)
- `backend/src/meho_backplane/mcp/tools/operations.py` is 673 lines (>600 code-quality soft limit) — pre-existing file-size debt, not introduced here.

Closes #1740


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Introduced "awaiting_approval" operation status for operations requiring human approval
  * Operations in this state display "parked for human approval" messaging with instructions to approve via the approval queue and re-dispatch
  * Full JSON output support maintains approval request metadata throughout workflows

<!-- end of auto-generated comment: release notes by coderabbit.ai -->