### PR TITLE
feat(ui): topology curated-edge annotate + unannotate writes (in-process BFF, tenant_admin) (#1953)

### DIFF
--- a/backend/src/meho_backplane/ui/routes/connectors/operator.py
+++ b/backend/src/meho_backplane/ui/routes/connectors/operator.py
@@ -57,6 +57,7 @@ from meho_backplane.ui.auth.session_store import load_session
 
 __all__ = [
     "OperatorRoleProbe",
+    "lift_operator_from_session",
     "resolve_operator_or_403",
     "resolve_role_probe",
 ]
@@ -132,12 +133,17 @@ def _assert_identity_matches(operator: Operator, session_ctx: UISessionContext) 
         )
 
 
-async def _lift_operator(session_ctx: UISessionContext) -> Operator:
+async def lift_operator_from_session(session_ctx: UISessionContext) -> Operator:
     """Lift the full :class:`Operator` from the BFF session row.
 
     Common helper for the read-only role probe and the write-gating
     403 dependency. The JWT chain caches the JWKS in process so the
     round-trip is local-only after the first hit.
+
+    Public so sibling console surfaces that need the same
+    JWT-revalidated operator (e.g. the topology curated-edge write gate,
+    Task #1953) reuse one identity-assertion path rather than
+    re-implementing the load + verify + identity-match chain.
     """
     access_token = await _load_access_token_or_401(session_ctx)
     settings = get_settings()
@@ -147,6 +153,13 @@ async def _lift_operator(session_ctx: UISessionContext) -> Operator:
     )
     _assert_identity_matches(operator, session_ctx)
     return operator
