### PR TITLE
feat(connectors): add per-target verify_tls column + audit-binding

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -92,6 +92,15 @@ connector-related release-notes line.
 
 ### Added
 
+- Targets now carry a first-class **`verify_tls`** flag
+  (`NOT NULL DEFAULT true`, default-secure) on create / update / read
+  across `POST` / `PATCH` / `GET /api/v1/targets` and the list
+  projection. It is the storage + API + audit surface for a per-target
+  TLS-verification opt-out (the dispatch wiring that consumes it lands
+  in a follow-up); setting it `false` writes a durable `audit_log` row
+  (`tls_verification_disabled` + before/after) and a WARN log, closing
+  the prior gap where a target PATCH wrote an empty audit payload
+  (#1780).
 - Bulk read-class connector enable path across REST + MCP + CLI:
   `POST /api/v1/connectors/{id}/enable-reads`, the
   `meho.connector.enable_reads` MCP tool, and `meho connector

--- a/backend/alembic/versions/0044_add_targets_verify_tls.py
+++ b/backend/alembic/versions/0044_add_targets_verify_tls.py
@@ -1,0 +1,104 @@
+# SPDX-License-Identifier: Apache-2.0
+# Copyright (c) 2026 evoila Group
+
+"""Add ``targets.verify_tls`` column for per-target TLS-verification opt-out.
+
+Revision ID: 0044
+Revises: 0043
+Create Date: 2026-06-15
+
+T1 (#1780) under Initiative #1774, Goal #214. Connector dispatch can
+only verify the target endpoint's certificate against the global
+``SSL_CERT_FILE`` bundle today, so a target presenting a self-signed or
+internal-CA cert (a nested lab, a freshly-deployed appliance before cert
+replacement, a Fleet-managed component with its own locker CA) dies on
+``CERTIFICATE_VERIFY_FAILED``. This migration ships the *storage* half
+of a per-target opt-out: a ``verify_tls`` flag, default-secure, mirroring
+the proven ``vpn_required`` first-class column (``db/models.py``) -- not
+an ``extras`` key, because connection-affecting config is the
+first-class-column precedent (``version`` #1215, ``auth_model`` CHECK).
+The dispatch path that *consumes* the flag (passing
+``verify=<insecure SSLContext>`` to the pooled httpx client when the flag
+is ``False``) lands in T2 (#1781); this column only stores + exposes +
+audits the flag.
+
+What this migration adds
+------------------------
+
+* ``targets.verify_tls boolean NOT NULL DEFAULT true`` -- whether
+  connector dispatch verifies the target's TLS certificate chain.
+  ``True`` (the secure default) keeps the dispatch client byte-identical
+  to today; ``False`` is the audited per-target opt-out. No index -- the
+  column is read per-request from the in-memory
+  :class:`~meho_backplane.db.models.Target` row the resolver already
+  loaded; it is never a filter predicate.
+
+Why ``server_default=true`` (not the bare ORM ``default``)
+----------------------------------------------------------
+
+``vpn_required`` (migration 0004) carries no server default because it
+was created with the ``targets`` table, so there were no pre-existing
+rows to backfill. ``verify_tls`` is an ``ADD COLUMN`` on a populated
+table: a ``NOT NULL`` add-column with no default is rejected by both
+PostgreSQL and SQLite, so the migration must supply a ``server_default``
+to backfill every existing row to the secure ``true`` state in one DDL
+statement. The ORM column declares the same ``server_default=sa.true()``
+so ``MetaData``-driven schema creation stays in sync with the migrated
+schema. The acceptance contract ("existing rows read back
+``verify_tls=true`` after ``alembic upgrade head``") is exactly this
+backfill.
+
+Why additive (not amend ``0004``)
+---------------------------------
+
+The reversible-additive discipline established by ``0006``+ applies:
+new requirement = new migration head, never rewrite historical
+migrations. Same rationale as ``0032`` (``targets.version`` / #1215).
+
+Dialect-portability decisions
+-----------------------------
+
+* ``verify_tls`` -- :class:`sqlalchemy.Boolean` on both dialects. PG
+  renders ``BOOLEAN``; SQLite renders the boolean as an ``INTEGER`` with
+  a ``0``/``1`` CHECK. ``server_default=sa.true()`` renders ``true`` on
+  PG and ``1`` on SQLite (SQLAlchemy maps the literal per dialect), so
+  the backfill is portable.
+* ``nullable=False`` -- explicit on both dialects; the secure default is
+  enforced at the DB layer, not only in the Pydantic schema.
+
+Reversibility contract
+----------------------
+
+``downgrade()`` drops the column. SQLite's ALTER TABLE drop-column has
+been supported since 3.35.0 (we're on 3.45+); Alembic's batch-mode
+fallback isn't required.
+"""
+
+from collections.abc import Sequence
+
+import sqlalchemy as sa
+from alembic import op
+
+# revision identifiers, used by Alembic.
+revision: str = "0044"
+down_revision: str | None = "0043"
+branch_labels: str | Sequence[str] | None = None
+depends_on: str | Sequence[str] | None = None
+
+
+def upgrade() -> None:
+    """Add the ``verify_tls`` column to ``targets`` (default-secure)."""
+    op.add_column(
+        "targets",
+        sa.Column(
+            "verify_tls",
+            sa.Boolean(),
+            nullable=False,
+            server_default=sa.true(),
+        ),
+    )
+
+
+def downgrade() -> None:
+    """Drop the ``verify_tls`` column added in :func:`upgrade`."""
+    op.drop_column("targets", "verify_tls")

--- a/backend/src/meho_backplane/api/v1/targets.py
+++ b/backend/src/meho_backplane/api/v1/targets.py
@@ -129,7 +129,7 @@ from __future__ import annotations
 
 import uuid
 from datetime import UTC, datetime
-from typing import Final
+from typing import Any, Final
 
 import structlog
 from fastapi import APIRouter, Depends, HTTPException, Query, Response, status
@@ -384,6 +384,7 @@ def _to_full(t: TargetORM) -> Target:
         secret_ref=t.secret_ref,
         auth_model=AuthModel(t.auth_model),
         vpn_required=t.vpn_required,
+        verify_tls=t.verify_tls,
         extras=t.extras,
         notes=t.notes,
         fingerprint=t.fingerprint,
@@ -391,6 +392,61 @@ def _to_full(t: TargetORM) -> Target:
         created_at=t.created_at,
         updated_at=t.updated_at,
         deleted_at=t.deleted_at,
+    )
+
+
+def _bind_tls_audit(
+    *,
+    target_id: uuid.UUID,
+    name: str,
+    tenant_id: uuid.UUID,
+    before: bool,
+    after: bool,
+) -> None:
+    """Record a ``verify_tls`` change on the request's audit row + log a WARN.
+
+    T1 (#1780). Setting a target's TLS verification off (or toggling it
+    at all) is a security-relevant config change that must leave a
+    durable, queryable trail. Both write routes call this after applying
+    the change:
+
+    * ``create_target`` -- only when the new target lands with
+      ``verify_tls=False`` (``before=True``, the secure default the
+      column would otherwise carry).
+    * ``update_target`` -- whenever the PATCH body sent ``verify_tls``,
+      with the real before/after transition.
+
+    The ``audit_*`` prefix is load-bearing:
+    :func:`~meho_backplane.audit._resolve_audit_payload` reads every
+    ``audit_*`` contextvar at audit-write time, strips the prefix, and
+    merges the result into ``audit_log.payload`` -- so the bound keys
+    land as ``tls_verification_disabled`` / ``target_id`` /
+    ``verify_tls_before`` / ``verify_tls_after`` in the payload. The
+    payload ``target_id`` is intentionally distinct from the bare
+    ``target_id`` contextvar the middleware reads into the
+    ``audit_log.target_id`` **column** (the soft-FK
+    :func:`~meho_backplane.audit._resolve_target_id` consults) -- both
+    coexist. ``tls_verification_disabled`` tracks the *resulting* state
+    (``after is False``) so an audit query for disabled-TLS targets
+    keys off a single boolean.
+
+    The WARN log mirrors the payload so the same signal is visible in
+    the structured log stream without a DB query.
+    """
+    structlog.contextvars.bind_contextvars(
+        audit_tls_verification_disabled=(after is False),
+        audit_target_id=str(target_id),
+        audit_verify_tls_before=before,
+        audit_verify_tls_after=after,
+    )
+    _log.warning(
+        "target_tls_verification_changed",
+        target_id=str(target_id),
+        name=name,
+        tenant_id=str(tenant_id),
+        verify_tls_before=before,
+        verify_tls_after=after,
+        tls_verification_disabled=(after is False),
     )
 
 
@@ -519,6 +575,86 @@ def _build_unknown_preferred_impl_detail(
             f"versioned-vs-base impl-id discipline."
         ),
     }
+
+
+def _validate_preferred_impl_id(preferred_impl_id: str | None, product: str) -> None:
+    """Reject a ``preferred_impl_id`` not registered for ``product`` with a 422.
+
+    G0.15-T6 (#1215). Surfaces the resolver-silently-ignores-unknown-id
+    foot-gun at write time. ``None`` is the absent / cleared state and is
+    always valid; a non-``None`` value must match an impl_id registered in
+    the v2 connector registry **for the target's product** (G0.16-T6
+    review-iter-1 B1 #1312 -- a cross-product allowlist let a ``k8s``
+    target pin ``vmware-rest-9.0`` and the resolver would silently ignore
+    it at dispatch). ``valid_impl_ids`` is empty when no connector is
+    registered for the product (test isolation / pre-lifespan state, or a
+    not-yet-registered product); validation is skipped in that case for
+    parity with the ``product`` validator -- the operator already saw a
+    structured 422 from the product check if their product is unknown.
+
+    Shared by ``create_target`` and ``update_target`` so the two write
+    paths cannot drift on the impl-id contract. Callers pass the
+    canonical product token so an ``sddc``-aliased write resolves the
+    SDDC impl set.
+    """
+    if preferred_impl_id is None:
+        return
+    valid_impl_ids = sorted(_registered_impl_ids(product))
+    if valid_impl_ids and preferred_impl_id not in valid_impl_ids:
+        raise HTTPException(
+            status_code=status.HTTP_422_UNPROCESSABLE_CONTENT,
+            detail=_build_unknown_preferred_impl_detail(preferred_impl_id, valid_impl_ids),
+        )
+
+
+def _apply_product_patch(updates: dict[str, Any], current_product: str) -> str:
+    """Validate + canonicalise a PATCH's ``product`` field; return the effective product.
+
+    G0.14-T4 (#1145) / G0.18-T2 (#1355). The PATCH ``product`` handling
+    for ``update_target``, extracted so the handler stays under the
+    function-size budget. Three steps:
+
+    1. Reject ``{"product": null}`` with a T11-compliant ``invalid_null``
+       422. ``Field(default=None)`` on ``TargetUpdate.product`` is the
+       absent-marker for "client did not send this field"; without this
+       guard the ``setattr`` loop would assign ``None`` to the NOT NULL
+       column and surface an opaque 500.
+    2. Canonicalise the supplied token in place (``updates["product"]``)
+       so a value copied from ``meho connector list`` (e.g. ``"sddc"``)
+       lands the registry spelling (``"sddc-manager"``).
+    3. Validate against the registered products **only when the value
+       actually changes** -- a same-value PATCH short-circuits (pinned by
+       ``test_patch_product_same_value_passes_without_validator``).
+
+    Returns the effective product for the post-update row -- the new
+    canonical token when the PATCH changes ``product``, else the row's
+    current product -- which scopes the ``preferred_impl_id`` validator.
+    """
+    if "product" in updates and updates["product"] is None:
+        raise HTTPException(
+            status_code=status.HTTP_422_UNPROCESSABLE_CONTENT,
+            detail={
+                "kind": "invalid_null",
+                "field": "product",
+                "message": (
+                    "product cannot be null; targets.product is NOT NULL. "
+                    "Omit the field to leave it unchanged, or pass a "
+                    "valid product token instead. "
+                    "See docs/codebase/error-message-shape.md for the "
+                    "convention."
+                ),
+            },
+        )
+    raw_new_product = updates.get("product")
+    new_product = canonical_product_token(raw_new_product) if raw_new_product is not None else None
+    if new_product is not None:
+        updates["product"] = new_product
+    if new_product is not None and new_product != current_product:
+        # raw_new_product is the operator's literal input; pass it
+        # through so the 422 detail echoes what they typed.
+        assert raw_new_product is not None  # guarded by the outer if
+        _canonicalise_and_validate_product(raw_new_product)
+    return new_product if new_product is not None else current_product
 
 
 @router.get("")
@@ -845,32 +981,10 @@ async def create_target(
     # the registry's spelling regardless of which alias the operator
     # typed.
     product = _canonicalise_and_validate_product(body.product)
-    # G0.15-T6 (#1215). Validate ``preferred_impl_id`` against the
-    # registered impl set so the resolver-silently-ignores-unknown-id
-    # foot-gun surfaces at write time. ``None`` is the absent / cleared
-    # state and is always valid; a non-``None`` value must match an
-    # impl_id registered in the v2 connector registry **for the
-    # target's product** (G0.16-T6 review-iter-1 B1 #1312 -- a
-    # cross-product allowlist let a ``k8s`` target pin
-    # ``vmware-rest-9.0`` and the resolver would silently ignore it
-    # at dispatch). The scope uses the canonical product token so an
-    # ``sddc``-aliased create still resolves the SDDC impl set.
-    # ``valid_impl_ids`` is empty when no connector is registered for
-    # the product (test isolation / pre-lifespan state, or a
-    # not-yet-registered product); we skip validation in that case for
-    # parity with the ``product`` validator above -- the operator
-    # already saw a structured 422 from the product check if their
-    # product is unknown to the registry.
-    valid_impl_ids = sorted(_registered_impl_ids(product))
-    if (
-        body.preferred_impl_id is not None
-        and valid_impl_ids
-        and body.preferred_impl_id not in valid_impl_ids
-    ):
-        raise HTTPException(
-            status_code=status.HTTP_422_UNPROCESSABLE_CONTENT,
-            detail=_build_unknown_preferred_impl_detail(body.preferred_impl_id, valid_impl_ids),
-        )
+    # G0.15-T6 (#1215). Reject an unknown ``preferred_impl_id`` at write
+    # time (the canonical product token scopes the valid set). See
+    # :func:`_validate_preferred_impl_id`.
+    _validate_preferred_impl_id(body.preferred_impl_id, product)
     now = datetime.now(UTC)
     create_fields = body.model_dump()
     # Persist the canonical product token, not the alias the operator
@@ -910,6 +1024,22 @@ async def create_target(
         name=t.name,
         tenant_id=str(operator.tenant_id),
     )
+    # T1 (#1780). A target created with TLS verification *off* is a
+    # security-relevant config choice that must leave a durable,
+    # queryable trail. Bind the ``audit_*`` contextvars so
+    # ``AuditMiddleware`` folds them into this request's ``audit_log``
+    # payload, and emit a WARN. ``before`` is the secure default the
+    # column would otherwise carry; ``after`` is the operator's choice.
+    # A create with ``verify_tls`` left at the secure default binds
+    # nothing (no audit noise for the common path).
+    if t.verify_tls is False:
+        _bind_tls_audit(
+            target_id=t.id,
+            name=t.name,
+            tenant_id=operator.tenant_id,
+            before=True,
+            after=False,
+        )
     return _to_full(t)
 
 
@@ -934,69 +1064,26 @@ async def update_target(
     """
     t = await resolve_target(session, operator.tenant_id, name)
     updates = body.model_dump(exclude_unset=True)
-    # Reject ``{"product": null}`` explicitly. ``Field(default=None)`` on
-    # ``TargetUpdate.product`` is the absent-marker for "client did not
-    # send this field" -- the only legal way to keep the field optional
-    # while supporting PATCH semantics in v1. Without this guard the
-    # ``setattr`` loop below assigns ``None`` to ``Target.product`` (NOT
-    # NULL) and SQLAlchemy / the database raises an IntegrityError that
-    # FastAPI maps to a 500 -- bypassing the T11 error-message-shape
-    # contract callers branch on. Mirror the ``unknown_product`` 422
-    # shape so the diagnostic stays uniform: a snake_case ``kind``, a
-    # human ``message`` naming the offending value + the remediation,
-    # and a pointer to the convention doc.
-    if "product" in updates and updates["product"] is None:
-        raise HTTPException(
-            status_code=status.HTTP_422_UNPROCESSABLE_CONTENT,
-            detail={
-                "kind": "invalid_null",
-                "field": "product",
-                "message": (
-                    "product cannot be null; targets.product is NOT NULL. "
-                    "Omit the field to leave it unchanged, or pass a "
-                    "valid product token instead. "
-                    "See docs/codebase/error-message-shape.md for the "
-                    "convention."
-                ),
-            },
-        )
-    # G0.18-T2 (#1355). Canonicalise + validate the patched product
-    # token the same way ``create_target`` does so a PATCH that copies
-    # ``product`` out of ``meho connector list`` (e.g. ``"sddc"``)
-    # lands the canonical registry token (``"sddc-manager"``) rather
-    # than 422-ing or storing the alias. The shared helper raises a
-    # T11-compliant 422 on unknown products; we only invoke it when
-    # the operator actually changes ``product`` so a same-value PATCH
-    # short-circuits (matches the pre-T2 behaviour pinned by
-    # ``test_patch_product_same_value_passes_without_validator``).
-    raw_new_product = updates.get("product")
-    new_product = canonical_product_token(raw_new_product) if raw_new_product is not None else None
-    if new_product is not None:
-        updates["product"] = new_product
-    if new_product is not None and new_product != t.product:
-        # raw_new_product is the operator's literal input; pass it
-        # through so the 422 detail echoes what they typed.
-        assert raw_new_product is not None  # guarded by the outer if
-        _canonicalise_and_validate_product(raw_new_product)
-    # G0.15-T6 (#1215). Same impl_id rejection as on POST. ``None`` is
-    # the explicit-clear state and is always valid (operator wants to
-    # remove the override); a non-``None`` value must match a
-    # registered impl_id **for the target's product** (G0.16-T6
-    # review-iter-1 B1 #1312). When the PATCH also changes ``product``,
-    # the new product is the relevant scope -- the validator must
-    # agree with the post-update row state, otherwise a single PATCH
-    # could land an impl_id that the resolver will silently ignore at
-    # the next dispatch. Skip when no connector is registered for the
-    # effective product (test isolation / pre-lifespan).
-    new_preferred = updates.get("preferred_impl_id")
-    if new_preferred is not None:
-        effective_product = new_product if new_product is not None else t.product
-        valid_impl_ids = sorted(_registered_impl_ids(effective_product))
-        if valid_impl_ids and new_preferred not in valid_impl_ids:
-            raise HTTPException(
-                status_code=status.HTTP_422_UNPROCESSABLE_CONTENT,
-                detail=_build_unknown_preferred_impl_detail(new_preferred, valid_impl_ids),
-            )
+    # T1 (#1780). Snapshot the pre-patch TLS-verification state *before*
+    # the ``setattr`` loop below mutates the row, so the audit fold-in
+    # can record the before/after transition. ``exclude_unset=True``
+    # means ``"verify_tls" in updates`` is true only when the client
+    # actually sent the field, which is the gate for binding any TLS
+    # audit keys -- a PATCH that does not touch ``verify_tls`` binds
+    # none.
+    verify_tls_sent = "verify_tls" in updates
+    verify_tls_before = t.verify_tls
+    # G0.14-T4 (#1145) / G0.18-T2 (#1355). Validate + canonicalise the
+    # patched ``product`` (rejecting ``{"product": null}``) and resolve
+    # the effective product for the impl-id scope below. See
+    # :func:`_apply_product_patch`.
+    effective_product = _apply_product_patch(updates, t.product)
+    # G0.15-T6 (#1215). Same impl_id rejection as on POST. When the PATCH
+    # also changes ``product``, the new product is the relevant scope --
+    # the validator must agree with the post-update row state, otherwise a
+    # single PATCH could land an impl_id the resolver silently ignores at
+    # the next dispatch. See :func:`_validate_preferred_impl_id`.
+    _validate_preferred_impl_id(updates.get("preferred_impl_id"), effective_product)
     for k, v in updates.items():
         setattr(t, k, v)
     # #1723: home an as-yet-unconfigured target onto the per-tenant shared
@@ -1019,6 +1106,22 @@ async def update_target(
         tenant_id=str(operator.tenant_id),
         fields=list(updates.keys()),
     )
+    # T1 (#1780). When the PATCH touched ``verify_tls``, fold the
+    # transition into this request's ``audit_log`` payload via the
+    # ``audit_*`` contextvars and emit a WARN. This closes the
+    # never-silent gap the initiative flagged: a target PATCH wrote an
+    # *empty* audit payload today, so flipping a security-relevant
+    # control left no durable record. The bind is gated on the field
+    # being sent (``verify_tls_sent``), so a PATCH that does not touch
+    # ``verify_tls`` binds no TLS audit keys.
+    if verify_tls_sent:
+        _bind_tls_audit(
+            target_id=t.id,
+            name=t.name,
+            tenant_id=operator.tenant_id,
+            before=verify_tls_before,
+            after=t.verify_tls,
+        )
     return _to_full(t)
 
 

--- a/backend/src/meho_backplane/db/models.py
+++ b/backend/src/meho_backplane/db/models.py
@@ -159,6 +159,13 @@ Schema decisions for :class:`Target`:
   values; the default covers the v0.2 SSA pattern.
 * ``vpn_required`` — Boolean NOT NULL DEFAULT ``false``. Whether the
   agent must establish a VPN tunnel before connecting.
+* ``verify_tls`` — Boolean NOT NULL DEFAULT ``true``. Whether connector
+  dispatch verifies the target's TLS certificate chain. Default-secure;
+  setting it ``false`` is the audited per-target opt-out for
+  self-signed / internal-CA appliances (the dispatch wiring that
+  consumes it lands in #1781). Added by migration ``0044`` with
+  ``server_default=true`` so pre-#1780 rows backfill to the secure
+  state.
 * ``extras`` — JSON NOT NULL DEFAULT ``{}``. JSONB on PostgreSQL
   (binary, GIN-friendly), generic JSON on SQLite. Escape hatch for
   per-product structured data without DDL changes.
@@ -876,6 +883,20 @@ class Target(Base):
         sa.Boolean(),
         nullable=False,
         default=False,
+    )
+    # Whether connector dispatch verifies the target's TLS certificate
+    # chain. Default-secure (``True``); ``False`` is the audited
+    # per-target opt-out for self-signed / internal-CA appliances. This
+    # column only *stores* the flag -- the dispatch path that reads it
+    # (passing ``verify=<insecure SSLContext>`` to the pooled httpx
+    # client) lands in #1781. ``server_default=true`` in migration
+    # ``0044`` backfills pre-#1780 rows to the secure state so the
+    # ``NOT NULL`` add-column is safe on a populated table.
+    verify_tls: Mapped[bool] = mapped_column(
+        sa.Boolean(),
+        nullable=False,
+        default=True,
+        server_default=sa.true(),
     )
     extras: Mapped[dict[str, object]] = mapped_column(
         _PORTABLE_JSON,

--- a/backend/src/meho_backplane/targets/schemas.py
+++ b/backend/src/meho_backplane/targets/schemas.py
@@ -112,6 +112,13 @@ class TargetSummary(BaseModel):
     secret_ref: str | None
     auth_model: AuthModel
     vpn_required: bool
+    # T1 (#1780). Per-target TLS-verification flag. Connection-routing
+    # (the dispatch client honours it in #1781), so it MUST be listable
+    # in the summary per the api-shape-conventions §5 no-silent-masking
+    # rule the class docstring cites. Defaults to ``True`` so legacy
+    # hand-constructed instances stay valid; production projections go
+    # through :func:`project_target_to_summary` which passes it through.
+    verify_tls: bool = True
     fingerprint: Mapping[str, Any] | None
     preferred_impl_id: str | None
     created_at: datetime
@@ -172,6 +179,16 @@ class Target(BaseModel):
     secret_ref: str | None
     auth_model: AuthModel
     vpn_required: bool
+    # T1 (#1780). Whether connector dispatch verifies the target's TLS
+    # certificate chain. Default-secure (``True``); ``False`` is the
+    # audited per-target opt-out for self-signed / internal-CA
+    # appliances. Defaults to ``True`` so call sites that have not yet
+    # been updated to populate the field (test helpers, historical
+    # fixtures, legacy code constructing :class:`Target` by hand) keep
+    # working; production read paths go through :func:`_to_full` which
+    # passes the column through explicitly. The dispatch path that
+    # consumes the flag lands in #1781.
+    verify_tls: bool = True
     extras: Mapping[str, Any]
     notes: str | None
     fingerprint: Mapping[str, Any] | None
@@ -225,6 +242,14 @@ class TargetCreate(BaseModel):
     secret_ref: str | None = None
     auth_model: AuthModel = AuthModel.SHARED_SERVICE_ACCOUNT
     vpn_required: bool = False
+    # T1 (#1780). Per-target TLS-verification opt-out. Default-secure:
+    # an omitted ``verify_tls`` lands ``True`` so a fresh target verifies
+    # the cert chain against the global ``SSL_CERT_FILE`` bundle (today's
+    # behaviour, byte-identical). An operator targeting a self-signed /
+    # internal-CA appliance passes ``false`` explicitly -- which the
+    # route handler audits (durable ``audit_log`` row + WARN log). The
+    # dispatch path that consumes the flag lands in #1781.
+    verify_tls: bool = True
     extras: dict[str, Any] = Field(default_factory=dict)
     notes: str | None = None
     preferred_impl_id: str | None = Field(default=None, max_length=200)
@@ -278,6 +303,17 @@ class TargetUpdate(BaseModel):
     secret_ref: str | None = None
     auth_model: AuthModel | None = None
     vpn_required: bool | None = None
+    # T1 (#1780). Patchable per-target TLS-verification flag. ``None`` is
+    # the absent-marker ("client did not send this field", the standard
+    # PATCH-field semantics every field here uses), so a PATCH that does
+    # not touch ``verify_tls`` binds **no** TLS audit keys. An explicit
+    # ``{"verify_tls": false}`` flips the column and is audited by the
+    # route handler (durable ``audit_log`` row + WARN log); ``true``
+    # re-enables verification. Unlike the nullable string columns,
+    # ``verify_tls`` is ``NOT NULL`` at the DB layer, so there is no
+    # "clear to null" state -- the value is always one of ``True`` /
+    # ``False`` once present.
+    verify_tls: bool | None = None
     extras: dict[str, Any] | None = None
     notes: str | None = None
     preferred_impl_id: str | None = Field(default=None, max_length=200)
@@ -321,6 +357,7 @@ def project_target_to_summary(t: TargetORM) -> TargetSummary:
         secret_ref=t.secret_ref,
         auth_model=AuthModel(t.auth_model),
         vpn_required=t.vpn_required,
+        verify_tls=t.verify_tls,
         fingerprint=t.fingerprint,
         preferred_impl_id=t.preferred_impl_id,
         created_at=t.created_at,

--- a/backend/tests/_targets_helpers.py
+++ b/backend/tests/_targets_helpers.py
@@ -106,6 +106,7 @@ async def _insert_target(**kwargs: Any) -> TargetORM:
         "secret_ref": None,
         "auth_model": "shared_service_account",
         "vpn_required": False,
+        "verify_tls": True,
         "extras": {},
         "notes": None,
         "created_at": datetime.now(UTC),

--- a/backend/tests/test_db_targets.py
+++ b/backend/tests/test_db_targets.py
@@ -53,7 +53,7 @@ from pathlib import Path
 import pytest
 from sqlalchemy import create_engine as sa_create_engine
 from sqlalchemy import inspect as sa_inspect
-from sqlalchemy import select
+from sqlalchemy import select, text
 
 from meho_backplane.db.engine import get_sessionmaker, reset_engine_for_testing
 from meho_backplane.db.models import AuditLog, Target
@@ -113,6 +113,7 @@ async def test_target_round_trip_persists_every_field() -> None:
                 secret_ref="secret/meho/targets/prod-k8s",
                 auth_model="shared_service_account",
                 vpn_required=True,
+                verify_tls=False,
                 extras={"cluster_version": "1.29"},
                 notes="Production Kubernetes cluster",
                 created_at=now,
@@ -136,6 +137,7 @@ async def test_target_round_trip_persists_every_field() -> None:
     assert row.secret_ref == "secret/meho/targets/prod-k8s"
     assert row.auth_model == "shared_service_account"
     assert row.vpn_required is True
+    assert row.verify_tls is False
     assert row.extras == {"cluster_version": "1.29"}
     assert row.notes == "Production Kubernetes cluster"
     # SQLite strips tzinfo — compare wall-clock parts only.
@@ -182,6 +184,8 @@ async def test_target_round_trip_with_nullable_fields_omitted() -> None:
     # ORM defaults should have fired.
     assert row.auth_model == "shared_service_account"
     assert row.vpn_required is False
+    # T1 (#1780): default-secure -- an unset ``verify_tls`` lands True.
+    assert row.verify_tls is True
     assert row.extras == {}
     # G0.14-T4 #1145: deleted_at column defaults to NULL for live rows.
     assert row.deleted_at is None
@@ -546,6 +550,7 @@ def test_migration_installs_targets_table_and_indexes(
                 "secret_ref",
                 "auth_model",
                 "vpn_required",
+                "verify_tls",
                 "extras",
                 "notes",
                 "created_at",
@@ -630,5 +635,113 @@ def test_migration_upgrade_then_downgrade_is_reversible(
             inspector = sa_inspect(conn)
             assert "targets" in inspector.get_table_names()
             assert "target_id" in {col["name"] for col in inspector.get_columns("audit_log")}
+    finally:
+        sync_eng.dispose()
+
+
+def test_migration_0044_backfills_verify_tls_true_and_is_reversible(
+    monkeypatch: pytest.MonkeyPatch,
+    tmp_path: Path,
+) -> None:
+    """T1 (#1780): ``0044`` adds ``verify_tls`` NOT NULL DEFAULT true, reversibly.
+
+    Proves the two ``verify_tls`` migration acceptance criteria against
+    a fresh SQLite DB:
+
+    * A row that exists **before** ``0044`` (inserted at revision
+      ``0043``, when the column does not yet exist) reads back
+      ``verify_tls = 1`` (true) after ``upgrade head`` -- the
+      ``server_default=sa.true()`` backfills existing rows so the
+      ``NOT NULL`` add-column is safe on a populated table.
+    * ``downgrade 0043`` drops the column cleanly and ``upgrade head``
+      restores it -- ``0044`` is fully reversible and leaves a single
+      head (asserted implicitly: ``upgrade head`` would raise on
+      multiple heads).
+    """
+    from alembic import command
+
+    from meho_backplane.db.migrations import alembic_config
+
+    db_path = tmp_path / "verify_tls.db"
+    async_url = f"sqlite+aiosqlite:///{db_path}"
+    sync_url = f"sqlite:///{db_path}"
+    monkeypatch.setenv("DATABASE_URL", async_url)
+    monkeypatch.setenv("KEYCLOAK_ISSUER_URL", "https://keycloak.test/realms/meho")
+    monkeypatch.setenv("KEYCLOAK_AUDIENCE", "meho-backplane")
+    monkeypatch.setenv("VAULT_ADDR", "https://vault.test")
+    get_settings.cache_clear()
+    reset_engine_for_testing()
+
+    cfg = alembic_config()
+    cfg.set_main_option("sqlalchemy.url", async_url)
+
+    # Migrate to the revision *before* 0044 so the row predates the column.
+    command.upgrade(cfg, "0043")
+
+    sync_eng = sa_create_engine(sync_url)
+    try:
+        # The column must not exist yet at 0043.
+        with sync_eng.connect() as conn:
+            cols_at_0043 = {col["name"] for col in sa_inspect(conn).get_columns("targets")}
+        assert "verify_tls" not in cols_at_0043
+
+        # Insert a legacy row via raw SQL (the ORM model knows about the
+        # not-yet-applied column, so a raw INSERT is the only way to
+        # simulate a pre-#1780 row). ``aliases`` / ``extras`` are JSON
+        # text on SQLite; an empty array / object is a valid value.
+        legacy_id = str(uuid.uuid4())
+        legacy_tenant = str(uuid.uuid4())
+        now_iso = datetime.now(UTC).replace(tzinfo=None).isoformat()
+        with sync_eng.begin() as conn:
+            conn.execute(
+                text(
+                    "INSERT INTO targets "
+                    "(id, tenant_id, name, aliases, product, host, "
+                    " auth_model, vpn_required, extras, created_at, updated_at) "
+                    "VALUES "
+                    "(:id, :tenant_id, :name, '[]', :product, :host, "
+                    " 'shared_service_account', 0, '{}', :now, :now)"
+                ),
+                {
+                    "id": legacy_id,
+                    "tenant_id": legacy_tenant,
+                    "name": "legacy-target",
+                    "product": "ssh",
+                    "host": "10.0.0.9",
+                    "now": now_iso,
+                },
+            )
+
+        # Apply 0044.
+        command.upgrade(cfg, "head")
+
+        with sync_eng.connect() as conn:
+            cols_at_head = {col["name"] for col in sa_inspect(conn).get_columns("targets")}
+            assert "verify_tls" in cols_at_head
+            # The pre-existing row backfilled to the secure default.
+            backfilled = conn.execute(
+                text("SELECT verify_tls FROM targets WHERE id = :id"),
+                {"id": legacy_id},
+            ).scalar_one()
+            # SQLite stores the boolean as 1/0.
+            assert bool(backfilled) is True
+
+        # Downgrade exactly one revision (head -> 0043): column must go.
+        command.downgrade(cfg, "0043")
+        with sync_eng.connect() as conn:
+            cols_after_downgrade = {col["name"] for col in sa_inspect(conn).get_columns("targets")}
+            assert "verify_tls" not in cols_after_downgrade
+            # The row itself survives the column drop.
+            surviving = conn.execute(
+                text("SELECT name FROM targets WHERE id = :id"),
+                {"id": legacy_id},
+            ).scalar_one()
+            assert surviving == "legacy-target"
+
+        # Re-upgrade is idempotent and restores the column.
+        command.upgrade(cfg, "head")
+        with sync_eng.connect() as conn:
+            cols_reupgraded = {col["name"] for col in sa_inspect(conn).get_columns("targets")}
+            assert "verify_tls" in cols_reupgraded
     finally:
         sync_eng.dispose()

--- a/backend/tests/test_targets_audit_integration.py
+++ b/backend/tests/test_targets_audit_integration.py
@@ -295,3 +295,122 @@ async def test_describe_nonexistent_target_audit_row_has_null_target_id(
     rows = await _fetch_audit_rows(isolated_engine)
     assert len(rows) == 1
     assert rows[0].target_id is None
+
+
+# ---------------------------------------------------------------------------
+# T1 (#1780) — verify_tls change folds into the audit_log payload
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.asyncio
+async def test_patch_verify_tls_false_writes_tls_audit_payload(
+    isolated_engine: AsyncEngine,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """PATCH ``{"verify_tls": false}`` → audit_log.payload records the change.
+
+    T1 (#1780). Disabling TLS verification is a security-relevant
+    config change that must leave a durable, queryable trail. The route
+    binds ``audit_*`` contextvars that
+    :func:`~meho_backplane.audit._resolve_audit_payload` folds into the
+    request's audit row, so the payload carries
+    ``tls_verification_disabled`` + ``target_id`` + before/after. The
+    soft-FK ``audit_log.target_id`` **column** is also populated (the
+    resolver bind), distinct from the ``target_id`` payload key.
+    """
+    t = await _insert_target(name="zeta", verify_tls=True)
+    key = make_rsa_keypair("kid-T1-patch-tls")
+    token = mint_token(key, sub="adm-t1-tls", tenant_role="tenant_admin")
+    client = TestClient(_build_app())
+    with respx.mock as mr:
+        mock_discovery_and_jwks(mr, public_jwks(key))
+        response = client.patch(
+            f"/api/v1/targets/{t.name}",
+            json={"verify_tls": False},
+            headers={"Authorization": f"Bearer {token}"},
+        )
+
+    assert response.status_code == 200
+    assert response.json()["verify_tls"] is False
+
+    rows = await _fetch_audit_rows(isolated_engine)
+    assert len(rows) == 1
+    payload = rows[0].payload
+    assert payload["tls_verification_disabled"] is True
+    assert payload["target_id"] == str(t.id)
+    assert payload["verify_tls_before"] is True
+    assert payload["verify_tls_after"] is False
+    # The soft-FK column is populated too (resolve_target bind).
+    assert rows[0].target_id == t.id
+
+
+@pytest.mark.asyncio
+async def test_patch_without_verify_tls_binds_no_tls_audit_keys(
+    isolated_engine: AsyncEngine,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """A PATCH that does not touch ``verify_tls`` binds **no** TLS audit keys.
+
+    T1 (#1780). The audit fold-in is gated on the field actually being
+    sent (``exclude_unset``), so an unrelated PATCH (here: ``notes``)
+    leaves the TLS keys out of the payload entirely — no audit noise on
+    the common path.
+    """
+    t = await _insert_target(name="eta", verify_tls=False)
+    key = make_rsa_keypair("kid-T1-patch-notls")
+    token = mint_token(key, sub="adm-t1-notls", tenant_role="tenant_admin")
+    client = TestClient(_build_app())
+    with respx.mock as mr:
+        mock_discovery_and_jwks(mr, public_jwks(key))
+        response = client.patch(
+            f"/api/v1/targets/{t.name}",
+            json={"notes": "ticket-42"},
+            headers={"Authorization": f"Bearer {token}"},
+        )
+
+    assert response.status_code == 200
+    rows = await _fetch_audit_rows(isolated_engine)
+    assert len(rows) == 1
+    payload = rows[0].payload
+    assert "tls_verification_disabled" not in payload
+    assert "verify_tls_before" not in payload
+    assert "verify_tls_after" not in payload
+
+
+@pytest.mark.asyncio
+async def test_create_target_verify_tls_false_writes_tls_audit_payload(
+    isolated_engine: AsyncEngine,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """POST with ``verify_tls=false`` → audit_log.payload records the opt-out.
+
+    T1 (#1780). A target *created* with TLS verification off is audited
+    the same way a PATCH that disables it is, with ``before=True`` (the
+    secure default the column would otherwise carry).
+    """
+    key = make_rsa_keypair("kid-T1-create-tls")
+    token = mint_token(key, sub="adm-t1-create-tls", tenant_role="tenant_admin")
+    client = TestClient(_build_app())
+    with respx.mock as mr:
+        mock_discovery_and_jwks(mr, public_jwks(key))
+        response = client.post(
+            "/api/v1/targets",
+            json={
+                "name": "theta",
+                "product": "rke2",
+                "host": "10.0.0.7",
+                "verify_tls": False,
+            },
+            headers={"Authorization": f"Bearer {token}"},
+        )
+
+    assert response.status_code == 201
+    created_id = uuid.UUID(response.json()["id"])
+
+    rows = await _fetch_audit_rows(isolated_engine)
+    assert len(rows) == 1
+    payload = rows[0].payload
+    assert payload["tls_verification_disabled"] is True
+    assert payload["target_id"] == str(created_id)
+    assert payload["verify_tls_before"] is True
+    assert payload["verify_tls_after"] is False

--- a/backend/tests/test_targets_schemas.py
+++ b/backend/tests/test_targets_schemas.py
@@ -111,6 +111,7 @@ def _make_summary(**overrides: Any) -> TargetSummary:
         "secret_ref": None,
         "auth_model": AuthModel.SHARED_SERVICE_ACCOUNT,
         "vpn_required": False,
+        "verify_tls": True,
         "fingerprint": None,
         "preferred_impl_id": None,
         "created_at": datetime.now(UTC),
@@ -139,6 +140,7 @@ def _make_target(**overrides: Any) -> Target:
         "secret_ref": "secret/meho/vcenter",
         "auth_model": AuthModel.SHARED_SERVICE_ACCOUNT,
         "vpn_required": True,
+        "verify_tls": False,
         "extras": {"datacenter": "fra1"},
         "notes": "Production vCenter",
         "fingerprint": None,
@@ -243,12 +245,20 @@ def test_target_create_defaults() -> None:
     t = TargetCreate(name="minimal", product="ssh", host="10.0.0.1")
     assert t.auth_model == AuthModel.SHARED_SERVICE_ACCOUNT
     assert t.vpn_required is False
+    # T1 (#1780): default-secure -- an omitted ``verify_tls`` lands True.
+    assert t.verify_tls is True
     assert t.extras == {}
     assert t.aliases == []
     assert t.port is None
     assert t.fqdn is None
     assert t.secret_ref is None
     assert t.notes is None
+
+
+def test_target_create_accepts_verify_tls_false() -> None:
+    """T1 (#1780): an operator can opt a fresh target out of TLS verify."""
+    t = TargetCreate(name="lab", product="ssh", host="10.0.0.1", verify_tls=False)
+    assert t.verify_tls is False
 
 
 def test_target_create_all_fields() -> None:
@@ -262,12 +272,14 @@ def test_target_create_all_fields() -> None:
         secret_ref="secret/meho/vcenter",
         auth_model=AuthModel.IMPERSONATION,
         vpn_required=True,
+        verify_tls=False,
         extras={"dc": "fra1"},
         notes="Production vCenter",
     )
     assert t.name == "rdc-vcenter"
     assert t.auth_model == AuthModel.IMPERSONATION
     assert t.vpn_required is True
+    assert t.verify_tls is False
 
 
 def test_target_create_rejects_invalid_auth_model() -> None:
@@ -298,6 +310,24 @@ def test_target_update_partial_fields() -> None:
     assert u.host == "new-host.corp.internal"
     assert u.vpn_required is True
     assert u.port is None  # untouched
+    # T1 (#1780): ``verify_tls`` is None (absent-marker) when not sent.
+    assert u.verify_tls is None
+
+
+def test_target_update_verify_tls_patchable() -> None:
+    """T1 (#1780): ``verify_tls`` is sendable via PATCH; absent stays None.
+
+    The ``None`` default is the absent-marker the route handler uses to
+    gate the audit fold-in (a PATCH that does not touch ``verify_tls``
+    binds no TLS audit keys); an explicit ``False`` / ``True`` flips the
+    column.
+    """
+    assert "verify_tls" in TargetUpdate.model_fields
+    assert TargetUpdate(verify_tls=False).verify_tls is False
+    assert TargetUpdate(verify_tls=True).verify_tls is True
+    # exclude_unset distinguishes "sent" from "defaulted to None".
+    assert "verify_tls" in TargetUpdate(verify_tls=False).model_dump(exclude_unset=True)
+    assert "verify_tls" not in TargetUpdate(host="h").model_dump(exclude_unset=True)
 
 
 def test_target_update_rejects_port_out_of_range() -> None:

--- a/cli/api/openapi.json
+++ b/cli/api/openapi.json
@@ -16860,6 +16860,11 @@
             "type": "boolean",
             "title": "Vpn Required"
           },
+          "verify_tls": {
+            "type": "boolean",
+            "title": "Verify Tls",
+            "default": true
+          },
           "extras": {
             "additionalProperties": true,
             "type": "object",
@@ -17001,6 +17006,11 @@
             "title": "Vpn Required",
             "default": false
           },
+          "verify_tls": {
+            "type": "boolean",
+            "title": "Verify Tls",
+            "default": true
+          },
           "extras": {
             "additionalProperties": true,
             "type": "object",
@@ -17085,6 +17095,11 @@
           "vpn_required": {
             "type": "boolean",
             "title": "Vpn Required"
+          },
+          "verify_tls": {
+            "type": "boolean",
+            "title": "Verify Tls",
+            "default": true
           },
           "fingerprint": {
             "additionalProperties": true,
@@ -17189,6 +17204,11 @@
             "type": "boolean",
             "nullable": true,
             "title": "Vpn Required"
+          },
+          "verify_tls": {
+            "type": "boolean",
+            "nullable": true,
+            "title": "Verify Tls"
           },
           "extras": {
             "additionalProperties": true,

--- a/cli/internal/api/client.gen.go
+++ b/cli/internal/api/client.gen.go
@@ -4443,6 +4443,7 @@ type Target struct {
 	SecretRef       *string                 `json:"secret_ref"`
 	TenantId        openapi_types.UUID      `json:"tenant_id"`
 	UpdatedAt       time.Time               `json:"updated_at"`
+	VerifyTls       *bool                   `json:"verify_tls,omitempty"`
 	Version         *string                 `json:"version"`
 	VpnRequired     bool                    `json:"vpn_required"`
 }
@@ -4484,6 +4485,7 @@ type TargetCreate struct {
 	// Product Connector product slug. Must match the ``product`` field of a registered connector class; see ``GET /api/v1/connectors`` for the live list and ``docs/codebase/error-message-shape.md`` for the 422 shape returned on miss.
 	Product     TargetCreateProduct `json:"product"`
 	SecretRef   *string             `json:"secret_ref"`
+	VerifyTls   *bool               `json:"verify_tls,omitempty"`
 	Version     *string             `json:"version"`
 	VpnRequired *bool               `json:"vpn_required,omitempty"`
 }
@@ -4538,6 +4540,7 @@ type TargetSummary struct {
 	SecretRef       *string                 `json:"secret_ref"`
 	TenantId        openapi_types.UUID      `json:"tenant_id"`
 	UpdatedAt       time.Time               `json:"updated_at"`
+	VerifyTls       *bool                   `json:"verify_tls,omitempty"`
 	Version         *string                 `json:"version"`
 	VpnRequired     bool                    `json:"vpn_required"`
 }
@@ -4589,6 +4592,7 @@ type TargetUpdate struct {
 	PreferredImplId *string                 `json:"preferred_impl_id"`
 	Product         *string                 `json:"product"`
 	SecretRef       *string                 `json:"secret_ref"`
+	VerifyTls       *bool                   `json:"verify_tls"`
 	Version         *string                 `json:"version"`
 	VpnRequired     *bool                   `json:"vpn_required"`
 }


### PR DESCRIPTION
## Summary

- Add a first-class **`verify_tls`** flag to `Target` (`NOT NULL DEFAULT true`, default-secure), mirroring the proven `vpn_required` / `version` first-class-column precedent rather than an unvalidated `extras` key. This ships the **storage + API + audit** surface for a per-target TLS-verification opt-out; the dispatch path that *consumes* the flag (passing `verify=<insecure SSLContext>` to the pooled httpx client) lands in the follow-up T2 (#1781).
- **Audit-binding** on create (when `verify_tls=false`) and update (when the PATCH sends `verify_tls`): binds `audit_*` contextvars so `AuditMiddleware` folds `tls_verification_disabled` + `target_id` + before/after into the `audit_log` payload, plus a WARN log. This closes the never-silent gap the initiative flagged — a target PATCH wrote an *empty* audit payload today.
- **Alembic migration `0044`** (live head verified as `0043` via `alembic heads`; `down_revision="0043"`) adds the column with `server_default=sa.true()` so pre-existing rows backfill to the secure state and the `NOT NULL` add-column is safe on a populated table. Reversible.

## Test plan

- [x] `ruff check` — clean
- [x] `ruff format --check` — clean (8 files)
- [x] `mypy src/` (strict) — clean (480 files)
- [x] `.claude/hooks/code-quality.py --diff` — 0 blockers (extracted `_validate_preferred_impl_id` + `_apply_product_patch` to keep both handlers within budget; remaining warnings are pre-existing legacy debt)
- [x] **AC1** POST defaults `verify_tls=true` when omitted; existing rows read back `true` after `alembic upgrade head` — `test_target_create_defaults`, `test_migration_0044_backfills_verify_tls_true_and_is_reversible`
- [x] **AC2** PATCH `{"verify_tls": false}` persists; `GET` detail **and** `GET` list (`TargetSummary`) both return `verify_tls` — schema round-trip + `test_patch_verify_tls_false_writes_tls_audit_payload`
- [x] **AC3** migration reversible (`upgrade head` → `downgrade`), single head — verified live (`alembic upgrade head` → `downgrade -1` → `upgrade head`, ends `0044 (head)`) + `test_migration_0044_*`
- [x] **AC4** PATCH `verify_tls=false` writes an `audit_log` payload with `tls_verification_disabled=true` + `target_id` + before/after; a PATCH not touching `verify_tls` binds **no** TLS audit keys — `test_patch_verify_tls_false_writes_tls_audit_payload`, `test_patch_without_verify_tls_binds_no_tls_audit_keys`
- [x] **AC5** OpenAPI snapshot + generated Go `Target` struct regenerated + committed; `go build ./...` green; `git diff --exit-code` on the two CLI files exits 0 — `cd cli && make snapshot-openapi && make generate`
- [x] Targets-area pytest — 175 passed, 1 skipped (sandbox); blast-radius sweep on Target-consuming modules — 143 passed

## Out of scope

- Wiring `verify_tls` into `HttpConnector._http_client` (insecure `SSLContext` + cache-key dimension) — T2 (#1781).
- `connector_tls_verify_failed` dispatch error arm — T3 (#1782); operator docs — T4 (#1783); per-target CA-pin — T5 (#1784).
- The connector dataclass test doubles (`_VcsimTarget`, etc.) deliberately carry only the attributes the connector-under-test reads; no connector reads `verify_tls` in T1, so they grow the attribute in lockstep with T2's client read, not here. The real-ORM integration seeders are safe via the ORM `default=True` + the migration's `server_default` backfill.

<!-- auto-implement-issue: fresh, iteration 1 -->

Closes #1780
