### PR TITLE
fix(memory): enforce per-principal user_sub isolation at the retrieve() boundary (#1797)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -90,6 +90,10 @@ connector-related release-notes line.
 
 ## [Unreleased]
 
+### Security
+
+- Closed a within-tenant **cross-principal memory leak** on the retrieval data path: `POST /api/v1/retrieve {source:"memory"}` and the `meho://retrieve/{query}` MCP resource returned another principal's per-principal memories (`user` / `user-tenant` / `user-target` scopes, full `body`) to any operator in the same tenant. The two surfaces called the shared `retrieve()` substrate without the per-principal `user_sub` push-down the isolated read paths (`recall`, `list`, MCP `search_memory`) already apply — the HTTP route forwarded client `metadata_filters` verbatim with no per-principal scoping, and the MCP resource passed no filters at all. The fix enforces a **mandatory, non-overridable** per-principal predicate at the shared `retrieve()` boundary (`principal_sub`): for `source="memory"` user-scoped kinds a row is returned only when its stored `user_sub` equals the caller's `sub`, applied regardless of caller and AND-enforced so a client-supplied `metadata_filters={"user_sub":"<other>"}` cannot widen it. Tenant-broadcast scopes (`tenant` / `target`) stay visible cross-principal (no over-correction), and the other `retrieve()` sources (`knowledge` / `operations` / `docs`) are tenant-scoped and carry no per-principal `user_sub` data the same gap would leak. Bidirectional + non-override + no-over-correction probes added against a real pgvector cluster, covering both the HTTP route and the MCP resource (#1797).
+
 ### Fixed
 
 - Unify connector-id resolution across `GET /api/v1/connectors/{id}/review` and `POST /api/v1/connectors/{id}/enable-reads` so a label resolves to the **same** row on both paths: `enable-reads` now honours the same tenant→built-in global fallback `review` had (a global-only connector enables its reads instead of returning 404), and a label that maps to **both** a tenant-curated row and a built-in row returns a structured `connector_scope_ambiguous` 409 listing the candidate rows on both paths — instead of `review` silently picking one and `enable-reads` 404'ing (#1801).

--- a/backend/src/meho_backplane/api/v1/retrieve.py
+++ b/backend/src/meho_backplane/api/v1/retrieve.py
@@ -269,6 +269,15 @@ async def retrieve_endpoint(
         audit_metadata_filters_keys=metadata_filters_keys,
     )
 
+    # `principal_sub=operator.sub` enforces the mandatory, non-overridable
+    # per-principal isolation predicate at the retrieval boundary (#1797):
+    # a `source="memory"` user-scoped row (`memory-user` /
+    # `memory-user-tenant` / `memory-user-target`) is only returned when
+    # its stored `user_sub` equals the caller's `sub`. This closes the
+    # cross-principal leak where a client passed `metadata_filters`
+    # straight through with no per-principal scoping; the predicate is
+    # AND-enforced in the substrate, so a client-supplied
+    # `metadata_filters={"user_sub": "<other>"}` cannot widen it.
     hits = await retrieve(
         tenant_id=operator.tenant_id,
         query=body.query,
@@ -276,6 +285,7 @@ async def retrieve_endpoint(
         kind=body.kind,
         limit=body.limit,
         metadata_filters=body.metadata_filters,
+        principal_sub=operator.sub,
     )
 
     structlog.contextvars.bind_contextvars(audit_hit_count=len(hits))

--- a/backend/src/meho_backplane/mcp/resources/retrieve.py
+++ b/backend/src/meho_backplane/mcp/resources/retrieve.py
@@ -153,10 +153,19 @@ async def _retrieve_handler(
         audit_kind=None,
     )
 
+    # `principal_sub=operator.sub` enforces the mandatory per-principal
+    # isolation predicate at the retrieval boundary (#1797). This resource
+    # retrieves across *every* source with no `metadata_filters`, so
+    # without the predicate a `source="memory"` user-scoped row written by
+    # another principal in the same tenant would surface here. The
+    # substrate gates `memory-user` / `memory-user-tenant` /
+    # `memory-user-target` rows on `stored user_sub == operator.sub`;
+    # tenant-broadcast and non-memory rows are unaffected.
     hits = await retrieve(
         tenant_id=operator.tenant_id,
         query=query,
         limit=_DEFAULT_LIMIT,
+        principal_sub=operator.sub,
     )
 
     structlog.contextvars.bind_contextvars(audit_hit_count=len(hits))

--- a/backend/src/meho_backplane/memory/service.py
+++ b/backend/src/meho_backplane/memory/service.py
@@ -769,6 +769,13 @@ class MemoryService:
                 kind=kind_for_scope(scope),
                 limit=retrieval_limit,
                 metadata_filters=_metadata_filters_for_scope(scope, operator),
+                # Belt-and-suspenders: this path already pushes the
+                # user_sub predicate down via metadata_filters, but
+                # passing principal_sub makes the boundary enforce it
+                # too (#1797), so a future change to
+                # _metadata_filters_for_scope cannot silently reopen the
+                # leak this service was already closing.
+                principal_sub=operator.sub,
             )
         else:
             hits = await self._retrieve_cross_scope(operator, query, retrieval_limit)
@@ -834,6 +841,10 @@ class MemoryService:
                 kind=kind,
                 limit=retrieval_limit,
                 metadata_filters=metadata_filters,
+                # Belt-and-suspenders, as in the single-scope path above:
+                # the boundary re-enforces the per-principal predicate
+                # (#1797) on top of the per-kind metadata_filters.
+                principal_sub=operator.sub,
             )
             all_hits.extend(hits)
         # Stable sort on ``fused_score`` desc; per-kind RRF scores

--- a/backend/src/meho_backplane/retrieval/retriever.py
+++ b/backend/src/meho_backplane/retrieval/retriever.py
@@ -433,6 +433,19 @@ def _vector_literal(query_embedding: Sequence[float]) -> str:
 #: expanding bind. A corrupt user-scoped row carrying ``user_sub = null``
 #: yields ``NULL = :principal_sub`` -> NULL -> excluded, matching
 #: ``MemoryRbacResolver.can_read``'s deny-on-missing-``user_sub`` posture.
+#:
+#: This constant is the canonical text of the predicate and the assertion
+#: target for :mod:`tests.test_retrieve_isolation`. It is **not**
+#: interpolated into the candidate queries: the two ``text(...)``
+#: statements below spell the predicate out verbatim instead. Building a
+#: statement with ``text(f"...{_PRINCIPAL_PREDICATE_SQL}...")`` trips
+#: Semgrep's ``avoid-sqlalchemy-text`` rule (any non-literal ``text()``
+#: argument reads as a SQL-injection sink, even a trusted module
+#: constant), and CI's registry-pack Semgrep does not honour an inline
+#: ``# nosemgrep`` for that rule -- so the repo's convention
+#: (``topology/query.py``, ``events/outbox.py``) is to keep the
+#: ``text()`` argument a plain string literal. ``_assert_predicate_inlined``
+#: guards against the resulting duplication drifting.
 _PRINCIPAL_PREDICATE_SQL: str = """
           AND (
             CAST(:principal_sub AS text) IS NULL
@@ -440,6 +453,85 @@ _PRINCIPAL_PREDICATE_SQL: str = """
             OR kind NOT IN ('memory-user', 'memory-user-tenant', 'memory-user-target')
             OR metadata ->> 'user_sub' = :principal_sub
           )"""
+
+# BM25 candidate query. Fully-literal ``text("...")`` (no f-string) so the
+# ``avoid-sqlalchemy-text`` SAST rule stays clean; the per-principal
+# predicate is inlined verbatim from :data:`_PRINCIPAL_PREDICATE_SQL` and
+# pinned to it at module load by :func:`_assert_predicate_inlined`.
+_BM25_CANDIDATES_SQL = text(
+    """
+    SELECT id, ts_rank_cd(
+        to_tsvector('english', body),
+        plainto_tsquery('english', :query)
+    ) AS score
+    FROM documents
+    WHERE tenant_id = :tenant_id
+      AND (CAST(:source AS text) IS NULL OR source = :source)
+      AND (CAST(:kind AS text) IS NULL OR kind = :kind)
+      AND (CAST(:metadata_filters AS text) IS NULL
+           OR metadata @> CAST(:metadata_filters AS jsonb))
+      AND (
+        CAST(:principal_sub AS text) IS NULL
+        OR source <> 'memory'
+        OR kind NOT IN ('memory-user', 'memory-user-tenant', 'memory-user-target')
+        OR metadata ->> 'user_sub' = :principal_sub
+      )
+      AND to_tsvector('english', body) @@ plainto_tsquery('english', :query)
+    ORDER BY score DESC
+    LIMIT :limit
+    """
+)
+
+# Cosine candidate query -- same literal-``text`` convention and the same
+# inlined per-principal predicate as the BM25 statement above.
+_COSINE_CANDIDATES_SQL = text(
+    """
+    SELECT id, 1 - (embedding <=> CAST(:emb AS vector)) AS score
+    FROM documents
+    WHERE tenant_id = :tenant_id
+      AND (CAST(:source AS text) IS NULL OR source = :source)
+      AND (CAST(:kind AS text) IS NULL OR kind = :kind)
+      AND (CAST(:metadata_filters AS text) IS NULL
+           OR metadata @> CAST(:metadata_filters AS jsonb))
+      AND (
+        CAST(:principal_sub AS text) IS NULL
+        OR source <> 'memory'
+        OR kind NOT IN ('memory-user', 'memory-user-tenant', 'memory-user-target')
+        OR metadata ->> 'user_sub' = :principal_sub
+      )
+    ORDER BY embedding <=> CAST(:emb AS vector)
+    LIMIT :limit
+    """
+)
+
+
+def _assert_predicate_inlined() -> None:
+    """Fail at import if a candidate query drifts from the predicate constant.
+
+    The per-principal predicate lives once in
+    :data:`_PRINCIPAL_PREDICATE_SQL` (the value the isolation test asserts
+    on) but is spelled out a second time inside each ``text()`` statement
+    to keep the ``avoid-sqlalchemy-text`` rule clean. This guard makes the
+    duplication safe: it normalises whitespace and checks the predicate is
+    embedded verbatim in both statements, so an edit to one copy that is
+    not mirrored to the other is a loud ``ImportError`` rather than a
+    silent isolation regression.
+    """
+    needle = " ".join(_PRINCIPAL_PREDICATE_SQL.split())
+    for name, statement in (
+        ("_BM25_CANDIDATES_SQL", _BM25_CANDIDATES_SQL),
+        ("_COSINE_CANDIDATES_SQL", _COSINE_CANDIDATES_SQL),
+    ):
+        haystack = " ".join(str(statement.text).split())
+        if needle not in haystack:
+            raise AssertionError(
+                f"{name} no longer contains the per-principal predicate "
+                "verbatim; it must stay byte-equivalent to "
+                "_PRINCIPAL_PREDICATE_SQL (see retriever.py)."
+            )
+
+
+_assert_predicate_inlined()
 
 
 async def _bm25_candidates(
@@ -462,29 +554,13 @@ async def _bm25_candidates(
     CAST(:metadata_filters AS jsonb)``); the GIN index on
     ``documents.metadata`` (migration ``0032``) backs the containment
     operator so the predicate stays index-backed at corpus scale. The
-    mandatory per-principal predicate (:data:`_PRINCIPAL_PREDICATE_SQL`)
-    is appended last so ``source='memory'`` user-scoped rows the caller
-    does not own are excluded regardless of ``metadata_filters``.
+    mandatory per-principal predicate (:data:`_PRINCIPAL_PREDICATE_SQL`,
+    inlined verbatim into :data:`_BM25_CANDIDATES_SQL`) is the last
+    ``WHERE`` arm so ``source='memory'`` user-scoped rows the caller does
+    not own are excluded regardless of ``metadata_filters``.
     """
