### PR TITLE
fix(connectors): best-effort datastore.usage VM enrichment + structured sub-op errors (#1908)

### DIFF
--- a/backend/src/meho_backplane/connectors/vmware_rest/composites/_read.py
+++ b/backend/src/meho_backplane/connectors/vmware_rest/composites/_read.py
@@ -85,6 +85,7 @@ from meho_backplane.connectors.vmware_rest.composites._preflight import (
 from meho_backplane.operations.composite import DispatchChild
 
 __all__ = [
+    "CompositeSubOpError",
     "cluster_drs_recommendations_composite",
     "datastore_usage_composite",
     "event_tail_composite",
@@ -181,21 +182,104 @@ def _unwrap_value(payload: Any) -> Any:
     return payload
 
 
+def _describe_sub_op_failure(result: OperationResult) -> str:
+    """Render the most diagnostic line a failed sub-op result carries.
+
+    The dispatcher's structured-error builders (``operations/_errors.py``)
+    put different fields on a sub-op's ``extras`` depending on the failure
+    class:
+
+    * An upstream ``403`` / ``422`` / ``401`` / ``440`` lands a structured
+      ``http_status`` plus the upstream's own ``upstream_message`` -- the
+      single most useful diagnostic line.
+    * Every other upstream status (``400``, ``404``, ``5xx`` ...) falls
+      through to the generic ``connector_error`` builder, which keeps the
+      stringified ``httpx.HTTPStatusError`` -- ``"Client error '400 Bad
+      Request' for url 'https://.../api/vcenter/vm?filter.datastores=...'"``
+      -- under ``exception_message``. That string already carries the
+      status code *and* the offending URL, so surfacing it is what the
+      ``filter.datastores`` 400 (#1908) needed.
+
+    Prefer the structured ``http_status`` + ``upstream_message`` when the
+    builder extracted them; otherwise fall back to the capped
+    ``exception_message``; otherwise the bare ``error`` summary. The detail
+    is appended to ``error`` only when it adds information beyond it.
+    """
+    extras = result.extras
+    http_status = extras.get("http_status")
+    upstream_message = extras.get("upstream_message")
+    detail = extras.get("exception_message")
+    parts: list[str] = []
+    if result.error:
+        parts.append(result.error)
+    if http_status is not None:
+        status_clause = f"HTTP {http_status}"
+        if isinstance(upstream_message, str) and upstream_message.strip():
+            status_clause = f"{status_clause}: {upstream_message}"
+        parts.append(status_clause)
+    elif isinstance(detail, str) and detail.strip() and detail != result.error:
+        parts.append(detail)
+    if not parts:
+        parts.append("<no error message>")
+    return " -- ".join(parts)
+
+
+class CompositeSubOpError(RuntimeError):
+    """A composite sub-op returned a non-OK :class:`OperationResult`.
+
+    Raised by :func:`_require_ok` when a *load-bearing* sub-op fails (the
+    datastore listing, a per-datastore detail read, an event/perf query).
+    The dispatcher's outer exception branch wraps the raised exception
+    into a ``connector_error`` :class:`OperationResult` for the composite
+    parent (``operations/_errors.py::result_connector_error``), which
+    records ``type(exc).__name__`` and the capped ``str(exc)`` under the
+    parent's ``extras``.
+
+    The pre-#1908 shape raised a bare :class:`RuntimeError` whose message
+    stopped at ``status='error'`` plus the sub-op's terse ``error``
+    summary (``connector_error: HTTPStatusError``) -- the actual status
+    code and offending URL only showed when the operator replayed the
+    sub-op by hand. This class threads the sub-op's structured failure
+    (``op_id`` / ``status`` / ``error`` / ``extras``) through as
+    attributes *and* folds the most diagnostic line
+    (:func:`_describe_sub_op_failure` -- a structured ``http_status`` +
+    upstream message, or the stringified ``HTTPStatusError`` carrying the
+    status + URL) into ``str(self)`` so it lands in the composite parent's
+    ``extras["exception_message"]`` rather than being lost.
+
+    The ``returned status='<status>'`` clause is preserved verbatim so
+    existing consumers that string-match it keep working.
+    """
+
+    def __init__(self, result: OperationResult) -> None:
+        self.op_id = result.op_id
+        self.status = result.status
+        self.sub_op_error = result.error
+        self.sub_op_extras = dict(result.extras)
+        super().__init__(
+            f"composite sub-op {result.op_id!r} returned status="
+            f"{result.status!r}: {_describe_sub_op_failure(result)}"
+        )
+
+
 def _require_ok(result: OperationResult) -> Any:
     """Return :attr:`OperationResult.result` or raise on a non-OK status.
 
-    The composite handlers prefer to fail loudly when a sub-op errors
-    -- a swallowed error would silently produce a malformed
-    aggregation. The dispatcher's outer exception branch wraps the
-    raised ``RuntimeError`` into a ``connector_error``
+    The composite handlers fail loudly when a *load-bearing* sub-op errors
+    -- a swallowed error would silently produce a malformed aggregation.
+    The dispatcher's outer exception branch wraps the raised
+    :class:`CompositeSubOpError` into a ``connector_error``
     :class:`OperationResult` for the composite parent, surfacing the
-    underlying sub-op's failure on ``extras["exception_class"]``.
+    underlying sub-op's failure (status code + URL where the sub-op
+    carried them) on ``extras["exception_message"]``.
+
+    Optional enrichment legs (e.g. the per-datastore VM-placement lookup
+    in :func:`datastore_usage_composite`) must NOT route through this
+    helper -- they degrade best-effort instead of sinking the whole
+    composite.
     """
     if result.status != "ok":
-        raise RuntimeError(
-            f"composite sub-op {result.op_id!r} returned status="
-            f"{result.status!r}: {result.error or '<no error message>'}"
-        )
+        raise CompositeSubOpError(result)
     return result.result
 
 
@@ -419,10 +503,11 @@ async def performance_summary_composite(
 
 
 # Pre-existing >100-line handler from G3.1-T5 #508; G0.14-T10 #1151
-# added a 6-line pre-flight call at the top, pushing the diff-only
-# checker into block territory. Refactor is out of scope for T10
-# (the L2-dependency strategy).
-# code-quality-allow: pre-existing G3.1-T5 #508 handler, T10 added preflight only
+# added a 6-line pre-flight call at the top and G0.27 #1908 made the
+# per-datastore VM-placement leg best-effort -- both extend an already
+# block-sized handler. Refactor (e.g. extracting the per-datastore row
+# builder) is out of scope here.
+# code-quality-allow: pre-existing G3.1-T5 #508 handler; #1908 best-effort enrichment only
 async def datastore_usage_composite(
     *,
     operator: Operator,
@@ -440,10 +525,19 @@ async def datastore_usage_composite(
        narrowed via ``filter.names``).
     2. For each datastore:
        a. ``GET:/vcenter/datastore/{datastore}`` -- detailed capacity /
-          free / type / accessible flag.
+          free / type / accessible flag (load-bearing: a failure here
+          sinks the composite).
        b. ``GET:/vcenter/vm`` with ``filter.datastores`` -- VMs whose
           working directory sits on this datastore. Drives the
-          ``vm_count`` + ``vm_names`` aggregation.
+          ``vm_count`` + ``vm_names`` aggregation. This leg is
+          **best-effort** (#1908): the capacity/free/type read -- the
+          data the "which datastores are filling up?" use case needs --
+          is already done by the time it runs, so when the VM lookup
+          errors (e.g. a vCenter that rejects the ``filter.datastores``
+          query with a 400) the row is still returned with
+          ``vm_count`` / ``vm_names`` set to ``null`` and an
+          ``enrichment_note`` recording why, rather than failing the
+          whole composite.
 
     Sequential dispatch is intentional: each datastore's detail call
     inherits the prior call's authentication state, and the audit
@@ -460,7 +554,11 @@ async def datastore_usage_composite(
         "capacity": ..., "free_space": ..., "vm_count": ...,
         "vm_names": [...]}, ...]}``. The ``capacity`` / ``free_space``
         fields may be ``None`` if the upstream payload omits them
-        (e.g. a partially-mounted datastore).
+        (e.g. a partially-mounted datastore). When the per-datastore
+        VM-placement enrichment errors, ``vm_count`` and ``vm_names``
+        are ``None`` and the row carries an ``enrichment_note`` string
+        describing the skipped enrichment; on success the row has no
+        ``enrichment_note`` key.
     """
     await preflight_l2_dependencies(
         composite_op_id=_COMPOSITE_OP_ID_DATASTORE_USAGE,
@@ -506,32 +604,47 @@ async def datastore_usage_composite(
             )
         )
         detail_payload = _unwrap_value(detail)
-        vms = _require_ok(
-            await dispatch_child(
-                connector_id=_CONNECTOR_ID,
-                op_id=_OP_LIST_VMS,
-                params={"filter.datastores": [ds_id]},
-            )
-        )
-        vm_entries = _unwrap_value(vms)
-        if not isinstance(vm_entries, list):
-            vm_entries = []
-        vm_names = [
-            v["name"] for v in vm_entries if isinstance(v, dict) and isinstance(v.get("name"), str)
-        ]
         capacity = detail_payload.get("capacity") if isinstance(detail_payload, dict) else None
         free_space = detail_payload.get("free_space") if isinstance(detail_payload, dict) else None
-        aggregated.append(
-            {
-                "id": ds_id,
-                "name": entry.get("name"),
-                "type": entry.get("type"),
-                "capacity": capacity,
-                "free_space": free_space,
-                "vm_count": len(vm_names),
-                "vm_names": vm_names,
-            }
+        row: dict[str, Any] = {
+            "id": ds_id,
+            "name": entry.get("name"),
+            "type": entry.get("type"),
+            "capacity": capacity,
+            "free_space": free_space,
+        }
+
+        # VM-placement enrichment is best-effort (#1908). The
+        # capacity/free/type read above already satisfies the
+        # storage-usage use case, so a failure on the optional VM lookup
+        # (e.g. a vCenter that 400s the ``filter.datastores`` query)
+        # nulls vm_count/vm_names and records why, rather than raising
+        # through ``_require_ok`` and sinking every datastore row.
+        vms_result = await dispatch_child(
+            connector_id=_CONNECTOR_ID,
+            op_id=_OP_LIST_VMS,
+            params={"filter.datastores": [ds_id]},
         )
+        if vms_result.status == "ok":
+            vm_entries = _unwrap_value(vms_result.result)
+            if not isinstance(vm_entries, list):
+                vm_entries = []
+            vm_names = [
+                v["name"]
+                for v in vm_entries
+                if isinstance(v, dict) and isinstance(v.get("name"), str)
+            ]
+            row["vm_count"] = len(vm_names)
+            row["vm_names"] = vm_names
+        else:
+            row["vm_count"] = None
+            row["vm_names"] = None
+            row["enrichment_note"] = (
+                f"vm-placement enrichment skipped: sub-op {_OP_LIST_VMS!r} "
+                f"returned status={vms_result.status!r}: "
+                f"{_describe_sub_op_failure(vms_result)}"
+            )
+        aggregated.append(row)
     return {"datastores": aggregated}
 
 

--- a/backend/src/meho_backplane/connectors/vmware_rest/composites/schemas.py
+++ b/backend/src/meho_backplane/connectors/vmware_rest/composites/schemas.py
@@ -425,14 +425,31 @@ DATASTORE_USAGE_RESPONSE_SCHEMA: dict[str, Any] = {
                         ),
                     },
                     "vm_count": {
-                        "type": "integer",
+                        "type": ["integer", "null"],
                         "minimum": 0,
-                        "description": "Number of VMs placed on this datastore.",
+                        "description": (
+                            "Number of VMs placed on this datastore; ``null`` when "
+                            "the best-effort VM-placement enrichment was skipped "
+                            "because its sub-call errored (see ``enrichment_note``)."
+                        ),
                     },
                     "vm_names": {
-                        "type": "array",
+                        "type": ["array", "null"],
                         "items": {"type": "string"},
-                        "description": "Names of VMs placed on this datastore.",
+                        "description": (
+                            "Names of VMs placed on this datastore; ``null`` when "
+                            "the best-effort VM-placement enrichment was skipped "
+                            "(see ``enrichment_note``)."
+                        ),
+                    },
+                    "enrichment_note": {
+                        "type": "string",
+                        "description": (
+                            "Present only when the VM-placement enrichment was "
+                            "skipped; records the failing sub-op, its status, and "
+                            "the underlying error (status code + URL where the "
+                            "sub-op carried them)."
+                        ),
                     },
                 },
                 "required": ["id", "vm_count", "vm_names"],

--- a/backend/tests/test_connectors_vmware_rest_composites_read.py
+++ b/backend/tests/test_connectors_vmware_rest_composites_read.py
@@ -36,6 +36,7 @@ from meho_backplane.auth.operator import Operator, TenantRole
 from meho_backplane.connectors import OperationResult
 from meho_backplane.connectors.vmware_rest.composites import _preflight
 from meho_backplane.connectors.vmware_rest.composites._read import (
+    CompositeSubOpError,
     cluster_drs_recommendations_composite,
     datastore_usage_composite,
     event_tail_composite,
@@ -164,6 +165,30 @@ def _err_result(op_id: str, error: str) -> OperationResult:
         op_id=op_id,
         error=error,
         duration_ms=1.0,
+    )
+
+
+def _connector_error_result(op_id: str, exception_message: str) -> OperationResult:
+    """Build a generic ``connector_error`` result the dispatcher emits for a 4xx/5xx.
+
+    Mirrors
+    :func:`meho_backplane.operations._errors.result_connector_error`: the
+    terse ``error`` summary plus the stringified ``httpx.HTTPStatusError``
+    (status line + URL) stashed under ``extras["exception_message"]``.
+    This is the exact shape a ``filter.datastores`` 400 (#1908) produces,
+    where the status code + offending URL live only in the
+    ``exception_message`` string (no structured ``http_status``).
+    """
+    return OperationResult(
+        status="error",
+        op_id=op_id,
+        error="connector_error: HTTPStatusError",
+        duration_ms=1.0,
+        extras={
+            "error_code": "connector_error",
+            "exception_class": "HTTPStatusError",
+            "exception_message": exception_message,
+        },
     )
 
 
@@ -550,6 +575,144 @@ async def test_datastore_usage_skips_malformed_listing_entries() -> None:
     # Only the well-formed entry produces sub-ops + a result row.
     assert len(out["datastores"]) == 1
     assert out["datastores"][0]["id"] == "datastore-1"
+
+
+@pytest.mark.asyncio
+async def test_datastore_usage_vm_enrichment_is_best_effort_on_sub_op_error() -> None:
+    """A failed VM-placement sub-op keeps the row; vm_count/vm_names null + note (#1908).
+
+    The capacity/free/type read is load-bearing and has already succeeded
+    by the time the optional ``filter.datastores`` VM lookup runs. When
+    that lookup 400s (the version-skew filter param the issue hit), the
+    datastore row is still returned -- capacity/free/type intact -- with
+    ``vm_count``/``vm_names`` nulled and an ``enrichment_note`` recording
+    why, rather than the whole composite failing.
+    """
+    sequence = [
+        _ok_result(
+            "GET:/vcenter/datastore",
+            [
+                {"datastore": "datastore-1", "name": "ds-1", "type": "VMFS"},
+                {"datastore": "datastore-2", "name": "ds-2", "type": "NFS"},
+            ],
+        ),
+        # datastore-1: detail OK, VM enrichment 400s -> best-effort skip.
+        _ok_result("GET:/vcenter/datastore/{datastore}", {"capacity": 100, "free_space": 40}),
+        _connector_error_result(
+            "GET:/vcenter/vm",
+            "Client error '400 Bad Request' for url "
+            "'https://vc/api/vcenter/vm?filter.datastores=datastore-1'",
+        ),
+        # datastore-2: detail OK, VM enrichment OK -> fully enriched.
+        _ok_result("GET:/vcenter/datastore/{datastore}", {"capacity": 500, "free_space": 250}),
+        _ok_result("GET:/vcenter/vm", [{"name": "vm-c"}]),
+    ]
+    dispatch = _RecordingDispatchChild(sequence)
+    out = await datastore_usage_composite(
+        operator=_make_operator(),
+        target=object(),
+        params={},
+        dispatch_child=dispatch,
+    )
+
+    # All 5 sub-ops fired -- the failed VM leg did not short-circuit.
+    assert len(dispatch.calls) == 5
+    rows = out["datastores"]
+    assert len(rows) == 2
+
+    # datastore-1: core data preserved, enrichment skipped.
+    ds1 = rows[0]
+    assert ds1["id"] == "datastore-1"
+    assert ds1["capacity"] == 100
+    assert ds1["free_space"] == 40
+    assert ds1["type"] == "VMFS"
+    assert ds1["vm_count"] is None
+    assert ds1["vm_names"] is None
+    assert "enrichment_note" in ds1
+    # The note bubbles the sub-op id, its status, the 400, and the URL.
+    note = ds1["enrichment_note"]
+    assert "GET:/vcenter/vm" in note
+    assert "400 Bad Request" in note
+    assert "filter.datastores=datastore-1" in note
+
+    # datastore-2: enriched normally, no note key.
+    ds2 = rows[1]
+    assert ds2["id"] == "datastore-2"
+    assert ds2["vm_count"] == 1
+    assert ds2["vm_names"] == ["vm-c"]
+    assert "enrichment_note" not in ds2
+
+
+@pytest.mark.asyncio
+async def test_datastore_usage_listing_error_bubbles_structured_detail() -> None:
+    """A load-bearing sub-op failure bubbles the sub-op's status code + URL (#1908).
+
+    Suggestion 2: the composite's failure envelope previously stopped at
+    ``connector_error: HTTPStatusError``; the actual 400 + offending URL
+    only showed on a manual replay. The raised
+    :class:`CompositeSubOpError` now folds the sub-op's diagnostic line
+    (status code + URL, from the stringified ``HTTPStatusError``) into its
+    message and exposes the sub-op's structured fields as attributes.
+    """
+    failing = _connector_error_result(
+        "GET:/vcenter/datastore",
+        "Client error '400 Bad Request' for url "
+        "'https://vc/api/vcenter/datastore?filter.names=bogus'",
+    )
+    dispatch = _RecordingDispatchChild([failing])
+    with pytest.raises(CompositeSubOpError) as excinfo:
+        await datastore_usage_composite(
+            operator=_make_operator(),
+            target=object(),
+            params={},
+            dispatch_child=dispatch,
+        )
+    # No per-datastore calls fire after the listing fails.
+    assert len(dispatch.calls) == 1
+    exc = excinfo.value
+    # Backward-compatible substring (existing consumers string-match it).
+    assert "returned status='error'" in str(exc)
+    # The structured detail now rides the message.
+    assert "400 Bad Request" in str(exc)
+    assert "filter.names=bogus" in str(exc)
+    # And the sub-op's structured fields are addressable as attributes.
+    assert exc.op_id == "GET:/vcenter/datastore"
+    assert exc.status == "error"
+    assert exc.sub_op_extras["error_code"] == "connector_error"
+
+
+@pytest.mark.asyncio
+async def test_datastore_usage_bubbles_structured_http_status_when_present() -> None:
+    """When a sub-op carried a structured ``http_status`` (403/422/auth), it bubbles too.
+
+    The generic 4xx path (400/404/5xx) carries the status + URL only in
+    ``exception_message``; the 403/422/401/440 builders instead extract a
+    structured ``http_status`` + ``upstream_message``. The bubble-up
+    prefers the structured form when it is present.
+    """
+    failing = OperationResult(
+        status="error",
+        op_id="GET:/vcenter/datastore",
+        error="connector_http_403: the upstream returned HTTP 403 Forbidden ...",
+        duration_ms=1.0,
+        extras={
+            "error_code": "connector_http_403",
+            "http_status": 403,
+            "upstream_message": "Resource not accessible by integration",
+            "permission_headers": {},
+        },
+    )
+    dispatch = _RecordingDispatchChild([failing])
+    with pytest.raises(CompositeSubOpError) as excinfo:
+        await datastore_usage_composite(
+            operator=_make_operator(),
+            target=object(),
+            params={},
+            dispatch_child=dispatch,
+        )
+    message = str(excinfo.value)
+    assert "HTTP 403" in message
+    assert "Resource not accessible by integration" in message
 
 
 # ---------------------------------------------------------------------------

--- a/docs/codebase/connectors-vmware-rest.md
+++ b/docs/codebase/connectors-vmware-rest.md
@@ -355,6 +355,45 @@ write composites prefer "stop and report" semantics over silent
 rollback -- the operator decides whether to manually finish or
 revert.
 
+### Read-composite best-effort enrichment (`datastore.usage`, #1908)
+
+Read composites distinguish **load-bearing** sub-ops from **optional
+enrichment** sub-ops. A load-bearing failure routes through
+`_require_ok` and raises `CompositeSubOpError`, which the dispatcher
+wraps into a `connector_error` envelope -- the whole composite fails.
+An optional enrichment failure must **not** sink the composite: the
+leg degrades and the rows the core use case needs are still returned.
+
+`datastore.usage` is the canonical example. Its per-datastore layout is
+`GET:/vcenter/datastore` (listing, load-bearing) → per row
+`GET:/vcenter/datastore/{datastore}` (capacity/free/type, load-bearing)
+→ `GET:/vcenter/vm?filter.datastores=...` (VM placement, **best-effort**).
+The "which datastores are filling up?" use case is satisfied by the
+capacity/free/type read, which has already succeeded by the time the VM
+lookup runs. So when the VM lookup errors -- e.g. an 8.0 vCenter that
+400s the `filter.datastores` query the 9.0 spec emits -- the row is
+still returned with `capacity`/`free_space`/`type` intact,
+`vm_count`/`vm_names` set to `null`, and an `enrichment_note` string
+recording the failing sub-op, its status, and the underlying error.
+The response schema marks `vm_count`/`vm_names` as nullable and adds the
+optional `enrichment_note` key (present only on a skipped row).
+
+### Bubbling a sub-op's structured error (#1908)
+
+`CompositeSubOpError` folds the failed sub-op's most diagnostic line
+into its message via `_describe_sub_op_failure`, rather than stopping at
+the terse `error` summary (`connector_error: HTTPStatusError`). The
+helper prefers the structured `http_status` + `upstream_message` the
+dispatcher's 403/422/auth builders extract; for every other status
+(400/404/5xx, routed through the generic `connector_error` builder) it
+falls back to `extras["exception_message"]` -- the stringified
+`httpx.HTTPStatusError`, which already carries the status code **and**
+the offending URL. The same helper feeds `datastore.usage`'s
+`enrichment_note`. Net effect: the 400 + URL that previously only showed
+on a manual sub-op replay now ride the composite's error envelope (or
+the per-row note). The `returned status='<status>'` clause is preserved
+so existing string-matching consumers keep working.
+
 ### Park-time approval previews (#1608)
 
 All 8 write composites ship `requires_approval=True`, so a human/agent


### PR DESCRIPTION
## Summary

- `vmware.composite.datastore.usage` hard-failed when its **optional** per-datastore VM-placement leg (`GET:/vcenter/vm?filter.datastores=...`) errored — e.g. an 8.0 vCenter that 400s the `filter.datastores` param the 9.0 spec emits. The capacity/free/type read the "which datastores are filling up?" use case needs has already succeeded by then, so sinking the whole composite was the wrong tradeoff (#1908 suggestion 1).
- Make the VM-placement enrichment **best-effort**: on a sub-call error the datastore row is still returned with `capacity`/`free_space`/`type` intact, `vm_count`/`vm_names` set to `null`, and a per-row `enrichment_note` recording the failing sub-op + status + underlying error. Load-bearing legs (listing, per-datastore detail) still fail loud. Response schema marks `vm_count`/`vm_names` nullable and adds the optional `enrichment_note` key.
- **Bubble the sub-op's structured error** into the composite envelope (#1908 suggestion 2). `CompositeSubOpError` (raised by `_require_ok`, reused for the note) folds the failed sub-op's most diagnostic line into its message via `_describe_sub_op_failure`: structured `http_status` + `upstream_message` for 403/422/auth, else the stringified `HTTPStatusError` (which carries the status code **and** offending URL) for the generic 4xx/5xx path. Previously the envelope stopped at `connector_error: HTTPStatusError` and the 400 + URL only showed on a manual replay. The `returned status='<status>'` clause is kept verbatim for existing string-matching consumers.

## Test plan

- [x] `ruff check` / `ruff format --check` — clean (3 changed py files)
- [x] `mypy src/.../composites/ --ignore-missing-imports` — clean (7 files)
- [x] `pytest tests/test_connectors_vmware_rest_composites_read.py` — 24 passed (incl. 3 new tests)
- [x] Broad sweep `pytest -k composite` — 213 passed, 2 skipped (vcsim acceptance skips cleanly in sandbox)
- [x] **AC1 best-effort enrichment**: new `test_datastore_usage_vm_enrichment_is_best_effort_on_sub_op_error` — failed VM leg keeps the row (capacity/free/type intact), nulls `vm_count`/`vm_names`, sets `enrichment_note` with the 400 + URL; a sibling datastore enriches normally; all 5 sub-ops fire (no short-circuit).
- [x] **AC2 structured bubbling**: new `test_datastore_usage_listing_error_bubbles_structured_detail` (generic 400 → status + URL in the message; sub-op fields as attributes) and `test_datastore_usage_bubbles_structured_http_status_when_present` (403 → structured `http_status` + upstream message).
- [x] End-to-end handler run with a mixed scenario (one datastore 400s, one succeeds) — core capacity/free report survives, status + URL surfaced.

## Notes

- No OpenAPI/CLI snapshot regen needed: the composite `response_schema` is connector-internal op metadata (op catalog / meta-tools), not part of the FastAPI HTTP OpenAPI surface (`cli/api/openapi.json` carries no `vm_count` / `datastore.usage` response body).
- `docs/codebase/connectors-vmware-rest.md` updated with two new subsections (read-composite best-effort enrichment; bubbling a sub-op's structured error).
- `_require_ok` / `CompositeSubOpError` is the shared chokepoint for all 5 read composites, so the richer error envelope (suggestion 2) applies fleet-wide, not just to `datastore.usage`.

## Out of scope

- The root-cause version skew in the vCenter VM-list filter param (`filter.datastores` rejected by 8.0; unprefixed `datastores=` accepted-but-ignored) — the consumer noted they didn't chase it and it's a separate spec-compat question. This PR makes the curated composite robust across that skew, which is what #1908 asked for.

<!-- auto-implement-issue: fresh, iteration 1 -->

Closes #1908
