### PR TITLE
fix(ui): re-auth expired runbooks sessions instead of opacity banner

### DIFF
--- a/backend/src/meho_backplane/ui/routes/runbooks/routes.py
+++ b/backend/src/meho_backplane/ui/routes/runbooks/routes.py
@@ -51,10 +51,15 @@ notice. This matches the REST surface's ``403 detail="opacity_floor"``
 posture while keeping the console a navigable page rather than an error.
 
 The role lift fails **soft** to operator-level privileges (no admin) when
-the JWT round-trip can't complete (session row vanished mid-request, JWKS
-transiently unreachable) -- the same posture
+the JWT round-trip can't complete for a *transient* reason (session row
+vanished mid-request, JWKS transiently unreachable, a malformed stored
+token) -- the same posture
 :func:`meho_backplane.ui.routes.connectors.operator.resolve_role_probe`
-adopts. The restricted-detail render is the safe default, never a 5xx.
+adopts. The restricted-detail render is the safe default, never a 5xx. The
+one exception is a **terminal** ``session_expired`` (the token aged out and
+its refresh failed): that is re-raised so the app-level handler redirects to
+re-auth, rather than silently degrading a genuine ``tenant_admin`` onto the
+restricted banner (#2114).
 
 Tenant scoping
 --------------
@@ -90,7 +95,7 @@ from dataclasses import dataclass
 from typing import Annotated, Final, Literal
 
 import structlog
-from fastapi import APIRouter, Depends, HTTPException, Query, Request
+from fastapi import APIRouter, Depends, HTTPException, Query, Request, status
 from fastapi.responses import HTMLResponse
 
 from meho_backplane.auth.operator import Operator, TenantRole
@@ -107,6 +112,7 @@ from meho_backplane.runbooks.service import (
 from meho_backplane.settings import get_settings
 from meho_backplane.ui.auth.middleware import UISessionContext, require_ui_session
 from meho_backplane.ui.auth.refresh import (
+    SESSION_EXPIRED_DETAIL,
     load_fresh_session,
     verify_access_token_with_refresh,
 )
@@ -174,12 +180,23 @@ async def _resolve_role(session_ctx: UISessionContext) -> Operator | None:
     re-verifying -- so an expired-but-refreshable token lifts the real role
     instead of degrading the operator to the restricted view mid-session.
 
-    Fails **soft**: any hiccup (session row vanished between the middleware
-    check and here, JWKS transiently unreachable, refresh unavailable,
-    identity mismatch on the decoded token) returns ``None`` -- the caller
-    then treats the request as a plain operator (no admin privilege). The
-    opacity-floor branch is the safe default; an unavailable role lift must
-    never 5xx the read surface.
+    Fails **soft** for a *recoverable-later* hiccup (session row vanished
+    between the middleware check and here, JWKS transiently unreachable, a
+    malformed / bad-signature stored token, identity mismatch on the decoded
+    token): returns ``None`` so the caller treats the request as a plain
+    operator (no admin privilege). The opacity-floor branch is the safe
+    default; a transiently-unavailable role lift must never 5xx the read
+    surface.
+
+    The one exception is a **terminal** ``session_expired`` -- the BFF
+    session's access token aged out and its refresh failed, so the row is
+    dead and can never mint a fresh token. That must **not** degrade to the
+    restricted view: doing so silently drops a genuine ``tenant_admin`` onto
+    the opacity banner ("complete a run to unlock"), non-deterministically
+    per browser as each session's token expires (#2114). It is re-raised so
+    the app-level ``session_expired`` handler
+    (:mod:`meho_backplane.ui.auth.errors`) redirects the browser to
+    re-authenticate; after re-login the fresh token lifts the real role.
     """
     try:
         decrypted = await load_fresh_session(session_ctx.session_id)
@@ -191,6 +208,12 @@ async def _resolve_role(session_ctx: UISessionContext) -> Operator | None:
             expected_audience=settings.keycloak_audience,
         )
     except Exception as exc:
+        if (
+            isinstance(exc, HTTPException)
+            and exc.status_code == status.HTTP_401_UNAUTHORIZED
+            and exc.detail == SESSION_EXPIRED_DETAIL
+        ):
+            raise
         log.info(
             "ui_runbooks_role_lift_unavailable",
             session_id=str(session_ctx.session_id),
@@ -217,9 +240,11 @@ async def _is_admin(session_ctx: UISessionContext) -> bool:
     Thin wrapper over :func:`_resolve_role` returning just the admin verdict --
     the catalog + list-fragment renders need the boolean (to show / hide the
     lifecycle row actions) but not the full :class:`Operator`. Fails soft to
-    ``False`` (operator privileges) via :func:`_resolve_role`, so the row
-    actions are hidden whenever the role lift can't complete. The POST handlers
-    re-check server-side, so a hidden-but-forged action is still a 403.
+    ``False`` (operator privileges) for a transient lift failure, so the row
+    actions are hidden whenever the role lift can't complete. A terminal
+    ``session_expired`` propagates (via :func:`_resolve_role`) to the re-auth
+    redirect rather than degrading. The POST handlers re-check server-side, so
+    a hidden-but-forged action is still a 403.
     """
     operator = await _resolve_role(session_ctx)
     return operator is not None and operator.tenant_role == TenantRole.TENANT_ADMIN

--- a/backend/tests/test_ui_runbooks_lifecycle.py
+++ b/backend/tests/test_ui_runbooks_lifecycle.py
@@ -44,13 +44,15 @@ import warnings
 from collections.abc import Iterator
 from datetime import UTC, datetime, timedelta
 from typing import Any
+from unittest.mock import AsyncMock, patch
 
 import pytest
 import respx
 from cryptography.fernet import Fernet
-from fastapi import FastAPI
+from fastapi import FastAPI, HTTPException, status
 from fastapi.staticfiles import StaticFiles
 from fastapi.testclient import TestClient
+from starlette.exceptions import HTTPException as StarletteHTTPException
 
 from meho_backplane.auth.jwt import clear_jwks_cache
 from meho_backplane.auth.operator import TenantRole
@@ -68,10 +70,13 @@ from meho_backplane.runbooks.service import RunbookTemplateService
 from meho_backplane.settings import get_settings
 from meho_backplane.ui.auth import SESSION_COOKIE_NAME, UISessionMiddleware
 from meho_backplane.ui.auth import build_router as build_ui_auth_router
+from meho_backplane.ui.auth.errors import ui_session_expired_exception_handler
 from meho_backplane.ui.auth.flow import (
     clear_discovery_cache,
     reset_verifier_store_for_testing,
 )
+from meho_backplane.ui.auth.middleware import UISessionContext
+from meho_backplane.ui.auth.refresh import SESSION_EXPIRED_DETAIL
 from meho_backplane.ui.auth.session_store import (
     create_session,
     reset_fernet_cache_for_testing,
@@ -916,3 +921,92 @@ def test_catalog_row_button_gates_refresh_on_success() -> None:
     assert "$event.detail.successful" in body
     assert "alert-error" in body  # appears in the gate expression
     assert "$dispatch('runbooks-refresh')" in body
+
+
+# ---------------------------------------------------------------------------
+# Role-lift failure on the detail read surface (#2114)
+#
+# The detail page recomputes the admin verdict per request by re-verifying the
+# session's stored access token (``_resolve_role``). A *terminal* session
+# expiry (token aged out + refresh failed) must NOT silently degrade a genuine
+# ``tenant_admin`` onto the opacity-restricted banner -- it must propagate the
+# ``session_expired`` 401 so the app-level handler redirects to re-auth. A
+# transient / malformed-token failure still fails soft (restricted view).
+# ---------------------------------------------------------------------------
+
+_RB_ROUTES = "meho_backplane.ui.routes.runbooks.routes"
+
+
+def _build_app_with_session_expired_handler() -> FastAPI:
+    """`_build_app` plus the app-level ``session_expired`` handler main wires."""
+    app = _build_app()
+    app.add_exception_handler(StarletteHTTPException, ui_session_expired_exception_handler)
+    return app
+
+
+@pytest.mark.asyncio
+async def test_resolve_role_reraises_session_expired() -> None:
+    """A terminal ``session_expired`` propagates (not swallowed to ``None``)."""
+    from meho_backplane.ui.routes.runbooks.routes import _resolve_role
+
+    ctx = UISessionContext(session_id=uuid.uuid4(), operator_sub=_OPERATOR_SUB, tenant_id=_TENANT_A)
+    expired = HTTPException(status_code=status.HTTP_401_UNAUTHORIZED, detail=SESSION_EXPIRED_DETAIL)
+    with (
+        patch(f"{_RB_ROUTES}.load_fresh_session", AsyncMock(return_value=object())),
+        patch(
+            f"{_RB_ROUTES}.verify_access_token_with_refresh",
+            AsyncMock(side_effect=expired),
+        ),
+        pytest.raises(HTTPException) as excinfo,
+    ):
+        await _resolve_role(ctx)
+    assert excinfo.value.status_code == status.HTTP_401_UNAUTHORIZED
+    assert excinfo.value.detail == SESSION_EXPIRED_DETAIL
+
+
+@pytest.mark.asyncio
+async def test_resolve_role_soft_fails_on_non_session_expired_401() -> None:
+    """A non-expiry verification failure still fails soft to ``None`` (operator)."""
+    from meho_backplane.ui.routes.runbooks.routes import _resolve_role
+
+    ctx = UISessionContext(session_id=uuid.uuid4(), operator_sub=_OPERATOR_SUB, tenant_id=_TENANT_A)
+    bad_signature = HTTPException(
+        status_code=status.HTTP_401_UNAUTHORIZED, detail="signature_verification_failed"
+    )
+    with (
+        patch(f"{_RB_ROUTES}.load_fresh_session", AsyncMock(return_value=object())),
+        patch(
+            f"{_RB_ROUTES}.verify_access_token_with_refresh",
+            AsyncMock(side_effect=bad_signature),
+        ),
+    ):
+        assert await _resolve_role(ctx) is None
+
+
+def test_detail_session_expired_redirects_admin_to_reauth() -> None:
+    """An admin whose session token expired is redirected to re-login, not the banner.
+
+    Regression for #2114: the fail-soft role lift used to drop a genuine
+    ``tenant_admin`` onto the opacity-restricted banner (``restricted=True``)
+    when the token re-verify raised ``session_expired``. It must instead
+    propagate to the app-level handler's 302 -> ``/ui/auth/login``.
+    """
+    _seed_tenant(_TENANT_A, "tenant-a")
+    _seed_template(tenant_id=_TENANT_A, slug="rotate-cert", publish=True)
+    session_id, _jwks = _admin_session()
+
+    client = TestClient(_build_app_with_session_expired_handler(), follow_redirects=False)
+    client.cookies.set(SESSION_COOKIE_NAME, str(session_id))
+    expired = HTTPException(status_code=status.HTTP_401_UNAUTHORIZED, detail=SESSION_EXPIRED_DETAIL)
+    with (
+        patch(f"{_RB_ROUTES}.load_fresh_session", AsyncMock(return_value=object())),
+        patch(
+            f"{_RB_ROUTES}.verify_access_token_with_refresh",
+            AsyncMock(side_effect=expired),
+        ),
+    ):
+        response = client.get("/ui/runbooks/rotate-cert", headers={"accept": "text/html"})
+
+    assert response.status_code == 302, response.text
+    assert response.headers["location"].startswith("/ui/auth/login?return_to=")
+    assert "Step details are restricted" not in response.text


### PR DESCRIPTION
## Summary

- Fixes the non-deterministic runbooks opacity banner (#2114). The detail read
  surface recomputes the admin verdict per request by re-verifying the session's
  stored access token (`_resolve_role`); it swallowed **every** exception and
  degraded to a plain operator. So a genuine `tenant_admin` whose session token
  aged out (refresh failed → `session_expired`) silently landed on the
  opacity-restricted banner ("complete a run to unlock") instead of a re-login
  prompt — browser-dependent, since each session's token expires independently,
  and template authors got locked out of viewing their own drafts.
- The fix: re-raise the **terminal** `session_expired` 401 so the app-level
  handler (`ui/auth/errors.py`, G0.25 #1694) redirects the browser to
  re-authenticate. After re-login the fresh token lifts the real role and full
  steps render. **Transient / malformed-token** lifts still fail soft to the
  restricted view (unchanged), so the anti-enumeration posture and "never 5xx
  the read surface" guarantee hold.
- Scope note: no separate "author can view own draft" short-circuit is needed —
  drafting requires `tenant_admin` (the `draft`/`edit` role floor), so every
  author already takes the admin path once their session is valid; the re-auth
  fix restores that path.

## Test plan

- [x] `pytest tests/test_ui_runbooks_lifecycle.py tests/test_ui_runbooks_acceptance.py tests/test_ui_runbook_driver_opacity.py tests/test_runbook_templates_api.py` — **83 passed**
- [x] New: `test_resolve_role_reraises_session_expired` — terminal `session_expired` propagates (not swallowed to `None`)
- [x] New: `test_resolve_role_soft_fails_on_non_session_expired_401` — a non-expiry 401 (bad signature) still degrades soft to operator
- [x] New: `test_detail_session_expired_redirects_admin_to_reauth` — admin detail GET with an expired session → **302 → `/ui/auth/login?return_to=…`**, not the restricted banner
- [x] Regression preserved: the acceptance suite's plaintext-token `operator_soft_session` still degrades to the restricted view (non-`session_expired` path unchanged)
- [x] `ruff check` / `ruff format --check` / `mypy` — clean

## Out of scope

- `resolve_role_probe` (`ui/routes/connectors/operator.py:183`) has the **same** swallow-and-degrade of `session_expired`, affecting the connectors detail page and the runbooks run-driver POST paths. Left untouched here (different surfaces than the reported read-surface banner); worth a follow-up so those surfaces also re-auth on terminal expiry rather than degrade.
- The broader "does the same session-cache pathology touch approvals / broadcast / agent / memory UI surfaces" call-out from the issue — a grep for the same pattern is warranted separately.

<!-- auto-implement-issue: fresh, iteration 1 -->

Closes #2114


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved runbook access behavior when a session has expired, so users are redirected to sign in again instead of seeing a restricted or partial view.
  * Preserved the existing fallback experience for other temporary authorization failures, avoiding server errors.
  
* **Tests**
  * Added coverage for session-expired redirects and for distinguishing terminal login-expired errors from other 401 responses.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->