### PR TITLE
feat(ui): global htmx 401 session-expiry safety net

### DIFF
--- a/backend/src/meho_backplane/ui/static/src/app/session-expiry.js
+++ b/backend/src/meho_backplane/ui/static/src/app/session-expiry.js
@@ -1,0 +1,125 @@
+// SPDX-License-Identifier: Apache-2.0
+// Copyright (c) 2026 evoila Group
+//
+// App-shell session-expiry safety net (#122).
+//
+// When a ``/ui/*`` htmx request (``hx-get`` / ``hx-post``) returns ``401``
+// mid-session, htmx 2.0.9 silently swallows it: the default
+// ``htmx.config.responseHandling`` classifies ``[45]..`` as
+// ``{swap: false, error: true}``, so the target container stays empty and
+// the only signal is a ``htmx:responseError`` event no global listener was
+// catching. The operator is left with a dead control and no clue their
+// session expired -- the headline session-expiry symptom #1694 fixed
+// server-side for full-page navigations but which still slips through on
+// background htmx XHRs (those send ``Accept: */*``, not ``text/html``, so
+// the ``ui.auth.errors`` handler returns the JSON 401 body rather than the
+// HTML login redirect -- the browser sees a swallowed error, not a page).
+//
+// This module is the client-side last-resort recovery path: any ``401`` on
+// an htmx request surfaces a visible banner ("your session expired -- sign
+// in again") with a button to ``/ui/auth/login?return_to=<current path>``.
+// It is the safety net (Axis B); the server-side refresh seam (#1694, and
+// the sibling #121) reduces how *often* a 401 occurs (Axis A). Both land.
+//
+// Seam: ``htmx:beforeOnLoad``. htmx fires this for EVERY response (including
+// errors) before any swap, redirect-header handling, or ``responseError``,
+// and ``preventDefault()`` on it aborts htmx's entire response processing
+// for that request (vendored htmx 2.0.9: ``Vn()`` returns early when the
+// event helper reports the default was prevented). We act ONLY on status
+// ``401`` -- every other status (a ``2xx`` swap, a ``422`` form-validation
+// re-render, a ``403`` CSRF error a form's ``hx-on::response-error`` handles)
+// flows through untouched, so legitimate non-auth responses are never
+// hijacked. Chosen over ``htmx.config.responseHandling`` (which would
+// reclassify status codes app-wide and risk the finely-tuned 4xx swap
+// behaviour the connectors/agents/kb form modals depend on -- #875, forms.py
+// 422 re-render) precisely because it is surgical: one status, one action.
+//
+// Registered via a plain ``htmx:beforeOnLoad`` listener on ``document.body``
+// (htmx events bubble to the body -- the same delegation pattern
+// ``modal-dialogs.js`` and ``kb/index.html`` use for ``htmx:afterSwap``), so
+// every ``hx-*`` element on every console page inherits it with no per-page
+// wiring. Loaded once from ``_head_assets.html`` after ``htmx.min.js`` so the
+// listener is registered before the first htmx request can resolve. Plain
+// first-party JS (no Alpine, no inline script) to preserve the chassis
+// "zero inline script" CSP posture, mirroring ``theme.js`` / ``modal-dialogs.js``.
+//
+// Idempotent banner: the recovery banner is created once and reused -- a
+// burst of failing background polls (the approvals badge, an SSE reconnect)
+// all hitting 401 must not stack N banners. ``preventDefault()`` also stops
+// the dead swap, so the operator's current view stays intact behind the
+// banner rather than being blanked.
+
+(function () {
+  "use strict";
+
+  // Build ``/ui/auth/login?return_to=<encoded current path+query>``. The
+  // login route's ``_safe_return_to`` accepts only same-origin paths under
+  // ``/ui/`` and percent-decodes the value, so we send the path+search
+  // (never a full URL -- an absolute URL is rejected as an open-redirect
+  // guard) percent-encoded wholesale, matching the server handler's
+  // ``quote(full_path, safe="")`` contract in ``ui.auth.errors``.
+  function loginUrl() {
+    var here = window.location.pathname + window.location.search;
+    return "/ui/auth/login?return_to=" + encodeURIComponent(here);
+  }
+
+  var BANNER_ID = "meho-session-expired-banner";
+
+  // Create (once) and reveal the recovery banner. Returns the existing node
+  // on every call after the first so repeated 401s never stack banners.
+  function showBanner() {
+    var existing = document.getElementById(BANNER_ID);
+    if (existing) {
+      return existing;
+    }
+    var banner = document.createElement("div");
+    banner.id = BANNER_ID;
+    banner.setAttribute("role", "alert");
+    banner.setAttribute("aria-live", "assertive");
+    // Fixed, top-centered, above every surface (the approvals modal sits at
+    // ``z-50``; the drawer sidebar at ``z-40``) so the recovery path is never
+    // occluded by whatever was on screen when the session died.
+    banner.className =
+      "alert alert-error fixed top-3 left-1/2 z-[60] w-[min(36rem,calc(100vw-1.5rem))] " +
+      "-translate-x-1/2 shadow-xl";
+    var message = document.createElement("span");
+    message.className = "flex-1";
+    message.textContent = "Your session expired — please sign in again.";
+    var action = document.createElement("a");
+    action.className = "btn btn-sm";
+    action.href = loginUrl();
+    action.textContent = "Sign in";
+    banner.appendChild(message);
+    banner.appendChild(action);
+    document.body.appendChild(banner);
+    return banner;
+  }
+
+  // The single global handler. Acts ONLY on a 401; returns immediately for
+  // every other status so normal swaps and non-auth 4xx/5xx handling are
+  // byte-for-byte unchanged.
+  function onBeforeOnLoad(event) {
+    var xhr = event && event.detail && event.detail.xhr;
+    if (!xhr || xhr.status !== 401) {
+      return;
+    }
+    // Abort htmx's response processing for this 401: no dead swap, no
+    // ``responseError`` confusion -- the operator's current view survives
+    // behind the banner.
+    event.preventDefault();
+    showBanner();
+  }
+
+  document.body.addEventListener("htmx:beforeOnLoad", onBeforeOnLoad);
+
+  // Exposed for the unit-style contract test (no JS test runner exists in
+  // this repo; the Python suite serves this file and asserts on its content,
+  // and a synthetic-event test can drive these directly). Not used by the
+  // page wiring itself.
+  window.mehoSessionExpiry = {
+    loginUrl: loginUrl,
+    showBanner: showBanner,
+    onBeforeOnLoad: onBeforeOnLoad,
+    BANNER_ID: BANNER_ID,
+  };
+})();

