### PR TITLE
feat(audit): stamp the policy-gate verdict on the audit row (policy_decision)

### DIFF
--- a/backend/alembic/versions/0051_add_audit_log_policy_decision.py
+++ b/backend/alembic/versions/0051_add_audit_log_policy_decision.py
@@ -1,0 +1,101 @@
+# SPDX-License-Identifier: Apache-2.0
+# Copyright (c) 2026 evoila Group
+
+"""Add ``audit_log.policy_decision`` — stamp the policy-gate verdict on the row.
+
+Task #130 under Initiative #128 (policy-gate hardening), Goal #87. The
+synchronous policy gate
+(:func:`meho_backplane.operations._validate.policy_gate`) computes a
+:class:`~meho_backplane.db.models.PermissionVerdict`
+(``auto-execute`` / ``needs-approval`` / ``deny``) on every governed
+``call_operation``, and the dispatcher branches on it — but the verdict was
+never persisted, so a consumer had to reconstruct it by joining
+``method``+``path`` patterns and parsing ``payload``. This migration adds the
+first-class column so the moat-pillar promise ("the verdict is stamped onto
+the operation's audit row") holds and a consumer can
+``WHERE policy_decision = '<verdict>'`` directly.
+
+What this migration adds
+------------------------
+
+* ``audit_log.policy_decision text NULL`` — the gate verdict, populated by
+  both audit writers (the dispatch-row writer and the approval-queue writer)
+  off the dispatch-scoped ``policy_decision_var`` contextvar. No index — it is
+  a low-cardinality equality filter normally combined with a time/principal
+  predicate that ``audit_log_occurred_at_idx`` / ``audit_log_operator_sub_idx``
+  already cover.
+* ``ck_audit_log_policy_decision`` CHECK — the value is the closed
+  ``PermissionVerdict`` set or ``NULL``, DB-enforced. Mirrors
+  ``ck_agent_permission_verdict``; the enum is intentionally closed (a fourth
+  verdict is a coordinated code + migration change).
+
+Why nullable (no ``server_default``, like ``0050``'s ``tls_server_name``)
+-------------------------------------------------------------------------
+
+"No gate ran for this row" is a first-class state, not a default value:
+pre-#130 rows, pre-gate usage-error rows (unknown op / invalid params /
+connector-resolution failures), and system-internal writers carry ``NULL``.
+A plain nullable ``ADD COLUMN`` is safe on a populated table — PostgreSQL and
+SQLite both add it as ``NULL`` for every existing row with no rewrite.
+
+Why ``batch_alter_table`` for the CHECK
+---------------------------------------
+
+Same portable cookbook ``0025`` used to add a CHECK to an existing table: on
+PostgreSQL Alembic issues plain ``ALTER TABLE ADD COLUMN`` + ``ADD
+CONSTRAINT`` (no copy); on SQLite it falls back to the table-recreate path
+(the only way SQLite adds a CHECK to an existing table). One batch block adds
+the column and the constraint together, so SQLite recreates once.
+
+Reversibility contract
+----------------------
+
+``downgrade()`` drops the constraint + column inside the same batch block.
+The reversible-additive discipline established by ``0006``+ applies: new
+requirement = new migration head, never rewrite historical migrations.
+"""
+
+from collections.abc import Sequence
+
+import sqlalchemy as sa
+from alembic import op
+
+# revision identifiers, used by Alembic.
+revision: str = "0051"
+down_revision: str | None = "0050"
+branch_labels: str | Sequence[str] | None = None
+depends_on: str | Sequence[str] | None = None
+
+# The closed PermissionVerdict vocabulary, mirrored in the CHECK. ``NULL`` is
+# permitted (no gate ran / pre-#130 row); a SQL CHECK passes on NULL, and the
+# explicit ``IS NULL`` arm keeps the intent legible + matches the model's
+# ``ck_audit_log_policy_decision``.
+_POLICY_DECISION_CHECK: str = (
+    "policy_decision IN ('auto-execute', 'needs-approval', 'deny') OR policy_decision IS NULL"
+)
+
+
+def upgrade() -> None:
+    """Add the nullable, CHECK-constrained ``policy_decision`` column."""
+    with op.batch_alter_table("audit_log") as batch_op:
+        batch_op.add_column(
+            sa.Column(
+                "policy_decision",
+                sa.Text(),
+                nullable=True,
+            )
+        )
+        batch_op.create_check_constraint(
+            "ck_audit_log_policy_decision",
+            _POLICY_DECISION_CHECK,
+        )
+
+
+def downgrade() -> None:
+    """Drop the ``policy_decision`` column + its CHECK added in :func:`upgrade`."""
+    with op.batch_alter_table("audit_log") as batch_op:
+        batch_op.drop_constraint(
+            "ck_audit_log_policy_decision",
+            type_="check",
+        )
+        batch_op.drop_column("policy_decision")

