### PR TITLE
fix(knowledge): make docs-corpus entitlement diagnosable across MCP / REST / UI (#1802)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -93,6 +93,7 @@ connector-related release-notes line.
 ### Fixed
 
 - Unify connector-id resolution across `GET /api/v1/connectors/{id}/review` and `POST /api/v1/connectors/{id}/enable-reads` so a label resolves to the **same** row on both paths: `enable-reads` now honours the same tenant→built-in global fallback `review` had (a global-only connector enables its reads instead of returning 404), and a label that maps to **both** a tenant-curated row and a built-in row returns a structured `connector_scope_ambiguous` 409 listing the candidate rows on both paths — instead of `review` silently picking one and `enable-reads` 404'ing (#1801).
+- Docs-corpus entitlement denials are now **diagnosable** instead of opaque: `/ui/corpus` names the missing `meho-docs:<collection>` capability + the resolved identity/tenant when a corpus exists but the session identity isn't entitled (distinct from the genuinely-unprovisioned empty state), and `POST /api/v1/search_docs` returns a structured `403` (`{"error":"not_entitled","collection","required_capability","operator_sub","tenant_id"}`) — so an operator can grant exactly the right claim. The MCP `search_docs` / `ask_docs` `-32602` carries the same on `error.data`. The three surfaces' entitlement contract is verified consistent (same `(tenant_id, capabilities)` derivation; the only divergence is the per-audience token MCP vs REST/UI validate), and the Keycloak per-audience `meho-docs:*` claim requirement is documented in `deploy/` (#1802).
 
 ### Documentation
 

--- a/backend/src/meho_backplane/api/v1/search_docs.py
+++ b/backend/src/meho_backplane/api/v1/search_docs.py
@@ -231,9 +231,20 @@ async def _resolve_collection_or_http_error(
             },
         ) from exc
     except CollectionForbiddenError as exc:
+        # Structured 403 (not a bare string) so a client / the CLI status
+        # renderer can name the *missing capability* and the *identity it
+        # checked* — the actionable diagnostic that turns an opaque "not
+        # entitled" into "grant meho-docs:<key> to <sub>/<tenant>" (T2 #1802).
         raise HTTPException(
             status_code=status.HTTP_403_FORBIDDEN,
-            detail=str(exc),
+            detail={
+                "error": "not_entitled",
+                "collection": exc.collection_key,
+                "required_capability": exc.required_capability,
+                "operator_sub": exc.operator_sub,
+                "tenant_id": exc.tenant_id,
+                "message": str(exc),
+            },
         ) from exc
     except CollectionDisabledError as exc:
         raise HTTPException(
@@ -314,11 +325,14 @@ async def _run_fanout_or_http_error(
                 "Terminal rejection of an otherwise-resolvable collection, "
                 "in one of two forms (both 403, distinguished by the "
                 "``detail.error`` field): the tenant is not entitled to the "
-                "named collection -- it lacks the ``meho-docs:<collection>`` "
-                "capability even though it can see the add-on -- or the "
-                "collection has been ``disabled`` by an operator "
-                "(``detail.error='collection_disabled'``). Neither is "
-                "retryable: the collection exists but the principal cannot "
+                "named collection (``detail.error='not_entitled'`` -- it "
+                "lacks the ``meho-docs:<collection>`` capability even though "
+                "it can see the add-on; the structured detail names the "
+                "``required_capability`` and the ``operator_sub`` / "
+                "``tenant_id`` it checked so the operator can grant the "
+                "missing claim) -- or the collection has been ``disabled`` by "
+                "an operator (``detail.error='collection_disabled'``). Neither "
+                "is retryable: the collection exists but the principal cannot "
                 "search it, or an operator switched it off."
             ),
         },

--- a/backend/src/meho_backplane/docs_search/collection_access.py
+++ b/backend/src/meho_backplane/docs_search/collection_access.py
@@ -137,11 +137,36 @@ class CollectionForbiddenError(CollectionAccessError):
     capability for *this* collection. Surfaces map this to a 403-class
     rejection so it reads as "denied", not "not found" — the collection
     exists; the principal just cannot search it.
+
+    The error names the **missing capability** (``required_capability``) and
+    the **identity it checked** (``operator_sub`` + ``tenant_id``) so every
+    surface can render an *actionable* diagnostic — "your identity ``<sub>``
+    (tenant ``<id>``) is missing capability ``meho-docs:<key>``" — instead of
+    an opaque "not entitled" / empty result (T2 #1802). The asymmetry that
+    motivated this (MCP succeeds where REST / the UI session 403 / empty) is
+    a per-audience Keycloak claim divergence: the surface telling the
+    operator *which* capability is absent *on which identity* is what lets
+    them fix the mapper rather than guess (see
+    ``deploy/values-examples/README.md`` § meho-docs entitlement claim).
     """
 
-    def __init__(self, collection_key: str) -> None:
+    def __init__(
+        self,
+        collection_key: str,
+        *,
+        required_capability: str,
+        operator_sub: str,
+        tenant_id: str,
+    ) -> None:
+        self.required_capability = required_capability
+        self.operator_sub = operator_sub
+        self.tenant_id = tenant_id
         super().__init__(
-            f"not entitled to doc collection {collection_key!r}",
+            (
+                f"identity {operator_sub!r} (tenant {tenant_id}) is not entitled to "
+                f"doc collection {collection_key!r}: missing capability "
+                f"{required_capability!r}"
+            ),
             collection_key=collection_key,
         )
 
@@ -290,10 +315,16 @@ async def resolve_entitled_ready_collection(
         _log.warning(
             "doc_collection_entitlement_denied",
             tenant_id=str(operator.tenant_id),
+            operator_sub=operator.sub,
             collection_key=row.collection_key,
             required_capability=capability,
         )
-        raise CollectionForbiddenError(row.collection_key)
+        raise CollectionForbiddenError(
+            row.collection_key,
+            required_capability=capability,
+            operator_sub=operator.sub,
+            tenant_id=str(operator.tenant_id),
+        )
 
     if row.status != _READY_STATUS:
         _log.info(

--- a/backend/src/meho_backplane/mcp/tools/docs.py
+++ b/backend/src/meho_backplane/mcp/tools/docs.py
@@ -213,7 +213,16 @@ async def _resolve_collection_or_error(
                 data={"known_collections": exc.known_keys},
             ) from exc
         except CollectionForbiddenError as exc:
-            raise McpInvalidParamsError(f"{tool}: {exc}") from exc
+            # ``str(exc)`` already names the missing capability + the identity
+            # it checked; also surface the capability key on ``error.data`` so
+            # an agent can self-correct without parsing the message (T2 #1802).
+            raise McpInvalidParamsError(
+                f"{tool}: {exc}",
+                data={
+                    "reason": "not_entitled",
+                    "required_capability": exc.required_capability,
+                },
+            ) from exc
         except CollectionDisabledError as exc:
             raise McpInvalidParamsError(
                 f"{tool}: {exc}",

--- a/backend/src/meho_backplane/ui/routes/corpus/routes.py
+++ b/backend/src/meho_backplane/ui/routes/corpus/routes.py
@@ -162,7 +162,9 @@ async def _resolve_operator(session: UISessionContext) -> Operator:
     return operator
 
 
-async def _list_entitled_collections(operator: Operator) -> list[DocCollectionSummary]:
+async def _list_entitled_collections(
+    operator: Operator,
+) -> tuple[list[DocCollectionSummary], list[str]]:
     """List the doc collections *operator* is entitled to search.
 
     Mirrors the ``GET /api/v1/doc_collections`` catalogue query: reads
@@ -172,6 +174,16 @@ async def _list_entitled_collections(operator: Operator) -> list[DocCollectionSu
     ``meho-docs:<collection_key>`` for -- the same per-collection
     entitlement ``search_docs`` enforces, so every listed key is one the
     search path will accept. An unprovisioned tenant gets an empty list.
+
+    Returns ``(entitled_summaries, unentitled_keys)``. ``unentitled_keys``
+    is the sorted set of visible collection keys the operator is **not**
+    entitled to (no ``meho-docs:<key>`` capability). It is the signal the
+    empty-state diagnostic uses to tell a "no docs corpus exists at all"
+    tenant apart from a "a corpus exists but your identity is missing the
+    capability" one — the diagnosability gap T2 (#1802) closes. The keys
+    are never rendered as a picker (an un-entitled collection stays hidden
+    from the search surface); they only name a concrete missing capability
+    in the diagnostic.
     """
     sessionmaker = get_sessionmaker()
     async with sessionmaker() as db_session:
@@ -191,13 +203,57 @@ async def _list_entitled_collections(operator: Operator) -> list[DocCollectionSu
         if existing is None or row.tenant_id is not None:
             by_key[row.collection_key] = row
 
-    entitled = [
-        row
-        for row in by_key.values()
-        if collection_capability_key(row.collection_key) in operator.capabilities
-    ]
+    entitled: list[DocCollectionORM] = []
+    unentitled_keys: list[str] = []
+    for row in by_key.values():
+        if collection_capability_key(row.collection_key) in operator.capabilities:
+            entitled.append(row)
+        else:
+            unentitled_keys.append(row.collection_key)
     entitled.sort(key=lambda row: row.collection_key)
-    return [project_doc_collection_to_summary(row) for row in entitled]
+    return (
+        [project_doc_collection_to_summary(row) for row in entitled],
+        sorted(unentitled_keys),
+    )
+
+
+def _entitlement_diagnostic(
+    operator: Operator,
+    unentitled_keys: list[str],
+) -> dict[str, object] | None:
+    """Build the empty-picker entitlement diagnostic, or ``None``.
+
+    Returns a context dict naming a concrete missing ``meho-docs:<key>``
+    capability and the identity it was checked against (``operator_sub`` +
+    ``tenant_id``) **only** when the catalogue holds at least one collection
+    the operator cannot see. That distinguishes the two empty-picker causes
+    the operator otherwise cannot tell apart (T2 #1802):
+
+    * **A corpus exists, the identity is missing the capability** — the
+      reported symptom (the ``vmware`` collection is attached + searchable
+      via MCP, but the UI session identity lacks ``meho-docs:vmware``). The
+      diagnostic names the first such key so the operator knows *exactly*
+      which claim to grant on *which* identity — turning the opaque
+      "No doc collections available" into an actionable next step. The
+      asymmetry's root cause is a per-audience Keycloak claim divergence; the
+      remediation lives in ``deploy/values-examples/README.md``.
+    * **No corpus exists at all** (``unentitled_keys`` empty) — the genuine
+      unprovisioned case. Returns ``None`` so the template keeps the plain
+      "ask an administrator to register and entitle a collection" copy.
+
+    The un-entitled keys are never surfaced as searchable options; only the
+    first (sorted, deterministic) key names the missing capability.
+    """
+    if not unentitled_keys:
+        return None
+    missing_key = unentitled_keys[0]
+    return {
+        "required_capability": collection_capability_key(missing_key),
+        "collection_key": missing_key,
+        "operator_sub": operator.sub,
+        "tenant_id": str(operator.tenant_id),
+        "unentitled_count": len(unentitled_keys),
+    }
 
 
 def _set_csrf_cookie(response: HTMLResponse, csrf_token: str) -> None:
@@ -257,11 +313,17 @@ def _search_or_error_context(exc: HTTPException) -> dict[str, object]:
     The ``corpus/_results.html`` fragment renders an ``error`` block when
     ``error_status`` is set. The detail string is surfaced verbatim
     (the backend service guarantees no corpus response body leaks through
-    a 503 detail); a structured ``dict`` detail (the ``collection_disabled``
-    / ``unknown_collection`` shapes) is flattened to a human string.
+    a 503 detail); a structured ``dict`` detail is flattened to a human
+    string, preferring the actionable ``message`` (the ``not_entitled``
+    shape names the missing ``meho-docs:<key>`` capability + the identity it
+    checked, T2 #1802) and falling back to the ``error`` code for the
+    code-only shapes (``collection_disabled`` / ``unknown_collection``).
     """
     detail = exc.detail
-    message = str(detail.get("error") or detail) if isinstance(detail, dict) else str(detail)
+    if isinstance(detail, dict):
+        message = str(detail.get("message") or detail.get("error") or detail)
+    else:
+        message = str(detail)
     return {"error_status": exc.status_code, "error_message": message}
 
 
@@ -315,11 +377,16 @@ async def _render_corpus_index(
     passes the double-submit check.
     """
     operator = await _resolve_operator(session)
-    collections = await _list_entitled_collections(operator)
+    collections, unentitled_keys = await _list_entitled_collections(operator)
     # Default-if-one: pre-select the sole entitled collection so an operator
     # with a single corpus can search without first opening the dropdown.
     # With zero or many, no collection is pre-selected.
     selected_collection = collections[0].collection_key if len(collections) == 1 else ""
+    # When the picker is empty, tell the operator *why*: a corpus exists but
+    # their identity lacks the capability (actionable), vs. no corpus at all.
+    entitlement_diagnostic = (
+        _entitlement_diagnostic(operator, unentitled_keys) if not collections else None
+    )
 
     csrf_token = mint_csrf_token(str(session.session_id))
     context: dict[str, object] = {
@@ -329,6 +396,7 @@ async def _render_corpus_index(
         "chunks": [],
         "searched": False,
         "operator_sub": session.operator_sub,
+        "entitlement_diagnostic": entitlement_diagnostic,
         "csrf_token": csrf_token,
         "active_surface": "corpus",
         "page_title": "Docs Corpus",
@@ -463,9 +531,20 @@ async def _resolve_collection_or_http_error(
             },
         ) from exc
     except CollectionForbiddenError as exc:
+        # Structured 403 mirroring the REST route: the error card names the
+        # missing ``meho-docs:<key>`` capability and the identity it checked
+        # so the operator sees *why* the search was denied, not just "Not
+        # permitted" (T2 #1802).
         raise HTTPException(
             status_code=status.HTTP_403_FORBIDDEN,
-            detail=str(exc),
+            detail={
+                "error": "not_entitled",
+                "collection": exc.collection_key,
+                "required_capability": exc.required_capability,
+                "operator_sub": exc.operator_sub,
+                "tenant_id": exc.tenant_id,
+                "message": str(exc),
+            },
         ) from exc
     except CollectionDisabledError as exc:
         raise HTTPException(

--- a/backend/src/meho_backplane/ui/templates/corpus/index.html
+++ b/backend/src/meho_backplane/ui/templates/corpus/index.html
@@ -26,6 +26,11 @@
     query                -- str: current query (empty on first render)
     chunks               -- list[DocsChunk]: empty on first render
     searched             -- bool: False on first render
+    entitlement_diagnostic -- dict | None: when the picker is empty AND a
+                              collection exists the identity can't see, names
+                              the missing meho-docs:<key> capability +
+                              operator_sub + tenant_id (T2 #1802); None when
+                              the tenant is genuinely unprovisioned
     csrf_token           -- str: minted double-submit token
 
   Note: ``ready`` is NOT passed here -- the chassis context processor
@@ -111,10 +116,40 @@
             Search
           </button>
         </form>
+      {% elif entitlement_diagnostic %}
+        {# A corpus EXISTS but the resolved session identity is missing the
+           per-collection capability -- the diagnosable case (T2 #1802). Name
+           the concrete missing meho-docs:<key> + the identity/tenant it was
+           checked against so the operator knows which Keycloak claim to grant
+           on which identity, instead of an opaque "no collections". #}
+        <div class="alert alert-warning" role="alert" aria-live="polite">
+          <div>
+            <h3 class="font-semibold">Not entitled to the attached docs corpus</h3>
+            <p class="text-sm opacity-90">
+              Your session identity
+              <code>{{ entitlement_diagnostic.operator_sub }}</code>
+              (tenant <code>{{ entitlement_diagnostic.tenant_id }}</code>)
+              is missing the capability
+              <code>{{ entitlement_diagnostic.required_capability }}</code>
+              needed to search collection
+              <code>{{ entitlement_diagnostic.collection_key }}</code>{% if entitlement_diagnostic.unentitled_count > 1 %}
+              (and {{ entitlement_diagnostic.unentitled_count - 1 }} other
+              collection{{ "s" if entitlement_diagnostic.unentitled_count > 2 else "" }}){% endif %}.
+            </p>
+            <p class="text-sm opacity-70">
+              The collection is attached but your token does not carry the
+              entitlement claim for it. Ask an administrator to grant
+              <code>{{ entitlement_diagnostic.required_capability }}</code>
+              to this identity in Keycloak (the claim is per-audience &mdash;
+              see the deployment&rsquo;s docs-corpus entitlement note).
+            </p>
+          </div>
+        </div>
       {% else %}
-        {# No entitled collections -- the tenant is unprovisioned for any
-           docs corpus. This is the not-yet-entitled empty state, distinct
-           from a zero-results search. #}
+        {# No entitled collections AND none visible at all -- the tenant is
+           genuinely unprovisioned for any docs corpus. Distinct from the
+           diagnosable missing-capability case above and from a zero-results
+           search. #}
         <div class="text-center py-8">
           <p class="text-lg opacity-60">No doc collections available</p>
           <p class="text-sm opacity-40">

--- a/backend/tests/test_docs_entitlement_cross_surface.py
+++ b/backend/tests/test_docs_entitlement_cross_surface.py
@@ -1,0 +1,221 @@
+# SPDX-License-Identifier: Apache-2.0
+# Copyright (c) 2026 evoila Group
+
+"""Cross-surface entitlement-contract consistency (T2 #1802).
+
+The docs-corpus entitlement asymmetry (`search_docs` over MCP returns
+chunks while the same collection over REST 403s and `/ui/corpus` renders
+empty) was reported as a backend bug. Grounding the v0.16.0 code overturns
+that: all three answerable surfaces — the REST route, the `search_docs` /
+`ask_docs` MCP tools, and the `/ui/corpus` BFF — gate on the *one* shared
+:func:`~meho_backplane.docs_search.resolve_entitled_ready_collection`
+check, which reads exactly two fields off the :class:`Operator`:
+``tenant_id`` and ``capabilities``. And all three build that ``Operator``
+from the **same** claim-derivation chain
+(:func:`~meho_backplane.auth.jwt.verify_jwt_for_audience` →
+``_decode_with_jwks`` → ``Operator(...)``), parametrised only by the
+*audience* the token is validated for.
+
+So the cross-surface contract is **verified consistent** here on two axes:
+
+1. **Same ``(tenant_id, capabilities)`` source.** Given the *same* claim
+   set, each surface's verifier yields an :class:`Operator` with identical
+   ``tenant_id`` + ``capabilities`` — behavioural proof that no surface
+   derives entitlement inputs differently (the test mints one token per
+   audience carrying the same ``capabilities`` claim and asserts equality).
+
+2. **The one deliberate divergence is the audience, and it is
+   intentional.** REST + the UI BFF both validate against
+   ``settings.keycloak_audience``; MCP validates against
+   ``mcp_resource_uri(settings)`` (``<backplane-url>/mcp``, RFC 8707
+   resource-scoped). This asymmetry is asserted *intentional* — it is why a
+   per-audience Keycloak token can carry a different ``meho-docs:*`` claim
+   set per audience, which is the reported symptom's root cause (a
+   claim-mapper gap, documented in ``deploy/values-examples/README.md``),
+   **not** a backplane inconsistency.
+
+This is the test the docs-search codebase doc's cross-surface invariant
+section names.
+"""
+
+from __future__ import annotations
+
+import uuid
+from collections.abc import Iterator
+from datetime import UTC, datetime, timedelta
+from typing import Any
+
+import pytest
+import respx
+
+from meho_backplane.auth.jwt import (
+    clear_jwks_cache,
+    verify_jwt,
+    verify_jwt_for_audience,
+)
+from meho_backplane.auth.operator import Operator
+from meho_backplane.mcp.auth import mcp_resource_uri, verify_mcp_jwt
+from meho_backplane.settings import get_settings
+from meho_backplane.ui.auth.refresh import verify_access_token_with_refresh
+from meho_backplane.ui.auth.session_store import DecryptedSession
+
+from ._oidc_jwt_helpers import ISSUER as _ISSUER
+from ._oidc_jwt_helpers import make_rsa_keypair as _make_rsa_keypair
+from ._oidc_jwt_helpers import mint_token as _mint_token
+from ._oidc_jwt_helpers import mock_discovery_and_jwks as _mock_discovery_and_jwks
+from ._oidc_jwt_helpers import public_jwks as _public_jwks
+
+# A capability set carrying the base add-on key + one per-collection key.
+_CAPS = ["meho-docs", "meho-docs:vmware"]
+_TENANT = "11111111-1111-1111-1111-111111111111"
+_SUB = "op-cross-surface"
+
+#: The MCP audience the chassis derives from BACKPLANE_URL when no explicit
+#: MCP_RESOURCE_URI is set: ``<backplane-url>/mcp``.
+_BACKPLANE_URL = "https://meho.test"
+_MCP_AUDIENCE = f"{_BACKPLANE_URL}/mcp"
+
+
+@pytest.fixture(autouse=True)
+def _auth_env(monkeypatch: pytest.MonkeyPatch) -> Iterator[None]:
+    """Pin the chassis auth env so both audiences resolve deterministically."""
+    monkeypatch.setenv("KEYCLOAK_ISSUER_URL", _ISSUER)
+    monkeypatch.setenv("KEYCLOAK_AUDIENCE", "meho-backplane")
+    monkeypatch.setenv("VAULT_ADDR", "https://vault.test")
+    monkeypatch.setenv("BACKPLANE_URL", _BACKPLANE_URL)
+    get_settings.cache_clear()
+    clear_jwks_cache()
+    yield
+    get_settings.cache_clear()
+    clear_jwks_cache()
+
+
+def _mint(key: Any, *, audience: str) -> str:
+    """Mint an RS256 token for *audience* carrying the shared claim set."""
+    return _mint_token(
+        key,
+        sub=_SUB,
+        audience=audience,
+        tenant_id=_TENANT,
+        tenant_role="operator",
+        capabilities=_CAPS,
+    )
+
+
+def test_three_surfaces_share_one_audience_contract() -> None:
+    """The audience each surface validates for is the one deliberate divergence.
+
+    REST + UI use ``keycloak_audience``; MCP uses ``mcp_resource_uri``. This
+    asserts the divergence is *exactly* that — and that REST and the UI BFF
+    agree (so they 403 / empty *together*, never one without the other).
+    """
+    settings = get_settings()
+    # REST (verify_jwt) and the UI BFF (verify_access_token_with_refresh)
+    # both bind the HTTP-API audience.
+    assert settings.keycloak_audience == "meho-backplane"
+    # MCP binds the resource-scoped URI — a *different* audience by design.
+    assert mcp_resource_uri(settings) == _MCP_AUDIENCE
+    assert mcp_resource_uri(settings) != settings.keycloak_audience
+
+
+async def test_rest_and_mcp_derive_same_tenant_and_capabilities() -> None:
+    """Given the same claim set, REST and MCP yield identical ``(tenant_id, caps)``.
+
+    REST goes through ``verify_jwt`` (audience = ``keycloak_audience``); MCP
+    through ``verify_mcp_jwt`` (audience = ``mcp_resource_uri``). Each token
+    is minted for its own audience but carries the **same** ``capabilities``
+    + ``tenant_id`` claims — so equal entitlement inputs prove the surfaces
+    share one ``Operator`` contract, not three divergent derivations.
+    """
+    key = _make_rsa_keypair("kid-A")
+    rest_token = _mint(key, audience="meho-backplane")
+    mcp_token = _mint(key, audience=_MCP_AUDIENCE)
+
+    with respx.mock as mock_router:
+        _mock_discovery_and_jwks(mock_router, _public_jwks(key))
+        rest_op = await verify_jwt(f"Bearer {rest_token}")
+        mcp_op = await verify_mcp_jwt(f"Bearer {mcp_token}")
+
+    # Same identity contract: tenant_id + capabilities are derived from the
+    # same claim names by the same projection, so they match exactly.
+    assert rest_op.tenant_id == mcp_op.tenant_id == uuid.UUID(_TENANT)
+    assert rest_op.capabilities == mcp_op.capabilities == frozenset(_CAPS)
+    assert rest_op.sub == mcp_op.sub == _SUB
+    # The per-collection entitlement key both surfaces gate on is present.
+    assert "meho-docs:vmware" in rest_op.capabilities
+    assert "meho-docs:vmware" in mcp_op.capabilities
+
+
+async def test_ui_bff_reconstructs_token_capabilities_not_session_tenant() -> None:
+    """The UI entitlement path uses the *token's* ``(tenant_id, capabilities)``.
+
+    The reported framing was "the UI BFF takes capabilities from the token
+    but tenant_id from the session row". For the *entitlement* path that is
+    not so: ``verify_access_token_with_refresh`` presents the stored access
+    token to the same chassis chain and returns a full token-derived
+    :class:`Operator` — so both ``tenant_id`` and ``capabilities`` come from
+    the token, matching what REST derives from an identical claim set. (The
+    session-row ``tenant_id`` is used only for the page-header chip.)
+    """
+    key = _make_rsa_keypair("kid-A")
+    ui_token = _mint(key, audience="meho-backplane")
+    now = datetime.now(UTC)
+    decrypted = DecryptedSession(
+        id=uuid.uuid4(),
+        operator_sub=_SUB,
+        # A *different* tenant on the session row than the token claim, to
+        # prove the entitlement path follows the TOKEN, not the row.
+        tenant_id=uuid.UUID("99999999-9999-9999-9999-999999999999"),
+        created_at=now,
+        # Far-future expiry so the reactive verify leg never refreshes: the
+        # stored token is valid, so verify_access_token_with_refresh returns
+        # the operator from the first verify without a refresh round-trip.
+        expires_at=now + timedelta(hours=1),
+        access_token=ui_token,
+        refresh_token="refresh-plaintext",
+        last_seen_at=now,
+    )
+
+    with respx.mock as mock_router:
+        _mock_discovery_and_jwks(mock_router, _public_jwks(key))
+        _refreshed, ui_op = await verify_access_token_with_refresh(
+            decrypted,
+            expected_audience=get_settings().keycloak_audience,
+        )
+
+    assert isinstance(ui_op, Operator)
+    # Entitlement inputs come from the TOKEN: tenant_id is the claim value,
+    # NOT the session-row 9999... tenant.
+    assert ui_op.tenant_id == uuid.UUID(_TENANT)
+    assert ui_op.capabilities == frozenset(_CAPS)
+    assert "meho-docs:vmware" in ui_op.capabilities
+
+
+async def test_all_three_call_one_audience_parametrised_verifier() -> None:
+    """All three surfaces route entitlement-input derivation through one seam.
+
+    A structural assertion complementing the behavioural ones: REST, UI, and
+    MCP all build the ``Operator`` via
+    :func:`~meho_backplane.auth.jwt.verify_jwt_for_audience`, the single
+    audience-parametrised verifier. The same token, verified directly
+    against either audience, yields equal ``(tenant_id, capabilities)`` — so
+    the only thing that can differ per surface is the audience, never the
+    entitlement-input derivation.
+    """
+    key = _make_rsa_keypair("kid-A")
+    rest_token = _mint(key, audience="meho-backplane")
+    mcp_token = _mint(key, audience=_MCP_AUDIENCE)
+
+    with respx.mock as mock_router:
+        _mock_discovery_and_jwks(mock_router, _public_jwks(key))
+        rest_direct = await verify_jwt_for_audience(
+            f"Bearer {rest_token}", expected_audience="meho-backplane"
+        )
+        mcp_direct = await verify_jwt_for_audience(
+            f"Bearer {mcp_token}", expected_audience=_MCP_AUDIENCE
+        )
+
+    assert (rest_direct.tenant_id, rest_direct.capabilities) == (
+        mcp_direct.tenant_id,
+        mcp_direct.capabilities,
+    )

--- a/backend/tests/test_mcp_tools_docs.py
+++ b/backend/tests/test_mcp_tools_docs.py
@@ -320,7 +320,14 @@ def test_tools_call_search_docs_403_when_not_entitled_to_collection(
     assert response.status_code == 200
     body = response.json()
     assert body["error"]["code"] == INVALID_PARAMS
-    assert "entitled" in body["error"]["message"].lower()
+    message = body["error"]["message"]
+    assert "entitled" in message.lower()
+    # The enriched diagnostic names the missing capability + the identity it
+    # checked, and carries it on error.data for agent self-correction (#1802).
+    assert "meho-docs:vmware" in message
+    assert "op-test" in message
+    assert body["error"]["data"]["reason"] == "not_entitled"
+    assert body["error"]["data"]["required_capability"] == "meho-docs:vmware"
     assert "query" not in spy.captured  # type: ignore[attr-defined]
 
 

--- a/backend/tests/test_search_docs_route.py
+++ b/backend/tests/test_search_docs_route.py
@@ -396,7 +396,9 @@ def test_not_entitled_to_collection_returns_403(client: TestClient) -> None:
 
     The base ``meho-docs`` capability authenticates the add-on; the
     per-collection entitlement is the finer gate that rejects the query.
-    The backend is never called.
+    The backend is never called. The 403 is a **structured** body naming the
+    missing capability + the identity it checked (T2 #1802) so an operator
+    can grant exactly that claim rather than guess at an opaque denial.
     """
     _seed_collection_sync()
     key = _make_rsa_keypair("kid-A")
@@ -418,7 +420,18 @@ def test_not_entitled_to_collection_returns_403(client: TestClient) -> None:
             headers={"Authorization": f"Bearer {token}"},
         )
     assert response.status_code == 403
-    assert "entitled" in json.dumps(response.json()["detail"])
+    detail = response.json()["detail"]
+    # Structured diagnostic, not a bare string.
+    assert isinstance(detail, dict)
+    assert detail["error"] == "not_entitled"
+    assert detail["collection"] == "vmware"
+    assert detail["required_capability"] == "meho-docs:vmware"
+    assert detail["operator_sub"] == "op-nopriv"
+    # The tenant it checked is named (the DEFAULT_TENANT_ID the minter uses).
+    assert detail["tenant_id"]
+    # The human message names both the capability and the identity.
+    assert "meho-docs:vmware" in detail["message"]
+    assert "op-nopriv" in detail["message"]
     fake_corpus.assert_not_awaited()
 
 

--- a/backend/tests/test_ui_corpus.py
+++ b/backend/tests/test_ui_corpus.py
@@ -388,11 +388,50 @@ def test_corpus_index_multiple_collections_no_default_selection() -> None:
 
 
 def test_corpus_index_empty_state_when_no_entitled_collections() -> None:
-    """An operator entitled to no collection sees the unprovisioned empty state."""
+    """A collection exists but the identity is unentitled -> diagnosable empty state.
+
+    This is the reported #1802 symptom: a ``vmware`` collection is attached
+    (and searchable via MCP) but the operator's session identity lacks
+    ``meho-docs:vmware``. The page must name the missing capability + the
+    identity it checked, NOT the opaque "No doc collections available".
+    """
     _seed_tenant(_TENANT_A, "tenant-a")
     _seed_collection(collection_key="vmware")
     session_id = _seed_session_sync(tenant_id=_TENANT_A)
-    # No ``meho-docs:vmware`` capability -> empty entitled set.
+    # No ``meho-docs:vmware`` capability -> empty entitled set, but a
+    # collection the operator can't see DOES exist.
+    operator = _operator(tenant_id=_TENANT_A, capabilities=frozenset(), sub="op-unentitled")
+
+    with respx.mock(assert_all_called=False):
+        client = _authenticated_client(session_id)
+        with patch(_RESOLVE_OPERATOR, new_callable=AsyncMock, return_value=operator):
+            response = client.get("/ui/corpus")
+
+    assert response.status_code == 200, response.text
+    body = response.text
+    # The actionable diagnostic names the missing capability + the identity.
+    assert "meho-docs:vmware" in body
+    assert "op-unentitled" in body
+    assert str(_TENANT_A) in body
+    assert "not entitled" in body.lower()
+    # It is NOT the generic unprovisioned copy (a corpus DOES exist).
+    assert "No doc collections available" not in body
+    # The search form is not rendered when there is nothing to search.
+    assert 'hx-post="/ui/corpus/search"' not in body
+
+
+def test_corpus_index_unprovisioned_state_when_no_collections_exist() -> None:
+    """A tenant with NO collections at all sees the generic unprovisioned copy.
+
+    Distinct from the diagnosable missing-capability state above: when the
+    catalogue holds nothing the operator could be entitled to, there is no
+    concrete ``meho-docs:<key>`` to name, so the page keeps the plain "ask an
+    administrator to register and entitle a collection" copy and does NOT
+    fabricate a capability name.
+    """
+    _seed_tenant(_TENANT_A, "tenant-a")
+    # No collection seeded at all.
+    session_id = _seed_session_sync(tenant_id=_TENANT_A)
     operator = _operator(tenant_id=_TENANT_A, capabilities=frozenset())
 
     with respx.mock(assert_all_called=False):
@@ -403,7 +442,8 @@ def test_corpus_index_empty_state_when_no_entitled_collections() -> None:
     assert response.status_code == 200, response.text
     body = response.text
     assert "No doc collections available" in body
-    # The search form is not rendered when there is nothing to search.
+    # No collection exists, so no missing-capability diagnostic is rendered.
+    assert "meho-docs:" not in body
     assert 'hx-post="/ui/corpus/search"' not in body
 
 
@@ -638,6 +678,48 @@ def test_corpus_search_disabled_collection_renders_403_card() -> None:
     assert 'role="alert"' in body
     assert "403" in body
     assert "Not permitted" in body
+
+
+def test_corpus_search_not_entitled_renders_403_card_naming_capability() -> None:
+    """Searching a collection the identity isn't entitled to names the missing claim.
+
+    The collection is seeded ``ready`` and the operator passes the static
+    ``meho-docs`` add-on gate but lacks the per-collection
+    ``meho-docs:vmware`` capability. The un-mocked resolve gate raises
+    ``CollectionForbiddenError``; the handler maps it to a 403 card whose
+    detail names the missing capability + the identity it checked (T2 #1802),
+    not just "Not permitted".
+    """
+    _seed_tenant(_TENANT_A, "tenant-a")
+    _seed_collection(collection_key="vmware")
+    session_id = _seed_session_sync(tenant_id=_TENANT_A)
+    csrf = _csrf_token(session_id)
+    # Base add-on capability only -> visible tool, but not entitled to vmware.
+    operator = _operator(
+        tenant_id=_TENANT_A,
+        capabilities=frozenset({"meho-docs"}),
+        sub="op-nopriv",
+    )
+
+    with respx.mock(assert_all_called=False):
+        client = _authenticated_client(session_id)
+        client.cookies.set(CSRF_COOKIE_NAME, csrf)
+        with patch(_RESOLVE_OPERATOR, new_callable=AsyncMock, return_value=operator):
+            response = client.post(
+                "/ui/corpus/search",
+                data={"collection": "vmware", "q": "snapshot"},
+                headers={CSRF_HEADER_NAME: csrf},
+            )
+
+    assert response.status_code == 200, response.text
+    body = response.text
+    assert 'role="alert"' in body
+    assert "403" in body
+    assert "Not permitted" in body
+    # The actionable diagnostic: the missing capability + the identity.
+    assert "meho-docs:vmware" in body
+    assert "op-nopriv" in body
+    assert str(_TENANT_A) in body
 
 
 def test_corpus_search_not_ready_collection_renders_409_card() -> None:

--- a/cli/api/openapi.json
+++ b/cli/api/openapi.json
@@ -445,7 +445,7 @@
             }
           },
           "403": {
-            "description": "Terminal rejection of an otherwise-resolvable collection, in one of two forms (both 403, distinguished by the ``detail.error`` field): the tenant is not entitled to the named collection -- it lacks the ``meho-docs:<collection>`` capability even though it can see the add-on -- or the collection has been ``disabled`` by an operator (``detail.error='collection_disabled'``). Neither is retryable: the collection exists but the principal cannot search it, or an operator switched it off."
+            "description": "Terminal rejection of an otherwise-resolvable collection, in one of two forms (both 403, distinguished by the ``detail.error`` field): the tenant is not entitled to the named collection (``detail.error='not_entitled'`` -- it lacks the ``meho-docs:<collection>`` capability even though it can see the add-on; the structured detail names the ``required_capability`` and the ``operator_sub`` / ``tenant_id`` it checked so the operator can grant the missing claim) -- or the collection has been ``disabled`` by an operator (``detail.error='collection_disabled'``). Neither is retryable: the collection exists but the principal cannot search it, or an operator switched it off."
           },
           "409": {
             "description": "The named collection is known and entitled but transiently not ``ready`` (provisioning / rebuilding) -- its backend is not answerable yet. Retryable once the rebuild finishes. A ``disabled`` collection is the terminal 403 above, not a 409."

--- a/deploy/values-examples/README.md
+++ b/deploy/values-examples/README.md
@@ -686,6 +686,95 @@ residual `invalid_token` is reserved for failures that aren't
 `DecodeError` (`alg: none` via `UnsupportedAlgorithmError`, future
 authlib `JoseError` subclasses, post-refresh kid miss).
 
+#### Step 3a — Docs-corpus entitlement claim (`meho-docs:*`) is per-audience
+
+> **Only relevant if you run the `meho-docs` add-on** (the federated
+> vendor-document corpus behind `search_docs` / `ask_docs` /
+> `/ui/corpus`). Skip this sub-step otherwise.
+
+The docs-corpus surfaces gate on a **capability claim**, not a role or a
+group: an operator may search collection `<key>` only when its token's
+`capabilities` claim contains `meho-docs:<key>` (e.g. `meho-docs:vmware`).
+The backplane reads that array from the claim named by
+`JWT_CAPABILITIES_CLAIM_NAME` (default `capabilities`), and **all three
+surfaces use the same `(tenant_id, capabilities)` contract** — so they
+either all see the entitlement or none do, *for a given token*.
+
+The catch is the word "token". MEHO validates each surface's token for a
+**different audience**:
+
+| Surface | Audience the token is validated for |
+| --- | --- |
+| REST `POST /api/v1/search_docs` | `KEYCLOAK_AUDIENCE` (`meho-backplane`) |
+| `/ui/corpus` (the operator web console BFF) | `KEYCLOAK_AUDIENCE` (`meho-backplane`) — same as REST |
+| MCP `search_docs` / `ask_docs` | `MCP_RESOURCE_URI` (`<backplane-url>/mcp`) |
+
+If your realm mints **per-audience tokens with different claim sets** (the
+common case once the `meho-mcp-audience` mapper from Step 3 is in play —
+the MCP token and the REST/UI token are issued for different audiences),
+the `meho-docs:*` capability can land on the MCP token but **not** the
+REST/UI token. The symptom is the [#1802](https://github.com/evoila/meho/issues/1802)
+dogfood report: `search_docs` over MCP returns cited chunks, while the same
+collection over REST 403s (`{"error":"not_entitled", ...}`) and `/ui/corpus`
+shows "Not entitled to the attached docs corpus". That is a **claim-mapper
+gap, not a backplane bug** — the entitlement check is identical across
+surfaces; the claim simply wasn't issued on every audience.
+
+**Fix: emit the `capabilities` claim on every audience the operator uses.**
+Add a `capabilities` mapper to the **realm-default client scope** every
+client inherits (the same `meho-backplane-claims` default scope the CIMD
+section recommends, or directly on each public client), so the claim rides
+both the `meho-backplane` and `<backplane-url>/mcp` audiences:
+
+| Mapper name | Type | Output claim | Notes |
+| --- | --- | --- | --- |
+| `meho-docs-capabilities` | `oidc-hardcoded-claim` (lab) or `oidc-usermodel-attribute-mapper` (realm with a `capabilities` user attribute) | `capabilities` (must match `JWT_CAPABILITIES_CLAIM_NAME`) | Claim **JSON type: `JSON`** and **Multivalued: On** so it serialises as a JSON array (`["meho-docs","meho-docs:vmware"]`), not a comma string. Include the base `meho-docs` add-on key **and** one `meho-docs:<collection_key>` per collection the identity may search. Add it to a **default** client scope (not per-client) so a CIMD-resolved or newly-added client inherits it too. |
+
+For the hardcoded-claim (lab) form, set **Claim value** to the literal JSON
+array, e.g. `["meho-docs", "meho-docs:vmware"]`.
+
+> **Per-collection, not all-or-nothing.** `meho-docs` alone makes the
+> add-on *visible* (the tool appears, the page loads); each
+> `meho-docs:<collection_key>` is what authorises searching *that*
+> collection. Granting `meho-docs` without any `meho-docs:<key>` is exactly
+> the empty-but-diagnosable state `/ui/corpus` now names explicitly.
+
+**Verify the claim is present on the audience that's failing.** Decode the
+token each surface validates and confirm both the audience and the
+capability. Using `meho status --print-token` (the CLI/REST audience):
+
+```bash
+# 1. The capabilities claim carries the per-collection key on the REST/UI
+#    audience token. (jwt-cli `jwt decode`, or jq over the base64 payload.)
+meho status --print-token \
+  | jwt decode --json - \
+  | jq '{aud: .payload.aud, capabilities: .payload.capabilities}'
+# Expect aud to include "meho-backplane" AND capabilities to include
+# "meho-docs:vmware". If capabilities is missing/empty here but the MCP
+# token has it, that is the per-audience gap — add the mapper above.
+
+# 2. Probe the REST surface directly: a 403 names the missing claim + the
+#    identity it checked, so you can grant exactly that capability.
+curl -s -X POST https://meho.example.com/api/v1/search_docs \
+  -H "Authorization: Bearer $(meho status --print-token)" \
+  -H 'Content-Type: application/json' \
+  -d '{"query":"x","collection":"vmware"}' | jq .detail
+# {
+#   "error": "not_entitled",
+#   "collection": "vmware",
+#   "required_capability": "meho-docs:vmware",
+#   "operator_sub": "<sub>",
+#   "tenant_id": "<uuid>",
+#   "message": "identity '<sub>' (tenant <uuid>) is not entitled to doc
+#               collection 'vmware': missing capability 'meho-docs:vmware'"
+# }
+```
+
+For the MCP-audience token (minted via the `meho-mcp-client` browser flow),
+decode that token the same way and confirm `aud` includes
+`<backplane-url>/mcp` **and** the same `capabilities` array — both audiences
+must carry it for all three surfaces to agree.
+
 #### Step 4 — Explicitly assign the 4 default client scopes
 
 | Scope | Why | What breaks if it's missing |

--- a/docs/codebase/docs-search.md
+++ b/docs/codebase/docs-search.md
@@ -149,7 +149,12 @@ policies, defined once so they cannot drift per surface:
   gate still governs *visibility* (tool / template absence when the add-on
   isn't provisioned); this finer gate governs *which collections* an
   entitled tenant may query. A miss → `CollectionForbiddenError`, mapped to
-  403 / `-32602` (the 403-projected dispatcher path).
+  403 / `-32602` (the 403-projected dispatcher path). The error carries the
+  **missing capability** (`required_capability`) and the **identity it
+  checked** (`operator_sub` + `tenant_id`), so every surface renders an
+  *actionable* diagnostic — "identity `<sub>` (tenant `<id>`) is missing
+  capability `meho-docs:<key>`" — instead of an opaque denial (T2 #1802; see
+  the cross-surface diagnosability note below).
 - **Readiness** — a collection whose registry `status` is not `"ready"`
   → `CollectionNotReadyError`, mapped to 409 (REST) / `-32603` (MCP,
   server-side condition). The richer reachability *probe* is T6 (#1555);
@@ -427,6 +432,53 @@ just makes the op name canonical for `query_audit` filtering.
 - `meho_backplane.settings` — `corpus_url` / `corpus_audience` /
   `corpus_timeout_seconds` / `corpus_require_filters`
   (`CORPUS_*` env vars).
+
+## Cross-surface entitlement contract + diagnosability (T2 #1802)
+
+All three answerable surfaces — the REST route, the `search_docs` /
+`ask_docs` MCP tools, and the `/ui/corpus` BFF — gate on the **one** shared
+`resolve_entitled_ready_collection` check, which reads exactly two fields
+off the `Operator`: `tenant_id` (scopes the tenant-first resolve) and
+`capabilities` (holds `meho-docs:<key>`). The entitlement contract is
+**verified consistent** because all three build that `Operator` from the
+**same constructor** via `verify_jwt_for_audience` → the chassis JWT chain,
+which lifts `tenant_id` from `jwt_tenant_claim_name` and `capabilities` from
+`jwt_capabilities_claim_name` — identical claim derivation, no per-surface
+divergence. (The UI `UISessionContext.tenant_id` from the session row is
+used only for the page-header chip + `operator_sub` display; the
+entitlement path reconstructs a full token-derived `Operator` via
+`verify_access_token_with_refresh`, so the check never mixes a session-row
+`tenant_id` with token capabilities.)
+
+The **one deliberate divergence** is the *audience* each surface validates
+the token for: REST and the UI BFF both use `settings.keycloak_audience`
+(the HTTP-API audience), while MCP uses `mcp_resource_uri(settings)`
+(`<backplane_url>/mcp`). This is intentional and spec-driven (RFC 8707
+resource-scoped tokens), but it means a Keycloak realm that mints
+**per-audience** tokens can carry a different `meho-docs:*` claim set per
+audience — the reported asymmetry where the MCP tool succeeds while REST /
+the UI session 403 or render empty. That is a **Keycloak claim-mapper
+config gap, not a backend bug**: the fix is to attach the `meho-docs:<key>`
+capability claim to *every* audience the operator uses (see
+`deploy/values-examples/README.md` § "Docs-corpus entitlement claim
+(`meho-docs:*`) is per-audience"). The cross-surface invariant — same
+`(tenant_id, capabilities)` source contract, single deliberate audience
+divergence — is asserted by `tests/test_docs_entitlement_cross_surface.py`.
+
+Because the divergence is invisible without help, every surface now emits an
+**actionable** diagnostic instead of an opaque denial (T2 #1802):
+
+- **REST `POST /api/v1/search_docs`** — the not-entitled 403 is a structured
+  body `{"error": "not_entitled", "collection", "required_capability",
+  "operator_sub", "tenant_id", "message"}`.
+- **`/ui/corpus`** — the search 403 card surfaces the same `message`; and the
+  empty collection picker, when the catalogue holds a collection the
+  identity cannot see, names the concrete missing `meho-docs:<key>` +
+  `operator_sub` + `tenant_id` (distinct from the genuinely-unprovisioned
+  "no corpus exists" empty state).
+- **MCP `search_docs` / `ask_docs`** — the `-32602` message names the missing
+  capability + identity, and `error.data` carries
+  `{"reason": "not_entitled", "required_capability"}` for self-correction.
 
 ## Known issues / boundaries
 


### PR DESCRIPTION
## Summary

- **Diagnosability.** The shipped `/ui/corpus` page (#1777) showed an opaque "No doc collections available" for the operator identity even though a `vmware` collection was attached and searchable via the MCP `search_docs` tool, while the same collection over REST returned a bare `403 "not entitled"`. This makes the denial **actionable** on all three surfaces: it names the missing `meho-docs:<collection>` capability **and** the identity it checked (`operator_sub` + `tenant_id`).
- **Cross-surface consistency (verified, not rewritten).** All three surfaces gate on the one shared `resolve_entitled_ready_collection` check and build the `Operator` from the same audience-parametrised verifier — so `(tenant_id, capabilities)` derivation is identical. The **one deliberate divergence** is the audience each token is validated for (MCP `mcp_resource_uri` vs REST/UI `keycloak_audience`); a Keycloak realm minting different `meho-docs:*` claims per audience is the asymmetry's root cause. That is a **claim-mapper config gap, not a backend bug**, so it is documented in `deploy/` rather than "fixed" in code (entitlement stays JWT-claim driven — no `capabilities` column, no granted entitlements, per the issue's out-of-scope).
- **What changed in code:** `CollectionForbiddenError` now carries `required_capability` + the checked identity; the REST `403` is a structured `{"error":"not_entitled", collection, required_capability, operator_sub, tenant_id, message}` body; the `/ui/corpus` search card surfaces the same; the empty picker names a concrete missing capability when a corpus exists the identity can't see (distinct from the genuinely-unprovisioned state); the MCP `-32602` names the capability + identity and carries it on `error.data`.
- **What changed in docs:** `deploy/values-examples/README.md` gains "Step 3a — Docs-corpus entitlement claim (`meho-docs:*`) is per-audience" (mapper config + `meho status --print-token` / `curl` verify commands); `docs/codebase/docs-search.md` documents the verified-consistent cross-surface invariant.

## Test plan

- [x] `ruff check src/ tests/` — clean
- [x] `ruff format --check` (all changed files) — clean
- [x] `uv run mypy src/` strict — Success, 480 files, no issues
- [x] `python3 .claude/hooks/code-quality.py --diff` — 0 blockers (8 pre-existing-debt warnings on touched files, recorded; the diff is mostly docstring growth, not new logic)
- [x] New `tests/test_docs_entitlement_cross_surface.py` — 4 tests asserting REST/MCP/UI derive identical `(tenant_id, capabilities)` from the same contract and that the audience divergence is intentional.
- [x] `tests/test_ui_corpus.py` — diagnosable empty-state names `meho-docs:vmware` + identity; genuinely-unprovisioned state stays generic (no fabricated capability); search `403` card names the capability + identity.
- [x] `tests/test_search_docs_route.py::test_not_entitled_to_collection_returns_403` — asserts the structured `403` payload (capability key + `operator_sub` + `tenant_id` + message).
- [x] `tests/test_mcp_tools_docs.py` — `-32602` message + `error.data` name the missing capability + identity.
- [x] Broader sweep `pytest -k "docs or corpus or collection or entitle or ui_ or mcp_tools_docs or search_docs"` — **867 passed, 3 skipped, 0 failed**.
- [x] **CLI OpenAPI snapshot** regenerated (`make snapshot-openapi && make generate`): the `403` response *description* changed, so `cli/api/openapi.json` is updated (one line); the generated Go client is unchanged; the snapshot is idempotent (CI freshness check will pass).

## Out of scope

- T1 (#1801, connector resolution) and T3 (#1803, modal dismiss) — sibling tasks on different files.
- Granting the RDC deployment's specific identities the `meho-docs:*` claim — a deployment action (the deploy note tells the operator how).
- Adding a `capabilities` column to `doc_collections` — explicitly out of scope; entitlement stays JWT-claim-driven.

### Adjacent findings (recorded, not edited)

- Pre-existing size/complexity warnings on touched files (`collection_access.py`, `mcp/tools/docs.py`, `ui/routes/corpus/routes.py`, `api/v1/search_docs.py`) — legacy debt, below block thresholds; not caused by this diff.

<!-- auto-implement-issue: fresh, iteration 1 -->

Closes #1802


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Bug Fixes
* Improved error message structure for document collection access denials—users now receive clear diagnostics showing the required capability and which identity/tenant was denied access, with consistent error formats across REST API, UI, and documentation tools.

## Documentation
* Added entitlement setup guide and diagnostic troubleshooting documentation for docs-corpus access configuration across all surfaces.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->