### PR TITLE
feat(ui): conventions author/edit modals + token-cost preview + delete confirm + history diff panel

### DIFF
--- a/backend/src/meho_backplane/ui/routes/conventions/history.py
+++ b/backend/src/meho_backplane/ui/routes/conventions/history.py
@@ -1,0 +1,74 @@
+# SPDX-License-Identifier: Apache-2.0
+# Copyright (c) 2026 evoila Group
+
+"""Conventions UI history diff panel render helper.
+
+Initiative #1838 (G10.12 Conventions console), Task #1896 (T2). Split
+out of :mod:`~meho_backplane.ui.routes.conventions.write` so neither
+module exceeds the chassis-wide ~600-line cap, and because the history
+panel is the one **read** surface in T2 (OPERATOR-tier, gated like the
+detail view) -- keeping it apart from the tenant_admin write helpers
+keeps the read/write split legible.
+
+The panel renders the ``tenant_convention_history`` rows newest-first
+(the service orders by ``ts DESC``) with a per-row ``body_before`` ->
+``body_after`` diff. Bodies render as escaped plain text in the
+template's ``<pre>`` blocks, so a body carrying raw HTML never executes
+in the diff view.
+"""
+
+from __future__ import annotations
+
+from fastapi import HTTPException, Request
+from fastapi.responses import HTMLResponse
+from sqlalchemy.ext.asyncio import AsyncSession
+
+from meho_backplane.conventions.service import (
+    ConventionNotFoundError,
+    ConventionsService,
+)
+from meho_backplane.ui.routes.conventions.operator import ConventionsReadContext
+from meho_backplane.ui.templating import get_templates
+
+__all__ = ["render_history_panel"]
+
+#: One shared service instance -- stateless (every method takes the
+#: session), mirroring the read views' module-level singleton.
+_service = ConventionsService()
+
+
+async def render_history_panel(
+    request: Request,
+    read_ctx: ConventionsReadContext,
+    *,
+    session: AsyncSession,
+    slug: str,
+) -> HTMLResponse:
+    """Render the history diff panel, newest-first.
+
+    Each row carries the ``body_before`` -> ``body_after`` diff; the
+    CREATE row (``body_before is None``) renders with no "before" pane.
+    Bodies are escaped (rendered as plain text in ``<pre>``), so a body
+    containing raw HTML never executes in the diff view.
+    """
+    try:
+        entries = await _service.list_history(
+            session=session,
+            tenant_id=read_ctx.operator.tenant_id,
+            slug=slug,
+        )
+    except ConventionNotFoundError as exc:
+        raise HTTPException(status_code=404, detail="convention_not_found") from exc
+    rows = [
+        {
+            "body_before": entry.body_before,
+            "body_after": entry.body_after,
+            "actor_sub": entry.actor_sub,
+            "ts": entry.ts,
+            "audit_id": str(entry.audit_id) if entry.audit_id is not None else None,
+            "is_create": entry.body_before is None,
+        }
+        for entry in entries
+    ]
+    context: dict[str, object] = {"slug": slug, "history": rows}
+    return get_templates().TemplateResponse(request, "conventions/_history_panel.html", context)

--- a/backend/src/meho_backplane/ui/routes/conventions/operator.py
+++ b/backend/src/meho_backplane/ui/routes/conventions/operator.py
@@ -35,31 +35,61 @@ this module composes the two existing lifts:
 
 from __future__ import annotations
 
+import uuid
 from dataclasses import dataclass
 
 from fastapi import Request
 
 from meho_backplane.auth.operator import Operator
 from meho_backplane.ui.auth.middleware import UISessionContext, require_ui_session
-from meho_backplane.ui.routes.connectors.operator import resolve_role_probe
+from meho_backplane.ui.routes.connectors.operator import (
+    resolve_operator_or_403,
+    resolve_role_probe,
+)
 from meho_backplane.ui.routes.memory.operator import build_read_operator
 
-__all__ = ["ConventionsReadContext", "resolve_read_context"]
+__all__ = [
+    "ConventionsReadContext",
+    "ConventionsWriteContext",
+    "resolve_read_context",
+    "resolve_write_context",
+]
 
 
 @dataclass(frozen=True)
 class ConventionsReadContext:
-    """The operator + admin-hint pair the read routes thread through.
+    """The operator + admin-hint + session-id triple the read routes thread.
 
     ``operator`` is a synthesised OPERATOR-tier
     :class:`~meho_backplane.auth.operator.Operator` -- enough for the
     tenant-scoped ``ConventionsService`` reads. ``is_tenant_admin`` is
     a soft UX hint that gates the T2 author / edit / delete affordances
     in the template; the write routes re-check role server-side.
+    ``session_id`` is carried so the T2 modal renders (loaded via the
+    read context) can mint a CSRF double-submit token for the write
+    form they embed.
     """
 
     operator: Operator
     is_tenant_admin: bool
+    session_id: uuid.UUID
+
+
+@dataclass(frozen=True)
+class ConventionsWriteContext:
+    """The full operator + session-id pair the T2 write routes thread.
+
+    ``operator`` is the real JWT-lifted
+    :class:`~meho_backplane.auth.operator.Operator` carrying
+    ``tenant_role`` -- resolved through
+    :func:`~meho_backplane.ui.routes.connectors.operator.resolve_operator_or_403`,
+    which 403s a non-``TENANT_ADMIN`` caller before the handler runs (the
+    server-side write gate). ``session_id`` lets a re-rendered modal mint
+    a fresh CSRF token.
+    """
+
+    operator: Operator
+    session_id: uuid.UUID
 
 
 async def resolve_read_context(
@@ -74,4 +104,25 @@ async def resolve_read_context(
     return ConventionsReadContext(
         operator=operator,
         is_tenant_admin=probe.is_tenant_admin,
+        session_id=session_ctx.session_id,
+    )
+
+
+async def resolve_write_context(
+    request: Request,
+    session_ctx: UISessionContext | None = None,
+) -> ConventionsWriteContext:
+    """FastAPI dependency: lift the full operator + gate to tenant_admin.
+
+    Used by every T2 write route. A non-admin caller raises 403 inside
+    :func:`resolve_operator_or_403` before the handler body runs -- the
+    server-side authority the read context's soft ``is_tenant_admin``
+    hint only optimistically mirrors in the template.
+    """
+    if session_ctx is None:
+        session_ctx = await require_ui_session(request)
+    operator = await resolve_operator_or_403(request, session_ctx)
+    return ConventionsWriteContext(
+        operator=operator,
+        session_id=session_ctx.session_id,
     )

--- a/backend/src/meho_backplane/ui/routes/conventions/routes.py
+++ b/backend/src/meho_backplane/ui/routes/conventions/routes.py
@@ -38,14 +38,17 @@ T2 adds re-check role server-side.
 
 from __future__ import annotations
 
-from fastapi import APIRouter, Depends, Query, Request
+from fastapi import APIRouter, Depends, Form, Query, Request
 from fastapi.responses import HTMLResponse
 from sqlalchemy.ext.asyncio import AsyncSession
 
-from meho_backplane.db.engine import get_session
+from meho_backplane.db.engine import get_raw_session, get_session
+from meho_backplane.ui.routes.conventions.history import render_history_panel
 from meho_backplane.ui.routes.conventions.operator import (
     ConventionsReadContext,
+    ConventionsWriteContext,
     resolve_read_context,
+    resolve_write_context,
 )
 from meho_backplane.ui.routes.conventions.views import (
     KIND_ALL,
@@ -53,13 +56,37 @@ from meho_backplane.ui.routes.conventions.views import (
     render_index,
     validate_slug,
 )
+from meho_backplane.ui.routes.conventions.write import (
+    BODY_MAX_LENGTH,
+    PRIORITY_MAX,
+    PRIORITY_MIN,
+    SLUG_MAX_LENGTH,
+    TITLE_MAX_LENGTH,
+    delete_convention,
+    render_create_modal,
+    render_delete_confirm,
+    render_edit_modal,
+    render_token_preview,
+    submit_create,
+    submit_update,
+)
 
 __all__ = ["build_conventions_router"]
 
 #: Module-level :class:`Depends` closures -- ruff B008 idiom mirroring
 #: the memory + topology routes (no calls in default argument positions).
 _session_dep = Depends(get_session)
+#: Write + modal-render handlers thread a NON-transactional session
+#: (no outer ``begin()``) so the service flush + the handler's explicit
+#: ``commit()`` / ``rollback()`` own the transaction. This is what lets a
+#: 409 / 422 roll the failed flush back and still return an inline-error
+#: 200 fragment -- the request-scoped :func:`get_session` would otherwise
+#: try to commit the dirty (or already-rolled-back) transaction on a
+#: clean handler return. Mirrors the G9.2 curated-edge service-owned-
+#: transaction routes' use of :func:`get_raw_session`.
+_raw_session_dep = Depends(get_raw_session)
 _read_ctx_dep = Depends(resolve_read_context)
+_write_ctx_dep = Depends(resolve_write_context)
 
 
 async def _list_handler(
@@ -83,15 +110,148 @@ async def _detail_handler(
     return await render_detail(request, read_ctx, session=session, slug=slug)
 
 
+# ---------------------------------------------------------------------------
+# T2 (#1896) -- write surface: author / edit / preview / delete + history
+# ---------------------------------------------------------------------------
+
+
+async def _create_modal_handler(
+    request: Request,
+    write_ctx: ConventionsWriteContext = _write_ctx_dep,
+) -> HTMLResponse:
+    """``GET /ui/conventions/create`` -- HTMX author modal fragment."""
+    return await render_create_modal(request, write_ctx)
+
+
+async def _create_submit_handler(
+    request: Request,
+    slug: str = Form(..., max_length=SLUG_MAX_LENGTH),
+    title: str = Form(..., max_length=TITLE_MAX_LENGTH),
+    body: str = Form(..., max_length=BODY_MAX_LENGTH),
+    kind: str = Form(..., max_length=32),
+    priority: int = Form(default=0, ge=PRIORITY_MIN, le=PRIORITY_MAX),
+    session: AsyncSession = _raw_session_dep,
+    write_ctx: ConventionsWriteContext = _write_ctx_dep,
+) -> HTMLResponse:
+    """``POST /ui/conventions/create`` -- author a convention via the service."""
+    return await submit_create(
+        request,
+        write_ctx,
+        session=session,
+        slug=slug,
+        title=title,
+        body=body,
+        kind=kind,
+        priority=priority,
+    )
+
+
+async def _preview_handler(
+    request: Request,
+    body: str = Form(default="", max_length=BODY_MAX_LENGTH),
+    kind: str = Form(default="operational", max_length=32),
+    write_ctx: ConventionsWriteContext = _write_ctx_dep,
+) -> HTMLResponse:
+    """``POST /ui/conventions/preview`` -- debounced token-cost preview.
+
+    Gated on tenant_admin (the preview is part of the author / edit
+    write flow); the chassis CSRF middleware already rejected an
+    anonymous / cross-site POST.
+    """
+    del write_ctx  # gate only -- the preview render needs no operator state.
+    return await render_token_preview(request, body=body, kind=kind)
+
+
+async def _edit_modal_handler(
+    request: Request,
+    slug: str,
+    session: AsyncSession = _raw_session_dep,
+    write_ctx: ConventionsWriteContext = _write_ctx_dep,
+) -> HTMLResponse:
+    """``GET /ui/conventions/{slug}/edit`` -- HTMX edit modal fragment."""
+    validate_slug(slug)
+    return await render_edit_modal(request, write_ctx, session=session, slug=slug)
+
+
+async def _delete_confirm_handler(
+    request: Request,
+    slug: str,
+    session: AsyncSession = _raw_session_dep,
+    write_ctx: ConventionsWriteContext = _write_ctx_dep,
+) -> HTMLResponse:
+    """``GET /ui/conventions/{slug}/delete`` -- HTMX delete-confirm gate."""
+    validate_slug(slug)
+    return await render_delete_confirm(request, write_ctx, session=session, slug=slug)
+
+
+async def _history_handler(
+    request: Request,
+    slug: str,
+    session: AsyncSession = _session_dep,
+    read_ctx: ConventionsReadContext = _read_ctx_dep,
+) -> HTMLResponse:
+    """``GET /ui/conventions/{slug}/history`` -- HTMX history diff panel.
+
+    Read surface (OPERATOR-tier) -- history is a read of the
+    ``tenant_convention_history`` rows, gated like the detail view.
+    """
+    validate_slug(slug)
+    return await render_history_panel(request, read_ctx, session=session, slug=slug)
+
+
+async def _patch_handler(
+    request: Request,
+    slug: str,
+    title: str = Form(..., max_length=TITLE_MAX_LENGTH),
+    body: str = Form(..., max_length=BODY_MAX_LENGTH),
+    priority: int = Form(..., ge=PRIORITY_MIN, le=PRIORITY_MAX),
+    session: AsyncSession = _raw_session_dep,
+    write_ctx: ConventionsWriteContext = _write_ctx_dep,
+) -> HTMLResponse:
+    """``PATCH /ui/conventions/{slug}`` -- apply an edit via the service.
+
+    ``kind`` + ``slug`` are not in the form -- the PATCH surface cannot
+    change them (the edit modal renders them read-only).
+    """
+    validate_slug(slug)
+    return await submit_update(
+        request,
+        write_ctx,
+        session=session,
+        slug=slug,
+        title=title,
+        body=body,
+        priority=priority,
+    )
+
+
+async def _delete_handler(
+    request: Request,
+    slug: str,
+    session: AsyncSession = _raw_session_dep,
+    write_ctx: ConventionsWriteContext = _write_ctx_dep,
+) -> HTMLResponse:
+    """``DELETE /ui/conventions/{slug}`` -- delete behind the confirm gate."""
+    validate_slug(slug)
+    return await delete_convention(
+        request,
+        write_ctx.operator,
+        session=session,
+        slug=slug,
+    )
+
+
 def _register_static_prefix_routes(router: APIRouter) -> None:
     """Wire the static-prefix routes onto *router*.
 
     Registration order is **load-bearing**: these static-prefix routes
     MUST register before :func:`_register_parametrized_routes`. The
