### PR TITLE
fix(connectors): import sets verify_tls + tls_ca_pin as first-class fields (#1793)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -189,6 +189,17 @@ connector-related release-notes line.
 
 ### Fixed
 
+- **`meho targets import` now sets the per-target TLS-trust columns
+  `verify_tls` and `tls_ca_pin`** instead of silently spilling them into
+  the `extras` JSONB blob. Both keys were missing from the import
+  mapper's `knownTopLevel` allow-set, so a descriptor that set
+  `verify_tls: false` (or pinned a CA via `tls_ca_pin`) produced a target
+  that kept its secure column defaults and still verified against the
+  global bundle — a silent, security-relevant surprise. They are now
+  first-class descriptor keys on both create and `--update`; the server's
+  mutual-exclusivity / PEM-validation `422` surfaces through the import
+  path, and genuinely-unknown keys still spill to `extras`. Completes the
+  import-side wiring of per-target TLS trust (#1780 / #1784) (#1793).
 - Operator-console **readiness pill now reflects real backend health on
   every page**, not just the dashboard. The sidebar-footer pill was
   stuck on yellow "starting" across all `/ui/*` surfaces because ~14
@@ -233,12 +244,12 @@ connector-related release-notes line.
   trust-bundle CA-trust as the **secure** path (including the #572
   public-roots-clobber footgun), and per-target CA-pin (#1784) as the
   planned secure supersession; it documents setting `verify_tls` via the
-  REST API `POST` / `PATCH /api/v1/targets` (the only supported path —
-  `meho targets import` spills the key into `extras` and does not set the
-  column), references the `connector_tls_verify_failed` dispatch error
-  (#1782), and names the two out-of-pool connectors (k8s probe, GitHub
-  token-exchange) that do not honour the flag.
-  `docs/architecture/connectors.md` cross-links it (#1783).
+  REST API `POST` / `PATCH /api/v1/targets` (and, since #1793, via
+  `meho targets import` as a first-class descriptor key), references the
+  `connector_tls_verify_failed` dispatch error (#1782), and names the two
+  out-of-pool connectors (k8s probe, GitHub token-exchange) that do not
+  honour the flag. `docs/architecture/connectors.md` cross-links it
+  (#1783).
 
 ## [0.15.0] - 2026-06-13
 

--- a/cli/internal/cmd/targets/import.go
+++ b/cli/internal/cmd/targets/import.go
@@ -58,6 +58,16 @@ type importDoc struct {
 // verb is the only writer; the API rejects any value via
 // `extra='forbid'`); see skipSilent below for the corresponding
 // skip rule.
+//
+// Initiative #1774 amendment: `verify_tls` (#1780) and `tls_ca_pin`
+// (#1784) are first-class per-target TLS-trust columns on both
+// TargetCreate and TargetUpdate. They must map to the top-level body
+// — spilling them into `extras` would leave the typed columns at
+// their secure defaults (`verify_tls NOT NULL DEFAULT true`,
+// `tls_ca_pin NULL`), silently ignoring an operator who set them in
+// the descriptor. The server enforces their mutual exclusivity
+// (`verify_tls=false` ⊕ `tls_ca_pin`) and PEM validation with a 422,
+// which the import path surfaces via the existing error handling.
 var knownTopLevel = map[string]struct{}{
 	"aliases":           {},
 	"auth_model":        {},
@@ -70,6 +80,8 @@ var knownTopLevel = map[string]struct{}{
 	"preferred_impl_id": {},
 	"product":           {},
 	"secret_ref":        {},
+	"tls_ca_pin":        {},
+	"verify_tls":        {},
 	"vpn_required":      {},
 }
 
@@ -167,10 +179,10 @@ func newImportCmd() *cobra.Command {
 			"Mapping rules. Top-level columns recognised on the API's " +
 			"TargetCreate / TargetUpdate models are mapped 1:1: name, aliases, " +
 			"product, host, port, fqdn, secret_ref, auth_model, vpn_required, " +
-			"notes, preferred_impl_id. Any other field is spilled into the " +
-			"`extras` JSONB column. `fingerprint` is server-managed and " +
-			"skipped with a warning if present in the YAML (the probe verb " +
-			"is the only legitimate writer).\n\n" +
+			"notes, preferred_impl_id, verify_tls, tls_ca_pin. Any other field " +
+			"is spilled into the `extras` JSONB column. `fingerprint` is " +
+			"server-managed and skipped with a warning if present in the YAML " +
+			"(the probe verb is the only legitimate writer).\n\n" +
 			"Idempotency. Default mode aborts the whole import if any entry's " +
 			"`name` already exists in the tenant (no partial write — the plan " +
 			"is built before any API call fires). `--update` PATCHes existing " +

--- a/cli/internal/cmd/targets/import_test.go
+++ b/cli/internal/cmd/targets/import_test.go
@@ -175,6 +175,94 @@ func TestMapEntryPreferredImplIDIsTopLevel(t *testing.T) {
 	}
 }
 
+func TestMapEntryTLSTrustKeysAreTopLevel(t *testing.T) {
+	t.Parallel()
+	// Initiative #1774: verify_tls (#1780) and tls_ca_pin (#1784) are
+	// first-class per-target TLS-trust columns on TargetCreate /
+	// TargetUpdate. They must land in the body root, NOT spill into
+	// extras — spilling would leave the typed columns at their secure
+	// defaults and silently ignore an operator who set them in the
+	// descriptor.
+	body, warnings := mapEntry(map[string]any{
+		"name":       "vcf-logs-lab",
+		"product":    "vmware-rest",
+		"host":       "vrli.nested.lab",
+		"verify_tls": false,
+		"tls_ca_pin": "-----BEGIN CERTIFICATE-----\nMIIB...\n-----END CERTIFICATE-----\n",
+	})
+	if len(warnings) != 0 {
+		t.Errorf("warnings: got %v; want none", warnings)
+	}
+	if v, ok := body["verify_tls"]; !ok || v != false {
+		t.Errorf("verify_tls top-level: got %v (present=%t); want false", v, ok)
+	}
+	if v, ok := body["tls_ca_pin"]; !ok || v == "" {
+		t.Errorf("tls_ca_pin top-level: got %v (present=%t); want the PEM", v, ok)
+	}
+	// Neither key may leak into extras.
+	if extras, ok := body["extras"].(map[string]any); ok {
+		for _, k := range []string{"verify_tls", "tls_ca_pin"} {
+			if _, leaked := extras[k]; leaked {
+				t.Errorf("%q leaked into extras: %v", k, extras)
+			}
+		}
+	}
+}
+
+func TestEntryToUpdateBodyTLSTrustKeysAreTopLevel(t *testing.T) {
+	t.Parallel()
+	// `meho targets import --update` routes through entryToUpdateBody.
+	// The TLS-trust keys must reach the sparse PATCH body's top level
+	// (TargetUpdate carries verify_tls / tls_ca_pin), not extras, so a
+	// descriptor re-import flips the columns rather than the JSONB blob.
+	body, _ := entryToUpdateBody(map[string]any{
+		"name":       "vcf-logs-lab",
+		"verify_tls": true,
+		"tls_ca_pin": nil, // clearing the pin is an explicit-null PATCH
+	})
+	if v, ok := body["verify_tls"]; !ok || v != true {
+		t.Errorf("verify_tls top-level on update: got %v (present=%t); want true", v, ok)
+	}
+	if _, ok := body["tls_ca_pin"]; !ok {
+		t.Errorf("tls_ca_pin missing from update body; want top-level null: %v", body)
+	}
+	if extras, ok := body["extras"].(map[string]any); ok {
+		for _, k := range []string{"verify_tls", "tls_ca_pin"} {
+			if _, leaked := extras[k]; leaked {
+				t.Errorf("%q leaked into extras on update: %v", k, extras)
+			}
+		}
+	}
+}
+
+func TestMapEntryTLSTrustTopLevelStillSpillsUnknown(t *testing.T) {
+	t.Parallel()
+	// No-regression guard: adding the TLS-trust keys to knownTopLevel
+	// must not change the extras-spill behaviour for genuinely-unknown
+	// keys. verify_tls / tls_ca_pin go top-level; an unrelated unknown
+	// key alongside them still spills into extras.
+	body, _ := mapEntry(map[string]any{
+		"name":       "vcf-logs-lab",
+		"product":    "vmware-rest",
+		"host":       "vrli.nested.lab",
+		"verify_tls": false,
+		"sso_realm":  "evba.lab", // unknown → spill
+	})
+	if v, ok := body["verify_tls"]; !ok || v != false {
+		t.Errorf("verify_tls top-level: got %v (present=%t); want false", v, ok)
+	}
+	extras, ok := body["extras"].(map[string]any)
+	if !ok {
+		t.Fatalf("extras: got %T; want map[string]any (unknown key should spill)", body["extras"])
+	}
+	if extras["sso_realm"] != "evba.lab" {
+		t.Errorf("extras.sso_realm: got %v; want evba.lab", extras["sso_realm"])
+	}
+	if _, leaked := extras["verify_tls"]; leaked {
+		t.Errorf("verify_tls must not be in extras: %v", extras)
+	}
+}
+
 func TestMapEntryExplicitExtrasMergesWithSpilled(t *testing.T) {
 	t.Parallel()
 	body, _ := mapEntry(map[string]any{

--- a/deploy/values-examples/README.md
+++ b/deploy/values-examples/README.md
@@ -502,24 +502,61 @@ does not mention `verify_tls` leaves it (and the TLS audit trail)
 untouched; only an explicit `{"verify_tls": false}` / `{"verify_tls": true}`
 flips the column and writes the audit row.
 
-> **`meho targets import` does NOT set `verify_tls` or `tls_ca_pin` (use
-> the REST API above).** The bulk-import path
-> ([`cli/internal/cmd/targets/import.go`](../../cli/internal/cmd/targets/import.go))
-> maps a fixed set of known top-level YAML keys onto the create/update
-> body and **spills every other key into the `extras` JSONB column**.
-> Neither `verify_tls` nor `tls_ca_pin` is in that known-key set, so a
-> `verify_tls: false` or `tls_ca_pin: ...` line in the descriptor file
-> silently lands in `extras` instead of the first-class column — the
-> `verify_tls` column keeps its secure default (`true`) and the target
-> stays unpinned. Setting either from the import file would give you a
-> target you *think* is opted out / pinned but that still verifies against
-> the global bundle. There is also no `meho targets create` / `meho
-> targets update` verb (the CLI's only write path is `import`; direct
-> write verbs are out of scope for v0.2 — see
-> [`cli/internal/cmd/targets/targets.go`](../../cli/internal/cmd/targets/targets.go)).
-> Until the import path learns the keys, the **REST API
-> `POST` / `PATCH /api/v1/targets`** shown above is the only supported
-> way to set `verify_tls` and `tls_ca_pin`.
+#### Setting `verify_tls` / `tls_ca_pin` from a `targets.yaml`
+
+`meho targets import` **does** set `verify_tls` and `tls_ca_pin` as
+first-class fields (#1793). The bulk-import path
+([`cli/internal/cmd/targets/import.go`](../../cli/internal/cmd/targets/import.go))
+maps a fixed set of known top-level YAML keys onto the create/update
+body and spills every other key into the `extras` JSONB column; both
+TLS-trust keys are in that known-key set, so a `verify_tls:` or
+`tls_ca_pin:` line in the descriptor reaches the typed column (it does
+**not** spill into `extras`). This covers both `meho targets import`
+(create) and `meho targets import --update` (PATCH). There is still no
+`meho targets create` / `meho targets update` verb — `import` is the
+CLI's only write path (direct write verbs are out of scope for v0.2;
+see [`cli/internal/cmd/targets/targets.go`](../../cli/internal/cmd/targets/targets.go))
+— so the REST `POST` / `PATCH /api/v1/targets` calls above and the
+descriptor below are the two supported ways to set these.
+
+```yaml
+# targets.yaml — imported with `meho targets import targets.yaml`
+# (add --update to PATCH targets that already exist).
+targets:
+  # Secure path: pin the appliance CA. Verification stays ON (chain +
+  # hostname) against the pinned CA. Prefer this over verify_tls: false.
+  - name: vcf-logs-lab
+    product: vmware-rest
+    host: vrli.nested.lab
+    auth_model: shared_service_account
+    tls_ca_pin: |
+      -----BEGIN CERTIFICATE-----
+      MIIB...appliance CA PEM...
+      -----END CERTIFICATE-----
+
+  # Last resort: verification OFF for this one target. Read the MITM /
+  # credential-exposure caveat above before setting this.
+  - name: legacy-appliance
+    product: vmware-rest
+    host: appliance.nested.lab
+    auth_model: shared_service_account
+    verify_tls: false
+```
+
+> **Security framing carries over to import.** `verify_tls: false` is
+> the same insecure last resort the section above describes — it
+> disables chain + hostname verification for that target, so a forwarded
+> credential is exposed to a man-in-the-middle. Prefer `tls_ca_pin`,
+> which keeps verification on against the pinned CA. The server enforces
+> the precedence and **mutual exclusion** noted above: a descriptor entry
+> that sets **both** `verify_tls: false` and `tls_ca_pin` on the same
+> target is rejected with a `422` (they are mutually exclusive), and a
+> malformed PEM is likewise rejected with a `422` — the import surfaces
+> the server's error rather than silently picking one or applying a bad
+> pin. Omitting both keys lands the secure default (`verify_tls: true`,
+> no pin), and on `--update` an omitted key follows the same sparse-PATCH
+> semantics as the REST `PATCH` (the column and its TLS audit trail are
+> left untouched).
 
 ### Coverage gap: two out-of-pool connectors do not honour `verify_tls`
 


### PR DESCRIPTION
## Summary

- `meho targets import` silently dropped the per-target TLS-trust keys `verify_tls` and `tls_ca_pin`: both were missing from the import mapper's `knownTopLevel` allow-set in `cli/internal/cmd/targets/import.go`, so `mapEntry` routed them into the `extras` JSONB blob instead of the typed columns. An operator who set `verify_tls: false` (or pinned a CA via `tls_ca_pin`) in their `targets.yaml` got a target that kept its secure column defaults and still verified against the global bundle — a silent, security-relevant surprise.
- Adds `tls_ca_pin` and `verify_tls` to `knownTopLevel` (kept alphabetically sorted: after `secret_ref`, before `vpn_required`) so both keys pass through to the top-level create/update body for `meho targets import` (create) and `--update` (PATCH via `entryToUpdateBody`).
- The Go client structs already carry `VerifyTls *bool` / `TlsCaPin *string` (regenerated in #1780 / #1784), so this is a **CLI-mapping + docs change only** — no API surface change; the OpenAPI snapshot is unchanged.
- Completes the import-side wiring of per-target TLS trust (Initiative #1774; columns #1780 / #1784; docs #1783).

## Test plan

- [x] `go build ./...` — clean
- [x] `go vet ./...` — clean
- [x] `gofmt -l` on changed files — clean (no output)
- [x] `go test ./internal/cmd/targets/...` — ok (73 tests; +3 new)
- [x] `go test ./...` (full CLI) — all packages ok
- [x] **CLI OpenAPI snapshot unchanged** — `git diff --exit-code -- cli/api/openapi.json cli/internal/api/client.gen.go` exits 0 (no regen)
- [x] **AC1** `verify_tls: false` / `tls_ca_pin` route to the top-level body, not `extras` — `TestMapEntryTLSTrustKeysAreTopLevel`
- [x] **AC2** `--update` updates the columns — `TestEntryToUpdateBodyTLSTrustKeysAreTopLevel` (the `--update` path goes through `entryToUpdateBody`)
- [x] **AC3** both `verify_tls: false` + `tls_ca_pin` set → the server's `422` (mutual exclusivity) surfaces through the import path's existing `httpError` → `renderHTTPStatus` handling (no new machinery; confirmed)
- [x] **AC4** genuinely-unknown keys still spill to `extras` (no allow-set regression) — `TestMapEntryTLSTrustTopLevelStillSpillsUnknown` + existing `TestMapEntryUnknownSpillsToExtras`
- [x] **AC5** docs updated — `deploy/values-examples/README.md`: the stale "`meho targets import` does NOT set `verify_tls`" caveat is replaced with the accurate first-class statement + a `targets.yaml` descriptor example; the `verify_tls=false` last-resort / MITM caveat and the CA-pin-is-secure framing are kept intact. The matching stale line in the CHANGELOG `[Unreleased]` #1783 bullet is corrected.

## Out of scope

- The `meho targets import --update --dry-run` CREATE-vs-UPDATE existence bug (#1785) — separate `buildOfflinePlan` issue.
- Any backend/API change (columns + validation + audit already ship via #1780 / #1784).

<!-- auto-implement-issue: fresh, iteration 1 -->

Closes #1793


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Fixed TLS trust field handling during target import. Fields are now properly mapped as standard descriptor keys instead of being stored in supplementary fields, ensuring correct column handling and validation behavior.

* **Documentation**
  * Updated documentation to clarify that TLS configuration is recognized and properly handled during target import operations for both creating and updating targets.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->