--- a/backend/src/meho_backplane/ui/templates/_head_assets.html
+++ b/backend/src/meho_backplane/ui/templates/_head_assets.html
@@ -33,5 +33,13 @@
 <link rel="preload" href="/ui/static/src/fonts/ibm-plex-mono-latin-400.woff2" as="font" type="font/woff2" crossorigin />
 {# Vendored JS — pinned SHA256 in static/src/vendor/VENDOR.md. #}
 <script src="/ui/static/src/vendor/htmx.min.js" defer></script>
+{# App-shell session-expiry safety net (#122). Registers a single global
+   ``htmx:beforeOnLoad`` listener on <body> that surfaces a recovery banner
+   on any ``401`` from an htmx request (a session-expiry that would otherwise
+   present as a silently dead control). ``defer`` after ``htmx.min.js`` so the
+   listener attaches before the first htmx request can resolve, and after the
+   document is parsed so ``document.body`` exists. Acts ONLY on 401 -- non-auth
+   responses (incl. 422 form-validation swaps) flow through untouched. #}
+<script src="/ui/static/src/app/session-expiry.js" defer></script>
 <script src="/ui/static/src/vendor/sse.min.js" defer></script>
 <script src="/ui/static/src/vendor/alpine.min.js" defer></script>

--- a/backend/tests/test_ui_templates.py
+++ b/backend/tests/test_ui_templates.py
@@ -405,3 +405,103 @@ def test_base_template_modal_controller_renders_in_html(ui_env: Environment) -> 
     """The controller ``<script>`` survives a real render of ``base.html``."""
     html = ui_env.get_template("base.html").render(ready=True)
     assert '<script src="/ui/static/src/app/modal-dialogs.js" defer></script>' in html
+
+
+# ---------------------------------------------------------------------------
+# Session-expiry safety net (#122)
+#
+# htmx 2.0.9 classifies a 401 as ``{swap: false, error: true}`` by default,
+# so a session-expiry on an ``hx-*`` request is a silent no-op -- a dead
+# control with no operator signal. The app-shell ``session-expiry.js`` handler
+# is the client-side recovery path: a single global ``htmx:beforeOnLoad``
+# listener that, on a 401 only, ``preventDefault()``s the dead swap and
+# surfaces a banner with a login link carrying ``return_to=<current path>``.
+# No JS test runner ships in this repo (no ``package.json`` under the UI
+# package); these tests assert the wiring (the deferred script tag, loaded
+# after ``htmx.min.js``) and the served handler's load-bearing contract by
+# inspecting its source -- mirroring how ``test_ui_broadcast_feed.py`` pins
+# the served ``broadcast-feed.js`` content.
+# ---------------------------------------------------------------------------
+
+
+def test_base_template_loads_session_expiry_handler_after_htmx() -> None:
+    """``_head_assets.html`` loads the 401 handler deferred, after ``htmx.min.js``.
+
+    AC #4: the handler is registered once globally and loads via the shared
+    head-asset block after the htmx bundle, so its ``htmx:beforeOnLoad``
+    listener is attached before the first htmx request can resolve. ``defer``
+    also guarantees ``document.body`` exists when the listener registers.
+    """
+    source = (templates_dir() / "_head_assets.html").read_text(encoding="utf-8")
+    assert '<script src="/ui/static/src/app/session-expiry.js" defer></script>' in source, (
+        "_head_assets.html must load the session-expiry handler (deferred)"
+    )
+    htmx_pos = source.index("/ui/static/src/vendor/htmx.min.js")
+    handler_pos = source.index("/ui/static/src/app/session-expiry.js")
+    assert htmx_pos < handler_pos, (
+        "the session-expiry handler must load AFTER htmx.min.js so the "
+        "htmx:beforeOnLoad listener attaches before the first request resolves"
+    )
+
+
+def test_session_expiry_handler_renders_once_in_base_html(ui_env: Environment) -> None:
+    """The handler ``<script>`` survives a real render and is included exactly once.
+
+    AC #4: registered once globally, not duplicated per template. ``base.html``
+    includes ``_head_assets.html`` exactly once, so the tag appears once.
+    """
+    html = ui_env.get_template("base.html").render(ready=True)
+    assert html.count("/ui/static/src/app/session-expiry.js") == 1
+
+
+def test_session_expiry_handler_source_carries_401_contract() -> None:
+    """The served handler embeds the load-bearing 401-only safety-net logic.
+
+    Asserts the grep-able contract issue #122 AC #3 pins, plus the behavioural
+    seams a JS unit test would otherwise drive:
+
+    * AC #1 -- on a 401 it surfaces a recovery path: ``preventDefault()`` the
+      dead swap + show a banner + a login link with ``return_to=<path>``.
+    * AC #2 -- it acts ONLY on 401: a guard returns early for every other
+      status, so a 422 form-validation re-render (and any non-auth response)
+      is never intercepted.
+    * AC #4 -- registered once on ``htmx:beforeOnLoad`` (the seam htmx fires
+      for every response before any swap; ``preventDefault()`` there aborts
+      htmx's whole response processing).
+    """
+    handler = static_src_dir() / "app" / "session-expiry.js"
+    assert handler.is_file(), f"session-expiry handler missing: {handler}"
+    source = handler.read_text(encoding="utf-8")
+
+    # AC #4 -- the global seam, registered on <body>.
+    assert "htmx:beforeOnLoad" in source
+    assert 'addEventListener("htmx:beforeOnLoad"' in source
+
+    # AC #2 -- 401-only: an early-return guard keyed on the xhr status, so a
+    # 422 (or any other status) flows through untouched. Asserting both the
+    # status read and the not-401 short-circuit pins the "don't hijack 422"
+    # contract.
+    assert "event.detail.xhr" in source
+    assert "xhr.status !== 401" in source
+
+    # AC #1 -- the recovery path: cancel the dead swap, show the banner, and
+    # link to the login route with the current path as ``return_to``.
+    assert "event.preventDefault()" in source
+    assert "/ui/auth/login?return_to=" in source
+    assert "encodeURIComponent" in source
+    assert "Your session expired" in source
+
+
+def test_session_expiry_handler_served_as_static_asset() -> None:
+    """The handler is reachable under the ``/ui/static/src/app/`` mount path.
+
+    The file lives where the ``StaticFiles`` mount serves
+    ``/ui/static/src/app/session-expiry.js`` from, so the deferred script tag
+    in ``_head_assets.html`` resolves at runtime (same posture as the other
+    app-shell scripts).
+    """
+    handler = static_src_dir() / "app" / "session-expiry.js"
+    assert handler.is_file()
+    # SPDX header posture matches the sibling app-shell scripts.
+    source = handler.read_text(encoding="utf-8")
+    assert "SPDX-License-Identifier: Apache-2.0" in source

--- a/docs/codebase/ui.md
+++ b/docs/codebase/ui.md
@@ -225,6 +225,33 @@ on that id) are byte-identical before and after a rotation, so
 already-rendered pages and their forms keep working -- the
 cookie-rotation desync class #1706 diagnosed cannot occur here.
 
+Client-side session-expiry safety net (#122): the server-side handler
+above only converts a `401 session_expired` to a login redirect when the
+request carries `Accept: text/html` (a full-page navigation). A
+background htmx XHR (the approvals badge poll, a form submit) sends
+`Accept: */*`, so it gets the JSON 401 body instead -- and htmx 2.0.9's
+default `responseHandling` classifies `[45]..` as
+`{swap: false, error: true}`, so that 401 is a silent no-op: the target
+container stays empty and the operator faces a dead control. The
+app-shell script `static/src/app/session-expiry.js` closes that gap with
+a single global `htmx:beforeOnLoad` listener on `<body>` (loaded from
+`_head_assets.html` after `htmx.min.js`). htmx fires `htmx:beforeOnLoad`
+for every response before any swap or redirect-header handling, and
+`preventDefault()` there aborts htmx's entire response processing for
+that request. The handler acts **only** on `xhr.status === 401`: it
+cancels the dead swap and reveals a fixed top banner ("Your session
+expired -- please sign in again") with a link to
+`/ui/auth/login?return_to=<encoded current path>` (matching the server
+handler's `quote(full_path, safe="")` contract, accepted by the login
+route's `_safe_return_to`). Every other status -- a `2xx` swap, a `422`
+form-validation re-render, a `403` CSRF error a form's
+`hx-on::response-error` handles -- returns early and flows through
+untouched, so legitimate non-auth responses are never hijacked. The
+banner is created once and reused, so a burst of failing background
+polls cannot stack duplicates. This is the client-side recovery path
+(Axis B); the refresh seam above reduces how *often* a 401 occurs
+(Axis A).
+
 Logout: revoke the row, clear the cookie, 302 to Keycloak's
 `end_session_endpoint` with `client_id` + `post_logout_redirect_uri`
 pointing back to `/ui/auth/login`. The IdP-side hop is best-effort


### PR DESCRIPTION
## Summary
- A 401 on a background htmx request (`hx-get`/`hx-post`) was a silent no-op in htmx 2.0.9: its default `responseHandling` treats `[45]..` as `{swap: false, error: true}`, so a mid-session session-expiry left the operator with a dead control and no signal. The server-side handler (#1694) only redirects on a full-page navigation (`Accept: text/html`); background XHRs send `Accept: */*` and htmx swallows the JSON 401.
- Adds an app-shell client-side safety net: a single global `htmx:beforeOnLoad` listener on `<body>` (`session-expiry.js`, loaded from `_head_assets.html` after `htmx.min.js`). htmx fires that event for every response before any swap, and `preventDefault()` there aborts htmx's whole response processing. The handler acts **only** on `xhr.status === 401` — cancels the dead swap and reveals a fixed recovery banner linking to `/ui/auth/login?return_to=<current path>` (matching the server handler's `quote(full_path)` contract / the login route's `_safe_return_to`).
- Every other status — a `2xx` swap, a `422` form-validation re-render, a `403` CSRF error a form's `hx-on::response-error` handles — returns early and is untouched, so non-auth responses are never hijacked. The `htmx:beforeOnLoad` seam was chosen over `htmx.config.responseHandling` precisely to avoid reclassifying status codes app-wide and disturbing the finely-tuned 4xx form-swap behaviour.
- This is the client-side recovery path (Axis B); the server-side refresh seam (#1694, and sibling task) reduces how *often* a 401 occurs (Axis A). `docs/codebase/ui.md` documents both.

## Test plan
- [x] `ruff check` / `ruff format --check` — clean (changed Python: `tests/test_ui_templates.py`)
- [x] `mypy --ignore-missing-imports` — clean
- [x] `pytest tests/test_ui_templates.py` — 34 passed (5 new)
- [x] `python3 .claude/hooks/code-quality.py --diff` — exit 0
- [x] **AC #1** (401 surfaces banner + login redirect): `test_session_expiry_handler_source_carries_401_contract` asserts `preventDefault()` + `showBanner()` + the `/ui/auth/login?return_to=` URL + banner copy.
- [x] **AC #2** (422 not intercepted): same test asserts the `xhr.status !== 401` early-return guard — non-401 responses flow through untouched.
- [x] **AC #3** (grep shows the global handler): `grep -rnE "401|token_expired|beforeOnLoad|responseHandling"` over the JS + `base.html` resolves; pinned in the test.
- [x] **AC #4** (registered once, after htmx): `test_base_template_loads_session_expiry_handler_after_htmx` + `test_session_expiry_handler_renders_once_in_base_html`.
- [x] **AC #5** (no regression in 2xx flows): `pytest tests/test_ui_approvals.py tests/test_ui_broadcast_feed.py` — 59 passed.

## Notes / deviations
- The issue body names the `token_expired` detail; the operator-facing terminal signal after #1694 is actually `session_expired` (the JWT chain's `token_expired` is refreshed-and-retried server-side and rarely reaches the client). The handler is the last-resort net, so it triggers on **any** 401 from an htmx request rather than gating on one detail string — on the BFF `/ui/*` surface a 401 is auth-expiry by construction (the chassis structured 401 codes live on `/api/*`). This satisfies the desired-state ("a 401 from any htmx request surfaces a recovery state") more robustly.
- No JS test runner ships in this repo (no `package.json` under the UI package), so the handler's behaviour is pinned via served-source contract tests (the established convention — see `test_ui_broadcast_feed.py`) rather than introducing a JS toolchain (out of scope).

## Out of scope
- Server-side refresh-seam coverage that reduces 401 frequency (sibling Axis-A task).
- Any change to the 401 response shape the BFF emits.

<!-- auto-implement-issue: fresh, iteration 1 -->

Refs evoila-bosnia/meho-internal#122


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Session expiry recovery: A banner now alerts users when their session expires during use, providing a sign-in link that preserves their current location for seamless re-authentication.

* **Documentation**
  * Added documentation for the session-expiry recovery mechanism and its behavior across different response types.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->