### PR TITLE
fix(ui): single-quote runbook editor x-data to close attribute-breakout XSS (#100)

### DIFF
--- a/backend/src/meho_backplane/ui/routes/runbooks/editor.py
+++ b/backend/src/meho_backplane/ui/routes/runbooks/editor.py
@@ -438,9 +438,13 @@ def build_editor_context(
 ) -> dict[str, object]:
     """Assemble the Jinja context the ``runbooks/editor.html`` template needs.
 
-    ``form_steps`` is JSON-serialised into ``initial_steps_json`` so the
+    ``form_steps`` is passed through as a raw list and the template renders
+    it with ``| tojson`` inside a single-quoted ``x-data`` attribute, so the
     Alpine model can hydrate from the server-rendered prefill (an edit
-    pre-loads the existing steps; a fresh ``new`` seeds one blank step). The
+    pre-loads the existing steps; a fresh ``new`` seeds one blank step)
+    without any field value being able to break out of the attribute. The
+    list is not pre-serialised here: ``json.dumps`` leaves ``"`` raw, which
+    would have terminated the old double-quoted ``| safe`` attribute. The
     post target + submit verb differ by ``mode`` so a single template serves
     both the draft-create and edit-in-place flows.
     """
@@ -450,7 +454,7 @@ def build_editor_context(
         "title": title,
         "description": description,
         "target_kind": target_kind,
-        "initial_steps_json": json.dumps(form_steps),
+        "form_steps": form_steps,
         "submit_url": "/ui/runbooks/new" if mode == "new" else f"/ui/runbooks/{slug}/edit",
         "submit_label": "Create draft" if mode == "new" else "Save changes",
         "error_message": error_message,

--- a/backend/src/meho_backplane/ui/templates/runbooks/editor.html
+++ b/backend/src/meho_backplane/ui/templates/runbooks/editor.html
@@ -14,8 +14,8 @@
   Alpine model:
     * Top-level fields: slug (new only), title, description, target_kind.
     * steps[]: the discriminated-union step tree, hydrated from
-      ``initial_steps_json`` (one blank step on a fresh new; the existing
-      steps on an edit). Add / remove / reorder mutate this array.
+      ``form_steps`` via ``| tojson`` (one blank step on a fresh new; the
+      existing steps on an edit). Add / remove / reorder mutate this array.
     * On submit, the whole step tree is JSON-serialised into the hidden
       ``steps`` form field so the union shape survives the round-trip; the
       params/expect JSON textareas are passed through as raw strings and
@@ -33,7 +33,8 @@
     mode              -- "new" | "edit"
     slug              -- str (locked on edit; the model's slug on new)
     title/description/target_kind -- str: prefilled top-level fields
-    initial_steps_json -- str: JSON array hydrating the Alpine ``steps`` model
+    form_steps        -- list[dict]: the step tree hydrating the Alpine
+                         ``steps`` model (rendered with ``| tojson``)
     submit_url        -- str: POST target (/ui/runbooks/new | .../{slug}/edit)
     submit_label      -- str: button label
     error_message     -- str | None: inline error banner copy
@@ -46,16 +47,35 @@
 {% block page_title %}{{ page_title }} &middot; MEHO Operator Console{% endblock %}
 
 {% block content %}
+{#-
+  XSS hardening (review precedent: PR #1044 single-quoted x-data)
+  --------------------------------------------------------------
+  Every value below is operator-authored text with no character
+  allowlist (the only schema validator is the ``${...}`` substitution
+  check). The ``x-data`` attribute uses SINGLE-quoted delimiters so the
+  ``| tojson`` output cannot break out: ``tojson`` escapes ``'`` to
+  ``'`` (never emitting a raw single quote) and escapes ``<`` /
+  ``>`` / ``&`` to their ``\uXXXX`` forms, so the host element's
+  attribute closes only on the author's own ``'`` and the entire
+  payload -- double quotes included -- stays inert inside the value.
+  ``initialSteps`` is the step tree rendered with ``| tojson`` over the
+  raw ``form_steps`` list, NOT the ``safe``-marked pre-serialised string
+  the old template used: the ``safe`` filter disables autoescape and
+  ``json.dumps`` leaves ``"`` raw, so a field containing ``"`` would
+  terminate a double-quoted attribute.
+  Mirrors the convention in ``broadcast/_feed.html``,
+  ``broadcast/_filter_bar.html``, and ``connectors/_recent_ops.html``.
+-#}
 <section
   class="space-y-4"
-  x-data="runbookEditor({
-    mode: '{{ mode }}',
-    initialSteps: {{ initial_steps_json | safe }},
+  x-data='runbookEditor({
+    mode: {{ mode | tojson }},
+    initialSteps: {{ form_steps | tojson }},
     slug: {{ slug | tojson }},
     title: {{ title | tojson }},
     description: {{ description | tojson }},
     targetKind: {{ target_kind | tojson }}
-  })"
+  })'
 >
   {# ---------- Header ---------- #}
   <header class="flex flex-wrap items-center justify-between gap-4">

--- a/backend/tests/test_ui_runbooks_editor.py
+++ b/backend/tests/test_ui_runbooks_editor.py
@@ -99,6 +99,10 @@ from tests._oidc_jwt_helpers import (
 from tests._oidc_jwt_helpers import (
     public_jwks as _public_jwks,
 )
+from tests.test_ui_broadcast_filters import (
+    _XSS_OP_ID,
+    _assert_no_xss_breakout,
+)
 
 # ---------------------------------------------------------------------------
 # Constants
@@ -806,3 +810,119 @@ def test_editor_preview_operator_forbidden() -> None:
 
     assert response.status_code == 403, response.text
     assert "<strong>" not in response.text
+
+
+# ---------------------------------------------------------------------------
+# XSS hardening — attribute-breakout via runbook fields (Task #100)
+# ---------------------------------------------------------------------------
+#
+# The editor binds operator-authored runbook fields into an Alpine
+# ``x-data`` attribute. PR #1044 established the safe convention
+# (single-quoted ``x-data`` + ``| tojson``) and the runbook editor was the
+# lone data-bearing island that never received it: it interpolated
+# ``initial_steps_json | safe`` and ``| tojson`` scalars inside a
+# *double-quoted* attribute, so a ``"`` in any field terminated the
+# attribute and grafted attacker markup onto the host element (stored XSS on
+# the edit page, reflected XSS on the create / 422 re-render path).
+#
+# Both tests reuse the parser-grounded harness from
+# :mod:`backend.tests.test_ui_broadcast_filters` (``_XSS_OP_ID`` +
+# ``_assert_no_xss_breakout``): they feed the rendered HTML through a stdlib
+# ``HTMLParser`` and assert no ``onfocus`` / ``autofocus`` / ``onerror``
+# leaks as a parsed attribute and that the marker stays inside an ``x-data``
+# value. They FAIL against the pre-fix double-quoted ``| safe`` template and
+# PASS after the single-quote + ``| tojson`` fix.
+
+
+def _xss_payload_body() -> RunbookTemplateBody:
+    """A valid one-step body whose step + template titles carry the payload.
+
+    ``_XSS_OP_ID`` contains every HTML metacharacter the hardening must
+    neutralise but no ``${...}`` substitution, so it passes the template's
+    only field-level validator (the substitution allowlist) and is stored
+    verbatim -- exactly the stored-XSS precondition the fix must defang on
+    re-render.
+    """
+    return RunbookTemplateBody(
+        title=_XSS_OP_ID,
+        description="Stored payload regression.",
+        target_kind="k8s-node",
+        steps=[
+            ManualStep(
+                id="drain",
+                title=_XSS_OP_ID,
+                body="Run the drain command.",
+                type="manual",
+                verify=ConfirmVerify(type="confirm", prompt="Node drained?"),
+            ),
+        ],
+    )
+
+
+def test_editor_edit_stored_xss_payload_cannot_break_out_of_x_data() -> None:
+    """A stored runbook field with a breakout payload stays inert on the edit page.
+
+    Regression for the stored-XSS finding (Task #100). The seeded template's
+    ``title`` and step ``title`` carry ``_XSS_OP_ID``; ``GET .../edit``
+    re-renders them into the Alpine ``x-data`` config. Fails on the pre-fix
+    double-quoted ``| safe`` template (the ``"`` bytes terminate the
+    attribute and the parser surfaces ``onfocus`` / ``autofocus`` /
+    ``onerror`` as live attributes); passes once single-quoted + ``| tojson``.
+    """
+    _seed_tenant(_TENANT_A, "tenant-a")
+    _seed_template(tenant_id=_TENANT_A, slug="xss-runbook", body=_xss_payload_body())
+    session_id, jwks = _admin_session()
+
+    mock = respx.mock(assert_all_called=False)
+    mock.start()
+    try:
+        _mock_discovery_and_jwks(mock, jwks)
+        client = _authenticated_client(session_id)
+        response = client.get("/ui/runbooks/xss-runbook/edit")
+    finally:
+        mock.stop()
+
+    assert response.status_code == 200, response.text
+    _assert_no_xss_breakout(response.text)
+
+
+def test_editor_new_reflected_xss_payload_cannot_break_out_of_x_data() -> None:
+    """A reflected breakout payload in ``title`` stays inert on the 422 re-render.
+
+    Regression for the reflected-XSS finding (Task #100). The POST carries
+    ``_XSS_OP_ID`` in ``title`` plus a structurally invalid step id, so the
+    server rejects the body (422) and re-renders the editor with the entered
+    ``title`` reflected into the Alpine ``x-data`` config. Same parser-
+    grounded breakout check as the stored path.
+    """
+    _seed_tenant(_TENANT_A, "tenant-a")
+    session_id, jwks = _admin_session()
+
+    # A dotted step id is illegal -> server 422 re-render, preserving title.
+    bad_steps = (
+        '[{"id":"bad.id","title":"Prep","body":"x","type":"manual",'
+        '"op_id":"","params":"{}",'
+        '"verify":{"type":"confirm","prompt":"ok?","op_id":"","params":"{}","expect":"{}"}}]'
+    )
+    mock = respx.mock(assert_all_called=False)
+    mock.start()
+    try:
+        _mock_discovery_and_jwks(mock, jwks)
+        client = _authenticated_client(session_id)
+        csrf = _csrf_token(session_id)
+        response = client.post(
+            "/ui/runbooks/new",
+            data={
+                "slug": "reflected-xss",
+                "title": _XSS_OP_ID,
+                "description": "Reflected payload regression.",
+                "target_kind": "",
+                "steps": bad_steps,
+            },
+            **_csrf_kwargs(csrf),
+        )
+    finally:
+        mock.stop()
+
+    assert response.status_code == 422, response.text
+    _assert_no_xss_breakout(response.text)

--- a/docs/codebase/ui.md
+++ b/docs/codebase/ui.md
@@ -1026,6 +1026,28 @@ sibling `value="{{ op_id_filter }}"` is in an autoescaped attribute
 and parse the response to assert no handler grafts onto an `x-data`
 element.
 
+**The runbook editor island (G2.x #100, Goal #87 security review).** The
+runbook authoring editor (`runbooks/editor.html`) was the lone
+data-bearing `x-data` that never received the PR #1044 hardening: it
+interpolated `initialSteps: {{ initial_steps_json | safe }}` (the `safe`
+filter disables autoescape entirely, and the upstream `json.dumps` leaves
+`"` raw) plus `| tojson` scalars (`slug` / `title` / `description` /
+`target_kind`) inside a **double-quoted** `x-data="…"`. Any runbook field
+(`OperationCallStep`/`ManualStep` `title`/`body`, `RunbookTemplateBody`
+`title`/`description`) containing a `"` broke out — a stored XSS on
+`GET /ui/runbooks/{slug}/edit` and a reflected XSS on the
+`POST /ui/runbooks/new` 422 re-render, both in an authenticated
+`tenant_admin`'s session. The fix is the canonical one: single-quote the
+attribute (`x-data='runbookEditor({…})'`) and render the step tree with
+`{{ form_steps | tojson }}` over the raw list (`build_editor_context` no
+longer `json.dumps`-es it), so every field — `"` bytes included — stays
+inert inside the value. This was the last `| safe` in an HTML-attribute
+context under `ui/templates/`; the single-quoted `x-data` + `| tojson`
+pair is now the canonical UI output-encoding rule for any template
+binding untrusted data into Alpine. Regression coverage lives in
+`test_ui_runbooks_editor.py` (stored + reflected paths), reusing the
+`_assert_no_xss_breakout` parser harness from `test_ui_broadcast_filters.py`.
+
 ### Cross-tenant isolation
 
 The page carries no tenant data beyond the operator's own identity; live


### PR DESCRIPTION
## Summary

- The runbook authoring editor bound operator-authored fields into a **double-quoted** Alpine `x-data="..."` attribute — the step tree via `| safe` (autoescape disabled) and the scalars via `| tojson` (which does not escape `"`). A field containing a `"` terminated the attribute and grafted attacker markup onto the host element (attribute-breakout XSS on the edit page and the create / 422 re-render path).
- This was the lone data-bearing `x-data` island that never received the PR #1044 hardening already applied to the broadcast feed, filter bar, and recent-ops surfaces.
- Fix applies the established convention: single-quote the attribute (`x-data='runbookEditor({...})'`) and render the step tree with `{{ form_steps | tojson }}` over the raw list — `build_editor_context` no longer pre-serialises it with `json.dumps`. `| tojson` escapes `'` to `&#39;` (never a raw single quote) plus `<`/`>`/`&`, so a single-quoted attribute is breakout-proof while the `"` bytes stay inert inside the value. This removes the last `| safe` in an HTML-attribute context under `ui/templates/`.

## Test plan

- [x] `ruff check` (edited Python files) — clean
- [x] `ruff format --check` — clean
- [x] `mypy src/.../runbooks/editor.py` — clean
- [x] `pytest tests/test_ui_runbooks_editor.py tests/test_ui_runbooks_lifecycle.py tests/test_ui_runbooks_acceptance.py -q` — 35 passed
- [x] New regression tests (stored GET-edit + reflected POST-new-422 paths) reuse the parser-grounded `_assert_no_xss_breakout` harness; verified they **fail** against the pre-fix double-quoted `| safe` template and **pass** after the fix.
- [x] `pytest tests/test_ui_broadcast_filters.py -q` (harness source) — 22 passed
- [x] No FastAPI route/schema signature change (context-dict key rename only) → no OpenAPI snapshot regen needed.

## Out of scope

- No change to the runbook field schemas (no character allowlist) — output-context escaping is the correct fix; a schema allowlist is a separate defence-in-depth item.
- CSP `frame-ancestors` / `X-Frame-Options` and the `<script type="application/json">` data-island refactor are tracked separately.

<!-- auto-implement-issue: fresh, iteration 1 -->

Refs evoila-bosnia/meho-internal#100
