### PR TITLE
fix(operations): tenant-scope count_known_ops to close cross-tenant oracle

### DIFF
--- a/backend/src/meho_backplane/connectors/bind9/connector.py
+++ b/backend/src/meho_backplane/connectors/bind9/connector.py
@@ -940,6 +940,7 @@ class Bind9Connector(SshConnector):
 
         if descriptor is None:
             known_op_count = await count_known_ops(
+                tenant_id=None,  # operator-less chassis path: global rows only
                 product=self.product,
                 version=self.version,
                 impl_id=self.impl_id,

--- a/backend/src/meho_backplane/connectors/holodeck/connector.py
+++ b/backend/src/meho_backplane/connectors/holodeck/connector.py
@@ -695,6 +695,7 @@ class HolodeckConnector(SshConnector):
 
         if descriptor is None:
             known_op_count = await count_known_ops(
+                tenant_id=None,  # operator-less chassis path: global rows only
                 product=self.product,
                 version=self.version,
                 impl_id=self.impl_id,

--- a/backend/src/meho_backplane/connectors/kubernetes/connector.py
+++ b/backend/src/meho_backplane/connectors/kubernetes/connector.py
@@ -1412,6 +1412,7 @@ class KubernetesConnector(Connector):
 
         if descriptor is None:
             known_op_count = await count_known_ops(
+                tenant_id=None,  # operator-less chassis path: global rows only
                 product=self.product,
                 version=self.version,
                 impl_id=self.impl_id,

--- a/backend/src/meho_backplane/connectors/pfsense/connector.py
+++ b/backend/src/meho_backplane/connectors/pfsense/connector.py
@@ -665,6 +665,7 @@ class PfSenseConnector(SshConnector):
 
         if descriptor is None:
             known_op_count = await count_known_ops(
+                tenant_id=None,  # operator-less chassis path: global rows only
                 product=self.product,
                 version=self.version,
                 impl_id=self.impl_id,

--- a/backend/src/meho_backplane/operations/_lookup.py
+++ b/backend/src/meho_backplane/operations/_lookup.py
@@ -186,21 +186,38 @@ async def descriptor_exists_any_state(
 
 async def count_known_ops(
     *,
+    tenant_id: UUID | None,
     product: str,
     version: str,
     impl_id: str,
 ) -> int:
-    """Count enabled descriptors for *(product, version, impl_id)*.
+    """Count *caller-visible* enabled descriptors for *(product, version, impl_id)*.
 
     Returned in the ``unknown_op`` error's ``extras`` so the caller has
     a "did you mean…" signal without enumerating every op id (the
     actual enumeration belongs to the ``list_operation_groups`` /
     ``search_operations`` meta-tools shipped in T8 #399).
+
+    The count is scoped to what the calling operator can see: built-in /
+    global rows (``tenant_id IS NULL``) plus this tenant's own rows
+    (``tenant_id == tenant_id``). This mirrors the tenant boundary
+    :func:`connector_exists` and the data-returning meta-tools enforce.
+    Without it the count is a cross-tenant oracle — a connector private
+    to tenant B would leak its enabled-op count into a tenant-A caller's
+    ``unknown_op`` error payload.
+
+    ``tenant_id=None`` is the operator-less chassis / CLI dispatch path
+    (the typed-connector ``execute`` shims, which resolve descriptors
+    against global rows only): the ``tenant_id == None`` clause compiles
+    to ``IS NULL``, so the predicate collapses to global rows — matching
+    those callers' own ``tenant_id IS NULL`` descriptor query.
     """
     sessionmaker = get_sessionmaker()
     async with sessionmaker() as session:
         result = await session.execute(
             select(EndpointDescriptor.id).where(
+                (EndpointDescriptor.tenant_id.is_(None))
+                | (EndpointDescriptor.tenant_id == tenant_id),
                 EndpointDescriptor.product == product,
                 EndpointDescriptor.version == version,
                 EndpointDescriptor.impl_id == impl_id,

--- a/backend/src/meho_backplane/operations/_request_preview.py
+++ b/backend/src/meho_backplane/operations/_request_preview.py
@@ -99,6 +99,7 @@ async def _resolve_previewable_descriptor(
     )
     if descriptor is None:
         known_op_count = await count_known_ops(
+            tenant_id=operator.tenant_id,
             product=product,
             version=version,
             impl_id=impl_id,

--- a/backend/src/meho_backplane/operations/dispatcher.py
+++ b/backend/src/meho_backplane/operations/dispatcher.py
@@ -1532,6 +1532,7 @@ async def dispatch(
     )
     if descriptor is None:
         known_op_count = await count_known_ops(
+            tenant_id=operator.tenant_id,
             product=product,
             version=version,
             impl_id=impl_id,

--- a/backend/tests/test_migration_0038_backfill_product_splits.py
+++ b/backend/tests/test_migration_0038_backfill_product_splits.py
@@ -534,13 +534,15 @@ def test_dispatch_probes_resolve_reconciled_connector(
         # closes so no aiosqlite connection outlives its loop.
         reset_engine_for_testing()
         try:
+            probe_tenant = uuid4()
             exists = await connector_exists(
-                tenant_id=uuid4(),
+                tenant_id=probe_tenant,
                 product=product,
                 version=version,
                 impl_id=impl_id,
             )
             known = await count_known_ops(
+                tenant_id=probe_tenant,
                 product=product,
                 version=version,
                 impl_id=impl_id,

--- a/backend/tests/test_migration_0049_retire_stale_vcf_logs_orphan_rows.py
+++ b/backend/tests/test_migration_0049_retire_stale_vcf_logs_orphan_rows.py
@@ -587,13 +587,15 @@ def test_live_short_twin_still_dispatches_post_migration(
         # closes so no aiosqlite connection outlives its loop.
         reset_engine_for_testing()
         try:
+            probe_tenant = uuid4()
             exists = await connector_exists(
-                tenant_id=uuid4(),
+                tenant_id=probe_tenant,
                 product=product,
                 version=version,
                 impl_id=impl_id,
             )
             known = await count_known_ops(
+                tenant_id=probe_tenant,
                 product=product,
                 version=version,
                 impl_id=impl_id,

--- a/backend/tests/test_operations_lookup_descriptor_exists.py
+++ b/backend/tests/test_operations_lookup_descriptor_exists.py
@@ -38,6 +38,7 @@ from sqlalchemy.ext.asyncio import AsyncSession
 from meho_backplane.db.engine import get_sessionmaker
 from meho_backplane.db.models import EndpointDescriptor
 from meho_backplane.operations._lookup import (
+    count_known_ops,
     descriptor_exists_any_state,
     lookup_descriptor,
 )
@@ -223,3 +224,68 @@ async def test_probe_does_not_leak_other_tenants_disabled_rows(
         op_id=op_id,
     )
     assert present_for_b is True, "tenant B sees its own disabled row"
+
+
+@pytest.mark.asyncio
+async def test_count_known_ops_does_not_leak_other_tenants_op_count(
+    session: AsyncSession,
+) -> None:
+    """``count_known_ops`` must not count tenant B's ops for tenant A (#101 L3).
+
+    ``count_known_ops`` feeds the ``known_op_count`` field of the
+    ``unknown_op`` error payload. Without a tenant predicate it is a
+    cross-tenant op-count / connector-existence oracle: a tenant-A
+    caller probing a connector private to tenant B would learn how many
+    enabled ops that connector has. The count is scoped exactly like
+    ``connector_exists`` — global rows plus the caller's own rows.
+
+    This asserts the boundary on **enabled** rows (the only ones
+    ``count_known_ops`` counts): tenant B owns one enabled op; tenant A
+    must see zero of it, tenant B sees its own.
+    """
+    await _insert_descriptor(
+        session, op_id="GET:/vcenter/private-b", is_enabled=True, tenant_id=_TENANT_B
+    )
+
+    count_for_a = await count_known_ops(
+        tenant_id=_TENANT_A,
+        product=_PRODUCT,
+        version=_VERSION,
+        impl_id=_IMPL_ID,
+    )
+    assert count_for_a == 0, "tenant B's op must not be counted for tenant A"
+
+    count_for_b = await count_known_ops(
+        tenant_id=_TENANT_B,
+        product=_PRODUCT,
+        version=_VERSION,
+        impl_id=_IMPL_ID,
+    )
+    assert count_for_b == 1, "tenant B counts its own enabled op"
+
+
+@pytest.mark.asyncio
+async def test_count_known_ops_counts_global_rows_for_any_tenant(
+    session: AsyncSession,
+) -> None:
+    """Global (``tenant_id IS NULL``) enabled ops count for every caller.
+
+    The scoping must not over-restrict: built-in / global descriptors
+    are caller-visible to every tenant and to the operator-less chassis
+    path (``tenant_id=None``). All three must see the same count.
+    """
+    await _insert_descriptor(
+        session, op_id="GET:/vcenter/global-vm", is_enabled=True, tenant_id=None
+    )
+    await _insert_descriptor(
+        session, op_id="GET:/vcenter/global-host", is_enabled=True, tenant_id=None
+    )
+
+    for caller in (_TENANT_A, _TENANT_B, None):
+        count = await count_known_ops(
+            tenant_id=caller,
+            product=_PRODUCT,
+            version=_VERSION,
+            impl_id=_IMPL_ID,
+        )
+        assert count == 2, f"global enabled ops must count for caller {caller!r}"


### PR DESCRIPTION
## Summary

- `count_known_ops` (surfaced in the `unknown_op` error payload's `known_op_count`) counted enabled `endpoint_descriptor` rows by `(product, version, impl_id)` with **no tenant predicate** — a tenant-A caller probing a connector private to tenant B learned its enabled-op count: a cross-tenant op-count / connector-existence oracle on the dispatch error path (info disclosure, IDOR-adjacent).
- Fix mirrors the in-repo precedent `connector_exists()` exactly: add `(tenant_id IS NULL) | (tenant_id == tenant_id)` to the count query and thread the caller's tenant from every call site.
- Operator-aware paths (`dispatch`, `preview_dispatch`) pass `operator.tenant_id`; the operator-less typed-connector chassis shims (holodeck / pfsense / kubernetes / bind9), which resolve descriptors against global rows only, pass `tenant_id=None` (compiles to `IS NULL`, collapsing the predicate to global rows — matching their own descriptor query). The parameter is `UUID | None` to type-honestly serve both caller classes.

## Test plan

- [x] `ruff check` / `ruff format --check` — clean (10 files)
- [x] `mypy` — clean (touched src files)
- [x] New regression test `test_count_known_ops_does_not_leak_other_tenants_op_count` — tenant-B's enabled op is **not** counted for tenant A; verified it **fails without** the predicate and passes with it (non-vacuous)
- [x] New `test_count_known_ops_counts_global_rows_for_any_tenant` — global rows still count for tenant A, tenant B, and the `None` chassis caller
- [x] `pytest tests/test_operations_lookup_descriptor_exists.py` — 6 passed
- [x] `pytest tests/test_operations_dispatcher.py tests/test_operations_request_preview.py` — 67 passed
- [x] `pytest` migration suites (0038, 0049) — 25 passed (call sites threaded)
- [x] Connector suites exercising the `unknown_op` envelope (k8s, holodeck, pfsense, bind9) — 349 passed
- [x] `code-quality.py --diff` — 0 blockers (25 pre-existing legacy size warnings on touched functions, none agent-introduced)

## Out of scope

- The other 16 Low + 6 Info + 2 Contested rows of the triage board remain open under their parent tracker.
- Pre-existing function-size warnings in `dispatcher.py` / `_request_preview.py` (recorded, not this row's scope).

<!-- auto-implement-issue: fresh, iteration 1 -->

Refs evoila-bosnia/meho-internal#101, addressing row L3
