### PR TITLE
fix(ui): render topology node drawer beside the table, not off-screen (#141)

### DIFF
--- a/backend/src/meho_backplane/ui/templates/topology/_drawer.html
+++ b/backend/src/meho_backplane/ui/templates/topology/_drawer.html
@@ -58,7 +58,7 @@
 {%- endmacro %}
 <aside
   id="node-drawer"
-  class="card bg-base-100 border-base-300 border shadow-sm"
+  class="card bg-base-100 border-base-300 border shadow-sm self-start"
   aria-label="Node detail drawer"
 >
   <div class="card-body space-y-3">

--- a/backend/src/meho_backplane/ui/templates/topology/_drawer_not_found.html
+++ b/backend/src/meho_backplane/ui/templates/topology/_drawer_not_found.html
@@ -14,7 +14,7 @@
 -#}
 <aside
   id="node-drawer"
-  class="card bg-base-100 border-base-300 border shadow-sm"
+  class="card bg-base-100 border-base-300 border shadow-sm self-start"
   aria-live="polite"
   aria-label="Node detail drawer"
 >

--- a/backend/src/meho_backplane/ui/templates/topology/graph.html
+++ b/backend/src/meho_backplane/ui/templates/topology/graph.html
@@ -222,27 +222,49 @@
     </label>
   </div>
 
+  {# ---------- Graph + drawer grid ----------
+     Same layout fix as the table surface (issue #141): the ``#cy``
+     Cytoscape mount and the ``#node-drawer`` slot share one grid so
+     the drawer lands *beside* the 600px graph on ``lg:`` viewports
+     instead of stacking below it (off-screen, hiding the
+     Annotate-edge affordance). ``lg:grid-cols-[1fr_28rem]`` gives the
+     graph the flexible column and the drawer a fixed 28rem sidebar;
+     narrower viewports stack them.
+
+     ``hx-on::after-swap`` scrolls the drawer into view when the
+     node-tap swap settles it in on a stacked (narrow) layout; it is a
+     harmless no-op on ``lg:`` where the drawer already sits beside the
+     graph. The node-tap handler in ``topology-graph.js`` issues the
+     ``htmx.ajax`` GET into ``#node-drawer`` (inside this wrapper), so
+     the ``htmx:afterSwap`` event bubbles up to here. -#}
+  <div
+    class="grid grid-cols-1 gap-4 lg:grid-cols-[1fr_28rem]"
+    hx-on::after-swap="if (event.detail.target && event.detail.target.id === 'node-drawer') event.detail.target.scrollIntoView({ block: 'nearest', behavior: 'smooth' })"
+  >
   {# ---------- Cytoscape mount ----------
-     Fixed-ish height so the layout has room. The ``aria-label`` is
-     the screen-reader hint; Cytoscape itself is canvas-rendered so
-     the graph is not directly keyboard-accessible (operators use the
-     table view for that). -#}
+     Fixed-ish height so the layout has room. ``min-w-0`` lets the
+     canvas shrink to its grid column instead of forcing the column
+     wide. The ``aria-label`` is the screen-reader hint; Cytoscape
+     itself is canvas-rendered so the graph is not directly
+     keyboard-accessible (operators use the table view for that). -#}
   <div
     id="cy"
-    class="rounded-box border border-base-300 bg-base-100"
+    class="rounded-box border border-base-300 bg-base-100 min-w-0"
     style="height: 600px; min-height: 480px;"
     role="img"
     aria-label="Topology graph -- click a node to open its detail drawer"
   ></div>
 
   {# ---------- Drawer slot ----------
-     Same id as the table view so the drawer fragment URL contract
-     stays identical across surfaces; the node-tap handler in
-     topology-graph.js issues ``htmx.ajax`` GET
-     ``/ui/topology/node/<id>`` into this slot. -#}
+     Second cell of the grid opened above. Same id as the table view so
+     the drawer fragment URL contract stays identical across surfaces;
+     the node-tap handler in topology-graph.js issues ``htmx.ajax`` GET
+     ``/ui/topology/node/<id>`` into this slot. ``self-start`` keeps a
+     short detail card at the top of its column rather than stretched to
+     the full graph height. -#}
   <aside
     id="node-drawer"
-    class="card bg-base-100 border-base-300 border shadow-sm"
+    class="card bg-base-100 border-base-300 border shadow-sm self-start"
     aria-live="polite"
     aria-label="Node detail drawer"
   >
@@ -250,6 +272,7 @@
       Click a node in the graph to inspect it.
     </div>
   </aside>
+  </div>
 
   {# ---------- Data island wrapper (G10.5-T3 #882) ----------
      The wrapper carries the HTMX polling trigger

--- a/backend/src/meho_backplane/ui/templates/topology/table.html
+++ b/backend/src/meho_backplane/ui/templates/topology/table.html
@@ -163,8 +163,28 @@
     </div>
   </form>
 
+  {# ---------- Table + drawer grid ----------
+     The table and the ``#node-drawer`` slot share one grid so the
+     drawer lands *beside* the table on ``lg:`` viewports instead of
+     stacking ~1300px below it (issue #141: the "View" button swapped
+     the drawer off-screen, hiding the Annotate-edge affordance with
+     it). ``lg:grid-cols-[1fr_28rem]`` gives the table the flexible
+     column and the drawer a fixed 28rem sidebar; on narrower
+     viewports the single-column grid stacks table over drawer.
+
+     ``hx-on::after-swap`` handles the narrow-viewport case: when a
+     row's "View" swap settles the drawer fragment in (target
+     ``#node-drawer``, which lives inside this wrapper, so the
+     ``htmx:afterSwap`` event bubbles up to here), scroll it into view.
+     On ``lg:`` the drawer is already beside the table, so the scroll
+     is a harmless no-op; on a stacked layout it brings the freshly
+     rendered detail into the viewport. -#}
+  <div
+    class="grid grid-cols-1 gap-4 lg:grid-cols-[1fr_28rem]"
+    hx-on::after-swap="if (event.detail.target && event.detail.target.id === 'node-drawer') event.detail.target.scrollIntoView({ block: 'nearest', behavior: 'smooth' })"
+  >
   {# ---------- Table ---------- #}
-  <div class="overflow-x-auto rounded-box border border-base-300 bg-base-100">
+  <div class="overflow-x-auto rounded-box border border-base-300 bg-base-100 min-w-0">
     <table class="table table-sm">
       <thead>
         <tr>
@@ -227,14 +247,17 @@
   </div>
 
   {# ---------- Drawer slot ----------
-     T1 lands the slot; row "view" buttons swap the drawer fragment
-     into it. The drawer renders to the right of the table on
-     ``lg:`` viewports via Tailwind grid + col-span; on smaller
-     viewports it stacks below.
+     Second cell of the grid opened above: on ``lg:`` viewports it
+     renders to the right of the table; on smaller viewports it stacks
+     below (single-column grid). ``self-start`` keeps the drawer from
+     stretching to the full table height so a short detail card sits at
+     the top of its column. Row "view" buttons swap the drawer fragment
+     into this slot (``hx-target="#node-drawer"``, ``hx-swap="outerHTML"``);
+     the fragment carries the same ``id`` so the swap is stable.
   -#}
   <aside
     id="node-drawer"
-    class="card bg-base-100 border-base-300 border shadow-sm"
+    class="card bg-base-100 border-base-300 border shadow-sm self-start"
     aria-live="polite"
     aria-label="Node detail drawer"
   >
@@ -242,6 +265,7 @@
       Select a row's <em>view</em> button to inspect a node.
     </div>
   </aside>
+  </div>
 </section>
 {% endblock %}
 

--- a/backend/tests/test_ui_topology_graph.py
+++ b/backend/tests/test_ui_topology_graph.py
@@ -294,6 +294,14 @@ def test_graph_full_page_renders_cytoscape_mount() -> None:
     assert "<title>Topology" in body
     # Cytoscape mount div.
     assert 'id="cy"' in body
+    # Issue #141: the graph mount + node drawer share a grid so the
+    # drawer lands beside the 600px graph on ``lg:`` viewports instead
+    # of stacking off-screen below it (same fix as the table surface).
+    assert "lg:grid-cols-[1fr_28rem]" in body
+    assert 'id="node-drawer"' in body
+    # Narrow-viewport scroll-into-view handler on swap.
+    assert "hx-on::after-swap" in body
+    assert "scrollIntoView" in body
     # The vendored layout-plugin chain is wired in load-bearing order
     # (see VENDOR.md "Cytoscape layout plugins"); each src appears
     # exactly once.

--- a/backend/tests/test_ui_topology_graph.py
+++ b/backend/tests/test_ui_topology_graph.py
@@ -750,7 +750,15 @@ def test_drawer_route_still_serves_node_detail_for_graph_tap() -> None:
         client = _authenticated_client(session_id)
         response = client.get(f"/ui/topology/node/{node_id}")
     assert response.status_code == 200, response.text
-    assert "vm-drawer-test" in response.text
+    body = response.text
+    assert "vm-drawer-test" in body
+    # Issue #141: on the graph surface the swapped-in drawer fragment must
+    # carry ``self-start`` on its root ``<aside id="node-drawer">`` so it
+    # sits as a short card at the top of its grid column instead of
+    # stretching to the full 600px graph height after the ``outerHTML``
+    # swap replaces the placeholder.
+    assert 'id="node-drawer"' in body
+    assert "self-start" in body
 
 
 # ---------------------------------------------------------------------------

--- a/backend/tests/test_ui_topology_table.py
+++ b/backend/tests/test_ui_topology_table.py
@@ -587,6 +587,14 @@ def test_drawer_renders_node_properties_and_edges() -> None:
         response = client.get(f"/ui/topology/node/{child_id}")
     assert response.status_code == 200, response.text
     body = response.text
+    # Issue #141: the swapped-in fragment root -- not just the
+    # placeholder in table.html -- must carry ``self-start``. The
+    # ``hx-swap="outerHTML"`` swap replaces the placeholder with this
+    # fragment's ``<aside id="node-drawer">``, so if ``self-start`` lived
+    # only on the placeholder the post-swap drawer would revert to
+    # stretching the full grid-column height. Pin it on the fragment.
+    assert 'id="node-drawer"' in body
+    assert "self-start" in body
     # Node identity surfaces.
     assert "vm-on-host-1" in body
     assert str(child_id) in body
@@ -657,7 +665,14 @@ def test_drawer_returns_404_for_unknown_node() -> None:
         client = _authenticated_client(session_id)
         response = client.get(f"/ui/topology/node/{uuid.uuid4()}")
     assert response.status_code == 404, response.text
-    assert "Node not found" in response.text
+    body = response.text
+    assert "Node not found" in body
+    # Issue #141: the not-found fragment swaps into ``#node-drawer`` via
+    # the same ``outerHTML`` swap as the happy path, so its root must also
+    # carry ``self-start`` to render as a top-aligned card rather than a
+    # full-column-height error panel.
+    assert 'id="node-drawer"' in body
+    assert "self-start" in body
 
 
 def test_drawer_isolates_other_tenants_node_id() -> None:

--- a/backend/tests/test_ui_topology_table.py
+++ b/backend/tests/test_ui_topology_table.py
@@ -341,6 +341,15 @@ def test_table_full_page_renders_seeded_nodes() -> None:
     assert 'hx-target="#node-drawer"' in body
     # The drawer placeholder slot is in place for the swap.
     assert 'id="node-drawer"' in body
+    # Issue #141: the table + drawer share a grid so the drawer lands
+    # beside the table on ``lg:`` viewports instead of stacking
+    # off-screen below it. The comment at table.html once promised this
+    # grid but the markup was absent; assert it is now present.
+    assert "lg:grid-cols-[1fr_28rem]" in body
+    # And the narrow-viewport scroll-into-view handler is wired so a
+    # stacked drawer is brought into view on swap.
+    assert "hx-on::after-swap" in body
+    assert "scrollIntoView" in body
     # CSRF cookie set by the route.
     assert CSRF_COOKIE_NAME in response.cookies
 


### PR DESCRIPTION
## Summary

- The topology node-detail drawer (`#node-drawer`) was a direct child of the page's vertical stack, rendered immediately after the full node table. On a many-row table the "View" hx-swap landed the drawer ~1300px below the fold, so the button read as "nothing happened" and the **Annotate edge** affordance (which lives inside the drawer) was hidden with it. The `table.html` comment even promised a Tailwind grid layout that was never present (issue #141).
- Wrap the table and the `#node-drawer` slot in a shared `grid grid-cols-1 gap-4 lg:grid-cols-[1fr_28rem]` so the drawer lands in a fixed sidebar column **beside** the table on `lg:` viewports and stacks below on narrower ones (`min-w-0` on the table column so it doesn't blow out the grid; `self-start` on the drawer).
- Add an `hx-on::after-swap` handler on the grid wrapper that `scrollIntoView`s the drawer when a swap settles it in — a no-op on `lg:` (already visible), and the fix for the stacked/narrow case. This uses the same inline-`hx-on::` idiom already used across the console (memory/connectors/runbooks).
- Apply the identical grid + handler to the **graph view** (`#cy` + drawer) so the placement is consistent across both surfaces.

## Test plan

- [x] `ruff check` / `ruff format --check` on touched test files — clean
- [x] `pytest tests/test_ui_topology_table.py tests/test_ui_topology_graph.py tests/test_ui_topology_annotate.py` — 64 passed
- [x] AC1 (drawer beside table on `lg:` without scrolling): asserted `lg:grid-cols-[1fr_28rem]` present in the table full-page render
- [x] AC2 (narrow viewport scroll-into-view on open): asserted `hx-on::after-swap` + `scrollIntoView` wired
- [x] AC3 (Annotate button opens the modal in the now-visible drawer): drawer is on-screen; `test_topology_ui_annotate_modal_open_renders_for_admin_with_csrf` + `..._controls_shown_for_tenant_admin_in_drawer` confirm the button + `#topology-edge-modal` population (all green)
- [x] AC4 (same placement in the graph view): asserted grid + handler present in the graph full-page render
- [x] `code-quality.py --diff` — exit 0

## Out of scope

- The annotate write itself (works server-side; this Task only ensures it is reachable).
- Graph cross-link selection (Task #142).
- Templates are Jinja/HTML + Tailwind classes only; no FastAPI routes/schemas touched, so no CLI OpenAPI snapshot regen needed. Tailwind 4 auto-scans `templates/**` at image build, so the new arbitrary grid utility compiles into `dist/tailwind.css` (no committed CSS to update).

<!-- auto-implement-issue: fresh, iteration 1 -->

Closes #141


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Updated the Topology pages to use a responsive two-column layout on larger screens, with the details drawer shown beside the graph or table.
  * Improved mobile and narrow-screen behavior so the details drawer automatically scrolls into view after an update.

* **Bug Fixes**
  * Refined drawer alignment and spacing so the layout stays compact and readable across screen sizes.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->