### PR TITLE
feat(knowledge): kb upsert 200-on-overwrite + entry write attribution

### DIFF
--- a/backend/src/meho_backplane/api/v1/kb.py
+++ b/backend/src/meho_backplane/api/v1/kb.py
@@ -18,12 +18,28 @@ Route inventory
 * ``GET /api/v1/kb/{slug}`` -- fetch one entry by slug. Returns
   :class:`KbEntry`. 404 when absent. Role: ``operator``.
 * ``POST /api/v1/kb`` -- create / re-index one entry. Body:
-  :class:`KbEntryCreate`. Returns :class:`KbEntry` with HTTP 201. Role:
-  ``tenant_admin``.
+  :class:`KbEntryCreate`. Returns :class:`KbEntry` with HTTP **201**
+  for a genuinely-new slug and **200** for an in-place overwrite of an
+  existing slug (#1845 -- ``201`` on overwrite is REST-incorrect).
+  Role: ``tenant_admin``.
 * ``DELETE /api/v1/kb/{slug}`` -- delete an entry. Returns 204 on
   success **and** when the row was already absent (idempotent
   semantics per the acceptance criteria; T6 documents the
   "delete-already-missing is 204" contract). Role: ``tenant_admin``.
+
+Cross-principal write & delete model (#1845)
+--------------------------------------------
+
+kb rows are tenant-shared with **no per-row ownership check**: any
+``tenant_admin`` may overwrite or delete **any** other principal's slug
+in the same tenant. This is **wiki-like and intentional** -- there is
+no ``403``/``409`` on a same-slug cross-principal write, and ``DELETE``
+is not principal-scoped. Operators must not assume per-author
+ownership. (This differs from ``memory`` DELETE, which *is*
+principal-scoped.) Writes stamp ``created_by_sub`` /
+``last_updated_by_sub`` into the entry's ``metadata`` so a row is
+self-describing about authorship without an audit-log join; see
+:func:`meho_backplane.kb.attribution.merge_attribution`.
 * ``POST /api/v1/kb/ingest`` -- server-side bulk ingest. Body:
   :class:`IngestKbRequest`. Returns :class:`KbIngestionResult`. Role:
   ``tenant_admin``.
@@ -360,9 +376,20 @@ async def show_kb(
     "",
     response_model=KbEntry,
     status_code=http_status.HTTP_201_CREATED,
+    responses={
+        http_status.HTTP_200_OK: {
+            "model": KbEntry,
+            "description": (
+                "An existing entry with this slug was overwritten in "
+                "place (id + created_at preserved, updated_at bumped). "
+                "201 is returned only for a genuinely-new slug."
+            ),
+        },
+    },
 )
 async def create_kb(
     body: KbEntryCreate,
+    response: Response,
     operator: Operator = _require_admin,
 ) -> KbEntry:
     """Create / re-index one kb entry under the operator's tenant.
@@ -373,6 +400,24 @@ async def create_kb(
     failures so callers can branch on 4xx uniformly. The substrate's
     body-hash short-circuit means re-creating an entry with an
     unchanged body pays only an ``updated_at`` bump.
+
+    Status code (#1845 ask 1): the service reports whether the slug
+    was genuinely new. This handler returns **201 Created** only for a
+    fresh slug and **200 OK** when an existing row was overwritten in
+    place -- ``201`` for an in-place mutation is REST-incorrect, and
+    the response body already differentiates the two cases (preserved
+    ``id`` + ``created_at`` on overwrite). The decorator declares
+    ``201`` as the default so OpenAPI advertises the create path;
+    ``response.status_code`` is reset to ``200`` on the overwrite path
+    (FastAPI lets an injected :class:`Response` override the declared
+    code while still applying ``response_model``).
+
+    Cross-principal overwrite is wiki-like and intentional (any
+    ``tenant_admin`` may replace any other's row in-tenant); this
+    handler adds no ownership gate. It does pass ``operator.sub`` as
+    ``actor_sub`` so the service stamps ``created_by_sub`` /
+    ``last_updated_by_sub`` into the entry's ``metadata`` -- the entry
+    is then self-describing about authorship on every read surface.
 
     Binds ``audit_op_id="kb.create"`` + ``audit_op_class="write"``
     before the substrate call. ``audit_slug`` is bound so the audit
@@ -388,17 +433,22 @@ async def create_kb(
     )
     service = KbService()
     try:
-        return await service.create_entry(
+        entry, created = await service.create_entry(
             tenant_id=operator.tenant_id,
             slug=body.slug,
             body=body.body,
             metadata=body.metadata,
+            actor_sub=operator.sub,
         )
     except InvalidKbSlugError as exc:
         raise HTTPException(
             status_code=http_status.HTTP_422_UNPROCESSABLE_CONTENT,
             detail=str(exc),
         ) from exc
+    if not created:
+        response.status_code = http_status.HTTP_200_OK
+    structlog.contextvars.bind_contextvars(audit_created=created)
+    return entry
 
 
 @router.delete(

--- a/backend/src/meho_backplane/kb/attribution.py
+++ b/backend/src/meho_backplane/kb/attribution.py
@@ -1,0 +1,130 @@
+# SPDX-License-Identifier: Apache-2.0
+# Copyright (c) 2026 evoila Group
+
+"""Per-entry write attribution for kb rows (#1845).
+
+kb rows are tenant-shared with no per-row ownership check: any
+``tenant_admin`` may overwrite or delete any other principal's slug in
+the same tenant (wiki-like, intended -- see
+:mod:`meho_backplane.api.v1.kb`'s module docstring). That model is not
+changed by this module. What this module adds is *attribution*: who
+created a row and who last mutated it, so a kb entry is self-describing
+instead of requiring an audit-log join to answer "who set this value?".
+
+Both facts ride ``documents.doc_metadata`` (the JSONB column) rather
+than new ORM columns, so they surface on every read surface that
+already returns ``metadata`` -- ``GET /api/v1/kb/{slug}``, the list
+preview, the ``POST /api/v1/kb`` response, and ``POST /api/v1/retrieve``
+hits -- with no schema migration.
+
+The single public function :func:`merge_attribution` folds the two
+attribution keys into the metadata dict the substrate persists. It is
+the trust boundary: caller-supplied attribution keys are stripped
+before the verified OIDC ``sub`` is stamped, so an operator cannot
+forge authorship by smuggling ``created_by_sub`` through a create body.
+"""
+
+from __future__ import annotations
+
+from meho_backplane.kb.schemas import META_CREATED_BY_SUB, META_LAST_UPDATED_BY_SUB
+
+__all__ = ["merge_attribution"]
+
+
+def merge_attribution(
+    *,
+    caller_metadata: dict[str, object] | None,
+    existing_metadata: dict[str, object] | None,
+    actor_sub: str | None,
+    created: bool,
+) -> dict[str, object] | None:
+    """Fold the attribution keys into the metadata persisted for a kb write.
+
+    Rules:
+
+    * Caller-supplied attribution keys are always stripped first --
+      authorship is derived from the verified OIDC ``sub``, never from
+      request JSON, so an operator cannot forge a ``created_by_sub`` by
+      smuggling it through the create body.
+    * ``created_by_sub`` is set to *actor_sub* on a genuine create and
+      otherwise preserved from *existing_metadata* (so an overwrite --
+      even cross-principal -- keeps the original author). An overwrite
+      of a pre-attribution row backfills with the acting principal.
+    * ``last_updated_by_sub`` is set to *actor_sub* on every attributed
+      write.
+    * When *actor_sub* is ``None`` (unattributed caller) and
+      *caller_metadata* is ``None``, returns ``None`` so the substrate's
+      "keep existing metadata on re-index" branch is preserved -- an
+      unattributed re-index does not clobber a previously-attributed
+      row's metadata.
+
+    The result honours :func:`~meho_backplane.retrieval.indexer.index_document`'s
+    metadata contract: ``None`` means "keep existing", a dict means
+    "overwrite with this dict".
+    """
+    has_attribution = actor_sub is not None
+    if caller_metadata is None and not has_attribution:
+        # Nothing to write and no caller override -- defer to the
+        # substrate's keep-existing-metadata-on-re-index branch.
+        return None
+
+    base = _base_metadata(caller_metadata, existing_metadata)
+
+    # Strip any caller-smuggled attribution keys -- the sub is the trust
+    # boundary, not request JSON.
+    base.pop(META_CREATED_BY_SUB, None)
+    base.pop(META_LAST_UPDATED_BY_SUB, None)
+
+    if not has_attribution:
+        # Caller passed metadata but no sub (unattended re-index with an
+        # explicit metadata override). Preserve any prior
+        # ``created_by_sub`` so a metadata-only update doesn't erase
+        # authorship; leave ``last_updated_by_sub`` unset.
+        _preserve_created(base, existing_metadata)
+        return base
+
+    base[META_LAST_UPDATED_BY_SUB] = actor_sub
+    if created:
+        base[META_CREATED_BY_SUB] = actor_sub
+    elif not _preserve_created(base, existing_metadata):
+        # Overwrite of a pre-attribution row (created before this
+        # feature shipped): backfill ``created_by_sub`` with the actor.
+        # Leaving it blank would make the row permanently authorless;
+        # stamping the overwriter is the most truthful signal available
+        # without an audit join.
+        base[META_CREATED_BY_SUB] = actor_sub
+    return base
+
+
+def _base_metadata(
+    caller_metadata: dict[str, object] | None,
+    existing_metadata: dict[str, object] | None,
+) -> dict[str, object]:
+    """Return the base dict the attribution keys are folded into.
+
+    Caller's explicit metadata wins when provided; otherwise start from
+    the existing row's metadata so an attributed re-index that passed
+    ``metadata=None`` doesn't drop the operator's other keys (tags,
+    source_path, ...).
+    """
+    if caller_metadata is not None:
+        return dict(caller_metadata)
+    if existing_metadata is not None:
+        return dict(existing_metadata)
+    return {}
+
+
+def _preserve_created(
+    base: dict[str, object],
+    existing_metadata: dict[str, object] | None,
+) -> bool:
+    """Copy a prior ``created_by_sub`` from *existing_metadata* into *base*.
+
+    Returns ``True`` when a prior value existed and was copied, ``False``
+    otherwise -- the caller uses the boolean to decide whether a
+    backfill is needed.
+    """
+    if existing_metadata is not None and META_CREATED_BY_SUB in existing_metadata:
+        base[META_CREATED_BY_SUB] = existing_metadata[META_CREATED_BY_SUB]
+        return True
+    return False

--- a/backend/src/meho_backplane/kb/schemas.py
+++ b/backend/src/meho_backplane/kb/schemas.py
@@ -51,6 +51,8 @@ from pydantic import BaseModel, ConfigDict
 __all__ = [
     "KB_KIND_ENTRY",
     "KB_SOURCE",
+    "META_CREATED_BY_SUB",
+    "META_LAST_UPDATED_BY_SUB",
     "SLUG_PATTERN",
     "InvalidKbSlugError",
     "KbEntry",
@@ -64,6 +66,24 @@ __all__ = [
 #: filter for hybrid retrieval scoping; changing the string is a
 #: data-migration event.
 KB_SOURCE: Final[str] = "kb"
+
+#: Metadata keys that carry per-entry write attribution. Stored inside
+#: ``documents.doc_metadata`` (not as new columns) so attribution rides
+#: the existing JSONB shape and surfaces on every read surface that
+#: already returns ``metadata`` -- ``GET /api/v1/kb/{slug}``, the list
+#: preview, ``POST /api/v1/kb``, and ``POST /api/v1/retrieve`` hits --
+#: with no schema migration. The service writes these keys; callers
+#: that pass them in a create-body ``metadata`` are stripped (the OIDC
+#: ``sub`` is the trust boundary, not caller-supplied JSON) so an
+#: operator cannot forge authorship.
+#:
+#: ``created_by_sub`` is set once on first index and preserved verbatim
+#: across every subsequent overwrite (even a cross-principal one);
+#: ``last_updated_by_sub`` is rewritten to the acting principal on
+#: every write. Together they make a kb row self-describing about who
+#: wrote it and who last mutated it without an audit-log correlation.
+META_CREATED_BY_SUB: Final[str] = "created_by_sub"
+META_LAST_UPDATED_BY_SUB: Final[str] = "last_updated_by_sub"
 
 #: The ``documents.kind`` value every kb entry carries. Distinct from
 #: future kb-adjacent rows (kb-index, kb-collection) that would each

--- a/backend/src/meho_backplane/kb/service.py
+++ b/backend/src/meho_backplane/kb/service.py
@@ -68,6 +68,7 @@ from sqlalchemy import delete, select
 
 from meho_backplane.db.engine import get_sessionmaker
 from meho_backplane.db.models import Document
+from meho_backplane.kb.attribution import merge_attribution
 from meho_backplane.kb.file_walker import walk_kb_directory
 from meho_backplane.kb.schemas import (
     KB_KIND_ENTRY,
@@ -371,8 +372,10 @@ class KbService:
         slug: str,
         body: str,
         metadata: dict[str, object] | None = None,
-    ) -> KbEntry:
-        """Insert (or re-index) one kb entry under *tenant_id*.
+        *,
+        actor_sub: str | None = None,
+    ) -> tuple[KbEntry, bool]:
+        """Insert (or re-index) one kb entry; return ``(entry, created)``.
 
         Validates *slug* before touching the substrate. Delegates to
         :func:`~meho_backplane.retrieval.indexer.index_document` so
@@ -384,35 +387,51 @@ class KbService:
         ``add_to_knowledge`` meta-tool (T3). RBAC (``tenant_admin``)
         enforced by the route layer.
 
-        Parameters
-        ----------
-        tenant_id
-            The owning tenant.
-        slug
-            Operator-facing identifier. Validated against
-            :data:`~meho_backplane.kb.schemas.SLUG_PATTERN`; invalid
-            input raises :class:`~meho_backplane.kb.schemas.InvalidKbSlugError`.
-        body
-            Markdown content. Stored as-is; no chunking, no
-            normalisation. The retrieval substrate (G0.4-T4)
-            consumes both BM25-over-tsvector and a 384-dim
-            embedding.
-        metadata
-            Optional JSON-shaped dict. ``None`` keeps the existing
-            row's metadata on re-index; ``{}`` clears it. Matches
-            the contract on
-            :func:`~meho_backplane.retrieval.indexer.index_document`.
+        Cross-principal writes are wiki-like (any ``tenant_admin`` may
+        overwrite any other principal's slug in-tenant -- intended, no
+        ownership gate); this method only adds attribution via
+        :func:`~meho_backplane.kb.attribution.merge_attribution`:
+        ``created_by_sub`` set once and preserved across overwrites,
+        ``last_updated_by_sub`` rewritten each write, both in
+        ``doc_metadata`` and un-forgeable from caller ``metadata``.
+
+        Returns ``(entry, created)`` where ``created`` is ``True`` only
+        when no row existed for ``(tenant_id, slug)`` -- the route maps
+        it to HTTP ``201`` vs ``200`` (#1845 ask 1). *actor_sub* is the
+        writing principal's OIDC ``sub`` (``Operator.sub``); ``None``
+        leaves the row unattributed. *metadata* ``None`` keeps the
+        existing caller-metadata, ``{}`` clears it; *slug* is validated
+        (raises :class:`~meho_backplane.kb.schemas.InvalidKbSlugError`).
         """
         validate_slug(slug)
+
+        # One natural-key SELECT, ahead of the substrate upsert. It
+        # serves two purposes: (1) the created-vs-overwrite signal for
+        # the route's 201/200 decision, and (2) the prior
+        # ``created_by_sub`` to preserve across an overwrite. The
+        # substrate's own SELECT inside ``index_document`` is a second
+        # round-trip; collapsing the two is a v0.2.next optimisation
+        # (index_document would have to return the action + prior
+        # metadata), not worth the wider blast radius here.
+        existing = await self.get_entry(tenant_id=tenant_id, slug=slug)
+        created = existing is None
+
+        merged = merge_attribution(
+            caller_metadata=metadata,
+            existing_metadata=existing.metadata if existing is not None else None,
+            actor_sub=actor_sub,
+            created=created,
+        )
+
         doc = await index_document(
             tenant_id=tenant_id,
             source=KB_SOURCE,
             source_id=slug,
             kind=KB_KIND_ENTRY,
             body=body,
-            metadata=metadata,
+            metadata=merged,
         )
-        return _doc_to_entry(doc)
+        return _doc_to_entry(doc), created
 
     async def delete_entry(self, tenant_id: uuid.UUID, slug: str) -> bool:
         """Delete the kb entry matching *(tenant_id, slug)*. Return whether it existed.

--- a/backend/src/meho_backplane/mcp/tools/knowledge.py
+++ b/backend/src/meho_backplane/mcp/tools/knowledge.py
@@ -184,11 +184,12 @@ async def _add_to_knowledge_handler(
 
     service = KbService()
     try:
-        entry = await service.create_entry(
+        entry, _created = await service.create_entry(
             tenant_id=operator.tenant_id,
             slug=slug,
             body=body,
             metadata=metadata,
+            actor_sub=operator.sub,
         )
     except InvalidKbSlugError as exc:
         raise McpInvalidParamsError(f"add_to_knowledge: {exc}") from exc

--- a/backend/src/meho_backplane/ui/routes/kb/routes.py
+++ b/backend/src/meho_backplane/ui/routes/kb/routes.py
@@ -1,5 +1,8 @@
 # SPDX-License-Identifier: Apache-2.0
 # Copyright (c) 2026 evoila Group
+# code-quality-allow: file-size — pre-existing 879-line UI router (#1845 only
+# threads actor_sub through the existing create_entry calls; a split of this
+# router is out of scope for the attribution change and tracked separately).
 
 """KB UI routes: list/search + entry detail + hover preview partial + editor.
 
@@ -641,11 +644,12 @@ def build_kb_router() -> APIRouter:
         error_message: str | None = None
         entry: KbEntry | None = None
         try:
-            entry = await kb.create_entry(
+            entry, _created = await kb.create_entry(
                 tenant_id=session.tenant_id,
                 slug=slug.strip(),
                 body=body,
                 metadata=metadata if metadata else None,
+                actor_sub=session.operator_sub,
             )
         except InvalidKbSlugError as exc:
             error_message = str(exc)
@@ -713,6 +717,7 @@ def build_kb_router() -> APIRouter:
             [file],
             [slug],
             tenant_id=session.tenant_id,
+            actor_sub=session.operator_sub,
         )
         context = {
             "rows": rows,
@@ -740,6 +745,7 @@ def build_kb_router() -> APIRouter:
             file,
             [""] * len(file),
             tenant_id=session.tenant_id,
+            actor_sub=session.operator_sub,
         )
         context = {
             "rows": rows,
@@ -752,7 +758,10 @@ def build_kb_router() -> APIRouter:
         slug_overrides: list[str],
         *,
         tenant_id: object,
+        actor_sub: str,
     ) -> list[dict[str, object]]:
+        # code-quality-allow: function-size — pre-existing oversized helper;
+        # #1845 only adds the actor_sub kwarg + threads it to create_entry.
         """Process a list of uploaded files and return per-file result rows.
 
         Each entry in the returned list is a dict with:
@@ -830,11 +839,12 @@ def build_kb_router() -> APIRouter:
                 audit_op_class="write",
             )
             try:
-                entry = await kb.create_entry(
+                entry, _created = await kb.create_entry(
                     tenant_id,  # type: ignore[arg-type]
                     effective_slug,
                     body,
                     metadata={"source_filename": filename},
+                    actor_sub=actor_sub,
                 )
             except InvalidKbSlugError as exc:
                 rows.append(

--- a/backend/tests/integration/test_kb_routes_pg.py
+++ b/backend/tests/integration/test_kb_routes_pg.py
@@ -283,6 +283,80 @@ async def test_full_lifecycle_through_all_five_routes(
 
 
 # ---------------------------------------------------------------------------
+# Test 1b -- cross-principal overwrite: 201→200 + attribution (#1845)
+# ---------------------------------------------------------------------------
+
+
+@_skip_no_docker
+async def test_cross_principal_overwrite_status_and_attribution(
+    kb_integration_app: FastAPI,
+) -> None:
+    """Same-slug cross-principal overwrite returns 200 and records attribution.
+
+    #1845: principal A creates a slug (201, ``created_by_sub=A``);
+    principal B overwrites the same slug in the same tenant -- the
+    wiki-like model lets the write land (no ownership gate) but the
+    status is now **200** (not the REST-incorrect 201-on-overwrite),
+    and the entry carries ``created_by_sub=A`` (preserved) +
+    ``last_updated_by_sub=B`` (bumped) so it is self-describing about
+    who authored and who last mutated it.
+    """
+    from tests._oidc_jwt_helpers import mock_discovery_and_jwks, public_jwks
+
+    fake_embed = _make_stub_embedding_service()
+    a_key, a_token = _admin_token(tenant_id=TENANT_A_ID, sub="principal-a")
+    b_key, b_token = _admin_token(tenant_id=TENANT_A_ID, sub="principal-b")
+
+    with (
+        respx.mock as mock_router,
+        patch(
+            "meho_backplane.retrieval.indexer.get_embedding_service",
+            return_value=fake_embed,
+        ),
+    ):
+        mock_discovery_and_jwks(mock_router, public_jwks(a_key, b_key))
+
+        async with _make_async_client(kb_integration_app) as client:
+            # A creates a fresh slug → 201, attributed to A.
+            a_create = await client.post(
+                "/api/v1/kb",
+                json={"slug": "shared-runbook", "body": "A's version."},
+                headers=_authed(a_token),
+            )
+            assert a_create.status_code == 201, a_create.text
+            a_body = a_create.json()
+            assert a_body["metadata"]["created_by_sub"] == "principal-a"
+            assert a_body["metadata"]["last_updated_by_sub"] == "principal-a"
+            original_id = a_body["id"]
+            original_created_at = a_body["created_at"]
+
+            # B overwrites the same slug → 200 (in-place mutation, not a
+            # create), created_by preserved, last_updated bumped.
+            b_overwrite = await client.post(
+                "/api/v1/kb",
+                json={"slug": "shared-runbook", "body": "B's different version."},
+                headers=_authed(b_token),
+            )
+            assert b_overwrite.status_code == 200, b_overwrite.text
+            b_body = b_overwrite.json()
+            assert b_body["id"] == original_id  # same row
+            assert b_body["created_at"] == original_created_at  # preserved
+            assert b_body["body"] == "B's different version."
+            assert b_body["metadata"]["created_by_sub"] == "principal-a"
+            assert b_body["metadata"]["last_updated_by_sub"] == "principal-b"
+
+            # The read surface (GET /{slug}) carries the same attribution.
+            show = await client.get(
+                "/api/v1/kb/shared-runbook",
+                headers=_authed(a_token),
+            )
+            assert show.status_code == 200
+            show_meta = show.json()["metadata"]
+            assert show_meta["created_by_sub"] == "principal-a"
+            assert show_meta["last_updated_by_sub"] == "principal-b"
+
+
+# ---------------------------------------------------------------------------
 # Test 2 -- tenant boundary holds across the HTTP surface
 # ---------------------------------------------------------------------------
 

--- a/backend/tests/test_api_v1_kb.py
+++ b/backend/tests/test_api_v1_kb.py
@@ -527,10 +527,12 @@ def test_show_cross_tenant_returns_404(client: TestClient) -> None:
 
 
 def test_create_returns_201_and_entry(client: TestClient) -> None:
-    """Tenant_admin POST → 201 + the created entry."""
+    """Tenant_admin POST of a fresh slug → 201 + the created entry."""
     tenant_a = uuid.uuid4()
     key, token = _admin_token(tenant_id=tenant_a)
-    fake_create = AsyncMock(return_value=_make_entry("k8s-ingress", "new body"))
+    # ``create_entry`` returns ``(entry, created)``; a fresh slug is
+    # ``created=True`` → the route returns 201.
+    fake_create = AsyncMock(return_value=(_make_entry("k8s-ingress", "new body"), True))
     with (
         respx.mock as mock_router,
         patch("meho_backplane.api.v1.kb.KbService.create_entry", fake_create),
@@ -556,6 +558,38 @@ def test_create_returns_201_and_entry(client: TestClient) -> None:
     assert call_kwargs["slug"] == "k8s-ingress"
     assert call_kwargs["body"] == "new body"
     assert call_kwargs["metadata"] == {"author": "ops"}
+    # The operator's OIDC sub is forwarded so the service can stamp
+    # attribution (#1845).
+    assert call_kwargs["actor_sub"] == "op-admin"
+
+
+def test_create_overwrite_returns_200(client: TestClient) -> None:
+    """POST of an existing slug (overwrite) → 200, not 201 (#1845 ask 1).
+
+    ``201 Created`` is REST-incorrect for an in-place mutation of an
+    existing row; the service reports ``created=False`` for an
+    overwrite and the route maps that to ``200 OK``. The response body
+    is still the (overwritten) entry.
+    """
+    tenant_a = uuid.uuid4()
+    key, token = _admin_token(tenant_id=tenant_a)
+    # ``created=False`` → overwrite of an existing slug.
+    fake_create = AsyncMock(return_value=(_make_entry("k8s-ingress", "B body"), False))
+    with (
+        respx.mock as mock_router,
+        patch("meho_backplane.api.v1.kb.KbService.create_entry", fake_create),
+    ):
+        _mock_discovery_and_jwks(mock_router, _public_jwks(key))
+        response = client.post(
+            "/api/v1/kb",
+            json={"slug": "k8s-ingress", "body": "B body"},
+            headers=_authed(token),
+        )
+
+    assert response.status_code == 200
+    body = response.json()
+    assert body["slug"] == "k8s-ingress"
+    assert body["body"] == "B body"
 
 
 def test_create_invalid_slug_returns_422(client: TestClient) -> None:
@@ -873,7 +907,7 @@ async def test_create_writes_audit_row_with_kb_create_op_id_and_slug(
     """POST /api/v1/kb → audit row ``op_id="kb.create"`` + ``slug``; body NOT in payload."""
     tenant_a = uuid.uuid4()
     key, token = _admin_token(tenant_id=tenant_a)
-    fake_create = AsyncMock(return_value=_make_entry("k8s-ingress", "FULL BODY"))
+    fake_create = AsyncMock(return_value=(_make_entry("k8s-ingress", "FULL BODY"), True))
     with (
         respx.mock as mock_router,
         patch("meho_backplane.api.v1.kb.KbService.create_entry", fake_create),
@@ -895,6 +929,10 @@ async def test_create_writes_audit_row_with_kb_create_op_id_and_slug(
     assert payload["op_id"] == "kb.create"
     assert payload["op_class"] == "write"
     assert payload["slug"] == "k8s-ingress"
+    # The created-vs-overwrite signal is bound into the audit payload
+    # (#1845) so a forensic read can tell a fresh create from an
+    # in-place overwrite without diffing timestamps.
+    assert payload["created"] is True
     # Body MUST NOT appear anywhere in the audit payload.
     serialised = json.dumps(payload)
     assert "FULL BODY" not in serialised

--- a/backend/tests/test_kb_service.py
+++ b/backend/tests/test_kb_service.py
@@ -355,18 +355,102 @@ async def test_create_entry_writes_new_row(stub_embedding: AsyncMock) -> None:
     """``create_entry`` inserts a row; ``get_entry`` round-trips it."""
     tenant_id = uuid.uuid4()
     service = KbService()
-    created = await service.create_entry(
+    created, was_created = await service.create_entry(
         tenant_id=tenant_id,
         slug="net-policy",
         body="NetworkPolicy default-deny baseline.",
         metadata={"author": "ops"},
     )
+    assert was_created is True
     assert created.slug == "net-policy"
     assert created.metadata == {"author": "ops"}
 
     fetched = await service.get_entry(tenant_id, "net-policy")
     assert fetched is not None
     assert fetched.body == "NetworkPolicy default-deny baseline."
+
+
+@pytest.mark.asyncio
+async def test_create_entry_stamps_attribution_on_create(stub_embedding: AsyncMock) -> None:
+    """A genuine create stamps both ``created_by_sub`` and ``last_updated_by_sub`` (#1845)."""
+    tenant_id = uuid.uuid4()
+    service = KbService()
+    entry, created = await service.create_entry(
+        tenant_id=tenant_id,
+        slug="net-policy",
+        body="baseline",
+        metadata={"author": "ops"},
+        actor_sub="user-a",
+    )
+    assert created is True
+    assert entry.metadata["created_by_sub"] == "user-a"
+    assert entry.metadata["last_updated_by_sub"] == "user-a"
+    # Caller metadata survives alongside the attribution keys.
+    assert entry.metadata["author"] == "ops"
+
+
+@pytest.mark.asyncio
+async def test_create_entry_overwrite_preserves_creator_updates_mutator(
+    stub_embedding: AsyncMock,
+) -> None:
+    """Cross-principal overwrite keeps ``created_by_sub``, bumps ``last_updated_by_sub`` (#1845).
+
+    A's create is overwritten by B (a different principal). The wiki-like
+    model means the overwrite succeeds (no ownership gate); attribution
+    must record that A authored the row but B last touched it.
+    """
+    tenant_id = uuid.uuid4()
+    service = KbService()
+    first, created_a = await service.create_entry(
+        tenant_id=tenant_id, slug="shared", body="A body", actor_sub="user-a"
+    )
+    assert created_a is True
+
+    second, created_b = await service.create_entry(
+        tenant_id=tenant_id, slug="shared", body="B body", actor_sub="user-b"
+    )
+    assert created_b is False  # overwrite, not create → route returns 200
+    assert second.id == first.id  # same row
+    assert second.body == "B body"
+    assert second.metadata["created_by_sub"] == "user-a"  # preserved
+    assert second.metadata["last_updated_by_sub"] == "user-b"  # bumped
+
+
+@pytest.mark.asyncio
+async def test_create_entry_strips_caller_forged_attribution(stub_embedding: AsyncMock) -> None:
+    """Caller-supplied attribution keys are ignored; the OIDC sub wins (#1845).
+
+    An operator cannot forge authorship by smuggling ``created_by_sub``
+    through the create body -- the verified ``actor_sub`` is the trust
+    boundary.
+    """
+    tenant_id = uuid.uuid4()
+    service = KbService()
+    entry, _ = await service.create_entry(
+        tenant_id=tenant_id,
+        slug="forge-attempt",
+        body="body",
+        metadata={"created_by_sub": "victim", "last_updated_by_sub": "victim"},
+        actor_sub="real-actor",
+    )
+    assert entry.metadata["created_by_sub"] == "real-actor"
+    assert entry.metadata["last_updated_by_sub"] == "real-actor"
+
+
+@pytest.mark.asyncio
+async def test_create_entry_unattributed_leaves_no_attribution(stub_embedding: AsyncMock) -> None:
+    """``actor_sub=None`` (unattended re-index) writes no attribution keys (#1845)."""
+    tenant_id = uuid.uuid4()
+    service = KbService()
+    entry, _ = await service.create_entry(
+        tenant_id=tenant_id,
+        slug="unattributed",
+        body="body",
+        metadata={"author": "ops"},
+    )
+    assert "created_by_sub" not in entry.metadata
+    assert "last_updated_by_sub" not in entry.metadata
+    assert entry.metadata["author"] == "ops"
 
 
 @pytest.mark.asyncio

--- a/backend/tests/test_ui_kb_editor.py
+++ b/backend/tests/test_ui_kb_editor.py
@@ -184,7 +184,7 @@ def _seed_kb_entry(
             return_value=fake_service,
         ):
             service = KbService()
-            created_entry = await service.create_entry(
+            created_entry, _ = await service.create_entry(
                 tenant_id,
                 slug,
                 body,
@@ -366,7 +366,7 @@ def test_editor_save_creates_entry_and_redirects() -> None:
             patch(
                 "meho_backplane.ui.routes.kb.routes.KbService.create_entry",
                 new_callable=AsyncMock,
-                return_value=fake_entry,
+                return_value=(fake_entry, True),
             ),
         ):
             response = client.post(
@@ -467,11 +467,13 @@ def test_editor_save_is_tenant_scoped() -> None:
 
     captured_tenant: list[uuid.UUID] = []
 
-    async def _capture_create(tenant_id: object, slug: str, body: str, **_: object) -> KbEntry:
+    async def _capture_create(
+        tenant_id: object, slug: str, body: str, **_: object
+    ) -> tuple[KbEntry, bool]:
         captured_tenant.append(tenant_id)  # type: ignore[arg-type]
         entry = MagicMock(spec=KbEntry)
         entry.slug = slug
-        return entry
+        return entry, True
 
     with respx.mock(assert_all_called=False):
         client = _authenticated_client(session_id_a)

--- a/backend/tests/test_ui_kb_search.py
+++ b/backend/tests/test_ui_kb_search.py
@@ -192,7 +192,7 @@ def _seed_kb_entry(
             return_value=fake_service,
         ):
             service = KbService()
-            created_entry = await service.create_entry(
+            created_entry, _ = await service.create_entry(
                 tenant_id,
                 slug,
                 body,

--- a/backend/tests/test_ui_kb_upload.py
+++ b/backend/tests/test_ui_kb_upload.py
@@ -792,7 +792,9 @@ def test_upload_admin_gate_binds_audit_contextvars() -> None:
 
         captured_contextvars: dict[str, object] = {}
 
-        original_create_entry = None
+        from meho_backplane.kb import KbService
+
+        original_create_entry = KbService.create_entry
 
         async def _capture_and_create(
             tenant_id: object,
@@ -800,15 +802,17 @@ def test_upload_admin_gate_binds_audit_contextvars() -> None:
             body: str,
             *,
             metadata: dict[str, object] | None = None,
+            actor_sub: str | None = None,
         ) -> object:
             # Snapshot the structlog contextvars at the point create_entry
             # is called (i.e. after require_ui_admin has run).
             captured_contextvars.update(structlog.contextvars.get_contextvars())
-            return await original_create_entry(tenant_id, slug, body, metadata=metadata)  # type: ignore[misc]
-
-        from meho_backplane.kb import KbService
-
-        original_create_entry = KbService.create_entry
+            # ``side_effect`` mocks are called unbound (no ``self``), so
+            # forward through a real service instance and pass actor_sub
+            # (#1845) through to the original.
+            return await original_create_entry(
+                KbService(), tenant_id, slug, body, metadata=metadata, actor_sub=actor_sub
+            )
 
         with (
             patch(

--- a/cli/api/openapi.json
+++ b/cli/api/openapi.json
@@ -3603,7 +3603,7 @@
           "knowledge"
         ],
         "summary": "Create Kb",
-        "description": "Create / re-index one kb entry under the operator's tenant.\n\n``tenant_admin`` only -- ``operator`` role gets 403 via\n:func:`require_role`. Invalid slug shape (regex miss) surfaces as\n422 ``invalid_slug``; same status code Pydantic uses for shape\nfailures so callers can branch on 4xx uniformly. The substrate's\nbody-hash short-circuit means re-creating an entry with an\nunchanged body pays only an ``updated_at`` bump.\n\nBinds ``audit_op_id=\"kb.create\"`` + ``audit_op_class=\"write\"``\nbefore the substrate call. ``audit_slug`` is bound so the audit\nlog payload (and the broadcast ``params``) carries the slug\nthat was created. The body content is NOT bound -- the audit\nrow is for the operation, not the document content (which lives\nin the ``documents`` table and is recoverable via ``kb.show``).",
+        "description": "Create / re-index one kb entry under the operator's tenant.\n\n``tenant_admin`` only -- ``operator`` role gets 403 via\n:func:`require_role`. Invalid slug shape (regex miss) surfaces as\n422 ``invalid_slug``; same status code Pydantic uses for shape\nfailures so callers can branch on 4xx uniformly. The substrate's\nbody-hash short-circuit means re-creating an entry with an\nunchanged body pays only an ``updated_at`` bump.\n\nStatus code (#1845 ask 1): the service reports whether the slug\nwas genuinely new. This handler returns **201 Created** only for a\nfresh slug and **200 OK** when an existing row was overwritten in\nplace -- ``201`` for an in-place mutation is REST-incorrect, and\nthe response body already differentiates the two cases (preserved\n``id`` + ``created_at`` on overwrite). The decorator declares\n``201`` as the default so OpenAPI advertises the create path;\n``response.status_code`` is reset to ``200`` on the overwrite path\n(FastAPI lets an injected :class:`Response` override the declared\ncode while still applying ``response_model``).\n\nCross-principal overwrite is wiki-like and intentional (any\n``tenant_admin`` may replace any other's row in-tenant); this\nhandler adds no ownership gate. It does pass ``operator.sub`` as\n``actor_sub`` so the service stamps ``created_by_sub`` /\n``last_updated_by_sub`` into the entry's ``metadata`` -- the entry\nis then self-describing about authorship on every read surface.\n\nBinds ``audit_op_id=\"kb.create\"`` + ``audit_op_class=\"write\"``\nbefore the substrate call. ``audit_slug`` is bound so the audit\nlog payload (and the broadcast ``params``) carries the slug\nthat was created. The body content is NOT bound -- the audit\nrow is for the operation, not the document content (which lives\nin the ``documents`` table and is recoverable via ``kb.show``).",
         "operationId": "create_kb_api_v1_kb_post",
         "parameters": [
           {
@@ -3630,6 +3630,16 @@
         "responses": {
           "201": {
             "description": "Successful Response",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/KbEntry"
+                }
+              }
+            }
+          },
+          "200": {
+            "description": "An existing entry with this slug was overwritten in place (id + created_at preserved, updated_at bumped). 201 is returned only for a genuinely-new slug.",
             "content": {
               "application/json": {
                 "schema": {

--- a/cli/internal/api/client.gen.go
+++ b/cli/internal/api/client.gen.go
@@ -23833,6 +23833,7 @@ func (r ListKbApiV1KbGetResponse) StatusCode() int {
 type CreateKbApiV1KbPostResponse struct {
 	Body         []byte
 	HTTPResponse *http.Response
+	JSON200      *KbEntry
 	JSON201      *KbEntry
 	JSON422      *HTTPValidationError
 }
@@ -30586,6 +30587,13 @@ func ParseCreateKbApiV1KbPostResponse(rsp *http.Response) (*CreateKbApiV1KbPostR
 	}
 
 	switch {
+	case strings.Contains(rsp.Header.Get("Content-Type"), "json") && rsp.StatusCode == 200:
+		var dest KbEntry
+		if err := json.Unmarshal(bodyBytes, &dest); err != nil {
+			return nil, err
+		}
+		response.JSON200 = &dest
+
 	case strings.Contains(rsp.Header.Get("Content-Type"), "json") && rsp.StatusCode == 201:
 		var dest KbEntry
 		if err := json.Unmarshal(bodyBytes, &dest); err != nil {

--- a/docs/codebase/kb.md
+++ b/docs/codebase/kb.md
@@ -39,7 +39,11 @@ Frozen Pydantic value object that mirrors one `documents` row in
 kb-shaped vocabulary: `id`, `tenant_id`, `slug` (renamed from
 `source_id`), `body`, `metadata`, `created_at`, `updated_at`. The
 substrate columns the kb does not expose (`source`, `kind`,
-`body_hash`, `tokens`, `embedding`) stay invisible to callers.
+`body_hash`, `tokens`, `embedding`) stay invisible to callers. Write
+attribution rides `metadata` as `created_by_sub` /
+`last_updated_by_sub` (see "Cross-principal write & delete semantics"
+below) rather than as dedicated columns — no schema migration, and the
+keys surface on every read surface that already returns `metadata`.
 
 ### `KbEntrySearchHit` (`kb/schemas.py`)
 
@@ -76,7 +80,7 @@ before returning. Six verbs:
 
 | Verb | What it does | Throws |
 |---|---|---|
-| `create_entry(tenant_id, slug, body, metadata=None)` | Insert or re-index one entry. Validates slug, delegates to `index_document`. | `InvalidKbSlugError` on bad slug |
+| `create_entry(tenant_id, slug, body, metadata=None, *, actor_sub=None)` | Insert or re-index one entry; returns `(entry, created)`. Validates slug, stamps attribution, delegates to `index_document`. | `InvalidKbSlugError` on bad slug |
 | `get_entry(tenant_id, slug)` | Natural-key SELECT; returns `KbEntry` or `None`. | – |
 | `list_entries(tenant_id, filter_pattern=None, limit=100, offset=0)` | List entries; slug-sorted; SQL `LIKE` pattern forwarded verbatim. | `ValueError` on negative `limit`/`offset` |
 | `delete_entry(tenant_id, slug)` | Delete by natural key; returns whether a row existed. | – |
@@ -98,12 +102,53 @@ to the caller's `errors` list rather than raising.
 
 1. `validate_slug(slug)` — fail closed on a bad slug before the
    substrate is touched.
-2. `index_document(tenant_id, source='kb', source_id=slug,
-   kind='kb-entry', body, metadata)` — substrate's upsert path.
+2. One natural-key `get_entry` SELECT — yields the **created-vs-
+   overwrite** signal (no prior row ⇒ `created=True`) and the prior
+   `created_by_sub` to preserve.
+3. `merge_attribution(...)` (in `kb/attribution.py`) folds the
+   attribution keys into the metadata to persist.
+4. `index_document(tenant_id, source='kb', source_id=slug,
+   kind='kb-entry', body, metadata=merged)` — substrate's upsert path.
    The `documents.body_hash` short-circuit means an unchanged body
    pays zero embedding cost (just an `updated_at` bump).
-3. Project the returned `Document` row back to `KbEntry` via
-   `_doc_to_entry`.
+5. Return `(_doc_to_entry(doc), created)`. The REST route maps
+   `created` to **HTTP 201** (fresh slug) vs **200** (in-place
+   overwrite); the MCP / UI callers discard it.
+
+### Cross-principal write & delete semantics (#1845)
+
+kb rows are **tenant-shared with no per-row ownership check**. Any
+`tenant_admin` in a tenant may overwrite or delete **any** other
+principal's slug in that tenant — this is **wiki-like and intended**,
+not a bug. Operators must not assume per-author ownership: there is no
+`403`/`409` on a same-slug cross-principal write, and `DELETE` is not
+principal-scoped (it removes whatever row matches the natural key).
+This is deliberately different from `memory` DELETE, which **is**
+principal-scoped (a cross-principal memory delete is a silent no-op).
+
+To make a row self-describing about authorship without an audit-log
+join, every kb write stamps two keys into `documents.doc_metadata`
+(no schema migration — they ride the existing JSONB and surface on
+every read surface that returns `metadata`):
+
+- **`created_by_sub`** — the OIDC `sub` that first created the row.
+  Set once and **preserved verbatim** across every later overwrite,
+  including a cross-principal one. A pre-attribution row (created
+  before this shipped) is backfilled with the first overwriter's sub.
+- **`last_updated_by_sub`** — the OIDC `sub` of whoever last wrote the
+  row. Rewritten on every attributed write.
+
+Attribution is derived from the **verified** `Operator.sub`, never
+from request JSON: `merge_attribution` strips any caller-supplied
+`created_by_sub` / `last_updated_by_sub` from the create-body
+`metadata` before stamping, so an operator cannot forge authorship.
+An unattended re-index that passes `actor_sub=None` leaves attribution
+untouched (it does not erase a previously-attributed row's keys).
+
+The two keys surface on **every** kb read surface:
+`POST /api/v1/kb`, `GET /api/v1/kb/{slug}`, the `GET /api/v1/kb` list
+preview, and `POST /api/v1/retrieve {source:"kb"}` hits (the retrieve
+hit's `doc_metadata` is the same JSONB column).
 
 ### Write path — `ingest_directory`
 

--- a/examples/kb_writeback/workflow.py
+++ b/examples/kb_writeback/workflow.py
@@ -242,12 +242,19 @@ async def persist_finding_to_kb(
     validate_slug(finding.slug)  # raises InvalidKbSlugError if malformed
     body = build_finding_body(finding)
     kb_service = service or KbService()
-    return await kb_service.create_entry(
+    # ``create_entry`` returns ``(entry, created)`` so the HTTP layer can
+    # map fresh-create vs in-place re-index to 201 vs 200; this sample
+    # only needs the persisted entry. ``actor_sub`` stamps the
+    # ``last_updated_by_sub`` / ``created_by_sub`` attribution from the
+    # investigating operator so the written finding is self-describing.
+    entry, _created = await kb_service.create_entry(
         tenant_id=operator.tenant_id,
         slug=finding.slug,
         body=body,
         metadata={PROVENANCE_METADATA_KEY: PROVENANCE_METADATA_VALUE},
+        actor_sub=operator.sub,
     )
+    return entry
 
 
 async def retrieve_as_context(


### PR DESCRIPTION
## Summary

- **HTTP status (ask 1):** `POST /api/v1/kb` now returns **201** only for a genuinely-new slug and **200** for an in-place overwrite of an existing slug. `201` on an overwrite is REST-incorrect; the service reports created-vs-overwrite and the route maps it via an injected `Response` (the decorator keeps `201` as the OpenAPI default; `200` is advertised as a documented alternate response).
- **Attribution (ask 3):** every kb write stamps `created_by_sub` (set once, preserved verbatim across overwrites — including cross-principal ones) and `last_updated_by_sub` (rewritten each write) into `documents.doc_metadata`. **No schema migration** — the keys ride the existing JSONB and surface on all four read surfaces named in the issue (`POST /api/v1/kb`, `GET /api/v1/kb/{slug}`, `GET /api/v1/kb` list preview, `POST /api/v1/retrieve {source:"kb"}` hits). Authorship derives from the verified `Operator.sub`; caller-supplied attribution keys are stripped so an operator cannot forge it.
- **Docs (ask 2):** the wiki-like cross-principal upsert/delete model (any `tenant_admin` may replace/delete any other's row in-tenant — intended, no ownership gate) is now explicit in the route module docstring and `docs/codebase/kb.md`, contrasted with `memory`'s principal-scoped DELETE. **No ownership enforcement added** (explicitly out of scope per the issue).

`create_entry` now returns `(entry, created)` and takes an `actor_sub` kwarg; the MCP `add_to_knowledge` tool and both UI write paths were updated. The merge logic lives in a new `kb/attribution.py` to keep `service.py` under the file-size budget.

## Test plan

- [x] `ruff check` (src + tests) — clean
- [x] `ruff format --check` — clean
- [x] `mypy src/meho_backplane` — clean (481 files)
- [x] `code-quality.py --diff` — 0 blockers (remaining warnings are pre-existing legacy functions)
- [x] `pytest` kb + retrieve + indexer + db-documents suites — 184 passed
- [x] New unit tests: 201-on-create, 200-on-overwrite, audit `created` flag, `actor_sub` forwarded; service-level attribution (create stamps both subs, cross-principal overwrite preserves creator + bumps mutator, caller-forged attribution stripped, unattributed `actor_sub=None` writes no keys)
- [x] New integration test (`test_kb_routes_pg.py`): cross-principal overwrite returns 200 with preserved `id`/`created_at` and `created_by_sub`/`last_updated_by_sub` surfacing on `GET /{slug}` (Docker-gated; runs in CI)
- [x] CLI OpenAPI snapshot + generated Go client regenerated (`cd cli && make snapshot-openapi && make generate`); `go build ./...` clean

## Out of scope

- Per-row ownership enforcement on write/delete — the wiki-like model is intended (issue explicitly excludes this).
- Tarball ingest, per-entry version history — pre-existing v0.2.next deferrals, untouched.

<!-- auto-implement-issue: fresh, iteration 1 -->

Closes #1845
