### PR TITLE
fix(mcp): map scheduler Vault write failure to -32602 on agent-principal register + document scheduler-token Vault write policy

### DIFF
--- a/backend/src/meho_backplane/mcp/tools/agent_principals.py
+++ b/backend/src/meho_backplane/mcp/tools/agent_principals.py
@@ -30,6 +30,12 @@ Error mapping
 * :class:`~meho_backplane.auth.keycloak_admin.KeycloakAdminError`
   → :class:`~meho_backplane.mcp.server.McpInvalidParamsError` with the
   error class name for operator diagnostics.
+* :class:`~meho_backplane.scheduler.vault_credentials.SchedulerVaultBrokerError`
+  (register only) → :class:`~meho_backplane.mcp.server.McpInvalidParamsError`
+  naming the ``VAULT_SCHEDULER_TOKEN`` write-policy remediation, mirroring
+  the REST/UI ``scheduler_vault_write_error`` 502 mapping. Without this
+  the broker error bubbled to the dispatcher's catch-all and surfaced as
+  an opaque ``-32603`` internal error.
 """
 
 from __future__ import annotations
@@ -52,6 +58,7 @@ from meho_backplane.auth.keycloak_admin import (
 from meho_backplane.auth.operator import Operator, TenantRole
 from meho_backplane.mcp.registry import ToolDefinition, register_mcp_tool
 from meho_backplane.mcp.server import McpInvalidParamsError
+from meho_backplane.scheduler.vault_credentials import SchedulerVaultBrokerError
 
 _log = structlog.get_logger(__name__)
 
@@ -155,6 +162,18 @@ async def _register_handler(
         ) from exc
     except KeycloakAdminError as exc:
         raise McpInvalidParamsError(f"Keycloak admin error: {type(exc).__name__}") from exc
+    except SchedulerVaultBrokerError as exc:
+        # ``VAULT_SCHEDULER_TOKEN`` is set but the Vault write failed
+        # (unreachable / denied — most often a read-only token policy). The
+        # just-created Keycloak client is already rolled back. Mirror the
+        # REST/UI 502 ``scheduler_vault_write_error`` mapping so the MCP
+        # caller gets an actionable ``-32602`` naming the cause, not the
+        # opaque ``-32603`` a bubbled exception would produce. The message
+        # names the remediation without leaking the secret.
+        raise McpInvalidParamsError(
+            "scheduler Vault write failed — VAULT_SCHEDULER_TOKEN policy must "
+            "grant create/update on the agent-credentials path"
+        ) from exc
     except ValueError as exc:
         raise McpInvalidParamsError(str(exc)) from exc
     return _row_to_dict(entry)

--- a/backend/src/meho_backplane/settings.py
+++ b/backend/src/meho_backplane/settings.py
@@ -167,10 +167,17 @@ class Settings(BaseModel):
         scheduler is operator-less — it has no Keycloak JWT to forward to
         Vault's JWT/OIDC auth method — so it reads under its own service
         identity instead. A token bound to a narrow policy that grants
-        read on ``scheduler_agent_vault_path_pattern`` (default
+        read/write on ``scheduler_agent_vault_path_pattern`` (default
         ``secret/data/agents/*/credentials``) is the lowest-friction
         service identity: it reuses the ``hvac.Client(token=…)`` primitive
-        with no AppRole ``secret_id`` bootstrap. Default ``""`` (unset)
+        with no AppRole ``secret_id`` bootstrap. **Write** (``create`` +
+        ``update``) is required because agent-principal registration mints
+        the Keycloak client secret into Vault via
+        :func:`~meho_backplane.scheduler.vault_credentials.write_agent_secret`;
+        a read-only token denies registration with
+        :class:`~meho_backplane.scheduler.vault_credentials.SchedulerVaultBrokerError`.
+        The operator-runbook stanza is in
+        ``docs/cross-repo/vault-provisioning.md``. Default ``""`` (unset)
         leaves Vault-sourced scheduling inoperative; the scheduler then
         falls back to the env-var path
         (:attr:`scheduler_agent_secret_env_pattern`). Never logged; never

--- a/backend/tests/mcp_test_fixtures.py
+++ b/backend/tests/mcp_test_fixtures.py
@@ -194,6 +194,7 @@ def isolated_registry() -> Iterator[None]:
     from meho_backplane.mcp.resources import tenant_feed, tenant_info
     from meho_backplane.mcp.tools import (
         agent_grants,
+        agent_principals,
         agent_runs,
         agents,
         approvals,
@@ -304,6 +305,15 @@ def isolated_registry() -> Iterator[None]:
     # RBAC suites (G11.2 follow-up #1113) rely on this entry to
     # exercise ``tools/list`` filter + ``tools/call`` re-check gates.
     importlib.reload(agent_grants)
+    # G11.2-T1 (#815): the agent-principal lifecycle MCP tools
+    # (``meho.agent_principals.{list,register,revoke}``) join the reload
+    # list for the same reason every other tool module does -- the autouse
+    # ``clear_registries()`` above would otherwise leave them unregistered
+    # in any test file that imports this fixture after the first one runs
+    # in the process. The register error-mapping suite (#2000) relies on
+    # this entry to exercise the ``SchedulerVaultBrokerError`` -> -32602
+    # wire mapping.
+    importlib.reload(agent_principals)
     importlib.reload(approvals)
     importlib.reload(tenant_info)
     importlib.reload(tenant_feed)

--- a/backend/tests/test_mcp_tool_agent_principals.py
+++ b/backend/tests/test_mcp_tool_agent_principals.py
@@ -1,0 +1,117 @@
+# SPDX-License-Identifier: Apache-2.0
+# Copyright (c) 2026 evoila Group
+
+"""Error-mapping tests for ``meho.agent_principals.register`` MCP tool.
+
+The register handler (:mod:`meho_backplane.mcp.tools.agent_principals`)
+mints the Keycloak client secret into Vault via
+:func:`~meho_backplane.scheduler.vault_credentials.write_agent_secret`.
+When ``VAULT_SCHEDULER_TOKEN`` is set but the write is denied (a
+read-only token policy → Vault 403) or Vault is unreachable, the service
+raises
+:class:`~meho_backplane.scheduler.vault_credentials.SchedulerVaultBrokerError`.
+
+Before #2000 the MCP handler caught
+``AgentPrincipalExistsError`` / ``KeycloakAdmin*`` / ``ValueError`` but
+**not** the broker error, so it bubbled to the dispatcher's catch-all and
+surfaced as an opaque JSON-RPC ``-32603`` ``internal error`` — the
+operator had no signal that the cause was a misscoped scheduler token.
+The REST face (``POST /api/v1/agent-principals``) and the UI form handler
+already mapped it to a ``502 scheduler_vault_write_error``; the MCP
+handler regressed it (a backend-isolation review miss when #1489 bolted
+the Vault write onto ``register``).
+
+This file pins the contract at the **wire** level: a ``tools/call``
+against ``meho.agent_principals.register`` whose Vault write raises
+``SchedulerVaultBrokerError`` returns ``-32602`` (invalid params) with a
+descriptive, secret-free message — mirroring
+``test_api_v1_agent_principals.py``'s REST equivalent.
+
+Out of scope:
+
+* Happy-path registration (service-layer suite covers it).
+* RBAC gating (``test_mcp_tool_agent_grants.py`` pattern covers the
+  list-filter + call-recheck gates generically).
+"""
+
+from __future__ import annotations
+
+from typing import Any
+
+import pytest
+from fastapi.testclient import TestClient
+
+from meho_backplane.auth.agent_principals import AgentPrincipalService
+from meho_backplane.auth.operator import Operator, TenantRole
+from meho_backplane.mcp.schemas import INTERNAL_ERROR, INVALID_PARAMS
+from meho_backplane.scheduler.vault_credentials import SchedulerVaultBrokerError
+from tests.mcp_test_fixtures import (
+    client_with_operator,  # noqa: F401 — pytest-discovered fixture
+    isolated_registry,  # noqa: F401 — pytest-discovered autouse fixture
+    post_mcp,
+    required_settings_env,  # noqa: F401 — pytest-discovered autouse fixture
+)
+
+_REGISTER_TOOL = "meho.agent_principals.register"
+
+#: A secret value the handler must never echo back in the error message.
+#: write_agent_secret would receive this; if any leg leaked it into the
+#: JSON-RPC error the assertion below would catch it.
+_SENTINEL_SECRET = "super-secret-client-credential-value"
+
+
+def _tools_call(name: str, arguments: dict[str, Any], call_id: int = 1) -> dict[str, Any]:
+    """Build a JSON-RPC ``tools/call`` envelope."""
+    return {
+        "jsonrpc": "2.0",
+        "id": call_id,
+        "method": "tools/call",
+        "params": {"name": name, "arguments": arguments},
+    }
+
+
+@pytest.mark.parametrize(
+    "client_with_operator",
+    [TenantRole.TENANT_ADMIN],
+    indirect=True,
+)
+def test_register_vault_write_failure_maps_to_invalid_params(
+    client_with_operator: tuple[TestClient, Operator],  # noqa: F811
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """Vault-write failure → JSON-RPC ``-32602`` with a secret-free message.
+
+    Monkeypatches ``AgentPrincipalService.register`` to raise
+    ``SchedulerVaultBrokerError`` (the post-rollback state the real
+    service reaches when the scheduler token can't write the minted
+    secret), then asserts the dispatched ``tools/call`` returns
+    INVALID_PARAMS (``-32602``) — **not** INTERNAL_ERROR (``-32603``) —
+    with a message that names the ``VAULT_SCHEDULER_TOKEN`` remediation
+    and leaks no secret.
+    """
+    client, _op = client_with_operator
+
+    async def _raise_broker_error(*_args: Any, **_kwargs: Any) -> Any:
+        raise SchedulerVaultBrokerError(
+            "vault rejected agent-secret write at "
+            "'secret/data/agents/VAULT_BOT/credentials': Forbidden"
+        )
+
+    monkeypatch.setattr(AgentPrincipalService, "register", _raise_broker_error)
+
+    resp = post_mcp(client, _tools_call(_REGISTER_TOOL, {"name": "vault-bot"}))
+    assert resp.status_code == 200, resp.text
+    body = resp.json()
+    assert "error" in body, body
+
+    # The defect: this used to be INTERNAL_ERROR (-32603) because the
+    # handler had no except for SchedulerVaultBrokerError.
+    assert body["error"]["code"] == INVALID_PARAMS, body
+    assert body["error"]["code"] != INTERNAL_ERROR, body
+
+    message = body["error"]["message"]
+    assert "VAULT_SCHEDULER_TOKEN" in message, message
+    assert "vault write failed" in message.lower(), message
+    # No secret leakage: neither the client secret nor a raw token value
+    # may appear in the operator-facing error.
+    assert _SENTINEL_SECRET not in message, message

--- a/docs/cross-repo/vault-provisioning.md
+++ b/docs/cross-repo/vault-provisioning.md
@@ -25,11 +25,15 @@ the contract on this page holds.
 
 ## What the backplane needs
 
-Five distinct Vault surfaces. The first four ship via Goal #11's
+Six distinct Vault surfaces. The first four ship via Goal #11's
 cross-repo deps (consumer commitment #5 — see
 [`#261`](https://github.com/evoila-bosnia/claude-rdc-hetzner-dc/issues/261)
 in the consumer repo). The fifth — the federation-proof test KV
-path — is the surface most easily missed during provisioning.
+path — is the surface most easily missed during provisioning. The
+sixth — the **scheduler service token** — is a *separate* static-token
+identity (not the JWT-login role) that the scheduler uses to read and
+**write** agent `client_credentials` secrets; its write capability is
+the one most easily under-provisioned (see surface 6).
 
 ### 1. JWT auth method — on a **dedicated mount**
 
@@ -159,6 +163,63 @@ read returning a non-error response with a `version` field). Any
 non-empty key set works; the two keys above are a self-documenting
 default the lab admin can grep for during incident response.
 
+### 6. Scheduler service token — read **and write** on agent credentials
+
+The scheduler is operator-less (no Keycloak JWT to forward to Vault's
+JWT auth method), so it authenticates with a **static service token**
+passed via `VAULT_SCHEDULER_TOKEN`
+([`backend/src/meho_backplane/settings.py`](../../backend/src/meho_backplane/settings.py)).
+This is a *distinct* identity from the `meho-mcp` JWT-login role
+(surfaces 1–3): it is bound to its own narrow policy on the
+agent-credentials KV path
+(`scheduler_agent_vault_path_pattern`, default
+`secret/data/agents/*/credentials`).
+
+The capability scope must be **read + write**, not read-only:
+
+- **Read** — the scheduler resolves an agent's `client_credentials`
+  secret Vault-first before firing a scheduled invocation
+  ([`read_agent_secret`](../../backend/src/meho_backplane/scheduler/vault_credentials.py)).
+- **Write** (`create` + `update`) — agent-principal **registration**
+  mints the Keycloak-generated client secret into Vault under the same
+  token
+  ([`write_agent_secret`](../../backend/src/meho_backplane/scheduler/vault_credentials.py),
+  called from
+  [`AgentPrincipalService.register`](../../backend/src/meho_backplane/auth/agent_principals.py)).
+  A read-only token makes Vault answer the write with a 403, which the
+  backplane surfaces as a `502 scheduler_vault_write_error` (REST/UI) or
+  a JSON-RPC `-32602` "scheduler Vault write failed" (MCP
+  `meho_agent_principals_register`); registration then rolls back the
+  just-created Keycloak client so no unschedulable agent is left behind.
+
+```hcl
+# Policy: meho-scheduler
+# KV v2 splits the secret value (/data/) from its metadata (/metadata/).
+# The write path mints + updates the value; the metadata read is needed
+# for create_or_update_secret's check-and-set bookkeeping.
+path "secret/data/agents/*/credentials" {
+  capabilities = ["create", "read", "update"]
+}
+path "secret/metadata/agents/*/credentials" {
+  capabilities = ["read"]
+}
+```
+
+Mint the token bound to that policy and feed it to the backplane Pod as
+`VAULT_SCHEDULER_TOKEN` (e.g. a long-lived periodic token, or a token a
+Vault Agent sidecar renews into the env var):
+
+```bash
+vault policy write meho-scheduler meho-scheduler.hcl
+vault token create -policy=meho-scheduler -period=768h -field=token
+```
+
+Substitute the path prefix if you set a non-default
+`SCHEDULER_AGENT_VAULT_PATH_PATTERN`. Unset `VAULT_SCHEDULER_TOKEN`
+disables the Vault path entirely — the scheduler then falls back to the
+`SCHEDULER_AGENT_SECRET_ENV_PATTERN` env-var convention (an *unset*
+token is not an error; an *under-scoped* one is).
+
 ## Verification
 
 Run from any host with the operator's Vault token (`vault login`
@@ -189,6 +250,15 @@ vault kv get -format=json secret/meho/test/federation \
 # Expect: a positive integer (the KV-v2 version number).
 # A "No value found at secret/data/meho/test/federation" error is
 # the smoking gun for missing surface #5.
+
+# 6. Scheduler token can WRITE agent credentials (the surface most
+#    easily under-provisioned). Run with the scheduler service token:
+vault token capabilities "$VAULT_SCHEDULER_TOKEN" \
+  secret/data/agents/example/credentials
+# Expect: a set including "create" and "update" (e.g.
+# "create read update"). A bare "read" is the live cause of
+# meho_agent_principals_register failing — widening the policy to
+# include create+update unblocks registration with no code change.
 ```
 
 When commands 1-5 all return non-error output and the JSON
@@ -205,9 +275,11 @@ everything it needs from Vault.
 | `/api/v1/health` returns `vault.reachable=true`, `vault.read_ok=false`, `detail="read_failed: InvalidPath"` | **Missing surface 5** — federation-proof KV path doesn't exist. | Run the provisioning command from surface 5 above |
 | `/api/v1/health` returns `vault.reachable=true`, `vault.read_ok=false`, `detail="read_failed: Forbidden"` | **Missing surface 3** — policy doesn't grant read on `secret/meho/*`. | Verify surface 3 (`vault policy read meho-mcp`); the policy must include both `secret/data/meho/*` and `secret/metadata/meho/*` |
 | `/api/v1/health` returns `vault.reachable=true`, `vault.read_ok=false`, `detail="read_failed: KeyError"` or `read_failed: TypeError` | Vault returned an unexpected payload shape — KV-v1 mount instead of v2, proxy mangling the response, etc. | Verify surface 4 (KV v2 mount); the mount must be type `kv` with `options.version="2"` |
+| Agent-principal registration fails — REST `502 scheduler_vault_write_error`, or MCP `meho_agent_principals_register` JSON-RPC `-32602` "scheduler Vault write failed" — while reads/listing still work | **Under-scoped surface 6** — `VAULT_SCHEDULER_TOKEN` policy grants read but not write on the agent-credentials path, so the secret-mint write is denied (Vault 403). Reads stay healthy because the read path is read-only-sufficient. | Verify surface 6 (`vault token capabilities "$VAULT_SCHEDULER_TOKEN" secret/data/agents/<name>/credentials`); widen the `meho-scheduler` policy to include `create`+`update` on `secret/data/agents/*/credentials` |
 
 ## References
 
+- Scheduler service-token read/write path (surface 6): [`docs/codebase/scheduler.md`](../codebase/scheduler.md), [`backend/src/meho_backplane/scheduler/vault_credentials.py`](../../backend/src/meho_backplane/scheduler/vault_credentials.py)
 - Producer-side handler: [`backend/src/meho_backplane/api/v1/health.py`](../../backend/src/meho_backplane/api/v1/health.py)
 - Producer-side Vault client: [`backend/src/meho_backplane/auth/vault.py`](../../backend/src/meho_backplane/auth/vault.py)
 - Backplane settings (env-var contract): [`backend/src/meho_backplane/settings.py`](../../backend/src/meho_backplane/settings.py)


### PR DESCRIPTION
## Summary
- `meho_agent_principals_register` over MCP let `SchedulerVaultBrokerError` bubble to the JSON-RPC dispatcher's catch-all, so a failed secret-mint write (most often a read-only `VAULT_SCHEDULER_TOKEN` policy → Vault 403) returned an opaque `-32603` internal error with no actionable signal. Adds the missing `except` to `_register_handler` mapping it to `-32602` (invalid params) with a descriptive, secret-free message naming the write-policy remediation — mirroring the REST/UI `502 scheduler_vault_write_error` mapping that #1489 added everywhere except the MCP handler.
- Documents the **scheduler service token** as a distinct Vault surface (read **and write** on the agent-credentials path) in `docs/cross-repo/vault-provisioning.md`: HCL policy stanza (`create`/`read`/`update` on `secret/data/agents/*/credentials` + `read` on `secret/metadata/...`), a `vault token capabilities` verification command, and a failure-mode table row.
- Corrects the `settings.py` `vault_scheduler_token` docstring from "read" to "read/write" to match `docs/codebase/scheduler.md` and the actual register write path.

## Test plan
- [x] `ruff check` / `ruff format --check` — clean
- [x] `mypy src/meho_backplane/mcp/tools/agent_principals.py` — clean
- [x] New `tests/test_mcp_tool_agent_principals.py` — wire-level `tools/call` with `register()` monkeypatched to raise `SchedulerVaultBrokerError` asserts JSON-RPC `-32602` (not `-32603`), a `VAULT_SCHEDULER_TOKEN`-naming message, and no secret leakage (mirrors the REST equivalent in `test_api_v1_agent_principals.py`). 1 passed.
- [x] `agent_principals` added to the shared `isolated_registry` reload list so the MCP tool is registered under test; no regression — `test_mcp_tool_agent_grants` / `test_mcp_registry` / `test_mcp_capability_gating` / `test_api_v1_agent_principals` / `test_ui_agent_principals` (99 passed) + `test_mcp_server` / `test_mcp_audit` / `test_mcp_tool_approvals` (63 passed).
- [x] `code-quality.py --diff` — 0 blockers (one pre-existing `settings.py` size warning, not agent-introduced).

## Operator note
`vault token capabilities <VAULT_SCHEDULER_TOKEN> secret/data/agents/<name>/credentials` returning only `read` is the live cause of registration failing; widening the policy to include `create`+`update` unblocks it. No code change unblocks an already-misscoped token — the code fix only improves the error's legibility.

## Out of scope
- The operator Keycloak / Vault consoles (#1941/#1942/#1943) — verified orthogonal (dispatch in-process; touch neither `agent_principals` nor `scheduler/vault_credentials`).
- Agent-principal lifecycle / Keycloak client-creation path changes.

<!-- auto-implement-issue: fresh, iteration 1 -->

Closes #2000
