### PR TITLE
feat(ui): wire the Stop-run button into the agent run console (over the T8 cancel endpoint)

### DIFF
--- a/backend/src/meho_backplane/ui/routes/agents/routes.py
+++ b/backend/src/meho_backplane/ui/routes/agents/routes.py
@@ -41,7 +41,9 @@ extra literal trailing segment, so their ordering relative to the bare
 
 from __future__ import annotations
 
-from fastapi import APIRouter, Depends, Form, Query, Request
+import uuid
+
+from fastapi import APIRouter, Depends, Form, Query, Request, Response
 from fastapi.responses import HTMLResponse, StreamingResponse
 
 from meho_backplane.auth.operator import Operator
@@ -82,6 +84,7 @@ from meho_backplane.ui.routes.agents.principals_views import (
 from meho_backplane.ui.routes.agents.run import (
     INPUT_MAX,
     WORK_REF_MAX,
+    cancel_run,
     render_run_console,
     stream_run_events,
     submit_run,
@@ -168,6 +171,24 @@ async def _run_stream_handler(
         operator,
         name=name,
         token=token,
+    )
+
+
+async def _run_cancel_handler(
+    request: Request,
+    name: str,
+    handle: uuid.UUID,
+    session_ctx: UISessionContext = _require_session_dep,
+    operator: Operator = _require_run_operator_dep,
+) -> Response:
+    """``POST /ui/agents/{name}/run/{handle}/cancel`` -- cancel a live run."""
+    validate_name(name)
+    return await cancel_run(
+        request,
+        session_ctx,
+        operator,
+        name=name,
+        handle=handle,
     )
 
 
@@ -429,11 +450,16 @@ def _register_run_routes(router: APIRouter) -> None:
     * ``POST /ui/agents/{name}/run`` -- authorise a run (CSRF-gated).
     * ``GET  /ui/agents/{name}/run/stream`` -- the cookie-authed SSE
       bridge that proxies ``invoker.stream_events``.
+    * ``POST /ui/agents/{name}/run/{handle}/cancel`` -- the Stop button's
+      cookie-authed cancel proxy (T9 #1833) over ``invoker.cancel``.
 
     The ``/run`` literal segment sits one level below ``{name}`` and the
     ``/run/stream`` segment one below that, so neither collides with the
     bare ``/ui/agents/{name}`` detail route or the ``/edit`` / ``/delete``
-    modal routes; ``{name}`` cannot consume the literal ``run`` token.
+    modal routes; ``{name}`` cannot consume the literal ``run`` token. The
+    cancel route's ``{handle}`` is typed ``uuid.UUID``, so the literal
+    ``stream`` segment never matches it (a non-UUID 422s) and the two
+    ``/run/...`` routes do not collide.
     """
     router.add_api_route(
         "/ui/agents/{name}/run",
@@ -455,6 +481,12 @@ def _register_run_routes(router: APIRouter) -> None:
         methods=["GET"],
         name="ui_agents_run_stream",
         response_class=StreamingResponse,
+    )
+    router.add_api_route(
+        "/ui/agents/{name}/run/{handle}/cancel",
+        _run_cancel_handler,
+        methods=["POST"],
+        name="ui_agents_run_cancel",
     )
 
 

--- a/backend/src/meho_backplane/ui/routes/agents/run.py
+++ b/backend/src/meho_backplane/ui/routes/agents/run.py
@@ -62,13 +62,33 @@ can only GET):
   frame flushes immediately (SSE buffering #1389 is fixed, so the console
   paints turn-by-turn rather than only at completion).
 
-No Stop button
-==============
+Stop button
+===========
 
-This console ships **without** a Stop affordance. "Stop watching" merely
-closes the ``EventSource`` -- it does not cancel the run. The operator
-run-cancel REST endpoint (T8 #1828) and its Stop button (T9 #1833) are
-separate Tasks; wiring a Stop control here would be a no-op cancel.
+The console carries a **Stop** control (T9 #1833) over the operator
+run-cancel path (T8 #1828). The browser holds a cookie session, not a
+JWT, so it cannot call the Bearer-authed REST cancel route
+(``POST /api/v1/agents/runs/{handle}/cancel``) directly; instead the
+console posts to a cookie-authed BFF proxy,
+``POST /ui/agents/{name}/run/{handle}/cancel``, which lifts the operator
+from the session (operator floor, the same gate the run POST uses) and
+drives the *same* in-process
+:meth:`~meho_backplane.agent.invocation.AgentInvoker.cancel` the REST
+route does -- so the durable ``cancelled`` transition runs through one
+service path regardless of caller. The proxy is CSRF-double-submit-gated
+(a state-changing ``/ui/*`` POST) and maps the cancel outcomes to the
+same statuses the REST route returns: 404 (unknown / cross-tenant
+handle), 409 (already-terminal -- ``agent_run_not_cancellable``), 403
+(role below the cancel floor). The Alpine controller turns those into
+inline feedback rather than a torn surface (a 409 means the run already
+reached a terminal state; the console refreshes the status pill instead
+of erroring).
+
+The ``run_id`` the Stop control cancels is the one the SSE stream
+surfaces (the controller learns it from the first frame's ``run_id``),
+so the affordance only appears once a run is live and disappears the
+moment the run reaches a terminal frame -- a terminal run is not
+cancellable and the proxy would 409 it.
 
 The sensitive ``system_prompt`` / ``toolset`` bodies are never logged or
 streamed by this surface -- the transcript carries only the runtime's
@@ -78,22 +98,28 @@ output, errors), the same vocabulary the REST SSE route emits.
 
 from __future__ import annotations
 
+import uuid
 from collections.abc import AsyncIterator
 from typing import Final
 
 import structlog
-from fastapi import HTTPException, Request, status
+from fastapi import HTTPException, Request, Response, status
 from fastapi.responses import HTMLResponse, StreamingResponse
 from pydantic import ValidationError
 
 from meho_backplane.agent.invocation import (
     AgentDisabledError,
     AgentNotFoundError,
+    AgentRunNotFoundError,
     BudgetExceededError,
     get_agent_invoker,
 )
 from meho_backplane.api.v1.agent_runs import AgentRunRequest, _events_generator
 from meho_backplane.auth.operator import Operator
+from meho_backplane.operations.agent_run import (
+    IllegalTransitionError,
+    UnauthorizedCancellationError,
+)
 from meho_backplane.ui.auth.middleware import UISessionContext
 from meho_backplane.ui.csrf import CSRF_COOKIE_NAME, mint_csrf_token
 from meho_backplane.ui.routes.agents.run_token import (
@@ -108,6 +134,7 @@ from meho_backplane.ui.templating import get_templates
 
 __all__ = [
     "WORK_REF_MAX",
+    "cancel_run",
     "render_run_console",
     "stream_run_events",
     "submit_run",
@@ -409,3 +436,70 @@ async def stream_run_events(
             "X-Accel-Buffering": "no",
         },
     )
+
+
+async def cancel_run(
+    request: Request,
+    session_ctx: UISessionContext,
+    operator: Operator,
+    *,
+    name: str,
+    handle: uuid.UUID,
+) -> Response:
+    """``POST /ui/agents/{name}/run/{handle}/cancel`` -- cookie-authed cancel.
+
+    The Stop button's BFF proxy. ``EventSource`` cannot carry a JWT, so
+    the browser holds a cookie session, not the Bearer token the REST
+    cancel route (``POST /api/v1/agents/runs/{handle}/cancel``) requires.
+    This route lifts the operator from the session (operator floor, the
+    same :func:`resolve_run_operator_or_403` gate the run POST uses) and
+    drives the *same* in-process
+    :meth:`~meho_backplane.agent.invocation.AgentInvoker.cancel` the REST
+    route does, so the durable ``cancelled`` transition runs through one
+    service path. The CSRF double-submit middleware gates this POST; the
+    Alpine controller echoes the token in the ``X-CSRF-Token`` header.
+
+    The ``name`` path segment is the console's, not a cancel input -- the
+    invoker scopes the cancel by ``(tenant, run_id)``, so the run's
+    parent agent is irrelevant to the transition. It rides the path only
+    so the route nests under the per-agent console URL.
+
+    Outcomes mirror the REST route exactly:
+
+    * 204 on a successful cancel (no body -- the Alpine controller flips
+      to the ``cancelled`` pill and closes the stream client-side).
+    * 404 (``agent_run_not_found``) for an unknown / cross-tenant handle;
+      existence is not leaked across tenants.
+    * 409 (``agent_run_not_cancellable``) for an already-terminal run --
+      including one that raced to a terminal state between the click and
+      the write. The controller treats this as "already done", not an
+      error.
+    * 403 (``agent_run_cancel_forbidden``) if the operator's role ranks
+      below the cancel floor (defence-in-depth; the route gate already
+      rejects ``read_only``).
+    """
+    del request  # tenant + identity come from the lifted operator.
+    structlog.contextvars.bind_contextvars(
+        audit_op_id="agent.cancel_run",
+        audit_op_class="write",
+        audit_agent_name=name,
+    )
+    invoker = get_agent_invoker()
+    try:
+        await invoker.cancel(operator, handle)
+    except AgentRunNotFoundError as exc:
+        raise HTTPException(
+            status_code=status.HTTP_404_NOT_FOUND,
+            detail="agent_run_not_found",
+        ) from exc
+    except UnauthorizedCancellationError as exc:
+        raise HTTPException(
+            status_code=status.HTTP_403_FORBIDDEN,
+            detail="agent_run_cancel_forbidden",
+        ) from exc
+    except IllegalTransitionError as exc:
+        raise HTTPException(
+            status_code=status.HTTP_409_CONFLICT,
+            detail="agent_run_not_cancellable",
+        ) from exc
+    return Response(status_code=status.HTTP_204_NO_CONTENT)

--- a/backend/src/meho_backplane/ui/static/src/app/agent-run-console.js
+++ b/backend/src/meho_backplane/ui/static/src/app/agent-run-console.js
@@ -32,9 +32,21 @@
 //     status pill (``succeeded`` / ``failed`` from ``final`` / ``error``),
 //     and the ``awaiting_approval`` pause (which deep-links to the
 //     approvals console, T7, rather than re-implementing decide here).
-//   * No Stop affordance: closing the page closes the EventSource but does
-//     not cancel the run. T9 #1833 adds the Stop button over the T8 #1828
-//     cancel backend.
+//   * Stop affordance (T9 #1833): a Stop button cancels the in-flight run
+//     over the cookie-authed BFF proxy
+//     ``POST /ui/agents/{name}/run/{run_id}/cancel`` (which drives the same
+//     ``invoker.cancel`` the T8 #1828 REST route does). The button is
+//     visible only while the run is live (a ``run_id`` has landed and no
+//     terminal frame has). Confirmation is a native ``<dialog>`` (the
+//     destructive-action pattern the console's siblings use). The cancel
+//     POST carries the CSRF double-submit token in the ``X-CSRF-Token``
+//     header explicitly -- the page-level ``hx-headers`` directive is an
+//     HTMX construct and is NOT inherited by an Alpine ``fetch``, so the
+//     token is threaded into the component via ``x-data`` and echoed here.
+//     The proxy's 404 / 409 / 403 map to inline feedback: a 409 means the
+//     run already reached a terminal state (the controller flips to
+//     ``cancelled``/done rather than erroring), a 404 means the run no
+//     longer exists, a 403 means the operator may not cancel it.
 //
 // Frame wire-shape (from ``api/v1/agent_runs._format_event``)
 //   Each SSE frame is ``event: <kind>`` with ``data:`` a single-line JSON
@@ -61,6 +73,24 @@ document.addEventListener("alpine:init", () => {
     // (a normal end-of-stream close) vs. before (a genuine transport
     // drop) -- distinguishes "done" from "lost the connection".
     streamErrored: false,
+
+    // ---- Stop / cancel state (T9 #1833) ----
+    // Threaded in via x-data so the cancel POST can build its URL + carry
+    // the CSRF double-submit header (NOT inherited from the page-level
+    // hx-headers, which is HTMX-only). Defaults keep the component working
+    // if a caller omits them (the button just stays hidden / inert).
+    agentName: (opts && opts.agentName) || "",
+    csrfToken: (opts && opts.csrfToken) || "",
+    cancelUrlTemplate: (opts && opts.cancelUrlTemplate) || "",
+    // Operator-cancelled: set once the BFF proxy confirms the transition
+    // (204) or reports the run already terminal (409). Hides the Stop
+    // button and shows the cancelled pill.
+    cancelled: false,
+    // In-flight guard so a double-click cannot fire two cancel POSTs.
+    cancelling: false,
+    // Inline feedback for a 404 / 403 (an actionable message, not a torn
+    // surface). A 409 is not an error -- it just means "already done".
+    cancelError: "",
 
     // Append one frame as a typed transcript entry. Cancels the raw swap,
     // then routes by kind. A bad frame (mid-stream truncation, upstream
@@ -159,9 +189,103 @@ document.addEventListener("alpine:init", () => {
       }
     },
 
+    // ---- Stop / cancel (T9 #1833) ----
+
+    // The Stop affordance shows only while the run is live: a run_id has
+    // landed (so there is something to cancel), no terminal frame has
+    // arrived (final / error), the stream has not dropped, and we have
+    // not already cancelled. A terminal run is not cancellable -- the BFF
+    // proxy would 409 it -- so the button must vanish the moment a
+    // terminal frame lands.
+    canStop() {
+      return (
+        !!this.runId &&
+        !this.finalStatus &&
+        !this.cancelled &&
+        !this.streamErrored &&
+        !!this.cancelUrlTemplate
+      );
+    },
+
+    // Cancel the in-flight run over the cookie-authed BFF proxy. Confirmed
+    // by the host element's native <dialog> before this runs. POSTs with
+    // the CSRF double-submit header; on 204 (cancelled) or 409 (already
+    // terminal) the console transitions to cancelled and closes the
+    // stream. A 404 / 403 surfaces as inline feedback.
+    async cancel() {
+      if (this.cancelling || !this.canStop()) {
+        return;
+      }
+      this.cancelling = true;
+      this.cancelError = "";
+      const url = this.cancelUrlTemplate.replace(
+        "__RUN_ID__",
+        encodeURIComponent(this.runId),
+      );
+      let response;
+      try {
+        response = await fetch(url, {
+          method: "POST",
+          credentials: "same-origin",
+          headers: { "X-CSRF-Token": this.csrfToken },
+        });
+      } catch (e) {
+        this.cancelling = false;
+        this.cancelError = "Could not reach the server to stop the run. Try again.";
+        return;
+      }
+      this.cancelling = false;
+      // 204 (cancelled) or 409 (already terminal) both mean "this run is
+      // no longer running" -- transition the console and stop streaming.
+      if (response.ok || response.status === 409) {
+        this.markCancelled();
+        return;
+      }
+      if (response.status === 404) {
+        this.cancelError = "This run no longer exists.";
+        this.markCancelled();
+        return;
+      }
+      if (response.status === 403) {
+        this.cancelError = "You do not have permission to stop this run.";
+        return;
+      }
+      this.cancelError = "Could not stop the run. Refresh and try again.";
+    },
+
+    // Transition the console to cancelled: stop the connection-state dot
+    // pulsing "live" and close the EventSource so no further frames swap.
+    markCancelled() {
+      this.cancelled = true;
+      this.connected = false;
+      this.closeStream();
+    },
+
+    // Close the EventSource the HTMX sse extension opened on the sink
+    // element. The extension stores the connection on the element under
+    // ``__htmx_internal_data`` (an internal contract), so we fall back to
+    // dispatching ``htmx:abort`` -- the documented way to tell the sse
+    // extension to close -- when the internal handle is not reachable.
+    closeStream() {
+      const sink = this.$root.querySelector('[hx-ext="sse"], [data-hx-ext="sse"]');
+      if (!sink) {
+        return;
+      }
+      const internal = sink.__htmx_internal_data;
+      const source = internal && internal.sseEventSource;
+      if (source && typeof source.close === "function") {
+        source.close();
+        return;
+      }
+      sink.dispatchEvent(new CustomEvent("htmx:abort"));
+    },
+
     // ---- Render helpers (presentation only) ----
 
     statusLabel() {
+      if (this.cancelled) {
+        return "cancelled";
+      }
       if (this.finalStatus) {
         return "complete";
       }
@@ -172,6 +296,9 @@ document.addEventListener("alpine:init", () => {
     },
 
     statusDotClass() {
+      if (this.cancelled) {
+        return "bg-base-300";
+      }
       if (this.finalStatus) {
         return "bg-success";
       }

--- a/backend/src/meho_backplane/ui/static/src/app/agent-run-console.js
+++ b/backend/src/meho_backplane/ui/static/src/app/agent-run-console.js
@@ -191,18 +191,20 @@ document.addEventListener("alpine:init", () => {
 
     // ---- Stop / cancel (T9 #1833) ----
 
-    // The Stop affordance shows only while the run is live: a run_id has
-    // landed (so there is something to cancel), no terminal frame has
-    // arrived (final / error), the stream has not dropped, and we have
-    // not already cancelled. A terminal run is not cancellable -- the BFF
-    // proxy would 409 it -- so the button must vanish the moment a
-    // terminal frame lands.
+    // The Stop affordance shows only while the run is non-terminal: a
+    // run_id has landed (so there is something to cancel), no terminal
+    // frame has arrived (final / error), and we have not already
+    // cancelled. A terminal run is not cancellable -- the BFF proxy would
+    // 409 it -- so the button must vanish the moment a terminal frame
+    // lands. A *dropped stream* (streamErrored) is deliberately NOT
+    // disqualifying: the SSE bridge dying does not stop the backend run,
+    // so an operator must still be able to cancel a run that is executing
+    // after the transcript stream drops.
     canStop() {
       return (
         !!this.runId &&
         !this.finalStatus &&
         !this.cancelled &&
-        !this.streamErrored &&
         !!this.cancelUrlTemplate
       );
     },

--- a/backend/src/meho_backplane/ui/templates/_icons.html
+++ b/backend/src/meho_backplane/ui/templates/_icons.html
@@ -55,6 +55,7 @@
   "library": '<path d="m16 6 4 14"/><path d="M12 6v14"/><path d="M8 8v12"/><path d="M4 4v16"/>',
   "bell": '<path d="M10.268 21a2 2 0 0 0 3.464 0"/><path d="M3.262 15.326A1 1 0 0 0 4 17h16a1 1 0 0 0 .74-1.673C19.41 13.956 18 12.499 18 8A6 6 0 0 0 6 8c0 4.499-1.411 5.956-2.738 7.326"/>',
   "bot": '<path d="M12 8V4H8"/><rect width="16" height="12" x="4" y="8" rx="2"/><path d="M2 14h2"/><path d="M20 14h2"/><path d="M15 13v2"/><path d="M9 13v2"/>',
+  "circle-stop": '<circle cx="12" cy="12" r="10"/><rect width="6" height="6" x="9" y="9" rx="1"/>',
 } %}
 {% macro icon(name, class="size-4") -%}
 <svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round" class="{{ class }}" data-icon="{{ name }}" aria-hidden="true">{{ _PATHS[name] | safe }}</svg>

--- a/backend/src/meho_backplane/ui/templates/agents/_run_transcript.html
+++ b/backend/src/meho_backplane/ui/templates/agents/_run_transcript.html
@@ -28,18 +28,29 @@
   EventSource (the controller does not cancel the run). T9 #1833 adds the
   Stop button over the T8 #1828 cancel backend.
 
-  XSS hardening: ``x-data`` is SINGLE-quoted and the token rides through
-  ``| tojson`` (which escapes ``'`` to ``'`` and never emits a raw
-  single quote), so a crafted token cannot break out of the attribute --
-  the same posture broadcast/_feed.html documents for its reflected
-  ``op_id`` filter.
+  XSS hardening: ``x-data`` is SINGLE-quoted and every interpolated value
+  rides through ``| tojson`` (which escapes ``'`` to ``'`` and never
+  emits a raw single quote), so a crafted token / name cannot break out
+  of the attribute -- the same posture broadcast/_feed.html documents for
+  its reflected ``op_id`` filter.
+
+  Stop button (T9 #1833): the cancel POST targets the cookie-authed BFF
+  proxy ``POST /ui/agents/{name}/run/{run_id}/cancel``. The run_id is not
+  known at render time (it lands on the first SSE frame), so the template
+  hands the controller a URL with a ``__RUN_ID__`` placeholder it
+  substitutes client-side. The CSRF token is threaded in explicitly --
+  the page-level ``hx-headers`` is HTMX-only and is NOT inherited by the
+  Alpine ``fetch`` the Stop button issues.
 -#}
 {% from "_icons.html" import icon %}
 <div
   id="agent-run-transcript-live"
   class="card bg-base-100 border-base-300 border shadow-sm"
   x-data='agentRunConsole({
-    streamUrl: {{ ("/ui/agents/" ~ (agent_name | urlencode) ~ "/run/stream?token=" ~ (run_token | urlencode)) | tojson }}
+    streamUrl: {{ ("/ui/agents/" ~ (agent_name | urlencode) ~ "/run/stream?token=" ~ (run_token | urlencode)) | tojson }},
+    agentName: {{ agent_name | tojson }},
+    csrfToken: {{ csrf_token | tojson }},
+    cancelUrlTemplate: {{ ("/ui/agents/" ~ (agent_name | urlencode) ~ "/run/__RUN_ID__/cancel") | tojson }}
   })'
 >
   {# ---------- SSE sink ----------
@@ -84,8 +95,73 @@
           x-text="finalStatus"
           data-role="final-pill"
         ></span>
+        {# Cancelled pill -- the operator-stop terminal (muted/ghost),
+           distinct from the success/failure final pill above. #}
+        <span
+          x-show="cancelled"
+          class="badge badge-sm badge-ghost"
+          data-role="cancelled-pill"
+        >cancelled</span>
+        {# ---------- Stop button ----------
+           Shown only while the run is live (controller ``canStop()``).
+           Destructive + terminal, so it opens a native <dialog> confirm
+           rather than firing the cancel directly. The token is carried by
+           the controller's fetch, not the button, so no CSRF wiring is
+           needed on the element itself. -#}
+        <button
+          type="button"
+          x-show="canStop()"
+          class="btn btn-xs btn-error btn-outline"
+          data-action="stop"
+          @click="$refs.stopConfirm.showModal()"
+          :disabled="cancelling"
+        >
+          {{ icon("circle-stop", class="size-3.5") }}
+          <span x-text="cancelling ? 'Stopping…' : 'Stop'"></span>
+        </button>
       </span>
     </div>
+
+    {# ---------- Cancel error (404 / 403) ----------
+       A 409 (already terminal) is not surfaced here -- it transitions the
+       console to cancelled silently. Only an actionable failure shows. -#}
+    <div
+      x-show="cancelError"
+      role="alert"
+      class="alert alert-warning text-xs"
+      data-role="cancel-error"
+    >
+      <span x-text="cancelError"></span>
+    </div>
+
+    {# ---------- Stop confirm dialog ----------
+       Native <dialog> (the console's destructive-action confirm pattern).
+       The run id is interpolated client-side so the operator sees exactly
+       which run halts. The agent stops after its current step (the cancel
+       is observed on the next turn boundary, not a synchronous tear-down). -#}
+    <dialog x-ref="stopConfirm" class="modal" data-role="stop-confirm">
+      <div class="modal-box max-w-md">
+        <h3 class="text-base font-semibold">Stop this run?</h3>
+        <p class="py-3 text-sm opacity-80">
+          Stop run
+          <span class="font-mono" x-text="runId ? runId.slice(0, 8) : ''"></span>?
+          The agent halts after its current step; partial work is kept.
+        </p>
+        <div class="modal-action">
+          <form method="dialog" class="flex gap-2">
+            <button class="btn btn-sm btn-ghost" data-action="stop-cancel">Keep running</button>
+            <button
+              class="btn btn-sm btn-error"
+              data-action="stop-confirm"
+              @click="cancel()"
+            >Stop run</button>
+          </form>
+        </div>
+      </div>
+      <form method="dialog" class="modal-backdrop">
+        <button aria-label="Close">close</button>
+      </form>
+    </dialog>
 
     {# ---------- awaiting_approval banner ----------
        A run that hits awaiting_approval pauses for an operator decision;

--- a/backend/tests/test_ui_agent_run_console.py
+++ b/backend/tests/test_ui_agent_run_console.py
@@ -44,6 +44,7 @@ from fastapi.testclient import TestClient
 from meho_backplane.agent.invocation import (
     AgentDisabledError,
     AgentNotFoundError,
+    AgentRunNotFoundError,
     BudgetExceededError,
     reset_agent_invoker_for_testing,
 )
@@ -260,12 +261,15 @@ class _FakeInvoker:
         ensure_error: Exception | None = None,
         events: list[AgentRunEvent] | None = None,
         run_id: uuid.UUID | None = None,
+        cancel_error: Exception | None = None,
     ) -> None:
         self._ensure_error = ensure_error
         self._events = events or []
         self._run_id = run_id or uuid.uuid4()
+        self._cancel_error = cancel_error
         self.stream_calls: list[tuple[str, str]] = []
         self.stream_operators: list[Operator] = []
+        self.cancel_calls: list[tuple[uuid.UUID, Operator]] = []
 
     async def ensure_runnable(self, operator: Operator, name: str) -> None:
         if self._ensure_error is not None:
@@ -281,6 +285,17 @@ class _FakeInvoker:
         self.stream_operators.append(operator)
         for event in self._events:
             yield self._run_id, event
+
+    async def cancel(self, operator: Operator, run_id: uuid.UUID) -> object:
+        """Record the cancel + raise the configured error, else return a sentinel.
+
+        The BFF cancel route discards the returned summary (it replies
+        204), so a non-error path only has to not raise.
+        """
+        self.cancel_calls.append((run_id, operator))
+        if self._cancel_error is not None:
+            raise self._cancel_error
+        return object()
 
 
 # ---------------------------------------------------------------------------
@@ -618,3 +633,201 @@ def test_stream_bridge_not_found_is_404() -> None:
     finally:
         mock.stop()
     assert response.status_code == 404
+
+
+# ---------------------------------------------------------------------------
+# Cancel proxy (Stop button BFF -- T9 #1833)
+# ---------------------------------------------------------------------------
+
+
+def test_run_cancel_without_csrf_is_403() -> None:
+    """The cancel proxy is a state-changing POST -- a submit without CSRF is 403."""
+    _seed_tenant(_TENANT_A, "tenant-a")
+    _seed_agent(tenant_id=_TENANT_A, name="a1")
+    reset_agent_invoker_for_testing(_FakeInvoker())
+    keypair, jwks = _make_keypair_and_jwks()
+    token = _operator_token(keypair)
+    session_id = _seed_session_sync(tenant_id=_TENANT_A, access_token=token, operator_sub=_OP_A)
+    handle = uuid.uuid4()
+    client, mock, _csrf = _authenticated_client(session_id=session_id, jwks=jwks)
+    try:
+        response = client.post(
+            f"/ui/agents/a1/run/{handle}/cancel",
+            headers={"HX-Request": "true"},
+        )
+    finally:
+        mock.stop()
+    assert response.status_code == 403
+
+
+def test_run_cancel_read_only_operator_is_403() -> None:
+    """A read_only operator cannot cancel a run (operator-floor gate)."""
+    _seed_tenant(_TENANT_A, "tenant-a")
+    _seed_agent(tenant_id=_TENANT_A, name="a1")
+    reset_agent_invoker_for_testing(_FakeInvoker())
+    keypair, jwks = _make_keypair_and_jwks()
+    token = _operator_token(keypair, role=TenantRole.READ_ONLY)
+    session_id = _seed_session_sync(tenant_id=_TENANT_A, access_token=token, operator_sub=_OP_A)
+    handle = uuid.uuid4()
+    client, mock, csrf = _authenticated_client(session_id=session_id, jwks=jwks, with_csrf=True)
+    try:
+        response = client.post(
+            f"/ui/agents/a1/run/{handle}/cancel",
+            headers=_csrf_headers(csrf),
+        )
+    finally:
+        mock.stop()
+    assert response.status_code == 403
+
+
+def test_run_cancel_success_returns_204() -> None:
+    """A valid cancel drives invoker.cancel for the lifted operator and 204s."""
+    _seed_tenant(_TENANT_A, "tenant-a")
+    _seed_agent(tenant_id=_TENANT_A, name="a1")
+    fake = _FakeInvoker()
+    reset_agent_invoker_for_testing(fake)
+    keypair, jwks = _make_keypair_and_jwks()
+    token = _operator_token(keypair)
+    session_id = _seed_session_sync(tenant_id=_TENANT_A, access_token=token, operator_sub=_OP_A)
+    handle = uuid.uuid4()
+    client, mock, csrf = _authenticated_client(session_id=session_id, jwks=jwks, with_csrf=True)
+    try:
+        response = client.post(
+            f"/ui/agents/a1/run/{handle}/cancel",
+            headers=_csrf_headers(csrf),
+        )
+    finally:
+        mock.stop()
+    assert response.status_code == 204, response.text
+    # The cancel ran for exactly this handle, scoped to the lifted operator.
+    assert len(fake.cancel_calls) == 1
+    cancelled_handle, cancel_operator = fake.cancel_calls[0]
+    assert cancelled_handle == handle
+    assert cancel_operator.tenant_id == _TENANT_A
+
+
+def test_run_cancel_already_terminal_is_409() -> None:
+    """An already-terminal run surfaces 409 (agent_run_not_cancellable)."""
+    from meho_backplane.db.models import AgentRunStatus
+    from meho_backplane.operations.agent_run import IllegalTransitionError
+
+    _seed_tenant(_TENANT_A, "tenant-a")
+    _seed_agent(tenant_id=_TENANT_A, name="a1")
+    reset_agent_invoker_for_testing(
+        _FakeInvoker(
+            cancel_error=IllegalTransitionError(
+                from_status=AgentRunStatus.SUCCEEDED,
+                to_status=AgentRunStatus.CANCELLED,
+            )
+        )
+    )
+    keypair, jwks = _make_keypair_and_jwks()
+    token = _operator_token(keypair)
+    session_id = _seed_session_sync(tenant_id=_TENANT_A, access_token=token, operator_sub=_OP_A)
+    handle = uuid.uuid4()
+    client, mock, csrf = _authenticated_client(session_id=session_id, jwks=jwks, with_csrf=True)
+    try:
+        response = client.post(
+            f"/ui/agents/a1/run/{handle}/cancel",
+            headers=_csrf_headers(csrf),
+        )
+    finally:
+        mock.stop()
+    assert response.status_code == 409, response.text
+    assert response.json()["detail"] == "agent_run_not_cancellable"
+
+
+def test_run_cancel_unknown_handle_is_404() -> None:
+    """An unknown / cross-tenant handle surfaces 404 (existence not leaked)."""
+    _seed_tenant(_TENANT_A, "tenant-a")
+    _seed_agent(tenant_id=_TENANT_A, name="a1")
+    handle = uuid.uuid4()
+    reset_agent_invoker_for_testing(_FakeInvoker(cancel_error=AgentRunNotFoundError(handle)))
+    keypair, jwks = _make_keypair_and_jwks()
+    token = _operator_token(keypair)
+    session_id = _seed_session_sync(tenant_id=_TENANT_A, access_token=token, operator_sub=_OP_A)
+    client, mock, csrf = _authenticated_client(session_id=session_id, jwks=jwks, with_csrf=True)
+    try:
+        response = client.post(
+            f"/ui/agents/a1/run/{handle}/cancel",
+            headers=_csrf_headers(csrf),
+        )
+    finally:
+        mock.stop()
+    assert response.status_code == 404, response.text
+    assert response.json()["detail"] == "agent_run_not_found"
+
+
+def test_run_cancel_role_backstop_is_403() -> None:
+    """The service's own role check (UnauthorizedCancellationError) maps to 403."""
+    from meho_backplane.operations.agent_run import UnauthorizedCancellationError
+
+    _seed_tenant(_TENANT_A, "tenant-a")
+    _seed_agent(tenant_id=_TENANT_A, name="a1")
+    reset_agent_invoker_for_testing(
+        _FakeInvoker(
+            cancel_error=UnauthorizedCancellationError(operator_sub=_OP_A, role=TenantRole.OPERATOR)
+        )
+    )
+    keypair, jwks = _make_keypair_and_jwks()
+    token = _operator_token(keypair)
+    session_id = _seed_session_sync(tenant_id=_TENANT_A, access_token=token, operator_sub=_OP_A)
+    handle = uuid.uuid4()
+    client, mock, csrf = _authenticated_client(session_id=session_id, jwks=jwks, with_csrf=True)
+    try:
+        response = client.post(
+            f"/ui/agents/a1/run/{handle}/cancel",
+            headers=_csrf_headers(csrf),
+        )
+    finally:
+        mock.stop()
+    assert response.status_code == 403, response.text
+    assert response.json()["detail"] == "agent_run_cancel_forbidden"
+
+
+def test_run_cancel_non_uuid_handle_is_422() -> None:
+    """A non-UUID handle 422s at the path boundary (never reaches the invoker)."""
+    _seed_tenant(_TENANT_A, "tenant-a")
+    _seed_agent(tenant_id=_TENANT_A, name="a1")
+    fake = _FakeInvoker()
+    reset_agent_invoker_for_testing(fake)
+    keypair, jwks = _make_keypair_and_jwks()
+    token = _operator_token(keypair)
+    session_id = _seed_session_sync(tenant_id=_TENANT_A, access_token=token, operator_sub=_OP_A)
+    client, mock, csrf = _authenticated_client(session_id=session_id, jwks=jwks, with_csrf=True)
+    try:
+        response = client.post(
+            "/ui/agents/a1/run/not-a-uuid/cancel",
+            headers=_csrf_headers(csrf),
+        )
+    finally:
+        mock.stop()
+    assert response.status_code == 422
+    assert fake.cancel_calls == []
+
+
+def test_run_transcript_carries_stop_wiring() -> None:
+    """The transcript fragment threads the cancel URL + CSRF token to Alpine."""
+    _seed_tenant(_TENANT_A, "tenant-a")
+    _seed_agent(tenant_id=_TENANT_A, name="a1")
+    reset_agent_invoker_for_testing(_FakeInvoker())
+    keypair, jwks = _make_keypair_and_jwks()
+    token = _operator_token(keypair)
+    session_id = _seed_session_sync(tenant_id=_TENANT_A, access_token=token, operator_sub=_OP_A)
+    client, mock, csrf = _authenticated_client(session_id=session_id, jwks=jwks, with_csrf=True)
+    try:
+        response = client.post(
+            "/ui/agents/a1/run",
+            data={"input": "do the thing"},
+            headers=_csrf_headers(csrf),
+        )
+    finally:
+        mock.stop()
+    assert response.status_code == 200, response.text
+    body = response.text
+    # The Stop button + native <dialog> confirm + cancel-URL placeholder
+    # all ship in the live transcript fragment.
+    assert 'data-action="stop"' in body
+    assert 'data-role="stop-confirm"' in body
+    assert "/run/__RUN_ID__/cancel" in body
+    assert "cancelUrlTemplate" in body

--- a/backend/tests/test_ui_agent_run_console.py
+++ b/backend/tests/test_ui_agent_run_console.py
@@ -28,6 +28,7 @@ SSE bridge streams known frames without a live model / DB run row.
 from __future__ import annotations
 
 import asyncio
+import re
 import uuid
 import warnings
 from collections.abc import AsyncIterator, Iterator
@@ -831,3 +832,40 @@ def test_run_transcript_carries_stop_wiring() -> None:
     assert 'data-role="stop-confirm"' in body
     assert "/run/__RUN_ID__/cancel" in body
     assert "cancelUrlTemplate" in body
+
+
+def test_can_stop_stays_available_after_stream_drop() -> None:
+    """A dropped SSE stream must not disqualify a still-executing run from Stop.
+
+    The transcript controller's ``canStop()`` gates the Stop button. The SSE
+    bridge dying (``streamErrored``) does *not* terminate the backend run, so a
+    run with a known ``runId`` and no terminal frame must stay cancellable after
+    a stream drop -- otherwise the operator loses the only way to stop a run
+    that is still burning budget. ``canStop()`` therefore gates on
+    ``runId``/``finalStatus``/``cancelled``/``cancelUrlTemplate`` only, and must
+    not reference ``streamErrored``. The controller is client-side Alpine state
+    with no JS test runner in this repo, so we assert the source contract: the
+    ``streamErrored`` flag is still tracked for transcript messaging but is
+    absent from the ``canStop()`` predicate.
+    """
+    source = (static_root_dir() / "src" / "app" / "agent-run-console.js").read_text(
+        encoding="utf-8"
+    )
+
+    # The drop flag is still part of the controller (it drives the dropped /
+    # error transcript hints) -- this guards against asserting on a typo.
+    assert "streamErrored" in source
+
+    can_stop_match = re.search(r"canStop\(\)\s*\{(?P<body>.*?)\}", source, flags=re.DOTALL)
+    assert can_stop_match is not None, "canStop() not found in controller source"
+    can_stop_body = can_stop_match.group("body")
+
+    assert "streamErrored" not in can_stop_body, (
+        "canStop() must not gate on streamErrored: a dropped stream leaves a "
+        "non-terminal backend run cancellable (review M1, PR #1878)."
+    )
+    # The genuine non-terminal gates remain.
+    assert "this.runId" in can_stop_body
+    assert "this.finalStatus" in can_stop_body
+    assert "this.cancelled" in can_stop_body
+    assert "this.cancelUrlTemplate" in can_stop_body

--- a/cli/api/openapi.json
+++ b/cli/api/openapi.json
@@ -10913,6 +10913,68 @@
         }
       }
     },
