### PR TITLE
fix(connectors): rank a hand-rolled class over an auto-shim in resolution (#1750)

### DIFF
--- a/backend/src/meho_backplane/connectors/resolver.py
+++ b/backend/src/meho_backplane/connectors/resolver.py
@@ -66,6 +66,25 @@ When two or more connectors advertise support for a target's
    version" and shouldn't compete with a connector that names a
    specific version triple.
 
+1b. **Hand-rolled class beats auto-shim.** The spec-ingestion pipeline
+   auto-registers a ``GenericRestConnector`` shim (see
+   :mod:`meho_backplane.operations.ingest.connector_registration`) per
+   ingested ``(product, version, impl_id)`` so a freshly ingested spec
+   resolves before any per-product class exists. On first ingest under a
+   *novel* impl_id, that shim becomes a candidate for the whole
+   ``(product, version)`` label alongside a shipped hand-rolled class.
+   The shim's ``derive_supported_version_range(version)``
+   pins a *narrower* range around the exact ingested version than a
+   hand-rolled class's broad range, so without this rung the shim would
+   win the most-specific-version-match step before ``priority`` is ever
+   consulted — a stray probe ingest shadowing a shipped connector for
+   everyone on a shared registry (#1750). When any hand-rolled candidate
+   is present, every ``GenericRestConnector`` candidate is dropped: a
+   hand-rolled class always outranks an auto-shim for the same label,
+   independent of version-range span or ``priority``. When only shims
+   exist for a label (a genuine catalog-first staging connector not yet
+   replaced), this rung is a no-op and the shim still resolves.
+
 2. **Most-specific-version-match wins.** A connector with
    ``supported_version_range=">=9.0,<10.0"`` (span = 1.0 minor versions)
    beats ``">=6.5,<10.0"`` (span = 3.5 minor versions) for a target with
@@ -86,9 +105,9 @@ When two or more connectors advertise support for a target's
    the integer :attr:`Connector.priority` class attribute breaks the
    tie — higher wins.
 
-If after all four steps two or more candidates remain, the resolver
-raises :exc:`AmbiguousConnectorResolution` listing the candidates so the
-operator can set ``preferred_impl_id`` to pick one.
+If after all the steps above two or more candidates remain, the
+resolver raises :exc:`AmbiguousConnectorResolution` listing the
+candidates so the operator can set ``preferred_impl_id`` to pick one.
 
 Zero candidates → :exc:`NoMatchingConnector`.
 
@@ -328,45 +347,139 @@ def resolve_connector(target: Any) -> type[Connector]:
     )
 
 
+def _demote_wildcards(candidates: list[_Candidate]) -> list[_Candidate]:
+    """Step 1 — versioned beats wildcard.
+
+    When a v1 wildcard entry (registry key ``(product, "", "")``) and ≥1
+    v2 versioned entries share the candidate list, demote the wildcard.
+    The wildcard is the v1 backward-compat fallback (KubernetesConnector
+    self-registers under both ``("k8s", "", "")`` and
+    ``("k8s", "1.x", "k8s")`` so ``get_connector("k8s")`` keeps working
+    for the ``/probe`` route); it should not compete on equal footing
+    with a connector that names a concrete ``(version, impl_id)`` pair.
+    Without this step, an unfingerprinted K8s target
+    (target.fingerprint = None → target_version = None) leaves both
+    entries in play, both score ``(_SPECIFICITY_UNBOUNDED, 0.0)`` on
+    supported_version_range, operator_preference is absent, priorities
+    tie, and ``AmbiguousConnectorResolution`` propagates as a bare-500
+    to the operator (G0.14-T2 / signal 9). The rule generalizes to any
+    future connector that uses the same double-registration shape.
+
+    No-op (returns the input unchanged) when no wildcard is present.
+    """
+    non_wildcards = [c for c in candidates if c.version != "" or c.impl_id != ""]
+    if non_wildcards and len(non_wildcards) < len(candidates):
+        return non_wildcards
+    return candidates
+
+
+def _demote_auto_shims(candidates: list[_Candidate]) -> list[_Candidate]:
+    """Step 1b — hand-rolled class beats auto-shim.
+
+    The spec-ingestion pipeline auto-registers a ``GenericRestConnector``
+    shim per ingested ``(product, version, impl_id)`` so a freshly
+    ingested spec resolves before any per-product class exists; on first
+    ingest under a *novel* impl_id, that shim becomes a candidate for the
+    whole ``(product, version)`` label alongside a shipped hand-rolled
+    class. The shim's ``derive_supported_version_range(version)`` pins a
+    *narrower* range around the exact ingested version than a hand-rolled
+    class's broad range, so without this rung the shim would win the
+    most-specific-version-match step before the hand-rolled class's
+    ``priority`` is ever consulted — a stray probe ingest shadowing a
+    shipped connector for everyone on a shared registry (v0.15.0 dogfood
+    signal, #1750). Drop every shim candidate the moment any hand-rolled
+    candidate is present: a hand-rolled class always outranks an
+    auto-shim for the same label, independent of version-range span or
+    ``priority``. When only shims exist (a genuine catalog-first staging
+    connector not yet replaced), this is a no-op and the shim still wins.
+
+    The ``GenericRestConnector`` import is function-local on purpose: it
+    keeps the ``connectors/`` → ``operations/ingest/`` module edge off
+    import time (the registration module already imports from
+    ``connectors/``, so a module-level import here would close a cycle).
+    """
+    from meho_backplane.operations.ingest.connector_registration import (
+        GenericRestConnector,
+    )
+
+    hand_rolled = [c for c in candidates if not issubclass(c.cls, GenericRestConnector)]
+    if hand_rolled and len(hand_rolled) < len(candidates):
+        return hand_rolled
+    return candidates
+
+
+def _match_operator_preference(
+    candidates: list[_Candidate],
+    preferred_impl_id: str | None,
+) -> list[_Candidate]:
+    """Step 3 — narrow to the operator/tenant-preferred candidate(s).
+
+    Falls through (returns the input unchanged) when the override is
+    unset or doesn't disambiguate — zero matches are ignored; multiple
+    matches (the corner case where two impls share the preferred id) are
+    returned so priority breaks the tie rather than the resolver raising.
+
+    G0.16-T6 Finding C (#1312). Accept both the base ``impl_id``
+    (``"nsx-rest"``) AND the versioned ``"{impl_id}-{version}"`` form
+    (``"nsx-rest-4.2"``) — the latter is the canonical shape per
+    ``docs/codebase/api-shape-conventions.md`` §3 and matches the
+    ``connector_id`` string the dispatcher's ``parse_connector_id``
+    round-trips through. Match on either alias against each candidate's
+    ``impl_id``-or-``impl_id-version`` pair so an operator pinning the
+    versioned form selects the connector that registered under the
+    matching base/version pair.
+    """
+    if not preferred_impl_id:
+        return candidates
+    preferred = [
+        c
+        for c in candidates
+        if c.impl_id == preferred_impl_id
+        or (c.impl_id and c.version and f"{c.impl_id}-{c.version}" == preferred_impl_id)
+    ]
+    return preferred if preferred else candidates
+
+
 def _run_tie_break_ladder(
     candidates: list[_Candidate],
     preferred_impl_id: str | None,
 ) -> tuple[_Candidate | None, str, list[_Candidate]]:
-    """Apply the four-step tie-break ladder to a non-empty candidate list.
+    """Apply the tie-break ladder to a non-empty candidate list.
 
     Returns ``(winner, reason, remaining)``:
 
     * ``winner`` — the single chosen candidate, or ``None`` if the ladder
       ended with two or more candidates still tied.
     * ``reason`` — the step that picked the winner
-      (``"versioned_over_wildcard"`` / ``"specificity"`` /
-      ``"operator_preference"`` / ``"priority"``) or ``"ambiguous"``.
+      (``"versioned_over_wildcard"`` / ``"hand_rolled_over_shim"`` /
+      ``"specificity"`` / ``"operator_preference"`` / ``"priority"``)
+      or ``"ambiguous"``.
     * ``remaining`` — the post-ladder candidate list. When ``winner`` is
       ``None`` the caller raises ``AmbiguousConnectorResolution`` with
       these as the candidates the operator must disambiguate.
+
+    Each rung is a pure ``list[_Candidate] -> list[_Candidate]`` filter
+    (see the ``_demote_*`` / ``_match_*`` helpers); this orchestrator
+    runs them in order and short-circuits the moment a *demotion* rung
+    narrows the field to a single candidate, recording the rung that
+    resolved it. A rung that leaves the field untouched never claims
+    credit — a lone candidate that no demotion rung acted on falls
+    through to the specificity step (reason ``"specificity"``), matching
+    the pre-refactor ``tie_break`` log value.
     """
-    # Step 1 — versioned beats wildcard. When a v1 wildcard entry
-    # (registry key ``(product, "", "")``) and ≥1 v2 versioned entries
-    # share the candidate list, demote the wildcard. The wildcard is the
-    # v1 backward-compat fallback (KubernetesConnector self-registers
-    # under both ``("k8s", "", "")`` and ``("k8s", "1.x", "k8s")`` so
-    # ``get_connector("k8s")`` keeps working for the ``/probe`` route);
-    # it should not compete on equal footing with a connector that
-    # names a concrete ``(version, impl_id)`` pair. Without this step,
-    # an unfingerprinted K8s target (target.fingerprint = None →
-    # target_version = None) leaves both entries in play, both score
-    # ``(_SPECIFICITY_UNBOUNDED, 0.0)`` on supported_version_range,
-    # operator_preference is absent, priorities tie, and
-    # ``AmbiguousConnectorResolution`` propagates as a bare-500 to the
-    # operator (G0.14-T2 / signal 9). The rule generalizes to any
-    # future connector that uses the same double-registration shape.
-    has_versioned = any(c.version != "" or c.impl_id != "" for c in candidates)
-    if has_versioned:
-        non_wildcards = [c for c in candidates if c.version != "" or c.impl_id != ""]
-        if len(non_wildcards) < len(candidates):
-            candidates = non_wildcards
-            if len(candidates) == 1:
-                return candidates[0], "versioned_over_wildcard", candidates
+    # Step 1 — versioned beats wildcard.
+    demoted = _demote_wildcards(candidates)
+    if len(demoted) < len(candidates):
+        candidates = demoted
+        if len(candidates) == 1:
+            return candidates[0], "versioned_over_wildcard", candidates
+
+    # Step 1b — hand-rolled class beats auto-shim.
+    demoted = _demote_auto_shims(candidates)
+    if len(demoted) < len(candidates):
+        candidates = demoted
+        if len(candidates) == 1:
+            return candidates[0], "hand_rolled_over_shim", candidates
 
     # Step 2 — most-specific-version-match.
     best_score = min(c.specificity_score for c in candidates)
@@ -374,31 +487,10 @@ def _run_tie_break_ladder(
     if len(candidates) == 1:
         return candidates[0], "specificity", candidates
 
-    # Step 3 — operator/tenant preference. Falls through to priority when
-    # the override doesn't disambiguate (zero matches → ignored; multiple
-    # matches → corner case where two impls share the preferred id, so
-    # let priority break it rather than raising).
-    #
-    # G0.16-T6 Finding C (#1312). Accept both the base ``impl_id``
-    # (``"nsx-rest"``) AND the versioned ``"{impl_id}-{version}"`` form
-    # (``"nsx-rest-4.2"``) — the latter is the canonical shape per
-    # ``docs/codebase/api-shape-conventions.md`` §3 and matches the
-    # ``connector_id`` string the dispatcher's ``parse_connector_id``
-    # round-trips through. Match on either alias against each
-    # candidate's ``impl_id``-or-``impl_id-version`` pair so an
-    # operator pinning the versioned form selects the connector that
-    # registered under the matching base/version pair.
-    if preferred_impl_id:
-        preferred = [
-            c
-            for c in candidates
-            if c.impl_id == preferred_impl_id
-            or (c.impl_id and c.version and f"{c.impl_id}-{c.version}" == preferred_impl_id)
-        ]
-        if len(preferred) == 1:
-            return preferred[0], "operator_preference", preferred
-        if len(preferred) > 1:
-            candidates = preferred
+    # Step 3 — operator/tenant preference.
+    candidates = _match_operator_preference(candidates, preferred_impl_id)
+    if len(candidates) == 1:
+        return candidates[0], "operator_preference", candidates
 
     # Step 4 — connector class priority (higher wins).
     best_priority = max(c.cls.priority for c in candidates)

--- a/backend/tests/test_connectors_resolver_shim_shadowing.py
+++ b/backend/tests/test_connectors_resolver_shim_shadowing.py
@@ -1,0 +1,295 @@
+# SPDX-License-Identifier: Apache-2.0
+# Copyright (c) 2026 evoila Group
+
+"""Resolver tie-break: a hand-rolled class beats a GenericRestConnector shim.
+
+Regression guard for the v0.15.0 dogfood signal #1750. The
+spec-ingestion pipeline auto-registers a ``GenericRestConnector`` shim
+per ingested ``(product, version, impl_id)``. On first ingest under a
+*novel* ``impl_id``, that shim becomes a candidate for the whole
+``(product, version)`` label alongside a shipped hand-rolled
+:class:`~meho_backplane.connectors.base.Connector` subclass. The shim's
+:func:`~meho_backplane.operations.ingest.connector_registration.derive_supported_version_range`
+pins a *narrower* range around the exact ingested version than a
+hand-rolled class's broad range, so before this Task the shim won the
+most-specific-version-match step before the hand-rolled class's
+``priority`` was ever consulted — a stray probe ingest shadowing a
+shipped connector for everyone on a shared registry.
+
+The resolver's ``hand_rolled_over_shim`` rung (added in
+:func:`~meho_backplane.connectors.resolver._run_tie_break_ladder`,
+before the most-specific-version-match step) drops every shim candidate
+the moment a hand-rolled candidate is present. These tests pin that
+invariant — and the no-op-when-only-shims case that keeps a genuine
+catalog-first staging connector resolving to its shim.
+"""
+
+from __future__ import annotations
+
+from collections.abc import Iterator
+from dataclasses import dataclass
+from typing import Any
+
+import pytest
+
+from meho_backplane.connectors import (
+    Connector,
+    FingerprintResult,
+    OperationResult,
+    ProbeResult,
+    register_connector_v2,
+    resolve_connector,
+)
+from meho_backplane.connectors.registry import all_connectors_v2, clear_registry
+from meho_backplane.operations.ingest.connector_registration import (
+    GenericRestConnector,
+    ensure_connector_class_registered,
+)
+
+# ---------------------------------------------------------------------------
+# Duck-typed target — the resolver only reads three attributes
+# ---------------------------------------------------------------------------
+
+
+@dataclass
+class _FakeFingerprint:
+    version: str | None
+
+
+@dataclass
+class _FakeTarget:
+    product: str
+    fingerprint: _FakeFingerprint | None = None
+    preferred_impl_id: str | None = None
+    version: str | None = None
+
+
+# ---------------------------------------------------------------------------
+# Hand-rolled connector under test — mirrors NsxConnector's resolver-relevant
+# shape: a deliberately *broad* range (so the shim's derived range is
+# narrower) and ``priority = 1`` (so the test proves priority is NOT what
+# saves it — the new rung is).
+# ---------------------------------------------------------------------------
+
+
+class _HandRolledNsx(Connector):
+    """Stand-in for the shipped NsxConnector (resolver-only contract)."""
+
+    product = "nsx"
+    # Broad on purpose: the auto-shim's derived ">=9.0,<10.0" is narrower,
+    # so the pre-fix specificity step would have picked the shim.
+    supported_version_range = ">=8.0,<11.0"
+    priority = 1
+
+    async def fingerprint(self, target: Any, operator: Any = None) -> FingerprintResult:  # type: ignore[override]
+        raise NotImplementedError
+
+    async def probe(self, target: Any) -> ProbeResult:  # type: ignore[override]
+        raise NotImplementedError
+
+    async def execute(self, target: Any, op_id: str, params: dict[str, Any]) -> OperationResult:  # type: ignore[override]
+        raise NotImplementedError
+
+
+@pytest.fixture(autouse=True)
+def _clean_registry() -> Iterator[None]:
+    clear_registry()
+    yield
+    clear_registry()
+
+
+def _register_probe_shim() -> type[Connector]:
+    """Register an auto-shim the production way, return the synthesised class.
+
+    Uses :func:`ensure_connector_class_registered` — the same entry
+    point the ingest pipeline calls on first ingest under a novel
+    ``impl_id`` — so the test exercises a real ``GenericRestConnector``
+    subclass with the real derived ``supported_version_range`` and
+    ``priority = 0``, not a hand-faked stand-in.
+    """
+    created = ensure_connector_class_registered(
+        product="nsx",
+        version="9.0",
+        impl_id="nsx-rest-probe",
+        base_url=None,
+    )
+    assert created is True
+    return all_connectors_v2()[("nsx", "9.0", "nsx-rest-probe")]
+
+
+# ---------------------------------------------------------------------------
+# The shadowing repro — the acceptance criterion
+# ---------------------------------------------------------------------------
+
+
+def test_hand_rolled_class_outranks_auto_shim_for_same_label() -> None:
+    """Hand-rolled class wins even when the shim's range is narrower.
+
+    The shipped ``_HandRolledNsx`` advertises a broad ``>=8.0,<11.0``
+    range; the auto-shim for the novel ``nsx-rest-probe`` impl_id derives
+    a *narrower* ``>=9.0,<10.0`` from the ingested version. Both match a
+    target fingerprinted at ``9.0.2``. Before the fix, the shim won the
+    most-specific-version-match step before the hand-rolled class's
+    ``priority = 1`` was consulted. The ``hand_rolled_over_shim`` rung
+    drops the shim first, so the hand-rolled class resolves.
+    """
+    register_connector_v2(
+        product="nsx",
+        version="9.0",
+        impl_id="nsx-rest",
+        cls=_HandRolledNsx,
+    )
+    shim_cls = _register_probe_shim()
+
+    # Sanity: the shim's derived range really is narrower than the
+    # hand-rolled class's — otherwise the test wouldn't exercise the bug.
+    assert shim_cls.supported_version_range == ">=9.0,<10.0"
+    assert _HandRolledNsx.supported_version_range == ">=8.0,<11.0"
+    assert issubclass(shim_cls, GenericRestConnector)
+    assert not issubclass(_HandRolledNsx, GenericRestConnector)
+
+    target = _FakeTarget(product="nsx", fingerprint=_FakeFingerprint("9.0.2"))
+    assert resolve_connector(target) is _HandRolledNsx
+
+
+def test_hand_rolled_over_shim_runs_before_specificity_log_reason(
+    capfd: pytest.CaptureFixture[str],
+) -> None:
+    """The resolution log line names the ``hand_rolled_over_shim`` reason.
+
+    Pins the *ordering*: the winning tie-break reason is
+    ``hand_rolled_over_shim``, not ``specificity``. If the rung were
+    placed after the most-specific-version-match step, the shim's
+    narrower range would win on specificity and this assertion would
+    fail.
+    """
+    from meho_backplane.logging import configure_logging
+
+    configure_logging()
+    register_connector_v2(
+        product="nsx",
+        version="9.0",
+        impl_id="nsx-rest",
+        cls=_HandRolledNsx,
+    )
+    _register_probe_shim()
+
+    target = _FakeTarget(product="nsx", fingerprint=_FakeFingerprint("9.0.2"))
+    assert resolve_connector(target) is _HandRolledNsx
+    out, _ = capfd.readouterr()
+    assert "connector_resolved" in out
+    assert '"tie_break": "hand_rolled_over_shim"' in out
+
+
+def test_hand_rolled_wins_even_with_default_priority() -> None:
+    """The rung is independent of ``priority`` — a default-priority class wins too.
+
+    ``priority`` semantics are unchanged by this Task; the new rung does
+    not lean on the hand-rolled class having a higher priority. A
+    hand-rolled class left at the default ``priority = 0`` (same as the
+    shim) still beats the shim for the same label.
+    """
+
+    class _DefaultPriorityNsx(_HandRolledNsx):
+        priority = 0  # same as the shim — the rung, not priority, decides.
+
+    register_connector_v2(
+        product="nsx",
+        version="9.0",
+        impl_id="nsx-rest",
+        cls=_DefaultPriorityNsx,
+    )
+    _register_probe_shim()
+
+    target = _FakeTarget(product="nsx", fingerprint=_FakeFingerprint("9.0.2"))
+    assert resolve_connector(target) is _DefaultPriorityNsx
+
+
+# ---------------------------------------------------------------------------
+# No behaviour change when only auto-shims exist for a label
+# ---------------------------------------------------------------------------
+
+
+def test_only_shim_for_label_still_resolves_to_shim() -> None:
+    """A genuine catalog-first staging connector still resolves to its shim.
+
+    When no hand-rolled candidate exists for the label, the
+    ``hand_rolled_over_shim`` rung is a no-op: dropping all candidates
+    would be wrong. The single auto-shim must still resolve so an
+    ingested-but-not-yet-replaced connector keeps dispatching (to the
+    degenerate shim, which the review-queue gate keeps disabled until a
+    real subclass lands).
+    """
+    shim_cls = _register_probe_shim()
+    target = _FakeTarget(product="nsx", fingerprint=_FakeFingerprint("9.0.2"))
+    assert resolve_connector(target) is shim_cls
+
+
+def test_two_shims_no_hand_rolled_falls_through_to_later_ladder() -> None:
+    """Two shims, no hand-rolled candidate → rung is a no-op, ladder continues.
+
+    With two competing shims and no hand-rolled class, the rung drops
+    nothing (it only fires when a hand-rolled candidate is present). The
+    rest of the ladder runs: here the two shims derive the *same*
+    ``>=9.0,<10.0`` range and carry the same ``priority``, so resolution
+    stays ambiguous exactly as it would without the rung — the rung
+    neither resolves nor collapses a real shim-vs-shim ambiguity.
+    """
+    from meho_backplane.connectors import AmbiguousConnectorResolution
+
+    _register_probe_shim()
+    second = ensure_connector_class_registered(
+        product="nsx",
+        version="9.0",
+        impl_id="nsx-rest-probe-b",
+        base_url=None,
+    )
+    assert second is True
+
+    target = _FakeTarget(product="nsx", fingerprint=_FakeFingerprint("9.0.2"))
+    with pytest.raises(AmbiguousConnectorResolution) as exc_info:
+        resolve_connector(target)
+    assert exc_info.value.candidates == [
+        ("nsx", "9.0", "nsx-rest-probe"),
+        ("nsx", "9.0", "nsx-rest-probe-b"),
+    ]
+
+
+def test_shim_dropped_when_multiple_hand_rolled_remain() -> None:
+    """The rung drops shims even when ≥2 hand-rolled candidates remain.
+
+    With two hand-rolled impls plus a shim, the shim is dropped and the
+    ladder continues among the hand-rolled candidates alone. Here the two
+    hand-rolled classes share a range and priority, so the resolver
+    raises ``AmbiguousConnectorResolution`` over the *hand-rolled*
+    candidates — the shim is gone from the operator-facing candidate
+    list, proving the rung fired before specificity collapsed anything.
+    """
+    from meho_backplane.connectors import AmbiguousConnectorResolution
+
+    class _HandRolledNsxAlt(_HandRolledNsx):
+        pass
+
+    register_connector_v2(
+        product="nsx",
+        version="9.0",
+        impl_id="nsx-rest",
+        cls=_HandRolledNsx,
+    )
+    register_connector_v2(
+        product="nsx",
+        version="9.0",
+        impl_id="nsx-soap",
+        cls=_HandRolledNsxAlt,
+    )
+    _register_probe_shim()
+
+    target = _FakeTarget(product="nsx", fingerprint=_FakeFingerprint("9.0.2"))
+    with pytest.raises(AmbiguousConnectorResolution) as exc_info:
+        resolve_connector(target)
+    # The shim ("nsx", "9.0", "nsx-rest-probe") is absent — dropped by the
+    # rung before the ambiguity surfaced.
+    assert exc_info.value.candidates == [
+        ("nsx", "9.0", "nsx-rest"),
+        ("nsx", "9.0", "nsx-soap"),
+    ]

--- a/docs/architecture/connector-resolution.md
+++ b/docs/architecture/connector-resolution.md
@@ -46,6 +46,31 @@ walks that table to pick the right class for a given target.
 When two or more connectors advertise support for a target's
 `(product, version)` pair:
 
+### Step 0 — hand-rolled class beats auto-shim
+
+The [spec-ingestion pipeline](spec-ingestion.md) auto-registers a
+`GenericRestConnector` shim per ingested `(product, version, impl_id)`
+so a freshly ingested spec resolves before any per-product class
+exists. When a shipped hand-rolled `Connector` subclass and an
+auto-shim are both candidates for the same `(product, version)` label,
+the hand-rolled class wins and every `GenericRestConnector` candidate
+is dropped — *before* the specificity step below.
+
+Without this rung, a stray ingest under a novel `impl_id` shadows a
+shipped connector: the shim's
+[`derive_supported_version_range`](../../backend/src/meho_backplane/operations/ingest/connector_registration.py)
+pins a *narrower* range around the exact ingested version than a
+hand-rolled class's broad range, so the shim would win
+most-specific-version-match before the hand-rolled class's `priority`
+is ever read ([#1750](https://github.com/evoila/meho/issues/1750), a
+v0.15.0 dogfood signal). The invariant is unconditional: a hand-rolled
+class always outranks an auto-shim for the same label, independent of
+version-range span or `priority`.
+
+When only auto-shims exist for a label (a genuine catalog-first
+staging connector not yet replaced by a hand-rolled subclass), this
+rung is a no-op and the shim still resolves.
+
 ### Step 1 — most-specific-version-match wins
 
 Specificity is measured by the size of the bounded interval the


### PR DESCRIPTION
## Summary
- Fixes a resolver tie-break bug (v0.15.0 dogfood signal, #1750): a `GenericRestConnector` auto-shim registered by a stray ingest under a novel `impl_id` could shadow a shipped hand-rolled connector for the whole `(product, version)` label.
- Root cause was ordering, not priority: the shim's `derive_supported_version_range()` pins a *narrower* range around the exact ingested version, so the most-specific-version-match rung selected the shim before `NsxConnector.priority=1` was ever consulted.
- Adds a `hand_rolled_over_shim` rung to the tie-break ladder, **before** the most-specific-version-match step: when any candidate is not a `GenericRestConnector` subclass, every `GenericRestConnector` candidate is dropped. A hand-rolled class always outranks an auto-shim for the same label, independent of version-range span or `priority`.
- No behaviour change when only auto-shims exist for a label (a catalog-first staging connector still resolves to its shim).

## Implementation notes
- The `GenericRestConnector` import inside the rung is function-local on purpose: `connectors/` must not gain a module-load edge to `operations/ingest/` (the registration module already imports from `connectors/`, so a module-level import would close a cycle).
- The ladder rungs were extracted into pure `list[_Candidate] -> list[_Candidate]` filter helpers (`_demote_wildcards`, `_demote_auto_shims`, `_match_operator_preference`) so `_run_tie_break_ladder` stays under the function-size (100 lines) and McCabe (≤10) gates after the new rung. The `tie_break` log reason for every pre-existing path is preserved verbatim (a rung only claims credit when it actually narrows the field).
- Docs: added the new rung to `docs/architecture/connector-resolution.md` and the `resolver.py` module docstring.

## Test plan
- [x] `ruff check` — clean
- [x] `ruff format --check` — clean
- [x] `mypy src/meho_backplane/` — clean (474 files)
- [x] `code-quality.py --diff` — 0 blockers (2 pre-existing warnings, untouched)
- [x] **New** `pytest backend/tests/test_connectors_resolver_shim_shadowing.py` — 6 passed. Proves the hand-rolled class wins even when the shim's range is narrower and hand-rolled `priority=1`; also covers default-priority, only-shims no-op, two-shim ambiguity, and the multi-hand-rolled drop case.
- [x] Regression: `pytest backend/tests/test_connectors_resolver.py` — 38 passed (existing ladder + reason-label assertions green).
- [x] Regression: `pytest backend/tests/test_operations_ingest_delete.py` — 13 passed (DELETE-deregisters-shim path unaffected; the issue named `test_operations_delete_connector.py`, which does not exist — this is the actual deregister suite).
- [x] Full backend suite — 7508 passed, 416 skipped.

## Out of scope
- impl_id-exact resolution (threading `impl_id` end-to-end through `resolve_connector`) — a larger correctness change, deferred per the issue.
- Ingest-time near-miss guard + auto-shim error wording — sibling task #1753 (edits `operations/ingest/connector_registration.py`).

## Adjacent findings (recorded, not edited)
- `connectors/resolver.py` is 711 lines (pre-existing, > 600 warn threshold) and `_filter_candidates` is 82 lines (> 60 warn) — both pre-date this change.
- `docs/architecture/connector-resolution.md` step numbering was already off-by-one from the code (it never documented the existing `versioned_over_wildcard` rung); the new rung is documented as "Step 0" without renumbering the rest to keep this diff focused.

<!-- auto-implement-issue: fresh, iteration 1 -->

Closes #1750
