### PR TITLE
fix(jsonflux): sandbox the DuckDB query-engine connection

### DIFF
--- a/backend/src/meho_backplane/jsonflux/query/engine.py
+++ b/backend/src/meho_backplane/jsonflux/query/engine.py
@@ -164,8 +164,24 @@ class QueryEngine:
 
     def __init__(self) -> None:
         self.conn = duckdb.connect(":memory:")
+        self._harden_connection()
         self.tables: dict[str, dict[str, Any]] = {}
         self._closed = False
+
+    def _harden_connection(self) -> None:
+        """Sandbox the in-memory DuckDB connection (defense-in-depth).
+
+        Data only ever enters this engine via in-memory Arrow tables
+        (``conn.register``); DuckDB never reads files or URLs itself. These
+        settings make that contract enforced rather than incidental, closing
+        the latent arbitrary-file-read / SSRF / untrusted-extension surface
+        that arbitrary SQL (e.g. a future ``result_query`` drill-in) would
+        otherwise expose. ``lock_configuration`` must be applied last because
+        it freezes all further configuration changes.
+        """
+        self.conn.execute("SET enable_external_access=false")
+        self.conn.execute("SET allow_community_extensions=false")
+        self.conn.execute("SET lock_configuration=true")
 
     def register(  # NOSONAR (cognitive complexity)
         self,

--- a/backend/tests/test_jsonflux_query_engine_sandbox.py
+++ b/backend/tests/test_jsonflux_query_engine_sandbox.py
@@ -1,0 +1,64 @@
+# SPDX-License-Identifier: Apache-2.0
+# Copyright (c) 2026 evoila Group
+
+"""Sandbox regression tests for the JSONFlux ``QueryEngine`` DuckDB connection (#101 L9).
+
+The engine only ever loads data via in-memory Arrow tables
+(``conn.register``); DuckDB is never asked to read files or URLs itself.
+``QueryEngine._harden_connection`` enforces that contract with
+``enable_external_access=false`` + ``allow_community_extensions=false`` +
+``lock_configuration=true`` (applied in that order), closing the latent
+arbitrary-file-read / SSRF / untrusted-extension surface that arbitrary SQL
+would otherwise expose.
+
+These tests assert both halves of the contract:
+
+* the legitimate in-memory query path still works, and
+* an external-access operation (reading a local file via DuckDB) is denied,
+  and the sandbox cannot be unlocked at runtime.
+"""
+
+from __future__ import annotations
+
+import duckdb
+import pytest
+
+from meho_backplane.jsonflux.query.engine import QueryEngine
+
+
+def test_in_memory_query_still_works() -> None:
+    """The hardening must not break the legitimate in-memory Arrow path."""
+    engine = QueryEngine()
+    try:
+        engine.register("items", [{"qty": 2}, {"qty": 3}, {"qty": 5}])
+        rows = engine.query("SELECT SUM(qty) AS total FROM items")
+        assert rows == [{"total": 10}]
+    finally:
+        engine.close()
+
+
+def test_external_file_read_is_denied(tmp_path) -> None:
+    """A DuckDB-native local-file read must be rejected by the sandbox."""
+    csv = tmp_path / "secret.csv"
+    csv.write_text("name\nalice\n")
+
+    engine = QueryEngine()
+    try:
+        with pytest.raises(duckdb.Error) as exc_info:
+            engine.query(f"SELECT * FROM read_csv('{csv}')")
+        # Surface the PermissionException specifically — a CatalogException
+        # (function-not-found) would mean the read function was merely absent,
+        # not that external access was actively denied.
+        assert isinstance(exc_info.value, duckdb.PermissionException)
+    finally:
+        engine.close()
+
+
+def test_configuration_is_locked() -> None:
+    """``lock_configuration`` must prevent re-enabling external access."""
+    engine = QueryEngine()
+    try:
+        with pytest.raises(duckdb.InvalidInputException):
+            engine.conn.execute("SET enable_external_access=true")
+    finally:
+        engine.close()

--- a/docs/architecture/jsonflux.md
+++ b/docs/architecture/jsonflux.md
@@ -185,6 +185,29 @@ verbatim on the `register()` docstring.
 > `register()`, so the row count (the threshold input) is correct for
 > every vendor shape. See `_normalize_rows` in `jsonflux_reducer.py`.
 
+### Connection sandbox
+
+Data only ever enters the engine via in-memory Arrow tables
+(`conn.register`); DuckDB is never asked to read a file or URL itself —
+sources are decoded in Python (`msgspec`) and handed over as Arrow. The
+`QueryEngine` constructor enforces that contract on the `:memory:`
+connection via `_harden_connection()`:
+
+```python
+self.conn.execute("SET enable_external_access=false")
+self.conn.execute("SET allow_community_extensions=false")
+self.conn.execute("SET lock_configuration=true")  # must be last
+```
+
+`enable_external_access=false` denies `ATTACH`, `COPY`, and
+`read_csv`/`read_json`/`read_parquet`; `allow_community_extensions=false`
+blocks third-party extension installs; `lock_configuration=true` freezes
+all further configuration and so must be applied **last** (it would
+otherwise prevent the preceding `SET`s). This is defense-in-depth against
+the latent arbitrary-file-read / SSRF / untrusted-extension surface that
+arbitrary SQL (e.g. a future `result_query` drill-in) would expose. See
+the [DuckDB securing guide](https://duckdb.org/docs/operations_manual/securing_duckdb/overview).
+
 ## Reducer adapter
 
 The dispatcher does not call the vendored package directly. The bridge is


### PR DESCRIPTION
## Summary

- The JSONFlux `QueryEngine` opened its `:memory:` DuckDB connection with no config restrictions (`backend/src/meho_backplane/jsonflux/query/engine.py:166`). Data only ever enters the engine via in-memory Arrow tables (`conn.register`) — DuckDB never reads a file or URL itself — so the unrestricted connection was a latent arbitrary-file-read / SSRF / untrusted-extension sink that arbitrary SQL (e.g. a future `result_query` drill-in) would expose.
- Hardens the connection at construction with `enable_external_access=false`, `allow_community_extensions=false`, then `lock_configuration=true` **last** (it freezes all further config, so the preceding `SET`s must run first). Defense-in-depth per the [DuckDB securing guide](https://duckdb.org/docs/operations_manual/securing_duckdb/overview).
- No legitimate path relied on DuckDB external access: sources are decoded in Python (`msgspec`) and handed to DuckDB as Arrow, so the full jsonflux/query suite still passes unchanged.

## Test plan

- [x] `ruff check` — clean (engine + new test)
- [x] `ruff format --check` — clean
- [x] `mypy src/.../query/engine.py --ignore-missing-imports` — clean
- [x] New regression test `tests/test_jsonflux_query_engine_sandbox.py` (non-vacuous, 3 assertions execute):
  - in-memory Arrow query still works (`SUM(qty)` over a registered table)
  - DuckDB-native local-file read is denied (`read_csv` raises `duckdb.PermissionException`)
  - locked configuration cannot be re-enabled at runtime (`SET enable_external_access=true` raises `duckdb.InvalidInputException`)
- [x] `pytest` jsonflux/query suite (sandbox + reducer + result_query + vault_kv_list) — 35 passed
- [x] code-quality `--diff` — 0 blockers (6 pre-existing legacy warnings in `engine.py`, none introduced here)
- [x] CLI API snapshot — `make snapshot-openapi && make generate` produced no diff in `cli/api/openapi.json` / `cli/internal/api/client.gen.go` (backend-internal change)

## Out of scope

- Other rows in the #101 triage backlog.
- Pre-existing size/complexity warnings on `engine.py` (`register`, `_build_prompt`, file length) — recorded as adjacent findings, not introduced by this change.

<!-- auto-implement-issue: fresh, iteration 1 -->

Refs evoila-bosnia/meho-internal#101, addressing row L9.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Enhanced security isolation for query execution to prevent unauthorized external data access.

* **Documentation**
  * Added details on query engine connection sandbox architecture and security hardening measures.

* **Tests**
  * Added comprehensive sandbox regression tests to verify security isolation and existing functionality.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->