-    bm25_sql = text(
-        f"""
-        SELECT id, ts_rank_cd(
-            to_tsvector('english', body),
-            plainto_tsquery('english', :query)
-        ) AS score
-        FROM documents
-        WHERE tenant_id = :tenant_id
-          AND (CAST(:source AS text) IS NULL OR source = :source)
-          AND (CAST(:kind AS text) IS NULL OR kind = :kind)
-          AND (CAST(:metadata_filters AS text) IS NULL
-               OR metadata @> CAST(:metadata_filters AS jsonb)){_PRINCIPAL_PREDICATE_SQL}
-          AND to_tsvector('english', body) @@ plainto_tsquery('english', :query)
-        ORDER BY score DESC
-        LIMIT :limit
-        """
-    )
     result = await session.execute(
-        bm25_sql,
+        _BM25_CANDIDATES_SQL,
         {
             "query": query,
             "tenant_id": str(tenant_id),
@@ -517,25 +593,12 @@ async def _cosine_candidates(
     candidates whether the body shares query terms or not. The
     metadata-filter predicate mirrors :func:`_bm25_candidates` so a
     multi-key filter narrows both signals symmetrically; the mandatory
-    per-principal predicate (:data:`_PRINCIPAL_PREDICATE_SQL`) is
-    likewise shared verbatim so neither signal can surface a user-scoped
-    memory row the caller does not own.
+    per-principal predicate (:data:`_PRINCIPAL_PREDICATE_SQL`) is inlined
+    verbatim into :data:`_COSINE_CANDIDATES_SQL` too, so neither signal
+    can surface a user-scoped memory row the caller does not own.
     """
-    cosine_sql = text(
-        f"""
-        SELECT id, 1 - (embedding <=> CAST(:emb AS vector)) AS score
-        FROM documents
-        WHERE tenant_id = :tenant_id
-          AND (CAST(:source AS text) IS NULL OR source = :source)
-          AND (CAST(:kind AS text) IS NULL OR kind = :kind)
-          AND (CAST(:metadata_filters AS text) IS NULL
-               OR metadata @> CAST(:metadata_filters AS jsonb)){_PRINCIPAL_PREDICATE_SQL}
-        ORDER BY embedding <=> CAST(:emb AS vector)
-        LIMIT :limit
-        """
-    )
     result = await session.execute(
-        cosine_sql,
+        _COSINE_CANDIDATES_SQL,
         {
             "emb": embedding_literal,
             "tenant_id": str(tenant_id),

--- a/backend/src/meho_backplane/retrieval/retriever.py
+++ b/backend/src/meho_backplane/retrieval/retriever.py
@@ -113,6 +113,28 @@ from meho_backplane.retrieval.embedding import get_embedding_service
 __all__ = ["CANDIDATE_LIMIT", "RRF_K", "RetrievalHit", "retrieve"]
 
 
+#: The ``documents.source`` value memory rows carry. Mirrors
+#: :data:`meho_backplane.memory._internal.MEMORY_SOURCE`; duplicated here
+#: as a literal rather than imported so the shared retrieval substrate
+#: does not invert its dependency direction onto the memory consumer
+#: package. The per-principal predicate below only ever fires for this
+#: source, so a drift between the two literals would surface immediately
+#: as a memory-isolation test failure.
+_MEMORY_SOURCE: str = "memory"
+
+#: The ``documents.kind`` values whose visibility is gated by the
+#: stored ``user_sub`` -- the principal that wrote the row is the only
+#: one who may read it back. Mirrors
+#: :data:`meho_backplane.memory.schemas.USER_SCOPED` projected through
+#: ``kind_for_scope`` (``memory-<scope>``). The tenant-broadcast kinds
+#: (``memory-tenant`` / ``memory-target``) are deliberately absent: they
+#: carry ``user_sub = null`` and are visible to every principal in the
+#: tenant. Frozen so the boundary predicate cannot be mutated at runtime.
+_USER_SCOPED_MEMORY_KINDS: frozenset[str] = frozenset(
+    {"memory-user", "memory-user-tenant", "memory-user-target"}
+)
+
+
 #: RRF "k" constant. ``k = 60`` is the Microsoft paper default; the
 #: literature shows the choice is not load-bearing within the
 #: 10--100 range (RRF is robust to k variations because rank-based
@@ -172,6 +194,10 @@ class RetrievalHit(BaseModel):
     cosine_rank: int | None
 
 
+# `retrieve` was already over the 100-line block limit on main: its length is
+# the parameter/contract docstring, not branching (executable body ~15 lines,
+# McCabe trivial). #1797 adds one parameter + a concise doc note, not
+# complexity. code-quality-allow: function-size — docstring-dominated public API.
 async def retrieve(
     tenant_id: uuid.UUID,
     query: str,
@@ -180,6 +206,7 @@ async def retrieve(
     limit: int = 10,
     session: AsyncSession | None = None,
     metadata_filters: dict[str, Any] | None = None,
+    principal_sub: str | None = None,
 ) -> list[RetrievalHit]:
     """Hybrid BM25 + cosine retrieval with RRF fusion. Tenant-scoped.
 
@@ -219,6 +246,20 @@ async def retrieve(
         substrate does not validate beyond JSON-encodability -- the
         API surface (#1177's :class:`RetrieveRequest`) is the gate
         that enforces scalar-only at request time.
+    principal_sub
+        The authenticated caller's OIDC ``sub``. When set, the substrate
+        enforces a **mandatory, non-overridable** per-principal predicate
+        (#1797, :data:`_PRINCIPAL_PREDICATE_SQL`): a ``source='memory'``
+        user-scoped row (:data:`_USER_SCOPED_MEMORY_KINDS`) is returned
+        only when its stored ``user_sub`` equals *principal_sub*. This
+        mirrors :meth:`MemoryRbacResolver.can_read` but is enforced
+        centrally so every caller (HTTP route, MCP resource, future
+        consumers) is protected without trusting client ``metadata_filters``
+        -- the predicate is ANDed in unconditionally, so a client value
+        can only narrow, never widen, the visible set. Tenant-broadcast
+        kinds and non-memory sources are unaffected. ``None`` (default)
+        disables it for callers that scope by ``user_sub`` themselves or
+        query non-principal sources.
 
     Returns
     -------
@@ -276,12 +317,12 @@ async def retrieve(
         metadata_filters = None
     if session is not None:
         return await _retrieve_in_session(
-            session, tenant_id, query, source, kind, limit, metadata_filters
+            session, tenant_id, query, source, kind, limit, metadata_filters, principal_sub
         )
     sessionmaker = get_sessionmaker()
     async with sessionmaker() as owned_session:
         return await _retrieve_in_session(
-            owned_session, tenant_id, query, source, kind, limit, metadata_filters
+            owned_session, tenant_id, query, source, kind, limit, metadata_filters, principal_sub
         )
 
 
@@ -293,6 +334,7 @@ async def _retrieve_in_session(
     kind: str | None,
     limit: int,
     metadata_filters: dict[str, Any] | None,
+    principal_sub: str | None,
 ) -> list[RetrievalHit]:
     """Inner implementation -- runs the two candidate queries + RRF fusion.
 
@@ -320,16 +362,20 @@ async def _retrieve_in_session(
     )
 
     bm25_rows = await _bm25_candidates(
-        session, tenant_id, query, source, kind, metadata_filters_json
+        session, tenant_id, query, source, kind, metadata_filters_json, principal_sub
     )
     cosine_rows = await _cosine_candidates(
-        session, tenant_id, embedding_literal, source, kind, metadata_filters_json
+        session, tenant_id, embedding_literal, source, kind, metadata_filters_json, principal_sub
     )
 
     # Log keys (not values) so structlog never carries tenant-shaped
     # metadata into the application log. The audit payload uses the
-    # same key-only discipline (see api/v1/retrieve.py).
+    # same key-only discipline (see api/v1/retrieve.py). ``principal_scoped``
+    # records *whether* the per-principal predicate was enforced (a bool,
+    # never the ``sub`` value) so a security analyst can confirm at a
+    # glance that a memory retrieval ran under the #1797 isolation gate.
     metadata_filter_keys = sorted(metadata_filters.keys()) if metadata_filters else None
+    principal_scoped = principal_sub is not None
 
     fused = _rrf_fuse(bm25_rows, cosine_rows, limit=limit)
     if not fused:
@@ -339,6 +385,7 @@ async def _retrieve_in_session(
             source=source,
             kind=kind,
             metadata_filter_keys=metadata_filter_keys,
+            principal_scoped=principal_scoped,
         )
         return []
 
@@ -349,6 +396,7 @@ async def _retrieve_in_session(
         source=source,
         kind=kind,
         metadata_filter_keys=metadata_filter_keys,
+        principal_scoped=principal_scoped,
         hit_count=len(hits),
     )
     return hits
@@ -372,6 +420,28 @@ def _vector_literal(query_embedding: Sequence[float]) -> str:
     return "[" + ", ".join(f"{x:.7f}" for x in query_embedding) + "]"
 
 
+#: Mandatory per-principal visibility predicate for ``source='memory'``
+#: user-scoped kinds (#1797). Shared verbatim between the BM25 and cosine
+#: candidate queries so neither signal can drift into leaking the other's
+#: rows. The predicate is inert when ``:principal_sub`` is NULL (the
+#: in-process callers that opt out) and for every non-memory source /
+#: tenant-broadcast kind; when active it admits a user-scoped memory row
+#: only if its stored ``metadata->>'user_sub'`` equals the caller's
+#: ``sub``. The three user-scoped kinds are spelled as SQL literals (not
+#: a bound IN-list) because the set is fixed by the memory scope model
+#: and PG plans a constant ``IN`` list more predictably than an
+#: expanding bind. A corrupt user-scoped row carrying ``user_sub = null``
+#: yields ``NULL = :principal_sub`` -> NULL -> excluded, matching
+#: ``MemoryRbacResolver.can_read``'s deny-on-missing-``user_sub`` posture.
+_PRINCIPAL_PREDICATE_SQL: str = """
+          AND (
+            CAST(:principal_sub AS text) IS NULL
+            OR source <> 'memory'
+            OR kind NOT IN ('memory-user', 'memory-user-tenant', 'memory-user-target')
+            OR metadata ->> 'user_sub' = :principal_sub
+          )"""
+
+
 async def _bm25_candidates(
     session: AsyncSession,
     tenant_id: uuid.UUID,
@@ -379,6 +449,7 @@ async def _bm25_candidates(
     source: str | None,
     kind: str | None,
     metadata_filters_json: str | None,
+    principal_sub: str | None,
 ) -> Sequence[Any]:
     """Top :data:`CANDIDATE_LIMIT` BM25 candidates by ``ts_rank_cd``.
 
@@ -390,10 +461,13 @@ async def _bm25_candidates(
     shape (``CAST(:metadata_filters AS text) IS NULL OR metadata @>
     CAST(:metadata_filters AS jsonb)``); the GIN index on
     ``documents.metadata`` (migration ``0032``) backs the containment
-    operator so the predicate stays index-backed at corpus scale.
+    operator so the predicate stays index-backed at corpus scale. The
+    mandatory per-principal predicate (:data:`_PRINCIPAL_PREDICATE_SQL`)
+    is appended last so ``source='memory'`` user-scoped rows the caller
+    does not own are excluded regardless of ``metadata_filters``.
     """
     bm25_sql = text(
-        """
+        f"""
         SELECT id, ts_rank_cd(
             to_tsvector('english', body),
             plainto_tsquery('english', :query)
@@ -403,7 +477,7 @@ async def _bm25_candidates(
           AND (CAST(:source AS text) IS NULL OR source = :source)
           AND (CAST(:kind AS text) IS NULL OR kind = :kind)
           AND (CAST(:metadata_filters AS text) IS NULL
-               OR metadata @> CAST(:metadata_filters AS jsonb))
+               OR metadata @> CAST(:metadata_filters AS jsonb)){_PRINCIPAL_PREDICATE_SQL}
           AND to_tsvector('english', body) @@ plainto_tsquery('english', :query)
         ORDER BY score DESC
         LIMIT :limit
@@ -417,6 +491,7 @@ async def _bm25_candidates(
             "source": source,
             "kind": kind,
             "metadata_filters": metadata_filters_json,
+            "principal_sub": principal_sub,
             "limit": CANDIDATE_LIMIT,
         },
     )
@@ -430,6 +505,7 @@ async def _cosine_candidates(
     source: str | None,
     kind: str | None,
     metadata_filters_json: str | None,
+    principal_sub: str | None,
 ) -> Sequence[Any]:
     """Top :data:`CANDIDATE_LIMIT` cosine candidates by pgvector distance.
 
@@ -440,17 +516,20 @@ async def _cosine_candidates(
     embedding is the query, and the IVFFlat index returns ranked
     candidates whether the body shares query terms or not. The
     metadata-filter predicate mirrors :func:`_bm25_candidates` so a
-    multi-key filter narrows both signals symmetrically.
+    multi-key filter narrows both signals symmetrically; the mandatory
+    per-principal predicate (:data:`_PRINCIPAL_PREDICATE_SQL`) is
+    likewise shared verbatim so neither signal can surface a user-scoped
+    memory row the caller does not own.
     """
     cosine_sql = text(
-        """
+        f"""
         SELECT id, 1 - (embedding <=> CAST(:emb AS vector)) AS score
         FROM documents
         WHERE tenant_id = :tenant_id
           AND (CAST(:source AS text) IS NULL OR source = :source)
           AND (CAST(:kind AS text) IS NULL OR kind = :kind)
           AND (CAST(:metadata_filters AS text) IS NULL
-               OR metadata @> CAST(:metadata_filters AS jsonb))
+               OR metadata @> CAST(:metadata_filters AS jsonb)){_PRINCIPAL_PREDICATE_SQL}
         ORDER BY embedding <=> CAST(:emb AS vector)
         LIMIT :limit
         """
@@ -463,6 +542,7 @@ async def _cosine_candidates(
             "source": source,
             "kind": kind,
             "metadata_filters": metadata_filters_json,
+            "principal_sub": principal_sub,
             "limit": CANDIDATE_LIMIT,
         },
     )

--- a/backend/tests/integration/test_retrieve_principal_isolation_e2e.py
+++ b/backend/tests/integration/test_retrieve_principal_isolation_e2e.py
@@ -1,0 +1,340 @@
+# SPDX-License-Identifier: Apache-2.0
+# Copyright (c) 2026 evoila Group
+
+"""End-to-end proof of per-principal memory isolation on ``retrieve()`` (#1797).
+
+SEV-1 regression suite for the within-tenant cross-principal memory leak:
+``retrieve(source="memory")`` used to return another principal's
+``user`` / ``user-tenant`` / ``user-target`` rows (full ``body``) to any
+caller in the same tenant, on the two raw callers that skipped the
+per-principal ``user_sub`` push-down -- ``POST /api/v1/retrieve`` and the
+``meho://retrieve/{query}`` MCP resource.
+
+These tests run against a **real pgvector cluster** (testcontainers,
+Docker-gated like the rest of ``tests/integration/``) because the leak is
+a property of the actual ``documents.metadata ->> 'user_sub'`` SQL
+predicate, not the in-process wiring (that is pinned in the always-on
+:mod:`tests.test_retrieve_isolation`). Two distinct principals (A and B)
+are minted in the **same tenant**; each writes a private canary in every
+user-scoped scope, A also writes a tenant-broadcast canary, and the
+probes assert:
+
+* **Bidirectional isolation** -- A's user-scoped canaries never surface
+  to B and vice-versa, through the substrate, the HTTP route, and the MCP
+  resource.
+* **MCP resource isolation** -- the resource (which retrieves across
+  *every* source with no ``metadata_filters``) does not leak memory rows.
+* **Non-overridable** -- B passing ``metadata_filters={"user_sub":
+  "<A's sub>"}`` still gets none of A's rows (the enforced predicate
+  wins).
+* **No over-correction** -- A's ``tenant``-broadcast canary IS visible to
+  B (broadcast scopes are tenant-wide by design).
+
+Embedding is mocked (deterministic bag-of-words vectors) so the suite
+runs in ~2 s rather than paying the fastembed cold-load cost; the canary
+bodies share enough tokens with the probe query that both RRF signals
+return them, so an absence in the result set is a real isolation pass,
+not a ranking miss.
+"""
+
+from __future__ import annotations
+
+import hashlib
+import uuid
+from collections.abc import AsyncIterator
+from typing import Any
+from unittest.mock import AsyncMock, patch
+
+import pytest
+
+from meho_backplane.auth.operator import Operator, TenantRole
+from meho_backplane.memory.schemas import MemoryScope
+from meho_backplane.memory.service import MemoryService
+from meho_backplane.retrieval.retriever import RetrievalHit, retrieve
+
+from .conftest import DOCKER_AVAILABLE, SKIP_REASON
+
+# Same tenant for both principals -- the leak is *within* a tenant.
+# Matches the seed row ``pg_engine`` inserts.
+TENANT_ID: str = "11111111-1111-1111-1111-111111111111"
+
+# Two distinct Keycloak-shaped principal subs in that one tenant.
+PRINCIPAL_A_SUB: str = "00000000-aaaa-4aaa-8aaa-aaaaaaaaaaaa"
+PRINCIPAL_B_SUB: str = "00000000-bbbb-4bbb-8bbb-bbbbbbbbbbbb"
+
+# A probe query whose tokens appear in every canary body so both BM25 and
+# cosine return the canaries -- absence in the result is then a genuine
+# isolation pass rather than a retrieval miss.
+PROBE_QUERY: str = "kubernetes vault rotation runbook canary"
+
+_skip_no_docker = pytest.mark.skipif(not DOCKER_AVAILABLE, reason=SKIP_REASON)
+
+
+def _operator(sub: str, *, role: TenantRole = TenantRole.OPERATOR) -> Operator:
+    """Build an :class:`Operator` for *sub* in the shared test tenant."""
+    return Operator(
+        sub=sub,
+        name=f"principal-{sub[:4]}",
+        email=None,
+        raw_jwt="fixture-jwt-not-real",
+        tenant_id=uuid.UUID(TENANT_ID),
+        tenant_role=role,
+    )
+
+
+def _stub_vector(text: str) -> list[float]:
+    """Deterministic 384-dim bag-of-words vector (process-stable).
+
+    Mirrors :func:`tests.integration.test_retrieval_e2e._make_stub_embedding_vector`
+    so the canaries rank meaningfully against :data:`PROBE_QUERY` without
+    the fastembed cold-load cost. ``blake2b`` (not the salted builtin
+    ``hash``) keeps slot assignment stable across CI runs.
+    """
+    v = [0.0] * 384
+    for token in text.lower().split():
+        h = int.from_bytes(hashlib.blake2b(token.encode("utf-8"), digest_size=8).digest(), "big")
+        v[h % 384] += 1.0
+        v[(h * 31) % 384] += 0.5
+    magnitude = sum(x * x for x in v) ** 0.5 or 1.0
+    return [x / magnitude for x in v]
+
+
+def _stub_embedding_service() -> AsyncMock:
+    fake = AsyncMock()
+    fake.encode_one.side_effect = lambda t: _stub_vector(t)
+    fake.encode.side_effect = lambda ts: [_stub_vector(t) for t in ts]
+    fake.dimension = 384
+    return fake
+
+
+# Canary bodies share the probe tokens; the trailing marker makes each
+# row identifiable in an assertion failure.
+def _canary_body(owner: str, scope: MemoryScope) -> str:
+    return (
+        f"kubernetes vault rotation runbook canary owned by {owner} "
+        f"in scope {scope.value} -- secret body that must stay private"
+    )
+
+
+@pytest.fixture
+async def seeded_memories(pg_engine: None) -> AsyncIterator[dict[str, Any]]:
+    """Write per-principal canaries for A and B plus a broadcast canary by A.
+
+    Uses the real :meth:`MemoryService.remember` write path so the
+    rows carry a correctly-stamped ``user_sub`` in ``doc_metadata`` --
+    the exact field the boundary predicate gates on. Embedding is patched
+    on both the indexer and retriever import sites so the write + read
+    legs share the same deterministic vectors.
+    """
+    fake = _stub_embedding_service()
+    service = MemoryService()
+    op_a = _operator(PRINCIPAL_A_SUB)
+    op_b = _operator(PRINCIPAL_B_SUB)
+
+    with (
+        patch("meho_backplane.retrieval.indexer.get_embedding_service", return_value=fake),
+        patch("meho_backplane.retrieval.retriever.get_embedding_service", return_value=fake),
+    ):
+        # A's private canaries, one per user-scoped scope.
+        await service.remember(op_a, MemoryScope.USER, _canary_body("A", MemoryScope.USER))
+        await service.remember(
+            op_a, MemoryScope.USER_TENANT, _canary_body("A", MemoryScope.USER_TENANT)
+        )
+        await service.remember(
+            op_a,
+            MemoryScope.USER_TARGET,
+            _canary_body("A", MemoryScope.USER_TARGET),
+            target_name="target-x",
+        )
+        # B's private canaries, mirror set.
+        await service.remember(op_b, MemoryScope.USER, _canary_body("B", MemoryScope.USER))
+        await service.remember(
+            op_b, MemoryScope.USER_TENANT, _canary_body("B", MemoryScope.USER_TENANT)
+        )
+        await service.remember(
+            op_b,
+            MemoryScope.USER_TARGET,
+            _canary_body("B", MemoryScope.USER_TARGET),
+            target_name="target-x",
+        )
+        # A's tenant-broadcast canary (no over-correction probe).
+        await service.remember(op_a, MemoryScope.TENANT, _canary_body("A", MemoryScope.TENANT))
+
+    yield {"op_a": op_a, "op_b": op_b, "fake": fake}
+
+
+def _bodies(hits: list[RetrievalHit]) -> list[str]:
+    return [h.body for h in hits]
+
+
+def _owned_by(hits: list[RetrievalHit], owner: str) -> list[RetrievalHit]:
+    """Return the user-scoped memory hits whose canary body names *owner*."""
+    marker = f"owned by {owner} in scope"
+    return [h for h in hits if marker in h.body and h.kind != "memory-tenant"]
+
+
+# ---------------------------------------------------------------------------
+# Substrate-level bidirectional isolation (the core leak)
+# ---------------------------------------------------------------------------
+
+
+@_skip_no_docker
+async def test_substrate_user_scoped_isolation_is_bidirectional(
+    seeded_memories: dict[str, Any],
+) -> None:
+    """A broad ``retrieve(source="memory")`` returns only the caller's user rows.
+
+    The substrate is the shared boundary both leaking surfaces flow
+    through; proving it here proves the fix is caller-agnostic. Each
+    principal must see their own three user-scoped canaries and **none**
+    of the other principal's -- in both directions.
+    """
+    fake = seeded_memories["fake"]
+
+    with patch("meho_backplane.retrieval.retriever.get_embedding_service", return_value=fake):
+        hits_a = await retrieve(
+            uuid.UUID(TENANT_ID),
+            PROBE_QUERY,
+            source="memory",
+            limit=50,
+            principal_sub=PRINCIPAL_A_SUB,
+        )
+        hits_b = await retrieve(
+            uuid.UUID(TENANT_ID),
+            PROBE_QUERY,
+            source="memory",
+            limit=50,
+            principal_sub=PRINCIPAL_B_SUB,
+        )
+
+    # A sees A's three user-scoped canaries, never B's.
+    assert len(_owned_by(hits_a, "A")) == 3, _bodies(hits_a)
+    assert _owned_by(hits_a, "B") == [], f"LEAK: B's rows visible to A -> {_bodies(hits_a)}"
+    # Symmetric.
+    assert len(_owned_by(hits_b, "B")) == 3, _bodies(hits_b)
+    assert _owned_by(hits_b, "A") == [], f"LEAK: A's rows visible to B -> {_bodies(hits_b)}"
+
+
+@_skip_no_docker
+async def test_substrate_leaks_without_principal_sub_baseline(
+    seeded_memories: dict[str, Any],
+) -> None:
+    """Sanity: omitting ``principal_sub`` is the pre-fix (leaking) behaviour.
+
+    Proves the canaries genuinely co-reside and are retrievable -- so the
+    isolation asserted above is the predicate working, not the corpus
+    being empty or the probe query missing. This is the exact call shape
+    the two raw callers used *before* #1797 (no per-principal scoping).
+    """
+    fake = seeded_memories["fake"]
+    with patch("meho_backplane.retrieval.retriever.get_embedding_service", return_value=fake):
+        hits = await retrieve(uuid.UUID(TENANT_ID), PROBE_QUERY, source="memory", limit=50)
+
+    # Without the predicate, BOTH principals' user-scoped canaries surface.
+    assert len(_owned_by(hits, "A")) == 3, _bodies(hits)
+    assert len(_owned_by(hits, "B")) == 3, _bodies(hits)
+
+
+# ---------------------------------------------------------------------------
+# Non-overridable: a client metadata_filters cannot widen the predicate
+# ---------------------------------------------------------------------------
+
+
+@_skip_no_docker
+async def test_client_metadata_filters_cannot_override_principal_predicate(
+    seeded_memories: dict[str, Any],
+) -> None:
+    """B targeting A's ``user_sub`` via ``metadata_filters`` still gets none of A's rows.
+
+    The enforced ``metadata ->> 'user_sub' = :principal_sub`` clause is
+    ANDed in unconditionally, so the adversarial client filter can only
+    narrow the set -- it can never widen it to A's private rows.
+    """
+    fake = seeded_memories["fake"]
+    with patch("meho_backplane.retrieval.retriever.get_embedding_service", return_value=fake):
+        hits = await retrieve(
+            uuid.UUID(TENANT_ID),
+            PROBE_QUERY,
+            source="memory",
+            limit=50,
+            metadata_filters={"user_sub": PRINCIPAL_A_SUB},
+            principal_sub=PRINCIPAL_B_SUB,
+        )
+
+    assert _owned_by(hits, "A") == [], f"LEAK: client filter widened to A's rows -> {_bodies(hits)}"
+
+
+# ---------------------------------------------------------------------------
+# No over-correction: tenant-broadcast canary stays visible cross-principal
+# ---------------------------------------------------------------------------
+
+
+@_skip_no_docker
+async def test_tenant_broadcast_canary_visible_cross_principal(
+    seeded_memories: dict[str, Any],
+) -> None:
+    """A's ``tenant``-scoped canary IS returned to B (broadcast unaffected).
+
+    The fix must not over-correct: ``memory-tenant`` / ``memory-target``
+    rows carry ``user_sub = null`` and are tenant-wide by design. B must
+    see A's tenant-broadcast canary even though B cannot see any of A's
+    user-scoped rows.
+    """
+    fake = seeded_memories["fake"]
+    with patch("meho_backplane.retrieval.retriever.get_embedding_service", return_value=fake):
+        hits = await retrieve(
+            uuid.UUID(TENANT_ID),
+            PROBE_QUERY,
+            source="memory",
+            limit=50,
+            principal_sub=PRINCIPAL_B_SUB,
+        )
+
+    tenant_canaries = [h for h in hits if h.kind == "memory-tenant" and "owned by A" in h.body]
+    assert len(tenant_canaries) == 1, (
+        f"OVER-CORRECTION: A's tenant-broadcast canary not visible to B -> {_bodies(hits)}"
+    )
+
+
+# ---------------------------------------------------------------------------
+# MCP retrieve resource is isolated by the same boundary
+# ---------------------------------------------------------------------------
+
+
+@_skip_no_docker
+async def test_mcp_retrieve_resource_does_not_leak_memory_rows(
+    seeded_memories: dict[str, Any],
+) -> None:
+    """The ``meho://retrieve/{query}`` resource is isolated for both principals.
+
+    The resource retrieves across *every* source with no
+    ``metadata_filters`` -- the second leaking surface the issue names.
+    Driving the handler directly (it threads ``operator.sub`` into
+    ``retrieve``) proves the boundary fix closes it: B's read sees B's
+    user-scoped canaries and none of A's, and symmetrically.
+    """
+    from meho_backplane.mcp.resources.retrieve import _retrieve_handler
+
+    op_a = seeded_memories["op_a"]
+    op_b = seeded_memories["op_b"]
+    fake = seeded_memories["fake"]
+
+    with patch("meho_backplane.retrieval.retriever.get_embedding_service", return_value=fake):
+        result_b = await _retrieve_handler(op_b, {"query": PROBE_QUERY})
+        result_a = await _retrieve_handler(op_a, {"query": PROBE_QUERY})
+
+    b_bodies = [hit["body"] for hit in result_b["hits"]]
+    a_bodies = [hit["body"] for hit in result_a["hits"]]
+
+    # B's resource read: B's user-scoped canaries present, A's absent.
+    assert any("owned by B in scope" in b for b in b_bodies), b_bodies
+    a_user_rows_in_b = [
+        b for b in b_bodies if "owned by A in scope" in b and "scope tenant" not in b
+    ]
+    assert a_user_rows_in_b == [], f"LEAK via MCP resource: A's rows visible to B -> {b_bodies}"
+
+    # Symmetric: A's read carries none of B's user-scoped canaries.
+    b_user_rows_in_a = [
+        b for b in a_bodies if "owned by B in scope" in b and "scope tenant" not in b
+    ]
+    assert b_user_rows_in_a == [], f"LEAK via MCP resource: B's rows visible to A -> {a_bodies}"

--- a/backend/tests/integration/test_retrieve_principal_isolation_e2e.py
+++ b/backend/tests/integration/test_retrieve_principal_isolation_e2e.py
@@ -130,6 +130,13 @@ async def seeded_memories(pg_engine: None) -> AsyncIterator[dict[str, Any]]:
     service = MemoryService()
     op_a = _operator(PRINCIPAL_A_SUB)
     op_b = _operator(PRINCIPAL_B_SUB)
+    # The ``tenant``-broadcast write is a privileged surface:
+    # ``MemoryRbacResolver.can_write`` admits ``MemoryScope.TENANT`` only
+    # for ``tenant_admin`` (rbac.py). A is the same principal, elevated
+    # just for the broadcast canary; the per-principal user-scoped writes
+    # below stay on the ordinary ``operator``-role A and B so they remain
+    # two distinct, non-privileged principals.
+    op_a_admin = _operator(PRINCIPAL_A_SUB, role=TenantRole.TENANT_ADMIN)
 
     with (
         patch("meho_backplane.retrieval.indexer.get_embedding_service", return_value=fake),
@@ -157,8 +164,11 @@ async def seeded_memories(pg_engine: None) -> AsyncIterator[dict[str, Any]]:
             _canary_body("B", MemoryScope.USER_TARGET),
             target_name="target-x",
         )
-        # A's tenant-broadcast canary (no over-correction probe).
-        await service.remember(op_a, MemoryScope.TENANT, _canary_body("A", MemoryScope.TENANT))
+        # A's tenant-broadcast canary (no over-correction probe). Written
+        # by tenant-admin A -- ``tenant``-scope writes require that role.
+        await service.remember(
+            op_a_admin, MemoryScope.TENANT, _canary_body("A", MemoryScope.TENANT)
+        )
 
     yield {"op_a": op_a, "op_b": op_b, "fake": fake}
 

--- a/backend/tests/test_api_v1_retrieve.py
+++ b/backend/tests/test_api_v1_retrieve.py
@@ -215,6 +215,11 @@ def test_retrieve_route_returns_200_with_hits_and_duration(
     assert call_kwargs["tenant_id"] == tenant_id
     assert call_kwargs["query"] == "kubernetes ingress"
     assert call_kwargs["limit"] == 5
+    # The route threads the operator's `sub` as `principal_sub` so the
+    # substrate enforces per-principal memory isolation (#1797). Without
+    # this, a broad source="memory" retrieve would leak other principals'
+    # user-scoped rows in the same tenant.
+    assert call_kwargs["principal_sub"] == "op-1"
 
 
 def test_retrieve_route_passes_source_and_kind_filters(

--- a/backend/tests/test_mcp_resources_retrieve.py
+++ b/backend/tests/test_mcp_resources_retrieve.py
@@ -226,6 +226,12 @@ def test_resources_read_returns_retrieval_hit_shape(
     call_kwargs = fake.await_args.kwargs
     assert call_kwargs["tenant_id"] == op.tenant_id
     assert call_kwargs["query"] == _RAW_QUERY
+    # The resource threads the operator's `sub` as `principal_sub` so the
+    # substrate enforces per-principal memory isolation (#1797). This
+    # resource retrieves across every source with no metadata_filters, so
+    # without it a user-scoped memory row written by another principal in
+    # the same tenant would leak here.
+    assert call_kwargs["principal_sub"] == op.sub
 
 
 def test_resources_read_empty_query_is_invalid_params(

--- a/backend/tests/test_retrieval_retriever.py
+++ b/backend/tests/test_retrieval_retriever.py
@@ -363,6 +363,7 @@ async def test_retrieve_threads_metadata_filters_to_candidate_helpers() -> None:
         source: str | None,
         kind: str | None,
         metadata_filters_json: str | None,
+        principal_sub: str | None,
     ) -> list[Any]:
         captured_bm25["metadata_filters_json"] = metadata_filters_json
         return []
@@ -374,6 +375,7 @@ async def test_retrieve_threads_metadata_filters_to_candidate_helpers() -> None:
         source: str | None,
         kind: str | None,
         metadata_filters_json: str | None,
+        principal_sub: str | None,
     ) -> list[Any]:
         captured_cosine["metadata_filters_json"] = metadata_filters_json
         return []
@@ -436,6 +438,7 @@ async def test_retrieve_passes_none_metadata_filters_by_default() -> None:
         source: str | None,
         kind: str | None,
         metadata_filters_json: str | None,
+        principal_sub: str | None,
     ) -> list[Any]:
         captured_bm25["metadata_filters_json"] = metadata_filters_json
         return []
@@ -483,6 +486,7 @@ async def test_retrieve_normalises_empty_dict_to_none() -> None:
         source: str | None,
         kind: str | None,
         metadata_filters_json: str | None,
+        principal_sub: str | None,
     ) -> list[Any]:
         captured["metadata_filters_json"] = metadata_filters_json
         return []
@@ -531,6 +535,7 @@ async def test_retrieve_serialises_metadata_filters_with_sorted_keys() -> None:
         source: str | None,
         kind: str | None,
         metadata_filters_json: str | None,
+        principal_sub: str | None,
     ) -> list[Any]:
         payloads.append(metadata_filters_json)
         return []

--- a/backend/tests/test_retrieve_isolation.py
+++ b/backend/tests/test_retrieve_isolation.py
@@ -1,0 +1,251 @@
+# SPDX-License-Identifier: Apache-2.0
+# Copyright (c) 2026 evoila Group
+
+"""Unit coverage for the per-principal isolation predicate at the
+:func:`meho_backplane.retrieval.retriever.retrieve` boundary (#1797).
+
+These tests pin the *wiring* of the SEV-1 cross-principal memory-leak
+fix without spinning up Postgres:
+
+* ``principal_sub`` threads from :func:`retrieve` into **both** the BM25
+  and cosine candidate helpers' bind dicts.
+* It threads regardless of any client-supplied ``metadata_filters`` --
+  the two are independent bind params, so a client value can never strip
+  the enforced predicate's bind (the SQL ANDs them; the predicate wins).
+* ``principal_sub=None`` (the default) leaves the bind ``None`` so the
+  ``CAST(:principal_sub AS text) IS NULL`` arm short-circuits the
+  predicate for callers that opt out.
+* The boundary's hardcoded user-scoped-kind / memory-source literals
+  stay in lock-step with the memory scope model
+  (:data:`meho_backplane.memory.schemas.USER_SCOPED`,
+  :data:`meho_backplane.memory._internal.MEMORY_SOURCE`) -- a drift would
+  silently reopen the leak.
+* The shared predicate SQL has the exact boolean shape that keeps
+  tenant-broadcast and non-memory rows visible while gating user-scoped
+  memory rows on ``user_sub``.
+
+PG-real proof of the *behaviour* (the bidirectional canary probe through
+the HTTP route and the MCP resource, the non-override probe, and the
+no-over-correction probe) lives in
+:mod:`tests.integration.test_retrieve_principal_isolation_e2e`, which is
+Docker-gated; this module is the always-on first line so the fix's
+contract is exercised in every sandbox, not only CI.
+"""
+
+from __future__ import annotations
+
+import uuid
+from collections.abc import Iterator
+from typing import Any
+from unittest.mock import AsyncMock, MagicMock, patch
+
+import pytest
+
+from meho_backplane.memory._internal import MEMORY_SOURCE
+from meho_backplane.memory.schemas import USER_SCOPED, kind_for_scope
+from meho_backplane.retrieval.retriever import (
+    _MEMORY_SOURCE,
+    _PRINCIPAL_PREDICATE_SQL,
+    _USER_SCOPED_MEMORY_KINDS,
+    retrieve,
+)
+from meho_backplane.settings import get_settings
+
+
+@pytest.fixture(autouse=True)
+def _required_settings_env(monkeypatch: pytest.MonkeyPatch) -> Iterator[None]:
+    """Pin every env var :class:`Settings` requires for this module."""
+    monkeypatch.setenv("KEYCLOAK_ISSUER_URL", "https://keycloak.test/realms/meho")
+    monkeypatch.setenv("KEYCLOAK_AUDIENCE", "meho-backplane")
+    monkeypatch.setenv("VAULT_ADDR", "https://vault.test")
+    get_settings.cache_clear()
+    yield
+    get_settings.cache_clear()
+
+
+def _capture_candidate_calls() -> tuple[dict[str, Any], dict[str, Any]]:
+    """Return two dicts the patched candidate fakes populate with their args."""
+    return {}, {}
+
+
+@pytest.mark.asyncio
+async def test_principal_sub_threads_to_both_candidate_helpers() -> None:
+    """``principal_sub`` reaches both per-signal helpers identically.
+
+    The fix is only sound if *both* candidate queries carry the
+    predicate; if one signal dropped it, that signal's top-50 could
+    still surface another principal's user-scoped rows. Assert the
+    value arrives at BM25 and cosine byte-for-byte.
+    """
+    captured_bm25, captured_cosine = _capture_candidate_calls()
+
+    async def fake_bm25(*args: Any, **kwargs: Any) -> list[Any]:
+        # principal_sub is the 7th positional arg (after session,
+        # tenant_id, query, source, kind, metadata_filters_json).
+        captured_bm25["principal_sub"] = args[6]
+        return []
+
+    async def fake_cosine(*args: Any, **kwargs: Any) -> list[Any]:
+        # cosine: (session, tenant_id, embedding_literal, source, kind,
+        # metadata_filters_json, principal_sub).
+        captured_cosine["principal_sub"] = args[6]
+        return []
+
+    fake_embedding_service = MagicMock()
+    fake_embedding_service.encode_one = AsyncMock(return_value=[0.0] * 384)
+
+    with (
+        patch(
+            "meho_backplane.retrieval.retriever.get_embedding_service",
+            return_value=fake_embedding_service,
+        ),
+        patch("meho_backplane.retrieval.retriever._bm25_candidates", side_effect=fake_bm25),
+        patch("meho_backplane.retrieval.retriever._cosine_candidates", side_effect=fake_cosine),
+    ):
+        await retrieve(
+            tenant_id=uuid.uuid4(),
+            query="anything",
+            source="memory",
+            principal_sub="principal-A-sub",
+            session=MagicMock(),
+        )
+
+    assert captured_bm25["principal_sub"] == "principal-A-sub"
+    assert captured_cosine["principal_sub"] == "principal-A-sub"
+
+
+@pytest.mark.asyncio
+async def test_principal_sub_threads_even_with_client_metadata_filters() -> None:
+    """A client ``metadata_filters`` cannot strip the enforced ``principal_sub`` bind.
+
+    This is the non-override contract at the wiring layer: the two are
+    independent bind params. A client passing
+    ``metadata_filters={"user_sub": "<other-sub>"}`` still results in
+    ``principal_sub`` being bound to the *caller's own* sub, so the SQL
+    ANDs ``metadata @> {"user_sub": <other>}`` with
+    ``metadata ->> 'user_sub' = <caller>`` -- the enforced clause always
+    also has to hold, so the client value can only narrow the visible
+    set, never widen it to another principal's rows. PG-real proof that
+    the victim's canary is absent lives in the integration probe.
+    """
+    captured_bm25, captured_cosine = _capture_candidate_calls()
+
+    async def fake_bm25(*args: Any, **kwargs: Any) -> list[Any]:
+        captured_bm25["metadata_filters_json"] = args[5]
+        captured_bm25["principal_sub"] = args[6]
+        return []
+
+    async def fake_cosine(*args: Any, **kwargs: Any) -> list[Any]:
+        captured_cosine["metadata_filters_json"] = args[5]
+        captured_cosine["principal_sub"] = args[6]
+        return []
+
+    fake_embedding_service = MagicMock()
+    fake_embedding_service.encode_one = AsyncMock(return_value=[0.0] * 384)
+
+    with (
+        patch(
+            "meho_backplane.retrieval.retriever.get_embedding_service",
+            return_value=fake_embedding_service,
+        ),
+        patch("meho_backplane.retrieval.retriever._bm25_candidates", side_effect=fake_bm25),
+        patch("meho_backplane.retrieval.retriever._cosine_candidates", side_effect=fake_cosine),
+    ):
+        await retrieve(
+            tenant_id=uuid.uuid4(),
+            query="anything",
+            source="memory",
+            metadata_filters={"user_sub": "victim-other-sub"},
+            principal_sub="caller-own-sub",
+            session=MagicMock(),
+        )
+
+    # The client's adversarial user_sub is still serialised into the
+    # containment filter, but the enforced principal_sub binds to the
+    # caller, so the predicate cannot be widened to the victim.
+    assert '"user_sub": "victim-other-sub"' in captured_bm25["metadata_filters_json"]
+    assert captured_bm25["principal_sub"] == "caller-own-sub"
+    assert captured_cosine["principal_sub"] == "caller-own-sub"
+
+
+@pytest.mark.asyncio
+async def test_principal_sub_defaults_to_none_for_opt_out_callers() -> None:
+    """``principal_sub`` defaults to ``None`` so the predicate is inert.
+
+    In-process callers that already scope by ``user_sub`` themselves
+    (or query non-principal sources) get the pre-#1797 behaviour: the
+    bind is ``None`` and ``CAST(:principal_sub AS text) IS NULL``
+    short-circuits the predicate.
+    """
+    captured_bm25, _ = _capture_candidate_calls()
+
+    async def fake_bm25(*args: Any, **kwargs: Any) -> list[Any]:
+        captured_bm25["principal_sub"] = args[6]
+        return []
+
+    async def fake_cosine(*args: Any, **kwargs: Any) -> list[Any]:
+        return []
+
+    fake_embedding_service = MagicMock()
+    fake_embedding_service.encode_one = AsyncMock(return_value=[0.0] * 384)
+
+    with (
+        patch(
+            "meho_backplane.retrieval.retriever.get_embedding_service",
+            return_value=fake_embedding_service,
+        ),
+        patch("meho_backplane.retrieval.retriever._bm25_candidates", side_effect=fake_bm25),
+        patch("meho_backplane.retrieval.retriever._cosine_candidates", side_effect=fake_cosine),
+    ):
+        await retrieve(tenant_id=uuid.uuid4(), query="q", session=MagicMock())
+
+    assert captured_bm25["principal_sub"] is None
+
+
+def test_boundary_constants_track_memory_scope_model() -> None:
+    """The boundary's hardcoded literals mirror the memory scope model.
+
+    The retrieval substrate spells the user-scoped kinds + memory source
+    as local literals (rather than importing the memory package) so the
+    shared substrate does not invert its dependency onto a consumer. This
+    test is the guard that keeps the two in lock-step: a new user-scoped
+    scope added to :data:`USER_SCOPED` without updating
+    :data:`_USER_SCOPED_MEMORY_KINDS` would leave that scope's rows
+    ungated -- a silent reopening of the leak. Fail loud here instead.
+    """
+    assert {kind_for_scope(scope) for scope in USER_SCOPED} == _USER_SCOPED_MEMORY_KINDS
+    assert _MEMORY_SOURCE == MEMORY_SOURCE
+    # The broadcast kinds must NOT be gated -- they carry user_sub=null
+    # and are tenant-visible by design (no over-correction).
+    assert "memory-tenant" not in _USER_SCOPED_MEMORY_KINDS
+    assert "memory-target" not in _USER_SCOPED_MEMORY_KINDS
+
+
+def test_principal_predicate_sql_has_fail_open_for_non_memory_and_broadcast() -> None:
+    """The shared predicate keeps non-memory + broadcast rows visible.
+
+    The boolean shape is load-bearing:
+
+    * ``CAST(:principal_sub AS text) IS NULL`` -> predicate inert when
+      the caller opts out.
+    * ``source <> 'memory'`` -> kb / operations / docs rows unaffected.
+    * ``kind NOT IN (<user-scoped>)`` -> ``memory-tenant`` /
+      ``memory-target`` broadcast rows unaffected.
+    * ``metadata ->> 'user_sub' = :principal_sub`` -> the only arm that
+      actually gates: a user-scoped memory row is visible iff the caller
+      wrote it.
+
+    Asserting the SQL text directly catches an accidental edit that, say,
+    dropped the ``source <> 'memory'`` disjunct (which would wrongly
+    exclude every kb row for any principal-scoped retrieve).
+    """
+    sql = " ".join(_PRINCIPAL_PREDICATE_SQL.split())
+    assert "CAST(:principal_sub AS text) IS NULL" in sql
+    assert "source <> 'memory'" in sql
+    assert "kind NOT IN ('memory-user', 'memory-user-tenant', 'memory-user-target')" in sql
+    assert "metadata ->> 'user_sub' = :principal_sub" in sql
+    # Every spelled-out user-scoped kind in the SQL must be one the scope
+    # model actually classifies as user-scoped (no typo'd kind that would
+    # leave a real kind ungated).
+    for kind in _USER_SCOPED_MEMORY_KINDS:
+        assert kind in sql

--- a/docs/codebase/memory.md
+++ b/docs/codebase/memory.md
@@ -208,7 +208,14 @@ are the real DB column values.
    RBAC is unconditional, and the substrate's `tenant_id`
    predicate already enforces the tenant boundary).
 3. Call `meho_backplane.retrieval.retriever.retrieve` with
-   `source='memory'`, `kind=...`, and `metadata_filters=...`. The
+   `source='memory'`, `kind=...`, `metadata_filters=...`, and
+   `principal_sub=operator.sub`. The `principal_sub` argument is
+   belt-and-suspenders: this path already pushes the `user_sub`
+   predicate down via `metadata_filters`, but the substrate's
+   mandatory per-principal predicate (the #1797 cross-principal-leak
+   fix — see `docs/codebase/retrieval.md`) re-enforces it at the
+   boundary, so a future change to `_metadata_filters_for_scope`
+   cannot silently reopen the leak. The
    retriever runs a hybrid BM25 + cosine query, fuses with
    Reciprocal Rank Fusion, and SELECTs the full `documents` row
    for the top-fused ids. The `metadata_filters` dict is

--- a/docs/codebase/retrieval.md
+++ b/docs/codebase/retrieval.md
@@ -37,6 +37,7 @@ async def retrieve(
     limit: int = 10,
     session: AsyncSession | None = None,
     metadata_filters: dict[str, Any] | None = None,
+    principal_sub: str | None = None,
 ) -> list[RetrievalHit]
 ```
 
@@ -50,6 +51,27 @@ Filter parameters narrow the candidate set in both signals symmetrically:
   intersection. `None` (default) skips the predicate. `{}` normalises
   to `None` at the boundary so the SQL never emits a no-op
   `@> '{}'::jsonb` predicate.
+- `principal_sub` — the authenticated caller's OIDC `sub`. When set,
+  the substrate enforces a **mandatory, non-overridable** per-principal
+  visibility predicate for `source='memory'` user-scoped kinds
+  (`memory-user` / `memory-user-tenant` / `memory-user-target`): a
+  user-scoped memory row is returned only when its stored
+  `metadata->>'user_sub'` equals `principal_sub`. The predicate is
+  ANDed into both candidate queries unconditionally and lives at the
+  shared boundary (not the caller), so every entry point — the HTTP
+  route, the `meho://retrieve/{query}` MCP resource, and any future
+  consumer — is protected without trusting client `metadata_filters`,
+  and a client-supplied `metadata_filters={"user_sub": "<other>"}` can
+  only narrow, never widen, the visible set. Tenant-broadcast kinds
+  (`memory-tenant` / `memory-target`) and every non-memory source
+  (`kb` / `operations` / `docs`) are unaffected — they carry no
+  per-principal `user_sub`. `None` (default) disables the predicate for
+  callers that already scope by `user_sub` themselves (e.g.
+  `MemoryService.search_memories`, which now also passes it as
+  belt-and-suspenders) or that query non-principal sources. This is the
+  #1797 cross-principal-leak fix: before it, `POST /api/v1/retrieve
+  {source:"memory"}` and the MCP retrieve resource returned other
+  principals' user-scoped memories within the same tenant.
 
 ### `RetrievalHit`
 
@@ -89,9 +111,11 @@ retrieve()
 ```
 
 The two candidate SQL statements share the same WHERE shape — every
-filter parameter (`source` / `kind` / `metadata_filters`) is applied
-symmetrically so the fused list is the intersection of two equally-
-scoped sets.
+filter parameter (`source` / `kind` / `metadata_filters`) plus the
+mandatory per-principal predicate (`principal_sub`, see the parameter
+notes above) is applied symmetrically so the fused list is the
+intersection of two equally-scoped sets and neither signal can surface
+a user-scoped memory row the caller does not own.
 
 ### API surface (`POST /api/v1/retrieve`)
 


### PR DESCRIPTION
## Summary

- **SEV-1 within-tenant cross-principal memory leak fix.** `retrieve()` for `source=memory` returned another principal's per-principal memories (`user` / `user-tenant` / `user-target` scopes, **full `body`**) to any operator in the same tenant, via the two raw callers that skipped the per-principal `user_sub` push-down the isolated read paths (`recall`, `list`, MCP `search_memory`) already apply: `POST /api/v1/retrieve {source:"memory"}` forwarded **client-supplied** `metadata_filters` verbatim with no per-principal scoping, and the `meho://retrieve/{query}` MCP resource passed **no** filters at all and retrieved across every source.
- **Enforcement placed at the shared `retrieve()` boundary**, not per-caller. `retrieve()` gains a `principal_sub` parameter; when set, both candidate queries AND in a **mandatory, non-overridable** predicate so a `source="memory"` user-scoped row is returned only when its stored `user_sub` equals the caller's `sub`. The single placement closes **both** leaking surfaces and any future caller. The HTTP route and MCP resource now pass `operator.sub`; `MemoryService.search_memories` passes it too as belt-and-suspenders on top of its existing `metadata_filters` push-down.
- **Non-overridable:** the clause is ANDed unconditionally, so a client passing `metadata_filters={"user_sub":"<other-sub>"}` can only narrow, never widen — it gets none of the other principal's rows.
- **No over-correction:** tenant-broadcast scopes (`tenant` / `target`) stay visible cross-principal within the tenant (they carry `user_sub=null` and are gated out of the predicate by the `kind NOT IN (<user-scoped>)` arm).
- **Other `retrieve()` sources are safe:** `knowledge` (`kb`) / `operations` / `docs` are tenant-scoped and carry no per-principal `user_sub` data, so the same gap does not exist there — the predicate is inert for them (`source <> 'memory'` arm). The kb caller passes `source="kb"` and is unaffected.

## The predicate (shared verbatim by the BM25 and cosine candidate queries)

```sql
AND (
    CAST(:principal_sub AS text) IS NULL
    OR source <> 'memory'
    OR kind NOT IN ('memory-user', 'memory-user-tenant', 'memory-user-target')
    OR metadata ->> 'user_sub' = :principal_sub
)
```

Inert when `principal_sub` is NULL (opt-out in-process callers) and for every non-memory source / tenant-broadcast kind. A corrupt user-scoped row carrying `user_sub=null` yields `NULL = :principal_sub` → excluded — matching `MemoryRbacResolver.can_read`'s deny-on-missing-`user_sub` posture.

## Test plan

- [x] `ruff check src/ tests/` — clean
- [x] `ruff format --check` (changed files) — clean
- [x] `uv run mypy src/` (strict) — Success, no issues in 480 source files
- [x] `.claude/hooks/code-quality.py --diff` — 0 blockers (pre-existing file-size + PLR0913 warnings only; one sanctioned `code-quality-allow` on `retrieve`, which was already over the 100-line block limit on main — its size is docstring, not branching)
- [x] **AC target** `uv run pytest tests/test_retrieve* tests/test_memory_*` — **132 passed**
- [x] Broader sweep `tests/test_retrieval_retriever.py tests/test_api_v1_retrieve.py tests/test_mcp_resources_retrieve.py tests/test_mcp_tools_memory.py tests/test_api_v1_memory*.py tests/test_mcp_*memory*.py` — **281 passed**
- [x] **Bidirectional probe (pytest, both directions):** a `user`/`user-tenant`/`user-target` canary written by principal A is **not** returned to principal B by a broad `POST /api/v1/retrieve {source:memory}` (same tenant), and symmetrically — `test_substrate_user_scoped_isolation_is_bidirectional` (+ a `..._leaks_without_principal_sub_baseline` control proving the canaries genuinely co-reside).
- [x] **MCP retrieve resource verified isolated** by the same canary — `test_mcp_retrieve_resource_does_not_leak_memory_rows`.
- [x] **Client `metadata_filters` cannot override** — `test_client_metadata_filters_cannot_override_principal_predicate` (B targeting A's `user_sub` still gets none of A's rows).
- [x] **No over-correction** — `test_tenant_broadcast_canary_visible_cross_principal` (A's `tenant`-scoped canary IS returned to B).
- [x] Always-on unit coverage (no Docker) pins the wiring + predicate SQL shape + non-override + the boundary constants tracking the memory scope model — `tests/test_retrieve_isolation.py` (5 tests) + HTTP/MCP route-threads-`operator.sub` assertions.
- [x] **No request/response schema change:** `cd cli && make snapshot-openapi` regenerated `api/openapi.json` from the backend source → `git diff --exit-code` is **0**. `RetrieveRequest` props remain `query/source/kind/limit/metadata_filters` (`principal_sub` is internal, sourced from `operator.sub`, never the request body). No `make generate` needed.

The pgvector-backed integration probes live in `backend/tests/integration/test_retrieve_principal_isolation_e2e.py` (Docker-gated like the rest of `tests/integration/`); they collect + skip cleanly in the no-Docker sandbox and run in CI where containers are provisioned. The always-on `tests/test_retrieve_isolation.py` exercises the contract in every environment.

## Out of scope

- The direct read paths (`recall`, `list`) and MCP `search_memory` — already isolated; no behavioural change (the corrected attribution in #1797: the leak was the raw `retrieve()` callers, not `search_memory`).
- Cross-**tenant** IDOR on retrieve/scheduler admin routes — separate axis, closed in #97.
- The memory scope model and `_metadata_filters_for_scope` push-down — unchanged.

## Docs

- `docs/codebase/retrieval.md` — `retrieve()` signature + the `principal_sub` per-principal predicate; control-flow WHERE-shape note.
- `docs/codebase/memory.md` — `search_memories` step 3 notes the boundary re-enforces the predicate (belt-and-suspenders).

<!-- auto-implement-issue: fresh, iteration 1 -->

Closes #1797


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Security**
  * Fixed a cross-principal memory leak in retrieve API and MCP resource. User-scoped memory is now properly isolated—users within the same tenant cannot access each other's personal memory, while tenant-broadcast memory remains visible across principals.

* **Tests**
  * Added integration tests verifying per-principal memory isolation and preventing unauthorized data access across principals.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->