### PR TITLE
fix(connectors): fold relative OpenAPI servers[].url base into ingested op paths

### DIFF
--- a/backend/src/meho_backplane/operations/ingest/openapi.py
+++ b/backend/src/meho_backplane/operations/ingest/openapi.py
@@ -146,6 +146,88 @@ _INLINE_SPEC_ONRAMP_REMEDIATION = (
 # ``{filter.names}``. Compiled once and reused per operation.
 _PATH_PARAM_RE = re.compile(r"\{([^{}/]+)\}")
 
+
+def _require_spec_mapping(value: Any, label: str) -> dict[str, Any]:
+    """Return ``value`` as a dict, or raise :exc:`InvalidSpecError` naming ``label``.
+
+    The OpenAPI ``components`` container and each of its sub-objects
+    (``schemas`` / ``parameters`` / ``responses`` / ``requestBodies``)
+    must be mappings; a scalar or list there is a malformed spec. Callers
+    pass ``spec.get(key) or {}`` so an absent key arrives as the empty
+    mapping and validates trivially.
+    """
+    if not isinstance(value, dict):
+        raise InvalidSpecError(f"{label!r} must be a mapping, got {type(value).__name__}")
+    return cast(dict[str, Any], value)
+
+
+def _server_base_path(servers: Any) -> str:
+    """Return the relative path prefix declared by ``servers[0].url``.
+
+    OpenAPI resolves an operation's effective URL by *appending* the
+    path-item key to the Server Object's ``url`` (OAS 3.1 §4.8.5: "The
+    path is appended (no relative URL resolution) to the expanded URL
+    from the Server Object's ``url`` field"). meho dispatches against the
+    operator-configured target host, so only the **path** component of a
+    *relative* server base is honoured -- it is folded into each op's
+    path at ingest time (#1796) so the dispatch path stays unchanged.
+
+    Returns the normalised base path (leading ``/``, no trailing ``/``)
+    for a relative server url such as ``/api/v2``; returns ``""`` (no
+    fold, today's behaviour) when:
+
+    * ``servers`` is absent / empty / malformed,
+    * the first server url is ``/`` or empty (a no-op base),
+    * the first server url is **absolute** (has a scheme or authority) --
+      an absolute base points at a spec-declared host, which meho does
+      not dispatch against (SSRF / topology boundary, out of scope per
+      #1796); only its path would be foldable and conflating the two is
+      a footgun, so absolute bases are left entirely to the operator's
+      target configuration.
+
+    Only the first server entry is consulted: OpenAPI allows multiple
+    servers for environment selection, but meho dispatches against one
+    operator-configured target, so the first (primary) base is the one
+    that pairs with it.
+    """
+    if not isinstance(servers, list) or not servers:
+        return ""
+    first = servers[0]
+    if not isinstance(first, dict):
+        return ""
+    url = first.get("url")
+    if not isinstance(url, str) or not url:
+        return ""
+    parsed = urlparse(url)
+    if parsed.scheme or parsed.netloc:
+        # Absolute URL (or protocol-relative ``//host/...``) -- out of
+        # scope; the host is the operator's target, not the spec's.
+        return ""
+    base = parsed.path.rstrip("/")
+    if not base or base == "/":
+        return ""
+    if not base.startswith("/"):
+        base = "/" + base
+    return base
+
+
+def _fold_server_base(base: str, path: str) -> str:
+    """Append an operation ``path`` to the relative server ``base``.
+
+    ``base`` is the normalised output of :func:`_server_base_path`
+    (leading ``/``, no trailing ``/``) or ``""``. Joins them into a
+    single path-template with exactly one separator slash, collapsing
+    the double slash that arises from ``base`` + a leading-``/`` ``path``
+    (``"/api/v2"`` + ``"/version"`` -> ``"/api/v2/version"``). An empty
+    ``base`` returns ``path`` unchanged (the no-server-base case).
+    """
+    if not base:
+        return path
+    if not path.startswith("/"):
+        path = "/" + path
+    return base + path
+
+
 # OpenAPI 3.x operation-level keys other than the verbs. Used to skip
 # ``parameters`` / ``summary`` / ``description`` while iterating verbs.
 _VERBS = frozenset({"get", "post", "put", "patch", "delete", "head", "options", "trace"})
@@ -245,7 +327,9 @@ def parse_openapi(
         A list of :class:`EndpointDescriptorProto`. One entry per
         (method, path) operation; path-level / spec-level metadata
         is not represented here. Paths with no operations are
-        silently skipped.
+        silently skipped. A relative ``servers[].url`` base is folded
+        into each op's ``path`` / ``op_id`` -- see
+        :func:`_server_base_path` (#1796).
 
     Raises:
         InvalidSpecError: Document is not a mapping, lacks ``paths``,
@@ -276,38 +360,25 @@ def parse_openapi(
     if not isinstance(paths, dict):
         raise InvalidSpecError(f"'paths' must be a mapping, got {type(paths).__name__}")
 
-    components = spec.get("components") or {}
-    if not isinstance(components, dict):
-        raise InvalidSpecError(f"'components' must be a mapping, got {type(components).__name__}")
-    component_schemas = components.get("schemas") or {}
-    if not isinstance(component_schemas, dict):
-        raise InvalidSpecError(
-            f"'components.schemas' must be a mapping, got {type(component_schemas).__name__}"
-        )
-    component_parameters = components.get("parameters") or {}
-    if not isinstance(component_parameters, dict):
-        raise InvalidSpecError(
-            f"'components.parameters' must be a mapping, got {type(component_parameters).__name__}"
-        )
-    component_responses = components.get("responses") or {}
-    if not isinstance(component_responses, dict):
-        raise InvalidSpecError(
-            f"'components.responses' must be a mapping, got {type(component_responses).__name__}"
-        )
-    component_request_bodies = components.get("requestBodies") or {}
-    if not isinstance(component_request_bodies, dict):
-        raise InvalidSpecError(
-            f"'components.requestBodies' must be a mapping, got "
-            f"{type(component_request_bodies).__name__}"
-        )
+    components = _require_spec_mapping(spec.get("components") or {}, "components")
+    server_base = _server_base_path(spec.get("servers"))
 
     return list(
         _iter_operations(
             paths=paths,
-            component_schemas=cast(dict[str, Any], component_schemas),
-            component_parameters=cast(dict[str, Any], component_parameters),
-            component_responses=cast(dict[str, Any], component_responses),
-            component_request_bodies=cast(dict[str, Any], component_request_bodies),
+            server_base=server_base,
+            component_schemas=_require_spec_mapping(
+                components.get("schemas") or {}, "components.schemas"
+            ),
+            component_parameters=_require_spec_mapping(
+                components.get("parameters") or {}, "components.parameters"
+            ),
+            component_responses=_require_spec_mapping(
+                components.get("responses") or {}, "components.responses"
+            ),
+            component_request_bodies=_require_spec_mapping(
+                components.get("requestBodies") or {}, "components.requestBodies"
+            ),
             spec_source=spec_source,
         )
     )
@@ -644,13 +715,21 @@ def _validate_openapi_version(spec: dict[str, Any]) -> None:
 def _iter_operations(
     *,
     paths: dict[str, Any],
+    server_base: str,
     component_schemas: dict[str, Any],
     component_parameters: dict[str, Any],
     component_responses: dict[str, Any],
     component_request_bodies: dict[str, Any],
     spec_source: str | None,
 ) -> Iterable[EndpointDescriptorProto]:
-    """Yield one :class:`EndpointDescriptorProto` per (method, path)."""
+    """Yield one :class:`EndpointDescriptorProto` per (method, path).
+
+    ``server_base`` is the normalised relative server-base path (e.g.
+    ``/api/v2``, or ``""`` for none) from :func:`_server_base_path`; it
+    is folded into each operation's path so the persisted ``path`` /
+    ``op_id`` carry the full template the dispatcher puts on the wire
+    (#1796).
+    """
     for path_template, path_item in paths.items():
         if not isinstance(path_item, dict):
             # A non-dict ``paths.<path>`` value is malformed per the
@@ -670,7 +749,7 @@ def _iter_operations(
                 continue
             yield _build_proto(
                 method=verb.upper(),
-                path=path_template,
+                path=_fold_server_base(server_base, path_template),
                 operation=operation,
                 path_level_params=path_level_params,
                 component_schemas=component_schemas,

--- a/backend/src/meho_backplane/operations/ingest/schemas.py
+++ b/backend/src/meho_backplane/operations/ingest/schemas.py
@@ -63,8 +63,11 @@ class EndpointDescriptorProto(BaseModel):
     ``"PATCH"`` / ``"DELETE"`` / ``"HEAD"`` / ``"OPTIONS"``)."""
 
     path: str
-    """URL path template with ``{var}`` placeholders, verbatim from
-    the spec's ``paths`` key."""
+    """URL path template with ``{var}`` placeholders. Verbatim from the
+    spec's ``paths`` key, except that a relative OpenAPI server base
+    (``servers:[{url:"/api/v2"}]``) is folded onto the front at ingest
+    (``/version`` -> ``/api/v2/version``, #1796) so the dispatcher's
+    ``host:port + path`` join honours the Server Object."""
 
     summary: str | None = None
     description: str | None = None

--- a/backend/src/meho_backplane/operations/ingest/specs/sddc_manager_minimal.yaml
+++ b/backend/src/meho_backplane/operations/ingest/specs/sddc_manager_minimal.yaml
@@ -37,9 +37,12 @@ info:
   license:
     name: Apache-2.0
     url: https://www.apache.org/licenses/LICENSE-2.0
-servers:
-  - url: /v1
-    description: SDDC Manager appliance API root.
+# No `servers` block: the `/v1` root is baked into each path key below
+# (`/v1/releases/system`, `/v1/sddc-managers`, ...). #1796 made the OpenAPI
+# Server Object load-bearing -- the ingest parser now folds a relative
+# `servers[].url` onto every op path. Declaring `servers:[{url:/v1}]` here
+# while the paths already carry `/v1` would double-prefix to
+# `/v1/v1/releases/system`. The root is documented in `info.description`.
 paths:
   /v1/releases/system:
     get:

--- a/backend/src/meho_backplane/operations/ingest/specs/vmware_rest_minimal.yaml
+++ b/backend/src/meho_backplane/operations/ingest/specs/vmware_rest_minimal.yaml
@@ -44,9 +44,13 @@ info:
   license:
     name: Apache-2.0
     url: https://www.apache.org/licenses/LICENSE-2.0
-servers:
-  - url: /api
-    description: Modern vCenter automation API mount (vSphere 8.0+).
+# No `servers` block: the `/api` mount is baked into each path key below
+# (`/api/about`, `/api/vcenter/...`). #1796 made the OpenAPI Server Object
+# load-bearing -- the ingest parser now folds a relative `servers[].url`
+# onto every op path. Declaring `servers:[{url:/api}]` here while the paths
+# already carry `/api` would double-prefix to `/api/api/about`. The mount is
+# documented in `info.description` instead; the vCenter connector's
+# `mount_op_path` hook owns the modern `/api` vs legacy `/rest` selection.
 paths:
   /api/about:
     get:

--- a/backend/tests/test_operations_ingest_openapi.py
+++ b/backend/tests/test_operations_ingest_openapi.py
@@ -41,6 +41,7 @@ from meho_backplane.operations.ingest.openapi import (
     _INLINE_SPEC_ONRAMP_REMEDIATION,
     _MAX_REDIRECTS,
     _assert_fetchable_remote_url,
+    _server_base_path,
 )
 
 FIXTURES = Path(__file__).parent / "fixtures" / "openapi"
@@ -312,6 +313,173 @@ def test_parse_path_param_without_operator_unchanged() -> None:
     props = op.parameter_schema["properties"]
     assert props["cluster"]["x-meho-param-loc"] == "path"
     assert "cluster" in op.parameter_schema["required"]
+
+
+# -- relative server base fold (#1796) -------------------------------------
+
+
+def _server_base_spec(server_url: object, op_path: str = "/version") -> bytes:
+    """Build a minimal one-op spec whose ``servers`` is ``server_url``.
+
+    ``server_url`` is placed verbatim into ``servers:[{url: ...}]`` so a
+    test can pass a relative base, ``"/"``, an absolute URL, or omit
+    ``servers`` entirely (pass ``None``).
+    """
+    spec: dict[str, object] = {
+        "openapi": "3.0.3",
+        "info": {"title": "server-base", "version": "1.0.0"},
+        "paths": {
+            op_path: {
+                "get": {
+                    "operationId": "op",
+                    "responses": {"200": {"description": "ok"}},
+                }
+            }
+        },
+    }
+    if server_url is not None:
+        spec["servers"] = [{"url": server_url}]
+    return yaml.safe_dump(spec).encode()
+
+
+def test_parse_relative_server_base_folded_into_path() -> None:
+    """A relative ``servers:[{url:"/api/v2"}]`` is folded onto each op path.
+
+    The vRLI / VCF-Operations-for-Logs case (#1796): without the fold the
+    dispatcher builds ``host:port/version`` and 404s; with it the persisted
+    ``path`` / ``op_id`` carry ``/api/v2/version``, which the dispatcher
+    puts on the wire verbatim against the operator-configured target host.
+    """
+    with respx.mock(assert_all_called=False) as router:
+        url = _mock_yaml_spec(router, "server_base.yaml", _server_base_spec("/api/v2"))
+        rows = parse_openapi(url)
+    ops = _by_op_id(rows)
+    # The folded path is the natural key the dispatcher resolves against:
+    # descriptor.path -> request path -> host:port + path on the wire.
+    assert "GET:/api/v2/version" in ops
+    assert "GET:/version" not in ops
+    assert ops["GET:/api/v2/version"].path == "/api/v2/version"
+
+
+def test_parse_relative_server_base_regression_dispatched_url_contains_base() -> None:
+    """AC regression: ``servers:[{url:"/base"}]`` + path ``/x`` -> ``/base/x``.
+
+    Asserts on the descriptor ``path`` -- the exact string the dispatcher
+    feeds httpx as the request path, so ``base_url(host:port) + /base/x``
+    lands on the real endpoint.
+    """
+    rows = parse_openapi(
+        "file:///x.yaml",
+        content=_server_base_spec("/base", op_path="/x").decode(),
+    )
+    op = _by_op_id(rows)["GET:/base/x"]
+    assert op.path == "/base/x"
+    assert "/base/x" in op.path
+
+
+def test_parse_relative_server_base_with_trailing_slash_no_double_slash() -> None:
+    """``servers:[{url:"/api/v2/"}]`` + ``/version`` joins as ``/api/v2/version``.
+
+    The OpenAPI spec leaves slash normalisation implementation-defined;
+    #1796 requires collapsing the double slash a trailing-slash base would
+    otherwise produce.
+    """
+    rows = parse_openapi(
+        "file:///x.yaml",
+        content=_server_base_spec("/api/v2/").decode(),
+    )
+    assert "GET:/api/v2/version" in _by_op_id(rows)
+
+
+def test_parse_relative_server_base_folds_before_rfc6570_template() -> None:
+    """The fold prefixes the base without disturbing a ``{+path}`` suffix.
+
+    ``/api/v2`` + ``/events/{+path}`` -> ``/api/v2/events/{+path}``; the
+    RFC6570 operator stays on the template so #2066's renderer still
+    selects reserved expansion.
+    """
+    spec = yaml.safe_dump(
+        {
+            "openapi": "3.0.3",
+            "info": {"title": "base-plus-path", "version": "1.0.0"},
+            "servers": [{"url": "/api/v2"}],
+            "paths": {
+                "/events/{+path}": {
+                    "get": {
+                        "operationId": "readEvents",
+                        "parameters": [
+                            {
+                                "name": "+path",
+                                "in": "path",
+                                "required": True,
+                                "schema": {"type": "string"},
+                            }
+                        ],
+                        "responses": {"200": {"description": "ok"}},
+                    }
+                }
+            },
+        }
+    ).encode()
+    rows = parse_openapi("file:///x.yaml", content=spec.decode())
+    op = _by_op_id(rows)["GET:/api/v2/events/{+path}"]
+    assert op.path == "/api/v2/events/{+path}"
+    # The bare-name param keying (#2066) is unaffected by the prefix.
+    assert "path" in op.parameter_schema["properties"]
+
+
+@pytest.mark.parametrize("server_url", [None, "/", ""])
+def test_parse_absent_or_root_server_base_no_regression(server_url: object) -> None:
+    """No ``servers``, ``"/"``, or empty base ingests exactly as today.
+
+    The bare spec path is kept verbatim -- no fold -- so existing
+    single-base-less specs are unchanged.
+    """
+    rows = parse_openapi(
+        "file:///x.yaml",
+        content=_server_base_spec(server_url).decode(),
+    )
+    assert "GET:/version" in _by_op_id(rows)
+
+
+def test_parse_absolute_server_base_not_folded_out_of_scope() -> None:
+    """An absolute ``servers[].url`` host is out of scope -- path is untouched.
+
+    meho dispatches against the operator-configured target host, not a
+    spec-declared one (SSRF / topology boundary, #1796 out-of-scope).
+    Folding only the path component of an absolute base would silently
+    diverge the op key from the operator's target, so absolute bases are
+    left entirely alone -- the bare spec path is kept.
+    """
+    rows = parse_openapi(
+        "file:///x.yaml",
+        content=_server_base_spec("https://other-host.example/api/v2").decode(),
+    )
+    assert "GET:/version" in _by_op_id(rows)
+    assert "GET:/api/v2/version" not in _by_op_id(rows)
+
+
+@pytest.mark.parametrize(
+    ("server_url", "expected"),
+    [
+        ("/api/v2", "/api/v2"),
+        ("/api/v2/", "/api/v2"),
+        ("api/v2", "/api/v2"),  # missing leading slash -> normalised
+        ("/", ""),
+        ("", ""),
+        ("https://h/api", ""),  # absolute -> no fold
+        ("//host/api", ""),  # protocol-relative authority -> no fold
+    ],
+)
+def test_server_base_path_normalisation(server_url: str, expected: str) -> None:
+    """``_server_base_path`` normalises the relative base and rejects absolutes."""
+    assert _server_base_path([{"url": server_url}]) == expected
+
+
+@pytest.mark.parametrize("servers", [None, [], [{}], [{"url": 123}], "not-a-list"])
+def test_server_base_path_malformed_yields_empty(servers: object) -> None:
+    """Absent / empty / malformed ``servers`` yields no base (no-op fold)."""
+    assert _server_base_path(servers) == ""
 
 
 def test_parse_bare_and_operator_path_param_collision_raises() -> None:


### PR DESCRIPTION
## Summary

- Ingested-connector dispatch dropped the OpenAPI `servers[].url` base: it built the request URL as `host:port + op_path`, so an op from a spec with a relative server base (e.g. vRLI's `servers:[{url:"/api/v2"}]`) dispatched to `host:port/version` and 404'd instead of `host:port/api/v2/version`.
- Fix per the reporter's **option A** (lowest blast radius): fold a *relative* server base into each op's `path`/`op_id` **at ingest time** — dispatch is unchanged (no new descriptor column, no dispatch-path edit). `_server_base_path` extracts + normalises the first server's relative url; `_fold_server_base` joins it onto each path, collapsing the double slash a trailing-slash base produces.
- **Absolute** server bases (`https://other-host/...`) are out of scope — meho dispatches against the operator-configured target host, not a spec-declared one (SSRF / topology boundary); only the path of a *relative* base is folded. The RFC6570 `{+path}` template (#2066) rides through untouched (base is a prefix; operator stays on the suffix var).
- Reconciled the two MEHO-authored shipped specs: `vmware_rest_minimal` / `sddc_manager_minimal` already baked their mount (`/api`, `/v1`) into every path key **and** redundantly declared it under `servers` — harmless while `servers` was ignored, but a double-prefix (`/api/api/about`) once it's load-bearing. Dropped the redundant `servers` block from both, so their op_ids are unchanged.

## Test plan

- [x] `ruff check` / `ruff format --check` — clean
- [x] `mypy` — clean
- [x] code-quality gate — 0 blockers
- [x] **AC: relative base folds** — `servers:[{url:"/api/v2"}]` + `/version` → op_id `GET:/api/v2/version`, `op.path == "/api/v2/version"` (the exact string the dispatcher feeds httpx as the request path).
- [x] **AC: no regression** — absent / `"/"` / empty `servers` ingests `GET:/version` as today (parametrised).
- [x] **AC: regression test** — `servers:[{url:"/base"}]` + `/x` asserts `op.path` contains `/base/x`.
- [x] **AC: double-slash normalised** — trailing-slash base `/api/v2/` + `/version` → `/api/v2/version`.
- [x] absolute-base out-of-scope test — `https://other-host/api/v2` leaves bare `/version`.
- [x] `{+path}` interaction — `/api/v2` + `/events/{+path}` → `/api/v2/events/{+path}`, bare-name param keying intact.
- [x] `pytest` ingest + connector sweep — 1246 passed, 35 skipped, 0 failed; shipped-spec op_ids unchanged after dropping redundant `servers`.
- [x] `cd cli && make snapshot-openapi` — **no delta** (ingest-internal change; no route/schema touched), so `make generate` not needed.

## Out of scope

- Absolute-URL server bases pointing at a different host (SSRF/topology boundary) — only the path component of a relative base is folded.
- Server `variables` templating (`{region}`) — no shipped MEHO spec uses it; file separately if needed.
- The vRLI `GET:/events/{+path}` ingest (#2066) and session-expiry recovery (#2067) — sibling log-sentry fixes, already merged.

<!-- auto-implement-issue: fresh, iteration 1 -->

Closes #1796


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * OpenAPI ingest now respects relative server base URLs when deriving endpoint paths, so operation IDs and dispatched paths include the correct prefix.
* **Bug Fixes**
  * Prevented double-prefixing and double slashes for specs that already include path prefixes.
  * Absolute, protocol-relative, empty, or malformed server URLs are left unchanged.
* **Documentation**
  * Clarified how ingested endpoint paths are built from OpenAPI path templates plus any relative server base.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->