### PR TITLE
feat(connectors): wire verify_tls into HttpConnector._http_client (#1781)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -101,6 +101,19 @@ connector-related release-notes line.
   (`tls_verification_disabled` + before/after) and a WARN log, closing
   the prior gap where a target PATCH wrote an empty audit payload
   (#1780).
+- Connector dispatch now **honors the per-target `verify_tls` flag**. A
+  target with `verify_tls=false` reaches a self-signed / internal-CA
+  appliance over an insecure TLS channel (a module-cached `SSLContext`
+  with `check_hostname` off + `CERT_NONE`), emitting a WARN at client
+  construction; a `verify_tls=true` target (the default) is built with
+  **no** `verify=` argument, so the global `SSL_CERT_FILE` / chart
+  trust-bundle path stays byte-identical to before. The pooled-client
+  key gains a `verify_tls` dimension — `(tenant_id, id, verify_tls)` — so
+  a PATCH that flips the flag is not served the stale client, while the
+  `(tenant_id, id)` cross-tenant isolation prefix is unchanged. `Harbor`
+  and `Gcloud` inherit the behaviour through `HttpConnector`; the
+  out-of-pool k8s reachability probe and GitHub App token-exchange are
+  unaffected (#1781).
 - Bulk read-class connector enable path across REST + MCP + CLI:
   `POST /api/v1/connectors/{id}/enable-reads`, the
   `meho.connector.enable_reads` MCP tool, and `meho connector

--- a/backend/src/meho_backplane/connectors/adapters/http.py
+++ b/backend/src/meho_backplane/connectors/adapters/http.py
@@ -24,27 +24,76 @@ client is host-bound via ``base_url``, the collision would route one
 tenant's request to the other tenant's host and leak credentials across
 the tenant boundary (evoila/meho#1682).
 
-**Cert-bundle support:** httpx honours ``SSL_CERT_FILE`` natively; no extra
-cert logic is needed here beyond not overriding the default ``verify`` flag.
+**Cert-bundle support:** httpx honours ``SSL_CERT_FILE`` natively. When a
+target verifies TLS (the default, ``verify_tls=True``) the client is built
+with **no** ``verify=`` argument, so the global ``SSL_CERT_FILE`` /
+chart-trust-bundle path (evoila/meho#209) is in effect unchanged. When a
+target opts out (``verify_tls=False``) the client is built with an explicit
+insecure :class:`ssl.SSLContext` (``check_hostname`` off, ``CERT_NONE``) so
+it can reach a self-signed / internal-CA appliance (evoila/meho#1774). The
+opt-out is per-target, never global, and loud — see
+:func:`_insecure_ssl_context` and the WARN emitted at client construction.
+
+**Client pool key:** the pool is keyed on
+:func:`~meho_backplane.connectors._shared.cache_key.target_cache_key`
+(``(tenant_id, id)``) **plus** :meth:`HttpConnector.extra_cache_dimensions`
+(``(verify_tls,)``), i.e. ``(tenant_id, id, verify_tls)``. Appending
+``verify_tls`` keeps the ``(tenant_id, id)`` tenant-isolation prefix intact
+(evoila/meho#1682/#1642) while ensuring a PATCH that flips ``verify_tls`` is
+not served the stale pooled client built under the previous flag.
 """
 
 from __future__ import annotations
 
 import asyncio
+import ssl
 from typing import Any
 
 import httpx
+import structlog
 from tenacity import retry, retry_if_exception, stop_after_attempt, wait_exponential
 
 from meho_backplane.auth.operator import Operator
 from meho_backplane.connectors._shared.cache_key import target_cache_key
 from meho_backplane.connectors.base import Connector
 
+logger = structlog.get_logger(__name__)
+
 # Forward declaration — replaced with `from meho_backplane.targets import Target`
 # once G0.3 lands the Target model.
 type Target = Any
 
 _IDEMPOTENT_METHODS = frozenset({"GET", "HEAD", "OPTIONS"})
+
+
+def _build_insecure_ssl_context() -> ssl.SSLContext:
+    """Return a one-shot insecure context (verification disabled).
+
+    Reuses the in-tree idiom (``backend/tests/acceptance/_vcsim.py``):
+    start from :func:`ssl.create_default_context`, then disable
+    ``check_hostname`` **before** dropping ``verify_mode`` to
+    :data:`ssl.CERT_NONE`. The order is load-bearing — assigning
+    ``CERT_NONE`` while ``check_hostname`` is still enabled raises
+    ``ValueError`` on Python 3.12 ("Cannot set verify_mode to CERT_NONE
+    when check_hostname is enabled.").
+    """
+    ctx = ssl.create_default_context()
+    ctx.check_hostname = False
+    ctx.verify_mode = ssl.CERT_NONE
+    return ctx
+
+
+# Built once and shared across every insecure dispatch in the process.
+# An ``SSLContext`` is safe to share between clients; it is never mutated
+# after construction, so a single cached instance avoids rebuilding the
+# context (and re-reading the default trust store it starts from) on each
+# verify_tls=False target.
+_INSECURE_SSL_CONTEXT = _build_insecure_ssl_context()
+
+
+def _insecure_ssl_context() -> ssl.SSLContext:
+    """Return the process-wide cached insecure :class:`ssl.SSLContext`."""
+    return _INSECURE_SSL_CONTEXT
 
 
 def _retryable(exc: BaseException) -> bool:
@@ -65,19 +114,70 @@ class HttpConnector(Connector):
 
     def __init__(self) -> None:
         # Keyed on the tenant-unique ``(tenant_id, id)`` tuple
-        # (``target_cache_key``), not ``target.name``: each pooled client
+        # (``target_cache_key``) plus ``extra_cache_dimensions`` (the
+        # ``(verify_tls,)`` flag), not ``target.name``: each pooled client
         # is host-bound via ``base_url``, and two tenants may legitimately
         # own same-named targets pointing at different hosts. Name-keying
         # would route the second tenant's request to the first tenant's
         # host and leak credentials across the boundary (evoila/meho#1682).
-        self._clients: dict[tuple[str, str], httpx.AsyncClient] = {}
+        # The ``verify_tls`` suffix keeps a PATCH that flips the flag from
+        # being served the stale client built under the old value.
+        self._clients: dict[tuple[str, ...], httpx.AsyncClient] = {}
         self._lock = asyncio.Lock()
+
+    def extra_cache_dimensions(self, target: Target) -> tuple[object, ...]:
+        """Return extra pool-key dimensions appended to ``target_cache_key``.
+
+        The base appends the resolved ``verify_tls`` flag so a target that
+        toggles TLS verification (e.g. via PATCH) gets a freshly built
+        client rather than the stale one cached under the previous value —
+        a client's ``verify`` is fixed at construction. The append preserves
+        the ``(tenant_id, id)`` prefix, so the cross-tenant isolation
+        guarantee (evoila/meho#1682/#1642) is unaffected. Subclasses that
+        reach into :attr:`_clients` directly MUST build their lookup key the
+        same way (``target_cache_key(target) + self.extra_cache_dimensions(target)``)
+        so they index the same entry the base created.
+        """
+        return (bool(getattr(target, "verify_tls", True)),)
+
+    def _client_cache_key(self, target: Target) -> tuple[str, ...]:
+        """Return the full pooled-client key for *target*.
+
+        ``target_cache_key`` (``(tenant_id, id)``) plus
+        :meth:`extra_cache_dimensions` (``(verify_tls,)``). Stringified into
+        a flat ``tuple[str, ...]`` so the key is hashable and a subclass that
+        derives it the same way produces an identical tuple.
+        """
+        return target_cache_key(target) + tuple(
+            str(dim) for dim in self.extra_cache_dimensions(target)
+        )
 
     async def _http_client(self, target: Target) -> httpx.AsyncClient:
         """Return the per-target pooled client, creating it on first use."""
-        cache_key = target_cache_key(target)
+        cache_key = self._client_cache_key(target)
+        verify_tls = bool(getattr(target, "verify_tls", True))
         async with self._lock:
             if cache_key not in self._clients:
+                # Pass ``verify=`` ONLY when the target opts out of
+                # verification. When ``verify_tls`` is True we omit the
+                # kwarg entirely so the client defaults to httpx's
+                # ``verify=True``, keeping the global ``SSL_CERT_FILE`` /
+                # chart-trust-bundle path (evoila/meho#209) byte-identical
+                # to a connector with no TLS opt-out at all.
+                verify_kwargs: dict[str, Any] = {}
+                if not verify_tls:
+                    # Per-target, audited last resort (evoila/meho#1774):
+                    # the dispatch forwards a Vault-resolved credential over
+                    # an unverified channel, so make it loud and queryable.
+                    # The audit row is written on target create/update
+                    # (T1 #1780); this WARN marks the actual insecure
+                    # dispatch construction.
+                    logger.warning(
+                        "connector_tls_verification_disabled",
+                        target=getattr(target, "name", None),
+                        host=getattr(target, "host", None),
+                    )
+                    verify_kwargs["verify"] = _insecure_ssl_context()
                 self._clients[cache_key] = httpx.AsyncClient(
                     base_url=self._base_url(target),
                     timeout=httpx.Timeout(connect=5.0, read=30.0, write=30.0, pool=5.0),
@@ -92,6 +192,7 @@ class HttpConnector(Connector):
                     # go through ``_post_json`` which the vendor APIs
                     # don't 301 mid-write.
                     follow_redirects=True,
+                    **verify_kwargs,
                 )
             return self._clients[cache_key]
 

--- a/backend/src/meho_backplane/connectors/nsx/connector.py
+++ b/backend/src/meho_backplane/connectors/nsx/connector.py
@@ -333,10 +333,11 @@ class NsxConnector(HttpConnector):
         async with self._session_lock:
             self._session_tokens.pop(cache_key, None)
             # The shared ``HttpConnector._clients`` pool is keyed on the
-            # same tenant-unique ``(tenant_id, id)`` tuple as the
-            # session-token cache (evoila/meho#1682), so the cookie jar we
-            # clear here belongs to exactly this tenant's host-bound client.
-            client = self._clients.get(cache_key)
+            # tenant-unique ``(tenant_id, id)`` prefix plus the
+            # ``verify_tls`` dimension (evoila/meho#1682/#1774), so build
+            # the full key the base would to index this tenant's
+            # host-bound client and clear exactly its cookie jar.
+            client = self._clients.get(self._client_cache_key(target))
             if client is not None:
                 client.cookies.clear()
 

--- a/backend/src/meho_backplane/connectors/vmware_rest/connector.py
+++ b/backend/src/meho_backplane/connectors/vmware_rest/connector.py
@@ -619,12 +619,21 @@ class VmwareRestConnector(HttpConnector):
             self._session_tokens.clear()
             self._session_paths.clear()
         for cache_key, token in tokens.items():
-            # ``_session_tokens`` and the shared ``HttpConnector._clients``
-            # pool are now keyed on the same tenant-unique
-            # ``(tenant_id, target.id)`` tuple (evoila/meho#1682), so the
-            # cached token's key indexes its host-bound client directly —
-            # no name reverse-map needed.
-            client = self._clients.get(cache_key)
+            # ``_session_tokens`` is keyed on the tenant-unique
+            # ``(tenant_id, target.id)`` tuple, while the shared
+            # ``HttpConnector._clients`` pool keys that same prefix plus a
+            # ``verify_tls`` dimension (evoila/meho#1682/#1774). The token
+            # was minted against exactly one per-target client, so match
+            # the pool entry whose key starts with this token's
+            # ``(tenant_id, id)`` prefix — no name reverse-map needed.
+            client = next(
+                (
+                    pooled
+                    for client_key, pooled in self._clients.items()
+                    if client_key[: len(cache_key)] == cache_key
+                ),
+                None,
+            )
             if client is None:
                 # Theoretically unreachable — every cached token was
                 # established against a per-target client that was

--- a/backend/tests/test_connectors_http_adapter.py
+++ b/backend/tests/test_connectors_http_adapter.py
@@ -21,10 +21,26 @@ Coverage matrix (per Task #242 acceptance criteria):
   different tenants with different hosts get distinct host-bound clients,
   and a dispatch for one tenant never reaches the other tenant's host.
 * ``aclose()`` closes all pooled clients and empties the pool dict.
+
+Per-target TLS trust (evoila/meho#1774, #1781):
+
+* ``verify_tls=True`` (the default) builds the client with **no**
+  ``verify=`` argument, so httpx keeps verification on against the global
+  ``SSL_CERT_FILE`` / chart trust-bundle path — byte-identical to a target
+  with no TLS opt-out at all (asserted via construction-kwarg inspection
+  and the live transport ``SSLContext``).
+* ``verify_tls=False`` builds the client with the module-cached insecure
+  ``SSLContext`` (``check_hostname is False`` **and** ``verify_mode ==
+  ssl.CERT_NONE``, set in that field order).
+* Flipping ``verify_tls`` yields a different pool key and a freshly built
+  client — the stale client is never reused.
+* The ``(tenant_id, id)`` prefix is intact after the append, so same-named
+  targets in different tenants still get distinct clients.
 """
 
 from __future__ import annotations
 
+import ssl
 import types
 from typing import Any
 from unittest.mock import patch
@@ -67,13 +83,16 @@ def _make_target(
     *,
     target_id: str = "11111111-1111-1111-1111-111111111111",
     tenant_id: str = "00000000-0000-0000-0000-000000000000",
+    verify_tls: bool = True,
 ) -> Any:
     """Return a minimal duck-typed Target stub.
 
     Carries ``id`` and ``tenant_id`` because the pooled-client cache is
     keyed on ``target_cache_key`` (``(tenant_id, id)``); a double missing
     either field raises ``AttributeError`` the moment it reaches the pool
-    (evoila/meho#1682).
+    (evoila/meho#1682). ``verify_tls`` defaults to ``True`` — the
+    default-secure model value (T1 #1780) — so the pool-key suffix and the
+    no-``verify=`` construction path match a verifying target.
     """
     return types.SimpleNamespace(
         name=name,
@@ -82,7 +101,21 @@ def _make_target(
         id=target_id,
         tenant_id=tenant_id,
         auth_model="impersonation",
+        verify_tls=verify_tls,
     )
+
+
+def _client_ssl_context(client: httpx.AsyncClient) -> ssl.SSLContext:
+    """Return the live :class:`ssl.SSLContext` httpx built for *client*.
+
+    httpx consumes ``verify`` at construction into the transport's
+    ``httpcore`` connection pool; the resolved context is reachable at
+    ``client._transport._pool._ssl_context``. Reaching into the private
+    attribute is intentional — it is the only way to assert what the
+    transport will actually present on the wire (verification on vs off)
+    rather than what kwarg was passed in.
+    """
+    return client._transport._pool._ssl_context  # type: ignore[attr-defined,no-any-return]
 
 
 class _ConcreteHttpConnector(HttpConnector):
@@ -321,9 +354,10 @@ async def test_different_targets_get_different_clients() -> None:
     client_b = await conn._http_client(target_b)
 
     assert client_a is not client_b
-    # Pool is keyed on the tenant-unique ``(tenant_id, id)`` tuple.
-    assert (target_a.tenant_id, target_a.id) in conn._clients
-    assert (target_b.tenant_id, target_b.id) in conn._clients
+    # Pool is keyed on the tenant-unique ``(tenant_id, id)`` tuple plus the
+    # ``verify_tls`` dimension (stubs default to verify_tls=True).
+    assert conn._client_cache_key(target_a) in conn._clients
+    assert conn._client_cache_key(target_b) in conn._clients
     await conn.aclose()
 
 
@@ -414,3 +448,178 @@ async def test_aclose_idempotent_on_empty_pool() -> None:
     conn = _ConcreteHttpConnector()
     await conn.aclose()
     assert conn._clients == {}
+
+
+# ---------------------------------------------------------------------------
+# Per-target TLS trust — verify_tls wiring (evoila/meho#1774, #1781)
+# ---------------------------------------------------------------------------
+
+
+def test_insecure_ssl_context_field_ordering() -> None:
+    """The module insecure context disables check_hostname before CERT_NONE.
+
+    The acceptance criterion is the *field state*: ``check_hostname is
+    False`` AND ``verify_mode == ssl.CERT_NONE``. That state is only
+    reachable by setting ``check_hostname`` False first — assigning
+    ``CERT_NONE`` while ``check_hostname`` is still enabled raises
+    ``ValueError`` on Python 3.12, so a context that exhibits both is proof
+    the ordering held.
+    """
+    from meho_backplane.connectors.adapters.http import _insecure_ssl_context
+
+    ctx = _insecure_ssl_context()
+    assert ctx.check_hostname is False
+    assert ctx.verify_mode == ssl.CERT_NONE
+
+
+def test_insecure_ssl_context_is_cached_at_module_scope() -> None:
+    """Repeated calls return the same shared context (built once)."""
+    from meho_backplane.connectors.adapters.http import (
+        _INSECURE_SSL_CONTEXT,
+        _insecure_ssl_context,
+    )
+
+    assert _insecure_ssl_context() is _insecure_ssl_context()
+    assert _insecure_ssl_context() is _INSECURE_SSL_CONTEXT
+
+
+@pytest.mark.asyncio
+async def test_verify_tls_false_client_uses_insecure_context() -> None:
+    """A verify_tls=False target's client presents the insecure context.
+
+    Asserts on the live transport ``SSLContext`` (what goes on the wire):
+    ``check_hostname is False``, ``verify_mode == CERT_NONE``, and that it
+    is the module-cached instance — not a per-client rebuild.
+    """
+    from meho_backplane.connectors.adapters.http import _INSECURE_SSL_CONTEXT
+
+    conn = _ConcreteHttpConnector()
+    target = _make_target(name="self-signed-appliance", verify_tls=False)
+
+    client = await conn._http_client(target)
+    ctx = _client_ssl_context(client)
+
+    assert ctx.check_hostname is False
+    assert ctx.verify_mode == ssl.CERT_NONE
+    assert ctx is _INSECURE_SSL_CONTEXT
+    await conn.aclose()
+
+
+@pytest.mark.asyncio
+async def test_verify_tls_true_client_passes_no_verify_arg() -> None:
+    """A verify_tls=True target builds the client with NO verify= kwarg.
+
+    The byte-identical-to-today guarantee (evoila/meho#209): when
+    verification is on we must not pass ``verify=`` at all, so httpx keeps
+    its default ``verify=True`` and honours ``SSL_CERT_FILE``. We assert on
+    the construction kwargs via a patched ``httpx.AsyncClient`` so the
+    proof is the *absence* of the argument, not merely an equivalent
+    context.
+    """
+    conn = _ConcreteHttpConnector()
+    target = _make_target(name="verifying-target", verify_tls=True)
+
+    with patch(
+        "meho_backplane.connectors.adapters.http.httpx.AsyncClient",
+        wraps=httpx.AsyncClient,
+    ) as mock_client:
+        await conn._http_client(target)
+
+    assert mock_client.call_count == 1
+    _, kwargs = mock_client.call_args
+    assert "verify" not in kwargs
+    await conn.aclose()
+
+
+@pytest.mark.asyncio
+async def test_verify_tls_true_client_keeps_default_verification() -> None:
+    """The verify_tls=True transport context verifies (CERT_REQUIRED + SNI).
+
+    Complements the kwarg-absence assertion with the resulting wire state:
+    a default httpx client verifies (``check_hostname`` on, ``verify_mode
+    == CERT_REQUIRED``) — exactly the pre-#1781 behaviour.
+    """
+    conn = _ConcreteHttpConnector()
+    target = _make_target(name="verifying-target", verify_tls=True)
+
+    client = await conn._http_client(target)
+    ctx = _client_ssl_context(client)
+
+    assert ctx.check_hostname is True
+    assert ctx.verify_mode == ssl.CERT_REQUIRED
+    await conn.aclose()
+
+
+@pytest.mark.asyncio
+async def test_flipping_verify_tls_yields_distinct_client_not_served_stale() -> None:
+    """Toggling verify_tls produces a different pool key and a fresh client.
+
+    A PATCH that flips verify_tls must not be served the stale pooled
+    client built under the previous flag (a client's ``verify`` is fixed at
+    construction). Same target identity (tenant_id, id), different flag →
+    distinct keys, distinct clients.
+    """
+    conn = _ConcreteHttpConnector()
+    secure = _make_target(name="t", target_id="same-id", tenant_id="same-tenant", verify_tls=True)
+    insecure = _make_target(
+        name="t", target_id="same-id", tenant_id="same-tenant", verify_tls=False
+    )
+
+    client_secure = await conn._http_client(secure)
+    client_insecure = await conn._http_client(insecure)
+
+    assert client_secure is not client_insecure
+    # Distinct pool keys, sharing the (tenant_id, id) prefix.
+    key_secure = conn._client_cache_key(secure)
+    key_insecure = conn._client_cache_key(insecure)
+    assert key_secure != key_insecure
+    assert key_secure[:2] == key_insecure[:2] == ("same-tenant", "same-id")
+    # The insecure client really is insecure; the secure one really verifies.
+    assert _client_ssl_context(client_insecure).verify_mode == ssl.CERT_NONE
+    assert _client_ssl_context(client_secure).verify_mode == ssl.CERT_REQUIRED
+    # Re-fetching the secure target returns the original secure client,
+    # never the insecure one minted in between.
+    assert await conn._http_client(secure) is client_secure
+    await conn.aclose()
+
+
+@pytest.mark.asyncio
+async def test_same_id_different_tenant_distinct_clients_with_verify_tls() -> None:
+    """The (tenant_id, id) prefix still isolates tenants after the append.
+
+    Two targets sharing an ``id`` but owned by different tenants (and
+    pointing at different hosts) get distinct host-bound clients even when
+    both carry the same verify_tls value — the appended dimension never
+    collapses the tenant prefix (evoila/meho#1682/#1642).
+    """
+    conn = _ConcreteHttpConnector()
+    target_a = _make_target(
+        name="prod", host="a.example.com", target_id="shared-id", tenant_id="tenant-a"
+    )
+    target_b = _make_target(
+        name="prod", host="b.example.com", target_id="shared-id", tenant_id="tenant-b"
+    )
+
+    client_a = await conn._http_client(target_a)
+    client_b = await conn._http_client(target_b)
+
+    assert client_a is not client_b
+    assert str(client_a.base_url) == "https://a.example.com"
+    assert str(client_b.base_url) == "https://b.example.com"
+    assert conn._client_cache_key(target_a) != conn._client_cache_key(target_b)
+    await conn.aclose()
+
+
+def test_extra_cache_dimensions_defaults_to_verify_tls_true() -> None:
+    """A target missing verify_tls defaults to the secure (True) dimension.
+
+    Guards the ``getattr(target, "verify_tls", True)`` fallback so a
+    duck-typed double or a pre-migration row defaults to verification on,
+    never silently insecure.
+    """
+    conn = _ConcreteHttpConnector()
+    without_attr = types.SimpleNamespace(
+        name="legacy", host="h", port=443, id="i", tenant_id="t", auth_model="impersonation"
+    )
+    assert conn.extra_cache_dimensions(without_attr) == (True,)
+    assert conn._client_cache_key(without_attr) == ("t", "i", "True")

--- a/docs/architecture/connectors.md
+++ b/docs/architecture/connectors.md
@@ -186,7 +186,7 @@ Connector (ABC)                                      ← G0.2-T1 (shipped)
     └── HolodeckConnector
 ```
 
-**HTTP adapter** (T3, shipped): shared `httpx.AsyncClient` per target with retry on idempotent verbs only, `SSL_CERT_FILE` honored natively for the trust-bundle wiring from PR #212.
+**HTTP adapter** (T3, shipped): shared `httpx.AsyncClient` per target with retry on idempotent verbs only. TLS trust is per-target (#1774): a `verify_tls=True` target (the default) is built with **no** `verify=` argument so `SSL_CERT_FILE` is honored natively for the trust-bundle wiring from PR #212 — byte-identical to a connector with no TLS opt-out; a `verify_tls=False` target is built with a module-cached insecure `SSLContext` (`check_hostname` off, `CERT_NONE`) so it can reach a self-signed / internal-CA appliance. The opt-out is per-target, off by default, and loud (WARN at construction + audit row from the create/update path). The client pool key is the tenant-unique `(tenant_id, id)` (`target_cache_key`) plus the `verify_tls` dimension (`extra_cache_dimensions`) → `(tenant_id, id, verify_tls)`, so a PATCH that flips the flag is not served the stale client and the `(tenant_id, id)` tenant-isolation prefix (#1682/#1642) is unchanged.
 
 **SSH adapter** (T4, shipped): asyncssh (async-native, no thread offload — beats paramiko for the event loop). Per-target connection cached in `SshConnector._connections`; `known_hosts=None` for v0.2 (host-key pinning deferred to v0.2.next). Auth reads `target.secret_ref`: `ssh_private_key` → key auth, `password` → password auth fallback. Closed on lifespan teardown via `aclose()`.
 


### PR DESCRIPTION
## Summary

- Wire the per-target **`verify_tls`** flag (T1 #1780) into `HttpConnector._http_client` so a `verify_tls=false` target can reach a self-signed / internal-CA appliance (Initiative #1774, Goal #214 connector-parity).
- `verify_tls=false` builds the pooled client with a **module-cached insecure `ssl.SSLContext`** (`check_hostname` disabled **before** `CERT_NONE` — reusing the in-tree `_vcsim.py` idiom; reverse order raises `ValueError`) and emits a WARN at construction so the insecure dispatch is loud, not silent.
- `verify_tls=true` (the default) passes **no `verify=` argument at all**, so the global `SSL_CERT_FILE` / chart trust-bundle path (#209) is byte-identical to before — verification stays on. (httpx 0.28.1: `verify=<ssl.SSLContext>` is the forward-safe shape.)
- The pooled-client key gains a `verify_tls` dimension via a new `extra_cache_dimensions` hook → `(tenant_id, id, verify_tls)`. Pure append: the `(tenant_id, id)` cross-tenant isolation prefix (#1682/#1642) is unchanged, and a PATCH that flips the flag is not served the stale client. The two subclass reach-ins into the inherited `_clients` pool (NSX cookie-clear on session re-establish; vSphere session-revoke on close) are updated to build the same full key.

## Test plan

- [x] `ruff check src/ tests/` — clean
- [x] `ruff format --check src/ tests/` — clean (984 files)
- [x] `mypy src/` (strict) — clean (480 source files)
- [x] `pytest -n 6 --dist loadscope --ignore=tests/integration` — 7625 passed, 195 skipped (sandbox secret guards)
- [x] code-quality `--diff` — 0 blockers, 7 pre-existing warnings
- [x] **AC: `verify_tls=true` builds client with NO `verify=` arg** — asserted via a patched `httpx.AsyncClient` (kwarg-absence) *and* the live transport `SSLContext` (`check_hostname` True, `verify_mode == CERT_REQUIRED`) — byte-identical to today.
- [x] **AC: `verify_tls=false` client uses the insecure context** — live transport `SSLContext` has `check_hostname is False` and `verify_mode == ssl.CERT_NONE`, and is the module-cached instance; a dedicated test asserts the field-ordering.
- [x] **AC: flipping `verify_tls` → distinct key + freshly built client** — stale client not reused; `(tenant_id, id)` prefix shared.
- [x] **AC: same-id different-tenant → distinct clients** — the appended dimension never collapses the tenant prefix.
- [x] **AC: `Harbor`/`Gcloud` inherit via `super()._http_client`** — no extra change; NSX + vSphere session-cleanup tests (`test_aclose_revokes_every_cached_session`, `test_downstream_401_triggers_relogin_and_retry_once`) pass with the new key shape.
- [x] CLI OpenAPI snapshot + generated client byte-unchanged (`git diff --exit-code -- cli/api/openapi.json cli/internal/api/client.gen.go` after `make snapshot-openapi && make generate`) — no route/schema change.

## Out of scope

- The two out-of-pool dispatch clients named out-of-scope in #1774 — the k8s reachability probe (`kubernetes/connector.py`, already hardcodes `verify=False`) and the GitHub App token-exchange (`github/session.py`, public-cert `api.github.com`) — do not honor `verify_tls` and are unchanged.
- CA-pin (T5 #1784) — the secure supersession follow-up; the friendlier error message (T3 #1782, already merged).
- Adjacent findings (recorded, not edited): pre-existing code-quality WARNs on `nsx/connector.py` (529 lines) and `vmware_rest/connector.py` (671 lines, file-size) and a few >60-line functions in those files; `_request_json`'s PLR0913 (6 args) — all pre-existing, untouched by this change.

<!-- auto-implement-issue: fresh, iteration 1 -->

Closes #1781
