### PR TITLE
fix(connectors): reject a mount-included vault.kv path with a shape hint

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -100,6 +100,20 @@ connector-related release-notes line.
   default-deny. Tenant-scope-aware, idempotent, and audited as a
   single bulk-enable event with the count of ops enabled (#1749).
 
+### Fixed
+
+- `vault.kv.*` now returns an actionable path-shape hint instead of an
+  opaque `Forbidden` 403 when a caller passes a `path` that re-includes
+  the mount segment (`path="secret/meho/…"` with `mount="secret"`).
+  hvac addresses a secret as `v1/<mount>/data/<path>`, so the mount
+  prefix would double to `v1/secret/data/secret/meho/…` and fail the
+  Vault ACL indistinguishably from a real permission denial. All six KV
+  ops (read / list / put / patch / versions / delete) now reject the
+  mount-double-prefix before the Vault round-trip with a
+  `VaultPathShapeError` naming the mount-relative form to use
+  (e.g. `meho/test/federation`). A bare single-segment path equal to the
+  mount name is still forwarded unchanged (#1755).
+
 ## [0.15.0] - 2026-06-13
 
 ### Added

--- a/backend/src/meho_backplane/connectors/vault/ops.py
+++ b/backend/src/meho_backplane/connectors/vault/ops.py
@@ -79,6 +79,7 @@ from meho_backplane.retrieval.embedding import EmbeddingService
 __all__ = [
     "VAULT_KV_READ_PARAMETER_SCHEMA",
     "VAULT_KV_WRITE_CAPABILITIES",
+    "VaultPathShapeError",
     "register_vault_typed_operations",
     "vault_kv_delete",
     "vault_kv_list",
@@ -131,6 +132,74 @@ _PATH_PROPERTY: dict[str, Any] = {
         "'meho/test/federation'. No leading slash, no mount prefix."
     ),
 }
+
+
+class VaultPathShapeError(Exception):
+    """A ``vault.kv.*`` call passed a ``path`` that re-includes the mount segment.
+
+    Raised by :func:`_extract_mount_and_path` **before** the hvac call (and
+    before the tenant-scope guard) when the supplied ``path`` begins with
+    ``"<mount>/"``. hvac addresses a KV-v2 secret as
+    ``v1/<mount>/data/<path>``, so a caller that passes the mount as part of
+    the ``path`` (``path="secret/meho/test/federation"`` with the default
+    ``mount="secret"``) doubles the mount segment to
+    ``v1/secret/data/secret/meho/test/federation`` — a path that fails the
+    Vault ACL policy and returns an opaque ``Forbidden`` 403,
+    indistinguishable from a genuine permission denial. The ``path`` schema
+    documents "no mount prefix" (:data:`_PATH_PROPERTY`) but cannot enforce
+    it (the mount name is not known at schema-validation time), so this
+    runtime guard names the mistake.
+
+    The dispatcher's ``connector_error`` branch wraps the raised exception
+    into a structured
+    :class:`~meho_backplane.connectors.schemas.OperationResult` with
+    ``extras["exception_class"] == "VaultPathShapeError"`` — distinct from
+    the ``VaultClientError`` family (login-phase) and from a Vault-side
+    ``Forbidden`` (read-phase permission denial), so a caller can tell a
+    *local path-shape mistake* apart from a real authorization failure.
+
+    The guard **rejects** rather than silently stripping the prefix: an
+    operator whose tenant layout legitimately starts a logical path with the
+    mount name (a genuine ``secret/...`` key under a non-default mount)
+    would be surprised by a silent rewrite, and the doubled-path failure is
+    the common case worth a clear, actionable message. The message names the
+    mount-relative form to use; it echoes only the (non-secret) mount/path
+    the caller already supplied, never any secret material — following
+    ``docs/codebase/error-message-shape.md`` (actionable error over an
+    opaque 403).
+    """
+
+
+def _extract_mount_and_path(op_id: str, params: dict[str, Any]) -> tuple[str, str]:
+    """Resolve the ``(mount, path)`` pair every KV-v2 handler forwards to hvac.
+
+    Centralises the ``mount`` defaulting + ``.strip()`` the six KV-v2
+    handlers (read / list / put / patch / versions / delete) each applied
+    inline, and adds a shared **path-shape pre-flight**: a ``path`` that
+    begins with ``"<mount>/"`` raises :class:`VaultPathShapeError` before any
+    Vault round-trip (and before :func:`enforce_tenant_scope`), so the
+    mount-double-prefix mistake surfaces as a clear, actionable error rather
+    than the opaque ``Forbidden`` 403 the doubled ``v1/<mount>/data/<mount>/…``
+    request would produce.
+
+    The check fires only on the ``"<mount>/"`` *prefix* — a bare
+    ``path == mount`` (a legitimate single-segment secret named after the
+    mount) is left untouched, matching hvac's ``v1/<mount>/data/<mount>``
+    address. ``mount`` is schema-constrained to a single slash-free segment
+    (:data:`_MOUNT_PROPERTY`), so ``mount + "/"`` is an unambiguous prefix.
+    """
+    mount: str = str(params.get("mount", _DEFAULT_KV_MOUNT)).strip()
+    path: str = str(params["path"]).strip()
+
+    if path.startswith(mount + "/"):
+        relative = path[len(mount) + 1 :]
+        raise VaultPathShapeError(
+            f"{op_id} path includes the mount segment '{mount}/'; pass the "
+            f"mount-relative path instead "
+            f"(e.g. {relative!r}, not {path!r})."
+        )
+
+    return mount, path
 
 
 #: JSON Schema 2020-12 for the ``vault.kv.read`` op's ``params`` argument.
@@ -288,12 +357,12 @@ async def vault_kv_read(operator: Operator, target: Any, params: dict[str, Any])
     ``issubclass(...)`` on the class name -- the exception class name
     is the contract, not the hierarchy at runtime.
     """
-    # Schema-enforced: ``path`` is a non-empty non-whitespace string.
-    # We re-strip so trailing whitespace doesn't slip into the hvac
-    # call -- the schema permits ``"a "`` (one non-whitespace char) and
-    # we want the wire shape to match what the operator typed.
-    mount: str = str(params.get("mount", _DEFAULT_KV_MOUNT)).strip()
-    path: str = str(params["path"]).strip()
+    # Schema-enforced: ``path`` is a non-empty non-whitespace string. The
+    # shared extractor re-strips (the schema permits ``"a "`` — one
+    # non-whitespace char — and the wire shape should match what the
+    # operator typed) and raises ``VaultPathShapeError`` before any Vault
+    # round-trip if ``path`` re-includes the ``"<mount>/"`` segment (#1755).
+    mount, path = _extract_mount_and_path("vault.kv.read", params)
 
     # Defense-in-depth tenant-scope check (#1643): deny a path outside the
     # operator's tenant namespace BEFORE the hvac call. No-op unless
@@ -396,8 +465,8 @@ async def vault_kv_list(operator: Operator, target: Any, params: dict[str, Any])
     hvac payload so the dispatcher's ``connector_error`` branch surfaces
     a structured error rather than an unhandled exception.
     """
-    mount: str = str(params.get("mount", _DEFAULT_KV_MOUNT)).strip()
-    path: str = str(params["path"]).strip()
+    # Shared mount/path extraction + path-shape pre-flight (#1755).
+    mount, path = _extract_mount_and_path("vault.kv.list", params)
 
     # Tenant-scope guard (#1643) — see vault_kv_read. Read-only op.
     enforce_tenant_scope(operator, mount=mount, path=path, read_only=True)
@@ -501,8 +570,8 @@ async def vault_kv_put(operator: Operator, target: Any, params: dict[str, Any]) 
     malformed hvac payload so the dispatcher reports a structured
     ``connector_error``.
     """
-    mount: str = str(params.get("mount", _DEFAULT_KV_MOUNT)).strip()
-    path: str = str(params["path"]).strip()
+    # Shared mount/path extraction + path-shape pre-flight (#1755).
+    mount, path = _extract_mount_and_path("vault.kv.put", params)
     secret: dict[str, Any] = params["data"]
     cas = params.get("cas")
 
@@ -666,8 +735,8 @@ async def vault_kv_patch(operator: Operator, target: Any, params: dict[str, Any]
     removal goes through :func:`vault_kv_put` (wholesale replace) or
     :func:`vault_kv_delete` (version soft-delete).
     """
-    mount: str = str(params.get("mount", _DEFAULT_KV_MOUNT)).strip()
-    path: str = str(params["path"]).strip()
+    # Shared mount/path extraction + path-shape pre-flight (#1755).
+    mount, path = _extract_mount_and_path("vault.kv.patch", params)
     secret: dict[str, Any] = params["data"]
 
     # Tenant-scope guard (#1643) — see vault_kv_read. Mutating patch: the
@@ -745,8 +814,8 @@ async def vault_kv_versions(
     /v1/<mount>/metadata/<path>``). Returns only metadata — never the
     secret values — so it is NOT in the ``credential_read`` allowlist.
     """
-    mount: str = str(params.get("mount", _DEFAULT_KV_MOUNT)).strip()
-    path: str = str(params["path"]).strip()
+    # Shared mount/path extraction + path-shape pre-flight (#1755).
+    mount, path = _extract_mount_and_path("vault.kv.versions", params)
 
     # Tenant-scope guard (#1643) — see vault_kv_read. Read-only op.
     enforce_tenant_scope(operator, mount=mount, path=path, read_only=True)
@@ -839,8 +908,8 @@ async def vault_kv_delete(
     a JSON payload and instead echoes the requested versions for an
     actionable agent-facing result.
     """
-    mount: str = str(params.get("mount", _DEFAULT_KV_MOUNT)).strip()
-    path: str = str(params["path"]).strip()
+    # Shared mount/path extraction + path-shape pre-flight (#1755).
+    mount, path = _extract_mount_and_path("vault.kv.delete", params)
     versions: list[int] = list(params["versions"])
 
     # Tenant-scope guard (#1643) — see vault_kv_read. Mutating delete: the

--- a/backend/tests/test_connectors_vault.py
+++ b/backend/tests/test_connectors_vault.py
@@ -427,7 +427,7 @@ async def test_execute_vault_kv_read_returns_secret_data(
     )
     result = await _dispatch_vault(
         "vault.kv.read",
-        {"path": "secret/meho/test/federation"},
+        {"path": "meho/test/federation"},
         jwt="op-jwt",
     )
 
@@ -441,9 +441,12 @@ async def test_execute_vault_kv_read_returns_secret_data(
         {"role": "meho-mcp", "jwt": "op-jwt", "path": "jwt"},
     ]
     # Mount defaults to "secret" when the caller omits it — the
-    # path-only call site keeps working unchanged.
+    # path-only call site keeps working unchanged. The path is
+    # mount-relative ("meho/test/federation", not "secret/meho/…"); a
+    # mount-included path is rejected by the #1755 path-shape guard
+    # (test_execute_kv_op_mount_included_path_returns_path_shape_error).
     assert fake.secrets.kv.v2.read_calls == [
-        {"path": "secret/meho/test/federation", "mount_point": "secret"},
+        {"path": "meho/test/federation", "mount_point": "secret"},
     ]
     assert fake.auth.token.revoke_calls == 1
 
@@ -1007,6 +1010,120 @@ async def test_execute_vault_kv_list_malformed_payload_is_structured_error(
     assert result.status == "error"
     assert result.extras.get("error_code") == "connector_error"
     assert result.extras.get("exception_class") == "KeyError"
+
+
+# ---------------------------------------------------------------------------
+# Mount-included path-shape guard (#1755)
+# ---------------------------------------------------------------------------
+
+#: Each KV-v2 verb with a ``path`` that re-includes the default
+#: ``"secret/"`` mount segment — the mount-double-prefix mistake the
+#: guard rejects. One row per op so a regression on any single handler's
+#: extraction call surfaces independently.
+_MOUNT_PREFIXED_PATH_CASES: list[tuple[str, dict[str, Any]]] = [
+    ("vault.kv.read", {"path": "secret/meho/test/federation"}),
+    ("vault.kv.list", {"path": "secret/meho/test"}),
+    ("vault.kv.put", {"path": "secret/meho/test", "data": {"k": "v"}}),
+    ("vault.kv.patch", {"path": "secret/meho/test", "data": {"k": "v"}}),
+    ("vault.kv.versions", {"path": "secret/meho/test"}),
+    ("vault.kv.delete", {"path": "secret/meho/test", "versions": [1]}),
+]
+
+
+@pytest.mark.parametrize(
+    "op_id,params",
+    _MOUNT_PREFIXED_PATH_CASES,
+    ids=[op_id for op_id, _ in _MOUNT_PREFIXED_PATH_CASES],
+)
+async def test_execute_kv_op_mount_included_path_returns_path_shape_error(
+    monkeypatch: pytest.MonkeyPatch,
+    op_id: str,
+    params: dict[str, Any],
+    _registered_vault_typed_ops: None,
+) -> None:
+    """A ``path`` re-including the mount segment → ``VaultPathShapeError``, no hvac call.
+
+    Regression for #1755: hvac addresses a KV-v2 secret as
+    ``v1/<mount>/data/<path>``, so a caller that passes
+    ``path="secret/meho/…"`` with the default ``mount="secret"`` doubles
+    the mount to ``v1/secret/data/secret/meho/…`` — an opaque ``Forbidden``
+    403 indistinguishable from a real permission denial. The shared
+    extractor rejects the mount-double-prefix *before* the Vault round-trip
+    (and before the tenant-scope guard), so the dispatcher surfaces a
+    structured ``connector_error`` with ``exception_class="VaultPathShapeError"``
+    rather than the doubled-path 403.
+    """
+    fake = install_fake_client(monkeypatch)
+    result = await _dispatch_vault(op_id, params)
+
+    assert result.status == "error"
+    assert result.error is not None
+    assert result.error.startswith("connector_error:")
+    assert result.extras.get("error_code") == "connector_error"
+    assert result.extras.get("exception_class") == "VaultPathShapeError"
+
+    # The message names the mistake (the mount segment) and the
+    # mount-relative form to use instead — an actionable error, not an
+    # opaque 403 (docs/codebase/error-message-shape.md).
+    message = result.extras.get("exception_message", "")
+    assert "secret/" in message
+    assert "mount-relative" in message
+
+    # hvac is never reached: no JWT/OIDC login, and the verb's own call
+    # log stays empty. The guard short-circuits ahead of every Vault call.
+    assert fake.auth.jwt.login_calls == []
+    kv = fake.secrets.kv.v2
+    assert kv.read_calls == []
+    assert kv.list_calls == []
+    assert kv.put_calls == []
+    assert kv.patch_calls == []
+    assert kv.versions_calls == []
+    assert kv.delete_calls == []
+
+
+async def test_execute_kv_op_mount_included_path_honors_explicit_non_default_mount(
+    monkeypatch: pytest.MonkeyPatch,
+    _registered_vault_typed_ops: None,
+) -> None:
+    """The guard keys off the *supplied* mount, not the literal ``"secret"``.
+
+    A non-default ``mount="kv-prod"`` with ``path="kv-prod/team"`` is the
+    same doubled-prefix mistake and is rejected the same way; the message
+    names the supplied mount and the mount-relative remainder.
+    """
+    fake = install_fake_client(monkeypatch)
+    result = await _dispatch_vault(
+        "vault.kv.read",
+        {"mount": "kv-prod", "path": "kv-prod/team/api-key"},
+    )
+
+    assert result.status == "error"
+    assert result.extras.get("exception_class") == "VaultPathShapeError"
+    message = result.extras.get("exception_message", "")
+    assert "kv-prod/" in message
+    assert "'team/api-key'" in message
+    assert fake.auth.jwt.login_calls == []
+    assert fake.secrets.kv.v2.read_calls == []
+
+
+async def test_execute_kv_op_path_equal_to_mount_is_not_rejected(
+    monkeypatch: pytest.MonkeyPatch,
+    _registered_vault_typed_ops: None,
+) -> None:
+    """A bare ``path == mount`` is a legitimate secret, not a doubled prefix.
+
+    The guard fires only on the ``"<mount>/"`` prefix; a single-segment
+    path that happens to equal the mount name (``path="secret"`` under
+    ``mount="secret"``) addresses ``v1/secret/data/secret`` and is forwarded
+    to hvac unchanged. Locks the boundary so the guard does not over-reject.
+    """
+    fake = install_fake_client(monkeypatch, secret={"k": "v"})
+    result = await _dispatch_vault("vault.kv.read", {"path": "secret"})
+
+    assert result.status == "ok", result.error
+    assert fake.secrets.kv.v2.read_calls == [
+        {"path": "secret", "mount_point": "secret"},
+    ]
 
 
 @pytest.mark.parametrize(

--- a/docs/codebase/connectors-vault.md
+++ b/docs/codebase/connectors-vault.md
@@ -291,6 +291,34 @@ degrades to a runtime `connector_error`; `[^/]+` rejects a
 slash-bearing value (`"secret/data"`) where hvac expects the bare
 mount handle.
 
+**Mount-included `path` guard (#1755).** All six handlers resolve their
+`(mount, path)` pair through the shared `_extract_mount_and_path(op_id,
+params)` helper, which applies the `mount` default + `.strip()` and adds
+a **path-shape pre-flight**: a `path` beginning with `"<mount>/"` raises
+`VaultPathShapeError` *before* the Vault round-trip (and before
+`enforce_tenant_scope`). hvac addresses a KV-v2 secret as
+`v1/<mount>/data/<path>`, so a caller that re-includes the mount in the
+`path` (`path="secret/meho/test/federation"` with the default
+`mount="secret"`) would double the mount segment to
+`v1/secret/data/secret/meho/test/federation` — a path the Vault ACL
+policy rejects with an opaque `Forbidden` 403 indistinguishable from a
+genuine permission denial. The `path` schema documents "no mount prefix"
+but cannot enforce it (the mount name is not known at schema-validation
+time), so this runtime guard names the mistake. The error message names
+the mount-relative form to use (e.g. `'meho/test/federation', not
+'secret/meho/test/federation'`) and echoes only the (non-secret)
+mount/path the caller already supplied — an actionable error over an
+opaque 403, per `docs/codebase/error-message-shape.md`. The guard
+**rejects** rather than silently stripping the prefix: an operator whose
+tenant layout legitimately starts a logical path with the mount name
+would be surprised by a silent rewrite. It fires only on the `"<mount>/"`
+*prefix* — a bare `path == mount` (a single-segment secret named after
+the mount) is forwarded unchanged. Tenant-scope denial (#1725) and this
+path-shape hint are distinct: the tenant guard's `VaultTenantScopeError`
+flags an out-of-namespace path, while `VaultPathShapeError` flags the
+mount-double-prefix typo specifically; the path-shape check runs first
+so its more specific message wins.
+
 **Two-phase failure model.** Login-side failures (Vault unreachable,
 role denied) raise `VaultClientError` subclasses; read/write-side
 failures (KV miss, malformed payload, CAS mismatch, permission
@@ -527,6 +555,16 @@ login-phase failure (any `VaultClientError` subclass:
 `VaultUnreachableError`, `VaultRoleDeniedError`) from read-phase
 failure (anything else). An unreachable or sealed Vault therefore never
 surfaces a raw traceback to the agent.
+
+Two pre-flight rejections raise **before** any Vault round-trip and so
+land as read-phase `connector_error`s with their own
+`extras["exception_class"]`, never a `VaultClientError`:
+`VaultTenantScopeError` (path outside the operator's tenant namespace,
+#1643/#1725) and `VaultPathShapeError` (the `path` re-includes the
+`"<mount>/"` segment, #1755 — see *Mount-included `path` guard* above).
+Both name only the non-secret mount/path the caller supplied, so an
+agent gets an actionable hint rather than the opaque `Forbidden` 403 the
+underlying mistake would otherwise produce.
 
 ## Dependencies
 


### PR DESCRIPTION
## Summary

- `vault.kv.*` returned an opaque `Forbidden` 403 when a caller passed a `path` that re-included the mount segment (`path="secret/meho/…"` with `mount="secret"`). hvac addresses a KV-v2 secret as `v1/<mount>/data/<path>`, so the mount prefix doubled to `v1/secret/data/secret/meho/…` and failed the Vault ACL indistinguishably from a real permission denial.
- All six KV-v2 handlers (read / list / put / patch / versions / delete) now resolve their `(mount, path)` pair through a shared `_extract_mount_and_path(op_id, params)` helper that raises a new `VaultPathShapeError` **before** the Vault round-trip (and before the tenant-scope guard) when `path` begins with `"<mount>/"`. The message names the mount-relative form to use (e.g. `meho/test/federation`) and echoes only the non-secret mount/path the caller supplied — an actionable error over an opaque 403, per `docs/codebase/error-message-shape.md`.
- The guard **rejects** rather than silently strips: an operator whose tenant layout legitimately starts a path with the mount name should not be surprised by a silent rewrite. A bare single-segment `path == mount` is forwarded unchanged.
- Corrected the pre-existing `vault.kv.read` happy-path test, which used a mount-doubled path (`secret/meho/test/federation`) as its stand-in mount-relative value, to the genuinely mount-relative form the production health route uses (`_FEDERATION_PROOF_PATH = "meho/test/federation"`).

## Test plan

- [x] `ruff check` (ops.py + test file) — clean
- [x] `ruff format --check` — clean
- [x] `mypy src/meho_backplane/connectors/vault/ops.py` — clean
- [x] `code-quality.py --diff` — 0 blockers (3 pre-existing function-size warnings on untouched bodies)
- [x] **AC (a)** New parametrized test: `vault.kv.read/list/put/patch/versions/delete` with `path="secret/…"`, `mount="secret"` → `status="error"`, `extras.exception_class="VaultPathShapeError"`, and **hvac never invoked** (`login_calls == []` and every `*_calls == []`). Plus a non-default-mount case.
- [x] **AC (b)** Mount-relative path still works — existing vault read/list/put/patch/versions/delete tests stay green; a new `path == mount` boundary test confirms the guard does not over-reject.
- [x] **AC (c)** The error message names the mount-relative form: asserted (`"mount-relative" in message`, `"'team/api-key'" in message`); `grep -n "mount-relative\|VaultPathShapeError" backend/src/meho_backplane/connectors/vault/ops.py` hits.
- [x] `pytest tests/test_connectors_vault.py tests/test_connectors_vault_creds.py tests/test_api_v1_health.py tests/test_api_health_failures.py tests/test_vault_failures.py tests/test_operations_preview.py tests/test_broadcast_events.py tests/test_approval_queue.py` — **282 passed**, 1 pre-existing unrelated teardown error (see Out of scope).

## Out of scope

- The tenant-scope guard's own messaging (#1725) — this PR is specifically the mount-double-prefix path-shape hint. `VaultTenantScopeError` and `VaultPathShapeError` stay distinct; the path-shape check runs first so its more specific message wins.
- `tests/test_connectors_vault.py::test_preflight_fail_soft_when_probe_raises` has a pre-existing **teardown** error (a pytest output-scanner false-positive matching `secret=` in the rich-traceback repr of the deliberately-raised `VaultDown` fake). Reproduces unchanged on `main` (`def9015f`); not touched by this PR.
- Pre-existing function-size warnings on `vault_kv_read` / `vault_kv_write_capability_preflight` / `register_vault_typed_operations` (this PR's edit to `vault_kv_read` is net-shorter; the bodies are otherwise untouched).

<!-- auto-implement-issue: fresh, iteration 1 -->

Closes #1755
