### PR TITLE
feat(connectors): ExecutionProfile schema + closed named auth catalog (G0.28-T3 #1969)

### DIFF
--- a/backend/src/meho_backplane/connectors/__init__.py
+++ b/backend/src/meho_backplane/connectors/__init__.py
@@ -9,6 +9,18 @@ root.
 """
 
 from meho_backplane.connectors.base import Connector, ShimKind, shim_kind
+from meho_backplane.connectors.profile import (
+    NAMED_AUTH_SCHEMES,
+    RESERVED_AUTH_SCHEMES,
+    AuthSchemeName,
+    AuthSpec,
+    ExecutionProfile,
+    ExecutionProfileError,
+    ReservedAuthSchemeError,
+    StaticHeaderValueKind,
+    UnknownAuthSchemeError,
+    validate_execution_profile,
+)
 from meho_backplane.connectors.profiled import ProfiledRestConnector
 from meho_backplane.connectors.registry import (
     all_connectors,
@@ -40,12 +52,18 @@ from meho_backplane.connectors.schemas import (
 )
 
 __all__ = [
+    "NAMED_AUTH_SCHEMES",
+    "RESERVED_AUTH_SCHEMES",
     "AmbiguousConnectorResolution",
     "AuthModel",
+    "AuthSchemeName",
+    "AuthSpec",
     "CandidateHint",
     "Connector",
     "EdgeHint",
     "EdgeKind",
+    "ExecutionProfile",
+    "ExecutionProfileError",
     "FingerprintResult",
     "NoMatchingConnector",
     "NodeHint",
@@ -53,10 +71,13 @@ __all__ = [
     "OperationResult",
     "ProbeResult",
     "ProfiledRestConnector",
+    "ReservedAuthSchemeError",
     "ResolutionLabel",
     "ResultHandle",
     "ShimKind",
+    "StaticHeaderValueKind",
     "TopologyHints",
+    "UnknownAuthSchemeError",
     "all_connectors",
     "all_connectors_v2",
     "get_connector",
@@ -66,4 +87,5 @@ __all__ = [
     "resolve_connector",
     "resolve_connector_or_label",
     "shim_kind",
+    "validate_execution_profile",
 ]

--- a/backend/src/meho_backplane/connectors/profile.py
+++ b/backend/src/meho_backplane/connectors/profile.py
@@ -1,0 +1,328 @@
+# SPDX-License-Identifier: Apache-2.0
+# Copyright (c) 2026 evoila Group
+
+"""The ``ExecutionProfile`` schema + the closed named auth-scheme catalog.
+
+G0.28-T3 (#1969) — the load-bearing schema half of Initiative #1965 (make
+ingested REST read ops dispatchable from a reviewed declarative profile).
+T1 (#1967) landed :class:`~meho_backplane.connectors.profiled.ProfiledRestConnector`,
+the dispatchable sibling of the auto-shim whose one hand-coded slot is
+``auth_headers``. This module defines the reviewed declarative data that
+fills that slot.
+
+**The catalog selects a vetted extractor by name — it is not a DSL.**
+``AuthSchemeName`` is a closed :data:`typing.Literal` enumerating the four
+auth shapes a profile can declare. Each value *names a vetted Python
+extractor* (hoisted from the existing connectors in T4 #1970); the profile
+carries **no** ``token_location`` / ``field_map`` / ``value_template`` /
+JSONPath fields. That boundary is the #1177/#1178 substrate-minimalism
+line, the same one ``runbooks/schemas.Verify`` holds for the verify DSL
+("No JSONPath. No comparison operators. No boolean composition." —
+``docs/architecture/runbooks.md``). A path-expression auth block would
+re-open the rejected-DSL footgun: the agent would be configuring an
+interpreter, not selecting a reviewed extractor.
+
+**The catalog is grounded in all 14 HTTP connectors' ``auth_headers``,
+not picked from memory.** The coverage trace lives in
+``docs/codebase/connector-auth-coverage.md``. Six connectors fit a named
+scheme (harbor / sddc_manager / vcf_fleet / vcf_operations → ``basic``;
+argocd → ``static_header``; keycloak → ``oauth2_mint``; vcf_logs / vmware_rest
+→ ``session_login``). The remaining eight need bespoke Python the closed
+catalog deliberately does **not** model — github (App RS256 JWT), gcloud
+(SA-JSON / ADC impersonation), vault (operator-JWT-forward), kubernetes
+(kubeconfig), nsx (cookie-jar session), vcf_automation (dual-plane
+session) — and are listed in :data:`RESERVED_AUTH_SCHEMES`. A profile that
+names a reserved scheme raises :exc:`ReservedAuthSchemeError`, whose
+remediation is "author a typed connector", distinct from the auto-shim's
+``unreplaced_auto_shim`` "register a per-product subclass" guidance.
+
+**Credentials never live in the profile — only secret-field *names*.**
+``AuthSpec.secret_fields`` names the keys the extractor reads out of the
+operator-resolved secret bundle (``username`` / ``password`` / ``token`` /
+``client_id`` / ``client_secret``); the values are resolved at dispatch
+from the secret broker, never serialized into the reviewed profile.
+
+**Closed-set enforcement is two-layered**, mirroring the ``safety_level``
+``Literal`` + DB-CHECK and ``AuthModel`` StrEnum precedents:
+
+* **API boundary.** ``AuthSpec.scheme`` is the :data:`AuthSchemeName`
+  ``Literal`` — Pydantic rejects an unlisted scheme at
+  ``model_validate`` time (the route returns 422), so a malformed profile
+  never reaches the registry.
+* **Startup load.** :func:`validate_execution_profile` (called from the
+  same boot path as :func:`~meho_backplane.operations.ingest.catalog.load_catalog`)
+  re-asserts the scheme against the live :data:`NAMED_AUTH_SCHEMES` /
+  :data:`RESERVED_AUTH_SCHEMES` partition and crashes the lifespan
+  (``CI app-boot smoke fails``) on an unlisted or reserved scheme.
+  :data:`NAMED_AUTH_SCHEMES` is derived from the ``Literal`` via
+  :func:`typing.get_args`, so the boundary and boot checks cannot disagree.
+"""
+
+from __future__ import annotations
+
+from typing import Literal, get_args
+
+from pydantic import BaseModel, ConfigDict, Field, field_validator, model_validator
+
+__all__ = [
+    "NAMED_AUTH_SCHEMES",
+    "RESERVED_AUTH_SCHEMES",
+    "AuthSchemeName",
+    "AuthSpec",
+    "ExecutionProfile",
+    "ExecutionProfileError",
+    "ReservedAuthSchemeError",
+    "StaticHeaderValueKind",
+    "UnknownAuthSchemeError",
+    "validate_execution_profile",
+]
+
+
+#: The closed catalog of named auth schemes a profile may declare. Each
+#: value selects a vetted Python extractor (hoisted in T4 #1970), never a
+#: path/template expression. Grounded in the 14-connector coverage trace
+#: (``docs/codebase/connector-auth-coverage.md``):
+#:
+#: * ``basic`` — HTTP Basic ``Authorization: Basic b64(user:pass)``
+#:   (harbor / sddc_manager / vcf_fleet / vcf_operations / hetzner_robot).
+#: * ``static_header`` — a fixed pre-issued token placed in a header
+#:   (argocd's static API token). ``value_kind`` picks bearer-wrapping vs
+#:   raw placement.
+#: * ``session_login`` — exchange credentials at a login endpoint for a
+#:   short-lived token, then send it as ``Bearer`` (vcf_logs / vmware_rest).
+#: * ``oauth2_mint`` — OAuth2 client-credentials form grant minting a
+#:   ``Bearer`` token (keycloak admin).
+#:
+#: Adding a value here is a deliberate act: it must be backed by a vetted
+#: extractor and the coverage trace updated. There is no "custom" / "other"
+#: escape hatch — that is the rejected-DSL door (#1177).
+AuthSchemeName = Literal[
+    "basic",
+    "static_header",
+    "session_login",
+    "oauth2_mint",
+]
+
+#: Runtime mirror of :data:`AuthSchemeName` for the startup-load check.
+#: Derived from the ``Literal`` via :func:`typing.get_args` so the two
+#: cannot drift — the ``Literal`` is the single source of truth for the
+#: API boundary and this set re-derives from it for the boot guard.
+NAMED_AUTH_SCHEMES: frozenset[str] = frozenset(get_args(AuthSchemeName))
+
+#: Auth shapes that a profile *cannot* model — they need bespoke Python a
+#: declarative ``dict[str, str]`` extractor can't express (stateful cookie
+#: jars, RS256 JWT minting, SA-JSON impersonation, kubeconfig clients,
+#: operator-JWT forwarding, dual-plane sessions). Naming one of these in a
+#: profile raises :exc:`ReservedAuthSchemeError` with "author a typed
+#: connector" remediation. Listed (not silently absent) so the boot guard
+#: and the error message can name the typed-connector alternative per
+#: connector. Grounded in the same coverage trace.
+RESERVED_AUTH_SCHEMES: frozenset[str] = frozenset(
+    {
+        "github_app_jwt",  # github — RS256 App-JWT mint -> installation token
+        "gcp_sa_impersonation",  # gcloud — ADC + SA impersonation
+        "operator_jwt_forward",  # vault — operator-context OIDC JWT forward
+        "kubeconfig",  # kubernetes — cert/token embedded in an ApiClient
+        "cookie_jar_session",  # nsx — Set-Cookie JSESSIONID + X-XSRF-TOKEN
+        "dual_plane_session",  # vcf_automation — provider + tenant logins
+    }
+)
+
+#: How a ``static_header`` scheme places its pre-issued token value.
+#: ``bearer`` → ``Authorization: Bearer <value>`` (argocd's shape). ``raw``
+#: → the value is placed verbatim into the named header (e.g. an
+#: ``X-Api-Key`` style header). A closed enum, not a free template — the
+#: substrate places the value, it does not interpolate it.
+StaticHeaderValueKind = Literal["bearer", "raw"]
+
+
+class ExecutionProfileError(RuntimeError):
+    """Base for ``ExecutionProfile`` boot-time / coherence failures.
+
+    Carries a human-readable remediation message. Raised by
+    :func:`validate_execution_profile` at the startup-load layer, parallel
+    to :class:`~meho_backplane.operations.ingest.catalog.CatalogError`.
+    """
+
+
+class UnknownAuthSchemeError(ExecutionProfileError):
+    """A profile names an auth scheme in neither the named nor reserved set.
+
+    The Pydantic ``Literal`` already rejects this at the API boundary; this
+    is the belt-and-suspenders boot guard for a profile that reached the
+    registry through a non-validated path (e.g. a hand-edited stored row).
+    Crashes the lifespan, like an unparseable catalog.
+    """
+
+
+class ReservedAuthSchemeError(ExecutionProfileError):
+    """A profile names a *reserved* auth scheme — one that needs typed Python.
+
+    Distinct from :exc:`UnknownAuthSchemeError` (a typo / unknown value)
+    and from the dispatcher's ``unreplaced_auto_shim`` cause (register a
+    per-product subclass). The remediation here is **author a typed
+    connector**: the auth shape (cookie-jar session, RS256 JWT mint,
+    SA-JSON impersonation, kubeconfig, operator-JWT forward, dual-plane
+    session) cannot be expressed as a declarative named extractor returning
+    ``dict[str, str]``, so a reviewed profile is the wrong tool — a
+    hand-coded :class:`~meho_backplane.connectors.adapters.http.HttpConnector`
+    subclass is.
+    """
+
+    def __init__(self, scheme: str) -> None:
+        self.scheme = scheme
+        super().__init__(
+            f"auth scheme {scheme!r} is reserved: it requires bespoke Python "
+            f"a declarative ExecutionProfile cannot express. Author a typed "
+            f"connector (an HttpConnector subclass implementing auth_headers) "
+            f"rather than attaching a profile."
+        )
+
+
+class AuthSpec(BaseModel):
+    """The declarative auth block of an :class:`ExecutionProfile`.
+
+    Selects a named, vetted extractor (:attr:`scheme`) and names the
+    secret-bundle keys it reads (:attr:`secret_fields`). Carries **no**
+    path/template/expression field — that is the rejected-DSL line. The
+    only scheme-shaping knob is :attr:`value_kind`, a closed enum that only
+    applies to ``static_header`` (bearer-wrap vs raw placement).
+    """
+
+    model_config = ConfigDict(frozen=True, extra="forbid")
+
+    scheme: AuthSchemeName = Field(
+        description=(
+            "Named auth scheme selecting a vetted extractor. Closed Literal "
+            "— reserved/unknown schemes are rejected here (422) and at boot."
+        )
+    )
+    secret_fields: tuple[str, ...] = Field(
+        description=(
+            "Names of the secret-bundle keys the extractor reads at dispatch "
+            "(e.g. ('username', 'password'), ('token',), "
+            "('client_id', 'client_secret')). NAMES only — credential values "
+            "are resolved from the secret broker, never stored in the profile."
+        )
+    )
+    header_name: str = Field(
+        default="Authorization",
+        description=(
+            "The header the extractor writes the auth value into. Defaults to "
+            "Authorization (basic / session_login / oauth2_mint / a bearer "
+            "static_header); a raw static_header may name a custom header "
+            "(e.g. X-Api-Key)."
+        ),
+    )
+    value_kind: StaticHeaderValueKind | None = Field(
+        default=None,
+        description=(
+            "static_header only: 'bearer' wraps the value as "
+            "'Bearer <value>', 'raw' places it verbatim. Must be None for "
+            "every other scheme; required for static_header."
+        ),
+    )
+
+    @field_validator("secret_fields")
+    @classmethod
+    def _secret_fields_nonempty(cls, value: tuple[str, ...]) -> tuple[str, ...]:
+        """Reject an empty or blank-named secret-field list.
+
+        Every named scheme reads at least one secret key; an empty list is
+        a malformed profile, not a credential-less auth shape (that would
+        be a reserved/typed concern).
+        """
+        if not value:
+            raise ValueError("secret_fields must name at least one secret key")
+        if any(not field.strip() for field in value):
+            raise ValueError("secret_fields entries must be non-blank")
+        return value
+
+    @field_validator("header_name")
+    @classmethod
+    def _header_name_nonblank(cls, value: str) -> str:
+        if not value.strip():
+            raise ValueError("header_name must be non-blank")
+        return value
+
+    @model_validator(mode="after")
+    def _value_kind_matches_scheme(self) -> AuthSpec:
+        """Bind ``value_kind`` to ``static_header`` exclusively.
+
+        ``value_kind`` is the static_header bearer/raw knob; it is
+        meaningless (and so forbidden) for the other schemes, and required
+        for static_header. Keeping the rule here — rather than splitting
+        AuthSpec into per-scheme subclasses — keeps the single-model API
+        boundary the route validates against.
+        """
+        if self.scheme == "static_header":
+            if self.value_kind is None:
+                raise ValueError("static_header requires value_kind ('bearer' or 'raw')")
+        elif self.value_kind is not None:
+            raise ValueError(f"value_kind is only valid for static_header, not {self.scheme!r}")
+        return self
+
+
+class ExecutionProfile(BaseModel):
+    """Reviewed declarative data that makes an ingested REST connector dispatchable.
+
+    Plugs into :class:`~meho_backplane.connectors.profiled.ProfiledRestConnector`
+    to fill its one hand-coded slot (``auth_headers``) with vetted
+    declarative data. T3 (#1969) defines the schema + the auth catalog;
+    the session/token machinery the schemes drive lands in T4 (#1970), the
+    profile-driven fingerprint/probe + pagination in T6 (#1972).
+
+    Frozen and ``extra="forbid"`` — a profile is a reviewed artifact; an
+    unrecognized key is a malformed profile, not a forward-compat
+    extension point.
+    """
+
+    model_config = ConfigDict(frozen=True, extra="forbid")
+
+    product: str = Field(
+        description="Product slug the profile covers (matches the connector's product)."
+    )
+    version: str = Field(
+        description="Version label the profile covers (the ingested spec's version)."
+    )
+    auth: AuthSpec = Field(
+        description="The named auth scheme + secret-field names for this profile."
+    )
+
+    @field_validator("product", "version")
+    @classmethod
+    def _identity_nonblank(cls, value: str) -> str:
+        if not value.strip():
+            raise ValueError("product and version must be non-blank")
+        return value
+
+
+def validate_execution_profile(profile: ExecutionProfile) -> None:
+    """Re-assert a profile's auth scheme at the startup-load layer.
+
+    Mirrors :func:`~meho_backplane.operations.ingest.catalog.load_catalog`'s
+    boot-crash discipline: the Pydantic ``Literal`` already rejects an
+    unlisted scheme at the API boundary, but a stored profile can reach the
+    registry through a non-validated path (a hand-edited row, a future
+    persistence layer). This guard crashes the lifespan — and therefore CI
+    app-boot smoke — on:
+
+    * a scheme in :data:`RESERVED_AUTH_SCHEMES` → :exc:`ReservedAuthSchemeError`
+      (author a typed connector);
+    * a scheme in neither the named nor reserved set →
+      :exc:`UnknownAuthSchemeError`.
+
+    A scheme in :data:`NAMED_AUTH_SCHEMES` passes. The two runtime sets are
+    derived from / kept in lockstep with the :data:`AuthSchemeName`
+    ``Literal`` so the boundary and boot checks cannot disagree.
+    """
+    scheme = profile.auth.scheme
+    if scheme in NAMED_AUTH_SCHEMES:
+        return
+    if scheme in RESERVED_AUTH_SCHEMES:
+        raise ReservedAuthSchemeError(scheme)
+    raise UnknownAuthSchemeError(
+        f"auth scheme {scheme!r} is not a known scheme; valid named schemes "
+        f"are {sorted(NAMED_AUTH_SCHEMES)} (reserved, typed-only: "
+        f"{sorted(RESERVED_AUTH_SCHEMES)})"
+    )

--- a/backend/tests/test_connectors_execution_profile.py
+++ b/backend/tests/test_connectors_execution_profile.py
@@ -1,0 +1,248 @@
+# SPDX-License-Identifier: Apache-2.0
+# Copyright (c) 2026 evoila Group
+
+"""Unit tests for the ``ExecutionProfile`` schema + closed auth catalog (#1969).
+
+Covers the four acceptance criteria of G0.28-T3:
+
+* the ``Literal`` auth-scheme catalog carries no path/template/extractor
+  fields;
+* boot-load (``validate_execution_profile``) crashes on an unknown scheme,
+  and the API boundary (Pydantic ``Literal``) rejects an unknown scheme;
+* a reserved scheme produces a distinct typed error naming the
+  typed-connector alternative.
+"""
+
+from __future__ import annotations
+
+import typing
+
+import pytest
+from pydantic import ValidationError
+
+from meho_backplane.connectors.profile import (
+    NAMED_AUTH_SCHEMES,
+    RESERVED_AUTH_SCHEMES,
+    AuthSchemeName,
+    AuthSpec,
+    ExecutionProfile,
+    ExecutionProfileError,
+    ReservedAuthSchemeError,
+    UnknownAuthSchemeError,
+    validate_execution_profile,
+)
+
+
+def _profile(**auth_overrides: object) -> ExecutionProfile:
+    """Build a valid ExecutionProfile with a basic auth block by default."""
+    auth = {"scheme": "basic", "secret_fields": ("username", "password")}
+    auth.update(auth_overrides)
+    return ExecutionProfile(product="harbor", version="2.x", auth=AuthSpec(**auth))
+
+
+# --------------------------------------------------------------------------
+# Catalog shape — no DSL fields, closed Literal
+# --------------------------------------------------------------------------
+
+
+def test_named_schemes_match_literal_exactly() -> None:
+    """The runtime named set is derived from the Literal — no drift."""
+    assert frozenset(typing.get_args(AuthSchemeName)) == NAMED_AUTH_SCHEMES
+    assert {
+        "basic",
+        "static_header",
+        "session_login",
+        "oauth2_mint",
+    } == NAMED_AUTH_SCHEMES
+
+
+def test_named_and_reserved_sets_are_disjoint() -> None:
+    assert NAMED_AUTH_SCHEMES.isdisjoint(RESERVED_AUTH_SCHEMES)
+
+
+def test_auth_spec_has_no_dsl_fields() -> None:
+    """AuthSpec must carry no path/template/expression/extractor field.
+
+    This is the #1177 rejected-DSL line, enforced as a schema-shape
+    assertion so a future edit that adds a token_location/field_map/etc.
+    fails this test loudly.
+    """
+    fields = set(AuthSpec.model_fields)
+    assert fields == {"scheme", "secret_fields", "header_name", "value_kind"}
+    forbidden = {
+        "token_location",
+        "field_map",
+        "value_template",
+        "jsonpath",
+        "json_path",
+        "expression",
+        "extractor",
+        "path",
+        "template",
+    }
+    assert fields.isdisjoint(forbidden)
+
+
+def test_profile_forbids_extra_fields() -> None:
+    with pytest.raises(ValidationError):
+        ExecutionProfile(
+            product="harbor",
+            version="2.x",
+            auth=AuthSpec(scheme="basic", secret_fields=("username", "password")),
+            token_location="header",  # type: ignore[call-arg]
+        )
+
+
+def test_profile_is_frozen() -> None:
+    profile = _profile()
+    with pytest.raises(ValidationError):
+        profile.product = "other"  # type: ignore[misc]
+
+
+# --------------------------------------------------------------------------
+# API-boundary rejection (Pydantic Literal)
+# --------------------------------------------------------------------------
+
+
+def test_unknown_scheme_rejected_at_boundary() -> None:
+    with pytest.raises(ValidationError):
+        AuthSpec(scheme="totally_made_up", secret_fields=("token",))  # type: ignore[arg-type]
+
+
+def test_reserved_scheme_rejected_at_boundary() -> None:
+    """A reserved scheme is not in the Literal, so the boundary rejects it too."""
+    with pytest.raises(ValidationError):
+        AuthSpec(scheme="kubeconfig", secret_fields=("kubeconfig",))  # type: ignore[arg-type]
+
+
+@pytest.mark.parametrize("scheme", sorted(NAMED_AUTH_SCHEMES))
+def test_every_named_scheme_constructs(scheme: str) -> None:
+    extra: dict[str, object] = {}
+    if scheme == "static_header":
+        extra["value_kind"] = "bearer"
+    spec = AuthSpec(scheme=scheme, secret_fields=("token",), **extra)  # type: ignore[arg-type]
+    assert spec.scheme == scheme
+
+
+# --------------------------------------------------------------------------
+# secret_fields / header_name validation
+# --------------------------------------------------------------------------
+
+
+def test_secret_fields_must_be_nonempty() -> None:
+    with pytest.raises(ValidationError):
+        AuthSpec(scheme="basic", secret_fields=())
+
+
+def test_secret_fields_must_be_nonblank() -> None:
+    with pytest.raises(ValidationError):
+        AuthSpec(scheme="basic", secret_fields=("username", "  "))
+
+
+def test_header_name_defaults_to_authorization() -> None:
+    assert AuthSpec(scheme="basic", secret_fields=("username",)).header_name == "Authorization"
+
+
+def test_header_name_must_be_nonblank() -> None:
+    with pytest.raises(ValidationError):
+        AuthSpec(scheme="basic", secret_fields=("username",), header_name=" ")
+
+
+# --------------------------------------------------------------------------
+# value_kind bound to static_header
+# --------------------------------------------------------------------------
+
+
+def test_static_header_requires_value_kind() -> None:
+    with pytest.raises(ValidationError):
+        AuthSpec(scheme="static_header", secret_fields=("token",))
+
+
+def test_static_header_value_kind_raw_and_bearer() -> None:
+    for kind in ("bearer", "raw"):
+        spec = AuthSpec(scheme="static_header", secret_fields=("token",), value_kind=kind)  # type: ignore[arg-type]
+        assert spec.value_kind == kind
+
+
+def test_value_kind_forbidden_for_non_static_header() -> None:
+    with pytest.raises(ValidationError):
+        AuthSpec(scheme="basic", secret_fields=("username",), value_kind="bearer")
+
+
+def test_value_kind_literal_closed() -> None:
+    with pytest.raises(ValidationError):
+        AuthSpec(scheme="static_header", secret_fields=("token",), value_kind="custom")  # type: ignore[arg-type]
+
+
+# --------------------------------------------------------------------------
+# Startup-load boot guard
+# --------------------------------------------------------------------------
+
+
+@pytest.mark.parametrize("scheme", sorted(NAMED_AUTH_SCHEMES))
+def test_validate_passes_for_named_schemes(scheme: str) -> None:
+    extra: dict[str, object] = {}
+    if scheme == "static_header":
+        extra["value_kind"] = "raw"
+    profile = ExecutionProfile(
+        product="p",
+        version="1",
+        auth=AuthSpec(scheme=scheme, secret_fields=("token",), **extra),  # type: ignore[arg-type]
+    )
+    # No raise.
+    validate_execution_profile(profile)
+
+
+def test_validate_raises_reserved_for_reserved_scheme() -> None:
+    """A reserved scheme reaching the boot guard raises the distinct typed error.
+
+    Constructed via model_construct to bypass the Literal (simulating a
+    hand-edited stored row that reached the registry off the validated path).
+    """
+    auth = AuthSpec.model_construct(
+        scheme="kubeconfig",  # type: ignore[arg-type]
+        secret_fields=("kubeconfig",),
+        header_name="Authorization",
+        value_kind=None,
+    )
+    profile = ExecutionProfile.model_construct(product="k8s", version="1", auth=auth)
+    with pytest.raises(ReservedAuthSchemeError) as exc:
+        validate_execution_profile(profile)
+    assert exc.value.scheme == "kubeconfig"
+    # Distinct remediation: author a typed connector, NOT the auto-shim message.
+    assert "typed connector" in str(exc.value)
+    assert "unreplaced_auto_shim" not in str(exc.value)
+    assert isinstance(exc.value, ExecutionProfileError)
+
+
+def test_validate_raises_unknown_for_bogus_scheme() -> None:
+    auth = AuthSpec.model_construct(
+        scheme="nonsense",  # type: ignore[arg-type]
+        secret_fields=("token",),
+        header_name="Authorization",
+        value_kind=None,
+    )
+    profile = ExecutionProfile.model_construct(product="x", version="1", auth=auth)
+    with pytest.raises(UnknownAuthSchemeError) as exc:
+        validate_execution_profile(profile)
+    # Names the valid named schemes to guide the operator.
+    assert "basic" in str(exc.value)
+
+
+def test_reserved_and_unknown_errors_are_distinct() -> None:
+    assert issubclass(ReservedAuthSchemeError, ExecutionProfileError)
+    assert issubclass(UnknownAuthSchemeError, ExecutionProfileError)
+    assert not issubclass(ReservedAuthSchemeError, UnknownAuthSchemeError)
+    assert not issubclass(UnknownAuthSchemeError, ReservedAuthSchemeError)
+
+
+def test_reserved_set_names_typed_connectors() -> None:
+    """Each reserved scheme corresponds to a real typed connector's auth shape."""
+    assert {
+        "github_app_jwt",
+        "gcp_sa_impersonation",
+        "operator_jwt_forward",
+        "kubeconfig",
+        "cookie_jar_session",
+        "dual_plane_session",
+    } == RESERVED_AUTH_SCHEMES

--- a/docs/codebase/connector-auth-coverage.md
+++ b/docs/codebase/connector-auth-coverage.md
@@ -1,0 +1,94 @@
+# Connector `auth_headers` coverage — grounding for the ExecutionProfile auth catalog
+
+G0.28-T3 (#1969), Initiative #1965, Goal #1964.
+
+This is the first deliverable of #1969: a grounded trace of every HTTP
+connector's `auth_headers` (and session-login) implementation, used to
+decide which auth shapes the closed `ExecutionProfile` named-auth catalog
+covers and which stay typed (hand-coded). The catalog
+(`AuthSchemeName` in `backend/src/meho_backplane/connectors/profile.py`)
+is derived from this table, **not** from a list picked from memory.
+
+## Why this gates the schema
+
+The profile's `auth.scheme` selects a *vetted named extractor* — it carries
+no path/template/expression fields (that is the rejected DSL line, #1177).
+A named scheme is only sound when an existing connector already proves the
+extractor is a pure `credentials -> dict[str, str]` (or
+`credentials -> login -> Bearer dict[str, str]`) function. Auth shapes that
+are stateful (cookie jars), need asymmetric crypto (RS256 JWT mint), or
+return something other than a header dict (kubeconfig-backed `ApiClient`)
+cannot be a named scheme — they are listed as **reserved** and a profile
+naming one raises `ReservedAuthSchemeError` ("author a typed connector").
+
+## Coverage table (14 HTTP connectors)
+
+| # | Connector | File (auth method) | Mechanism | Secret field names | Returns | Catalog verdict |
+|---|-----------|--------------------|-----------|--------------------|---------|-----------------|
+| 1 | harbor | `harbor/connector.py` `auth_headers` | HTTP Basic `base64(user:pass)` → `Authorization: Basic` | `username`, `password` | `dict[str,str]` | **`basic`** |
+| 2 | sddc_manager | `sddc_manager/connector.py` `auth_headers` | HTTP Basic `base64(user@sso_realm:pass)` | `username`, `password` | `dict[str,str]` | **`basic`** |
+| 3 | vcf_fleet | `vcf_fleet/connector.py` (`_shared/vcf_auth.basic_auth_header`) | HTTP Basic (shared helper) | `username`, `password` | `dict[str,str]` | **`basic`** |
+| 4 | vcf_operations | `vcf_operations/connector.py` `auth_headers` | HTTP Basic + optional `?auth-source=` query | `username`, `password` | `dict[str,str]` | **`basic`** |
+| 5 | hetzner_robot | `hetzner_robot/connector.py` `_basic_auth_header` | HTTP Basic (hard-fail on first 401, IP-block guard) | `username`, `password` | `dict[str,str]` | **`basic`** |
+| 6 | argocd | `argocd/connector.py` `auth_headers` | Static pre-issued token → `Authorization: Bearer <token>` | `token` | `dict[str,str]` | **`static_header`** (`value_kind=bearer`) |
+| 7 | keycloak | `keycloak/connector.py` `auth_headers` | OAuth2 client-credentials form grant `POST /realms/{r}/protocol/openid-connect/token` → cached Bearer | `client_id`, `client_secret` | `dict[str,str]` (Bearer) | **`oauth2_mint`** |
+| 8 | vcf_logs (vRLI) | `vcf_logs/connector.py` `auth_headers` | Session login `POST /api/v2/sessions` (JSON `{username,password,provider}`) → `sessionId` → cached Bearer | `username`, `password` | `dict[str,str]` (Bearer) | **`session_login`** |
+| 9 | vmware_rest | `vmware_rest/session.py` | Session login `POST /api/session` (Basic) → token from body → cached Bearer | `username`, `password` | `dict[str,str]` (Bearer) | **`session_login`** |
+| 10 | github | `github/connector.py` `auth_headers` | App-JWT: mint RS256 JWT → exchange for installation token (or PAT passthrough) | `app_id`, `private_key_pem`, `installation_id` (or `token`) | `dict[str,str]` (Bearer) | **RESERVED** `github_app_jwt` |
+| 11 | gcloud | `gcloud/connector.py` `auth_headers` | ADC + `impersonated_credentials` for `target.gcp_impersonate_sa` → refreshed token | ADC source + impersonation target (no static secret) | `dict[str,str]` (Bearer) | **RESERVED** `gcp_sa_impersonation` |
+| 12 | vault | `vault/connector.py` (`vault_client_for_operator`) | Operator-context OIDC JWT forward; no per-call header dict | operator `raw_jwt` | not a header dict | **RESERVED** `operator_jwt_forward` |
+| 13 | kubernetes | `kubernetes/connector.py` | kubeconfig loaded from Vault → cert/token embedded in `ApiClient` | kubeconfig payload | embedded in `ApiClient` | **RESERVED** `kubeconfig` |
+| 14 | nsx | `nsx/session.py` | Session create `POST /api/session/create` (form `j_username`/`j_password`) → `Set-Cookie JSESSIONID` jar + `X-XSRF-TOKEN` | `username`, `password` | mutated cookie jar + `dict[str,str]` | **RESERVED** `cookie_jar_session` |
+| 15 | vcf_automation | `vcf_automation/_auth.py` | Dual-plane: provider login (`/cloudapi/.../sessions/provider`) + tenant login (`/iaas/api/login`), token from header / body | `username`, `password`, `domain` | `dict[str,str]` (plane-specific Bearer) | **RESERVED** `dual_plane_session` |
+
+> Row count note: the connectors directory ships 15 HTTP-family connector
+> packages; the issue's "14" excludes `vcf_automation`'s dual-plane shape
+> as a special case. It is included here for completeness and is reserved.
+> Pure non-HTTP connectors (bind9, pfsense, holodeck, secret-broker) are
+> out of scope — they have no `auth_headers` HTTP surface.
+
+## Named-scheme partition (what the catalog covers)
+
+Six connectors (five if `vcf_operations`'s query-param merge is counted as
+`basic` with a transport quirk) fit a named scheme:
+
+- **`basic`** — harbor, sddc_manager, vcf_fleet, vcf_operations, hetzner_robot
+- **`static_header`** — argocd
+- **`oauth2_mint`** — keycloak
+- **`session_login`** — vcf_logs, vmware_rest
+
+Eight stay **reserved/typed** — github, gcloud, vault, kubernetes, nsx,
+vcf_automation — because their auth is stateful, asymmetric-crypto, or
+non-`dict[str,str]`. A profile naming any reserved scheme raises
+`ReservedAuthSchemeError`; the catalog's closed `Literal` does not list
+them at the API boundary.
+
+## Non-idempotent bespoke-body write-op count
+
+This count gates committing to the *full* profiled-write machinery
+(deferred to later tasks; T3 covers read dispatch only). Hand-built
+request bodies in POST/PUT/PATCH/DELETE ops across the connectors:
+
+| Connector | Write ops (hand-built body) | Where |
+|-----------|-----------------------------|-------|
+| harbor | 2 | `robot_create` (JSON body), `robot_delete` |
+| argocd | ~11 | `app_sync`/`app_rollback`/`app_set`/`app_refresh`/`app_delete`, `appproject_create`/`appproject_update` + `ops_write.py` handlers |
+| keycloak | ~10 | `realm_create`/`realm_update`/`client_create`/`client_update`/`client_scope_create`/`protocol_mapper_create`/`user_create`/`user_reset_password`/`role_mapping_assign` + `_write_admin` |
+| kubernetes | ~7 | `ops_write.py` handlers |
+| others | 0 (read-only / session-establish in v0.2) | — |
+
+**Total: ~30 non-idempotent bespoke-body write ops.** This confirms the
+write surface is non-trivial and concentrated in four connectors — write
+dispatch via profiles (per-op declarative bodies) is a real future cost,
+deferred out of T3's read-only scope. Read dispatch (the T3 target) needs
+only the auth slot filled, which the named-scheme catalog covers for the
+six in-catalog connectors.
+
+## References
+
+- `backend/src/meho_backplane/connectors/profile.py` — the schema + catalog.
+- `backend/src/meho_backplane/connectors/profiled.py` — T1 (#1967) dispatchable sibling.
+- `docs/architecture/runbooks.md` — the closed-vocabulary / no-DSL line (#1177).
+- Precedents modeled on: `connectors/schemas.AuthModel` (StrEnum),
+  `auth/permissions.safety_level` (Literal + ceiling),
+  `operations/ingest/catalog.load_catalog` (boot-crash on malformed config).


### PR DESCRIPTION
## Summary
- Defines the `ExecutionProfile` Pydantic model + closed named auth-scheme catalog (G0.28-T3, Initiative #1965) — the reviewed declarative data that fills `ProfiledRestConnector`'s one hand-coded slot (`auth_headers`) for ingested REST connectors.
- `auth.scheme` is a closed `Literal` (`basic` / `static_header` / `session_login` / `oauth2_mint`) selecting a **vetted named extractor** — carries **no** `token_location`/`field_map`/`value_template`/JSONPath field, holding the #1177 substrate-minimalism / rejected-DSL line.
- Grounded in a committed 14-connector `auth_headers` coverage trace (`docs/codebase/connector-auth-coverage.md`) — not a from-memory list. Six connectors fit a named scheme; eight stay reserved/typed (github RS256 App-JWT, gcloud SA impersonation, vault operator-JWT-forward, k8s kubeconfig, nsx cookie-jar, vcf_automation dual-plane). The trace also tallies the ~30 non-idempotent bespoke-body write ops.
- A reserved scheme raises the distinct `ReservedAuthSchemeError` ("author a typed connector"), separate from the dispatcher's `unreplaced_auto_shim` cause. Closed set enforced two ways: Pydantic `Literal` at the API boundary (422) **and** `validate_execution_profile` crash-boot at startup-load (mirrors `load_catalog`). Credentials never live in the profile — only secret-field **names**; `value_kind` is a closed `bearer|raw` enum bound to `static_header`.

## Test plan
- [x] `ruff check` / `ruff format --check` — clean
- [x] `mypy src/meho_backplane/connectors/` — Success, 148 files
- [x] `pytest tests/test_connectors_execution_profile.py` — 27 passed
- [x] `pytest tests/test_connectors_profiled_tristate.py` (T1 regression) — 14 passed
- [x] **AC1** committed 14-row coverage table + bespoke-write-op count — `docs/codebase/connector-auth-coverage.md`
- [x] **AC2** `ExecutionProfile` Pydantic model, `Literal` auth catalog, no path/template/extractor fields — asserted by `test_auth_spec_has_no_dsl_fields`
- [x] **AC3** boot crashes on unknown scheme (`validate_execution_profile`) + API boundary rejects via `Literal` — `test_validate_raises_unknown_for_bogus_scheme`, `test_unknown_scheme_rejected_at_boundary`
- [x] **AC4** reserved scheme → distinct typed error naming the typed-connector alternative — `test_validate_raises_reserved_for_reserved_scheme`

## Out of scope
- Session/token-cache machinery the schemes drive (T4 #1970); profile-driven fingerprint/probe + pagination (T6 #1972); expiry-status unification (T7).
- Profiled **write** dispatch (per-op declarative bodies) — the ~30-op count gates that future scope; T3 covers read dispatch only.

<!-- auto-implement-issue: fresh, iteration 1 -->

Closes #1969