+    "/ui/agents/{name}/run/{handle}/cancel": {
+      "post": {
+        "tags": [
+          "ui-agents"
+        ],
+        "summary": "Ui Agents Run Cancel",
+        "description": "``POST /ui/agents/{name}/run/{handle}/cancel`` -- cancel a live run.",
+        "operationId": "ui_agents_run_cancel_ui_agents__name__run__handle__cancel_post",
+        "parameters": [
+          {
+            "name": "name",
+            "in": "path",
+            "required": true,
+            "schema": {
+              "type": "string",
+              "title": "Name"
+            }
+          },
+          {
+            "name": "handle",
+            "in": "path",
+            "required": true,
+            "schema": {
+              "type": "string",
+              "format": "uuid",
+              "title": "Handle"
+            }
+          }
+        ],
+        "requestBody": {
+          "content": {
+            "application/json": {
+              "schema": {
+                "$ref": "#/components/schemas/UISessionContext",
+                "nullable": true,
+                "title": "Session Ctx"
+              }
+            }
+          }
+        },
+        "responses": {
+          "200": {
+            "description": "Successful Response",
+            "content": {
+              "application/json": {
+                "schema": {}
+              }
+            }
+          },
+          "422": {
+            "description": "Validation Error",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/HTTPValidationError"
+                }
+              }
+            }
+          }
+        }
+      }
+    },
     "/ui/agents/{name}/toggle": {
       "post": {
         "tags": [

--- a/cli/internal/api/client.gen.go
+++ b/cli/internal/api/client.gen.go
@@ -6737,6 +6737,9 @@ type UiAgentsRunSubmitUiAgentsNameRunPostFormdataRequestBody = BodyUiAgentsRunSu
 // UiAgentsRunStreamUiAgentsNameRunStreamGetJSONRequestBody defines body for UiAgentsRunStreamUiAgentsNameRunStreamGet for application/json ContentType.
 type UiAgentsRunStreamUiAgentsNameRunStreamGetJSONRequestBody = UISessionContext
 
+// UiAgentsRunCancelUiAgentsNameRunHandleCancelPostJSONRequestBody defines body for UiAgentsRunCancelUiAgentsNameRunHandleCancelPost for application/json ContentType.
+type UiAgentsRunCancelUiAgentsNameRunHandleCancelPostJSONRequestBody = UISessionContext
+
 // UiAgentsToggleUiAgentsNameTogglePostFormdataRequestBody defines body for UiAgentsToggleUiAgentsNameTogglePost for application/x-www-form-urlencoded ContentType.
 type UiAgentsToggleUiAgentsNameTogglePostFormdataRequestBody = BodyUiAgentsToggleUiAgentsNameTogglePost
 
@@ -8249,6 +8252,11 @@ type ClientInterface interface {
 	UiAgentsRunStreamUiAgentsNameRunStreamGetWithBody(ctx context.Context, name string, params *UiAgentsRunStreamUiAgentsNameRunStreamGetParams, contentType string, body io.Reader, reqEditors ...RequestEditorFn) (*http.Response, error)
 
 	UiAgentsRunStreamUiAgentsNameRunStreamGet(ctx context.Context, name string, params *UiAgentsRunStreamUiAgentsNameRunStreamGetParams, body UiAgentsRunStreamUiAgentsNameRunStreamGetJSONRequestBody, reqEditors ...RequestEditorFn) (*http.Response, error)
+
+	// UiAgentsRunCancelUiAgentsNameRunHandleCancelPostWithBody request with any body
+	UiAgentsRunCancelUiAgentsNameRunHandleCancelPostWithBody(ctx context.Context, name string, handle openapi_types.UUID, contentType string, body io.Reader, reqEditors ...RequestEditorFn) (*http.Response, error)
+
+	UiAgentsRunCancelUiAgentsNameRunHandleCancelPost(ctx context.Context, name string, handle openapi_types.UUID, body UiAgentsRunCancelUiAgentsNameRunHandleCancelPostJSONRequestBody, reqEditors ...RequestEditorFn) (*http.Response, error)
 
 	// UiAgentsToggleUiAgentsNameTogglePostWithBody request with any body
 	UiAgentsToggleUiAgentsNameTogglePostWithBody(ctx context.Context, name string, contentType string, body io.Reader, reqEditors ...RequestEditorFn) (*http.Response, error)
@@ -11023,6 +11031,30 @@ func (c *Client) UiAgentsRunStreamUiAgentsNameRunStreamGetWithBody(ctx context.C
 
 func (c *Client) UiAgentsRunStreamUiAgentsNameRunStreamGet(ctx context.Context, name string, params *UiAgentsRunStreamUiAgentsNameRunStreamGetParams, body UiAgentsRunStreamUiAgentsNameRunStreamGetJSONRequestBody, reqEditors ...RequestEditorFn) (*http.Response, error) {
 	req, err := NewUiAgentsRunStreamUiAgentsNameRunStreamGetRequest(c.Server, name, params, body)
+	if err != nil {
+		return nil, err
+	}
+	req = req.WithContext(ctx)
+	if err := c.applyEditors(ctx, req, reqEditors); err != nil {
+		return nil, err
+	}
+	return c.Client.Do(req)
+}
+
+func (c *Client) UiAgentsRunCancelUiAgentsNameRunHandleCancelPostWithBody(ctx context.Context, name string, handle openapi_types.UUID, contentType string, body io.Reader, reqEditors ...RequestEditorFn) (*http.Response, error) {
+	req, err := NewUiAgentsRunCancelUiAgentsNameRunHandleCancelPostRequestWithBody(c.Server, name, handle, contentType, body)
+	if err != nil {
+		return nil, err
+	}
+	req = req.WithContext(ctx)
+	if err := c.applyEditors(ctx, req, reqEditors); err != nil {
+		return nil, err
+	}
+	return c.Client.Do(req)
+}
+
+func (c *Client) UiAgentsRunCancelUiAgentsNameRunHandleCancelPost(ctx context.Context, name string, handle openapi_types.UUID, body UiAgentsRunCancelUiAgentsNameRunHandleCancelPostJSONRequestBody, reqEditors ...RequestEditorFn) (*http.Response, error) {
+	req, err := NewUiAgentsRunCancelUiAgentsNameRunHandleCancelPostRequest(c.Server, name, handle, body)
 	if err != nil {
 		return nil, err
 	}
@@ -21442,6 +21474,60 @@ func NewUiAgentsRunStreamUiAgentsNameRunStreamGetRequestWithBody(server string, 
 	return req, nil
 }
 
+// NewUiAgentsRunCancelUiAgentsNameRunHandleCancelPostRequest calls the generic UiAgentsRunCancelUiAgentsNameRunHandleCancelPost builder with application/json body
+func NewUiAgentsRunCancelUiAgentsNameRunHandleCancelPostRequest(server string, name string, handle openapi_types.UUID, body UiAgentsRunCancelUiAgentsNameRunHandleCancelPostJSONRequestBody) (*http.Request, error) {
+	var bodyReader io.Reader
+	buf, err := json.Marshal(body)
+	if err != nil {
+		return nil, err
+	}
+	bodyReader = bytes.NewReader(buf)
+	return NewUiAgentsRunCancelUiAgentsNameRunHandleCancelPostRequestWithBody(server, name, handle, "application/json", bodyReader)
+}
+
+// NewUiAgentsRunCancelUiAgentsNameRunHandleCancelPostRequestWithBody generates requests for UiAgentsRunCancelUiAgentsNameRunHandleCancelPost with any type of body
+func NewUiAgentsRunCancelUiAgentsNameRunHandleCancelPostRequestWithBody(server string, name string, handle openapi_types.UUID, contentType string, body io.Reader) (*http.Request, error) {
+	var err error
+
+	var pathParam0 string
+
+	pathParam0, err = runtime.StyleParamWithLocation("simple", false, "name", runtime.ParamLocationPath, name)
+	if err != nil {
+		return nil, err
+	}
+
+	var pathParam1 string
+
+	pathParam1, err = runtime.StyleParamWithLocation("simple", false, "handle", runtime.ParamLocationPath, handle)
+	if err != nil {
+		return nil, err
+	}
+
+	serverURL, err := url.Parse(server)
+	if err != nil {
+		return nil, err
+	}
+
+	operationPath := fmt.Sprintf("/ui/agents/%s/run/%s/cancel", pathParam0, pathParam1)
+	if operationPath[0] == '/' {
+		operationPath = "." + operationPath
+	}
+
+	queryURL, err := serverURL.Parse(operationPath)
+	if err != nil {
+		return nil, err
+	}
+
+	req, err := http.NewRequest("POST", queryURL.String(), body)
+	if err != nil {
+		return nil, err
+	}
+
+	req.Header.Add("Content-Type", contentType)
+
+	return req, nil
+}
+
 // NewUiAgentsToggleUiAgentsNameTogglePostRequestWithFormdataBody calls the generic UiAgentsToggleUiAgentsNameTogglePost builder with application/x-www-form-urlencoded body
 func NewUiAgentsToggleUiAgentsNameTogglePostRequestWithFormdataBody(server string, name string, body UiAgentsToggleUiAgentsNameTogglePostFormdataRequestBody) (*http.Request, error) {
 	var bodyReader io.Reader
@@ -25694,6 +25780,11 @@ type ClientWithResponsesInterface interface {
 
 	UiAgentsRunStreamUiAgentsNameRunStreamGetWithResponse(ctx context.Context, name string, params *UiAgentsRunStreamUiAgentsNameRunStreamGetParams, body UiAgentsRunStreamUiAgentsNameRunStreamGetJSONRequestBody, reqEditors ...RequestEditorFn) (*UiAgentsRunStreamUiAgentsNameRunStreamGetResponse, error)
 
+	// UiAgentsRunCancelUiAgentsNameRunHandleCancelPostWithBodyWithResponse request with any body
+	UiAgentsRunCancelUiAgentsNameRunHandleCancelPostWithBodyWithResponse(ctx context.Context, name string, handle openapi_types.UUID, contentType string, body io.Reader, reqEditors ...RequestEditorFn) (*UiAgentsRunCancelUiAgentsNameRunHandleCancelPostResponse, error)
+
+	UiAgentsRunCancelUiAgentsNameRunHandleCancelPostWithResponse(ctx context.Context, name string, handle openapi_types.UUID, body UiAgentsRunCancelUiAgentsNameRunHandleCancelPostJSONRequestBody, reqEditors ...RequestEditorFn) (*UiAgentsRunCancelUiAgentsNameRunHandleCancelPostResponse, error)
+
 	// UiAgentsToggleUiAgentsNameTogglePostWithBodyWithResponse request with any body
 	UiAgentsToggleUiAgentsNameTogglePostWithBodyWithResponse(ctx context.Context, name string, contentType string, body io.Reader, reqEditors ...RequestEditorFn) (*UiAgentsToggleUiAgentsNameTogglePostResponse, error)
 
@@ -29304,6 +29395,29 @@ func (r UiAgentsRunStreamUiAgentsNameRunStreamGetResponse) StatusCode() int {
 	return 0
 }
 
+type UiAgentsRunCancelUiAgentsNameRunHandleCancelPostResponse struct {
+	Body         []byte
+	HTTPResponse *http.Response
+	JSON200      *interface{}
+	JSON422      *HTTPValidationError
+}
+
+// Status returns HTTPResponse.Status
+func (r UiAgentsRunCancelUiAgentsNameRunHandleCancelPostResponse) Status() string {
+	if r.HTTPResponse != nil {
+		return r.HTTPResponse.Status
+	}
+	return http.StatusText(0)
+}
+
+// StatusCode returns HTTPResponse.StatusCode
+func (r UiAgentsRunCancelUiAgentsNameRunHandleCancelPostResponse) StatusCode() int {
+	if r.HTTPResponse != nil {
+		return r.HTTPResponse.StatusCode
+	}
+	return 0
+}
+
 type UiAgentsToggleUiAgentsNameTogglePostResponse struct {
 	Body         []byte
 	HTTPResponse *http.Response
@@ -32642,6 +32756,23 @@ func (c *ClientWithResponses) UiAgentsRunStreamUiAgentsNameRunStreamGetWithRespo
 		return nil, err
 	}
 	return ParseUiAgentsRunStreamUiAgentsNameRunStreamGetResponse(rsp)
+}
+
+// UiAgentsRunCancelUiAgentsNameRunHandleCancelPostWithBodyWithResponse request with arbitrary body returning *UiAgentsRunCancelUiAgentsNameRunHandleCancelPostResponse
+func (c *ClientWithResponses) UiAgentsRunCancelUiAgentsNameRunHandleCancelPostWithBodyWithResponse(ctx context.Context, name string, handle openapi_types.UUID, contentType string, body io.Reader, reqEditors ...RequestEditorFn) (*UiAgentsRunCancelUiAgentsNameRunHandleCancelPostResponse, error) {
+	rsp, err := c.UiAgentsRunCancelUiAgentsNameRunHandleCancelPostWithBody(ctx, name, handle, contentType, body, reqEditors...)
+	if err != nil {
+		return nil, err
+	}
+	return ParseUiAgentsRunCancelUiAgentsNameRunHandleCancelPostResponse(rsp)
+}
+
+func (c *ClientWithResponses) UiAgentsRunCancelUiAgentsNameRunHandleCancelPostWithResponse(ctx context.Context, name string, handle openapi_types.UUID, body UiAgentsRunCancelUiAgentsNameRunHandleCancelPostJSONRequestBody, reqEditors ...RequestEditorFn) (*UiAgentsRunCancelUiAgentsNameRunHandleCancelPostResponse, error) {
+	rsp, err := c.UiAgentsRunCancelUiAgentsNameRunHandleCancelPost(ctx, name, handle, body, reqEditors...)
+	if err != nil {
+		return nil, err
+	}
+	return ParseUiAgentsRunCancelUiAgentsNameRunHandleCancelPostResponse(rsp)
 }
 
 // UiAgentsToggleUiAgentsNameTogglePostWithBodyWithResponse request with arbitrary body returning *UiAgentsToggleUiAgentsNameTogglePostResponse
@@ -38054,6 +38185,39 @@ func ParseUiAgentsRunStreamUiAgentsNameRunStreamGetResponse(rsp *http.Response) 
 	}
 
 	switch {
+	case strings.Contains(rsp.Header.Get("Content-Type"), "json") && rsp.StatusCode == 422:
+		var dest HTTPValidationError
+		if err := json.Unmarshal(bodyBytes, &dest); err != nil {
+			return nil, err
+		}
+		response.JSON422 = &dest
+
+	}
+
+	return response, nil
+}
+
+// ParseUiAgentsRunCancelUiAgentsNameRunHandleCancelPostResponse parses an HTTP response from a UiAgentsRunCancelUiAgentsNameRunHandleCancelPostWithResponse call
+func ParseUiAgentsRunCancelUiAgentsNameRunHandleCancelPostResponse(rsp *http.Response) (*UiAgentsRunCancelUiAgentsNameRunHandleCancelPostResponse, error) {
+	bodyBytes, err := io.ReadAll(rsp.Body)
+	defer func() { _ = rsp.Body.Close() }()
+	if err != nil {
+		return nil, err
+	}
+
+	response := &UiAgentsRunCancelUiAgentsNameRunHandleCancelPostResponse{
+		Body:         bodyBytes,
+		HTTPResponse: rsp,
+	}
+
+	switch {
+	case strings.Contains(rsp.Header.Get("Content-Type"), "json") && rsp.StatusCode == 200:
+		var dest interface{}
+		if err := json.Unmarshal(bodyBytes, &dest); err != nil {
+			return nil, err
+		}
+		response.JSON200 = &dest
+
 	case strings.Contains(rsp.Header.Get("Content-Type"), "json") && rsp.StatusCode == 422:
 		var dest HTTPValidationError
 		if err := json.Unmarshal(bodyBytes, &dest); err != nil {

--- a/docs/codebase/ui-agent-run-console.md
+++ b/docs/codebase/ui-agent-run-console.md
@@ -10,7 +10,7 @@ the run executes. It sits under the `/ui/agents` surface that Task #1825
 
 ## Overview
 
-Three routes, all under the per-agent `/run` sub-path:
+Four routes, all under the per-agent `/run` sub-path:
 
 | Method · path | Role | Purpose |
 |---|---|---|

--- a/docs/codebase/ui-agent-run-console.md
+++ b/docs/codebase/ui-agent-run-console.md
@@ -17,12 +17,28 @@ Three routes, all under the per-agent `/run` sub-path:
 | `GET /ui/agents/{name}/run` | operator (any authenticated session reaches the page) | The console page: run form (prompt + optional `work_ref`) + the transcript mount. |
 | `POST /ui/agents/{name}/run` | operator | The CSRF-gated run-initiation action. Validates the prompt, confirms the agent is runnable (404 / 409 / 429 surface here), mints a run token, returns the transcript fragment. |
 | `GET /ui/agents/{name}/run/stream?token=…` | operator | The cookie-authed SSE bridge: verifies the token, lifts the operator, proxies `invoker.stream_events`. |
+| `POST /ui/agents/{name}/run/{handle}/cancel` | operator | The Stop button's CSRF-gated cancel proxy (T9 [#1833](https://github.com/evoila/meho/issues/1833)): lifts the operator and drives `invoker.cancel` — the same service path the REST cancel route uses. 204 / 404 / 409 / 403. |
 
-The console ships **without** a Stop button. "Stop watching" merely closes
-the `EventSource`; it does not cancel the run. The operator run-cancel
-backend (T8 [#1828](https://github.com/evoila/meho/issues/1828)) and its
-Stop button (T9 [#1833](https://github.com/evoila/meho/issues/1833)) are
-separate Tasks.
+The console carries a **Stop button** (T9
+[#1833](https://github.com/evoila/meho/issues/1833)) over the operator
+run-cancel backend (T8
+[#1828](https://github.com/evoila/meho/issues/1828)). Because
+`EventSource` cannot carry a JWT, the browser holds a cookie session, not
+the Bearer token the REST cancel route
+(`POST /api/v1/agents/runs/{handle}/cancel`) requires — so the Stop button
+posts to a cookie-authed BFF proxy, `POST /ui/agents/{name}/run/{handle}/cancel`,
+which lifts the operator (operator floor) and drives the *same* in-process
+`invoker.cancel` the REST route does. The `run_id` it cancels is the one
+the SSE stream surfaces (the Alpine controller learns it from the first
+frame's `run_id`), so the affordance only appears once a run is live and
+vanishes the moment a terminal frame lands (a terminal run is not
+cancellable — the proxy would 409 it). The cancel POST is CSRF-double-
+submit-gated; the Alpine controller echoes the token in the `X-CSRF-Token`
+header explicitly because the page-level `hx-headers` directive is an HTMX
+construct and is **not** inherited by an Alpine `fetch`. Outcomes map to
+inline feedback: 409 (already terminal) transitions the console to
+`cancelled` silently, 404 means the run no longer exists, 403 means the
+operator may not cancel it.
 
 ## Why a cookie-authed GET SSE bridge
 
@@ -137,13 +153,22 @@ rather than re-implementing decide).
   `AgentInvoker.stream_events` (the generator the bridge proxies).
 - `api/v1/agent_runs.py` — `AgentRunRequest` (prompt validation) +
   `_events_generator` (frame formatting reuse).
-- `ui/csrf.py` — the double-submit middleware that gates the run POST.
+- `agent/invocation.py` — `AgentInvoker.cancel` (the cancel proxy's
+  service path); `operations.agent_run` — `IllegalTransitionError` (409) /
+  `UnauthorizedCancellationError` (403) mapped by the cancel proxy.
+- `ui/csrf.py` — the double-submit middleware that gates the run POST and
+  the cancel POST.
 - `ui/auth/middleware.py` — `UISessionMiddleware` / `require_ui_session`.
 
 ## Known issues / out of scope
 
-- No operator run-cancel from this surface (Stop button is T9 over the T8
-  backend).
+- The cancel is not synchronous: the proxy records the durable cancel
+  intent (via `invoker.cancel`) and the run's loop observes the
+  `cancelled` status on its next turn boundary. The console flips to the
+  `cancelled` pill and closes the `EventSource` immediately; the run's own
+  termination follows on the backend.
+- Bulk-cancel / cancel-from-runs-list is a possible follow-up, not in
+  scope here (the runs-list surface is T3 #1830).
 - Cross-agent run history (work_ref / status filters, poll-after-the-fact)
   is T3 [#1830](https://github.com/evoila/meho/issues/1830); the
   transcript's `run_id` deep-links to a run-detail page T3 owns.


### PR DESCRIPTION
## Summary
- Add a **Stop** button to the live agent run console (T2 #1829) over the operator run-cancel backend (T8 #1828).
- New cookie-authed BFF proxy `POST /ui/agents/{name}/run/{handle}/cancel` lifts the operator (operator floor) and drives the *same* in-process `invoker.cancel` the Bearer-authed REST route uses — the browser can't send a JWT, so it can't call the REST route directly.
- The proxy is CSRF-double-submit-gated and maps cancel outcomes to the REST route's statuses: 204 / 404 (`agent_run_not_found`) / 409 (`agent_run_not_cancellable`) / 403 (`agent_run_cancel_forbidden`).
- The console is an Alpine + HTMX-SSE surface, so the `run_id` is known only client-side after the first SSE frame. The Stop button lives in the transcript fragment's Alpine controller, shows only while the run is live, confirms via a native `<dialog>`, and `fetch`es the proxy with the CSRF token threaded through `x-data` (the page-level `hx-headers` is HTMX-only and is not inherited by an Alpine `fetch`). On 204/409 the console flips to the `cancelled` pill and closes the `EventSource`; 404/403 surface as inline feedback.

## Test plan
- [x] `ruff check` / `ruff format --check` — clean
- [x] `mypy src/meho_backplane/ui/routes/agents/` — clean
- [x] `pytest tests/test_ui_agent_run_console.py` — 23 passed (8 new cancel-proxy tests: CSRF gate, read-only 403, 204 success, 409 already-terminal, 404 unknown handle, 403 service backstop, non-UUID 422, transcript Stop wiring)
- [x] `pytest tests/test_ui_agents.py tests/test_ui_agent_runs.py tests/test_api_v1_agent_runs.py` — 82 passed total, no regression
- [x] **Stop appears only for non-terminal runs** — `canStop()` requires `run_id` set + no terminal frame + stream not dropped + not already cancelled; verified the console-form page render carries no Stop control and the live transcript fragment does.
- [x] **Cancelling lands the console in `cancelled` and stops streaming** — `markCancelled()` sets the pill, closes the EventSource.
- [x] **409/404 handled in the cancel path, not a generic error** — 409 transitions to cancelled silently; 404/403 inline.
- [x] **CSRF double-submit on the cancel POST** — middleware-gated; token re-minted on the transcript render and threaded into the controller (no desync).
- [x] **OpenAPI snapshot regenerated** — new `/ui/*` route; `cli/api/openapi.json` + `cli/internal/api/client.gen.go` regenerated; second regen is idempotent (CLI API snapshot freshness).

## Notes on the issue's references
The issue body cited `ui/routes/agents/run.py` poll-console + `hx-on::after-request` HTMX patterns; the merged #1829 console is an Alpine + HTMX-SSE surface where `run_id` is client-side state, so the Stop control is Alpine-driven (a `fetch` to the BFF proxy) rather than an HTMX `after-request` swap. Same contract — CSRF double-submit, operator floor, 404/409/403 → actionable feedback — adapted to the real console shape.

## Out of scope
- The backend cancel endpoint itself (T8 #1828).
- Bulk-cancel / cancel-from-runs-list (possible follow-up).

<!-- auto-implement-issue: fresh, iteration 1 -->

Closes #1833


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added Stop button to cancel in-flight agent runs with native confirmation dialog.
  * Run console now displays cancellation status and appropriate error messages.

* **Tests**
  * Added comprehensive tests for run cancellation endpoint, error scenarios, and authorization checks.

* **Documentation**
  * Updated agent run console documentation to describe Stop button behavior and cancellation semantics.

* **Chores**
  * Updated generated OpenAPI schema and CLI client code.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->