### PR TITLE
feat(runbooks): add discard verb for unpublished draft templates

### DIFF
--- a/backend/src/meho_backplane/api/v1/runbook_templates.py
+++ b/backend/src/meho_backplane/api/v1/runbook_templates.py
@@ -3,7 +3,7 @@
 
 """``/api/v1/runbooks/templates*`` -- REST surface for the runbook template layer.
 
-G12.2-T3 (#1297) of Initiative #1197. Six routes mounted under
+G12.2-T3 (#1297) of Initiative #1197. Seven routes mounted under
 ``/api/v1/runbooks/templates*`` that expose
 :class:`~meho_backplane.runbooks.service.RunbookTemplateService` (T2
 #1296) to operators and ops UIs. The MCP tools (T4 #1298) wrap the same
@@ -41,6 +41,9 @@ Route inventory
   published. Body: ``{"version": int}``. Role: ``tenant_admin``.
 * ``POST /api/v1/runbooks/templates/{slug}/deprecate`` -- retire a
   published version. Body: ``{"version": int}``. Role: ``tenant_admin``.
+* ``POST /api/v1/runbooks/templates/{slug}/discard`` -- delete an
+  unpublished draft version (the delete-for-drafts lifecycle leg). Body:
+  ``{"version": int}``. Role: ``tenant_admin``.
 
 Tenant scoping
 --------------
@@ -49,7 +52,7 @@ Every route derives ``tenant_id`` from the JWT-validated
 :class:`~meho_backplane.auth.operator.Operator`. No surface accepts a
 tenant id from the body or query string -- cross-tenant access is
 impossible by construction. A cross-tenant ``show`` / ``publish`` /
-``deprecate`` / ``edit`` probe surfaces as 404 (the service's tenant
+``deprecate`` / ``discard`` / ``edit`` probe surfaces as 404 (the service's tenant
 filter makes the row invisible, so :class:`TemplateNotFoundError` fires
 exactly as it would for a genuinely absent slug); the conflation
 prevents enumerating another tenant's templates via status-code
@@ -59,7 +62,8 @@ Role floor
 ----------
 
 ``list`` accepts ``operator`` (and ``tenant_admin``); ``draft`` /
-``edit`` / ``publish`` / ``deprecate`` require ``tenant_admin``. ``show``
+``edit`` / ``publish`` / ``deprecate`` / ``discard`` require
+``tenant_admin``. ``show``
 admits ``operator`` at the role gate but applies a *run-state-conditional*
 carve-out in the handler (G12.3-T4 / #1309): a ``tenant_admin`` is a
 pass-through, an ``operator`` is granted the read only when
@@ -101,7 +105,7 @@ publish-on-write broadcast hook (G6.1-T3) classify the row correctly:
   ``runbook.deprecate_template`` (the canonical operation identifiers
   tracked under :data:`_RUNBOOK_OP_IDS`).
 * ``audit_op_class`` -- ``"read"`` for ``list`` / ``show``, ``"write"``
-  for ``draft`` / ``edit`` / ``publish`` / ``deprecate``. Bound
+  for ``draft`` / ``edit`` / ``publish`` / ``deprecate`` / ``discard``. Bound
   explicitly because
   :func:`~meho_backplane.broadcast.events.classify_op` would not reliably
   suffix-match these op ids -- ``runbook.list_templates`` /
@@ -112,7 +116,7 @@ publish-on-write broadcast hook (G6.1-T3) classify the row correctly:
   :mod:`meho_backplane.api.v1.kb` documents.
 
 The ``audit_slug`` (all per-slug routes) and ``audit_version`` (the
-version-targeted publish / deprecate routes) are bound so the audit_log
+version-targeted publish / deprecate / discard routes) are bound so the audit_log
 payload (and the broadcast ``params``) carries the operation's
 coordinates -- the template body / step contents are **never** in the
 payload, only the slug + version.
@@ -149,6 +153,8 @@ from meho_backplane.runbooks.run_service import RunbookRunService
 from meho_backplane.runbooks.schemas import (
     DeprecateTemplateRequest,
     DeprecateTemplateResponse,
+    DiscardTemplateRequest,
+    DiscardTemplateResponse,
     DraftTemplateRequest,
     DraftTemplateResponse,
     EditTemplateRequest,
@@ -189,11 +195,12 @@ _RUNBOOK_OP_IDS: Final[dict[str, str]] = {
     "edit": "runbook.edit_template",
     "publish": "runbook.publish_template",
     "deprecate": "runbook.deprecate_template",
+    "discard": "runbook.discard_template",
 }
 
 #: Register the one typed exception this surface maps through the shared
-#: ``http_for`` emitter -- a slug failing SLUG_PATTERN on the four write
-#: routes (draft / edit / publish / deprecate); ``type_tag`` / ``loc``
+#: ``http_for`` emitter -- a slug failing SLUG_PATTERN on the five write
+#: routes (draft / edit / publish / deprecate / discard); ``type_tag`` / ``loc``
 #: feed the OpenAPI 422 validation-error LIST shape (see ``_errors``).
 register_error(
     InvalidKbSlugError,
@@ -218,7 +225,7 @@ class RunbookTemplateListResponse(BaseModel):
 
 
 class _VersionBody(BaseModel):
-    """Request body for the publish / deprecate routes -- carries ``version`` only.
+    """Request body for the publish / deprecate / discard routes -- carries ``version`` only.
 
     The slug is the URL's job (the route's ``{slug}`` path parameter); the
     body carries just the integer version to act on. ``extra="forbid"``
@@ -629,6 +636,59 @@ async def deprecate_template(
             detail=str(exc),
         ) from exc
     except TemplateNotPublishedError as exc:
+        raise HTTPException(
+            status_code=http_status.HTTP_400_BAD_REQUEST,
+            detail=str(exc),
+        ) from exc
+
+
+@router.post("/{slug}/discard", response_model=DiscardTemplateResponse)
+async def discard_template(
+    slug: str,
+    body: _VersionBody,
+    operator: Operator = _require_admin,
+) -> DiscardTemplateResponse:
+    """Delete an **unpublished draft** ``(slug, body.version)``.
+
+    ``tenant_admin`` only -- the delete-for-drafts leg of the template
+    lifecycle. A draft version is removed outright (subsequent ``GET
+    /{slug}`` / ``list`` no longer surface it). A missing
+    ``(tenant, slug, version)`` triple surfaces as 404
+    :class:`TemplateNotFoundError` (cross-tenant probes collapse here too,
+    and a re-discard of an already-removed draft is a 404 rather than a
+    silent success). A version that exists but is ``published`` /
+    ``deprecated`` surfaces as 400 :class:`TemplateNotDraftError` -- those
+    are retired via ``/deprecate`` (preserving lifecycle history), never
+    discarded.
+
+    A path slug that fails :data:`~meho_backplane.kb.schemas.SLUG_PATTERN`
+    surfaces as 422 :class:`InvalidKbSlugError` -- checked **before** the
+    audit/broadcast contextvars are bound so a rejected slug never fires a
+    write-classified audit row (consistent with the sibling write routes).
+
+    Binds ``audit_op_id="runbook.discard_template"`` + ``audit_op_class=
+    "write"`` + ``audit_slug`` + ``audit_version`` before the service call.
+    """
+    try:
+        validate_slug(slug)
+    except InvalidKbSlugError as exc:
+        raise http_for(exc) from exc
+    structlog.contextvars.bind_contextvars(
+        audit_op_id=_RUNBOOK_OP_IDS["discard"],
+        audit_op_class="write",
+        audit_slug=slug,
+        audit_version=body.version,
+    )
+    discard_request = DiscardTemplateRequest(slug=slug, version=body.version)
+    service = RunbookTemplateService()
+    try:
+        return await service.discard(operator.tenant_id, discard_request)
+    except TemplateNotFoundError as exc:
+        raise HTTPException(
+            status_code=http_status.HTTP_404_NOT_FOUND,
+            detail=str(exc),
+        ) from exc
+    except TemplateNotDraftError as exc:
         raise HTTPException(
             status_code=http_status.HTTP_400_BAD_REQUEST,
             detail=str(exc),

--- a/backend/src/meho_backplane/mcp/tools/runbooks.py
+++ b/backend/src/meho_backplane/mcp/tools/runbooks.py
@@ -1,7 +1,7 @@
 # SPDX-License-Identifier: Apache-2.0
 # Copyright (c) 2026 evoila Group
 # code-quality-allow: load-bearing tool descriptions per issue #1298; the
-# six template-verb descriptions teach the multi-session drafting pattern,
+# seven template-verb descriptions teach the multi-session drafting pattern,
 # fork-on-edit semantics, and the opacity-floor carve-out, and are
 # regression-tested verbatim. The file was already over the 600-line limit
 # on main; #1625's removal of the deprecated-alias machinery shrank it.
@@ -10,7 +10,7 @@
 
 """``meho.runbook.*`` template-lifecycle MCP tools (G12.2-T4).
 
