### PR TITLE
fix(ui): coerce empty topology kind/q filters to no-filter

### DIFF
--- a/backend/src/meho_backplane/ui/query_filters.py
+++ b/backend/src/meho_backplane/ui/query_filters.py
@@ -43,8 +43,21 @@ the extra and the empty string keeps 422-ing::
 
     status: Annotated[_RunStateFilter | None, EMPTY_STR_TO_NONE, Query()] = None
 
-``str | None`` filter params (e.g. ``assignee``, ``target_kind``) do not
-need this: an empty string is a valid ``str``, so they never 422.
+``str | None`` filter params never 422 on the empty string (it is a
+valid ``str``) -- but they still need the coercion whenever the value
+flows into an exact-match SQL filter, where ``""`` silently becomes
+``WHERE col = ''`` and matches nothing (the runbook catalog's
+``target_kind``, the topology table's ``kind``). For those, pin any
+``max_length`` guard on the inner ``str`` branch via
+:class:`pydantic.StringConstraints` -- a bare ``Query(max_length=...)``
+on the nullable field raises ``TypeError`` when the validator produces
+``None``::
+
+    kind: Annotated[
+        Annotated[str, StringConstraints(max_length=64)] | None,
+        EMPTY_STR_TO_NONE,
+        Query(),
+    ] = None
 
 Existing surfaces that use an in-vocabulary ``all`` sentinel enum member
 (e.g. the connector-registry ``ConnectorStatusFilter`` -- ``value="all"``,

--- a/backend/src/meho_backplane/ui/routes/topology/table.py
+++ b/backend/src/meho_backplane/ui/routes/topology/table.py
@@ -80,10 +80,11 @@ from __future__ import annotations
 
 import uuid
 from enum import StrEnum
-from typing import Final
+from typing import Annotated, Final
 
 from fastapi import APIRouter, Depends, HTTPException, Query, Request
 from fastapi.responses import HTMLResponse
+from pydantic import StringConstraints
 from sqlalchemy.ext.asyncio import AsyncSession
 
 from meho_backplane.db.engine import get_raw_session
@@ -91,6 +92,7 @@ from meho_backplane.db.models import _GRAPH_NODE_KINDS
 from meho_backplane.topology.query import list_nodes
 from meho_backplane.ui.auth.middleware import UISessionContext, require_ui_session
 from meho_backplane.ui.csrf import CSRF_COOKIE_NAME, mint_csrf_token
+from meho_backplane.ui.query_filters import EMPTY_STR_TO_NONE
 from meho_backplane.ui.routes.connectors.operator import resolve_role_probe
 from meho_backplane.ui.routes.topology.graph import OverlayDirection, render_graph
 from meho_backplane.ui.routes.topology.queries import (
@@ -444,8 +446,26 @@ def build_table_router() -> APIRouter:
                 "the graph overlay branch (``view=graph&from=<name>``)."
             ),
         ),
-        kind: str | None = Query(default=None, max_length=64),
-        q: str | None = Query(default=None, max_length=256),
+        # ``kind`` / ``q`` coerce ``"" -> None`` so the filter bar's
+        # "All kinds" option (``<option value="">``) and a cleared
+        # search box mean "no filter". The form co-submits ``kind`` on
+        # every search keystroke (``hx-include="closest form"``), so
+        # without the coercion an empty ``kind`` reaches
+        # :func:`list_nodes` as an exact match on ``''`` and wipes the
+        # grid. ``max_length`` rides on the inner ``str`` branch via
+        # ``StringConstraints`` -- a bare ``Query(max_length=...)`` on
+        # the nullable field would apply the guard to the ``None`` the
+        # BeforeValidator produces and raise ``TypeError``.
+        kind: Annotated[
+            Annotated[str, StringConstraints(max_length=64)] | None,
+            EMPTY_STR_TO_NONE,
+            Query(),
+        ] = None,
+        q: Annotated[
+            Annotated[str, StringConstraints(max_length=256)] | None,
+            EMPTY_STR_TO_NONE,
+            Query(),
+        ] = None,
         limit: int = Query(default=_LIMIT_DEFAULT, ge=1, le=_LIMIT_MAX),
         view: _ViewMode = Query(default=_ViewMode.TABLE),
         selected: uuid.UUID | None = Query(default=None),

--- a/backend/tests/test_ui_topology_table.py
+++ b/backend/tests/test_ui_topology_table.py
@@ -460,6 +460,64 @@ def test_table_filter_by_name_substring_narrows_results() -> None:
     assert "vm-staging-01" not in body
 
 
+def test_table_empty_kind_filter_returns_all_rows() -> None:
+    """An empty ``?kind=`` ("All kinds") returns the full grid, not zero rows.
+
+    The filter bar's default option is ``<option value="">``, so picking
+    "All kinds" submits ``?kind=``. Without the empty-string coercion the
+    exact-match filter applied ``WHERE kind = ''`` and wiped the grid.
+    """
+    _seed_tenant_row(_TENANT_A, "tenant-a")
+    _seed_node(tenant_id=_TENANT_A, kind="vm", name="vm-keep")
+    _seed_node(tenant_id=_TENANT_A, kind="target", name="target-keep")
+
+    session_id = _seed_session_sync(tenant_id=_TENANT_A)
+    with respx.mock(assert_all_called=False):
+        client = _authenticated_client(session_id)
+        response = client.get("/ui/topology?kind=", headers={"HX-Request": "true"})
+    assert response.status_code == 200, response.text
+    body = response.text
+    assert "vm-keep" in body
+    assert "target-keep" in body
+
+
+def test_table_empty_kind_with_name_search_still_narrows() -> None:
+    """``?q=prod&kind=`` applies the name filter only.
+
+    The filter ``<form>`` co-submits ``kind`` on every search keystroke
+    (``hx-include="closest form"``), so a name search always rides with
+    the (usually empty) ``kind``. The empty ``kind`` must be a no-op --
+    previously it zeroed every search result.
+    """
+    _seed_tenant_row(_TENANT_A, "tenant-a")
+    _seed_node(tenant_id=_TENANT_A, kind="vm", name="vm-prod-01")
+    _seed_node(tenant_id=_TENANT_A, kind="vm", name="vm-staging-01")
+
+    session_id = _seed_session_sync(tenant_id=_TENANT_A)
+    with respx.mock(assert_all_called=False):
+        client = _authenticated_client(session_id)
+        response = client.get(
+            "/ui/topology", params={"q": "prod", "kind": ""}, headers={"HX-Request": "true"}
+        )
+    assert response.status_code == 200, response.text
+    body = response.text
+    assert "vm-prod-01" in body
+    assert "vm-staging-01" not in body
+
+
+def test_table_bogus_kind_filter_still_returns_no_rows() -> None:
+    """Empty != invalid: a non-existent ``?kind=`` value still filters to zero rows."""
+    _seed_tenant_row(_TENANT_A, "tenant-a")
+    _seed_node(tenant_id=_TENANT_A, kind="vm", name="vm-keep")
+
+    session_id = _seed_session_sync(tenant_id=_TENANT_A)
+    with respx.mock(assert_all_called=False):
+        client = _authenticated_client(session_id)
+        response = client.get("/ui/topology?kind=not-a-kind", headers={"HX-Request": "true"})
+    assert response.status_code == 200, response.text
+    assert "vm-keep" not in response.text
+
+
 # ---------------------------------------------------------------------------
 # Cross-tenant isolation -- the table
 # ---------------------------------------------------------------------------

--- a/backend/tests/test_ui_topology_table.py
+++ b/backend/tests/test_ui_topology_table.py
@@ -518,6 +518,27 @@ def test_table_bogus_kind_filter_still_returns_no_rows() -> None:
     assert "vm-keep" not in response.text
 
 
+def test_table_overlong_kind_and_q_still_422() -> None:
+    """``max_length`` still fires after moving onto the inner ``str`` branch.
+
+    The empty-string coercion relocated the guard from ``Query(max_length=...)``
+    to ``StringConstraints`` on the nullable params' ``str`` branch; an
+    over-limit value must still be rejected at the HTTP boundary.
+    """
+    _seed_tenant_row(_TENANT_A, "tenant-a")
+    session_id = _seed_session_sync(tenant_id=_TENANT_A)
+    with respx.mock(assert_all_called=False):
+        client = _authenticated_client(session_id)
+        kind_response = client.get(
+            "/ui/topology", params={"kind": "x" * 65}, headers={"HX-Request": "true"}
+        )
+        q_response = client.get(
+            "/ui/topology", params={"q": "x" * 257}, headers={"HX-Request": "true"}
+        )
+    assert kind_response.status_code == 422, kind_response.text
+    assert q_response.status_code == 422, q_response.text
+
+
 # ---------------------------------------------------------------------------
 # Cross-tenant isolation -- the table
 # ---------------------------------------------------------------------------


### PR DESCRIPTION
## Summary

- The `/ui/topology` `kind` filter treated an empty string as an exact-match value (`WHERE kind = ''`), so the "All kinds" option (`<option value="">`) returned zero rows — and because the filter `<form>` co-submits `kind` on every search keystroke (`hx-include="closest form"`), name search always rode with `kind=` and returned nothing either.
- Coerce `"" -> None` on `kind` (and defensively on `q`) with the shared `EMPTY_STR_TO_NONE` `BeforeValidator` — the same pattern #2125 applied to the runbooks `target_kind` filter (which named this exact bug as the same footgun class). The coercion covers both the table branch and the graph branch, which share the params.
- `max_length` moves onto the inner `str` branch via `StringConstraints` so the guard is not applied to the `None` the validator produces (a bare `Query(max_length=...)` on the nullable field raises `TypeError`).
- Updated the `query_filters.py` docstring paragraph that claimed `str | None` params never need the coercion — stale since #2125; it now names the exact-match-SQL case and the `StringConstraints` gotcha.

## Test plan

- [x] `ruff check src/ tests/` — clean
- [x] `ruff format --check src/ tests/` — clean
- [x] `mypy src/` (strict) — clean, 563 files
- [x] `pytest tests/test_ui_topology_table.py` — 25 passed (22 existing + 3 new)
- [x] `pytest tests/test_ui_topology_graph.py tests/test_ui_topology_queries.py` — 47 passed (params are shared with the graph branch)
- [x] AC1: `GET /ui/topology?kind=` (HX-Request) returns all nodes — `test_table_empty_kind_filter_returns_all_rows`
- [x] AC2: `?q=prod&kind=` returns the substring matches, not 0 — `test_table_empty_kind_with_name_search_still_narrows`
- [x] AC3: bogus `?kind=not-a-kind` still returns 0 rows (empty ≠ invalid) — `test_table_bogus_kind_filter_still_returns_no_rows`
- [x] AC4: route test covers empty-string `kind` → unfiltered — same tests
- [x] Pattern verified live against the pinned stack (FastAPI 0.137.2, Pydantic 2.13.4): `"" -> None`, in-vocabulary value passes, overlong value still 422s

## Out of scope

- Sibling topology-console tasks: sort-toggle staleness (meho-internal#140), drawer placement (#141), graph `?selected` cross-link (#142).
- The template's `hx-include` co-submit behaviour needs no change once empty `kind` is a no-op.
- `from_`/`from_kind`/`to`/`to_kind` overlay params — graph-overlay territory, untouched.

<!-- auto-implement-issue: fresh, iteration 1 -->

Closes evoila-bosnia/meho-internal#139


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Topology list filters now handle empty inputs more consistently, so leaving filter fields blank no longer causes unintended filtering.
  * Search results continue to narrow correctly when a text search is used alongside an empty category filter.
  * Invalid filter values still return no matching rows as expected.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->