### PR TITLE
feat(docs-collections): hint create -> probe -> ready in the create response

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -100,6 +100,18 @@ connector-related release-notes line.
   default-deny. Tenant-scope-aware, idempotent, and audited as a
   single bulk-enable event with the count of ops enabled (#1749).
 
+### Changed
+
+- `POST /api/v1/doc_collections` now returns a `next_step` hint on its
+  `201` response pointing at
+  `POST /api/v1/doc_collections/{collection_key}/probe` while the new
+  collection is `provisioning`. A created collection is not searchable
+  until an explicit probe promotes it to `ready`, so the hint surfaces
+  the `create → probe → ready` flow inline instead of leaving operators
+  to discover the probe route after a confusing not-ready error on the
+  first `search_docs`. Discoverability only — create still does not
+  self-probe (#1756).
+
 ## [0.15.0] - 2026-06-13
 
 ### Added

--- a/backend/src/meho_backplane/api/v1/doc_collections.py
+++ b/backend/src/meho_backplane/api/v1/doc_collections.py
@@ -70,14 +70,14 @@ from meho_backplane.auth.rbac import require_role
 from meho_backplane.db.engine import get_session
 from meho_backplane.db.models import DocCollection as DocCollectionORM
 from meho_backplane.docs_collections import (
-    DocCollection,
     DocCollectionBackendTypeError,
     DocCollectionConflictError,
     DocCollectionCreate,
+    DocCollectionCreateResponse,
     DocCollectionSummary,
     create_doc_collection,
     probe_collection,
-    project_doc_collection,
+    project_doc_collection_create_response,
     project_doc_collection_to_summary,
     resolve_doc_collection,
     set_collection_enabled,
@@ -196,9 +196,19 @@ async def list_doc_collections_endpoint(
 
 @router.post(
     "",
-    response_model=DocCollection,
+    response_model=DocCollectionCreateResponse,
     status_code=status.HTTP_201_CREATED,
     responses={
+        201: {
+            "description": (
+                "Collection registered. It starts at ``status=provisioning`` "
+                "— the **create → probe → ready** flow: ``search_docs`` only "
+                "accepts a ``ready`` collection, so call "
+                "``POST /api/v1/doc_collections/{collection_key}/probe`` to "
+                "promote it before searching. The response carries that "
+                "instruction inline as ``next_step``."
+            ),
+        },
         409: {
             "description": (
                 "A collection with this ``collection_key`` already exists "
@@ -217,7 +227,7 @@ async def create_doc_collection_endpoint(
     body: DocCollectionCreate,
     operator: Operator = _require_admin,
     session: AsyncSession = Depends(get_session),
-) -> DocCollection:
+) -> DocCollectionCreateResponse:
     """Register a new doc collection in the requesting tenant.
 
     The create sibling of the lifecycle write routes — ``tenant_admin``-
@@ -230,6 +240,12 @@ async def create_doc_collection_endpoint(
     set, not a deferred 503), and a cross-scope ``collection_key`` collision
     → 409. The create binds ``op_id="meho.docs.collections.create"`` so the
     registration joins the ``op_id="meho.docs.*"`` who-touched trail.
+
+    Because a created collection is ``provisioning`` and ``search_docs``
+    rejects a non-``ready`` collection, the response carries a ``next_step``
+    hint pointing at the probe route (#1756) so the ``create → probe →
+    ready`` flow is discoverable from the create reply rather than only from
+    a confusing not-ready error on the first search.
     """
     try:
         row = await create_doc_collection(session, operator, body)
@@ -243,7 +259,7 @@ async def create_doc_collection_endpoint(
             status_code=status.HTTP_409_CONFLICT,
             detail=str(exc),
         ) from exc
-    return project_doc_collection(row)
+    return project_doc_collection_create_response(row)
 
 
 @router.post(

--- a/backend/src/meho_backplane/docs_collections/__init__.py
+++ b/backend/src/meho_backplane/docs_collections/__init__.py
@@ -25,8 +25,10 @@ from meho_backplane.docs_collections.resolver import (
 from meho_backplane.docs_collections.schemas import (
     DocCollection,
     DocCollectionCreate,
+    DocCollectionCreateResponse,
     DocCollectionSummary,
     project_doc_collection,
+    project_doc_collection_create_response,
     project_doc_collection_to_summary,
 )
 from meho_backplane.docs_collections.service import (
@@ -42,12 +44,14 @@ __all__ = [
     "DocCollectionBackendTypeError",
     "DocCollectionConflictError",
     "DocCollectionCreate",
+    "DocCollectionCreateResponse",
     "DocCollectionNotFoundError",
     "DocCollectionStateError",
     "DocCollectionSummary",
     "create_doc_collection",
     "probe_collection",
     "project_doc_collection",
+    "project_doc_collection_create_response",
     "project_doc_collection_to_summary",
     "resolve_doc_collection",
     "set_collection_enabled",

--- a/backend/src/meho_backplane/docs_collections/schemas.py
+++ b/backend/src/meho_backplane/docs_collections/schemas.py
@@ -30,6 +30,19 @@ particular comes from the JWT, never the body (the ``create_target``
 precedent). There is still no ``DocCollectionUpdate`` here — PATCH /
 DELETE are a separate follow-up (out of scope per #1739).
 
+:class:`DocCollectionCreateResponse` is the create route's reply (#1756):
+the full :class:`DocCollection` read shape plus a ``next_step`` hint that
+names the ``create → probe → ready`` flow while the row is still
+``provisioning``. A freshly-created collection defaults to
+``provisioning`` and ``search_docs`` rejects a non-``ready`` collection,
+so the only path to a searchable collection is an explicit
+``POST /api/v1/doc_collections/{collection_key}/probe``; the hint points
+the operator straight at it instead of leaving them to discover the probe
+route after a confusing not-ready error. The hint is create-surface-only —
+it is deliberately **not** on :class:`DocCollection` so the read shape the
+collection-scoped search path and the MCP docs tools return stays a clean
+1:1 mirror of the table.
+
 :func:`project_doc_collection_to_summary` is the **single** ORM→wire
 projection, mirroring :func:`targets.schemas.project_target_to_summary`.
 Every surface that lists collections (the catalogue tool, the CLI
@@ -46,14 +59,18 @@ from uuid import UUID
 
 from pydantic import BaseModel, ConfigDict, Field, field_validator
 
+from meho_backplane.docs_collections.lifecycle import STATUS_PROVISIONING
+
 if TYPE_CHECKING:
     from meho_backplane.db.models import DocCollection as DocCollectionORM
 
 __all__ = [
     "DocCollection",
     "DocCollectionCreate",
+    "DocCollectionCreateResponse",
     "DocCollectionSummary",
     "project_doc_collection",
+    "project_doc_collection_create_response",
     "project_doc_collection_to_summary",
 ]
 
@@ -146,6 +163,29 @@ class DocCollection(BaseModel):
     updated_at: datetime
 
 
+class DocCollectionCreateResponse(DocCollection):
+    """The create route's reply: the full read shape plus a ``next_step`` hint.
+
+    Extends :class:`DocCollection` with a single create-surface-only field,
+    ``next_step`` (#1756). A create defaults ``status`` to ``provisioning``
+    and ``search_docs`` rejects a non-``ready`` collection, so the operator
+    must run an explicit ``POST /api/v1/doc_collections/{collection_key}/probe``
+    before the collection is searchable. ``next_step`` carries that
+    instruction inline so the ``create → probe → ready`` flow is
+    discoverable from the create response itself, not only from a confusing
+    not-ready error on the first search.
+
+    ``next_step`` is ``None`` for any non-``provisioning`` create (no
+    behaviour today creates a collection in another state, but the field is
+    typed ``str | None`` so the contract is honest if one ever does). The
+    field lives here, not on :class:`DocCollection`, so every read surface
+    that returns the bare read shape (the collection-scoped search path, the
+    ``list_doc_collections`` catalogue, the MCP docs tools) is unaffected.
+    """
+
+    next_step: str | None = None
+
+
 class DocCollectionSummary(BaseModel):
     """Short shape for the catalogue list (``list_doc_collections``, T4).
 
@@ -202,6 +242,42 @@ def project_doc_collection(c: DocCollectionORM) -> DocCollection:
         extras=c.extras,
         created_at=c.created_at,
         updated_at=c.updated_at,
+    )
+
+
+def _next_step_for_status(status: str, collection_key: str) -> str | None:
+    """Build the ``next_step`` create-response hint for *status* (#1756).
+
+    A freshly-created collection is ``provisioning`` and ``search_docs``
+    rejects a non-``ready`` collection, so the operator's next action is an
+    explicit probe — return the route + key to call. Any other status (no
+    create path produces one today) returns ``None``: there is no single
+    obvious next step to advertise, and a stale hint is worse than none.
+    """
+    if status == STATUS_PROVISIONING:
+        return (
+            f"POST /api/v1/doc_collections/{collection_key}/probe to make "
+            f"this collection searchable (it is provisioning until a probe "
+            f"confirms its index is ready)."
+        )
+    return None
+
+
+def project_doc_collection_create_response(
+    c: DocCollectionORM,
+) -> DocCollectionCreateResponse:
+    """Project a created :class:`DocCollectionORM` row to the create reply (#1756).
+
+    The create route's projection: the full :class:`DocCollection` read
+    shape plus the ``next_step`` hint that names the ``create → probe →
+    ready`` flow while the row is ``provisioning``. Reuses
+    :func:`project_doc_collection` for the shared fields so the read shape
+    never drifts between the two, then layers ``next_step`` on top.
+    """
+    base = project_doc_collection(c)
+    return DocCollectionCreateResponse(
+        **base.model_dump(),
+        next_step=_next_step_for_status(c.status, c.collection_key),
     )
 
 

--- a/backend/tests/test_doc_collections_create.py
+++ b/backend/tests/test_doc_collections_create.py
@@ -8,7 +8,10 @@ covered in :mod:`tests.test_mcp_tools_doc_collections`), mirroring the
 ``create_target`` precedent's guardrails:
 
 * **201 + full body** — a valid create returns the full ``DocCollection``
-  with a server-generated ``id`` / timestamps and ``status="provisioning"``.
+  with a server-generated ``id`` / timestamps and ``status="provisioning"``,
+  plus a ``next_step`` hint pointing at the probe route so the
+  ``create → probe → ready`` flow is discoverable from the create response
+  (#1756).
 * **tenant_id from JWT, never the body** — a body that tries to smuggle a
   ``tenant_id`` is rejected by the schema (``extra="forbid"``); the created
   row's tenant is always the operator's.
@@ -171,6 +174,31 @@ def test_create_returns_201_with_full_collection(client: TestClient) -> None:
     assert body["doc_count"] is None
     # The backend record round-trips (it is part of the full read shape).
     assert body["backend"] == {"type": "corpus-http", "ref": {"endpoint": _CORPUS_URL}}
+    # The create-surface-only next_step hint is present (asserted in depth in
+    # test_create_response_hints_probe_next_step).
+    assert "next_step" in body
+
+
+def test_create_response_hints_probe_next_step(client: TestClient) -> None:
+    """A provisioning create returns a ``next_step`` hint at the probe route (#1756).
+
+    A created collection is ``provisioning`` and ``search_docs`` rejects a
+    non-``ready`` collection, so the ``create → probe → ready`` flow is the
+    only path to a searchable collection. The create response advertises that
+    next step inline so an operator does not have to discover the probe route
+    after a confusing not-ready error.
+    """
+    key = make_rsa_keypair("kid-A")
+    resp = _post(client, key, _admin_token(key), _valid_body(collection_key="vmware"))
+    assert resp.status_code == 201, resp.text
+    body = resp.json()
+    assert body["status"] == "provisioning"
+    next_step = body["next_step"]
+    assert next_step is not None
+    # The hint names the probe route for *this* collection_key so it is
+    # directly actionable, and the verb that promotes it to searchable.
+    assert "POST /api/v1/doc_collections/vmware/probe" in next_step
+    assert "searchable" in next_step
 
 
 @pytest.mark.asyncio

--- a/cli/api/openapi.json
+++ b/cli/api/openapi.json
@@ -543,7 +543,7 @@
           "docs"
         ],
         "summary": "Create Doc Collection Endpoint",
-        "description": "Register a new doc collection in the requesting tenant.\n\nThe create sibling of the lifecycle write routes \u2014 ``tenant_admin``-\ngated, tenant-scoped (``tenant_id`` from the JWT, never the body), with\nthe validation + audit every other registry write gets. Mirrors\n``POST /api/v1/targets``: ``id`` / timestamps are generated server-side,\n``status`` defaults to ``provisioning`` (a follow-up ``probe`` promotes\nit to ``ready``), the ``backend.type`` is validated against the\nsearch-backend registry (an unregistered type \u2192 422 listing the valid\nset, not a deferred 503), and a cross-scope ``collection_key`` collision\n\u2192 409. The create binds ``op_id=\"meho.docs.collections.create\"`` so the\nregistration joins the ``op_id=\"meho.docs.*\"`` who-touched trail.",
+        "description": "Register a new doc collection in the requesting tenant.\n\nThe create sibling of the lifecycle write routes \u2014 ``tenant_admin``-\ngated, tenant-scoped (``tenant_id`` from the JWT, never the body), with\nthe validation + audit every other registry write gets. Mirrors\n``POST /api/v1/targets``: ``id`` / timestamps are generated server-side,\n``status`` defaults to ``provisioning`` (a follow-up ``probe`` promotes\nit to ``ready``), the ``backend.type`` is validated against the\nsearch-backend registry (an unregistered type \u2192 422 listing the valid\nset, not a deferred 503), and a cross-scope ``collection_key`` collision\n\u2192 409. The create binds ``op_id=\"meho.docs.collections.create\"`` so the\nregistration joins the ``op_id=\"meho.docs.*\"`` who-touched trail.\n\nBecause a created collection is ``provisioning`` and ``search_docs``\nrejects a non-``ready`` collection, the response carries a ``next_step``\nhint pointing at the probe route (#1756) so the ``create \u2192 probe \u2192\nready`` flow is discoverable from the create reply rather than only from\na confusing not-ready error on the first search.",
         "operationId": "create_doc_collection_endpoint_api_v1_doc_collections_post",
         "parameters": [
           {
@@ -569,11 +569,11 @@
         },
         "responses": {
           "201": {
-            "description": "Successful Response",
+            "description": "Collection registered. It starts at ``status=provisioning`` \u2014 the **create \u2192 probe \u2192 ready** flow: ``search_docs`` only accepts a ``ready`` collection, so call ``POST /api/v1/doc_collections/{collection_key}/probe`` to promote it before searching. The response carries that instruction inline as ``next_step``.",
             "content": {
               "application/json": {
                 "schema": {
-                  "$ref": "#/components/schemas/DocCollection"
+                  "$ref": "#/components/schemas/DocCollectionCreateResponse"
                 }
               }
             }
@@ -13187,7 +13187,80 @@
         "title": "DeprecateTemplateResponse",
         "description": "Response for ``meho.runbook.deprecate_template`` -- the now-deprecated coordinates."
       },
-      "DocCollection": {
+      "DocCollectionBackend": {
+        "properties": {
+          "type": {
+            "type": "string",
+            "minLength": 1,
+            "title": "Type"
+          },
+          "ref": {
+            "additionalProperties": true,
+            "type": "object",
+            "title": "Ref"
+          }
+        },
+        "additionalProperties": false,
+        "type": "object",
+        "required": [
+          "type",
+          "ref"
+        ],
+        "title": "DocCollectionBackend",
+        "description": "The ``{type, ref}`` backend routing record a create supplies.\n\n``type`` is the search-backend type the row routes to (validated at\nthe service layer against\n:func:`~meho_backplane.docs_search.backends.registry.all_backends` so\nan unroutable row is rejected at create time, not at probe time).\n``ref`` is the per-collection backend config the resolved adapter\nreads (e.g. ``{\"endpoint\": \"https://corpus/v1/search\"}`` for\n``corpus-http``); it is opaque to the create surface \u2014 the adapter\nowns its shape \u2014 so it is a free ``Mapping``."
+      },
+      "DocCollectionCreate": {
+        "properties": {
+          "collection_key": {
+            "type": "string",
+            "maxLength": 128,
+            "minLength": 1,
+            "title": "Collection Key"
+          },
+          "vendor": {
+            "type": "string",
+            "maxLength": 256,
+            "minLength": 1,
+            "title": "Vendor"
+          },
+          "products": {
+            "items": {
+              "type": "string"
+            },
+            "type": "array",
+            "title": "Products",
+            "default": []
+          },
+          "description": {
+            "type": "string",
+            "nullable": true,
+            "title": "Description"
+          },
+          "when_to_use": {
+            "type": "string",
+            "nullable": true,
+            "title": "When To Use"
+          },
+          "backend": {
+            "$ref": "#/components/schemas/DocCollectionBackend"
+          },
+          "extras": {
+            "additionalProperties": true,
+            "type": "object",
+            "title": "Extras"
+          }
+        },
+        "additionalProperties": false,
+        "type": "object",
+        "required": [
+          "collection_key",
+          "vendor",
+          "backend"
+        ],
+        "title": "DocCollectionCreate",
+        "description": "Request body for creating a doc collection (#1739).\n\nCarries only the operator-set identity + routing fields. The\nserver derives ``id`` / ``tenant_id`` / ``created_at`` /\n``updated_at`` / ``status`` and leaves the probe-written liveness\n(``last_ingested_at`` / ``doc_count`` / ``readiness``) NULL until the\nfirst probe \u2014 so none of those appear here. ``tenant_id`` is taken\nfrom the JWT in every front, never the body; a body carrying one is\nnot modelled (``extra=\"forbid\"`` rejects it) so a writer cannot even\nattempt a cross-tenant create. Mirrors\n:class:`~meho_backplane.targets.schemas.TargetCreate`."
+      },
+      "DocCollectionCreateResponse": {
         "properties": {
           "id": {
             "type": "string",
@@ -13265,6 +13338,11 @@
             "type": "string",
             "format": "date-time",
             "title": "Updated At"
+          },
+          "next_step": {
+            "type": "string",
+            "nullable": true,
+            "title": "Next Step"
           }
         },
         "type": "object",
@@ -13285,81 +13363,8 @@
           "created_at",
           "updated_at"
         ],
-        "title": "DocCollection",
-        "description": "Full read shape \u2014 maps 1:1 to the ``doc_collections`` table.\n\nFrozen so callers can stash instances in request state or structured\nlogs without fear of mutation. ``products`` is ``tuple[str, ...]``\nand the JSON columns are ``Mapping[str, Any]`` so a frozen instance\ncannot be mutated in-place via ``list.append`` / ``dict.__setitem__``.\n\n``backend`` is the operator-set ``{type, ref}`` routing record the\nT2 (#1551) router resolves server-side. ``status`` is the lifecycle\nenum (``provisioning`` / ``ready`` / ``rebuilding`` / ``disabled``);\n``last_ingested_at`` / ``doc_count`` / ``readiness`` are\nprobe-written liveness (T6 #1555), ``None`` until the first probe."
-      },
-      "DocCollectionBackend": {
-        "properties": {
-          "type": {
-            "type": "string",
-            "minLength": 1,
-            "title": "Type"
-          },
-          "ref": {
-            "additionalProperties": true,
-            "type": "object",
-            "title": "Ref"
-          }
-        },
-        "additionalProperties": false,
-        "type": "object",
-        "required": [
-          "type",
-          "ref"
-        ],
-        "title": "DocCollectionBackend",
-        "description": "The ``{type, ref}`` backend routing record a create supplies.\n\n``type`` is the search-backend type the row routes to (validated at\nthe service layer against\n:func:`~meho_backplane.docs_search.backends.registry.all_backends` so\nan unroutable row is rejected at create time, not at probe time).\n``ref`` is the per-collection backend config the resolved adapter\nreads (e.g. ``{\"endpoint\": \"https://corpus/v1/search\"}`` for\n``corpus-http``); it is opaque to the create surface \u2014 the adapter\nowns its shape \u2014 so it is a free ``Mapping``."
-      },
-      "DocCollectionCreate": {
-        "properties": {
-          "collection_key": {
-            "type": "string",
-            "maxLength": 128,
-            "minLength": 1,
-            "title": "Collection Key"
-          },
-          "vendor": {
-            "type": "string",
-            "maxLength": 256,
-            "minLength": 1,
-            "title": "Vendor"
-          },
-          "products": {
-            "items": {
-              "type": "string"
-            },
-            "type": "array",
-            "title": "Products",
-            "default": []
-          },
-          "description": {
-            "type": "string",
-            "nullable": true,
-            "title": "Description"
-          },
-          "when_to_use": {
-            "type": "string",
-            "nullable": true,
-            "title": "When To Use"
-          },
-          "backend": {
-            "$ref": "#/components/schemas/DocCollectionBackend"
-          },
-          "extras": {
-            "additionalProperties": true,
-            "type": "object",
-            "title": "Extras"
-          }
-        },
-        "additionalProperties": false,
-        "type": "object",
-        "required": [
-          "collection_key",
-          "vendor",
-          "backend"
-        ],
-        "title": "DocCollectionCreate",
-        "description": "Request body for creating a doc collection (#1739).\n\nCarries only the operator-set identity + routing fields. The\nserver derives ``id`` / ``tenant_id`` / ``created_at`` /\n``updated_at`` / ``status`` and leaves the probe-written liveness\n(``last_ingested_at`` / ``doc_count`` / ``readiness``) NULL until the\nfirst probe \u2014 so none of those appear here. ``tenant_id`` is taken\nfrom the JWT in every front, never the body; a body carrying one is\nnot modelled (``extra=\"forbid\"`` rejects it) so a writer cannot even\nattempt a cross-tenant create. Mirrors\n:class:`~meho_backplane.targets.schemas.TargetCreate`."
+        "title": "DocCollectionCreateResponse",
+        "description": "The create route's reply: the full read shape plus a ``next_step`` hint.\n\nExtends :class:`DocCollection` with a single create-surface-only field,\n``next_step`` (#1756). A create defaults ``status`` to ``provisioning``\nand ``search_docs`` rejects a non-``ready`` collection, so the operator\nmust run an explicit ``POST /api/v1/doc_collections/{collection_key}/probe``\nbefore the collection is searchable. ``next_step`` carries that\ninstruction inline so the ``create \u2192 probe \u2192 ready`` flow is\ndiscoverable from the create response itself, not only from a confusing\nnot-ready error on the first search.\n\n``next_step`` is ``None`` for any non-``provisioning`` create (no\nbehaviour today creates a collection in another state, but the field is\ntyped ``str | None`` so the contract is honest if one ever does). The\nfield lives here, not on :class:`DocCollection`, so every read surface\nthat returns the bare read shape (the collection-scoped search path, the\n``list_doc_collections`` catalogue, the MCP docs tools) is unaffected."
       },
       "DocCollectionSummary": {
         "properties": {

--- a/cli/internal/api/client.gen.go
+++ b/cli/internal/api/client.gen.go
@@ -2202,36 +2202,6 @@ type DeprecateTemplateResponse struct {
 	Version int    `json:"version"`
 }
 
-// DocCollection Full read shape — maps 1:1 to the “doc_collections“ table.
-//
-// Frozen so callers can stash instances in request state or structured
-// logs without fear of mutation. “products“ is “tuple[str, ...]“
-// and the JSON columns are “Mapping[str, Any]“ so a frozen instance
-// cannot be mutated in-place via “list.append“ / “dict.__setitem__“.
-//
-// “backend“ is the operator-set “{type, ref}“ routing record the
-// T2 (#1551) router resolves server-side. “status“ is the lifecycle
-// enum (“provisioning“ / “ready“ / “rebuilding“ / “disabled“);
-// “last_ingested_at“ / “doc_count“ / “readiness“ are
-// probe-written liveness (T6 #1555), “None“ until the first probe.
-type DocCollection struct {
-	Backend        map[string]interface{}  `json:"backend"`
-	CollectionKey  string                  `json:"collection_key"`
-	CreatedAt      time.Time               `json:"created_at"`
-	Description    *string                 `json:"description"`
-	DocCount       *int                    `json:"doc_count"`
-	Extras         map[string]interface{}  `json:"extras"`
-	Id             openapi_types.UUID      `json:"id"`
-	LastIngestedAt *time.Time              `json:"last_ingested_at"`
-	Products       []string                `json:"products"`
-	Readiness      *map[string]interface{} `json:"readiness"`
-	Status         string                  `json:"status"`
-	TenantId       *openapi_types.UUID     `json:"tenant_id"`
-	UpdatedAt      time.Time               `json:"updated_at"`
-	Vendor         string                  `json:"vendor"`
-	WhenToUse      *string                 `json:"when_to_use"`
-}
-
 // DocCollectionBackend The “{type, ref}“ backend routing record a create supplies.
 //
 // “type“ is the search-backend type the row routes to (validated at
@@ -2276,6 +2246,42 @@ type DocCollectionCreate struct {
 	Products      *[]string               `json:"products,omitempty"`
 	Vendor        string                  `json:"vendor"`
 	WhenToUse     *string                 `json:"when_to_use"`
+}
+
+// DocCollectionCreateResponse The create route's reply: the full read shape plus a “next_step“ hint.
+//
+// Extends :class:`DocCollection` with a single create-surface-only field,
+// “next_step“ (#1756). A create defaults “status“ to “provisioning“
+// and “search_docs“ rejects a non-“ready“ collection, so the operator
+// must run an explicit “POST /api/v1/doc_collections/{collection_key}/probe“
+// before the collection is searchable. “next_step“ carries that
+// instruction inline so the “create → probe → ready“ flow is
+// discoverable from the create response itself, not only from a confusing
+// not-ready error on the first search.
+//
+// “next_step“ is “None“ for any non-“provisioning“ create (no
+// behaviour today creates a collection in another state, but the field is
+// typed “str | None“ so the contract is honest if one ever does). The
+// field lives here, not on :class:`DocCollection`, so every read surface
+// that returns the bare read shape (the collection-scoped search path, the
+// “list_doc_collections“ catalogue, the MCP docs tools) is unaffected.
+type DocCollectionCreateResponse struct {
+	Backend        map[string]interface{}  `json:"backend"`
+	CollectionKey  string                  `json:"collection_key"`
+	CreatedAt      time.Time               `json:"created_at"`
+	Description    *string                 `json:"description"`
+	DocCount       *int                    `json:"doc_count"`
+	Extras         map[string]interface{}  `json:"extras"`
+	Id             openapi_types.UUID      `json:"id"`
+	LastIngestedAt *time.Time              `json:"last_ingested_at"`
+	NextStep       *string                 `json:"next_step"`
+	Products       []string                `json:"products"`
+	Readiness      *map[string]interface{} `json:"readiness"`
+	Status         string                  `json:"status"`
+	TenantId       *openapi_types.UUID     `json:"tenant_id"`
+	UpdatedAt      time.Time               `json:"updated_at"`
+	Vendor         string                  `json:"vendor"`
+	WhenToUse      *string                 `json:"when_to_use"`
 }
 
 // DocCollectionSummary Short shape for the catalogue list (“list_doc_collections“, T4).
@@ -23213,7 +23219,7 @@ func (r ListDocCollectionsEndpointApiV1DocCollectionsGetResponse) StatusCode() i
 type CreateDocCollectionEndpointApiV1DocCollectionsPostResponse struct {
 	Body         []byte
 	HTTPResponse *http.Response
-	JSON201      *DocCollection
+	JSON201      *DocCollectionCreateResponse
 }
 
 // Status returns HTTPResponse.Status
@@ -29677,7 +29683,7 @@ func ParseCreateDocCollectionEndpointApiV1DocCollectionsPostResponse(rsp *http.R
 
 	switch {
 	case strings.Contains(rsp.Header.Get("Content-Type"), "json") && rsp.StatusCode == 201:
-		var dest DocCollection
+		var dest DocCollectionCreateResponse
 		if err := json.Unmarshal(bodyBytes, &dest); err != nil {
 			return nil, err
 		}

--- a/cli/internal/cmd/docs/collections_create_test.go
+++ b/cli/internal/cmd/docs/collections_create_test.go
@@ -120,11 +120,13 @@ func TestRunCollectionCreateHappyPath(t *testing.T) {
 			}
 			w.Header().Set("Content-Type", "application/json")
 			w.WriteHeader(http.StatusCreated)
-			_ = json.NewEncoder(w).Encode(api.DocCollection{
+			nextStep := "POST /api/v1/doc_collections/vmware/probe to make this collection searchable"
+			_ = json.NewEncoder(w).Encode(api.DocCollectionCreateResponse{
 				CollectionKey: "vmware",
 				Vendor:        "VMware by Broadcom",
 				Status:        "provisioning",
 				Backend:       map[string]interface{}{"type": "corpus-http"},
+				NextStep:      &nextStep,
 			})
 		},
 	)

--- a/docs/codebase/doc-collections.md
+++ b/docs/codebase/doc-collections.md
@@ -73,15 +73,23 @@ tenant-curated `vmware` coexist (the resolver prefers the tenant row).
 
 ### `DocCollection` / `DocCollectionSummary` (`meho_backplane.docs_collections.schemas`)
 
-Frozen Pydantic-v2 read models. `DocCollection` maps 1:1 to the table
-columns. `DocCollectionSummary` is the short shape for the catalogue
-list — it carries the identification + routing-decision fields plus the
-operator-facing liveness fields but **omits `backend`** (the backend is
-resolved server-side and never appears in a catalogue response, the
-backend-agnostic contract from #1548) and `extras`.
+Pydantic-v2 models. The two read models are frozen: `DocCollection` maps
+1:1 to the table columns; `DocCollectionSummary` is the short shape for
+the catalogue list — it carries the identification + routing-decision
+fields plus the operator-facing liveness fields but **omits `backend`**
+(the backend is resolved server-side and never appears in a catalogue
+response, the backend-agnostic contract from #1548) and `extras`.
 
-There are no `Create` / `Update` write schemas — v1 collections are
-operator-managed seed. When an import API lands it adds them here.
+The write / response half: `DocCollectionCreate` (#1739) is the create
+request body (operator-set identity + routing fields only; `extra="forbid"`
+so a smuggled `tenant_id` is rejected), and `DocCollectionCreateResponse`
+(#1756) is the REST create reply — `DocCollection` plus a `next_step`
+string that names the `create → probe → ready` flow while the row is
+`provisioning` (see
+[The `create → probe → ready` flow](#the-create--probe--ready-flow-1756)).
+`next_step` lives on the create-response model only, never on the shared
+`DocCollection` read shape. There is still no `Update` schema — PATCH /
+DELETE are a later follow-up.
 
 ### `project_doc_collection_to_summary(...)` (`meho_backplane.docs_collections.schemas`)
 
@@ -331,18 +339,55 @@ The service primitive
 Three fronts forward to the same primitive:
 
 - **REST** — `POST /api/v1/doc_collections` → `201` with the full
-  `DocCollection`, `tenant_admin`-gated (parity with the lifecycle
-  routes). The route maps the two service exceptions to `422` / `409`.
+  `DocCollection` read shape plus a `next_step` hint
+  (`DocCollectionCreateResponse`, #1756; see
+  [The `create → probe → ready` flow](#the-create--probe--ready-flow-1756)),
+  `tenant_admin`-gated (parity with the lifecycle routes). The route maps
+  the two service exceptions to `422` / `409`.
 - **MCP** — the `create_doc_collections` write-class tool
   (`meho_backplane.mcp.tools.doc_collections_create`), `tenant_admin` +
   `required_capability="meho-docs"`. The exceptions map to JSON-RPC
-  `INVALID_PARAMS` with the structured detail in `error.data`.
+  `INVALID_PARAMS` with the structured detail in `error.data`. The tool's
+  description already names the probe-to-`ready` step, so it returns the
+  bare created collection (no `next_step` field — the REST hint is the
+  surface that lacked the cue).
 - **CLI** — `meho docs collections create <key> --vendor … --backend-type …
   --backend-ref '{…}'` (or `--from-file <path>`), in
   `cli/internal/cmd/docs/collections_create.go`.
 
+### The `create → probe → ready` flow (#1756)
+
+A created collection is `provisioning`, and the search-time access gate
+(`resolve_entitled_ready_collection`) rejects a non-`ready` collection with
+`CollectionNotReadyError`. There is no update API and create never
+self-probes (auto-promotion is out of scope — it couples to ingest cost),
+so **`create → probe → ready` is the only path to a searchable
+collection**:
+
+1. `POST /api/v1/doc_collections` registers the row at
+   `status=provisioning`.
+2. `POST /api/v1/doc_collections/{collection_key}/probe` reads the
+   backend's readiness and, on a built index, promotes the row to `ready`.
+3. `search_docs` / `ask_docs` now accept the collection.
+
+Before #1756 the create response carried the registry state but no cue
+that a probe was required, so an operator hit a confusing not-ready error
+on the first search. The REST create response now carries a `next_step`
+string (`DocCollectionCreateResponse.next_step`) naming the exact probe
+route + `collection_key` to call while the row is `provisioning`
+(`None` for any other create status — no path produces one today). The
+hint is **create-surface-only**: it lives on `DocCollectionCreateResponse`
+(built by `project_doc_collection_create_response`), not on the shared
+`DocCollection` read model, so every read surface that returns the bare
+read shape (the collection-scoped search path, the `list_doc_collections`
+catalogue, the MCP docs tools) is unchanged. The route's `201` OpenAPI
+`description` names the same flow.
+
 Out of scope (a later follow-up): PATCH / DELETE, cross-tenant sharing,
 and bulk import beyond the single-collection `--from-file` on-ramp.
+Auto-promotion / self-probe on create stays out of scope (#1756) — it is a
+behaviour change with ingest-cost implications; #1756 is discoverability
+only.
 
 ## Dependencies
 


### PR DESCRIPTION
## Summary

- A freshly-created doc collection defaults to `status=provisioning`, and the search-time access gate rejects a non-`ready` collection with `CollectionNotReadyError`. With no update API and no self-probe on create, an explicit `POST /api/v1/doc_collections/{collection_key}/probe` is the only path to a searchable collection — but the create response carried no cue, so operators hit a confusing not-ready error on the first `search_docs` (RDC Hetzner-DC v0.15.0 dogfood, #1751).
- Adds a `next_step` hint to the REST create response while the row is `provisioning`, naming the probe route for that `collection_key`. The hint lives on a dedicated `DocCollectionCreateResponse` model (`DocCollection` + `next_step`, built by `project_doc_collection_create_response`), so the shared `DocCollection` read shape that the collection-scoped search path and the MCP docs tools return stays a clean 1:1 mirror of the table.
- The route's `201` OpenAPI `description` and `docs/codebase/doc-collections.md` both name the `create → probe → ready` flow.
- Discoverability only — create still does **not** self-probe (auto-promotion couples to ingest cost and is out of scope per #1756).

## Test plan

- [x] `ruff check` (changed files) — clean
- [x] `ruff format --check` (changed files) — clean
- [x] `mypy src/meho_backplane/docs_collections/ api/v1/doc_collections.py` — clean
- [x] `pytest tests/test_doc_collections_create.py` — 7 passed (new `test_create_response_hints_probe_next_step` asserts the `201` body carries a `next_step` pointing at `POST /api/v1/doc_collections/vmware/probe` while `status=provisioning`) — **acceptance (a)**
- [x] `pytest` across the doc-collections + search-docs + MCP-docs + `test_app_starts` surface — 178 passed, 0 failed (the shared `DocCollection` read shape consumed by `search_docs` / MCP is unaffected)
- [x] `201` OpenAPI `description` and `docs/codebase/doc-collections.md` name the `create → probe → ready` flow — **acceptance (b)**
- [x] Response schema changed (`next_step` added) → `cd cli && make snapshot-openapi && make generate`; committed the regenerated `cli/api/openapi.json` + `cli/internal/api/client.gen.go` (semantic diff: +`DocCollectionCreateResponse`, the `201` ref + description; `DocCollection` drops out as it is no longer referenced by any REST path). CLI `go build ./...` + `go test ./...` green — **acceptance (c)** + CLI API snapshot freshness gate

## Out of scope

- Auto-promotion / self-probe on create (a behaviour change with ingest-cost implications) — discoverability only.
- The vertex-rag `GET /status` 404 / `doc_count: null` — a knowledge-backend (sibling repo) follow-up.

<!-- auto-implement-issue: fresh, iteration 1 -->

Closes #1756


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Document collection creation responses now include a `next_step` field providing workflow guidance.

* **Changed**
  * Newly created collections start in provisioning status and require an explicit probe request to become searchable.

* **Documentation**
  * API documentation now clarifies the complete collection lifecycle from creation through probing to ready status.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->