### PR TITLE
feat(connectors)!: promote product↔impl_id round-trip check to hard-fail in register_connector_v2 (#1816)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -90,6 +90,10 @@ connector-related release-notes line.
 
 ## [Unreleased]
 
+### Changed
+
+- Promote the connector `product`↔`impl_id` round-trip check in `register_connector_v2` from an advisory WARN to a **hard fail** — now that the family is realigned (#1814) nothing diverges, so a future divergent registration crashes `_eager_import_connectors` at boot (a deploy-time typo) instead of silently shadowing the connector behind an auto-shim (#1816).
+
 ### Security
 
 - Closed a within-tenant **cross-principal memory leak** on the retrieval data path: `POST /api/v1/retrieve {source:"memory"}` and the `meho://retrieve/{query}` MCP resource returned another principal's per-principal memories (`user` / `user-tenant` / `user-target` scopes, full `body`) to any operator in the same tenant. The two surfaces called the shared `retrieve()` substrate without the per-principal `user_sub` push-down the isolated read paths (`recall`, `list`, MCP `search_memory`) already apply — the HTTP route forwarded client `metadata_filters` verbatim with no per-principal scoping, and the MCP resource passed no filters at all. The fix enforces a **mandatory, non-overridable** per-principal predicate at the shared `retrieve()` boundary (`principal_sub`): for `source="memory"` user-scoped kinds a row is returned only when its stored `user_sub` equals the caller's `sub`, applied regardless of caller and AND-enforced so a client-supplied `metadata_filters={"user_sub":"<other>"}` cannot widen it. Tenant-broadcast scopes (`tenant` / `target`) stay visible cross-principal (no over-correction), and the other `retrieve()` sources (`knowledge` / `operations` / `docs`) are tenant-scoped and carry no per-principal `user_sub` data the same gap would leak. Bidirectional + non-override + no-over-correction probes added against a real pgvector cluster, covering both the HTTP route and the MCP resource (#1797).

--- a/backend/src/meho_backplane/connectors/registry.py
+++ b/backend/src/meho_backplane/connectors/registry.py
@@ -144,7 +144,10 @@ def register_connector_v2(
 
     Raises :exc:`TypeError` when ``cls`` is not a :class:`Connector` subclass.
     Raises :exc:`RuntimeError` on duplicate registration of the same
-    three-tuple key.
+    three-tuple key, and (G0.27 / T2 #1816) when the declared ``product``
+    does not round-trip through :func:`parse_connector_id` for the
+    ``impl_id`` / ``version`` — see
+    :func:`_assert_product_impl_id_round_trips`.
 
     Does **not** write to the v1 registry. v2-only registrations are
     invisible to :func:`get_connector` (which keys on product alone);
@@ -163,7 +166,7 @@ def register_connector_v2(
             f"connector already registered for v2 key {key!r}: "
             f"existing={_REGISTRY_V2[key].__name__}, attempted={cls.__name__}"
         )
-    _warn_if_product_impl_id_diverges(product=product, version=version, impl_id=impl_id, cls=cls)
+    _assert_product_impl_id_round_trips(product=product, version=version, impl_id=impl_id, cls=cls)
     _REGISTRY_V2[key] = cls
     _log.info(
         "connector_registered_v2",
@@ -174,18 +177,19 @@ def register_connector_v2(
     )
 
 
-def _warn_if_product_impl_id_diverges(
+def _assert_product_impl_id_round_trips(
     *,
     product: str,
     version: str,
     impl_id: str,
     cls: type[Connector],
 ) -> None:
-    """Log a WARN when ``product`` does not round-trip through the connector_id.
+    """Raise when ``product`` does not round-trip through the connector_id.
 
-    G0.26-T4 (#1798). The dispatch / discovery surface never sees a
-    connector's registration triple directly: it receives a
-    ``connector_id`` string and recovers the product via
+    G0.26-T4 (#1798) introduced this as a structured WARN; G0.27 / T2
+    (#1816) promotes it to a **hard fail**. The dispatch / discovery
+    surface never sees a connector's registration triple directly: it
+    receives a ``connector_id`` string and recovers the product via
     :func:`~meho_backplane.operations._lookup.parse_connector_id`, which
     derives it from the first hyphen-segment of ``impl_id``
     (``"vrli-rest" -> "vrli"``). When a connector registers a ``product``
@@ -195,23 +199,42 @@ def _warn_if_product_impl_id_diverges(
     mismatch that shadowed :class:`~meho_backplane.connectors.vcf_logs.connector.VcfLogsConnector`
     behind an auto-shim in the v0.16.0 dogfood.
 
-    This is **advisory only** — it logs and returns; it never raises.
     The five formerly-divergent ``_PRODUCT_SPLITS`` legacy connectors
     (``sddc-manager`` / ``vcf-automation`` / ``vcf-fleet`` /
     ``vcf-operations`` / ``hetzner-robot``) were realigned to their
     short, dispatch-canonical product token by #1814 (Initiative
     #1810), so — together with vRLI (#1798) — every shipped connector
-    now round-trips and this check is silent at boot. The check stays a
-    WARN (not a hard-fail) so a future connector that reintroduces a
-    divergent registration is flagged loudly without crashing
-    :func:`_eager_import_connectors`; promoting it to a boot-time raise
-    now that the family is aligned is **#1816**'s job.
+    now round-trips. With nothing left to violate the invariant the
+    check can fail closed: a divergent registration is a deploy-time
+    bug (a new connector mis-declaring ``product``, or an ``impl_id``
+    typo), so it raises :exc:`RuntimeError` and crashes
+    :func:`_eager_import_connectors` at boot rather than letting the
+    mismatch silently shadow the connector behind an auto-shim. There
+    is no allowlist — every shipped connector is expected to round-trip,
+    and a future divergence must be fixed at the registration, not
+    sanctioned here.
 
-    The wildcard / v1-compat row ``(product, "", "")`` is skipped: an
+    The wildcard / v1-compat row ``(product, "", "")`` is exempt: an
     empty ``version`` / ``impl_id`` renders a parser-incompatible
     ``connector_id`` (``"-"``) that has no derived product to compare,
     and the padding row is a resolver-internal detail, never an
     operator-addressable connector.
+
+    Scope of the check — only **lossless** connector_ids: the invariant
+    is about the *product* segment, and it is only meaningful when
+    :func:`~meho_backplane.operations._lookup.parse_connector_id` can
+    actually recover the triple. The parser's version segment must be
+    digit-leading (``vmware-rest-9.0`` -> ``("vmware", "9.0",
+    "vmware-rest")``); a non-numeric version label (``vmware-rest-rest``,
+    a synthetic discriminator some impls register under) doesn't match,
+    so the parser falls back to ``(connector_id, "", "")`` — it didn't
+    derive a *different product*, it failed to parse at all. In that case
+    there is no dispatch-canonical product to compare against (the
+    resolver matches such a connector on its ``supported_version_range``,
+    not on a parsed connector_id), so the check skips rather than firing
+    spuriously. It raises only when the parse round-trips losslessly
+    (same ``version`` + ``impl_id`` back out) and the recovered product
+    still disagrees — exactly the ``_PRODUCT_SPLITS`` shadow shape.
 
     ``parse_connector_id`` is imported call-locally to keep the
     ``connectors.registry`` -> ``operations._lookup`` edge off module
@@ -223,28 +246,22 @@ def _warn_if_product_impl_id_diverges(
     from meho_backplane.operations._lookup import parse_connector_id
 
     connector_id = f"{impl_id}-{version}"
-    derived_product = parse_connector_id(connector_id)[0]
+    derived_product, derived_version, derived_impl_id = parse_connector_id(connector_id)
+    # Only enforce on a lossless parse: a connector_id whose version label
+    # is not digit-leading parses back to (connector_id, "", ""), losing the
+    # version/impl_id — there is no meaningfully-derived product to compare.
+    if derived_version != version or derived_impl_id != impl_id:
+        return
     if derived_product == product:
         return
-    _log.warning(
-        "connector_product_impl_id_divergence",
-        product=product,
-        version=version,
-        impl_id=impl_id,
-        cls=cls.__name__,
-        derived_product=derived_product,
-        connector_id=connector_id,
-        message=(
-            f"connector {cls.__name__} registers product={product!r} but "
-            f"connector_id {connector_id!r} parses to product "
-            f"{derived_product!r}; an operator target with "
-            f"product={derived_product!r} (the dispatch-canonical token "
-            f"the connector listing emits) resolves a different namespace "
-            f"than this registration. Align product to {derived_product!r} "
-            f"or rename impl_id so it derives {product!r}. Family "
-            f"realignment + promotion of this check to a hard error is "
-            f"tracked under Initiative #1810."
-        ),
+    raise RuntimeError(
+        f"connector {cls.__name__} registers product={product!r} but "
+        f"connector_id {connector_id!r} parses to product "
+        f"{derived_product!r}; an operator target with "
+        f"product={derived_product!r} (the dispatch-canonical token "
+        f"the connector listing emits) resolves a different namespace "
+        f"than this registration. Align product to {derived_product!r} "
+        f"or rename impl_id so it derives {product!r}."
     )
 
 

--- a/backend/src/meho_backplane/operations/ingest/connector_registration.py
+++ b/backend/src/meho_backplane/operations/ingest/connector_registration.py
@@ -362,13 +362,40 @@ def ensure_connector_class_registered(
 
     Returns ``True`` when a new shim class was synthesised and
     registered; ``False`` when an entry already exists for the
-    ``(product, version, impl_id)`` key in the v2 registry, **or** when a
-    hand-coded connector already covers the ``(version, impl_id)`` under a
-    divergent product token (the ingest guard — see below). The return
-    value drives the ``connector_registered`` flag on
+    canonical ``(product, version, impl_id)`` key in the v2 registry,
+    **or** when a hand-coded connector already covers the
+    ``(version, impl_id)`` under a divergent product token (the ingest
+    guard — see below). The return value drives the
+    ``connector_registered`` flag on
     :class:`~meho_backplane.operations.ingest.register_ingested.IngestionResult`
     so the CLI can report "first ingest registered the connector"
     vs "subsequent ingest reused the existing connector".
+
+    Canonical-product registration (G0.27 / T2 #1816): the shim is
+    synthesised and registered under the **dispatch-canonical** product
+    (:func:`~meho_backplane.operations._lookup.dispatch_product`, i.e. the
+    token :func:`~meho_backplane.operations._lookup.parse_connector_id`
+    derives from the connector_id), **not** the raw operator-supplied
+    ``product``. Two reasons converge:
+
+    * It is the correct, dispatchable spelling. The ingested rows already
+      persist under the dispatch-canonical product
+      (:func:`~meho_backplane.operations.ingest.register_ingested._reconciled_row_product`).
+      Registering the shim under the supplied product when the two diverge
+      (an operator ingesting ``--product drift-test --impl-id drift-impl``,
+      where the connector_id ``drift-impl-…`` parses to ``drift``) put the
+      shim in a namespace the dispatcher never queries — a non-dispatchable
+      shim that resolves nothing. Aligning the shim to the row product
+      fixes that latent footgun (the same product-namespace shadow the
+      round-trip check exists to kill).
+    * ``register_connector_v2`` now hard-fails (G0.27 / T2 #1816) when the
+      declared ``product`` does not round-trip its connector_id. Synthesising
+      under the canonical product makes the shim round-trip *by construction*,
+      so the auto-shim path satisfies the invariant rather than tripping it.
+
+    For aligned connectors (the overwhelmingly common case — the operator's
+    product already equals the parser-derived one) the canonical and
+    supplied products are identical, so this is a no-op.
 
     Ingest guard (G0.26-T4 #1798): before synthesising a shim, defer to
     any hand-coded connector already registered for the same
@@ -377,13 +404,9 @@ def ensure_connector_class_registered(
     divergent product token (``--product vcf-logs`` for ``vrli-rest``,
     after the realignment moved ``VcfLogsConnector``
     to ``product="vrli"``) would scaffold a non-dispatchable
-    ``GenericRestConnector`` shim under ``(vcf-logs, …, vrli-rest)`` that
-    shadows the real connector. The guard keys on ``impl_id`` (the
-    connector's product-independent identity), so a product-namespace
-    divergence cannot route around it. The persisted rows still reconcile
-    to the dispatch-canonical product
-    (:func:`~meho_backplane.operations.ingest.register_ingested._reconciled_row_product`),
-    so the ingested ops resolve through the hand-coded connector.
+    ``GenericRestConnector`` shim that shadows the real connector. The
+    guard keys on ``impl_id`` (the connector's product-independent
+    identity), so a product-namespace divergence cannot route around it.
 
     Idempotency note: the v2 registry rejects duplicate
     registration with :class:`RuntimeError`, so checking presence
@@ -393,30 +416,38 @@ def ensure_connector_class_registered(
     are operator-driven and serialised) so the race is theoretical.
     """
     from meho_backplane.connectors.registry import all_connectors_v2
+    from meho_backplane.operations._lookup import dispatch_product
+
+    # The shim must live under the dispatch-canonical product the ingested
+    # rows persist under (and that register_connector_v2's round-trip check
+    # now hard-fails on if violated) — not the raw operator-supplied one.
+    canonical_product = dispatch_product(product=product, version=version, impl_id=impl_id)
 
     existing = all_connectors_v2()
-    if (product, version, impl_id) in existing:
+    if (canonical_product, version, impl_id) in existing:
         _log.info(
             "connector_auto_register_skipped",
             product=product,
+            canonical_product=canonical_product,
             version=version,
             impl_id=impl_id,
-            existing_cls=existing[(product, version, impl_id)].__name__,
+            existing_cls=existing[(canonical_product, version, impl_id)].__name__,
         )
         return False
 
     handrolled = handrolled_class_for_impl_id(version=version, impl_id=impl_id)
-    if handrolled is not None and handrolled.product != product:
+    if handrolled is not None and handrolled.product != canonical_product:
         _log.info(
             "connector_auto_register_deferred_to_handrolled",
             product=product,
+            canonical_product=canonical_product,
             version=version,
             impl_id=impl_id,
             handrolled_cls=handrolled.__name__,
             handrolled_product=handrolled.product,
             message=(
                 f"not scaffolding a GenericRestConnector shim for "
-                f"({product!r}, {version!r}, {impl_id!r}): hand-coded "
+                f"({canonical_product!r}, {version!r}, {impl_id!r}): hand-coded "
                 f"{handrolled.__name__} already covers impl_id {impl_id!r} "
                 f"under product {handrolled.product!r}. Ingested rows "
                 f"reconcile to the dispatch-canonical product and dispatch "
@@ -426,13 +457,13 @@ def ensure_connector_class_registered(
         return False
 
     cls = _synthesise_shim_class(
-        product=product,
+        product=canonical_product,
         version=version,
         impl_id=impl_id,
         base_url=base_url,
     )
     register_connector_v2(
-        product=product,
+        product=canonical_product,
         version=version,
         impl_id=impl_id,
         cls=cls,
@@ -440,6 +471,7 @@ def ensure_connector_class_registered(
     _log.info(
         "connector_auto_registered",
         product=product,
+        canonical_product=canonical_product,
         version=version,
         impl_id=impl_id,
         cls=cls.__name__,

--- a/backend/tests/test_api_v1_connectors_ingest.py
+++ b/backend/tests/test_api_v1_connectors_ingest.py
@@ -958,10 +958,14 @@ def _registered_class_only_with_uncatalogued_entry() -> Iterator[None]:
     """Register one v2 connector whose ``(product, version)`` is NOT in the catalog.
 
     Drives the not-in-catalog branch of :func:`_next_step_for_registered`.
-    Uses a deliberately synthetic ``("custom-vendor", "1.0")`` triple — no
+    Uses a deliberately synthetic ``("customvendor", "1.0")`` triple — no
     catalog entry exists under that pair (the catalog ships seven curated
-    products and ``custom-vendor`` is not one of them), so the hint must
-    fall through to the manual-mode rationale.
+    products and ``customvendor`` is not one of them), so the hint must
+    fall through to the manual-mode rationale. The triple is aligned
+    (``customvendor-rest-1.0`` parses back to ``customvendor``): since
+    #1816 promoted the registration round-trip check to a hard-fail, a
+    divergent ``(product, impl_id)`` can no longer be registered at all, so
+    the catalog-miss branch is exercised with a round-tripping product.
 
     Re-uses :class:`HarborConnector` as the placeholder class because it
     has a no-arg construct path and the test only exercises the listing —
@@ -974,11 +978,11 @@ def _registered_class_only_with_uncatalogued_entry() -> Iterator[None]:
     )
 
     existing = all_connectors_v2()
-    if ("custom-vendor", "1.0", "custom-rest") not in existing:
+    if ("customvendor", "1.0", "customvendor-rest") not in existing:
         register_connector_v2(
-            product="custom-vendor",
+            product="customvendor",
             version="1.0",
-            impl_id="custom-rest",
+            impl_id="customvendor-rest",
             cls=HarborConnector,
         )
     yield
@@ -1085,25 +1089,19 @@ async def test_list_registered_row_without_catalog_entry_points_at_manual_mode(
     doesn't carry the registered connector, the rationale says so and
     points at manual-mode ``meho connector ingest`` with ``--spec``.
 
-    Uses a synthetic ``("custom-vendor", "1.0", "custom-rest")`` v2
-    registration with no catalog entry. The registry product
-    (``custom-vendor``) differs from the product the dispatcher derives
-    from the connector_id (``parse_connector_id("custom-rest-1.0") ->
-    "custom"``) — the same long↔short split shape the VCF family carries.
-    The hint must:
+    Uses a synthetic ``("customvendor", "1.0", "customvendor-rest")`` v2
+    registration with no catalog entry. The triple is aligned
+    (``parse_connector_id("customvendor-rest-1.0") -> "customvendor"``):
+    since #1816 promoted the registration round-trip check to a hard-fail,
+    a long↔short split registration (the shape the VCF family used to
+    carry) can no longer be registered at all, so the registry product and
+    the parser-derived listing token always agree. The hint must:
 
-    * point at ``meho connector ingest --product custom-vendor --version
-      1.0 --impl custom-rest --spec <upstream-openapi-uri>`` (the
-      manual-mode invocation), emitting the **registry** ``--product``
-      (the spelling the connector class registers under) so the operator's
-      ingest finds the real class and runs a real version-coverage
-      pre-flight. Register-time row reconciliation persists the rows under
-      the parser-derived dispatch product (``custom``), so it still
-      round-trips to a *dispatchable* ingest — that reconciliation, not
-      switching the verb to the short product, is what closes the
-      claude-rdc-hetzner-dc#1136 false-success (the dispatchable round-trip
-      is pinned end-to-end in
-      ``test_operations_ingest_catalog.test_registered_next_step_verb_round_trips_to_dispatchable_ingest``);
+    * point at ``meho connector ingest --product customvendor --version
+      1.0 --impl customvendor-rest --spec <upstream-openapi-uri>`` (the
+      manual-mode invocation), emitting the registry ``--product`` so the
+      operator's ingest finds the real class and runs a real
+      version-coverage pre-flight;
     * carry a rationale that says the catalog has no entry so the
       operator knows they need to source the OpenAPI spec themselves;
     * name the hand-authored on-ramp (#1533 / ci-07) so a spec-less
@@ -1119,20 +1117,19 @@ async def test_list_registered_row_without_catalog_entry_points_at_manual_mode(
     assert response.status_code == 200
     by_id = {c["connector_id"]: c for c in response.json()["connectors"]}
 
-    custom = by_id["custom-rest-1.0"]
+    custom = by_id["customvendor-rest-1.0"]
     assert custom["state"] == "registered"
-    # The listing row advertises the parser-derived product.
-    assert custom["product"] == "custom"
+    # The listing row advertises the parser-derived product, which for an
+    # aligned registration equals the registry product.
+    assert custom["product"] == "customvendor"
     assert custom["next_step"] is not None
     verb = custom["next_step"]["verb"]
     assert "--catalog" not in verb
-    # The verb emits the registry product (so the operator's ingest finds
-    # the real class + runs a real version-coverage pre-flight); register-
-    # time reconciliation lands the rows dispatchably under the short
-    # product, so it still round-trips (claude-rdc-hetzner-dc#1136).
-    assert "--product custom-vendor " in verb
+    # The verb emits the registry product so the operator's ingest finds
+    # the real class + runs a real version-coverage pre-flight.
+    assert "--product customvendor " in verb
     assert "--version 1.0" in verb
-    assert "--impl custom-rest" in verb
+    assert "--impl customvendor-rest" in verb
     assert "--spec" in verb
     rationale = custom["next_step"]["rationale"]
     assert "not in catalog" in rationale
@@ -2695,9 +2692,9 @@ class _RangedTestConnector(Connector):
     looks like what a real misconfigured ingest produces.
     """
 
-    product = "t9-vmware"
+    product = "t9vmware"
     version = "9.0"
-    impl_id = "t9-vmware-rest"
+    impl_id = "t9vmware-rest"
     supported_version_range = ">=8.5,<10.0"
     priority = 1
 
@@ -2726,15 +2723,15 @@ def _registered_ranged_connector() -> Iterator[None]:
     from meho_backplane.connectors.registry import register_connector_v2
 
     register_connector_v2(
-        product="t9-vmware",
+        product="t9vmware",
         version="9.0",
-        impl_id="t9-vmware-rest",
+        impl_id="t9vmware-rest",
         cls=_RangedTestConnector,
     )
     try:
         yield
     finally:
-        _registry_mod._REGISTRY_V2.pop(("t9-vmware", "9.0", "t9-vmware-rest"), None)
+        _registry_mod._REGISTRY_V2.pop(("t9vmware", "9.0", "t9vmware-rest"), None)
 
 
 def test_ingest_returns_422_when_version_outside_registered_class_range(
@@ -2775,9 +2772,9 @@ paths:
         response = client.post(
             "/api/v1/connectors/ingest",
             json={
-                "product": "t9-vmware",
+                "product": "t9vmware",
                 "version": "7.0",
-                "impl_id": "t9-vmware-rest",
+                "impl_id": "t9vmware-rest",
                 "specs": [{"uri": spec_url}],
                 "async": False,
             },
@@ -2785,14 +2782,14 @@ paths:
         )
     assert response.status_code == 422, response.text
     detail = response.json()["detail"]
-    assert detail["product"] == "t9-vmware"
+    assert detail["product"] == "t9vmware"
     assert detail["version"] == "7.0"
-    assert detail["impl_id"] == "t9-vmware-rest"
+    assert detail["impl_id"] == "t9vmware-rest"
     assert detail["registered_classes"] == [
         {
             "class_name": "_RangedTestConnector",
             "version": "9.0",
-            "impl_id": "t9-vmware-rest",
+            "impl_id": "t9vmware-rest",
             "supported_version_range": ">=8.5,<10.0",
         },
     ]
@@ -2840,9 +2837,9 @@ paths:
         response = client.post(
             "/api/v1/connectors/ingest",
             json={
-                "product": "t9-vmware",
+                "product": "t9vmware",
                 "version": "7.0",
-                "impl_id": "t9-vmware-rest",
+                "impl_id": "t9vmware-rest",
                 "specs": [{"uri": spec_url}],
                 "async": False,
             },
@@ -2852,10 +2849,10 @@ paths:
     # The same exception the pre-flight raises for this triple + registered
     # class. ``candidates`` is ``(version, impl_id, class_name, range)``.
     expected_exc = UncoveredVersionLabel(
-        product="t9-vmware",
+        product="t9vmware",
         version="7.0",
-        impl_id="t9-vmware-rest",
-        candidates=[("9.0", "t9-vmware-rest", "_RangedTestConnector", ">=8.5,<10.0")],
+        impl_id="t9vmware-rest",
+        candidates=[("9.0", "t9vmware-rest", "_RangedTestConnector", ">=8.5,<10.0")],
     )
     assert response.json()["detail"] == build_uncovered_version_label_detail(expected_exc)
 
@@ -2893,9 +2890,9 @@ paths:
         response = client.post(
             "/api/v1/connectors/ingest",
             json={
-                "product": "t9-vmware",
+                "product": "t9vmware",
                 "version": "7.0",
-                "impl_id": "t9-vmware-rest",
+                "impl_id": "t9vmware-rest",
                 "specs": [{"uri": spec_url}],
                 "dry_run": True,
             },

--- a/backend/tests/test_api_v1_targets.py
+++ b/backend/tests/test_api_v1_targets.py
@@ -371,7 +371,7 @@ async def test_probe_resolves_v2_only_registration(client: TestClient) -> None:
     )
 
     class _V2OnlyConnector(Connector):
-        product = "vmware-like"
+        product = "vmwarelike"
         # No supported_version_range → matches any target_version
         # including the no-fingerprint case (matches the resolver's
         # "v1-style + no range" pathway used by the test).
@@ -385,12 +385,14 @@ async def test_probe_resolves_v2_only_registration(client: TestClient) -> None:
         async def execute(self, target: Any, op_id: str, params: dict[str, Any]) -> OperationResult:  # type: ignore[override]
             raise NotImplementedError
 
-    # v2-only registration — no register_connector("vmware-like", ...)
-    # call. The pre-#1142 /probe path would 501 on this shape.
+    # v2-only registration — no register_connector("vmwarelike", ...)
+    # call. The pre-#1142 /probe path would 501 on this shape. The triple
+    # is aligned (``vmwarelike-rest-9.0`` parses back to ``vmwarelike``) so
+    # it satisfies the #1816 registration round-trip hard-fail.
     register_connector_v2(
-        product="vmware-like",
+        product="vmwarelike",
         version="9.0",
-        impl_id="vmware-rest",
+        impl_id="vmwarelike-rest",
         cls=_V2OnlyConnector,
     )
 
@@ -398,7 +400,7 @@ async def test_probe_resolves_v2_only_registration(client: TestClient) -> None:
     await _insert_target(
         tenant_id=uuid.UUID(tenant_id),
         name="rdc-vcenter",
-        product="vmware-like",
+        product="vmwarelike",
         host="vcenter.corp.internal",
     )
     key = make_rsa_keypair("kid-A")
@@ -520,7 +522,7 @@ async def test_probe_forwards_operator_jwt_with_three_part_token(
     captured: dict[str, Any] = {}
 
     class _OperatorCapturingConnector(Connector):
-        product = "operator-capture-probe"
+        product = "opcaptureprobe"
 
         async def probe(self, target: Any) -> ProbeResult:
             raise NotImplementedError
@@ -533,7 +535,7 @@ async def test_probe_forwards_operator_jwt_with_three_part_token(
             captured["operator"] = operator
             return FingerprintResult(
                 vendor="test",
-                product="operator-capture-probe",
+                product="opcaptureprobe",
                 version="1.0",
                 reachable=True,
                 probed_at=datetime.now(UTC),
@@ -549,9 +551,9 @@ async def test_probe_forwards_operator_jwt_with_three_part_token(
             raise NotImplementedError
 
     register_connector_v2(
-        product="operator-capture-probe",
+        product="opcaptureprobe",
         version="1.0",
-        impl_id="default",
+        impl_id="opcaptureprobe",
         cls=_OperatorCapturingConnector,
     )
 
@@ -559,7 +561,7 @@ async def test_probe_forwards_operator_jwt_with_three_part_token(
     await _insert_target(
         tenant_id=uuid.UUID(tenant_id),
         name="rke2-infra-k8s",
-        product="operator-capture-probe",
+        product="opcaptureprobe",
         host="capture.test",
     )
     key = make_rsa_keypair("kid-A")
@@ -631,9 +633,9 @@ async def test_probe_fingerprint_exception_returns_structured_500(
     from meho_backplane.connectors.schemas import FingerprintResult, OperationResult
 
     class _FailingConnector(Connector):
-        product = "k8s-fail"
+        product = "k8sfail"
         version = "1.x"
-        impl_id = "k8s"
+        impl_id = "k8sfail"
 
         async def probe(self, target: Any) -> ProbeResult:
             raise NotImplementedError
@@ -645,9 +647,9 @@ async def test_probe_fingerprint_exception_returns_structured_500(
             raise NotImplementedError
 
     register_connector_v2(
-        product="k8s-fail",
+        product="k8sfail",
         version="1.x",
-        impl_id="k8s",
+        impl_id="k8sfail",
         cls=_FailingConnector,
     )
 
@@ -655,7 +657,7 @@ async def test_probe_fingerprint_exception_returns_structured_500(
     await _insert_target(
         tenant_id=uuid.UUID(tenant_id),
         name="rke2-infra-k8s",
-        product="k8s-fail",
+        product="k8sfail",
         host="10.10.0.1",
     )
     key = make_rsa_keypair("kid-A")
@@ -676,7 +678,7 @@ async def test_probe_fingerprint_exception_returns_structured_500(
     # capped message, and a doc reference. Each assertion pins one
     # clause of the convention.
     assert detail["error"] == "fingerprint_failed"
-    assert detail["connector_id"] == "k8s-1.x"
+    assert detail["connector_id"] == "k8sfail-1.x"
     assert detail["target_name"] == "rke2-infra-k8s"
     assert detail["exception_class"] == "RuntimeError"
     assert "kubeconfig credential load failed" in detail["exception_message"]
@@ -705,9 +707,9 @@ async def test_probe_fingerprint_exception_caps_message_length(
     huge_message = "X" * 1024
 
     class _NoisyConnector(Connector):
-        product = "k8s-noisy"
+        product = "k8snoisy"
         version = "1.x"
-        impl_id = "k8s"
+        impl_id = "k8snoisy"
 
         async def probe(self, target: Any) -> ProbeResult:
             raise NotImplementedError
@@ -719,16 +721,16 @@ async def test_probe_fingerprint_exception_caps_message_length(
             raise NotImplementedError
 
     register_connector_v2(
-        product="k8s-noisy",
+        product="k8snoisy",
         version="1.x",
-        impl_id="k8s",
+        impl_id="k8snoisy",
         cls=_NoisyConnector,
     )
     tenant_id = DEFAULT_TENANT_ID
     await _insert_target(
         tenant_id=uuid.UUID(tenant_id),
         name="noisy-k8s",
-        product="k8s-noisy",
+        product="k8snoisy",
         host="10.10.0.2",
     )
     key = make_rsa_keypair("kid-A")

--- a/backend/tests/test_api_v1_targets_discover.py
+++ b/backend/tests/test_api_v1_targets_discover.py
@@ -68,7 +68,13 @@ from ._oidc_jwt_helpers import public_jwks as _public_jwks
 from ._targets_helpers import _insert_target
 
 _TENANT_ID = UUID("11111111-1111-1111-1111-111111111111")
-_PRODUCT = "discover-product"
+# Hyphen-free product whose value equals the first hyphen-segment of every
+# impl_id registered below. register_connector_v2 derives the connector_id as
+# f"{impl_id}-{version}", and connectors/registry._assert_product_impl_id_round_trips
+# hard-fails when the declared product does not round-trip back out of it. A
+# hyphenated product (e.g. "discover-product") parses to only its first segment
+# ("discover"), so it can never round-trip — hence the flat token + prefixed impl_ids.
+_PRODUCT = "discoverp"
 
 
 # ---------------------------------------------------------------------------
@@ -248,9 +254,11 @@ def test_discover_missing_product_returns_422(client: TestClient) -> None:
 def test_discover_merges_candidates_across_connectors(client: TestClient) -> None:
     """Candidates from every connector for the product are merged."""
     register_connector_v2(
-        product=_PRODUCT, version="9.0", impl_id="impl-a", cls=_CandidatesConnector
+        product=_PRODUCT, version="9.0", impl_id="discoverp-a", cls=_CandidatesConnector
     )
-    register_connector_v2(product=_PRODUCT, version="8.0", impl_id="impl-b", cls=_EmptyConnector)
+    register_connector_v2(
+        product=_PRODUCT, version="8.0", impl_id="discoverp-b", cls=_EmptyConnector
+    )
     key, token = _token(TenantRole.OPERATOR)
     with respx.mock as mock_router:
         _mock_discovery_and_jwks(mock_router, _public_jwks(key))
@@ -264,13 +272,17 @@ def test_discover_merges_candidates_across_connectors(client: TestClient) -> Non
     assert body["discovered"][0]["confidence"] == "high"
     # The empty connector lands in skipped with the clean-but-empty reason.
     skipped = {s["name"]: s["reason"] for s in body["skipped"]}
-    assert skipped["impl-b"] == "no candidates"
+    assert skipped["discoverp-b"] == "no candidates"
 
 
 def test_discover_records_raising_connector_and_continues(client: TestClient) -> None:
     """One connector raising does not abort the sweep — it is skipped."""
-    register_connector_v2(product=_PRODUCT, version="9.0", impl_id="good", cls=_CandidatesConnector)
-    register_connector_v2(product=_PRODUCT, version="8.0", impl_id="bad", cls=_RaisingConnector)
+    register_connector_v2(
+        product=_PRODUCT, version="9.0", impl_id="discoverp-good", cls=_CandidatesConnector
+    )
+    register_connector_v2(
+        product=_PRODUCT, version="8.0", impl_id="discoverp-bad", cls=_RaisingConnector
+    )
     key, token = _token(TenantRole.OPERATOR)
     with respx.mock as mock_router:
         _mock_discovery_and_jwks(mock_router, _public_jwks(key))
@@ -283,7 +295,7 @@ def test_discover_records_raising_connector_and_continues(client: TestClient) ->
     # The good connector still contributed despite the bad one raising.
     assert [c["name"] for c in body["discovered"]] == ["esxi-7"]
     skipped = {s["name"]: s["reason"] for s in body["skipped"]}
-    assert "RuntimeError: connector exploded" in skipped["bad"]
+    assert "RuntimeError: connector exploded" in skipped["discoverp-bad"]
 
 
 def test_discover_unknown_product_returns_empty(client: TestClient) -> None:
@@ -317,7 +329,7 @@ def test_discover_with_seed_target_resolves_and_forwards(client: TestClient) -> 
         )
     )
     register_connector_v2(
-        product=_PRODUCT, version="9.0", impl_id="impl-a", cls=_CandidatesConnector
+        product=_PRODUCT, version="9.0", impl_id="discoverp-a", cls=_CandidatesConnector
     )
     key, token = _token(TenantRole.OPERATOR)
     with respx.mock as mock_router:
@@ -335,7 +347,7 @@ def test_discover_with_seed_target_resolves_and_forwards(client: TestClient) -> 
 
 def test_discover_unknown_seed_target_returns_404(client: TestClient) -> None:
     register_connector_v2(
-        product=_PRODUCT, version="9.0", impl_id="impl-a", cls=_CandidatesConnector
+        product=_PRODUCT, version="9.0", impl_id="discoverp-a", cls=_CandidatesConnector
     )
     key, token = _token(TenantRole.OPERATOR)
     with respx.mock as mock_router:
@@ -355,7 +367,7 @@ def test_discover_unknown_seed_target_returns_404(client: TestClient) -> None:
 async def test_discover_binds_canonical_op_id(client: TestClient) -> None:
     """The audit row's payload carries op_id=targets.discover + op_class=read."""
     register_connector_v2(
-        product=_PRODUCT, version="9.0", impl_id="impl-a", cls=_CandidatesConnector
+        product=_PRODUCT, version="9.0", impl_id="discoverp-a", cls=_CandidatesConnector
     )
     key, token = _token(TenantRole.OPERATOR)
     with respx.mock as mock_router:

--- a/backend/tests/test_connectors_registry_v2.py
+++ b/backend/tests/test_connectors_registry_v2.py
@@ -459,9 +459,21 @@ def test_eager_import_connectors_boots_clean_with_all_connectors_aligned() -> No
         assert tokens, "expected connectors to self-register at import"
         assert {"sddc", "vcfa", "fleet", "vrops", "hetzner", "vrli"} <= tokens
     finally:
-        # Restore the import cache so the eviction is invisible to later
-        # tests; the registry contents are restored by the autouse fixtures.
+        # Restore the import cache so the eviction is invisible to later tests;
+        # the registry contents are restored by the autouse fixtures.
         sys.modules.update(evicted)
+        # _eager_import_connectors re-imported the evicted subpackages, creating
+        # FRESH module objects that it also bound as child attributes on their
+        # parent packages. The update() above restores the ORIGINAL objects into
+        # sys.modules, but the parent-package attrs still point at the fresh ones
+        # — a desync that makes a later importlib.reload of any of these modules
+        # fail with "ImportError: module ... not in sys.modules". Rebind each
+        # original onto its parent package to fully undo the re-import.
+        for _name, _module in evicted.items():
+            _parent_name, _, _child = _name.rpartition(".")
+            _parent = sys.modules.get(_parent_name)
+            if _parent is not None and _child:
+                setattr(_parent, _child, _module)
 
 
 # ---------------------------------------------------------------------------

--- a/backend/tests/test_connectors_registry_v2.py
+++ b/backend/tests/test_connectors_registry_v2.py
@@ -15,7 +15,6 @@ from collections.abc import Iterator
 from typing import Any
 
 import pytest
-import structlog.testing
 
 from meho_backplane.connectors import (
     Connector,
@@ -28,37 +27,7 @@ from meho_backplane.connectors import (
     register_connector,
     register_connector_v2,
 )
-from meho_backplane.connectors import registry as registry_module
 from meho_backplane.connectors.registry import clear_registry, registered_product_tokens
-
-
-def _private_log_capture(
-    monkeypatch: pytest.MonkeyPatch,
-) -> structlog.testing.LogCapture:
-    """Bind an xdist-safe private LogCapture onto ``registry._log``.
-
-    Mirrors the pattern in :mod:`tests.test_connector_registration` (#1254):
-    :func:`structlog.testing.capture_logs` swaps the *global* processor
-    list, which a concurrent :func:`structlog.configure` (lifespan boot /
-    observability fixtures) can race so the divergence WARN lands on the
-    real (cached) logger's stdout chain instead of the capture list. The
-    private-logger pattern is process-local, contextvar-free, and
-    auto-restored on teardown.
-    """
-    capture = structlog.testing.LogCapture()
-    private_log = structlog.wrap_logger(
-        structlog.PrintLogger(),
-        processors=[capture],
-    )
-    monkeypatch.setattr(registry_module, "_log", private_log)
-    return capture
-
-
-def _divergence_events(
-    capture: structlog.testing.LogCapture,
-) -> list[dict[str, Any]]:
-    return [e for e in capture.entries if e.get("event") == "connector_product_impl_id_divergence"]
-
 
 # ---------------------------------------------------------------------------
 # Helpers
@@ -248,60 +217,57 @@ def test_register_v2_keyword_only_arguments() -> None:
 
 
 # ---------------------------------------------------------------------------
-# Product↔impl_id round-trip invariant — G0.26-T4 (#1798)
+# Product↔impl_id round-trip invariant — G0.26-T4 (#1798), hard-fail G0.27/T2 (#1816)
 #
-# register_connector_v2 logs a WARN (never raises) when the declared
-# product does not equal the product parse_connector_id derives from the
-# connector_id. The check must NOT crash _eager_import_connectors. Since
-# #1814 (Initiative #1810) realigned the five sanctioned _PRODUCT_SPLITS
-# connectors to their short token (and #1798 realigned vRLI), every
-# shipped connector now round-trips and registers silently — the WARN
-# stays as the guard against a *future* divergent registration (its
-# promotion to a hard-fail is #1816).
+# register_connector_v2 RAISES (RuntimeError) when the declared product
+# does not equal the product parse_connector_id derives from the
+# connector_id. #1798 introduced this as an advisory WARN (it could not
+# raise while the five _PRODUCT_SPLITS connectors still diverged at boot);
+# #1814 (Initiative #1810) realigned those five to their short token (and
+# #1798 realigned vRLI), so nothing diverges anymore and #1816 promotes
+# the check to a hard-fail: a future divergent registration crashes
+# _eager_import_connectors at boot instead of silently shadowing the
+# connector behind an auto-shim. There is no allowlist.
 # ---------------------------------------------------------------------------
 
 
-def test_register_v2_warns_on_divergent_product(monkeypatch: pytest.MonkeyPatch) -> None:
-    """A registration whose product != parser-derived product emits a WARN.
+def test_register_v2_raises_on_divergent_product() -> None:
+    """A registration whose product != parser-derived product RAISES.
 
     ``product="vcf-logs"`` with ``impl_id="vrli-rest"`` parses to
     ``"vrli"`` — the historical split shape that shadowed VcfLogsConnector
-    behind an auto-shim. The WARN names both spellings and points at the
-    follow-up Initiative; the registration still succeeds (advisory, not
-    a hard fail).
+    behind an auto-shim. Post-#1816 this is a hard fail: register_connector_v2
+    raises RuntimeError naming the connector, the declared product, and the
+    parser-derived product, and the divergent triple is NOT registered.
     """
-    capture = _private_log_capture(monkeypatch)
+    with pytest.raises(RuntimeError) as exc_info:
+        register_connector_v2(
+            product="vcf-logs",
+            version="9.0",
+            impl_id="vrli-rest",
+            cls=_FakeConnector,
+        )
 
-    register_connector_v2(
-        product="vcf-logs",
-        version="9.0",
-        impl_id="vrli-rest",
-        cls=_FakeConnector,
-    )
+    msg = str(exc_info.value)
+    # The message names the connector class and both product spellings, and
+    # gives the actionable remediation.
+    assert "_FakeConnector" in msg
+    assert "vcf-logs" in msg
+    assert "vrli" in msg
+    assert "Align product" in msg
 
-    # The registration succeeded despite the divergence.
-    assert ("vcf-logs", "9.0", "vrli-rest") in all_connectors_v2()
-
-    divergence = _divergence_events(capture)
-    assert len(divergence) == 1, f"expected exactly one divergence WARN; got {capture.entries!r}"
-    entry = divergence[0]
-    assert entry["log_level"] == "warning"
-    assert entry["product"] == "vcf-logs"
-    assert entry["derived_product"] == "vrli"
-    assert entry["impl_id"] == "vrli-rest"
-    # The message points operators at the family-realignment Initiative.
-    assert "#1810" in entry["message"]
+    # The divergent registration was rejected — nothing landed in the table.
+    assert ("vcf-logs", "9.0", "vrli-rest") not in all_connectors_v2()
 
 
-def test_register_v2_silent_on_aligned_product(monkeypatch: pytest.MonkeyPatch) -> None:
-    """A registration whose product round-trips parse_connector_id emits no WARN.
+def test_register_v2_aligned_product_registers_without_raising() -> None:
+    """A registration whose product round-trips parse_connector_id is accepted.
 
     ``product="vmware"`` with ``impl_id="vmware-rest"`` parses back to
     ``"vmware"`` — the aligned shape (and the shape vRLI now takes under
-    ``product="vrli"`` / ``impl_id="vrli-rest"``). No divergence event.
+    ``product="vrli"`` / ``impl_id="vrli-rest"``). No raise; the triple
+    registers.
     """
-    capture = _private_log_capture(monkeypatch)
-
     register_connector_v2(
         product="vmware",
         version="9.0",
@@ -309,15 +275,11 @@ def test_register_v2_silent_on_aligned_product(monkeypatch: pytest.MonkeyPatch) 
         cls=_FakeConnector,
     )
 
-    assert _divergence_events(capture) == []
+    assert ("vmware", "9.0", "vmware-rest") in all_connectors_v2()
 
 
-def test_register_v2_silent_on_aligned_single_segment_product(
-    monkeypatch: pytest.MonkeyPatch,
-) -> None:
-    """A single-segment impl_id (``vault`` / ``vault``) round-trips and is silent."""
-    capture = _private_log_capture(monkeypatch)
-
+def test_register_v2_aligned_single_segment_product_registers_without_raising() -> None:
+    """A single-segment impl_id (``vault`` / ``vault``) round-trips and is accepted."""
     register_connector_v2(
         product="vault",
         version="1.x",
@@ -325,19 +287,18 @@ def test_register_v2_silent_on_aligned_single_segment_product(
         cls=_FakeConnector,
     )
 
-    assert _divergence_events(capture) == []
+    assert ("vault", "1.x", "vault") in all_connectors_v2()
 
 
-def test_register_v2_wildcard_row_is_silent(monkeypatch: pytest.MonkeyPatch) -> None:
-    """The ``(product, "", "")`` wildcard / v1-compat row never warns.
+def test_register_v2_wildcard_row_is_exempt() -> None:
+    """The ``(product, "", "")`` wildcard / v1-compat row never raises.
 
     An empty version/impl_id renders a parser-incompatible connector_id
     with no derived product to compare; the check skips it so the dual
     registration pattern (versioned + wildcard) some connectors use does
-    not emit a spurious divergence on the wildcard leg.
+    not fail closed on the wildcard leg — even when the wildcard product
+    would diverge from a hypothetical parse.
     """
-    capture = _private_log_capture(monkeypatch)
-
     register_connector_v2(
         product="vcf-logs",
         version="",
@@ -345,19 +306,17 @@ def test_register_v2_wildcard_row_is_silent(monkeypatch: pytest.MonkeyPatch) -> 
         cls=_FakeConnector,
     )
 
-    assert _divergence_events(capture) == []
+    assert ("vcf-logs", "", "") in all_connectors_v2()
 
 
-def test_register_v2_vrli_alignment_is_silent(monkeypatch: pytest.MonkeyPatch) -> None:
-    """The real VcfLogsConnector, aligned to product=\"vrli\", no longer warns.
+def test_register_v2_vrli_alignment_does_not_raise() -> None:
+    """The real VcfLogsConnector, aligned to product=\"vrli\", registers cleanly.
 
     Direct regression pin for the vRLI half of #1798: registering the
-    shipped connector under its (now canonical) triple must be silent,
-    proving the divergence the WARN catches is gone for vRLI.
+    shipped connector under its (now canonical) triple must not raise,
+    proving the divergence the hard-fail catches is gone for vRLI.
     """
     from meho_backplane.connectors.vcf_logs import VcfLogsConnector
-
-    capture = _private_log_capture(monkeypatch)
 
     register_connector_v2(
         product=VcfLogsConnector.product,
@@ -367,24 +326,24 @@ def test_register_v2_vrli_alignment_is_silent(monkeypatch: pytest.MonkeyPatch) -
     )
 
     assert VcfLogsConnector.product == "vrli"
-    assert _divergence_events(capture) == []
+    assert (VcfLogsConnector.product, VcfLogsConnector.version, VcfLogsConnector.impl_id) in (
+        all_connectors_v2()
+    )
 
 
-def test_realigned_splits_register_silently(
-    monkeypatch: pytest.MonkeyPatch,
-) -> None:
-    """The five formerly-split connectors now register WITHOUT a divergence WARN.
+def test_realigned_splits_register_without_raising() -> None:
+    """The five formerly-split connectors now register WITHOUT raising.
 
     #1814 (Initiative #1810) realigned sddc-manager → ``sddc``,
     vcf-automation → ``vcfa``, vcf-fleet → ``fleet``, vcf-operations →
     ``vrops`` and hetzner-robot → ``hetzner``, so each connector's
     declared ``product`` now equals the token ``parse_connector_id``
     derives from its ``impl_id``/``version``. Registering each real class
-    under its real triple inside a log capture must therefore emit **zero**
-    ``connector_product_impl_id_divergence`` events — together with vRLI
-    (#1798) the whole hand-coded family round-trips. (Before #1814 these
-    five WARNed at boot; this test pins that the realignment silenced
-    them.)
+    under its real triple must therefore NOT trip the hard-fail —
+    together with vRLI (#1798) the whole hand-coded family round-trips.
+    (Before #1814 these five diverged; under #1816's hard-fail a single
+    surviving divergence would crash this registration, so this test
+    doubles as the proof the realignment is complete.)
 
     Registering the real classes directly (rather than calling
     :func:`_eager_import_connectors`, which is a ``sys.modules``-cached
@@ -420,8 +379,8 @@ def test_realigned_splits_register_silently(
             f"got {cls.product!r}"
         )
 
-    capture = _private_log_capture(monkeypatch)
-
+    # The hard-fail raises on any divergence, so a clean pass through the
+    # whole family is the assertion: every class round-trips.
     for cls in (*realigned_classes, VcfLogsConnector):
         register_connector_v2(
             product=cls.product,
@@ -434,15 +393,75 @@ def test_realigned_splits_register_silently(
     snapshot = all_connectors_v2()
     for cls in (*realigned_classes, VcfLogsConnector):
         assert snapshot[(cls.product, cls.version, cls.impl_id)] is cls
-
-    # And not one of them tripped the divergence WARN — the whole point of
-    # the realignment.
-    divergent_products = {e["product"] for e in _divergence_events(capture)}
-    assert divergent_products == set(), (
-        f"realigned connectors must register silently; got divergence WARNs for "
-        f"{divergent_products!r}"
-    )
     assert VcfLogsConnector.product == "vrli"
+
+
+def test_eager_import_connectors_boots_clean_with_all_connectors_aligned() -> None:
+    """Every shipped connector self-registers via _eager_import_connectors without raising.
+
+    The acceptance pin for the hard-fail: importing every
+    ``connectors/<product>/`` subpackage (each of which calls
+    ``register_connector`` / ``register_connector_v2`` at module
+    top-level) — the same path the chassis lifespan runs at boot — must
+    complete without tripping the product↔impl_id hard-fail. With #1814 +
+    #1798 having realigned the whole family, none diverges; if ANY
+    connector still did, this would raise :exc:`RuntimeError`, which is
+    exactly the early-warning the promotion buys.
+
+    To make the assertion exercise the registration side effects
+    *deterministically regardless of import history*, the connector
+    subpackage modules are evicted from ``sys.modules`` and the registry
+    is cleared before the eager import, so every module body re-executes
+    its ``register_connector*`` call under the hard-fail in this test —
+    rather than being a no-op against the conftest-cached imports. The
+    modules are restored afterward so eviction does not leak into other
+    tests (autouse ``_clean_registry`` + conftest's
+    ``_isolate_global_registries`` restore the registry contents; this
+    restores the import cache the eviction touched).
+    """
+    import sys
+
+    import meho_backplane.connectors as conn_pkg
+    from meho_backplane.connectors.registry import _eager_import_connectors
+
+    prefix = f"{conn_pkg.__name__}."
+    # Evict the per-connector subpackage modules (not the registry / base /
+    # adapters modules) so their top-level register_connector* side effects
+    # re-fire on re-import.
+    evicted = {
+        name: module
+        for name, module in list(sys.modules.items())
+        if name.startswith(prefix)
+        and not name.startswith(
+            (
+                f"{prefix}registry",
+                f"{prefix}base",
+                f"{prefix}resolver",
+                f"{prefix}schemas",
+                f"{prefix}adapters",
+            )
+        )
+    }
+    for name in evicted:
+        del sys.modules[name]
+    clear_registry()
+    try:
+        # Raises RuntimeError if any connector diverges — a clean return is
+        # the assertion. Every shipped connector's module-level registration
+        # re-runs here against the freshly-cleared registry.
+        _eager_import_connectors()
+
+        # The registry is populated (the lifespan path produced a usable
+        # table) and the canonical split-family tokens are present under
+        # their short, round-tripping spelling — the realignment that makes
+        # the hard-fail safe.
+        tokens = registered_product_tokens()
+        assert tokens, "expected connectors to self-register at import"
+        assert {"sddc", "vcfa", "fleet", "vrops", "hetzner", "vrli"} <= tokens
+    finally:
+        # Restore the import cache so the eviction is invisible to later
+        # tests; the registry contents are restored by the autouse fixtures.
+        sys.modules.update(evicted)
 
 
 # ---------------------------------------------------------------------------

--- a/backend/tests/test_connectors_resolver.py
+++ b/backend/tests/test_connectors_resolver.py
@@ -610,7 +610,7 @@ def test_resolve_multiple_versioned_with_wildcard_still_disambiguates() -> None:
     register_connector_v2(
         product="k8s",
         version="1.x",
-        impl_id="eks",
+        impl_id="k8s-eks",
         cls=_K8sEksConnector,
     )
     target = _FakeTarget(product="k8s", fingerprint=None)
@@ -619,8 +619,8 @@ def test_resolve_multiple_versioned_with_wildcard_still_disambiguates() -> None:
     # The wildcard ('k8s', '', '') is demoted; the operator-facing
     # candidates list names the two real impl_ids.
     assert exc_info.value.candidates == [
-        ("k8s", "1.x", "eks"),
         ("k8s", "1.x", "k8s"),
+        ("k8s", "1.x", "k8s-eks"),
     ]
 
 

--- a/backend/tests/test_operations_register_ingested.py
+++ b/backend/tests/test_operations_register_ingested.py
@@ -68,7 +68,6 @@ from meho_backplane.db.models import EndpointDescriptor
 from meho_backplane.operations._lookup import (
     connector_exists,
     dispatch_product,
-    parse_connector_id,
 )
 from meho_backplane.operations.ingest import (
     EndpointDescriptorProto,
@@ -1041,11 +1040,13 @@ async def test_register_ingested_warns_and_proceeds_when_no_class_registered(
     )
     monkeypatch.setattr(connector_registration, "_log", private_log)
 
-    # Registry empty for ``(unknown-vendor, brand-new-impl)``.
+    # Registry empty for ``(newvendor, newvendor-rest)``. The triple is
+    # aligned (``newvendor-rest-1.0`` parses back to ``newvendor``) so the
+    # orphaned-class path is exercised without a product↔impl_id divergence.
     result = await register_ingested_operations(
-        product="unknown-vendor",
+        product="newvendor",
         version="1.0",
-        impl_id="brand-new-impl",
+        impl_id="newvendor-rest",
         spec_source="vendor.yaml",
         operations=[_proto("GET:/things", path="/things")],
         embedding_service=stub_embedding_service,
@@ -1059,12 +1060,12 @@ async def test_register_ingested_warns_and_proceeds_when_no_class_registered(
     ]
     assert len(orphan_events) == 1
     event = orphan_events[0]
-    assert event["product"] == "unknown-vendor"
+    assert event["product"] == "newvendor"
     assert event["version"] == "1.0"
-    assert event["impl_id"] == "brand-new-impl"
+    assert event["impl_id"] == "newvendor-rest"
     # The auto-shim is registered after the orphan log (the ingest
     # proceeded — that's the warn-but-proceed semantics).
-    assert ("unknown-vendor", "1.0", "brand-new-impl") in all_connectors_v2()
+    assert ("newvendor", "1.0", "newvendor-rest") in all_connectors_v2()
 
 
 @pytest.mark.asyncio
@@ -1097,119 +1098,23 @@ async def test_register_ingested_passes_pre_flight_for_compatible_version(
 # ---------------------------------------------------------------------------
 # Product-slug reconciliation (claude-rdc-hetzner-dc#1136)
 #
-# The remaining VCF-family splits register under a long product
-# (``product="vcf-automation"``) while the dispatch/query surface derives
-# the short product (``"vcfa"``) from the connector_id's impl_id segment.
-# Ingesting under the long product used to persist rows the dispatcher
-# never queries → the catalog reported ``registered, 0 ops``. These
-# tests pin that an ingest under the long (registry) product now lands
-# rows under the short (dispatch) product so ``connector_exists`` — the
-# gate ``search_operations`` / ``list_operation_groups`` enforce —
-# returns True. (vRLI / ``vrli-rest`` was aligned to the short product in
-# G0.26-T4 #1798 and is no longer a split — see
-# ``test_vrli_ingest_is_aligned_no_reconciliation`` below.)
+# Historically the VCF-family connectors registered under a long product
+# (``product="vcf-automation"``) while the dispatch/query surface derived
+# the short product (``"vcfa"``) from the connector_id's impl_id segment,
+# so an ingest under the long product had to be reconciled down to the
+# short one to stay dispatchable. #1814 (Initiative #1810) realigned the
+# whole family to register under the short token directly, and #1816
+# promoted ``register_connector_v2``'s product↔impl_id round-trip check
+# to a hard-fail — so a connector can no longer register under a divergent
+# long product at all (the old ``_VCF_PRODUCT_SPLITS`` /
+# ``_register_split_connector`` setup would now raise ``RuntimeError``).
+# The aligned ingest path (the only one that remains) is covered by
+# ``test_aligned_product_ingest_is_unchanged`` and
+# ``test_vrli_ingest_is_aligned_no_reconciliation`` below; the
+# divergent-product ingest *guard* (deferring to a hand-coded class rather
+# than scaffolding a shadowing shim) by
+# ``test_ingest_guard_defers_to_handrolled_under_divergent_product``.
 # ---------------------------------------------------------------------------
-
-
-def _register_split_connector(*, registry_product: str, version: str, impl_id: str) -> None:
-    """Register a fake connector class under a long↔short *split* product.
-
-    Mirrors the remaining split VCF-family classes (e.g.
-    ``VcfAutomationConnector`` -> ``product="vcf-automation"`` /
-    ``impl_id="vcfa-rest"``) closely enough for the ingest pre-flight +
-    auto-shim skip path: the class registers under the registry (long)
-    product with a ``>=MAJOR,<MAJOR+1`` range that covers *version*.
-    """
-    cls = type(
-        f"_FakeSplit_{registry_product}",
-        (_FakeRangedConnector,),
-        {
-            "product": registry_product,
-            "version": version,
-            "impl_id": impl_id,
-            "supported_version_range": ">=9.0,<10.0",
-            "priority": 1,
-        },
-    )
-    register_connector_v2(
-        product=registry_product,
-        version=version,
-        impl_id=impl_id,
-        cls=cls,
-    )
-
-
-#: The remaining VCF-family long↔short splits, as ``(registry_product,
-#: impl_id, dispatch_product)``. The registry product is what the
-#: connector class registers under (and what the catalog / pre-#1136
-#: next_step verb hand the operator); the dispatch product is what
-#: ``parse_connector_id`` derives from ``f"{impl_id}-{version}"`` and what
-#: the rows must persist under to be dispatchable. Mirrors
-#: ``_KNOWN_LISTING_PRODUCT_DRIFT`` in ``test_operations_ingest_catalog.py``
-#: plus the already-handled SDDC case (same split shape). vRLI /
-#: ``vrli-rest`` was aligned to ``product="vrli"`` in G0.26-T4 (#1798) so
-#: it round-trips and is no longer a split; the remaining five are
-#: deferred to Initiative #1810.
-_VCF_PRODUCT_SPLITS: list[tuple[str, str, str]] = [
-    ("hetzner-robot", "hetzner-rest", "hetzner"),
-    ("sddc-manager", "sddc-rest", "sddc"),
-    ("vcf-automation", "vcfa-rest", "vcfa"),
-    ("vcf-fleet", "fleet-rest", "fleet"),
-    ("vcf-operations", "vrops-rest", "vrops"),
-]
-
-
-@pytest.mark.asyncio
-@pytest.mark.parametrize(("registry_product", "impl_id", "dispatch_product"), _VCF_PRODUCT_SPLITS)
-async def test_ingest_under_registry_product_persists_dispatchable_rows(
-    stub_embedding_service: AsyncMock,
-    registry_product: str,
-    impl_id: str,
-    dispatch_product: str,
-) -> None:
-    """Ingesting under the long (registry) product lands rows under the short (dispatch) one.
-
-    For every VCF-family split, an operator ingesting ``--product
-    <registry_product>`` (what the catalog row / next_step verb name)
-    must produce a connector the dispatch/query surface resolves. Rows
-    persist under the parser-derived short product and ``connector_exists``
-    — the exact gate ``search_operations`` enforces — returns True.
-    """
-    version = "9.0"
-    _register_split_connector(registry_product=registry_product, version=version, impl_id=impl_id)
-
-    result = await register_ingested_operations(
-        product=registry_product,  # the LONG product the operator was told to use
-        version=version,
-        impl_id=impl_id,
-        spec_source="upstream.yaml",
-        operations=[_proto("GET:/api/v2/version", path="/api/v2/version")],
-        embedding_service=stub_embedding_service,
-    )
-    assert result.inserted_count == 1
-
-    # Rows persisted under the SHORT (dispatch) product, never the long one.
-    sessionmaker = get_sessionmaker()
-    async with sessionmaker() as fresh:
-        rows = (await fresh.execute(select(EndpointDescriptor))).scalars().all()
-    assert len(rows) == 1
-    assert rows[0].product == dispatch_product, (
-        f"row persisted under {rows[0].product!r}; expected the dispatch product "
-        f"{dispatch_product!r} so the dispatcher (which parses it out of the "
-        f"connector_id) can resolve it"
-    )
-
-    # connector_exists — the dispatch/query gate — keyed on the parsed
-    # natural key returns True (the connector is dispatchable).
-    parsed_product, parsed_version, parsed_impl_id = parse_connector_id(f"{impl_id}-{version}")
-    assert parsed_product == dispatch_product
-    exists = await connector_exists(
-        tenant_id=uuid.uuid4(),
-        product=parsed_product,
-        version=parsed_version,
-        impl_id=parsed_impl_id,
-    )
-    assert exists is True
 
 
 @pytest.mark.asyncio
@@ -1236,6 +1141,53 @@ async def test_aligned_product_ingest_is_unchanged(
         rows = (await fresh.execute(select(EndpointDescriptor))).scalars().all()
     assert rows[0].product == "vmware"
     assert dispatch_product(product="vmware", version="9.0", impl_id="vmware-rest") == "vmware"
+
+
+@pytest.mark.asyncio
+async def test_divergent_product_ingest_scaffolds_shim_under_canonical_product(
+    stub_embedding_service: AsyncMock,
+) -> None:
+    """A divergent-product ingest with no hand-coded class scaffolds the shim under the
+    dispatch-canonical product, not the supplied one.
+
+    G0.27 / T2 (#1816). When the operator ingests a novel vendor under a
+    ``product`` token that does not equal the connector_id's parser-derived
+    product (``--product drift-test --impl-id drift-impl`` →
+    ``drift-impl-9.1`` parses to ``drift``), the auto-shim is registered
+    under the dispatch-canonical ``drift`` — the same product the rows
+    persist under — so it is actually dispatchable. Registering it under the
+    supplied ``drift-test`` (the pre-#1816 behavior) put the shim in a
+    namespace the dispatcher never queries (a non-dispatchable shadow) and
+    now also trips ``register_connector_v2``'s product↔impl_id hard-fail.
+    Reconciling the shim to the canonical product keeps the warn-but-proceed
+    ingest semantics while satisfying the invariant.
+    """
+    canonical = dispatch_product(product="drift-test", version="9.1", impl_id="drift-impl")
+    assert canonical == "drift"
+
+    result = await register_ingested_operations(
+        product="drift-test",  # diverges from the parser-derived "drift"
+        version="9.1",
+        impl_id="drift-impl",
+        spec_source="vendor.yaml",
+        operations=[_proto("GET:/things", path="/things")],
+        embedding_service=stub_embedding_service,
+    )
+    assert result.inserted_count == 1
+    assert result.connector_registered is True
+
+    # The shim landed under the canonical product, NOT the supplied one.
+    snapshot = all_connectors_v2()
+    assert ("drift", "9.1", "drift-impl") in snapshot
+    assert ("drift-test", "9.1", "drift-impl") not in snapshot
+    assert issubclass(snapshot[("drift", "9.1", "drift-impl")], GenericRestConnector)
+
+    # Rows persist under the same canonical product so the shim resolves them.
+    sessionmaker = get_sessionmaker()
+    async with sessionmaker() as fresh:
+        rows = (await fresh.execute(select(EndpointDescriptor))).scalars().all()
+    assert len(rows) == 1
+    assert rows[0].product == "drift"
 
 
 @pytest.mark.asyncio


### PR DESCRIPTION
Initiative #1810 T2. #1798 added the `register_connector_v2` round-trip check (declared `product` == `parse_connector_id`-derived product) as an advisory **WARN** (the VCF `_PRODUCT_SPLITS` family deliberately diverged). #1814 realigned the last 5, so the family now round-trips and the check is silent at boot.

This promotes it to a **hard fail**: a divergent registration raises `RuntimeError` (naming the connector + declared vs parser-derived product) and crashes `_eager_import_connectors` — a divergence is now a deploy-time error to fix at the registration, not something to silently shadow behind an auto-shim. No allowlist. Tests: a synthetic divergent registration raises; the aligned connector set registers clean; the app boots.

Closes #1816. Part of #1810. (Finalized by the orchestrator after the implement worker's transient-529 death — changes verified: ruff/mypy-strict clean, 174 connector/registration tests pass incl. `test_all_routes_mounted_on_main_app`.)

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **Bug Fixes**
  * Connector registration now enforces strict validation at startup, failing immediately when connector identifiers are misaligned rather than silently shadowing the issue, ensuring configuration problems are caught early.

* **Changed**
  * Standardized connector product naming conventions across the system for consistency.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->