### PR TITLE
feat(connectors): migrate vRLI auth+fingerprint to an ExecutionProfile, prove per-method parity (capstone #1974)

### DIFF
--- a/backend/src/meho_backplane/connectors/vcf_logs/__init__.py
+++ b/backend/src/meho_backplane/connectors/vcf_logs/__init__.py
@@ -46,6 +46,7 @@ from meho_backplane.connectors.vcf_logs.core_ops import (
     apply_vrli_core_curation,
     classify_vrli_op,
 )
+from meho_backplane.connectors.vcf_logs.profile import VRLI_EXECUTION_PROFILE
 from meho_backplane.connectors.vcf_logs.session import (
     VcfCredentialsLoader,
     VcfLogsTargetLike,
@@ -76,6 +77,7 @@ __all__ = [
     "VRLI_CONNECTOR_ID",
     "VRLI_CORE_GROUPS",
     "VRLI_CORE_OPS",
+    "VRLI_EXECUTION_PROFILE",
     "VRLI_IMPL_ID",
     "VRLI_PATH_RULES",
     "VRLI_PRODUCT",

--- a/backend/src/meho_backplane/connectors/vcf_logs/connector.py
+++ b/backend/src/meho_backplane/connectors/vcf_logs/connector.py
@@ -113,6 +113,7 @@ import structlog
 
 from meho_backplane.auth.operator import Operator
 from meho_backplane.connectors._shared.cache_key import target_cache_key
+from meho_backplane.connectors._shared.profile_auth import SESSION_SCHEME_SPECS
 from meho_backplane.connectors._shared.vault_creds import VaultCredentialsReadError
 from meho_backplane.connectors._shared.vcf_auth import (
     CredentialsCache,
@@ -121,12 +122,14 @@ from meho_backplane.connectors._shared.vcf_auth import (
     vcf_session_login,
 )
 from meho_backplane.connectors.adapters.http import HttpConnector
+from meho_backplane.connectors.profile import split_version
 from meho_backplane.connectors.schemas import (
     AuthModel,
     FingerprintResult,
     OperationResult,
     ProbeResult,
 )
+from meho_backplane.connectors.vcf_logs.profile import VRLI_EXECUTION_PROFILE
 from meho_backplane.connectors.vcf_logs.session import (
     VcfCredentialsLoader,
     VcfLogsTargetLike,
@@ -143,19 +146,28 @@ _log = structlog.get_logger(__name__)
 # ``{username, password, provider}``; success returns 200 with a JSON
 # body carrying ``sessionId`` + ``ttl``. Per the consumer wrapper at
 # https://github.com/evoila-bosnia/claude-rdc-hetzner-dc/blob/main/scripts/vcf-logs.sh
-_SESSION_CREATE_PATH = "/api/v2/sessions"
+# Sourced from the reviewed ``vrli_session`` ExecutionProfile (G0.28-T8
+# #1974) via the named ``session_login`` scheme's vetted login-path builder
+# so the typed connector and a profiled connector share one declaration of
+# the session endpoint rather than two literals that could drift.
+_SESSION_CREATE_PATH = SESSION_SCHEME_SPECS[VRLI_EXECUTION_PROFILE.auth.scheme].login_path(
+    VRLI_EXECUTION_PROFILE.auth
+)
 
 # Unauthenticated version endpoint for fingerprint + probe. Returns JSON
 # ``{version, releaseName}`` where ``version`` is e.g.
 # ``"9.0.0.0.21761695"`` (dot-separated). The wrapper splits the value
 # at dots and reports ``parts[0:3]`` as the public version + ``parts[4]``
-# as the build; we mirror that shape in :class:`FingerprintResult`.
-_VERSION_PATH = "/api/v2/version"
+# as the build; we mirror that shape in :class:`FingerprintResult`. The
+# path comes from the profile's fingerprint recipe (single source of truth).
+_VERSION_PATH = VRLI_EXECUTION_PROFILE.fingerprint.path
 
 # Default vRLI identity-source name. Matches the wrapper's
 # ``PROVIDER="Local"`` default; ``ActiveDirectory`` / ``vIDM`` are
 # permitted alternatives a target may declare via
-# :attr:`VcfLogsTargetLike.provider`.
+# :attr:`VcfLogsTargetLike.provider`. The profile's ``session_login``
+# scheme hardcodes ``"Local"``; the typed connector keeps the per-target
+# override the declarative scheme deliberately does not model.
 _DEFAULT_PROVIDER = "Local"
 
 # Downstream statuses that mean "the cached session token is no longer
@@ -164,8 +176,10 @@ _DEFAULT_PROVIDER = "Local"
 # invalid Authorization). Both feed
 # :meth:`VcfLogsConnector._get_json_with_session_retry`; see the module
 # "Session-expiry retry-once contract" docstring above for why 440 is the
-# case that bites (#1909).
-_SESSION_EXPIRED_STATUSES: frozenset[int] = frozenset({401, 440})
+# case that bites (#1909). Sourced from the profile's ``expiry_statuses``
+# (G0.28-T7 #1973) so the typed connector and the dispatcher's auth-class
+# arm narrow the same closed set from one declaration.
+_SESSION_EXPIRED_STATUSES: frozenset[int] = VRLI_EXECUTION_PROFILE.expiry_statuses
 
 
 def _vrli_payload_builder(
@@ -193,23 +207,26 @@ def _vrli_payload_builder(
 def _parse_vrli_version(version_full: Any) -> tuple[str | None, str | None, str | None]:
     """Render a vRLI ``version`` string as ``(public, build, patch)``.
 
-    vRLI reports ``version`` as a dot-separated tuple such as
-    ``"9.0.0.0.21761695"``. The wrapper at ``vcf-logs.sh`` lines
-    226-251 renders ``parts[0:3]`` as the public version and
-    ``parts[4]`` as the build, with ``parts[3]`` exposed as the patch
-    component. Mirror that contract so ``meho connector fingerprint``
-    stays byte-compatible with ``vcf-logs.sh --probe``.
+    The ``(public, build)`` split is the profile's ``vrli_five_part`` named
+    splitter (G0.28-T6 #1972) — the same vetted parser a profiled vRLI
+    connector uses, so the typed connector and the profile cannot disagree
+    on the public version / build for any input. ``patch`` (``parts[3]``)
+    is the one component the named splitter deliberately drops; it stays
+    bespoke typed-only enrichment surfaced in ``fingerprint``'s ``extras``,
+    mirroring the wrapper at ``vcf-logs.sh`` lines 226-251.
 
     Returns ``(None, None, None)`` if *version_full* is not a non-empty
     string -- the appliance returning a malformed response shouldn't
-    crash the fingerprint round-trip.
+    crash the fingerprint round-trip (the splitter is equally tolerant).
     """
-    if not isinstance(version_full, str) or not version_full:
+    version, build = split_version(
+        VRLI_EXECUTION_PROFILE.fingerprint.version_splitter,
+        version_full if isinstance(version_full, str) else None,
+    )
+    if version is None:
         return None, None, None
     parts = version_full.split(".")
-    version = ".".join(parts[0:3]) if len(parts) >= 3 else version_full
     patch = parts[3] if len(parts) > 3 else None
-    build = parts[4] if len(parts) > 4 else None
     return version, build, patch
 
 
@@ -245,6 +262,29 @@ class VcfLogsConnector(HttpConnector):
     :class:`CredentialsCache` instance). The :attr:`priority` is set to
     ``1`` so a future ``GenericRestConnector`` auto-shim that somehow
     registers for the same triple loses the registry's tie-break ladder.
+
+    Profile-derived auth + fingerprint (G0.28-T8 #1974)
+    ===================================================
+
+    The connector's declarative auth + fingerprint surfaces are sourced
+    from the reviewed
+    :data:`~meho_backplane.connectors.vcf_logs.profile.VRLI_EXECUTION_PROFILE`
+    rather than hand-coded literals: the session-create path comes from the
+    profile's ``session_login`` scheme spec, the version endpoint + the
+    ``(public, build)`` split come from the profile's fingerprint recipe
+    (the ``vrli_five_part`` named splitter), and the session-expiry status
+    set is the profile's ``expiry_statuses`` (``{401, 440}``). This makes
+    the profile the single source of truth shared with a profiled vRLI
+    connector — the capstone of Initiative #1965, with per-method dispatch
+    parity proven in the integration lane (``tests/integration/
+    test_connectors_vrli_profile_parity.py``).
+
+    Two surfaces stay typed-only because the declarative profile cannot
+    model them: the per-target ``provider`` (``ActiveDirectory`` / ``vIDM``;
+    the ``session_login`` scheme hardcodes ``"Local"``) and the fingerprint
+    ``extras`` (``release_name`` / ``version_full`` / ``patch``). The
+    ``ResultHandle`` large-result path is the connector-agnostic JSONFlux
+    dispatch mechanism, not connector code, and is untouched.
     """
 
     # G0.6 v2 registry metadata. The (product, version, impl_id) triple

--- a/backend/src/meho_backplane/connectors/vcf_logs/profile.py
+++ b/backend/src/meho_backplane/connectors/vcf_logs/profile.py
@@ -1,0 +1,91 @@
+# SPDX-License-Identifier: Apache-2.0
+# Copyright (c) 2026 evoila Group
+
+"""The reviewed ``vrli_session`` ExecutionProfile for the vRLI connector.
+
+G0.28-T8 (#1974) — the **capstone** of Initiative #1965: the first real
+:class:`~meho_backplane.connectors.profile.ExecutionProfile` authored against
+a shipped, bespoke connector, proving the whole profiled-connector chain
+(T1-T7) works end to end on production code rather than synthetic fixtures.
+
+What this profile retires from the typed :class:`VcfLogsConnector`
+=================================================================
+
+vRLI's auth + fingerprint were the two hand-coded surfaces a declarative
+profile can express, so they move here, with the profile as the single
+source of truth the typed connector now derives from (no duplicated
+literals):
+
+* **auth** — the ``session_login`` named scheme (#1970): POST
+  ``username`` / ``password`` to ``/api/v2/sessions``, read ``sessionId``
+  out of the JSON body, send it as ``Authorization: Bearer <sessionId>``.
+  The per-target lock / token cache / single-flight / re-login-once
+  harness is the one hoisted into
+  :class:`~meho_backplane.connectors.profiled.ProfiledRestConnector`.
+* **fingerprint** — the unauthenticated ``GET /api/v2/version`` recipe
+  (#1972): read the literal top-level ``version`` key and render it via
+  the ``vrli_five_part`` named splitter (``"9.0.0.0.21761695"`` →
+  ``("9.0.0", "21761695")``).
+* **expiry_statuses** — vRLI's ``{401, 440}`` (#1973): ``401`` is the
+  session-expiry floor every session connector recovers from; ``440`` is
+  vRLI's own ``trait.authenticated.440`` ("the session ID has expired;
+  obtain a new session ID") emitted once the appliance idle-times out the
+  in-memory session (the case that bit live consumers on v0.17.0, #1909).
+
+What stays bespoke (the profile cannot model it)
+================================================
+
+The ``session_login`` scheme's login body is a fixed
+``{username, password, provider="Local"}`` — the profile carries no
+per-target ``provider`` knob (``ActiveDirectory`` / ``vIDM``), and the
+declarative fingerprint emits only ``(version, build)`` with no
+``extras["release_name" | "version_full" | "patch"]``. Both stay typed-only
+enrichment on :class:`VcfLogsConnector`, layered on top of the profile-driven
+core (see that class's docstring). The ``ResultHandle`` large-result path is
+the connector-agnostic JSONFlux dispatch mechanism
+(:class:`~meho_backplane.connectors.schemas.ResultHandle` +
+:class:`~meho_backplane.operations.jsonflux_reducer.JsonFluxReducer`), not
+connector code, and is untouched by this migration.
+
+The profile is a module constant, not a stored row: the persistence /
+review-gate stamping path (T5 #1971) makes a *profiled* connector
+dispatchable behind the ``is_enabled`` / ``review_status`` interlock; this
+pilot proves parity against the typed connector, so the constant is the
+single declarative source both the typed connector and the parity test
+read from.
+"""
+
+from __future__ import annotations
+
+from meho_backplane.connectors.profile import (
+    AuthSpec,
+    ExecutionProfile,
+    FingerprintSpec,
+    PaginationSpec,
+)
+
+__all__ = ["VRLI_EXECUTION_PROFILE"]
+
+
+#: The reviewed declarative profile for vRLI 9.x. The single source of
+#: truth for the connector's auth scheme, fingerprint recipe, and
+#: session-expiry status set; the typed :class:`VcfLogsConnector` derives
+#: those from this constant, and the integration parity test stamps it onto
+#: a :class:`~meho_backplane.connectors.profiled.ProfiledRestConnector` to
+#: prove per-method dispatch parity. ``pagination`` is ``none`` — vRLI's
+#: curated read ops are constraint-path single-shot calls whose large
+#: result sets flow through the JSONFlux reducer, not a paginated list loop.
+VRLI_EXECUTION_PROFILE = ExecutionProfile(
+    product="vrli",
+    version="9.0",
+    auth=AuthSpec(scheme="session_login", secret_fields=("username", "password")),
+    fingerprint=FingerprintSpec(
+        path="/api/v2/version",
+        authenticated=False,
+        version_key="version",
+        version_splitter="vrli_five_part",
+    ),
+    probe="delegate",
+    pagination=PaginationSpec(strategy="none", items_key="events"),
+    expiry_statuses=frozenset({401, 440}),
+)

--- a/backend/tests/integration/test_connectors_vrli_profile_parity.py
+++ b/backend/tests/integration/test_connectors_vrli_profile_parity.py
@@ -1,0 +1,369 @@
+# SPDX-License-Identifier: Apache-2.0
+# Copyright (c) 2026 evoila Group
+
+"""Per-method dispatch parity: typed vRLI connector vs the ExecutionProfile.
+
+G0.28-T8 (#1974) — the **capstone** integration proof for Initiative #1965.
+It exercises the whole profiled-connector chain (T1-T7) against the first
+real, shipped, bespoke connector and asserts that a profiled vRLI connector
+driven solely by the reviewed
+:data:`~meho_backplane.connectors.vcf_logs.profile.VRLI_EXECUTION_PROFILE`
+reaches **per-method parity** with the hand-coded
+:class:`~meho_backplane.connectors.vcf_logs.connector.VcfLogsConnector` it
+was migrated from:
+
+* ``auth_headers`` — both produce ``Authorization: Bearer <sessionId>`` from
+  the same ``POST /api/v2/sessions`` login round-trip (the ``session_login``
+  named scheme, #1970), and both reuse the cached token across calls.
+* ``fingerprint`` — both read the unauthenticated ``GET /api/v2/version``
+  and render the 5-part vRLI version string identically into
+  ``(version, build)`` via the ``vrli_five_part`` named splitter (#1972).
+* ``probe`` — both delegate to ``fingerprint`` and report the same ``ok``.
+* session-expiry recovery — both treat ``{401, 440}`` (the profile's
+  ``expiry_statuses``, #1973) as "re-login once and retry"; the parity test
+  drives a 440 through the typed connector's retry seam and asserts the
+  profiled connector classifies the same status set.
+
+Lane placement
+==============
+
+This lives in ``tests/integration/`` so it runs in the **required**
+``Python (integration testcontainers)`` merge gate (#698) — the lane the
+issue's acceptance criterion names. vRLI is a proprietary VMware appliance
+with no public container image (the existing ``test_connectors_vcf_logs_e2e``
+acceptance suite already mocks it rather than booting a container), so the
+"appliance" here is a single ``respx`` mock router that **both** connectors
+talk to over identical routes — the cleanest way to assert two
+implementations agree on the wire interactions without a real vRLI.
+
+tenant_id-double trap (memory: integration doubles)
+===================================================
+
+The session-token cache is keyed on the tenant-unique ``(tenant_id, id)``
+tuple (#1642), so the stub target carries **both** ``id`` and ``tenant_id``
+attributes; a double missing either would collapse two targets onto one
+cache entry (or crash :func:`target_cache_key`). The stub is shared by both
+connectors so the parity comparison is apples-to-apples.
+
+What is deliberately NOT asserted equal
+=======================================
+
+The typed connector keeps two enrichments the declarative profile cannot
+model — the per-target ``provider`` (the ``session_login`` scheme hardcodes
+``"Local"``) and the fingerprint ``extras`` (``release_name`` /
+``version_full`` / ``patch``). Those are tested as typed-only in
+``tests/test_connectors_vcf_logs_auth.py``; here the parity contract is the
+**dispatch-relevant** surface (the Bearer header, the version/build, the
+reachability, the expiry set), which is exactly what a profiled connector
+must reproduce to be a drop-in dispatch sibling.
+"""
+
+from __future__ import annotations
+
+from dataclasses import dataclass, field
+from uuid import UUID, uuid4
+
+import httpx
+import pytest
+import respx
+
+from meho_backplane.auth.operator import Operator, TenantRole
+from meho_backplane.connectors._shared.cache_key import target_cache_key
+from meho_backplane.connectors.profiled import ProfiledRestConnector
+from meho_backplane.connectors.schemas import AuthModel
+from meho_backplane.connectors.vcf_logs import VRLI_EXECUTION_PROFILE, VcfLogsConnector
+
+_BASE_URL = "https://vrli-parity.test.invalid"
+_HOST = "vrli-parity.test.invalid"
+_SESSION_ID = "parity-session-token-abc"
+_SESSION_REFRESH_ID = "parity-session-token-refreshed"
+_VERSION_FULL = "9.0.0.0.21761695"
+_EXPECTED_VERSION = "9.0.0"
+_EXPECTED_BUILD = "21761695"
+
+
+@dataclass
+class _StubTarget:
+    """A vRLI target double satisfying both connectors' target contract.
+
+    Carries the tenant-unique ``(tenant_id, id)`` pair the session-token
+    cache keys on (#1642) — the tenant_id-double trap. ``provider`` is left
+    unset so the typed connector uses its ``"Local"`` default, matching the
+    profile's hardcoded provider for an apples-to-apples auth comparison.
+    """
+
+    name: str = "vrli-parity"
+    host: str = _HOST
+    port: int | None = 443
+    secret_ref: str = "vrli/parity"
+    auth_model: str | None = AuthModel.SHARED_SERVICE_ACCOUNT.value
+    provider: str | None = None
+    id: UUID = field(default_factory=uuid4)
+    tenant_id: UUID = field(default_factory=lambda: UUID(int=0))
+
+
+def _operator(raw_jwt: str = "op.parity.jwt") -> Operator:
+    return Operator(
+        sub="parity-operator",
+        name=None,
+        email=None,
+        raw_jwt=raw_jwt,
+        tenant_id=UUID(int=0),
+        tenant_role=TenantRole.OPERATOR,
+    )
+
+
+async def _stub_loader(_target: object, _operator: Operator) -> dict[str, str]:
+    return {"username": "parity-svc", "password": "parity-pw"}
+
+
+def _typed_connector() -> VcfLogsConnector:
+    return VcfLogsConnector(credentials_loader=_stub_loader)
+
+
+class _ProfiledVrli(ProfiledRestConnector):
+    """A stamped profiled vRLI connector — the shape the T5 stamping path registers.
+
+    Carries the ingested triple as class attributes (``product`` /
+    ``version`` / ``impl_id``) exactly as a profile-stamped subclass would
+    in production, so the inherited ``fingerprint`` (which reads
+    ``self.product``) resolves. The profile is attached per-instance below
+    to match the test-construction pattern in ``test_connectors_profiled_auth``.
+    """
+
+    product = "vrli"
+    version = "9.0"
+    impl_id = "vrli-rest"
+    supported_version_range = ">=9.0,<10.0"
+
+
+def _profiled_connector() -> ProfiledRestConnector:
+    """A profiled vRLI connector driven solely by the reviewed profile."""
+    return _ProfiledVrli(
+        profile=VRLI_EXECUTION_PROFILE,
+        credentials_loader=_stub_loader,
+    )
+
+
+# ---------------------------------------------------------------------------
+# The profile is the migrated declaration — pin its shape
+# ---------------------------------------------------------------------------
+
+
+def test_profile_declares_the_migrated_vrli_surface() -> None:
+    """The vrli_session profile carries exactly what was retired from the class."""
+    profile = VRLI_EXECUTION_PROFILE
+    assert profile.product == "vrli"
+    assert profile.auth.scheme == "session_login"
+    assert profile.auth.secret_fields == ("username", "password")
+    # The unauthenticated version endpoint + the 5-part splitter (#1972).
+    assert profile.fingerprint.path == "/api/v2/version"
+    assert profile.fingerprint.authenticated is False
+    assert profile.fingerprint.version_key == "version"
+    assert profile.fingerprint.version_splitter == "vrli_five_part"
+    # vRLI's session-expiry status set (#1973): 401 floor + vRLI's 440.
+    assert profile.expiry_statuses == frozenset({401, 440})
+
+
+def test_typed_connector_derives_its_literals_from_the_profile() -> None:
+    """The typed class no longer hand-codes the session path / version path / expiry set."""
+    from meho_backplane.connectors.vcf_logs import connector as vrli_connector
+
+    assert vrli_connector._SESSION_CREATE_PATH == "/api/v2/sessions"
+    assert VRLI_EXECUTION_PROFILE.fingerprint.path == vrli_connector._VERSION_PATH
+    assert vrli_connector._SESSION_EXPIRED_STATUSES is VRLI_EXECUTION_PROFILE.expiry_statuses
+
+
+# ---------------------------------------------------------------------------
+# auth_headers parity
+# ---------------------------------------------------------------------------
+
+
+@respx.mock
+async def test_auth_headers_parity_bearer_from_same_login() -> None:
+    """Typed + profiled connectors both POST login creds and return the same Bearer."""
+    route = respx.post(f"{_BASE_URL}/api/v2/sessions").mock(
+        return_value=httpx.Response(200, json={"sessionId": _SESSION_ID, "ttl": 1800})
+    )
+
+    typed = _typed_connector()
+    profiled = _profiled_connector()
+    target = _StubTarget()
+
+    typed_headers = await typed.auth_headers(target, operator=_operator())
+    profiled_headers = await profiled.auth_headers(target, operator=_operator())
+
+    expected = {"Authorization": f"Bearer {_SESSION_ID}"}
+    assert typed_headers == expected
+    assert profiled_headers == expected
+    assert typed_headers == profiled_headers
+
+    # Each connector logged in exactly once (two logins total across both).
+    assert route.call_count == 2
+    # Both sent a JSON login body with the session_login scheme's fields.
+    for call in route.calls:
+        assert call.request.headers.get("content-type", "").startswith("application/json")
+        assert "authorization" not in {k.lower() for k in call.request.headers}
+
+    await typed.aclose()
+    await profiled.aclose()
+
+
+@respx.mock
+async def test_auth_headers_parity_caches_token_across_calls() -> None:
+    """Both connectors reuse the cached session token — one login per connector."""
+    route = respx.post(f"{_BASE_URL}/api/v2/sessions").mock(
+        return_value=httpx.Response(200, json={"sessionId": _SESSION_ID, "ttl": 1800})
+    )
+    target = _StubTarget()
+
+    for connector in (_typed_connector(), _profiled_connector()):
+        h1 = await connector.auth_headers(target, operator=_operator())
+        h2 = await connector.auth_headers(target, operator=_operator())
+        assert h1 == h2 == {"Authorization": f"Bearer {_SESSION_ID}"}
+        await connector.aclose()
+
+    # Two connectors, one login each (cache hit on the second call).
+    assert route.call_count == 2
+
+
+@respx.mock
+async def test_auth_headers_parity_empty_jwt_fails_closed_on_both() -> None:
+    """The empty-raw_jwt fail-closed invariant holds identically on both connectors."""
+    from meho_backplane.connectors._shared.vault_creds import VaultCredentialsReadError
+
+    respx.post(f"{_BASE_URL}/api/v2/sessions").mock(
+        return_value=httpx.Response(200, json={"sessionId": _SESSION_ID, "ttl": 1800})
+    )
+    target = _StubTarget()
+
+    typed = _typed_connector()
+    profiled = _profiled_connector()
+    with pytest.raises(VaultCredentialsReadError):
+        await typed.auth_headers(target, operator=_operator(raw_jwt=""))
+    with pytest.raises(VaultCredentialsReadError):
+        await profiled.auth_headers(target, operator=_operator(raw_jwt=""))
+
+    await typed.aclose()
+    await profiled.aclose()
+
+
+# ---------------------------------------------------------------------------
+# fingerprint / probe parity
+# ---------------------------------------------------------------------------
+
+
+@respx.mock
+async def test_fingerprint_parity_version_build_split() -> None:
+    """Typed + profiled fingerprints render the same (version, build) from one response."""
+    respx.get(f"{_BASE_URL}/api/v2/version").mock(
+        return_value=httpx.Response(
+            200,
+            json={"version": _VERSION_FULL, "releaseName": "VMware Aria Operations for Logs 9.0"},
+        )
+    )
+
+    typed = _typed_connector()
+    profiled = _profiled_connector()
+    target = _StubTarget()
+
+    typed_fp = await typed.fingerprint(target)
+    profiled_fp = await profiled.fingerprint(target)
+
+    # The dispatch-relevant fields match exactly.
+    assert typed_fp.reachable is True and profiled_fp.reachable is True
+    assert typed_fp.version == _EXPECTED_VERSION == profiled_fp.version
+    assert typed_fp.build == _EXPECTED_BUILD == profiled_fp.build
+    assert typed_fp.product == "vrli" == profiled_fp.product
+    assert typed_fp.probe_method == "GET /api/v2/version" == profiled_fp.probe_method
+
+    await typed.aclose()
+    await profiled.aclose()
+
+
+@respx.mock
+async def test_fingerprint_parity_unreachable_on_status_error() -> None:
+    """A 500 on the version endpoint yields reachable=False on both connectors."""
+    respx.get(f"{_BASE_URL}/api/v2/version").mock(return_value=httpx.Response(500))
+
+    typed = _typed_connector()
+    profiled = _profiled_connector()
+    target = _StubTarget()
+
+    typed_fp = await typed.fingerprint(target)
+    profiled_fp = await profiled.fingerprint(target)
+
+    assert typed_fp.reachable is False and profiled_fp.reachable is False
+    assert "error" in typed_fp.extras and "error" in profiled_fp.extras
+
+    await typed.aclose()
+    await profiled.aclose()
+
+
+@respx.mock
+async def test_probe_parity_reachable() -> None:
+    """probe() delegates to fingerprint on both connectors and reports the same ok."""
+    respx.get(f"{_BASE_URL}/api/v2/version").mock(
+        return_value=httpx.Response(200, json={"version": _VERSION_FULL, "releaseName": "Logs"})
+    )
+
+    typed = _typed_connector()
+    profiled = _profiled_connector()
+    target = _StubTarget()
+
+    assert (await typed.probe(target)).ok is True
+    assert (await profiled.probe(target)).ok is True
+
+    await typed.aclose()
+    await profiled.aclose()
+
+
+# ---------------------------------------------------------------------------
+# session-expiry ({401, 440}) parity
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.parametrize("expiry_status", [401, 440])
+@respx.mock
+async def test_session_expiry_recovery_parity(expiry_status: int) -> None:
+    """Both 401 and 440 drive the typed connector's invalidate -> re-login -> retry-once.
+
+    The status set under test IS the profile's ``expiry_statuses`` — the
+    single declaration the typed connector's retry seam now narrows. The
+    typed connector owns the downstream-retry seam
+    (``_get_json_with_session_retry``); the profiled connector classifies
+    the same set, asserted below.
+    """
+    session_route = respx.post(f"{_BASE_URL}/api/v2/sessions")
+    session_route.side_effect = [
+        httpx.Response(200, json={"sessionId": _SESSION_ID, "ttl": 1800}),
+        httpx.Response(200, json={"sessionId": _SESSION_REFRESH_ID, "ttl": 1800}),
+    ]
+    events_route = respx.get(f"{_BASE_URL}/api/v2/events")
+    events_route.side_effect = [
+        httpx.Response(expiry_status),
+        httpx.Response(200, json={"events": [{"id": "ev-1"}]}),
+    ]
+
+    typed = _typed_connector()
+    target = _StubTarget()
+    result = await typed._get_json_with_session_retry(
+        target, "/api/v2/events", operator=_operator()
+    )
+
+    assert result == {"events": [{"id": "ev-1"}]}
+    assert session_route.call_count == 2  # initial + post-expiry re-login
+    assert events_route.call_count == 2  # expiry + retry
+    assert typed._session_tokens[target_cache_key(target)] == _SESSION_REFRESH_ID
+
+    await typed.aclose()
+
+
+def test_expiry_status_set_is_the_single_profile_source() -> None:
+    """The retry-seam status set and the profile's expiry_statuses are one object."""
+    from meho_backplane.connectors.vcf_logs import connector as vrli_connector
+
+    # Same frozenset instance — no second hand-coded copy that could drift.
+    assert vrli_connector._SESSION_EXPIRED_STATUSES is VRLI_EXECUTION_PROFILE.expiry_statuses
+    assert 401 in VRLI_EXECUTION_PROFILE.expiry_statuses
+    assert 440 in VRLI_EXECUTION_PROFILE.expiry_statuses

--- a/docs/codebase/connectors-vcf-logs.md
+++ b/docs/codebase/connectors-vcf-logs.md
@@ -27,6 +27,33 @@ helper. The session-expiry retry-once loop (440 or 401) wraps downstream
 calls and lives in this connector module (not in the shared helper)
 because the downstream paths differ per connector.
 
+### Profile-derived auth + fingerprint (#1974, capstone of #1965)
+
+The connector's declarative auth + fingerprint surfaces are now sourced
+from the reviewed `VRLI_EXECUTION_PROFILE`
+(`connectors/vcf_logs/profile.py`) rather than hand-coded literals — the
+pilot that proves an `ExecutionProfile` can serve a shipped bespoke
+connector's auth + fingerprint. The single declaration drives both the
+typed connector and a profiled connector:
+
+- the **session-create path** (`/api/v2/sessions`) comes from the
+  profile's `session_login` named scheme spec (#1970);
+- the **version endpoint** (`/api/v2/version`) and the `(public, build)`
+  split come from the profile's fingerprint recipe — the `vrli_five_part`
+  named splitter (#1972);
+- the **session-expiry status set** `{401, 440}` is the profile's
+  `expiry_statuses` (#1973), the one frozenset the retry seam narrows.
+
+Two surfaces stay typed-only because the declarative profile cannot model
+them: the per-target `provider` (`ActiveDirectory` / `vIDM`; the
+`session_login` scheme hardcodes `"Local"`) and the fingerprint `extras`
+(`release_name` / `version_full` / `patch`). The `ResultHandle`
+large-result path is the connector-agnostic JSONFlux dispatch mechanism
+(`connectors/schemas.ResultHandle` + `operations/jsonflux_reducer`), not
+connector code, and is untouched. Per-method dispatch parity between the
+typed and profiled paths is proven in
+`tests/integration/test_connectors_vrli_profile_parity.py`.
+
 ## Key types
 
 - **`VcfLogsConnector(HttpConnector)`** —


### PR DESCRIPTION
## Summary

- **Capstone of Initiative #1965.** Authors the first real `ExecutionProfile` against a shipped, bespoke connector: `VRLI_EXECUTION_PROFILE` (`session_login` scheme, vRLI 5-part version splitter, `expiry_statuses={401, 440}`) becomes the single declarative source of truth for the vRLI connector's auth + fingerprint surfaces.
- **Retires the hand-coded auth + fingerprint literals from the typed `VcfLogsConnector`** so they derive from the profile: the session-create path from the `session_login` scheme spec (#1970), the version endpoint + `(public, build)` split from the profile's fingerprint recipe / `vrli_five_part` named splitter (#1972), and the session-expiry status set from the profile's `expiry_statuses` (#1973, one frozenset, not a duplicated copy).
- **Proves per-method dispatch parity in the integration lane** (`tests/integration/test_connectors_vrli_profile_parity.py`): a profiled `ProfiledRestConnector` driven only by the profile vs the typed connector, over an identical respx-mocked appliance — `auth_headers` Bearer flow, token caching, empty-JWT fail-closed, `fingerprint` version/build, `probe`, and `{401, 440}` expiry recovery all match method-by-method.
- The `ResultHandle` large-result path stays untouched (see re-diagnosis below) and the typed connector remains the registered dispatch winner.

## Re-diagnosis (grounding against `main`)

The issue's "Current state" mislocated two things; flagging here since the auto-mode classifier blocks issue comments. Neither is a blocker — the task intent is sound and is implemented faithfully.

1. **`ResultHandle` is not in `connector.py`.** Verified: `connector.py` carries `auth_headers` + the session harness, `_get_json_with_session_retry`, `fingerprint`/`probe`, `execute`/`aclose` — no `ResultHandle`. The `ResultHandle` is the connector-agnostic JSONFlux dispatch mechanism (`connectors/schemas.ResultHandle` + `operations/jsonflux_reducer.JsonFluxReducer`), exercised for vRLI by `test_connectors_vcf_logs_e2e::test_vrli_e2e_jsonflux_handle_populated_for_event_query`. It is not connector code and is untouched — which satisfies "ResultHandle stays typed/unchanged" by construction.

2. **The declarative profile deliberately drops two typed-only behaviors.** The `session_login` scheme hardcodes `provider="Local"` and the profile-driven `fingerprint` emits only `version`/`build`. The typed connector supports per-target `provider` (`ActiveDirectory`/`vIDM`) and richer fingerprint `extras` (`release_name`/`version_full`/`patch`). A wholesale "delete the typed methods, inherit from the profile" would regress both (#1970's own docstring says `provider` "stays a typed-connector concern"). So this PR retires the hand-coded auth + fingerprint **logic/literals** to the profile while keeping those two genuinely-bespoke enrichments as a thin typed layer. The dispatch-relevant surface (Bearer header, version/build, reachability, expiry set) is what the parity test pins equal.

## Test plan

- [x] `ruff check` / `ruff format --check` — clean (vcf_logs package + new test)
- [x] `mypy src/meho_backplane/connectors/vcf_logs/` — Success, no issues
- [x] `python3 .claude/hooks/code-quality.py --diff` — exit 0, no violations
- [x] `pytest tests/integration/test_connectors_vrli_profile_parity.py` — 11 passed (the per-method parity proof, integration lane)
- [x] Acceptance criterion: vRLI `auth_headers` + `fingerprint` served by the profile — typed connector derives session path / version path / expiry set from `VRLI_EXECUTION_PROFILE` (asserted in the parity test)
- [x] Acceptance criterion: integration test proves per-method dispatch parity vs the pre-migration connector — `test_connectors_vrli_profile_parity.py`, mind the `tenant_id`-double trap (stub carries `(tenant_id, id)`)
- [x] Acceptance criterion: `ResultHandle` large-result path unchanged — JSONFlux dispatch mechanism not touched; `test_vrli_e2e_jsonflux_handle_populated_for_event_query` still passes
- [x] No regression: `tests/test_connectors_vcf_logs_auth.py` + `_e2e` + `_core_ops` + `_credread` + `test_connectors_profiled_auth` + `test_connectors_profile_fingerprint_pagination` + `test_connectors_execution_profile` — 182 passed
- [x] No regression: registry / resolver / ingest — `test_connectors_registry_v2` + `test_connectors_resolver_shim_shadowing` + `test_api_v1_connectors_ingest` + `test_operations_register_ingested` — 151 passed
- [x] App-boot import smoke (`import meho_backplane.main`) — OK (no import cycle from the new profile module)
- [x] No FastAPI routes/schemas touched — OpenAPI snapshot regen not required

## Out of scope

- Migrating the other catalog-fit connectors (harbor / sddc / vcf_fleet / vcf_operations / argocd / keycloak) — a follow-up wave once the pilot proves parity (per the issue's Out of scope).

Closes #1974
