### PR TITLE
fix(bind9): require approval for dangerous config-apply ops (close four-eyes bypass)

### DIFF
--- a/backend/src/meho_backplane/connectors/bind9/ops_config.py
+++ b/backend/src/meho_backplane/connectors/bind9/ops_config.py
@@ -1364,7 +1364,7 @@ CONFIG_OPS: tuple[Bind9Op, ...] = (
         group_key="config",
         tags=("write", "config", "atomic-apply"),
         safety_level="dangerous",
-        requires_approval=False,
+        requires_approval=True,
         llm_instructions=BIND9_CONFIG_APPLY_FILE_LLM_INSTRUCTIONS,
     ),
     Bind9Op(
@@ -1384,7 +1384,7 @@ CONFIG_OPS: tuple[Bind9Op, ...] = (
         group_key="config",
         tags=("write", "config", "atomic-apply"),
         safety_level="dangerous",
-        requires_approval=False,
+        requires_approval=True,
         llm_instructions=BIND9_CONFIG_APPLY_VIEWS_LLM_INSTRUCTIONS,
     ),
     Bind9Op(

--- a/backend/tests/integration/test_g3_4_bind9_e2e.py
+++ b/backend/tests/integration/test_g3_4_bind9_e2e.py
@@ -989,6 +989,14 @@ async def test_dispatch_config_apply_file_writes_state_before_after(
 ) -> None:
     """``bind9.config.apply_file`` writes a fragment + audit row carries
     state_before / state_after.
+
+    ``apply_file`` is a dangerous, four-eyes-gated op (#129): a lone-operator
+    dispatch parks awaiting approval. ``_approved=True`` is the flag
+    ``api.v1.approvals`` passes on the resume re-dispatch after a *second*
+    operator approves; here it drives the post-approval execution path so the
+    write + state_before/after audit assertions still hold. The park/gate
+    itself is unit-covered (``test_dispatch_human_requires_approval_op_queues``
+    + ``test_no_dangerous_op_bypasses_approval``).
     """
     operator = _make_operator(sub="op-apply-file", tenant_id=_OPERATOR_TENANT_ID)
     result = await dispatch(
@@ -1000,6 +1008,7 @@ async def test_dispatch_config_apply_file_writes_state_before_after(
             "path": "named.conf.options",
             "content": "// e2e applied fragment\n",
         },
+        _approved=True,
     )
     assert result.status == "ok", result.error
     assert result.result["op_class"] == "write"
@@ -1016,7 +1025,12 @@ async def test_dispatch_config_apply_file_writes_state_before_after(
 async def test_dispatch_config_apply_views_writes_multi_file_tree(
     bind9_e2e: _Bind9Target,
 ) -> None:
-    """``bind9.config.apply_views`` writes a multi-file tree successfully."""
+    """``bind9.config.apply_views`` writes a multi-file tree successfully.
+
+    Like ``apply_file``, ``apply_views`` is dangerous + four-eyes-gated (#129);
+    ``_approved=True`` drives the post-approval resume execution path (the
+    park/gate is unit-covered). See the ``apply_file`` e2e above.
+    """
     operator = _make_operator(sub="op-apply-views", tenant_id=_OPERATOR_TENANT_ID)
     result = await dispatch(
         operator=operator,
@@ -1028,6 +1042,7 @@ async def test_dispatch_config_apply_views_writes_multi_file_tree(
                 "named.conf.smoke-e2e": "// apply_views e2e smoke fragment\n",
             },
         },
+        _approved=True,
     )
     assert result.status == "ok", result.error
     assert result.result["op_class"] == "write"

--- a/backend/tests/test_connectors_bind9_config.py
+++ b/backend/tests/test_connectors_bind9_config.py
@@ -773,20 +773,38 @@ class TestT4OpsRegistration:
         assert len(BIND9_OPS) == 11
 
     @pytest.mark.parametrize(
-        "op_id, expected_safety",
+        "op_id, expected_safety, expected_requires_approval",
         [
-            ("bind9.config.apply_file", "dangerous"),
-            ("bind9.config.apply_views", "dangerous"),
-            ("bind9.config.backup", "caution"),
-            ("bind9.config.reload", "caution"),
+            # The two dangerous config-replacement ops require four-eyes on
+            # every principal kind (#129) — the non-agent gate keys on
+            # requires_approval, so a dangerous op must set it or a human
+            # tenant_admin could run it with no approval.
+            ("bind9.config.apply_file", "dangerous", True),
+            ("bind9.config.apply_views", "dangerous", True),
+            # caution ops stay default-allow for humans (auto-execute).
+            ("bind9.config.backup", "caution", False),
+            ("bind9.config.reload", "caution", False),
         ],
     )
-    def test_safety_levels_pin_to_spec(self, op_id: str, expected_safety: str) -> None:
+    def test_safety_levels_pin_to_spec(
+        self, op_id: str, expected_safety: str, expected_requires_approval: bool
+    ) -> None:
         op = next(o for o in BIND9_OPS if o.op_id == op_id)
         assert op.safety_level == expected_safety
-        # Dev-default: no production approval gate yet (G7/G10 keys on
-        # safety_level, not on requires_approval).
-        assert op.requires_approval is False
+        assert op.requires_approval is expected_requires_approval
+
+    def test_no_dangerous_op_bypasses_approval(self) -> None:
+        """No ``dangerous`` bind9 op ships ``requires_approval=False`` (#129).
+
+        The non-agent policy gate (``_non_agent_verdict``) keys only on
+        ``requires_approval``, so a ``dangerous`` op left ``requires_approval=
+        False`` lets a human/service principal execute it with no four-eyes
+        step. Pin the invariant so a future write op can't reintroduce the gap.
+        """
+        offenders = [
+            o.op_id for o in BIND9_OPS if o.safety_level == "dangerous" and not o.requires_approval
+        ]
+        assert offenders == [], offenders
 
     @pytest.mark.parametrize("op_id", ["bind9.config.apply_file", "bind9.config.apply_views"])
     def test_dangerous_op_carries_global_atomic_warning_in_description(self, op_id: str) -> None:


### PR DESCRIPTION
## What

`bind9.config.apply_file` and `bind9.config.apply_views` shipped
`safety_level="dangerous"` + `requires_approval=False`. This PR flips both to
`requires_approval=True` so they are four-eyes-gated on **every** principal
path — not just the agent path.

## Why

The non-agent policy gate (`operations/_validate.py:_non_agent_verdict`) keys
**only** on `requires_approval`, not `safety_level`:

```python
if descriptor.requires_approval:
    return PermissionVerdict.NEEDS_APPROVAL
return PermissionVerdict.AUTO_EXECUTE   # safety_level logged, not consulted
```

The agent path floors `dangerous`→`NEEDS_APPROVAL` via `_SAFETY_CEILING`
(`auth/permissions.py`), but a human `tenant_admin` (or any non-agent
principal) executing a `dangerous`-class op registered `requires_approval=False`
got `AUTO_EXECUTE` — no approval gate. Both bind9 ops perform full DNS-config /
view-tree **replacement**, so a single operator could overwrite live DNS with
no four-eyes step. Setting `requires_approval=True` routes them through the
existing park→approve→resume flow for all principals.

## Tests

- New invariant `test_no_dangerous_op_bypasses_approval` — pins that **no**
  `dangerous` bind9 op ships `requires_approval=False`, so a future write op
  can't silently reintroduce the gap. (Scoped to `BIND9_OPS`; see the
  connector-wide sweep below for the other connectors.)
- Updated `test_safety_levels_pin_to_spec` to the per-op contract
  (apply_file/apply_views → approval-required; backup/reload → not).
- The gate mechanism itself is already covered by
  `test_dispatch_human_requires_approval_op_queues` (human + `requires_approval=True`
  → `awaiting_approval`), so the metadata flip + that test together prove the
  bind9 ops now park for a human.
- `test_connectors_bind9_config.py` + `test_broadcast_credential_mint_dispatch.py`:
  **49 passed, 3 skipped** (the 3 skips are the Redis-gated credential-mint tests —
  see deferral). `ruff` / `ruff format --check` / `mypy` clean.

Connector-wide sweep (`grep -rnE "safety_level.*dangerous|requires_approval"
backend/src/meho_backplane/connectors/`): argocd, kubernetes, vmware-rest
composites, and github composites already gate every `dangerous` op with
`requires_approval=True`. bind9 was the only `dangerous`-with-bypass offender.

## Deferred — `harbor.robot.create` (remaining #129 work)

The task also flagged `harbor.robot.create` (credential-mint, `caution`).
Gating it **parks** the op, which breaks the `credential_mint` broadcast-redaction
tests (`test_broadcast_credential_mint_dispatch.py`) — those dispatch
`robot.create` as a human operator and assert `status=="ok"` + a redacted
broadcast, i.e. they require the op to **execute** to verify redaction. Gating
would need them reworked through the approve→resume flow, and they **skip**
without `BROADCAST_REDIS_URL`, so that rework can't be fail-closed-verified in
this sandbox. Deferring keeps this PR green-in-CI. Recommend a follow-up pairing
the harbor flip with a Redis-enabled rework of those three tests.

Refs evoila-bosnia/meho-internal#129


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Updated BIND9 configuration actions so the more sensitive config changes now require approval before they can run.
  * Added safeguards to ensure risky BIND9 operations can’t bypass the approval step.

* **Tests**
  * Expanded coverage to verify approval requirements for key BIND9 actions.
  * Added checks to prevent dangerous operations from being marked as approval-free.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->