### PR TITLE
docs(connectors): align connector docs to short canonical product tokens (#1818)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -109,6 +109,7 @@ connector-related release-notes line.
 ### Documentation
 
 - Fix the `meho targets import` examples in the VCF Operations / VCF Logs onboarding guides — they used an unsupported flag form, but `import` takes a `targets.yaml` **file** — and show the per-target `verify_tls` / `tls_ca_pin` TLS-trust fields for reaching self-signed / internal-CA appliances; refresh the vROps "probe fails with TLS error" troubleshooting row to name the per-target options (#1774).
+- Update the connector docs for the short canonical product tokens that the connector-family realignment (#1814) shipped. `docs/architecture/connector-resolution.md` now documents the single canonical product↔impl_id identity — `target.product` is the same token `parse_connector_id` derives, the long↔short split is retired — with a historical note on the five realigned connectors. The SDDC Manager / VCF Automation / VCF Fleet / VCF Operations / Hetzner Robot onboarding guides now use the short `--product` value, `product:` field, and probe/audit output (`sddc`/`vcfa`/`fleet`/`vrops`/`hetzner`) so operators copy a working token; CLI verb trees, wrapper script names, and the vendor-reported Hetzner `robot-webservice` fingerprint are left unchanged (they are names, not the registry token) (#1818).
 
 ## [0.16.0] - 2026-06-15
 

--- a/docs/architecture/connector-resolution.md
+++ b/docs/architecture/connector-resolution.md
@@ -41,6 +41,35 @@ walks that table to pick the right class for a given target.
   (#224)](https://github.com/evoila/meho/issues/224); until that lands,
   the resolver reads it via `getattr(..., None)` and tolerates absence.
 
+### Canonical product identity
+
+`target.product` is the single canonical product token a connector
+registers under — the same token its `connector_id` round-trips to via
+[`parse_connector_id`](../../backend/src/meho_backplane/operations/_lookup.py).
+Every shipped connector satisfies
+`parse_connector_id(f"{impl_id}-{version}")[0] == product`: the
+registry product and the dispatch-derived product are one token, so the
+filter above (`target.product`) and the product the dispatcher resolves
+for a row never diverge.
+
+This was not always so. Six VCF-suite connectors shipped with a *long*
+registry product and a *short* dispatch-/parser-derived product
+(`sddc-manager` vs `sddc`, `vcf-automation` vs `vcfa`, `vcf-fleet` vs
+`fleet`, `vcf-operations` vs `vrops`, `hetzner-robot` vs `hetzner`, and
+`vcf-logs` vs `vrli`), bridged by sanctioned band-aids. vRLI was
+realigned in [#1798](https://github.com/evoila/meho/issues/1798); the
+remaining five in
+[#1814](https://github.com/evoila/meho/issues/1814) (Initiative
+[#1810](https://github.com/evoila/meho/issues/1810)). The split is
+retired — each connector now carries one short canonical token, and a
+target's `product` is that token verbatim.
+
+[`register_connector_v2`](../../backend/src/meho_backplane/connectors/registry.py)
+logs a WARN when a registration's product does not round-trip; with the
+family aligned this check is silent at boot and stays advisory until
+[#1816](https://github.com/evoila/meho/issues/1816) promotes it to a
+hard fail.
+
 ## Tie-break ladder
 
 When two or more connectors advertise support for a target's

--- a/docs/cross-repo/hetzner-robot-onboarding.md
+++ b/docs/cross-repo/hetzner-robot-onboarding.md
@@ -153,7 +153,7 @@ Add an entry to `targets.yaml` in `claude-rdc-hetzner-dc`:
 
 ```yaml
 - name: rdc-robot          # stable slug used in --target flags
-  product: hetzner-robot
+  product: hetzner
   host: robot.hetzner.com
   port: 443                # HTTPS, optional (443 is the default)
   secret_ref: kv/data/hetzner/rdc-robot

--- a/docs/cross-repo/sddc-manager-onboarding.md
+++ b/docs/cross-repo/sddc-manager-onboarding.md
@@ -21,7 +21,7 @@ read-only ops are stored as `EndpointDescriptor` rows seeded from
 [`SDDC_CORE_OPS`](../../backend/src/meho_backplane/connectors/sddc_manager/core_ops.py)
 and dispatched through `HttpConnector._request_json` by the G0.6
 `dispatch_ingested` branch. The connector registers under the
-`(product="sddc-manager", version="9.0", impl_id="sddc-rest")` registry triple —
+`(product="sddc", version="9.0", impl_id="sddc-rest")` registry triple —
 the connector id `sddc-rest-9.0`. Auth is **HTTP Basic** on every request
 (`username@sso_realm:password`); no session establish or XSRF-token dance is
 needed. The connector handles this transparently via `SddcManagerConnector.auth_headers`.
@@ -66,7 +66,7 @@ a separate data path and is **not** mirrored on the MCP surface
   HTTP Basic auth. Credentials are cached in-process per target after first
   use.
 - **A registered SDDC Manager target.** The CLI verbs take `--target <slug>`
-  (e.g. `--target rdc-sddc-manager`). The target carries `product="sddc-manager"`,
+  (e.g. `--target rdc-sddc-manager`). The target carries `product="sddc"`,
   `host` (the appliance FQDN — no `https://`), `port` (default 443),
   `secret_ref` (the Vault path to the credentials),
   `auth_model="shared_service_account"`, and optionally `sso_realm` if the
@@ -107,7 +107,7 @@ To register a new target via the CLI:
 ```bash
 meho targets import \
   --name rdc-sddc-manager \
-  --product sddc-manager \
+  --product sddc \
   --host sddc-manager.rdc.evoila.io \
   --port 443 \
   --secret-ref kv/data/sddc-manager/rdc \
@@ -119,7 +119,7 @@ If your VCF deployment uses a custom SSO realm:
 ```bash
 meho targets import \
   --name rdc-sddc-manager \
-  --product sddc-manager \
+  --product sddc \
   --host sddc-manager.rdc.evoila.io \
   --port 443 \
   --secret-ref kv/data/sddc-manager/rdc \
@@ -131,7 +131,7 @@ Verify the fingerprint resolved correctly:
 
 ```bash
 meho targets probe --name rdc-sddc-manager --json | jq '{product, version, reachable}'
-# expected: {"product": "sddc-manager", "version": "9.0", "reachable": true}
+# expected: {"product": "sddc", "version": "9.0", "reachable": true}
 ```
 
 ## Quick-start

--- a/docs/cross-repo/vcf-automation-onboarding.md
+++ b/docs/cross-repo/vcf-automation-onboarding.md
@@ -23,7 +23,7 @@ seeded from
 [`VCFA_CORE_OPS`](../../backend/src/meho_backplane/connectors/vcf_automation/core_ops.py)
 and dispatched through `HttpConnector._request_json` by the G0.6
 `dispatch_ingested` branch. The connector registers under the
-`(product="vcf-automation", version="9.0", impl_id="vcfa-rest")`
+`(product="vcfa", version="9.0", impl_id="vcfa-rest")`
 registry triple — the connector id `vcfa-rest-9.0`.
 
 VCFA 9.x is structurally different from the other three VCF
@@ -132,7 +132,7 @@ inlines into its reasoning context.
   `svc-meho` split — see "Per-plane credential override" below).
 - **A registered VCFA target.** The CLI verbs take `--target <slug>`
   (e.g. `--target rdc-vcfa`). The target carries
-  `product="vcf-automation"`, `host`, `port` (default 443), `fqdn`
+  `product="vcfa"`, `host`, `port` (default 443), `fqdn`
   (when reached by IP), `secret_ref`, and
   `auth_model="shared_service_account"`. v0.5 supports only
   `shared_service_account`; other auth models surface a clear
@@ -163,7 +163,7 @@ meho targets import path/to/targets.yaml
 ```yaml
 targets:
   - name: rdc-vcfa
-    product: vcf-automation
+    product: vcfa
     host: 10.5.50.100       # IP host requires fqdn below
     port: 443
     fqdn: vcfa.rdc.evoila.io  # canonical vhost
@@ -180,7 +180,7 @@ override fields:
 ```yaml
 targets:
   - name: rdc-vcfa
-    product: vcf-automation
+    product: vcfa
     host: vcfa.rdc.evoila.io
     port: 443
     secret_ref: kv/data/vcfa/rdc-vcfa-tenant      # tenant credentials
@@ -198,7 +198,7 @@ Verify the fingerprint resolved both planes:
 ```bash
 meho targets probe --name rdc-vcfa --json \
   | jq '{product, version, reachable, planes: .extras.planes}'
-# expected: {"product": "vcf-automation", "version": "9.0",
+# expected: {"product": "vcfa", "version": "9.0",
 #            "reachable": true, "planes": ["provider", "tenant"]}
 ```
 
@@ -319,7 +319,7 @@ Every VCFA v0.5 op is `safety_level=safe`, `requires_approval=false` —
 the read-only surface never mutates state. The audit row carries:
 `method='DISPATCH'`, `path=<op_id>`, `target_id=<uuid>`,
 `payload={"op_id": …, "params_hash": …, "source_kind": "ingested",
-"connector_product": "vcf-automation", "connector_version": "9.0",
+"connector_product": "vcfa", "connector_version": "9.0",
 "connector_impl_id": "vcfa-rest", "result_status": "ok"|"error"}`.
 
 Broadcast events publish per-tenant on every successful dispatch.

--- a/docs/cross-repo/vcf-fleet-onboarding.md
+++ b/docs/cross-repo/vcf-fleet-onboarding.md
@@ -21,7 +21,7 @@ read-only ops are stored as `EndpointDescriptor` rows seeded from
 [`FLEET_CORE_OPS`](../../backend/src/meho_backplane/connectors/vcf_fleet/core_ops.py)
 and dispatched through `HttpConnector._request_json` by the G0.6
 `dispatch_ingested` branch. The connector registers under the
-`(product="vcf-fleet", version="9.0", impl_id="fleet-rest")` registry triple —
+`(product="fleet", version="9.0", impl_id="fleet-rest")` registry triple —
 the connector id `fleet-rest-9.0`. Auth is **HTTP Basic** on every request
 against Fleet's local LCM user store (typical service account: `admin@local`);
 no SSO federation, no session establish, no XSRF-token dance. The connector
@@ -98,7 +98,7 @@ without code changes.
   `admin@local`); no realm suffix is appended. Credentials are cached in-process
   per target after first use via the shared `CredentialsCache` helper (#841).
 - **A registered VCF Fleet target.** The CLI verbs take `--target <slug>`
-  (e.g. `--target rdc-fleet`). The target carries `product="vcf-fleet"`,
+  (e.g. `--target rdc-fleet`). The target carries `product="fleet"`,
   `host` (the appliance FQDN — no `https://`), `port` (default 443),
   `secret_ref` (the Vault path to the credentials), and
   `auth_model="shared_service_account"`.
@@ -138,7 +138,7 @@ To register a new target via the CLI:
 ```bash
 meho targets import \
   --name rdc-fleet \
-  --product vcf-fleet \
+  --product fleet \
   --host vcf-fleet.rdc.evoila.io \
   --port 443 \
   --secret-ref kv/data/vcf-fleet/rdc \
@@ -149,7 +149,7 @@ Verify the fingerprint resolved correctly:
 
 ```bash
 meho targets probe --name rdc-fleet --json | jq '{product, version, reachable, extras}'
-# expected: {"product": "vcf-fleet", "version": "8.0", "reachable": true,
+# expected: {"product": "fleet", "version": "8.0", "reachable": true,
 #            "extras": {"lcm_api_version": "8.0", "datacenter_count": N, ...}}
 # Note: `version` carries the LCM API version (the only working version source
 # in 9.0), not the product version. The connector's class-level

--- a/docs/cross-repo/vcf-operations-onboarding.md
+++ b/docs/cross-repo/vcf-operations-onboarding.md
@@ -24,7 +24,7 @@ G0.7 spec ingestion of the vROps `/suite-api` OpenAPI spec (G3.6-T2
 through `HttpConnector._request_json` by the G0.6 `dispatch_ingested`
 branch. The connector class
 [`VcfOperationsConnector`](../../backend/src/meho_backplane/connectors/vcf_operations/connector.py)
-registers under the `(product="vcf-operations", version="9.0",
+registers under the `(product="vrops", version="9.0",
 impl_id="vrops-rest")` registry triple — the connector id
 `vrops-rest-9.0`. Auth is HTTP Basic on every request (vROps'
 `/suite-api/api/*` surface is stateless — no session token, no 401
@@ -80,7 +80,7 @@ a separate data path and is **not** mirrored on the MCP surface
   Basic auth is stateless on vROps — no session token to refresh.
 - **A registered vROps target.** The CLI verbs take `--target <slug>`
   (e.g. `--target rdc-vrops`). The target carries
-  `product="vcf-operations"`, `host` (the vROps FQDN — no `https://`),
+  `product="vrops"`, `host` (the vROps FQDN — no `https://`),
   `port` (default 443), `secret_ref` (the Vault path to the
   credentials), and `auth_model="shared_service_account"`. Optional
   `target.auth_source` routes the Basic challenge to a non-local vROps
@@ -130,7 +130,7 @@ verb in v0.2 — `import` is the CLI's only write path):
 # rdc-vrops.yaml
 targets:
   - name: rdc-vrops
-    product: vcf-operations
+    product: vrops
     host: vrops-mgr.rdc.evoila.io
     port: 443
     secret_ref: kv/data/vcf-operations/rdc-vrops
@@ -162,7 +162,7 @@ Verify the fingerprint resolved correctly:
 
 ```bash
 meho targets probe --name rdc-vrops --json | jq '{product, version, reachable}'
-# expected: {"product": "vcf-operations", "version": "9.0.0.…", "reachable": true}
+# expected: {"product": "vrops", "version": "9.0.0.…", "reachable": true}
 ```
 
 ## Quick-start


### PR DESCRIPTION
## Summary

- Align the connector docs to the **short canonical product tokens** that the connector-family realignment (#1814, Initiative #1810) shipped — `sddc-manager`→`sddc`, `vcf-automation`→`vcfa`, `vcf-fleet`→`fleet`, `vcf-operations`→`vrops`, `hetzner-robot`→`hetzner`. Operators copying the old long token from these guides got a value that now `422`s on `POST /api/v1/targets`.
- `docs/architecture/connector-resolution.md` gains a **Canonical product identity** subsection: `target.product` is the single token `parse_connector_id` round-trips to, the long↔short split is retired, with a historical note on the five (plus vRLI #1798) realigned connectors. It also records that `register_connector_v2`'s round-trip check is still an advisory WARN (silent at boot now that the family is aligned) until #1816 promotes it to a hard fail — the ingest-path bridges are **not** documented as removed (that's #1817).
- The five onboarding guides (`sddc-manager` / `vcf-automation` / `vcf-fleet` / `vcf-operations` / `hetzner-robot`) now use the short token in the registry-triple prose, the `--product` flag, the `product:` `targets.yaml` field, and the probe/audit example output (including a now-corrected stale `connector_product: vcf-automation` audit row).
- **No CLI snapshot change** — #1814 already regenerated it. Verified `make snapshot-openapi && make generate` leaves `cli/api/openapi.json` + `cli/internal/api/client.gen.go` unchanged (`git diff --exit-code` → 0).

### Doc-accuracy discipline (#1798/#1799)

Only the **registry product token** was changed. Every long-token occurrence that is a **name** was verified against the realigned code and left verbatim:

- `meho <product> …` CLI verb trees and `cli/internal/cmd/<product>/` directories
- the consumer `scripts/<product>.sh` wrappers and `*-onboarding.md` / `connectors-*.md` doc filenames
- `rdc-*` target slugs, `kv/data/*` Vault paths, appliance hostnames, the `/v1/sddc-managers` API path
- `refresh.py --connector <name>` recipe keys (validated against `choices=` in the tool — `fleet` would be rejected) and the `backend/tests/fixtures/vcf/<name>/` output dir
- the `hetzner-robot.*` op-id naming (`core_ops.py`), the literal backplane error string `vcf-automation … session re-login failed` (`connector.py:461`), and the vendor-reported Hetzner `FingerprintResult.product="robot-webservice"` (`connector.py:296`)

## Test plan

- [x] `make snapshot-openapi && make generate` → `git diff --exit-code -- cli/api/openapi.json cli/internal/api/client.gen.go` returns **0** (snapshot already correct post-#1814; `TargetCreate.product` enum carries `sddc`/`vcfa`/`fleet`/`vrops`/`hetzner`/`vrli`).
- [x] `pre-commit run --files <changed>` — trailing-whitespace / EOF / check-json / gitleaks / mixed-line-ending all pass.
- [x] Grep audit: zero long-token **registry-product-token** contexts remain across the 6 files; every residual long-token string is a verified name.
- [x] Each long-token "keep" decision cross-checked against the realigned backend/CLI code, not memory.

## Out of scope

- The registration realignment + `targets.product` migration (#1814) — prerequisite, already landed.
- Removing the dormant ingest-path bridges (`dispatch_product` etc.) — #1817.
- Promoting the registration round-trip WARN to hard-fail — #1816.
- `docs/codebase/connectors-*.md`, canary docs, and other `docs/` files carrying long tokens — not in this task's scope.

<!-- auto-implement-issue: fresh, iteration 1 -->

Closes #1818


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Updated onboarding guides to standardize connector product naming conventions.
  * Product identifiers now consistently use shorter canonical tokens (e.g., `sddc`, `vcfa`, `fleet`, `vrops`, `hetzner`) across documentation and target configuration examples.
  * Added documentation clarifying canonical product identity usage for connector registry registration and resolution.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->