### PR TITLE
fix(connectors): migration 0049 — retire stale long-product (vcf-logs) ingest orphan rows (#2001)

### DIFF
--- a/backend/alembic/versions/0049_retire_stale_vcf_logs_orphan_rows.py
+++ b/backend/alembic/versions/0049_retire_stale_vcf_logs_orphan_rows.py
@@ -1,0 +1,289 @@
+# SPDX-License-Identifier: Apache-2.0
+# Copyright (c) 2026 evoila Group
+
+"""Retire the stale long-product ingest orphan rows ``0038`` skipped.
+
+Revision ID: 0049
+Revises: 0048
+Create Date: 2026-06-21
+
+Initiative #1998 (G0.28 closed-loop dogfood hardening), Task #2001.
+The operation-row cleanup the long↔short product realignment
+(#1810 / #1814) deferred, and the destructive complement migration
+``0038`` deliberately left undone.
+
+Why this migration exists
+-------------------------
+
+The endpoint-descriptor product-split backfill (migration ``0038``,
+#1701) reconciled built-in ``tenant_id IS NULL`` rows from the long
+registry spelling (``vcf-logs`` etc.) to the short, dispatch-canonical
+spelling (``vrli`` etc.) -- **except** where a short-spelling twin
+already existed on the same global natural key. ``0038``'s correlated
+``NOT EXISTS`` guard *skips* those long rows rather than rewriting them
+(which would collide with the partial unique indexes from migration
+``0005``). A short twin pre-exists exactly when an operator re-ingested
+a VCF-family connector after upgrading -- the re-ingest auto-registers
+the short-product rows, and the post-#1677 register-time reconciliation
+writes new ingests under the short spelling too. The long row is then
+left behind, untouched.
+
+Those skipped rows are dead weight:
+
+* **Non-dispatchable.** Every dispatch / query probe
+  (:func:`~meho_backplane.operations._lookup.connector_exists`,
+  ``count_known_ops``, ``list_operation_groups``) keys on the short,
+  ``parse_connector_id``-derived product. A row physically stored under
+  ``product='vcf-logs'`` for ``impl_id='vrli-rest'`` is invisible to
+  all of them -- the short twin is the live row.
+* **Undeletable.** ``meho.connector.delete``
+  (:meth:`~meho_backplane.operations.ingest.service.IngestService.delete_connector`)
+  resolves its target via ``parse_connector_id``, which derives
+  ``product='vrli'`` from a ``vrli-rest-9.0.2`` connector_id. There is
+  no ``product`` selector on the REST route or the MCP tool, so the
+  long ``vcf-logs`` row can never be the DELETE target -- the only
+  outcome is ``ConnectorNotFoundError`` (#1910, the v0.16.x dogfood
+  finding). ``0038``'s own docstring delegated this cleanup to "the
+  DELETE surface (#1700)", which provably cannot reach a
+  divergent-product row.
+* **A review/enable_reads shadow.** Because the long row shares
+  ``(version, impl_id)`` with the live short twin, it surfaces as a
+  redundant ``vcf-logs`` candidate when an operator reviews / enables
+  reads on ``vrli-rest-9.0.2``.
+
+Migration ``0047`` (#1814) already reconciled the ``targets.product``
+side of this realignment; it neither did nor can retire these
+operation-row orphans (it rewrites ``targets``, not
+``operation_group`` / ``endpoint_descriptor``). This migration is the
+operation-row complement: it DELETEs the orphans the resolver can't
+reach.
+
+Fix shape -- Alembic data migration
+-----------------------------------
+
+Same self-contained shape as migrations ``0011`` / ``0038`` / ``0046``
+/ ``0047``: lightweight :func:`sa.table` / :func:`sa.column` shims
+mirror only the columns the migration touches, no ORM imports
+(importing the live models would pin the migration to one moment in the
+schema's history and break replay), and each statement executes
+synchronously via ``op.get_bind()``. No UUID bind params are written
+(this migration only DELETEs by text predicates), so the
+``docs/codebase/migrations.md`` UUID-binding rule does not apply.
+
+Mapping table
+-------------
+
+The six long->short product splits, snapshotted from ``_PRODUCT_SPLITS``
+in migration ``0038`` (which mirrors the connector registrations PR
+#1677 reconciled). ``vcf-logs`` -> ``vrli`` is the one the #1910 finding
+hit; the others are retired under the identical rule for completeness so
+no VCF-family connector carries an undeletable long-product shadow:
+
+==================  ================
+registry product    dispatch product
+==================  ================
+``hetzner-robot``   ``hetzner``
+``sddc-manager``    ``sddc``
+``vcf-automation``  ``vcfa``
+``vcf-fleet``       ``fleet``
+``vcf-logs``        ``vrli``
+``vcf-operations``  ``vrops``
+==================  ================
+
+Row-narrowing predicate
+-----------------------
+
+A row is deleted only when **all** of the following hold -- the exact
+inverse of ``0038``'s collision-skip:
+
+* ``tenant_id IS NULL`` -- built-in / global rows only. Tenant-scoped
+  rows are operator-owned (the #1699 NULL/UUID-namespace contract);
+  operators re-ingest under their tenant to update those. Same boundary
+  ``0038`` drew on the write side. **Never delete a tenant row.**
+* ``product = '<long>'`` -- the row still carries the pre-#1677 registry
+  spelling. (After ``0038`` ran, a long row only survives *because* it
+  was skipped -- i.e. a short twin exists; this DELETE finishes that
+  cleanup.)
+* ``impl_id = '<short>' OR impl_id LIKE '<short>-%'`` --
+  ``parse_connector_id``'s first-hyphen-segment rule expressed in
+  portable SQL. It scopes the DELETE to rows the dispatcher *would*
+  resolve under the short spelling, so a hypothetical
+  ``product='vcf-logs'`` row whose ``impl_id`` derives some *other*
+  product is left alone rather than wrongly retired.
+* ``EXISTS (<short twin>)`` -- the live-twin guard. A long row is
+  retired only when a short-product twin already exists on the same
+  global natural key, so the connector's operations remain represented
+  by the live (dispatchable) short rows. This is the same correlated
+  natural-key probe ``0038`` uses, with the polarity flipped from
+  ``NOT EXISTS`` (skip the long row) to ``EXISTS`` (retire it).
+  Crucially, a long row **without** a short twin is NOT deleted: it is
+  still the only representation of that operation, and ``0038`` would
+  have already rewritten it to the short spelling -- so a surviving
+  twin-less long row is an edge case (e.g. ``0038`` not yet applied)
+  where deleting would lose data. Leaving it for ``0038``'s rewrite is
+  the safe choice.
+
+Idempotency
+-----------
+
+The DELETE is self-idempotent: once the orphan rows are gone, the
+predicate matches nothing, so a re-run (or the stamp-back replay the
+test suite exercises) is a no-op. No ``updated_at`` to bump on a
+delete.
+
+``group_id`` linkage needs no touch-up: the deleted ``operation_group``
+orphans and their ``endpoint_descriptor`` orphans are retired under the
+same predicate, so a connector's descriptors and groups are removed
+together. The live short twins (a separate ``group_id`` lineage created
+by the re-ingest) are untouched.
+
+Reversibility contract
+----------------------
+
+``downgrade()`` is a documented no-op, same rationale as ``0038``: the
+deleted rows were never dispatchable (that is the defect) and carried no
+operator value -- the live short twins served every dispatch / review
+probe. Recreating them would re-introduce the undeletable shadow.
+Production rollback is image-revert plus the additive-only forward-compat
+contract (``docs/codebase/migrations.md``): a reverted image reads the
+live short rows exactly as it did before, because the short spelling is
+what the dispatch surface keyed on in every release. No DDL runs in
+``upgrade()``, so there is nothing to undo at the schema layer either.
+
+Cross-references
+----------------
+
+* Task #2001 / Initiative #1998 -- this cleanup.
+* Issue #1910 -- the dogfood finding (stale ``vcf-logs`` row +
+  undeletability) this retires.
+* Migration ``0038`` / #1701 -- the backfill whose collision-skip left
+  these orphans; this migration is its destructive complement.
+* Migration ``0047`` / #1814 -- the ``targets.product`` reconciliation
+  this completes on the operation-row side.
+* :func:`~meho_backplane.operations._lookup.parse_connector_id` -- the
+  product-derivation rule that makes a divergent-product row unreachable
+  for DELETE.
+* :mod:`tests.test_migration_0049_retire_stale_vcf_logs_orphan_rows` --
+  the behavioural contract: retire-with-twin, tenant boundary,
+  twin-less long row preserved, foreign impl_id preserved, unmapped
+  product preserved, idempotency, post-migration dispatch parity.
+"""
+
+from __future__ import annotations
+
+from collections.abc import Sequence
+
+import sqlalchemy as sa
+from alembic import op
+
+# revision identifiers, used by Alembic.
+revision: str = "0049"
+down_revision: str | None = "0048"
+branch_labels: str | Sequence[str] | None = None
+depends_on: str | Sequence[str] | None = None
+
+
+#: Every known long->short product split, as ``(long_product,
+#: short_product)``. Snapshot of ``_PRODUCT_SPLITS`` in migration
+#: ``0038`` (minus the per-split impl_id column: the impl_id predicate
+#: is *derived* from the short product below, mirroring how
+#: :func:`~meho_backplane.operations._lookup.parse_connector_id`
+#: derives the product from the first hyphen-segment of ``impl_id``).
+_PRODUCT_SPLITS: tuple[tuple[str, str], ...] = (
+    ("hetzner-robot", "hetzner"),
+    ("sddc-manager", "sddc"),
+    ("vcf-automation", "vcfa"),
+    ("vcf-fleet", "fleet"),
+    ("vcf-logs", "vrli"),
+    ("vcf-operations", "vrops"),
+)
+
+
+def _retire_table(*, table_name: str, op_discriminator: str) -> None:
+    """Issue one guarded DELETE per product split against *table_name*.
+
+    ``op_discriminator`` names the per-operation natural-key column that
+    completes the global unique index alongside ``(product, version,
+    impl_id)`` -- ``op_id`` on ``endpoint_descriptor``, ``group_key`` on
+    ``operation_group``. It participates only in the live-twin
+    correlation; the retire predicate itself is per-connector.
+
+    One statement per split (12 total across both tables) rather than a
+    single bulk DELETE -- same auditability call as ``0038``: the row
+    volume is small and per-split statements keep the SQL log
+    attributable.
+    """
+    shim = sa.table(
+        table_name,
+        sa.column("tenant_id", sa.Uuid()),
+        sa.column("product", sa.Text()),
+        sa.column("version", sa.Text()),
+        sa.column("impl_id", sa.Text()),
+        sa.column(op_discriminator, sa.Text()),
+    )
+    twin = shim.alias("twin")
+    bind = op.get_bind()
+
+    for long_product, short_product in _PRODUCT_SPLITS:
+        # Correlated existence probe for a live row already persisted
+        # under the short spelling on the same global natural key. The
+        # outer DELETE target correlates automatically; only ``twin`` is
+        # selected from. EXISTS (not NOT EXISTS as in 0038): we retire
+        # the long orphan only when the short twin is there to represent
+        # the connector.
+        short_twin_exists = (
+            sa.select(sa.literal(1))
+            .select_from(twin)
+            .where(
+                twin.c.tenant_id.is_(None),
+                twin.c.product == short_product,
+                twin.c.version == shim.c.version,
+                twin.c.impl_id == shim.c.impl_id,
+                twin.c[op_discriminator] == shim.c[op_discriminator],
+            )
+            .exists()
+        )
+        stmt = sa.delete(shim).where(
+            shim.c.tenant_id.is_(None),
+            shim.c.product == long_product,
+            # First-hyphen-segment rule from ``parse_connector_id``: the
+            # dispatcher resolves this row under ``short_product`` exactly
+            # when ``impl_id`` is the short product itself or starts with
+            # ``"<short>-"``.
+            sa.or_(
+                shim.c.impl_id == short_product,
+                shim.c.impl_id.like(f"{short_product}-%"),
+            ),
+            short_twin_exists,
+        )
+        bind.execute(stmt)
+
+
+def upgrade() -> None:
+    """Retire the long-product orphan rows whose live short twin exists.
+
+    Both row surfaces the dispatch/query layer reads --
+    ``endpoint_descriptor`` and ``operation_group`` -- are retired under
+    the same predicate so a connector's orphaned operations and groups
+    are removed together, leaving the live short twins as the sole
+    representation.
+    """
+    _retire_table(table_name="endpoint_descriptor", op_discriminator="op_id")
+    _retire_table(table_name="operation_group", op_discriminator="group_key")
+
+
+def downgrade() -> None:
+    """No-op by design.
+
+    The retired rows were never dispatchable (that is the defect this
+    migration fixes) and carried no operator value -- the live short
+    twins served every dispatch / review probe. Recreating them would
+    re-introduce the undeletable ``vcf-logs`` shadow. Production rollback
+    is image-revert plus the additive-only forward-compat contract
+    (``docs/codebase/migrations.md``); a reverted image reads the live
+    short rows exactly as it did before. No DDL runs in ``upgrade()``, so
+    there is nothing to undo at the schema layer either. Same
+    documented-no-op shape as migration ``0038``.
+    """
+    # Intentionally empty -- see docstring. The function stays defined so
+    # ``alembic downgrade -1`` resolves the symbol cleanly.

--- a/backend/tests/test_migration_0038_backfill_product_splits.py
+++ b/backend/tests/test_migration_0038_backfill_product_splits.py
@@ -403,8 +403,14 @@ def test_short_twin_collision_is_skipped_not_crashed(
         group_key="system",
     )
 
-    # Must not raise -- the guard, not the unique index, decides.
-    command.upgrade(cfg, "head")
+    # Must not raise -- the guard, not the unique index, decides. Pin the
+    # target to ``0038`` so this exercises 0038's collision-skip in
+    # isolation: a later leaf migration (``0049``) is the destructive
+    # complement that retires exactly this skipped long row, and running
+    # the full chain through ``head`` would delete it before the assertion
+    # below. The retire case is covered by
+    # ``test_migration_0049_*::test_orphan_with_live_twin_is_retired``.
+    command.upgrade(cfg, "0038")
 
     for table, long_id, short_id in (
         ("endpoint_descriptor", long_descriptor, short_descriptor),

--- a/backend/tests/test_migration_0049_retire_stale_vcf_logs_orphan_rows.py
+++ b/backend/tests/test_migration_0049_retire_stale_vcf_logs_orphan_rows.py
@@ -1,0 +1,611 @@
+# SPDX-License-Identifier: Apache-2.0
+# Copyright (c) 2026 evoila Group
+
+"""Behavioural tests for ``0049_retire_stale_vcf_logs_orphan_rows``.
+
+Initiative #1998 (G0.28 closed-loop dogfood hardening), Task #2001.
+The migration DELETEs the built-in ``tenant_id IS NULL`` long-product
+ingest orphans (``vcf-logs`` etc.) that migration ``0038``'s
+collision-guard deliberately skipped -- the operation-row complement
+of that backfill and of the ``targets.product`` reconciliation (#1814,
+migration ``0047``). Those orphans are non-dispatchable and unreachable
+by ``meho.connector.delete`` (#1910).
+
+Test matrix
+-----------
+
+* **Orphan with live twin -> retired.** A long ``(vcf-logs, 9.0,
+  vrli-rest)`` descriptor + group whose short ``(vrli, …)`` twin
+  already exists is DELETEd; the short twin survives untouched.
+* **All six splits, SQL-level counts.** One orphan + its short twin per
+  split; post-migration every long-product count is 0 and every
+  short-product count is 1, on both tables.
+* **Tenant-scoped rows -> preserved.** ``tenant_id IS NOT NULL`` rows
+  are operator-owned (#1699 scoping contract) and never deleted, even
+  with a short twin present.
+* **Twin-less long row -> preserved.** A long-product row with NO short
+  twin is the only representation of that operation; the EXISTS guard
+  leaves it alone (``0038`` rewrites it on the write side).
+* **Foreign impl_id -> preserved.** A ``product='vcf-logs'`` row whose
+  ``impl_id`` derives some other product is not retired (the predicate
+  mirrors ``parse_connector_id``'s first-hyphen-segment rule).
+* **Unmapped product -> preserved.** Aligned connectors
+  (``vmware`` / ``vmware-rest``) are outside the mapping and untouched.
+* **Idempotency.** Re-running ``upgrade()`` against an already-cleaned
+  DB (stamp back + re-upgrade) deletes nothing further and does not
+  disturb the surviving twins.
+* **Dispatch parity post-migration.** The live short twin still
+  resolves through ``connector_exists`` / ``count_known_ops`` after the
+  orphan is gone -- the cleanup removes only the invisible long rows.
+
+Sync-test constraint: ``alembic.command.upgrade`` drives env.py's
+async cookbook through ``asyncio.run``, so test functions stay sync and
+the dispatch-probe test wraps its async probe in its own
+``asyncio.run`` with an engine-cache reset on each side. Mirrors
+:mod:`tests.test_migration_0038_backfill_product_splits`.
+"""
+
+from __future__ import annotations
+
+import asyncio
+from collections.abc import Iterator
+from pathlib import Path
+from typing import Final
+from uuid import UUID, uuid4
+
+import pytest
+from alembic import command
+from alembic.config import Config
+from sqlalchemy import create_engine as sa_create_engine
+from sqlalchemy import text
+
+from meho_backplane.db.engine import dispose_engine, reset_engine_for_testing
+from meho_backplane.db.migrations import alembic_config
+from meho_backplane.operations._lookup import (
+    connector_exists,
+    count_known_ops,
+    parse_connector_id,
+)
+from meho_backplane.settings import get_settings
+
+#: The six long->short splits the migration retires, as
+#: ``(long_product, impl_id, short_product)``. Mirrors ``_PRODUCT_SPLITS``
+#: inside migration 0049 (which snapshots migration 0038's mapping).
+_SPLITS: Final[list[tuple[str, str, str]]] = [
+    ("hetzner-robot", "hetzner-rest", "hetzner"),
+    ("sddc-manager", "sddc-rest", "sddc"),
+    ("vcf-automation", "vcfa-rest", "vcfa"),
+    ("vcf-fleet", "fleet-rest", "fleet"),
+    ("vcf-logs", "vrli-rest", "vrli"),
+    ("vcf-operations", "vrops-rest", "vrops"),
+]
+
+_VERSION: Final[str] = "9.0"
+
+#: Stable seed timestamp -- lets assertions tell "row untouched" apart.
+_SEED_TS: Final[str] = "2026-01-01T00:00:00+00:00"
+
+
+@pytest.fixture
+def alembic_cfg(
+    monkeypatch: pytest.MonkeyPatch,
+    tmp_path: Path,
+) -> Iterator[tuple[Config, str]]:
+    """Pin env, reset caches, return an Alembic config + sync URL.
+
+    Same harness as :mod:`tests.test_migration_0038_backfill_product_splits`:
+    sync fixture (``alembic.command`` calls ``asyncio.run`` internally),
+    per-test SQLite file under ``tmp_path``, settings + engine caches
+    reset on both sides so the alembic env and the dispatch probes read
+    *this* ``DATABASE_URL``.
+    """
+    db_path = tmp_path / "migration_0049.db"
+    async_url = f"sqlite+aiosqlite:///{db_path}"
+    sync_url = f"sqlite:///{db_path}"
+    monkeypatch.setenv("DATABASE_URL", async_url)
+    monkeypatch.setenv("KEYCLOAK_ISSUER_URL", "https://keycloak.test/realms/meho")
+    monkeypatch.setenv("KEYCLOAK_AUDIENCE", "meho-backplane")
+    monkeypatch.setenv("VAULT_ADDR", "https://vault.test")
+    get_settings.cache_clear()
+    reset_engine_for_testing()
+
+    cfg = alembic_config()
+    cfg.set_main_option("sqlalchemy.url", async_url)
+    try:
+        yield cfg, sync_url
+    finally:
+        get_settings.cache_clear()
+        reset_engine_for_testing()
+
+
+def _insert_descriptor_row(
+    sync_url: str,
+    *,
+    tenant_id: UUID | None,
+    product: str,
+    impl_id: str,
+    op_id: str,
+    version: str = _VERSION,
+) -> UUID:
+    """Insert one minimal ``endpoint_descriptor`` row at the migration base.
+
+    Raw SQL (not the ORM) keeps the seed pinned to the schema the
+    migration actually runs against. Columns with SQLite server defaults
+    from migration 0005 (``tags``, ``parameter_schema``, ``safety_level``,
+    ``requires_approval``, ``is_enabled``) are omitted; ``is_enabled``
+    therefore defaults to 1, which the ``count_known_ops`` probe relies
+    on. UUID binds use ``.hex`` per ``docs/codebase/migrations.md``.
+    """
+    row_id = uuid4()
+    sync_eng = sa_create_engine(sync_url)
+    try:
+        with sync_eng.begin() as conn:
+            conn.execute(
+                text(
+                    """
+                    INSERT INTO endpoint_descriptor (
+                        id, tenant_id, product, version, impl_id, op_id,
+                        source_kind, created_at, updated_at
+                    ) VALUES (
+                        :id, :tenant_id, :product, :version, :impl_id, :op_id,
+                        'ingested', :ts, :ts
+                    )
+                    """,
+                ),
+                {
+                    "id": row_id.hex,
+                    "tenant_id": tenant_id.hex if tenant_id is not None else None,
+                    "product": product,
+                    "version": version,
+                    "impl_id": impl_id,
+                    "op_id": op_id,
+                    "ts": _SEED_TS,
+                },
+            )
+    finally:
+        sync_eng.dispose()
+    return row_id
+
+
+def _insert_group_row(
+    sync_url: str,
+    *,
+    tenant_id: UUID | None,
+    product: str,
+    impl_id: str,
+    group_key: str,
+    version: str = _VERSION,
+) -> UUID:
+    """Insert one minimal ``operation_group`` row at the migration base."""
+    row_id = uuid4()
+    sync_eng = sa_create_engine(sync_url)
+    try:
+        with sync_eng.begin() as conn:
+            conn.execute(
+                text(
+                    """
+                    INSERT INTO operation_group (
+                        id, tenant_id, product, version, impl_id, group_key,
+                        name, when_to_use, review_status, created_at, updated_at
+                    ) VALUES (
+                        :id, :tenant_id, :product, :version, :impl_id, :group_key,
+                        :name, 'seeded for 0049 retire test', 'enabled', :ts, :ts
+                    )
+                    """,
+                ),
+                {
+                    "id": row_id.hex,
+                    "tenant_id": tenant_id.hex if tenant_id is not None else None,
+                    "product": product,
+                    "version": version,
+                    "impl_id": impl_id,
+                    "group_key": group_key,
+                    "name": group_key.title(),
+                    "ts": _SEED_TS,
+                },
+            )
+    finally:
+        sync_eng.dispose()
+    return row_id
+
+
+def _row_exists(sync_url: str, table: str, row_id: UUID) -> bool:
+    """Return whether a row with ``row_id`` is still present in ``table``."""
+    sync_eng = sa_create_engine(sync_url)
+    try:
+        with sync_eng.connect() as conn:
+            count = conn.execute(
+                text(f"SELECT COUNT(*) FROM {table} WHERE id = :id"),
+                {"id": row_id.hex},
+            ).scalar_one()
+            return int(count) == 1
+    finally:
+        sync_eng.dispose()
+
+
+def _read_updated_at(sync_url: str, table: str, row_id: UUID) -> str:
+    """Return ``updated_at`` for one row, as a string."""
+    sync_eng = sa_create_engine(sync_url)
+    try:
+        with sync_eng.connect() as conn:
+            row = conn.execute(
+                text(f"SELECT updated_at FROM {table} WHERE id = :id"),
+                {"id": row_id.hex},
+            ).one()
+            return str(row.updated_at)
+    finally:
+        sync_eng.dispose()
+
+
+def _count_by_product(sync_url: str, table: str, product: str) -> int:
+    """Return ``COUNT(*)`` for one product on one table."""
+    sync_eng = sa_create_engine(sync_url)
+    try:
+        with sync_eng.connect() as conn:
+            count = conn.execute(
+                text(f"SELECT COUNT(*) FROM {table} WHERE product = :product"),
+                {"product": product},
+            ).scalar_one()
+            return int(count)
+    finally:
+        sync_eng.dispose()
+
+
+def test_orphan_with_live_twin_is_retired(
+    alembic_cfg: tuple[Config, str],
+) -> None:
+    """The long orphan is deleted; its live short twin survives untouched.
+
+    Both row surfaces move together -- the orphaned descriptor and its
+    group are retired under the same predicate -- while the short twins
+    (a separate group_id lineage) are left as the sole representation.
+    """
+    cfg, sync_url = alembic_cfg
+    command.upgrade(cfg, "0048")
+
+    orphan_descriptor = _insert_descriptor_row(
+        sync_url,
+        tenant_id=None,
+        product="vcf-logs",
+        impl_id="vrli-rest",
+        op_id="GET:/api/v2/version",
+    )
+    twin_descriptor = _insert_descriptor_row(
+        sync_url,
+        tenant_id=None,
+        product="vrli",
+        impl_id="vrli-rest",
+        op_id="GET:/api/v2/version",
+    )
+    orphan_group = _insert_group_row(
+        sync_url,
+        tenant_id=None,
+        product="vcf-logs",
+        impl_id="vrli-rest",
+        group_key="system",
+    )
+    twin_group = _insert_group_row(
+        sync_url,
+        tenant_id=None,
+        product="vrli",
+        impl_id="vrli-rest",
+        group_key="system",
+    )
+
+    command.upgrade(cfg, "head")
+
+    for table, orphan_id, twin_id in (
+        ("endpoint_descriptor", orphan_descriptor, twin_descriptor),
+        ("operation_group", orphan_group, twin_group),
+    ):
+        assert not _row_exists(sync_url, table, orphan_id), (
+            f"the stale long-product {table} orphan must be deleted"
+        )
+        assert _row_exists(sync_url, table, twin_id), (
+            f"the live short-product {table} twin must survive"
+        )
+        assert _read_updated_at(sync_url, table, twin_id) == _SEED_TS, (
+            f"the surviving {table} twin must not be touched"
+        )
+
+
+def test_all_six_splits_retire_to_expected_counts(
+    alembic_cfg: tuple[Config, str],
+) -> None:
+    """SQL-level validation: post-migration only the short twins remain.
+
+    One orphan + its short twin seeded per split; after the upgrade
+    every long-product count is 0 and every short-product count is 1,
+    on both tables.
+    """
+    cfg, sync_url = alembic_cfg
+    command.upgrade(cfg, "0048")
+
+    for long_product, impl_id, short_product in _SPLITS:
+        for product in (long_product, short_product):
+            _insert_descriptor_row(
+                sync_url,
+                tenant_id=None,
+                product=product,
+                impl_id=impl_id,
+                op_id="GET:/api/v2/version",
+            )
+            _insert_group_row(
+                sync_url,
+                tenant_id=None,
+                product=product,
+                impl_id=impl_id,
+                group_key="system",
+            )
+
+    command.upgrade(cfg, "head")
+
+    for long_product, _, short_product in _SPLITS:
+        for table in ("endpoint_descriptor", "operation_group"):
+            assert _count_by_product(sync_url, table, long_product) == 0, (
+                f"no {table} row may remain under {long_product!r} after retire"
+            )
+            assert _count_by_product(sync_url, table, short_product) == 1, (
+                f"the live {table} short twin under {short_product!r} must remain"
+            )
+
+
+def test_tenant_scoped_rows_preserved(
+    alembic_cfg: tuple[Config, str],
+) -> None:
+    """``tenant_id IS NOT NULL`` rows are operator-owned and never deleted.
+
+    Even with a global short twin present, a tenant-scoped long row is
+    out of scope (#1699 scoping contract -- distinct shadow copies).
+    """
+    cfg, sync_url = alembic_cfg
+    command.upgrade(cfg, "0048")
+
+    tenant_id = uuid4()
+    tenant_descriptor = _insert_descriptor_row(
+        sync_url,
+        tenant_id=tenant_id,
+        product="vcf-logs",
+        impl_id="vrli-rest",
+        op_id="GET:/api/v2/version",
+    )
+    tenant_group = _insert_group_row(
+        sync_url,
+        tenant_id=tenant_id,
+        product="vcf-logs",
+        impl_id="vrli-rest",
+        group_key="system",
+    )
+    # A global short twin exists, so only the NULL-tenant boundary keeps
+    # the tenant rows alive.
+    _insert_descriptor_row(
+        sync_url,
+        tenant_id=None,
+        product="vrli",
+        impl_id="vrli-rest",
+        op_id="GET:/api/v2/version",
+    )
+    _insert_group_row(
+        sync_url,
+        tenant_id=None,
+        product="vrli",
+        impl_id="vrli-rest",
+        group_key="system",
+    )
+
+    command.upgrade(cfg, "head")
+
+    for table, row_id in (
+        ("endpoint_descriptor", tenant_descriptor),
+        ("operation_group", tenant_group),
+    ):
+        assert _row_exists(sync_url, table, row_id), (
+            f"tenant-scoped {table} row must never be deleted"
+        )
+
+
+def test_twin_less_long_row_preserved(
+    alembic_cfg: tuple[Config, str],
+) -> None:
+    """A long-product row with NO short twin is the sole representation.
+
+    The EXISTS guard retires a long orphan only when a live short twin
+    is present. A twin-less long row is left for ``0038``'s rewrite (the
+    write-side path); deleting it would lose the only copy of that
+    operation.
+    """
+    cfg, sync_url = alembic_cfg
+    command.upgrade(cfg, "0048")
+
+    lone_descriptor = _insert_descriptor_row(
+        sync_url,
+        tenant_id=None,
+        product="vcf-logs",
+        impl_id="vrli-rest",
+        op_id="GET:/api/v2/version",
+    )
+    lone_group = _insert_group_row(
+        sync_url,
+        tenant_id=None,
+        product="vcf-logs",
+        impl_id="vrli-rest",
+        group_key="system",
+    )
+
+    command.upgrade(cfg, "head")
+
+    for table, row_id in (
+        ("endpoint_descriptor", lone_descriptor),
+        ("operation_group", lone_group),
+    ):
+        assert _row_exists(sync_url, table, row_id), (
+            f"a twin-less long {table} row must be preserved (no live short twin)"
+        )
+
+
+def test_foreign_impl_id_rows_preserved(
+    alembic_cfg: tuple[Config, str],
+) -> None:
+    """The retire follows ``parse_connector_id``, not a blanket product match.
+
+    A ``product='vcf-logs'`` row whose ``impl_id`` first-hyphen-segment
+    is not ``vrli`` is not what the dispatcher resolves under ``vrli``,
+    so the migration leaves it alone even if a ``vrli`` twin exists.
+    """
+    cfg, sync_url = alembic_cfg
+    command.upgrade(cfg, "0048")
+
+    foreign_impl = _insert_descriptor_row(
+        sync_url,
+        tenant_id=None,
+        product="vcf-logs",
+        impl_id="custom-rest",
+        op_id="GET:/api/v2/version",
+    )
+    # A vrli twin on a *different* impl_id must not make the foreign row
+    # eligible -- the twin probe correlates impl_id.
+    _insert_descriptor_row(
+        sync_url,
+        tenant_id=None,
+        product="vrli",
+        impl_id="vrli-rest",
+        op_id="GET:/api/v2/version",
+    )
+
+    command.upgrade(cfg, "head")
+
+    assert _row_exists(sync_url, "endpoint_descriptor", foreign_impl), (
+        "a long-product row whose impl_id derives another product must be preserved"
+    )
+
+
+def test_unmapped_product_rows_preserved(
+    alembic_cfg: tuple[Config, str],
+) -> None:
+    """Aligned connectors outside the split mapping are never touched."""
+    cfg, sync_url = alembic_cfg
+    command.upgrade(cfg, "0048")
+
+    aligned = _insert_descriptor_row(
+        sync_url,
+        tenant_id=None,
+        product="vmware",
+        impl_id="vmware-rest",
+        op_id="GET:/api/vcenter/cluster",
+    )
+
+    command.upgrade(cfg, "head")
+
+    assert _row_exists(sync_url, "endpoint_descriptor", aligned), (
+        "aligned connectors are outside the mapping and must not be deleted"
+    )
+
+
+def test_re_running_migration_is_idempotent(
+    alembic_cfg: tuple[Config, str],
+) -> None:
+    """Replaying ``upgrade()`` on a cleaned DB deletes nothing further.
+
+    Same stamp-back replay shape as the 0038 test: after the first pass
+    the orphan is gone, so a second execution of the migration body is a
+    filter-shaped no-op -- the surviving short twin must stay put. Both
+    passes pin the target to ``0049`` so future schema migrations cannot
+    leak into the replay.
+    """
+    cfg, sync_url = alembic_cfg
+    command.upgrade(cfg, "0048")
+
+    orphan = _insert_descriptor_row(
+        sync_url,
+        tenant_id=None,
+        product="vcf-logs",
+        impl_id="vrli-rest",
+        op_id="GET:/api/v2/version",
+    )
+    twin = _insert_descriptor_row(
+        sync_url,
+        tenant_id=None,
+        product="vrli",
+        impl_id="vrli-rest",
+        op_id="GET:/api/v2/version",
+    )
+
+    command.upgrade(cfg, "0049")
+    assert not _row_exists(sync_url, "endpoint_descriptor", orphan)  # first pass landed
+    assert _row_exists(sync_url, "endpoint_descriptor", twin)
+
+    command.stamp(cfg, "0048")
+    command.upgrade(cfg, "0049")
+
+    assert not _row_exists(sync_url, "endpoint_descriptor", orphan), (
+        "the orphan stays gone on replay"
+    )
+    assert _row_exists(sync_url, "endpoint_descriptor", twin), (
+        "the live short twin must survive an idempotent replay"
+    )
+    assert _read_updated_at(sync_url, "endpoint_descriptor", twin) == _SEED_TS, (
+        "a no-op replay must not disturb the surviving twin"
+    )
+
+
+def test_live_short_twin_still_dispatches_post_migration(
+    alembic_cfg: tuple[Config, str],
+) -> None:
+    """The cleanup removes only invisible long rows; the short twin stays live.
+
+    The dispatch surface keys on the triple ``parse_connector_id``
+    derives. The long orphan was already invisible to it (the #1910
+    symptom); after the migration the short twin still resolves and
+    counts its enabled ops -- dispatch parity is preserved.
+    """
+    cfg, sync_url = alembic_cfg
+    command.upgrade(cfg, "0048")
+
+    for op_id in ("GET:/api/v2/version", "GET:/api/v2/events"):
+        # The invisible long orphan...
+        _insert_descriptor_row(
+            sync_url,
+            tenant_id=None,
+            product="vcf-logs",
+            impl_id="vrli-rest",
+            op_id=op_id,
+        )
+        # ...and its live short twin (what dispatch actually resolves).
+        _insert_descriptor_row(
+            sync_url,
+            tenant_id=None,
+            product="vrli",
+            impl_id="vrli-rest",
+            op_id=op_id,
+        )
+
+    product, version, impl_id = parse_connector_id("vrli-rest-9.0")
+    assert (product, version, impl_id) == ("vrli", "9.0", "vrli-rest")
+
+    async def _probe() -> tuple[bool, int]:
+        # Fresh engine on this event loop; disposed before the loop
+        # closes so no aiosqlite connection outlives its loop.
+        reset_engine_for_testing()
+        try:
+            exists = await connector_exists(
+                tenant_id=uuid4(),
+                product=product,
+                version=version,
+                impl_id=impl_id,
+            )
+            known = await count_known_ops(
+                product=product,
+                version=version,
+                impl_id=impl_id,
+            )
+            return exists, known
+        finally:
+            await dispose_engine()
+
+    command.upgrade(cfg, "head")
+
+    exists_after, known_after = asyncio.run(_probe())
+    assert exists_after is True, "the live short twin must still resolve post-cleanup"
+    assert known_after == 2, "both enabled ops on the short twin must still count"
+    # And the long orphans are gone.
+    assert _count_by_product(sync_url, "endpoint_descriptor", "vcf-logs") == 0


### PR DESCRIPTION
## Summary

- Adds Alembic migration **`0049`** (`down_revision="0048"`) that DELETEs the built-in `tenant_id IS NULL` long-product operation rows (`operation_group` + `endpoint_descriptor`) that migration `0038`'s collision-guard deliberately skipped — the operation-row complement of that backfill and of the `0047` `targets.product` reconciliation (#1814).
- These orphans (`product='vcf-logs'` / `impl_id='vrli-rest'` etc.) are **non-dispatchable** (every probe keys on the short, `parse_connector_id`-derived product) and **unreachable by `meho.connector.delete`** (the resolver derives `product='vrli'` from `vrli-rest-9.0.2`; no product selector exists on the route/MCP tool), so they could only ever return `ConnectorNotFoundError` (#1910). They also surfaced as a redundant `vcf-logs` candidate on `review`/`enable_reads` of the live short twin.
- The retire predicate is the **exact inverse** of `0038`'s collision-skip: `tenant_id IS NULL` AND `product='<long>'` AND the `parse_connector_id` first-hyphen-segment rule on `impl_id` AND a live short-product twin **EXISTS** on the same global natural key. A twin-less long row is preserved (left for `0038`'s write-side rewrite) so no operation loses its only representation.
- Self-contained `sa.table`/`sa.column` shims (no ORM import), idempotent DELETE, documented no-op downgrade (the orphans were never dispatchable). Mirrors the `0038`/`0046`/`0047` precedent.

## Test plan

- [x] `alembic heads` — reports a single head `0049` after the migration
- [x] Full chain `alembic upgrade head` on fresh SQLite — replays clean through `0048 -> 0049`
- [x] `ruff check` / `ruff format --check` — clean
- [x] `mypy --ignore-missing-imports` — clean
- [x] `pytest tests/test_migration_0049_retire_stale_vcf_logs_orphan_rows.py` — 8 passed
- [x] `pytest tests/test_alembic_uuid_param_consistency.py` — 52 passed (drift guard; this migration writes no UUID binds)

### Acceptance criteria

- [x] New `0049_retire_stale_vcf_logs_orphan_rows.py` with `down_revision="0048"`; single head after it.
- [x] Upgrade deletes **only** stale long-product `tenant_id IS NULL` orphans whose short twin exists; tests confirm tenant-scoped, twin-less long, foreign-`impl_id`, and unmapped-product rows are all preserved, and the short twins survive untouched.
- [x] Post-migration the live short twin still resolves via `connector_exists`/`count_known_ops` (dispatch parity) and the `vcf-logs` shadow is gone — `review`/`enable_reads` no longer surface it.
- [x] Downgrade is a documented no-op (deleted rows were never dispatchable).

## Out of scope

- The resolver tenant-vs-builtin precedence change and a `delete`-by-product selector (the registration-time product-identity invariant #1798/#1800 is the real fix for *future* divergent-product rows).
- **Live-registry verification of the orphan rows** could not be run from the sandbox (no DB access); the diagnosis is grounded in code: `parse_connector_id` (`operations/_lookup.py`) derives `product='vrli'` from `vrli-rest-*`, and `0038`'s `NOT EXISTS` collision-skip leaves exactly these twin-having long rows behind. Confirm against the live registry before merge.

## Sequencing / migration ordering

- This task = `0049`. The TLS `tls_server_name` task in Initiative #1998 = `0050` (`down_revision="0049"`). Gate this migration before the TLS one. If the head moves at branch time, the orchestrator reconciles via `merge-main-in`.

<!-- auto-implement-issue: fresh, iteration 1 -->

Closes #2001


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Tests**
  * Added comprehensive test suite for database migration verification, including idempotency and data integrity checks
* **Chores**
  * Database maintenance migration to identify and safely remove orphaned records while preserving associated data

<!-- end of auto-generated comment: release notes by coderabbit.ai -->