-Six tool registrations that surface
+Seven tool registrations that surface
 :class:`~meho_backplane.runbooks.service.RunbookTemplateService` on the
 MCP transport. The matching REST routes are owned by the sibling Task
 #1297; both transports converge on the same service, so the versioning
@@ -53,8 +53,8 @@ The description IS the contract for "how to use this tool well."
 RBAC, audit, error mapping
 ===========================
 
-Four of the six tools are ``TENANT_ADMIN``-only (authoring + status
-flips). ``meho.runbook.list_templates`` is ``OPERATOR``-readable
+Five of the seven tools are ``TENANT_ADMIN``-only (authoring + status
+flips + draft discard). ``meho.runbook.list_templates`` is ``OPERATOR``-readable
 (summaries, no step bodies). ``meho.runbook.show_template`` admits an
 ``OPERATOR`` at the
 dispatcher gate but applies a *run-state-conditional* carve-out inside
@@ -103,6 +103,7 @@ from meho_backplane.mcp.server import McpInvalidParamsError
 from meho_backplane.runbooks.run_service import RunbookRunService
 from meho_backplane.runbooks.schemas import (
     DeprecateTemplateRequest,
+    DiscardTemplateRequest,
     DraftTemplateRequest,
     EditTemplateRequest,
     ListTemplatesFilter,
@@ -286,6 +287,25 @@ _DEPRECATE_DESCRIPTION: Final[str] = (
     "Requires TENANT_ADMIN role."
 )
 
+_DISCARD_DESCRIPTION: Final[str] = (
+    "Delete an UNPUBLISHED DRAFT version of a template. The delete-for-drafts "
+    "leg of the\n"
+    "template lifecycle: use it to throw away a draft you got wrong (typo'd "
+    "slug, wrong\n"
+    "steps) instead of the publish-then-deprecate workaround.\n\n"
+    "ONLY drafts are discardable. A published or deprecated version is "
+    "refused with\n"
+    "-32602 — those are retired with `meho.runbook.deprecate_template` "
+    "(which preserves\n"
+    "lifecycle history), never erased. A missing (slug, version) is also "
+    "-32602, so a\n"
+    "re-discard of an already-removed draft is a not-found, not a silent "
+    "success.\n\n"
+    "Use when: you drafted a template incorrectly and want it gone before "
+    "publishing.\n\n"
+    "Requires TENANT_ADMIN role."
+)
+
 _LIST_DESCRIPTION: Final[str] = (
     "List runbook templates in the operator's tenant. Returns "
     "template_slugs + titles + status\n"
@@ -348,7 +368,7 @@ _TEMPLATE_SLUG_PROPERTY: Final[dict[str, Any]] = {
         "entries): must start with a lowercase letter and contain only "
         "lowercase letters, digits, hyphens, or dots. Example: "
         "'vcenter-9.0-cert-rotation'. REQUIRED. Canonical field name "
-        "across all 11 runbook tools (#1612) — the same name "
+        "across all 12 runbook tools (#1612) — the same name "
         "`meho.runbook.start` takes and every template response returns."
     ),
 }
@@ -481,6 +501,31 @@ async def _deprecate_template_handler(
         )
     except (ValidationError, *_INVALID_PARAMS_ERRORS) as exc:
         raise _to_invalid_params("meho.runbook.deprecate_template", exc) from exc
+    return _mirror_template_slug(response.model_dump(mode="json"))
+
+
+async def _discard_template_handler(
+    operator: Operator,
+    arguments: dict[str, Any],
+) -> dict[str, Any]:
+    """Delete an unpublished draft ``(slug, version)``.
+
+    Maps :class:`TemplateNotDraftError` (version is published/deprecated)
+    and :class:`TemplateNotFoundError` (missing / already-removed) to
+    ``-32602`` via :data:`_INVALID_PARAMS_ERRORS`.
+    """
+    service = RunbookTemplateService()
+    slug = _resolve_template_slug("meho.runbook.discard_template", arguments)
+    try:
+        request = DiscardTemplateRequest.model_validate(
+            {"slug": slug, "version": arguments["version"]}
+        )
+        response = await service.discard(
+            tenant_id=operator.tenant_id,
+            request=request,
+        )
+    except (ValidationError, *_INVALID_PARAMS_ERRORS) as exc:
+        raise _to_invalid_params("meho.runbook.discard_template", exc) from exc
     return _mirror_template_slug(response.model_dump(mode="json"))
 
 
@@ -700,6 +745,26 @@ register_mcp_tool(
         op_class=_OP_CLASS_WRITE,
     ),
     handler=_deprecate_template_handler,
+)
+
+
+register_mcp_tool(
+    definition=ToolDefinition(
+        name="meho.runbook.discard_template",
+        description=_DISCARD_DESCRIPTION,
+        inputSchema={
+            "type": "object",
+            "properties": {
+                "template_slug": _TEMPLATE_SLUG_PROPERTY,
+                "version": _VERSION_PROPERTY,
+            },
+            "required": ["template_slug", "version"],
+            "additionalProperties": False,
+        },
+        required_role=TenantRole.TENANT_ADMIN,
+        op_class=_OP_CLASS_WRITE,
+    ),
+    handler=_discard_template_handler,
 )
 
 

