### PR TITLE
docs(vault): name the empty-prefix upgrade action for custom KV layouts (#1758)

### DIFF
--- a/docs/codebase/connectors-vault-tenant-scope.md
+++ b/docs/codebase/connectors-vault-tenant-scope.md
@@ -118,16 +118,29 @@ canonical layout addresses secrets as mount `secret`, path
 candidate — it would deny **every** legitimate per-tenant call. The default
 is therefore the mount-pinned `secret/tenants/{tenant_id}/`.
 
-**Migration prerequisite.** The backplane homes *new* targets on
-`tenants/<tenant_id>/`, but a deploy upgrading from a pre-#1723 release may
-still hold *existing* secrets under the retired per-`sub` layout. Until
-those are relocated by the migration runbook
-([`vault-per-tenant-migration.md`](../cross-repo/vault-per-tenant-migration.md)),
-the default-on guard would deny every not-yet-relocated `vault.kv.*` call.
-Such a deploy must **explicitly disable** the guard
-(`VAULT_KV_TENANT_SCOPE_PREFIX=""`) until the migration completes, then drop
-the override to let the default enforce. A fresh deploy (all secrets under
-`tenants/<tenant_id>/`) needs no action — the default already enforces.
+**Adopter action on upgrade (#1725).** The default-on guard denies any
+authenticated `vault.kv.*` call whose normalised `<mount>/<path>` does not
+begin with `secret/tenants/<tenant_id>/`. Two kinds of deploy must act
+before upgrading to keep their daily-driver `vault.kv.read` path working:
+
+- A deploy upgrading from a pre-#1723 release that still holds *existing*
+  secrets under the retired per-`sub` layout (`secret/data/targets/<sub>/*`).
+  Relocate them with the migration runbook
+  ([`vault-per-tenant-migration.md`](../cross-repo/vault-per-tenant-migration.md)).
+- A deploy running a **deliberate custom layout** under neither
+  `targets/<sub>/*` nor `secret/tenants/{tenant_id}/` (e.g. an org-chosen
+  mount/path scheme set via explicit `secret_ref` values, which the
+  backplane honours verbatim and never re-homes).
+
+In **both** cases, **explicitly disable** the guard before upgrading by
+setting `VAULT_KV_TENANT_SCOPE_PREFIX=""` — otherwise the default-on guard
+denies every not-yet-conforming `vault.kv.*` call with
+`exception_class=VaultTenantScopeError`. A per-`sub` deploy drops the
+override once the migration completes; a custom-layout deploy may keep it
+empty as its steady state (migrating to `secret/tenants/{tenant_id}/` later
+is optional — see the runbook's "Custom / non-standard layout" subsection).
+A fresh deploy (all secrets under `tenants/<tenant_id>/`) needs no action —
+the default already enforces.
 
 **Platform-path exemption.** A closed allow-list of fixed, shared,
 non-tenant platform secrets (`PLATFORM_EXEMPT_PATHS` in `tenant_scope.py`)
@@ -188,8 +201,9 @@ blocks boot).
 ## Choosing a layout
 
 The guard is default-on (`secret/tenants/{tenant_id}/`), matching the
-canonical per-tenant layout. The only deploy that needs to touch the prefix
-is one still holding secrets under the retired per-`sub` layout:
+canonical per-tenant layout. Any deploy whose secrets are **not** under
+`secret/tenants/{tenant_id}/` — the retired per-`sub` layout or a
+deliberate custom layout — must touch the prefix:
 
 - **Per-tenant layout (canonical since #1723; guard default-on).** Secrets
   are partitioned by tenant under `tenants/<tenant_id>/<target>` on the
@@ -211,6 +225,20 @@ is one still holding secrets under the retired per-`sub` layout:
   [`vault-per-tenant-migration.md`](../cross-repo/vault-per-tenant-migration.md),
   then drop the override.
 
+- **Custom / non-standard layout (neither per-`sub` nor per-tenant).**
+  Secrets live under a deploy-chosen mount/path scheme set via explicit
+  `secret_ref` values (the backplane honours these verbatim and never
+  re-homes them), so the candidate never begins with
+  `secret/tenants/<tenant_id>/` and the default-on guard would deny every
+  `vault.kv.*` call. **Explicitly disable** the guard with
+  `VAULT_KV_TENANT_SCOPE_PREFIX=""` before upgrading; isolation then rests
+  entirely on the `meho-mcp` Vault policy, which must stay correct. Unlike
+  the per-`sub` case, a migration is **optional** — keeping the prefix empty
+  is a valid steady state. The runbook's
+  [Custom / non-standard layout](../cross-repo/vault-per-tenant-migration.md)
+  subsection covers the upgrade action and the optional path to adopting the
+  per-tenant layout later.
+
 **The active (default) prefix and its preconditions:**
 
 1. The canonical Vault KV layout is per-tenant: mount `secret`, path
@@ -229,10 +257,13 @@ is one still holding secrets under the retired per-`sub` layout:
    system/shim operator (Nil-UUID tenant, `vault.sys.health` only) is
    exempt, so the default does not break the health probe.
 
-Because step 3 denies every per-`sub` call that is *not* under a
-`tenants/<id>/` prefix, a deploy still on the retired per-`sub` layout must
-disable the guard until its secrets are relocated — which is exactly what
-the `VAULT_KV_TENANT_SCOPE_PREFIX=""` opt-out is for.
+Because step 3 denies every call that is *not* under a `tenants/<id>/`
+prefix, any deploy whose secrets sit elsewhere — the retired per-`sub`
+layout or a deliberate custom layout — must disable the guard with
+`VAULT_KV_TENANT_SCOPE_PREFIX=""` before upgrading. That is exactly what
+the empty-prefix opt-out is for: a per-`sub` deploy drops it once the
+migration completes, while a custom-layout deploy may keep it empty
+indefinitely.
 
 ## Scope notes
 

--- a/docs/cross-repo/vault-per-tenant-migration.md
+++ b/docs/cross-repo/vault-per-tenant-migration.md
@@ -184,11 +184,57 @@ enforce.
 
 See
 [`connectors-vault-tenant-scope.md`](../codebase/connectors-vault-tenant-scope.md)
-("Enabling the prefix requires all of") for the preconditions and the
-startup advisory. Do **not** enable the prefix until every legitimate
-`vault.kv.*` caller's secrets are under it — once set, any in-namespace
-mismatch is denied with `exception_class=VaultTenantScopeError` before the
-hvac call.
+("The active (default) prefix and its preconditions") for the
+preconditions and the startup advisory. Do **not** enable the prefix until
+every legitimate `vault.kv.*` caller's secrets are under it — once set, any
+in-namespace mismatch is denied with `exception_class=VaultTenantScopeError`
+before the hvac call.
+
+### Custom / non-standard layout (neither per-`sub` nor per-tenant)
+
+The body of this runbook assumes you are moving **from** the retired
+per-`sub` layout (`secret/data/targets/<sub>/*`) **to** the canonical
+per-tenant layout (`secret/data/tenants/<tenant_id>/<target>`). Some
+deploys run secrets under a **deliberate custom layout** that is *neither*
+— e.g. an org-chosen mount or path scheme such as
+`secret/data/<team>/<env>/<target>` set via explicit `secret_ref` values.
+That is a supported configuration: the backplane honours an
+explicitly-supplied `secret_ref` verbatim and never re-homes it (see
+"What the backplane does for you").
+
+**What the default-on guard enforces (#1725).** With
+`VAULT_KV_TENANT_SCOPE_PREFIX` left at its mount-pinned default
+`secret/tenants/{tenant_id}/`, every authenticated `vault.kv.*` call must
+address a normalised `<mount>/<path>` that begins with
+`secret/tenants/<your-tenant-id>/`. A path under any other scheme — your
+custom layout included — is denied with
+`exception_class=VaultTenantScopeError` **before** the hvac call. The
+denial is local (no Vault round-trip) and reports the requested path
+against the rendered tenant prefix.
+
+**Upgrade action.** If your secrets are under neither `targets/<sub>/*`
+nor `secret/tenants/{tenant_id}/`, the default-on guard will reject your
+daily-driver `vault.kv.read` (and every other `vault.kv.*` op) on upgrade
+to v0.15.0. Set the prefix **empty** to keep those calls working:
+
+```text
+VAULT_KV_TENANT_SCOPE_PREFIX=
+```
+
+An empty prefix makes the guard a no-op — behaviour is byte-for-byte what
+it was before the guard existed; isolation falls back entirely to the
+templated `meho-mcp` Vault policy
+([`connector-vault-policy.md`](./connector-vault-policy.md) §2), which
+must stay correct because it is then the only gate. The startup advisory
+(`vault_tenant_scope_unenforced`) fires once at boot to keep that
+unenforced state visible.
+
+**Migrating later is optional, not required.** A custom layout does not
+*have* to move to `secret/tenants/{tenant_id}/`. If you later choose to
+adopt the per-tenant layout so the app-layer guard becomes a real
+backstop, follow the per-target procedure above (relocate the bytes,
+rewrite each `secret_ref`), then drop the empty-prefix override. Until
+then, keeping the prefix empty is the correct steady state.
 
 ## Rollback
 


### PR DESCRIPTION
## Summary

- The #1643 Vault tenant-scope guard flipped **default-on** in v0.15.0
  (#1725) with the mount-pinned
  `VAULT_KV_TENANT_SCOPE_PREFIX="secret/tenants/{tenant_id}/"`. Both Vault
  docs only framed the empty-prefix escape hatch as a *mid-migration*
  (per-`sub` → per-tenant) step, so an adopter running a **deliberate
  custom layout** — secrets under neither `targets/<sub>/*` nor
  `secret/tenants/{tenant_id}/` — had no first-class "do this on upgrade"
  instruction. Their daily-driver `vault.kv.read` path breaks on upgrade.
- Adds a **"Custom / non-standard layout"** subsection to
  `docs/cross-repo/vault-per-tenant-migration.md` naming
  `VAULT_KV_TENANT_SCOPE_PREFIX=""` as the upgrade action, stating exactly
  what the guard enforces by default, and noting that a later migration to
  the per-tenant layout is **optional** (an empty prefix is a valid steady
  state for a custom layout).
- Broadens `docs/codebase/connectors-vault-tenant-scope.md` (adopter-action
  note + "Choosing a layout") to cover the custom-layout case alongside
  per-`sub`, so the release-notes-aligned guidance states the default-on
  adopter action plainly for **any** non-per-tenant layout.
- Docs only — **no change** to the guard behaviour or defaults (#1725 is
  shipped and intended). Also corrects a stale cross-reference anchor in
  the runbook (the codebase page's heading is "The active (default) prefix
  and its preconditions", not the old "Enabling the prefix requires all of").

## Test plan

- [x] **Acceptance (a)** — `grep -niE 'custom|neither|VAULT_KV_TENANT_SCOPE_PREFIX=""' docs/cross-repo/vault-per-tenant-migration.md` matches the new `### Custom / non-standard layout (neither per-`sub` nor per-tenant)` subsection.
- [x] **Acceptance (b)** — `docs/codebase/connectors-vault-tenant-scope.md` states the default-on adopter action with the `VAULT_KV_TENANT_SCOPE_PREFIX=""` escape hatch for non-per-tenant (including custom) layouts.
- [x] **Acceptance (c)** — `git diff --name-only` shows only the two docs; no code, tests, or CHANGELOG touched.
- [x] Every referenced relative path (`tenant_scope.py`, `tenant_paths.py`, `main.py`, `connector-vault-policy.md`, the sibling doc) resolves from each doc's directory.
- [x] Every quoted cross-doc heading matches a real heading (the runbook's `### Custom / non-standard layout`; the codebase page's "The active (default) prefix and its preconditions").
- [x] Claims verified against source: env var name + mount-pinned default (`settings.py`, `tenant_scope.py`), default-on (#1725), empty-prefix = byte-for-byte-pre-guard no-op (`tenant_scope.py` `enforce_tenant_scope`), the two supported layouts, `exception_class=VaultTenantScopeError` raised before the hvac call, and the `vault_tenant_scope_unenforced` startup advisory (`main.py`).

## Out of scope

- Any change to the guard behaviour or defaults — #1725 is shipped and intended; this closes only the adopter-facing documentation gap.
- No CHANGELOG entry: per repo precedent (e.g. #1744), pure doc-clarification PRs that don't ship a behaviour change skip the CHANGELOG; v0.15.0 is already released and the `### Documentation` clarification is satisfied by the doc pages themselves.

<!-- auto-implement-issue: fresh, iteration 1 -->

Closes #1758


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Updated upgrade guidance for the vault tenant-scope guard with explicit deployment scenarios and configuration instructions for deployers.
  * Added comprehensive documentation for custom and non-standard vault layouts, including migration options and prefix configuration requirements.
  * Clarified conditions and steps for safely upgrading across different layout types.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->