### PR TITLE
test: adapt tests to FastAPI 0.137 router-tree + exception internals, unpin fastapi (#1819)

### DIFF
--- a/backend/pyproject.toml
+++ b/backend/pyproject.toml
@@ -6,12 +6,7 @@ readme = "README.md"
 requires-python = ">=3.12"
 license = "Apache-2.0"
 dependencies = [
-    # Pinned <0.137: FastAPI 0.137.0 regressed include_router for prefixed
-    # routers — every `/api/v1/*` router (built APIRouter(prefix=...) + relative
-    # routes) mounts ZERO routes on the app, dropping the entire API surface
-    # (caught by test_all_routes_mounted_on_main_app). Unpin once the app is
-    # adapted to 0.137's include_router semantics (tracked follow-up).
-    "fastapi>=0.136.3,<0.137",
+    "fastapi>=0.137.1,<0.138",
     "uvicorn[standard]>=0.49.0",
     "pydantic[email]>=2.13.4",
     "structlog>=26.1.0",

--- a/backend/tests/_route_tree_helpers.py
+++ b/backend/tests/_route_tree_helpers.py
@@ -1,0 +1,40 @@
+# SPDX-License-Identifier: Apache-2.0
+# Copyright (c) 2026 evoila Group
+
+"""Helpers for introspecting the FastAPI 0.137+ route tree in tests.
+
+FastAPI 0.137 (`PR #15745 <https://github.com/fastapi/fastapi/pull/15745>`_)
+stopped flattening included routers into a single ``router.routes`` list.
+``include_router()`` now leaves an ``_IncludedRouter`` wrapper whose nested
+routes live under ``original_router.routes``, forming a tree. Tests that
+depended on a flat ``routes`` list — for route-presence or
+first-match-ordering assertions — must walk that tree.
+
+:func:`iter_routes` does a depth-first walk in registration order, so the
+literal-before-param ordering assertions these tests make (first-match-wins
+routing) still hold. Pure route-*presence* tests prefer
+``app.openapi()["paths"]``; reach for this helper only when the assertion
+needs route ordering or a route attribute OpenAPI does not expose (e.g. the
+handler ``name``).
+"""
+
+from __future__ import annotations
+
+from collections.abc import Iterable, Iterator
+from typing import Any
+
+
+def iter_routes(routes: Iterable[Any]) -> Iterator[Any]:
+    """Yield leaf routes from a FastAPI 0.137+ route tree, in registration order.
+
+    ``_IncludedRouter`` wrappers (produced by ``include_router()`` under
+    0.137) carry no ``path``/``methods`` of their own; their real routes
+    hang off ``original_router.routes``. Descend through those so callers
+    see the same flat, ordered sequence the pre-0.137 ``routes`` list gave.
+    """
+    for route in routes:
+        original = getattr(route, "original_router", None)
+        if original is not None:
+            yield from iter_routes(original.routes)
+        else:
+            yield route

--- a/backend/tests/test_api_v1_connectors_ingest.py
+++ b/backend/tests/test_api_v1_connectors_ingest.py
@@ -463,18 +463,20 @@ def test_all_routes_mounted_on_main_app() -> None:
     """
     from meho_backplane.main import app
 
+    openapi_paths = app.openapi()["paths"]
+
     expected_paths = {
         "/api/v1/connectors/ingest",
         "/api/v1/connectors/ingest/jobs/{job_id}",
         "/api/v1/connectors",
         "/api/v1/connectors/{connector_id}/review",
         "/api/v1/connectors/{connector_id}/groups/{group_key}",
-        "/api/v1/connectors/{connector_id}/operations/{op_id:path}",
+        # FastAPI 0.137 strips the `:path` converter in OpenAPI path keys
+        "/api/v1/connectors/{connector_id}/operations/{op_id}",
         "/api/v1/connectors/{connector_id}/enable",
         "/api/v1/connectors/{connector_id}/disable",
     }
-    actual_paths = {getattr(r, "path", None) for r in app.routes}
-    missing = expected_paths - actual_paths
+    missing = expected_paths - openapi_paths.keys()
     assert not missing, f"missing routes: {missing}"
 
 

--- a/backend/tests/test_api_v1_kb.py
+++ b/backend/tests/test_api_v1_kb.py
@@ -51,11 +51,13 @@ from typing import Any
 from unittest.mock import AsyncMock, patch
 from uuid import UUID
 
+import httpx
 import pytest
 import respx
 import structlog
 from fastapi import FastAPI
 from fastapi.testclient import TestClient
+from httpx import ASGITransport
 from sqlalchemy import select
 
 from meho_backplane.api.v1.kb import router as kb_router
@@ -240,18 +242,18 @@ def test_all_five_routes_mounted_on_main_app() -> None:
     """All five routes appear in :mod:`meho_backplane.main`'s app + OpenAPI."""
     from meho_backplane.main import app
 
+    # Verify the OpenAPI doc enumerates every method on each path.
+    openapi = app.openapi()
+    paths = openapi["paths"]
+
     expected_paths = {
         "/api/v1/kb",
         "/api/v1/kb/{slug}",
         "/api/v1/kb/ingest",
     }
-    actual_paths = {getattr(r, "path", None) for r in app.routes}
-    missing = expected_paths - actual_paths
+    missing = expected_paths - paths.keys()
     assert not missing, f"missing routes: {missing}"
 
-    # Verify the OpenAPI doc enumerates every method on each path.
-    openapi = app.openapi()
-    paths = openapi["paths"]
     assert "get" in paths["/api/v1/kb"]
     assert "post" in paths["/api/v1/kb"]
     assert "get" in paths["/api/v1/kb/{slug}"]
@@ -1026,7 +1028,9 @@ async def test_delete_writes_audit_row_with_existed_flag(
 
 
 @pytest.mark.asyncio
-async def test_delete_substrate_exception_still_writes_kb_delete_audit_row() -> None:
+async def test_delete_substrate_exception_still_writes_kb_delete_audit_row(
+    log_buffer: io.StringIO,
+) -> None:
     """Substrate raising during delete still produces ``op_id="kb.delete"`` audit row.
 
     Regression for the bind-ordering bug: before the fix the
@@ -1044,25 +1048,27 @@ async def test_delete_substrate_exception_still_writes_kb_delete_audit_row() -> 
     whether the row existed because the query failed), which is the
     truthful signal.
 
-    Uses a TestClient constructed with
-    ``raise_server_exceptions=False`` so the re-raised handler
-    exception surfaces as the 500 an operator would actually see
-    in production, rather than failing the test with the
-    propagated exception. Same posture as
-    :mod:`tests.test_audit_middleware`'s 500-classification tests.
+    Driven via ``httpx.AsyncClient`` with
+    ``ASGITransport(raise_app_exceptions=False)`` so the re-raised
+    handler exception surfaces as the 500 an operator would actually
+    see in production, rather than leaking through TestClient's portal
+    teardown.
     """
     tenant_a = uuid.uuid4()
     key, token = _admin_token(tenant_id=tenant_a)
     # Substrate raises RuntimeError mid-delete -- mimics a PG
     # connection drop or a deadlock that fails the statement.
     fake_delete = AsyncMock(side_effect=RuntimeError("simulated substrate failure"))
-    raising_client = TestClient(_build_app(), raise_server_exceptions=False)
-    with (
-        respx.mock as mock_router,
-        patch("meho_backplane.api.v1.kb.KbService.delete_entry", fake_delete),
-    ):
-        _mock_discovery_and_jwks(mock_router, _public_jwks(key))
-        response = raising_client.delete("/api/v1/kb/k8s-ingress", headers=_authed(token))
+    transport = ASGITransport(app=_build_app(), raise_app_exceptions=False)
+    async with httpx.AsyncClient(
+        transport=transport, base_url="https://testserver"
+    ) as raising_client:
+        with (
+            respx.mock as mock_router,
+            patch("meho_backplane.api.v1.kb.KbService.delete_entry", fake_delete),
+        ):
+            _mock_discovery_and_jwks(mock_router, _public_jwks(key))
+            response = await raising_client.delete("/api/v1/kb/k8s-ingress", headers=_authed(token))
 
     # The outer ServerErrorMiddleware converts the re-raised handler
     # exception into a 500 -- the audit row still commits with the

--- a/backend/tests/test_api_v1_kb.py
+++ b/backend/tests/test_api_v1_kb.py
@@ -1027,10 +1027,12 @@ async def test_delete_writes_audit_row_with_existed_flag(
     assert payload["existed"] is True
 
 
+# usefixtures(log_buffer): requested for its side effect only — it routes
+# structlog to a buffer so the 0.137 re-raised handler exception doesn't
+# surface as a teardown ERROR. ASGITransport alone does not suppress it.
+@pytest.mark.usefixtures("log_buffer")
 @pytest.mark.asyncio
-async def test_delete_substrate_exception_still_writes_kb_delete_audit_row(
-    log_buffer: io.StringIO,
-) -> None:
+async def test_delete_substrate_exception_still_writes_kb_delete_audit_row() -> None:
     """Substrate raising during delete still produces ``op_id="kb.delete"`` audit row.
 
     Regression for the bind-ordering bug: before the fix the

--- a/backend/tests/test_api_v1_memory.py
+++ b/backend/tests/test_api_v1_memory.py
@@ -49,11 +49,13 @@ from typing import Any
 from unittest.mock import AsyncMock, patch
 from uuid import UUID
 
+import httpx
 import pytest
 import respx
 import structlog
 from fastapi import FastAPI
 from fastapi.testclient import TestClient
+from httpx import ASGITransport
 from sqlalchemy import select
 
 from meho_backplane.api.v1.memory import router as memory_router
@@ -251,16 +253,16 @@ def test_all_four_routes_mounted_on_main_app() -> None:
     """All four routes appear in :mod:`meho_backplane.main`'s app + OpenAPI."""
     from meho_backplane.main import app
 
+    openapi = app.openapi()
+    paths = openapi["paths"]
+
     expected_paths = {
         "/api/v1/memory",
         "/api/v1/memory/{scope}/{slug}",
     }
-    actual_paths = {getattr(r, "path", None) for r in app.routes}
-    missing = expected_paths - actual_paths
+    missing = expected_paths - paths.keys()
     assert not missing, f"missing routes: {missing}"
 
-    openapi = app.openapi()
-    paths = openapi["paths"]
     assert "post" in paths["/api/v1/memory"]
     assert "get" in paths["/api/v1/memory"]
     assert "get" in paths["/api/v1/memory/{scope}/{slug}"]
@@ -1245,7 +1247,9 @@ async def test_forget_writes_audit_row_with_existed_flag(
 
 
 @pytest.mark.asyncio
-async def test_remember_substrate_exception_still_writes_memory_remember_audit_row() -> None:
+async def test_remember_substrate_exception_still_writes_memory_remember_audit_row(
+    log_buffer: io.StringIO,
+) -> None:
     """Substrate raising mid-remember still produces ``op_id="memory.remember"`` audit row.
 
     Regression guarantee for the bind-ordering rule: the audit
@@ -1256,26 +1260,29 @@ async def test_remember_substrate_exception_still_writes_memory_remember_audit_r
     that would bucket as ``op_class="other"`` and defeat the
     broadcast-redaction contract for write ops.
 
-    Uses a TestClient constructed with
-    ``raise_server_exceptions=False`` so the re-raised handler
-    exception surfaces as the 500 an operator would actually see in
-    production, rather than failing the test with the propagated
-    exception. Mirrors the kb-delete regression in test_api_v1_kb.py.
+    Driven via ``httpx.AsyncClient`` with
+    ``ASGITransport(raise_app_exceptions=False)`` so the re-raised
+    handler exception surfaces as the 500 an operator would actually
+    see in production, rather than leaking through TestClient's portal
+    teardown.
     """
     tenant_a = uuid.uuid4()
     key, token = _operator_token(tenant_id=tenant_a)
     fake_remember = AsyncMock(side_effect=RuntimeError("simulated substrate failure"))
-    raising_client = TestClient(_build_app(), raise_server_exceptions=False)
-    with (
-        respx.mock as mock_router,
-        patch("meho_backplane.api.v1.memory.MemoryService.remember", fake_remember),
-    ):
-        _mock_discovery_and_jwks(mock_router, _public_jwks(key))
-        response = raising_client.post(
-            "/api/v1/memory",
-            json={"scope": "user", "body": "x", "slug": "boom"},
-            headers=_authed(token),
-        )
+    transport = ASGITransport(app=_build_app(), raise_app_exceptions=False)
+    async with httpx.AsyncClient(
+        transport=transport, base_url="https://testserver"
+    ) as raising_client:
+        with (
+            respx.mock as mock_router,
+            patch("meho_backplane.api.v1.memory.MemoryService.remember", fake_remember),
+        ):
+            _mock_discovery_and_jwks(mock_router, _public_jwks(key))
+            response = await raising_client.post(
+                "/api/v1/memory",
+                json={"scope": "user", "body": "x", "slug": "boom"},
+                headers=_authed(token),
+            )
 
     assert response.status_code == 500
 

--- a/backend/tests/test_api_v1_memory.py
+++ b/backend/tests/test_api_v1_memory.py
@@ -1246,10 +1246,12 @@ async def test_forget_writes_audit_row_with_existed_flag(
     assert payload["existed"] is True
 
 
+# usefixtures(log_buffer): requested for its side effect only — it routes
+# structlog to a buffer so the 0.137 re-raised handler exception doesn't
+# surface as a teardown ERROR. ASGITransport alone does not suppress it.
+@pytest.mark.usefixtures("log_buffer")
 @pytest.mark.asyncio
-async def test_remember_substrate_exception_still_writes_memory_remember_audit_row(
-    log_buffer: io.StringIO,
-) -> None:
+async def test_remember_substrate_exception_still_writes_memory_remember_audit_row() -> None:
     """Substrate raising mid-remember still produces ``op_id="memory.remember"`` audit row.
 
     Regression guarantee for the bind-ordering rule: the audit

--- a/backend/tests/test_api_v1_memory_promote.py
+++ b/backend/tests/test_api_v1_memory_promote.py
@@ -34,18 +34,22 @@ contextvar binding all run for real.
 
 from __future__ import annotations
 
+import io
 import json
+import logging
 import uuid
 from collections.abc import Iterator
 from typing import Any
 from unittest.mock import AsyncMock, patch
 from uuid import UUID
 
+import httpx
 import pytest
 import respx
 import structlog
 from fastapi import FastAPI
 from fastapi.testclient import TestClient
+from httpx import ASGITransport
 from sqlalchemy import select
 
 from meho_backplane.api.v1.memory import router as memory_router
@@ -113,6 +117,35 @@ def _fake_embedding_service() -> Iterator[None]:
         return_value=fake,
     ):
         yield
+
+
+# ---------------------------------------------------------------------------
+# Structlog capture
+# ---------------------------------------------------------------------------
+
+
+def _configure_capture(buf: io.StringIO) -> None:
+    structlog.reset_defaults()
+    structlog.configure(
+        processors=[
+            structlog.contextvars.merge_contextvars,
+            structlog.processors.add_log_level,
+            structlog.processors.TimeStamper(fmt="iso", utc=True),
+            structlog.processors.dict_tracebacks,
+            structlog.processors.JSONRenderer(),
+        ],
+        wrapper_class=structlog.make_filtering_bound_logger(logging.INFO),
+        logger_factory=structlog.PrintLoggerFactory(file=buf),
+        cache_logger_on_first_use=False,
+    )
+
+
+@pytest.fixture
+def log_buffer() -> Iterator[io.StringIO]:
+    buf = io.StringIO()
+    _configure_capture(buf)
+    yield buf
+    structlog.reset_defaults()
 
 
 # ---------------------------------------------------------------------------
@@ -253,10 +286,8 @@ def test_promote_route_mounted_on_main_app() -> None:
     """The promote route appears on the main app + OpenAPI document."""
     from meho_backplane.main import app
 
-    actual_paths = {getattr(r, "path", None) for r in app.routes}
-    assert "/api/v1/memory/{scope}/{slug}/promote" in actual_paths
-
     openapi = app.openapi()
+    assert "/api/v1/memory/{scope}/{slug}/promote" in openapi["paths"]
     assert "post" in openapi["paths"]["/api/v1/memory/{scope}/{slug}/promote"]
 
 
@@ -632,6 +663,7 @@ async def test_promote_audit_row_carries_promotion_target_scope_payload_key(
 @pytest.mark.asyncio
 async def test_promote_failed_target_insert_leaves_source_intact(
     client: TestClient,
+    log_buffer: io.StringIO,
 ) -> None:
     """AC: failed target insert leaves source intact (transaction boundary).
 
@@ -645,22 +677,25 @@ async def test_promote_failed_target_insert_leaves_source_intact(
     key, token = _operator_token(tenant_id=tenant_a, sub=alice_sub)
     await _insert_user_memory(tenant_id=tenant_a, user_sub=alice_sub)
 
-    raising_client = TestClient(_build_app(), raise_server_exceptions=False)
-    with (
-        respx.mock as mock_router,
-        patch(
-            "meho_backplane.memory.service.index_document",
-            side_effect=RuntimeError("simulated insert failure"),
-        ),
-    ):
-        _mock_discovery_and_jwks(mock_router, _public_jwks(key))
-        response = raising_client.post(
-            "/api/v1/memory/user/wine-preference/promote",
-            json={"to": "user-tenant", "move": True},
-            headers=_authed(token),
-        )
+    transport = ASGITransport(app=_build_app(), raise_app_exceptions=False)
+    async with httpx.AsyncClient(
+        transport=transport, base_url="https://testserver"
+    ) as raising_client:
+        with (
+            respx.mock as mock_router,
+            patch(
+                "meho_backplane.memory.service.index_document",
+                side_effect=RuntimeError("simulated insert failure"),
+            ),
+        ):
+            _mock_discovery_and_jwks(mock_router, _public_jwks(key))
+            response = await raising_client.post(
+                "/api/v1/memory/user/wine-preference/promote",
+                json={"to": "user-tenant", "move": True},
+                headers=_authed(token),
+            )
 
-    # Handler exception → 500 with raise_server_exceptions=False.
+    # Handler exception → 500 with ASGITransport(raise_app_exceptions=False).
     assert response.status_code == 500
     # Source row still there: the failed transaction rolled back the
     # in-flight delete (the delete and insert share the same session).

--- a/backend/tests/test_api_v1_memory_promote.py
+++ b/backend/tests/test_api_v1_memory_promote.py
@@ -660,10 +660,13 @@ async def test_promote_audit_row_carries_promotion_target_scope_payload_key(
 # ---------------------------------------------------------------------------
 
 
+# usefixtures(log_buffer): requested for its side effect only — it routes
+# structlog to a buffer so the 0.137 re-raised handler exception doesn't
+# surface as a teardown ERROR. ASGITransport alone does not suppress it.
+@pytest.mark.usefixtures("log_buffer")
 @pytest.mark.asyncio
 async def test_promote_failed_target_insert_leaves_source_intact(
     client: TestClient,
-    log_buffer: io.StringIO,
 ) -> None:
     """AC: failed target insert leaves source intact (transaction boundary).
 

--- a/backend/tests/test_api_v1_topology.py
+++ b/backend/tests/test_api_v1_topology.py
@@ -157,16 +157,16 @@ def test_all_topology_routes_mounted_on_main_app() -> None:
     """The four topology routes appear on the prod app + OpenAPI doc."""
     from meho_backplane.main import app
 
+    paths = app.openapi()["paths"]
+
     expected = {
         "/api/v1/topology/dependents/{name}",
         "/api/v1/topology/dependencies/{name}",
         "/api/v1/topology/path",
         "/api/v1/topology/refresh/{target_name}",
     }
-    actual = {getattr(r, "path", None) for r in app.routes}
-    assert not (expected - actual), f"missing: {expected - actual}"
+    assert not (expected - paths.keys()), f"missing: {expected - paths.keys()}"
 
-    paths = app.openapi()["paths"]
     assert "get" in paths["/api/v1/topology/dependents/{name}"]
     assert "get" in paths["/api/v1/topology/dependencies/{name}"]
     assert "get" in paths["/api/v1/topology/path"]
@@ -640,14 +640,14 @@ def test_curated_edge_routes_mounted_on_main_app() -> None:
     """The three curated-edge routes appear on the prod app + OpenAPI doc."""
     from meho_backplane.main import app
 
+    paths = app.openapi()["paths"]
+
     expected = {
         "/api/v1/topology/edges",
         "/api/v1/topology/edges/{edge_id}",
     }
-    actual = {getattr(r, "path", None) for r in app.routes}
-    assert not (expected - actual), f"missing: {expected - actual}"
+    assert not (expected - paths.keys()), f"missing: {expected - paths.keys()}"
 
-    paths = app.openapi()["paths"]
     assert "post" in paths["/api/v1/topology/edges"]
     assert "get" in paths["/api/v1/topology/edges"]
     assert "delete" in paths["/api/v1/topology/edges/{edge_id}"]

--- a/backend/tests/test_audit_middleware.py
+++ b/backend/tests/test_audit_middleware.py
@@ -36,16 +36,20 @@ and Vault's KV v2 read mirror the patterns established in
 
 from __future__ import annotations
 
+import io
+import logging
 import uuid
 from collections.abc import AsyncIterator, Iterator
 from pathlib import Path
 from typing import Any
 
+import httpx
 import pytest
 import respx
 import structlog
 from alembic import command
 from fastapi.testclient import TestClient
+from httpx import ASGITransport
 from sqlalchemy import select
 from sqlalchemy.ext.asyncio import AsyncEngine
 
@@ -167,6 +171,35 @@ async def isolated_audit_engine(
     finally:
         await dispose_engine()
         reset_engine_for_testing()
+
+
+# ---------------------------------------------------------------------------
+# Structlog capture
+# ---------------------------------------------------------------------------
+
+
+def _configure_capture(buf: io.StringIO) -> None:
+    structlog.reset_defaults()
+    structlog.configure(
+        processors=[
+            structlog.contextvars.merge_contextvars,
+            structlog.processors.add_log_level,
+            structlog.processors.TimeStamper(fmt="iso", utc=True),
+            structlog.processors.dict_tracebacks,
+            structlog.processors.JSONRenderer(),
+        ],
+        wrapper_class=structlog.make_filtering_bound_logger(logging.INFO),
+        logger_factory=structlog.PrintLoggerFactory(file=buf),
+        cache_logger_on_first_use=False,
+    )
+
+
+@pytest.fixture
+def log_buffer() -> Iterator[io.StringIO]:
+    buf = io.StringIO()
+    _configure_capture(buf)
+    yield buf
+    structlog.reset_defaults()
 
 
 # ---------------------------------------------------------------------------
@@ -435,6 +468,7 @@ async def test_audit_write_failure_converts_request_to_500(
 async def test_handler_exception_writes_audit_row_with_status_500(
     isolated_audit_engine: AsyncEngine,
     monkeypatch: pytest.MonkeyPatch,
+    log_buffer: io.StringIO,
 ) -> None:
     """A handler exception still produces an audit row with ``status=500``.
 
@@ -454,10 +488,11 @@ async def test_handler_exception_writes_audit_row_with_status_500(
     circuit before the audit write — the test would prove the wrong
     branch.
 
-    ``TestClient`` is constructed with ``raise_server_exceptions=False``
-    so the re-raised handler exception surfaces as the 500 the
-    operator would actually see in production rather than failing the
-    test with a propagated exception.
+    Driven via ``httpx.AsyncClient`` with
+    ``ASGITransport(raise_app_exceptions=False)`` so the re-raised
+    handler exception surfaces as the 500 the operator would actually
+    see in production rather than leaking through TestClient's portal
+    teardown.
     """
     import meho_backplane.api.v1.health as health_module
 
@@ -470,13 +505,14 @@ async def test_handler_exception_writes_audit_row_with_status_500(
 
     monkeypatch.setattr(health_module, "_probe_vault_federation", _raising_probe)
 
-    client = TestClient(app, raise_server_exceptions=False)
-    with respx.mock as mock_router:
-        _mock_discovery_and_jwks(mock_router, _public_jwks(key))
-        response = client.get(
-            "/api/v1/health",
-            headers={"Authorization": f"Bearer {token}"},
-        )
+    transport = ASGITransport(app=app, raise_app_exceptions=False)
+    async with httpx.AsyncClient(transport=transport, base_url="https://testserver") as client:
+        with respx.mock as mock_router:
+            _mock_discovery_and_jwks(mock_router, _public_jwks(key))
+            response = await client.get(
+                "/api/v1/health",
+                headers={"Authorization": f"Bearer {token}"},
+            )
 
     # Outer ServerErrorMiddleware converts the re-raised handler
     # exception into a 500 response with Starlette's generic body —

--- a/backend/tests/test_audit_middleware.py
+++ b/backend/tests/test_audit_middleware.py
@@ -464,11 +464,14 @@ async def test_audit_write_failure_converts_request_to_500(
     assert response.headers.get("x-request-id")
 
 
+# usefixtures(log_buffer): requested for its side effect only — it routes
+# structlog to a buffer so the 0.137 re-raised handler exception doesn't
+# surface as a teardown ERROR. ASGITransport alone does not suppress it.
+@pytest.mark.usefixtures("log_buffer")
 @pytest.mark.asyncio
 async def test_handler_exception_writes_audit_row_with_status_500(
     isolated_audit_engine: AsyncEngine,
     monkeypatch: pytest.MonkeyPatch,
-    log_buffer: io.StringIO,
 ) -> None:
     """A handler exception still produces an audit row with ``status=500``.
 

--- a/backend/tests/test_auth_config.py
+++ b/backend/tests/test_auth_config.py
@@ -178,15 +178,10 @@ def test_auth_config_route_is_registered_in_main_app() -> None:
     404s in production. The assertion is path-and-method-specific so a
     typo in the prefix would surface as a mismatch.
     """
-    matching_routes = [
-        route
-        for route in app.routes
-        # FastAPI's APIRoute exposes ``path`` + ``methods``; non-APIRoute
-        # entries (Mount, etc.) don't have ``methods`` so guard the
-        # attribute access defensively.
-        if getattr(route, "path", None) == "/api/v1/auth-config"
-        and "GET" in getattr(route, "methods", set())
-    ]
-    assert len(matching_routes) == 1, (
-        f"expected exactly one GET /api/v1/auth-config route, got {len(matching_routes)}"
+    openapi_paths = app.openapi()["paths"]
+    assert "/api/v1/auth-config" in openapi_paths, (
+        "expected /api/v1/auth-config in OpenAPI paths"
+    )
+    assert "get" in openapi_paths["/api/v1/auth-config"], (
+        "expected GET /api/v1/auth-config in OpenAPI paths"
     )

--- a/backend/tests/test_auth_config.py
+++ b/backend/tests/test_auth_config.py
@@ -179,9 +179,7 @@ def test_auth_config_route_is_registered_in_main_app() -> None:
     typo in the prefix would surface as a mismatch.
     """
     openapi_paths = app.openapi()["paths"]
-    assert "/api/v1/auth-config" in openapi_paths, (
-        "expected /api/v1/auth-config in OpenAPI paths"
-    )
+    assert "/api/v1/auth-config" in openapi_paths, "expected /api/v1/auth-config in OpenAPI paths"
     assert "get" in openapi_paths["/api/v1/auth-config"], (
         "expected GET /api/v1/auth-config in OpenAPI paths"
     )

--- a/backend/tests/test_operations_ingest_catalog.py
+++ b/backend/tests/test_operations_ingest_catalog.py
@@ -912,7 +912,7 @@ def _build_app() -> FastAPI:
 
 
 def test_catalog_route_is_mounted() -> None:
-    paths = {route.path for route in _build_app().routes}  # type: ignore[attr-defined]
+    paths = _build_app().openapi()["paths"]
     assert "/api/v1/connectors/catalog" in paths
 
 

--- a/backend/tests/test_runbook_runs_api.py
+++ b/backend/tests/test_runbook_runs_api.py
@@ -309,18 +309,18 @@ def test_all_five_routes_mounted_on_main_app() -> None:
     """All five routes appear in :mod:`meho_backplane.main`'s app + OpenAPI."""
     from meho_backplane.main import app
 
+    openapi = app.openapi()
+    paths = openapi["paths"]
+
     expected_paths = {
         "/api/v1/runbooks/runs",
         "/api/v1/runbooks/runs/{run_id}/next",
         "/api/v1/runbooks/runs/{run_id}/abort",
         "/api/v1/runbooks/runs/{run_id}/reassign",
     }
-    actual_paths = {getattr(r, "path", None) for r in app.routes}
-    missing = expected_paths - actual_paths
+    missing = expected_paths - paths.keys()
     assert not missing, f"missing routes: {missing}"
 
-    openapi = app.openapi()
-    paths = openapi["paths"]
     assert "post" in paths["/api/v1/runbooks/runs"]
     assert "get" in paths["/api/v1/runbooks/runs"]
     assert "post" in paths["/api/v1/runbooks/runs/{run_id}/next"]

--- a/backend/tests/test_runbook_templates_api.py
+++ b/backend/tests/test_runbook_templates_api.py
@@ -262,18 +262,18 @@ def test_all_six_routes_mounted_on_main_app() -> None:
     """All six routes appear in :mod:`meho_backplane.main`'s app + OpenAPI."""
     from meho_backplane.main import app
 
+    openapi = app.openapi()
+    paths = openapi["paths"]
+
     expected_paths = {
         "/api/v1/runbooks/templates",
         "/api/v1/runbooks/templates/{slug}",
         "/api/v1/runbooks/templates/{slug}/publish",
         "/api/v1/runbooks/templates/{slug}/deprecate",
     }
-    actual_paths = {getattr(r, "path", None) for r in app.routes}
-    missing = expected_paths - actual_paths
+    missing = expected_paths - paths.keys()
     assert not missing, f"missing routes: {missing}"
 
-    openapi = app.openapi()
-    paths = openapi["paths"]
     assert "post" in paths["/api/v1/runbooks/templates"]
     assert "get" in paths["/api/v1/runbooks/templates"]
     assert "get" in paths["/api/v1/runbooks/templates/{slug}"]

--- a/backend/tests/test_ui_broadcast_overrides.py
+++ b/backend/tests/test_ui_broadcast_overrides.py
@@ -123,6 +123,15 @@ def _bff_env(monkeypatch: pytest.MonkeyPatch) -> Iterator[None]:
     reset_engine_for_testing()
 
 
+def _iter_routes(routes):  # type: ignore[no-untyped-def]
+    """Recursively yield leaf routes from the FastAPI 0.137+ route tree."""
+    for route in routes:
+        if hasattr(route, "routes"):
+            yield from _iter_routes(route.routes)
+        else:
+            yield route
+
+
 def _build_app() -> FastAPI:
     """Construct a minimal FastAPI app wired for the broadcast UI tests."""
     app = FastAPI()
@@ -483,9 +492,11 @@ def test_overrides_route_resolves_before_event() -> None:
     # (path, method) to disambiguate. The GET must bind the overrides
     # list handler (registered before the event router), never the event
     # drawer's ``/ui/broadcast/event/{audit_id}``.
+    # Use _iter_routes to walk the 0.137+ route tree (include_router now
+    # produces nested _IncludedRouter objects, not a flat list).
     routes = {
         (getattr(route, "path", ""), method): getattr(route, "name", None)
-        for route in app.routes
+        for route in _iter_routes(app.routes)
         for method in (getattr(route, "methods", None) or set())
         if getattr(route, "path", "").startswith("/ui/broadcast/overrides")
     }

--- a/backend/tests/test_ui_broadcast_overrides.py
+++ b/backend/tests/test_ui_broadcast_overrides.py
@@ -84,6 +84,7 @@ from tests._oidc_jwt_helpers import (
 from tests._oidc_jwt_helpers import (
     public_jwks as _public_jwks,
 )
+from tests._route_tree_helpers import iter_routes
 
 _BACKPLANE_URL = "https://meho.test"
 _TENANT_A = uuid.UUID("11111111-1111-1111-1111-111111111111")
@@ -121,15 +122,6 @@ def _bff_env(monkeypatch: pytest.MonkeyPatch) -> Iterator[None]:
     clear_discovery_cache()
     clear_jwks_cache()
     reset_engine_for_testing()
-
-
-def _iter_routes(routes):  # type: ignore[no-untyped-def]
-    """Recursively yield leaf routes from the FastAPI 0.137+ route tree."""
-    for route in routes:
-        if hasattr(route, "routes"):
-            yield from _iter_routes(route.routes)
-        else:
-            yield route
 
 
 def _build_app() -> FastAPI:
@@ -492,11 +484,11 @@ def test_overrides_route_resolves_before_event() -> None:
     # (path, method) to disambiguate. The GET must bind the overrides
     # list handler (registered before the event router), never the event
     # drawer's ``/ui/broadcast/event/{audit_id}``.
-    # Use _iter_routes to walk the 0.137+ route tree (include_router now
+    # Use iter_routes to walk the 0.137+ route tree (include_router now
     # produces nested _IncludedRouter objects, not a flat list).
     routes = {
         (getattr(route, "path", ""), method): getattr(route, "name", None)
-        for route in _iter_routes(app.routes)
+        for route in iter_routes(app.routes)
         for method in (getattr(route, "methods", None) or set())
         if getattr(route, "path", "").startswith("/ui/broadcast/overrides")
     }
@@ -509,17 +501,11 @@ def test_overrides_route_resolves_before_event() -> None:
 
     # The overrides router is included before the event router in
     # build_router(), so a literal /ui/broadcast/overrides resolves to the
-    # overrides list handler, not the event handler.
-    overrides_idx = next(
-        i
-        for i, route in enumerate(app.routes)
-        if getattr(route, "path", "") == "/ui/broadcast/overrides"
-    )
-    event_idx = next(
-        i
-        for i, route in enumerate(app.routes)
-        if getattr(route, "path", "") == "/ui/broadcast/event/{audit_id}"
-    )
+    # overrides list handler, not the event handler. iter_routes flattens the
+    # 0.137+ tree in registration order, preserving first-match-wins order.
+    ordered_paths = [getattr(route, "path", "") for route in iter_routes(app.routes)]
+    overrides_idx = ordered_paths.index("/ui/broadcast/overrides")
+    event_idx = ordered_paths.index("/ui/broadcast/event/{audit_id}")
     assert overrides_idx < event_idx
 
     # And it actually renders the overrides pane (not the event drawer).

--- a/backend/tests/test_ui_connectors_registry_ingest.py
+++ b/backend/tests/test_ui_connectors_registry_ingest.py
@@ -98,6 +98,7 @@ from tests._oidc_jwt_helpers import make_rsa_keypair as _make_rsa_keypair
 from tests._oidc_jwt_helpers import mint_token as _mint_token
 from tests._oidc_jwt_helpers import mock_discovery_and_jwks as _mock_discovery_and_jwks
 from tests._oidc_jwt_helpers import public_jwks as _public_jwks
+from tests._route_tree_helpers import iter_routes
 
 _BACKPLANE_URL = "https://meho.test"
 
@@ -293,9 +294,12 @@ def _job_count() -> int:
 def test_ingest_routes_registered_before_detail_and_param() -> None:
     """First-match-wins: the literal ingest routes precede the param routes."""
     router = build_connectors_router()
+    # 0.137+ nests included routers; iter_routes flattens the tree in
+    # registration order so the first-match-wins ordering check still holds.
+    leaves = list(iter_routes(router.routes))
 
     def _index(path: str, method: str) -> int:
-        for i, route in enumerate(router.routes):
+        for i, route in enumerate(leaves):
             if route.path == path and method in (route.methods or set()):
                 return i
         raise AssertionError(f"route not found: {method} {path}")

--- a/backend/tests/test_ui_connectors_registry_list.py
+++ b/backend/tests/test_ui_connectors_registry_list.py
@@ -88,6 +88,7 @@ from tests._oidc_jwt_helpers import make_rsa_keypair as _make_rsa_keypair
 from tests._oidc_jwt_helpers import mint_token as _mint_token
 from tests._oidc_jwt_helpers import mock_discovery_and_jwks as _mock_discovery_and_jwks
 from tests._oidc_jwt_helpers import public_jwks as _public_jwks
+from tests._route_tree_helpers import iter_routes
 
 _BACKPLANE_URL = "https://meho.test"
 
@@ -402,13 +403,16 @@ def test_registry_list_status_filter_all_sentinel_renders() -> None:
 def test_registry_route_registered_before_detail() -> None:
     """First-match-wins: ``/ui/connectors/registry`` precedes ``/ui/connectors/{name}``."""
     router = build_connectors_router()
-    paths = [route.path for route in router.routes]
+    # 0.137+ nests included routers; iter_routes flattens the tree in
+    # registration order so the first-match-wins ordering check still holds.
+    leaves = list(iter_routes(router.routes))
+    paths = [route.path for route in leaves]
 
     registry_index = paths.index("/ui/connectors/registry")
     # The detail GET route -- distinguished from the PATCH on the same path.
     detail_index = next(
         i
-        for i, route in enumerate(router.routes)
+        for i, route in enumerate(leaves)
         if route.path == "/ui/connectors/{name}" and "GET" in (route.methods or set())
     )
     assert registry_index < detail_index, (

--- a/backend/tests/test_ui_connectors_registry_review.py
+++ b/backend/tests/test_ui_connectors_registry_review.py
@@ -86,6 +86,7 @@ from tests._oidc_jwt_helpers import make_rsa_keypair as _make_rsa_keypair
 from tests._oidc_jwt_helpers import mint_token as _mint_token
 from tests._oidc_jwt_helpers import mock_discovery_and_jwks as _mock_discovery_and_jwks
 from tests._oidc_jwt_helpers import public_jwks as _public_jwks
+from tests._route_tree_helpers import iter_routes
 
 _BACKPLANE_URL = "https://meho.test"
 
@@ -756,11 +757,14 @@ def test_review_unknown_connector_panel() -> None:
 def test_review_routes_registered_before_detail() -> None:
     """First-match-wins: the review + op routes precede ``/ui/connectors/{name}``."""
     router = build_connectors_router()
-    paths = [route.path for route in router.routes]
+    # 0.137+ nests included routers; iter_routes flattens the tree in
+    # registration order so the first-match-wins ordering check still holds.
+    leaves = list(iter_routes(router.routes))
+    paths = [route.path for route in leaves]
 
     detail_index = next(
         i
-        for i, route in enumerate(router.routes)
+        for i, route in enumerate(leaves)
         if route.path == "/ui/connectors/{name}" and "GET" in (route.methods or set())
     )
     review_index = paths.index("/ui/connectors/registry/{connector_id}/review")
@@ -782,7 +786,7 @@ def test_op_route_uses_path_converter() -> None:
     and ``group_key`` are slash-free plain string params.
     """
     router = build_connectors_router()
-    paths = [route.path for route in router.routes]
+    paths = [route.path for route in iter_routes(router.routes)]
     # The op route carries the :path converter on op_id only.
     assert "/ui/connectors/registry/{connector_id}/operations/{op_id:path}" in paths
     # The drawer + group-body routes use plain params (no :path).

--- a/backend/tests/test_ui_keycloak.py
+++ b/backend/tests/test_ui_keycloak.py
@@ -81,6 +81,7 @@ from tests._oidc_jwt_helpers import make_rsa_keypair as _make_rsa_keypair
 from tests._oidc_jwt_helpers import mint_token as _mint_token
 from tests._oidc_jwt_helpers import mock_discovery_and_jwks as _mock_discovery_and_jwks
 from tests._oidc_jwt_helpers import public_jwks as _public_jwks
+from tests._route_tree_helpers import iter_routes
 
 _BACKPLANE_URL = "https://meho.test"
 _TENANT_A = uuid.UUID("11111111-1111-1111-1111-111111111111")
@@ -599,7 +600,9 @@ def test_keycloak_ui_client_detail_route_resolves_to_detail_handler() -> None:
     ``/ui/keycloak/clients/`` prefix.
     """
     router = build_keycloak_router()
-    paths = [getattr(route, "path", None) for route in router.routes]
+    # 0.137+ nests included routers; iter_routes flattens the tree in
+    # registration order so the first-match-wins ordering check still holds.
+    paths = [getattr(route, "path", None) for route in iter_routes(router.routes)]
     assert "/ui/keycloak/clients/{client_uuid}" in paths
     assert "/ui/keycloak" in paths
     # The client-detail (parametrised) route is registered before the bare
@@ -1001,7 +1004,9 @@ def test_keycloak_ui_user_routes_literal_before_param() -> None:
     First-match-wins: ``create`` must never be captured as a ``{user_uuid}``.
     """
     router = build_keycloak_router()
-    paths = [getattr(route, "path", None) for route in router.routes]
+    # 0.137+ nests included routers; iter_routes flattens the tree in
+    # registration order so the first-match-wins ordering check still holds.
+    paths = [getattr(route, "path", None) for route in iter_routes(router.routes)]
     assert "/ui/keycloak/users" in paths
     assert "/ui/keycloak/users/create" in paths
     create_idx = paths.index("/ui/keycloak/users/create")

--- a/backend/tests/test_ui_topology_annotate.py
+++ b/backend/tests/test_ui_topology_annotate.py
@@ -344,13 +344,11 @@ def test_topology_ui_annotate_route_registers_before_node_param() -> None:
     # route binding (the admin gate fires inside the annotate handler, never
     # the node-detail one).
     app = _build_app()
-    matched = [
-        route
-        for route in app.routes
-        if getattr(route, "path", None) == "/ui/topology/edges/annotate"
-    ]
-    assert matched, "annotate route not registered on the app"
-    assert "GET" in matched[0].methods  # type: ignore[attr-defined]
+    openapi_paths = app.openapi()["paths"]
+    assert "/ui/topology/edges/annotate" in openapi_paths, (
+        "annotate route not registered on the app"
+    )
+    assert "get" in openapi_paths["/ui/topology/edges/annotate"]
 
 
 # ---------------------------------------------------------------------------

--- a/backend/tests/test_ui_topology_annotate.py
+++ b/backend/tests/test_ui_topology_annotate.py
@@ -83,6 +83,7 @@ from tests._oidc_jwt_helpers import (
 from tests._oidc_jwt_helpers import (
     public_jwks as _public_jwks,
 )
+from tests._route_tree_helpers import iter_routes
 
 # ---------------------------------------------------------------------------
 # Fixtures + helpers
@@ -334,7 +335,9 @@ def test_topology_ui_annotate_route_registers_before_node_param() -> None:
     convention ``topology/__init__.py`` documents.
     """
     router = build_topology_router()
-    paths = [route.path for route in router.routes if hasattr(route, "methods")]
+    # 0.137+ nests included routers; iter_routes flattens the tree in
+    # registration order so the first-match-wins ordering check still holds.
+    paths = [route.path for route in iter_routes(router.routes) if hasattr(route, "methods")]
     annotate_idx = paths.index("/ui/topology/edges/annotate")
     node_idx = paths.index("/ui/topology/node/{node_id}")
     assert annotate_idx < node_idx, paths
@@ -344,11 +347,13 @@ def test_topology_ui_annotate_route_registers_before_node_param() -> None:
     # route binding (the admin gate fires inside the annotate handler, never
     # the node-detail one).
     app = _build_app()
-    openapi_paths = app.openapi()["paths"]
-    assert "/ui/topology/edges/annotate" in openapi_paths, (
-        "annotate route not registered on the app"
-    )
-    assert "get" in openapi_paths["/ui/topology/edges/annotate"]
+    matched = [
+        route
+        for route in iter_routes(app.routes)
+        if getattr(route, "path", None) == "/ui/topology/edges/annotate"
+    ]
+    assert matched, "annotate route not registered on the app"
+    assert "GET" in matched[0].methods  # type: ignore[attr-defined]
 
 
 # ---------------------------------------------------------------------------

--- a/backend/tests/test_ui_topology_bulk_refresh.py
+++ b/backend/tests/test_ui_topology_bulk_refresh.py
@@ -90,6 +90,7 @@ from tests._oidc_jwt_helpers import (
 from tests._oidc_jwt_helpers import (
     public_jwks as _public_jwks,
 )
+from tests._route_tree_helpers import iter_routes
 
 # ---------------------------------------------------------------------------
 # Fixtures + helpers
@@ -369,7 +370,9 @@ def test_topology_ui_batch_routes_register_before_node_param() -> None:
     route so the first-match-wins lookup never binds them as a node id.
     """
     router = build_topology_router()
-    paths = [route.path for route in router.routes if hasattr(route, "methods")]
+    # 0.137+ nests included routers; iter_routes flattens the tree in
+    # registration order so the first-match-wins ordering check still holds.
+    paths = [route.path for route in iter_routes(router.routes) if hasattr(route, "methods")]
     bulk_idx = paths.index("/ui/topology/edges/bulk")
     refresh_idx = paths.index("/ui/topology/refresh/{target_name}")
     node_idx = paths.index("/ui/topology/node/{node_id}")
@@ -379,16 +382,14 @@ def test_topology_ui_batch_routes_register_before_node_param() -> None:
     # Resolve through a real app: the routes must be registered with their
     # expected methods (the role gate fires inside the handlers, not here).
     app = _build_app()
-    openapi_paths = app.openapi()["paths"]
-    assert "get" in openapi_paths.get("/ui/topology/edges/bulk", {}), (
-        "GET /ui/topology/edges/bulk not registered"
-    )
-    assert "post" in openapi_paths.get("/ui/topology/edges/bulk", {}), (
-        "POST /ui/topology/edges/bulk not registered"
-    )
-    assert "post" in openapi_paths.get("/ui/topology/refresh/{target_name}", {}), (
-        "POST /ui/topology/refresh/{target_name} not registered"
-    )
+    by_path: dict[str, set[str]] = {}
+    for route in iter_routes(app.routes):
+        path = getattr(route, "path", None)
+        if path in ("/ui/topology/edges/bulk", "/ui/topology/refresh/{target_name}"):
+            by_path.setdefault(path, set()).update(route.methods)  # type: ignore[attr-defined]
+    assert "GET" in by_path["/ui/topology/edges/bulk"]
+    assert "POST" in by_path["/ui/topology/edges/bulk"]
+    assert "POST" in by_path["/ui/topology/refresh/{target_name}"]
 
 
 # ---------------------------------------------------------------------------

--- a/backend/tests/test_ui_topology_bulk_refresh.py
+++ b/backend/tests/test_ui_topology_bulk_refresh.py
@@ -379,14 +379,16 @@ def test_topology_ui_batch_routes_register_before_node_param() -> None:
     # Resolve through a real app: the routes must be registered with their
     # expected methods (the role gate fires inside the handlers, not here).
     app = _build_app()
-    by_path: dict[str, set[str]] = {}
-    for route in app.routes:
-        path = getattr(route, "path", None)
-        if path in ("/ui/topology/edges/bulk", "/ui/topology/refresh/{target_name}"):
-            by_path.setdefault(path, set()).update(route.methods)  # type: ignore[attr-defined]
-    assert "GET" in by_path["/ui/topology/edges/bulk"]
-    assert "POST" in by_path["/ui/topology/edges/bulk"]
-    assert "POST" in by_path["/ui/topology/refresh/{target_name}"]
+    openapi_paths = app.openapi()["paths"]
+    assert "get" in openapi_paths.get("/ui/topology/edges/bulk", {}), (
+        "GET /ui/topology/edges/bulk not registered"
+    )
+    assert "post" in openapi_paths.get("/ui/topology/edges/bulk", {}), (
+        "POST /ui/topology/edges/bulk not registered"
+    )
+    assert "post" in openapi_paths.get("/ui/topology/refresh/{target_name}", {}), (
+        "POST /ui/topology/refresh/{target_name} not registered"
+    )
 
 
 # ---------------------------------------------------------------------------

--- a/backend/tests/test_ui_topology_temporal.py
+++ b/backend/tests/test_ui_topology_temporal.py
@@ -324,14 +324,14 @@ def test_topology_ui_temporal_routes_register_before_node_param() -> None:
     # Resolve through a real app: each temporal route binds GET and is its own
     # handler, not the node-detail param route.
     app = _build_app()
+    openapi_paths = app.openapi()["paths"]
     for literal in (
         "/ui/topology/timeline",
         "/ui/topology/diff",
         "/ui/topology/history/{name}",
     ):
-        matched = [route for route in app.routes if getattr(route, "path", None) == literal]
-        assert matched, f"{literal} not registered on the app"
-        assert "GET" in matched[0].methods  # type: ignore[attr-defined]
+        assert literal in openapi_paths, f"{literal} not registered on the app"
+        assert "get" in openapi_paths[literal], f"GET not registered for {literal}"
 
 
 # ---------------------------------------------------------------------------

--- a/backend/tests/test_ui_topology_temporal.py
+++ b/backend/tests/test_ui_topology_temporal.py
@@ -86,6 +86,7 @@ from tests._oidc_jwt_helpers import (
 from tests._oidc_jwt_helpers import (
     public_jwks as _public_jwks,
 )
+from tests._route_tree_helpers import iter_routes
 
 # ---------------------------------------------------------------------------
 # Fixtures + helpers
@@ -311,7 +312,9 @@ def test_topology_ui_temporal_routes_register_before_node_param() -> None:
     convention ``topology/__init__.py`` documents.
     """
     router = build_topology_router()
-    paths = [route.path for route in router.routes if hasattr(route, "methods")]
+    # 0.137+ nests included routers; iter_routes flattens the tree in
+    # registration order so the first-match-wins ordering check still holds.
+    paths = [route.path for route in iter_routes(router.routes) if hasattr(route, "methods")]
     node_idx = paths.index("/ui/topology/node/{node_id}")
     for literal in (
         "/ui/topology/timeline",
@@ -324,14 +327,16 @@ def test_topology_ui_temporal_routes_register_before_node_param() -> None:
     # Resolve through a real app: each temporal route binds GET and is its own
     # handler, not the node-detail param route.
     app = _build_app()
-    openapi_paths = app.openapi()["paths"]
+    by_path = {
+        route.path: route.methods for route in iter_routes(app.routes) if hasattr(route, "methods")
+    }
     for literal in (
         "/ui/topology/timeline",
         "/ui/topology/diff",
         "/ui/topology/history/{name}",
     ):
-        assert literal in openapi_paths, f"{literal} not registered on the app"
-        assert "get" in openapi_paths[literal], f"GET not registered for {literal}"
+        assert literal in by_path, f"{literal} not registered on the app"
+        assert "GET" in by_path[literal], f"GET not registered for {literal}"
 
 
 # ---------------------------------------------------------------------------

--- a/backend/uv.lock
+++ b/backend/uv.lock
@@ -860,7 +860,7 @@ wheels = [
 
 [[package]]
 name = "fastapi"
-version = "0.136.3"
+version = "0.137.2"
 source = { registry = "https://pypi.org/simple" }
 dependencies = [
     { name = "annotated-doc" },
@@ -869,9 +869,9 @@ dependencies = [
     { name = "typing-extensions" },
     { name = "typing-inspection" },
 ]
-sdist = { url = "https://files.pythonhosted.org/packages/81/2d/ff8d91d7b564d464629a0fd50a4489c97fcb836ac230bf3a7269232a9b1f/fastapi-0.136.3.tar.gz", hash = "sha256:e487fae93ad408e6f47641ee4dfe389864fd7bec92e547ea8498fc13f43e83ab", size = 396410, upload-time = "2026-05-23T18:53:15.192Z" }
+sdist = { url = "https://files.pythonhosted.org/packages/e2/29/cc5819dc24d3daa80cdaa1aec023bf8652a70dd7fd1c96b0b225c99a7690/fastapi-0.137.2.tar.gz", hash = "sha256:b9d893bebc97dcfbdcb1917e88a292d062844ea19445a5fa4f7eb28c4baea9e3", size = 410332, upload-time = "2026-06-18T06:58:24.434Z" }
 wheels = [
-    { url = "https://files.pythonhosted.org/packages/e0/82/45359b62a067409bd929ae8a56b8ed13e5a8c8a61194b3c236920999ab83/fastapi-0.136.3-py3-none-any.whl", hash = "sha256:3d2a69bdf04b7e9f3afa292c3bc7a98816bbfafa10bc9b45f3f3700d2f761620", size = 117481, upload-time = "2026-05-23T18:53:16.924Z" },
+    { url = "https://files.pythonhosted.org/packages/2f/ed/0c6b644e99fb5697d8bdcd36cdb47c52e77a63fc7a1514b1f03a6ecab955/fastapi-0.137.2-py3-none-any.whl", hash = "sha256:791d36261e916a98b25ac85ee591bc3db159394070f6d3d096d94fb378f60ce2", size = 122252, upload-time = "2026-06-18T06:58:26.074Z" },
 ]
 
 [[package]]
@@ -1685,7 +1685,7 @@ requires-dist = [
     { name = "croniter", specifier = ">=6.2.2" },
     { name = "defusedxml", specifier = ">=0.7.1" },
     { name = "duckdb", specifier = ">=1.5.4" },
-    { name = "fastapi", specifier = ">=0.136.3,<0.137" },
+    { name = "fastapi", specifier = ">=0.137.1,<0.138" },
     { name = "fastembed", specifier = ">=0.7,<1.0" },
     { name = "google-auth", specifier = ">=2.55.0" },
     { name = "httpx", specifier = ">=0.27" },


### PR DESCRIPTION
## Summary

**Part A — Route-tree tests**: Adapted all `*_mounted_on_main_app` tests (memory, kb, topology, connectors-ingest, runbook runs/templates, memory-promote) to assert via `app.openapi()["paths"]` instead of iterating `app.routes`. FastAPI 0.137 builds a router *tree* internally; the flat `app.routes` list no longer contains the nested `APIRouter` routes after `include_router`, so the old assertions yielded false-negatives (missing routes were not caught).

**Part B — Audit exception tests**: Rewrote `test_handler_exception_writes_audit_row_with_status_500` and related tests in `test_audit_middleware.py` to use `httpx.AsyncClient` with `ASGITransport` instead of `TestClient(app, raise_server_exceptions=False)`. FastAPI 0.137 changed portal teardown behaviour so that `raise_server_exceptions=False` leaks the re-raised exception out of the sync `TestClient` wrapper, causing the test to error rather than receive the 500 response.

**Part C — Unpin fastapi**: Bumped the fastapi dependency from `>=0.136.3,<0.137` to `>=0.137.1,<0.138` and updated `uv.lock` accordingly. The previous workaround comment (frozen at `<0.137` to avoid the router-tree regression) is removed.

## Verification

- `grep -rn "for r in app.routes" backend/tests/` → no matches
- `grep -rn "raise_server_exceptions=False" backend/tests/` → only pre-existing occurrences in unrelated test files (test_observability.py, test_ui_audit.py, test_targets_fingerprint.py) that were not part of this issue
- `uv run pytest tests/test_api_v1_connectors_ingest.py tests/test_api_v1_kb.py tests/test_api_v1_memory.py tests/test_api_v1_memory_promote.py tests/test_api_v1_topology.py tests/test_audit_middleware.py tests/test_runbook_runs_api.py tests/test_runbook_templates_api.py` → **322 passed, 0 failed**
- CLI OpenAPI snapshot regenerated → no diff (API surface unchanged)

Closes #1819

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Chores**
  * Updated the FastAPI dependency pin to `0.137.1` (range adjusted).

* **Tests**
  * Enhanced test infrastructure to correctly traverse nested router trees in FastAPI `0.137+` for route-order assertions.
  * Updated route-mounting and registration checks to validate expected endpoints via the generated OpenAPI schema rather than internal route tables.
  * Improved async test execution (using ASGI-backed requests) for more reliable exception behavior.
  * Added structured log capture in relevant regression tests to avoid teardown errors.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->