### PR TITLE
fix(connectors): key ingested {+path} params on the bare name (#2066)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -90,6 +90,19 @@ connector-related release-notes line.
 
 ## [Unreleased]
 
+### Fixed — RFC6570 {+path} ingest
+
+- Ingest now keys an `in: path` parameter whose declared name carries a
+  leading RFC6570 expression operator (e.g. `{"name": "+path"}` for a
+  `/v1/{+path}` template) on the **bare** name (`path`), matching the
+  dispatch renderer (PR #2020) which strips the operator before looking the
+  value up — so these ops dispatch instead of dying with a `KeyError`. The
+  operator set is now a single shared constant, so the ingest key and the
+  render lookup can't drift again. A spec declaring both `path` and `+path`
+  path params fails ingest loudly. `preview_operation` on such an op now
+  returns a structured `dispatch_error` envelope instead of an uncaught
+  exception / MCP `-32603` (#2066).
+
 ## [0.19.0] - 2026-06-22
 
 ### Fixed — profiled vCenter legacy session-token shape

--- a/backend/src/meho_backplane/operations/_branches.py
+++ b/backend/src/meho_backplane/operations/_branches.py
@@ -40,6 +40,7 @@ from urllib.parse import quote
 from meho_backplane.auth.operator import Operator
 from meho_backplane.connectors.base import Connector
 from meho_backplane.db.models import EndpointDescriptor
+from meho_backplane.operations._rfc6570 import RFC6570_PATH_OPERATORS
 
 __all__ = [
     "IngestedRequest",
@@ -71,8 +72,12 @@ _PARAM_LOC_KEY = "x-meho-param-loc"
 # ``KeyError`` even though the param is supplied. Only ``+`` (and ``#``)
 # change the encoding safe set; the remaining operator chars are captured
 # so the regex never mis-includes a leading operator in the name, even for
-# operators this substituter does not (yet) special-case.
-_PATH_VAR_RE = re.compile(r"\{([+#./;?&]?)([^{}]+)\}")
+# operators this substituter does not (yet) special-case. The operator
+# character class is shared with the ingest parser via
+# :data:`~meho_backplane.operations._rfc6570.RFC6570_PATH_OPERATORS` so the
+# name the renderer looks up can never drift from the name ingest keys the
+# JSON-Schema property on (#2003 / #2066).
+_PATH_VAR_RE = re.compile(rf"\{{([{re.escape(RFC6570_PATH_OPERATORS)}]?)([^{{}}]+)\}}")
 
 # RFC6570 §3.2.3 reserved-expansion safe set: the gen-delims + sub-delims
 # from RFC3986 §2.2 that a ``{+var}`` / ``{#var}`` expression leaves

--- a/backend/src/meho_backplane/operations/_request_preview.py
+++ b/backend/src/meho_backplane/operations/_request_preview.py
@@ -204,9 +204,12 @@ async def _build_ingested_preview(
 
     Dispatch Step 5 (connector resolution) followed by the literal-request
     resolve (shared with :func:`dispatch_ingested`) and body redaction.
-    Returns the ``status="ok"`` envelope, or a structured ``no_connector`` /
+    Returns the ``status="ok"`` envelope, a structured ``no_connector`` /
     ``ambiguous_connector`` error envelope when the target resolves no
-    connector. Never sends the request.
+    connector, or a ``dispatch_error`` envelope when the request can't be
+    resolved (an unsubstituted path var or a descriptor missing its
+    method/path -- the two faults :func:`resolve_ingested_request` raises).
+    Never sends the request; never raises for those faults.
     """
     cls, label, exc_message = resolve_connector_or_label(target)
     if label is not None:
@@ -224,13 +227,40 @@ async def _build_ingested_preview(
 
     # The literal request, resolved through the SAME code path
     # ``dispatch_ingested`` sends through -- no drift.
-    request = await resolve_ingested_request(
-        connector=connector_instance,
-        descriptor=descriptor,
-        operator=operator,
-        target=target,
-        params=params,
-    )
+    #
+    # ``resolve_ingested_request`` deliberately *raises* on a path-template
+    # fault (``KeyError`` for an unsubstituted path var, ``RuntimeError`` for
+    # a descriptor missing its method/path) because the execute path relies on
+    # the dispatcher's structured-error mapping (``dispatcher`` generic
+    # ``except``) to convert them. The preview path has no such wrapper, so we
+    # catch those two -- and only those two -- here and map them to the same
+    # structured ``error`` envelope every other preview fault returns, honouring
+    # this module's documented never-raises contract (#2066). ``resolve_*``
+    # itself is left untouched so the execute-path contract is unchanged.
+    try:
+        request = await resolve_ingested_request(
+            connector=connector_instance,
+            descriptor=descriptor,
+            operator=operator,
+            target=target,
+            params=params,
+        )
+    except (KeyError, RuntimeError) as exc:
+        return {
+            "status": "error",
+            "op_id": op_id,
+            "connector_id": connector_id,
+            "source_kind": descriptor.source_kind,
+            "error": (
+                f"dispatch_error: the operation's request could not be resolved "
+                f"({exc}). This usually means a required path parameter was not "
+                "supplied or the descriptor is missing its method/path."
+            ),
+            "extras": {
+                "error_code": "dispatch_error",
+                "exception_message": str(exc),
+            },
+        }
     redacted_body = _redact_request_body(
         request.body, connector_id=connector_id, operator=operator, op_id=op_id
     )
@@ -288,9 +318,9 @@ async def preview_dispatch(
 
     * ``status`` -- ``"ok"`` when the request resolved; ``"error"`` on a
       structured failure (``unknown_op`` / ``invalid_params`` /
-      ``no_connector`` / ``ambiguous_connector``); ``"unavailable"`` when
-      the op is not previewable (a ``typed`` / ``composite`` op has no
-      literal HTTP request).
+      ``no_connector`` / ``ambiguous_connector`` / ``dispatch_error``);
+      ``"unavailable"`` when the op is not previewable (a ``typed`` /
+      ``composite`` op has no literal HTTP request).
     * ``op_id`` / ``connector_id`` -- echoed for correlation.
     * ``source_kind`` -- the descriptor's source kind (present whenever a
       descriptor resolved).

--- a/backend/src/meho_backplane/operations/_rfc6570.py
+++ b/backend/src/meho_backplane/operations/_rfc6570.py
@@ -54,9 +54,14 @@ def split_path_operator(name: str) -> tuple[str, str]:
     """Split a single leading RFC6570 operator off a path-variable name.
 
     Mirrors the renderer's ``_PATH_VAR_RE`` capture exactly: at most one
-    leading character is consumed as an operator, and only when it is one
-    of :data:`RFC6570_PATH_OPERATORS`. A second operator char, or an
-    operator anywhere but the first position, stays part of the name.
+    leading character is consumed as an operator, and only when it is one of
+    :data:`RFC6570_PATH_OPERATORS` **and** a non-empty name remains after it.
+    A second operator char, or an operator anywhere but the first position,
+    stays part of the name; an operator-only token (``"+"``) is treated as the
+    whole name, because ``_PATH_VAR_RE``'s ``[^{}]+`` name group requires at
+    least one character -- so for ``{+}`` the regex captures operator ``""`` /
+    name ``"+"``, and this helper must classify it identically (the module's
+    anti-drift invariant).
 
     >>> split_path_operator("+path")
     ('+', 'path')
@@ -66,10 +71,12 @@ def split_path_operator(name: str) -> tuple[str, str]:
     ('+', '+weird')
     >>> split_path_operator("path+")
     ('', 'path+')
+    >>> split_path_operator("+")
+    ('', '+')
 
     Returns ``(operator, bare_name)`` where ``operator`` is ``""`` when the
     name carries none.
     """
-    if name and name[0] in RFC6570_PATH_OPERATORS:
+    if len(name) >= 2 and name[0] in RFC6570_PATH_OPERATORS:
         return name[0], name[1:]
     return "", name

--- a/backend/src/meho_backplane/operations/_rfc6570.py
+++ b/backend/src/meho_backplane/operations/_rfc6570.py
@@ -1,0 +1,75 @@
+# SPDX-License-Identifier: Apache-2.0
+# Copyright (c) 2026 evoila Group
+
+"""Shared RFC6570 expression-operator vocabulary for ingested-op paths.
+
+A single source of truth for the one RFC6570 (URI Template) detail two
+otherwise-decoupled stages of the ingested-op pipeline must agree on:
+the set of leading **expression operators** a path-template variable may
+carry, and how the *bare* variable name is recovered from an
+operator-bearing one.
+
+* The **ingest parser** (:mod:`meho_backplane.operations.ingest.openapi`)
+  reads a vendor spec's ``parameters`` and keys each one's JSON-Schema
+  property on its name. For an ``in: path`` parameter whose declared
+  ``name`` carries an operator -- e.g. VCF Operations-for-Logs declares
+  ``{"name": "+path", "in": "path"}`` for the template ``/events/{+path}``
+  -- the property must be keyed on the **bare** name (``path``).
+* The **path renderer** (:func:`meho_backplane.operations._branches._substitute_path`)
+  expands the template at dispatch time, stripping the operator to look
+  the value up by the same bare name and choosing the encoding safe-set
+  from the operator (reserved expansion for ``+`` / ``#``).
+
+If those two stages used different operator sets the property key and the
+lookup key would disagree and the op would be undispatchable (#2003 /
+#2066). Sharing this leaf module -- which imports nothing beyond the
+standard library, so neither the heavyweight dispatch branch nor the
+dependency-free parser is coupled to the other -- makes that drift
+impossible by construction.
+
+The operator set is RFC6570 §2.2's expression operators restricted to the
+ones that can sensibly head a single-segment path variable:
+``+`` (reserved expansion, §3.2.3), ``#`` (fragment), ``.`` (label),
+``/`` (path segment), ``;`` (path-style param), ``?`` / ``&`` (form-style
+query). The reserved/query operators are not *expanded* specially by the
+single-segment substituter, but they are recognised so the operator is
+never mistaken for part of the variable name.
+"""
+
+from __future__ import annotations
+
+__all__ = [
+    "RFC6570_PATH_OPERATORS",
+    "split_path_operator",
+]
+
+# The RFC6570 §2.2 expression operators recognised at the head of a
+# single-segment path-template variable. Mirrored verbatim by the
+# renderer's ``_PATH_VAR_RE`` character class so the parser and the
+# renderer can never disagree on what counts as an operator.
+RFC6570_PATH_OPERATORS = "+#./;?&"
+
+
+def split_path_operator(name: str) -> tuple[str, str]:
+    """Split a single leading RFC6570 operator off a path-variable name.
+
+    Mirrors the renderer's ``_PATH_VAR_RE`` capture exactly: at most one
+    leading character is consumed as an operator, and only when it is one
+    of :data:`RFC6570_PATH_OPERATORS`. A second operator char, or an
+    operator anywhere but the first position, stays part of the name.
+
+    >>> split_path_operator("+path")
+    ('+', 'path')
+    >>> split_path_operator("path")
+    ('', 'path')
+    >>> split_path_operator("++weird")
+    ('+', '+weird')
+    >>> split_path_operator("path+")
+    ('', 'path+')
+
+    Returns ``(operator, bare_name)`` where ``operator`` is ``""`` when the
+    name carries none.
+    """
+    if name and name[0] in RFC6570_PATH_OPERATORS:
+        return name[0], name[1:]
+    return "", name

--- a/backend/src/meho_backplane/operations/ingest/openapi.py
+++ b/backend/src/meho_backplane/operations/ingest/openapi.py
@@ -856,30 +856,51 @@ def _populate_param_properties(
     force the caller to pass ``+path`` to satisfy validation, which the renderer
     would then fail to resolve -- the #2003/#2066 dead-op. ``descriptor.path``
     keeps the operator verbatim so the renderer still selects reserved
-    expansion. A spec declaring both ``path`` and ``+path`` collapses onto the
-    same bare key and raises :class:`InvalidSchemaError` rather than silently
-    dropping one.
+    expansion.
+
+    Two **path** parameters that collapse onto the same bare key (a spec
+    declaring both ``path`` and ``+path``) raise :class:`InvalidSchemaError`
+    rather than silently dropping one -- one of the resulting template vars
+    would be unsatisfiable. A same-name collision *across different* ``in``
+    locations (the legal OpenAPI ``id``-in-path + ``id``-in-query) is **not** a
+    fault and never raises: the params flatten to one property (the model
+    carries a single ``x-meho-param-loc`` per name), and the **path** location
+    wins regardless of declaration order so the path template var stays
+    satisfiable -- a query/header twin can't shadow it into an undispatchable
+    op. The guard is scoped to path-vs-path so it never rejects this legal
+    shape.
     """
+    path_bare_names: set[str] = set()
     for (name, location), param in merged.items():
         prop_schema = _build_param_property(param, component_schemas)
         prop_schema["x-meho-param-loc"] = location
         prop_name = name
         if location == "path":
             _operator, prop_name = split_path_operator(name)
-        if prop_name in properties:
-            # Two path params collapse onto the same property key once the
-            # RFC6570 operator is stripped (a spec declaring both ``path`` and
-            # ``+path``, in either order). A raw duplicate ``(name, in)`` can't
-            # reach here -- ``merged`` already dedupes those -- so a collision
-            # is always an operator-normalised path-param clash. Fail loudly
-            # rather than silently drop a parameter the renderer still needs.
-            raise InvalidSchemaError(
-                f"paths.{path}.{method.lower()}: path parameter {name!r} "
-                f"normalises to property key {prop_name!r} (RFC6570 operator "
-                "stripped), which is already declared; a spec must not declare "
-                "both the bare and an operator-prefixed form of one path "
-                "variable."
-            )
+            if prop_name in path_bare_names:
+                # Another path param already claimed this bare key once the
+                # RFC6570 operator was stripped (``path`` + ``+path``, in either
+                # order). Failing loudly beats silently dropping a path var the
+                # renderer still needs. Scoped to path-vs-path: a collision with
+                # a non-path param of the same name is the legal cross-location
+                # shape handled below.
+                raise InvalidSchemaError(
+                    f"paths.{path}.{method.lower()}: path parameter {name!r} "
+                    f"normalises to property key {prop_name!r} (RFC6570 operator "
+                    "stripped), which another path parameter already declares; a "
+                    "spec must not declare both the bare and an operator-prefixed "
+                    "form of one path variable."
+                )
+            path_bare_names.add(prop_name)
+        elif prop_name in path_bare_names:
+            # A non-path param shares its name with a path param already
+            # placed. Don't let it overwrite the path property -- the path var
+            # must stay substitutable or the op is undispatchable. Keep the
+            # path binding; drop this twin (it can't have its own property key
+            # in the flattened model anyway). Order-independent: the symmetric
+            # "path declared after the twin" case is handled by the path branch
+            # overwriting the twin below.
+            continue
         properties[prop_name] = prop_schema
         is_required = param.get("required") is True or location == "path"
         if is_required and prop_name not in required:

--- a/backend/src/meho_backplane/operations/ingest/openapi.py
+++ b/backend/src/meho_backplane/operations/ingest/openapi.py
@@ -62,6 +62,7 @@ from urllib.parse import urljoin, urlparse
 import httpx
 import yaml
 
+from meho_backplane.operations._rfc6570 import split_path_operator
 from meho_backplane.operations.ingest.exceptions import (
     InvalidSchemaError,
     InvalidSpecError,
@@ -758,6 +759,17 @@ def _build_parameter_schema(
     a top-level property on the returned object with the
     ``x-meho-param-loc`` extension carrying its OpenAPI ``in`` value.
 
+    A path parameter whose declared ``name`` carries a leading RFC6570
+    expression operator (``{"name": "+path", "in": "path"}`` for a
+    ``/events/{+path}`` template) is keyed on the *bare* name (``path``) so
+    the property matches the name the renderer resolves the value by after
+    stripping the operator from the template (the operator set is shared via
+    :data:`~meho_backplane.operations._rfc6570.RFC6570_PATH_OPERATORS`).
+    ``descriptor.path`` keeps the operator verbatim -- the renderer needs it
+    to select reserved expansion. A spec declaring both ``path`` and
+    ``+path`` as path parameters collides on the bare key and raises
+    :class:`InvalidSchemaError` rather than silently dropping one.
+
     Parameters may be inlined (``{"name": ..., "in": ..., "schema": ...}``)
     or referenced via ``{"$ref": "#/components/parameters/<name>"}`` —
     the second form is what ``vi-json.yaml`` uses on every operation
@@ -796,14 +808,14 @@ def _build_parameter_schema(
             continue
         merged[(name, location)] = resolved
 
-    for (name, location), param in merged.items():
-        prop_schema = _build_param_property(param, component_schemas)
-        prop_schema["x-meho-param-loc"] = location
-        properties[name] = prop_schema
-        # Path parameters are implicitly required per OpenAPI 3.x.
-        is_required = param.get("required") is True or location == "path"
-        if is_required and name not in required:
-            required.append(name)
+    _populate_param_properties(
+        merged,
+        properties=properties,
+        required=required,
+        component_schemas=component_schemas,
+        path=path,
+        method=method,
+    )
 
     body_property = _build_body_property(request_body, component_schemas, component_request_bodies)
     if body_property is not None:
@@ -817,6 +829,61 @@ def _build_parameter_schema(
     if required:
         schema["required"] = required
     return schema
+
+
+def _populate_param_properties(
+    merged: dict[tuple[str, str], dict[str, Any]],
+    *,
+    properties: dict[str, object],
+    required: list[str],
+    component_schemas: dict[str, Any],
+    path: str,
+    method: str,
+) -> None:
+    """Add one JSON-Schema property per merged parameter, keyed on its name.
+
+    Mutates *properties* and *required* in place (the body property is added by
+    the caller afterwards). Each parameter's ``x-meho-param-loc`` carries its
+    OpenAPI ``in``; a ``path`` parameter is implicitly required per OpenAPI 3.x.
+
+    A path parameter whose declared ``name`` carries a leading RFC6570
+    expression operator (e.g. VCF Operations-for-Logs declares
+    ``{"name": "+path"}`` for the template ``/events/{+path}``) is keyed on the
+    *bare* name (``path``): that is the name the renderer
+    (:func:`~meho_backplane.operations._branches._substitute_path`) resolves
+    the value by after stripping the operator from the template, and so the
+    name the caller supplies. Keeping the operator in the property key would
+    force the caller to pass ``+path`` to satisfy validation, which the renderer
+    would then fail to resolve -- the #2003/#2066 dead-op. ``descriptor.path``
+    keeps the operator verbatim so the renderer still selects reserved
+    expansion. A spec declaring both ``path`` and ``+path`` collapses onto the
+    same bare key and raises :class:`InvalidSchemaError` rather than silently
+    dropping one.
+    """
+    for (name, location), param in merged.items():
+        prop_schema = _build_param_property(param, component_schemas)
+        prop_schema["x-meho-param-loc"] = location
+        prop_name = name
+        if location == "path":
+            _operator, prop_name = split_path_operator(name)
+        if prop_name in properties:
+            # Two path params collapse onto the same property key once the
+            # RFC6570 operator is stripped (a spec declaring both ``path`` and
+            # ``+path``, in either order). A raw duplicate ``(name, in)`` can't
+            # reach here -- ``merged`` already dedupes those -- so a collision
+            # is always an operator-normalised path-param clash. Fail loudly
+            # rather than silently drop a parameter the renderer still needs.
+            raise InvalidSchemaError(
+                f"paths.{path}.{method.lower()}: path parameter {name!r} "
+                f"normalises to property key {prop_name!r} (RFC6570 operator "
+                "stripped), which is already declared; a spec must not declare "
+                "both the bare and an operator-prefixed form of one path "
+                "variable."
+            )
+        properties[prop_name] = prop_schema
+        is_required = param.get("required") is True or location == "path"
+        if is_required and prop_name not in required:
+            required.append(prop_name)
 
 
 def _build_param_property(

--- a/backend/tests/test_operations_ingest_openapi.py
+++ b/backend/tests/test_operations_ingest_openapi.py
@@ -351,6 +351,57 @@ def test_parse_bare_and_operator_path_param_collision_raises() -> None:
             parse_openapi(url)
 
 
+def _same_name_path_query_spec(*, path_first: bool) -> bytes:
+    """A legal OpenAPI op declaring ``id`` in BOTH path and query.
+
+    OpenAPI permits the same parameter ``name`` in different ``in`` locations.
+    The two are emitted in *path_first* or query-first order to prove the
+    flatten result is order-independent.
+    """
+    path_param = {"name": "id", "in": "path", "required": True, "schema": {"type": "string"}}
+    query_param = {"name": "id", "in": "query", "required": False, "schema": {"type": "string"}}
+    params = [path_param, query_param] if path_first else [query_param, path_param]
+    return yaml.safe_dump(
+        {
+            "openapi": "3.0.3",
+            "info": {"title": "same-name-diff-loc", "version": "1.0.0"},
+            "paths": {
+                "/v1/items/{id}": {
+                    "get": {
+                        "operationId": "getItem",
+                        "parameters": params,
+                        "responses": {"200": {"description": "ok"}},
+                    }
+                }
+            },
+        }
+    ).encode()
+
+
+@pytest.mark.parametrize("path_first", [True, False])
+def test_parse_same_name_path_and_query_param_ingests_path_wins(path_first: bool) -> None:
+    """``id`` in path AND query is legal: it ingests, and the path location wins.
+
+    Regression for the over-broad collision guard (#2066 review B1): the guard
+    must fire only on path-vs-path bare-name collisions, never on the legal
+    same-name-across-different-``in`` shape. The flattened single property keeps
+    ``x-meho-param-loc: path`` regardless of declaration order so the path
+    template var ``{id}`` stays substitutable (the op stays dispatchable); a
+    query twin can't shadow it into an undispatchable op.
+    """
+    spec = _same_name_path_query_spec(path_first=path_first)
+    with respx.mock(assert_all_called=False) as router:
+        url = _mock_yaml_spec(router, "same_name.yaml", spec)
+        rows = parse_openapi(url)  # must NOT raise
+    op = _by_op_id(rows)["GET:/v1/items/{id}"]
+    props = op.parameter_schema["properties"]
+    assert "id" in props
+    # Path location wins (order-independent) so the path var is satisfiable.
+    assert props["id"]["x-meho-param-loc"] == "path"
+    # Path params are implicitly required.
+    assert "id" in op.parameter_schema["required"]
+
+
 def test_parse_petstore_30_request_body_inlined_with_param_loc() -> None:
     with respx.mock(assert_all_called=False) as router:
         url = _mock_yaml_spec(router, "petstore_30.yaml", PETSTORE_30.read_bytes())

--- a/backend/tests/test_operations_ingest_openapi.py
+++ b/backend/tests/test_operations_ingest_openapi.py
@@ -220,6 +220,137 @@ def test_parse_petstore_30_path_param_is_required() -> None:
     assert "petId" in get_pet.parameter_schema["required"]
 
 
+# -- RFC6570 operator-bearing path-param names (#2003 / #2066) --------------
+
+# A minimal spec whose path parameter declares a leading RFC6570 reserved-
+# expansion operator in its ``name`` -- the shape VCF Operations-for-Logs
+# uses for ``/events/{+path}``. Built inline (not a fixture file) so the
+# operator-bearing name is right next to the assertion that the parser keys
+# the property on the *bare* name.
+_PLUS_PATH_SPEC = yaml.safe_dump(
+    {
+        "openapi": "3.0.3",
+        "info": {"title": "plus-path", "version": "1.0.0"},
+        "paths": {
+            "/v1/{+path}": {
+                "get": {
+                    "operationId": "readPath",
+                    "parameters": [
+                        {
+                            "name": "+path",
+                            "in": "path",
+                            "required": True,
+                            "schema": {"type": "string"},
+                        }
+                    ],
+                    "responses": {"200": {"description": "ok"}},
+                }
+            }
+        },
+    }
+).encode()
+
+
+def test_parse_operator_bearing_path_param_keyed_on_bare_name() -> None:
+    """A ``{"name": "+path", "in": "path"}`` param is keyed on the bare ``path``.
+
+    The ingest half of #2003 (#2066): the renderer strips the RFC6570
+    operator from the ``{+path}`` template and looks the value up by ``path``,
+    so the parser must register the JSON-Schema property under the same bare
+    name -- not ``+path`` -- or the op is undispatchable.
+    """
+    with respx.mock(assert_all_called=False) as router:
+        url = _mock_yaml_spec(router, "plus_path.yaml", _PLUS_PATH_SPEC)
+        rows = parse_openapi(url)
+    op = _by_op_id(rows)["GET:/v1/{+path}"]
+    props = op.parameter_schema["properties"]
+    assert isinstance(props, dict)
+    # Keyed on the bare name -- the operator is gone from the property key.
+    assert "path" in props
+    assert "+path" not in props
+    assert props["path"]["x-meho-param-loc"] == "path"
+    # Required under the bare name too.
+    assert "path" in op.parameter_schema["required"]
+    assert "+path" not in op.parameter_schema["required"]
+    # The template keeps the operator verbatim -- the renderer needs it to
+    # select reserved expansion so the value's ``/`` stays literal.
+    assert op.path == "/v1/{+path}"
+
+
+def test_parse_path_param_without_operator_unchanged() -> None:
+    """A plain ``{"name": "cluster"}`` path param keeps its name verbatim."""
+    spec = yaml.safe_dump(
+        {
+            "openapi": "3.0.3",
+            "info": {"title": "plain-path", "version": "1.0.0"},
+            "paths": {
+                "/v1/{cluster}": {
+                    "get": {
+                        "operationId": "readCluster",
+                        "parameters": [
+                            {
+                                "name": "cluster",
+                                "in": "path",
+                                "required": True,
+                                "schema": {"type": "string"},
+                            }
+                        ],
+                        "responses": {"200": {"description": "ok"}},
+                    }
+                }
+            },
+        }
+    ).encode()
+    with respx.mock(assert_all_called=False) as router:
+        url = _mock_yaml_spec(router, "plain_path.yaml", spec)
+        rows = parse_openapi(url)
+    op = _by_op_id(rows)["GET:/v1/{cluster}"]
+    props = op.parameter_schema["properties"]
+    assert props["cluster"]["x-meho-param-loc"] == "path"
+    assert "cluster" in op.parameter_schema["required"]
+
+
+def test_parse_bare_and_operator_path_param_collision_raises() -> None:
+    """A spec declaring both ``path`` and ``+path`` path params fails loudly.
+
+    Both collapse onto the bare property key ``path``; silently keeping one
+    would drop a parameter the renderer still needs, so ingest of that op
+    raises :class:`InvalidSchemaError` rather than half-building it.
+    """
+    spec = yaml.safe_dump(
+        {
+            "openapi": "3.0.3",
+            "info": {"title": "collision", "version": "1.0.0"},
+            "paths": {
+                "/v1/{path}/{+path}": {
+                    "get": {
+                        "operationId": "collide",
+                        "parameters": [
+                            {
+                                "name": "path",
+                                "in": "path",
+                                "required": True,
+                                "schema": {"type": "string"},
+                            },
+                            {
+                                "name": "+path",
+                                "in": "path",
+                                "required": True,
+                                "schema": {"type": "string"},
+                            },
+                        ],
+                        "responses": {"200": {"description": "ok"}},
+                    }
+                }
+            },
+        }
+    ).encode()
+    with respx.mock(assert_all_called=False) as router:
+        url = _mock_yaml_spec(router, "collision.yaml", spec)
+        with pytest.raises(InvalidSchemaError, match="normalises to property key 'path'"):
+            parse_openapi(url)
+
+
 def test_parse_petstore_30_request_body_inlined_with_param_loc() -> None:
     with respx.mock(assert_all_called=False) as router:
         url = _mock_yaml_spec(router, "petstore_30.yaml", PETSTORE_30.read_bytes())

--- a/backend/tests/test_operations_request_preview.py
+++ b/backend/tests/test_operations_request_preview.py
@@ -835,3 +835,206 @@ async def test_preview_operation_missing_target_name_raises_valueerror() -> None
                 "params": {},
             },
         )
+
+
+# ---------------------------------------------------------------------------
+# RFC6570 {+path} end-to-end: dispatch succeeds + preview never raises (#2066)
+# ---------------------------------------------------------------------------
+#
+# The descriptor shape these tests seed is exactly what the ingest parser now
+# produces for an operator-bearing path param ({"name": "+path"} keyed on the
+# bare ``path`` -- proven by the parser-level tests in
+# tests/test_operations_ingest_openapi.py): template carries the operator
+# verbatim, the parameter_schema property is keyed on the bare name. These
+# tests close the loop by proving that shape dispatches and previews cleanly.
+
+
+@pytest.mark.asyncio
+async def test_call_operation_dispatches_operator_bearing_path_param(
+    stub_embedding_service: AsyncMock,
+    session: AsyncSession,
+) -> None:
+    """``call_operation`` on a ``/v1/{+path}`` op dispatches via reserved expansion.
+
+    The renderer strips the ``+`` operator, looks the value up by the bare
+    ``path`` the schema keys, and reserved-expands it so ``/`` stays literal.
+    No ``KeyError`` reaches the wire -- the #2066 dead-op is gone.
+    """
+    from meho_backplane.operations.dispatcher import dispatch
+
+    connector = _register_recording_gh_connector()
+    await _insert_ingested_descriptor(
+        session=session,
+        product="gh",
+        version="3",
+        impl_id="gh-rest",
+        op_id="GET:/v1/{+path}",
+        embedding=stub_embedding_service.encode_one.return_value,
+        method="GET",
+        path="/v1/{+path}",
+        parameter_schema={
+            "type": "object",
+            "properties": {"path": {"type": "string", "x-meho-param-loc": "path"}},
+            "required": ["path"],
+        },
+    )
+
+    result = await dispatch(
+        operator=_make_operator(),
+        connector_id="gh-rest-3",
+        op_id="GET:/v1/{+path}",
+        target=_FakeTarget(name="gh-prod"),
+        params={"path": "events/CONTAINS error"},
+    )
+
+    assert result.status == "ok", result.error
+    assert len(connector.calls) == 1
+    sent = connector.calls[0]
+    assert sent["verb"] == "GET"
+    # Reserved expansion: the slash stays literal, the space is still encoded.
+    assert sent["path"] == "/v1/events/CONTAINS%20error"
+
+
+@pytest.mark.asyncio
+async def test_preview_operator_bearing_path_param_resolves_clean(
+    stub_embedding_service: AsyncMock,
+    session: AsyncSession,
+    captured_events: list[BroadcastEvent],
+) -> None:
+    """Previewing the same ``/v1/{+path}`` op returns the reserved-expanded path."""
+    connector = _register_recording_gh_connector()
+    await _insert_ingested_descriptor(
+        session=session,
+        product="gh",
+        version="3",
+        impl_id="gh-rest",
+        op_id="GET:/v1/{+path}",
+        embedding=stub_embedding_service.encode_one.return_value,
+        method="GET",
+        path="/v1/{+path}",
+        parameter_schema={
+            "type": "object",
+            "properties": {"path": {"type": "string", "x-meho-param-loc": "path"}},
+            "required": ["path"],
+        },
+    )
+
+    envelope = await preview_dispatch(
+        operator=_make_operator(),
+        connector_id="gh-rest-3",
+        op_id="GET:/v1/{+path}",
+        target=_FakeTarget(name="gh-prod"),
+        params={"path": "a/b/c"},
+    )
+
+    assert envelope["status"] == "ok"
+    assert envelope["resolved_path"] == "/v1/a/b/c"
+    assert connector.calls == []
+
+
+@pytest.mark.asyncio
+async def test_preview_unresolvable_path_var_returns_structured_dispatch_error(
+    stub_embedding_service: AsyncMock,
+    session: AsyncSession,
+    captured_events: list[BroadcastEvent],
+) -> None:
+    """A path template var with no schema property -> structured ``dispatch_error``.
+
+    Restores the preview's never-raises contract (#2066): pre-fix the
+    ``KeyError`` ``resolve_ingested_request`` raises for an unsubstituted path
+    var escaped the preview path uncaught and surfaced as MCP ``-32603`` /
+    HTTP 500. Here the template needs ``{+path}`` but the parameter_schema
+    declares no ``path`` property, so ``validate_params`` passes (nothing is
+    required) yet the renderer can't resolve the var. The preview must return a
+    structured ``status="error"`` envelope -- never an uncaught exception.
+    """
+    connector = _register_recording_gh_connector()
+    await _insert_ingested_descriptor(
+        session=session,
+        product="gh",
+        version="3",
+        impl_id="gh-rest",
+        op_id="GET:/v1/{+path}",
+        embedding=stub_embedding_service.encode_one.return_value,
+        method="GET",
+        path="/v1/{+path}",
+        # Empty schema: nothing required, so validation passes; the renderer
+        # then KeyErrors on the unsatisfiable ``{+path}`` template var.
+        parameter_schema={"type": "object", "properties": {}},
+    )
+
+    envelope = await preview_dispatch(
+        operator=_make_operator(),
+        connector_id="gh-rest-3",
+        op_id="GET:/v1/{+path}",
+        target=_FakeTarget(name="gh-prod"),
+        params={},
+    )
+
+    assert envelope["status"] == "error"
+    assert envelope["error"].startswith("dispatch_error:")
+    assert envelope["extras"]["error_code"] == "dispatch_error"
+    assert "path" in envelope["extras"]["exception_message"]
+    assert connector.calls == []
+
+
+@pytest.mark.asyncio
+async def test_preview_operation_meta_tool_missing_path_var_never_raises(
+    stub_embedding_service: AsyncMock,
+    session: AsyncSession,
+    captured_events: list[BroadcastEvent],
+) -> None:
+    """The shared ``preview_operation`` funnel returns the structured error too.
+
+    Proves the never-raises fix holds through the meta-tool both REST and MCP
+    call -- the MCP ``preview_operation`` tool is a thin shim over this
+    function, so an uncaught exception here would surface as ``-32603``.
+    """
+    _register_recording_gh_connector()
+    await _insert_ingested_descriptor(
+        session=session,
+        product="gh",
+        version="3",
+        impl_id="gh-rest",
+        op_id="GET:/v1/{+path}",
+        embedding=stub_embedding_service.encode_one.return_value,
+        method="GET",
+        path="/v1/{+path}",
+        parameter_schema={"type": "object", "properties": {}},
+    )
+    target_id = uuid.uuid4()
+    sessionmaker = get_sessionmaker()
+    async with sessionmaker() as s, s.begin():
+        s.add(
+            TargetORM(
+                id=target_id,
+                tenant_id=_TENANT,
+                name="gh-prod",
+                aliases=[],
+                product="gh",
+                version="3",
+                host="api.github.com",
+                port=443,
+                fqdn=None,
+                secret_ref=None,
+                auth_model="shared_service_account",
+                vpn_required=False,
+                extras={},
+                notes=None,
+                created_at=datetime.now(UTC),
+                updated_at=datetime.now(UTC),
+            )
+        )
+
+    envelope = await preview_operation(
+        _make_operator(),
+        {
+            "connector_id": "gh-rest-3",
+            "op_id": "GET:/v1/{+path}",
+            "target": "gh-prod",
+            "params": {},
+        },
+    )
+
+    assert envelope["status"] == "error"
+    assert envelope["extras"]["error_code"] == "dispatch_error"

--- a/backend/tests/test_operations_request_preview.py
+++ b/backend/tests/test_operations_request_preview.py
@@ -1038,3 +1038,49 @@ async def test_preview_operation_meta_tool_missing_path_var_never_raises(
 
     assert envelope["status"] == "error"
     assert envelope["extras"]["error_code"] == "dispatch_error"
+
+
+@pytest.mark.asyncio
+async def test_call_operation_same_name_path_and_query_param_dispatches(
+    stub_embedding_service: AsyncMock,
+    session: AsyncSession,
+) -> None:
+    """An op with ``id`` in both path and query dispatches: the path var substitutes.
+
+    End-to-end proof for #2066 review B1 — the legal same-name-across-locations
+    shape is dispatchable. Ingest keys the flattened property on ``id`` with
+    ``x-meho-param-loc: path`` (path wins), so the caller's ``id`` routes to the
+    path bucket and ``/v1/items/{id}`` substitutes with no ``KeyError``.
+    """
+    from meho_backplane.operations.dispatcher import dispatch
+
+    connector = _register_recording_gh_connector()
+    await _insert_ingested_descriptor(
+        session=session,
+        product="gh",
+        version="3",
+        impl_id="gh-rest",
+        op_id="GET:/v1/items/{id}",
+        embedding=stub_embedding_service.encode_one.return_value,
+        method="GET",
+        path="/v1/items/{id}",
+        # The shape ingest produces for ``id`` in path + query: one property,
+        # path location wins (proven by the parser test).
+        parameter_schema={
+            "type": "object",
+            "properties": {"id": {"type": "string", "x-meho-param-loc": "path"}},
+            "required": ["id"],
+        },
+    )
+
+    result = await dispatch(
+        operator=_make_operator(),
+        connector_id="gh-rest-3",
+        op_id="GET:/v1/items/{id}",
+        target=_FakeTarget(name="gh-prod"),
+        params={"id": "42"},
+    )
+
+    assert result.status == "ok", result.error
+    assert len(connector.calls) == 1
+    assert connector.calls[0]["path"] == "/v1/items/42"

--- a/backend/tests/test_operations_rfc6570.py
+++ b/backend/tests/test_operations_rfc6570.py
@@ -1,0 +1,63 @@
+# SPDX-License-Identifier: Apache-2.0
+# Copyright (c) 2026 evoila Group
+
+"""Unit tests for the shared RFC6570 path-operator vocabulary (#2066).
+
+:mod:`meho_backplane.operations._rfc6570` is the single source of truth the
+ingest parser and the path renderer share so the property key the parser
+registers can never drift from the bare name the renderer looks up. These
+tests pin :func:`split_path_operator`'s exact (single-leading-operator)
+behaviour and assert the renderer's regex operator class is built from the
+same constant.
+"""
+
+from __future__ import annotations
+
+import pytest
+
+from meho_backplane.operations._branches import _PATH_VAR_RE
+from meho_backplane.operations._rfc6570 import (
+    RFC6570_PATH_OPERATORS,
+    split_path_operator,
+)
+
+
+@pytest.mark.parametrize(
+    ("name", "expected"),
+    [
+        ("+path", ("+", "path")),
+        ("#frag", ("#", "frag")),
+        (".label", (".", "label")),
+        ("/seg", ("/", "seg")),
+        (";p", (";", "p")),
+        ("?q", ("?", "q")),
+        ("&r", ("&", "r")),
+        ("path", ("", "path")),  # no operator
+        ("++weird", ("+", "+weird")),  # only the first leading char is consumed
+        ("path+", ("", "path+")),  # a trailing operator stays part of the name
+        ("", ("", "")),  # empty name
+    ],
+)
+def test_split_path_operator(name: str, expected: tuple[str, str]) -> None:
+    assert split_path_operator(name) == expected
+
+
+def test_renderer_regex_uses_the_shared_operator_set() -> None:
+    """Every shared operator is recognised by the renderer regex, and vice versa.
+
+    The anti-drift guarantee: the parser strips exactly the operators the
+    renderer recognises, because both read :data:`RFC6570_PATH_OPERATORS`.
+    Asserting the renderer's compiled regex strips each shared operator (and
+    that a non-operator leading char is *not* stripped) keeps the two stages
+    locked together even if the regex construction is later refactored.
+    """
+    for op in RFC6570_PATH_OPERATORS:
+        match = _PATH_VAR_RE.fullmatch(f"{{{op}name}}")
+        assert match is not None
+        assert match.group(1) == op
+        assert match.group(2) == "name"
+    # A char outside the set is not treated as an operator (stays in the name).
+    no_op = _PATH_VAR_RE.fullmatch("{xname}")
+    assert no_op is not None
+    assert no_op.group(1) == ""
+    assert no_op.group(2) == "xname"

--- a/backend/tests/test_operations_rfc6570.py
+++ b/backend/tests/test_operations_rfc6570.py
@@ -36,6 +36,12 @@ from meho_backplane.operations._rfc6570 import (
         ("++weird", ("+", "+weird")),  # only the first leading char is consumed
         ("path+", ("", "path+")),  # a trailing operator stays part of the name
         ("", ("", "")),  # empty name
+        # Operator-only tokens: stripping would leave an empty name, which
+        # ``_PATH_VAR_RE``'s ``[^{}]+`` group can't match -- so the operator is
+        # the whole name, no operator stripped (m1, #2066).
+        ("+", ("", "+")),
+        ("#", ("", "#")),
+        ("&", ("", "&")),
     ],
 )
 def test_split_path_operator(name: str, expected: tuple[str, str]) -> None:
@@ -61,3 +67,43 @@ def test_renderer_regex_uses_the_shared_operator_set() -> None:
     assert no_op is not None
     assert no_op.group(1) == ""
     assert no_op.group(2) == "xname"
+
+
+@pytest.mark.parametrize(
+    "name",
+    [
+        "+",  # operator-only: m1 regression
+        "#",
+        ".",
+        "/",
+        ";",
+        "?",
+        "&",
+        "+path",
+        "path",
+        "++weird",
+        "path+",
+        "+a",
+        "ab",
+    ],
+)
+def test_split_path_operator_agrees_with_renderer_regex(name: str) -> None:
+    """``split_path_operator`` classifies a var name identically to ``_PATH_VAR_RE``.
+
+    The module's anti-drift invariant: for any single-segment template
+    ``{<name>}``, the (operator, bare-name) split the parser computes must equal
+    the one the renderer's compiled regex computes. The load-bearing case is an
+    **operator-only** token like ``{+}``: the regex's ``[^{}]+`` name group
+    can't match an empty name, so it captures operator ``""`` / name ``"+"`` --
+    and ``split_path_operator`` must agree (m1, #2066), or the parser would key
+    a property the renderer can't look up (or vice versa).
+    """
+    split = split_path_operator(name)
+    match = _PATH_VAR_RE.fullmatch(f"{{{name}}}")
+    if match is None:
+        # The regex rejects the whole ``{<name>}`` as a template var (the name
+        # group couldn't match). The only way that happens for a non-empty name
+        # is never, given ``[^{}]+`` -- assert the contract holds regardless.
+        assert split == ("", name)
+    else:
+        assert (match.group(1), match.group(2)) == split

--- a/docs/codebase/dispatch-request-preview.md
+++ b/docs/codebase/dispatch-request-preview.md
@@ -119,7 +119,7 @@ surfaces stay `OPERATOR`-gated at the route / tool layer.
 | `status` | meaning | extra fields |
 |---|---|---|
 | `ok` | request resolved | `method`, `resolved_path`, `query` (object/null), `redacted_body` (object/null), `source_kind` |
-| `error` | structured failure | `error` (`"<code>: …"`), `extras.error_code` (`unknown_op` / `invalid_params` / `no_connector` / `ambiguous_connector`) + per-code detail |
+| `error` | structured failure | `error` (`"<code>: …"`), `extras.error_code` (`unknown_op` / `invalid_params` / `no_connector` / `ambiguous_connector` / `dispatch_error`) + per-code detail |
 | `unavailable` | not an HTTP-ingested op | `source_kind`, `extras.error_code=preview_unavailable`, `extras.reason=not_ingested` |
 
 Operator-input faults come back **inside** the envelope (not as
@@ -127,6 +127,18 @@ exceptions), mirroring the dispatcher's never-raises contract so the REST
 route and MCP tool keep one uniform shape. The only exception the
 meta-tool raises is the missing-`target.name` `ValueError`, which the
 route maps to a `400` (identical to `/call`).
+
+The shared resolver `resolve_ingested_request` deliberately *raises* on a
+path-template fault — `KeyError` for an unsubstituted path var, `RuntimeError`
+for a descriptor missing its method/path — because the **execute** path relies
+on the dispatcher's generic `except` to convert them to a structured
+`connector_error`. The preview path has no such wrapper, so
+`_build_ingested_preview` catches exactly those two and maps them to a
+`dispatch_error` envelope (#2066). Before that wrap they escaped uncaught and
+surfaced as MCP `-32603` / HTTP 500 — violating the never-raises contract this
+table documents. `resolve_ingested_request` itself is unchanged (the
+execute-path contract must keep raising), so the two surfaces stay aligned via
+their respective wrappers, not a shared swallow.
 
 ## Redaction
 

--- a/docs/codebase/spec-ingestion.md
+++ b/docs/codebase/spec-ingestion.md
@@ -458,8 +458,13 @@ verbatim — the renderer needs it to pick reserved expansion. The operator set
 both stages strip is shared via `operations/_rfc6570.RFC6570_PATH_OPERATORS`,
 so the property key and the lookup key can never drift (the keying-vs-rendering
 mismatch that made these ops undispatchable at v0.19.0). A spec declaring both
-`path` and `+path` as path parameters collapses onto the same bare key and
-raises `InvalidSchemaError` rather than silently dropping one.
+`path` and `+path` as **path** parameters collapses onto the same bare key and
+raises `InvalidSchemaError` rather than silently dropping one. The collision
+guard is scoped to path-vs-path only: a name shared *across different* `in`
+locations (the legal OpenAPI `id`-in-path + `id`-in-query) is **not** a fault —
+it flattens to one property, and the **path** location wins regardless of
+declaration order so the path template var stays substitutable (a query/header
+twin can't shadow the op into being undispatchable).
 
 ### `GroupProposal` / `GroupingResult` / `GroupingConfig` (`ingest/llm_groups.py`)
 

--- a/docs/codebase/spec-ingestion.md
+++ b/docs/codebase/spec-ingestion.md
@@ -444,6 +444,23 @@ owns `group_id` (NULL until grouping runs). T4 owns
 `custom_description`, `custom_notes`, `llm_instructions` (operator-
 authored overrides at review time).
 
+#### RFC6570 operator-bearing path-param names (#2003 / #2066)
+
+A vendor spec may declare an `in: path` parameter whose `name` carries a
+leading RFC6570 expression operator — VCF Operations-for-Logs uses
+`{"name": "+path", "in": "path"}` for the template `/events/{+path}`
+(reserved expansion, so the constraint's `/` stays literal on the wire). The
+parameter-schema builder keys the JSON-Schema property on the **bare** name
+(`path`), not the operator-bearing one, because that is the name the dispatch
+renderer (`operations/_branches._substitute_path`) resolves the value by after
+stripping the operator from the template. `descriptor.path` keeps the operator
+verbatim — the renderer needs it to pick reserved expansion. The operator set
+both stages strip is shared via `operations/_rfc6570.RFC6570_PATH_OPERATORS`,
+so the property key and the lookup key can never drift (the keying-vs-rendering
+mismatch that made these ops undispatchable at v0.19.0). A spec declaring both
+`path` and `+path` as path parameters collapses onto the same bare key and
+raises `InvalidSchemaError` rather than silently dropping one.
+
 ### `GroupProposal` / `GroupingResult` / `GroupingConfig` (`ingest/llm_groups.py`)
 
 Pydantic `frozen=True` model + two frozen-slotted dataclasses, one


### PR DESCRIPTION
## Summary

- Lands the **un-landed ingest half of #2003** (the renderer half, PR #2020, already merged). An ingested OpenAPI op whose path parameter declares a leading RFC6570 expression operator in its name — e.g. VCF Operations-for-Logs declares `{"name": "+path", "in": "path"}` for `/events/{+path}` — was undispatchable at v0.19.0 because ingest keyed the JSON-Schema property on the raw `+path` while the renderer looks the value up by the bare `path`. No caller param-set satisfied both halves (both vRLI events ops were dead reads).
- **Ingest now keys an `in: path` param on the bare name** (operator stripped), matching the renderer. `descriptor.path` keeps the operator verbatim so the renderer still selects reserved expansion (the value's `/` stays literal on the wire).
- **The operator set is now a single shared constant** (`operations/_rfc6570.RFC6570_PATH_OPERATORS`) consumed by both the renderer regex and the ingest strip — so the ingest key and the render lookup can't drift again (the root cause of this bug class).
- **A spec declaring both `path` and `+path`** path params fails ingest loudly (`InvalidSchemaError`) instead of silently dropping one.
- **`preview_operation` honours its documented never-raises contract again**: the preview path catches the `KeyError`/`RuntimeError` `resolve_ingested_request` raises and maps them to a structured `dispatch_error` envelope, instead of letting the exception escape as MCP `-32603` / HTTP 500. `resolve_ingested_request` itself is unchanged (the execute path relies on the dispatcher's structured mapping), so the two surfaces stay aligned via their own wrappers.

## Test plan

- [x] `ruff check src/ tests/` — clean
- [x] `ruff format --check src/ tests/` — clean (1128 files)
- [x] `mypy src/` — clean (563 source files)
- [x] Full CI unit lane (`pytest -n3 --dist loadscope --ignore=tests/integration tests/`) — **8746 passed, 195 skipped**
- [x] Blast-radius sweep (dispatch + ingest + preview + connector e2e + MCP + UI) — 544 passed
- [x] **AC**: real `parse_openapi` over a `{+path}` spec keys the property on bare `path` with `x-meho-param-loc: "path"` (`test_parse_operator_bearing_path_param_keyed_on_bare_name`)
- [x] **AC**: `call_operation` on a `/v1/{+path}` op dispatches; the wire path is `/v1/events/CONTAINS%20error` (slash literal, space encoded) — no `KeyError` (`test_call_operation_dispatches_operator_bearing_path_param`)
- [x] **AC**: `preview_operation` on a missing/unresolvable path var returns a structured `dispatch_error` envelope — never `-32603` — via both `preview_dispatch` and the meta-tool funnel
- [x] **AC**: a `path` + `+path` collision raises `InvalidSchemaError` at ingest
- [x] OpenAPI snapshot: **proven zero delta** — a fresh regen is byte-identical with and without this change; `cli/api/openapi.json` left untouched

## Out of scope

- The renderer-side reserved-expansion encoding itself (shipped by #2020) — unchanged.
- No `uritemplate` dependency — the hand-rolled single-segment substitution stays (per #2003).
- #1796 (servers base-path) — a separate dispatch defect on the same vRLI ops.
- **Pre-existing, unrelated:** `cli/api/openapi.json` on `main` is ~10k lines stale vs a fresh regen (FastAPI 0.137 route-nesting). This PR does **not** touch the snapshot (committing the regen would inject a 10k-line unrelated diff); a snapshot refresh is a separate task.

Closes #2066


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved handling of RFC6570-style path parameters so reserved path values work correctly during dispatch and preview.
  * Preview requests now return a structured error response instead of failing with an uncaught exception when a path value can’t be resolved.
  * Specs that define both bare and operator-prefixed versions of the same path parameter now fail fast with a clear validation error.

* **Documentation**
  * Updated release and API docs to reflect the new preview error format and RFC6570 path-parameter behavior.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->