### PR TITLE
feat(ui): Vault console confirm-gated KV writes — put CAS / delete / secret.move with approval handoff (G10.18-T2 #1957)

### DIFF
--- a/backend/src/meho_backplane/ui/routes/__init__.py
+++ b/backend/src/meho_backplane/ui/routes/__init__.py
@@ -107,7 +107,10 @@ from meho_backplane.ui.routes.runbooks import build_runbooks_router
 from meho_backplane.ui.routes.scheduler import build_scheduler_router
 from meho_backplane.ui.routes.stubs import build_stubs_router
 from meho_backplane.ui.routes.topology import build_router as build_topology_router
-from meho_backplane.ui.routes.vault import build_vault_router
+from meho_backplane.ui.routes.vault import (
+    build_vault_router,
+    build_vault_writes_router,
+)
 
 __all__ = [
     "build_account_router",
@@ -132,6 +135,7 @@ __all__ = [
     "build_stubs_router",
     "build_topology_router",
     "build_vault_router",
+    "build_vault_writes_router",
 ]
 
 
@@ -260,5 +264,15 @@ def build_router() -> APIRouter:
     # stubs aggregate so its concrete paths win the first-match-wins lookup
     # against the placeholder ``/ui/{slug}``.
     router.include_router(build_vault_router())
+    # Vault / secrets console confirm-gated WRITES (G10.18-T2 #1957):
+    # ``GET /ui/vault/{put,delete,move}/confirm`` (the unmissable confirm
+    # modals) + the CSRF-gated ``POST /ui/vault/{put,delete,move}`` dispatch
+    # routes. A SEPARATE module from the T1 browser so the read / write
+    # surfaces evolve without serial-merge collisions; the literal
+    # ``put``/``delete``/``move`` segments register before any ``{param}``
+    # route (first-match-wins, and these are POST / distinct-literal routes so
+    # they cannot collide with T1's GET slug routes regardless). Registered
+    # before the stubs aggregate so its concrete paths win the lookup.
+    router.include_router(build_vault_writes_router())
     router.include_router(build_stubs_router())
     return router

--- a/backend/src/meho_backplane/ui/routes/vault/__init__.py
+++ b/backend/src/meho_backplane/ui/routes/vault/__init__.py
@@ -1,17 +1,20 @@
 # SPDX-License-Identifier: Apache-2.0
 # Copyright (c) 2026 evoila Group
 
-"""Vault / secrets console UI routes (read-only KV browser).
+"""Vault / secrets console UI routes (read-only KV browser + confirm-gated writes).
 
-Initiative #1942 (G10.18 Vault / secrets console), Task #1956 (T1). The
-read-only KV browser is the scaffold the write (T2 #1957) and status
-(T3 #1958) surfaces build on. Exposes :func:`build_vault_router`, the
-``/ui/vault*`` :class:`~fastapi.APIRouter`, included ahead of the stubs
+Initiative #1942 (G10.18 Vault / secrets console). Task #1956 (T1) ships the
+read-only KV browser scaffold (:func:`build_vault_router`); Task #1957 (T2)
+adds the confirm-gated KV write verbs in a SEPARATE module
+(:func:`build_vault_writes_router` -- put / delete / move) so the read and
+write surfaces (and the parallel T3 status view #1958) evolve without
+serial-merge collisions. Both routers are included ahead of the stubs
 aggregate in :func:`meho_backplane.ui.routes.build_router`.
 """
 
 from __future__ import annotations
 
 from meho_backplane.ui.routes.vault.routes import build_vault_router
+from meho_backplane.ui.routes.vault.writes import build_vault_writes_router
 
-__all__ = ["build_vault_router"]
+__all__ = ["build_vault_router", "build_vault_writes_router"]

--- a/backend/src/meho_backplane/ui/routes/vault/writes.py
+++ b/backend/src/meho_backplane/ui/routes/vault/writes.py
@@ -1,0 +1,741 @@
+# SPDX-License-Identifier: Apache-2.0
+# Copyright (c) 2026 evoila Group
+# code-quality-allow: file-size -- a single-surface UI router carrying the
+# three Vault write verbs (put / delete / move) of the secrets console: the
+# confirm-modal GETs + dispatch POSTs + their form-field parsers + render
+# helpers. Each route is a thin BFF handler delegating to a ``_render_*``
+# helper, so the length is the count of write surfaces this one module owns
+# (plus the load-bearing redaction/CSRF/RBAC docstring), not per-function
+# complexity. Mirrors the operations router's same file-size escape valve.
+
+"""Vault / secrets console WRITE routes: confirm-gated KV put / delete / move.
+
+Initiative #1942 (G10.18 Vault / secrets console), Task #1957 (T2). The
+mutating verbs over the T1 (#1956) read-only KV browser scaffold: the
+confirm-gated ``vault.kv.put`` (CAS-aware), ``vault.kv.delete`` (soft-delete
+specific versions), and ``secret.move`` (references-not-values). These are the
+highest-blast-radius actions the Vault console gains -- every one is
+``requires_approval=True``, so the gate must be UNMISSABLE and the result
+render must surface the approval handoff rather than a silent success.
+
+This module is intentionally SEPARATE from T1's :mod:`.routes` (which owns the
+read-only GET browser) so the two surfaces -- and the parallel T3 status view
+(#1958) -- can evolve without serial-merge collisions. It REUSES T1's operator
+lift, connector-id resolver, and default-path helper (imported below) rather
+than re-deriving them, so the load-bearing connector-id-shape invariant lives
+in exactly one place.
+
+Why a session BFF (same rationale as T1)
+----------------------------------------
+
+The Bearer-gated ``POST /api/v1/operations/call`` cannot be authenticated by a
+browser carrying only the BFF session cookie, so these routes are
+``require_ui_session``-gated and call
+:func:`~meho_backplane.operations.meta_tools.call_operation` IN-PROCESS -- the
+exact confirm-gated-dispatch pattern ``ui/routes/operations/routes.py`` uses
+for its Run surface. ``call_operation`` is complete and tested; NO backend
+work happens here (no new route, op, or meta-tool).
+
+Route inventory (write -- confirm GETs + dispatch POSTs)
+--------------------------------------------------------
+
+* ``GET /ui/vault/put/confirm`` / ``…/delete/confirm`` / ``…/move/confirm`` --
+  the UNMISSABLE destructive-confirm modal fragments, modelled on the
+  operations Run modal (``_render_run_modal``). Each renders a prominent
+  ``safety_level`` / ``requires_approval`` banner (``put`` = ``caution``,
+  ``delete`` / ``move`` = ``dangerous``; all three ``requires_approval``), the
+  op-specific inputs, and a confirm button carrying its OWN ``hx-headers``
+  CSRF echo. The GET mints a fresh CSRF token and re-sets the ``meho_csrf``
+  cookie so the double-submit pair lines up after the HTMX swap rotated it
+  (the #1693 / #1754 cookie-desync class).
+* ``POST /ui/vault/put`` -- dispatch ``vault.kv.put``
+  (``connector_id="vault-1.x"``, target + ``{mount, path, data, cas?}``). The
+  ``cas`` Check-And-Set guard rides in ``params`` ONLY when the operator
+  explicitly set it (mirrors the CLI's ``Changed("cas")`` rule -- an unset
+  field writes unconditionally, ``cas=0`` writes only if absent).
+* ``POST /ui/vault/delete`` -- dispatch ``vault.kv.delete`` with the
+  ``versions[]`` to soft-delete.
+* ``POST /ui/vault/move`` -- dispatch ``secret.move`` against the DIFFERENT
+  ``secret-broker-1.x`` connector with the schema's ``from`` / ``to``
+  references (+ optional ``reason``). VALUE-FREE by contract: there is NO
+  inline value input, the dispatched params carry no value, and the render
+  surfaces only the ``{status, value_sha256, length}`` confirmation -- the
+  value never enters op params, the response, a log event, or the audit row.
+
+CSRF (load-bearing -- writes, unlike T1's reads, are gated)
+-----------------------------------------------------------
+
+T1's four GET reads are CSRF-free (the middleware only guards state-changing
+methods). These POSTs ARE gated: the ``ui/csrf.py`` double-submit middleware
+verifies the ``X-CSRF-Token`` header (or ``csrf_token`` form field) against
+the ``meho_csrf`` cookie HMAC, BEFORE the route runs -- so a POST without the
+token is a 403 the route never sees. The confirm GET mints + re-sets the
+cookie so the swapped-in confirm button's ``hx-headers`` echo matches.
+
+awaiting_approval (load-bearing -- the silent-success trap)
+-----------------------------------------------------------
+
+``call_operation`` ALWAYS returns a structured
+:class:`~meho_backplane.connectors.schemas.OperationResult` envelope; errors
+land INSIDE it (``status="error"``), not as HTTP 4xx. Because every write op
+is ``requires_approval=True``, a human OPERATOR running one is routed to the
+approval queue (G11.7-T1 #1401), so the COMMON return is
+``status="awaiting_approval"`` with ``extras["approval_request_id"]`` (the
+durable pending-row UUID, ``operations/_errors.py`` ``result_awaiting_approval``).
+The result fragment surfaces it as a banner + a deep-link into
+``/ui/approvals/{approval_request_id}`` (the surface #1778 shipped) so the
+operator never thinks the write silently no-op'd.
+
+Redaction (load-bearing -- the top-sensitivity surface)
+-------------------------------------------------------
+
+No secret value reaches a server log, audit row, telemetry frame, or
+request-preview body. ``vault.kv.put``'s ``data`` object is operator-supplied
+secret material: the BFF logs ONLY the op-id / connector-id / status /
+approval-id (never the ``data`` / the ``params``). ``secret.move`` is
+value-free by the connector's own contract; the UI keeps that invariant by
+never offering a value field. The default-on per-tenant scope guard
+(``connectors/vault/tenant_scope.py``) denies a write outside
+``secret/tenants/{tenant_id}/`` as a ``status="error"`` envelope with
+``extras.exception_class == "VaultTenantScopeError"`` -- rendered as a clear
+scope message, not a raw 403.
+
+RBAC (load-bearing -- OPERATOR tier, the gate is policy not role)
+-----------------------------------------------------------------
+
+The write verbs are OPERATOR-tier (like the operations Run surface) -- there
+is NO ``tenant_admin`` hard-403 on the write POST. Safety is enforced by the
+confirm modal + the dispatcher's ``policy_gate`` -> approval queue, NOT by
+``TenantRole``; adding a role gate here would contradict the backend gate and
+the sibling operations console. Tenant scoping derives from
+``operator.tenant_id`` only (the session), never a form field a caller could
+spoof.
+
+Route ordering
+--------------
+
+The literal ``put`` / ``delete`` / ``move`` (and their ``…/confirm``)
+segments register before any ``{param}`` route on the shared ``/ui/vault``
+router (first-match-wins); these are POST / distinct-literal-prefix routes, so
+they cannot collide with T1's GET slug routes regardless, but the ordering
+discipline is pinned.
+"""
+
+from __future__ import annotations
+
+import json
+from typing import Any, Final
+
+import structlog
+from fastapi import APIRouter, Depends, Form, Request, status
+from fastapi.responses import HTMLResponse
+
+from meho_backplane.auth.operator import Operator
+from meho_backplane.operations.ingest.list_connectors import list_ingested_connectors
+from meho_backplane.operations.meta_tools import call_operation
+from meho_backplane.ui.auth.middleware import UISessionContext, require_ui_session
+from meho_backplane.ui.csrf import mint_csrf_token
+from meho_backplane.ui.routes.approvals.render import set_csrf_cookie
+from meho_backplane.ui.routes.vault.routes import (
+    _DEFAULT_MOUNT,
+    _MAX_MOUNT_LENGTH,
+    _MAX_PATH_LENGTH,
+    _MAX_TARGET_LENGTH,
+    _default_path,
+    _resolve_operator,
+    _vault_connector_id,
+)
+from meho_backplane.ui.templating import get_templates
+
+__all__ = ["build_vault_writes_router"]
+
+log = structlog.get_logger(__name__)
+
+#: The mutating Vault KV op-ids this surface dispatches. ``vault.kv.put`` and
+#: ``vault.kv.delete`` go to the ``vault-1.x`` connector; ``secret.move`` goes
+#: to the SEPARATE ``secret-broker-1.x`` connector (sourced independently
+#: below). Source of truth: the descriptor-spec tables in
+#: :mod:`meho_backplane.connectors.vault.ops` /
+#: :mod:`meho_backplane.connectors.secret.ops`.
+_OP_PUT: Final[str] = "vault.kv.put"
+_OP_DELETE: Final[str] = "vault.kv.delete"
+_OP_MOVE: Final[str] = "secret.move"
+
+#: The product slug whose ingested connector backs ``secret.move``. The
+#: dispatchable id (``secret-broker-1.x``) is picked out of the ingested list
+#: rather than hard-coded, so a re-version flows through without a literal
+#: edit; the bare slug ``secret`` is never emitted (it 404s through
+#: ``parse_connector_id``). DISTINCT from the vault product slug -- ``move``
+#: is a different connector than ``put`` / ``delete``.
+_SECRET_BROKER_PRODUCT: Final[str] = "secret"
+
+#: ``safety_level`` per write verb, for the confirm modal's banner. ``put`` is
+#: caution (state-changing, replaces the latest version wholesale); ``delete``
+#: and ``move`` are dangerous (destructive / change-class). These mirror the
+#: backend descriptor specs exactly; rendered, never dispatched.
+_SAFETY_PUT: Final[str] = "caution"
+_SAFETY_DELETE: Final[str] = "dangerous"
+_SAFETY_MOVE: Final[str] = "dangerous"
+
+#: Maximum raw ``data`` JSON length accepted on the put form. The secret
+#: key/value object is a free-form JSON textarea; 64 KiB is a comfortable
+#: ceiling for a real secret while bounding the body parse against an oversized
+#: paste. The CSRF middleware already caps the buffered body at 256 KiB; this
+#: is the surface-specific, friendlier-error bound. Matches the operations
+#: console's ``_MAX_PARAMS_LENGTH``.
+_MAX_DATA_LENGTH: Final[int] = 64 * 1024
+
+#: Maximum ``versions`` field length on the delete form. The field is a short
+#: comma-separated list of integers (``3,4,5``); a tight bound rejects an
+#: oversized paste at the form boundary.
+_MAX_VERSIONS_LENGTH: Final[int] = 1024
+
+#: Maximum length of a ``secret.move`` ``<kind>:<ref>`` reference / the reason
+#: string. A reference is a short store-qualified pointer
+#: (``vault:secret/db/prod#password``); 1024 leaves room for a real URI-shaped
+#: ref while bounding the parse.
+_MAX_REF_LENGTH: Final[int] = 1024
+
+#: Module-level ``Depends`` closure -- built once (rather than inline) to
+#: satisfy ruff B008, matching the operations / approvals / T1 routers.
+_require_session = Depends(require_ui_session)
+
+
+async def _secret_broker_connector_id(operator: Operator) -> str | None:
+    """Resolve the dispatchable ``secret-broker-1.x`` id, or ``None``.
+
+    ``secret.move`` lives on a DIFFERENT connector than ``vault.kv.*``. Picks
+    the secret-broker product's id out of the ingested-connector list (the
+    same listing the operations picker + T1's vault resolver use), so the
+    emitted id round-trips :func:`parse_connector_id` by construction (#773)
+    and a re-version (``secret-broker-2.x``) flows through without a literal
+    edit. The bare product slug ``secret`` is never emitted. ``None`` when no
+    secret-broker connector is ingested for this operator's visibility -- the
+    move confirm renders a "no secret-broker connector" hint rather than a
+    dead-end 404.
+    """
+    items = await list_ingested_connectors(operator=operator)
+    for item in items:
+        if item.state == "ingested" and item.product == _SECRET_BROKER_PRODUCT:
+            return item.connector_id
+    return None
+
+
+# A FastAPI route-registration factory. Every ``@router.<verb>`` handler must
+# be declared INSIDE the factory so a test app can build parallel routers
+# without shared route state (the convention every UI surface router follows,
+# mirroring the operations / T1-vault routers' same escape valve). The six
+# handler stubs are thin -- each delegates straight to a module-level
+# ``_render_*`` helper -- so the length is decorator boilerplate, not logic.
+# code-quality-allow: function-size -- route-registration factory (see above).
+def build_vault_writes_router() -> APIRouter:
+    """Construct the ``/ui/vault`` WRITE :class:`APIRouter` (T2 #1957).
+
+    Factory function (not a module-level constant) so a test app can construct
+    parallel routers without shared route state -- the convention every
+    surface router follows. Included ahead of the stubs aggregate in
+    :func:`meho_backplane.ui.routes.build_router`, alongside T1's
+    :func:`~meho_backplane.ui.routes.vault.routes.build_vault_router`.
+
+    The literal ``put`` / ``delete`` / ``move`` (+ ``…/confirm``) segments
+    register BEFORE any ``{param}`` route on the shared ``/ui/vault`` router so
+    the first-match-wins lookup is unambiguous; these are POST / distinct-
+    literal routes so they cannot collide with T1's GET slug routes
+    regardless, but the ordering discipline is pinned.
+    """
+    router = APIRouter(tags=["ui-vault-writes"])
+
+    # ----- Confirm-modal GETs (mint + re-set the CSRF cookie) -----
+
+    @router.get("/ui/vault/put/confirm", response_class=HTMLResponse)
+    async def vault_put_confirm(
+        request: Request,
+        session: UISessionContext = _require_session,
+        target: str = "",
+        mount: str = _DEFAULT_MOUNT,
+        path: str = "",
+    ) -> HTMLResponse:
+        """Render the ``vault.kv.put`` confirm modal (caution / requires approval).
+
+        Mints + re-sets the ``meho_csrf`` cookie so the confirm button's OWN
+        ``hx-headers`` echo lines up after the HTMX swap rotated it. Put is
+        OPERATOR-tier -- no tenant_admin step; the policy gate escalates the
+        ``requires_approval`` op to ``awaiting_approval`` on dispatch.
+        """
+        return await _render_confirm(
+            request,
+            session,
+            verb="put",
+            op_id=_OP_PUT,
+            safety_level=_SAFETY_PUT,
+            target=target,
+            mount=mount,
+            path=path,
+        )
+
+    @router.get("/ui/vault/delete/confirm", response_class=HTMLResponse)
+    async def vault_delete_confirm(
+        request: Request,
+        session: UISessionContext = _require_session,
+        target: str = "",
+        mount: str = _DEFAULT_MOUNT,
+        path: str = "",
+    ) -> HTMLResponse:
+        """Render the ``vault.kv.delete`` confirm modal (dangerous / requires approval).
+
+        Soft-delete is reversible, but it stops reads from returning the named
+        versions -- a destructive-class op, so the banner gets the loud
+        treatment. Mints + re-sets the CSRF cookie like the put confirm.
+        """
+        return await _render_confirm(
+            request,
+            session,
+            verb="delete",
+            op_id=_OP_DELETE,
+            safety_level=_SAFETY_DELETE,
+            target=target,
+            mount=mount,
+            path=path,
+        )
+
+    @router.get("/ui/vault/move/confirm", response_class=HTMLResponse)
+    async def vault_move_confirm(
+        request: Request,
+        session: UISessionContext = _require_session,
+    ) -> HTMLResponse:
+        """Render the ``secret.move`` confirm modal (dangerous / requires approval).
+
+        VALUE-FREE: the modal carries ``from`` / ``to`` reference inputs and an
+        optional reason, but NO value input -- the no-``--value`` invariant the
+        CLI keeps. Resolves the SEPARATE ``secret-broker-1.x`` connector;
+        renders a hint when it is not ingested. Mints + re-sets the CSRF cookie.
+        """
+        return await _render_move_confirm(request, session)
+
+    # ----- Dispatch POSTs (CSRF-gated by the middleware) -----
+
+    @router.post("/ui/vault/put", response_class=HTMLResponse)
+    async def vault_put(
+        request: Request,
+        session: UISessionContext = _require_session,
+        target: str = Form(default="", max_length=_MAX_TARGET_LENGTH),
+        mount: str = Form(default=_DEFAULT_MOUNT, max_length=_MAX_MOUNT_LENGTH),
+        path: str = Form(default="", max_length=_MAX_PATH_LENGTH),
+        data: str = Form(default="", max_length=_MAX_DATA_LENGTH),
+        cas: str = Form(default="", max_length=32),
+    ) -> HTMLResponse:
+        """Dispatch ``vault.kv.put`` in-process; render the result inline.
+
+        CSRF-gated (a ``POST`` under ``/ui/``) + ``require_ui_session``-gated.
+        ``data`` is the operator-supplied secret key/value JSON object;
+        ``cas`` rides in ``params`` ONLY when the operator set it (the CLI
+        ``Changed("cas")`` rule). The BFF logs no secret material.
+        """
+        return await _render_put_result(request, session, target, mount, path, data, cas)
+
+    @router.post("/ui/vault/delete", response_class=HTMLResponse)
+    async def vault_delete(
+        request: Request,
+        session: UISessionContext = _require_session,
+        target: str = Form(default="", max_length=_MAX_TARGET_LENGTH),
+        mount: str = Form(default=_DEFAULT_MOUNT, max_length=_MAX_MOUNT_LENGTH),
+        path: str = Form(default="", max_length=_MAX_PATH_LENGTH),
+        versions: str = Form(default="", max_length=_MAX_VERSIONS_LENGTH),
+    ) -> HTMLResponse:
+        """Dispatch ``vault.kv.delete`` in-process; render the result inline.
+
+        CSRF-gated + ``require_ui_session``-gated. ``versions`` is the
+        comma-separated list of version numbers to soft-delete.
+        """
+        return await _render_delete_result(request, session, target, mount, path, versions)
+
+    @router.post("/ui/vault/move", response_class=HTMLResponse)
+    async def vault_move(
+        request: Request,
+        session: UISessionContext = _require_session,
+        from_ref: str = Form(default="", alias="from", max_length=_MAX_REF_LENGTH),
+        to_ref: str = Form(default="", alias="to", max_length=_MAX_REF_LENGTH),
+        reason: str = Form(default="", max_length=_MAX_REF_LENGTH),
+    ) -> HTMLResponse:
+        """Dispatch ``secret.move`` in-process; render the value-free result.
+
+        CSRF-gated + ``require_ui_session``-gated. Dispatches the SEPARATE
+        ``secret-broker-1.x`` connector with ``from`` / ``to`` references (+
+        optional reason). VALUE-FREE: no value field is accepted, dispatched,
+        logged, or rendered -- only the ``{status, value_sha256, length}``
+        confirmation surfaces.
+        """
+        return await _render_move_result(request, session, from_ref, to_ref, reason)
+
+    return router
+
+
+# ---------------------------------------------------------------------------
+# Confirm-modal renders (mint + re-set the CSRF cookie)
+# ---------------------------------------------------------------------------
+
+
+async def _render_confirm(
+    request: Request,
+    session: UISessionContext,
+    *,
+    verb: str,
+    op_id: str,
+    safety_level: str,
+    target: str,
+    mount: str,
+    path: str,
+) -> HTMLResponse:
+    """Render a ``vault.kv.put`` / ``vault.kv.delete`` confirm modal fragment.
+
+    Both share the ``vault-1.x`` connector + the mount/path inputs, so one
+    renderer drives both via *verb* / *op_id* / *safety_level*. Mints a fresh
+    CSRF token and re-sets the ``meho_csrf`` cookie so the confirm button's own
+    ``hx-headers`` echo lines up after the HTMX swap rotated it (#1693 /
+    #1754). A deploy with no ingested vault connector renders the
+    no-connector hint rather than a confirm form that would 404 on dispatch.
+    """
+    operator = await _resolve_operator(session)
+    connector_id = await _vault_connector_id(operator)
+    csrf_token = mint_csrf_token(str(session.session_id))
+    context: dict[str, Any] = {
+        "verb": verb,
+        "op_id": op_id,
+        "safety_level": safety_level,
+        "connector_id": connector_id,
+        "default_mount": (mount or _DEFAULT_MOUNT).strip(),
+        # Prefill the path with the supplied value, falling back to the
+        # operator's tenant prefix so the common case never trips the guard.
+        "default_path": path.strip() or _default_path(operator),
+        "target": target.strip(),
+        "csrf_token": csrf_token,
+    }
+    response = get_templates().TemplateResponse(request, f"vault/_confirm_{verb}.html", context)
+    set_csrf_cookie(response, csrf_token)
+    return response
+
+
+async def _render_move_confirm(
+    request: Request,
+    session: UISessionContext,
+) -> HTMLResponse:
+    """Render the ``secret.move`` confirm modal fragment (VALUE-FREE).
+
+    Resolves the SEPARATE ``secret-broker-1.x`` connector (not the vault
+    connector); renders a hint when it is not ingested. The modal carries
+    ``from`` / ``to`` reference inputs + an optional reason but NO value input
+    -- the no-``--value`` invariant. Mints + re-sets the CSRF cookie like the
+    put / delete confirms.
+    """
+    operator = await _resolve_operator(session)
+    connector_id = await _secret_broker_connector_id(operator)
+    csrf_token = mint_csrf_token(str(session.session_id))
+    context: dict[str, Any] = {
+        "verb": "move",
+        "op_id": _OP_MOVE,
+        "safety_level": _SAFETY_MOVE,
+        "connector_id": connector_id,
+        "csrf_token": csrf_token,
+    }
+    response = get_templates().TemplateResponse(request, "vault/_confirm_move.html", context)
+    set_csrf_cookie(response, csrf_token)
+    return response
+
+
+# ---------------------------------------------------------------------------
+# Dispatch + result renders
+# ---------------------------------------------------------------------------
+
+
+async def _render_put_result(
+    request: Request,
+    session: UISessionContext,
+    target: str,
+    mount: str,
+    path: str,
+    data: str,
+    cas: str,
+) -> HTMLResponse:
+    """Dispatch ``vault.kv.put`` in-process and render the result inline.
+
+    Parses the free-form ``data`` JSON object server-side (a malformed body is
+    a typed inline 400 form error, not a 422); attaches ``cas`` ONLY when the
+    operator set it (the CLI ``Changed("cas")`` rule). The structured envelope
+    (``awaiting_approval`` is the common case; ``error`` / ``denied`` /
+    ``ok``) is surfaced verbatim by the shared write-result fragment.
+    """
+    operator = await _resolve_operator(session)
+    connector_id = await _vault_connector_id(operator)
+    if connector_id is None:
+        return _render_write_form_error(request, "put", "no_vault_connector")
+
+    try:
+        data_obj = _parse_data_object(data)
+    except ValueError as exc:
+        return _render_write_form_error(request, "put", str(exc))
+    try:
+        cas_value = _parse_cas(cas)
+    except ValueError as exc:
+        return _render_write_form_error(request, "put", str(exc))
+
+    params: dict[str, Any] = {"path": path.strip(), "data": data_obj}
+    clean_mount = mount.strip()
+    if clean_mount:
+        params["mount"] = clean_mount
+    # CAS is the Check-And-Set guard. Carry it ONLY when the operator set the
+    # field, so an unset field writes unconditionally and an explicit ``0``
+    # writes only if the key is absent (the CLI ``Changed("cas")`` rule). A
+    # blank field is "flag absent", NOT ``cas=0``.
+    if cas_value is not None:
+        params["cas"] = cas_value
+
+    envelope = await _dispatch_write(operator, connector_id, _OP_PUT, target, params)
+    return _render_write_result(request, "put", envelope)
+
+
+async def _render_delete_result(
+    request: Request,
+    session: UISessionContext,
+    target: str,
+    mount: str,
+    path: str,
+    versions: str,
+) -> HTMLResponse:
+    """Dispatch ``vault.kv.delete`` in-process and render the result inline.
+
+    Parses the comma-separated ``versions`` field into a list of positive
+    integers (an empty / malformed list is a typed inline 400 form error). The
+    structured envelope is surfaced verbatim by the shared write-result
+    fragment.
+    """
+    operator = await _resolve_operator(session)
+    connector_id = await _vault_connector_id(operator)
+    if connector_id is None:
+        return _render_write_form_error(request, "delete", "no_vault_connector")
+
+    try:
+        version_list = _parse_versions(versions)
+    except ValueError as exc:
+        return _render_write_form_error(request, "delete", str(exc))
+
+    params: dict[str, Any] = {"path": path.strip(), "versions": version_list}
+    clean_mount = mount.strip()
+    if clean_mount:
+        params["mount"] = clean_mount
+
+    envelope = await _dispatch_write(operator, connector_id, _OP_DELETE, target, params)
+    return _render_write_result(request, "delete", envelope)
+
+
+async def _render_move_result(
+    request: Request,
+    session: UISessionContext,
+    from_ref: str,
+    to_ref: str,
+    reason: str,
+) -> HTMLResponse:
+    """Dispatch ``secret.move`` in-process and render the VALUE-FREE result.
+
+    Dispatches the SEPARATE ``secret-broker-1.x`` connector with the schema's
+    ``from`` / ``to`` reference fields (+ optional ``reason``). NO value field
+    is accepted or forwarded -- the no-``--value`` invariant -- and the result
+    fragment renders only ``{status, value_sha256, length}``. A blank ``from``
+    or ``to`` is a typed inline 400 form error (the schema requires both).
+    """
+    operator = await _resolve_operator(session)
+    connector_id = await _secret_broker_connector_id(operator)
+    if connector_id is None:
+        return _render_write_form_error(request, "move", "no_secret_broker_connector")
+
+    clean_from = from_ref.strip()
+    clean_to = to_ref.strip()
+    if not clean_from or not clean_to:
+        return _render_write_form_error(
+            request, "move", "Both a source (from) and a destination (to) reference are required."
+        )
+
+    # References ONLY -- never a value field. ``additionalProperties: false``
+    # on the backend schema rejects a smuggled value, but the UI never offers
+    # one in the first place (the no-``--value`` invariant).
+    params: dict[str, Any] = {"from": clean_from, "to": clean_to}
+    clean_reason = reason.strip()
+    if clean_reason:
+        params["reason"] = clean_reason
+
+    envelope = await _dispatch_write(operator, connector_id, _OP_MOVE, target="", params=params)
+    return _render_write_result(request, "move", envelope)
+
+
+async def _dispatch_write(
+    operator: Operator,
+    connector_id: str,
+    op_id: str,
+    target: str,
+    params: dict[str, Any],
+) -> dict[str, Any]:
+    """Call ``call_operation`` in-process for one write op; return the envelope.
+
+    Builds the ``{connector_id, op_id, target, params}`` arguments the
+    meta-tool expects (``target`` empty -> ``None``: vault + secret-broker are
+    connector-id-routed and their handlers do not consume a target). The
+    structured envelope rides back verbatim -- ``awaiting_approval`` (the
+    common case for these ``requires_approval`` ops) / ``ok`` / ``error`` /
+    ``denied`` all inside it; a ``VaultTenantScopeError`` comes back as
+    ``status="error"`` with ``extras.exception_class`` set, never a 4xx.
+
+    The log line records ONLY non-secret fields -- the op-id / connector-id /
+    status / approval-id. It NEVER logs ``params`` (``vault.kv.put``'s ``data``
+    is secret material) or the envelope ``result`` (the redaction invariant on
+    the top-sensitivity surface).
+    """
+    arguments: dict[str, Any] = {
+        "connector_id": connector_id,
+        "op_id": op_id,
+        "target": target.strip() or None,
+        "params": params,
+    }
+    envelope = await call_operation(operator, arguments)
+    extras = envelope.get("extras") or {}
+    log.info(
+        "ui_vault_write_dispatch",
+        op_id=op_id,
+        connector_id=connector_id,
+        status=envelope.get("status"),
+        approval_request_id=extras.get("approval_request_id"),
+        tenant_id=str(operator.tenant_id),
+    )
+    return envelope
+
+
+def _render_write_result(
+    request: Request,
+    verb: str,
+    envelope: dict[str, Any],
+) -> HTMLResponse:
+    """Render the shared write-result fragment for a dispatched write op.
+
+    One fragment (``vault/_write_result.html``) drives all three verbs; *verb*
+    selects the value-free ``secret.move`` ``ok`` branch vs the put / delete
+    success branch. The ``awaiting_approval`` (deep-link), ``error`` /
+    ``denied`` (with the tenant-scope special case), and form-error branches
+    are verb-agnostic.
+    """
+    context: dict[str, Any] = {
+        "verb": verb,
+        "envelope": envelope,
+        "error_message": None,
+        "error_kind": None,
+    }
+    return get_templates().TemplateResponse(request, "vault/_write_result.html", context)
+
+
+def _render_write_form_error(
+    request: Request,
+    verb: str,
+    message_or_kind: str,
+) -> HTMLResponse:
+    """Render the write-result fragment with an inline form error (HTTP 400).
+
+    Covers the malformed-input cases (bad ``data`` JSON, empty / non-integer
+    ``versions``, missing ``from`` / ``to``) and the no-connector-ingested
+    cases (``no_vault_connector`` / ``no_secret_broker_connector``, passed as a
+    typed *kind* the template maps to a friendly hint). The op was never
+    dispatched; the ``400`` status lets a caller distinguish a form fault from
+    a structured in-envelope status. No ``envelope`` is set so the template
+    renders the alert instead of a dispatch result.
+    """
+    known_kinds = {"no_vault_connector", "no_secret_broker_connector"}
+    error_kind = message_or_kind if message_or_kind in known_kinds else None
+    context: dict[str, Any] = {
+        "verb": verb,
+        "envelope": None,
+        "error_message": None if error_kind else message_or_kind,
+        "error_kind": error_kind,
+    }
+    return get_templates().TemplateResponse(
+        request,
+        "vault/_write_result.html",
+        context,
+        status_code=status.HTTP_400_BAD_REQUEST,
+    )
+
+
+# ---------------------------------------------------------------------------
+# Form-field parsers (typed inline errors, never a 422)
+# ---------------------------------------------------------------------------
+
+
+def _parse_data_object(data: str) -> dict[str, Any]:
+    """Parse the put form's free-form ``data`` JSON into a non-empty object.
+
+    The backend schema requires a JSON object with ``minProperties: 1``. A
+    blank field, a malformed body, a non-object value (list / scalar), or an
+    empty object raises :class:`ValueError` with an operator-legible message
+    the caller renders inline -- so the operator stays in the modal rather than
+    getting a raw 422. The error message names only the structural fault, never
+    echoes the (secret) value.
+    """
+    text = data.strip()
+    if not text:
+        raise ValueError('Provide the secret data as a JSON object (e.g. {"password": "..."}).')
+    try:
+        value = json.loads(text)
+    except json.JSONDecodeError as exc:
+        raise ValueError(f"data is not valid JSON: {exc.msg} (line {exc.lineno})") from exc
+    if not isinstance(value, dict):
+        raise ValueError('data must be a JSON object (e.g. {"password": "..."}).')
+    if not value:
+        raise ValueError("data must contain at least one key/value pair.")
+    return value
+
+
+def _parse_cas(cas: str) -> int | None:
+    """Parse the optional Check-And-Set field into an int, or ``None`` if unset.
+
+    A blank field means "flag absent" -> ``None`` (write unconditionally), NOT
+    ``cas=0``. A non-empty field must parse to a non-negative integer (``0`` ⇒
+    write only if absent; ``N`` ⇒ write only if the current version is exactly
+    ``N``). Anything else raises :class:`ValueError` rendered inline.
+    """
+    text = cas.strip()
+    if not text:
+        return None
+    _cas_error = "CAS must be a non-negative integer (or blank to write unconditionally)."
+    try:
+        value = int(text)
+    except ValueError as exc:
+        raise ValueError(_cas_error) from exc
+    if value < 0:
+        raise ValueError(_cas_error)
+    return value
+
+
+def _parse_versions(versions: str) -> list[int]:
+    """Parse the delete form's comma-separated ``versions`` into positive ints.
+
+    The backend schema requires a non-empty array of integers ``>= 1``. A
+    blank field, a non-integer token, or a non-positive value raises
+    :class:`ValueError` rendered inline -- so the operator stays in the modal.
+    Duplicate / unordered tokens are accepted as typed (Vault de-dupes); the
+    parse only enforces the ``>= 1`` integer shape.
+    """
+    text = versions.strip()
+    if not text:
+        raise ValueError("Provide at least one version number to delete (e.g. 3,4,5).")
+    result: list[int] = []
+    for token in text.split(","):
+        token = token.strip()
+        if not token:
+            continue
+        try:
+            value = int(token)
+        except ValueError as exc:
+            raise ValueError(
+                f"versions must be a comma-separated list of integers; '{token}' is not an integer."
+            ) from exc
+        if value < 1:
+            raise ValueError("version numbers must be 1 or greater.")
+        result.append(value)
+    if not result:
+        raise ValueError("Provide at least one version number to delete (e.g. 3,4,5).")
+    return result

--- a/backend/src/meho_backplane/ui/templates/vault/_confirm_delete.html
+++ b/backend/src/meho_backplane/ui/templates/vault/_confirm_delete.html
@@ -1,0 +1,158 @@
+{#-
+  SPDX-License-Identifier: Apache-2.0
+  Copyright (c) 2026 evoila Group
+
+  Vault KV delete confirm modal (Initiative #1942 G10.18, Task #1957 T2).
+
+  Swapped into ``#vault-write-modal-container`` by the browser's "Delete
+  versions" affordance (``hx-get /ui/vault/delete/confirm``).
+  ``vault.kv.delete`` is safety_level=dangerous + requires_approval=True:
+  it soft-deletes the named KV-v2 versions (reversible via Vault's undelete
+  path, but reads stop returning them). The confirm gate must be UNMISSABLE.
+
+  The confirm POST carries the OWASP signed double-submit CSRF token on the
+  confirm button's OWN ``hx-headers``; the confirm GET minted the token +
+  re-set the matching ``meho_csrf`` cookie. The confirm button disables
+  itself during dispatch so a destructive op cannot be double-fired.
+
+  The result swaps into ``#vault-write-result-region`` (``_write_result.html``).
+  Delete is OPERATOR-tier -- no tenant_admin step; the policy gate (NOT RBAC)
+  escalates the requires_approval op to awaiting_approval on dispatch.
+
+  Context:
+    verb / op_id / safety_level (="dangerous") / connector_id / default_mount /
+    default_path / target / csrf_token (as for the put confirm).
+-#}
+{% from "_icons.html" import icon %}
+<dialog id="vault-write-modal" class="modal" aria-label="Delete secret versions">
+  <div class="modal-box max-w-2xl">
+    <div class="flex items-start justify-between gap-4">
+      <div class="min-w-0">
+        <h3 class="truncate font-mono text-lg font-semibold" id="vault-delete-title">
+          Delete secret versions
+        </h3>
+        <p class="mt-0.5 text-sm opacity-70">{{ op_id }}</p>
+      </div>
+      <form method="dialog">
+        <button type="submit" class="btn btn-ghost btn-square btn-sm" aria-label="Close">
+          {{ icon("x", class="size-4") }}
+        </button>
+      </form>
+    </div>
+
+    {% if not connector_id %}
+      <div role="alert" class="alert alert-warning mt-4" data-vault-write-error="no_vault_connector">
+        <div>
+          <h4 class="text-sm font-semibold">No Vault connector available</h4>
+          <p class="text-xs">
+            No ingested <code>vault</code> connector is visible to your tenant.
+          </p>
+        </div>
+      </div>
+    {% else %}
+      {#- UNMISSABLE dangerous gate. Soft-delete is reversible but reads stop
+          returning the named versions; it routes through the approval gate. -#}
+      <div
+        role="alert"
+        class="alert alert-error mt-4 items-start"
+        data-vault-write-gate="confirm"
+        data-safety-level="{{ safety_level }}"
+      >
+        {{ icon("shield-check", class="size-5 shrink-0") }}
+        <div>
+          <h4 class="text-sm font-semibold">Destructive operation</h4>
+          <p class="text-xs [overflow-wrap:anywhere]">
+            This soft-deletes the named versions: reads stop returning them.
+            It is <span class="font-semibold">reversible</span> via Vault's
+            undelete path (the underlying data is retained until destroyed),
+            and it <span class="font-semibold">requires approval</span>:
+            confirming parks a request for a reviewer rather than executing
+            immediately.
+          </p>
+          <div class="mt-2 flex flex-wrap items-center gap-2">
+            <span class="badge badge-error badge-sm" data-vault-write-safety>safety: {{ safety_level }}</span>
+            <span class="badge badge-outline badge-sm" data-vault-write-requires-approval>requires approval</span>
+          </div>
+        </div>
+      </div>
+
+      <form
+        class="mt-4 space-y-3"
+        hx-post="/ui/vault/delete"
+        hx-target="#vault-write-result-region"
+        hx-swap="innerHTML"
+        hx-headers='{"X-CSRF-Token": "{{ csrf_token }}"}'
+        hx-disabled-elt="find button[data-action='vault-delete']"
+        data-vault-write-form="delete"
+      >
+        <input type="hidden" name="target" value="{{ target }}" />
+
+        <div class="grid gap-3 sm:grid-cols-[minmax(0,12rem)_1fr]">
+          <label class="form-control">
+            <span class="label-text mb-1 text-xs opacity-70">Mount</span>
+            <input
+              type="text"
+              name="mount"
+              value="{{ default_mount }}"
+              maxlength="256"
+              class="input input-bordered input-sm w-full font-mono"
+              aria-label="KV mount"
+              autocomplete="off"
+            />
+          </label>
+          <label class="form-control">
+            <span class="label-text mb-1 text-xs opacity-70">Path</span>
+            <input
+              type="text"
+              name="path"
+              value="{{ default_path }}"
+              maxlength="1024"
+              placeholder="tenants/&lt;tenant&gt;/&lt;target&gt;"
+              class="input input-bordered input-sm w-full font-mono"
+              aria-label="KV path"
+              autocomplete="off"
+            />
+          </label>
+        </div>
+
+        <label class="form-control">
+          <span class="label-text mb-1 text-xs opacity-70">
+            Versions <span class="opacity-50">(comma-separated version numbers to soft-delete, e.g. 3,4,5)</span>
+          </span>
+          <input
+            type="text"
+            name="versions"
+            maxlength="1024"
+            class="input input-bordered input-sm w-full font-mono"
+            placeholder="3,4,5"
+            aria-label="Versions to soft-delete"
+            autocomplete="off"
+          />
+        </label>
+
+        <div class="flex items-center justify-end gap-2 pt-1">
+          <button
+            type="button"
+            class="btn btn-ghost btn-sm"
+            onclick="document.getElementById('vault-write-modal').close()"
+          >
+            Cancel
+          </button>
+          <button
+            type="submit"
+            data-action="vault-delete"
+            class="btn btn-error btn-sm gap-1"
+          >
+            {{ icon("ban", class="size-4") }}
+            Delete (request approval)
+          </button>
+        </div>
+      </form>
+
+      <div id="vault-write-result-region" class="mt-4"></div>
+    {% endif %}
+  </div>
+  <form method="dialog" class="modal-backdrop">
+    <button type="submit" aria-label="Close">close</button>
+  </form>
+</dialog>

--- a/backend/src/meho_backplane/ui/templates/vault/_confirm_move.html
+++ b/backend/src/meho_backplane/ui/templates/vault/_confirm_move.html
@@ -1,0 +1,176 @@
+{#-
+  SPDX-License-Identifier: Apache-2.0
+  Copyright (c) 2026 evoila Group
+
+  secret.move confirm modal (Initiative #1942 G10.18, Task #1957 T2).
+
+  Swapped into ``#vault-write-modal-container`` by the browser's "Move
+  secret" affordance (``hx-get /ui/vault/move/confirm``). ``secret.move`` is
+  a SEPARATE connector (``secret-broker-1.x``, NOT vault-1.x):
+  safety_level=dangerous + requires_approval=True. It copies one credential
+  field server-side from a source store to a sink store; the value is read,
+  hashed, and written entirely inside the backplane.
+
+  VALUE-FREE CONTRACT (load-bearing -- the no-``--value`` invariant):
+  the move submits ONLY ``<kind>:<ref>`` references (``from`` / ``to``) and an
+  optional reason. There is DELIBERATELY no value input -- the value never
+  enters the op params, the response, a log event, or the audit row. The
+  result render surfaces only {status, value_sha256, length}. Do NOT add a
+  value/secret field here.
+
+  The confirm POST carries the OWASP signed double-submit CSRF token on the
+  confirm button's OWN ``hx-headers``; the confirm GET minted the token +
+  re-set the matching ``meho_csrf`` cookie. The confirm button disables
+  itself during dispatch. The result swaps into ``#vault-write-result-region``
+  (``_write_result.html``).
+
+  Move is OPERATOR-tier -- no tenant_admin step; the policy gate (NOT RBAC)
+  escalates the requires_approval op to awaiting_approval on dispatch.
+
+  Context:
+    verb ("move") / op_id ("secret.move") / safety_level ("dangerous") /
+    connector_id (the secret-broker-1.x id, None -> hint) / csrf_token.
+-#}
+{% from "_icons.html" import icon %}
+<dialog id="vault-write-modal" class="modal" aria-label="Move secret">
+  <div class="modal-box max-w-2xl">
+    <div class="flex items-start justify-between gap-4">
+      <div class="min-w-0">
+        <h3 class="truncate font-mono text-lg font-semibold" id="vault-move-title">
+          Move secret
+        </h3>
+        <p class="mt-0.5 text-sm opacity-70">{{ op_id }}</p>
+      </div>
+      <form method="dialog">
+        <button type="submit" class="btn btn-ghost btn-square btn-sm" aria-label="Close">
+          {{ icon("x", class="size-4") }}
+        </button>
+      </form>
+    </div>
+
+    {% if not connector_id %}
+      {#- No secret-broker connector ingested: render a hint, not a confirm
+          form that would 404 on dispatch. -#}
+      <div role="alert" class="alert alert-warning mt-4" data-vault-write-error="no_secret_broker_connector">
+        <div>
+          <h4 class="text-sm font-semibold">No secret-broker connector available</h4>
+          <p class="text-xs">
+            No ingested <code>secret-broker</code> connector is visible to your
+            tenant. The move action needs it (it is a different connector than
+            the vault KV browser).
+          </p>
+        </div>
+      </div>
+    {% else %}
+      {#- UNMISSABLE dangerous gate. Change-class; routes through the approval
+          gate; the value never leaves the backplane. -#}
+      <div
+        role="alert"
+        class="alert alert-error mt-4 items-start"
+        data-vault-write-gate="confirm"
+        data-safety-level="{{ safety_level }}"
+      >
+        {{ icon("shield-check", class="size-5 shrink-0") }}
+        <div>
+          <h4 class="text-sm font-semibold">Change-class operation &mdash; references only</h4>
+          <p class="text-xs [overflow-wrap:anywhere]">
+            This moves a single credential field from the source store to the
+            sink store <span class="font-semibold">server-side</span>: the
+            value is read, hashed, and written entirely inside the backplane
+            and is <span class="font-semibold">never returned</span> -- you
+            submit only <code>&lt;kind&gt;:&lt;ref&gt;</code> references, never
+            a value. It <span class="font-semibold">requires approval</span>:
+            confirming parks a request for a reviewer rather than executing
+            immediately.
+          </p>
+          <div class="mt-2 flex flex-wrap items-center gap-2">
+            <span class="badge badge-error badge-sm" data-vault-write-safety>safety: {{ safety_level }}</span>
+            <span class="badge badge-outline badge-sm" data-vault-write-requires-approval>requires approval</span>
+          </div>
+        </div>
+      </div>
+
+      {#- References only. There is NO value input by design (the no-``--value``
+          invariant the CLI keeps). -#}
+      <form
+        class="mt-4 space-y-3"
+        hx-post="/ui/vault/move"
+        hx-target="#vault-write-result-region"
+        hx-swap="innerHTML"
+        hx-headers='{"X-CSRF-Token": "{{ csrf_token }}"}'
+        hx-disabled-elt="find button[data-action='vault-move']"
+        data-vault-write-form="move"
+      >
+        <label class="form-control">
+          <span class="label-text mb-1 text-xs opacity-70">
+            From <span class="opacity-50">(source <code>&lt;kind&gt;:&lt;ref&gt;</code>, e.g. vault:secret/db/prod#password)</span>
+          </span>
+          <input
+            type="text"
+            name="from"
+            maxlength="1024"
+            class="input input-bordered input-sm w-full font-mono"
+            placeholder="vault:secret/db/prod#password"
+            aria-label="Source reference"
+            autocomplete="off"
+            required
+          />
+        </label>
+
+        <label class="form-control">
+          <span class="label-text mb-1 text-xs opacity-70">
+            To <span class="opacity-50">(destination <code>&lt;kind&gt;:&lt;ref&gt;</code>)</span>
+          </span>
+          <input
+            type="text"
+            name="to"
+            maxlength="1024"
+            class="input input-bordered input-sm w-full font-mono"
+            placeholder="vault:secret/db/staging#password"
+            aria-label="Destination reference"
+            autocomplete="off"
+            required
+          />
+        </label>
+
+        <label class="form-control">
+          <span class="label-text mb-1 text-xs opacity-70">
+            Reason <span class="opacity-50">(optional; recorded for the approver -- must not contain a secret value)</span>
+          </span>
+          <input
+            type="text"
+            name="reason"
+            maxlength="1024"
+            class="input input-bordered input-sm w-full font-mono"
+            placeholder="why this move is needed"
+            aria-label="Reason"
+            autocomplete="off"
+          />
+        </label>
+
+        <div class="flex items-center justify-end gap-2 pt-1">
+          <button
+            type="button"
+            class="btn btn-ghost btn-sm"
+            onclick="document.getElementById('vault-write-modal').close()"
+          >
+            Cancel
+          </button>
+          <button
+            type="submit"
+            data-action="vault-move"
+            class="btn btn-error btn-sm gap-1"
+          >
+            {{ icon("arrow-right", class="size-4") }}
+            Move (request approval)
+          </button>
+        </div>
+      </form>
+
+      <div id="vault-write-result-region" class="mt-4"></div>
+    {% endif %}
+  </div>
+  <form method="dialog" class="modal-backdrop">
+    <button type="submit" aria-label="Close">close</button>
+  </form>
+</dialog>

--- a/backend/src/meho_backplane/ui/templates/vault/_confirm_put.html
+++ b/backend/src/meho_backplane/ui/templates/vault/_confirm_put.html
@@ -1,0 +1,193 @@
+{#-
+  SPDX-License-Identifier: Apache-2.0
+  Copyright (c) 2026 evoila Group
+
+  Vault KV put confirm modal (Initiative #1942 G10.18, Task #1957 T2).
+
+  Swapped into ``#vault-write-modal-container`` by the browser's "Write
+  secret" affordance (``hx-get /ui/vault/put/confirm``). ``vault.kv.put``
+  is safety_level=caution + requires_approval=True: writing replaces the
+  latest KV-v2 version WHOLESALE (no merge). The confirm gate must be
+  UNMISSABLE.
+
+  The confirm POST carries the OWASP signed double-submit CSRF token on the
+  confirm button's OWN ``hx-headers`` (HTMX does not inherit ``hx-headers``
+  to children -- the element issuing the request must carry it). The confirm
+  GET minted the token + re-set the matching ``meho_csrf`` cookie. The
+  confirm button disables itself during dispatch (``hx-disabled-elt``) so a
+  high-impact write cannot be double-fired.
+
+  The result swaps into ``#vault-write-result-region`` inside this modal
+  (``vault/_write_result.html``); the modal stays open so the operator reads
+  the awaiting_approval deep-link in place.
+
+  Put is OPERATOR-tier -- no tenant_admin step. The policy gate (NOT RBAC) is
+  what escalates the requires_approval op to awaiting_approval once dispatched.
+
+  REDACTION: the ``data`` field is operator-supplied secret material. It is
+  posted to the BFF, which forwards it to the dispatcher WITHOUT logging it;
+  it never lands in a server log, audit row, or telemetry frame.
+
+  Context:
+    verb          -- "put"
+    op_id         -- "vault.kv.put"
+    safety_level  -- "caution"
+    connector_id  -- str | None: the dispatchable vault-1.x id (None -> hint)
+    default_mount -- str: the mount the field pre-fills ("secret")
+    default_path  -- str: the path the field pre-fills (tenant prefix)
+    target        -- str: the (optional) target name carried from the browser
+    csrf_token    -- str: minted double-submit token for the put POST
+-#}
+{% from "_icons.html" import icon %}
+<dialog id="vault-write-modal" class="modal" aria-label="Write secret">
+  <div class="modal-box max-w-2xl">
+    <div class="flex items-start justify-between gap-4">
+      <div class="min-w-0">
+        <h3 class="truncate font-mono text-lg font-semibold" id="vault-put-title">
+          Write secret
+        </h3>
+        <p class="mt-0.5 text-sm opacity-70">{{ op_id }}</p>
+      </div>
+      <form method="dialog">
+        <button type="submit" class="btn btn-ghost btn-square btn-sm" aria-label="Close">
+          {{ icon("x", class="size-4") }}
+        </button>
+      </form>
+    </div>
+
+    {% if not connector_id %}
+      {#- No vault connector ingested: render a hint, not a confirm form that
+          would 404 on dispatch. -#}
+      <div role="alert" class="alert alert-warning mt-4" data-vault-write-error="no_vault_connector">
+        <div>
+          <h4 class="text-sm font-semibold">No Vault connector available</h4>
+          <p class="text-xs">
+            No ingested <code>vault</code> connector is visible to your tenant.
+          </p>
+        </div>
+      </div>
+    {% else %}
+      {#- UNMISSABLE caution gate. vault.kv.put replaces the latest version
+          wholesale and routes through the approval gate. -#}
+      <div
+        role="alert"
+        class="alert alert-warning mt-4 items-start"
+        data-vault-write-gate="confirm"
+        data-safety-level="{{ safety_level }}"
+      >
+        {{ icon("shield-check", class="size-5 shrink-0") }}
+        <div>
+          <h4 class="text-sm font-semibold">State-changing operation</h4>
+          <p class="text-xs [overflow-wrap:anywhere]">
+            This writes a new version of the secret and replaces the latest
+            version <span class="font-semibold">wholesale</span> (KV v2 does
+            not merge -- carry forward any keys that must survive). It
+            <span class="font-semibold">requires approval</span>: confirming
+            parks a request for a reviewer rather than executing immediately.
+          </p>
+          <div class="mt-2 flex flex-wrap items-center gap-2">
+            <span class="badge badge-warning badge-sm" data-vault-write-safety>safety: {{ safety_level }}</span>
+            <span class="badge badge-outline badge-sm" data-vault-write-requires-approval>requires approval</span>
+          </div>
+        </div>
+      </div>
+
+      <form
+        class="mt-4 space-y-3"
+        hx-post="/ui/vault/put"
+        hx-target="#vault-write-result-region"
+        hx-swap="innerHTML"
+        hx-headers='{"X-CSRF-Token": "{{ csrf_token }}"}'
+        hx-disabled-elt="find button[data-action='vault-put']"
+        data-vault-write-form="put"
+      >
+        <input type="hidden" name="target" value="{{ target }}" />
+
+        <div class="grid gap-3 sm:grid-cols-[minmax(0,12rem)_1fr]">
+          <label class="form-control">
+            <span class="label-text mb-1 text-xs opacity-70">Mount</span>
+            <input
+              type="text"
+              name="mount"
+              value="{{ default_mount }}"
+              maxlength="256"
+              class="input input-bordered input-sm w-full font-mono"
+              aria-label="KV mount"
+              autocomplete="off"
+            />
+          </label>
+          <label class="form-control">
+            <span class="label-text mb-1 text-xs opacity-70">Path</span>
+            <input
+              type="text"
+              name="path"
+              value="{{ default_path }}"
+              maxlength="1024"
+              placeholder="tenants/&lt;tenant&gt;/&lt;target&gt;"
+              class="input input-bordered input-sm w-full font-mono"
+              aria-label="KV path"
+              autocomplete="off"
+            />
+          </label>
+        </div>
+
+        <label class="form-control">
+          <span class="label-text mb-1 text-xs opacity-70">
+            Secret data <span class="opacity-50">(JSON object; replaces the latest version)</span>
+          </span>
+          <textarea
+            name="data"
+            rows="5"
+            maxlength="65536"
+            class="textarea textarea-bordered textarea-sm w-full font-mono text-xs"
+            placeholder='{"password": "..."}'
+            aria-label="Secret data as JSON"
+            autocomplete="off"
+          ></textarea>
+        </label>
+
+        <label class="form-control">
+          <span class="label-text mb-1 text-xs opacity-70">
+            CAS <span class="opacity-50">(optional Check-And-Set; 0 = write only if absent, N = only if current version is N; blank = unconditional)</span>
+          </span>
+          <input
+            type="number"
+            name="cas"
+            min="0"
+            step="1"
+            class="input input-bordered input-sm w-full font-mono sm:max-w-[12rem]"
+            placeholder="(blank)"
+            aria-label="Check-And-Set version guard"
+            autocomplete="off"
+          />
+        </label>
+
+        <div class="flex items-center justify-end gap-2 pt-1">
+          <button
+            type="button"
+            class="btn btn-ghost btn-sm"
+            onclick="document.getElementById('vault-write-modal').close()"
+          >
+            Cancel
+          </button>
+          <button
+            type="submit"
+            data-action="vault-put"
+            class="btn btn-warning btn-sm gap-1"
+          >
+            {{ icon("key-round", class="size-4") }}
+            Write (request approval)
+          </button>
+        </div>
+      </form>
+
+      {#- Swap target for the rendered write result. Empty until the operator
+          confirms; the modal stays open so the awaiting_approval deep-link
+          reads in place. -#}
+      <div id="vault-write-result-region" class="mt-4"></div>
+    {% endif %}
+  </div>
+  <form method="dialog" class="modal-backdrop">
+    <button type="submit" aria-label="Close">close</button>
+  </form>
+</dialog>

--- a/backend/src/meho_backplane/ui/templates/vault/_write_result.html
+++ b/backend/src/meho_backplane/ui/templates/vault/_write_result.html
@@ -1,0 +1,169 @@
+{#-
+  SPDX-License-Identifier: Apache-2.0
+  Copyright (c) 2026 evoila Group
+
+  Vault write-result fragment (Initiative #1942 G10.18, Task #1957 T2).
+
+  Swapped into ``#vault-write-result-region`` (inside a put / delete / move
+  confirm modal) by the confirm button's ``hx-post``. Renders the dispatched
+  write op's ``OperationResult`` envelope inline. ONE fragment drives all
+  three verbs; ``verb`` selects the value-free ``secret.move`` success branch
+  vs the put / delete success branch.
+
+  Because every write op is requires_approval=True, the COMMON return is
+  ``awaiting_approval`` -- never render that as a silent success; surface the
+  approval handoff + a deep-link to /ui/approvals/{id} (#1778).
+
+  Render branches:
+    * ``error_message`` set (no ``envelope``) -> an inline form error (HTTP
+      400): malformed input (bad data JSON, empty/non-integer versions,
+      missing from/to). The op was never dispatched.
+    * ``error_kind`` set (no ``envelope``) -> a typed no-connector hint
+      (no_vault_connector / no_secret_broker_connector).
+    * ``status == "awaiting_approval"`` -> the policy gate parked the op and
+      created a durable ApprovalRequest. Surface extras.approval_request_id
+      with a DEEP-LINK into /ui/approvals/{id}.
+    * ``status == "ok"`` -> the write executed (uncommon for these governed
+      ops). ``move`` renders ONLY {status, value_sha256, length} (value-free);
+      put / delete render a plain success.
+    * ``status in ("error", "denied")`` -> the structured fault, via the
+      shared ``vault_envelope_error`` macro (which renders the tenant-scope
+      "outside your tenant scope" special case + the generic error_code).
+
+  REDACTION: no secret value is rendered here. ``vault.kv.put``'s success
+  carries no value; ``secret.move``'s response is value-free by contract;
+  errors never echo secret material.
+
+  Context:
+    verb          -- "put" | "delete" | "move"
+    envelope      -- dict | None: the call_operation envelope, or None on a
+                     form/no-connector error
+    error_message -- str | None: the inline form-error message (400 branch)
+    error_kind    -- str | None: a typed no-connector kind (400 branch)
+-#}
+{% from "_icons.html" import icon %}
+{% from "vault/_envelope_error.html" import vault_envelope_error %}
+
+{% if error_kind == "no_vault_connector" %}
+  <div role="alert" class="alert alert-warning" data-vault-write-status="no_vault_connector">
+    <div>
+      <h4 class="text-sm font-semibold">No Vault connector available</h4>
+      <p class="text-xs">No ingested <code>vault</code> connector is visible to your tenant.</p>
+    </div>
+  </div>
+{% elif error_kind == "no_secret_broker_connector" %}
+  <div role="alert" class="alert alert-warning" data-vault-write-status="no_secret_broker_connector">
+    <div>
+      <h4 class="text-sm font-semibold">No secret-broker connector available</h4>
+      <p class="text-xs">No ingested <code>secret-broker</code> connector is visible to your tenant.</p>
+    </div>
+  </div>
+{% elif error_message %}
+  {#- Inline form error (400): malformed input. The op was never dispatched. -#}
+  <div role="alert" class="alert alert-error" data-vault-write-status="form_error">
+    <div>
+      <h4 class="text-sm font-semibold">Cannot {{ verb }}</h4>
+      <p class="text-xs [overflow-wrap:anywhere]">{{ error_message }}</p>
+    </div>
+  </div>
+{% elif envelope.status == "awaiting_approval" %}
+  {#- The op requires approval: the policy gate parked it and created a durable
+      ApprovalRequest. NEVER a silent success -- surface the handoff with a
+      deep-link into the approvals surface (#1778). -#}
+  {%- set extras = envelope.get("extras") or {} -%}
+  {%- set approval_id = extras.get("approval_request_id") -%}
+  <div role="alert" class="alert alert-info items-start" data-vault-write-status="awaiting_approval">
+    {{ icon("clock", class="size-5 shrink-0") }}
+    <div>
+      <h4 class="text-sm font-semibold">Awaiting approval</h4>
+      <p class="text-xs [overflow-wrap:anywhere]">
+        This {{ verb }} requires approval before it executes. A request has been
+        parked for a reviewer &mdash; it has <span class="font-semibold">not</span>
+        run yet.
+      </p>
+      {% if approval_id %}
+        <p class="mt-1 text-xs opacity-70">
+          Request id <code data-approval-request-id>{{ approval_id }}</code>
+        </p>
+        {#- Deep-link into /ui/approvals/{id}: hx-get the detail modal into the
+            shared app-shell approvals container so the reviewer can open it
+            without leaving the page. The plain href is the fallback for a
+            non-HTMX navigation / a new tab. -#}
+        <a
+          class="btn btn-primary btn-sm mt-2 gap-1"
+          href="/ui/approvals/{{ approval_id }}"
+          hx-get="/ui/approvals/{{ approval_id }}"
+          hx-target="#meho-approvals-modal-container"
+          hx-swap="innerHTML"
+          data-approval-deep-link
+        >
+          {{ icon("external-link", class="size-4") }}
+          Review in approvals
+        </a>
+      {% else %}
+        <a
+          class="btn btn-primary btn-sm mt-2 gap-1"
+          href="/ui/approvals"
+          hx-get="/ui/approvals"
+          hx-target="#meho-approvals-modal-container"
+          hx-swap="innerHTML"
+          data-approval-deep-link
+        >
+          {{ icon("external-link", class="size-4") }}
+          Open approvals
+        </a>
+      {% endif %}
+    </div>
+  </div>
+{% elif envelope.status == "ok" %}
+  {%- set result = envelope.get("result") or {} -%}
+  {% if verb == "move" %}
+    {#- VALUE-FREE move confirmation: render ONLY {status, value_sha256,
+        length}, never an inline value. The backend response carries exactly
+        these three keys; the value never reaches this template. -#}
+    <div class="space-y-2" data-vault-write-status="ok" data-vault-move-result>
+      <div class="flex items-center gap-2">
+        <span class="badge badge-success badge-sm">moved</span>
+      </div>
+      <dl class="space-y-1 text-xs">
+        <div class="flex gap-2">
+          <dt class="opacity-60">Status</dt>
+          <dd class="font-mono" data-move-status>{{ result.get("status") }}</dd>
+        </div>
+        <div class="flex gap-2">
+          <dt class="opacity-60">Value SHA-256</dt>
+          <dd class="font-mono [overflow-wrap:anywhere]" data-move-value-sha256>{{ result.get("value_sha256") }}</dd>
+        </div>
+        <div class="flex gap-2">
+          <dt class="opacity-60">Length</dt>
+          <dd class="font-mono" data-move-length>{{ result.get("length") }}</dd>
+        </div>
+      </dl>
+      <p class="text-xs opacity-60">
+        The value was moved server-side and never returned &mdash; only its
+        SHA-256 + byte length are shown as provenance.
+      </p>
+    </div>
+  {% else %}
+    {#- put / delete executed (uncommon for these governed ops). A plain
+        success; the put response carries no secret value. -#}
+    <div class="space-y-2" data-vault-write-status="ok">
+      <div class="flex items-center gap-2">
+        <span class="badge badge-success badge-sm">executed</span>
+        {% if envelope.get("duration_ms") is not none %}
+          <span class="text-xs opacity-60">{{ "%.0f"|format(envelope.duration_ms) }} ms</span>
+        {% endif %}
+      </div>
+      <p class="text-xs opacity-70">
+        The {{ verb }} completed. {% if verb == "put" %}A new version was written.{% else %}The named versions were soft-deleted.{% endif %}
+      </p>
+    </div>
+  {% endif %}
+{% else %}
+  {#- status in ("error", "denied") -- the dispatcher's structured fault,
+      surfaced inline (HTTP 200, not 4xx) via the shared macro. The macro
+      renders the VaultTenantScopeError "outside your tenant scope" special
+      case (the default-on guard denying a write outside the tenant prefix) +
+      the generic extras.error_code branch. -#}
+  {{ vault_envelope_error(None, envelope) }}
+{% endif %}

--- a/backend/src/meho_backplane/ui/templates/vault/index.html
+++ b/backend/src/meho_backplane/ui/templates/vault/index.html
@@ -149,6 +149,60 @@
       </div>
     </form>
 
+    {#- Write actions (Task #1957 T2). Each button opens an unmissable
+        confirm modal (``hx-get`` into ``#vault-write-modal-container``; the
+        shared modal controller ``app/modal-dialogs.js`` auto-opens the
+        swapped-in ``<dialog class="modal">``). Put / Delete carry the
+        browser's current mount/path/target via ``hx-include`` so the confirm
+        modal prefills them; Move takes references (a separate connector), so
+        it carries no path inputs. The GET confirm routes are CSRF-free reads;
+        only the confirm POST inside each modal is CSRF-gated. -#}
+    <section aria-label="Write actions" class="space-y-2" data-vault-writes>
+      <h2 class="text-sm font-semibold opacity-80">Write</h2>
+      <div class="flex flex-wrap gap-2">
+        <button
+          type="button"
+          class="btn btn-warning btn-sm gap-1"
+          hx-get="/ui/vault/put/confirm"
+          hx-target="#vault-write-modal-container"
+          hx-swap="innerHTML"
+          hx-include="[data-vault-browser]"
+          data-vault-write-open="put"
+        >
+          {{ icon("key-round", class="size-4") }}
+          Write secret
+        </button>
+        <button
+          type="button"
+          class="btn btn-error btn-sm gap-1"
+          hx-get="/ui/vault/delete/confirm"
+          hx-target="#vault-write-modal-container"
+          hx-swap="innerHTML"
+          hx-include="[data-vault-browser]"
+          data-vault-write-open="delete"
+        >
+          {{ icon("ban", class="size-4") }}
+          Delete versions
+        </button>
+        <button
+          type="button"
+          class="btn btn-error btn-sm gap-1"
+          hx-get="/ui/vault/move/confirm"
+          hx-target="#vault-write-modal-container"
+          hx-swap="innerHTML"
+          data-vault-write-open="move"
+        >
+          {{ icon("arrow-right", class="size-4") }}
+          Move secret
+        </button>
+      </div>
+      <p class="text-xs opacity-60">
+        Every write requires approval: confirming parks a request for a
+        reviewer in <a href="/ui/approvals" class="link">Approvals</a> rather
+        than executing immediately.
+      </p>
+    </section>
+
     {#- Three independent swap regions. Each starts with an empty-state
         prompt; the matching control swaps its partial in. They are
         separate so reading a secret does not wipe the key list. -#}
@@ -180,6 +234,14 @@
         </div>
       </div>
     </section>
+
+    {#- Stable write-modal container (Task #1957 T2) -- never replaced. The
+        put / delete / move confirm fragments swap their own
+        ``<dialog id="vault-write-modal" class="modal">`` into this via
+        ``hx-swap="innerHTML"``; the shared modal controller opens each via
+        ``showModal()`` and dismisses it on close/ESC/backdrop -- the same
+        container pattern the approvals + operations modals use. -#}
+    <div id="vault-write-modal-container"></div>
   {% endif %}
 </section>
 {% endblock %}

--- a/backend/tests/test_ui_vault_writes.py
+++ b/backend/tests/test_ui_vault_writes.py
@@ -1,0 +1,1012 @@
+# SPDX-License-Identifier: Apache-2.0
+# Copyright (c) 2026 evoila Group
+
+"""Behavioural tests for the Vault console WRITE UI surface.
+
+Initiative #1942 (G10.18 Vault / secrets console), Task #1957 (T2). The
+confirm-gated KV write verbs over the T1 (#1956) read-only browser:
+``vault.kv.put`` (CAS-aware), ``vault.kv.delete`` (soft-delete versions),
+and ``secret.move`` (references-only, a SEPARATE ``secret-broker-1.x``
+connector). The acceptance criteria on issue #1957 are:
+
+* a confirmed ``POST /ui/vault/put`` whose dispatch returns
+  ``status="awaiting_approval"`` renders the approval banner with
+  ``extras["approval_request_id"]`` AND a link to ``/ui/approvals`` -- the
+  operator is NEVER shown a silent / empty success.
+* the ``vault.kv.delete`` confirm modal renders the ``dangerous`` /
+  ``requires_approval`` banner; ``POST /ui/vault/delete`` without the CSRF
+  token -> 403, with it -> 200; the literal ``GET /ui/vault/put/confirm``
+  resolves to the confirm handler, not a T1 ``{param}`` route.
+* ``POST /ui/vault/put`` carries ``cas`` in the dispatched params ONLY when
+  the operator set it (the CLI ``Changed("cas")`` rule).
+* ``POST /ui/vault/move`` dispatches ``connector_id="secret-broker-1.x"`` op
+  ``secret.move`` with ``from`` / ``to`` references and NO value field; the
+  rendered result contains only ``status`` / ``value_sha256`` / ``length``;
+  the move form has no value/secret input.
+* a valid **operator** session can run all three writes; no tenant_admin
+  hard-403 on the write POST; tenant scoping derives from the session.
+
+The harness mirrors :mod:`backend.tests.test_ui_vault`: a minimal FastAPI app
+with the UI session + CSRF middlewares, a ``web_session`` row carrying a real
+Keycloak-minted access token, seeded ``operation_group`` / ``endpoint_descriptor``
+rows so the pickers resolve ``vault-1.x`` + ``secret-broker-1.x`` as ingested,
+the registered vault + secret-broker typed ops, and the shared in-process
+Vault fake. The awaiting_approval branches drive the REAL dispatch (the policy
+gate parks a ``requires_approval`` op for a human OPERATOR, G11.7-T1 #1401);
+the argument-shape branches patch the route module's ``call_operation`` to
+capture the dispatched arguments (mirroring ``test_ui_operations``).
+"""
+
+from __future__ import annotations
+
+import asyncio
+import uuid
+import warnings
+from collections.abc import Iterator
+from datetime import timedelta
+from typing import Any
+from unittest.mock import AsyncMock
+
+import pytest
+import respx
+from cryptography.fernet import Fernet
+from fastapi import FastAPI
+from fastapi.staticfiles import StaticFiles
+from fastapi.testclient import TestClient
+
+from meho_backplane.auth.jwt import clear_jwks_cache
+from meho_backplane.auth.operator import TenantRole
+from meho_backplane.connectors.registry import clear_registry, register_connector_v2
+from meho_backplane.connectors.secret.ops import register_secret_broker_operations
+from meho_backplane.connectors.vault import VaultConnector
+from meho_backplane.connectors.vault.ops import register_vault_typed_operations
+from meho_backplane.db.engine import get_sessionmaker, reset_engine_for_testing
+from meho_backplane.db.models import EndpointDescriptor, OperationGroup, Tenant
+from meho_backplane.operations import reset_dispatcher_caches
+from meho_backplane.settings import get_settings
+from meho_backplane.ui.auth import SESSION_COOKIE_NAME, UISessionMiddleware
+from meho_backplane.ui.auth import build_router as build_ui_auth_router
+from meho_backplane.ui.auth.flow import (
+    clear_discovery_cache,
+    reset_verifier_store_for_testing,
+)
+from meho_backplane.ui.auth.session_store import (
+    create_session,
+    reset_fernet_cache_for_testing,
+)
+from meho_backplane.ui.csrf import CSRF_COOKIE_NAME, CSRFMiddleware, mint_csrf_token
+from meho_backplane.ui.paths import static_root_dir
+from meho_backplane.ui.routes import build_router as build_ui_router
+from meho_backplane.ui.templating import reset_templating_for_testing
+from tests._oidc_jwt_helpers import AUDIENCE as _DEFAULT_AUDIENCE
+from tests._oidc_jwt_helpers import ISSUER as _DEFAULT_ISSUER
+from tests._oidc_jwt_helpers import make_rsa_keypair as _make_rsa_keypair
+from tests._oidc_jwt_helpers import mint_token as _mint_token
+from tests._oidc_jwt_helpers import mock_discovery_and_jwks as _mock_discovery_and_jwks
+from tests._oidc_jwt_helpers import public_jwks as _public_jwks
+from tests._vault_fakes import install_fake_client
+
+_BACKPLANE_URL = "https://meho.test"
+_TENANT_A = uuid.UUID("11111111-1111-1111-1111-111111111111")
+_OP_OPERATOR = "op-operator"
+
+#: A secret-value sentinel: no write render may carry it, and a move's
+#: value-free response must never echo it.
+_SECRET_VALUE = "SUPER-SECRET-VALUE-do-not-leak-9f3a"
+
+_FROM_REF = "vault:secret/db/prod#password"
+_TO_REF = "vault:secret/db/replica#password"
+
+
+@pytest.fixture(autouse=True)
+def _bff_env(monkeypatch: pytest.MonkeyPatch) -> Iterator[None]:
+    """Pin chassis + BFF + Vault env vars (mirrors the vault UI suite)."""
+    monkeypatch.setenv("KEYCLOAK_ISSUER_URL", _DEFAULT_ISSUER)
+    monkeypatch.setenv("KEYCLOAK_AUDIENCE", _DEFAULT_AUDIENCE)
+    monkeypatch.setenv("VAULT_ADDR", "https://vault.test")
+    monkeypatch.setenv("VAULT_OIDC_ROLE", "meho-mcp")
+    monkeypatch.setenv("VAULT_OIDC_MOUNT_PATH", "jwt")
+    monkeypatch.setenv("VAULT_TIMEOUT_SECONDS", "5.0")
+    monkeypatch.delenv("VAULT_NAMESPACE", raising=False)
+    # Default-on tenant scope (the v0.15.0 #1725 production default).
+    monkeypatch.setenv("VAULT_KV_TENANT_SCOPE_PREFIX", "secret/tenants/{tenant_id}/")
+    monkeypatch.setenv("BACKPLANE_URL", _BACKPLANE_URL)
+    monkeypatch.setenv("UI_SESSION_ENCRYPTION_KEY", Fernet.generate_key().decode())
+    monkeypatch.setenv("UI_KEYCLOAK_CLIENT_ID", "meho-web")
+    monkeypatch.setenv("UI_KEYCLOAK_CLIENT_SECRET", "test-client-secret")
+    get_settings.cache_clear()
+    reset_fernet_cache_for_testing()
+    reset_verifier_store_for_testing()
+    reset_templating_for_testing()
+    clear_discovery_cache()
+    clear_jwks_cache()
+    reset_engine_for_testing()
+    clear_registry()
+    reset_dispatcher_caches()
+    yield
+    get_settings.cache_clear()
+    reset_fernet_cache_for_testing()
+    reset_verifier_store_for_testing()
+    reset_templating_for_testing()
+    clear_discovery_cache()
+    clear_jwks_cache()
+    reset_engine_for_testing()
+    clear_registry()
+    reset_dispatcher_caches()
+
+
+@pytest.fixture
+def _stub_embedding_service() -> AsyncMock:
+    """Deterministic embedding stub so ``register_typed_operation`` skips ONNX."""
+    service = AsyncMock()
+    service.encode_one.return_value = [0.1] * 384
+    service.encode.return_value = [[0.1] * 384]
+    service.dimension = 384
+    return service
+
+
+def _build_app() -> FastAPI:
+    """Construct a minimal FastAPI app wired for the vault write UI tests."""
+    app = FastAPI()
+    app.add_middleware(CSRFMiddleware)
+    app.add_middleware(UISessionMiddleware)
+    app.mount(
+        "/ui/static",
+        StaticFiles(directory=str(static_root_dir()), check_dir=False),
+        name="ui_static",
+    )
+    app.include_router(build_ui_auth_router())
+    app.include_router(build_ui_router())
+    return app
+
+
+def _seed_tenant(tenant_id: uuid.UUID, slug: str) -> None:
+    async def _do() -> None:
+        sessionmaker = get_sessionmaker()
+        async with sessionmaker() as session, session.begin():
+            session.add(Tenant(id=tenant_id, slug=slug, name=f"Tenant {slug}"))
+
+    asyncio.run(_do())
+
+
+def _seed_vault_descriptor() -> None:
+    """Seed an enabled vault ``operation_group`` + ``endpoint_descriptor``.
+
+    Makes the connector listing report ``vault-1.x`` as ``state="ingested"``
+    so the put / delete pickers + connector-id resolver find it. The actual
+    dispatch goes through the registered typed ops, not this row.
+    """
+    group_id = uuid.uuid4()
+    desc_id = uuid.uuid4()
+
+    async def _do() -> None:
+        sessionmaker = get_sessionmaker()
+        async with sessionmaker() as session, session.begin():
+            session.add(
+                OperationGroup(
+                    id=group_id,
+                    tenant_id=None,
+                    product="vault",
+                    version="1.x",
+                    impl_id="vault",
+                    group_key="kv",
+                    name="KV secrets",
+                    when_to_use="browse the KV secret tree",
+                    review_status="enabled",
+                ),
+            )
+            session.add(
+                EndpointDescriptor(
+                    id=desc_id,
+                    tenant_id=None,
+                    product="vault",
+                    version="1.x",
+                    impl_id="vault",
+                    op_id="vault.kv.put",
+                    source_kind="typed",
+                    method="PUT",
+                    path="/v1/secret/data",
+                    summary="Write a KV secret.",
+                    description="writes a secret value",
+                    group_id=group_id,
+                    parameter_schema={
+                        "type": "object",
+                        "properties": {"path": {"type": "string"}},
+                    },
+                    llm_instructions=None,
+                    safety_level="caution",
+                    requires_approval=True,
+                    is_enabled=True,
+                ),
+            )
+
+    asyncio.run(_do())
+
+
+def _seed_secret_broker_descriptor() -> None:
+    """Seed an enabled ``secret-broker`` ``operation_group`` + descriptor.
+
+    Makes the connector listing report ``secret-broker-1.x`` as
+    ``state="ingested"`` so the move connector-id resolver finds it. The
+    actual dispatch goes through the registered ``secret.move`` typed op.
+    """
+    group_id = uuid.uuid4()
+    desc_id = uuid.uuid4()
+
+    async def _do() -> None:
+        sessionmaker = get_sessionmaker()
+        async with sessionmaker() as session, session.begin():
+            session.add(
+                OperationGroup(
+                    id=group_id,
+                    tenant_id=None,
+                    product="secret",
+                    version="1.x",
+                    impl_id="secret-broker",
+                    group_key="broker",
+                    name="Secret broker",
+                    when_to_use="move a credential between stores",
+                    review_status="enabled",
+                ),
+            )
+            session.add(
+                EndpointDescriptor(
+                    id=desc_id,
+                    tenant_id=None,
+                    product="secret",
+                    version="1.x",
+                    impl_id="secret-broker",
+                    op_id="secret.move",
+                    source_kind="typed",
+                    method="POST",
+                    path="/secret/move",
+                    summary="Move a credential.",
+                    description="moves a credential value-free",
+                    group_id=group_id,
+                    parameter_schema={
+                        "type": "object",
+                        "properties": {"from": {"type": "string"}, "to": {"type": "string"}},
+                    },
+                    llm_instructions=None,
+                    safety_level="dangerous",
+                    requires_approval=True,
+                    is_enabled=True,
+                ),
+            )
+
+    asyncio.run(_do())
+
+
+def _register_vault(stub_embedding_service: AsyncMock) -> None:
+    """Register the vault v2 connector + upsert the typed-op descriptors."""
+    register_connector_v2(product="vault", version="1.x", impl_id="vault", cls=VaultConnector)
+
+    async def _do() -> None:
+        await register_vault_typed_operations(embedding_service=stub_embedding_service)
+
+    asyncio.run(_do())
+
+
+def _register_secret_broker(stub_embedding_service: AsyncMock) -> None:
+    """Upsert the ``secret.move`` typed op (the synthetic broker connector).
+
+    ``secret-broker`` registers neither ``register_connector`` nor
+    ``register_connector_v2`` -- it is a typed-op-only synthetic connector the
+    dispatcher resolves from the registered op alone.
+    """
+
+    async def _do() -> None:
+        await register_secret_broker_operations(embedding_service=stub_embedding_service)
+
+    asyncio.run(_do())
+
+
+def _seed_session_sync(*, tenant_id: uuid.UUID, access_token: str, operator_sub: str) -> uuid.UUID:
+    async def _do() -> uuid.UUID:
+        sessionmaker = get_sessionmaker()
+        async with sessionmaker() as session, session.begin():
+            decrypted = await create_session(
+                session,
+                operator_sub=operator_sub,
+                tenant_id=tenant_id,
+                access_token=access_token,
+                refresh_token="refresh-token-plaintext",
+                lifetime=timedelta(hours=1),
+            )
+            return decrypted.id
+
+    return asyncio.run(_do())
+
+
+def _make_keypair_and_jwks() -> tuple[Any, dict[str, Any]]:
+    with warnings.catch_warnings():
+        warnings.simplefilter("ignore")
+        keypair = _make_rsa_keypair(f"ui-vault-writes-test-kid-{uuid.uuid4().hex[:8]}")
+    return keypair, _public_jwks(keypair)
+
+
+def _client_with_role_and_csrf(
+    *,
+    tenant_id: uuid.UUID,
+    operator_sub: str,
+    role: TenantRole,
+) -> tuple[TestClient, respx.MockRouter, str]:
+    """Return a TestClient + respx mock + minted CSRF token for the write routes.
+
+    Sets BOTH the session cookie and the ``meho_csrf`` double-submit cookie so
+    a state-changing POST carrying the matching ``X-CSRF-Token`` header passes
+    the middleware (mirrors ``test_ui_operations._client_with_role_and_csrf``).
+    """
+    keypair, jwks = _make_keypair_and_jwks()
+    access_token = _mint_token(
+        keypair,
+        sub=operator_sub,
+        tenant_id=str(tenant_id),
+        tenant_role=role.value,
+    )
+    session_id = _seed_session_sync(
+        tenant_id=tenant_id,
+        access_token=access_token,
+        operator_sub=operator_sub,
+    )
+    mock = respx.mock(assert_all_called=False)
+    _mock_discovery_and_jwks(mock, jwks)
+    client = TestClient(_build_app(), follow_redirects=False)
+    client.cookies.set(SESSION_COOKIE_NAME, str(session_id))
+    csrf_token = mint_csrf_token(str(session_id))
+    client.cookies.set(CSRF_COOKIE_NAME, csrf_token)
+    return client, mock, csrf_token
+
+
+def _csrf_headers(token: str) -> dict[str, str]:
+    """Headers for an HTMX state-changing request -- CSRF + HX-Request."""
+    return {"X-CSRF-Token": token, "HX-Request": "true"}
+
+
+def _tenant_path(tenant_id: uuid.UUID, suffix: str = "") -> str:
+    """The in-scope KV path for *tenant_id* under the default-on guard."""
+    base = f"tenants/{tenant_id}"
+    return f"{base}/{suffix}" if suffix else base
+
+
+def _patch_call_operation(
+    monkeypatch: pytest.MonkeyPatch, envelope: dict[str, Any]
+) -> list[dict[str, Any]]:
+    """Patch the write route module's ``call_operation`` to return *envelope*.
+
+    Records every ``arguments`` dict so a test can assert the BFF threaded the
+    connector_id / op_id / target / params (incl. the CAS rule + the value-free
+    move shape) through unchanged. The dispatch contract itself is covered by
+    the connector suites; these BFF tests verify route wiring + render branches.
+    """
+    received: list[dict[str, Any]] = []
+
+    async def _fake_call_operation(operator: Any, arguments: dict[str, Any]) -> dict[str, Any]:
+        received.append(arguments)
+        return envelope
+
+    monkeypatch.setattr(
+        "meho_backplane.ui.routes.vault.writes.call_operation",
+        _fake_call_operation,
+    )
+    return received
+
+
+def _awaiting_envelope(op_id: str) -> dict[str, Any]:
+    """A canonical ``awaiting_approval`` envelope with a pending-row id."""
+    return {
+        "status": "awaiting_approval",
+        "op_id": op_id,
+        "result": None,
+        "error": f"awaiting_approval: {op_id!r} requires approval before execution",
+        "duration_ms": 3.0,
+        "handle": None,
+        "extras": {
+            "error_code": "awaiting_approval",
+            "approval_request_id": str(uuid.uuid4()),
+        },
+    }
+
+
+# ---------------------------------------------------------------------------
+# Confirm modals: unmissable safety banner + CSRF re-mint
+# ---------------------------------------------------------------------------
+
+
+def test_vault_put_confirm_renders_caution_requires_approval_banner(
+    _stub_embedding_service: AsyncMock,
+) -> None:
+    """``GET /ui/vault/put/confirm`` renders the caution / requires-approval banner."""
+    _seed_tenant(_TENANT_A, "tenant-a")
+    _seed_vault_descriptor()
+    _register_vault(_stub_embedding_service)
+    client, mock, _csrf = _client_with_role_and_csrf(
+        tenant_id=_TENANT_A, operator_sub=_OP_OPERATOR, role=TenantRole.OPERATOR
+    )
+    with mock:
+        response = client.get(
+            "/ui/vault/put/confirm",
+            params={"mount": "secret", "path": _tenant_path(_TENANT_A, "app")},
+            headers={"HX-Request": "true"},
+        )
+    assert response.status_code == 200, response.text
+    body = response.text
+    assert 'data-vault-write-gate="confirm"' in body
+    assert 'data-safety-level="caution"' in body
+    assert "data-vault-write-requires-approval" in body
+    # The confirm POST carries its own CSRF header echo + disables itself.
+    assert 'hx-post="/ui/vault/put"' in body
+    assert "X-CSRF-Token" in body
+    assert "hx-disabled-elt" in body
+    # The path defaulted from the supplied value (prefilled).
+    assert _tenant_path(_TENANT_A, "app") in body
+    # A fresh CSRF cookie was re-set on the modal render (cookie-desync defence).
+    assert CSRF_COOKIE_NAME in response.headers.get("set-cookie", "")
+
+
+def test_vault_delete_confirm_renders_dangerous_requires_approval_banner(
+    _stub_embedding_service: AsyncMock,
+) -> None:
+    """``GET /ui/vault/delete/confirm`` renders the dangerous / requires-approval banner.
+
+    (Acceptance criterion: the delete confirm modal renders the dangerous /
+    requires_approval banner.)
+    """
+    _seed_tenant(_TENANT_A, "tenant-a")
+    _seed_vault_descriptor()
+    _register_vault(_stub_embedding_service)
+    client, mock, _csrf = _client_with_role_and_csrf(
+        tenant_id=_TENANT_A, operator_sub=_OP_OPERATOR, role=TenantRole.OPERATOR
+    )
+    with mock:
+        response = client.get(
+            "/ui/vault/delete/confirm",
+            params={"mount": "secret", "path": _tenant_path(_TENANT_A, "app")},
+            headers={"HX-Request": "true"},
+        )
+    assert response.status_code == 200, response.text
+    body = response.text
+    assert 'data-vault-write-gate="confirm"' in body
+    assert 'data-safety-level="dangerous"' in body
+    assert "data-vault-write-requires-approval" in body
+    assert 'hx-post="/ui/vault/delete"' in body
+
+
+def test_vault_move_confirm_renders_value_free_form_no_value_input(
+    _stub_embedding_service: AsyncMock,
+) -> None:
+    """``GET /ui/vault/move/confirm`` renders from/to refs + reason, NO value input.
+
+    (Acceptance criterion, part: assert the move form has no value/secret
+    input.)
+    """
+    _seed_tenant(_TENANT_A, "tenant-a")
+    _seed_secret_broker_descriptor()
+    _register_secret_broker(_stub_embedding_service)
+    client, mock, _csrf = _client_with_role_and_csrf(
+        tenant_id=_TENANT_A, operator_sub=_OP_OPERATOR, role=TenantRole.OPERATOR
+    )
+    with mock:
+        response = client.get("/ui/vault/move/confirm", headers={"HX-Request": "true"})
+    assert response.status_code == 200, response.text
+    body = response.text
+    assert 'data-safety-level="dangerous"' in body
+    assert 'hx-post="/ui/vault/move"' in body
+    # Reference inputs + reason are present.
+    assert 'name="from"' in body
+    assert 'name="to"' in body
+    assert 'name="reason"' in body
+    # NO value / secret input field exists (the no-``--value`` invariant).
+    assert 'name="value"' not in body
+    assert 'name="secret"' not in body
+    assert 'name="data"' not in body
+    assert "references only" in body.lower()
+
+
+# ---------------------------------------------------------------------------
+# awaiting_approval: the silent-success trap (acceptance criterion)
+# ---------------------------------------------------------------------------
+
+
+def test_vault_put_awaiting_approval_renders_banner_and_approvals_link() -> None:
+    """A confirmed put parking at ``awaiting_approval`` surfaces the banner + link.
+
+    (Acceptance criterion #1.) End-to-end through the REAL dispatch: a human
+    OPERATOR running a ``requires_approval`` op is routed to the approval queue
+    (G11.7-T1 #1401), which returns ``status="awaiting_approval"`` with
+    ``extras["approval_request_id"]``. The fragment must surface that id with a
+    deep-link to ``/ui/approvals`` -- NEVER a silent empty success.
+    """
+    _seed_tenant(_TENANT_A, "tenant-a")
+    _seed_vault_descriptor()
+    # Register the connector + ops + the in-process Vault fake so the parked
+    # dispatch reaches the real policy gate (the handler never runs on a park).
+    with pytest.MonkeyPatch.context() as mp:
+        install_fake_client(mp, secret={"password": _SECRET_VALUE})
+        _register_vault(_make_stub())
+        client, mock, csrf = _client_with_role_and_csrf(
+            tenant_id=_TENANT_A, operator_sub=_OP_OPERATOR, role=TenantRole.OPERATOR
+        )
+        with mock:
+            response = client.post(
+                "/ui/vault/put",
+                headers=_csrf_headers(csrf),
+                data={
+                    "target": "",
+                    "mount": "secret",
+                    "path": _tenant_path(_TENANT_A, "app/db"),
+                    "data": '{"password": "new-value"}',
+                },
+            )
+    assert response.status_code == 200, response.text
+    body = response.text
+    assert 'data-vault-write-status="awaiting_approval"' in body
+    assert "data-approval-request-id" in body
+    assert "/ui/approvals/" in body
+    assert "data-approval-deep-link" in body
+    # The operator is NOT shown a silent success.
+    assert 'data-vault-write-status="ok"' not in body
+
+
+def test_vault_move_awaiting_approval_renders_banner_and_approvals_link(
+    _stub_embedding_service: AsyncMock,
+) -> None:
+    """A confirmed move parking at ``awaiting_approval`` surfaces the banner + link.
+
+    The real ``secret.move`` change-class gate parks a USER operator's move at
+    ``awaiting_approval`` (the handler never runs). The render must surface the
+    approval handoff, never a silent success.
+    """
+    _seed_tenant(_TENANT_A, "tenant-a")
+    _seed_secret_broker_descriptor()
+    _register_secret_broker(_stub_embedding_service)
+    with pytest.MonkeyPatch.context() as mp:
+        install_fake_client(mp, secret={"password": _SECRET_VALUE})
+        client, mock, csrf = _client_with_role_and_csrf(
+            tenant_id=_TENANT_A, operator_sub=_OP_OPERATOR, role=TenantRole.OPERATOR
+        )
+        with mock:
+            response = client.post(
+                "/ui/vault/move",
+                headers=_csrf_headers(csrf),
+                data={"from": _FROM_REF, "to": _TO_REF, "reason": "promote replica"},
+            )
+    assert response.status_code == 200, response.text
+    body = response.text
+    assert 'data-vault-write-status="awaiting_approval"' in body
+    assert "/ui/approvals/" in body
+    # No secret value reaches the render.
+    assert _SECRET_VALUE not in body
+
+
+# ---------------------------------------------------------------------------
+# CSRF gate + route ordering (acceptance criterion)
+# ---------------------------------------------------------------------------
+
+
+def test_vault_delete_post_without_csrf_token_is_403(
+    _stub_embedding_service: AsyncMock,
+) -> None:
+    """``POST /ui/vault/delete`` WITHOUT the CSRF token is rejected (403).
+
+    (Acceptance criterion, part: without CSRF -> 403, with it -> 200.)
+    """
+    _seed_tenant(_TENANT_A, "tenant-a")
+    _seed_vault_descriptor()
+    _register_vault(_stub_embedding_service)
+    client, mock, _csrf = _client_with_role_and_csrf(
+        tenant_id=_TENANT_A, operator_sub=_OP_OPERATOR, role=TenantRole.OPERATOR
+    )
+    with mock:
+        # Drop the CSRF cookie and omit the header so the double-submit fails.
+        client.cookies.delete(CSRF_COOKIE_NAME)
+        response = client.post(
+            "/ui/vault/delete",
+            headers={"HX-Request": "true"},
+            data={
+                "mount": "secret",
+                "path": _tenant_path(_TENANT_A, "app/db"),
+                "versions": "3,4",
+            },
+        )
+    assert response.status_code == 403, response.text
+
+
+def test_vault_delete_post_with_csrf_token_is_200(monkeypatch: pytest.MonkeyPatch) -> None:
+    """``POST /ui/vault/delete`` WITH the CSRF token dispatches + renders (200).
+
+    (Acceptance criterion, part.) The dispatch is patched to a canonical
+    awaiting_approval envelope so the assertion isolates the CSRF + render
+    wiring from the connector.
+    """
+    _seed_tenant(_TENANT_A, "tenant-a")
+    _seed_vault_descriptor()
+    _register_vault(_make_stub())
+    _patch_call_operation(monkeypatch, _awaiting_envelope("vault.kv.delete"))
+    client, mock, csrf = _client_with_role_and_csrf(
+        tenant_id=_TENANT_A, operator_sub=_OP_OPERATOR, role=TenantRole.OPERATOR
+    )
+    with mock:
+        response = client.post(
+            "/ui/vault/delete",
+            headers=_csrf_headers(csrf),
+            data={
+                "mount": "secret",
+                "path": _tenant_path(_TENANT_A, "app/db"),
+                "versions": "3,4",
+            },
+        )
+    assert response.status_code == 200, response.text
+    assert 'data-vault-write-status="awaiting_approval"' in response.text
+
+
+def test_vault_put_confirm_route_resolves_to_confirm_handler_not_param(
+    _stub_embedding_service: AsyncMock,
+) -> None:
+    """``GET /ui/vault/put/confirm`` resolves to the confirm handler, not a T1 param route.
+
+    (Acceptance criterion, part: first-match-wins -- literals before params.)
+    The literal ``put/confirm`` segment renders the confirm modal (200), not a
+    404/422 from a hypothetical T1 ``{param}`` route on the shared router.
+    """
+    _seed_tenant(_TENANT_A, "tenant-a")
+    _seed_vault_descriptor()
+    _register_vault(_stub_embedding_service)
+    client, mock, _csrf = _client_with_role_and_csrf(
+        tenant_id=_TENANT_A, operator_sub=_OP_OPERATOR, role=TenantRole.OPERATOR
+    )
+    with mock:
+        response = client.get("/ui/vault/put/confirm", headers={"HX-Request": "true"})
+    assert response.status_code == 200, response.text
+    assert 'hx-post="/ui/vault/put"' in response.text
+
+
+# ---------------------------------------------------------------------------
+# CAS rule: carried only when the operator set it (acceptance criterion)
+# ---------------------------------------------------------------------------
+
+
+def test_vault_put_carries_cas_only_when_operator_set_it(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """``POST /ui/vault/put`` includes ``cas`` in params ONLY when set.
+
+    (Acceptance criterion #3 -- the CLI ``Changed("cas")`` rule.) Two dispatches
+    against the same patched ``call_operation``: one with an explicit CAS, one
+    omitting it. The dispatched params carry ``cas`` only in the first.
+    """
+    _seed_tenant(_TENANT_A, "tenant-a")
+    _seed_vault_descriptor()
+    _register_vault(_make_stub())
+    received = _patch_call_operation(monkeypatch, _awaiting_envelope("vault.kv.put"))
+    client, mock, csrf = _client_with_role_and_csrf(
+        tenant_id=_TENANT_A, operator_sub=_OP_OPERATOR, role=TenantRole.OPERATOR
+    )
+    with mock:
+        # (a) explicit CAS=0 (must-not-exist).
+        client.post(
+            "/ui/vault/put",
+            headers=_csrf_headers(csrf),
+            data={
+                "mount": "secret",
+                "path": _tenant_path(_TENANT_A, "app/db"),
+                "data": '{"password": "v"}',
+                "cas": "0",
+            },
+        )
+        # (b) CAS field omitted entirely (write unconditionally).
+        client.post(
+            "/ui/vault/put",
+            headers=_csrf_headers(csrf),
+            data={
+                "mount": "secret",
+                "path": _tenant_path(_TENANT_A, "app/db"),
+                "data": '{"password": "v"}',
+            },
+        )
+    assert len(received) == 2
+    with_cas, without_cas = received
+    # (a) carries cas (explicit 0, the must-not-exist guard).
+    assert with_cas["params"]["cas"] == 0
+    assert with_cas["params"]["data"] == {"password": "v"}
+    assert with_cas["connector_id"] == "vault-1.x"
+    assert with_cas["op_id"] == "vault.kv.put"
+    # (b) carries NO cas key -- an unset field is "flag absent", not cas=0.
+    assert "cas" not in without_cas["params"]
+
+
+def test_vault_put_blank_cas_is_unconditional_not_zero(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """A whitespace/blank CAS field is "flag absent", not ``cas=0``."""
+    _seed_tenant(_TENANT_A, "tenant-a")
+    _seed_vault_descriptor()
+    _register_vault(_make_stub())
+    received = _patch_call_operation(monkeypatch, _awaiting_envelope("vault.kv.put"))
+    client, mock, csrf = _client_with_role_and_csrf(
+        tenant_id=_TENANT_A, operator_sub=_OP_OPERATOR, role=TenantRole.OPERATOR
+    )
+    with mock:
+        client.post(
+            "/ui/vault/put",
+            headers=_csrf_headers(csrf),
+            data={
+                "mount": "secret",
+                "path": _tenant_path(_TENANT_A, "app/db"),
+                "data": '{"password": "v"}',
+                "cas": "   ",
+            },
+        )
+    assert len(received) == 1
+    assert "cas" not in received[0]["params"]
+
+
+# ---------------------------------------------------------------------------
+# secret.move value-free contract (acceptance criterion #4)
+# ---------------------------------------------------------------------------
+
+
+def test_vault_move_dispatches_secret_broker_refs_only_no_value(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """``POST /ui/vault/move`` dispatches secret-broker-1.x with refs + NO value.
+
+    (Acceptance criterion #4.) The dispatched params carry ``from`` / ``to``
+    (+ reason) and NO value field; the result renders only ``status`` /
+    ``value_sha256`` / ``length`` and no secret value text.
+    """
+    _seed_tenant(_TENANT_A, "tenant-a")
+    _seed_secret_broker_descriptor()
+    _register_secret_broker(_make_stub())
+    moved_envelope = {
+        "status": "ok",
+        "op_id": "secret.move",
+        "result": {
+            "status": "moved",
+            "value_sha256": "a" * 64,
+            "length": 21,
+        },
+        "error": None,
+        "duration_ms": 9.0,
+        "handle": None,
+        "extras": {},
+    }
+    received = _patch_call_operation(monkeypatch, moved_envelope)
+    client, mock, csrf = _client_with_role_and_csrf(
+        tenant_id=_TENANT_A, operator_sub=_OP_OPERATOR, role=TenantRole.OPERATOR
+    )
+    with mock:
+        response = client.post(
+            "/ui/vault/move",
+            headers=_csrf_headers(csrf),
+            # A smuggled ``value`` field must NOT reach the dispatched params.
+            data={
+                "from": _FROM_REF,
+                "to": _TO_REF,
+                "reason": "promote replica",
+                "value": _SECRET_VALUE,
+            },
+        )
+    assert response.status_code == 200, response.text
+    # The dispatched connector + op + params are references only.
+    assert len(received) == 1
+    args = received[0]
+    assert args["connector_id"] == "secret-broker-1.x"
+    assert args["op_id"] == "secret.move"
+    assert args["params"] == {"from": _FROM_REF, "to": _TO_REF, "reason": "promote replica"}
+    # No value field was forwarded, even though one was smuggled into the form.
+    assert "value" not in args["params"]
+    assert _SECRET_VALUE not in str(args["params"])
+    # The render carries only the value-free triple.
+    body = response.text
+    assert "data-vault-move-result" in body
+    assert "data-move-value-sha256" in body
+    assert "data-move-length" in body
+    assert "a" * 64 in body
+    assert _SECRET_VALUE not in body
+
+
+def test_vault_move_missing_from_or_to_is_inline_form_error(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """A move with a blank ``from`` or ``to`` renders an inline 400 form error.
+
+    No dispatch happens (the schema requires both references).
+    """
+    _seed_tenant(_TENANT_A, "tenant-a")
+    _seed_secret_broker_descriptor()
+    _register_secret_broker(_make_stub())
+    received = _patch_call_operation(monkeypatch, _awaiting_envelope("secret.move"))
+    client, mock, csrf = _client_with_role_and_csrf(
+        tenant_id=_TENANT_A, operator_sub=_OP_OPERATOR, role=TenantRole.OPERATOR
+    )
+    with mock:
+        response = client.post(
+            "/ui/vault/move",
+            headers=_csrf_headers(csrf),
+            data={"from": _FROM_REF, "to": "", "reason": "x"},
+        )
+    assert response.status_code == 400, response.text
+    assert 'data-vault-write-status="form_error"' in response.text
+    # The op was never dispatched.
+    assert received == []
+
+
+# ---------------------------------------------------------------------------
+# RBAC: operator-tier, no tenant_admin hard-403 (acceptance criterion #5)
+# ---------------------------------------------------------------------------
+
+
+def test_vault_writes_operator_tier_no_tenant_admin_403(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """A plain OPERATOR session can run all three writes -- no tenant_admin 403.
+
+    (Acceptance criterion #5.) The gate is the policy/approval gate, not a role
+    tier; the write POSTs carry NO ``tenant_admin`` hard-403. Tenant scoping is
+    derived from the session, never a form field.
+    """
+    _seed_tenant(_TENANT_A, "tenant-a")
+    _seed_vault_descriptor()
+    _seed_secret_broker_descriptor()
+    _register_vault(_make_stub())
+    _register_secret_broker(_make_stub())
+    # Patch both dispatch surfaces (vault + secret-broker share the writes
+    # module's ``call_operation``) to a canonical awaiting_approval envelope.
+    _patch_call_operation(monkeypatch, _awaiting_envelope("vault.kv.put"))
+    client, mock, csrf = _client_with_role_and_csrf(
+        tenant_id=_TENANT_A, operator_sub=_OP_OPERATOR, role=TenantRole.OPERATOR
+    )
+    with mock:
+        put_resp = client.post(
+            "/ui/vault/put",
+            headers=_csrf_headers(csrf),
+            data={
+                "mount": "secret",
+                "path": _tenant_path(_TENANT_A, "app"),
+                "data": '{"k": "v"}',
+            },
+        )
+        delete_resp = client.post(
+            "/ui/vault/delete",
+            headers=_csrf_headers(csrf),
+            data={"mount": "secret", "path": _tenant_path(_TENANT_A, "app"), "versions": "1"},
+        )
+        move_resp = client.post(
+            "/ui/vault/move",
+            headers=_csrf_headers(csrf),
+            data={"from": _FROM_REF, "to": _TO_REF},
+        )
+    # None of the three is a 403 -- the operator runs every write.
+    assert put_resp.status_code == 200, put_resp.text
+    assert delete_resp.status_code == 200, delete_resp.text
+    assert move_resp.status_code == 200, move_resp.text
+
+
+# ---------------------------------------------------------------------------
+# Tenant-scope guard: out-of-scope write -> friendly message, not a raw 403
+# ---------------------------------------------------------------------------
+
+
+def test_vault_put_tenant_scope_error_renders_friendly_message(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """A put whose dispatch returns a ``VaultTenantScopeError`` fault renders the scope message.
+
+    The default-on guard (``connectors/vault/tenant_scope.py``) raises
+    ``VaultTenantScopeError`` when an APPROVED write re-dispatches against a
+    path outside ``secret/tenants/{tenant_id}/``; the dispatcher wraps it as
+    ``status="error"`` with ``extras.exception_class == "VaultTenantScopeError"``.
+    The BFF render must surface the "outside your tenant scope" message, NOT a
+    raw 403 (the structured fault rides on a 200 body). The dispatch is patched
+    to that error shape so the assertion isolates the BFF's render branch (the
+    real guard's behaviour is covered by the connector suites).
+    """
+    _seed_tenant(_TENANT_A, "tenant-a")
+    _seed_vault_descriptor()
+    _register_vault(_make_stub())
+    scope_error_envelope = {
+        "status": "error",
+        "op_id": "vault.kv.put",
+        "result": None,
+        "error": "secret/tenants/99999999.../x is outside the tenant scope",
+        "duration_ms": 1.0,
+        "handle": None,
+        "extras": {
+            "error_code": "connector_error",
+            "exception_class": "VaultTenantScopeError",
+        },
+    }
+    _patch_call_operation(monkeypatch, scope_error_envelope)
+    client, mock, csrf = _client_with_role_and_csrf(
+        tenant_id=_TENANT_A, operator_sub=_OP_OPERATOR, role=TenantRole.OPERATOR
+    )
+    with mock:
+        response = client.post(
+            "/ui/vault/put",
+            headers=_csrf_headers(csrf),
+            data={
+                "mount": "secret",
+                "path": "tenants/99999999-0000-0000-0000-000000000000/x",
+                "data": '{"k": "v"}',
+            },
+        )
+    assert response.status_code == 200, response.text
+    assert 'data-vault-error="tenant_scope"' in response.text
+    assert "Outside your tenant scope" in response.text
+
+
+# ---------------------------------------------------------------------------
+# Malformed-input inline errors (no 422; the operator stays in the modal)
+# ---------------------------------------------------------------------------
+
+
+def test_vault_put_malformed_data_json_is_inline_form_error(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """A put with malformed ``data`` JSON renders an inline 400 form error."""
+    _seed_tenant(_TENANT_A, "tenant-a")
+    _seed_vault_descriptor()
+    _register_vault(_make_stub())
+    received = _patch_call_operation(monkeypatch, _awaiting_envelope("vault.kv.put"))
+    client, mock, csrf = _client_with_role_and_csrf(
+        tenant_id=_TENANT_A, operator_sub=_OP_OPERATOR, role=TenantRole.OPERATOR
+    )
+    with mock:
+        response = client.post(
+            "/ui/vault/put",
+            headers=_csrf_headers(csrf),
+            data={
+                "mount": "secret",
+                "path": _tenant_path(_TENANT_A, "app"),
+                "data": "{not json",
+            },
+        )
+    assert response.status_code == 400, response.text
+    assert 'data-vault-write-status="form_error"' in response.text
+    assert received == []
+
+
+def test_vault_delete_empty_versions_is_inline_form_error(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """A delete with an empty ``versions`` field renders an inline 400 form error."""
+    _seed_tenant(_TENANT_A, "tenant-a")
+    _seed_vault_descriptor()
+    _register_vault(_make_stub())
+    received = _patch_call_operation(monkeypatch, _awaiting_envelope("vault.kv.delete"))
+    client, mock, csrf = _client_with_role_and_csrf(
+        tenant_id=_TENANT_A, operator_sub=_OP_OPERATOR, role=TenantRole.OPERATOR
+    )
+    with mock:
+        response = client.post(
+            "/ui/vault/delete",
+            headers=_csrf_headers(csrf),
+            data={"mount": "secret", "path": _tenant_path(_TENANT_A, "app"), "versions": ""},
+        )
+    assert response.status_code == 400, response.text
+    assert 'data-vault-write-status="form_error"' in response.text
+    assert received == []
+
+
+# ---------------------------------------------------------------------------
+# Session gate (the writes are session-gated like the reads)
+# ---------------------------------------------------------------------------
+
+
+def test_vault_write_confirm_requires_session() -> None:
+    """An unauthenticated GET on a write confirm route is redirected to login."""
+    _seed_tenant(_TENANT_A, "tenant-a")
+    client = TestClient(_build_app(), follow_redirects=False)
+    response = client.get("/ui/vault/put/confirm")
+    assert response.status_code in (302, 303, 307), response.status_code
+    assert "/ui/auth/login" in response.headers.get("location", "")
+
+
+def _make_stub() -> AsyncMock:
+    """A deterministic embedding stub (module-level helper for non-fixture use)."""
+    service = AsyncMock()
+    service.encode_one.return_value = [0.1] * 384
+    service.encode.return_value = [[0.1] * 384]
+    service.dimension = 384
+    return service

--- a/cli/api/openapi.json
+++ b/cli/api/openapi.json
@@ -16266,6 +16266,279 @@
         }
       }
     },
+    "/ui/vault/put/confirm": {
+      "get": {
+        "tags": [
+          "ui-vault-writes"
+        ],
+        "summary": "Vault Put Confirm",
+        "description": "Render the ``vault.kv.put`` confirm modal (caution / requires approval).\n\nMints + re-sets the ``meho_csrf`` cookie so the confirm button's OWN\n``hx-headers`` echo lines up after the HTMX swap rotated it. Put is\nOPERATOR-tier -- no tenant_admin step; the policy gate escalates the\n``requires_approval`` op to ``awaiting_approval`` on dispatch.",
+        "operationId": "vault_put_confirm_ui_vault_put_confirm_get",
+        "parameters": [
+          {
+            "name": "target",
+            "in": "query",
+            "required": false,
+            "schema": {
+              "type": "string",
+              "default": "",
+              "title": "Target"
+            }
+          },
+          {
+            "name": "mount",
+            "in": "query",
+            "required": false,
+            "schema": {
+              "type": "string",
+              "default": "secret",
+              "title": "Mount"
+            }
+          },
+          {
+            "name": "path",
+            "in": "query",
+            "required": false,
+            "schema": {
+              "type": "string",
+              "default": "",
+              "title": "Path"
+            }
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "Successful Response",
+            "content": {
+              "text/html": {
+                "schema": {
+                  "type": "string"
+                }
+              }
+            }
+          },
+          "422": {
+            "description": "Validation Error",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/HTTPValidationError"
+                }
+              }
+            }
+          }
+        }
+      }
+    },
+    "/ui/vault/delete/confirm": {
+      "get": {
+        "tags": [
+          "ui-vault-writes"
+        ],
+        "summary": "Vault Delete Confirm",
+        "description": "Render the ``vault.kv.delete`` confirm modal (dangerous / requires approval).\n\nSoft-delete is reversible, but it stops reads from returning the named\nversions -- a destructive-class op, so the banner gets the loud\ntreatment. Mints + re-sets the CSRF cookie like the put confirm.",
+        "operationId": "vault_delete_confirm_ui_vault_delete_confirm_get",
+        "parameters": [
+          {
+            "name": "target",
+            "in": "query",
+            "required": false,
+            "schema": {
+              "type": "string",
+              "default": "",
+              "title": "Target"
+            }
+          },
+          {
+            "name": "mount",
+            "in": "query",
+            "required": false,
+            "schema": {
+              "type": "string",
+              "default": "secret",
+              "title": "Mount"
+            }
+          },
+          {
+            "name": "path",
+            "in": "query",
+            "required": false,
+            "schema": {
+              "type": "string",
+              "default": "",
+              "title": "Path"
+            }
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "Successful Response",
+            "content": {
+              "text/html": {
+                "schema": {
+                  "type": "string"
+                }
+              }
+            }
+          },
+          "422": {
+            "description": "Validation Error",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/HTTPValidationError"
+                }
+              }
+            }
+          }
+        }
+      }
+    },
+    "/ui/vault/move/confirm": {
+      "get": {
+        "tags": [
+          "ui-vault-writes"
+        ],
+        "summary": "Vault Move Confirm",
+        "description": "Render the ``secret.move`` confirm modal (dangerous / requires approval).\n\nVALUE-FREE: the modal carries ``from`` / ``to`` reference inputs and an\noptional reason, but NO value input -- the no-``--value`` invariant the\nCLI keeps. Resolves the SEPARATE ``secret-broker-1.x`` connector;\nrenders a hint when it is not ingested. Mints + re-sets the CSRF cookie.",
+        "operationId": "vault_move_confirm_ui_vault_move_confirm_get",
+        "responses": {
+          "200": {
+            "description": "Successful Response",
+            "content": {
+              "text/html": {
+                "schema": {
+                  "type": "string"
+                }
+              }
+            }
+          }
+        }
+      }
+    },
+    "/ui/vault/put": {
+      "post": {
+        "tags": [
+          "ui-vault-writes"
+        ],
+        "summary": "Vault Put",
+        "description": "Dispatch ``vault.kv.put`` in-process; render the result inline.\n\nCSRF-gated (a ``POST`` under ``/ui/``) + ``require_ui_session``-gated.\n``data`` is the operator-supplied secret key/value JSON object;\n``cas`` rides in ``params`` ONLY when the operator set it (the CLI\n``Changed(\"cas\")`` rule). The BFF logs no secret material.",
+        "operationId": "vault_put_ui_vault_put_post",
+        "requestBody": {
+          "content": {
+            "application/x-www-form-urlencoded": {
+              "schema": {
+                "$ref": "#/components/schemas/Body_vault_put_ui_vault_put_post"
+              }
+            }
+          }
+        },
+        "responses": {
+          "200": {
+            "description": "Successful Response",
+            "content": {
+              "text/html": {
+                "schema": {
+                  "type": "string"
+                }
+              }
+            }
+          },
+          "422": {
+            "description": "Validation Error",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/HTTPValidationError"
+                }
+              }
+            }
+          }
+        }
+      }
+    },
+    "/ui/vault/delete": {
+      "post": {
+        "tags": [
+          "ui-vault-writes"
+        ],
+        "summary": "Vault Delete",
+        "description": "Dispatch ``vault.kv.delete`` in-process; render the result inline.\n\nCSRF-gated + ``require_ui_session``-gated. ``versions`` is the\ncomma-separated list of version numbers to soft-delete.",
+        "operationId": "vault_delete_ui_vault_delete_post",
+        "requestBody": {
+          "content": {
+            "application/x-www-form-urlencoded": {
+              "schema": {
+                "$ref": "#/components/schemas/Body_vault_delete_ui_vault_delete_post"
+              }
+            }
+          }
+        },
+        "responses": {
+          "200": {
+            "description": "Successful Response",
+            "content": {
+              "text/html": {
+                "schema": {
+                  "type": "string"
+                }
+              }
+            }
+          },
+          "422": {
+            "description": "Validation Error",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/HTTPValidationError"
+                }
+              }
+            }
+          }
+        }
+      }
+    },
+    "/ui/vault/move": {
+      "post": {
+        "tags": [
+          "ui-vault-writes"
+        ],
+        "summary": "Vault Move",
+        "description": "Dispatch ``secret.move`` in-process; render the value-free result.\n\nCSRF-gated + ``require_ui_session``-gated. Dispatches the SEPARATE\n``secret-broker-1.x`` connector with ``from`` / ``to`` references (+\noptional reason). VALUE-FREE: no value field is accepted, dispatched,\nlogged, or rendered -- only the ``{status, value_sha256, length}``\nconfirmation surfaces.",
+        "operationId": "vault_move_ui_vault_move_post",
+        "requestBody": {
+          "content": {
+            "application/x-www-form-urlencoded": {
+              "schema": {
+                "$ref": "#/components/schemas/Body_vault_move_ui_vault_move_post"
+              }
+            }
+          }
+        },
+        "responses": {
+          "200": {
+            "description": "Successful Response",
+            "content": {
+              "text/html": {
+                "schema": {
+                  "type": "string"
+                }
+              }
+            }
+          },
+          "422": {
+            "description": "Validation Error",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/HTTPValidationError"
+                }
+              }
+            }
+          }
+        }
+      }
+    },
     "/": {
       "get": {
         "summary": "Root",
@@ -18971,6 +19244,96 @@
         },
         "type": "object",
         "title": "Body_ui_scheduler_validate_cron_ui_scheduler_validate_cron_post"
+      },
+      "Body_vault_delete_ui_vault_delete_post": {
+        "properties": {
+          "target": {
+            "type": "string",
+            "maxLength": 256,
+            "title": "Target",
+            "default": ""
+          },
+          "mount": {
+            "type": "string",
+            "maxLength": 256,
+            "title": "Mount",
+            "default": "secret"
+          },
+          "path": {
+            "type": "string",
+            "maxLength": 1024,
+            "title": "Path",
+            "default": ""
+          },
+          "versions": {
+            "type": "string",
+            "maxLength": 1024,
+            "title": "Versions",
+            "default": ""
+          }
+        },
+        "type": "object",
+        "title": "Body_vault_delete_ui_vault_delete_post"
+      },
+      "Body_vault_move_ui_vault_move_post": {
+        "properties": {
+          "from": {
+            "type": "string",
+            "maxLength": 1024,
+            "title": "From",
+            "default": ""
+          },
+          "to": {
+            "type": "string",
+            "maxLength": 1024,
+            "title": "To",
+            "default": ""
+          },
+          "reason": {
+            "type": "string",
+            "maxLength": 1024,
+            "title": "Reason",
+            "default": ""
+          }
+        },
+        "type": "object",
+        "title": "Body_vault_move_ui_vault_move_post"
+      },
+      "Body_vault_put_ui_vault_put_post": {
+        "properties": {
+          "target": {
+            "type": "string",
+            "maxLength": 256,
+            "title": "Target",
+            "default": ""
+          },
+          "mount": {
+            "type": "string",
+            "maxLength": 256,
+            "title": "Mount",
+            "default": "secret"
+          },
+          "path": {
+            "type": "string",
+            "maxLength": 1024,
+            "title": "Path",
+            "default": ""
+          },
+          "data": {
+            "type": "string",
+            "maxLength": 65536,
+            "title": "Data",
+            "default": ""
+          },
+          "cas": {
+            "type": "string",
+            "maxLength": 32,
+            "title": "Cas",
+            "default": ""
+          }
+        },
+        "type": "object",
+        "title": "Body_vault_put_ui_vault_put_post"
       },
       "BroadcastOverrideCreate": {
         "properties": {

--- a/cli/internal/api/client.gen.go
+++ b/cli/internal/api/client.gen.go
@@ -2094,6 +2094,30 @@ type BodyUiSchedulerValidateCronUiSchedulerValidateCronPost struct {
 	Timezone   *string           `json:"timezone,omitempty"`
 }
 
+// BodyVaultDeleteUiVaultDeletePost defines model for Body_vault_delete_ui_vault_delete_post.
+type BodyVaultDeleteUiVaultDeletePost struct {
+	Mount    *string `json:"mount,omitempty"`
+	Path     *string `json:"path,omitempty"`
+	Target   *string `json:"target,omitempty"`
+	Versions *string `json:"versions,omitempty"`
+}
+
+// BodyVaultMoveUiVaultMovePost defines model for Body_vault_move_ui_vault_move_post.
+type BodyVaultMoveUiVaultMovePost struct {
+	From   *string `json:"from,omitempty"`
+	Reason *string `json:"reason,omitempty"`
+	To     *string `json:"to,omitempty"`
+}
+
+// BodyVaultPutUiVaultPutPost defines model for Body_vault_put_ui_vault_put_post.
+type BodyVaultPutUiVaultPutPost struct {
+	Cas    *string `json:"cas,omitempty"`
+	Data   *string `json:"data,omitempty"`
+	Mount  *string `json:"mount,omitempty"`
+	Path   *string `json:"path,omitempty"`
+	Target *string `json:"target,omitempty"`
+}
+
 // BroadcastOverrideCreate Incoming POST body. Pydantic v2 strict.
 //
 // “extra="forbid"“ rejects unknown fields with 422 -- catches a
@@ -7006,8 +7030,22 @@ type UiTopologyTableUiTopologyGetParams struct {
 	MaxHops   *int                `form:"max_hops,omitempty" json:"max_hops,omitempty"`
 }
 
+// VaultDeleteConfirmUiVaultDeleteConfirmGetParams defines parameters for VaultDeleteConfirmUiVaultDeleteConfirmGet.
+type VaultDeleteConfirmUiVaultDeleteConfirmGetParams struct {
+	Target *string `form:"target,omitempty" json:"target,omitempty"`
+	Mount  *string `form:"mount,omitempty" json:"mount,omitempty"`
+	Path   *string `form:"path,omitempty" json:"path,omitempty"`
+}
+
 // VaultListUiVaultListGetParams defines parameters for VaultListUiVaultListGet.
 type VaultListUiVaultListGetParams struct {
+	Target *string `form:"target,omitempty" json:"target,omitempty"`
+	Mount  *string `form:"mount,omitempty" json:"mount,omitempty"`
+	Path   *string `form:"path,omitempty" json:"path,omitempty"`
+}
+
+// VaultPutConfirmUiVaultPutConfirmGetParams defines parameters for VaultPutConfirmUiVaultPutConfirmGet.
+type VaultPutConfirmUiVaultPutConfirmGetParams struct {
 	Target *string `form:"target,omitempty" json:"target,omitempty"`
 	Mount  *string `form:"mount,omitempty" json:"mount,omitempty"`
 	Path   *string `form:"path,omitempty" json:"path,omitempty"`
@@ -7497,6 +7535,15 @@ type AnnotateUiTopologyEdgesPostFormdataRequestBody = BodyAnnotateUiTopologyEdge
 
 // UiTopologyNodeDetailUiTopologyNodeNodeIdGetJSONRequestBody defines body for UiTopologyNodeDetailUiTopologyNodeNodeIdGet for application/json ContentType.
 type UiTopologyNodeDetailUiTopologyNodeNodeIdGetJSONRequestBody = UISessionContext
+
+// VaultDeleteUiVaultDeletePostFormdataRequestBody defines body for VaultDeleteUiVaultDeletePost for application/x-www-form-urlencoded ContentType.
+type VaultDeleteUiVaultDeletePostFormdataRequestBody = BodyVaultDeleteUiVaultDeletePost
+
+// VaultMoveUiVaultMovePostFormdataRequestBody defines body for VaultMoveUiVaultMovePost for application/x-www-form-urlencoded ContentType.
+type VaultMoveUiVaultMovePostFormdataRequestBody = BodyVaultMoveUiVaultMovePost
+
+// VaultPutUiVaultPutPostFormdataRequestBody defines body for VaultPutUiVaultPutPost for application/x-www-form-urlencoded ContentType.
+type VaultPutUiVaultPutPostFormdataRequestBody = BodyVaultPutUiVaultPutPost
 
 // AsApproveResponseBodyDispatchResult0 returns the union data inside the ApproveResponseBody_DispatchResult as a ApproveResponseBodyDispatchResult0
 func (t ApproveResponseBody_DispatchResult) AsApproveResponseBodyDispatchResult0() (ApproveResponseBodyDispatchResult0, error) {
@@ -9478,8 +9525,32 @@ type ClientInterface interface {
 	// VaultIndexUiVaultGet request
 	VaultIndexUiVaultGet(ctx context.Context, reqEditors ...RequestEditorFn) (*http.Response, error)
 
+	// VaultDeleteUiVaultDeletePostWithBody request with any body
+	VaultDeleteUiVaultDeletePostWithBody(ctx context.Context, contentType string, body io.Reader, reqEditors ...RequestEditorFn) (*http.Response, error)
+
+	VaultDeleteUiVaultDeletePostWithFormdataBody(ctx context.Context, body VaultDeleteUiVaultDeletePostFormdataRequestBody, reqEditors ...RequestEditorFn) (*http.Response, error)
+
+	// VaultDeleteConfirmUiVaultDeleteConfirmGet request
+	VaultDeleteConfirmUiVaultDeleteConfirmGet(ctx context.Context, params *VaultDeleteConfirmUiVaultDeleteConfirmGetParams, reqEditors ...RequestEditorFn) (*http.Response, error)
+
 	// VaultListUiVaultListGet request
 	VaultListUiVaultListGet(ctx context.Context, params *VaultListUiVaultListGetParams, reqEditors ...RequestEditorFn) (*http.Response, error)
+
+	// VaultMoveUiVaultMovePostWithBody request with any body
+	VaultMoveUiVaultMovePostWithBody(ctx context.Context, contentType string, body io.Reader, reqEditors ...RequestEditorFn) (*http.Response, error)
+
+	VaultMoveUiVaultMovePostWithFormdataBody(ctx context.Context, body VaultMoveUiVaultMovePostFormdataRequestBody, reqEditors ...RequestEditorFn) (*http.Response, error)
+
+	// VaultMoveConfirmUiVaultMoveConfirmGet request
+	VaultMoveConfirmUiVaultMoveConfirmGet(ctx context.Context, reqEditors ...RequestEditorFn) (*http.Response, error)
+
+	// VaultPutUiVaultPutPostWithBody request with any body
+	VaultPutUiVaultPutPostWithBody(ctx context.Context, contentType string, body io.Reader, reqEditors ...RequestEditorFn) (*http.Response, error)
+
+	VaultPutUiVaultPutPostWithFormdataBody(ctx context.Context, body VaultPutUiVaultPutPostFormdataRequestBody, reqEditors ...RequestEditorFn) (*http.Response, error)
+
+	// VaultPutConfirmUiVaultPutConfirmGet request
+	VaultPutConfirmUiVaultPutConfirmGet(ctx context.Context, params *VaultPutConfirmUiVaultPutConfirmGetParams, reqEditors ...RequestEditorFn) (*http.Response, error)
 
 	// VaultReadUiVaultReadGet request
 	VaultReadUiVaultReadGet(ctx context.Context, params *VaultReadUiVaultReadGetParams, reqEditors ...RequestEditorFn) (*http.Response, error)
@@ -14711,8 +14782,116 @@ func (c *Client) VaultIndexUiVaultGet(ctx context.Context, reqEditors ...Request
 	return c.Client.Do(req)
 }
 
+func (c *Client) VaultDeleteUiVaultDeletePostWithBody(ctx context.Context, contentType string, body io.Reader, reqEditors ...RequestEditorFn) (*http.Response, error) {
+	req, err := NewVaultDeleteUiVaultDeletePostRequestWithBody(c.Server, contentType, body)
+	if err != nil {
+		return nil, err
+	}
+	req = req.WithContext(ctx)
+	if err := c.applyEditors(ctx, req, reqEditors); err != nil {
+		return nil, err
+	}
+	return c.Client.Do(req)
+}
+
+func (c *Client) VaultDeleteUiVaultDeletePostWithFormdataBody(ctx context.Context, body VaultDeleteUiVaultDeletePostFormdataRequestBody, reqEditors ...RequestEditorFn) (*http.Response, error) {
+	req, err := NewVaultDeleteUiVaultDeletePostRequestWithFormdataBody(c.Server, body)
+	if err != nil {
+		return nil, err
+	}
+	req = req.WithContext(ctx)
+	if err := c.applyEditors(ctx, req, reqEditors); err != nil {
+		return nil, err
+	}
+	return c.Client.Do(req)
+}
+
+func (c *Client) VaultDeleteConfirmUiVaultDeleteConfirmGet(ctx context.Context, params *VaultDeleteConfirmUiVaultDeleteConfirmGetParams, reqEditors ...RequestEditorFn) (*http.Response, error) {
+	req, err := NewVaultDeleteConfirmUiVaultDeleteConfirmGetRequest(c.Server, params)
+	if err != nil {
+		return nil, err
+	}
+	req = req.WithContext(ctx)
+	if err := c.applyEditors(ctx, req, reqEditors); err != nil {
+		return nil, err
+	}
+	return c.Client.Do(req)
+}
+
 func (c *Client) VaultListUiVaultListGet(ctx context.Context, params *VaultListUiVaultListGetParams, reqEditors ...RequestEditorFn) (*http.Response, error) {
 	req, err := NewVaultListUiVaultListGetRequest(c.Server, params)
+	if err != nil {
+		return nil, err
+	}
+	req = req.WithContext(ctx)
+	if err := c.applyEditors(ctx, req, reqEditors); err != nil {
+		return nil, err
+	}
+	return c.Client.Do(req)
+}
+
+func (c *Client) VaultMoveUiVaultMovePostWithBody(ctx context.Context, contentType string, body io.Reader, reqEditors ...RequestEditorFn) (*http.Response, error) {
+	req, err := NewVaultMoveUiVaultMovePostRequestWithBody(c.Server, contentType, body)
+	if err != nil {
+		return nil, err
+	}
+	req = req.WithContext(ctx)
+	if err := c.applyEditors(ctx, req, reqEditors); err != nil {
+		return nil, err
+	}
+	return c.Client.Do(req)
+}
+
+func (c *Client) VaultMoveUiVaultMovePostWithFormdataBody(ctx context.Context, body VaultMoveUiVaultMovePostFormdataRequestBody, reqEditors ...RequestEditorFn) (*http.Response, error) {
+	req, err := NewVaultMoveUiVaultMovePostRequestWithFormdataBody(c.Server, body)
+	if err != nil {
+		return nil, err
+	}
+	req = req.WithContext(ctx)
+	if err := c.applyEditors(ctx, req, reqEditors); err != nil {
+		return nil, err
+	}
+	return c.Client.Do(req)
+}
+
+func (c *Client) VaultMoveConfirmUiVaultMoveConfirmGet(ctx context.Context, reqEditors ...RequestEditorFn) (*http.Response, error) {
+	req, err := NewVaultMoveConfirmUiVaultMoveConfirmGetRequest(c.Server)
+	if err != nil {
+		return nil, err
+	}
+	req = req.WithContext(ctx)
+	if err := c.applyEditors(ctx, req, reqEditors); err != nil {
+		return nil, err
+	}
+	return c.Client.Do(req)
+}
+
+func (c *Client) VaultPutUiVaultPutPostWithBody(ctx context.Context, contentType string, body io.Reader, reqEditors ...RequestEditorFn) (*http.Response, error) {
+	req, err := NewVaultPutUiVaultPutPostRequestWithBody(c.Server, contentType, body)
+	if err != nil {
+		return nil, err
+	}
+	req = req.WithContext(ctx)
+	if err := c.applyEditors(ctx, req, reqEditors); err != nil {
+		return nil, err
+	}
+	return c.Client.Do(req)
+}
+
+func (c *Client) VaultPutUiVaultPutPostWithFormdataBody(ctx context.Context, body VaultPutUiVaultPutPostFormdataRequestBody, reqEditors ...RequestEditorFn) (*http.Response, error) {
+	req, err := NewVaultPutUiVaultPutPostRequestWithFormdataBody(c.Server, body)
+	if err != nil {
+		return nil, err
+	}
+	req = req.WithContext(ctx)
+	if err := c.applyEditors(ctx, req, reqEditors); err != nil {
+		return nil, err
+	}
+	return c.Client.Do(req)
+}
+
+func (c *Client) VaultPutConfirmUiVaultPutConfirmGet(ctx context.Context, params *VaultPutConfirmUiVaultPutConfirmGetParams, reqEditors ...RequestEditorFn) (*http.Response, error) {
+	req, err := NewVaultPutConfirmUiVaultPutConfirmGetRequest(c.Server, params)
 	if err != nil {
 		return nil, err
 	}
@@ -30911,6 +31090,127 @@ func NewVaultIndexUiVaultGetRequest(server string) (*http.Request, error) {
 	return req, nil
 }
 
+// NewVaultDeleteUiVaultDeletePostRequestWithFormdataBody calls the generic VaultDeleteUiVaultDeletePost builder with application/x-www-form-urlencoded body
+func NewVaultDeleteUiVaultDeletePostRequestWithFormdataBody(server string, body VaultDeleteUiVaultDeletePostFormdataRequestBody) (*http.Request, error) {
+	var bodyReader io.Reader
+	bodyStr, err := runtime.MarshalForm(body, nil)
+	if err != nil {
+		return nil, err
+	}
+	bodyReader = strings.NewReader(bodyStr.Encode())
+	return NewVaultDeleteUiVaultDeletePostRequestWithBody(server, "application/x-www-form-urlencoded", bodyReader)
+}
+
+// NewVaultDeleteUiVaultDeletePostRequestWithBody generates requests for VaultDeleteUiVaultDeletePost with any type of body
+func NewVaultDeleteUiVaultDeletePostRequestWithBody(server string, contentType string, body io.Reader) (*http.Request, error) {
+	var err error
+
+	serverURL, err := url.Parse(server)
+	if err != nil {
+		return nil, err
+	}
+
+	operationPath := fmt.Sprintf("/ui/vault/delete")
+	if operationPath[0] == '/' {
+		operationPath = "." + operationPath
+	}
+
+	queryURL, err := serverURL.Parse(operationPath)
+	if err != nil {
+		return nil, err
+	}
+
+	req, err := http.NewRequest("POST", queryURL.String(), body)
+	if err != nil {
+		return nil, err
+	}
+
+	req.Header.Add("Content-Type", contentType)
+
+	return req, nil
+}
+
+// NewVaultDeleteConfirmUiVaultDeleteConfirmGetRequest generates requests for VaultDeleteConfirmUiVaultDeleteConfirmGet
+func NewVaultDeleteConfirmUiVaultDeleteConfirmGetRequest(server string, params *VaultDeleteConfirmUiVaultDeleteConfirmGetParams) (*http.Request, error) {
+	var err error
+
+	serverURL, err := url.Parse(server)
+	if err != nil {
+		return nil, err
+	}
+
+	operationPath := fmt.Sprintf("/ui/vault/delete/confirm")
+	if operationPath[0] == '/' {
+		operationPath = "." + operationPath
+	}
+
+	queryURL, err := serverURL.Parse(operationPath)
+	if err != nil {
+		return nil, err
+	}
+
+	if params != nil {
+		queryValues := queryURL.Query()
+
+		if params.Target != nil {
+
+			if queryFrag, err := runtime.StyleParamWithLocation("form", true, "target", runtime.ParamLocationQuery, *params.Target); err != nil {
+				return nil, err
+			} else if parsed, err := url.ParseQuery(queryFrag); err != nil {
+				return nil, err
+			} else {
+				for k, v := range parsed {
+					for _, v2 := range v {
+						queryValues.Add(k, v2)
+					}
+				}
+			}
+
+		}
+
+		if params.Mount != nil {
+
+			if queryFrag, err := runtime.StyleParamWithLocation("form", true, "mount", runtime.ParamLocationQuery, *params.Mount); err != nil {
+				return nil, err
+			} else if parsed, err := url.ParseQuery(queryFrag); err != nil {
+				return nil, err
+			} else {
+				for k, v := range parsed {
+					for _, v2 := range v {
+						queryValues.Add(k, v2)
+					}
+				}
+			}
+
+		}
+
+		if params.Path != nil {
+
+			if queryFrag, err := runtime.StyleParamWithLocation("form", true, "path", runtime.ParamLocationQuery, *params.Path); err != nil {
+				return nil, err
+			} else if parsed, err := url.ParseQuery(queryFrag); err != nil {
+				return nil, err
+			} else {
+				for k, v := range parsed {
+					for _, v2 := range v {
+						queryValues.Add(k, v2)
+					}
+				}
+			}
+
+		}
+
+		queryURL.RawQuery = queryValues.Encode()
+	}
+
+	req, err := http.NewRequest("GET", queryURL.String(), nil)
+	if err != nil {
+		return nil, err
+	}
+
+	return req, nil
+}
+
 // NewVaultListUiVaultListGetRequest generates requests for VaultListUiVaultListGet
 func NewVaultListUiVaultListGetRequest(server string, params *VaultListUiVaultListGetParams) (*http.Request, error) {
 	var err error
@@ -30921,6 +31221,194 @@ func NewVaultListUiVaultListGetRequest(server string, params *VaultListUiVaultLi
 	}
 
 	operationPath := fmt.Sprintf("/ui/vault/list")
+	if operationPath[0] == '/' {
+		operationPath = "." + operationPath
+	}
+
+	queryURL, err := serverURL.Parse(operationPath)
+	if err != nil {
+		return nil, err
+	}
+
+	if params != nil {
+		queryValues := queryURL.Query()
+
+		if params.Target != nil {
+
+			if queryFrag, err := runtime.StyleParamWithLocation("form", true, "target", runtime.ParamLocationQuery, *params.Target); err != nil {
+				return nil, err
+			} else if parsed, err := url.ParseQuery(queryFrag); err != nil {
+				return nil, err
+			} else {
+				for k, v := range parsed {
+					for _, v2 := range v {
+						queryValues.Add(k, v2)
+					}
+				}
+			}
+
+		}
+
+		if params.Mount != nil {
+
+			if queryFrag, err := runtime.StyleParamWithLocation("form", true, "mount", runtime.ParamLocationQuery, *params.Mount); err != nil {
+				return nil, err
+			} else if parsed, err := url.ParseQuery(queryFrag); err != nil {
+				return nil, err
+			} else {
+				for k, v := range parsed {
+					for _, v2 := range v {
+						queryValues.Add(k, v2)
+					}
+				}
+			}
+
+		}
+
+		if params.Path != nil {
+
+			if queryFrag, err := runtime.StyleParamWithLocation("form", true, "path", runtime.ParamLocationQuery, *params.Path); err != nil {
+				return nil, err
+			} else if parsed, err := url.ParseQuery(queryFrag); err != nil {
+				return nil, err
+			} else {
+				for k, v := range parsed {
+					for _, v2 := range v {
+						queryValues.Add(k, v2)
+					}
+				}
+			}
+
+		}
+
+		queryURL.RawQuery = queryValues.Encode()
+	}
+
+	req, err := http.NewRequest("GET", queryURL.String(), nil)
+	if err != nil {
+		return nil, err
+	}
+
+	return req, nil
+}
+
+// NewVaultMoveUiVaultMovePostRequestWithFormdataBody calls the generic VaultMoveUiVaultMovePost builder with application/x-www-form-urlencoded body
+func NewVaultMoveUiVaultMovePostRequestWithFormdataBody(server string, body VaultMoveUiVaultMovePostFormdataRequestBody) (*http.Request, error) {
+	var bodyReader io.Reader
+	bodyStr, err := runtime.MarshalForm(body, nil)
+	if err != nil {
+		return nil, err
+	}
+	bodyReader = strings.NewReader(bodyStr.Encode())
+	return NewVaultMoveUiVaultMovePostRequestWithBody(server, "application/x-www-form-urlencoded", bodyReader)
+}
+
+// NewVaultMoveUiVaultMovePostRequestWithBody generates requests for VaultMoveUiVaultMovePost with any type of body
+func NewVaultMoveUiVaultMovePostRequestWithBody(server string, contentType string, body io.Reader) (*http.Request, error) {
+	var err error
+
+	serverURL, err := url.Parse(server)
+	if err != nil {
+		return nil, err
+	}
+
+	operationPath := fmt.Sprintf("/ui/vault/move")
+	if operationPath[0] == '/' {
+		operationPath = "." + operationPath
+	}
+
+	queryURL, err := serverURL.Parse(operationPath)
+	if err != nil {
+		return nil, err
+	}
+
+	req, err := http.NewRequest("POST", queryURL.String(), body)
+	if err != nil {
+		return nil, err
+	}
+
+	req.Header.Add("Content-Type", contentType)
+
+	return req, nil
+}
+
+// NewVaultMoveConfirmUiVaultMoveConfirmGetRequest generates requests for VaultMoveConfirmUiVaultMoveConfirmGet
+func NewVaultMoveConfirmUiVaultMoveConfirmGetRequest(server string) (*http.Request, error) {
+	var err error
+
+	serverURL, err := url.Parse(server)
+	if err != nil {
+		return nil, err
+	}
+
+	operationPath := fmt.Sprintf("/ui/vault/move/confirm")
+	if operationPath[0] == '/' {
+		operationPath = "." + operationPath
+	}
+
+	queryURL, err := serverURL.Parse(operationPath)
+	if err != nil {
+		return nil, err
+	}
+
+	req, err := http.NewRequest("GET", queryURL.String(), nil)
+	if err != nil {
+		return nil, err
+	}
+
+	return req, nil
+}
+
+// NewVaultPutUiVaultPutPostRequestWithFormdataBody calls the generic VaultPutUiVaultPutPost builder with application/x-www-form-urlencoded body
+func NewVaultPutUiVaultPutPostRequestWithFormdataBody(server string, body VaultPutUiVaultPutPostFormdataRequestBody) (*http.Request, error) {
+	var bodyReader io.Reader
+	bodyStr, err := runtime.MarshalForm(body, nil)
+	if err != nil {
+		return nil, err
+	}
+	bodyReader = strings.NewReader(bodyStr.Encode())
+	return NewVaultPutUiVaultPutPostRequestWithBody(server, "application/x-www-form-urlencoded", bodyReader)
+}
+
+// NewVaultPutUiVaultPutPostRequestWithBody generates requests for VaultPutUiVaultPutPost with any type of body
+func NewVaultPutUiVaultPutPostRequestWithBody(server string, contentType string, body io.Reader) (*http.Request, error) {
+	var err error
+
+	serverURL, err := url.Parse(server)
+	if err != nil {
+		return nil, err
+	}
+
+	operationPath := fmt.Sprintf("/ui/vault/put")
+	if operationPath[0] == '/' {
+		operationPath = "." + operationPath
+	}
+
+	queryURL, err := serverURL.Parse(operationPath)
+	if err != nil {
+		return nil, err
+	}
+
+	req, err := http.NewRequest("POST", queryURL.String(), body)
+	if err != nil {
+		return nil, err
+	}
+
+	req.Header.Add("Content-Type", contentType)
+
+	return req, nil
+}
+
+// NewVaultPutConfirmUiVaultPutConfirmGetRequest generates requests for VaultPutConfirmUiVaultPutConfirmGet
+func NewVaultPutConfirmUiVaultPutConfirmGetRequest(server string, params *VaultPutConfirmUiVaultPutConfirmGetParams) (*http.Request, error) {
+	var err error
+
+	serverURL, err := url.Parse(server)
+	if err != nil {
+		return nil, err
+	}
+
+	operationPath := fmt.Sprintf("/ui/vault/put/confirm")
 	if operationPath[0] == '/' {
 		operationPath = "." + operationPath
 	}
@@ -32376,8 +32864,32 @@ type ClientWithResponsesInterface interface {
 	// VaultIndexUiVaultGetWithResponse request
 	VaultIndexUiVaultGetWithResponse(ctx context.Context, reqEditors ...RequestEditorFn) (*VaultIndexUiVaultGetResponse, error)
 
+	// VaultDeleteUiVaultDeletePostWithBodyWithResponse request with any body
+	VaultDeleteUiVaultDeletePostWithBodyWithResponse(ctx context.Context, contentType string, body io.Reader, reqEditors ...RequestEditorFn) (*VaultDeleteUiVaultDeletePostResponse, error)
+
+	VaultDeleteUiVaultDeletePostWithFormdataBodyWithResponse(ctx context.Context, body VaultDeleteUiVaultDeletePostFormdataRequestBody, reqEditors ...RequestEditorFn) (*VaultDeleteUiVaultDeletePostResponse, error)
+
+	// VaultDeleteConfirmUiVaultDeleteConfirmGetWithResponse request
+	VaultDeleteConfirmUiVaultDeleteConfirmGetWithResponse(ctx context.Context, params *VaultDeleteConfirmUiVaultDeleteConfirmGetParams, reqEditors ...RequestEditorFn) (*VaultDeleteConfirmUiVaultDeleteConfirmGetResponse, error)
+
 	// VaultListUiVaultListGetWithResponse request
 	VaultListUiVaultListGetWithResponse(ctx context.Context, params *VaultListUiVaultListGetParams, reqEditors ...RequestEditorFn) (*VaultListUiVaultListGetResponse, error)
+
+	// VaultMoveUiVaultMovePostWithBodyWithResponse request with any body
+	VaultMoveUiVaultMovePostWithBodyWithResponse(ctx context.Context, contentType string, body io.Reader, reqEditors ...RequestEditorFn) (*VaultMoveUiVaultMovePostResponse, error)
+
+	VaultMoveUiVaultMovePostWithFormdataBodyWithResponse(ctx context.Context, body VaultMoveUiVaultMovePostFormdataRequestBody, reqEditors ...RequestEditorFn) (*VaultMoveUiVaultMovePostResponse, error)
+
+	// VaultMoveConfirmUiVaultMoveConfirmGetWithResponse request
+	VaultMoveConfirmUiVaultMoveConfirmGetWithResponse(ctx context.Context, reqEditors ...RequestEditorFn) (*VaultMoveConfirmUiVaultMoveConfirmGetResponse, error)
+
+	// VaultPutUiVaultPutPostWithBodyWithResponse request with any body
+	VaultPutUiVaultPutPostWithBodyWithResponse(ctx context.Context, contentType string, body io.Reader, reqEditors ...RequestEditorFn) (*VaultPutUiVaultPutPostResponse, error)
+
+	VaultPutUiVaultPutPostWithFormdataBodyWithResponse(ctx context.Context, body VaultPutUiVaultPutPostFormdataRequestBody, reqEditors ...RequestEditorFn) (*VaultPutUiVaultPutPostResponse, error)
+
+	// VaultPutConfirmUiVaultPutConfirmGetWithResponse request
+	VaultPutConfirmUiVaultPutConfirmGetWithResponse(ctx context.Context, params *VaultPutConfirmUiVaultPutConfirmGetParams, reqEditors ...RequestEditorFn) (*VaultPutConfirmUiVaultPutConfirmGetResponse, error)
 
 	// VaultReadUiVaultReadGetWithResponse request
 	VaultReadUiVaultReadGetWithResponse(ctx context.Context, params *VaultReadUiVaultReadGetParams, reqEditors ...RequestEditorFn) (*VaultReadUiVaultReadGetResponse, error)
@@ -38756,6 +39268,50 @@ func (r VaultIndexUiVaultGetResponse) StatusCode() int {
 	return 0
 }
 
+type VaultDeleteUiVaultDeletePostResponse struct {
+	Body         []byte
+	HTTPResponse *http.Response
+	JSON422      *HTTPValidationError
+}
+
+// Status returns HTTPResponse.Status
+func (r VaultDeleteUiVaultDeletePostResponse) Status() string {
+	if r.HTTPResponse != nil {
+		return r.HTTPResponse.Status
+	}
+	return http.StatusText(0)
+}
+
+// StatusCode returns HTTPResponse.StatusCode
+func (r VaultDeleteUiVaultDeletePostResponse) StatusCode() int {
+	if r.HTTPResponse != nil {
+		return r.HTTPResponse.StatusCode
+	}
+	return 0
+}
+
+type VaultDeleteConfirmUiVaultDeleteConfirmGetResponse struct {
+	Body         []byte
+	HTTPResponse *http.Response
+	JSON422      *HTTPValidationError
+}
+
+// Status returns HTTPResponse.Status
+func (r VaultDeleteConfirmUiVaultDeleteConfirmGetResponse) Status() string {
+	if r.HTTPResponse != nil {
+		return r.HTTPResponse.Status
+	}
+	return http.StatusText(0)
+}
+
+// StatusCode returns HTTPResponse.StatusCode
+func (r VaultDeleteConfirmUiVaultDeleteConfirmGetResponse) StatusCode() int {
+	if r.HTTPResponse != nil {
+		return r.HTTPResponse.StatusCode
+	}
+	return 0
+}
+
 type VaultListUiVaultListGetResponse struct {
 	Body         []byte
 	HTTPResponse *http.Response
@@ -38772,6 +39328,93 @@ func (r VaultListUiVaultListGetResponse) Status() string {
 
 // StatusCode returns HTTPResponse.StatusCode
 func (r VaultListUiVaultListGetResponse) StatusCode() int {
+	if r.HTTPResponse != nil {
+		return r.HTTPResponse.StatusCode
+	}
+	return 0
+}
+
+type VaultMoveUiVaultMovePostResponse struct {
+	Body         []byte
+	HTTPResponse *http.Response
+	JSON422      *HTTPValidationError
+}
+
+// Status returns HTTPResponse.Status
+func (r VaultMoveUiVaultMovePostResponse) Status() string {
+	if r.HTTPResponse != nil {
+		return r.HTTPResponse.Status
+	}
+	return http.StatusText(0)
+}
+
+// StatusCode returns HTTPResponse.StatusCode
+func (r VaultMoveUiVaultMovePostResponse) StatusCode() int {
+	if r.HTTPResponse != nil {
+		return r.HTTPResponse.StatusCode
+	}
+	return 0
+}
+
+type VaultMoveConfirmUiVaultMoveConfirmGetResponse struct {
+	Body         []byte
+	HTTPResponse *http.Response
+}
+
+// Status returns HTTPResponse.Status
+func (r VaultMoveConfirmUiVaultMoveConfirmGetResponse) Status() string {
+	if r.HTTPResponse != nil {
+		return r.HTTPResponse.Status
+	}
+	return http.StatusText(0)
+}
+
+// StatusCode returns HTTPResponse.StatusCode
+func (r VaultMoveConfirmUiVaultMoveConfirmGetResponse) StatusCode() int {
+	if r.HTTPResponse != nil {
+		return r.HTTPResponse.StatusCode
+	}
+	return 0
+}
+
+type VaultPutUiVaultPutPostResponse struct {
+	Body         []byte
+	HTTPResponse *http.Response
+	JSON422      *HTTPValidationError
+}
+
+// Status returns HTTPResponse.Status
+func (r VaultPutUiVaultPutPostResponse) Status() string {
+	if r.HTTPResponse != nil {
+		return r.HTTPResponse.Status
+	}
+	return http.StatusText(0)
+}
+
+// StatusCode returns HTTPResponse.StatusCode
+func (r VaultPutUiVaultPutPostResponse) StatusCode() int {
+	if r.HTTPResponse != nil {
+		return r.HTTPResponse.StatusCode
+	}
+	return 0
+}
+
+type VaultPutConfirmUiVaultPutConfirmGetResponse struct {
+	Body         []byte
+	HTTPResponse *http.Response
+	JSON422      *HTTPValidationError
+}
+
+// Status returns HTTPResponse.Status
+func (r VaultPutConfirmUiVaultPutConfirmGetResponse) Status() string {
+	if r.HTTPResponse != nil {
+		return r.HTTPResponse.Status
+	}
+	return http.StatusText(0)
+}
+
+// StatusCode returns HTTPResponse.StatusCode
+func (r VaultPutConfirmUiVaultPutConfirmGetResponse) StatusCode() int {
 	if r.HTTPResponse != nil {
 		return r.HTTPResponse.StatusCode
 	}
@@ -42606,6 +43249,32 @@ func (c *ClientWithResponses) VaultIndexUiVaultGetWithResponse(ctx context.Conte
 	return ParseVaultIndexUiVaultGetResponse(rsp)
 }
 
+// VaultDeleteUiVaultDeletePostWithBodyWithResponse request with arbitrary body returning *VaultDeleteUiVaultDeletePostResponse
+func (c *ClientWithResponses) VaultDeleteUiVaultDeletePostWithBodyWithResponse(ctx context.Context, contentType string, body io.Reader, reqEditors ...RequestEditorFn) (*VaultDeleteUiVaultDeletePostResponse, error) {
+	rsp, err := c.VaultDeleteUiVaultDeletePostWithBody(ctx, contentType, body, reqEditors...)
+	if err != nil {
+		return nil, err
+	}
+	return ParseVaultDeleteUiVaultDeletePostResponse(rsp)
+}
+
+func (c *ClientWithResponses) VaultDeleteUiVaultDeletePostWithFormdataBodyWithResponse(ctx context.Context, body VaultDeleteUiVaultDeletePostFormdataRequestBody, reqEditors ...RequestEditorFn) (*VaultDeleteUiVaultDeletePostResponse, error) {
+	rsp, err := c.VaultDeleteUiVaultDeletePostWithFormdataBody(ctx, body, reqEditors...)
+	if err != nil {
+		return nil, err
+	}
+	return ParseVaultDeleteUiVaultDeletePostResponse(rsp)
+}
+
+// VaultDeleteConfirmUiVaultDeleteConfirmGetWithResponse request returning *VaultDeleteConfirmUiVaultDeleteConfirmGetResponse
+func (c *ClientWithResponses) VaultDeleteConfirmUiVaultDeleteConfirmGetWithResponse(ctx context.Context, params *VaultDeleteConfirmUiVaultDeleteConfirmGetParams, reqEditors ...RequestEditorFn) (*VaultDeleteConfirmUiVaultDeleteConfirmGetResponse, error) {
+	rsp, err := c.VaultDeleteConfirmUiVaultDeleteConfirmGet(ctx, params, reqEditors...)
+	if err != nil {
+		return nil, err
+	}
+	return ParseVaultDeleteConfirmUiVaultDeleteConfirmGetResponse(rsp)
+}
+
 // VaultListUiVaultListGetWithResponse request returning *VaultListUiVaultListGetResponse
 func (c *ClientWithResponses) VaultListUiVaultListGetWithResponse(ctx context.Context, params *VaultListUiVaultListGetParams, reqEditors ...RequestEditorFn) (*VaultListUiVaultListGetResponse, error) {
 	rsp, err := c.VaultListUiVaultListGet(ctx, params, reqEditors...)
@@ -42613,6 +43282,58 @@ func (c *ClientWithResponses) VaultListUiVaultListGetWithResponse(ctx context.Co
 		return nil, err
 	}
 	return ParseVaultListUiVaultListGetResponse(rsp)
+}
+
+// VaultMoveUiVaultMovePostWithBodyWithResponse request with arbitrary body returning *VaultMoveUiVaultMovePostResponse
+func (c *ClientWithResponses) VaultMoveUiVaultMovePostWithBodyWithResponse(ctx context.Context, contentType string, body io.Reader, reqEditors ...RequestEditorFn) (*VaultMoveUiVaultMovePostResponse, error) {
+	rsp, err := c.VaultMoveUiVaultMovePostWithBody(ctx, contentType, body, reqEditors...)
+	if err != nil {
+		return nil, err
+	}
+	return ParseVaultMoveUiVaultMovePostResponse(rsp)
+}
+
+func (c *ClientWithResponses) VaultMoveUiVaultMovePostWithFormdataBodyWithResponse(ctx context.Context, body VaultMoveUiVaultMovePostFormdataRequestBody, reqEditors ...RequestEditorFn) (*VaultMoveUiVaultMovePostResponse, error) {
+	rsp, err := c.VaultMoveUiVaultMovePostWithFormdataBody(ctx, body, reqEditors...)
+	if err != nil {
+		return nil, err
+	}
+	return ParseVaultMoveUiVaultMovePostResponse(rsp)
+}
+
+// VaultMoveConfirmUiVaultMoveConfirmGetWithResponse request returning *VaultMoveConfirmUiVaultMoveConfirmGetResponse
+func (c *ClientWithResponses) VaultMoveConfirmUiVaultMoveConfirmGetWithResponse(ctx context.Context, reqEditors ...RequestEditorFn) (*VaultMoveConfirmUiVaultMoveConfirmGetResponse, error) {
+	rsp, err := c.VaultMoveConfirmUiVaultMoveConfirmGet(ctx, reqEditors...)
+	if err != nil {
+		return nil, err
+	}
+	return ParseVaultMoveConfirmUiVaultMoveConfirmGetResponse(rsp)
+}
+
+// VaultPutUiVaultPutPostWithBodyWithResponse request with arbitrary body returning *VaultPutUiVaultPutPostResponse
+func (c *ClientWithResponses) VaultPutUiVaultPutPostWithBodyWithResponse(ctx context.Context, contentType string, body io.Reader, reqEditors ...RequestEditorFn) (*VaultPutUiVaultPutPostResponse, error) {
+	rsp, err := c.VaultPutUiVaultPutPostWithBody(ctx, contentType, body, reqEditors...)
+	if err != nil {
+		return nil, err
+	}
+	return ParseVaultPutUiVaultPutPostResponse(rsp)
+}
+
+func (c *ClientWithResponses) VaultPutUiVaultPutPostWithFormdataBodyWithResponse(ctx context.Context, body VaultPutUiVaultPutPostFormdataRequestBody, reqEditors ...RequestEditorFn) (*VaultPutUiVaultPutPostResponse, error) {
+	rsp, err := c.VaultPutUiVaultPutPostWithFormdataBody(ctx, body, reqEditors...)
+	if err != nil {
+		return nil, err
+	}
+	return ParseVaultPutUiVaultPutPostResponse(rsp)
+}
+
+// VaultPutConfirmUiVaultPutConfirmGetWithResponse request returning *VaultPutConfirmUiVaultPutConfirmGetResponse
+func (c *ClientWithResponses) VaultPutConfirmUiVaultPutConfirmGetWithResponse(ctx context.Context, params *VaultPutConfirmUiVaultPutConfirmGetParams, reqEditors ...RequestEditorFn) (*VaultPutConfirmUiVaultPutConfirmGetResponse, error) {
+	rsp, err := c.VaultPutConfirmUiVaultPutConfirmGet(ctx, params, reqEditors...)
+	if err != nil {
+		return nil, err
+	}
+	return ParseVaultPutConfirmUiVaultPutConfirmGetResponse(rsp)
 }
 
 // VaultReadUiVaultReadGetWithResponse request returning *VaultReadUiVaultReadGetResponse
@@ -50601,6 +51322,58 @@ func ParseVaultIndexUiVaultGetResponse(rsp *http.Response) (*VaultIndexUiVaultGe
 	return response, nil
 }
 
+// ParseVaultDeleteUiVaultDeletePostResponse parses an HTTP response from a VaultDeleteUiVaultDeletePostWithResponse call
+func ParseVaultDeleteUiVaultDeletePostResponse(rsp *http.Response) (*VaultDeleteUiVaultDeletePostResponse, error) {
+	bodyBytes, err := io.ReadAll(rsp.Body)
+	defer func() { _ = rsp.Body.Close() }()
+	if err != nil {
+		return nil, err
+	}
+
+	response := &VaultDeleteUiVaultDeletePostResponse{
+		Body:         bodyBytes,
+		HTTPResponse: rsp,
+	}
+
+	switch {
+	case strings.Contains(rsp.Header.Get("Content-Type"), "json") && rsp.StatusCode == 422:
+		var dest HTTPValidationError
+		if err := json.Unmarshal(bodyBytes, &dest); err != nil {
+			return nil, err
+		}
+		response.JSON422 = &dest
+
+	}
+
+	return response, nil
+}
+
+// ParseVaultDeleteConfirmUiVaultDeleteConfirmGetResponse parses an HTTP response from a VaultDeleteConfirmUiVaultDeleteConfirmGetWithResponse call
+func ParseVaultDeleteConfirmUiVaultDeleteConfirmGetResponse(rsp *http.Response) (*VaultDeleteConfirmUiVaultDeleteConfirmGetResponse, error) {
+	bodyBytes, err := io.ReadAll(rsp.Body)
+	defer func() { _ = rsp.Body.Close() }()
+	if err != nil {
+		return nil, err
+	}
+
+	response := &VaultDeleteConfirmUiVaultDeleteConfirmGetResponse{
+		Body:         bodyBytes,
+		HTTPResponse: rsp,
+	}
+
+	switch {
+	case strings.Contains(rsp.Header.Get("Content-Type"), "json") && rsp.StatusCode == 422:
+		var dest HTTPValidationError
+		if err := json.Unmarshal(bodyBytes, &dest); err != nil {
+			return nil, err
+		}
+		response.JSON422 = &dest
+
+	}
+
+	return response, nil
+}
+
 // ParseVaultListUiVaultListGetResponse parses an HTTP response from a VaultListUiVaultListGetWithResponse call
 func ParseVaultListUiVaultListGetResponse(rsp *http.Response) (*VaultListUiVaultListGetResponse, error) {
 	bodyBytes, err := io.ReadAll(rsp.Body)
@@ -50610,6 +51383,100 @@ func ParseVaultListUiVaultListGetResponse(rsp *http.Response) (*VaultListUiVault
 	}
 
 	response := &VaultListUiVaultListGetResponse{
+		Body:         bodyBytes,
+		HTTPResponse: rsp,
+	}
+
+	switch {
+	case strings.Contains(rsp.Header.Get("Content-Type"), "json") && rsp.StatusCode == 422:
+		var dest HTTPValidationError
+		if err := json.Unmarshal(bodyBytes, &dest); err != nil {
+			return nil, err
+		}
+		response.JSON422 = &dest
+
+	}
+
+	return response, nil
+}
+
+// ParseVaultMoveUiVaultMovePostResponse parses an HTTP response from a VaultMoveUiVaultMovePostWithResponse call
+func ParseVaultMoveUiVaultMovePostResponse(rsp *http.Response) (*VaultMoveUiVaultMovePostResponse, error) {
+	bodyBytes, err := io.ReadAll(rsp.Body)
+	defer func() { _ = rsp.Body.Close() }()
+	if err != nil {
+		return nil, err
+	}
+
+	response := &VaultMoveUiVaultMovePostResponse{
+		Body:         bodyBytes,
+		HTTPResponse: rsp,
+	}
+
+	switch {
+	case strings.Contains(rsp.Header.Get("Content-Type"), "json") && rsp.StatusCode == 422:
+		var dest HTTPValidationError
+		if err := json.Unmarshal(bodyBytes, &dest); err != nil {
+			return nil, err
+		}
+		response.JSON422 = &dest
+
+	}
+
+	return response, nil
+}
+
+// ParseVaultMoveConfirmUiVaultMoveConfirmGetResponse parses an HTTP response from a VaultMoveConfirmUiVaultMoveConfirmGetWithResponse call
+func ParseVaultMoveConfirmUiVaultMoveConfirmGetResponse(rsp *http.Response) (*VaultMoveConfirmUiVaultMoveConfirmGetResponse, error) {
+	bodyBytes, err := io.ReadAll(rsp.Body)
+	defer func() { _ = rsp.Body.Close() }()
+	if err != nil {
+		return nil, err
+	}
+
+	response := &VaultMoveConfirmUiVaultMoveConfirmGetResponse{
+		Body:         bodyBytes,
+		HTTPResponse: rsp,
+	}
+
+	return response, nil
+}
+
+// ParseVaultPutUiVaultPutPostResponse parses an HTTP response from a VaultPutUiVaultPutPostWithResponse call
+func ParseVaultPutUiVaultPutPostResponse(rsp *http.Response) (*VaultPutUiVaultPutPostResponse, error) {
+	bodyBytes, err := io.ReadAll(rsp.Body)
+	defer func() { _ = rsp.Body.Close() }()
+	if err != nil {
+		return nil, err
+	}
+
+	response := &VaultPutUiVaultPutPostResponse{
+		Body:         bodyBytes,
+		HTTPResponse: rsp,
+	}
+
+	switch {
+	case strings.Contains(rsp.Header.Get("Content-Type"), "json") && rsp.StatusCode == 422:
+		var dest HTTPValidationError
+		if err := json.Unmarshal(bodyBytes, &dest); err != nil {
+			return nil, err
+		}
+		response.JSON422 = &dest
+
+	}
+
+	return response, nil
+}
+
+// ParseVaultPutConfirmUiVaultPutConfirmGetResponse parses an HTTP response from a VaultPutConfirmUiVaultPutConfirmGetWithResponse call
+func ParseVaultPutConfirmUiVaultPutConfirmGetResponse(rsp *http.Response) (*VaultPutConfirmUiVaultPutConfirmGetResponse, error) {
+	bodyBytes, err := io.ReadAll(rsp.Body)
+	defer func() { _ = rsp.Body.Close() }()
+	if err != nil {
+		return nil, err
+	}
+
+	response := &VaultPutConfirmUiVaultPutConfirmGetResponse{
 		Body:         bodyBytes,
 		HTTPResponse: rsp,
 	}

--- a/docs/codebase/ui.md
+++ b/docs/codebase/ui.md
@@ -2874,3 +2874,152 @@ is bound from `operator.sub` (`principal_sub=`) — there is no `tenant_filter`
   reuse without rotation, 401 propagation on a dead session), and the route
   ordering (retrieval include before stubs; literal diagnostics before any param
   route) + dashboard tile.
+
+## Vault console — confirm-gated writes (G10.18-T2 #1957)
+
+The mutating verbs over the T1 (#1956) read-only KV browser:
+confirm-gated `vault.kv.put` (CAS-aware), `vault.kv.delete` (soft-delete
+specific versions), and `secret.move` (references-not-values). These are the
+highest-blast-radius actions the Vault console gains — every one is
+`requires_approval=True`, so the gate is unmissable and the result render
+surfaces the approval handoff rather than a silent success. BFF + template
+assembly over the existing dispatcher; no new backend route, op, or
+meta-tool.
+
+### Module placement (separate from T1)
+
+The write routes live in `ui/routes/vault/writes.py`
+(`build_vault_writes_router`), a **separate module** from T1's
+`ui/routes/vault/routes.py` (`build_vault_router`, the read-only GET
+browser), so the read / write surfaces — and the parallel T3 status view
+(#1958) — evolve without serial-merge collisions on one shared file. The
+write module **reuses** T1's `_resolve_operator` / `_vault_connector_id` /
+`_default_path` (imported from `routes.py`) rather than re-deriving them, so
+the load-bearing connector-id-shape invariant lives in one place. Both
+routers are included ahead of the stubs aggregate in
+`ui.routes.build_router` (`build_vault_router()` then
+`build_vault_writes_router()`).
+
+### Routes
+
+* `GET /ui/vault/{put,delete,move}/confirm` — the unmissable
+  destructive-confirm modal fragments, modelled on the operations Run modal
+  (`operations/_run_modal.html`). Each renders a prominent `safety_level` /
+  `requires_approval` banner (`put` = `caution`, `delete` / `move` =
+  `dangerous`; all three `requires_approval`), the op-specific inputs, and a
+  confirm button carrying its **own** `hx-headers` CSRF echo (HTMX does not
+  inherit `hx-headers` to children). The GET mints a fresh CSRF token and
+  re-sets the `meho_csrf` cookie (`set_csrf_cookie`) so the double-submit
+  pair lines up after the HTMX swap rotated it (the #1693 / #1754
+  cookie-desync class). The confirm button carries `hx-disabled-elt` so a
+  high-impact write cannot be double-fired. Templates:
+  `vault/_confirm_{put,delete,move}.html`.
+* `POST /ui/vault/put` — dispatch `vault.kv.put` (`connector_id="vault-1.x"`,
+  target + `{mount, path, data, cas?}`). The `cas` Check-And-Set guard rides
+  in `params` **only when the operator set the field** (mirrors the CLI's
+  `Changed("cas")` rule: a blank field is "flag absent" → write
+  unconditionally, an explicit `cas=0` → write only if absent). The `data`
+  JSON is parsed server-side; malformed input is an inline 400 form error,
+  not a 422.
+* `POST /ui/vault/delete` — dispatch `vault.kv.delete` with the
+  comma-separated `versions` parsed into a non-empty list of positive ints.
+* `POST /ui/vault/move` — dispatch `secret.move` against the **separate**
+  `secret-broker-1.x` connector with the schema's `from` / `to` references
+  (+ optional `reason`). **Value-free**: no value input exists, no value
+  reaches the dispatched params, and the render surfaces only the
+  `{status, value_sha256, length}` confirmation — the no-`--value` invariant
+  the CLI keeps.
+
+### Two connector ids (load-bearing)
+
+`vault.kv.put` / `vault.kv.delete` dispatch `vault-1.x`; `secret.move`
+dispatches `secret-broker-1.x` — a **different** connector. Both
+`<impl_id>-<version>` ids are sourced from `list_ingested_connectors`
+(`state == "ingested"`, filtering `product == "vault"` vs
+`product == "secret"`) so a re-version flows through without a literal edit;
+the bare slugs `vault` / `secret` are never emitted (they 404 through
+`parse_connector_id`). `secret-broker` is a typed-op-only synthetic
+connector (no `register_connector_v2`), so the dispatcher resolves it from
+the registered `secret.move` op alone; the listing reports it ingested off
+its DB-backed `operation_group` / `endpoint_descriptor` rows.
+
+### CSRF (writes are gated; T1 reads are not)
+
+T1's four GET reads are CSRF-free (the middleware only guards
+state-changing methods). The write POSTs are gated by the `ui/csrf.py`
+double-submit middleware, which verifies the `X-CSRF-Token` header (or
+`csrf_token` form field) against the `meho_csrf` cookie HMAC **before** the
+route runs — so a POST without the token is a 403 the route never sees. The
+confirm GET mints + re-sets the cookie so the swapped-in confirm button's
+`hx-headers` echo matches.
+
+### awaiting_approval (the silent-success trap)
+
+`call_operation` always returns a structured `OperationResult` envelope;
+errors land inside it, not as HTTP 4xx. Because every write op is
+`requires_approval=True`, a human OPERATOR running one is routed to the
+approval queue (G11.7-T1 #1401), so the **common** return is
+`status="awaiting_approval"` with `extras["approval_request_id"]`. The
+shared result fragment (`vault/_write_result.html`) surfaces it as a banner
++ a deep-link into `/ui/approvals/{approval_request_id}` (the surface #1778
+shipped, `hx-get` into `#meho-approvals-modal-container`), so the operator
+never thinks the write silently no-op'd. The fragment's other branches:
+the value-free `secret.move` `ok` render (status / value_sha256 / length
+only); the put / delete `ok` render (a plain success, no secret value); the
+`error` / `denied` render via the shared `vault/_envelope_error.html` macro
+(which carries the `VaultTenantScopeError` "outside your tenant scope"
+friendly message — surfaced when an approved write re-dispatches against an
+out-of-scope path — and the generic `extras.error_code`); and the inline
+400 form-error / no-connector-hint branches.
+
+### RBAC (operator tier; the gate is policy, not role)
+
+The write verbs are OPERATOR-tier (like the operations Run surface) — there
+is **no** `tenant_admin` hard-403 on the write POST. Safety is enforced by
+the confirm modal + the dispatcher's `policy_gate` → approval queue, not by
+`TenantRole`; a role gate here would contradict the backend gate and the
+operations console. Tenant scoping derives from `operator.tenant_id` only
+(the session), never a form field. The tenant-scope guard
+(`connectors/vault/tenant_scope.py`, default-on since v0.15.0 #1725) runs
+**inside the connector handler**, so it trips on the executed (post-approval
+re-dispatch) path, not on the initial parked dispatch.
+
+### Redaction (top-sensitivity surface)
+
+No secret value reaches a server log, audit row, telemetry frame, or
+request-preview body. `vault.kv.put`'s `data` object is operator-supplied
+secret material; the BFF logs only op-id / connector-id / status /
+approval-id (`ui_vault_write_dispatch`), never the `params` or the envelope
+`result`. `secret.move` is value-free by the connector's own contract; the
+UI keeps that invariant by never offering a value field (a smuggled `value`
+form field is dropped — the dispatched params carry only `from` / `to` /
+`reason`).
+
+### Entry points + route ordering
+
+The T1 `vault/index.html` gains an additive "Write" action bar (Write /
+Delete / Move buttons that `hx-get` the confirm modals into a stable
+`#vault-write-modal-container`; the shared `app/modal-dialogs.js` controller
+auto-opens the swapped-in `<dialog class="modal">` via `showModal()`). Put /
+Delete carry the browser's current mount/path/target via `hx-include` so the
+confirm modal prefills them; Move takes references (a separate connector), so
+no path inputs. The literal `put` / `delete` / `move` (+ `…/confirm`)
+segments register before any `{param}` route on the shared `/ui/vault`
+router (first-match-wins); they are POST / distinct-literal routes, so they
+cannot collide with T1's GET slug routes regardless, but the ordering
+discipline is pinned.
+
+### Tests
+
+* `backend/tests/test_ui_vault_writes.py` — the confirm modals' safety
+  banners + CSRF re-mint + value-free move form (no value/secret/data input);
+  the `awaiting_approval` render (banner + `/ui/approvals` deep-link) end-to-
+  end through the real policy gate for put + move; the CSRF gate (403 without
+  the token, 200 with it); route ordering (`put/confirm` → confirm handler);
+  the CAS rule (carried only when set, blank ≠ `cas=0`); the `secret.move`
+  value-free contract (dispatches `secret-broker-1.x` with refs only, a
+  smuggled `value` field dropped, render carries only status/value_sha256/
+  length); RBAC (a plain operator runs all three writes, no `tenant_admin`
+  403); the `VaultTenantScopeError` friendly-message render branch; inline
+  400 form errors for malformed `data` / empty `versions` / missing
+  `from`/`to`; and the session gate.


### PR DESCRIPTION
## Summary

- **G10.18-T2 (#1957)** — adds the confirm-gated **write** verbs over the T1 (#1956) read-only Vault KV browser: `vault.kv.put` (CAS-aware), `vault.kv.delete` (soft-delete versions), and `secret.move` (references-not-values). The highest-blast-radius actions the Vault console gains.
- **BFF + template assembly only** — dispatches the existing, tested `call_operation` in-process (the same pattern the operations Run surface uses); no new backend route, op, or meta-tool.
- **Every write is `requires_approval=True`** → the confirm gate is unmissable and the result render surfaces the **approval handoff** (deep-linked to `/ui/approvals/{id}`) rather than a silent success.
- New module `ui/routes/vault/writes.py` (`build_vault_writes_router`), **separate** from T1's `routes.py` and the parallel T3 status view (#1958), to minimize serial-merge collisions; reuses T1's operator-lift + connector-id resolver.

### Load-bearing invariants

- **Two connector ids**, both sourced from `list_ingested_connectors` (never the bare slug / a hard-coded literal): `vault.kv.put`/`vault.kv.delete` → `vault-1.x`; `secret.move` → `secret-broker-1.x` (a *different* connector).
- **CSRF-gated POSTs** — the confirm GET mints + re-sets the `meho_csrf` cookie so the confirm button's `hx-headers` echo lines up after the HTMX swap; T1's reads stay CSRF-free.
- **`secret.move` value-free** — no value input, no value in dispatched params / response / log / render; only `{status, value_sha256, length}` surfaces (a smuggled `value` form field is dropped).
- **CAS rule** — `cas` rides in params only when the operator set the field (blank ≠ `cas=0`), mirroring the CLI `Changed("cas")` rule.
- **RBAC = operator tier** — no `tenant_admin` hard-403 on the write POST; the policy/approval gate (not a role tier) escalates the write. The tenant-scope guard's denial renders a friendly message, not a raw 403.
- **Redaction** — the BFF logs only op-id / connector-id / status / approval-id; never the `data` / `params` / result.

## Test plan

- [x] `ruff check` / `ruff format --check` — clean (backend writes module + tests)
- [x] `mypy src/meho_backplane/ui/routes/vault/` — clean
- [x] `pytest tests/test_ui_vault_writes.py` — **17 passed** (all acceptance criteria)
- [x] awaiting_approval (banner + `/ui/approvals` deep-link) for put + move — end-to-end through the **real policy gate**
- [x] `POST /ui/vault/delete` without CSRF → 403, with it → 200; `put/confirm` resolves to the confirm handler (route ordering)
- [x] CAS carried only when set (blank ≠ `cas=0`); `secret.move` dispatches `secret-broker-1.x` with refs only, smuggled `value` dropped, render value-free; operator runs all three writes (no `tenant_admin` 403); `VaultTenantScopeError` friendly render; inline 400 form errors
- [x] `pytest tests/test_ui_vault.py` — **10 passed** (T1 read regression after the `index.html` write-bar edit)
- [x] `pytest tests/test_ui_operations.py tests/test_ui_approvals.py` — **65 passed** (reused modal container + deep-link)
- [x] `pytest tests/test_secret_move_approval.py` — **10 passed** (secret.move connector regression)
- [x] `code-quality.py --diff` — exit 0
- [x] `cd cli && make snapshot-openapi && make generate` — regenerated `cli/api/openapi.json` + `cli/internal/api/client.gen.go` (the 6 new `/ui/vault/{put,delete,move}*` routes; `go build ./...` clean)

## Out of scope

- The KV browser scaffold (picker / list / read / versions) → T1 (#1956).
- Seal/health/mounts + auth-methods status view → T3 (#1958).
- The approval *decide* flow → `/ui/approvals` (#1778); this task only deep-links to it.
- `vault.kv.patch` (no CLI verb surfaces it).

<!-- auto-implement-issue: fresh, iteration 1 -->

Closes #1957


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **New Features**
  * Added write capabilities to the Vault secrets console: create/update secrets with optional consistency checks, soft-delete specific versions, and move secret references.
  * All write operations require confirmation and approval before execution, integrated into the approvals workflow.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->