### PR TITLE
feat(ui): read-only Keycloak console — realm config + client list/detail + client-scope list (#1959)

### DIFF
--- a/backend/src/meho_backplane/ui/routes/__init__.py
+++ b/backend/src/meho_backplane/ui/routes/__init__.py
@@ -99,6 +99,7 @@ from meho_backplane.ui.routes.conventions import build_conventions_router
 from meho_backplane.ui.routes.corpus import build_corpus_router
 from meho_backplane.ui.routes.dashboard import build_dashboard_router
 from meho_backplane.ui.routes.kb import build_kb_router
+from meho_backplane.ui.routes.keycloak import build_keycloak_router
 from meho_backplane.ui.routes.memory import build_memory_router
 from meho_backplane.ui.routes.operations import build_operations_router
 from meho_backplane.ui.routes.retrieval import build_retrieval_router
@@ -119,6 +120,7 @@ __all__ = [
     "build_corpus_router",
     "build_dashboard_router",
     "build_kb_router",
+    "build_keycloak_router",
     "build_memory_router",
     "build_operations_router",
     "build_retrieval_router",
@@ -131,6 +133,13 @@ __all__ = [
 ]
 
 
+# A flat router-registration aggregate: every console surface contributes
+# one ``router.include_router(...)`` line (plus an ordering rationale
+# comment). Splitting it would break the single-place registration-order
+# contract this function exists to hold -- first-match-wins ordering is only
+# legible when every include is in one linear list. Each surface's own
+# router stays a separate factory.
+# code-quality-allow: function-size -- linear include aggregate, see above.
 def build_router() -> APIRouter:
     """Aggregate the dashboard + surface routers (broadcast … runbooks).
 
@@ -209,6 +218,17 @@ def build_router() -> APIRouter:
     # segment can never bind as a descriptor id; registered before the
     # stubs aggregate so its concrete paths win the first-match-wins lookup.
     router.include_router(build_operations_router())
+    # Keycloak console (Initiative #1943, G10.x-T1 #1959): the read-only realm
+    # browser -- ``/ui/keycloak`` (realm-config card + client list +
+    # client-scope list) + ``/ui/keycloak/clients/{client_uuid}`` (per-client
+    # detail). All surfaces dispatch the curated ``keycloak.*`` read ops
+    # in-process through ``call_operation`` against the PINNED
+    # ``connector_id="keycloak-admin-26.x"`` (never the bare ``keycloak``
+    # slug). The only ``{param}`` route sits under the distinct
+    # ``/ui/keycloak/clients/`` prefix, so a future literal ``/ui/keycloak/users``
+    # (T2) registered before any ``{param}`` route binds first; included before
+    # the stubs aggregate so its concrete paths win the first-match-wins lookup.
+    router.include_router(build_keycloak_router())
     # Audit-query forensic console (G10.15-T1 #1944): ``/ui/audit`` (filter
     # form + first result page) + ``/ui/audit/results`` (filter-submit +
     # forward-cursor "Load more" fragment). Reads dispatch the

--- a/backend/src/meho_backplane/ui/routes/keycloak/__init__.py
+++ b/backend/src/meho_backplane/ui/routes/keycloak/__init__.py
@@ -1,0 +1,24 @@
+# SPDX-License-Identifier: Apache-2.0
+# Copyright (c) 2026 evoila Group
+
+"""Keycloak console UI package.
+
+Initiative #1943 (G10.x Keycloak console), Task #1959 (T1). The
+read-only realm-administration scaffold: a realm-config card, the
+realm's client list + per-client detail, and the realm's client-scope
+list -- all rendered from the curated ``keycloak.*`` read ops dispatched
+in-process through the operation meta-tools.
+
+The router (:func:`build_keycloak_router`) is a thin BFF over
+:func:`meho_backplane.operations.meta_tools.call_operation` called
+in-process, mirroring the operations launcher's session-BFF precedent
+(:mod:`meho_backplane.ui.routes.operations`) rather than any Bearer-gated
+REST surface (there is none for Keycloak -- the CLI verbs ride the
+operations dispatcher too).
+"""
+
+from __future__ import annotations
+
+from meho_backplane.ui.routes.keycloak.routes import build_keycloak_router
+
+__all__ = ["build_keycloak_router"]

--- a/backend/src/meho_backplane/ui/routes/keycloak/routes.py
+++ b/backend/src/meho_backplane/ui/routes/keycloak/routes.py
@@ -1,0 +1,424 @@
+# SPDX-License-Identifier: Apache-2.0
+# Copyright (c) 2026 evoila Group
+
+"""Keycloak console UI routes: realm config + client list/detail + scope list.
+
+Initiative #1943 (G10.x Keycloak console), Task #1959 (T1, read-only
+scaffold). MEHO already administers a Keycloak realm end-to-end from the
+CLI (``meho keycloak realm/client/client-scope ...``), but the operator
+console has had no realm-administration surface -- only the narrow
+agent-principals kill switch at ``/ui/agents/principals`` (#1831/#1866).
+This package adds the read-only realm browser the two write tasks (T2 user
+management, T3 scope/mapper management) build on.
+
+Why a session BFF and not a REST surface
+----------------------------------------
+
+There is **no** ``/api/v1/keycloak`` REST surface: every CLI keycloak verb
+is a thin Cobra layer over ``POST /api/v1/operations/call`` against the
+pre-baked ``connector_id="keycloak-admin-26.x"`` (the CLI's
+``ConnectorID`` constant, ``cli/internal/cmd/keycloak/keycloak.go``).
+Keycloak admin flows ride the operations dispatcher. So this console is
+pure UI/BFF assembly: it dispatches the curated ``keycloak.*`` **read**
+ops in-process through
+:func:`~meho_backplane.operations.meta_tools.call_operation` -- the exact
+in-process pattern the MERGED ``/ui/operations`` console uses
+(:mod:`meho_backplane.ui.routes.operations.routes`) -- and renders a
+domain-shaped UX (realm-config card, client list/detail, client-scope
+list) instead of the generic op drawer. A browser carrying only the BFF
+session cookie cannot authenticate the Bearer-gated REST routes, so the
+in-process call is the only path.
+
+connector_id is pinned (load-bearing)
+-------------------------------------
+
+The dispatched ``connector_id`` is the module constant
+:data:`KEYCLOAK_CONNECTOR_ID` (``"keycloak-admin-26.x"``) -- never typed
+by the operator, never re-derived from the bare product slug
+``keycloak``. The bare slug parses to ``(product="keycloak", version="",
+impl_id="")`` (:func:`~meho_backplane.operations._lookup.parse_connector_id`)
+which names no registered connector and dead-ends the dispatch. The slug
+the operator *does* pick is the **target** slug (which Keycloak deployment
+to read), carried on the query string; the connector is fixed.
+
+Read ops dispatched (all ``safety_level="safe"`` / no approval)
+---------------------------------------------------------------
+
+* ``keycloak.realm.get`` -- the managed realm's top-level config.
+* ``keycloak.client.list`` -- the realm's clients (``{rows, total}``).
+* ``keycloak.client.get`` -- one client by **internal UUID** (the ``id``
+  from a list row, NOT the human ``clientId``).
+* ``keycloak.client_scope.list`` -- the realm's client scopes.
+
+(``keycloak.user.list`` / ``keycloak.role_mapping.get`` exist too but are
+T2's surface; this scaffold does not touch them.)
+
+Secret redaction is upstream, not here (load-bearing)
+-----------------------------------------------------
+
+Every keycloak read op scrubs nested secrets at the connector boundary
+(:func:`~meho_backplane.connectors.keycloak.redaction.redact_secret_fields`)
+before the result leaves the connector, substituting the ``REDACTED``
+sentinel. The UI **trusts** this and never re-exposes the raw envelope:
+the templates render projected, named fields (clientId, enabled, redirect
+URIs, protocol mappers, ...) -- they never dump the verbatim
+``OperationResult`` blob into the page, which would re-surface whatever a
+future op forgot to scrub. The realm/client/scope dicts carried inside the
+envelope's ``result`` are already secret-free by the connector's
+guarantee.
+
+RBAC: reads are operator-tier
+-----------------------------
+
+The dispatch is gated only by :func:`require_ui_session`; the underlying
+``POST /api/v1/operations/call`` is ``_require_operator``
+(``TenantRole.OPERATOR``), so a plain operator can read every surface
+here. The page still threads an ``is_tenant_admin`` flag (via the
+soft-failing :func:`resolve_role_probe`) so T2/T3 can hide their write
+affordances from operators -- but a non-admin render must succeed, which
+the RBAC test asserts.
+
+Tenant isolation
+----------------
+
+The target list and the dispatch both derive ``tenant_id`` from the
+validated session only (via the lifted :class:`Operator`). There is **no**
+tenant-override query/form param: a cross-tenant target slug is simply
+absent from the operator's target list and dispatches against nothing --
+the no-tenant-override posture the kb router documents (cross-tenant slug
+-> 404, never a cross-tenant escape). A cross-tenant target/realm selector
+is deferred console-wide (#865).
+
+Route ordering
+--------------
+
+The literal ``/ui/keycloak/clients/{client_uuid}`` route registers BEFORE
+the bare ``/ui/keycloak`` index; the only ``{param}`` route sits under the
+distinct ``/ui/keycloak/clients/`` prefix, so a future literal segment
+(``/ui/keycloak/users`` in T2) registered ahead of any ``{param}`` route
+binds first (first-match-wins -- the discipline the operations router
+documents). The router is registered ahead of the stubs aggregate in
+:func:`meho_backplane.ui.routes.build_router`.
+"""
+
+from __future__ import annotations
+
+from typing import Any, Final
+
+import structlog
+from fastapi import APIRouter, Depends, HTTPException, Query, Request, status
+from fastapi.responses import HTMLResponse
+from sqlalchemy import select
+
+from meho_backplane.auth.jwt import verify_jwt_for_audience
+from meho_backplane.auth.operator import Operator
+from meho_backplane.db.engine import get_sessionmaker
+from meho_backplane.db.models import Target as TargetORM
+from meho_backplane.operations.meta_tools import call_operation
+from meho_backplane.settings import get_settings
+from meho_backplane.ui.auth.middleware import UISessionContext, require_ui_session
+from meho_backplane.ui.auth.session_store import load_session
+from meho_backplane.ui.routes.connectors.operator import (
+    OperatorRoleProbe,
+    resolve_role_probe,
+)
+from meho_backplane.ui.templating import get_templates
+
+__all__ = ["KEYCLOAK_CONNECTOR_ID", "KEYCLOAK_PRODUCT", "build_keycloak_router"]
+
+log = structlog.get_logger(__name__)
+
+#: The pinned dispatchable connector id for every keycloak read op. Mirrors
+#: the CLI's ``ConnectorID`` constant (``cli/internal/cmd/keycloak/keycloak.go``).
+#: The bare product slug ``keycloak`` names no connector
+#: (:func:`~meho_backplane.operations._lookup.parse_connector_id`); only
+#: this ``<impl_id>-<version>`` form resolves through the dispatcher. Never
+#: typed by the operator, never re-derived from the slug.
+KEYCLOAK_CONNECTOR_ID: Final[str] = "keycloak-admin-26.x"
+
+#: The ``Target.product`` value the keycloak deployments register under.
+#: Used to scope the target picker to keycloak targets the operator's
+#: tenant owns.
+KEYCLOAK_PRODUCT: Final[str] = "keycloak"
+
+#: Maximum target-slug length accepted on the query string. A target slug
+#: is a short name (``rdc-keycloak``); the bound rejects an oversized paste
+#: at the form boundary (422) before it reaches the dispatch.
+_MAX_TARGET_LENGTH: Final[int] = 256
+
+#: Module-level ``Depends`` closures -- built once (rather than inline) to
+#: satisfy ruff B008, matching the operations / approvals / kb routers.
+_require_session = Depends(require_ui_session)
+_role_probe_dep = Depends(resolve_role_probe)
+
+
+async def _resolve_operator(session: UISessionContext) -> Operator:
+    """Reconstruct the full :class:`Operator` from the BFF session.
+
+    The dispatch needs a real :class:`Operator` (the meta-tool reads
+    ``operator.tenant_id`` for the tenant-scoped resolve, and the keycloak
+    read ops authorise the operator-context Vault read that backs the
+    admin-token mint). Mirrors the operations console's lift: load the
+    decrypted session row and re-verify its access token through the
+    chassis JWT chain so a same-session role demotion is caught on the next
+    browse rather than cached for the session TTL.
+
+    Raises :class:`fastapi.HTTPException` 401 when the session was revoked
+    / expired between the middleware check and here.
+    """
+    sessionmaker = get_sessionmaker()
+    async with sessionmaker() as db_session, db_session.begin():
+        decrypted = await load_session(db_session, session.session_id)
+    if decrypted is None:
+        raise HTTPException(
+            status_code=status.HTTP_401_UNAUTHORIZED,
+            detail="ui_session_required",
+        )
+    settings = get_settings()
+    return await verify_jwt_for_audience(
+        f"Bearer {decrypted.access_token}",
+        expected_audience=settings.keycloak_audience,
+    )
+
+
+async def _list_keycloak_targets(operator: Operator) -> list[dict[str, Any]]:
+    """Project the tenant's keycloak targets into the picker's option shape.
+
+    Tenant-scoped to ``operator.tenant_id`` only -- no query/header/path
+    tenant override, so a cross-tenant keycloak target never enters the
+    rendered set. Filtered to ``product == "keycloak"`` so the picker lists
+    only deployments the keycloak read ops can dispatch against.
+    """
+    sessionmaker = get_sessionmaker()
+    async with sessionmaker() as db_session:
+        result = await db_session.execute(
+            select(TargetORM.name)
+            .where(
+                TargetORM.tenant_id == operator.tenant_id,
+                TargetORM.product == KEYCLOAK_PRODUCT,
+            )
+            .order_by(TargetORM.name)
+        )
+        return [{"name": name} for name in result.scalars().all()]
+
+
+def _dispatch_failed(envelope: dict[str, Any]) -> str | None:
+    """Return a human error string when *envelope* is not a clean ``ok``.
+
+    ``call_operation`` always returns a structured envelope -- a denied /
+    errored / unavailable dispatch lands as ``status != "ok"`` with the
+    cause in ``error``, never as an exception. The index surfaces that
+    inline so a bad target or an unreachable Keycloak is a legible banner,
+    not an empty card.
+    """
+    if envelope.get("status") == "ok":
+        return None
+    return envelope.get("error") or envelope.get("status") or "dispatch_failed"
+
+
+async def _dispatch_read(
+    operator: Operator,
+    *,
+    op_id: str,
+    target: str,
+    params: dict[str, Any] | None = None,
+) -> dict[str, Any]:
+    """Dispatch one keycloak read op in-process against the pinned connector.
+
+    The ``connector_id`` is :data:`KEYCLOAK_CONNECTOR_ID` -- pinned, never
+    the bare slug. The structured envelope is returned verbatim; callers
+    read ``status`` / ``result`` / ``error`` off it.
+    """
+    return await call_operation(
+        operator,
+        {
+            "connector_id": KEYCLOAK_CONNECTOR_ID,
+            "op_id": op_id,
+            "target": target,
+            "params": params or {},
+        },
+    )
+
+
+def build_keycloak_router() -> APIRouter:
+    """Construct the ``/ui/keycloak*`` :class:`APIRouter`.
+
+    Factory function (not a module-level constant) so a test app can
+    construct parallel routers without shared route state -- the convention
+    every surface router (operations / approvals / kb / connectors)
+    follows. Registered ahead of the stubs aggregate in
+    :func:`meho_backplane.ui.routes.build_router`.
+    """
+    router = APIRouter(tags=["ui-keycloak"])
+
+    # NOTE: the literal ``/ui/keycloak/clients/{client_uuid}`` route is
+    # registered BEFORE the bare ``/ui/keycloak`` index. The only ``{param}``
+    # route sits under the distinct ``/ui/keycloak/clients/`` prefix, so a
+    # future literal segment (``/ui/keycloak/users`` in T2) registered ahead
+    # of any ``{param}`` route binds first (first-match-wins -- the ordering
+    # discipline the operations / approvals routers document).
+
+    @router.get("/ui/keycloak/clients/{client_uuid}", response_class=HTMLResponse)
+    async def keycloak_client_detail(
+        request: Request,
+        client_uuid: str,
+        session: UISessionContext = _require_session,
+        target: str = Query(default="", max_length=_MAX_TARGET_LENGTH),
+        role_probe: OperatorRoleProbe = _role_probe_dep,
+    ) -> HTMLResponse:
+        """Render the client-detail fragment for *client_uuid* (read-only).
+
+        ``client_uuid`` is the client's **internal UUID** (the ``id`` from a
+        ``keycloak.client.list`` row, NOT the human ``clientId``). Dispatches
+        ``keycloak.client.get`` and renders projected, redaction-trusting
+        fields only -- the client secret is already scrubbed by the
+        connector; the raw envelope is NEVER dumped into the page.
+        """
+        return await _render_client_detail(request, session, client_uuid, target, role_probe)
+
+    @router.get("/ui/keycloak", response_class=HTMLResponse)
+    async def keycloak_index(
+        request: Request,
+        session: UISessionContext = _require_session,
+        target: str = Query(default="", max_length=_MAX_TARGET_LENGTH),
+        role_probe: OperatorRoleProbe = _role_probe_dep,
+    ) -> HTMLResponse:
+        """Render the full-page realm browser.
+
+        Lists the tenant's keycloak targets in a picker; when a target is
+        selected (or there is exactly one), dispatches ``keycloak.realm.get``
+        + ``keycloak.client.list`` + ``keycloak.client_scope.list`` and
+        renders the realm-config card + client list + client-scope list. All
+        dispatches pin ``connector_id`` to :data:`KEYCLOAK_CONNECTOR_ID`.
+        """
+        return await _render_index(request, session, target, role_probe)
+
+    return router
+
+
+async def _render_index(
+    request: Request,
+    session: UISessionContext,
+    target: str,
+    role_probe: OperatorRoleProbe,
+) -> HTMLResponse:
+    """Assemble + render the realm-browser page context."""
+    operator = await _resolve_operator(session)
+    targets = await _list_keycloak_targets(operator)
+
+    # Resolve the active target: an explicit (in-list) selection wins;
+    # otherwise default to the sole target when exactly one exists. A
+    # selection that is NOT in the operator's tenant-scoped list is dropped
+    # (treated as no selection) -- the no-tenant-override posture: a
+    # cross-tenant slug can never drive a dispatch.
+    target = target.strip()
+    target_names = {t["name"] for t in targets}
+    active_target: str | None = None
+    if target and target in target_names:
+        active_target = target
+    elif not target and len(targets) == 1:
+        active_target = targets[0]["name"]
+
+    context: dict[str, Any] = {
+        "active_surface": "keycloak",
+        "page_title": "Keycloak",
+        "connector_id": KEYCLOAK_CONNECTOR_ID,
+        "targets": targets,
+        "active_target": active_target,
+        "is_tenant_admin": role_probe.is_tenant_admin,
+        "realm": None,
+        "clients": [],
+        "client_scopes": [],
+        "error": None,
+    }
+
+    if active_target is not None:
+        realm_env = await _dispatch_read(operator, op_id="keycloak.realm.get", target=active_target)
+        clients_env = await _dispatch_read(
+            operator, op_id="keycloak.client.list", target=active_target
+        )
+        scopes_env = await _dispatch_read(
+            operator, op_id="keycloak.client_scope.list", target=active_target
+        )
+        # Surface the first dispatch fault inline rather than rendering
+        # empty cards over a denied / unreachable Keycloak.
+        context["error"] = (
+            _dispatch_failed(realm_env)
+            or _dispatch_failed(clients_env)
+            or _dispatch_failed(scopes_env)
+        )
+        # The connector guarantees secrets are scrubbed inside ``result``;
+        # we read the named projections, never the raw envelope.
+        context["realm"] = (realm_env.get("result") or {}).get("realm")
+        context["clients"] = (clients_env.get("result") or {}).get("rows", [])
+        context["client_scopes"] = (scopes_env.get("result") or {}).get("rows", [])
+
+    return get_templates().TemplateResponse(request, "keycloak/index.html", context)
+
+
+async def _render_client_detail(
+    request: Request,
+    session: UISessionContext,
+    client_uuid: str,
+    target: str,
+    role_probe: OperatorRoleProbe,
+) -> HTMLResponse:
+    """Dispatch ``keycloak.client.get`` and render the projected detail.
+
+    A blank / cross-tenant ``target`` resolves to nothing the operator can
+    dispatch against, so the fragment renders its inline error rather than
+    leaking a cross-tenant read. The client secret is already redacted by
+    the connector; this render projects named fields only and never dumps
+    the raw envelope.
+    """
+    operator = await _resolve_operator(session)
+
+    target = target.strip()
+    targets = await _list_keycloak_targets(operator)
+    target_names = {t["name"] for t in targets}
+    if not target or target not in target_names:
+        return _render_client_detail_error(
+            request, client_uuid, target, "Select a Keycloak target first."
+        )
+
+    envelope = await _dispatch_read(
+        operator,
+        op_id="keycloak.client.get",
+        target=target,
+        params={"id": client_uuid},
+    )
+    error = _dispatch_failed(envelope)
+    client = (envelope.get("result") or {}).get("client") if error is None else None
+
+    context: dict[str, Any] = {
+        "client_uuid": client_uuid,
+        "target": target,
+        "connector_id": KEYCLOAK_CONNECTOR_ID,
+        "client": client,
+        "error": error,
+        "is_tenant_admin": role_probe.is_tenant_admin,
+    }
+    return get_templates().TemplateResponse(request, "keycloak/_client_detail.html", context)
+
+
+def _render_client_detail_error(
+    request: Request,
+    client_uuid: str,
+    target: str,
+    message: str,
+) -> HTMLResponse:
+    """Render the client-detail fragment with an inline error (HTTP 400)."""
+    context: dict[str, Any] = {
+        "client_uuid": client_uuid,
+        "target": target,
+        "connector_id": KEYCLOAK_CONNECTOR_ID,
+        "client": None,
+        "error": message,
+        "is_tenant_admin": False,
+    }
+    return get_templates().TemplateResponse(
+        request,
+        "keycloak/_client_detail.html",
+        context,
+        status_code=status.HTTP_400_BAD_REQUEST,
+    )

--- a/backend/src/meho_backplane/ui/templates/_icons.html
+++ b/backend/src/meho_backplane/ui/templates/_icons.html
@@ -60,6 +60,7 @@
   "circle-stop": '<circle cx="12" cy="12" r="10"/><rect width="6" height="6" x="9" y="9" rx="1"/>',
   "terminal": '<path d="M12 19h8"/><path d="m4 17 6-6-6-6"/>',
   "gauge": '<path d="m12 14 4-4"/><path d="M3.34 19a10 10 0 1 1 17.32 0"/>',
+  "key-round": '<path d="M2.586 17.414A2 2 0 0 0 2 18.828V21a1 1 0 0 0 1 1h3a1 1 0 0 0 1-1v-1a1 1 0 0 1 1-1h1a1 1 0 0 0 1-1v-1a1 1 0 0 1 1-1h.172a2 2 0 0 0 1.414-.586l.814-.814a6.5 6.5 0 1 0-4-4z"/><circle cx="16.5" cy="7.5" r=".5" fill="currentColor"/>',
 } %}
 {% macro icon(name, class="size-4") -%}
 <svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round" class="{{ class }}" data-icon="{{ name }}" aria-hidden="true">{{ _PATHS[name] | safe }}</svg>

--- a/backend/src/meho_backplane/ui/templates/base.html
+++ b/backend/src/meho_backplane/ui/templates/base.html
@@ -47,6 +47,7 @@
   ("runbooks", "/ui/runbooks", "scroll", "Runbooks"),
   ("scheduler", "/ui/scheduler", "clock", "Scheduler"),
   ("operations", "/ui/operations", "terminal", "Operations"),
+  ("keycloak", "/ui/keycloak", "key-round", "Keycloak"),
   ("approvals", "/ui/approvals", "bell", "Approvals"),
   ("audit", "/ui/audit", "scroll-text", "Audit"),
 ] %}

--- a/backend/src/meho_backplane/ui/templates/keycloak/_client_detail.html
+++ b/backend/src/meho_backplane/ui/templates/keycloak/_client_detail.html
@@ -1,0 +1,154 @@
+{#-
+  SPDX-License-Identifier: Apache-2.0
+  Copyright (c) 2026 evoila Group
+
+  Keycloak client-detail fragment (Initiative #1943, Task #1959).
+
+  The swap target for a client row's "Detail" button on the realm browser.
+  Dispatches ``keycloak.client.get`` keyed on the client's INTERNAL UUID
+  (the ``id`` from a list row, NOT the human clientId) and renders
+  PROJECTED, redaction-trusting fields only: clientId, enabled,
+  publicClient, redirect URIs, web origins, protocol mappers.
+
+  Secret handling (load-bearing): the client ``secret`` is already scrubbed
+  by the connector (the ``REDACTED`` sentinel). This fragment NEVER dumps
+  the raw ``OperationResult`` envelope into the page -- it reads named
+  fields off the already-redacted ``client`` dict, so a future op that
+  forgot to scrub a field cannot leak it through a verbatim blob here.
+
+  Cross-link (do not duplicate): when a client backs an agent principal the
+  canonical kill switch stays on ``/ui/agents/principals`` (#1831/#1866);
+  this surface only links there.
+
+  The drawer open/close is Alpine-driven (``x-data``); dismiss on close or
+  Escape.
+
+  Context keys: ``client_uuid``, ``target``, ``client``, ``error``,
+  ``is_tenant_admin`` (see ``keycloak/routes.py``).
+-#}
+{% from "_icons.html" import icon %}
+
+<div
+  class="card border border-base-300 bg-base-100 shadow-lg"
+  data-keycloak-client-detail
+  data-client-uuid="{{ client_uuid }}"
+  x-data="{ open: true }"
+  x-show="open"
+  @keydown.escape.window="open = false"
+>
+  <div class="card-body gap-3">
+    <div class="flex items-start justify-between gap-3">
+      <h3 class="card-title text-base">
+        {{ icon("plug", class="size-4 opacity-70") }}
+        Client detail
+      </h3>
+      <button
+        type="button"
+        class="btn btn-ghost btn-xs btn-square"
+        aria-label="Close client detail"
+        @click="open = false"
+      >{{ icon("x", class="size-4") }}</button>
+    </div>
+
+    {% if error %}
+      <div role="alert" class="alert alert-warning" data-keycloak-error>
+        <p class="text-xs">{{ error }}</p>
+      </div>
+    {% elif client %}
+      <div class="flex flex-wrap items-center gap-2">
+        <span class="font-mono text-sm font-semibold">{{ client.get("clientId") | default("—", true) }}</span>
+        {% if client.get("enabled") %}
+          <span class="badge badge-success badge-sm">enabled</span>
+        {% else %}
+          <span class="badge badge-ghost badge-sm">disabled</span>
+        {% endif %}
+        {% if client.get("publicClient") %}
+          <span class="badge badge-ghost badge-sm">public</span>
+        {% else %}
+          <span class="badge badge-outline badge-sm">confidential</span>
+        {% endif %}
+      </div>
+
+      <dl class="grid grid-cols-1 gap-x-6 gap-y-2 text-sm sm:grid-cols-2">
+        <div>
+          <dt class="text-xs opacity-60">Internal UUID</dt>
+          <dd class="font-mono break-all text-xs">{{ client.get("id") | default(client_uuid, true) }}</dd>
+        </div>
+        <div>
+          <dt class="text-xs opacity-60">Protocol</dt>
+          <dd>{{ client.get("protocol") | default("openid-connect", true) }}</dd>
+        </div>
+        <div>
+          <dt class="text-xs opacity-60">Standard flow</dt>
+          <dd>{{ client.get("standardFlowEnabled") | default("—", true) }}</dd>
+        </div>
+        <div>
+          <dt class="text-xs opacity-60">Service accounts</dt>
+          <dd>{{ client.get("serviceAccountsEnabled") | default("—", true) }}</dd>
+        </div>
+      </dl>
+
+      {#- Redirect URIs -#}
+      <div data-client-redirect-uris>
+        <h4 class="mb-1 text-xs font-semibold opacity-60">Redirect URIs</h4>
+        {% if client.get("redirectUris") %}
+          <ul class="space-y-1">
+            {% for uri in client.get("redirectUris") %}
+              <li class="font-mono text-xs break-all">{{ uri }}</li>
+            {% endfor %}
+          </ul>
+        {% else %}
+          <p class="text-xs opacity-60">None configured.</p>
+        {% endif %}
+      </div>
+
+      {#- Web origins -#}
+      {% if client.get("webOrigins") %}
+        <div data-client-web-origins>
+          <h4 class="mb-1 text-xs font-semibold opacity-60">Web origins</h4>
+          <ul class="space-y-1">
+            {% for origin in client.get("webOrigins") %}
+              <li class="font-mono text-xs break-all">{{ origin }}</li>
+            {% endfor %}
+          </ul>
+        </div>
+      {% endif %}
+
+      {#- Protocol mappers (names only -- the projected view, not the raw
+          mapper config blob). -#}
+      <div data-client-protocol-mappers>
+        <h4 class="mb-1 text-xs font-semibold opacity-60">Protocol mappers</h4>
+        {% if client.get("protocolMappers") %}
+          <ul class="space-y-1">
+            {% for mapper in client.get("protocolMappers") %}
+              <li class="text-xs">
+                <span class="font-mono">{{ mapper.get("name") | default("—", true) }}</span>
+                <span class="opacity-60">— {{ mapper.get("protocolMapper") | default("", true) }}</span>
+              </li>
+            {% endfor %}
+          </ul>
+        {% else %}
+          <p class="text-xs opacity-60">None configured.</p>
+        {% endif %}
+      </div>
+
+      {#- Cross-link to the agent-principals kill switch. The canonical
+          register/revoke surface stays there (#1831/#1866); this is a
+          navigation hint, not a duplicate. -#}
+      <div class="mt-1 border-t border-base-300 pt-3">
+        <a
+          href="/ui/agents/principals"
+          class="link link-hover inline-flex items-center gap-1 text-xs"
+          data-principals-cross-link
+        >
+          {{ icon("shield-check", class="size-3.5") }}
+          Manage agent principals
+        </a>
+      </div>
+    {% else %}
+      <div role="alert" class="alert alert-warning" data-keycloak-error>
+        <p class="text-xs">Client not found.</p>
+      </div>
+    {% endif %}
+  </div>
+</div>

--- a/backend/src/meho_backplane/ui/templates/keycloak/index.html
+++ b/backend/src/meho_backplane/ui/templates/keycloak/index.html
@@ -1,0 +1,256 @@
+{#-
+  SPDX-License-Identifier: Apache-2.0
+  Copyright (c) 2026 evoila Group
+
+  Keycloak console -- read-only realm browser (Initiative #1943, Task #1959).
+
+  The read-only realm-administration scaffold the two write tasks (T2 user
+  management, T3 scope/mapper management) build on. Three surfaces on one
+  page, all dispatched in-process through ``call_operation`` against the
+  PINNED ``connector_id="keycloak-admin-26.x"`` (never the bare ``keycloak``
+  slug):
+
+    * realm-config card        (``keycloak.realm.get``)
+    * client list              (``keycloak.client.list``)
+    * client-scope list        (``keycloak.client_scope.list``)
+
+  Each client row drills into ``/ui/keycloak/clients/{client_uuid}`` (keyed
+  on the internal UUID, NOT the human clientId) via ``hx-get`` into the
+  shared drawer container.
+
+  Secret handling: every field rendered here is a NAMED projection from the
+  read op's already-redacted ``result`` -- the raw ``OperationResult``
+  envelope is NEVER dumped into the page. Client secrets are scrubbed
+  upstream by the connector (the ``REDACTED`` sentinel).
+
+  Context keys: ``connector_id``, ``targets``, ``active_target``, ``realm``,
+  ``clients``, ``client_scopes``, ``error``, ``is_tenant_admin`` (see
+  ``keycloak/routes.py``).
+-#}
+{% extends "base.html" %}
+
+{% from "_icons.html" import icon %}
+
+{% block page_title %}Keycloak &middot; MEHO Operator Console{% endblock %}
+
+{% block content %}
+<section class="space-y-5" data-surface="keycloak">
+  <header class="flex flex-wrap items-center justify-between gap-4">
+    <div>
+      <h1 class="text-2xl font-semibold">Keycloak</h1>
+      <p class="text-sm opacity-70">
+        Read-only realm browser: realm configuration, clients, and client
+        scopes for the managed realm. Client secrets are redacted.
+      </p>
+    </div>
+  </header>
+
+  {#- Target picker. The connector is fixed (keycloak-admin-26.x); the
+      operator only picks WHICH Keycloak deployment to read. Changing the
+      target re-fetches this whole page with the new ``?target=``. The
+      options are tenant-scoped server-side -- a cross-tenant target never
+      appears here. -#}
+  <form
+    class="grid gap-3 sm:grid-cols-[minmax(0,22rem)_1fr]"
+    hx-get="/ui/keycloak"
+    hx-target="body"
+    hx-push-url="true"
+  >
+    <label class="form-control">
+      <span class="label-text mb-1 text-xs opacity-70">Keycloak target</span>
+      <select
+        name="target"
+        class="select select-bordered select-sm w-full font-mono"
+        aria-label="Keycloak target"
+        hx-get="/ui/keycloak"
+        hx-target="body"
+        hx-trigger="change"
+        hx-push-url="true"
+      >
+        <option value="">Select a target…</option>
+        {% for t in targets %}
+          <option
+            value="{{ t.name }}"
+            {% if t.name == active_target %}selected{% endif %}
+          >{{ t.name }}</option>
+        {% endfor %}
+      </select>
+    </label>
+  </form>
+
+  {% if not targets %}
+    <div class="rounded-box border border-base-300 bg-base-100 px-4 py-8 text-center text-sm opacity-60">
+      No Keycloak targets registered for this tenant. Register a
+      <code>keycloak</code> target to browse its realm.
+    </div>
+  {% elif not active_target %}
+    <div class="rounded-box border border-base-300 bg-base-100 px-4 py-8 text-center text-sm opacity-60">
+      Select a Keycloak target to browse its realm configuration, clients,
+      and client scopes.
+    </div>
+  {% else %}
+    {% if error %}
+      <div role="alert" class="alert alert-warning" data-keycloak-error>
+        <div>
+          <h3 class="text-sm font-semibold">Could not read the realm</h3>
+          <p class="text-xs">
+            Dispatch against <code>{{ active_target }}</code> failed:
+            <code>{{ error }}</code>
+          </p>
+        </div>
+      </div>
+    {% endif %}
+
+    {#- ---- Realm config card -------------------------------------------- -#}
+    <section aria-label="Realm configuration" data-keycloak-realm>
+      <h2 class="mb-2 text-sm font-semibold opacity-80">Realm configuration</h2>
+      {% if realm %}
+        <div class="rounded-box border border-base-300 bg-base-100 p-4">
+          <div class="flex flex-wrap items-center gap-2">
+            <span class="text-lg font-semibold">{{ realm.get("realm") | default("—", true) }}</span>
+            {% if realm.get("enabled") %}
+              <span class="badge badge-success badge-sm">enabled</span>
+            {% else %}
+              <span class="badge badge-ghost badge-sm">disabled</span>
+            {% endif %}
+          </div>
+          {% if realm.get("displayName") %}
+            <p class="mt-1 text-sm opacity-70">{{ realm.get("displayName") }}</p>
+          {% endif %}
+          <dl class="mt-3 grid grid-cols-2 gap-x-6 gap-y-2 text-sm sm:grid-cols-3">
+            <div>
+              <dt class="text-xs opacity-60">Login with email</dt>
+              <dd>{{ realm.get("loginWithEmailAllowed") | default("—", true) }}</dd>
+            </div>
+            <div>
+              <dt class="text-xs opacity-60">Registration</dt>
+              <dd>{{ realm.get("registrationAllowed") | default("—", true) }}</dd>
+            </div>
+            <div>
+              <dt class="text-xs opacity-60">Access token lifespan (s)</dt>
+              <dd>{{ realm.get("accessTokenLifespan") | default("—", true) }}</dd>
+            </div>
+            <div>
+              <dt class="text-xs opacity-60">SSO session idle (s)</dt>
+              <dd>{{ realm.get("ssoSessionIdleTimeout") | default("—", true) }}</dd>
+            </div>
+            <div>
+              <dt class="text-xs opacity-60">SSO session max (s)</dt>
+              <dd>{{ realm.get("ssoSessionMaxLifespan") | default("—", true) }}</dd>
+            </div>
+            <div>
+              <dt class="text-xs opacity-60">Login theme</dt>
+              <dd>{{ realm.get("loginTheme") | default("—", true) }}</dd>
+            </div>
+          </dl>
+        </div>
+      {% else %}
+        <div class="rounded-box border border-base-300 bg-base-100 px-4 py-6 text-center text-sm opacity-60">
+          No realm configuration returned.
+        </div>
+      {% endif %}
+    </section>
+
+    {#- ---- Client list -------------------------------------------------- -#}
+    <section aria-label="Clients" data-keycloak-clients>
+      <h2 class="mb-2 text-sm font-semibold opacity-80">
+        Clients <span class="text-xs opacity-60">({{ clients | length }})</span>
+      </h2>
+      {% if clients %}
+        <div class="overflow-x-auto rounded-box border border-base-300 bg-base-100">
+          <table class="table table-sm">
+            <thead>
+              <tr>
+                <th>Client ID</th>
+                <th>Enabled</th>
+                <th>Public</th>
+                <th>Protocol</th>
+                <th></th>
+              </tr>
+            </thead>
+            <tbody>
+              {% for client in clients %}
+                <tr data-client-row data-client-uuid="{{ client.get('id') | default('', true) }}">
+                  <td class="font-mono">{{ client.get("clientId") | default("—", true) }}</td>
+                  <td>
+                    {% if client.get("enabled") %}
+                      <span class="badge badge-success badge-xs">yes</span>
+                    {% else %}
+                      <span class="badge badge-ghost badge-xs">no</span>
+                    {% endif %}
+                  </td>
+                  <td>
+                    {% if client.get("publicClient") %}
+                      <span class="badge badge-ghost badge-xs">public</span>
+                    {% else %}
+                      <span class="badge badge-outline badge-xs">confidential</span>
+                    {% endif %}
+                  </td>
+                  <td class="text-xs opacity-70">{{ client.get("protocol") | default("openid-connect", true) }}</td>
+                  <td class="text-right">
+                    {% if client.get("id") %}
+                      <button
+                        type="button"
+                        class="btn btn-ghost btn-xs"
+                        hx-get="/ui/keycloak/clients/{{ client.get('id') }}?target={{ active_target | urlencode }}"
+                        hx-target="#keycloak-drawer-container"
+                        hx-swap="innerHTML"
+                        data-client-detail-link
+                      >
+                        {{ icon("arrow-right", class="size-3.5") }}
+                        Detail
+                      </button>
+                    {% endif %}
+                  </td>
+                </tr>
+              {% endfor %}
+            </tbody>
+          </table>
+        </div>
+      {% else %}
+        <div class="rounded-box border border-base-300 bg-base-100 px-4 py-6 text-center text-sm opacity-60">
+          No clients in this realm.
+        </div>
+      {% endif %}
+    </section>
+
+    {#- ---- Client-scope list -------------------------------------------- -#}
+    <section aria-label="Client scopes" data-keycloak-scopes>
+      <h2 class="mb-2 text-sm font-semibold opacity-80">
+        Client scopes <span class="text-xs opacity-60">({{ client_scopes | length }})</span>
+      </h2>
+      {% if client_scopes %}
+        <div class="overflow-x-auto rounded-box border border-base-300 bg-base-100">
+          <table class="table table-sm">
+            <thead>
+              <tr>
+                <th>Name</th>
+                <th>Protocol</th>
+                <th>Description</th>
+              </tr>
+            </thead>
+            <tbody>
+              {% for scope in client_scopes %}
+                <tr data-scope-row>
+                  <td class="font-mono">{{ scope.get("name") | default("—", true) }}</td>
+                  <td class="text-xs opacity-70">{{ scope.get("protocol") | default("openid-connect", true) }}</td>
+                  <td class="text-xs opacity-70">{{ scope.get("description") | default("", true) }}</td>
+                </tr>
+              {% endfor %}
+            </tbody>
+          </table>
+        </div>
+      {% else %}
+        <div class="rounded-box border border-base-300 bg-base-100 px-4 py-6 text-center text-sm opacity-60">
+          No client scopes in this realm.
+        </div>
+      {% endif %}
+    </section>
+  {% endif %}
+
+  {#- Stable drawer container -- lives OUTSIDE the surfaces above so a
+      client-detail swap never wipes the lists. Each client row's Detail
+      button ``hx-get``s the detail fragment into this container. -#}
+  <div id="keycloak-drawer-container"></div>
+</section>
+{% endblock %}

--- a/backend/tests/test_ui_keycloak.py
+++ b/backend/tests/test_ui_keycloak.py
@@ -1,0 +1,563 @@
+# SPDX-License-Identifier: Apache-2.0
+# Copyright (c) 2026 evoila Group
+
+"""Behavioural tests for the read-only Keycloak console UI surface.
+
+Initiative #1943 (G10.x Keycloak console), Task #1959 (T1). The acceptance
+criteria on issue #1959 are:
+
+* ``GET /ui/keycloak`` renders the realm-config card + client list +
+  client-scope list; the dispatched ``connector_id`` is
+  ``keycloak-admin-26.x`` and the bare slug ``keycloak`` is NOT used (the
+  pinned id is asserted on the captured ``call_operation`` arguments,
+  mirroring the ``/ui/operations`` picker test that rejects the bare
+  product slug).
+* ``GET /ui/keycloak/clients/{uuid}`` renders projected client fields; a
+  planted live ``secret`` does NOT appear in the response body and no
+  verbatim ``OperationResult`` envelope blob is dumped into the page.
+* A plain **operator** session (not tenant_admin) successfully renders
+  ``/ui/keycloak`` and the client detail (reads are operator-tier).
+* Route order: the literal ``/ui/keycloak/clients/{client_uuid}`` resolves
+  to the client-detail handler, and ``build_keycloak_router`` is included
+  before ``build_stubs_router()``.
+
+Suite shape mirrors :mod:`backend.tests.test_ui_operations`: a minimal
+FastAPI app with the UI session + CSRF middlewares, a ``web_session`` row
+carrying a real Keycloak-minted access token (so the operator lift + role
+probe re-verify the token and pick up the right :class:`TenantRole`), a
+seeded keycloak ``Target`` row, and the route module's ``call_operation``
+patched to a recording double (the dispatch contract itself is covered by
+``test_operations_meta_tools`` / the keycloak connector suites; these BFF
+tests verify the route wiring + the render branches).
+"""
+
+from __future__ import annotations
+
+import asyncio
+import uuid
+import warnings
+from collections.abc import Iterator
+from datetime import timedelta
+from typing import Any
+
+import pytest
+import respx
+from cryptography.fernet import Fernet
+from fastapi import FastAPI
+from fastapi.staticfiles import StaticFiles
+from fastapi.testclient import TestClient
+
+from meho_backplane.auth.jwt import clear_jwks_cache
+from meho_backplane.auth.operator import TenantRole
+from meho_backplane.db.engine import get_sessionmaker, reset_engine_for_testing
+from meho_backplane.db.models import Target as TargetORM
+from meho_backplane.db.models import Tenant
+from meho_backplane.operations import reset_dispatcher_caches
+from meho_backplane.settings import get_settings
+from meho_backplane.ui.auth import SESSION_COOKIE_NAME, UISessionMiddleware
+from meho_backplane.ui.auth import build_router as build_ui_auth_router
+from meho_backplane.ui.auth.flow import (
+    clear_discovery_cache,
+    reset_verifier_store_for_testing,
+)
+from meho_backplane.ui.auth.session_store import (
+    create_session,
+    reset_fernet_cache_for_testing,
+)
+from meho_backplane.ui.csrf import CSRFMiddleware
+from meho_backplane.ui.paths import static_root_dir
+from meho_backplane.ui.routes import build_keycloak_router
+from meho_backplane.ui.routes import build_router as build_ui_router
+from meho_backplane.ui.routes.keycloak.routes import KEYCLOAK_CONNECTOR_ID
+from meho_backplane.ui.templating import reset_templating_for_testing
+from tests._oidc_jwt_helpers import AUDIENCE as _DEFAULT_AUDIENCE
+from tests._oidc_jwt_helpers import ISSUER as _DEFAULT_ISSUER
+from tests._oidc_jwt_helpers import make_rsa_keypair as _make_rsa_keypair
+from tests._oidc_jwt_helpers import mint_token as _mint_token
+from tests._oidc_jwt_helpers import mock_discovery_and_jwks as _mock_discovery_and_jwks
+from tests._oidc_jwt_helpers import public_jwks as _public_jwks
+
+_BACKPLANE_URL = "https://meho.test"
+_TENANT_A = uuid.UUID("11111111-1111-1111-1111-111111111111")
+_TENANT_B = uuid.UUID("22222222-2222-2222-2222-222222222222")
+_OP_OPERATOR = "op-operator"
+_TARGET_NAME = "rdc-keycloak"
+
+#: A live client secret planted in the dispatch double's envelope. The
+#: client-detail render must NEVER echo this (the connector redacts secrets
+#: upstream; the UI must not re-surface a raw blob that would carry it).
+_PLANTED_SECRET = "PLANTED-LIVE-CLIENT-SECRET-do-not-leak"
+
+
+@pytest.fixture(autouse=True)
+def _bff_env(monkeypatch: pytest.MonkeyPatch) -> Iterator[None]:
+    """Pin chassis + BFF env vars for every test (mirrors the UI suites)."""
+    monkeypatch.setenv("KEYCLOAK_ISSUER_URL", _DEFAULT_ISSUER)
+    monkeypatch.setenv("KEYCLOAK_AUDIENCE", _DEFAULT_AUDIENCE)
+    monkeypatch.setenv("VAULT_ADDR", "https://vault.test")
+    monkeypatch.setenv("BACKPLANE_URL", _BACKPLANE_URL)
+    monkeypatch.setenv("UI_SESSION_ENCRYPTION_KEY", Fernet.generate_key().decode())
+    monkeypatch.setenv("UI_KEYCLOAK_CLIENT_ID", "meho-web")
+    monkeypatch.setenv("UI_KEYCLOAK_CLIENT_SECRET", "test-client-secret")
+    get_settings.cache_clear()
+    reset_fernet_cache_for_testing()
+    reset_verifier_store_for_testing()
+    reset_templating_for_testing()
+    clear_discovery_cache()
+    clear_jwks_cache()
+    reset_engine_for_testing()
+    reset_dispatcher_caches()
+    yield
+    get_settings.cache_clear()
+    reset_fernet_cache_for_testing()
+    reset_verifier_store_for_testing()
+    reset_templating_for_testing()
+    clear_discovery_cache()
+    clear_jwks_cache()
+    reset_engine_for_testing()
+    reset_dispatcher_caches()
+
+
+def _build_app() -> FastAPI:
+    """Construct a minimal FastAPI app wired for the keycloak UI tests."""
+    app = FastAPI()
+    app.add_middleware(CSRFMiddleware)
+    app.add_middleware(UISessionMiddleware)
+    app.mount(
+        "/ui/static",
+        StaticFiles(directory=str(static_root_dir()), check_dir=False),
+        name="ui_static",
+    )
+    app.include_router(build_ui_auth_router())
+    app.include_router(build_ui_router())
+    return app
+
+
+def _seed_tenant(tenant_id: uuid.UUID, slug: str) -> None:
+    async def _do() -> None:
+        sessionmaker = get_sessionmaker()
+        async with sessionmaker() as session, session.begin():
+            session.add(Tenant(id=tenant_id, slug=slug, name=f"Tenant {slug}"))
+
+    asyncio.run(_do())
+
+
+def _seed_keycloak_target(
+    *,
+    tenant_id: uuid.UUID,
+    name: str = _TARGET_NAME,
+    product: str = "keycloak",
+) -> None:
+    """Seed one keycloak ``Target`` row scoped to *tenant_id*."""
+
+    async def _do() -> None:
+        sessionmaker = get_sessionmaker()
+        async with sessionmaker() as session, session.begin():
+            session.add(
+                TargetORM(
+                    id=uuid.uuid4(),
+                    tenant_id=tenant_id,
+                    name=name,
+                    product=product,
+                    host="keycloak.test",
+                ),
+            )
+
+    asyncio.run(_do())
+
+
+def _seed_session_sync(
+    *,
+    tenant_id: uuid.UUID,
+    access_token: str,
+    operator_sub: str,
+) -> uuid.UUID:
+    async def _do() -> uuid.UUID:
+        sessionmaker = get_sessionmaker()
+        async with sessionmaker() as session, session.begin():
+            decrypted = await create_session(
+                session,
+                operator_sub=operator_sub,
+                tenant_id=tenant_id,
+                access_token=access_token,
+                refresh_token="refresh-token-plaintext",
+                lifetime=timedelta(hours=1),
+            )
+            return decrypted.id
+
+    return asyncio.run(_do())
+
+
+def _make_keypair_and_jwks() -> tuple[Any, dict[str, Any]]:
+    # Unique kid per call so a JWKS cached in a prior test cannot shadow
+    # this token's signing key (the ``jws_signature_mismatch`` failure mode
+    # when every test reuses one kid).
+    with warnings.catch_warnings():
+        warnings.simplefilter("ignore")
+        keypair = _make_rsa_keypair(f"ui-keycloak-test-kid-{uuid.uuid4().hex[:8]}")
+    return keypair, _public_jwks(keypair)
+
+
+def _client_with_role(
+    *,
+    tenant_id: uuid.UUID,
+    operator_sub: str,
+    role: TenantRole,
+) -> tuple[TestClient, respx.MockRouter]:
+    """Return a TestClient + UN-started respx mock for the keycloak routes.
+
+    The operator lift + role probe re-validate the BFF session's access
+    token through the JWT chain; the chain needs the JWKS endpoint mocked.
+    The caller enters ``mock`` as a context manager (start AND stop exactly
+    once) -- starting it here too would leave the httpx patch active after
+    the ``with`` block, so the next test's JWKS fetch would hit stale routes.
+    """
+    keypair, jwks = _make_keypair_and_jwks()
+    access_token = _mint_token(
+        keypair,
+        sub=operator_sub,
+        tenant_id=str(tenant_id),
+        tenant_role=role.value,
+    )
+    session_id = _seed_session_sync(
+        tenant_id=tenant_id,
+        access_token=access_token,
+        operator_sub=operator_sub,
+    )
+    mock = respx.mock(assert_all_called=False)
+    _mock_discovery_and_jwks(mock, jwks)
+    client = TestClient(_build_app(), follow_redirects=False)
+    client.cookies.set(SESSION_COOKIE_NAME, str(session_id))
+    return client, mock
+
+
+def _patch_call_operation(
+    monkeypatch: pytest.MonkeyPatch, envelopes: dict[str, dict[str, Any]]
+) -> list[dict[str, Any]]:
+    """Patch the route module's ``call_operation`` to a recording double.
+
+    *envelopes* maps an ``op_id`` to the structured envelope the double
+    returns for it. Each call's ``arguments`` dict is recorded so a test can
+    assert the BFF pinned ``connector_id`` + threaded the op id / target /
+    params through unchanged.
+    """
+    received: list[dict[str, Any]] = []
+
+    async def _fake_call_operation(operator: Any, arguments: dict[str, Any]) -> dict[str, Any]:
+        received.append(arguments)
+        op_id = arguments.get("op_id", "")
+        return envelopes.get(
+            op_id,
+            {"status": "ok", "op_id": op_id, "result": {}, "error": None, "extras": {}},
+        )
+
+    monkeypatch.setattr(
+        "meho_backplane.ui.routes.keycloak.routes.call_operation",
+        _fake_call_operation,
+    )
+    return received
+
+
+def _ok(op_id: str, result: dict[str, Any]) -> dict[str, Any]:
+    """Build an ``ok`` envelope shaped like ``OperationResult.model_dump``."""
+    return {
+        "status": "ok",
+        "op_id": op_id,
+        "result": result,
+        "error": None,
+        "duration_ms": 1.0,
+        "handle": None,
+        "extras": {},
+    }
+
+
+def _index_envelopes() -> dict[str, dict[str, Any]]:
+    """Envelopes for the three index dispatches (realm / clients / scopes)."""
+    return {
+        "keycloak.realm.get": _ok(
+            "keycloak.realm.get",
+            {
+                "realm": {
+                    "realm": "evba",
+                    "enabled": True,
+                    "displayName": "EVBA Realm",
+                    "accessTokenLifespan": 300,
+                }
+            },
+        ),
+        "keycloak.client.list": _ok(
+            "keycloak.client.list",
+            {
+                "rows": [
+                    {
+                        "id": "aaaaaaaa-aaaa-aaaa-aaaa-aaaaaaaaaaaa",
+                        "clientId": "meho-web",
+                        "enabled": True,
+                        "publicClient": False,
+                        "protocol": "openid-connect",
+                    }
+                ],
+                "total": 1,
+            },
+        ),
+        "keycloak.client_scope.list": _ok(
+            "keycloak.client_scope.list",
+            {
+                "rows": [
+                    {
+                        "name": "profile",
+                        "protocol": "openid-connect",
+                        "description": "User profile scope",
+                    }
+                ],
+                "total": 1,
+            },
+        ),
+    }
+
+
+# ---------------------------------------------------------------------------
+# Index: renders the three surfaces + pins connector_id (rejects bare slug)
+# ---------------------------------------------------------------------------
+
+
+def test_keycloak_ui_index_renders_three_surfaces_with_pinned_connector_id(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """``GET /ui/keycloak`` renders realm card + client list + scope list.
+
+    The dispatched ``connector_id`` is ``keycloak-admin-26.x`` on EVERY
+    dispatch; the bare slug ``keycloak`` is never used.
+    """
+    _seed_tenant(_TENANT_A, "tenant-a")
+    _seed_keycloak_target(tenant_id=_TENANT_A)
+    received = _patch_call_operation(monkeypatch, _index_envelopes())
+    client, mock = _client_with_role(
+        tenant_id=_TENANT_A, operator_sub=_OP_OPERATOR, role=TenantRole.OPERATOR
+    )
+    with mock:
+        response = client.get("/ui/keycloak")
+    assert response.status_code == 200, response.text
+    body = response.text
+    # The three domain surfaces render.
+    assert "data-keycloak-realm" in body
+    assert "data-keycloak-clients" in body
+    assert "data-keycloak-scopes" in body
+    # Projected fields from each surface.
+    assert "evba" in body  # realm name
+    assert "meho-web" in body  # client clientId
+    assert "profile" in body  # client scope name
+    # The pinned connector id was used on every dispatch; the bare slug was
+    # NEVER used.
+    assert len(received) == 3
+    op_ids = {args["op_id"] for args in received}
+    assert op_ids == {
+        "keycloak.realm.get",
+        "keycloak.client.list",
+        "keycloak.client_scope.list",
+    }
+    for args in received:
+        assert args["connector_id"] == KEYCLOAK_CONNECTOR_ID
+        assert args["connector_id"] != "keycloak"
+        assert args["target"] == _TARGET_NAME
+
+
+def test_keycloak_ui_index_no_target_prompts_selection(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """With no keycloak target, the index prompts instead of dispatching."""
+    _seed_tenant(_TENANT_A, "tenant-a")
+    received = _patch_call_operation(monkeypatch, {})
+    client, mock = _client_with_role(
+        tenant_id=_TENANT_A, operator_sub=_OP_OPERATOR, role=TenantRole.OPERATOR
+    )
+    with mock:
+        response = client.get("/ui/keycloak")
+    assert response.status_code == 200, response.text
+    assert "No Keycloak targets registered" in response.text
+    # No dispatch happens without a resolvable target.
+    assert received == []
+
+
+def test_keycloak_ui_index_ignores_cross_tenant_target(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """A ``?target=`` naming another tenant's target drives no dispatch.
+
+    The no-tenant-override posture: a cross-tenant slug is absent from the
+    operator's tenant-scoped target list, so it never selects an active
+    target and never dispatches (no cross-tenant read).
+    """
+    _seed_tenant(_TENANT_A, "tenant-a")
+    _seed_tenant(_TENANT_B, "tenant-b")
+    _seed_keycloak_target(tenant_id=_TENANT_B, name="other-keycloak")
+    received = _patch_call_operation(monkeypatch, _index_envelopes())
+    client, mock = _client_with_role(
+        tenant_id=_TENANT_A, operator_sub=_OP_OPERATOR, role=TenantRole.OPERATOR
+    )
+    with mock:
+        response = client.get("/ui/keycloak?target=other-keycloak")
+    assert response.status_code == 200, response.text
+    assert received == []
+
+
+# ---------------------------------------------------------------------------
+# Client detail: projected fields, secret-redaction trap, no raw envelope
+# ---------------------------------------------------------------------------
+
+
+def test_keycloak_ui_client_detail_redacts_secret_and_no_raw_envelope(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """``GET /ui/keycloak/clients/{uuid}`` renders projected fields only.
+
+    A planted live ``secret`` in the envelope's client dict does NOT appear
+    in the body, and no verbatim ``OperationResult`` envelope blob (the
+    ``status``/``duration_ms``/``handle`` machinery) is dumped into the page.
+    """
+    _seed_tenant(_TENANT_A, "tenant-a")
+    _seed_keycloak_target(tenant_id=_TENANT_A)
+    client_uuid = "aaaaaaaa-aaaa-aaaa-aaaa-aaaaaaaaaaaa"
+    # The connector redacts secrets upstream; we plant one here to prove the
+    # UI does not re-surface a raw blob carrying it even if it slipped through.
+    detail_env = _ok(
+        "keycloak.client.get",
+        {
+            "client": {
+                "id": client_uuid,
+                "clientId": "meho-web",
+                "enabled": True,
+                "publicClient": False,
+                "protocol": "openid-connect",
+                "secret": _PLANTED_SECRET,
+                "redirectUris": ["https://meho.test/ui/auth/callback"],
+                "protocolMappers": [
+                    {"name": "audience-mapper", "protocolMapper": "oidc-audience-mapper"}
+                ],
+            }
+        },
+    )
+    received = _patch_call_operation(monkeypatch, {"keycloak.client.get": detail_env})
+    client, mock = _client_with_role(
+        tenant_id=_TENANT_A, operator_sub=_OP_OPERATOR, role=TenantRole.OPERATOR
+    )
+    with mock:
+        response = client.get(f"/ui/keycloak/clients/{client_uuid}?target={_TARGET_NAME}")
+    assert response.status_code == 200, response.text
+    body = response.text
+    # Projected fields render.
+    assert "meho-web" in body
+    assert "https://meho.test/ui/auth/callback" in body
+    assert "audience-mapper" in body
+    # The planted secret never reaches the body.
+    assert _PLANTED_SECRET not in body
+    # No verbatim envelope blob -- the render projects named fields, never
+    # the raw OperationResult machinery.
+    assert "duration_ms" not in body
+    assert '"handle"' not in body
+    # The dispatch pinned the connector id + keyed on the internal UUID.
+    assert len(received) == 1
+    args = received[0]
+    assert args["connector_id"] == KEYCLOAK_CONNECTOR_ID
+    assert args["op_id"] == "keycloak.client.get"
+    assert args["params"] == {"id": client_uuid}
+    assert args["target"] == _TARGET_NAME
+
+
+def test_keycloak_ui_client_detail_cross_links_to_principals(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """The client-detail view links to the agent-principals kill switch."""
+    _seed_tenant(_TENANT_A, "tenant-a")
+    _seed_keycloak_target(tenant_id=_TENANT_A)
+    client_uuid = "aaaaaaaa-aaaa-aaaa-aaaa-aaaaaaaaaaaa"
+    detail_env = _ok(
+        "keycloak.client.get",
+        {"client": {"id": client_uuid, "clientId": "meho-web", "enabled": True}},
+    )
+    _patch_call_operation(monkeypatch, {"keycloak.client.get": detail_env})
+    client, mock = _client_with_role(
+        tenant_id=_TENANT_A, operator_sub=_OP_OPERATOR, role=TenantRole.OPERATOR
+    )
+    with mock:
+        response = client.get(f"/ui/keycloak/clients/{client_uuid}?target={_TARGET_NAME}")
+    assert response.status_code == 200, response.text
+    assert "/ui/agents/principals" in response.text
+
+
+# ---------------------------------------------------------------------------
+# RBAC: reads are operator-tier (a non-admin renders both surfaces)
+# ---------------------------------------------------------------------------
+
+
+def test_keycloak_ui_operator_role_can_render_index(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """A plain operator (not tenant_admin) renders ``/ui/keycloak``."""
+    _seed_tenant(_TENANT_A, "tenant-a")
+    _seed_keycloak_target(tenant_id=_TENANT_A)
+    _patch_call_operation(monkeypatch, _index_envelopes())
+    client, mock = _client_with_role(
+        tenant_id=_TENANT_A, operator_sub=_OP_OPERATOR, role=TenantRole.OPERATOR
+    )
+    with mock:
+        response = client.get("/ui/keycloak")
+    assert response.status_code == 200, response.text
+    assert "data-keycloak-clients" in response.text
+
+
+def test_keycloak_ui_operator_role_can_render_client_detail(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """A plain operator (not tenant_admin) renders the client detail."""
+    _seed_tenant(_TENANT_A, "tenant-a")
+    _seed_keycloak_target(tenant_id=_TENANT_A)
+    client_uuid = "aaaaaaaa-aaaa-aaaa-aaaa-aaaaaaaaaaaa"
+    detail_env = _ok(
+        "keycloak.client.get",
+        {"client": {"id": client_uuid, "clientId": "meho-web", "enabled": True}},
+    )
+    _patch_call_operation(monkeypatch, {"keycloak.client.get": detail_env})
+    client, mock = _client_with_role(
+        tenant_id=_TENANT_A, operator_sub=_OP_OPERATOR, role=TenantRole.OPERATOR
+    )
+    with mock:
+        response = client.get(f"/ui/keycloak/clients/{client_uuid}?target={_TARGET_NAME}")
+    assert response.status_code == 200, response.text
+    assert "meho-web" in response.text
+
+
+# ---------------------------------------------------------------------------
+# Route order: literal clients/{uuid} resolves to the detail handler
+# ---------------------------------------------------------------------------
+
+
+def test_keycloak_ui_router_included_before_stubs() -> None:
+    """``build_keycloak_router`` is included before ``build_stubs_router()``."""
+    import inspect
+
+    from meho_backplane.ui import routes as routes_module
+
+    source = inspect.getsource(routes_module.build_router)
+    kc_pos = source.index("build_keycloak_router()")
+    stubs_pos = source.index("build_stubs_router()")
+    assert kc_pos < stubs_pos
+
+
+def test_keycloak_ui_client_detail_route_resolves_to_detail_handler() -> None:
+    """The literal ``/ui/keycloak/clients/{client_uuid}`` resolves to detail.
+
+    A future literal ``/ui/keycloak/users`` (T2) registered before any
+    ``{param}`` route would resolve before the params route (first-match-
+    wins): the only ``{param}`` route here sits under the distinct
+    ``/ui/keycloak/clients/`` prefix.
+    """
+    router = build_keycloak_router()
+    paths = [getattr(route, "path", None) for route in router.routes]
+    assert "/ui/keycloak/clients/{client_uuid}" in paths
+    assert "/ui/keycloak" in paths
+    # The client-detail (parametrised) route is registered before the bare
+    # index so the first-match-wins lookup is unambiguous.
+    detail_idx = paths.index("/ui/keycloak/clients/{client_uuid}")
+    index_idx = paths.index("/ui/keycloak")
+    assert detail_idx < index_idx

--- a/cli/api/openapi.json
+++ b/cli/api/openapi.json
@@ -15291,6 +15291,127 @@
         }
       }
     },
+    "/ui/keycloak/clients/{client_uuid}": {
+      "get": {
+        "tags": [
+          "ui-keycloak"
+        ],
+        "summary": "Keycloak Client Detail",
+        "description": "Render the client-detail fragment for *client_uuid* (read-only).\n\n``client_uuid`` is the client's **internal UUID** (the ``id`` from a\n``keycloak.client.list`` row, NOT the human ``clientId``). Dispatches\n``keycloak.client.get`` and renders projected, redaction-trusting\nfields only -- the client secret is already scrubbed by the\nconnector; the raw envelope is NEVER dumped into the page.",
+        "operationId": "keycloak_client_detail_ui_keycloak_clients__client_uuid__get",
+        "parameters": [
+          {
+            "name": "client_uuid",
+            "in": "path",
+            "required": true,
+            "schema": {
+              "type": "string",
+              "title": "Client Uuid"
+            }
+          },
+          {
+            "name": "target",
+            "in": "query",
+            "required": false,
+            "schema": {
+              "type": "string",
+              "maxLength": 256,
+              "default": "",
+              "title": "Target"
+            }
+          }
+        ],
+        "requestBody": {
+          "content": {
+            "application/json": {
+              "schema": {
+                "$ref": "#/components/schemas/UISessionContext",
+                "nullable": true,
+                "title": "Session Ctx"
+              }
+            }
+          }
+        },
+        "responses": {
+          "200": {
+            "description": "Successful Response",
+            "content": {
+              "text/html": {
+                "schema": {
+                  "type": "string"
+                }
+              }
+            }
+          },
+          "422": {
+            "description": "Validation Error",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/HTTPValidationError"
+                }
+              }
+            }
+          }
+        }
+      }
+    },
+    "/ui/keycloak": {
+      "get": {
+        "tags": [
+          "ui-keycloak"
+        ],
+        "summary": "Keycloak Index",
+        "description": "Render the full-page realm browser.\n\nLists the tenant's keycloak targets in a picker; when a target is\nselected (or there is exactly one), dispatches ``keycloak.realm.get``\n+ ``keycloak.client.list`` + ``keycloak.client_scope.list`` and\nrenders the realm-config card + client list + client-scope list. All\ndispatches pin ``connector_id`` to :data:`KEYCLOAK_CONNECTOR_ID`.",
+        "operationId": "keycloak_index_ui_keycloak_get",
+        "parameters": [
+          {
+            "name": "target",
+            "in": "query",
+            "required": false,
+            "schema": {
+              "type": "string",
+              "maxLength": 256,
+              "default": "",
+              "title": "Target"
+            }
+          }
+        ],
+        "requestBody": {
+          "content": {
+            "application/json": {
+              "schema": {
+                "$ref": "#/components/schemas/UISessionContext",
+                "nullable": true,
+                "title": "Session Ctx"
+              }
+            }
+          }
+        },
+        "responses": {
+          "200": {
+            "description": "Successful Response",
+            "content": {
+              "text/html": {
+                "schema": {
+                  "type": "string"
+                }
+              }
+            }
+          },
+          "422": {
+            "description": "Validation Error",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/HTTPValidationError"
+                }
+              }
+            }
+          }
+        }
+      }
+    },
     "/ui/audit/results": {
       "get": {
         "tags": [

--- a/cli/internal/api/client.gen.go
+++ b/cli/internal/api/client.gen.go
@@ -6909,6 +6909,16 @@ type KbEntryPreviewUiKbSlugPreviewGetParams struct {
 	Q *string `form:"q,omitempty" json:"q,omitempty"`
 }
 
+// KeycloakIndexUiKeycloakGetParams defines parameters for KeycloakIndexUiKeycloakGet.
+type KeycloakIndexUiKeycloakGetParams struct {
+	Target *string `form:"target,omitempty" json:"target,omitempty"`
+}
+
+// KeycloakClientDetailUiKeycloakClientsClientUuidGetParams defines parameters for KeycloakClientDetailUiKeycloakClientsClientUuidGet.
+type KeycloakClientDetailUiKeycloakClientsClientUuidGetParams struct {
+	Target *string `form:"target,omitempty" json:"target,omitempty"`
+}
+
 // UiMemoryListUiMemoryGetParams defines parameters for UiMemoryListUiMemoryGet.
 type UiMemoryListUiMemoryGetParams struct {
 	Scope *string `form:"scope,omitempty" json:"scope,omitempty"`
@@ -7350,6 +7360,12 @@ type KbUploadSingleUiKbUploadPostMultipartRequestBody = BodyKbUploadSingleUiKbUp
 
 // KbUploadBulkUiKbUploadBulkPostMultipartRequestBody defines body for KbUploadBulkUiKbUploadBulkPost for multipart/form-data ContentType.
 type KbUploadBulkUiKbUploadBulkPostMultipartRequestBody = BodyKbUploadBulkUiKbUploadBulkPost
+
+// KeycloakIndexUiKeycloakGetJSONRequestBody defines body for KeycloakIndexUiKeycloakGet for application/json ContentType.
+type KeycloakIndexUiKeycloakGetJSONRequestBody = UISessionContext
+
+// KeycloakClientDetailUiKeycloakClientsClientUuidGetJSONRequestBody defines body for KeycloakClientDetailUiKeycloakClientsClientUuidGet for application/json ContentType.
+type KeycloakClientDetailUiKeycloakClientsClientUuidGetJSONRequestBody = UISessionContext
 
 // UiMemoryBulkUiMemoryBulkPostFormdataRequestBody defines body for UiMemoryBulkUiMemoryBulkPost for application/x-www-form-urlencoded ContentType.
 type UiMemoryBulkUiMemoryBulkPostFormdataRequestBody = BodyUiMemoryBulkUiMemoryBulkPost
@@ -9188,6 +9204,16 @@ type ClientInterface interface {
 
 	// KbEntryPreviewUiKbSlugPreviewGet request
 	KbEntryPreviewUiKbSlugPreviewGet(ctx context.Context, slug string, params *KbEntryPreviewUiKbSlugPreviewGetParams, reqEditors ...RequestEditorFn) (*http.Response, error)
+
+	// KeycloakIndexUiKeycloakGetWithBody request with any body
+	KeycloakIndexUiKeycloakGetWithBody(ctx context.Context, params *KeycloakIndexUiKeycloakGetParams, contentType string, body io.Reader, reqEditors ...RequestEditorFn) (*http.Response, error)
+
+	KeycloakIndexUiKeycloakGet(ctx context.Context, params *KeycloakIndexUiKeycloakGetParams, body KeycloakIndexUiKeycloakGetJSONRequestBody, reqEditors ...RequestEditorFn) (*http.Response, error)
+
+	// KeycloakClientDetailUiKeycloakClientsClientUuidGetWithBody request with any body
+	KeycloakClientDetailUiKeycloakClientsClientUuidGetWithBody(ctx context.Context, clientUuid string, params *KeycloakClientDetailUiKeycloakClientsClientUuidGetParams, contentType string, body io.Reader, reqEditors ...RequestEditorFn) (*http.Response, error)
+
+	KeycloakClientDetailUiKeycloakClientsClientUuidGet(ctx context.Context, clientUuid string, params *KeycloakClientDetailUiKeycloakClientsClientUuidGetParams, body KeycloakClientDetailUiKeycloakClientsClientUuidGetJSONRequestBody, reqEditors ...RequestEditorFn) (*http.Response, error)
 
 	// UiMemoryListUiMemoryGet request
 	UiMemoryListUiMemoryGet(ctx context.Context, params *UiMemoryListUiMemoryGetParams, reqEditors ...RequestEditorFn) (*http.Response, error)
@@ -13532,6 +13558,54 @@ func (c *Client) KbEntryDetailUiKbSlugGet(ctx context.Context, slug string, reqE
 
 func (c *Client) KbEntryPreviewUiKbSlugPreviewGet(ctx context.Context, slug string, params *KbEntryPreviewUiKbSlugPreviewGetParams, reqEditors ...RequestEditorFn) (*http.Response, error) {
 	req, err := NewKbEntryPreviewUiKbSlugPreviewGetRequest(c.Server, slug, params)
+	if err != nil {
+		return nil, err
+	}
+	req = req.WithContext(ctx)
+	if err := c.applyEditors(ctx, req, reqEditors); err != nil {
+		return nil, err
+	}
+	return c.Client.Do(req)
+}
+
+func (c *Client) KeycloakIndexUiKeycloakGetWithBody(ctx context.Context, params *KeycloakIndexUiKeycloakGetParams, contentType string, body io.Reader, reqEditors ...RequestEditorFn) (*http.Response, error) {
+	req, err := NewKeycloakIndexUiKeycloakGetRequestWithBody(c.Server, params, contentType, body)
+	if err != nil {
+		return nil, err
+	}
+	req = req.WithContext(ctx)
+	if err := c.applyEditors(ctx, req, reqEditors); err != nil {
+		return nil, err
+	}
+	return c.Client.Do(req)
+}
+
+func (c *Client) KeycloakIndexUiKeycloakGet(ctx context.Context, params *KeycloakIndexUiKeycloakGetParams, body KeycloakIndexUiKeycloakGetJSONRequestBody, reqEditors ...RequestEditorFn) (*http.Response, error) {
+	req, err := NewKeycloakIndexUiKeycloakGetRequest(c.Server, params, body)
+	if err != nil {
+		return nil, err
+	}
+	req = req.WithContext(ctx)
+	if err := c.applyEditors(ctx, req, reqEditors); err != nil {
+		return nil, err
+	}
+	return c.Client.Do(req)
+}
+
+func (c *Client) KeycloakClientDetailUiKeycloakClientsClientUuidGetWithBody(ctx context.Context, clientUuid string, params *KeycloakClientDetailUiKeycloakClientsClientUuidGetParams, contentType string, body io.Reader, reqEditors ...RequestEditorFn) (*http.Response, error) {
+	req, err := NewKeycloakClientDetailUiKeycloakClientsClientUuidGetRequestWithBody(c.Server, clientUuid, params, contentType, body)
+	if err != nil {
+		return nil, err
+	}
+	req = req.WithContext(ctx)
+	if err := c.applyEditors(ctx, req, reqEditors); err != nil {
+		return nil, err
+	}
+	return c.Client.Do(req)
+}
+
+func (c *Client) KeycloakClientDetailUiKeycloakClientsClientUuidGet(ctx context.Context, clientUuid string, params *KeycloakClientDetailUiKeycloakClientsClientUuidGetParams, body KeycloakClientDetailUiKeycloakClientsClientUuidGetJSONRequestBody, reqEditors ...RequestEditorFn) (*http.Response, error) {
+	req, err := NewKeycloakClientDetailUiKeycloakClientsClientUuidGetRequest(c.Server, clientUuid, params, body)
 	if err != nil {
 		return nil, err
 	}
@@ -27961,6 +28035,137 @@ func NewKbEntryPreviewUiKbSlugPreviewGetRequest(server string, slug string, para
 	return req, nil
 }
 
+// NewKeycloakIndexUiKeycloakGetRequest calls the generic KeycloakIndexUiKeycloakGet builder with application/json body
+func NewKeycloakIndexUiKeycloakGetRequest(server string, params *KeycloakIndexUiKeycloakGetParams, body KeycloakIndexUiKeycloakGetJSONRequestBody) (*http.Request, error) {
+	var bodyReader io.Reader
+	buf, err := json.Marshal(body)
+	if err != nil {
+		return nil, err
+	}
+	bodyReader = bytes.NewReader(buf)
+	return NewKeycloakIndexUiKeycloakGetRequestWithBody(server, params, "application/json", bodyReader)
+}
+
+// NewKeycloakIndexUiKeycloakGetRequestWithBody generates requests for KeycloakIndexUiKeycloakGet with any type of body
+func NewKeycloakIndexUiKeycloakGetRequestWithBody(server string, params *KeycloakIndexUiKeycloakGetParams, contentType string, body io.Reader) (*http.Request, error) {
+	var err error
+
+	serverURL, err := url.Parse(server)
+	if err != nil {
+		return nil, err
+	}
+
+	operationPath := fmt.Sprintf("/ui/keycloak")
+	if operationPath[0] == '/' {
+		operationPath = "." + operationPath
+	}
+
+	queryURL, err := serverURL.Parse(operationPath)
+	if err != nil {
+		return nil, err
+	}
+
+	if params != nil {
+		queryValues := queryURL.Query()
+
+		if params.Target != nil {
+
+			if queryFrag, err := runtime.StyleParamWithLocation("form", true, "target", runtime.ParamLocationQuery, *params.Target); err != nil {
+				return nil, err
+			} else if parsed, err := url.ParseQuery(queryFrag); err != nil {
+				return nil, err
+			} else {
+				for k, v := range parsed {
+					for _, v2 := range v {
+						queryValues.Add(k, v2)
+					}
+				}
+			}
+
+		}
+
+		queryURL.RawQuery = queryValues.Encode()
+	}
+
+	req, err := http.NewRequest("GET", queryURL.String(), body)
+	if err != nil {
+		return nil, err
+	}
+
+	req.Header.Add("Content-Type", contentType)
+
+	return req, nil
+}
+
+// NewKeycloakClientDetailUiKeycloakClientsClientUuidGetRequest calls the generic KeycloakClientDetailUiKeycloakClientsClientUuidGet builder with application/json body
+func NewKeycloakClientDetailUiKeycloakClientsClientUuidGetRequest(server string, clientUuid string, params *KeycloakClientDetailUiKeycloakClientsClientUuidGetParams, body KeycloakClientDetailUiKeycloakClientsClientUuidGetJSONRequestBody) (*http.Request, error) {
+	var bodyReader io.Reader
+	buf, err := json.Marshal(body)
+	if err != nil {
+		return nil, err
+	}
+	bodyReader = bytes.NewReader(buf)
+	return NewKeycloakClientDetailUiKeycloakClientsClientUuidGetRequestWithBody(server, clientUuid, params, "application/json", bodyReader)
+}
+
+// NewKeycloakClientDetailUiKeycloakClientsClientUuidGetRequestWithBody generates requests for KeycloakClientDetailUiKeycloakClientsClientUuidGet with any type of body
+func NewKeycloakClientDetailUiKeycloakClientsClientUuidGetRequestWithBody(server string, clientUuid string, params *KeycloakClientDetailUiKeycloakClientsClientUuidGetParams, contentType string, body io.Reader) (*http.Request, error) {
+	var err error
+
+	var pathParam0 string
+
+	pathParam0, err = runtime.StyleParamWithLocation("simple", false, "client_uuid", runtime.ParamLocationPath, clientUuid)
+	if err != nil {
+		return nil, err
+	}
+
+	serverURL, err := url.Parse(server)
+	if err != nil {
+		return nil, err
+	}
+
+	operationPath := fmt.Sprintf("/ui/keycloak/clients/%s", pathParam0)
+	if operationPath[0] == '/' {
+		operationPath = "." + operationPath
+	}
+
+	queryURL, err := serverURL.Parse(operationPath)
+	if err != nil {
+		return nil, err
+	}
+
+	if params != nil {
+		queryValues := queryURL.Query()
+
+		if params.Target != nil {
+
+			if queryFrag, err := runtime.StyleParamWithLocation("form", true, "target", runtime.ParamLocationQuery, *params.Target); err != nil {
+				return nil, err
+			} else if parsed, err := url.ParseQuery(queryFrag); err != nil {
+				return nil, err
+			} else {
+				for k, v := range parsed {
+					for _, v2 := range v {
+						queryValues.Add(k, v2)
+					}
+				}
+			}
+
+		}
+
+		queryURL.RawQuery = queryValues.Encode()
+	}
+
+	req, err := http.NewRequest("GET", queryURL.String(), body)
+	if err != nil {
+		return nil, err
+	}
+
+	req.Header.Add("Content-Type", contentType)
+
+	return req, nil
+}
+
 // NewUiMemoryListUiMemoryGetRequest generates requests for UiMemoryListUiMemoryGet
 func NewUiMemoryListUiMemoryGetRequest(server string, params *UiMemoryListUiMemoryGetParams) (*http.Request, error) {
 	var err error
@@ -31380,6 +31585,16 @@ type ClientWithResponsesInterface interface {
 
 	// KbEntryPreviewUiKbSlugPreviewGetWithResponse request
 	KbEntryPreviewUiKbSlugPreviewGetWithResponse(ctx context.Context, slug string, params *KbEntryPreviewUiKbSlugPreviewGetParams, reqEditors ...RequestEditorFn) (*KbEntryPreviewUiKbSlugPreviewGetResponse, error)
+
+	// KeycloakIndexUiKeycloakGetWithBodyWithResponse request with any body
+	KeycloakIndexUiKeycloakGetWithBodyWithResponse(ctx context.Context, params *KeycloakIndexUiKeycloakGetParams, contentType string, body io.Reader, reqEditors ...RequestEditorFn) (*KeycloakIndexUiKeycloakGetResponse, error)
+
+	KeycloakIndexUiKeycloakGetWithResponse(ctx context.Context, params *KeycloakIndexUiKeycloakGetParams, body KeycloakIndexUiKeycloakGetJSONRequestBody, reqEditors ...RequestEditorFn) (*KeycloakIndexUiKeycloakGetResponse, error)
+
+	// KeycloakClientDetailUiKeycloakClientsClientUuidGetWithBodyWithResponse request with any body
+	KeycloakClientDetailUiKeycloakClientsClientUuidGetWithBodyWithResponse(ctx context.Context, clientUuid string, params *KeycloakClientDetailUiKeycloakClientsClientUuidGetParams, contentType string, body io.Reader, reqEditors ...RequestEditorFn) (*KeycloakClientDetailUiKeycloakClientsClientUuidGetResponse, error)
+
+	KeycloakClientDetailUiKeycloakClientsClientUuidGetWithResponse(ctx context.Context, clientUuid string, params *KeycloakClientDetailUiKeycloakClientsClientUuidGetParams, body KeycloakClientDetailUiKeycloakClientsClientUuidGetJSONRequestBody, reqEditors ...RequestEditorFn) (*KeycloakClientDetailUiKeycloakClientsClientUuidGetResponse, error)
 
 	// UiMemoryListUiMemoryGetWithResponse request
 	UiMemoryListUiMemoryGetWithResponse(ctx context.Context, params *UiMemoryListUiMemoryGetParams, reqEditors ...RequestEditorFn) (*UiMemoryListUiMemoryGetResponse, error)
@@ -36758,6 +36973,50 @@ func (r KbEntryPreviewUiKbSlugPreviewGetResponse) StatusCode() int {
 	return 0
 }
 
+type KeycloakIndexUiKeycloakGetResponse struct {
+	Body         []byte
+	HTTPResponse *http.Response
+	JSON422      *HTTPValidationError
+}
+
+// Status returns HTTPResponse.Status
+func (r KeycloakIndexUiKeycloakGetResponse) Status() string {
+	if r.HTTPResponse != nil {
+		return r.HTTPResponse.Status
+	}
+	return http.StatusText(0)
+}
+
+// StatusCode returns HTTPResponse.StatusCode
+func (r KeycloakIndexUiKeycloakGetResponse) StatusCode() int {
+	if r.HTTPResponse != nil {
+		return r.HTTPResponse.StatusCode
+	}
+	return 0
+}
+
+type KeycloakClientDetailUiKeycloakClientsClientUuidGetResponse struct {
+	Body         []byte
+	HTTPResponse *http.Response
+	JSON422      *HTTPValidationError
+}
+
+// Status returns HTTPResponse.Status
+func (r KeycloakClientDetailUiKeycloakClientsClientUuidGetResponse) Status() string {
+	if r.HTTPResponse != nil {
+		return r.HTTPResponse.Status
+	}
+	return http.StatusText(0)
+}
+
+// StatusCode returns HTTPResponse.StatusCode
+func (r KeycloakClientDetailUiKeycloakClientsClientUuidGetResponse) StatusCode() int {
+	if r.HTTPResponse != nil {
+		return r.HTTPResponse.StatusCode
+	}
+	return 0
+}
+
 type UiMemoryListUiMemoryGetResponse struct {
 	Body         []byte
 	HTTPResponse *http.Response
@@ -40838,6 +41097,40 @@ func (c *ClientWithResponses) KbEntryPreviewUiKbSlugPreviewGetWithResponse(ctx c
 		return nil, err
 	}
 	return ParseKbEntryPreviewUiKbSlugPreviewGetResponse(rsp)
+}
+
+// KeycloakIndexUiKeycloakGetWithBodyWithResponse request with arbitrary body returning *KeycloakIndexUiKeycloakGetResponse
+func (c *ClientWithResponses) KeycloakIndexUiKeycloakGetWithBodyWithResponse(ctx context.Context, params *KeycloakIndexUiKeycloakGetParams, contentType string, body io.Reader, reqEditors ...RequestEditorFn) (*KeycloakIndexUiKeycloakGetResponse, error) {
+	rsp, err := c.KeycloakIndexUiKeycloakGetWithBody(ctx, params, contentType, body, reqEditors...)
+	if err != nil {
+		return nil, err
+	}
+	return ParseKeycloakIndexUiKeycloakGetResponse(rsp)
+}
+
+func (c *ClientWithResponses) KeycloakIndexUiKeycloakGetWithResponse(ctx context.Context, params *KeycloakIndexUiKeycloakGetParams, body KeycloakIndexUiKeycloakGetJSONRequestBody, reqEditors ...RequestEditorFn) (*KeycloakIndexUiKeycloakGetResponse, error) {
+	rsp, err := c.KeycloakIndexUiKeycloakGet(ctx, params, body, reqEditors...)
+	if err != nil {
+		return nil, err
+	}
+	return ParseKeycloakIndexUiKeycloakGetResponse(rsp)
+}
+
+// KeycloakClientDetailUiKeycloakClientsClientUuidGetWithBodyWithResponse request with arbitrary body returning *KeycloakClientDetailUiKeycloakClientsClientUuidGetResponse
+func (c *ClientWithResponses) KeycloakClientDetailUiKeycloakClientsClientUuidGetWithBodyWithResponse(ctx context.Context, clientUuid string, params *KeycloakClientDetailUiKeycloakClientsClientUuidGetParams, contentType string, body io.Reader, reqEditors ...RequestEditorFn) (*KeycloakClientDetailUiKeycloakClientsClientUuidGetResponse, error) {
+	rsp, err := c.KeycloakClientDetailUiKeycloakClientsClientUuidGetWithBody(ctx, clientUuid, params, contentType, body, reqEditors...)
+	if err != nil {
+		return nil, err
+	}
+	return ParseKeycloakClientDetailUiKeycloakClientsClientUuidGetResponse(rsp)
+}
+
+func (c *ClientWithResponses) KeycloakClientDetailUiKeycloakClientsClientUuidGetWithResponse(ctx context.Context, clientUuid string, params *KeycloakClientDetailUiKeycloakClientsClientUuidGetParams, body KeycloakClientDetailUiKeycloakClientsClientUuidGetJSONRequestBody, reqEditors ...RequestEditorFn) (*KeycloakClientDetailUiKeycloakClientsClientUuidGetResponse, error) {
+	rsp, err := c.KeycloakClientDetailUiKeycloakClientsClientUuidGet(ctx, clientUuid, params, body, reqEditors...)
+	if err != nil {
+		return nil, err
+	}
+	return ParseKeycloakClientDetailUiKeycloakClientsClientUuidGetResponse(rsp)
 }
 
 // UiMemoryListUiMemoryGetWithResponse request returning *UiMemoryListUiMemoryGetResponse
@@ -48120,6 +48413,58 @@ func ParseKbEntryPreviewUiKbSlugPreviewGetResponse(rsp *http.Response) (*KbEntry
 	}
 
 	response := &KbEntryPreviewUiKbSlugPreviewGetResponse{
+		Body:         bodyBytes,
+		HTTPResponse: rsp,
+	}
+
+	switch {
+	case strings.Contains(rsp.Header.Get("Content-Type"), "json") && rsp.StatusCode == 422:
+		var dest HTTPValidationError
+		if err := json.Unmarshal(bodyBytes, &dest); err != nil {
+			return nil, err
+		}
+		response.JSON422 = &dest
+
+	}
+
+	return response, nil
+}
+
+// ParseKeycloakIndexUiKeycloakGetResponse parses an HTTP response from a KeycloakIndexUiKeycloakGetWithResponse call
+func ParseKeycloakIndexUiKeycloakGetResponse(rsp *http.Response) (*KeycloakIndexUiKeycloakGetResponse, error) {
+	bodyBytes, err := io.ReadAll(rsp.Body)
+	defer func() { _ = rsp.Body.Close() }()
+	if err != nil {
+		return nil, err
+	}
+
+	response := &KeycloakIndexUiKeycloakGetResponse{
+		Body:         bodyBytes,
+		HTTPResponse: rsp,
+	}
+
+	switch {
+	case strings.Contains(rsp.Header.Get("Content-Type"), "json") && rsp.StatusCode == 422:
+		var dest HTTPValidationError
+		if err := json.Unmarshal(bodyBytes, &dest); err != nil {
+			return nil, err
+		}
+		response.JSON422 = &dest
+
+	}
+
+	return response, nil
+}
+
+// ParseKeycloakClientDetailUiKeycloakClientsClientUuidGetResponse parses an HTTP response from a KeycloakClientDetailUiKeycloakClientsClientUuidGetWithResponse call
+func ParseKeycloakClientDetailUiKeycloakClientsClientUuidGetResponse(rsp *http.Response) (*KeycloakClientDetailUiKeycloakClientsClientUuidGetResponse, error) {
+	bodyBytes, err := io.ReadAll(rsp.Body)
+	defer func() { _ = rsp.Body.Close() }()
+	if err != nil {
+		return nil, err
+	}
+
+	response := &KeycloakClientDetailUiKeycloakClientsClientUuidGetResponse{
 		Body:         bodyBytes,
 		HTTPResponse: rsp,
 	}

--- a/docs/codebase/ui-keycloak-console.md
+++ b/docs/codebase/ui-keycloak-console.md
@@ -1,0 +1,133 @@
+# `ui/routes/keycloak` — the read-only Keycloak realm browser
+
+Initiative [#1943](https://github.com/evoila/meho/issues/1943) (G10.x
+Keycloak console), Task [#1959](https://github.com/evoila/meho/issues/1959)
+(T1). The read-only scaffold the two write tasks (T2 user management, T3
+scope/mapper management) build on. It gives an operator a domain-shaped
+view of the managed Keycloak realm — realm configuration, clients (with a
+per-client detail drill-in), and client scopes — directly in the operator
+console, where before the only way to read realm config from MEHO was the
+`meho keycloak ...` CLI.
+
+## Overview
+
+Two routes, both `require_ui_session`-gated (GET reads need no CSRF):
+
+| Method · path | Role | Purpose |
+|---|---|---|
+| `GET /ui/keycloak` | operator | Full-page realm browser: a tenant-scoped target picker + realm-config card + client list + client-scope list. |
+| `GET /ui/keycloak/clients/{client_uuid}` | operator | Client-detail fragment (HTMX-swapped into a drawer container), keyed on the client's **internal UUID**. |
+
+## Control flow
+
+This surface is **pure UI/BFF assembly** — it adds no backend route and no
+meta-tool. There is no `/api/v1/keycloak` REST surface at all: every CLI
+keycloak verb is a thin Cobra layer over `POST /api/v1/operations/call`
+against a pre-baked connector id, so Keycloak admin flows ride the
+operations dispatcher. This console dispatches the curated `keycloak.*`
+**read** ops in-process through
+`operations.meta_tools.call_operation`, the same in-process pattern the
+`/ui/operations` console uses, then renders a domain-shaped UX instead of
+the generic op drawer. A browser carrying only the BFF session cookie
+cannot authenticate the Bearer-gated REST route, so the in-process call is
+the only path.
+
+`GET /ui/keycloak`:
+
+1. Lift the full `Operator` from the BFF session (re-verify the access
+   token through the JWT chain — picks up a same-session role demotion).
+2. List the tenant's `product == "keycloak"` targets (the picker options).
+3. Resolve the active target: an explicit in-list `?target=` selection
+   wins; otherwise default to the sole target when exactly one exists.
+4. When a target is active, dispatch `keycloak.realm.get` +
+   `keycloak.client.list` + `keycloak.client_scope.list` and read the
+   named projections off each envelope's `result`.
+
+`GET /ui/keycloak/clients/{client_uuid}` dispatches `keycloak.client.get`
+with `params={"id": client_uuid}` and renders projected fields.
+
+## Pinned connector id (load-bearing)
+
+Every dispatch pins `connector_id` to the module constant
+`KEYCLOAK_CONNECTOR_ID = "keycloak-admin-26.x"` — never typed by the
+operator, never re-derived from the bare product slug `keycloak`. The bare
+slug parses to `(product="keycloak", version="", impl_id="")`
+(`operations/_lookup.py::parse_connector_id`), which names no registered
+connector and dead-ends the dispatch with an unknown-connector fault. The
+slug the operator *does* select is the **target** slug (which Keycloak
+deployment to read), carried on the query string; the connector is fixed.
+A re-versioning (`keycloak-admin-27.x`) is a one-line edit on the
+constant, mirroring the CLI's `ConnectorID`.
+
+## Secret redaction is upstream, not here (load-bearing)
+
+Every keycloak read op scrubs nested secrets at the connector boundary
+(`connectors/keycloak/redaction.py::redact_secret_fields`, the
+`***REDACTED***` sentinel) before the result leaves the connector. The UI
+**trusts** this and never re-exposes the raw envelope: the templates
+render projected, named fields (clientId, enabled, redirect URIs, protocol
+mappers, …) and never dump the verbatim `OperationResult` blob into the
+page — so a future op that forgot to scrub a field cannot leak it through
+a raw-blob render here.
+
+## RBAC: reads are operator-tier
+
+The dispatch is gated only by `require_ui_session`; the underlying
+`POST /api/v1/operations/call` floor is `TenantRole.OPERATOR`, so a plain
+operator can read every surface here. The page threads an
+`is_tenant_admin` flag (via the soft-failing `resolve_role_probe`) so T2/T3
+can hide their write affordances from operators — but a non-admin render
+must succeed.
+
+## Tenant isolation
+
+The target list and every dispatch derive `tenant_id` from the validated
+session only. There is **no** tenant-override query/form param: a
+cross-tenant target slug is simply absent from the operator's target list
+and drives no dispatch — the no-tenant-override posture the kb router
+documents. A cross-tenant target/realm selector is deferred console-wide
+([#865](https://github.com/evoila/meho/issues/865)).
+
+## Cross-link, not duplicate
+
+The client-detail view links to `/ui/agents/principals` (the agent
+register/revoke kill switch,
+[#1831](https://github.com/evoila/meho/issues/1831)/[#1866](https://github.com/evoila/meho/issues/1866)),
+which stays the canonical agent-principal surface via
+`auth/keycloak_admin.py`. This console only reads.
+
+## Route ordering
+
+`build_keycloak_router` registers the literal
+`/ui/keycloak/clients/{client_uuid}` route before the bare `/ui/keycloak`
+index; the only `{param}` route sits under the distinct
+`/ui/keycloak/clients/` prefix, so a future literal `/ui/keycloak/users`
+(T2) registered ahead of any `{param}` route binds first (first-match-wins).
+The router is included before the stubs aggregate in
+`ui/routes/__init__.py::build_router`.
+
+## Dependencies
+
+- `operations.meta_tools.call_operation` — the in-process dispatch entry.
+- `connectors/keycloak/ops_read.py` — the curated `keycloak.*` read ops
+  (`realm.get`, `client.list`, `client.get`, `client_scope.list` used here).
+- `ui/routes/connectors/operator.py::resolve_role_probe` — the soft-failing
+  role probe driving `is_tenant_admin`.
+- `db.models.Target` — the tenant-scoped target picker source.
+
+## Known limitations
+
+- Read-only by design (T1). User management is T2; client-scope/mapper
+  create is T3.
+- Single managed realm per target (the connector resolves the realm from
+  the target's `managed_realm`); no realm selector.
+
+## References
+
+- Task [#1959](https://github.com/evoila/meho/issues/1959), Initiative
+  [#1943](https://github.com/evoila/meho/issues/1943).
+- Operations console precedent:
+  [#1835](https://github.com/evoila/meho/issues/1835)
+  (`docs/codebase/ui.md`, `ui/routes/operations/routes.py`).
+- Keycloak connector + read ops:
+  `docs/codebase/connectors-keycloak.md`.


### PR DESCRIPTION
## Summary

- Adds the `/ui/keycloak` **read-only** realm browser the Keycloak-console initiative (#1943) write tasks build on: a new `ui/routes/keycloak/` package whose `build_keycloak_router` factory dispatches the curated `keycloak.*` read ops (`realm.get`, `client.list`, `client.get`, `client_scope.list`) **in-process** through `operations.meta_tools.call_operation` — the same session-BFF pattern as `/ui/operations`. There is no `/api/v1/keycloak` REST surface (Keycloak admin rides the operations dispatcher), so this is pure UI/BFF + template assembly; no backend route or meta-tool is added.
- Renders a domain-shaped UX (realm-config card + client list + per-client detail drawer + client-scope list) instead of the generic op drawer, plus a Keycloak sidebar nav entry and the `key-round` icon.
- `connector_id` is **pinned** to the constant `keycloak-admin-26.x` on every dispatch; the operator only picks the *target* slug (which Keycloak deployment), never the connector. The bare `keycloak` slug (which names no connector) is never used.
- Secret redaction stays at the connector layer: the templates render named, projected fields only and never dump the raw `OperationResult` envelope, so a future un-scrubbed field can't leak through a verbatim blob.

## Test plan

- [x] `pytest -k "keycloak_ui and index"` — 4 passed: `GET /ui/keycloak` renders the realm-config card + client list + client-scope list; the dispatched `connector_id` is asserted `== keycloak-admin-26.x` (and `!= "keycloak"`) on every captured `call_operation` call.
- [x] Secret-redaction trap test — a planted live `secret` in the dispatch double's client dict does **not** appear in the client-detail body, and no verbatim envelope blob (`duration_ms` / `"handle"`) is rendered.
- [x] RBAC tests — a plain **operator** (not tenant_admin) session renders both `/ui/keycloak` and the client detail (reads are operator-tier; `is_tenant_admin` threaded via the soft-failing role probe for T2/T3 write affordances).
- [x] Route-order tests — `build_keycloak_router` is included before `build_stubs_router()`; the literal `/ui/keycloak/clients/{client_uuid}` registers before the bare `/ui/keycloak` index (first-match-wins; a future `/ui/keycloak/users` in T2 drops in cleanly).
- [x] No-tenant-override test — a `?target=` naming another tenant's keycloak target drives no dispatch.
- [x] `cd cli && make snapshot-openapi && make generate` run; `cli/api/openapi.json` (now carries `/ui/keycloak` + `/ui/keycloak/clients/{client_uuid}`) + `cli/internal/api/client.gen.go` committed; `go build ./...` clean.
- [x] `ruff check` (changed files) + `ruff format --check` + `mypy src/` clean; `code-quality.py --diff` — 0 blockers.
- [x] `/ui/operations` + chassis-smoke + icon suites green (nav/router/icon changes don't regress other surfaces).

## Out of scope

- User management (list/create/reset-password/role-assign) → T2.
- Client-scope **create** + protocol-mapper create → T3.
- Agent-principal register/revoke stays on `/ui/agents/principals` (#1831/#1866); this surface only cross-links.
- Cross-tenant target/realm selector (deferred console-wide, #865).

### Adjacent findings (deferred)

- `ui/routes/keycloak/routes.py` is 425 lines (code-quality **warn** at >400, well under the 600 block) — mostly the load-bearing module docstring; recorded, not split.
- `build_router` in `ui/routes/__init__.py` crossed the 100-line function-size limit as the linear include-aggregate grew; annotated with a `code-quality-allow: function-size` escape valve (a flat registration list whose length is the surface count, not logic).

<!-- auto-implement-issue: fresh, iteration 1 -->

Closes #1959
