### PR TITLE
feat(connectors): surface an unbacked composite with a catalog-ingest next_step

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -99,6 +99,18 @@ connector-related release-notes line.
   pass, leaving every write-shaped op (POST/PUT/PATCH/DELETE)
   default-deny. Tenant-scope-aware, idempotent, and audited as a
   single bulk-enable event with the count of ops enabled (#1749).
+- The operation listing now flags an **enabled-but-unbacked composite**.
+  `search_operations` (REST `GET /api/v1/operations/search` + the MCP
+  tool) marks a composite hit `unbacked=true` with a `next_step`
+  pointing at `meho connector ingest --catalog <product>/<version>`
+  while the composite's L2 sub-operations are not ingested — so an
+  operator/agent sees "enabled — run the catalog ingest first" instead
+  of a silent dead-end (`composite_l2_missing`) at the first dispatch.
+  The marker is tenant-scoped, mirrors the dispatch-time preflight's
+  enable-aware check, and disappears once the catalog ingest lands the
+  sub-ops; ordinary ops and fully-backed composites never carry it.
+  `gh.composite.pr_status_summary` is wired; the registry generalises to
+  future composites (#1757).
 
 ### Changed
 

--- a/backend/src/meho_backplane/connectors/github/composites/_register.py
+++ b/backend/src/meho_backplane/connectors/github/composites/_register.py
@@ -51,13 +51,19 @@ from __future__ import annotations
 from collections.abc import Awaitable, Callable
 from typing import Any, Literal, NamedTuple
 
+from meho_backplane.connectors.github._catalog_command import (
+    catalog_command_for_github_rest,
+)
 from meho_backplane.connectors.github.composites._read import (
+    _CONNECTOR_ID,
+    _SUB_OPS_PR_STATUS_SUMMARY,
     pr_status_summary_composite,
 )
 from meho_backplane.connectors.github.composites.schemas import (
     PR_STATUS_SUMMARY_PARAMETER_SCHEMA,
     PR_STATUS_SUMMARY_RESPONSE_SCHEMA,
 )
+from meho_backplane.operations.composite_backing import register_composite_backing
 from meho_backplane.operations.typed_register import register_composite_operation
 from meho_backplane.retrieval.embedding import EmbeddingService
 
@@ -113,6 +119,12 @@ class _CompositeSpec(NamedTuple):
     tags: list[str]
     safety_level: Literal["safe", "caution", "dangerous"]
     requires_approval: bool
+    #: The L2 sub-op-ids the handler dispatches into -- the SAME tuple the
+    #: handler hands its preflight (``_read.py``'s ``_SUB_OPS_*``). Carried
+    #: on the spec so the import-time backing registration (below) and the
+    #: dispatch-time preflight read one source of truth, and the listing's
+    #: ``unbacked`` marker can never drift from what the composite hits.
+    sub_op_ids: tuple[str, ...]
 
 
 _COMPOSITES: tuple[_CompositeSpec, ...] = (
@@ -142,8 +154,30 @@ _COMPOSITES: tuple[_CompositeSpec, ...] = (
         tags=["composite", "read-only", "pulls", "status"],
         safety_level="safe",
         requires_approval=False,
+        sub_op_ids=_SUB_OPS_PR_STATUS_SUMMARY,
     ),
 )
+
+
+# Import-time backing registration (G0.25-T6 #1757). A pure in-process
+# dict write -- no DB / embedding work -- so it runs at import (when this
+# module is first loaded, alongside the package ``__init__``'s
+# lifespan-registrar queueing), well before any request reaches the op
+# listing. This lets ``search_operations`` mark a composite ``unbacked``
+# with the catalog-ingest ``next_step`` while its L2 sub-ops are absent,
+# instead of advertising it as enabled-but-broken until the first
+# dispatch trips ``composite_l2_missing``. The ``connector_id`` +
+# ``catalog_command`` are the same values the preflight's
+# ``CompositeL2DependencyMissing`` carries, and ``sub_op_ids`` is the same
+# tuple the handler hands the preflight -- one source of truth across the
+# listing and the dispatch.
+for _spec in _COMPOSITES:
+    register_composite_backing(
+        composite_op_id=_spec.op_id,
+        connector_id=_CONNECTOR_ID,
+        sub_op_ids=_spec.sub_op_ids,
+        catalog_command=catalog_command_for_github_rest(),
+    )
 
 
 async def register_github_composite_operations(

--- a/backend/src/meho_backplane/mcp/tools/operations.py
+++ b/backend/src/meho_backplane/mcp/tools/operations.py
@@ -305,7 +305,10 @@ register_mcp_tool(
             "exclude relevant hits. Returns the top N operations ranked "
             "by combined lexical + semantic match. Inspect each hit's "
             "`safety_level` and `requires_approval` before calling "
-            "`call_operation` on it. Arguments: `connector_id` (required), "
+            "`call_operation` on it; if a hit is `unbacked=true` (a "
+            "composite whose L2 sub-ops aren't ingested), run its "
+            "`next_step.verb` first — dispatching it as-is fails with "
+            "`composite_l2_missing`. Arguments: `connector_id` (required), "
             "`query` (required, free-form), `group` (optional, narrows "
             "to that group's ops), `limit` (default 10, max 50). "
             "`connector_id` is `<impl_id>-<version>` (NOT the bare "
@@ -371,12 +374,31 @@ register_mcp_tool(
                             "fused_score": {"type": "number"},
                             "bm25_score": {"type": ["number", "null"]},
                             "cosine_score": {"type": ["number", "null"]},
+                            # G0.25-T6 (#1757): a composite that is enabled
+                            # but whose L2 sub-ops aren't ingested yet is
+                            # flagged ``unbacked=true`` with the catalog-
+                            # ingest ``next_step`` so an agent self-corrects
+                            # to the ingest verb before dispatching into a
+                            # ``composite_l2_missing`` dead end. Both stay
+                            # falsy for ordinary ops and fully-backed
+                            # composites.
+                            "unbacked": {"type": "boolean"},
+                            "next_step": {
+                                "type": ["object", "null"],
+                                "properties": {
+                                    "verb": {"type": "string"},
+                                    "rationale": {"type": "string"},
+                                },
+                                "required": ["verb", "rationale"],
+                                "additionalProperties": False,
+                            },
                         },
                         "required": [
                             "op_id",
                             "safety_level",
                             "requires_approval",
                             "fused_score",
+                            "unbacked",
                         ],
                     },
                 },

--- a/backend/src/meho_backplane/operations/composite_backing.py
+++ b/backend/src/meho_backplane/operations/composite_backing.py
@@ -1,0 +1,245 @@
+# SPDX-License-Identifier: Apache-2.0
+# Copyright (c) 2026 evoila Group
+
+"""Composite-backing registry + an ``unbacked`` op-listing marker.
+
+G0.25-T6 (#1757). A composite op (``gh.composite.pr_status_summary``,
+``vmware.composite.datastore.usage``, ...) is itself an ingested
+``endpoint_descriptor`` row -- ``source_kind="composite"``,
+``is_enabled=True`` -- so it shows up in the op listing
+(:func:`~meho_backplane.operations.meta_tools.search_operations`) as a
+normal, callable hit. But the raw-REST L2 primitives it dispatches into
+ship as ``ingested`` descriptors that only land after an operator runs
+``meho connector ingest --catalog <product>/<version>``. Until that
+ingest happens, the composite's first dispatch trips the preflight
+(:mod:`~meho_backplane.connectors.github.composites._preflight`) and
+raises :class:`~meho_backplane.operations.composite.CompositeL2DependencyMissing`
+before any HTTP call -- a composite advertised as *enabled* dead-ends
+at the first call.
+
+This module closes the surfacing gap the
+``CompositeL2DependencyMissing`` error opened at dispatch time but never
+reflected on the listing: it lets each connector register, per composite
+op_id, the L2 sub-ops the composite depends on plus the catalog command
+that ingests them, and exposes an async check the op listing consults to
+mark a composite ``unbacked`` (with the catalog-ingest ``next_step``)
+while its sub-ops are absent. The marker disappears once the operator
+runs the ingest -- the same DB state the preflight reads, so the listing
+and the dispatch agree.
+
+Why a registry and not the preflight's per-call constants
+---------------------------------------------------------
+
+The preflight already walks each composite's declared ``sub_op_ids``,
+but it does so from inside the handler at dispatch time -- the sub-op
+tuple is passed as a call argument, not stored anywhere the *listing*
+can reach. The listing runs in a different code path
+(``search_operations`` over ``endpoint_descriptor`` rows) with only the
+op_id in hand. A small process-wide registry, populated by the same
+connector composite registrars that own the ``_SUB_OPS_*`` constants,
+gives the listing a lookup from op_id -> (sub_op_ids, catalog command)
+without coupling the generic meta-tool to any one connector's module
+layout. The connector registers the *same* constants it hands the
+preflight, so the two stay a single source of truth.
+
+Why ``lookup_descriptor`` (the enable-aware probe)
+--------------------------------------------------
+
+:func:`~meho_backplane.operations._lookup.lookup_descriptor` filters on
+``is_enabled=True`` -- exactly the rows a dispatch can resolve. The
+preflight uses it for the same reason, so an op that is ingested but
+left disabled counts as *missing* for both the marker and the dispatch.
+Mirroring the preflight's probe keeps the listing's "unbacked" verdict
+faithful to what the composite would actually hit on its next call.
+
+Registration timing
+--------------------
+
+Registration is a pure in-process dict write with no DB / embedding
+work, so connector composite modules register at import time (alongside
+the lifespan-registrar queueing in their package ``__init__``). The
+registry is therefore populated before any request reaches the listing.
+``gh.composite.*`` sub-ops (composite-to-composite recursion) are
+skipped by the presence walk for the same reason the preflight skips
+them: their registration is guaranteed by the lifespan registrar, and
+they are not catalog-ingested raw primitives.
+"""
+
+from __future__ import annotations
+
+from typing import Final, NamedTuple
+from uuid import UUID
+
+import structlog
+
+from meho_backplane.operations._lookup import lookup_descriptor, parse_connector_id
+from meho_backplane.operations.ingest.api_schemas import NextStep
+
+__all__ = [
+    "CompositeBacking",
+    "register_composite_backing",
+    "registered_composite_backing",
+    "reset_composite_backing_registry",
+    "unbacked_composite_next_step",
+]
+
+_log = structlog.get_logger(__name__)
+
+
+class CompositeBacking(NamedTuple):
+    """The L2 dependency surface of one composite op, for the listing check.
+
+    Field-table form (the same shape the connector registrars already use
+    for their per-composite metadata) so a maintainer reading a
+    registration sees the whole row at a glance.
+
+    Attributes
+    ----------
+    connector_id:
+        The connector_id the composite dispatches against
+        (``"gh-rest-3"``). Parsed into ``(product, version, impl_id)`` for
+        the descriptor probe -- the same triple the preflight derives.
+    sub_op_ids:
+        The L2 sub-op-ids the composite dispatches into. The same tuple
+        the connector hands the preflight, so the listing's verdict and
+        the dispatch-time preflight read one source of truth.
+    catalog_command:
+        The operator-facing CLI verb that ingests the missing L2 ops
+        (``"meho connector ingest --catalog gh/3"``). Becomes the
+        ``next_step.verb`` on the unbacked marker -- the same command the
+        ``CompositeL2DependencyMissing`` dispatch error carries.
+    """
+
+    connector_id: str
+    sub_op_ids: tuple[str, ...]
+    catalog_command: str
+
+
+#: Process-wide registry of composite op_id -> its backing dependency
+#: surface. Populated at import time by connector composite registrars
+#: (see the module docstring on timing). A plain dict keeps the lookup
+#: O(1) for the listing's per-hit check.
+_REGISTRY: Final[dict[str, CompositeBacking]] = {}
+
+#: Infix that marks a composite-to-composite recursion sub-op
+#: (``gh.composite.*`` / ``vmware.composite.*``). Skipped by the presence
+#: walk for the same reason the connector preflights skip it -- such
+#: sub-ops are registered by the lifespan registrar, not catalog-ingested,
+#: so they can never be the cause of an unbacked composite. The infix
+#: form (rather than a per-connector ``<product>.composite.`` prefix)
+#: keeps this generic across connectors; raw-REST L2 primitives are
+#: ``METHOD:/path`` strings and never contain it.
+_COMPOSITE_OP_INFIX: Final[str] = ".composite."
+
+
+def register_composite_backing(
+    *,
+    composite_op_id: str,
+    connector_id: str,
+    sub_op_ids: tuple[str, ...],
+    catalog_command: str,
+) -> None:
+    """Register a composite's L2 dependency surface for the listing check.
+
+    Called once per composite op at connector import time. Idempotent: a
+    re-registration with the same payload is a no-op; a re-registration
+    that *changes* the payload overwrites and logs, so a copy-paste
+    mistake (two composites sharing an op_id constant) surfaces in the
+    structured log rather than silently shadowing.
+
+    Parameters
+    ----------
+    composite_op_id:
+        The composite's own op_id -- the key the listing looks up by.
+    connector_id, sub_op_ids, catalog_command:
+        See :class:`CompositeBacking`.
+    """
+    backing = CompositeBacking(
+        connector_id=connector_id,
+        sub_op_ids=sub_op_ids,
+        catalog_command=catalog_command,
+    )
+    existing = _REGISTRY.get(composite_op_id)
+    if existing is not None and existing != backing:
+        _log.warning(
+            "composite_backing_reregistered",
+            composite_op_id=composite_op_id,
+            previous_connector_id=existing.connector_id,
+            new_connector_id=connector_id,
+        )
+    _REGISTRY[composite_op_id] = backing
+
+
+def registered_composite_backing(composite_op_id: str) -> CompositeBacking | None:
+    """Return the registered backing for *composite_op_id*, or ``None``.
+
+    ``None`` means the op_id is not a registered composite -- the listing
+    treats it as an ordinary op and never attaches an unbacked marker.
+    """
+    return _REGISTRY.get(composite_op_id)
+
+
+def reset_composite_backing_registry() -> None:
+    """Clear the registry. Test seam only -- never called in production.
+
+    Lets a unit test register a synthetic composite, exercise the marker,
+    and tear the entry down without leaking into sibling tests.
+    """
+    _REGISTRY.clear()
+
+
+async def unbacked_composite_next_step(
+    *,
+    op_id: str,
+    tenant_id: UUID,
+) -> NextStep | None:
+    """Return the catalog-ingest ``next_step`` when *op_id* is an unbacked composite.
+
+    The op listing calls this per composite hit. Three outcomes:
+
+    * *op_id is not a registered composite* -> ``None`` (ordinary op; no
+      marker).
+    * *op_id is a registered composite, every raw L2 sub-op resolves to an
+      enabled descriptor* -> ``None`` (the composite dispatches cleanly;
+      no marker).
+    * *op_id is a registered composite, at least one raw L2 sub-op is
+      absent (or ingested-but-disabled)* -> a :class:`NextStep` whose
+      ``verb`` is the catalog-ingest command, so the operator sees
+      "enabled -- run the catalog ingest first" instead of a silent
+      dead-end at dispatch.
+
+    The presence probe is :func:`lookup_descriptor` -- the enable-aware
+    lookup the dispatch-time preflight uses -- under *tenant_id*'s
+    tenant-scoped-then-global fallback, so the marker reflects what the
+    composite would actually resolve on its next call for this operator.
+    ``composite.*`` sub-ops (composite-to-composite recursion) are skipped
+    for the same reason the preflight skips them.
+    """
+    backing = _REGISTRY.get(op_id)
+    if backing is None:
+        return None
+    raw_sub_ops = tuple(
+        sub_op for sub_op in backing.sub_op_ids if _COMPOSITE_OP_INFIX not in sub_op
+    )
+    if not raw_sub_ops:
+        return None
+    product, version, impl_id = parse_connector_id(backing.connector_id)
+    for sub_op_id in raw_sub_ops:
+        descriptor = await lookup_descriptor(
+            tenant_id=tenant_id,
+            product=product,
+            version=version,
+            impl_id=impl_id,
+            op_id=sub_op_id,
+        )
+        if descriptor is None:
+            return NextStep(
+                verb=backing.catalog_command,
+                rationale=(
+                    "This composite is enabled but its L2 sub-operations are not "
+                    "ingested yet, so the first dispatch fails with "
+                    "composite_l2_missing before any call. Run the catalog ingest "
+                    "to populate them, then retry."
+                ),
+            )
+    return None

--- a/backend/src/meho_backplane/operations/meta_tools.py
+++ b/backend/src/meho_backplane/operations/meta_tools.py
@@ -96,7 +96,9 @@ from meho_backplane.operations._lookup import (
 )
 from meho_backplane.operations._request_preview import preview_dispatch
 from meho_backplane.operations._search import hybrid_search, resolve_group_id
+from meho_backplane.operations.composite_backing import unbacked_composite_next_step
 from meho_backplane.operations.dispatcher import dispatch
+from meho_backplane.operations.ingest.api_schemas import NextStep
 from meho_backplane.operations.ingest.list_connectors import next_step_for_registered_connector
 from meho_backplane.targets.resolver import resolve_target
 
@@ -260,6 +262,18 @@ class OperationSearchHit(BaseModel):
     tuning operation description quality want to see whether the top
     candidate scored well on BM25 (lexical match) or cosine (semantic
     match) or both.
+
+    ``unbacked`` / ``next_step`` (G0.25-T6 #1757) flag a composite op that
+    is *enabled* but whose L2 sub-operations are not ingested yet, so its
+    first dispatch would trip ``composite_l2_missing`` before any call.
+    ``unbacked`` is ``True`` exactly when ``next_step`` is set; the
+    ``next_step.verb`` is the ``meho connector ingest --catalog …`` command
+    that closes the gap. Both stay falsy (``unbacked=False``,
+    ``next_step=None``) for ordinary ops and for composites whose sub-ops
+    are fully ingested — the common case — so no existing hit gains a
+    false marker. The verdict mirrors the dispatch-time preflight's
+    enable-aware probe, so the listing and the dispatch agree on whether
+    the composite is callable.
     """
 
     model_config = ConfigDict(frozen=True)
@@ -273,6 +287,8 @@ class OperationSearchHit(BaseModel):
     fused_score: float
     bm25_score: float | None
     cosine_score: float | None
+    unbacked: bool = False
+    next_step: NextStep | None = None
 
 
 class OperationDescriptor(BaseModel):
@@ -714,6 +730,43 @@ async def list_operation_groups(
     }
 
 
+async def _attach_unbacked_composite_markers(
+    hits: list[OperationSearchHit],
+    *,
+    tenant_id: uuid.UUID,
+) -> list[OperationSearchHit]:
+    """Flag composite hits whose L2 sub-ops aren't ingested (G0.25-T6 #1757).
+
+    For each hit, :func:`unbacked_composite_next_step` returns the
+    catalog-ingest ``next_step`` when the hit's op_id is a *registered
+    composite* with at least one absent (or disabled) raw L2 sub-op, and
+    ``None`` otherwise — for an ordinary op, or for a composite whose
+    sub-ops are fully ingested. A non-``None`` result re-projects the
+    frozen hit with ``unbacked=True`` + the ``next_step``; everything else
+    passes through unchanged, so the common case allocates nothing new and
+    no hit gains a false marker.
+
+    The probe is enable-aware (it reuses the dispatch-time preflight's
+    :func:`~meho_backplane.operations._lookup.lookup_descriptor`) and
+    tenant-scoped, so the marker reflects what *this* operator's next
+    dispatch of the composite would actually resolve. Each probe opens its
+    own short-lived session; the hit list is tiny (``limit`` ≤ 50) and
+    only the composite hits probe at all, so the extra round-trips are
+    bounded and rare.
+    """
+    marked: list[OperationSearchHit] = []
+    for hit in hits:
+        next_step = await unbacked_composite_next_step(
+            op_id=hit.op_id,
+            tenant_id=tenant_id,
+        )
+        if next_step is None:
+            marked.append(hit)
+            continue
+        marked.append(hit.model_copy(update={"unbacked": True, "next_step": next_step}))
+    return marked
+
+
 async def search_operations(
     operator: Operator,
     arguments: dict[str, Any],
@@ -790,12 +843,19 @@ async def search_operations(
             query=query,
             limit=limit,
         )
+    # Flag any composite hit that is enabled but whose L2 sub-ops aren't
+    # ingested yet, so the operator sees the catalog-ingest next_step on
+    # the listing instead of a silent dead-end at the first dispatch
+    # (G0.25-T6 #1757). Runs after the search session closes — the probe
+    # opens its own short-lived sessions and only the composite hits probe.
+    hits = await _attach_unbacked_composite_markers(hits, tenant_id=operator.tenant_id)
     duration_ms = (time.monotonic() - started) * 1000
     _log.info(
         "search_operations",
         connector_id=connector_id,
         group=group_key,
         hit_count=len(hits),
+        unbacked_composite_count=sum(1 for h in hits if h.unbacked),
         tenant_id=str(operator.tenant_id),
         duration_ms=duration_ms,
     )

--- a/backend/tests/test_connectors_github_composites_register.py
+++ b/backend/tests/test_connectors_github_composites_register.py
@@ -334,6 +334,34 @@ def test_importing_github_composites_queues_registrar() -> None:
     )
 
 
+def test_importing_github_composites_registers_l2_backing() -> None:
+    """Import-time backing registration wires the composite's L2 surface (G0.25-T6 #1757).
+
+    The op listing reads this registry to mark the composite ``unbacked``
+    while its L2 sub-ops are absent. The registered ``sub_op_ids`` must be
+    the SAME tuple the dispatch-time preflight walks (``_read.py``'s
+    ``_SUB_OPS_PR_STATUS_SUMMARY``) and the ``catalog_command`` the same
+    one ``CompositeL2DependencyMissing`` carries, so the listing and the
+    dispatch can't drift.
+    """
+    from meho_backplane.connectors.github._catalog_command import (
+        catalog_command_for_github_rest,
+    )
+    from meho_backplane.connectors.github.composites._read import (
+        _CONNECTOR_ID,
+        _SUB_OPS_PR_STATUS_SUMMARY,
+    )
+    from meho_backplane.operations.composite_backing import registered_composite_backing
+
+    # The package import (already triggered by this module's top-level
+    # imports) runs the import-time registration as a side effect.
+    backing = registered_composite_backing("gh.composite.pr_status_summary")
+    assert backing is not None, "expected gh.composite.pr_status_summary to register a backing"
+    assert backing.connector_id == _CONNECTOR_ID
+    assert backing.sub_op_ids == _SUB_OPS_PR_STATUS_SUMMARY
+    assert backing.catalog_command == catalog_command_for_github_rest()
+
+
 def test_handler_is_module_level_coroutine_function() -> None:
     """The handler is a plain module-level ``async def`` -- no closures / partials / lambdas.
 

--- a/backend/tests/test_operations_composite_backing.py
+++ b/backend/tests/test_operations_composite_backing.py
@@ -1,0 +1,412 @@
+# SPDX-License-Identifier: Apache-2.0
+# Copyright (c) 2026 evoila Group
+
+"""Tests for the composite-backing registry + the op-listing ``unbacked`` marker.
+
+G0.25-T6 (#1757). A composite op is itself an ingested, enabled
+``endpoint_descriptor`` row, so it surfaces in ``search_operations`` as a
+normal hit -- but its raw-REST L2 sub-ops only land after an operator
+runs ``meho connector ingest --catalog <product>/<version>``. Until then
+the composite's first dispatch trips ``composite_l2_missing`` before any
+HTTP call. This module covers the surfacing fix that closes that gap on
+the listing:
+
+* :func:`unbacked_composite_next_step` (unit, ``lookup_descriptor``
+  stubbed -- same style as the gh-rest preflight tests):
+  - op_id not in the registry -> ``None`` (ordinary op, no marker).
+  - registered + every raw L2 sub-op present -> ``None`` (backed).
+  - registered + a sub-op absent -> a ``NextStep`` carrying the catalog
+    command.
+  - ``*.composite.*`` recursion sub-ops are skipped (never probed).
+
+* ``search_operations`` end-to-end (against the SQLite-fallback engine):
+  - a composite hit is flagged ``unbacked=True`` + ``next_step`` while its
+    L2 sub-ops are absent;
+  - the same composite loses the marker once the sub-ops are seeded
+    (``is_enabled=True``);
+  - a non-composite hit alongside it never gains a false marker.
+
+The gh-rest wiring (the one composite that ships today registers its
+backing at import time) is asserted in
+:mod:`tests.test_connectors_github_composites_register`.
+"""
+
+from __future__ import annotations
+
+import uuid
+from collections.abc import AsyncIterator, Iterator
+from datetime import UTC, datetime
+from typing import Any
+from unittest.mock import AsyncMock
+from uuid import UUID
+
+import pytest
+from sqlalchemy.ext.asyncio import AsyncSession
+
+from meho_backplane.auth.operator import Operator, TenantRole
+from meho_backplane.db.engine import get_sessionmaker
+from meho_backplane.db.models import EndpointDescriptor, OperationGroup
+from meho_backplane.operations import composite_backing as _backing
+from meho_backplane.operations import reset_dispatcher_caches
+from meho_backplane.operations.composite_backing import (
+    register_composite_backing,
+    registered_composite_backing,
+    reset_composite_backing_registry,
+    unbacked_composite_next_step,
+)
+from meho_backplane.operations.meta_tools import search_operations
+from meho_backplane.settings import get_settings
+
+_TENANT_A: UUID = UUID("00000000-0000-0000-0000-0000000000aa")
+
+# The gh-rest composite surface under test.
+_CONNECTOR_ID = "gh-rest-3"
+_PRODUCT = "gh"
+_VERSION = "3"
+_IMPL_ID = "gh-rest"
+_COMPOSITE_OP_ID = "gh.composite.pr_status_summary"
+_CATALOG_COMMAND = "meho connector ingest --catalog gh/3"
+_SUB_OPS: tuple[str, ...] = (
+    "GET:/repos/{owner}/{repo}/pulls/{pull_number}",
+    "GET:/repos/{owner}/{repo}/commits/{ref}/check-runs",
+    "GET:/repos/{owner}/{repo}/pulls/{pull_number}/reviews",
+)
+
+
+@pytest.fixture(autouse=True)
+def _required_settings_env(monkeypatch: pytest.MonkeyPatch) -> Iterator[None]:
+    """Pin env vars :class:`Settings` requires for this module."""
+    monkeypatch.setenv("KEYCLOAK_ISSUER_URL", "https://keycloak.test/realms/meho")
+    monkeypatch.setenv("KEYCLOAK_AUDIENCE", "meho-backplane")
+    monkeypatch.setenv("VAULT_ADDR", "https://vault.test")
+    get_settings.cache_clear()
+    yield
+    get_settings.cache_clear()
+
+
+@pytest.fixture(autouse=True)
+def _reset_module_state() -> Iterator[None]:
+    """Isolate the backing registry + dispatcher caches around every test.
+
+    The backing registry is process-wide and populated at import time by
+    the gh-rest composite package. Each test wants a known synthetic
+    surface, so clear it before the test -- but snapshot+restore the prior
+    contents afterward (the same discipline the gh-rest register test uses
+    for the typed-op registrar list) so a sibling module that relies on
+    the import-time gh-rest entry is not left with an empty registry when
+    this module runs first.
+    """
+    saved = dict(_backing._REGISTRY)
+    reset_dispatcher_caches()
+    reset_composite_backing_registry()
+    yield
+    reset_dispatcher_caches()
+    reset_composite_backing_registry()
+    _backing._REGISTRY.update(saved)
+
+
+@pytest.fixture
+def stub_embedding_service(monkeypatch: pytest.MonkeyPatch) -> AsyncMock:
+    """Deterministic embedding stub for the SQLite-fallback cosine branch."""
+    service = AsyncMock()
+    service.encode_one.return_value = [0.1] * 384
+    service.encode.return_value = [[0.1] * 384]
+    service.dimension = 384
+
+    def _fake_get_embedding_service() -> AsyncMock:
+        return service
+
+    monkeypatch.setattr(
+        "meho_backplane.operations._search.get_embedding_service",
+        _fake_get_embedding_service,
+    )
+    return service
+
+
+@pytest.fixture
+async def session() -> AsyncIterator[AsyncSession]:
+    """Yield an :class:`AsyncSession` against the autouse-migrated SQLite engine."""
+    sessionmaker = get_sessionmaker()
+    async with sessionmaker() as s:
+        yield s
+
+
+def _make_operator(tenant_id: UUID = _TENANT_A) -> Operator:
+    return Operator(
+        sub="op-test",
+        name="Test Operator",
+        email=None,
+        raw_jwt="<test-raw-jwt>",
+        tenant_id=tenant_id,
+        tenant_role=TenantRole.OPERATOR,
+    )
+
+
+# ---------------------------------------------------------------------------
+# unit: unbacked_composite_next_step (lookup_descriptor stubbed)
+# ---------------------------------------------------------------------------
+
+
+def _patch_lookup(monkeypatch: pytest.MonkeyPatch, *, present: set[str]) -> list[str]:
+    """Stub ``lookup_descriptor`` to behave as if ``present`` is the registered set."""
+    calls: list[str] = []
+
+    async def _stub_lookup_descriptor(
+        *, tenant_id: Any, product: str, version: str, impl_id: str, op_id: str
+    ) -> object | None:
+        calls.append(op_id)
+        return object() if op_id in present else None
+
+    monkeypatch.setattr(_backing, "lookup_descriptor", _stub_lookup_descriptor)
+    return calls
+
+
+@pytest.mark.asyncio
+async def test_next_step_none_for_unregistered_op(monkeypatch: pytest.MonkeyPatch) -> None:
+    """An op_id absent from the registry is an ordinary op -> no marker, no probe."""
+    calls = _patch_lookup(monkeypatch, present=set())
+    result = await unbacked_composite_next_step(op_id="gh.pr.get_files", tenant_id=_TENANT_A)
+    assert result is None
+    assert calls == [], "an unregistered op_id must not probe the descriptor table"
+
+
+@pytest.mark.asyncio
+async def test_next_step_none_when_all_sub_ops_present(monkeypatch: pytest.MonkeyPatch) -> None:
+    """A registered composite whose every raw L2 sub-op resolves -> no marker."""
+    register_composite_backing(
+        composite_op_id=_COMPOSITE_OP_ID,
+        connector_id=_CONNECTOR_ID,
+        sub_op_ids=_SUB_OPS,
+        catalog_command=_CATALOG_COMMAND,
+    )
+    _patch_lookup(monkeypatch, present=set(_SUB_OPS))
+    result = await unbacked_composite_next_step(op_id=_COMPOSITE_OP_ID, tenant_id=_TENANT_A)
+    assert result is None
+
+
+@pytest.mark.asyncio
+async def test_next_step_returned_when_a_sub_op_missing(monkeypatch: pytest.MonkeyPatch) -> None:
+    """A registered composite missing even one raw L2 sub-op -> catalog next_step."""
+    register_composite_backing(
+        composite_op_id=_COMPOSITE_OP_ID,
+        connector_id=_CONNECTOR_ID,
+        sub_op_ids=_SUB_OPS,
+        catalog_command=_CATALOG_COMMAND,
+    )
+    # Only the primary PR sub-op is ingested; the checks + reviews ops are absent.
+    _patch_lookup(monkeypatch, present={_SUB_OPS[0]})
+    result = await unbacked_composite_next_step(op_id=_COMPOSITE_OP_ID, tenant_id=_TENANT_A)
+    assert result is not None
+    assert result.verb == _CATALOG_COMMAND
+    assert "ingest" in result.rationale.lower()
+
+
+@pytest.mark.asyncio
+async def test_next_step_skips_composite_recursion_sub_ops(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """``*.composite.*`` sub-ops are never probed and never trigger a marker."""
+    register_composite_backing(
+        composite_op_id="gh.composite.future_recursive",
+        connector_id=_CONNECTOR_ID,
+        sub_op_ids=("gh.composite.pr_status_summary",),
+        catalog_command=_CATALOG_COMMAND,
+    )
+    calls = _patch_lookup(monkeypatch, present=set())
+    result = await unbacked_composite_next_step(
+        op_id="gh.composite.future_recursive", tenant_id=_TENANT_A
+    )
+    assert result is None, "a composite whose only sub-op is a recursion is never unbacked"
+    assert calls == [], "composite recursion sub-ops are skipped, not probed"
+
+
+def test_register_is_idempotent_but_logs_on_conflict() -> None:
+    """Re-registering the same payload is a no-op; a conflicting one overwrites."""
+    register_composite_backing(
+        composite_op_id=_COMPOSITE_OP_ID,
+        connector_id=_CONNECTOR_ID,
+        sub_op_ids=_SUB_OPS,
+        catalog_command=_CATALOG_COMMAND,
+    )
+    register_composite_backing(
+        composite_op_id=_COMPOSITE_OP_ID,
+        connector_id=_CONNECTOR_ID,
+        sub_op_ids=_SUB_OPS,
+        catalog_command=_CATALOG_COMMAND,
+    )
+    backing = registered_composite_backing(_COMPOSITE_OP_ID)
+    assert backing is not None
+    assert backing.connector_id == _CONNECTOR_ID
+    assert backing.sub_op_ids == _SUB_OPS
+    assert backing.catalog_command == _CATALOG_COMMAND
+
+
+# ---------------------------------------------------------------------------
+# end-to-end: the marker through search_operations
+# ---------------------------------------------------------------------------
+
+
+async def _seed_composite_listing(*, seed_sub_ops: bool) -> None:
+    """Seed the composite descriptor + an enabled group (+ optionally the L2 sub-ops).
+
+    Always seeds: an enabled ``pulls`` group, the enabled composite
+    descriptor, and an ordinary enabled L2 op (the "no false marker"
+    control). When *seed_sub_ops* is true, also seeds the three raw L2
+    primitives the composite depends on as enabled descriptors -- the
+    "backed" state in which the marker must disappear.
+    """
+    sessionmaker = get_sessionmaker()
+    group_id = uuid.uuid4()
+    now = datetime.now(UTC)
+    async with sessionmaker() as s, s.begin():
+        s.add(
+            OperationGroup(
+                id=group_id,
+                tenant_id=None,
+                product=_PRODUCT,
+                version=_VERSION,
+                impl_id=_IMPL_ID,
+                group_key="pulls",
+                name="Pull requests",
+                when_to_use="PR status questions.",
+                review_status="enabled",
+            )
+        )
+
+        def _descriptor(*, op_id: str, source_kind: str, summary: str) -> EndpointDescriptor:
+            return EndpointDescriptor(
+                id=uuid.uuid4(),
+                tenant_id=None,
+                product=_PRODUCT,
+                version=_VERSION,
+                impl_id=_IMPL_ID,
+                op_id=op_id,
+                source_kind=source_kind,
+                method=None,
+                path=None,
+                handler_ref=None,
+                summary=summary,
+                description=summary,
+                group_id=group_id,
+                tags=[],
+                parameter_schema={"type": "object"},
+                response_schema=None,
+                llm_instructions=None,
+                safety_level="safe",
+                requires_approval=False,
+                is_enabled=True,
+                embedding=None,
+                custom_description=None,
+                custom_notes=None,
+                created_at=now,
+                updated_at=now,
+            )
+
+        s.add(
+            _descriptor(
+                op_id=_COMPOSITE_OP_ID,
+                source_kind="composite",
+                summary="Return PR status: metadata, checks, reviews in one call.",
+            )
+        )
+        # Ordinary (non-composite) op in the same connector -- the control
+        # that must never gain a false marker.
+        s.add(
+            _descriptor(
+                op_id="gh.pr.get_files",
+                source_kind="ingested",
+                summary="List the files changed in a pull request.",
+            )
+        )
+        if seed_sub_ops:
+            for sub_op in _SUB_OPS:
+                s.add(
+                    _descriptor(
+                        op_id=sub_op,
+                        source_kind="ingested",
+                        summary=f"Raw L2 primitive {sub_op}.",
+                    )
+                )
+
+
+def _hit_by_op_id(hits: list[dict[str, Any]], op_id: str) -> dict[str, Any]:
+    matches = [h for h in hits if h["op_id"] == op_id]
+    assert matches, f"expected a hit for {op_id!r}; got {[h['op_id'] for h in hits]}"
+    return matches[0]
+
+
+@pytest.mark.asyncio
+async def test_search_marks_composite_unbacked_when_sub_ops_absent(
+    stub_embedding_service: AsyncMock,
+) -> None:
+    """AC (a): the composite hit carries ``unbacked`` + ``next_step`` while sub-ops are absent."""
+    register_composite_backing(
+        composite_op_id=_COMPOSITE_OP_ID,
+        connector_id=_CONNECTOR_ID,
+        sub_op_ids=_SUB_OPS,
+        catalog_command=_CATALOG_COMMAND,
+    )
+    await _seed_composite_listing(seed_sub_ops=False)
+    operator = _make_operator()
+
+    result = await search_operations(
+        operator, {"connector_id": _CONNECTOR_ID, "query": "pull request status", "limit": 50}
+    )
+    hits = result["hits"]
+
+    composite_hit = _hit_by_op_id(hits, _COMPOSITE_OP_ID)
+    assert composite_hit["unbacked"] is True
+    assert composite_hit["next_step"] is not None
+    assert composite_hit["next_step"]["verb"] == _CATALOG_COMMAND
+
+    # AC (c): the ordinary op alongside it must NOT gain a false marker.
+    ordinary_hit = _hit_by_op_id(hits, "gh.pr.get_files")
+    assert ordinary_hit["unbacked"] is False
+    assert ordinary_hit["next_step"] is None
+
+
+@pytest.mark.asyncio
+async def test_search_drops_marker_once_sub_ops_ingested(
+    stub_embedding_service: AsyncMock,
+) -> None:
+    """AC (a)/(c): once the L2 sub-ops are ingested, the composite loses the marker."""
+    register_composite_backing(
+        composite_op_id=_COMPOSITE_OP_ID,
+        connector_id=_CONNECTOR_ID,
+        sub_op_ids=_SUB_OPS,
+        catalog_command=_CATALOG_COMMAND,
+    )
+    await _seed_composite_listing(seed_sub_ops=True)
+    operator = _make_operator()
+
+    result = await search_operations(
+        operator, {"connector_id": _CONNECTOR_ID, "query": "pull request status", "limit": 50}
+    )
+    hits = result["hits"]
+
+    composite_hit = _hit_by_op_id(hits, _COMPOSITE_OP_ID)
+    assert composite_hit["unbacked"] is False
+    assert composite_hit["next_step"] is None
+
+
+@pytest.mark.asyncio
+async def test_search_no_marker_when_backing_unregistered(
+    stub_embedding_service: AsyncMock,
+) -> None:
+    """A composite descriptor with NO registered backing never gains a marker.
+
+    Defends the "registry is the gate" contract: a composite the listing
+    knows about as a descriptor row but that no connector registered a
+    backing for is treated as an ordinary op (no false positive from the
+    descriptor's ``source_kind`` alone).
+    """
+    # Deliberately do NOT register a backing.
+    await _seed_composite_listing(seed_sub_ops=False)
+    operator = _make_operator()
+
+    result = await search_operations(
+        operator, {"connector_id": _CONNECTOR_ID, "query": "pull request status", "limit": 50}
+    )
+    composite_hit = _hit_by_op_id(result["hits"], _COMPOSITE_OP_ID)
+    assert composite_hit["unbacked"] is False
+    assert composite_hit["next_step"] is None

--- a/docs/codebase/connectors-github.md
+++ b/docs/codebase/connectors-github.md
@@ -55,6 +55,26 @@ multiple L2 sub-ops into one governed call. T4 ships the first one,
   list. The parent `github/__init__.py` imports this subpackage so the
   registrar lands during `_eager_import_connectors`.
 
+The preflight only fires at **dispatch** time, so a composite whose L2
+sub-ops are not ingested used to look fully enabled on the op listing
+and only dead-ended on the first call (`composite_l2_missing`). G0.25-T6
+(#1757) closes that gap on the **listing**: `_register.py` registers the
+composite's `(connector_id, sub_op_ids, catalog_command)` into the
+process-wide registry in `operations/composite_backing.py` at import
+time (the same `_SUB_OPS_PR_STATUS_SUMMARY` tuple the handler hands the
+preflight, so the two can't drift). `search_operations`
+(`operations/meta_tools.py`) consults
+`unbacked_composite_next_step` per composite hit and, when any raw L2
+sub-op is absent (or ingested-but-disabled — the probe is the
+preflight's enable-aware `lookup_descriptor`), flags the hit
+`unbacked=true` with a `next_step` carrying
+`meho connector ingest --catalog gh/3`. The marker is tenant-scoped and
+disappears once the catalog ingest lands the sub-ops, so the listing
+agrees with what the next dispatch would resolve. Ordinary ops and
+fully-backed composites never gain the marker. The MCP
+`search_operations` `outputSchema` carries the two fields so the agent
+transport sees the same shape.
+
 Both summarisers — `_summarize_checks` and `_summarize_reviews` — are
 intentionally conservative: an unexpected payload shape collapses to
 `"unknown"` rather than guessing, and `_summarize_reviews` honours


### PR DESCRIPTION
## Summary

- A composite op (`gh.composite.pr_status_summary`) is itself an ingested, enabled `endpoint_descriptor` row, so it shows up in the operation listing as a normal callable hit — but its raw-REST L2 sub-ops only land after `meho connector ingest --catalog gh/3`. Until then the composite's **first dispatch** trips the preflight and raises `composite_l2_missing` before any HTTP call, with nothing on the listing to warn the operator.
- This surfaces the gap on the listing (it does **not** auto-ingest — explicitly out of scope). A new generic, process-wide composite-backing registry (`operations/composite_backing.py`) lets each connector record, at import time, its composites' `(connector_id, sub_op_ids, catalog_command)` — the **same** sub-op tuple the handler hands the dispatch-time preflight, so the listing verdict and the dispatch can't drift.
- `search_operations` (REST `GET /api/v1/operations/search` + the MCP tool) consults `unbacked_composite_next_step` per composite hit and flags it `unbacked=true` with a `next_step` catalog-ingest hint whenever any raw L2 sub-op is absent (or ingested-but-disabled — the probe reuses the preflight's enable-aware `lookup_descriptor`). Tenant-scoped; disappears once the sub-ops are ingested; never lands on ordinary ops or fully-backed composites.
- `gh.composite.pr_status_summary` is wired (reusing `_SUB_OPS_PR_STATUS_SUMMARY` + `catalog_command_for_github_rest()`). The registry generalises to the vmware-rest composites and future ones — they can register in their own task.

## Test plan

- [x] `ruff check` — clean (after import-sort autofix)
- [x] `ruff format --check` — clean
- [x] `mypy src/meho_backplane/` — Success, no issues (475 files)
- [x] `code-quality.py --diff` — 0 blockers (4 pre-existing/under-threshold warnings recorded)
- [x] Unit suite (CI-equivalent `--ignore=tests/integration`) — **7540 passed, 195 skipped**
- [x] **AC (a)** `pytest tests/test_operations_composite_backing.py` — composite hit carries `unbacked=true` + `next_step` when sub-ops absent; marker disappears once the three L2 sub-ops are seeded (`is_enabled=True`).
- [x] **AC (b)** composite dispatches cleanly after ingest (no `composite_l2_missing`) — unchanged dispatch path; covered by `tests/integration/test_github_composite_dispatch.py` (live, xfail-strict in CI; collects cleanly).
- [x] **AC (c)** no false marker: an ordinary op alongside the composite, a fully-backed composite, and a composite with no registered backing all stay `unbacked=false` / `next_step=null` (asserted in the new test module).
- [x] gh-rest import-time backing registration asserted in `tests/test_connectors_github_composites_register.py`.
- [x] CLI OpenAPI snapshot unchanged — `OperationSearchHit` is not a FastAPI `response_model`, so the `/operations/search` response stays a generic object; verified a 0-line regen diff against the branch's committed `cli/api/openapi.json`. No snapshot regen required.

## Out of scope

- **Auto-ingesting catalogs at boot** — couples to the catalog-driven ingest line; a separate decision (per the issue). This task only makes the existing gap visible.
- **Wiring the vmware-rest composites into the backing registry** — the generic mechanism supports them; their registration is left to a follow-up so this PR stays scoped to the task target.

## Adjacent findings (deferred)

- `operations/meta_tools.py::search_operations` is now 96 lines (code-quality warn >60, block at 100) — a non-blocking warning the marker-attach call nudged up; the bulk is its long docstring + the DB query. The file already carries a `code-quality-allow: file-size`. Not refactored to avoid fragmenting the shared meta-tool; recorded only.

<!-- auto-implement-issue: fresh, iteration 1 -->

Closes #1757
