### PR TITLE
fix(runbooks): skip the no-op fork when a template edit is byte-identical

### DIFF
--- a/backend/src/meho_backplane/runbooks/schemas.py
+++ b/backend/src/meho_backplane/runbooks/schemas.py
@@ -376,13 +376,21 @@ class EditTemplateResponse(BaseModel):
     which case :attr:`forked_from` is populated with the source's
     :class:`ForkInfo`. On the draft-edit path :attr:`forked_from` is
     ``None``.
+
+    :attr:`status` is normally ``"draft"`` (both the in-place edit and the
+    fork mint/keep a draft). The one exception is the **no-op fork skip**
+    (#144): editing a published/deprecated version with a body byte-identical
+    to the source creates no draft and returns the *unchanged source* — so
+    ``version`` is the source version, ``forked_from`` is ``None``, and
+    ``status`` is the source's own ``"published"`` / ``"deprecated"``. The
+    non-``"draft"`` status is the signal that no new draft was created.
     """
 
     model_config = ConfigDict(frozen=True)
 
     slug: str
     version: int
-    status: Literal["draft"]
+    status: Literal["draft", "published", "deprecated"]
     forked_from: ForkInfo | None = None
 
 

--- a/backend/src/meho_backplane/runbooks/service.py
+++ b/backend/src/meho_backplane/runbooks/service.py
@@ -247,6 +247,30 @@ class RunbookTemplateService:
                     raise TemplateNotFoundError(
                         f"no template for slug {request.slug!r}; nothing to edit or fork"
                     )
+                source_row = await self._load_exact(
+                    session, tenant_id, request.slug, source_version
+                )
+                # ``source_row`` is non-None: ``source_version`` came from a
+                # real row via ``_resolve_latest_version`` and this session
+                # holds the read lock.
+                if source_row is not None and _body_matches(source_row, request.body):
+                    # #144: byte-identical edit of a published/deprecated
+                    # version is a no-op -- do NOT mint a redundant
+                    # ``v=max+1`` draft that differs only in metadata. Return
+                    # the unchanged source (no new row, no fork). Both the UI
+                    # editor and the REST PATCH path inherit this from here.
+                    structlog.get_logger().info(
+                        "runbook_template_edit_noop",
+                        tenant_id=str(tenant_id),
+                        slug=request.slug,
+                        version=source_version,
+                    )
+                    return EditTemplateResponse(
+                        slug=request.slug,
+                        version=source_version,
+                        status=_narrow_status(source_row.status),
+                        forked_from=None,
+                    )
                 in_flight = await _count_in_flight_runs(
                     session, tenant_id, request.slug, source_version
                 )
@@ -635,6 +659,29 @@ async def _count_in_flight_runs(
 def _steps_to_storage(steps: list[Step]) -> list[dict[str, object]]:
     """Serialise validated Pydantic steps to the ``steps`` JSONB column shape."""
     return [step.model_dump(mode="json") for step in steps]
+
+
+def _body_matches(row: RunbookTemplate, body: RunbookTemplateBody) -> bool:
+    """Whether *body* is content-identical to the persisted *row* (#144).
+
+    Compares only the author-supplied body fields — ``title`` /
+    ``description`` / ``target_kind`` / ``steps`` — excluding the metadata a
+    fork would change anyway (``version`` / ``status`` / ``created_by`` /
+    ``edited_by`` / ``edited_at``). ``steps`` is compared in the JSONB storage
+    shape (:func:`_steps_to_storage`) so the incoming validated models are
+    matched against the row exactly as stored — the same serialisation a fork
+    would persist, so equality here means the fork would be byte-identical.
+
+    When this returns ``True`` on the fork path, :meth:`update_or_fork` skips
+    the fork and returns the unchanged source, keeping a no-op edit a no-op
+    (idempotent) instead of minting a redundant draft.
+    """
+    return (
+        row.title == body.title
+        and row.description == body.description
+        and row.target_kind == body.target_kind
+        and row.steps == _steps_to_storage(body.steps)
+    )
 
 
 def _steps_from_storage(steps: list[dict[str, object]]) -> list[Step]:

--- a/backend/tests/test_runbook_templates_api.py
+++ b/backend/tests/test_runbook_templates_api.py
@@ -1335,3 +1335,50 @@ async def test_draft_rejects_blank_step_body_422(blank_body: str) -> None:
             headers=_authed(token),
         )
     assert response.status_code == 422, response.text
+
+
+@pytest.mark.asyncio
+async def test_patch_noop_identical_body_does_not_fork_via_route() -> None:
+    """#144 AC3: a PATCH byte-identical to the published source mints no new version.
+
+    Exercises the **real** service end-to-end through the route (``update_or_fork``
+    is NOT mocked): seed a published v1, then PATCH with an identical body. The
+    dedup lands engine-side, so the route returns the unchanged source
+    (``forked_from=null``, source version + status) and ``show`` confirms no v2.
+    """
+    tenant = uuid.uuid4()
+    key, token = _admin_token(tenant_id=tenant)
+    test_client = TestClient(_build_app())
+    with respx.mock as mock_router:
+        _mock_discovery_and_jwks(mock_router, _public_jwks(key))
+        # Seed a published v1 through the route (real service, real DB).
+        created = test_client.post(
+            "/api/v1/runbooks/templates",
+            json={"slug": "rotate-cert", "body": _template_body()},
+            headers=_authed(token),
+        )
+        assert created.status_code == 201, created.text
+        published = test_client.post(
+            "/api/v1/runbooks/templates/rotate-cert/publish",
+            json={"version": 1},
+            headers=_authed(token),
+        )
+        assert published.status_code == 200, published.text
+        # PATCH with a byte-identical body → no-op fork skip.
+        patched = test_client.patch(
+            "/api/v1/runbooks/templates/rotate-cert",
+            json=_template_body(),
+            headers=_authed(token),
+        )
+        assert patched.status_code == 200, patched.text
+        edit = patched.json()
+        assert edit["version"] == 1
+        assert edit["forked_from"] is None
+        assert edit["status"] == "published"
+        # No v2 draft was created — the latest version is still 1.
+        shown = test_client.get(
+            "/api/v1/runbooks/templates/rotate-cert",
+            headers=_authed(token),
+        )
+        assert shown.status_code == 200, shown.text
+        assert shown.json()["version"] == 1

--- a/backend/tests/test_runbooks_template_service.py
+++ b/backend/tests/test_runbooks_template_service.py
@@ -221,6 +221,35 @@ async def test_update_or_fork_forks_from_published() -> None:
 
 
 @pytest.mark.asyncio
+async def test_update_or_fork_noop_on_identical_body_skips_fork() -> None:
+    """#144 AC1: editing a published version with a byte-identical body creates no fork.
+
+    A re-submit that changed nothing must not mint a redundant ``v=max+1`` draft
+    that differs only in metadata. The edit returns the unchanged source
+    (``forked_from=None``, source version, source status) and no new row lands.
+    """
+    service = RunbookTemplateService()
+    tenant_id = uuid.uuid4()
+    await service.create_draft(
+        tenant_id, OPERATOR, DraftTemplateRequest(slug="drain-node", body=_body())
+    )
+    await service.publish(tenant_id, PublishTemplateRequest(slug="drain-node", version=1))
+
+    resp = await service.update_or_fork(
+        tenant_id,
+        OPERATOR,
+        # Body identical to the published v1 — a no-op edit.
+        EditTemplateRequest(slug="drain-node", body=_body()),
+    )
+
+    assert resp.forked_from is None
+    assert resp.version == 1
+    assert resp.status == "published"
+    # No v2 row was minted: the latest version is still 1.
+    assert (await service.show_template(tenant_id, "drain-node")).version == 1
+
+
+@pytest.mark.asyncio
 async def test_update_or_fork_in_flight_run_count() -> None:
     """Fork reports only in_progress runs pinned to the source version."""
     service = RunbookTemplateService()
@@ -239,8 +268,11 @@ async def test_update_or_fork_in_flight_run_count() -> None:
     # An in-progress run against a different version is NOT counted.
     await _seed_run(tenant_id, "drain-node", 2, "in_progress")
 
+    # A *changed* body so the edit actually forks (a byte-identical body is now
+    # a no-op that skips the fork, #144) — this test exercises the fork path's
+    # in_flight_run_count reporting.
     resp = await service.update_or_fork(
-        tenant_id, OPERATOR, EditTemplateRequest(slug="drain-node", body=_body())
+        tenant_id, OPERATOR, EditTemplateRequest(slug="drain-node", body=_body(title="Forked v2"))
     )
 
     assert resp.forked_from is not None
@@ -360,8 +392,10 @@ async def test_list_templates_filters() -> None:
         tenant_id, OPERATOR, DraftTemplateRequest(slug="alpha", body=_body())
     )
     await service.publish(tenant_id, PublishTemplateRequest(slug="alpha", version=1))
+    # A changed body so the edit forks v2 (a byte-identical body is now a no-op
+    # that skips the fork, #144).
     await service.update_or_fork(
-        tenant_id, OPERATOR, EditTemplateRequest(slug="alpha", body=_body())
+        tenant_id, OPERATOR, EditTemplateRequest(slug="alpha", body=_body(title="alpha v2"))
     )
     await service.create_draft(tenant_id, OPERATOR, DraftTemplateRequest(slug="beta", body=_body()))
 

--- a/cli/api/openapi.json
+++ b/cli/api/openapi.json
@@ -22128,7 +22128,11 @@
           },
           "status": {
             "type": "string",
-            "const": "draft",
+            "enum": [
+              "draft",
+              "published",
+              "deprecated"
+            ],
             "title": "Status"
           },
           "forked_from": {
@@ -22143,7 +22147,7 @@
           "status"
         ],
         "title": "EditTemplateResponse",
-        "description": "Response for ``meho.runbook.edit_template``.\n\n:attr:`version` equals the input version when editing a draft in\nplace; it is a new version when forking from a published template, in\nwhich case :attr:`forked_from` is populated with the source's\n:class:`ForkInfo`. On the draft-edit path :attr:`forked_from` is\n``None``."
+        "description": "Response for ``meho.runbook.edit_template``.\n\n:attr:`version` equals the input version when editing a draft in\nplace; it is a new version when forking from a published template, in\nwhich case :attr:`forked_from` is populated with the source's\n:class:`ForkInfo`. On the draft-edit path :attr:`forked_from` is\n``None``.\n\n:attr:`status` is normally ``\"draft\"`` (both the in-place edit and the\nfork mint/keep a draft). The one exception is the **no-op fork skip**\n(#144): editing a published/deprecated version with a body byte-identical\nto the source creates no draft and returns the *unchanged source* \u2014 so\n``version`` is the source version, ``forked_from`` is ``None``, and\n``status`` is the source's own ``\"published\"`` / ``\"deprecated\"``. The\nnon-``\"draft\"`` status is the signal that no new draft was created."
       },
       "EnableReadsResponse": {
         "properties": {

--- a/cli/internal/api/client.gen.go
+++ b/cli/internal/api/client.gen.go
@@ -134,6 +134,13 @@ const (
 	EditOpWarningCodeUnreplacedAutoShim    EditOpWarningCode = "unreplaced_auto_shim"
 )
 
+// Defines values for EditTemplateResponseStatus.
+const (
+	EditTemplateResponseStatusDeprecated EditTemplateResponseStatus = "deprecated"
+	EditTemplateResponseStatusDraft      EditTemplateResponseStatus = "draft"
+	EditTemplateResponseStatusPublished  EditTemplateResponseStatus = "published"
+)
+
 // Defines values for EvalRequestSurface.
 const (
 	EvalRequestSurfaceAll        EvalRequestSurface = "all"
@@ -461,9 +468,9 @@ const (
 
 // Defines values for RunbooksListUiRunbooksListGetParamsStatus.
 const (
-	Deprecated RunbooksListUiRunbooksListGetParamsStatus = "deprecated"
-	Draft      RunbooksListUiRunbooksListGetParamsStatus = "draft"
-	Published  RunbooksListUiRunbooksListGetParamsStatus = "published"
+	RunbooksListUiRunbooksListGetParamsStatusDeprecated RunbooksListUiRunbooksListGetParamsStatus = "deprecated"
+	RunbooksListUiRunbooksListGetParamsStatusDraft      RunbooksListUiRunbooksListGetParamsStatus = "draft"
+	RunbooksListUiRunbooksListGetParamsStatusPublished  RunbooksListUiRunbooksListGetParamsStatus = "published"
 )
 
 // Defines values for RunbooksRunsUiRunbooksRunsGetParamsStatus.
@@ -3333,6 +3340,14 @@ type EditOpWarningCode string
 // which case :attr:`forked_from` is populated with the source's
 // :class:`ForkInfo`. On the draft-edit path :attr:`forked_from` is
 // “None“.
+//
+// :attr:`status` is normally “"draft"“ (both the in-place edit and the
+// fork mint/keep a draft). The one exception is the **no-op fork skip**
+// (#144): editing a published/deprecated version with a body byte-identical
+// to the source creates no draft and returns the *unchanged source* — so
+// “version“ is the source version, “forked_from“ is “None“, and
+// “status“ is the source's own “"published"“ / “"deprecated"“. The
+// non-“"draft"“ status is the signal that no new draft was created.
 type EditTemplateResponse struct {
 	// ForkedFrom Surfaced by ``meho.runbook.edit_template`` when editing a published template forks.
 	//
@@ -3341,11 +3356,14 @@ type EditTemplateResponse struct {
 	// shape tells the senior what they are forking from -- the source
 	// version and how many runs are still pinned to it -- so they can decide
 	// whether the fork is the right move.
-	ForkedFrom *ForkInfo `json:"forked_from,omitempty"`
-	Slug       string    `json:"slug"`
-	Status     string    `json:"status"`
-	Version    int       `json:"version"`
+	ForkedFrom *ForkInfo                  `json:"forked_from,omitempty"`
+	Slug       string                     `json:"slug"`
+	Status     EditTemplateResponseStatus `json:"status"`
+	Version    int                        `json:"version"`
 }
+
+// EditTemplateResponseStatus defines model for EditTemplateResponse.Status.
+type EditTemplateResponseStatus string
 
 // EnableReadsResponse Response body for “POST /api/v1/connectors/{id}/enable-reads“ (G0.25-T7 #1749).
 //

--- a/docs/runbooks/authoring.md
+++ b/docs/runbooks/authoring.md
@@ -143,6 +143,15 @@ The edit response then carries a `forked_from` block:
 against the version you forked from. It is the senior's decision input: it
 says how many operators are mid-procedure on the old version right now.
 
+**No-op edits don't fork.** If the submitted body is byte-identical to the
+source version (a re-submit that changed nothing — e.g. an accidental Edit →
+Submit of the pre-populated form), the edit is a no-op: no draft is created.
+The response then describes the *unchanged source* — `version` is the source
+version, `forked_from` is `null`, and `status` is the source's own
+`published` / `deprecated` (not `draft`). A non-`draft` status is the signal
+that no new draft was minted. A genuine change still forks `max(version) + 1`
+as above.
+
 What the fork does and does not change:
 
 - **In-flight runs keep advancing on their pinned version.** A run is pinned


### PR DESCRIPTION
## Summary

- Editing a **published** runbook template forks a `v=max+1` draft (published
  versions are immutable) — but `update_or_fork` had **no byte-identical dedup**,
  so a re-submit that changed nothing (e.g. an accidental Edit → Submit of the
  pre-populated UI form) minted a redundant draft differing only in metadata,
  polluting the version history.
- Add a byte-identical guard on the fork path: a new `_body_matches` helper
  compares the four author-supplied body fields (title / description /
  target_kind / steps, in storage shape) against the source row; on a match,
  **skip the fork** and return the unchanged source (`forked_from=None`).
  Engine-side in `update_or_fork` → **both** the UI editor and REST `PATCH`
  inherit the dedup from one seam. Draft-in-place edits + genuine forks unchanged.

## Design note (reviewer heads-up)

`EditTemplateResponse.status` widened from `Literal["draft"]` to
`Literal["draft","published","deprecated"]`: the no-op return describes the
*unchanged source* (published/deprecated), so a non-`draft` status is the honest
signal that **no new draft was created**. Additive to the wire (a string field
gains permitted values); the UI editor keys on `forked_from` (not `.status`), so
no consumer breaks. CLI snapshot + docs updated.

Two existing service tests that edited a published version with a *byte-identical*
body while expecting a fork (they leaned on the old always-fork behavior to set
up their scenarios) are updated to submit a **changed** body — preserving their
real intent (`in_flight_run_count` reporting; list-filter versions).

## Test plan

- [x] `ruff` / `ruff format --check` / `mypy` — clean; `code-quality.py --diff` — pass (exit 0)
- [x] **AC1** `test_update_or_fork_noop_on_identical_body_skips_fork` — identical body → `forked_from=None`, version unchanged, no v2 row
- [x] **AC2** `test_update_or_fork_forks_from_published` (existing) — changed body still forks v2 with `forked_from` (regression guard)
- [x] **AC3** `test_patch_noop_identical_body_does_not_fork_via_route` — un-mocked REST PATCH (real service + DB): identical body → 200, `forked_from=null`, `status="published"`, `show` confirms max version still 1
- [x] **AC4** `grep "def update_or_fork"` shows the `_body_matches` guard on the fork branch
- [x] **AC5** `pytest -k "update_or_fork or (runbook and (fork or edit))"` — 39 passed; broader runbook-template/editor/lifecycle suites — 175 passed

## Out of scope

- `evoila/meho#2115` main finding (403 + fork-commit divergence) — not a bug.
- `forked_from`-on-GET observation — not a bug (`EditTemplateResponse`-only field).
- Retroactive cleanup of already-accumulated no-op draft forks — separate op concern.
- Optional client-side "no changes" UI detection — the engine-side dedup is load-bearing.

Fully implements evoila-bosnia/meho-internal#144. Cross-repo `Refs`; close on merge.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Editing a runbook template with no actual content changes now keeps the current version instead of creating a new draft.
  * The edit response now correctly reflects the original template’s status when no fork is needed.
  * Runbook listings and edit flows now behave more consistently when working with published or deprecated templates.

* **Documentation**
  * Updated runbook authoring docs to describe the no-op edit behavior and when a new draft is created.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->