### PR TITLE
fix(connectors): fold relative servers[].url base into ingested op paths (#1796)

### DIFF
--- a/backend/src/meho_backplane/operations/ingest/openapi.py
+++ b/backend/src/meho_backplane/operations/ingest/openapi.py
@@ -1,5 +1,8 @@
 # SPDX-License-Identifier: Apache-2.0
 # Copyright (c) 2026 evoila Group
+# code-quality-allow: file-size — pre-existing 1000+-line parser; #1796 only
+# adds the servers-base fold helpers. Splitting this module by responsibility
+# is a separate refactor (tracked as an adjacent finding), out of scope here.
 
 """Pure-function OpenAPI 3.0/3.1 spec parser.
 
@@ -304,6 +307,7 @@ def parse_openapi(
     return list(
         _iter_operations(
             paths=paths,
+            server_base_path=_server_base_path(spec),
             component_schemas=cast(dict[str, Any], component_schemas),
             component_parameters=cast(dict[str, Any], component_parameters),
             component_responses=cast(dict[str, Any], component_responses),
@@ -641,9 +645,60 @@ def _validate_openapi_version(spec: dict[str, Any]) -> None:
         )
 
 
+def _server_base_path(spec: dict[str, Any]) -> str:
+    """Return the path prefix to fold into every op, from ``servers[0].url``.
+
+    OpenAPI resolves an operation's effective URL as ``server.url + path``
+    (Server Object, OAS 3.1 §4.8.5). MEHO always dispatches against the
+    operator-configured *target* host, so only the **path** component of a
+    **relative** server base contributes: an absolute ``servers[].url`` names
+    a host MEHO must not adopt (the SSRF / topology boundary), and a
+    server-variable-templated base (``/{region}/api``) cannot be resolved
+    here. Those, plus an absent or bare ``"/"`` base, return ``""`` -- no
+    fold, the pre-#1796 behaviour.
+
+    The first server wins (OpenAPI orders ``servers`` by preference).
+    Returns a normalised prefix with a leading and no trailing slash
+    (``"/api/v2"``), or ``""`` when nothing should be folded.
+    """
+    servers = spec.get("servers")
+    if not isinstance(servers, list) or not servers:
+        return ""
+    first = servers[0]
+    if not isinstance(first, dict):
+        return ""
+    url = first.get("url")
+    if not isinstance(url, str) or not url:
+        return ""
+    parsed = urlparse(url)
+    if parsed.scheme or parsed.netloc:
+        # Absolute base -> out of scope: never adopt a spec-declared host.
+        return ""
+    base = parsed.path.rstrip("/")
+    if not base or "{" in base:
+        # "/" or "" -> nothing to fold; "{" -> unresolvable server-variable
+        # templating (out of scope).
+        return ""
+    return base if base.startswith("/") else "/" + base
+
+
+def _apply_server_base(server_base: str, path: str) -> str:
+    """Prefix *path* with the relative server base (see :func:`_server_base_path`).
+
+    No-op when *server_base* is ``""``. The result is the op's
+    dispatch-canonical path -- e.g. base ``/api/v2`` + path ``/events/{+path}``
+    -> ``/api/v2/events/{+path}`` -- which becomes both the descriptor ``path``
+    the renderer substitutes at dispatch and the ``op_id`` suffix.
+    """
+    if not server_base:
+        return path
+    return f"{server_base}{path}" if path.startswith("/") else f"{server_base}/{path}"
+
+
 def _iter_operations(
     *,
     paths: dict[str, Any],
+    server_base_path: str,
     component_schemas: dict[str, Any],
     component_parameters: dict[str, Any],
     component_responses: dict[str, Any],
@@ -671,6 +726,7 @@ def _iter_operations(
             yield _build_proto(
                 method=verb.upper(),
                 path=path_template,
+                server_base_path=server_base_path,
                 operation=operation,
                 path_level_params=path_level_params,
                 component_schemas=component_schemas,
@@ -685,6 +741,7 @@ def _build_proto(
     *,
     method: str,
     path: str,
+    server_base_path: str,
     operation: dict[str, Any],
     path_level_params: list[Any],
     component_schemas: dict[str, Any],
@@ -693,7 +750,14 @@ def _build_proto(
     component_request_bodies: dict[str, Any],
     spec_source: str | None,
 ) -> EndpointDescriptorProto:
-    """Assemble a single :class:`EndpointDescriptorProto`."""
+    """Assemble a single :class:`EndpointDescriptorProto`.
+
+    *path* is the literal spec path key (used verbatim in parameter-schema
+    error messages so they point at the spec location the author wrote).
+    The descriptor's dispatch-canonical ``path`` / ``op_id`` fold in
+    *server_base_path* (#1796) so a relative ``servers[].url`` base is honoured
+    at dispatch.
+    """
     op_params = operation.get("parameters") or []
     if not isinstance(op_params, list):
         raise InvalidSchemaError(
@@ -733,10 +797,11 @@ def _build_proto(
     if spec_source is not None:
         tags.append(spec_source)
 
+    full_path = _apply_server_base(server_base_path, path)
     return EndpointDescriptorProto(
-        op_id=f"{method}:{path}",
+        op_id=f"{method}:{full_path}",
         method=method,
-        path=path,
+        path=full_path,
         summary=_optional_string(operation.get("summary")),
         description=_optional_string(operation.get("description")),
         tags=tags,

--- a/backend/src/meho_backplane/operations/ingest/specs/sddc_manager_minimal.yaml
+++ b/backend/src/meho_backplane/operations/ingest/specs/sddc_manager_minimal.yaml
@@ -41,7 +41,7 @@ servers:
   - url: /v1
     description: SDDC Manager appliance API root.
 paths:
-  /v1/releases/system:
+  /releases/system:
     get:
       operationId: getSystemRelease
       summary: Get the SDDC Manager software release
@@ -55,7 +55,7 @@ paths:
             application/json:
               schema:
                 $ref: "#/components/schemas/Release"
-  /v1/sddc-managers:
+  /sddc-managers:
     get:
       operationId: listSddcManagers
       summary: List SDDC Manager appliances
@@ -69,7 +69,7 @@ paths:
             application/json:
               schema:
                 $ref: "#/components/schemas/SddcManagerPage"
-  /v1/domains:
+  /domains:
     get:
       operationId: listDomains
       summary: List workload and management domains
@@ -83,7 +83,7 @@ paths:
             application/json:
               schema:
                 $ref: "#/components/schemas/DomainPage"
-  /v1/domains/{id}:
+  /domains/{id}:
     get:
       operationId: getDomain
       summary: Get a domain by id
@@ -102,7 +102,7 @@ paths:
             application/json:
               schema:
                 $ref: "#/components/schemas/Domain"
-  /v1/clusters:
+  /clusters:
     get:
       operationId: listClusters
       summary: List clusters across all domains
@@ -116,7 +116,7 @@ paths:
             application/json:
               schema:
                 $ref: "#/components/schemas/ClusterPage"
-  /v1/hosts:
+  /hosts:
     get:
       operationId: listHosts
       summary: List ESXi hosts across all domains
@@ -130,7 +130,7 @@ paths:
             application/json:
               schema:
                 $ref: "#/components/schemas/HostPage"
-  /v1/network-pools:
+  /network-pools:
     get:
       operationId: listNetworkPools
       summary: List network pools
@@ -142,7 +142,7 @@ paths:
             application/json:
               schema:
                 $ref: "#/components/schemas/NetworkPoolPage"
-  /v1/bundles:
+  /bundles:
     get:
       operationId: listBundles
       summary: List lifecycle-management bundles
@@ -156,7 +156,7 @@ paths:
             application/json:
               schema:
                 $ref: "#/components/schemas/BundlePage"
-  /v1/tasks:
+  /tasks:
     get:
       operationId: listTasks
       summary: List workflow tasks

--- a/backend/src/meho_backplane/operations/ingest/specs/vmware_rest_minimal.yaml
+++ b/backend/src/meho_backplane/operations/ingest/specs/vmware_rest_minimal.yaml
@@ -48,7 +48,7 @@ servers:
   - url: /api
     description: Modern vCenter automation API mount (vSphere 8.0+).
 paths:
-  /api/about:
+  /about:
     get:
       operationId: getSystemAbout
       summary: Get vCenter system information
@@ -63,7 +63,7 @@ paths:
             application/json:
               schema:
                 $ref: "#/components/schemas/About"
-  /api/vcenter/datacenter:
+  /vcenter/datacenter:
     get:
       operationId: listDatacenters
       summary: List datacenters
@@ -77,7 +77,7 @@ paths:
                 type: array
                 items:
                   $ref: "#/components/schemas/DatacenterSummary"
-  /api/vcenter/cluster:
+  /vcenter/cluster:
     get:
       operationId: listClusters
       summary: List clusters
@@ -91,7 +91,7 @@ paths:
                 type: array
                 items:
                   $ref: "#/components/schemas/ClusterSummary"
-  /api/vcenter/host:
+  /vcenter/host:
     get:
       operationId: listHosts
       summary: List ESXi hosts
@@ -105,7 +105,7 @@ paths:
                 type: array
                 items:
                   $ref: "#/components/schemas/HostSummary"
-  /api/vcenter/datastore:
+  /vcenter/datastore:
     get:
       operationId: listDatastores
       summary: List datastores
@@ -119,7 +119,7 @@ paths:
                 type: array
                 items:
                   $ref: "#/components/schemas/DatastoreSummary"
-  /api/vcenter/network:
+  /vcenter/network:
     get:
       operationId: listNetworks
       summary: List networks
@@ -133,7 +133,7 @@ paths:
                 type: array
                 items:
                   $ref: "#/components/schemas/NetworkSummary"
-  /api/vcenter/folder:
+  /vcenter/folder:
     get:
       operationId: listFolders
       summary: List folders
@@ -147,7 +147,7 @@ paths:
                 type: array
                 items:
                   $ref: "#/components/schemas/FolderSummary"
-  /api/vcenter/vm:
+  /vcenter/vm:
     get:
       operationId: listVms
       summary: List virtual machines
@@ -161,7 +161,7 @@ paths:
                 type: array
                 items:
                   $ref: "#/components/schemas/VmSummary"
-  /api/vcenter/vm/{vm}:
+  /vcenter/vm/{vm}:
     get:
       operationId: getVm
       summary: Get a virtual machine by id

--- a/backend/tests/test_operations_ingest_openapi.py
+++ b/backend/tests/test_operations_ingest_openapi.py
@@ -355,6 +355,105 @@ def test_parse_bare_and_operator_path_param_collision_raises() -> None:
             parse_openapi(url)
 
 
+# -- parse_openapi: servers[].url base path (#1796) ------------------------
+
+
+def _servers_spec(*, server_url: str | None, path: str) -> bytes:
+    """A minimal one-GET-op spec with an optional ``servers`` base."""
+    spec: dict[str, object] = {
+        "openapi": "3.0.3",
+        "info": {"title": "servers-base", "version": "1.0.0"},
+        "paths": {
+            path: {
+                "get": {
+                    "operationId": "readThing",
+                    "responses": {"200": {"description": "ok"}},
+                }
+            }
+        },
+    }
+    if server_url is not None:
+        spec["servers"] = [{"url": server_url}]
+    return yaml.safe_dump(spec).encode()
+
+
+def test_parse_relative_server_base_folded_into_op_path() -> None:
+    """A relative ``servers[].url`` is folded into the op_id and path (#1796).
+
+    The vRLI / VCF Operations-for-Logs spec declares ``servers: [{url: /api/v2}]``
+    with paths relative to it. Pre-#1796 ingest dropped the base, so
+    ``GET:/version`` dispatched to ``host/version`` and 404'd; the real endpoint
+    is ``host/api/v2/version``.
+    """
+    with respx.mock(assert_all_called=False) as router:
+        url = _mock_yaml_spec(
+            router, "servers_rel.yaml", _servers_spec(server_url="/api/v2", path="/version")
+        )
+        rows = parse_openapi(url)
+    ops = _by_op_id(rows)
+    assert "GET:/api/v2/version" in ops
+    assert ops["GET:/api/v2/version"].path == "/api/v2/version"
+
+
+def test_parse_no_servers_op_path_unchanged() -> None:
+    """No ``servers`` block -> the op path is the bare spec path (no fold)."""
+    with respx.mock(assert_all_called=False) as router:
+        url = _mock_yaml_spec(
+            router, "servers_none.yaml", _servers_spec(server_url=None, path="/version")
+        )
+        rows = parse_openapi(url)
+    assert "GET:/version" in _by_op_id(rows)
+
+
+def test_parse_root_server_base_is_noop() -> None:
+    """A bare ``servers: [{url: /}]`` base contributes nothing (no fold)."""
+    with respx.mock(assert_all_called=False) as router:
+        url = _mock_yaml_spec(
+            router, "servers_root.yaml", _servers_spec(server_url="/", path="/version")
+        )
+        rows = parse_openapi(url)
+    assert "GET:/version" in _by_op_id(rows)
+
+
+def test_parse_absolute_server_base_not_folded() -> None:
+    """An absolute ``servers[].url`` host is NOT adopted (#1796 out-of-scope).
+
+    MEHO dispatches against the operator-configured target host, never a
+    spec-declared one, so an absolute base contributes no path prefix.
+    """
+    with respx.mock(assert_all_called=False) as router:
+        url = _mock_yaml_spec(
+            router,
+            "servers_abs.yaml",
+            _servers_spec(server_url="https://vendor.example/api/v2", path="/version"),
+        )
+        rows = parse_openapi(url)
+    ops = _by_op_id(rows)
+    assert "GET:/version" in ops
+    assert "GET:/api/v2/version" not in ops
+
+
+def test_parse_server_base_composes_with_operator_path_param() -> None:
+    """The base fold composes with the #2066 bare-name keying for ``{+path}``.
+
+    The log-sentry events op ``GET:/api/v2/events/{+path}`` must carry the folded
+    base in its op_id/path AND key its path param on the bare ``path``.
+    """
+    decoded = yaml.safe_load(_servers_spec(server_url="/api/v2", path="/events/{+path}"))
+    decoded["paths"]["/events/{+path}"]["get"]["parameters"] = [
+        {"name": "+path", "in": "path", "required": True, "schema": {"type": "string"}}
+    ]
+    with respx.mock(assert_all_called=False) as router:
+        url = _mock_yaml_spec(router, "servers_operator.yaml", yaml.safe_dump(decoded).encode())
+        rows = parse_openapi(url)
+    op = _by_op_id(rows)["GET:/api/v2/events/{+path}"]
+    assert op.path == "/api/v2/events/{+path}"
+    props = op.parameter_schema["properties"]
+    assert isinstance(props, dict)
+    assert "path" in props
+    assert "+path" not in props
+
+
 def _same_name_path_query_spec(*, path_first: bool) -> bytes:
     """A legal OpenAPI op declaring ``id`` in BOTH path and query.
 

--- a/docs/codebase/spec-ingestion.md
+++ b/docs/codebase/spec-ingestion.md
@@ -427,7 +427,7 @@ Frozen Pydantic v2 model. One per operation. Maps 1:1 to a subset of
 |---|---|---|
 | `op_id` | `op_id` | `f"{METHOD}:{path}"`; the connector-side natural key |
 | `method` | `method` | Upper-case HTTP verb |
-| `path` | `path` | URL template, `{var}` placeholders |
+| `path` | `path` | URL template, `{var}` placeholders. A **relative** `servers[].url` base is folded in at parse time (#1796) — e.g. `servers: [{url: /api/v2}]` + `/version` → `/api/v2/version` — so dispatch (`host + path`) reaches the real endpoint. Absolute/templated bases are left unfolded (MEHO never adopts a spec-declared host). |
 | `summary` | `summary` | Verbatim from spec |
 | `description` | `description` | Verbatim from spec |
 | `tags` | `tags` | Spec tags + optional `spec:<source>` marker |


### PR DESCRIPTION
## Summary

- Ingest now honours an OpenAPI spec's **relative** `servers[].url` base. Previously the base was silently dropped, so a spec like vRLI's `servers: [{url: /api/v2}]` ingested `GET:/version` and dispatched to `host/version` → 404 instead of `host/api/v2/version` (#1796).
- `parse_openapi` folds the path component of a relative `servers[0].url` into each op's `op_id` and `path`. **Absolute** or **server-variable-templated** bases are left unfolded — meho dispatches against the operator-configured target host, never a spec-declared one (the SSRF / topology boundary).
- **Scope note (bigger than the ticket implied — please review):** the two shipped MEHO package-data specs had already baked the prefix into their path keys as a workaround for this bug (`vmware_rest_minimal.yaml` under `/api`, `sddc_manager_minimal.yaml` under `/v1`). A naive fold would have double-prefixed them, so this PR restores both to RFC-compliant relative paths. The fold reconstructs their op-ids **byte-for-byte** (`GET:/api/about`, `GET:/v1/releases/system`), so vmware/sddc dispatch is unchanged.

## Test plan

- [x] `ruff check` / `ruff format --check` — clean
- [x] `mypy` (openapi.py) — clean
- [x] `.claude/hooks/code-quality.py --diff` — 0 blockers (pre-existing file-size on the 1100-line parser carries a scoped `# code-quality-allow`; splitting it is a separate refactor)
- [x] New parse-level tests: relative-base fold, no-servers no-op, root (`/`) no-op, absolute-base-not-folded, and composition with the #2066 `{+path}` bare-name keying
- [x] **Op-id invariance guard** (the load-bearing safety check for the spec edits): `test_connectors_sddc_manager_core_ops`, `test_connectors_sddc_manager_e2e`, `tests/acceptance/test_vmware_rest_dispatch_smoke`, `test_operations_ingest_catalog`, `test_connectors_vmware_rest_composites_l2_ingest_reconcile` — all green; the shipped connectors' op-ids are unchanged
- [x] Broader ingest sweep (register/delete/llm-groups/mcp-ingest/nsx/acceptance) — 137 passed, integration skipped-in-sandbox
- No OpenAPI snapshot delta (ingest-internal; op-ids unchanged; no FastAPI route/schema change)

## Out of scope

- Absolute `servers[].url` bases that name a different host, and server-variable templating — left unfolded by design (documented in `_server_base_path`).
- Splitting the 1100-line `openapi.py` parser — pre-existing debt, recorded as an adjacent finding.
- #2068 (migration 0051) — the other open log-sentry-adjacent task, parked separately.

<!-- auto-implement-issue: fresh, iteration 1, --no-dance -->

Closes #1796
