### PR TITLE
fix(connectors): reconcile /review op count + structured not-ingested 404 (#137, #125)

### DIFF
--- a/backend/src/meho_backplane/api/v1/connectors_ingest.py
+++ b/backend/src/meho_backplane/api/v1/connectors_ingest.py
@@ -174,9 +174,14 @@ from meho_backplane.api.v1._envelope import (
     EnvelopeVersion,
     wrap_v2_envelope,
 )
+from meho_backplane.api.v1.operations import connector_not_ingested_404
 from meho_backplane.auth.operator import Operator, TenantRole
 from meho_backplane.auth.rbac import require_role
-from meho_backplane.operations._lookup import connector_exists, parse_connector_id
+from meho_backplane.operations._lookup import (
+    connector_class_registered,
+    connector_exists,
+    parse_connector_id,
+)
 from meho_backplane.operations.ingest import (
     AmbiguousConnectorScopeError,
     CatalogListResponse,
@@ -235,6 +240,10 @@ from meho_backplane.operations.ingest.api_schemas import (
     GroupingResultModel,
     IngestionResultModel,
 )
+from meho_backplane.operations.ingest.list_connectors import (
+    next_step_for_registered_connector,
+)
+from meho_backplane.operations.meta_tools import ConnectorNotIngestedError
 
 __all__ = [
     "get_llm_client_factory",
@@ -1177,6 +1186,45 @@ async def catalog_endpoint(
     return CatalogListResponse(catalog=load_catalog().entries)
 
 
+def _not_ingested_404_if_registered(connector_id: str) -> HTTPException | None:
+    """Structured ``connector_not_ingested`` 404 iff *connector_id* is a registered class (#137).
+
+    Called when :meth:`ReviewService.get_review_payload` raises
+    :class:`ConnectorNotFoundError` (no visible rows). Distinguishes a
+    registered-but-not-ingested built-in — whose class *is* in the v2 registry
+    but has zero descriptor rows — from a genuinely-unknown / cross-tenant id,
+    mirroring ``/operations/groups``'s :func:`_require_dispatchable_connector`:
+
+    * class registered → the same structured 404 ``/operations/groups`` emits
+      (:func:`connector_not_ingested_404` with the shared
+      :func:`next_step_for_registered_connector` hint) — returned here.
+    * not registered (unknown, or a tenant-curated id whose class isn't in the
+      registry) → ``None``, so the caller keeps the deliberate plain-string 404
+      (the cross-tenant conflation is unchanged). Built-in class rows are global
+      (``tenant_id IS NULL``, visible to every tenant), so "registered class +
+      no visible rows" is genuinely not-ingested, never cross-tenant-hidden.
+
+    A malformed / unrecognised ``connector_id`` parses to a triple no class
+    is registered for → ``None`` → plain 404.
+    """
+    product, version, impl_id = parse_connector_id(connector_id)
+    if not connector_class_registered(product=product, version=version, impl_id=impl_id):
+        return None
+    next_step = next_step_for_registered_connector(
+        product=product, version=version, impl_id=impl_id
+    )
+    verb = next_step.verb if next_step is not None else "meho connector ingest …"
+    return connector_not_ingested_404(
+        ConnectorNotIngestedError(
+            f"connector {connector_id!r} is registered but not yet ingested "
+            f"(no operations to review). Run `{verb}` to populate its "
+            f"operations, then retry.",
+            connector_id=connector_id,
+            next_step=next_step.model_dump(mode="json") if next_step is not None else None,
+        )
+    )
+
+
 @router.get("/{connector_id}/review", response_model=ConnectorReviewPayload)
 async def get_review_endpoint(
     connector_id: str,
@@ -1219,6 +1267,12 @@ async def get_review_endpoint(
             detail=build_connector_scope_ambiguous_detail(exc),
         ) from exc
     except ConnectorNotFoundError as exc:
+        # #137: a registered-but-not-ingested built-in gets the structured
+        # ``connector_not_ingested`` 404 (mirroring /operations/groups); a
+        # genuinely-unknown / cross-tenant id keeps the plain-string 404.
+        structured = _not_ingested_404_if_registered(connector_id)
+        if structured is not None:
+            raise structured from exc
         raise HTTPException(
             status_code=http_status.HTTP_404_NOT_FOUND,
             detail=str(exc),

--- a/backend/src/meho_backplane/api/v1/operations.py
+++ b/backend/src/meho_backplane/api/v1/operations.py
@@ -97,8 +97,13 @@ _require_operator = Depends(require_role(TenantRole.OPERATOR))
 _require_admin = Depends(require_role(TenantRole.TENANT_ADMIN))
 
 
-def _connector_not_ingested_404(exc: ConnectorNotIngestedError) -> HTTPException:
+def connector_not_ingested_404(exc: ConnectorNotIngestedError) -> HTTPException:
     """Map :class:`ConnectorNotIngestedError` to a structured ``404``.
+
+    The **shared** mapper for the registered-but-not-ingested 404 shape:
+    ``GET /operations/groups`` (here) and ``GET /connectors/{id}/review``
+    (#137) both route through it, so the two surfaces emit byte-identical
+    ``{message, reason, connector_id, next_step}`` and cannot drift.
 
     Both the registered-but-not-ingested case and the genuinely-unknown
     case are ``404`` on REST (no resolvable connector to dispatch), but
@@ -174,7 +179,7 @@ async def get_groups(
             {"connector_id": connector_id, "limit": limit, "cursor": cursor},
         )
     except ConnectorNotIngestedError as exc:
-        raise _connector_not_ingested_404(exc) from exc
+        raise connector_not_ingested_404(exc) from exc
     except UnknownConnectorError as exc:
         raise HTTPException(status_code=404, detail=str(exc)) from exc
 
@@ -241,7 +246,7 @@ async def get_search(
             },
         )
     except ConnectorNotIngestedError as exc:
-        raise _connector_not_ingested_404(exc) from exc
+        raise connector_not_ingested_404(exc) from exc
     except UnknownConnectorError as exc:
         raise HTTPException(status_code=404, detail=str(exc)) from exc
 

--- a/backend/src/meho_backplane/operations/ingest/_internals.py
+++ b/backend/src/meho_backplane/operations/ingest/_internals.py
@@ -29,7 +29,7 @@ from typing import Any, Final
 from uuid import UUID
 
 import structlog
-from sqlalchemy import CursorResult, literal, select, update
+from sqlalchemy import CursorResult, func, literal, select, update
 from sqlalchemy.ext.asyncio import AsyncSession
 
 from meho_backplane.db.models import AuditLog, EndpointDescriptor, OperationGroup
@@ -292,6 +292,31 @@ async def load_ops_in_groups(
     stmt = stmt.order_by(EndpointDescriptor.op_id)
     result = await session.execute(stmt)
     return list(result.scalars().all())
+
+
+async def count_ops_in_scope(session: AsyncSession, scope: ConnectorScope) -> int:
+    """Count **every** :class:`EndpointDescriptor` row for *scope*, group or not.
+
+    The review payload's ``total_op_count`` sums only ops in *rendered* groups,
+    so ops with a null ``group_id`` (or in an unrendered group) are excluded
+    from it. This counts the same universe the ``GET /api/v1/connectors``
+    listing does (:func:`~meho_backplane.operations.ingest.list_connectors._operation_count_by_connector`
+    — ``count(EndpointDescriptor.id)`` by the connector triple, no group join),
+    so the review can report a ``ungrouped_op_count`` that reconciles
+    ``total_op_count + ungrouped_op_count`` to the listing's ``operation_count``
+    (#125). Same scope predicate as :func:`load_ops_in_groups` minus the
+    ``group_id`` filter, so the two read one consistent universe.
+    """
+    stmt = select(func.count(EndpointDescriptor.id)).where(
+        EndpointDescriptor.product == scope.product,
+        EndpointDescriptor.version == scope.version,
+        EndpointDescriptor.impl_id == scope.impl_id,
+    )
+    if scope.tenant_id is None:
+        stmt = stmt.where(EndpointDescriptor.tenant_id.is_(None))
+    else:
+        stmt = stmt.where(EndpointDescriptor.tenant_id == scope.tenant_id)
+    return int(await session.scalar(stmt) or 0)
 
 
 # ---------------------------------------------------------------------------

--- a/backend/src/meho_backplane/operations/ingest/_internals.py
+++ b/backend/src/meho_backplane/operations/ingest/_internals.py
@@ -300,9 +300,10 @@ async def count_ops_in_scope(session: AsyncSession, scope: ConnectorScope) -> in
     The review payload's ``total_op_count`` sums only ops in *rendered* groups,
     so ops with a null ``group_id`` (or in an unrendered group) are excluded
     from it. This counts the same universe the ``GET /api/v1/connectors``
-    listing does (:func:`~meho_backplane.operations.ingest.list_connectors._operation_count_by_connector`
-    — ``count(EndpointDescriptor.id)`` by the connector triple, no group join),
-    so the review can report a ``ungrouped_op_count`` that reconciles
+    listing does — the listing's
+    :func:`~meho_backplane.operations.ingest.list_connectors._operation_count_by_connector`
+    counts ``count(EndpointDescriptor.id)`` by the connector triple, no group
+    join — so the review can report a ``ungrouped_op_count`` that reconciles
     ``total_op_count + ungrouped_op_count`` to the listing's ``operation_count``
     (#125). Same scope predicate as :func:`load_ops_in_groups` minus the
     ``group_id`` filter, so the two read one consistent universe.

--- a/backend/src/meho_backplane/operations/ingest/payload.py
+++ b/backend/src/meho_backplane/operations/ingest/payload.py
@@ -120,5 +120,14 @@ class ConnectorReviewPayload(BaseModel):
     tenant_id: UUID | None
     groups: list[ConnectorReviewGroup]
     total_op_count: int
+    # ``total_op_count`` sums only ops in the *rendered* groups above. #125:
+    # ``ungrouped_op_count`` is every other descriptor row for this connector —
+    # ops with a null ``group_id`` or in an unrendered group — so
+    # ``total_op_count + ungrouped_op_count`` reconciles exactly to the
+    # ``operation_count`` the ``GET /api/v1/connectors`` listing reports for
+    # the same connector (both count the same descriptor universe). ``0`` when
+    # every op is grouped (the common case). Additive; defaults to ``0`` so
+    # existing construction call sites keep working.
+    ungrouped_op_count: int = 0
     kind: ConnectorAuthoringKind = "ingested-shim"
     dispatchable: bool = False

--- a/backend/src/meho_backplane/operations/ingest/service.py
+++ b/backend/src/meho_backplane/operations/ingest/service.py
@@ -94,6 +94,7 @@ from meho_backplane.operations.ingest._internals import (
     audit_profile_stamp,
     bulk_enable_read_ops,
     cascade_is_enabled,
+    count_ops_in_scope,
     enable_time_auto_shim_warnings,
     load_group,
     load_groups,
@@ -503,6 +504,13 @@ class ReviewService:
             for group in groups
         ]
         kind, dispatchable = _authoring_kind_for_payload(scope, rendered_groups)
+        grouped_op_count = sum(group.op_count for group in rendered_groups)
+        # #125: count the full descriptor universe (the same one the
+        # ``GET /api/v1/connectors`` listing counts) so ops not in a rendered
+        # group aren't silently dropped from the connector's reported total.
+        # ``ungrouped_op_count`` is the reconciling remainder:
+        # ``total_op_count + ungrouped_op_count == listing.operation_count``.
+        all_op_count = await count_ops_in_scope(session, scope)
         return ConnectorReviewPayload(
             connector_id=connector_id,
             product=scope.product,
@@ -510,7 +518,8 @@ class ReviewService:
             impl_id=scope.impl_id,
             tenant_id=scope.tenant_id,
             groups=rendered_groups,
-            total_op_count=sum(group.op_count for group in rendered_groups),
+            total_op_count=grouped_op_count,
+            ungrouped_op_count=max(all_op_count - grouped_op_count, 0),
             kind=kind,
             dispatchable=dispatchable,
         )

--- a/backend/tests/test_api_v1_connectors_ingest.py
+++ b/backend/tests/test_api_v1_connectors_ingest.py
@@ -4154,3 +4154,191 @@ paths:
 
 # Silence unused-import lints on test seams reserved for sibling tasks.
 _ = (AsyncMock, patch, GroupingResult, IngestionResult)
+
+
+# ---------------------------------------------------------------------------
+# #137 — registered-but-not-ingested → structured connector_not_ingested 404
+# ---------------------------------------------------------------------------
+
+
+class _GhostReviewConnector(Connector):
+    """v2-registered class with no DB rows — the registered-but-not-ingested case."""
+
+    product = "ghostreview"
+    version = "9.0"
+    impl_id = "ghostreview-rest"
+
+    async def fingerprint(self, target, operator=None):  # type: ignore[no-untyped-def]
+        raise NotImplementedError
+
+    async def probe(self, target):  # type: ignore[no-untyped-def]
+        raise NotImplementedError
+
+    async def execute(self, target, op_id, params):  # type: ignore[no-untyped-def]
+        raise NotImplementedError
+
+
+def test_get_review_registered_not_ingested_returns_typed_404(client: TestClient) -> None:
+    """#137 AC1: a registered-but-0-ops connector → structured connector_not_ingested 404."""
+    from meho_backplane.connectors.registry import register_connector_v2
+
+    register_connector_v2(
+        product="ghostreview",
+        version="9.0",
+        impl_id="ghostreview-rest",
+        cls=_GhostReviewConnector,
+    )
+    key, token = _operator_token()
+    with respx.mock as mock_router:
+        _mock_discovery_and_jwks(mock_router, _public_jwks(key))
+        response = client.get(
+            "/api/v1/connectors/ghostreview-rest-9.0/review",
+            headers=_authed(token),
+        )
+    assert response.status_code == 404
+    detail = response.json()["detail"]
+    assert isinstance(detail, dict), detail
+    assert detail["reason"] == "connector_not_ingested"
+    assert detail["connector_id"] == "ghostreview-rest-9.0"
+    assert detail["next_step"] is not None
+    assert "ingest" in detail["next_step"]["verb"]
+
+
+def test_get_review_unknown_connector_keeps_plain_404(client: TestClient) -> None:
+    """#137 AC3: a genuinely-unknown connector_id keeps the plain-string 404."""
+    key, token = _operator_token()
+    with respx.mock as mock_router:
+        _mock_discovery_and_jwks(mock_router, _public_jwks(key))
+        response = client.get(
+            "/api/v1/connectors/nope-not-a-connector-9.9/review",
+            headers=_authed(token),
+        )
+    assert response.status_code == 404
+    # Unknown (not class-registered) → the deliberate plain-string conflation.
+    assert isinstance(response.json()["detail"], str)
+
+
+def test_review_and_groups_same_not_ingested_shape() -> None:
+    """#137 AC2: /review and /operations/groups emit the same not_ingested reason + next_step."""
+    from fastapi import FastAPI
+
+    from meho_backplane.api.v1.operations import router as operations_router
+    from meho_backplane.connectors.registry import register_connector_v2
+
+    register_connector_v2(
+        product="ghostreview",
+        version="9.0",
+        impl_id="ghostreview-rest",
+        cls=_GhostReviewConnector,
+    )
+    app = FastAPI()
+    app.add_middleware(AuditMiddleware)
+    app.add_middleware(RequestContextMiddleware)
+    app.include_router(connectors_ingest_router)
+    app.include_router(operations_router)
+    both = TestClient(app)
+
+    key, token = _operator_token()
+    with respx.mock as mock_router:
+        _mock_discovery_and_jwks(mock_router, _public_jwks(key))
+        review = both.get(
+            "/api/v1/connectors/ghostreview-rest-9.0/review",
+            headers=_authed(token),
+        )
+        groups = both.get(
+            "/api/v1/operations/groups?connector_id=ghostreview-rest-9.0",
+            headers=_authed(token),
+        )
+    assert review.status_code == 404
+    assert groups.status_code == 404
+    r_detail = review.json()["detail"]
+    g_detail = groups.json()["detail"]
+    # Byte-identical reason + next_step (shared mapper + shared next_step builder).
+    assert r_detail["reason"] == g_detail["reason"] == "connector_not_ingested"
+    assert r_detail["next_step"] == g_detail["next_step"]
+    assert r_detail["connector_id"] == g_detail["connector_id"] == "ghostreview-rest-9.0"
+
+
+# ---------------------------------------------------------------------------
+# #125 — review total_op_count reconciles with the listing operation_count
+# ---------------------------------------------------------------------------
+
+
+async def _seed_ungrouped_op(
+    *,
+    tenant_id: UUID | None,
+    product: str = "vmware",
+    version: str = "9.0",
+    impl_id: str = "vmware-rest",
+    op_id: str = "GET:/api/v1/ungrouped/0",
+) -> None:
+    """Seed one EndpointDescriptor with a NULL group_id (excluded from review groups)."""
+    sessionmaker = get_sessionmaker()
+    async with sessionmaker() as session:
+        session.add(
+            EndpointDescriptor(
+                tenant_id=tenant_id,
+                product=product,
+                version=version,
+                impl_id=impl_id,
+                op_id=op_id,
+                source_kind="ingested",
+                method="GET",
+                path="/api/v1/ungrouped/0",
+                group_id=None,
+                summary="An ungrouped op.",
+                is_enabled=False,
+            ),
+        )
+        await session.commit()
+
+
+@pytest.mark.asyncio
+async def test_review_total_reconciles_with_ungrouped_ops(client: TestClient) -> None:
+    """#125 AC1: total_op_count + ungrouped_op_count == listing operation_count.
+
+    Seed 2 groups x 3 ops (grouped) + 1 ungrouped descriptor. The review's
+    grouped total is 6; the ungrouped remainder is 1; the listing counts all 7.
+    """
+    tenant_a = uuid.uuid4()
+    await _seed_connector(tenant_id=tenant_a, group_count=2, ops_per_group=3)
+    await _seed_ungrouped_op(tenant_id=tenant_a)
+
+    key, token = _operator_token(tenant_id=tenant_a)
+    with respx.mock as mock_router:
+        _mock_discovery_and_jwks(mock_router, _public_jwks(key))
+        review = client.get(
+            "/api/v1/connectors/vmware-rest-9.0/review",
+            headers=_authed(token),
+        )
+        listing = client.get("/api/v1/connectors", headers=_authed(token))
+    assert review.status_code == 200
+    r = review.json()
+    assert r["total_op_count"] == 6
+    assert r["ungrouped_op_count"] == 1
+
+    listed = {c["connector_id"]: c for c in listing.json()["connectors"]}
+    op_count = listed["vmware-rest-9.0"]["operation_count"]
+    assert op_count == 7
+    # The reconciliation contract: review total + ungrouped == listing total.
+    assert r["total_op_count"] + r["ungrouped_op_count"] == op_count
+
+
+@pytest.mark.asyncio
+async def test_review_all_grouped_counts_match_listing(client: TestClient) -> None:
+    """#125 AC2: with every op grouped, review total == listing total, ungrouped == 0."""
+    tenant_a = uuid.uuid4()
+    await _seed_connector(tenant_id=tenant_a, group_count=2, ops_per_group=3)
+
+    key, token = _operator_token(tenant_id=tenant_a)
+    with respx.mock as mock_router:
+        _mock_discovery_and_jwks(mock_router, _public_jwks(key))
+        review = client.get(
+            "/api/v1/connectors/vmware-rest-9.0/review",
+            headers=_authed(token),
+        )
+        listing = client.get("/api/v1/connectors", headers=_authed(token))
+    r = review.json()
+    assert r["ungrouped_op_count"] == 0
+    listed = {c["connector_id"]: c for c in listing.json()["connectors"]}
+    assert r["total_op_count"] == listed["vmware-rest-9.0"]["operation_count"] == 6

--- a/cli/api/openapi.json
+++ b/cli/api/openapi.json
@@ -20988,6 +20988,11 @@
             "type": "integer",
             "title": "Total Op Count"
           },
+          "ungrouped_op_count": {
+            "type": "integer",
+            "title": "Ungrouped Op Count",
+            "default": 0
+          },
           "kind": {
             "type": "string",
             "enum": [

--- a/cli/internal/api/client.gen.go
+++ b/cli/internal/api/client.gen.go
@@ -2539,15 +2539,16 @@ type ConnectorReviewOp struct {
 // (the Goal flags secret-handling sensitivity). See
 // :data:`~meho_backplane.operations.ingest.api_schemas.ConnectorAuthoringKind`.
 type ConnectorReviewPayload struct {
-	ConnectorId  string                      `json:"connector_id"`
-	Dispatchable *bool                       `json:"dispatchable,omitempty"`
-	Groups       []ConnectorReviewGroup      `json:"groups"`
-	ImplId       string                      `json:"impl_id"`
-	Kind         *ConnectorReviewPayloadKind `json:"kind,omitempty"`
-	Product      string                      `json:"product"`
-	TenantId     *openapi_types.UUID         `json:"tenant_id"`
-	TotalOpCount int                         `json:"total_op_count"`
-	Version      string                      `json:"version"`
+	ConnectorId      string                      `json:"connector_id"`
+	Dispatchable     *bool                       `json:"dispatchable,omitempty"`
+	Groups           []ConnectorReviewGroup      `json:"groups"`
+	ImplId           string                      `json:"impl_id"`
+	Kind             *ConnectorReviewPayloadKind `json:"kind,omitempty"`
+	Product          string                      `json:"product"`
+	TenantId         *openapi_types.UUID         `json:"tenant_id"`
+	TotalOpCount     int                         `json:"total_op_count"`
+	UngroupedOpCount *int                        `json:"ungrouped_op_count,omitempty"`
+	Version          string                      `json:"version"`
 }
 
 // ConnectorReviewPayloadKind defines model for ConnectorReviewPayload.Kind.


### PR DESCRIPTION
## Summary

Two `/connectors/{id}/review`-vs-listing consistency fixes (Initiative #124),
**batched** — both touch `ReviewService.get_review_payload` + the review route.

**#125 — op-count divergence.** Review's `total_op_count` summed only ops in
*rendered groups*, while `GET /connectors` counts every `EndpointDescriptor`
row (no group join) — so they disagreed by the ungrouped-op count (a consumer
saw 136 vs 135). Added `count_ops_in_scope` (mirrors the listing's count
universe) + an **additive** `ungrouped_op_count` on `ConnectorReviewPayload`:
`total_op_count` stays the grouped sum, and `total_op_count + ungrouped_op_count`
now reconciles exactly to the listing's `operation_count`. `total_op_count`
semantics unchanged → existing consumers/tests unaffected.

**#137 — bare 404 for a registered-but-not-ingested connector.** `/review`
returned a plain-string "not found" for a registered built-in with 0 ingested
ops (e.g. `vrli-rest-9.0`), conflating "exists, not ingested" with "unknown" —
while `/operations/groups` already returns a structured `connector_not_ingested`
404 (#1482). Mirror it: the route checks `connector_class_registered` (a
built-in class with no visible rows is genuinely not-ingested — built-in rows
are global, never cross-tenant-hidden) and raises the same
`ConnectorNotIngestedError`, mapped by the **shared** `connector_not_ingested_404`
(promoted from private `_connector_not_ingested_404` so both routes use one
mapper — no drift). Tenant-curated / unknown / cross-tenant ids aren't
class-registered → keep the deliberate plain-string 404.

## Test plan

- [x] `ruff` / `ruff format --check` / `mypy` — clean; `code-quality.py --diff` — pass (exit 0)
- [x] **#137 AC1** `test_get_review_registered_not_ingested_returns_typed_404` — structured detail (`reason`, `connector_id`, `next_step` with "ingest")
- [x] **#137 AC2** `test_review_and_groups_same_not_ingested_shape` — mounts **both** routers; asserts identical `reason` + `next_step`
- [x] **#137 AC3** `test_get_review_unknown_connector_keeps_plain_404` — unknown id → plain-string 404 (`isinstance(detail, str)`)
- [x] **#125 AC1** `test_review_total_reconciles_with_ungrouped_ops` — 6 grouped + 1 ungrouped → `total=6`, `ungrouped=1`, `6+1 == listing.operation_count (7)`
- [x] **#125 AC2** `test_review_all_grouped_counts_match_listing` — all grouped → `ungrouped=0`, `total == listing == 6`
- [x] AC5 (both): `-k "review and (connector or ingest or not_ingested)"` — 149 passed; `-k "review and (connector or op_count or count)"` — 114 passed; broader connector/ingest/MCP/UI suites — 225 passed
- [x] CLI OpenAPI snapshot regenerated (new `ungrouped_op_count`) + Go client compiles

## Out of scope (per both issues)

- `connector_scope_ambiguous` 409 disambiguation — unchanged.
- Genuinely-unknown / cross-tenant 404 conflation — deliberate; only the registered-but-empty case is reshaped.
- `enabled_operation_count` rollup — already agrees.
- Whether a global registered connector should be reviewable / grouping semantics — only the error *shape* + *total* are touched.

Implements evoila-bosnia/meho-internal#137 and #125. Cross-repo `Refs`; close both on merge (most of Initiative #124).


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Connector review responses now include `ungrouped_op_count` (default `0`) to clearly account for operations not shown in grouped results.
  * Review and related operations endpoints now return a more specific structured 404 for registered-but-not-ingested connectors, including a next-step hint; unknown connectors keep the existing plain 404.

* **Bug Fixes**
  * Review total operation counts now reconcile with the full in-scope dataset, matching the listing count even when some operations are ungrouped.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->