### PR TITLE
refactor(conventions): extract ConventionsService from inline route handlers (#1894)

### DIFF
--- a/backend/src/meho_backplane/api/v1/conventions.py
+++ b/backend/src/meho_backplane/api/v1/conventions.py
@@ -9,6 +9,17 @@ substrate (T1 #313). T3 (#315) layers CLI verbs over this
 surface; T4 (#316) layers the session-preamble assembler that
 reads through the same Pydantic shapes.
 
+G10.12-T0 (#1894): the CRUD + budget + history + pre-allocated-
+audit-id logic now lives in
+:class:`~meho_backplane.conventions.service.ConventionsService` so the
+in-process console BFF (T1/T2 #1838) can reuse it without copying the
+handlers. These handlers are a thin HTTP shell: they bind the audit
+contextvars, delegate to the service, and map the service's typed
+error vocabulary (:class:`ConventionNotFoundError` / :class:`ConventionConflictError`
+/ :class:`OverBudgetError`) onto ``HTTPException`` status codes. The
+wire behaviour (status codes, response bodies, audit rows, history
+rows) is identical to the pre-extraction inline implementation.
+
 Routes (all tenant-scoped; cross-tenant probes 404, never 403):
 
 * ``GET ``                              list (``?kind=`` filter, operator)
@@ -33,9 +44,9 @@ bound and exempt.
 Audit row + history row commit in the same transaction. The
 history row's ``audit_id`` soft-FK matches the chassis
 :class:`~meho_backplane.audit.AuditMiddleware` row's ``id`` --
-the handler pre-allocates the uuid via
-:func:`~meho_backplane.audit.bind_preallocated_audit_id` and the
-middleware honours it; G8's audit-query path joins on that
+:class:`~meho_backplane.conventions.service.ConventionsService`
+pre-allocates the uuid (binding it onto the audit contextvar) and
+the middleware honours it; G8's audit-query path joins on that
 soft-FK for forensic queries.
 
 Every route binds ``audit_op_id`` / ``audit_op_class`` /
@@ -46,42 +57,30 @@ classifies correctly even when the handler raises.
 from __future__ import annotations
 
 import uuid
-from datetime import UTC, datetime
 from typing import Annotated, Final
 
 import structlog
 from fastapi import APIRouter, Depends, HTTPException, Path, Query, status
 from fastapi.responses import JSONResponse, Response
-from sqlalchemy import delete as sql_delete
-from sqlalchemy import select
-from sqlalchemy.exc import IntegrityError
 from sqlalchemy.ext.asyncio import AsyncSession
 
-from meho_backplane.audit import bind_preallocated_audit_id
 from meho_backplane.auth.operator import Operator, TenantRole
 from meho_backplane.auth.rbac import require_role
-from meho_backplane.conventions.preamble import (
-    BLOCK_END as _CONVENTIONS_BLOCK_END,
-)
-from meho_backplane.conventions.preamble import (
-    assemble_preamble,
-    assemble_preamble_detailed,
-)
 from meho_backplane.conventions.schemas import (
-    DEFAULT_MAX_PREAMBLE_TOKENS,
-    BudgetStatus,
     Convention,
     ConventionCreate,
     ConventionHistoryEntry,
     ConventionKind,
     ConventionListResponse,
-    ConventionSummary,
     ConventionUpdate,
-    PreambleInclusion,
-    estimate_tokens,
+)
+from meho_backplane.conventions.service import (
+    ConventionConflictError,
+    ConventionNotFoundError,
+    ConventionsService,
+    OverBudgetError,
 )
 from meho_backplane.db.engine import get_session
-from meho_backplane.db.models import TenantConvention, TenantConventionHistory
 from meho_backplane.mcp.server import RESOURCES_SUBSCRIBE_ENABLED
 
 __all__ = ["router"]
@@ -103,6 +102,10 @@ router = APIRouter(prefix="/api/v1/conventions", tags=["conventions"])
 #: :mod:`~meho_backplane.api.v1.broadcast_overrides`.
 _require_operator = Depends(require_role(TenantRole.OPERATOR))
 _require_tenant_admin = Depends(require_role(TenantRole.TENANT_ADMIN))
+
+#: Single service instance -- stateless (no held session / connection),
+#: so one module-level object is safe to share across requests.
+_service = ConventionsService()
 
 
 #: Canonical operation identifiers bound into ``audit_op_id`` per
@@ -127,45 +130,23 @@ _OP_ID_HISTORY: Final[str] = "conventions.history"
 _SLUG_MAX_LENGTH: Final[int] = 128
 
 
-def _conventions_text_only(preamble_text: str) -> str:
-    """Return the conventions text band from a combined preamble string.
+def _not_found() -> HTTPException:
+    """The consistent 404 the tenant-boundary info-leak avoidance requires."""
+    return HTTPException(
+        status_code=status.HTTP_404_NOT_FOUND,
+        detail="convention_not_found",
+    )
 
-    G12.4-T2 (#1316). The assembled preamble may now stitch two text
-    bands: tenant conventions wrapped in
-    ``<<TENANT_CONVENTIONS ... END_TENANT_CONVENTIONS>>`` followed by
-    runbook priming wrapped in
-    ``<<RUNBOOK_PRIMING — CRITICAL>> ... <<END_RUNBOOK_PRIMING>>``,
-    separated by a blank line. The list endpoint's ``budget_status``
-    reports the conventions-band token count only -- priming is
-    bounded by its own implicit cap (``MAX_PRIMING_BLOCKS``) and is
-    not charged to the conventions budget.
 
-    Strategy: slice up to and including the conventions terminator
-    (:data:`~meho_backplane.conventions.preamble.BLOCK_END`); whatever
-    follows is the priming band (or empty). When the preamble carries
-    only priming (no conventions), the terminator is absent and the
-    function returns the empty string -- ``estimate_tokens("") == 0``,
-    so the budget status correctly reports zero conventions weight
-    for a tenant whose preamble is priming-only.
-
-    The slice is a defensive read: it relies only on the wrapper-
-    emitted terminator (never substituted from user content per the
-    positional-wrapper discipline in
-    :mod:`meho_backplane.conventions.preamble`), so a malicious
-    convention body containing the literal terminator string cannot
-    cause the slice to mis-attribute priming text as conventions
-    text.
-    """
-    if not preamble_text:
-        return ""
-    end = preamble_text.find(_CONVENTIONS_BLOCK_END)
-    if end == -1:
-        # No conventions band in the assembled text -- it is
-        # priming-only (operator has runs but tenant has no
-        # operational conventions). The conventions-only weight is
-        # zero.
-        return ""
-    return preamble_text[: end + len(_CONVENTIONS_BLOCK_END)]
+def _over_budget_422(exc: OverBudgetError) -> HTTPException:
+    """Map the service's over-budget error to the 422 the wire contract names."""
+    return HTTPException(
+        status_code=status.HTTP_422_UNPROCESSABLE_CONTENT,
+        detail=(
+            f"convention body exceeds preamble budget "
+            f"(estimated={exc.estimated}, budget={exc.budget})"
+        ),
+    )
 
 
 def _maybe_emit_resource_updated(
@@ -226,234 +207,9 @@ def _maybe_emit_resource_updated(
     )
 
 
-def _enforce_budget(body: str, kind: ConventionKind) -> None:
-    """Raise 422 when an ``operational`` body exceeds the preamble budget.
-
-    The single-entry write-time gate the issue body calls out: a
-    convention whose own token estimate exceeds
-    :data:`DEFAULT_MAX_PREAMBLE_TOKENS` cannot fit the preamble at
-    any priority, so failing the write loudly is the correct
-    response (the alternative is silent drop at every future
-    preamble assembly -- the failure mode the "``kubectl apply
-    --dry-run=server`` discipline" is named for). The check is a
-    no-op for ``workflow`` and ``reference`` conventions (which
-    are not packed into the preamble).
-
-    Detail message names ``estimated`` vs ``budget`` per the
-    acceptance criterion's "detail names estimated vs budget"
-    requirement; the integer values are useful for CLI users
-    rewriting the body to fit.
-    """
-    if kind is not ConventionKind.OPERATIONAL:
-        return
-    estimated = estimate_tokens(body)
-    if estimated > DEFAULT_MAX_PREAMBLE_TOKENS:
-        raise HTTPException(
-            status_code=status.HTTP_422_UNPROCESSABLE_CONTENT,
-            detail=(
-                f"convention body exceeds preamble budget "
-                f"(estimated={estimated}, budget={DEFAULT_MAX_PREAMBLE_TOKENS})"
-            ),
-        )
-
-
-def _resolve_patch_fields(
-    body: ConventionUpdate,
-    existing: TenantConvention,
-) -> tuple[str, str, int]:
-    """Pick post-PATCH ``(title, body, priority)`` honouring v2 set-vs-null.
-
-    Pydantic v2's :attr:`BaseModel.model_fields_set` distinguishes
-    "field absent from JSON" from "field present with null". For
-    each column in the PATCH surface: take the request body's
-    value iff the field was both explicitly set AND non-null;
-    otherwise fall through to the existing column. The type-
-    narrowing yields concrete ``str`` / ``int`` locals so the
-    handler's ORM assignments don't need ``cast`` calls.
-    """
-    explicit = body.model_fields_set
-    title = body.title if "title" in explicit and body.title is not None else existing.title
-    new_body = body.body if "body" in explicit and body.body is not None else existing.body
-    priority = (
-        body.priority if "priority" in explicit and body.priority is not None else existing.priority
-    )
-    return title, new_body, priority
-
-
-def _enforce_patch_budget(
-    body: ConventionUpdate,
-    new_body: str,
-    existing: TenantConvention,
-) -> None:
-    """Run the over-budget 422 gate iff the patch carries a body change.
-
-    Priority-only or title-only PATCHes against an oversize body
-    are intentionally not surfaced: the bug was already there at
-    the prior write; rejecting on an unrelated edit would be
-    confused-deputy behaviour. When ``body`` is in the patch, we
-    validate against the existing kind (PATCH cannot change kind
-    per :class:`ConventionUpdate`). An existing row carrying a
-    kind value outside the closed :class:`ConventionKind`
-    vocabulary (possible per T1's Out of scope on DB-level enum)
-    falls back to :attr:`ConventionKind.REFERENCE` -- the safe
-    direction; reference-kind never triggers the gate.
-    """
-    if "body" not in body.model_fields_set or body.body is None:
-        return
-    try:
-        existing_kind = ConventionKind(existing.kind)
-    except ValueError:
-        existing_kind = ConventionKind.REFERENCE
-    _enforce_budget(new_body, existing_kind)
-
-
-async def _compute_preamble_status(
-    *,
-    session: AsyncSession,
-    tenant_id: uuid.UUID,
-    operator_sub: str,
-    slug: str,
-    kind: ConventionKind,
-) -> PreambleInclusion | None:
-    """Resolve preamble inclusion for the just-written *(tenant, slug)* pair.
-
-    G0.14-T8 (#1149, signal 18). Returns ``None`` for kinds that
-    don't enter the preamble (``workflow`` / ``reference``); a
-    populated :class:`PreambleInclusion` for ``operational`` rows.
-
-    The function runs
-    :func:`~meho_backplane.conventions.preamble.assemble_preamble_detailed`
-    through the route handler's *session* so the pack reflects the
-    in-progress write. SQLAlchemy 2.x reads within the same
-    transaction see flushed-but-not-committed rows, so the caller
-    must :meth:`session.flush` the convention INSERT/UPDATE before
-    calling; the read here will then include it. Threading the
-    route's session through (over opening a new one) means the
-    feedback reflects the same state the post-commit MCP
-    ``initialize`` handler will see -- no risk of an in-flight
-    concurrent write from another request changing the answer
-    mid-response.
-
-    Three reads from the detailed assembly drive the four output
-    fields:
-
-    * ``kept_slugs.index(slug) + 1`` -> ``position`` (1-based, or
-      ``None`` when this slug was dropped).
-    * ``slug in kept_slugs`` -> ``included``.
-    * ``token_counts[slug]`` -> ``token_count`` (own body weight).
-    * ``dropped_slugs`` -> ``would_drop_slugs`` (verbatim).
-
-    The ``slug`` argument is the slug as written (POST: ``body.slug``;
-    PATCH: the path parameter — PATCH cannot rename, so the slug
-    is stable across the update). ``kind`` is the convention's
-    current kind: POST uses the request body's kind; PATCH uses the
-    existing row's kind (PATCH cannot change kind per the
-    :class:`ConventionUpdate` schema).
-
-    G12.4-T2 (#1316) added the *operator_sub* parameter so the
-    assembler can include runbook priming in the assembled preamble
-    -- the post-write preview now reflects exactly what the operator's
-    MCP session receives, priming included. The
-    :class:`PreambleInclusion` projection (``position`` /
-    ``included`` / ``token_count`` / ``would_drop_slugs``) is
-    *conventions-only* -- those fields describe the conventions
-    pack; the priming portion is summarised on the detailed
-    assembly's ``runbook_block_count`` / ``runbook_summarized``
-    fields, which are not surfaced here (the route's
-    :class:`PreambleInclusion` schema is the slug-scoped feedback
-    surface, not a general preamble report).
-    """
-    if kind is not ConventionKind.OPERATIONAL:
-        # ``workflow`` / ``reference`` are not preamble-bound -- a
-        # write against them does not affect the assembled preamble,
-        # so the operator's "did this land in the preamble?" question
-        # doesn't apply. Returning ``None`` (over a stub
-        # ``PreambleInclusion(included=False, ...)``) keeps the
-        # response shape honest: ``preamble_status`` present iff the
-        # write was a preamble-bound one.
-        return None
-    assembly = await assemble_preamble_detailed(
-        tenant_id,
-        operator_sub,
-        session=session,
-    )
-    included = slug in assembly.kept_slugs
-    position = assembly.kept_slugs.index(slug) + 1 if included else None
-    # ``token_counts`` carries every considered slug (kept + dropped);
-    # the just-written slug must appear there because the assembler
-    # ran after the write flushed. The ``get`` fallback is paranoia
-    # against an unforeseen race (e.g. a concurrent DELETE) and
-    # short-circuits to 0 so the response shape still validates.
-    token_count = assembly.token_counts.get(slug, 0)
-    return PreambleInclusion(
-        included=included,
-        position=position,
-        token_count=token_count,
-        would_drop_slugs=assembly.dropped_slugs,
-    )
-
-
-async def _load_convention(
-    *,
-    session: AsyncSession,
-    tenant_id: uuid.UUID,
-    slug: str,
-) -> TenantConvention | None:
-    """Fetch the convention by ``(tenant_id, slug)`` or return ``None``.
-
-    Hits the composite-unique index
-    ``tenant_conventions_tenant_slug_idx`` (per the substrate's
-    declared index discipline) -- one btree probe. ``None`` means
-    "the row does not exist in this operator's tenant"; collapses
-    "wrong tenant" and "wrong slug" into the same return value so
-    the route layer can apply the consistent 404 the tenant
-    boundary's info-leak avoidance requires.
-    """
-    stmt = select(TenantConvention).where(
-        TenantConvention.tenant_id == tenant_id,
-        TenantConvention.slug == slug,
-    )
-    return (await session.execute(stmt)).scalar_one_or_none()
-
-
 # ---------------------------------------------------------------------------
 # GET /api/v1/conventions -- list
 # ---------------------------------------------------------------------------
-
-
-async def _compute_budget_status(operator: Operator) -> BudgetStatus:
-    """Compute the conventions preamble budget for *operator*'s tenant.
-
-    Runs the same :func:`assemble_preamble` primitive T4's MCP
-    ``initialize`` handler uses, so ``estimated_tokens`` on the list
-    response and the preamble actually delivered to agent sessions cannot
-    drift. The assembler opens its own DB session (the MCP ``initialize``
-    path is not a FastAPI request handler), adding one round-trip; that is
-    acceptable for the v0.2 budget contract and the natural unit for "what
-    the preamble actually weighs".
-
-    The ``budget_status`` arithmetic is **conventions-only**:
-    ``estimated_tokens`` measures the conventions band against
-    ``DEFAULT_MAX_PREAMBLE_TOKENS``. The other bands — priming (G12.4-T2
-    #1316, capped by ``MAX_PRIMING_BLOCKS``) and the doc-collection
-    catalogue (G4.6-T4 #1553, its own ``MAX_CATALOGUE_TOKENS``) — are not
-    charged to the conventions budget. The preamble is assembled with both
-    (``sub`` + ``capabilities``) so the list view reflects the exact wire
-    shape MCP ``initialize`` ships, then ``_conventions_text_only`` strips
-    everything after the conventions terminator before measuring — a tenant
-    with zero operational conventions reports ``estimated_tokens=0``
-    regardless of how many runs or entitled collections the operator has.
-    """
-    preamble = await assemble_preamble(
-        operator.tenant_id, operator.sub, capabilities=operator.capabilities
-    )
-    conventions_only_text = _conventions_text_only(preamble.text)
-    return BudgetStatus(
-        max_tokens=DEFAULT_MAX_PREAMBLE_TOKENS,
-        estimated_tokens=estimate_tokens(conventions_only_text),
-        over_budget=bool(preamble.dropped_slugs),
-        dropped_slugs=preamble.dropped_slugs,
-    )
 
 
 @router.get("", response_model=ConventionListResponse)
@@ -499,20 +255,12 @@ async def list_conventions(
         audit_op_id=_OP_ID_LIST,
         audit_op_class="read",
     )
-    stmt = select(TenantConvention).where(
-        TenantConvention.tenant_id == operator.tenant_id,
+    entries, budget_status = await _service.list_conventions(
+        session=session,
+        operator=operator,
+        kind=kind,
     )
-    if kind is not None:
-        stmt = stmt.where(TenantConvention.kind == kind.value)
-    stmt = stmt.order_by(
-        TenantConvention.priority.desc(),
-        TenantConvention.created_at.asc(),
-    )
-    rows = (await session.execute(stmt)).scalars().all()
 
-    budget_status = await _compute_budget_status(operator)
-
-    entries = [ConventionSummary.model_validate(row) for row in rows]
     if envelope == "v2":
         return JSONResponse(
             wrap_v2_envelope(
@@ -549,17 +297,14 @@ async def show_convention(
         audit_op_class="read",
         audit_slug=slug,
     )
-    row = await _load_convention(
-        session=session,
-        tenant_id=operator.tenant_id,
-        slug=slug,
-    )
-    if row is None:
-        raise HTTPException(
-            status_code=status.HTTP_404_NOT_FOUND,
-            detail="convention_not_found",
+    try:
+        return await _service.get_convention(
+            session=session,
+            tenant_id=operator.tenant_id,
+            slug=slug,
         )
-    return Convention.model_validate(row)
+    except ConventionNotFoundError as exc:
+        raise _not_found() from exc
 
 
 # ---------------------------------------------------------------------------
@@ -589,79 +334,24 @@ async def create_convention(
         audit_op_class="write",
         audit_slug=body.slug,
     )
-    _enforce_budget(body.body, body.kind)
-
-    audit_id = uuid.uuid4()
-    bind_preallocated_audit_id(audit_id)
-    now = datetime.now(UTC)
-    convention = TenantConvention(
-        id=uuid.uuid4(),
-        tenant_id=operator.tenant_id,
-        slug=body.slug,
-        title=body.title,
-        body=body.body,
-        kind=body.kind.value,
-        priority=body.priority,
-        created_by_sub=operator.sub,
-        created_at=now,
-        updated_at=now,
-    )
-    history = TenantConventionHistory(
-        id=uuid.uuid4(),
-        convention_id=convention.id,
-        body_before=None,
-        body_after=body.body,
-        actor_sub=operator.sub,
-        ts=now,
-        audit_id=audit_id,
-    )
-    session.add_all([convention, history])
     try:
-        await session.flush()
-    except IntegrityError as exc:
-        # Narrow the 409 to actual composite-unique-index violations
-        # on ``(tenant_id, slug)``; other IntegrityError shapes
-        # (CHECK / NOT NULL violations from a future tightening
-        # migration) propagate so a genuine corruption surfaces as
-        # a 500 rather than a misleading "already exists".
-        #
-        # PG via asyncpg: ``PostgresError.sqlstate == "23505"`` is
-        # the unique-violation code. SQLite: ``UNIQUE constraint
-        # failed`` substring is the documented form. Same shape the
-        # broadcast_overrides router uses for the same purpose.
-        orig = getattr(exc, "orig", None)
-        sqlstate = getattr(orig, "sqlstate", None) or getattr(orig, "pgcode", None)
-        orig_msg = str(orig or exc)
-        is_unique_violation = sqlstate == "23505" or "UNIQUE constraint failed" in orig_msg
-        if is_unique_violation:
-            raise HTTPException(
-                status_code=status.HTTP_409_CONFLICT,
-                detail=f"convention {body.slug!r} already exists",
-            ) from exc
-        raise
-    # Refresh so any DB-side defaults are visible on the returned
-    # row (mirrors the broadcast_overrides + memory surfaces).
-    await session.refresh(convention)
-    # G0.14-T8 (#1149, signal 18) preamble-status feedback.
-    # The convention has flushed inside the route's session (above
-    # at ``session.flush()``); reads through the same session see it,
-    # so the preamble assembler resolves the just-written slug's
-    # position against the post-write state. ``None`` for
-    # workflow/reference (preamble-unbound kinds).
-    preamble_status = await _compute_preamble_status(
-        session=session,
-        tenant_id=operator.tenant_id,
-        operator_sub=operator.sub,
-        slug=body.slug,
-        kind=body.kind,
-    )
+        convention = await _service.create_convention(
+            session=session,
+            operator=operator,
+            body=body,
+        )
+    except OverBudgetError as exc:
+        raise _over_budget_422(exc) from exc
+    except ConventionConflictError as exc:
+        raise HTTPException(
+            status_code=status.HTTP_409_CONFLICT,
+            detail=f"convention {body.slug!r} already exists",
+        ) from exc
     # Conditional MCP resources/updated notification (T4 #316).
     # No-op while ``resources.subscribe`` is False; structured emit
     # call site is in place for the v0.2.next subscribe flip.
     _maybe_emit_resource_updated(tenant_id=operator.tenant_id, slug=body.slug)
-    return Convention.model_validate(convention).model_copy(
-        update={"preamble_status": preamble_status},
-    )
+    return convention
 
 
 # ---------------------------------------------------------------------------
@@ -693,69 +383,22 @@ async def update_convention(
         audit_op_class="write",
         audit_slug=slug,
     )
-
-    existing = await _load_convention(
-        session=session,
-        tenant_id=operator.tenant_id,
-        slug=slug,
-    )
-    if existing is None:
-        raise HTTPException(
-            status_code=status.HTTP_404_NOT_FOUND,
-            detail="convention_not_found",
-        )
-
-    new_title, new_body, new_priority = _resolve_patch_fields(body, existing)
-    _enforce_patch_budget(body, new_body, existing)
-
-    audit_id = uuid.uuid4()
-    bind_preallocated_audit_id(audit_id)
-    now = datetime.now(UTC)
-    body_before = existing.body
-
-    existing.title = new_title
-    existing.body = new_body
-    existing.priority = new_priority
-    existing.updated_at = now
-
-    history = TenantConventionHistory(
-        id=uuid.uuid4(),
-        convention_id=existing.id,
-        body_before=body_before,
-        body_after=new_body,
-        actor_sub=operator.sub,
-        ts=now,
-        audit_id=audit_id,
-    )
-    session.add(history)
-    await session.flush()
-    await session.refresh(existing)
-    # G0.14-T8 (#1149, signal 18) preamble-status feedback. PATCH
-    # cannot change kind per :class:`ConventionUpdate`, so the
-    # post-PATCH kind is the existing row's kind; resolve back to
-    # the enum for the helper. An existing row carrying a kind
-    # outside the closed :class:`ConventionKind` vocabulary
-    # (possible per T1's Out of scope on DB-level enum) falls back
-    # to ``REFERENCE`` -- the safe direction; reference-kind
-    # short-circuits to ``preamble_status=None`` (preamble-unbound).
     try:
-        existing_kind = ConventionKind(existing.kind)
-    except ValueError:
-        existing_kind = ConventionKind.REFERENCE
-    preamble_status = await _compute_preamble_status(
-        session=session,
-        tenant_id=operator.tenant_id,
-        operator_sub=operator.sub,
-        slug=slug,
-        kind=existing_kind,
-    )
+        convention = await _service.update_convention(
+            session=session,
+            operator=operator,
+            slug=slug,
+            body=body,
+        )
+    except ConventionNotFoundError as exc:
+        raise _not_found() from exc
+    except OverBudgetError as exc:
+        raise _over_budget_422(exc) from exc
     # Conditional MCP resources/updated notification (T4 #316).
     # No-op while ``resources.subscribe`` is False; structured emit
     # call site is in place for the v0.2.next subscribe flip.
     _maybe_emit_resource_updated(tenant_id=operator.tenant_id, slug=slug)
-    return Convention.model_validate(existing).model_copy(
-        update={"preamble_status": preamble_status},
-    )
+    return convention
 
 
 # ---------------------------------------------------------------------------
@@ -790,44 +433,14 @@ async def delete_convention(
         audit_op_class="write",
         audit_slug=slug,
     )
-
-    existing = await _load_convention(
-        session=session,
-        tenant_id=operator.tenant_id,
-        slug=slug,
-    )
-    if existing is None:
-        raise HTTPException(
-            status_code=status.HTTP_404_NOT_FOUND,
-            detail="convention_not_found",
+    try:
+        await _service.delete_convention(
+            session=session,
+            operator=operator,
+            slug=slug,
         )
-
-    audit_id = uuid.uuid4()
-    bind_preallocated_audit_id(audit_id)
-    now = datetime.now(UTC)
-    convention_id = existing.id
-
-    history = TenantConventionHistory(
-        id=uuid.uuid4(),
-        convention_id=convention_id,
-        body_before=existing.body,
-        body_after=existing.body,
-        actor_sub=operator.sub,
-        ts=now,
-        audit_id=audit_id,
-    )
-    session.add(history)
-    # Flush the history row before the DELETE -- SQLAlchemy 2.x's
-    # session ordering between pending inserts and deletes is
-    # implementation-defined, and the explicit flush keeps the
-    # row-pair contract T4/T5 expect.
-    await session.flush()
-    await session.execute(
-        sql_delete(TenantConvention).where(
-            TenantConvention.id == convention_id,
-            TenantConvention.tenant_id == operator.tenant_id,
-        ),
-    )
+    except ConventionNotFoundError as exc:
+        raise _not_found() from exc
     # Conditional MCP resources/updated notification (T4 #316).
     # DELETE is also a resource-state change that subscribing
     # clients need to refresh on, per MCP 2025-06-18 §Resources.
@@ -862,22 +475,11 @@ async def list_history(
         audit_op_class="read",
         audit_slug=slug,
     )
-
-    existing = await _load_convention(
-        session=session,
-        tenant_id=operator.tenant_id,
-        slug=slug,
-    )
-    if existing is None:
-        raise HTTPException(
-            status_code=status.HTTP_404_NOT_FOUND,
-            detail="convention_not_found",
+    try:
+        return await _service.list_history(
+            session=session,
+            tenant_id=operator.tenant_id,
+            slug=slug,
         )
-
-    stmt = (
-        select(TenantConventionHistory)
-        .where(TenantConventionHistory.convention_id == existing.id)
-        .order_by(TenantConventionHistory.ts.desc())
-    )
-    rows = (await session.execute(stmt)).scalars().all()
-    return [ConventionHistoryEntry.model_validate(row) for row in rows]
+    except ConventionNotFoundError as exc:
+        raise _not_found() from exc

--- a/backend/src/meho_backplane/conventions/_internal.py
+++ b/backend/src/meho_backplane/conventions/_internal.py
@@ -1,0 +1,180 @@
+# SPDX-License-Identifier: Apache-2.0
+# Copyright (c) 2026 evoila Group
+
+"""Pure helpers + error vocabulary for :class:`ConventionsService`.
+
+G10.12-T0 (#1894). Splits the side-effect-free pieces of the
+conventions service out of :mod:`meho_backplane.conventions.service`
+(mirrors the :mod:`meho_backplane.memory._internal` split): the typed
+error vocabulary the route / BFF map to their transport, the budget
+gate, the conventions-band slicer, and the PATCH set-vs-null
+resolution. None of these touch a DB session -- they operate on
+schemas, strings, and ORM rows already in hand -- so isolating them
+keeps the service module to its class wiring.
+"""
+
+from __future__ import annotations
+
+from meho_backplane.conventions.preamble import BLOCK_END as _CONVENTIONS_BLOCK_END
+from meho_backplane.conventions.schemas import (
+    DEFAULT_MAX_PREAMBLE_TOKENS,
+    ConventionKind,
+    ConventionUpdate,
+    estimate_tokens,
+)
+from meho_backplane.db.models import TenantConvention
+
+__all__ = [
+    "ConventionConflictError",
+    "ConventionNotFoundError",
+    "ConventionServiceError",
+    "OverBudgetError",
+    "conventions_text_only",
+    "enforce_budget",
+    "enforce_patch_budget",
+    "resolve_patch_fields",
+]
+
+
+class ConventionServiceError(Exception):
+    """Base class for the conventions service error vocabulary."""
+
+
+class ConventionNotFoundError(ConventionServiceError):
+    """The ``(tenant_id, slug)`` pair resolves to no row.
+
+    Raised by reads (:meth:`ConventionsService.get_convention`,
+    :meth:`ConventionsService.list_history`) and by the update / delete
+    writes when the target row is absent or belongs to another tenant.
+    The route maps it to 404; collapsing wrong-tenant and wrong-slug
+    into one error preserves the tenant-boundary info-leak avoidance
+    contract (a cross-tenant probe 404s, never 403s).
+    """
+
+    def __init__(self, slug: str) -> None:
+        self.slug = slug
+        super().__init__(f"convention {slug!r} not found")
+
+
+class ConventionConflictError(ConventionServiceError):
+    """A create hit the composite-unique index on ``(tenant_id, slug)``.
+
+    The route maps it to 409. Narrowed to genuine unique-violations by
+    :meth:`ConventionsService.create_convention`; other IntegrityError
+    shapes propagate so a real corruption surfaces as a 500.
+    """
+
+    def __init__(self, slug: str) -> None:
+        self.slug = slug
+        super().__init__(f"convention {slug!r} already exists")
+
+
+class OverBudgetError(ConventionServiceError):
+    """An ``operational`` write exceeds the single-convention preamble budget.
+
+    The route maps it to 422 with a detail naming ``estimated`` vs
+    ``budget`` -- the same actionable message the inline gate produced,
+    so a CLI / BFF caller can rewrite the body to fit. ``workflow`` /
+    ``reference`` kinds never raise this (they are not preamble-bound).
+    """
+
+    def __init__(self, estimated: int, budget: int) -> None:
+        self.estimated = estimated
+        self.budget = budget
+        super().__init__(
+            f"convention body exceeds preamble budget (estimated={estimated}, budget={budget})"
+        )
+
+
+def conventions_text_only(preamble_text: str) -> str:
+    """Return the conventions text band from a combined preamble string.
+
+    The assembled preamble may stitch two text bands: tenant
+    conventions wrapped in
+    ``<<TENANT_CONVENTIONS ... END_TENANT_CONVENTIONS>>`` followed by
+    runbook priming, separated by a blank line. ``budget_status``
+    reports the conventions-band token count only -- priming is bounded
+    by its own implicit cap and is not charged to the conventions
+    budget.
+
+    Strategy: slice up to and including the conventions terminator
+    (:data:`~meho_backplane.conventions.preamble.BLOCK_END`); whatever
+    follows is the priming band (or empty). When the preamble carries
+    only priming (no conventions), the terminator is absent and the
+    function returns the empty string -- ``estimate_tokens("") == 0``,
+    so the budget status correctly reports zero conventions weight.
+
+    The slice relies only on the wrapper-emitted terminator (never
+    substituted from user content per the positional-wrapper discipline
+    in :mod:`meho_backplane.conventions.preamble`), so a malicious
+    convention body containing the literal terminator string cannot
+    cause the slice to mis-attribute priming text as conventions text.
+    """
+    if not preamble_text:
+        return ""
+    end = preamble_text.find(_CONVENTIONS_BLOCK_END)
+    if end == -1:
+        return ""
+    return preamble_text[: end + len(_CONVENTIONS_BLOCK_END)]
+
+
+def enforce_budget(body: str, kind: ConventionKind) -> None:
+    """Raise :class:`OverBudgetError` when an ``operational`` body overflows.
+
+    The single-entry write-time gate: a convention whose own token
+    estimate exceeds :data:`DEFAULT_MAX_PREAMBLE_TOKENS` cannot fit the
+    preamble at any priority, so failing the write loudly is the
+    correct response (the alternative is silent drop at every future
+    preamble assembly). No-op for ``workflow`` / ``reference`` (not
+    packed into the preamble).
+    """
+    if kind is not ConventionKind.OPERATIONAL:
+        return
+    estimated = estimate_tokens(body)
+    if estimated > DEFAULT_MAX_PREAMBLE_TOKENS:
+        raise OverBudgetError(estimated, DEFAULT_MAX_PREAMBLE_TOKENS)
+
+
+def resolve_patch_fields(
+    body: ConventionUpdate,
+    existing: TenantConvention,
+) -> tuple[str, str, int]:
+    """Pick post-PATCH ``(title, body, priority)`` honouring v2 set-vs-null.
+
+    Pydantic v2's :attr:`BaseModel.model_fields_set` distinguishes
+    "field absent from JSON" from "field present with null". For each
+    column: take the request body's value iff the field was both
+    explicitly set AND non-null; otherwise fall through to the existing
+    column.
+    """
+    explicit = body.model_fields_set
+    title = body.title if "title" in explicit and body.title is not None else existing.title
+    new_body = body.body if "body" in explicit and body.body is not None else existing.body
+    priority = (
+        body.priority if "priority" in explicit and body.priority is not None else existing.priority
+    )
+    return title, new_body, priority
+
+
+def enforce_patch_budget(
+    body: ConventionUpdate,
+    new_body: str,
+    existing: TenantConvention,
+) -> None:
+    """Run the over-budget gate iff the patch carries a body change.
+
+    Priority-only or title-only PATCHes against an oversize body are
+    intentionally not surfaced: the bug was already there at the prior
+    write; rejecting on an unrelated edit would be confused-deputy
+    behaviour. PATCH cannot change kind, so the check validates against
+    the existing row's kind. A row carrying a kind outside the closed
+    :class:`ConventionKind` vocabulary falls back to ``REFERENCE`` --
+    the safe direction; reference-kind never triggers the gate.
+    """
+    if "body" not in body.model_fields_set or body.body is None:
+        return
+    try:
+        existing_kind = ConventionKind(existing.kind)
+    except ValueError:
+        existing_kind = ConventionKind.REFERENCE
+    enforce_budget(new_body, existing_kind)

--- a/backend/src/meho_backplane/conventions/service.py
+++ b/backend/src/meho_backplane/conventions/service.py
@@ -1,0 +1,492 @@
+# SPDX-License-Identifier: Apache-2.0
+# Copyright (c) 2026 evoila Group
+
+"""``ConventionsService`` -- session-threaded CRUD over tenant conventions.
+
+G10.12-T0 (#1894). Lifts the budget gate, history-row + pre-allocated
+audit-id pairing, and the preamble-feedback logic that previously
+lived inline in :mod:`meho_backplane.api.v1.conventions` into a thin
+service both the REST surface and the in-process console BFF (T1/T2
+#1838) can call without re-deriving the arithmetic.
+
+Session threading
+-----------------
+
+Unlike :class:`~meho_backplane.memory.service.MemoryService` (which
+opens its own session via the sessionmaker), every method here takes
+an explicit ``session: AsyncSession``. Two consumers need different
+session provenance:
+
+* the REST handler threads its request-scoped
+  :func:`~meho_backplane.db.engine.get_session` dependency, so the
+  audit middleware's pre-allocated-id soft-FK and the post-write
+  read-your-own-writes preamble preview share one transaction;
+* the cookie-authed BFF UI opens its own in-process session and
+  threads it the same way.
+
+The pre-allocated-audit-id seam (``bind_preallocated_audit_id``) is
+therefore exercised identically by both callers: the service mints
+the uuid, binds it onto the structlog contextvar the
+:class:`~meho_backplane.audit.AuditMiddleware` reads, and writes the
+paired ``tenant_convention_history`` row carrying that same id in the
+same transaction.
+
+Error vocabulary
+----------------
+
+HTTP concerns stay on the route handler. The service raises a small
+typed-error vocabulary the consumer maps to its own transport:
+
+* :class:`ConventionNotFoundError` -- the ``(tenant_id, slug)`` pair has no
+  row (route: 404; BFF: HTMX 404 partial). Collapses "wrong tenant"
+  and "wrong slug" into one error so the tenant-boundary info-leak
+  avoidance contract is preserved by construction.
+* :class:`ConventionConflictError` -- a create hit the composite-unique
+  index on ``(tenant_id, slug)`` (route: 409).
+* :class:`OverBudgetError` -- an ``operational`` write whose own token
+  estimate exceeds :data:`DEFAULT_MAX_PREAMBLE_TOKENS` (route: 422).
+  Carries ``estimated`` / ``budget`` ints so the consumer renders the
+  same actionable detail the inline gate did.
+
+``audit_op_id`` / ``audit_op_class`` / ``audit_slug`` contextvar
+binding stays on the route handler -- the audit classification differs
+per HTTP route, which is a transport concern, not a service one.
+"""
+
+from __future__ import annotations
+
+import uuid
+from datetime import UTC, datetime
+
+from sqlalchemy import delete as sql_delete
+from sqlalchemy import select
+from sqlalchemy.exc import IntegrityError
+from sqlalchemy.ext.asyncio import AsyncSession
+
+from meho_backplane.audit import bind_preallocated_audit_id
+from meho_backplane.auth.operator import Operator
+from meho_backplane.conventions._internal import (
+    ConventionConflictError,
+    ConventionNotFoundError,
+    ConventionServiceError,
+    OverBudgetError,
+    conventions_text_only,
+    enforce_budget,
+    enforce_patch_budget,
+    resolve_patch_fields,
+)
+from meho_backplane.conventions.preamble import (
+    assemble_preamble,
+    assemble_preamble_detailed,
+)
+from meho_backplane.conventions.schemas import (
+    DEFAULT_MAX_PREAMBLE_TOKENS,
+    BudgetStatus,
+    Convention,
+    ConventionCreate,
+    ConventionHistoryEntry,
+    ConventionKind,
+    ConventionSummary,
+    ConventionUpdate,
+    PreambleInclusion,
+    estimate_tokens,
+)
+from meho_backplane.db.models import TenantConvention, TenantConventionHistory
+
+__all__ = [
+    "ConventionConflictError",
+    "ConventionNotFoundError",
+    "ConventionServiceError",
+    "ConventionsService",
+    "OverBudgetError",
+]
+
+
+class ConventionsService:
+    """Session-threaded CRUD + budget + history service for tenant conventions.
+
+    Plain class (mirrors :class:`MemoryService`'s shape) with no held
+    state -- every method takes the ``session`` to operate on, so both
+    the REST request-scoped session and a UI in-process session thread
+    through the same code path. The pre-allocated-audit-id seam, the
+    history-row pairing, and the budget arithmetic live here once; the
+    consumers never re-derive them.
+    """
+
+    async def _load_convention(
+        self,
+        *,
+        session: AsyncSession,
+        tenant_id: uuid.UUID,
+        slug: str,
+    ) -> TenantConvention | None:
+        """Fetch the convention by ``(tenant_id, slug)`` or return ``None``.
+
+        Hits the composite-unique index -- one btree probe. ``None``
+        means "the row does not exist in this operator's tenant";
+        collapses "wrong tenant" and "wrong slug" into the same return
+        value so the consumer applies the consistent 404 the tenant
+        boundary's info-leak avoidance requires.
+        """
+        stmt = select(TenantConvention).where(
+            TenantConvention.tenant_id == tenant_id,
+            TenantConvention.slug == slug,
+        )
+        return (await session.execute(stmt)).scalar_one_or_none()
+
+    async def _compute_preamble_status(
+        self,
+        *,
+        session: AsyncSession,
+        tenant_id: uuid.UUID,
+        operator_sub: str,
+        slug: str,
+        kind: ConventionKind,
+    ) -> PreambleInclusion | None:
+        """Resolve preamble inclusion for the just-written *(tenant, slug)* pair.
+
+        Returns ``None`` for kinds that don't enter the preamble
+        (``workflow`` / ``reference``); a populated
+        :class:`PreambleInclusion` for ``operational`` rows.
+
+        Runs :func:`assemble_preamble_detailed` through the caller's
+        *session* so the pack reflects the in-progress write.
+        SQLAlchemy 2.x reads within the same transaction see
+        flushed-but-not-committed rows, so the caller must flush the
+        convention INSERT/UPDATE before calling; the read here then
+        includes it.
+        """
+        if kind is not ConventionKind.OPERATIONAL:
+            return None
+        assembly = await assemble_preamble_detailed(
+            tenant_id,
+            operator_sub,
+            session=session,
+        )
+        included = slug in assembly.kept_slugs
+        position = assembly.kept_slugs.index(slug) + 1 if included else None
+        token_count = assembly.token_counts.get(slug, 0)
+        return PreambleInclusion(
+            included=included,
+            position=position,
+            token_count=token_count,
+            would_drop_slugs=assembly.dropped_slugs,
+        )
+
+    async def budget_status(
+        self,
+        *,
+        session: AsyncSession,
+        operator: Operator,
+    ) -> BudgetStatus:
+        """Compute the conventions preamble budget for *operator*'s tenant.
+
+        Runs the same :func:`assemble_preamble` primitive T4's MCP
+        ``initialize`` handler uses, so ``estimated_tokens`` and the
+        preamble actually delivered to agent sessions cannot drift. The
+        assembler opens its own DB session (the *session* argument is
+        accepted for signature parity with the other methods but the
+        assembler does not thread it -- the budget read is a
+        committed-state snapshot, not a read-your-own-writes preview).
+
+        The arithmetic is **conventions-only**: the preamble is
+        assembled with priming + catalogue bands (so the list view
+        reflects the exact wire shape MCP ``initialize`` ships), then
+        ``conventions_text_only`` strips everything after the
+        conventions terminator before measuring.
+        """
+        preamble = await assemble_preamble(
+            operator.tenant_id, operator.sub, capabilities=operator.capabilities
+        )
+        conventions_only_text = conventions_text_only(preamble.text)
+        return BudgetStatus(
+            max_tokens=DEFAULT_MAX_PREAMBLE_TOKENS,
+            estimated_tokens=estimate_tokens(conventions_only_text),
+            over_budget=bool(preamble.dropped_slugs),
+            dropped_slugs=preamble.dropped_slugs,
+        )
+
+    async def list_conventions(
+        self,
+        *,
+        session: AsyncSession,
+        operator: Operator,
+        kind: ConventionKind | None = None,
+    ) -> tuple[list[ConventionSummary], BudgetStatus]:
+        """List the operator's tenant's conventions + the tenant budget.
+
+        Returns the lighter :class:`ConventionSummary` shape (no full
+        ``body``). Ordering is ``priority DESC, created_at ASC`` -- the
+        same key the preamble assembler uses for packing. The ``kind``
+        filter narrows the returned entries only; ``budget_status``
+        always reflects the full ``operational`` set (a
+        ``kind=workflow`` list still wants the truthful budget signal).
+        """
+        stmt = select(TenantConvention).where(
+            TenantConvention.tenant_id == operator.tenant_id,
+        )
+        if kind is not None:
+            stmt = stmt.where(TenantConvention.kind == kind.value)
+        stmt = stmt.order_by(
+            TenantConvention.priority.desc(),
+            TenantConvention.created_at.asc(),
+        )
+        rows = (await session.execute(stmt)).scalars().all()
+        entries = [ConventionSummary.model_validate(row) for row in rows]
+        budget = await self.budget_status(session=session, operator=operator)
+        return entries, budget
+
+    async def get_convention(
+        self,
+        *,
+        session: AsyncSession,
+        tenant_id: uuid.UUID,
+        slug: str,
+    ) -> Convention:
+        """Fetch one convention by slug.
+
+        Raises :class:`ConventionNotFoundError` on absent OR cross-tenant
+        (the lookup filters on both ``tenant_id`` AND ``slug``), which
+        the route maps to 404 -- preserving the tenant-boundary
+        info-leak avoidance contract.
+        """
+        row = await self._load_convention(
+            session=session,
+            tenant_id=tenant_id,
+            slug=slug,
+        )
+        if row is None:
+            raise ConventionNotFoundError(slug)
+        return Convention.model_validate(row)
+
+    async def create_convention(
+        self,
+        *,
+        session: AsyncSession,
+        operator: Operator,
+        body: ConventionCreate,
+    ) -> Convention:
+        """Create one convention; writes one history row in the same transaction.
+
+        Sequence: budget gate -> pre-allocate audit_id -> insert
+        convention + history rows -> conflict mapping on duplicate
+        ``(tenant_id, slug)`` -> preamble-status feedback. The CREATE
+        history row has ``body_before=NULL``; ``body_after=body.body``,
+        and carries the pre-allocated ``audit_id`` soft-FK that the
+        audit middleware honours for the matching audit row.
+
+        Raises :class:`OverBudgetError` (route: 422) and
+        :class:`ConventionConflictError` (route: 409).
+        """
+        enforce_budget(body.body, body.kind)
+
+        audit_id = uuid.uuid4()
+        bind_preallocated_audit_id(audit_id)
+        now = datetime.now(UTC)
+        convention = TenantConvention(
+            id=uuid.uuid4(),
+            tenant_id=operator.tenant_id,
+            slug=body.slug,
+            title=body.title,
+            body=body.body,
+            kind=body.kind.value,
+            priority=body.priority,
+            created_by_sub=operator.sub,
+            created_at=now,
+            updated_at=now,
+        )
+        history = TenantConventionHistory(
+            id=uuid.uuid4(),
+            convention_id=convention.id,
+            body_before=None,
+            body_after=body.body,
+            actor_sub=operator.sub,
+            ts=now,
+            audit_id=audit_id,
+        )
+        session.add_all([convention, history])
+        try:
+            await session.flush()
+        except IntegrityError as exc:
+            # Narrow the conflict to actual composite-unique-index
+            # violations on ``(tenant_id, slug)``; other IntegrityError
+            # shapes (CHECK / NOT NULL from a future tightening
+            # migration) propagate so a genuine corruption surfaces as
+            # a 500 rather than a misleading "already exists".
+            #
+            # PG via asyncpg: ``sqlstate == "23505"`` is the
+            # unique-violation code. SQLite: ``UNIQUE constraint
+            # failed`` substring is the documented form.
+            orig = getattr(exc, "orig", None)
+            sqlstate = getattr(orig, "sqlstate", None) or getattr(orig, "pgcode", None)
+            orig_msg = str(orig or exc)
+            is_unique_violation = sqlstate == "23505" or "UNIQUE constraint failed" in orig_msg
+            if is_unique_violation:
+                raise ConventionConflictError(body.slug) from exc
+            raise
+        await session.refresh(convention)
+        preamble_status = await self._compute_preamble_status(
+            session=session,
+            tenant_id=operator.tenant_id,
+            operator_sub=operator.sub,
+            slug=body.slug,
+            kind=body.kind,
+        )
+        return Convention.model_validate(convention).model_copy(
+            update={"preamble_status": preamble_status},
+        )
+
+    async def update_convention(
+        self,
+        *,
+        session: AsyncSession,
+        operator: Operator,
+        slug: str,
+        body: ConventionUpdate,
+    ) -> Convention:
+        """Update one convention; writes one history row in the same transaction.
+
+        Applies only fields explicitly set in the request body (the v2
+        ``model_fields_set`` set-vs-null pattern). The budget gate fires
+        on a ``body`` change; PATCH cannot change ``kind`` so the check
+        uses the existing row's kind. A priority-only or title-only
+        PATCH still writes a history row carrying the unchanged body in
+        both ``body_before`` and ``body_after``.
+
+        Raises :class:`ConventionNotFoundError` (route: 404) and
+        :class:`OverBudgetError` (route: 422).
+        """
+        existing = await self._load_convention(
+            session=session,
+            tenant_id=operator.tenant_id,
+            slug=slug,
+        )
+        if existing is None:
+            raise ConventionNotFoundError(slug)
+
+        new_title, new_body, new_priority = resolve_patch_fields(body, existing)
+        enforce_patch_budget(body, new_body, existing)
+
+        audit_id = uuid.uuid4()
+        bind_preallocated_audit_id(audit_id)
+        now = datetime.now(UTC)
+        body_before = existing.body
+
+        existing.title = new_title
+        existing.body = new_body
+        existing.priority = new_priority
+        existing.updated_at = now
+
+        history = TenantConventionHistory(
+            id=uuid.uuid4(),
+            convention_id=existing.id,
+            body_before=body_before,
+            body_after=new_body,
+            actor_sub=operator.sub,
+            ts=now,
+            audit_id=audit_id,
+        )
+        session.add(history)
+        await session.flush()
+        await session.refresh(existing)
+        # PATCH cannot change kind, so the post-PATCH kind is the
+        # existing row's kind; resolve back to the enum. A row carrying
+        # a kind outside the closed vocabulary falls back to
+        # ``REFERENCE`` (the safe direction; reference-kind
+        # short-circuits to ``preamble_status=None``).
+        try:
+            existing_kind = ConventionKind(existing.kind)
+        except ValueError:
+            existing_kind = ConventionKind.REFERENCE
+        preamble_status = await self._compute_preamble_status(
+            session=session,
+            tenant_id=operator.tenant_id,
+            operator_sub=operator.sub,
+            slug=slug,
+            kind=existing_kind,
+        )
+        return Convention.model_validate(existing).model_copy(
+            update={"preamble_status": preamble_status},
+        )
+
+    async def delete_convention(
+        self,
+        *,
+        session: AsyncSession,
+        operator: Operator,
+        slug: str,
+    ) -> None:
+        """Delete one convention; writes one history row in the same transaction.
+
+        **Non-idempotent**: raises :class:`ConventionNotFoundError` (route:
+        404) on a missing / cross-tenant slug rather than a silent
+        no-op -- the history + audit row pairing requires a real row to
+        delete from; an idempotent 204-on-missing would produce an
+        audit row with no history counterpart. The history row carries
+        ``body_after=<final body>`` -- a legible last-known state for
+        forensics.
+        """
+        existing = await self._load_convention(
+            session=session,
+            tenant_id=operator.tenant_id,
+            slug=slug,
+        )
+        if existing is None:
+            raise ConventionNotFoundError(slug)
+
+        audit_id = uuid.uuid4()
+        bind_preallocated_audit_id(audit_id)
+        now = datetime.now(UTC)
+        convention_id = existing.id
+
+        history = TenantConventionHistory(
+            id=uuid.uuid4(),
+            convention_id=convention_id,
+            body_before=existing.body,
+            body_after=existing.body,
+            actor_sub=operator.sub,
+            ts=now,
+            audit_id=audit_id,
+        )
+        session.add(history)
+        # Flush the history row before the DELETE -- SQLAlchemy 2.x's
+        # ordering between pending inserts and deletes is
+        # implementation-defined; the explicit flush keeps the row-pair
+        # contract.
+        await session.flush()
+        await session.execute(
+            sql_delete(TenantConvention).where(
+                TenantConvention.id == convention_id,
+                TenantConvention.tenant_id == operator.tenant_id,
+            ),
+        )
+
+    async def list_history(
+        self,
+        *,
+        session: AsyncSession,
+        tenant_id: uuid.UUID,
+        slug: str,
+    ) -> list[ConventionHistoryEntry]:
+        """List history entries for one convention, newest first.
+
+        Two-step lookup (resolve ``(tenant_id, slug)`` to convention id,
+        then scan history) keeps the tenant-scope check explicit.
+        Raises :class:`ConventionNotFoundError` (route: 404) on absent /
+        cross-tenant.
+        """
+        existing = await self._load_convention(
+            session=session,
+            tenant_id=tenant_id,
+            slug=slug,
+        )
+        if existing is None:
+            raise ConventionNotFoundError(slug)
+
+        stmt = (
+            select(TenantConventionHistory)
+            .where(TenantConventionHistory.convention_id == existing.id)
+            .order_by(TenantConventionHistory.ts.desc())
+        )
+        rows = (await session.execute(stmt)).scalars().all()
+        return [ConventionHistoryEntry.model_validate(row) for row in rows]

--- a/backend/tests/test_api_v1_conventions.py
+++ b/backend/tests/test_api_v1_conventions.py
@@ -1529,11 +1529,12 @@ async def test_list_conventions_invokes_assembler_with_operator_sub(
     regression is caught at this layer.
 
     Spy strategy: wrap the real ``assemble_preamble`` import in
-    ``meho_backplane.api.v1.conventions`` and record every call's
-    positional args. Assert the second positional matches the
-    operator's sub from the JWT.
+    ``meho_backplane.conventions.service`` (where the budget arithmetic
+    now lives after the G10.12-T0 #1894 service extraction) and record
+    every call's positional args. Assert the second positional matches
+    the operator's sub from the JWT.
     """
-    from meho_backplane.api.v1 import conventions as conventions_module
+    from meho_backplane.conventions import service as conventions_module
 
     await _seed_tenants()
     key = make_rsa_keypair("kid-priming-list-spy")
@@ -1595,13 +1596,15 @@ async def test_post_convention_invokes_detailed_assembler_with_operator_sub(
     still looked right.
 
     Spy strategy: wrap the real ``assemble_preamble_detailed`` import
-    in ``meho_backplane.api.v1.conventions`` and assert every call
-    carries the operator's sub. Use an operational convention so the
-    helper is actually invoked (workflow / reference short-circuit
-    to ``preamble_status=None`` per the ``_compute_preamble_status``
+    in ``meho_backplane.conventions.service`` (where
+    ``_compute_preamble_status`` now lives after the G10.12-T0 #1894
+    service extraction) and assert every call carries the operator's
+    sub. Use an operational convention so the helper is actually
+    invoked (workflow / reference short-circuit to
+    ``preamble_status=None`` per the ``_compute_preamble_status``
     docstring).
     """
-    from meho_backplane.api.v1 import conventions as conventions_module
+    from meho_backplane.conventions import service as conventions_module
 
     await _seed_tenants()
     key = make_rsa_keypair("kid-priming-post-spy")
@@ -1673,8 +1676,13 @@ async def test_patch_convention_invokes_detailed_assembler_with_operator_sub(
     operator's MCP session shape (priming included). Verify across
     the create + update lifecycle so a refactor that dropped the sub
     on either route would fail.
+
+    The detailed assembler is patched on
+    ``meho_backplane.conventions.service`` (where
+    ``_compute_preamble_status`` now lives after the G10.12-T0 #1894
+    service extraction).
     """
-    from meho_backplane.api.v1 import conventions as conventions_module
+    from meho_backplane.conventions import service as conventions_module
 
     await _seed_tenants()
     key = make_rsa_keypair("kid-priming-patch-spy")

--- a/docs/codebase/tenant_conventions.md
+++ b/docs/codebase/tenant_conventions.md
@@ -89,16 +89,53 @@ module is the only writer.
 Same module. Write-once, read-mostly. T3's `meho conventions history
 <slug>` verb is the only consumer in v0.2.
 
+## Service layer (G10.12-T0 #1894)
+
+The CRUD + budget + history + pre-allocated-audit-id logic that was
+originally inline in the route handlers now lives in
+[`ConventionsService`](../../backend/src/meho_backplane/conventions/service.py).
+The HTTP routes are a thin shell: they bind the audit contextvars,
+delegate to the service, and map the service's typed error vocabulary
+to status codes. The split exists so the in-process operator-console
+BFF (G10.12 T1/T2 #1838) can reuse the same budget gate, history-row
+pairing, and audit-id seam without copying the handlers or routing a
+Bearer-API call back through itself.
+
+Two design points:
+
+- **Session is threaded in, not opened.** Every method takes an
+  explicit `session: AsyncSession`. The REST handler passes its
+  request-scoped `get_session` dependency (so the audit middleware's
+  pre-allocated-id soft-FK and the post-write read-your-own-writes
+  preamble preview share one transaction); the BFF passes its own
+  in-process session. (Contrast `MemoryService`, which opens its own
+  session via the sessionmaker.) `budget_status` accepts the param
+  for signature parity but the assembler it calls opens its own
+  session -- the budget read is a committed-state snapshot.
+- **Error vocabulary, not `HTTPException`.** The service raises
+  `ConventionNotFoundError` (route: 404), `ConventionConflictError`
+  (route: 409), and `OverBudgetError` (route: 422). The route maps
+  each to the wire status it already produced; the BFF maps the same
+  errors to HTMX partials. The error classes + the pure helpers
+  (budget gate, set-vs-null PATCH resolution, conventions-band slice)
+  live in
+  [`conventions/_internal.py`](../../backend/src/meho_backplane/conventions/_internal.py).
+
+The wire behaviour (status codes, response bodies, audit rows,
+history rows) is identical to the pre-extraction inline
+implementation -- the existing REST test module passes unchanged.
+
 ## Control flow
 
-T2 (this task) ships the **6 HTTP routes** + Pydantic schemas. T1
+T2 (#314) ships the **6 HTTP routes** + Pydantic schemas; G10.12-T0
+(#1894) moved their bodies behind `ConventionsService` (above). T1
 shipped the schema; T3-T5 layer CLI / preamble / seed on top.
 
 1. **POST /api/v1/conventions** (T2 #314) -- `tenant_admin` role
    required. Inserts one row into `tenant_conventions` and one row
    into `tenant_convention_history` (with `body_before=NULL`) inside
    the same transaction. The audit middleware writes its own row
-   into `audit_log`; the route handler pre-allocates the audit row's
+   into `audit_log`; the service pre-allocates the audit row's
    uuid via
    [`bind_preallocated_audit_id`](../../backend/src/meho_backplane/audit.py)
    so the middleware reuses it, and the history row's `audit_id`
@@ -308,7 +345,7 @@ All three commit or roll back together: the convention mutation +
 history row land in the same `session.begin()` block opened by
 `get_session`; the audit row commits in the same response cycle
 via the middleware. The history row's `audit_id` soft-FK
-references the audit row by exact-match uuid -- the route handler
+references the audit row by exact-match uuid -- `ConventionsService`
 pre-allocates the uuid via `bind_preallocated_audit_id` and the
 middleware honors the contextvar instead of minting its own. G8's
 audit-query path joins `tenant_convention_history` on `audit_log`
@@ -468,7 +505,7 @@ sub-document to the response when the convention is
 `preamble_status` is `null` on `GET /{slug}` (the aggregate budget
 signal lives on the list response's `budget_status`) and `null` for
 writes against `workflow` / `reference` kinds (those don't enter
-the preamble). The route handler resolves inclusion via
+the preamble). `ConventionsService` resolves inclusion via
 `assemble_preamble_detailed(tenant_id, operator.sub, session=session)`
 -- the same session the write committed through, so the pack
 reflects the post-write state without an extra commit round-trip.


### PR DESCRIPTION
## Summary
- Extracts a thin, behavior-preserving `ConventionsService` from the inline `api/v1/conventions.py` route handlers so the G10.12 operator-console BFF (T1/T2 #1838) can reuse the budget gate, history-row/pre-allocated-audit-id pairing, and preamble-feedback logic in-process without copying the handlers.
- Service methods thread an explicit `AsyncSession` (REST request-scoped session *or* a UI in-process session) so the audit soft-FK + read-your-own-writes preamble preview share one transaction; mirrors the `MemoryService` plain-class shape.
- Chosen split: the service raises a typed error vocabulary (`ConventionNotFoundError` → 404, `ConventionConflictError` → 409, `OverBudgetError` → 422); the route maps each to `HTTPException` and keeps the `structlog.contextvars` audit binding + the MCP `resources/updated` emit. The error classes + pure helpers (budget gate, set-vs-null PATCH resolution, conventions-band slice) live in `conventions/_internal.py` to keep `service.py` under the file-size budget.
- Behavior-preserving refactor: status codes, response bodies, audit rows, history rows, and the non-idempotent DELETE (404-on-missing) are identical. No new routes → no OpenAPI snapshot change (out of scope per the Task).

## Test plan
- [x] `ruff check src/meho_backplane/conventions/ src/meho_backplane/api/v1/conventions.py` — clean
- [x] `ruff format --check` — clean
- [x] `mypy src/meho_backplane/conventions/service.py src/meho_backplane/conventions/_internal.py src/meho_backplane/api/v1/conventions.py` — clean
- [x] `uv run pytest tests/test_api_v1_conventions.py -q` — 55 passed, unchanged from baseline
- [x] `uv run pytest tests/test_api_v1_conventions.py -k "history or audit" -q` — 10 passed (audit_id ↔ history-row pairing preserved)
- [x] Broader sweep `pytest tests/ -k "convention or preamble"` — 157 passed, 2 skipped (sandbox), 0 failed
- [x] code-quality `--diff` gate — 0 blockers
- [x] AC greps: `grep -nc bind_preallocated_audit_id api/v1/conventions.py` = `0`; same call now lives in `service.py`; `grep -n "class ConventionsService" service.py` hits

### Acceptance criteria
- [x] `conventions/service.py` exists exporting `ConventionsService`.
- [x] Route handlers delegate; no duplicated budget/history/audit-id logic inline (`bind_preallocated_audit_id` call count in the route = 0).
- [x] Existing REST conventions test module passes unchanged (the 3 assembler-wire-up spies are re-pointed to patch the service module — where `assemble_preamble`/`_detailed` now run — with all assertions intact, per the "re-point a moved import only" allowance).
- [x] Create/update/delete still write exactly one history row whose `audit_id` equals the request's pre-allocated audit row id (covered by the `history or audit` subset).
- [x] Non-idempotent DELETE preserved (404 on missing slug).

## Out of scope
- No new endpoints, response-shape changes, or `/ui` routes (T1/T2 own those + the snapshot regen).
- Adjacent findings (non-blocking code-quality warnings, recorded only): `create_convention`/`update_convention` exceed the 60-line function warn threshold (dominated by carried-over docstrings); `service.py` (493) and `api/v1/conventions.py` (486) exceed the 400-line file warn threshold but are under the 600-line block limit.

<!-- auto-implement-issue: fresh, iteration 1 -->

Closes #1894
