### PR TITLE
feat(agents): add operator agent run-cancel REST endpoint + CLI verb (#1828)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -90,6 +90,10 @@ connector-related release-notes line.
 
 ## [Unreleased]
 
+### Added
+
+- **Operator agent run-cancel**: `POST /api/v1/agents/runs/{handle}/cancel` (REST) and `meho agent run-cancel <handle>` (CLI) let an operator stop a non-terminal agent run — previously only the internal reaper/scheduler could write `cancelled`. Both wrap the existing `cancel_run` service path, so the durable `cancelled` transition and its `agent_run.completed` lifecycle outbox event (emitted by the shared `transition` for every terminal state) are produced by one code path with no second status-write. The route is operator-role, tenant-scoped (an unknown / cross-tenant handle is `404`, no existence leak) and race-safe: a run that completes between the request and the write returns `409 agent_run_not_cancellable`, not a 500. An `awaiting_approval` run cancels cleanly; its pending approval is left to expire / be rejected on resume. The OpenAPI snapshot and the generated Go client are regenerated in lock-step (#1828).
+
 ### Changed
 
 - Promote the connector `product`↔`impl_id` round-trip check in `register_connector_v2` from an advisory WARN to a **hard fail** — now that the family is realigned (#1814) nothing diverges, so a future divergent registration crashes `_eager_import_connectors` at boot (a deploy-time typo) instead of silently shadowing the connector behind an auto-shim (#1816).

--- a/backend/src/meho_backplane/agent/invocation.py
+++ b/backend/src/meho_backplane/agent/invocation.py
@@ -1223,6 +1223,54 @@ class AgentInvoker:
                 raise AgentRunNotFoundError(run_id)
             return _row_to_view(row)
 
+    async def cancel(self, operator: Operator, run_id: uuid.UUID) -> AgentRunSummary:
+        """Cancel a non-terminal run the operator's tenant owns.
+
+        The operator-facing cancel path behind ``POST
+        /api/v1/agents/runs/{handle}/cancel`` and ``meho agent
+        run-cancel``. It wraps the shared
+        :func:`~meho_backplane.operations.agent_run.cancel_run` service
+        helper -- the *same* terminal-transition path the reaper writes
+        through -- so the durable ``cancelled`` state and the
+        ``agent_run.completed`` outbox event
+        (:func:`~meho_backplane.operations.agent_run.transition` emits one
+        for every terminal transition, cancellation included) are produced
+        by one code path, never a second status-write.
+
+        Tenant isolation is enforced here, before the service call: a
+        cross-tenant / unknown handle raises :class:`AgentRunNotFoundError`
+        (mapped to 404 by the boundary) so a run's existence is not leaked
+        across tenants -- the same posture :meth:`poll` takes. The service
+        helper additionally raises
+        :class:`~meho_backplane.operations.agent_run.IllegalTransitionError`
+        for an already-terminal run (mapped to 409) and
+        :class:`~meho_backplane.operations.agent_run.UnauthorizedCancellationError`
+        for a sub-operator role (mapped to 403). An ``awaiting_approval``
+        run cancels cleanly (the state machine permits the edge); its
+        pending approval is left to expire / be rejected on resume rather
+        than being force-decided here.
+
+        The in-flight async loop is *not* interrupted synchronously: this
+        records the durable cancel intent, and the loop observes the
+        ``cancelled`` status on its next turn boundary and stops -- the
+        cancellation contract :func:`cancel_run` documents.
+
+        Raises:
+            AgentRunNotFoundError: no run for *run_id* in the tenant.
+            run_lifecycle.UnauthorizedCancellationError: the operator's
+                role ranks below the cancel minimum.
+            run_lifecycle.IllegalTransitionError: the run is already
+                terminal (succeeded / failed / cancelled).
+        """
+        sessionmaker = get_sessionmaker()
+        async with sessionmaker() as session:
+            row = await run_lifecycle.get_run(session, run_id)
+            if row is None or row.tenant_id != operator.tenant_id:
+                raise AgentRunNotFoundError(run_id)
+            cancelled = await run_lifecycle.cancel_run(session, run_id, operator=operator)
+            await session.commit()
+            return _row_to_summary(cancelled)
+
     async def list_runs(
         self,
         operator: Operator,

--- a/backend/src/meho_backplane/api/v1/agent_runs.py
+++ b/backend/src/meho_backplane/api/v1/agent_runs.py
@@ -23,6 +23,12 @@ Route inventory
 * ``GET /api/v1/agents/runs/{handle}`` — poll a run's durable status.
   Returns :class:`AgentRunStatusResponse`; 404 for an unknown /
   cross-tenant handle. Role: ``operator``.
+* ``POST /api/v1/agents/runs/{handle}/cancel`` — cancel a non-terminal
+  run. Transitions a ``pending`` / ``running`` / ``awaiting_approval`` run
+  to ``cancelled`` via the shared ``cancel_run`` service path and returns
+  the updated :class:`AgentRunSummaryResponse`. 404 for an unknown /
+  cross-tenant handle; 409 for an already-terminal run. Role:
+  ``operator``.
 * ``GET /api/v1/agents/runs/{handle}/events`` — Server-Sent Events stream
   of a *fresh* run's events. **Note:** the handle path segment names the
   agent definition, not an existing run — an SSE stream drives a new run
@@ -74,6 +80,10 @@ from meho_backplane.auth.operator import Operator, TenantRole
 from meho_backplane.auth.rbac import require_role
 from meho_backplane.db.models import AgentRunStatus
 from meho_backplane.operations._audit import work_ref_var
+from meho_backplane.operations.agent_run import (
+    IllegalTransitionError,
+    UnauthorizedCancellationError,
+)
 
 __all__ = ["router"]
 
@@ -92,6 +102,7 @@ _RUN_OP_IDS: Final[dict[str, str]] = {
     "run": "agent.run",
     "status": "agent.run_status",
     "events": "agent.run_events",
+    "cancel": "agent.cancel_run",
 }
 
 #: Max length of the ``{name}`` path parameter — same defence-in-depth cap
@@ -382,6 +393,54 @@ async def get_run_status(
         output=view.output,
         error=view.error,
     )
+
+
+@router.post("/runs/{handle}/cancel", response_model=AgentRunSummaryResponse)
+async def cancel_run(
+    handle: uuid.UUID,
+    operator: Operator = _require_operator,
+) -> AgentRunSummaryResponse:
+    """Cancel a non-terminal run by handle (the run id).
+
+    Transitions a ``pending`` / ``running`` / ``awaiting_approval`` run to
+    ``cancelled`` through the shared
+    :func:`~meho_backplane.operations.agent_run.cancel_run` service path --
+    the same terminal-transition the reaper writes, so the durable state
+    and the ``agent_run.completed`` lifecycle event are produced by one
+    code path (no second status-write). The async loop is not torn down
+    synchronously: the durable cancel intent is recorded and the loop
+    observes it on its next turn boundary.
+
+    An unknown / cross-tenant handle is 404 (existence is not leaked across
+    tenants, matching the poll route). An already-terminal run -- including
+    one that *raced* to ``succeeded`` / ``failed`` between the operator's
+    request and the write -- is 409, not a 500. A ``read_only`` operator is
+    rejected by the route's role gate; the service's own role check is a
+    defence-in-depth backstop mapped to 403 should it ever fire.
+    """
+    structlog.contextvars.bind_contextvars(
+        audit_op_id=_RUN_OP_IDS["cancel"],
+        audit_op_class="write",
+    )
+    invoker = get_agent_invoker()
+    try:
+        summary = await invoker.cancel(operator, handle)
+    except AgentRunNotFoundError as exc:
+        raise HTTPException(
+            status_code=http_status.HTTP_404_NOT_FOUND,
+            detail="agent_run_not_found",
+        ) from exc
+    except UnauthorizedCancellationError as exc:
+        raise HTTPException(
+            status_code=http_status.HTTP_403_FORBIDDEN,
+            detail="agent_run_cancel_forbidden",
+        ) from exc
+    except IllegalTransitionError as exc:
+        raise HTTPException(
+            status_code=http_status.HTTP_409_CONFLICT,
+            detail="agent_run_not_cancellable",
+        ) from exc
+    return _summary_response(summary)
 
 
 def _format_event(run_id: uuid.UUID, event: AgentRunEvent) -> str:

--- a/backend/tests/test_api_v1_agent_runs.py
+++ b/backend/tests/test_api_v1_agent_runs.py
@@ -46,8 +46,9 @@ from meho_backplane.agent.run import PydanticAgentRun
 from meho_backplane.auth.jwt import clear_jwks_cache
 from meho_backplane.auth.operator import TenantRole
 from meho_backplane.db.engine import get_sessionmaker
-from meho_backplane.db.models import AgentDefinition, Tenant
+from meho_backplane.db.models import AgentDefinition, AgentRunStatus, AgentRunTrigger, Tenant
 from meho_backplane.main import app
+from meho_backplane.operations.agent_run import create_run
 from meho_backplane.settings import get_settings
 
 from ._oidc_jwt_helpers import AUDIENCE as _AUDIENCE
@@ -534,3 +535,124 @@ async def test_rest_sse_returns_429_pre_stream_when_budget_exceeded(
     assert isinstance(body["detail"], dict), body
     assert body["detail"]["error"] == "budget_exceeded"
     assert "global kill switch" in body["detail"]["reason"]
+
+
+# ---------------------------------------------------------------------------
+# #1828 -- operator run-cancel route contract
+# ---------------------------------------------------------------------------
+#
+# POST /api/v1/agents/runs/{handle}/cancel wraps the shared ``cancel_run``
+# service path. The matrix below pins the four boundary shapes: 200 (a
+# non-terminal run lands ``cancelled``), 404 (unknown / cross-tenant
+# handle), 409 (already-terminal run -- including the complete-then-cancel
+# race), and 403 (a ``read_only`` operator rejected by the role gate).
+
+
+async def _seed_run(
+    *,
+    tenant_id: UUID = _TENANT_A,
+    status: AgentRunStatus = AgentRunStatus.RUNNING,
+) -> UUID:
+    """Insert an ``agent_run`` row in *tenant_id* forced to *status*.
+
+    Returns the run id. The status is written directly (not through the
+    transition guard) so the test can position a row at any state -- the
+    cancel route's behaviour is what's under test, not the state machine.
+    """
+    await _seed_tenants()
+    sessionmaker = get_sessionmaker()
+    async with sessionmaker() as session:
+        run = await create_run(
+            session,
+            tenant_id=tenant_id,
+            identity_sub="op-user",
+            trigger=AgentRunTrigger.DIRECT,
+            model_tier="standard",
+        )
+        run.status = status.value
+        await session.flush()
+        run_id = run.id
+        await session.commit()
+    return run_id
+
+
+@pytest.mark.asyncio
+async def test_cancel_run_cancels_non_terminal_run(client: TestClient) -> None:
+    """POST /runs/{handle}/cancel transitions a running run to cancelled (200)."""
+    run_id = await _seed_run(status=AgentRunStatus.RUNNING)
+    _install_invoker()
+    key = make_rsa_keypair("kid-cancel-ok")
+    with respx.mock as r:
+        mock_discovery_and_jwks(r, public_jwks(key))
+        resp = client.post(
+            f"/api/v1/agents/runs/{run_id}/cancel",
+            headers={"Authorization": f"Bearer {_token(key)}"},
+        )
+    assert resp.status_code == 200, resp.text
+    body = resp.json()
+    assert body["run_id"] == str(run_id)
+    assert body["status"] == "cancelled"
+    assert body["ended_at"] is not None
+
+
+@pytest.mark.asyncio
+async def test_cancel_run_unknown_handle_is_404(client: TestClient) -> None:
+    """Cancelling an unknown handle returns 404 agent_run_not_found."""
+    await _seed_tenants()
+    _install_invoker()
+    key = make_rsa_keypair("kid-cancel-404")
+    with respx.mock as r:
+        mock_discovery_and_jwks(r, public_jwks(key))
+        resp = client.post(
+            "/api/v1/agents/runs/00000000-0000-0000-0000-000000000000/cancel",
+            headers={"Authorization": f"Bearer {_token(key)}"},
+        )
+    assert resp.status_code == 404, resp.text
+    assert resp.json()["detail"] == "agent_run_not_found"
+
+
+@pytest.mark.asyncio
+async def test_cancel_run_cross_tenant_handle_is_404(client: TestClient) -> None:
+    """Tenant B cannot cancel tenant A's run (404, no existence leak)."""
+    run_id = await _seed_run(tenant_id=_TENANT_A, status=AgentRunStatus.RUNNING)
+    _install_invoker()
+    key = make_rsa_keypair("kid-cancel-xtenant")
+    with respx.mock as r:
+        mock_discovery_and_jwks(r, public_jwks(key))
+        resp = client.post(
+            f"/api/v1/agents/runs/{run_id}/cancel",
+            headers={"Authorization": f"Bearer {_token(key, sub='op-b', tenant_id=_TENANT_B)}"},
+        )
+    assert resp.status_code == 404, resp.text
+    assert resp.json()["detail"] == "agent_run_not_found"
+
+
+@pytest.mark.asyncio
+async def test_cancel_run_already_terminal_is_409(client: TestClient) -> None:
+    """Cancelling an already-succeeded run returns 409 (race-safe, not 500)."""
+    run_id = await _seed_run(status=AgentRunStatus.SUCCEEDED)
+    _install_invoker()
+    key = make_rsa_keypair("kid-cancel-409")
+    with respx.mock as r:
+        mock_discovery_and_jwks(r, public_jwks(key))
+        resp = client.post(
+            f"/api/v1/agents/runs/{run_id}/cancel",
+            headers={"Authorization": f"Bearer {_token(key)}"},
+        )
+    assert resp.status_code == 409, resp.text
+    assert resp.json()["detail"] == "agent_run_not_cancellable"
+
+
+@pytest.mark.asyncio
+async def test_cancel_run_read_only_rejected(client: TestClient) -> None:
+    """A read_only operator is rejected (403) by the route's role gate."""
+    run_id = await _seed_run(status=AgentRunStatus.RUNNING)
+    _install_invoker()
+    key = make_rsa_keypair("kid-cancel-ro")
+    with respx.mock as r:
+        mock_discovery_and_jwks(r, public_jwks(key))
+        resp = client.post(
+            f"/api/v1/agents/runs/{run_id}/cancel",
+            headers={"Authorization": f"Bearer {_token(key, role=TenantRole.READ_ONLY)}"},
+        )
+    assert resp.status_code == 403, resp.text

--- a/cli/api/openapi.json
+++ b/cli/api/openapi.json
@@ -6027,6 +6027,60 @@
         }
       }
     },
+    "/api/v1/agents/runs/{handle}/cancel": {
+      "post": {
+        "tags": [
+          "agents"
+        ],
+        "summary": "Cancel Run",
+        "description": "Cancel a non-terminal run by handle (the run id).\n\nTransitions a ``pending`` / ``running`` / ``awaiting_approval`` run to\n``cancelled`` through the shared\n:func:`~meho_backplane.operations.agent_run.cancel_run` service path --\nthe same terminal-transition the reaper writes, so the durable state\nand the ``agent_run.completed`` lifecycle event are produced by one\ncode path (no second status-write). The async loop is not torn down\nsynchronously: the durable cancel intent is recorded and the loop\nobserves it on its next turn boundary.\n\nAn unknown / cross-tenant handle is 404 (existence is not leaked across\ntenants, matching the poll route). An already-terminal run -- including\none that *raced* to ``succeeded`` / ``failed`` between the operator's\nrequest and the write -- is 409, not a 500. A ``read_only`` operator is\nrejected by the route's role gate; the service's own role check is a\ndefence-in-depth backstop mapped to 403 should it ever fire.",
+        "operationId": "cancel_run_api_v1_agents_runs__handle__cancel_post",
+        "parameters": [
+          {
+            "name": "handle",
+            "in": "path",
+            "required": true,
+            "schema": {
+              "type": "string",
+              "format": "uuid",
+              "title": "Handle"
+            }
+          },
+          {
+            "name": "authorization",
+            "in": "header",
+            "required": false,
+            "schema": {
+              "type": "string",
+              "nullable": true,
+              "title": "Authorization"
+            }
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "Successful Response",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/AgentRunSummaryResponse"
+                }
+              }
+            }
+          },
+          "422": {
+            "description": "Validation Error",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/HTTPValidationError"
+                }
+              }
+            }
+          }
+        }
+      }
+    },
     "/api/v1/agents/{name}/run/events": {
       "post": {
         "tags": [

--- a/cli/internal/api/client.gen.go
+++ b/cli/internal/api/client.gen.go
@@ -5401,6 +5401,11 @@ type GetRunStatusApiV1AgentsRunsHandleGetParams struct {
 	Authorization *string `json:"authorization,omitempty"`
 }
 
+// CancelRunApiV1AgentsRunsHandleCancelPostParams defines parameters for CancelRunApiV1AgentsRunsHandleCancelPost.
+type CancelRunApiV1AgentsRunsHandleCancelPostParams struct {
+	Authorization *string `json:"authorization,omitempty"`
+}
+
 // DeleteAgentApiV1AgentsNameDeleteParams defines parameters for DeleteAgentApiV1AgentsNameDelete.
 type DeleteAgentApiV1AgentsNameDeleteParams struct {
 	Authorization *string `json:"authorization,omitempty"`
@@ -7268,6 +7273,9 @@ type ClientInterface interface {
 	// GetRunStatusApiV1AgentsRunsHandleGet request
 	GetRunStatusApiV1AgentsRunsHandleGet(ctx context.Context, handle openapi_types.UUID, params *GetRunStatusApiV1AgentsRunsHandleGetParams, reqEditors ...RequestEditorFn) (*http.Response, error)
 
+	// CancelRunApiV1AgentsRunsHandleCancelPost request
+	CancelRunApiV1AgentsRunsHandleCancelPost(ctx context.Context, handle openapi_types.UUID, params *CancelRunApiV1AgentsRunsHandleCancelPostParams, reqEditors ...RequestEditorFn) (*http.Response, error)
+
 	// DeleteAgentApiV1AgentsNameDelete request
 	DeleteAgentApiV1AgentsNameDelete(ctx context.Context, name string, params *DeleteAgentApiV1AgentsNameDeleteParams, reqEditors ...RequestEditorFn) (*http.Response, error)
 
@@ -8107,6 +8115,18 @@ func (c *Client) ListRunsApiV1AgentsRunsGet(ctx context.Context, params *ListRun
 
 func (c *Client) GetRunStatusApiV1AgentsRunsHandleGet(ctx context.Context, handle openapi_types.UUID, params *GetRunStatusApiV1AgentsRunsHandleGetParams, reqEditors ...RequestEditorFn) (*http.Response, error) {
 	req, err := NewGetRunStatusApiV1AgentsRunsHandleGetRequest(c.Server, handle, params)
+	if err != nil {
+		return nil, err
+	}
+	req = req.WithContext(ctx)
+	if err := c.applyEditors(ctx, req, reqEditors); err != nil {
+		return nil, err
+	}
+	return c.Client.Do(req)
+}
+
+func (c *Client) CancelRunApiV1AgentsRunsHandleCancelPost(ctx context.Context, handle openapi_types.UUID, params *CancelRunApiV1AgentsRunsHandleCancelPostParams, reqEditors ...RequestEditorFn) (*http.Response, error) {
+	req, err := NewCancelRunApiV1AgentsRunsHandleCancelPostRequest(c.Server, handle, params)
 	if err != nil {
 		return nil, err
 	}
@@ -11762,6 +11782,55 @@ func NewGetRunStatusApiV1AgentsRunsHandleGetRequest(server string, handle openap
 	}
 
 	req, err := http.NewRequest("GET", queryURL.String(), nil)
+	if err != nil {
+		return nil, err
+	}
+
+	if params != nil {
+
+		if params.Authorization != nil {
+			var headerParam0 string
+
+			headerParam0, err = runtime.StyleParamWithLocation("simple", false, "authorization", runtime.ParamLocationHeader, *params.Authorization)
+			if err != nil {
+				return nil, err
+			}
+
+			req.Header.Set("authorization", headerParam0)
+		}
+
+	}
+
+	return req, nil
+}
+
+// NewCancelRunApiV1AgentsRunsHandleCancelPostRequest generates requests for CancelRunApiV1AgentsRunsHandleCancelPost
+func NewCancelRunApiV1AgentsRunsHandleCancelPostRequest(server string, handle openapi_types.UUID, params *CancelRunApiV1AgentsRunsHandleCancelPostParams) (*http.Request, error) {
+	var err error
+
+	var pathParam0 string
+
+	pathParam0, err = runtime.StyleParamWithLocation("simple", false, "handle", runtime.ParamLocationPath, handle)
+	if err != nil {
+		return nil, err
+	}
+
+	serverURL, err := url.Parse(server)
+	if err != nil {
+		return nil, err
+	}
+
+	operationPath := fmt.Sprintf("/api/v1/agents/runs/%s/cancel", pathParam0)
+	if operationPath[0] == '/' {
+		operationPath = "." + operationPath
+	}
+
+	queryURL, err := serverURL.Parse(operationPath)
+	if err != nil {
+		return nil, err
+	}
+
+	req, err := http.NewRequest("POST", queryURL.String(), nil)
 	if err != nil {
 		return nil, err
 	}
@@ -21838,6 +21907,9 @@ type ClientWithResponsesInterface interface {
 	// GetRunStatusApiV1AgentsRunsHandleGetWithResponse request
 	GetRunStatusApiV1AgentsRunsHandleGetWithResponse(ctx context.Context, handle openapi_types.UUID, params *GetRunStatusApiV1AgentsRunsHandleGetParams, reqEditors ...RequestEditorFn) (*GetRunStatusApiV1AgentsRunsHandleGetResponse, error)
 
+	// CancelRunApiV1AgentsRunsHandleCancelPostWithResponse request
+	CancelRunApiV1AgentsRunsHandleCancelPostWithResponse(ctx context.Context, handle openapi_types.UUID, params *CancelRunApiV1AgentsRunsHandleCancelPostParams, reqEditors ...RequestEditorFn) (*CancelRunApiV1AgentsRunsHandleCancelPostResponse, error)
+
 	// DeleteAgentApiV1AgentsNameDeleteWithResponse request
 	DeleteAgentApiV1AgentsNameDeleteWithResponse(ctx context.Context, name string, params *DeleteAgentApiV1AgentsNameDeleteParams, reqEditors ...RequestEditorFn) (*DeleteAgentApiV1AgentsNameDeleteResponse, error)
 
@@ -22795,6 +22867,29 @@ func (r GetRunStatusApiV1AgentsRunsHandleGetResponse) Status() string {
 
 // StatusCode returns HTTPResponse.StatusCode
 func (r GetRunStatusApiV1AgentsRunsHandleGetResponse) StatusCode() int {
+	if r.HTTPResponse != nil {
+		return r.HTTPResponse.StatusCode
+	}
+	return 0
+}
+
+type CancelRunApiV1AgentsRunsHandleCancelPostResponse struct {
+	Body         []byte
+	HTTPResponse *http.Response
+	JSON200      *AgentRunSummaryResponse
+	JSON422      *HTTPValidationError
+}
+
+// Status returns HTTPResponse.Status
+func (r CancelRunApiV1AgentsRunsHandleCancelPostResponse) Status() string {
+	if r.HTTPResponse != nil {
+		return r.HTTPResponse.Status
+	}
+	return http.StatusText(0)
+}
+
+// StatusCode returns HTTPResponse.StatusCode
+func (r CancelRunApiV1AgentsRunsHandleCancelPostResponse) StatusCode() int {
 	if r.HTTPResponse != nil {
 		return r.HTTPResponse.StatusCode
 	}
@@ -26687,6 +26782,15 @@ func (c *ClientWithResponses) GetRunStatusApiV1AgentsRunsHandleGetWithResponse(c
 	return ParseGetRunStatusApiV1AgentsRunsHandleGetResponse(rsp)
 }
 
+// CancelRunApiV1AgentsRunsHandleCancelPostWithResponse request returning *CancelRunApiV1AgentsRunsHandleCancelPostResponse
+func (c *ClientWithResponses) CancelRunApiV1AgentsRunsHandleCancelPostWithResponse(ctx context.Context, handle openapi_types.UUID, params *CancelRunApiV1AgentsRunsHandleCancelPostParams, reqEditors ...RequestEditorFn) (*CancelRunApiV1AgentsRunsHandleCancelPostResponse, error) {
+	rsp, err := c.CancelRunApiV1AgentsRunsHandleCancelPost(ctx, handle, params, reqEditors...)
+	if err != nil {
+		return nil, err
+	}
+	return ParseCancelRunApiV1AgentsRunsHandleCancelPostResponse(rsp)
+}
+
 // DeleteAgentApiV1AgentsNameDeleteWithResponse request returning *DeleteAgentApiV1AgentsNameDeleteResponse
 func (c *ClientWithResponses) DeleteAgentApiV1AgentsNameDeleteWithResponse(ctx context.Context, name string, params *DeleteAgentApiV1AgentsNameDeleteParams, reqEditors ...RequestEditorFn) (*DeleteAgentApiV1AgentsNameDeleteResponse, error) {
 	rsp, err := c.DeleteAgentApiV1AgentsNameDelete(ctx, name, params, reqEditors...)
@@ -29138,6 +29242,39 @@ func ParseGetRunStatusApiV1AgentsRunsHandleGetResponse(rsp *http.Response) (*Get
 	switch {
 	case strings.Contains(rsp.Header.Get("Content-Type"), "json") && rsp.StatusCode == 200:
 		var dest AgentRunStatusResponse
+		if err := json.Unmarshal(bodyBytes, &dest); err != nil {
+			return nil, err
+		}
+		response.JSON200 = &dest
+
+	case strings.Contains(rsp.Header.Get("Content-Type"), "json") && rsp.StatusCode == 422:
+		var dest HTTPValidationError
+		if err := json.Unmarshal(bodyBytes, &dest); err != nil {
+			return nil, err
+		}
+		response.JSON422 = &dest
+
+	}
+
+	return response, nil
+}
+
+// ParseCancelRunApiV1AgentsRunsHandleCancelPostResponse parses an HTTP response from a CancelRunApiV1AgentsRunsHandleCancelPostWithResponse call
+func ParseCancelRunApiV1AgentsRunsHandleCancelPostResponse(rsp *http.Response) (*CancelRunApiV1AgentsRunsHandleCancelPostResponse, error) {
+	bodyBytes, err := io.ReadAll(rsp.Body)
+	defer func() { _ = rsp.Body.Close() }()
+	if err != nil {
+		return nil, err
+	}
+
+	response := &CancelRunApiV1AgentsRunsHandleCancelPostResponse{
+		Body:         bodyBytes,
+		HTTPResponse: rsp,
+	}
+
+	switch {
+	case strings.Contains(rsp.Header.Get("Content-Type"), "json") && rsp.StatusCode == 200:
+		var dest AgentRunSummaryResponse
 		if err := json.Unmarshal(bodyBytes, &dest); err != nil {
 			return nil, err
 		}

--- a/cli/internal/cmd/agent/agent.go
+++ b/cli/internal/cmd/agent/agent.go
@@ -34,6 +34,13 @@
 //     run's events over SSE from POST /api/v1/agents/{name}/run/events.
 //     Role: operator.
 //
+// #1828 adds one operator-facing run-control verb:
+//
+//   - `meho agent run-cancel <handle> [--json]` — cancel a non-terminal
+//     run via POST /api/v1/agents/runs/{handle}/cancel. The run lands in
+//     cancelled; 404 for an unknown / cross-tenant handle, 409 for an
+//     already-terminal run. Role: operator.
+//
 // Authentication piggybacks on the token meho login wrote — same
 // pattern as `meho kb`, `meho broadcast`, `meho audit`. RBAC at the
 // backend rejects non-tenant_admin write callers with HTTP 403; the
@@ -98,6 +105,9 @@ func NewRootCmd() *cobra.Command {
 	cmd.AddCommand(newRunStatusCmd())
 	cmd.AddCommand(newRunListCmd())
 	cmd.AddCommand(newRunEventsCmd())
+	// #1828: operator run-cancel — stop a non-terminal run via
+	// POST /api/v1/agents/runs/{handle}/cancel.
+	cmd.AddCommand(newRunCancelCmd())
 	// G11.2-T6 (#819): permission grant management sub-tree — grant list /
 	// show / create / elevate / revoke. All verbs require tenant_admin.
 	cmd.AddCommand(NewGrantRootCmd())

--- a/cli/internal/cmd/agent/run_cancel.go
+++ b/cli/internal/cmd/agent/run_cancel.go
@@ -1,0 +1,138 @@
+// SPDX-License-Identifier: Apache-2.0
+// Copyright (c) 2026 evoila Group
+
+package agent
+
+import (
+	"context"
+	"fmt"
+	"io"
+	"net/http"
+
+	"github.com/google/uuid"
+	"github.com/spf13/cobra"
+
+	"github.com/evoila/meho/cli/internal/api"
+	"github.com/evoila/meho/cli/internal/backplane"
+	"github.com/evoila/meho/cli/internal/output"
+)
+
+// newRunCancelCmd returns the `meho agent run-cancel` command.
+//
+//	meho agent run-cancel <handle> [--json] [--backplane <url>]
+//
+// Role: operator. Cancels a non-terminal run via
+// POST /api/v1/agents/runs/{handle}/cancel. The run transitions to
+// cancelled and the updated summary is rendered. A 404 means no such run
+// in your tenant; a 409 means the run already reached a terminal state
+// (succeeded / failed / cancelled) and cannot be cancelled.
+func newRunCancelCmd() *cobra.Command {
+	var (
+		jsonOut           bool
+		backplaneOverride string
+	)
+	cmd := &cobra.Command{
+		Use:   "run-cancel <handle>",
+		Short: "Cancel a non-terminal agent run by handle",
+		Long: "run-cancel calls POST /api/v1/agents/runs/{handle}/cancel and " +
+			"stops a pending / running / awaiting_approval run: the run " +
+			"transitions to cancelled and the updated summary is rendered. " +
+			"The handle is the run id printed by `meho agent run`. A 404 " +
+			"means no such run in your tenant; a 409 means the run already " +
+			"reached a terminal state (succeeded / failed / cancelled) and " +
+			"cannot be cancelled. --json emits the raw " +
+			"AgentRunSummaryResponse for scripting.",
+		Args:          cobra.ExactArgs(1),
+		SilenceUsage:  true,
+		SilenceErrors: true,
+		RunE: func(cmd *cobra.Command, args []string) error {
+			return runRunCancel(cmd, runCancelOptions{
+				Handle:            args[0],
+				JSONOut:           jsonOut,
+				BackplaneOverride: backplaneOverride,
+			})
+		},
+	}
+	cmd.Flags().BoolVar(&jsonOut, "json", false,
+		"emit the raw AgentRunSummaryResponse JSON instead of the human summary")
+	cmd.Flags().StringVar(&backplaneOverride, "backplane", "",
+		"backplane URL to query (defaults to the URL recorded by the most recent `meho login`)")
+	return cmd
+}
+
+type runCancelOptions struct {
+	Handle            string
+	JSONOut           bool
+	BackplaneOverride string
+}
+
+func runRunCancel(cmd *cobra.Command, opts runCancelOptions) error {
+	if opts.Handle == "" {
+		return output.RenderError(cmd.ErrOrStderr(),
+			output.Unexpected("run-cancel requires a non-empty <handle> argument"), opts.JSONOut)
+	}
+	// The generated client takes the handle as a uuid.UUID (the OpenAPI
+	// spec marks the path param as format=uuid), so parse the operator's
+	// string argument once at the verb edge and surface a clean
+	// CLI-side error before the request is built.
+	handle, err := uuid.Parse(opts.Handle)
+	if err != nil {
+		return output.RenderError(cmd.ErrOrStderr(),
+			output.Unexpected(fmt.Sprintf("invalid <handle>: %v", err)), opts.JSONOut)
+	}
+	backplaneURL, err := backplane.Resolve(opts.BackplaneOverride)
+	if err != nil {
+		return output.RenderError(cmd.ErrOrStderr(), backplane.ClassifyError(err), opts.JSONOut)
+	}
+	resp, err := cancelRun(cmd.Context(), backplaneURL, handle)
+	if err != nil {
+		return renderRequestError(cmd, backplaneURL, err, opts.JSONOut)
+	}
+	if resp.StatusCode() != http.StatusOK {
+		return renderHTTPStatus(cmd, backplaneURL, resp.StatusCode(), resp.Body, opts.JSONOut)
+	}
+	if opts.JSONOut {
+		return output.PrintJSON(cmd.OutOrStdout(), resp.JSON200)
+	}
+	printRunSummary(cmd.OutOrStdout(), resp.JSON200)
+	return nil
+}
+
+func cancelRun(ctx context.Context, backplaneURL string, handle uuid.UUID) (*api.CancelRunApiV1AgentsRunsHandleCancelPostResponse, error) {
+	authed, err := newAuthedClient(ctx, backplaneURL)
+	if err != nil {
+		return nil, err
+	}
+	return retryOn401(ctx, authed,
+		func(ctx context.Context) (*api.CancelRunApiV1AgentsRunsHandleCancelPostResponse, error) {
+			return authed.CancelRunApiV1AgentsRunsHandleCancelPostWithResponse(ctx, handle, nil)
+		},
+		func(r *api.CancelRunApiV1AgentsRunsHandleCancelPostResponse) int { return r.StatusCode() },
+	)
+}
+
+// printRunSummary renders an AgentRunSummaryResponse as a key-value
+// summary — the shape the cancel route returns for the updated run.
+func printRunSummary(w io.Writer, s *api.AgentRunSummaryResponse) {
+	if s == nil {
+		return
+	}
+	fmt.Fprintf(w, "%-16s %s\n", "run_id:", s.RunId.String())
+	fmt.Fprintf(w, "%-16s %s\n", "status:", string(s.Status))
+	fmt.Fprintf(w, "%-16s %s\n", "trigger:", s.Trigger)
+	fmt.Fprintf(w, "%-16s %s\n", "model_tier:", s.ModelTier)
+	fmt.Fprintf(w, "%-16s %d\n", "turns:", s.Turns)
+	if s.Provider != nil {
+		fmt.Fprintf(w, "%-16s %s\n", "provider:", *s.Provider)
+	}
+	if s.Model != nil {
+		fmt.Fprintf(w, "%-16s %s\n", "model:", *s.Model)
+	}
+	if s.WorkRef != nil && *s.WorkRef != "" {
+		fmt.Fprintf(w, "%-16s %s\n", "work_ref:", *s.WorkRef)
+	}
+	fmt.Fprintf(w, "%-16s %s\n", "created_at:", s.CreatedAt.UTC().Format("2006-01-02T15:04:05Z"))
+	if s.EndedAt != nil {
+		fmt.Fprintf(w, "%-16s %s\n", "ended_at:", s.EndedAt.UTC().Format("2006-01-02T15:04:05Z"))
+	}
+}

--- a/cli/internal/cmd/agent/run_test.go
+++ b/cli/internal/cmd/agent/run_test.go
@@ -170,6 +170,99 @@ func TestRunStatusNotFoundRendersError(t *testing.T) {
 	}
 }
 
+// --- run-cancel ---
+
+func TestRunCancelRejectsInvalidUUID(t *testing.T) {
+	cmd, _, stderr := newTestCmd(t)
+	err := runRunCancel(cmd, runCancelOptions{Handle: "abc", BackplaneOverride: "http://x"})
+	if err == nil {
+		t.Fatalf("expected error for non-UUID handle")
+	}
+	if !strings.Contains(stderr.String(), "invalid <handle>") {
+		t.Errorf("stderr missing parse-error hint; got %q", stderr.String())
+	}
+}
+
+func TestRunCancelHappyPath(t *testing.T) {
+	handle := "11111111-1111-1111-1111-111111111111"
+	provider := "anthropic"
+	model := "claude-sonnet-4-6"
+	mux := http.NewServeMux()
+	mux.HandleFunc("/api/v1/agents/runs/"+handle+"/cancel", func(w http.ResponseWriter, r *http.Request) {
+		if r.Method != http.MethodPost {
+			t.Errorf("expected POST, got %s", r.Method)
+		}
+		if r.Header.Get("Authorization") == "" {
+			t.Errorf("missing Authorization header")
+		}
+		w.Header().Set("Content-Type", "application/json")
+		_ = json.NewEncoder(w).Encode(api.AgentRunSummaryResponse{
+			RunId:     uuid.MustParse(handle),
+			Status:    api.AgentRunStatusCancelled,
+			Trigger:   "direct",
+			ModelTier: "standard",
+			Provider:  &provider,
+			Model:     &model,
+			Turns:     1,
+		})
+	})
+	srv := httptest.NewServer(mux)
+	defer srv.Close()
+	seedXDGAndToken(t, srv.URL)
+
+	cmd, stdout, stderr := newTestCmd(t)
+	if err := runRunCancel(cmd, runCancelOptions{Handle: handle, BackplaneOverride: srv.URL}); err != nil {
+		t.Fatalf("runRunCancel: %v; stderr=%s", err, stderr.String())
+	}
+	for _, want := range []string{"cancelled", handle, "anthropic"} {
+		if !strings.Contains(stdout.String(), want) {
+			t.Errorf("stdout missing %q in %q", want, stdout.String())
+		}
+	}
+}
+
+func TestRunCancelNotFoundRendersError(t *testing.T) {
+	handle := "33333333-3333-3333-3333-333333333333"
+	mux := http.NewServeMux()
+	mux.HandleFunc("/api/v1/agents/runs/"+handle+"/cancel", func(w http.ResponseWriter, _ *http.Request) {
+		w.WriteHeader(http.StatusNotFound)
+		_ = json.NewEncoder(w).Encode(map[string]any{"detail": "agent_run_not_found"})
+	})
+	srv := httptest.NewServer(mux)
+	defer srv.Close()
+	seedXDGAndToken(t, srv.URL)
+
+	cmd, _, stderr := newTestCmd(t)
+	err := runRunCancel(cmd, runCancelOptions{Handle: handle, BackplaneOverride: srv.URL})
+	if err == nil {
+		t.Fatalf("expected error on 404")
+	}
+	if !strings.Contains(stderr.String(), "agent_run_not_found") {
+		t.Errorf("error should carry the detail; got %q", stderr.String())
+	}
+}
+
+func TestRunCancelAlreadyTerminalRendersError(t *testing.T) {
+	handle := "44444444-4444-4444-4444-444444444444"
+	mux := http.NewServeMux()
+	mux.HandleFunc("/api/v1/agents/runs/"+handle+"/cancel", func(w http.ResponseWriter, _ *http.Request) {
+		w.WriteHeader(http.StatusConflict)
+		_ = json.NewEncoder(w).Encode(map[string]any{"detail": "agent_run_not_cancellable"})
+	})
+	srv := httptest.NewServer(mux)
+	defer srv.Close()
+	seedXDGAndToken(t, srv.URL)
+
+	cmd, _, stderr := newTestCmd(t)
+	err := runRunCancel(cmd, runCancelOptions{Handle: handle, BackplaneOverride: srv.URL})
+	if err == nil {
+		t.Fatalf("expected error on 409")
+	}
+	if !strings.Contains(stderr.String(), "agent_run_not_cancellable") {
+		t.Errorf("error should carry the 409 detail; got %q", stderr.String())
+	}
+}
+
 // --- run-events (SSE) ---
 
 func TestRunEventsStreamsFrames(t *testing.T) {

--- a/docs/codebase/agent-run.md
+++ b/docs/codebase/agent-run.md
@@ -55,7 +55,11 @@ T4 (#825) extends both with the in-flight-reclaim contract:
 What is **not** in T6 or T4 (other tasks own these):
 
 - The invocation surface (sync + async handle/poll/SSE on REST + MCP +
-  CLI) — G11.1-T4 (#811). T4 calls this service.
+  CLI) — G11.1-T4 (#811). T4 calls this service. The operator-facing
+  cancel entry point (`POST /api/v1/agents/runs/{handle}/cancel` +
+  `meho agent run-cancel`, #1828) also calls `cancel_run` here — it adds
+  the tenant-scoping check (cross-tenant handle -> 404) on top of the
+  service's role + state-machine checks.
 - The Pydantic-AI loop seam that actually runs the agent — G11.1-T1
   (#808). The agent loop must call `heartbeat()` at ≈ `ttl_seconds/2`
   cadence so the reaper does not reclaim a healthy run; the loop must

--- a/docs/codebase/agent-runtime.md
+++ b/docs/codebase/agent-runtime.md
@@ -205,18 +205,24 @@ not a raised exception, so an SSE consumer always sees a terminal frame.
 
 - **REST** (`api/v1/agent_runs.py`): `POST /api/v1/agents/{name}/run`
   (200 with the result for a terminal sync run; 202 with a handle for async
-  / converted-to-async), `GET /api/v1/agents/runs/{handle}` (poll), and
+  / converted-to-async), `GET /api/v1/agents/runs/{handle}` (poll),
+  `POST /api/v1/agents/runs/{handle}/cancel` (cancel — #1828: transitions a
+  non-terminal run to `cancelled` via the shared `cancel_run` service path,
+  returns the updated `AgentRunSummaryResponse`; 404 for an unknown /
+  cross-tenant handle, 409 for an already-terminal run), and
   `POST /api/v1/agents/{name}/run/events` (SSE — `text/event-stream`, the
-  G6 broadcast-feed transport shape). The poll/events sub-paths are two
-  segments deep so they never collide with the one-segment `/{name}`
-  definition-CRUD routes.
+  G6 broadcast-feed transport shape). The poll/cancel/events sub-paths are
+  two-or-more segments deep so they never collide with the one-segment
+  `/{name}` definition-CRUD routes.
 - **MCP** (`mcp/tools/agent_runs.py`): `meho.agents.run` (sync/async via an
   `async` arg) + `meho.agents.run_status` (poll). SSE is REST-only; an MCP
-  caller polls. Both drive the same `AgentInvoker` singleton, so a run
-  started over MCP is poll-able over REST and vice versa.
+  caller polls. Cancel is REST/CLI-only (no MCP verb). Both drive the same
+  `AgentInvoker` singleton, so a run started over MCP is poll-able over REST
+  and vice versa.
 - **CLI** (`cli/internal/cmd/agent/run.go`, `run_status.go`,
-  `run_events.go`): `meho agent run <name> --input … [--async]`,
-  `meho agent run-status <handle>`, `meho agent run-events <name> --input …`.
+  `run_cancel.go`, `run_events.go`): `meho agent run <name> --input …
+  [--async]`, `meho agent run-status <handle>`, `meho agent run-cancel
+  <handle>` (#1828), `meho agent run-events <name> --input …`.
 
 All fronts require the `operator` role and are tenant-scoped via the JWT.
 


### PR DESCRIPTION
## Summary
- Add an **operator agent run-cancel** entry point: `POST /api/v1/agents/runs/{handle}/cancel` (REST) and `meho agent run-cancel <handle>` (CLI). Operators previously had no way to stop a running agent run — only the internal reaper/scheduler could write the `cancelled` terminal state.
- Both fronts wrap the existing operator-authorized `cancel_run` service path (`operations/agent_run.py`); the new `AgentInvoker.cancel` adds only the tenant-scoping check on top of `cancel_run`'s role + state-machine guards. No second status-write — the `agent_run.completed` lifecycle outbox event is emitted by the shared `transition` for every terminal state (cancellation included), so cancel gets it for free.
- Tenant-scoped + race-safe: unknown / cross-tenant handle → `404` (no existence leak); a run that completes between the request and the write → `409 agent_run_not_cancellable`, not a 500. An `awaiting_approval` run cancels cleanly; its pending approval is left to expire / be rejected on resume.
- This is the backend enabler for the run-console Stop button (T9).

## Test plan
- [x] `ruff check` / `ruff format --check` — clean (whole `src/` + touched tests)
- [x] `mypy src/meho_backplane/` — clean (480 files)
- [x] `pytest tests/test_api_v1_agent_runs.py` — 19 passed (5 new: 200 / 404-unknown / 404-cross-tenant / 409-terminal / 403-read_only)
- [x] `pytest` agent-run + lifecycle + invocation + outbox + mcp + reaper suites — 137 passed
- [x] `go test ./...` (CLI) — all packages green; 4 new `run-cancel` verb tests (invalid-UUID / 200 / 404 / 409)
- [x] `cd cli && make snapshot-openapi && make generate` — OpenAPI snapshot + generated Go client regenerated in lock-step (this Task touches `api/v1`)
- [x] `.claude/hooks/code-quality.py --diff` — 0 blockers (warnings are pre-existing legacy debt on touched files)
- [x] docs: `docs/codebase/agent-run.md` + `agent-runtime.md` updated; CHANGELOG `### Added` entry

## Out of scope
- The UI Stop-run button is T9 (depends on this).
- No MCP `cancel` verb (run/run_status have MCP tools; cancel is REST/CLI-only per the issue scope) — recorded as an adjacent finding.

## Adjacent findings (out of scope)
- `agent/invocation.py` carries pre-existing function-size / PLR0913 warnings (`run`, `run_scheduled`, `_launch_scheduled_run`, `stream_events`) and `api/v1/agent_runs.py` is 534 lines (warn >400). Not agent-introduced; left as-is.

<!-- auto-implement-issue: fresh, iteration 1 -->

Closes #1828
