### PR TITLE
feat(connectors): hoist session + token-cache harness into ProfiledRestConnector (G0.28-T4 #1970)

### DIFF
--- a/backend/src/meho_backplane/connectors/_shared/profile_auth.py
+++ b/backend/src/meho_backplane/connectors/_shared/profile_auth.py
@@ -1,0 +1,337 @@
+# SPDX-License-Identifier: Apache-2.0
+# Copyright (c) 2026 evoila Group
+
+"""Named auth-scheme extractors for ``ProfiledRestConnector`` (#1970).
+
+G0.28-T4 — the runtime half of the named-auth catalog T3 (#1969) defined as
+a closed :data:`~meho_backplane.connectors.profile.AuthSchemeName` Literal.
+Each catalog value selects one vetted Python extractor here; this module is
+the registry that maps a scheme name to that extractor. No DSL — the
+profile names a scheme, the scheme names a function, the function returns a
+``dict[str, str]`` (the substrate-minimalism line #1177 holds: the profile
+configures *which* reviewed extractor runs, never *how* a token is parsed).
+
+The four named schemes split on whether they hold session state:
+
+* **Stateless per request** — ``basic`` (HTTP Basic from
+  ``username``/``password``) and ``static_header`` (a pre-issued token
+  placed bearer-wrapped or raw). These compute the header from the secret
+  bundle on every call; no token cache, no login round-trip.
+* **Session-stateful** — ``session_login`` (POST credentials to a login
+  endpoint, read a short-lived token out of the JSON body, send it as
+  ``Bearer``; vRLI's shape) and ``oauth2_mint`` (an OAuth2
+  client-credentials *form* grant minting a ``Bearer`` token with a TTL;
+  keycloak's shape). These two need the per-target lock / token cache /
+  single-flight / TTL-or-expiry-driven refresh / fail-closed harness, which
+  :class:`~meho_backplane.connectors.profiled.ProfiledRestConnector` owns
+  **once** (the whole point of T4 — the harness was duplicated across vRLI
+  and keycloak before).
+
+This module supplies the *scheme-specific* pieces the harness drives:
+
+* :func:`build_static_headers` — the stateless ``basic`` / ``static_header``
+  computation.
+* :class:`SessionSchemeSpec` — the per-scheme login mechanics
+  (login path builder, request encoding, token + TTL extractor) the
+  stateful harness invokes. :data:`SESSION_SCHEME_SPECS` registers one per
+  session scheme, selected by the profile's ``auth.scheme``.
+
+The login round-trip itself reuses the audited transport seams on
+:class:`~meho_backplane.connectors.adapters.http.HttpConnector`
+(``_post_json``'s ``json=`` / ``data=`` body shapes from T2 #1968) so a
+profiled connector inherits the same retry / TLS-trust / pooling behaviour
+the typed connectors have.
+"""
+
+from __future__ import annotations
+
+import base64
+from collections.abc import Callable, Mapping
+from dataclasses import dataclass
+from typing import Any
+
+from meho_backplane.connectors.profile import AuthSpec
+
+__all__ = [
+    "SESSION_SCHEME_SPECS",
+    "STATELESS_SCHEMES",
+    "ProfileAuthError",
+    "SessionSchemeSpec",
+    "SessionToken",
+    "build_static_headers",
+]
+
+
+class ProfileAuthError(RuntimeError):
+    """A profile-driven auth extractor could not produce a usable result.
+
+    Raised when a named scheme's secret bundle is missing a field the
+    scheme declared in ``auth.secret_fields`` (a misconfigured profile /
+    Vault secret), or a session-login response carried no usable token.
+    The message names the scheme and the offending field / target; it
+    never echoes a credential value.
+    """
+
+
+# ---------------------------------------------------------------------------
+# Secret-bundle field access (shared by every scheme)
+# ---------------------------------------------------------------------------
+
+
+def _require_field(secret: Mapping[str, str], field: str, *, scheme: str) -> str:
+    """Return ``secret[field]`` or raise a profile-named error.
+
+    The credential loader (``load_basic_credentials`` with the profile's
+    ``secret_fields``) already raises when a *declared* field is absent in
+    Vault, so this is the defensive second gate for an extractor reading a
+    field the profile didn't declare — a programming error in the scheme
+    wiring rather than an operator misconfiguration. Never echoes the value.
+    """
+    value = secret.get(field)
+    if not value:
+        raise ProfileAuthError(
+            f"{scheme!r} auth scheme requires a non-empty {field!r} secret field; "
+            f"the resolved secret bundle has no usable {field!r} value"
+        )
+    return value
+
+
+# ---------------------------------------------------------------------------
+# Stateless schemes — basic / static_header
+# ---------------------------------------------------------------------------
+
+#: The two named schemes that compute their header per request with no
+#: session state. The session-stateful schemes (``session_login`` /
+#: ``oauth2_mint``) are everything in
+#: :data:`~meho_backplane.connectors.profile.NAMED_AUTH_SCHEMES` minus these.
+STATELESS_SCHEMES: frozenset[str] = frozenset({"basic", "static_header"})
+
+
+def _basic_auth_value(username: str, password: str) -> str:
+    """Return the ``Basic <b64(user:pass)>`` header value.
+
+    Same UTF-8-then-base64 encoding the typed connectors use
+    (:func:`meho_backplane.connectors._shared.vcf_auth.basic_auth_header`);
+    duplicated as a one-liner here rather than imported so the profiled
+    auth path carries no coupling to the VCF-specific module.
+    """
+    encoded = base64.b64encode(f"{username}:{password}".encode()).decode()
+    return f"Basic {encoded}"
+
+
+def build_static_headers(auth: AuthSpec, secret: Mapping[str, str]) -> dict[str, str]:
+    """Compute the per-request headers for a stateless scheme.
+
+    Handles the two no-session schemes:
+
+    * ``basic`` — reads ``username`` / ``password`` from *secret* and
+      returns ``{auth.header_name: "Basic <b64>"}``.
+    * ``static_header`` — reads the single pre-issued token field and places
+      it per ``auth.value_kind``: ``bearer`` wraps it as ``"Bearer <tok>"``,
+      ``raw`` places it verbatim (an ``X-Api-Key``-style header).
+
+    The token field for ``static_header`` is the *first* name in
+    ``auth.secret_fields`` (the profile declares exactly the field the
+    pre-issued token lives under). Raises :class:`ProfileAuthError` for a
+    scheme this builder does not handle — the caller's stateful path owns
+    ``session_login`` / ``oauth2_mint``.
+    """
+    if auth.scheme == "basic":
+        username = _require_field(secret, "username", scheme="basic")
+        password = _require_field(secret, "password", scheme="basic")
+        return {auth.header_name: _basic_auth_value(username, password)}
+    if auth.scheme == "static_header":
+        token_field = auth.secret_fields[0]
+        token = _require_field(secret, token_field, scheme="static_header")
+        # value_kind is required for static_header (AuthSpec enforces it),
+        # so it is never None here; bearer wraps, raw places verbatim.
+        value = f"Bearer {token}" if auth.value_kind == "bearer" else token
+        return {auth.header_name: value}
+    raise ProfileAuthError(
+        f"build_static_headers does not handle scheme {auth.scheme!r}; "
+        f"session schemes route through the session-token harness"
+    )
+
+
+# ---------------------------------------------------------------------------
+# Session-stateful schemes — session_login / oauth2_mint
+# ---------------------------------------------------------------------------
+
+
+@dataclass(frozen=True)
+class SessionToken:
+    """A minted session token plus its optional TTL.
+
+    ``ttl_seconds`` is ``None`` for a scheme whose login response carries no
+    expiry (vRLI's session is idle-expiry-driven, recovered by a re-login on
+    a downstream session-expiry status rather than a proactive TTL refresh).
+    A finite ``ttl_seconds`` (keycloak's ``expires_in``) lets the harness
+    re-mint before the token would fail a downstream call.
+    """
+
+    token: str
+    ttl_seconds: float | None
+
+
+@dataclass(frozen=True)
+class SessionSchemeSpec:
+    """The scheme-specific mechanics of a session-stateful named scheme.
+
+    The connector-owned harness drives the lock / cache / single-flight /
+    refresh; this spec supplies what differs per scheme — the login path,
+    the request body encoding, the request headers, and how the token (plus
+    TTL) is read out of the response. One instance per session scheme lives
+    in :data:`SESSION_SCHEME_SPECS`, selected by the profile's
+    ``auth.scheme``.
+
+    Attributes
+    ----------
+    login_path
+        Builds the login endpoint path from the resolved ``AuthSpec`` (a
+        constant for vRLI; keycloak's realm path is profile-independent so
+        it is also constant here — realm routing is a T6 concern).
+    encoding
+        ``"json"`` serialises the login body as JSON (vRLI);
+        ``"form"`` serialises it as ``application/x-www-form-urlencoded``
+        (OAuth2 token grants). Picks the matching ``_post_json`` body slot.
+    build_body
+        Builds the login request body from the secret bundle.
+    request_headers
+        Static headers sent on the login POST (``Content-Type`` /
+        ``Accept``).
+    extract_token
+        Reads ``(token, ttl)`` out of the parsed JSON response body, or
+        ``None`` when no usable token is present (the harness then raises a
+        target-named :class:`ProfileAuthError`).
+    """
+
+    login_path: Callable[[AuthSpec], str]
+    encoding: str
+    build_body: Callable[[AuthSpec, Mapping[str, str]], dict[str, str]]
+    request_headers: Mapping[str, str]
+    extract_token: Callable[[Any], SessionToken | None]
+
+
+# -- session_login (vRLI: json login -> body .sessionId -> Bearer) ----------
+
+#: vRLI's session-establish endpoint. The connector POSTs the JSON body and
+#: reads ``sessionId`` out of the response. Behaviour parity with
+#: :class:`~meho_backplane.connectors.vcf_logs.connector.VcfLogsConnector`.
+_VRLI_SESSION_PATH = "/api/v2/sessions"
+
+#: vRLI identity-source default, matching the typed connector + wrapper.
+_VRLI_DEFAULT_PROVIDER = "Local"
+
+
+def _session_login_body(auth: AuthSpec, secret: Mapping[str, str]) -> dict[str, str]:
+    """Build vRLI's ``{username, password, provider}`` login body.
+
+    ``provider`` is a non-secret constant (``"Local"``) — the profile carries
+    no per-target provider knob (that stays a typed-connector concern), so a
+    profiled vRLI uses the wrapper's default identity source. ``username`` /
+    ``password`` come from the secret bundle the profile declared.
+    """
+    return {
+        "username": _require_field(secret, "username", scheme="session_login"),
+        "password": _require_field(secret, "password", scheme="session_login"),
+        "provider": _VRLI_DEFAULT_PROVIDER,
+    }
+
+
+def _extract_session_login_token(payload: Any) -> SessionToken | None:
+    """Read ``sessionId`` out of the vRLI login response body.
+
+    vRLI returns ``{"sessionId": "<token>", "ttl": <seconds>}``. The
+    session is idle-expiry-driven and recovered by a re-login on a
+    downstream session-expiry status, so the harness does **not** key a
+    proactive refresh off ``ttl`` — ``ttl_seconds`` is ``None``, matching
+    the typed connector which caches the token until a 440/401 invalidates
+    it. Returns ``None`` for a missing / non-string / empty ``sessionId``
+    so the harness raises the consistent target-named error.
+    """
+    if not isinstance(payload, dict):
+        return None
+    value = payload.get("sessionId")
+    if not isinstance(value, str) or not value:
+        return None
+    return SessionToken(token=value, ttl_seconds=None)
+
+
+# -- oauth2_mint (keycloak: form client-credentials grant -> Bearer) --------
+
+#: Keycloak's token endpoint path. The admin-realm segment in the typed
+#: connector is a realm-routing concern T6 owns; the named scheme uses the
+#: conventional ``master`` admin realm so a profiled keycloak mints against
+#: the same endpoint shape the typed connector does.
+_OAUTH2_TOKEN_PATH = "/realms/master/protocol/openid-connect/token"
+
+#: Refresh margin shaved off ``expires_in`` so a near-expiry token is
+#: re-minted before a downstream call fails on it. Mirrors the typed
+#: keycloak connector's ``_TOKEN_REFRESH_MARGIN_SECONDS``.
+_OAUTH2_REFRESH_MARGIN_SECONDS = 30.0
+
+#: Fallback TTL when the token response omits / malforms ``expires_in``.
+#: Keycloak's admin access-token lifespan defaults to 60 s; the floor keeps
+#: a malformed response from pinning a token forever.
+_OAUTH2_DEFAULT_TTL_SECONDS = 60.0
+
+
+def _oauth2_mint_body(auth: AuthSpec, secret: Mapping[str, str]) -> dict[str, str]:
+    """Build the OAuth2 client-credentials grant form body.
+
+    ``grant_type=client_credentials`` with ``client_id`` / ``client_secret``
+    from the secret bundle the profile declared. Form-encoded by the
+    ``oauth2_mint`` spec's ``encoding="form"`` — Keycloak's token endpoint
+    does not accept JSON.
+    """
+    return {
+        "grant_type": "client_credentials",
+        "client_id": _require_field(secret, "client_id", scheme="oauth2_mint"),
+        "client_secret": _require_field(secret, "client_secret", scheme="oauth2_mint"),
+    }
+
+
+def _extract_oauth2_token(payload: Any) -> SessionToken | None:
+    """Read ``access_token`` + effective TTL out of an OAuth2 token response.
+
+    Returns the access token with ``ttl_seconds = expires_in - margin``
+    (floored at 1 s), or :data:`_OAUTH2_DEFAULT_TTL_SECONDS` when
+    ``expires_in`` is missing / non-numeric. Returns ``None`` for a body
+    carrying no usable ``access_token`` so the harness raises the
+    target-named error. Mirrors the typed connector's
+    ``_parse_token_response``.
+    """
+    if not isinstance(payload, dict):
+        return None
+    token = payload.get("access_token")
+    if not isinstance(token, str) or not token:
+        return None
+    expires_in = payload.get("expires_in")
+    ttl = float(expires_in) if isinstance(expires_in, (int, float)) else _OAUTH2_DEFAULT_TTL_SECONDS
+    effective = max(1.0, ttl - _OAUTH2_REFRESH_MARGIN_SECONDS)
+    return SessionToken(token=token, ttl_seconds=effective)
+
+
+#: One :class:`SessionSchemeSpec` per session-stateful named scheme,
+#: selected by the profile's ``auth.scheme``. The connector-owned harness
+#: looks the spec up here and drives it; adding a session scheme is a
+#: deliberate act (a new Literal value in T3 + a vetted spec here).
+SESSION_SCHEME_SPECS: dict[str, SessionSchemeSpec] = {
+    "session_login": SessionSchemeSpec(
+        login_path=lambda _auth: _VRLI_SESSION_PATH,
+        encoding="json",
+        build_body=_session_login_body,
+        request_headers={"Content-Type": "application/json", "Accept": "application/json"},
+        extract_token=_extract_session_login_token,
+    ),
+    "oauth2_mint": SessionSchemeSpec(
+        login_path=lambda _auth: _OAUTH2_TOKEN_PATH,
+        encoding="form",
+        build_body=_oauth2_mint_body,
+        request_headers={
+            "Content-Type": "application/x-www-form-urlencoded",
+            "Accept": "application/json",
+        },
+        extract_token=_extract_oauth2_token,
+    ),
+}

--- a/backend/src/meho_backplane/connectors/profiled.py
+++ b/backend/src/meho_backplane/connectors/profiled.py
@@ -39,43 +39,118 @@ keeps a profiled connector *above* a bare shim (it is dispatchable) but
 *below* a hand-coded class (a bespoke connector always wins), with
 ``priority = 0`` so it never out-ranks on the priority rung either.
 
-Scope of T1 — the class + the tri-state classification only. The
-``ExecutionProfile`` schema and the named auth catalog land in T3 (#1969);
-the hoisted session-lifecycle / token-cache machinery in T4 (#1970); the
-profile-driven ``fingerprint`` / ``probe`` and pagination in T6 (#1972).
-Until those land, the four overridden methods below raise
-:class:`NotImplementedError` with a profile-oriented message — distinct
-from the auto-shim's "replace with a per-product subclass" guidance,
-because the remediation here is "attach a reviewed ``ExecutionProfile``",
-not "write Python". A ``ProfiledRestConnector`` that reaches dispatch
-before its profile machinery is wired is therefore classified
-``unsupported_feature`` by the dispatcher, **never** ``unreplaced_auto_shim``
-— it is not a dead shim, it is a dispatchable connector whose profile
-wiring is incomplete.
+The session-lifecycle / token-cache harness (G0.28-T4 #1970)
+============================================================
+
+T4 hoists the per-target session machinery — the lock, the token cache, the
+single-flight, the re-login-once, the empty-``raw_jwt`` fail-closed gate —
+**once** into this class, parameterised by the profile's named auth scheme.
+Before T4 this harness was copy-pasted across the typed session connectors
+(vRLI, keycloak); a profiled connector now reuses the one audited
+implementation. The scheme-specific pieces (login path, body encoding,
+token + TTL extraction) live in
+:mod:`meho_backplane.connectors._shared.profile_auth`, selected by
+``self.profile.auth.scheme``:
+
+* ``basic`` / ``static_header`` — **stateless**: the header is computed from
+  the secret bundle on every call, no token cache or login round-trip.
+* ``session_login`` (vRLI parity: JSON login → body ``.sessionId`` →
+  ``Bearer``) and ``oauth2_mint`` (keycloak parity: form client-credentials
+  grant → ``Bearer`` with TTL) — **session-stateful**: driven by the harness
+  below. ``session_login`` caches until a downstream re-login (idle-expiry
+  driven, no TTL); ``oauth2_mint`` re-mints on TTL expiry.
+
+NSX is **out of scope** and stays typed — its auth depends on the httpx
+cookie jar (``JSESSIONID`` via ``Set-Cookie``), which the ``dict[str, str]``
+``auth_headers`` return contract cannot model (it is the ``cookie_jar_session``
+*reserved* scheme in :data:`~meho_backplane.connectors.profile.RESERVED_AUTH_SCHEMES`).
+
+Auth-model gating + fail-closed invariant
+=========================================
+
+Every shipped REST connector hardcodes ``shared_service_account`` and
+rejects ``per_user`` / impersonation with a :exc:`NotImplementedError`
+naming the target + requested mode. The profiled connector follows the same
+pattern. The empty-``raw_jwt`` fail-closed check is preserved as a
+security-load-bearing invariant: a system-initiated caller (empty JWT)
+cannot read the per-target vendor credential out of Vault, so it must never
+be served a session token primed by an authenticated caller via a cache hit
+— the guard runs *before* the cache lookup.
+
+Scope of T6 (#1972) — the profile-driven ``fingerprint`` / ``probe`` and
+pagination — is still pending; those two methods raise
+:class:`NotImplementedError` with a profile-oriented message until T6 lands.
+A ``ProfiledRestConnector`` that reaches fingerprint/probe before T6 is
+therefore classified ``unsupported_feature`` by the dispatcher, **never**
+``unreplaced_auto_shim`` — it is not a dead shim, it is a dispatchable
+connector whose remaining wiring is incomplete.
 """
 
 from __future__ import annotations
 
+import asyncio
+import time
+from collections.abc import Awaitable, Callable, Mapping
 from typing import Any
 
+import structlog
+
 from meho_backplane.auth.operator import Operator
+from meho_backplane.connectors._shared.cache_key import target_cache_key
+from meho_backplane.connectors._shared.profile_auth import (
+    SESSION_SCHEME_SPECS,
+    STATELESS_SCHEMES,
+    ProfileAuthError,
+    SessionSchemeSpec,
+    SessionToken,
+    build_static_headers,
+)
+from meho_backplane.connectors._shared.vault_creds import (
+    VaultCredentialsReadError,
+    load_basic_credentials,
+)
+from meho_backplane.connectors._shared.vcf_auth import is_acceptable_auth_model
 from meho_backplane.connectors.adapters.http import HttpConnector
 from meho_backplane.connectors.base import ShimKind
+from meho_backplane.connectors.profile import ExecutionProfile
 from meho_backplane.connectors.schemas import (
+    AuthModel,
     FingerprintResult,
     OperationResult,
     ProbeResult,
 )
 
-__all__ = ["ProfiledRestConnector"]
+__all__ = ["ProfileCredentialsLoader", "ProfiledRestConnector"]
 
-_PROFILE_PENDING = (
-    "ProfiledRestConnector requires a reviewed ExecutionProfile to "
-    "dispatch; the profile schema (G0.28-T3 #1969), session/token "
-    "machinery (T4 #1970), and profile-driven fingerprint/probe (T6 "
-    "#1972) are not wired yet. Attach a vetted profile rather than "
-    "hand-coding this method."
+_log = structlog.get_logger(__name__)
+
+_PROFILE_PENDING_PROBE = (
+    "ProfiledRestConnector's profile-driven fingerprint/probe is wired in "
+    "G0.28-T6 (#1972), not yet landed. Attach a vetted ExecutionProfile and "
+    "wait for T6 rather than hand-coding this method."
 )
+
+#: Async callable resolving a ``(target, operator)`` pair to the secret
+#: bundle the profile's auth scheme reads. Injected for tests; the default
+#: is the shared operator-context Vault KV-v2 reader. The returned dict's
+#: keys are the names the profile declared in ``auth.secret_fields``.
+ProfileCredentialsLoader = Callable[[Any, Operator], Awaitable[dict[str, str]]]
+
+
+class _CachedSessionToken:
+    """A minted session token plus the monotonic time it expires at (or never)."""
+
+    __slots__ = ("expires_at", "token")
+
+    def __init__(self, token: str, expires_at: float | None) -> None:
+        self.token = token
+        #: ``None`` → never proactively expires (vRLI's idle-expiry session,
+        #: recovered by a downstream re-login). A finite value → re-mint when
+        #: the monotonic clock passes it (keycloak's TTL refresh).
+        self.expires_at = expires_at
+
+    def is_fresh(self, now: float) -> bool:
+        return self.expires_at is None or now < self.expires_at
 
 
 class ProfiledRestConnector(HttpConnector):
@@ -87,14 +162,20 @@ class ProfiledRestConnector(HttpConnector):
     dispatchable — above a bare auto-shim, below a hand-coded class. Carries
     the default ``priority = 0``; registered profiled classes advertise a
     bounded ``supported_version_range`` (derived from the ingested spec's
-    version, the same shape the auto-shim derives) so they beat a bare shim
-    on dispatchability but never out-specific a bespoke hand-coded class.
+    version) so they beat a bare shim on dispatchability but never
+    out-specific a bespoke hand-coded class.
 
-    The method bodies are intentionally degenerate in T1 — they raise
-    :class:`NotImplementedError` with profile-oriented guidance until the
-    profile machinery lands in T3/T4/T6. The class is concrete (instantiable)
-    so it can stand in for the dispatchable tier in resolver / dispatcher
-    classification tests without a hand-faked stand-in.
+    The vetted :class:`~meho_backplane.connectors.profile.ExecutionProfile`
+    is a **class attribute** (``profile``): the profile-stamping path
+    (G0.28-T5 #1971) registers a ``ProfiledRestConnector`` subclass carrying
+    the reviewed profile, and the dispatcher instantiates that subclass with
+    no constructor args (one cached instance per class). Tests construct an
+    instance directly, passing ``profile=`` (and a stub
+    ``credentials_loader=``) to exercise a scheme without a registry round-trip.
+
+    The session/token harness (lock / cache / single-flight / re-login-once /
+    TTL refresh / empty-jwt fail-closed) lives here once, parameterised by
+    ``self.profile.auth.scheme``; see the module docstring.
     """
 
     # G0.28-T1 (#1967) — the "profiled" tier of the tri-state classifier.
@@ -105,22 +186,250 @@ class ProfiledRestConnector(HttpConnector):
     # priority rung against a hand-coded class.
     priority: int = 0
 
+    #: The vetted profile this connector dispatches against. Set on the
+    #: stamped subclass by the profile-stamping path; ``None`` on the bare
+    #: base class (which is registered only as the resolver's dispatchable
+    #: stand-in in tests). ``auth_headers`` raises a clear error when it is
+    #: ``None`` rather than dereferencing it.
+    profile: ExecutionProfile | None = None
+
+    def __init__(
+        self,
+        *,
+        profile: ExecutionProfile | None = None,
+        credentials_loader: ProfileCredentialsLoader | None = None,
+    ) -> None:
+        super().__init__()
+        # A constructor-supplied profile (tests) overrides the class
+        # attribute; production stamped subclasses set the class attribute
+        # and instantiate with no args.
+        if profile is not None:
+            self.profile = profile
+        self._injected_loader = credentials_loader
+        # Per-target session-token cache keyed on the tenant-unique
+        # ``(tenant_id, id)`` tuple (#1642), guarded by one lock per
+        # connector instance. Only the two session-stateful schemes
+        # (session_login / oauth2_mint) populate it.
+        self._session_tokens: dict[tuple[str, str], _CachedSessionToken] = {}
+        self._session_lock = asyncio.Lock()
+
+    # -- auth -----------------------------------------------------------
+
+    def _require_profile(self, target: Any) -> ExecutionProfile:
+        """Return the attached profile or raise a clear error.
+
+        A profiled connector with no profile is a wiring error (a bare base
+        class reached dispatch). The message names the target so the operator
+        sees which target tried to dispatch against an unstamped connector.
+        """
+        if self.profile is None:
+            raise NotImplementedError(
+                f"{type(self).__name__} has no ExecutionProfile attached; "
+                f"target {getattr(target, 'name', '?')!r} cannot dispatch. Stamp a "
+                f"reviewed profile (G0.28-T5) before dispatching."
+            )
+        return self.profile
+
+    async def _load_credentials(self, target: Any, operator: Operator) -> dict[str, str]:
+        """Resolve the secret bundle the profile's auth scheme reads.
+
+        An injected loader (tests) wins; otherwise the default operator-context
+        Vault read pulls **exactly the fields the profile declared** in
+        ``auth.secret_fields`` out of ``target.secret_ref`` via the shared
+        :func:`load_basic_credentials` helper. Reading the declared field
+        names (rather than the helper's ``username``/``password`` default) is
+        what lets ``static_header`` (a ``token`` field) and ``oauth2_mint``
+        (``client_id`` / ``client_secret``) resolve the right secret shape
+        through the one shared reader — same no-secret-in-logs discipline and
+        fail-closed empty-JWT / missing-field error contract every connector
+        reuses.
+        """
+        if self._injected_loader is not None:
+            return await self._injected_loader(target, operator)
+        profile = self._require_profile(target)
+        return await load_basic_credentials(target, operator, fields=profile.auth.secret_fields)
+
     async def auth_headers(self, target: Any, operator: Operator) -> dict[str, str]:
-        """Raise until the profile's named auth scheme is wired (T3/T4)."""
-        raise NotImplementedError(_PROFILE_PENDING)
+        """Return the auth headers for *target*, driven by the profile's scheme.
+
+        Rejects any ``auth_model`` other than ``shared_service_account`` /
+        ``None`` with a :exc:`NotImplementedError` naming the target + mode
+        — the same pattern every typed REST connector uses (``per_user`` /
+        impersonation is out of scope; a profile is a shared-service-account
+        construct).
+
+        Stateless schemes (``basic`` / ``static_header``) compute the header
+        from the freshly resolved secret bundle. Session-stateful schemes
+        (``session_login`` / ``oauth2_mint``) return ``{header_name: "Bearer
+        <token>"}`` for a token obtained through the session harness (cached,
+        single-flight, refresh-on-expiry, fail-closed).
+        """
+        profile = self._require_profile(target)
+        auth = profile.auth
+        auth_model = getattr(target, "auth_model", None)
+        if not is_acceptable_auth_model(auth_model):
+            raise NotImplementedError(
+                f"{type(self).__name__} only supports auth_model="
+                f"{AuthModel.SHARED_SERVICE_ACCOUNT.value!r}; target "
+                f"{getattr(target, 'name', '?')!r} requested auth_model={auth_model!r}"
+            )
+
+        if auth.scheme in STATELESS_SCHEMES:
+            # Stateless: the credential read still fails closed on an empty
+            # operator JWT inside the loader; no token cache is involved.
+            secret = await self._load_credentials(target, operator)
+            return build_static_headers(auth, secret)
+
+        token = await self._session_token(target, operator)
+        return {auth.header_name: f"Bearer {token}"}
+
+    # -- session-token harness (session_login / oauth2_mint) ------------
+
+    async def _session_token(self, target: Any, operator: Operator) -> str:
+        """Return the cached session token for *target*, minting on first use / expiry.
+
+        The hoisted harness, once: lock-serialised single-flight so two
+        concurrent first-use callers don't both pay the login round-trip, a
+        cache fast-path under the lock, and a fail-closed empty-``raw_jwt``
+        gate *before* the cache lookup so a system-initiated caller cannot be
+        served a token primed by an authenticated caller (the
+        security-load-bearing invariant preserved from the typed
+        connectors). ``session_login`` caches until invalidated by a
+        downstream re-login (``ttl_seconds=None`` → never proactively
+        expires); ``oauth2_mint`` re-mints once the monotonic clock passes
+        the TTL.
+        """
+        if not operator.raw_jwt:
+            raise VaultCredentialsReadError(
+                "operator-context credential read requires an authenticated operator; "
+                f"target={getattr(target, 'name', '?')!r} has no operator JWT "
+                "(system-initiated calls cannot read per-target vendor credentials)"
+            )
+        cache_key = target_cache_key(target)
+        async with self._session_lock:
+            now = time.monotonic()
+            cached = self._session_tokens.get(cache_key)
+            if cached is not None and cached.is_fresh(now):
+                return cached.token
+            minted = await self._mint_session_token(target, operator)
+            expires_at = None if minted.ttl_seconds is None else now + minted.ttl_seconds
+            self._session_tokens[cache_key] = _CachedSessionToken(minted.token, expires_at)
+            return minted.token
+
+    async def _mint_session_token(self, target: Any, operator: Operator) -> SessionToken:
+        """Run the scheme's login round-trip and return the minted token + TTL.
+
+        Reads the secret bundle (operator-context, fail-closed) then POSTs
+        the scheme's login body on the pooled client (see :meth:`_post_login`
+        for why this bypasses the ``auth_headers``-stamping ``_post_json``
+        seam). ``encoding`` picks the body slot: JSON for ``session_login``,
+        form-encoded for ``oauth2_mint``. A non-2xx surfaces as
+        :exc:`httpx.HTTPStatusError`; a 2xx with no usable token surfaces as
+        :exc:`ProfileAuthError` naming the target + scheme.
+        """
+        profile = self._require_profile(target)
+        auth = profile.auth
+        spec = self._session_spec(auth.scheme)
+        secret = await self._load_credentials(target, operator)
+        body = spec.build_body(auth, secret)
+        path = spec.login_path(auth)
+        payload = await self._post_login(target, spec, path, body)
+        minted = spec.extract_token(payload)
+        if minted is None:
+            raise ProfileAuthError(
+                f"{auth.scheme!r} session login for target "
+                f"{getattr(target, 'name', '?')!r} returned no usable token"
+            )
+        _log.info(
+            "profiled_session_established",
+            target=getattr(target, "name", None),
+            host=getattr(target, "host", None),
+            scheme=auth.scheme,
+            product=profile.product,
+        )
+        return minted
+
+    async def _post_login(
+        self,
+        target: Any,
+        spec: SessionSchemeSpec,
+        path: str,
+        body: Mapping[str, str],
+    ) -> Any:
+        """POST the login body on the pooled client and return the parsed JSON.
+
+        Goes through the pooled :class:`httpx.AsyncClient` **directly** rather
+        than the inherited ``_post_json`` seam, for two load-bearing reasons:
+
+        * ``_post_json`` calls :meth:`auth_headers` to stamp the request — but
+          a profiled connector's ``auth_headers`` is *what is establishing
+          this session*, so routing the login POST through it would recurse
+          (and deadlock on the non-reentrant session lock the caller already
+          holds). The login carries its credentials in the **body**, not an
+          ``Authorization`` header, so it must skip ``auth_headers`` entirely.
+        * The login round-trip is "one attempt, surface the failure cleanly"
+          — it deliberately bypasses the idempotent-GET tenacity retry, the
+          same posture
+          :func:`~meho_backplane.connectors._shared.vcf_auth.vcf_session_login`
+          takes for the typed connectors.
+
+        The client is still the pooled per-target client, so it inherits the
+        connector's TLS-trust / base-URL / timeout config. The body slot is
+        picked from the spec's ``encoding`` (``json`` → ``json=``, ``form`` →
+        ``data=``). A non-2xx surfaces as :exc:`httpx.HTTPStatusError`.
+        """
+        client = await self._http_client(target)
+        request_headers = dict(spec.request_headers)
+        if spec.encoding == "form":
+            resp = await client.post(path, data=dict(body), headers=request_headers)
+        else:
+            resp = await client.post(path, json=dict(body), headers=request_headers)
+        resp.raise_for_status()
+        return resp.json()
+
+    @staticmethod
+    def _session_spec(scheme: str) -> SessionSchemeSpec:
+        """Return the :class:`SessionSchemeSpec` for a session-stateful scheme.
+
+        Raises :class:`ProfileAuthError` for a scheme with no spec — a
+        non-session scheme should have been handled by the stateless branch,
+        so reaching here is a wiring error.
+        """
+        spec = SESSION_SCHEME_SPECS.get(scheme)
+        if spec is None:
+            raise ProfileAuthError(
+                f"no session spec registered for scheme {scheme!r}; "
+                f"stateless schemes route through build_static_headers"
+            )
+        return spec
+
+    async def _invalidate_session(self, target: Any) -> None:
+        """Drop the cached session token for *target*.
+
+        Called on a downstream session-expiry status so the next
+        :meth:`_session_token` re-establishes from a clean state. Holds the
+        lock so a concurrent re-establish doesn't race the invalidation.
+        Mirrors the typed connectors' re-login-once recovery seam; the
+        downstream-call retry loop that invokes it lands with the
+        profile-driven dispatch path (the dispatcher owns the wire call).
+        """
+        async with self._session_lock:
+            self._session_tokens.pop(target_cache_key(target), None)
+
+    # -- fingerprint / probe (G0.28-T6 #1972) ---------------------------
 
     async def fingerprint(
         self,
         target: Any,
         operator: Operator | None = None,
     ) -> FingerprintResult:
-        """Raise until the profile-driven fingerprint is wired (T6)."""
-        del operator  # unused until the profile machinery lands
-        raise NotImplementedError(_PROFILE_PENDING)
+        """Raise until the profile-driven fingerprint is wired (T6 #1972)."""
+        del operator  # unused until the profile-driven probe lands
+        raise NotImplementedError(_PROFILE_PENDING_PROBE)
 
     async def probe(self, target: Any) -> ProbeResult:
-        """Raise until the profile-driven probe is wired (T6)."""
-        raise NotImplementedError(_PROFILE_PENDING)
+        """Raise until the profile-driven probe is wired (T6 #1972)."""
+        raise NotImplementedError(_PROFILE_PENDING_PROBE)
 
     async def execute(
         self,
@@ -137,4 +446,19 @@ class ProfiledRestConnector(HttpConnector):
         :class:`OperationResult` annotation satisfies the
         :class:`~meho_backplane.connectors.base.Connector` ABC.
         """
-        raise NotImplementedError(_PROFILE_PENDING)
+        raise NotImplementedError(
+            "ProfiledRestConnector.execute is a dead shim; ingested ops dispatch "
+            "through dispatch_ingested off the EndpointDescriptor row, not here."
+        )
+
+    async def aclose(self) -> None:
+        """Clear cached session tokens then tear down the httpx pool.
+
+        No revoke is issued — the cached tokens are short-lived (TTL refresh
+        for ``oauth2_mint``; idle-expiry for ``session_login``) and a
+        per-target revoke round-trip during lifespan shutdown is more risk
+        than benefit (the same posture every typed session connector takes).
+        """
+        async with self._session_lock:
+            self._session_tokens.clear()
+        await super().aclose()

--- a/backend/tests/test_connectors_profiled_auth.py
+++ b/backend/tests/test_connectors_profiled_auth.py
@@ -1,0 +1,462 @@
+# SPDX-License-Identifier: Apache-2.0
+# Copyright (c) 2026 evoila Group
+
+"""Unit tests for the hoisted profile-driven auth harness (G0.28-T4 #1970).
+
+Pins the four acceptance criteria:
+
+* The per-target lock / token cache / single-flight / re-login-once /
+  empty-jwt fail-closed harness lives once in ``ProfiledRestConnector`` and
+  is exercised through the named auth scheme.
+* vRLI (``session_login``) + keycloak (``oauth2_mint``) auth each reduce to
+  a named member with no behaviour loss — token mint + refresh-on-expiry
+  parity tests for both.
+* ``per_user`` / impersonation is rejected with the standard
+  :exc:`NotImplementedError` pattern.
+* The empty-``raw_jwt`` fail-closed invariant has an explicit security test.
+
+The stateless schemes (``basic`` / ``static_header``) are covered too — they
+prove the catalog's no-session members produce the right header without a
+login round-trip.
+"""
+
+from __future__ import annotations
+
+import base64
+import time
+from dataclasses import dataclass, field
+from uuid import UUID, uuid4
+
+import httpx
+import pytest
+import respx
+
+from meho_backplane.auth.operator import Operator, TenantRole
+from meho_backplane.connectors._shared.cache_key import target_cache_key
+from meho_backplane.connectors._shared.profile_auth import ProfileAuthError
+from meho_backplane.connectors._shared.vault_creds import VaultCredentialsReadError
+from meho_backplane.connectors.profile import AuthSpec, ExecutionProfile
+from meho_backplane.connectors.profiled import ProfiledRestConnector
+from meho_backplane.connectors.schemas import AuthModel
+
+
+def _operator(raw_jwt: str = "op.test.jwt") -> Operator:
+    return Operator(
+        sub="test-operator",
+        name=None,
+        email=None,
+        raw_jwt=raw_jwt,
+        tenant_id=UUID(int=0),
+        tenant_role=TenantRole.OPERATOR,
+    )
+
+
+@dataclass
+class _StubTarget:
+    name: str
+    host: str
+    port: int | None = 443
+    secret_ref: str | None = "p/secret"
+    auth_model: str | None = AuthModel.SHARED_SERVICE_ACCOUNT.value
+    id: UUID = field(default_factory=uuid4)
+    tenant_id: UUID = field(default_factory=lambda: UUID(int=0))
+
+
+def _profile(scheme: str, **auth_overrides: object) -> ExecutionProfile:
+    """Build a profile for *scheme* with sensible per-scheme defaults."""
+    defaults: dict[str, object] = {
+        "basic": {"secret_fields": ("username", "password")},
+        "static_header": {"secret_fields": ("token",), "value_kind": "bearer"},
+        "session_login": {"secret_fields": ("username", "password")},
+        "oauth2_mint": {"secret_fields": ("client_id", "client_secret")},
+    }[scheme]
+    auth_kwargs: dict[str, object] = {"scheme": scheme, **defaults}
+    auth_kwargs.update(auth_overrides)
+    return ExecutionProfile(product="acme", version="1.0", auth=AuthSpec(**auth_kwargs))
+
+
+def _connector(
+    scheme: str,
+    secret: dict[str, str],
+    *,
+    profile: ExecutionProfile | None = None,
+) -> ProfiledRestConnector:
+    """Build a profiled connector with a stub loader returning *secret*."""
+
+    async def _loader(_target: object, _operator: Operator) -> dict[str, str]:
+        return dict(secret)
+
+    return ProfiledRestConnector(
+        profile=profile if profile is not None else _profile(scheme),
+        credentials_loader=_loader,
+    )
+
+
+# ---------------------------------------------------------------------------
+# Stateless schemes — basic / static_header
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.asyncio
+async def test_basic_scheme_builds_basic_auth_header_without_login() -> None:
+    """``basic`` computes Authorization: Basic <b64> from the secret bundle."""
+    connector = _connector("basic", {"username": "svc", "password": "pw"})
+    target = _StubTarget(name="t", host="t.invalid")
+
+    headers = await connector.auth_headers(target, operator=_operator())
+
+    expected = base64.b64encode(b"svc:pw").decode()
+    assert headers == {"Authorization": f"Basic {expected}"}
+    # No session token is cached for a stateless scheme.
+    assert connector._session_tokens == {}
+    await connector.aclose()
+
+
+@pytest.mark.asyncio
+async def test_static_header_bearer_wraps_token() -> None:
+    """``static_header`` with value_kind=bearer wraps the token as Bearer."""
+    connector = _connector("static_header", {"token": "pre-issued-xyz"})
+    target = _StubTarget(name="t", host="t.invalid")
+
+    headers = await connector.auth_headers(target, operator=_operator())
+
+    assert headers == {"Authorization": "Bearer pre-issued-xyz"}
+    await connector.aclose()
+
+
+@pytest.mark.asyncio
+async def test_static_header_raw_places_token_verbatim_in_custom_header() -> None:
+    """``static_header`` value_kind=raw places the token verbatim in a custom header."""
+    profile = _profile(
+        "static_header",
+        secret_fields=("token",),
+        value_kind="raw",
+        header_name="X-Api-Key",
+    )
+    connector = _connector("static_header", {"token": "raw-key"}, profile=profile)
+    target = _StubTarget(name="t", host="t.invalid")
+
+    headers = await connector.auth_headers(target, operator=_operator())
+
+    assert headers == {"X-Api-Key": "raw-key"}
+    await connector.aclose()
+
+
+# ---------------------------------------------------------------------------
+# session_login (vRLI parity) — mint + cache + single-flight + refresh
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.asyncio
+async def test_session_login_mints_token_via_json_post_and_returns_bearer() -> None:
+    """``session_login`` POSTs a JSON login body and returns Bearer <sessionId>.
+
+    Behaviour parity with VcfLogsConnector: JSON body, ``sessionId`` read
+    out of the response body, no Authorization header on the login POST.
+    """
+    connector = _connector("session_login", {"username": "svc", "password": "pw"})
+    target = _StubTarget(name="vrli", host="vrli.invalid")
+
+    async with respx.mock(base_url="https://vrli.invalid") as mock:
+        route = mock.post("/api/v2/sessions").respond(
+            200, json={"sessionId": "sess-abc", "ttl": 1800}
+        )
+        headers = await connector.auth_headers(target, operator=_operator())
+
+    assert headers == {"Authorization": "Bearer sess-abc"}
+    request = route.calls[0].request
+    assert request.headers.get("content-type", "").startswith("application/json")
+    import json
+
+    assert json.loads(request.read().decode()) == {
+        "username": "svc",
+        "password": "pw",
+        "provider": "Local",
+    }
+    # The login POST must NOT carry a stale Authorization header.
+    assert "authorization" not in {k.lower() for k in request.headers}
+    await connector.aclose()
+
+
+@pytest.mark.asyncio
+async def test_session_login_caches_token_single_flight() -> None:
+    """A second call reuses the cached session — exactly one login POST."""
+    connector = _connector("session_login", {"username": "svc", "password": "pw"})
+    target = _StubTarget(name="vrli", host="vrli.invalid")
+
+    async with respx.mock(base_url="https://vrli.invalid") as mock:
+        route = mock.post("/api/v2/sessions").respond(
+            200, json={"sessionId": "sess-cached", "ttl": 1800}
+        )
+        h1 = await connector.auth_headers(target, operator=_operator())
+        h2 = await connector.auth_headers(target, operator=_operator())
+
+    assert h1 == h2 == {"Authorization": "Bearer sess-cached"}
+    assert route.call_count == 1
+    await connector.aclose()
+
+
+@pytest.mark.asyncio
+async def test_session_login_does_not_proactively_expire_on_ttl() -> None:
+    """A session_login token has no proactive TTL — it caches until invalidated.
+
+    vRLI's session is idle-expiry-driven, recovered by a downstream
+    re-login. The cache entry must therefore carry ``expires_at=None`` so a
+    long-lived connector keeps reusing the token rather than re-minting on a
+    clock-based margin (behaviour parity with the typed connector).
+    """
+    connector = _connector("session_login", {"username": "svc", "password": "pw"})
+    target = _StubTarget(name="vrli", host="vrli.invalid")
+
+    async with respx.mock(base_url="https://vrli.invalid") as mock:
+        mock.post("/api/v2/sessions").respond(200, json={"sessionId": "s", "ttl": 5})
+        await connector.auth_headers(target, operator=_operator())
+
+    cached = connector._session_tokens[target_cache_key(target)]
+    assert cached.expires_at is None
+    assert cached.is_fresh(time.monotonic() + 10_000) is True
+    await connector.aclose()
+
+
+@pytest.mark.asyncio
+async def test_session_login_missing_token_raises_naming_scheme_and_target() -> None:
+    """A 2xx login with no sessionId raises ProfileAuthError naming the target."""
+    connector = _connector("session_login", {"username": "svc", "password": "pw"})
+    target = _StubTarget(name="vrli", host="vrli.invalid")
+
+    async with respx.mock(base_url="https://vrli.invalid") as mock:
+        mock.post("/api/v2/sessions").respond(200, json={"ttl": 1800})
+        with pytest.raises(ProfileAuthError, match=r"vrli") as exc:
+            await connector.auth_headers(target, operator=_operator())
+
+    assert "session_login" in str(exc.value)
+    await connector.aclose()
+
+
+# ---------------------------------------------------------------------------
+# oauth2_mint (keycloak parity) — form grant + TTL refresh
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.asyncio
+async def test_oauth2_mint_uses_form_client_credentials_grant() -> None:
+    """``oauth2_mint`` POSTs a form-encoded client-credentials grant.
+
+    Behaviour parity with KeycloakConnector: form body (NOT JSON),
+    grant_type=client_credentials, client_id/client_secret from the secret
+    bundle, Bearer access_token returned.
+    """
+    connector = _connector("oauth2_mint", {"client_id": "cid", "client_secret": "csec"})
+    target = _StubTarget(name="kc", host="kc.invalid")
+
+    async with respx.mock(base_url="https://kc.invalid") as mock:
+        route = mock.post("/realms/master/protocol/openid-connect/token").respond(
+            200, json={"access_token": "tok-kc", "expires_in": 300}
+        )
+        headers = await connector.auth_headers(target, operator=_operator())
+
+    assert headers == {"Authorization": "Bearer tok-kc"}
+    request = route.calls[0].request
+    assert request.headers.get("content-type", "").startswith("application/x-www-form-urlencoded")
+    # Form-encoded body carries the grant fields.
+    body = request.read().decode()
+    assert "grant_type=client_credentials" in body
+    assert "client_id=cid" in body
+    assert "client_secret=csec" in body
+    await connector.aclose()
+
+
+@pytest.mark.asyncio
+async def test_oauth2_mint_refreshes_on_ttl_expiry(monkeypatch: pytest.MonkeyPatch) -> None:
+    """An oauth2_mint token re-mints once the monotonic clock passes its TTL.
+
+    The refresh-on-expiry half of the behaviour-parity criterion: with a
+    short ``expires_in``, advancing the monotonic clock past the
+    margin-adjusted TTL forces a second token mint rather than serving the
+    stale token.
+    """
+    connector = _connector("oauth2_mint", {"client_id": "cid", "client_secret": "csec"})
+    target = _StubTarget(name="kc", host="kc.invalid")
+
+    clock = {"t": 1000.0}
+    monkeypatch.setattr("meho_backplane.connectors.profiled.time.monotonic", lambda: clock["t"])
+
+    async with respx.mock(base_url="https://kc.invalid") as mock:
+        route = mock.post("/realms/master/protocol/openid-connect/token")
+        route.side_effect = [
+            httpx.Response(200, json={"access_token": "tok-1", "expires_in": 60}),
+            httpx.Response(200, json={"access_token": "tok-2", "expires_in": 60}),
+        ]
+        h1 = await connector.auth_headers(target, operator=_operator())
+        # expires_in=60 minus 30s margin => fresh for 30s; advance past it.
+        clock["t"] += 31.0
+        h2 = await connector.auth_headers(target, operator=_operator())
+
+    assert h1 == {"Authorization": "Bearer tok-1"}
+    assert h2 == {"Authorization": "Bearer tok-2"}
+    assert route.call_count == 2
+    await connector.aclose()
+
+
+@pytest.mark.asyncio
+async def test_oauth2_mint_caches_within_ttl() -> None:
+    """Within the TTL window the token is reused — one mint for two calls."""
+    connector = _connector("oauth2_mint", {"client_id": "cid", "client_secret": "csec"})
+    target = _StubTarget(name="kc", host="kc.invalid")
+
+    async with respx.mock(base_url="https://kc.invalid") as mock:
+        route = mock.post("/realms/master/protocol/openid-connect/token").respond(
+            200, json={"access_token": "tok", "expires_in": 3600}
+        )
+        await connector.auth_headers(target, operator=_operator())
+        await connector.auth_headers(target, operator=_operator())
+
+    assert route.call_count == 1
+    await connector.aclose()
+
+
+# ---------------------------------------------------------------------------
+# Per-target isolation — the hoisted cache keys on (tenant_id, id)
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.asyncio
+async def test_per_target_isolation_keeps_tokens_separate() -> None:
+    """Two targets get two distinct cached tokens; no cross-target leakage."""
+    connector = _connector("session_login", {"username": "svc", "password": "pw"})
+    target_a = _StubTarget(name="a", host="a.invalid")
+    target_b = _StubTarget(name="b", host="b.invalid")
+
+    async with respx.mock() as mock:
+        mock.post("https://a.invalid/api/v2/sessions").respond(200, json={"sessionId": "tok-a"})
+        mock.post("https://b.invalid/api/v2/sessions").respond(200, json={"sessionId": "tok-b"})
+        h_a = await connector.auth_headers(target_a, operator=_operator())
+        h_b = await connector.auth_headers(target_b, operator=_operator())
+
+    assert h_a == {"Authorization": "Bearer tok-a"}
+    assert h_b == {"Authorization": "Bearer tok-b"}
+    assert connector._session_tokens[target_cache_key(target_a)].token == "tok-a"
+    assert connector._session_tokens[target_cache_key(target_b)].token == "tok-b"
+    await connector.aclose()
+
+
+# ---------------------------------------------------------------------------
+# Auth-model gating — per_user / impersonation rejected (AC3)
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.asyncio
+@pytest.mark.parametrize(
+    "auth_model",
+    [AuthModel.PER_USER.value, AuthModel.IMPERSONATION.value, "unknown-mode"],
+)
+async def test_rejects_non_shared_service_account_modes(auth_model: str) -> None:
+    """per_user / impersonation raise NotImplementedError naming target + mode."""
+    connector = _connector("session_login", {"username": "svc", "password": "pw"})
+    target = _StubTarget(name="t-pu", host="t.invalid", auth_model=auth_model)
+
+    with pytest.raises(NotImplementedError) as exc:
+        await connector.auth_headers(target, operator=_operator())
+
+    assert "t-pu" in str(exc.value)
+    assert auth_model in str(exc.value)
+    await connector.aclose()
+
+
+@pytest.mark.asyncio
+async def test_accepts_none_auth_model_for_pre_g03_targets() -> None:
+    """auth_model=None (pre-G0.3) is accepted (basic scheme, no login)."""
+    connector = _connector("basic", {"username": "u", "password": "p"})
+    target = _StubTarget(name="t", host="t.invalid", auth_model=None)
+
+    headers = await connector.auth_headers(target, operator=_operator())
+    assert headers["Authorization"].startswith("Basic ")
+    await connector.aclose()
+
+
+# ---------------------------------------------------------------------------
+# Empty-jwt fail-closed invariant (AC4) — explicit security test
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.asyncio
+async def test_empty_jwt_fails_closed_before_session_cache_lookup() -> None:
+    """A system-initiated caller (empty raw_jwt) is rejected before the cache.
+
+    Security-load-bearing invariant: a token primed by an authenticated
+    caller must never be served to an empty-JWT caller via a cache hit. The
+    guard runs before the cache lookup, so even with a warm cache the
+    empty-JWT call fails closed.
+    """
+    connector = _connector("session_login", {"username": "svc", "password": "pw"})
+    target = _StubTarget(name="vrli", host="vrli.invalid")
+
+    # Prime the cache with an authenticated caller.
+    async with respx.mock(base_url="https://vrli.invalid") as mock:
+        mock.post("/api/v2/sessions").respond(200, json={"sessionId": "warm"})
+        await connector.auth_headers(target, operator=_operator())
+    assert target_cache_key(target) in connector._session_tokens
+
+    # An empty-JWT caller must NOT be served the warm token.
+    with pytest.raises(VaultCredentialsReadError, match=r"vrli"):
+        await connector.auth_headers(target, operator=_operator(raw_jwt=""))
+    await connector.aclose()
+
+
+@pytest.mark.asyncio
+async def test_empty_jwt_does_not_leak_token_to_unauthenticated_caller() -> None:
+    """The empty-JWT rejection returns no token even when the cache is warm."""
+    connector = _connector("oauth2_mint", {"client_id": "c", "client_secret": "s"})
+    target = _StubTarget(name="kc", host="kc.invalid")
+
+    with pytest.raises(VaultCredentialsReadError):
+        await connector.auth_headers(target, operator=_operator(raw_jwt=""))
+    # No mint happened, no token cached.
+    assert connector._session_tokens == {}
+    await connector.aclose()
+
+
+# ---------------------------------------------------------------------------
+# aclose + no-profile guard
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.asyncio
+async def test_aclose_clears_session_cache_and_pool() -> None:
+    """aclose() clears the session-token cache and tears down the httpx pool."""
+    connector = _connector("session_login", {"username": "svc", "password": "pw"})
+    target = _StubTarget(name="vrli", host="vrli.invalid")
+
+    async with respx.mock(base_url="https://vrli.invalid") as mock:
+        mock.post("/api/v2/sessions").respond(200, json={"sessionId": "tok"})
+        await connector.auth_headers(target, operator=_operator())
+
+    assert connector._session_tokens != {}
+    await connector.aclose()
+    assert connector._session_tokens == {}
+    assert connector._clients == {}
+
+
+@pytest.mark.asyncio
+async def test_no_profile_attached_raises_naming_target() -> None:
+    """A profiled connector with no profile raises a clear NotImplementedError."""
+    connector = ProfiledRestConnector()
+    target = _StubTarget(name="orphan", host="t.invalid")
+
+    with pytest.raises(NotImplementedError, match=r"orphan"):
+        await connector.auth_headers(target, operator=_operator())
+    await connector.aclose()
+
+
+def test_class_attribute_profile_is_used_when_not_injected() -> None:
+    """A stamped subclass carrying a class-level profile is used at construction."""
+
+    class _StampedProfiled(ProfiledRestConnector):
+        product = "acme"
+        supported_version_range = ">=1.0,<2.0"
+        profile = _profile("basic")
+
+    instance = _StampedProfiled()
+    assert instance.profile is _StampedProfiled.profile
+    assert instance.profile is not None
+    assert instance.profile.auth.scheme == "basic"

--- a/docs/codebase/connector-auth-coverage.md
+++ b/docs/codebase/connector-auth-coverage.md
@@ -84,10 +84,52 @@ deferred out of T3's read-only scope. Read dispatch (the T3 target) needs
 only the auth slot filled, which the named-scheme catalog covers for the
 six in-catalog connectors.
 
+## T4 (#1970) — the runtime extractors + hoisted session harness
+
+T3's catalog named four schemes; T4 lands the Python that runs them, so a
+stamped `ProfiledRestConnector` actually dispatches. Each `AuthSchemeName`
+value now resolves to one vetted extractor, with **no behaviour loss**
+against the typed connectors the row was grounded on:
+
+- **`basic` / `static_header`** — *stateless*. `build_static_headers` in
+  `backend/src/meho_backplane/connectors/_shared/profile_auth.py` computes
+  the header from the secret bundle on every call (Basic `base64(user:pass)`;
+  bearer-wrapped or raw pre-issued token per `value_kind`). No token cache,
+  no login round-trip.
+- **`session_login` (vRLI) / `oauth2_mint` (keycloak)** — *session-stateful*.
+  The per-target lock / token cache (keyed `(tenant_id, id)`) / single-flight
+  / TTL-or-expiry refresh / empty-`raw_jwt` fail-closed harness lives **once**
+  in `ProfiledRestConnector` (it was duplicated across `vcf_logs` and
+  `keycloak` before). The scheme-specific login mechanics — login path, body
+  encoding (`json` for vRLI's `{username,password,provider}`, `form` for the
+  OAuth2 client-credentials grant), and the token + TTL extractor — are
+  `SessionSchemeSpec` entries in `SESSION_SCHEME_SPECS`, selected by
+  `profile.auth.scheme`. `session_login` caches until a downstream re-login
+  (idle-expiry, `ttl_seconds=None`); `oauth2_mint` re-mints once the
+  monotonic clock passes the margin-adjusted `expires_in`.
+
+The login POST goes through the pooled `httpx.AsyncClient` directly (not the
+`auth_headers`-stamping `_post_json` seam) — the login *is* what establishes
+auth, so routing it through `auth_headers` would recurse and deadlock on the
+session lock. `auth_headers` rejects `per_user` / impersonation with the
+standard `NotImplementedError` (a profile is a `shared_service_account`
+construct). The default credential loader reads exactly the profile's
+declared `secret_fields` via the shared `load_basic_credentials` helper, so
+`static_header` (`token`) and `oauth2_mint` (`client_id`/`client_secret`)
+resolve the right secret shape through the one fail-closed reader.
+
+NSX stays typed (the `cookie_jar_session` reserved scheme): its
+`JSESSIONID` Set-Cookie jar cannot be modeled by the `dict[str, str]`
+`auth_headers` return contract.
+
 ## References
 
 - `backend/src/meho_backplane/connectors/profile.py` — the schema + catalog.
-- `backend/src/meho_backplane/connectors/profiled.py` — T1 (#1967) dispatchable sibling.
+- `backend/src/meho_backplane/connectors/profiled.py` — T1 (#1967)
+  dispatchable sibling; T4 (#1970) hoisted session harness + scheme-driven
+  `auth_headers`.
+- `backend/src/meho_backplane/connectors/_shared/profile_auth.py` — T4
+  (#1970) named extractors (`build_static_headers`, `SESSION_SCHEME_SPECS`).
 - `docs/architecture/runbooks.md` — the closed-vocabulary / no-DSL line (#1177).
 - Precedents modeled on: `connectors/schemas.AuthModel` (StrEnum),
   `auth/permissions.safety_level` (Literal + ceiling),


### PR DESCRIPTION
## Summary
- Hoists the per-target session-lifecycle + token-cache harness (lock / token cache keyed `(tenant_id, id)` / single-flight / refresh-on-expiry / empty-`raw_jwt` fail-closed) **once** into `ProfiledRestConnector`, parameterised by the profile's named auth scheme — it was copy-pasted across the vRLI and keycloak typed connectors before.
- Adds `_shared/profile_auth.py`: the runtime half of the T3 (#1969) named-auth catalog. Each `AuthSchemeName` value resolves to one vetted extractor — `basic` / `static_header` are stateless (`build_static_headers`); `session_login` (vRLI: JSON login → body `.sessionId` → Bearer) and `oauth2_mint` (keycloak: form client-credentials grant → Bearer with TTL) are session-stateful `SessionSchemeSpec` entries the hoisted harness drives.
- vRLI + keycloak auth each reduce to a named member with **no behaviour loss**: token mint + refresh-on-expiry parity tests for both.
- `auth_headers` hardcodes `shared_service_account` and rejects `per_user`/impersonation with the standard `NotImplementedError` pattern; the empty-`raw_jwt` fail-closed invariant is preserved (guarded before the cache lookup) with an explicit security test.
- NSX stays typed — its `JSESSIONID` cookie-jar auth (the `cookie_jar_session` reserved scheme) cannot be modeled by the `dict[str, str]` `auth_headers` return contract.

The login POST goes through the pooled `httpx.AsyncClient` directly rather than the `auth_headers`-stamping `_post_json` seam: the login *is* what establishes auth, so routing it through `auth_headers` would recurse and deadlock on the session lock.

## Test plan
- [x] `ruff check` / `ruff format --check` — clean (connectors + new test)
- [x] `mypy src/meho_backplane/connectors/` — clean (149 files)
- [x] `pytest tests/test_connectors_profiled_auth.py` — 20 passed (the four ACs: harness lives once + exercised via scheme; vRLI+keycloak named-member parity incl. refresh-on-expiry; per_user/impersonation rejected; empty-jwt fail-closed security test)
- [x] Regression: `tristate` + `execution_profile` + `profile_stamp_gate` + `vcf_logs_auth` + `keycloak_auth` + new suite — 118 passed
- [x] `code-quality.py --diff` — 0 blockers (profiled.py 465 lines, under the 600 block threshold; recorded)

## Out of scope
- Profile-driven `fingerprint` / `probe` + pagination (T6 #1972 — those two methods still raise `NotImplementedError`).
- The downstream-call re-login-once retry *loop* (the dispatcher owns the wire call); the `_invalidate_session` seam is in place for it.
- Migrating the typed vRLI/keycloak connectors onto the harness (they keep their own copies; this lands the shared one for profiled connectors).

<!-- auto-implement-issue: fresh, iteration 1 -->

Closes #1970


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **New Features**
  * Added support for multiple authentication schemes including basic authentication, bearer token authentication, and session-based OAuth2 authentication
  * Implemented automatic session token caching and refresh capabilities
  * Enhanced authentication validation and error handling for improved reliability

* **Documentation**
  * Updated connector authentication documentation with details on all supported authentication schemes

<!-- end of auto-generated comment: release notes by coderabbit.ai -->