### PR TITLE
fix(ui): show live readiness on the footer pill on every console page

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -126,6 +126,18 @@ connector-related release-notes line.
 
 ### Fixed
 
+- Operator-console **readiness pill now reflects real backend health on
+  every page**, not just the dashboard. The sidebar-footer pill was
+  stuck on yellow "starting" across all `/ui/*` surfaces because ~14
+  routes hardcoded `ready=False` in their template context; only the
+  dashboard computed it. The live verdict is now injected into every
+  render by the shared context processor, read from a short-TTL-cached
+  (`2 s`) readiness snapshot the session middleware computes from the
+  same probe registry `GET /ready` uses — so a non-dashboard page shows
+  green "ready" when the backend is healthy and "starting" when `/ready`
+  would 503, at negligible per-render cost. The per-route literals are
+  dropped; the dashboard's own fresh-probe behaviour is unchanged
+  (#1776).
 - Operator-console memory **create no longer 403s** under a background
   list refresh. The memory list's 60-second card poll re-used the
   page handler, which re-minted and `Set-Cookie`-d a fresh CSRF token

--- a/backend/src/meho_backplane/docs_search/readiness_probe.py
+++ b/backend/src/meho_backplane/docs_search/readiness_probe.py
@@ -59,8 +59,11 @@ PROBE_NAME = "docs_backends"
 def docs_backends_readiness_probe() -> ProbeResult:
     """Report which search backends are configured — never failing readiness.
 
-    Synchronous (no I/O — :meth:`is_configured` is a config read), so the
-    health registry calls it inline. Registered ≠ configured (#1606): the
+    Synchronous (no I/O — :meth:`is_configured` is a config read). The
+    async health sweep (:func:`~meho_backplane.health.run_probes_async`)
+    runs sync probes on a worker thread so a blocking probe can't stall
+    the event loop; this one returns immediately either way. Registered ≠
+    configured (#1606): the
     registry holds every backend that self-registered at import, while
     only the subset whose :meth:`is_configured` is true is actually wired
     on this deploy. Unconfigured backends are **skipped** — the docs

--- a/backend/src/meho_backplane/health.py
+++ b/backend/src/meho_backplane/health.py
@@ -225,7 +225,11 @@ def _build_readiness_snapshot(results: list[ProbeResult]) -> dict[str, object]:
     }
 
 
-async def readiness_snapshot(*, max_age_s: float = DEFAULT_READINESS_TTL_S) -> dict[str, object]:
+async def readiness_snapshot(
+    *,
+    max_age_s: float = DEFAULT_READINESS_TTL_S,
+    timeout_s: float | None = None,
+) -> dict[str, object]:
     """Return a short-TTL-cached readiness snapshot ``{ready, checks}``.
 
     Runs the full probe sweep (:func:`run_probes_async`, sync + async
@@ -240,6 +244,21 @@ async def readiness_snapshot(*, max_age_s: float = DEFAULT_READINESS_TTL_S) -> d
 
     The ``checks`` detail mirrors the ``/ready`` payload so a caller can
     surface the same per-probe breakdown without a second sweep.
+
+    *timeout_s* bounds the probe sweep. The registry's probes do live
+    network I/O (Keycloak/Vault/DB), run **sequentially**, and carry no
+    internal timeout of their own (see :func:`run_probes_async`), so a
+    slow or black-holed dependency would otherwise hang the caller
+    indefinitely. When *timeout_s* is set and a refresh is required, the
+    sweep is wrapped in :func:`asyncio.wait_for`; if it does not finish
+    in time the call degrades to a not-ready verdict carrying a single
+    synthetic ``timeout`` check and **does not** cache that verdict — a
+    transient stall must not pin a misleading result for the rest of the
+    TTL window, and the next caller retries a fresh sweep. ``None`` (the
+    default) leaves the sweep unbounded: ``GET /ready`` and the dashboard
+    (``max_age_s=0``) keep their existing fidelity, while the per-request
+    UI hot path passes a short bound (see
+    :func:`~meho_backplane.ui.auth.middleware._stash_ui_readiness`).
     """
     global _readiness_cache
     now = time.monotonic()
@@ -254,7 +273,30 @@ async def readiness_snapshot(*, max_age_s: float = DEFAULT_READINESS_TTL_S) -> d
         refreshed_now = time.monotonic()
         if cached is not None and max_age_s > 0 and (refreshed_now - cached[0]) < max_age_s:
             return cached[1]
-        snapshot = _build_readiness_snapshot(await run_probes_async())
+        if timeout_s is None:
+            results = await run_probes_async()
+        else:
+            try:
+                results = await asyncio.wait_for(run_probes_async(), timeout_s)
+            except TimeoutError:
+                # The sweep blew its budget (a probe is hung on network
+                # I/O). ``asyncio.wait_for`` has already cancelled the
+                # underlying coroutine. ``asyncio.CancelledError`` is a
+                # ``BaseException``, not an ``Exception``, so it is *not*
+                # caught here and continues to propagate on a genuine
+                # task cancellation. Return — but deliberately do NOT
+                # cache — a not-ready verdict so the next request retries.
+                return {
+                    "ready": False,
+                    "checks": [
+                        {
+                            "name": "timeout",
+                            "ok": False,
+                            "detail": f"readiness probe sweep exceeded {timeout_s}s",
+                        }
+                    ],
+                }
+        snapshot = _build_readiness_snapshot(results)
         _readiness_cache = (time.monotonic(), snapshot)
         return snapshot
 

--- a/backend/src/meho_backplane/health.py
+++ b/backend/src/meho_backplane/health.py
@@ -50,6 +50,7 @@ from collections.abc import Awaitable, Callable
 from dataclasses import asdict, dataclass
 from typing import cast
 
+import structlog
 from fastapi import APIRouter
 from fastapi.responses import JSONResponse
 
@@ -67,6 +68,7 @@ __all__ = [
     "router",
     "run_probes",
     "run_probes_async",
+    "ui_readiness_verdict",
 ]
 
 
@@ -232,6 +234,15 @@ def clear_probes() -> None:
 #: ``max_age_s=0`` to force a fresh sweep so its behaviour is unchanged.
 DEFAULT_READINESS_TTL_S: float = 2.0
 
+#: Upper bound (seconds) on the bounded sweeps :func:`ui_readiness_verdict`
+#: runs — the cold-cache first-warm sweep and every background refresh it
+#: schedules. Kept well under :data:`DEFAULT_READINESS_TTL_S` so a
+#: black-holed dependency degrades the warm sweep to a not-ready verdict
+#: in a fraction of a second instead of pinning the cold-start render. The
+#: UI middleware can pass its own bound; this is the default the hot-path
+#: accessor uses when none is given.
+_READINESS_HOT_PATH_TIMEOUT_S: float = 1.0
+
 
 #: Monotonic-clock-stamped cache for :func:`readiness_snapshot`:
 #: ``(captured_at_monotonic, snapshot)`` or ``None`` before the first
@@ -240,6 +251,21 @@ DEFAULT_READINESS_TTL_S: float = 2.0
 #: thundering herd of probe sweeps.
 _readiness_cache: tuple[float, dict[str, object]] | None = None
 _readiness_lock = asyncio.Lock()
+
+#: Handle on the single in-flight background refresh spawned by
+#: :func:`ui_readiness_verdict`. ``None`` when no refresh is running. The
+#: reference is kept alive here (not just on the event loop) so the task
+#: is not garbage-collected mid-flight — a fire-and-forget
+#: :func:`asyncio.create_task` whose only reference is a local would be a
+#: candidate for collection before it completes (a documented asyncio
+#: footgun). The task clears this handle in its own ``finally`` so a new
+#: refresh can be scheduled once the previous one finishes. This is the
+#: single-flight guard for the *stale-while-revalidate* hot path:
+#: ``ui_readiness_verdict`` only spawns a refresh when this is ``None``,
+#: so a burst of ``/ui/*`` requests against a stale cache triggers at
+#: most one background sweep — and therefore at most one probe-worker
+#: thread — rather than one per request (the #1776 CI-unit-lane overrun).
+_readiness_refresh_task: asyncio.Task[None] | None = None
 
 
 def _build_readiness_snapshot(results: list[ProbeResult]) -> dict[str, object]:
@@ -336,6 +362,135 @@ async def readiness_snapshot(
         return snapshot
 
 
+async def _refresh_readiness_cache(timeout_s: float) -> None:
+    """Background single-flight refresh of the readiness cache.
+
+    Runs one bounded sweep via :func:`readiness_snapshot` (which offloads
+    sync probes to a worker thread and caches a successful result on its
+    normal path). A sweep that times out is *not* cached by
+    ``readiness_snapshot`` — which is exactly right for stale-while-
+    revalidate: the cache keeps its last-known verdict and the hot path
+    keeps serving it, rather than flipping the pill to "starting" on a
+    transient stall. Spawned (and singled-flighted) by
+    :func:`ui_readiness_verdict`; never awaited by a request.
+    """
+    try:
+        await readiness_snapshot(max_age_s=0, timeout_s=timeout_s)
+    except Exception:  # pragma: no cover — defensive
+        # A probe raised (vs. merely timing out). Swallow it here so the
+        # fire-and-forget task does not surface a "Task exception was
+        # never retrieved" warning; the cache simply keeps its prior
+        # value and the next refresh retries. ``asyncio.CancelledError``
+        # is a ``BaseException`` — not caught here — so a genuine
+        # cancellation (test teardown) still propagates and clears the
+        # handle via ``finally``.
+        structlog.get_logger(__name__).warning(
+            "ui_readiness_background_refresh_failed", exc_info=True
+        )
+    finally:
+        # Release the single-flight slot so the next stale read can
+        # schedule a fresh refresh — but only if the handle still points
+        # at *this* task. ``clear_readiness_cache`` (test teardown) may
+        # have already detached us and a successor may have been
+        # scheduled; clearing unconditionally would clobber that handle.
+        global _readiness_refresh_task
+        if _readiness_refresh_task is asyncio.current_task():
+            _readiness_refresh_task = None
+
+
+def _schedule_readiness_refresh(timeout_s: float) -> None:
+    """Start a background readiness refresh unless one is already running.
+
+    The single-flight guard is :data:`_readiness_refresh_task`: a non-
+    ``None`` handle means a refresh is in flight, so we skip. The new
+    task's reference is retained on the module global (not just the event
+    loop) so it cannot be garbage-collected before it completes.
+    """
+    global _readiness_refresh_task
+    if _readiness_refresh_task is not None:
+        return
+    _readiness_refresh_task = asyncio.create_task(_refresh_readiness_cache(timeout_s))
+
+
+async def ui_readiness_verdict(*, timeout_s: float = _READINESS_HOT_PATH_TIMEOUT_S) -> bool:
+    """Non-blocking readiness verdict for the per-request UI hot path.
+
+    This is the *stale-while-revalidate* accessor the
+    :class:`~meho_backplane.ui.auth.middleware.UISessionMiddleware` reads
+    on every ``/ui/*`` render to colour the footer pill. Unlike
+    :func:`readiness_snapshot` it **never blocks the request on a probe
+    sweep** — the whole point of #1776's "inject ``ready`` at negligible
+    cost" intent, and the fix for the CI-unit-lane overrun caused by the
+    earlier inline-sweep design (every request hitting the 1 s timeout,
+    serialised through the single-flight lock, orphaning a probe thread
+    each time):
+
+    * **Cache present (any age).** Return the cached verdict immediately
+      — stale is fine; the pill is an at-a-glance hint, not the
+      kubernetes readiness contract. If the entry is older than
+      :data:`DEFAULT_READINESS_TTL_S`, schedule a single-flight
+      background refresh (:func:`_schedule_readiness_refresh`) so the
+      next render sees a fresh value, but do **not** await it.
+    * **Cache absent (first-ever call).** Do one bounded sweep to warm
+      the cache so a healthy backend renders "ready" on first paint
+      (preserving the existing acceptance criteria + tests). The sweep is
+      bounded by *timeout_s*, and — unlike :func:`readiness_snapshot` —
+      the result is cached **even on timeout**, so a cold-start blocking
+      probe cannot make every subsequent request re-sweep. Concurrent
+      first callers share the one warm sweep via the single-flight
+      :data:`_readiness_lock`.
+
+    Returns the boolean ``ready`` verdict (the only field the pill needs);
+    the middleware's caller maps a missing verdict to ``False``
+    ("starting"). ``GET /ready`` and the dashboard deliberately do **not**
+    route through here — they call :func:`readiness_snapshot` with
+    ``max_age_s=0`` for a fresh, full-fidelity sweep.
+    """
+    global _readiness_cache
+    cached = _readiness_cache
+    if cached is not None:
+        captured_at, snapshot = cached
+        if (time.monotonic() - captured_at) >= DEFAULT_READINESS_TTL_S:
+            # Stale: kick off a background refresh (single-flight) and
+            # serve the last-known verdict without waiting for it.
+            _schedule_readiness_refresh(timeout_s)
+        return bool(snapshot["ready"])
+
+    # Cold cache: warm it with one bounded sweep, single-flighted through
+    # the readiness lock so concurrent first callers don't each sweep.
+    async with _readiness_lock:
+        cached = _readiness_cache
+        if cached is not None:
+            # A peer warmed the cache while we waited for the lock.
+            return bool(cached[1]["ready"])
+        try:
+            results = await asyncio.wait_for(run_probes_async(), timeout_s)
+            snapshot = _build_readiness_snapshot(results)
+        except TimeoutError:
+            # Cold-start blocking probe. ``asyncio.wait_for`` cancelled
+            # the sweep; the orphaned worker thread drains in the
+            # background. Cache the not-ready verdict (unlike
+            # ``readiness_snapshot``, which deliberately does not cache a
+            # transient timeout for ``/ready``): on the hot path the
+            # alternative is re-sweeping on *every* request while the
+            # probe stays black-holed — the exact CI overrun #1776 fixes.
+            # The TTL makes this self-healing: the next render past the
+            # window schedules a background refresh that picks up
+            # recovery.
+            snapshot = {
+                "ready": False,
+                "checks": [
+                    {
+                        "name": "timeout",
+                        "ok": False,
+                        "detail": f"readiness probe sweep exceeded {timeout_s}s",
+                    }
+                ],
+            }
+        _readiness_cache = (time.monotonic(), snapshot)
+        return bool(snapshot["ready"])
+
+
 def clear_readiness_cache() -> None:
     """Drop the cached readiness snapshot. Test-only.
 
@@ -343,9 +498,22 @@ def clear_readiness_cache() -> None:
     is the only refresh trigger. Tests that register a fresh probe set
     call this so a snapshot cached by an earlier test (potentially on
     the same xdist worker) cannot leak a stale verdict.
+
+    Also cancels any in-flight background refresh spawned by
+    :func:`ui_readiness_verdict` and detaches its handle, so a refresh
+    started by one test cannot (a) write a verdict into a sibling test's
+    cache or (b) surface a "Task was destroyed but it is pending!"
+    warning when the test's event loop is torn down. The cancel is
+    fire-and-forget — the task's own ``finally`` clears the module
+    handle; we drop our reference here so a pending task on a
+    soon-to-close loop is not kept alive by this module.
     """
-    global _readiness_cache
+    global _readiness_cache, _readiness_refresh_task
     _readiness_cache = None
+    task = _readiness_refresh_task
+    _readiness_refresh_task = None
+    if task is not None and not task.done():
+        task.cancel()
 
 
 router = APIRouter(tags=["health"])

--- a/backend/src/meho_backplane/health.py
+++ b/backend/src/meho_backplane/health.py
@@ -43,7 +43,9 @@ Usage::
     register_probe("vault", vault_probe)
 """
 
+import asyncio
 import inspect
+import time
 from collections.abc import Awaitable, Callable
 from dataclasses import asdict, dataclass
 
@@ -54,9 +56,12 @@ from meho_backplane.features import build_features_block
 from meho_backplane.settings import get_settings
 
 __all__ = [
+    "DEFAULT_READINESS_TTL_S",
     "ProbeFn",
     "ProbeResult",
     "clear_probes",
+    "clear_readiness_cache",
+    "readiness_snapshot",
     "register_probe",
     "router",
     "run_probes",
@@ -177,6 +182,93 @@ async def run_probes_async() -> list[ProbeResult]:
 def clear_probes() -> None:
     """Empty the registry. Test-only — never call from production code."""
     _probes.clear()
+
+
+#: Default freshness window for :func:`readiness_snapshot`. The UI
+#: chassis injects the readiness verdict into every ``/ui/*`` page
+#: render via a synchronous Jinja context processor that cannot itself
+#: await the probe sweep; the snapshot is computed in the async session
+#: middleware and read from ``request.state`` by the processor. Caching
+#: the verdict for a short window keeps that hot path at "negligible
+#: cost" (issue #1776) — at most one probe sweep per window across all
+#: concurrent page loads, rather than a fresh sweep per render — while
+#: still surfacing a 503→200 (or 200→503) transition within ~2s. The
+#: dashboard, which owns the detailed readiness card, passes
+#: ``max_age_s=0`` to force a fresh sweep so its behaviour is unchanged.
+DEFAULT_READINESS_TTL_S: float = 2.0
+
+
+#: Monotonic-clock-stamped cache for :func:`readiness_snapshot`:
+#: ``(captured_at_monotonic, snapshot)`` or ``None`` before the first
+#: sweep. Guarded by :data:`_readiness_lock` so a burst of concurrent
+#: requests triggers a single refresh (single-flight) rather than a
+#: thundering herd of probe sweeps.
+_readiness_cache: tuple[float, dict[str, object]] | None = None
+_readiness_lock = asyncio.Lock()
+
+
+def _build_readiness_snapshot(results: list[ProbeResult]) -> dict[str, object]:
+    """Project probe *results* into the ``{ready, checks}`` snapshot shape.
+
+    The shape mirrors the ``/ready`` payload (minus the ``features``
+    block, which is a deploy-config concern orthogonal to the live
+    readiness verdict) so the UI footer pill, the dashboard readiness
+    card, and ``/ready`` all read one contract. ``ready`` is ``False``
+    for an empty registry because ``all([])`` is vacuously ``True`` —
+    the chassis must fail closed until concrete probes are wired (see
+    the module docstring and :func:`ready`).
+    """
+    ready_ok = bool(results) and all(r.ok for r in results)
+    return {
+        "ready": ready_ok,
+        "checks": [{"name": r.name, "ok": r.ok, "detail": r.detail or ""} for r in results],
+    }
+
+
+async def readiness_snapshot(*, max_age_s: float = DEFAULT_READINESS_TTL_S) -> dict[str, object]:
+    """Return a short-TTL-cached readiness snapshot ``{ready, checks}``.
+
+    Runs the full probe sweep (:func:`run_probes_async`, sync + async
+    probes alike) at most once per *max_age_s* window and caches the
+    result. A cached entry younger than *max_age_s* is returned without
+    re-running probes; otherwise the cache is refreshed under a
+    single-flight lock so concurrent callers share one sweep.
+
+    Pass ``max_age_s=0`` to force a fresh sweep (and refresh the cache)
+    — the dashboard does this so its readiness card stays live while
+    every other surface reads the cheap cached verdict.
+
+    The ``checks`` detail mirrors the ``/ready`` payload so a caller can
+    surface the same per-probe breakdown without a second sweep.
+    """
+    global _readiness_cache
+    now = time.monotonic()
+    cached = _readiness_cache
+    if cached is not None and max_age_s > 0 and (now - cached[0]) < max_age_s:
+        return cached[1]
+
+    async with _readiness_lock:
+        # Re-check under the lock: a peer may have refreshed while we
+        # waited to acquire it, so we avoid a redundant second sweep.
+        cached = _readiness_cache
+        refreshed_now = time.monotonic()
+        if cached is not None and max_age_s > 0 and (refreshed_now - cached[0]) < max_age_s:
+            return cached[1]
+        snapshot = _build_readiness_snapshot(await run_probes_async())
+        _readiness_cache = (time.monotonic(), snapshot)
+        return snapshot
+
+
+def clear_readiness_cache() -> None:
+    """Drop the cached readiness snapshot. Test-only.
+
+    Production never invalidates the cache out-of-band; the TTL window
+    is the only refresh trigger. Tests that register a fresh probe set
+    call this so a snapshot cached by an earlier test (potentially on
+    the same xdist worker) cannot leak a stale verdict.
+    """
+    global _readiness_cache
+    _readiness_cache = None
 
 
 router = APIRouter(tags=["health"])

--- a/backend/src/meho_backplane/health.py
+++ b/backend/src/meho_backplane/health.py
@@ -48,6 +48,7 @@ import inspect
 import time
 from collections.abc import Awaitable, Callable
 from dataclasses import asdict, dataclass
+from typing import cast
 
 from fastapi import APIRouter
 from fastapi.responses import JSONResponse
@@ -96,8 +97,10 @@ class ProbeResult:
 #: + ``httpx`` sync clients wrapped where needed) or an ``async def``
 #: coroutine returning the same (the DB-migration-state probe — the
 #: SQLAlchemy 2.x async engine forces the I/O onto the event loop).
-#: The registry stores both shapes; the ``/ready`` handler awaits
-#: coroutine-returning probes and calls sync probes inline.
+#: The registry stores both shapes; :func:`run_probes_async` awaits
+#: coroutine-returning probes directly and runs sync probes on a worker
+#: thread (via :func:`asyncio.to_thread`) so a blocking probe cannot
+#: stall the event loop or defeat the caller's timeout bound.
 ProbeFn = Callable[[], ProbeResult] | Callable[[], Awaitable[ProbeResult]]
 
 
@@ -157,25 +160,57 @@ def run_probes() -> list[ProbeResult]:
 async def run_probes_async() -> list[ProbeResult]:
     """Evaluate every registered probe — sync and async alike.
 
-    Async probes are awaited; sync probes are called inline. Probes
-    run sequentially in registration order (parallelising readiness
-    checks across dependencies is a v0.2 optimisation; v0.1 favours
-    deterministic ordering for readable ``/ready`` payloads and
-    audit logs).
+    Async probes are awaited directly; **synchronous** probes are run
+    via :func:`asyncio.to_thread` so a probe that does blocking I/O
+    cannot stall the event loop. Probes run sequentially in
+    registration order (parallelising readiness checks across
+    dependencies is a v0.2 optimisation; v0.1 favours deterministic
+    ordering for readable ``/ready`` payloads and audit logs), and the
+    returned list preserves that order.
+
+    Why off-load sync probes to a thread (the #1776 CI-hang root cause):
+    :func:`readiness_snapshot` wraps this sweep in
+    :func:`asyncio.wait_for` when called with ``timeout_s`` set (the
+    per-request UI hot path passes a short bound). ``wait_for`` can only
+    cancel an *awaiting* coroutine — it cannot interrupt a synchronous
+    call blocking the loop. A sync probe doing blocking network I/O
+    (the docs-backends probe is ``def``) would therefore defeat the
+    bound and hang every ``/ui/*`` render, which is exactly what
+    starved the CI unit-lane runner. Running the sync call on a worker
+    thread keeps the loop free, so ``wait_for`` fires for sync probes
+    too. On timeout ``wait_for`` cancels this coroutine; the orphaned
+    worker thread is not killed but finishes harmlessly in the
+    background, and the TTL cache + single-flight lock in
+    :func:`readiness_snapshot` cap how often a fresh sweep (and thus a
+    fresh thread) is spawned.
+
+    This also keeps ``/ready`` and the dashboard's fresh sweep from
+    blocking the loop on a slow sync probe — behaviour-preserving on
+    results, just non-loop-blocking.
     """
     results: list[ProbeResult] = []
     for _name, fn in _probes:
         if inspect.iscoroutinefunction(fn):
             results.append(await fn())
+            continue
+        # Synchronous probe: run the (possibly blocking) call on a
+        # worker thread so it cannot stall the event loop. ``fn`` is the
+        # ``ProbeFn`` union; ``iscoroutinefunction`` above excluded the
+        # ``async def`` arm, but mypy can't infer ``asyncio.to_thread``'s
+        # generic return type across a *union* of callables (it falls
+        # back to ``object``), so we cast to the sync arm — widened to
+        # also admit the defensive "mis-annotated probe returns an
+        # awaitable" case handled just below.
+        sync_fn = cast("Callable[[], ProbeResult | Awaitable[ProbeResult]]", fn)
+        value = await asyncio.to_thread(sync_fn)
+        # Defensive: a sync-typed callable that returned an awaitable
+        # (mis-annotated probe) gets awaited on the loop rather than
+        # silently dropped on the floor. The sync ``fn()`` ran in the
+        # thread; only the returned awaitable is awaited here.
+        if inspect.isawaitable(value):  # pragma: no cover — defensive
+            results.append(await value)
         else:
-            value = fn()
-            # Defensive: a sync-typed callable that returned an
-            # awaitable (mis-annotated probe) gets awaited rather
-            # than silently dropped on the floor.
-            if inspect.isawaitable(value):  # pragma: no cover — defensive
-                results.append(await value)
-            else:
-                results.append(value)
+            results.append(value)
     return results
 
 

--- a/backend/src/meho_backplane/ui/auth/middleware.py
+++ b/backend/src/meho_backplane/ui/auth/middleware.py
@@ -90,6 +90,7 @@ from starlette.types import ASGIApp, Receive, Scope, Send
 
 from meho_backplane.db.engine import get_sessionmaker
 from meho_backplane.db.models import Tenant
+from meho_backplane.health import readiness_snapshot
 from meho_backplane.ui.audit import bind_ui_view_audit
 from meho_backplane.ui.auth.routes import LOGIN_PATH, SESSION_COOKIE_NAME
 from meho_backplane.ui.auth.session_store import load_session
@@ -219,6 +220,33 @@ def _redirect_to_login(original_path_with_query: str) -> tuple[int, list[tuple[b
     ]
 
 
+async def _stash_ui_readiness(scope_state: dict[str, object], *, path: str) -> None:
+    """Stash the live backplane readiness verdict on the request scope.
+
+    The synchronous Jinja context processor
+    (:func:`~meho_backplane.ui.templating._ui_session_context_processor`)
+    colours ``base.html``'s sidebar-footer pill off ``request.state.ui_ready``
+    but cannot itself await the probe sweep. This middleware -- which
+    already runs once per ``/ui/*`` page render -- computes it here from a
+    short-TTL-cached :func:`~meho_backplane.health.readiness_snapshot`, so
+    the cost is at most one probe sweep per cache window across all
+    concurrent page loads (#1776).
+
+    A misbehaving probe must not 500 the page: on any exception out of
+    the sweep, degrade to ``False`` ("starting" -- the same fail-safe
+    default the processor uses when the key is unbound) and log, rather
+    than letting it propagate out of the render path.
+    """
+    try:
+        snapshot = await readiness_snapshot()
+        scope_state["ui_ready"] = bool(snapshot["ready"])
+    except Exception:  # pragma: no cover -- defensive
+        structlog.get_logger(__name__).warning(
+            "ui_readiness_snapshot_failed", path=path, exc_info=True
+        )
+        scope_state["ui_ready"] = False
+
+
 class UISessionMiddleware:
     """Pure-ASGI middleware: load operator identity from the session cookie.
 
@@ -231,6 +259,11 @@ class UISessionMiddleware:
     def __init__(self, app: ASGIApp) -> None:
         self.app = app
 
+    # Pre-existing 132-line / C901-13 ASGI dispatch handler (cookie-parse →
+    # session-load → readiness-stash → passthrough, read top-to-bottom).
+    # #1776 only adds one call to the extracted `_stash_ui_readiness`
+    # helper; splitting the request lifecycle is out of scope for a
+    # readiness-pill fix. code-quality-allow: pre-existing oversize handler
     async def __call__(self, scope: Scope, receive: Receive, send: Send) -> None:
         # Non-HTTP scopes (websocket, lifespan) pass through. The BFF
         # has no websocket surface in v0.2 and the lifespan must not
@@ -349,6 +382,7 @@ class UISessionMiddleware:
         scope_state = scope.setdefault("state", {})
         if isinstance(scope_state, dict):
             scope_state["ui_session"] = session_context
+            await _stash_ui_readiness(scope_state, path=path)
 
         # G0.15-T7 (#1216): bind audit contextvars per-request happens
         # later, inside :func:`require_ui_session` (the FastAPI

--- a/backend/src/meho_backplane/ui/auth/middleware.py
+++ b/backend/src/meho_backplane/ui/auth/middleware.py
@@ -90,7 +90,7 @@ from starlette.types import ASGIApp, Receive, Scope, Send
 
 from meho_backplane.db.engine import get_sessionmaker
 from meho_backplane.db.models import Tenant
-from meho_backplane.health import readiness_snapshot
+from meho_backplane.health import ui_readiness_verdict
 from meho_backplane.ui.audit import bind_ui_view_audit
 from meho_backplane.ui.auth.routes import LOGIN_PATH, SESSION_COOKIE_NAME
 from meho_backplane.ui.auth.session_store import load_session
@@ -123,13 +123,17 @@ AUTH_PREFIX: Final[str] = "/ui/auth/"
 #: CSS load without authentication -- otherwise the operator would
 #: see an unstyled login page when their session expires.
 STATIC_PREFIX: Final[str] = "/ui/static/"
-#: Upper bound (seconds) on the per-request readiness sweep run from
-#: :func:`_stash_ui_readiness`. Kept well under
+#: Upper bound (seconds) handed to
+#: :func:`~meho_backplane.health.ui_readiness_verdict` for the bounded
+#: sweeps it runs *off* the request path — the cold-cache first-warm
+#: sweep and every single-flight background refresh. The per-request path
+#: itself never runs a sweep (it reads the cached verdict, stale-while-
+#: revalidate), so this bound only caps how long a *cold-start* render
+#: waits and how long a background refresh runs; it no longer gates a
+#: per-request sweep. Kept well under
 #: :data:`~meho_backplane.health.DEFAULT_READINESS_TTL_S` (2.0s) so a
-#: slow/unreachable probe degrades the footer pill to "starting" within
-#: a fraction of a second rather than hanging the ``/ui/*`` render: the
-#: registry's probes do live network I/O, run sequentially, and have no
-#: internal timeout of their own (#1776).
+#: slow/unreachable probe degrades the footer pill to "starting" within a
+#: fraction of a second on the first paint rather than blocking it (#1776).
 _READINESS_TIMEOUT_S: Final[float] = 1.0
 
 
@@ -235,28 +239,31 @@ async def _stash_ui_readiness(scope_state: dict[str, object], *, path: str) -> N
     (:func:`~meho_backplane.ui.templating._ui_session_context_processor`)
     colours ``base.html``'s sidebar-footer pill off ``request.state.ui_ready``
     but cannot itself await the probe sweep. This middleware -- which
-    already runs once per ``/ui/*`` page render -- computes it here from a
-    short-TTL-cached :func:`~meho_backplane.health.readiness_snapshot`, so
-    the cost is at most one probe sweep per cache window across all
-    concurrent page loads (#1776).
+    already runs once per ``/ui/*`` page render -- reads the verdict here
+    from :func:`~meho_backplane.health.ui_readiness_verdict`, the
+    *stale-while-revalidate* hot-path accessor.
 
-    A misbehaving probe must not stall or 500 the page. The registry's
-    probes do live network I/O and run sequentially with no internal
-    timeout (the Keycloak probe in particular documents its timeout as a
-    deferred TODO), so an unreachable or black-holed dependency would
-    hang the render indefinitely on this hot path -- a hang is not an
-    exception, so the ``try``/``except`` below cannot catch it. We pass a
-    short ``timeout_s`` bound (well under
-    :data:`~meho_backplane.health.DEFAULT_READINESS_TTL_S`) so the sweep
-    degrades to not-ready ("starting") instead of blocking, and the
-    ``except`` still catches any probe that raises. Either way the pill
-    falls back to "starting" -- the same fail-safe default the processor
-    uses when the key is unbound -- rather than letting the failure
-    propagate out of the render path.
+    Crucially, that accessor **does not run a probe sweep on the request
+    path**: it returns the cached verdict immediately (refreshing it in a
+    single-flight background task when stale) and only ever sweeps inline
+    on the very first request, to warm a cold cache. That decoupling is
+    the #1776 fix -- the earlier design awaited the sweep on every render,
+    so under a black-holed dependency each request hit the timeout bound,
+    serialised through the readiness single-flight lock, and orphaned a
+    probe thread; hundreds of ``/ui/*`` requests then overran the CI unit
+    lane's hard job timeout. With the accessor the per-request cost is a
+    dict read regardless of probe health.
+
+    A misbehaving probe must still not stall or 500 the page. The cold-
+    cache warm sweep the accessor runs is bounded by ``timeout_s`` (a hang
+    is not an exception, so the ``try``/``except`` below could not catch
+    one), and the ``except`` still catches any probe that raises. Either
+    way the pill falls back to "starting" -- the same fail-safe default
+    the processor uses when the key is unbound -- rather than letting the
+    failure propagate out of the render path.
     """
     try:
-        snapshot = await readiness_snapshot(timeout_s=_READINESS_TIMEOUT_S)
-        scope_state["ui_ready"] = bool(snapshot["ready"])
+        scope_state["ui_ready"] = await ui_readiness_verdict(timeout_s=_READINESS_TIMEOUT_S)
     except Exception:  # pragma: no cover -- defensive
         structlog.get_logger(__name__).warning(
             "ui_readiness_snapshot_failed", path=path, exc_info=True

--- a/backend/src/meho_backplane/ui/auth/middleware.py
+++ b/backend/src/meho_backplane/ui/auth/middleware.py
@@ -123,6 +123,14 @@ AUTH_PREFIX: Final[str] = "/ui/auth/"
 #: CSS load without authentication -- otherwise the operator would
 #: see an unstyled login page when their session expires.
 STATIC_PREFIX: Final[str] = "/ui/static/"
+#: Upper bound (seconds) on the per-request readiness sweep run from
+#: :func:`_stash_ui_readiness`. Kept well under
+#: :data:`~meho_backplane.health.DEFAULT_READINESS_TTL_S` (2.0s) so a
+#: slow/unreachable probe degrades the footer pill to "starting" within
+#: a fraction of a second rather than hanging the ``/ui/*`` render: the
+#: registry's probes do live network I/O, run sequentially, and have no
+#: internal timeout of their own (#1776).
+_READINESS_TIMEOUT_S: Final[float] = 1.0
 
 
 @dataclass(frozen=True)
@@ -232,13 +240,22 @@ async def _stash_ui_readiness(scope_state: dict[str, object], *, path: str) -> N
     the cost is at most one probe sweep per cache window across all
     concurrent page loads (#1776).
 
-    A misbehaving probe must not 500 the page: on any exception out of
-    the sweep, degrade to ``False`` ("starting" -- the same fail-safe
-    default the processor uses when the key is unbound) and log, rather
-    than letting it propagate out of the render path.
+    A misbehaving probe must not stall or 500 the page. The registry's
+    probes do live network I/O and run sequentially with no internal
+    timeout (the Keycloak probe in particular documents its timeout as a
+    deferred TODO), so an unreachable or black-holed dependency would
+    hang the render indefinitely on this hot path -- a hang is not an
+    exception, so the ``try``/``except`` below cannot catch it. We pass a
+    short ``timeout_s`` bound (well under
+    :data:`~meho_backplane.health.DEFAULT_READINESS_TTL_S`) so the sweep
+    degrades to not-ready ("starting") instead of blocking, and the
+    ``except`` still catches any probe that raises. Either way the pill
+    falls back to "starting" -- the same fail-safe default the processor
+    uses when the key is unbound -- rather than letting the failure
+    propagate out of the render path.
     """
     try:
-        snapshot = await readiness_snapshot()
+        snapshot = await readiness_snapshot(timeout_s=_READINESS_TIMEOUT_S)
         scope_state["ui_ready"] = bool(snapshot["ready"])
     except Exception:  # pragma: no cover -- defensive
         structlog.get_logger(__name__).warning(

--- a/backend/src/meho_backplane/ui/routes/broadcast/feed.py
+++ b/backend/src/meho_backplane/ui/routes/broadcast/feed.py
@@ -278,11 +278,6 @@ async def _render_page(
         "operator_sub": session_ctx.operator_sub,
         "tenant_id": str(session_ctx.tenant_id),
         "csrf_token": csrf_token,
-        # ``base.html``'s footer reads ``ready`` to colour the readiness
-        # pill; the broadcast surface does not poll readiness (the
-        # dashboard owns that), so ship ``False`` so ``StrictUndefined``
-        # does not raise on the read.
-        "ready": False,
         **_feed_context(
             target_names=target_names,
             op_class=op_class,

--- a/backend/src/meho_backplane/ui/routes/connectors/detail.py
+++ b/backend/src/meho_backplane/ui/routes/connectors/detail.py
@@ -537,11 +537,6 @@ async def _render_detail(
         # affordance only surfaces to operators with the privilege.
         "is_tenant_admin": role_probe.is_tenant_admin,
         "csrf_token": csrf_token,
-        # The footer in ``base.html`` reads ``ready`` to colour the
-        # readiness pill; the connectors surface doesn't poll readiness
-        # itself, so ship ``False`` here so Jinja's ``StrictUndefined``
-        # env does not raise on the read.
-        "ready": False,
     }
     response = get_templates().TemplateResponse(request, "connectors/detail.html", context)
     response.set_cookie(

--- a/backend/src/meho_backplane/ui/routes/connectors/forms.py
+++ b/backend/src/meho_backplane/ui/routes/connectors/forms.py
@@ -260,7 +260,6 @@ def _build_form_context(csrf_token: str, *, mode: str) -> dict[str, object]:
     return {
         "page_title": "Connectors",
         "active_surface": "connectors",
-        "ready": False,
         "csrf_token": csrf_token,
         "mode": mode,
         "product_options": _product_options(),
@@ -480,7 +479,6 @@ async def render_delete_modal(
     context: dict[str, object] = {
         "page_title": "Targets",
         "active_surface": "connectors",
-        "ready": False,
         "csrf_token": csrf_token,
         "target": {"name": target.name},
         "graph_node_refs": graph_node_refs,

--- a/backend/src/meho_backplane/ui/routes/connectors/import_view.py
+++ b/backend/src/meho_backplane/ui/routes/connectors/import_view.py
@@ -375,7 +375,6 @@ def _render_inline_error(
         request,
         "connectors/_import_preview.html",
         {
-            "ready": False,
             "csrf_token": csrf_token,
             "error": message,
             "rows": [],
@@ -417,7 +416,6 @@ async def render_import_page(
         {
             "page_title": "Connectors",
             "active_surface": "connectors",
-            "ready": False,
             "csrf_token": csrf_token,
         },
     )
@@ -458,7 +456,6 @@ async def render_preview(
         request,
         "connectors/_import_preview.html",
         {
-            "ready": False,
             "csrf_token": csrf_token,
             "error": None,
             "rows": rows,
@@ -536,7 +533,6 @@ async def submit_confirm(
         request,
         "connectors/_import_result.html",
         {
-            "ready": False,
             "csrf_token": csrf_token,
             "created": created,
             "updated": updated,

--- a/backend/src/meho_backplane/ui/routes/connectors/list_view.py
+++ b/backend/src/meho_backplane/ui/routes/connectors/list_view.py
@@ -387,11 +387,6 @@ async def _render(
         # transient JWT-validation hiccup -- the write routes remain the
         # security authority.
         "is_tenant_admin": is_tenant_admin,
-        # The footer in ``base.html`` reads ``ready`` to colour the
-        # readiness pill; the connectors surface doesn't poll readiness
-        # (the dashboard owns that), so ship ``False`` here so Jinja's
-        # ``StrictUndefined`` env does not raise on the read.
-        "ready": False,
     }
     template_name = (
         "connectors/_table_rows.html" if _is_htmx_request(request) else "connectors/list.html"

--- a/backend/src/meho_backplane/ui/routes/dashboard.py
+++ b/backend/src/meho_backplane/ui/routes/dashboard.py
@@ -72,7 +72,7 @@ from typing import Final
 from fastapi import APIRouter, Depends, Request
 from fastapi.responses import HTMLResponse
 
-from meho_backplane.health import run_probes_async
+from meho_backplane.health import readiness_snapshot
 from meho_backplane.ui.auth.middleware import UISessionContext, require_ui_session
 from meho_backplane.ui.csrf import CSRF_COOKIE_NAME, mint_csrf_token
 from meho_backplane.ui.templating import get_templates
@@ -153,16 +153,17 @@ async def _readiness_snapshot() -> dict[str, object]:
     """Project the chassis readiness-probe results into the dashboard shape.
 
     Returns ``{"ready": bool, "checks": [{"name": ..., "ok": ..., "detail": ...}, ...]}``.
-    The shape mirrors the ``/ready`` endpoint payload so a future
-    "expanded readiness card" surface Initiative reuses the same
+    The shape mirrors the ``/ready`` endpoint payload so the dashboard's
+    detailed readiness card and the chassis footer pill read one
     contract.
+
+    Delegates to :func:`~meho_backplane.health.readiness_snapshot` with
+    ``max_age_s=0`` so the dashboard always runs a *fresh* probe sweep
+    (its pre-#1776 behaviour), rather than reading the short-TTL cache
+    the other surfaces share via the session middleware. The dashboard
+    owns the live readiness card, so freshness is the right trade here.
     """
-    results = await run_probes_async()
-    ready_ok = bool(results) and all(r.ok for r in results)
-    return {
-        "ready": ready_ok,
-        "checks": [{"name": r.name, "ok": r.ok, "detail": r.detail or ""} for r in results],
-    }
+    return await readiness_snapshot(max_age_s=0)
 
 
 async def _render_dashboard(
@@ -181,6 +182,15 @@ async def _render_dashboard(
     double-submit check.
     """
     readiness = await _readiness_snapshot()
+    # The chassis context processor injects ``ready`` into every render
+    # from ``request.state.ui_ready`` (the middleware's short-TTL-cached
+    # verdict) and -- because Starlette runs context processors after
+    # the route context -- it wins over the ``ready`` in ``context``
+    # below. Write the dashboard's own *fresh* verdict back to
+    # ``request.state.ui_ready`` so the processor re-injects that exact
+    # value: the footer pill and the dashboard's readiness card stay in
+    # lock-step, and the dashboard's behaviour is unchanged (#1776).
+    request.state.ui_ready = bool(readiness["ready"])
     csrf_token = mint_csrf_token(str(session.session_id))
     context = {
         "page_title": "Dashboard",

--- a/backend/src/meho_backplane/ui/routes/kb/routes.py
+++ b/backend/src/meho_backplane/ui/routes/kb/routes.py
@@ -320,6 +320,10 @@ def _filename_to_slug(filename: str) -> str:
     return slug[:200]
 
 
+# Pre-existing 556-line / C901-29 router factory that registers every
+# `/ui/kb*` route as a closure over shared deps. #1776 only *removes* three
+# `ready=False` literals from it (net smaller); splitting the factory is a
+# sibling-surface refactor out of scope. code-quality-allow: pre-existing oversize factory
 def build_kb_router() -> APIRouter:
     """Construct the ``/ui/kb*`` :class:`APIRouter`.
 
@@ -380,7 +384,6 @@ def build_kb_router() -> APIRouter:
             "csrf_token": csrf_token,
             "active_surface": "knowledge",
             "page_title": "Knowledge",
-            "ready": False,
         }
 
         if is_htmx:
@@ -470,7 +473,6 @@ def build_kb_router() -> APIRouter:
             "csrf_token": csrf_token,
             "active_surface": "knowledge",
             "page_title": "Upload · Knowledge",
-            "ready": False,
         }
         response = get_templates().TemplateResponse(request, "kb/upload.html", context)
         response.set_cookie(
@@ -528,7 +530,6 @@ def build_kb_router() -> APIRouter:
             "csrf_token": csrf_token,
             "active_surface": "knowledge",
             "page_title": f"{slug} · Knowledge",
-            "ready": False,
         }
         response = get_templates().TemplateResponse(request, "kb/detail.html", context)
         response.set_cookie(

--- a/backend/src/meho_backplane/ui/routes/memory/_modal_shared.py
+++ b/backend/src/meho_backplane/ui/routes/memory/_modal_shared.py
@@ -155,7 +155,6 @@ def build_common_template_context(
     return {
         "page_title": "Memory",
         "active_surface": "memory",
-        "ready": False,
         "operator_sub": session_ctx.operator_sub,
         "csrf_token": csrf_token,
     }

--- a/backend/src/meho_backplane/ui/routes/memory/views.py
+++ b/backend/src/meho_backplane/ui/routes/memory/views.py
@@ -308,7 +308,6 @@ def _common_template_context(
     return {
         "page_title": "Memory",
         "active_surface": "memory",
-        "ready": False,
         "operator_sub": session_ctx.operator_sub,
         "csrf_token": csrf_token,
     }

--- a/backend/src/meho_backplane/ui/routes/runbooks/editor.py
+++ b/backend/src/meho_backplane/ui/routes/runbooks/editor.py
@@ -459,7 +459,6 @@ def build_editor_context(
         "operator_sub": session.operator_sub,
         "active_surface": "runbooks",
         "page_title": "New runbook" if mode == "new" else f"Edit {slug}",
-        "ready": False,
     }
 
 

--- a/backend/src/meho_backplane/ui/routes/runbooks/routes.py
+++ b/backend/src/meho_backplane/ui/routes/runbooks/routes.py
@@ -292,7 +292,6 @@ async def _render_index(
         "csrf_token": csrf_token,
         "active_surface": "runbooks",
         "page_title": "Runbooks",
-        "ready": False,
     }
     if request.headers.get("HX-Request") == "true":
         return get_templates().TemplateResponse(request, "runbooks/_list.html", context)
@@ -376,7 +375,6 @@ async def _render_detail(
         "csrf_token": csrf_token,
         "active_surface": "runbooks",
         "page_title": f"{detail.template.slug} · Runbooks",
-        "ready": False,
     }
     response = get_templates().TemplateResponse(request, "runbooks/detail.html", context)
     _set_csrf_cookie(response, csrf_token)

--- a/backend/src/meho_backplane/ui/routes/stubs.py
+++ b/backend/src/meho_backplane/ui/routes/stubs.py
@@ -107,11 +107,6 @@ def _make_stub_handler(stub: _SurfaceStub) -> _StubHandler:
             # Highlights the matching sidebar link (base.html reads it;
             # the surface routes that replaced their stubs pass it too).
             "active_surface": stub.slug,
-            # ``base.html``'s sidebar status line reads ``ready`` to
-            # colour the readiness pill. Stubs do not poll readiness
-            # (the dashboard owns that surface) -- ship ``False`` so
-            # the ``StrictUndefined`` env does not raise on the read.
-            "ready": False,
         }
         response = get_templates().TemplateResponse(request, "_stub.html", context)
         response.set_cookie(

--- a/backend/src/meho_backplane/ui/routes/topology/graph.py
+++ b/backend/src/meho_backplane/ui/routes/topology/graph.py
@@ -379,10 +379,6 @@ def _build_template_context(
         # ``None`` surfaces to the template as an empty string --
         # Jinja's ``StrictUndefined`` env requires the key present.
         "selected_id": str(selected_id) if selected_id is not None else "",
-        # ``ready=False`` so ``base.html``'s footer pill stays the
-        # same colour as the table surface (the dashboard owns the
-        # readiness signal).
-        "ready": False,
     }
 
 
@@ -513,7 +509,6 @@ def _build_overlay_template_context(
         # so Jinja's ``StrictUndefined`` env does not raise on the
         # template read.
         "selected_id": "",
-        "ready": False,
         # Overlay-specific bindings the template renders only when
         # ``overlay_mode`` is set.
         "overlay_mode": overlay_mode,
@@ -842,7 +837,6 @@ def _render_overlay_error(
         "csrf_token": csrf_token,
         "error_status": status_code,
         "error_message": message,
-        "ready": False,
     }
     response = get_templates().TemplateResponse(
         request,

--- a/backend/src/meho_backplane/ui/routes/topology/table.py
+++ b/backend/src/meho_backplane/ui/routes/topology/table.py
@@ -241,11 +241,6 @@ async def _render_table(
         # string represents "no selection" so Jinja's ``StrictUndefined``
         # env does not raise on a missing-key read in the template.
         "selected_id": str(selected_id) if selected_id is not None else "",
-        # The footer in ``base.html`` reads ``ready`` to colour the
-        # readiness pill; topology does not poll readiness itself
-        # (the dashboard owns that surface), so ship ``False`` so
-        # the ``StrictUndefined`` env does not raise on the read.
-        "ready": False,
     }
     template_name = (
         "topology/_table_rows.html" if _is_htmx_request(request) else "topology/table.html"

--- a/backend/src/meho_backplane/ui/templating.py
+++ b/backend/src/meho_backplane/ui/templating.py
@@ -110,7 +110,7 @@ def get_jinja_env() -> Environment:
 
 
 def _ui_session_context_processor(request: Request) -> dict[str, Any]:
-    """Surface the active BFF session's tenant into every UI template.
+    """Surface the BFF session tenant + live readiness into every template.
 
     G0.15-T9 (#1217) — the operator-console header chip used to render a
     hard-coded "(sign in to choose)" placeholder regardless of whether
@@ -121,7 +121,7 @@ def _ui_session_context_processor(request: Request) -> dict[str, Any]:
     auto-selected at session-create time, so by the time any UI route
     renders a page the tenant is already known.
 
-    The context processor exposes one variable to every Jinja render:
+    The context processor exposes two variables to every Jinja render:
 
     * ``session_tenant`` -- a ``dict`` carrying ``id`` / ``slug`` /
       ``name``, or ``None`` when the request hit a surface where the
@@ -130,24 +130,47 @@ def _ui_session_context_processor(request: Request) -> dict[str, Any]:
       definition not signed in there). ``base.html``'s header chip
       conditionally renders the tenant name when this dict is present
       and falls back to a neutral "Sign in" link otherwise.
+    * ``ready`` -- the live backplane readiness verdict that colours
+      ``base.html``'s sidebar-footer pill (green "ready" vs yellow
+      "starting"). Every ``/ui/*`` surface used to hardcode
+      ``ready=False`` in its own context dict, so the pill was stuck on
+      "starting" on every page but the dashboard (#1776). The verdict
+      now comes from ``request.state.ui_ready``, computed once per
+      request by :class:`~meho_backplane.ui.auth.middleware.UISessionMiddleware`
+      from a short-TTL-cached :func:`~meho_backplane.health.readiness_snapshot`.
+      Because Starlette runs context processors *after* the route's own
+      context dict and ``dict.update``\\ s their output over it
+      (``starlette.templating.Jinja2Templates.TemplateResponse``), this
+      value wins over any stray per-route literal -- so the surfaces drop
+      theirs. The dashboard writes its own freshly-probed verdict back
+      to ``request.state.ui_ready`` so the processor re-injects the same
+      value and the dashboard's behaviour is unchanged.
+
+      The default is ``False`` ("starting"), the correct fail-safe when
+      no verdict is bound: the auth/static surfaces (no session
+      middleware), or a bare ``Environment.render`` outside the request
+      path. ``base.html`` reads ``ready`` under ``StrictUndefined``, so
+      the key must always be present.
 
     Synchronous by Starlette contract: context processors execute
     inside the synchronous ``Jinja2Templates.TemplateResponse`` call;
     asynchronous processors are explicitly not supported (see
-    https://www.starlette.io/templates/). The lookup here is a pure
-    attribute read off ``request.state`` -- the middleware already
-    paid the DB round-trip on its way in, so the processor itself
-    issues zero IO.
+    https://www.starlette.io/templates/). Both lookups here are pure
+    attribute reads off ``request.state`` -- the middleware already
+    paid the DB round-trip and the (cached) probe sweep on its way in,
+    so the processor itself issues zero IO.
     """
+    ready = bool(getattr(request.state, "ui_ready", False))
     session_ctx = getattr(request.state, "ui_session", None)
     if session_ctx is None:
-        return {"session_tenant": None}
+        return {"session_tenant": None, "ready": ready}
     return {
         "session_tenant": {
             "id": str(session_ctx.tenant_id),
             "slug": session_ctx.tenant_slug,
             "name": session_ctx.tenant_name,
         },
+        "ready": ready,
     }
 
 

--- a/backend/src/meho_backplane/ui/templating.py
+++ b/backend/src/meho_backplane/ui/templating.py
@@ -135,9 +135,11 @@ def _ui_session_context_processor(request: Request) -> dict[str, Any]:
       "starting"). Every ``/ui/*`` surface used to hardcode
       ``ready=False`` in its own context dict, so the pill was stuck on
       "starting" on every page but the dashboard (#1776). The verdict
-      now comes from ``request.state.ui_ready``, computed once per
+      now comes from ``request.state.ui_ready``, read once per
       request by :class:`~meho_backplane.ui.auth.middleware.UISessionMiddleware`
-      from a short-TTL-cached :func:`~meho_backplane.health.readiness_snapshot`.
+      from :func:`~meho_backplane.health.ui_readiness_verdict` -- the
+      stale-while-revalidate accessor that serves the cached verdict and
+      never runs a probe sweep on the request path.
       Because Starlette runs context processors *after* the route's own
       context dict and ``dict.update``\\ s their output over it
       (``starlette.templating.Jinja2Templates.TemplateResponse``), this

--- a/backend/tests/conftest.py
+++ b/backend/tests/conftest.py
@@ -709,6 +709,56 @@ def _isolate_global_registries() -> Iterator[None]:
         set_default_reducer(default_reducer)
 
 
+@pytest.fixture(autouse=True)
+def _isolate_readiness_state() -> Iterator[None]:
+    """Reset the readiness-probe registry + verdict cache around each test.
+
+    ``meho_backplane.health`` keeps two pieces of process-global mutable
+    state: the probe registry ``_probes`` (populated by
+    ``register_probe`` — the app lifespan in ``main.py`` registers the
+    real ``keycloak`` / ``vault`` / ``db`` / ``broadcast`` /
+    ``docs_backends`` probes there) and the ``_readiness_cache`` verdict
+    (plus its in-flight ``_readiness_refresh_task`` background handle).
+    Neither had a process-wide per-test reset, so any test that booted
+    the full app — directly or by importing ``meho_backplane.main`` —
+    left the real probes registered for whatever test the (xdist
+    ``--dist loadscope``) scheduler ran next on the same worker.
+
+    That cross-test leak is benign while readiness is only swept on an
+    explicit ``/ready`` hit, but #1776 made each ``/ui/*`` render schedule
+    a *background* readiness refresh (``ui_readiness_verdict`` ->
+    ``_schedule_readiness_refresh`` -> ``run_probes_async``). A leaked DB-
+    touching ``db`` probe then runs that sweep *concurrently* with a
+    later test's own SQLite writes, and aiosqlite reports
+    ``database is locked`` (it surfaced as a flake in
+    ``test_ui_runbooks_acceptance``). Pre-fix the sweep ran inline on the
+    request path, so a leaked probe merely slowed it rather than
+    contending.
+
+    Clearing (not snapshot/restoring like ``_isolate_global_registries``)
+    is correct here: probes are re-registered from scratch on every app
+    boot, so no test should depend on a probe registered by a *previous*
+    test — that would itself be a latent order-dependency bug.
+    ``clear_readiness_cache`` additionally cancels and detaches any
+    in-flight background refresh, so a sweep one test scheduled cannot
+    write into a sibling's cache or leak a pending task onto a
+    soon-to-close event loop. Reset both before *and* after so a test
+    that aborts mid-run cannot leak either. Redundant-but-harmless for
+    the handful of suites (``test_health``, ``test_alembic_probe``,
+    ``test_ui_readiness_pill``, ...) that already clear the registry
+    themselves.
+    """
+    from meho_backplane.health import clear_probes, clear_readiness_cache
+
+    clear_probes()
+    clear_readiness_cache()
+    try:
+        yield
+    finally:
+        clear_probes()
+        clear_readiness_cache()
+
+
 # ---------------------------------------------------------------------------
 # Shared JWT / JWKS helpers (lifted from tests/test_auth_jwt.py)
 # ---------------------------------------------------------------------------

--- a/backend/tests/test_ui_readiness_pill.py
+++ b/backend/tests/test_ui_readiness_pill.py
@@ -33,6 +33,7 @@ from __future__ import annotations
 
 import asyncio
 import re
+import time
 import uuid
 from collections.abc import Iterator
 from datetime import timedelta
@@ -260,6 +261,76 @@ async def test_snapshot_one_failing_probe_is_not_ready() -> None:
     assert snapshot["ready"] is False
 
 
+async def test_snapshot_timeout_degrades_to_not_ready_without_hanging() -> None:
+    """A probe slower than ``timeout_s`` degrades to not-ready, promptly.
+
+    The registry's real probes do live network I/O with no internal
+    timeout, so a blocked dependency would hang the per-request sweep
+    indefinitely (#1776 CI-unit-lane hang). ``timeout_s`` bounds it: the
+    call must return well inside the bound's slack with ``ready=False``
+    and a synthetic ``timeout`` check -- not raise, not block for the
+    probe's full sleep.
+    """
+
+    async def _slow_probe() -> ProbeResult:
+        await asyncio.sleep(5)  # >> the 0.1s bound below
+        return ProbeResult(name="slow", ok=True)
+
+    register_probe("slow", _slow_probe)
+    loop = asyncio.get_running_loop()
+    started = loop.time()
+    snapshot = await readiness_snapshot(max_age_s=0, timeout_s=0.1)
+    elapsed = loop.time() - started
+
+    assert snapshot["ready"] is False
+    assert snapshot["checks"] == [
+        {"name": "timeout", "ok": False, "detail": "readiness probe sweep exceeded 0.1s"}
+    ]
+    # Returned on the timeout, not after the probe's 5s sleep.
+    assert elapsed < 2.0, f"sweep should bail at the bound, took {elapsed:.2f}s"
+
+
+async def test_snapshot_timeout_is_not_cached() -> None:
+    """A timed-out sweep must not pin a misleading verdict for the TTL.
+
+    Caching the not-ready timeout result would lock the pill to
+    "starting" for the whole window even after the dependency recovers.
+    The next caller must re-run the sweep; here a fast probe registered
+    after the timeout is seen immediately on a cached (``max_age_s>0``)
+    read, proving nothing was cached by the timed-out call.
+    """
+
+    async def _slow_probe() -> ProbeResult:
+        await asyncio.sleep(5)
+        return ProbeResult(name="slow", ok=True)
+
+    register_probe("slow", _slow_probe)
+    timed_out = await readiness_snapshot(max_age_s=60, timeout_s=0.1)
+    assert timed_out["ready"] is False
+
+    clear_probes()
+    register_probe("vault", lambda: ProbeResult(name="vault", ok=True))
+    # max_age_s=60 would serve a cached verdict had the timeout cached one;
+    # instead it runs a fresh sweep and sees the healthy probe.
+    after = await readiness_snapshot(max_age_s=60)
+    assert after["ready"] is True, "timed-out verdict must not have been cached"
+
+
+async def test_snapshot_unbounded_default_preserves_dashboard_path() -> None:
+    """``timeout_s=None`` (default) leaves the sweep unbounded.
+
+    ``GET /ready`` and the dashboard (``max_age_s=0``) rely on the
+    unbounded sweep; this guards that a fast probe set still produces a
+    cached verdict identical to the pre-#1776 behaviour when no bound is
+    passed.
+    """
+    register_probe("vault", lambda: ProbeResult(name="vault", ok=True))
+    register_probe("db", lambda: ProbeResult(name="db", ok=True))
+    snapshot = await readiness_snapshot(max_age_s=0)
+    assert snapshot["ready"] is True
+    assert [c["name"] for c in snapshot["checks"]] == ["vault", "db"]  # type: ignore[index,union-attr]
+
+
 async def test_snapshot_serves_cached_verdict_within_ttl() -> None:
     """A cached verdict younger than the window is served without re-probing.
 
@@ -371,6 +442,46 @@ def test_non_dashboard_pill_is_starting_with_empty_registry() -> None:
         mock.stop()
     assert response.status_code == 200, response.text
     assert _pill_state(response.text) == ("bg-warning", "starting")
+
+
+def test_non_dashboard_pill_is_starting_when_probe_hangs(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """A hung probe degrades the render to "starting" instead of hanging it.
+
+    Regression for the #1776 CI-unit-lane hang: moving the readiness
+    sweep into the per-request middleware made every ``/ui/*`` render
+    block on a slow/black-holed probe (no internal timeout on the real
+    Keycloak/Vault/DB probes). The middleware now bounds the sweep, so a
+    probe that sleeps far longer than the bound must still let the page
+    render **promptly** with the fail-safe "starting" pill rather than
+    starving the request. The bound is shrunk here so the assertion runs
+    fast.
+    """
+    from meho_backplane.ui.auth import middleware as ui_middleware
+
+    monkeypatch.setattr(ui_middleware, "_READINESS_TIMEOUT_S", 0.1)
+
+    async def _hung_probe() -> ProbeResult:
+        await asyncio.sleep(10)  # >> the 0.1s bound; would hang the render pre-fix
+        return ProbeResult(name="keycloak", ok=True)
+
+    register_probe("keycloak", _hung_probe)
+    _seed_tenant(_TENANT_A, "tenant-a")
+    session_id = _seed_session_sync(tenant_id=_TENANT_A, operator_sub=_OP_A)
+    client, mock = _authenticated_client(session_id)
+    loop_start = time.monotonic()
+    try:
+        response = client.get("/ui/memory")
+    finally:
+        mock.stop()
+    elapsed = time.monotonic() - loop_start
+
+    assert response.status_code == 200, response.text
+    assert "<title>Memory" in response.text
+    assert _pill_state(response.text) == ("bg-warning", "starting")
+    # The render returned on the readiness bound, not the probe's 10s sleep.
+    assert elapsed < 5.0, f"render should not block on the hung probe, took {elapsed:.2f}s"
 
 
 def test_dashboard_pill_follows_probe_state_unchanged() -> None:

--- a/backend/tests/test_ui_readiness_pill.py
+++ b/backend/tests/test_ui_readiness_pill.py
@@ -1,0 +1,395 @@
+# SPDX-License-Identifier: Apache-2.0
+# Copyright (c) 2026 evoila Group
+
+"""Readiness-pill tests for the operator-console chassis (G10.7-T1, #1776).
+
+The sidebar-footer readiness pill in ``base.html`` colours ``bg-success``
+/ "ready" vs ``bg-warning`` / "starting" off the ``ready`` template
+variable. Before #1776 only the dashboard computed it; every other
+``/ui/*`` surface hardcoded ``ready=False`` in its own context dict, so
+the pill was stuck on yellow "starting" on every page but the dashboard
+regardless of actual backend health.
+
+The fix injects the live verdict into *every* render from
+``request.state.ui_ready`` -- a short-TTL-cached
+:func:`~meho_backplane.health.readiness_snapshot` computed once per
+request by :class:`~meho_backplane.ui.auth.middleware.UISessionMiddleware`
+and read by the synchronous chassis context processor
+(:func:`~meho_backplane.ui.templating._ui_session_context_processor`).
+
+This suite covers three layers:
+
+* The cached snapshot helper itself -- fail-closed empty registry, the
+  TTL window, and ``max_age_s=0`` force-fresh (the dashboard's path).
+* The context processor's injection + fail-safe default.
+* The acceptance criterion end-to-end: rendering a **non-dashboard**
+  surface (``GET /ui/memory``) through the full TestClient chassis shows
+  green "ready" when the registered probes pass and yellow "starting"
+  when a probe fails -- proving the pill reflects readiness rather than a
+  hardcoded ``False`` -- while the dashboard's behaviour is unchanged.
+"""
+
+from __future__ import annotations
+
+import asyncio
+import re
+import uuid
+from collections.abc import Iterator
+from datetime import timedelta
+from typing import Any
+
+import pytest
+import respx
+from cryptography.fernet import Fernet
+from fastapi import FastAPI
+from fastapi.staticfiles import StaticFiles
+from fastapi.testclient import TestClient
+from starlette.requests import Request
+
+from meho_backplane.auth.jwt import clear_jwks_cache
+from meho_backplane.db.engine import get_sessionmaker, reset_engine_for_testing
+from meho_backplane.db.models import Tenant
+from meho_backplane.health import (
+    ProbeResult,
+    clear_probes,
+    clear_readiness_cache,
+    readiness_snapshot,
+    register_probe,
+)
+from meho_backplane.settings import get_settings
+from meho_backplane.ui.auth import SESSION_COOKIE_NAME, UISessionMiddleware
+from meho_backplane.ui.auth import build_router as build_ui_auth_router
+from meho_backplane.ui.auth.flow import (
+    clear_discovery_cache,
+    reset_verifier_store_for_testing,
+)
+from meho_backplane.ui.auth.session_store import (
+    create_session,
+    reset_fernet_cache_for_testing,
+)
+from meho_backplane.ui.csrf import CSRFMiddleware
+from meho_backplane.ui.paths import static_root_dir
+from meho_backplane.ui.routes import build_router as build_ui_router
+from meho_backplane.ui.templating import (
+    _ui_session_context_processor,
+    reset_templating_for_testing,
+)
+from tests._oidc_jwt_helpers import AUDIENCE as _DEFAULT_AUDIENCE
+from tests._oidc_jwt_helpers import ISSUER as _DEFAULT_ISSUER
+from tests._oidc_jwt_helpers import make_rsa_keypair as _make_rsa_keypair
+from tests._oidc_jwt_helpers import mock_discovery_and_jwks as _mock_discovery_and_jwks
+from tests._oidc_jwt_helpers import public_jwks as _public_jwks
+
+_BACKPLANE_URL = "https://meho.test"
+_TENANT_A = uuid.UUID("11111111-1111-1111-1111-111111111111")
+_OP_A = "op-alice"
+
+
+@pytest.fixture(autouse=True)
+def _bff_env(monkeypatch: pytest.MonkeyPatch) -> Iterator[None]:
+    """Pin chassis + BFF env vars; mirrors the other UI surface suites."""
+    monkeypatch.setenv("KEYCLOAK_ISSUER_URL", _DEFAULT_ISSUER)
+    monkeypatch.setenv("KEYCLOAK_AUDIENCE", _DEFAULT_AUDIENCE)
+    monkeypatch.setenv("VAULT_ADDR", "https://vault.test")
+    monkeypatch.setenv("BACKPLANE_URL", _BACKPLANE_URL)
+    monkeypatch.setenv("UI_SESSION_ENCRYPTION_KEY", Fernet.generate_key().decode())
+    monkeypatch.setenv("UI_KEYCLOAK_CLIENT_ID", "meho-web")
+    monkeypatch.setenv("UI_KEYCLOAK_CLIENT_SECRET", "test-client-secret")
+    get_settings.cache_clear()
+    reset_fernet_cache_for_testing()
+    reset_verifier_store_for_testing()
+    reset_templating_for_testing()
+    clear_discovery_cache()
+    clear_jwks_cache()
+    reset_engine_for_testing()
+    yield
+    get_settings.cache_clear()
+    reset_fernet_cache_for_testing()
+    reset_verifier_store_for_testing()
+    reset_templating_for_testing()
+    clear_discovery_cache()
+    clear_jwks_cache()
+    reset_engine_for_testing()
+
+
+@pytest.fixture(autouse=True)
+def _isolated_readiness() -> Iterator[None]:
+    """Reset the probe registry + cached snapshot around every test.
+
+    Both are process globals; without this a probe set or a cached
+    verdict from one test leaks into the next on the same xdist worker
+    (run-order becomes load-bearing). Clear before *and* after so a
+    mid-test abort can't poison a sibling.
+    """
+    clear_probes()
+    clear_readiness_cache()
+    yield
+    clear_probes()
+    clear_readiness_cache()
+
+
+def _build_app() -> FastAPI:
+    """Construct a minimal FastAPI app with the full UI chassis wired in.
+
+    Mirrors the production wiring + the other surface suites: StaticFiles
+    at ``/ui/static``, BFF auth router + UI surface router,
+    ``UISessionMiddleware`` outermost + ``CSRFMiddleware`` next.
+    """
+    app = FastAPI()
+    app.add_middleware(CSRFMiddleware)
+    app.add_middleware(UISessionMiddleware)
+    app.mount(
+        "/ui/static",
+        StaticFiles(directory=str(static_root_dir()), check_dir=False),
+        name="ui_static",
+    )
+    app.include_router(build_ui_auth_router())
+    app.include_router(build_ui_router())
+    return app
+
+
+def _seed_tenant(tenant_id: uuid.UUID, slug: str) -> None:
+    """Insert one ``tenant`` row so the session's tenant FK resolves."""
+
+    async def _do() -> None:
+        sessionmaker = get_sessionmaker()
+        async with sessionmaker() as session, session.begin():
+            session.add(Tenant(id=tenant_id, slug=slug, name=f"Tenant {slug}"))
+
+    asyncio.run(_do())
+
+
+def _seed_session_sync(
+    *,
+    tenant_id: uuid.UUID,
+    operator_sub: str,
+    lifetime: timedelta = timedelta(hours=1),
+) -> uuid.UUID:
+    """Create a ``web_session`` row directly and return its UUID."""
+
+    async def _do() -> uuid.UUID:
+        sessionmaker = get_sessionmaker()
+        async with sessionmaker() as session, session.begin():
+            decrypted = await create_session(
+                session,
+                operator_sub=operator_sub,
+                tenant_id=tenant_id,
+                access_token="access-token-plaintext",
+                refresh_token="refresh-token-plaintext",
+                lifetime=lifetime,
+            )
+            return decrypted.id
+
+    return asyncio.run(_do())
+
+
+def _jwks() -> dict[str, Any]:
+    """Mint a JWKS document for the discovery/JWKS respx stub.
+
+    The ``GET /ui/memory`` list render only needs the session cookie
+    (``require_ui_session``); no token is presented. The stub keeps the
+    auth router happy if any transitive lookup touches discovery.
+    """
+    import warnings
+
+    with warnings.catch_warnings():
+        warnings.simplefilter("ignore")
+        keypair = _make_rsa_keypair("ui-readiness-test-kid")
+    return _public_jwks(keypair)
+
+
+def _authenticated_client(session_id: uuid.UUID) -> tuple[TestClient, respx.MockRouter]:
+    """Return a TestClient with the session cookie + an open respx mock."""
+    mock = respx.mock(assert_all_called=False)
+    mock.start()
+    _mock_discovery_and_jwks(mock, _jwks())
+    client = TestClient(_build_app(), follow_redirects=False)
+    client.cookies.set(SESSION_COOKIE_NAME, str(session_id))
+    return client, mock
+
+
+def _pill_state(html: str) -> tuple[str | None, str | None]:
+    """Extract the footer pill's ``(colour-class, label)`` from rendered HTML.
+
+    ``base.html`` renders the dot as
+    ``rounded-full {bg-success|bg-warning}`` and the label as a
+    ``<span>{ready|starting}</span>``. Returning both lets a test assert
+    the pill reflects readiness end-to-end rather than trusting a single
+    substring that could appear elsewhere on the page.
+    """
+    colour = re.search(r"rounded-full\s+(bg-success|bg-warning)", html)
+    label = re.search(r"<span>(ready|starting)</span>", html)
+    return (colour.group(1) if colour else None, label.group(1) if label else None)
+
+
+def _make_request(state: dict[str, Any]) -> Request:
+    """Build a bare ``/ui/*`` GET request carrying *state* on its scope."""
+    return Request(
+        {"type": "http", "method": "GET", "path": "/ui/memory", "headers": [], "state": state}
+    )
+
+
+# ---------------------------------------------------------------------------
+# Cached readiness snapshot helper
+# ---------------------------------------------------------------------------
+
+
+async def test_snapshot_empty_registry_is_not_ready() -> None:
+    """An empty probe registry fails closed (``all([])`` is vacuously True)."""
+    snapshot = await readiness_snapshot(max_age_s=0)
+    assert snapshot == {"ready": False, "checks": []}
+
+
+async def test_snapshot_all_passing_is_ready_with_checks() -> None:
+    """Every probe ``ok`` -> ready, and the checks detail mirrors ``/ready``."""
+    register_probe("vault", lambda: ProbeResult(name="vault", ok=True, detail="auth ok"))
+    register_probe("db", lambda: ProbeResult(name="db", ok=True))
+    snapshot = await readiness_snapshot(max_age_s=0)
+    assert snapshot["ready"] is True
+    assert snapshot["checks"] == [
+        {"name": "vault", "ok": True, "detail": "auth ok"},
+        {"name": "db", "ok": True, "detail": ""},
+    ]
+
+
+async def test_snapshot_one_failing_probe_is_not_ready() -> None:
+    """A single failing probe flips the verdict to not-ready."""
+    register_probe("vault", lambda: ProbeResult(name="vault", ok=True))
+    register_probe("db", lambda: ProbeResult(name="db", ok=False, detail="migration pending"))
+    snapshot = await readiness_snapshot(max_age_s=0)
+    assert snapshot["ready"] is False
+
+
+async def test_snapshot_serves_cached_verdict_within_ttl() -> None:
+    """A cached verdict younger than the window is served without re-probing.
+
+    Registering a *failing* probe after a healthy snapshot is cached must
+    not change the cached read (the cache is the whole point of the hot
+    path), while ``max_age_s=0`` forces a fresh sweep that sees it.
+    """
+    register_probe("vault", lambda: ProbeResult(name="vault", ok=True))
+    first = await readiness_snapshot(max_age_s=60)
+    assert first["ready"] is True
+
+    register_probe("db", lambda: ProbeResult(name="db", ok=False))
+    cached = await readiness_snapshot(max_age_s=60)
+    assert cached["ready"] is True, "stale-but-fresh-enough cache must be served"
+
+    fresh = await readiness_snapshot(max_age_s=0)
+    assert fresh["ready"] is False, "max_age_s=0 must bypass the cache"
+
+
+# ---------------------------------------------------------------------------
+# Context processor injection
+# ---------------------------------------------------------------------------
+
+
+def test_processor_injects_ready_true_from_state() -> None:
+    """``request.state.ui_ready=True`` surfaces as ``ready=True``."""
+    ctx = _ui_session_context_processor(_make_request({"ui_ready": True}))
+    assert ctx["ready"] is True
+
+
+def test_processor_injects_ready_false_from_state() -> None:
+    """``request.state.ui_ready=False`` surfaces as ``ready=False``."""
+    ctx = _ui_session_context_processor(_make_request({"ui_ready": False}))
+    assert ctx["ready"] is False
+
+
+def test_processor_defaults_to_starting_when_unbound() -> None:
+    """No bound verdict (auth/static surfaces) fails safe to ``ready=False``.
+
+    ``base.html`` reads ``ready`` under ``StrictUndefined``, so the key
+    must always be present even when the middleware never ran.
+    """
+    ctx = _ui_session_context_processor(_make_request({}))
+    assert ctx["ready"] is False
+    assert ctx["session_tenant"] is None
+
+
+# ---------------------------------------------------------------------------
+# Acceptance criterion: the pill reflects readiness on a NON-dashboard route
+# ---------------------------------------------------------------------------
+
+
+def test_non_dashboard_pill_is_ready_when_backend_healthy() -> None:
+    """``GET /ui/memory`` shows green "ready" when the readiness probes pass.
+
+    The memory surface used to hardcode ``ready=False``; this asserts the
+    pill now reflects the live verdict (#1776). A healthy backend == every
+    registered probe ``ok``, the same condition ``GET /ready`` returns 200
+    on.
+    """
+    register_probe("vault", lambda: ProbeResult(name="vault", ok=True))
+    register_probe("db", lambda: ProbeResult(name="db", ok=True))
+    _seed_tenant(_TENANT_A, "tenant-a")
+    session_id = _seed_session_sync(tenant_id=_TENANT_A, operator_sub=_OP_A)
+    client, mock = _authenticated_client(session_id)
+    try:
+        response = client.get("/ui/memory")
+    finally:
+        mock.stop()
+    assert response.status_code == 200, response.text
+    # Sanity: this is the memory surface, not the dashboard.
+    assert "<title>Memory" in response.text
+    assert _pill_state(response.text) == ("bg-success", "ready")
+
+
+def test_non_dashboard_pill_is_starting_when_backend_not_ready() -> None:
+    """``GET /ui/memory`` shows yellow "starting" when ``/ready`` would 503.
+
+    A failing probe is the not-ready condition (``/ready`` returns 503);
+    the pill must follow it on a non-dashboard surface rather than being
+    pinned to a hardcoded value.
+    """
+    register_probe("vault", lambda: ProbeResult(name="vault", ok=True))
+    register_probe("db", lambda: ProbeResult(name="db", ok=False, detail="migration pending"))
+    _seed_tenant(_TENANT_A, "tenant-a")
+    session_id = _seed_session_sync(tenant_id=_TENANT_A, operator_sub=_OP_A)
+    client, mock = _authenticated_client(session_id)
+    try:
+        response = client.get("/ui/memory")
+    finally:
+        mock.stop()
+    assert response.status_code == 200, response.text
+    assert "<title>Memory" in response.text
+    assert _pill_state(response.text) == ("bg-warning", "starting")
+
+
+def test_non_dashboard_pill_is_starting_with_empty_registry() -> None:
+    """An empty probe registry (fail-closed) renders "starting", not "ready".
+
+    Guards the vacuous-``all([])`` trap end-to-end through the render
+    path: zero probes must not flip the pill green.
+    """
+    _seed_tenant(_TENANT_A, "tenant-a")
+    session_id = _seed_session_sync(tenant_id=_TENANT_A, operator_sub=_OP_A)
+    client, mock = _authenticated_client(session_id)
+    try:
+        response = client.get("/ui/memory")
+    finally:
+        mock.stop()
+    assert response.status_code == 200, response.text
+    assert _pill_state(response.text) == ("bg-warning", "starting")
+
+
+def test_dashboard_pill_follows_probe_state_unchanged() -> None:
+    """The dashboard pill still reflects a fresh probe sweep (behaviour unchanged).
+
+    The dashboard computes its own verdict and writes it to
+    ``request.state.ui_ready`` so the context processor re-injects the
+    same value; the footer pill and the dashboard's readiness card stay
+    in lock-step. This asserts the dashboard remains correct after the
+    context-processor change.
+    """
+    register_probe("vault", lambda: ProbeResult(name="vault", ok=True))
+    register_probe("db", lambda: ProbeResult(name="db", ok=True))
+    _seed_tenant(_TENANT_A, "tenant-a")
+    session_id = _seed_session_sync(tenant_id=_TENANT_A, operator_sub=_OP_A)
+    client, mock = _authenticated_client(session_id)
+    try:
+        response = client.get("/ui/")
+    finally:
+        mock.stop()
+    assert response.status_code == 200, response.text
+    assert _pill_state(response.text) == ("bg-success", "ready")

--- a/backend/tests/test_ui_readiness_pill.py
+++ b/backend/tests/test_ui_readiness_pill.py
@@ -33,6 +33,7 @@ from __future__ import annotations
 
 import asyncio
 import re
+import threading
 import time
 import uuid
 from collections.abc import Iterator
@@ -632,3 +633,119 @@ def test_dashboard_pill_follows_probe_state_unchanged() -> None:
         mock.stop()
     assert response.status_code == 200, response.text
     assert _pill_state(response.text) == ("bg-success", "ready")
+
+
+async def test_sequential_ui_requests_do_not_serialise_on_a_blocking_probe(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """N ``/ui/*`` renders stay fast + sweep a bounded number of times.
+
+    This is the load-bearing regression for the #1776 CI-unit-lane
+    overrun. The earlier design awaited the probe sweep **inline** on
+    every ``/ui/*`` render. Under a black-holed dependency each sweep hit
+    the timeout bound, the timeout verdict was **not** cached, so every
+    subsequent request re-swept — serialised through the readiness
+    single-flight lock and orphaning a probe-worker thread each time.
+    Hundreds of UI tests x ~1 s serialised + thread accumulation overran
+    the unit lane's hard job-timeout cap (it died at ~15 min on every
+    run; the local sweep passed only because ``ECONNREFUSED`` fails fast).
+
+    The fix decouples the request path from probe execution
+    (stale-while-revalidate): the hot-path accessor
+    (:func:`~meho_backplane.health.ui_readiness_verdict`) returns the
+    cached verdict immediately and refreshes it in a single-flight
+    background task; only the first-ever request warms a cold cache with
+    one bounded sweep. So N sequential requests against a blocking probe
+    must (a) complete in well under N x the bound — they don't serialise —
+    and (b) invoke the probe only a small constant number of times
+    (warm + at most one background refresh in flight), not once per
+    request.
+
+    Driven through ``httpx.ASGITransport`` on this test's persistent event
+    loop rather than ``TestClient`` — ``TestClient``'s blocking portal
+    joins the orphaned ``asyncio.to_thread`` future before returning,
+    which would inflate the test's wall-clock to the probe's full sleep
+    (a harness artifact, not a property of the production hot path).
+
+    On the pre-fix head (``fb725e5d``) this FAILS: with the timeout
+    verdict never cached, all N renders re-sweep and the wall-time
+    balloons to ≈ N x the bound (blowing the time assertion) while the
+    probe is invoked once per request (blowing the invocation assertion).
+    """
+    from meho_backplane.ui.auth import middleware as ui_middleware
+
+    # Shrink the per-sweep bound so the test runs fast; on the pre-fix
+    # head N renders each pay this bound serially.
+    bound = 0.1
+    monkeypatch.setattr(ui_middleware, "_READINESS_TIMEOUT_S", bound)
+
+    invocations = 0
+    invocations_lock = threading.Lock()
+
+    def _blocking_sync_probe() -> ProbeResult:
+        # The probe runs on a worker thread (``asyncio.to_thread``); guard
+        # the counter so concurrent sweeps can't race the increment.
+        nonlocal invocations
+        with invocations_lock:
+            invocations += 1
+        time.sleep(10)  # >> the bound and the TTL: a black-holed dependency
+        return ProbeResult(name="docs_backends", ok=True)
+
+    register_probe("docs_backends", _blocking_sync_probe)
+
+    # Seed inline with ``await`` (this test runs on the pytest-asyncio
+    # loop; ``asyncio.run`` cannot be re-entered from a running loop).
+    sessionmaker = get_sessionmaker()
+    async with sessionmaker() as session, session.begin():
+        session.add(Tenant(id=_TENANT_A, slug="tenant-a", name="Tenant tenant-a"))
+    async with sessionmaker() as session, session.begin():
+        decrypted = await create_session(
+            session,
+            operator_sub=_OP_A,
+            tenant_id=_TENANT_A,
+            access_token="access-token-plaintext",
+            refresh_token="refresh-token-plaintext",
+            lifetime=timedelta(hours=1),
+        )
+        session_id = decrypted.id
+
+    mock = respx.mock(assert_all_called=False)
+    mock.start()
+    _mock_discovery_and_jwks(mock, _jwks())
+    transport = httpx.ASGITransport(app=_build_app())
+    n_requests = 30
+    loop = asyncio.get_running_loop()
+    started = loop.time()
+    try:
+        async with httpx.AsyncClient(
+            transport=transport,
+            base_url=_BACKPLANE_URL,
+            cookies={SESSION_COOKIE_NAME: str(session_id)},
+            follow_redirects=False,
+        ) as client:
+            for _ in range(n_requests):
+                response = await client.get("/ui/memory")
+                assert response.status_code == 200, response.text
+                # Every render is a valid pill state; a blocking probe
+                # never resolves, so the verdict is "starting".
+                assert _pill_state(response.text) == ("bg-warning", "starting")
+    finally:
+        mock.stop()
+    elapsed = loop.time() - started
+
+    # (a) The N renders did NOT serialise on the sweep. Pre-fix this is
+    # ≈ N x bound (= 3.0 s here); the cached-verdict hot path keeps it to
+    # a small constant (one cold-warm sweep + cheap dict reads).
+    assert elapsed < 2.0, (
+        f"{n_requests} renders should not serialise on the blocking probe; "
+        f"took {elapsed:.2f}s (≈Nxbound={n_requests * bound:.1f}s would mean inline re-sweeps)"
+    )
+    # (b) Single-flight + caching bound the probe invocations to a small
+    # constant — NOT once per request. Pre-fix the probe runs ~N times
+    # (one inline sweep per render). Allow a little slack for the cold
+    # warm plus at most a couple of background refreshes that may start
+    # before the cache is consulted again.
+    assert invocations <= 4, (
+        f"probe should be swept a small constant number of times "
+        f"(single-flight + cache), got {invocations} for {n_requests} requests"
+    )

--- a/backend/tests/test_ui_readiness_pill.py
+++ b/backend/tests/test_ui_readiness_pill.py
@@ -39,6 +39,7 @@ from collections.abc import Iterator
 from datetime import timedelta
 from typing import Any
 
+import httpx
 import pytest
 import respx
 from cryptography.fernet import Fernet
@@ -290,6 +291,45 @@ async def test_snapshot_timeout_degrades_to_not_ready_without_hanging() -> None:
     assert elapsed < 2.0, f"sweep should bail at the bound, took {elapsed:.2f}s"
 
 
+async def test_snapshot_timeout_bounds_a_blocking_sync_probe() -> None:
+    """A **synchronous** probe that blocks is bounded by ``timeout_s`` too.
+
+    Regression for the #1776 CI-unit-lane hang's true root cause: the
+    first fix bounded the sweep with :func:`asyncio.wait_for`, but
+    ``wait_for`` can only cancel an *awaiting* coroutine -- it cannot
+    interrupt a synchronous call blocking the event loop. The
+    docs-backends probe (and the Keycloak/Vault sync probes) are ``def``;
+    a slow/black-holed sync probe therefore defeated the bound and hung
+    every ``/ui/*`` render, starving the CI runner. The sweep now runs
+    sync probes on a worker thread (:func:`asyncio.to_thread`), so the
+    bound fires for them as well: this must return well inside the bound
+    with ``ready=False`` and the synthetic ``timeout`` check, NOT block
+    for the probe's full sleep.
+
+    This test FAILS on the pre-thread fix (the ``time.sleep`` blocks the
+    loop for its full duration, so ``elapsed`` >> the bound) and PASSES
+    once sync probes are off-loaded to a thread.
+    """
+
+    def _slow_sync_probe() -> ProbeResult:
+        time.sleep(3)  # blocking I/O surrogate; >> the 0.2s bound below
+        return ProbeResult(name="slow_sync", ok=True)
+
+    register_probe("slow_sync", _slow_sync_probe)
+    loop = asyncio.get_running_loop()
+    started = loop.time()
+    snapshot = await readiness_snapshot(max_age_s=0, timeout_s=0.2)
+    elapsed = loop.time() - started
+
+    assert snapshot["ready"] is False
+    assert snapshot["checks"] == [
+        {"name": "timeout", "ok": False, "detail": "readiness probe sweep exceeded 0.2s"}
+    ]
+    # Returned on the timeout bound, not after the sync probe's 3s sleep.
+    # The whole point: a blocking sync probe must not stall the loop.
+    assert elapsed < 1.0, f"blocking sync probe should bail at the bound, took {elapsed:.2f}s"
+
+
 async def test_snapshot_timeout_is_not_cached() -> None:
     """A timed-out sweep must not pin a misleading verdict for the TTL.
 
@@ -482,6 +522,94 @@ def test_non_dashboard_pill_is_starting_when_probe_hangs(
     assert _pill_state(response.text) == ("bg-warning", "starting")
     # The render returned on the readiness bound, not the probe's 10s sleep.
     assert elapsed < 5.0, f"render should not block on the hung probe, took {elapsed:.2f}s"
+
+
+async def test_non_dashboard_pill_is_starting_when_sync_probe_blocks(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """A blocking **synchronous** probe degrades the render to "starting".
+
+    The true #1776 CI-hang regression. ``asyncio.wait_for`` (the first
+    fix's bound) can only cancel an *awaiting* coroutine -- it cannot
+    interrupt a synchronous call blocking the event loop. So a
+    slow/black-holed **sync** probe -- the shape the docs-backends and
+    Keycloak/Vault probes actually use -- still hung every ``/ui/*``
+    render and starved the CI runner, even with the bound in place. The
+    sweep now runs sync probes on a worker thread
+    (:func:`asyncio.to_thread`), so the bound fires for them too: the
+    render returns **promptly** with the fail-safe "starting" pill while
+    the orphaned probe thread finishes harmlessly in the background.
+
+    Driven through ``httpx.ASGITransport`` on the test's own (persistent)
+    event loop rather than the synchronous ``TestClient``. ``TestClient``
+    runs the app via an ``anyio`` blocking portal that joins outstanding
+    loop work -- including the orphaned ``asyncio.to_thread`` future --
+    before returning to the calling thread, so a long sync sleep would
+    inflate the *test's* wall-clock to the full sleep even though the
+    HTTP response was produced at the bound. A persistent loop (the
+    production uvicorn shape) delivers the response at the bound and lets
+    the thread drain afterwards, which is exactly the property under
+    test.
+
+    Discriminator against the pre-thread fix: with the loop blocked by
+    the sync ``time.sleep``, ``wait_for`` never gets to fire, so the
+    probe runs to completion and reports ``ok=True`` -- the pill would
+    render green **"ready"**. Post-fix the bound fires and the verdict is
+    not-ready -- yellow **"starting"**. The wall-clock assertion adds the
+    "promptly" guarantee on top. The bound is shrunk here so the test
+    runs fast.
+    """
+    from meho_backplane.ui.auth import middleware as ui_middleware
+
+    monkeypatch.setattr(ui_middleware, "_READINESS_TIMEOUT_S", 0.1)
+
+    def _blocking_sync_probe() -> ProbeResult:
+        time.sleep(10)  # >> the 0.1s bound; blocks the loop pre-fix
+        return ProbeResult(name="docs_backends", ok=True)
+
+    register_probe("docs_backends", _blocking_sync_probe)
+
+    # Seed inline with ``await`` rather than the ``asyncio.run``-based
+    # ``_seed_*`` sync helpers: this test runs on the pytest-asyncio loop,
+    # and ``asyncio.run`` cannot be called from a running loop.
+    sessionmaker = get_sessionmaker()
+    async with sessionmaker() as session, session.begin():
+        session.add(Tenant(id=_TENANT_A, slug="tenant-a", name="Tenant tenant-a"))
+    async with sessionmaker() as session, session.begin():
+        decrypted = await create_session(
+            session,
+            operator_sub=_OP_A,
+            tenant_id=_TENANT_A,
+            access_token="access-token-plaintext",
+            refresh_token="refresh-token-plaintext",
+            lifetime=timedelta(hours=1),
+        )
+        session_id = decrypted.id
+
+    mock = respx.mock(assert_all_called=False)
+    mock.start()
+    _mock_discovery_and_jwks(mock, _jwks())
+    transport = httpx.ASGITransport(app=_build_app())
+    loop = asyncio.get_running_loop()
+    started = loop.time()
+    try:
+        async with httpx.AsyncClient(
+            transport=transport,
+            base_url=_BACKPLANE_URL,
+            cookies={SESSION_COOKIE_NAME: str(session_id)},
+            follow_redirects=False,
+        ) as client:
+            response = await client.get("/ui/memory")
+    finally:
+        mock.stop()
+    elapsed = loop.time() - started
+
+    assert response.status_code == 200, response.text
+    assert "<title>Memory" in response.text
+    assert _pill_state(response.text) == ("bg-warning", "starting")
+    # The render returned on the readiness bound, not the sync probe's 10s
+    # sleep: a blocking sync probe must not stall the /ui/* hot path.
+    assert elapsed < 5.0, f"render should not block on the blocking sync probe, took {elapsed:.2f}s"
 
 
 def test_dashboard_pill_follows_probe_state_unchanged() -> None:

--- a/docs/codebase/ui.md
+++ b/docs/codebase/ui.md
@@ -406,14 +406,33 @@ Two properties make this correct:
   own value rather than the (possibly staler) cached one — the footer
   pill and the dashboard card stay in lock-step.
 
-A misbehaving probe must not 500 a page render: `_stash_ui_readiness`
-degrades to `False` ("starting") on any exception out of the sweep and
-logs `ui_readiness_snapshot_failed`. `GET /ready` itself is unchanged —
-it still computes fresh on every hit (the kubernetes readiness contract)
-and keeps its `features` block, which the UI verdict deliberately omits.
-The `test_ui_readiness_pill.py` suite pins the cache semantics, the
-processor injection + fail-safe, and the end-to-end pill state on a
-non-dashboard surface (`/ui/memory`).
+A misbehaving probe must not stall *or* 500 a page render.
+`_stash_ui_readiness` degrades to `False` ("starting") on any exception
+out of the sweep and logs `ui_readiness_snapshot_failed`. Crucially it
+also bounds the sweep with a short `timeout_s` (`_READINESS_TIMEOUT_S`,
+1 s — well under the 2 s TTL): the registry's real probes
+(`keycloak`, `vault`, `db`, `broadcast`, `docs_backends`) do live
+network I/O, run **sequentially**, and have no internal timeout of their
+own (the Keycloak probe documents its timeout as a deferred TODO), so an
+unreachable/black-holed dependency would otherwise hang every `/ui/*`
+render indefinitely — a hang is not an exception, so the `try`/`except`
+alone cannot catch it. With the bound, `readiness_snapshot` wraps the
+sweep in `asyncio.wait_for`; on timeout it returns a not-ready verdict
+(a synthetic `timeout` check) and deliberately **does not cache** it, so
+a transient stall degrades the pill to "starting" for that request
+without pinning a stale verdict for the rest of the window. (This was
+the #1776 CI-unit-lane hang: in CI those endpoints are black-holed, so
+the unbounded per-request sweep ballooned the unit run past its timeout
+budget; locally the connects fail fast with `ECONNREFUSED`, which is why
+it passed there.) `GET /ready` and the dashboard's fresh sweep
+(`max_age_s=0`) pass no bound (`timeout_s=None`), so their behaviour is
+unchanged — `/ready` still computes fresh on every hit (the kubernetes
+readiness contract) and keeps its `features` block, which the UI verdict
+deliberately omits. The `test_ui_readiness_pill.py` suite pins the cache
+semantics, the timeout degrade-and-don't-cache behaviour, the processor
+injection + fail-safe, and the end-to-end pill state on a non-dashboard
+surface (`/ui/memory`) — including that a hung probe renders "starting"
+promptly rather than blocking.
 
 ## Dependencies
 

--- a/docs/codebase/ui.md
+++ b/docs/codebase/ui.md
@@ -43,7 +43,7 @@ Locked decisions:
 | Module | Purpose |
 | ------ | ------- |
 | `meho_backplane.ui.paths` | Resolves `templates/`, `static/src/`, `static/dist/` directories at runtime. Source-tree dev and image deploy both work via `Path(__file__).resolve().parent`. |
-| `meho_backplane.ui.templating` | Jinja2 `Environment` factory with `FileSystemLoader`, `select_autoescape`, `StrictUndefined`, and the `app_version` global pre-bound from `meho_backplane.version.deployed_version_label()` -- the deployed-build label (`v<CHART_VERSION>`, else 12-char `GIT_SHA` truncation, else `unknown`) read from the same env vars `GET /version` reports, bound once at env construction because the values are process-immutable (#1698; the global used to bind the static package `__version__`, so every deploy's footer said `0.1.0-dev`). Routes must not pass their own `app_version` context key -- render context shadows env globals. `get_templates()` registers `_ui_session_context_processor` so every render sees a `session_tenant` dict ({id, slug, name}, or None on unauthenticated auth surfaces) -- G0.15-T9 #1217. |
+| `meho_backplane.ui.templating` | Jinja2 `Environment` factory with `FileSystemLoader`, `select_autoescape`, `StrictUndefined`, and the `app_version` global pre-bound from `meho_backplane.version.deployed_version_label()` -- the deployed-build label (`v<CHART_VERSION>`, else 12-char `GIT_SHA` truncation, else `unknown`) read from the same env vars `GET /version` reports, bound once at env construction because the values are process-immutable (#1698; the global used to bind the static package `__version__`, so every deploy's footer said `0.1.0-dev`). Routes must not pass their own `app_version` context key -- render context shadows env globals. `get_templates()` registers `_ui_session_context_processor` so every render sees a `session_tenant` dict ({id, slug, name}, or None on unauthenticated auth surfaces) -- G0.15-T9 #1217 -- and the live `ready` verdict for the footer pill, read from `request.state.ui_ready` (stashed by the session middleware from a short-TTL-cached `health.readiness_snapshot`); G10.7-T1 #1776. Context processors run *after* the route context and `update` over it, so the injected `ready` wins over any per-route literal. |
 | `meho_backplane.ui.routes` | Aggregate `APIRouter`. `build_router()` aggregates the dashboard (`GET /ui/`), the real broadcast routes (`GET /ui/broadcast` + `/ui/broadcast/stream`, G10.1-T1 #867), the real topology routes (`GET /ui/topology` + node detail, G10.5-T1 #880), the real KB routes (`GET /ui/kb` + search + detail + preview, G10.2-T1 #870), and the remaining surface stubs (`GET /ui/{connectors,memory}`, `_stub.html` placeholders). Real routers are included **before** the stubs so their concrete paths win the first-match-wins lookup. G10.3-G10.4 replace the remaining stubs the same way. |
 | `meho_backplane.ui.csrf` | T5 (#866) double-submit-cookie CSRF middleware on state-changing `/ui/*` requests (POST/PATCH/PUT/DELETE). Signed-double-submit per OWASP -- the token is `hmac_sha256(session_secret, session_id || random) + "." + random`; the cookie is JS-readable (`meho_csrf`) so HTMX can echo it in `X-CSRF-Token`. Mismatch / missing token / forged signature -> 403. Read-only methods + out-of-prefix paths pass through. |
 | `meho_backplane.ui.auth` | BFF auth subpackage. T3 (#864) landed `session_store` (encrypted token custody + RFC 9700 refresh-token rotation); T4 (#865) lands `/ui/auth/{login,callback,logout}` + session middleware; G0.25 (#1694) wires the rotation primitive into the request path (`refresh` + `errors` modules). |
@@ -361,6 +361,59 @@ were a measurement artifact of the consumer running with seed data
 that didn't match the active tenant. The `test_ui_tenant_chip.py`
 suite pins the cascade contract (Memory and Broadcast surfaces both
 render against the session tenant) as a regression guard.
+
+### Readiness pill (G10.7-T1 #1776)
+
+`base.html`'s sidebar-footer pill colours `bg-success` / "ready" vs
+`bg-warning` / "starting" off a `ready` template variable. Originally
+only the dashboard computed it; every other `/ui/*` surface hardcoded
+`ready=False` in its own context dict (~14 routes, several with a "the
+dashboard owns readiness" comment), so the pill was stuck on yellow
+"starting" on every page but the dashboard regardless of actual backend
+health. The accurate `GET /ready` endpoint existed but the console
+never consumed it.
+
+The fix injects the live verdict into *every* render through the same
+`_ui_session_context_processor` that surfaces the tenant chip. The
+processor exposes a second variable, `ready`, read from
+`request.state.ui_ready`. That value is computed once per request by
+`UISessionMiddleware` (`_stash_ui_readiness`) from
+[`readiness_snapshot`](../../backend/src/meho_backplane/health.py) — a
+short-TTL-cached (`DEFAULT_READINESS_TTL_S`, 2 s) projection of the
+probe registry into the same `{ready, checks}` shape `/ready` returns.
+Caching keeps the page-render hot path at "negligible cost": at most one
+probe sweep per cache window across all concurrent loads, not a sweep
+per render. The processor is synchronous (Starlette contract), so it
+cannot itself await the sweep — computing it in the async middleware and
+reading it off `request.state` is the seam that bridges the two.
+
+Two properties make this correct:
+
+* **Processor wins over route literals.** Starlette runs context
+  processors *after* the route's own context dict and `dict.update`s
+  their output over it
+  (`starlette.templating.Jinja2Templates.TemplateResponse`), so the
+  injected `ready` overrides any stray per-route value. The ~14
+  `ready=False` literals were therefore dropped (they were dead once the
+  processor owns the key); `StrictUndefined` still requires the key
+  present, and the processor's `False` default ("starting") is the
+  fail-safe for the auth/static surfaces where no session middleware
+  runs and for any bare `Environment.render`.
+* **Dashboard behaviour unchanged.** The dashboard still runs a *fresh*
+  probe sweep (`readiness_snapshot(max_age_s=0)`) for its detailed
+  readiness card, and writes that fresh verdict back to
+  `request.state.ui_ready` so the processor re-injects the dashboard's
+  own value rather than the (possibly staler) cached one — the footer
+  pill and the dashboard card stay in lock-step.
+
+A misbehaving probe must not 500 a page render: `_stash_ui_readiness`
+degrades to `False` ("starting") on any exception out of the sweep and
+logs `ui_readiness_snapshot_failed`. `GET /ready` itself is unchanged —
+it still computes fresh on every hit (the kubernetes readiness contract)
+and keeps its `features` block, which the UI verdict deliberately omits.
+The `test_ui_readiness_pill.py` suite pins the cache semantics, the
+processor injection + fail-safe, and the end-to-end pill state on a
+non-dashboard surface (`/ui/memory`).
 
 ## Dependencies
 

--- a/docs/codebase/ui.md
+++ b/docs/codebase/ui.md
@@ -424,15 +424,31 @@ without pinning a stale verdict for the rest of the window. (This was
 the #1776 CI-unit-lane hang: in CI those endpoints are black-holed, so
 the unbounded per-request sweep ballooned the unit run past its timeout
 budget; locally the connects fail fast with `ECONNREFUSED`, which is why
-it passed there.) `GET /ready` and the dashboard's fresh sweep
+it passed there.)
+
+The bound only fires, though, if the sweep actually yields to the event
+loop. `asyncio.wait_for` can cancel an *awaiting* coroutine but cannot
+interrupt a **synchronous** call that is blocking the loop — and several
+probes are `def` (the `docs_backends` probe, and the Keycloak/Vault
+probes wrap sync clients). A blocking sync probe would therefore sail
+past `wait_for` and hang the render even with the bound in place (the
+residual #1776 hang). `run_probes_async` closes this: async probes are
+awaited directly, but sync probes run via `asyncio.to_thread` so the
+blocking call happens on a worker thread and the loop stays free for
+`wait_for` to fire. On timeout the orphaned thread is not killed — it
+drains harmlessly in the background — and the TTL cache + single-flight
+lock cap how often a fresh sweep (and thus a fresh thread) is spawned.
+This also keeps `/ready` and the dashboard's fresh sweep from blocking
+the loop on a slow sync probe (behaviour-preserving on results). `GET /ready` and the dashboard's fresh sweep
 (`max_age_s=0`) pass no bound (`timeout_s=None`), so their behaviour is
 unchanged — `/ready` still computes fresh on every hit (the kubernetes
 readiness contract) and keeps its `features` block, which the UI verdict
 deliberately omits. The `test_ui_readiness_pill.py` suite pins the cache
 semantics, the timeout degrade-and-don't-cache behaviour, the processor
 injection + fail-safe, and the end-to-end pill state on a non-dashboard
-surface (`/ui/memory`) — including that a hung probe renders "starting"
-promptly rather than blocking.
+surface (`/ui/memory`) — including that both a hung **async** probe and a
+blocking **sync** probe render "starting" promptly rather than blocking
+the render.
 
 ## Dependencies
 

--- a/docs/codebase/ui.md
+++ b/docs/codebase/ui.md
@@ -43,7 +43,7 @@ Locked decisions:
 | Module | Purpose |
 | ------ | ------- |
 | `meho_backplane.ui.paths` | Resolves `templates/`, `static/src/`, `static/dist/` directories at runtime. Source-tree dev and image deploy both work via `Path(__file__).resolve().parent`. |
-| `meho_backplane.ui.templating` | Jinja2 `Environment` factory with `FileSystemLoader`, `select_autoescape`, `StrictUndefined`, and the `app_version` global pre-bound from `meho_backplane.version.deployed_version_label()` -- the deployed-build label (`v<CHART_VERSION>`, else 12-char `GIT_SHA` truncation, else `unknown`) read from the same env vars `GET /version` reports, bound once at env construction because the values are process-immutable (#1698; the global used to bind the static package `__version__`, so every deploy's footer said `0.1.0-dev`). Routes must not pass their own `app_version` context key -- render context shadows env globals. `get_templates()` registers `_ui_session_context_processor` so every render sees a `session_tenant` dict ({id, slug, name}, or None on unauthenticated auth surfaces) -- G0.15-T9 #1217 -- and the live `ready` verdict for the footer pill, read from `request.state.ui_ready` (stashed by the session middleware from a short-TTL-cached `health.readiness_snapshot`); G10.7-T1 #1776. Context processors run *after* the route context and `update` over it, so the injected `ready` wins over any per-route literal. |
+| `meho_backplane.ui.templating` | Jinja2 `Environment` factory with `FileSystemLoader`, `select_autoescape`, `StrictUndefined`, and the `app_version` global pre-bound from `meho_backplane.version.deployed_version_label()` -- the deployed-build label (`v<CHART_VERSION>`, else 12-char `GIT_SHA` truncation, else `unknown`) read from the same env vars `GET /version` reports, bound once at env construction because the values are process-immutable (#1698; the global used to bind the static package `__version__`, so every deploy's footer said `0.1.0-dev`). Routes must not pass their own `app_version` context key -- render context shadows env globals. `get_templates()` registers `_ui_session_context_processor` so every render sees a `session_tenant` dict ({id, slug, name}, or None on unauthenticated auth surfaces) -- G0.15-T9 #1217 -- and the live `ready` verdict for the footer pill, read from `request.state.ui_ready` (stashed by the session middleware from `health.ui_readiness_verdict`, the stale-while-revalidate hot-path accessor that never sweeps probes on the request path); G10.7-T1 #1776. Context processors run *after* the route context and `update` over it, so the injected `ready` wins over any per-route literal. |
 | `meho_backplane.ui.routes` | Aggregate `APIRouter`. `build_router()` aggregates the dashboard (`GET /ui/`), the real broadcast routes (`GET /ui/broadcast` + `/ui/broadcast/stream`, G10.1-T1 #867), the real topology routes (`GET /ui/topology` + node detail, G10.5-T1 #880), the real KB routes (`GET /ui/kb` + search + detail + preview, G10.2-T1 #870), and the remaining surface stubs (`GET /ui/{connectors,memory}`, `_stub.html` placeholders). Real routers are included **before** the stubs so their concrete paths win the first-match-wins lookup. G10.3-G10.4 replace the remaining stubs the same way. |
 | `meho_backplane.ui.csrf` | T5 (#866) double-submit-cookie CSRF middleware on state-changing `/ui/*` requests (POST/PATCH/PUT/DELETE). Signed-double-submit per OWASP -- the token is `hmac_sha256(session_secret, session_id || random) + "." + random`; the cookie is JS-readable (`meho_csrf`) so HTMX can echo it in `X-CSRF-Token`. Mismatch / missing token / forged signature -> 403. Read-only methods + out-of-prefix paths pass through. |
 | `meho_backplane.ui.auth` | BFF auth subpackage. T3 (#864) landed `session_store` (encrypted token custody + RFC 9700 refresh-token rotation); T4 (#865) lands `/ui/auth/{login,callback,logout}` + session middleware; G0.25 (#1694) wires the rotation primitive into the request path (`refresh` + `errors` modules). |
@@ -376,16 +376,37 @@ never consumed it.
 The fix injects the live verdict into *every* render through the same
 `_ui_session_context_processor` that surfaces the tenant chip. The
 processor exposes a second variable, `ready`, read from
-`request.state.ui_ready`. That value is computed once per request by
+`request.state.ui_ready`. That value is read once per request by
 `UISessionMiddleware` (`_stash_ui_readiness`) from
-[`readiness_snapshot`](../../backend/src/meho_backplane/health.py) — a
-short-TTL-cached (`DEFAULT_READINESS_TTL_S`, 2 s) projection of the
-probe registry into the same `{ready, checks}` shape `/ready` returns.
-Caching keeps the page-render hot path at "negligible cost": at most one
-probe sweep per cache window across all concurrent loads, not a sweep
-per render. The processor is synchronous (Starlette contract), so it
-cannot itself await the sweep — computing it in the async middleware and
-reading it off `request.state` is the seam that bridges the two.
+[`ui_readiness_verdict`](../../backend/src/meho_backplane/health.py) — the
+*stale-while-revalidate* hot-path accessor over the same short-TTL
+(`DEFAULT_READINESS_TTL_S`, 2 s) cache `readiness_snapshot` maintains. The
+processor is synchronous (Starlette contract), so it cannot itself await a
+probe sweep — computing the verdict in the async middleware and reading it
+off `request.state` is the seam that bridges the two.
+
+The accessor keeps the page-render hot path at "negligible cost" by
+**never running a probe sweep on the request path**:
+
+* **Cache present (any age).** Return the cached `ready` verdict
+  immediately — stale is fine; the pill is an at-a-glance hint, not the
+  kubernetes readiness contract. If the entry is older than the TTL,
+  schedule a *single-flight* background refresh (`asyncio.create_task`,
+  guarded by the `_readiness_refresh_task` handle so at most one runs at a
+  time; the reference is retained on the module so the task isn't
+  GC'd mid-flight, and its `finally` clears the handle) and serve the
+  last-known value without awaiting it.
+* **Cache absent (first-ever call).** Do *one* bounded sweep to warm the
+  cache so a healthy backend renders green "ready" on first paint
+  (preserving the original acceptance criteria). Concurrent first callers
+  share that one sweep via the `_readiness_lock` single-flight. Unlike
+  `readiness_snapshot`, the warm path caches **even a timeout** verdict so
+  a cold-start black-holed probe can't make every subsequent request
+  re-sweep; the TTL makes it self-healing (the next render past the window
+  schedules a background refresh that picks up recovery).
+
+So under any probe health the per-request cost is a dict read plus, at
+most, scheduling one background task — never a serialised sweep.
 
 Two properties make this correct:
 
@@ -406,49 +427,61 @@ Two properties make this correct:
   own value rather than the (possibly staler) cached one — the footer
   pill and the dashboard card stay in lock-step.
 
-A misbehaving probe must not stall *or* 500 a page render.
-`_stash_ui_readiness` degrades to `False` ("starting") on any exception
-out of the sweep and logs `ui_readiness_snapshot_failed`. Crucially it
-also bounds the sweep with a short `timeout_s` (`_READINESS_TIMEOUT_S`,
-1 s — well under the 2 s TTL): the registry's real probes
-(`keycloak`, `vault`, `db`, `broadcast`, `docs_backends`) do live
-network I/O, run **sequentially**, and have no internal timeout of their
-own (the Keycloak probe documents its timeout as a deferred TODO), so an
-unreachable/black-holed dependency would otherwise hang every `/ui/*`
-render indefinitely — a hang is not an exception, so the `try`/`except`
-alone cannot catch it. With the bound, `readiness_snapshot` wraps the
-sweep in `asyncio.wait_for`; on timeout it returns a not-ready verdict
-(a synthetic `timeout` check) and deliberately **does not cache** it, so
-a transient stall degrades the pill to "starting" for that request
-without pinning a stale verdict for the rest of the window. (This was
-the #1776 CI-unit-lane hang: in CI those endpoints are black-holed, so
-the unbounded per-request sweep ballooned the unit run past its timeout
-budget; locally the connects fail fast with `ECONNREFUSED`, which is why
-it passed there.)
+**Why the decoupling, not just a bound (the #1776 CI-unit-lane overrun).**
+The first cut at this feature awaited the probe sweep *inline* in
+`_stash_ui_readiness` on every render, with a short `timeout_s`
+(`_READINESS_TIMEOUT_S`, 1 s) to keep a hung dependency from blocking the
+page. That stopped the event-loop *hang* but not the overrun. In CI the 5
+real network probes (`keycloak`, `vault`, `db`, `broadcast`,
+`docs_backends`, registered in `main.py`) leak into the process-global
+registry — `conftest.py` has no global probe isolation and several
+suites register them without clearing — and those endpoints are
+black-holed. `readiness_snapshot` deliberately **does not cache** a
+timed-out sweep (a transient stall must not pin "starting" on `/ready`
+for the whole TTL), so every `/ui/*` request re-swept, serialised through
+the readiness single-flight lock, orphaning a probe-worker thread each
+time. Hundreds of UI tests x ~1 s serialised + thread accumulation
+overran the unit lane's hard `timeout-minutes` job cap (it died at
+~15 min on every full run); locally the connects fail fast with
+`ECONNREFUSED`, which is why the local sweep passed. The accessor removes
+the sweep from the request path entirely (stale-while-revalidate, above),
+which is the actual fix; `test_ui_readiness_pill.py` pins it with a
+deterministic regression test (a blocking sync probe + N=30 sequential
+`/ui/memory` renders must stay well under N x the bound in wall-time and
+sweep the probe only a small constant number of times — it FAILS on the
+inline-sweep design at ≈ N x bound).
 
-The bound only fires, though, if the sweep actually yields to the event
-loop. `asyncio.wait_for` can cancel an *awaiting* coroutine but cannot
-interrupt a **synchronous** call that is blocking the loop — and several
-probes are `def` (the `docs_backends` probe, and the Keycloak/Vault
-probes wrap sync clients). A blocking sync probe would therefore sail
-past `wait_for` and hang the render even with the bound in place (the
-residual #1776 hang). `run_probes_async` closes this: async probes are
-awaited directly, but sync probes run via `asyncio.to_thread` so the
-blocking call happens on a worker thread and the loop stays free for
-`wait_for` to fire. On timeout the orphaned thread is not killed — it
-drains harmlessly in the background — and the TTL cache + single-flight
-lock cap how often a fresh sweep (and thus a fresh thread) is spawned.
-This also keeps `/ready` and the dashboard's fresh sweep from blocking
-the loop on a slow sync probe (behaviour-preserving on results). `GET /ready` and the dashboard's fresh sweep
-(`max_age_s=0`) pass no bound (`timeout_s=None`), so their behaviour is
-unchanged — `/ready` still computes fresh on every hit (the kubernetes
-readiness contract) and keeps its `features` block, which the UI verdict
-deliberately omits. The `test_ui_readiness_pill.py` suite pins the cache
-semantics, the timeout degrade-and-don't-cache behaviour, the processor
-injection + fail-safe, and the end-to-end pill state on a non-dashboard
-surface (`/ui/memory`) — including that both a hung **async** probe and a
-blocking **sync** probe render "starting" promptly rather than blocking
-the render.
+The bounded sweeps the accessor *does* run (the cold-cache warm and each
+background refresh) go through `readiness_snapshot(max_age_s=0,
+timeout_s=…)`, which wraps the sweep in `asyncio.wait_for`. That bound
+only fires if the sweep yields to the loop: `wait_for` can cancel an
+*awaiting* coroutine but cannot interrupt a **synchronous** call blocking
+it — and several probes are `def` (the `docs_backends` probe, and the
+Keycloak/Vault sync-client probes). `run_probes_async` closes that gap by
+running sync probes via `asyncio.to_thread`, so the blocking call happens
+on a worker thread and the loop stays free for `wait_for` to fire. On
+timeout the orphaned thread is not killed — it drains harmlessly — and
+single-flight (`_readiness_refresh_task` for background refreshes,
+`_readiness_lock` for the cold warm) caps how many threads can ever be in
+flight at once: one, not one per request.
+
+`_stash_ui_readiness` still degrades to `False` ("starting") on any
+exception out of the accessor and logs `ui_readiness_snapshot_failed`,
+and an unbound `ui_ready` key falls back to "starting" in the processor —
+the same fail-safe default.
+
+`GET /ready` and the dashboard's fresh sweep (`max_age_s=0`,
+`timeout_s=None`) are deliberately **not** routed through the accessor —
+they call `readiness_snapshot` directly for a fresh, full-fidelity sweep
+on every hit (the kubernetes readiness contract), and `/ready` keeps its
+`features` block, which the UI verdict deliberately omits. The dashboard
+still writes its own fresh verdict back to `request.state.ui_ready` so
+the processor re-injects it, keeping the footer pill and the dashboard
+card in lock-step. The `test_ui_readiness_pill.py` suite also pins the
+cache semantics, the processor injection + fail-safe, and the end-to-end
+pill state on a non-dashboard surface (`/ui/memory`) — including that
+both a hung **async** probe and a blocking **sync** probe render
+"starting" promptly rather than blocking the render.
 
 ## Dependencies
 


### PR DESCRIPTION
## Summary

- The operator-console sidebar-footer **readiness pill was stuck on yellow "starting" on every page but the dashboard** — ~14 `/ui/*` routes hardcoded `ready=False` in their template context, so the pill never reflected actual backend health even though the accurate `GET /ready` endpoint existed.
- Injects the **live** verdict into every render through the shared `_ui_session_context_processor` (read from `request.state.ui_ready`), computed once per request by the session middleware from a new **short-TTL-cached** `health.readiness_snapshot` over the same probe registry `/ready` uses. The synchronous context processor can't await the sweep itself, so the async middleware computes it and stashes it on `request.state` — negligible per-render cost (at most one probe sweep per cache window across all concurrent loads).
- Starlette runs context processors *after* the route context and `update`s over it, so the injected `ready` wins; the ~14 per-route `ready=False` literals are **dropped**. `StrictUndefined` still requires the key — the processor's `False` default is the fail-safe for the auth/static surfaces.
- **Dashboard behaviour unchanged**: it still runs a *fresh* probe sweep for its detailed readiness card and writes that fresh verdict back to `request.state.ui_ready`, so the pill and the card stay in lock-step. `GET /ready` is untouched (still fresh per hit, keeps its `features` block). A misbehaving probe degrades the pill to "starting" rather than 500-ing the render.

## Test plan

- [x] `ruff check src/ tests/` — clean
- [x] `ruff format --check src/ tests/` — clean
- [x] `mypy src/` (strict) — `Success: no issues found in 475 source files`
- [x] code-quality gate (`--diff`) — 0 blockers (the two flagged functions are pre-existing oversize legacy debt this change only touches / shrinks; scoped `code-quality-allow` markers added)
- [x] Full unit sweep `pytest -n 6 --dist loadscope --ignore=tests/integration` — **7551 passed, 195 skipped**
- [x] New `backend/tests/test_ui_readiness_pill.py` (11 tests) covering:
  - **Acceptance:** `GET /ui/memory` (a non-dashboard surface) shows green `bg-success` "ready" when the registered probes pass, and yellow `bg-warning` "starting" when a probe fails (the `/ready` 503 condition) or the registry is empty — proving the pill reflects readiness, not a hardcoded `False`.
  - `readiness_snapshot` cache semantics: fail-closed empty registry, TTL window serves the cached verdict, `max_age_s=0` forces a fresh sweep.
  - Context-processor injection (`True`/`False`) + the fail-safe `False` default when unbound.
  - Dashboard pill still follows a fresh probe sweep (behaviour unchanged).
- [x] `grep -rn '"ready": False' backend/src/meho_backplane/ui/routes/` returns **nothing** (acceptance criterion 2).

## Out of scope

- Surfacing the per-probe `checks[]` detail in the pill (a tooltip/detail view) — a follow-up per the issue.
- The two pre-existing oversize functions the diff touches (`UISessionMiddleware.__call__`, `build_kb_router`) — refactoring them is a sibling-surface concern, not a readiness-pill fix; the change only adds one helper call to the former and removes three literals from the latter.

Closes #1776


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Updated the operator-console “readiness pill” to mirror real backend health on every `/ui/*` page via a short-lived readiness snapshot (no more hardcoded “not ready” values).
  * Kept the dashboard readiness card consistent by using a fresh readiness evaluation for that page.
* **Tests**
  * Added end-to-end and unit coverage for readiness snapshot behavior, caching/timeout handling, and pill rendering on both dashboard and non-dashboard pages.
* **Documentation**
  * Documented the template context behavior and readiness pill semantics, including safe fallback to “starting” when readiness can’t be determined.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->