### PR TITLE
feat(docs-search): expose a grounding signal on search_docs (out-of-corpus discipline)

### DIFF
--- a/backend/src/meho_backplane/api/v1/search_docs.py
+++ b/backend/src/meho_backplane/api/v1/search_docs.py
@@ -127,6 +127,7 @@ from meho_backplane.docs_search import (
     parse_collection_scope,
     resolve_entitled_ready_collection,
     resolve_entitled_ready_collections,
+    retrieval_is_grounded,
     search_docs,
     search_docs_fanout,
 )
@@ -184,11 +185,32 @@ class SearchDocsResponse(BaseModel):
     surface so the wire contract is decoupled from the corpus's. Frozen
     so an accidental post-construction mutation surfaces as a pydantic
     error rather than a silently-altered response.
+
+    ``grounded`` is the **out-of-corpus discipline signal** (#133): ``True``
+    when retrieval returned at least one chunk to ground on, ``False`` when it
+    returned none. A consumer must treat ``grounded=False`` as *"the corpus
+    has no answer"* and **not** fall back to ungrounded generation — the
+    feature's contract (*empty/low-score = not in the corpus; do not silently
+    fall back to training data*). The verdict is computed server-side by the
+    shared :func:`~meho_backplane.docs_search.retrieval_is_grounded` seam —
+    the **same** determination ``ask_docs`` uses to short-circuit to its "no
+    grounded answer" reply, so the two surfaces never diverge.
+
+    **Score scale + limits of this signal.** Each chunk's ``score`` is the
+    corpus's raw relevance score — an **opaque, backend-defined scale** MEHO
+    does not normalise or threshold; do not compare it across collections or
+    against a fixed cutoff. ``grounded`` is therefore **presence-based**, not
+    relevance-judged: a query that retrieves topically-irrelevant chunks at
+    high scores still reports ``grounded=True``. Distinguishing that case
+    needs a calibrated per-collection score floor, deferred as the Option-A
+    follow-on (evoila-bosnia/meho-internal#133); it will refine
+    ``retrieval_is_grounded`` in one place for both surfaces.
     """
 
     model_config = ConfigDict(frozen=True)
 
     chunks: list[DocsChunk]
+    grounded: bool
 
 
 def _compute_query_hash(query: str) -> str:
@@ -481,7 +503,10 @@ async def _handle_single(
         version=docs_scope.version,
         hit_count=len(result.chunks),
     )
-    return SearchDocsResponse(chunks=result.chunks)
+    return SearchDocsResponse(
+        chunks=result.chunks,
+        grounded=retrieval_is_grounded(result.chunks),
+    )
 
 
 async def _handle_fanout(
@@ -526,4 +551,7 @@ async def _handle_fanout(
         collections=queried,
         hit_count=len(result.chunks),
     )
-    return SearchDocsResponse(chunks=result.chunks)
+    return SearchDocsResponse(
+        chunks=result.chunks,
+        grounded=retrieval_is_grounded(result.chunks),
+    )

--- a/backend/src/meho_backplane/docs_search/__init__.py
+++ b/backend/src/meho_backplane/docs_search/__init__.py
@@ -83,6 +83,7 @@ from meho_backplane.docs_search.service import (
     DocsSearchResult,
     MissingDocsFilterError,
     build_docs_scope,
+    retrieval_is_grounded,
     search_docs,
 )
 from meho_backplane.docs_search.synthesis import (
@@ -130,6 +131,7 @@ __all__ = [
     "resolve_citation_link",
     "resolve_entitled_ready_collection",
     "resolve_entitled_ready_collections",
+    "retrieval_is_grounded",
     "retrieve_multi_query",
     "rrf_merge",
     "search_docs",

--- a/backend/src/meho_backplane/docs_search/service.py
+++ b/backend/src/meho_backplane/docs_search/service.py
@@ -35,6 +35,7 @@ touches the raw query beyond forwarding it to the corpus.
 
 from __future__ import annotations
 
+from collections.abc import Sequence
 from typing import TYPE_CHECKING
 
 import structlog
@@ -179,6 +180,35 @@ class DocsSearchResult(BaseModel):
     model_config = ConfigDict(frozen=True)
 
     chunks: list[DocsChunk] = Field(default_factory=list)
+
+
+def retrieval_is_grounded(chunks: Sequence[DocsChunk]) -> bool:
+    """Return whether a retrieval has anything to ground an answer on (#133).
+
+    The **single source of truth** for the groundedness verdict both
+    retrieval surfaces expose: ``search_docs`` reports it as the
+    :attr:`SearchDocsResponse.grounded` flag, and ``ask_docs`` uses the same
+    check to short-circuit to
+    :data:`~meho_backplane.docs_search.synthesis.NO_GROUNDED_ANSWER` — so the
+    two never diverge on what "grounded" means (a second, drifting threshold
+    is exactly what #133 forbids).
+
+    The verdict is **presence-based and deterministic**: grounded ⇔ retrieval
+    returned at least one chunk. This is `ask_docs`'s existing empty-evidence
+    determination (it answers ``NO_GROUNDED_ANSWER`` *without calling the
+    model* when retrieval is empty), lifted verbatim; it makes no model call
+    and reads no score, so ``search_docs`` stays pure retrieval.
+
+    What it deliberately does **not** do: judge whether *present* chunks are
+    topically relevant. A query that retrieves noise chunks at deceptively
+    high scores (the corpus ``score`` is an opaque, undocumented scale, and
+    out-of-corpus scores have been observed *higher* than in-corpus ones — so
+    no absolute floor separates them) still reports ``grounded=True`` here.
+    Distinguishing that case needs a calibrated, per-collection score floor —
+    deferred as the Option-A follow-on in #133 — and this function is the one
+    seam that refinement lands in, for both surfaces at once.
+    """
+    return len(chunks) > 0
 
 
 def build_docs_scope(

--- a/backend/src/meho_backplane/docs_search/synthesis.py
+++ b/backend/src/meho_backplane/docs_search/synthesis.py
@@ -57,7 +57,11 @@ from typing import Final, cast
 import structlog
 from pydantic import BaseModel, ConfigDict, Field, ValidationError
 
-from meho_backplane.docs_search.service import DocsChunk, DocsSearchResult
+from meho_backplane.docs_search.service import (
+    DocsChunk,
+    DocsSearchResult,
+    retrieval_is_grounded,
+)
 from meho_backplane.operations.ingest import (
     StructuredJsonLlmClient,
     build_anthropic_ingest_llm_client,
@@ -407,9 +411,11 @@ async def synthesize_docs_answer(
             retrieved set. Also surfaces as ``-32603``.
     """
     chunks = list(retrieval.chunks)
-    if not chunks:
+    if not retrieval_is_grounded(chunks):
         # Empty evidence: the only answer path that produces text without
-        # calling the model, precisely so it cannot hallucinate.
+        # calling the model, precisely so it cannot hallucinate. The verdict
+        # is the shared :func:`retrieval_is_grounded` seam (#133) so this
+        # short-circuit and ``search_docs``'s ``grounded`` flag never diverge.
         _log.info("docs_ask_no_grounding", hit_count=0)
         return DocsAnswer(answer=NO_GROUNDED_ANSWER, citations=[])
 

--- a/backend/src/meho_backplane/mcp/tools/docs.py
+++ b/backend/src/meho_backplane/mcp/tools/docs.py
@@ -114,6 +114,7 @@ from meho_backplane.docs_search import (
     parse_collection_scope,
     resolve_entitled_ready_collection,
     resolve_entitled_ready_collections,
+    retrieval_is_grounded,
     retrieve_multi_query,
     search_docs,
     search_docs_fanout,
@@ -313,6 +314,11 @@ async def _search_docs_handler(
         result = await _run_search_single("search_docs", operator, arguments, query, limit)
     return {
         "chunks": [chunk.model_dump(mode="json") for chunk in result.chunks],
+        # Out-of-corpus discipline signal (#133): same shared verdict the REST
+        # search_docs response + ask_docs's no-grounded-answer short-circuit
+        # use, so the MCP tool never diverges. grounded=False ⇒ treat as "not
+        # in the corpus", do not fall back to ungrounded generation.
+        "grounded": retrieval_is_grounded(result.chunks),
     }
 
 

--- a/backend/tests/test_mcp_tools_docs.py
+++ b/backend/tests/test_mcp_tools_docs.py
@@ -376,6 +376,8 @@ def test_tools_call_search_docs_routes_to_collection_backend(
     assert len(payload["chunks"]) == 1
     chunk = payload["chunks"][0]
     assert chunk["chunk_id"] == "nsx-9.0-maximums-0007"
+    # #133: the MCP search_docs tool exposes the same grounded verdict as REST.
+    assert payload["grounded"] is True
     # The backend id never appears in the response.
     assert "backend" not in json.dumps(payload)
 

--- a/backend/tests/test_search_docs_route.py
+++ b/backend/tests/test_search_docs_route.py
@@ -912,6 +912,9 @@ def test_fanout_all_sentinel_queries_entitled_collections_and_tags_provenance(
     # Every chunk carries its source-collection provenance tag.
     seen_collections = {c["collection"] for c in body["chunks"]}
     assert seen_collections == {"vmware", "netapp"}
+    # #133: the fan-out branch computes `grounded` off the RRF-merged chunks
+    # via the same shared seam as the single-collection path.
+    assert body["grounded"] is True
     assert "backend" not in json.dumps(body)
 
 

--- a/backend/tests/test_search_docs_route.py
+++ b/backend/tests/test_search_docs_route.py
@@ -228,6 +228,8 @@ def test_search_docs_returns_200_with_cited_chunks(client: TestClient) -> None:
     assert len(body["chunks"]) == 2
     assert body["chunks"][0]["chunk_id"] == "c1"
     assert body["chunks"][0]["content"] == "vSAN disk groups..."
+    # #133: a query that retrieved chunks signals grounded (AC2).
+    assert body["grounded"] is True
     # The backend id never appears in the response.
     assert "backend" not in json.dumps(body)
 
@@ -237,6 +239,83 @@ def test_search_docs_returns_200_with_cited_chunks(client: TestClient) -> None:
     assert operator_arg.tenant_id == tenant_id
     assert call_args.args[1] == "vsan disk groups"
     assert call_args.kwargs["limit"] == 5
+
+
+def test_search_docs_out_of_corpus_query_not_grounded(client: TestClient) -> None:
+    """#133 AC1 (re-scoped): a query the corpus can't answer signals not-grounded.
+
+    An out-of-corpus query returns no chunks, so ``grounded`` is ``False`` — a
+    consumer switches on that single boolean to refuse an ungrounded answer,
+    distinguishable from an in-corpus query (``grounded=True``, covered by
+    ``test_search_docs_returns_200_with_cited_chunks``).
+
+    Per the Option-1 re-scope of #133, the verdict is presence-based (empty
+    retrieval → not grounded), the deterministic determination ``ask_docs``
+    already uses. The live "3 noise chunks at deceptively-high scores" case
+    (the guitar-string probe) returns chunks and so still reports grounded
+    here; separating it needs the deferred Option-A calibrated score floor.
+    """
+    _seed_collection_sync()
+    key = _make_rsa_keypair("kid-A")
+    token = _mint_token(
+        key,
+        sub="op-1",
+        tenant_role=TenantRole.OPERATOR.value,
+        tenant_id=str(UUID("33333333-3333-3333-3333-333333333333")),
+        capabilities=_ENTITLED_CAPS,
+    )
+
+    empty_corpus = _mock_corpus()  # no chunks → out-of-corpus
+    with (
+        respx.mock as mock_router,
+        patch(_CORPUS_SEAM, new=empty_corpus),
+    ):
+        _mock_discovery_and_jwks(mock_router, _public_jwks(key))
+        response = client.post(
+            "/api/v1/search_docs",
+            json={
+                "query": "how do I tune my acoustic guitar strings",
+                "collection": "vmware",
+                "limit": 5,
+            },
+            headers={"Authorization": f"Bearer {token}"},
+        )
+
+    assert response.status_code == 200
+    body = response.json()
+    assert body["chunks"] == []
+    assert body["grounded"] is False
+
+
+@pytest.mark.asyncio
+async def test_search_docs_grounded_verdict_shared_with_ask_docs() -> None:
+    """#133 AC3: search_docs' grounded flag and ask_docs agree via one seam.
+
+    Both surfaces read :func:`retrieval_is_grounded`; ``ask_docs``'s synthesis
+    short-circuits to ``NO_GROUNDED_ANSWER`` on exactly the retrievals that
+    helper calls not-grounded. Assert the boundary agrees, so the two cannot
+    drift to divergent thresholds.
+    """
+    from meho_backplane.docs_search import (
+        NO_GROUNDED_ANSWER,
+        DocsChunk,
+        DocsSearchResult,
+        retrieval_is_grounded,
+        synthesize_docs_answer,
+    )
+
+    empty = DocsSearchResult(chunks=[])
+    assert retrieval_is_grounded(empty.chunks) is False
+    # ask_docs short-circuits (no model call) on the same emptiness.
+    answer = await synthesize_docs_answer("any question", empty)
+    assert answer.answer == NO_GROUNDED_ANSWER
+    assert answer.citations == []
+
+    # A non-empty retrieval is grounded by the same shared verdict.
+    non_empty = DocsSearchResult(
+        chunks=[DocsChunk(chunk_id="c1", content="vSphere maxima", source_url=None, score=0.3)]
+    )
+    assert retrieval_is_grounded(non_empty.chunks) is True
 
 
 def test_search_docs_source_url_never_leaks_gs_backend(client: TestClient) -> None:

--- a/cli/api/openapi.json
+++ b/cli/api/openapi.json
@@ -24597,14 +24597,19 @@
             },
             "type": "array",
             "title": "Chunks"
+          },
+          "grounded": {
+            "type": "boolean",
+            "title": "Grounded"
           }
         },
         "type": "object",
         "required": [
-          "chunks"
+          "chunks",
+          "grounded"
         ],
         "title": "SearchDocsResponse",
-        "description": "Successful response shape for ``/api/v1/search_docs``.\n\n``chunks`` is the corpus's ranked cited-chunk list (best first),\nprojected into MEHO's :class:`~meho_backplane.docs_search.DocsChunk`\nsurface so the wire contract is decoupled from the corpus's. Frozen\nso an accidental post-construction mutation surfaces as a pydantic\nerror rather than a silently-altered response."
+        "description": "Successful response shape for ``/api/v1/search_docs``.\n\n``chunks`` is the corpus's ranked cited-chunk list (best first),\nprojected into MEHO's :class:`~meho_backplane.docs_search.DocsChunk`\nsurface so the wire contract is decoupled from the corpus's. Frozen\nso an accidental post-construction mutation surfaces as a pydantic\nerror rather than a silently-altered response.\n\n``grounded`` is the **out-of-corpus discipline signal** (#133): ``True``\nwhen retrieval returned at least one chunk to ground on, ``False`` when it\nreturned none. A consumer must treat ``grounded=False`` as *\"the corpus\nhas no answer\"* and **not** fall back to ungrounded generation \u2014 the\nfeature's contract (*empty/low-score = not in the corpus; do not silently\nfall back to training data*). The verdict is computed server-side by the\nshared :func:`~meho_backplane.docs_search.retrieval_is_grounded` seam \u2014\nthe **same** determination ``ask_docs`` uses to short-circuit to its \"no\ngrounded answer\" reply, so the two surfaces never diverge.\n\n**Score scale + limits of this signal.** Each chunk's ``score`` is the\ncorpus's raw relevance score \u2014 an **opaque, backend-defined scale** MEHO\ndoes not normalise or threshold; do not compare it across collections or\nagainst a fixed cutoff. ``grounded`` is therefore **presence-based**, not\nrelevance-judged: a query that retrieves topically-irrelevant chunks at\nhigh scores still reports ``grounded=True``. Distinguishing that case\nneeds a calibrated per-collection score floor, deferred as the Option-A\nfollow-on (evoila-bosnia/meho-internal#133); it will refine\n``retrieval_is_grounded`` in one place for both surfaces."
       },
       "ShowTemplateResponse": {
         "properties": {

--- a/cli/internal/api/client.gen.go
+++ b/cli/internal/api/client.gen.go
@@ -4981,8 +4981,29 @@ type SearchDocsRequest struct {
 // surface so the wire contract is decoupled from the corpus's. Frozen
 // so an accidental post-construction mutation surfaces as a pydantic
 // error rather than a silently-altered response.
+//
+// “grounded“ is the **out-of-corpus discipline signal** (#133): “True“
+// when retrieval returned at least one chunk to ground on, “False“ when it
+// returned none. A consumer must treat “grounded=False“ as *"the corpus
+// has no answer"* and **not** fall back to ungrounded generation — the
+// feature's contract (*empty/low-score = not in the corpus; do not silently
+// fall back to training data*). The verdict is computed server-side by the
+// shared :func:`~meho_backplane.docs_search.retrieval_is_grounded` seam —
+// the **same** determination “ask_docs“ uses to short-circuit to its "no
+// grounded answer" reply, so the two surfaces never diverge.
+//
+// **Score scale + limits of this signal.** Each chunk's “score“ is the
+// corpus's raw relevance score — an **opaque, backend-defined scale** MEHO
+// does not normalise or threshold; do not compare it across collections or
+// against a fixed cutoff. “grounded“ is therefore **presence-based**, not
+// relevance-judged: a query that retrieves topically-irrelevant chunks at
+// high scores still reports “grounded=True“. Distinguishing that case
+// needs a calibrated per-collection score floor, deferred as the Option-A
+// follow-on (evoila-bosnia/meho-internal#133); it will refine
+// “retrieval_is_grounded“ in one place for both surfaces.
 type SearchDocsResponse struct {
-	Chunks []DocsChunk `json:"chunks"`
+	Chunks   []DocsChunk `json:"chunks"`
+	Grounded bool        `json:"grounded"`
 }
 
 // ShowTemplateResponse Full template surface returned by “meho.runbook.show_template“.

--- a/docs/codebase/docs-search.md
+++ b/docs/codebase/docs-search.md
@@ -478,6 +478,29 @@ audit contextvars (including `audit_collection`), runs the shared
 403, not ready → 409), then calls the service. Takes a
 `Depends(get_session)` DB session for the resolve.
 
+`SearchDocsResponse` is `{chunks: list[DocsChunk], grounded: bool}`. The
+`grounded` field (#133) is the **out-of-corpus discipline signal**: `True`
+when retrieval returned ≥1 chunk, `False` when it returned none. A consumer
+must treat `grounded=False` as *"the corpus has no answer"* and **not** fall
+back to ungrounded generation — the feature contract (*empty/low-score = not
+in the corpus; do not silently fall back to training data*). It is computed
+server-side by the shared
+[`retrieval_is_grounded`](../../backend/src/meho_backplane/docs_search/service.py)
+seam — the **same** verdict `ask_docs`'s synthesis uses to short-circuit to
+`NO_GROUNDED_ANSWER`, so the two surfaces cannot diverge. The MCP `search_docs`
+tool returns the same `grounded` key.
+
+**Score scale + what `grounded` does *not* cover.** Each chunk's `score` is
+the corpus's raw relevance score — an **opaque, backend-defined scale** MEHO
+neither normalises nor thresholds; it is not comparable across collections
+and there is no fixed cutoff. `grounded` is therefore **presence-based**, not
+relevance-judged: a query that retrieves topically-irrelevant chunks at
+high scores still reports `grounded=True` (out-of-corpus scores have been
+observed *higher* than in-corpus ones, so no absolute floor separates them).
+Catching that case needs a calibrated per-collection score floor, deferred as
+the Option-A follow-on (evoila-bosnia/meho-internal#133); it will refine
+`retrieval_is_grounded` in the one place both surfaces read.
+
 ### `POST /api/v1/ask_docs` (`meho_backplane.api.v1.ask_docs`, T2 #1917)
 
 The REST face of the **answer** pipeline — the synthesis sibling of


### PR DESCRIPTION
## Summary

- `search_docs` returned top-K chunks with **no signal** a consumer could use
  to tell "the corpus has no answer" from a real hit — so a caller couldn't
  enforce the feature's contract (*empty/low-score = not in the corpus; do not
  silently fall back to training data*). `ask_docs` already had that
  discipline; `search_docs` callers didn't.
- Add a server-computed **`grounded: bool`** to `SearchDocsResponse` (additive)
  **and** the MCP `search_docs` tool payload, computed by a new shared
  **`retrieval_is_grounded()`** seam extracted from `ask_docs`'s empty-evidence
  determination. `ask_docs`'s synthesis short-circuit now calls the same
  helper → **one verdict, no divergent threshold** (AC3).

## Design note — implements the maintainer's Option-1 decision on the #133 pushback

I paused on this task first ([pushback](https://github.com/evoila-bosnia/meho-internal/issues/133)) because AC1 as originally written (deterministically flag the live 3-chunk guitar query) was unsatisfiable within scope: `search_docs` is pure retrieval, `ask_docs`'s only *deterministic* grounding check is empty-retrieval (won't fire on 3 chunks), and the out-of-corpus scores were **higher** than in-corpus (0.48 > 0.30) so no floor separates them. Maintainer chose **Option 1**:

- Verdict is **presence-based + deterministic** (`grounded ⇔ ≥1 chunk`): no model call (search_docs stays pure retrieval), no score read (the corpus `score` is an opaque, unthreshold-able scale).
- **AC1 re-scoped** to the deterministic contract (empty retrieval → not-grounded). The topically-irrelevant-chunks-at-high-scores case needs a calibrated per-collection score floor — deferred as the **Option-A follow-on**; `retrieval_is_grounded` is the single seam that refinement lands in for both surfaces.

## Test plan

- [x] `ruff` / `ruff format --check` / `mypy` — clean; `code-quality.py --diff` — pass (exit 0)
- [x] **AC1 (re-scoped)** `test_search_docs_out_of_corpus_query_not_grounded` — empty retrieval → `grounded=False`
- [x] **AC2** `test_search_docs_returns_200_with_cited_chunks` asserts `grounded is True`; in-corpus still returns chunks
- [x] **AC3** `test_search_docs_grounded_verdict_shared_with_ask_docs` — both read `retrieval_is_grounded`; `ask_docs` short-circuits to `NO_GROUNDED_ANSWER` on exactly the retrievals the helper calls not-grounded
- [x] MCP parity: `test_mcp_tools_docs` asserts the tool payload carries `grounded`
- [x] **AC4** additive (`chunks` unchanged; flag new); score-scale + contract documented in `docs/codebase/docs-search.md` + the `SearchDocsResponse` OpenAPI description
- [x] **AC5** `pytest -k "search_docs and (grounded or out_of_corpus or no_match or score)"` — **4 passed**; full affected suites — **100 passed**
- [x] CLI OpenAPI snapshot regenerated + typed Go client compiles

## Out of scope

- Calibrated per-collection score floors (Option A) — the deferred follow-on.
- Changing `ask_docs`'s fail-closed behavior — only surfaced/shared its verdict.
- The `source_url` backend leak — sibling #132 (merged).

Fully implements evoila-bosnia/meho-internal#133 (Option 1). Cross-repo `Refs`; close the tracking issue on merge. Closes Initiative #131.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Search responses now include a `grounded` flag so clients can tell whether results are backed by retrieved corpus content.
  * The same grounded status is now returned consistently across the API and tool-based search experience.

* **Bug Fixes**
  * Improved consistency between search results and answer generation when no supported evidence is found.

* **Documentation**
  * Updated API and developer docs to describe the new response field and expected client behavior when `grounded` is `false`.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->