+
+
+#: Backwards-compatible private alias. The helper was introduced as
+#: ``_lift_operator`` (used by the two dependencies below); promoting it to
+#: the public name keeps both internal call sites working without churning
+#: this module's own references.
+_lift_operator = lift_operator_from_session
 
 
 async def resolve_role_probe(

--- a/backend/src/meho_backplane/ui/routes/topology/__init__.py
+++ b/backend/src/meho_backplane/ui/routes/topology/__init__.py
@@ -30,8 +30,17 @@ Module layout:
   and the graph view (HTMX node-tap handler) with node properties,
   incoming/outgoing edges, recent audit operations on the node's
   target (when one is attached), and a "show dependents" link.
+* :mod:`~meho_backplane.ui.routes.topology.edges` -- the curated-edge
+  **write** routes (``GET /ui/topology/edges/annotate`` modal,
+  ``POST /ui/topology/edges`` annotate, ``DELETE
+  /ui/topology/edges/{edge_id}`` unannotate). ``require_ui_session`` +
+  CSRF-gated + ``tenant_admin`` (Initiative #1941 Task #1953); calls the
+  :mod:`~meho_backplane.topology.annotate` service in-process. The literal
+  ``edges`` / ``annotate`` segments are registered **before** the detail
+  router's ``node/{node_id}`` param route so the first-match-wins lookup
+  never binds them as a node id.
 
-The umbrella :func:`build_router` aggregates both. It is mounted
+The umbrella :func:`build_router` aggregates all three. It is mounted
 **before** :func:`meho_backplane.ui.routes.stubs.build_stubs_router`
 in :func:`meho_backplane.ui.routes.build_router` so the real
 ``/ui/topology`` handler wins the first-match-wins lookup -- a later
@@ -46,6 +55,7 @@ from __future__ import annotations
 from fastapi import APIRouter
 
 from meho_backplane.ui.routes.topology.detail import build_detail_router
+from meho_backplane.ui.routes.topology.edges import build_edges_router
 from meho_backplane.ui.routes.topology.table import build_table_router
 
 __all__ = ["build_router"]
@@ -62,5 +72,13 @@ def build_router() -> APIRouter:
     """
     router = APIRouter()
     router.include_router(build_table_router())
+    # Edge-write routes BEFORE the detail router: the literal
+    # ``/ui/topology/edges/annotate`` must win the first-match-wins lookup
+    # against ``detail.py``'s ``/ui/topology/node/{node_id}`` param route.
+    # (The two literal segments ``edges`` / ``annotate`` cannot bind as a
+    # ``{node_id}`` UUID anyway, but registering ahead keeps the ordering
+    # discipline explicit and robust against a future bare ``{param}``
+    # route landing in this aggregator.)
+    router.include_router(build_edges_router())
     router.include_router(build_detail_router())
     return router

--- a/backend/src/meho_backplane/ui/routes/topology/detail.py
+++ b/backend/src/meho_backplane/ui/routes/topology/detail.py
@@ -65,6 +65,9 @@ from sqlalchemy.orm import aliased
 from meho_backplane.db.engine import get_raw_session
 from meho_backplane.db.models import AuditLog, GraphEdge, GraphNode
 from meho_backplane.ui.auth.middleware import UISessionContext, require_ui_session
+from meho_backplane.ui.csrf import mint_csrf_token
+from meho_backplane.ui.routes.approvals.render import set_csrf_cookie
+from meho_backplane.ui.routes.connectors.operator import OperatorRoleProbe, resolve_role_probe
 from meho_backplane.ui.templating import get_templates
 
 __all__ = ["build_detail_router"]
@@ -271,6 +274,7 @@ async def _fetch_recent_ops(
 #: Module-level :class:`fastapi.Depends` closures -- ruff B008 guard.
 _require_ui_session_dep = Depends(require_ui_session)
 _get_raw_session_dep = Depends(get_raw_session)
+_resolve_role_probe_dep = Depends(resolve_role_probe)
 
 
 def _build_drawer_context(
@@ -279,6 +283,8 @@ def _build_drawer_context(
     outgoing: list[_EdgeRow],
     incoming: list[_EdgeRow],
     recent_ops: list[AuditLog],
+    is_tenant_admin: bool,
+    csrf_token: str,
 ) -> dict[str, object]:
     """Assemble the Jinja2 context dict the drawer template renders.
 
@@ -287,6 +293,15 @@ def _build_drawer_context(
     "show dependents" link target -- T3 (#882) wired the handler; the
     URL contract is ``?from=<name>&from_kind=<kind>`` so the
     dependents subgraph overlay loads with the right anchor.
+
+    ``is_tenant_admin`` drives the **soft-hide** of the curated-edge
+    annotate / remove controls (Task #1953): an operator never sees the
+    write affordances. The server-side authority is the
+    ``/ui/topology/edges*`` routes' ``tenant_admin`` gate -- the hidden
+    button is UX only; a forged POST still 403s. ``csrf_token`` is the
+    double-submit token the annotate-modal-open ``hx-get`` and the
+    per-edge remove ``hx-delete`` echo back so the CSRF middleware accepts
+    them; the drawer render (re)sets the matching ``meho_csrf`` cookie.
 
     ``graph_node.name`` is unconstrained Text (connector-populated);
     a name containing ``&`` / ``?`` / ``#`` / ``+`` / ``%`` / space
@@ -300,12 +315,89 @@ def _build_drawer_context(
         "outgoing_edges": outgoing,
         "incoming_edges": incoming,
         "recent_ops": recent_ops,
+        "is_tenant_admin": is_tenant_admin,
+        "csrf_token": csrf_token,
+        "annotate_modal_href": "/ui/topology/edges/annotate",
         "dependents_href": (
             f"/ui/topology?view=graph"
             f"&from={quote(node.name, safe='')}"
             f"&from_kind={quote(node.kind, safe='')}"
         ),
     }
+
+
+async def _render_node_detail(
+    request: Request,
+    node_id: uuid.UUID,
+    *,
+    session_ctx: UISessionContext,
+    db_session: AsyncSession,
+    role_probe: OperatorRoleProbe,
+) -> HTMLResponse:
+    """Resolve the node tenant-scoped and render the drawer fragment.
+
+    Pulls the incoming + outgoing edges via the SQLite-portable ORM query
+    and the recent ``audit_log`` rows, then renders ``topology/_drawer.html``
+    with the full context. The ``role_probe`` (fail-soft ``tenant_admin``
+    projection) drives the soft-hide of the curated-edge write controls; the
+    drawer also mints + re-sets the ``meho_csrf`` cookie so an admin's
+    annotate / remove request carries a valid double-submit token.
+
+    Returns the not-found drawer fragment (HTTP 404) for a missing /
+    cross-tenant id; HTMX swaps either response into ``#node-drawer``.
+    """
+    node = await _fetch_node(
+        db_session,
+        tenant_id=session_ctx.tenant_id,
+        node_id=node_id,
+    )
+    if node is None:
+        # 404 fragment -- HTMX swaps it into the drawer and the operator
+        # sees the "not found" message without a full page reload. HTMX does
+        # not auto-clear the swap target on 4xx by default, which is the
+        # desired behaviour.
+        return get_templates().TemplateResponse(
+            request,
+            "topology/_drawer_not_found.html",
+            {"node_id": str(node_id)},
+            status_code=404,
+        )
+
+    outgoing = await _fetch_edges(
+        db_session,
+        tenant_id=session_ctx.tenant_id,
+        node_id=node.id,
+        direction="out",
+        limit=_EDGE_LIMIT,
+    )
+    incoming = await _fetch_edges(
+        db_session,
+        tenant_id=session_ctx.tenant_id,
+        node_id=node.id,
+        direction="in",
+        limit=_EDGE_LIMIT,
+    )
+    recent_ops = await _fetch_recent_ops(
+        db_session,
+        tenant_id=session_ctx.tenant_id,
+        target_id=node.target_id,
+    )
+
+    csrf_token = mint_csrf_token(str(session_ctx.session_id))
+    context = _build_drawer_context(
+        node=node,
+        outgoing=outgoing,
+        incoming=incoming,
+        recent_ops=recent_ops,
+        is_tenant_admin=role_probe.is_tenant_admin,
+        csrf_token=csrf_token,
+    )
+    response = get_templates().TemplateResponse(request, "topology/_drawer.html", context)
+    # Re-set the matching ``meho_csrf`` cookie so the drawer's annotate /
+    # remove controls' echoed token lines up after the HTMX swap (the
+    # cookie-desync class the approvals modal also guards against).
+    set_csrf_cookie(response, csrf_token)
+    return response
 
 
 def build_detail_router() -> APIRouter:
@@ -323,60 +415,16 @@ def build_detail_router() -> APIRouter:
         node_id: uuid.UUID,
         session_ctx: UISessionContext = _require_ui_session_dep,
         db_session: AsyncSession = _get_raw_session_dep,
+        role_probe: OperatorRoleProbe = _resolve_role_probe_dep,
     ) -> HTMLResponse:
-        """``GET /ui/topology/node/{node_id}``.
-
-        Resolves the node tenant-scoped, then pulls the incoming +
-        outgoing edges via :func:`list_edges` and the recent
-        operations directly from ``audit_log``. Renders the
-        ``topology/_drawer.html`` fragment with the full context.
-        """
-        node = await _fetch_node(
-            db_session,
-            tenant_id=session_ctx.tenant_id,
-            node_id=node_id,
+        """``GET /ui/topology/node/{node_id}`` -- delegates to the renderer."""
+        return await _render_node_detail(
+            request,
+            node_id,
+            session_ctx=session_ctx,
+            db_session=db_session,
+            role_probe=role_probe,
         )
-        if node is None:
-            # 404 fragment -- HTMX swaps it into the drawer and the
-            # operator sees the "not found" message without a full
-            # page reload. The 404 status code is also surfaced to
-            # the swap so a future ``hx-on::after-request`` hook can
-            # branch on it; HTMX does not auto-clear the swap target
-            # on 4xx by default, which is the desired behaviour.
-            return get_templates().TemplateResponse(
-                request,
-                "topology/_drawer_not_found.html",
-                {"node_id": str(node_id)},
-                status_code=404,
-            )
-
-        outgoing = await _fetch_edges(
-            db_session,
-            tenant_id=session_ctx.tenant_id,
-            node_id=node.id,
-            direction="out",
-            limit=_EDGE_LIMIT,
-        )
-        incoming = await _fetch_edges(
-            db_session,
-            tenant_id=session_ctx.tenant_id,
-            node_id=node.id,
-            direction="in",
-            limit=_EDGE_LIMIT,
-        )
-        recent_ops = await _fetch_recent_ops(
-            db_session,
-            tenant_id=session_ctx.tenant_id,
-            target_id=node.target_id,
-        )
-
-        context = _build_drawer_context(
-            node=node,
-            outgoing=outgoing,
-            incoming=incoming,
-            recent_ops=recent_ops,
-        )
-        return get_templates().TemplateResponse(request, "topology/_drawer.html", context)
 
     router.add_api_route(
         "/ui/topology/node/{node_id}",

--- a/backend/src/meho_backplane/ui/routes/topology/edges.py
+++ b/backend/src/meho_backplane/ui/routes/topology/edges.py
@@ -1,0 +1,585 @@
+# SPDX-License-Identifier: Apache-2.0
+# Copyright (c) 2026 evoila Group
+
+"""Curated-edge **write** routes for the topology console (in-process BFF).
+
+Initiative #1941 (G10.17 Topology console writes), Task #1953 (T1). The
+read-only topology surface (table + Cytoscape graph + node drawer, #880 /
+#881 / #882) carries no write verbs; the curated-edge annotate / unannotate
+verbs exist only on the CLI (``meho topology annotate`` / ``unannotate``)
+and the Bearer REST API (``POST`` / ``DELETE /api/v1/topology/edges``). This
+module is the operator-console face of those verbs.
+
+Why a session BFF and not the Bearer ``/api/v1/topology/edges`` routes
+---------------------------------------------------------------------
+
+The REST edge routes are Bearer-gated (``_require_admin`` over a verified
+JWT). A browser carrying only the BFF session cookie + the CSRF
+double-submit token cannot authenticate them. So this module adds
+``/ui/topology/edges*`` sub-routes that are ``require_ui_session`` +
+CSRF-gated and call the
+:mod:`~meho_backplane.topology.annotate` **service** in-process
+(:func:`~meho_backplane.topology.annotate.annotate_edge` /
+:func:`~meho_backplane.topology.annotate.unannotate_edge`) — the same
+console-surface pattern the approvals / connectors surfaces use. The
+in-process call keeps the synchronous-audit binding and avoids a self-HTTP
+hop the cookie could not auth anyway.
+
+Route inventory
+---------------
+
+* ``GET /ui/topology/edges/annotate`` — the annotate-modal fragment. The
+  literal ``edges`` / ``annotate`` segments register **ahead of**
+  ``detail.py``'s ``/ui/topology/node/{node_id}`` param route so the
+  first-match-wins lookup never binds them as a node id (verified at
+  construction time with a FastAPI test client). The modal mints + sets a
+  fresh ``meho_csrf`` cookie so the POST carries a valid double-submit
+  token.
+* ``POST /ui/topology/edges`` — CSRF-gated. Reconstructs the operator,
+  builds two :class:`~meho_backplane.topology.annotate.NodeRef` endpoints
+  (``from`` is a Python-reserved word, so the wire field never carries a
+  raw ``from`` key — the handler constructs the ``NodeRef`` directly), and
+  calls :func:`annotate_edge` in-process. Renders the created edge inline +
+  fires an ``HX-Trigger`` so an open graph view re-pulls.
+* ``DELETE /ui/topology/edges/{edge_id}`` — CSRF-gated, confirm-gated.
+  Calls :func:`unannotate_edge` in-process; on success swaps the row out +
+  fires the same graph-refresh trigger. The ``{edge_id}`` param route is a
+  ``DELETE``, so it never collides with the ``GET`` annotate-modal route.
+
+RBAC tier split (load-bearing)
+------------------------------
+
+Curated-edge writes are **``tenant_admin``** at the REST layer (an
+annotation can shrink the auto-flagged blast radius of an op the operator
+then runs — the same gate as ``POST /api/v1/targets``). The BFF mirrors
+this two ways:
+
+* **Soft-hide** — the drawer (``_drawer.html``) renders the annotate /
+  remove controls only when ``is_tenant_admin`` (projected via
+  :func:`~meho_backplane.ui.routes.connectors.operator.resolve_role_probe`,
+  fail-soft). An operator never sees the affordances.
+* **Hard-403** — every route here gates on
+  :func:`_require_topology_admin` (mirrors
+  :func:`~meho_backplane.ui.routes.connectors.operator.resolve_operator_or_403`)
+  so a forged POST from a non-admin session is rejected server-side. The
+  same template serving both roles is the regression trap — the disabled /
+  absent button is UX only; the gate is the authority.
+
+Recoverable typed errors
+-------------------------
+
+The service raises HTTP-agnostic ``ValueError`` subclasses; this module
+maps each to a re-rendered fragment with a legible banner rather than a
+dead 5xx, mirroring the REST layer's status codes:
+
+* :class:`~meho_backplane.topology.resolvers.AmbiguousNodeError` → re-render
+  the annotate modal with the candidate ``kinds`` listed so the operator
+  re-submits with a disambiguating ``kind`` (the REST 409 ``ambiguous_node``
+  surface).
+* :class:`~meho_backplane.topology.resolvers.NodeNotFoundError` /
+  :class:`~meho_backplane.topology.annotate.InvalidEdgeKindError` → re-render
+  the modal with the typed error banner.
+* :class:`~meho_backplane.topology.annotate.AutoEdgeDeletionError` →
+  re-render the row with the recoverable "this is an auto edge; annotate
+  over it first" banner (the REST 409 ``auto_edge_deletion`` surface). Auto
+  edges resurrect on the next refresh, so a naive DELETE retry would
+  confuse the operator.
+
+Tenant isolation
+----------------
+
+Every write derives ``tenant_id`` from the reconstructed
+:class:`~meho_backplane.auth.operator.Operator` (itself validated against
+the session) — never a form / query field. The service's endpoint resolver
+scopes on ``operator.tenant_id``, so a cross-tenant node name is
+indistinguishable from a missing one (404-class), and a cross-tenant
+``edge_id`` is indistinguishable from a missing one (the
+``unannotate_edge`` tenant-boundary contract).
+"""
+
+from __future__ import annotations
+
+import uuid
+from dataclasses import dataclass
+
+import structlog
+from fastapi import APIRouter, Depends, Form, HTTPException, Request, status
+from fastapi.responses import HTMLResponse
+from sqlalchemy import select
+from sqlalchemy.ext.asyncio import AsyncSession
+from sqlalchemy.orm import aliased
+
+from meho_backplane.auth.operator import Operator, TenantRole
+from meho_backplane.db.engine import get_sessionmaker
+from meho_backplane.db.models import GraphEdge, GraphEdgeKind, GraphNode
+from meho_backplane.topology.annotate import (
+    AutoEdgeDeletionError,
+    InvalidEdgeKindError,
+    NodeRef,
+    annotate_edge,
+    unannotate_edge,
+)
+from meho_backplane.topology.resolvers import AmbiguousNodeError, NodeNotFoundError
+from meho_backplane.ui.auth.middleware import UISessionContext, require_ui_session
+from meho_backplane.ui.csrf import mint_csrf_token
+from meho_backplane.ui.routes.approvals.render import set_csrf_cookie
+from meho_backplane.ui.routes.connectors.operator import lift_operator_from_session
+from meho_backplane.ui.templating import get_templates
+
+__all__ = ["build_edges_router"]
+
+_log = structlog.get_logger(__name__)
+
+#: ``HX-Trigger`` event name fired on a successful annotate / unannotate.
+#: The graph view's data-island wrapper (``topology-graph.js``) listens for
+#: it and re-pulls the graph JSON so a just-written / removed edge shows
+#: without a hard reload (the issue's "the graph reflects writes" criterion).
+_EDGE_CHANGED_EVENT = "meho:topology-edge-changed"
+
+#: Bound on the operator-supplied free-text fields, matching the REST
+#: ``_AnnotateEdgeRequest`` (``note`` / ``evidence_url`` ``max_length=2000``)
+#: so an oversized paste is rejected at the form boundary rather than
+#: forwarded into the service.
+_MAX_NOTE_LENGTH = 2000
+_MAX_EVIDENCE_URL_LENGTH = 2000
+
+#: The closed v0.2 edge-kind vocabulary, surfaced to the modal's ``kind``
+#: dropdown. Sourced from the enum (single source of truth) so a future
+#: widening of :class:`GraphEdgeKind` lands in the modal for free.
+_EDGE_KIND_OPTIONS = [k.value for k in GraphEdgeKind]
+
+
+@dataclass(frozen=True)
+class _EdgeEndpointRow:
+    """Compact endpoint shape the created-edge fragment renders.
+
+    Mirrors :class:`meho_backplane.ui.routes.topology.detail._EdgeEndpointRow`
+    so the inline created-edge row and the drawer's neighbour list share a
+    template-facing shape.
+    """
+
+    id: uuid.UUID
+    kind: str
+    name: str
+
+
+@dataclass(frozen=True)
+class _EdgeRow:
+    """One curated edge rendered inline after a successful annotate.
+
+    Built from the :class:`GraphEdge` row :func:`annotate_edge` returns
+    (plus a re-fetch of the two endpoint nodes for their human-readable
+    ``(kind, name)``). Matches the drawer's ``_EdgeRow`` field shape so the
+    created-edge fragment can reuse the drawer's edge-row markup.
+    """
+
+    id: uuid.UUID
+    kind: str
+    source: str
+    from_endpoint: _EdgeEndpointRow
+    to_endpoint: _EdgeEndpointRow
+
+
+@dataclass(frozen=True)
+class _AnnotateForm:
+    """The annotate POST's form fields, bundled so they pass as one value.
+
+    Keeps the ``POST /ui/topology/edges`` handler and the in-process
+    annotate helper from threading seven discrete arguments each (the
+    ``from`` / ``kind`` / ``to`` / ``note`` / ``evidence_url`` wire shape).
+    The ``submitted`` projection echoes the operator's input back into the
+    modal on a re-render after a disambiguation hint.
+    """
+
+    from_name: str
+    from_kind: str
+    kind: str
+    to_name: str
+    to_kind: str
+    note: str
+    evidence_url: str
+
+    def submitted(self) -> dict[str, str]:
+        """The form fields as a template dict for the modal-re-render echo."""
+        return {
+            "from_name": self.from_name,
+            "from_kind": self.from_kind,
+            "kind": self.kind,
+            "to_name": self.to_name,
+            "to_kind": self.to_kind,
+            "note": self.note,
+            "evidence_url": self.evidence_url,
+        }
+
+
+#: Module-level ``Depends`` closures (ruff B008 guard), matching the
+#: convention every UI surface router follows.
+_require_session = Depends(require_ui_session)
+
+
+async def _require_topology_admin(
+    request: Request,
+    session_ctx: UISessionContext = _require_session,
+) -> Operator:
+    """FastAPI dependency: lift the operator + hard-gate to ``tenant_admin``.
+
+    Mirrors
+    :func:`~meho_backplane.ui.routes.connectors.operator.resolve_operator_or_403`
+    but raises a topology-specific 403 detail. Used by every write route
+    here (the annotate-modal GET, the annotate POST, the unannotate DELETE)
+    so a non-admin session — even one that forged the request past the
+    soft-hidden controls — is rejected server-side. The role probe used for
+    the drawer's soft-hide is UX only; this gate is the authority.
+    """
+    operator = await lift_operator_from_session(session_ctx)
+    if operator.tenant_role != TenantRole.TENANT_ADMIN:
+        raise HTTPException(
+            status_code=status.HTTP_403_FORBIDDEN,
+            detail="curated-edge writes require tenant_admin",
+        )
+    return operator
+
+
+async def _load_edge_row(session: AsyncSession, *, edge: GraphEdge) -> _EdgeRow:
+    """Project a freshly-written :class:`GraphEdge` into the inline row shape.
+
+    Re-fetches the two endpoint nodes (the ORM row carries only the FK ids)
+    so the created-edge fragment can render the human-readable
+    ``(kind, name)`` for each side. Tenant scoping is already guaranteed —
+    the edge was written under ``operator.tenant_id`` and both endpoints
+    resolved within that tenant — so this read does not re-assert it.
+    """
+    from_alias = aliased(GraphNode)
+    to_alias = aliased(GraphNode)
+    stmt = (
+        select(
+            from_alias.id.label("from_id"),
+            from_alias.kind.label("from_kind"),
+            from_alias.name.label("from_name"),
+            to_alias.id.label("to_id"),
+            to_alias.kind.label("to_kind"),
+            to_alias.name.label("to_name"),
+        )
+        .select_from(GraphEdge)
+        .join(from_alias, from_alias.id == GraphEdge.from_node_id)
+        .join(to_alias, to_alias.id == GraphEdge.to_node_id)
+        .where(GraphEdge.id == edge.id)
+    )
+    result = await session.execute(stmt)
+    row = result.one()
+    return _EdgeRow(
+        id=edge.id,
+        kind=edge.kind,
+        source=edge.source,
+        from_endpoint=_EdgeEndpointRow(id=row.from_id, kind=row.from_kind, name=row.from_name),
+        to_endpoint=_EdgeEndpointRow(id=row.to_id, kind=row.to_kind, name=row.to_name),
+    )
+
+
+def _annotate_modal_context(
+    *,
+    csrf_token: str,
+    error_message: str | None = None,
+    ambiguous_name: str | None = None,
+    ambiguous_kinds: list[str] | None = None,
+    submitted: dict[str, str] | None = None,
+) -> dict[str, object]:
+    """Assemble the annotate-modal context dict.
+
+    The ``error_*`` / ``ambiguous_*`` keys let the POST handler re-render
+    the modal with a typed banner (and, for an ambiguous node, the
+    candidate ``kinds``) without a second round trip. ``submitted`` echoes
+    the operator's prior input back into the form fields so a re-submission
+    after a disambiguation hint does not start from a blank slate.
+    """
+    return {
+        "csrf_token": csrf_token,
+        "edge_kind_options": _EDGE_KIND_OPTIONS,
+        "error_message": error_message,
+        "ambiguous_name": ambiguous_name,
+        "ambiguous_kinds": ambiguous_kinds or [],
+        "submitted": submitted or {},
+        "max_note_length": _MAX_NOTE_LENGTH,
+        "max_evidence_url_length": _MAX_EVIDENCE_URL_LENGTH,
+    }
+
+
+def _render_annotate_modal(
+    request: Request,
+    *,
+    session_id: uuid.UUID,
+    status_code: int = 200,
+    error_message: str | None = None,
+    ambiguous_name: str | None = None,
+    ambiguous_kinds: list[str] | None = None,
+    submitted: dict[str, str] | None = None,
+) -> HTMLResponse:
+    """Render ``topology/_annotate_modal.html`` + (re)set the CSRF cookie.
+
+    The modal render rotates the CSRF token and re-sets the ``meho_csrf``
+    cookie on the same response so the form's echoed token always lines up
+    with the cookie after the HTMX swap (the cookie-desync class the
+    approvals modal also guards against). Used both for the initial
+    modal-open GET and for the typed-error re-render on a failed POST.
+    """
+    csrf_token = mint_csrf_token(str(session_id))
+    context = _annotate_modal_context(
+        csrf_token=csrf_token,
+        error_message=error_message,
+        ambiguous_name=ambiguous_name,
+        ambiguous_kinds=ambiguous_kinds,
+        submitted=submitted,
+    )
+    response = get_templates().TemplateResponse(
+        request,
+        "topology/_annotate_modal.html",
+        context,
+        status_code=status_code,
+    )
+    set_csrf_cookie(response, csrf_token)
+    return response
+
+
+def _node_ref(name: str, kind: str) -> NodeRef:
+    """Build a :class:`NodeRef` from a form ``name`` + optional ``kind``.
+
+    A blank ``kind`` (the operator left the optional disambiguator empty)
+    becomes ``None`` so the resolver runs its bare-name branch — which may
+    raise :class:`AmbiguousNodeError` the POST handler surfaces. ``from`` is
+    never posted as a raw JSON key; the handler always reaches the service
+    through this constructor.
+    """
+    return NodeRef(name=name.strip(), kind=kind.strip() or None)
+
+
+def build_edges_router() -> APIRouter:
+    """Construct the ``/ui/topology/edges*`` write :class:`APIRouter`.
+
+    Factory function (not a module-level constant) so a test app can
+    construct parallel routers without shared route state — the convention
+    every topology / approvals / connectors surface router follows. The
+    literal ``edges`` / ``annotate`` segments are registered through this
+    router, which :func:`meho_backplane.ui.routes.topology.build_router`
+    includes **before** ``build_detail_router()`` so the
+    ``/ui/topology/node/{node_id}`` param route never shadows them.
+    """
+    router = APIRouter(tags=["ui-topology"])
+
+    _require_admin = Depends(_require_topology_admin)
+
+    @router.get("/ui/topology/edges/annotate", response_class=HTMLResponse)
+    async def annotate_modal(
+        request: Request,
+        session_ctx: UISessionContext = _require_session,
+        # Hard-gate the modal-open too: an operator never reaches the
+        # annotate form (defense in depth on top of the drawer soft-hide).
+        operator: Operator = _require_admin,
+    ) -> HTMLResponse:
+        """``GET /ui/topology/edges/annotate`` — render the annotate modal."""
+        return _render_annotate_modal(request, session_id=session_ctx.session_id)
+
+    @router.post("/ui/topology/edges", response_class=HTMLResponse)
+    async def annotate(
+        request: Request,
+        session_ctx: UISessionContext = _require_session,
+        operator: Operator = _require_admin,
+        from_name: str = Form(..., min_length=1),
+        from_kind: str = Form(default=""),
+        kind: str = Form(..., min_length=1),
+        to_name: str = Form(..., min_length=1),
+        to_kind: str = Form(default=""),
+        note: str = Form(default="", max_length=_MAX_NOTE_LENGTH),
+        evidence_url: str = Form(default="", max_length=_MAX_EVIDENCE_URL_LENGTH),
+    ) -> HTMLResponse:
+        """``POST /ui/topology/edges`` — annotate a curated edge in-process."""
+        return await _annotate(
+            request,
+            session_ctx=session_ctx,
+            operator=operator,
+            form=_AnnotateForm(
+                from_name=from_name,
+                from_kind=from_kind,
+                kind=kind,
+                to_name=to_name,
+                to_kind=to_kind,
+                note=note,
+                evidence_url=evidence_url,
+            ),
+        )
+
+    @router.delete("/ui/topology/edges/{edge_id}", response_class=HTMLResponse)
+    async def unannotate(
+        request: Request,
+        edge_id: uuid.UUID,
+        operator: Operator = _require_admin,
+    ) -> HTMLResponse:
+        """``DELETE /ui/topology/edges/{edge_id}`` — remove a curated edge."""
+        return await _unannotate(request, operator=operator, edge_id=edge_id)
+
+    return router
+
+
+def _annotate_error_modal(
+    request: Request,
+    *,
+    session_id: uuid.UUID,
+    exc: AmbiguousNodeError | NodeNotFoundError | InvalidEdgeKindError,
+    submitted: dict[str, str],
+) -> HTMLResponse:
+    """Map a recoverable annotate failure to a modal re-render.
+
+    Mirrors the REST layer's status codes
+    (:mod:`meho_backplane.api.v1.topology`): 409 ``ambiguous_node`` (with
+    the candidate ``kinds`` echoed so the operator re-submits with a
+    disambiguating ``kind``), 404 for an unknown node, 422 for an
+    out-of-vocabulary edge kind. The modal stays open with the typed banner
+    rather than tearing the operator out of the flow.
+    """
+    if isinstance(exc, AmbiguousNodeError):
+        return _render_annotate_modal(
+            request,
+            session_id=session_id,
+            status_code=status.HTTP_409_CONFLICT,
+            error_message=(
+                f"The name {exc.name!r} is ambiguous in this tenant — it exists as "
+                "more than one kind. Pick a kind below and re-submit."
+            ),
+            ambiguous_name=exc.name,
+            ambiguous_kinds=sorted(exc.kinds),
+            submitted=submitted,
+        )
+    if isinstance(exc, NodeNotFoundError):
+        return _render_annotate_modal(
+            request,
+            session_id=session_id,
+            status_code=status.HTTP_404_NOT_FOUND,
+            error_message=f"No node matched {exc.name!r} in this tenant.",
+            submitted=submitted,
+        )
+    return _render_annotate_modal(
+        request,
+        session_id=session_id,
+        status_code=status.HTTP_422_UNPROCESSABLE_ENTITY,
+        error_message=(
+            f"Edge kind {exc.kind!r} is not in the v0.2 vocabulary. Pick a valid kind below."
+        ),
+        submitted=submitted,
+    )
+
+
+async def _annotate(
+    request: Request,
+    *,
+    session_ctx: UISessionContext,
+    operator: Operator,
+    form: _AnnotateForm,
+) -> HTMLResponse:
+    """Resolve endpoints + upsert the curated edge; render the outcome.
+
+    On success renders the created edge inline and fires the
+    :data:`_EDGE_CHANGED_EVENT` ``HX-Trigger`` so an open graph view
+    re-pulls. A recoverable failure (ambiguous node, unknown node, invalid
+    kind) re-renders the annotate modal with the typed banner via
+    :func:`_annotate_error_modal` rather than tearing the operator out of
+    the flow.
+    """
+    sessionmaker = get_sessionmaker()
+    async with sessionmaker() as db_session:
+        try:
+            edge = await annotate_edge(
+                db_session,
+                operator,
+                _node_ref(form.from_name, form.from_kind),
+                form.kind,
+                _node_ref(form.to_name, form.to_kind),
+                note=form.note.strip() or None,
+                evidence_url=form.evidence_url.strip() or None,
+            )
+        except (AmbiguousNodeError, NodeNotFoundError, InvalidEdgeKindError) as exc:
+            return _annotate_error_modal(
+                request,
+                session_id=session_ctx.session_id,
+                exc=exc,
+                submitted=form.submitted(),
+            )
+        edge_row = await _load_edge_row(db_session, edge=edge)
+
+    _log.info(
+        "ui_topology_edge_annotated",
+        edge_id=str(edge_row.id),
+        kind=edge_row.kind,
+        operator_sub=operator.sub,
+        tenant_id=str(operator.tenant_id),
+    )
+    response = get_templates().TemplateResponse(
+        request,
+        "topology/_edge_created.html",
+        {"edge": edge_row},
+    )
+    response.headers["HX-Trigger"] = _EDGE_CHANGED_EVENT
+    return response
+
+
+async def _unannotate(
+    request: Request,
+    *,
+    operator: Operator,
+    edge_id: uuid.UUID,
+) -> HTMLResponse:
+    """Hard-delete the curated edge; render the outcome.
+
+    On success swaps the row out (an empty fragment + an ``HX-Trigger`` so
+    an open graph view re-pulls). An ``auto_edge_deletion`` refusal
+    re-renders a recoverable banner ("this is an auto edge; annotate over it
+    first") rather than a dead error — auto edges resurrect on the next
+    refresh, so a naive DELETE retry would confuse the operator. A
+    missing / cross-tenant id renders a not-found banner.
+    """
+    sessionmaker = get_sessionmaker()
+    async with sessionmaker() as db_session:
+        try:
+            await unannotate_edge(db_session, operator, edge_id=edge_id)
+        except AutoEdgeDeletionError as exc:
+            return get_templates().TemplateResponse(
+                request,
+                "topology/_edge_remove_error.html",
+                {
+                    "edge_id": str(exc.edge_id),
+                    "error_kind": "auto_edge_deletion",
+                    "error_message": (
+                        "This is an auto-discovered edge; auto edges resurrect on the "
+                        "next refresh, so removing it is a no-op. Annotate over the auto "
+                        "edge first, then remove the curated row."
+                    ),
+                },
+                status_code=status.HTTP_409_CONFLICT,
+            )
+        except ValueError:
+            # The id-form selector raises ValueError when the row is not in
+            # this tenant (cross-tenant ids are indistinguishable from
+            # missing ones — the tenant-boundary contract). Mirrors the REST
+            # 404 ``edge_not_found`` surface.
+            return get_templates().TemplateResponse(
+                request,
+                "topology/_edge_remove_error.html",
+                {
+                    "edge_id": str(edge_id),
+                    "error_kind": "edge_not_found",
+                    "error_message": f"No edge {edge_id} found in this tenant.",
+                },
+                status_code=status.HTTP_404_NOT_FOUND,
+            )
+
+    _log.info(
+        "ui_topology_edge_unannotated",
+        edge_id=str(edge_id),
+        operator_sub=operator.sub,
+        tenant_id=str(operator.tenant_id),
+    )
+    response = get_templates().TemplateResponse(
+        request,
+        "topology/_edge_removed.html",
+        {"edge_id": str(edge_id)},
+    )
+    response.headers["HX-Trigger"] = _EDGE_CHANGED_EVENT
+    return response

--- a/backend/src/meho_backplane/ui/templates/topology/_annotate_modal.html
+++ b/backend/src/meho_backplane/ui/templates/topology/_annotate_modal.html
@@ -1,0 +1,155 @@
+{#-
+  SPDX-License-Identifier: Apache-2.0
+  Copyright (c) 2026 evoila Group
+
+  Curated-edge **annotate** modal (Initiative #1941 Task #1953). Rendered
+  by ``GET /ui/topology/edges/annotate`` (modal-open) and re-rendered by
+  ``POST /ui/topology/edges`` on a recoverable error (ambiguous node,
+  unknown node, invalid kind).
+
+  The form posts ``hx-post="/ui/topology/edges"`` carrying the CSRF
+  double-submit token on its OWN ``hx-headers`` (HTMX does not inherit
+  ``hx-headers`` to children -- the element issuing the request must carry
+  it). On success the response swaps in the created-edge fragment + fires an
+  ``HX-Trigger`` the graph view listens for; on a recoverable error this
+  modal re-renders with the typed banner (and, for an ambiguous node, the
+  candidate ``kinds``).
+
+  ``from`` is a Python-reserved word, so the wire fields are ``from_name`` /
+  ``from_kind`` -- the BFF never posts a raw ``from`` JSON key; it builds the
+  ``NodeRef`` server-side.
+-#}
+<div
+  id="topology-edge-modal"
+  class="card bg-base-100 border-base-300 border shadow-md"
+  x-data="{ open: true }"
+  x-show="open"
+  aria-label="Annotate curated edge"
+>
+  <div class="card-body space-y-3">
+    <header class="flex items-start justify-between gap-2">
+      <h2 class="card-title text-base">Annotate curated edge</h2>
+      <button
+        type="button"
+        class="btn btn-ghost btn-xs"
+        aria-label="Close annotate modal"
+        @click="open = false"
+      >
+        Close
+      </button>
+    </header>
+
+    {% if error_message %}
+      <div role="alert" class="alert alert-error text-sm" data-test="annotate-error">
+        <span>{{ error_message }}</span>
+      </div>
+    {% endif %}
+
+    {% if ambiguous_kinds %}
+      <div class="text-sm" data-test="ambiguous-kinds">
+        <p class="opacity-70">
+          Candidate kinds for <span class="font-mono">{{ ambiguous_name }}</span>:
+        </p>
+        <ul class="mt-1 flex flex-wrap gap-1">
+          {% for k in ambiguous_kinds %}
+            <li><span class="badge badge-outline badge-sm font-mono">{{ k }}</span></li>
+          {% endfor %}
+        </ul>
+      </div>
+    {% endif %}
+
+    <form
+      hx-post="/ui/topology/edges"
+      hx-target="#topology-edge-modal"
+      hx-swap="outerHTML"
+      hx-headers='{"X-CSRF-Token": "{{ csrf_token }}"}'
+      class="space-y-3"
+    >
+      <fieldset class="grid grid-cols-2 gap-2">
+        <label class="form-control">
+          <span class="label-text text-xs opacity-70">from (name)</span>
+          <input
+            type="text" name="from_name" required
+            value="{{ submitted.from_name | default('') }}"
+            class="input input-bordered input-sm font-mono"
+            aria-label="From node name"
+          />
+        </label>
+        <label class="form-control">
+          <span class="label-text text-xs opacity-70">from kind (optional)</span>
+          <input
+            type="text" name="from_kind"
+            value="{{ submitted.from_kind | default('') }}"
+            class="input input-bordered input-sm font-mono"
+            aria-label="From node kind"
+          />
+        </label>
+      </fieldset>
+
+      <label class="form-control">
+        <span class="label-text text-xs opacity-70">edge kind</span>
+        <select
+          name="kind" required
+          class="select select-bordered select-sm font-mono"
+          aria-label="Edge kind"
+        >
+          <option value="" disabled {{ 'selected' if not submitted.get('kind') else '' }}>
+            Select a kind…
+          </option>
+          {% for k in edge_kind_options %}
+            <option value="{{ k }}" {{ 'selected' if submitted.get('kind') == k else '' }}>{{ k }}</option>
+          {% endfor %}
+        </select>
+      </label>
+
+      <fieldset class="grid grid-cols-2 gap-2">
+        <label class="form-control">
+          <span class="label-text text-xs opacity-70">to (name)</span>
+          <input
+            type="text" name="to_name" required
+            value="{{ submitted.to_name | default('') }}"
+            class="input input-bordered input-sm font-mono"
+            aria-label="To node name"
+          />
+        </label>
+        <label class="form-control">
+          <span class="label-text text-xs opacity-70">to kind (optional)</span>
+          <input
+            type="text" name="to_kind"
+            value="{{ submitted.to_kind | default('') }}"
+            class="input input-bordered input-sm font-mono"
+            aria-label="To node kind"
+          />
+        </label>
+      </fieldset>
+
+      <label class="form-control">
+        <span class="label-text text-xs opacity-70">note (optional)</span>
+        <textarea
+          name="note" rows="2" maxlength="{{ max_note_length }}"
+          class="textarea textarea-bordered textarea-sm"
+          aria-label="Annotation note"
+        >{{ submitted.note | default('') }}</textarea>
+      </label>
+
+      <label class="form-control">
+        <span class="label-text text-xs opacity-70">evidence_url (optional)</span>
+        <input
+          type="url" name="evidence_url" maxlength="{{ max_evidence_url_length }}"
+          value="{{ submitted.evidence_url | default('') }}"
+          class="input input-bordered input-sm font-mono"
+          aria-label="Evidence URL"
+        />
+      </label>
+
+      <footer class="flex justify-end gap-2">
+        <button type="button" class="btn btn-ghost btn-sm" @click="open = false">
+          Cancel
+        </button>
+        <button type="submit" class="btn btn-primary btn-sm" data-test="annotate-submit">
+          Annotate edge
+        </button>
+      </footer>
+    </form>
+  </div>
+</div>

--- a/backend/src/meho_backplane/ui/templates/topology/_drawer.html
+++ b/backend/src/meho_backplane/ui/templates/topology/_drawer.html
@@ -13,13 +13,49 @@
     2. Properties -- key fields rendered as a description list, plus
        the raw JSON properties bag in a <pre> for forensic shape.
     3. Outgoing + incoming edges -- per-direction list with edge
-       kind + neighbour name + source (auto/curated).
+       kind + neighbour name + source (auto/curated). For a
+       ``tenant_admin`` (``is_tenant_admin``), curated edges carry a
+       confirm-gated Remove control (Task #1953).
     4. Recent operations -- the last few audit_log rows on this
        node's target (empty when target_id is null).
-    5. "Show dependents" link -- hands off to the future T3 graph
-       view; URL contract surfaces today so the link works as soon
-       as T3 lands.
+    5. "Show dependents" link -- hands off to the T3 graph view.
+
+  Curated-edge writes (Task #1953):
+    * The "Annotate edge" button (header, ``tenant_admin``-only soft-hide)
+      ``hx-get``s ``/ui/topology/edges/annotate`` into the
+      ``#topology-edge-modal`` slot.
+    * Each curated edge's Remove control ``hx-delete``s
+      ``/ui/topology/edges/{id}`` behind a native confirm; both carry the
+      CSRF double-submit token on their OWN ``hx-headers`` (HTMX does not
+      inherit ``hx-headers`` to children).
+    * The server-side ``tenant_admin`` gate on those routes is the
+      authority; the soft-hidden button is UX only.
 -#}
+{#-
+  Per-curated-edge Remove control. Confirm-gated via ``hx-confirm`` (the
+  destructive-removal confirm the issue requires: unannotate is a hard
+  DELETE 204). ``hx-delete`` carries the CSRF token on its OWN element. On
+  success the response swaps the row's ``<li>`` (``outerHTML``, targeting
+  the stable ``#topology-edge-row-{id}`` container) to the removed / error
+  fragment; a 409 ``auto_edge_deletion`` -- which only fires if the row's
+  ``source`` raced from curated to auto -- renders the recoverable banner.
+-#}
+{% macro _edge_remove_control(edge, csrf_token) -%}
+  <button
+    type="button"
+    class="btn btn-error btn-xs ml-auto"
+    data-test="edge-remove"
+    data-edge-id="{{ edge.id }}"
+    aria-label="Remove curated edge {{ edge.id }}"
+    hx-delete="/ui/topology/edges/{{ edge.id }}"
+    hx-target="#topology-edge-row-{{ edge.id }}"
+    hx-swap="outerHTML"
+    hx-headers='{"X-CSRF-Token": "{{ csrf_token }}"}'
+    hx-confirm="Remove this curated edge? This cannot be undone."
+  >
+    Remove
+  </button>
+{%- endmacro %}
 <aside
   id="node-drawer"
   class="card bg-base-100 border-base-300 border shadow-sm"
@@ -44,21 +80,51 @@
         ``hx-*`` attributes leaves the inline ``onclick`` as the sole
         handler -- no network round trip required for a Close.
       -#}
-      <button
-        type="button"
-        class="btn btn-ghost btn-xs"
-        aria-label="Close node detail drawer"
-        onclick="
-          const el = document.getElementById('node-drawer');
-          if (el) {
-            el.outerHTML = '<aside id=\'node-drawer\' class=\'card bg-base-100 border-base-300 border shadow-sm\' aria-live=\'polite\' aria-label=\'Node detail drawer\'><div class=\'card-body text-sm opacity-70\'>Select a row to inspect a node.</div></aside>';
-          }
-          return false;
-        "
-      >
-        Close
-      </button>
+      <div class="flex items-center gap-1">
+        {#-
+          Annotate-edge affordance -- soft-hidden for non-admins. The
+          server-side ``tenant_admin`` gate on ``/ui/topology/edges*`` is
+          the authority; this button is a UX hint. ``hx-get`` opens the
+          annotate modal into the slot below; the modal mints its own CSRF
+          token, so the GET needs none.
+        -#}
+        {% if is_tenant_admin %}
+          <button
+            type="button"
+            class="btn btn-primary btn-xs"
+            data-test="annotate-edge-open"
+            aria-label="Annotate a curated edge"
+            hx-get="{{ annotate_modal_href }}"
+            hx-target="#topology-edge-modal"
+            hx-swap="outerHTML"
+          >
+            Annotate edge
+          </button>
+        {% endif %}
+        <button
+          type="button"
+          class="btn btn-ghost btn-xs"
+          aria-label="Close node detail drawer"
+          onclick="
+            const el = document.getElementById('node-drawer');
+            if (el) {
+              el.outerHTML = '<aside id=\'node-drawer\' class=\'card bg-base-100 border-base-300 border shadow-sm\' aria-live=\'polite\' aria-label=\'Node detail drawer\'><div class=\'card-body text-sm opacity-70\'>Select a row to inspect a node.</div></aside>';
+            }
+            return false;
+          "
+        >
+          Close
+        </button>
+      </div>
     </header>
+
+    {#-
+      Annotate-modal mount slot. Empty until the "Annotate edge" button
+      ``hx-get``s the modal fragment into it; the fragment's outer element
+      shares this id so the swap is stable, and a successful POST swaps the
+      created-edge fragment back into the same slot.
+    -#}
+    <div id="topology-edge-modal" data-test="edge-modal-slot"></div>
 
     {# ---------- Properties ---------- #}
     <section aria-label="Node properties">
@@ -99,12 +165,15 @@
       {% if outgoing_edges %}
         <ul class="space-y-1 text-sm">
           {% for edge in outgoing_edges %}
-            <li class="flex items-center gap-2">
+            <li id="topology-edge-row-{{ edge.id }}" class="flex items-center gap-2">
               <span class="badge badge-outline badge-xs">{{ edge.kind }}</span>
               <span class="opacity-60">&rarr;</span>
               <span class="font-mono">{{ edge.to_endpoint.name }}</span>
               <span class="badge badge-ghost badge-xs">{{ edge.to_endpoint.kind }}</span>
               <span class="text-xs opacity-50">({{ edge.source }})</span>
+              {% if is_tenant_admin and edge.source == "curated" %}
+                {{ _edge_remove_control(edge, csrf_token) }}
+              {% endif %}
             </li>
           {% endfor %}
         </ul>
@@ -121,12 +190,15 @@
       {% if incoming_edges %}
         <ul class="space-y-1 text-sm">
           {% for edge in incoming_edges %}
-            <li class="flex items-center gap-2">
+            <li id="topology-edge-row-{{ edge.id }}" class="flex items-center gap-2">
               <span class="font-mono">{{ edge.from_endpoint.name }}</span>
               <span class="badge badge-ghost badge-xs">{{ edge.from_endpoint.kind }}</span>
               <span class="opacity-60">&rarr;</span>
               <span class="badge badge-outline badge-xs">{{ edge.kind }}</span>
               <span class="text-xs opacity-50">({{ edge.source }})</span>
+              {% if is_tenant_admin and edge.source == "curated" %}
+                {{ _edge_remove_control(edge, csrf_token) }}
+              {% endif %}
             </li>
           {% endfor %}
         </ul>

--- a/backend/src/meho_backplane/ui/templates/topology/_edge_created.html
+++ b/backend/src/meho_backplane/ui/templates/topology/_edge_created.html
@@ -1,0 +1,36 @@
+{#-
+  SPDX-License-Identifier: Apache-2.0
+  Copyright (c) 2026 evoila Group
+
+  Created curated-edge fragment (Initiative #1941 Task #1953). Swapped into
+  ``#topology-edge-modal`` (replacing the annotate form) after a successful
+  ``POST /ui/topology/edges``. The POST response also carries
+  ``HX-Trigger: meho:topology-edge-changed`` so an open graph view re-pulls
+  and the new edge shows without a hard reload.
+-#}
+<div
+  id="topology-edge-modal"
+  class="card bg-base-100 border-success border shadow-sm"
+  data-test="edge-created"
+  aria-label="Curated edge created"
+>
+  <div class="card-body space-y-2">
+    <header class="flex items-center gap-2">
+      <span class="badge badge-success badge-sm">created</span>
+      <h2 class="card-title text-base">Curated edge created</h2>
+    </header>
+    <p class="flex items-center gap-2 text-sm">
+      <span class="font-mono">{{ edge.from_endpoint.name }}</span>
+      <span class="badge badge-ghost badge-xs">{{ edge.from_endpoint.kind }}</span>
+      <span class="opacity-60">&rarr;</span>
+      <span class="badge badge-outline badge-xs">{{ edge.kind }}</span>
+      <span class="opacity-60">&rarr;</span>
+      <span class="font-mono">{{ edge.to_endpoint.name }}</span>
+      <span class="badge badge-ghost badge-xs">{{ edge.to_endpoint.kind }}</span>
+      <span class="text-xs opacity-50">({{ edge.source }})</span>
+    </p>
+    <p class="text-xs opacity-60">
+      Edge id <span class="font-mono">{{ edge.id }}</span>.
+    </p>
+  </div>
+</div>

--- a/backend/src/meho_backplane/ui/templates/topology/_edge_remove_error.html
+++ b/backend/src/meho_backplane/ui/templates/topology/_edge_remove_error.html
@@ -1,0 +1,31 @@
+{#-
+  SPDX-License-Identifier: Apache-2.0
+  Copyright (c) 2026 evoila Group
+
+  Recoverable edge-removal error banner (Initiative #1941 Task #1953).
+  Swapped in over the per-edge row after a ``DELETE /ui/topology/edges/{id}``
+  that the service refused.
+
+  Two cases:
+
+  * ``auto_edge_deletion`` (HTTP 409) -- the §3 auto-edge no-op rule of
+    Initiative #364. Auto edges resurrect on the next refresh, so removing
+    one is meaningless; the banner tells the operator to annotate OVER the
+    auto edge first. This must NOT surface as a dead 500/empty error -- the
+    operator has a concrete recovery path.
+  * ``edge_not_found`` (HTTP 404) -- a missing / cross-tenant id (the
+    tenant boundary is opaque, so cross-tenant ids read as missing).
+
+  The banner stays in place (it replaces the row's controls region) so the
+  operator reads the remediation without losing the rest of the drawer.
+-#}
+<li
+  class="text-sm"
+  data-test="edge-remove-error"
+  data-error-kind="{{ error_kind }}"
+  data-edge-id="{{ edge_id }}"
+>
+  <div role="alert" class="alert alert-warning text-sm">
+    <span>{{ error_message }}</span>
+  </div>
+</li>

--- a/backend/src/meho_backplane/ui/templates/topology/_edge_removed.html
+++ b/backend/src/meho_backplane/ui/templates/topology/_edge_removed.html
@@ -1,0 +1,21 @@
+{#-
+  SPDX-License-Identifier: Apache-2.0
+  Copyright (c) 2026 evoila Group
+
+  Removed curated-edge fragment (Initiative #1941 Task #1953). Swapped in
+  (``outerHTML``) over the per-edge row's container after a successful
+  confirm-gated ``DELETE /ui/topology/edges/{edge_id}``. The DELETE response
+  also carries ``HX-Trigger: meho:topology-edge-changed`` so an open graph
+  view re-pulls and the removed edge disappears without a hard reload.
+
+  The fragment renders an empty (visually quiet) acknowledgement rather than
+  vanishing entirely so the operator gets feedback the row was removed.
+-#}
+<li
+  class="text-sm opacity-60"
+  data-test="edge-removed"
+  data-edge-id="{{ edge_id }}"
+>
+  <span class="badge badge-ghost badge-xs">removed</span>
+  Curated edge removed.
+</li>

--- a/backend/src/meho_backplane/ui/templates/topology/_graph_data_island.html
+++ b/backend/src/meho_backplane/ui/templates/topology/_graph_data_island.html
@@ -34,7 +34,7 @@
 <div
   id="topology-graph-data-wrapper"
   hx-get="{{ refresh_url | default('') }}"
-  hx-trigger="every 30s"
+  hx-trigger="every 30s, meho:topology-edge-changed from:body"
   hx-swap="outerHTML"
   hx-headers='{"X-CSRF-Token": "{{ csrf_token }}"}'
   data-overlay-mode="{{ overlay_mode | default('') }}"

--- a/backend/tests/test_ui_topology_annotate.py
+++ b/backend/tests/test_ui_topology_annotate.py
@@ -1,0 +1,804 @@
+# SPDX-License-Identifier: Apache-2.0
+# Copyright (c) 2026 evoila Group
+
+"""Behavioural tests for the topology console curated-edge **write** surface.
+
+Initiative #1941 (G10.17 Topology console writes), Task #1953 (T1).
+Acceptance criteria from the issue body:
+
+* A CSRF-bearing ``POST /ui/topology/edges`` as a ``tenant_admin`` session
+  creates a curated edge (note + evidence_url persisted) and re-renders the
+  edge inline; the same POST WITHOUT the CSRF token -> 403.
+* A confirm-gated ``DELETE /ui/topology/edges/{id}`` against a
+  ``source='auto'`` edge surfaces the 409 ``auto_edge_deletion`` path as a
+  recoverable typed banner ("this is an auto edge; annotate over it first"),
+  NOT a dead 500/empty error.
+* Annotating with a bare ``from`` / ``to`` name that resolves to >1 kind
+  re-renders the modal with the candidate ``kinds`` listed (not a dead 409).
+* A plain ``operator`` session does NOT see the annotate / remove controls
+  in the rendered drawer (soft-hide), AND a forged ``POST
+  /ui/topology/edges`` from a non-admin gets a hard 403 (server-side
+  ``tenant_admin`` gate).
+* A route-order test (FastAPI test client at construction) asserts
+  ``/ui/topology/edges/annotate`` resolves to the annotate handler, NOT
+  ``detail.py``'s ``node/{node_id}`` param route.
+
+The role-bearing JWKS client + CSRF header helpers mirror
+:mod:`backend.tests.test_ui_connectors_view`; the per-tenant graph seed
+helpers mirror :mod:`backend.tests.test_ui_topology_queries`.
+"""
+
+from __future__ import annotations
+
+import asyncio
+import uuid
+import warnings
+from collections.abc import Iterator
+from datetime import UTC, datetime, timedelta
+from typing import Any
+
+import pytest
+import respx
+from cryptography.fernet import Fernet
+from fastapi import FastAPI
+from fastapi.staticfiles import StaticFiles
+from fastapi.testclient import TestClient
+from sqlalchemy import select
+
+from meho_backplane.auth.jwt import clear_jwks_cache
+from meho_backplane.auth.operator import TenantRole
+from meho_backplane.db.engine import get_sessionmaker, reset_engine_for_testing
+from meho_backplane.db.models import GraphEdge, GraphNode, Tenant
+from meho_backplane.settings import get_settings
+from meho_backplane.ui.auth import SESSION_COOKIE_NAME, UISessionMiddleware
+from meho_backplane.ui.auth import build_router as build_ui_auth_router
+from meho_backplane.ui.auth.flow import (
+    clear_discovery_cache,
+    reset_verifier_store_for_testing,
+)
+from meho_backplane.ui.auth.session_store import (
+    create_session,
+    reset_fernet_cache_for_testing,
+)
+from meho_backplane.ui.csrf import CSRF_COOKIE_NAME, CSRFMiddleware, mint_csrf_token
+from meho_backplane.ui.paths import static_root_dir
+from meho_backplane.ui.routes import build_router as build_ui_router
+from meho_backplane.ui.routes.topology import build_router as build_topology_router
+from meho_backplane.ui.templating import reset_templating_for_testing
+from tests._oidc_jwt_helpers import (
+    AUDIENCE as _DEFAULT_AUDIENCE,
+)
+from tests._oidc_jwt_helpers import (
+    ISSUER as _DEFAULT_ISSUER,
+)
+from tests._oidc_jwt_helpers import (
+    make_rsa_keypair as _make_rsa_keypair,
+)
+from tests._oidc_jwt_helpers import (
+    mint_token as _mint_token,
+)
+from tests._oidc_jwt_helpers import (
+    mock_discovery_and_jwks as _mock_discovery_and_jwks,
+)
+from tests._oidc_jwt_helpers import (
+    public_jwks as _public_jwks,
+)
+
+# ---------------------------------------------------------------------------
+# Fixtures + helpers
+# ---------------------------------------------------------------------------
+
+_BACKPLANE_URL = "https://meho.test"
+
+_TENANT_A = uuid.UUID("11111111-1111-1111-1111-111111111111")
+_TENANT_B = uuid.UUID("22222222-2222-2222-2222-222222222222")
+
+_OP_OPERATOR = "op-operator"
+_OP_ADMIN = "op-admin"
+
+
+@pytest.fixture(autouse=True)
+def _bff_env(monkeypatch: pytest.MonkeyPatch) -> Iterator[None]:
+    """Pin chassis + BFF env vars for every test.
+
+    Mirrors the UI-surface baseline (``test_ui_topology_queries`` /
+    ``test_ui_connectors_view``): chassis Keycloak / Vault / DB /
+    encryption-key env + cache resets on both setup and teardown so a
+    failing test cannot leak template / session-engine state.
+    """
+    monkeypatch.setenv("KEYCLOAK_ISSUER_URL", _DEFAULT_ISSUER)
+    monkeypatch.setenv("KEYCLOAK_AUDIENCE", _DEFAULT_AUDIENCE)
+    monkeypatch.setenv("VAULT_ADDR", "https://vault.test")
+    monkeypatch.setenv("BACKPLANE_URL", _BACKPLANE_URL)
+    monkeypatch.setenv("UI_SESSION_ENCRYPTION_KEY", Fernet.generate_key().decode())
+    monkeypatch.setenv("UI_KEYCLOAK_CLIENT_ID", "meho-web")
+    monkeypatch.setenv("UI_KEYCLOAK_CLIENT_SECRET", "test-client-secret")
+    get_settings.cache_clear()
+    reset_fernet_cache_for_testing()
+    reset_verifier_store_for_testing()
+    reset_templating_for_testing()
+    clear_discovery_cache()
+    clear_jwks_cache()
+    reset_engine_for_testing()
+    yield
+    get_settings.cache_clear()
+    reset_fernet_cache_for_testing()
+    reset_verifier_store_for_testing()
+    reset_templating_for_testing()
+    clear_discovery_cache()
+    clear_jwks_cache()
+    reset_engine_for_testing()
+
+
+def _build_app() -> FastAPI:
+    """Construct the minimal FastAPI app wired for the topology write tests."""
+    app = FastAPI()
+    app.add_middleware(CSRFMiddleware)
+    app.add_middleware(UISessionMiddleware)
+    app.mount(
+        "/ui/static",
+        StaticFiles(directory=str(static_root_dir()), check_dir=False),
+        name="ui_static",
+    )
+    app.include_router(build_ui_auth_router())
+    app.include_router(build_ui_router())
+    return app
+
+
+def _seed_tenant_row(tenant_id: uuid.UUID, slug: str) -> None:
+    async def _do() -> None:
+        sessionmaker = get_sessionmaker()
+        async with sessionmaker() as session, session.begin():
+            session.add(Tenant(id=tenant_id, slug=slug, name=f"Tenant {slug}"))
+
+    asyncio.run(_do())
+
+
+def _seed_node(
+    *,
+    tenant_id: uuid.UUID,
+    kind: str,
+    name: str,
+    target_id: uuid.UUID | None = None,
+) -> uuid.UUID:
+    node_id = uuid.uuid4()
+
+    async def _do() -> None:
+        sessionmaker = get_sessionmaker()
+        async with sessionmaker() as session, session.begin():
+            session.add(
+                GraphNode(
+                    id=node_id,
+                    tenant_id=tenant_id,
+                    kind=kind,
+                    name=name,
+                    target_id=target_id,
+                    properties={},
+                    discovered_by="test",
+                    first_seen=datetime.now(UTC),
+                    last_seen=datetime.now(UTC),
+                ),
+            )
+
+    asyncio.run(_do())
+    return node_id
+
+
+def _seed_edge(
+    *,
+    tenant_id: uuid.UUID,
+    from_node_id: uuid.UUID,
+    to_node_id: uuid.UUID,
+    kind: str = "runs-on",
+    source: str = "auto",
+) -> uuid.UUID:
+    edge_id = uuid.uuid4()
+
+    async def _do() -> None:
+        sessionmaker = get_sessionmaker()
+        async with sessionmaker() as session, session.begin():
+            session.add(
+                GraphEdge(
+                    id=edge_id,
+                    tenant_id=tenant_id,
+                    from_node_id=from_node_id,
+                    to_node_id=to_node_id,
+                    kind=kind,
+                    source=source,
+                    properties={},
+                    discovered_by="test",
+                    first_seen=datetime.now(UTC),
+                    last_seen=datetime.now(UTC),
+                ),
+            )
+
+    asyncio.run(_do())
+    return edge_id
+
+
+def _fetch_edge(edge_id: uuid.UUID) -> GraphEdge | None:
+    async def _do() -> GraphEdge | None:
+        sessionmaker = get_sessionmaker()
+        async with sessionmaker() as session:
+            result = await session.execute(select(GraphEdge).where(GraphEdge.id == edge_id))
+            return result.scalar_one_or_none()
+
+    return asyncio.run(_do())
+
+
+def _fetch_curated_edge_id(tenant_id: uuid.UUID) -> uuid.UUID | None:
+    """Return the id of the single curated edge in *tenant_id*, if any."""
+
+    async def _do() -> uuid.UUID | None:
+        sessionmaker = get_sessionmaker()
+        async with sessionmaker() as session:
+            result = await session.execute(
+                select(GraphEdge.id).where(
+                    GraphEdge.tenant_id == tenant_id,
+                    GraphEdge.source == "curated",
+                )
+            )
+            return result.scalars().first()
+
+    return asyncio.run(_do())
+
+
+def _seed_session_sync(
+    *,
+    tenant_id: uuid.UUID,
+    operator_sub: str = _OP_OPERATOR,
+    access_token: str = "unused",
+    lifetime: timedelta = timedelta(hours=1),
+) -> uuid.UUID:
+    async def _do() -> uuid.UUID:
+        sessionmaker = get_sessionmaker()
+        async with sessionmaker() as session, session.begin():
+            decrypted = await create_session(
+                session,
+                operator_sub=operator_sub,
+                tenant_id=tenant_id,
+                access_token=access_token,
+                refresh_token="refresh-token-plaintext",
+                lifetime=lifetime,
+            )
+            return decrypted.id
+
+    return asyncio.run(_do())
+
+
+def _make_keypair_and_jwks() -> tuple[Any, dict[str, Any]]:
+    with warnings.catch_warnings():
+        warnings.simplefilter("ignore")
+        keypair = _make_rsa_keypair("ui-topology-write-test-kid")
+    return keypair, _public_jwks(keypair)
+
+
+def _authenticated_client(session_id: uuid.UUID) -> TestClient:
+    """Return a TestClient with the session cookie pre-set (no JWKS mock)."""
+    client = TestClient(_build_app(), follow_redirects=False)
+    client.cookies.set(SESSION_COOKIE_NAME, str(session_id))
+    return client
+
+
+def _authenticated_client_with_role_jwks(
+    *,
+    tenant_id: uuid.UUID,
+    operator_sub: str,
+    role: TenantRole,
+) -> tuple[TestClient, respx.MockRouter, str]:
+    """Return a TestClient + respx mock + csrf token for the role-gated routes.
+
+    The write gate (``_require_topology_admin``) re-validates the BFF
+    session's access token through the JWT chain, which needs the JWKS
+    endpoint mocked. The caller stops the mock in a ``finally``.
+    """
+    keypair, jwks = _make_keypair_and_jwks()
+    access_token = _mint_token(
+        keypair,
+        sub=operator_sub,
+        tenant_id=str(tenant_id),
+        tenant_role=role.value,
+    )
+    session_id = _seed_session_sync(
+        tenant_id=tenant_id,
+        access_token=access_token,
+        operator_sub=operator_sub,
+    )
+    mock = respx.mock(assert_all_called=False)
+    mock.start()
+    _mock_discovery_and_jwks(mock, jwks)
+    client = TestClient(_build_app(), follow_redirects=False)
+    client.cookies.set(SESSION_COOKIE_NAME, str(session_id))
+    csrf_token = mint_csrf_token(str(session_id))
+    client.cookies.set(CSRF_COOKIE_NAME, csrf_token)
+    return client, mock, csrf_token
+
+
+def _csrf_headers(token: str) -> dict[str, str]:
+    """Headers for an HTMX state-changing request -- CSRF + HX-Request."""
+    return {"X-CSRF-Token": token, "HX-Request": "true"}
+
+
+# ---------------------------------------------------------------------------
+# Route ordering (acceptance criterion: literal beats the {node_id} param)
+# ---------------------------------------------------------------------------
+
+
+def test_topology_ui_annotate_route_registers_before_node_param() -> None:
+    """``/ui/topology/edges/annotate`` resolves to the annotate handler.
+
+    The literal ``edges`` / ``annotate`` segments must register BEFORE
+    ``detail.py``'s ``/ui/topology/node/{node_id}`` param route so the
+    first-match-wins lookup never binds them as a node id. Verified at
+    construction with a FastAPI test client matching the route, per the
+    convention ``topology/__init__.py`` documents.
+    """
+    router = build_topology_router()
+    paths = [route.path for route in router.routes if hasattr(route, "methods")]
+    annotate_idx = paths.index("/ui/topology/edges/annotate")
+    node_idx = paths.index("/ui/topology/node/{node_id}")
+    assert annotate_idx < node_idx, paths
+
+    # Resolve through a real app: the GET annotate route must not be the
+    # node-detail param route. A non-admin session is enough to confirm the
+    # route binding (the admin gate fires inside the annotate handler, never
+    # the node-detail one).
+    app = _build_app()
+    matched = [
+        route
+        for route in app.routes
+        if getattr(route, "path", None) == "/ui/topology/edges/annotate"
+    ]
+    assert matched, "annotate route not registered on the app"
+    assert "GET" in matched[0].methods  # type: ignore[attr-defined]
+
+
+# ---------------------------------------------------------------------------
+# Annotate happy path + CSRF gate
+# ---------------------------------------------------------------------------
+
+
+def test_topology_ui_annotate_creates_curated_edge_with_note_and_evidence() -> None:
+    """A CSRF-bearing admin POST creates a curated edge + re-renders inline."""
+    _seed_tenant_row(_TENANT_A, "tenant-a")
+    _seed_node(tenant_id=_TENANT_A, kind="principal", name="sa-foo")
+    _seed_node(tenant_id=_TENANT_A, kind="vault-role", name="role-bar")
+
+    client, mock, csrf = _authenticated_client_with_role_jwks(
+        tenant_id=_TENANT_A,
+        operator_sub=_OP_ADMIN,
+        role=TenantRole.TENANT_ADMIN,
+    )
+    try:
+        response = client.post(
+            "/ui/topology/edges",
+            data={
+                "from_name": "sa-foo",
+                "from_kind": "principal",
+                "kind": "authenticates-via",
+                "to_name": "role-bar",
+                "to_kind": "vault-role",
+                "note": "asserted from INVENTORY.md",
+                "evidence_url": "https://example.test/evidence",
+            },
+            headers=_csrf_headers(csrf),
+        )
+    finally:
+        mock.stop()
+
+    assert response.status_code == 200, response.text
+    body = response.text
+    # The created edge is re-rendered inline.
+    assert 'data-test="edge-created"' in body
+    assert "sa-foo" in body
+    assert "role-bar" in body
+    assert "authenticates-via" in body
+    # The graph-refresh trigger fired so an open graph view re-pulls.
+    assert response.headers.get("HX-Trigger") == "meho:topology-edge-changed"
+
+    # note + evidence_url persisted on the curated row.
+    edge_id = _fetch_curated_edge_id(_TENANT_A)
+    assert edge_id is not None
+    edge = _fetch_edge(edge_id)
+    assert edge is not None
+    assert edge.source == "curated"
+    assert edge.kind == "authenticates-via"
+    assert edge.properties.get("note") == "asserted from INVENTORY.md"
+    assert edge.properties.get("evidence_url") == "https://example.test/evidence"
+
+
+def test_topology_ui_annotate_without_csrf_token_is_403() -> None:
+    """The same admin POST WITHOUT the CSRF token is rejected by the middleware."""
+    _seed_tenant_row(_TENANT_A, "tenant-a")
+    _seed_node(tenant_id=_TENANT_A, kind="principal", name="sa-foo")
+    _seed_node(tenant_id=_TENANT_A, kind="vault-role", name="role-bar")
+
+    client, mock, _csrf = _authenticated_client_with_role_jwks(
+        tenant_id=_TENANT_A,
+        operator_sub=_OP_ADMIN,
+        role=TenantRole.TENANT_ADMIN,
+    )
+    try:
+        # No X-CSRF-Token header, and drop the cookie so the double-submit
+        # cannot be satisfied from either source.
+        client.cookies.delete(CSRF_COOKIE_NAME)
+        response = client.post(
+            "/ui/topology/edges",
+            data={
+                "from_name": "sa-foo",
+                "kind": "authenticates-via",
+                "to_name": "role-bar",
+            },
+            headers={"HX-Request": "true"},
+        )
+    finally:
+        mock.stop()
+
+    assert response.status_code == 403, response.text
+    # The CSRF middleware short-circuits before the edge is ever written.
+    assert _fetch_curated_edge_id(_TENANT_A) is None
+
+
+# ---------------------------------------------------------------------------
+# Ambiguous-node re-render (acceptance criterion)
+# ---------------------------------------------------------------------------
+
+
+def test_topology_ui_annotate_ambiguous_name_rerenders_modal_with_kinds() -> None:
+    """A bare name resolving to >1 kind re-renders the modal with candidates."""
+    _seed_tenant_row(_TENANT_A, "tenant-a")
+    # ``app`` exists as two kinds -> bare-name resolution is ambiguous.
+    _seed_node(tenant_id=_TENANT_A, kind="target", name="app")
+    _seed_node(tenant_id=_TENANT_A, kind="vm", name="app")
+    _seed_node(tenant_id=_TENANT_A, kind="vault-role", name="role-bar")
+
+    client, mock, csrf = _authenticated_client_with_role_jwks(
+        tenant_id=_TENANT_A,
+        operator_sub=_OP_ADMIN,
+        role=TenantRole.TENANT_ADMIN,
+    )
+    try:
+        response = client.post(
+            "/ui/topology/edges",
+            data={
+                "from_name": "app",  # bare, no from_kind -> ambiguous
+                "kind": "depends-on",
+                "to_name": "role-bar",
+                "to_kind": "vault-role",
+            },
+            headers=_csrf_headers(csrf),
+        )
+    finally:
+        mock.stop()
+
+    assert response.status_code == 409, response.text
+    body = response.text
+    # The modal re-renders (not a dead 409) with the candidate kinds so the
+    # operator can re-submit with a disambiguating kind.
+    assert 'id="topology-edge-modal"' in body
+    assert 'data-test="ambiguous-kinds"' in body
+    assert "target" in body
+    assert "vm" in body
+    # No edge was created.
+    assert _fetch_curated_edge_id(_TENANT_A) is None
+
+
+def test_topology_ui_annotate_ambiguous_resolves_with_kind_pin() -> None:
+    """Re-submitting with the disambiguating ``from_kind`` then succeeds."""
+    _seed_tenant_row(_TENANT_A, "tenant-a")
+    _seed_node(tenant_id=_TENANT_A, kind="target", name="app")
+    _seed_node(tenant_id=_TENANT_A, kind="vm", name="app")
+    _seed_node(tenant_id=_TENANT_A, kind="vault-role", name="role-bar")
+
+    client, mock, csrf = _authenticated_client_with_role_jwks(
+        tenant_id=_TENANT_A,
+        operator_sub=_OP_ADMIN,
+        role=TenantRole.TENANT_ADMIN,
+    )
+    try:
+        response = client.post(
+            "/ui/topology/edges",
+            data={
+                "from_name": "app",
+                "from_kind": "vm",  # disambiguated
+                "kind": "depends-on",
+                "to_name": "role-bar",
+                "to_kind": "vault-role",
+            },
+            headers=_csrf_headers(csrf),
+        )
+    finally:
+        mock.stop()
+
+    assert response.status_code == 200, response.text
+    assert 'data-test="edge-created"' in response.text
+    assert _fetch_curated_edge_id(_TENANT_A) is not None
+
+
+# ---------------------------------------------------------------------------
+# Unannotate: auto_edge_deletion recoverable banner (acceptance criterion)
+# ---------------------------------------------------------------------------
+
+
+def test_topology_ui_annotate_delete_auto_edge_surfaces_recoverable_banner() -> None:
+    """DELETE of a ``source='auto'`` edge surfaces the 409 recoverable banner."""
+    _seed_tenant_row(_TENANT_A, "tenant-a")
+    a = _seed_node(tenant_id=_TENANT_A, kind="vm", name="vm-1")
+    b = _seed_node(tenant_id=_TENANT_A, kind="host", name="host-1")
+    auto_edge = _seed_edge(
+        tenant_id=_TENANT_A,
+        from_node_id=a,
+        to_node_id=b,
+        kind="runs-on",
+        source="auto",
+    )
+
+    client, mock, csrf = _authenticated_client_with_role_jwks(
+        tenant_id=_TENANT_A,
+        operator_sub=_OP_ADMIN,
+        role=TenantRole.TENANT_ADMIN,
+    )
+    try:
+        response = client.request(
+            "DELETE",
+            f"/ui/topology/edges/{auto_edge}",
+            headers=_csrf_headers(csrf),
+        )
+    finally:
+        mock.stop()
+
+    assert response.status_code == 409, response.text
+    body = response.text
+    # Recoverable typed banner, NOT a dead 500/empty error.
+    assert 'data-error-kind="auto_edge_deletion"' in body
+    assert "annotate over the auto edge first" in body.lower()
+    assert "no-op" in body.lower()
+    # The auto edge is untouched (it would resurrect on refresh anyway).
+    assert _fetch_edge(auto_edge) is not None
+
+
+def test_topology_ui_annotate_delete_curated_edge_succeeds() -> None:
+    """DELETE of a curated edge removes it + fires the graph-refresh trigger."""
+    _seed_tenant_row(_TENANT_A, "tenant-a")
+    a = _seed_node(tenant_id=_TENANT_A, kind="principal", name="sa-foo")
+    b = _seed_node(tenant_id=_TENANT_A, kind="vault-role", name="role-bar")
+    curated = _seed_edge(
+        tenant_id=_TENANT_A,
+        from_node_id=a,
+        to_node_id=b,
+        kind="authenticates-via",
+        source="curated",
+    )
+
+    client, mock, csrf = _authenticated_client_with_role_jwks(
+        tenant_id=_TENANT_A,
+        operator_sub=_OP_ADMIN,
+        role=TenantRole.TENANT_ADMIN,
+    )
+    try:
+        response = client.request(
+            "DELETE",
+            f"/ui/topology/edges/{curated}",
+            headers=_csrf_headers(csrf),
+        )
+    finally:
+        mock.stop()
+
+    assert response.status_code == 200, response.text
+    assert 'data-test="edge-removed"' in response.text
+    assert response.headers.get("HX-Trigger") == "meho:topology-edge-changed"
+    # The curated row is gone.
+    assert _fetch_edge(curated) is None
+
+
+# ---------------------------------------------------------------------------
+# RBAC: soft-hide + hard-403 (acceptance criterion — same-template trap)
+# ---------------------------------------------------------------------------
+
+
+def test_topology_ui_annotate_controls_hidden_for_operator_in_drawer() -> None:
+    """An operator session does NOT see the annotate / remove controls."""
+    _seed_tenant_row(_TENANT_A, "tenant-a")
+    a = _seed_node(tenant_id=_TENANT_A, kind="principal", name="sa-foo")
+    b = _seed_node(tenant_id=_TENANT_A, kind="vault-role", name="role-bar")
+    _seed_edge(
+        tenant_id=_TENANT_A,
+        from_node_id=a,
+        to_node_id=b,
+        kind="authenticates-via",
+        source="curated",
+    )
+
+    client, mock, _csrf = _authenticated_client_with_role_jwks(
+        tenant_id=_TENANT_A,
+        operator_sub=_OP_OPERATOR,
+        role=TenantRole.OPERATOR,
+    )
+    try:
+        response = client.get(f"/ui/topology/node/{a}")
+    finally:
+        mock.stop()
+
+    assert response.status_code == 200, response.text
+    body = response.text
+    # Neither the annotate-open button nor any per-edge remove control.
+    assert 'data-test="annotate-edge-open"' not in body
+    assert 'data-test="edge-remove"' not in body
+
+
+def test_topology_ui_annotate_controls_shown_for_tenant_admin_in_drawer() -> None:
+    """A tenant_admin session DOES see the annotate + remove controls."""
+    _seed_tenant_row(_TENANT_A, "tenant-a")
+    a = _seed_node(tenant_id=_TENANT_A, kind="principal", name="sa-foo")
+    b = _seed_node(tenant_id=_TENANT_A, kind="vault-role", name="role-bar")
+    _seed_edge(
+        tenant_id=_TENANT_A,
+        from_node_id=a,
+        to_node_id=b,
+        kind="authenticates-via",
+        source="curated",
+    )
+
+    client, mock, _csrf = _authenticated_client_with_role_jwks(
+        tenant_id=_TENANT_A,
+        operator_sub=_OP_ADMIN,
+        role=TenantRole.TENANT_ADMIN,
+    )
+    try:
+        response = client.get(f"/ui/topology/node/{a}")
+    finally:
+        mock.stop()
+
+    assert response.status_code == 200, response.text
+    body = response.text
+    assert 'data-test="annotate-edge-open"' in body
+    # The curated outgoing edge carries a Remove control.
+    assert 'data-test="edge-remove"' in body
+
+
+def test_topology_ui_annotate_forged_post_from_operator_is_403() -> None:
+    """A forged annotate POST from a non-admin gets a hard server-side 403."""
+    _seed_tenant_row(_TENANT_A, "tenant-a")
+    _seed_node(tenant_id=_TENANT_A, kind="principal", name="sa-foo")
+    _seed_node(tenant_id=_TENANT_A, kind="vault-role", name="role-bar")
+
+    # Operator session carries a valid CSRF token (they forged past the
+    # soft-hidden button) -- the hard gate is the authority.
+    client, mock, csrf = _authenticated_client_with_role_jwks(
+        tenant_id=_TENANT_A,
+        operator_sub=_OP_OPERATOR,
+        role=TenantRole.OPERATOR,
+    )
+    try:
+        response = client.post(
+            "/ui/topology/edges",
+            data={
+                "from_name": "sa-foo",
+                "from_kind": "principal",
+                "kind": "authenticates-via",
+                "to_name": "role-bar",
+                "to_kind": "vault-role",
+            },
+            headers=_csrf_headers(csrf),
+        )
+    finally:
+        mock.stop()
+
+    assert response.status_code == 403, response.text
+    # No edge was written despite a valid CSRF token.
+    assert _fetch_curated_edge_id(_TENANT_A) is None
+
+
+def test_topology_ui_annotate_forged_delete_from_operator_is_403() -> None:
+    """A forged unannotate DELETE from a non-admin gets a hard 403."""
+    _seed_tenant_row(_TENANT_A, "tenant-a")
+    a = _seed_node(tenant_id=_TENANT_A, kind="principal", name="sa-foo")
+    b = _seed_node(tenant_id=_TENANT_A, kind="vault-role", name="role-bar")
+    curated = _seed_edge(
+        tenant_id=_TENANT_A,
+        from_node_id=a,
+        to_node_id=b,
+        kind="authenticates-via",
+        source="curated",
+    )
+
+    client, mock, csrf = _authenticated_client_with_role_jwks(
+        tenant_id=_TENANT_A,
+        operator_sub=_OP_OPERATOR,
+        role=TenantRole.OPERATOR,
+    )
+    try:
+        response = client.request(
+            "DELETE",
+            f"/ui/topology/edges/{curated}",
+            headers=_csrf_headers(csrf),
+        )
+    finally:
+        mock.stop()
+
+    assert response.status_code == 403, response.text
+    # The curated row survives the forged delete.
+    assert _fetch_edge(curated) is not None
+
+
+def test_topology_ui_annotate_modal_open_requires_tenant_admin() -> None:
+    """The annotate-modal GET is hard-gated to tenant_admin (defense in depth)."""
+    _seed_tenant_row(_TENANT_A, "tenant-a")
+
+    client, mock, _csrf = _authenticated_client_with_role_jwks(
+        tenant_id=_TENANT_A,
+        operator_sub=_OP_OPERATOR,
+        role=TenantRole.OPERATOR,
+    )
+    try:
+        response = client.get("/ui/topology/edges/annotate")
+    finally:
+        mock.stop()
+
+    assert response.status_code == 403, response.text
+
+
+def test_topology_ui_annotate_modal_open_renders_for_admin_with_csrf() -> None:
+    """The annotate-modal GET renders the form + sets the meho_csrf cookie."""
+    _seed_tenant_row(_TENANT_A, "tenant-a")
+
+    client, mock, _csrf = _authenticated_client_with_role_jwks(
+        tenant_id=_TENANT_A,
+        operator_sub=_OP_ADMIN,
+        role=TenantRole.TENANT_ADMIN,
+    )
+    try:
+        response = client.get("/ui/topology/edges/annotate")
+    finally:
+        mock.stop()
+
+    assert response.status_code == 200, response.text
+    body = response.text
+    assert 'id="topology-edge-modal"' in body
+    assert 'data-test="annotate-submit"' in body
+    # The modal mints + sets a fresh meho_csrf cookie so the POST carries a
+    # valid double-submit token.
+    assert CSRF_COOKIE_NAME in response.cookies
+    # The closed edge-kind vocabulary is surfaced in the dropdown.
+    assert "authenticates-via" in body
+
+
+# ---------------------------------------------------------------------------
+# Tenant isolation on the write surface
+# ---------------------------------------------------------------------------
+
+
+def test_topology_ui_annotate_delete_isolates_other_tenants_edge() -> None:
+    """An admin cannot delete another tenant's curated edge (reads as 404)."""
+    _seed_tenant_row(_TENANT_A, "tenant-a")
+    _seed_tenant_row(_TENANT_B, "tenant-b")
+    a = _seed_node(tenant_id=_TENANT_B, kind="principal", name="sa-foo")
+    b = _seed_node(tenant_id=_TENANT_B, kind="vault-role", name="role-bar")
+    other_edge = _seed_edge(
+        tenant_id=_TENANT_B,
+        from_node_id=a,
+        to_node_id=b,
+        kind="authenticates-via",
+        source="curated",
+    )
+
+    # Admin in tenant A tries to delete tenant B's edge by id.
+    client, mock, csrf = _authenticated_client_with_role_jwks(
+        tenant_id=_TENANT_A,
+        operator_sub=_OP_ADMIN,
+        role=TenantRole.TENANT_ADMIN,
+    )
+    try:
+        response = client.request(
+            "DELETE",
+            f"/ui/topology/edges/{other_edge}",
+            headers=_csrf_headers(csrf),
+        )
+    finally:
+        mock.stop()
+
+    # Cross-tenant id is indistinguishable from missing -> 404 not-found
+    # banner; the row survives.
+    assert response.status_code == 404, response.text
+    assert 'data-error-kind="edge_not_found"' in response.text
+    assert _fetch_edge(other_edge) is not None

--- a/backend/tests/test_ui_topology_queries.py
+++ b/backend/tests/test_ui_topology_queries.py
@@ -452,7 +452,13 @@ def test_path_overlay_unreachable_returns_no_path_state() -> None:
 
 
 def test_graph_full_page_includes_polling_trigger() -> None:
-    """The data-island wrapper carries ``hx-trigger="every 30s"``."""
+    """The data-island wrapper carries the 30s poll + edge-changed trigger.
+
+    The trigger is a comma-separated list: the original ``every 30s`` poll
+    plus ``meho:topology-edge-changed from:body`` (Task #1953) so a
+    curated-edge write re-pulls the graph immediately rather than waiting up
+    to 30s for the next poll.
+    """
     _seed_tenant_row(_TENANT_A, "tenant-a")
     _seed_node(tenant_id=_TENANT_A, kind="vm", name="vm-1")
 
@@ -462,7 +468,9 @@ def test_graph_full_page_includes_polling_trigger() -> None:
         response = client.get("/ui/topology?view=graph")
     body = response.text
     assert 'id="topology-graph-data-wrapper"' in body
-    assert 'hx-trigger="every 30s"' in body
+    assert "hx-trigger=" in body
+    assert "every 30s" in body
+    assert "meho:topology-edge-changed from:body" in body
     assert 'hx-swap="outerHTML"' in body
     # The refresh URL re-fetches the same view.
     assert 'hx-get="/ui/topology?view=graph' in body
@@ -493,7 +501,8 @@ def test_htmx_fragment_returns_data_island_wrapper_only() -> None:
     # But it carries the data islands the controller reads.
     assert 'id="topology-graph-data-wrapper"' in body
     assert 'id="topology-graph-data"' in body
-    assert 'hx-trigger="every 30s"' in body
+    assert "every 30s" in body
+    assert "meho:topology-edge-changed from:body" in body
 
 
 def test_htmx_fragment_carries_overlay_data() -> None:

--- a/cli/api/openapi.json
+++ b/cli/api/openapi.json
@@ -8529,13 +8529,121 @@
         }
       }
     },
+    "/ui/topology/edges/annotate": {
+      "get": {
+        "tags": [
+          "ui-topology"
+        ],
+        "summary": "Annotate Modal",
+        "description": "``GET /ui/topology/edges/annotate`` \u2014 render the annotate modal.",
+        "operationId": "annotate_modal_ui_topology_edges_annotate_get",
+        "responses": {
+          "200": {
+            "description": "Successful Response",
+            "content": {
+              "text/html": {
+                "schema": {
+                  "type": "string"
+                }
+              }
+            }
+          }
+        }
+      }
+    },
+    "/ui/topology/edges": {
+      "post": {
+        "tags": [
+          "ui-topology"
+        ],
+        "summary": "Annotate",
+        "description": "``POST /ui/topology/edges`` \u2014 annotate a curated edge in-process.",
+        "operationId": "annotate_ui_topology_edges_post",
+        "requestBody": {
+          "content": {
+            "application/x-www-form-urlencoded": {
+              "schema": {
+                "$ref": "#/components/schemas/Body_annotate_ui_topology_edges_post"
+              }
+            }
+          },
+          "required": true
+        },
+        "responses": {
+          "200": {
+            "description": "Successful Response",
+            "content": {
+              "text/html": {
+                "schema": {
+                  "type": "string"
+                }
+              }
+            }
+          },
+          "422": {
+            "description": "Validation Error",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/HTTPValidationError"
+                }
+              }
+            }
+          }
+        }
+      }
+    },
+    "/ui/topology/edges/{edge_id}": {
+      "delete": {
+        "tags": [
+          "ui-topology"
+        ],
+        "summary": "Unannotate",
+        "description": "``DELETE /ui/topology/edges/{edge_id}`` \u2014 remove a curated edge.",
+        "operationId": "unannotate_ui_topology_edges__edge_id__delete",
+        "parameters": [
+          {
+            "name": "edge_id",
+            "in": "path",
+            "required": true,
+            "schema": {
+              "type": "string",
+              "format": "uuid",
+              "title": "Edge Id"
+            }
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "Successful Response",
+            "content": {
+              "text/html": {
+                "schema": {
+                  "type": "string"
+                }
+              }
+            }
+          },
+          "422": {
+            "description": "Validation Error",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/HTTPValidationError"
+                }
+              }
+            }
+          }
+        }
+      }
+    },
     "/ui/topology/node/{node_id}": {
       "get": {
         "tags": [
           "ui-topology"
         ],
         "summary": "Ui Topology Node Detail",
-        "description": "``GET /ui/topology/node/{node_id}``.\n\nResolves the node tenant-scoped, then pulls the incoming +\noutgoing edges via :func:`list_edges` and the recent\noperations directly from ``audit_log``. Renders the\n``topology/_drawer.html`` fragment with the full context.",
+        "description": "``GET /ui/topology/node/{node_id}`` -- delegates to the renderer.",
         "operationId": "ui_topology_node_detail_ui_topology_node__node_id__get",
         "parameters": [
           {
@@ -8549,6 +8657,17 @@
             }
           }
         ],
+        "requestBody": {
+          "content": {
+            "application/json": {
+              "schema": {
+                "$ref": "#/components/schemas/UISessionContext",
+                "nullable": true,
+                "title": "Session Ctx"
+              }
+            }
+          }
+        },
         "responses": {
           "200": {
             "description": "Successful Response",
@@ -17157,6 +17276,54 @@
         ],
         "title": "BaselineMetricsOverride",
         "description": "Per-surface baseline metrics supplied by the caller.\n\nCriterion 4 (MEHO \u2265 baseline) needs side-by-side numbers from a\nbaseline retrieval (``grep -r kb/`` for kb; ``grep paths.txt +\nyq`` for operations). The v0.2 backplane has no checked-in\ncorpus snapshot to evaluate the baseline against (see\n:mod:`meho_backplane.api.v1.retrieve_eval` \u2014 explicit\n``baseline=grep`` on that route is rejected with 501); the CLI\nruns the baseline locally against the operator's kb/ checkout and\ncan pass the resulting numbers here so the retire-checklist\nverdict honestly reflects criterion 4 instead of always reporting\nyellow (\"baseline did not run\") on the API path.\n\nWithout an override, criterion 4 stays yellow for v0.2 production\ncallers \u2014 the documented \"READY TO RETIRE\" path is unreachable\nvia the bare API alone, which is the honest v0.2 posture. T7\n(#446) / v0.2.next is expected to wire a server-side corpus\nsnapshot and remove the need for this override."
+      },
+      "Body_annotate_ui_topology_edges_post": {
+        "properties": {
+          "from_name": {
+            "type": "string",
+            "minLength": 1,
+            "title": "From Name"
+          },
+          "from_kind": {
+            "type": "string",
+            "title": "From Kind",
+            "default": ""
+          },
+          "kind": {
+            "type": "string",
+            "minLength": 1,
+            "title": "Kind"
+          },
+          "to_name": {
+            "type": "string",
+            "minLength": 1,
+            "title": "To Name"
+          },
+          "to_kind": {
+            "type": "string",
+            "title": "To Kind",
+            "default": ""
+          },
+          "note": {
+            "type": "string",
+            "maxLength": 2000,
+            "title": "Note",
+            "default": ""
+          },
+          "evidence_url": {
+            "type": "string",
+            "maxLength": 2000,
+            "title": "Evidence Url",
+            "default": ""
+          }
+        },
+        "type": "object",
+        "required": [
+          "from_name",
+          "kind",
+          "to_name"
+        ],
+        "title": "Body_annotate_ui_topology_edges_post"
       },
       "Body_approval_approve_ui_approvals__request_id__approve_post": {
         "properties": {

--- a/cli/internal/api/client.gen.go
+++ b/cli/internal/api/client.gen.go
@@ -1206,6 +1206,17 @@ type BaselineMetricsOverride struct {
 	PrecisionAt5 float32 `json:"precision_at_5"`
 }
 
+// BodyAnnotateUiTopologyEdgesPost defines model for Body_annotate_ui_topology_edges_post.
+type BodyAnnotateUiTopologyEdgesPost struct {
+	EvidenceUrl *string `json:"evidence_url,omitempty"`
+	FromKind    *string `json:"from_kind,omitempty"`
+	FromName    string  `json:"from_name"`
+	Kind        string  `json:"kind"`
+	Note        *string `json:"note,omitempty"`
+	ToKind      *string `json:"to_kind,omitempty"`
+	ToName      string  `json:"to_name"`
+}
+
 // BodyApprovalApproveUiApprovalsRequestIdApprovePost defines model for Body_approval_approve_ui_approvals__request_id__approve_post.
 type BodyApprovalApproveUiApprovalsRequestIdApprovePost struct {
 	Reason *string `json:"reason,omitempty"`
@@ -7444,6 +7455,12 @@ type UiSchedulerCancelModalUiSchedulerTriggerIdCancelGetJSONRequestBody = UISess
 // UiSchedulerCancelSubmitUiSchedulerTriggerIdCancelPostJSONRequestBody defines body for UiSchedulerCancelSubmitUiSchedulerTriggerIdCancelPost for application/json ContentType.
 type UiSchedulerCancelSubmitUiSchedulerTriggerIdCancelPostJSONRequestBody = UISessionContext
 
+// AnnotateUiTopologyEdgesPostFormdataRequestBody defines body for AnnotateUiTopologyEdgesPost for application/x-www-form-urlencoded ContentType.
+type AnnotateUiTopologyEdgesPostFormdataRequestBody = BodyAnnotateUiTopologyEdgesPost
+
+// UiTopologyNodeDetailUiTopologyNodeNodeIdGetJSONRequestBody defines body for UiTopologyNodeDetailUiTopologyNodeNodeIdGet for application/json ContentType.
+type UiTopologyNodeDetailUiTopologyNodeNodeIdGetJSONRequestBody = UISessionContext
+
 // AsApproveResponseBodyDispatchResult0 returns the union data inside the ApproveResponseBody_DispatchResult as a ApproveResponseBodyDispatchResult0
 func (t ApproveResponseBody_DispatchResult) AsApproveResponseBodyDispatchResult0() (ApproveResponseBodyDispatchResult0, error) {
 	var body ApproveResponseBodyDispatchResult0
@@ -9395,8 +9412,21 @@ type ClientInterface interface {
 	// UiTopologyTableUiTopologyGet request
 	UiTopologyTableUiTopologyGet(ctx context.Context, params *UiTopologyTableUiTopologyGetParams, reqEditors ...RequestEditorFn) (*http.Response, error)
 
-	// UiTopologyNodeDetailUiTopologyNodeNodeIdGet request
-	UiTopologyNodeDetailUiTopologyNodeNodeIdGet(ctx context.Context, nodeId openapi_types.UUID, reqEditors ...RequestEditorFn) (*http.Response, error)
+	// AnnotateUiTopologyEdgesPostWithBody request with any body
+	AnnotateUiTopologyEdgesPostWithBody(ctx context.Context, contentType string, body io.Reader, reqEditors ...RequestEditorFn) (*http.Response, error)
+
+	AnnotateUiTopologyEdgesPostWithFormdataBody(ctx context.Context, body AnnotateUiTopologyEdgesPostFormdataRequestBody, reqEditors ...RequestEditorFn) (*http.Response, error)
+
+	// AnnotateModalUiTopologyEdgesAnnotateGet request
+	AnnotateModalUiTopologyEdgesAnnotateGet(ctx context.Context, reqEditors ...RequestEditorFn) (*http.Response, error)
+
+	// UnannotateUiTopologyEdgesEdgeIdDelete request
+	UnannotateUiTopologyEdgesEdgeIdDelete(ctx context.Context, edgeId openapi_types.UUID, reqEditors ...RequestEditorFn) (*http.Response, error)
+
+	// UiTopologyNodeDetailUiTopologyNodeNodeIdGetWithBody request with any body
+	UiTopologyNodeDetailUiTopologyNodeNodeIdGetWithBody(ctx context.Context, nodeId openapi_types.UUID, contentType string, body io.Reader, reqEditors ...RequestEditorFn) (*http.Response, error)
+
+	UiTopologyNodeDetailUiTopologyNodeNodeIdGet(ctx context.Context, nodeId openapi_types.UUID, body UiTopologyNodeDetailUiTopologyNodeNodeIdGetJSONRequestBody, reqEditors ...RequestEditorFn) (*http.Response, error)
 
 	// VersionVersionGet request
 	VersionVersionGet(ctx context.Context, reqEditors ...RequestEditorFn) (*http.Response, error)
@@ -14490,8 +14520,68 @@ func (c *Client) UiTopologyTableUiTopologyGet(ctx context.Context, params *UiTop
 	return c.Client.Do(req)
 }
 
-func (c *Client) UiTopologyNodeDetailUiTopologyNodeNodeIdGet(ctx context.Context, nodeId openapi_types.UUID, reqEditors ...RequestEditorFn) (*http.Response, error) {
-	req, err := NewUiTopologyNodeDetailUiTopologyNodeNodeIdGetRequest(c.Server, nodeId)
+func (c *Client) AnnotateUiTopologyEdgesPostWithBody(ctx context.Context, contentType string, body io.Reader, reqEditors ...RequestEditorFn) (*http.Response, error) {
+	req, err := NewAnnotateUiTopologyEdgesPostRequestWithBody(c.Server, contentType, body)
+	if err != nil {
+		return nil, err
+	}
+	req = req.WithContext(ctx)
+	if err := c.applyEditors(ctx, req, reqEditors); err != nil {
+		return nil, err
+	}
+	return c.Client.Do(req)
+}
+
+func (c *Client) AnnotateUiTopologyEdgesPostWithFormdataBody(ctx context.Context, body AnnotateUiTopologyEdgesPostFormdataRequestBody, reqEditors ...RequestEditorFn) (*http.Response, error) {
+	req, err := NewAnnotateUiTopologyEdgesPostRequestWithFormdataBody(c.Server, body)
+	if err != nil {
+		return nil, err
+	}
+	req = req.WithContext(ctx)
+	if err := c.applyEditors(ctx, req, reqEditors); err != nil {
+		return nil, err
+	}
+	return c.Client.Do(req)
+}
+
+func (c *Client) AnnotateModalUiTopologyEdgesAnnotateGet(ctx context.Context, reqEditors ...RequestEditorFn) (*http.Response, error) {
+	req, err := NewAnnotateModalUiTopologyEdgesAnnotateGetRequest(c.Server)
+	if err != nil {
+		return nil, err
+	}
+	req = req.WithContext(ctx)
+	if err := c.applyEditors(ctx, req, reqEditors); err != nil {
+		return nil, err
+	}
+	return c.Client.Do(req)
+}
+
+func (c *Client) UnannotateUiTopologyEdgesEdgeIdDelete(ctx context.Context, edgeId openapi_types.UUID, reqEditors ...RequestEditorFn) (*http.Response, error) {
+	req, err := NewUnannotateUiTopologyEdgesEdgeIdDeleteRequest(c.Server, edgeId)
+	if err != nil {
+		return nil, err
+	}
+	req = req.WithContext(ctx)
+	if err := c.applyEditors(ctx, req, reqEditors); err != nil {
+		return nil, err
+	}
+	return c.Client.Do(req)
+}
+
+func (c *Client) UiTopologyNodeDetailUiTopologyNodeNodeIdGetWithBody(ctx context.Context, nodeId openapi_types.UUID, contentType string, body io.Reader, reqEditors ...RequestEditorFn) (*http.Response, error) {
+	req, err := NewUiTopologyNodeDetailUiTopologyNodeNodeIdGetRequestWithBody(c.Server, nodeId, contentType, body)
+	if err != nil {
+		return nil, err
+	}
+	req = req.WithContext(ctx)
+	if err := c.applyEditors(ctx, req, reqEditors); err != nil {
+		return nil, err
+	}
+	return c.Client.Do(req)
+}
+
+func (c *Client) UiTopologyNodeDetailUiTopologyNodeNodeIdGet(ctx context.Context, nodeId openapi_types.UUID, body UiTopologyNodeDetailUiTopologyNodeNodeIdGetJSONRequestBody, reqEditors ...RequestEditorFn) (*http.Response, error) {
+	req, err := NewUiTopologyNodeDetailUiTopologyNodeNodeIdGetRequest(c.Server, nodeId, body)
 	if err != nil {
 		return nil, err
 	}
@@ -30360,8 +30450,120 @@ func NewUiTopologyTableUiTopologyGetRequest(server string, params *UiTopologyTab
 	return req, nil
 }
 
-// NewUiTopologyNodeDetailUiTopologyNodeNodeIdGetRequest generates requests for UiTopologyNodeDetailUiTopologyNodeNodeIdGet
-func NewUiTopologyNodeDetailUiTopologyNodeNodeIdGetRequest(server string, nodeId openapi_types.UUID) (*http.Request, error) {
+// NewAnnotateUiTopologyEdgesPostRequestWithFormdataBody calls the generic AnnotateUiTopologyEdgesPost builder with application/x-www-form-urlencoded body
+func NewAnnotateUiTopologyEdgesPostRequestWithFormdataBody(server string, body AnnotateUiTopologyEdgesPostFormdataRequestBody) (*http.Request, error) {
+	var bodyReader io.Reader
+	bodyStr, err := runtime.MarshalForm(body, nil)
+	if err != nil {
+		return nil, err
+	}
+	bodyReader = strings.NewReader(bodyStr.Encode())
+	return NewAnnotateUiTopologyEdgesPostRequestWithBody(server, "application/x-www-form-urlencoded", bodyReader)
+}
+
+// NewAnnotateUiTopologyEdgesPostRequestWithBody generates requests for AnnotateUiTopologyEdgesPost with any type of body
+func NewAnnotateUiTopologyEdgesPostRequestWithBody(server string, contentType string, body io.Reader) (*http.Request, error) {
+	var err error
+
+	serverURL, err := url.Parse(server)
+	if err != nil {
+		return nil, err
+	}
+
+	operationPath := fmt.Sprintf("/ui/topology/edges")
+	if operationPath[0] == '/' {
+		operationPath = "." + operationPath
+	}
+
+	queryURL, err := serverURL.Parse(operationPath)
+	if err != nil {
+		return nil, err
+	}
+
+	req, err := http.NewRequest("POST", queryURL.String(), body)
+	if err != nil {
+		return nil, err
+	}
+
+	req.Header.Add("Content-Type", contentType)
+
+	return req, nil
+}
+
+// NewAnnotateModalUiTopologyEdgesAnnotateGetRequest generates requests for AnnotateModalUiTopologyEdgesAnnotateGet
+func NewAnnotateModalUiTopologyEdgesAnnotateGetRequest(server string) (*http.Request, error) {
+	var err error
+
+	serverURL, err := url.Parse(server)
+	if err != nil {
+		return nil, err
+	}
+
+	operationPath := fmt.Sprintf("/ui/topology/edges/annotate")
+	if operationPath[0] == '/' {
+		operationPath = "." + operationPath
+	}
+
+	queryURL, err := serverURL.Parse(operationPath)
+	if err != nil {
+		return nil, err
+	}
+
+	req, err := http.NewRequest("GET", queryURL.String(), nil)
+	if err != nil {
+		return nil, err
+	}
+
+	return req, nil
+}
+
+// NewUnannotateUiTopologyEdgesEdgeIdDeleteRequest generates requests for UnannotateUiTopologyEdgesEdgeIdDelete
+func NewUnannotateUiTopologyEdgesEdgeIdDeleteRequest(server string, edgeId openapi_types.UUID) (*http.Request, error) {
+	var err error
+
+	var pathParam0 string
+
+	pathParam0, err = runtime.StyleParamWithLocation("simple", false, "edge_id", runtime.ParamLocationPath, edgeId)
+	if err != nil {
+		return nil, err
+	}
+
+	serverURL, err := url.Parse(server)
+	if err != nil {
+		return nil, err
+	}
+
+	operationPath := fmt.Sprintf("/ui/topology/edges/%s", pathParam0)
+	if operationPath[0] == '/' {
+		operationPath = "." + operationPath
+	}
+
+	queryURL, err := serverURL.Parse(operationPath)
+	if err != nil {
+		return nil, err
+	}
+
+	req, err := http.NewRequest("DELETE", queryURL.String(), nil)
+	if err != nil {
+		return nil, err
+	}
+
+	return req, nil
+}
+
+// NewUiTopologyNodeDetailUiTopologyNodeNodeIdGetRequest calls the generic UiTopologyNodeDetailUiTopologyNodeNodeIdGet builder with application/json body
+func NewUiTopologyNodeDetailUiTopologyNodeNodeIdGetRequest(server string, nodeId openapi_types.UUID, body UiTopologyNodeDetailUiTopologyNodeNodeIdGetJSONRequestBody) (*http.Request, error) {
+	var bodyReader io.Reader
+	buf, err := json.Marshal(body)
+	if err != nil {
+		return nil, err
+	}
+	bodyReader = bytes.NewReader(buf)
+	return NewUiTopologyNodeDetailUiTopologyNodeNodeIdGetRequestWithBody(server, nodeId, "application/json", bodyReader)
+}
+
+// NewUiTopologyNodeDetailUiTopologyNodeNodeIdGetRequestWithBody generates requests for UiTopologyNodeDetailUiTopologyNodeNodeIdGet with any type of body
+func NewUiTopologyNodeDetailUiTopologyNodeNodeIdGetRequestWithBody(server string, nodeId openapi_types.UUID, contentType string, body io.Reader) (*http.Request, error) {
 	var err error
 
 	var pathParam0 string
@@ -30386,10 +30588,12 @@ func NewUiTopologyNodeDetailUiTopologyNodeNodeIdGetRequest(server string, nodeId
 		return nil, err
 	}
 
-	req, err := http.NewRequest("GET", queryURL.String(), nil)
+	req, err := http.NewRequest("GET", queryURL.String(), body)
 	if err != nil {
 		return nil, err
 	}
+
+	req.Header.Add("Content-Type", contentType)
 
 	return req, nil
 }
@@ -31587,8 +31791,21 @@ type ClientWithResponsesInterface interface {
 	// UiTopologyTableUiTopologyGetWithResponse request
 	UiTopologyTableUiTopologyGetWithResponse(ctx context.Context, params *UiTopologyTableUiTopologyGetParams, reqEditors ...RequestEditorFn) (*UiTopologyTableUiTopologyGetResponse, error)
 
-	// UiTopologyNodeDetailUiTopologyNodeNodeIdGetWithResponse request
-	UiTopologyNodeDetailUiTopologyNodeNodeIdGetWithResponse(ctx context.Context, nodeId openapi_types.UUID, reqEditors ...RequestEditorFn) (*UiTopologyNodeDetailUiTopologyNodeNodeIdGetResponse, error)
+	// AnnotateUiTopologyEdgesPostWithBodyWithResponse request with any body
+	AnnotateUiTopologyEdgesPostWithBodyWithResponse(ctx context.Context, contentType string, body io.Reader, reqEditors ...RequestEditorFn) (*AnnotateUiTopologyEdgesPostResponse, error)
+
+	AnnotateUiTopologyEdgesPostWithFormdataBodyWithResponse(ctx context.Context, body AnnotateUiTopologyEdgesPostFormdataRequestBody, reqEditors ...RequestEditorFn) (*AnnotateUiTopologyEdgesPostResponse, error)
+
+	// AnnotateModalUiTopologyEdgesAnnotateGetWithResponse request
+	AnnotateModalUiTopologyEdgesAnnotateGetWithResponse(ctx context.Context, reqEditors ...RequestEditorFn) (*AnnotateModalUiTopologyEdgesAnnotateGetResponse, error)
+
+	// UnannotateUiTopologyEdgesEdgeIdDeleteWithResponse request
+	UnannotateUiTopologyEdgesEdgeIdDeleteWithResponse(ctx context.Context, edgeId openapi_types.UUID, reqEditors ...RequestEditorFn) (*UnannotateUiTopologyEdgesEdgeIdDeleteResponse, error)
+
+	// UiTopologyNodeDetailUiTopologyNodeNodeIdGetWithBodyWithResponse request with any body
+	UiTopologyNodeDetailUiTopologyNodeNodeIdGetWithBodyWithResponse(ctx context.Context, nodeId openapi_types.UUID, contentType string, body io.Reader, reqEditors ...RequestEditorFn) (*UiTopologyNodeDetailUiTopologyNodeNodeIdGetResponse, error)
+
+	UiTopologyNodeDetailUiTopologyNodeNodeIdGetWithResponse(ctx context.Context, nodeId openapi_types.UUID, body UiTopologyNodeDetailUiTopologyNodeNodeIdGetJSONRequestBody, reqEditors ...RequestEditorFn) (*UiTopologyNodeDetailUiTopologyNodeNodeIdGetResponse, error)
 
 	// VersionVersionGetWithResponse request
 	VersionVersionGetWithResponse(ctx context.Context, reqEditors ...RequestEditorFn) (*VersionVersionGetResponse, error)
@@ -37809,6 +38026,71 @@ func (r UiTopologyTableUiTopologyGetResponse) StatusCode() int {
 	return 0
 }
 
+type AnnotateUiTopologyEdgesPostResponse struct {
+	Body         []byte
+	HTTPResponse *http.Response
+	JSON422      *HTTPValidationError
+}
+
+// Status returns HTTPResponse.Status
+func (r AnnotateUiTopologyEdgesPostResponse) Status() string {
+	if r.HTTPResponse != nil {
+		return r.HTTPResponse.Status
+	}
+	return http.StatusText(0)
+}
+
+// StatusCode returns HTTPResponse.StatusCode
+func (r AnnotateUiTopologyEdgesPostResponse) StatusCode() int {
+	if r.HTTPResponse != nil {
+		return r.HTTPResponse.StatusCode
+	}
+	return 0
+}
+
+type AnnotateModalUiTopologyEdgesAnnotateGetResponse struct {
+	Body         []byte
+	HTTPResponse *http.Response
+}
+
+// Status returns HTTPResponse.Status
+func (r AnnotateModalUiTopologyEdgesAnnotateGetResponse) Status() string {
+	if r.HTTPResponse != nil {
+		return r.HTTPResponse.Status
+	}
+	return http.StatusText(0)
+}
+
+// StatusCode returns HTTPResponse.StatusCode
+func (r AnnotateModalUiTopologyEdgesAnnotateGetResponse) StatusCode() int {
+	if r.HTTPResponse != nil {
+		return r.HTTPResponse.StatusCode
+	}
+	return 0
+}
+
+type UnannotateUiTopologyEdgesEdgeIdDeleteResponse struct {
+	Body         []byte
+	HTTPResponse *http.Response
+	JSON422      *HTTPValidationError
+}
+
+// Status returns HTTPResponse.Status
+func (r UnannotateUiTopologyEdgesEdgeIdDeleteResponse) Status() string {
+	if r.HTTPResponse != nil {
+		return r.HTTPResponse.Status
+	}
+	return http.StatusText(0)
+}
+
+// StatusCode returns HTTPResponse.StatusCode
+func (r UnannotateUiTopologyEdgesEdgeIdDeleteResponse) StatusCode() int {
+	if r.HTTPResponse != nil {
+		return r.HTTPResponse.StatusCode
+	}
+	return 0
+}
+
 type UiTopologyNodeDetailUiTopologyNodeNodeIdGetResponse struct {
 	Body         []byte
 	HTTPResponse *http.Response
@@ -41520,9 +41802,52 @@ func (c *ClientWithResponses) UiTopologyTableUiTopologyGetWithResponse(ctx conte
 	return ParseUiTopologyTableUiTopologyGetResponse(rsp)
 }
 
-// UiTopologyNodeDetailUiTopologyNodeNodeIdGetWithResponse request returning *UiTopologyNodeDetailUiTopologyNodeNodeIdGetResponse
-func (c *ClientWithResponses) UiTopologyNodeDetailUiTopologyNodeNodeIdGetWithResponse(ctx context.Context, nodeId openapi_types.UUID, reqEditors ...RequestEditorFn) (*UiTopologyNodeDetailUiTopologyNodeNodeIdGetResponse, error) {
-	rsp, err := c.UiTopologyNodeDetailUiTopologyNodeNodeIdGet(ctx, nodeId, reqEditors...)
+// AnnotateUiTopologyEdgesPostWithBodyWithResponse request with arbitrary body returning *AnnotateUiTopologyEdgesPostResponse
+func (c *ClientWithResponses) AnnotateUiTopologyEdgesPostWithBodyWithResponse(ctx context.Context, contentType string, body io.Reader, reqEditors ...RequestEditorFn) (*AnnotateUiTopologyEdgesPostResponse, error) {
+	rsp, err := c.AnnotateUiTopologyEdgesPostWithBody(ctx, contentType, body, reqEditors...)
+	if err != nil {
+		return nil, err
+	}
+	return ParseAnnotateUiTopologyEdgesPostResponse(rsp)
+}
+
+func (c *ClientWithResponses) AnnotateUiTopologyEdgesPostWithFormdataBodyWithResponse(ctx context.Context, body AnnotateUiTopologyEdgesPostFormdataRequestBody, reqEditors ...RequestEditorFn) (*AnnotateUiTopologyEdgesPostResponse, error) {
+	rsp, err := c.AnnotateUiTopologyEdgesPostWithFormdataBody(ctx, body, reqEditors...)
+	if err != nil {
+		return nil, err
+	}
+	return ParseAnnotateUiTopologyEdgesPostResponse(rsp)
+}
+
+// AnnotateModalUiTopologyEdgesAnnotateGetWithResponse request returning *AnnotateModalUiTopologyEdgesAnnotateGetResponse
+func (c *ClientWithResponses) AnnotateModalUiTopologyEdgesAnnotateGetWithResponse(ctx context.Context, reqEditors ...RequestEditorFn) (*AnnotateModalUiTopologyEdgesAnnotateGetResponse, error) {
+	rsp, err := c.AnnotateModalUiTopologyEdgesAnnotateGet(ctx, reqEditors...)
+	if err != nil {
+		return nil, err
+	}
+	return ParseAnnotateModalUiTopologyEdgesAnnotateGetResponse(rsp)
+}
+
+// UnannotateUiTopologyEdgesEdgeIdDeleteWithResponse request returning *UnannotateUiTopologyEdgesEdgeIdDeleteResponse
+func (c *ClientWithResponses) UnannotateUiTopologyEdgesEdgeIdDeleteWithResponse(ctx context.Context, edgeId openapi_types.UUID, reqEditors ...RequestEditorFn) (*UnannotateUiTopologyEdgesEdgeIdDeleteResponse, error) {
+	rsp, err := c.UnannotateUiTopologyEdgesEdgeIdDelete(ctx, edgeId, reqEditors...)
+	if err != nil {
+		return nil, err
+	}
+	return ParseUnannotateUiTopologyEdgesEdgeIdDeleteResponse(rsp)
+}
+
+// UiTopologyNodeDetailUiTopologyNodeNodeIdGetWithBodyWithResponse request with arbitrary body returning *UiTopologyNodeDetailUiTopologyNodeNodeIdGetResponse
+func (c *ClientWithResponses) UiTopologyNodeDetailUiTopologyNodeNodeIdGetWithBodyWithResponse(ctx context.Context, nodeId openapi_types.UUID, contentType string, body io.Reader, reqEditors ...RequestEditorFn) (*UiTopologyNodeDetailUiTopologyNodeNodeIdGetResponse, error) {
+	rsp, err := c.UiTopologyNodeDetailUiTopologyNodeNodeIdGetWithBody(ctx, nodeId, contentType, body, reqEditors...)
+	if err != nil {
+		return nil, err
+	}
+	return ParseUiTopologyNodeDetailUiTopologyNodeNodeIdGetResponse(rsp)
+}
+
+func (c *ClientWithResponses) UiTopologyNodeDetailUiTopologyNodeNodeIdGetWithResponse(ctx context.Context, nodeId openapi_types.UUID, body UiTopologyNodeDetailUiTopologyNodeNodeIdGetJSONRequestBody, reqEditors ...RequestEditorFn) (*UiTopologyNodeDetailUiTopologyNodeNodeIdGetResponse, error) {
+	rsp, err := c.UiTopologyNodeDetailUiTopologyNodeNodeIdGet(ctx, nodeId, body, reqEditors...)
 	if err != nil {
 		return nil, err
 	}
@@ -49318,6 +49643,74 @@ func ParseUiTopologyTableUiTopologyGetResponse(rsp *http.Response) (*UiTopologyT
 	}
 
 	response := &UiTopologyTableUiTopologyGetResponse{
+		Body:         bodyBytes,
+		HTTPResponse: rsp,
+	}
+
+	switch {
+	case strings.Contains(rsp.Header.Get("Content-Type"), "json") && rsp.StatusCode == 422:
+		var dest HTTPValidationError
+		if err := json.Unmarshal(bodyBytes, &dest); err != nil {
+			return nil, err
+		}
+		response.JSON422 = &dest
+
+	}
+
+	return response, nil
+}
+
+// ParseAnnotateUiTopologyEdgesPostResponse parses an HTTP response from a AnnotateUiTopologyEdgesPostWithResponse call
+func ParseAnnotateUiTopologyEdgesPostResponse(rsp *http.Response) (*AnnotateUiTopologyEdgesPostResponse, error) {
+	bodyBytes, err := io.ReadAll(rsp.Body)
+	defer func() { _ = rsp.Body.Close() }()
+	if err != nil {
+		return nil, err
+	}
+
+	response := &AnnotateUiTopologyEdgesPostResponse{
+		Body:         bodyBytes,
+		HTTPResponse: rsp,
+	}
+
+	switch {
+	case strings.Contains(rsp.Header.Get("Content-Type"), "json") && rsp.StatusCode == 422:
+		var dest HTTPValidationError
+		if err := json.Unmarshal(bodyBytes, &dest); err != nil {
+			return nil, err
+		}
+		response.JSON422 = &dest
+
+	}
+
+	return response, nil
+}
+
+// ParseAnnotateModalUiTopologyEdgesAnnotateGetResponse parses an HTTP response from a AnnotateModalUiTopologyEdgesAnnotateGetWithResponse call
+func ParseAnnotateModalUiTopologyEdgesAnnotateGetResponse(rsp *http.Response) (*AnnotateModalUiTopologyEdgesAnnotateGetResponse, error) {
+	bodyBytes, err := io.ReadAll(rsp.Body)
+	defer func() { _ = rsp.Body.Close() }()
+	if err != nil {
+		return nil, err
+	}
+
+	response := &AnnotateModalUiTopologyEdgesAnnotateGetResponse{
+		Body:         bodyBytes,
+		HTTPResponse: rsp,
+	}
+
+	return response, nil
+}
+
+// ParseUnannotateUiTopologyEdgesEdgeIdDeleteResponse parses an HTTP response from a UnannotateUiTopologyEdgesEdgeIdDeleteWithResponse call
+func ParseUnannotateUiTopologyEdgesEdgeIdDeleteResponse(rsp *http.Response) (*UnannotateUiTopologyEdgesEdgeIdDeleteResponse, error) {
+	bodyBytes, err := io.ReadAll(rsp.Body)
+	defer func() { _ = rsp.Body.Close() }()
+	if err != nil {
+		return nil, err
+	}
+
+	response := &UnannotateUiTopologyEdgesEdgeIdDeleteResponse{
 		Body:         bodyBytes,
 		HTTPResponse: rsp,
 	}

--- a/docs/codebase/ui.md
+++ b/docs/codebase/ui.md
@@ -1141,6 +1141,61 @@ the template.
 | `topology/_drawer.html` | Drawer fragment with node properties (id, kind, name, target_id, first_seen, last_seen, discovered_by, raw JSON), outgoing + incoming edges, recent operations on the node's target (empty for inner graph nodes with no `target_id`), and the "Show dependents" link handing off to T2/T3's graph view. |
 | `topology/_drawer_not_found.html` | 404 drawer fragment for an unknown / cross-tenant node id. Same outer `aside#node-drawer` shape so the HTMX `outerHTML` swap remains semantically consistent. |
 
+### Curated-edge writes (Task #1953)
+
+Initiative [#1941](https://github.com/evoila/meho/issues/1941) (G10.17),
+Task #1953 (T1) layers the curated-edge **annotate / unannotate** write
+verbs onto the read-only drawer. The console face is an **in-process BFF**:
+the `/api/v1/topology/edges` routes are Bearer-gated, so a session-cookie
+browser cannot auth them; instead `meho_backplane.ui.routes.topology.edges`
+adds `/ui/topology/edges*` sub-routes that are `require_ui_session` +
+CSRF-gated and call the `meho_backplane.topology.annotate` **service**
+(`annotate_edge` / `unannotate_edge`) directly — the same pattern the
+approvals / connectors surfaces use. No new `/api/v1` route or service
+function is introduced.
+
+| Method | Path | Purpose |
+| ------ | ---- | ------- |
+| `GET` | `/ui/topology/edges/annotate` | Annotate-modal fragment. Mints + sets a fresh `meho_csrf` cookie so the POST carries a valid double-submit token. The literal `edges` / `annotate` segments register **before** `detail.py`'s `node/{node_id}` param route (first-match-wins). `tenant_admin`-gated. |
+| `POST` | `/ui/topology/edges` | Annotate a curated edge in-process. Builds two `NodeRef(name, kind)` endpoints (never posts a raw `from` JSON key — `from` is a Python keyword) and calls `annotate_edge`. Renders the created edge inline + fires `HX-Trigger: meho:topology-edge-changed`. CSRF + `tenant_admin`. |
+| `DELETE` | `/ui/topology/edges/{edge_id}` | Hard-delete a curated edge (confirm-gated via `hx-confirm`). Calls `unannotate_edge`; on success swaps the row out + fires the graph-refresh trigger. CSRF + `tenant_admin`. |
+
+**RBAC tier split.** Curated-edge writes are `tenant_admin` at the REST
+layer; the BFF mirrors this two ways. The drawer (`_drawer.html`)
+**soft-hides** the annotate / per-edge-remove controls behind
+`is_tenant_admin` (projected via `connectors.operator.resolve_role_probe`,
+fail-soft); every write route additionally **hard-403s** a non-admin via
+`_require_topology_admin` (mirrors `connectors.operator.resolve_operator_or_403`,
+reusing the promoted `lift_operator_from_session` JWT-revalidation helper).
+The same template serving both roles is the regression trap — the
+soft-hidden button is UX only; a forged POST still 403s.
+
+**Recoverable typed errors.** The service raises HTTP-agnostic `ValueError`
+subclasses; the BFF maps each to a re-rendered fragment (mirroring the REST
+status codes) rather than a dead 5xx:
+
+* `AmbiguousNodeError` → re-render the annotate modal (`_annotate_modal.html`)
+  with the candidate `kinds` listed (409) so the operator re-submits with a
+  disambiguating `kind`.
+* `NodeNotFoundError` (404) / `InvalidEdgeKindError` (422) → re-render the
+  modal with a typed banner.
+* `AutoEdgeDeletionError` → re-render `_edge_remove_error.html` with the
+  recoverable "this is an auto edge; annotate over it first" banner (409,
+  the §3 auto-edge no-op rule of Initiative #364). Auto edges resurrect on
+  the next refresh, so a naive DELETE retry would confuse the operator.
+
+**Graph reflects the write.** The annotate / unannotate responses fire
+`HX-Trigger: meho:topology-edge-changed`; `_graph_data_island.html`'s
+wrapper listens via `hx-trigger="… , meho:topology-edge-changed from:body"`
+and re-pulls the graph JSON, so a just-written / removed edge shows without
+a hard reload (in addition to the existing 30s poll).
+
+**OpenAPI snapshot.** `/ui/*` routes DO register into the snapshot, so the
+three new `/ui/topology/edges*` paths land in `cli/api/openapi.json` +
+`cli/internal/api/client.gen.go` (regenerated via `cd cli && make
+snapshot-openapi && make generate`; the "CLI API snapshot freshness" CI
+lane enforces it).
+
 ### HTMX wiring
 
 * **Sort + filter on `/ui/topology`** — the filter form uses


### PR DESCRIPTION
## Summary
- Adds the curated-edge **annotate / unannotate** write verbs to the `/ui/topology` console. The verbs existed only on the CLI + the Bearer REST API; a session-cookie browser cannot auth the Bearer routes, so this is an **in-process BFF** (`/ui/topology/edges*`, `require_ui_session` + CSRF-gated) calling the `topology.annotate` service directly — the approvals/connectors pattern. No new `/api/v1` route or service function.
- `GET /ui/topology/edges/annotate` (modal, mints+sets `meho_csrf`), `POST /ui/topology/edges` (annotate), `DELETE /ui/topology/edges/{edge_id}` (unannotate, confirm-gated). Literal `edges`/`annotate` register **before** `detail.py`'s `node/{node_id}` param route (first-match-wins, verified at construction).
- Writes are **`tenant_admin`**: the drawer soft-hides the annotate/remove controls behind `is_tenant_admin` (`resolve_role_probe`, fail-soft) AND every route hard-403s a non-admin via a topology admin gate reusing the promoted `connectors.operator.lift_operator_from_session` helper. Same-template-both-roles regression trap is covered.
- Recoverable typed errors mirror the REST status codes: **409 `ambiguous_node`** re-renders the modal with the candidate `kinds`; **409 `auto_edge_deletion`** re-renders a recoverable "annotate over the auto edge first" banner (not a dead 500). The graph reflects writes immediately — responses fire `HX-Trigger: meho:topology-edge-changed` and the graph data-island wrapper re-pulls.

## Test plan
- [x] `ruff check` — clean (topology + connectors.operator + tests)
- [x] `ruff format --check` — clean
- [x] `mypy src/` — clean (edges.py, detail.py, connectors/operator.py)
- [x] `code-quality.py --diff` — 0 blockers
- [x] New suite `tests/test_ui_topology_annotate.py` (14 tests) — annotate creates a curated edge with note+evidence persisted + inline re-render; POST without CSRF → 403; ambiguous bare-name re-renders the modal with candidate kinds (+ kind-pin resolves); DELETE of a `source='auto'` edge → recoverable `auto_edge_deletion` 409 banner (asserts NOT a dead 500); DELETE of a curated edge succeeds; operator drawer hides controls / admin drawer shows them; forged operator POST + DELETE → hard 403; modal-open admin-gated; cross-tenant DELETE → 404 not-found banner.
- [x] Route-order test asserts `/ui/topology/edges/annotate` resolves to the annotate handler, not `node/{node_id}`.
- [x] Regression sweep `-k "ui_topology or ui_connectors or topology_ui"` — 207 passed.
- [x] `cd cli && make snapshot-openapi && make generate` run; `cli/api/openapi.json` + `cli/internal/api/client.gen.go` committed (3 new `/ui/topology/edges*` paths); `go build ./...` compiles.
- [x] `docs/codebase/ui.md` Topology section extended with the write surface.

## Out of scope
- Bulk-import + refresh → T2 (#1954). History / timeline / diff temporal reads → T3 (#1955).
- Closure (dependents/dependencies) already ships as graph overlays.

<!-- auto-implement-issue: fresh, iteration 1 -->

Closes #1953