--- a/backend/src/meho_backplane/runbooks/schemas.py
+++ b/backend/src/meho_backplane/runbooks/schemas.py
@@ -61,6 +61,8 @@ __all__ = [
     "ConfirmVerify",
     "DeprecateTemplateRequest",
     "DeprecateTemplateResponse",
+    "DiscardTemplateRequest",
+    "DiscardTemplateResponse",
     "DraftTemplateRequest",
     "DraftTemplateResponse",
     "EditTemplateRequest",
@@ -420,6 +422,34 @@ class DeprecateTemplateResponse(BaseModel):
     slug: str
     version: int
     status: Literal["deprecated"]
+
+
+class DiscardTemplateRequest(BaseModel):
+    """Request body for ``meho.runbook.discard_template`` -- delete an unpublished draft."""
+
+    model_config = ConfigDict(frozen=True)
+
+    slug: Annotated[str, Field(pattern=SLUG_PATTERN.pattern)]
+    version: int
+
+
+class DiscardTemplateResponse(BaseModel):
+    """Response for ``meho.runbook.discard_template`` -- the discarded draft's coordinates.
+
+    ``status`` is the synthetic terminal marker ``"discarded"`` -- unlike
+    the other lifecycle verbs it is **not** a stored
+    :class:`~meho_backplane.db.models.RunbookTemplate` status (the row is
+    deleted, not transitioned), it signals to the caller that the draft
+    was removed. Only unpublished drafts are discardable; published /
+    deprecated versions are retired via ``deprecate`` (preserving history),
+    never discarded.
+    """
+
+    model_config = ConfigDict(frozen=True)
+
+    slug: str
+    version: int
+    status: Literal["discarded"]
 
 
 class ListTemplatesFilter(BaseModel):

--- a/backend/src/meho_backplane/runbooks/service.py
+++ b/backend/src/meho_backplane/runbooks/service.py
@@ -68,6 +68,8 @@ from meho_backplane.kb.schemas import validate_slug
 from meho_backplane.runbooks.schemas import (
     DeprecateTemplateRequest,
     DeprecateTemplateResponse,
+    DiscardTemplateRequest,
+    DiscardTemplateResponse,
     DraftTemplateRequest,
     DraftTemplateResponse,
     EditTemplateRequest,
@@ -112,7 +114,12 @@ class TemplateNotFoundError(LookupError):
 
 
 class TemplateNotDraftError(ValueError):
-    """Raised when publish is called against a non-draft template."""
+    """Raised when a draft-only op hits a non-draft template.
+
+    Both ``publish`` (a published/deprecated version cannot be re-published)
+    and ``discard`` (a published/deprecated version is retired via
+    ``deprecate``, never discarded) require the target to be a draft.
+    """
 
 
 class TemplateNotPublishedError(ValueError):
@@ -363,6 +370,55 @@ class RunbookTemplateService:
         )
         return DeprecateTemplateResponse(
             slug=request.slug, version=request.version, status="deprecated"
+        )
+
+    async def discard(
+        self,
+        tenant_id: uuid.UUID,
+        request: DiscardTemplateRequest,
+    ) -> DiscardTemplateResponse:
+        """Delete an **unpublished draft** ``(tenant_id, slug, version)``.
+
+        Completes the template CRUD lifecycle with a delete-for-drafts leg:
+        an operator who drafts incorrectly (typo'd slug, wrong steps) can
+        remove the draft cleanly instead of the publish-then-deprecate
+        workaround. Only ``draft`` rows are discardable -- a ``published``
+        or ``deprecated`` version raises :class:`TemplateNotDraftError`
+        (those are retired via :meth:`deprecate`, never erased, preserving
+        the audit/lifecycle of anything that was ever live). A missing
+        ``(tenant, slug, version)`` triple raises
+        :class:`TemplateNotFoundError` -- the same not-found posture as
+        :meth:`publish` / :meth:`deprecate` (so a re-discard of an
+        already-removed draft is a 404, not a silent success).
+
+        A pure draft cannot have runs (``start_run`` pins to a *published*
+        version), so there is no cascade to handle -- the row is deleted
+        outright.
+        """
+        sessionmaker = get_sessionmaker()
+        async with sessionmaker() as session:
+            row = await self._load_exact(session, tenant_id, request.slug, request.version)
+            if row is None:
+                raise TemplateNotFoundError(
+                    f"no template {request.slug!r} v{request.version} for tenant"
+                )
+            if row.status != "draft":
+                raise TemplateNotDraftError(
+                    f"template {request.slug!r} v{request.version} is "
+                    f"{row.status!r}, not draft; cannot discard "
+                    f"(use deprecate to retire a published version)"
+                )
+            await session.delete(row)
+            await session.commit()
+
+        structlog.get_logger().info(
+            "runbook_template_discarded",
+            tenant_id=str(tenant_id),
+            slug=request.slug,
+            version=request.version,
+        )
+        return DiscardTemplateResponse(
+            slug=request.slug, version=request.version, status="discarded"
         )
 
     async def count_in_flight_runs(

--- a/backend/tests/test_mcp_tools_list_shape_conventions.py
+++ b/backend/tests/test_mcp_tools_list_shape_conventions.py
@@ -404,14 +404,16 @@ def test_list_operation_groups_paginates_keyset_on_group_key() -> None:
 # §14.9 — runbook family: dotted names only + template_slug field
 # ---------------------------------------------------------------------------
 
-#: The 11 canonical dotted runbook tool names (#1612). After #1625 these
-#: are the *only* runbook tools on the surface — the flat ``runbook_*``
-#: aliases that bridged the one-release migration window were removed.
+#: The 12 canonical dotted runbook tool names (#1612, + discard_template
+#: #135). After #1625 these are the *only* runbook tools on the surface —
+#: the flat ``runbook_*`` aliases that bridged the one-release migration
+#: window were removed.
 _DOTTED_RUNBOOK_TOOLS = (
     "meho.runbook.draft_template",
     "meho.runbook.edit_template",
     "meho.runbook.publish_template",
     "meho.runbook.deprecate_template",
+    "meho.runbook.discard_template",
     "meho.runbook.list_templates",
     "meho.runbook.show_template",
     "meho.runbook.start",
@@ -437,14 +439,14 @@ _REMOVED_FLAT_RUNBOOK_TOOLS = (
 )
 
 
-def test_runbook_family_is_exactly_eleven_dotted_tools() -> None:
-    """Convention §14.9: the runbook family is exactly 11 dotted tools, zero flat.
+def test_runbook_family_is_exactly_twelve_dotted_tools() -> None:
+    """Convention §14.9: the runbook family is exactly 12 dotted tools, zero flat.
 
     The runbook family was the last flat multi-verb family on the surface
     (#1612). #1612 made the dotted ``meho.runbook.<verb>`` names canonical
     and kept the flat ``runbook_*`` names as deprecated aliases for one
-    release; #1625 removed them. The wire surface now serves exactly the
-    11 dotted tools and no flat aliases.
+    release; #1625 removed them. #135 added ``discard_template``. The wire
+    surface now serves exactly the 12 dotted tools and no flat aliases.
     """
     # Enumerate the live tool registry (the same private map the
     # dispatcher resolves against). The structural pin is total: the set

--- a/backend/tests/test_mcp_tools_runbooks_templates.py
+++ b/backend/tests/test_mcp_tools_runbooks_templates.py
@@ -3,11 +3,11 @@
 
 """Tests for the ``meho.runbook.*`` template-lifecycle MCP tools (G12.2-T4, #1298).
 
-Covers the task's acceptance criteria for the six template-lifecycle
+Covers the task's acceptance criteria for the seven template-lifecycle
 tools that wrap :class:`~meho_backplane.runbooks.service.RunbookTemplateService`
-on the MCP transport:
+on the MCP transport (``discard_template`` added by #135):
 
-* All six tools register against the G0.5 registry with strict 2020-12
+* All seven tools register against the G0.5 registry with strict 2020-12
   ``inputSchema`` and the MEHO-internal RBAC fields stripped from the
   wire shape.
 * RBAC: five tools are ``TENANT_ADMIN``-only; ``meho.runbook.list_templates``
@@ -63,6 +63,7 @@ _ADMIN_TOOLS = {
     "meho.runbook.edit_template",
     "meho.runbook.publish_template",
     "meho.runbook.deprecate_template",
+    "meho.runbook.discard_template",
 }
 # ``meho.runbook.show_template`` is OPERATOR-readable at the dispatcher gate
 # (G12.3-T4 / #1309); the run-state-conditional opacity-floor check lives
@@ -128,10 +129,10 @@ def _result_payload(body: Any) -> Any:
 
 
 @pytest.mark.parametrize("client_with_operator", [TenantRole.TENANT_ADMIN], indirect=True)
-def test_all_six_tools_registered_with_strict_schema(
+def test_all_seven_tools_registered_with_strict_schema(
     client_with_operator: tuple[TestClient, Operator],  # noqa: F811
 ) -> None:
-    """AC: all six tools surface for a TENANT_ADMIN with strict input schemas."""
+    """AC: all seven tools surface for a TENANT_ADMIN with strict input schemas."""
     client, _op = client_with_operator
     response = post_mcp(client, {"jsonrpc": "2.0", "id": 1, "method": "tools/list"})
     tools_by_name = {t["name"]: t for t in response.json()["result"]["tools"]}
@@ -378,6 +379,41 @@ def test_deprecate_tool_invocation(
         "version": 1,
         "status": "deprecated",
     }
+
+
+@pytest.mark.parametrize("client_with_operator", [TenantRole.TENANT_ADMIN], indirect=True)
+def test_discard_tool_invocation(
+    client_with_operator: tuple[TestClient, Operator],  # noqa: F811
+) -> None:
+    """AC4: discard a draft; a published version and a re-discard both → ``-32602``."""
+    client, _op = client_with_operator
+    _call(client, "meho.runbook.draft_template", {"template_slug": "cert-rotate", "body": _body()})
+
+    ok = _result_payload(
+        _call(
+            client, "meho.runbook.discard_template", {"template_slug": "cert-rotate", "version": 1}
+        )
+    )
+    assert ok == {
+        "slug": "cert-rotate",
+        "template_slug": "cert-rotate",
+        "version": 1,
+        "status": "discarded",
+    }
+
+    # Re-discarding the now-removed draft → TemplateNotFoundError → -32602.
+    gone = _call(
+        client, "meho.runbook.discard_template", {"template_slug": "cert-rotate", "version": 1}
+    )
+    assert gone["error"]["code"] == INVALID_PARAMS
+
+    # Discarding a published version is refused (retired via deprecate, not discarded).
+    _call(client, "meho.runbook.draft_template", {"template_slug": "drain-node", "body": _body()})
+    _call(client, "meho.runbook.publish_template", {"template_slug": "drain-node", "version": 1})
+    published = _call(
+        client, "meho.runbook.discard_template", {"template_slug": "drain-node", "version": 1}
+    )
+    assert published["error"]["code"] == INVALID_PARAMS
 
 
 # ---------------------------------------------------------------------------

--- a/backend/tests/test_runbook_templates_api.py
+++ b/backend/tests/test_runbook_templates_api.py
@@ -60,6 +60,7 @@ from meho_backplane.kb.schemas import InvalidKbSlugError
 from meho_backplane.middleware import RequestContextMiddleware
 from meho_backplane.runbooks.schemas import (
     DeprecateTemplateResponse,
+    DiscardTemplateResponse,
     DraftTemplateResponse,
     EditTemplateResponse,
     ForkInfo,
@@ -258,8 +259,8 @@ async def _audit_rows_for_path(path: str) -> list[AuditLog]:
 # ---------------------------------------------------------------------------
 
 
-def test_all_six_routes_mounted_on_main_app() -> None:
-    """All six routes appear in :mod:`meho_backplane.main`'s app + OpenAPI."""
+def test_all_seven_routes_mounted_on_main_app() -> None:
+    """All seven routes appear in :mod:`meho_backplane.main`'s app + OpenAPI."""
     from meho_backplane.main import app
 
     openapi = app.openapi()
@@ -270,6 +271,7 @@ def test_all_six_routes_mounted_on_main_app() -> None:
         "/api/v1/runbooks/templates/{slug}",
         "/api/v1/runbooks/templates/{slug}/publish",
         "/api/v1/runbooks/templates/{slug}/deprecate",
+        "/api/v1/runbooks/templates/{slug}/discard",
     }
     missing = expected_paths - paths.keys()
     assert not missing, f"missing routes: {missing}"
@@ -280,6 +282,7 @@ def test_all_six_routes_mounted_on_main_app() -> None:
     assert "patch" in paths["/api/v1/runbooks/templates/{slug}"]
     assert "post" in paths["/api/v1/runbooks/templates/{slug}/publish"]
     assert "post" in paths["/api/v1/runbooks/templates/{slug}/deprecate"]
+    assert "post" in paths["/api/v1/runbooks/templates/{slug}/discard"]
 
 
 # ---------------------------------------------------------------------------
@@ -977,6 +980,83 @@ def test_deprecate_draft_400(client: TestClient) -> None:
 
 
 # ---------------------------------------------------------------------------
+# POST /{slug}/discard  (#135)
+# ---------------------------------------------------------------------------
+
+
+def test_discard_200(client: TestClient) -> None:
+    """POST /discard deletes a draft → 200 with status="discarded"."""
+    key, token = _admin_token()
+    fake_discard = AsyncMock(
+        return_value=DiscardTemplateResponse(slug="rotate-cert", version=1, status="discarded")
+    )
+    with (
+        respx.mock as mock_router,
+        patch(f"{_ROUTE}.discard", fake_discard),
+    ):
+        _mock_discovery_and_jwks(mock_router, _public_jwks(key))
+        response = client.post(
+            "/api/v1/runbooks/templates/rotate-cert/discard",
+            json={"version": 1},
+            headers=_authed(token),
+        )
+    assert response.status_code == 200
+    assert response.json()["status"] == "discarded"
+
+
+def test_discard_published_400(client: TestClient) -> None:
+    """POST /discard on a published version → 400 (TemplateNotDraftError)."""
+    key, token = _admin_token()
+    fake_discard = AsyncMock(
+        side_effect=TemplateNotDraftError(
+            "is 'published', not draft; cannot discard (use deprecate)"
+        )
+    )
+    with (
+        respx.mock as mock_router,
+        patch(f"{_ROUTE}.discard", fake_discard),
+    ):
+        _mock_discovery_and_jwks(mock_router, _public_jwks(key))
+        response = client.post(
+            "/api/v1/runbooks/templates/rotate-cert/discard",
+            json={"version": 1},
+            headers=_authed(token),
+        )
+    assert response.status_code == 400
+    assert "deprecate" in response.json()["detail"]
+
+
+def test_discard_missing_404(client: TestClient) -> None:
+    """POST /discard on a missing (slug, version) → 404 (TemplateNotFoundError)."""
+    key, token = _admin_token()
+    fake_discard = AsyncMock(side_effect=TemplateNotFoundError("no template 'ghost' v1 for tenant"))
+    with (
+        respx.mock as mock_router,
+        patch(f"{_ROUTE}.discard", fake_discard),
+    ):
+        _mock_discovery_and_jwks(mock_router, _public_jwks(key))
+        response = client.post(
+            "/api/v1/runbooks/templates/ghost/discard",
+            json={"version": 1},
+            headers=_authed(token),
+        )
+    assert response.status_code == 404
+
+
+def test_discard_operator_role_403(client: TestClient) -> None:
+    """Operator on POST /discard → 403 (tenant_admin-only, matches sibling verbs)."""
+    key, token = _operator_token()
+    with respx.mock as mock_router:
+        _mock_discovery_and_jwks(mock_router, _public_jwks(key))
+        response = client.post(
+            "/api/v1/runbooks/templates/rotate-cert/discard",
+            json={"version": 1},
+            headers=_authed(token),
+        )
+    assert response.status_code == 403
+
+
+# ---------------------------------------------------------------------------
 # Malformed path slug on the model-rebuilding routes (regression: #1336 B1)
 #
 # PATCH /{slug}, POST /{slug}/publish, and POST /{slug}/deprecate rebuild a
@@ -1063,6 +1143,25 @@ def test_deprecate_malformed_slug_422_no_service_call(client: TestClient) -> Non
     assert response.status_code == 422
     _assert_invalid_kb_slug_shape(response.json()["detail"])
     fake_deprecate.assert_not_awaited()
+
+
+def test_discard_malformed_slug_422_no_service_call(client: TestClient) -> None:
+    """POST /discard on a malformed path slug → 422, service never invoked."""
+    key, token = _admin_token()
+    fake_discard = AsyncMock()
+    with (
+        respx.mock as mock_router,
+        patch(f"{_ROUTE}.discard", fake_discard),
+    ):
+        _mock_discovery_and_jwks(mock_router, _public_jwks(key))
+        response = client.post(
+            f"/api/v1/runbooks/templates/{_MALFORMED_SLUG}/discard",
+            json={"version": 1},
+            headers=_authed(token),
+        )
+    assert response.status_code == 422
+    _assert_invalid_kb_slug_shape(response.json()["detail"])
+    fake_discard.assert_not_awaited()
 
 
 @pytest.mark.asyncio
@@ -1181,6 +1280,35 @@ async def test_publish_writes_audit_row_with_publish_op_id_and_version() -> None
     # The template body / step contents never reach the audit payload.
     serialised = json.dumps(payload)
     assert "revoke-old-cert" not in serialised
+
+
+@pytest.mark.asyncio
+async def test_discard_writes_audit_row_with_discard_op_id_and_version() -> None:
+    """POST /discard → audit row ``op_id="runbook.discard_template"`` + slug + version (AC4)."""
+    key, token = _admin_token()
+    fake_discard = AsyncMock(
+        return_value=DiscardTemplateResponse(slug="rotate-cert", version=2, status="discarded")
+    )
+    test_client = TestClient(_build_app())
+    with (
+        respx.mock as mock_router,
+        patch(f"{_ROUTE}.discard", fake_discard),
+    ):
+        _mock_discovery_and_jwks(mock_router, _public_jwks(key))
+        response = test_client.post(
+            "/api/v1/runbooks/templates/rotate-cert/discard",
+            json={"version": 2},
+            headers=_authed(token),
+        )
+    assert response.status_code == 200
+
+    rows = await _audit_rows_for_path("/api/v1/runbooks/templates/rotate-cert/discard")
+    assert len(rows) == 1
+    payload = rows[0].payload
+    assert payload["op_id"] == "runbook.discard_template"
+    assert payload["op_class"] == "write"
+    assert payload["slug"] == "rotate-cert"
+    assert payload["version"] == 2
 
 
 @pytest.mark.asyncio

--- a/backend/tests/test_runbooks_template_service.py
+++ b/backend/tests/test_runbooks_template_service.py
@@ -41,6 +41,7 @@ from meho_backplane.kb.schemas import InvalidKbSlugError
 from meho_backplane.runbooks.schemas import (
     ConfirmVerify,
     DeprecateTemplateRequest,
+    DiscardTemplateRequest,
     DraftTemplateRequest,
     EditTemplateRequest,
     ListTemplatesFilter,
@@ -449,3 +450,88 @@ async def test_show_template_missing_raises() -> None:
 
     with pytest.raises(TemplateNotFoundError):
         await service.show_template(tenant_id, "ghost")
+
+
+# ---------------------------------------------------------------------------
+# discard (delete-for-drafts leg, #135)
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.asyncio
+async def test_discard_removes_draft() -> None:
+    """A draft discards cleanly; a subsequent show 404s (AC1)."""
+    service = RunbookTemplateService()
+    tenant_id = uuid.uuid4()
+    await service.create_draft(
+        tenant_id, OPERATOR, DraftTemplateRequest(slug="drain-node", body=_body("v1"))
+    )
+
+    resp = await service.discard(tenant_id, DiscardTemplateRequest(slug="drain-node", version=1))
+    assert resp.status == "discarded"
+    assert resp.slug == "drain-node"
+    assert resp.version == 1
+
+    # The draft is gone: show now raises, and the slug re-drafts as v1.
+    with pytest.raises(TemplateNotFoundError):
+        await service.show_template(tenant_id, "drain-node", version=1)
+    listed = await service.list_templates(tenant_id, ListTemplatesFilter())
+    assert [t.slug for t in listed] == []
+
+
+@pytest.mark.asyncio
+async def test_discard_slug_is_reusable_after_discard() -> None:
+    """Discarding v1 frees the slug: create_draft succeeds again at v1."""
+    service = RunbookTemplateService()
+    tenant_id = uuid.uuid4()
+    await service.create_draft(
+        tenant_id, OPERATOR, DraftTemplateRequest(slug="drain-node", body=_body("v1"))
+    )
+    await service.discard(tenant_id, DiscardTemplateRequest(slug="drain-node", version=1))
+
+    # No DuplicateDraftError -- the slug has no rows left.
+    again = await service.create_draft(
+        tenant_id, OPERATOR, DraftTemplateRequest(slug="drain-node", body=_body("v1-again"))
+    )
+    assert again.version == 1
+
+
+@pytest.mark.asyncio
+async def test_discard_published_raises_pointing_at_deprecate() -> None:
+    """Discarding a published version raises TemplateNotDraftError naming deprecate (AC2)."""
+    service = RunbookTemplateService()
+    tenant_id = uuid.uuid4()
+    await service.create_draft(
+        tenant_id, OPERATOR, DraftTemplateRequest(slug="drain-node", body=_body("v1"))
+    )
+    await service.publish(tenant_id, PublishTemplateRequest(slug="drain-node", version=1))
+
+    with pytest.raises(TemplateNotDraftError, match="deprecate"):
+        await service.discard(tenant_id, DiscardTemplateRequest(slug="drain-node", version=1))
+
+    # The published row is untouched by the refused discard.
+    assert (await service.show_template(tenant_id, "drain-node", version=1)).status == "published"
+
+
+@pytest.mark.asyncio
+async def test_discard_deprecated_raises() -> None:
+    """Discarding a deprecated version is refused (retired, not discardable)."""
+    service = RunbookTemplateService()
+    tenant_id = uuid.uuid4()
+    await service.create_draft(
+        tenant_id, OPERATOR, DraftTemplateRequest(slug="drain-node", body=_body("v1"))
+    )
+    await service.publish(tenant_id, PublishTemplateRequest(slug="drain-node", version=1))
+    await service.deprecate(tenant_id, DeprecateTemplateRequest(slug="drain-node", version=1))
+
+    with pytest.raises(TemplateNotDraftError):
+        await service.discard(tenant_id, DiscardTemplateRequest(slug="drain-node", version=1))
+
+
+@pytest.mark.asyncio
+async def test_discard_missing_raises() -> None:
+    """Discarding a non-existent (slug, version) raises TemplateNotFoundError."""
+    service = RunbookTemplateService()
+    tenant_id = uuid.uuid4()
+
+    with pytest.raises(TemplateNotFoundError):
+        await service.discard(tenant_id, DiscardTemplateRequest(slug="ghost", version=1))

--- a/backend/tests/test_runbooks_template_service.py
+++ b/backend/tests/test_runbooks_template_service.py
@@ -479,6 +479,43 @@ async def test_discard_removes_draft() -> None:
 
 
 @pytest.mark.asyncio
+async def test_discard_forked_draft_leaves_published_parent_and_runs_intact() -> None:
+    """Discarding a forked v2 draft must not touch the published v1 or its runs.
+
+    The interesting correctness path: a draft forked from a published version
+    that has in-flight runs. Discarding the fork removes only the v2 row --
+    v1 stays published, its pinned run survives (``runbook_runs`` carries no
+    FK to ``runbook_templates``), and v1 becomes the latest again.
+    """
+    service = RunbookTemplateService()
+    tenant_id = uuid.uuid4()
+    await service.create_draft(
+        tenant_id, OPERATOR, DraftTemplateRequest(slug="drain-node", body=_body("v1"))
+    )
+    await service.publish(tenant_id, PublishTemplateRequest(slug="drain-node", version=1))
+    await _seed_run(tenant_id, "drain-node", 1, "in_progress")
+    # Editing a published slug with no draft forks a new v2 draft.
+    forked = await service.update_or_fork(
+        tenant_id, OPERATOR, EditTemplateRequest(slug="drain-node", body=_body("v2"))
+    )
+    assert forked.version == 2
+
+    resp = await service.discard(tenant_id, DiscardTemplateRequest(slug="drain-node", version=2))
+    assert resp.status == "discarded"
+
+    # v1 is untouched and is once again the latest version.
+    v1 = await service.show_template(tenant_id, "drain-node", version=1)
+    assert v1.status == "published"
+    with pytest.raises(TemplateNotFoundError):
+        await service.show_template(tenant_id, "drain-node", version=2)
+    latest = await service.show_template(tenant_id, "drain-node")
+    assert latest.version == 1
+
+    # The in-flight run pinned to v1 survives the fork's discard.
+    assert await service.count_in_flight_runs(tenant_id, "drain-node", 1) == 1
+
+
+@pytest.mark.asyncio
 async def test_discard_slug_is_reusable_after_discard() -> None:
     """Discarding v1 frees the slug: create_draft succeeds again at v1."""
     service = RunbookTemplateService()

--- a/cli/api/openapi.json
+++ b/cli/api/openapi.json
@@ -4335,6 +4335,69 @@
         }
       }
     },
+    "/api/v1/runbooks/templates/{slug}/discard": {
+      "post": {
+        "tags": [
+          "runbooks"
+        ],
+        "summary": "Discard Template",
+        "description": "Delete an **unpublished draft** ``(slug, body.version)``.\n\n``tenant_admin`` only -- the delete-for-drafts leg of the template\nlifecycle. A draft version is removed outright (subsequent ``GET\n/{slug}`` / ``list`` no longer surface it). A missing\n``(tenant, slug, version)`` triple surfaces as 404\n:class:`TemplateNotFoundError` (cross-tenant probes collapse here too,\nand a re-discard of an already-removed draft is a 404 rather than a\nsilent success). A version that exists but is ``published`` /\n``deprecated`` surfaces as 400 :class:`TemplateNotDraftError` -- those\nare retired via ``/deprecate`` (preserving lifecycle history), never\ndiscarded.\n\nA path slug that fails :data:`~meho_backplane.kb.schemas.SLUG_PATTERN`\nsurfaces as 422 :class:`InvalidKbSlugError` -- checked **before** the\naudit/broadcast contextvars are bound so a rejected slug never fires a\nwrite-classified audit row (consistent with the sibling write routes).\n\nBinds ``audit_op_id=\"runbook.discard_template\"`` + ``audit_op_class=\n\"write\"`` + ``audit_slug`` + ``audit_version`` before the service call.",
+        "operationId": "discard_template_api_v1_runbooks_templates__slug__discard_post",
+        "parameters": [
+          {
+            "name": "slug",
+            "in": "path",
+            "required": true,
+            "schema": {
+              "type": "string",
+              "title": "Slug"
+            }
+          },
+          {
+            "name": "authorization",
+            "in": "header",
+            "required": false,
+            "schema": {
+              "type": "string",
+              "nullable": true,
+              "title": "Authorization"
+            }
+          }
+        ],
+        "requestBody": {
+          "required": true,
+          "content": {
+            "application/json": {
+              "schema": {
+                "$ref": "#/components/schemas/_VersionBody"
+              }
+            }
+          }
+        },
+        "responses": {
+          "200": {
+            "description": "Successful Response",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/DiscardTemplateResponse"
+                }
+              }
+            }
+          },
+          "422": {
+            "description": "Validation Error",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/HTTPValidationError"
+                }
+              }
+            }
+          }
+        }
+      }
+    },
     "/api/v1/runbooks/runs": {
       "post": {
         "tags": [
@@ -21569,6 +21632,31 @@
         "title": "DeprecateTemplateResponse",
         "description": "Response for ``meho.runbook.deprecate_template`` -- the now-deprecated coordinates."
       },
+      "DiscardTemplateResponse": {
+        "properties": {
+          "slug": {
+            "type": "string",
+            "title": "Slug"
+          },
+          "version": {
+            "type": "integer",
+            "title": "Version"
+          },
+          "status": {
+            "type": "string",
+            "const": "discarded",
+            "title": "Status"
+          }
+        },
+        "type": "object",
+        "required": [
+          "slug",
+          "version",
+          "status"
+        ],
+        "title": "DiscardTemplateResponse",
+        "description": "Response for ``meho.runbook.discard_template`` -- the discarded draft's coordinates.\n\n``status`` is the synthetic terminal marker ``\"discarded\"`` -- unlike\nthe other lifecycle verbs it is **not** a stored\n:class:`~meho_backplane.db.models.RunbookTemplate` status (the row is\ndeleted, not transitioned), it signals to the caller that the draft\nwas removed. Only unpublished drafts are discardable; published /\ndeprecated versions are retired via ``deprecate`` (preserving history),\nnever discarded."
+      },
       "DocCollectionBackend": {
         "properties": {
           "type": {
@@ -26274,7 +26362,7 @@
           "version"
         ],
         "title": "_VersionBody",
-        "description": "Request body for the publish / deprecate routes -- carries ``version`` only.\n\nThe slug is the URL's job (the route's ``{slug}`` path parameter); the\nbody carries just the integer version to act on. ``extra=\"forbid\"``\nrejects a stray ``slug`` in the body at 422 rather than silently\nignoring it -- the URL is the single source of truth for which\ntemplate the operation targets, and a body that smuggled a different\nslug would otherwise be a confused-deputy footgun."
+        "description": "Request body for the publish / deprecate / discard routes -- carries ``version`` only.\n\nThe slug is the URL's job (the route's ``{slug}`` path parameter); the\nbody carries just the integer version to act on. ``extra=\"forbid\"``\nrejects a stray ``slug`` in the body at 422 rather than silently\nignoring it -- the URL is the single source of truth for which\ntemplate the operation targets, and a body that smuggled a different\nslug would otherwise be a confused-deputy footgun."
       },
       "_ViewMode": {
         "type": "string",

--- a/cli/internal/api/client.gen.go
+++ b/cli/internal/api/client.gen.go
@@ -3014,6 +3014,21 @@ type DeprecateTemplateResponse struct {
 	Version int    `json:"version"`
 }
 
+// DiscardTemplateResponse Response for “meho.runbook.discard_template“ -- the discarded draft's coordinates.
+//
+// “status“ is the synthetic terminal marker “"discarded"“ -- unlike
+// the other lifecycle verbs it is **not** a stored
+// :class:`~meho_backplane.db.models.RunbookTemplate` status (the row is
+// deleted, not transitioned), it signals to the caller that the draft
+// was removed. Only unpublished drafts are discardable; published /
+// deprecated versions are retired via “deprecate“ (preserving history),
+// never discarded.
+type DiscardTemplateResponse struct {
+	Slug    string `json:"slug"`
+	Status  string `json:"status"`
+	Version int    `json:"version"`
+}
+
 // DocCollectionBackend The “{type, ref}“ backend routing record a create supplies.
 //
 // “type“ is the search-backend type the row routes to (validated at
@@ -6134,7 +6149,7 @@ type UnderscoreSortDirection string
 // }}“ rendering stable (“"all"“, not “"_StatusFilter.ALL"“).
 type UnderscoreStatusFilter string
 
-// UnderscoreVersionBody Request body for the publish / deprecate routes -- carries “version“ only.
+// UnderscoreVersionBody Request body for the publish / deprecate / discard routes -- carries “version“ only.
 //
 // The slug is the URL's job (the route's “{slug}“ path parameter); the
 // body carries just the integer version to act on. “extra="forbid"“
@@ -6755,6 +6770,11 @@ type DeprecateTemplateApiV1RunbooksTemplatesSlugDeprecatePostParams struct {
 	Authorization *string `json:"authorization,omitempty"`
 }
 
+// DiscardTemplateApiV1RunbooksTemplatesSlugDiscardPostParams defines parameters for DiscardTemplateApiV1RunbooksTemplatesSlugDiscardPost.
+type DiscardTemplateApiV1RunbooksTemplatesSlugDiscardPostParams struct {
+	Authorization *string `json:"authorization,omitempty"`
+}
+
 // PublishTemplateApiV1RunbooksTemplatesSlugPublishPostParams defines parameters for PublishTemplateApiV1RunbooksTemplatesSlugPublishPost.
 type PublishTemplateApiV1RunbooksTemplatesSlugPublishPostParams struct {
 	Authorization *string `json:"authorization,omitempty"`
@@ -7372,6 +7392,9 @@ type EditTemplateApiV1RunbooksTemplatesSlugPatchJSONRequestBody = RunbookTemplat
 
 // DeprecateTemplateApiV1RunbooksTemplatesSlugDeprecatePostJSONRequestBody defines body for DeprecateTemplateApiV1RunbooksTemplatesSlugDeprecatePost for application/json ContentType.
 type DeprecateTemplateApiV1RunbooksTemplatesSlugDeprecatePostJSONRequestBody = UnderscoreVersionBody
+
+// DiscardTemplateApiV1RunbooksTemplatesSlugDiscardPostJSONRequestBody defines body for DiscardTemplateApiV1RunbooksTemplatesSlugDiscardPost for application/json ContentType.
+type DiscardTemplateApiV1RunbooksTemplatesSlugDiscardPostJSONRequestBody = UnderscoreVersionBody
 
 // PublishTemplateApiV1RunbooksTemplatesSlugPublishPostJSONRequestBody defines body for PublishTemplateApiV1RunbooksTemplatesSlugPublishPost for application/json ContentType.
 type PublishTemplateApiV1RunbooksTemplatesSlugPublishPostJSONRequestBody = UnderscoreVersionBody
@@ -8942,6 +8965,11 @@ type ClientInterface interface {
 	DeprecateTemplateApiV1RunbooksTemplatesSlugDeprecatePostWithBody(ctx context.Context, slug string, params *DeprecateTemplateApiV1RunbooksTemplatesSlugDeprecatePostParams, contentType string, body io.Reader, reqEditors ...RequestEditorFn) (*http.Response, error)
 
 	DeprecateTemplateApiV1RunbooksTemplatesSlugDeprecatePost(ctx context.Context, slug string, params *DeprecateTemplateApiV1RunbooksTemplatesSlugDeprecatePostParams, body DeprecateTemplateApiV1RunbooksTemplatesSlugDeprecatePostJSONRequestBody, reqEditors ...RequestEditorFn) (*http.Response, error)
+
+	// DiscardTemplateApiV1RunbooksTemplatesSlugDiscardPostWithBody request with any body
+	DiscardTemplateApiV1RunbooksTemplatesSlugDiscardPostWithBody(ctx context.Context, slug string, params *DiscardTemplateApiV1RunbooksTemplatesSlugDiscardPostParams, contentType string, body io.Reader, reqEditors ...RequestEditorFn) (*http.Response, error)
+
+	DiscardTemplateApiV1RunbooksTemplatesSlugDiscardPost(ctx context.Context, slug string, params *DiscardTemplateApiV1RunbooksTemplatesSlugDiscardPostParams, body DiscardTemplateApiV1RunbooksTemplatesSlugDiscardPostJSONRequestBody, reqEditors ...RequestEditorFn) (*http.Response, error)
 
 	// PublishTemplateApiV1RunbooksTemplatesSlugPublishPostWithBody request with any body
 	PublishTemplateApiV1RunbooksTemplatesSlugPublishPostWithBody(ctx context.Context, slug string, params *PublishTemplateApiV1RunbooksTemplatesSlugPublishPostParams, contentType string, body io.Reader, reqEditors ...RequestEditorFn) (*http.Response, error)
@@ -11355,6 +11383,30 @@ func (c *Client) DeprecateTemplateApiV1RunbooksTemplatesSlugDeprecatePostWithBod
 
 func (c *Client) DeprecateTemplateApiV1RunbooksTemplatesSlugDeprecatePost(ctx context.Context, slug string, params *DeprecateTemplateApiV1RunbooksTemplatesSlugDeprecatePostParams, body DeprecateTemplateApiV1RunbooksTemplatesSlugDeprecatePostJSONRequestBody, reqEditors ...RequestEditorFn) (*http.Response, error) {
 	req, err := NewDeprecateTemplateApiV1RunbooksTemplatesSlugDeprecatePostRequest(c.Server, slug, params, body)
+	if err != nil {
+		return nil, err
+	}
+	req = req.WithContext(ctx)
+	if err := c.applyEditors(ctx, req, reqEditors); err != nil {
+		return nil, err
+	}
+	return c.Client.Do(req)
+}
+
+func (c *Client) DiscardTemplateApiV1RunbooksTemplatesSlugDiscardPostWithBody(ctx context.Context, slug string, params *DiscardTemplateApiV1RunbooksTemplatesSlugDiscardPostParams, contentType string, body io.Reader, reqEditors ...RequestEditorFn) (*http.Response, error) {
+	req, err := NewDiscardTemplateApiV1RunbooksTemplatesSlugDiscardPostRequestWithBody(c.Server, slug, params, contentType, body)
+	if err != nil {
+		return nil, err
+	}
+	req = req.WithContext(ctx)
+	if err := c.applyEditors(ctx, req, reqEditors); err != nil {
+		return nil, err
+	}
+	return c.Client.Do(req)
+}
+
+func (c *Client) DiscardTemplateApiV1RunbooksTemplatesSlugDiscardPost(ctx context.Context, slug string, params *DiscardTemplateApiV1RunbooksTemplatesSlugDiscardPostParams, body DiscardTemplateApiV1RunbooksTemplatesSlugDiscardPostJSONRequestBody, reqEditors ...RequestEditorFn) (*http.Response, error) {
+	req, err := NewDiscardTemplateApiV1RunbooksTemplatesSlugDiscardPostRequest(c.Server, slug, params, body)
 	if err != nil {
 		return nil, err
 	}
@@ -21407,6 +21459,68 @@ func NewDeprecateTemplateApiV1RunbooksTemplatesSlugDeprecatePostRequestWithBody(
 	}
 
 	operationPath := fmt.Sprintf("/api/v1/runbooks/templates/%s/deprecate", pathParam0)
+	if operationPath[0] == '/' {
+		operationPath = "." + operationPath
+	}
+
+	queryURL, err := serverURL.Parse(operationPath)
+	if err != nil {
+		return nil, err
+	}
+
+	req, err := http.NewRequest("POST", queryURL.String(), body)
+	if err != nil {
+		return nil, err
+	}
+
+	req.Header.Add("Content-Type", contentType)
+
+	if params != nil {
+
+		if params.Authorization != nil {
+			var headerParam0 string
+
+			headerParam0, err = runtime.StyleParamWithLocation("simple", false, "authorization", runtime.ParamLocationHeader, *params.Authorization)
+			if err != nil {
+				return nil, err
+			}
+
+			req.Header.Set("authorization", headerParam0)
+		}
+
+	}
+
+	return req, nil
+}
+
+// NewDiscardTemplateApiV1RunbooksTemplatesSlugDiscardPostRequest calls the generic DiscardTemplateApiV1RunbooksTemplatesSlugDiscardPost builder with application/json body
+func NewDiscardTemplateApiV1RunbooksTemplatesSlugDiscardPostRequest(server string, slug string, params *DiscardTemplateApiV1RunbooksTemplatesSlugDiscardPostParams, body DiscardTemplateApiV1RunbooksTemplatesSlugDiscardPostJSONRequestBody) (*http.Request, error) {
+	var bodyReader io.Reader
+	buf, err := json.Marshal(body)
+	if err != nil {
+		return nil, err
+	}
+	bodyReader = bytes.NewReader(buf)
+	return NewDiscardTemplateApiV1RunbooksTemplatesSlugDiscardPostRequestWithBody(server, slug, params, "application/json", bodyReader)
+}
+
+// NewDiscardTemplateApiV1RunbooksTemplatesSlugDiscardPostRequestWithBody generates requests for DiscardTemplateApiV1RunbooksTemplatesSlugDiscardPost with any type of body
+func NewDiscardTemplateApiV1RunbooksTemplatesSlugDiscardPostRequestWithBody(server string, slug string, params *DiscardTemplateApiV1RunbooksTemplatesSlugDiscardPostParams, contentType string, body io.Reader) (*http.Request, error) {
+	var err error
+
+	var pathParam0 string
+
+	pathParam0, err = runtime.StyleParamWithLocation("simple", false, "slug", runtime.ParamLocationPath, slug)
+	if err != nil {
+		return nil, err
+	}
+
+	serverURL, err := url.Parse(server)
+	if err != nil {
+		return nil, err
+	}
+
+	operationPath := fmt.Sprintf("/api/v1/runbooks/templates/%s/discard", pathParam0)
 	if operationPath[0] == '/' {
 		operationPath = "." + operationPath
 	}
@@ -33700,6 +33814,11 @@ type ClientWithResponsesInterface interface {
 
 	DeprecateTemplateApiV1RunbooksTemplatesSlugDeprecatePostWithResponse(ctx context.Context, slug string, params *DeprecateTemplateApiV1RunbooksTemplatesSlugDeprecatePostParams, body DeprecateTemplateApiV1RunbooksTemplatesSlugDeprecatePostJSONRequestBody, reqEditors ...RequestEditorFn) (*DeprecateTemplateApiV1RunbooksTemplatesSlugDeprecatePostResponse, error)
 
+	// DiscardTemplateApiV1RunbooksTemplatesSlugDiscardPostWithBodyWithResponse request with any body
+	DiscardTemplateApiV1RunbooksTemplatesSlugDiscardPostWithBodyWithResponse(ctx context.Context, slug string, params *DiscardTemplateApiV1RunbooksTemplatesSlugDiscardPostParams, contentType string, body io.Reader, reqEditors ...RequestEditorFn) (*DiscardTemplateApiV1RunbooksTemplatesSlugDiscardPostResponse, error)
+
+	DiscardTemplateApiV1RunbooksTemplatesSlugDiscardPostWithResponse(ctx context.Context, slug string, params *DiscardTemplateApiV1RunbooksTemplatesSlugDiscardPostParams, body DiscardTemplateApiV1RunbooksTemplatesSlugDiscardPostJSONRequestBody, reqEditors ...RequestEditorFn) (*DiscardTemplateApiV1RunbooksTemplatesSlugDiscardPostResponse, error)
+
 	// PublishTemplateApiV1RunbooksTemplatesSlugPublishPostWithBodyWithResponse request with any body
 	PublishTemplateApiV1RunbooksTemplatesSlugPublishPostWithBodyWithResponse(ctx context.Context, slug string, params *PublishTemplateApiV1RunbooksTemplatesSlugPublishPostParams, contentType string, body io.Reader, reqEditors ...RequestEditorFn) (*PublishTemplateApiV1RunbooksTemplatesSlugPublishPostResponse, error)
 
@@ -36679,6 +36798,29 @@ func (r DeprecateTemplateApiV1RunbooksTemplatesSlugDeprecatePostResponse) Status
 
 // StatusCode returns HTTPResponse.StatusCode
 func (r DeprecateTemplateApiV1RunbooksTemplatesSlugDeprecatePostResponse) StatusCode() int {
+	if r.HTTPResponse != nil {
+		return r.HTTPResponse.StatusCode
+	}
+	return 0
+}
+
+type DiscardTemplateApiV1RunbooksTemplatesSlugDiscardPostResponse struct {
+	Body         []byte
+	HTTPResponse *http.Response
+	JSON200      *DiscardTemplateResponse
+	JSON422      *HTTPValidationError
+}
+
+// Status returns HTTPResponse.Status
+func (r DiscardTemplateApiV1RunbooksTemplatesSlugDiscardPostResponse) Status() string {
+	if r.HTTPResponse != nil {
+		return r.HTTPResponse.Status
+	}
+	return http.StatusText(0)
+}
+
+// StatusCode returns HTTPResponse.StatusCode
+func (r DiscardTemplateApiV1RunbooksTemplatesSlugDiscardPostResponse) StatusCode() int {
 	if r.HTTPResponse != nil {
 		return r.HTTPResponse.StatusCode
 	}
@@ -42713,6 +42855,23 @@ func (c *ClientWithResponses) DeprecateTemplateApiV1RunbooksTemplatesSlugDepreca
 	return ParseDeprecateTemplateApiV1RunbooksTemplatesSlugDeprecatePostResponse(rsp)
 }
 
+// DiscardTemplateApiV1RunbooksTemplatesSlugDiscardPostWithBodyWithResponse request with arbitrary body returning *DiscardTemplateApiV1RunbooksTemplatesSlugDiscardPostResponse
+func (c *ClientWithResponses) DiscardTemplateApiV1RunbooksTemplatesSlugDiscardPostWithBodyWithResponse(ctx context.Context, slug string, params *DiscardTemplateApiV1RunbooksTemplatesSlugDiscardPostParams, contentType string, body io.Reader, reqEditors ...RequestEditorFn) (*DiscardTemplateApiV1RunbooksTemplatesSlugDiscardPostResponse, error) {
+	rsp, err := c.DiscardTemplateApiV1RunbooksTemplatesSlugDiscardPostWithBody(ctx, slug, params, contentType, body, reqEditors...)
+	if err != nil {
+		return nil, err
+	}
+	return ParseDiscardTemplateApiV1RunbooksTemplatesSlugDiscardPostResponse(rsp)
+}
+
+func (c *ClientWithResponses) DiscardTemplateApiV1RunbooksTemplatesSlugDiscardPostWithResponse(ctx context.Context, slug string, params *DiscardTemplateApiV1RunbooksTemplatesSlugDiscardPostParams, body DiscardTemplateApiV1RunbooksTemplatesSlugDiscardPostJSONRequestBody, reqEditors ...RequestEditorFn) (*DiscardTemplateApiV1RunbooksTemplatesSlugDiscardPostResponse, error) {
+	rsp, err := c.DiscardTemplateApiV1RunbooksTemplatesSlugDiscardPost(ctx, slug, params, body, reqEditors...)
+	if err != nil {
+		return nil, err
+	}
+	return ParseDiscardTemplateApiV1RunbooksTemplatesSlugDiscardPostResponse(rsp)
+}
+
 // PublishTemplateApiV1RunbooksTemplatesSlugPublishPostWithBodyWithResponse request with arbitrary body returning *PublishTemplateApiV1RunbooksTemplatesSlugPublishPostResponse
 func (c *ClientWithResponses) PublishTemplateApiV1RunbooksTemplatesSlugPublishPostWithBodyWithResponse(ctx context.Context, slug string, params *PublishTemplateApiV1RunbooksTemplatesSlugPublishPostParams, contentType string, body io.Reader, reqEditors ...RequestEditorFn) (*PublishTemplateApiV1RunbooksTemplatesSlugPublishPostResponse, error) {
 	rsp, err := c.PublishTemplateApiV1RunbooksTemplatesSlugPublishPostWithBody(ctx, slug, params, contentType, body, reqEditors...)
@@ -48588,6 +48747,39 @@ func ParseDeprecateTemplateApiV1RunbooksTemplatesSlugDeprecatePostResponse(rsp *
 	switch {
 	case strings.Contains(rsp.Header.Get("Content-Type"), "json") && rsp.StatusCode == 200:
 		var dest DeprecateTemplateResponse
+		if err := json.Unmarshal(bodyBytes, &dest); err != nil {
+			return nil, err
+		}
+		response.JSON200 = &dest
+
+	case strings.Contains(rsp.Header.Get("Content-Type"), "json") && rsp.StatusCode == 422:
+		var dest HTTPValidationError
+		if err := json.Unmarshal(bodyBytes, &dest); err != nil {
+			return nil, err
+		}
+		response.JSON422 = &dest
+
+	}
+
+	return response, nil
+}
+
+// ParseDiscardTemplateApiV1RunbooksTemplatesSlugDiscardPostResponse parses an HTTP response from a DiscardTemplateApiV1RunbooksTemplatesSlugDiscardPostWithResponse call
+func ParseDiscardTemplateApiV1RunbooksTemplatesSlugDiscardPostResponse(rsp *http.Response) (*DiscardTemplateApiV1RunbooksTemplatesSlugDiscardPostResponse, error) {
+	bodyBytes, err := io.ReadAll(rsp.Body)
+	defer func() { _ = rsp.Body.Close() }()
+	if err != nil {
+		return nil, err
+	}
+
+	response := &DiscardTemplateApiV1RunbooksTemplatesSlugDiscardPostResponse{
+		Body:         bodyBytes,
+		HTTPResponse: rsp,
+	}
+
+	switch {
+	case strings.Contains(rsp.Header.Get("Content-Type"), "json") && rsp.StatusCode == 200:
+		var dest DiscardTemplateResponse
 		if err := json.Unmarshal(bodyBytes, &dest); err != nil {
 			return nil, err
 		}

--- a/docs/architecture/runbooks.md
+++ b/docs/architecture/runbooks.md
@@ -27,7 +27,7 @@ meho.runbook.list_runs(filter?, assignee?, status?, limit?) -> [{run_id, templat
 meho.runbook.reassign(run_id, new_assignee) -> {run_id, assigned_to, reassigned_at}  # TENANT_ADMIN
 ```
 
-The six template-lifecycle tools (`meho.runbook.draft_template` / `.edit_template` / `.publish_template` / `.deprecate_template` / `.list_templates` / `.show_template`) live on the same MCP surface from G12.2 and are documented in the authoring counterpart.
+The seven template-lifecycle tools (`meho.runbook.draft_template` / `.edit_template` / `.publish_template` / `.deprecate_template` / `.discard_template` / `.list_templates` / `.show_template`) live on the same MCP surface from G12.2 (`.discard_template` added by #135) and are documented in the authoring counterpart.
 
 The dotted names are canonical as of #1612; the original flat `runbook_*` names were kept as deprecated aliases for one release and removed in v0.15.0 (#1625; the deadline was deferred once from the original v0.14.0 window by #1702). The template id is `template_slug` on every tool — the deprecated `slug` input alias on the template verbs was removed alongside the flat names. See [`docs/codebase/mcp.md`](../codebase/mcp.md) §Tool naming grammar.
 

--- a/docs/runbooks/authoring.md
+++ b/docs/runbooks/authoring.md
@@ -40,8 +40,8 @@ same time.
 
 - **Senior** — owns the procedure. Walks Claude through it during authoring,
   reviews the draft, and signs off on publish. The senior is the only role
-  that drafts, edits, publishes, or deprecates a template (those tools are
-  `TENANT_ADMIN`-only).
+  that drafts, edits, publishes, deprecates, or discards a template (those
+  tools are `TENANT_ADMIN`-only).
 - **Claude** — the authoring agent. During a drafting session it captures
   what the senior demonstrates (bash, SSH, the verification at each step)
   into the template body and persists it through the `meho.runbook.*` template
@@ -105,6 +105,17 @@ scratchpad you keep appending to until the senior signs off.
 The status state machine is `draft -> published -> deprecated`. Publish is
 idempotent (re-publishing an already-published version is a no-op);
 deprecate is idempotent the same way.
+
+**Discarding a draft.** A draft you got wrong (typo'd slug, wrong steps)
+can be thrown away before publishing with
+`meho.runbook.discard_template(template_slug, version)` (REST: `POST
+/api/v1/runbooks/templates/{slug}/discard`). It deletes the draft row
+outright — no publish-then-deprecate workaround. Only **drafts** are
+discardable: a `published` or `deprecated` version is refused (retire it
+with `deprecate`, which preserves lifecycle history, rather than erasing
+it). A missing `(slug, version)` — including a re-discard of an
+already-removed draft — is a not-found, not a silent success.
+`tenant_admin` only, like the other authoring verbs.
 
 ## Fork-on-edit semantics
 
@@ -303,8 +314,8 @@ would be rejected at publish.
 - [Goal #1195](https://github.com/evoila/meho/issues/1195) — G12 Runbooks
   (the overall outcome).
 - [Initiative #1197](https://github.com/evoila/meho/issues/1197) — G12.2
-  template lifecycle (draft / edit / publish / deprecate / list / show + this
-  drafting pattern + fork-visibility-on-edit).
+  template lifecycle (draft / edit / publish / deprecate / discard / list / show
+  + this drafting pattern + fork-visibility-on-edit).
 - [Initiative #1198](https://github.com/evoila/meho/issues/1198) — G12.3 run
   lifecycle (the execution-side counterpart: start / next / abort / reassign).
 - [#1191](https://github.com/evoila/meho/issues/1191) — design source for the


### PR DESCRIPTION
## Summary

- Completes the runbook template CRUD lifecycle with a **delete-for-drafts** leg.
  A draft (typo'd slug, wrong steps) had no discard path — the only removal was
  the publish-then-deprecate workaround, since `/deprecate` refuses a draft.
- Adds the verb across both operator surfaces (CLI+MCP parity on one backplane):
  - **Service**: `RunbookTemplateService.discard()` — deletes a
    `(tenant, slug, version)` row **only when `status == "draft"`**. Published /
    deprecated versions raise `TemplateNotDraftError` (retire via `deprecate` —
    preserves lifecycle history, never erased); a missing triple raises
    `TemplateNotFoundError` (a re-discard is a 404, not a silent success). No
    cascade: a pure draft can't have runs (`start_run` pins to a *published*
    version).
  - **REST**: `POST /api/v1/runbooks/templates/{slug}/discard`, `tenant_admin`
    only — mirrors the `deprecate` route (role gate + `http_for` mapping + audit
    binding `audit_op_id="runbook.discard_template"`, `op_class="write"`).
  - **MCP**: `meho.runbook.discard_template` — shares the same service method.
- Chose `POST /{slug}/discard` over `DELETE {slug}` to mirror the sibling
  `publish`/`deprecate` verbs (version-in-body) and avoid DELETE-with-body's
  undefined semantics (RFC 7231).

## Test plan

- [x] `ruff check` / `ruff format --check` — clean
- [x] `mypy` (changed source) — clean
- [x] `code-quality.py --diff` — pass (exit 0)
- [x] **AC1** draft → discard → gone: `test_discard_removes_draft`,
      `test_discard_slug_is_reusable_after_discard` (service, real SQLite)
- [x] **AC2** discard published → 4xx typed error naming `deprecate`:
      `test_discard_published_raises_pointing_at_deprecate` (service, `match="deprecate"`)
      + `test_discard_published_400` (API, asserts `"deprecate"` in detail)
- [x] **AC3** operator → 403: `test_discard_operator_role_403`
- [x] **AC4** audit `op_id="runbook.discard_template"` + MCP tool exists + shares
      service: `test_discard_writes_audit_row_with_discard_op_id_and_version`,
      `test_discard_tool_invocation`, `test_runbook_family_is_exactly_twelve_dotted_tools`
- [x] **AC5** `pytest -k "runbook and (discard or template)"` — **120 passed**
- [x] Full affected suites — **145 passed**
- [x] CLI OpenAPI snapshot regenerated (`make snapshot-openapi && make generate`),
      generated Go client compiles (`go build ./...`), re-snapshot idempotent

## Docs

- `docs/runbooks/authoring.md` + `docs/architecture/runbooks.md` — discard verb
  documented; tool-count enumerations updated (six→seven template tools).
- Runbook tool-count invariant test bumped eleven→twelve dotted tools.

## Out of scope

- CLI verb surface (G12.5) — only the OpenAPI snapshot + typed client are
  refreshed to keep the freshness gate green; no new `meho` verb added.
- Hard-deleting published/deprecated versions — deliberately excluded; those are
  retired via `deprecate`, preserving lifecycle history.

Fully implements evoila-bosnia/meho-internal#135 (cross-repo `Refs`; GitHub does
not auto-close across repos — close the tracking issue on merge).
