### PR TITLE
docs(targets): align import --dry-run godoc with read-only behavior

### DIFF
--- a/cli/internal/cmd/targets/import.go
+++ b/cli/internal/cmd/targets/import.go
@@ -153,7 +153,7 @@ func (p *plan) summary() string {
 //
 //	meho targets import <file>
 //	  [--update]              # PATCH existing targets instead of erroring on duplicates
-//	  [--dry-run]             # print the plan; no API calls
+//	  [--dry-run]             # print the plan (read-only: one GET, no writes)
 //	  [--json]                # output the plan as JSON (use with --dry-run)
 //	  [--backplane <url>]     # override the backplane URL
 //


### PR DESCRIPTION
## What

Follow-up to #1785 (PR #1861). The `newImportCmd` godoc still described `--dry-run` as `# print the plan; no API calls` — stale since #1785 routed dry-run through the live existence-aware planner (one GET, no writes). This aligns the comment with the already-updated flag help (`print the plan (read-only: one GET, no writes); does not apply`).

## Scope

- Comment-only. One line in `cli/internal/cmd/targets/import.go`.
- No behavior change; `gofmt`/`go vet`/`go build ./...` clean.

Refs #1785.