-    literal ``/ui/conventions`` list path lives here; T2 (#1838-T2) adds
-    ``/ui/conventions/create`` + ``/ui/conventions/preview`` to this
-    group so the literal segments are never bound to the ``{slug}``
-    parameter of the detail route.
+    literal ``/ui/conventions`` list path and T2's
+    ``/ui/conventions/create`` + ``/ui/conventions/preview`` live here so
+    the literal segments are never bound to the ``{slug}`` parameter of
+    the detail / edit / history routes (FastAPI matches the first route
+    whose template fits, and ``{slug}`` would otherwise swallow the
+    literal ``"create"`` / ``"preview"`` token).
     """
     router.add_api_route(
         "/ui/conventions",
@@ -100,21 +260,80 @@ def _register_static_prefix_routes(router: APIRouter) -> None:
         name="ui_conventions_list",
         response_class=HTMLResponse,
     )
+    router.add_api_route(
+        "/ui/conventions/create",
+        _create_modal_handler,
+        methods=["GET"],
+        name="ui_conventions_create_modal",
+        response_class=HTMLResponse,
+    )
+    router.add_api_route(
+        "/ui/conventions/create",
+        _create_submit_handler,
+        methods=["POST"],
+        name="ui_conventions_create_submit",
+        response_class=HTMLResponse,
+    )
+    router.add_api_route(
+        "/ui/conventions/preview",
+        _preview_handler,
+        methods=["POST"],
+        name="ui_conventions_preview",
+        response_class=HTMLResponse,
+    )
 
 
 def _register_parametrized_routes(router: APIRouter) -> None:
     """Wire the parametrised ``{slug}`` routes onto *router*.
 
     Must register **after** :func:`_register_static_prefix_routes` --
-    the literal ``/ui/conventions`` (and T2's ``/create`` + ``/preview``)
-    carry segments that would otherwise bind to the ``{slug}`` parameter
-    and resolve the wrong handler.
+    the literal ``/ui/conventions`` + ``/create`` + ``/preview`` carry
+    segments that would otherwise bind to the ``{slug}`` parameter and
+    resolve the wrong handler. The ``/{slug}/edit``, ``/{slug}/delete``,
+    and ``/{slug}/history`` sub-paths carry a trailing literal so they
+    register cleanly after the bare detail route without a further
+    ordering hazard.
     """
     router.add_api_route(
         "/ui/conventions/{slug}",
         _detail_handler,
         methods=["GET"],
         name="ui_conventions_detail",
+        response_class=HTMLResponse,
+    )
+    router.add_api_route(
+        "/ui/conventions/{slug}/edit",
+        _edit_modal_handler,
+        methods=["GET"],
+        name="ui_conventions_edit_modal",
+        response_class=HTMLResponse,
+    )
+    router.add_api_route(
+        "/ui/conventions/{slug}/delete",
+        _delete_confirm_handler,
+        methods=["GET"],
+        name="ui_conventions_delete_confirm",
+        response_class=HTMLResponse,
+    )
+    router.add_api_route(
+        "/ui/conventions/{slug}/history",
+        _history_handler,
+        methods=["GET"],
+        name="ui_conventions_history",
+        response_class=HTMLResponse,
+    )
+    router.add_api_route(
+        "/ui/conventions/{slug}",
+        _patch_handler,
+        methods=["PATCH"],
+        name="ui_conventions_patch",
+        response_class=HTMLResponse,
+    )
+    router.add_api_route(
+        "/ui/conventions/{slug}",
+        _delete_handler,
+        methods=["DELETE"],
+        name="ui_conventions_delete",
         response_class=HTMLResponse,
     )
 

--- a/backend/src/meho_backplane/ui/routes/conventions/write.py
+++ b/backend/src/meho_backplane/ui/routes/conventions/write.py
@@ -1,0 +1,573 @@
+# SPDX-License-Identifier: Apache-2.0
+# Copyright (c) 2026 evoila Group
+
+"""Conventions UI write surface -- author / edit / delete modals + history.
+
+Initiative #1838 (G10.12 Conventions console), Task #1896 (T2). Layers
+the write surface on top of T1's (#1895) read pages:
+
+* ``GET /ui/conventions/create`` -- HTMX ``<dialog>`` author modal with a
+  debounced token-cost preview wiring.
+* ``POST /ui/conventions/create`` -- submit; on success 204 +
+  ``HX-Redirect: /ui/conventions``; on 409 / 422 render the error inline.
+* ``GET /ui/conventions/{slug}/edit`` -- HTMX edit modal (title / priority
+  / body editable; kind + slug read-only -- PATCH cannot change them).
+* ``PATCH /ui/conventions/{slug}`` -- submit; calls
+  :meth:`ConventionsService.update_convention`.
+* ``POST /ui/conventions/preview`` -- debounced server-side token-cost
+  preview: takes ``body`` + ``kind``, renders the estimated tokens vs the
+  600 budget (red when an ``operational`` body is over) plus the
+  sanitised Markdown render.
+* ``GET /ui/conventions/{slug}/delete`` -- the confirm ``<dialog>`` gate.
+* ``DELETE /ui/conventions/{slug}`` -- delete behind the confirm gate; a
+  second DELETE on the already-gone slug renders a benign "already
+  deleted" fragment rather than surfacing the service's non-idempotent
+  404 (the service 404s on a missing row).
+* ``GET /ui/conventions/{slug}/history`` -- the history diff panel,
+  newest-first, with a per-row ``body_before`` -> ``body_after`` diff.
+
+Service reuse
+-------------
+
+Every write goes through the shared
+:class:`~meho_backplane.conventions.service.ConventionsService` so the
+budget gate, the ``tenant_convention_history`` row, and the
+pre-allocated-audit-id soft-FK pairing
+(:func:`~meho_backplane.audit.bind_preallocated_audit_id`, called inside
+the service) are exercised identically to the REST surface. This module
+never re-derives the budget arithmetic -- the token-cost preview calls
+:func:`~meho_backplane.conventions.schemas.estimate_tokens` directly (the
+single source of truth) rather than re-deriving the chars-per-token
+ratio.
+
+Audit binding
+-------------
+
+The chassis :class:`~meho_backplane.audit.AuditMiddleware` writes one row
+per request iff ``operator_sub`` is bound to the structlog contextvars
+when the hook fires. The BFF session middleware does not bind them, so
+each write handler binds the same ``audit_op_id`` / ``audit_op_class`` /
+``audit_slug`` triple the REST handler uses before the service call --
+and because the service mints + binds the pre-allocated audit id in the
+same transaction as the history row, the history row's ``audit_id``
+joins the audit row rather than landing NULL.
+
+RBAC + CSRF
+-----------
+
+Write = TENANT_ADMIN. Every write handler resolves the operator through
+:func:`~meho_backplane.ui.routes.connectors.operator.resolve_operator_or_403`
+(403 on a non-admin) -- the connectors surface is the authoritative
+precedent for these BFF write helpers. The CSRF double-submit pair is
+enforced by the chassis :class:`~meho_backplane.ui.csrf.CSRFMiddleware`
+on every ``/ui/*`` mutating verb; each modal render mints a fresh token
+and sets the matching ``meho_csrf`` cookie on the same response so the
+form's ``hx-headers`` echo lines up (#1693).
+"""
+
+from __future__ import annotations
+
+import structlog
+from fastapi import HTTPException, Request, status
+from fastapi.responses import HTMLResponse
+from sqlalchemy.ext.asyncio import AsyncSession
+
+from meho_backplane.auth.operator import Operator
+from meho_backplane.conventions.schemas import (
+    DEFAULT_MAX_PREAMBLE_TOKENS,
+    ConventionCreate,
+    ConventionKind,
+    ConventionUpdate,
+    PreambleInclusion,
+    estimate_tokens,
+)
+from meho_backplane.conventions.service import (
+    ConventionConflictError,
+    ConventionNotFoundError,
+    ConventionsService,
+    OverBudgetError,
+)
+from meho_backplane.ui.csrf import CSRF_COOKIE_NAME, mint_csrf_token
+from meho_backplane.ui.routes.conventions.operator import ConventionsWriteContext
+from meho_backplane.ui.routes.memory.render import render_markdown
+from meho_backplane.ui.templating import get_templates
+
+__all__ = [
+    "BODY_MAX_LENGTH",
+    "PRIORITY_MAX",
+    "PRIORITY_MIN",
+    "SLUG_MAX_LENGTH",
+    "TITLE_MAX_LENGTH",
+    "delete_convention",
+    "render_create_modal",
+    "render_delete_confirm",
+    "render_edit_modal",
+    "render_token_preview",
+    "submit_create",
+    "submit_update",
+]
+
+_log = structlog.get_logger(__name__)
+
+#: One shared service instance -- stateless (every method takes the
+#: session), mirroring the read views' module-level singleton.
+_service = ConventionsService()
+
+#: Field bounds mirrored from :class:`ConventionCreate` / the substrate
+#: so the modal's ``maxlength`` / ``min`` / ``max`` HTML attributes match
+#: the validation the service enforces (a paste-past-the-cap surfaces as
+#: the service's 422 rather than a silent truncation).
+SLUG_MAX_LENGTH = 128
+TITLE_MAX_LENGTH = 200
+BODY_MAX_LENGTH = 64_000
+PRIORITY_MIN = -32768
+PRIORITY_MAX = 32767
+
+#: Audit op-id triple mirrored from the REST surface (``conventions.*``)
+#: so the BFF writes land in the same G8 audit / dashboard classes.
+_OP_ID_CREATE = "conventions.create"
+_OP_ID_UPDATE = "conventions.update"
+_OP_ID_DELETE = "conventions.delete"
+
+
+def _set_csrf_cookie(response: HTMLResponse, csrf_token: str) -> None:
+    """Set the ``meho_csrf`` double-submit cookie on a modal response.
+
+    Mirrors the memory modal's cookie posture: ``Secure`` +
+    ``SameSite=Strict`` + ``path=/ui`` so the cookie the modal mints
+    rides the same response as the form's header echo and the chassis
+    middleware's double-submit check lines up on the next write POST.
+    """
+    response.set_cookie(
+        key=CSRF_COOKIE_NAME,
+        value=csrf_token,
+        httponly=False,
+        secure=True,
+        samesite="strict",
+        path="/ui",
+    )
+
+
+def _kind_options() -> list[dict[str, str]]:
+    """Render the kind selector's (value, label) pairs for the author modal."""
+    return [
+        {"value": ConventionKind.OPERATIONAL.value, "label": "Operational"},
+        {"value": ConventionKind.WORKFLOW.value, "label": "Workflow"},
+        {"value": ConventionKind.REFERENCE.value, "label": "Reference"},
+    ]
+
+
+def _bind_write_audit(*, operator: Operator, op_id: str, slug: str) -> None:
+    """Bind the contextvars the chassis audit hook reads for a write.
+
+    Same shape the REST conventions handlers use -- ``operator_sub`` +
+    ``tenant_id`` so the chassis :class:`AuditMiddleware` commits a row
+    at all, plus the canonical ``audit_op_id`` / ``audit_op_class`` /
+    ``audit_slug`` so the row carries the right op id. The service then
+    mints + binds the pre-allocated audit id in the same transaction as
+    the history row, so the history ``audit_id`` joins this audit row.
+    """
+    structlog.contextvars.bind_contextvars(
+        operator_sub=operator.sub,
+        tenant_id=str(operator.tenant_id),
+        audit_op_id=op_id,
+        audit_op_class="write",
+        audit_slug=slug,
+    )
+
+
+async def render_create_modal(
+    request: Request,
+    write_ctx: ConventionsWriteContext,
+) -> HTMLResponse:
+    """Render the HTMX author ``<dialog>`` fragment.
+
+    Mints a fresh CSRF token, embeds it in the form's ``hx-headers``
+    echo, and sets the matching ``meho_csrf`` cookie on this response.
+    The body textarea wires a debounced ``hx-post`` to
+    ``/ui/conventions/preview`` (``keyup changed delay:300ms``) so the
+    token-cost preview updates live as the operator types.
+    """
+    csrf_token = mint_csrf_token(str(write_ctx.session_id))
+    context: dict[str, object] = {
+        "csrf_token": csrf_token,
+        "kind_options": _kind_options(),
+        "slug_max_length": SLUG_MAX_LENGTH,
+        "title_max_length": TITLE_MAX_LENGTH,
+        "body_max_length": BODY_MAX_LENGTH,
+        "priority_min": PRIORITY_MIN,
+        "priority_max": PRIORITY_MAX,
+        "max_tokens": DEFAULT_MAX_PREAMBLE_TOKENS,
+    }
+    response = get_templates().TemplateResponse(request, "conventions/_create_modal.html", context)
+    _set_csrf_cookie(response, csrf_token)
+    return response
+
+
+async def render_edit_modal(
+    request: Request,
+    write_ctx: ConventionsWriteContext,
+    *,
+    session: AsyncSession,
+    slug: str,
+) -> HTMLResponse:
+    """Render the HTMX edit ``<dialog>`` fragment, pre-filled from the row.
+
+    ``kind`` and ``slug`` are shown read-only -- the PATCH surface cannot
+    change them (operators delete + recreate to switch kind). Only
+    ``title`` / ``priority`` / ``body`` are editable + submitted.
+    """
+    try:
+        convention = await _service.get_convention(
+            session=session,
+            tenant_id=write_ctx.operator.tenant_id,
+            slug=slug,
+        )
+    except ConventionNotFoundError as exc:
+        raise HTTPException(status_code=404, detail="convention_not_found") from exc
+    csrf_token = mint_csrf_token(str(write_ctx.session_id))
+    context: dict[str, object] = {
+        "csrf_token": csrf_token,
+        "convention": {
+            "slug": convention.slug,
+            "title": convention.title,
+            "kind": convention.kind,
+            "priority": convention.priority,
+            "body": convention.body,
+        },
+        "title_max_length": TITLE_MAX_LENGTH,
+        "body_max_length": BODY_MAX_LENGTH,
+        "priority_min": PRIORITY_MIN,
+        "priority_max": PRIORITY_MAX,
+        "max_tokens": DEFAULT_MAX_PREAMBLE_TOKENS,
+    }
+    response = get_templates().TemplateResponse(request, "conventions/_edit_modal.html", context)
+    _set_csrf_cookie(response, csrf_token)
+    return response
+
+
+async def render_token_preview(
+    request: Request,
+    *,
+    body: str,
+    kind: str,
+) -> HTMLResponse:
+    """Render the debounced token-cost preview fragment.
+
+    Computes the estimated token cost via
+    :func:`~meho_backplane.conventions.schemas.estimate_tokens` (the
+    single source of truth -- no re-derived chars/token ratio). The
+    fragment marks an ``operational`` body that exceeds
+    :data:`DEFAULT_MAX_PREAMBLE_TOKENS` in red; the same body as
+    ``workflow`` / ``reference`` is not flagged (those kinds never enter
+    the preamble, so they are exempt from the budget gate). A sanitised
+    Markdown render of the body is shown alongside.
+    """
+    estimated = estimate_tokens(body)
+    # Resolve the kind defensively: an unknown token (a tampered form,
+    # or the selector mid-change) falls back to REFERENCE -- the safe
+    # direction (exempt from the budget gate), so a transient bad value
+    # never flashes a spurious red over-budget warning.
+    try:
+        kind_enum = ConventionKind(kind)
+    except ValueError:
+        kind_enum = ConventionKind.REFERENCE
+    counts_against_budget = kind_enum is ConventionKind.OPERATIONAL
+    over_budget = counts_against_budget and estimated > DEFAULT_MAX_PREAMBLE_TOKENS
+    context: dict[str, object] = {
+        "estimated_tokens": estimated,
+        "max_tokens": DEFAULT_MAX_PREAMBLE_TOKENS,
+        "counts_against_budget": counts_against_budget,
+        "over_budget": over_budget,
+        "kind": kind_enum.value,
+        "body_html": render_markdown(body) if body.strip() else None,
+    }
+    return get_templates().TemplateResponse(request, "conventions/_token_preview.html", context)
+
+
+def _preamble_status_context(status_: PreambleInclusion | None) -> dict[str, object] | None:
+    """Project a :class:`PreambleInclusion` into the result-fragment shape."""
+    if status_ is None:
+        return None
+    return {
+        "included": status_.included,
+        "position": status_.position,
+        "token_count": status_.token_count,
+        "would_drop_slugs": list(status_.would_drop_slugs),
+    }
+
+
+def _render_create_error(
+    request: Request,
+    *,
+    message: str,
+) -> HTMLResponse:
+    """Render the inline create-error fragment (409 / 422) -- no redirect.
+
+    The author modal's form posts with ``hx-target`` pointed at an inline
+    result slot, so a 409 (duplicate slug) or 422 (over budget) renders
+    the actionable message in place rather than navigating away and
+    losing the operator's input.
+    """
+    context = {"message": message}
+    return get_templates().TemplateResponse(
+        request,
+        "conventions/_write_error.html",
+        context,
+        status_code=status.HTTP_200_OK,
+    )
+
+
+async def submit_create(
+    request: Request,
+    write_ctx: ConventionsWriteContext,
+    *,
+    session: AsyncSession,
+    slug: str,
+    title: str,
+    body: str,
+    kind: str,
+    priority: int,
+) -> HTMLResponse:
+    """Persist a new convention via the service; HX-Redirect on success.
+
+    On success returns 204 + ``HX-Redirect: /ui/conventions`` so HTMX
+    navigates back to the list with the new row visible -- unless the new
+    ``operational`` rule was dropped from the preamble on budget
+    overflow, in which case the result fragment surfaces the red
+    "DROPPED" ``preamble_status`` indicator instead so the operator sees
+    the rule will not reach agents before leaving the modal.
+
+    On a duplicate slug (:class:`ConventionConflictError` -> 409) or an
+    over-budget single body (:class:`OverBudgetError` -> 422), renders
+    the error inline in the modal (no redirect).
+    """
+    try:
+        kind_enum = ConventionKind(kind)
+    except ValueError:
+        return _render_create_error(
+            request,
+            message=(f"kind must be one of {[k.value for k in ConventionKind]}; got {kind!r}"),
+        )
+
+    try:
+        create_body = ConventionCreate(
+            slug=slug,
+            title=title,
+            body=body,
+            kind=kind_enum,
+            priority=priority,
+        )
+    except ValueError as exc:
+        return _render_create_error(request, message=str(exc))
+
+    operator = write_ctx.operator
+    _bind_write_audit(operator=operator, op_id=_OP_ID_CREATE, slug=create_body.slug)
+    try:
+        convention = await _service.create_convention(
+            session=session,
+            operator=operator,
+            body=create_body,
+        )
+        await session.commit()
+    except ConventionConflictError:
+        await session.rollback()
+        return _render_create_error(
+            request,
+            message=f"A convention with slug {slug!r} already exists.",
+        )
+    except OverBudgetError as exc:
+        await session.rollback()
+        return _render_create_error(
+            request,
+            message=(
+                f"Body exceeds the preamble budget "
+                f"(estimated {exc.estimated} tokens, budget {exc.budget}). "
+                f"Trim the body or set kind to workflow / reference."
+            ),
+        )
+
+    _log.info(
+        "ui_conventions_create",
+        tenant_id=str(operator.tenant_id),
+        operator_sub=operator.sub,
+        slug=create_body.slug,
+        kind=kind_enum.value,
+    )
+    return _post_write_response(
+        request,
+        preamble_status=convention.preamble_status,
+        slug=create_body.slug,
+    )
+
+
+async def submit_update(
+    request: Request,
+    write_ctx: ConventionsWriteContext,
+    *,
+    session: AsyncSession,
+    slug: str,
+    title: str,
+    body: str,
+    priority: int,
+) -> HTMLResponse:
+    """Apply a PATCH via the service; HX-Redirect on success.
+
+    The edit modal submits ``title`` / ``priority`` / ``body`` only --
+    ``kind`` + ``slug`` are read-only because the PATCH surface cannot
+    change them. On an over-budget body change renders the error inline;
+    otherwise HX-Redirects (or surfaces the ``preamble_status`` drop, as
+    create does).
+    """
+    try:
+        update_body = ConventionUpdate(title=title, body=body, priority=priority)
+    except ValueError as exc:
+        return _render_create_error(request, message=str(exc))
+
+    operator = write_ctx.operator
+    _bind_write_audit(operator=operator, op_id=_OP_ID_UPDATE, slug=slug)
+    try:
+        convention = await _service.update_convention(
+            session=session,
+            operator=operator,
+            slug=slug,
+            body=update_body,
+        )
+        await session.commit()
+    except ConventionNotFoundError as exc:
+        await session.rollback()
+        raise HTTPException(status_code=404, detail="convention_not_found") from exc
+    except OverBudgetError as exc:
+        await session.rollback()
+        return _render_create_error(
+            request,
+            message=(
+                f"Body exceeds the preamble budget "
+                f"(estimated {exc.estimated} tokens, budget {exc.budget})."
+            ),
+        )
+
+    _log.info(
+        "ui_conventions_update",
+        tenant_id=str(operator.tenant_id),
+        operator_sub=operator.sub,
+        slug=slug,
+    )
+    return _post_write_response(
+        request,
+        preamble_status=convention.preamble_status,
+        slug=slug,
+    )
+
+
+def _post_write_response(
+    request: Request,
+    *,
+    preamble_status: PreambleInclusion | None,
+    slug: str,
+) -> HTMLResponse:
+    """Build the create/update response: HX-Redirect or a DROPPED warning.
+
+    When the just-written ``operational`` rule landed in the preamble (or
+    the kind never enters the preamble), HX-Redirect back to the list.
+    When the rule was dropped on budget overflow
+    (``preamble_status.included is False``), the operator must see that
+    before navigating away -- so render the red "DROPPED" fragment naming
+    ``would_drop_slugs`` instead of redirecting silently.
+    """
+    if preamble_status is not None and not preamble_status.included:
+        context = {
+            "preamble_status": _preamble_status_context(preamble_status),
+            "slug": slug,
+        }
+        return get_templates().TemplateResponse(
+            request, "conventions/_preamble_dropped.html", context
+        )
+    return HTMLResponse(
+        status_code=status.HTTP_204_NO_CONTENT,
+        headers={"HX-Redirect": "/ui/conventions"},
+    )
+
+
+async def render_delete_confirm(
+    request: Request,
+    write_ctx: ConventionsWriteContext,
+    *,
+    session: AsyncSession,
+    slug: str,
+) -> HTMLResponse:
+    """Render the delete-confirm ``<dialog>`` gate.
+
+    The actual DELETE fires only from the button inside this confirm
+    dialog -- a plain row/detail click never deletes directly. Loads the
+    convention so the confirm copy can name the title; a missing slug
+    404s (the operator's view is stale).
+    """
+    try:
+        convention = await _service.get_convention(
+            session=session,
+            tenant_id=write_ctx.operator.tenant_id,
+            slug=slug,
+        )
+    except ConventionNotFoundError as exc:
+        raise HTTPException(status_code=404, detail="convention_not_found") from exc
+    csrf_token = mint_csrf_token(str(write_ctx.session_id))
+    context: dict[str, object] = {
+        "csrf_token": csrf_token,
+        "slug": convention.slug,
+        "title": convention.title,
+        "kind": convention.kind,
+    }
+    response = get_templates().TemplateResponse(
+        request, "conventions/_delete_confirm.html", context
+    )
+    _set_csrf_cookie(response, csrf_token)
+    return response
+
+
+async def delete_convention(
+    request: Request,
+    operator: Operator,
+    *,
+    session: AsyncSession,
+    slug: str,
+) -> HTMLResponse:
+    """Delete a convention via the service; HX-Redirect on success.
+
+    The service DELETE is **non-idempotent**: it 404s on a missing row
+    (and writes a history row before deleting). A naive "delete then
+    re-render the list" double-fires that 404 when the confirm button is
+    clicked twice (or re-submitted from a stale modal). This handler
+    catches :class:`ConventionNotFoundError` and renders a benign
+    "already deleted" fragment rather than surfacing a raw 404, so the
+    re-fire is safe.
+    """
+    _bind_write_audit(operator=operator, op_id=_OP_ID_DELETE, slug=slug)
+    try:
+        await _service.delete_convention(
+            session=session,
+            operator=operator,
+            slug=slug,
+        )
+        await session.commit()
+    except ConventionNotFoundError:
+        await session.rollback()
+        # Non-idempotent re-fire: the row is already gone. Render the
+        # benign already-deleted message instead of a 404 so a
+        # double-click on the confirm button does not surface an error.
+        return get_templates().TemplateResponse(
+            request,
+            "conventions/_delete_done.html",
+            {"slug": slug, "already_deleted": True},
+        )
+
+    _log.info(
+        "ui_conventions_delete",
+        tenant_id=str(operator.tenant_id),
+        operator_sub=operator.sub,
+        slug=slug,
+    )
+    return HTMLResponse(
+        status_code=status.HTTP_204_NO_CONTENT,
+        headers={"HX-Redirect": "/ui/conventions"},
+    )

--- a/backend/src/meho_backplane/ui/templates/conventions/_create_modal.html
+++ b/backend/src/meho_backplane/ui/templates/conventions/_create_modal.html
@@ -1,0 +1,163 @@
+{#-
+  SPDX-License-Identifier: Apache-2.0
+  Copyright (c) 2026 evoila Group
+
+  HTMX-loaded author modal for the Conventions surface (Initiative
+  #1838 Task #1896). Loaded into ``#conventions-modal-container`` on the
+  list page by the "New convention" button's ``hx-get`` to
+  ``/ui/conventions/create``. The shared app-shell modal controller
+  opens the inserted ``<dialog class="modal">`` via ``showModal()`` on
+  ``htmx:afterSwap``.
+
+  Form posts to ``POST /ui/conventions/create``:
+    * On success the route returns 204 + ``HX-Redirect: /ui/conventions``
+      and HTMX reloads the list so the new row appears -- unless the new
+      operational rule was dropped from the preamble on budget overflow,
+      in which case the route returns the red "DROPPED" fragment into the
+      ``#conventions-write-result`` slot instead.
+    * On 409 (duplicate slug) / 422 (over budget) the route returns the
+      inline error fragment into ``#conventions-write-result`` -- no
+      redirect, the operator's input survives.
+
+  Token-cost preview: the body textarea + kind selector both drive a
+  debounced ``hx-post`` to ``/ui/conventions/preview``
+  (``keyup changed delay:300ms`` on the body, ``change`` on the kind
+  selector). The preview fragment shows ``estimate_tokens(body)`` vs the
+  600-token budget, red when an operational body is over.
+
+  CSRF posture: the form declares its own ``hx-headers`` echo of the
+  token THIS render minted; the route set the matching ``meho_csrf``
+  cookie on the same response, so the double-submit pair lines up
+  (#1693). The form-level declaration also covers the body textarea's
+  debounced preview ``hx-post`` (children inherit ``hx-headers``).
+
+  RBAC: this modal is only reachable through the tenant_admin-gated
+  ``resolve_write_context`` dependency, so a plain operator never gets
+  this fragment (the GET 403s) and never sees the "New convention"
+  button (server-hidden in ``index.html``).
+-#}
+<dialog id="conventions-create-modal" class="modal">
+  <div class="modal-box max-w-3xl">
+    <h3 class="font-semibold text-lg" id="conventions-create-modal-title">
+      New convention
+    </h3>
+
+    <form
+      id="conventions-create-form"
+      hx-post="/ui/conventions/create"
+      hx-headers='{"X-CSRF-Token": "{{ csrf_token }}"}'
+      hx-target="#conventions-write-result"
+      hx-swap="innerHTML"
+      hx-disabled-elt="find button[type=submit]"
+      class="space-y-3 py-2"
+      aria-labelledby="conventions-create-modal-title"
+    >
+      <div id="conventions-write-result" aria-live="assertive"></div>
+
+      <div class="grid gap-3 md:grid-cols-2">
+        <label class="form-control">
+          <span class="label-text">Slug</span>
+          <input
+            type="text"
+            name="slug"
+            required
+            maxlength="{{ slug_max_length }}"
+            pattern="[a-z0-9][a-z0-9\-]*"
+            class="input input-bordered input-sm font-mono"
+            placeholder="confirm-before-applying"
+            aria-describedby="conventions-create-slug-hint"
+          />
+          <span id="conventions-create-slug-hint" class="text-xs opacity-60 mt-1">
+            Lowercase letters, digits, hyphen. The natural key within your tenant.
+          </span>
+        </label>
+
+        <label class="form-control">
+          <span class="label-text">Kind</span>
+          <select
+            name="kind"
+            class="select select-bordered select-sm"
+            required
+            data-action="kind-select"
+            hx-post="/ui/conventions/preview"
+            hx-trigger="change"
+            hx-target="#conventions-token-preview"
+            hx-swap="outerHTML"
+            hx-include="closest form"
+          >
+            {% for opt in kind_options %}
+              <option value="{{ opt.value }}">{{ opt.label }}</option>
+            {% endfor %}
+          </select>
+        </label>
+      </div>
+
+      <label class="form-control">
+        <span class="label-text">Title</span>
+        <input
+          type="text"
+          name="title"
+          required
+          maxlength="{{ title_max_length }}"
+          class="input input-bordered input-sm"
+          placeholder="Confirm before applying a destructive change"
+        />
+      </label>
+
+      <label class="form-control max-w-[12rem]">
+        <span class="label-text">Priority</span>
+        <input
+          type="number"
+          name="priority"
+          value="0"
+          min="{{ priority_min }}"
+          max="{{ priority_max }}"
+          class="input input-bordered input-sm font-mono"
+          aria-describedby="conventions-create-priority-hint"
+        />
+        <span id="conventions-create-priority-hint" class="text-xs opacity-60 mt-1">
+          Higher wins when the preamble packer drops on overflow.
+        </span>
+      </label>
+
+      <div class="grid gap-3 md:grid-cols-2">
+        <label class="form-control">
+          <span class="label-text">Body (Markdown)</span>
+          <textarea
+            name="body"
+            required
+            maxlength="{{ body_max_length }}"
+            class="textarea textarea-bordered min-h-[14rem] font-mono text-sm"
+            hx-post="/ui/conventions/preview"
+            hx-trigger="keyup changed delay:300ms"
+            hx-target="#conventions-token-preview"
+            hx-swap="outerHTML"
+            hx-include="closest form"
+            aria-label="Convention body in Markdown"
+            placeholder="Always confirm the change set with the operator before applying."
+          ></textarea>
+        </label>
+
+        <div class="space-y-2">
+          {% include "conventions/_token_preview.html" %}
+        </div>
+      </div>
+
+      <div class="modal-action">
+        <button
+          type="button"
+          class="btn btn-sm btn-ghost"
+          onclick="document.getElementById('conventions-create-modal').close()"
+        >
+          Cancel
+        </button>
+        <button type="submit" class="btn btn-sm btn-primary" data-action="create-submit">
+          Create
+        </button>
+      </div>
+    </form>
+  </div>
+  <form method="dialog" class="modal-backdrop">
+    <button>close</button>
+  </form>
+</dialog>

--- a/backend/src/meho_backplane/ui/templates/conventions/_delete_confirm.html
+++ b/backend/src/meho_backplane/ui/templates/conventions/_delete_confirm.html
@@ -1,0 +1,61 @@
+{#-
+  SPDX-License-Identifier: Apache-2.0
+  Copyright (c) 2026 evoila Group
+
+  Delete-confirm ``<dialog>`` gate for the Conventions surface
+  (Initiative #1838 Task #1896). Loaded into
+  ``#conventions-modal-container`` by the "Delete" button's ``hx-get`` to
+  ``/ui/conventions/{slug}/delete``.
+
+  The actual DELETE fires ONLY from the Confirm button inside this dialog
+  -- a plain row / detail click never deletes directly (the confirm gate
+  the issue's acceptance criterion requires). The service DELETE is
+  non-idempotent (404s on a missing row), so the route catches the
+  not-found and renders the benign "already deleted" fragment into
+  ``#conventions-write-result`` rather than surfacing a raw 404 on a
+  double-fire.
+
+  CSRF: the form echoes the token this render minted via ``hx-headers``
+  and the route set the matching ``meho_csrf`` cookie on this response.
+-#}
+<dialog id="conventions-delete-modal" class="modal">
+  <div class="modal-box">
+    <h3 class="font-semibold text-lg text-error" id="conventions-delete-modal-title">
+      Delete convention
+    </h3>
+
+    <div id="conventions-write-result" aria-live="assertive"></div>
+
+    <p class="py-3 text-sm">
+      Delete <span class="font-mono font-semibold">{{ slug }}</span>
+      &mdash; <em>{{ title }}</em> ({{ kind }})? This writes a history row and
+      cannot be undone. Operators relying on this rule will lose it from the
+      next session preamble.
+    </p>
+
+    <form
+      id="conventions-delete-form"
+      hx-delete="/ui/conventions/{{ slug | urlencode }}"
+      hx-headers='{"X-CSRF-Token": "{{ csrf_token }}"}'
+      hx-target="#conventions-write-result"
+      hx-swap="innerHTML"
+      hx-disabled-elt="find button[type=submit]"
+    >
+      <div class="modal-action">
+        <button
+          type="button"
+          class="btn btn-sm btn-ghost"
+          onclick="document.getElementById('conventions-delete-modal').close()"
+        >
+          Cancel
+        </button>
+        <button type="submit" class="btn btn-sm btn-error" data-action="delete-confirm">
+          Delete
+        </button>
+      </div>
+    </form>
+  </div>
+  <form method="dialog" class="modal-backdrop">
+    <button>close</button>
+  </form>
+</dialog>

--- a/backend/src/meho_backplane/ui/templates/conventions/_delete_done.html
+++ b/backend/src/meho_backplane/ui/templates/conventions/_delete_done.html
@@ -1,0 +1,26 @@
+{#-
+  SPDX-License-Identifier: Apache-2.0
+  Copyright (c) 2026 evoila Group
+
+  Benign "already deleted" fragment for the Conventions delete flow
+  (Initiative #1838 Task #1896). Rendered into ``#conventions-write-result``
+  when a DELETE re-fires on an already-gone slug -- the service DELETE is
+  non-idempotent and 404s on a missing row, so a double-click on the
+  Confirm button (or a re-submit from a stale modal) would otherwise
+  surface a raw 404. This fragment turns that into a calm "already
+  deleted" message and offers a link back to the refreshed list.
+-#}
+<div class="alert alert-info" role="status" data-already-deleted>
+  <span>
+    <span class="font-mono">{{ slug }}</span> is already deleted.
+    <a
+      href="/ui/conventions"
+      class="link"
+      hx-get="/ui/conventions"
+      hx-target="body"
+      hx-push-url="true"
+    >
+      Back to conventions
+    </a>
+  </span>
+</div>

--- a/backend/src/meho_backplane/ui/templates/conventions/_edit_modal.html
+++ b/backend/src/meho_backplane/ui/templates/conventions/_edit_modal.html
@@ -1,0 +1,130 @@
+{#-
+  SPDX-License-Identifier: Apache-2.0
+  Copyright (c) 2026 evoila Group
+
+  HTMX-loaded edit modal for the Conventions surface (Initiative #1838
+  Task #1896). Loaded into ``#conventions-modal-container`` on the detail
+  page by the "Edit" button's ``hx-get`` to
+  ``/ui/conventions/{slug}/edit``.
+
+  ``kind`` and ``slug`` are rendered read-only -- the PATCH surface
+  cannot change them (operators delete + recreate to switch kind, which
+  produces a clean two-row history trail). Only ``title`` / ``priority``
+  / ``body`` are editable, and only those three are submitted.
+
+  Form posts (``PATCH``) to ``/ui/conventions/{slug}``; on success the
+  route returns 204 + ``HX-Redirect`` (or the DROPPED fragment when the
+  edit pushes the rule out of the preamble); on 422 (over budget) the
+  inline error renders in ``#conventions-write-result``.
+-#}
+<dialog id="conventions-edit-modal" class="modal">
+  <div class="modal-box max-w-3xl">
+    <h3 class="font-semibold text-lg" id="conventions-edit-modal-title">
+      Edit convention
+    </h3>
+
+    <form
+      id="conventions-edit-form"
+      hx-patch="/ui/conventions/{{ convention.slug | urlencode }}"
+      hx-headers='{"X-CSRF-Token": "{{ csrf_token }}"}'
+      hx-target="#conventions-write-result"
+      hx-swap="innerHTML"
+      hx-disabled-elt="find button[type=submit]"
+      class="space-y-3 py-2"
+      aria-labelledby="conventions-edit-modal-title"
+    >
+      <div id="conventions-write-result" aria-live="assertive"></div>
+
+      <div class="grid gap-3 md:grid-cols-2">
+        <label class="form-control">
+          <span class="label-text">Slug <span class="opacity-60">(read-only)</span></span>
+          <input
+            type="text"
+            value="{{ convention.slug }}"
+            readonly
+            class="input input-bordered input-sm font-mono opacity-70"
+            data-readonly-slug
+          />
+        </label>
+
+        <label class="form-control">
+          <span class="label-text">Kind <span class="opacity-60">(read-only)</span></span>
+          <input
+            type="text"
+            value="{{ convention.kind }}"
+            readonly
+            class="input input-bordered input-sm font-mono opacity-70"
+            data-readonly-kind
+          />
+          <span class="text-xs opacity-60 mt-1">
+            Delete + recreate to change the kind.
+          </span>
+        </label>
+      </div>
+
+      <label class="form-control">
+        <span class="label-text">Title</span>
+        <input
+          type="text"
+          name="title"
+          required
+          maxlength="{{ title_max_length }}"
+          value="{{ convention.title }}"
+          class="input input-bordered input-sm"
+        />
+      </label>
+
+      <label class="form-control max-w-[12rem]">
+        <span class="label-text">Priority</span>
+        <input
+          type="number"
+          name="priority"
+          value="{{ convention.priority }}"
+          min="{{ priority_min }}"
+          max="{{ priority_max }}"
+          class="input input-bordered input-sm font-mono"
+        />
+      </label>
+
+      <input type="hidden" name="kind" value="{{ convention.kind }}" data-preview-kind />
+
+      <div class="grid gap-3 md:grid-cols-2">
+        <label class="form-control">
+          <span class="label-text">Body (Markdown)</span>
+          <textarea
+            name="body"
+            required
+            maxlength="{{ body_max_length }}"
+            class="textarea textarea-bordered min-h-[14rem] font-mono text-sm"
+            hx-post="/ui/conventions/preview"
+            hx-trigger="keyup changed delay:300ms"
+            hx-target="#conventions-token-preview"
+            hx-swap="outerHTML"
+            hx-include="closest form"
+            aria-label="Convention body in Markdown"
+          >{{ convention.body }}</textarea>
+        </label>
+
+        <div class="space-y-2">
+          {% include "conventions/_token_preview.html" %}
+        </div>
+      </div>
+
+      <div class="modal-action">
+        <button
+          type="button"
+          class="btn btn-sm btn-ghost"
+          onclick="document.getElementById('conventions-edit-modal').close()"
+        >
+          Cancel
+        </button>
+        <button type="submit" class="btn btn-sm btn-primary" data-action="edit-submit">
+          Save changes
+        </button>
+      </div>
+    </form>
+  </div>
+  <form method="dialog" class="modal-backdrop">
+    <button>close</button>
+  </form>
+</dialog>

--- a/backend/src/meho_backplane/ui/templates/conventions/_history_panel.html
+++ b/backend/src/meho_backplane/ui/templates/conventions/_history_panel.html
@@ -1,0 +1,80 @@
+{#-
+  SPDX-License-Identifier: Apache-2.0
+  Copyright (c) 2026 evoila Group
+
+  History diff panel for the Conventions detail view (Initiative #1838
+  Task #1896). Loaded into ``#conventions-history-panel`` on the detail
+  page by the "History" button's ``hx-get`` to
+  ``/ui/conventions/{slug}/history``.
+
+  Rows are newest-first (the service orders by ``ts DESC``). Each row
+  shows the ``body_before`` -> ``body_after`` diff side by side; the
+  CREATE row (``is_create`` / ``body_before is None``) shows no "before"
+  pane (there was no prior state). Bodies render as escaped plain text in
+  ``<pre>`` blocks, so a body containing raw HTML never executes in the
+  diff view. Each row also surfaces the actor + timestamp + the
+  ``audit_id`` soft-FK (when present) so the row joins back to the G8
+  audit log.
+-#}
+<section
+  id="conventions-history-panel"
+  class="space-y-3"
+  data-history-slug="{{ slug }}"
+  aria-label="Convention history"
+>
+  <h2 class="text-lg font-semibold">History</h2>
+
+  {% if not history %}
+    <p class="text-sm opacity-70" data-history-empty>No history yet.</p>
+  {% else %}
+    <ol class="space-y-3">
+      {% for row in history %}
+        <li
+          class="card bg-base-100 border-base-300 border shadow-sm"
+          data-history-row
+          data-is-create="{{ 'true' if row.is_create else 'false' }}"
+        >
+          <div class="card-body p-3 space-y-2">
+            <div class="text-xs opacity-70 flex flex-wrap gap-x-4 gap-y-1">
+              <span data-history-actor>by {{ row.actor_sub }}</span>
+              <span data-history-ts="{{ row.ts.isoformat() }}">
+                {{ row.ts.isoformat() }}
+              </span>
+              {% if row.audit_id %}
+                <span class="font-mono" data-history-audit-id="{{ row.audit_id }}">
+                  audit {{ row.audit_id[:8] }}
+                </span>
+              {% endif %}
+              {% if row.is_create %}
+                <span class="badge badge-success badge-xs">created</span>
+              {% endif %}
+            </div>
+
+            <div class="grid gap-3 md:grid-cols-2">
+              {% if row.is_create %}
+                <div class="opacity-50 text-sm" data-history-no-before>
+                  (no prior state &mdash; this is the CREATE event)
+                </div>
+              {% else %}
+                <div>
+                  <div class="text-xs font-semibold opacity-70 mb-1">Before</div>
+                  <pre
+                    class="text-xs whitespace-pre-wrap break-words bg-base-200 rounded-box p-2 max-h-48 overflow-auto"
+                    data-history-before
+                  >{{ row.body_before }}</pre>
+                </div>
+              {% endif %}
+              <div>
+                <div class="text-xs font-semibold opacity-70 mb-1">After</div>
+                <pre
+                  class="text-xs whitespace-pre-wrap break-words bg-base-200 rounded-box p-2 max-h-48 overflow-auto"
+                  data-history-after
+                >{{ row.body_after }}</pre>
+              </div>
+            </div>
+          </div>
+        </li>
+      {% endfor %}
+    </ol>
+  {% endif %}
+</section>

--- a/backend/src/meho_backplane/ui/templates/conventions/_preamble_dropped.html
+++ b/backend/src/meho_backplane/ui/templates/conventions/_preamble_dropped.html
@@ -1,0 +1,49 @@
+{#-
+  SPDX-License-Identifier: Apache-2.0
+  Copyright (c) 2026 evoila Group
+
+  Post-write "DROPPED" indicator for the Conventions author / edit modals
+  (Initiative #1838 Task #1896). Rendered into ``#conventions-write-result``
+  when a create / edit succeeds at the DB level but the just-written
+  ``operational`` rule was dropped from the assembled preamble on budget
+  overflow (``preamble_status.included is False``).
+
+  The operator MUST see this before navigating away -- the rule was saved
+  but agents will not see it. The fragment names every dropped slug
+  (``would_drop_slugs``) so the operator knows which rules lost the budget
+  contest, and offers a link onward to the list once acknowledged.
+-#}
+<div class="alert alert-warning items-start" role="alert" data-preamble-dropped>
+  <div class="space-y-2">
+    <div>
+      <span class="font-semibold">Saved, but DROPPED from the agent preamble.</span>
+    </div>
+    <p class="text-sm">
+      <span class="font-mono">{{ slug }}</span> was saved, but the preamble is over
+      budget so agents will not see this rule. The following operational rule{{ "" if
+      preamble_status.would_drop_slugs | length == 1 else "s" }}
+      {{ "is" if preamble_status.would_drop_slugs | length == 1 else "are" }} currently
+      dropped:
+    </p>
+    <ul class="flex flex-wrap gap-2" aria-label="Dropped conventions">
+      {% for dropped in preamble_status.would_drop_slugs %}
+        <li>
+          <span class="badge badge-error gap-1 font-mono" data-dropped-slug="{{ dropped }}">
+            {{ dropped }}
+          </span>
+        </li>
+      {% endfor %}
+    </ul>
+    <div>
+      <a
+        href="/ui/conventions"
+        class="btn btn-sm"
+        hx-get="/ui/conventions"
+        hx-target="body"
+        hx-push-url="true"
+      >
+        Back to conventions
+      </a>
+    </div>
+  </div>
+</div>

--- a/backend/src/meho_backplane/ui/templates/conventions/_token_preview.html
+++ b/backend/src/meho_backplane/ui/templates/conventions/_token_preview.html
@@ -1,0 +1,75 @@
+{#-
+  SPDX-License-Identifier: Apache-2.0
+  Copyright (c) 2026 evoila Group
+
+  Debounced token-cost preview fragment for the Conventions author /
+  edit modals (Initiative #1838 Task #1896). Returned by
+  ``POST /ui/conventions/preview`` on every debounced keystroke from the
+  body textarea (and on the kind selector's change).
+
+  The estimated token cost comes from
+  :func:`~meho_backplane.conventions.schemas.estimate_tokens` server-side
+  -- the single source of truth, never a re-derived chars/token ratio on
+  the client. An ``operational`` body whose estimate exceeds the 600-token
+  budget renders in red (``data-over-budget="true"``); ``workflow`` /
+  ``reference`` bodies are exempt (they never enter the preamble) and
+  render in a calm style regardless of size.
+
+  The element id ``#conventions-token-preview`` matches the modal's HTMX
+  swap target; ``outerHTML`` replaces the element including its id so
+  subsequent swaps land on the same target. The modal's initial render
+  includes this same partial with no ``estimated_tokens`` in context, so
+  the ``is defined`` guard renders the empty placeholder first.
+-#}
+<div
+  id="conventions-token-preview"
+  class="space-y-2"
+  aria-live="polite"
+>
+  {% if estimated_tokens is defined %}
+    <div
+      class="rounded-box border p-2 text-sm
+        {% if over_budget %}border-error bg-error/10 text-error{% else %}border-base-300 bg-base-100{% endif %}"
+      data-token-preview
+      data-over-budget="{{ 'true' if over_budget else 'false' }}"
+      data-counts-against-budget="{{ 'true' if counts_against_budget else 'false' }}"
+    >
+      <span class="font-semibold">Token cost:</span>
+      <span class="font-mono" data-estimated-tokens="{{ estimated_tokens }}">
+        {{ estimated_tokens }} / {{ max_tokens }} tokens
+      </span>
+      {% if counts_against_budget %}
+        {% if over_budget %}
+          <span class="badge badge-error badge-sm ml-1">over budget</span>
+          <p class="mt-1 text-xs">
+            This operational rule exceeds the {{ max_tokens }}-token preamble budget and
+            will be rejected on save. Trim the body, or set kind to workflow / reference.
+          </p>
+        {% else %}
+          <span class="badge badge-success badge-sm ml-1">within budget</span>
+        {% endif %}
+      {% else %}
+        <span class="badge badge-ghost badge-sm ml-1">{{ kind }} &mdash; exempt</span>
+        <p class="mt-1 text-xs opacity-70">
+          Only operational rules are packed into the agent preamble; this kind is exempt
+          from the token budget.
+        </p>
+      {% endif %}
+    </div>
+    {% if body_html %}
+      <article
+        class="prose prose-sm max-w-none bg-base-100 border-base-300 border rounded-box p-3"
+        aria-label="Convention body preview"
+      >
+        {{ body_html }}
+      </article>
+    {% endif %}
+  {% else %}
+    <div
+      class="rounded-box border border-base-300 bg-base-100 p-2 text-sm opacity-50"
+      data-token-preview
+    >
+      Token cost will appear here as you type.
+    </div>
+  {% endif %}
+</div>

--- a/backend/src/meho_backplane/ui/templates/conventions/_write_error.html
+++ b/backend/src/meho_backplane/ui/templates/conventions/_write_error.html
@@ -1,0 +1,16 @@
+{#-
+  SPDX-License-Identifier: Apache-2.0
+  Copyright (c) 2026 evoila Group
+
+  Inline write-error fragment for the Conventions author / edit modals
+  (Initiative #1838 Task #1896). Rendered into the
+  ``#conventions-write-result`` slot when a create hits a 409 (duplicate
+  slug) or an over-budget 422, or when an edit hits an over-budget 422.
+
+  No redirect -- the operator's input survives in the form fields for an
+  immediate fix-and-retry. The message is server-composed and escaped by
+  Jinja autoescape.
+-#}
+<div class="alert alert-error" role="alert" data-write-error>
+  <span>{{ message }}</span>
+</div>

--- a/backend/src/meho_backplane/ui/templates/conventions/detail.html
+++ b/backend/src/meho_backplane/ui/templates/conventions/detail.html
@@ -28,11 +28,54 @@
 {{ pygments_css }}
 </style>
 <section class="space-y-4">
-  <nav class="text-sm" aria-label="Breadcrumb">
-    <a href="/ui/conventions" class="link link-hover">Conventions</a>
-    <span aria-hidden="true">/</span>
-    <span class="font-mono">{{ convention.slug }}</span>
-  </nav>
+  <div class="flex flex-wrap items-center justify-between gap-3">
+    <nav class="text-sm" aria-label="Breadcrumb">
+      <a href="/ui/conventions" class="link link-hover">Conventions</a>
+      <span aria-hidden="true">/</span>
+      <span class="font-mono">{{ convention.slug }}</span>
+    </nav>
+
+    <div class="flex items-center gap-2">
+      {# History is a read affordance -- available to every operator. #}
+      <button
+        type="button"
+        class="btn btn-sm btn-ghost"
+        data-action="show-history"
+        hx-get="/ui/conventions/{{ convention.slug | urlencode }}/history"
+        hx-target="#conventions-history-panel"
+        hx-swap="outerHTML"
+      >
+        History
+      </button>
+      {# Edit / Delete -- server-hidden from non-admins; the write routes
+         re-check role (resolve_write_context 403s) as the authority. #}
+      {% if is_tenant_admin %}
+        <button
+          type="button"
+          class="btn btn-sm"
+          data-action="edit-convention"
+          hx-get="/ui/conventions/{{ convention.slug | urlencode }}/edit"
+          hx-target="#conventions-modal-container"
+          hx-swap="innerHTML"
+        >
+          Edit
+        </button>
+        <button
+          type="button"
+          class="btn btn-sm btn-error btn-outline"
+          data-action="delete-convention"
+          hx-get="/ui/conventions/{{ convention.slug | urlencode }}/delete"
+          hx-target="#conventions-modal-container"
+          hx-swap="innerHTML"
+        >
+          Delete
+        </button>
+      {% endif %}
+    </div>
+  </div>
+
+  {# HTMX modal mount for the edit / delete-confirm fragments. #}
+  <div id="conventions-modal-container"></div>
 
   <header
     class="card bg-base-100 border-base-300 border shadow-sm"
@@ -66,5 +109,9 @@
 
   {# Body slot -- full convention body rendered as sanitised Markdown. #}
   {% include "conventions/_body_view.html" %}
+
+  {# History diff panel mount -- the "History" button lazy-loads the
+     newest-first diff rows into this element via HTMX (outerHTML swap). #}
+  <section id="conventions-history-panel" aria-label="Convention history"></section>
 </section>
 {% endblock %}

--- a/backend/src/meho_backplane/ui/templates/conventions/index.html
+++ b/backend/src/meho_backplane/ui/templates/conventions/index.html
@@ -35,10 +35,31 @@
         Operator-authored rules packed into every agent session preamble.
       </p>
     </div>
-    <span class="text-sm opacity-70" aria-live="polite">
-      {{ entry_count }} convention{{ "" if entry_count == 1 else "s" }}
-    </span>
+    <div class="flex items-center gap-3">
+      <span class="text-sm opacity-70" aria-live="polite">
+        {{ entry_count }} convention{{ "" if entry_count == 1 else "s" }}
+      </span>
+      {# Author affordance -- server-hidden from non-admins. The write
+         route re-checks role (resolve_write_context 403s), so this is a
+         UX gate only. #}
+      {% if is_tenant_admin %}
+        <button
+          type="button"
+          class="btn btn-sm btn-primary"
+          data-action="new-convention"
+          hx-get="/ui/conventions/create"
+          hx-target="#conventions-modal-container"
+          hx-swap="innerHTML"
+        >
+          New convention
+        </button>
+      {% endif %}
+    </div>
   </header>
+
+  {# HTMX modal mount: the author modal fragment is injected here and the
+     shared modal controller opens it on htmx:afterSwap. #}
+  <div id="conventions-modal-container"></div>
 
   {# ---------- Always-on preamble token-budget banner ---------- #}
   {% include "conventions/_budget_banner.html" %}

--- a/backend/tests/test_ui_conventions_write.py
+++ b/backend/tests/test_ui_conventions_write.py
@@ -1,0 +1,792 @@
+# SPDX-License-Identifier: Apache-2.0
+# Copyright (c) 2026 evoila Group
+
+"""Behavioural tests for the Conventions UI write surface.
+
+Initiative #1838 (G10.12 Conventions console), Task #1896 (T2). Covers
+the author / edit modals + debounced token-cost preview, the
+non-idempotent DELETE confirm gate (double-fire safety), the history
+diff panel, the post-write ``preamble_status`` surfacing, and the
+RBAC + CSRF gates.
+
+Suite shape mirrors :mod:`backend.tests.test_ui_runbooks_lifecycle` (a
+real RSA-signed ``tenant_admin`` JWT lifted through the BFF session so
+``resolve_operator_or_403`` passes) and
+:mod:`backend.tests.test_ui_conventions_list` (the seed helpers).
+"""
+
+from __future__ import annotations
+
+import asyncio
+import uuid
+import warnings
+from collections.abc import Iterator
+from datetime import UTC, datetime, timedelta
+from typing import Any
+
+import pytest
+import respx
+from cryptography.fernet import Fernet
+from fastapi import FastAPI
+from fastapi.staticfiles import StaticFiles
+from fastapi.testclient import TestClient
+
+from meho_backplane.auth.jwt import clear_jwks_cache
+from meho_backplane.auth.operator import TenantRole
+from meho_backplane.conventions.schemas import ConventionKind
+from meho_backplane.db.engine import get_sessionmaker, reset_engine_for_testing
+from meho_backplane.db.models import Tenant, TenantConvention, TenantConventionHistory
+from meho_backplane.settings import get_settings
+from meho_backplane.ui.auth import SESSION_COOKIE_NAME, UISessionMiddleware
+from meho_backplane.ui.auth import build_router as build_ui_auth_router
+from meho_backplane.ui.auth.flow import (
+    clear_discovery_cache,
+    reset_verifier_store_for_testing,
+)
+from meho_backplane.ui.auth.session_store import (
+    create_session,
+    reset_fernet_cache_for_testing,
+)
+from meho_backplane.ui.csrf import (
+    CSRF_COOKIE_NAME,
+    CSRF_HEADER_NAME,
+    CSRFMiddleware,
+    mint_csrf_token,
+)
+from meho_backplane.ui.paths import static_root_dir
+from meho_backplane.ui.routes import build_router as build_ui_router
+from meho_backplane.ui.templating import reset_templating_for_testing
+from tests._oidc_jwt_helpers import (
+    make_rsa_keypair as _make_rsa_keypair,
+)
+from tests._oidc_jwt_helpers import (
+    mint_token as _mint_token,
+)
+from tests._oidc_jwt_helpers import (
+    mock_discovery_and_jwks as _mock_discovery_and_jwks,
+)
+from tests._oidc_jwt_helpers import (
+    public_jwks as _public_jwks,
+)
+
+# ---------------------------------------------------------------------------
+# Constants
+# ---------------------------------------------------------------------------
+
+_BACKPLANE_URL = "https://meho.test"
+
+_TENANT_A = uuid.UUID("11111111-1111-1111-1111-111111111111")
+_OPERATOR_SUB = "op-alice"
+
+#: ~1500-char operational body. Estimated cost (~460 tokens) is under
+#: the 600 budget alone, but two of them sum over budget -- so seeding a
+#: high-priority one first and then creating a second drops the second.
+_BIG_BODY = "Always confirm the change set with the operator before applying. " * 24
+
+#: A body whose single estimate exceeds the 600-token budget outright
+#: (>~2000 chars / 3.3). Used for the create/preview over-budget cases.
+_OVER_BUDGET_BODY = "x" * 2200
+
+
+# ---------------------------------------------------------------------------
+# Fixtures
+# ---------------------------------------------------------------------------
+
+
+@pytest.fixture(autouse=True)
+def _bff_env(monkeypatch: pytest.MonkeyPatch) -> Iterator[None]:
+    """Pin chassis + BFF env vars for every test (mirrors the list suite)."""
+    monkeypatch.setenv("KEYCLOAK_ISSUER_URL", "https://keycloak.test/realms/meho")
+    monkeypatch.setenv("KEYCLOAK_AUDIENCE", "meho-backplane")
+    monkeypatch.setenv("VAULT_ADDR", "https://vault.test")
+    monkeypatch.setenv("BACKPLANE_URL", _BACKPLANE_URL)
+    monkeypatch.setenv("UI_SESSION_ENCRYPTION_KEY", Fernet.generate_key().decode())
+    monkeypatch.setenv("UI_KEYCLOAK_CLIENT_ID", "meho-web")
+    monkeypatch.setenv("UI_KEYCLOAK_CLIENT_SECRET", "test-client-secret")
+    get_settings.cache_clear()
+    reset_fernet_cache_for_testing()
+    reset_verifier_store_for_testing()
+    reset_templating_for_testing()
+    clear_discovery_cache()
+    clear_jwks_cache()
+    reset_engine_for_testing()
+    yield
+    get_settings.cache_clear()
+    reset_fernet_cache_for_testing()
+    reset_verifier_store_for_testing()
+    reset_templating_for_testing()
+    clear_discovery_cache()
+    clear_jwks_cache()
+    reset_engine_for_testing()
+
+
+# ---------------------------------------------------------------------------
+# Helpers
+# ---------------------------------------------------------------------------
+
+
+def _build_app() -> FastAPI:
+    """Construct a minimal FastAPI app wired for the conventions UI tests."""
+    app = FastAPI()
+    app.add_middleware(CSRFMiddleware)
+    app.add_middleware(UISessionMiddleware)
+    app.mount(
+        "/ui/static",
+        StaticFiles(directory=str(static_root_dir()), check_dir=False),
+        name="ui_static",
+    )
+    app.include_router(build_ui_auth_router())
+    app.include_router(build_ui_router())
+    return app
+
+
+def _seed_tenant(tenant_id: uuid.UUID, slug: str) -> None:
+    """Insert one ``tenant`` row so the convention tenant FK resolves."""
+
+    async def _do() -> None:
+        sessionmaker = get_sessionmaker()
+        async with sessionmaker() as session, session.begin():
+            session.add(Tenant(id=tenant_id, slug=slug, name=f"Tenant {slug}"))
+
+    asyncio.run(_do())
+
+
+def _seed_convention(
+    *,
+    tenant_id: uuid.UUID,
+    slug: str,
+    title: str,
+    body: str,
+    kind: ConventionKind,
+    priority: int = 0,
+) -> None:
+    """Persist one ``tenant_convention`` row directly."""
+    now = datetime.now(UTC)
+
+    async def _do() -> None:
+        sessionmaker = get_sessionmaker()
+        async with sessionmaker() as session, session.begin():
+            session.add(
+                TenantConvention(
+                    id=uuid.uuid4(),
+                    tenant_id=tenant_id,
+                    slug=slug,
+                    title=title,
+                    body=body,
+                    kind=kind.value,
+                    priority=priority,
+                    created_by_sub=_OPERATOR_SUB,
+                    created_at=now,
+                    updated_at=now,
+                ),
+            )
+
+    asyncio.run(_do())
+
+
+def _seed_session_sync(
+    *,
+    tenant_id: uuid.UUID,
+    access_token: str,
+    operator_sub: str = _OPERATOR_SUB,
+    lifetime: timedelta = timedelta(hours=1),
+) -> uuid.UUID:
+    """Create a ``web_session`` row carrying *access_token* and return its UUID."""
+
+    async def _do() -> uuid.UUID:
+        sessionmaker = get_sessionmaker()
+        async with sessionmaker() as session, session.begin():
+            decrypted = await create_session(
+                session,
+                operator_sub=operator_sub,
+                tenant_id=tenant_id,
+                access_token=access_token,
+                refresh_token="refresh-token-plaintext",
+                lifetime=lifetime,
+            )
+            return decrypted.id
+
+    return asyncio.run(_do())
+
+
+def _make_keypair_and_jwks() -> tuple[Any, dict[str, Any]]:
+    """Mint a stable RSA-2048 keypair + the matching JWKS document."""
+    with warnings.catch_warnings():
+        warnings.simplefilter("ignore")
+        keypair = _make_rsa_keypair("ui-conventions-write-test-kid")
+    return keypair, _public_jwks(keypair)
+
+
+def _role_session(
+    role: TenantRole,
+    tenant_id: uuid.UUID = _TENANT_A,
+) -> tuple[uuid.UUID, dict[str, Any]]:
+    """Seed a session whose access token is a real JWT carrying *role*.
+
+    A ``TENANT_ADMIN`` token passes ``resolve_operator_or_403``; an
+    ``OPERATOR`` token decodes cleanly but fails the role rank check
+    -> 403.
+    """
+    keypair, jwks = _make_keypair_and_jwks()
+    access_token = _mint_token(
+        keypair,
+        sub=_OPERATOR_SUB,
+        tenant_id=str(tenant_id),
+        tenant_role=role.value,
+    )
+    session_id = _seed_session_sync(tenant_id=tenant_id, access_token=access_token)
+    return session_id, jwks
+
+
+def _admin_session(tenant_id: uuid.UUID = _TENANT_A) -> tuple[uuid.UUID, dict[str, Any]]:
+    """Seed an admin session whose access token is a real tenant_admin JWT."""
+    return _role_session(TenantRole.TENANT_ADMIN, tenant_id)
+
+
+def _authenticated_client(
+    *,
+    session_id: uuid.UUID,
+    jwks: dict[str, Any],
+) -> tuple[TestClient, respx.MockRouter]:
+    """Return a TestClient + a respx mock for the JWKS endpoint."""
+    mock = respx.mock(assert_all_called=False)
+    mock.start()
+    _mock_discovery_and_jwks(mock, jwks)
+    client = TestClient(_build_app(), follow_redirects=False)
+    client.cookies.set(SESSION_COOKIE_NAME, str(session_id))
+    return client, mock
+
+
+def _csrf_kwargs(session_id: uuid.UUID) -> dict[str, Any]:
+    """Header + cookie kwargs that satisfy the double-submit CSRF check."""
+    token = mint_csrf_token(str(session_id))
+    return {
+        "headers": {CSRF_HEADER_NAME: token, "X-CSRF-Token": token},
+        "cookies": {CSRF_COOKIE_NAME: token},
+    }
+
+
+def _row_exists(tenant_id: uuid.UUID, slug: str) -> bool:
+    """Return whether a ``tenant_convention`` row exists for ``(tenant, slug)``."""
+
+    async def _do() -> bool:
+        from sqlalchemy import select
+
+        sessionmaker = get_sessionmaker()
+        async with sessionmaker() as session:
+            stmt = select(TenantConvention).where(
+                TenantConvention.tenant_id == tenant_id,
+                TenantConvention.slug == slug,
+            )
+            return (await session.execute(stmt)).scalar_one_or_none() is not None
+
+    return asyncio.run(_do())
+
+
+def _history_count(tenant_id: uuid.UUID, slug: str) -> int:
+    """Count history rows for a convention by ``(tenant, slug)``."""
+
+    async def _do() -> int:
+        from sqlalchemy import select
+
+        sessionmaker = get_sessionmaker()
+        async with sessionmaker() as session:
+            conv_stmt = select(TenantConvention.id).where(
+                TenantConvention.tenant_id == tenant_id,
+                TenantConvention.slug == slug,
+            )
+            conv_id = (await session.execute(conv_stmt)).scalar_one_or_none()
+            if conv_id is None:
+                # Row may already be deleted; count via any history row id.
+                return 0
+            hist_stmt = select(TenantConventionHistory).where(
+                TenantConventionHistory.convention_id == conv_id,
+            )
+            return len((await session.execute(hist_stmt)).scalars().all())
+
+    return asyncio.run(_do())
+
+
+# ---------------------------------------------------------------------------
+# Author modal -- create end-to-end + duplicate conflict inline
+# ---------------------------------------------------------------------------
+
+
+def test_create_modal_renders_for_admin() -> None:
+    """``GET /ui/conventions/create`` renders the author modal for an admin."""
+    _seed_tenant(_TENANT_A, "tenant-a")
+    session_id, jwks = _admin_session()
+    client, mock = _authenticated_client(session_id=session_id, jwks=jwks)
+    try:
+        response = client.get("/ui/conventions/create")
+    finally:
+        mock.stop()
+    assert response.status_code == 200, response.text
+    body = response.text
+    assert 'id="conventions-create-modal"' in body
+    # The debounced preview wiring is present.
+    assert 'hx-post="/ui/conventions/preview"' in body
+    assert "keyup changed delay:300ms" in body
+
+
+def test_create_end_to_end_returns_hx_redirect() -> None:
+    """A tenant_admin create persists the row and returns HX-Redirect."""
+    _seed_tenant(_TENANT_A, "tenant-a")
+    session_id, jwks = _admin_session()
+    client, mock = _authenticated_client(session_id=session_id, jwks=jwks)
+    try:
+        response = client.post(
+            "/ui/conventions/create",
+            data={
+                "slug": "confirm-first",
+                "title": "Confirm before applying",
+                "body": "Always confirm before a destructive change.",
+                "kind": "operational",
+                "priority": "10",
+            },
+            **_csrf_kwargs(session_id),
+        )
+    finally:
+        mock.stop()
+    assert response.status_code == 204, response.text
+    assert response.headers["HX-Redirect"] == "/ui/conventions"
+    assert _row_exists(_TENANT_A, "confirm-first")
+    # Service write path wrote the paired CREATE history row.
+    assert _history_count(_TENANT_A, "confirm-first") == 1
+
+
+def test_create_duplicate_slug_renders_409_inline_no_redirect() -> None:
+    """A duplicate slug renders the conflict inline (no HX-Redirect)."""
+    _seed_tenant(_TENANT_A, "tenant-a")
+    _seed_convention(
+        tenant_id=_TENANT_A,
+        slug="dupe",
+        title="Existing",
+        body="already here",
+        kind=ConventionKind.REFERENCE,
+    )
+    session_id, jwks = _admin_session()
+    client, mock = _authenticated_client(session_id=session_id, jwks=jwks)
+    try:
+        response = client.post(
+            "/ui/conventions/create",
+            data={
+                "slug": "dupe",
+                "title": "Second",
+                "body": "trying to clash",
+                "kind": "reference",
+                "priority": "0",
+            },
+            **_csrf_kwargs(session_id),
+        )
+    finally:
+        mock.stop()
+    # Inline error: 200 fragment, no redirect, with an actionable message.
+    assert response.status_code == 200, response.text
+    assert "HX-Redirect" not in response.headers
+    assert "data-write-error" in response.text
+    assert "already exists" in response.text
+
+
+def test_create_over_budget_renders_422_inline() -> None:
+    """An over-budget operational body renders the 422 inline (no redirect)."""
+    _seed_tenant(_TENANT_A, "tenant-a")
+    session_id, jwks = _admin_session()
+    client, mock = _authenticated_client(session_id=session_id, jwks=jwks)
+    try:
+        response = client.post(
+            "/ui/conventions/create",
+            data={
+                "slug": "too-big",
+                "title": "Too big",
+                "body": _OVER_BUDGET_BODY,
+                "kind": "operational",
+                "priority": "0",
+            },
+            **_csrf_kwargs(session_id),
+        )
+    finally:
+        mock.stop()
+    assert response.status_code == 200, response.text
+    assert "HX-Redirect" not in response.headers
+    assert "data-write-error" in response.text
+    assert "budget" in response.text.lower()
+    # The row was NOT created (failed flush rolled back).
+    assert not _row_exists(_TENANT_A, "too-big")
+
+
+def test_create_displacing_operational_surfaces_dropped_preamble_status() -> None:
+    """A create that drops an existing rule surfaces the red DROPPED indicator.
+
+    Seed a high-priority operational rule that nearly fills the budget,
+    then create a low-priority one. The packer keeps the high-priority
+    one and drops the new low-priority one -> ``preamble_status.included``
+    is False, so the response is the DROPPED fragment (not a redirect).
+    """
+    _seed_tenant(_TENANT_A, "tenant-a")
+    _seed_convention(
+        tenant_id=_TENANT_A,
+        slug="high-rule",
+        title="High",
+        body=_BIG_BODY,
+        kind=ConventionKind.OPERATIONAL,
+        priority=100,
+    )
+    session_id, jwks = _admin_session()
+    client, mock = _authenticated_client(session_id=session_id, jwks=jwks)
+    try:
+        response = client.post(
+            "/ui/conventions/create",
+            data={
+                "slug": "low-rule",
+                "title": "Low",
+                "body": _BIG_BODY,
+                "kind": "operational",
+                "priority": "1",
+            },
+            **_csrf_kwargs(session_id),
+        )
+    finally:
+        mock.stop()
+    # Saved at the DB level, but the response warns it was dropped.
+    assert response.status_code == 200, response.text
+    assert "HX-Redirect" not in response.headers
+    assert "data-preamble-dropped" in response.text
+    assert 'data-dropped-slug="low-rule"' in response.text
+    assert _row_exists(_TENANT_A, "low-rule")
+
+
+# ---------------------------------------------------------------------------
+# Debounced token-cost preview
+# ---------------------------------------------------------------------------
+
+
+def test_preview_over_budget_operational_flagged_red() -> None:
+    """An over-budget operational body is flagged over the 600 budget in red."""
+    _seed_tenant(_TENANT_A, "tenant-a")
+    session_id, jwks = _admin_session()
+    client, mock = _authenticated_client(session_id=session_id, jwks=jwks)
+    try:
+        response = client.post(
+            "/ui/conventions/preview",
+            data={"body": _OVER_BUDGET_BODY, "kind": "operational"},
+            **_csrf_kwargs(session_id),
+        )
+    finally:
+        mock.stop()
+    assert response.status_code == 200, response.text
+    body = response.text
+    assert 'data-over-budget="true"' in body
+    assert "/ 600 tokens" in body
+    assert "text-error" in body
+
+
+def test_preview_same_body_as_reference_not_flagged() -> None:
+    """The same over-budget body as kind=reference is NOT flagged (exempt)."""
+    _seed_tenant(_TENANT_A, "tenant-a")
+    session_id, jwks = _admin_session()
+    client, mock = _authenticated_client(session_id=session_id, jwks=jwks)
+    try:
+        response = client.post(
+            "/ui/conventions/preview",
+            data={"body": _OVER_BUDGET_BODY, "kind": "reference"},
+            **_csrf_kwargs(session_id),
+        )
+    finally:
+        mock.stop()
+    assert response.status_code == 200, response.text
+    body = response.text
+    assert 'data-over-budget="false"' in body
+    assert 'data-counts-against-budget="false"' in body
+
+
+# ---------------------------------------------------------------------------
+# Non-idempotent DELETE confirm gate + double-fire safety
+# ---------------------------------------------------------------------------
+
+
+def test_delete_confirm_gate_renders_before_delete() -> None:
+    """The delete confirm step renders a dialog; the row still exists."""
+    _seed_tenant(_TENANT_A, "tenant-a")
+    _seed_convention(
+        tenant_id=_TENANT_A,
+        slug="to-delete",
+        title="To delete",
+        body="bye",
+        kind=ConventionKind.REFERENCE,
+    )
+    session_id, jwks = _admin_session()
+    client, mock = _authenticated_client(session_id=session_id, jwks=jwks)
+    try:
+        response = client.get("/ui/conventions/to-delete/delete")
+    finally:
+        mock.stop()
+    assert response.status_code == 200, response.text
+    body = response.text
+    assert 'id="conventions-delete-modal"' in body
+    assert 'hx-delete="/ui/conventions/to-delete"' in body
+    # Confirm gate only -- the row is untouched.
+    assert _row_exists(_TENANT_A, "to-delete")
+
+
+def test_delete_then_double_fire_renders_already_deleted_not_404() -> None:
+    """First DELETE removes the row; a second DELETE is benign (no raw 404).
+
+    The service DELETE is non-idempotent (404s on a missing row). The
+    confirm-gated handler must turn the re-fire into a benign "already
+    deleted" fragment rather than surfacing the raw 404.
+    """
+    _seed_tenant(_TENANT_A, "tenant-a")
+    _seed_convention(
+        tenant_id=_TENANT_A,
+        slug="gone-soon",
+        title="Gone soon",
+        body="bye",
+        kind=ConventionKind.REFERENCE,
+    )
+    session_id, jwks = _admin_session()
+    client, mock = _authenticated_client(session_id=session_id, jwks=jwks)
+    try:
+        first = client.request(
+            "DELETE",
+            "/ui/conventions/gone-soon",
+            **_csrf_kwargs(session_id),
+        )
+        second = client.request(
+            "DELETE",
+            "/ui/conventions/gone-soon",
+            **_csrf_kwargs(session_id),
+        )
+    finally:
+        mock.stop()
+    # First delete: HX-Redirect, row gone.
+    assert first.status_code == 204, first.text
+    assert first.headers["HX-Redirect"] == "/ui/conventions"
+    assert not _row_exists(_TENANT_A, "gone-soon")
+    # Second delete (double-fire): benign already-deleted fragment, NOT 404.
+    assert second.status_code == 200, second.text
+    assert "data-already-deleted" in second.text
+    assert "already deleted" in second.text
+
+
+# ---------------------------------------------------------------------------
+# Edit modal -- kind/slug not submittable, PATCH succeeds
+# ---------------------------------------------------------------------------
+
+
+def test_edit_modal_shows_kind_and_slug_readonly() -> None:
+    """The edit modal renders kind + slug read-only (PATCH cannot change them)."""
+    _seed_tenant(_TENANT_A, "tenant-a")
+    _seed_convention(
+        tenant_id=_TENANT_A,
+        slug="editable",
+        title="Editable",
+        body="original body",
+        kind=ConventionKind.WORKFLOW,
+        priority=3,
+    )
+    session_id, jwks = _admin_session()
+    client, mock = _authenticated_client(session_id=session_id, jwks=jwks)
+    try:
+        response = client.get("/ui/conventions/editable/edit")
+    finally:
+        mock.stop()
+    assert response.status_code == 200, response.text
+    body = response.text
+    assert "data-readonly-slug" in body
+    assert "data-readonly-kind" in body
+    # The title/priority/body editable fields are pre-filled.
+    assert 'value="Editable"' in body
+    assert "original body" in body
+
+
+def test_edit_patch_updates_title_priority_body() -> None:
+    """A PATCH with title/priority/body succeeds and writes a history row."""
+    _seed_tenant(_TENANT_A, "tenant-a")
+    _seed_convention(
+        tenant_id=_TENANT_A,
+        slug="patch-me",
+        title="Old title",
+        body="old body",
+        kind=ConventionKind.REFERENCE,
+        priority=0,
+    )
+    session_id, jwks = _admin_session()
+    client, mock = _authenticated_client(session_id=session_id, jwks=jwks)
+    try:
+        response = client.request(
+            "PATCH",
+            "/ui/conventions/patch-me",
+            data={"title": "New title", "body": "new body", "priority": "7"},
+            **_csrf_kwargs(session_id),
+        )
+    finally:
+        mock.stop()
+    assert response.status_code == 204, response.text
+    assert response.headers["HX-Redirect"] == "/ui/conventions"
+
+    # Read back the persisted row.
+    async def _read() -> tuple[str, str, int]:
+        from sqlalchemy import select
+
+        sessionmaker = get_sessionmaker()
+        async with sessionmaker() as session:
+            row = (
+                await session.execute(
+                    select(TenantConvention).where(
+                        TenantConvention.tenant_id == _TENANT_A,
+                        TenantConvention.slug == "patch-me",
+                    )
+                )
+            ).scalar_one()
+            return row.title, row.body, row.priority
+
+    title, body_text, priority = asyncio.run(_read())
+    assert title == "New title"
+    assert body_text == "new body"
+    assert priority == 7
+    # The update wrote a history row.
+    assert _history_count(_TENANT_A, "patch-me") == 1
+
+
+# ---------------------------------------------------------------------------
+# History diff panel -- newest-first, CREATE row has no "before"
+# ---------------------------------------------------------------------------
+
+
+def test_history_panel_renders_newest_first_with_diff() -> None:
+    """History renders newest-first; the CREATE row shows no 'before' pane."""
+    _seed_tenant(_TENANT_A, "tenant-a")
+    session_id, jwks = _admin_session()
+    client, mock = _authenticated_client(session_id=session_id, jwks=jwks)
+    try:
+        # Create (history row #1, body_before=None) then PATCH (row #2).
+        client.post(
+            "/ui/conventions/create",
+            data={
+                "slug": "history-rule",
+                "title": "v1 title",
+                "body": "first body",
+                "kind": "reference",
+                "priority": "0",
+            },
+            **_csrf_kwargs(session_id),
+        )
+        client.request(
+            "PATCH",
+            "/ui/conventions/history-rule",
+            data={"title": "v2 title", "body": "second body", "priority": "0"},
+            **_csrf_kwargs(session_id),
+        )
+        response = client.get("/ui/conventions/history-rule/history")
+    finally:
+        mock.stop()
+    assert response.status_code == 200, response.text
+    body = response.text
+    assert 'id="conventions-history-panel"' in body
+    # Two history rows present.
+    assert body.count("data-history-row") == 2
+    # Newest-first: the PATCH row (after="second body") appears before the
+    # CREATE row (no before pane).
+    first_idx = body.index("second body")
+    create_idx = body.index("this is the CREATE event") if "CREATE event" in body else len(body)
+    assert first_idx < create_idx
+    # The CREATE row carries no "before" diff pane.
+    assert "data-history-no-before" in body
+    # The PATCH row shows the before->after diff.
+    assert "data-history-before" in body
+    assert "first body" in body  # body_before of the PATCH row
+
+
+# ---------------------------------------------------------------------------
+# RBAC + CSRF gates
+# ---------------------------------------------------------------------------
+
+
+def test_create_non_admin_operator_gets_403() -> None:
+    """A plain operator (non-admin) is 403'd on the create POST."""
+    _seed_tenant(_TENANT_A, "tenant-a")
+    session_id, jwks = _role_session(TenantRole.OPERATOR)
+    client, mock = _authenticated_client(session_id=session_id, jwks=jwks)
+    try:
+        response = client.post(
+            "/ui/conventions/create",
+            data={
+                "slug": "nope",
+                "title": "Nope",
+                "body": "should be blocked",
+                "kind": "reference",
+                "priority": "0",
+            },
+            **_csrf_kwargs(session_id),
+        )
+    finally:
+        mock.stop()
+    assert response.status_code == 403, response.text
+    assert not _row_exists(_TENANT_A, "nope")
+
+
+def test_create_missing_csrf_blocked() -> None:
+    """A create POST without the CSRF double-submit pair is blocked (403)."""
+    _seed_tenant(_TENANT_A, "tenant-a")
+    session_id, jwks = _admin_session()
+    client, mock = _authenticated_client(session_id=session_id, jwks=jwks)
+    try:
+        response = client.post(
+            "/ui/conventions/create",
+            data={
+                "slug": "no-csrf",
+                "title": "No CSRF",
+                "body": "blocked",
+                "kind": "reference",
+                "priority": "0",
+            },
+        )
+    finally:
+        mock.stop()
+    assert response.status_code == 403, response.text
+    assert not _row_exists(_TENANT_A, "no-csrf")
+
+
+def test_delete_non_admin_operator_gets_403() -> None:
+    """A plain operator is 403'd on the DELETE (and the row survives)."""
+    _seed_tenant(_TENANT_A, "tenant-a")
+    _seed_convention(
+        tenant_id=_TENANT_A,
+        slug="protected",
+        title="Protected",
+        body="stays",
+        kind=ConventionKind.REFERENCE,
+    )
+    session_id, jwks = _role_session(TenantRole.OPERATOR)
+    client, mock = _authenticated_client(session_id=session_id, jwks=jwks)
+    try:
+        response = client.request(
+            "DELETE",
+            "/ui/conventions/protected",
+            **_csrf_kwargs(session_id),
+        )
+    finally:
+        mock.stop()
+    assert response.status_code == 403, response.text
+    assert _row_exists(_TENANT_A, "protected")
+
+
+# ---------------------------------------------------------------------------
+# Route ordering -- static /create + /preview before /{slug}
+# ---------------------------------------------------------------------------
+
+
+def test_route_order_create_not_swallowed_by_slug() -> None:
+    """``/ui/conventions/create`` hits the author modal, not ``{slug}=create``."""
+    _seed_tenant(_TENANT_A, "tenant-a")
+    session_id, jwks = _admin_session()
+    client, mock = _authenticated_client(session_id=session_id, jwks=jwks)
+    try:
+        response = client.get("/ui/conventions/create")
+    finally:
+        mock.stop()
+    assert response.status_code == 200, response.text
+    # The author-modal marker proves the literal route won (the detail
+    # handler would 404 on a non-existent slug "create").
+    assert 'id="conventions-create-modal"' in response.text

--- a/cli/api/openapi.json
+++ b/cli/api/openapi.json
@@ -9747,6 +9747,130 @@
         }
       }
     },
+    "/ui/conventions/create": {
+      "get": {
+        "tags": [
+          "ui-conventions"
+        ],
+        "summary": "Ui Conventions Create Modal",
+        "description": "``GET /ui/conventions/create`` -- HTMX author modal fragment.",
+        "operationId": "ui_conventions_create_modal_ui_conventions_create_get",
+        "requestBody": {
+          "content": {
+            "application/json": {
+              "schema": {
+                "$ref": "#/components/schemas/UISessionContext",
+                "nullable": true,
+                "title": "Session Ctx"
+              }
+            }
+          }
+        },
+        "responses": {
+          "200": {
+            "description": "Successful Response",
+            "content": {
+              "text/html": {
+                "schema": {
+                  "type": "string"
+                }
+              }
+            }
+          },
+          "422": {
+            "description": "Validation Error",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/HTTPValidationError"
+                }
+              }
+            }
+          }
+        }
+      },
+      "post": {
+        "tags": [
+          "ui-conventions"
+        ],
+        "summary": "Ui Conventions Create Submit",
+        "description": "``POST /ui/conventions/create`` -- author a convention via the service.",
+        "operationId": "ui_conventions_create_submit_ui_conventions_create_post",
+        "requestBody": {
+          "content": {
+            "application/x-www-form-urlencoded": {
+              "schema": {
+                "$ref": "#/components/schemas/Body_ui_conventions_create_submit_ui_conventions_create_post"
+              }
+            }
+          },
+          "required": true
+        },
+        "responses": {
+          "200": {
+            "description": "Successful Response",
+            "content": {
+              "text/html": {
+                "schema": {
+                  "type": "string"
+                }
+              }
+            }
+          },
+          "422": {
+            "description": "Validation Error",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/HTTPValidationError"
+                }
+              }
+            }
+          }
+        }
+      }
+    },
+    "/ui/conventions/preview": {
+      "post": {
+        "tags": [
+          "ui-conventions"
+        ],
+        "summary": "Ui Conventions Preview",
+        "description": "``POST /ui/conventions/preview`` -- debounced token-cost preview.\n\nGated on tenant_admin (the preview is part of the author / edit\nwrite flow); the chassis CSRF middleware already rejected an\nanonymous / cross-site POST.",
+        "operationId": "ui_conventions_preview_ui_conventions_preview_post",
+        "requestBody": {
+          "content": {
+            "application/x-www-form-urlencoded": {
+              "schema": {
+                "$ref": "#/components/schemas/Body_ui_conventions_preview_ui_conventions_preview_post"
+              }
+            }
+          }
+        },
+        "responses": {
+          "200": {
+            "description": "Successful Response",
+            "content": {
+              "text/html": {
+                "schema": {
+                  "type": "string"
+                }
+              }
+            }
+          },
+          "422": {
+            "description": "Validation Error",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/HTTPValidationError"
+                }
+              }
+            }
+          }
+        }
+      }
+    },
     "/ui/conventions/{slug}": {
       "get": {
         "tags": [
@@ -9755,6 +9879,271 @@
         "summary": "Ui Conventions Detail",
         "description": "``GET /ui/conventions/{slug}`` -- detail page or HTMX body fragment.",
         "operationId": "ui_conventions_detail_ui_conventions__slug__get",
+        "parameters": [
+          {
+            "name": "slug",
+            "in": "path",
+            "required": true,
+            "schema": {
+              "type": "string",
+              "title": "Slug"
+            }
+          }
+        ],
+        "requestBody": {
+          "content": {
+            "application/json": {
+              "schema": {
+                "$ref": "#/components/schemas/UISessionContext",
+                "nullable": true,
+                "title": "Session Ctx"
+              }
+            }
+          }
+        },
+        "responses": {
+          "200": {
+            "description": "Successful Response",
+            "content": {
+              "text/html": {
+                "schema": {
+                  "type": "string"
+                }
+              }
+            }
+          },
+          "422": {
+            "description": "Validation Error",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/HTTPValidationError"
+                }
+              }
+            }
+          }
+        }
+      },
+      "patch": {
+        "tags": [
+          "ui-conventions"
+        ],
+        "summary": "Ui Conventions Patch",
+        "description": "``PATCH /ui/conventions/{slug}`` -- apply an edit via the service.\n\n``kind`` + ``slug`` are not in the form -- the PATCH surface cannot\nchange them (the edit modal renders them read-only).",
+        "operationId": "ui_conventions_patch_ui_conventions__slug__patch",
+        "parameters": [
+          {
+            "name": "slug",
+            "in": "path",
+            "required": true,
+            "schema": {
+              "type": "string",
+              "title": "Slug"
+            }
+          }
+        ],
+        "requestBody": {
+          "required": true,
+          "content": {
+            "application/x-www-form-urlencoded": {
+              "schema": {
+                "$ref": "#/components/schemas/Body_ui_conventions_patch_ui_conventions__slug__patch"
+              }
+            }
+          }
+        },
+        "responses": {
+          "200": {
+            "description": "Successful Response",
+            "content": {
+              "text/html": {
+                "schema": {
+                  "type": "string"
+                }
+              }
+            }
+          },
+          "422": {
+            "description": "Validation Error",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/HTTPValidationError"
+                }
+              }
+            }
+          }
+        }
+      },
+      "delete": {
+        "tags": [
+          "ui-conventions"
+        ],
+        "summary": "Ui Conventions Delete",
+        "description": "``DELETE /ui/conventions/{slug}`` -- delete behind the confirm gate.",
+        "operationId": "ui_conventions_delete_ui_conventions__slug__delete",
+        "parameters": [
+          {
+            "name": "slug",
+            "in": "path",
+            "required": true,
+            "schema": {
+              "type": "string",
+              "title": "Slug"
+            }
+          }
+        ],
+        "requestBody": {
+          "content": {
+            "application/json": {
+              "schema": {
+                "$ref": "#/components/schemas/UISessionContext",
+                "nullable": true,
+                "title": "Session Ctx"
+              }
+            }
+          }
+        },
+        "responses": {
+          "200": {
+            "description": "Successful Response",
+            "content": {
+              "text/html": {
+                "schema": {
+                  "type": "string"
+                }
+              }
+            }
+          },
+          "422": {
+            "description": "Validation Error",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/HTTPValidationError"
+                }
+              }
+            }
+          }
+        }
+      }
+    },
+    "/ui/conventions/{slug}/edit": {
+      "get": {
+        "tags": [
+          "ui-conventions"
+        ],
+        "summary": "Ui Conventions Edit Modal",
+        "description": "``GET /ui/conventions/{slug}/edit`` -- HTMX edit modal fragment.",
+        "operationId": "ui_conventions_edit_modal_ui_conventions__slug__edit_get",
+        "parameters": [
+          {
+            "name": "slug",
+            "in": "path",
+            "required": true,
+            "schema": {
+              "type": "string",
+              "title": "Slug"
+            }
+          }
+        ],
+        "requestBody": {
+          "content": {
+            "application/json": {
+              "schema": {
+                "$ref": "#/components/schemas/UISessionContext",
+                "nullable": true,
+                "title": "Session Ctx"
+              }
+            }
+          }
+        },
+        "responses": {
+          "200": {
+            "description": "Successful Response",
+            "content": {
+              "text/html": {
+                "schema": {
+                  "type": "string"
+                }
+              }
+            }
+          },
+          "422": {
+            "description": "Validation Error",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/HTTPValidationError"
+                }
+              }
+            }
+          }
+        }
+      }
+    },
+    "/ui/conventions/{slug}/delete": {
+      "get": {
+        "tags": [
+          "ui-conventions"
+        ],
+        "summary": "Ui Conventions Delete Confirm",
+        "description": "``GET /ui/conventions/{slug}/delete`` -- HTMX delete-confirm gate.",
+        "operationId": "ui_conventions_delete_confirm_ui_conventions__slug__delete_get",
+        "parameters": [
+          {
+            "name": "slug",
+            "in": "path",
+            "required": true,
+            "schema": {
+              "type": "string",
+              "title": "Slug"
+            }
+          }
+        ],
+        "requestBody": {
+          "content": {
+            "application/json": {
+              "schema": {
+                "$ref": "#/components/schemas/UISessionContext",
+                "nullable": true,
+                "title": "Session Ctx"
+              }
+            }
+          }
+        },
+        "responses": {
+          "200": {
+            "description": "Successful Response",
+            "content": {
+              "text/html": {
+                "schema": {
+                  "type": "string"
+                }
+              }
+            }
+          },
+          "422": {
+            "description": "Validation Error",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/HTTPValidationError"
+                }
+              }
+            }
+          }
+        }
+      }
+    },
+    "/ui/conventions/{slug}/history": {
+      "get": {
+        "tags": [
+          "ui-conventions"
+        ],
+        "summary": "Ui Conventions History",
+        "description": "``GET /ui/conventions/{slug}/history`` -- HTMX history diff panel.\n\nRead surface (OPERATOR-tier) -- history is a read of the\n``tenant_convention_history`` rows, gated like the detail view.",
+        "operationId": "ui_conventions_history_ui_conventions__slug__history_get",
         "parameters": [
           {
             "name": "slug",
@@ -15924,6 +16313,102 @@
         },
         "type": "object",
         "title": "Body_ui_connectors_import_preview_ui_connectors_import_post"
+      },
+      "Body_ui_conventions_create_submit_ui_conventions_create_post": {
+        "properties": {
+          "slug": {
+            "type": "string",
+            "maxLength": 128,
+            "title": "Slug"
+          },
+          "title": {
+            "type": "string",
+            "maxLength": 200,
+            "title": "Title"
+          },
+          "body": {
+            "type": "string",
+            "maxLength": 64000,
+            "title": "Body"
+          },
+          "kind": {
+            "type": "string",
+            "maxLength": 32,
+            "title": "Kind"
+          },
+          "priority": {
+            "type": "integer",
+            "maximum": 32767.0,
+            "minimum": -32768.0,
+            "title": "Priority",
+            "default": 0
+          },
+          "session_ctx": {
+            "$ref": "#/components/schemas/UISessionContext",
+            "nullable": true
+          }
+        },
+        "type": "object",
+        "required": [
+          "slug",
+          "title",
+          "body",
+          "kind"
+        ],
+        "title": "Body_ui_conventions_create_submit_ui_conventions_create_post"
+      },
+      "Body_ui_conventions_patch_ui_conventions__slug__patch": {
+        "properties": {
+          "title": {
+            "type": "string",
+            "maxLength": 200,
+            "title": "Title"
+          },
+          "body": {
+            "type": "string",
+            "maxLength": 64000,
+            "title": "Body"
+          },
+          "priority": {
+            "type": "integer",
+            "maximum": 32767.0,
+            "minimum": -32768.0,
+            "title": "Priority"
+          },
+          "session_ctx": {
+            "$ref": "#/components/schemas/UISessionContext",
+            "nullable": true
+          }
+        },
+        "type": "object",
+        "required": [
+          "title",
+          "body",
+          "priority"
+        ],
+        "title": "Body_ui_conventions_patch_ui_conventions__slug__patch"
+      },
+      "Body_ui_conventions_preview_ui_conventions_preview_post": {
+        "properties": {
+          "body": {
+            "type": "string",
+            "maxLength": 64000,
+            "title": "Body",
+            "default": ""
+          },
+          "kind": {
+            "type": "string",
+            "maxLength": 32,
+            "title": "Kind",
+            "default": "operational"
+          },
+          "session_ctx": {
+            "$ref": "#/components/schemas/UISessionContext",
+            "nullable": true
+          }
+        },
+        "type": "object",
+        "title": "Body_ui_conventions_preview_ui_conventions_preview_post"
       },
       "Body_ui_corpus_collections_register_submit_ui_corpus_collections_register_post": {
         "properties": {

--- a/cli/internal/api/client.gen.go
+++ b/cli/internal/api/client.gen.go
@@ -1650,6 +1650,91 @@ type BodyUiConnectorsImportPreviewUiConnectorsImportPost struct {
 	Upload     *string           `json:"upload"`
 }
 
+// BodyUiConventionsCreateSubmitUiConventionsCreatePost defines model for Body_ui_conventions_create_submit_ui_conventions_create_post.
+type BodyUiConventionsCreateSubmitUiConventionsCreatePost struct {
+	Body     string `json:"body"`
+	Kind     string `json:"kind"`
+	Priority *int   `json:"priority,omitempty"`
+
+	// SessionCtx Per-request session identity exposed on ``request.state``.
+	//
+	// Frozen so a route handler that stashes the context on a logger
+	// or forwards it to a service layer cannot accidentally mutate
+	// fields downstream. The shape mirrors :class:`Operator` for the
+	// fields T5 (#866) needs to render an authenticated page header;
+	// ``raw_jwt`` / ``tenant_role`` are intentionally absent because
+	// the session-cookie path does not load them today (the encrypted
+	// row carries only the access token, not the decoded claims).
+	//
+	// ``tenant_slug`` / ``tenant_name`` are populated by the middleware
+	// from a same-request lookup against the ``tenant`` table (keyed on
+	// :attr:`tenant_id`). The fields are surfaced into every UI template
+	// by the chassis context processor so the page header's tenant chip
+	// renders the operator-readable name without each route having to
+	// re-fetch the row (G0.15-T9 #1217). Both are ``None`` only when the
+	// tenant row was deleted between session-creation and the request
+	// (an ops anomaly; the operator still authenticates fine, the chip
+	// just falls back to the tenant UUID).
+	SessionCtx *UISessionContext `json:"session_ctx,omitempty"`
+	Slug       string            `json:"slug"`
+	Title      string            `json:"title"`
+}
+
+// BodyUiConventionsPatchUiConventionsSlugPatch defines model for Body_ui_conventions_patch_ui_conventions__slug__patch.
+type BodyUiConventionsPatchUiConventionsSlugPatch struct {
+	Body     string `json:"body"`
+	Priority int    `json:"priority"`
+
+	// SessionCtx Per-request session identity exposed on ``request.state``.
+	//
+	// Frozen so a route handler that stashes the context on a logger
+	// or forwards it to a service layer cannot accidentally mutate
+	// fields downstream. The shape mirrors :class:`Operator` for the
+	// fields T5 (#866) needs to render an authenticated page header;
+	// ``raw_jwt`` / ``tenant_role`` are intentionally absent because
+	// the session-cookie path does not load them today (the encrypted
+	// row carries only the access token, not the decoded claims).
+	//
+	// ``tenant_slug`` / ``tenant_name`` are populated by the middleware
+	// from a same-request lookup against the ``tenant`` table (keyed on
+	// :attr:`tenant_id`). The fields are surfaced into every UI template
+	// by the chassis context processor so the page header's tenant chip
+	// renders the operator-readable name without each route having to
+	// re-fetch the row (G0.15-T9 #1217). Both are ``None`` only when the
+	// tenant row was deleted between session-creation and the request
+	// (an ops anomaly; the operator still authenticates fine, the chip
+	// just falls back to the tenant UUID).
+	SessionCtx *UISessionContext `json:"session_ctx,omitempty"`
+	Title      string            `json:"title"`
+}
+
+// BodyUiConventionsPreviewUiConventionsPreviewPost defines model for Body_ui_conventions_preview_ui_conventions_preview_post.
+type BodyUiConventionsPreviewUiConventionsPreviewPost struct {
+	Body *string `json:"body,omitempty"`
+	Kind *string `json:"kind,omitempty"`
+
+	// SessionCtx Per-request session identity exposed on ``request.state``.
+	//
+	// Frozen so a route handler that stashes the context on a logger
+	// or forwards it to a service layer cannot accidentally mutate
+	// fields downstream. The shape mirrors :class:`Operator` for the
+	// fields T5 (#866) needs to render an authenticated page header;
+	// ``raw_jwt`` / ``tenant_role`` are intentionally absent because
+	// the session-cookie path does not load them today (the encrypted
+	// row carries only the access token, not the decoded claims).
+	//
+	// ``tenant_slug`` / ``tenant_name`` are populated by the middleware
+	// from a same-request lookup against the ``tenant`` table (keyed on
+	// :attr:`tenant_id`). The fields are surfaced into every UI template
+	// by the chassis context processor so the page header's tenant chip
+	// renders the operator-readable name without each route having to
+	// re-fetch the row (G0.15-T9 #1217). Both are ``None`` only when the
+	// tenant row was deleted between session-creation and the request
+	// (an ops anomaly; the operator still authenticates fine, the chip
+	// just falls back to the tenant UUID).
+	SessionCtx *UISessionContext `json:"session_ctx,omitempty"`
+}
+
 // BodyUiCorpusCollectionsRegisterSubmitUiCorpusCollectionsRegisterPost defines model for Body_ui_corpus_collections_register_submit_ui_corpus_collections_register_post.
 type BodyUiCorpusCollectionsRegisterSubmitUiCorpusCollectionsRegisterPost struct {
 	BackendRef    *string `json:"backend_ref"`
@@ -6948,8 +7033,32 @@ type UiConnectorsReprobeUiConnectorsNameProbePostJSONRequestBody = UISessionCont
 // UiConventionsListUiConventionsGetJSONRequestBody defines body for UiConventionsListUiConventionsGet for application/json ContentType.
 type UiConventionsListUiConventionsGetJSONRequestBody = UISessionContext
 
+// UiConventionsCreateModalUiConventionsCreateGetJSONRequestBody defines body for UiConventionsCreateModalUiConventionsCreateGet for application/json ContentType.
+type UiConventionsCreateModalUiConventionsCreateGetJSONRequestBody = UISessionContext
+
+// UiConventionsCreateSubmitUiConventionsCreatePostFormdataRequestBody defines body for UiConventionsCreateSubmitUiConventionsCreatePost for application/x-www-form-urlencoded ContentType.
+type UiConventionsCreateSubmitUiConventionsCreatePostFormdataRequestBody = BodyUiConventionsCreateSubmitUiConventionsCreatePost
+
+// UiConventionsPreviewUiConventionsPreviewPostFormdataRequestBody defines body for UiConventionsPreviewUiConventionsPreviewPost for application/x-www-form-urlencoded ContentType.
+type UiConventionsPreviewUiConventionsPreviewPostFormdataRequestBody = BodyUiConventionsPreviewUiConventionsPreviewPost
+
+// UiConventionsDeleteUiConventionsSlugDeleteJSONRequestBody defines body for UiConventionsDeleteUiConventionsSlugDelete for application/json ContentType.
+type UiConventionsDeleteUiConventionsSlugDeleteJSONRequestBody = UISessionContext
+
 // UiConventionsDetailUiConventionsSlugGetJSONRequestBody defines body for UiConventionsDetailUiConventionsSlugGet for application/json ContentType.
 type UiConventionsDetailUiConventionsSlugGetJSONRequestBody = UISessionContext
+
+// UiConventionsPatchUiConventionsSlugPatchFormdataRequestBody defines body for UiConventionsPatchUiConventionsSlugPatch for application/x-www-form-urlencoded ContentType.
+type UiConventionsPatchUiConventionsSlugPatchFormdataRequestBody = BodyUiConventionsPatchUiConventionsSlugPatch
+
+// UiConventionsDeleteConfirmUiConventionsSlugDeleteGetJSONRequestBody defines body for UiConventionsDeleteConfirmUiConventionsSlugDeleteGet for application/json ContentType.
+type UiConventionsDeleteConfirmUiConventionsSlugDeleteGetJSONRequestBody = UISessionContext
+
+// UiConventionsEditModalUiConventionsSlugEditGetJSONRequestBody defines body for UiConventionsEditModalUiConventionsSlugEditGet for application/json ContentType.
+type UiConventionsEditModalUiConventionsSlugEditGetJSONRequestBody = UISessionContext
+
+// UiConventionsHistoryUiConventionsSlugHistoryGetJSONRequestBody defines body for UiConventionsHistoryUiConventionsSlugHistoryGet for application/json ContentType.
+type UiConventionsHistoryUiConventionsSlugHistoryGetJSONRequestBody = UISessionContext
 
 // UiCorpusCollectionsTableUiCorpusCollectionsGetJSONRequestBody defines body for UiCorpusCollectionsTableUiCorpusCollectionsGet for application/json ContentType.
 type UiCorpusCollectionsTableUiCorpusCollectionsGetJSONRequestBody = UISessionContext
@@ -8586,10 +8695,50 @@ type ClientInterface interface {
 
 	UiConventionsListUiConventionsGet(ctx context.Context, params *UiConventionsListUiConventionsGetParams, body UiConventionsListUiConventionsGetJSONRequestBody, reqEditors ...RequestEditorFn) (*http.Response, error)
 
+	// UiConventionsCreateModalUiConventionsCreateGetWithBody request with any body
+	UiConventionsCreateModalUiConventionsCreateGetWithBody(ctx context.Context, contentType string, body io.Reader, reqEditors ...RequestEditorFn) (*http.Response, error)
+
+	UiConventionsCreateModalUiConventionsCreateGet(ctx context.Context, body UiConventionsCreateModalUiConventionsCreateGetJSONRequestBody, reqEditors ...RequestEditorFn) (*http.Response, error)
+
+	// UiConventionsCreateSubmitUiConventionsCreatePostWithBody request with any body
+	UiConventionsCreateSubmitUiConventionsCreatePostWithBody(ctx context.Context, contentType string, body io.Reader, reqEditors ...RequestEditorFn) (*http.Response, error)
+
+	UiConventionsCreateSubmitUiConventionsCreatePostWithFormdataBody(ctx context.Context, body UiConventionsCreateSubmitUiConventionsCreatePostFormdataRequestBody, reqEditors ...RequestEditorFn) (*http.Response, error)
+
+	// UiConventionsPreviewUiConventionsPreviewPostWithBody request with any body
+	UiConventionsPreviewUiConventionsPreviewPostWithBody(ctx context.Context, contentType string, body io.Reader, reqEditors ...RequestEditorFn) (*http.Response, error)
+
+	UiConventionsPreviewUiConventionsPreviewPostWithFormdataBody(ctx context.Context, body UiConventionsPreviewUiConventionsPreviewPostFormdataRequestBody, reqEditors ...RequestEditorFn) (*http.Response, error)
+
+	// UiConventionsDeleteUiConventionsSlugDeleteWithBody request with any body
+	UiConventionsDeleteUiConventionsSlugDeleteWithBody(ctx context.Context, slug string, contentType string, body io.Reader, reqEditors ...RequestEditorFn) (*http.Response, error)
+
+	UiConventionsDeleteUiConventionsSlugDelete(ctx context.Context, slug string, body UiConventionsDeleteUiConventionsSlugDeleteJSONRequestBody, reqEditors ...RequestEditorFn) (*http.Response, error)
+
 	// UiConventionsDetailUiConventionsSlugGetWithBody request with any body
 	UiConventionsDetailUiConventionsSlugGetWithBody(ctx context.Context, slug string, contentType string, body io.Reader, reqEditors ...RequestEditorFn) (*http.Response, error)
 
 	UiConventionsDetailUiConventionsSlugGet(ctx context.Context, slug string, body UiConventionsDetailUiConventionsSlugGetJSONRequestBody, reqEditors ...RequestEditorFn) (*http.Response, error)
+
+	// UiConventionsPatchUiConventionsSlugPatchWithBody request with any body
+	UiConventionsPatchUiConventionsSlugPatchWithBody(ctx context.Context, slug string, contentType string, body io.Reader, reqEditors ...RequestEditorFn) (*http.Response, error)
+
+	UiConventionsPatchUiConventionsSlugPatchWithFormdataBody(ctx context.Context, slug string, body UiConventionsPatchUiConventionsSlugPatchFormdataRequestBody, reqEditors ...RequestEditorFn) (*http.Response, error)
+
+	// UiConventionsDeleteConfirmUiConventionsSlugDeleteGetWithBody request with any body
+	UiConventionsDeleteConfirmUiConventionsSlugDeleteGetWithBody(ctx context.Context, slug string, contentType string, body io.Reader, reqEditors ...RequestEditorFn) (*http.Response, error)
+
+	UiConventionsDeleteConfirmUiConventionsSlugDeleteGet(ctx context.Context, slug string, body UiConventionsDeleteConfirmUiConventionsSlugDeleteGetJSONRequestBody, reqEditors ...RequestEditorFn) (*http.Response, error)
+
+	// UiConventionsEditModalUiConventionsSlugEditGetWithBody request with any body
+	UiConventionsEditModalUiConventionsSlugEditGetWithBody(ctx context.Context, slug string, contentType string, body io.Reader, reqEditors ...RequestEditorFn) (*http.Response, error)
+
+	UiConventionsEditModalUiConventionsSlugEditGet(ctx context.Context, slug string, body UiConventionsEditModalUiConventionsSlugEditGetJSONRequestBody, reqEditors ...RequestEditorFn) (*http.Response, error)
+
+	// UiConventionsHistoryUiConventionsSlugHistoryGetWithBody request with any body
+	UiConventionsHistoryUiConventionsSlugHistoryGetWithBody(ctx context.Context, slug string, contentType string, body io.Reader, reqEditors ...RequestEditorFn) (*http.Response, error)
+
+	UiConventionsHistoryUiConventionsSlugHistoryGet(ctx context.Context, slug string, body UiConventionsHistoryUiConventionsSlugHistoryGetJSONRequestBody, reqEditors ...RequestEditorFn) (*http.Response, error)
 
 	// CorpusIndexUiCorpusGet request
 	CorpusIndexUiCorpusGet(ctx context.Context, reqEditors ...RequestEditorFn) (*http.Response, error)
@@ -11912,6 +12061,102 @@ func (c *Client) UiConventionsListUiConventionsGet(ctx context.Context, params *
 	return c.Client.Do(req)
 }
 
+func (c *Client) UiConventionsCreateModalUiConventionsCreateGetWithBody(ctx context.Context, contentType string, body io.Reader, reqEditors ...RequestEditorFn) (*http.Response, error) {
+	req, err := NewUiConventionsCreateModalUiConventionsCreateGetRequestWithBody(c.Server, contentType, body)
+	if err != nil {
+		return nil, err
+	}
+	req = req.WithContext(ctx)
+	if err := c.applyEditors(ctx, req, reqEditors); err != nil {
+		return nil, err
+	}
+	return c.Client.Do(req)
+}
+
+func (c *Client) UiConventionsCreateModalUiConventionsCreateGet(ctx context.Context, body UiConventionsCreateModalUiConventionsCreateGetJSONRequestBody, reqEditors ...RequestEditorFn) (*http.Response, error) {
+	req, err := NewUiConventionsCreateModalUiConventionsCreateGetRequest(c.Server, body)
+	if err != nil {
+		return nil, err
+	}
+	req = req.WithContext(ctx)
+	if err := c.applyEditors(ctx, req, reqEditors); err != nil {
+		return nil, err
+	}
+	return c.Client.Do(req)
+}
+
+func (c *Client) UiConventionsCreateSubmitUiConventionsCreatePostWithBody(ctx context.Context, contentType string, body io.Reader, reqEditors ...RequestEditorFn) (*http.Response, error) {
+	req, err := NewUiConventionsCreateSubmitUiConventionsCreatePostRequestWithBody(c.Server, contentType, body)
+	if err != nil {
+		return nil, err
+	}
+	req = req.WithContext(ctx)
+	if err := c.applyEditors(ctx, req, reqEditors); err != nil {
+		return nil, err
+	}
+	return c.Client.Do(req)
+}
+
+func (c *Client) UiConventionsCreateSubmitUiConventionsCreatePostWithFormdataBody(ctx context.Context, body UiConventionsCreateSubmitUiConventionsCreatePostFormdataRequestBody, reqEditors ...RequestEditorFn) (*http.Response, error) {
+	req, err := NewUiConventionsCreateSubmitUiConventionsCreatePostRequestWithFormdataBody(c.Server, body)
+	if err != nil {
+		return nil, err
+	}
+	req = req.WithContext(ctx)
+	if err := c.applyEditors(ctx, req, reqEditors); err != nil {
+		return nil, err
+	}
+	return c.Client.Do(req)
+}
+
+func (c *Client) UiConventionsPreviewUiConventionsPreviewPostWithBody(ctx context.Context, contentType string, body io.Reader, reqEditors ...RequestEditorFn) (*http.Response, error) {
+	req, err := NewUiConventionsPreviewUiConventionsPreviewPostRequestWithBody(c.Server, contentType, body)
+	if err != nil {
+		return nil, err
+	}
+	req = req.WithContext(ctx)
+	if err := c.applyEditors(ctx, req, reqEditors); err != nil {
+		return nil, err
+	}
+	return c.Client.Do(req)
+}
+
+func (c *Client) UiConventionsPreviewUiConventionsPreviewPostWithFormdataBody(ctx context.Context, body UiConventionsPreviewUiConventionsPreviewPostFormdataRequestBody, reqEditors ...RequestEditorFn) (*http.Response, error) {
+	req, err := NewUiConventionsPreviewUiConventionsPreviewPostRequestWithFormdataBody(c.Server, body)
+	if err != nil {
+		return nil, err
+	}
+	req = req.WithContext(ctx)
+	if err := c.applyEditors(ctx, req, reqEditors); err != nil {
+		return nil, err
+	}
+	return c.Client.Do(req)
+}
+
+func (c *Client) UiConventionsDeleteUiConventionsSlugDeleteWithBody(ctx context.Context, slug string, contentType string, body io.Reader, reqEditors ...RequestEditorFn) (*http.Response, error) {
+	req, err := NewUiConventionsDeleteUiConventionsSlugDeleteRequestWithBody(c.Server, slug, contentType, body)
+	if err != nil {
+		return nil, err
+	}
+	req = req.WithContext(ctx)
+	if err := c.applyEditors(ctx, req, reqEditors); err != nil {
+		return nil, err
+	}
+	return c.Client.Do(req)
+}
+
+func (c *Client) UiConventionsDeleteUiConventionsSlugDelete(ctx context.Context, slug string, body UiConventionsDeleteUiConventionsSlugDeleteJSONRequestBody, reqEditors ...RequestEditorFn) (*http.Response, error) {
+	req, err := NewUiConventionsDeleteUiConventionsSlugDeleteRequest(c.Server, slug, body)
+	if err != nil {
+		return nil, err
+	}
+	req = req.WithContext(ctx)
+	if err := c.applyEditors(ctx, req, reqEditors); err != nil {
+		return nil, err
+	}
+	return c.Client.Do(req)
+}
+
 func (c *Client) UiConventionsDetailUiConventionsSlugGetWithBody(ctx context.Context, slug string, contentType string, body io.Reader, reqEditors ...RequestEditorFn) (*http.Response, error) {
 	req, err := NewUiConventionsDetailUiConventionsSlugGetRequestWithBody(c.Server, slug, contentType, body)
 	if err != nil {
@@ -11926,6 +12171,102 @@ func (c *Client) UiConventionsDetailUiConventionsSlugGetWithBody(ctx context.Con
 
 func (c *Client) UiConventionsDetailUiConventionsSlugGet(ctx context.Context, slug string, body UiConventionsDetailUiConventionsSlugGetJSONRequestBody, reqEditors ...RequestEditorFn) (*http.Response, error) {
 	req, err := NewUiConventionsDetailUiConventionsSlugGetRequest(c.Server, slug, body)
+	if err != nil {
+		return nil, err
+	}
+	req = req.WithContext(ctx)
+	if err := c.applyEditors(ctx, req, reqEditors); err != nil {
+		return nil, err
+	}
+	return c.Client.Do(req)
+}
+
+func (c *Client) UiConventionsPatchUiConventionsSlugPatchWithBody(ctx context.Context, slug string, contentType string, body io.Reader, reqEditors ...RequestEditorFn) (*http.Response, error) {
+	req, err := NewUiConventionsPatchUiConventionsSlugPatchRequestWithBody(c.Server, slug, contentType, body)
+	if err != nil {
+		return nil, err
+	}
+	req = req.WithContext(ctx)
+	if err := c.applyEditors(ctx, req, reqEditors); err != nil {
+		return nil, err
+	}
+	return c.Client.Do(req)
+}
+
+func (c *Client) UiConventionsPatchUiConventionsSlugPatchWithFormdataBody(ctx context.Context, slug string, body UiConventionsPatchUiConventionsSlugPatchFormdataRequestBody, reqEditors ...RequestEditorFn) (*http.Response, error) {
+	req, err := NewUiConventionsPatchUiConventionsSlugPatchRequestWithFormdataBody(c.Server, slug, body)
+	if err != nil {
+		return nil, err
+	}
+	req = req.WithContext(ctx)
+	if err := c.applyEditors(ctx, req, reqEditors); err != nil {
+		return nil, err
+	}
+	return c.Client.Do(req)
+}
+
+func (c *Client) UiConventionsDeleteConfirmUiConventionsSlugDeleteGetWithBody(ctx context.Context, slug string, contentType string, body io.Reader, reqEditors ...RequestEditorFn) (*http.Response, error) {
+	req, err := NewUiConventionsDeleteConfirmUiConventionsSlugDeleteGetRequestWithBody(c.Server, slug, contentType, body)
+	if err != nil {
+		return nil, err
+	}
+	req = req.WithContext(ctx)
+	if err := c.applyEditors(ctx, req, reqEditors); err != nil {
+		return nil, err
+	}
+	return c.Client.Do(req)
+}
+
+func (c *Client) UiConventionsDeleteConfirmUiConventionsSlugDeleteGet(ctx context.Context, slug string, body UiConventionsDeleteConfirmUiConventionsSlugDeleteGetJSONRequestBody, reqEditors ...RequestEditorFn) (*http.Response, error) {
+	req, err := NewUiConventionsDeleteConfirmUiConventionsSlugDeleteGetRequest(c.Server, slug, body)
+	if err != nil {
+		return nil, err
+	}
+	req = req.WithContext(ctx)
+	if err := c.applyEditors(ctx, req, reqEditors); err != nil {
+		return nil, err
+	}
+	return c.Client.Do(req)
+}
+
+func (c *Client) UiConventionsEditModalUiConventionsSlugEditGetWithBody(ctx context.Context, slug string, contentType string, body io.Reader, reqEditors ...RequestEditorFn) (*http.Response, error) {
+	req, err := NewUiConventionsEditModalUiConventionsSlugEditGetRequestWithBody(c.Server, slug, contentType, body)
+	if err != nil {
+		return nil, err
+	}
+	req = req.WithContext(ctx)
+	if err := c.applyEditors(ctx, req, reqEditors); err != nil {
+		return nil, err
+	}
+	return c.Client.Do(req)
+}
+
+func (c *Client) UiConventionsEditModalUiConventionsSlugEditGet(ctx context.Context, slug string, body UiConventionsEditModalUiConventionsSlugEditGetJSONRequestBody, reqEditors ...RequestEditorFn) (*http.Response, error) {
+	req, err := NewUiConventionsEditModalUiConventionsSlugEditGetRequest(c.Server, slug, body)
+	if err != nil {
+		return nil, err
+	}
+	req = req.WithContext(ctx)
+	if err := c.applyEditors(ctx, req, reqEditors); err != nil {
+		return nil, err
+	}
+	return c.Client.Do(req)
+}
+
+func (c *Client) UiConventionsHistoryUiConventionsSlugHistoryGetWithBody(ctx context.Context, slug string, contentType string, body io.Reader, reqEditors ...RequestEditorFn) (*http.Response, error) {
+	req, err := NewUiConventionsHistoryUiConventionsSlugHistoryGetRequestWithBody(c.Server, slug, contentType, body)
+	if err != nil {
+		return nil, err
+	}
+	req = req.WithContext(ctx)
+	if err := c.applyEditors(ctx, req, reqEditors); err != nil {
+		return nil, err
+	}
+	return c.Client.Do(req)
+}
+
+func (c *Client) UiConventionsHistoryUiConventionsSlugHistoryGet(ctx context.Context, slug string, body UiConventionsHistoryUiConventionsSlugHistoryGetJSONRequestBody, reqEditors ...RequestEditorFn) (*http.Response, error) {
+	req, err := NewUiConventionsHistoryUiConventionsSlugHistoryGetRequest(c.Server, slug, body)
 	if err != nil {
 		return nil, err
 	}
@@ -23987,6 +24328,173 @@ func NewUiConventionsListUiConventionsGetRequestWithBody(server string, params *
 	return req, nil
 }
 
+// NewUiConventionsCreateModalUiConventionsCreateGetRequest calls the generic UiConventionsCreateModalUiConventionsCreateGet builder with application/json body
+func NewUiConventionsCreateModalUiConventionsCreateGetRequest(server string, body UiConventionsCreateModalUiConventionsCreateGetJSONRequestBody) (*http.Request, error) {
+	var bodyReader io.Reader
+	buf, err := json.Marshal(body)
+	if err != nil {
+		return nil, err
+	}
+	bodyReader = bytes.NewReader(buf)
+	return NewUiConventionsCreateModalUiConventionsCreateGetRequestWithBody(server, "application/json", bodyReader)
+}
+
+// NewUiConventionsCreateModalUiConventionsCreateGetRequestWithBody generates requests for UiConventionsCreateModalUiConventionsCreateGet with any type of body
+func NewUiConventionsCreateModalUiConventionsCreateGetRequestWithBody(server string, contentType string, body io.Reader) (*http.Request, error) {
+	var err error
+
+	serverURL, err := url.Parse(server)
+	if err != nil {
+		return nil, err
+	}
+
+	operationPath := fmt.Sprintf("/ui/conventions/create")
+	if operationPath[0] == '/' {
+		operationPath = "." + operationPath
+	}
+
+	queryURL, err := serverURL.Parse(operationPath)
+	if err != nil {
+		return nil, err
+	}
+
+	req, err := http.NewRequest("GET", queryURL.String(), body)
+	if err != nil {
+		return nil, err
+	}
+
+	req.Header.Add("Content-Type", contentType)
+
+	return req, nil
+}
+
+// NewUiConventionsCreateSubmitUiConventionsCreatePostRequestWithFormdataBody calls the generic UiConventionsCreateSubmitUiConventionsCreatePost builder with application/x-www-form-urlencoded body
+func NewUiConventionsCreateSubmitUiConventionsCreatePostRequestWithFormdataBody(server string, body UiConventionsCreateSubmitUiConventionsCreatePostFormdataRequestBody) (*http.Request, error) {
+	var bodyReader io.Reader
+	bodyStr, err := runtime.MarshalForm(body, nil)
+	if err != nil {
+		return nil, err
+	}
+	bodyReader = strings.NewReader(bodyStr.Encode())
+	return NewUiConventionsCreateSubmitUiConventionsCreatePostRequestWithBody(server, "application/x-www-form-urlencoded", bodyReader)
+}
+
+// NewUiConventionsCreateSubmitUiConventionsCreatePostRequestWithBody generates requests for UiConventionsCreateSubmitUiConventionsCreatePost with any type of body
+func NewUiConventionsCreateSubmitUiConventionsCreatePostRequestWithBody(server string, contentType string, body io.Reader) (*http.Request, error) {
+	var err error
+
+	serverURL, err := url.Parse(server)
+	if err != nil {
+		return nil, err
+	}
+
+	operationPath := fmt.Sprintf("/ui/conventions/create")
+	if operationPath[0] == '/' {
+		operationPath = "." + operationPath
+	}
+
+	queryURL, err := serverURL.Parse(operationPath)
+	if err != nil {
+		return nil, err
+	}
+
+	req, err := http.NewRequest("POST", queryURL.String(), body)
+	if err != nil {
+		return nil, err
+	}
+
+	req.Header.Add("Content-Type", contentType)
+
+	return req, nil
+}
+
+// NewUiConventionsPreviewUiConventionsPreviewPostRequestWithFormdataBody calls the generic UiConventionsPreviewUiConventionsPreviewPost builder with application/x-www-form-urlencoded body
+func NewUiConventionsPreviewUiConventionsPreviewPostRequestWithFormdataBody(server string, body UiConventionsPreviewUiConventionsPreviewPostFormdataRequestBody) (*http.Request, error) {
+	var bodyReader io.Reader
+	bodyStr, err := runtime.MarshalForm(body, nil)
+	if err != nil {
+		return nil, err
+	}
+	bodyReader = strings.NewReader(bodyStr.Encode())
+	return NewUiConventionsPreviewUiConventionsPreviewPostRequestWithBody(server, "application/x-www-form-urlencoded", bodyReader)
+}
+
+// NewUiConventionsPreviewUiConventionsPreviewPostRequestWithBody generates requests for UiConventionsPreviewUiConventionsPreviewPost with any type of body
+func NewUiConventionsPreviewUiConventionsPreviewPostRequestWithBody(server string, contentType string, body io.Reader) (*http.Request, error) {
+	var err error
+
+	serverURL, err := url.Parse(server)
+	if err != nil {
+		return nil, err
+	}
+
+	operationPath := fmt.Sprintf("/ui/conventions/preview")
+	if operationPath[0] == '/' {
+		operationPath = "." + operationPath
+	}
+
+	queryURL, err := serverURL.Parse(operationPath)
+	if err != nil {
+		return nil, err
+	}
+
+	req, err := http.NewRequest("POST", queryURL.String(), body)
+	if err != nil {
+		return nil, err
+	}
+
+	req.Header.Add("Content-Type", contentType)
+
+	return req, nil
+}
+
+// NewUiConventionsDeleteUiConventionsSlugDeleteRequest calls the generic UiConventionsDeleteUiConventionsSlugDelete builder with application/json body
+func NewUiConventionsDeleteUiConventionsSlugDeleteRequest(server string, slug string, body UiConventionsDeleteUiConventionsSlugDeleteJSONRequestBody) (*http.Request, error) {
+	var bodyReader io.Reader
+	buf, err := json.Marshal(body)
+	if err != nil {
+		return nil, err
+	}
+	bodyReader = bytes.NewReader(buf)
+	return NewUiConventionsDeleteUiConventionsSlugDeleteRequestWithBody(server, slug, "application/json", bodyReader)
+}
+
+// NewUiConventionsDeleteUiConventionsSlugDeleteRequestWithBody generates requests for UiConventionsDeleteUiConventionsSlugDelete with any type of body
+func NewUiConventionsDeleteUiConventionsSlugDeleteRequestWithBody(server string, slug string, contentType string, body io.Reader) (*http.Request, error) {
+	var err error
+
+	var pathParam0 string
+
+	pathParam0, err = runtime.StyleParamWithLocation("simple", false, "slug", runtime.ParamLocationPath, slug)
+	if err != nil {
+		return nil, err
+	}
+
+	serverURL, err := url.Parse(server)
+	if err != nil {
+		return nil, err
+	}
+
+	operationPath := fmt.Sprintf("/ui/conventions/%s", pathParam0)
+	if operationPath[0] == '/' {
+		operationPath = "." + operationPath
+	}
+
+	queryURL, err := serverURL.Parse(operationPath)
+	if err != nil {
+		return nil, err
+	}
+
+	req, err := http.NewRequest("DELETE", queryURL.String(), body)
+	if err != nil {
+		return nil, err
+	}
+
+	req.Header.Add("Content-Type", contentType)
+
+	return req, nil
+}
+
 // NewUiConventionsDetailUiConventionsSlugGetRequest calls the generic UiConventionsDetailUiConventionsSlugGet builder with application/json body
 func NewUiConventionsDetailUiConventionsSlugGetRequest(server string, slug string, body UiConventionsDetailUiConventionsSlugGetJSONRequestBody) (*http.Request, error) {
 	var bodyReader io.Reader
@@ -24015,6 +24523,194 @@ func NewUiConventionsDetailUiConventionsSlugGetRequestWithBody(server string, sl
 	}
 
 	operationPath := fmt.Sprintf("/ui/conventions/%s", pathParam0)
+	if operationPath[0] == '/' {
+		operationPath = "." + operationPath
+	}
+
+	queryURL, err := serverURL.Parse(operationPath)
+	if err != nil {
+		return nil, err
+	}
+
+	req, err := http.NewRequest("GET", queryURL.String(), body)
+	if err != nil {
+		return nil, err
+	}
+
+	req.Header.Add("Content-Type", contentType)
+
+	return req, nil
+}
+
+// NewUiConventionsPatchUiConventionsSlugPatchRequestWithFormdataBody calls the generic UiConventionsPatchUiConventionsSlugPatch builder with application/x-www-form-urlencoded body
+func NewUiConventionsPatchUiConventionsSlugPatchRequestWithFormdataBody(server string, slug string, body UiConventionsPatchUiConventionsSlugPatchFormdataRequestBody) (*http.Request, error) {
+	var bodyReader io.Reader
+	bodyStr, err := runtime.MarshalForm(body, nil)
+	if err != nil {
+		return nil, err
+	}
+	bodyReader = strings.NewReader(bodyStr.Encode())
+	return NewUiConventionsPatchUiConventionsSlugPatchRequestWithBody(server, slug, "application/x-www-form-urlencoded", bodyReader)
+}
+
+// NewUiConventionsPatchUiConventionsSlugPatchRequestWithBody generates requests for UiConventionsPatchUiConventionsSlugPatch with any type of body
+func NewUiConventionsPatchUiConventionsSlugPatchRequestWithBody(server string, slug string, contentType string, body io.Reader) (*http.Request, error) {
+	var err error
+
+	var pathParam0 string
+
+	pathParam0, err = runtime.StyleParamWithLocation("simple", false, "slug", runtime.ParamLocationPath, slug)
+	if err != nil {
+		return nil, err
+	}
+
+	serverURL, err := url.Parse(server)
+	if err != nil {
+		return nil, err
+	}
+
+	operationPath := fmt.Sprintf("/ui/conventions/%s", pathParam0)
+	if operationPath[0] == '/' {
+		operationPath = "." + operationPath
+	}
+
+	queryURL, err := serverURL.Parse(operationPath)
+	if err != nil {
+		return nil, err
+	}
+
+	req, err := http.NewRequest("PATCH", queryURL.String(), body)
+	if err != nil {
+		return nil, err
+	}
+
+	req.Header.Add("Content-Type", contentType)
+
+	return req, nil
+}
+
+// NewUiConventionsDeleteConfirmUiConventionsSlugDeleteGetRequest calls the generic UiConventionsDeleteConfirmUiConventionsSlugDeleteGet builder with application/json body
+func NewUiConventionsDeleteConfirmUiConventionsSlugDeleteGetRequest(server string, slug string, body UiConventionsDeleteConfirmUiConventionsSlugDeleteGetJSONRequestBody) (*http.Request, error) {
+	var bodyReader io.Reader
+	buf, err := json.Marshal(body)
+	if err != nil {
+		return nil, err
+	}
+	bodyReader = bytes.NewReader(buf)
+	return NewUiConventionsDeleteConfirmUiConventionsSlugDeleteGetRequestWithBody(server, slug, "application/json", bodyReader)
+}
+
+// NewUiConventionsDeleteConfirmUiConventionsSlugDeleteGetRequestWithBody generates requests for UiConventionsDeleteConfirmUiConventionsSlugDeleteGet with any type of body
+func NewUiConventionsDeleteConfirmUiConventionsSlugDeleteGetRequestWithBody(server string, slug string, contentType string, body io.Reader) (*http.Request, error) {
+	var err error
+
+	var pathParam0 string
+
+	pathParam0, err = runtime.StyleParamWithLocation("simple", false, "slug", runtime.ParamLocationPath, slug)
+	if err != nil {
+		return nil, err
+	}
+
+	serverURL, err := url.Parse(server)
+	if err != nil {
+		return nil, err
+	}
+
+	operationPath := fmt.Sprintf("/ui/conventions/%s/delete", pathParam0)
+	if operationPath[0] == '/' {
+		operationPath = "." + operationPath
+	}
+
+	queryURL, err := serverURL.Parse(operationPath)
+	if err != nil {
+		return nil, err
+	}
+
+	req, err := http.NewRequest("GET", queryURL.String(), body)
+	if err != nil {
+		return nil, err
+	}
+
+	req.Header.Add("Content-Type", contentType)
+
+	return req, nil
+}
+
+// NewUiConventionsEditModalUiConventionsSlugEditGetRequest calls the generic UiConventionsEditModalUiConventionsSlugEditGet builder with application/json body
+func NewUiConventionsEditModalUiConventionsSlugEditGetRequest(server string, slug string, body UiConventionsEditModalUiConventionsSlugEditGetJSONRequestBody) (*http.Request, error) {
+	var bodyReader io.Reader
+	buf, err := json.Marshal(body)
+	if err != nil {
+		return nil, err
+	}
+	bodyReader = bytes.NewReader(buf)
+	return NewUiConventionsEditModalUiConventionsSlugEditGetRequestWithBody(server, slug, "application/json", bodyReader)
+}
+
+// NewUiConventionsEditModalUiConventionsSlugEditGetRequestWithBody generates requests for UiConventionsEditModalUiConventionsSlugEditGet with any type of body
+func NewUiConventionsEditModalUiConventionsSlugEditGetRequestWithBody(server string, slug string, contentType string, body io.Reader) (*http.Request, error) {
+	var err error
+
+	var pathParam0 string
+
+	pathParam0, err = runtime.StyleParamWithLocation("simple", false, "slug", runtime.ParamLocationPath, slug)
+	if err != nil {
+		return nil, err
+	}
+
+	serverURL, err := url.Parse(server)
+	if err != nil {
+		return nil, err
+	}
+
+	operationPath := fmt.Sprintf("/ui/conventions/%s/edit", pathParam0)
+	if operationPath[0] == '/' {
+		operationPath = "." + operationPath
+	}
+
+	queryURL, err := serverURL.Parse(operationPath)
+	if err != nil {
+		return nil, err
+	}
+
+	req, err := http.NewRequest("GET", queryURL.String(), body)
+	if err != nil {
+		return nil, err
+	}
+
+	req.Header.Add("Content-Type", contentType)
+
+	return req, nil
+}
+
+// NewUiConventionsHistoryUiConventionsSlugHistoryGetRequest calls the generic UiConventionsHistoryUiConventionsSlugHistoryGet builder with application/json body
+func NewUiConventionsHistoryUiConventionsSlugHistoryGetRequest(server string, slug string, body UiConventionsHistoryUiConventionsSlugHistoryGetJSONRequestBody) (*http.Request, error) {
+	var bodyReader io.Reader
+	buf, err := json.Marshal(body)
+	if err != nil {
+		return nil, err
+	}
+	bodyReader = bytes.NewReader(buf)
+	return NewUiConventionsHistoryUiConventionsSlugHistoryGetRequestWithBody(server, slug, "application/json", bodyReader)
+}
+
+// NewUiConventionsHistoryUiConventionsSlugHistoryGetRequestWithBody generates requests for UiConventionsHistoryUiConventionsSlugHistoryGet with any type of body
+func NewUiConventionsHistoryUiConventionsSlugHistoryGetRequestWithBody(server string, slug string, contentType string, body io.Reader) (*http.Request, error) {
+	var err error
+
+	var pathParam0 string
+
+	pathParam0, err = runtime.StyleParamWithLocation("simple", false, "slug", runtime.ParamLocationPath, slug)
+	if err != nil {
+		return nil, err
+	}
+
+	serverURL, err := url.Parse(server)
+	if err != nil {
+		return nil, err
+	}
+
+	operationPath := fmt.Sprintf("/ui/conventions/%s/history", pathParam0)
 	if operationPath[0] == '/' {
 		operationPath = "." + operationPath
 	}
@@ -27842,10 +28538,50 @@ type ClientWithResponsesInterface interface {
 
 	UiConventionsListUiConventionsGetWithResponse(ctx context.Context, params *UiConventionsListUiConventionsGetParams, body UiConventionsListUiConventionsGetJSONRequestBody, reqEditors ...RequestEditorFn) (*UiConventionsListUiConventionsGetResponse, error)
 
+	// UiConventionsCreateModalUiConventionsCreateGetWithBodyWithResponse request with any body
+	UiConventionsCreateModalUiConventionsCreateGetWithBodyWithResponse(ctx context.Context, contentType string, body io.Reader, reqEditors ...RequestEditorFn) (*UiConventionsCreateModalUiConventionsCreateGetResponse, error)
+
+	UiConventionsCreateModalUiConventionsCreateGetWithResponse(ctx context.Context, body UiConventionsCreateModalUiConventionsCreateGetJSONRequestBody, reqEditors ...RequestEditorFn) (*UiConventionsCreateModalUiConventionsCreateGetResponse, error)
+
+	// UiConventionsCreateSubmitUiConventionsCreatePostWithBodyWithResponse request with any body
+	UiConventionsCreateSubmitUiConventionsCreatePostWithBodyWithResponse(ctx context.Context, contentType string, body io.Reader, reqEditors ...RequestEditorFn) (*UiConventionsCreateSubmitUiConventionsCreatePostResponse, error)
+
+	UiConventionsCreateSubmitUiConventionsCreatePostWithFormdataBodyWithResponse(ctx context.Context, body UiConventionsCreateSubmitUiConventionsCreatePostFormdataRequestBody, reqEditors ...RequestEditorFn) (*UiConventionsCreateSubmitUiConventionsCreatePostResponse, error)
+
+	// UiConventionsPreviewUiConventionsPreviewPostWithBodyWithResponse request with any body
+	UiConventionsPreviewUiConventionsPreviewPostWithBodyWithResponse(ctx context.Context, contentType string, body io.Reader, reqEditors ...RequestEditorFn) (*UiConventionsPreviewUiConventionsPreviewPostResponse, error)
+
+	UiConventionsPreviewUiConventionsPreviewPostWithFormdataBodyWithResponse(ctx context.Context, body UiConventionsPreviewUiConventionsPreviewPostFormdataRequestBody, reqEditors ...RequestEditorFn) (*UiConventionsPreviewUiConventionsPreviewPostResponse, error)
+
+	// UiConventionsDeleteUiConventionsSlugDeleteWithBodyWithResponse request with any body
+	UiConventionsDeleteUiConventionsSlugDeleteWithBodyWithResponse(ctx context.Context, slug string, contentType string, body io.Reader, reqEditors ...RequestEditorFn) (*UiConventionsDeleteUiConventionsSlugDeleteResponse, error)
+
+	UiConventionsDeleteUiConventionsSlugDeleteWithResponse(ctx context.Context, slug string, body UiConventionsDeleteUiConventionsSlugDeleteJSONRequestBody, reqEditors ...RequestEditorFn) (*UiConventionsDeleteUiConventionsSlugDeleteResponse, error)
+
 	// UiConventionsDetailUiConventionsSlugGetWithBodyWithResponse request with any body
 	UiConventionsDetailUiConventionsSlugGetWithBodyWithResponse(ctx context.Context, slug string, contentType string, body io.Reader, reqEditors ...RequestEditorFn) (*UiConventionsDetailUiConventionsSlugGetResponse, error)
 
 	UiConventionsDetailUiConventionsSlugGetWithResponse(ctx context.Context, slug string, body UiConventionsDetailUiConventionsSlugGetJSONRequestBody, reqEditors ...RequestEditorFn) (*UiConventionsDetailUiConventionsSlugGetResponse, error)
+
+	// UiConventionsPatchUiConventionsSlugPatchWithBodyWithResponse request with any body
+	UiConventionsPatchUiConventionsSlugPatchWithBodyWithResponse(ctx context.Context, slug string, contentType string, body io.Reader, reqEditors ...RequestEditorFn) (*UiConventionsPatchUiConventionsSlugPatchResponse, error)
+
+	UiConventionsPatchUiConventionsSlugPatchWithFormdataBodyWithResponse(ctx context.Context, slug string, body UiConventionsPatchUiConventionsSlugPatchFormdataRequestBody, reqEditors ...RequestEditorFn) (*UiConventionsPatchUiConventionsSlugPatchResponse, error)
+
+	// UiConventionsDeleteConfirmUiConventionsSlugDeleteGetWithBodyWithResponse request with any body
+	UiConventionsDeleteConfirmUiConventionsSlugDeleteGetWithBodyWithResponse(ctx context.Context, slug string, contentType string, body io.Reader, reqEditors ...RequestEditorFn) (*UiConventionsDeleteConfirmUiConventionsSlugDeleteGetResponse, error)
+
+	UiConventionsDeleteConfirmUiConventionsSlugDeleteGetWithResponse(ctx context.Context, slug string, body UiConventionsDeleteConfirmUiConventionsSlugDeleteGetJSONRequestBody, reqEditors ...RequestEditorFn) (*UiConventionsDeleteConfirmUiConventionsSlugDeleteGetResponse, error)
+
+	// UiConventionsEditModalUiConventionsSlugEditGetWithBodyWithResponse request with any body
+	UiConventionsEditModalUiConventionsSlugEditGetWithBodyWithResponse(ctx context.Context, slug string, contentType string, body io.Reader, reqEditors ...RequestEditorFn) (*UiConventionsEditModalUiConventionsSlugEditGetResponse, error)
+
+	UiConventionsEditModalUiConventionsSlugEditGetWithResponse(ctx context.Context, slug string, body UiConventionsEditModalUiConventionsSlugEditGetJSONRequestBody, reqEditors ...RequestEditorFn) (*UiConventionsEditModalUiConventionsSlugEditGetResponse, error)
+
+	// UiConventionsHistoryUiConventionsSlugHistoryGetWithBodyWithResponse request with any body
+	UiConventionsHistoryUiConventionsSlugHistoryGetWithBodyWithResponse(ctx context.Context, slug string, contentType string, body io.Reader, reqEditors ...RequestEditorFn) (*UiConventionsHistoryUiConventionsSlugHistoryGetResponse, error)
+
+	UiConventionsHistoryUiConventionsSlugHistoryGetWithResponse(ctx context.Context, slug string, body UiConventionsHistoryUiConventionsSlugHistoryGetJSONRequestBody, reqEditors ...RequestEditorFn) (*UiConventionsHistoryUiConventionsSlugHistoryGetResponse, error)
 
 	// CorpusIndexUiCorpusGetWithResponse request
 	CorpusIndexUiCorpusGetWithResponse(ctx context.Context, reqEditors ...RequestEditorFn) (*CorpusIndexUiCorpusGetResponse, error)
@@ -32101,6 +32837,94 @@ func (r UiConventionsListUiConventionsGetResponse) StatusCode() int {
 	return 0
 }
 
+type UiConventionsCreateModalUiConventionsCreateGetResponse struct {
+	Body         []byte
+	HTTPResponse *http.Response
+	JSON422      *HTTPValidationError
+}
+
+// Status returns HTTPResponse.Status
+func (r UiConventionsCreateModalUiConventionsCreateGetResponse) Status() string {
+	if r.HTTPResponse != nil {
+		return r.HTTPResponse.Status
+	}
+	return http.StatusText(0)
+}
+
+// StatusCode returns HTTPResponse.StatusCode
+func (r UiConventionsCreateModalUiConventionsCreateGetResponse) StatusCode() int {
+	if r.HTTPResponse != nil {
+		return r.HTTPResponse.StatusCode
+	}
+	return 0
+}
+
+type UiConventionsCreateSubmitUiConventionsCreatePostResponse struct {
+	Body         []byte
+	HTTPResponse *http.Response
+	JSON422      *HTTPValidationError
+}
+
+// Status returns HTTPResponse.Status
+func (r UiConventionsCreateSubmitUiConventionsCreatePostResponse) Status() string {
+	if r.HTTPResponse != nil {
+		return r.HTTPResponse.Status
+	}
+	return http.StatusText(0)
+}
+
+// StatusCode returns HTTPResponse.StatusCode
+func (r UiConventionsCreateSubmitUiConventionsCreatePostResponse) StatusCode() int {
+	if r.HTTPResponse != nil {
+		return r.HTTPResponse.StatusCode
+	}
+	return 0
+}
+
+type UiConventionsPreviewUiConventionsPreviewPostResponse struct {
+	Body         []byte
+	HTTPResponse *http.Response
+	JSON422      *HTTPValidationError
+}
+
+// Status returns HTTPResponse.Status
+func (r UiConventionsPreviewUiConventionsPreviewPostResponse) Status() string {
+	if r.HTTPResponse != nil {
+		return r.HTTPResponse.Status
+	}
+	return http.StatusText(0)
+}
+
+// StatusCode returns HTTPResponse.StatusCode
+func (r UiConventionsPreviewUiConventionsPreviewPostResponse) StatusCode() int {
+	if r.HTTPResponse != nil {
+		return r.HTTPResponse.StatusCode
+	}
+	return 0
+}
+
+type UiConventionsDeleteUiConventionsSlugDeleteResponse struct {
+	Body         []byte
+	HTTPResponse *http.Response
+	JSON422      *HTTPValidationError
+}
+
+// Status returns HTTPResponse.Status
+func (r UiConventionsDeleteUiConventionsSlugDeleteResponse) Status() string {
+	if r.HTTPResponse != nil {
+		return r.HTTPResponse.Status
+	}
+	return http.StatusText(0)
+}
+
+// StatusCode returns HTTPResponse.StatusCode
+func (r UiConventionsDeleteUiConventionsSlugDeleteResponse) StatusCode() int {
+	if r.HTTPResponse != nil {
+		return r.HTTPResponse.StatusCode
+	}
+	return 0
+}
+
 type UiConventionsDetailUiConventionsSlugGetResponse struct {
 	Body         []byte
 	HTTPResponse *http.Response
@@ -32117,6 +32941,94 @@ func (r UiConventionsDetailUiConventionsSlugGetResponse) Status() string {
 
 // StatusCode returns HTTPResponse.StatusCode
 func (r UiConventionsDetailUiConventionsSlugGetResponse) StatusCode() int {
+	if r.HTTPResponse != nil {
+		return r.HTTPResponse.StatusCode
+	}
+	return 0
+}
+
+type UiConventionsPatchUiConventionsSlugPatchResponse struct {
+	Body         []byte
+	HTTPResponse *http.Response
+	JSON422      *HTTPValidationError
+}
+
+// Status returns HTTPResponse.Status
+func (r UiConventionsPatchUiConventionsSlugPatchResponse) Status() string {
+	if r.HTTPResponse != nil {
+		return r.HTTPResponse.Status
+	}
+	return http.StatusText(0)
+}
+
+// StatusCode returns HTTPResponse.StatusCode
+func (r UiConventionsPatchUiConventionsSlugPatchResponse) StatusCode() int {
+	if r.HTTPResponse != nil {
+		return r.HTTPResponse.StatusCode
+	}
+	return 0
+}
+
+type UiConventionsDeleteConfirmUiConventionsSlugDeleteGetResponse struct {
+	Body         []byte
+	HTTPResponse *http.Response
+	JSON422      *HTTPValidationError
+}
+
+// Status returns HTTPResponse.Status
+func (r UiConventionsDeleteConfirmUiConventionsSlugDeleteGetResponse) Status() string {
+	if r.HTTPResponse != nil {
+		return r.HTTPResponse.Status
+	}
+	return http.StatusText(0)
+}
+
+// StatusCode returns HTTPResponse.StatusCode
+func (r UiConventionsDeleteConfirmUiConventionsSlugDeleteGetResponse) StatusCode() int {
+	if r.HTTPResponse != nil {
+		return r.HTTPResponse.StatusCode
+	}
+	return 0
+}
+
+type UiConventionsEditModalUiConventionsSlugEditGetResponse struct {
+	Body         []byte
+	HTTPResponse *http.Response
+	JSON422      *HTTPValidationError
+}
+
+// Status returns HTTPResponse.Status
+func (r UiConventionsEditModalUiConventionsSlugEditGetResponse) Status() string {
+	if r.HTTPResponse != nil {
+		return r.HTTPResponse.Status
+	}
+	return http.StatusText(0)
+}
+
+// StatusCode returns HTTPResponse.StatusCode
+func (r UiConventionsEditModalUiConventionsSlugEditGetResponse) StatusCode() int {
+	if r.HTTPResponse != nil {
+		return r.HTTPResponse.StatusCode
+	}
+	return 0
+}
+
+type UiConventionsHistoryUiConventionsSlugHistoryGetResponse struct {
+	Body         []byte
+	HTTPResponse *http.Response
+	JSON422      *HTTPValidationError
+}
+
+// Status returns HTTPResponse.Status
+func (r UiConventionsHistoryUiConventionsSlugHistoryGetResponse) Status() string {
+	if r.HTTPResponse != nil {
+		return r.HTTPResponse.Status
+	}
+	return http.StatusText(0)
+}
+
+// StatusCode returns HTTPResponse.StatusCode
+func (r UiConventionsHistoryUiConventionsSlugHistoryGetResponse) StatusCode() int {
 	if r.HTTPResponse != nil {
 		return r.HTTPResponse.StatusCode
 	}
@@ -35731,6 +36643,74 @@ func (c *ClientWithResponses) UiConventionsListUiConventionsGetWithResponse(ctx 
 	return ParseUiConventionsListUiConventionsGetResponse(rsp)
 }
 
+// UiConventionsCreateModalUiConventionsCreateGetWithBodyWithResponse request with arbitrary body returning *UiConventionsCreateModalUiConventionsCreateGetResponse
+func (c *ClientWithResponses) UiConventionsCreateModalUiConventionsCreateGetWithBodyWithResponse(ctx context.Context, contentType string, body io.Reader, reqEditors ...RequestEditorFn) (*UiConventionsCreateModalUiConventionsCreateGetResponse, error) {
+	rsp, err := c.UiConventionsCreateModalUiConventionsCreateGetWithBody(ctx, contentType, body, reqEditors...)
+	if err != nil {
+		return nil, err
+	}
+	return ParseUiConventionsCreateModalUiConventionsCreateGetResponse(rsp)
+}
+
+func (c *ClientWithResponses) UiConventionsCreateModalUiConventionsCreateGetWithResponse(ctx context.Context, body UiConventionsCreateModalUiConventionsCreateGetJSONRequestBody, reqEditors ...RequestEditorFn) (*UiConventionsCreateModalUiConventionsCreateGetResponse, error) {
+	rsp, err := c.UiConventionsCreateModalUiConventionsCreateGet(ctx, body, reqEditors...)
+	if err != nil {
+		return nil, err
+	}
+	return ParseUiConventionsCreateModalUiConventionsCreateGetResponse(rsp)
+}
+
+// UiConventionsCreateSubmitUiConventionsCreatePostWithBodyWithResponse request with arbitrary body returning *UiConventionsCreateSubmitUiConventionsCreatePostResponse
+func (c *ClientWithResponses) UiConventionsCreateSubmitUiConventionsCreatePostWithBodyWithResponse(ctx context.Context, contentType string, body io.Reader, reqEditors ...RequestEditorFn) (*UiConventionsCreateSubmitUiConventionsCreatePostResponse, error) {
+	rsp, err := c.UiConventionsCreateSubmitUiConventionsCreatePostWithBody(ctx, contentType, body, reqEditors...)
+	if err != nil {
+		return nil, err
+	}
+	return ParseUiConventionsCreateSubmitUiConventionsCreatePostResponse(rsp)
+}
+
+func (c *ClientWithResponses) UiConventionsCreateSubmitUiConventionsCreatePostWithFormdataBodyWithResponse(ctx context.Context, body UiConventionsCreateSubmitUiConventionsCreatePostFormdataRequestBody, reqEditors ...RequestEditorFn) (*UiConventionsCreateSubmitUiConventionsCreatePostResponse, error) {
+	rsp, err := c.UiConventionsCreateSubmitUiConventionsCreatePostWithFormdataBody(ctx, body, reqEditors...)
+	if err != nil {
+		return nil, err
+	}
+	return ParseUiConventionsCreateSubmitUiConventionsCreatePostResponse(rsp)
+}
+
+// UiConventionsPreviewUiConventionsPreviewPostWithBodyWithResponse request with arbitrary body returning *UiConventionsPreviewUiConventionsPreviewPostResponse
+func (c *ClientWithResponses) UiConventionsPreviewUiConventionsPreviewPostWithBodyWithResponse(ctx context.Context, contentType string, body io.Reader, reqEditors ...RequestEditorFn) (*UiConventionsPreviewUiConventionsPreviewPostResponse, error) {
+	rsp, err := c.UiConventionsPreviewUiConventionsPreviewPostWithBody(ctx, contentType, body, reqEditors...)
+	if err != nil {
+		return nil, err
+	}
+	return ParseUiConventionsPreviewUiConventionsPreviewPostResponse(rsp)
+}
+
+func (c *ClientWithResponses) UiConventionsPreviewUiConventionsPreviewPostWithFormdataBodyWithResponse(ctx context.Context, body UiConventionsPreviewUiConventionsPreviewPostFormdataRequestBody, reqEditors ...RequestEditorFn) (*UiConventionsPreviewUiConventionsPreviewPostResponse, error) {
+	rsp, err := c.UiConventionsPreviewUiConventionsPreviewPostWithFormdataBody(ctx, body, reqEditors...)
+	if err != nil {
+		return nil, err
+	}
+	return ParseUiConventionsPreviewUiConventionsPreviewPostResponse(rsp)
+}
+
+// UiConventionsDeleteUiConventionsSlugDeleteWithBodyWithResponse request with arbitrary body returning *UiConventionsDeleteUiConventionsSlugDeleteResponse
+func (c *ClientWithResponses) UiConventionsDeleteUiConventionsSlugDeleteWithBodyWithResponse(ctx context.Context, slug string, contentType string, body io.Reader, reqEditors ...RequestEditorFn) (*UiConventionsDeleteUiConventionsSlugDeleteResponse, error) {
+	rsp, err := c.UiConventionsDeleteUiConventionsSlugDeleteWithBody(ctx, slug, contentType, body, reqEditors...)
+	if err != nil {
+		return nil, err
+	}
+	return ParseUiConventionsDeleteUiConventionsSlugDeleteResponse(rsp)
+}
+
+func (c *ClientWithResponses) UiConventionsDeleteUiConventionsSlugDeleteWithResponse(ctx context.Context, slug string, body UiConventionsDeleteUiConventionsSlugDeleteJSONRequestBody, reqEditors ...RequestEditorFn) (*UiConventionsDeleteUiConventionsSlugDeleteResponse, error) {
+	rsp, err := c.UiConventionsDeleteUiConventionsSlugDelete(ctx, slug, body, reqEditors...)
+	if err != nil {
+		return nil, err
+	}
+	return ParseUiConventionsDeleteUiConventionsSlugDeleteResponse(rsp)
+}
+
 // UiConventionsDetailUiConventionsSlugGetWithBodyWithResponse request with arbitrary body returning *UiConventionsDetailUiConventionsSlugGetResponse
 func (c *ClientWithResponses) UiConventionsDetailUiConventionsSlugGetWithBodyWithResponse(ctx context.Context, slug string, contentType string, body io.Reader, reqEditors ...RequestEditorFn) (*UiConventionsDetailUiConventionsSlugGetResponse, error) {
 	rsp, err := c.UiConventionsDetailUiConventionsSlugGetWithBody(ctx, slug, contentType, body, reqEditors...)
@@ -35746,6 +36726,74 @@ func (c *ClientWithResponses) UiConventionsDetailUiConventionsSlugGetWithRespons
 		return nil, err
 	}
 	return ParseUiConventionsDetailUiConventionsSlugGetResponse(rsp)
+}
+
+// UiConventionsPatchUiConventionsSlugPatchWithBodyWithResponse request with arbitrary body returning *UiConventionsPatchUiConventionsSlugPatchResponse
+func (c *ClientWithResponses) UiConventionsPatchUiConventionsSlugPatchWithBodyWithResponse(ctx context.Context, slug string, contentType string, body io.Reader, reqEditors ...RequestEditorFn) (*UiConventionsPatchUiConventionsSlugPatchResponse, error) {
+	rsp, err := c.UiConventionsPatchUiConventionsSlugPatchWithBody(ctx, slug, contentType, body, reqEditors...)
+	if err != nil {
+		return nil, err
+	}
+	return ParseUiConventionsPatchUiConventionsSlugPatchResponse(rsp)
+}
+
+func (c *ClientWithResponses) UiConventionsPatchUiConventionsSlugPatchWithFormdataBodyWithResponse(ctx context.Context, slug string, body UiConventionsPatchUiConventionsSlugPatchFormdataRequestBody, reqEditors ...RequestEditorFn) (*UiConventionsPatchUiConventionsSlugPatchResponse, error) {
+	rsp, err := c.UiConventionsPatchUiConventionsSlugPatchWithFormdataBody(ctx, slug, body, reqEditors...)
+	if err != nil {
+		return nil, err
+	}
+	return ParseUiConventionsPatchUiConventionsSlugPatchResponse(rsp)
+}
+
+// UiConventionsDeleteConfirmUiConventionsSlugDeleteGetWithBodyWithResponse request with arbitrary body returning *UiConventionsDeleteConfirmUiConventionsSlugDeleteGetResponse
+func (c *ClientWithResponses) UiConventionsDeleteConfirmUiConventionsSlugDeleteGetWithBodyWithResponse(ctx context.Context, slug string, contentType string, body io.Reader, reqEditors ...RequestEditorFn) (*UiConventionsDeleteConfirmUiConventionsSlugDeleteGetResponse, error) {
+	rsp, err := c.UiConventionsDeleteConfirmUiConventionsSlugDeleteGetWithBody(ctx, slug, contentType, body, reqEditors...)
+	if err != nil {
+		return nil, err
+	}
+	return ParseUiConventionsDeleteConfirmUiConventionsSlugDeleteGetResponse(rsp)
+}
+
+func (c *ClientWithResponses) UiConventionsDeleteConfirmUiConventionsSlugDeleteGetWithResponse(ctx context.Context, slug string, body UiConventionsDeleteConfirmUiConventionsSlugDeleteGetJSONRequestBody, reqEditors ...RequestEditorFn) (*UiConventionsDeleteConfirmUiConventionsSlugDeleteGetResponse, error) {
+	rsp, err := c.UiConventionsDeleteConfirmUiConventionsSlugDeleteGet(ctx, slug, body, reqEditors...)
+	if err != nil {
+		return nil, err
+	}
+	return ParseUiConventionsDeleteConfirmUiConventionsSlugDeleteGetResponse(rsp)
+}
+
+// UiConventionsEditModalUiConventionsSlugEditGetWithBodyWithResponse request with arbitrary body returning *UiConventionsEditModalUiConventionsSlugEditGetResponse
+func (c *ClientWithResponses) UiConventionsEditModalUiConventionsSlugEditGetWithBodyWithResponse(ctx context.Context, slug string, contentType string, body io.Reader, reqEditors ...RequestEditorFn) (*UiConventionsEditModalUiConventionsSlugEditGetResponse, error) {
+	rsp, err := c.UiConventionsEditModalUiConventionsSlugEditGetWithBody(ctx, slug, contentType, body, reqEditors...)
+	if err != nil {
+		return nil, err
+	}
+	return ParseUiConventionsEditModalUiConventionsSlugEditGetResponse(rsp)
+}
+
+func (c *ClientWithResponses) UiConventionsEditModalUiConventionsSlugEditGetWithResponse(ctx context.Context, slug string, body UiConventionsEditModalUiConventionsSlugEditGetJSONRequestBody, reqEditors ...RequestEditorFn) (*UiConventionsEditModalUiConventionsSlugEditGetResponse, error) {
+	rsp, err := c.UiConventionsEditModalUiConventionsSlugEditGet(ctx, slug, body, reqEditors...)
+	if err != nil {
+		return nil, err
+	}
+	return ParseUiConventionsEditModalUiConventionsSlugEditGetResponse(rsp)
+}
+
+// UiConventionsHistoryUiConventionsSlugHistoryGetWithBodyWithResponse request with arbitrary body returning *UiConventionsHistoryUiConventionsSlugHistoryGetResponse
+func (c *ClientWithResponses) UiConventionsHistoryUiConventionsSlugHistoryGetWithBodyWithResponse(ctx context.Context, slug string, contentType string, body io.Reader, reqEditors ...RequestEditorFn) (*UiConventionsHistoryUiConventionsSlugHistoryGetResponse, error) {
+	rsp, err := c.UiConventionsHistoryUiConventionsSlugHistoryGetWithBody(ctx, slug, contentType, body, reqEditors...)
+	if err != nil {
+		return nil, err
+	}
+	return ParseUiConventionsHistoryUiConventionsSlugHistoryGetResponse(rsp)
+}
+
+func (c *ClientWithResponses) UiConventionsHistoryUiConventionsSlugHistoryGetWithResponse(ctx context.Context, slug string, body UiConventionsHistoryUiConventionsSlugHistoryGetJSONRequestBody, reqEditors ...RequestEditorFn) (*UiConventionsHistoryUiConventionsSlugHistoryGetResponse, error) {
+	rsp, err := c.UiConventionsHistoryUiConventionsSlugHistoryGet(ctx, slug, body, reqEditors...)
+	if err != nil {
+		return nil, err
+	}
+	return ParseUiConventionsHistoryUiConventionsSlugHistoryGetResponse(rsp)
 }
 
 // CorpusIndexUiCorpusGetWithResponse request returning *CorpusIndexUiCorpusGetResponse
@@ -41889,6 +42937,110 @@ func ParseUiConventionsListUiConventionsGetResponse(rsp *http.Response) (*UiConv
 	return response, nil
 }
 
+// ParseUiConventionsCreateModalUiConventionsCreateGetResponse parses an HTTP response from a UiConventionsCreateModalUiConventionsCreateGetWithResponse call
+func ParseUiConventionsCreateModalUiConventionsCreateGetResponse(rsp *http.Response) (*UiConventionsCreateModalUiConventionsCreateGetResponse, error) {
+	bodyBytes, err := io.ReadAll(rsp.Body)
+	defer func() { _ = rsp.Body.Close() }()
+	if err != nil {
+		return nil, err
+	}
+
+	response := &UiConventionsCreateModalUiConventionsCreateGetResponse{
+		Body:         bodyBytes,
+		HTTPResponse: rsp,
+	}
+
+	switch {
+	case strings.Contains(rsp.Header.Get("Content-Type"), "json") && rsp.StatusCode == 422:
+		var dest HTTPValidationError
+		if err := json.Unmarshal(bodyBytes, &dest); err != nil {
+			return nil, err
+		}
+		response.JSON422 = &dest
+
+	}
+
+	return response, nil
+}
+
+// ParseUiConventionsCreateSubmitUiConventionsCreatePostResponse parses an HTTP response from a UiConventionsCreateSubmitUiConventionsCreatePostWithResponse call
+func ParseUiConventionsCreateSubmitUiConventionsCreatePostResponse(rsp *http.Response) (*UiConventionsCreateSubmitUiConventionsCreatePostResponse, error) {
+	bodyBytes, err := io.ReadAll(rsp.Body)
+	defer func() { _ = rsp.Body.Close() }()
+	if err != nil {
+		return nil, err
+	}
+
+	response := &UiConventionsCreateSubmitUiConventionsCreatePostResponse{
+		Body:         bodyBytes,
+		HTTPResponse: rsp,
+	}
+
+	switch {
+	case strings.Contains(rsp.Header.Get("Content-Type"), "json") && rsp.StatusCode == 422:
+		var dest HTTPValidationError
+		if err := json.Unmarshal(bodyBytes, &dest); err != nil {
+			return nil, err
+		}
+		response.JSON422 = &dest
+
+	}
+
+	return response, nil
+}
+
+// ParseUiConventionsPreviewUiConventionsPreviewPostResponse parses an HTTP response from a UiConventionsPreviewUiConventionsPreviewPostWithResponse call
+func ParseUiConventionsPreviewUiConventionsPreviewPostResponse(rsp *http.Response) (*UiConventionsPreviewUiConventionsPreviewPostResponse, error) {
+	bodyBytes, err := io.ReadAll(rsp.Body)
+	defer func() { _ = rsp.Body.Close() }()
+	if err != nil {
+		return nil, err
+	}
+
+	response := &UiConventionsPreviewUiConventionsPreviewPostResponse{
+		Body:         bodyBytes,
+		HTTPResponse: rsp,
+	}
+
+	switch {
+	case strings.Contains(rsp.Header.Get("Content-Type"), "json") && rsp.StatusCode == 422:
+		var dest HTTPValidationError
+		if err := json.Unmarshal(bodyBytes, &dest); err != nil {
+			return nil, err
+		}
+		response.JSON422 = &dest
+
+	}
+
+	return response, nil
+}
+
+// ParseUiConventionsDeleteUiConventionsSlugDeleteResponse parses an HTTP response from a UiConventionsDeleteUiConventionsSlugDeleteWithResponse call
+func ParseUiConventionsDeleteUiConventionsSlugDeleteResponse(rsp *http.Response) (*UiConventionsDeleteUiConventionsSlugDeleteResponse, error) {
+	bodyBytes, err := io.ReadAll(rsp.Body)
+	defer func() { _ = rsp.Body.Close() }()
+	if err != nil {
+		return nil, err
+	}
+
+	response := &UiConventionsDeleteUiConventionsSlugDeleteResponse{
+		Body:         bodyBytes,
+		HTTPResponse: rsp,
+	}
+
+	switch {
+	case strings.Contains(rsp.Header.Get("Content-Type"), "json") && rsp.StatusCode == 422:
+		var dest HTTPValidationError
+		if err := json.Unmarshal(bodyBytes, &dest); err != nil {
+			return nil, err
+		}
+		response.JSON422 = &dest
+
+	}
+
+	return response, nil
+}
+
 // ParseUiConventionsDetailUiConventionsSlugGetResponse parses an HTTP response from a UiConventionsDetailUiConventionsSlugGetWithResponse call
 func ParseUiConventionsDetailUiConventionsSlugGetResponse(rsp *http.Response) (*UiConventionsDetailUiConventionsSlugGetResponse, error) {
 	bodyBytes, err := io.ReadAll(rsp.Body)
@@ -41898,6 +43050,110 @@ func ParseUiConventionsDetailUiConventionsSlugGetResponse(rsp *http.Response) (*
 	}
 
 	response := &UiConventionsDetailUiConventionsSlugGetResponse{
+		Body:         bodyBytes,
+		HTTPResponse: rsp,
+	}
+
+	switch {
+	case strings.Contains(rsp.Header.Get("Content-Type"), "json") && rsp.StatusCode == 422:
+		var dest HTTPValidationError
+		if err := json.Unmarshal(bodyBytes, &dest); err != nil {
+			return nil, err
+		}
+		response.JSON422 = &dest
+
+	}
+
+	return response, nil
+}
+
+// ParseUiConventionsPatchUiConventionsSlugPatchResponse parses an HTTP response from a UiConventionsPatchUiConventionsSlugPatchWithResponse call
+func ParseUiConventionsPatchUiConventionsSlugPatchResponse(rsp *http.Response) (*UiConventionsPatchUiConventionsSlugPatchResponse, error) {
+	bodyBytes, err := io.ReadAll(rsp.Body)
+	defer func() { _ = rsp.Body.Close() }()
+	if err != nil {
+		return nil, err
+	}
+
+	response := &UiConventionsPatchUiConventionsSlugPatchResponse{
+		Body:         bodyBytes,
+		HTTPResponse: rsp,
+	}
+
+	switch {
+	case strings.Contains(rsp.Header.Get("Content-Type"), "json") && rsp.StatusCode == 422:
+		var dest HTTPValidationError
+		if err := json.Unmarshal(bodyBytes, &dest); err != nil {
+			return nil, err
+		}
+		response.JSON422 = &dest
+
+	}
+
+	return response, nil
+}
+
+// ParseUiConventionsDeleteConfirmUiConventionsSlugDeleteGetResponse parses an HTTP response from a UiConventionsDeleteConfirmUiConventionsSlugDeleteGetWithResponse call
+func ParseUiConventionsDeleteConfirmUiConventionsSlugDeleteGetResponse(rsp *http.Response) (*UiConventionsDeleteConfirmUiConventionsSlugDeleteGetResponse, error) {
+	bodyBytes, err := io.ReadAll(rsp.Body)
+	defer func() { _ = rsp.Body.Close() }()
+	if err != nil {
+		return nil, err
+	}
+
+	response := &UiConventionsDeleteConfirmUiConventionsSlugDeleteGetResponse{
+		Body:         bodyBytes,
+		HTTPResponse: rsp,
+	}
+
+	switch {
+	case strings.Contains(rsp.Header.Get("Content-Type"), "json") && rsp.StatusCode == 422:
+		var dest HTTPValidationError
+		if err := json.Unmarshal(bodyBytes, &dest); err != nil {
+			return nil, err
+		}
+		response.JSON422 = &dest
+
+	}
+
+	return response, nil
+}
+
+// ParseUiConventionsEditModalUiConventionsSlugEditGetResponse parses an HTTP response from a UiConventionsEditModalUiConventionsSlugEditGetWithResponse call
+func ParseUiConventionsEditModalUiConventionsSlugEditGetResponse(rsp *http.Response) (*UiConventionsEditModalUiConventionsSlugEditGetResponse, error) {
+	bodyBytes, err := io.ReadAll(rsp.Body)
+	defer func() { _ = rsp.Body.Close() }()
+	if err != nil {
+		return nil, err
+	}
+
+	response := &UiConventionsEditModalUiConventionsSlugEditGetResponse{
+		Body:         bodyBytes,
+		HTTPResponse: rsp,
+	}
+
+	switch {
+	case strings.Contains(rsp.Header.Get("Content-Type"), "json") && rsp.StatusCode == 422:
+		var dest HTTPValidationError
+		if err := json.Unmarshal(bodyBytes, &dest); err != nil {
+			return nil, err
+		}
+		response.JSON422 = &dest
+
+	}
+
+	return response, nil
+}
+
+// ParseUiConventionsHistoryUiConventionsSlugHistoryGetResponse parses an HTTP response from a UiConventionsHistoryUiConventionsSlugHistoryGetWithResponse call
+func ParseUiConventionsHistoryUiConventionsSlugHistoryGetResponse(rsp *http.Response) (*UiConventionsHistoryUiConventionsSlugHistoryGetResponse, error) {
+	bodyBytes, err := io.ReadAll(rsp.Body)
+	defer func() { _ = rsp.Body.Close() }()
+	if err != nil {
+		return nil, err
+	}
+
+	response := &UiConventionsHistoryUiConventionsSlugHistoryGetResponse{
 		Body:         bodyBytes,
 		HTTPResponse: rsp,
 	}


### PR DESCRIPTION
## Summary

- Adds the **write surface** to the `/ui/conventions` operator console (T1 #1895 shipped the read pages) under Initiative #1838 (G10.12 Conventions console): author + edit HTMX modals, a debounced token-cost preview, a non-idempotent DELETE confirm gate, and a history diff panel.
- **Token-cost preview** is server-side and reuses `estimate_tokens` directly (no re-derived chars/token ratio). An `operational` body over the 600-token preamble budget flags red; the same body as `workflow`/`reference` is exempt. After a create/edit, the returned `preamble_status` surfaces a red "DROPPED" indicator (naming `would_drop_slugs`) when a new operational rule loses the budget contest — so the operator sees it will not reach agents before leaving the modal.
- **Non-idempotent DELETE** sits behind a confirm `<dialog>`; the service DELETE 404s on a missing row, so a double-fire is caught and rendered as a benign "already deleted" fragment rather than a raw 404.
- All writes go through the shared `ConventionsService`, so the budget gate, the history row, and the pre-allocated-audit-id soft-FK pairing (`bind_preallocated_audit_id`) are exercised identically to REST — the history row's `audit_id` joins the AuditMiddleware row instead of landing NULL.

## Design notes

- **Route ordering:** the static `/ui/conventions/create` + `/preview` register before `/ui/conventions/{slug}` (first-match-wins), mirroring `memory/routes.py`.
- **RBAC:** write = TENANT_ADMIN via `resolve_operator_or_403` (non-admin → 403); read views (list/detail/history) stay OPERATOR. The `is_tenant_admin` hint soft-hides the New/Edit/Delete affordances.
- **CSRF:** double-submit pair on every `/ui` write — each modal mints a fresh token and sets the matching cookie on the same response.
- **Transactions:** write handlers thread `get_raw_session` (no outer `begin()`) so a 409/422 can roll the failed flush back and still return the inline-error 200 fragment.
- Split the history-panel render into its own `history.py` module to keep `write.py` under the chassis 600-line cap.

## Test plan

- [x] `ruff check` / `ruff format --check` — clean
- [x] `mypy` — clean
- [x] `python3 .claude/hooks/code-quality.py --diff` — 0 blockers
- [x] `uv run pytest tests/test_ui_conventions_write.py -q` — 16 passed
- [x] `uv run pytest tests/ -k conventions -q` — 174 passed, 2 skipped (no regression in T1 list suite)
- [x] Acceptance greps: `estimate_tokens` present in `ui/routes/conventions/*.py`; `3.3` absent under `ui/routes/conventions/`; `resolve_operator_or_403` present
- [x] OpenAPI snapshot regenerated (`make snapshot-openapi && make generate`) — `cli/api/openapi.json` + `cli/internal/api/client.gen.go` updated; re-regen is deterministic (no drift); `go build ./...` clean

## Out of scope

- No backend route/shape changes (T0 #1894 extracted the service; `kind`/`slug` stay non-patchable by design).
- No DB-level enum on `kind`; no change to `estimate_tokens` / `assemble_preamble`; no real tokenizer.

<!-- auto-implement-issue: fresh, iteration 1 -->

Closes #1896
