### PR TITLE
fix(cli): require https for the backplane URL (#101 L17)

### DIFF
--- a/cli/internal/backplane/backplane.go
+++ b/cli/internal/backplane/backplane.go
@@ -146,10 +146,11 @@ func validateScheme(u *url.URL, allowHTTP bool) error {
 }
 
 // isLoopbackHost reports whether host (a URL hostname, port already
-// stripped) refers to the local machine: the literal "localhost", or
-// any IP literal in a loopback range (127.0.0.0/8, ::1).
+// stripped) refers to the local machine: the literal "localhost"
+// (case-insensitive, since hostnames are per RFC 4343), or any IP
+// literal in a loopback range (127.0.0.0/8, ::1).
 func isLoopbackHost(host string) bool {
-	if host == "localhost" {
+	if strings.EqualFold(host, "localhost") {
 		return true
 	}
 	ip := net.ParseIP(host)

--- a/cli/internal/backplane/backplane.go
+++ b/cli/internal/backplane/backplane.go
@@ -16,6 +16,7 @@ package backplane
 import (
 	"errors"
 	"fmt"
+	"net"
 	"net/url"
 	"strings"
 
@@ -63,9 +64,35 @@ func ClassifyError(err error) *output.StructuredError {
 	return output.Unexpected(err.Error())
 }
 
-// NormaliseURL strips trailing slashes + parses the URL to fail fast on
-// garbage input.
+// NormaliseURL strips trailing slashes, parses the URL to fail fast on
+// garbage input, and enforces the transport-security policy: https is
+// always accepted; plaintext http:// is accepted only for a loopback
+// host (localhost / 127.0.0.0/8 / ::1); http:// to any routed host is
+// rejected. The bearer token minted by `meho login` rides every request
+// in an Authorization header, so plaintext to a routed host would
+// transmit it in the clear (OWASP Transport Layer Security cheat sheet)
+// — but a loopback connection never leaves the machine, so it carries
+// no such risk. This is the resolver every verb runs against the stored
+// (already login-vetted) URL or a --backplane override.
 func NormaliseURL(s string) (string, error) {
+	// The stored/override path tolerates loopback http: a value can
+	// only have reached the config by passing `meho login`'s stricter
+	// gate (which requires --insecure-allow-http even for loopback),
+	// and httptest harnesses dial loopback http.
+	return NormaliseURLAllowHTTP(s, true)
+}
+
+// NormaliseURLAllowHTTP is NormaliseURL with explicit control over the
+// loopback-http allowance. `meho login` passes allowHTTP=false by
+// default so first-contact login is https-only, and allowHTTP=true only
+// when the operator passes --insecure-allow-http for a localhost
+// backplane. Regardless of allowHTTP, plaintext http:// to a routed
+// (non-loopback) host is always rejected — a token sent over http:// to
+// a routed host crosses the network in the clear regardless of operator
+// intent. This mirrors the deliberately narrow gating of the
+// `--insecure-skip-tls-verify` bootstrap flag: a convenience for local
+// dev, never a blanket cleartext escape hatch.
+func NormaliseURLAllowHTTP(s string, allowHTTP bool) (string, error) {
 	trimmed := strings.TrimRight(strings.TrimSpace(s), "/")
 	if trimmed == "" {
 		return "", errors.New("backplane URL is empty")
@@ -74,9 +101,57 @@ func NormaliseURL(s string) (string, error) {
 	if err != nil {
 		return "", fmt.Errorf("invalid backplane URL %q: %w", s, err)
 	}
+	// Scheme before host: the transport-security policy is the more
+	// fundamental gate, and it gives a clearer message for hostless
+	// non-http schemes (e.g. file:///tmp/x, whose host is empty) than
+	// the generic "has no host".
+	if err := validateScheme(u, allowHTTP); err != nil {
+		return "", err
+	}
 	if u.Host == "" {
 		return "", fmt.Errorf("backplane URL %q has no host", s)
 	}
 	u.Path = strings.TrimRight(u.Path, "/")
 	return u.String(), nil
+}
+
+// validateScheme enforces the transport-security policy on a parsed
+// backplane URL: https always passes; plaintext http to a routed host
+// is always rejected; plaintext http to a loopback host passes only
+// when allowHTTP is set; any other scheme is rejected.
+func validateScheme(u *url.URL, allowHTTP bool) error {
+	switch u.Scheme {
+	case "https":
+		return nil
+	case "http":
+		// Routed-host plaintext is rejected regardless of allowHTTP:
+		// the token would cross the network in the clear no matter the
+		// operator's intent.
+		if !isLoopbackHost(u.Hostname()) {
+			return fmt.Errorf(
+				"backplane URL %q uses plaintext http:// to a routed host — the bearer token would be "+
+					"sent in the clear; use https://", u.String())
+		}
+		// Loopback plaintext never leaves the machine, but first-contact
+		// login still demands the explicit --insecure-allow-http opt-in.
+		if !allowHTTP {
+			return fmt.Errorf(
+				"backplane URL %q uses plaintext http:// — pass --insecure-allow-http to allow a "+
+					"localhost backplane, or use https://", u.String())
+		}
+		return nil
+	default:
+		return fmt.Errorf("backplane URL %q must use https (or http for a localhost backplane)", u.String())
+	}
+}
+
+// isLoopbackHost reports whether host (a URL hostname, port already
+// stripped) refers to the local machine: the literal "localhost", or
+// any IP literal in a loopback range (127.0.0.0/8, ::1).
+func isLoopbackHost(host string) bool {
+	if host == "localhost" {
+		return true
+	}
+	ip := net.ParseIP(host)
+	return ip != nil && ip.IsLoopback()
 }

--- a/cli/internal/backplane/backplane_test.go
+++ b/cli/internal/backplane/backplane_test.go
@@ -94,8 +94,11 @@ func TestNormaliseURLAllowHTTPFalseRejectsLoopback(t *testing.T) {
 func TestNormaliseURLAllowHTTPPermitsLoopback(t *testing.T) {
 	cases := map[string]string{
 		"http://localhost:8080/": "http://localhost:8080",
-		"http://127.0.0.1:8080":  "http://127.0.0.1:8080",
-		"http://[::1]:8080":      "http://[::1]:8080",
+		// Hostnames are case-insensitive (RFC 4343); url.Hostname()
+		// preserves case, so the loopback check must fold case.
+		"http://LOCALHOST:8080": "http://LOCALHOST:8080",
+		"http://127.0.0.1:8080": "http://127.0.0.1:8080",
+		"http://[::1]:8080":     "http://[::1]:8080",
 	}
 	for in, want := range cases {
 		got, err := NormaliseURLAllowHTTP(in, true)

--- a/cli/internal/backplane/backplane_test.go
+++ b/cli/internal/backplane/backplane_test.go
@@ -24,6 +24,107 @@ func TestNormaliseURLTrimsAndValidates(t *testing.T) {
 	}
 }
 
+// TestNormaliseURLRejectsRemoteHTTP — plaintext http:// to a routed
+// host must always be rejected on the resolution path: the bearer token
+// rides every request in cleartext over http (OWASP TLS cheat sheet,
+// #101 L17).
+func TestNormaliseURLRejectsRemoteHTTP(t *testing.T) {
+	cases := []string{
+		"http://meho.test",
+		"http://169.254.169.254",
+		"http://10.0.0.5:8080",
+	}
+	for _, in := range cases {
+		if _, err := NormaliseURL(in); err == nil || !strings.Contains(err.Error(), "routed host") {
+			t.Errorf("NormaliseURL(%q): want routed-host rejection, got %v", in, err)
+		}
+	}
+}
+
+// TestNormaliseURLAcceptsLoopbackHTTP — plaintext http:// to a loopback
+// host is accepted on the resolution path: it never leaves the machine,
+// so there is no cleartext-transmission risk. (login itself is stricter
+// — it requires --insecure-allow-http even for loopback.)
+func TestNormaliseURLAcceptsLoopbackHTTP(t *testing.T) {
+	cases := map[string]string{
+		"http://localhost:8080/": "http://localhost:8080",
+		"http://127.0.0.1:8080":  "http://127.0.0.1:8080",
+		"http://[::1]:8080":      "http://[::1]:8080",
+	}
+	for in, want := range cases {
+		got, err := NormaliseURL(in)
+		if err != nil || got != want {
+			t.Errorf("NormaliseURL(%q): got %q, err %v (want %q)", in, got, err, want)
+		}
+	}
+}
+
+// TestNormaliseURLAcceptsHTTPS — https is the happy path and stays
+// untouched apart from trailing-slash trimming.
+func TestNormaliseURLAcceptsHTTPS(t *testing.T) {
+	got, err := NormaliseURL("https://meho.test:8443/")
+	if err != nil || got != "https://meho.test:8443" {
+		t.Fatalf("NormaliseURL(https): got %q, err %v", got, err)
+	}
+}
+
+// TestNormaliseURLRejectsNonHTTPScheme — non-http(s) schemes the CLI
+// can't dial fail fast with an actionable error.
+func TestNormaliseURLRejectsNonHTTPScheme(t *testing.T) {
+	for _, in := range []string{"ftp://meho.test", "ssh://meho.test", "file:///tmp/x"} {
+		if _, err := NormaliseURL(in); err == nil || !strings.Contains(err.Error(), "must use https") {
+			t.Errorf("NormaliseURL(%q): want scheme rejection, got %v", in, err)
+		}
+	}
+}
+
+// TestNormaliseURLAllowHTTPFalseRejectsLoopback — with allowHTTP=false
+// (the login default) even loopback http is rejected, demanding the
+// explicit --insecure-allow-http opt-in.
+func TestNormaliseURLAllowHTTPFalseRejectsLoopback(t *testing.T) {
+	for _, in := range []string{"http://localhost:8080", "http://127.0.0.1:8080"} {
+		if _, err := NormaliseURLAllowHTTP(in, false); err == nil || !strings.Contains(err.Error(), "--insecure-allow-http") {
+			t.Errorf("NormaliseURLAllowHTTP(%q, false): want opt-in hint, got %v", in, err)
+		}
+	}
+}
+
+// TestNormaliseURLAllowHTTPPermitsLoopback — the --insecure-allow-http
+// opt-in permits plaintext only for loopback hosts.
+func TestNormaliseURLAllowHTTPPermitsLoopback(t *testing.T) {
+	cases := map[string]string{
+		"http://localhost:8080/": "http://localhost:8080",
+		"http://127.0.0.1:8080":  "http://127.0.0.1:8080",
+		"http://[::1]:8080":      "http://[::1]:8080",
+	}
+	for in, want := range cases {
+		got, err := NormaliseURLAllowHTTP(in, true)
+		if err != nil || got != want {
+			t.Errorf("NormaliseURLAllowHTTP(%q, true): got %q, err %v (want %q)", in, got, err, want)
+		}
+	}
+}
+
+// TestNormaliseURLAllowHTTPRejectsRemote — even with the opt-in,
+// plaintext http:// to a routed (non-loopback) host is rejected: the
+// token would still cross the network in the clear.
+func TestNormaliseURLAllowHTTPRejectsRemote(t *testing.T) {
+	for _, in := range []string{"http://meho.test", "http://169.254.169.254", "http://10.0.0.5:8080"} {
+		if _, err := NormaliseURLAllowHTTP(in, true); err == nil || !strings.Contains(err.Error(), "routed host") {
+			t.Errorf("NormaliseURLAllowHTTP(%q, true): want routed-host rejection, got %v", in, err)
+		}
+	}
+}
+
+// TestNormaliseURLAllowHTTPStillAcceptsHTTPS — passing the opt-in does
+// not weaken the https happy path.
+func TestNormaliseURLAllowHTTPStillAcceptsHTTPS(t *testing.T) {
+	got, err := NormaliseURLAllowHTTP("https://meho.test/", true)
+	if err != nil || got != "https://meho.test" {
+		t.Fatalf("NormaliseURLAllowHTTP(https, true): got %q, err %v", got, err)
+	}
+}
+
 func TestResolveOverrideWins(t *testing.T) {
 	got, err := Resolve("https://override.test/")
 	if err != nil || got != "https://override.test" {

--- a/cli/internal/cmd/login.go
+++ b/cli/internal/cmd/login.go
@@ -10,13 +10,12 @@ import (
 	"fmt"
 	"io"
 	"net/http"
-	"net/url"
-	"strings"
 
 	"github.com/spf13/cobra"
 	"golang.org/x/oauth2"
 
 	"github.com/evoila/meho/cli/internal/auth"
+	"github.com/evoila/meho/cli/internal/backplane"
 	"github.com/evoila/meho/cli/internal/migrate"
 )
 
@@ -30,9 +29,10 @@ import (
 // successor — not in scope for this Task) deliberately stay out.
 func newLoginCmd() *cobra.Command {
 	var (
-		issuerOverride   string
-		clientIDOverride string
-		scopes           []string
+		issuerOverride    string
+		clientIDOverride  string
+		scopes            []string
+		insecureAllowHTTP bool
 	)
 
 	cmd := &cobra.Command{
@@ -62,9 +62,14 @@ func newLoginCmd() *cobra.Command {
 		Args:         cobra.ExactArgs(1),
 		SilenceUsage: true,
 		RunE: func(cmd *cobra.Command, args []string) error {
-			backplaneURL := strings.TrimRight(args[0], "/")
-			if _, err := url.ParseRequestURI(backplaneURL); err != nil {
-				return fmt.Errorf("invalid backplane URL %q: %w", backplaneURL, err)
+			// Normalise + enforce transport security before any
+			// network call. https is required by default so the
+			// bearer token minted below is never sent in the clear;
+			// --insecure-allow-http opts a loopback backplane out
+			// (see NormaliseURLAllowHTTP).
+			backplaneURL, err := backplane.NormaliseURLAllowHTTP(args[0], insecureAllowHTTP)
+			if err != nil {
+				return err
 			}
 
 			// Discovery and auth-config fetches honour the ambient
@@ -158,6 +163,9 @@ func newLoginCmd() *cobra.Command {
 		"OAuth client_id to use for the device-code flow (auto-discovered when blank)")
 	cmd.Flags().StringSliceVar(&scopes, "scope", nil,
 		"OAuth scopes to request (default: openid). Repeat or comma-separate for multiple.")
+	cmd.Flags().BoolVar(&insecureAllowHTTP, "insecure-allow-http", false,
+		"permit a plaintext http:// backplane URL for a localhost backplane only "+
+			"(local-dev convenience; the bearer token is sent in the clear — never use against a remote host)")
 	return cmd
 }
 

--- a/cli/internal/cmd/login_test.go
+++ b/cli/internal/cmd/login_test.go
@@ -275,6 +275,61 @@ func TestLoginCommandRejectsMissingArg(t *testing.T) {
 	}
 }
 
+// TestLoginRejectsPlaintextHTTPArg confirms the login arg-parse refuses
+// a plaintext http:// backplane URL by default — the bearer token would
+// otherwise be sent in the clear (#101 L17). The error fires before any
+// network call, so no httptest server is needed.
+func TestLoginRejectsPlaintextHTTPArg(t *testing.T) {
+	cmd := newLoginCmd()
+	cmd.SetArgs([]string{"http://meho.test"})
+	var out strings.Builder
+	cmd.SetOut(&out)
+	cmd.SetErr(&out)
+	err := cmd.Execute()
+	if err == nil || !strings.Contains(err.Error(), "routed host") {
+		t.Fatalf("expected routed-host plaintext rejection, got %v", err)
+	}
+}
+
+// TestLoginRejectsLoopbackHTTPWithoutFlag confirms login is stricter
+// than the resolver: even a loopback http:// URL is rejected unless
+// --insecure-allow-http is passed, and the error points at the flag.
+func TestLoginRejectsLoopbackHTTPWithoutFlag(t *testing.T) {
+	cmd := newLoginCmd()
+	cmd.SetArgs([]string{"http://localhost:8080"})
+	var out strings.Builder
+	cmd.SetOut(&out)
+	cmd.SetErr(&out)
+	err := cmd.Execute()
+	if err == nil || !strings.Contains(err.Error(), "--insecure-allow-http") {
+		t.Fatalf("expected opt-in hint for loopback http, got %v", err)
+	}
+}
+
+// TestLoginInsecureAllowHTTPRejectsRemote confirms that even with
+// --insecure-allow-http, a non-loopback http:// host is rejected: the
+// flag is a localhost-only convenience, not a blanket cleartext escape.
+func TestLoginInsecureAllowHTTPRejectsRemote(t *testing.T) {
+	cmd := newLoginCmd()
+	cmd.SetArgs([]string{"--insecure-allow-http", "http://meho.test"})
+	var out strings.Builder
+	cmd.SetOut(&out)
+	cmd.SetErr(&out)
+	err := cmd.Execute()
+	if err == nil || !strings.Contains(err.Error(), "routed host") {
+		t.Fatalf("expected routed-host rejection, got %v", err)
+	}
+}
+
+// TestLoginCommandHelpListsInsecureAllowHTTP pins the flag's
+// discoverability — install scripts and operators grep --help for it.
+func TestLoginCommandHelpListsInsecureAllowHTTP(t *testing.T) {
+	cmd := newLoginCmd()
+	if out := cmd.UsageString(); !strings.Contains(out, "--insecure-allow-http") {
+		t.Errorf("usage missing --insecure-allow-http flag:\n%s", out)
+	}
+}
+
 // ── Post-login nudge ──────────────────────────────────────────────────────────
 
 func writeMemoryFixture(t *testing.T, dir, name, content string) {

--- a/cli/internal/cmd/operation/client_test.go
+++ b/cli/internal/cmd/operation/client_test.go
@@ -522,7 +522,7 @@ func TestRunCallAwaitingApprovalRealPath(t *testing.T) {
 	var out, errBuf bytes.Buffer
 	cmd.SetOut(&out)
 	cmd.SetErr(&errBuf)
-	cmd.SetArgs([]string{"argocd-api-3.x", "argocd.app.sync", "--target", "rdc-argocd", "--backplane", "http://x"})
+	cmd.SetArgs([]string{"argocd-api-3.x", "argocd.app.sync", "--target", "rdc-argocd", "--backplane", "https://x"})
 	if err := cmd.Execute(); err != nil {
 		t.Fatalf("awaiting_approval must not be an error (parked, exit 0); got %v", err)
 	}
@@ -553,7 +553,7 @@ func TestRunCallAwaitingApprovalJSON(t *testing.T) {
 	var out bytes.Buffer
 	cmd.SetOut(&out)
 	cmd.SetErr(&bytes.Buffer{})
-	cmd.SetArgs([]string{"argocd-api-3.x", "argocd.app.sync", "--target", "rdc-argocd", "--json", "--backplane", "http://x"})
+	cmd.SetArgs([]string{"argocd-api-3.x", "argocd.app.sync", "--target", "rdc-argocd", "--json", "--backplane", "https://x"})
 	if err := cmd.Execute(); err != nil {
 		t.Fatalf("execute: %v", err)
 	}

--- a/docs/codebase/cli.md
+++ b/docs/codebase/cli.md
@@ -380,6 +380,22 @@ The login subcommand authenticates the operator against the
 backplane's configured Keycloak realm using the OAuth 2.0 Device
 Authorization Grant (RFC 8628). End-to-end shape:
 
+0. **Transport-security gate (arg parse).** The `<backplane-url>`
+   argument is normalised through `backplane.NormaliseURLAllowHTTP`
+   before any network call. `https://` is required by default: the
+   access token minted below rides every subsequent request in an
+   `Authorization` header, so a plaintext `http://` backplane would
+   transmit it in the clear (OWASP TLS cheat sheet). Plaintext is
+   permitted only for a **loopback** backplane
+   (`localhost` / `127.0.0.0/8` / `::1`) and only when the operator
+   passes `--insecure-allow-http`; `http://` to any routed host is
+   rejected even with the flag, because the token would still cross
+   the network unencrypted. The shared resolver
+   `backplane.NormaliseURL` (run by every verb against the stored or
+   `--backplane` URL) applies the same policy but tolerates loopback
+   `http://` without the flag — a stored value can only have passed
+   login's stricter gate, and a loopback connection never leaves the
+   machine.
 1. **Auth-config discovery.** The CLI calls
    `GET <backplane-url>/api/v1/auth-config` to learn the Keycloak
    realm issuer and the public device-code `client_id` to use. The


### PR DESCRIPTION
## Summary

- `meho login` and the shared backplane resolver previously accepted any URL scheme, so a plaintext `http://` backplane would transmit the `meho login` bearer token in the clear on every subsequent request (cleartext credential transmission, OWASP TLS cheat sheet).
- `backplane.NormaliseURL` now enforces a transport-security policy: `https://` always passes; plaintext `http://` passes only for a loopback host (`localhost` / `127.0.0.0/8` / `::1`); `http://` to any routed host is rejected.
- `meho login` is stricter at first contact — it normalises via the new `NormaliseURLAllowHTTP(arg, allowHTTP)` with `allowHTTP=false`, so login is https-only even for loopback, and adds an `--insecure-allow-http` opt-in (mirroring the gating/wording of the existing `--insecure-skip-tls-verify` keycloak bootstrap flag) that permits a localhost plaintext backplane for local dev. The flag never permits plaintext to a routed host.
- Bare host with no scheme: `url.ParseRequestURI` rejects it (parse error) — no scheme is silently assumed.

## Test plan

- [x] `gofmt -l` — clean on all touched files
- [x] `go vet ./...` — clean
- [x] `golangci-lint run` — no issues
- [x] `go test -race -cover ./...` — 1882 passed (full CLI suite)
- [x] Go regression tests added in `internal/backplane/backplane_test.go`: routed `http://` rejected; loopback `http://` accepted on the resolver; `https://` accepted; `--insecure-allow-http`-equivalent permits loopback http and rejects routed http; non-http(s) schemes rejected.
- [x] Go regression tests added in `internal/cmd/login_test.go`: login rejects routed `http://`; login rejects loopback `http://` without the flag (points at `--insecure-allow-http`); login with the flag still rejects routed `http://`; `--help` lists the flag.

## Notes

- Go-specific change — the Python gates (ruff/mypy/pytest) don't apply. Applied general Go idioms: error wrapping with `%w`, table-driven tests, no panics on user input, switch-based scheme classification.
- No `cli/api/` or generated `*.gen.go` files touched, so the CLI OpenAPI snapshot stays fresh (no regeneration needed).
- Updated `internal/cmd/operation/client_test.go` (2 placeholder `http://x` backplane URLs → `https://x`; the tests use a fake client and never dial). The `agent` / `broadcast` tests that pass placeholder `http://` URLs assert on pre-resolution validation errors and are unaffected.
- `docs/codebase/cli.md` login-flow section updated with the new transport-security gate.

## Out of scope

- The per-package legacy `normaliseURL` copies (`cmd/argocd`, `cmd/connector`, etc.) already enforce http-or-https; this Task's anchor is `backplane.NormaliseURL` + `cmd/login.go` only.

Refs evoila-bosnia/meho-internal#101, addressing row L17.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added a new login option to allow plain HTTP for local backplane addresses when explicitly enabled.
  * Improved backplane URL handling with clearer validation for supported schemes and hosts.

* **Bug Fixes**
  * Prevented non-secure HTTP connections to remote backplane hosts by default.
  * Added clearer errors for invalid URLs, including missing hosts and unsupported schemes.

* **Documentation**
  * Updated CLI help and usage docs to explain when HTTP is allowed and when HTTPS is required.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->