--- a/backend/src/meho_backplane/audit_query/query.py
+++ b/backend/src/meho_backplane/audit_query/query.py
@@ -341,6 +341,7 @@ def _build_audit_entry(row: AuditLog, target_name: str | None) -> AuditEntry:
         parent_audit_id=row.parent_audit_id,
         agent_session_id=row.agent_session_id,
         work_ref=row.work_ref,
+        policy_decision=row.policy_decision,
         broadcast_event_id=None,
     )
 

--- a/backend/src/meho_backplane/audit_query/schemas.py
+++ b/backend/src/meho_backplane/audit_query/schemas.py
@@ -154,6 +154,13 @@ class AuditEntry(BaseModel):
     parent_audit_id: uuid.UUID | None
     agent_session_id: uuid.UUID | None
     work_ref: str | None
+    # Policy-gate verdict stamped on the row (#130): ``auto-execute`` /
+    # ``needs-approval`` / ``deny``, or ``None`` on rows where no gate ran
+    # (pre-#130 rows, pre-gate usage errors, system-internal writers). Sourced
+    # from the real ``audit_log.policy_decision`` column, so a consumer reads
+    # the verdict directly instead of joining ``method``+``path`` + parsing
+    # ``payload``.
+    policy_decision: str | None
     broadcast_event_id: uuid.UUID | None
 
 

--- a/backend/src/meho_backplane/db/models.py
+++ b/backend/src/meho_backplane/db/models.py
@@ -547,8 +547,39 @@ class AuditLog(Base):
         nullable=True,
         default=None,
     )
