### PR TITLE
fix(ui): repair runbooks authoring surface (preview, draft edit, body)

### DIFF
--- a/backend/src/meho_backplane/runbooks/schemas.py
+++ b/backend/src/meho_backplane/runbooks/schemas.py
@@ -220,7 +220,7 @@ class OperationCallStep(BaseModel):
 
     id: Annotated[str, Field(pattern=STEP_ID_PATTERN.pattern)]
     title: str
-    body: str
+    body: Annotated[str, Field(min_length=1)]
     type: Literal["operation_call"]
     op_id: str
     params: dict[str, object]
@@ -239,7 +239,7 @@ class ManualStep(BaseModel):
 
     id: Annotated[str, Field(pattern=STEP_ID_PATTERN.pattern)]
     title: str
-    body: str
+    body: Annotated[str, Field(min_length=1)]
     type: Literal["manual"]
     verify: Verify
 

--- a/backend/src/meho_backplane/runbooks/schemas.py
+++ b/backend/src/meho_backplane/runbooks/schemas.py
@@ -51,7 +51,7 @@ import re
 from datetime import datetime
 from typing import Annotated, Final, Literal
 
-from pydantic import BaseModel, ConfigDict, Field, model_validator
+from pydantic import BaseModel, ConfigDict, Field, StringConstraints, model_validator
 
 from meho_backplane.kb.schemas import SLUG_PATTERN
 
@@ -220,7 +220,7 @@ class OperationCallStep(BaseModel):
 
     id: Annotated[str, Field(pattern=STEP_ID_PATTERN.pattern)]
     title: str
-    body: Annotated[str, Field(min_length=1)]
+    body: Annotated[str, StringConstraints(strip_whitespace=True, min_length=1)]
     type: Literal["operation_call"]
     op_id: str
     params: dict[str, object]
@@ -239,7 +239,7 @@ class ManualStep(BaseModel):
 
     id: Annotated[str, Field(pattern=STEP_ID_PATTERN.pattern)]
     title: str
-    body: Annotated[str, Field(min_length=1)]
+    body: Annotated[str, StringConstraints(strip_whitespace=True, min_length=1)]
     type: Literal["manual"]
     verify: Verify
 

--- a/backend/src/meho_backplane/ui/templates/runbooks/_detail_actions.html
+++ b/backend/src/meho_backplane/ui/templates/runbooks/_detail_actions.html
@@ -70,6 +70,16 @@
         >
           Publish
         </button>
