### PR TITLE
fix(deps): pin fastapi <0.137 — 0.137.0 drops the entire /api router surface

### DIFF
--- a/backend/pyproject.toml
+++ b/backend/pyproject.toml
@@ -6,7 +6,12 @@ readme = "README.md"
 requires-python = ">=3.12"
 license = "Apache-2.0"
 dependencies = [
-    "fastapi>=0.137.0",
+    # Pinned <0.137: FastAPI 0.137.0 regressed include_router for prefixed
+    # routers — every `/api/v1/*` router (built APIRouter(prefix=...) + relative
+    # routes) mounts ZERO routes on the app, dropping the entire API surface
+    # (caught by test_all_routes_mounted_on_main_app). Unpin once the app is
+    # adapted to 0.137's include_router semantics (tracked follow-up).
+    "fastapi>=0.136.3,<0.137",
     "uvicorn[standard]>=0.49.0",
     "pydantic[email]>=2.13.4",
     "structlog>=26.1.0",

--- a/backend/uv.lock
+++ b/backend/uv.lock
@@ -860,7 +860,7 @@ wheels = [
 
 [[package]]
 name = "fastapi"
-version = "0.137.0"
+version = "0.136.3"
 source = { registry = "https://pypi.org/simple" }
 dependencies = [
     { name = "annotated-doc" },
@@ -869,9 +869,9 @@ dependencies = [
     { name = "typing-extensions" },
     { name = "typing-inspection" },
 ]
-sdist = { url = "https://files.pythonhosted.org/packages/da/fe/fb25c287ff7e0f79fc6acf2e8b812725dad28d2a1446c0410bab1422ac90/fastapi-0.137.0.tar.gz", hash = "sha256:d0565d551f65a803ecff245390840867186f456ef98971f750724eed16e1541c", size = 408023, upload-time = "2026-06-14T12:51:30.672Z" }
+sdist = { url = "https://files.pythonhosted.org/packages/81/2d/ff8d91d7b564d464629a0fd50a4489c97fcb836ac230bf3a7269232a9b1f/fastapi-0.136.3.tar.gz", hash = "sha256:e487fae93ad408e6f47641ee4dfe389864fd7bec92e547ea8498fc13f43e83ab", size = 396410, upload-time = "2026-05-23T18:53:15.192Z" }
 wheels = [
-    { url = "https://files.pythonhosted.org/packages/e7/f1/b38481428e50131e5345b535414d11d196f14990122fe69c9020c64e5683/fastapi-0.137.0-py3-none-any.whl", hash = "sha256:6dcbde8d464f92117c1accb9e42720f8e423fa9b86cb563b1f5862f785a06498", size = 121777, upload-time = "2026-06-14T12:51:29.067Z" },
+    { url = "https://files.pythonhosted.org/packages/e0/82/45359b62a067409bd929ae8a56b8ed13e5a8c8a61194b3c236920999ab83/fastapi-0.136.3-py3-none-any.whl", hash = "sha256:3d2a69bdf04b7e9f3afa292c3bc7a98816bbfafa10bc9b45f3f3700d2f761620", size = 117481, upload-time = "2026-05-23T18:53:16.924Z" },
 ]
 
 [[package]]
@@ -1685,7 +1685,7 @@ requires-dist = [
     { name = "croniter", specifier = ">=6.2.2" },
     { name = "defusedxml", specifier = ">=0.7.1" },
     { name = "duckdb", specifier = ">=1.4.3" },
-    { name = "fastapi", specifier = ">=0.137.0" },
+    { name = "fastapi", specifier = ">=0.136.3,<0.137" },
     { name = "fastembed", specifier = ">=0.7,<1.0" },
     { name = "google-auth", specifier = ">=2.54.0" },
     { name = "httpx", specifier = ">=0.27" },


### PR DESCRIPTION
## What
FastAPI **0.137.0** (dependabot #1773) regressed `include_router` for prefixed routers: every `api/v1` router (`APIRouter(prefix="/api/v1/...")` + relative routes) mounts **zero** routes under 0.137. `main.app` went from **86 `/api` paths to 0** — the entire REST surface vanished, caught by the deterministic `test_all_routes_mounted_on_main_app` failure on `main` (it has been red on every PR's unit lane since the bump).

## Fix
Pin `fastapi>=0.136.3,<0.137` (last working line) + re-lock to 0.136.3. Verified locally: `main.app` is back to **86 `/api` paths** and `test_all_routes_mounted_on_main_app` passes. CLI OpenAPI snapshot is byte-identical (no surface change vs the committed 0.136.3-era snapshot).

## Follow-up
Adapting to 0.137's `include_router` semantics + unpinning is tracked in #1819.

Refs #1773, #1819.

🤖 Generated with [Claude Code](https://claude.com/claude-code)