### PR TITLE
feat(ui): Keycloak console user management — list + create/reset-password/role-assign (G10.19-T2 #1960)

### DIFF
--- a/backend/src/meho_backplane/ui/routes/keycloak/routes.py
+++ b/backend/src/meho_backplane/ui/routes/keycloak/routes.py
@@ -103,21 +103,24 @@ documents). The router is registered ahead of the stubs aggregate in
 
 from __future__ import annotations
 
+import json
 from typing import Any, Final
 
 import structlog
-from fastapi import APIRouter, Depends, HTTPException, Query, Request, status
+from fastapi import APIRouter, Depends, Form, HTTPException, Query, Request, status
 from fastapi.responses import HTMLResponse
 from sqlalchemy import select
 
 from meho_backplane.auth.jwt import verify_jwt_for_audience
-from meho_backplane.auth.operator import Operator
+from meho_backplane.auth.operator import Operator, TenantRole
 from meho_backplane.db.engine import get_sessionmaker
 from meho_backplane.db.models import Target as TargetORM
 from meho_backplane.operations.meta_tools import call_operation
 from meho_backplane.settings import get_settings
 from meho_backplane.ui.auth.middleware import UISessionContext, require_ui_session
 from meho_backplane.ui.auth.session_store import load_session
+from meho_backplane.ui.csrf import mint_csrf_token
+from meho_backplane.ui.routes.approvals.render import set_csrf_cookie
 from meho_backplane.ui.routes.connectors.operator import (
     OperatorRoleProbe,
     resolve_role_probe,
@@ -146,10 +149,52 @@ KEYCLOAK_PRODUCT: Final[str] = "keycloak"
 #: at the form boundary (422) before it reaches the dispatch.
 _MAX_TARGET_LENGTH: Final[int] = 256
 
+#: Maximum length accepted for a Vault KV path / username / role-name form
+#: field. A KV path is a short slug-ish string; the bound rejects an
+#: oversized paste at the form boundary (422) before it reaches the dispatch.
+_MAX_FORM_FIELD_LENGTH: Final[int] = 512
+
+#: Maximum length accepted for the create-user ``UserRepresentation`` JSON
+#: textarea. A UserRepresentation is small (username + a few attributes);
+#: the bound matches the operations Run modal's params textarea.
+_MAX_REPRESENTATION_LENGTH: Final[int] = 65536
+
+
+async def _resolve_admin_or_403(
+    request: Request,
+    session: UISessionContext = Depends(require_ui_session),
+) -> Operator:
+    """FastAPI dependency: lift the operator and hard-403 a non-tenant_admin.
+
+    The server-side authority for the three high-blast keycloak writes
+    (create / reset-password / role-assign). Mirrors
+    :func:`~meho_backplane.ui.routes.connectors.operator.resolve_operator_or_403`
+    but raises a keycloak-appropriate 403 ``detail`` (the connectors
+    dependency's string is ``"re-probe requires tenant_admin"`` -- wrong
+    surface) so a forged POST from a plain operator gets a legible
+    ``403`` the template's ``hx-on::after-request`` alert can branch on,
+    not a silent dispatch.
+
+    The lift re-verifies the session's access token through the JWT chain
+    (catching a same-session role demotion) -- the same round-trip the read
+    probe and the operations console use. The soft-failing
+    :func:`resolve_role_probe` drives the template's button-hide; THIS gate
+    is what actually stops the write.
+    """
+    operator = await _resolve_operator(session)
+    if operator.tenant_role != TenantRole.TENANT_ADMIN:
+        raise HTTPException(
+            status_code=status.HTTP_403_FORBIDDEN,
+            detail="keycloak user management requires tenant_admin",
+        )
+    return operator
+
+
 #: Module-level ``Depends`` closures -- built once (rather than inline) to
 #: satisfy ruff B008, matching the operations / approvals / kb routers.
 _require_session = Depends(require_ui_session)
 _role_probe_dep = Depends(resolve_role_probe)
+_require_admin = Depends(_resolve_admin_or_403)
 
 
 async def _resolve_operator(session: UISessionContext) -> Operator:
@@ -240,6 +285,89 @@ async def _dispatch_read(
     )
 
 
+async def _dispatch_write(
+    operator: Operator,
+    *,
+    op_id: str,
+    target: str,
+    params: dict[str, Any],
+) -> dict[str, Any]:
+    """Dispatch one keycloak WRITE op in-process against the pinned connector.
+
+    Identical wiring to :func:`_dispatch_read` -- the dispatcher's contract
+    is "always return a structured envelope": ``ok`` / ``error`` /
+    ``denied`` / ``awaiting_approval`` all come back INSIDE the envelope,
+    never as an exception. Every keycloak write op is
+    ``requires_approval=True``, so the policy gate routes a confirmed write
+    to ``status="awaiting_approval"`` with ``extras["approval_request_id"]``
+    rather than executing immediately; the result template surfaces that
+    id with a deep-link into ``/ui/approvals``.
+    """
+    return await call_operation(
+        operator,
+        {
+            "connector_id": KEYCLOAK_CONNECTOR_ID,
+            "op_id": op_id,
+            "target": target,
+            "params": params,
+        },
+    )
+
+
+def _parse_representation(raw: str) -> dict[str, Any]:
+    """Parse the create-user form's ``UserRepresentation`` JSON textarea.
+
+    A blank field is rejected (a create needs at least a ``username``). A
+    non-blank field must be a JSON **object**; a malformed body or a
+    non-object value raises :class:`ValueError` with an operator-legible
+    message the caller renders inline -- the op's ``representation`` param
+    is a dict (the Keycloak ``UserRepresentation``).
+    """
+    text = raw.strip()
+    if not text:
+        raise ValueError("Provide a UserRepresentation JSON object (at least a username).")
+    try:
+        value = json.loads(text)
+    except json.JSONDecodeError as exc:
+        msg = f"representation is not valid JSON: {exc.msg} (line {exc.lineno})"
+        raise ValueError(msg) from exc
+    if not isinstance(value, dict):
+        raise ValueError('representation must be a JSON object (e.g. {"username": "operator-a"}).')
+    return value
+
+
+def _password_secret_params(
+    *,
+    secret_ref: str,
+    secret_mount: str,
+    secret_key: str,
+    temporary: bool,
+) -> dict[str, Any]:
+    """Build the Vault-ref password params from the form fields.
+
+    The password VALUE is never collected -- only its Vault KV location
+    (``password_secret_ref`` + the optional mount / key / temporary
+    overrides), mirroring the CLI's ``passwordSecretFlags`` bundle. Only
+    non-empty overrides are written so the connector's defaults (mount
+    ``secret``, key ``password``) apply. The password therefore never lands
+    in form params, request logs, or the audit row -- the backend reads it
+    from Vault at dispatch time.
+    """
+    params: dict[str, Any] = {}
+    ref = secret_ref.strip()
+    if ref:
+        params["password_secret_ref"] = ref
+    mount = secret_mount.strip()
+    if mount:
+        params["password_secret_mount"] = mount
+    key = secret_key.strip()
+    if key:
+        params["password_secret_key"] = key
+    if temporary:
+        params["temporary"] = True
+    return params
+
+
 def build_keycloak_router() -> APIRouter:
     """Construct the ``/ui/keycloak*`` :class:`APIRouter`.
 
@@ -251,12 +379,16 @@ def build_keycloak_router() -> APIRouter:
     """
     router = APIRouter(tags=["ui-keycloak"])
 
-    # NOTE: the literal ``/ui/keycloak/clients/{client_uuid}`` route is
-    # registered BEFORE the bare ``/ui/keycloak`` index. The only ``{param}``
-    # route sits under the distinct ``/ui/keycloak/clients/`` prefix, so a
-    # future literal segment (``/ui/keycloak/users`` in T2) registered ahead
-    # of any ``{param}`` route binds first (first-match-wins -- the ordering
-    # discipline the operations / approvals routers document).
+    # ROUTE ORDERING (first-match-wins). The literal user-management routes
+    # are registered FIRST, with the literal segments (``users``,
+    # ``users/create``) ahead of any ``{user_uuid}`` route, then the literal
+    # ``clients/{client_uuid}`` route, then the bare ``/ui/keycloak`` index.
+    # The only ``{param}`` routes sit under the distinct ``users/`` and
+    # ``clients/`` prefixes; a literal ``users/create`` registered before
+    # ``users/{user_uuid}/...`` binds first so ``create`` is never captured
+    # as a UUID -- the ordering discipline the operations / approvals routers
+    # document.
+    _register_user_routes(router)
 
     @router.get("/ui/keycloak/clients/{client_uuid}", response_class=HTMLResponse)
     async def keycloak_client_detail(
@@ -294,6 +426,189 @@ def build_keycloak_router() -> APIRouter:
         return await _render_index(request, session, target, role_probe)
 
     return router
+
+
+def _register_user_routes(router: APIRouter) -> None:
+    """Register the user-management routes on *router* (Task #1960).
+
+    Split out of :func:`build_keycloak_router` to keep each factory small.
+    The literal ``users`` / ``users/create`` segments are registered ahead of
+    any ``{user_uuid}`` route so ``create`` is never captured as a UUID
+    (first-match-wins). The list read is OPERATOR-tier; the three writes
+    (create / reset-password / role-assign) hard-gate on tenant_admin via
+    :data:`_require_admin` and render an unmissable confirm before POST.
+    """
+
+    # ---- User management: list (read, operator-tier) -------------------
+    @router.get("/ui/keycloak/users", response_class=HTMLResponse)
+    async def keycloak_user_list(
+        request: Request,
+        session: UISessionContext = _require_session,
+        target: str = Query(default="", max_length=_MAX_TARGET_LENGTH),
+        username: str = Query(default="", max_length=_MAX_FORM_FIELD_LENGTH),
+        role_probe: OperatorRoleProbe = _role_probe_dep,
+    ) -> HTMLResponse:
+        """Render the realm's user list (read; OPERATOR-tier).
+
+        Dispatches ``keycloak.user.list`` (``safety_level="safe"``); an
+        optional ``username`` filter maps to Keycloak's ``?username=``.
+        Credential material is redacted from every row by the connector;
+        this render projects named fields only and never dumps the raw
+        envelope. The create / reset / assign affordances are soft-hidden
+        from a plain operator (``is_tenant_admin`` from the soft-failing
+        role probe); the write POSTs are hard-gated server-side.
+        """
+        return await _render_user_list(request, session, target, username, role_probe)
+
+    # ---- User management: create (write, tenant_admin) -----------------
+    @router.get("/ui/keycloak/users/create", response_class=HTMLResponse)
+    async def keycloak_user_create_modal(
+        request: Request,
+        session: UISessionContext = _require_session,
+        operator: Operator = _require_admin,
+        target: str = Query(default="", max_length=_MAX_TARGET_LENGTH),
+    ) -> HTMLResponse:
+        """Render the create-user confirm modal (tenant_admin only).
+
+        Collects a ``UserRepresentation`` JSON body + a Vault KV path for
+        the password (NO plaintext password field). Mints + re-sets the
+        ``meho_csrf`` cookie so the confirm button's own ``hx-headers`` echo
+        lines up after the HTMX swap rotated it.
+        """
+        return _render_user_create_modal(request, session, target)
+
+    @router.post("/ui/keycloak/users/create", response_class=HTMLResponse)
+    async def keycloak_user_create(
+        request: Request,
+        session: UISessionContext = _require_session,
+        operator: Operator = _require_admin,
+        target: str = Form(default="", max_length=_MAX_TARGET_LENGTH),
+        representation: str = Form(default="", max_length=_MAX_REPRESENTATION_LENGTH),
+        password_secret_ref: str = Form(default="", max_length=_MAX_FORM_FIELD_LENGTH),
+        password_secret_mount: str = Form(default="", max_length=_MAX_FORM_FIELD_LENGTH),
+        password_secret_key: str = Form(default="", max_length=_MAX_FORM_FIELD_LENGTH),
+        temporary: bool = Form(default=False),
+    ) -> HTMLResponse:
+        """Dispatch ``keycloak.user.create``; render the write result inline.
+
+        CSRF-gated (a ``POST`` under ``/ui/``) and tenant_admin-gated. The
+        password is supplied as a Vault KV path only -- it never lands in
+        form params, request logs, or the audit row. The op is
+        ``requires_approval=True``, so a clean dispatch returns
+        ``status="awaiting_approval"`` with the approval-request deep-link.
+        """
+        return await _render_user_create_result(
+            request,
+            operator,
+            target=target,
+            representation=representation,
+            password_secret_ref=password_secret_ref,
+            password_secret_mount=password_secret_mount,
+            password_secret_key=password_secret_key,
+            temporary=temporary,
+        )
+
+    _register_user_password_role_routes(router)
+
+
+def _register_user_password_role_routes(router: APIRouter) -> None:
+    """Register the reset-password + role-assign write routes (Task #1960).
+
+    Split from :func:`_register_user_routes` to keep each registration
+    function small. These are the two ``{user_uuid}``-parametrised writes;
+    they must be registered AFTER the literal ``users`` / ``users/create``
+    routes (the caller orders the two registration calls), so ``create`` is
+    never captured as a UUID. Both hard-gate on tenant_admin
+    (:data:`_require_admin`) and are CSRF-gated.
+    """
+
+    # ---- User management: reset-password (write, tenant_admin) ---------
+    @router.get("/ui/keycloak/users/{user_uuid}/reset-password", response_class=HTMLResponse)
+    async def keycloak_user_reset_password_modal(
+        request: Request,
+        user_uuid: str,
+        session: UISessionContext = _require_session,
+        operator: Operator = _require_admin,
+        target: str = Query(default="", max_length=_MAX_TARGET_LENGTH),
+    ) -> HTMLResponse:
+        """Render the reset-password confirm modal (tenant_admin only).
+
+        Keyed on the user's internal UUID. Collects only a Vault KV path
+        (NO plaintext password field). Mints + re-sets the ``meho_csrf``
+        cookie for the confirm button's own ``hx-headers`` echo.
+        """
+        return _render_reset_password_modal(request, session, user_uuid, target)
+
+    @router.post("/ui/keycloak/users/{user_uuid}/reset-password", response_class=HTMLResponse)
+    async def keycloak_user_reset_password(
+        request: Request,
+        user_uuid: str,
+        session: UISessionContext = _require_session,
+        operator: Operator = _require_admin,
+        target: str = Form(default="", max_length=_MAX_TARGET_LENGTH),
+        password_secret_ref: str = Form(default="", max_length=_MAX_FORM_FIELD_LENGTH),
+        password_secret_mount: str = Form(default="", max_length=_MAX_FORM_FIELD_LENGTH),
+        password_secret_key: str = Form(default="", max_length=_MAX_FORM_FIELD_LENGTH),
+        temporary: bool = Form(default=False),
+    ) -> HTMLResponse:
+        """Dispatch ``keycloak.user.reset_password``; render the result inline.
+
+        CSRF-gated and tenant_admin-gated. Keyed on the user UUID. The new
+        password is supplied as a Vault KV path only -- never inline. The op
+        is ``requires_approval=True`` (``awaiting_approval`` deep-link).
+        """
+        return await _render_reset_password_result(
+            request,
+            operator,
+            user_uuid=user_uuid,
+            target=target,
+            password_secret_ref=password_secret_ref,
+            password_secret_mount=password_secret_mount,
+            password_secret_key=password_secret_key,
+            temporary=temporary,
+        )
+
+    # ---- User management: role-assign (write, tenant_admin) ------------
+    @router.get("/ui/keycloak/users/{user_uuid}/roles/assign", response_class=HTMLResponse)
+    async def keycloak_role_assign_modal(
+        request: Request,
+        user_uuid: str,
+        session: UISessionContext = _require_session,
+        operator: Operator = _require_admin,
+        target: str = Query(default="", max_length=_MAX_TARGET_LENGTH),
+    ) -> HTMLResponse:
+        """Render the role-assign confirm modal (tenant_admin only).
+
+        A PRIVILEGE GRANT (``safety_level="dangerous"``). Reads the user's
+        current realm/client role mappings (``keycloak.role_mapping.get``)
+        for context, then collects realm role names to grant. The confirm
+        banner names it a privilege grant and surfaces ``dangerous``.
+        """
+        return await _render_role_assign_modal(request, session, operator, user_uuid, target)
+
+    @router.post("/ui/keycloak/users/{user_uuid}/roles/assign", response_class=HTMLResponse)
+    async def keycloak_role_assign(
+        request: Request,
+        user_uuid: str,
+        session: UISessionContext = _require_session,
+        operator: Operator = _require_admin,
+        target: str = Form(default="", max_length=_MAX_TARGET_LENGTH),
+        roles: list[str] = Form(default_factory=list),
+    ) -> HTMLResponse:
+        """Dispatch ``keycloak.role_mapping.assign``; render the result inline.
+
+        CSRF-gated and tenant_admin-gated. A privilege grant. ``roles`` is a
+        list of realm role names (string list); the dispatched params are
+        ``{"roles": [...], "id": <uuid>}``. The op is
+        ``requires_approval=True`` (``awaiting_approval`` deep-link).
+        """
+        return await _render_role_assign_result(
+            request,
+            operator,
+            user_uuid=user_uuid,
+            target=target,
+            roles=roles,
+        )
 
 
 async def _render_index(
@@ -422,3 +737,311 @@ def _render_client_detail_error(
         context,
         status_code=status.HTTP_400_BAD_REQUEST,
     )
+
+
+async def _resolve_active_target(operator: Operator, target: str) -> str | None:
+    """Resolve a query/form ``target`` against the operator's keycloak targets.
+
+    Returns the target name only when it is in the operator's tenant-scoped
+    keycloak target list, or the sole target when exactly one exists and no
+    explicit selection was made. A cross-tenant / unknown slug resolves to
+    ``None`` -- the no-tenant-override posture: a cross-tenant slug can never
+    drive a dispatch.
+    """
+    target = target.strip()
+    targets = await _list_keycloak_targets(operator)
+    target_names = {t["name"] for t in targets}
+    if target and target in target_names:
+        return target
+    if not target and len(targets) == 1:
+        return str(targets[0]["name"])
+    return None
+
+
+# ---------------------------------------------------------------------------
+# User list (read; operator-tier)
+# ---------------------------------------------------------------------------
+
+
+async def _render_user_list(
+    request: Request,
+    session: UISessionContext,
+    target: str,
+    username: str,
+    role_probe: OperatorRoleProbe,
+) -> HTMLResponse:
+    """Assemble + render the user-list page (``keycloak.user.list``).
+
+    OPERATOR-tier read. The write affordances (create / reset / assign) are
+    threaded behind ``is_tenant_admin`` so a plain operator never sees them;
+    the write POSTs are the server-side authority. Credential material is
+    redacted from every row by the connector -- this render projects named
+    fields only.
+    """
+    operator = await _resolve_operator(session)
+    targets = await _list_keycloak_targets(operator)
+    active_target = await _resolve_active_target(operator, target)
+    username_filter = username.strip()
+
+    context: dict[str, Any] = {
+        "active_surface": "keycloak",
+        "page_title": "Keycloak users",
+        "connector_id": KEYCLOAK_CONNECTOR_ID,
+        "targets": targets,
+        "active_target": active_target,
+        "username_filter": username_filter,
+        "is_tenant_admin": role_probe.is_tenant_admin,
+        "users": [],
+        "error": None,
+    }
+
+    if active_target is not None:
+        params: dict[str, Any] = {}
+        if username_filter:
+            params["username"] = username_filter
+        users_env = await _dispatch_read(
+            operator, op_id="keycloak.user.list", target=active_target, params=params
+        )
+        context["error"] = _dispatch_failed(users_env)
+        # The connector redacts credential material inside ``result``; read
+        # the named ``rows`` projection, never the raw envelope.
+        context["users"] = (users_env.get("result") or {}).get("rows", [])
+
+    return get_templates().TemplateResponse(request, "keycloak/users.html", context)
+
+
+# ---------------------------------------------------------------------------
+# Write modals + results (tenant_admin; CSRF-gated; approval handoff)
+# ---------------------------------------------------------------------------
+
+
+def _render_write_result(request: Request, envelope: dict[str, Any]) -> HTMLResponse:
+    """Render a keycloak write op's structured envelope inline.
+
+    The shared result fragment for all three writes. The dispatcher's
+    contract is "always return a structured envelope" -- ``ok`` /
+    ``awaiting_approval`` / ``error`` / ``denied`` all come back inside it
+    (HTTP 200). Because every keycloak write is ``requires_approval=True``,
+    the expected clean outcome is ``awaiting_approval``: the fragment
+    surfaces ``extras["approval_request_id"]`` with a deep-link into
+    ``/ui/approvals`` so the operator is never shown a silent / empty
+    success.
+    """
+    return get_templates().TemplateResponse(
+        request,
+        "keycloak/_write_result.html",
+        {"envelope": envelope, "error_message": None},
+    )
+
+
+def _render_write_form_error(request: Request, message: str) -> HTMLResponse:
+    """Render the write-result fragment with an inline form error (HTTP 400).
+
+    Covers a malformed ``representation`` JSON or a missing required field
+    (no Vault ref / no roles). The op was never dispatched; the operator
+    stays in the modal to correct the input.
+    """
+    return get_templates().TemplateResponse(
+        request,
+        "keycloak/_write_result.html",
+        {"envelope": None, "error_message": message},
+        status_code=status.HTTP_400_BAD_REQUEST,
+    )
+
+
+def _render_user_create_modal(
+    request: Request,
+    session: UISessionContext,
+    target: str,
+) -> HTMLResponse:
+    """Render the create-user confirm modal with a fresh CSRF token.
+
+    Mints + re-sets the ``meho_csrf`` cookie so the confirm button's own
+    ``hx-headers`` double-submit pair lines up after the HTMX swap rotated
+    it (the cookie-desync defence the operations Run modal applies).
+    """
+    csrf_token = mint_csrf_token(str(session.session_id))
+    context: dict[str, Any] = {
+        "connector_id": KEYCLOAK_CONNECTOR_ID,
+        "target": target.strip(),
+        "csrf_token": csrf_token,
+    }
+    response = get_templates().TemplateResponse(
+        request, "keycloak/_user_create_modal.html", context
+    )
+    set_csrf_cookie(response, csrf_token)
+    return response
+
+
+async def _render_user_create_result(
+    request: Request,
+    operator: Operator,
+    *,
+    target: str,
+    representation: str,
+    password_secret_ref: str,
+    password_secret_mount: str,
+    password_secret_key: str,
+    temporary: bool,
+) -> HTMLResponse:
+    """Validate + dispatch ``keycloak.user.create``; render the result."""
+    active_target = await _resolve_active_target(operator, target)
+    if active_target is None:
+        return _render_write_form_error(request, "Select a Keycloak target first.")
+    try:
+        rep = _parse_representation(representation)
+    except ValueError as exc:
+        return _render_write_form_error(request, str(exc))
+
+    params: dict[str, Any] = {"representation": rep}
+    # Vault-ref password ONLY -- the value is never collected. ``create``
+    # allows an SSO-only user with no password, so the ref is optional here.
+    params.update(
+        _password_secret_params(
+            secret_ref=password_secret_ref,
+            secret_mount=password_secret_mount,
+            secret_key=password_secret_key,
+            temporary=temporary,
+        )
+    )
+    envelope = await _dispatch_write(
+        operator, op_id="keycloak.user.create", target=active_target, params=params
+    )
+    return _render_write_result(request, envelope)
+
+
+def _render_reset_password_modal(
+    request: Request,
+    session: UISessionContext,
+    user_uuid: str,
+    target: str,
+) -> HTMLResponse:
+    """Render the reset-password confirm modal with a fresh CSRF token."""
+    csrf_token = mint_csrf_token(str(session.session_id))
+    context: dict[str, Any] = {
+        "connector_id": KEYCLOAK_CONNECTOR_ID,
+        "user_uuid": user_uuid,
+        "target": target.strip(),
+        "csrf_token": csrf_token,
+    }
+    response = get_templates().TemplateResponse(
+        request, "keycloak/_reset_password_modal.html", context
+    )
+    set_csrf_cookie(response, csrf_token)
+    return response
+
+
+async def _render_reset_password_result(
+    request: Request,
+    operator: Operator,
+    *,
+    user_uuid: str,
+    target: str,
+    password_secret_ref: str,
+    password_secret_mount: str,
+    password_secret_key: str,
+    temporary: bool,
+) -> HTMLResponse:
+    """Validate + dispatch ``keycloak.user.reset_password``; render the result."""
+    active_target = await _resolve_active_target(operator, target)
+    if active_target is None:
+        return _render_write_form_error(request, "Select a Keycloak target first.")
+    if not password_secret_ref.strip():
+        return _render_write_form_error(
+            request, "A Vault KV path (password secret ref) is required to reset a password."
+        )
+
+    # Keyed on the user UUID. Vault-ref password ONLY -- never inline.
+    params: dict[str, Any] = {"id": user_uuid}
+    params.update(
+        _password_secret_params(
+            secret_ref=password_secret_ref,
+            secret_mount=password_secret_mount,
+            secret_key=password_secret_key,
+            temporary=temporary,
+        )
+    )
+    envelope = await _dispatch_write(
+        operator, op_id="keycloak.user.reset_password", target=active_target, params=params
+    )
+    return _render_write_result(request, envelope)
+
+
+async def _render_role_assign_modal(
+    request: Request,
+    session: UISessionContext,
+    operator: Operator,
+    user_uuid: str,
+    target: str,
+) -> HTMLResponse:
+    """Render the role-assign confirm modal (a privilege grant).
+
+    Reads the user's CURRENT realm/client role mappings
+    (``keycloak.role_mapping.get``) for context so the operator can see what
+    the user already holds before granting more. Mints + re-sets the
+    ``meho_csrf`` cookie for the confirm button's own ``hx-headers`` echo.
+    The confirm banner names it a privilege grant + surfaces ``dangerous``.
+    """
+    active_target = await _resolve_active_target(operator, target)
+    current_roles: list[str] = []
+    error: str | None = None
+    if active_target is None:
+        error = "Select a Keycloak target first."
+    else:
+        env = await _dispatch_read(
+            operator,
+            op_id="keycloak.role_mapping.get",
+            target=active_target,
+            params={"id": user_uuid},
+        )
+        error = _dispatch_failed(env)
+        if error is None:
+            mappings = (env.get("result") or {}).get("role_mappings") or {}
+            realm_mappings = mappings.get("realmMappings") or []
+            current_roles = [
+                str(r.get("name")) for r in realm_mappings if isinstance(r, dict) and r.get("name")
+            ]
+
+    csrf_token = mint_csrf_token(str(session.session_id))
+    context: dict[str, Any] = {
+        "connector_id": KEYCLOAK_CONNECTOR_ID,
+        "user_uuid": user_uuid,
+        "target": active_target or target.strip(),
+        "current_roles": current_roles,
+        "error": error,
+        "csrf_token": csrf_token,
+    }
+    response = get_templates().TemplateResponse(
+        request, "keycloak/_role_assign_modal.html", context
+    )
+    set_csrf_cookie(response, csrf_token)
+    return response
+
+
+async def _render_role_assign_result(
+    request: Request,
+    operator: Operator,
+    *,
+    user_uuid: str,
+    target: str,
+    roles: list[str],
+) -> HTMLResponse:
+    """Validate + dispatch ``keycloak.role_mapping.assign``; render the result.
+
+    A privilege grant. ``roles`` is a string list of realm role names; the
+    dispatched params are ``{"roles": [...], "id": <uuid>}``.
+    """
+    active_target = await _resolve_active_target(operator, target)
+    if active_target is None:
+        return _render_write_form_error(request, "Select a Keycloak target first.")
+    role_names = [r.strip() for r in roles if r.strip()]
+    if not role_names:
+        return _render_write_form_error(request, "Select at least one realm role to grant.")
+
+    envelope = await _dispatch_write(
+        operator,
+        op_id="keycloak.role_mapping.assign",
+        target=active_target,
+        params={"roles": role_names, "id": user_uuid},
+    )
+    return _render_write_result(request, envelope)

--- a/backend/src/meho_backplane/ui/templates/keycloak/_reset_password_modal.html
+++ b/backend/src/meho_backplane/ui/templates/keycloak/_reset_password_modal.html
@@ -1,0 +1,116 @@
+{#-
+  SPDX-License-Identifier: Apache-2.0
+  Copyright (c) 2026 evoila Group
+
+  Keycloak reset-password confirm modal (Initiative #1943, Task #1960).
+
+  Swapped into ``#keycloak-user-modal-container`` by a user row's "Reset
+  password" button. Dispatches ``keycloak.user.reset_password``
+  (``safety_level="caution"``, ``requires_approval=True``), keyed on the
+  user's internal UUID.
+
+  PASSWORD HANDLING (load-bearing): NO plaintext password field. The form
+  collects only a Vault KV path; the backend reads the new password from
+  Vault at dispatch time. The value never lands in form params, request
+  logs, or the audit row.
+
+  CSRF: confirm POST carries the double-submit token on the FORM's own
+  ``hx-headers`` (not inherited to children). The GET minted + re-set the
+  matching ``meho_csrf`` cookie. ``hx-disabled-elt`` blocks a double-fire.
+
+  Context: ``connector_id``, ``user_uuid``, ``target``, ``csrf_token``.
+-#}
+{% from "_icons.html" import icon %}
+<dialog id="keycloak-user-modal" class="modal modal-open" aria-label="Reset Keycloak user password" data-keycloak-modal="reset-password">
+  <div class="modal-box max-w-lg">
+    <div class="flex items-start justify-between gap-4">
+      <h3 class="text-lg font-semibold">Reset password</h3>
+      <button type="button" class="btn btn-ghost btn-square btn-sm" aria-label="Close"
+              onclick="document.getElementById('keycloak-user-modal').close()">
+        {{ icon("x", class="size-4") }}
+      </button>
+    </div>
+
+    <p class="mt-1 text-xs opacity-60">
+      User <code class="font-mono" data-user-uuid>{{ user_uuid }}</code>
+    </p>
+
+    <div role="alert" class="alert alert-warning mt-4 items-start" data-keycloak-confirm="caution">
+      {{ icon("shield-check", class="size-5 shrink-0") }}
+      <div>
+        <h4 class="text-sm font-semibold">State-changing operation</h4>
+        <p class="text-xs">
+          Resetting a password is approval-gated: confirming parks a request
+          for a reviewer rather than executing immediately.
+        </p>
+        <div class="mt-2 flex flex-wrap items-center gap-2">
+          <span class="badge badge-warning badge-sm" data-keycloak-safety>safety: caution</span>
+          <span class="badge badge-outline badge-sm" data-keycloak-requires-approval>requires approval</span>
+        </div>
+      </div>
+    </div>
+
+    <form
+      class="mt-4 space-y-3"
+      hx-post="/ui/keycloak/users/{{ user_uuid }}/reset-password"
+      hx-target="#keycloak-reset-password-result"
+      hx-swap="innerHTML"
+      hx-headers='{"X-CSRF-Token": "{{ csrf_token }}"}'
+      hx-disabled-elt="find button[data-action='submit']"
+    >
+      <input type="hidden" name="target" value="{{ target }}" />
+
+      <p class="text-xs opacity-60">
+        The new password is read from Vault at dispatch time &mdash; it is
+        never typed here.
+      </p>
+      <label class="form-control">
+        <span class="label-text mb-1 text-xs opacity-70">Vault KV path (password secret ref)</span>
+        <input
+          type="text"
+          name="password_secret_ref"
+          maxlength="512"
+          required
+          class="input input-bordered input-sm w-full font-mono"
+          placeholder="rdc-hetzner-dc/keycloak/operator-a"
+          aria-label="Password secret ref (Vault KV path)"
+          autocomplete="off"
+        />
+      </label>
+      <div class="grid gap-2 sm:grid-cols-2">
+        <label class="form-control">
+          <span class="label-text mb-1 text-xs opacity-70">Mount <span class="opacity-50">(optional)</span></span>
+          <input type="text" name="password_secret_mount" maxlength="512"
+                 class="input input-bordered input-sm w-full font-mono" placeholder="secret"
+                 aria-label="Vault mount" autocomplete="off" />
+        </label>
+        <label class="form-control">
+          <span class="label-text mb-1 text-xs opacity-70">Key <span class="opacity-50">(optional)</span></span>
+          <input type="text" name="password_secret_key" maxlength="512"
+                 class="input input-bordered input-sm w-full font-mono" placeholder="password"
+                 aria-label="Vault secret key" autocomplete="off" />
+        </label>
+      </div>
+      <label class="label cursor-pointer justify-start gap-2">
+        <input type="checkbox" name="temporary" value="true" class="checkbox checkbox-sm" />
+        <span class="label-text text-xs">Force a password change on first login (temporary)</span>
+      </label>
+
+      <div class="flex items-center justify-end gap-2 pt-1">
+        <button type="button" class="btn btn-ghost btn-sm"
+                onclick="document.getElementById('keycloak-user-modal').close()">
+          Cancel
+        </button>
+        <button type="submit" data-action="submit" class="btn btn-sm btn-warning gap-1">
+          {{ icon("key-round", class="size-4") }}
+          Reset (request approval)
+        </button>
+      </div>
+    </form>
+
+    <div id="keycloak-reset-password-result" class="mt-4"></div>
+  </div>
+  <form method="dialog" class="modal-backdrop">
+    <button type="submit" aria-label="Close">close</button>
+  </form>
+</dialog>

--- a/backend/src/meho_backplane/ui/templates/keycloak/_role_assign_modal.html
+++ b/backend/src/meho_backplane/ui/templates/keycloak/_role_assign_modal.html
@@ -1,0 +1,143 @@
+{#-
+  SPDX-License-Identifier: Apache-2.0
+  Copyright (c) 2026 evoila Group
+
+  Keycloak role-assign confirm modal (Initiative #1943, Task #1960).
+
+  Swapped into ``#keycloak-user-modal-container`` by a user row's "Assign
+  roles" button. Dispatches ``keycloak.role_mapping.assign`` -- a PRIVILEGE
+  GRANT (``safety_level="dangerous"``, ``requires_approval=True``), keyed on
+  the user's internal UUID.
+
+  The confirm banner MUST name it a privilege grant and surface the
+  ``dangerous`` safety level -- granting a realm role widens the user's
+  authority, so the gate is the loudest of the three.
+
+  Current roles: the user's existing realm role mappings
+  (``keycloak.role_mapping.get``) are shown for context so the operator sees
+  what the user already holds before granting more. The grant is idempotent
+  server-side (re-assigning a held role is a no-op).
+
+  Roles input: one or more realm role NAMES (a string list). The form posts
+  repeated ``roles`` fields -> FastAPI collects them as ``list[str]`` -> the
+  dispatch params are ``{"roles": [...], "id": <uuid>}``.
+
+  CSRF: confirm POST carries the double-submit token on the FORM's own
+  ``hx-headers`` (not inherited to children); the GET minted + re-set the
+  matching ``meho_csrf`` cookie. ``hx-disabled-elt`` blocks a double-fire.
+
+  Context: ``connector_id``, ``user_uuid``, ``target``, ``current_roles``,
+  ``error``, ``csrf_token``.
+-#}
+{% from "_icons.html" import icon %}
+<dialog id="keycloak-user-modal" class="modal modal-open" aria-label="Assign Keycloak realm roles" data-keycloak-modal="role-assign">
+  <div class="modal-box max-w-lg">
+    <div class="flex items-start justify-between gap-4">
+      <h3 class="text-lg font-semibold">Assign realm roles</h3>
+      <button type="button" class="btn btn-ghost btn-square btn-sm" aria-label="Close"
+              onclick="document.getElementById('keycloak-user-modal').close()">
+        {{ icon("x", class="size-4") }}
+      </button>
+    </div>
+
+    <p class="mt-1 text-xs opacity-60">
+      User <code class="font-mono" data-user-uuid>{{ user_uuid }}</code>
+    </p>
+
+    {#- PRIVILEGE-GRANT banner. The loudest of the three writes: granting a
+        realm role widens the user's authority. Names it a privilege grant +
+        surfaces the dangerous safety level explicitly. -#}
+    <div role="alert" class="alert alert-error mt-4 items-start" data-keycloak-confirm="dangerous">
+      {{ icon("shield-check", class="size-5 shrink-0") }}
+      <div>
+        <h4 class="text-sm font-semibold" data-keycloak-privilege-grant>
+          Privilege grant &mdash; widens this user's authority
+        </h4>
+        <p class="text-xs">
+          Assigning a realm role is a privilege grant: it gives the user every
+          permission the role carries. It is approval-gated &mdash; confirming
+          parks a request for a reviewer rather than executing immediately.
+        </p>
+        <div class="mt-2 flex flex-wrap items-center gap-2">
+          <span class="badge badge-error badge-sm" data-keycloak-safety>safety: dangerous</span>
+          <span class="badge badge-outline badge-sm" data-keycloak-requires-approval>requires approval</span>
+        </div>
+      </div>
+    </div>
+
+    {% if error %}
+      <div role="alert" class="alert alert-warning mt-3" data-keycloak-error>
+        <p class="text-xs">Could not read current roles: <code>{{ error }}</code></p>
+      </div>
+    {% else %}
+      <div class="mt-3" data-keycloak-current-roles>
+        <span class="text-xs opacity-60">Currently assigned realm roles:</span>
+        {% if current_roles %}
+          <div class="mt-1 flex flex-wrap gap-1">
+            {% for role in current_roles %}
+              <span class="badge badge-ghost badge-sm font-mono">{{ role }}</span>
+            {% endfor %}
+          </div>
+        {% else %}
+          <span class="text-xs opacity-50">none</span>
+        {% endif %}
+      </div>
+    {% endif %}
+
+    <form
+      class="mt-4 space-y-3"
+      x-data="{ roles: [''] }"
+      hx-post="/ui/keycloak/users/{{ user_uuid }}/roles/assign"
+      hx-target="#keycloak-role-assign-result"
+      hx-swap="innerHTML"
+      hx-headers='{"X-CSRF-Token": "{{ csrf_token }}"}'
+      hx-disabled-elt="find button[data-action='submit']"
+    >
+      <input type="hidden" name="target" value="{{ target }}" />
+
+      <div class="form-control">
+        <span class="label-text mb-1 text-xs opacity-70">Realm role names to grant</span>
+        <template x-for="(role, idx) in roles" :key="idx">
+          <div class="mb-1 flex gap-1">
+            <input
+              type="text"
+              name="roles"
+              maxlength="512"
+              x-model="roles[idx]"
+              class="input input-bordered input-sm w-full font-mono"
+              placeholder="realm-role-name"
+              aria-label="Realm role name to grant"
+              autocomplete="off"
+            />
+            <button type="button" class="btn btn-ghost btn-sm btn-square"
+                    aria-label="Remove role"
+                    @click="roles.length > 1 && roles.splice(idx, 1)">
+              {{ icon("x", class="size-4") }}
+            </button>
+          </div>
+        </template>
+        <button type="button" class="btn btn-ghost btn-xs gap-1 self-start"
+                @click="roles.push('')" data-keycloak-add-role>
+          {{ icon("user", class="size-3.5") }}
+          Add another role
+        </button>
+      </div>
+
+      <div class="flex items-center justify-end gap-2 pt-1">
+        <button type="button" class="btn btn-ghost btn-sm"
+                onclick="document.getElementById('keycloak-user-modal').close()">
+          Cancel
+        </button>
+        <button type="submit" data-action="submit" class="btn btn-sm btn-error gap-1">
+          {{ icon("shield-check", class="size-4") }}
+          Grant roles (request approval)
+        </button>
+      </div>
+    </form>
+
+    <div id="keycloak-role-assign-result" class="mt-4"></div>
+  </div>
+  <form method="dialog" class="modal-backdrop">
+    <button type="submit" aria-label="Close">close</button>
+  </form>
+</dialog>

--- a/backend/src/meho_backplane/ui/templates/keycloak/_user_create_modal.html
+++ b/backend/src/meho_backplane/ui/templates/keycloak/_user_create_modal.html
@@ -1,0 +1,133 @@
+{#-
+  SPDX-License-Identifier: Apache-2.0
+  Copyright (c) 2026 evoila Group
+
+  Keycloak create-user confirm modal (Initiative #1943, Task #1960).
+
+  Swapped into ``#keycloak-user-modal-container`` by the "Create user" button.
+  Dispatches ``keycloak.user.create`` (``safety_level="caution"``,
+  ``requires_approval=True``) -- a state-changing write, so the confirm is
+  UNMISSABLE.
+
+  PASSWORD HANDLING (load-bearing): the form has NO plaintext password field.
+  It collects only a Vault KV path (``password_secret_ref`` + optional
+  mount / key / temporary). The backend reads the password from Vault at
+  dispatch time and sets it as a credential; the value never lands in form
+  params, request logs, or the audit row. ``create`` allows an SSO-only user
+  with no password, so the Vault ref is optional here.
+
+  CSRF: the confirm POST carries the OWASP signed double-submit token on the
+  confirm FORM's own ``hx-headers`` (HTMX does NOT inherit ``hx-headers`` to
+  children -- the element that issues the request carries it). The GET minted
+  the token + re-set the matching ``meho_csrf`` cookie. The submit button
+  disables itself during dispatch (``hx-disabled-elt``) so the write cannot
+  be double-fired.
+
+  Context: ``connector_id``, ``target``, ``csrf_token``.
+-#}
+{% from "_icons.html" import icon %}
+<dialog id="keycloak-user-modal" class="modal modal-open" aria-label="Create Keycloak user" data-keycloak-modal="user-create">
+  <div class="modal-box max-w-2xl">
+    <div class="flex items-start justify-between gap-4">
+      <h3 class="text-lg font-semibold">Create user</h3>
+      <button type="button" class="btn btn-ghost btn-square btn-sm" aria-label="Close"
+              onclick="document.getElementById('keycloak-user-modal').close()">
+        {{ icon("x", class="size-4") }}
+      </button>
+    </div>
+
+    <div role="alert" class="alert alert-warning mt-4 items-start" data-keycloak-confirm="caution">
+      {{ icon("shield-check", class="size-5 shrink-0") }}
+      <div>
+        <h4 class="text-sm font-semibold">State-changing operation</h4>
+        <p class="text-xs">
+          Creating a user is approval-gated: confirming parks a request for a
+          reviewer rather than executing immediately.
+        </p>
+        <div class="mt-2 flex flex-wrap items-center gap-2">
+          <span class="badge badge-warning badge-sm" data-keycloak-safety>safety: caution</span>
+          <span class="badge badge-outline badge-sm" data-keycloak-requires-approval>requires approval</span>
+        </div>
+      </div>
+    </div>
+
+    <form
+      class="mt-4 space-y-3"
+      hx-post="/ui/keycloak/users/create"
+      hx-target="#keycloak-user-create-result"
+      hx-swap="innerHTML"
+      hx-headers='{"X-CSRF-Token": "{{ csrf_token }}"}'
+      hx-disabled-elt="find button[data-action='submit']"
+    >
+      <input type="hidden" name="target" value="{{ target }}" />
+
+      <label class="form-control">
+        <span class="label-text mb-1 text-xs opacity-70">
+          UserRepresentation <span class="opacity-50">(JSON object; at least a username)</span>
+        </span>
+        <textarea
+          name="representation"
+          rows="6"
+          maxlength="65536"
+          class="textarea textarea-bordered textarea-sm w-full font-mono text-xs"
+          placeholder='{"username": "operator-a", "email": "operator-a@example.com", "enabled": true}'
+          aria-label="UserRepresentation as JSON"
+        ></textarea>
+      </label>
+
+      <fieldset class="rounded-box border border-base-300 p-3">
+        <legend class="px-1 text-xs opacity-70">Password (from Vault)</legend>
+        <p class="mb-2 text-xs opacity-60">
+          The password is read from Vault at dispatch time &mdash; it is never
+          typed here. Leave blank for an SSO-only user.
+        </p>
+        <label class="form-control">
+          <span class="label-text mb-1 text-xs opacity-70">Vault KV path (password secret ref)</span>
+          <input
+            type="text"
+            name="password_secret_ref"
+            maxlength="512"
+            class="input input-bordered input-sm w-full font-mono"
+            placeholder="rdc-hetzner-dc/keycloak/operator-a"
+            aria-label="Password secret ref (Vault KV path)"
+            autocomplete="off"
+          />
+        </label>
+        <div class="mt-2 grid gap-2 sm:grid-cols-2">
+          <label class="form-control">
+            <span class="label-text mb-1 text-xs opacity-70">Mount <span class="opacity-50">(optional)</span></span>
+            <input type="text" name="password_secret_mount" maxlength="512"
+                   class="input input-bordered input-sm w-full font-mono" placeholder="secret"
+                   aria-label="Vault mount" autocomplete="off" />
+          </label>
+          <label class="form-control">
+            <span class="label-text mb-1 text-xs opacity-70">Key <span class="opacity-50">(optional)</span></span>
+            <input type="text" name="password_secret_key" maxlength="512"
+                   class="input input-bordered input-sm w-full font-mono" placeholder="password"
+                   aria-label="Vault secret key" autocomplete="off" />
+          </label>
+        </div>
+        <label class="label mt-2 cursor-pointer justify-start gap-2">
+          <input type="checkbox" name="temporary" value="true" class="checkbox checkbox-sm" />
+          <span class="label-text text-xs">Force a password change on first login (temporary)</span>
+        </label>
+      </fieldset>
+
+      <div class="flex items-center justify-end gap-2 pt-1">
+        <button type="button" class="btn btn-ghost btn-sm"
+                onclick="document.getElementById('keycloak-user-modal').close()">
+          Cancel
+        </button>
+        <button type="submit" data-action="submit" class="btn btn-sm btn-warning gap-1">
+          {{ icon("user", class="size-4") }}
+          Create (request approval)
+        </button>
+      </div>
+    </form>
+
+    <div id="keycloak-user-create-result" class="mt-4"></div>
+  </div>
+  <form method="dialog" class="modal-backdrop">
+    <button type="submit" aria-label="Close">close</button>
+  </form>
+</dialog>

--- a/backend/src/meho_backplane/ui/templates/keycloak/_write_result.html
+++ b/backend/src/meho_backplane/ui/templates/keycloak/_write_result.html
@@ -1,0 +1,109 @@
+{#-
+  SPDX-License-Identifier: Apache-2.0
+  Copyright (c) 2026 evoila Group
+
+  Keycloak write-result fragment (Initiative #1943, Task #1960).
+
+  The shared swap target for all three keycloak user-management writes
+  (create / reset-password / role-assign). Renders the dispatched op's
+  structured ``call_operation`` envelope inline -- the console's write
+  outcome surface.
+
+  Every keycloak write op is ``requires_approval=True``, so the EXPECTED
+  clean outcome is ``awaiting_approval``: the policy gate parked the op and
+  created a durable ApprovalRequest. This MUST be surfaced with the
+  ``extras.approval_request_id`` and a DEEP-LINK into ``/ui/approvals`` --
+  otherwise the operator thinks the write silently no-op'd.
+
+  Render branches:
+    * ``error_message`` set (no ``envelope``) -> inline form error (400):
+      a malformed representation JSON or a missing required field. The op
+      was never dispatched; the operator stays in the modal.
+    * ``status == "awaiting_approval"`` -> the approval banner + deep-link.
+    * ``status == "ok"`` -> the (rare for these ops) immediate success.
+    * ``status in ("error", "denied")`` -> the structured fault.
+
+  Context:
+    envelope      -- dict | None: the call_operation envelope
+    error_message -- str | None: the inline form-error message (400 branch)
+-#}
+{% from "_icons.html" import icon %}
+
+{% if error_message %}
+  <div role="alert" class="alert alert-error" data-write-status="form_error">
+    <div>
+      <h4 class="text-sm font-semibold">Cannot submit</h4>
+      <p class="text-xs [overflow-wrap:anywhere]">{{ error_message }}</p>
+    </div>
+  </div>
+{% elif envelope.status == "awaiting_approval" %}
+  {%- set extras = envelope.get("extras") or {} -%}
+  {%- set approval_id = extras.get("approval_request_id") -%}
+  <div role="alert" class="alert alert-info items-start" data-write-status="awaiting_approval">
+    {{ icon("clock", class="size-5 shrink-0") }}
+    <div>
+      <h4 class="text-sm font-semibold">Awaiting approval</h4>
+      <p class="text-xs [overflow-wrap:anywhere]">
+        This operation requires approval before it executes. A request has
+        been parked for a reviewer &mdash; it has <span class="font-semibold">not</span>
+        run yet.
+      </p>
+      {% if approval_id %}
+        <p class="mt-1 text-xs opacity-70">
+          Request id <code data-approval-request-id>{{ approval_id }}</code>
+        </p>
+        <a
+          class="btn btn-primary btn-sm mt-2 gap-1"
+          href="/ui/approvals/{{ approval_id }}"
+          hx-get="/ui/approvals/{{ approval_id }}"
+          hx-target="#meho-approvals-modal-container"
+          hx-swap="innerHTML"
+          data-approval-deep-link
+        >
+          {{ icon("external-link", class="size-4") }}
+          Review in approvals
+        </a>
+      {% else %}
+        <a
+          class="btn btn-primary btn-sm mt-2 gap-1"
+          href="/ui/approvals"
+          hx-get="/ui/approvals"
+          hx-target="#meho-approvals-modal-container"
+          hx-swap="innerHTML"
+          data-approval-deep-link
+        >
+          {{ icon("external-link", class="size-4") }}
+          Open approvals
+        </a>
+      {% endif %}
+    </div>
+  </div>
+{% elif envelope.status == "ok" %}
+  <div role="status" class="alert alert-success items-start" data-write-status="ok">
+    {{ icon("check", class="size-5 shrink-0") }}
+    <div>
+      <h4 class="text-sm font-semibold">Done</h4>
+      <p class="text-xs">The operation completed.</p>
+    </div>
+  </div>
+{% else %}
+  {%- set extras = envelope.get("extras") or {} -%}
+  <div
+    role="alert"
+    class="alert {{ 'alert-warning' if envelope.status == 'denied' else 'alert-error' }} items-start"
+    data-write-status="{{ envelope.status }}"
+  >
+    {{ icon("ban", class="size-5 shrink-0") }}
+    <div>
+      <h4 class="text-sm font-semibold">
+        {% if envelope.status == "denied" %}Operation denied{% else %}Operation failed{% endif %}
+        {% if extras.get("error_code") %}
+          <code class="ml-1 text-xs" data-write-error-code>{{ extras.get("error_code") }}</code>
+        {% endif %}
+      </h4>
+      {% if envelope.get("error") %}
+        <p class="text-xs [overflow-wrap:anywhere]">{{ envelope.get("error") }}</p>
+      {% endif %}
+    </div>
+  </div>
+{% endif %}

--- a/backend/src/meho_backplane/ui/templates/keycloak/users.html
+++ b/backend/src/meho_backplane/ui/templates/keycloak/users.html
@@ -1,0 +1,221 @@
+{#-
+  SPDX-License-Identifier: Apache-2.0
+  Copyright (c) 2026 evoila Group
+
+  Keycloak console -- user management (Initiative #1943, Task #1960).
+
+  The realm's human-user list plus the three high-blast write affordances
+  (create / reset-password / role-assign), all dispatched in-process through
+  ``call_operation`` against the PINNED ``connector_id="keycloak-admin-26.x"``
+  (never the bare ``keycloak`` slug).
+
+  RBAC: the list itself is OPERATOR-tier (``keycloak.user.list`` is
+  ``safety_level="safe"``). The three write affordances are surfaced ONLY to
+  a tenant_admin (``is_tenant_admin``); a plain operator never sees them
+  (soft-hide). The write POSTs are hard-gated server-side
+  (``_resolve_admin_or_403``) -- the soft-hide is a UX hint, not the
+  authority.
+
+  Secret handling: credential material is redacted from every row by the
+  connector; this render projects named fields only -- the raw
+  ``OperationResult`` envelope is NEVER dumped into the page.
+
+  Context keys: ``connector_id``, ``targets``, ``active_target``,
+  ``username_filter``, ``users``, ``error``, ``is_tenant_admin`` (see
+  ``keycloak/routes.py``).
+-#}
+{% extends "base.html" %}
+
+{% from "_icons.html" import icon %}
+
+{% block page_title %}Keycloak users &middot; MEHO Operator Console{% endblock %}
+
+{% block content %}
+<section class="space-y-5" data-surface="keycloak-users">
+  <header class="flex flex-wrap items-center justify-between gap-4">
+    <div>
+      <h1 class="text-2xl font-semibold">Keycloak users</h1>
+      <p class="text-sm opacity-70">
+        List, create, reset passwords, and assign realm roles for the managed
+        realm's users. Credential material is redacted.
+      </p>
+    </div>
+    <a href="/ui/keycloak{% if active_target %}?target={{ active_target | urlencode }}{% endif %}"
+       class="btn btn-ghost btn-sm gap-1">
+      {{ icon("arrow-right", class="size-4") }}
+      Realm browser
+    </a>
+  </header>
+
+  {#- Target picker + optional username filter. The connector is fixed; the
+      operator picks WHICH Keycloak deployment + an optional username filter.
+      Options are tenant-scoped server-side. -#}
+  <form
+    class="grid gap-3 sm:grid-cols-[minmax(0,22rem)_minmax(0,18rem)_auto]"
+    hx-get="/ui/keycloak/users"
+    hx-target="body"
+    hx-push-url="true"
+  >
+    <label class="form-control">
+      <span class="label-text mb-1 text-xs opacity-70">Keycloak target</span>
+      <select
+        name="target"
+        class="select select-bordered select-sm w-full font-mono"
+        aria-label="Keycloak target"
+        hx-get="/ui/keycloak/users"
+        hx-target="body"
+        hx-trigger="change"
+        hx-push-url="true"
+      >
+        <option value="">Select a target…</option>
+        {% for t in targets %}
+          <option
+            value="{{ t.name }}"
+            {% if t.name == active_target %}selected{% endif %}
+          >{{ t.name }}</option>
+        {% endfor %}
+      </select>
+    </label>
+    <label class="form-control">
+      <span class="label-text mb-1 text-xs opacity-70">Username filter</span>
+      <input
+        type="text"
+        name="username"
+        maxlength="512"
+        value="{{ username_filter }}"
+        class="input input-bordered input-sm w-full font-mono"
+        placeholder="operator-a"
+        aria-label="Username filter"
+        autocomplete="off"
+      />
+    </label>
+    <div class="flex items-end">
+      <button type="submit" class="btn btn-sm btn-primary gap-1">
+        {{ icon("search", class="size-4") }}
+        Filter
+      </button>
+    </div>
+  </form>
+
+  {% if not targets %}
+    <div class="rounded-box border border-base-300 bg-base-100 px-4 py-8 text-center text-sm opacity-60">
+      No Keycloak targets registered for this tenant.
+    </div>
+  {% elif not active_target %}
+    <div class="rounded-box border border-base-300 bg-base-100 px-4 py-8 text-center text-sm opacity-60">
+      Select a Keycloak target to list its users.
+    </div>
+  {% else %}
+    {% if is_tenant_admin %}
+      <div class="flex justify-end">
+        <button
+          type="button"
+          class="btn btn-sm btn-primary gap-1"
+          data-keycloak-user-create
+          hx-get="/ui/keycloak/users/create?target={{ active_target | urlencode }}"
+          hx-target="#keycloak-user-modal-container"
+          hx-swap="innerHTML"
+        >
+          {{ icon("user", class="size-4") }}
+          Create user
+        </button>
+      </div>
+    {% endif %}
+
+    {% if error %}
+      <div role="alert" class="alert alert-warning" data-keycloak-error>
+        <div>
+          <h3 class="text-sm font-semibold">Could not list users</h3>
+          <p class="text-xs">
+            Dispatch against <code>{{ active_target }}</code> failed:
+            <code>{{ error }}</code>
+          </p>
+        </div>
+      </div>
+    {% endif %}
+
+    <section aria-label="Users" data-keycloak-users>
+      <h2 class="mb-2 text-sm font-semibold opacity-80">
+        Users <span class="text-xs opacity-60">({{ users | length }})</span>
+      </h2>
+      {% if users %}
+        <div class="overflow-x-auto rounded-box border border-base-300 bg-base-100">
+          <table class="table table-sm">
+            <thead>
+              <tr>
+                <th>Username</th>
+                <th>Email</th>
+                <th>Enabled</th>
+                <th>Email verified</th>
+                {% if is_tenant_admin %}<th class="text-right">Actions</th>{% endif %}
+              </tr>
+            </thead>
+            <tbody>
+              {% for user in users %}
+                <tr data-user-row data-user-uuid="{{ user.get('id') | default('', true) }}">
+                  <td class="font-mono">{{ user.get("username") | default("—", true) }}</td>
+                  <td class="text-xs opacity-70">{{ user.get("email") | default("—", true) }}</td>
+                  <td>
+                    {% if user.get("enabled") %}
+                      <span class="badge badge-success badge-xs">yes</span>
+                    {% else %}
+                      <span class="badge badge-ghost badge-xs">no</span>
+                    {% endif %}
+                  </td>
+                  <td>
+                    {% if user.get("emailVerified") %}
+                      <span class="badge badge-ghost badge-xs">yes</span>
+                    {% else %}
+                      <span class="badge badge-ghost badge-xs">no</span>
+                    {% endif %}
+                  </td>
+                  {% if is_tenant_admin %}
+                    <td class="text-right">
+                      {% if user.get("id") %}
+                        {%- set uid = user.get("id") -%}
+                        <div class="flex justify-end gap-1">
+                          <button
+                            type="button"
+                            class="btn btn-ghost btn-xs"
+                            data-keycloak-reset-password
+                            hx-get="/ui/keycloak/users/{{ uid }}/reset-password?target={{ active_target | urlencode }}"
+                            hx-target="#keycloak-user-modal-container"
+                            hx-swap="innerHTML"
+                          >
+                            {{ icon("key-round", class="size-3.5") }}
+                            Reset password
+                          </button>
+                          <button
+                            type="button"
+                            class="btn btn-ghost btn-xs"
+                            data-keycloak-role-assign
+                            hx-get="/ui/keycloak/users/{{ uid }}/roles/assign?target={{ active_target | urlencode }}"
+                            hx-target="#keycloak-user-modal-container"
+                            hx-swap="innerHTML"
+                          >
+                            {{ icon("shield-check", class="size-3.5") }}
+                            Assign roles
+                          </button>
+                        </div>
+                      {% endif %}
+                    </td>
+                  {% endif %}
+                </tr>
+              {% endfor %}
+            </tbody>
+          </table>
+        </div>
+      {% else %}
+        <div class="rounded-box border border-base-300 bg-base-100 px-4 py-6 text-center text-sm opacity-60">
+          No users in this realm{% if username_filter %} matching <code>{{ username_filter }}</code>{% endif %}.
+        </div>
+      {% endif %}
+    </section>
+  {% endif %}
+
+  {#- Stable modal container -- each write affordance ``hx-get``s its
+      confirm modal here; the modal's confirm POST swaps the result fragment
+      into its own in-modal result region. -#}
+  <div id="keycloak-user-modal-container"></div>
+</section>
+{% endblock %}

--- a/backend/tests/test_ui_keycloak.py
+++ b/backend/tests/test_ui_keycloak.py
@@ -64,7 +64,12 @@ from meho_backplane.ui.auth.session_store import (
     create_session,
     reset_fernet_cache_for_testing,
 )
-from meho_backplane.ui.csrf import CSRFMiddleware
+from meho_backplane.ui.csrf import (
+    CSRF_COOKIE_NAME,
+    CSRF_HEADER_NAME,
+    CSRFMiddleware,
+    mint_csrf_token,
+)
 from meho_backplane.ui.paths import static_root_dir
 from meho_backplane.ui.routes import build_keycloak_router
 from meho_backplane.ui.routes import build_router as build_ui_router
@@ -229,6 +234,47 @@ def _client_with_role(
     client = TestClient(_build_app(), follow_redirects=False)
     client.cookies.set(SESSION_COOKIE_NAME, str(session_id))
     return client, mock
+
+
+def _client_with_role_and_session(
+    *,
+    tenant_id: uuid.UUID,
+    operator_sub: str,
+    role: TenantRole,
+) -> tuple[TestClient, respx.MockRouter, uuid.UUID]:
+    """Like :func:`_client_with_role` but also returns the seeded session id.
+
+    The write tests need the session id to mint the matching double-submit
+    CSRF token (the token is derived from the session id, so a forged POST
+    without it -- or with a token minted from a different session -- fails
+    the ``ui/csrf.py`` gate).
+    """
+    keypair, jwks = _make_keypair_and_jwks()
+    access_token = _mint_token(
+        keypair,
+        sub=operator_sub,
+        tenant_id=str(tenant_id),
+        tenant_role=role.value,
+    )
+    session_id = _seed_session_sync(
+        tenant_id=tenant_id,
+        access_token=access_token,
+        operator_sub=operator_sub,
+    )
+    mock = respx.mock(assert_all_called=False)
+    _mock_discovery_and_jwks(mock, jwks)
+    client = TestClient(_build_app(), follow_redirects=False)
+    client.cookies.set(SESSION_COOKIE_NAME, str(session_id))
+    return client, mock, session_id
+
+
+def _csrf_kwargs(session_id: uuid.UUID) -> dict[str, Any]:
+    """Header + cookie kwargs that satisfy the double-submit CSRF check."""
+    token = mint_csrf_token(str(session_id))
+    return {
+        "headers": {CSRF_HEADER_NAME: token},
+        "cookies": {CSRF_COOKIE_NAME: token},
+    }
 
 
 def _patch_call_operation(
@@ -561,3 +607,406 @@ def test_keycloak_ui_client_detail_route_resolves_to_detail_handler() -> None:
     detail_idx = paths.index("/ui/keycloak/clients/{client_uuid}")
     index_idx = paths.index("/ui/keycloak")
     assert detail_idx < index_idx
+
+
+# ---------------------------------------------------------------------------
+# User management (Task #1960): list + create / reset-password / role-assign
+# ---------------------------------------------------------------------------
+
+
+def _awaiting_approval(op_id: str, approval_request_id: str) -> dict[str, Any]:
+    """Build an ``awaiting_approval`` envelope like the policy gate returns.
+
+    Every keycloak write op is ``requires_approval=True``, so a confirmed
+    write returns ``status="awaiting_approval"`` with the durable
+    ApprovalRequest id under ``extras["approval_request_id"]``.
+    """
+    return {
+        "status": "awaiting_approval",
+        "op_id": op_id,
+        "result": None,
+        "error": None,
+        "duration_ms": 1.0,
+        "handle": None,
+        "extras": {"approval_request_id": approval_request_id},
+    }
+
+
+def _seed_user_target_and_envs(
+    *, users: list[dict[str, Any]] | None = None
+) -> dict[str, dict[str, Any]]:
+    """Seed tenant A + a keycloak target; return the user.list envelope map."""
+    _seed_tenant(_TENANT_A, "tenant-a")
+    _seed_keycloak_target(tenant_id=_TENANT_A)
+    rows = (
+        users
+        if users is not None
+        else [
+            {
+                "id": "bbbbbbbb-bbbb-bbbb-bbbb-bbbbbbbbbbbb",
+                "username": "operator-a",
+                "email": "operator-a@example.com",
+                "enabled": True,
+                "emailVerified": True,
+            }
+        ]
+    )
+    return {"keycloak.user.list": _ok("keycloak.user.list", {"rows": rows, "total": len(rows)})}
+
+
+# ---- user list: read is operator-tier, writes soft-hidden ------------------
+
+
+def test_keycloak_ui_user_list_operator_sees_no_write_buttons(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """A plain operator renders the user list but sees NO write affordances.
+
+    Reads are operator-tier (``keycloak.user.list`` is ``safe``); the
+    create / reset / assign buttons are soft-hidden from a non-admin via the
+    ``resolve_role_probe``-driven ``is_tenant_admin`` flag.
+    """
+    received = _patch_call_operation(monkeypatch, _seed_user_target_and_envs())
+    client, mock = _client_with_role(
+        tenant_id=_TENANT_A, operator_sub=_OP_OPERATOR, role=TenantRole.OPERATOR
+    )
+    with mock:
+        response = client.get("/ui/keycloak/users")
+    assert response.status_code == 200, response.text
+    body = response.text
+    # The list renders with the projected user row.
+    assert "data-keycloak-users" in body
+    assert "operator-a" in body
+    # No write affordances for a plain operator.
+    assert "data-keycloak-user-create" not in body
+    assert "data-keycloak-reset-password" not in body
+    assert "data-keycloak-role-assign" not in body
+    # The read pinned the connector id (never the bare slug).
+    assert len(received) == 1
+    assert received[0]["connector_id"] == KEYCLOAK_CONNECTOR_ID
+    assert received[0]["op_id"] == "keycloak.user.list"
+
+
+def test_keycloak_ui_user_list_admin_sees_write_buttons(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """A tenant_admin sees the create / reset / assign affordances."""
+    _patch_call_operation(monkeypatch, _seed_user_target_and_envs())
+    client, mock = _client_with_role(
+        tenant_id=_TENANT_A, operator_sub=_OP_OPERATOR, role=TenantRole.TENANT_ADMIN
+    )
+    with mock:
+        response = client.get("/ui/keycloak/users")
+    assert response.status_code == 200, response.text
+    body = response.text
+    assert "data-keycloak-user-create" in body
+    assert "data-keycloak-reset-password" in body
+    assert "data-keycloak-role-assign" in body
+
+
+# ---- create: awaiting_approval banner + deep-link --------------------------
+
+
+def test_keycloak_ui_user_create_awaiting_approval_deep_links_to_approvals(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """A confirmed create whose dispatch returns ``awaiting_approval`` renders
+    the approval banner with the request id AND a link to ``/ui/approvals``.
+
+    The operator is never shown a silent / empty success: every keycloak
+    write is ``requires_approval=True``, so the result MUST surface the
+    parked ApprovalRequest with a deep-link into the approvals surface.
+    """
+    _seed_tenant(_TENANT_A, "tenant-a")
+    _seed_keycloak_target(tenant_id=_TENANT_A)
+    approval_id = "33333333-3333-3333-3333-333333333333"
+    received = _patch_call_operation(
+        monkeypatch,
+        {"keycloak.user.create": _awaiting_approval("keycloak.user.create", approval_id)},
+    )
+    client, mock, session_id = _client_with_role_and_session(
+        tenant_id=_TENANT_A, operator_sub=_OP_OPERATOR, role=TenantRole.TENANT_ADMIN
+    )
+    with mock:
+        response = client.post(
+            "/ui/keycloak/users/create",
+            data={
+                "target": _TARGET_NAME,
+                "representation": '{"username": "operator-a", "enabled": true}',
+                "password_secret_ref": "rdc/keycloak/operator-a",
+            },
+            **_csrf_kwargs(session_id),
+        )
+    assert response.status_code == 200, response.text
+    body = response.text
+    assert 'data-write-status="awaiting_approval"' in body
+    assert approval_id in body
+    assert f'href="/ui/approvals/{approval_id}"' in body
+    # The dispatch pinned the connector id + carried the representation.
+    assert len(received) == 1
+    assert received[0]["connector_id"] == KEYCLOAK_CONNECTOR_ID
+    assert received[0]["op_id"] == "keycloak.user.create"
+
+
+# ---- Vault-ref password, never inline --------------------------------------
+
+
+def test_keycloak_ui_user_create_password_is_vault_ref_never_inline(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """Create dispatches a ``password_secret_ref`` and NO plaintext password.
+
+    The create form exposes a Vault KV path field and no plaintext password
+    field; the dispatched params carry ``password_secret_ref`` and contain
+    no key named ``password`` / ``value`` and no plaintext secret.
+    """
+    _seed_tenant(_TENANT_A, "tenant-a")
+    _seed_keycloak_target(tenant_id=_TENANT_A)
+    received = _patch_call_operation(
+        monkeypatch,
+        {"keycloak.user.create": _awaiting_approval("keycloak.user.create", "id-1")},
+    )
+    client, mock, session_id = _client_with_role_and_session(
+        tenant_id=_TENANT_A, operator_sub=_OP_OPERATOR, role=TenantRole.TENANT_ADMIN
+    )
+    # The modal GET exposes the Vault-ref field and no plaintext password.
+    with mock:
+        modal = client.get(f"/ui/keycloak/users/create?target={_TARGET_NAME}")
+        assert modal.status_code == 200, modal.text
+        assert 'name="password_secret_ref"' in modal.text
+        assert 'name="password"' not in modal.text
+        assert 'type="password"' not in modal.text
+        # The dispatched params carry only the Vault ref, never a value.
+        response = client.post(
+            "/ui/keycloak/users/create",
+            data={
+                "target": _TARGET_NAME,
+                "representation": '{"username": "operator-a"}',
+                "password_secret_ref": "rdc/keycloak/operator-a",
+            },
+            **_csrf_kwargs(session_id),
+        )
+    assert response.status_code == 200, response.text
+    assert len(received) == 1
+    params = received[0]["params"]
+    assert params["password_secret_ref"] == "rdc/keycloak/operator-a"
+    assert "password" not in params
+    assert "value" not in params
+    # The representation carries no credentials block / plaintext secret.
+    assert "password" not in params["representation"]
+
+
+# ---- role-assign: privilege-grant confirm + CSRF ---------------------------
+
+
+def test_keycloak_ui_role_assign_modal_names_privilege_grant_and_dangerous(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """The role-assign modal names it a privilege grant + surfaces dangerous."""
+    _seed_tenant(_TENANT_A, "tenant-a")
+    _seed_keycloak_target(tenant_id=_TENANT_A)
+    user_uuid = "bbbbbbbb-bbbb-bbbb-bbbb-bbbbbbbbbbbb"
+    _patch_call_operation(
+        monkeypatch,
+        {
+            "keycloak.role_mapping.get": _ok(
+                "keycloak.role_mapping.get",
+                {"role_mappings": {"realmMappings": [{"name": "viewer"}], "clientMappings": {}}},
+            )
+        },
+    )
+    client, mock = _client_with_role(
+        tenant_id=_TENANT_A, operator_sub=_OP_OPERATOR, role=TenantRole.TENANT_ADMIN
+    )
+    with mock:
+        response = client.get(f"/ui/keycloak/users/{user_uuid}/roles/assign?target={_TARGET_NAME}")
+    assert response.status_code == 200, response.text
+    body = response.text
+    assert "data-keycloak-privilege-grant" in body
+    assert "Privilege grant" in body
+    assert "data-keycloak-safety>safety: dangerous" in body
+    # Current realm roles render for context.
+    assert "viewer" in body
+
+
+def test_keycloak_ui_role_assign_without_csrf_403_with_csrf_dispatches(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """``POST .../roles/assign`` without CSRF -> 403; with it -> dispatches.
+
+    The dispatch carries ``{"roles": [...], "id": <uuid>}`` with roles as a
+    string list, and the op id is ``keycloak.role_mapping.assign``.
+    """
+    _seed_tenant(_TENANT_A, "tenant-a")
+    _seed_keycloak_target(tenant_id=_TENANT_A)
+    user_uuid = "bbbbbbbb-bbbb-bbbb-bbbb-bbbbbbbbbbbb"
+    received = _patch_call_operation(
+        monkeypatch,
+        {
+            "keycloak.role_mapping.assign": _awaiting_approval(
+                "keycloak.role_mapping.assign", "approval-rm-1"
+            )
+        },
+    )
+    client, mock, session_id = _client_with_role_and_session(
+        tenant_id=_TENANT_A, operator_sub=_OP_OPERATOR, role=TenantRole.TENANT_ADMIN
+    )
+    with mock:
+        # No CSRF token -> the double-submit middleware rejects with 403.
+        no_csrf = client.post(
+            f"/ui/keycloak/users/{user_uuid}/roles/assign",
+            data={"target": _TARGET_NAME, "roles": ["operator", "auditor"]},
+        )
+        assert no_csrf.status_code == 403, no_csrf.text
+        assert received == []
+        # With the matching CSRF pair -> dispatches.
+        ok = client.post(
+            f"/ui/keycloak/users/{user_uuid}/roles/assign",
+            data={"target": _TARGET_NAME, "roles": ["operator", "auditor"]},
+            **_csrf_kwargs(session_id),
+        )
+    assert ok.status_code == 200, ok.text
+    assert 'data-write-status="awaiting_approval"' in ok.text
+    assert len(received) == 1
+    args = received[0]
+    assert args["op_id"] == "keycloak.role_mapping.assign"
+    assert args["connector_id"] == KEYCLOAK_CONNECTOR_ID
+    assert args["params"] == {"roles": ["operator", "auditor"], "id": user_uuid}
+
+
+# ---- RBAC: non-admin write POST hard-403s ----------------------------------
+
+
+def test_keycloak_ui_user_create_non_admin_post_is_403(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """A forged create POST from a plain operator hard-403s (server-side gate).
+
+    The soft-hide hides the button; ``_resolve_admin_or_403`` is the
+    authority -- a non-admin POST never dispatches.
+    """
+    _seed_tenant(_TENANT_A, "tenant-a")
+    _seed_keycloak_target(tenant_id=_TENANT_A)
+    received = _patch_call_operation(
+        monkeypatch,
+        {"keycloak.user.create": _awaiting_approval("keycloak.user.create", "id-x")},
+    )
+    client, mock, session_id = _client_with_role_and_session(
+        tenant_id=_TENANT_A, operator_sub=_OP_OPERATOR, role=TenantRole.OPERATOR
+    )
+    with mock:
+        response = client.post(
+            "/ui/keycloak/users/create",
+            data={
+                "target": _TARGET_NAME,
+                "representation": '{"username": "operator-a"}',
+                "password_secret_ref": "rdc/keycloak/operator-a",
+            },
+            **_csrf_kwargs(session_id),
+        )
+    assert response.status_code == 403, response.text
+    # The dispatch never happened.
+    assert received == []
+
+
+def test_keycloak_ui_reset_password_non_admin_post_is_403(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """A forged reset-password POST from a plain operator hard-403s."""
+    _seed_tenant(_TENANT_A, "tenant-a")
+    _seed_keycloak_target(tenant_id=_TENANT_A)
+    user_uuid = "bbbbbbbb-bbbb-bbbb-bbbb-bbbbbbbbbbbb"
+    received = _patch_call_operation(monkeypatch, {})
+    client, mock, session_id = _client_with_role_and_session(
+        tenant_id=_TENANT_A, operator_sub=_OP_OPERATOR, role=TenantRole.OPERATOR
+    )
+    with mock:
+        response = client.post(
+            f"/ui/keycloak/users/{user_uuid}/reset-password",
+            data={"target": _TARGET_NAME, "password_secret_ref": "rdc/keycloak/operator-a"},
+            **_csrf_kwargs(session_id),
+        )
+    assert response.status_code == 403, response.text
+    assert received == []
+
+
+def test_keycloak_ui_role_assign_non_admin_post_is_403(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """A forged role-assign POST from a plain operator hard-403s."""
+    _seed_tenant(_TENANT_A, "tenant-a")
+    _seed_keycloak_target(tenant_id=_TENANT_A)
+    user_uuid = "bbbbbbbb-bbbb-bbbb-bbbb-bbbbbbbbbbbb"
+    received = _patch_call_operation(monkeypatch, {})
+    client, mock, session_id = _client_with_role_and_session(
+        tenant_id=_TENANT_A, operator_sub=_OP_OPERATOR, role=TenantRole.OPERATOR
+    )
+    with mock:
+        response = client.post(
+            f"/ui/keycloak/users/{user_uuid}/roles/assign",
+            data={"target": _TARGET_NAME, "roles": ["operator"]},
+            **_csrf_kwargs(session_id),
+        )
+    assert response.status_code == 403, response.text
+    assert received == []
+
+
+# ---- reset-password: Vault-ref, awaiting_approval --------------------------
+
+
+def test_keycloak_ui_reset_password_vault_ref_awaiting_approval(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """Reset-password collects a Vault ref (no plaintext) + deep-links approvals."""
+    _seed_tenant(_TENANT_A, "tenant-a")
+    _seed_keycloak_target(tenant_id=_TENANT_A)
+    user_uuid = "bbbbbbbb-bbbb-bbbb-bbbb-bbbbbbbbbbbb"
+    received = _patch_call_operation(
+        monkeypatch,
+        {
+            "keycloak.user.reset_password": _awaiting_approval(
+                "keycloak.user.reset_password", "approval-rp-1"
+            )
+        },
+    )
+    client, mock, session_id = _client_with_role_and_session(
+        tenant_id=_TENANT_A, operator_sub=_OP_OPERATOR, role=TenantRole.TENANT_ADMIN
+    )
+    with mock:
+        modal = client.get(f"/ui/keycloak/users/{user_uuid}/reset-password?target={_TARGET_NAME}")
+        assert modal.status_code == 200, modal.text
+        assert 'name="password_secret_ref"' in modal.text
+        assert 'type="password"' not in modal.text
+        response = client.post(
+            f"/ui/keycloak/users/{user_uuid}/reset-password",
+            data={"target": _TARGET_NAME, "password_secret_ref": "rdc/keycloak/operator-a"},
+            **_csrf_kwargs(session_id),
+        )
+    assert response.status_code == 200, response.text
+    assert 'data-write-status="awaiting_approval"' in response.text
+    assert len(received) == 1
+    params = received[0]["params"]
+    assert params["id"] == user_uuid
+    assert params["password_secret_ref"] == "rdc/keycloak/operator-a"
+    assert "password" not in params
+    assert "value" not in params
+
+
+# ---- route order: literal users/create before users/{uuid} -----------------
+
+
+def test_keycloak_ui_user_routes_literal_before_param() -> None:
+    """The literal ``users/create`` is registered before ``users/{user_uuid}``.
+
+    First-match-wins: ``create`` must never be captured as a ``{user_uuid}``.
+    """
+    router = build_keycloak_router()
+    paths = [getattr(route, "path", None) for route in router.routes]
+    assert "/ui/keycloak/users" in paths
+    assert "/ui/keycloak/users/create" in paths
+    create_idx = paths.index("/ui/keycloak/users/create")
+    # Every parametrised user route sits after the literal create route.
+    param_paths = [p for p in paths if p and p.startswith("/ui/keycloak/users/{user_uuid}")]
+    assert param_paths, "expected at least one /ui/keycloak/users/{user_uuid} route"
+    for p in param_paths:
+        assert create_idx < paths.index(p)

--- a/cli/api/openapi.json
+++ b/cli/api/openapi.json
@@ -15291,6 +15291,365 @@
         }
       }
     },
+    "/ui/keycloak/users": {
+      "get": {
+        "tags": [
+          "ui-keycloak"
+        ],
+        "summary": "Keycloak User List",
+        "description": "Render the realm's user list (read; OPERATOR-tier).\n\nDispatches ``keycloak.user.list`` (``safety_level=\"safe\"``); an\noptional ``username`` filter maps to Keycloak's ``?username=``.\nCredential material is redacted from every row by the connector;\nthis render projects named fields only and never dumps the raw\nenvelope. The create / reset / assign affordances are soft-hidden\nfrom a plain operator (``is_tenant_admin`` from the soft-failing\nrole probe); the write POSTs are hard-gated server-side.",
+        "operationId": "keycloak_user_list_ui_keycloak_users_get",
+        "parameters": [
+          {
+            "name": "target",
+            "in": "query",
+            "required": false,
+            "schema": {
+              "type": "string",
+              "maxLength": 256,
+              "default": "",
+              "title": "Target"
+            }
+          },
+          {
+            "name": "username",
+            "in": "query",
+            "required": false,
+            "schema": {
+              "type": "string",
+              "maxLength": 512,
+              "default": "",
+              "title": "Username"
+            }
+          }
+        ],
+        "requestBody": {
+          "content": {
+            "application/json": {
+              "schema": {
+                "$ref": "#/components/schemas/UISessionContext",
+                "nullable": true,
+                "title": "Session Ctx"
+              }
+            }
+          }
+        },
+        "responses": {
+          "200": {
+            "description": "Successful Response",
+            "content": {
+              "text/html": {
+                "schema": {
+                  "type": "string"
+                }
+              }
+            }
+          },
+          "422": {
+            "description": "Validation Error",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/HTTPValidationError"
+                }
+              }
+            }
+          }
+        }
+      }
+    },
+    "/ui/keycloak/users/create": {
+      "get": {
+        "tags": [
+          "ui-keycloak"
+        ],
+        "summary": "Keycloak User Create Modal",
+        "description": "Render the create-user confirm modal (tenant_admin only).\n\nCollects a ``UserRepresentation`` JSON body + a Vault KV path for\nthe password (NO plaintext password field). Mints + re-sets the\n``meho_csrf`` cookie so the confirm button's own ``hx-headers`` echo\nlines up after the HTMX swap rotated it.",
+        "operationId": "keycloak_user_create_modal_ui_keycloak_users_create_get",
+        "parameters": [
+          {
+            "name": "target",
+            "in": "query",
+            "required": false,
+            "schema": {
+              "type": "string",
+              "maxLength": 256,
+              "default": "",
+              "title": "Target"
+            }
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "Successful Response",
+            "content": {
+              "text/html": {
+                "schema": {
+                  "type": "string"
+                }
+              }
+            }
+          },
+          "422": {
+            "description": "Validation Error",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/HTTPValidationError"
+                }
+              }
+            }
+          }
+        }
+      },
+      "post": {
+        "tags": [
+          "ui-keycloak"
+        ],
+        "summary": "Keycloak User Create",
+        "description": "Dispatch ``keycloak.user.create``; render the write result inline.\n\nCSRF-gated (a ``POST`` under ``/ui/``) and tenant_admin-gated. The\npassword is supplied as a Vault KV path only -- it never lands in\nform params, request logs, or the audit row. The op is\n``requires_approval=True``, so a clean dispatch returns\n``status=\"awaiting_approval\"`` with the approval-request deep-link.",
+        "operationId": "keycloak_user_create_ui_keycloak_users_create_post",
+        "requestBody": {
+          "content": {
+            "application/x-www-form-urlencoded": {
+              "schema": {
+                "$ref": "#/components/schemas/Body_keycloak_user_create_ui_keycloak_users_create_post"
+              }
+            }
+          }
+        },
+        "responses": {
+          "200": {
+            "description": "Successful Response",
+            "content": {
+              "text/html": {
+                "schema": {
+                  "type": "string"
+                }
+              }
+            }
+          },
+          "422": {
+            "description": "Validation Error",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/HTTPValidationError"
+                }
+              }
+            }
+          }
+        }
+      }
+    },
+    "/ui/keycloak/users/{user_uuid}/reset-password": {
+      "get": {
+        "tags": [
+          "ui-keycloak"
+        ],
+        "summary": "Keycloak User Reset Password Modal",
+        "description": "Render the reset-password confirm modal (tenant_admin only).\n\nKeyed on the user's internal UUID. Collects only a Vault KV path\n(NO plaintext password field). Mints + re-sets the ``meho_csrf``\ncookie for the confirm button's own ``hx-headers`` echo.",
+        "operationId": "keycloak_user_reset_password_modal_ui_keycloak_users__user_uuid__reset_password_get",
+        "parameters": [
+          {
+            "name": "user_uuid",
+            "in": "path",
+            "required": true,
+            "schema": {
+              "type": "string",
+              "title": "User Uuid"
+            }
+          },
+          {
+            "name": "target",
+            "in": "query",
+            "required": false,
+            "schema": {
+              "type": "string",
+              "maxLength": 256,
+              "default": "",
+              "title": "Target"
+            }
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "Successful Response",
+            "content": {
+              "text/html": {
+                "schema": {
+                  "type": "string"
+                }
+              }
+            }
+          },
+          "422": {
+            "description": "Validation Error",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/HTTPValidationError"
+                }
+              }
+            }
+          }
+        }
+      },
+      "post": {
+        "tags": [
+          "ui-keycloak"
+        ],
+        "summary": "Keycloak User Reset Password",
+        "description": "Dispatch ``keycloak.user.reset_password``; render the result inline.\n\nCSRF-gated and tenant_admin-gated. Keyed on the user UUID. The new\npassword is supplied as a Vault KV path only -- never inline. The op\nis ``requires_approval=True`` (``awaiting_approval`` deep-link).",
+        "operationId": "keycloak_user_reset_password_ui_keycloak_users__user_uuid__reset_password_post",
+        "parameters": [
+          {
+            "name": "user_uuid",
+            "in": "path",
+            "required": true,
+            "schema": {
+              "type": "string",
+              "title": "User Uuid"
+            }
+          }
+        ],
+        "requestBody": {
+          "content": {
+            "application/x-www-form-urlencoded": {
+              "schema": {
+                "$ref": "#/components/schemas/Body_keycloak_user_reset_password_ui_keycloak_users__user_uuid__reset_password_post"
+              }
+            }
+          }
+        },
+        "responses": {
+          "200": {
+            "description": "Successful Response",
+            "content": {
+              "text/html": {
+                "schema": {
+                  "type": "string"
+                }
+              }
+            }
+          },
+          "422": {
+            "description": "Validation Error",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/HTTPValidationError"
+                }
+              }
+            }
+          }
+        }
+      }
+    },
+    "/ui/keycloak/users/{user_uuid}/roles/assign": {
+      "get": {
+        "tags": [
+          "ui-keycloak"
+        ],
+        "summary": "Keycloak Role Assign Modal",
+        "description": "Render the role-assign confirm modal (tenant_admin only).\n\nA PRIVILEGE GRANT (``safety_level=\"dangerous\"``). Reads the user's\ncurrent realm/client role mappings (``keycloak.role_mapping.get``)\nfor context, then collects realm role names to grant. The confirm\nbanner names it a privilege grant and surfaces ``dangerous``.",
+        "operationId": "keycloak_role_assign_modal_ui_keycloak_users__user_uuid__roles_assign_get",
+        "parameters": [
+          {
+            "name": "user_uuid",
+            "in": "path",
+            "required": true,
+            "schema": {
+              "type": "string",
+              "title": "User Uuid"
+            }
+          },
+          {
+            "name": "target",
+            "in": "query",
+            "required": false,
+            "schema": {
+              "type": "string",
+              "maxLength": 256,
+              "default": "",
+              "title": "Target"
+            }
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "Successful Response",
+            "content": {
+              "text/html": {
+                "schema": {
+                  "type": "string"
+                }
+              }
+            }
+          },
+          "422": {
+            "description": "Validation Error",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/HTTPValidationError"
+                }
+              }
+            }
+          }
+        }
+      },
+      "post": {
+        "tags": [
+          "ui-keycloak"
+        ],
+        "summary": "Keycloak Role Assign",
+        "description": "Dispatch ``keycloak.role_mapping.assign``; render the result inline.\n\nCSRF-gated and tenant_admin-gated. A privilege grant. ``roles`` is a\nlist of realm role names (string list); the dispatched params are\n``{\"roles\": [...], \"id\": <uuid>}``. The op is\n``requires_approval=True`` (``awaiting_approval`` deep-link).",
+        "operationId": "keycloak_role_assign_ui_keycloak_users__user_uuid__roles_assign_post",
+        "parameters": [
+          {
+            "name": "user_uuid",
+            "in": "path",
+            "required": true,
+            "schema": {
+              "type": "string",
+              "title": "User Uuid"
+            }
+          }
+        ],
+        "requestBody": {
+          "content": {
+            "application/x-www-form-urlencoded": {
+              "schema": {
+                "$ref": "#/components/schemas/Body_keycloak_role_assign_ui_keycloak_users__user_uuid__roles_assign_post"
+              }
+            }
+          }
+        },
+        "responses": {
+          "200": {
+            "description": "Successful Response",
+            "content": {
+              "text/html": {
+                "schema": {
+                  "type": "string"
+                }
+              }
+            }
+          },
+          "422": {
+            "description": "Validation Error",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/HTTPValidationError"
+                }
+              }
+            }
+          }
+        }
+      }
+    },
     "/ui/keycloak/clients/{client_uuid}": {
       "get": {
         "tags": [
@@ -17412,6 +17771,101 @@
           "file"
         ],
         "title": "Body_kb_upload_single_ui_kb_upload_post"
+      },
+      "Body_keycloak_role_assign_ui_keycloak_users__user_uuid__roles_assign_post": {
+        "properties": {
+          "target": {
+            "type": "string",
+            "maxLength": 256,
+            "title": "Target",
+            "default": ""
+          },
+          "roles": {
+            "items": {
+              "type": "string"
+            },
+            "type": "array",
+            "title": "Roles"
+          }
+        },
+        "type": "object",
+        "title": "Body_keycloak_role_assign_ui_keycloak_users__user_uuid__roles_assign_post"
+      },
+      "Body_keycloak_user_create_ui_keycloak_users_create_post": {
+        "properties": {
+          "target": {
+            "type": "string",
+            "maxLength": 256,
+            "title": "Target",
+            "default": ""
+          },
+          "representation": {
+            "type": "string",
+            "maxLength": 65536,
+            "title": "Representation",
+            "default": ""
+          },
+          "password_secret_ref": {
+            "type": "string",
+            "maxLength": 512,
+            "title": "Password Secret Ref",
+            "default": ""
+          },
+          "password_secret_mount": {
+            "type": "string",
+            "maxLength": 512,
+            "title": "Password Secret Mount",
+            "default": ""
+          },
+          "password_secret_key": {
+            "type": "string",
+            "maxLength": 512,
+            "title": "Password Secret Key",
+            "default": ""
+          },
+          "temporary": {
+            "type": "boolean",
+            "title": "Temporary",
+            "default": false
+          }
+        },
+        "type": "object",
+        "title": "Body_keycloak_user_create_ui_keycloak_users_create_post"
+      },
+      "Body_keycloak_user_reset_password_ui_keycloak_users__user_uuid__reset_password_post": {
+        "properties": {
+          "target": {
+            "type": "string",
+            "maxLength": 256,
+            "title": "Target",
+            "default": ""
+          },
+          "password_secret_ref": {
+            "type": "string",
+            "maxLength": 512,
+            "title": "Password Secret Ref",
+            "default": ""
+          },
+          "password_secret_mount": {
+            "type": "string",
+            "maxLength": 512,
+            "title": "Password Secret Mount",
+            "default": ""
+          },
+          "password_secret_key": {
+            "type": "string",
+            "maxLength": 512,
+            "title": "Password Secret Key",
+            "default": ""
+          },
+          "temporary": {
+            "type": "boolean",
+            "title": "Temporary",
+            "default": false
+          }
+        },
+        "type": "object",
+        "title": "Body_keycloak_user_reset_password_ui_keycloak_users__user_uuid__reset_password_post"
       },
       "Body_operations_call_ui_operations_call_post": {
         "properties": {

--- a/cli/internal/api/client.gen.go
+++ b/cli/internal/api/client.gen.go
@@ -1251,6 +1251,31 @@ type BodyKbUploadSingleUiKbUploadPost struct {
 	Slug *string `json:"slug,omitempty"`
 }
 
+// BodyKeycloakRoleAssignUiKeycloakUsersUserUuidRolesAssignPost defines model for Body_keycloak_role_assign_ui_keycloak_users__user_uuid__roles_assign_post.
+type BodyKeycloakRoleAssignUiKeycloakUsersUserUuidRolesAssignPost struct {
+	Roles  *[]string `json:"roles,omitempty"`
+	Target *string   `json:"target,omitempty"`
+}
+
+// BodyKeycloakUserCreateUiKeycloakUsersCreatePost defines model for Body_keycloak_user_create_ui_keycloak_users_create_post.
+type BodyKeycloakUserCreateUiKeycloakUsersCreatePost struct {
+	PasswordSecretKey   *string `json:"password_secret_key,omitempty"`
+	PasswordSecretMount *string `json:"password_secret_mount,omitempty"`
+	PasswordSecretRef   *string `json:"password_secret_ref,omitempty"`
+	Representation      *string `json:"representation,omitempty"`
+	Target              *string `json:"target,omitempty"`
+	Temporary           *bool   `json:"temporary,omitempty"`
+}
+
+// BodyKeycloakUserResetPasswordUiKeycloakUsersUserUuidResetPasswordPost defines model for Body_keycloak_user_reset_password_ui_keycloak_users__user_uuid__reset_password_post.
+type BodyKeycloakUserResetPasswordUiKeycloakUsersUserUuidResetPasswordPost struct {
+	PasswordSecretKey   *string `json:"password_secret_key,omitempty"`
+	PasswordSecretMount *string `json:"password_secret_mount,omitempty"`
+	PasswordSecretRef   *string `json:"password_secret_ref,omitempty"`
+	Target              *string `json:"target,omitempty"`
+	Temporary           *bool   `json:"temporary,omitempty"`
+}
+
 // BodyOperationsCallUiOperationsCallPost defines model for Body_operations_call_ui_operations_call_post.
 type BodyOperationsCallUiOperationsCallPost struct {
 	ConnectorId string  `json:"connector_id"`
@@ -6919,6 +6944,27 @@ type KeycloakClientDetailUiKeycloakClientsClientUuidGetParams struct {
 	Target *string `form:"target,omitempty" json:"target,omitempty"`
 }
 
+// KeycloakUserListUiKeycloakUsersGetParams defines parameters for KeycloakUserListUiKeycloakUsersGet.
+type KeycloakUserListUiKeycloakUsersGetParams struct {
+	Target   *string `form:"target,omitempty" json:"target,omitempty"`
+	Username *string `form:"username,omitempty" json:"username,omitempty"`
+}
+
+// KeycloakUserCreateModalUiKeycloakUsersCreateGetParams defines parameters for KeycloakUserCreateModalUiKeycloakUsersCreateGet.
+type KeycloakUserCreateModalUiKeycloakUsersCreateGetParams struct {
+	Target *string `form:"target,omitempty" json:"target,omitempty"`
+}
+
+// KeycloakUserResetPasswordModalUiKeycloakUsersUserUuidResetPasswordGetParams defines parameters for KeycloakUserResetPasswordModalUiKeycloakUsersUserUuidResetPasswordGet.
+type KeycloakUserResetPasswordModalUiKeycloakUsersUserUuidResetPasswordGetParams struct {
+	Target *string `form:"target,omitempty" json:"target,omitempty"`
+}
+
+// KeycloakRoleAssignModalUiKeycloakUsersUserUuidRolesAssignGetParams defines parameters for KeycloakRoleAssignModalUiKeycloakUsersUserUuidRolesAssignGet.
+type KeycloakRoleAssignModalUiKeycloakUsersUserUuidRolesAssignGetParams struct {
+	Target *string `form:"target,omitempty" json:"target,omitempty"`
+}
+
 // UiMemoryListUiMemoryGetParams defines parameters for UiMemoryListUiMemoryGet.
 type UiMemoryListUiMemoryGetParams struct {
 	Scope *string `form:"scope,omitempty" json:"scope,omitempty"`
@@ -7366,6 +7412,18 @@ type KeycloakIndexUiKeycloakGetJSONRequestBody = UISessionContext
 
 // KeycloakClientDetailUiKeycloakClientsClientUuidGetJSONRequestBody defines body for KeycloakClientDetailUiKeycloakClientsClientUuidGet for application/json ContentType.
 type KeycloakClientDetailUiKeycloakClientsClientUuidGetJSONRequestBody = UISessionContext
+
+// KeycloakUserListUiKeycloakUsersGetJSONRequestBody defines body for KeycloakUserListUiKeycloakUsersGet for application/json ContentType.
+type KeycloakUserListUiKeycloakUsersGetJSONRequestBody = UISessionContext
+
+// KeycloakUserCreateUiKeycloakUsersCreatePostFormdataRequestBody defines body for KeycloakUserCreateUiKeycloakUsersCreatePost for application/x-www-form-urlencoded ContentType.
+type KeycloakUserCreateUiKeycloakUsersCreatePostFormdataRequestBody = BodyKeycloakUserCreateUiKeycloakUsersCreatePost
+
+// KeycloakUserResetPasswordUiKeycloakUsersUserUuidResetPasswordPostFormdataRequestBody defines body for KeycloakUserResetPasswordUiKeycloakUsersUserUuidResetPasswordPost for application/x-www-form-urlencoded ContentType.
+type KeycloakUserResetPasswordUiKeycloakUsersUserUuidResetPasswordPostFormdataRequestBody = BodyKeycloakUserResetPasswordUiKeycloakUsersUserUuidResetPasswordPost
+
+// KeycloakRoleAssignUiKeycloakUsersUserUuidRolesAssignPostFormdataRequestBody defines body for KeycloakRoleAssignUiKeycloakUsersUserUuidRolesAssignPost for application/x-www-form-urlencoded ContentType.
+type KeycloakRoleAssignUiKeycloakUsersUserUuidRolesAssignPostFormdataRequestBody = BodyKeycloakRoleAssignUiKeycloakUsersUserUuidRolesAssignPost
 
 // UiMemoryBulkUiMemoryBulkPostFormdataRequestBody defines body for UiMemoryBulkUiMemoryBulkPost for application/x-www-form-urlencoded ContentType.
 type UiMemoryBulkUiMemoryBulkPostFormdataRequestBody = BodyUiMemoryBulkUiMemoryBulkPost
@@ -9214,6 +9272,35 @@ type ClientInterface interface {
 	KeycloakClientDetailUiKeycloakClientsClientUuidGetWithBody(ctx context.Context, clientUuid string, params *KeycloakClientDetailUiKeycloakClientsClientUuidGetParams, contentType string, body io.Reader, reqEditors ...RequestEditorFn) (*http.Response, error)
 
 	KeycloakClientDetailUiKeycloakClientsClientUuidGet(ctx context.Context, clientUuid string, params *KeycloakClientDetailUiKeycloakClientsClientUuidGetParams, body KeycloakClientDetailUiKeycloakClientsClientUuidGetJSONRequestBody, reqEditors ...RequestEditorFn) (*http.Response, error)
+
+	// KeycloakUserListUiKeycloakUsersGetWithBody request with any body
+	KeycloakUserListUiKeycloakUsersGetWithBody(ctx context.Context, params *KeycloakUserListUiKeycloakUsersGetParams, contentType string, body io.Reader, reqEditors ...RequestEditorFn) (*http.Response, error)
+
+	KeycloakUserListUiKeycloakUsersGet(ctx context.Context, params *KeycloakUserListUiKeycloakUsersGetParams, body KeycloakUserListUiKeycloakUsersGetJSONRequestBody, reqEditors ...RequestEditorFn) (*http.Response, error)
+
+	// KeycloakUserCreateModalUiKeycloakUsersCreateGet request
+	KeycloakUserCreateModalUiKeycloakUsersCreateGet(ctx context.Context, params *KeycloakUserCreateModalUiKeycloakUsersCreateGetParams, reqEditors ...RequestEditorFn) (*http.Response, error)
+
+	// KeycloakUserCreateUiKeycloakUsersCreatePostWithBody request with any body
+	KeycloakUserCreateUiKeycloakUsersCreatePostWithBody(ctx context.Context, contentType string, body io.Reader, reqEditors ...RequestEditorFn) (*http.Response, error)
+
+	KeycloakUserCreateUiKeycloakUsersCreatePostWithFormdataBody(ctx context.Context, body KeycloakUserCreateUiKeycloakUsersCreatePostFormdataRequestBody, reqEditors ...RequestEditorFn) (*http.Response, error)
+
+	// KeycloakUserResetPasswordModalUiKeycloakUsersUserUuidResetPasswordGet request
+	KeycloakUserResetPasswordModalUiKeycloakUsersUserUuidResetPasswordGet(ctx context.Context, userUuid string, params *KeycloakUserResetPasswordModalUiKeycloakUsersUserUuidResetPasswordGetParams, reqEditors ...RequestEditorFn) (*http.Response, error)
+
+	// KeycloakUserResetPasswordUiKeycloakUsersUserUuidResetPasswordPostWithBody request with any body
+	KeycloakUserResetPasswordUiKeycloakUsersUserUuidResetPasswordPostWithBody(ctx context.Context, userUuid string, contentType string, body io.Reader, reqEditors ...RequestEditorFn) (*http.Response, error)
+
+	KeycloakUserResetPasswordUiKeycloakUsersUserUuidResetPasswordPostWithFormdataBody(ctx context.Context, userUuid string, body KeycloakUserResetPasswordUiKeycloakUsersUserUuidResetPasswordPostFormdataRequestBody, reqEditors ...RequestEditorFn) (*http.Response, error)
+
+	// KeycloakRoleAssignModalUiKeycloakUsersUserUuidRolesAssignGet request
+	KeycloakRoleAssignModalUiKeycloakUsersUserUuidRolesAssignGet(ctx context.Context, userUuid string, params *KeycloakRoleAssignModalUiKeycloakUsersUserUuidRolesAssignGetParams, reqEditors ...RequestEditorFn) (*http.Response, error)
+
+	// KeycloakRoleAssignUiKeycloakUsersUserUuidRolesAssignPostWithBody request with any body
+	KeycloakRoleAssignUiKeycloakUsersUserUuidRolesAssignPostWithBody(ctx context.Context, userUuid string, contentType string, body io.Reader, reqEditors ...RequestEditorFn) (*http.Response, error)
+
+	KeycloakRoleAssignUiKeycloakUsersUserUuidRolesAssignPostWithFormdataBody(ctx context.Context, userUuid string, body KeycloakRoleAssignUiKeycloakUsersUserUuidRolesAssignPostFormdataRequestBody, reqEditors ...RequestEditorFn) (*http.Response, error)
 
 	// UiMemoryListUiMemoryGet request
 	UiMemoryListUiMemoryGet(ctx context.Context, params *UiMemoryListUiMemoryGetParams, reqEditors ...RequestEditorFn) (*http.Response, error)
@@ -13606,6 +13693,138 @@ func (c *Client) KeycloakClientDetailUiKeycloakClientsClientUuidGetWithBody(ctx 
 
 func (c *Client) KeycloakClientDetailUiKeycloakClientsClientUuidGet(ctx context.Context, clientUuid string, params *KeycloakClientDetailUiKeycloakClientsClientUuidGetParams, body KeycloakClientDetailUiKeycloakClientsClientUuidGetJSONRequestBody, reqEditors ...RequestEditorFn) (*http.Response, error) {
 	req, err := NewKeycloakClientDetailUiKeycloakClientsClientUuidGetRequest(c.Server, clientUuid, params, body)
+	if err != nil {
+		return nil, err
+	}
+	req = req.WithContext(ctx)
+	if err := c.applyEditors(ctx, req, reqEditors); err != nil {
+		return nil, err
+	}
+	return c.Client.Do(req)
+}
+
+func (c *Client) KeycloakUserListUiKeycloakUsersGetWithBody(ctx context.Context, params *KeycloakUserListUiKeycloakUsersGetParams, contentType string, body io.Reader, reqEditors ...RequestEditorFn) (*http.Response, error) {
+	req, err := NewKeycloakUserListUiKeycloakUsersGetRequestWithBody(c.Server, params, contentType, body)
+	if err != nil {
+		return nil, err
+	}
+	req = req.WithContext(ctx)
+	if err := c.applyEditors(ctx, req, reqEditors); err != nil {
+		return nil, err
+	}
+	return c.Client.Do(req)
+}
+
+func (c *Client) KeycloakUserListUiKeycloakUsersGet(ctx context.Context, params *KeycloakUserListUiKeycloakUsersGetParams, body KeycloakUserListUiKeycloakUsersGetJSONRequestBody, reqEditors ...RequestEditorFn) (*http.Response, error) {
+	req, err := NewKeycloakUserListUiKeycloakUsersGetRequest(c.Server, params, body)
+	if err != nil {
+		return nil, err
+	}
+	req = req.WithContext(ctx)
+	if err := c.applyEditors(ctx, req, reqEditors); err != nil {
+		return nil, err
+	}
+	return c.Client.Do(req)
+}
+
+func (c *Client) KeycloakUserCreateModalUiKeycloakUsersCreateGet(ctx context.Context, params *KeycloakUserCreateModalUiKeycloakUsersCreateGetParams, reqEditors ...RequestEditorFn) (*http.Response, error) {
+	req, err := NewKeycloakUserCreateModalUiKeycloakUsersCreateGetRequest(c.Server, params)
+	if err != nil {
+		return nil, err
+	}
+	req = req.WithContext(ctx)
+	if err := c.applyEditors(ctx, req, reqEditors); err != nil {
+		return nil, err
+	}
+	return c.Client.Do(req)
+}
+
+func (c *Client) KeycloakUserCreateUiKeycloakUsersCreatePostWithBody(ctx context.Context, contentType string, body io.Reader, reqEditors ...RequestEditorFn) (*http.Response, error) {
+	req, err := NewKeycloakUserCreateUiKeycloakUsersCreatePostRequestWithBody(c.Server, contentType, body)
+	if err != nil {
+		return nil, err
+	}
+	req = req.WithContext(ctx)
+	if err := c.applyEditors(ctx, req, reqEditors); err != nil {
+		return nil, err
+	}
+	return c.Client.Do(req)
+}
+
+func (c *Client) KeycloakUserCreateUiKeycloakUsersCreatePostWithFormdataBody(ctx context.Context, body KeycloakUserCreateUiKeycloakUsersCreatePostFormdataRequestBody, reqEditors ...RequestEditorFn) (*http.Response, error) {
+	req, err := NewKeycloakUserCreateUiKeycloakUsersCreatePostRequestWithFormdataBody(c.Server, body)
+	if err != nil {
+		return nil, err
+	}
+	req = req.WithContext(ctx)
+	if err := c.applyEditors(ctx, req, reqEditors); err != nil {
+		return nil, err
+	}
+	return c.Client.Do(req)
+}
+
+func (c *Client) KeycloakUserResetPasswordModalUiKeycloakUsersUserUuidResetPasswordGet(ctx context.Context, userUuid string, params *KeycloakUserResetPasswordModalUiKeycloakUsersUserUuidResetPasswordGetParams, reqEditors ...RequestEditorFn) (*http.Response, error) {
+	req, err := NewKeycloakUserResetPasswordModalUiKeycloakUsersUserUuidResetPasswordGetRequest(c.Server, userUuid, params)
+	if err != nil {
+		return nil, err
+	}
+	req = req.WithContext(ctx)
+	if err := c.applyEditors(ctx, req, reqEditors); err != nil {
+		return nil, err
+	}
+	return c.Client.Do(req)
+}
+
+func (c *Client) KeycloakUserResetPasswordUiKeycloakUsersUserUuidResetPasswordPostWithBody(ctx context.Context, userUuid string, contentType string, body io.Reader, reqEditors ...RequestEditorFn) (*http.Response, error) {
+	req, err := NewKeycloakUserResetPasswordUiKeycloakUsersUserUuidResetPasswordPostRequestWithBody(c.Server, userUuid, contentType, body)
+	if err != nil {
+		return nil, err
+	}
+	req = req.WithContext(ctx)
+	if err := c.applyEditors(ctx, req, reqEditors); err != nil {
+		return nil, err
+	}
+	return c.Client.Do(req)
+}
+
+func (c *Client) KeycloakUserResetPasswordUiKeycloakUsersUserUuidResetPasswordPostWithFormdataBody(ctx context.Context, userUuid string, body KeycloakUserResetPasswordUiKeycloakUsersUserUuidResetPasswordPostFormdataRequestBody, reqEditors ...RequestEditorFn) (*http.Response, error) {
+	req, err := NewKeycloakUserResetPasswordUiKeycloakUsersUserUuidResetPasswordPostRequestWithFormdataBody(c.Server, userUuid, body)
+	if err != nil {
+		return nil, err
+	}
+	req = req.WithContext(ctx)
+	if err := c.applyEditors(ctx, req, reqEditors); err != nil {
+		return nil, err
+	}
+	return c.Client.Do(req)
+}
+
+func (c *Client) KeycloakRoleAssignModalUiKeycloakUsersUserUuidRolesAssignGet(ctx context.Context, userUuid string, params *KeycloakRoleAssignModalUiKeycloakUsersUserUuidRolesAssignGetParams, reqEditors ...RequestEditorFn) (*http.Response, error) {
+	req, err := NewKeycloakRoleAssignModalUiKeycloakUsersUserUuidRolesAssignGetRequest(c.Server, userUuid, params)
+	if err != nil {
+		return nil, err
+	}
+	req = req.WithContext(ctx)
+	if err := c.applyEditors(ctx, req, reqEditors); err != nil {
+		return nil, err
+	}
+	return c.Client.Do(req)
+}
+
+func (c *Client) KeycloakRoleAssignUiKeycloakUsersUserUuidRolesAssignPostWithBody(ctx context.Context, userUuid string, contentType string, body io.Reader, reqEditors ...RequestEditorFn) (*http.Response, error) {
+	req, err := NewKeycloakRoleAssignUiKeycloakUsersUserUuidRolesAssignPostRequestWithBody(c.Server, userUuid, contentType, body)
+	if err != nil {
+		return nil, err
+	}
+	req = req.WithContext(ctx)
+	if err := c.applyEditors(ctx, req, reqEditors); err != nil {
+		return nil, err
+	}
+	return c.Client.Do(req)
+}
+
+func (c *Client) KeycloakRoleAssignUiKeycloakUsersUserUuidRolesAssignPostWithFormdataBody(ctx context.Context, userUuid string, body KeycloakRoleAssignUiKeycloakUsersUserUuidRolesAssignPostFormdataRequestBody, reqEditors ...RequestEditorFn) (*http.Response, error) {
+	req, err := NewKeycloakRoleAssignUiKeycloakUsersUserUuidRolesAssignPostRequestWithFormdataBody(c.Server, userUuid, body)
 	if err != nil {
 		return nil, err
 	}
@@ -28166,6 +28385,379 @@ func NewKeycloakClientDetailUiKeycloakClientsClientUuidGetRequestWithBody(server
 	return req, nil
 }
 
+// NewKeycloakUserListUiKeycloakUsersGetRequest calls the generic KeycloakUserListUiKeycloakUsersGet builder with application/json body
+func NewKeycloakUserListUiKeycloakUsersGetRequest(server string, params *KeycloakUserListUiKeycloakUsersGetParams, body KeycloakUserListUiKeycloakUsersGetJSONRequestBody) (*http.Request, error) {
+	var bodyReader io.Reader
+	buf, err := json.Marshal(body)
+	if err != nil {
+		return nil, err
+	}
+	bodyReader = bytes.NewReader(buf)
+	return NewKeycloakUserListUiKeycloakUsersGetRequestWithBody(server, params, "application/json", bodyReader)
+}
+
+// NewKeycloakUserListUiKeycloakUsersGetRequestWithBody generates requests for KeycloakUserListUiKeycloakUsersGet with any type of body
+func NewKeycloakUserListUiKeycloakUsersGetRequestWithBody(server string, params *KeycloakUserListUiKeycloakUsersGetParams, contentType string, body io.Reader) (*http.Request, error) {
+	var err error
+
+	serverURL, err := url.Parse(server)
+	if err != nil {
+		return nil, err
+	}
+
+	operationPath := fmt.Sprintf("/ui/keycloak/users")
+	if operationPath[0] == '/' {
+		operationPath = "." + operationPath
+	}
+
+	queryURL, err := serverURL.Parse(operationPath)
+	if err != nil {
+		return nil, err
+	}
+
+	if params != nil {
+		queryValues := queryURL.Query()
+
+		if params.Target != nil {
+
+			if queryFrag, err := runtime.StyleParamWithLocation("form", true, "target", runtime.ParamLocationQuery, *params.Target); err != nil {
+				return nil, err
+			} else if parsed, err := url.ParseQuery(queryFrag); err != nil {
+				return nil, err
+			} else {
+				for k, v := range parsed {
+					for _, v2 := range v {
+						queryValues.Add(k, v2)
+					}
+				}
+			}
+
+		}
+
+		if params.Username != nil {
+
+			if queryFrag, err := runtime.StyleParamWithLocation("form", true, "username", runtime.ParamLocationQuery, *params.Username); err != nil {
+				return nil, err
+			} else if parsed, err := url.ParseQuery(queryFrag); err != nil {
+				return nil, err
+			} else {
+				for k, v := range parsed {
+					for _, v2 := range v {
+						queryValues.Add(k, v2)
+					}
+				}
+			}
+
+		}
+
+		queryURL.RawQuery = queryValues.Encode()
+	}
+
+	req, err := http.NewRequest("GET", queryURL.String(), body)
+	if err != nil {
+		return nil, err
+	}
+
+	req.Header.Add("Content-Type", contentType)
+
+	return req, nil
+}
+
+// NewKeycloakUserCreateModalUiKeycloakUsersCreateGetRequest generates requests for KeycloakUserCreateModalUiKeycloakUsersCreateGet
+func NewKeycloakUserCreateModalUiKeycloakUsersCreateGetRequest(server string, params *KeycloakUserCreateModalUiKeycloakUsersCreateGetParams) (*http.Request, error) {
+	var err error
+
+	serverURL, err := url.Parse(server)
+	if err != nil {
+		return nil, err
+	}
+
+	operationPath := fmt.Sprintf("/ui/keycloak/users/create")
+	if operationPath[0] == '/' {
+		operationPath = "." + operationPath
+	}
+
+	queryURL, err := serverURL.Parse(operationPath)
+	if err != nil {
+		return nil, err
+	}
+
+	if params != nil {
+		queryValues := queryURL.Query()
+
+		if params.Target != nil {
+
+			if queryFrag, err := runtime.StyleParamWithLocation("form", true, "target", runtime.ParamLocationQuery, *params.Target); err != nil {
+				return nil, err
+			} else if parsed, err := url.ParseQuery(queryFrag); err != nil {
+				return nil, err
+			} else {
+				for k, v := range parsed {
+					for _, v2 := range v {
+						queryValues.Add(k, v2)
+					}
+				}
+			}
+
+		}
+
+		queryURL.RawQuery = queryValues.Encode()
+	}
+
+	req, err := http.NewRequest("GET", queryURL.String(), nil)
+	if err != nil {
+		return nil, err
+	}
+
+	return req, nil
+}
+
+// NewKeycloakUserCreateUiKeycloakUsersCreatePostRequestWithFormdataBody calls the generic KeycloakUserCreateUiKeycloakUsersCreatePost builder with application/x-www-form-urlencoded body
+func NewKeycloakUserCreateUiKeycloakUsersCreatePostRequestWithFormdataBody(server string, body KeycloakUserCreateUiKeycloakUsersCreatePostFormdataRequestBody) (*http.Request, error) {
+	var bodyReader io.Reader
+	bodyStr, err := runtime.MarshalForm(body, nil)
+	if err != nil {
+		return nil, err
+	}
+	bodyReader = strings.NewReader(bodyStr.Encode())
+	return NewKeycloakUserCreateUiKeycloakUsersCreatePostRequestWithBody(server, "application/x-www-form-urlencoded", bodyReader)
+}
+
+// NewKeycloakUserCreateUiKeycloakUsersCreatePostRequestWithBody generates requests for KeycloakUserCreateUiKeycloakUsersCreatePost with any type of body
+func NewKeycloakUserCreateUiKeycloakUsersCreatePostRequestWithBody(server string, contentType string, body io.Reader) (*http.Request, error) {
+	var err error
+
+	serverURL, err := url.Parse(server)
+	if err != nil {
+		return nil, err
+	}
+
+	operationPath := fmt.Sprintf("/ui/keycloak/users/create")
+	if operationPath[0] == '/' {
+		operationPath = "." + operationPath
+	}
+
+	queryURL, err := serverURL.Parse(operationPath)
+	if err != nil {
+		return nil, err
+	}
+
+	req, err := http.NewRequest("POST", queryURL.String(), body)
+	if err != nil {
+		return nil, err
+	}
+
+	req.Header.Add("Content-Type", contentType)
+
+	return req, nil
+}
+
+// NewKeycloakUserResetPasswordModalUiKeycloakUsersUserUuidResetPasswordGetRequest generates requests for KeycloakUserResetPasswordModalUiKeycloakUsersUserUuidResetPasswordGet
+func NewKeycloakUserResetPasswordModalUiKeycloakUsersUserUuidResetPasswordGetRequest(server string, userUuid string, params *KeycloakUserResetPasswordModalUiKeycloakUsersUserUuidResetPasswordGetParams) (*http.Request, error) {
+	var err error
+
+	var pathParam0 string
+
+	pathParam0, err = runtime.StyleParamWithLocation("simple", false, "user_uuid", runtime.ParamLocationPath, userUuid)
+	if err != nil {
+		return nil, err
+	}
+
+	serverURL, err := url.Parse(server)
+	if err != nil {
+		return nil, err
+	}
+
+	operationPath := fmt.Sprintf("/ui/keycloak/users/%s/reset-password", pathParam0)
+	if operationPath[0] == '/' {
+		operationPath = "." + operationPath
+	}
+
+	queryURL, err := serverURL.Parse(operationPath)
+	if err != nil {
+		return nil, err
+	}
+
+	if params != nil {
+		queryValues := queryURL.Query()
+
+		if params.Target != nil {
+
+			if queryFrag, err := runtime.StyleParamWithLocation("form", true, "target", runtime.ParamLocationQuery, *params.Target); err != nil {
+				return nil, err
+			} else if parsed, err := url.ParseQuery(queryFrag); err != nil {
+				return nil, err
+			} else {
+				for k, v := range parsed {
+					for _, v2 := range v {
+						queryValues.Add(k, v2)
+					}
+				}
+			}
+
+		}
+
+		queryURL.RawQuery = queryValues.Encode()
+	}
+
+	req, err := http.NewRequest("GET", queryURL.String(), nil)
+	if err != nil {
+		return nil, err
+	}
+
+	return req, nil
+}
+
+// NewKeycloakUserResetPasswordUiKeycloakUsersUserUuidResetPasswordPostRequestWithFormdataBody calls the generic KeycloakUserResetPasswordUiKeycloakUsersUserUuidResetPasswordPost builder with application/x-www-form-urlencoded body
+func NewKeycloakUserResetPasswordUiKeycloakUsersUserUuidResetPasswordPostRequestWithFormdataBody(server string, userUuid string, body KeycloakUserResetPasswordUiKeycloakUsersUserUuidResetPasswordPostFormdataRequestBody) (*http.Request, error) {
+	var bodyReader io.Reader
+	bodyStr, err := runtime.MarshalForm(body, nil)
+	if err != nil {
+		return nil, err
+	}
+	bodyReader = strings.NewReader(bodyStr.Encode())
+	return NewKeycloakUserResetPasswordUiKeycloakUsersUserUuidResetPasswordPostRequestWithBody(server, userUuid, "application/x-www-form-urlencoded", bodyReader)
+}
+
+// NewKeycloakUserResetPasswordUiKeycloakUsersUserUuidResetPasswordPostRequestWithBody generates requests for KeycloakUserResetPasswordUiKeycloakUsersUserUuidResetPasswordPost with any type of body
+func NewKeycloakUserResetPasswordUiKeycloakUsersUserUuidResetPasswordPostRequestWithBody(server string, userUuid string, contentType string, body io.Reader) (*http.Request, error) {
+	var err error
+
+	var pathParam0 string
+
+	pathParam0, err = runtime.StyleParamWithLocation("simple", false, "user_uuid", runtime.ParamLocationPath, userUuid)
+	if err != nil {
+		return nil, err
+	}
+
+	serverURL, err := url.Parse(server)
+	if err != nil {
+		return nil, err
+	}
+
+	operationPath := fmt.Sprintf("/ui/keycloak/users/%s/reset-password", pathParam0)
+	if operationPath[0] == '/' {
+		operationPath = "." + operationPath
+	}
+
+	queryURL, err := serverURL.Parse(operationPath)
+	if err != nil {
+		return nil, err
+	}
+
+	req, err := http.NewRequest("POST", queryURL.String(), body)
+	if err != nil {
+		return nil, err
+	}
+
+	req.Header.Add("Content-Type", contentType)
+
+	return req, nil
+}
+
+// NewKeycloakRoleAssignModalUiKeycloakUsersUserUuidRolesAssignGetRequest generates requests for KeycloakRoleAssignModalUiKeycloakUsersUserUuidRolesAssignGet
+func NewKeycloakRoleAssignModalUiKeycloakUsersUserUuidRolesAssignGetRequest(server string, userUuid string, params *KeycloakRoleAssignModalUiKeycloakUsersUserUuidRolesAssignGetParams) (*http.Request, error) {
+	var err error
+
+	var pathParam0 string
+
+	pathParam0, err = runtime.StyleParamWithLocation("simple", false, "user_uuid", runtime.ParamLocationPath, userUuid)
+	if err != nil {
+		return nil, err
+	}
+
+	serverURL, err := url.Parse(server)
+	if err != nil {
+		return nil, err
+	}
+
+	operationPath := fmt.Sprintf("/ui/keycloak/users/%s/roles/assign", pathParam0)
+	if operationPath[0] == '/' {
+		operationPath = "." + operationPath
+	}
+
+	queryURL, err := serverURL.Parse(operationPath)
+	if err != nil {
+		return nil, err
+	}
+
+	if params != nil {
+		queryValues := queryURL.Query()
+
+		if params.Target != nil {
+
+			if queryFrag, err := runtime.StyleParamWithLocation("form", true, "target", runtime.ParamLocationQuery, *params.Target); err != nil {
+				return nil, err
+			} else if parsed, err := url.ParseQuery(queryFrag); err != nil {
+				return nil, err
+			} else {
+				for k, v := range parsed {
+					for _, v2 := range v {
+						queryValues.Add(k, v2)
+					}
+				}
+			}
+
+		}
+
+		queryURL.RawQuery = queryValues.Encode()
+	}
+
+	req, err := http.NewRequest("GET", queryURL.String(), nil)
+	if err != nil {
+		return nil, err
+	}
+
+	return req, nil
+}
+
+// NewKeycloakRoleAssignUiKeycloakUsersUserUuidRolesAssignPostRequestWithFormdataBody calls the generic KeycloakRoleAssignUiKeycloakUsersUserUuidRolesAssignPost builder with application/x-www-form-urlencoded body
+func NewKeycloakRoleAssignUiKeycloakUsersUserUuidRolesAssignPostRequestWithFormdataBody(server string, userUuid string, body KeycloakRoleAssignUiKeycloakUsersUserUuidRolesAssignPostFormdataRequestBody) (*http.Request, error) {
+	var bodyReader io.Reader
+	bodyStr, err := runtime.MarshalForm(body, nil)
+	if err != nil {
+		return nil, err
+	}
+	bodyReader = strings.NewReader(bodyStr.Encode())
+	return NewKeycloakRoleAssignUiKeycloakUsersUserUuidRolesAssignPostRequestWithBody(server, userUuid, "application/x-www-form-urlencoded", bodyReader)
+}
+
+// NewKeycloakRoleAssignUiKeycloakUsersUserUuidRolesAssignPostRequestWithBody generates requests for KeycloakRoleAssignUiKeycloakUsersUserUuidRolesAssignPost with any type of body
+func NewKeycloakRoleAssignUiKeycloakUsersUserUuidRolesAssignPostRequestWithBody(server string, userUuid string, contentType string, body io.Reader) (*http.Request, error) {
+	var err error
+
+	var pathParam0 string
+
+	pathParam0, err = runtime.StyleParamWithLocation("simple", false, "user_uuid", runtime.ParamLocationPath, userUuid)
+	if err != nil {
+		return nil, err
+	}
+
+	serverURL, err := url.Parse(server)
+	if err != nil {
+		return nil, err
+	}
+
+	operationPath := fmt.Sprintf("/ui/keycloak/users/%s/roles/assign", pathParam0)
+	if operationPath[0] == '/' {
+		operationPath = "." + operationPath
+	}
+
+	queryURL, err := serverURL.Parse(operationPath)
+	if err != nil {
+		return nil, err
+	}
+
+	req, err := http.NewRequest("POST", queryURL.String(), body)
+	if err != nil {
+		return nil, err
+	}
+
+	req.Header.Add("Content-Type", contentType)
+
+	return req, nil
+}
+
 // NewUiMemoryListUiMemoryGetRequest generates requests for UiMemoryListUiMemoryGet
 func NewUiMemoryListUiMemoryGetRequest(server string, params *UiMemoryListUiMemoryGetParams) (*http.Request, error) {
 	var err error
@@ -31595,6 +32187,35 @@ type ClientWithResponsesInterface interface {
 	KeycloakClientDetailUiKeycloakClientsClientUuidGetWithBodyWithResponse(ctx context.Context, clientUuid string, params *KeycloakClientDetailUiKeycloakClientsClientUuidGetParams, contentType string, body io.Reader, reqEditors ...RequestEditorFn) (*KeycloakClientDetailUiKeycloakClientsClientUuidGetResponse, error)
 
 	KeycloakClientDetailUiKeycloakClientsClientUuidGetWithResponse(ctx context.Context, clientUuid string, params *KeycloakClientDetailUiKeycloakClientsClientUuidGetParams, body KeycloakClientDetailUiKeycloakClientsClientUuidGetJSONRequestBody, reqEditors ...RequestEditorFn) (*KeycloakClientDetailUiKeycloakClientsClientUuidGetResponse, error)
+
+	// KeycloakUserListUiKeycloakUsersGetWithBodyWithResponse request with any body
+	KeycloakUserListUiKeycloakUsersGetWithBodyWithResponse(ctx context.Context, params *KeycloakUserListUiKeycloakUsersGetParams, contentType string, body io.Reader, reqEditors ...RequestEditorFn) (*KeycloakUserListUiKeycloakUsersGetResponse, error)
+
+	KeycloakUserListUiKeycloakUsersGetWithResponse(ctx context.Context, params *KeycloakUserListUiKeycloakUsersGetParams, body KeycloakUserListUiKeycloakUsersGetJSONRequestBody, reqEditors ...RequestEditorFn) (*KeycloakUserListUiKeycloakUsersGetResponse, error)
+
+	// KeycloakUserCreateModalUiKeycloakUsersCreateGetWithResponse request
+	KeycloakUserCreateModalUiKeycloakUsersCreateGetWithResponse(ctx context.Context, params *KeycloakUserCreateModalUiKeycloakUsersCreateGetParams, reqEditors ...RequestEditorFn) (*KeycloakUserCreateModalUiKeycloakUsersCreateGetResponse, error)
+
+	// KeycloakUserCreateUiKeycloakUsersCreatePostWithBodyWithResponse request with any body
+	KeycloakUserCreateUiKeycloakUsersCreatePostWithBodyWithResponse(ctx context.Context, contentType string, body io.Reader, reqEditors ...RequestEditorFn) (*KeycloakUserCreateUiKeycloakUsersCreatePostResponse, error)
+
+	KeycloakUserCreateUiKeycloakUsersCreatePostWithFormdataBodyWithResponse(ctx context.Context, body KeycloakUserCreateUiKeycloakUsersCreatePostFormdataRequestBody, reqEditors ...RequestEditorFn) (*KeycloakUserCreateUiKeycloakUsersCreatePostResponse, error)
+
+	// KeycloakUserResetPasswordModalUiKeycloakUsersUserUuidResetPasswordGetWithResponse request
+	KeycloakUserResetPasswordModalUiKeycloakUsersUserUuidResetPasswordGetWithResponse(ctx context.Context, userUuid string, params *KeycloakUserResetPasswordModalUiKeycloakUsersUserUuidResetPasswordGetParams, reqEditors ...RequestEditorFn) (*KeycloakUserResetPasswordModalUiKeycloakUsersUserUuidResetPasswordGetResponse, error)
+
+	// KeycloakUserResetPasswordUiKeycloakUsersUserUuidResetPasswordPostWithBodyWithResponse request with any body
+	KeycloakUserResetPasswordUiKeycloakUsersUserUuidResetPasswordPostWithBodyWithResponse(ctx context.Context, userUuid string, contentType string, body io.Reader, reqEditors ...RequestEditorFn) (*KeycloakUserResetPasswordUiKeycloakUsersUserUuidResetPasswordPostResponse, error)
+
+	KeycloakUserResetPasswordUiKeycloakUsersUserUuidResetPasswordPostWithFormdataBodyWithResponse(ctx context.Context, userUuid string, body KeycloakUserResetPasswordUiKeycloakUsersUserUuidResetPasswordPostFormdataRequestBody, reqEditors ...RequestEditorFn) (*KeycloakUserResetPasswordUiKeycloakUsersUserUuidResetPasswordPostResponse, error)
+
+	// KeycloakRoleAssignModalUiKeycloakUsersUserUuidRolesAssignGetWithResponse request
+	KeycloakRoleAssignModalUiKeycloakUsersUserUuidRolesAssignGetWithResponse(ctx context.Context, userUuid string, params *KeycloakRoleAssignModalUiKeycloakUsersUserUuidRolesAssignGetParams, reqEditors ...RequestEditorFn) (*KeycloakRoleAssignModalUiKeycloakUsersUserUuidRolesAssignGetResponse, error)
+
+	// KeycloakRoleAssignUiKeycloakUsersUserUuidRolesAssignPostWithBodyWithResponse request with any body
+	KeycloakRoleAssignUiKeycloakUsersUserUuidRolesAssignPostWithBodyWithResponse(ctx context.Context, userUuid string, contentType string, body io.Reader, reqEditors ...RequestEditorFn) (*KeycloakRoleAssignUiKeycloakUsersUserUuidRolesAssignPostResponse, error)
+
+	KeycloakRoleAssignUiKeycloakUsersUserUuidRolesAssignPostWithFormdataBodyWithResponse(ctx context.Context, userUuid string, body KeycloakRoleAssignUiKeycloakUsersUserUuidRolesAssignPostFormdataRequestBody, reqEditors ...RequestEditorFn) (*KeycloakRoleAssignUiKeycloakUsersUserUuidRolesAssignPostResponse, error)
 
 	// UiMemoryListUiMemoryGetWithResponse request
 	UiMemoryListUiMemoryGetWithResponse(ctx context.Context, params *UiMemoryListUiMemoryGetParams, reqEditors ...RequestEditorFn) (*UiMemoryListUiMemoryGetResponse, error)
@@ -37017,6 +37638,160 @@ func (r KeycloakClientDetailUiKeycloakClientsClientUuidGetResponse) StatusCode()
 	return 0
 }
 
+type KeycloakUserListUiKeycloakUsersGetResponse struct {
+	Body         []byte
+	HTTPResponse *http.Response
+	JSON422      *HTTPValidationError
+}
+
+// Status returns HTTPResponse.Status
+func (r KeycloakUserListUiKeycloakUsersGetResponse) Status() string {
+	if r.HTTPResponse != nil {
+		return r.HTTPResponse.Status
+	}
+	return http.StatusText(0)
+}
+
+// StatusCode returns HTTPResponse.StatusCode
+func (r KeycloakUserListUiKeycloakUsersGetResponse) StatusCode() int {
+	if r.HTTPResponse != nil {
+		return r.HTTPResponse.StatusCode
+	}
+	return 0
+}
+
+type KeycloakUserCreateModalUiKeycloakUsersCreateGetResponse struct {
+	Body         []byte
+	HTTPResponse *http.Response
+	JSON422      *HTTPValidationError
+}
+
+// Status returns HTTPResponse.Status
+func (r KeycloakUserCreateModalUiKeycloakUsersCreateGetResponse) Status() string {
+	if r.HTTPResponse != nil {
+		return r.HTTPResponse.Status
+	}
+	return http.StatusText(0)
+}
+
+// StatusCode returns HTTPResponse.StatusCode
+func (r KeycloakUserCreateModalUiKeycloakUsersCreateGetResponse) StatusCode() int {
+	if r.HTTPResponse != nil {
+		return r.HTTPResponse.StatusCode
+	}
+	return 0
+}
+
+type KeycloakUserCreateUiKeycloakUsersCreatePostResponse struct {
+	Body         []byte
+	HTTPResponse *http.Response
+	JSON422      *HTTPValidationError
+}
+
+// Status returns HTTPResponse.Status
+func (r KeycloakUserCreateUiKeycloakUsersCreatePostResponse) Status() string {
+	if r.HTTPResponse != nil {
+		return r.HTTPResponse.Status
+	}
+	return http.StatusText(0)
+}
+
+// StatusCode returns HTTPResponse.StatusCode
+func (r KeycloakUserCreateUiKeycloakUsersCreatePostResponse) StatusCode() int {
+	if r.HTTPResponse != nil {
+		return r.HTTPResponse.StatusCode
+	}
+	return 0
+}
+
+type KeycloakUserResetPasswordModalUiKeycloakUsersUserUuidResetPasswordGetResponse struct {
+	Body         []byte
+	HTTPResponse *http.Response
+	JSON422      *HTTPValidationError
+}
+
+// Status returns HTTPResponse.Status
+func (r KeycloakUserResetPasswordModalUiKeycloakUsersUserUuidResetPasswordGetResponse) Status() string {
+	if r.HTTPResponse != nil {
+		return r.HTTPResponse.Status
+	}
+	return http.StatusText(0)
+}
+
+// StatusCode returns HTTPResponse.StatusCode
+func (r KeycloakUserResetPasswordModalUiKeycloakUsersUserUuidResetPasswordGetResponse) StatusCode() int {
+	if r.HTTPResponse != nil {
+		return r.HTTPResponse.StatusCode
+	}
+	return 0
+}
+
+type KeycloakUserResetPasswordUiKeycloakUsersUserUuidResetPasswordPostResponse struct {
+	Body         []byte
+	HTTPResponse *http.Response
+	JSON422      *HTTPValidationError
+}
+
+// Status returns HTTPResponse.Status
+func (r KeycloakUserResetPasswordUiKeycloakUsersUserUuidResetPasswordPostResponse) Status() string {
+	if r.HTTPResponse != nil {
+		return r.HTTPResponse.Status
+	}
+	return http.StatusText(0)
+}
+
+// StatusCode returns HTTPResponse.StatusCode
+func (r KeycloakUserResetPasswordUiKeycloakUsersUserUuidResetPasswordPostResponse) StatusCode() int {
+	if r.HTTPResponse != nil {
+		return r.HTTPResponse.StatusCode
+	}
+	return 0
+}
+
+type KeycloakRoleAssignModalUiKeycloakUsersUserUuidRolesAssignGetResponse struct {
+	Body         []byte
+	HTTPResponse *http.Response
+	JSON422      *HTTPValidationError
+}
+
+// Status returns HTTPResponse.Status
+func (r KeycloakRoleAssignModalUiKeycloakUsersUserUuidRolesAssignGetResponse) Status() string {
+	if r.HTTPResponse != nil {
+		return r.HTTPResponse.Status
+	}
+	return http.StatusText(0)
+}
+
+// StatusCode returns HTTPResponse.StatusCode
+func (r KeycloakRoleAssignModalUiKeycloakUsersUserUuidRolesAssignGetResponse) StatusCode() int {
+	if r.HTTPResponse != nil {
+		return r.HTTPResponse.StatusCode
+	}
+	return 0
+}
+
+type KeycloakRoleAssignUiKeycloakUsersUserUuidRolesAssignPostResponse struct {
+	Body         []byte
+	HTTPResponse *http.Response
+	JSON422      *HTTPValidationError
+}
+
+// Status returns HTTPResponse.Status
+func (r KeycloakRoleAssignUiKeycloakUsersUserUuidRolesAssignPostResponse) Status() string {
+	if r.HTTPResponse != nil {
+		return r.HTTPResponse.Status
+	}
+	return http.StatusText(0)
+}
+
+// StatusCode returns HTTPResponse.StatusCode
+func (r KeycloakRoleAssignUiKeycloakUsersUserUuidRolesAssignPostResponse) StatusCode() int {
+	if r.HTTPResponse != nil {
+		return r.HTTPResponse.StatusCode
+	}
+	return 0
+}
+
 type UiMemoryListUiMemoryGetResponse struct {
 	Body         []byte
 	HTTPResponse *http.Response
@@ -41131,6 +41906,101 @@ func (c *ClientWithResponses) KeycloakClientDetailUiKeycloakClientsClientUuidGet
 		return nil, err
 	}
 	return ParseKeycloakClientDetailUiKeycloakClientsClientUuidGetResponse(rsp)
+}
+
+// KeycloakUserListUiKeycloakUsersGetWithBodyWithResponse request with arbitrary body returning *KeycloakUserListUiKeycloakUsersGetResponse
+func (c *ClientWithResponses) KeycloakUserListUiKeycloakUsersGetWithBodyWithResponse(ctx context.Context, params *KeycloakUserListUiKeycloakUsersGetParams, contentType string, body io.Reader, reqEditors ...RequestEditorFn) (*KeycloakUserListUiKeycloakUsersGetResponse, error) {
+	rsp, err := c.KeycloakUserListUiKeycloakUsersGetWithBody(ctx, params, contentType, body, reqEditors...)
+	if err != nil {
+		return nil, err
+	}
+	return ParseKeycloakUserListUiKeycloakUsersGetResponse(rsp)
+}
+
+func (c *ClientWithResponses) KeycloakUserListUiKeycloakUsersGetWithResponse(ctx context.Context, params *KeycloakUserListUiKeycloakUsersGetParams, body KeycloakUserListUiKeycloakUsersGetJSONRequestBody, reqEditors ...RequestEditorFn) (*KeycloakUserListUiKeycloakUsersGetResponse, error) {
+	rsp, err := c.KeycloakUserListUiKeycloakUsersGet(ctx, params, body, reqEditors...)
+	if err != nil {
+		return nil, err
+	}
+	return ParseKeycloakUserListUiKeycloakUsersGetResponse(rsp)
+}
+
+// KeycloakUserCreateModalUiKeycloakUsersCreateGetWithResponse request returning *KeycloakUserCreateModalUiKeycloakUsersCreateGetResponse
+func (c *ClientWithResponses) KeycloakUserCreateModalUiKeycloakUsersCreateGetWithResponse(ctx context.Context, params *KeycloakUserCreateModalUiKeycloakUsersCreateGetParams, reqEditors ...RequestEditorFn) (*KeycloakUserCreateModalUiKeycloakUsersCreateGetResponse, error) {
+	rsp, err := c.KeycloakUserCreateModalUiKeycloakUsersCreateGet(ctx, params, reqEditors...)
+	if err != nil {
+		return nil, err
+	}
+	return ParseKeycloakUserCreateModalUiKeycloakUsersCreateGetResponse(rsp)
+}
+
+// KeycloakUserCreateUiKeycloakUsersCreatePostWithBodyWithResponse request with arbitrary body returning *KeycloakUserCreateUiKeycloakUsersCreatePostResponse
+func (c *ClientWithResponses) KeycloakUserCreateUiKeycloakUsersCreatePostWithBodyWithResponse(ctx context.Context, contentType string, body io.Reader, reqEditors ...RequestEditorFn) (*KeycloakUserCreateUiKeycloakUsersCreatePostResponse, error) {
+	rsp, err := c.KeycloakUserCreateUiKeycloakUsersCreatePostWithBody(ctx, contentType, body, reqEditors...)
+	if err != nil {
+		return nil, err
+	}
+	return ParseKeycloakUserCreateUiKeycloakUsersCreatePostResponse(rsp)
+}
+
+func (c *ClientWithResponses) KeycloakUserCreateUiKeycloakUsersCreatePostWithFormdataBodyWithResponse(ctx context.Context, body KeycloakUserCreateUiKeycloakUsersCreatePostFormdataRequestBody, reqEditors ...RequestEditorFn) (*KeycloakUserCreateUiKeycloakUsersCreatePostResponse, error) {
+	rsp, err := c.KeycloakUserCreateUiKeycloakUsersCreatePostWithFormdataBody(ctx, body, reqEditors...)
+	if err != nil {
+		return nil, err
+	}
+	return ParseKeycloakUserCreateUiKeycloakUsersCreatePostResponse(rsp)
+}
+
+// KeycloakUserResetPasswordModalUiKeycloakUsersUserUuidResetPasswordGetWithResponse request returning *KeycloakUserResetPasswordModalUiKeycloakUsersUserUuidResetPasswordGetResponse
+func (c *ClientWithResponses) KeycloakUserResetPasswordModalUiKeycloakUsersUserUuidResetPasswordGetWithResponse(ctx context.Context, userUuid string, params *KeycloakUserResetPasswordModalUiKeycloakUsersUserUuidResetPasswordGetParams, reqEditors ...RequestEditorFn) (*KeycloakUserResetPasswordModalUiKeycloakUsersUserUuidResetPasswordGetResponse, error) {
+	rsp, err := c.KeycloakUserResetPasswordModalUiKeycloakUsersUserUuidResetPasswordGet(ctx, userUuid, params, reqEditors...)
+	if err != nil {
+		return nil, err
+	}
+	return ParseKeycloakUserResetPasswordModalUiKeycloakUsersUserUuidResetPasswordGetResponse(rsp)
+}
+
+// KeycloakUserResetPasswordUiKeycloakUsersUserUuidResetPasswordPostWithBodyWithResponse request with arbitrary body returning *KeycloakUserResetPasswordUiKeycloakUsersUserUuidResetPasswordPostResponse
+func (c *ClientWithResponses) KeycloakUserResetPasswordUiKeycloakUsersUserUuidResetPasswordPostWithBodyWithResponse(ctx context.Context, userUuid string, contentType string, body io.Reader, reqEditors ...RequestEditorFn) (*KeycloakUserResetPasswordUiKeycloakUsersUserUuidResetPasswordPostResponse, error) {
+	rsp, err := c.KeycloakUserResetPasswordUiKeycloakUsersUserUuidResetPasswordPostWithBody(ctx, userUuid, contentType, body, reqEditors...)
+	if err != nil {
+		return nil, err
+	}
+	return ParseKeycloakUserResetPasswordUiKeycloakUsersUserUuidResetPasswordPostResponse(rsp)
+}
+
+func (c *ClientWithResponses) KeycloakUserResetPasswordUiKeycloakUsersUserUuidResetPasswordPostWithFormdataBodyWithResponse(ctx context.Context, userUuid string, body KeycloakUserResetPasswordUiKeycloakUsersUserUuidResetPasswordPostFormdataRequestBody, reqEditors ...RequestEditorFn) (*KeycloakUserResetPasswordUiKeycloakUsersUserUuidResetPasswordPostResponse, error) {
+	rsp, err := c.KeycloakUserResetPasswordUiKeycloakUsersUserUuidResetPasswordPostWithFormdataBody(ctx, userUuid, body, reqEditors...)
+	if err != nil {
+		return nil, err
+	}
+	return ParseKeycloakUserResetPasswordUiKeycloakUsersUserUuidResetPasswordPostResponse(rsp)
+}
+
+// KeycloakRoleAssignModalUiKeycloakUsersUserUuidRolesAssignGetWithResponse request returning *KeycloakRoleAssignModalUiKeycloakUsersUserUuidRolesAssignGetResponse
+func (c *ClientWithResponses) KeycloakRoleAssignModalUiKeycloakUsersUserUuidRolesAssignGetWithResponse(ctx context.Context, userUuid string, params *KeycloakRoleAssignModalUiKeycloakUsersUserUuidRolesAssignGetParams, reqEditors ...RequestEditorFn) (*KeycloakRoleAssignModalUiKeycloakUsersUserUuidRolesAssignGetResponse, error) {
+	rsp, err := c.KeycloakRoleAssignModalUiKeycloakUsersUserUuidRolesAssignGet(ctx, userUuid, params, reqEditors...)
+	if err != nil {
+		return nil, err
+	}
+	return ParseKeycloakRoleAssignModalUiKeycloakUsersUserUuidRolesAssignGetResponse(rsp)
+}
+
+// KeycloakRoleAssignUiKeycloakUsersUserUuidRolesAssignPostWithBodyWithResponse request with arbitrary body returning *KeycloakRoleAssignUiKeycloakUsersUserUuidRolesAssignPostResponse
+func (c *ClientWithResponses) KeycloakRoleAssignUiKeycloakUsersUserUuidRolesAssignPostWithBodyWithResponse(ctx context.Context, userUuid string, contentType string, body io.Reader, reqEditors ...RequestEditorFn) (*KeycloakRoleAssignUiKeycloakUsersUserUuidRolesAssignPostResponse, error) {
+	rsp, err := c.KeycloakRoleAssignUiKeycloakUsersUserUuidRolesAssignPostWithBody(ctx, userUuid, contentType, body, reqEditors...)
+	if err != nil {
+		return nil, err
+	}
+	return ParseKeycloakRoleAssignUiKeycloakUsersUserUuidRolesAssignPostResponse(rsp)
+}
+
+func (c *ClientWithResponses) KeycloakRoleAssignUiKeycloakUsersUserUuidRolesAssignPostWithFormdataBodyWithResponse(ctx context.Context, userUuid string, body KeycloakRoleAssignUiKeycloakUsersUserUuidRolesAssignPostFormdataRequestBody, reqEditors ...RequestEditorFn) (*KeycloakRoleAssignUiKeycloakUsersUserUuidRolesAssignPostResponse, error) {
+	rsp, err := c.KeycloakRoleAssignUiKeycloakUsersUserUuidRolesAssignPostWithFormdataBody(ctx, userUuid, body, reqEditors...)
+	if err != nil {
+		return nil, err
+	}
+	return ParseKeycloakRoleAssignUiKeycloakUsersUserUuidRolesAssignPostResponse(rsp)
 }
 
 // UiMemoryListUiMemoryGetWithResponse request returning *UiMemoryListUiMemoryGetResponse
@@ -48465,6 +49335,188 @@ func ParseKeycloakClientDetailUiKeycloakClientsClientUuidGetResponse(rsp *http.R
 	}
 
 	response := &KeycloakClientDetailUiKeycloakClientsClientUuidGetResponse{
+		Body:         bodyBytes,
+		HTTPResponse: rsp,
+	}
+
+	switch {
+	case strings.Contains(rsp.Header.Get("Content-Type"), "json") && rsp.StatusCode == 422:
+		var dest HTTPValidationError
+		if err := json.Unmarshal(bodyBytes, &dest); err != nil {
+			return nil, err
+		}
+		response.JSON422 = &dest
+
+	}
+
+	return response, nil
+}
+
+// ParseKeycloakUserListUiKeycloakUsersGetResponse parses an HTTP response from a KeycloakUserListUiKeycloakUsersGetWithResponse call
+func ParseKeycloakUserListUiKeycloakUsersGetResponse(rsp *http.Response) (*KeycloakUserListUiKeycloakUsersGetResponse, error) {
+	bodyBytes, err := io.ReadAll(rsp.Body)
+	defer func() { _ = rsp.Body.Close() }()
+	if err != nil {
+		return nil, err
+	}
+
+	response := &KeycloakUserListUiKeycloakUsersGetResponse{
+		Body:         bodyBytes,
+		HTTPResponse: rsp,
+	}
+
+	switch {
+	case strings.Contains(rsp.Header.Get("Content-Type"), "json") && rsp.StatusCode == 422:
+		var dest HTTPValidationError
+		if err := json.Unmarshal(bodyBytes, &dest); err != nil {
+			return nil, err
+		}
+		response.JSON422 = &dest
+
+	}
+
+	return response, nil
+}
+
+// ParseKeycloakUserCreateModalUiKeycloakUsersCreateGetResponse parses an HTTP response from a KeycloakUserCreateModalUiKeycloakUsersCreateGetWithResponse call
+func ParseKeycloakUserCreateModalUiKeycloakUsersCreateGetResponse(rsp *http.Response) (*KeycloakUserCreateModalUiKeycloakUsersCreateGetResponse, error) {
+	bodyBytes, err := io.ReadAll(rsp.Body)
+	defer func() { _ = rsp.Body.Close() }()
+	if err != nil {
+		return nil, err
+	}
+
+	response := &KeycloakUserCreateModalUiKeycloakUsersCreateGetResponse{
+		Body:         bodyBytes,
+		HTTPResponse: rsp,
+	}
+
+	switch {
+	case strings.Contains(rsp.Header.Get("Content-Type"), "json") && rsp.StatusCode == 422:
+		var dest HTTPValidationError
+		if err := json.Unmarshal(bodyBytes, &dest); err != nil {
+			return nil, err
+		}
+		response.JSON422 = &dest
+
+	}
+
+	return response, nil
+}
+
+// ParseKeycloakUserCreateUiKeycloakUsersCreatePostResponse parses an HTTP response from a KeycloakUserCreateUiKeycloakUsersCreatePostWithResponse call
+func ParseKeycloakUserCreateUiKeycloakUsersCreatePostResponse(rsp *http.Response) (*KeycloakUserCreateUiKeycloakUsersCreatePostResponse, error) {
+	bodyBytes, err := io.ReadAll(rsp.Body)
+	defer func() { _ = rsp.Body.Close() }()
+	if err != nil {
+		return nil, err
+	}
+
+	response := &KeycloakUserCreateUiKeycloakUsersCreatePostResponse{
+		Body:         bodyBytes,
+		HTTPResponse: rsp,
+	}
+
+	switch {
+	case strings.Contains(rsp.Header.Get("Content-Type"), "json") && rsp.StatusCode == 422:
+		var dest HTTPValidationError
+		if err := json.Unmarshal(bodyBytes, &dest); err != nil {
+			return nil, err
+		}
+		response.JSON422 = &dest
+
+	}
+
+	return response, nil
+}
+
+// ParseKeycloakUserResetPasswordModalUiKeycloakUsersUserUuidResetPasswordGetResponse parses an HTTP response from a KeycloakUserResetPasswordModalUiKeycloakUsersUserUuidResetPasswordGetWithResponse call
+func ParseKeycloakUserResetPasswordModalUiKeycloakUsersUserUuidResetPasswordGetResponse(rsp *http.Response) (*KeycloakUserResetPasswordModalUiKeycloakUsersUserUuidResetPasswordGetResponse, error) {
+	bodyBytes, err := io.ReadAll(rsp.Body)
+	defer func() { _ = rsp.Body.Close() }()
+	if err != nil {
+		return nil, err
+	}
+
+	response := &KeycloakUserResetPasswordModalUiKeycloakUsersUserUuidResetPasswordGetResponse{
+		Body:         bodyBytes,
+		HTTPResponse: rsp,
+	}
+
+	switch {
+	case strings.Contains(rsp.Header.Get("Content-Type"), "json") && rsp.StatusCode == 422:
+		var dest HTTPValidationError
+		if err := json.Unmarshal(bodyBytes, &dest); err != nil {
+			return nil, err
+		}
+		response.JSON422 = &dest
+
+	}
+
+	return response, nil
+}
+
+// ParseKeycloakUserResetPasswordUiKeycloakUsersUserUuidResetPasswordPostResponse parses an HTTP response from a KeycloakUserResetPasswordUiKeycloakUsersUserUuidResetPasswordPostWithResponse call
+func ParseKeycloakUserResetPasswordUiKeycloakUsersUserUuidResetPasswordPostResponse(rsp *http.Response) (*KeycloakUserResetPasswordUiKeycloakUsersUserUuidResetPasswordPostResponse, error) {
+	bodyBytes, err := io.ReadAll(rsp.Body)
+	defer func() { _ = rsp.Body.Close() }()
+	if err != nil {
+		return nil, err
+	}
+
+	response := &KeycloakUserResetPasswordUiKeycloakUsersUserUuidResetPasswordPostResponse{
+		Body:         bodyBytes,
+		HTTPResponse: rsp,
+	}
+
+	switch {
+	case strings.Contains(rsp.Header.Get("Content-Type"), "json") && rsp.StatusCode == 422:
+		var dest HTTPValidationError
+		if err := json.Unmarshal(bodyBytes, &dest); err != nil {
+			return nil, err
+		}
+		response.JSON422 = &dest
+
+	}
+
+	return response, nil
+}
+
+// ParseKeycloakRoleAssignModalUiKeycloakUsersUserUuidRolesAssignGetResponse parses an HTTP response from a KeycloakRoleAssignModalUiKeycloakUsersUserUuidRolesAssignGetWithResponse call
+func ParseKeycloakRoleAssignModalUiKeycloakUsersUserUuidRolesAssignGetResponse(rsp *http.Response) (*KeycloakRoleAssignModalUiKeycloakUsersUserUuidRolesAssignGetResponse, error) {
+	bodyBytes, err := io.ReadAll(rsp.Body)
+	defer func() { _ = rsp.Body.Close() }()
+	if err != nil {
+		return nil, err
+	}
+
+	response := &KeycloakRoleAssignModalUiKeycloakUsersUserUuidRolesAssignGetResponse{
+		Body:         bodyBytes,
+		HTTPResponse: rsp,
+	}
+
+	switch {
+	case strings.Contains(rsp.Header.Get("Content-Type"), "json") && rsp.StatusCode == 422:
+		var dest HTTPValidationError
+		if err := json.Unmarshal(bodyBytes, &dest); err != nil {
+			return nil, err
+		}
+		response.JSON422 = &dest
+
+	}
+
+	return response, nil
+}
+
+// ParseKeycloakRoleAssignUiKeycloakUsersUserUuidRolesAssignPostResponse parses an HTTP response from a KeycloakRoleAssignUiKeycloakUsersUserUuidRolesAssignPostWithResponse call
+func ParseKeycloakRoleAssignUiKeycloakUsersUserUuidRolesAssignPostResponse(rsp *http.Response) (*KeycloakRoleAssignUiKeycloakUsersUserUuidRolesAssignPostResponse, error) {
+	bodyBytes, err := io.ReadAll(rsp.Body)
+	defer func() { _ = rsp.Body.Close() }()
+	if err != nil {
+		return nil, err
+	}
+
+	response := &KeycloakRoleAssignUiKeycloakUsersUserUuidRolesAssignPostResponse{
 		Body:         bodyBytes,
 		HTTPResponse: rsp,
 	}

--- a/docs/codebase/ui-keycloak-console.md
+++ b/docs/codebase/ui-keycloak-console.md
@@ -1,22 +1,59 @@
-# `ui/routes/keycloak` — the read-only Keycloak realm browser
+# `ui/routes/keycloak` — the Keycloak realm browser + user management
 
 Initiative [#1943](https://github.com/evoila/meho/issues/1943) (G10.x
-Keycloak console), Task [#1959](https://github.com/evoila/meho/issues/1959)
-(T1). The read-only scaffold the two write tasks (T2 user management, T3
-scope/mapper management) build on. It gives an operator a domain-shaped
-view of the managed Keycloak realm — realm configuration, clients (with a
-per-client detail drill-in), and client scopes — directly in the operator
-console, where before the only way to read realm config from MEHO was the
+Keycloak console), Tasks
+[#1959](https://github.com/evoila/meho/issues/1959) (T1, read-only
+scaffold) and [#1960](https://github.com/evoila/meho/issues/1960) (T2, user
+management). It gives an operator a domain-shaped view of the managed
+Keycloak realm — realm configuration, clients (with a per-client detail
+drill-in), and client scopes — plus the day-to-day human-user admin
+(list / create / reset-password / role-assign), directly in the operator
+console, where before the only way to do this from MEHO was the
 `meho keycloak ...` CLI.
 
 ## Overview
 
-Two routes, both `require_ui_session`-gated (GET reads need no CSRF):
+Reads are `require_ui_session`-gated only (GET reads need no CSRF); every
+write is CSRF-gated by the `ui/csrf.py` double-submit middleware AND
+hard-gated to `tenant_admin`:
 
 | Method · path | Role | Purpose |
 |---|---|---|
 | `GET /ui/keycloak` | operator | Full-page realm browser: a tenant-scoped target picker + realm-config card + client list + client-scope list. |
 | `GET /ui/keycloak/clients/{client_uuid}` | operator | Client-detail fragment (HTMX-swapped into a drawer container), keyed on the client's **internal UUID**. |
+| `GET /ui/keycloak/users` | operator | Full-page user list (`keycloak.user.list`, `safe`) + optional `?username=` filter. Write affordances soft-hidden from non-admins. |
+| `GET /ui/keycloak/users/create` | tenant_admin | Create-user confirm modal (CSRF token minted + cookie re-set). |
+| `POST /ui/keycloak/users/create` | tenant_admin | Dispatch `keycloak.user.create` (`caution`, requires approval). |
+| `GET /ui/keycloak/users/{user_uuid}/reset-password` | tenant_admin | Reset-password confirm modal. |
+| `POST /ui/keycloak/users/{user_uuid}/reset-password` | tenant_admin | Dispatch `keycloak.user.reset_password` (`caution`, requires approval). |
+| `GET /ui/keycloak/users/{user_uuid}/roles/assign` | tenant_admin | Role-assign confirm modal (a **privilege grant**; reads current roles via `keycloak.role_mapping.get`). |
+| `POST /ui/keycloak/users/{user_uuid}/roles/assign` | tenant_admin | Dispatch `keycloak.role_mapping.assign` (`dangerous`, requires approval). |
+
+## User management writes — confirm, approval handoff, Vault-ref passwords
+
+The three writes (create / reset-password / role-assign) share one
+contract. Each renders an **unmissable confirm** modal before the POST; the
+confirm button carries the OWASP signed double-submit CSRF token on its own
+form's `hx-headers` (HTMX does **not** inherit `hx-headers` to children),
+and `hx-disabled-elt` blocks a double-fire. Every write op is registered
+`requires_approval=True`, so the dispatcher's policy gate routes a confirmed
+write to `status="awaiting_approval"` with `extras["approval_request_id"]`
+rather than executing immediately. The shared `_write_result.html` fragment
+surfaces that id with a **deep-link into `/ui/approvals`** — without it the
+operator would think the write silently no-op'd.
+
+Passwords are **Vault-ref, never inline**. The create and reset-password
+forms collect a Vault KV path (`password_secret_ref` + optional
+`password_secret_mount` / `password_secret_key` / `temporary`) and have **no
+plaintext password field**. The backend reads the password from Vault at
+dispatch time; the value never lands in form params, request logs, or the
+audit row — mirroring the CLI's `passwordSecretFlags` bundle.
+
+Role-assign is the **highest-blast** write: granting a realm role widens the
+user's authority, so it is `safety_level="dangerous"` and the confirm banner
+names it a privilege grant explicitly. `roles` is a string list of realm
+role names; the dispatch params are `{"roles": [...], "id": <uuid>}` (the
+grant is idempotent server-side).
 
 ## Control flow
 
@@ -70,14 +107,24 @@ mappers, …) and never dump the verbatim `OperationResult` blob into the
 page — so a future op that forgot to scrub a field cannot leak it through
 a raw-blob render here.
 
-## RBAC: reads are operator-tier
+## RBAC: reads operator-tier, writes tenant_admin
 
-The dispatch is gated only by `require_ui_session`; the underlying
+Reads are gated only by `require_ui_session`; the underlying
 `POST /api/v1/operations/call` floor is `TenantRole.OPERATOR`, so a plain
-operator can read every surface here. The page threads an
-`is_tenant_admin` flag (via the soft-failing `resolve_role_probe`) so T2/T3
-can hide their write affordances from operators — but a non-admin render
-must succeed.
+operator can read every browse surface (realm/client/scope list and the
+user list). The user-list page threads an `is_tenant_admin` flag (via the
+soft-failing `resolve_role_probe`) so the create / reset / assign buttons
+are **soft-hidden** from a plain operator — but a non-admin render must
+still succeed.
+
+The soft-hide is only a UX hint. The three write POSTs are the
+server-side authority: they depend on `_resolve_admin_or_403` (a
+keycloak-local mirror of `connectors/operator.py::resolve_operator_or_403`
+with a keycloak-appropriate 403 `detail`), so a forged POST from a plain
+operator gets a hard `403` and never dispatches. The dispatch floor itself
+is operator-tier; this BFF-layer `tenant_admin` gate is layered on top for
+blast radius (create/reset are caution writes, role-assign is a privilege
+grant), the same pattern existing UI write routes use.
 
 ## Tenant isolation
 
@@ -98,34 +145,53 @@ which stays the canonical agent-principal surface via
 
 ## Route ordering
 
-`build_keycloak_router` registers the literal
-`/ui/keycloak/clients/{client_uuid}` route before the bare `/ui/keycloak`
-index; the only `{param}` route sits under the distinct
-`/ui/keycloak/clients/` prefix, so a future literal `/ui/keycloak/users`
-(T2) registered ahead of any `{param}` route binds first (first-match-wins).
-The router is included before the stubs aggregate in
+`build_keycloak_router` registers, in order: the user-management routes
+(via `_register_user_routes` → `_register_user_password_role_routes`), then
+the literal `/ui/keycloak/clients/{client_uuid}`, then the bare
+`/ui/keycloak` index. The literal `users` and `users/create` segments are
+registered ahead of any `{user_uuid}` route, so `create` is never captured
+as a UUID (first-match-wins). The registration is split across helper
+functions purely to keep each function under the code-quality size budget;
+the call order in the factory preserves the ordering invariant. The router
+is included before the stubs aggregate in
 `ui/routes/__init__.py::build_router`.
 
 ## Dependencies
 
-- `operations.meta_tools.call_operation` — the in-process dispatch entry.
+- `operations.meta_tools.call_operation` — the in-process dispatch entry
+  (reads and writes).
 - `connectors/keycloak/ops_read.py` — the curated `keycloak.*` read ops
-  (`realm.get`, `client.list`, `client.get`, `client_scope.list` used here).
+  (`realm.get`, `client.list`, `client.get`, `client_scope.list`,
+  `user.list`, `role_mapping.get`).
+- `connectors/keycloak/ops_write.py` — the write ops (`user.create`,
+  `user.reset_password`, `role_mapping.assign`), all `requires_approval=True`.
+- `ui/csrf.py` (`mint_csrf_token`) + `ui/routes/approvals/render.py`
+  (`set_csrf_cookie`) — the double-submit token minted on each write modal.
 - `ui/routes/connectors/operator.py::resolve_role_probe` — the soft-failing
   role probe driving `is_tenant_admin`.
 - `db.models.Target` — the tenant-scoped target picker source.
 
 ## Known limitations
 
-- Read-only by design (T1). User management is T2; client-scope/mapper
-  create is T3.
+- Client-scope / protocol-mapper create is T3
+  ([#1943](https://github.com/evoila/meho/issues/1943)); not in this surface.
 - Single managed realm per target (the connector resolves the realm from
   the target's `managed_realm`); no realm selector.
+- The role-assign picker collects free-text realm role names rather than a
+  catalog dropdown (the realm role catalog op is not in this task's verb
+  set); current realm roles are shown for context via `role_mapping.get`.
+- `routes.py` exceeds the 600-line code-quality file-size budget (warning,
+  pre-existing from the T1 scaffold); the route handlers are FastAPI Form
+  closures whose param lists trip PLR0913. Both are recorded as warnings,
+  not blockers.
 
 ## References
 
-- Task [#1959](https://github.com/evoila/meho/issues/1959), Initiative
+- Tasks [#1959](https://github.com/evoila/meho/issues/1959) (T1) +
+  [#1960](https://github.com/evoila/meho/issues/1960) (T2), Initiative
   [#1943](https://github.com/evoila/meho/issues/1943).
+- Approval handoff surface: `/ui/approvals`
+  ([#1778](https://github.com/evoila/meho/issues/1778)).
 - Operations console precedent:
   [#1835](https://github.com/evoila/meho/issues/1835)
   (`docs/codebase/ui.md`, `ui/routes/operations/routes.py`).


### PR DESCRIPTION
## Summary
- Adds Keycloak **user management** to the operator console (G10.19-T2 #1960), on top of #1959's read-only scaffold: a user **list** (operator-tier) plus three **tenant_admin** writes — **create**, **reset-password**, **role-assign**.
- All four verbs dispatch the curated `keycloak.*` op IDs in-process via `operations.meta_tools.call_operation` against the pinned `connector_id="keycloak-admin-26.x"` — no new REST route, no `auth/keycloak_admin.py`.
- Every write is `requires_approval=True`: a confirmed POST returns `status="awaiting_approval"` with `extras["approval_request_id"]`, surfaced as a banner that **deep-links `/ui/approvals`** (no silent no-op).
- Passwords are **Vault-ref, never inline** (`password_secret_ref` + optional mount/key/temporary); the value never lands in form params, logs, or audit rows.

## Key invariants
- **RBAC**: writes hard-gate on `tenant_admin` via a keycloak-local `_resolve_admin_or_403` (forged non-admin POST → 403, not a silent dispatch); affordances soft-hide via `resolve_role_probe`. List read stays operator-tier.
- **Privilege grant**: `role_mapping.assign` is named a privilege grant + surfaces `safety_level="dangerous"`; roles post as a string list → `{"roles": [...], "id": <uuid>}`.
- **CSRF**: double-submit token on each confirm button's own `hx-headers` (HTMX does not inherit it to children), cookie re-minted on modal render.
- **Route ordering**: literal `users` / `users/create` before any `{user_uuid}` route.
- No tenant-override param (tenant_id from session only).

## Test plan
- [x] `ruff check` / `ruff format --check` — clean (keycloak routes + tests)
- [x] `mypy src/` — clean (549 files)
- [x] `pytest tests/test_ui_keycloak.py` — 20 passed (8 new)
- [x] `pytest -k "keycloak_ui and user_create and awaiting_approval"` — 1 passed (approval banner + `/ui/approvals` deep-link)
- [x] Vault-ref test: create/reset forms expose `password_secret_ref`, no plaintext password field; dispatched params carry no `password`/`value` key
- [x] Privilege-grant + CSRF test: role-assign modal names it a privilege grant + `dangerous`; POST without CSRF → 403, with it → `awaiting_approval` + correct `{roles, id}` dispatch
- [x] RBAC test: operator sees no write buttons + non-admin write POSTs → 403; tenant_admin sees buttons and dispatches
- [x] `cd cli && make snapshot-openapi && make generate` run; `cli/api/openapi.json` + `cli/internal/api/client.gen.go` committed (four new `/ui/keycloak/users*` routes)
- [x] `docs/codebase/ui-keycloak-console.md` updated (writes / approval handoff / Vault-ref / RBAC / route ordering)

## Out of scope
- Client-scope/protocol-mapper create → T3 (#1943); approval **decide** flow lives on `/ui/approvals` (#1778) — this only deep-links.
- Adjacent findings (recorded, not blocking): `keycloak/routes.py` exceeds the 600-line code-quality file-size budget (pre-existing warning from the T1 scaffold); FastAPI Form-closure handlers trip PLR0913 (warnings, not blockers).

<!-- auto-implement-issue: fresh, iteration 1 -->

Closes #1960
