### PR TITLE
feat(ui): Retire Checklist tab on /ui/retrieval — 5-criterion three-state verdict + platform_admin tenant_filter (#1890)

### DIFF
--- a/backend/src/meho_backplane/ui/routes/retrieval/routes.py
+++ b/backend/src/meho_backplane/ui/routes/retrieval/routes.py
@@ -1,17 +1,18 @@
 # SPDX-License-Identifier: Apache-2.0
 # Copyright (c) 2026 evoila Group
 
-"""Retrieval UI routes: in-process diagnostics + usage + eval, no new REST endpoint.
+"""Retrieval UI routes: in-process diagnostics + usage + eval + retire, no REST endpoint.
 
 Initiative #1840 (G10.14 Retrieval diagnostics & quality console), Tasks #1888
-(Diagnostics) + #1889 (Usage Analytics + Eval Quality).
+(Diagnostics) + #1889 (Usage Analytics + Eval Quality) + #1890 (Retire
+Checklist).
 
 ``GET /ui/retrieval`` renders the page: a tabbed shell (Diagnostics tab
-default-active; Usage Analytics + Eval Quality live as of T2; the Retire tab is
-a placeholder T3 fills in) with the diagnostics query form and an empty
-``#retrieval-diagnostics-results`` region. Three HTMX fragment endpoints front
-the three in-process services -- none adds a ``/api/v1`` endpoint, exactly as
-``ui/routes/corpus/routes.py`` fronts ``search_docs``:
+default-active; Usage Analytics + Eval Quality + Retire Checklist all live) with
+the diagnostics query form and an empty ``#retrieval-diagnostics-results``
+region. Four HTMX fragment endpoints front the four in-process services -- none
+adds a ``/api/v1`` endpoint, exactly as ``ui/routes/corpus/routes.py`` fronts
+``search_docs``:
 
 * ``POST /ui/retrieval/diagnostics`` -- reconstructs the session operator, binds
   the privacy ``audit_*`` contextvars, runs in-process
@@ -35,6 +36,32 @@ the three in-process services -- none adds a ``/api/v1`` endpoint, exactly as
   ``retrieval/_eval_results.html`` with per-surface ``precision_at_5`` / ``mrr``
   / ``coverage`` + a green/yellow/red verdict pill (mapped in the template from
   the verdict token the service returns verbatim) + the ``overall_verdict``.
