### PR TITLE
feat(ui): add /ui/agents/runs cross-agent run list + detail with work_ref/status filters

### DIFF
--- a/backend/src/meho_backplane/ui/routes/__init__.py
+++ b/backend/src/meho_backplane/ui/routes/__init__.py
@@ -27,6 +27,14 @@ ships the umbrella :func:`build_router` that aggregates:
   write routes delegate to ``AgentDefinitionService`` in-process so the
   UI and REST surfaces share one validation + identity-ref-check +
   persist code path.
+* :mod:`~meho_backplane.ui.routes.agents.runs` -- the agent-runs read
+  surface (G10.8-T3 #1830): ``GET /ui/agents/runs`` cross-agent run list
+  (``status`` + ``work_ref`` filters, full-page / HTMX-fragment) and
+  ``GET /ui/agents/runs/{handle}`` per-run detail (poll-after-the-fact
+  while non-terminal, static once terminal). Operator-readable; reuses the
+  in-process ``AgentInvoker`` ``list_runs`` / ``poll`` read path. Its
+  router is included **before** ``build_agents_router`` so the literal
+  ``/ui/agents/runs`` segment is not bound as ``/ui/agents/{name}``.
 * :mod:`~meho_backplane.ui.routes.kb` -- ``GET /ui/kb``,
   ``POST /ui/kb/search``, ``GET /ui/kb/<slug>``,
   ``GET /ui/kb/<slug>/preview`` -- KB read surface (G10.2-T1 #870).
@@ -71,6 +79,7 @@ from __future__ import annotations
 from fastapi import APIRouter
 
 from meho_backplane.ui.routes.agents import build_agents_router
+from meho_backplane.ui.routes.agents.runs import build_runs_router
 from meho_backplane.ui.routes.approvals import build_approvals_router
 from meho_backplane.ui.routes.broadcast import build_router as build_broadcast_router
 from meho_backplane.ui.routes.connectors import build_router as build_connectors_router
@@ -94,6 +103,7 @@ __all__ = [
     "build_memory_router",
     "build_router",
     "build_runbooks_router",
+    "build_runs_router",
     "build_scheduler_router",
     "build_stubs_router",
     "build_topology_router",
@@ -130,6 +140,12 @@ def build_router() -> APIRouter:
     router.include_router(build_topology_router())
     router.include_router(build_memory_router())
     router.include_router(build_connectors_router())
+    # Agent-runs read surface (G10.8-T3 #1830) before the agents-definition
+    # router: ``/ui/agents/runs`` + ``/ui/agents/runs/{handle}`` are literal-
+    # prefixed under ``/ui/agents`` and MUST win the first-match-wins lookup
+    # against the definition surface's ``/ui/agents/{name}`` (which would
+    # otherwise bind ``"runs"`` as a definition name).
+    router.include_router(build_runs_router())
     router.include_router(build_agents_router())
     router.include_router(build_kb_router())
     router.include_router(build_corpus_router())

--- a/backend/src/meho_backplane/ui/routes/agents/runs/__init__.py
+++ b/backend/src/meho_backplane/ui/routes/agents/runs/__init__.py
@@ -1,0 +1,84 @@
+# SPDX-License-Identifier: Apache-2.0
+# Copyright (c) 2026 evoila Group
+
+"""Agent-runs UI routes: cross-agent run list + per-run detail/poll.
+
+Initiative #1824 (G10.8 Agents console), Task #1830 (T3). This surface is
+the console face of the agent run-history read path
+(``api/v1/agent_runs.py`` -- ``GET /api/v1/agents/runs`` +
+``GET /api/v1/agents/runs/{handle}``): an operator could only see run
+history / poll a run's durable status from the CLI / REST, never the
+console. This task adds the read-only ``/ui/agents/runs`` list + detail on
+the established HTMX/Jinja chassis, hung off the ``/ui/agents`` scaffold
+(#1825).
+
+Module layout
+-------------
+
+* :mod:`~meho_backplane.ui.routes.agents.runs.list_view` -- ``GET
+  /ui/agents/runs``. One handler serves the full page (browser nav) and the
+  table-rows fragment (HTMX filter swap). Filters: ``status`` (closed enum)
+  + ``work_ref`` (exact match). Operator-readable.
+* :mod:`~meho_backplane.ui.routes.agents.runs.detail` -- ``GET
+  /ui/agents/runs/{handle}``. The full run state; the status panel polls
+  while the run is non-terminal and renders statically once terminal.
+  Operator-readable.
+* :mod:`~meho_backplane.ui.routes.agents.runs.views` -- row-to-view
+  projection + status-badge + UTC coercion shared by both handlers.
+* :mod:`~meho_backplane.ui.routes.agents.runs.operator` -- the read-path
+  operator lift (synthesised tenant-scoped ``OPERATOR`` for the invoker
+  call) + the re-exported role probe.
+
+Why a session BFF and not the Bearer ``/api/v1/agents/runs`` routes
+-------------------------------------------------------------------
+
+The REST run routes are Bearer-gated over a verified JWT; a browser
+carrying only the BFF session cookie cannot authenticate them. So this
+surface calls the in-process
+:class:`~meho_backplane.agent.invocation.AgentInvoker` (the same
+``list_runs`` / ``poll`` the REST + MCP + CLI surfaces share) -- the same
+console-surface pattern the connectors / scheduler / approvals surfaces
+use. Tenant isolation is enforced by the invoker on the operator's
+``tenant_id``; a cross-tenant run is invisible (list) or 404 (detail).
+
+Registration order is **load-bearing** at the umbrella
+:func:`~meho_backplane.ui.routes.build_router`: this router is included
+**before** :func:`~meho_backplane.ui.routes.agents.build_agents_router` so
+the literal ``/ui/agents/runs`` + ``/ui/agents/runs/{handle}`` routes win
+the first-match-wins lookup against the definition surface's
+``/ui/agents/{name}`` (which would otherwise bind ``"runs"`` as a name).
+
+Scope (Initiative #1824): reads only. Invoking / streaming a run is the run
+console (T2 #1829); cancelling a run is T8/T9. The list / detail never
+expose ``system_prompt`` / ``toolset`` / approval params -- the invoker's
+summary + poll projections carry none of them.
+"""
+
+from __future__ import annotations
+
+from fastapi import APIRouter
+
+from meho_backplane.ui.routes.agents.runs.detail import build_runs_detail_router
+from meho_backplane.ui.routes.agents.runs.list_view import build_runs_list_router
+
+__all__ = ["build_runs_router"]
+
+
+def build_runs_router() -> APIRouter:
+    """Aggregate the agent-runs UI routes into one ``/ui/agents/runs*`` router.
+
+    Factory function (chassis convention) so a test app can construct
+    parallel routers without sharing route state.
+
+    Registration order within this router is **load-bearing**: the literal
+    list route (``/ui/agents/runs``) registers before the parametrised
+    detail route (``/ui/agents/runs/{handle}``) so the bare ``runs`` segment
+    is matched as the list rather than captured as a ``{handle}``. (The
+    ``uuid.UUID`` path type on ``{handle}`` already 422s a non-UUID segment,
+    so this ordering is belt-and-suspenders, but it mirrors every other
+    surface router's literal-before-parametrised discipline.)
+    """
+    router = APIRouter()
+    router.include_router(build_runs_list_router())
+    router.include_router(build_runs_detail_router())
+    return router

--- a/backend/src/meho_backplane/ui/routes/agents/runs/detail.py
+++ b/backend/src/meho_backplane/ui/routes/agents/runs/detail.py
@@ -1,0 +1,152 @@
+# SPDX-License-Identifier: Apache-2.0
+# Copyright (c) 2026 evoila Group
+
+"""``GET /ui/agents/runs/{handle}`` -- the per-run detail + poll surface.
+
+Initiative #1824 (G10.8 Agents console), Task #1830 (T3). A durable view
+of one run after the request that started it has returned: status, turn
+count, resolved provider + model, the structured ``output`` blob, and the
+``error`` reason on a failed run. The page polls *after the fact* (not the
+live SSE run console -- that is the sibling run console, #1829): while the
+run is non-terminal it re-fetches the status panel on a timer; once the run
+reaches a terminal state (``succeeded`` / ``failed`` / ``cancelled``) the
+panel renders statically and the poll stops.
+
+Two response shapes from one handler:
+
+* **Full page** (browser navigation) -- the ``agents/runs/detail.html``
+  page extending ``base.html``. It embeds the status panel
+  (``agents/runs/_status_panel.html``) which self-polls via
+  ``hx-trigger="load delay:Ns, every Ns"`` while non-terminal.
+* **HTMX fragment** (``HX-Request: true``) -- the status panel partial
+  alone, so each poll tick swaps only the panel. The panel template emits
+  the ``hx-trigger`` poll directive **only while the run is non-terminal**;
+  a terminal render drops the directive so HTMX's load-poll cycle ends
+  naturally (the documented "stop returning the polling element" pattern,
+  https://htmx.org/docs/#polling) -- no JS, no 286-response plumbing.
+
+Read at ``operator`` role via the in-process
+:class:`~meho_backplane.agent.invocation.AgentInvoker` (the same ``poll``
+the Bearer ``GET /api/v1/agents/runs/{handle}`` route uses). Tenant scoping
+is non-overrideable: the invoker's ``poll`` raises
+:class:`~meho_backplane.agent.invocation.AgentRunNotFoundError` for a
+cross-tenant / absent handle, which this handler maps to 404 -- the same
+existence-leak collapse the REST surface relies on, so a run id typed into
+the URL bar that belongs to another tenant is indistinguishable from one
+that does not exist. The detail never exposes ``system_prompt`` /
+``toolset`` / approval params: the poll view carries only the run's
+runtime state + result.
+"""
+
+from __future__ import annotations
+
+import json
+import uuid
+
+from fastapi import APIRouter, Depends, HTTPException, Request, status
+from fastapi.responses import HTMLResponse
+
+from meho_backplane.agent.invocation import (
+    AgentRunNotFoundError,
+    get_agent_invoker,
+)
+from meho_backplane.auth.operator import Operator
+from meho_backplane.ui.auth.middleware import UISessionContext, require_ui_session
+from meho_backplane.ui.csrf import CSRF_COOKIE_NAME, mint_csrf_token
+from meho_backplane.ui.routes.agents.runs.operator import resolve_run_reader
+from meho_backplane.ui.routes.agents.runs.views import project_detail_to_view
+from meho_backplane.ui.templating import get_templates
+
+__all__ = ["build_runs_detail_router"]
+
+#: Seconds between status-panel polls while a run is non-terminal. A run
+#: progresses on the order of seconds-to-minutes (an LLM tool-use loop), so
+#: a 3 s cadence is responsive without hammering the durable row.
+_POLL_INTERVAL_SECONDS = 3
+
+_require_session_dep = Depends(require_ui_session)
+_run_reader_dep = Depends(resolve_run_reader)
+
+
+def _is_htmx_request(request: Request) -> bool:
+    """Return ``True`` when HTMX issued the request (``HX-Request: true``)."""
+    return request.headers.get("hx-request", "").lower() == "true"
+
+
+def _pretty_json(value: dict[str, object] | None) -> str | None:
+    """Render the run ``output`` blob as indented text (``None`` -> ``None``).
+
+    ``output`` is a free-shape JSON object (structured agent output, or a
+    ``{"text": ...}`` projection of a free-text answer); rendering it
+    sorted + 2-space-indented gives a stable, diff-friendly view.
+    ``default=str`` keeps a stray non-JSON-native value (e.g. a datetime)
+    from raising mid-render.
+    """
+    if value is None:
+        return None
+    return json.dumps(value, indent=2, sort_keys=True, default=str)
+
+
+def _build_context(
+    detail: dict[str, object],
+    *,
+    csrf_token: str,
+) -> dict[str, object]:
+    """Assemble the detail-page / status-panel template context."""
+    return {
+        "page_title": "Agent run",
+        "active_surface": "agents",
+        "run": detail,
+        "output_json": _pretty_json(detail.get("output")),  # type: ignore[arg-type]
+        "poll_interval_seconds": _POLL_INTERVAL_SECONDS,
+        "csrf_token": csrf_token,
+    }
+
+
+def build_runs_detail_router() -> APIRouter:
+    """Construct the agent-run-detail :class:`APIRouter`.
+
+    Factory function (chassis convention). The umbrella router includes the
+    list router (``/ui/agents/runs``) and this detail router before the
+    agents-definition router so the ``runs`` segment is never bound as a
+    definition ``{name}``; the ``uuid.UUID`` path type also 422s a non-UUID
+    handle, but the include-order discipline is the primary guard.
+    """
+    router = APIRouter(tags=["ui-agents"])
+
+    @router.get("/ui/agents/runs/{handle}", response_class=HTMLResponse)
+    async def run_detail(
+        request: Request,
+        handle: uuid.UUID,
+        session_ctx: UISessionContext = _require_session_dep,
+        operator: Operator = _run_reader_dep,
+    ) -> HTMLResponse:
+        """Render the per-run detail page or poll the status-panel fragment."""
+        invoker = get_agent_invoker()
+        try:
+            view = await invoker.poll(operator, handle)
+        except AgentRunNotFoundError as exc:
+            raise HTTPException(
+                status_code=status.HTTP_404_NOT_FOUND,
+                detail="agent_run_not_found",
+            ) from exc
+        detail = project_detail_to_view(view)
+        csrf_token = mint_csrf_token(str(session_ctx.session_id))
+        context = _build_context(detail, csrf_token=csrf_token)
+        template_name = (
+            "agents/runs/_status_panel.html"
+            if _is_htmx_request(request)
+            else "agents/runs/detail.html"
+        )
+        response = get_templates().TemplateResponse(request, template_name, context)
+        response.set_cookie(
+            key=CSRF_COOKIE_NAME,
+            value=csrf_token,
+            httponly=False,
+            secure=True,
+            samesite="strict",
+            path="/ui",
+        )
+        return response
+
+    return router

--- a/backend/src/meho_backplane/ui/routes/agents/runs/list_view.py
+++ b/backend/src/meho_backplane/ui/routes/agents/runs/list_view.py
@@ -1,0 +1,166 @@
+# SPDX-License-Identifier: Apache-2.0
+# Copyright (c) 2026 evoila Group
+
+"""``GET /ui/agents/runs`` -- the cross-agent run-history list.
+
+Initiative #1824 (G10.8 Agents console), Task #1830 (T3). A scannable
+index of the tenant's agent runs, newest-first, filterable by ``status``
+and ``work_ref`` -- the console face of ``meho agent runs`` / ``GET
+/api/v1/agents/runs``. One handler serves two response shapes (mirroring
+:mod:`meho_backplane.ui.routes.connectors.list_view` /
+:mod:`meho_backplane.ui.routes.scheduler.list_view`):
+
+* **Full page** (browser navigation) -- the ``agents/runs/list.html`` page
+  extending ``base.html``, carrying the "Agents" surface chrome + a
+  Definitions/Runs tab strip.
+* **HTMX fragment** (``HX-Request: true``) -- the
+  ``agents/runs/_table_rows.html`` partial so a filter change re-renders
+  only the table body.
+
+The list reads at ``operator`` role via the in-process
+:class:`~meho_backplane.agent.invocation.AgentInvoker` (the same
+``list_runs`` the Bearer ``GET /api/v1/agents/runs`` route calls) rather
+than the REST surface, because a browser carrying only the BFF session
+cookie cannot authenticate the Bearer route. Tenant scoping is
+non-overrideable -- the invoker's ``list_runs`` keys every query on the
+synthesised operator's ``tenant_id``; no query parameter carries a tenant
+id (cross-tenant runs are invisible).
+
+URL contract::
+
+    GET /ui/agents/runs
+        [?status=pending|running|awaiting_approval|succeeded|failed|cancelled
+         &work_ref=<exact-match string>]
+
+An out-of-enum ``status`` -> 422 (the ``StrEnum`` query validator at the
+HTTP boundary). The list never exposes ``system_prompt`` / ``toolset`` /
+approval params -- the summary projection the invoker returns carries none
+of them.
+"""
+
+from __future__ import annotations
+
+from datetime import UTC, datetime
+
+from fastapi import APIRouter, Depends, Query, Request
+from fastapi.responses import HTMLResponse
+
+from meho_backplane.agent.invocation import get_agent_invoker
+from meho_backplane.auth.operator import Operator
+from meho_backplane.db.models import AgentRunStatus
+from meho_backplane.ui.auth.middleware import UISessionContext, require_ui_session
+from meho_backplane.ui.csrf import CSRF_COOKIE_NAME, mint_csrf_token
+from meho_backplane.ui.routes.agents.runs.operator import resolve_run_reader
+from meho_backplane.ui.routes.agents.runs.views import project_run_to_view
+from meho_backplane.ui.templating import get_templates
+
+__all__ = ["build_runs_list_router"]
+
+#: Hard cap on the runs a single list render considers. The runs list is a
+#: glance surface; an operator chasing a deep history pages via the CLI /
+#: REST ``offset``. Matches the invoker's ``list_runs`` ``le=500`` clamp
+#: ceiling while keeping the default render bounded.
+_LIST_LIMIT = 200
+
+_require_session_dep = Depends(require_ui_session)
+_run_reader_dep = Depends(resolve_run_reader)
+
+
+def _is_htmx_request(request: Request) -> bool:
+    """Return ``True`` when HTMX issued the request (``HX-Request: true``).
+
+    HTMX 2 sets ``HX-Request: true`` on every fetch its directives drive
+    (https://htmx.org/reference/#request_headers). The handler branches on
+    this header to decide between the full page (browser nav) and the
+    table-rows fragment (filter swap). Case-insensitive per the HTTP spec.
+    """
+    return request.headers.get("hx-request", "").lower() == "true"
+
+
+async def _render(
+    request: Request,
+    *,
+    status_filter: AgentRunStatus | None,
+    work_ref: str | None,
+    session_ctx: UISessionContext,
+    operator: Operator,
+) -> HTMLResponse:
+    """Render the runs list page or the table-rows fragment.
+
+    Both branches receive the same context shape so the fragment template
+    and the full-page template stay interchangeable.
+    """
+    invoker = get_agent_invoker()
+    summaries = await invoker.list_runs(
+        operator,
+        work_ref=work_ref or None,
+        status=status_filter,
+        limit=_LIST_LIMIT,
+    )
+    rows = [project_run_to_view(summary) for summary in summaries]
+
+    csrf_token = mint_csrf_token(str(session_ctx.session_id))
+    context: dict[str, object] = {
+        "page_title": "Agent runs",
+        "active_surface": "agents",
+        "rows": rows,
+        # Shared "now" so the relative-time macro stays consistent across
+        # rows within one render (per-row datetime.now would drift).
+        "now_utc": datetime.now(UTC),
+        "status_options": [s.value for s in AgentRunStatus],
+        "status_filter": status_filter.value if status_filter is not None else "",
+        "work_ref_filter": work_ref or "",
+        "csrf_token": csrf_token,
+    }
+    template_name = (
+        "agents/runs/_table_rows.html" if _is_htmx_request(request) else "agents/runs/list.html"
+    )
+    response = get_templates().TemplateResponse(request, template_name, context)
+    response.set_cookie(
+        key=CSRF_COOKIE_NAME,
+        value=csrf_token,
+        httponly=False,
+        secure=True,
+        samesite="strict",
+        path="/ui",
+    )
+    return response
+
+
+def build_runs_list_router() -> APIRouter:
+    """Construct the agent-runs-list :class:`APIRouter`.
+
+    Factory function (chassis convention) so a test app can construct
+    parallel routers without sharing route state. Registers the single
+    ``GET /ui/agents/runs`` route serving both the full page and the HTMX
+    fragment from one handler. The umbrella router includes this **before**
+    the agents-definition router so the literal ``/ui/agents/runs`` segment
+    is matched before the definition surface's ``/ui/agents/{name}`` would
+    bind ``"runs"`` as a name.
+    """
+    router = APIRouter(tags=["ui-agents"])
+
+    async def _handler(
+        request: Request,
+        status: AgentRunStatus | None = Query(default=None),
+        work_ref: str | None = Query(default=None, max_length=256),
+        session_ctx: UISessionContext = _require_session_dep,
+        operator: Operator = _run_reader_dep,
+    ) -> HTMLResponse:
+        """Serve ``GET /ui/agents/runs``. See module docstring for the URL contract."""
+        return await _render(
+            request,
+            status_filter=status,
+            work_ref=work_ref,
+            session_ctx=session_ctx,
+            operator=operator,
+        )
+
+    router.add_api_route(
+        "/ui/agents/runs",
+        _handler,
+        methods=["GET"],
+        name="ui_agents_runs_list",
+        response_class=HTMLResponse,
+    )
+    return router

--- a/backend/src/meho_backplane/ui/routes/agents/runs/operator.py
+++ b/backend/src/meho_backplane/ui/routes/agents/runs/operator.py
@@ -1,0 +1,69 @@
+# SPDX-License-Identifier: Apache-2.0
+# Copyright (c) 2026 evoila Group
+
+"""Role lift for the agent-runs UI surface (Task #1830, G10.8-T3).
+
+The runs list + detail are operator-readable (Initiative #1824: reads =
+operator, writes = tenant_admin). The two reads call the in-process
+:class:`~meho_backplane.agent.invocation.AgentInvoker`, whose ``list_runs``
+/ ``poll`` take a full :class:`~meho_backplane.auth.operator.Operator` and
+tenant-scope every query on :attr:`Operator.tenant_id` (a cross-tenant run
+surfaces as :class:`AgentRunNotFoundError`). The invoker does **not**
+re-check the role on the read path -- the caller is expected to have gated
+the surface on ``operator`` -- so the read handler needs a tenant-scoped
+:class:`Operator`, not just the boolean role probe.
+
+This module wires both halves:
+
+* :func:`resolve_role_probe` -- re-exported from the connectors surface
+  (one JWT-lift implementation across the console). Soft-fails to a
+  no-privileges probe so the read surface keeps rendering through a
+  transient JWKS hiccup; it only drives the UX affordance (the
+  ``awaiting_approval`` deep-link is operator-visible regardless).
+* :func:`resolve_run_reader` -- the read-path dependency. Synthesises a
+  tenant-scoped :class:`Operator` with :attr:`TenantRole.OPERATOR`
+  directly from the BFF session (the same no-JWT-round-trip path the
+  memory list surface's :func:`build_read_operator` takes). Sound because
+  the chassis session middleware already authenticated the request and the
+  invoker enforces tenant isolation on ``operator.tenant_id``; the role is
+  not consulted on the read path, so synthesising ``OPERATOR`` is correct
+  for ``list_runs`` / ``poll`` and avoids a JWT decode on every poll tick.
+"""
+
+from __future__ import annotations
+
+from fastapi import Depends, Request
+
+from meho_backplane.auth.operator import Operator
+from meho_backplane.ui.auth.middleware import UISessionContext, require_ui_session
+from meho_backplane.ui.routes.connectors.operator import (
+    OperatorRoleProbe,
+    resolve_role_probe,
+)
+from meho_backplane.ui.routes.memory.operator import build_read_operator
+
+__all__ = [
+    "OperatorRoleProbe",
+    "resolve_role_probe",
+    "resolve_run_reader",
+]
+
+_require_session_dep = Depends(require_ui_session)
+
+
+async def resolve_run_reader(
+    request: Request,
+    session_ctx: UISessionContext = _require_session_dep,
+) -> Operator:
+    """FastAPI dependency: synthesise the tenant-scoped read :class:`Operator`.
+
+    The runs list / detail handlers hand this to the invoker's ``list_runs``
+    / ``poll``, which tenant-scope on :attr:`Operator.tenant_id`. The
+    session middleware already authenticated the request, so synthesising an
+    ``OPERATOR``-role operator from the session context (rather than
+    re-decoding the access token) is the read-path shape the memory surface
+    established (#877). Tenant isolation is the invoker's job and is keyed on
+    the synthesised ``tenant_id``; a cross-tenant run id is invisible.
+    """
+    del request  # the session context is resolved by the dependency chain.
+    return build_read_operator(session_ctx)

--- a/backend/src/meho_backplane/ui/routes/agents/runs/views.py
+++ b/backend/src/meho_backplane/ui/routes/agents/runs/views.py
@@ -1,0 +1,162 @@
+# SPDX-License-Identifier: Apache-2.0
+# Copyright (c) 2026 evoila Group
+
+"""Projection + shared helpers for the agent-runs UI surface (Task #1830).
+
+The list / detail handlers project the invoker's read dataclasses
+(:class:`~meho_backplane.agent.invocation.AgentRunSummary` for a list row,
+:class:`~meho_backplane.agent.invocation.AgentRunStatusView` for the detail
+poll) into the flat dict shape the templates read. Keeping the projection
+here (not in the route modules) means the row-to-view mapping is
+unit-testable without a FastAPI request fixture, and the list + detail
+renders share one status-badge + UTC-coercion vocabulary.
+
+UTC coercion
+------------
+
+``AgentRun`` carries ``DateTime(timezone=True)`` columns (``created_at`` /
+``started_at`` / ``ended_at``). On PostgreSQL the ORM round-trips them
+tz-aware; on the SQLite ``aiosqlite`` test driver they come back naive
+(the chassis fixture leaves ``detect_types`` unset). The list template's
+relative-time macro does ``now_utc - ts`` arithmetic, which raises
+``TypeError: can't subtract offset-naive and offset-aware datetimes`` on a
+naive value. :func:`coerce_utc_aware` normalises every timestamp before it
+reaches the template -- the same shape the connectors / scheduler list
+views apply.
+
+The status filter
+-----------------
+
+The list ``?status=`` filter uses the runtime
+:class:`~meho_backplane.db.models.AgentRunStatus` enum directly as the
+FastAPI ``Query`` type (it is a ``StrEnum``, so an out-of-enum value 422s at
+the HTTP boundary rather than silently matching nothing, and the
+``<select>`` options are built from the same source enum). Reusing the
+source enum -- rather than mirroring a parallel one -- removes any drift
+risk between the filter vocabulary and the runtime states.
+"""
+
+from __future__ import annotations
+
+from datetime import UTC, datetime
+from typing import Final
+
+from meho_backplane.agent.invocation import AgentRunStatusView, AgentRunSummary
+from meho_backplane.db.models import AgentRunStatus
+
+__all__ = [
+    "coerce_utc_aware",
+    "is_terminal_status",
+    "project_detail_to_view",
+    "project_run_to_view",
+    "status_badge_class",
+]
+
+
+#: Lifecycle states from which a run never transitions again -- the detail
+#: view stops polling once a run reaches one. Mirrors the terminal set the
+#: runtime's state machine treats as final (``succeeded`` / ``failed`` /
+#: ``cancelled``).
+_TERMINAL_STATUSES: Final[frozenset[str]] = frozenset(
+    {
+        AgentRunStatus.SUCCEEDED.value,
+        AgentRunStatus.FAILED.value,
+        AgentRunStatus.CANCELLED.value,
+    }
+)
+
+#: DaisyUI badge modifier per status. ``succeeded`` is the healthy terminal
+#: (success); ``failed`` is the error terminal (error); ``running`` is live
+#: (info); ``awaiting_approval`` is the policy-gated pause (warning);
+#: ``cancelled`` is the operator stop (ghost/muted); ``pending`` is the
+#: not-yet-started state (neutral). An unknown value falls through to the
+#: ghost badge so a future status never renders unstyled.
+_STATUS_BADGE: Final[dict[str, str]] = {
+    AgentRunStatus.PENDING.value: "badge-neutral",
+    AgentRunStatus.RUNNING.value: "badge-info",
+    AgentRunStatus.AWAITING_APPROVAL.value: "badge-warning",
+    AgentRunStatus.SUCCEEDED.value: "badge-success",
+    AgentRunStatus.FAILED.value: "badge-error",
+    AgentRunStatus.CANCELLED.value: "badge-ghost",
+}
+
+
+def coerce_utc_aware(ts: datetime | None) -> datetime | None:
+    """Normalise *ts* to a tz-aware UTC :class:`datetime` (``None`` passes through).
+
+    The SQLite test driver hands back naive datetimes for the
+    ``DateTime(timezone=True)`` columns; the list template's relative-time
+    macro does timedelta arithmetic against a tz-aware "now", so a naive
+    value raises ``TypeError`` mid-render. Attaching :data:`datetime.UTC`
+    to a naive value keeps the substrate dialect-portable without teaching
+    the column shape about the dialect mismatch (same fix the connectors /
+    scheduler list views apply).
+    """
+    if ts is None:
+        return None
+    if ts.tzinfo is None:
+        return ts.replace(tzinfo=UTC)
+    return ts
+
+
+def status_badge_class(status_value: str) -> str:
+    """Return the DaisyUI badge modifier class for a run status."""
+    return _STATUS_BADGE.get(status_value, "badge-ghost")
+
+
+def is_terminal_status(status_value: str) -> bool:
+    """Return ``True`` when a run in *status_value* will never change again.
+
+    The detail view polls only while a run is non-terminal; a terminal run
+    renders statically. Centralised here so the route handler and the
+    template-context builder agree on what "terminal" means.
+    """
+    return status_value in _TERMINAL_STATUSES
+
+
+def project_run_to_view(summary: AgentRunSummary) -> dict[str, object]:
+    """Project one :class:`AgentRunSummary` into the list-row dict shape.
+
+    The summary deliberately omits the run's ``output`` blob (the list is a
+    scannable index); the detail poll carries it. The ``trigger`` field is
+    surfaced as the run's provenance label (``direct`` / ``scheduled`` /
+    ``event`` / ``agent-invoked``) -- the summary carries no per-run agent
+    name (no ``agent_definition_id`` back-link on the wire model), so the
+    provenance is the closest scannable "what kicked this off" column.
+    """
+    return {
+        "run_id": str(summary.run_id),
+        "status": summary.status.value,
+        "status_badge": status_badge_class(summary.status.value),
+        "trigger": summary.trigger,
+        "model_tier": summary.model_tier,
+        "provider": summary.provider,
+        "model": summary.model,
+        "turns": summary.turns,
+        "work_ref": summary.work_ref,
+        "created_at": coerce_utc_aware(summary.created_at),
+        "started_at": coerce_utc_aware(summary.started_at),
+        "ended_at": coerce_utc_aware(summary.ended_at),
+        "is_awaiting_approval": (summary.status == AgentRunStatus.AWAITING_APPROVAL),
+    }
+
+
+def project_detail_to_view(view: AgentRunStatusView) -> dict[str, object]:
+    """Project an :class:`AgentRunStatusView` into the detail-template shape.
+
+    ``output`` / ``error`` are populated only once the run is terminal; the
+    template renders the JSON ``output`` block and the ``error`` reason when
+    present. ``is_terminal`` drives whether the status panel keeps polling.
+    """
+    return {
+        "run_id": str(view.run_id),
+        "status": view.status.value,
+        "status_badge": status_badge_class(view.status.value),
+        "turns": view.turns,
+        "provider": view.provider,
+        "model": view.model,
+        "output": view.output,
+        "error": view.error,
+        "is_terminal": is_terminal_status(view.status.value),
+        "is_awaiting_approval": view.status == AgentRunStatus.AWAITING_APPROVAL,
+    }

--- a/backend/src/meho_backplane/ui/templates/agents/detail.html
+++ b/backend/src/meho_backplane/ui/templates/agents/detail.html
@@ -23,10 +23,17 @@
   class="space-y-4"
   hx-headers='{"X-CSRF-Token": "{{ csrf_token }}"}'
 >
-  <nav class="text-sm" aria-label="Breadcrumb">
-    <a href="/ui/agents" class="link link-hover">Agents</a>
-    <span aria-hidden="true">/</span>
-    <span class="font-mono">{{ agent.name }}</span>
+  <nav class="text-sm flex items-center justify-between gap-4" aria-label="Breadcrumb">
+    <div>
+      <a href="/ui/agents" class="link link-hover">Agents</a>
+      <span aria-hidden="true">/</span>
+      <span class="font-mono">{{ agent.name }}</span>
+    </div>
+    {# Entry point to the run history (T3 #1830). The run summaries carry no
+       per-run agent-definition back-link in the substrate, so this links to
+       the cross-agent runs list (filterable there by status / work_ref)
+       rather than fabricating an agent filter the read path cannot serve. #}
+    <a href="/ui/agents/runs" class="link link-primary">Recent runs &rarr;</a>
   </nav>
 
   {# Body slot -- full agent projection. #}

--- a/backend/src/meho_backplane/ui/templates/agents/index.html
+++ b/backend/src/meho_backplane/ui/templates/agents/index.html
@@ -30,6 +30,12 @@
   class="space-y-4"
   hx-headers='{"X-CSRF-Token": "{{ csrf_token }}"}'
 >
+  {# ---------- Definitions / Runs tab strip (T3 #1830) ---------- #}
+  <div role="tablist" class="tabs tabs-bordered">
+    <a role="tab" class="tab tab-active" aria-current="page" href="/ui/agents">Definitions</a>
+    <a role="tab" class="tab" href="/ui/agents/runs">Runs</a>
+  </div>
+
   <header class="flex flex-wrap items-center justify-between gap-4">
     <div>
       <h1 class="text-2xl font-semibold">Agents</h1>

--- a/backend/src/meho_backplane/ui/templates/agents/runs/_status_panel.html
+++ b/backend/src/meho_backplane/ui/templates/agents/runs/_status_panel.html
@@ -1,0 +1,85 @@
+{#-
+  SPDX-License-Identifier: Apache-2.0
+  Copyright (c) 2026 evoila Group
+
+  Agent-run status panel (Task #1830). Rendered in two contexts:
+    * ``{% include %}``d by ``detail.html`` on the initial full-page render.
+    * Returned standalone by ``GET /ui/agents/runs/{handle}`` when the
+      ``HX-Request`` header is set (a poll tick). HTMX outerHTML-swaps it
+      into the existing ``#agent-run-status-panel`` element.
+
+  Polling contract (https://htmx.org/docs/#polling):
+    While the run is NON-terminal the wrapper carries
+    ``hx-get`` + ``hx-trigger="every Ns"`` so HTMX re-fetches the panel on
+    a timer. Once the run is terminal (succeeded / failed / cancelled) the
+    wrapper drops those directives, so the load-poll cycle ends naturally --
+    "stop returning the polling element". No JS, no 286-response plumbing.
+
+  Output / error are populated only on a terminal run; the panel shows the
+  pretty-printed ``output`` JSON or the ``error`` reason accordingly. The
+  panel never renders ``system_prompt`` / ``toolset`` / approval params --
+  the poll view carries none of them.
+-#}
+<div
+  id="agent-run-status-panel"
+  class="space-y-5"
+  {% if not run.is_terminal %}
+  hx-get="/ui/agents/runs/{{ run.run_id }}"
+  hx-trigger="every {{ poll_interval_seconds }}s"
+  hx-swap="outerHTML"
+  {% endif %}
+>
+  {# ---------- Lifecycle card ---------- #}
+  <div class="card bg-base-100 border-base-300 border shadow-sm">
+    <div class="card-body">
+      <h2 class="card-title text-base flex items-center gap-3">
+        <span class="badge {{ run.status_badge }}">{{ run.status }}</span>
+        {% if not run.is_terminal %}
+          <span class="text-xs opacity-60" aria-live="polite">
+            live · refreshing every {{ poll_interval_seconds }}s
+          </span>
+        {% endif %}
+      </h2>
+
+      {% if run.is_awaiting_approval %}
+        {# Parked on a policy-gated tool call -- deep-link to the approvals
+           queue so an operator can decide it (T7). #}
+        <div class="alert alert-warning text-sm">
+          <span>
+            This run is paused awaiting approval of a policy-gated tool call.
+          </span>
+          <a href="/ui/approvals" class="link link-primary">Review approvals &rarr;</a>
+        </div>
+      {% endif %}
+
+      <dl class="grid grid-cols-[8rem_1fr] gap-y-2 text-sm">
+        <dt class="opacity-60">Turns</dt>
+        <dd>{{ run.turns }}</dd>
+
+        <dt class="opacity-60">Provider</dt>
+        <dd>{% if run.provider %}{{ run.provider }}{% else %}<span class="opacity-40">— (not resolved)</span>{% endif %}</dd>
+
+        <dt class="opacity-60">Model</dt>
+        <dd class="font-mono text-xs">{% if run.model %}{{ run.model }}{% else %}<span class="opacity-40">— (not resolved)</span>{% endif %}</dd>
+      </dl>
+    </div>
+  </div>
+
+  {# ---------- Output / error card ---------- #}
+  <div class="card bg-base-100 border-base-300 border shadow-sm">
+    <div class="card-body">
+      <h2 class="card-title text-base">Result</h2>
+      {% if run.error %}
+        <div class="alert alert-error text-sm">
+          <span class="font-mono whitespace-pre-wrap">{{ run.error }}</span>
+        </div>
+      {% elif output_json %}
+        <pre class="bg-base-200 rounded p-3 text-xs overflow-x-auto">{{ output_json }}</pre>
+      {% elif run.is_terminal %}
+        <p class="text-sm opacity-60">This run produced no output.</p>
+      {% else %}
+        <p class="text-sm opacity-60">No result yet — the run is still in progress.</p>
+      {% endif %}
+    </div>
+  </div>
+</div>

--- a/backend/src/meho_backplane/ui/templates/agents/runs/_table_rows.html
+++ b/backend/src/meho_backplane/ui/templates/agents/runs/_table_rows.html
@@ -1,0 +1,105 @@
+{#-
+  SPDX-License-Identifier: Apache-2.0
+  Copyright (c) 2026 evoila Group
+
+  Agent-runs table-rows fragment (Task #1830).
+
+  Rendered in two contexts:
+    * As a partial ``{% include %}``d by ``list.html`` on the initial
+      full-page render.
+    * As a standalone fragment ``GET /ui/agents/runs`` returns when the
+      ``HX-Request`` header is set (filter change). HTMX outerHTML-swaps
+      it into the existing ``#agent-runs-table-body`` element.
+
+  The ``Created`` column renders a relative string ("3 h ago") with a
+  tooltip carrying the full ISO timestamp; ``Duration`` renders the
+  ended-minus-started span for a finished run (em-dash while a run has not
+  ended). Pure server-side; no JS, no client date library. All timestamps
+  are tz-aware UTC (coerced in the view projection).
+-#}
+{% macro _ago(ts) -%}
+  {#- Past-relative renderer ("X ago"). Input is a tz-aware UTC datetime
+      (coerced in the projection); the tooltip carries the exact ISO
+      timestamp for operators needing precision. -#}
+  {%- set ago = (now_utc - ts).total_seconds() | int -%}
+  {%- if ago < 0 -%}just now
+  {%- elif ago < 60 -%}just now
+  {%- elif ago < 3600 -%}{{ (ago // 60) }} min ago
+  {%- elif ago < 86400 -%}{{ (ago // 3600) }} h ago
+  {%- elif ago < 604800 -%}{{ (ago // 86400) }} d ago
+  {%- else -%}{{ ts.strftime("%Y-%m-%d") }}
+  {%- endif -%}
+{%- endmacro %}
+{% macro _duration(started, ended) -%}
+  {#- Human span between two tz-aware instants. Only rendered when both are
+      present (a run that has started and ended). -#}
+  {%- set secs = (ended - started).total_seconds() | int -%}
+  {%- if secs < 0 -%}—
+  {%- elif secs < 60 -%}{{ secs }} s
+  {%- elif secs < 3600 -%}{{ (secs // 60) }} min {{ (secs % 60) }} s
+  {%- else -%}{{ (secs // 3600) }} h {{ ((secs % 3600) // 60) }} min
+  {%- endif -%}
+{%- endmacro %}
+<tbody id="agent-runs-table-body">
+  {% if rows %}
+    {% for row in rows %}
+      <tr data-run-id="{{ row.run_id }}">
+        <td class="font-mono text-xs">{{ row.run_id[:8] }}…</td>
+        <td>
+          <span class="badge {{ row.status_badge }} badge-sm">{{ row.status }}</span>
+          {% if row.is_awaiting_approval %}
+            {# A run parked on a policy-gated tool call deep-links to the
+               approvals queue so an operator can act on it (T7). #}
+            <a href="/ui/approvals" class="link link-primary text-xs ml-1" aria-label="Review pending approval">review &rarr;</a>
+          {% endif %}
+        </td>
+        <td><span class="badge badge-ghost badge-sm">{{ row.trigger }}</span></td>
+        <td class="text-xs">
+          {% if row.model %}
+            <span class="font-mono">{{ row.model }}</span>
+            <span class="opacity-50 block">{{ row.provider or "—" }} · {{ row.model_tier }}</span>
+          {% else %}
+            <span class="opacity-50">{{ row.model_tier }}</span>
+          {% endif %}
+        </td>
+        <td class="text-xs">{{ row.turns }}</td>
+        <td>
+          {% if row.work_ref %}
+            <span class="badge badge-outline badge-xs font-mono">{{ row.work_ref }}</span>
+          {% else %}
+            <span class="opacity-40">—</span>
+          {% endif %}
+        </td>
+        <td>
+          {% if row.created_at %}
+            <span class="text-xs" title="{{ row.created_at.isoformat() }}">{{ _ago(row.created_at) }}</span>
+          {% else %}
+            <span class="opacity-40">—</span>
+          {% endif %}
+        </td>
+        <td class="text-xs">
+          {% if row.started_at and row.ended_at %}
+            {{ _duration(row.started_at, row.ended_at) }}
+          {% else %}
+            <span class="opacity-40">—</span>
+          {% endif %}
+        </td>
+        <td>
+          <a
+            href="/ui/agents/runs/{{ row.run_id }}"
+            class="btn btn-ghost btn-xs"
+            aria-label="View run {{ row.run_id }}"
+          >
+            View
+          </a>
+        </td>
+      </tr>
+    {% endfor %}
+  {% else %}
+    <tr>
+      <td colspan="9" class="text-center text-sm opacity-60 py-6">
+        No agent runs match the current filter.
+      </td>
+    </tr>
+  {% endif %}
+</tbody>

--- a/backend/src/meho_backplane/ui/templates/agents/runs/detail.html
+++ b/backend/src/meho_backplane/ui/templates/agents/runs/detail.html
@@ -1,0 +1,33 @@
+{#-
+  SPDX-License-Identifier: Apache-2.0
+  Copyright (c) 2026 evoila Group
+
+  Per-run detail page (Initiative #1824, Task #1830, G10.8-T3). Extends
+  ``base.html``. Renders the durable run state read via the in-process
+  invoker ``poll``: run id, status, turns, provider + model, the structured
+  ``output`` blob, and the ``error`` reason on a failed run.
+
+  The status panel (``_status_panel.html``) self-polls while the run is
+  non-terminal and renders statically once terminal -- a poll-after-the-fact
+  view, not the live SSE run console (#1829). The panel owns the
+  ``hx-trigger`` poll directive (emitted only while non-terminal), so this
+  page just embeds it.
+-#}
+{% extends "base.html" %}
+
+{% block page_title %}Agent run &middot; MEHO Operator Console{% endblock %}
+
+{% block content %}
+<section class="space-y-5">
+  <header class="space-y-1">
+    <a href="/ui/agents/runs" class="link link-hover text-sm opacity-70">&larr; Agent runs</a>
+    <h1 class="text-xl font-semibold flex items-center gap-3">
+      <span>Run</span>
+      <span class="font-mono text-sm opacity-70">{{ run.run_id }}</span>
+    </h1>
+  </header>
+
+  {# Status panel -- self-polling while non-terminal (see the fragment). #}
+  {% include "agents/runs/_status_panel.html" %}
+</section>
+{% endblock %}

--- a/backend/src/meho_backplane/ui/templates/agents/runs/list.html
+++ b/backend/src/meho_backplane/ui/templates/agents/runs/list.html
@@ -1,0 +1,107 @@
+{#-
+  SPDX-License-Identifier: Apache-2.0
+  Copyright (c) 2026 evoila Group
+
+  Full-page render of the agent-runs list (Initiative #1824, Task #1830,
+  G10.8-T3). Extends ``base.html`` so the chrome matches the rest of the
+  console; the "Agents" sidebar entry stays active (``active_surface`` ==
+  "agents") and a Definitions/Runs tab strip switches between the two
+  agents surfaces.
+
+  Layout (top-down):
+    * Tab strip -- Definitions (/ui/agents) | Runs (this page).
+    * Header -- title + blurb.
+    * Filter bar -- status <select> (closed enum) + ``work_ref`` text
+      input, HTMX-bound to ``/ui/agents/runs`` swapping only the <tbody>.
+    * Table body (``_table_rows.html`` partial) -- one row per run.
+
+  HTMX wiring mirrors the scheduler list: the filter form ``hx-get``s
+  ``/ui/agents/runs`` with ``hx-include="closest form"`` so every filter
+  value rides along, ``hx-target="#agent-runs-table-body"`` to swap only
+  the table body, and ``hx-push-url`` so the URL reflects the active
+  filter (copy/paste reproduces it).
+-#}
+{% extends "base.html" %}
+
+{% block page_title %}Agent runs &middot; MEHO Operator Console{% endblock %}
+
+{% block content %}
+<section class="space-y-4">
+  {# ---------- Definitions / Runs tab strip ---------- #}
+  <div role="tablist" class="tabs tabs-bordered">
+    <a role="tab" class="tab" href="/ui/agents">Definitions</a>
+    <a role="tab" class="tab tab-active" aria-current="page" href="/ui/agents/runs">Runs</a>
+  </div>
+
+  <header class="flex flex-wrap items-center justify-between gap-4">
+    <div>
+      <h1 class="text-2xl font-semibold">Agent runs</h1>
+      <p class="text-sm opacity-70">
+        Every agent invocation in this tenant, newest first. Filter by
+        lifecycle status or change ticket (work_ref); click a run to inspect
+        its status, turns, model, and output.
+      </p>
+    </div>
+  </header>
+
+  {# ---------- Filter bar ---------- #}
+  <form
+    class="card bg-base-100 border-base-300 border shadow-sm"
+    hx-get="/ui/agents/runs"
+    hx-target="#agent-runs-table-body"
+    hx-swap="outerHTML"
+    hx-trigger="change from:find select, input delay:400ms from:find input[name=work_ref]"
+    hx-include="closest form"
+    hx-push-url="true"
+    role="search"
+    aria-label="Filter runs"
+    onsubmit="return false;"
+  >
+    <div class="card-body grid gap-3 md:grid-cols-2">
+      <label class="form-control">
+        <span class="label-text">Status</span>
+        <select name="status" class="select select-bordered select-sm" aria-label="Filter by status">
+          <option value="">All statuses</option>
+          {% for option in status_options %}
+            <option value="{{ option }}" {% if option == status_filter %}selected{% endif %}>
+              {{ option }}
+            </option>
+          {% endfor %}
+        </select>
+      </label>
+      <label class="form-control">
+        <span class="label-text">Change ticket (work_ref)</span>
+        <input
+          type="text"
+          name="work_ref"
+          value="{{ work_ref_filter }}"
+          class="input input-bordered input-sm"
+          placeholder="exact match"
+          maxlength="256"
+          aria-label="Filter by work_ref"
+        />
+      </label>
+    </div>
+  </form>
+
+  {# ---------- Table ---------- #}
+  <div class="overflow-x-auto rounded-box border border-base-300 bg-base-100">
+    <table class="table table-sm">
+      <thead>
+        <tr>
+          <th>Run</th>
+          <th>Status</th>
+          <th>Trigger</th>
+          <th>Model</th>
+          <th>Turns</th>
+          <th>Change ticket</th>
+          <th>Created</th>
+          <th>Duration</th>
+          <th class="w-16"></th>
+        </tr>
+      </thead>
+      {% include "agents/runs/_table_rows.html" %}
+    </table>
+  </div>
+</section>
+{% endblock %}

--- a/backend/tests/test_ui_agent_runs.py
+++ b/backend/tests/test_ui_agent_runs.py
@@ -1,0 +1,407 @@
+# SPDX-License-Identifier: Apache-2.0
+# Copyright (c) 2026 evoila Group
+
+"""Behavioural tests for the agent-runs UI surface (Task #1830, G10.8-T3).
+
+Initiative #1824 (G10.8 Agents console). Acceptance criteria on issue
+#1830:
+
+* Status + work_ref filters work and are bookmarkable; empty states per
+  filter.
+* Detail polls only while non-terminal; terminal runs render statically.
+* Timestamps coerce to UTC-aware before relative rendering (so the SQLite
+  test path does not ``TypeError``).
+* Operator-gated; no writes here. Tenant-scoped (cross-tenant / absent ->
+  404 on detail, invisible on list).
+* Never leaks ``system_prompt`` / ``toolset`` / approval params.
+
+Harness shape mirrors :mod:`backend.tests.test_ui_scheduler`: a minimal
+FastAPI app wired with the UI session + CSRF middlewares, a ``web_session``
+row carrying the tenant id (the read path synthesises an ``OPERATOR`` from
+the session context -- no JWT round-trip), and seeded ``tenant`` /
+``agent_run`` rows in the autouse SQLite engine.
+"""
+
+from __future__ import annotations
+
+import asyncio
+import uuid
+from collections.abc import Iterator
+from datetime import UTC, datetime, timedelta
+
+import pytest
+from cryptography.fernet import Fernet
+from fastapi import FastAPI
+from fastapi.staticfiles import StaticFiles
+from fastapi.testclient import TestClient
+
+from meho_backplane.db.engine import get_sessionmaker, reset_engine_for_testing
+from meho_backplane.db.models import (
+    AgentRun,
+    AgentRunStatus,
+    AgentRunTrigger,
+    Tenant,
+)
+from meho_backplane.settings import get_settings
+from meho_backplane.ui.auth import SESSION_COOKIE_NAME, UISessionMiddleware
+from meho_backplane.ui.auth import build_router as build_ui_auth_router
+from meho_backplane.ui.auth.session_store import (
+    create_session,
+    reset_fernet_cache_for_testing,
+)
+from meho_backplane.ui.csrf import CSRFMiddleware
+from meho_backplane.ui.paths import static_root_dir
+from meho_backplane.ui.routes import build_router as build_ui_router
+from meho_backplane.ui.templating import reset_templating_for_testing
+
+_TENANT_A = uuid.UUID("11111111-1111-1111-1111-111111111111")
+_TENANT_B = uuid.UUID("22222222-2222-2222-2222-222222222222")
+
+_OP_OPERATOR = "op-operator"
+
+
+@pytest.fixture(autouse=True)
+def _bff_env(monkeypatch: pytest.MonkeyPatch) -> Iterator[None]:
+    """Pin chassis + BFF env vars for every test (mirrors the scheduler suite)."""
+    monkeypatch.setenv("KEYCLOAK_ISSUER_URL", "https://kc.test/realms/meho")
+    monkeypatch.setenv("KEYCLOAK_AUDIENCE", "meho-backplane")
+    monkeypatch.setenv("VAULT_ADDR", "https://vault.test")
+    monkeypatch.setenv("BACKPLANE_URL", "https://meho.test")
+    monkeypatch.setenv("UI_SESSION_ENCRYPTION_KEY", Fernet.generate_key().decode())
+    monkeypatch.setenv("UI_KEYCLOAK_CLIENT_ID", "meho-web")
+    monkeypatch.setenv("UI_KEYCLOAK_CLIENT_SECRET", "test-client-secret")
+    get_settings.cache_clear()
+    reset_fernet_cache_for_testing()
+    reset_templating_for_testing()
+    reset_engine_for_testing()
+    yield
+    get_settings.cache_clear()
+    reset_fernet_cache_for_testing()
+    reset_templating_for_testing()
+    reset_engine_for_testing()
+
+
+# ---------------------------------------------------------------------------
+# Harness helpers
+# ---------------------------------------------------------------------------
+
+
+def _build_app() -> FastAPI:
+    app = FastAPI()
+    app.add_middleware(CSRFMiddleware)
+    app.add_middleware(UISessionMiddleware)
+    app.mount(
+        "/ui/static",
+        StaticFiles(directory=str(static_root_dir()), check_dir=False),
+        name="ui_static",
+    )
+    app.include_router(build_ui_auth_router())
+    app.include_router(build_ui_router())
+    return app
+
+
+def _seed_tenant(tenant_id: uuid.UUID, slug: str) -> None:
+    async def _do() -> None:
+        sessionmaker = get_sessionmaker()
+        async with sessionmaker() as session, session.begin():
+            session.add(Tenant(id=tenant_id, slug=slug, name=f"Tenant {slug}"))
+
+    asyncio.run(_do())
+
+
+def _seed_run(
+    *,
+    tenant_id: uuid.UUID,
+    run_id: uuid.UUID | None = None,
+    status_value: str = AgentRunStatus.RUNNING.value,
+    trigger: str = AgentRunTrigger.DIRECT.value,
+    work_ref: str | None = None,
+    provider: str | None = "anthropic",
+    model: str | None = "claude-sonnet",
+    model_tier: str = "standard",
+    turns: int = 2,
+    output: dict[str, object] | None = None,
+    error: str | None = None,
+    started_at: datetime | None = None,
+    ended_at: datetime | None = None,
+) -> uuid.UUID:
+    """Insert an ``agent_run`` row positioned at *status_value*.
+
+    Status / output / timestamps are written directly (not through the
+    transition guard) so a test can place a row at any state -- the UI's
+    render is what's under test, not the state machine.
+    """
+    rid = run_id or uuid.uuid4()
+    now = datetime.now(UTC)
+
+    async def _do() -> uuid.UUID:
+        sessionmaker = get_sessionmaker()
+        async with sessionmaker() as session, session.begin():
+            session.add(
+                AgentRun(
+                    id=rid,
+                    agent_definition_id=None,
+                    tenant_id=tenant_id,
+                    identity_sub=_OP_OPERATOR,
+                    identity_act=None,
+                    trigger=trigger,
+                    model_tier=model_tier,
+                    provider=provider,
+                    model=model,
+                    status=status_value,
+                    turns=turns,
+                    output=output,
+                    error=error,
+                    work_ref=work_ref,
+                    created_at=now,
+                    started_at=started_at,
+                    ended_at=ended_at,
+                ),
+            )
+        return rid
+
+    return asyncio.run(_do())
+
+
+def _seed_session_sync(*, tenant_id: uuid.UUID, operator_sub: str = _OP_OPERATOR) -> uuid.UUID:
+    async def _do() -> uuid.UUID:
+        sessionmaker = get_sessionmaker()
+        async with sessionmaker() as session, session.begin():
+            decrypted = await create_session(
+                session,
+                operator_sub=operator_sub,
+                tenant_id=tenant_id,
+                access_token="unused-on-the-read-path",
+                refresh_token="refresh-token-plaintext",
+                lifetime=timedelta(hours=1),
+            )
+            return decrypted.id
+
+    return asyncio.run(_do())
+
+
+def _client_for_tenant(tenant_id: uuid.UUID) -> TestClient:
+    """A TestClient carrying a BFF session cookie for *tenant_id*.
+
+    The runs read path synthesises an ``OPERATOR`` operator from the
+    session context (no JWT round-trip), so no respx mock / minted token is
+    needed -- just a session row with the tenant id.
+    """
+    session_id = _seed_session_sync(tenant_id=tenant_id)
+    client = TestClient(_build_app(), follow_redirects=False)
+    client.cookies.set(SESSION_COOKIE_NAME, str(session_id))
+    return client
+
+
+# ---------------------------------------------------------------------------
+# Authentication boundary
+# ---------------------------------------------------------------------------
+
+
+def test_list_unauthenticated_redirects_to_login() -> None:
+    """``GET /ui/agents/runs`` without a session 302s to the BFF login."""
+    client = TestClient(_build_app(), follow_redirects=False)
+    response = client.get("/ui/agents/runs")
+    assert response.status_code == 302
+    assert response.headers["location"].startswith("/ui/auth/login?return_to=")
+
+
+def test_detail_unauthenticated_redirects_to_login() -> None:
+    """``GET /ui/agents/runs/{handle}`` without a session 302s to login."""
+    client = TestClient(_build_app(), follow_redirects=False)
+    response = client.get(f"/ui/agents/runs/{uuid.uuid4()}")
+    assert response.status_code == 302
+
+
+# ---------------------------------------------------------------------------
+# GET /ui/agents/runs -- list
+# ---------------------------------------------------------------------------
+
+
+def test_list_renders_run_row_for_operator() -> None:
+    """An operator sees their tenant's run; the row + relative created render."""
+    _seed_tenant(_TENANT_A, "tenant-a")
+    rid = _seed_run(tenant_id=_TENANT_A, status_value=AgentRunStatus.SUCCEEDED.value)
+    client = _client_for_tenant(_TENANT_A)
+    response = client.get("/ui/agents/runs")
+    assert response.status_code == 200, response.text
+    body = response.text
+    assert str(rid)[:8] in body
+    assert "succeeded" in body
+    # The list never leaks the agent's prompt / toolset.
+    assert "system_prompt" not in body
+    assert "toolset" not in body
+
+
+def test_list_status_filter_narrows_rows() -> None:
+    """``?status=failed`` shows only the failed run, not the running one."""
+    _seed_tenant(_TENANT_A, "tenant-a")
+    failed = _seed_run(tenant_id=_TENANT_A, status_value=AgentRunStatus.FAILED.value)
+    running = _seed_run(tenant_id=_TENANT_A, status_value=AgentRunStatus.RUNNING.value)
+    client = _client_for_tenant(_TENANT_A)
+    response = client.get("/ui/agents/runs", params={"status": "failed"})
+    assert response.status_code == 200
+    body = response.text
+    assert str(failed)[:8] in body
+    assert str(running)[:8] not in body
+
+
+def test_list_work_ref_filter_narrows_rows() -> None:
+    """``?work_ref=`` (exact) shows only the matching run."""
+    _seed_tenant(_TENANT_A, "tenant-a")
+    matching = _seed_run(tenant_id=_TENANT_A, work_ref="gh:evoila/meho#11")
+    other = _seed_run(tenant_id=_TENANT_A, work_ref="gh:evoila/meho#99")
+    client = _client_for_tenant(_TENANT_A)
+    response = client.get("/ui/agents/runs", params={"work_ref": "gh:evoila/meho#11"})
+    assert response.status_code == 200
+    body = response.text
+    assert str(matching)[:8] in body
+    assert str(other)[:8] not in body
+
+
+def test_list_empty_state_renders() -> None:
+    """A filter matching nothing renders the empty-state row, not an error."""
+    _seed_tenant(_TENANT_A, "tenant-a")
+    _seed_run(tenant_id=_TENANT_A, status_value=AgentRunStatus.SUCCEEDED.value)
+    client = _client_for_tenant(_TENANT_A)
+    response = client.get("/ui/agents/runs", params={"status": "cancelled"})
+    assert response.status_code == 200
+    assert "No agent runs match the current filter." in response.text
+
+
+def test_list_htmx_request_returns_fragment_not_full_page() -> None:
+    """An ``HX-Request`` list fetch returns the rows fragment, not the chrome."""
+    _seed_tenant(_TENANT_A, "tenant-a")
+    _seed_run(tenant_id=_TENANT_A)
+    client = _client_for_tenant(_TENANT_A)
+    response = client.get("/ui/agents/runs", headers={"HX-Request": "true"})
+    assert response.status_code == 200
+    body = response.text
+    assert 'id="agent-runs-table-body"' in body
+    # The fragment is the <tbody> only -- no <html>/sidebar chrome.
+    assert "<html" not in body.lower()
+
+
+def test_list_invalid_status_filter_is_422() -> None:
+    """An out-of-enum ``?status=`` fails at the HTTP boundary with 422."""
+    _seed_tenant(_TENANT_A, "tenant-a")
+    client = _client_for_tenant(_TENANT_A)
+    response = client.get("/ui/agents/runs", params={"status": "bogus"})
+    assert response.status_code == 422
+
+
+def test_list_is_tenant_isolated() -> None:
+    """Tenant B's runs never appear on tenant A's list."""
+    _seed_tenant(_TENANT_A, "tenant-a")
+    _seed_tenant(_TENANT_B, "tenant-b")
+    b_run = _seed_run(tenant_id=_TENANT_B, status_value=AgentRunStatus.RUNNING.value)
+    client = _client_for_tenant(_TENANT_A)
+    response = client.get("/ui/agents/runs")
+    assert response.status_code == 200
+    assert str(b_run)[:8] not in response.text
+    assert "No agent runs match the current filter." in response.text
+
+
+def test_list_awaiting_approval_deep_links_to_approvals() -> None:
+    """An ``awaiting_approval`` row surfaces a deep-link to /ui/approvals."""
+    _seed_tenant(_TENANT_A, "tenant-a")
+    _seed_run(tenant_id=_TENANT_A, status_value=AgentRunStatus.AWAITING_APPROVAL.value)
+    client = _client_for_tenant(_TENANT_A)
+    response = client.get("/ui/agents/runs")
+    assert response.status_code == 200
+    assert 'href="/ui/approvals"' in response.text
+
+
+# ---------------------------------------------------------------------------
+# GET /ui/agents/runs/{handle} -- detail + poll
+# ---------------------------------------------------------------------------
+
+
+def test_detail_renders_terminal_run_statically() -> None:
+    """A succeeded run renders its output and does NOT carry a poll directive."""
+    _seed_tenant(_TENANT_A, "tenant-a")
+    now = datetime.now(UTC)
+    rid = _seed_run(
+        tenant_id=_TENANT_A,
+        status_value=AgentRunStatus.SUCCEEDED.value,
+        output={"text": "done-ok"},
+        started_at=now - timedelta(seconds=30),
+        ended_at=now,
+    )
+    client = _client_for_tenant(_TENANT_A)
+    response = client.get(f"/ui/agents/runs/{rid}")
+    assert response.status_code == 200, response.text
+    body = response.text
+    assert "done-ok" in body
+    # Terminal => the status panel carries no self-poll directive. (The
+    # full page's chrome carries unrelated hx-trigger directives -- e.g.
+    # the approvals bell -- so we assert the panel's own poll target is
+    # absent rather than the bare "hx-trigger" substring.)
+    assert f'hx-get="/ui/agents/runs/{rid}"' not in body
+
+
+def test_detail_non_terminal_run_self_polls() -> None:
+    """A running run renders the poll directive so HTMX keeps refreshing."""
+    _seed_tenant(_TENANT_A, "tenant-a")
+    rid = _seed_run(tenant_id=_TENANT_A, status_value=AgentRunStatus.RUNNING.value)
+    client = _client_for_tenant(_TENANT_A)
+    # Fetch the panel fragment (HX-Request) so the assertion sees the panel
+    # alone, not the chrome -- the self-poll directives belong to the panel.
+    response = client.get(f"/ui/agents/runs/{rid}", headers={"HX-Request": "true"})
+    assert response.status_code == 200
+    body = response.text
+    assert f'hx-get="/ui/agents/runs/{rid}"' in body
+    assert 'hx-trigger="every' in body
+
+
+def test_detail_htmx_request_returns_status_panel_fragment() -> None:
+    """An ``HX-Request`` detail fetch returns the status-panel fragment only."""
+    _seed_tenant(_TENANT_A, "tenant-a")
+    rid = _seed_run(tenant_id=_TENANT_A, status_value=AgentRunStatus.RUNNING.value)
+    client = _client_for_tenant(_TENANT_A)
+    response = client.get(f"/ui/agents/runs/{rid}", headers={"HX-Request": "true"})
+    assert response.status_code == 200
+    body = response.text
+    assert 'id="agent-run-status-panel"' in body
+    assert "<html" not in body.lower()
+
+
+def test_detail_failed_run_shows_error_not_output() -> None:
+    """A failed run renders its error reason."""
+    _seed_tenant(_TENANT_A, "tenant-a")
+    rid = _seed_run(
+        tenant_id=_TENANT_A,
+        status_value=AgentRunStatus.FAILED.value,
+        output=None,
+        error="ToolError: backend 503",
+    )
+    client = _client_for_tenant(_TENANT_A)
+    response = client.get(f"/ui/agents/runs/{rid}")
+    assert response.status_code == 200
+    assert "ToolError: backend 503" in response.text
+
+
+def test_detail_cross_tenant_is_404() -> None:
+    """Tenant A polling tenant B's run id gets 404 (existence not leaked)."""
+    _seed_tenant(_TENANT_A, "tenant-a")
+    _seed_tenant(_TENANT_B, "tenant-b")
+    b_run = _seed_run(tenant_id=_TENANT_B, status_value=AgentRunStatus.RUNNING.value)
+    client = _client_for_tenant(_TENANT_A)
+    response = client.get(f"/ui/agents/runs/{b_run}")
+    assert response.status_code == 404
+
+
+def test_detail_absent_run_is_404() -> None:
+    """An unknown run id is 404 -- indistinguishable from cross-tenant."""
+    _seed_tenant(_TENANT_A, "tenant-a")
+    client = _client_for_tenant(_TENANT_A)
+    response = client.get(f"/ui/agents/runs/{uuid.uuid4()}")
+    assert response.status_code == 404
+
+
+def test_detail_non_uuid_handle_is_422() -> None:
+    """A non-UUID handle 422s at the path-param boundary (not bound as a name)."""
+    _seed_tenant(_TENANT_A, "tenant-a")
+    client = _client_for_tenant(_TENANT_A)
+    response = client.get("/ui/agents/runs/not-a-uuid")
+    assert response.status_code == 422

--- a/cli/api/openapi.json
+++ b/cli/api/openapi.json
@@ -9570,6 +9570,105 @@
         }
       }
     },
+    "/ui/agents/runs": {
+      "get": {
+        "tags": [
+          "ui-agents"
+        ],
+        "summary": "Ui Agents Runs List",
+        "description": "Serve ``GET /ui/agents/runs``. See module docstring for the URL contract.",
+        "operationId": "ui_agents_runs_list_ui_agents_runs_get",
+        "parameters": [
+          {
+            "name": "status",
+            "in": "query",
+            "required": false,
+            "schema": {
+              "$ref": "#/components/schemas/AgentRunStatus",
+              "nullable": true,
+              "title": "Status"
+            }
+          },
+          {
+            "name": "work_ref",
+            "in": "query",
+            "required": false,
+            "schema": {
+              "type": "string",
+              "maxLength": 256,
+              "nullable": true,
+              "title": "Work Ref"
+            }
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "Successful Response",
+            "content": {
+              "text/html": {
+                "schema": {
+                  "type": "string"
+                }
+              }
+            }
+          },
+          "422": {
+            "description": "Validation Error",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/HTTPValidationError"
+                }
+              }
+            }
+          }
+        }
+      }
+    },
+    "/ui/agents/runs/{handle}": {
+      "get": {
+        "tags": [
+          "ui-agents"
+        ],
+        "summary": "Run Detail",
+        "description": "Render the per-run detail page or poll the status-panel fragment.",
+        "operationId": "run_detail_ui_agents_runs__handle__get",
+        "parameters": [
+          {
+            "name": "handle",
+            "in": "path",
+            "required": true,
+            "schema": {
+              "type": "string",
+              "format": "uuid",
+              "title": "Handle"
+            }
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "Successful Response",
+            "content": {
+              "text/html": {
+                "schema": {
+                  "type": "string"
+                }
+              }
+            }
+          },
+          "422": {
+            "description": "Validation Error",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/HTTPValidationError"
+                }
+              }
+            }
+          }
+        }
+      }
+    },
     "/ui/agents/create": {
       "get": {
         "tags": [

--- a/cli/internal/api/client.gen.go
+++ b/cli/internal/api/client.gen.go
@@ -6224,6 +6224,12 @@ type McpDispatchMcpPostParams struct {
 	Authorization *string `json:"authorization,omitempty"`
 }
 
+// UiAgentsRunsListUiAgentsRunsGetParams defines parameters for UiAgentsRunsListUiAgentsRunsGet.
+type UiAgentsRunsListUiAgentsRunsGetParams struct {
+	Status  *AgentRunStatus `form:"status,omitempty" json:"status,omitempty"`
+	WorkRef *string         `form:"work_ref,omitempty" json:"work_ref,omitempty"`
+}
+
 // ApprovalsIndexUiApprovalsGetParams defines parameters for ApprovalsIndexUiApprovalsGet.
 type ApprovalsIndexUiApprovalsGetParams struct {
 	Tab     *string `form:"tab,omitempty" json:"tab,omitempty"`
@@ -7914,6 +7920,12 @@ type ClientInterface interface {
 	UiAgentsCreateSubmitUiAgentsCreatePostWithBody(ctx context.Context, contentType string, body io.Reader, reqEditors ...RequestEditorFn) (*http.Response, error)
 
 	UiAgentsCreateSubmitUiAgentsCreatePostWithFormdataBody(ctx context.Context, body UiAgentsCreateSubmitUiAgentsCreatePostFormdataRequestBody, reqEditors ...RequestEditorFn) (*http.Response, error)
+
+	// UiAgentsRunsListUiAgentsRunsGet request
+	UiAgentsRunsListUiAgentsRunsGet(ctx context.Context, params *UiAgentsRunsListUiAgentsRunsGetParams, reqEditors ...RequestEditorFn) (*http.Response, error)
+
+	// RunDetailUiAgentsRunsHandleGet request
+	RunDetailUiAgentsRunsHandleGet(ctx context.Context, handle openapi_types.UUID, reqEditors ...RequestEditorFn) (*http.Response, error)
 
 	// UiAgentsDetailUiAgentsNameGetWithBody request with any body
 	UiAgentsDetailUiAgentsNameGetWithBody(ctx context.Context, name string, contentType string, body io.Reader, reqEditors ...RequestEditorFn) (*http.Response, error)
@@ -10185,6 +10197,30 @@ func (c *Client) UiAgentsCreateSubmitUiAgentsCreatePostWithBody(ctx context.Cont
 
 func (c *Client) UiAgentsCreateSubmitUiAgentsCreatePostWithFormdataBody(ctx context.Context, body UiAgentsCreateSubmitUiAgentsCreatePostFormdataRequestBody, reqEditors ...RequestEditorFn) (*http.Response, error) {
 	req, err := NewUiAgentsCreateSubmitUiAgentsCreatePostRequestWithFormdataBody(c.Server, body)
+	if err != nil {
+		return nil, err
+	}
+	req = req.WithContext(ctx)
+	if err := c.applyEditors(ctx, req, reqEditors); err != nil {
+		return nil, err
+	}
+	return c.Client.Do(req)
+}
+
+func (c *Client) UiAgentsRunsListUiAgentsRunsGet(ctx context.Context, params *UiAgentsRunsListUiAgentsRunsGetParams, reqEditors ...RequestEditorFn) (*http.Response, error) {
+	req, err := NewUiAgentsRunsListUiAgentsRunsGetRequest(c.Server, params)
+	if err != nil {
+		return nil, err
+	}
+	req = req.WithContext(ctx)
+	if err := c.applyEditors(ctx, req, reqEditors); err != nil {
+		return nil, err
+	}
+	return c.Client.Do(req)
+}
+
+func (c *Client) RunDetailUiAgentsRunsHandleGet(ctx context.Context, handle openapi_types.UUID, reqEditors ...RequestEditorFn) (*http.Response, error) {
+	req, err := NewRunDetailUiAgentsRunsHandleGetRequest(c.Server, handle)
 	if err != nil {
 		return nil, err
 	}
@@ -19560,6 +19596,105 @@ func NewUiAgentsCreateSubmitUiAgentsCreatePostRequestWithBody(server string, con
 	return req, nil
 }
 
+// NewUiAgentsRunsListUiAgentsRunsGetRequest generates requests for UiAgentsRunsListUiAgentsRunsGet
+func NewUiAgentsRunsListUiAgentsRunsGetRequest(server string, params *UiAgentsRunsListUiAgentsRunsGetParams) (*http.Request, error) {
+	var err error
+
+	serverURL, err := url.Parse(server)
+	if err != nil {
+		return nil, err
+	}
+
+	operationPath := fmt.Sprintf("/ui/agents/runs")
+	if operationPath[0] == '/' {
+		operationPath = "." + operationPath
+	}
+
+	queryURL, err := serverURL.Parse(operationPath)
+	if err != nil {
+		return nil, err
+	}
+
+	if params != nil {
+		queryValues := queryURL.Query()
+
+		if params.Status != nil {
+
+			if queryFrag, err := runtime.StyleParamWithLocation("form", true, "status", runtime.ParamLocationQuery, *params.Status); err != nil {
+				return nil, err
+			} else if parsed, err := url.ParseQuery(queryFrag); err != nil {
+				return nil, err
+			} else {
+				for k, v := range parsed {
+					for _, v2 := range v {
+						queryValues.Add(k, v2)
+					}
+				}
+			}
+
+		}
+
+		if params.WorkRef != nil {
+
+			if queryFrag, err := runtime.StyleParamWithLocation("form", true, "work_ref", runtime.ParamLocationQuery, *params.WorkRef); err != nil {
+				return nil, err
+			} else if parsed, err := url.ParseQuery(queryFrag); err != nil {
+				return nil, err
+			} else {
+				for k, v := range parsed {
+					for _, v2 := range v {
+						queryValues.Add(k, v2)
+					}
+				}
+			}
+
+		}
+
+		queryURL.RawQuery = queryValues.Encode()
+	}
+
+	req, err := http.NewRequest("GET", queryURL.String(), nil)
+	if err != nil {
+		return nil, err
+	}
+
+	return req, nil
+}
+
+// NewRunDetailUiAgentsRunsHandleGetRequest generates requests for RunDetailUiAgentsRunsHandleGet
+func NewRunDetailUiAgentsRunsHandleGetRequest(server string, handle openapi_types.UUID) (*http.Request, error) {
+	var err error
+
+	var pathParam0 string
+
+	pathParam0, err = runtime.StyleParamWithLocation("simple", false, "handle", runtime.ParamLocationPath, handle)
+	if err != nil {
+		return nil, err
+	}
+
+	serverURL, err := url.Parse(server)
+	if err != nil {
+		return nil, err
+	}
+
+	operationPath := fmt.Sprintf("/ui/agents/runs/%s", pathParam0)
+	if operationPath[0] == '/' {
+		operationPath = "." + operationPath
+	}
+
+	queryURL, err := serverURL.Parse(operationPath)
+	if err != nil {
+		return nil, err
+	}
+
+	req, err := http.NewRequest("GET", queryURL.String(), nil)
+	if err != nil {
+		return nil, err
+	}
+
+	return req, nil
+}
+
 // NewUiAgentsDetailUiAgentsNameGetRequest calls the generic UiAgentsDetailUiAgentsNameGet builder with application/json body
 func NewUiAgentsDetailUiAgentsNameGetRequest(server string, name string, body UiAgentsDetailUiAgentsNameGetJSONRequestBody) (*http.Request, error) {
 	var bodyReader io.Reader
@@ -23936,6 +24071,12 @@ type ClientWithResponsesInterface interface {
 
 	UiAgentsCreateSubmitUiAgentsCreatePostWithFormdataBodyWithResponse(ctx context.Context, body UiAgentsCreateSubmitUiAgentsCreatePostFormdataRequestBody, reqEditors ...RequestEditorFn) (*UiAgentsCreateSubmitUiAgentsCreatePostResponse, error)
 
+	// UiAgentsRunsListUiAgentsRunsGetWithResponse request
+	UiAgentsRunsListUiAgentsRunsGetWithResponse(ctx context.Context, params *UiAgentsRunsListUiAgentsRunsGetParams, reqEditors ...RequestEditorFn) (*UiAgentsRunsListUiAgentsRunsGetResponse, error)
+
+	// RunDetailUiAgentsRunsHandleGetWithResponse request
+	RunDetailUiAgentsRunsHandleGetWithResponse(ctx context.Context, handle openapi_types.UUID, reqEditors ...RequestEditorFn) (*RunDetailUiAgentsRunsHandleGetResponse, error)
+
 	// UiAgentsDetailUiAgentsNameGetWithBodyWithResponse request with any body
 	UiAgentsDetailUiAgentsNameGetWithBodyWithResponse(ctx context.Context, name string, contentType string, body io.Reader, reqEditors ...RequestEditorFn) (*UiAgentsDetailUiAgentsNameGetResponse, error)
 
@@ -27064,6 +27205,50 @@ func (r UiAgentsCreateSubmitUiAgentsCreatePostResponse) StatusCode() int {
 	return 0
 }
 
+type UiAgentsRunsListUiAgentsRunsGetResponse struct {
+	Body         []byte
+	HTTPResponse *http.Response
+	JSON422      *HTTPValidationError
+}
+
+// Status returns HTTPResponse.Status
+func (r UiAgentsRunsListUiAgentsRunsGetResponse) Status() string {
+	if r.HTTPResponse != nil {
+		return r.HTTPResponse.Status
+	}
+	return http.StatusText(0)
+}
+
+// StatusCode returns HTTPResponse.StatusCode
+func (r UiAgentsRunsListUiAgentsRunsGetResponse) StatusCode() int {
+	if r.HTTPResponse != nil {
+		return r.HTTPResponse.StatusCode
+	}
+	return 0
+}
+
+type RunDetailUiAgentsRunsHandleGetResponse struct {
+	Body         []byte
+	HTTPResponse *http.Response
+	JSON422      *HTTPValidationError
+}
+
+// Status returns HTTPResponse.Status
+func (r RunDetailUiAgentsRunsHandleGetResponse) Status() string {
+	if r.HTTPResponse != nil {
+		return r.HTTPResponse.Status
+	}
+	return http.StatusText(0)
+}
+
+// StatusCode returns HTTPResponse.StatusCode
+func (r RunDetailUiAgentsRunsHandleGetResponse) StatusCode() int {
+	if r.HTTPResponse != nil {
+		return r.HTTPResponse.StatusCode
+	}
+	return 0
+}
+
 type UiAgentsDetailUiAgentsNameGetResponse struct {
 	Body         []byte
 	HTTPResponse *http.Response
@@ -30137,6 +30322,24 @@ func (c *ClientWithResponses) UiAgentsCreateSubmitUiAgentsCreatePostWithFormdata
 		return nil, err
 	}
 	return ParseUiAgentsCreateSubmitUiAgentsCreatePostResponse(rsp)
+}
+
+// UiAgentsRunsListUiAgentsRunsGetWithResponse request returning *UiAgentsRunsListUiAgentsRunsGetResponse
+func (c *ClientWithResponses) UiAgentsRunsListUiAgentsRunsGetWithResponse(ctx context.Context, params *UiAgentsRunsListUiAgentsRunsGetParams, reqEditors ...RequestEditorFn) (*UiAgentsRunsListUiAgentsRunsGetResponse, error) {
+	rsp, err := c.UiAgentsRunsListUiAgentsRunsGet(ctx, params, reqEditors...)
+	if err != nil {
+		return nil, err
+	}
+	return ParseUiAgentsRunsListUiAgentsRunsGetResponse(rsp)
+}
+
+// RunDetailUiAgentsRunsHandleGetWithResponse request returning *RunDetailUiAgentsRunsHandleGetResponse
+func (c *ClientWithResponses) RunDetailUiAgentsRunsHandleGetWithResponse(ctx context.Context, handle openapi_types.UUID, reqEditors ...RequestEditorFn) (*RunDetailUiAgentsRunsHandleGetResponse, error) {
+	rsp, err := c.RunDetailUiAgentsRunsHandleGet(ctx, handle, reqEditors...)
+	if err != nil {
+		return nil, err
+	}
+	return ParseRunDetailUiAgentsRunsHandleGetResponse(rsp)
 }
 
 // UiAgentsDetailUiAgentsNameGetWithBodyWithResponse request with arbitrary body returning *UiAgentsDetailUiAgentsNameGetResponse
@@ -35024,6 +35227,58 @@ func ParseUiAgentsCreateSubmitUiAgentsCreatePostResponse(rsp *http.Response) (*U
 	}
 
 	response := &UiAgentsCreateSubmitUiAgentsCreatePostResponse{
+		Body:         bodyBytes,
+		HTTPResponse: rsp,
+	}
+
+	switch {
+	case strings.Contains(rsp.Header.Get("Content-Type"), "json") && rsp.StatusCode == 422:
+		var dest HTTPValidationError
+		if err := json.Unmarshal(bodyBytes, &dest); err != nil {
+			return nil, err
+		}
+		response.JSON422 = &dest
+
+	}
+
+	return response, nil
+}
+
+// ParseUiAgentsRunsListUiAgentsRunsGetResponse parses an HTTP response from a UiAgentsRunsListUiAgentsRunsGetWithResponse call
+func ParseUiAgentsRunsListUiAgentsRunsGetResponse(rsp *http.Response) (*UiAgentsRunsListUiAgentsRunsGetResponse, error) {
+	bodyBytes, err := io.ReadAll(rsp.Body)
+	defer func() { _ = rsp.Body.Close() }()
+	if err != nil {
+		return nil, err
+	}
+
+	response := &UiAgentsRunsListUiAgentsRunsGetResponse{
+		Body:         bodyBytes,
+		HTTPResponse: rsp,
+	}
+
+	switch {
+	case strings.Contains(rsp.Header.Get("Content-Type"), "json") && rsp.StatusCode == 422:
+		var dest HTTPValidationError
+		if err := json.Unmarshal(bodyBytes, &dest); err != nil {
+			return nil, err
+		}
+		response.JSON422 = &dest
+
+	}
+
+	return response, nil
+}
+
+// ParseRunDetailUiAgentsRunsHandleGetResponse parses an HTTP response from a RunDetailUiAgentsRunsHandleGetWithResponse call
+func ParseRunDetailUiAgentsRunsHandleGetResponse(rsp *http.Response) (*RunDetailUiAgentsRunsHandleGetResponse, error) {
+	bodyBytes, err := io.ReadAll(rsp.Body)
+	defer func() { _ = rsp.Body.Close() }()
+	if err != nil {
+		return nil, err
+	}
+
+	response := &RunDetailUiAgentsRunsHandleGetResponse{
 		Body:         bodyBytes,
 		HTTPResponse: rsp,
 	}

--- a/docs/codebase/ui.md
+++ b/docs/codebase/ui.md
@@ -44,7 +44,7 @@ Locked decisions:
 | ------ | ------- |
 | `meho_backplane.ui.paths` | Resolves `templates/`, `static/src/`, `static/dist/` directories at runtime. Source-tree dev and image deploy both work via `Path(__file__).resolve().parent`. |
 | `meho_backplane.ui.templating` | Jinja2 `Environment` factory with `FileSystemLoader`, `select_autoescape`, `StrictUndefined`, and the `app_version` global pre-bound from `meho_backplane.version.deployed_version_label()` -- the deployed-build label (`v<CHART_VERSION>`, else 12-char `GIT_SHA` truncation, else `unknown`) read from the same env vars `GET /version` reports, bound once at env construction because the values are process-immutable (#1698; the global used to bind the static package `__version__`, so every deploy's footer said `0.1.0-dev`). Routes must not pass their own `app_version` context key -- render context shadows env globals. `get_templates()` registers `_ui_session_context_processor` so every render sees a `session_tenant` dict ({id, slug, name}, or None on unauthenticated auth surfaces) -- G0.15-T9 #1217 -- and the live `ready` verdict for the footer pill, read from `request.state.ui_ready` (stashed by the session middleware from `health.ui_readiness_verdict`, the stale-while-revalidate hot-path accessor that never sweeps probes on the request path); G10.7-T1 #1776. Context processors run *after* the route context and `update` over it, so the injected `ready` wins over any per-route literal. |
-| `meho_backplane.ui.routes` | Aggregate `APIRouter`. `build_router()` aggregates the dashboard (`GET /ui/`), the real broadcast routes (`GET /ui/broadcast` + `/ui/broadcast/stream`, G10.1-T1 #867), the real topology routes (`GET /ui/topology` + node detail, G10.5-T1 #880), the real memory + connectors routes (G10.4-T1 #877 / G10.3-T1 #873), the real KB routes (`GET /ui/kb` + search + detail + preview, G10.2-T1 #870), the real docs-corpus routes (`GET /ui/corpus` + `POST /ui/corpus/search` -- collection picker, default-if-one, + ask-the-corpus over the reused `search_docs` / `doc_collections` backends, G10.7-T1 #1777), the real runbooks routes (G10.6-T1 #1382), and the real approvals routes (`GET /ui/approvals/badge` + `GET /ui/approvals` panel + `GET /ui/approvals/{id}` detail modal + `POST .../approve` + `POST .../reject` -- the bell/badge + approve/deny modal over a session BFF that calls the `approval_queue` service in-process, G10.7-T3 #1778), and the real scheduler routes (`GET /ui/scheduler` list + `GET /ui/scheduler/{id}` detail + `GET`/`POST /ui/scheduler/create` create modal + live `POST /ui/scheduler/validate-cron` cron preview + `GET`/`POST /ui/scheduler/{id}/cancel` terminal-confirm cancel -- the trigger control plane over a session BFF that calls `SchedulerAdminService` in-process; reads `operator`, writes `tenant_admin`, cancel fronted by a strong native-`<dialog>` confirm since it is terminal, G10.8-T6 #1826). All surfaces now ship real routers, so the stubs aggregate is empty; real routers are still included **before** the stubs so their concrete paths win the first-match-wins lookup (the literal `/ui/approvals/badge` is registered ahead of the `/ui/approvals/{request_id}` slug for the same reason; the scheduler router registers its literal `/ui/scheduler/create` + `/ui/scheduler/validate-cron` ahead of the `/ui/scheduler/{trigger_id}` detail slug). |
+| `meho_backplane.ui.routes` | Aggregate `APIRouter`. `build_router()` aggregates the dashboard (`GET /ui/`), the real broadcast routes (`GET /ui/broadcast` + `/ui/broadcast/stream`, G10.1-T1 #867), the real topology routes (`GET /ui/topology` + node detail, G10.5-T1 #880), the real memory + connectors routes (G10.4-T1 #877 / G10.3-T1 #873), the real KB routes (`GET /ui/kb` + search + detail + preview, G10.2-T1 #870), the real docs-corpus routes (`GET /ui/corpus` + `POST /ui/corpus/search` -- collection picker, default-if-one, + ask-the-corpus over the reused `search_docs` / `doc_collections` backends, G10.7-T1 #1777), the real runbooks routes (G10.6-T1 #1382), and the real approvals routes (`GET /ui/approvals/badge` + `GET /ui/approvals` panel + `GET /ui/approvals/{id}` detail modal + `POST .../approve` + `POST .../reject` -- the bell/badge + approve/deny modal over a session BFF that calls the `approval_queue` service in-process, G10.7-T3 #1778), and the real scheduler routes (`GET /ui/scheduler` list + `GET /ui/scheduler/{id}` detail + `GET`/`POST /ui/scheduler/create` create modal + live `POST /ui/scheduler/validate-cron` cron preview + `GET`/`POST /ui/scheduler/{id}/cancel` terminal-confirm cancel -- the trigger control plane over a session BFF that calls `SchedulerAdminService` in-process; reads `operator`, writes `tenant_admin`, cancel fronted by a strong native-`<dialog>` confirm since it is terminal, G10.8-T6 #1826), the real agents routes (`/ui/agents` definitions list + detail + tenant_admin CRUD, G10.8-T1 #1825), and the real agent-runs routes (`GET /ui/agents/runs` cross-agent run list + `GET /ui/agents/runs/{handle}` per-run detail/poll, operator-read, G10.8-T3 #1830). All surfaces now ship real routers, so the stubs aggregate is empty; real routers are still included **before** the stubs so their concrete paths win the first-match-wins lookup (the literal `/ui/approvals/badge` is registered ahead of the `/ui/approvals/{request_id}` slug for the same reason; the scheduler router registers its literal `/ui/scheduler/create` + `/ui/scheduler/validate-cron` ahead of the `/ui/scheduler/{trigger_id}` detail slug; the agent-runs router is included ahead of the agents router so `/ui/agents/runs` is not captured by `/ui/agents/{name}`). |
 | `meho_backplane.ui.csrf` | T5 (#866) double-submit-cookie CSRF middleware on state-changing `/ui/*` requests (POST/PATCH/PUT/DELETE). Signed-double-submit per OWASP -- the token is `hmac_sha256(session_secret, session_id || random) + "." + random`; the cookie is JS-readable (`meho_csrf`) so HTMX can echo it in `X-CSRF-Token`. Mismatch / missing token / forged signature -> 403. Read-only methods + out-of-prefix paths pass through. |
 | `meho_backplane.ui.auth` | BFF auth subpackage. T3 (#864) landed `session_store` (encrypted token custody + RFC 9700 refresh-token rotation); T4 (#865) lands `/ui/auth/{login,callback,logout}` + session middleware; G0.25 (#1694) wires the rotation primitive into the request path (`refresh` + `errors` modules). |
 | `meho_backplane.ui.auth.session_store` | Fernet-encrypted server-side session storage. `create_session`, `load_session`, `load_session_for_update` (side-effect-free `SELECT ... FOR UPDATE` variant for the refresh path, G0.25 #1694), `revoke_session`, `rotate_refresh` against the `web_session` Postgres table. `rotate_refresh` optionally extends `expires_at` by a refreshed token's lifetime (`new_lifetime=`), monotonic and clamped to `created_at + ui_session_absolute_lifetime_seconds`, and accepts a caller-supplied clock (`now=`, default wall clock) so a caller that pre-checks `expires_at` (the inline refresh path) shares one reading with the internal replay gate -- two independent clock reads would leave a microsecond gap where the gate's "expired" branch self-deadlocks on the caller's own row lock. Replay of a used refresh token revokes the session and writes a `ui.session.refresh_replay` audit row on a dedicated transaction so the security signal survives caller rollback. |
@@ -2222,8 +2222,9 @@ T2 #1829, run history T3 #1830, principals T4 #1831, grants T5 #1832).
   read-only `system_prompt` in a monospace block, and `toolset` /
   `output_schema` as collapsible pretty-printed JSON. A non-existent /
   cross-tenant name → 404 (the service returns `None` for both — the
-  existence-leak collapse the REST surface holds). Entry points to Run
-  (T2) and a recent-runs strip (T3) land here once those Tasks ship.
+  existence-leak collapse the REST surface holds). A "Recent runs →" link
+  in the breadcrumb row points at the runs list (T3 #1830); the Run entry
+  point (T2) lands here once that Task ships.
 - `POST/GET /ui/agents/create`, `GET/PATCH /ui/agents/{name}` (edit),
   `POST /ui/agents/{name}/toggle` (enable/disable), `GET/POST
   /ui/agents/{name}/delete` — the write surface, **tenant_admin only**.
@@ -2293,8 +2294,100 @@ surfacing is the accepted shape per the #1825 issue body.
   entry in `base.html`'s `nav_surfaces`, the `bot` icon in `_icons.html`,
   and the Agents tile in `dashboard.py`'s `_SURFACE_TILES`.
 
-This is a UI-only surface — it touches no `api/v1` schema, so the OpenAPI
-snapshot is unchanged.
+This surface ships no `api/v1` schema, but its `/ui/*` routes still
+register into the app's route table, so the CLI OpenAPI snapshot
+(`cli/api/openapi.json`) and the generated Go client
+(`cli/internal/api/client.gen.go`) gain the new paths — re-snapshot +
+re-generate (`cd cli && make snapshot-openapi && make generate`) when
+adding or changing any `/ui/*` route, or the "CLI API snapshot freshness"
+CI lane fails.
+
+## Agent-runs surface (G10.8-T3 #1830)
+
+Initiative [#1824](https://github.com/evoila/meho/issues/1824). The
+read-only console face of the agent run-history read path
+(`api/v1/agent_runs.py` — `GET /api/v1/agents/runs` +
+`GET /api/v1/agents/runs/{handle}`): before this Task an operator could
+see run history / poll a run's durable status only from the CLI / REST.
+Hung off the `/ui/agents` scaffold (#1825) as a **Runs sub-tab** rather
+than a new sidebar entry (`active_surface` stays `agents`); a
+Definitions/Runs tab strip on the index + detail pages switches between
+the two agents surfaces, and the agent detail page carries a
+"Recent runs →" link.
+
+`meho_backplane.ui.routes.agents.runs` ships:
+
+- `GET /ui/agents/runs` — the cross-agent run list, newest-first. One
+  handler serves both shapes (branch on `HX-Request`): the full
+  `agents/runs/list.html` page on a browser nav, the
+  `agents/runs/_table_rows.html` `<tbody>` fragment on a filter swap.
+  Filters: `status` (the runtime `AgentRunStatus` `StrEnum` used directly
+  as the `Query` type — an out-of-enum value 422s) + `work_ref` (exact
+  match). Both ride `hx-push-url` so the filtered view is bookmarkable.
+  Columns: run-id prefix, status pill, trigger provenance, model +
+  provider + tier, turns, work_ref chip, relative created, duration.
+  An `awaiting_approval` row deep-links to `/ui/approvals` (T7).
+- `GET /ui/agents/runs/{handle}` — the per-run detail. The status panel
+  (`agents/runs/_status_panel.html`) **polls after the fact** (not the
+  live SSE run console — that is the sibling #1829): while the run is
+  non-terminal it carries `hx-get` + `hx-trigger="every Ns"` so HTMX
+  re-fetches it on a timer; once the run is terminal (`succeeded` /
+  `failed` / `cancelled`) the panel drops those directives so the
+  load-poll cycle ends naturally (the
+  [HTMX "stop returning the polling element"](https://htmx.org/docs/#polling)
+  pattern — no JS, no `286`-response plumbing). Renders status, turns,
+  provider + model, the pretty-printed `output` JSON, or the `error`
+  reason on a failed run. A cross-tenant / absent handle → 404; a
+  non-UUID handle → 422.
+
+### RBAC posture + tenant scoping
+
+Reads are **operator** (Initiative #1824: reads operator, writes
+tenant_admin — there are no writes on this surface). The two reads call
+the in-process `AgentInvoker` (`list_runs` / `poll`) — the same read path
+the Bearer REST routes use — because a browser carrying only the BFF
+session cookie cannot authenticate the Bearer route. The invoker takes a
+full `Operator` and tenant-scopes every query on `operator.tenant_id`, so
+`ui/routes/agents/runs/operator.py`'s `resolve_run_reader` synthesises a
+tenant-scoped `OPERATOR` from the BFF session context (the no-JWT-round-
+trip read path the memory surface's `build_read_operator` established,
+#877) — sound because the chassis session middleware already
+authenticated the request and tenant isolation is the invoker's job. A
+cross-tenant run is invisible on the list and 404 on the detail. The
+surface never exposes `system_prompt` / `toolset` / approval params — the
+invoker's summary + poll projections carry none of them.
+
+### Agent ↔ run correlation gap
+
+`AgentRunSummary` carries no `agent_definition_id` back-link (a documented
+substrate gap — same one the scheduler detail's "Recent fires" panel
+handles), so the runs list cannot filter by a specific agent. The agent
+detail page's "Recent runs →" link therefore lands on the unfiltered
+cross-agent list (filterable there by `status` / `work_ref`) rather than
+fabricating an agent filter the read path cannot serve. The only
+correlation key across triggers and runs is `work_ref`.
+
+### Files
+
+* `backend/src/meho_backplane/ui/routes/agents/runs/list_view.py` — the
+  list handler (full page + `<tbody>` fragment).
+* `backend/src/meho_backplane/ui/routes/agents/runs/detail.py` — the
+  detail handler (full page + self-polling status-panel fragment).
+* `backend/src/meho_backplane/ui/routes/agents/runs/views.py` — the
+  row-to-view projections + status-badge map + UTC coercion +
+  terminal-status predicate (shared by both handlers).
+* `backend/src/meho_backplane/ui/routes/agents/runs/operator.py` — the
+  read-path `Operator` lift + the re-exported role probe.
+* `backend/src/meho_backplane/ui/templates/agents/runs/list.html`,
+  `_table_rows.html`, `detail.html`, `_status_panel.html`.
+
+The `build_runs_router()` aggregate is included in `ui/routes/__init__`'s
+`build_router()` **before** `build_agents_router()` so the literal
+`/ui/agents/runs` + `/ui/agents/runs/{handle}` routes win the
+first-match-wins lookup against the definition surface's
+`/ui/agents/{name}` (which would otherwise bind `"runs"` as a name). Like
+every `/ui/*` surface this changes the CLI OpenAPI snapshot — re-snapshot
++ re-generate when touching it.
 
 ## Runbooks surface (G10.6)
 


### PR DESCRIPTION
## Summary

- Adds the read-only **agent-runs** surface under `/ui/agents/runs` (G10.8-T3), hung off the `/ui/agents` scaffold (#1825) as a **Runs sub-tab** — no new sidebar entry; `active_surface` stays `agents`, a Definitions/Runs tab strip switches between them, and the agent detail page carries a "Recent runs →" link.
- **List** (`GET /ui/agents/runs`): cross-agent run history, newest-first, filterable by `status` + `work_ref` (both bookmarkable via `hx-push-url`); one handler serves the full page (browser nav) and the `<tbody>` fragment (HTMX filter swap); empty-state per filter; `awaiting_approval` rows deep-link to `/ui/approvals`.
- **Detail** (`GET /ui/agents/runs/{handle}`): per-run status/turns/provider/model/output/error. The status panel **polls after the fact** while non-terminal (`hx-trigger="every Ns"`) and renders statically once terminal — the HTMX "stop returning the polling element" pattern, no JS, no `286` plumbing. Not the live SSE run console (that's sibling #1829).
- Reuses the in-process `AgentInvoker` (`list_runs` / `poll`) — the same read path the Bearer REST routes use — with a tenant-scoped `OPERATOR` synthesised from the BFF session (the no-JWT-round-trip read path from the memory surface, #877). Tenant isolation is the invoker's job (keyed on `operator.tenant_id`): cross-tenant runs are invisible on the list and `404` on the detail. The surface never exposes `system_prompt` / `toolset` / approval params.

## Routing

The runs router is included **before** the agents-definition router in `build_router()` so the literal `/ui/agents/runs` + `/ui/agents/runs/{handle}` win the first-match-wins lookup against `/ui/agents/{name}` (which would otherwise bind `"runs"` as a name). Verified by the route-registration order + a `test_detail_non_uuid_handle_is_422`.

## Test plan

- [x] `ruff check` / `ruff format --check` — clean
- [x] `mypy src/meho_backplane/ui/` — Success, no issues (76 files)
- [x] `.claude/hooks/code-quality.py --diff` — exit 0, no violations
- [x] `pytest tests/test_ui_agent_runs.py` — 17 passed (auth boundary, status + work_ref filters, empty state, HTMX fragment vs full page, 422 on bad enum, tenant isolation, awaiting_approval deep-link, terminal-static vs non-terminal-self-poll, error rendering, cross-tenant/absent 404, non-UUID 422)
- [x] `pytest tests/test_ui_agents.py tests/test_ui_scheduler.py tests/test_ui_templates.py tests/test_api_v1_agent_runs.py` — no regressions
- [x] OpenAPI snapshot regenerated (`cd cli && make snapshot-openapi && make generate`); `/ui/agents/runs` + `/ui/agents/runs/{handle}` present; **second `make snapshot-openapi` yields no diff** (idempotent) — CLI API snapshot freshness lane will pass
- [x] `docs/codebase/ui.md` updated (new Agent-runs section + router-aggregate row + the `/ui/*`-changes-the-snapshot note)

## Out of scope

- Invoking / streaming a run → T2 #1829. Cancelling a run → T8/T9.
- **Substrate gap:** `AgentRunSummary` has no `agent_definition_id` back-link, so the runs list cannot filter by a specific agent — the agent-detail link lands on the unfiltered cross-agent list (filterable there by `status` / `work_ref`). The only cross-trigger/run correlation key is `work_ref` (same gap the scheduler detail handles).

<!-- auto-implement-issue: fresh, iteration 1 -->

Closes #1830


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added agent runs list page at `/ui/agents/runs` with status and work reference filtering
  * Added agent run detail page at `/ui/agents/runs/{handle}` with live polling for active runs
  * Added navigation tabs to switch between agent definitions and runs
  * Added "Recent runs" link from agent detail page to cross-agent runs list

* **Documentation**
  * Updated UI module documentation with new agent runs surface details and route ordering information

<!-- end of auto-generated comment: release notes by coderabbit.ai -->