+        {# Edit — a draft is mutable, so the editor route mutates it in place
+           (no fork; the engine's update_or_fork forks only a published version).
+           Lets an author fix a draft without publishing it first. #}
+        <a
+          href="/ui/runbooks/{{ template.slug }}/edit"
+          class="btn btn-outline btn-sm"
+          aria-label="Edit {{ template.slug }} v{{ template.version }}"
+        >
+          Edit
+        </a>
       {% elif template.status == "published" %}
         {# Deprecate — retires this published version. #}
         <button

--- a/backend/src/meho_backplane/ui/templates/runbooks/_step_fields.html
+++ b/backend/src/meho_backplane/ui/templates/runbooks/_step_fields.html
@@ -121,7 +121,7 @@
                   x-bind:data-step-index="idx"
                   hx-post="/ui/runbooks/preview"
                   hx-trigger="input changed delay:500ms"
-                  hx-target="closest .flex-wrap >> .runbook-step-preview"
+                  hx-target="next .runbook-step-preview"
                   hx-swap="innerHTML"
                   hx-vals='js:{body: event.target.value}'
                   hx-headers='{"X-CSRF-Token": "{{ csrf_token | default('') }}"}'

--- a/backend/tests/test_runbook_templates_api.py
+++ b/backend/tests/test_runbook_templates_api.py
@@ -1181,3 +1181,25 @@ async def test_publish_writes_audit_row_with_publish_op_id_and_version() -> None
     # The template body / step contents never reach the audit payload.
     serialised = json.dumps(payload)
     assert "revoke-old-cert" not in serialised
+
+
+@pytest.mark.asyncio
+async def test_draft_rejects_empty_step_body_422() -> None:
+    """A step with an empty body is rejected at request validation (#2117 D3).
+
+    ``ManualStep.body`` / ``OperationCallStep.body`` carry ``min_length=1``; an
+    empty body is a non-functional step (the operator sees a blank verify
+    prompt), so it must not be silently accepted.
+    """
+    key, token = _admin_token()
+    payload = _template_body()
+    payload["steps"][0]["body"] = ""  # empty body -> min_length=1 violation
+    test_client = TestClient(_build_app())
+    with respx.mock as mock_router:
+        _mock_discovery_and_jwks(mock_router, _public_jwks(key))
+        response = test_client.post(
+            "/api/v1/runbooks/templates",
+            json={"slug": "rotate-cert", "body": payload},
+            headers=_authed(token),
+        )
+    assert response.status_code == 422, response.text

--- a/backend/tests/test_runbook_templates_api.py
+++ b/backend/tests/test_runbook_templates_api.py
@@ -1184,16 +1184,20 @@ async def test_publish_writes_audit_row_with_publish_op_id_and_version() -> None
 
 
 @pytest.mark.asyncio
-async def test_draft_rejects_empty_step_body_422() -> None:
-    """A step with an empty body is rejected at request validation (#2117 D3).
+@pytest.mark.parametrize("blank_body", ["", "   ", "\t\n  "])
+async def test_draft_rejects_blank_step_body_422(blank_body: str) -> None:
+    """A step with an empty or whitespace-only body is rejected at request validation (#2117 D3).
 
-    ``ManualStep.body`` / ``OperationCallStep.body`` carry ``min_length=1``; an
-    empty body is a non-functional step (the operator sees a blank verify
-    prompt), so it must not be silently accepted.
+    ``ManualStep.body`` / ``OperationCallStep.body`` carry
+    ``StringConstraints(strip_whitespace=True, min_length=1)``; a blank body
+    (empty *or* whitespace-only) is a non-functional step (the operator sees a
+    blank verify prompt), so it must not be silently accepted. Pydantic v2
+    strips before the min_length check, so a whitespace-only body collapses to
+    ``""`` and fails.
     """
     key, token = _admin_token()
     payload = _template_body()
-    payload["steps"][0]["body"] = ""  # empty body -> min_length=1 violation
+    payload["steps"][0]["body"] = blank_body  # blank body -> min_length violation after strip
     test_client = TestClient(_build_app())
     with respx.mock as mock_router:
         _mock_discovery_and_jwks(mock_router, _public_jwks(key))

--- a/backend/tests/test_ui_runbooks_editor.py
+++ b/backend/tests/test_ui_runbooks_editor.py
@@ -926,3 +926,29 @@ def test_editor_new_reflected_xss_payload_cannot_break_out_of_x_data() -> None:
 
     assert response.status_code == 422, response.text
     _assert_no_xss_breakout(response.text)
+
+
+def test_editor_new_step_preview_uses_valid_hx_target() -> None:
+    """The step-body live-preview targets ``next .runbook-step-preview`` (#2117 D1).
+
+    The prior ``closest .flex-wrap >> .runbook-step-preview`` used the
+    shadow-DOM piercing combinator ``>>``, invalid in htmx target resolution /
+    ``Element.closest()`` — it threw a JS SyntaxError and killed the preview.
+    """
+    _seed_tenant(_TENANT_A, "tenant-a")
+    session_id, jwks = _admin_session()
+
+    mock = respx.mock(assert_all_called=False)
+    mock.start()
+    try:
+        _mock_discovery_and_jwks(mock, jwks)
+        client = _authenticated_client(session_id)
+        response = client.get("/ui/runbooks/new")
+    finally:
+        mock.stop()
+
+    assert response.status_code == 200, response.text
+    body = response.text
+    assert 'hx-target="next .runbook-step-preview"' in body
+    # The invalid combinator selector must be gone.
+    assert ".flex-wrap >> .runbook-step-preview" not in body

--- a/backend/tests/test_ui_runbooks_lifecycle.py
+++ b/backend/tests/test_ui_runbooks_lifecycle.py
@@ -916,3 +916,30 @@ def test_catalog_row_button_gates_refresh_on_success() -> None:
     assert "$event.detail.successful" in body
     assert "alert-error" in body  # appears in the gate expression
     assert "$dispatch('runbooks-refresh')" in body
+
+
+def test_detail_draft_shows_edit_affordance() -> None:
+    """A draft detail exposes an in-place Edit link, not just Publish (#2117 D2).
+
+    Editing a draft mutates it in place (the engine's ``update_or_fork`` forks
+    only a published version), so an author can fix a draft without publishing
+    first. The Edit link routes to the shared ``/ui/runbooks/<slug>/edit`` editor.
+    """
+    _seed_tenant(_TENANT_A, "tenant-a")
+    _seed_template(tenant_id=_TENANT_A, slug="rotate-cert")  # publish defaults False -> draft
+    session_id, jwks = _admin_session()
+
+    mock = respx.mock(assert_all_called=False)
+    mock.start()
+    try:
+        _mock_discovery_and_jwks(mock, jwks)
+        client = _authenticated_client(session_id)
+        response = client.get("/ui/runbooks/rotate-cert")
+    finally:
+        mock.stop()
+
+    assert response.status_code == 200, response.text
+    body = response.text
+    assert 'href="/ui/runbooks/rotate-cert/edit"' in body
+    # The draft still shows Publish alongside Edit.
+    assert "Publish" in body

--- a/cli/api/openapi.json
+++ b/cli/api/openapi.json
@@ -22767,6 +22767,7 @@
           },
           "body": {
             "type": "string",
+            "minLength": 1,
             "title": "Body"
           },
           "type": {
@@ -22951,6 +22952,7 @@
           },
           "body": {
             "type": "string",
+            "minLength": 1,
             "title": "Body"
           },
           "type": {


### PR DESCRIPTION
## Summary

Repairs three defects on the `/ui/runbooks` **authoring** surface (evoila/meho#2117 — D1, D2, D3). D4 (slug doubling) and D5 (post-deprecate list refresh empties) from the same report are **not reproducible from the code** and are tracked separately (see Out of scope).

- **D1 — Preview was dead (invalid selector).** The step-body live-preview used `hx-target="closest .flex-wrap >> .runbook-step-preview"`; `>>` is the shadow-DOM piercing combinator, invalid in htmx target resolution / `Element.closest()`, so Preview threw a JS `SyntaxError` and never fired. Retargeted to `next .runbook-step-preview` — the preview div is the next match in document order after each step's textarea (verified against the htmx `hx-target` docs; `find` reaches only descendants, which the cousin preview isn't).
- **D2 — no Edit affordance on drafts.** A draft detail page offered only Publish, forcing authors to publish a possibly-broken first cut to get an Edit button. Added an in-place **Edit** link on the draft branch routing to the shared `/ui/runbooks/<slug>/edit` editor; the engine's `update_or_fork` mutates a draft in place (forks only a published version), so no vestigial version is left behind.
- **D3 — empty step body silently accepted.** `ManualStep.body` / `OperationCallStep.body` were plain `str`; `""` passed. Added `min_length=1` so an empty body is a 422 at request validation (mirrors the existing non-empty title/description checks; covers both REST and MCP entry points via the shared schema).

## Test plan

- [x] `ruff check` / `ruff format --check` / `mypy` — clean
- [x] New: `test_editor_new_step_preview_uses_valid_hx_target` — the rendered editor uses `next .runbook-step-preview`, and the invalid `.flex-wrap >> .runbook-step-preview` selector is gone.
- [x] New: `test_detail_draft_shows_edit_affordance` — a draft detail exposes an Edit link to `/ui/runbooks/<slug>/edit` alongside Publish.
- [x] New: `test_draft_rejects_empty_step_body_422` — a POST with an empty step body is a 422 at request validation.
- [x] `pytest` — **201 passed** across the runbook suites (templates / editor / lifecycle / run-service / template-service / acceptance / MCP-templates / MCP-runs / driver-opacity); D3's `min_length` broke no existing fixture.

## Out of scope

- **D4 (slug doubles on submit):** no code mechanism — the two `name="slug"` inputs are mode-exclusive (`editor.html`), and `x-model="slug"` has no auto-slugify/concat. Likely a client autofill artifact; tracked separately pending a live DevTools trace.
- **D5 (deprecate → list refresh empties):** no code mechanism — `_render_index` and `_render_list_fragment` share `_list_summaries(...)` with identical filters. Tracked separately pending a live Network trace of the refresh request.

<!-- auto-implement-issue: fresh, iteration 1 -->

Refs evoila/meho#2117


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Draft runbooks now show an **Edit** action directly in the lifecycle controls, making draft changes easier to access.
* **Bug Fixes**
  * Empty step content is now rejected, preventing runbooks from being saved with blank step bodies.
  * Live step previews now update in the correct place while editing, improving preview reliability.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->