+* ``POST /ui/retrieval/retire-checklist`` (#1890) -- runs in-process
+  :func:`~meho_backplane.retrieval.retire.compute_retire_checklist` over every
+  :data:`~meho_backplane.retrieval.retire.SURFACE_VERDICT_ORDER` surface (kb,
+  memory, operations), opening a read-only session via
+  :func:`~meho_backplane.db.engine.get_sessionmaker` (the service is keyword-only
+  and **requires** a ``session``; it runs ``eval_all`` internally for criteria
+  3+4, so the handler does not). Swaps ``retrieval/_retire_results.html`` with
+  the three-state ``overall_verdict`` pill heading the fragment and, per surface,
+  a three-state verdict pill + the five-criterion table (``name``,
+  green/yellow/red dot, ``observed_value``, ``threshold_summary``, ``notes``
+  rendered verbatim). The surface is **read-only** -- no purge / dry-run /
+  execute-retirement affordance exists; the only POST is this checklist run.
+
+  Tenant scoping differs from the sibling tabs: a **platform admin** may audit
+  any tenant's retirement readiness via a ``tenant_filter`` UUID selector. The
+  selector renders only when ``operator.platform_admin`` is true (a soft-hide UX
+  hint); the service stays the authority --
+  :func:`~meho_backplane.auth.rbac.authorize_tenant_scope` raises HTTP 403
+  ``cross_tenant_requires_platform_admin`` on a forged cross-tenant ``tenant_filter``
+  from a non-platform-admin, which this handler surfaces as an inline error card
+  (never a 500). The UI sends **no** ``blocker_counts`` / ``baseline_overrides``
+  -- those are CLI-fill-only, so criterion 4 (``meho_vs_baseline``) reads yellow
+  ("baseline did not run") and "READY TO RETIRE" is effectively unreachable via
+  the bare UI: the honest v0.2 posture, which the template surfaces with an
+  explanatory note + the ``rest_excluded`` / ``counted_surfaces`` honesty-gap
+  explainer (criteria 1+2 are fed only by the audited ``/mcp`` search tools).
 
 Reusing the substrate (no new ``/api/v1`` endpoint)
 ---------------------------------------------------
@@ -97,6 +124,7 @@ from __future__ import annotations
 
 import hashlib
 import time
+import uuid
 from datetime import UTC, datetime
 from typing import Final
 
@@ -105,8 +133,14 @@ from fastapi import APIRouter, Depends, Form, HTTPException, Request, status
 from fastapi.responses import HTMLResponse
 
 from meho_backplane.auth.operator import Operator
+from meho_backplane.auth.rbac import authorize_tenant_scope
 from meho_backplane.db.engine import get_sessionmaker
 from meho_backplane.retrieval.eval import EvalResult, eval_all
+from meho_backplane.retrieval.retire import (
+    SURFACE_VERDICT_ORDER,
+    RetireChecklistReport,
+    compute_retire_checklist,
+)
 from meho_backplane.retrieval.retriever import (
     CANDIDATE_LIMIT,
     RetrievalHit,
@@ -160,6 +194,12 @@ _LIMIT_OPTIONS: Final[tuple[int, ...]] = (5, 10, 20, 50)
 #: form boundary rather than forwarded to :func:`parse_since`.
 _MAX_SINCE_LENGTH: Final[int] = 32
 
+#: Maximum ``tenant_filter`` value length accepted by the retire fragment.
+#: A UUID string is 36 chars; the small slack tolerates surrounding whitespace
+#: a paste might carry. An over-long value is rejected at the form boundary
+#: rather than forwarded to :class:`uuid.UUID` parsing.
+_MAX_TENANT_FILTER_LENGTH: Final[int] = 64
+
 #: The ``since`` presets the usage selector offers. ``30d`` (the backend
 #: :data:`~meho_backplane.retrieval.usage.DEFAULT_SINCE`) is the retire-decision
 #: window Goal #215 keys off; the others are common shorter lookbacks. An
@@ -201,6 +241,32 @@ async def _resolve_operator(session: UISessionContext) -> Operator:
         expected_audience=settings.keycloak_audience,
     )
     return operator
+
+
+async def _resolve_platform_admin_softly(session: UISessionContext) -> bool:
+    """Return ``operator.platform_admin`` for the page render, failing **soft**.
+
+    The retire tab renders the cross-tenant ``tenant_filter`` selector only for a
+    platform admin. Deciding that requires reconstructing the operator on the
+    read-only ``GET /ui/retrieval`` render, but the page must keep rendering even
+    when the JWT round-trip can't complete (a transient JWKS outage, a session
+    revoked in the gap since the middleware check). So any failure projects to
+    ``False`` -- the selector is hidden -- mirroring the soft-hide posture
+    :func:`~meho_backplane.ui.routes.connectors.operator.resolve_role_probe`
+    uses. The hide is only a UX hint: the ``POST`` handler reconstructs the
+    operator for real and :func:`~meho_backplane.auth.rbac.authorize_tenant_scope`
+    stays the server-side authority on every cross-tenant claim.
+    """
+    try:
+        operator = await _resolve_operator(session)
+    except Exception as exc:
+        log.info(
+            "ui_retrieval_platform_admin_probe_unavailable",
+            session_id=str(session.session_id),
+            reason=type(exc).__name__,
+        )
+        return False
+    return operator.platform_admin
 
 
 def _compute_query_hash(query: str) -> str:
@@ -332,6 +398,15 @@ def build_retrieval_router() -> APIRouter:
         """Run the Eval Quality fragment (delegates to :func:`_render_eval`)."""
         return await _render_eval(request, session)
 
+    @router.post("/ui/retrieval/retire-checklist", response_class=HTMLResponse)
+    async def retrieval_retire_checklist(
+        request: Request,
+        session: UISessionContext = _require_session,
+        tenant_filter: str = Form(default="", max_length=_MAX_TENANT_FILTER_LENGTH),
+    ) -> HTMLResponse:
+        """Run the Retire Checklist fragment (delegates to :func:`_render_retire`)."""
+        return await _render_retire(request, session, tenant_filter)
+
     return router
 
 
@@ -363,8 +438,14 @@ async def _render_retrieval_index(
     Renders the tabbed shell with the Diagnostics tab active and an empty
     results region. Mints a CSRF token and sets the ``meho_csrf`` cookie so the
     diagnostics form's ``hx-headers`` echo passes the double-submit check.
+
+    Resolves ``operator.platform_admin`` (soft-hiding on any JWT hiccup) so the
+    Retire-checklist tab renders the cross-tenant ``tenant_filter`` selector only
+    for a platform admin -- a UX hint, not the authority (the POST handler
+    re-checks server-side via ``authorize_tenant_scope``).
     """
     csrf_token = mint_csrf_token(str(session.session_id))
+    platform_admin = await _resolve_platform_admin_softly(session)
     context: dict[str, object] = {
         **_diagnostics_form_context(
             query="",
@@ -384,6 +465,13 @@ async def _render_retrieval_index(
         "since_options": _SINCE_OPTIONS,
         "report": None,
         "result": None,
+        # Retire Checklist tab (#1890): ``checklist`` is ``None`` on the initial
+        # render so the included partial falls through to its quiet prompt;
+        # ``platform_admin`` gates the cross-tenant ``tenant_filter`` selector
+        # (a soft-hide hint -- the POST handler re-checks server-side).
+        "checklist": None,
+        "platform_admin": platform_admin,
+        "tenant_filter": "",
         "operator_sub": session.operator_sub,
         "active_surface": "retrieval",
         "page_title": "Retrieval",
@@ -657,3 +745,125 @@ async def _run_eval(operator: Operator) -> EvalResult:
         surface_count=len(result.surfaces),
     )
     return result
+
+
+# ---------------------------------------------------------------------------
+# Retire Checklist tab (#1890)
+# ---------------------------------------------------------------------------
+
+
+async def _render_retire(
+    request: Request,
+    session: UISessionContext,
+    tenant_filter: str,
+) -> HTMLResponse:
+    """Run the HTMX Retire Checklist fragment for ``POST /ui/retrieval/retire-checklist``.
+
+    Reconstructs the operator and runs the in-process
+    :func:`~meho_backplane.retrieval.retire.compute_retire_checklist` over every
+    :data:`~meho_backplane.retrieval.retire.SURFACE_VERDICT_ORDER` surface, then
+    swaps ``retrieval/_retire_results.html`` into ``#retrieval-retire-results``.
+
+    Tenant scoping mirrors the REST route (``retrieve_retire.py``):
+
+    * A blank ``tenant_filter`` (the common case, and the only shape a
+      non-platform-admin can produce from the rendered form) resolves to the
+      operator's own tenant.
+    * A platform admin may name a different tenant; the resolution defers to
+      :func:`~meho_backplane.auth.rbac.authorize_tenant_scope`, which returns the
+      requested tenant for a platform admin and raises HTTP 403
+      ``cross_tenant_requires_platform_admin`` otherwise. A forged cross-tenant
+      ``tenant_filter`` from a non-platform-admin therefore surfaces as an inline
+      error card (the 403 detail), **not** a 500.
+    * A malformed (non-UUID) ``tenant_filter`` renders an inline error card too,
+      rather than escaping as a 422/500.
+
+    The UI sends **no** ``blocker_counts`` / ``baseline_overrides`` (CLI-fill-only),
+    so criterion 4 reads yellow and the template surfaces that honest-posture
+    note. ``compute_retire_checklist`` is keyword-only and **requires** a
+    ``session: AsyncSession``, opened here via
+    :func:`~meho_backplane.db.engine.get_sessionmaker` exactly as the corpus
+    console does; it runs ``eval_all`` internally for criteria 3+4, so this
+    handler never calls ``eval_all`` itself.
+    """
+    requested = tenant_filter.strip()
+
+    checklist: RetireChecklistReport | None = None
+    error_message: str | None = None
+    operator = await _resolve_operator(session)
+    try:
+        target_tenant = _resolve_target_tenant(operator, requested)
+        checklist = await _run_retire(operator, target_tenant)
+    except HTTPException as exc:
+        # A 401 from the operator-reconstruction seam is an auth condition that
+        # must propagate (the BFF maps it to a login redirect); a 403 from the
+        # cross-tenant gate is a denied-but-handled condition that renders inline.
+        if exc.status_code == status.HTTP_403_FORBIDDEN:
+            error_message = str(exc.detail)
+        else:
+            raise
+    except ValueError as exc:
+        # A malformed (non-UUID) tenant_filter -- render inline, never a 500.
+        error_message = f"Invalid tenant filter: {exc}"
+
+    csrf_token, set_csrf = _resolve_fragment_csrf(request, str(session.session_id))
+    context: dict[str, object] = {
+        "checklist": checklist,
+        "error_message": error_message,
+        "platform_admin": operator.platform_admin,
+        "tenant_filter": requested,
+        "csrf_token": csrf_token,
+    }
+    response = get_templates().TemplateResponse(request, "retrieval/_retire_results.html", context)
+    if set_csrf:
+        _set_csrf_cookie(response, csrf_token)
+    return response
+
+
+def _resolve_target_tenant(operator: Operator, requested: str) -> uuid.UUID:
+    """Resolve the effective tenant for a retire-checklist run.
+
+    A blank *requested* (the own-tenant path) skips the cross-tenant gate and
+    returns ``operator.tenant_id`` directly. A non-blank value is parsed to a
+    :class:`uuid.UUID` (a malformed value raises :class:`ValueError`, which the
+    caller renders inline) and then run through
+    :func:`~meho_backplane.auth.rbac.authorize_tenant_scope`, which is the
+    server-side authority on the cross-tenant claim (403 for a non-platform-admin).
+    """
+    if not requested:
+        return operator.tenant_id
+    parsed = uuid.UUID(requested)
+    return authorize_tenant_scope(operator, parsed)
+
+
+async def _run_retire(
+    operator: Operator,
+    target_tenant: uuid.UUID,
+) -> RetireChecklistReport:
+    """Open a read-only session and run in-process ``compute_retire_checklist``.
+
+    Scoped to *target_tenant* (the operator's own tenant, or the
+    platform-admin-authorized ``tenant_filter`` tenant) over every
+    :data:`~meho_backplane.retrieval.retire.SURFACE_VERDICT_ORDER` surface. The
+    session is opened via :func:`~meho_backplane.db.engine.get_sessionmaker` and
+    closed by the ``async with``. No ``blocker_counts`` / ``baseline_overrides``
+    are passed (CLI-fill-only), so criterion 5 reads yellow ("unknown") and
+    criterion 4 reads yellow ("baseline did not run") -- the honest v0.2 posture.
+    """
+    sessionmaker = get_sessionmaker()
+    async with sessionmaker() as db_session:
+        checklist = await compute_retire_checklist(
+            session=db_session,
+            surfaces=list(SURFACE_VERDICT_ORDER),
+            tenant_id=target_tenant,
+        )
+    log.info(
+        "ui_retrieval_retire_checklist_completed",
+        operator_sub=operator.sub,
+        operator_tenant_id=str(operator.tenant_id),
+        target_tenant_id=str(target_tenant),
+        cross_tenant=target_tenant != operator.tenant_id,
+        overall_verdict=checklist.overall_verdict,
+        surface_count=len(checklist.surfaces),
+    )
+    return checklist

--- a/backend/src/meho_backplane/ui/templates/retrieval/_retire_results.html
+++ b/backend/src/meho_backplane/ui/templates/retrieval/_retire_results.html
@@ -1,0 +1,209 @@
+{#-
+  SPDX-License-Identifier: Apache-2.0
+  Copyright (c) 2026 evoila Group
+
+  Retrieval Retire-Checklist results partial.
+
+  Initiative #1840 (G10.14 Retrieval diagnostics & quality console),
+  Task #1890. Swapped into ``#retrieval-retire-results`` by the HTMX
+  ``POST /ui/retrieval/retire-checklist``; also included into ``index.html``
+  for the initial render so both paths share identical markup.
+
+  Render branches (first match wins):
+    1. ``error_message`` set -> an inline error card (a cross-tenant 403 from
+       ``authorize_tenant_scope`` for a forged ``tenant_filter``, or a malformed
+       UUID). Never a 500.
+    2. ``checklist`` set -> the three-state ``overall_verdict`` pill heading the
+       fragment, the honesty-gap explainer (``rest_excluded`` /
+       ``counted_surfaces``), and per surface (in ``SURFACE_VERDICT_ORDER``) a
+       three-state verdict pill + the five-criterion table.
+    3. otherwise (initial render) -> a quiet prompt.
+
+  THREE-state verdict (load-bearing -- do NOT collapse to a binary toggle):
+    ``ChecklistVerdict`` is one of "READY TO RETIRE" / "REVIEW MANUALLY" /
+    "NOT YET". Each maps to a distinct daisyUI badge color via ``verdict_pill``:
+    "READY TO RETIRE" -> success (green), "REVIEW MANUALLY" -> warning (yellow),
+    "NOT YET" -> error (red). The token is rendered verbatim; only the color is
+    mapped here. The overall verdict is the worst across surfaces in scope.
+
+  Per-criterion dot (green/yellow/red):
+    Each ``CriterionResult`` carries a ``verdict`` of "green" / "yellow" / "red".
+    The dot maps that to a color via ``criterion_dot``; ``observed_value``,
+    ``threshold_summary``, and ``notes`` render verbatim from the service.
+
+  Criterion-4 yellow honesty note (load-bearing):
+    ``meho_vs_baseline`` stays yellow for v0.2 UI callers -- the backplane has no
+    server-side corpus snapshot and the UI does not (by design) offer a
+    baseline-entry form, so "READY TO RETIRE" is effectively unreachable via the
+    bare UI. When that criterion reads yellow, surface the explanatory note so an
+    operator understands the verdict ceiling is honest, not a bug.
+
+  Read-only:
+    There is deliberately NO purge / dry-run / execute-retirement affordance.
+    The only POST is the ``hx-post`` to ``/ui/retrieval/retire-checklist`` in
+    index.html. This partial renders no write form / button.
+
+  Context variables:
+    checklist       -- RetireChecklistReport | None: per-surface checklist
+    error_message   -- str | None: a cross-tenant 403 / malformed-UUID detail
+    platform_admin  -- bool: whether the tenant_filter selector was offered
+    tenant_filter   -- str: the submitted tenant_filter (for the input value)
+    csrf_token      -- str: minted double-submit token (un-rendered here; the
+                       form lives in index.html)
+-#}
+{#- Three-state surface/overall verdict -> daisyUI badge-color pill. The verdict
+    token is rendered verbatim; only the color class is mapped here. -#}
+{% macro verdict_pill(verdict) %}
+  {%- if verdict == "NOT YET" -%}
+    {% set badge_class = "badge-error" %}
+  {%- elif verdict == "REVIEW MANUALLY" -%}
+    {% set badge_class = "badge-warning" %}
+  {%- else -%}
+    {% set badge_class = "badge-success" %}
+  {%- endif -%}
+  <span
+    class="badge {{ badge_class }} badge-outline uppercase"
+    data-verdict="{{ verdict }}"
+    aria-label="Verdict {{ verdict }}"
+  >{{ verdict }}</span>
+{% endmacro %}
+{#- Per-criterion green/yellow/red dot. The band token is rendered into the
+    ``data-band`` attribute verbatim; only the color is mapped here. -#}
+{% macro criterion_dot(band) %}
+  {%- if band == "red" -%}
+    {% set dot_class = "bg-error" %}
+  {%- elif band == "yellow" -%}
+    {% set dot_class = "bg-warning" %}
+  {%- else -%}
+    {% set dot_class = "bg-success" %}
+  {%- endif -%}
+  <span
+    class="inline-block h-2.5 w-2.5 rounded-full {{ dot_class }}"
+    data-band="{{ band }}"
+    role="img"
+    aria-label="{{ band }}"
+    title="{{ band }}"
+  ></span>
+{% endmacro %}
+<div id="retrieval-retire-results" class="space-y-3">
+  {% set checklist = checklist | default(none) %}
+  {% set error_message = error_message | default(none) %}
+  {% if error_message %}
+    {# ---------- Inline error card (cross-tenant 403 / malformed UUID) ---------- #}
+    <div class="alert alert-error" role="alert" aria-live="assertive">
+      <div>
+        <h3 class="font-semibold">Retire checklist unavailable</h3>
+        <p class="text-sm opacity-90">{{ error_message }}</p>
+      </div>
+    </div>
+
+  {% elif checklist is not none %}
+    {# ---------- Overall verdict header ---------- #}
+    <div class="flex flex-wrap items-center justify-between gap-2">
+      <p class="text-sm opacity-70" aria-live="polite">
+        Retire checklist &middot;
+        <span class="font-mono">{{ checklist.ran_at.strftime("%Y-%m-%d %H:%M") }}</span> UTC
+      </p>
+      <div class="flex items-center gap-2">
+        <span class="text-sm opacity-70">Overall</span>
+        {{ verdict_pill(checklist.overall_verdict) }}
+      </div>
+    </div>
+
+    {# ---------- Honesty-gap explainer (rest_excluded / counted_surfaces) ----------
+       Criteria 1 (daily-use duration) + 2 (operator breadth) are fed only by the
+       audited /mcp search tools; the REST POST /api/v1/retrieve diagnostic
+       queries (this console's Diagnostics tab included) audit under their own
+       path and do not feed the retire decision. So a stuck criterion 1/2 clock
+       is not "no activity" -- it's "REST excluded". The badge disambiguates. #}
+    {% if checklist.rest_excluded %}
+      <div class="alert alert-info" role="status">
+        <div>
+          <h3 class="font-semibold">REST excluded &mdash; only audited /mcp search tools feed criteria 1 &amp; 2</h3>
+          <p class="text-sm opacity-90">
+            Daily-use duration and operator breadth are fed only by these audited
+            <span class="font-mono">/mcp</span> search tools. REST
+            <span class="font-mono">POST /api/v1/retrieve</span> diagnostic
+            queries (including this console's Diagnostics tab) audit under their
+            own path and do <strong>not</strong> advance the retire clock:
+          </p>
+          {% if checklist.counted_surfaces %}
+            <div class="mt-1 flex flex-wrap gap-1">
+              {% for surface in checklist.counted_surfaces %}
+                <span class="badge badge-ghost badge-outline font-mono">{{ surface }}</span>
+              {% endfor %}
+            </div>
+          {% endif %}
+        </div>
+      </div>
+    {% endif %}
+
+    {# ---------- Per-surface checklists ---------- #}
+    {% for surface in checklist.surfaces %}
+      <div class="card bg-base-100 border-base-300 border shadow-sm">
+        <div class="card-body py-3 space-y-2">
+          <div class="flex flex-wrap items-center justify-between gap-2">
+            <span class="badge badge-ghost badge-outline">{{ surface.surface }}</span>
+            {{ verdict_pill(surface.verdict) }}
+          </div>
+          <div class="overflow-x-auto">
+            <table class="table table-xs" aria-label="Five-criterion retire checklist for {{ surface.surface }}">
+              <thead>
+                <tr>
+                  <th></th>
+                  <th>Criterion</th>
+                  <th>Observed</th>
+                  <th>Threshold</th>
+                </tr>
+              </thead>
+              <tbody>
+                {% for criterion in surface.criteria %}
+                  <tr>
+                    <td>{{ criterion_dot(criterion.verdict) }}</td>
+                    <td class="font-medium" data-criterion="{{ criterion.name }}">{{ criterion.name }}</td>
+                    <td class="font-mono">{{ criterion.observed_value }}</td>
+                    <td class="font-mono">{{ criterion.threshold_summary }}</td>
+                  </tr>
+                  {% if criterion.notes %}
+                    <tr>
+                      <td></td>
+                      <td colspan="3" class="text-xs opacity-70">{{ criterion.notes }}</td>
+                    </tr>
+                  {% endif %}
+                  {#- Criterion-4 yellow honesty note: explain that "baseline did
+                      not run" is the expected v0.2 UI ceiling, not a bug, so
+                      "READY TO RETIRE" being unreachable via the bare UI reads as
+                      honest posture. Rendered only when the criterion is yellow. -#}
+                  {% if criterion.name == "meho_vs_baseline" and criterion.verdict == "yellow" %}
+                    <tr>
+                      <td></td>
+                      <td colspan="3" class="text-xs opacity-70">
+                        <span class="font-semibold">Baseline is CLI-only in v0.2.</span>
+                        The backplane has no server-side corpus snapshot, so this
+                        criterion stays yellow via the console and
+                        &ldquo;READY TO RETIRE&rdquo; is effectively unreachable
+                        here. Run the retire checklist from the CLI with a local
+                        baseline to evaluate this criterion for real.
+                      </td>
+                    </tr>
+                  {% endif %}
+                {% endfor %}
+              </tbody>
+            </table>
+          </div>
+        </div>
+      </div>
+    {% endfor %}
+
+  {% else %}
+    {# ---------- Initial prompt (no run yet) ---------- #}
+    <div class="card bg-base-100 border-base-300 border border-dashed shadow-sm">
+      <div class="card-body text-center py-10">
+        <p class="text-base opacity-50">
+          Run the retire checklist to read back the five-criterion verdict per
+          surface (kb / memory / operations) and the overall retire decision.
+        </p>
+      </div>
+    </div>
+  {% endif %}
+</div>

--- a/backend/src/meho_backplane/ui/templates/retrieval/index.html
+++ b/backend/src/meho_backplane/ui/templates/retrieval/index.html
@@ -275,11 +275,66 @@
     {% include "retrieval/_eval_results.html" %}
   </div>
 
-  {# ---------- Placeholder tab panel (T3) ---------- #}
-  <div role="tabpanel" x-show="tab === 'retire'" x-cloak class="card bg-base-100 border-base-300 border border-dashed shadow-sm">
-    <div class="card-body text-center py-10">
-      <p class="text-base opacity-50">Retire Checklist lands in a follow-up task.</p>
+  {# ---------- Retire Checklist tab panel (T3, #1890) ---------- #}
+  {#- ``POST /ui/retrieval/retire-checklist`` swaps ``#retrieval-retire-results``.
+      The form declares its OWN ``hx-headers`` ``X-CSRF-Token`` (HTMX does not
+      propagate ``hx-headers`` to a descendant form, #1693). READ-ONLY -- there is
+      no purge / dry-run / execute-retirement affordance; the only POST is this
+      checklist run. The ``tenant_filter`` UUID selector renders ONLY for a
+      platform admin (a soft-hide hint -- the POST handler re-checks server-side
+      via ``authorize_tenant_scope``); a non-platform-admin sees no selector and
+      is scoped to their own tenant. The UI sends NO ``blocker_counts`` /
+      ``baseline_overrides`` (CLI-fill-only). -#}
+  <div role="tabpanel" x-show="tab === 'retire'" x-cloak class="space-y-4">
+    <div class="card bg-base-100 border-base-300 border shadow-sm">
+      <div class="card-body py-4">
+        <form
+          id="retrieval-retire-form"
+          hx-post="/ui/retrieval/retire-checklist"
+          hx-target="#retrieval-retire-results"
+          hx-swap="outerHTML"
+          hx-headers='{"X-CSRF-Token": "{{ csrf_token }}"}'
+          class="flex flex-col gap-3 sm:flex-row sm:items-end sm:justify-between"
+          aria-label="Run the retire-decision checklist"
+        >
+          <p class="max-w-prose text-sm opacity-70">
+            Read back the five-criterion retire-decision verdict per surface
+            (kb / memory / operations) and the overall decision. Read-only &mdash;
+            no retirement is executed.
+          </p>
+          <div class="flex flex-col gap-3 sm:flex-row sm:items-end">
+            {% if platform_admin %}
+              {#- Platform-admin-only cross-tenant selector. A non-platform-admin
+                  never sees this field, so the form they can submit carries no
+                  ``tenant_filter`` and they stay own-tenant scoped. A forged
+                  cross-tenant value still hits the backend 403. -#}
+              <label class="form-control w-full sm:w-80">
+                <div class="label">
+                  <span class="label-text">Tenant filter <span class="opacity-50">(platform admin)</span></span>
+                </div>
+                <input
+                  type="text"
+                  name="tenant_filter"
+                  value="{{ tenant_filter }}"
+                  maxlength="64"
+                  placeholder="Tenant UUID (blank = own tenant)"
+                  class="input input-bordered w-full font-mono"
+                  aria-label="Cross-tenant filter (platform admin only)"
+                  autocomplete="off"
+                />
+              </label>
+            {% endif %}
+            <button type="submit" class="btn btn-primary gap-1" aria-label="Run the retire checklist">
+              {{ icon("shield-check") }}
+              Run checklist
+            </button>
+          </div>
+        </form>
+      </div>
     </div>
+
+    {# ---------- Retire results region ---------- #}
+    {% include "retrieval/_retire_results.html" %}
   </div>
 </section>
 {% endblock %}

--- a/backend/tests/test_ui_retrieval.py
+++ b/backend/tests/test_ui_retrieval.py
@@ -51,6 +51,11 @@ from meho_backplane.auth.operator import Operator, TenantRole
 from meho_backplane.db.engine import get_sessionmaker, reset_engine_for_testing
 from meho_backplane.db.models import Tenant
 from meho_backplane.retrieval.eval.result_models import EvalResult, SurfaceResult
+from meho_backplane.retrieval.retire import (
+    CriterionResult,
+    RetireChecklistReport,
+    SurfaceChecklist,
+)
 from meho_backplane.retrieval.retriever import RetrievalHit
 from meho_backplane.retrieval.usage import UsageReport
 from meho_backplane.settings import get_settings
@@ -101,6 +106,12 @@ _COMPUTE_USAGE = "meho_backplane.ui.routes.retrieval.routes.compute_usage"
 #: The route-module symbol the Eval tab calls; mocked to return a constructed
 #: :class:`EvalResult` without a live corpus + embedder run (#1889).
 _EVAL_ALL = "meho_backplane.ui.routes.retrieval.routes.eval_all"
+
+#: The route-module symbol the Retire tab calls; mocked to return a constructed
+#: :class:`RetireChecklistReport` without a live audit-log + eval run (#1890).
+_COMPUTE_RETIRE = "meho_backplane.ui.routes.retrieval.routes.compute_retire_checklist"
+
+_TENANT_B = uuid.UUID("bbbbbbbb-bbbb-bbbb-bbbb-bbbbbbbbbbbb")
 
 #: The contextvars binder the handler calls; patched to capture the audit
 #: payload without a live structlog pipeline.
@@ -212,6 +223,7 @@ def _operator(
     *,
     tenant_id: uuid.UUID,
     sub: str = "op-42",
+    platform_admin: bool = False,
 ) -> Operator:
     """Build an :class:`Operator` the patched ``_resolve_operator`` returns."""
     return Operator(
@@ -220,6 +232,7 @@ def _operator(
         tenant_id=tenant_id,
         tenant_role=TenantRole.OPERATOR,
         capabilities=frozenset(),
+        platform_admin=platform_admin,
     )
 
 
@@ -1063,3 +1076,526 @@ def test_retrieval_usage_eval_literals_before_any_param_route() -> None:
         idx = retrieval_paths.index(literal)
         for path in retrieval_paths[:idx]:
             assert "{" not in path, f"param route {path!r} precedes the literal {literal!r}"
+
+
+# ===========================================================================
+# Retire Checklist tab (#1890)
+# ===========================================================================
+
+
+def _criterion(
+    *,
+    name: str = "daily_use_duration",
+    verdict: str = "green",
+    observed_value: str = "45 days since first use",
+    threshold_summary: str = ">= 30 days",
+    notes: str | None = None,
+) -> CriterionResult:
+    """Build a :class:`CriterionResult` for a stubbed surface checklist."""
+    return CriterionResult(
+        name=name,  # type: ignore[arg-type]
+        verdict=verdict,  # type: ignore[arg-type]
+        observed_value=observed_value,
+        threshold_summary=threshold_summary,
+        notes=notes,
+    )
+
+
+def _full_criteria(*, c4_yellow: bool = True) -> list[CriterionResult]:
+    """Build the five canonical criteria; criterion 4 yellow by default (UI ceiling)."""
+    return [
+        _criterion(name="daily_use_duration", verdict="green"),
+        _criterion(
+            name="operator_breadth",
+            verdict="green",
+            observed_value="3 qualified operators",
+            threshold_summary=">= 3 operators",
+        ),
+        _criterion(
+            name="eval_precision",
+            verdict="green",
+            observed_value="precision@5 = 0.840",
+            threshold_summary=">= 0.80",
+        ),
+        _criterion(
+            name="meho_vs_baseline",
+            verdict="yellow" if c4_yellow else "green",
+            observed_value="baseline did not run" if c4_yellow else "every metric >= baseline",
+            threshold_summary="every metric >= baseline",
+            notes=("no baseline corpus configured for this surface in v0.2" if c4_yellow else None),
+        ),
+        _criterion(
+            name="open_blockers",
+            verdict="green",
+            observed_value="0 open",
+            threshold_summary="== 0 open blockers",
+        ),
+    ]
+
+
+def _surface_checklist(
+    *,
+    surface: str = "kb",
+    verdict: str = "REVIEW MANUALLY",
+    criteria: list[CriterionResult] | None = None,
+) -> SurfaceChecklist:
+    """Build a :class:`SurfaceChecklist` for a stubbed retire report."""
+    return SurfaceChecklist(
+        surface=surface,  # type: ignore[arg-type]
+        verdict=verdict,  # type: ignore[arg-type]
+        criteria=criteria if criteria is not None else _full_criteria(),
+    )
+
+
+def _retire_report(
+    *,
+    surfaces: list[SurfaceChecklist] | None = None,
+    overall_verdict: str = "REVIEW MANUALLY",
+    tenant_id: uuid.UUID = _TENANT_A,
+) -> RetireChecklistReport:
+    """Build a :class:`RetireChecklistReport` the patched service returns."""
+    now = datetime(2026, 6, 19, 12, 0, tzinfo=UTC)
+    return RetireChecklistReport(
+        ran_at=now,
+        tenant_id=tenant_id,
+        since=now - timedelta(days=90),
+        until=now,
+        surfaces=surfaces if surfaces is not None else [_surface_checklist()],
+        overall_verdict=overall_verdict,  # type: ignore[arg-type]
+    )
+
+
+def test_retire_renders_three_distinct_verdict_states_not_binary() -> None:
+    """The Retire fragment renders all three verdict states with distinct pills.
+
+    Acceptance criterion: a report whose surfaces carry "READY TO RETIRE",
+    "REVIEW MANUALLY", and "NOT YET" must render each as a distinct verdict pill
+    (no collapse to a binary retire / hold).
+    """
+    _seed_tenant(_TENANT_A, "tenant-a")
+    session_id = _seed_session_sync(tenant_id=_TENANT_A)
+    csrf = _csrf_token(session_id)
+    operator = _operator(tenant_id=_TENANT_A)
+    report = _retire_report(
+        surfaces=[
+            _surface_checklist(surface="kb", verdict="READY TO RETIRE"),
+            _surface_checklist(surface="memory", verdict="REVIEW MANUALLY"),
+            _surface_checklist(surface="operations", verdict="NOT YET"),
+        ],
+        overall_verdict="NOT YET",
+    )
+
+    with respx.mock(assert_all_called=False):
+        client = _authenticated_client(session_id)
+        client.cookies.set(CSRF_COOKIE_NAME, csrf)
+        with (
+            patch(_RESOLVE_OPERATOR, new_callable=AsyncMock, return_value=operator),
+            patch(_COMPUTE_RETIRE, new_callable=AsyncMock, return_value=report),
+        ):
+            response = client.post(
+                "/ui/retrieval/retire-checklist",
+                data={},
+                headers={CSRF_HEADER_NAME: csrf},
+            )
+
+    assert response.status_code == 200, response.text
+    body = response.text
+    # Fragment, not full page.
+    assert 'id="retrieval-retire-results"' in body
+    assert "<!doctype html>" not in body.lower()
+    # All three states render as distinct pills, verbatim.
+    assert 'data-verdict="READY TO RETIRE"' in body
+    assert 'data-verdict="REVIEW MANUALLY"' in body
+    assert 'data-verdict="NOT YET"' in body
+    # Each maps to its own daisyUI color (success/warning/error) -- not collapsed.
+    assert "badge-success" in body
+    assert "badge-warning" in body
+    assert "badge-error" in body
+    # The overall verdict pill heads the fragment (worst-of -> NOT YET here).
+    assert "Overall" in body
+    assert body.count('data-verdict="NOT YET"') >= 2
+
+
+def test_retire_renders_five_criteria_verbatim_with_c4_yellow_note() -> None:
+    """Each surface renders its five criteria verbatim + the criterion-4 yellow note.
+
+    Acceptance criterion: the five criterion names render with their
+    verdict/observed/threshold/notes verbatim, and the criterion-4 yellow honesty
+    note copy is present when ``meho_vs_baseline.verdict == "yellow"``.
+    """
+    _seed_tenant(_TENANT_A, "tenant-a")
+    session_id = _seed_session_sync(tenant_id=_TENANT_A)
+    csrf = _csrf_token(session_id)
+    operator = _operator(tenant_id=_TENANT_A)
+    report = _retire_report(
+        surfaces=[_surface_checklist(surface="kb", criteria=_full_criteria(c4_yellow=True))]
+    )
+
+    with respx.mock(assert_all_called=False):
+        client = _authenticated_client(session_id)
+        client.cookies.set(CSRF_COOKIE_NAME, csrf)
+        with (
+            patch(_RESOLVE_OPERATOR, new_callable=AsyncMock, return_value=operator),
+            patch(_COMPUTE_RETIRE, new_callable=AsyncMock, return_value=report),
+        ):
+            response = client.post(
+                "/ui/retrieval/retire-checklist",
+                data={},
+                headers={CSRF_HEADER_NAME: csrf},
+            )
+
+    assert response.status_code == 200, response.text
+    body = response.text
+    # All five criterion names render verbatim.
+    for name in (
+        "daily_use_duration",
+        "operator_breadth",
+        "eval_precision",
+        "meho_vs_baseline",
+        "open_blockers",
+    ):
+        assert name in body
+    # Observed/threshold fields render verbatim.
+    assert "precision@5 = 0.840" in body
+    assert "3 qualified operators" in body
+    # The criterion-4 yellow honesty note is surfaced (baseline is CLI-only in v0.2).
+    assert "Baseline is CLI-only in v0.2" in body
+    # A green/yellow/red dot is rendered per criterion (the yellow c4 dot here).
+    assert 'data-band="yellow"' in body
+    assert 'data-band="green"' in body
+
+
+def test_retire_c4_yellow_note_absent_when_criterion_green() -> None:
+    """The criterion-4 honesty note is NOT shown when ``meho_vs_baseline`` is green."""
+    _seed_tenant(_TENANT_A, "tenant-a")
+    session_id = _seed_session_sync(tenant_id=_TENANT_A)
+    csrf = _csrf_token(session_id)
+    operator = _operator(tenant_id=_TENANT_A)
+    report = _retire_report(
+        surfaces=[
+            _surface_checklist(
+                surface="kb",
+                verdict="READY TO RETIRE",
+                criteria=_full_criteria(c4_yellow=False),
+            )
+        ],
+        overall_verdict="READY TO RETIRE",
+    )
+
+    with respx.mock(assert_all_called=False):
+        client = _authenticated_client(session_id)
+        client.cookies.set(CSRF_COOKIE_NAME, csrf)
+        with (
+            patch(_RESOLVE_OPERATOR, new_callable=AsyncMock, return_value=operator),
+            patch(_COMPUTE_RETIRE, new_callable=AsyncMock, return_value=report),
+        ):
+            response = client.post(
+                "/ui/retrieval/retire-checklist",
+                data={},
+                headers={CSRF_HEADER_NAME: csrf},
+            )
+
+    assert response.status_code == 200, response.text
+    body = response.text
+    assert "Baseline is CLI-only in v0.2" not in body
+
+
+def test_retire_tenant_filter_selector_hidden_for_non_platform_admin() -> None:
+    """The ``tenant_filter`` selector is absent for a non-platform-admin operator.
+
+    Acceptance criterion: a non-platform-admin sees no cross-tenant selector and
+    is own-tenant scoped.
+    """
+    _seed_tenant(_TENANT_A, "tenant-a")
+    session_id = _seed_session_sync(tenant_id=_TENANT_A)
+    operator = _operator(tenant_id=_TENANT_A, platform_admin=False)
+
+    with respx.mock(assert_all_called=False):
+        client = _authenticated_client(session_id)
+        with patch(_RESOLVE_OPERATOR, new_callable=AsyncMock, return_value=operator):
+            response = client.get("/ui/retrieval")
+
+    assert response.status_code == 200, response.text
+    body = response.text
+    # The retire form posts to the read-only fragment route...
+    assert 'hx-post="/ui/retrieval/retire-checklist"' in body
+    # ...but the cross-tenant selector is hidden for a non-platform-admin.
+    assert 'name="tenant_filter"' not in body
+
+
+def test_retire_tenant_filter_selector_shown_for_platform_admin() -> None:
+    """The ``tenant_filter`` selector renders for a platform-admin operator.
+
+    Acceptance criterion: a platform admin sees the cross-tenant selector.
+    """
+    _seed_tenant(_TENANT_A, "tenant-a")
+    session_id = _seed_session_sync(tenant_id=_TENANT_A)
+    operator = _operator(tenant_id=_TENANT_A, platform_admin=True)
+
+    with respx.mock(assert_all_called=False):
+        client = _authenticated_client(session_id)
+        with patch(_RESOLVE_OPERATOR, new_callable=AsyncMock, return_value=operator):
+            response = client.get("/ui/retrieval")
+
+    assert response.status_code == 200, response.text
+    body = response.text
+    assert 'name="tenant_filter"' in body
+
+
+def test_retire_platform_admin_forwards_tenant_filter() -> None:
+    """A platform admin's ``tenant_filter`` is authorized + forwarded to the service."""
+    _seed_tenant(_TENANT_A, "tenant-a")
+    session_id = _seed_session_sync(tenant_id=_TENANT_A)
+    csrf = _csrf_token(session_id)
+    operator = _operator(tenant_id=_TENANT_A, platform_admin=True)
+    retire_mock = AsyncMock(return_value=_retire_report(tenant_id=_TENANT_B))
+
+    with respx.mock(assert_all_called=False):
+        client = _authenticated_client(session_id)
+        client.cookies.set(CSRF_COOKIE_NAME, csrf)
+        with (
+            patch(_RESOLVE_OPERATOR, new_callable=AsyncMock, return_value=operator),
+            patch(_COMPUTE_RETIRE, retire_mock),
+        ):
+            response = client.post(
+                "/ui/retrieval/retire-checklist",
+                data={"tenant_filter": str(_TENANT_B)},
+                headers={CSRF_HEADER_NAME: csrf},
+            )
+
+    assert response.status_code == 200, response.text
+    retire_mock.assert_awaited_once()
+    kwargs = retire_mock.await_args.kwargs
+    # The cross-tenant claim is authorized (platform admin) and forwarded.
+    assert kwargs["tenant_id"] == _TENANT_B
+    # Every supported surface is requested, in order.
+    assert list(kwargs["surfaces"]) == ["kb", "memory", "operations"]
+    # The UI sends no CLI-fill-only body fields.
+    assert "blocker_counts" not in kwargs
+    assert "baseline_overrides" not in kwargs
+
+
+def test_retire_own_tenant_when_no_tenant_filter() -> None:
+    """A blank ``tenant_filter`` scopes the run to the operator's own tenant."""
+    _seed_tenant(_TENANT_A, "tenant-a")
+    session_id = _seed_session_sync(tenant_id=_TENANT_A)
+    csrf = _csrf_token(session_id)
+    operator = _operator(tenant_id=_TENANT_A, platform_admin=False)
+    retire_mock = AsyncMock(return_value=_retire_report())
+
+    with respx.mock(assert_all_called=False):
+        client = _authenticated_client(session_id)
+        client.cookies.set(CSRF_COOKIE_NAME, csrf)
+        with (
+            patch(_RESOLVE_OPERATOR, new_callable=AsyncMock, return_value=operator),
+            patch(_COMPUTE_RETIRE, retire_mock),
+        ):
+            response = client.post(
+                "/ui/retrieval/retire-checklist",
+                data={},
+                headers={CSRF_HEADER_NAME: csrf},
+            )
+
+    assert response.status_code == 200, response.text
+    retire_mock.assert_awaited_once()
+    kwargs = retire_mock.await_args.kwargs
+    assert kwargs["tenant_id"] == _TENANT_A
+
+
+def test_retire_forged_cross_tenant_filter_renders_403_card_not_500() -> None:
+    """A non-platform-admin's forged ``tenant_filter`` surfaces the 403 inline, not a 500.
+
+    Acceptance criterion: a non-platform-admin POST carrying a foreign
+    ``tenant_filter`` surfaces the backend ``cross_tenant_requires_platform_admin``
+    403 as an inline error card -- ``compute_retire_checklist`` is never reached.
+    """
+    _seed_tenant(_TENANT_A, "tenant-a")
+    session_id = _seed_session_sync(tenant_id=_TENANT_A)
+    csrf = _csrf_token(session_id)
+    operator = _operator(tenant_id=_TENANT_A, platform_admin=False)
+    retire_mock = AsyncMock(return_value=_retire_report())
+
+    with respx.mock(assert_all_called=False):
+        client = _authenticated_client(session_id)
+        client.cookies.set(CSRF_COOKIE_NAME, csrf)
+        with (
+            patch(_RESOLVE_OPERATOR, new_callable=AsyncMock, return_value=operator),
+            patch(_COMPUTE_RETIRE, retire_mock),
+        ):
+            response = client.post(
+                "/ui/retrieval/retire-checklist",
+                data={"tenant_filter": str(_TENANT_B)},
+                headers={CSRF_HEADER_NAME: csrf},
+            )
+
+    # Not a 500 -- the cross-tenant denial is caught and rendered inline.
+    assert response.status_code == 200, response.text
+    body = response.text
+    assert 'role="alert"' in body
+    assert "cross_tenant_requires_platform_admin" in body
+    # The cross-tenant gate short-circuits before the service runs.
+    retire_mock.assert_not_awaited()
+
+
+def test_retire_malformed_tenant_filter_renders_error_card_not_500() -> None:
+    """A malformed (non-UUID) ``tenant_filter`` renders an inline error card, not a 500."""
+    _seed_tenant(_TENANT_A, "tenant-a")
+    session_id = _seed_session_sync(tenant_id=_TENANT_A)
+    csrf = _csrf_token(session_id)
+    operator = _operator(tenant_id=_TENANT_A, platform_admin=True)
+    retire_mock = AsyncMock(return_value=_retire_report())
+
+    with respx.mock(assert_all_called=False):
+        client = _authenticated_client(session_id)
+        client.cookies.set(CSRF_COOKIE_NAME, csrf)
+        with (
+            patch(_RESOLVE_OPERATOR, new_callable=AsyncMock, return_value=operator),
+            patch(_COMPUTE_RETIRE, retire_mock),
+        ):
+            response = client.post(
+                "/ui/retrieval/retire-checklist",
+                data={"tenant_filter": "not-a-uuid"},
+                headers={CSRF_HEADER_NAME: csrf},
+            )
+
+    assert response.status_code == 200, response.text
+    body = response.text
+    assert 'role="alert"' in body
+    assert "Invalid tenant filter" in body
+    retire_mock.assert_not_awaited()
+
+
+def test_retire_renders_rest_excluded_honesty_explainer() -> None:
+    """The fragment surfaces the ``rest_excluded`` / ``counted_surfaces`` explainer."""
+    _seed_tenant(_TENANT_A, "tenant-a")
+    session_id = _seed_session_sync(tenant_id=_TENANT_A)
+    csrf = _csrf_token(session_id)
+    operator = _operator(tenant_id=_TENANT_A)
+    report = _retire_report()
+
+    with respx.mock(assert_all_called=False):
+        client = _authenticated_client(session_id)
+        client.cookies.set(CSRF_COOKIE_NAME, csrf)
+        with (
+            patch(_RESOLVE_OPERATOR, new_callable=AsyncMock, return_value=operator),
+            patch(_COMPUTE_RETIRE, new_callable=AsyncMock, return_value=report),
+        ):
+            response = client.post(
+                "/ui/retrieval/retire-checklist",
+                data={},
+                headers={CSRF_HEADER_NAME: csrf},
+            )
+
+    assert response.status_code == 200, response.text
+    body = response.text
+    # rest_excluded defaults True on the model, so the explainer renders.
+    assert "REST excluded" in body
+    assert "mcp:search_knowledge" in body
+
+
+def test_retire_no_write_affordance_read_only() -> None:
+    """The retire surface is read-only: the only POST is the checklist run.
+
+    Acceptance criterion: no purge / dry-run / execute-retirement affordance --
+    no write form/button beyond the read-only ``hx-post`` to the checklist route.
+    """
+    _seed_tenant(_TENANT_A, "tenant-a")
+    session_id = _seed_session_sync(tenant_id=_TENANT_A)
+    operator = _operator(tenant_id=_TENANT_A, platform_admin=True)
+
+    with respx.mock(assert_all_called=False):
+        client = _authenticated_client(session_id)
+        with patch(_RESOLVE_OPERATOR, new_callable=AsyncMock, return_value=operator):
+            response = client.get("/ui/retrieval")
+
+    assert response.status_code == 200, response.text
+    body = response.text
+    # The only retire POST is the read-only checklist run.
+    assert 'hx-post="/ui/retrieval/retire-checklist"' in body
+    # No purge / dry-run / execute-retirement affordance anywhere.
+    for forbidden in ("purge", "dry-run", "dry run", "execute-retirement", "execute retirement"):
+        assert forbidden not in body.lower()
+    # The UI never offers a baseline-entry form for criterion 4.
+    assert 'name="baseline"' not in body
+    assert 'name="blocker_counts"' not in body
+    assert 'name="baseline_overrides"' not in body
+
+
+def test_retire_rejected_without_csrf_token() -> None:
+    """A retire POST without the CSRF header is rejected 403 by the middleware."""
+    _seed_tenant(_TENANT_A, "tenant-a")
+    session_id = _seed_session_sync(tenant_id=_TENANT_A)
+    csrf = _csrf_token(session_id)
+
+    with respx.mock(assert_all_called=False):
+        client = _authenticated_client(session_id)
+        client.cookies.set(CSRF_COOKIE_NAME, csrf)
+        response = client.post("/ui/retrieval/retire-checklist", data={})
+
+    assert response.status_code == 403
+
+
+def test_retire_reuses_live_csrf_cookie_without_rotation() -> None:
+    """The retire fragment reuses the live CSRF cookie and does NOT rotate it."""
+    _seed_tenant(_TENANT_A, "tenant-a")
+    session_id = _seed_session_sync(tenant_id=_TENANT_A)
+    csrf = _csrf_token(session_id)
+    operator = _operator(tenant_id=_TENANT_A)
+
+    with respx.mock(assert_all_called=False):
+        client = _authenticated_client(session_id)
+        client.cookies.set(CSRF_COOKIE_NAME, csrf)
+        with (
+            patch(_RESOLVE_OPERATOR, new_callable=AsyncMock, return_value=operator),
+            patch(_COMPUTE_RETIRE, new_callable=AsyncMock, return_value=_retire_report()),
+        ):
+            response = client.post(
+                "/ui/retrieval/retire-checklist",
+                data={},
+                headers={CSRF_HEADER_NAME: csrf},
+            )
+
+    assert response.status_code == 200, response.text
+    set_cookie = response.headers.get("set-cookie", "")
+    assert CSRF_COOKIE_NAME not in set_cookie
+
+
+def test_retire_session_gone_propagates_401() -> None:
+    """A 401 from the operator-reconstruction seam surfaces as 401, not an error card."""
+    _seed_tenant(_TENANT_A, "tenant-a")
+    session_id = _seed_session_sync(tenant_id=_TENANT_A)
+    csrf = _csrf_token(session_id)
+
+    with respx.mock(assert_all_called=False):
+        client = _authenticated_client(session_id)
+        client.cookies.set(CSRF_COOKIE_NAME, csrf)
+        with patch(
+            _RESOLVE_OPERATOR,
+            new_callable=AsyncMock,
+            side_effect=HTTPException(
+                status_code=status.HTTP_401_UNAUTHORIZED, detail="session_expired"
+            ),
+        ):
+            response = client.post(
+                "/ui/retrieval/retire-checklist",
+                data={},
+                headers={CSRF_HEADER_NAME: csrf},
+            )
+
+    assert response.status_code == 401
+
+
+def test_retire_literal_before_any_param_route() -> None:
+    """No ``/ui/retrieval/{param}`` route precedes the literal ``retire-checklist`` POST."""
+    from meho_backplane.ui.routes.retrieval import build_retrieval_router
+
+    router = build_retrieval_router()
+    retrieval_paths = [
+        route.path  # type: ignore[attr-defined]
+        for route in router.routes
+        if getattr(route, "path", "").startswith("/ui/retrieval")
+    ]
+    assert "/ui/retrieval/retire-checklist" in retrieval_paths
+    idx = retrieval_paths.index("/ui/retrieval/retire-checklist")
+    for path in retrieval_paths[:idx]:
+        assert "{" not in path, f"param route {path!r} precedes the literal retire-checklist route"

--- a/cli/api/openapi.json
+++ b/cli/api/openapi.json
@@ -13186,6 +13186,47 @@
         }
       }
     },
