### PR TITLE
feat(ui): /ui/retrieval Usage Analytics + Eval Quality tabs (precision@5 / MRR / coverage, green/yellow/red per surface)

### DIFF
--- a/backend/src/meho_backplane/ui/routes/retrieval/routes.py
+++ b/backend/src/meho_backplane/ui/routes/retrieval/routes.py
@@ -1,20 +1,40 @@
 # SPDX-License-Identifier: Apache-2.0
 # Copyright (c) 2026 evoila Group
 
-"""Retrieval-diagnostics UI routes: in-process hybrid query + per-signal breakdown.
+"""Retrieval UI routes: in-process diagnostics + usage + eval, no new REST endpoint.
 
-Initiative #1840 (G10.14 Retrieval diagnostics & quality console), Task #1888.
+Initiative #1840 (G10.14 Retrieval diagnostics & quality console), Tasks #1888
+(Diagnostics) + #1889 (Usage Analytics + Eval Quality).
 
 ``GET /ui/retrieval`` renders the page: a tabbed shell (Diagnostics tab
-default-active; the Usage / Eval / Retire tabs are placeholders T2/T3 fill
-in) with a query form (a query textarea, optional ``source`` / ``kind``
-inputs, a ``limit`` selector) and an empty ``#retrieval-diagnostics-results``
-region. ``POST /ui/retrieval/diagnostics`` is the HTMX fragment endpoint --
-it reconstructs the session operator, binds the privacy ``audit_*``
-contextvars, runs the in-process :func:`~meho_backplane.retrieval.retriever.retrieve`
-service, and swaps ``retrieval/_diagnostics_results.html`` (one card per hit,
-each with the ``fused_score`` and the per-signal RRF score/rank breakdown)
-into ``#retrieval-diagnostics-results``.
+default-active; Usage Analytics + Eval Quality live as of T2; the Retire tab is
+a placeholder T3 fills in) with the diagnostics query form and an empty
+``#retrieval-diagnostics-results`` region. Three HTMX fragment endpoints front
+the three in-process services -- none adds a ``/api/v1`` endpoint, exactly as
+``ui/routes/corpus/routes.py`` fronts ``search_docs``:
+
+* ``POST /ui/retrieval/diagnostics`` -- reconstructs the session operator, binds
+  the privacy ``audit_*`` contextvars, runs in-process
+  :func:`~meho_backplane.retrieval.retriever.retrieve`, and swaps
+  ``retrieval/_diagnostics_results.html`` (one card per hit, each with the
+  ``fused_score`` and the per-signal RRF score/rank breakdown) into
+  ``#retrieval-diagnostics-results``.
+* ``POST /ui/retrieval/usage`` (#1889) -- runs in-process
+  :func:`~meho_backplane.retrieval.usage.compute_usage` own-tenant over a
+  ``since`` window (opening a read-only session via
+  :func:`~meho_backplane.db.engine.get_sessionmaker`, which ``compute_usage``
+  requires), and swaps ``retrieval/_usage_results.html`` with the per-day /
+  per-surface buckets, ``total_searches``, and -- load-bearing -- the
+  ``rest_excluded`` / ``counted_surfaces`` honesty-gap explainer so a
+  ``total_searches=0`` reads as "REST excluded", not "no activity". A malformed
+  ``since`` (:class:`~meho_backplane.retrieval.usage.SinceValueError`) renders an
+  inline 400 error card, never a 500.
+* ``POST /ui/retrieval/eval`` (#1889) -- runs in-process
+  :func:`~meho_backplane.retrieval.eval.eval_all` own-tenant with **no
+  baseline** (the server-side baseline path is 501 today), and swaps
+  ``retrieval/_eval_results.html`` with per-surface ``precision_at_5`` / ``mrr``
+  / ``coverage`` + a green/yellow/red verdict pill (mapped in the template from
+  the verdict token the service returns verbatim) + the ``overall_verdict``.
 
 Reusing the substrate (no new ``/api/v1`` endpoint)
 ---------------------------------------------------
@@ -61,7 +81,7 @@ mints the token and sets the ``meho_csrf`` cookie. The fragment swaps only
 **reuses** the live cookie token (cookie untouched) rather than rotating a
 fresh one out from under the un-swapped form -- the cookie-rotation desync the
 corpus surface diagnosed (#1754). A missing / invalid cookie falls back to a
-fresh mint + re-set. See :func:`_resolve_diagnostics_csrf`.
+fresh mint + re-set. See :func:`_resolve_fragment_csrf`.
 
 Tenant scoping + RBAC
 ---------------------
@@ -77,6 +97,7 @@ from __future__ import annotations
 
 import hashlib
 import time
+from datetime import UTC, datetime
 from typing import Final
 
 import structlog
@@ -84,10 +105,20 @@ from fastapi import APIRouter, Depends, Form, HTTPException, Request, status
 from fastapi.responses import HTMLResponse
 
 from meho_backplane.auth.operator import Operator
+from meho_backplane.db.engine import get_sessionmaker
+from meho_backplane.retrieval.eval import EvalResult, eval_all
 from meho_backplane.retrieval.retriever import (
     CANDIDATE_LIMIT,
     RetrievalHit,
     retrieve,
+)
+from meho_backplane.retrieval.usage import (
+    DEFAULT_SINCE,
+    SUPPORTED_SURFACES,
+    SinceValueError,
+    UsageReport,
+    compute_usage,
+    parse_since,
 )
 from meho_backplane.settings import get_settings
 from meho_backplane.ui.auth.middleware import UISessionContext, require_ui_session
@@ -122,6 +153,19 @@ _DEFAULT_LIMIT: Final[int] = 10
 
 #: The ``limit`` options the selector renders.
 _LIMIT_OPTIONS: Final[tuple[int, ...]] = (5, 10, 20, 50)
+
+#: Maximum ``since`` value length accepted by the usage fragment. Mirrors the
+#: backend ``GET /api/v1/retrieve/usage`` ``since`` query cap (max 32 chars,
+#: ``retrieve_usage.py``) so an oversized free-form window is rejected at the
+#: form boundary rather than forwarded to :func:`parse_since`.
+_MAX_SINCE_LENGTH: Final[int] = 32
+
+#: The ``since`` presets the usage selector offers. ``30d`` (the backend
+#: :data:`~meho_backplane.retrieval.usage.DEFAULT_SINCE`) is the retire-decision
+#: window Goal #215 keys off; the others are common shorter lookbacks. An
+#: operator can still type any ``<N>d`` / ``<N>h`` / ISO-8601 value the backend
+#: parser accepts.
+_SINCE_OPTIONS: Final[tuple[str, ...]] = ("24h", "7d", "30d", "90d")
 
 #: Module-level ``Depends`` closure for the operator-session gate. Built once
 #: (rather than inline) to satisfy ruff B008, matching the convention the
@@ -190,14 +234,14 @@ def _set_csrf_cookie(response: HTMLResponse, csrf_token: str) -> None:
     )
 
 
-def _resolve_diagnostics_csrf(request: Request, session_id: str) -> tuple[str, bool]:
-    """Pick the CSRF token the diagnostics fragment echoes + whether to set the cookie.
+def _resolve_fragment_csrf(request: Request, session_id: str) -> tuple[str, bool]:
+    """Pick the CSRF token a retrieval fragment echoes + whether to set the cookie.
 
-    Returns ``(token, set_cookie)``. The fragment swaps only
-    ``#retrieval-diagnostics-results`` -- the diagnostics ``<form>`` that
-    carries the ``hx-headers`` ``X-CSRF-Token`` lives in ``index.html`` and is
-    **not** re-rendered. So the rule (mirroring the corpus surface's
-    ``_resolve_search_csrf``, the #1754 fix) is:
+    Returns ``(token, set_cookie)``. Shared by every ``/ui/retrieval`` HTMX
+    fragment (Diagnostics / Usage / Eval) -- each swaps only its own results
+    region; the ``<form>`` that carries the ``hx-headers`` ``X-CSRF-Token``
+    lives in ``index.html`` and is **not** re-rendered. So the rule (mirroring
+    the corpus surface's ``_resolve_search_csrf``, the #1754 fix) is:
 
     * **Live cookie present + valid** -- *reuse* that token and do **not**
       re-set the cookie. Minting a fresh token + ``Set-Cookie`` here would
@@ -271,6 +315,23 @@ def build_retrieval_router() -> APIRouter:
         """Run the diagnostics fragment (delegates to :func:`_render_diagnostics`)."""
         return await _render_diagnostics(request, session, query, source, kind, limit)
 
+    @router.post("/ui/retrieval/usage", response_class=HTMLResponse)
+    async def retrieval_usage(
+        request: Request,
+        session: UISessionContext = _require_session,
+        since: str = Form(default=DEFAULT_SINCE, max_length=_MAX_SINCE_LENGTH),
+    ) -> HTMLResponse:
+        """Run the Usage Analytics fragment (delegates to :func:`_render_usage`)."""
+        return await _render_usage(request, session, since)
+
+    @router.post("/ui/retrieval/eval", response_class=HTMLResponse)
+    async def retrieval_eval(
+        request: Request,
+        session: UISessionContext = _require_session,
+    ) -> HTMLResponse:
+        """Run the Eval Quality fragment (delegates to :func:`_render_eval`)."""
+        return await _render_eval(request, session)
+
     return router
 
 
@@ -315,6 +376,14 @@ async def _render_retrieval_index(
         "hits": [],
         "searched": False,
         "candidate_limit": CANDIDATE_LIMIT,
+        # Usage Analytics tab (#1889): the lookback form defaults to the
+        # retire-decision window; the partials read their data off
+        # ``report`` / ``result`` (both ``None`` on the initial render, so the
+        # included fragments fall through to their quiet prompts).
+        "since": DEFAULT_SINCE,
+        "since_options": _SINCE_OPTIONS,
+        "report": None,
+        "result": None,
         "operator_sub": session.operator_sub,
         "active_surface": "retrieval",
         "page_title": "Retrieval",
@@ -344,7 +413,7 @@ async def _render_diagnostics(
     The privacy ``audit_*`` contextvars are bound **before** the ``retrieve``
     call (and ``audit_hit_count`` after) so the in-process audit row carries the
     SHA-256 query trace even on a mid-retrieval exception. CSRF handling defers
-    to :func:`_resolve_diagnostics_csrf`.
+    to :func:`_resolve_fragment_csrf`.
     """
     query_text = query.strip()
     source_filter = source.strip()
@@ -366,7 +435,7 @@ async def _render_diagnostics(
             # login redirect), matching the corpus surface.
             raise
 
-    csrf_token, set_csrf = _resolve_diagnostics_csrf(request, str(session.session_id))
+    csrf_token, set_csrf = _resolve_fragment_csrf(request, str(session.session_id))
     context: dict[str, object] = {
         **_diagnostics_form_context(
             query=query_text,
@@ -434,3 +503,157 @@ async def _run_diagnostics(
         duration_ms=duration_ms,
     )
     return hits, duration_ms
+
+
+# ---------------------------------------------------------------------------
+# Usage Analytics tab (#1889)
+# ---------------------------------------------------------------------------
+
+
+async def _render_usage(
+    request: Request,
+    session: UISessionContext,
+    since: str,
+) -> HTMLResponse:
+    """Run the HTMX Usage Analytics fragment for ``POST /ui/retrieval/usage``.
+
+    Reconstructs the operator and runs the in-process
+    :func:`~meho_backplane.retrieval.usage.compute_usage` own-tenant (no
+    ``tenant_filter`` -- the ``platform_admin`` cross-tenant selector is the
+    sibling T3 concern), then swaps ``retrieval/_usage_results.html`` into
+    ``#retrieval-usage-results``.
+
+    ``compute_usage`` is keyword-only and **requires** a ``session:
+    AsyncSession``, so this handler opens one via
+    :func:`~meho_backplane.db.engine.get_sessionmaker` exactly as the corpus
+    console does -- the helper is read-only and does not commit or close the
+    session (lifetime is the caller's concern). The ``since`` string is
+    resolved with :func:`~meho_backplane.retrieval.usage.parse_since`; a
+    :class:`~meho_backplane.retrieval.usage.SinceValueError` renders an inline
+    400 error card (mirroring the REST route's
+    ``raise HTTPException(status_code=400, ...)``) rather than escaping as a
+    500.
+
+    The honesty-gap explainer is load-bearing: a ``total_searches == 0`` with
+    ``rest_excluded`` / ``counted_surfaces`` must read as "REST excluded -- only
+    audited /mcp search tools are counted", not "no activity". The template
+    renders that badge from the :class:`~meho_backplane.retrieval.usage.UsageReport`
+    fields verbatim.
+    """
+    since_value = since.strip() or DEFAULT_SINCE
+
+    report: UsageReport | None = None
+    error_message: str | None = None
+    now = datetime.now(UTC)
+    try:
+        since_dt = parse_since(since_value, now=now)
+    except SinceValueError as exc:
+        # Surface the parser's rejection as an inline 400-class error card --
+        # the same shape the REST route maps to ``HTTPException(400, ...)`` --
+        # rather than letting it escape as a 500.
+        error_message = str(exc)
+    else:
+        operator = await _resolve_operator(session)
+        report = await _run_usage(operator, since_dt, now)
+
+    csrf_token, set_csrf = _resolve_fragment_csrf(request, str(session.session_id))
+    context: dict[str, object] = {
+        "since": since_value,
+        "since_options": _SINCE_OPTIONS,
+        "report": report,
+        "error_message": error_message,
+        "csrf_token": csrf_token,
+    }
+    response = get_templates().TemplateResponse(request, "retrieval/_usage_results.html", context)
+    if set_csrf:
+        _set_csrf_cookie(response, csrf_token)
+    return response
+
+
+async def _run_usage(
+    operator: Operator,
+    since_dt: datetime,
+    now: datetime,
+) -> UsageReport:
+    """Open a read-only session and run in-process ``compute_usage`` own-tenant.
+
+    Scoped to ``operator.tenant_id`` (no ``tenant_filter``) across every
+    :data:`~meho_backplane.retrieval.usage.SUPPORTED_SURFACES`. The session is
+    opened via :func:`~meho_backplane.db.engine.get_sessionmaker` and closed by
+    the ``async with`` -- ``compute_usage`` neither commits nor closes it.
+    """
+    sessionmaker = get_sessionmaker()
+    async with sessionmaker() as db_session:
+        report = await compute_usage(
+            session=db_session,
+            since=since_dt,
+            until=now,
+            surfaces=SUPPORTED_SURFACES,
+            tenant_id=operator.tenant_id,
+        )
+    log.info(
+        "ui_retrieval_usage_completed",
+        operator_sub=operator.sub,
+        tenant_id=str(operator.tenant_id),
+        total_searches=report.total_searches,
+        bucket_count=len(report.buckets),
+    )
+    return report
+
+
+# ---------------------------------------------------------------------------
+# Eval Quality tab (#1889)
+# ---------------------------------------------------------------------------
+
+
+async def _render_eval(
+    request: Request,
+    session: UISessionContext,
+) -> HTMLResponse:
+    """Run the HTMX Eval Quality fragment for ``POST /ui/retrieval/eval``.
+
+    Reconstructs the operator and runs the in-process
+    :func:`~meho_backplane.retrieval.eval.eval_all` own-tenant with **no
+    baseline** -- the server-side baseline path is rejected 501
+    (``retrieve_eval.py``) since v0.2 ships no checked-in corpus snapshot, so
+    this surface never offers a baseline toggle and never reaches that path.
+    Unlike usage, ``eval_all`` takes **no session** (it owns its own retrieval
+    plumbing), so it is called as ``await eval_all(tenant_id=operator.tenant_id)``.
+
+    Swaps ``retrieval/_eval_results.html`` into ``#retrieval-eval-results``: per
+    surface, ``precision_at_5`` / ``mrr`` / ``coverage`` and a green/yellow/red
+    verdict pill mapped (in the template) from the verdict token the service
+    returns verbatim, plus the ``overall_verdict``. An empty-corpus surface
+    legitimately returns ``green``; the verdict is rendered as-is, never
+    recomputed.
+    """
+    operator = await _resolve_operator(session)
+    result = await _run_eval(operator)
+
+    csrf_token, set_csrf = _resolve_fragment_csrf(request, str(session.session_id))
+    context: dict[str, object] = {
+        "result": result,
+        "csrf_token": csrf_token,
+    }
+    response = get_templates().TemplateResponse(request, "retrieval/_eval_results.html", context)
+    if set_csrf:
+        _set_csrf_cookie(response, csrf_token)
+    return response
+
+
+async def _run_eval(operator: Operator) -> EvalResult:
+    """Run in-process ``eval_all`` own-tenant with no baseline.
+
+    Scoped to ``operator.tenant_id``; ``eval_all`` runs every shipped surface's
+    corpus (the default) and computes MEHO-only metrics -- no ``baseline``
+    argument, so the 501 baseline path is never reached.
+    """
+    result = await eval_all(tenant_id=operator.tenant_id)
+    log.info(
+        "ui_retrieval_eval_completed",
+        operator_sub=operator.sub,
+        tenant_id=str(operator.tenant_id),
+        overall_verdict=result.overall_verdict,
+        surface_count=len(result.surfaces),
+    )
+    return result

--- a/backend/src/meho_backplane/ui/templates/retrieval/_eval_results.html
+++ b/backend/src/meho_backplane/ui/templates/retrieval/_eval_results.html
@@ -1,0 +1,107 @@
+{#-
+  SPDX-License-Identifier: Apache-2.0
+  Copyright (c) 2026 evoila Group
+
+  Retrieval Eval-Quality results partial.
+
+  Initiative #1840 (G10.14 Retrieval diagnostics & quality console),
+  Task #1889. Swapped into ``#retrieval-eval-results`` by the HTMX
+  ``POST /ui/retrieval/eval``; also included into ``index.html`` for the
+  initial render so both paths share identical markup.
+
+  Render branches (first match wins):
+    1. ``result`` set -> the ``overall_verdict`` pill + one row per surface
+       with ``precision_at_5`` / ``mrr`` / ``coverage`` and a verdict pill.
+    2. otherwise (initial render) -> a quiet prompt.
+
+  Verdict -> color mapping (lives here, NOT in the service):
+    The service returns a ``Verdict`` token (``green`` / ``yellow`` / ``red``)
+    verbatim -- an empty-corpus surface legitimately returns ``green``. The
+    template maps the token to a daisyUI badge color via ``_verdict_pill``; it
+    NEVER recomputes the verdict. ``red`` -> ``badge-error``, ``yellow`` ->
+    ``badge-warning``, ``green`` -> ``badge-success``.
+
+  No baseline:
+    There is deliberately NO baseline column and NO baseline toggle -- the
+    server-side baseline path is 501 today (v0.2 ships no checked-in corpus
+    snapshot). ``eval_all`` is called without a baseline, so the 501 path is
+    never reached.
+
+  Context variables:
+    result      -- EvalResult | None: per-surface metrics + overall_verdict
+    csrf_token  -- str: minted double-submit token (un-rendered here; the form
+                   lives in index.html)
+-#}
+{#- Verdict -> daisyUI badge-color pill. The verdict token is rendered
+    verbatim; only the color class is mapped here. -#}
+{% macro verdict_pill(verdict) %}
+  {%- if verdict == "red" -%}
+    {% set badge_class = "badge-error" %}
+  {%- elif verdict == "yellow" -%}
+    {% set badge_class = "badge-warning" %}
+  {%- else -%}
+    {% set badge_class = "badge-success" %}
+  {%- endif -%}
+  <span
+    class="badge {{ badge_class }} badge-outline uppercase"
+    data-verdict="{{ verdict }}"
+    aria-label="Verdict {{ verdict }}"
+  >{{ verdict }}</span>
+{% endmacro %}
+<div id="retrieval-eval-results" class="space-y-3">
+  {% set result = result | default(none) %}
+  {% if result is not none %}
+    {# ---------- Overall verdict header ---------- #}
+    <div class="flex flex-wrap items-center justify-between gap-2">
+      <p class="text-sm opacity-70" aria-live="polite">
+        Eval run &middot;
+        <span class="font-mono">{{ result.ran_at.strftime("%Y-%m-%d %H:%M") }}</span> UTC
+      </p>
+      <div class="flex items-center gap-2">
+        <span class="text-sm opacity-70">Overall</span>
+        {{ verdict_pill(result.overall_verdict) }}
+      </div>
+    </div>
+
+    {# ---------- Per-surface metrics table ---------- #}
+    <div class="overflow-x-auto">
+      <table class="table table-sm" aria-label="Per-surface eval metrics">
+        <thead>
+          <tr>
+            <th>Surface</th>
+            <th class="text-right">Queries</th>
+            <th class="text-right">precision@5</th>
+            <th class="text-right">MRR</th>
+            <th class="text-right">coverage</th>
+            <th class="text-right">Verdict</th>
+          </tr>
+        </thead>
+        <tbody>
+          {% for surface in result.surfaces %}
+            <tr>
+              <td>
+                <span class="badge badge-ghost badge-outline">{{ surface.surface }}</span>
+              </td>
+              <td class="text-right font-mono">{{ surface.query_count }}</td>
+              <td class="text-right font-mono">{{ "%.3f" | format(surface.precision_at_5) }}</td>
+              <td class="text-right font-mono">{{ "%.3f" | format(surface.mrr) }}</td>
+              <td class="text-right font-mono">{{ "%.3f" | format(surface.coverage) }}</td>
+              <td class="text-right">{{ verdict_pill(surface.verdict) }}</td>
+            </tr>
+          {% endfor %}
+        </tbody>
+      </table>
+    </div>
+
+  {% else %}
+    {# ---------- Initial prompt (no run yet) ---------- #}
+    <div class="card bg-base-100 border-base-300 border border-dashed shadow-sm">
+      <div class="card-body text-center py-10">
+        <p class="text-base opacity-50">
+          Run the eval corpus to read back precision@5 / MRR / coverage and a
+          green/yellow/red verdict per surface.
+        </p>
+      </div>
+    </div>
+  {% endif %}
+</div>

--- a/backend/src/meho_backplane/ui/templates/retrieval/_usage_results.html
+++ b/backend/src/meho_backplane/ui/templates/retrieval/_usage_results.html
@@ -1,0 +1,135 @@
+{#-
+  SPDX-License-Identifier: Apache-2.0
+  Copyright (c) 2026 evoila Group
+
+  Retrieval Usage-Analytics results partial.
+
+  Initiative #1840 (G10.14 Retrieval diagnostics & quality console),
+  Task #1889. Swapped into ``#retrieval-usage-results`` by the HTMX
+  ``POST /ui/retrieval/usage``; also included into ``index.html`` for the
+  initial render so both paths share identical markup.
+
+  Render branches (first match wins):
+    1. ``error_message`` set -> an inline 400-class error card (a malformed
+       ``since`` rejected by ``parse_since`` -> ``SinceValueError``; never a
+       500).
+    2. ``report`` set -> the window header, the honesty-gap explainer (always
+       shown when ``total_searches == 0``), and either a per-(day, surface)
+       bucket table or a zero state.
+    3. otherwise (initial render) -> a quiet prompt.
+
+  Honesty-gap explainer (load-bearing -- must surface, not hide):
+    ``compute_usage`` counts only the audited ``/mcp`` search meta-tools; the
+    REST ``POST /api/v1/retrieve`` diagnostic queries (the very thing the
+    Diagnostics tab runs) are NOT counted (``rest_excluded``). So a
+    ``total_searches == 0`` with a non-empty ``counted_surfaces`` must read as
+    "REST excluded -- only audited /mcp search tools are counted", NOT as "no
+    retrieval activity". The badge renders whenever the count is zero.
+
+  Context variables:
+    since          -- str: the submitted lookback window (for the input value)
+    since_options  -- tuple[str]: the lookback presets the selector offers
+    report         -- UsageReport | None: the usage aggregate (None on error)
+    error_message  -- str | None: a ``SinceValueError`` detail (inline 400 card)
+    csrf_token     -- str: minted double-submit token (un-rendered here; the
+                      form lives in index.html)
+-#}
+<div id="retrieval-usage-results" class="space-y-3">
+  {% set error_message = error_message | default(none) %}
+  {% set report = report | default(none) %}
+  {% if error_message %}
+    {# ---------- Inline 400 error card (malformed since) ---------- #}
+    <div class="alert alert-error" role="alert" aria-live="assertive">
+      <div>
+        <h3 class="font-semibold">Invalid lookback window</h3>
+        <p class="text-sm opacity-90">{{ error_message }}</p>
+      </div>
+    </div>
+
+  {% elif report is not none %}
+    {# ---------- Window header ---------- #}
+    <div class="flex flex-wrap items-center justify-between gap-2">
+      <p class="text-sm opacity-70" aria-live="polite">
+        <span class="font-mono">{{ report.total_searches }}</span>
+        search{% if report.total_searches != 1 %}es{% endif %} counted
+        &middot; <span class="font-mono">{{ report.since.strftime("%Y-%m-%d %H:%M") }}</span>
+        &ndash; <span class="font-mono">{{ report.until.strftime("%Y-%m-%d %H:%M") }}</span> UTC
+      </p>
+    </div>
+
+    {# ---------- Honesty-gap explainer (shown whenever the count is zero) ----------
+       A zero is ambiguous: it could mean "no retrieval activity" OR "you only
+       dogfood through REST, which this counter deliberately excludes". The
+       badge disambiguates so the zero never reads as inactivity. #}
+    {% if report.total_searches == 0 and report.rest_excluded %}
+      <div class="alert alert-info" role="status">
+        <div>
+          <h3 class="font-semibold">REST excluded &mdash; only audited /mcp search tools are counted</h3>
+          <p class="text-sm opacity-90">
+            A zero here does <strong>not</strong> mean "no retrieval activity".
+            The REST <span class="font-mono">POST /api/v1/retrieve</span>
+            diagnostic queries (including this console's Diagnostics tab) audit
+            under their own path and are not counted. Only these audited
+            <span class="font-mono">/mcp</span> search meta-tools tick the
+            counter:
+          </p>
+          {% if report.counted_surfaces %}
+            <div class="mt-1 flex flex-wrap gap-1">
+              {% for surface in report.counted_surfaces %}
+                <span class="badge badge-ghost badge-outline font-mono">{{ surface }}</span>
+              {% endfor %}
+            </div>
+          {% endif %}
+        </div>
+      </div>
+    {% endif %}
+
+    {# ---------- Per-(day, surface) bucket table ---------- #}
+    {% if report.buckets %}
+      <div class="overflow-x-auto">
+        <table class="table table-sm" aria-label="Per-day per-surface usage">
+          <thead>
+            <tr>
+              <th>Date</th>
+              <th>Surface</th>
+              <th class="text-right">Searches</th>
+              <th class="text-right">Distinct operators</th>
+              <th class="text-right">Action conversion</th>
+            </tr>
+          </thead>
+          <tbody>
+            {% for bucket in report.buckets %}
+              <tr>
+                <td class="font-mono">{{ bucket.date.isoformat() }}</td>
+                <td>
+                  <span class="badge badge-ghost badge-outline">{{ bucket.surface }}</span>
+                </td>
+                <td class="text-right font-mono">{{ bucket.search_count }}</td>
+                <td class="text-right font-mono">{{ bucket.distinct_operators }}</td>
+                <td class="text-right font-mono">{{ "%.2f" | format(bucket.action_conversion_pct) }}%</td>
+              </tr>
+            {% endfor %}
+          </tbody>
+        </table>
+      </div>
+    {% elif report.total_searches != 0 %}
+      {# total_searches > 0 but no buckets would be a contradiction; guard anyway. #}
+      <div class="card bg-base-100 border-base-300 border shadow-sm">
+        <div class="card-body text-center py-8">
+          <p class="text-sm opacity-50">No per-day breakdown available for this window.</p>
+        </div>
+      </div>
+    {% endif %}
+
+  {% else %}
+    {# ---------- Initial prompt (no run yet) ---------- #}
+    <div class="card bg-base-100 border-base-300 border border-dashed shadow-sm">
+      <div class="card-body text-center py-10">
+        <p class="text-base opacity-50">
+          Pick a lookback window and run to read back audited search usage per
+          surface.
+        </p>
+      </div>
+    </div>
+  {% endif %}
+</div>

--- a/backend/src/meho_backplane/ui/templates/retrieval/index.html
+++ b/backend/src/meho_backplane/ui/templates/retrieval/index.html
@@ -193,17 +193,89 @@
     {% include "retrieval/_diagnostics_results.html" %}
   </div>
 
-  {# ---------- Placeholder tab panels (T2 / T3) ---------- #}
-  <div role="tabpanel" x-show="tab === 'usage'" x-cloak class="card bg-base-100 border-base-300 border border-dashed shadow-sm">
-    <div class="card-body text-center py-10">
-      <p class="text-base opacity-50">Usage Analytics lands in a follow-up task.</p>
+  {# ---------- Usage Analytics tab panel (T2) ---------- #}
+  {#- ``POST /ui/retrieval/usage`` swaps ``#retrieval-usage-results``. The form
+      declares its OWN ``hx-headers`` ``X-CSRF-Token`` (HTMX does not propagate
+      ``hx-headers`` to a descendant form, #1693). Own-tenant only -- there is
+      no ``tenant_filter`` field (that is T3's ``platform_admin`` selector). -#}
+  <div role="tabpanel" x-show="tab === 'usage'" x-cloak class="space-y-4">
+    <div class="card bg-base-100 border-base-300 border shadow-sm">
+      <div class="card-body py-4">
+        <form
+          id="retrieval-usage-form"
+          hx-post="/ui/retrieval/usage"
+          hx-target="#retrieval-usage-results"
+          hx-swap="outerHTML"
+          hx-headers='{"X-CSRF-Token": "{{ csrf_token }}"}'
+          class="flex flex-col gap-3 sm:flex-row sm:items-end"
+          aria-label="Run a retrieval usage report"
+        >
+          <label class="form-control w-full sm:w-48">
+            <div class="label">
+              <span class="label-text">Lookback window</span>
+            </div>
+            <input
+              type="text"
+              name="since"
+              value="{{ since }}"
+              maxlength="32"
+              list="retrieval-usage-since-options"
+              placeholder="e.g. 30d, 24h, 2026-05-01"
+              class="input input-bordered w-full"
+              aria-label="Usage lookback window"
+              autocomplete="off"
+            />
+            <datalist id="retrieval-usage-since-options">
+              {% for option in since_options %}
+                <option value="{{ option }}"></option>
+              {% endfor %}
+            </datalist>
+          </label>
+          <button type="submit" class="btn btn-primary gap-1" aria-label="Run the usage report">
+            {{ icon("activity") }}
+            Run
+          </button>
+        </form>
+      </div>
     </div>
+
+    {# ---------- Usage results region ---------- #}
+    {% include "retrieval/_usage_results.html" %}
   </div>
-  <div role="tabpanel" x-show="tab === 'eval'" x-cloak class="card bg-base-100 border-base-300 border border-dashed shadow-sm">
-    <div class="card-body text-center py-10">
-      <p class="text-base opacity-50">Eval Quality lands in a follow-up task.</p>
+
+  {# ---------- Eval Quality tab panel (T2) ---------- #}
+  {#- ``POST /ui/retrieval/eval`` swaps ``#retrieval-eval-results``. No baseline
+      toggle (the server-side baseline path is 501 today). Own-tenant only. -#}
+  <div role="tabpanel" x-show="tab === 'eval'" x-cloak class="space-y-4">
+    <div class="card bg-base-100 border-base-300 border shadow-sm">
+      <div class="card-body py-4">
+        <form
+          id="retrieval-eval-form"
+          hx-post="/ui/retrieval/eval"
+          hx-target="#retrieval-eval-results"
+          hx-swap="outerHTML"
+          hx-headers='{"X-CSRF-Token": "{{ csrf_token }}"}'
+          class="flex flex-wrap items-center justify-between gap-3"
+          aria-label="Run the retrieval eval corpus"
+        >
+          <p class="text-sm opacity-70">
+            Run the checked-in eval corpus against this tenant&rsquo;s substrate
+            and read back precision@5 / MRR / coverage with a green/yellow/red
+            verdict per surface.
+          </p>
+          <button type="submit" class="btn btn-primary gap-1" aria-label="Run the eval corpus">
+            {{ icon("gauge") }}
+            Run eval
+          </button>
+        </form>
+      </div>
     </div>
+
+    {# ---------- Eval results region ---------- #}
+    {% include "retrieval/_eval_results.html" %}
   </div>
+
+  {# ---------- Placeholder tab panel (T3) ---------- #}
   <div role="tabpanel" x-show="tab === 'retire'" x-cloak class="card bg-base-100 border-base-300 border border-dashed shadow-sm">
     <div class="card-body text-center py-10">
       <p class="text-base opacity-50">Retire Checklist lands in a follow-up task.</p>

--- a/backend/tests/test_ui_retrieval.py
+++ b/backend/tests/test_ui_retrieval.py
@@ -50,7 +50,9 @@ from meho_backplane.auth.jwt import clear_jwks_cache
 from meho_backplane.auth.operator import Operator, TenantRole
 from meho_backplane.db.engine import get_sessionmaker, reset_engine_for_testing
 from meho_backplane.db.models import Tenant
+from meho_backplane.retrieval.eval.result_models import EvalResult, SurfaceResult
 from meho_backplane.retrieval.retriever import RetrievalHit
+from meho_backplane.retrieval.usage import UsageReport
 from meho_backplane.settings import get_settings
 from meho_backplane.ui.auth import (
     SESSION_COOKIE_NAME,
@@ -91,6 +93,14 @@ _RESOLVE_OPERATOR = "meho_backplane.ui.routes.retrieval.routes._resolve_operator
 #: The route-module symbol the diagnostics handler calls; mocked to control the
 #: returned hit list / raised failure without a live corpus + embedder.
 _RETRIEVE = "meho_backplane.ui.routes.retrieval.routes.retrieve"
+
+#: The route-module symbol the Usage tab calls; mocked to return a
+#: constructed :class:`UsageReport` without a live audit_log scan (#1889).
+_COMPUTE_USAGE = "meho_backplane.ui.routes.retrieval.routes.compute_usage"
+
+#: The route-module symbol the Eval tab calls; mocked to return a constructed
+#: :class:`EvalResult` without a live corpus + embedder run (#1889).
+_EVAL_ALL = "meho_backplane.ui.routes.retrieval.routes.eval_all"
 
 #: The contextvars binder the handler calls; patched to capture the audit
 #: payload without a live structlog pipeline.
@@ -613,3 +623,443 @@ def test_dashboard_surface_grid_includes_retrieval_tile() -> None:
     body = response.text
     assert 'href="/ui/retrieval"' in body
     assert "Retrieval" in body
+
+
+# ===========================================================================
+# Usage Analytics tab (#1889)
+# ===========================================================================
+
+
+def _usage_report(
+    *,
+    total_searches: int = 0,
+    buckets: list[object] | None = None,
+    rest_excluded: bool = True,
+) -> UsageReport:
+    """Build a :class:`UsageReport` the patched ``compute_usage`` returns.
+
+    ``counted_surfaces`` / ``rest_excluded`` default from the model (so the
+    honesty-gap explainer fields are populated as production would emit them).
+    """
+    now = datetime(2026, 6, 19, 12, 0, tzinfo=UTC)
+    return UsageReport(
+        since=now - timedelta(days=30),
+        until=now,
+        surfaces=["kb", "memory", "operations"],
+        tenant_id=_TENANT_A,
+        buckets=buckets or [],  # type: ignore[arg-type]
+        total_searches=total_searches,
+        rest_excluded=rest_excluded,
+    )
+
+
+def test_usage_renders_total_and_rest_excluded_explainer_on_zero() -> None:
+    """A ``total_searches=0`` renders the REST-excluded explainer, not "no activity".
+
+    Acceptance criterion: ``compute_usage`` returns a ``UsageReport`` with
+    ``total_searches=0, rest_excluded=True``; the fragment must surface the
+    "REST excluded" / ``counted_surfaces`` explainer so the zero does not read
+    as inactivity.
+    """
+    _seed_tenant(_TENANT_A, "tenant-a")
+    session_id = _seed_session_sync(tenant_id=_TENANT_A)
+    csrf = _csrf_token(session_id)
+    operator = _operator(tenant_id=_TENANT_A)
+    report = _usage_report(total_searches=0, rest_excluded=True)
+
+    with respx.mock(assert_all_called=False):
+        client = _authenticated_client(session_id)
+        client.cookies.set(CSRF_COOKIE_NAME, csrf)
+        with (
+            patch(_RESOLVE_OPERATOR, new_callable=AsyncMock, return_value=operator),
+            patch(_COMPUTE_USAGE, new_callable=AsyncMock, return_value=report),
+        ):
+            response = client.post(
+                "/ui/retrieval/usage",
+                data={"since": "30d"},
+                headers={CSRF_HEADER_NAME: csrf},
+            )
+
+    assert response.status_code == 200, response.text
+    body = response.text
+    # Fragment, not full page.
+    assert 'id="retrieval-usage-results"' in body
+    assert "<!doctype html>" not in body.lower()
+    # The honesty-gap explainer reads as "REST excluded", not "no activity".
+    assert "REST excluded" in body
+    # At least one counted /mcp surface badge renders so the zero is self-explaining.
+    assert "mcp:search_knowledge" in body
+
+
+def test_usage_renders_per_surface_buckets() -> None:
+    """A non-zero report renders ``total_searches`` + the per-(day, surface) table."""
+    from meho_backplane.retrieval.usage import DailyUsageBucket
+
+    _seed_tenant(_TENANT_A, "tenant-a")
+    session_id = _seed_session_sync(tenant_id=_TENANT_A)
+    csrf = _csrf_token(session_id)
+    operator = _operator(tenant_id=_TENANT_A)
+    bucket = DailyUsageBucket(
+        date=datetime(2026, 6, 18, tzinfo=UTC).date(),
+        surface="kb",
+        search_count=7,
+        distinct_operators=2,
+        action_conversion_pct=42.86,
+    )
+    report = _usage_report(total_searches=7, buckets=[bucket])
+
+    with respx.mock(assert_all_called=False):
+        client = _authenticated_client(session_id)
+        client.cookies.set(CSRF_COOKIE_NAME, csrf)
+        with (
+            patch(_RESOLVE_OPERATOR, new_callable=AsyncMock, return_value=operator),
+            patch(_COMPUTE_USAGE, new_callable=AsyncMock, return_value=report),
+        ):
+            response = client.post(
+                "/ui/retrieval/usage",
+                data={"since": "30d"},
+                headers={CSRF_HEADER_NAME: csrf},
+            )
+
+    assert response.status_code == 200, response.text
+    body = response.text
+    assert "7" in body
+    assert "2026-06-18" in body
+    assert "kb" in body
+    assert "42.86" in body
+    # A non-zero count does not show the zero-explainer.
+    assert "REST excluded" not in body
+
+
+def test_usage_own_tenant_only_no_tenant_filter() -> None:
+    """The Usage handler runs own-tenant: ``compute_usage`` gets ``operator.tenant_id``."""
+    _seed_tenant(_TENANT_A, "tenant-a")
+    session_id = _seed_session_sync(tenant_id=_TENANT_A)
+    csrf = _csrf_token(session_id)
+    operator = _operator(tenant_id=_TENANT_A)
+    usage_mock = AsyncMock(return_value=_usage_report(total_searches=0))
+
+    with respx.mock(assert_all_called=False):
+        client = _authenticated_client(session_id)
+        client.cookies.set(CSRF_COOKIE_NAME, csrf)
+        with (
+            patch(_RESOLVE_OPERATOR, new_callable=AsyncMock, return_value=operator),
+            patch(_COMPUTE_USAGE, usage_mock),
+        ):
+            response = client.post(
+                "/ui/retrieval/usage",
+                data={"since": "30d"},
+                headers={CSRF_HEADER_NAME: csrf},
+            )
+
+    assert response.status_code == 200, response.text
+    usage_mock.assert_awaited_once()
+    kwargs = usage_mock.await_args.kwargs
+    # Own-tenant only -- the report is scoped to the reconstructed operator's
+    # tenant; there is no cross-tenant tenant_filter on this surface.
+    assert kwargs["tenant_id"] == _TENANT_A
+
+
+def test_usage_malformed_since_renders_inline_400_card_not_500() -> None:
+    """A malformed ``since`` surfaces the ``SinceValueError`` as an inline error card.
+
+    Acceptance criterion: a ``since`` like ``"banana"`` must render an inline
+    400-class error card (the backend ``SinceValueError`` detail), NOT a 500 --
+    and ``compute_usage`` must never be reached (the parse fails first).
+    """
+    _seed_tenant(_TENANT_A, "tenant-a")
+    session_id = _seed_session_sync(tenant_id=_TENANT_A)
+    csrf = _csrf_token(session_id)
+    operator = _operator(tenant_id=_TENANT_A)
+    usage_mock = AsyncMock(return_value=_usage_report())
+
+    with respx.mock(assert_all_called=False):
+        client = _authenticated_client(session_id)
+        client.cookies.set(CSRF_COOKIE_NAME, csrf)
+        with (
+            patch(_RESOLVE_OPERATOR, new_callable=AsyncMock, return_value=operator),
+            patch(_COMPUTE_USAGE, usage_mock),
+        ):
+            response = client.post(
+                "/ui/retrieval/usage",
+                data={"since": "banana"},
+                headers={CSRF_HEADER_NAME: csrf},
+            )
+
+    # Not a 500 -- the parser rejection is caught and rendered inline.
+    assert response.status_code == 200, response.text
+    body = response.text
+    assert 'role="alert"' in body
+    assert "Invalid lookback window" in body
+    # The substrate was never reached -- the bad window short-circuits the run.
+    usage_mock.assert_not_awaited()
+
+
+def test_usage_rejected_without_csrf_token() -> None:
+    """A usage POST without the CSRF header is rejected 403 by the middleware."""
+    _seed_tenant(_TENANT_A, "tenant-a")
+    session_id = _seed_session_sync(tenant_id=_TENANT_A)
+    csrf = _csrf_token(session_id)
+
+    with respx.mock(assert_all_called=False):
+        client = _authenticated_client(session_id)
+        client.cookies.set(CSRF_COOKIE_NAME, csrf)
+        response = client.post("/ui/retrieval/usage", data={"since": "30d"})
+
+    assert response.status_code == 403
+
+
+def test_usage_reuses_live_csrf_cookie_without_rotation() -> None:
+    """The usage fragment reuses the live CSRF cookie and does NOT rotate it."""
+    _seed_tenant(_TENANT_A, "tenant-a")
+    session_id = _seed_session_sync(tenant_id=_TENANT_A)
+    csrf = _csrf_token(session_id)
+    operator = _operator(tenant_id=_TENANT_A)
+
+    with respx.mock(assert_all_called=False):
+        client = _authenticated_client(session_id)
+        client.cookies.set(CSRF_COOKIE_NAME, csrf)
+        with (
+            patch(_RESOLVE_OPERATOR, new_callable=AsyncMock, return_value=operator),
+            patch(_COMPUTE_USAGE, new_callable=AsyncMock, return_value=_usage_report()),
+        ):
+            response = client.post(
+                "/ui/retrieval/usage",
+                data={"since": "30d"},
+                headers={CSRF_HEADER_NAME: csrf},
+            )
+
+    assert response.status_code == 200, response.text
+    set_cookie = response.headers.get("set-cookie", "")
+    assert CSRF_COOKIE_NAME not in set_cookie
+
+
+# ===========================================================================
+# Eval Quality tab (#1889)
+# ===========================================================================
+
+
+def _surface_result(
+    *,
+    surface: str = "kb",
+    precision_at_5: float = 0.8,
+    mrr: float = 0.75,
+    coverage: float = 0.9,
+    verdict: str = "green",
+    query_count: int = 10,
+) -> SurfaceResult:
+    """Build a :class:`SurfaceResult` for mocked ``eval_all`` returns."""
+    return SurfaceResult(
+        surface=surface,  # type: ignore[arg-type]
+        query_count=query_count,
+        precision_at_5=precision_at_5,
+        mrr=mrr,
+        coverage=coverage,
+        verdict=verdict,  # type: ignore[arg-type]
+    )
+
+
+def _eval_result(
+    *,
+    surfaces: list[SurfaceResult] | None = None,
+    overall_verdict: str = "green",
+) -> EvalResult:
+    """Build an :class:`EvalResult` the patched ``eval_all`` returns."""
+    return EvalResult(
+        ran_at=datetime(2026, 6, 19, 12, 0, tzinfo=UTC),
+        surfaces=surfaces if surfaces is not None else [_surface_result()],
+        overall_verdict=overall_verdict,  # type: ignore[arg-type]
+    )
+
+
+def test_eval_renders_metrics_and_verdict_pills() -> None:
+    """The Eval fragment renders per-surface metrics + a verdict pill + the overall.
+
+    Acceptance criterion: a stubbed ``eval_all`` returning a ``red`` surface
+    renders the red pill (``data-verdict="red"``) AND a red ``overall_verdict``.
+    """
+    _seed_tenant(_TENANT_A, "tenant-a")
+    session_id = _seed_session_sync(tenant_id=_TENANT_A)
+    csrf = _csrf_token(session_id)
+    operator = _operator(tenant_id=_TENANT_A)
+    result = _eval_result(
+        surfaces=[
+            _surface_result(
+                surface="kb",
+                precision_at_5=0.2,
+                mrr=0.15,
+                coverage=0.3,
+                verdict="red",
+            )
+        ],
+        overall_verdict="red",
+    )
+
+    with respx.mock(assert_all_called=False):
+        client = _authenticated_client(session_id)
+        client.cookies.set(CSRF_COOKIE_NAME, csrf)
+        with (
+            patch(_RESOLVE_OPERATOR, new_callable=AsyncMock, return_value=operator),
+            patch(_EVAL_ALL, new_callable=AsyncMock, return_value=result),
+        ):
+            response = client.post(
+                "/ui/retrieval/eval",
+                data={},
+                headers={CSRF_HEADER_NAME: csrf},
+            )
+
+    assert response.status_code == 200, response.text
+    body = response.text
+    # Fragment, not full page.
+    assert 'id="retrieval-eval-results"' in body
+    assert "<!doctype html>" not in body.lower()
+    # Per-surface metrics rendered.
+    assert "0.200" in body  # precision@5
+    assert "0.150" in body  # mrr
+    assert "0.300" in body  # coverage
+    # The verdict token is rendered verbatim with its mapped color class.
+    assert 'data-verdict="red"' in body
+    assert "badge-error" in body
+    # The overall verdict is red too (worst-of every surface).
+    assert body.count('data-verdict="red"') >= 2
+
+
+def test_eval_renders_green_for_empty_corpus_surface_verbatim() -> None:
+    """An empty-corpus surface's ``green`` verdict is rendered verbatim, not recomputed."""
+    _seed_tenant(_TENANT_A, "tenant-a")
+    session_id = _seed_session_sync(tenant_id=_TENANT_A)
+    csrf = _csrf_token(session_id)
+    operator = _operator(tenant_id=_TENANT_A)
+    result = _eval_result(
+        surfaces=[
+            _surface_result(
+                surface="memory",
+                precision_at_5=0.0,
+                mrr=0.0,
+                coverage=0.0,
+                verdict="green",
+                query_count=0,
+            )
+        ],
+        overall_verdict="green",
+    )
+
+    with respx.mock(assert_all_called=False):
+        client = _authenticated_client(session_id)
+        client.cookies.set(CSRF_COOKIE_NAME, csrf)
+        with (
+            patch(_RESOLVE_OPERATOR, new_callable=AsyncMock, return_value=operator),
+            patch(_EVAL_ALL, new_callable=AsyncMock, return_value=result),
+        ):
+            response = client.post(
+                "/ui/retrieval/eval",
+                data={},
+                headers={CSRF_HEADER_NAME: csrf},
+            )
+
+    assert response.status_code == 200, response.text
+    body = response.text
+    assert 'data-verdict="green"' in body
+    assert "badge-success" in body
+
+
+def test_eval_own_tenant_only_no_baseline() -> None:
+    """The Eval handler calls ``eval_all`` own-tenant with no baseline argument.
+
+    Acceptance criterion: the 501 baseline path is never reached -- ``eval_all``
+    is invoked with ``tenant_id`` only (no ``baseline*`` kwarg).
+    """
+    _seed_tenant(_TENANT_A, "tenant-a")
+    session_id = _seed_session_sync(tenant_id=_TENANT_A)
+    csrf = _csrf_token(session_id)
+    operator = _operator(tenant_id=_TENANT_A)
+    eval_mock = AsyncMock(return_value=_eval_result())
+
+    with respx.mock(assert_all_called=False):
+        client = _authenticated_client(session_id)
+        client.cookies.set(CSRF_COOKIE_NAME, csrf)
+        with (
+            patch(_RESOLVE_OPERATOR, new_callable=AsyncMock, return_value=operator),
+            patch(_EVAL_ALL, eval_mock),
+        ):
+            response = client.post(
+                "/ui/retrieval/eval",
+                data={},
+                headers={CSRF_HEADER_NAME: csrf},
+            )
+
+    assert response.status_code == 200, response.text
+    eval_mock.assert_awaited_once()
+    kwargs = eval_mock.await_args.kwargs
+    assert kwargs["tenant_id"] == _TENANT_A
+    # No baseline argument is ever passed -- the 501 server-side baseline path
+    # cannot be reached from this surface.
+    assert not any("baseline" in key for key in kwargs)
+    assert eval_mock.await_args.args == ()
+
+
+def test_eval_rejected_without_csrf_token() -> None:
+    """An eval POST without the CSRF header is rejected 403 by the middleware."""
+    _seed_tenant(_TENANT_A, "tenant-a")
+    session_id = _seed_session_sync(tenant_id=_TENANT_A)
+    csrf = _csrf_token(session_id)
+
+    with respx.mock(assert_all_called=False):
+        client = _authenticated_client(session_id)
+        client.cookies.set(CSRF_COOKIE_NAME, csrf)
+        response = client.post("/ui/retrieval/eval", data={})
+
+    assert response.status_code == 403
+
+
+# ===========================================================================
+# Tab panes + template wiring (#1889)
+# ===========================================================================
+
+
+def test_index_renders_usage_and_eval_forms_no_baseline_field() -> None:
+    """``GET /ui/retrieval`` wires the live Usage + Eval tab forms (no baseline field).
+
+    Acceptance criteria: the Eval tab offers no baseline toggle (assert no
+    ``baseline`` form field), and both tabs are own-tenant only (no
+    ``tenant_filter`` form field).
+    """
+    _seed_tenant(_TENANT_A, "tenant-a")
+    session_id = _seed_session_sync(tenant_id=_TENANT_A)
+    operator = _operator(tenant_id=_TENANT_A)
+
+    with respx.mock(assert_all_called=False):
+        client = _authenticated_client(session_id)
+        with patch(_RESOLVE_OPERATOR, new_callable=AsyncMock, return_value=operator):
+            response = client.get("/ui/retrieval")
+
+    assert response.status_code == 200, response.text
+    body = response.text
+    # Both tab forms post to their fragment routes.
+    assert 'hx-post="/ui/retrieval/usage"' in body
+    assert 'hx-post="/ui/retrieval/eval"' in body
+    # Both results regions present for the initial (empty) render.
+    assert 'id="retrieval-usage-results"' in body
+    assert 'id="retrieval-eval-results"' in body
+    # No baseline toggle anywhere -- the 501 baseline path must be unreachable.
+    assert 'name="baseline"' not in body
+    assert ">baseline<" not in body.lower()
+    # Own-tenant only -- no cross-tenant selector on either tab (T3 owns that).
+    assert 'name="tenant_filter"' not in body
+
+
+def test_retrieval_usage_eval_literals_before_any_param_route() -> None:
+    """No ``/ui/retrieval/{param}`` route precedes the literal usage / eval POSTs."""
+    from meho_backplane.ui.routes.retrieval import build_retrieval_router
+
+    router = build_retrieval_router()
+    retrieval_paths = [
+        route.path  # type: ignore[attr-defined]
+        for route in router.routes
+        if getattr(route, "path", "").startswith("/ui/retrieval")
+    ]
+    for literal in ("/ui/retrieval/usage", "/ui/retrieval/eval"):
+        assert literal in retrieval_paths
+        idx = retrieval_paths.index(literal)
+        for path in retrieval_paths[:idx]:
+            assert "{" not in path, f"param route {path!r} precedes the literal {literal!r}"

--- a/cli/api/openapi.json
+++ b/cli/api/openapi.json
@@ -12987,6 +12987,69 @@
         }
       }
     },
+    "/ui/retrieval/usage": {
+      "post": {
+        "tags": [
+          "ui-retrieval"
+        ],
+        "summary": "Retrieval Usage",
+        "description": "Run the Usage Analytics fragment (delegates to :func:`_render_usage`).",
+        "operationId": "retrieval_usage_ui_retrieval_usage_post",
+        "requestBody": {
+          "content": {
+            "application/x-www-form-urlencoded": {
+              "schema": {
+                "$ref": "#/components/schemas/Body_retrieval_usage_ui_retrieval_usage_post"
+              }
+            }
+          }
+        },
+        "responses": {
+          "200": {
+            "description": "Successful Response",
+            "content": {
+              "text/html": {
+                "schema": {
+                  "type": "string"
+                }
+              }
+            }
+          },
+          "422": {
+            "description": "Validation Error",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/HTTPValidationError"
+                }
+              }
+            }
+          }
+        }
+      }
+    },
+    "/ui/retrieval/eval": {
+      "post": {
+        "tags": [
+          "ui-retrieval"
+        ],
+        "summary": "Retrieval Eval",
+        "description": "Run the Eval Quality fragment (delegates to :func:`_render_eval`).",
+        "operationId": "retrieval_eval_ui_retrieval_eval_post",
+        "responses": {
+          "200": {
+            "description": "Successful Response",
+            "content": {
+              "text/html": {
+                "schema": {
+                  "type": "string"
+                }
+              }
+            }
+          }
+        }
+      }
+    },
     "/ui/runbooks": {
       "get": {
         "tags": [
@@ -16332,6 +16395,18 @@
         },
         "type": "object",
         "title": "Body_retrieval_diagnostics_ui_retrieval_diagnostics_post"
+      },
+      "Body_retrieval_usage_ui_retrieval_usage_post": {
+        "properties": {
+          "since": {
+            "type": "string",
+            "maxLength": 32,
+            "title": "Since",
+            "default": "30d"
+          }
+        },
+        "type": "object",
+        "title": "Body_retrieval_usage_ui_retrieval_usage_post"
       },
       "Body_runbooks_deprecate_ui_runbooks__slug__deprecate_post": {
         "properties": {

--- a/cli/internal/api/client.gen.go
+++ b/cli/internal/api/client.gen.go
@@ -1262,6 +1262,11 @@ type BodyRetrievalDiagnosticsUiRetrievalDiagnosticsPost struct {
 	Source *string `json:"source,omitempty"`
 }
 
+// BodyRetrievalUsageUiRetrievalUsagePost defines model for Body_retrieval_usage_ui_retrieval_usage_post.
+type BodyRetrievalUsageUiRetrievalUsagePost struct {
+	Since *string `json:"since,omitempty"`
+}
+
 // BodyRunbooksDeprecateUiRunbooksSlugDeprecatePost defines model for Body_runbooks_deprecate_ui_runbooks__slug__deprecate_post.
 type BodyRunbooksDeprecateUiRunbooksSlugDeprecatePost struct {
 	Version *string `json:"version,omitempty"`
@@ -7203,6 +7208,9 @@ type OperationsPreviewUiOperationsPreviewPostFormdataRequestBody = BodyOperation
 // RetrievalDiagnosticsUiRetrievalDiagnosticsPostFormdataRequestBody defines body for RetrievalDiagnosticsUiRetrievalDiagnosticsPost for application/x-www-form-urlencoded ContentType.
 type RetrievalDiagnosticsUiRetrievalDiagnosticsPostFormdataRequestBody = BodyRetrievalDiagnosticsUiRetrievalDiagnosticsPost
 
+// RetrievalUsageUiRetrievalUsagePostFormdataRequestBody defines body for RetrievalUsageUiRetrievalUsagePost for application/x-www-form-urlencoded ContentType.
+type RetrievalUsageUiRetrievalUsagePostFormdataRequestBody = BodyRetrievalUsageUiRetrievalUsagePost
+
 // RunbooksEditorCreateUiRunbooksNewPostFormdataRequestBody defines body for RunbooksEditorCreateUiRunbooksNewPost for application/x-www-form-urlencoded ContentType.
 type RunbooksEditorCreateUiRunbooksNewPostFormdataRequestBody = BodyRunbooksEditorCreateUiRunbooksNewPost
 
@@ -9016,6 +9024,14 @@ type ClientInterface interface {
 	RetrievalDiagnosticsUiRetrievalDiagnosticsPostWithBody(ctx context.Context, contentType string, body io.Reader, reqEditors ...RequestEditorFn) (*http.Response, error)
 
 	RetrievalDiagnosticsUiRetrievalDiagnosticsPostWithFormdataBody(ctx context.Context, body RetrievalDiagnosticsUiRetrievalDiagnosticsPostFormdataRequestBody, reqEditors ...RequestEditorFn) (*http.Response, error)
+
+	// RetrievalEvalUiRetrievalEvalPost request
+	RetrievalEvalUiRetrievalEvalPost(ctx context.Context, reqEditors ...RequestEditorFn) (*http.Response, error)
+
+	// RetrievalUsageUiRetrievalUsagePostWithBody request with any body
+	RetrievalUsageUiRetrievalUsagePostWithBody(ctx context.Context, contentType string, body io.Reader, reqEditors ...RequestEditorFn) (*http.Response, error)
+
+	RetrievalUsageUiRetrievalUsagePostWithFormdataBody(ctx context.Context, body RetrievalUsageUiRetrievalUsagePostFormdataRequestBody, reqEditors ...RequestEditorFn) (*http.Response, error)
 
 	// RunbooksIndexUiRunbooksGet request
 	RunbooksIndexUiRunbooksGet(ctx context.Context, params *RunbooksIndexUiRunbooksGetParams, reqEditors ...RequestEditorFn) (*http.Response, error)
@@ -13369,6 +13385,42 @@ func (c *Client) RetrievalDiagnosticsUiRetrievalDiagnosticsPostWithBody(ctx cont
 
 func (c *Client) RetrievalDiagnosticsUiRetrievalDiagnosticsPostWithFormdataBody(ctx context.Context, body RetrievalDiagnosticsUiRetrievalDiagnosticsPostFormdataRequestBody, reqEditors ...RequestEditorFn) (*http.Response, error) {
 	req, err := NewRetrievalDiagnosticsUiRetrievalDiagnosticsPostRequestWithFormdataBody(c.Server, body)
+	if err != nil {
+		return nil, err
+	}
+	req = req.WithContext(ctx)
+	if err := c.applyEditors(ctx, req, reqEditors); err != nil {
+		return nil, err
+	}
+	return c.Client.Do(req)
+}
+
+func (c *Client) RetrievalEvalUiRetrievalEvalPost(ctx context.Context, reqEditors ...RequestEditorFn) (*http.Response, error) {
+	req, err := NewRetrievalEvalUiRetrievalEvalPostRequest(c.Server)
+	if err != nil {
+		return nil, err
+	}
+	req = req.WithContext(ctx)
+	if err := c.applyEditors(ctx, req, reqEditors); err != nil {
+		return nil, err
+	}
+	return c.Client.Do(req)
+}
+
+func (c *Client) RetrievalUsageUiRetrievalUsagePostWithBody(ctx context.Context, contentType string, body io.Reader, reqEditors ...RequestEditorFn) (*http.Response, error) {
+	req, err := NewRetrievalUsageUiRetrievalUsagePostRequestWithBody(c.Server, contentType, body)
+	if err != nil {
+		return nil, err
+	}
+	req = req.WithContext(ctx)
+	if err := c.applyEditors(ctx, req, reqEditors); err != nil {
+		return nil, err
+	}
+	return c.Client.Do(req)
+}
+
+func (c *Client) RetrievalUsageUiRetrievalUsagePostWithFormdataBody(ctx context.Context, body RetrievalUsageUiRetrievalUsagePostFormdataRequestBody, reqEditors ...RequestEditorFn) (*http.Response, error) {
+	req, err := NewRetrievalUsageUiRetrievalUsagePostRequestWithFormdataBody(c.Server, body)
 	if err != nil {
 		return nil, err
 	}
@@ -27273,6 +27325,73 @@ func NewRetrievalDiagnosticsUiRetrievalDiagnosticsPostRequestWithBody(server str
 	return req, nil
 }
 
+// NewRetrievalEvalUiRetrievalEvalPostRequest generates requests for RetrievalEvalUiRetrievalEvalPost
+func NewRetrievalEvalUiRetrievalEvalPostRequest(server string) (*http.Request, error) {
+	var err error
+
+	serverURL, err := url.Parse(server)
+	if err != nil {
+		return nil, err
+	}
+
+	operationPath := fmt.Sprintf("/ui/retrieval/eval")
+	if operationPath[0] == '/' {
+		operationPath = "." + operationPath
+	}
+
+	queryURL, err := serverURL.Parse(operationPath)
+	if err != nil {
+		return nil, err
+	}
+
+	req, err := http.NewRequest("POST", queryURL.String(), nil)
+	if err != nil {
+		return nil, err
+	}
+
+	return req, nil
+}
+
+// NewRetrievalUsageUiRetrievalUsagePostRequestWithFormdataBody calls the generic RetrievalUsageUiRetrievalUsagePost builder with application/x-www-form-urlencoded body
+func NewRetrievalUsageUiRetrievalUsagePostRequestWithFormdataBody(server string, body RetrievalUsageUiRetrievalUsagePostFormdataRequestBody) (*http.Request, error) {
+	var bodyReader io.Reader
+	bodyStr, err := runtime.MarshalForm(body, nil)
+	if err != nil {
+		return nil, err
+	}
+	bodyReader = strings.NewReader(bodyStr.Encode())
+	return NewRetrievalUsageUiRetrievalUsagePostRequestWithBody(server, "application/x-www-form-urlencoded", bodyReader)
+}
+
+// NewRetrievalUsageUiRetrievalUsagePostRequestWithBody generates requests for RetrievalUsageUiRetrievalUsagePost with any type of body
+func NewRetrievalUsageUiRetrievalUsagePostRequestWithBody(server string, contentType string, body io.Reader) (*http.Request, error) {
+	var err error
+
+	serverURL, err := url.Parse(server)
+	if err != nil {
+		return nil, err
+	}
+
+	operationPath := fmt.Sprintf("/ui/retrieval/usage")
+	if operationPath[0] == '/' {
+		operationPath = "." + operationPath
+	}
+
+	queryURL, err := serverURL.Parse(operationPath)
+	if err != nil {
+		return nil, err
+	}
+
+	req, err := http.NewRequest("POST", queryURL.String(), body)
+	if err != nil {
+		return nil, err
+	}
+
+	req.Header.Add("Content-Type", contentType)
+
+	return req, nil
+}
+
 // NewRunbooksIndexUiRunbooksGetRequest generates requests for RunbooksIndexUiRunbooksGet
 func NewRunbooksIndexUiRunbooksGetRequest(server string, params *RunbooksIndexUiRunbooksGetParams) (*http.Request, error) {
 	var err error
@@ -29685,6 +29804,14 @@ type ClientWithResponsesInterface interface {
 	RetrievalDiagnosticsUiRetrievalDiagnosticsPostWithBodyWithResponse(ctx context.Context, contentType string, body io.Reader, reqEditors ...RequestEditorFn) (*RetrievalDiagnosticsUiRetrievalDiagnosticsPostResponse, error)
 
 	RetrievalDiagnosticsUiRetrievalDiagnosticsPostWithFormdataBodyWithResponse(ctx context.Context, body RetrievalDiagnosticsUiRetrievalDiagnosticsPostFormdataRequestBody, reqEditors ...RequestEditorFn) (*RetrievalDiagnosticsUiRetrievalDiagnosticsPostResponse, error)
+
+	// RetrievalEvalUiRetrievalEvalPostWithResponse request
+	RetrievalEvalUiRetrievalEvalPostWithResponse(ctx context.Context, reqEditors ...RequestEditorFn) (*RetrievalEvalUiRetrievalEvalPostResponse, error)
+
+	// RetrievalUsageUiRetrievalUsagePostWithBodyWithResponse request with any body
+	RetrievalUsageUiRetrievalUsagePostWithBodyWithResponse(ctx context.Context, contentType string, body io.Reader, reqEditors ...RequestEditorFn) (*RetrievalUsageUiRetrievalUsagePostResponse, error)
+
+	RetrievalUsageUiRetrievalUsagePostWithFormdataBodyWithResponse(ctx context.Context, body RetrievalUsageUiRetrievalUsagePostFormdataRequestBody, reqEditors ...RequestEditorFn) (*RetrievalUsageUiRetrievalUsagePostResponse, error)
 
 	// RunbooksIndexUiRunbooksGetWithResponse request
 	RunbooksIndexUiRunbooksGetWithResponse(ctx context.Context, params *RunbooksIndexUiRunbooksGetParams, reqEditors ...RequestEditorFn) (*RunbooksIndexUiRunbooksGetResponse, error)
@@ -35031,6 +35158,49 @@ func (r RetrievalDiagnosticsUiRetrievalDiagnosticsPostResponse) StatusCode() int
 	return 0
 }
 
+type RetrievalEvalUiRetrievalEvalPostResponse struct {
+	Body         []byte
+	HTTPResponse *http.Response
+}
+
+// Status returns HTTPResponse.Status
+func (r RetrievalEvalUiRetrievalEvalPostResponse) Status() string {
+	if r.HTTPResponse != nil {
+		return r.HTTPResponse.Status
+	}
+	return http.StatusText(0)
+}
+
+// StatusCode returns HTTPResponse.StatusCode
+func (r RetrievalEvalUiRetrievalEvalPostResponse) StatusCode() int {
+	if r.HTTPResponse != nil {
+		return r.HTTPResponse.StatusCode
+	}
+	return 0
+}
+
+type RetrievalUsageUiRetrievalUsagePostResponse struct {
+	Body         []byte
+	HTTPResponse *http.Response
+	JSON422      *HTTPValidationError
+}
+
+// Status returns HTTPResponse.Status
+func (r RetrievalUsageUiRetrievalUsagePostResponse) Status() string {
+	if r.HTTPResponse != nil {
+		return r.HTTPResponse.Status
+	}
+	return http.StatusText(0)
+}
+
+// StatusCode returns HTTPResponse.StatusCode
+func (r RetrievalUsageUiRetrievalUsagePostResponse) StatusCode() int {
+	if r.HTTPResponse != nil {
+		return r.HTTPResponse.StatusCode
+	}
+	return 0
+}
+
 type RunbooksIndexUiRunbooksGetResponse struct {
 	Body         []byte
 	HTTPResponse *http.Response
@@ -38683,6 +38853,32 @@ func (c *ClientWithResponses) RetrievalDiagnosticsUiRetrievalDiagnosticsPostWith
 		return nil, err
 	}
 	return ParseRetrievalDiagnosticsUiRetrievalDiagnosticsPostResponse(rsp)
+}
+
+// RetrievalEvalUiRetrievalEvalPostWithResponse request returning *RetrievalEvalUiRetrievalEvalPostResponse
+func (c *ClientWithResponses) RetrievalEvalUiRetrievalEvalPostWithResponse(ctx context.Context, reqEditors ...RequestEditorFn) (*RetrievalEvalUiRetrievalEvalPostResponse, error) {
+	rsp, err := c.RetrievalEvalUiRetrievalEvalPost(ctx, reqEditors...)
+	if err != nil {
+		return nil, err
+	}
+	return ParseRetrievalEvalUiRetrievalEvalPostResponse(rsp)
+}
+
+// RetrievalUsageUiRetrievalUsagePostWithBodyWithResponse request with arbitrary body returning *RetrievalUsageUiRetrievalUsagePostResponse
+func (c *ClientWithResponses) RetrievalUsageUiRetrievalUsagePostWithBodyWithResponse(ctx context.Context, contentType string, body io.Reader, reqEditors ...RequestEditorFn) (*RetrievalUsageUiRetrievalUsagePostResponse, error) {
+	rsp, err := c.RetrievalUsageUiRetrievalUsagePostWithBody(ctx, contentType, body, reqEditors...)
+	if err != nil {
+		return nil, err
+	}
+	return ParseRetrievalUsageUiRetrievalUsagePostResponse(rsp)
+}
+
+func (c *ClientWithResponses) RetrievalUsageUiRetrievalUsagePostWithFormdataBodyWithResponse(ctx context.Context, body RetrievalUsageUiRetrievalUsagePostFormdataRequestBody, reqEditors ...RequestEditorFn) (*RetrievalUsageUiRetrievalUsagePostResponse, error) {
+	rsp, err := c.RetrievalUsageUiRetrievalUsagePostWithFormdataBody(ctx, body, reqEditors...)
+	if err != nil {
+		return nil, err
+	}
+	return ParseRetrievalUsageUiRetrievalUsagePostResponse(rsp)
 }
 
 // RunbooksIndexUiRunbooksGetWithResponse request returning *RunbooksIndexUiRunbooksGetResponse
@@ -45726,6 +45922,48 @@ func ParseRetrievalDiagnosticsUiRetrievalDiagnosticsPostResponse(rsp *http.Respo
 	}
 
 	response := &RetrievalDiagnosticsUiRetrievalDiagnosticsPostResponse{
+		Body:         bodyBytes,
+		HTTPResponse: rsp,
+	}
+
+	switch {
+	case strings.Contains(rsp.Header.Get("Content-Type"), "json") && rsp.StatusCode == 422:
+		var dest HTTPValidationError
+		if err := json.Unmarshal(bodyBytes, &dest); err != nil {
+			return nil, err
+		}
+		response.JSON422 = &dest
+
+	}
+
+	return response, nil
+}
+
+// ParseRetrievalEvalUiRetrievalEvalPostResponse parses an HTTP response from a RetrievalEvalUiRetrievalEvalPostWithResponse call
+func ParseRetrievalEvalUiRetrievalEvalPostResponse(rsp *http.Response) (*RetrievalEvalUiRetrievalEvalPostResponse, error) {
+	bodyBytes, err := io.ReadAll(rsp.Body)
+	defer func() { _ = rsp.Body.Close() }()
+	if err != nil {
+		return nil, err
+	}
+
+	response := &RetrievalEvalUiRetrievalEvalPostResponse{
+		Body:         bodyBytes,
+		HTTPResponse: rsp,
+	}
+
+	return response, nil
+}
+
+// ParseRetrievalUsageUiRetrievalUsagePostResponse parses an HTTP response from a RetrievalUsageUiRetrievalUsagePostWithResponse call
+func ParseRetrievalUsageUiRetrievalUsagePostResponse(rsp *http.Response) (*RetrievalUsageUiRetrievalUsagePostResponse, error) {
+	bodyBytes, err := io.ReadAll(rsp.Body)
+	defer func() { _ = rsp.Body.Close() }()
+	if err != nil {
+		return nil, err
+	}
+
+	response := &RetrievalUsageUiRetrievalUsagePostResponse{
 		Body:         bodyBytes,
 		HTTPResponse: rsp,
 	}


### PR DESCRIPTION
## Summary
- Adds the **Usage Analytics** + **Eval Quality** tabs to `/ui/retrieval`, extending T1's (#1888) page scaffold + tab strip. Both are read-only and front in-process services — **no new `/api/v1` endpoint**.
- **Usage** (`POST /ui/retrieval/usage`): runs `compute_usage` own-tenant over a `since` window (opens the required `AsyncSession` via `get_sessionmaker()`, as corpus does). A malformed `since` (`SinceValueError`) renders an inline 400 error card, **not a 500**. The load-bearing honesty-gap explainer fires whenever `total_searches == 0`: the `rest_excluded` / `counted_surfaces` badge makes the zero read as "REST excluded — only audited `/mcp` search tools are counted", never "no activity".
- **Eval** (`POST /ui/retrieval/eval`): runs `eval_all` own-tenant with **no baseline** (the server-side baseline path is 501 today; the surface offers no toggle, so it is unreachable). `eval_all` takes no session. Renders per-surface `precision@5` / `mrr` / `coverage` + a green/yellow/red verdict pill; the verdict token is rendered **verbatim** (an empty-corpus surface legitimately returns `green`) and the verdict→color mapping lives in the template.
- Both tabs are **own-tenant only** (no `tenant_filter` — the `platform_admin` cross-tenant selector is T3's concern) and enforce CSRF double-submit via the shared `_resolve_fragment_csrf` helper (renamed from `_resolve_diagnostics_csrf`), reusing the live cookie token on a fragment swap.

## Test plan
- [x] `ruff check` — clean (route + test)
- [x] `ruff format --check` — clean
- [x] `mypy src/.../retrieval/routes.py` — clean
- [x] `pytest backend/tests/test_ui_retrieval.py` — **26 passed** (13 from T1 + 13 new); `+ test_ui_corpus.py` sibling sweep 49 passed, no regression
- [x] Usage zero renders the `REST excluded` / `counted_surfaces` explainer (not "no activity") — asserted
- [x] Malformed `since` ("banana") → inline 400 error card, `compute_usage` never reached — asserted
- [x] Eval `red` surface renders the red pill (`data-verdict="red"` + `badge-error`) and a red `overall_verdict` — asserted; empty-corpus `green` rendered verbatim — asserted
- [x] No `baseline` form field; no `tenant_filter` form field — asserted via the rendered page
- [x] OpenAPI snapshot regenerated (`cd cli && make snapshot-openapi && make generate`); `/ui/retrieval/usage` + `/ui/retrieval/eval` present in `cli/api/openapi.json`; `cli/internal/api/client.gen.go` regenerated; `go build ./...` clean

## Out of scope
- Diagnostics tab (T1 #1888); Retire-checklist tab + the `platform_admin` cross-tenant `tenant_filter` selector (T3); server-side eval baseline (501 today); any new `/api/v1` endpoint.

## Adjacent findings
- `backend/src/meho_backplane/ui/routes/retrieval/routes.py` lands at 659 lines (mostly docstrings). Left as the single per-surface `routes.py` to match the established convention — sibling UI route modules are larger (`corpus` 781, `kb` 889, `operations` 911, `approvals` 707), and the literal-before-param ordering test depends on the one-factory shape.

<!-- auto-implement-issue: fresh, iteration 1 -->

Closes #1889


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added **Usage Analytics** tab to Retrieval UI with configurable lookback window to view retrieval usage statistics and per-surface breakdown.
  * Added **Eval Quality** tab to Retrieval UI displaying evaluation metrics (precision, MRR, coverage) and verdict indicators per surface.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->