### PR TITLE
feat(ui): /ui/retrieval page + Diagnostics tab — per-signal RRF score/rank breakdown (#1888)

### DIFF
--- a/backend/src/meho_backplane/ui/routes/__init__.py
+++ b/backend/src/meho_backplane/ui/routes/__init__.py
@@ -99,6 +99,7 @@ from meho_backplane.ui.routes.dashboard import build_dashboard_router
 from meho_backplane.ui.routes.kb import build_kb_router
 from meho_backplane.ui.routes.memory import build_memory_router
 from meho_backplane.ui.routes.operations import build_operations_router
+from meho_backplane.ui.routes.retrieval import build_retrieval_router
 from meho_backplane.ui.routes.runbooks import build_runbooks_router
 from meho_backplane.ui.routes.scheduler import build_scheduler_router
 from meho_backplane.ui.routes.stubs import build_stubs_router
@@ -116,6 +117,7 @@ __all__ = [
     "build_kb_router",
     "build_memory_router",
     "build_operations_router",
+    "build_retrieval_router",
     "build_router",
     "build_runbooks_router",
     "build_runs_router",
@@ -179,6 +181,15 @@ def build_router() -> APIRouter:
     router.include_router(build_agents_router())
     router.include_router(build_kb_router())
     router.include_router(build_corpus_router())
+    # Retrieval diagnostics & quality console (G10.14-T1 #1888): the anchor
+    # surface for ``/ui/retrieval`` + ``POST /ui/retrieval/diagnostics``. The
+    # only state-changing route is the literal ``/diagnostics`` POST -- there
+    # is no ``/ui/retrieval/{param}`` route yet (the T2/T3 tabs are
+    # client-side panels on the one page), but the literal-before-param
+    # ordering is pinned inside ``build_retrieval_router`` for when one lands.
+    # Registered before the stubs aggregate so its concrete paths win the
+    # first-match-wins lookup against the placeholder ``/ui/{slug}``.
+    router.include_router(build_retrieval_router())
     router.include_router(build_runbooks_router())
     router.include_router(build_approvals_router())
     # Scheduler lands ``/ui/scheduler`` + ``/ui/scheduler/{trigger_id}`` +

--- a/backend/src/meho_backplane/ui/routes/dashboard.py
+++ b/backend/src/meho_backplane/ui/routes/dashboard.py
@@ -107,6 +107,12 @@ _SURFACE_TILES: Final[tuple[dict[str, str], ...]] = (
         "icon": "library",
     },
     {
+        "title": "Retrieval",
+        "summary": "Diagnose retrieval: per-signal RRF score & rank breakdown.",
+        "href": "/ui/retrieval",
+        "icon": "search",
+    },
+    {
         "title": "Topology",
         "summary": "Targets, clusters, and dependencies.",
         "href": "/ui/topology",

--- a/backend/src/meho_backplane/ui/routes/retrieval/__init__.py
+++ b/backend/src/meho_backplane/ui/routes/retrieval/__init__.py
@@ -1,0 +1,25 @@
+# SPDX-License-Identifier: Apache-2.0
+# Copyright (c) 2026 evoila Group
+
+"""Retrieval-diagnostics UI surface package.
+
+Initiative #1840 (G10.14 Retrieval diagnostics & quality console), Task #1888.
+
+The anchor Task stands up the ``/ui/retrieval`` page scaffold (the sidebar
+entry, the tab strip, the page chrome) + its default Diagnostics tab. Sibling
+Tasks T2 (Usage / Eval tabs) and T3 (Retire-checklist tab) nest into the same
+page as additional client-side tab panels.
+
+Exposes :func:`~meho_backplane.ui.routes.retrieval.routes.build_retrieval_router`
+-- the ``GET /ui/retrieval`` + ``POST /ui/retrieval/diagnostics`` factory -- so
+:func:`meho_backplane.ui.routes.build_router` can include it ahead of the stubs
+router. The factory pattern (not a module-level constant) mirrors the corpus /
+kb chassis convention so a test app can build parallel routers without sharing
+route state.
+"""
+
+from __future__ import annotations
+
+from meho_backplane.ui.routes.retrieval.routes import build_retrieval_router
+
+__all__ = ["build_retrieval_router"]

--- a/backend/src/meho_backplane/ui/routes/retrieval/routes.py
+++ b/backend/src/meho_backplane/ui/routes/retrieval/routes.py
@@ -1,0 +1,436 @@
+# SPDX-License-Identifier: Apache-2.0
+# Copyright (c) 2026 evoila Group
+
+"""Retrieval-diagnostics UI routes: in-process hybrid query + per-signal breakdown.
+
+Initiative #1840 (G10.14 Retrieval diagnostics & quality console), Task #1888.
+
+``GET /ui/retrieval`` renders the page: a tabbed shell (Diagnostics tab
+default-active; the Usage / Eval / Retire tabs are placeholders T2/T3 fill
+in) with a query form (a query textarea, optional ``source`` / ``kind``
+inputs, a ``limit`` selector) and an empty ``#retrieval-diagnostics-results``
+region. ``POST /ui/retrieval/diagnostics`` is the HTMX fragment endpoint --
+it reconstructs the session operator, binds the privacy ``audit_*``
+contextvars, runs the in-process :func:`~meho_backplane.retrieval.retriever.retrieve`
+service, and swaps ``retrieval/_diagnostics_results.html`` (one card per hit,
+each with the ``fused_score`` and the per-signal RRF score/rank breakdown)
+into ``#retrieval-diagnostics-results``.
+
+Reusing the substrate (no new ``/api/v1`` endpoint)
+---------------------------------------------------
+
+The page does not add a REST endpoint. It calls the same in-process
+:func:`~meho_backplane.retrieval.retriever.retrieve` service the
+``POST /api/v1/retrieve`` route fronts (``api/v1/retrieve.py``), tenant-scoped
+to ``operator.tenant_id`` with the mandatory per-principal isolation predicate
+(``principal_sub=operator.sub``). Routing through the service -- not a
+self-HTTP call -- keeps the in-process audit binding and avoids a network hop,
+exactly as ``ui/routes/corpus/routes.py`` fronts ``search_docs``.
+
+Audit / privacy binding (load-bearing)
+--------------------------------------
+
+The REST handler binds the privacy ``audit_*`` contextvars **before** calling
+``retrieve`` so the audit_log row carries a privacy-preserving query trace even
+on a mid-retrieval exception. This handler reproduces that binding: it binds
+``audit_query_hash`` (the SHA-256 hex digest of the raw query via the same
+:func:`~meho_backplane.api.v1.retrieve._compute_query_hash` encoding contract
+-- never the raw query), ``audit_source``, ``audit_kind`` before the call and
+``audit_hit_count`` after. The raw query is deliberately ephemeral.
+
+Operator reconstruction
+-----------------------
+
+The :class:`~meho_backplane.ui.auth.middleware.UISessionContext` the
+``require_ui_session`` dependency hands route handlers carries only
+``operator_sub`` / ``tenant_id`` -- not the full
+:class:`~meho_backplane.auth.operator.Operator` (with its ``sub`` for the
+per-principal predicate). The handler reconstructs the operator from the
+session via the same proven seam :func:`_resolve_operator` mirrors from the
+corpus console: load the decrypted session, present its (silently-refreshed)
+access token to the chassis JWT chain via
+:func:`~meho_backplane.ui.auth.refresh.verify_access_token_with_refresh`.
+
+CSRF
+----
+
+The diagnostics form declares its own ``hx-headers`` ``X-CSRF-Token`` (HTMX
+does not propagate ``hx-headers`` to child elements). ``GET /ui/retrieval``
+mints the token and sets the ``meho_csrf`` cookie. The fragment swaps only
+``#retrieval-diagnostics-results`` and leaves the form in place, so it
+**reuses** the live cookie token (cookie untouched) rather than rotating a
+fresh one out from under the un-swapped form -- the cookie-rotation desync the
+corpus surface diagnosed (#1754). A missing / invalid cookie falls back to a
+fresh mint + re-set. See :func:`_resolve_diagnostics_csrf`.
+
+Tenant scoping + RBAC
+---------------------
+
+``operator`` role minimum (enforced by ``require_ui_session``; matches the
+OPERATOR floor the ``POST /api/v1/retrieve`` route carries). Diagnostics is
+**own-tenant only** -- tenant identity is derived from ``session.tenant_id``
+via the reconstructed operator, there is no ``tenant_filter`` (that is the
+sibling T3 concern). The whole surface is read-only -- no confirm gates.
+"""
+
+from __future__ import annotations
+
+import hashlib
+import time
+from typing import Final
+
+import structlog
+from fastapi import APIRouter, Depends, Form, HTTPException, Request, status
+from fastapi.responses import HTMLResponse
+
+from meho_backplane.auth.operator import Operator
+from meho_backplane.retrieval.retriever import (
+    CANDIDATE_LIMIT,
+    RetrievalHit,
+    retrieve,
+)
+from meho_backplane.settings import get_settings
+from meho_backplane.ui.auth.middleware import UISessionContext, require_ui_session
+from meho_backplane.ui.auth.refresh import (
+    load_fresh_session,
+    verify_access_token_with_refresh,
+)
+from meho_backplane.ui.csrf import CSRF_COOKIE_NAME, mint_csrf_token, verify_csrf_token
+from meho_backplane.ui.templating import get_templates
+
+__all__ = ["build_retrieval_router"]
+
+log = structlog.get_logger(__name__)
+
+#: Maximum query length accepted by the diagnostics fragment. Mirrors the
+#: backend ``RetrieveRequest.query`` cap (max 2000 chars) so an oversized
+#: free-form query is rejected at the form boundary (FastAPI 422) rather than
+#: forwarded.
+_MAX_QUERY_LENGTH: Final[int] = 2000
+
+#: Maximum ``source`` / ``kind`` filter length. Mirrors the backend
+#: ``RetrieveRequest.source`` / ``.kind`` caps (max 64 chars).
+_MAX_FILTER_LENGTH: Final[int] = 64
+
+#: Maximum ``limit`` the selector offers. Mirrors the backend
+#: ``RetrieveRequest.limit`` cap (1--50). The form renders a fixed set of
+#: options; an out-of-range value is clamped at the handler boundary.
+_MAX_LIMIT: Final[int] = 50
+
+#: Default ``limit``. Mirrors the backend ``RetrieveRequest.limit`` default.
+_DEFAULT_LIMIT: Final[int] = 10
+
+#: The ``limit`` options the selector renders.
+_LIMIT_OPTIONS: Final[tuple[int, ...]] = (5, 10, 20, 50)
+
+#: Module-level ``Depends`` closure for the operator-session gate. Built once
+#: (rather than inline) to satisfy ruff B008, matching the convention the
+#: corpus / kb / dashboard routes established.
+_require_session = Depends(require_ui_session)
+
+
+async def _resolve_operator(session: UISessionContext) -> Operator:
+    """Reconstruct the full :class:`Operator` from the BFF session.
+
+    Loads the decrypted session row and presents its access token to the
+    chassis JWT chain (silently refreshing on the ``token_expired`` 401) via
+    :func:`~meho_backplane.ui.auth.refresh.verify_access_token_with_refresh`
+    -- the same seam the corpus console + ``require_ui_admin`` use to surface
+    the operator's claims. The returned operator carries the ``sub`` the
+    per-principal isolation predicate reads and the ``tenant_id`` retrieval is
+    scoped to.
+
+    Raises :class:`fastapi.HTTPException` 401 when the session has been
+    revoked / expired in the gap since the middleware check (the BFF error
+    handler maps the ``session_expired`` detail to a login redirect for HTML
+    requests).
+    """
+    decrypted = await load_fresh_session(session.session_id)
+    if decrypted is None:
+        raise HTTPException(
+            status_code=status.HTTP_401_UNAUTHORIZED,
+            detail="ui_session_required",
+        )
+    settings = get_settings()
+    _refreshed, operator = await verify_access_token_with_refresh(
+        decrypted,
+        expected_audience=settings.keycloak_audience,
+    )
+    return operator
+
+
+def _compute_query_hash(query: str) -> str:
+    """SHA-256 hex digest of *query* (UTF-8 encoded).
+
+    Byte-equivalent to :func:`meho_backplane.api.v1.retrieve._compute_query_hash`
+    so the in-process audit row this UI surface produces correlates with the
+    REST surface's ``audit_log.payload.query_hash`` for the same query string.
+    The raw query is never bound to the audit payload -- only this hash.
+    """
+    return hashlib.sha256(query.encode("utf-8")).hexdigest()
+
+
+def _set_csrf_cookie(response: HTMLResponse, csrf_token: str) -> None:
+    """Set the ``meho_csrf`` double-submit cookie on *response*.
+
+    The cookie value MUST equal the token the rendered markup echoes via
+    ``hx-headers`` -- the CSRF middleware rejects a mismatch
+    (``value_mismatch``). Mirrors the SameSite=Strict + Secure + non-HttpOnly
+    posture every UI surface's CSRF cookie carries (HTMX must read it to
+    populate ``X-CSRF-Token``; the HMAC binding to the session id defeats the
+    cookie-injection vector JS-read would otherwise open).
+    """
+    response.set_cookie(
+        key=CSRF_COOKIE_NAME,
+        value=csrf_token,
+        httponly=False,
+        secure=True,
+        samesite="strict",
+        path="/ui",
+    )
+
+
+def _resolve_diagnostics_csrf(request: Request, session_id: str) -> tuple[str, bool]:
+    """Pick the CSRF token the diagnostics fragment echoes + whether to set the cookie.
+
+    Returns ``(token, set_cookie)``. The fragment swaps only
+    ``#retrieval-diagnostics-results`` -- the diagnostics ``<form>`` that
+    carries the ``hx-headers`` ``X-CSRF-Token`` lives in ``index.html`` and is
+    **not** re-rendered. So the rule (mirroring the corpus surface's
+    ``_resolve_search_csrf``, the #1754 fix) is:
+
+    * **Live cookie present + valid** -- *reuse* that token and do **not**
+      re-set the cookie. Minting a fresh token + ``Set-Cookie`` here would
+      rotate the cookie out from under the un-swapped form, whose still-rendered
+      ``hx-headers`` snapshot then carries the old token while the cookie holds
+      the new one -- the ``value_mismatch`` 403 the cookie-rotation desync class
+      produces. The CSRF token is stateless and HMAC-bound to the session, so
+      the same token validates on every diagnostics run until logout.
+    * **Cookie missing / invalid** -- defensive fallback: mint a fresh token and
+      re-set the cookie so a direct fragment fetch with no prior full-page load
+      (or a tampered cookie) still establishes a working double-submit pair.
+
+    The reuse is gated on :func:`verify_csrf_token` so a foreign or tampered
+    cookie value never gets echoed back as the fragment's token.
+    """
+    existing = request.cookies.get(CSRF_COOKIE_NAME)
+    if existing and verify_csrf_token(session_id, existing):
+        return existing, False
+    return mint_csrf_token(session_id), True
+
+
+def _clamp_limit(raw: int) -> int:
+    """Clamp a submitted ``limit`` into the backend-accepted 1--50 range.
+
+    The selector only renders in-range options, but a forged form post could
+    carry an out-of-range value; clamping (rather than 422-ing) keeps the
+    diagnostics tool forgiving for an operator while never forwarding a value
+    the substrate would reject.
+    """
+    if raw < 1:
+        return 1
+    if raw > _MAX_LIMIT:
+        return _MAX_LIMIT
+    return raw
+
+
+def build_retrieval_router() -> APIRouter:
+    """Construct the ``GET /ui/retrieval`` + ``POST /ui/retrieval/diagnostics`` router.
+
+    Factory function (not a module-level constant) so a test app can construct
+    parallel routers without shared route state -- the same convention the
+    corpus / kb / dashboard surface routers follow.
+    """
+    router = APIRouter(tags=["ui-retrieval"])
+
+    @router.get("/ui/retrieval", response_class=HTMLResponse)
+    async def retrieval_index(
+        request: Request,
+        session: UISessionContext = _require_session,
+    ) -> HTMLResponse:
+        """Render the retrieval page (delegates to :func:`_render_retrieval_index`)."""
+        return await _render_retrieval_index(request, session)
+
+    # NOTE: the literal ``POST /ui/retrieval/diagnostics`` route is registered
+    # here, ahead of any future ``/ui/retrieval/{param}`` route on this
+    # surface, so first-match-wins routing never binds the literal
+    # ``diagnostics`` segment as a slug parameter -- the same ordering
+    # discipline the corpus / kb / scheduler routers document. The T2/T3 tabs
+    # are client-side toggles on this one page, so no per-tab param route
+    # exists today, but the ordering invariant is pinned now for when one does.
+
+    @router.post("/ui/retrieval/diagnostics", response_class=HTMLResponse)
+    async def retrieval_diagnostics(
+        request: Request,
+        session: UISessionContext = _require_session,
+        query: str = Form(default="", max_length=_MAX_QUERY_LENGTH),
+        source: str = Form(default="", max_length=_MAX_FILTER_LENGTH),
+        kind: str = Form(default="", max_length=_MAX_FILTER_LENGTH),
+        limit: int = Form(default=_DEFAULT_LIMIT),
+    ) -> HTMLResponse:
+        """Run the diagnostics fragment (delegates to :func:`_render_diagnostics`)."""
+        return await _render_diagnostics(request, session, query, source, kind, limit)
+
+    return router
+
+
+def _diagnostics_form_context(
+    *,
+    query: str,
+    source: str,
+    kind: str,
+    limit: int,
+    csrf_token: str,
+) -> dict[str, object]:
+    """Shared form-state context for the index render + the fragment re-render."""
+    return {
+        "query": query,
+        "source": source,
+        "kind": kind,
+        "limit": limit,
+        "limit_options": _LIMIT_OPTIONS,
+        "csrf_token": csrf_token,
+    }
+
+
+async def _render_retrieval_index(
+    request: Request,
+    session: UISessionContext,
+) -> HTMLResponse:
+    """Render the retrieval page for ``GET /ui/retrieval``.
+
+    Renders the tabbed shell with the Diagnostics tab active and an empty
+    results region. Mints a CSRF token and sets the ``meho_csrf`` cookie so the
+    diagnostics form's ``hx-headers`` echo passes the double-submit check.
+    """
+    csrf_token = mint_csrf_token(str(session.session_id))
+    context: dict[str, object] = {
+        **_diagnostics_form_context(
+            query="",
+            source="",
+            kind="",
+            limit=_DEFAULT_LIMIT,
+            csrf_token=csrf_token,
+        ),
+        "hits": [],
+        "searched": False,
+        "candidate_limit": CANDIDATE_LIMIT,
+        "operator_sub": session.operator_sub,
+        "active_surface": "retrieval",
+        "page_title": "Retrieval",
+    }
+    response = get_templates().TemplateResponse(request, "retrieval/index.html", context)
+    _set_csrf_cookie(response, csrf_token)
+    return response
+
+
+async def _render_diagnostics(
+    request: Request,
+    session: UISessionContext,
+    query: str,
+    source: str,
+    kind: str,
+    limit: int,
+) -> HTMLResponse:
+    """Run the HTMX diagnostics fragment for ``POST /ui/retrieval/diagnostics``.
+
+    Swaps ``retrieval/_diagnostics_results.html`` into
+    ``#retrieval-diagnostics-results``. A successful run renders one card per
+    hit (body excerpt + ``source`` / ``source_id`` / ``kind``, the
+    ``fused_score``, and a per-signal breakdown where a ``None`` rank renders
+    an explicit "absent from this signal's top-N" marker); an empty hit list
+    renders a "no matches" state.
+
+    The privacy ``audit_*`` contextvars are bound **before** the ``retrieve``
+    call (and ``audit_hit_count`` after) so the in-process audit row carries the
+    SHA-256 query trace even on a mid-retrieval exception. CSRF handling defers
+    to :func:`_resolve_diagnostics_csrf`.
+    """
+    query_text = query.strip()
+    source_filter = source.strip()
+    kind_filter = kind.strip()
+    clamped_limit = _clamp_limit(limit)
+
+    hits: list[RetrievalHit] = []
+    duration_ms: float | None = None
+    error_message: str | None = None
+    if query_text:
+        operator = await _resolve_operator(session)
+        try:
+            hits, duration_ms = await _run_diagnostics(
+                operator, query_text, source_filter, kind_filter, clamped_limit
+            )
+        except HTTPException:
+            # A 401 from the operator-reconstruction seam is an auth condition,
+            # not a search failure -- let it propagate (the BFF maps it to a
+            # login redirect), matching the corpus surface.
+            raise
+
+    csrf_token, set_csrf = _resolve_diagnostics_csrf(request, str(session.session_id))
+    context: dict[str, object] = {
+        **_diagnostics_form_context(
+            query=query_text,
+            source=source_filter,
+            kind=kind_filter,
+            limit=clamped_limit,
+            csrf_token=csrf_token,
+        ),
+        "hits": hits,
+        "searched": bool(query_text),
+        "duration_ms": duration_ms,
+        "candidate_limit": CANDIDATE_LIMIT,
+        "error_message": error_message,
+    }
+    response = get_templates().TemplateResponse(
+        request, "retrieval/_diagnostics_results.html", context
+    )
+    if set_csrf:
+        _set_csrf_cookie(response, csrf_token)
+    return response
+
+
+async def _run_diagnostics(
+    operator: Operator,
+    query: str,
+    source: str,
+    kind: str,
+    limit: int,
+) -> tuple[list[RetrievalHit], float]:
+    """Bind the privacy audit contextvars, then run in-process ``retrieve``.
+
+    Reproduces the ``POST /api/v1/retrieve`` audit binding (``retrieve.py``):
+    binds ``audit_query_hash`` (SHA-256 hex of the raw query, never the raw
+    query), ``audit_source``, ``audit_kind`` **before** the retrieval call so
+    the audit_log row's ``payload`` carries the privacy-preserving query trace
+    even on a mid-retrieval exception, then ``audit_hit_count`` after. Tenant-
+    scoped to ``operator.tenant_id`` with the mandatory per-principal isolation
+    predicate (``principal_sub=operator.sub``) -- own-tenant only, no
+    tenant_filter. Returns ``(hits, duration_ms)``.
+    """
+    start = time.monotonic()
+    query_hash = _compute_query_hash(query)
+    structlog.contextvars.bind_contextvars(
+        audit_query_hash=query_hash,
+        audit_source=source or None,
+        audit_kind=kind or None,
+    )
+    hits = await retrieve(
+        tenant_id=operator.tenant_id,
+        query=query,
+        source=source or None,
+        kind=kind or None,
+        limit=limit,
+        principal_sub=operator.sub,
+    )
+    structlog.contextvars.bind_contextvars(audit_hit_count=len(hits))
+    duration_ms = round((time.monotonic() - start) * 1000, 2)
+    log.info(
+        "ui_retrieval_diagnostics_completed",
+        operator_sub=operator.sub,
+        tenant_id=str(operator.tenant_id),
+        source=source or None,
+        kind=kind or None,
+        hit_count=len(hits),
+        duration_ms=duration_ms,
+    )
+    return hits, duration_ms

--- a/backend/src/meho_backplane/ui/templates/base.html
+++ b/backend/src/meho_backplane/ui/templates/base.html
@@ -37,6 +37,7 @@
   ("broadcast", "/ui/broadcast", "radio-tower", "Broadcast"),
   ("knowledge", "/ui/kb", "book-open", "Knowledge"),
   ("corpus", "/ui/corpus", "library", "Docs Corpus"),
+  ("retrieval", "/ui/retrieval", "search", "Retrieval"),
   ("topology", "/ui/topology", "waypoints", "Topology"),
   ("connectors", "/ui/connectors", "plug", "Connectors"),
   ("memory", "/ui/memory", "brain", "Memory"),

--- a/backend/src/meho_backplane/ui/templates/dashboard.html
+++ b/backend/src/meho_backplane/ui/templates/dashboard.html
@@ -75,14 +75,16 @@
      Span rhythm: 5-4-3 / 3-4-5 / 6-6 across three lg rows. The map is
      keyed by loop.index0; the Broadcast hero additionally gets the
      signal-washed card face. -#}
-  {#- One span per surface tile (``loop.index0`` indexes this list), tuned
-     so each lg row sums to 12 across the 12-col bento grid: row 1 = 5+4+3,
-     row 2 = 3+4+5, row 3 = 4+4+4 (the 7th-9th tiles -- Agents + Runbooks +
-     Approvals). The deploy cell drops to its own full-width row below.
-     #1777 grew this to 7 entries; #1778 added the 8th (Approvals); #1825
-     adds the 9th (Agents). Keep the entry count in lock-step with
-     ``_SURFACE_TILES`` in ``dashboard.py`` -- a tile without a span trips
-     ``StrictUndefined``. -#}
+  {#- One span per surface tile (``loop.index0`` indexes this list -- the
+     spans are positional, not per-surface), tuned so each lg row sums to 12
+     across the 12-col bento grid: row 1 = 5+4+3, row 2 = 3+4+5, row 3 = 4+4+4,
+     row 4 = 6 (the 10th cell on its own half-row). The deploy cell drops to
+     its own full-width row below. #1777 grew this to 7 entries; #1778 added
+     the 8th (Approvals); #1825 added the 9th (Agents); #1888 adds the 10th
+     (the Retrieval tile is inserted after Docs Corpus, so the surfaces shift
+     down a slot -- only the entry count must stay in lock-step). Keep the
+     count in lock-step with ``_SURFACE_TILES`` in ``dashboard.py`` -- a tile
+     without a span trips ``StrictUndefined``. -#}
   {% set tile_spans = [
     "md:col-span-6 lg:col-span-5",
     "md:col-span-6 lg:col-span-4",
@@ -93,6 +95,7 @@
     "md:col-span-6 lg:col-span-4",
     "md:col-span-6 lg:col-span-4",
     "md:col-span-6 lg:col-span-4",
+    "md:col-span-6 lg:col-span-6",
   ] %}
   <div
     class="meho-stagger grid grid-cols-1 gap-4 md:grid-cols-12"

--- a/backend/src/meho_backplane/ui/templates/retrieval/_diagnostics_results.html
+++ b/backend/src/meho_backplane/ui/templates/retrieval/_diagnostics_results.html
@@ -1,0 +1,133 @@
+{#-
+  SPDX-License-Identifier: Apache-2.0
+  Copyright (c) 2026 evoila Group
+
+  Retrieval-diagnostics results partial.
+
+  Initiative #1840 (G10.14 Retrieval diagnostics & quality console),
+  Task #1888. This fragment is swapped into ``#retrieval-diagnostics-results``
+  by the HTMX diagnostics POST; it is also included directly into
+  ``index.html`` for the initial (empty) page render so both paths share
+  identical markup.
+
+  Render branches (first match wins):
+    1. ``error_message`` set -> a plain error card.
+    2. ``hits`` non-empty -> one hit card each, with the fused_score + the
+       per-signal RRF score/rank breakdown table.
+    3. ``searched`` true (a query ran, no error, no hits) -> "no matches".
+    4. otherwise (initial render, no query yet) -> a quiet prompt.
+
+  Per-signal breakdown (the load-bearing render):
+    Each hit carries ``bm25_score`` / ``bm25_rank`` and ``cosine_score`` /
+    ``cosine_rank`` (float|None / int|None). A ``None`` rank means the
+    document was absent from that signal's top-``candidate_limit`` candidate
+    list -- it is rendered as an explicit "absent from this signal's top-N"
+    marker, NOT a blank cell, so an operator can tell "scored 0" apart from
+    "never appeared in that signal".
+
+  Context variables:
+    query           -- str: the submitted query (for the heading + empty state)
+    hits            -- list[RetrievalHit]: ranked hits (best first by fused_score)
+    searched        -- bool: whether a query actually ran
+    duration_ms     -- float | None: wall-clock retrieval duration
+    candidate_limit -- int: the per-signal candidate pull (CANDIDATE_LIMIT, 50)
+    error_message   -- str | None: a non-auth failure detail
+-#}
+{#- Per-signal breakdown row macro: renders one signal's (score, rank) pair,
+    or the explicit absent marker when the rank is None. -#}
+{% macro signal_row(label, score, rank, candidate_limit) %}
+  <tr>
+    <td class="font-medium">{{ label }}</td>
+    {% if rank is none %}
+      <td colspan="2" class="opacity-60 italic">
+        absent from this signal&rsquo;s top-{{ candidate_limit }}
+      </td>
+    {% else %}
+      <td class="font-mono">{% if score is not none %}{{ "%.4f" | format(score) }}{% else %}&mdash;{% endif %}</td>
+      <td class="font-mono">#{{ rank }}</td>
+    {% endif %}
+  </tr>
+{% endmacro %}
+<div id="retrieval-diagnostics-results" class="space-y-3">
+  {% set error_message = error_message | default(none) %}
+  {% set duration_ms = duration_ms | default(none) %}
+  {% if error_message %}
+    {# ---------- Error card ---------- #}
+    <div class="alert alert-error" role="alert" aria-live="assertive">
+      <div>
+        <h3 class="font-semibold">Diagnostics query failed</h3>
+        <p class="text-sm opacity-90">{{ error_message }}</p>
+      </div>
+    </div>
+
+  {% elif hits %}
+    {# ---------- Hit cards ---------- #}
+    <p class="text-sm opacity-70" aria-live="polite">
+      {{ hits | length }} hit{% if hits | length != 1 %}s{% endif %}
+      for <em>&ldquo;{{ query }}&rdquo;</em>{% if duration_ms is not none %}
+      &middot; <span class="font-mono">{{ "%.2f" | format(duration_ms) }}&nbsp;ms</span>{% endif %}
+    </p>
+    <ul class="space-y-3" role="list" aria-label="Retrieval hits">
+      {% for hit in hits %}
+      <li class="card bg-base-100 border-base-300 border shadow-sm">
+        <div class="card-body py-3 space-y-2">
+          <div class="flex flex-wrap items-start justify-between gap-2">
+            <div class="flex flex-wrap items-center gap-1 text-xs" aria-label="Hit provenance">
+              <span class="badge badge-ghost badge-outline" title="Source namespace">{{ hit.source }}</span>
+              <span class="badge badge-ghost badge-outline" title="Document kind">{{ hit.kind }}</span>
+              <span class="badge badge-ghost badge-outline font-mono" title="Source id">{{ hit.source_id }}</span>
+            </div>
+            <span
+              class="badge badge-primary badge-outline"
+              title="Fused RRF score (sorted by)"
+              aria-label="Fused score {{ '%.6f' | format(hit.fused_score) }}"
+            >
+              fused {{ "%.6f" | format(hit.fused_score) }}
+            </span>
+          </div>
+          <p class="text-sm whitespace-pre-wrap">{{ hit.body }}</p>
+          {# Per-signal RRF score/rank breakdown -- a None rank renders the
+             explicit absent marker, not a blank. #}
+          <div class="overflow-x-auto">
+            <table class="table table-xs" aria-label="Per-signal RRF breakdown">
+              <thead>
+                <tr>
+                  <th>Signal</th>
+                  <th>Score</th>
+                  <th>Rank</th>
+                </tr>
+              </thead>
+              <tbody>
+                {{ signal_row("BM25", hit.bm25_score, hit.bm25_rank, candidate_limit) }}
+                {{ signal_row("Cosine", hit.cosine_score, hit.cosine_rank, candidate_limit) }}
+              </tbody>
+            </table>
+          </div>
+        </div>
+      </li>
+      {% endfor %}
+    </ul>
+
+  {% elif searched %}
+    {# ---------- No-matches state (a query ran, zero hits, not an error) ---------- #}
+    <div class="card bg-base-100 border-base-300 border shadow-sm">
+      <div class="card-body text-center py-10">
+        <p class="text-lg opacity-60">No hits for &ldquo;{{ query }}&rdquo;</p>
+        <p class="text-sm opacity-40">
+          Neither retrieval signal returned a candidate. Try a different query,
+          source, or kind.
+        </p>
+      </div>
+    </div>
+
+  {% else %}
+    {# ---------- Initial prompt (no query submitted yet) ---------- #}
+    <div class="card bg-base-100 border-base-300 border border-dashed shadow-sm">
+      <div class="card-body text-center py-10">
+        <p class="text-base opacity-50">
+          Enter a query to run retrieval and inspect the per-signal breakdown.
+        </p>
+      </div>
+    </div>
+  {% endif %}
+</div>

--- a/backend/src/meho_backplane/ui/templates/retrieval/index.html
+++ b/backend/src/meho_backplane/ui/templates/retrieval/index.html
@@ -1,0 +1,213 @@
+{#-
+  SPDX-License-Identifier: Apache-2.0
+  Copyright (c) 2026 evoila Group
+
+  Retrieval diagnostics & quality console page.
+
+  Initiative #1840 (G10.14 Retrieval diagnostics & quality console),
+  Task #1888 -- the ANCHOR task. Stands up the ``/ui/retrieval`` page
+  scaffold (sidebar entry, tab strip, page chrome) + the default
+  Diagnostics tab. Sibling tasks nest in:
+    * T2 -- Usage Analytics + Eval Quality tab panels (placeholder here).
+    * T3 -- Retire-checklist tab panel (placeholder here).
+
+  Tab strip:
+    * A client-side Alpine toggle (``x-data`` holding the active tab; each
+      tab button flips it, each panel ``x-show``s on it). The Diagnostics
+      tab is the default-active panel; the other three render a "coming
+      soon" placeholder so the chrome reads as a real tabbed surface from
+      day one without 8 dead links.
+
+  Diagnostics tab HTMX wiring:
+    * The diagnostics form (``#retrieval-diagnostics-form``) declares its OWN
+      ``hx-headers`` ``X-CSRF-Token`` -- HTMX does NOT propagate ``hx-headers``
+      from an ancestor to a descendant form (#1693), so the token must ride
+      the form element that issues the request.
+    * Submit fires ``POST /ui/retrieval/diagnostics`` with the ``query`` +
+      optional ``source`` / ``kind`` + ``limit`` and swaps
+      ``#retrieval-diagnostics-results`` (``hx-target`` +
+      ``hx-swap="outerHTML"``).
+    * Results render server-side into ``retrieval/_diagnostics_results.html``;
+      the same partial is included here for the initial (empty) render so both
+      paths share identical markup.
+
+  Context variables:
+    query           -- str: current query (empty on first render)
+    source          -- str: current source filter (empty on first render)
+    kind            -- str: current kind filter (empty on first render)
+    limit           -- int: current limit selection
+    limit_options   -- tuple[int]: the limit selector's options
+    hits            -- list[RetrievalHit]: empty on first render
+    searched        -- bool: False on first render
+    candidate_limit -- int: the per-signal candidate pull (CANDIDATE_LIMIT, 50)
+    csrf_token      -- str: minted double-submit token
+
+  Note: ``ready`` is NOT passed here -- the chassis context processor injects
+  it globally from the session middleware's cached verdict; a route literal
+  would shadow the live value.
+-#}
+{% extends "base.html" %}
+{% from "_icons.html" import icon %}
+
+{% block page_title %}Retrieval &middot; MEHO Operator Console{% endblock %}
+
+{% block content %}
+<section
+  class="space-y-4"
+  x-data="{ tab: 'diagnostics' }"
+>
+  <header class="flex flex-wrap items-center justify-between gap-4">
+    <div>
+      <h1 class="text-2xl font-semibold">Retrieval</h1>
+      <p class="text-sm opacity-70">
+        Run a query in-process and read back the ranked hits with the
+        per-signal RRF score &amp; rank breakdown the substrate carries.
+      </p>
+    </div>
+  </header>
+
+  {# ---------- Tab strip (client-side Alpine toggle) ---------- #}
+  {#- The Diagnostics tab is the only live panel in this anchor task; the
+      Usage / Eval / Retire tabs are placeholders T2/T3 fill in. Each button
+      flips ``tab``; each panel ``x-show``s on it. ``aria-selected`` mirrors
+      the active state for assistive tech. -#}
+  <div role="tablist" class="tabs tabs-bordered" aria-label="Retrieval console tabs">
+    <button
+      type="button"
+      role="tab"
+      class="tab"
+      x-bind:class="tab === 'diagnostics' ? 'tab-active' : ''"
+      x-bind:aria-selected="(tab === 'diagnostics').toString()"
+      x-on:click="tab = 'diagnostics'"
+    >Diagnostics</button>
+    <button
+      type="button"
+      role="tab"
+      class="tab"
+      x-bind:class="tab === 'usage' ? 'tab-active' : ''"
+      x-bind:aria-selected="(tab === 'usage').toString()"
+      x-on:click="tab = 'usage'"
+    >Usage Analytics</button>
+    <button
+      type="button"
+      role="tab"
+      class="tab"
+      x-bind:class="tab === 'eval' ? 'tab-active' : ''"
+      x-bind:aria-selected="(tab === 'eval').toString()"
+      x-on:click="tab = 'eval'"
+    >Eval Quality</button>
+    <button
+      type="button"
+      role="tab"
+      class="tab"
+      x-bind:class="tab === 'retire' ? 'tab-active' : ''"
+      x-bind:aria-selected="(tab === 'retire').toString()"
+      x-on:click="tab = 'retire'"
+    >Retire Checklist</button>
+  </div>
+
+  {# ---------- Diagnostics tab panel (default active) ---------- #}
+  <div role="tabpanel" x-show="tab === 'diagnostics'" class="space-y-4">
+    <div class="card bg-base-100 border-base-300 border shadow-sm">
+      <div class="card-body py-4">
+        <form
+          id="retrieval-diagnostics-form"
+          hx-post="/ui/retrieval/diagnostics"
+          hx-target="#retrieval-diagnostics-results"
+          hx-swap="outerHTML"
+          hx-headers='{"X-CSRF-Token": "{{ csrf_token }}"}'
+          class="space-y-3"
+          role="search"
+          aria-label="Run a retrieval diagnostics query"
+        >
+          <label class="form-control w-full">
+            <div class="label">
+              <span class="label-text">Query</span>
+            </div>
+            <textarea
+              name="query"
+              rows="2"
+              maxlength="{{ 2000 }}"
+              placeholder="Enter a representative query&hellip;"
+              class="textarea textarea-bordered w-full"
+              aria-label="Retrieval query"
+              autocomplete="off"
+              required
+            >{{ query }}</textarea>
+          </label>
+          <div class="flex flex-col gap-3 sm:flex-row sm:items-end">
+            <label class="form-control w-full sm:w-48">
+              <div class="label">
+                <span class="label-text">Source <span class="opacity-50">(optional)</span></span>
+              </div>
+              <input
+                type="text"
+                name="source"
+                value="{{ source }}"
+                maxlength="64"
+                placeholder="e.g. kb, memory"
+                class="input input-bordered w-full"
+                aria-label="Source filter"
+                autocomplete="off"
+              />
+            </label>
+            <label class="form-control w-full sm:w-48">
+              <div class="label">
+                <span class="label-text">Kind <span class="opacity-50">(optional)</span></span>
+              </div>
+              <input
+                type="text"
+                name="kind"
+                value="{{ kind }}"
+                maxlength="64"
+                placeholder="e.g. kb-entry"
+                class="input input-bordered w-full"
+                aria-label="Kind filter"
+                autocomplete="off"
+              />
+            </label>
+            <label class="form-control w-full sm:w-32">
+              <div class="label">
+                <span class="label-text">Limit</span>
+              </div>
+              <select
+                name="limit"
+                class="select select-bordered w-full"
+                aria-label="Maximum hits to return"
+              >
+                {% for option in limit_options %}
+                  <option value="{{ option }}"{% if option == limit %} selected{% endif %}>{{ option }}</option>
+                {% endfor %}
+              </select>
+            </label>
+            <button type="submit" class="btn btn-primary gap-1" aria-label="Run the diagnostics query">
+              {{ icon("search") }}
+              Run
+            </button>
+          </div>
+        </form>
+      </div>
+    </div>
+
+    {# ---------- Results region ---------- #}
+    {% include "retrieval/_diagnostics_results.html" %}
+  </div>
+
+  {# ---------- Placeholder tab panels (T2 / T3) ---------- #}
+  <div role="tabpanel" x-show="tab === 'usage'" x-cloak class="card bg-base-100 border-base-300 border border-dashed shadow-sm">
+    <div class="card-body text-center py-10">
+      <p class="text-base opacity-50">Usage Analytics lands in a follow-up task.</p>
+    </div>
+  </div>
+  <div role="tabpanel" x-show="tab === 'eval'" x-cloak class="card bg-base-100 border-base-300 border border-dashed shadow-sm">
+    <div class="card-body text-center py-10">
+      <p class="text-base opacity-50">Eval Quality lands in a follow-up task.</p>
+    </div>
+  </div>
+  <div role="tabpanel" x-show="tab === 'retire'" x-cloak class="card bg-base-100 border-base-300 border border-dashed shadow-sm">
+    <div class="card-body text-center py-10">
+      <p class="text-base opacity-50">Retire Checklist lands in a follow-up task.</p>
+    </div>
+  </div>
+</section>
+{% endblock %}

--- a/backend/tests/test_ui_retrieval.py
+++ b/backend/tests/test_ui_retrieval.py
@@ -1,0 +1,615 @@
+# SPDX-License-Identifier: Apache-2.0
+# Copyright (c) 2026 evoila Group
+
+"""Behavioural tests for the retrieval-diagnostics UI surface.
+
+Initiative #1840 (G10.14 Retrieval diagnostics & quality console), Task #1888.
+Acceptance criteria on issue #1888:
+
+* ``GET /ui/retrieval`` returns 200 for an operator session and renders the
+  Diagnostics tab active with an empty results region; an anonymous session is
+  redirected to login via ``require_ui_session``.
+* ``POST /ui/retrieval/diagnostics`` with a query swaps a fragment containing,
+  per hit, the ``fused_score`` and a per-signal RRF score/rank breakdown where
+  a ``None`` ``bm25_rank`` / ``cosine_rank`` renders an explicit "absent"
+  marker, not a blank.
+* The diagnostics handler binds ``audit_query_hash`` (SHA-256 of the raw query,
+  never the raw query), ``audit_source``, ``audit_kind``, ``audit_hit_count``
+  before/after the ``retrieve`` call -- the raw query is absent from the bound
+  audit payload.
+* CSRF double-submit is enforced on ``POST /ui/retrieval/diagnostics``: a
+  request with no/invalid ``meho_csrf`` cookie+header pair is rejected; the
+  fragment reuses the live cookie token (cookie untouched).
+
+Suite shape mirrors ``test_ui_corpus.py``: ``_build_app`` wires StaticFiles,
+the BFF auth router, the UI surface router (retrieval ahead of stubs),
+``UISessionMiddleware`` outermost + ``CSRFMiddleware`` next. The operator-
+reconstruction seam (``_resolve_operator``) is patched to return a constructed
+:class:`Operator` so the tests do not need a live Keycloak / JWKS round-trip;
+the in-process ``retrieve`` is mocked at the route's import so the tests focus
+on the UI layer (the substrate is exercised in the retriever's own tests).
+"""
+
+from __future__ import annotations
+
+import asyncio
+import hashlib
+import uuid
+from collections.abc import Iterator
+from datetime import UTC, datetime, timedelta
+from unittest.mock import AsyncMock, patch
+
+import pytest
+import respx
+from cryptography.fernet import Fernet
+from fastapi import FastAPI, HTTPException, status
+from fastapi.staticfiles import StaticFiles
+from fastapi.testclient import TestClient
+
+from meho_backplane.auth.jwt import clear_jwks_cache
+from meho_backplane.auth.operator import Operator, TenantRole
+from meho_backplane.db.engine import get_sessionmaker, reset_engine_for_testing
+from meho_backplane.db.models import Tenant
+from meho_backplane.retrieval.retriever import RetrievalHit
+from meho_backplane.settings import get_settings
+from meho_backplane.ui.auth import (
+    SESSION_COOKIE_NAME,
+    UISessionMiddleware,
+)
+from meho_backplane.ui.auth import build_router as build_ui_auth_router
+from meho_backplane.ui.auth.flow import (
+    clear_discovery_cache,
+    reset_verifier_store_for_testing,
+)
+from meho_backplane.ui.auth.session_store import (
+    create_session,
+    reset_fernet_cache_for_testing,
+)
+from meho_backplane.ui.csrf import (
+    CSRF_COOKIE_NAME,
+    CSRF_HEADER_NAME,
+    CSRFMiddleware,
+    mint_csrf_token,
+)
+from meho_backplane.ui.paths import static_root_dir
+from meho_backplane.ui.routes import build_router as build_ui_router
+from meho_backplane.ui.templating import reset_templating_for_testing
+from tests.conftest import DEFAULT_AUDIENCE, DEFAULT_ISSUER
+
+# ---------------------------------------------------------------------------
+# Constants
+# ---------------------------------------------------------------------------
+
+_BACKPLANE_URL = "https://meho.test"
+
+_TENANT_A = uuid.UUID("aaaaaaaa-aaaa-aaaa-aaaa-aaaaaaaaaaaa")
+
+#: The route-module symbol patched so the handlers get an operator without a
+#: live JWKS round-trip.
+_RESOLVE_OPERATOR = "meho_backplane.ui.routes.retrieval.routes._resolve_operator"
+
+#: The route-module symbol the diagnostics handler calls; mocked to control the
+#: returned hit list / raised failure without a live corpus + embedder.
+_RETRIEVE = "meho_backplane.ui.routes.retrieval.routes.retrieve"
+
+#: The contextvars binder the handler calls; patched to capture the audit
+#: payload without a live structlog pipeline.
+_BIND_CONTEXTVARS = (
+    "meho_backplane.ui.routes.retrieval.routes.structlog.contextvars.bind_contextvars"
+)
+
+
+# ---------------------------------------------------------------------------
+# Fixtures
+# ---------------------------------------------------------------------------
+
+
+@pytest.fixture(autouse=True)
+def _bff_env(monkeypatch: pytest.MonkeyPatch) -> Iterator[None]:
+    """Pin chassis + BFF env vars for every test (mirrors the corpus UI suite)."""
+    monkeypatch.setenv("KEYCLOAK_ISSUER_URL", DEFAULT_ISSUER)
+    monkeypatch.setenv("KEYCLOAK_AUDIENCE", DEFAULT_AUDIENCE)
+    monkeypatch.setenv("VAULT_ADDR", "https://vault.test")
+    monkeypatch.setenv("BACKPLANE_URL", _BACKPLANE_URL)
+    monkeypatch.setenv("UI_SESSION_ENCRYPTION_KEY", Fernet.generate_key().decode())
+    monkeypatch.setenv("UI_KEYCLOAK_CLIENT_ID", "meho-web")
+    monkeypatch.setenv("UI_KEYCLOAK_CLIENT_SECRET", "test-client-secret")
+    get_settings.cache_clear()
+    reset_fernet_cache_for_testing()
+    reset_verifier_store_for_testing()
+    reset_templating_for_testing()
+    clear_discovery_cache()
+    clear_jwks_cache()
+    reset_engine_for_testing()
+    yield
+    get_settings.cache_clear()
+    reset_fernet_cache_for_testing()
+    reset_verifier_store_for_testing()
+    reset_templating_for_testing()
+    clear_discovery_cache()
+    clear_jwks_cache()
+    reset_engine_for_testing()
+
+
+# ---------------------------------------------------------------------------
+# Helpers
+# ---------------------------------------------------------------------------
+
+
+def _build_app() -> FastAPI:
+    """Minimal FastAPI app wired for retrieval UI tests (mirrors corpus)."""
+    app = FastAPI()
+    app.add_middleware(CSRFMiddleware)
+    app.add_middleware(UISessionMiddleware)
+    app.mount(
+        "/ui/static",
+        StaticFiles(directory=str(static_root_dir()), check_dir=False),
+        name="ui_static",
+    )
+    app.include_router(build_ui_auth_router())
+    app.include_router(build_ui_router())
+    return app
+
+
+def _seed_tenant(tenant_id: uuid.UUID, slug: str) -> None:
+    """Insert one ``tenant`` row so the session FK resolves."""
+
+    async def _do() -> None:
+        sessionmaker = get_sessionmaker()
+        async with sessionmaker() as session, session.begin():
+            session.add(Tenant(id=tenant_id, slug=slug, name=f"Tenant {slug}"))
+
+    asyncio.run(_do())
+
+
+def _seed_session_sync(
+    *,
+    tenant_id: uuid.UUID,
+    operator_sub: str = "op-42",
+    lifetime: timedelta = timedelta(hours=1),
+) -> uuid.UUID:
+    """Create a ``web_session`` row and return its UUID (bypasses OAuth)."""
+
+    async def _do() -> uuid.UUID:
+        sessionmaker = get_sessionmaker()
+        async with sessionmaker() as session, session.begin():
+            decrypted = await create_session(
+                session,
+                operator_sub=operator_sub,
+                tenant_id=tenant_id,
+                access_token="access-token-plaintext",
+                refresh_token="refresh-token-plaintext",
+                lifetime=lifetime,
+            )
+            return decrypted.id
+
+    return asyncio.run(_do())
+
+
+def _authenticated_client(session_id: uuid.UUID) -> TestClient:
+    """Return a TestClient with the session cookie pre-set."""
+    client = TestClient(_build_app(), follow_redirects=False)
+    client.cookies.set(SESSION_COOKIE_NAME, str(session_id))
+    return client
+
+
+def _csrf_token(session_id: uuid.UUID) -> str:
+    """Return a valid CSRF token for *session_id*."""
+    return mint_csrf_token(str(session_id))
+
+
+def _operator(
+    *,
+    tenant_id: uuid.UUID,
+    sub: str = "op-42",
+) -> Operator:
+    """Build an :class:`Operator` the patched ``_resolve_operator`` returns."""
+    return Operator(
+        sub=sub,
+        raw_jwt="header.payload.signature",
+        tenant_id=tenant_id,
+        tenant_role=TenantRole.OPERATOR,
+        capabilities=frozenset(),
+    )
+
+
+def _hit(
+    *,
+    source: str = "kb",
+    source_id: str = "kb-entry-1",
+    kind: str = "kb-entry",
+    body: str = "Snapshots quiesce the guest before capture.",
+    fused_score: float = 0.0327,
+    bm25_score: float | None = 1.234,
+    cosine_score: float | None = 0.876,
+    bm25_rank: int | None = 1,
+    cosine_rank: int | None = 2,
+) -> RetrievalHit:
+    """Build a :class:`RetrievalHit` for mocked retrieve returns."""
+    now = datetime(2026, 6, 19, tzinfo=UTC)
+    return RetrievalHit(
+        document_id=uuid.uuid4(),
+        tenant_id=_TENANT_A,
+        source=source,
+        source_id=source_id,
+        kind=kind,
+        body=body,
+        doc_metadata={},
+        created_at=now,
+        updated_at=now,
+        fused_score=fused_score,
+        bm25_score=bm25_score,
+        cosine_score=cosine_score,
+        bm25_rank=bm25_rank,
+        cosine_rank=cosine_rank,
+    )
+
+
+# ---------------------------------------------------------------------------
+# Authentication boundary
+# ---------------------------------------------------------------------------
+
+
+def test_retrieval_index_unauthenticated_redirects_to_login() -> None:
+    """``GET /ui/retrieval`` without a session 302s to the BFF login."""
+    with respx.mock(assert_all_called=False):
+        client = TestClient(_build_app(), follow_redirects=False)
+        response = client.get("/ui/retrieval")
+    assert response.status_code == 302
+    assert response.headers["location"].startswith("/ui/auth/login?return_to=")
+
+
+def test_retrieval_diagnostics_unauthenticated_rejected() -> None:
+    """``POST /ui/retrieval/diagnostics`` without a session never reaches the handler."""
+    with respx.mock(assert_all_called=False):
+        client = TestClient(_build_app(), follow_redirects=False)
+        response = client.post("/ui/retrieval/diagnostics", data={"query": "x"})
+    assert response.status_code in (302, 403)
+
+
+# ---------------------------------------------------------------------------
+# GET /ui/retrieval -- page render
+# ---------------------------------------------------------------------------
+
+
+def test_retrieval_index_renders_diagnostics_tab_active_and_empty_results() -> None:
+    """``GET /ui/retrieval`` renders the Diagnostics tab active + an empty results region."""
+    _seed_tenant(_TENANT_A, "tenant-a")
+    session_id = _seed_session_sync(tenant_id=_TENANT_A)
+    operator = _operator(tenant_id=_TENANT_A)
+
+    with respx.mock(assert_all_called=False):
+        client = _authenticated_client(session_id)
+        with patch(_RESOLVE_OPERATOR, new_callable=AsyncMock, return_value=operator):
+            response = client.get("/ui/retrieval")
+
+    assert response.status_code == 200, response.text
+    body = response.text
+    assert "<title>Retrieval" in body
+    # Tab strip present with all four tabs; Diagnostics is the default-active panel.
+    assert "Diagnostics" in body
+    assert "Usage Analytics" in body
+    assert "Eval Quality" in body
+    assert "tab: 'diagnostics'" in body
+    # Empty results region present, no hits rendered yet.
+    assert 'id="retrieval-diagnostics-results"' in body
+    assert "Enter a query to run retrieval" in body
+    # Sidebar nav link.
+    assert 'href="/ui/retrieval"' in body
+    # CSRF cookie set + form carries the token.
+    assert CSRF_COOKIE_NAME in response.cookies
+    assert "X-CSRF-Token" in body
+    assert 'hx-post="/ui/retrieval/diagnostics"' in body
+
+
+# ---------------------------------------------------------------------------
+# POST /ui/retrieval/diagnostics -- successful fragment + per-signal breakdown
+# ---------------------------------------------------------------------------
+
+
+def test_diagnostics_renders_fused_score_and_per_signal_breakdown() -> None:
+    """A successful run swaps a fragment with the fused_score + per-signal table."""
+    _seed_tenant(_TENANT_A, "tenant-a")
+    session_id = _seed_session_sync(tenant_id=_TENANT_A)
+    csrf = _csrf_token(session_id)
+    operator = _operator(tenant_id=_TENANT_A)
+    hits = [_hit(fused_score=0.0327, bm25_score=1.234, cosine_score=0.876)]
+
+    with respx.mock(assert_all_called=False):
+        client = _authenticated_client(session_id)
+        client.cookies.set(CSRF_COOKIE_NAME, csrf)
+        with (
+            patch(_RESOLVE_OPERATOR, new_callable=AsyncMock, return_value=operator),
+            patch(_RETRIEVE, new_callable=AsyncMock, return_value=hits),
+        ):
+            response = client.post(
+                "/ui/retrieval/diagnostics",
+                data={"query": "snapshot quiesce", "source": "", "kind": "", "limit": 10},
+                headers={CSRF_HEADER_NAME: csrf},
+            )
+
+    assert response.status_code == 200, response.text
+    body = response.text
+    # Fragment, not full page.
+    assert 'id="retrieval-diagnostics-results"' in body
+    assert "<!doctype html>" not in body.lower()
+    # Body excerpt + provenance.
+    assert "Snapshots quiesce the guest" in body
+    assert "kb-entry-1" in body
+    # Fused score rendered.
+    assert "0.032700" in body
+    # Per-signal breakdown: both signals present with ranks.
+    assert "BM25" in body
+    assert "Cosine" in body
+    assert "#1" in body
+    assert "#2" in body
+    assert "1 hit" in body
+
+
+def test_diagnostics_renders_absent_marker_for_none_rank() -> None:
+    """A hit absent from a signal's top-N renders an explicit 'absent' marker, not a blank.
+
+    Acceptance criterion: a ``cosine_score=None, cosine_rank=None`` hit must
+    render the "absent from this signal's top-50" marker (the document never
+    appeared in that signal's candidate list), distinguishing it from a
+    zero-score blank.
+    """
+    _seed_tenant(_TENANT_A, "tenant-a")
+    session_id = _seed_session_sync(tenant_id=_TENANT_A)
+    csrf = _csrf_token(session_id)
+    operator = _operator(tenant_id=_TENANT_A)
+    hits = [_hit(bm25_score=1.5, bm25_rank=1, cosine_score=None, cosine_rank=None)]
+
+    with respx.mock(assert_all_called=False):
+        client = _authenticated_client(session_id)
+        client.cookies.set(CSRF_COOKIE_NAME, csrf)
+        with (
+            patch(_RESOLVE_OPERATOR, new_callable=AsyncMock, return_value=operator),
+            patch(_RETRIEVE, new_callable=AsyncMock, return_value=hits),
+        ):
+            response = client.post(
+                "/ui/retrieval/diagnostics",
+                data={"query": "lexical only", "limit": 10},
+                headers={CSRF_HEADER_NAME: csrf},
+            )
+
+    assert response.status_code == 200, response.text
+    body = response.text
+    # The explicit absent marker is rendered for the None-rank signal.
+    assert "absent from this signal" in body
+    assert "top-50" in body
+    # The present signal still shows its rank.
+    assert "#1" in body
+
+
+def test_diagnostics_empty_results_renders_no_matches_state() -> None:
+    """A run returning zero hits renders the no-matches state, not an error."""
+    _seed_tenant(_TENANT_A, "tenant-a")
+    session_id = _seed_session_sync(tenant_id=_TENANT_A)
+    csrf = _csrf_token(session_id)
+    operator = _operator(tenant_id=_TENANT_A)
+
+    with respx.mock(assert_all_called=False):
+        client = _authenticated_client(session_id)
+        client.cookies.set(CSRF_COOKIE_NAME, csrf)
+        with (
+            patch(_RESOLVE_OPERATOR, new_callable=AsyncMock, return_value=operator),
+            patch(_RETRIEVE, new_callable=AsyncMock, return_value=[]),
+        ):
+            response = client.post(
+                "/ui/retrieval/diagnostics",
+                data={"query": "nonexistent term", "limit": 10},
+                headers={CSRF_HEADER_NAME: csrf},
+            )
+
+    assert response.status_code == 200, response.text
+    body = response.text
+    assert "No hits for" in body
+    assert "nonexistent term" in body
+    assert 'role="alert"' not in body
+
+
+def test_diagnostics_forwards_operator_tenant_and_filters() -> None:
+    """The handler forwards the reconstructed operator's tenant + sub + filters."""
+    _seed_tenant(_TENANT_A, "tenant-a")
+    session_id = _seed_session_sync(tenant_id=_TENANT_A)
+    csrf = _csrf_token(session_id)
+    operator = _operator(tenant_id=_TENANT_A, sub="op-principal")
+    retrieve_mock = AsyncMock(return_value=[_hit()])
+
+    with respx.mock(assert_all_called=False):
+        client = _authenticated_client(session_id)
+        client.cookies.set(CSRF_COOKIE_NAME, csrf)
+        with (
+            patch(_RESOLVE_OPERATOR, new_callable=AsyncMock, return_value=operator),
+            patch(_RETRIEVE, retrieve_mock),
+        ):
+            response = client.post(
+                "/ui/retrieval/diagnostics",
+                data={"query": "vcenter maximums", "source": "kb", "kind": "kb-entry", "limit": 20},
+                headers={CSRF_HEADER_NAME: csrf},
+            )
+
+    assert response.status_code == 200, response.text
+    retrieve_mock.assert_awaited_once()
+    kwargs = retrieve_mock.await_args.kwargs
+    assert kwargs["tenant_id"] == _TENANT_A
+    assert kwargs["query"] == "vcenter maximums"
+    assert kwargs["source"] == "kb"
+    assert kwargs["kind"] == "kb-entry"
+    assert kwargs["limit"] == 20
+    # Own-tenant only -- the per-principal predicate is bound from the operator.
+    assert kwargs["principal_sub"] == "op-principal"
+
+
+# ---------------------------------------------------------------------------
+# Audit / privacy binding
+# ---------------------------------------------------------------------------
+
+
+def test_diagnostics_binds_query_hash_not_raw_query() -> None:
+    """The handler binds the SHA-256 query hash + source/kind/hit_count, never the raw query."""
+    _seed_tenant(_TENANT_A, "tenant-a")
+    session_id = _seed_session_sync(tenant_id=_TENANT_A)
+    csrf = _csrf_token(session_id)
+    operator = _operator(tenant_id=_TENANT_A)
+    raw_query = "a-very-secret-query-string"
+    expected_hash = hashlib.sha256(raw_query.encode("utf-8")).hexdigest()
+
+    bound_payloads: list[dict[str, object]] = []
+
+    def _capture(**kwargs: object) -> None:
+        bound_payloads.append(dict(kwargs))
+
+    with respx.mock(assert_all_called=False):
+        client = _authenticated_client(session_id)
+        client.cookies.set(CSRF_COOKIE_NAME, csrf)
+        with (
+            patch(_RESOLVE_OPERATOR, new_callable=AsyncMock, return_value=operator),
+            patch(_RETRIEVE, new_callable=AsyncMock, return_value=[_hit()]),
+            patch(_BIND_CONTEXTVARS, side_effect=_capture),
+        ):
+            response = client.post(
+                "/ui/retrieval/diagnostics",
+                data={"query": raw_query, "source": "kb", "kind": "kb-entry", "limit": 10},
+                headers={CSRF_HEADER_NAME: csrf},
+            )
+
+    assert response.status_code == 200, response.text
+    # Flatten every bound payload.
+    merged: dict[str, object] = {}
+    for payload in bound_payloads:
+        merged.update(payload)
+    # The query hash is bound, the raw query is NOT.
+    assert merged["audit_query_hash"] == expected_hash
+    assert merged["audit_source"] == "kb"
+    assert merged["audit_kind"] == "kb-entry"
+    assert merged["audit_hit_count"] == 1
+    # The raw query never appears in any bound payload (value or key).
+    for payload in bound_payloads:
+        for value in payload.values():
+            assert value != raw_query
+        assert raw_query not in payload
+
+
+# ---------------------------------------------------------------------------
+# CSRF
+# ---------------------------------------------------------------------------
+
+
+def test_diagnostics_rejected_without_csrf_token() -> None:
+    """A diagnostics POST without the CSRF header is rejected 403 by the middleware."""
+    _seed_tenant(_TENANT_A, "tenant-a")
+    session_id = _seed_session_sync(tenant_id=_TENANT_A)
+    csrf = _csrf_token(session_id)
+
+    with respx.mock(assert_all_called=False):
+        client = _authenticated_client(session_id)
+        client.cookies.set(CSRF_COOKIE_NAME, csrf)
+        # No X-CSRF-Token header -> the double-submit pair is incomplete.
+        response = client.post(
+            "/ui/retrieval/diagnostics",
+            data={"query": "snapshot"},
+        )
+
+    assert response.status_code == 403
+
+
+def test_diagnostics_reuses_live_csrf_cookie_without_rotation() -> None:
+    """The diagnostics fragment reuses the live CSRF cookie and does NOT rotate it."""
+    _seed_tenant(_TENANT_A, "tenant-a")
+    session_id = _seed_session_sync(tenant_id=_TENANT_A)
+    csrf = _csrf_token(session_id)
+    operator = _operator(tenant_id=_TENANT_A)
+
+    with respx.mock(assert_all_called=False):
+        client = _authenticated_client(session_id)
+        client.cookies.set(CSRF_COOKIE_NAME, csrf)
+        with (
+            patch(_RESOLVE_OPERATOR, new_callable=AsyncMock, return_value=operator),
+            patch(_RETRIEVE, new_callable=AsyncMock, return_value=[]),
+        ):
+            response = client.post(
+                "/ui/retrieval/diagnostics",
+                data={"query": "snapshot", "limit": 10},
+                headers={CSRF_HEADER_NAME: csrf},
+            )
+
+    assert response.status_code == 200, response.text
+    # No Set-Cookie for meho_csrf on the fragment response (live token reused).
+    set_cookie = response.headers.get("set-cookie", "")
+    assert CSRF_COOKIE_NAME not in set_cookie
+
+
+def test_diagnostics_session_gone_propagates_401() -> None:
+    """A 401 from the operator-reconstruction seam surfaces as 401, not an error card."""
+    _seed_tenant(_TENANT_A, "tenant-a")
+    session_id = _seed_session_sync(tenant_id=_TENANT_A)
+    csrf = _csrf_token(session_id)
+
+    with respx.mock(assert_all_called=False):
+        client = _authenticated_client(session_id)
+        client.cookies.set(CSRF_COOKIE_NAME, csrf)
+        with patch(
+            _RESOLVE_OPERATOR,
+            new_callable=AsyncMock,
+            side_effect=HTTPException(
+                status_code=status.HTTP_401_UNAUTHORIZED, detail="session_expired"
+            ),
+        ):
+            response = client.post(
+                "/ui/retrieval/diagnostics",
+                data={"query": "snapshot", "limit": 10},
+                headers={CSRF_HEADER_NAME: csrf},
+            )
+
+    assert response.status_code == 401
+
+
+# ---------------------------------------------------------------------------
+# Route ordering + nav registration
+# ---------------------------------------------------------------------------
+
+
+def test_retrieval_router_registered_before_stubs() -> None:
+    """The retrieval include precedes the stubs include in build_router."""
+    import inspect
+
+    from meho_backplane.ui import routes as routes_module
+
+    source = inspect.getsource(routes_module.build_router)
+    retrieval_pos = source.index("build_retrieval_router()")
+    stubs_pos = source.index("build_stubs_router()")
+    assert retrieval_pos < stubs_pos
+
+
+def test_retrieval_diagnostics_literal_before_any_param_route() -> None:
+    """No ``/ui/retrieval/{param}`` route precedes the literal ``/diagnostics`` POST."""
+    from meho_backplane.ui.routes.retrieval import build_retrieval_router
+
+    router = build_retrieval_router()
+    retrieval_paths = [
+        route.path  # type: ignore[attr-defined]
+        for route in router.routes
+        if getattr(route, "path", "").startswith("/ui/retrieval")
+    ]
+    # The literal diagnostics route exists; no param route precedes it.
+    assert "/ui/retrieval/diagnostics" in retrieval_paths
+    diagnostics_idx = retrieval_paths.index("/ui/retrieval/diagnostics")
+    for path in retrieval_paths[:diagnostics_idx]:
+        assert "{" not in path, f"param route {path!r} precedes the literal diagnostics route"
+
+
+def test_dashboard_surface_grid_includes_retrieval_tile() -> None:
+    """The dashboard surface-tile grid links to ``/ui/retrieval``."""
+    _seed_tenant(_TENANT_A, "tenant-a")
+    session_id = _seed_session_sync(tenant_id=_TENANT_A)
+
+    with respx.mock(assert_all_called=False):
+        client = _authenticated_client(session_id)
+        response = client.get("/ui/")
+
+    assert response.status_code == 200, response.text
+    body = response.text
+    assert 'href="/ui/retrieval"' in body
+    assert "Retrieval" in body

--- a/cli/api/openapi.json
+++ b/cli/api/openapi.json
@@ -12433,6 +12433,69 @@
         }
       }
     },
+    "/ui/retrieval": {
+      "get": {
+        "tags": [
+          "ui-retrieval"
+        ],
+        "summary": "Retrieval Index",
+        "description": "Render the retrieval page (delegates to :func:`_render_retrieval_index`).",
+        "operationId": "retrieval_index_ui_retrieval_get",
+        "responses": {
+          "200": {
+            "description": "Successful Response",
+            "content": {
+              "text/html": {
+                "schema": {
+                  "type": "string"
+                }
+              }
+            }
+          }
+        }
+      }
+    },
+    "/ui/retrieval/diagnostics": {
+      "post": {
+        "tags": [
+          "ui-retrieval"
+        ],
+        "summary": "Retrieval Diagnostics",
+        "description": "Run the diagnostics fragment (delegates to :func:`_render_diagnostics`).",
+        "operationId": "retrieval_diagnostics_ui_retrieval_diagnostics_post",
+        "requestBody": {
+          "content": {
+            "application/x-www-form-urlencoded": {
+              "schema": {
+                "$ref": "#/components/schemas/Body_retrieval_diagnostics_ui_retrieval_diagnostics_post"
+              }
+            }
+          }
+        },
+        "responses": {
+          "200": {
+            "description": "Successful Response",
+            "content": {
+              "text/html": {
+                "schema": {
+                  "type": "string"
+                }
+              }
+            }
+          },
+          "422": {
+            "description": "Validation Error",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/HTTPValidationError"
+                }
+              }
+            }
+          }
+        }
+      }
+    },
     "/ui/runbooks": {
       "get": {
         "tags": [
@@ -15749,6 +15812,35 @@
           "op_id"
         ],
         "title": "Body_operations_preview_ui_operations_preview_post"
+      },
+      "Body_retrieval_diagnostics_ui_retrieval_diagnostics_post": {
+        "properties": {
+          "query": {
+            "type": "string",
+            "maxLength": 2000,
+            "title": "Query",
+            "default": ""
+          },
+          "source": {
+            "type": "string",
+            "maxLength": 64,
+            "title": "Source",
+            "default": ""
+          },
+          "kind": {
+            "type": "string",
+            "maxLength": 64,
+            "title": "Kind",
+            "default": ""
+          },
+          "limit": {
+            "type": "integer",
+            "title": "Limit",
+            "default": 10
+          }
+        },
+        "type": "object",
+        "title": "Body_retrieval_diagnostics_ui_retrieval_diagnostics_post"
       },
       "Body_runbooks_deprecate_ui_runbooks__slug__deprecate_post": {
         "properties": {

--- a/cli/internal/api/client.gen.go
+++ b/cli/internal/api/client.gen.go
@@ -1246,6 +1246,14 @@ type BodyOperationsPreviewUiOperationsPreviewPost struct {
 	Target      *string `json:"target,omitempty"`
 }
 
+// BodyRetrievalDiagnosticsUiRetrievalDiagnosticsPost defines model for Body_retrieval_diagnostics_ui_retrieval_diagnostics_post.
+type BodyRetrievalDiagnosticsUiRetrievalDiagnosticsPost struct {
+	Kind   *string `json:"kind,omitempty"`
+	Limit  *int    `json:"limit,omitempty"`
+	Query  *string `json:"query,omitempty"`
+	Source *string `json:"source,omitempty"`
+}
+
 // BodyRunbooksDeprecateUiRunbooksSlugDeprecatePost defines model for Body_runbooks_deprecate_ui_runbooks__slug__deprecate_post.
 type BodyRunbooksDeprecateUiRunbooksSlugDeprecatePost struct {
 	Version *string `json:"version,omitempty"`
@@ -7138,6 +7146,9 @@ type OperationsDescriptorUiOperationsDescriptorDescriptorIdGetJSONRequestBody = 
 // OperationsPreviewUiOperationsPreviewPostFormdataRequestBody defines body for OperationsPreviewUiOperationsPreviewPost for application/x-www-form-urlencoded ContentType.
 type OperationsPreviewUiOperationsPreviewPostFormdataRequestBody = BodyOperationsPreviewUiOperationsPreviewPost
 
+// RetrievalDiagnosticsUiRetrievalDiagnosticsPostFormdataRequestBody defines body for RetrievalDiagnosticsUiRetrievalDiagnosticsPost for application/x-www-form-urlencoded ContentType.
+type RetrievalDiagnosticsUiRetrievalDiagnosticsPostFormdataRequestBody = BodyRetrievalDiagnosticsUiRetrievalDiagnosticsPost
+
 // RunbooksEditorCreateUiRunbooksNewPostFormdataRequestBody defines body for RunbooksEditorCreateUiRunbooksNewPost for application/x-www-form-urlencoded ContentType.
 type RunbooksEditorCreateUiRunbooksNewPostFormdataRequestBody = BodyRunbooksEditorCreateUiRunbooksNewPost
 
@@ -8898,6 +8909,14 @@ type ClientInterface interface {
 
 	// OperationsSearchUiOperationsSearchGet request
 	OperationsSearchUiOperationsSearchGet(ctx context.Context, params *OperationsSearchUiOperationsSearchGetParams, reqEditors ...RequestEditorFn) (*http.Response, error)
+
+	// RetrievalIndexUiRetrievalGet request
+	RetrievalIndexUiRetrievalGet(ctx context.Context, reqEditors ...RequestEditorFn) (*http.Response, error)
+
+	// RetrievalDiagnosticsUiRetrievalDiagnosticsPostWithBody request with any body
+	RetrievalDiagnosticsUiRetrievalDiagnosticsPostWithBody(ctx context.Context, contentType string, body io.Reader, reqEditors ...RequestEditorFn) (*http.Response, error)
+
+	RetrievalDiagnosticsUiRetrievalDiagnosticsPostWithFormdataBody(ctx context.Context, body RetrievalDiagnosticsUiRetrievalDiagnosticsPostFormdataRequestBody, reqEditors ...RequestEditorFn) (*http.Response, error)
 
 	// RunbooksIndexUiRunbooksGet request
 	RunbooksIndexUiRunbooksGet(ctx context.Context, params *RunbooksIndexUiRunbooksGetParams, reqEditors ...RequestEditorFn) (*http.Response, error)
@@ -12999,6 +13018,42 @@ func (c *Client) OperationsRunUiOperationsRunDescriptorIdGet(ctx context.Context
 
 func (c *Client) OperationsSearchUiOperationsSearchGet(ctx context.Context, params *OperationsSearchUiOperationsSearchGetParams, reqEditors ...RequestEditorFn) (*http.Response, error) {
 	req, err := NewOperationsSearchUiOperationsSearchGetRequest(c.Server, params)
+	if err != nil {
+		return nil, err
+	}
+	req = req.WithContext(ctx)
+	if err := c.applyEditors(ctx, req, reqEditors); err != nil {
+		return nil, err
+	}
+	return c.Client.Do(req)
+}
+
+func (c *Client) RetrievalIndexUiRetrievalGet(ctx context.Context, reqEditors ...RequestEditorFn) (*http.Response, error) {
+	req, err := NewRetrievalIndexUiRetrievalGetRequest(c.Server)
+	if err != nil {
+		return nil, err
+	}
+	req = req.WithContext(ctx)
+	if err := c.applyEditors(ctx, req, reqEditors); err != nil {
+		return nil, err
+	}
+	return c.Client.Do(req)
+}
+
+func (c *Client) RetrievalDiagnosticsUiRetrievalDiagnosticsPostWithBody(ctx context.Context, contentType string, body io.Reader, reqEditors ...RequestEditorFn) (*http.Response, error) {
+	req, err := NewRetrievalDiagnosticsUiRetrievalDiagnosticsPostRequestWithBody(c.Server, contentType, body)
+	if err != nil {
+		return nil, err
+	}
+	req = req.WithContext(ctx)
+	if err := c.applyEditors(ctx, req, reqEditors); err != nil {
+		return nil, err
+	}
+	return c.Client.Do(req)
+}
+
+func (c *Client) RetrievalDiagnosticsUiRetrievalDiagnosticsPostWithFormdataBody(ctx context.Context, body RetrievalDiagnosticsUiRetrievalDiagnosticsPostFormdataRequestBody, reqEditors ...RequestEditorFn) (*http.Response, error) {
+	req, err := NewRetrievalDiagnosticsUiRetrievalDiagnosticsPostRequestWithFormdataBody(c.Server, body)
 	if err != nil {
 		return nil, err
 	}
@@ -26382,6 +26437,73 @@ func NewOperationsSearchUiOperationsSearchGetRequest(server string, params *Oper
 	return req, nil
 }
 
+// NewRetrievalIndexUiRetrievalGetRequest generates requests for RetrievalIndexUiRetrievalGet
+func NewRetrievalIndexUiRetrievalGetRequest(server string) (*http.Request, error) {
+	var err error
+
+	serverURL, err := url.Parse(server)
+	if err != nil {
+		return nil, err
+	}
+
+	operationPath := fmt.Sprintf("/ui/retrieval")
+	if operationPath[0] == '/' {
+		operationPath = "." + operationPath
+	}
+
+	queryURL, err := serverURL.Parse(operationPath)
+	if err != nil {
+		return nil, err
+	}
+
+	req, err := http.NewRequest("GET", queryURL.String(), nil)
+	if err != nil {
+		return nil, err
+	}
+
+	return req, nil
+}
+
+// NewRetrievalDiagnosticsUiRetrievalDiagnosticsPostRequestWithFormdataBody calls the generic RetrievalDiagnosticsUiRetrievalDiagnosticsPost builder with application/x-www-form-urlencoded body
+func NewRetrievalDiagnosticsUiRetrievalDiagnosticsPostRequestWithFormdataBody(server string, body RetrievalDiagnosticsUiRetrievalDiagnosticsPostFormdataRequestBody) (*http.Request, error) {
+	var bodyReader io.Reader
+	bodyStr, err := runtime.MarshalForm(body, nil)
+	if err != nil {
+		return nil, err
+	}
+	bodyReader = strings.NewReader(bodyStr.Encode())
+	return NewRetrievalDiagnosticsUiRetrievalDiagnosticsPostRequestWithBody(server, "application/x-www-form-urlencoded", bodyReader)
+}
+
+// NewRetrievalDiagnosticsUiRetrievalDiagnosticsPostRequestWithBody generates requests for RetrievalDiagnosticsUiRetrievalDiagnosticsPost with any type of body
+func NewRetrievalDiagnosticsUiRetrievalDiagnosticsPostRequestWithBody(server string, contentType string, body io.Reader) (*http.Request, error) {
+	var err error
+
+	serverURL, err := url.Parse(server)
+	if err != nil {
+		return nil, err
+	}
+
+	operationPath := fmt.Sprintf("/ui/retrieval/diagnostics")
+	if operationPath[0] == '/' {
+		operationPath = "." + operationPath
+	}
+
+	queryURL, err := serverURL.Parse(operationPath)
+	if err != nil {
+		return nil, err
+	}
+
+	req, err := http.NewRequest("POST", queryURL.String(), body)
+	if err != nil {
+		return nil, err
+	}
+
+	req.Header.Add("Content-Type", contentType)
+
+	return req, nil
+}
+
 // NewRunbooksIndexUiRunbooksGetRequest generates requests for RunbooksIndexUiRunbooksGet
 func NewRunbooksIndexUiRunbooksGetRequest(server string, params *RunbooksIndexUiRunbooksGetParams) (*http.Request, error) {
 	var err error
@@ -28741,6 +28863,14 @@ type ClientWithResponsesInterface interface {
 
 	// OperationsSearchUiOperationsSearchGetWithResponse request
 	OperationsSearchUiOperationsSearchGetWithResponse(ctx context.Context, params *OperationsSearchUiOperationsSearchGetParams, reqEditors ...RequestEditorFn) (*OperationsSearchUiOperationsSearchGetResponse, error)
+
+	// RetrievalIndexUiRetrievalGetWithResponse request
+	RetrievalIndexUiRetrievalGetWithResponse(ctx context.Context, reqEditors ...RequestEditorFn) (*RetrievalIndexUiRetrievalGetResponse, error)
+
+	// RetrievalDiagnosticsUiRetrievalDiagnosticsPostWithBodyWithResponse request with any body
+	RetrievalDiagnosticsUiRetrievalDiagnosticsPostWithBodyWithResponse(ctx context.Context, contentType string, body io.Reader, reqEditors ...RequestEditorFn) (*RetrievalDiagnosticsUiRetrievalDiagnosticsPostResponse, error)
+
+	RetrievalDiagnosticsUiRetrievalDiagnosticsPostWithFormdataBodyWithResponse(ctx context.Context, body RetrievalDiagnosticsUiRetrievalDiagnosticsPostFormdataRequestBody, reqEditors ...RequestEditorFn) (*RetrievalDiagnosticsUiRetrievalDiagnosticsPostResponse, error)
 
 	// RunbooksIndexUiRunbooksGetWithResponse request
 	RunbooksIndexUiRunbooksGetWithResponse(ctx context.Context, params *RunbooksIndexUiRunbooksGetParams, reqEditors ...RequestEditorFn) (*RunbooksIndexUiRunbooksGetResponse, error)
@@ -33846,6 +33976,49 @@ func (r OperationsSearchUiOperationsSearchGetResponse) StatusCode() int {
 	return 0
 }
 
+type RetrievalIndexUiRetrievalGetResponse struct {
+	Body         []byte
+	HTTPResponse *http.Response
+}
+
+// Status returns HTTPResponse.Status
+func (r RetrievalIndexUiRetrievalGetResponse) Status() string {
+	if r.HTTPResponse != nil {
+		return r.HTTPResponse.Status
+	}
+	return http.StatusText(0)
+}
+
+// StatusCode returns HTTPResponse.StatusCode
+func (r RetrievalIndexUiRetrievalGetResponse) StatusCode() int {
+	if r.HTTPResponse != nil {
+		return r.HTTPResponse.StatusCode
+	}
+	return 0
+}
+
+type RetrievalDiagnosticsUiRetrievalDiagnosticsPostResponse struct {
+	Body         []byte
+	HTTPResponse *http.Response
+	JSON422      *HTTPValidationError
+}
+
+// Status returns HTTPResponse.Status
+func (r RetrievalDiagnosticsUiRetrievalDiagnosticsPostResponse) Status() string {
+	if r.HTTPResponse != nil {
+		return r.HTTPResponse.Status
+	}
+	return http.StatusText(0)
+}
+
+// StatusCode returns HTTPResponse.StatusCode
+func (r RetrievalDiagnosticsUiRetrievalDiagnosticsPostResponse) StatusCode() int {
+	if r.HTTPResponse != nil {
+		return r.HTTPResponse.StatusCode
+	}
+	return 0
+}
+
 type RunbooksIndexUiRunbooksGetResponse struct {
 	Body         []byte
 	HTTPResponse *http.Response
@@ -37319,6 +37492,32 @@ func (c *ClientWithResponses) OperationsSearchUiOperationsSearchGetWithResponse(
 		return nil, err
 	}
 	return ParseOperationsSearchUiOperationsSearchGetResponse(rsp)
+}
+
+// RetrievalIndexUiRetrievalGetWithResponse request returning *RetrievalIndexUiRetrievalGetResponse
+func (c *ClientWithResponses) RetrievalIndexUiRetrievalGetWithResponse(ctx context.Context, reqEditors ...RequestEditorFn) (*RetrievalIndexUiRetrievalGetResponse, error) {
+	rsp, err := c.RetrievalIndexUiRetrievalGet(ctx, reqEditors...)
+	if err != nil {
+		return nil, err
+	}
+	return ParseRetrievalIndexUiRetrievalGetResponse(rsp)
+}
+
+// RetrievalDiagnosticsUiRetrievalDiagnosticsPostWithBodyWithResponse request with arbitrary body returning *RetrievalDiagnosticsUiRetrievalDiagnosticsPostResponse
+func (c *ClientWithResponses) RetrievalDiagnosticsUiRetrievalDiagnosticsPostWithBodyWithResponse(ctx context.Context, contentType string, body io.Reader, reqEditors ...RequestEditorFn) (*RetrievalDiagnosticsUiRetrievalDiagnosticsPostResponse, error) {
+	rsp, err := c.RetrievalDiagnosticsUiRetrievalDiagnosticsPostWithBody(ctx, contentType, body, reqEditors...)
+	if err != nil {
+		return nil, err
+	}
+	return ParseRetrievalDiagnosticsUiRetrievalDiagnosticsPostResponse(rsp)
+}
+
+func (c *ClientWithResponses) RetrievalDiagnosticsUiRetrievalDiagnosticsPostWithFormdataBodyWithResponse(ctx context.Context, body RetrievalDiagnosticsUiRetrievalDiagnosticsPostFormdataRequestBody, reqEditors ...RequestEditorFn) (*RetrievalDiagnosticsUiRetrievalDiagnosticsPostResponse, error) {
+	rsp, err := c.RetrievalDiagnosticsUiRetrievalDiagnosticsPostWithFormdataBody(ctx, body, reqEditors...)
+	if err != nil {
+		return nil, err
+	}
+	return ParseRetrievalDiagnosticsUiRetrievalDiagnosticsPostResponse(rsp)
 }
 
 // RunbooksIndexUiRunbooksGetWithResponse request returning *RunbooksIndexUiRunbooksGetResponse
@@ -44086,6 +44285,48 @@ func ParseOperationsSearchUiOperationsSearchGetResponse(rsp *http.Response) (*Op
 	}
 
 	response := &OperationsSearchUiOperationsSearchGetResponse{
+		Body:         bodyBytes,
+		HTTPResponse: rsp,
+	}
+
+	switch {
+	case strings.Contains(rsp.Header.Get("Content-Type"), "json") && rsp.StatusCode == 422:
+		var dest HTTPValidationError
+		if err := json.Unmarshal(bodyBytes, &dest); err != nil {
+			return nil, err
+		}
+		response.JSON422 = &dest
+
+	}
+
+	return response, nil
+}
+
+// ParseRetrievalIndexUiRetrievalGetResponse parses an HTTP response from a RetrievalIndexUiRetrievalGetWithResponse call
+func ParseRetrievalIndexUiRetrievalGetResponse(rsp *http.Response) (*RetrievalIndexUiRetrievalGetResponse, error) {
+	bodyBytes, err := io.ReadAll(rsp.Body)
+	defer func() { _ = rsp.Body.Close() }()
+	if err != nil {
+		return nil, err
+	}
+
+	response := &RetrievalIndexUiRetrievalGetResponse{
+		Body:         bodyBytes,
+		HTTPResponse: rsp,
+	}
+
+	return response, nil
+}
+
+// ParseRetrievalDiagnosticsUiRetrievalDiagnosticsPostResponse parses an HTTP response from a RetrievalDiagnosticsUiRetrievalDiagnosticsPostWithResponse call
+func ParseRetrievalDiagnosticsUiRetrievalDiagnosticsPostResponse(rsp *http.Response) (*RetrievalDiagnosticsUiRetrievalDiagnosticsPostResponse, error) {
+	bodyBytes, err := io.ReadAll(rsp.Body)
+	defer func() { _ = rsp.Body.Close() }()
+	if err != nil {
+		return nil, err
+	}
+
+	response := &RetrievalDiagnosticsUiRetrievalDiagnosticsPostResponse{
 		Body:         bodyBytes,
 		HTTPResponse: rsp,
 	}

--- a/docs/codebase/ui.md
+++ b/docs/codebase/ui.md
@@ -2703,3 +2703,107 @@ surface uses.
 * `backend/tests/test_ui_runbooks_lifecycle.py` — the T3 lifecycle controls: admin publish / deprecate flips status + swaps the OOB badge, operator forged POST → 403, missing-CSRF → 403, the typed-400 inline alerts (publishing a non-draft, deprecating a non-published version), idempotent re-actions, the catalog-row vs detail-page fragment branch, version-in-body targeting.
 * `backend/tests/test_ui_runbooks_acceptance.py` — the **cross-cutting** end-to-end acceptance (T4 #1385): one test exercises the surface as a whole against a single app instance — operator browse (catalog + filters) → operator opacity-floor restricted-detail (not a raw 403) → `tenant_admin` author (draft) → publish → deprecate round-trip with status transitions read back through the read surface → operator blocked (403) from author / publish / deprecate → sidebar link + dashboard tile render. A companion test pins the post-completion operator crossing the floor (completed run → full steps).
 * `backend/tests/test_ui_connectors_import.py` — `build_plan` mapping / classification unit tests (extras spill, explicit-extras merge, fingerprint drop, sparse UPDATE) + behavioural tests: auth / RBAC (403 operator, 403 missing CSRF), preview (paste + upload + parse error + missing-field error + schema-invalid-value inline error), confirm (in-process create + update, sparse PATCH preserves omitted columns, malformed-YAML no-write, schema-invalid entry 422 + zero writes), cross-tenant isolation (import lands in caller tenant only; same-name in another tenant does not flip CREATE→UPDATE).
+
+## Retrieval diagnostics surface (G10.14-T1 #1888)
+
+`meho_backplane.ui.routes.retrieval` ships the **anchor** surface for the
+retrieval diagnostics & quality console at `/ui/retrieval` (Initiative #1840).
+It is the operator-console face of the in-process hybrid retriever
+(`meho_backplane.retrieval.retriever.retrieve`) the `POST /api/v1/retrieve`
+route fronts: diagnosing "is retrieval returning what I expect?" previously
+meant a Python REPL inside the cluster or a `curl` against the REST endpoint.
+
+The anchor task stands up the page scaffold (the sidebar entry, the tab strip,
+the page chrome) + its default **Diagnostics** tab. Sibling tasks nest into the
+same page as additional client-side tab panels: T2 fills the **Usage Analytics**
++ **Eval Quality** tabs, T3 the **Retire Checklist** tab — all rendered as
+placeholders by this task so the chrome reads as a real tabbed surface from day
+one.
+
+### Routes
+
+* `GET /ui/retrieval` — the page. Renders the tabbed shell (a client-side
+  Alpine `x-data="{ tab: 'diagnostics' }"` toggle; the Diagnostics tab is the
+  default-active panel, the other three render a "lands in a follow-up task"
+  placeholder) with the Diagnostics query form (a `query` textarea, optional
+  `source` / `kind` text inputs, a `limit` selector over `(5, 10, 20, 50)`) and
+  an empty `#retrieval-diagnostics-results` region. Mints a CSRF token + sets
+  the `meho_csrf` cookie, passes `active_surface="retrieval"` for the sidebar
+  highlight.
+* `POST /ui/retrieval/diagnostics` — the HTMX fragment. Reconstructs the
+  session operator, binds the privacy `audit_*` contextvars, runs the in-process
+  `retrieve` service, and swaps `retrieval/_diagnostics_results.html` (one card
+  per hit) into `#retrieval-diagnostics-results`. An empty hit list renders a
+  "no matches" state.
+
+### Mirroring the docs-corpus console
+
+The surface is a near-line-for-line mirror of `ui/routes/corpus/routes.py` (the
+convention authority): the `_resolve_operator` seam (`load_fresh_session` +
+`verify_access_token_with_refresh`) reconstructs the full `Operator` from the
+BFF session (the `UISessionContext` carries only `operator_sub` / `tenant_id`,
+not the `sub` the per-principal predicate needs); the `_set_csrf_cookie` +
+`_resolve_diagnostics_csrf` pair implements the same reuse-live-token
+double-submit pattern (the fragment swaps only the results region and leaves the
+form in place, so it reuses the live cookie token rather than rotating a fresh
+one out from under the un-swapped form — the #1754 desync class); the
+`build_retrieval_router()` factory + module-level `Depends(require_ui_session)`
+closure follow the chassis convention. Like corpus, it routes **through the
+in-process service**, not a self-HTTP call, keeping the audit binding in-process
+and avoiding a network hop — there is no new `/api/v1` endpoint.
+
+### Per-signal RRF breakdown (the load-bearing render)
+
+Each `RetrievalHit` carries the full per-signal breakdown the substrate already
+computes: `fused_score` (the RRF score the hits are sorted by), `bm25_score` /
+`cosine_score` (`float | None`), and `bm25_rank` / `cosine_rank`
+(`int | None`). A `None` rank means the document was **absent** from that
+signal's top-`CANDIDATE_LIMIT` (50) candidate list. The diagnostics fragment
+renders each hit's breakdown as a 2-row table (BM25 + Cosine); a `None` rank
+renders the explicit `absent from this signal's top-50` marker, **not** a blank
+cell, so an operator can tell "scored 0 in that signal" apart from "never
+appeared in that signal". `query_duration_ms` is shown in the result heading.
+
+### Audit / privacy binding (load-bearing)
+
+The handler reproduces the `POST /api/v1/retrieve` audit binding before calling
+`retrieve`: it binds `audit_query_hash` (the SHA-256 hex digest of the raw query
+via the same `_compute_query_hash` encoding contract — **never** the raw query),
+`audit_source`, `audit_kind` up-front and `audit_hit_count` after, so the
+in-process `audit_log` row carries the privacy-preserving query trace even on a
+mid-retrieval exception. The raw query and filter values are deliberately
+ephemeral.
+
+### Tenant scoping + RBAC
+
+`operator` role minimum (the whole surface sits behind `require_ui_session`,
+**not** `require_ui_admin`, matching the OPERATOR floor the REST route carries).
+Diagnostics is **own-tenant only**: tenant identity is derived from the
+reconstructed operator's `tenant_id` and the per-principal isolation predicate
+is bound from `operator.sub` (`principal_sub=`) — there is no `tenant_filter`
+(that is the sibling T3 concern). The surface is read-only, so no confirm gates.
+
+### Route ordering (two levels, both load-bearing)
+
+* `build_router()` includes `build_retrieval_router()` alongside the other
+  surface routers and **before** `build_stubs_router()` — the stubs router owns
+  the catch-all `/ui/{slug}`, so a surface registered after it loses the
+  first-match-wins lookup.
+* Inside `build_retrieval_router`, the literal `POST /ui/retrieval/diagnostics`
+  is registered ahead of any `{param}` route (a NOTE comment pins the invariant
+  mirroring `corpus/routes.py`). The T2/T3 tabs are client-side panels on the
+  one page, so no per-tab param route exists today, but the ordering is pinned
+  for when one lands.
+
+### Tests
+
+* `backend/tests/test_ui_retrieval.py` — auth boundary (unauthenticated GET →
+  login redirect, POST → 302/403), page render (Diagnostics tab active + empty
+  results region + sidebar link + CSRF cookie/token), the per-signal breakdown
+  (fused score + both signals' score/rank, and the explicit absent marker for a
+  `None` rank), the no-matches state, the operator/tenant/filter forwarding
+  (own-tenant `principal_sub`), the audit binding (query hash bound, raw query
+  absent from every bound payload), CSRF (403 on missing header, live-cookie
+  reuse without rotation, 401 propagation on a dead session), and the route
+  ordering (retrieval include before stubs; literal diagnostics before any param
+  route) + dashboard tile.


### PR DESCRIPTION
## Summary
- Stands up the **anchor** surface of the retrieval diagnostics & quality console (Initiative #1840, G10.14): `GET /ui/retrieval` renders a tabbed page (Diagnostics default-active; Usage/Eval/Retire are client-side placeholders T2/T3 fill in) + `POST /ui/retrieval/diagnostics` runs the in-process hybrid retriever and swaps a fragment with the per-signal RRF breakdown.
- Per hit: the `fused_score` + a 2-row breakdown table (BM25 / Cosine score+rank). A `None` `bm25_rank`/`cosine_rank` renders an explicit **"absent from this signal's top-50"** marker, not a blank — so "scored 0" reads apart from "never appeared in that signal".
- Mirrors `ui/routes/corpus/routes.py` line-for-line: operator reconstruction (`load_fresh_session` + `verify_access_token_with_refresh`), the reuse-live-token CSRF double-submit pattern, the `build_retrieval_router()` factory + module-level `Depends(require_ui_session)` closure, and routing **through the in-process `retrieve` service** (no new `/api/v1` endpoint, no self-HTTP hop).
- Reproduces the `POST /api/v1/retrieve` **audit binding**: `audit_query_hash` (SHA-256 of the raw query — never the raw query), `audit_source`, `audit_kind` before the call + `audit_hit_count` after. Own-tenant only (`principal_sub=operator.sub`); operator-gated (`require_ui_session`, not `require_ui_admin`); read-only — no confirm gates.

## Test plan
- [x] `ruff check` / `ruff format --check` — clean
- [x] `mypy src/meho_backplane/ui/routes/retrieval/` — clean
- [x] `pytest backend/tests/test_ui_retrieval.py` — 14 passed
- [x] Regression: `test_ui_chassis_smoke.py` + `test_ui_templates.py` + `test_ui_corpus.py` — 81 passed, 1 skipped
- [x] **AC1** — `GET /ui/retrieval` 200 for operator + Diagnostics tab active + empty results; unauthenticated → login redirect (`test_retrieval_index_*`)
- [x] **AC2** — fragment renders `fused_score` + per-signal breakdown; `None` rank → explicit "absent" marker (`test_diagnostics_renders_absent_marker_for_none_rank`)
- [x] **AC3** — handler binds `audit_query_hash`/`audit_source`/`audit_kind`/`audit_hit_count`; raw query absent from every bound payload (`test_diagnostics_binds_query_hash_not_raw_query`)
- [x] **AC4** — CSRF: 403 on missing header; live cookie reused without rotation (`test_diagnostics_rejected_without_csrf_token`, `..._reuses_live_csrf_cookie_without_rotation`)
- [x] **AC5** — OpenAPI snapshot regenerated (`cd cli && make snapshot-openapi && make generate`); `grep -c '/ui/retrieval' cli/api/openapi.json` = 2; `cli/internal/api/client.gen.go` committed
- [x] **AC6** — route ordering: retrieval include before stubs + literal `/diagnostics` before any param route (`test_retrieval_router_registered_before_stubs`, `..._literal_before_any_param_route`)

## Out of scope
- Usage Analytics + Eval Quality tabs → T2; Retire-checklist tab → T3 (sibling Tasks under #1840) — placeholders only here.
- `metadata_filters` free-form JSON entry on the form (substrate supports it; this Task ships `source`/`kind` only).

<!-- auto-implement-issue: fresh, iteration 1 -->

Closes #1888
