### PR TITLE
feat(docs-collections): add create/import surface across REST + MCP + CLI (#1739)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -92,6 +92,19 @@ connector-related release-notes line.
 
 ### Added
 
+- Doc-collection **create/import** surface across all three fronts
+  (#1739): `POST /api/v1/doc_collections`, the `create_doc_collections`
+  MCP tool, and `meho docs collections create` (with `--from-file`).
+  Closes the validated, audited create-half gap — registering a
+  collection no longer requires a raw `INSERT INTO doc_collections`. The
+  create derives `tenant_id` from the JWT (never the body), validates
+  `backend.type` against the search-backend registry (an unregistered
+  type is a structured `422`, not a deferred probe-time `503`), maps a
+  cross-scope `collection_key` collision to `409`, defaults `status` to
+  `provisioning`, and writes an audit row under
+  `op_id="meho.docs.collections.create"`. All three fronts are
+  `tenant_admin`-gated (REST/CLI) / `tenant_admin` + `meho-docs`-gated
+  (MCP). Update / delete and cross-tenant sharing remain out of scope.
 - Per-tenant templated Vault ACL policies (≤3, by role) keyed on
   `{{identity.entity.metadata.tenant_id}}`: a deploy runbook
   (`docs/cross-repo/connector-vault-tenant-policy.md`) with the three

--- a/backend/src/meho_backplane/api/v1/doc_collections.py
+++ b/backend/src/meho_backplane/api/v1/doc_collections.py
@@ -70,8 +70,14 @@ from meho_backplane.auth.rbac import require_role
 from meho_backplane.db.engine import get_session
 from meho_backplane.db.models import DocCollection as DocCollectionORM
 from meho_backplane.docs_collections import (
+    DocCollection,
+    DocCollectionBackendTypeError,
+    DocCollectionConflictError,
+    DocCollectionCreate,
     DocCollectionSummary,
+    create_doc_collection,
     probe_collection,
+    project_doc_collection,
     project_doc_collection_to_summary,
     resolve_doc_collection,
     set_collection_enabled,
@@ -186,6 +192,58 @@ async def list_doc_collections_endpoint(
         if collection_capability_key(row.collection_key) in operator.capabilities
     ]
     return [project_doc_collection_to_summary(row) for row in entitled[:limit]]
+
+
+@router.post(
+    "",
+    response_model=DocCollection,
+    status_code=status.HTTP_201_CREATED,
+    responses={
+        409: {
+            "description": (
+                "A collection with this ``collection_key`` already exists "
+                "in the tenant's scope (global or per-tenant)."
+            ),
+        },
+        422: {
+            "description": (
+                "The ``backend.type`` is not a registered search backend; "
+                "the detail enumerates the registered types."
+            ),
+        },
+    },
+)
+async def create_doc_collection_endpoint(
+    body: DocCollectionCreate,
+    operator: Operator = _require_admin,
+    session: AsyncSession = Depends(get_session),
+) -> DocCollection:
+    """Register a new doc collection in the requesting tenant.
+
+    The create sibling of the lifecycle write routes — ``tenant_admin``-
+    gated, tenant-scoped (``tenant_id`` from the JWT, never the body), with
+    the validation + audit every other registry write gets. Mirrors
+    ``POST /api/v1/targets``: ``id`` / timestamps are generated server-side,
+    ``status`` defaults to ``provisioning`` (a follow-up ``probe`` promotes
+    it to ``ready``), the ``backend.type`` is validated against the
+    search-backend registry (an unregistered type → 422 listing the valid
+    set, not a deferred 503), and a cross-scope ``collection_key`` collision
+    → 409. The create binds ``op_id="meho.docs.collections.create"`` so the
+    registration joins the ``op_id="meho.docs.*"`` who-touched trail.
+    """
+    try:
+        row = await create_doc_collection(session, operator, body)
+    except DocCollectionBackendTypeError as exc:
+        raise HTTPException(
+            status_code=status.HTTP_422_UNPROCESSABLE_CONTENT,
+            detail=exc.detail,
+        ) from exc
+    except DocCollectionConflictError as exc:
+        raise HTTPException(
+            status_code=status.HTTP_409_CONFLICT,
+            detail=str(exc),
+        ) from exc
+    return project_doc_collection(row)
 
 
 @router.post(

--- a/backend/src/meho_backplane/docs_collections/__init__.py
+++ b/backend/src/meho_backplane/docs_collections/__init__.py
@@ -24,20 +24,30 @@ from meho_backplane.docs_collections.resolver import (
 )
 from meho_backplane.docs_collections.schemas import (
     DocCollection,
+    DocCollectionCreate,
     DocCollectionSummary,
+    project_doc_collection,
     project_doc_collection_to_summary,
 )
 from meho_backplane.docs_collections.service import (
+    DocCollectionBackendTypeError,
+    DocCollectionConflictError,
+    create_doc_collection,
     probe_collection,
     set_collection_enabled,
 )
 
 __all__ = [
     "DocCollection",
+    "DocCollectionBackendTypeError",
+    "DocCollectionConflictError",
+    "DocCollectionCreate",
     "DocCollectionNotFoundError",
     "DocCollectionStateError",
     "DocCollectionSummary",
+    "create_doc_collection",
     "probe_collection",
+    "project_doc_collection",
     "project_doc_collection_to_summary",
     "resolve_doc_collection",
     "set_collection_enabled",

--- a/backend/src/meho_backplane/docs_collections/schemas.py
+++ b/backend/src/meho_backplane/docs_collections/schemas.py
@@ -19,10 +19,16 @@ Two read models cover the registry's wire contract:
   never appears in a catalogue response (#1548 backend-agnostic
   contract). Frozen.
 
-There is no ``DocCollectionCreate`` / ``DocCollectionUpdate`` here: v1
-collections are operator-managed seed (no create/import API until a
-collection needs one — out of scope per #1550). When that API lands it
-adds the write schemas alongside these read models.
+:class:`DocCollectionCreate` is the write half (#1739): the request body
+for ``POST /api/v1/doc_collections`` + the ``create_doc_collections`` MCP
+tool + ``meho docs collections create``. It carries only the operator-set
+identity + routing fields (``collection_key`` / ``vendor`` / ``products`` /
+``backend`` + the optional ``description`` / ``when_to_use`` / ``extras``);
+``id`` / ``tenant_id`` / timestamps / ``status`` / the probe-written
+liveness are server-derived and deliberately absent — ``tenant_id`` in
+particular comes from the JWT, never the body (the ``create_target``
+precedent). There is still no ``DocCollectionUpdate`` here — PATCH /
+DELETE are a separate follow-up (out of scope per #1739).
 
 :func:`project_doc_collection_to_summary` is the **single** ORM→wire
 projection, mirroring :func:`targets.schemas.project_target_to_summary`.
@@ -38,16 +44,71 @@ from datetime import datetime
 from typing import TYPE_CHECKING, Any
 from uuid import UUID
 
-from pydantic import BaseModel, ConfigDict
+from pydantic import BaseModel, ConfigDict, Field, field_validator
 
 if TYPE_CHECKING:
     from meho_backplane.db.models import DocCollection as DocCollectionORM
 
 __all__ = [
     "DocCollection",
+    "DocCollectionCreate",
     "DocCollectionSummary",
+    "project_doc_collection",
     "project_doc_collection_to_summary",
 ]
+
+
+class DocCollectionBackend(BaseModel):
+    """The ``{type, ref}`` backend routing record a create supplies.
+
+    ``type`` is the search-backend type the row routes to (validated at
+    the service layer against
+    :func:`~meho_backplane.docs_search.backends.registry.all_backends` so
+    an unroutable row is rejected at create time, not at probe time).
+    ``ref`` is the per-collection backend config the resolved adapter
+    reads (e.g. ``{"endpoint": "https://corpus/v1/search"}`` for
+    ``corpus-http``); it is opaque to the create surface — the adapter
+    owns its shape — so it is a free ``Mapping``.
+    """
+
+    model_config = ConfigDict(extra="forbid")
+
+    type: str = Field(min_length=1)
+    ref: Mapping[str, Any]
+
+
+class DocCollectionCreate(BaseModel):
+    """Request body for creating a doc collection (#1739).
+
+    Carries only the operator-set identity + routing fields. The
+    server derives ``id`` / ``tenant_id`` / ``created_at`` /
+    ``updated_at`` / ``status`` and leaves the probe-written liveness
+    (``last_ingested_at`` / ``doc_count`` / ``readiness``) NULL until the
+    first probe — so none of those appear here. ``tenant_id`` is taken
+    from the JWT in every front, never the body; a body carrying one is
+    not modelled (``extra="forbid"`` rejects it) so a writer cannot even
+    attempt a cross-tenant create. Mirrors
+    :class:`~meho_backplane.targets.schemas.TargetCreate`.
+    """
+
+    model_config = ConfigDict(extra="forbid")
+
+    collection_key: str = Field(min_length=1, max_length=128)
+    vendor: str = Field(min_length=1, max_length=256)
+    products: tuple[str, ...] = ()
+    description: str | None = None
+    when_to_use: str | None = None
+    backend: DocCollectionBackend
+    extras: Mapping[str, Any] = Field(default_factory=dict)
+
+    @field_validator("products")
+    @classmethod
+    def _strip_empty_products(cls, value: tuple[str, ...]) -> tuple[str, ...]:
+        """Reject blank product tokens — a ``""`` entry is a typo, not a product."""
+        if any(not p.strip() for p in value):
+            msg = "products entries must be non-empty"
+            raise ValueError(msg)
+        return value
 
 
 class DocCollection(BaseModel):
@@ -113,6 +174,35 @@ class DocCollectionSummary(BaseModel):
     readiness: Mapping[str, Any] | None
     created_at: datetime
     updated_at: datetime
+
+
+def project_doc_collection(c: DocCollectionORM) -> DocCollection:
+    """Project a :class:`DocCollectionORM` row to the full wire shape.
+
+    The detail counterpart to :func:`project_doc_collection_to_summary` —
+    the single ORM→:class:`DocCollection` projection the create route
+    returns (#1739). Coerces the ORM's mutable ``list[str]`` ``products``
+    column to the frozen schema's ``tuple[str, ...]`` so the returned
+    instance is genuinely immutable; the JSON columns (``backend`` /
+    ``readiness`` / ``extras``) ride through as ``Mapping``.
+    """
+    return DocCollection(
+        id=c.id,
+        tenant_id=c.tenant_id,
+        collection_key=c.collection_key,
+        vendor=c.vendor,
+        products=tuple(c.products),
+        description=c.description,
+        when_to_use=c.when_to_use,
+        backend=c.backend,
+        status=c.status,
+        last_ingested_at=c.last_ingested_at,
+        doc_count=c.doc_count,
+        readiness=c.readiness,
+        extras=c.extras,
+        created_at=c.created_at,
+        updated_at=c.updated_at,
+    )
 
 
 def project_doc_collection_to_summary(c: DocCollectionORM) -> DocCollectionSummary:

--- a/backend/src/meho_backplane/docs_collections/service.py
+++ b/backend/src/meho_backplane/docs_collections/service.py
@@ -1,10 +1,17 @@
 # SPDX-License-Identifier: Apache-2.0
 # Copyright (c) 2026 evoila Group
 
-"""Probe write-back + operator lifecycle service for doc collections (T6 #1555).
+"""Create + probe write-back + operator lifecycle service for doc collections.
 
-Two write paths against a :class:`~meho_backplane.db.models.DocCollection`
-row, both modelled on the ``probe_target`` / connector-enable precedents:
+Three write paths against a :class:`~meho_backplane.db.models.DocCollection`
+row. :func:`create_doc_collection` (#1739) registers a new row, modelled on
+``create_target``: ``tenant_id`` from the operator (never the body), the
+``backend.type`` validated against the search-backend registry with a
+structured 422 (the ``create_target`` unknown-product shape), an
+``IntegrityError`` on a cross-scope ``collection_key`` collision mapped to
+409, and the ``meho.docs.collections.create`` audit op bound so the write
+joins the ``op_id="meho.docs.*"`` who-touched trail. The other two are
+modelled on the ``probe_target`` / connector-enable precedents:
 
 * :func:`probe_collection` — resolve the row's backend, read its typed
   :class:`~meho_backplane.docs_search.backends.base.BackendReadiness`, and
@@ -28,9 +35,11 @@ meho probes + reflects).
 
 from __future__ import annotations
 
+import uuid
 from datetime import UTC, datetime
 
 import structlog
+from sqlalchemy.exc import IntegrityError
 from sqlalchemy.ext.asyncio import AsyncSession
 
 from meho_backplane.auth.operator import Operator
@@ -42,14 +51,166 @@ from meho_backplane.docs_collections.lifecycle import (
     apply_probe_transition,
     status_for_readiness,
 )
+from meho_backplane.docs_collections.schemas import DocCollectionCreate
 from meho_backplane.docs_search.backends import BackendReadiness, resolve_backend
+from meho_backplane.docs_search.backends.registry import all_backends
 
 __all__ = [
+    "DocCollectionBackendTypeError",
+    "DocCollectionConflictError",
+    "create_doc_collection",
     "probe_collection",
     "set_collection_enabled",
 ]
 
 _log = structlog.get_logger(__name__)
+
+#: Canonical audit op_id for the create — the SAME ``meho.docs.*`` family
+#: the list route / lifecycle verbs bind, so a ``query_audit`` filter on
+#: ``op_id="meho.docs.*"`` catches the registration transport-independently
+#: (G4.5-T8 #1549). ``op_class="write"`` — create mutates the registry.
+_CREATE_OP_ID = "meho.docs.collections.create"
+
+
+class DocCollectionBackendTypeError(Exception):
+    """The ``backend.type`` is not a registered search backend.
+
+    Carries the structured 422 ``detail`` the create fronts surface so an
+    operator who typed an unroutable backend type sees the registered set
+    at create time instead of an opaque 503 at probe/search time. The
+    detail shape mirrors ``create_target``'s ``unknown_product`` 422 (a
+    stable ``kind`` code + the offending value + the valid set + a human
+    ``message``).
+    """
+
+    def __init__(self, backend_type: str, valid_types: list[str]) -> None:
+        self.backend_type = backend_type
+        self.valid_types = valid_types
+        self.detail: dict[str, object] = {
+            "kind": "unknown_backend_type",
+            "backend_type": backend_type,
+            "valid_backend_types": valid_types,
+            "message": (
+                f"backend.type={backend_type!r} is not a registered search "
+                f"backend; pick one of {valid_types!r}. An unroutable "
+                f"collection would commit but fail every probe / search with "
+                f"a 503."
+            ),
+        }
+        super().__init__(self.detail["message"])
+
+
+class DocCollectionConflictError(Exception):
+    """A collection with this ``collection_key`` already exists in the scope.
+
+    Raised when the create's flush hits one of the two partial-unique
+    indexes (global ``collection_key`` / per-tenant
+    ``(tenant_id, collection_key)``). The fronts map it to 409 (REST) /
+    ``-32602`` (MCP) so a cross-scope collision is a typed conflict, not
+    an opaque 500 / IntegrityError.
+    """
+
+    def __init__(self, collection_key: str, *, tenant_scoped: bool) -> None:
+        self.collection_key = collection_key
+        self.tenant_scoped = tenant_scoped
+        scope = "tenant" if tenant_scoped else "global"
+        super().__init__(f"doc collection {collection_key!r} already exists in the {scope} scope")
+
+
+async def create_doc_collection(
+    session: AsyncSession,
+    operator: Operator,
+    body: DocCollectionCreate,
+) -> DocCollectionORM:
+    """Register a new doc collection in the operator's tenant.
+
+    Mirrors :func:`~meho_backplane.api.v1.targets.create_target`:
+    ``tenant_id`` is always the operator's (the body cannot override it);
+    ``id`` / timestamps are generated server-side; ``status`` defaults to
+    ``provisioning`` (a follow-up probe promotes it to ``ready``).
+    ``backend.type`` is validated against
+    :func:`~meho_backplane.docs_search.backends.registry.all_backends`
+    before the insert so an unroutable type is a structured 422
+    (:class:`DocCollectionBackendTypeError`), not a deferred probe-time
+    503. A cross-scope ``collection_key`` collision surfaces as a typed
+    :class:`DocCollectionConflictError` (409), not an opaque IntegrityError.
+
+    The caller owns the transaction boundary (the route's
+    ``async with session.begin()``); this function flushes but never
+    commits, so a downstream failure rolls the insert back.
+
+    Args:
+        session: Active async session inside the front's open transaction.
+        operator: The verified operator; ``operator.tenant_id`` is the
+            row's tenant — the body's ``tenant_id`` (if any) is ignored
+            (the schema forbids it).
+        body: The validated create request.
+
+    Returns:
+        The flushed :class:`DocCollectionORM` row (``id`` / timestamps
+        populated).
+
+    Raises:
+        DocCollectionBackendTypeError: ``backend.type`` is not registered;
+            the front maps it to 422.
+        DocCollectionConflictError: a collection with this ``collection_key``
+            already exists in the operator's scope; the front maps it to 409.
+    """
+    # Bind the canonical op_id up-front so a persisted audit row is
+    # filterable by ``op_id="meho.docs.*"`` even if the insert raises
+    # below (G4.5-T8 #1549). ``op_class="write"`` — create mutates the
+    # registry.
+    structlog.contextvars.bind_contextvars(
+        audit_op_id=_CREATE_OP_ID,
+        audit_op_class="write",
+    )
+
+    # Validate ``backend.type`` against the registry BEFORE the insert so
+    # the operator sees the registered set at create time. ``all_backends``
+    # is populated at import time (the adapters self-register), so the set
+    # is non-empty in every real deploy; an empty registry would be a
+    # boot-order bug, and validating against an empty set would reject
+    # every create, so — matching ``create_target``'s empty-registry skip —
+    # we only enforce when the registry is populated.
+    valid_types = sorted(all_backends())
+    if valid_types and body.backend.type not in valid_types:
+        raise DocCollectionBackendTypeError(body.backend.type, valid_types)
+
+    now = datetime.now(UTC)
+    row = DocCollectionORM(
+        id=uuid.uuid4(),
+        tenant_id=operator.tenant_id,
+        collection_key=body.collection_key,
+        vendor=body.vendor,
+        products=list(body.products),
+        description=body.description,
+        when_to_use=body.when_to_use,
+        backend={"type": body.backend.type, "ref": dict(body.backend.ref)},
+        status=STATUS_PROVISIONING,
+        last_ingested_at=None,
+        doc_count=None,
+        readiness=None,
+        extras=dict(body.extras),
+        created_at=now,
+        updated_at=now,
+    )
+    session.add(row)
+    try:
+        await session.flush()
+    except IntegrityError as exc:
+        raise DocCollectionConflictError(
+            body.collection_key,
+            tenant_scoped=operator.tenant_id is not None,
+        ) from exc
+
+    _log.info(
+        "doc_collection_created",
+        collection_key=row.collection_key,
+        tenant_scope="tenant" if row.tenant_id is not None else "global",
+        backend_type=body.backend.type,
+        status=row.status,
+    )
+    return row
 
 
 async def probe_collection(

--- a/backend/src/meho_backplane/mcp/tools/doc_collections_create.py
+++ b/backend/src/meho_backplane/mcp/tools/doc_collections_create.py
@@ -1,0 +1,243 @@
+# SPDX-License-Identifier: Apache-2.0
+# Copyright (c) 2026 evoila Group
+
+"""``create_doc_collections`` — the registry-create MCP tool (#1739).
+
+The write sibling of the ``list_doc_collections`` catalogue tool
+(``mcp/tools/doc_collections.py``). ``list_doc_collections`` answers "what
+docs can I search?"; this tool registers a new collection so an operator /
+agent can seed one without a raw ``INSERT INTO doc_collections`` — closing
+the validated, audited create-half gap Ops hit on the first co-located
+corpus round-trip (claude-rdc-hetzner-dc#975).
+
+Two gates, mirroring the lifecycle write fronts
+================================================
+
+* ``required_capability="meho-docs"`` (G4.5-T1 #1519) — a tenant that has
+  not provisioned the add-on never sees the tool in ``tools/list`` and a
+  direct ``tools/call`` is rejected before the handler runs. The same gate
+  ``list_doc_collections`` / ``search_docs`` declare.
+* ``required_role=TENANT_ADMIN``, ``op_class="write"`` — a create mutates
+  the registry, so it carries the tenant_admin floor the REST create route
+  and the ``meho.connector.*`` write tools use, not the OPERATOR floor the
+  read-class catalogue tool uses.
+
+The tool is a thin front: it validates + builds a
+:class:`~meho_backplane.docs_collections.DocCollectionCreate` from the
+JSON-Schema-validated arguments and forwards to
+:func:`~meho_backplane.docs_collections.create_doc_collection`, which owns
+``tenant_id``-from-operator, ``backend.type`` registry validation, the
+``IntegrityError → conflict`` mapping, and the
+``op_id="meho.docs.collections.create"`` audit bind. ``tenant_id`` is never
+an argument — ``additionalProperties: false`` already rejects a smuggled
+one at the schema layer, so a cross-tenant create is structurally
+impossible.
+
+A separate module (not an addition to ``mcp/tools/doc_collections.py``)
+mirrors ``topology_create_node`` splitting off ``mcp/tools/topology`` —
+the tool registry auto-discovers every module under
+``meho_backplane.mcp.tools``, so a new file registers identically without
+wiring changes and keeps the read-class catalogue module focused.
+"""
+
+from __future__ import annotations
+
+from typing import Any, Final
+
+from pydantic import ValidationError
+
+from meho_backplane.auth.operator import Operator, TenantRole
+from meho_backplane.db.engine import get_sessionmaker
+from meho_backplane.docs_collections import (
+    DocCollectionBackendTypeError,
+    DocCollectionConflictError,
+    DocCollectionCreate,
+    create_doc_collection,
+    project_doc_collection,
+)
+from meho_backplane.mcp.registry import ToolDefinition, register_mcp_tool
+from meho_backplane.mcp.server import McpInvalidParamsError
+
+__all__: list[str] = []
+
+_DOCS_CAPABILITY: Final[str] = "meho-docs"
+_OP_CLASS_WRITE: Final[str] = "write"
+_CREATE_TOOL_NAME: Final[str] = "create_doc_collections"
+
+
+_CREATE_DOC_COLLECTIONS_DESCRIPTION: Final[str] = (
+    "Register a new documentation collection in your tenant so "
+    "`search_docs` / `ask_docs` can route to it — the write half of the "
+    "doc-collection registry (tenant_admin only). Seeds identity + the "
+    "backend binding; it does NOT trigger ingest or an index rebuild — "
+    "`status` defaults to `provisioning` and a follow-up "
+    "`meho.docs.collections` probe promotes it to `ready` once its index "
+    "confirms.\n\n"
+    "Tenant-scoped automatically — there is no `tenant_id` argument "
+    "(cross-tenant creation is structurally impossible; the collection is "
+    "created in your own tenant). `backend.type` must be a registered "
+    "search backend (e.g. `corpus-http`) — an unregistered type is "
+    "rejected up front rather than committing an unroutable row that "
+    "would fail every later probe / search. A `collection_key` that "
+    "already exists in your scope is rejected as a conflict.\n\n"
+    "WHEN TO CALL: to register a corpus an operator has stood up "
+    "(e.g. a co-located MEHO.Knowledge project) so agents can search it, "
+    "instead of seeding the row by a raw database INSERT. Returns the "
+    "full created collection `{id, collection_key, vendor, products, "
+    "backend, status, ...}`."
+)
+
+
+_CREATE_DOC_COLLECTIONS_INPUT_SCHEMA: Final[dict[str, Any]] = {
+    "type": "object",
+    "properties": {
+        "collection_key": {
+            "type": "string",
+            "minLength": 1,
+            "maxLength": 128,
+            "description": (
+                "Stable operator-chosen id (e.g. `vmware`). The key an "
+                "agent passes as `search_docs --collection`; must match the "
+                "`meho-docs:<collection_key>` capability that entitles a "
+                "tenant to search it. Unique within your scope."
+            ),
+        },
+        "vendor": {
+            "type": "string",
+            "minLength": 1,
+            "maxLength": 256,
+            "description": "The vendor the corpus covers (e.g. 'VMware by Broadcom').",
+        },
+        "products": {
+            "type": "array",
+            "items": {"type": "string", "minLength": 1},
+            "description": "Products the corpus covers, e.g. ['vsphere', 'nsx']. Optional.",
+        },
+        "description": {
+            "type": ["string", "null"],
+            "description": "Optional free-text description of the collection.",
+        },
+        "when_to_use": {
+            "type": ["string", "null"],
+            "description": (
+                "Optional 'pick this collection when…' blurb surfaced "
+                "verbatim by `list_doc_collections` so an agent can choose "
+                "the right corpus before searching."
+            ),
+        },
+        "backend": {
+            "type": "object",
+            "properties": {
+                "type": {
+                    "type": "string",
+                    "minLength": 1,
+                    "description": (
+                        "The search-backend type this collection routes to "
+                        "(e.g. `corpus-http`). Must be a registered backend."
+                    ),
+                },
+                "ref": {
+                    "type": "object",
+                    "description": (
+                        "Per-collection backend config the adapter reads "
+                        "(e.g. {'endpoint': 'https://corpus/v1/search'} for "
+                        "`corpus-http`). Shape is owned by the backend type."
+                    ),
+                },
+            },
+            "required": ["type", "ref"],
+            "additionalProperties": False,
+            "description": "The {type, ref} backend routing record. Required.",
+        },
+        "extras": {
+            "type": "object",
+            "description": "Optional forward-compat structured fields with no first-class column.",
+        },
+    },
+    "required": ["collection_key", "vendor", "backend"],
+    "additionalProperties": False,
+}
+
+
+_CREATE_DOC_COLLECTIONS_OUTPUT_SCHEMA: Final[dict[str, Any]] = {
+    "type": "object",
+    "properties": {
+        "id": {"type": "string"},
+        "tenant_id": {"type": ["string", "null"]},
+        "collection_key": {"type": "string"},
+        "vendor": {"type": "string"},
+        "products": {"type": "array", "items": {"type": "string"}},
+        "description": {"type": ["string", "null"]},
+        "when_to_use": {"type": ["string", "null"]},
+        "backend": {"type": "object"},
+        "status": {"type": "string"},
+        "created_at": {"type": "string"},
+        "updated_at": {"type": "string"},
+    },
+    "required": [
+        "id",
+        "collection_key",
+        "vendor",
+        "products",
+        "backend",
+        "status",
+    ],
+}
+
+
+async def _create_doc_collections_handler(
+    operator: Operator,
+    arguments: dict[str, Any],
+) -> dict[str, Any]:
+    """Dispatch a ``create_doc_collections`` call to :func:`create_doc_collection`.
+
+    The dispatcher has already jsonschema-validated *arguments* against
+    :data:`_CREATE_DOC_COLLECTIONS_INPUT_SCHEMA` (so ``collection_key`` /
+    ``vendor`` / ``backend`` are present and ``additionalProperties: false``
+    has rejected a smuggled ``tenant_id``); the Pydantic
+    :class:`DocCollectionCreate` re-validation is a belt-and-suspenders
+    boundary that also normalises ``products`` and rejects a blank product
+    token. The service owns ``tenant_id``-from-operator + the registry /
+    conflict mapping; this front only translates the typed exceptions into
+    the JSON-RPC ``INVALID_PARAMS`` envelope (the MCP analogue of the REST
+    422 / 409).
+    """
+    try:
+        body = DocCollectionCreate.model_validate(arguments)
+    except ValidationError as exc:
+        raise McpInvalidParamsError(
+            "invalid create_doc_collections arguments",
+            data={"errors": exc.errors(include_url=False)},
+        ) from exc
+
+    sessionmaker = get_sessionmaker()
+    async with sessionmaker() as session:
+        try:
+            async with session.begin():
+                row = await create_doc_collection(session, operator, body)
+                # Project inside the transaction so the frozen wire model is
+                # built off attributes still attached to the live session.
+                created = project_doc_collection(row)
+        except DocCollectionBackendTypeError as exc:
+            raise McpInvalidParamsError(str(exc), data=exc.detail) from exc
+        except DocCollectionConflictError as exc:
+            raise McpInvalidParamsError(
+                str(exc),
+                data={"kind": "collection_conflict", "collection_key": exc.collection_key},
+            ) from exc
+
+    return created.model_dump(mode="json")
+
+
+register_mcp_tool(
+    definition=ToolDefinition(
+        name=_CREATE_TOOL_NAME,
+        description=_CREATE_DOC_COLLECTIONS_DESCRIPTION,
+        inputSchema=_CREATE_DOC_COLLECTIONS_INPUT_SCHEMA,
+        outputSchema=_CREATE_DOC_COLLECTIONS_OUTPUT_SCHEMA,
+        required_role=TenantRole.TENANT_ADMIN,
+        op_class=_OP_CLASS_WRITE,
+        required_capability=_DOCS_CAPABILITY,
+    ),
+    handler=_create_doc_collections_handler,
+)

--- a/backend/tests/mcp_test_fixtures.py
+++ b/backend/tests/mcp_test_fixtures.py
@@ -215,6 +215,9 @@ def isolated_registry() -> Iterator[None]:
     from meho_backplane.mcp.tools import (
         doc_collections as doc_collections_tools,
     )
+    from meho_backplane.mcp.tools import (
+        doc_collections_create as doc_collections_create_tool,
+    )
     from meho_backplane.mcp.tools import memory as memory_tools
     from meho_backplane.mcp.tools import memory_promote as memory_promote_tool
 
@@ -257,6 +260,14 @@ def isolated_registry() -> Iterator[None]:
     # otherwise leave it unregistered in any test file that imports this
     # fixture after the first one runs in the process.
     importlib.reload(doc_collections_tools)
+    # #1739: the ``create_doc_collections`` registry-create tool lives in a
+    # separate module (mirroring topology_create_node) so the read-class
+    # ``doc_collections`` catalogue module stays focused; it joins the
+    # reload list for the same reason every other tool module does -- the
+    # autouse ``clear_registries()`` above would otherwise leave it
+    # unregistered in any test file that imports this fixture after the
+    # first one runs in the process.
+    importlib.reload(doc_collections_create_tool)
     importlib.reload(topology)
     importlib.reload(topology_create_node)
     # G12.2-T4 (#1298): the runbook template MCP tools

--- a/backend/tests/test_doc_collections_create.py
+++ b/backend/tests/test_doc_collections_create.py
@@ -1,0 +1,250 @@
+# SPDX-License-Identifier: Apache-2.0
+# Copyright (c) 2026 evoila Group
+
+"""Behavioural tests for the doc-collection create surface (#1739).
+
+Covers the create half added across REST + service (the MCP create tool is
+covered in :mod:`tests.test_mcp_tools_doc_collections`), mirroring the
+``create_target`` precedent's guardrails:
+
+* **201 + full body** — a valid create returns the full ``DocCollection``
+  with a server-generated ``id`` / timestamps and ``status="provisioning"``.
+* **tenant_id from JWT, never the body** — a body that tries to smuggle a
+  ``tenant_id`` is rejected by the schema (``extra="forbid"``); the created
+  row's tenant is always the operator's.
+* **unknown backend type → 422** (not a deferred 503), and the detail
+  enumerates the registered backend types.
+* **cross-scope key collision → 409** (not an opaque 500 / IntegrityError).
+* **non-tenant_admin → 403** (parity with enable / disable).
+* **audit** — the create writes one ``audit_log`` row with
+  ``op_id="meho.docs.collections.create"`` / ``op_class="write"``,
+  joinable under an ``op_id="meho.docs.*"`` filter.
+
+Runs against ``sqlite+aiosqlite`` via the shared pre-migrated engine, the
+same harness :mod:`tests.test_doc_collections_readiness` uses.
+"""
+
+from __future__ import annotations
+
+import uuid
+from collections.abc import Iterator
+from typing import Any
+
+import pytest
+import respx
+from fastapi import FastAPI
+from fastapi.testclient import TestClient
+from sqlalchemy import select
+
+from meho_backplane.audit import AuditMiddleware
+from meho_backplane.auth.jwt import clear_jwks_cache
+from meho_backplane.auth.operator import TenantRole
+from meho_backplane.db.engine import get_sessionmaker, reset_engine_for_testing
+from meho_backplane.db.models import AuditLog
+from meho_backplane.db.models import DocCollection as DocCollectionORM
+from meho_backplane.middleware import RequestContextMiddleware
+from meho_backplane.settings import get_settings
+
+from ._oidc_jwt_helpers import (
+    AUDIENCE as _AUDIENCE,
+)
+from ._oidc_jwt_helpers import (
+    DEFAULT_TENANT_ID,
+    make_rsa_keypair,
+    mint_token,
+    mock_discovery_and_jwks,
+    public_jwks,
+)
+from ._oidc_jwt_helpers import (
+    ISSUER as _ISSUER,
+)
+
+_CORPUS_URL = "https://corpus.test/v1/search"
+
+
+@pytest.fixture(autouse=True)
+def _settings_env(monkeypatch: pytest.MonkeyPatch) -> Iterator[None]:
+    """Pin the env :class:`Settings` requires + a configured corpus."""
+    monkeypatch.setenv("KEYCLOAK_ISSUER_URL", _ISSUER)
+    monkeypatch.setenv("KEYCLOAK_AUDIENCE", _AUDIENCE)
+    monkeypatch.setenv("KEYCLOAK_JWKS_CACHE_TTL_SECONDS", "300")
+    monkeypatch.setenv("KEYCLOAK_JWT_LEEWAY_SECONDS", "30")
+    monkeypatch.setenv("VAULT_ADDR", "https://vault.test")
+    monkeypatch.setenv("VAULT_OIDC_ROLE", "meho-mcp")
+    monkeypatch.setenv("VAULT_OIDC_MOUNT_PATH", "jwt")
+    monkeypatch.setenv("VAULT_TIMEOUT_SECONDS", "5.0")
+    monkeypatch.delenv("VAULT_NAMESPACE", raising=False)
+    monkeypatch.setenv("CORPUS_URL", _CORPUS_URL)
+    monkeypatch.setenv("CORPUS_AUDIENCE", "")
+    get_settings.cache_clear()
+    yield
+    get_settings.cache_clear()
+
+
+@pytest.fixture(autouse=True)
+def _isolated_jwks_cache() -> Iterator[None]:
+    clear_jwks_cache()
+    yield
+    clear_jwks_cache()
+
+
+def _build_app() -> FastAPI:
+    from meho_backplane.api.v1.doc_collections import router as doc_collections_router
+
+    app = FastAPI()
+    app.add_middleware(AuditMiddleware)
+    app.add_middleware(RequestContextMiddleware)
+    app.include_router(doc_collections_router)
+    return app
+
+
+@pytest.fixture
+def client() -> Iterator[TestClient]:
+    reset_engine_for_testing()
+    yield TestClient(_build_app())
+
+
+def _admin_token(key: Any) -> str:
+    return mint_token(key, sub="admin-1", tenant_role=TenantRole.TENANT_ADMIN.value)
+
+
+def _operator_token(key: Any) -> str:
+    return mint_token(key, sub="op-1", tenant_role=TenantRole.OPERATOR.value)
+
+
+def _valid_body(**overrides: Any) -> dict[str, Any]:
+    body: dict[str, Any] = {
+        "collection_key": "vmware",
+        "vendor": "VMware by Broadcom",
+        "products": ["vsphere", "nsx"],
+        "when_to_use": "Use for VMware product questions.",
+        "backend": {"type": "corpus-http", "ref": {"endpoint": _CORPUS_URL}},
+    }
+    body.update(overrides)
+    return body
+
+
+def _post(client: TestClient, key: Any, token: str, body: dict[str, Any]) -> Any:
+    with respx.mock as mock_router:
+        mock_discovery_and_jwks(mock_router, public_jwks(key))
+        return client.post(
+            "/api/v1/doc_collections",
+            json=body,
+            headers={"Authorization": f"Bearer {token}"},
+        )
+
+
+async def _fetch_row(collection_key: str) -> DocCollectionORM:
+    sm = get_sessionmaker()
+    async with sm() as session:
+        return (
+            await session.execute(
+                select(DocCollectionORM).where(DocCollectionORM.collection_key == collection_key)
+            )
+        ).scalar_one()
+
+
+async def _audit_rows() -> list[AuditLog]:
+    sm = get_sessionmaker()
+    async with sm() as session:
+        result = await session.execute(select(AuditLog).order_by(AuditLog.occurred_at))
+        return list(result.scalars().all())
+
+
+# ---------------------------------------------------------------------------
+# Happy path
+# ---------------------------------------------------------------------------
+
+
+def test_create_returns_201_with_full_collection(client: TestClient) -> None:
+    key = make_rsa_keypair("kid-A")
+    resp = _post(client, key, _admin_token(key), _valid_body())
+    assert resp.status_code == 201, resp.text
+    body = resp.json()
+    assert body["collection_key"] == "vmware"
+    assert body["vendor"] == "VMware by Broadcom"
+    assert body["products"] == ["vsphere", "nsx"]
+    # Server-derived fields.
+    assert uuid.UUID(body["id"])
+    assert body["status"] == "provisioning"
+    assert body["last_ingested_at"] is None
+    assert body["doc_count"] is None
+    # The backend record round-trips (it is part of the full read shape).
+    assert body["backend"] == {"type": "corpus-http", "ref": {"endpoint": _CORPUS_URL}}
+
+
+@pytest.mark.asyncio
+async def test_create_tenant_id_comes_from_jwt_not_body(client: TestClient) -> None:
+    """A body smuggling a different tenant_id cannot override the JWT's."""
+    key = make_rsa_keypair("kid-A")
+    foreign_tenant = str(uuid.uuid4())
+    body = _valid_body(tenant_id=foreign_tenant)
+    resp = _post(client, key, _admin_token(key), body)
+    # extra="forbid" rejects the unmodelled tenant_id field outright (422).
+    assert resp.status_code == 422, resp.text
+
+    # And a clean create lands on the operator's tenant, never a body value.
+    resp_ok = _post(client, key, _admin_token(key), _valid_body())
+    assert resp_ok.status_code == 201, resp_ok.text
+    row = await _fetch_row("vmware")
+    assert str(row.tenant_id) == DEFAULT_TENANT_ID
+
+
+# ---------------------------------------------------------------------------
+# Validation: unknown backend type → 422 (not a deferred 503)
+# ---------------------------------------------------------------------------
+
+
+def test_unknown_backend_type_is_422_listing_registered_types(client: TestClient) -> None:
+    key = make_rsa_keypair("kid-A")
+    body = _valid_body(backend={"type": "no-such-backend", "ref": {}})
+    resp = _post(client, key, _admin_token(key), body)
+    assert resp.status_code == 422, resp.text
+    detail = resp.json()["detail"]
+    assert detail["kind"] == "unknown_backend_type"
+    assert detail["backend_type"] == "no-such-backend"
+    # The detail enumerates the registered backend types (from all_backends()).
+    assert "corpus-http" in detail["valid_backend_types"]
+
+
+# ---------------------------------------------------------------------------
+# Conflict: duplicate key in the same scope → 409 (not an opaque 500)
+# ---------------------------------------------------------------------------
+
+
+def test_duplicate_collection_key_in_scope_is_409(client: TestClient) -> None:
+    key = make_rsa_keypair("kid-A")
+    first = _post(client, key, _admin_token(key), _valid_body())
+    assert first.status_code == 201, first.text
+    second = _post(client, key, _admin_token(key), _valid_body())
+    assert second.status_code == 409, second.text
+
+
+# ---------------------------------------------------------------------------
+# RBAC: non-tenant_admin → 403 (parity with enable / disable)
+# ---------------------------------------------------------------------------
+
+
+def test_create_requires_tenant_admin(client: TestClient) -> None:
+    key = make_rsa_keypair("kid-A")
+    resp = _post(client, key, _operator_token(key), _valid_body())
+    assert resp.status_code == 403, resp.text
+
+
+# ---------------------------------------------------------------------------
+# Audit
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.asyncio
+async def test_create_writes_audit_row_with_canonical_op_id(client: TestClient) -> None:
+    key = make_rsa_keypair("kid-A")
+    resp = _post(client, key, _admin_token(key), _valid_body())
+    assert resp.status_code == 201, resp.text
+
+    rows = await _audit_rows()
+    create_rows = [r for r in rows if r.payload.get("op_id") == "meho.docs.collections.create"]
+    assert len(create_rows) == 1, [r.payload.get("op_id") for r in rows]
+    assert create_rows[0].payload["op_class"] == "write"
+    # Joinable under the meho.docs.* who-touched filter.
+    assert create_rows[0].payload["op_id"].startswith("meho.docs.")

--- a/backend/tests/test_mcp_tools_doc_collections_create.py
+++ b/backend/tests/test_mcp_tools_doc_collections_create.py
@@ -1,0 +1,303 @@
+# SPDX-License-Identifier: Apache-2.0
+# Copyright (c) 2026 evoila Group
+
+"""Tests for the ``create_doc_collections`` registry-create MCP tool (#1739).
+
+Covers the write half added to the doc-collections MCP surface, mirroring
+the ``list_doc_collections`` test harness:
+
+* **Registration gates** — the tool declares ``tenant_admin`` role,
+  ``write`` op_class, and the ``meho-docs`` capability (parity with the
+  REST create route + the ``meho.connector.*`` write-tool precedent).
+* **Capability gate** — absent from ``tools/list`` for an unprovisioned
+  tenant; a direct ``tools/call`` 403s before the handler runs.
+* **Role gate** — a provisioned plain OPERATOR (not tenant_admin) is 403'd.
+* **Happy path** — a valid create returns the full collection with
+  ``status="provisioning"`` and a server-generated id; the row lands on the
+  operator's tenant.
+* **Unknown backend type → INVALID_PARAMS** with the registered set in
+  ``error.data`` (the MCP analogue of the REST 422).
+* **Duplicate key → INVALID_PARAMS** (the MCP analogue of the REST 409).
+* **Audit** — one ``audit_log`` row with
+  ``op_id="meho.docs.collections.create"`` / ``op_class="write"``.
+"""
+
+from __future__ import annotations
+
+import json
+from collections.abc import Iterator
+from typing import Any
+
+import pytest
+from fastapi.testclient import TestClient
+from sqlalchemy import select
+
+from meho_backplane.auth.operator import Operator, TenantRole
+from meho_backplane.db.engine import get_sessionmaker
+from meho_backplane.db.models import AuditLog
+from meho_backplane.db.models import DocCollection as DocCollectionORM
+from meho_backplane.main import app
+from meho_backplane.mcp.auth import verify_mcp_jwt_and_bind
+from meho_backplane.mcp.registry import get_tool
+from meho_backplane.mcp.schemas import INVALID_PARAMS
+from tests.mcp_test_fixtures import (
+    OPERATOR_TENANT_ID,
+    isolated_registry,  # noqa: F401 — pytest-discovered autouse fixture
+    post_mcp,
+    required_settings_env,  # noqa: F401 — pytest-discovered autouse fixture
+    seeded_operator_tenant,  # noqa: F401 — pytest-discovered fixture
+)
+
+_DOCS_CAPABILITY = "meho-docs"
+_CREATE_TOOL = "create_doc_collections"
+
+
+def _operator(
+    *,
+    role: TenantRole = TenantRole.TENANT_ADMIN,
+    capabilities: frozenset[str] = frozenset(),
+) -> Operator:
+    return Operator(
+        sub="admin-test",
+        name="Admin",
+        email=None,
+        raw_jwt="fixture-jwt-not-real",
+        tenant_id=OPERATOR_TENANT_ID,
+        tenant_role=role,
+        capabilities=capabilities,
+    )
+
+
+@pytest.fixture
+def admin_client(
+    request: pytest.FixtureRequest,
+) -> Iterator[tuple[TestClient, Operator]]:
+    """``TestClient`` whose operator's role + capability set are parametrised.
+
+    Default is a tenant_admin with no capability (so the capability gate is
+    exercisable); provision with
+    ``@pytest.mark.parametrize("admin_client", [(role, frozenset({...}))], indirect=True)``.
+    """
+    param = getattr(request, "param", None)
+    if param is None:
+        role, capabilities = TenantRole.TENANT_ADMIN, frozenset()
+    else:
+        role, capabilities = param
+    op = _operator(role=role, capabilities=capabilities)
+
+    async def _fake_verify() -> Operator:
+        return op
+
+    app.dependency_overrides[verify_mcp_jwt_and_bind] = _fake_verify
+    try:
+        with TestClient(app) as client:
+            yield client, op
+    finally:
+        app.dependency_overrides.pop(verify_mcp_jwt_and_bind, None)
+
+
+def _valid_args(**overrides: Any) -> dict[str, Any]:
+    args: dict[str, Any] = {
+        "collection_key": "vmware",
+        "vendor": "VMware by Broadcom",
+        "products": ["vsphere", "nsx"],
+        "backend": {"type": "corpus-http", "ref": {"endpoint": "https://corpus.test/v1/search"}},
+    }
+    args.update(overrides)
+    return args
+
+
+def _call_create(client: TestClient, arguments: dict[str, Any]) -> dict[str, Any]:
+    response = post_mcp(
+        client,
+        {
+            "jsonrpc": "2.0",
+            "id": 1,
+            "method": "tools/call",
+            "params": {"name": _CREATE_TOOL, "arguments": arguments},
+        },
+    )
+    assert response.status_code == 200
+    return response.json()
+
+
+def _payload(body: dict[str, Any]) -> dict[str, Any]:
+    assert body["result"]["isError"] is False, body
+    return json.loads(body["result"]["content"][0]["text"])
+
+
+async def _fetch_row(collection_key: str) -> DocCollectionORM:
+    sm = get_sessionmaker()
+    async with sm() as session:
+        return (
+            await session.execute(
+                select(DocCollectionORM).where(DocCollectionORM.collection_key == collection_key)
+            )
+        ).scalar_one()
+
+
+async def _mcp_audit_rows() -> list[AuditLog]:
+    sm = get_sessionmaker()
+    async with sm() as session:
+        result = await session.execute(select(AuditLog).order_by(AuditLog.occurred_at))
+        return [row for row in result.scalars().all() if row.method == "MCP"]
+
+
+# ---------------------------------------------------------------------------
+# Registration gates
+# ---------------------------------------------------------------------------
+
+
+def test_registered_definition_is_admin_write_capability_gated() -> None:
+    entry = get_tool(_CREATE_TOOL)
+    assert entry is not None
+    defn, _handler = entry
+    assert defn.required_role == TenantRole.TENANT_ADMIN
+    assert defn.op_class == "write"
+    assert defn.required_capability == _DOCS_CAPABILITY
+
+
+@pytest.mark.parametrize(
+    "admin_client",
+    [(TenantRole.TENANT_ADMIN, frozenset({_DOCS_CAPABILITY}))],
+    indirect=True,
+)
+def test_present_with_strict_schema_for_provisioned_admin(
+    admin_client: tuple[TestClient, Operator],
+) -> None:
+    client, _op = admin_client
+    response = post_mcp(client, {"jsonrpc": "2.0", "id": 1, "method": "tools/list"})
+    tools_by_name = {t["name"]: t for t in response.json()["result"]["tools"]}
+    assert _CREATE_TOOL in tools_by_name
+    schema = tools_by_name[_CREATE_TOOL]["inputSchema"]
+    assert schema["additionalProperties"] is False
+    # tenant_id is NOT an argument — a cross-tenant create is impossible.
+    assert "tenant_id" not in schema["properties"]
+    assert set(schema["required"]) == {"collection_key", "vendor", "backend"}
+
+
+def test_absent_from_tools_list_for_unprovisioned_admin(
+    admin_client: tuple[TestClient, Operator],
+) -> None:
+    client, _op = admin_client  # default: admin, no capability
+    response = post_mcp(client, {"jsonrpc": "2.0", "id": 1, "method": "tools/list"})
+    names = {t["name"] for t in response.json()["result"]["tools"]}
+    assert _CREATE_TOOL not in names
+
+
+# ---------------------------------------------------------------------------
+# Gates on tools/call
+# ---------------------------------------------------------------------------
+
+
+def test_tools_call_403_when_unprovisioned(
+    admin_client: tuple[TestClient, Operator],
+) -> None:
+    client, _op = admin_client
+    body = _call_create(client, _valid_args())
+    assert body["error"]["code"] == INVALID_PARAMS
+    assert "forbidden" in body["error"]["message"].lower()
+
+
+@pytest.mark.parametrize(
+    "admin_client",
+    [(TenantRole.OPERATOR, frozenset({_DOCS_CAPABILITY}))],
+    indirect=True,
+)
+def test_tools_call_403_for_plain_operator(
+    admin_client: tuple[TestClient, Operator],
+) -> None:
+    """The capability does not relax the role gate: OPERATOR cannot create."""
+    client, _op = admin_client
+    body = _call_create(client, _valid_args())
+    assert body["error"]["code"] == INVALID_PARAMS
+    assert "forbidden" in body["error"]["message"].lower()
+
+
+# ---------------------------------------------------------------------------
+# Happy path + tenant scope
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.asyncio
+@pytest.mark.parametrize(
+    "admin_client",
+    [(TenantRole.TENANT_ADMIN, frozenset({_DOCS_CAPABILITY}))],
+    indirect=True,
+)
+async def test_create_returns_full_collection_on_operators_tenant(
+    admin_client: tuple[TestClient, Operator],
+    seeded_operator_tenant: None,  # noqa: F811
+) -> None:
+    client, _op = admin_client
+    body = _call_create(client, _valid_args())
+    result = _payload(body)
+    assert result["collection_key"] == "vmware"
+    assert result["status"] == "provisioning"
+    assert result["backend"]["type"] == "corpus-http"
+
+    row = await _fetch_row("vmware")
+    assert row.tenant_id == OPERATOR_TENANT_ID
+
+
+# ---------------------------------------------------------------------------
+# Validation + conflict
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.parametrize(
+    "admin_client",
+    [(TenantRole.TENANT_ADMIN, frozenset({_DOCS_CAPABILITY}))],
+    indirect=True,
+)
+def test_unknown_backend_type_is_invalid_params(
+    admin_client: tuple[TestClient, Operator],
+) -> None:
+    client, _op = admin_client
+    body = _call_create(client, _valid_args(backend={"type": "no-such-backend", "ref": {}}))
+    assert body["error"]["code"] == INVALID_PARAMS
+    data = body["error"]["data"]
+    assert data["kind"] == "unknown_backend_type"
+    assert "corpus-http" in data["valid_backend_types"]
+
+
+@pytest.mark.parametrize(
+    "admin_client",
+    [(TenantRole.TENANT_ADMIN, frozenset({_DOCS_CAPABILITY}))],
+    indirect=True,
+)
+def test_duplicate_key_is_invalid_params(
+    admin_client: tuple[TestClient, Operator],
+    seeded_operator_tenant: None,  # noqa: F811
+) -> None:
+    client, _op = admin_client
+    first = _call_create(client, _valid_args())
+    assert first["result"]["isError"] is False, first
+    second = _call_create(client, _valid_args())
+    assert second["error"]["code"] == INVALID_PARAMS
+    assert second["error"]["data"]["kind"] == "collection_conflict"
+
+
+# ---------------------------------------------------------------------------
+# Audit
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.asyncio
+@pytest.mark.parametrize(
+    "admin_client",
+    [(TenantRole.TENANT_ADMIN, frozenset({_DOCS_CAPABILITY}))],
+    indirect=True,
+)
+async def test_create_writes_audit_row_with_canonical_op_id(
+    admin_client: tuple[TestClient, Operator],
+    seeded_operator_tenant: None,  # noqa: F811
+) -> None:
+    client, _op = admin_client
+    body = _call_create(client, _valid_args())
+    assert body["result"]["isError"] is False, body
+
+    rows = await _mcp_audit_rows()
+    create_rows = [r for r in rows if r.payload.get("op_id") == "meho.docs.collections.create"]
+    assert len(create_rows) == 1, [r.payload.get("op_id") for r in rows]
+    assert create_rows[0].payload["op_class"] == "write"

--- a/cli/api/openapi.json
+++ b/cli/api/openapi.json
@@ -537,6 +537,54 @@
             }
           }
         }
+      },
+      "post": {
+        "tags": [
+          "docs"
+        ],
+        "summary": "Create Doc Collection Endpoint",
+        "description": "Register a new doc collection in the requesting tenant.\n\nThe create sibling of the lifecycle write routes \u2014 ``tenant_admin``-\ngated, tenant-scoped (``tenant_id`` from the JWT, never the body), with\nthe validation + audit every other registry write gets. Mirrors\n``POST /api/v1/targets``: ``id`` / timestamps are generated server-side,\n``status`` defaults to ``provisioning`` (a follow-up ``probe`` promotes\nit to ``ready``), the ``backend.type`` is validated against the\nsearch-backend registry (an unregistered type \u2192 422 listing the valid\nset, not a deferred 503), and a cross-scope ``collection_key`` collision\n\u2192 409. The create binds ``op_id=\"meho.docs.collections.create\"`` so the\nregistration joins the ``op_id=\"meho.docs.*\"`` who-touched trail.",
+        "operationId": "create_doc_collection_endpoint_api_v1_doc_collections_post",
+        "parameters": [
+          {
+            "name": "authorization",
+            "in": "header",
+            "required": false,
+            "schema": {
+              "type": "string",
+              "nullable": true,
+              "title": "Authorization"
+            }
+          }
+        ],
+        "requestBody": {
+          "required": true,
+          "content": {
+            "application/json": {
+              "schema": {
+                "$ref": "#/components/schemas/DocCollectionCreate"
+              }
+            }
+          }
+        },
+        "responses": {
+          "201": {
+            "description": "Successful Response",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/DocCollection"
+                }
+              }
+            }
+          },
+          "409": {
+            "description": "A collection with this ``collection_key`` already exists in the tenant's scope (global or per-tenant)."
+          },
+          "422": {
+            "description": "The ``backend.type`` is not a registered search backend; the detail enumerates the registered types."
+          }
+        }
       }
     },
     "/api/v1/doc_collections/{collection_key}/probe": {
@@ -13085,6 +13133,180 @@
         ],
         "title": "DeprecateTemplateResponse",
         "description": "Response for ``meho.runbook.deprecate_template`` -- the now-deprecated coordinates."
+      },
+      "DocCollection": {
+        "properties": {
+          "id": {
+            "type": "string",
+            "format": "uuid",
+            "title": "Id"
+          },
+          "tenant_id": {
+            "type": "string",
+            "format": "uuid",
+            "nullable": true,
+            "title": "Tenant Id"
+          },
+          "collection_key": {
+            "type": "string",
+            "title": "Collection Key"
+          },
+          "vendor": {
+            "type": "string",
+            "title": "Vendor"
+          },
+          "products": {
+            "items": {
+              "type": "string"
+            },
+            "type": "array",
+            "title": "Products"
+          },
+          "description": {
+            "type": "string",
+            "nullable": true,
+            "title": "Description"
+          },
+          "when_to_use": {
+            "type": "string",
+            "nullable": true,
+            "title": "When To Use"
+          },
+          "backend": {
+            "additionalProperties": true,
+            "type": "object",
+            "title": "Backend"
+          },
+          "status": {
+            "type": "string",
+            "title": "Status"
+          },
+          "last_ingested_at": {
+            "type": "string",
+            "format": "date-time",
+            "nullable": true,
+            "title": "Last Ingested At"
+          },
+          "doc_count": {
+            "type": "integer",
+            "nullable": true,
+            "title": "Doc Count"
+          },
+          "readiness": {
+            "additionalProperties": true,
+            "type": "object",
+            "nullable": true,
+            "title": "Readiness"
+          },
+          "extras": {
+            "additionalProperties": true,
+            "type": "object",
+            "title": "Extras"
+          },
+          "created_at": {
+            "type": "string",
+            "format": "date-time",
+            "title": "Created At"
+          },
+          "updated_at": {
+            "type": "string",
+            "format": "date-time",
+            "title": "Updated At"
+          }
+        },
+        "type": "object",
+        "required": [
+          "id",
+          "tenant_id",
+          "collection_key",
+          "vendor",
+          "products",
+          "description",
+          "when_to_use",
+          "backend",
+          "status",
+          "last_ingested_at",
+          "doc_count",
+          "readiness",
+          "extras",
+          "created_at",
+          "updated_at"
+        ],
+        "title": "DocCollection",
+        "description": "Full read shape \u2014 maps 1:1 to the ``doc_collections`` table.\n\nFrozen so callers can stash instances in request state or structured\nlogs without fear of mutation. ``products`` is ``tuple[str, ...]``\nand the JSON columns are ``Mapping[str, Any]`` so a frozen instance\ncannot be mutated in-place via ``list.append`` / ``dict.__setitem__``.\n\n``backend`` is the operator-set ``{type, ref}`` routing record the\nT2 (#1551) router resolves server-side. ``status`` is the lifecycle\nenum (``provisioning`` / ``ready`` / ``rebuilding`` / ``disabled``);\n``last_ingested_at`` / ``doc_count`` / ``readiness`` are\nprobe-written liveness (T6 #1555), ``None`` until the first probe."
+      },
+      "DocCollectionBackend": {
+        "properties": {
+          "type": {
+            "type": "string",
+            "minLength": 1,
+            "title": "Type"
+          },
+          "ref": {
+            "additionalProperties": true,
+            "type": "object",
+            "title": "Ref"
+          }
+        },
+        "additionalProperties": false,
+        "type": "object",
+        "required": [
+          "type",
+          "ref"
+        ],
+        "title": "DocCollectionBackend",
+        "description": "The ``{type, ref}`` backend routing record a create supplies.\n\n``type`` is the search-backend type the row routes to (validated at\nthe service layer against\n:func:`~meho_backplane.docs_search.backends.registry.all_backends` so\nan unroutable row is rejected at create time, not at probe time).\n``ref`` is the per-collection backend config the resolved adapter\nreads (e.g. ``{\"endpoint\": \"https://corpus/v1/search\"}`` for\n``corpus-http``); it is opaque to the create surface \u2014 the adapter\nowns its shape \u2014 so it is a free ``Mapping``."
+      },
+      "DocCollectionCreate": {
+        "properties": {
+          "collection_key": {
+            "type": "string",
+            "maxLength": 128,
+            "minLength": 1,
+            "title": "Collection Key"
+          },
+          "vendor": {
+            "type": "string",
+            "maxLength": 256,
+            "minLength": 1,
+            "title": "Vendor"
+          },
+          "products": {
+            "items": {
+              "type": "string"
+            },
+            "type": "array",
+            "title": "Products",
+            "default": []
+          },
+          "description": {
+            "type": "string",
+            "nullable": true,
+            "title": "Description"
+          },
+          "when_to_use": {
+            "type": "string",
+            "nullable": true,
+            "title": "When To Use"
+          },
+          "backend": {
+            "$ref": "#/components/schemas/DocCollectionBackend"
+          },
+          "extras": {
+            "additionalProperties": true,
+            "type": "object",
+            "title": "Extras"
+          }
+        },
+        "additionalProperties": false,
+        "type": "object",
+        "required": [
+          "collection_key",
+          "vendor",
+          "backend"
+        ],
+        "title": "DocCollectionCreate",
+        "description": "Request body for creating a doc collection (#1739).\n\nCarries only the operator-set identity + routing fields. The\nserver derives ``id`` / ``tenant_id`` / ``created_at`` /\n``updated_at`` / ``status`` and leaves the probe-written liveness\n(``last_ingested_at`` / ``doc_count`` / ``readiness``) NULL until the\nfirst probe \u2014 so none of those appear here. ``tenant_id`` is taken\nfrom the JWT in every front, never the body; a body carrying one is\nnot modelled (``extra=\"forbid\"`` rejects it) so a writer cannot even\nattempt a cross-tenant create. Mirrors\n:class:`~meho_backplane.targets.schemas.TargetCreate`."
       },
       "DocCollectionSummary": {
         "properties": {

--- a/cli/internal/api/client.gen.go
+++ b/cli/internal/api/client.gen.go
@@ -2202,6 +2202,82 @@ type DeprecateTemplateResponse struct {
 	Version int    `json:"version"`
 }
 
+// DocCollection Full read shape — maps 1:1 to the “doc_collections“ table.
+//
+// Frozen so callers can stash instances in request state or structured
+// logs without fear of mutation. “products“ is “tuple[str, ...]“
+// and the JSON columns are “Mapping[str, Any]“ so a frozen instance
+// cannot be mutated in-place via “list.append“ / “dict.__setitem__“.
+//
+// “backend“ is the operator-set “{type, ref}“ routing record the
+// T2 (#1551) router resolves server-side. “status“ is the lifecycle
+// enum (“provisioning“ / “ready“ / “rebuilding“ / “disabled“);
+// “last_ingested_at“ / “doc_count“ / “readiness“ are
+// probe-written liveness (T6 #1555), “None“ until the first probe.
+type DocCollection struct {
+	Backend        map[string]interface{}  `json:"backend"`
+	CollectionKey  string                  `json:"collection_key"`
+	CreatedAt      time.Time               `json:"created_at"`
+	Description    *string                 `json:"description"`
+	DocCount       *int                    `json:"doc_count"`
+	Extras         map[string]interface{}  `json:"extras"`
+	Id             openapi_types.UUID      `json:"id"`
+	LastIngestedAt *time.Time              `json:"last_ingested_at"`
+	Products       []string                `json:"products"`
+	Readiness      *map[string]interface{} `json:"readiness"`
+	Status         string                  `json:"status"`
+	TenantId       *openapi_types.UUID     `json:"tenant_id"`
+	UpdatedAt      time.Time               `json:"updated_at"`
+	Vendor         string                  `json:"vendor"`
+	WhenToUse      *string                 `json:"when_to_use"`
+}
+
+// DocCollectionBackend The “{type, ref}“ backend routing record a create supplies.
+//
+// “type“ is the search-backend type the row routes to (validated at
+// the service layer against
+// :func:`~meho_backplane.docs_search.backends.registry.all_backends` so
+// an unroutable row is rejected at create time, not at probe time).
+// “ref“ is the per-collection backend config the resolved adapter
+// reads (e.g. “{"endpoint": "https://corpus/v1/search"}“ for
+// “corpus-http“); it is opaque to the create surface — the adapter
+// owns its shape — so it is a free “Mapping“.
+type DocCollectionBackend struct {
+	Ref  map[string]interface{} `json:"ref"`
+	Type string                 `json:"type"`
+}
+
+// DocCollectionCreate Request body for creating a doc collection (#1739).
+//
+// Carries only the operator-set identity + routing fields. The
+// server derives “id“ / “tenant_id“ / “created_at“ /
+// “updated_at“ / “status“ and leaves the probe-written liveness
+// (“last_ingested_at“ / “doc_count“ / “readiness“) NULL until the
+// first probe — so none of those appear here. “tenant_id“ is taken
+// from the JWT in every front, never the body; a body carrying one is
+// not modelled (“extra="forbid"“ rejects it) so a writer cannot even
+// attempt a cross-tenant create. Mirrors
+// :class:`~meho_backplane.targets.schemas.TargetCreate`.
+type DocCollectionCreate struct {
+	// Backend The ``{type, ref}`` backend routing record a create supplies.
+	//
+	// ``type`` is the search-backend type the row routes to (validated at
+	// the service layer against
+	// :func:`~meho_backplane.docs_search.backends.registry.all_backends` so
+	// an unroutable row is rejected at create time, not at probe time).
+	// ``ref`` is the per-collection backend config the resolved adapter
+	// reads (e.g. ``{"endpoint": "https://corpus/v1/search"}`` for
+	// ``corpus-http``); it is opaque to the create surface — the adapter
+	// owns its shape — so it is a free ``Mapping``.
+	Backend       DocCollectionBackend    `json:"backend"`
+	CollectionKey string                  `json:"collection_key"`
+	Description   *string                 `json:"description"`
+	Extras        *map[string]interface{} `json:"extras,omitempty"`
+	Products      *[]string               `json:"products,omitempty"`
+	Vendor        string                  `json:"vendor"`
+	WhenToUse     *string                 `json:"when_to_use"`
+}
+
 // DocCollectionSummary Short shape for the catalogue list (“list_doc_collections“, T4).
 //
 // Carries the fields an agent needs to choose a collection before
@@ -5490,6 +5566,11 @@ type ListDocCollectionsEndpointApiV1DocCollectionsGetParams struct {
 	Authorization *string `json:"authorization,omitempty"`
 }
 
+// CreateDocCollectionEndpointApiV1DocCollectionsPostParams defines parameters for CreateDocCollectionEndpointApiV1DocCollectionsPost.
+type CreateDocCollectionEndpointApiV1DocCollectionsPostParams struct {
+	Authorization *string `json:"authorization,omitempty"`
+}
+
 // DisableCollectionEndpointApiV1DocCollectionsCollectionKeyDisablePostParams defines parameters for DisableCollectionEndpointApiV1DocCollectionsCollectionKeyDisablePost.
 type DisableCollectionEndpointApiV1DocCollectionsCollectionKeyDisablePostParams struct {
 	Authorization *string `json:"authorization,omitempty"`
@@ -6075,6 +6156,9 @@ type CreateConventionApiV1ConventionsPostJSONRequestBody = ConventionCreate
 
 // UpdateConventionApiV1ConventionsSlugPatchJSONRequestBody defines body for UpdateConventionApiV1ConventionsSlugPatch for application/json ContentType.
 type UpdateConventionApiV1ConventionsSlugPatchJSONRequestBody = ConventionUpdate
+
+// CreateDocCollectionEndpointApiV1DocCollectionsPostJSONRequestBody defines body for CreateDocCollectionEndpointApiV1DocCollectionsPost for application/json ContentType.
+type CreateDocCollectionEndpointApiV1DocCollectionsPostJSONRequestBody = DocCollectionCreate
 
 // CreateKbApiV1KbPostJSONRequestBody defines body for CreateKbApiV1KbPost for application/json ContentType.
 type CreateKbApiV1KbPostJSONRequestBody = KbEntryCreate
@@ -7255,6 +7339,11 @@ type ClientInterface interface {
 
 	// ListDocCollectionsEndpointApiV1DocCollectionsGet request
 	ListDocCollectionsEndpointApiV1DocCollectionsGet(ctx context.Context, params *ListDocCollectionsEndpointApiV1DocCollectionsGetParams, reqEditors ...RequestEditorFn) (*http.Response, error)
+
+	// CreateDocCollectionEndpointApiV1DocCollectionsPostWithBody request with any body
+	CreateDocCollectionEndpointApiV1DocCollectionsPostWithBody(ctx context.Context, params *CreateDocCollectionEndpointApiV1DocCollectionsPostParams, contentType string, body io.Reader, reqEditors ...RequestEditorFn) (*http.Response, error)
+
+	CreateDocCollectionEndpointApiV1DocCollectionsPost(ctx context.Context, params *CreateDocCollectionEndpointApiV1DocCollectionsPostParams, body CreateDocCollectionEndpointApiV1DocCollectionsPostJSONRequestBody, reqEditors ...RequestEditorFn) (*http.Response, error)
 
 	// DisableCollectionEndpointApiV1DocCollectionsCollectionKeyDisablePost request
 	DisableCollectionEndpointApiV1DocCollectionsCollectionKeyDisablePost(ctx context.Context, collectionKey string, params *DisableCollectionEndpointApiV1DocCollectionsCollectionKeyDisablePostParams, reqEditors ...RequestEditorFn) (*http.Response, error)
@@ -8523,6 +8612,30 @@ func (c *Client) ListHistoryApiV1ConventionsSlugHistoryGet(ctx context.Context, 
 
 func (c *Client) ListDocCollectionsEndpointApiV1DocCollectionsGet(ctx context.Context, params *ListDocCollectionsEndpointApiV1DocCollectionsGetParams, reqEditors ...RequestEditorFn) (*http.Response, error) {
 	req, err := NewListDocCollectionsEndpointApiV1DocCollectionsGetRequest(c.Server, params)
+	if err != nil {
+		return nil, err
+	}
+	req = req.WithContext(ctx)
+	if err := c.applyEditors(ctx, req, reqEditors); err != nil {
+		return nil, err
+	}
+	return c.Client.Do(req)
+}
+
+func (c *Client) CreateDocCollectionEndpointApiV1DocCollectionsPostWithBody(ctx context.Context, params *CreateDocCollectionEndpointApiV1DocCollectionsPostParams, contentType string, body io.Reader, reqEditors ...RequestEditorFn) (*http.Response, error) {
+	req, err := NewCreateDocCollectionEndpointApiV1DocCollectionsPostRequestWithBody(c.Server, params, contentType, body)
+	if err != nil {
+		return nil, err
+	}
+	req = req.WithContext(ctx)
+	if err := c.applyEditors(ctx, req, reqEditors); err != nil {
+		return nil, err
+	}
+	return c.Client.Do(req)
+}
+
+func (c *Client) CreateDocCollectionEndpointApiV1DocCollectionsPost(ctx context.Context, params *CreateDocCollectionEndpointApiV1DocCollectionsPostParams, body CreateDocCollectionEndpointApiV1DocCollectionsPostJSONRequestBody, reqEditors ...RequestEditorFn) (*http.Response, error) {
+	req, err := NewCreateDocCollectionEndpointApiV1DocCollectionsPostRequest(c.Server, params, body)
 	if err != nil {
 		return nil, err
 	}
@@ -13680,6 +13793,61 @@ func NewListDocCollectionsEndpointApiV1DocCollectionsGetRequest(server string, p
 	if err != nil {
 		return nil, err
 	}
+
+	if params != nil {
+
+		if params.Authorization != nil {
+			var headerParam0 string
+
+			headerParam0, err = runtime.StyleParamWithLocation("simple", false, "authorization", runtime.ParamLocationHeader, *params.Authorization)
+			if err != nil {
+				return nil, err
+			}
+
+			req.Header.Set("authorization", headerParam0)
+		}
+
+	}
+
+	return req, nil
+}
+
+// NewCreateDocCollectionEndpointApiV1DocCollectionsPostRequest calls the generic CreateDocCollectionEndpointApiV1DocCollectionsPost builder with application/json body
+func NewCreateDocCollectionEndpointApiV1DocCollectionsPostRequest(server string, params *CreateDocCollectionEndpointApiV1DocCollectionsPostParams, body CreateDocCollectionEndpointApiV1DocCollectionsPostJSONRequestBody) (*http.Request, error) {
+	var bodyReader io.Reader
+	buf, err := json.Marshal(body)
+	if err != nil {
+		return nil, err
+	}
+	bodyReader = bytes.NewReader(buf)
+	return NewCreateDocCollectionEndpointApiV1DocCollectionsPostRequestWithBody(server, params, "application/json", bodyReader)
+}
+
+// NewCreateDocCollectionEndpointApiV1DocCollectionsPostRequestWithBody generates requests for CreateDocCollectionEndpointApiV1DocCollectionsPost with any type of body
+func NewCreateDocCollectionEndpointApiV1DocCollectionsPostRequestWithBody(server string, params *CreateDocCollectionEndpointApiV1DocCollectionsPostParams, contentType string, body io.Reader) (*http.Request, error) {
+	var err error
+
+	serverURL, err := url.Parse(server)
+	if err != nil {
+		return nil, err
+	}
+
+	operationPath := fmt.Sprintf("/api/v1/doc_collections")
+	if operationPath[0] == '/' {
+		operationPath = "." + operationPath
+	}
+
+	queryURL, err := serverURL.Parse(operationPath)
+	if err != nil {
+		return nil, err
+	}
+
+	req, err := http.NewRequest("POST", queryURL.String(), body)
+	if err != nil {
+		return nil, err
+	}
+
+	req.Header.Add("Content-Type", contentType)
 
 	if params != nil {
 
@@ -21282,6 +21450,11 @@ type ClientWithResponsesInterface interface {
 	// ListDocCollectionsEndpointApiV1DocCollectionsGetWithResponse request
 	ListDocCollectionsEndpointApiV1DocCollectionsGetWithResponse(ctx context.Context, params *ListDocCollectionsEndpointApiV1DocCollectionsGetParams, reqEditors ...RequestEditorFn) (*ListDocCollectionsEndpointApiV1DocCollectionsGetResponse, error)
 
+	// CreateDocCollectionEndpointApiV1DocCollectionsPostWithBodyWithResponse request with any body
+	CreateDocCollectionEndpointApiV1DocCollectionsPostWithBodyWithResponse(ctx context.Context, params *CreateDocCollectionEndpointApiV1DocCollectionsPostParams, contentType string, body io.Reader, reqEditors ...RequestEditorFn) (*CreateDocCollectionEndpointApiV1DocCollectionsPostResponse, error)
+
+	CreateDocCollectionEndpointApiV1DocCollectionsPostWithResponse(ctx context.Context, params *CreateDocCollectionEndpointApiV1DocCollectionsPostParams, body CreateDocCollectionEndpointApiV1DocCollectionsPostJSONRequestBody, reqEditors ...RequestEditorFn) (*CreateDocCollectionEndpointApiV1DocCollectionsPostResponse, error)
+
 	// DisableCollectionEndpointApiV1DocCollectionsCollectionKeyDisablePostWithResponse request
 	DisableCollectionEndpointApiV1DocCollectionsCollectionKeyDisablePostWithResponse(ctx context.Context, collectionKey string, params *DisableCollectionEndpointApiV1DocCollectionsCollectionKeyDisablePostParams, reqEditors ...RequestEditorFn) (*DisableCollectionEndpointApiV1DocCollectionsCollectionKeyDisablePostResponse, error)
 
@@ -22915,6 +23088,28 @@ func (r ListDocCollectionsEndpointApiV1DocCollectionsGetResponse) Status() strin
 
 // StatusCode returns HTTPResponse.StatusCode
 func (r ListDocCollectionsEndpointApiV1DocCollectionsGetResponse) StatusCode() int {
+	if r.HTTPResponse != nil {
+		return r.HTTPResponse.StatusCode
+	}
+	return 0
+}
+
+type CreateDocCollectionEndpointApiV1DocCollectionsPostResponse struct {
+	Body         []byte
+	HTTPResponse *http.Response
+	JSON201      *DocCollection
+}
+
+// Status returns HTTPResponse.Status
+func (r CreateDocCollectionEndpointApiV1DocCollectionsPostResponse) Status() string {
+	if r.HTTPResponse != nil {
+		return r.HTTPResponse.Status
+	}
+	return http.StatusText(0)
+}
+
+// StatusCode returns HTTPResponse.StatusCode
+func (r CreateDocCollectionEndpointApiV1DocCollectionsPostResponse) StatusCode() int {
 	if r.HTTPResponse != nil {
 		return r.HTTPResponse.StatusCode
 	}
@@ -26200,6 +26395,23 @@ func (c *ClientWithResponses) ListDocCollectionsEndpointApiV1DocCollectionsGetWi
 	return ParseListDocCollectionsEndpointApiV1DocCollectionsGetResponse(rsp)
 }
 
+// CreateDocCollectionEndpointApiV1DocCollectionsPostWithBodyWithResponse request with arbitrary body returning *CreateDocCollectionEndpointApiV1DocCollectionsPostResponse
+func (c *ClientWithResponses) CreateDocCollectionEndpointApiV1DocCollectionsPostWithBodyWithResponse(ctx context.Context, params *CreateDocCollectionEndpointApiV1DocCollectionsPostParams, contentType string, body io.Reader, reqEditors ...RequestEditorFn) (*CreateDocCollectionEndpointApiV1DocCollectionsPostResponse, error) {
+	rsp, err := c.CreateDocCollectionEndpointApiV1DocCollectionsPostWithBody(ctx, params, contentType, body, reqEditors...)
+	if err != nil {
+		return nil, err
+	}
+	return ParseCreateDocCollectionEndpointApiV1DocCollectionsPostResponse(rsp)
+}
+
+func (c *ClientWithResponses) CreateDocCollectionEndpointApiV1DocCollectionsPostWithResponse(ctx context.Context, params *CreateDocCollectionEndpointApiV1DocCollectionsPostParams, body CreateDocCollectionEndpointApiV1DocCollectionsPostJSONRequestBody, reqEditors ...RequestEditorFn) (*CreateDocCollectionEndpointApiV1DocCollectionsPostResponse, error) {
+	rsp, err := c.CreateDocCollectionEndpointApiV1DocCollectionsPost(ctx, params, body, reqEditors...)
+	if err != nil {
+		return nil, err
+	}
+	return ParseCreateDocCollectionEndpointApiV1DocCollectionsPostResponse(rsp)
+}
+
 // DisableCollectionEndpointApiV1DocCollectionsCollectionKeyDisablePostWithResponse request returning *DisableCollectionEndpointApiV1DocCollectionsCollectionKeyDisablePostResponse
 func (c *ClientWithResponses) DisableCollectionEndpointApiV1DocCollectionsCollectionKeyDisablePostWithResponse(ctx context.Context, collectionKey string, params *DisableCollectionEndpointApiV1DocCollectionsCollectionKeyDisablePostParams, reqEditors ...RequestEditorFn) (*DisableCollectionEndpointApiV1DocCollectionsCollectionKeyDisablePostResponse, error) {
 	rsp, err := c.DisableCollectionEndpointApiV1DocCollectionsCollectionKeyDisablePost(ctx, collectionKey, params, reqEditors...)
@@ -29286,6 +29498,32 @@ func ParseListDocCollectionsEndpointApiV1DocCollectionsGetResponse(rsp *http.Res
 			return nil, err
 		}
 		response.JSON422 = &dest
+
+	}
+
+	return response, nil
+}
+
+// ParseCreateDocCollectionEndpointApiV1DocCollectionsPostResponse parses an HTTP response from a CreateDocCollectionEndpointApiV1DocCollectionsPostWithResponse call
+func ParseCreateDocCollectionEndpointApiV1DocCollectionsPostResponse(rsp *http.Response) (*CreateDocCollectionEndpointApiV1DocCollectionsPostResponse, error) {
+	bodyBytes, err := io.ReadAll(rsp.Body)
+	defer func() { _ = rsp.Body.Close() }()
+	if err != nil {
+		return nil, err
+	}
+
+	response := &CreateDocCollectionEndpointApiV1DocCollectionsPostResponse{
+		Body:         bodyBytes,
+		HTTPResponse: rsp,
+	}
+
+	switch {
+	case strings.Contains(rsp.Header.Get("Content-Type"), "json") && rsp.StatusCode == 201:
+		var dest DocCollection
+		if err := json.Unmarshal(bodyBytes, &dest); err != nil {
+			return nil, err
+		}
+		response.JSON201 = &dest
 
 	}
 

--- a/cli/internal/cmd/docs/collections.go
+++ b/cli/internal/cmd/docs/collections.go
@@ -32,11 +32,13 @@ import (
 func newCollectionsCmd(provisioned bool) *cobra.Command {
 	cmd := &cobra.Command{
 		Use:   "collections",
-		Short: "List doc collections, and probe / toggle their backends",
+		Short: "List, create, and probe / toggle doc collections",
 		Long: "collections operates the doc-collection catalogue. `list` " +
 			"(operator) shows the collections you are entitled to search — " +
-			"the keys `meho docs search --collection` accepts. The lifecycle " +
-			"verbs (tenant_admin) operate readiness: `probe` refreshes a " +
+			"the keys `meho docs search --collection` accepts. `create` " +
+			"(tenant_admin) registers a new collection so search can route " +
+			"to it — the audited alternative to a raw database INSERT. The " +
+			"lifecycle verbs (tenant_admin) operate readiness: `probe` refreshes a " +
 			"collection's cached liveness (doc count, last ingest, " +
 			"readiness) from its backend and transitions its status; " +
 			"`enable` / `disable` move a collection in / out of search " +
@@ -48,6 +50,7 @@ func newCollectionsCmd(provisioned bool) *cobra.Command {
 		SilenceUsage: true,
 	}
 	cmd.AddCommand(newCollectionsListCmd(provisioned))
+	cmd.AddCommand(newCollectionsCreateCmd(provisioned))
 	cmd.AddCommand(newCollectionsProbeCmd(provisioned))
 	cmd.AddCommand(newCollectionsEnableCmd(provisioned))
 	cmd.AddCommand(newCollectionsDisableCmd(provisioned))

--- a/cli/internal/cmd/docs/collections_create.go
+++ b/cli/internal/cmd/docs/collections_create.go
@@ -1,0 +1,236 @@
+// SPDX-License-Identifier: Apache-2.0
+// Copyright (c) 2026 evoila Group
+
+package docs
+
+import (
+	"context"
+	"encoding/json"
+	"fmt"
+	"net/http"
+	"os"
+	"strings"
+
+	"github.com/spf13/cobra"
+
+	"github.com/evoila/meho/cli/internal/api"
+	"github.com/evoila/meho/cli/internal/backplane"
+	"github.com/evoila/meho/cli/internal/output"
+)
+
+// newCollectionsCreateCmd returns the `meho docs collections create` command.
+//
+// #1739. The write half of the doc-collection registry: it calls
+// POST /api/v1/doc_collections to register a new collection so
+// `meho docs search --collection` (and the MCP / agent fronts) can route
+// to it — replacing the raw `INSERT INTO doc_collections` an operator
+// would otherwise run. tenant_admin only (parity with probe / enable /
+// disable); tenant-scoped server-side (the collection lands in the
+// operator's own tenant, never a flag value).
+//
+// Two input shapes:
+//   - flags: --vendor / --product / --backend-type / --backend-ref (+ the
+//     <collection-key> positional). The everyday single-collection path.
+//   - --from-file <path>: a JSON object matching the DocCollectionCreate
+//     body, for an operator who already has the row described as data. The
+//     CLI `import`-style on-ramp (mirrors `meho targets import`'s file
+//     read) without a bulk format — one collection per call.
+//
+// Exit codes mirror the sibling collections verbs (renderHTTPStatus maps
+// 422 → unexpected with the unknown-backend-type detail, 409 → unexpected
+// with the conflict detail, 403 → insufficient_role).
+func newCollectionsCreateCmd(provisioned bool) *cobra.Command {
+	var opts createCollectionOptions
+	cmd := &cobra.Command{
+		Use:   "create <collection-key>",
+		Short: "Register a new doc collection (tenant_admin)",
+		Long: "create calls POST /api/v1/doc_collections to register a new " +
+			"documentation collection in your tenant so `meho docs search " +
+			"--collection <key>` can route to it — the audited, validated " +
+			"alternative to a raw database INSERT. It seeds identity + the " +
+			"backend binding only; it does not trigger ingest or an index " +
+			"rebuild — the new collection starts in `provisioning` and a " +
+			"follow-up `probe` promotes it to `ready` once its index " +
+			"confirms.\n\n" +
+			"Supply the fields with flags (--vendor, --product, " +
+			"--backend-type, --backend-ref) plus the <collection-key> " +
+			"positional, or pass --from-file <path> with a JSON body " +
+			"matching the create schema. The backend type must be a " +
+			"registered search backend (e.g. corpus-http); an unregistered " +
+			"type is rejected up front (422) rather than committing an " +
+			"unroutable row. A collection key that already exists in your " +
+			"scope is a conflict (409). tenant_admin only.",
+		Args:          cobra.MaximumNArgs(1),
+		SilenceUsage:  true,
+		SilenceErrors: true,
+		RunE: func(cmd *cobra.Command, args []string) error {
+			if len(args) == 1 {
+				opts.CollectionKey = args[0]
+			}
+			opts.Provisioned = provisioned
+			return runCollectionCreate(cmd, opts)
+		},
+	}
+	cmd.Flags().StringVar(&opts.Vendor, "vendor", "",
+		"vendor the corpus covers (e.g. 'VMware by Broadcom')")
+	cmd.Flags().StringSliceVar(&opts.Products, "product", nil,
+		"product the corpus covers (repeatable, e.g. --product vsphere --product nsx)")
+	cmd.Flags().StringVar(&opts.Description, "description", "",
+		"optional free-text description")
+	cmd.Flags().StringVar(&opts.WhenToUse, "when-to-use", "",
+		"optional 'pick this collection when…' blurb surfaced to agents")
+	cmd.Flags().StringVar(&opts.BackendType, "backend-type", "",
+		"search-backend type to route to (e.g. corpus-http)")
+	cmd.Flags().StringVar(&opts.BackendRef, "backend-ref", "",
+		"backend config as a JSON object (e.g. '{\"endpoint\":\"https://corpus/v1/search\"}')")
+	cmd.Flags().StringVar(&opts.FromFile, "from-file", "",
+		"read the full create body from a JSON file instead of the flags")
+	cmd.Flags().BoolVar(&opts.JSONOut, "json", false,
+		"emit the created collection as JSON instead of a confirmation line")
+	cmd.Flags().StringVar(&opts.BackplaneOverride, "backplane", "",
+		"backplane URL to query (defaults to the URL recorded by the most recent `meho login`)")
+	return cmd
+}
+
+// createCollectionOptions is the flag/arg set for the create verb.
+type createCollectionOptions struct {
+	CollectionKey     string
+	Vendor            string
+	Products          []string
+	Description       string
+	WhenToUse         string
+	BackendType       string
+	BackendRef        string
+	FromFile          string
+	JSONOut           bool
+	BackplaneOverride string
+	Provisioned       bool
+}
+
+func runCollectionCreate(cmd *cobra.Command, opts createCollectionOptions) error {
+	if !opts.Provisioned {
+		return errNotProvisioned(cmd, opts.JSONOut)
+	}
+	body, buildErr := buildCreateBody(opts)
+	if buildErr != nil {
+		return output.RenderError(cmd.ErrOrStderr(), output.Unexpected(buildErr.Error()), opts.JSONOut)
+	}
+	backplaneURL, err := backplane.Resolve(opts.BackplaneOverride)
+	if err != nil {
+		return output.RenderError(cmd.ErrOrStderr(), backplane.ClassifyError(err), opts.JSONOut)
+	}
+	resp, err := createCollection(cmd.Context(), backplaneURL, body)
+	if err != nil {
+		return renderRequestError(cmd, backplaneURL, err, opts.JSONOut)
+	}
+	if resp.StatusCode() != http.StatusCreated {
+		return renderHTTPStatus(cmd, backplaneURL, resp.StatusCode(), resp.Body, opts.JSONOut)
+	}
+	if resp.JSON201 == nil {
+		return output.RenderError(
+			cmd.ErrOrStderr(),
+			output.Unexpected(fmt.Sprintf(
+				"call %s: HTTP 201 without a DocCollection payload", backplaneURL,
+			)),
+			opts.JSONOut,
+		)
+	}
+	if opts.JSONOut {
+		return output.PrintJSON(cmd.OutOrStdout(), *resp.JSON201)
+	}
+	fmt.Fprintf(cmd.OutOrStdout(),
+		"collection %q created (status %s); run `meho docs collections probe %s` to promote it\n",
+		resp.JSON201.CollectionKey, resp.JSON201.Status, resp.JSON201.CollectionKey)
+	return nil
+}
+
+// buildCreateBody assembles the typed DocCollectionCreate body from either
+// --from-file or the individual flags. Exposed for tests so the
+// flag→body wiring (and the mutually-exclusive --from-file path) stays
+// unit-checkable without standing up an httptest.Server.
+func buildCreateBody(opts createCollectionOptions) (api.DocCollectionCreate, error) {
+	if opts.FromFile != "" {
+		return buildCreateBodyFromFile(opts)
+	}
+	return buildCreateBodyFromFlags(opts)
+}
+
+func buildCreateBodyFromFile(opts createCollectionOptions) (api.DocCollectionCreate, error) {
+	var body api.DocCollectionCreate
+	raw, err := os.ReadFile(opts.FromFile)
+	if err != nil {
+		return body, fmt.Errorf("read --from-file %s: %w", opts.FromFile, err)
+	}
+	dec := json.NewDecoder(strings.NewReader(string(raw)))
+	dec.DisallowUnknownFields()
+	if err := dec.Decode(&body); err != nil {
+		return body, fmt.Errorf("parse --from-file %s as a doc-collection create body: %w", opts.FromFile, err)
+	}
+	// A bare positional <collection-key> overrides the file's key only when
+	// the file omitted it — otherwise the file is authoritative.
+	if body.CollectionKey == "" {
+		body.CollectionKey = opts.CollectionKey
+	}
+	if body.CollectionKey == "" {
+		return body, fmt.Errorf("--from-file body is missing collection_key (and no <collection-key> argument was given)")
+	}
+	return body, nil
+}
+
+func buildCreateBodyFromFlags(opts createCollectionOptions) (api.DocCollectionCreate, error) {
+	var body api.DocCollectionCreate
+	if opts.CollectionKey == "" {
+		return body, fmt.Errorf("a <collection-key> argument is required (or use --from-file)")
+	}
+	if opts.Vendor == "" {
+		return body, fmt.Errorf("--vendor is required")
+	}
+	if opts.BackendType == "" {
+		return body, fmt.Errorf("--backend-type is required (e.g. corpus-http)")
+	}
+	ref := map[string]interface{}{}
+	if opts.BackendRef != "" {
+		if err := json.Unmarshal([]byte(opts.BackendRef), &ref); err != nil {
+			return body, fmt.Errorf("--backend-ref must be a JSON object: %w", err)
+		}
+	}
+	body.CollectionKey = opts.CollectionKey
+	body.Vendor = opts.Vendor
+	body.Backend = api.DocCollectionBackend{Type: opts.BackendType, Ref: ref}
+	if len(opts.Products) > 0 {
+		products := append([]string(nil), opts.Products...)
+		body.Products = &products
+	}
+	if opts.Description != "" {
+		d := opts.Description
+		body.Description = &d
+	}
+	if opts.WhenToUse != "" {
+		w := opts.WhenToUse
+		body.WhenToUse = &w
+	}
+	return body, nil
+}
+
+func createCollection(
+	ctx context.Context,
+	backplaneURL string,
+	body api.DocCollectionCreate,
+) (*api.CreateDocCollectionEndpointApiV1DocCollectionsPostResponse, error) {
+	authed, err := newAuthedClient(ctx, backplaneURL)
+	if err != nil {
+		return nil, err
+	}
+	return retryOn401(ctx, authed,
+		func(ctx context.Context) (*api.CreateDocCollectionEndpointApiV1DocCollectionsPostResponse, error) {
+			return authed.CreateDocCollectionEndpointApiV1DocCollectionsPostWithResponse(
+				ctx,
+				&api.CreateDocCollectionEndpointApiV1DocCollectionsPostParams{},
+				body,
+			)
+		},
+		func(r *api.CreateDocCollectionEndpointApiV1DocCollectionsPostResponse) int {
+			return r.StatusCode()
+		},
+	)
+}

--- a/cli/internal/cmd/docs/collections_create_test.go
+++ b/cli/internal/cmd/docs/collections_create_test.go
@@ -1,0 +1,229 @@
+// SPDX-License-Identifier: Apache-2.0
+// Copyright (c) 2026 evoila Group
+
+package docs
+
+import (
+	"encoding/json"
+	"net/http"
+	"net/http/httptest"
+	"os"
+	"path/filepath"
+	"strings"
+	"testing"
+
+	"github.com/evoila/meho/cli/internal/api"
+)
+
+func TestRunCollectionCreateRefusesWhenUnprovisioned(t *testing.T) {
+	cmd, _, stderr := newRunCmd(t)
+	err := runCollectionCreate(cmd, createCollectionOptions{
+		CollectionKey: "vmware",
+		Vendor:        "VMware",
+		BackendType:   "corpus-http",
+		Provisioned:   false,
+	})
+	if exitCodeOf(t, err) != 5 {
+		t.Errorf("expected exit 5 (insufficient_role family); got %d", exitCodeOf(t, err))
+	}
+	if !strings.Contains(stderr.String(), "addon_not_provisioned") {
+		t.Errorf("expected addon_not_provisioned code; got %q", stderr.String())
+	}
+}
+
+func TestBuildCreateBodyFromFlagsRequiresVendorAndBackend(t *testing.T) {
+	cases := []struct {
+		name string
+		opts createCollectionOptions
+	}{
+		{"missing key", createCollectionOptions{Vendor: "V", BackendType: "corpus-http"}},
+		{"missing vendor", createCollectionOptions{CollectionKey: "k", BackendType: "corpus-http"}},
+		{"missing backend type", createCollectionOptions{CollectionKey: "k", Vendor: "V"}},
+	}
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			if _, err := buildCreateBody(tc.opts); err == nil {
+				t.Errorf("expected an error for %s", tc.name)
+			}
+		})
+	}
+}
+
+func TestBuildCreateBodyFromFlagsHappyPath(t *testing.T) {
+	body, err := buildCreateBody(createCollectionOptions{
+		CollectionKey: "vmware",
+		Vendor:        "VMware by Broadcom",
+		Products:      []string{"vsphere", "nsx"},
+		BackendType:   "corpus-http",
+		BackendRef:    `{"endpoint":"https://corpus/v1/search"}`,
+	})
+	if err != nil {
+		t.Fatalf("buildCreateBody: %v", err)
+	}
+	if body.CollectionKey != "vmware" || body.Vendor != "VMware by Broadcom" {
+		t.Errorf("identity not wired: %+v", body)
+	}
+	if body.Backend.Type != "corpus-http" {
+		t.Errorf("backend type not wired: %+v", body.Backend)
+	}
+	if got := body.Backend.Ref["endpoint"]; got != "https://corpus/v1/search" {
+		t.Errorf("backend ref not parsed: %v", body.Backend.Ref)
+	}
+	if body.Products == nil || len(*body.Products) != 2 {
+		t.Errorf("products not wired: %v", body.Products)
+	}
+}
+
+func TestBuildCreateBodyRejectsMalformedBackendRef(t *testing.T) {
+	_, err := buildCreateBody(createCollectionOptions{
+		CollectionKey: "vmware",
+		Vendor:        "V",
+		BackendType:   "corpus-http",
+		BackendRef:    "not-json",
+	})
+	if err == nil {
+		t.Errorf("expected an error for a non-JSON --backend-ref")
+	}
+}
+
+func TestBuildCreateBodyFromFile(t *testing.T) {
+	dir := t.TempDir()
+	path := filepath.Join(dir, "collection.json")
+	payload := `{"collection_key":"netapp","vendor":"NetApp",` +
+		`"backend":{"type":"corpus-http","ref":{"endpoint":"https://corpus/v1/search"}}}`
+	if err := os.WriteFile(path, []byte(payload), 0o600); err != nil {
+		t.Fatalf("write fixture: %v", err)
+	}
+	body, err := buildCreateBody(createCollectionOptions{FromFile: path})
+	if err != nil {
+		t.Fatalf("buildCreateBody from file: %v", err)
+	}
+	if body.CollectionKey != "netapp" || body.Backend.Type != "corpus-http" {
+		t.Errorf("file body not parsed: %+v", body)
+	}
+}
+
+func TestRunCollectionCreateHappyPath(t *testing.T) {
+	mux := http.NewServeMux()
+	mux.HandleFunc(
+		"/api/v1/doc_collections",
+		func(w http.ResponseWriter, r *http.Request) {
+			if r.Method != http.MethodPost {
+				t.Errorf("expected POST; got %s", r.Method)
+			}
+			var got api.DocCollectionCreate
+			if err := json.NewDecoder(r.Body).Decode(&got); err != nil {
+				t.Errorf("decode body: %v", err)
+			}
+			if got.CollectionKey != "vmware" {
+				t.Errorf("unexpected key: %s", got.CollectionKey)
+			}
+			w.Header().Set("Content-Type", "application/json")
+			w.WriteHeader(http.StatusCreated)
+			_ = json.NewEncoder(w).Encode(api.DocCollection{
+				CollectionKey: "vmware",
+				Vendor:        "VMware by Broadcom",
+				Status:        "provisioning",
+				Backend:       map[string]interface{}{"type": "corpus-http"},
+			})
+		},
+	)
+	srv := httptest.NewServer(mux)
+	defer srv.Close()
+	seedXDGAndToken(t, srv.URL, "eyJ.test.token")
+
+	cmd, stdout, stderr := newRunCmd(t)
+	err := runCollectionCreate(cmd, createCollectionOptions{
+		CollectionKey:     "vmware",
+		Vendor:            "VMware by Broadcom",
+		BackendType:       "corpus-http",
+		BackendRef:        `{"endpoint":"https://corpus/v1/search"}`,
+		Provisioned:       true,
+		BackplaneOverride: srv.URL,
+	})
+	if err != nil {
+		t.Fatalf("runCollectionCreate: %v; stderr=%s", err, stderr.String())
+	}
+	for _, want := range []string{"vmware", "provisioning", "probe"} {
+		if !strings.Contains(stdout.String(), want) {
+			t.Errorf("stdout missing %q in %q", want, stdout.String())
+		}
+	}
+}
+
+func TestRunCollectionCreateRendersUnknownBackend422(t *testing.T) {
+	mux := http.NewServeMux()
+	mux.HandleFunc(
+		"/api/v1/doc_collections",
+		func(w http.ResponseWriter, _ *http.Request) {
+			w.Header().Set("Content-Type", "application/json")
+			w.WriteHeader(http.StatusUnprocessableEntity)
+			_ = json.NewEncoder(w).Encode(map[string]interface{}{
+				"detail": map[string]interface{}{
+					"kind":                "unknown_backend_type",
+					"backend_type":        "no-such-backend",
+					"valid_backend_types": []string{"corpus-http"},
+					"message":             "backend.type='no-such-backend' is not a registered search backend",
+				},
+			})
+		},
+	)
+	srv := httptest.NewServer(mux)
+	defer srv.Close()
+	seedXDGAndToken(t, srv.URL, "eyJ.test.token")
+
+	cmd, _, stderr := newRunCmd(t)
+	err := runCollectionCreate(cmd, createCollectionOptions{
+		CollectionKey:     "vmware",
+		Vendor:            "VMware",
+		BackendType:       "no-such-backend",
+		Provisioned:       true,
+		BackplaneOverride: srv.URL,
+	})
+	if exitCodeOf(t, err) != 4 {
+		t.Errorf("expected exit 4 (unexpected_response) for a 422; got %d", exitCodeOf(t, err))
+	}
+	if !strings.Contains(stderr.String(), "no-such-backend") {
+		t.Errorf("expected the unknown-backend detail surfaced; got %q", stderr.String())
+	}
+}
+
+func TestRunCollectionCreateRendersConflict409(t *testing.T) {
+	mux := http.NewServeMux()
+	mux.HandleFunc(
+		"/api/v1/doc_collections",
+		func(w http.ResponseWriter, _ *http.Request) {
+			w.Header().Set("Content-Type", "application/json")
+			w.WriteHeader(http.StatusConflict)
+			_ = json.NewEncoder(w).Encode(map[string]interface{}{
+				"detail": "doc collection 'vmware' already exists in the tenant scope",
+			})
+		},
+	)
+	srv := httptest.NewServer(mux)
+	defer srv.Close()
+	seedXDGAndToken(t, srv.URL, "eyJ.test.token")
+
+	cmd, _, stderr := newRunCmd(t)
+	err := runCollectionCreate(cmd, createCollectionOptions{
+		CollectionKey:     "vmware",
+		Vendor:            "VMware",
+		BackendType:       "corpus-http",
+		Provisioned:       true,
+		BackplaneOverride: srv.URL,
+	})
+	if exitCodeOf(t, err) != 4 {
+		t.Errorf("expected exit 4 (unexpected_response) for a 409; got %d", exitCodeOf(t, err))
+	}
+	if !strings.Contains(stderr.String(), "already exists") {
+		t.Errorf("expected the conflict detail surfaced; got %q", stderr.String())
+	}
+}
+
+func TestCollectionsCreateHelpExitsZero(t *testing.T) {
+	cmd := newCollectionsCreateCmd(true)
+	cmd.SetArgs([]string{"--help"})
+	if err := cmd.Execute(); err != nil {
+		t.Fatalf("create --help: %v", err)
+	}
+}

--- a/docs/codebase/doc-collections.md
+++ b/docs/codebase/doc-collections.md
@@ -15,8 +15,12 @@ The registry deliberately splits two kinds of field by who writes them
 
 - **Operator-set, authoritative for identity + routing** —
   `collection_key`, `vendor`, `products`, `description`, `when_to_use`,
-  and `backend`. These are seeded by an operator (no create/import API
-  in v1; operator-managed seed only).
+  and `backend`. A tenant_admin registers these through the create
+  surface (#1739) — `POST /api/v1/doc_collections`, the
+  `create_doc_collections` MCP tool, or `meho docs collections create` —
+  which validates the `backend.type`, derives `tenant_id` from the JWT,
+  defaults `status` to `provisioning`, and audits the write. See
+  [Create / register a collection](#create--register-a-collection-1739).
 - **Probe-written liveness** — `status`, `last_ingested_at`,
   `doc_count`, and `readiness`. The backend is the source of truth for
   liveness; the readiness probe (G4.6-T6, #1555) writes these from the
@@ -291,6 +295,55 @@ form pointing at `list_doc_collections` and logs
 delimiters are wrapper-emitted (never substituted from row content), so a
 malicious `when_to_use` carrying the terminator cannot escape the block.
 
+## Create / register a collection (#1739)
+
+The write half of the registry, mirroring the `create_target` precedent
+(`backend/src/meho_backplane/api/v1/targets.py`). It closes the gap Ops
+hit on the first co-located corpus round-trip
+(claude-rdc-hetzner-dc#975): before #1739 the only way to register a
+collection was a raw `INSERT INTO doc_collections`, which bypassed every
+guardrail the rest of MEHO's registry writes enforce (backend
+routability, tenant scoping, typed conflict, audit).
+
+The service primitive
+`create_doc_collection(session, operator, body)`
+(`meho_backplane.docs_collections.service`) owns the substrate:
+
+- **`tenant_id` from the operator**, never the body — a cross-tenant
+  create is structurally impossible (the `DocCollectionCreate` schema is
+  `extra="forbid"`, so a body carrying a `tenant_id` is rejected).
+- **`backend.type` validated against the registry** —
+  `docs_search.backends.registry.all_backends()` is the source of truth;
+  an unregistered type raises `DocCollectionBackendTypeError`, surfaced as
+  a structured `422` whose detail enumerates the registered types (the
+  `create_target` unknown-product shape). This moves the failure forward
+  from a deferred probe/search-time `503` to create time.
+- **Server-derived fields** — `id` / `created_at` / `updated_at` are
+  generated; `status` defaults to `provisioning` (a follow-up `probe`
+  promotes it); the probe-written liveness stays `NULL`.
+- **Typed conflict** — a cross-scope `collection_key` collision (either
+  partial-unique index) maps `IntegrityError` →
+  `DocCollectionConflictError` → `409`, not an opaque `500`.
+- **Audit** — binds `op_id="meho.docs.collections.create"` /
+  `op_class="write"`, so the registration joins the `op_id="meho.docs.*"`
+  who-touched trail every other docs operation shares.
+
+Three fronts forward to the same primitive:
+
+- **REST** — `POST /api/v1/doc_collections` → `201` with the full
+  `DocCollection`, `tenant_admin`-gated (parity with the lifecycle
+  routes). The route maps the two service exceptions to `422` / `409`.
+- **MCP** — the `create_doc_collections` write-class tool
+  (`meho_backplane.mcp.tools.doc_collections_create`), `tenant_admin` +
+  `required_capability="meho-docs"`. The exceptions map to JSON-RPC
+  `INVALID_PARAMS` with the structured detail in `error.data`.
+- **CLI** — `meho docs collections create <key> --vendor … --backend-type …
+  --backend-ref '{…}'` (or `--from-file <path>`), in
+  `cli/internal/cmd/docs/collections_create.go`.
+
+Out of scope (a later follow-up): PATCH / DELETE, cross-tenant sharing,
+and bulk import beyond the single-collection `--from-file` on-ramp.
+
 ## Dependencies
 
 - SQLAlchemy 2.0 typed ORM (`Mapped[...]` / `mapped_column`), the
@@ -324,9 +377,13 @@ malicious `when_to_use` carrying the terminator cannot escape the block.
   terminal `disabled` (403 / `-32602`) from the transient `provisioning` /
   `rebuilding` (409 / `-32603`). There is no second `ensure_collection_searchable`
   duplicate.
-- **No write API.** Collections are operator-managed seed for v1. An
-  `import` verb (mirroring `meho targets import`) is a later add if a
-  collection needs one.
+- **Create is the write half; update / delete / sharing are not.** A
+  tenant_admin registers a collection through the create surface (#1739,
+  see [Create / register a collection](#create--register-a-collection-1739));
+  there is still no PATCH / DELETE and no cross-tenant sharing API — those
+  are a later follow-up (out of scope per #1739). A shared/global row
+  (`tenant_id IS NULL`) is still seeded out-of-band, since the create
+  always scopes to the caller's tenant.
 - **Entitlement is not enforced here.** The per-collection capability
   gate (`meho-docs:<collection>`) and the `audit_collection` binding
   land in T3 (#1552); the registry only stores and resolves rows.

--- a/docs/cross-repo/meho-docs-addon.md
+++ b/docs/cross-repo/meho-docs-addon.md
@@ -191,16 +191,29 @@ access on its own — the backplane re-validates the JWT and the backend
 federation enforces the real boundary, so a forged claim can change only
 what a client *shows*, never what the server *allows*.
 
-### 2. Seed the collection + bind its backend (deploy side)
+### 2. Register the collection + bind its backend (deploy side)
 
-Collections are **operator-managed seed** for v1 — there is no
-create/import API yet; a deployment seeds `doc_collections` rows directly.
-A minimal seed row binds identity + a backend:
+A tenant_admin registers a collection through the create surface
+(#1739) — pick whichever front fits the deploy tooling:
+
+- **REST** — `POST /api/v1/doc_collections` with the create body below.
+- **CLI** — `meho docs collections create <collection_key> --vendor … --product … --backend-type corpus-http --backend-ref '{"endpoint":"…"}'` (or `--from-file <path>` with the JSON body).
+- **MCP** — the `create_doc_collections` tool (tenant_admin, `meho-docs`).
+
+The create validates `backend.type` against the search-backend registry
+(an unregistered type is a `422`, not a row that fails later at probe /
+search), derives `tenant_id` from the JWT (the body cannot set it),
+defaults `status` to `provisioning`, and writes an audit row under
+`op_id="meho.docs.collections.create"` — so a registration is never
+unroutable, never cross-tenant, and never invisible the way a raw
+`INSERT INTO doc_collections` could be. A follow-up `probe` promotes the
+collection from `provisioning` to `ready` once its index confirms. A
+minimal create binds identity + a backend:
 
 | Field | Example | Notes |
 |---|---|---|
-| `collection_key` | `vmware` | The agent-facing id; must match the `meho-docs:vmware` capability key above. |
-| `tenant_id` | `NULL` *or* `<tenant uuid>` | `NULL` = shared across tenants; set = curated for one tenant (shadows a global key). |
+| `collection_key` | `vmware` | The agent-facing id; must match the `meho-docs:vmware` capability key above. Unique within the scope (global or per-tenant); a collision is a `409`. |
+| `tenant_id` | *(derived from the JWT)* | Never supplied in the body — the create always scopes the row to the caller's tenant. A shared/global row is seeded out-of-band (operator DB seed) since cross-tenant sharing is out of the create scope. |
 | `vendor` | `VMware by Broadcom` | |
 | `products` | `["vsphere", "nsx"]` | |
 | `when_to_use` | `Vendor docs for VMware Cloud Foundation…` | The blurb the agent reads to pick the collection. |


### PR DESCRIPTION
## Summary
- Add the **create/import** half of the `doc_collections` registry across all three fronts (#1739): `POST /api/v1/doc_collections`, the `create_doc_collections` MCP tool, and `meho docs collections create` (with `--from-file`). Registering a collection no longer needs a raw `INSERT INTO doc_collections`.
- A `create_doc_collection` service primitive (mirroring `create_target`) derives `tenant_id` from the JWT (never the body), validates `backend.type` against the search-backend registry (unregistered type → structured **422** listing the registered set, not a deferred probe-time 503), maps a cross-scope `collection_key` collision to **409**, defaults `status` to `provisioning`, and binds `op_id="meho.docs.collections.create"` / `op_class="write"` so the write joins the `meho.docs.*` audit trail.
- Gating: REST/CLI `tenant_admin`; MCP `tenant_admin` + `required_capability="meho-docs"`. Update/delete and cross-tenant sharing are out of scope.

## Test plan
- [x] `ruff check` / `ruff format --check` — clean
- [x] `mypy src/meho_backplane/` — Success, no issues (474 files)
- [x] `python3 .claude/hooks/code-quality.py --diff` — 0 blockers
- [x] `uv run pytest tests/ -k doc_collections` — 94 passed (15 new: 6 REST/service + 9 MCP)
- [x] MCP registry / capability-gating / audit sweep — 205 passed
- [x] `go vet ./...` + `go test ./...` — clean (new CLI tests: happy path, 422/409 render, --from-file, --help exit 0)
- [x] `cd cli && make snapshot-openapi && make generate` — re-run is a no-op (snapshot + Go client committed); `grep doc_collections client.gen.go` shows the new create op
- [x] Acceptance greps: `@router.post("")` 201 + `response_model=DocCollection`; `class DocCollectionCreate` exported; MCP tool `op_class="write"` + `meho-docs` + `TENANT_ADMIN`; CLI verb wired; docs deferred-API language removed
- [x] No `tests/integration/` doubles reference doc_collections (testcontainers lane unaffected)

## Out of scope
- PATCH / DELETE of collections and cross-tenant sharing — a separate follow-up (this is the create half only).
- Triggering ingest / index rebuild — stays ops/backend side; create registers identity + backend binding, `status=provisioning`, a follow-up `probe` promotes it.
- New backend adapter types beyond the registered `corpus-http`.

<!-- auto-implement-issue: fresh, iteration 1 -->

Closes #1739