+    # Policy-gate verdict stamped on the row (#130). The synchronous gate
+    # (:func:`meho_backplane.operations._validate.policy_gate`) computes a
+    # :class:`PermissionVerdict` on every governed dispatch; the dispatcher
+    # binds it to :data:`meho_backplane.operations._audit.policy_decision_var`
+    # and both audit writers (the dispatch-row writer and the approval-queue
+    # writer) read it here so a consumer can ``WHERE policy_decision = ...``
+    # without joining ``method``+``path`` and parsing ``payload``. The closed
+    # vocabulary is the real ``PermissionVerdict`` enum
+    # (``auto-execute`` / ``needs-approval`` / ``deny``) — DB-enforced by the
+    # CHECK below, matching ``agent_permission.verdict``. Nullable: pre-#130
+    # rows, and rows written on a path where no gate ran (pre-gate usage
+    # errors, system-internal writers), carry NULL. Added by migration
+    # ``0051``. No index — it is a low-cardinality equality filter usually
+    # combined with a time/principal predicate that an existing index covers.
+    policy_decision: Mapped[str | None] = mapped_column(
+        Text,
+        nullable=True,
+        default=None,
+    )
 
     __table_args__ = (
+        # Verdict vocabulary is the closed ``PermissionVerdict`` set. The
+        # literal mirrors ``_PERMISSION_VERDICTS`` (defined later in this
+        # module, after the enum) rather than referencing it — this
+        # ``__table_args__`` is evaluated at class-definition time, before the
+        # enum/helper exist. The enum is intentionally closed (a fourth verdict
+        # is a coordinated code+migration change), so the duplication cannot
+        # drift silently. ``... IS NULL`` keeps pre-#130 / no-gate rows valid.
+        sa.CheckConstraint(
+            "policy_decision IN ('auto-execute', 'needs-approval', 'deny') "
+            "OR policy_decision IS NULL",
+            name="ck_audit_log_policy_decision",
+        ),
         Index(
             "audit_log_occurred_at_idx",
             "occurred_at",

--- a/backend/src/meho_backplane/operations/_audit.py
+++ b/backend/src/meho_backplane/operations/_audit.py
@@ -51,6 +51,7 @@ __all__ = [
     "agent_session_id_var",
     "audit_and_broadcast_safe",
     "parent_audit_id_var",
+    "policy_decision_var",
     "publish_broadcast",
     "run_id_var",
     "step_id_var",
@@ -161,6 +162,22 @@ step_id_var: ContextVar[str | None] = ContextVar(
 #: column stays NULL except where a caller binds the var directly.
 work_ref_var: ContextVar[str | None] = ContextVar(
     "work_ref",
+    default=None,
+)
+
+#: The policy-gate verdict for the in-flight dispatch (#130). The
+#: dispatcher binds it (a :class:`PermissionVerdict` value string) right
+#: after :func:`~meho_backplane.operations._validate.policy_gate` decides,
+#: with a token/finally reset scoping it to the dispatch — the same
+#: bound-at-a-boundary / read-at-every-write-call-site discipline as
+#: :data:`run_id_var`. Both audit writers read it: the dispatch-row writer
+#: (:func:`write_audit_row`) and the approval-queue writer
+#: (:func:`meho_backplane.operations.approval_queue._write_audit_row`, so the
+#: parked "request" row carries ``needs-approval``). ``None`` where no gate
+#: ran (pre-gate usage errors, system-internal writers) — the correct value
+#: for the nullable ``audit_log.policy_decision`` column.
+policy_decision_var: ContextVar[str | None] = ContextVar(
+    "policy_decision",
     default=None,
 )
 
@@ -435,6 +452,12 @@ async def write_audit_row(
     # is ``None`` until a caller binds the var.
     if hasattr(AuditLog, "work_ref"):
         runbook_kwargs["work_ref"] = work_ref_var.get()
+    # policy-gate verdict (#130) -- read the dispatch-scoped var the
+    # dispatcher bound after the gate decided. Same hasattr forward-compat
+    # guard as the runbook / work_ref columns: the ``policy_decision`` column
+    # is added by migration ``0051``. ``None`` when no gate ran for this row.
+    if hasattr(AuditLog, "policy_decision"):
+        runbook_kwargs["policy_decision"] = policy_decision_var.get()
     async with sessionmaker() as session:
         row = AuditLog(
             id=audit_id,

--- a/backend/src/meho_backplane/operations/approval_queue.py
+++ b/backend/src/meho_backplane/operations/approval_queue.py
@@ -73,7 +73,7 @@ from meho_backplane.db.models import (
     ApprovalRequestStatus,
     AuditLog,
 )
-from meho_backplane.operations._audit import work_ref_var
+from meho_backplane.operations._audit import policy_decision_var, work_ref_var
 from meho_backplane.operations._errors import result_denied
 from meho_backplane.operations._validate import compute_params_hash
 
@@ -229,6 +229,16 @@ async def _write_audit_row(
     }
     if extra_payload:
         payload.update(extra_payload)
+    # policy-gate verdict (#130). The parked "request" row is written on the
+    # requester's task, where the dispatcher bound ``policy_decision_var`` to
+    # ``needs-approval`` before parking, so the var carries the verdict here.
+    # A "decision" row is written on the *approver's* task (var unset) and on
+    # a path where no gate ran, so it correctly stays NULL — the operator's
+    # approve/reject is recorded via ``result_status``, not a gate verdict.
+    # ``hasattr`` guard mirrors ``write_audit_row``: the column lands in ``0051``.
+    policy_kwargs: dict[str, Any] = {}
+    if hasattr(AuditLog, "policy_decision"):
+        policy_kwargs["policy_decision"] = policy_decision_var.get()
     row = AuditLog(
         id=audit_id,
         occurred_at=_now(),
@@ -250,6 +260,7 @@ async def _write_audit_row(
         # durable source of truth -- it keeps both audit rows aligned with
         # the value the request was parked under.
         work_ref=request.work_ref,
+        **policy_kwargs,
     )
     session.add(row)
     await session.flush()

--- a/backend/src/meho_backplane/operations/dispatcher.py
+++ b/backend/src/meho_backplane/operations/dispatcher.py
@@ -219,6 +219,7 @@ from meho_backplane.db.models import EndpointDescriptor, PermissionVerdict
 from meho_backplane.operations._audit import (
     audit_and_broadcast_safe,
     parent_audit_id_var,
+    policy_decision_var,
 )
 from meho_backplane.operations._branches import (
     dispatch_composite,
@@ -1741,108 +1742,129 @@ async def dispatch(
     # Skipped on the approval-queue resume path (``_approved``): a human
     # operator already approved this exact call, so re-running the gate
     # would only re-deny or re-queue it. The approval is the authorization.
-    if not _approved:
-        # G11.2-T3: async, three-state verdict (auto-execute / needs-approval
-        # / deny). The call site signature is unchanged; the function now
-        # awaits a DB read to load the principal's AgentPermission rows.
-        verdict, gate_reason = await policy_gate(
-            operator=operator, descriptor=descriptor, target=target
+    # #130: scope the policy-gate verdict to this dispatch so both audit
+    # writers (the dispatch-row writer and the approval-queue writer) can
+    # stamp ``audit_log.policy_decision`` off ``policy_decision_var`` without
+    # threading it through every write call site. Bound to the decided
+    # verdict below (or to ``needs-approval`` on the approval resume path,
+    # where the approval *was* the authorization). The token reset in the
+    # ``finally`` restores a composite parent dispatch's verdict after a
+    # child ``dispatch`` rebinds the var, and clears it for the next dispatch
+    # reusing this task.
+    _verdict_token = policy_decision_var.set(None)
+    try:
+        if not _approved:
+            # G11.2-T3: async, three-state verdict (auto-execute / needs-approval
+            # / deny). The call site signature is unchanged; the function now
+            # awaits a DB read to load the principal's AgentPermission rows.
+            verdict, gate_reason = await policy_gate(
+                operator=operator, descriptor=descriptor, target=target
+            )
+            policy_decision_var.set(verdict.value)
+            if verdict == PermissionVerdict.DENY:
+                duration_ms = _elapsed_ms(started)
+                await audit_and_broadcast_safe(
+                    audit_id=uuid.uuid4(),
+                    operator=operator,
+                    descriptor=descriptor,
+                    target=target,
+                    params=params,
+                    params_hash=params_hash,
+                    result_status="denied",
+                    duration_ms=duration_ms,
+                )
+                return result_denied(op_id, gate_reason or "policy denied", duration_ms)
+            if verdict == PermissionVerdict.NEEDS_APPROVAL:
+                # G11.2-T4 (#817): write a durable ApprovalRequest row (+ its
+                # synchronous "request" audit row) and return an
+                # awaiting_approval result. Reached by an agent principal
+                # whose verdict floors to needs-approval AND (G11.7-T1 #1401)
+                # by a human/service principal hitting a requires_approval op
+                # — both park the call durably for an operator to decide.
+                duration_ms = _elapsed_ms(started)
+                return await _handle_needs_approval(
+                    op_id=op_id,
+                    connector_id=connector_id,
+                    operator=operator,
+                    descriptor=descriptor,
+                    target=target,
+                    params=params,
+                    params_hash=params_hash,
+                    duration_ms=duration_ms,
+                )
+            if verdict is not PermissionVerdict.AUTO_EXECUTE:
+                # Defensive fail-closed: only an explicit AUTO_EXECUTE proceeds
+                # to execution. Any unexpected verdict (a future enum member, a
+                # bug in the resolver) denies rather than silently executing.
+                duration_ms = _elapsed_ms(started)
+                await audit_and_broadcast_safe(
+                    audit_id=uuid.uuid4(),
+                    operator=operator,
+                    descriptor=descriptor,
+                    target=target,
+                    params=params,
+                    params_hash=params_hash,
+                    result_status="denied",
+                    duration_ms=duration_ms,
+                )
+                return result_denied(
+                    op_id,
+                    gate_reason or f"unexpected policy verdict {verdict!r}; denied",
+                    duration_ms,
+                )
+        else:
+            # Approval-queue resume path: the gate is skipped because an
+            # operator already approved this exact call. Stamp the row with
+            # the verdict that governed it — ``needs-approval`` — so the
+            # executed row honestly records it was four-eyes-gated, not
+            # auto-executed.
+            policy_decision_var.set(PermissionVerdict.NEEDS_APPROVAL.value)
+
+        # --- Step 5: connector resolution ---------------------------------
+        connector_instance, resolution_error, exception_message = await _resolve_connector_instance(
+            descriptor, target
         )
-        if verdict == PermissionVerdict.DENY:
-            duration_ms = _elapsed_ms(started)
-            await audit_and_broadcast_safe(
-                audit_id=uuid.uuid4(),
-                operator=operator,
-                descriptor=descriptor,
-                target=target,
-                params=params,
-                params_hash=params_hash,
-                result_status="denied",
-                duration_ms=duration_ms,
-            )
-            return result_denied(op_id, gate_reason or "policy denied", duration_ms)
-        if verdict == PermissionVerdict.NEEDS_APPROVAL:
-            # G11.2-T4 (#817): write a durable ApprovalRequest row (+ its
-            # synchronous "request" audit row) and return an
-            # awaiting_approval result. Reached by an agent principal
-            # whose verdict floors to needs-approval AND (G11.7-T1 #1401)
-            # by a human/service principal hitting a requires_approval op
-            # — both park the call durably for an operator to decide.
-            duration_ms = _elapsed_ms(started)
-            return await _handle_needs_approval(
-                op_id=op_id,
-                connector_id=connector_id,
-                operator=operator,
-                descriptor=descriptor,
-                target=target,
-                params=params,
-                params_hash=params_hash,
-                duration_ms=duration_ms,
-            )
-        if verdict is not PermissionVerdict.AUTO_EXECUTE:
-            # Defensive fail-closed: only an explicit AUTO_EXECUTE proceeds
-            # to execution. Any unexpected verdict (a future enum member, a
-            # bug in the resolver) denies rather than silently executing.
-            duration_ms = _elapsed_ms(started)
-            await audit_and_broadcast_safe(
-                audit_id=uuid.uuid4(),
-                operator=operator,
-                descriptor=descriptor,
-                target=target,
-                params=params,
-                params_hash=params_hash,
-                result_status="denied",
-                duration_ms=duration_ms,
-            )
-            return result_denied(
+        if resolution_error == "target_required":
+            # G0.20-T6 (#1506): a connector-bound (self-first) typed/composite
+            # handler invoked with ``target=None``. Clean usage error before
+            # the handler proceeds unbound and trips ``dispatch_typed``'s loud
+            # self-guard RuntimeError (preserved for genuine instance-cache
+            # faults, which only arise when a target *was* supplied).
+            return result_target_required(op_id, _elapsed_ms(started))
+        if resolution_error == "no_connector":
+            return result_no_connector(
                 op_id,
-                gate_reason or f"unexpected policy verdict {verdict!r}; denied",
-                duration_ms,
+                product,
+                version,
+                _elapsed_ms(started),
+                exception_message=exception_message,
+            )
+        if resolution_error == "ambiguous_connector":
+            # The exception's message is the single most diagnostic string
+            # the resolver computes (candidate list + remediation step);
+            # surface it verbatim under ``extras["exception_message"]``.
+            # ``exception_message`` is guaranteed non-None for this label
+            # by ``resolve_connector_or_label``'s contract — the empty
+            # string fallback is a defensive type-check guard, never hit.
+            return result_ambiguous_connector(
+                op_id,
+                product,
+                version,
+                exception_message or "",
+                _elapsed_ms(started),
             )
 
-    # --- Step 5: connector resolution -------------------------------------
-    connector_instance, resolution_error, exception_message = await _resolve_connector_instance(
-        descriptor, target
-    )
-    if resolution_error == "target_required":
-        # G0.20-T6 (#1506): a connector-bound (self-first) typed/composite
-        # handler invoked with ``target=None``. Clean usage error before
-        # the handler proceeds unbound and trips ``dispatch_typed``'s loud
-        # self-guard RuntimeError (preserved for genuine instance-cache
-        # faults, which only arise when a target *was* supplied).
-        return result_target_required(op_id, _elapsed_ms(started))
-    if resolution_error == "no_connector":
-        return result_no_connector(
-            op_id,
-            product,
-            version,
-            _elapsed_ms(started),
-            exception_message=exception_message,
+        # --- Steps 6/7/8/9: branch + reduce + audit + broadcast -----------
+        return await _execute_and_audit(
+            op_id=op_id,
+            connector_id=connector_id,
+            descriptor=descriptor,
+            connector_instance=connector_instance,
+            operator=operator,
+            target=target,
+            params=params,
+            params_hash=params_hash,
+            started=started,
         )
-    if resolution_error == "ambiguous_connector":
-        # The exception's message is the single most diagnostic string
-        # the resolver computes (candidate list + remediation step);
-        # surface it verbatim under ``extras["exception_message"]``.
-        # ``exception_message`` is guaranteed non-None for this label
-        # by ``resolve_connector_or_label``'s contract — the empty
-        # string fallback is a defensive type-check guard, never hit.
-        return result_ambiguous_connector(
-            op_id,
-            product,
-            version,
-            exception_message or "",
-            _elapsed_ms(started),
-        )
-
-    # --- Steps 6/7/8/9: branch + reduce + audit + broadcast ---------------
-    return await _execute_and_audit(
-        op_id=op_id,
-        connector_id=connector_id,
-        descriptor=descriptor,
-        connector_instance=connector_instance,
-        operator=operator,
-        target=target,
-        params=params,
-        params_hash=params_hash,
-        started=started,
-    )
+    finally:
+        policy_decision_var.reset(_verdict_token)

--- a/backend/tests/test_api_audit_routes.py
+++ b/backend/tests/test_api_audit_routes.py
@@ -189,6 +189,7 @@ def _make_entry(
     audit_id: UUID = _DEFAULT_AUDIT_ID,
     tenant_id: UUID = _TENANT_A,
     principal_sub: str = "op-1",
+    policy_decision: str | None = None,
 ) -> AuditEntry:
     return AuditEntry(
         id=audit_id,
@@ -210,6 +211,7 @@ def _make_entry(
         parent_audit_id=None,
         agent_session_id=None,
         work_ref=None,
+        policy_decision=policy_decision,
         broadcast_event_id=None,
     )
 
@@ -468,6 +470,46 @@ def test_my_recent_injects_principal_from_jwt(client: TestClient) -> None:
     assert resp.status_code == 200
     filters = mock_query.await_args.args[0]
     assert filters.principal == "op-42-jwt-sub"
+
+
+def test_audit_query_row_includes_policy_decision(client: TestClient) -> None:
+    """#130 AC2: the ``/audit/query`` row shape carries ``policy_decision``."""
+    key = make_rsa_keypair("kid-A")
+    token = _token(key)
+    entry = _make_entry(policy_decision="deny")
+    mock_query = AsyncMock(return_value=AuditQueryResult(rows=[entry], next_cursor=None))
+    with (
+        respx.mock as r,
+        patch("meho_backplane.api.v1.audit.query_audit", new=mock_query),
+    ):
+        mock_discovery_and_jwks(r, public_jwks(key))
+        resp = client.post(
+            "/api/v1/audit/query",
+            json={},
+            headers={"Authorization": f"Bearer {token}"},
+        )
+    assert resp.status_code == 200
+    rows = resp.json()["rows"]
+    assert rows[0]["policy_decision"] == "deny"
+
+
+def test_audit_my_recent_row_includes_policy_decision(client: TestClient) -> None:
+    """#130 AC2: the ``/audit/my-recent`` row shape carries ``policy_decision``."""
+    key = make_rsa_keypair("kid-A")
+    token = _token(key)
+    entry = _make_entry(policy_decision="needs-approval")
+    mock_query = AsyncMock(return_value=AuditQueryResult(rows=[entry], next_cursor=None))
+    with (
+        respx.mock as r,
+        patch("meho_backplane.api.v1.audit.query_audit", new=mock_query),
+    ):
+        mock_discovery_and_jwks(r, public_jwks(key))
+        resp = client.get(
+            "/api/v1/audit/my-recent",
+            headers={"Authorization": f"Bearer {token}"},
+        )
+    assert resp.status_code == 200
+    assert resp.json()["rows"][0]["policy_decision"] == "needs-approval"
 
 
 # ---------------------------------------------------------------------------

--- a/backend/tests/test_audit_query_schemas.py
+++ b/backend/tests/test_audit_query_schemas.py
@@ -112,6 +112,7 @@ def _make_entry(**overrides: object) -> AuditEntry:
         "parent_audit_id": None,
         "agent_session_id": None,
         "work_ref": None,
+        "policy_decision": None,
         "broadcast_event_id": None,
     }
     defaults.update(overrides)

--- a/backend/tests/test_audit_replay.py
+++ b/backend/tests/test_audit_replay.py
@@ -442,6 +442,7 @@ def test_replay_node_is_frozen() -> None:
         parent_audit_id=None,
         agent_session_id=None,
         work_ref=None,
+        policy_decision=None,
         broadcast_event_id=None,
         depth=0,
         children=[],

--- a/backend/tests/test_mcp_tool_audit_replay.py
+++ b/backend/tests/test_mcp_tool_audit_replay.py
@@ -71,6 +71,7 @@ def _node(node_id: str, *, depth: int, children: list[ReplayNode] | None = None)
         parent_audit_id=None,
         agent_session_id=uuid.UUID(_SESSION_ID),
         work_ref=None,
+        policy_decision=None,
         broadcast_event_id=None,
         depth=depth,
         children=children or [],

--- a/backend/tests/test_mcp_tool_query_audit.py
+++ b/backend/tests/test_mcp_tool_query_audit.py
@@ -330,6 +330,7 @@ def test_tools_call_handler_returns_result_model_dump(
         parent_audit_id=None,
         agent_session_id=None,
         work_ref=None,
+        policy_decision=None,
         broadcast_event_id=None,
     )
     mock_query = AsyncMock(

--- a/backend/tests/test_operations_dispatcher.py
+++ b/backend/tests/test_operations_dispatcher.py
@@ -1989,6 +1989,88 @@ async def test_dispatch_pending_caution_op_no_permission_row(
 
 
 @pytest.mark.asyncio
+async def test_audit_row_stamps_policy_decision_per_verdict(
+    stub_embedding_service: AsyncMock,
+    captured_events: list[BroadcastEvent],
+) -> None:
+    """#130 AC1: each governed dispatch stamps its gate verdict on ``policy_decision``.
+
+    An ``auto-execute`` dispatch (safe op, human), a ``needs-approval`` park
+    (caution op, agent → the ``approval.request`` row), and a ``deny`` (dangerous
+    op, agent, no grant) each land the matching :class:`PermissionVerdict` on the
+    ``audit_log`` row — queryable without joining ``method``+``path`` + parsing
+    ``payload``.
+    """
+    from meho_backplane.db.models import ApprovalRequest
+
+    register_connector_v2(product="vault", version="", impl_id="", cls=_NoOpVaultConnector)
+    for op_id, safety in (
+        ("vault.kv.autoexec", "safe"),
+        ("vault.kv.needsapproval", "caution"),
+        ("vault.kv.deny", "dangerous"),
+    ):
+        await register_typed_operation(
+            product="vault",
+            version="1.x",
+            impl_id="vault",
+            op_id=op_id,
+            handler=_module_handler_returning_dict,
+            summary=f"{safety} op.",
+            description=f"A {safety} operation.",
+            parameter_schema={"type": "object"},
+            safety_level=safety,
+            when_to_use=None,
+            embedding_service=stub_embedding_service,
+        )
+
+    target = _FakeTarget(product="vault")
+
+    auto = await dispatch(
+        operator=_make_operator(),
+        connector_id="vault-1.x",
+        op_id="vault.kv.autoexec",
+        target=target,
+        params={},
+    )
+    assert auto.status == "ok", auto.error
+
+    parked = await dispatch(
+        operator=_make_operator(principal_kind=PrincipalKind.AGENT),
+        connector_id="vault-1.x",
+        op_id="vault.kv.needsapproval",
+        target=target,
+        params={},
+    )
+    assert parked.status == "awaiting_approval", parked.error
+
+    denied = await dispatch(
+        operator=_make_operator(principal_kind=PrincipalKind.AGENT),
+        connector_id="vault-1.x",
+        op_id="vault.kv.deny",
+        target=target,
+        params={},
+    )
+    assert denied.status == "denied", denied.error
+
+    sessionmaker = get_sessionmaker()
+    async with sessionmaker() as fresh:
+        by_path = {row.path: row for row in (await fresh.execute(select(AuditLog))).scalars().all()}
+        parked_request = await fresh.get(
+            ApprovalRequest, UUID(parked.extras["approval_request_id"])
+        )
+        assert parked_request is not None
+
+    # auto-execute dispatch row.
+    assert by_path["vault.kv.autoexec"].policy_decision == "auto-execute"
+    # deny dispatch row.
+    assert by_path["vault.kv.deny"].policy_decision == "deny"
+    # the parked "request" row carries the needs-approval verdict; the op's own
+    # path wrote no row (it never executed).
+    assert by_path["approval.request"].policy_decision == "needs-approval"
+    assert "vault.kv.needsapproval" not in by_path
+
+
+@pytest.mark.asyncio
 async def test_dispatch_human_dangerous_op_auto_executes(
     stub_embedding_service: AsyncMock,
     captured_events: list[BroadcastEvent],

--- a/cli/api/openapi.json
+++ b/cli/api/openapi.json
@@ -18640,6 +18640,11 @@
             "nullable": true,
             "title": "Work Ref"
           },
+          "policy_decision": {
+            "type": "string",
+            "nullable": true,
+            "title": "Policy Decision"
+          },
           "broadcast_event_id": {
             "type": "string",
             "format": "uuid",
@@ -18668,6 +18673,7 @@
           "parent_audit_id",
           "agent_session_id",
           "work_ref",
+          "policy_decision",
           "broadcast_event_id"
         ],
         "title": "AuditEntry",
@@ -23791,6 +23797,11 @@
             "nullable": true,
             "title": "Work Ref"
           },
+          "policy_decision": {
+            "type": "string",
+            "nullable": true,
+            "title": "Policy Decision"
+          },
           "broadcast_event_id": {
             "type": "string",
             "format": "uuid",
@@ -23830,6 +23841,7 @@
           "parent_audit_id",
           "agent_session_id",
           "work_ref",
+          "policy_decision",
           "broadcast_event_id",
           "depth"
         ],

--- a/cli/internal/api/client.gen.go
+++ b/cli/internal/api/client.gen.go
@@ -1071,6 +1071,7 @@ type AuditEntry struct {
 	ParentAuditId    *openapi_types.UUID    `json:"parent_audit_id"`
 	Path             string                 `json:"path"`
 	Payload          map[string]interface{} `json:"payload"`
+	PolicyDecision   *string                `json:"policy_decision"`
 	PrincipalName    *string                `json:"principal_name"`
 	PrincipalSub     string                 `json:"principal_sub"`
 	RequestId        *openapi_types.UUID    `json:"request_id"`
@@ -4382,6 +4383,7 @@ type ReplayNode struct {
 	ParentAuditId    *openapi_types.UUID    `json:"parent_audit_id"`
 	Path             string                 `json:"path"`
 	Payload          map[string]interface{} `json:"payload"`
+	PolicyDecision   *string                `json:"policy_decision"`
 	PrincipalName    *string                `json:"principal_name"`
 	PrincipalSub     string                 `json:"principal_sub"`
 	RequestId        *openapi_types.UUID    `json:"request_id"`

--- a/docs/codebase/audit_query.md
+++ b/docs/codebase/audit_query.md
@@ -57,6 +57,7 @@ Field-to-source mapping:
 | `parent_audit_id` | `audit_log.parent_audit_id` — composite-operation lineage column (G0.6-T7 #398, migration `0006`). Surfaced on the row since G8.2-T3 (#1011); the flat *filter* on it stays gated. |
 | `agent_session_id` | `audit_log.agent_session_id` — MCP-session correlation column (G8.2-T1 #1009, migration `0014`). Surfaced + filterable since G8.2-T3 (#1011). |
 | `work_ref` | `audit_log.work_ref` — external change-ticket reference (work_ref I1-T1 #1655, migration `0039`). An opaque string (e.g. `"gh:evoila/meho#1"`) correlating a governed operation to the out-of-band change record that authorised it. Surfaced + exact-match-filterable since work_ref I1-T3 (#1658). Bind sources: the request/agent/dispatch boundary (work_ref I1-T2 #1657) and runbook runs (work_ref I3-T1 #1661 — a run's `runbook_runs.work_ref` is bound around each `operation_call` step's dispatch + on the abort row, so the step audit rows inherit the run's change ticket). NULL when no bind source is in scope; system-internal writers leave it NULL by design. |
+| `policy_decision` | `audit_log.policy_decision` — the synchronous policy-gate verdict stamped on the row (#130, migration `0051`). One of the closed `PermissionVerdict` set — `"auto-execute"` / `"needs-approval"` / `"deny"` — or `None` where no gate ran (pre-#130 rows, pre-gate usage errors like unknown-op / invalid-params / connector-resolution failures, and system-internal writers). Populated by both audit writers off the dispatch-scoped `policy_decision_var` contextvar: the parked "request" row carries `"needs-approval"`; the approval "decision" row carries `None` (an operator's approve/reject is not a gate verdict — it is recorded via `result_status`). A consumer reads the verdict directly (`WHERE policy_decision = '<verdict>'`) instead of reconstructing it from `method`+`path`+`payload`. **Verdict catalog:** the persisted set is exactly the three-value `PermissionVerdict` enum. `time_window_violation` / `quota_exceeded` are **not** implemented (no such policy classes exist in code); any external catalog listing them overstates the surface. |
 | `broadcast_event_id` | **None in v0.2** — FK direction is reversed: `BroadcastEvent.audit_id` points at the audit row. |
 
 The three computed fields use exactly the same rules
@@ -113,6 +114,7 @@ query_audit(filters, tenant_id, session)
   │                 parent_audit_id=row.parent_audit_id,
   │                 agent_session_id=row.agent_session_id,
   │                 work_ref=row.work_ref,
+  │                 policy_decision=row.policy_decision,
   │                 principal_name=principal_name, broadcast_event_id=None)
   │
   └─ next_cursor = encode_cursor(CursorPosition(ts=last.ts, id=last.id))


### PR DESCRIPTION
## Summary

- The synchronous policy gate computes a `PermissionVerdict`
  (`auto-execute` / `needs-approval` / `deny`) on every governed
  `call_operation`, but it was **never persisted** — the moat-pillar promise
  "the verdict is stamped onto the operation's audit row" wasn't met, and a
  consumer had to reconstruct it by joining `method`+`path` + parsing `payload`.
- Adds a first-class, nullable, CHECK-constrained **`audit_log.policy_decision`**
  column (migration `0051`), populated from a dispatch-scoped
  `policy_decision_var` contextvar the dispatcher binds right after the gate
  decides. Both audit writers read it — the dispatch-row writer and the
  approval-queue writer (so the parked "request" row carries `needs-approval`).
- Surfaced on `AuditEntry`, so `POST /api/v1/audit/query` and
  `GET /audit/my-recent` return it → `WHERE policy_decision = '<verdict>'` with
  no join/parse.

## Design note (reviewer heads-up)

**Threading via a contextvar, not a param through every audit call site.** This
matches the codebase's established pattern for cross-cutting audit fields
(`run_id` / `work_ref` / `agent_session_id` are all read from contextvars in
`write_audit_row`), covers both writers (in separate modules) with one seam,
and — via a **token/`finally` reset** in `dispatch()` — stays correct under
composite recursion: a child dispatch's rebind is restored to the parent's
verdict on exit. Rows where no gate ran (pre-#130, pre-gate usage errors, the
approval "decision" row, system-internal writers) correctly carry `NULL`.

**Verdict-catalog reconciliation (AC4).** The persisted set is exactly the
three-value `PermissionVerdict` enum. `time_window_violation` / `quota_exceeded`
are **not** implemented (no such policy classes exist); `docs/codebase/audit_query.md`
now documents the real set and marks those two unimplemented rather than listing
them as live. (No in-repo doc listed them as live — the overstatement is in the
external `FEATURES.md` artifact, outside this repo.)

## Test plan

- [x] `ruff` / `ruff format --check` / `mypy` — clean; `code-quality.py --diff` — pass (exit 0)
- [x] **AC1** `test_audit_row_stamps_policy_decision_per_verdict` — an `auto-execute`
      dispatch, a `needs-approval` park (the `approval.request` row), and a `deny`
      each land the matching verdict on the `audit_log` row
- [x] **AC2** `test_audit_query_row_includes_policy_decision` +
      `test_audit_my_recent_row_includes_policy_decision`
- [x] **AC3** migration applies clean forward (verified up **and** down on SQLite),
      column nullable; `pytest -k migration` — **258 passed**
- [x] **AC4** verdict catalog documented + reconciled to `PermissionVerdict`;
      `grep time_window_violation|quota_exceeded docs/` is clean in-repo
- [x] **AC5** `pytest -k "audit and (policy or verdict or decision)"` — **16 passed**
- [x] Regression: dispatcher + audit + approval + middleware suites — **223 passed**;
      UI/agent audit — **40 passed** (every `AuditEntry` construction site updated
      for the new required field)
- [x] CLI OpenAPI snapshot regenerated + typed Go client compiles

## Out of scope

- Implementing `time_window_violation` / `quota_exceeded` policy classes.
- A `/api/v1/policies` enumeration endpoint.
- Cross-principal audit-read scoping; which rows are written (only the verdict
  field is added).

Fully implements evoila-bosnia/meho-internal#130 (cross-repo `Refs`; GitHub does
not auto-close across repos — close the tracking issue on merge). Sibling #129
(four-eyes on dangerous writes) already merged; this closes Initiative #128's
other half.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added a new policy decision field to audit records and API responses.
  * Audit entries can now show whether an action was auto-executed, needs approval, or was denied.

* **Bug Fixes**
  * Audit and approval flows now consistently preserve the policy decision on related records.
  * Query and replay views now include the new field so returned data stays complete.

* **Documentation**
  * Updated audit query docs to explain the new policy decision value and how to use it.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->