### PR TITLE
fix(ui): coerce empty runbooks list target_kind filter to no-filter

### DIFF
--- a/backend/src/meho_backplane/ui/routes/runbooks/routes.py
+++ b/backend/src/meho_backplane/ui/routes/runbooks/routes.py
@@ -97,6 +97,7 @@ from typing import Annotated, Final, Literal
 import structlog
 from fastapi import APIRouter, Depends, HTTPException, Query, Request, status
 from fastapi.responses import HTMLResponse
+from pydantic import StringConstraints
 
 from meho_backplane.auth.operator import Operator, TenantRole
 from meho_backplane.runbooks.run_service import RunbookRunService
@@ -433,7 +434,11 @@ def build_runbooks_router() -> APIRouter:
         request: Request,
         session: UISessionContext = _require_session,
         status: Annotated[_StatusFilter | None, EMPTY_STR_TO_NONE, Query()] = None,
-        target_kind: str | None = Query(default=None, max_length=_MAX_TARGET_KIND_LENGTH),
+        target_kind: Annotated[
+            Annotated[str, StringConstraints(max_length=_MAX_TARGET_KIND_LENGTH)] | None,
+            EMPTY_STR_TO_NONE,
+            Query(),
+        ] = None,
     ) -> HTMLResponse:
         return await _render_index(request, session, status, target_kind)
 
@@ -442,7 +447,11 @@ def build_runbooks_router() -> APIRouter:
         request: Request,
         session: UISessionContext = _require_session,
         status: Annotated[_StatusFilter | None, EMPTY_STR_TO_NONE, Query()] = None,
-        target_kind: str | None = Query(default=None, max_length=_MAX_TARGET_KIND_LENGTH),
+        target_kind: Annotated[
+            Annotated[str, StringConstraints(max_length=_MAX_TARGET_KIND_LENGTH)] | None,
+            EMPTY_STR_TO_NONE,
+            Query(),
+        ] = None,
     ) -> HTMLResponse:
         return await _render_list_fragment(request, session, status, target_kind)
 

--- a/backend/tests/test_ui_runbooks_list.py
+++ b/backend/tests/test_ui_runbooks_list.py
@@ -507,6 +507,38 @@ def test_runbooks_list_empty_status_filter_is_200_unfiltered() -> None:
     assert "drain-node" in index_response.text
 
 
+def test_runbooks_list_empty_target_kind_filter_is_200_unfiltered() -> None:
+    """An empty ``?target_kind=`` (and combined empty filters) returns the full catalog (#2117 D5).
+
+    The post-deprecate ``runbooks-refresh`` re-fetches ``/ui/runbooks/list``
+    with ``hx-include="[name='status'], [name='target_kind']"``, so an empty
+    target-kind input submits ``?target_kind=``. Without the empty-string
+    coercion the filter applied ``WHERE target_kind = ''`` and matched nothing,
+    emptying the list after every deprecate (the same footgun as the status
+    filter, which already coerces). Both filters empty must return the
+    unfiltered catalog.
+    """
+    _seed_tenant(_TENANT_A, "tenant-a")
+    _seed_template(tenant_id=_TENANT_A, slug="k8s-drain", body=_manual_body(target_kind="k8s-node"))
+    _seed_template(
+        tenant_id=_TENANT_A, slug="vcenter-cert", body=_manual_body(target_kind="vmware-vcenter")
+    )
+
+    session_id = _seed_session_sync(tenant_id=_TENANT_A)
+    with respx.mock(assert_all_called=False):
+        client = _authenticated_client(session_id)
+        tk_only = client.get("/ui/runbooks/list", params={"target_kind": ""})
+        both = client.get("/ui/runbooks/list", params={"status": "", "target_kind": ""})
+
+    assert tk_only.status_code == 200, tk_only.text
+    assert "k8s-drain" in tk_only.text
+    assert "vcenter-cert" in tk_only.text
+    # The exact post-deprecate refresh shape: both filters empty -> full catalog.
+    assert both.status_code == 200, both.text
+    assert "k8s-drain" in both.text
+    assert "vcenter-cert" in both.text
+
+
 # ---------------------------------------------------------------------------
 # GET /ui/runbooks/<slug> -- detail (admin / post-completion sees full steps)
 # ---------------------------------------------------------------------------


### PR DESCRIPTION
## Summary

Fixes **D5** of evoila/meho#2117: deprecating a template from the list view blanked the whole catalog.

- **Root cause:** the `/ui/runbooks` + `/ui/runbooks/list` `target_kind` query param lacked the `EMPTY_STR_TO_NONE` coercion the `status` param already has. An empty `?target_kind=` reached `RunbookTemplateService.list_templates` as `""` and applied `WHERE target_kind = ''` (`service.py`: `if filter_.target_kind is not None`), matching nothing.
- **Trigger:** the post-deprecate `runbooks-refresh` re-fetches `/ui/runbooks/list` with `hx-include="[name='status'], [name='target_kind']"` (`index.html`), so an empty target-kind filter input submitted `?target_kind=` and emptied the list after every deprecate. (Same footgun class as the topology empty-kind filter.)
- **Fix:** coerce empty → `None` on both routes (mirroring `status`). The `max_length` guard moves onto the inner `str` branch via `StringConstraints`, so it isn't applied to the `None` the `EMPTY_STR_TO_NONE` `BeforeValidator` yields — a bare `Query(max_length=...)` on the nullable field raises `TypeError` on `None` (verified: that was the initial failure, fixed by the branch-scoped constraint).

## Test plan

- [x] `ruff check` / `ruff format --check` / `mypy` — clean
- [x] New `test_runbooks_list_empty_target_kind_filter_is_200_unfiltered`: `?target_kind=` **and** the exact refresh shape `?status=&target_kind=` (both empty) return the full catalog (both seeded templates present) — fails on `main` (empty list), passes with the fix.
- [x] Existing `test_runbooks_list_filters_by_target_kind` (non-empty still narrows) + `test_runbooks_list_empty_status_filter_is_200_unfiltered` still green.
- [x] `pytest tests/test_ui_runbooks_list.py` — 21 passed.

## Out of scope

- **D4 (slug doubling):** not reproducible from the code (mode-exclusive `name="slug"` inputs, no auto-slugify/concat handler, single `hx-post` form serialization). Tracked as `evoila-bosnia/meho-internal#145` pending a live DevTools trace.
- **D1/D2/D3** already shipped (#2122).

<!-- auto-implement-issue: fresh, iteration 1 -->

Refs evoila/meho#2117


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved handling of empty runbook filters so requests with an empty `target_kind` now return the full catalog instead of failing or filtering unexpectedly.
  * Ensured combining empty `status` and `target_kind` also returns the unfiltered runbooks list at HTTP 200.

* **Tests**
  * Added coverage for empty filter values on the runbooks list page to verify the expected results are shown.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->