+    "/ui/retrieval/retire-checklist": {
+      "post": {
+        "tags": [
+          "ui-retrieval"
+        ],
+        "summary": "Retrieval Retire Checklist",
+        "description": "Run the Retire Checklist fragment (delegates to :func:`_render_retire`).",
+        "operationId": "retrieval_retire_checklist_ui_retrieval_retire_checklist_post",
+        "requestBody": {
+          "content": {
+            "application/x-www-form-urlencoded": {
+              "schema": {
+                "$ref": "#/components/schemas/Body_retrieval_retire_checklist_ui_retrieval_retire_checklist_post"
+              }
+            }
+          }
+        },
+        "responses": {
+          "200": {
+            "description": "Successful Response",
+            "content": {
+              "text/html": {
+                "schema": {
+                  "type": "string"
+                }
+              }
+            }
+          },
+          "422": {
+            "description": "Validation Error",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/HTTPValidationError"
+                }
+              }
+            }
+          }
+        }
+      }
+    },
     "/ui/runbooks": {
       "get": {
         "tags": [
@@ -16531,6 +16572,18 @@
         },
         "type": "object",
         "title": "Body_retrieval_diagnostics_ui_retrieval_diagnostics_post"
+      },
+      "Body_retrieval_retire_checklist_ui_retrieval_retire_checklist_post": {
+        "properties": {
+          "tenant_filter": {
+            "type": "string",
+            "maxLength": 64,
+            "title": "Tenant Filter",
+            "default": ""
+          }
+        },
+        "type": "object",
+        "title": "Body_retrieval_retire_checklist_ui_retrieval_retire_checklist_post"
       },
       "Body_retrieval_usage_ui_retrieval_usage_post": {
         "properties": {

--- a/cli/internal/api/client.gen.go
+++ b/cli/internal/api/client.gen.go
@@ -1262,6 +1262,11 @@ type BodyRetrievalDiagnosticsUiRetrievalDiagnosticsPost struct {
 	Source *string `json:"source,omitempty"`
 }
 
+// BodyRetrievalRetireChecklistUiRetrievalRetireChecklistPost defines model for Body_retrieval_retire_checklist_ui_retrieval_retire_checklist_post.
+type BodyRetrievalRetireChecklistUiRetrievalRetireChecklistPost struct {
+	TenantFilter *string `json:"tenant_filter,omitempty"`
+}
+
 // BodyRetrievalUsageUiRetrievalUsagePost defines model for Body_retrieval_usage_ui_retrieval_usage_post.
 type BodyRetrievalUsageUiRetrievalUsagePost struct {
 	Since *string `json:"since,omitempty"`
@@ -7249,6 +7254,9 @@ type OperationsPreviewUiOperationsPreviewPostFormdataRequestBody = BodyOperation
 // RetrievalDiagnosticsUiRetrievalDiagnosticsPostFormdataRequestBody defines body for RetrievalDiagnosticsUiRetrievalDiagnosticsPost for application/x-www-form-urlencoded ContentType.
 type RetrievalDiagnosticsUiRetrievalDiagnosticsPostFormdataRequestBody = BodyRetrievalDiagnosticsUiRetrievalDiagnosticsPost
 
+// RetrievalRetireChecklistUiRetrievalRetireChecklistPostFormdataRequestBody defines body for RetrievalRetireChecklistUiRetrievalRetireChecklistPost for application/x-www-form-urlencoded ContentType.
+type RetrievalRetireChecklistUiRetrievalRetireChecklistPostFormdataRequestBody = BodyRetrievalRetireChecklistUiRetrievalRetireChecklistPost
+
 // RetrievalUsageUiRetrievalUsagePostFormdataRequestBody defines body for RetrievalUsageUiRetrievalUsagePost for application/x-www-form-urlencoded ContentType.
 type RetrievalUsageUiRetrievalUsagePostFormdataRequestBody = BodyRetrievalUsageUiRetrievalUsagePost
 
@@ -9083,6 +9091,11 @@ type ClientInterface interface {
 
 	// RetrievalEvalUiRetrievalEvalPost request
 	RetrievalEvalUiRetrievalEvalPost(ctx context.Context, reqEditors ...RequestEditorFn) (*http.Response, error)
+
+	// RetrievalRetireChecklistUiRetrievalRetireChecklistPostWithBody request with any body
+	RetrievalRetireChecklistUiRetrievalRetireChecklistPostWithBody(ctx context.Context, contentType string, body io.Reader, reqEditors ...RequestEditorFn) (*http.Response, error)
+
+	RetrievalRetireChecklistUiRetrievalRetireChecklistPostWithFormdataBody(ctx context.Context, body RetrievalRetireChecklistUiRetrievalRetireChecklistPostFormdataRequestBody, reqEditors ...RequestEditorFn) (*http.Response, error)
 
 	// RetrievalUsageUiRetrievalUsagePostWithBody request with any body
 	RetrievalUsageUiRetrievalUsagePostWithBody(ctx context.Context, contentType string, body io.Reader, reqEditors ...RequestEditorFn) (*http.Response, error)
@@ -13525,6 +13538,30 @@ func (c *Client) RetrievalDiagnosticsUiRetrievalDiagnosticsPostWithFormdataBody(
 
 func (c *Client) RetrievalEvalUiRetrievalEvalPost(ctx context.Context, reqEditors ...RequestEditorFn) (*http.Response, error) {
 	req, err := NewRetrievalEvalUiRetrievalEvalPostRequest(c.Server)
+	if err != nil {
+		return nil, err
+	}
+	req = req.WithContext(ctx)
+	if err := c.applyEditors(ctx, req, reqEditors); err != nil {
+		return nil, err
+	}
+	return c.Client.Do(req)
+}
+
+func (c *Client) RetrievalRetireChecklistUiRetrievalRetireChecklistPostWithBody(ctx context.Context, contentType string, body io.Reader, reqEditors ...RequestEditorFn) (*http.Response, error) {
+	req, err := NewRetrievalRetireChecklistUiRetrievalRetireChecklistPostRequestWithBody(c.Server, contentType, body)
+	if err != nil {
+		return nil, err
+	}
+	req = req.WithContext(ctx)
+	if err := c.applyEditors(ctx, req, reqEditors); err != nil {
+		return nil, err
+	}
+	return c.Client.Do(req)
+}
+
+func (c *Client) RetrievalRetireChecklistUiRetrievalRetireChecklistPostWithFormdataBody(ctx context.Context, body RetrievalRetireChecklistUiRetrievalRetireChecklistPostFormdataRequestBody, reqEditors ...RequestEditorFn) (*http.Response, error) {
+	req, err := NewRetrievalRetireChecklistUiRetrievalRetireChecklistPostRequestWithFormdataBody(c.Server, body)
 	if err != nil {
 		return nil, err
 	}
@@ -27607,6 +27644,46 @@ func NewRetrievalEvalUiRetrievalEvalPostRequest(server string) (*http.Request, e
 	return req, nil
 }
 
+// NewRetrievalRetireChecklistUiRetrievalRetireChecklistPostRequestWithFormdataBody calls the generic RetrievalRetireChecklistUiRetrievalRetireChecklistPost builder with application/x-www-form-urlencoded body
+func NewRetrievalRetireChecklistUiRetrievalRetireChecklistPostRequestWithFormdataBody(server string, body RetrievalRetireChecklistUiRetrievalRetireChecklistPostFormdataRequestBody) (*http.Request, error) {
+	var bodyReader io.Reader
+	bodyStr, err := runtime.MarshalForm(body, nil)
+	if err != nil {
+		return nil, err
+	}
+	bodyReader = strings.NewReader(bodyStr.Encode())
+	return NewRetrievalRetireChecklistUiRetrievalRetireChecklistPostRequestWithBody(server, "application/x-www-form-urlencoded", bodyReader)
+}
+
+// NewRetrievalRetireChecklistUiRetrievalRetireChecklistPostRequestWithBody generates requests for RetrievalRetireChecklistUiRetrievalRetireChecklistPost with any type of body
+func NewRetrievalRetireChecklistUiRetrievalRetireChecklistPostRequestWithBody(server string, contentType string, body io.Reader) (*http.Request, error) {
+	var err error
+
+	serverURL, err := url.Parse(server)
+	if err != nil {
+		return nil, err
+	}
+
+	operationPath := fmt.Sprintf("/ui/retrieval/retire-checklist")
+	if operationPath[0] == '/' {
+		operationPath = "." + operationPath
+	}
+
+	queryURL, err := serverURL.Parse(operationPath)
+	if err != nil {
+		return nil, err
+	}
+
+	req, err := http.NewRequest("POST", queryURL.String(), body)
+	if err != nil {
+		return nil, err
+	}
+
+	req.Header.Add("Content-Type", contentType)
+
+	return req, nil
+}
+
 // NewRetrievalUsageUiRetrievalUsagePostRequestWithFormdataBody calls the generic RetrievalUsageUiRetrievalUsagePost builder with application/x-www-form-urlencoded body
 func NewRetrievalUsageUiRetrievalUsagePostRequestWithFormdataBody(server string, body RetrievalUsageUiRetrievalUsagePostFormdataRequestBody) (*http.Request, error) {
 	var bodyReader io.Reader
@@ -30077,6 +30154,11 @@ type ClientWithResponsesInterface interface {
 
 	// RetrievalEvalUiRetrievalEvalPostWithResponse request
 	RetrievalEvalUiRetrievalEvalPostWithResponse(ctx context.Context, reqEditors ...RequestEditorFn) (*RetrievalEvalUiRetrievalEvalPostResponse, error)
+
+	// RetrievalRetireChecklistUiRetrievalRetireChecklistPostWithBodyWithResponse request with any body
+	RetrievalRetireChecklistUiRetrievalRetireChecklistPostWithBodyWithResponse(ctx context.Context, contentType string, body io.Reader, reqEditors ...RequestEditorFn) (*RetrievalRetireChecklistUiRetrievalRetireChecklistPostResponse, error)
+
+	RetrievalRetireChecklistUiRetrievalRetireChecklistPostWithFormdataBodyWithResponse(ctx context.Context, body RetrievalRetireChecklistUiRetrievalRetireChecklistPostFormdataRequestBody, reqEditors ...RequestEditorFn) (*RetrievalRetireChecklistUiRetrievalRetireChecklistPostResponse, error)
 
 	// RetrievalUsageUiRetrievalUsagePostWithBodyWithResponse request with any body
 	RetrievalUsageUiRetrievalUsagePostWithBodyWithResponse(ctx context.Context, contentType string, body io.Reader, reqEditors ...RequestEditorFn) (*RetrievalUsageUiRetrievalUsagePostResponse, error)
@@ -35515,6 +35597,28 @@ func (r RetrievalEvalUiRetrievalEvalPostResponse) StatusCode() int {
 	return 0
 }
 
+type RetrievalRetireChecklistUiRetrievalRetireChecklistPostResponse struct {
+	Body         []byte
+	HTTPResponse *http.Response
+	JSON422      *HTTPValidationError
+}
+
+// Status returns HTTPResponse.Status
+func (r RetrievalRetireChecklistUiRetrievalRetireChecklistPostResponse) Status() string {
+	if r.HTTPResponse != nil {
+		return r.HTTPResponse.Status
+	}
+	return http.StatusText(0)
+}
+
+// StatusCode returns HTTPResponse.StatusCode
+func (r RetrievalRetireChecklistUiRetrievalRetireChecklistPostResponse) StatusCode() int {
+	if r.HTTPResponse != nil {
+		return r.HTTPResponse.StatusCode
+	}
+	return 0
+}
+
 type RetrievalUsageUiRetrievalUsagePostResponse struct {
 	Body         []byte
 	HTTPResponse *http.Response
@@ -39249,6 +39353,23 @@ func (c *ClientWithResponses) RetrievalEvalUiRetrievalEvalPostWithResponse(ctx c
 		return nil, err
 	}
 	return ParseRetrievalEvalUiRetrievalEvalPostResponse(rsp)
+}
+
+// RetrievalRetireChecklistUiRetrievalRetireChecklistPostWithBodyWithResponse request with arbitrary body returning *RetrievalRetireChecklistUiRetrievalRetireChecklistPostResponse
+func (c *ClientWithResponses) RetrievalRetireChecklistUiRetrievalRetireChecklistPostWithBodyWithResponse(ctx context.Context, contentType string, body io.Reader, reqEditors ...RequestEditorFn) (*RetrievalRetireChecklistUiRetrievalRetireChecklistPostResponse, error) {
+	rsp, err := c.RetrievalRetireChecklistUiRetrievalRetireChecklistPostWithBody(ctx, contentType, body, reqEditors...)
+	if err != nil {
+		return nil, err
+	}
+	return ParseRetrievalRetireChecklistUiRetrievalRetireChecklistPostResponse(rsp)
+}
+
+func (c *ClientWithResponses) RetrievalRetireChecklistUiRetrievalRetireChecklistPostWithFormdataBodyWithResponse(ctx context.Context, body RetrievalRetireChecklistUiRetrievalRetireChecklistPostFormdataRequestBody, reqEditors ...RequestEditorFn) (*RetrievalRetireChecklistUiRetrievalRetireChecklistPostResponse, error) {
+	rsp, err := c.RetrievalRetireChecklistUiRetrievalRetireChecklistPostWithFormdataBody(ctx, body, reqEditors...)
+	if err != nil {
+		return nil, err
+	}
+	return ParseRetrievalRetireChecklistUiRetrievalRetireChecklistPostResponse(rsp)
 }
 
 // RetrievalUsageUiRetrievalUsagePostWithBodyWithResponse request with arbitrary body returning *RetrievalUsageUiRetrievalUsagePostResponse
@@ -46415,6 +46536,32 @@ func ParseRetrievalEvalUiRetrievalEvalPostResponse(rsp *http.Response) (*Retriev
 	response := &RetrievalEvalUiRetrievalEvalPostResponse{
 		Body:         bodyBytes,
 		HTTPResponse: rsp,
+	}
+
+	return response, nil
+}
+
+// ParseRetrievalRetireChecklistUiRetrievalRetireChecklistPostResponse parses an HTTP response from a RetrievalRetireChecklistUiRetrievalRetireChecklistPostWithResponse call
+func ParseRetrievalRetireChecklistUiRetrievalRetireChecklistPostResponse(rsp *http.Response) (*RetrievalRetireChecklistUiRetrievalRetireChecklistPostResponse, error) {
+	bodyBytes, err := io.ReadAll(rsp.Body)
+	defer func() { _ = rsp.Body.Close() }()
+	if err != nil {
+		return nil, err
+	}
+
+	response := &RetrievalRetireChecklistUiRetrievalRetireChecklistPostResponse{
+		Body:         bodyBytes,
+		HTTPResponse: rsp,
+	}
+
+	switch {
+	case strings.Contains(rsp.Header.Get("Content-Type"), "json") && rsp.StatusCode == 422:
+		var dest HTTPValidationError
+		if err := json.Unmarshal(bodyBytes, &dest); err != nil {
+			return nil, err
+		}
+		response.JSON422 = &dest
+
 	}
 
 	return response, nil


### PR DESCRIPTION
## Summary

- Adds the final **Retire Checklist** tab on `/ui/retrieval` (Initiative #1840, G10.14). `POST /ui/retrieval/retire-checklist` reconstructs the operator and runs the in-process `meho_backplane.retrieval.retire.compute_retire_checklist` over every `SURFACE_VERDICT_ORDER` surface (kb, memory, operations) — **no new `/api/v1` endpoint**, mirroring how the corpus console fronts `search_docs`. The service is keyword-only and **requires** a `session: AsyncSession` (opened via `get_sessionmaker`); it runs `eval_all` internally for criteria 3+4, so the handler does not.
- **Three-state verdict** (`READY TO RETIRE` / `REVIEW MANUALLY` / `NOT YET`) rendered distinctly per state — never collapsed to a binary toggle. The `overall_verdict` pill heads the fragment; each surface shows its three-state pill + the five-criterion table with `name` / green-yellow-red dot / `observed_value` / `threshold_summary` / `notes` rendered verbatim.
- **Honest v0.2 posture surfaced:** criterion 4 (`meho_vs_baseline`) stays yellow for bare-UI callers (no server-side corpus snapshot; baseline is CLI-only), so "READY TO RETIRE" is effectively unreachable via the console — a note explains the yellow, plus the `rest_excluded` / `counted_surfaces` honesty-gap explainer (criteria 1+2 are fed only by the audited `/mcp` search tools). **No** purge / dry-run / execute-retirement affordance; the UI sends **no** `blocker_counts` / `baseline_overrides`.
- **platform_admin cross-tenant `tenant_filter` selector** (new vs T1/T2): renders only when `operator.platform_admin` is true (a soft-hide UX hint resolved on the page render, failing soft on a JWT hiccup like `resolve_role_probe`). The POST handler stays the authority — `authorize_tenant_scope` raises 403 `cross_tenant_requires_platform_admin` on a forged cross-tenant filter from a non-platform-admin, surfaced as an inline error card (never a 500); a malformed UUID renders inline too.
- Regenerated the OpenAPI snapshot + typed Go client for the new route.

## Test plan

- [x] `ruff check` — clean (routes.py + tests)
- [x] `ruff format --check` — clean
- [x] `mypy src/.../retrieval/routes.py` — Success, no issues (CI mypy scopes `files = ["src"]`)
- [x] `code-quality.py --diff` — 0 blockers (6 WARN-class, pre-existing-file size + sibling-consistent function sizes)
- [x] `uv run pytest backend/tests/test_ui_retrieval.py` — **41 passed** (26 existing + 15 new)
- [x] Three verdict states render distinct pills (`data-verdict` = each of the three) — no binary collapse
- [x] Five criteria render verbatim; criterion-4 yellow note present iff `meho_vs_baseline.verdict == "yellow"`, absent when green
- [x] `tenant_filter` selector absent for non-platform-admin, present for platform-admin; cross-tenant 403 + malformed-UUID render inline error cards, not 500s; service not reached on the denied paths
- [x] No write affordance (grep: no purge / dry-run / execute-retirement / `baseline` / `blocker_counts` / `baseline_overrides` fields)
- [x] CSRF double-submit enforced + live-cookie reuse (no rotation); session-gone 401 propagates
- [x] Literal `/ui/retrieval/retire-checklist` precedes any param route
- [x] OpenAPI snapshot regenerated — `/ui/retrieval/retire-checklist` present in `cli/api/openapi.json` + `cli/internal/api/client.gen.go` (additive diff only)

## Out of scope

- Diagnostics / Usage / Eval tabs (#1888 / #1889 — merged; this Task extends their page scaffold + tab strip).
- Any purge / retirement-execution action (none exists in the backend; none invented).
- A baseline-metrics entry form for criterion 4 (CLI-only in v0.2; criterion 4 reads yellow via the UI by design).
- Any new `/api/v1` endpoint.

<!-- auto-implement-issue: fresh, iteration 1 -->

Closes #1890


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added "Retire Checklist" tab to the Retrieval UI for evaluating data retirement readiness.
  * Displays retirement verdict status (Ready, Review Manually, Not Yet) and per-surface criteria evaluation results.
  * Platform admins can view retirement status across tenants via tenant selector.
  * Includes error handling and validation for user inputs.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->