### PR TITLE
fix(runbooks): reject ${...} substitution in step/verify op_id at publish (#101 L13)

### DIFF
--- a/backend/src/meho_backplane/runbooks/schemas.py
+++ b/backend/src/meho_backplane/runbooks/schemas.py
@@ -77,6 +77,7 @@ __all__ = [
     "Step",
     "TemplateSummary",
     "Verify",
+    "validate_op_id_static",
     "validate_substitutions",
 ]
 
@@ -139,6 +140,27 @@ def validate_substitutions(value: object) -> None:
             validate_substitutions(item)
     # Scalars other than str (int / float / bool / None) carry no
     # substitution surface; nothing to walk.
+
+
+def validate_op_id_static(op_id: str) -> None:
+    """Reject *any* ``${...}`` substitution token in an ``op_id``.
+
+    Stricter than :func:`validate_substitutions`: an ``op_id`` names the
+    operation a runbook step dispatches -- it is operation *identity*,
+    not call payload. Neither allowlisted form (``${run.target}`` /
+    ``${run.params.X}``) is legal here. Permitting even an allowlisted
+    substitution would let an operator-supplied run parameter redirect a
+    published step or verify to a different operation at runtime
+    (parameter injection into operation identity), defeating the
+    publish-time review of which operations a runbook may invoke. The
+    operation set a runbook can call is fixed at publish time.
+
+    Raised as :class:`ValueError` so Pydantic renders it as a 422 at the
+    HTTP boundary, matching :func:`validate_substitutions`.
+    """
+    match = _SUBSTITUTION_PATTERN.search(op_id)
+    if match is not None:
+        raise ValueError(f"disallowed substitution in op_id: {match.group(0)}")
 
 
 class ConfirmVerify(BaseModel):
@@ -272,6 +294,10 @@ class RunbookTemplateBody(BaseModel):
            and any ``${...}`` pattern other than ``${run.target}`` /
            ``${run.params.X}`` is rejected (defense in depth; G12.3
            re-checks at advance time via :func:`validate_substitutions`).
+           Step / verify ``op_id`` is held to the stricter
+           :func:`validate_op_id_static` rule -- operation identity is
+           static, so *no* substitution (not even an allowlisted one) may
+           appear there.
         """
         seen: set[str] = set()
         for step in self.steps:
@@ -282,8 +308,10 @@ class RunbookTemplateBody(BaseModel):
             validate_substitutions(step.body)
             verify = step.verify
             if isinstance(step, OperationCallStep):
+                validate_op_id_static(step.op_id)
                 validate_substitutions(step.params)
             if isinstance(verify, OperationCallVerify):
+                validate_op_id_static(verify.op_id)
                 validate_substitutions(verify.params)
                 validate_substitutions(verify.expect)
         return self

--- a/backend/tests/test_runbooks_schemas.py
+++ b/backend/tests/test_runbooks_schemas.py
@@ -43,6 +43,7 @@ from meho_backplane.runbooks.schemas import (
     RunbookTemplateBody,
     Step,
     Verify,
+    validate_op_id_static,
     validate_substitutions,
 )
 
@@ -218,6 +219,85 @@ def test_substitution_rejected(bad: str) -> None:
                 ),
             ],
         )
+
+
+# ---------------------------------------------------------------------------
+# op_id is operation identity -- no substitution, not even an allowlisted one
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.parametrize(
+    "bad_op_id",
+    [
+        "${run.params.target_op}",  # an allowlisted form is still illegal here
+        "${run.target}",  # the other allowlisted form -- also illegal in op_id
+        "vmware.${run.params.verb}.create",  # embedded substitution
+        "${anything_else}",
+    ],
+)
+def test_op_id_static_rejects_substitution(bad_op_id: str) -> None:
+    with pytest.raises(ValueError, match="disallowed substitution in op_id"):
+        validate_op_id_static(bad_op_id)
+
+
+def test_op_id_static_accepts_plain_op_id() -> None:
+    # A normal, fully-qualified op_id with no ${...} passes.
+    validate_op_id_static("vmware.composite.vm.create")
+
+
+def test_template_rejects_substitution_in_step_and_verify_op_id() -> None:
+    # A runbook whose step op_id AND verify op_id both carry a ${...}
+    # token is rejected at publish/validation time -- operation identity
+    # may not be parameter-injected. The assertion executes (non-vacuous):
+    # constructing the body raises before the model is built.
+    with pytest.raises(ValidationError, match="disallowed substitution in op_id"):
+        RunbookTemplateBody(
+            title="t",
+            description="d",
+            steps=[
+                OperationCallStep(
+                    id="inject",
+                    title="t",
+                    body="b",
+                    type="operation_call",
+                    op_id="${run.params.step_op}",
+                    params={},
+                    verify=OperationCallVerify(
+                        type="operation_call",
+                        op_id="${run.params.verify_op}",
+                        params={},
+                        expect={"ok": True},
+                    ),
+                ),
+            ],
+        )
+
+
+def test_template_accepts_static_op_id_with_allowlisted_substitutions_elsewhere() -> None:
+    # The static-op_id rule does not regress the allowlist for the other
+    # fields: a body with static op_ids but ${run.target} / ${run.params.X}
+    # in body / params / expect still validates.
+    body = RunbookTemplateBody(
+        title="t",
+        description="d",
+        steps=[
+            OperationCallStep(
+                id="rotate",
+                title="Rotate",
+                body="Rotate on ${run.target}",
+                type="operation_call",
+                op_id="vault.kv.rotate",
+                params={"path": "${run.params.secret_path}"},
+                verify=OperationCallVerify(
+                    type="operation_call",
+                    op_id="vault.kv.read",
+                    params={"path": "${run.params.secret_path}"},
+                    expect={"target": "${run.target}"},
+                ),
+            ),
+        ],
+    )
+    assert body.steps[0].op_id == "vault.kv.rotate"
 
 
 # ---------------------------------------------------------------------------

--- a/docs/runbooks/authoring.md
+++ b/docs/runbooks/authoring.md
@@ -168,11 +168,16 @@ the grain wastes a publish attempt; here is what is out of bounds.
   "do these two at once".
 
 - **Template expressions beyond the allowlist.** The only substitutions
-  accepted anywhere in the body are `${run.target}` and `${run.params.X}`
+  accepted in the body are `${run.target}` and `${run.params.X}`
   (where `X` is one flat parameter name matching `[a-z_][a-z0-9_]*` — nested
   paths like `${run.params.x.y}` are rejected). Every other `${...}` pattern
   is refused when the template is validated. The check walks the whole body
   recursively, including dict keys, so there is nowhere to smuggle one in.
+  The one field that takes *no* substitution at all is `op_id`: it names the
+  operation a step or verify dispatches, which is operation identity and must
+  be fixed at publish time. Any `${...}` in an `op_id` — even an allowlisted
+  one — is rejected, so a run parameter can never redirect a published step to
+  a different operation.
 
 - **Verify DSLs.** A step's `verify` is one of exactly two shapes:
   - `confirm` — MEHO shows a `prompt` to the operator and only an affirmative


### PR DESCRIPTION
## Summary
- A runbook step's and verify's `op_id` is **operation identity** — it names the operation the step dispatches. The publish-time substitution validator (`_validate_step_ids_unique_and_substitutions_allowlisted`) walked step `body`, op-call `params`, verify `params` and verify `expect` through `validate_substitutions`, but **skipped both `op_id` fields**. A `${...}` token in `op_id` therefore reached storage unchecked and was substituted at run time (`run_service.py` `_substitute_string(verify.op_id, ...)`), letting an operator-supplied run parameter redirect a published step/verify to a different operation — parameter injection into operation identity.
- Fix: hold `op_id` to a **stricter** rule than the other fields. Operation identity must be static, so **no** substitution is legal there — not even an allowlisted `${run.target}` / `${run.params.X}`. New `validate_op_id_static` helper rejects any `${...}` in `op_id` and is wired into the template-body validator. Such a template is now refused at publish (422, error `disallowed substitution in op_id: …`) instead of silently substituted at dispatch.
- The runtime substitution at `run_service.py:1096` is left as harmless defense-in-depth: a static `op_id` passes through `_substitute_string` unchanged.
- Interpretation chosen: **no substitution in `op_id`** (the stricter of the two readings the finding allowed), documented in the helper docstring and `docs/runbooks/authoring.md`.

## Test plan
- [x] `ruff check` / `ruff format --check` — clean
- [x] `mypy src/meho_backplane/runbooks/schemas.py` — clean
- [x] `pytest tests/test_runbooks_schemas.py` — 26 passed (+6 new)
- [x] Regression test: a runbook with `${...}` in **both** step `op_id` and verify `op_id` is rejected at publish (`ValidationError`, matches `disallowed substitution in op_id`); a static `op_id` still validates; allowlisted substitutions in body/params/expect still validate.
- [x] Non-vacuity confirmed: with the gate stubbed to a no-op the malicious body builds without raising — so the assertion exercises a real behavior change.
- [x] Broader runbook suite (`run_service`, `engine`, `substitution`, `templates_api`, `template_service`, `priming`) — 133 passed, no regression.
- [x] `cd cli && make snapshot-openapi && make generate` + `git diff --exit-code -- cli/api/openapi.json cli/internal/api/client.gen.go` — clean.

## Out of scope
- The other 16 Low and 6 Info rows in the triage tracker (#101) — each landed/handled separately.
- Runtime substitution behavior in `run_service.py` is unchanged (publish-time rejection is the fix; the runtime call is now a guaranteed no-op for valid templates).

<!-- auto-implement-issue: fresh, iteration 1 -->

Refs evoila-bosnia/meho-internal#101, addressing row L13.
