### PR TITLE
fix(connectors): honour RFC6570 reserved expansion in ingested-op path substitution (#2003)

### DIFF
--- a/backend/src/meho_backplane/operations/_branches.py
+++ b/backend/src/meho_backplane/operations/_branches.py
@@ -57,10 +57,29 @@ __all__ = [
 # into URL path substitution / query-string / request body.
 _PARAM_LOC_KEY = "x-meho-param-loc"
 
-# Path-template substitution pattern. ``"/api/vcenter/cluster/{cluster}"``
-# matches ``{cluster}``; the substituted value is :func:`urllib.parse.quote`-d
-# at substitution time (RFC 3986 reserved chars only).
-_PATH_VAR_RE = re.compile(r"\{([^{}]+)\}")
+# Path-template substitution pattern. Captures an optional leading
+# RFC6570 expression operator and the bare expression body:
+#
+# * ``{cluster}``      -> operator ``""``,  name ``"cluster"``     (simple
+#   expansion, RFC6570 §3.2.2 -- reserved chars in the value are encoded)
+# * ``{+constraints}`` -> operator ``"+"``, name ``"constraints"`` (reserved
+#   expansion, RFC6570 §3.2.3 -- reserved/gen-delim chars pass through literal)
+#
+# The operator is stripped from the captured name so the param lookup
+# keys on the bare variable name the ingest pipeline registers (``path``,
+# not ``+path``) -- without the strip a literal ``{+path}`` spec would
+# ``KeyError`` even though the param is supplied. Only ``+`` (and ``#``)
+# change the encoding safe set; the remaining operator chars are captured
+# so the regex never mis-includes a leading operator in the name, even for
+# operators this substituter does not (yet) special-case.
+_PATH_VAR_RE = re.compile(r"\{([+#./;?&]?)([^{}]+)\}")
+
+# RFC6570 §3.2.3 reserved-expansion safe set: the gen-delims + sub-delims
+# from RFC3986 §2.2 that a ``{+var}`` / ``{#var}`` expression leaves
+# unencoded so they keep their structural meaning in the URL. Genuinely
+# unsafe characters (space, control chars) are still percent-encoded by
+# :func:`urllib.parse.quote` because they are absent from this set.
+_RFC6570_RESERVED_SAFE = ":/?#[]@!$&'()*+,;="
 
 
 def _split_ingested_params(
@@ -130,21 +149,39 @@ def _unwrap_body(body_params: dict[str, Any]) -> Any:
 
 
 def _substitute_path(path_template: str, path_params: dict[str, Any]) -> str:
-    """Substitute ``{var}`` placeholders in *path_template* from *path_params*.
+    """Substitute ``{var}`` / ``{+var}`` placeholders in *path_template*.
 
-    Missing path vars raise :class:`KeyError` so the dispatcher's
-    caller surfaces them as ``invalid_params`` rather than producing
-    a request with literal ``{var}`` in the URL. RFC 3986 path
-    reserved chars in the substituted value are percent-encoded by
-    :func:`urllib.parse.quote` (safe set: empty, so ``/`` in a value
-    is also encoded -- matches OpenAPI's default path-style).
+    Honours RFC6570 expression operators so an ingested op's path
+    template expands with the encoding the spec author intended:
+
+    * **Simple expansion** ``{var}`` (RFC6570 §3.2.2) -- the value is
+      percent-encoded with an empty safe set, so reserved chars like
+      ``/`` become ``%2F`` (OpenAPI's default ``style: simple`` path
+      parameter behaviour: a value cannot leak a path separator).
+    * **Reserved expansion** ``{+var}`` / ``{#var}`` (RFC6570 §3.2.3) --
+      the value is encoded with the reserved/gen-delim safe set
+      (:data:`_RFC6570_RESERVED_SAFE`), so structural chars (``/``,
+      ``:``, ``,`` ...) pass through literal. This is the form a path
+      that carries a *sub-path* expression uses, e.g. vRLI's
+      ``/api/v2/events/{+constraints}`` where the constraint is itself a
+      slash-delimited segment chain (``text/CONTAINS error/hostname/...``).
+
+    In both forms a genuinely-unsafe character (space, control chars) is
+    still percent-encoded -- only the reserved structural chars differ.
+
+    Missing path vars raise :class:`KeyError` so the dispatcher's caller
+    surfaces them as ``invalid_params`` rather than producing a request
+    with a literal ``{var}`` in the URL. The lookup is keyed on the bare
+    variable name (operator stripped), so ``{+constraints}`` resolves the
+    param named ``constraints``.
     """
 
     def _replace(match: re.Match[str]) -> str:
-        name = match.group(1)
+        operator, name = match.group(1), match.group(2)
         if name not in path_params:
             raise KeyError(f"path template requires {name!r} but it was not supplied")
-        return quote(str(path_params[name]), safe="")
+        safe = _RFC6570_RESERVED_SAFE if operator in ("+", "#") else ""
+        return quote(str(path_params[name]), safe=safe)
 
     return _PATH_VAR_RE.sub(_replace, path_template)
 

--- a/backend/tests/acceptance/_vrli_canary_fixtures.py
+++ b/backend/tests/acceptance/_vrli_canary_fixtures.py
@@ -43,6 +43,7 @@ from uuid import UUID
 
 import pytest
 import respx
+from sqlalchemy import select
 
 from meho_backplane.auth.operator import Operator, TenantRole
 from meho_backplane.connectors.registry import all_connectors_v2
@@ -72,9 +73,14 @@ __all__ = [
     "VRLI_CANARY_SESSION_ID",
     "VRLI_CANARY_SESSION_REFRESH_ID",
     "VRLI_FORCE_HANDLE_LIST_OP_ID",
+    "VRLI_RESERVED_CONSTRAINT_OP_ID",
+    "VRLI_RESERVED_CONSTRAINT_VALUE",
+    "VRLI_RESERVED_CONSTRAINT_WIRE_PATH",
     "VRLI_TARGET_NAME",
     "IngestedVrliCanary",
     "_insert_vrli_descriptors",
+    "_insert_vrli_reserved_constraint_descriptor",
+    "_register_vrli_reserved_constraint_route",
     "_register_vrli_routes",
     "_vrli_credentials_loader",
     "ingested_vrli_canary",
@@ -341,6 +347,88 @@ def _register_vrli_routes(mock: respx.MockRouter) -> None:
     mock.get("/api/v2/content/contentpack/list").respond(200, json=_VRLI_CANARY_CONTENT_PACKS)
     # vrli.alert.list — configured alert definitions.
     mock.get("/api/v2/alerts").respond(200, json=_VRLI_CANARY_ALERTS)
+
+
+#: A non-curated reserved-expansion events op the #2003 canary seeds
+#: directly. Its path uses RFC6570 reserved expansion ``{+constraints}``
+#: so the slash-delimited constraint chain stays literal on the wire —
+#: the exact vRLI constraint-query shape the curated empty-constraint op
+#: cannot exercise. Kept off :data:`VRLI_CORE_OPS` so the curated 7-op
+#: set (and every test keyed on its op_ids) is untouched.
+VRLI_RESERVED_CONSTRAINT_OP_ID: str = "GET:/api/v2/events/{+constraints}"
+
+#: A non-empty constraint carrying reserved structural chars: the
+#: slash-delimited ``field/OP value`` chain vRLI's printQuery renders.
+#: Under reserved expansion the slashes pass through literal, so the wire
+#: path is ``/api/v2/events/text/CONTAINS%20error/hostname/CONTAINS%20vcsa``
+#: (space still encoded; only the structural ``/`` differs from simple
+#: expansion's ``%2F`` mangling).
+VRLI_RESERVED_CONSTRAINT_VALUE: str = "text/CONTAINS error/hostname/CONTAINS vcsa"
+
+#: The literal wire path the reserved-expansion op resolves to — slashes
+#: preserved, space percent-encoded. The respx route registers against it.
+VRLI_RESERVED_CONSTRAINT_WIRE_PATH: str = (
+    "/api/v2/events/text/CONTAINS%20error/hostname/CONTAINS%20vcsa"
+)
+
+
+async def _insert_vrli_reserved_constraint_descriptor() -> None:
+    """Seed one ``{+constraints}`` reserved-expansion events descriptor (#2003).
+
+    Reuses the ``vrli-events`` group seeded by
+    :func:`_insert_vrli_descriptors`; insert that first. The descriptor's
+    ``parameter_schema`` declares ``constraints`` as a path param, so the
+    dispatcher routes the caller's value into ``_substitute_path`` — which,
+    seeing the ``+`` operator, keeps the slash-delimited constraint chain
+    literal on the wire.
+    """
+    sessionmaker = get_sessionmaker()
+    async with sessionmaker() as session:
+        group_row = (
+            await session.execute(
+                select(OperationGroup).where(OperationGroup.group_key == "vrli-events")
+            )
+        ).scalar_one()
+        method, path = VRLI_RESERVED_CONSTRAINT_OP_ID.split(":", 1)
+        descriptor = EndpointDescriptor(
+            tenant_id=None,
+            product=VRLI_PRODUCT,
+            version=VRLI_VERSION,
+            impl_id=VRLI_IMPL_ID,
+            op_id=VRLI_RESERVED_CONSTRAINT_OP_ID,
+            source_kind="ingested",
+            method=method,
+            path=path,
+            handler_ref=None,
+            group_id=group_row.id,
+            summary="vRLI events query with reserved-expansion constraint (#2003).",
+            description="vRLI events query with reserved-expansion constraint (#2003).",
+            parameter_schema={
+                "type": "object",
+                "properties": {
+                    "constraints": {"type": "string", "x-meho-param-loc": "path"},
+                },
+                "required": ["constraints"],
+            },
+            response_schema={"type": "object"},
+            llm_instructions="Reserved-expansion constraint canary.",
+            safety_level="safe",
+            requires_approval=False,
+            is_enabled=True,
+            tags=["spec:vcf-logs-9.0/openapi.yaml"],
+        )
+        session.add(descriptor)
+        await session.commit()
+
+
+def _register_vrli_reserved_constraint_route(mock: respx.MockRouter) -> Any:
+    """Register the literal-slash wire route for the reserved-expansion op.
+
+    Returns the respx route so a test can assert it was called — proof the
+    wire URL kept ``/`` literal (a ``%2F``-mangled URL would miss this
+    route and 404 against the catch-all).
+    """
+    return mock.get(VRLI_RESERVED_CONSTRAINT_WIRE_PATH).respond(200, json=VRLI_CANARY_EVENTS)
 
 
 @dataclass(frozen=True)

--- a/backend/tests/test_connectors_vcf_logs_e2e.py
+++ b/backend/tests/test_connectors_vcf_logs_e2e.py
@@ -94,7 +94,11 @@ from tests.acceptance._vrli_canary_fixtures import (
     VRLI_CANARY_SESSION_REFRESH_ID,
     VRLI_CONSTRAINT_OP_PARAMS,
     VRLI_FORCE_HANDLE_LIST_OP_ID,
+    VRLI_RESERVED_CONSTRAINT_OP_ID,
+    VRLI_RESERVED_CONSTRAINT_VALUE,
     _insert_vrli_descriptors,
+    _insert_vrli_reserved_constraint_descriptor,
+    _register_vrli_reserved_constraint_route,
     _register_vrli_routes,
     _vrli_credentials_loader,
 )
@@ -932,4 +936,87 @@ async def test_vrli_e2e_jsonflux_handle_populated_for_event_query(
     payload = result_envelope.get("result")
     assert payload is not None and payload.get("row_count") == expected_rows, (
         f"Expected reducer summary on result.row_count={expected_rows}; got result={payload!r}"
+    )
+
+
+# ---------------------------------------------------------------------------
+# Reserved-expansion constraint canary (#2003)
+# ---------------------------------------------------------------------------
+
+
+@pytest.fixture
+async def vrli_e2e_reserved_constraint(
+    captured_events: list[Any],
+) -> AsyncIterator[tuple[_VrliE2EBundle, Any]]:
+    """vRLI setup seeding the ``{+constraints}`` reserved-expansion events op.
+
+    Layers a single non-curated ``GET:/api/v2/events/{+constraints}``
+    descriptor on top of the standard happy-path setup and registers a
+    respx route against the **literal-slash** wire path. The route is
+    yielded so the test can assert it was hit — a ``%2F``-mangled URL
+    would miss it.
+    """
+    del captured_events
+
+    await _insert_vrli_descriptors()
+    await _insert_vrli_reserved_constraint_descriptor()
+    seeded_target = await _seed_target()
+    instance = _resolve_connector()
+
+    async with respx.mock(
+        base_url=VRLI_CANARY_BASE_URL,
+        assert_all_called=False,
+        assert_all_mocked=False,
+    ) as mock:
+        _register_vrli_routes(mock)
+        reserved_route = _register_vrli_reserved_constraint_route(mock)
+        try:
+            yield (
+                _VrliE2EBundle(
+                    target_name=_E2E_TARGET_NAME,
+                    connector_instance=instance,
+                    db_target=seeded_target,
+                ),
+                reserved_route,
+            )
+        finally:
+            await instance.aclose()
+            reset_dispatcher_caches()
+
+
+async def test_vrli_e2e_reserved_constraint_keeps_slash_literal_on_wire(
+    vrli_e2e_reserved_constraint: tuple[_VrliE2EBundle, Any],
+) -> None:
+    """A non-empty ``{+constraints}`` query keeps ``/`` literal on the wire.
+
+    The constraint-query gap the empty-constraint canary cannot exercise:
+    a reserved-char constraint (``text/CONTAINS error/...``) dispatched
+    through the full ``call_operation`` stack must reach vRLI with the
+    slash-delimited chain intact (``%2F``-mangling 400s the appliance).
+    Asserts the dispatch succeeds AND the literal-slash respx route was
+    the one hit — proof the wire URL was not over-encoded (#2003).
+    """
+    bundle, reserved_route = vrli_e2e_reserved_constraint
+
+    result_envelope = await call_operation(
+        _OPERATOR,
+        {
+            "connector_id": VRLI_CONNECTOR_ID,
+            "op_id": VRLI_RESERVED_CONSTRAINT_OP_ID,
+            "target": {"name": bundle.target_name},
+            "params": {"constraints": VRLI_RESERVED_CONSTRAINT_VALUE},
+        },
+    )
+
+    assert result_envelope["status"] == "ok", (
+        f"reserved-constraint dispatch did not succeed: {result_envelope!r}"
+    )
+    assert reserved_route.called, (
+        "literal-slash wire route was never hit — the constraint chain was "
+        "over-encoded (%2F) instead of passing through as reserved expansion"
+    )
+    # The wire path on the actual request keeps the structural slashes.
+    wire_path = reserved_route.calls.last.request.url.path
+    assert wire_path == "/api/v2/events/text/CONTAINS error/hostname/CONTAINS vcsa", (
+        f"unexpected wire path: {wire_path!r}"
     )

--- a/backend/tests/test_operations_branches_substitute_path.py
+++ b/backend/tests/test_operations_branches_substitute_path.py
@@ -1,0 +1,80 @@
+# SPDX-License-Identifier: Apache-2.0
+# Copyright (c) 2026 evoila Group
+
+"""Unit tests for ``_substitute_path`` RFC6570 expansion semantics (#2003).
+
+The ingested-op path substituter honours the RFC6570 expression
+operator so a curated/ingested op's path template expands with the
+encoding its author intended:
+
+* simple expansion ``{var}`` (§3.2.2) percent-encodes reserved chars,
+* reserved expansion ``{+var}`` / ``{#var}`` (§3.2.3) lets reserved
+  structural chars (``/``, ``:``, ``,`` ...) pass through literal.
+
+These tests pin the divergence between the two forms — the defect that
+blocked vRLI's ``/api/v2/events/{+constraints}`` constraint queries, where
+``{constraints}`` mangled the slash-delimited constraint chain into
+``%2F``-soup — plus the latent ``KeyError`` a literal ``{+var}`` template
+would have hit before the operator was stripped from the lookup name.
+"""
+
+from __future__ import annotations
+
+import pytest
+
+from meho_backplane.operations._branches import _substitute_path
+
+
+def test_simple_expansion_encodes_reserved_slash() -> None:
+    """``{var}`` percent-encodes ``/`` in the value (simple expansion)."""
+    result = _substitute_path("/api/v2/events/{constraints}", {"constraints": "a/b"})
+    assert result == "/api/v2/events/a%2Fb"
+
+
+def test_reserved_expansion_keeps_reserved_slash_literal() -> None:
+    """``{+var}`` lets ``/`` pass through literal (reserved expansion)."""
+    result = _substitute_path("/api/v2/events/{+constraints}", {"constraints": "a/b"})
+    assert result == "/api/v2/events/a/b"
+
+
+def test_simple_and_reserved_diverge_on_same_value() -> None:
+    """The two forms diverge: simple encodes ``/``, reserved keeps it.
+
+    The load-bearing assertion of #2003 — same value, same param name,
+    different operator, different wire encoding.
+    """
+    value = "text/CONTAINS error/hostname/CONTAINS vcsa"
+    simple = _substitute_path("/api/v2/events/{constraints}", {"constraints": value})
+    reserved = _substitute_path("/api/v2/events/{+constraints}", {"constraints": value})
+    # Simple expansion mangles every separator.
+    assert "%2F" in simple
+    assert "/api/v2/events/a/b" not in simple  # belt-and-suspenders
+    # Reserved expansion keeps the slash-delimited constraint chain literal.
+    assert "/CONTAINS" in reserved
+    assert "%2F" not in reserved
+
+
+def test_reserved_expansion_still_encodes_genuinely_unsafe_chars() -> None:
+    """A space stays ``%20`` under reserved expansion; only structural chars differ."""
+    result = _substitute_path("/api/v2/events/{+constraints}", {"constraints": "a b"})
+    assert result == "/api/v2/events/a%20b"
+
+
+def test_reserved_operator_resolves_bare_param_name_no_keyerror() -> None:
+    """``{+path}`` resolves the param keyed ``path`` (operator stripped from lookup).
+
+    Regression guard for the latent ``KeyError``: before the operator was
+    stripped, ``_PATH_VAR_RE`` captured ``+path`` (operator included) while
+    the ingest pipeline names the param ``path``, so substitution raised
+    ``KeyError`` → ``invalid_params`` before the request ever reached the wire.
+    """
+    result = _substitute_path("/v1/{+path}", {"path": "a/b/c"})
+    assert result == "/v1/a/b/c"
+
+
+def test_missing_param_still_raises_keyerror() -> None:
+    """A genuinely-absent path var still raises ``KeyError`` (both forms)."""
+    with pytest.raises(KeyError):
+        _substitute_path("/v1/{+path}", {})
+    with pytest.raises(KeyError):
+        _substitute_path("/v1/{cluster}", {})

--- a/docs/architecture/operations-substrate.md
+++ b/docs/architecture/operations-substrate.md
@@ -260,7 +260,14 @@ Treat `result + handle` as a tagged union: `result` carries either the raw paylo
 
 ### Path-parameter substitution for ingested ops
 
-[`_branches.py::_substitute_path`](../../backend/src/meho_backplane/operations/_branches.py) handles OpenAPI path-templating. `parameter_schema` properties carry an `x-meho-param-loc` extension (set by G0.7's ingester) — one of `"path"` / `"query"` / `"header"` / `"body"` (default `"query"`). The dispatcher splits incoming `params` into four buckets, substitutes `{var}` placeholders in `descriptor.path` with `urllib.parse.quote(safe="")`-encoded values, and routes idempotent verbs (GET / HEAD / OPTIONS) through `HttpConnector._request_json` (with retry) and non-idempotent verbs through `HttpConnector._post_json` (no retry).
+[`_branches.py::_substitute_path`](../../backend/src/meho_backplane/operations/_branches.py) handles OpenAPI path-templating. `parameter_schema` properties carry an `x-meho-param-loc` extension (set by G0.7's ingester) — one of `"path"` / `"query"` / `"header"` / `"body"` (default `"query"`). The dispatcher splits incoming `params` into four buckets, substitutes the placeholders in `descriptor.path`, and routes idempotent verbs (GET / HEAD / OPTIONS) through `HttpConnector._request_json` (with retry) and non-idempotent verbs through `HttpConnector._post_json` (no retry).
+
+Substitution honours the RFC6570 expression operator so the encoding matches the spec author's intent:
+
+- **Simple expansion** `{var}` (RFC6570 §3.2.2) — the value is `urllib.parse.quote(safe="")`-encoded, so a reserved char like `/` becomes `%2F` (OpenAPI's default `style: simple` path parameter: a value cannot leak a path separator).
+- **Reserved expansion** `{+var}` / `{#var}` (RFC6570 §3.2.3) — the value is quoted with the reserved/gen-delim safe set (`:/?#[]@!$&'()*+,;=`), so structural chars pass through literal. This is the form a template carrying a *sub-path* expression uses, e.g. vRLI's `/api/v2/events/{+constraints}` where the constraint is itself a slash-delimited chain (`text/CONTAINS error/...`); simple expansion would `%2F`-mangle it and the appliance 400s.
+
+In both forms a genuinely-unsafe char (space, control chars) is still percent-encoded — only the reserved structural chars differ. The lookup keys on the bare variable name (operator stripped), so `{+constraints}` resolves the param named `constraints`.
 
 ### Audit contextvar binding pattern
 


### PR DESCRIPTION
## Summary

- The ingested-op path substituter percent-encoded **every** reserved char unconditionally (`urllib.parse.quote(safe="")`), so an RFC6570 reserved expansion `{+var}` mangled its slash-delimited value into `%2F`-soup. This blocked vRLI events constraint queries (`/api/v2/events/{+constraints}` with `text/CONTAINS error/...`) — the appliance 400s when the structural slashes arrive encoded.
- `_substitute_path` / `_PATH_VAR_RE` now parse the RFC6570 expression operator: **simple expansion** `{var}` (§3.2.2) keeps `safe=""` (reserved chars encoded, OpenAPI default path-style); **reserved expansion** `{+var}`/`{#var}` (§3.2.3) quotes with the reserved/gen-delim safe set so structural chars pass through literal. Genuinely-unsafe chars (space, control) stay encoded in both arms.
- Also fixes a **latent KeyError**: the regex previously captured the operator into the lookup name, so a literal `{+path}` spec would `KeyError` even with the param supplied. The operator is now stripped from the lookup name.
- Hand-rolled — no `uritemplate` dependency added (templates are single-segment; lower blast radius).

## Test plan

- [x] `ruff check` — clean
- [x] `ruff format --check` — clean
- [x] `mypy src/.../_branches.py` — clean
- [x] `pytest tests/test_operations_branches_substitute_path.py` — 6 passed (unit: `{+var}` keeps `/` literal while `{var}` encodes it; `{+path}` resolves the `path` param with no KeyError; space stays `%20` under reserved expansion; missing param still raises)
- [x] `pytest tests/test_connectors_vcf_logs_e2e.py` — 24 passed, incl. new `test_vrli_e2e_reserved_constraint_keeps_slash_literal_on_wire` (non-empty reserved-char constraint dispatched through the full `call_operation` stack hits the literal-slash respx route)
- [x] `pytest tests/test_operations_request_preview.py tests/test_operations_dispatcher.py tests/test_connectors_vcf_logs_core_ops.py` — no regression
- [x] `code-quality.py --diff` — 0 blockers (2 pre-existing warnings on `_branches.py` size, not introduced here)
- [x] No FastAPI route/schema changed → no OpenAPI snapshot regen needed (verified: diff touches no routers/schemas)

## Out of scope

- Renaming the curated vRLI descriptor op_id `GET:/api/v2/events/{constraints}` → `{+constraints}` in `VRLI_CORE_OPS`/`core_ops.py`: that ripples across the curated 7-op set, group maps, migration + ingest tests, and overlaps the vRLI artifact reshape (#1972/#1974). The issue explicitly asks to **coordinate** that descriptor edit; this PR keeps the fix to the substitution engine and proves the behaviour with a non-curated `{+constraints}` canary descriptor. The curated descriptor flip can land once with the coordinated vRLI change.
- TLS SNI work (#2002, sibling task in this initiative) — kept out to minimize `_branches.py` overlap.

<!-- auto-implement-issue: fresh, iteration 1 -->

Closes #2003
