### PR TITLE
fix(docs-search): model corpus document_id Optional, blank → None (#2004)

### DIFF
--- a/backend/src/meho_backplane/auth/corpus.py
+++ b/backend/src/meho_backplane/auth/corpus.py
@@ -49,7 +49,7 @@ from urllib.parse import urlsplit, urlunsplit
 
 import httpx
 import structlog
-from pydantic import AliasChoices, BaseModel, ConfigDict, Field
+from pydantic import AliasChoices, BaseModel, ConfigDict, Field, field_validator
 
 from meho_backplane.auth.operator import Operator
 from meho_backplane.settings import get_settings
@@ -136,12 +136,26 @@ class CorpusChunk(BaseModel):
     for downstream callers regardless of which wire dialect the corpus
     speaks. ``populate_by_name=True`` keeps the internal name usable when
     constructing the model directly in tests.
+
+    ``document_id`` is modelled ``str | None`` (#2004). The contract names
+    the field ``document_id`` — MEHO.Knowledge speaks that exact key, so
+    there is no second wire name to alias (the #1732 fix aliased the three
+    fields that *did* drift; ``document_id`` is not one of them). What it
+    can be is **absent**: MEHO.Knowledge returns ``document_id: ""`` when a
+    chunk has no owning-document concept. ``document_id`` is only ever read
+    as a *citation-label fallback* (``title -> document_id -> filename ->
+    URL`` in :func:`~meho_backplane.docs_search.citation_links._label_for`)
+    and is never used to resolve or ground a citation, so a blank value is
+    not a contract breach — but carrying it as a required ``""`` is a lie.
+    The validator below normalises blank-after-strip to ``None`` so the
+    absence is honestly typed and the label chain skips a cleanly-``None``
+    rung rather than a misleading empty string.
     """
 
     model_config = ConfigDict(frozen=True, extra="ignore", populate_by_name=True)
 
     chunk_id: str
-    document_id: str
+    document_id: str | None = None
     content: str = Field(validation_alias=AliasChoices("content", "text"))
     source_url: str | None = Field(
         default=None,
@@ -149,6 +163,21 @@ class CorpusChunk(BaseModel):
     )
     score: float | None = None
     metadata: dict[str, Any] = Field(default_factory=dict)
+
+    @field_validator("document_id", mode="before")
+    @classmethod
+    def _blank_document_id_to_none(cls, value: object) -> object:
+        """Normalise a blank ``document_id`` to ``None`` (#2004).
+
+        MEHO.Knowledge returns ``document_id: ""`` for a chunk with no
+        owning-document concept. A required ``""`` would validate but lie;
+        ``Optional`` alone keeps the empty string. Mapping blank-after-strip
+        to ``None`` here makes the absence honest, so the citation-label
+        fallback skips a cleanly-``None`` rung.
+        """
+        if isinstance(value, str) and not value.strip():
+            return None
+        return value
 
 
 class CorpusSearchResponse(BaseModel):

--- a/backend/src/meho_backplane/docs_search/service.py
+++ b/backend/src/meho_backplane/docs_search/service.py
@@ -143,12 +143,16 @@ class DocsChunk(BaseModel):
     path (the collection is already implied by the request scope) and set
     to the source collection key on the cross-collection fan-out path so an
     agent fusing hits from several collections can attribute each chunk.
+
+    ``document_id`` is ``str | None`` (#2004): it mirrors the corpus's own
+    optional owning-document id (``None`` when the corpus has no document
+    concept for a chunk) and is only read as a citation-label fallback.
     """
 
     model_config = ConfigDict(frozen=True)
 
     chunk_id: str
-    document_id: str
+    document_id: str | None = None
     content: str
     source_url: str | None = None
     score: float | None = None

--- a/backend/tests/test_corpus_client.py
+++ b/backend/tests/test_corpus_client.py
@@ -322,6 +322,75 @@ async def test_results_envelope_with_text_fields_returns_real_hits(
 
 
 @pytest.mark.asyncio
+async def test_document_id_threads_through_from_results_envelope(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """A populated ``document_id`` arrives on the chunk (#2004).
+
+    The contract names the field ``document_id`` and MEHO.Knowledge speaks
+    that exact key (unlike ``content``/``source_url``, it has no second wire
+    name to alias), so a non-blank value must thread straight through the
+    ``results`` envelope onto the consumed ``document_id``.
+    """
+    _pin_settings(monkeypatch, corpus_url=_CORPUS_URL)
+    response = httpx.Response(
+        200,
+        json={
+            "results": [
+                {
+                    "chunk_id": "c1",
+                    "document_id": "d-042",
+                    "text": "owning-doc body",
+                    "source_uri": "https://docs.example/d-042",
+                }
+            ],
+        },
+    )
+    _patch_async_client(monkeypatch, _transport_capturing([], response), [])
+
+    result = await search_corpus(_make_operator(), "q")
+
+    assert result.chunks[0].document_id == "d-042"
+
+
+@pytest.mark.asyncio
+async def test_blank_document_id_normalises_to_none(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """An empty ``document_id`` is honestly typed as ``None`` (#2004).
+
+    MEHO.Knowledge returns ``document_id: ""`` for a chunk with no owning-
+    document concept. ``document_id`` is ``str | None``; a blank-after-strip
+    value normalises to ``None`` rather than threading a misleading ``""``,
+    so the citation-label fallback (``title -> document_id -> filename ->
+    URL``) skips a cleanly-``None`` rung. The blank must NOT fail parse —
+    ``document_id`` is a label fallback, not a grounding key.
+    """
+    _pin_settings(monkeypatch, corpus_url=_CORPUS_URL)
+    response = httpx.Response(
+        200,
+        json={
+            "results": [
+                {
+                    "chunk_id": "c1",
+                    "document_id": "",
+                    "text": "no owning doc",
+                    "source_uri": "https://docs.example/c1",
+                }
+            ],
+        },
+    )
+    _patch_async_client(monkeypatch, _transport_capturing([], response), [])
+
+    result = await search_corpus(_make_operator(), "q")
+
+    assert result.chunks[0].document_id is None
+    # The chunk still parses and carries its other consumed fields.
+    assert result.chunks[0].chunk_id == "c1"
+    assert result.chunks[0].content == "no owning doc"
+
+
+@pytest.mark.asyncio
 async def test_unrecognized_envelope_fails_loud_not_zero(
     monkeypatch: pytest.MonkeyPatch,
 ) -> None:

--- a/cli/api/openapi.json
+++ b/cli/api/openapi.json
@@ -21790,6 +21790,7 @@
           },
           "document_id": {
             "type": "string",
+            "nullable": true,
             "title": "Document Id"
           },
           "content": {
@@ -21815,11 +21816,10 @@
         "type": "object",
         "required": [
           "chunk_id",
-          "document_id",
           "content"
         ],
         "title": "DocsChunk",
-        "description": "One cited chunk in MEHO's ``search_docs`` response surface.\n\nA stable projection of the corpus's :class:`~meho_backplane.auth.corpus.CorpusChunk`\ninto the shape the MCP tool (T4) and CLI (T5) render: chunk text +\nsource citation + score. Decoupling MEHO's surface from the corpus's\nwire contract means a corpus field rename doesn't churn the public\n``search_docs`` response; the projection in :func:`_project_chunk` is\nthe one place that mapping lives.\n\n``collection`` is the **provenance** tag (G4.6-T5 #1554): which\ncollection the chunk came from. It is ``None`` on the single-collection\npath (the collection is already implied by the request scope) and set\nto the source collection key on the cross-collection fan-out path so an\nagent fusing hits from several collections can attribute each chunk."
+        "description": "One cited chunk in MEHO's ``search_docs`` response surface.\n\nA stable projection of the corpus's :class:`~meho_backplane.auth.corpus.CorpusChunk`\ninto the shape the MCP tool (T4) and CLI (T5) render: chunk text +\nsource citation + score. Decoupling MEHO's surface from the corpus's\nwire contract means a corpus field rename doesn't churn the public\n``search_docs`` response; the projection in :func:`_project_chunk` is\nthe one place that mapping lives.\n\n``collection`` is the **provenance** tag (G4.6-T5 #1554): which\ncollection the chunk came from. It is ``None`` on the single-collection\npath (the collection is already implied by the request scope) and set\nto the source collection key on the cross-collection fan-out path so an\nagent fusing hits from several collections can attribute each chunk.\n\n``document_id`` is ``str | None`` (#2004): it mirrors the corpus's own\noptional owning-document id (``None`` when the corpus has no document\nconcept for a chunk) and is only read as a citation-label fallback."
       },
       "DraftTemplateRequest": {
         "properties": {

--- a/cli/internal/api/client.gen.go
+++ b/cli/internal/api/client.gen.go
@@ -3113,11 +3113,15 @@ type DocCollectionSummary struct {
 // path (the collection is already implied by the request scope) and set
 // to the source collection key on the cross-collection fan-out path so an
 // agent fusing hits from several collections can attribute each chunk.
+//
+// “document_id“ is “str | None“ (#2004): it mirrors the corpus's own
+// optional owning-document id (“None“ when the corpus has no document
+// concept for a chunk) and is only read as a citation-label fallback.
 type DocsChunk struct {
 	ChunkId    string   `json:"chunk_id"`
 	Collection *string  `json:"collection"`
 	Content    string   `json:"content"`
-	DocumentId string   `json:"document_id"`
+	DocumentId *string  `json:"document_id"`
 	Score      *float32 `json:"score"`
 	SourceUrl  *string  `json:"source_url"`
 }

--- a/cli/internal/cmd/docs/search.go
+++ b/cli/internal/cmd/docs/search.go
@@ -332,7 +332,7 @@ func printSearchTable(w io.Writer, r *api.SearchDocsResponse) {
 		fmt.Fprintf(w, "%-5d %-8s %-40s %s\n",
 			i+1,
 			formatScore(chunk.Score),
-			truncate(chunk.DocumentId, 40),
+			truncate(docID(chunk.DocumentId), 40),
 			truncate(snippetOf(chunk.Content), 80),
 		)
 	}
@@ -362,10 +362,21 @@ func printFanoutTable(w io.Writer, chunks []api.DocsChunk) {
 			i+1,
 			truncate(collection, 16),
 			formatScore(chunk.Score),
-			truncate(chunk.DocumentId, 32),
+			truncate(docID(chunk.DocumentId), 32),
 			truncate(snippetOf(chunk.Content), 80),
 		)
 	}
+}
+
+// docID dereferences the optional document-id citation, which is now a
+// *string on the wire (DocsChunk.DocumentId). A nil id renders as a blank
+// cell — mirroring the nil-guard used for the optional Collection field —
+// so an absent citation stays empty rather than panicking on a nil deref.
+func docID(p *string) string {
+	if p == nil {
+		return ""
+	}
+	return *p
 }
 
 // formatScore renders the corpus score, which is optional on the wire

--- a/cli/internal/cmd/docs/search_test.go
+++ b/cli/internal/cmd/docs/search_test.go
@@ -314,7 +314,7 @@ func TestRunSearchHappyPath(t *testing.T) {
 				{
 					ChunkId:    "chunk-1",
 					Content:    "NSX configuration maximums for vSphere 9.0 are …",
-					DocumentId: "nsx-config-maximums-9.0",
+					DocumentId: ptrStr("nsx-config-maximums-9.0"),
 					Score:      ptrFloat32(0.95),
 					SourceUrl:  ptrStr("https://docs.example/nsx"),
 				},
@@ -446,7 +446,7 @@ func TestRunSearchJSONHappyPath(t *testing.T) {
 				{
 					ChunkId:    "chunk-1",
 					Content:    "body",
-					DocumentId: "doc-1",
+					DocumentId: ptrStr("doc-1"),
 					Score:      ptrFloat32(0.5),
 					SourceUrl:  ptrStr("https://docs.example/x"),
 				},
@@ -481,7 +481,7 @@ func TestRunSearchRendersAbsentScoreAsDash(t *testing.T) {
 		w.Header().Set("Content-Type", "application/json")
 		_ = json.NewEncoder(w).Encode(api.SearchDocsResponse{
 			Chunks: []api.DocsChunk{
-				{ChunkId: "c", Content: "b", DocumentId: "doc-1", Score: nil},
+				{ChunkId: "c", Content: "b", DocumentId: ptrStr("doc-1"), Score: nil},
 			},
 		})
 	})
@@ -668,8 +668,8 @@ func TestRunSearchFanoutRendersProvenanceColumn(t *testing.T) {
 		w.Header().Set("Content-Type", "application/json")
 		_ = json.NewEncoder(w).Encode(api.SearchDocsResponse{
 			Chunks: []api.DocsChunk{
-				{ChunkId: "c1", Content: "vmware hit", DocumentId: "dv1", Collection: ptrStr("vmware")},
-				{ChunkId: "c2", Content: "netapp hit", DocumentId: "dn1", Collection: ptrStr("netapp")},
+				{ChunkId: "c1", Content: "vmware hit", DocumentId: ptrStr("dv1"), Collection: ptrStr("vmware")},
+				{ChunkId: "c2", Content: "netapp hit", DocumentId: ptrStr("dn1"), Collection: ptrStr("netapp")},
 			},
 		})
 	})

--- a/docs/cross-repo/meho-docs-addon.md
+++ b/docs/cross-repo/meho-docs-addon.md
@@ -527,7 +527,7 @@ meho expects a `2xx` JSON body with a **top-level `chunks`** array, ranked
 |---|---|---|---|
 | `chunks` | `[chunk]` | **yes** (top-level key) | The ordered hit list. **Not** `results` / `hits` / `data`. |
 | `chunk_id` | `str` | **yes** | Per-chunk id. |
-| `document_id` | `str` | **yes** | Owning document id. |
+| `document_id` | `str` | optional (#2004) | Owning document id; read only as a citation-label fallback. A blank `""` or an omitted key normalises to `None` — it is **not** a grounding key, so absence does not fail parse. |
 | `content` | `str` | **yes** | The chunk text. **Not** `text` / `body` / `snippet`. |
 | `source_url` | `str` | optional | Citation URL. **Not** `source_uri` / `url`. |
 | `score` | `float` | optional | Rank score (meho keeps corpus order regardless). |
@@ -538,8 +538,10 @@ meho reads top-level **`chunks`** and per-chunk **`content`** /
 is **not** speaking this contract (and triggers the empty-parse footgun
 below, not a loud failure). Extra fields meho does not name are ignored
 (`extra="ignore"`), so a corpus may add fields freely; **dropping** a
-required field (`chunk_id` / `document_id` / `content`) fails parse and is
-surfaced as `CorpusUnavailable` → 503. Source: `CorpusChunk` /
+required field (`chunk_id` / `content`) fails parse and is surfaced as
+`CorpusUnavailable` → 503. `document_id` is the lone exception (#2004): it
+is a citation-label fallback only, so a blank or omitted value normalises
+to `None` rather than failing parse. Source: `CorpusChunk` /
 `CorpusSearchResponse`, `corpus.py:88-122`.
 
 ### Readiness — request + response


### PR DESCRIPTION
## Summary

- `search_docs` hits carried `document_id: ""` because MEHO.Knowledge returns an empty owning-document id for chunks with no document concept; the field was a required `str`, so the empty value validated silently and surfaced as a misleading `""` on the citation-label fallback chain rather than an honest absence.
- Took the **Optional** branch the task and Initiative DoD explicitly sanction. The #1732 precedent aliased the three `/search` fields that genuinely drift (`content←text`, `source_url←source_uri`, `chunks←results`); `document_id` is **not** one of them — the normative wire contract (`meho-docs-addon.md`, derived from `corpus.py`) names the field `document_id` and MEHO.Knowledge speaks that exact key, so there is no second wire name to alias. Adding a speculative alias to a guessed name (`doc_id`/`id`/`documentId`) would be inventing a value, which the task forbids.
- `CorpusChunk.document_id` and `DocsChunk.document_id` are now `str | None`, with a `mode="before"` validator on `CorpusChunk` normalising blank-after-strip to `None` (plain `Optional` alone keeps the `""` the corpus sends). `document_id` is read **only** as a citation-label fallback (`title → document_id → filename → URL`), never as a grounding/resolution key, so a blank is not a contract breach — the chain already accepts `str | None` end to end.
- Contract doc, OpenAPI snapshot, and generated CLI client updated to match (`DocumentId *string`, no longer in `required`).

## Test plan

- [x] `ruff check` — clean
- [x] `ruff format --check` — clean
- [x] `mypy src/` — Success: no issues found in 559 source files
- [x] `pytest tests/test_corpus_client.py` — 24 passed (22 original + 2 new)
  - `test_document_id_threads_through_from_results_envelope` — a `{results:[{… "document_id":"d-042" …}]}` 200 yields `chunks[0].document_id == "d-042"` (the #1732-shape regression the task asks for)
  - `test_blank_document_id_normalises_to_none` — a `document_id: ""` 200 yields `chunks[0].document_id is None`, parse does not fail, other consumed fields intact
- [x] Downstream suites green — `pytest test_citation_links test_ui_corpus test_mcp_tools_docs test_ask_docs_route test_mcp_resources_docs test_search_docs_route test_search_docs_fanout_rrf test_docs_backends_router` — 149 passed
- [x] `cd cli && make snapshot-openapi && make generate` — `DocsChunk.document_id` now `nullable: true` and dropped from `required`; generated Go client `DocumentId *string`

## Out of scope

- `collection: null` on single-collection search — by design (per the task), not touched.
- No AliasChoices added: the contract names the field `document_id` and the corpus speaks that key; the empty value is an honest absence, not a wire-name mismatch.

<!-- auto-implement-issue: fresh, iteration 1 -->

Closes #2004


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **Bug Fixes**
  * Improved handling of missing or empty document IDs in corpus search results; empty values are now properly normalized.

* **Documentation**
  * Updated API schemas and documentation to reflect that `document_id` is now optional in corpus chunks rather than required.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->