### PR TITLE
feat(approvals): generic redaction-safe params-echo default for proposed_effect (#1856)

### DIFF
--- a/backend/src/meho_backplane/operations/_preview.py
+++ b/backend/src/meho_backplane/operations/_preview.py
@@ -22,9 +22,15 @@ post-approval op result.
 Design contract
 ---------------
 
-* **Opt-in per op.** A builder is registered against an ``op_id``; ops
-  without a registered builder fall through to the identifier-only
-  default exactly as before -- no extra work, no new failure mode.
+* **Opt-in bespoke builder, generic echo default.** A builder is
+  registered against an ``op_id`` to compute a richer preview (a
+  computed dry-run, before/after specs, …). An op *without* a registered
+  builder no longer falls straight through to the identifier-only
+  default: it gets a **generic params-echo default** (#1856) that echoes
+  the requested params -- redaction-safe -- so every approval-gated op
+  has param-level legibility for free. The identifier-only default is
+  reached only when the op is credential-class (suppressed), its params
+  are empty, or the params dict normalises to nothing to show.
 * **Fail-soft, never silent.** A builder that raises (a dry-run that
   hits the API server and errors, a transient connector fault) must
   never block the park: :func:`build_proposed_effect` swallows the
@@ -35,8 +41,9 @@ Design contract
   ``{op_class, preview_unavailable: True, preview_error}`` marker
   rather than ``None``, so the reviewer can tell "blast-radius
   unknown" from a genuinely small action. Only a *declined* preview
-  (no builder registered, builder returns ``None``, credential-class
-  suppression) yields ``None`` → the identifier-only default.
+  (builder returns ``None``, credential-class suppression, or an empty
+  params dict with no builder) yields ``None`` → the identifier-only
+  default.
 * **Redaction-safe.** The preview lands in a durable row surfaced over
   REST / MCP / CLI, so it must not carry secret material. The hook
   reuses the single-sourced sensitivity classification from
@@ -63,6 +70,7 @@ from typing import TYPE_CHECKING, Any, Protocol
 import structlog
 
 from meho_backplane.broadcast.events import classify_op
+from meho_backplane.redaction import apply_connector_boundary_redaction
 
 if TYPE_CHECKING:
     from meho_backplane.auth.operator import Operator
@@ -86,6 +94,46 @@ _SENSITIVE_CLASSES: frozenset[str] = frozenset(
     {"credential_read", "credential_mint", "credential_write"}
 )
 
+#: Sentinel substituted for a scrubbed secret-bearing param value. A
+#: non-empty marker (rather than dropping the key) keeps the param shape
+#: legible -- the reviewer sees that a ``password`` field *existed* on the
+#: parked call without learning its value. Mirrors the keycloak read-op
+#: scrub sentinel (:data:`~meho_backplane.connectors.keycloak.redaction.REDACTED`).
+_PARAM_REDACTED = "***REDACTED***"
+
+#: Param key names whose value is secret material regardless of its
+#: string shape, scrubbed by exact (case-insensitive) key match before the
+#: echo is stored. The connector-boundary redaction engine matches secret
+#: *value* shapes (JWTs, bearer tokens, labelled ``key=value`` strings in a
+#: single leaf) but walks Mappings key-by-key without inspecting the key
+#: itself -- so a structured ``{"password": "hunter2"}`` param slips
+#: through it. This set closes that gap for the generic echo: a
+#: secret-by-key-name param never lands verbatim in the durable approval
+#: row even when its value carries no recognisable secret signature. Kept
+#: deliberately narrow (the well-known credential param spellings); a
+#: connector whose params need richer scrubbing registers a bespoke
+#: builder (e.g. the keycloak write preview, #1857) that owns its own
+#: field discipline.
+_SECRET_PARAM_KEYS: frozenset[str] = frozenset(
+    {
+        "password",
+        "passwd",
+        "pwd",
+        "secret",
+        "client_secret",
+        "secret_id",
+        "token",
+        "api_key",
+        "apikey",
+        "access_token",
+        "refresh_token",
+        "auth_token",
+        "session_token",
+        "private_key",
+        "credentials",
+    }
+)
+
 #: Truncation bound for the reviewer-facing ``preview_error`` reason. A
 #: builder fault is normally a one-line message; the cap keeps a
 #: pathological exception repr (an HTTP error echoing a response body)
@@ -107,6 +155,96 @@ def _preview_failure_reason(exc: Exception) -> str:
     return reason
 
 
+def _scrub_secret_param_keys(value: Any) -> Any:
+    """Replace secret-by-name param values with :data:`_PARAM_REDACTED`.
+
+    Walks dicts + lists recursively. For every dict, a key matching
+    :data:`_SECRET_PARAM_KEYS` (case-insensitively) has its whole value
+    replaced -- scalar or subtree -- so a nested ``{"credentials": [...]}``
+    leaks no element. Every other value is walked so a secret keyed deep
+    inside the params tree is still caught. Scalars pass through. The input
+    is never mutated; a new structure is returned.
+
+    This is the key-name half of the generic echo's redaction; the
+    value-shape half is :func:`apply_connector_boundary_redaction`.
+    """
+    if isinstance(value, dict):
+        return {
+            key: (
+                _PARAM_REDACTED
+                if isinstance(key, str) and key.lower() in _SECRET_PARAM_KEYS
+                else _scrub_secret_param_keys(item)
+            )
+            for key, item in value.items()
+        }
+    if isinstance(value, list):
+        return [_scrub_secret_param_keys(item) for item in value]
+    return value
+
+
+def _redact_echoed_params(
+    params: dict[str, Any],
+    *,
+    connector_id: str | None,
+    tenant: str | None,
+    op_id: str,
+) -> dict[str, Any]:
+    """Scrub a params dict for the generic params-echo default.
+
+    Two passes, both reusing the existing redaction discipline:
+
+    1. **Key-name scrub** (:func:`_scrub_secret_param_keys`) -- masks
+       values keyed by a well-known credential name. The connector-boundary
+       engine walks Mappings key-by-key but matches secret *value* shapes
+       only, so a structured ``{"password": "hunter2"}`` would otherwise
+       echo verbatim.
+    2. **Value-shape scrub** (:func:`apply_connector_boundary_redaction`)
+       -- the same connector-boundary pipeline the response path and the
+       dispatch-request preview (:mod:`._request_preview`) run, catching
+       JWTs / bearer tokens / kubeconfig blobs / labelled ``key=value``
+       secrets embedded in a string leaf. Run *after* the key-name pass so
+       a masked sentinel is what the engine sees, never the raw secret.
+
+    Returns a JSON-shaped dict (the engine normalises models / tuples).
+    """
+    key_scrubbed = _scrub_secret_param_keys(params)
+    redaction = apply_connector_boundary_redaction(
+        key_scrubbed,
+        connector_id=connector_id,
+        tenant=tenant,
+        op=op_id,
+    )
+    # The engine normalises a dict input to a dict (``.redacted`` is typed
+    # ``Any``); narrow it so the echo envelope value stays well-typed.
+    redacted = redaction.redacted
+    return redacted if isinstance(redacted, dict) else {}
+
+
+def _generic_params_echo(ctx: PreviewContext, *, op_class: str) -> dict[str, Any] | None:
+    """Build the generic params-echo default for an op with no builder (#1856).
+
+    Echoes the requested params under a ``params_echo`` envelope key
+    (distinct from a computed ``preview``) after the two-pass redaction in
+    :func:`_redact_echoed_params`, so the approval surface can tell a
+    generic echo from a bespoke preview. Empty params carry no more
+    legibility than the identifier-only default and collapse to ``None``
+    (the caller's fallback). Credential-class suppression is handled by the
+    caller *before* this runs, so a secret-class op never reaches here.
+    """
+    if not ctx.params:
+        return None
+    tenant = str(ctx.operator.tenant_id) if ctx.operator.tenant_id is not None else None
+    return {
+        "op_class": op_class,
+        "params_echo": _redact_echoed_params(
+            ctx.params,
+            connector_id=ctx.connector_id,
+            tenant=tenant,
+            op_id=ctx.descriptor.op_id,
+        ),
+    }
+
+
 @dataclass(frozen=True)
 class PreviewContext:
     """Everything a preview builder needs to compute a dry-run.
@@ -123,6 +261,12 @@ class PreviewContext:
         operator: The authenticated operator whose dispatch parked.
         target: The dispatch target (or ``None`` for tenant-wide ops).
         params: The original dispatch params.
+        connector_id: The call's natural-key connector id (e.g.
+            ``"vault-1.x"``), used to resolve the per-connector
+            :class:`~meho_backplane.redaction.policy.RedactionPolicy` for
+            the generic params-echo default. ``None`` (the default) falls
+            back to the conservative connector-boundary default policy --
+            the same behaviour as an unmatched override.
     """
 
     descriptor: EndpointDescriptor
@@ -130,6 +274,7 @@ class PreviewContext:
     operator: Operator
     target: Any
     params: dict[str, Any]
+    connector_id: str | None = None
 
 
 class PreviewBuilder(Protocol):
@@ -198,11 +343,25 @@ def register_permission_preflight(op_id: str, preflight: PermissionPreflight) ->
 async def build_proposed_effect(ctx: PreviewContext) -> dict[str, Any] | None:
     """Compute the ``proposed_effect`` preview for a parking dispatch.
 
-    Looks up a builder for ``ctx.descriptor.op_id``; returns ``None``
-    (caller uses the identifier-only default) when no builder is
-    registered, when the op classifies as a credential class (the
-    preview is suppressed to stay redaction-safe), or when the builder
-    declines.
+    Resolution order:
+
+    1. **Credential-class suppression first.** An op classifying as a
+       credential class (:data:`_SENSITIVE_CLASSES`) never surfaces
+       request/response detail in a durable row -- not via a bespoke
+       builder, and not via the generic params-echo default. Returns
+       ``None`` (caller uses the identifier-only default).
+    2. **Bespoke builder, if registered** for ``ctx.descriptor.op_id``.
+       Its result is wrapped ``{op_class, preview}``; ``None`` from the
+       builder declines to the identifier-only default. Richer than the
+       generic echo (a computed dry-run, before/after specs, …).
+    3. **Generic params-echo default** when no builder is registered
+       (#1856). The requested params are echoed under a ``params_echo``
+       envelope key (distinct from a computed ``preview``) after a
+       two-pass redaction -- key-name scrub + connector-boundary
+       value-shape scrub (:func:`_redact_echoed_params`) -- so every
+       approval-gated op gets param-level legibility for free without
+       leaking secret material. Empty params carry no more legibility
+       than the identifier-only default and collapse to ``None``.
 
     A builder that **raises** is still fail-soft -- the park proceeds
     regardless -- but no longer silent (#1628): the hook returns an
@@ -212,22 +371,19 @@ async def build_proposed_effect(ctx: PreviewContext) -> dict[str, Any] | None:
     default indistinguishable from a small action. The dispatcher
     merges the marker onto the identifier fields before parking.
 
-    On success the returned dict is wrapped with a ``"preview"`` envelope
-    key + the op's sensitivity ``"op_class"`` so the approval surface can
-    label it as a computed preview rather than the bare identifier
-    default.
+    On builder success the returned dict is wrapped with a ``"preview"``
+    envelope key + the op's sensitivity ``"op_class"`` so the approval
+    surface can label it as a computed preview rather than the bare
+    identifier default; the generic default uses ``"params_echo"`` in
+    place of ``"preview"``.
     """
     op_id = ctx.descriptor.op_id
-    builder = _PREVIEW_BUILDERS.get(op_id)
-    if builder is None:
-        return None
-
     op_class = classify_op(op_id)
     if op_class in _SENSITIVE_CLASSES:
         # A credential-class op must not surface request/response detail
-        # in a durable row. Refuse the preview outright rather than risk
-        # a builder that echoes secret material; the reviewer still sees
-        # the identifier-only default via the caller's fallback.
+        # in a durable row -- not via a bespoke builder, and not via the
+        # generic params-echo default below. Refuse outright; the reviewer
+        # still sees the identifier-only default via the caller's fallback.
         _log.info(
             "proposed_effect_preview_suppressed",
             op_id=op_id,
@@ -235,6 +391,12 @@ async def build_proposed_effect(ctx: PreviewContext) -> dict[str, Any] | None:
             reason="sensitive_op_class",
         )
         return None
+
+    builder = _PREVIEW_BUILDERS.get(op_id)
+    if builder is None:
+        # No bespoke builder: fall back to the generic params-echo default
+        # so every approval-gated op gets param-level legibility for free.
+        return _generic_params_echo(ctx, op_class=op_class)
 
     try:
         preview = await builder(ctx)

--- a/backend/src/meho_backplane/operations/dispatcher.py
+++ b/backend/src/meho_backplane/operations/dispatcher.py
@@ -1288,6 +1288,7 @@ async def _build_proposed_effect(
             operator=operator,
             target=target,
             params=params,
+            connector_id=connector_id,
         )
         preview = await build_proposed_effect(ctx)
         if preview is not None and preview.get("preview_unavailable") is True:

--- a/backend/tests/test_connectors_argocd_write_e2e.py
+++ b/backend/tests/test_connectors_argocd_write_e2e.py
@@ -604,27 +604,33 @@ async def test_park_appproject_update_populates_before_after_preview(
         ("argocd.app.refresh", {"name": _APP_NAME}),
     ],
 )
-async def test_park_no_builder_ops_use_identifier_only_default(
+async def test_park_no_builder_ops_use_generic_params_echo(
     argocd_write_e2e: ArgoCdConnector,
     op_id: str,
     params: dict[str, Any],
 ) -> None:
-    """sync / rollback / refresh park with the identifier-only default — no preview.
+    """sync / rollback / refresh park with the generic params-echo (#1856).
 
-    They register no builder, so proposed_effect stays the bare
-    ``{op_id, connector_id, target_id}`` and no cluster call fires on the
-    park path (the handler is never reached, and no preview read is issued).
+    They register no bespoke builder, so since #1856 their proposed_effect
+    is the generic ``{op_class, params_echo}`` default (param-level
+    legibility for free) rather than a computed ``preview``. No cluster
+    call fires on the park path: the echo only redacts the already-known
+    params, the handler is never reached, and no preview read is issued.
     """
     with respx.mock(base_url=_ARGOCD_BASE_URL, assert_all_called=False) as mock:
         result = await _dispatch(op_id, params, approved=False)
         assert result["status"] == "awaiting_approval", result
         assert not mock.calls, f"{op_id} must make no cluster call on the park path"
 
+    from meho_backplane.broadcast.events import classify_op
+
     request_id = result["extras"]["approval_request_id"]
     effect = await _parked_proposed_effect(request_id)
-    # Identifier-only default: no preview envelope, just the call identity.
+    # Generic params-echo default: no computed preview, but the requested
+    # params are echoed (none secret-bearing here, so they pass through).
     assert "preview" not in effect
-    assert effect["op_id"] == op_id
+    assert effect["op_class"] == classify_op(op_id)
+    assert effect["params_echo"] == params
 
 
 @pytest.mark.asyncio

--- a/backend/tests/test_operations_dispatcher.py
+++ b/backend/tests/test_operations_dispatcher.py
@@ -2150,11 +2150,13 @@ async def test_park_merges_permission_preflight_onto_identifier_default(
 ) -> None:
     """A parked write with a registered permission preflight stores its banner.
 
-    G0.20-T4 (#1504): a credential-class write has no preview (suppressed),
-    but its capability-only permission preflight still runs and is merged
-    under ``proposed_effect["permission_preflight"]`` — so the reviewer
-    sees "this write will be denied" at park time, alongside the
-    identifier-only default (op identity is preserved).
+    G0.20-T4 (#1504): the capability-only permission preflight runs and is
+    merged under ``proposed_effect["permission_preflight"]`` — so the
+    reviewer sees "this write will be denied" at park time. Since #1856,
+    a non-credential write with no bespoke builder also carries the
+    generic params-echo default, so the preflight rides on the
+    ``{op_class, params_echo}`` base rather than the bare identifier
+    default; the banner is present either way.
     """
     from meho_backplane.db.models import ApprovalRequest
     from meho_backplane.operations._preview import (
@@ -2204,10 +2206,10 @@ async def test_park_merges_permission_preflight_onto_identifier_default(
         async with sessionmaker() as fresh:
             row = await fresh.get(ApprovalRequest, approval_request_id)
             assert row is not None
-            # Identifier default is preserved, with the preflight merged in.
-            assert row.proposed_effect["op_id"] == "vault.kv.preflight_op"
-            assert row.proposed_effect["connector_id"] == "vault-1.x"
-            assert row.proposed_effect["target_id"] == str(target.id)
+            # Generic params-echo base (#1856) carries the op identity via
+            # op_class + the echoed params; the preflight is merged in.
+            assert row.proposed_effect["op_class"] == "other"
+            assert row.proposed_effect["params_echo"] == {"path": "meho/test/x"}
             preflight = row.proposed_effect["permission_preflight"]
             assert preflight["will_be_denied"] is True
             assert preflight["required"] == ["create", "update"]

--- a/backend/tests/test_operations_preview.py
+++ b/backend/tests/test_operations_preview.py
@@ -155,16 +155,133 @@ async def test_k8s_apply_preview_none_without_connector() -> None:
 
 
 @pytest.mark.asyncio
-async def test_no_builder_op_yields_none() -> None:
-    """An op without a registered builder parks with no preview."""
+async def test_no_builder_credential_class_op_yields_none() -> None:
+    """A credential-class op with no builder still parks with no preview.
+
+    Since #1856 a no-builder op gets the generic params-echo default, but
+    the credential-class suppression runs *first*: ``vault.kv.put`` is
+    ``credential_write``, so it collapses to the identifier-only default
+    (caller fallback) rather than echoing its (secret-bearing) params.
+    """
     ctx = PreviewContext(
         descriptor=_FakeDescriptor(op_id="vault.kv.put"),  # type: ignore[arg-type]
         connector_instance=None,
         operator=_operator(),
         target=_FakeTarget(),
-        params={"path": "secret/data/x"},
+        params={"path": "secret/data/x", "data": {"k": "v"}},
     )
     assert await build_proposed_effect(ctx) is None
+
+
+@pytest.mark.asyncio
+async def test_no_builder_op_echoes_params() -> None:
+    """A non-credential op with no builder echoes its params (#1856).
+
+    Every approval-gated op gets param-level legibility for free: the
+    requested params land under a ``params_echo`` envelope key (distinct
+    from a computed ``preview``) tagged with the op's sensitivity class.
+    """
+    ctx = PreviewContext(
+        descriptor=_FakeDescriptor(op_id="keycloak.realm.update"),  # type: ignore[arg-type]
+        connector_instance=None,
+        operator=_operator(),
+        target=_FakeTarget(),
+        connector_id="keycloak-1.x",
+        params={"realm": "master", "displayName": "Master Realm", "enabled": True},
+    )
+    effect = await build_proposed_effect(ctx)
+    assert effect == {
+        "op_class": "write",
+        "params_echo": {
+            "realm": "master",
+            "displayName": "Master Realm",
+            "enabled": True,
+        },
+    }
+
+
+@pytest.mark.asyncio
+async def test_no_builder_op_empty_params_yields_none() -> None:
+    """Empty params collapse to the identifier-only default (no echo).
+
+    An empty params dict carries no more legibility than the bare
+    identifier default, so the generic echo declines (returns ``None``)
+    rather than storing an empty ``params_echo``.
+    """
+    ctx = PreviewContext(
+        descriptor=_FakeDescriptor(op_id="keycloak.realm.update"),  # type: ignore[arg-type]
+        connector_instance=None,
+        operator=_operator(),
+        target=_FakeTarget(),
+        connector_id="keycloak-1.x",
+        params={},
+    )
+    assert await build_proposed_effect(ctx) is None
+
+
+@pytest.mark.asyncio
+async def test_no_builder_echo_scrubs_secret_param_keys() -> None:
+    """The generic echo scrubs secret-by-name params (#1856 redaction).
+
+    The connector-boundary engine matches secret *value* shapes but walks
+    a params Mapping key-by-key without inspecting the key, so a
+    structured ``{"password": "hunter2"}`` would otherwise echo verbatim.
+    The key-name scrub closes that gap -- recursively, including nested
+    dicts and lists -- while leaving non-secret params legible.
+    """
+    ctx = PreviewContext(
+        descriptor=_FakeDescriptor(op_id="keycloak.user.update"),  # type: ignore[arg-type]
+        connector_instance=None,
+        operator=_operator(),
+        target=_FakeTarget(),
+        connector_id="keycloak-1.x",
+        params={
+            "username": "alice",
+            "password": "hunter2",
+            "client_secret": "s3cr3t",
+            "profile": {"email": "alice@example.com", "token": "raw-token-value"},
+            "credentials": [{"type": "password", "value": "nested-secret"}],
+        },
+    )
+    effect = await build_proposed_effect(ctx)
+    assert effect is not None
+    echo = effect["params_echo"]
+    # Non-secret params stay legible.
+    assert echo["username"] == "alice"
+    assert echo["profile"]["email"] == "alice@example.com"
+    # Secret-by-name params are masked, including nested keys + the whole
+    # ``credentials`` subtree.
+    assert echo["password"] == "***REDACTED***"
+    assert echo["client_secret"] == "***REDACTED***"
+    assert echo["profile"]["token"] == "***REDACTED***"
+    assert echo["credentials"] == "***REDACTED***"
+
+
+@pytest.mark.asyncio
+async def test_no_builder_echo_scrubs_secret_value_shapes() -> None:
+    """The generic echo runs the connector-boundary value-shape scrub too.
+
+    A JWT in an *un*-credential-named param (so the key-name scrub misses
+    it) is still caught by the connector-boundary redaction engine -- the
+    same pipeline the response path and the dispatch-request preview use.
+    """
+    # Built by concatenation so the literal never forms a single
+    # high-entropy token the secret scanner flags (it is a fake fixture).
+    jwt = "eyJhbGciOiJIUzI1NiJ9" + "." + "eyJzdWIiOiIxMjM0NTY3ODkwIn0" + "." + "abcdefghij"
+    ctx = PreviewContext(
+        descriptor=_FakeDescriptor(op_id="keycloak.user.update"),  # type: ignore[arg-type]
+        connector_instance=None,
+        operator=_operator(),
+        target=_FakeTarget(),
+        connector_id="keycloak-1.x",
+        params={"username": "alice", "note": jwt},
+    )
+    effect = await build_proposed_effect(ctx)
+    assert effect is not None
+    echo = effect["params_echo"]
+    assert echo["username"] == "alice"
+    # The raw JWT never lands verbatim in the durable row.
+    assert jwt not in str(echo["note"])
 
 
 @pytest.mark.asyncio

--- a/docs/codebase/approvals.md
+++ b/docs/codebase/approvals.md
@@ -311,14 +311,24 @@ The per-op preview is opt-in via a builder registry in
   operator + target + params.
 - At the park point, `dispatcher._handle_needs_approval` resolves the
   connector instance (same path the execute branch uses) and calls
-  `build_proposed_effect`. The result — wrapped as
+  `build_proposed_effect`. A bespoke builder's result — wrapped as
   `{op_class, preview}` — is passed to `create_pending_request` as
-  `proposed_effect`; `None` falls back to the identifier-only default.
+  `proposed_effect`; an op with no bespoke builder gets the **generic
+  params-echo default** (`{op_class, params_echo}`, see invariant 1);
+  `None` falls back to the identifier-only default.
 
 Three invariants make the hook safe to wire on the park path:
 
-1. **Opt-in / no regression.** An op with no registered builder yields
-   `None` and parks exactly as before.
+1. **Generic echo default, opt-in bespoke builder (#1856).** An op
+   *without* a registered builder no longer yields `None` — it gets a
+   **generic params-echo default**: the requested params are echoed under
+   a `params_echo` envelope key (distinct from a computed `preview`),
+   redaction-safe (see invariant 3), so every approval-gated op
+   (keycloak, nsx, sddc, vcfa, …) gets param-level legibility for free
+   instead of showing the approver only `{op_id, connector_id,
+   target_id}`. A registered builder still wins (no double-echo). The
+   identifier-only default is reached only when the op is credential-class
+   (suppressed), its params are empty, or a registered builder declines.
 2. **Fail-soft, never silent.** A builder that raises (a dry-run that
    hits the API and errors, a preview listing read that can't execute)
    never blocks the park — the safety-relevant action always proceeds.
@@ -335,10 +345,21 @@ Three invariants make the hook safe to wire on the park path:
 3. **Redaction-safe.** `build_proposed_effect` classifies the op via
    `classify_op` (the same single-sourced sensitivity classification used
    for broadcast/audit redaction, #1401) and **suppresses** the preview
-   for any credential class (`credential_read` / `credential_mint` /
-   `credential_write`) before the builder even runs — a durable row
-   never carries secret material. Builders are themselves expected to
-   return identity-only summaries.
+   (bespoke *and* generic) for any credential class (`credential_read` /
+   `credential_mint` / `credential_write`) — the suppression check runs
+   first, before the builder lookup — so a credential-class op never
+   surfaces request/response detail in a durable row. Builders are
+   themselves expected to return identity-only summaries. The generic
+   params-echo default (#1856) scrubs the echoed params with **two**
+   passes that reuse the existing redaction discipline:
+   `_scrub_secret_param_keys` masks values keyed by a well-known
+   credential name (`password` / `client_secret` / `token` / … —
+   recursively, since the connector-boundary engine walks Mappings
+   key-by-key without inspecting the *key*), then
+   `apply_connector_boundary_redaction` (the same per-`(connector_id,
+   tenant, op)` pipeline the response path and the dispatch-request
+   preview run) catches secret *value* shapes (JWTs, bearer tokens,
+   kubeconfig blobs, labelled `key=value` strings in a single leaf).
 
 The only builder wired in #1437 is **`k8s.apply`**: it re-invokes the
 `k8s_apply` handler with `dry_run="server"` forced on (the API's


### PR DESCRIPTION
## Summary
- Add a **generic params-echo default** to `build_proposed_effect`: an approval-gated op with no bespoke preview builder now echoes its requested params under a `params_echo` envelope key instead of falling back to the identifier-only default. Every connector outside k8s/vmware/argocd (keycloak, nsx, sddc, vcfa, …) gets param-level legibility for free.
- The echo is **redaction-safe** via two passes reusing the existing discipline: a key-name scrub (`_scrub_secret_param_keys`) masks values keyed by a well-known credential name — the connector-boundary engine walks Mappings key-by-key without inspecting the *key*, so a structured `{"password": "..."}` would otherwise slip through — then `apply_connector_boundary_redaction` (the same per-`(connector_id, tenant, op)` pipeline the response path and the dispatch-request preview run) catches secret *value* shapes (JWTs, bearer tokens, kubeconfig).
- **Credential-class suppression now runs first**, before the builder lookup, so it gates the generic echo too; ops in `_SENSITIVE_CLASSES` stay suppressed. Empty params collapse to the identifier-only default. Ops with a bespoke builder keep using it (no double-echo).
- `PreviewContext` gains an optional `connector_id` so the echo can resolve the per-connector redaction policy — keeps the extension points clean for the keycloak-aware builder (#1857, depends on this).

## Test plan
- [x] `ruff check` / `ruff format --check` — clean
- [x] `mypy src/meho_backplane/operations/{_preview,dispatcher}.py` — clean
- [x] `code-quality.py --diff` — 0 blockers (extracted `_generic_params_echo` to stay under the function-size limit)
- [x] **AC1** — parking a no-builder op surfaces params: `test_no_builder_op_echoes_params`
- [x] **AC2** — secrets scrubbed + credential-class still suppressed: `test_no_builder_echo_scrubs_secret_param_keys`, `test_no_builder_echo_scrubs_secret_value_shapes`, `test_no_builder_credential_class_op_yields_none`
- [x] **AC3** — bespoke builder still wins (no double-echo): existing `test_k8s_apply_preview_*` / vmware composite preview suite pass unchanged
- [x] **AC4** — regression tests for echo + redaction (above) + empty-params decline (`test_no_builder_op_empty_params_yields_none`)
- [x] Updated behavior-change tests: `test_park_merges_permission_preflight_onto_identifier_default` (dispatcher), `test_park_no_builder_ops_use_generic_params_echo` (argocd e2e)
- [x] `pytest -k "preview or proposed_effect or approval or redact"` — 504 passed, 15 skipped

## Out of scope
- Keycloak-aware write preview (#1857, depends on this) — layers a bespoke builder on top of this generic default.
- `safety_level` promotion (#1855, sibling).
- Pre-existing dispatcher function-size warnings (adjacent finding, not agent-introduced).

<!-- auto-implement-issue: fresh, iteration 1 -->

Closes #1856
