### PR TITLE
fix(memory-ui): stop CSRF cookie rotating under list polls + surface the silent create 403

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -100,6 +100,18 @@ connector-related release-notes line.
   default-deny. Tenant-scope-aware, idempotent, and audited as a
   single bulk-enable event with the count of ops enabled (#1749).
 
+### Fixed
+
+- Operator-console memory **create no longer 403s** under a background
+  list refresh. The memory list's 60-second card poll re-used the
+  page handler, which re-minted and `Set-Cookie`-d a fresh CSRF token
+  on every render — rotating the cookie out from under an open create
+  modal so the next submit failed the double-submit check with a
+  silent `csrf_token_invalid`. The handler now sets the CSRF cookie on
+  full-page loads only; polls reuse the live cookie token and leave it
+  untouched, and the create modal now renders a visible error banner
+  instead of swallowing a rejected submit (#1754).
+
 ## [0.15.0] - 2026-06-13
 
 ### Added

--- a/backend/src/meho_backplane/ui/routes/memory/views.py
+++ b/backend/src/meho_backplane/ui/routes/memory/views.py
@@ -49,7 +49,11 @@ from meho_backplane.memory import (
     PermissionDeniedError,
 )
 from meho_backplane.ui.auth.middleware import UISessionContext
-from meho_backplane.ui.csrf import CSRF_COOKIE_NAME, mint_csrf_token
+from meho_backplane.ui.csrf import (
+    CSRF_COOKIE_NAME,
+    mint_csrf_token,
+    verify_csrf_token,
+)
 from meho_backplane.ui.routes.memory.bulk import (
     BULK_EXTEND_DURATIONS,
     format_countdown,
@@ -261,6 +265,41 @@ def _set_csrf_cookie(response: HTMLResponse, csrf_token: str) -> None:
     )
 
 
+def _resolve_list_csrf(request: Request, session_id: str, *, is_htmx: bool) -> tuple[str, bool]:
+    """Pick the CSRF token the list render echoes + whether to set the cookie.
+
+    Returns ``(token, set_cookie)``. The list page and its
+    ``hx-trigger="every 60s"`` cards fragment share one handler
+    (:func:`render_index`); the rule (#1754) is:
+
+    * **Full-page render** -- mint a fresh token, echo it, and set the
+      ``meho_csrf`` cookie so the double-submit pair is established for
+      the freshly loaded page.
+    * **HTMX fragment render (the poll)** -- *reuse* the token already
+      carried by the request's ``meho_csrf`` cookie and do **not** set
+      the cookie. A fresh mint + ``Set-Cookie`` on every poll rotates
+      the token out from under any open create modal (whose echoed
+      snapshot from #1693 then fails the middleware's cookie/header
+      match) and out from under the cards fragment's own bulk-action
+      ``hx-headers`` echo. Reusing the live cookie token keeps the
+      rendered echo aligned with the un-rotated cookie, so both the
+      modal create POST and the bulk POST still validate.
+
+    The reuse is gated on :func:`verify_csrf_token` so a tampered or
+    foreign cookie value never gets echoed back as the page's token; a
+    missing-or-invalid cookie on a fragment fetch (defensive -- e.g. a
+    direct fragment request with no prior full-page load) falls back to
+    a fresh mint + ``Set-Cookie`` so the fragment's own forms stay
+    functional.
+    """
+    if not is_htmx:
+        return mint_csrf_token(session_id), True
+    existing = request.cookies.get(CSRF_COOKIE_NAME)
+    if existing and verify_csrf_token(session_id, existing):
+        return existing, False
+    return mint_csrf_token(session_id), True
+
+
 def _common_template_context(
     session_ctx: UISessionContext,
     csrf_token: str,
@@ -355,12 +394,24 @@ async def render_index(
     ``hx-trigger="every 60s"`` on the cards fragment is what refreshes
     the countdown badges; the same handler responds to both the full
     page render and the HTMX poll.
+
+    The ``meho_csrf`` cookie is set on the full-page render **only**,
+    never on the HTMX fragment response (#1754). The cards fragment
+    polls this same handler every 60 seconds; setting the cookie on a
+    poll would rotate the double-submit token out from under any open
+    create modal, whose echoed token snapshot (#1693) would then fail
+    the middleware's cookie/header match and 403 the create POST. The
+    full-page load mints the cookie once; the open modal's token stays
+    valid across polls because the poll no longer touches the cookie.
+    This mirrors the inline-refresh path's zero-``Set-Cookie`` posture
+    (G0.25 #1694) that keeps in-flight pages' CSRF tokens stable.
     """
     scope_filter = resolve_scope_filter(scope)
     operator = build_read_operator(session_ctx)
     entries = await _list_for_render(operator, scope_filter, tag)
     active, recently_expired = partition_expired(entries)
-    csrf_token = mint_csrf_token(str(session_ctx.session_id))
+    is_htmx = is_htmx_request(request)
+    csrf_token, set_csrf = _resolve_list_csrf(request, str(session_ctx.session_id), is_htmx=is_htmx)
     # The refresh URL preserves the active scope + tag so the HTMX
     # poll re-renders with the same filter state. T1's tabs already
     # encode the query string into the request URL; the fragment
@@ -379,9 +430,10 @@ async def render_index(
         "bulk_extend_durations": BULK_EXTEND_DURATIONS,
         "refresh_url": refresh_url,
     }
-    template_name = "memory/_cards.html" if is_htmx_request(request) else "memory/index.html"
+    template_name = "memory/_cards.html" if is_htmx else "memory/index.html"
     response = get_templates().TemplateResponse(request, template_name, context)
-    _set_csrf_cookie(response, csrf_token)
+    if set_csrf:
+        _set_csrf_cookie(response, csrf_token)
     return response
 
 

--- a/backend/src/meho_backplane/ui/templates/memory/_create_modal.html
+++ b/backend/src/meho_backplane/ui/templates/memory/_create_modal.html
@@ -71,7 +71,31 @@
         data-target-scoped-values="{{ target_scoped_values | join(',') }}"
         class="space-y-3 py-2"
         aria-labelledby="memory-create-modal-title"
+        hx-on::before-request="this.querySelector('[data-create-error]').classList.add('hidden')"
+        hx-on::response-error="window.memoryCreateShowError(this, event)"
       >
+        {#- Visible error banner for a failed create submit (#1754). The
+            form posts with ``hx-swap="none"``, so a non-2xx response
+            (most importantly the chassis CSRF middleware's 403
+            ``{"detail":"csrf_token_invalid"}``) would otherwise be
+            dropped silently -- the operator clicks Create and nothing
+            happens, values still in the fields but no signal why. The
+            ``hx-on::response-error`` handler above un-hides this banner
+            and fills it with a status-appropriate message; the form
+            body is never swapped, so the operator's input survives for
+            an immediate retry (a CSRF 403 is recoverable: the page's
+            poll keeps the cookie live, so re-clicking Create with the
+            same field values succeeds once the modal re-echoes a
+            matching token on its next render). ``aria-live`` makes a
+            screen reader announce the message when it appears. -#}
+        <div
+          data-create-error
+          class="alert alert-error hidden"
+          role="alert"
+          aria-live="assertive"
+        >
+          <span data-create-error-message></span>
+        </div>
         <label class="form-control">
           <span class="label-text">Scope</span>
           <select
@@ -206,6 +230,52 @@ Markdown body. Bare URLs (https://example.com) are linkified."
     <button>close</button>
   </form>
 </dialog>
+
+{# Visible-error handler for the create submit (#1754). Defined on
+   ``window`` (idempotently, so repeated modal renders don't redefine
+   it) because the form's ``hx-on::response-error`` attribute resolves
+   the handler by name at event time. Translates the failed request's
+   HTTP status into an operator-facing message and reveals the banner
+   the form renders above its fields; the form's ``hx-swap="none"``
+   means the field values are never cleared, so the operator can fix
+   and retry without re-typing. The 403 branch is the headline case --
+   the chassis CSRF middleware rejects a stale double-submit token with
+   ``403 {"detail":"csrf_token_invalid"}`` and, before this handler,
+   htmx dropped that response on the floor. #}
+<script>
+  window.memoryCreateShowError = window.memoryCreateShowError || function (form, event) {
+    if (!form) return;
+    var banner = form.querySelector('[data-create-error]');
+    var message = form.querySelector('[data-create-error-message]');
+    if (!banner || !message) return;
+    var xhr = event && event.detail ? event.detail.xhr : null;
+    var status = xhr ? xhr.status : 0;
+    var text;
+    if (status === 403) {
+      text =
+        'Your session security token expired before the form was submitted. ' +
+        'No changes were saved. Click Create again to retry, or reload the ' +
+        'page if it keeps failing.';
+    } else if (status === 0) {
+      text =
+        'Could not reach the server. Check your connection and try Create ' +
+        'again. No changes were saved.';
+    } else {
+      var detail = '';
+      try {
+        detail = (JSON.parse(xhr.responseText) || {}).detail || '';
+      } catch (e) {
+        detail = '';
+      }
+      text =
+        'The memory could not be created (error ' + status + ').' +
+        (detail ? ' ' + detail : '') +
+        ' No changes were saved.';
+    }
+    message.textContent = text;
+    banner.classList.remove('hidden');
+  };
+</script>
 
 {# Tiny inline script: toggle the target_name row's visibility when
    the scope selector changes. Scoped to this modal -- the script

--- a/backend/tests/test_ui_memory_create_promote.py
+++ b/backend/tests/test_ui_memory_create_promote.py
@@ -726,6 +726,150 @@ def test_create_submit_real_modal_cookie_header_pair_returns_204() -> None:
     assert _count_documents(_TENANT_A, MemoryScope.USER) == 1
 
 
+def test_create_after_background_poll_keeps_modal_token_valid_returns_204() -> None:
+    """Modal render -> 60s poll -> create POST with the modal pair -> 204 (#1754).
+
+    Headline regression. The reproduction the hand-minted sibling tests
+    miss: open the create modal (which mints + Set-Cookies a token and
+    echoes the same value in the form's ``hx-headers``), then fire the
+    cards fragment's ``hx-trigger="every 60s"`` poll
+    (``GET /ui/memory`` with ``HX-Request: true``) *before* submitting.
+    Pre-fix, the poll re-minted + Set-Cookied a fresh ``meho_csrf``,
+    rotating the cookie out from under the modal's captured token, so
+    the create POST presented a header that no longer matched the cookie
+    and the chassis middleware returned ``403 csrf_token_invalid``.
+    Post-fix the poll leaves the cookie untouched, so the modal's
+    captured pair still validates -> 204.
+    """
+    _seed_tenant(_TENANT_A, "tenant-a")
+    keypair, jwks = _make_keypair_and_jwks()
+    access_token = _mint_token(
+        keypair,
+        sub=_OP_A,
+        tenant_id=str(_TENANT_A),
+        tenant_role=TenantRole.OPERATOR.value,
+    )
+    session_id = _seed_session_sync(
+        tenant_id=_TENANT_A, access_token=access_token, operator_sub=_OP_A
+    )
+    client, mock, _csrf = _authenticated_client(session_id=session_id, jwks=jwks)
+    try:
+        # 1. Open the modal: capture the cookie + the form's echoed token.
+        modal = client.get("/ui/memory/create", headers={"HX-Request": "true"})
+        assert modal.status_code == 200, modal.text
+        cookie_match = _CSRF_SETCOOKIE_RE.search(modal.headers.get("set-cookie", ""))
+        assert cookie_match, "modal render set no meho_csrf cookie"
+        modal_token = cookie_match.group(1)
+        header_tokens = _FORM_HX_HEADERS_RE.findall(modal.text)
+        assert header_tokens == [modal_token], (
+            "modal cookie + form hx-headers token must be the same minted value"
+        )
+        # The chassis cookie is ``Secure``, which the http-scheme
+        # TestClient jar drops, so seed it explicitly -- the browser
+        # round-trip that holds it across the poll + the create POST.
+        client.cookies.set(CSRF_COOKIE_NAME, modal_token, path="/ui")
+
+        # 2. The cards fragment's every-60s poll fires while the modal is
+        #    open. This must NOT rotate the cookie.
+        poll = client.get("/ui/memory?scope=all", headers={"HX-Request": "true"})
+        assert poll.status_code == 200, poll.text
+        poll_set_cookie = poll.headers.get_list("set-cookie")
+        assert not any(f"{CSRF_COOKIE_NAME}=" in h for h in poll_set_cookie), (
+            "the background poll rotated meho_csrf -- the #1754 root cause"
+        )
+
+        # 3. Submit the create using the modal's captured pair, exactly as
+        #    the browser would after the poll.
+        with _stub_embedding_service():
+            response = client.post(
+                "/ui/memory/create",
+                data={"scope": "user", "body": "# survives the poll\n\nbody"},
+                headers=_csrf_headers(modal_token),
+            )
+    finally:
+        mock.stop()
+    assert response.status_code == 204, response.text
+    assert response.headers.get("HX-Redirect") == "/ui/memory"
+    assert _count_documents(_TENANT_A, MemoryScope.USER) == 1
+
+
+def test_create_modal_renders_visible_error_handler() -> None:
+    """The create form wires a visible-error path for a failed submit (#1754).
+
+    The form posts with ``hx-swap="none"``, so a non-2xx response (the
+    CSRF middleware's silent 403, chiefly) is dropped unless the form
+    handles it. Assert the form carries an ``hx-on::response-error``
+    handler and the modal renders the error-banner element + the
+    ``window.memoryCreateShowError`` handler it calls, so a rejection
+    surfaces in the modal instead of failing silently.
+    """
+    _seed_tenant(_TENANT_A, "tenant-a")
+    keypair, jwks = _make_keypair_and_jwks()
+    access_token = _mint_token(
+        keypair,
+        sub=_OP_A,
+        tenant_id=str(_TENANT_A),
+        tenant_role=TenantRole.OPERATOR.value,
+    )
+    session_id = _seed_session_sync(
+        tenant_id=_TENANT_A, access_token=access_token, operator_sub=_OP_A
+    )
+    client, mock, _csrf = _authenticated_client(session_id=session_id, jwks=jwks)
+    try:
+        modal = client.get("/ui/memory/create", headers={"HX-Request": "true"})
+    finally:
+        mock.stop()
+    assert modal.status_code == 200, modal.text
+    body = modal.text
+    # The form handles the htmx error event (the chassis 403 included).
+    assert "hx-on::response-error" in body
+    # The banner the handler reveals + the handler it calls are present.
+    assert "data-create-error" in body
+    assert "window.memoryCreateShowError" in body
+
+
+def test_create_forged_header_still_rejected_after_poll_returns_403() -> None:
+    """No CSRF regression: a forged double-submit is still 403, poll or not (#1754).
+
+    Stopping the gratuitous cookie rotation must not weaken the
+    middleware: a create POST whose ``X-CSRF-Token`` header does not
+    match the cookie (the same-site forgery vector the double-submit
+    defends) is still rejected. Driven through the real modal + poll
+    sequence so the assertion lands on the post-fix code path.
+    """
+    _seed_tenant(_TENANT_A, "tenant-a")
+    keypair, jwks = _make_keypair_and_jwks()
+    access_token = _mint_token(
+        keypair,
+        sub=_OP_A,
+        tenant_id=str(_TENANT_A),
+        tenant_role=TenantRole.OPERATOR.value,
+    )
+    session_id = _seed_session_sync(
+        tenant_id=_TENANT_A, access_token=access_token, operator_sub=_OP_A
+    )
+    client, mock, _csrf = _authenticated_client(session_id=session_id, jwks=jwks)
+    try:
+        modal = client.get("/ui/memory/create", headers={"HX-Request": "true"})
+        cookie_match = _CSRF_SETCOOKIE_RE.search(modal.headers.get("set-cookie", ""))
+        assert cookie_match
+        modal_token = cookie_match.group(1)
+        client.cookies.set(CSRF_COOKIE_NAME, modal_token)
+        client.get("/ui/memory?scope=all", headers={"HX-Request": "true"})
+        with _stub_embedding_service():
+            response = client.post(
+                "/ui/memory/create",
+                data={"scope": "user", "body": "forged attempt"},
+                # Cookie holds the real token; header presents a foreign one.
+                headers=_csrf_headers("forged-token-not-matching-cookie"),
+            )
+    finally:
+        mock.stop()
+    assert response.status_code == 403, response.text
+    assert response.json()["detail"] == "csrf_token_invalid"
+    assert _count_documents(_TENANT_A, MemoryScope.USER) == 0
+
+
 # ---------------------------------------------------------------------------
 # Create submit -- default-TTL injection (#1697, policy from G5.2-T2 #624)
 # ---------------------------------------------------------------------------

--- a/backend/tests/test_ui_memory_list.py
+++ b/backend/tests/test_ui_memory_list.py
@@ -425,6 +425,93 @@ def test_list_htmx_fragment_returns_cards_partial_only() -> None:
     assert "<title>" not in body
 
 
+def _sets_csrf_cookie(response: Any) -> bool:
+    """Return ``True`` iff the response carries a ``meho_csrf`` ``Set-Cookie``.
+
+    Reads every ``Set-Cookie`` header (``get_list`` -- a response can
+    carry more than one) rather than the comma-joined ``.get`` shape so
+    the assertion is robust if a sibling cookie ever rides the same
+    response.
+    """
+    return any(
+        f"{CSRF_COOKIE_NAME}=" in header for header in response.headers.get_list("set-cookie")
+    )
+
+
+def test_list_full_page_render_sets_fresh_csrf_cookie() -> None:
+    """A full-page ``GET /ui/memory`` mints + Set-Cookies a fresh ``meho_csrf`` (#1754)."""
+    _seed_tenant(_TENANT_A, "tenant-a")
+    _, jwks = _make_keypair_and_jwks()
+    session_id = _seed_session_sync(tenant_id=_TENANT_A, access_token="unused", operator_sub=_OP_A)
+    client, mock, _csrf = _authenticated_client(session_id=session_id, jwks=jwks)
+    try:
+        response = client.get("/ui/memory")
+    finally:
+        mock.stop()
+    assert response.status_code == 200
+    assert _sets_csrf_cookie(response), (
+        "full-page list render must Set-Cookie meho_csrf so the page's "
+        "double-submit pair is established"
+    )
+
+
+def test_list_htmx_poll_does_not_rotate_csrf_cookie() -> None:
+    """The ``every 60s`` HTMX poll returns NO ``Set-Cookie: meho_csrf`` (#1754).
+
+    Root cause of the memory-create 403: ``render_index`` used to Set-
+    Cookie a freshly-minted ``meho_csrf`` on every render -- including
+    the cards fragment's 60-second poll. A poll firing while the create
+    modal is open rotated the cookie out from under the modal's echoed
+    token (#1693), so the next create POST failed the chassis double-
+    submit match with ``403 csrf_token_invalid``. The fix sets the
+    cookie on full-page renders only; a poll carrying a valid cookie
+    re-echoes that same token and leaves the cookie untouched.
+    """
+    _seed_tenant(_TENANT_A, "tenant-a")
+    _, jwks = _make_keypair_and_jwks()
+    session_id = _seed_session_sync(tenant_id=_TENANT_A, access_token="unused", operator_sub=_OP_A)
+    client, mock, csrf = _authenticated_client(session_id=session_id, jwks=jwks)
+    try:
+        # The browser holds the cookie the full-page load set; replay it
+        # on the poll (the chassis cookie is ``Secure``, which the
+        # http-scheme TestClient jar drops, so seed it explicitly).
+        client.cookies.set(CSRF_COOKIE_NAME, csrf)
+        response = client.get("/ui/memory?scope=all", headers={"HX-Request": "true"})
+    finally:
+        mock.stop()
+    assert response.status_code == 200
+    assert not _sets_csrf_cookie(response), (
+        "an HTMX poll carrying a live meho_csrf cookie must NOT rotate it -- "
+        "rotating mid-page-stay is exactly the #1754 create-403 regression"
+    )
+
+
+def test_list_htmx_fragment_mints_cookie_when_none_present() -> None:
+    """Defensive: an HTMX fragment fetch with no prior cookie still mints one (#1754).
+
+    The poll-no-rotation rule reuses the request's existing ``meho_csrf``
+    cookie. A fragment fetched without any prior full-page load (so no
+    cookie on the request) must still get a freshly-minted cookie set,
+    otherwise the fragment's own bulk-action form would carry an echoed
+    token with no matching cookie and 403 on submit.
+    """
+    _seed_tenant(_TENANT_A, "tenant-a")
+    _, jwks = _make_keypair_and_jwks()
+    session_id = _seed_session_sync(tenant_id=_TENANT_A, access_token="unused", operator_sub=_OP_A)
+    client, mock, _csrf = _authenticated_client(session_id=session_id, jwks=jwks)
+    try:
+        # No CSRF cookie seeded -- simulate a fragment hit with no prior
+        # full-page render on this client.
+        response = client.get("/ui/memory?scope=all", headers={"HX-Request": "true"})
+    finally:
+        mock.stop()
+    assert response.status_code == 200
+    assert _sets_csrf_cookie(response), (
+        "a fragment fetched without a prior meho_csrf cookie must mint + "
+        "Set-Cookie one so its own forms validate"
+    )
+
+
 def test_list_scope_filter_narrows_to_one_scope() -> None:
     """``?scope=tenant`` returns only tenant-scoped memories."""
     _seed_tenant(_TENANT_A, "tenant-a")

--- a/docs/codebase/ui.md
+++ b/docs/codebase/ui.md
@@ -1449,6 +1449,22 @@ silent no-op that audits worse).
   on every HTMX request from that page; the index page sets the
   same directive so future state-changing actions on the list (T3's
   bulk delete) inherit the token without per-element wiring.
+* `render_index` sets the `meho_csrf` cookie on the **full-page
+  render only**, never on the HTMX card-list fragment (#1754). The
+  `_cards.html` wrapper polls the same handler every 60s
+  (`hx-trigger="every 60s"`); minting + `Set-Cookie`-ing a fresh
+  token on each poll rotated the cookie out from under any open
+  create modal, whose render-time echo (#1693) then failed the
+  middleware's cookie/header match and 403'd the create POST. The
+  poll now **reuses** the token carried by the request's existing
+  `meho_csrf` cookie (validated via `verify_csrf_token`, so a
+  tampered value is never echoed back) and leaves the cookie
+  untouched, so the modal's token — and the cards fragment's own
+  bulk-action echo — stay valid across polls. A fragment fetched
+  with no prior cookie (defensive: no full-page load happened first)
+  falls back to a fresh mint + `Set-Cookie`. This mirrors the
+  inline-refresh path's zero-`Set-Cookie` posture (G0.25 #1694) that
+  keeps in-flight pages' CSRF tokens stable across a token rotation.
 
 ### Tests
 
@@ -1575,6 +1591,26 @@ before calling the service.
   (https://htmx.org/attributes/hx-headers/), so the form-level echo
   keeps the double-submit pair aligned — and the body textarea's
   debounced preview `hx-post` inherits the fresh token from the form.
+  (The cookie-rotation half of the same desync class — a background
+  list poll rotating the cookie *after* the modal renders — is fixed
+  separately in `render_index`; see the T1 "HTMX conventions" note on
+  #1754.)
+* The create form surfaces a failed submit instead of dropping it.
+  Because the form posts with `hx-swap="none"`, a non-2xx response —
+  most importantly the chassis CSRF middleware's
+  `403 {"detail":"csrf_token_invalid"}` — would otherwise be
+  swallowed silently (the operator clicks Create and nothing visibly
+  happens). The form carries
+  `hx-on::response-error="window.memoryCreateShowError(this, event)"`
+  (htmx 2.x double-colon shorthand for the `htmx:responseError`
+  event) which un-hides an `alert alert-error` banner above the form
+  fields with a status-tailored message read off
+  `event.detail.xhr.status` — a 403 reads as an expired session
+  token with a retry hint, a network error (`status === 0`) as a
+  connectivity message, any other status surfaces the server's
+  `detail` string. The form body is never swapped, so the operator's
+  input survives for an immediate retry; `hx-on::before-request`
+  hides the banner so a retry starts clean (#1754).
 * `hx-trigger="keyup changed delay:300ms"` on the create modal's
   body textarea drives the debounced server-side preview — see
   https://htmx.org/attributes/hx-trigger/. `delay:300ms` matches


### PR DESCRIPTION
## Summary

- **Headline v0.15.0 dogfood regression:** the operator-console memory page still 403'd (`csrf_token_invalid`) on create despite #1693. The `_cards.html` list fragment polls `GET /ui/memory` every 60s through `render_index`, which re-minted and `Set-Cookie`-d a fresh `meho_csrf` on every render — **including the poll**. A poll firing while the create modal is open rotated the cookie out from under the modal's echoed token, so the next create POST failed the chassis double-submit check. The 403 is JSON and the form posts `hx-swap="none"` with no error handler, so it was **dropped silently** — the operator clicked Create and nothing happened.
- **Fix 1 — stop the rotation on safe polls:** `render_index` now sets the cookie on the **full-page render only**. On the HTMX fragment it reuses the token already on the request's cookie (validated via `verify_csrf_token` so a tampered value is never echoed back) and leaves the cookie untouched, so the open modal's token — and the cards fragment's own bulk-action echo — stay valid across polls. A fragment with no prior cookie falls back to a fresh mint + `Set-Cookie`. Mirrors the inline-refresh path's zero-`Set-Cookie` posture (G0.25 #1694).
- **Fix 2 — surface the silent 403:** the create form gains `hx-on::response-error` (htmx 2.x shorthand for `htmx:responseError`) that reveals an `alert alert-error` banner with a status-tailored message (403 = expired token + retry hint, network error = connectivity, other = the server's `detail`). `hx-swap="none"` keeps the field values intact for an immediate retry.
- The double-submit scheme is **unchanged** — a forged / cross-site submit is still rejected; only gratuitous rotation on safe polls stops. Out of scope per the issue: reworking the double-submit chassis itself.

## Test plan

- [x] `ruff check src/ tests/` — clean
- [x] `ruff format --check src/ tests/` — clean (3 files formatted)
- [x] `mypy src/` (strict) — Success, 474 files
- [x] Full unit suite `pytest -n 6 --dist loadscope --ignore=tests/integration` — **7522 passed, 195 skipped**
- [x] **AC (a)** `GET /ui/memory?scope=all` with `HX-Request: true` + a live cookie returns **no** `Set-Cookie: meho_csrf`; a full-page `GET /ui/memory` still sets a fresh cookie — `test_list_htmx_poll_does_not_rotate_csrf_cookie`, `test_list_full_page_render_sets_fresh_csrf_cookie`, plus the defensive-mint case `test_list_htmx_fragment_mints_cookie_when_none_present`.
- [x] **AC (b)** render modal → simulate the `every 60s` poll → `POST /ui/memory/create` with the modal's paired cookie/header → **204, not 403** — `test_create_after_background_poll_keeps_modal_token_valid_returns_204`.
- [x] **AC (c)** the create form wires a visible-error path (`hx-on::response-error` + the banner element + `window.memoryCreateShowError`) — `test_create_modal_renders_visible_error_handler`.
- [x] **AC (d)** no CSRF regression: a forged header is still **403 `csrf_token_invalid`** after a poll — `test_create_forged_header_still_rejected_after_poll_returns_403`; existing chassis CSRF middleware tests stay green.
- [x] Both rotation tests **fail against the pre-fix handler** (verified by reverting the guard) — they are genuine regression guards, not vacuous.

## Out of scope

- Adjacent finding (recorded, not edited): `render_detail` / `render_edit_form` / `patch_entry` also set the CSRF cookie unconditionally on their HTMX fragment responses (the detail page's `_body_view.html`). That is a latent variant of the same desync class, but the detail page has no `every Ns` poll trigger so it does not reproduce the regression; the issue scopes the fix to `render_index` (the poll source).

<!-- auto-implement-issue: fresh, iteration 1 -->

Closes #1754
