### PR TITLE
feat(connectors): add holodeck.disk.usage read op for pre-eviction disk diagnosis (#2153)

### DIFF
--- a/backend/src/meho_backplane/connectors/holodeck/connector.py
+++ b/backend/src/meho_backplane/connectors/holodeck/connector.py
@@ -174,6 +174,17 @@ _WHEN_TO_USE_BY_GROUP: dict[str, str] = {
         "drill-in. Transport: plain SSH for vtysh + dhcpd.leases; "
         "pwsh-over-SSH for the DNS zone summary."
     ),
+    "diagnostics": (
+        "Use for the HoloRouter's disk-pressure snapshot before a "
+        "root-fs fill evicts pods: ``holodeck.disk.usage`` returns "
+        "root-fs total/used/available bytes + percent-used plus the "
+        "byte usage of the two known growth directories "
+        "(``/var/backups``, ``/holodeck-runtime``), each with its own "
+        "``ok`` flag. Takes no path argument -- the measured dirs are "
+        "fixed in code, never operator input. Poll it for early "
+        "warning on the 74 GB root fs (VCF-9.x backup fill). "
+        "Transport: plain SSH (``df`` / ``du``)."
+    ),
 }
 
 
@@ -574,6 +585,22 @@ class HolodeckConnector(SshConnector):
         )
 
         return await _holodeck_networking_show(self, target, params)
+
+    async def disk_usage(
+        self,
+        target: Target,
+        params: dict[str, Any],
+    ) -> dict[str, Any]:
+        """Bound-method shim for ``holodeck.disk.usage`` (G3.18-T1 #2153).
+
+        Delegates to
+        :func:`~meho_backplane.connectors.holodeck.ops_read.holodeck_disk_usage`.
+        """
+        from meho_backplane.connectors.holodeck.ops_read import (
+            holodeck_disk_usage as _holodeck_disk_usage,
+        )
+
+        return await _holodeck_disk_usage(self, target, params)
 
     @classmethod
     async def register_operations(cls) -> None:

--- a/backend/src/meho_backplane/connectors/holodeck/ops.py
+++ b/backend/src/meho_backplane/connectors/holodeck/ops.py
@@ -162,8 +162,9 @@ def _holodeck_ops() -> tuple[HolodeckOp, ...]:
 #: (``holodeck.config.show``, ``holodeck.pod.list``,
 #: ``holodeck.pod.info``, ``holodeck.service.list``,
 #: ``holodeck.k8s.exec``, ``holodeck.logs.tail``,
-#: ``holodeck.networking.show``) -- 8 ops total. The registration
+#: ``holodeck.networking.show``); G3.18-T1 (#2153) appends
+#: ``holodeck.disk.usage`` -- 9 ops total. The registration
 #: walk in :meth:`HolodeckConnector.register_operations` does not
-#: need to change between T1 and T2; only :func:`_holodeck_ops`
+#: need to change as ops are added; only :func:`_holodeck_ops`
 #: composes the merged tuple.
 HOLODECK_OPS: tuple[HolodeckOp, ...] = _holodeck_ops()

--- a/backend/src/meho_backplane/connectors/holodeck/ops_read.py
+++ b/backend/src/meho_backplane/connectors/holodeck/ops_read.py
@@ -134,19 +134,38 @@ if TYPE_CHECKING:
     from meho_backplane.connectors.holodeck.connector import HolodeckConnector
 
 __all__ = [
+    "GROWTH_DIRS",
     "READ_OPS",
     "KubectlSafetyError",
     "holodeck_config_show",
+    "holodeck_disk_usage",
     "holodeck_k8s_exec",
     "holodeck_logs_tail",
     "holodeck_networking_show",
     "holodeck_pod_info",
     "holodeck_pod_list",
     "holodeck_service_list",
+    "parse_disk_usage_output",
     "parse_kubectl_command",
     "parse_logs_tail_output",
     "parse_networking_payload",
 ]
+
+
+# ---------------------------------------------------------------------------
+# Disk-usage growth-dir constant (G3.18-T1 #2153)
+# ---------------------------------------------------------------------------
+
+#: Fixed set of HoloRouter directories the ``holodeck.disk.usage`` op
+#: measures with ``du`` alongside the root-fs ``df``. VCF-9.x fills the
+#: 74 GB root fs via backup accumulation under ``/var/backups`` plus
+#: pod-runtime growth under ``/holodeck-runtime`` (Initiative #2145);
+#: those two dirs crack ~all pre-eviction incidents. The set is a
+#: **code constant on purpose** -- the op takes no path parameter, so it
+#: can never be coerced into an arbitrary ``du`` over an operator-chosen
+#: (or attacker-chosen) path. Adding a growth dir is a code change with a
+#: review, not runtime input.
+GROWTH_DIRS: tuple[str, ...] = ("/var/backups", "/holodeck-runtime")
 
 
 # ---------------------------------------------------------------------------
@@ -535,6 +554,127 @@ def parse_networking_payload(
     }
 
 
+def _parse_df_root(df_root_text: str) -> dict[str, Any]:
+    """Parse ``df -B1 /`` byte-count output into the root-fs sub-section.
+
+    ``df -B1`` reports every column in bytes (``-B1`` = 1-byte block
+    size) so the envelope never has to reverse a human-readable suffix.
+    The expected two-line shape is::
+
+        Filesystem  1B-blocks  Used  Available Use% Mounted on
+        /dev/md2    467909804032  58598952960  385467109376  14%  /
+
+    The parser skips the header, reads the last non-empty data row
+    (a device path may soft-wrap onto its own line on very long
+    device names, in which case the counts land on the following
+    row -- taking the last row with >=4 trailing numeric-ish fields
+    is robust to that), and pulls total / used / available from the
+    1B-block columns. ``percent_used`` is computed from the byte
+    counts rather than trusting ``df``'s rounded ``Use%`` column, so
+    a scheduler polling this value sees a stable float.
+
+    Returns ``{"ok": False}`` (with null counts) when the output is
+    empty or unparseable -- mirroring the ``networking.show`` per
+    sub-section ``ok`` convention so one failed sub-command never
+    blanks the others.
+    """
+    failed: dict[str, Any] = {
+        "total_bytes": None,
+        "used_bytes": None,
+        "avail_bytes": None,
+        "percent_used": None,
+        "ok": False,
+    }
+    if not df_root_text.strip():
+        return failed
+    data_row: list[str] | None = None
+    for line in df_root_text.splitlines():
+        fields = line.split()
+        if not fields or fields[0].lower() == "filesystem":
+            continue
+        # A valid data row carries at least: device, total, used,
+        # avail, use%, mount. Require the three byte columns to be
+        # digit-only so a wrapped device-name-only line is skipped.
+        if len(fields) >= 4 and fields[1].isdigit() and fields[2].isdigit() and fields[3].isdigit():
+            data_row = fields
+    if data_row is None:
+        return failed
+    total = int(data_row[1])
+    used = int(data_row[2])
+    avail = int(data_row[3])
+    # Percent-used off the byte counts (df's Use% is rounded). Guard
+    # a zero-total (unmounted / pseudo fs) so we never divide by zero.
+    percent_used = round((used / total) * 100.0, 2) if total > 0 else None
+    return {
+        "total_bytes": total,
+        "used_bytes": used,
+        "avail_bytes": avail,
+        "percent_used": percent_used,
+        "ok": True,
+    }
+
+
+def _parse_du_bytes(path: str, du_text: str) -> dict[str, Any]:
+    """Parse ``du -sb <dir>`` output into one growth-dir sub-section.
+
+    ``du -sb`` prints a single line ``<bytes>\\t<path>``. The first
+    whitespace-delimited field is the apparent size in bytes. Empty
+    output (the sub-command failed -- ``_safe_run_text`` maps a
+    missing dir / SSH error to ``""``) or a non-numeric first field
+    yields ``ok: False`` for this entry without touching the others.
+    """
+    stripped = du_text.strip()
+    if not stripped:
+        return {"path": path, "used_bytes": None, "ok": False}
+    first_field = stripped.split()[0]
+    if not first_field.isdigit():
+        return {"path": path, "used_bytes": None, "ok": False}
+    return {"path": path, "used_bytes": int(first_field), "ok": True}
+
+
+def parse_disk_usage_output(
+    *,
+    df_root_text: str,
+    dir_usages: list[tuple[str, str]],
+) -> dict[str, Any]:
+    """Compose the ``holodeck.disk.usage`` envelope from raw command text.
+
+    Inputs:
+
+    * ``df_root_text`` -- stdout of ``df -B1 /``.
+    * ``dir_usages`` -- ``[(path, du_stdout), ...]`` in
+      :data:`GROWTH_DIRS` order; one ``du -sb`` run per growth dir.
+
+    Returns:
+
+    .. code-block:: python
+
+        {
+            "root_fs": {
+                "total_bytes": 467909804032,
+                "used_bytes": 58598952960,
+                "avail_bytes": 385467109376,
+                "percent_used": 12.52,
+                "ok": True,
+            },
+            "growth_dirs": [
+                {"path": "/var/backups", "used_bytes": 40000000000, "ok": True},
+                {"path": "/holodeck-runtime", "used_bytes": None, "ok": False},
+            ],
+        }
+
+    Each sub-section carries its own ``ok`` flag; a failed ``df`` or a
+    single failed ``du`` (empty / unparseable output) flips only that
+    entry's ``ok`` to ``False`` while the rest of the envelope stays
+    populated -- the same failure-isolation contract
+    :func:`parse_networking_payload` follows for ``networking.show``.
+    """
+    return {
+        "root_fs": _parse_df_root(df_root_text),
+        "growth_dirs": [_parse_du_bytes(path, du_text) for path, du_text in dir_usages],
+    }
+
+
 # ---------------------------------------------------------------------------
 # Handler functions (bound-method shims on HolodeckConnector)
 # ---------------------------------------------------------------------------
@@ -853,6 +993,48 @@ async def holodeck_networking_show(
         dns_zones_json=dns_zones_payload,
         dhcp_leases_text=dhcp_text,
     )
+
+
+async def holodeck_disk_usage(
+    self: HolodeckConnector,
+    target: Any,
+    params: dict[str, Any],
+) -> dict[str, Any]:
+    """Report root-fs usage plus the fixed growth-dir set.
+
+    Op-id: ``holodeck.disk.usage``. Runs, over the pooled SSH
+    connection:
+
+    1. ``df -B1 /`` -- root-fs total / used / available in bytes.
+    2. ``du -sb <dir>`` for each dir in :data:`GROWTH_DIRS`
+       (``/var/backups``, ``/holodeck-runtime``) -- the two known
+       VCF-9.x root-fill sources.
+
+    The op takes **no** path parameter: the growth-dir set is the
+    :data:`GROWTH_DIRS` module constant, so this can never become an
+    arbitrary ``du`` over operator-supplied input. Each dir token is
+    still ``shlex.quote``- d before interpolation as belt-and-braces
+    (the constants contain no metacharacters today, but a future edit
+    to the constant is protected from accidentally breaking the
+    quoting invariant).
+
+    Sub-command failures are isolated the way ``networking.show``
+    isolates its four sub-sections: each runs through
+    :func:`_safe_run_text` (SSH / OSError -> empty string), and
+    :func:`parse_disk_usage_output` flips only the empty entry's
+    ``ok`` to ``False`` -- a missing ``/var/backups`` never blanks
+    the root-fs numbers or the other growth dir. Read-only; issues
+    no mutating command.
+    """
+    del params  # declared empty; intentionally ignored
+
+    df_root_text = await _safe_run_text(self, target, "df -B1 /")
+    dir_usages: list[tuple[str, str]] = []
+    for path in GROWTH_DIRS:
+        du_text = await _safe_run_text(self, target, f"du -sb {shlex.quote(path)}")
+        dir_usages.append((path, du_text))
+
+    return parse_disk_usage_output(df_root_text=df_root_text, dir_usages=dir_usages)
 
 
 # ---------------------------------------------------------------------------
@@ -1434,6 +1616,82 @@ READ_OPS: tuple[HolodeckOp, ...] = (
                 "routes are operator-formatted text (vtysh output); "
                 "DNS is structured (parsed JSON); DHCP is the raw "
                 "leases file."
+            ),
+        },
+    ),
+    HolodeckOp(
+        op_id="holodeck.disk.usage",
+        handler_attr="disk_usage",
+        summary="Root-fs usage plus fixed growth-dir usage for pre-eviction disk diagnosis.",
+        description=(
+            "Runs ``df -B1 /`` for the HoloRouter root filesystem plus "
+            "``du -sb`` on a fixed, code-constant set of known growth "
+            "directories (``/var/backups``, ``/holodeck-runtime``) over "
+            "the pooled SSH connection. Returns an envelope with a "
+            "``root_fs`` sub-section (total / used / available bytes + "
+            "computed ``percent_used``) and a ``growth_dirs`` list "
+            "(per-dir ``used_bytes``), each carrying its own ``ok`` flag "
+            "so one failed sub-command doesn't blank the others. Takes "
+            "no path parameter -- the growth-dir set is fixed in code, "
+            "so it can never become an arbitrary ``du``. Read-only; the "
+            "value is stable enough for a scheduler to poll for "
+            "early-warning on a filling 74 GB root fs (VCF-9.x backup "
+            "fill)."
+        ),
+        parameter_schema=_EMPTY_PARAMS,
+        response_schema={
+            "type": "object",
+            "properties": {
+                "root_fs": {
+                    "type": "object",
+                    "properties": {
+                        "total_bytes": {"type": ["integer", "null"]},
+                        "used_bytes": {"type": ["integer", "null"]},
+                        "avail_bytes": {"type": ["integer", "null"]},
+                        "percent_used": {"type": ["number", "null"]},
+                        "ok": {"type": "boolean"},
+                    },
+                },
+                "growth_dirs": {
+                    "type": "array",
+                    "items": {
+                        "type": "object",
+                        "properties": {
+                            "path": {"type": "string"},
+                            "used_bytes": {"type": ["integer", "null"]},
+                            "ok": {"type": "boolean"},
+                        },
+                    },
+                },
+            },
+            "additionalProperties": True,
+        },
+        group_key="diagnostics",
+        tags=("read-only", "diagnostics", "disk", "holodeck"),
+        safety_level="safe",
+        requires_approval=False,
+        llm_instructions={
+            "when_to_use": (
+                "Call when the operator (or a scheduler) needs the "
+                "HoloRouter's disk pressure before a root-fs fill "
+                "evicts pods: root-fs total/used/available + "
+                "percent-used, plus the byte usage of the two known "
+                "growth directories (``/var/backups``, "
+                "``/holodeck-runtime``). This is the complete "
+                "pre-eviction diagnostic signal -- pair it with "
+                "``holodeck.logs.tail`` to find what is writing. Takes "
+                "no path argument; the measured dirs are fixed in "
+                "code. " + _SSH_TRANSPORT_NOTE
+            ),
+            "parameter_hints": {},
+            "output_shape": (
+                "``{root_fs: {total_bytes, used_bytes, avail_bytes, "
+                "percent_used, ok}, growth_dirs: [{path, used_bytes, "
+                "ok}, ...]}``. All byte counts are integers "
+                "(``df -B1`` / ``du -sb`` -- 1-byte block size). "
+                "``percent_used`` is computed from the byte counts. "
+                "Each sub-section's ``ok`` flips false when its "
+                "sub-command failed or produced empty output."
             ),
         },
     ),

--- a/backend/tests/test_connectors_holodeck_auth.py
+++ b/backend/tests/test_connectors_holodeck_auth.py
@@ -208,7 +208,7 @@ def test_about_canary_op_remains_at_index_zero() -> None:
     """
     assert HOLODECK_OPS[0].op_id == "holodeck.about"
     assert HOLODECK_OPS[0].handler_attr == "about"
-    assert len(HOLODECK_OPS) == 8
+    assert len(HOLODECK_OPS) == 9
 
 
 # ---------------------------------------------------------------------------

--- a/backend/tests/test_connectors_holodeck_e2e.py
+++ b/backend/tests/test_connectors_holodeck_e2e.py
@@ -193,6 +193,14 @@ _PLAIN_SSH_FIXTURES: dict[str, str] = {
         '  client-hostname "esxi-1";\n'
         "}\n"
     ),
+    # holodeck.disk.usage — root-fs df in bytes + du on the fixed
+    # GROWTH_DIRS (no operator path; the command strings are fixed).
+    "df -B1 /": (
+        "Filesystem     1B-blocks         Used    Available Use% Mounted on\n"
+        "/dev/sda2    79456894976  58598952960  16811528192  78% /\n"
+    ),
+    "du -sb /var/backups": "42000000000\t/var/backups\n",
+    "du -sb /holodeck-runtime": "9500000000\t/holodeck-runtime\n",
     # holodeck.k8s.exec — verbatim kubectl forward. Two fixtures here:
     # the safe `kubectl get pods` invocation that the read-only safelist
     # accepts, and an alternate `kubectl get nodes` for the second test
@@ -377,6 +385,7 @@ EXPECTED_OP_IDS: tuple[str, ...] = (
     "holodeck.k8s.exec",
     "holodeck.logs.tail",
     "holodeck.networking.show",
+    "holodeck.disk.usage",
 )
 
 # ---------------------------------------------------------------------------
@@ -490,11 +499,11 @@ async def holodeck_e2e(
 
 
 def test_holodeck_ops_registration_count() -> None:
-    """All 8 Holodeck ops are registered in HOLODECK_OPS."""
+    """All 9 Holodeck ops are registered in HOLODECK_OPS."""
     op_ids = {op.op_id for op in HOLODECK_OPS}
     missing = set(EXPECTED_OP_IDS) - op_ids
     assert not missing, f"Missing ops: {missing}"
-    assert len(HOLODECK_OPS) == 8, f"Expected 8 ops, got {len(HOLODECK_OPS)}"
+    assert len(HOLODECK_OPS) == 9, f"Expected 9 ops, got {len(HOLODECK_OPS)}"
 
 
 def test_holodeck_ops_all_safe_and_no_approval_required() -> None:
@@ -505,7 +514,7 @@ def test_holodeck_ops_all_safe_and_no_approval_required() -> None:
 
 
 def test_holodeck_ops_all_have_llm_instructions() -> None:
-    """All 8 ops carry non-empty llm_instructions for agent discoverability."""
+    """All 9 ops carry non-empty llm_instructions for agent discoverability."""
     for op in HOLODECK_OPS:
         assert op.llm_instructions, f"{op.op_id}: llm_instructions must not be empty"
         instr = op.llm_instructions
@@ -522,7 +531,7 @@ def test_holodeck_ops_all_carry_ssh_only_transport_note() -> None:
 
     The exact phrase to look for is "Holodeck has no REST API"; the
     shared :data:`SSH_TRANSPORT_NOTE` constant guarantees consistency
-    across all 8 ops.
+    across all 9 ops.
     """
     canonical_phrase = "Holodeck has no REST API"
     pwsh_phrase = "PowerShell-over-SSH"
@@ -827,6 +836,38 @@ async def test_holodeck_e2e_networking_show_dispatches_ok(
     assert "lease 10.50.0.5" in envelope["dhcp"]["leases_text"]
 
 
+@pytest.mark.asyncio
+async def test_holodeck_e2e_disk_usage_dispatches_ok(
+    holodeck_e2e: _HolodeckE2EBundle,
+    captured_events: list[Any],
+) -> None:
+    """holodeck.disk.usage composes root-fs df + fixed growth-dir du (G3.18-T1 #2153)."""
+    del captured_events
+    result = await call_operation(
+        _OPERATOR,
+        {
+            "connector_id": "holodeck-ssh-9.0",
+            "op_id": "holodeck.disk.usage",
+            "target": {"name": _TARGET_NAME},
+            "params": {},
+        },
+    )
+    assert result["status"] == "ok", f"holodeck.disk.usage failed: {result.get('error')}"
+    envelope = result["result"]
+    root = envelope["root_fs"]
+    assert root["ok"] is True
+    assert root["total_bytes"] == 79456894976
+    assert root["used_bytes"] == 58598952960
+    assert root["avail_bytes"] == 16811528192
+    assert root["percent_used"] == round((58598952960 / 79456894976) * 100.0, 2)
+    dirs = {d["path"]: d for d in envelope["growth_dirs"]}
+    assert set(dirs) == {"/var/backups", "/holodeck-runtime"}
+    assert dirs["/var/backups"]["used_bytes"] == 42000000000
+    assert dirs["/var/backups"]["ok"] is True
+    assert dirs["/holodeck-runtime"]["used_bytes"] == 9500000000
+    assert dirs["/holodeck-runtime"]["ok"] is True
+
+
 # ---------------------------------------------------------------------------
 # Acceptance criterion (c) — pod.list JSONFlux handle path
 # ---------------------------------------------------------------------------
@@ -965,7 +1006,7 @@ async def test_holodeck_e2e_all_ops_write_audit_rows(
     holodeck_e2e: _HolodeckE2EBundle,
     captured_events: list[Any],
 ) -> None:
-    """All 8 Holodeck ops each produce an audit row after dispatch.
+    """All 9 Holodeck ops each produce an audit row after dispatch.
 
     Dispatches every op in EXPECTED_OP_IDS and asserts that each one
     inserted at least one ``DISPATCH`` AuditLog row.

--- a/backend/tests/test_connectors_holodeck_ops.py
+++ b/backend/tests/test_connectors_holodeck_ops.py
@@ -59,8 +59,10 @@ import pytest
 import meho_backplane.connectors.holodeck  # noqa: F401 -- import for registry side-effects
 from meho_backplane.connectors.holodeck import HOLODECK_OPS, HolodeckConnector
 from meho_backplane.connectors.holodeck.ops_read import (
+    GROWTH_DIRS,
     READ_OPS,
     KubectlSafetyError,
+    parse_disk_usage_output,
     parse_kubectl_command,
     parse_logs_tail_output,
     parse_networking_payload,
@@ -1062,13 +1064,178 @@ async def test_networking_show_isolates_sub_command_failures() -> None:
 
 
 # ---------------------------------------------------------------------------
+# parse_disk_usage_output (G3.18-T1 #2153)
+# ---------------------------------------------------------------------------
+
+
+_DF_ROOT_OK = (
+    "Filesystem     1B-blocks         Used    Available Use% Mounted on\n"
+    "/dev/md2    467909804032  58598952960 385467109376  14% /\n"
+)
+
+
+def test_parse_disk_usage_root_fs_byte_counts_and_percent() -> None:
+    payload = parse_disk_usage_output(
+        df_root_text=_DF_ROOT_OK,
+        dir_usages=[
+            ("/var/backups", "40000000000\t/var/backups\n"),
+            ("/holodeck-runtime", "12345\t/holodeck-runtime\n"),
+        ],
+    )
+    root = payload["root_fs"]
+    assert root["ok"] is True
+    assert root["total_bytes"] == 467909804032
+    assert root["used_bytes"] == 58598952960
+    assert root["avail_bytes"] == 385467109376
+    # percent computed off the byte counts, not df's rounded Use%.
+    assert root["percent_used"] == round((58598952960 / 467909804032) * 100.0, 2)
+
+
+def test_parse_disk_usage_growth_dirs_carry_used_bytes_and_ok() -> None:
+    payload = parse_disk_usage_output(
+        df_root_text=_DF_ROOT_OK,
+        dir_usages=[
+            ("/var/backups", "40000000000\t/var/backups\n"),
+            ("/holodeck-runtime", "12345\t/holodeck-runtime\n"),
+        ],
+    )
+    dirs = {d["path"]: d for d in payload["growth_dirs"]}
+    assert dirs["/var/backups"]["used_bytes"] == 40000000000
+    assert dirs["/var/backups"]["ok"] is True
+    assert dirs["/holodeck-runtime"]["used_bytes"] == 12345
+    assert dirs["/holodeck-runtime"]["ok"] is True
+    # Order + count mirror the input tuple.
+    assert [d["path"] for d in payload["growth_dirs"]] == [
+        "/var/backups",
+        "/holodeck-runtime",
+    ]
+
+
+def test_parse_disk_usage_failed_du_does_not_blank_the_others() -> None:
+    """A single empty du output flips only that entry's ok -- isolation contract."""
+    payload = parse_disk_usage_output(
+        df_root_text=_DF_ROOT_OK,
+        dir_usages=[
+            ("/var/backups", ""),  # du failed (missing dir / SSH error)
+            ("/holodeck-runtime", "12345\t/holodeck-runtime\n"),
+        ],
+    )
+    assert payload["root_fs"]["ok"] is True
+    dirs = {d["path"]: d for d in payload["growth_dirs"]}
+    assert dirs["/var/backups"]["ok"] is False
+    assert dirs["/var/backups"]["used_bytes"] is None
+    assert dirs["/holodeck-runtime"]["ok"] is True
+    assert dirs["/holodeck-runtime"]["used_bytes"] == 12345
+
+
+def test_parse_disk_usage_empty_df_flips_root_ok_false() -> None:
+    payload = parse_disk_usage_output(
+        df_root_text="",
+        dir_usages=[("/var/backups", "40000000000\t/var/backups\n")],
+    )
+    root = payload["root_fs"]
+    assert root["ok"] is False
+    assert root["total_bytes"] is None
+    assert root["percent_used"] is None
+    # Growth dir still resolves independently.
+    assert payload["growth_dirs"][0]["ok"] is True
+
+
+def test_parse_disk_usage_non_numeric_du_flips_entry_false() -> None:
+    payload = parse_disk_usage_output(
+        df_root_text=_DF_ROOT_OK,
+        dir_usages=[("/var/backups", "du: cannot access '/var/backups'\n")],
+    )
+    entry = payload["growth_dirs"][0]
+    assert entry["ok"] is False
+    assert entry["used_bytes"] is None
+
+
+# ---------------------------------------------------------------------------
+# Bound-method shim -- disk_usage (G3.18-T1 #2153)
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.asyncio
+async def test_disk_usage_reports_root_fs_and_growth_dirs() -> None:
+    connector = HolodeckConnector()
+    # Sub-command order: df -B1 /, then du -sb per GROWTH_DIRS entry.
+    sequence = [
+        _proc(stdout=_DF_ROOT_OK),
+        _proc(stdout="40000000000\t/var/backups\n"),
+        _proc(stdout="12345\t/holodeck-runtime\n"),
+    ]
+    with patch.object(connector, "_run_command", new_callable=AsyncMock) as mock_cmd:
+        mock_cmd.side_effect = sequence
+        result = await connector.disk_usage(_TARGET, {})
+    assert result["root_fs"]["ok"] is True
+    assert result["root_fs"]["total_bytes"] == 467909804032
+    dirs = {d["path"]: d for d in result["growth_dirs"]}
+    assert set(dirs) == set(GROWTH_DIRS)
+    assert dirs["/var/backups"]["used_bytes"] == 40000000000
+    assert dirs["/holodeck-runtime"]["used_bytes"] == 12345
+
+
+@pytest.mark.asyncio
+async def test_disk_usage_runs_df_and_du_no_path_param() -> None:
+    """The op issues df on / and du on the fixed GROWTH_DIRS -- no operator path."""
+    connector = HolodeckConnector()
+    sequence = [
+        _proc(stdout=_DF_ROOT_OK),
+        _proc(stdout="40000000000\t/var/backups\n"),
+        _proc(stdout="12345\t/holodeck-runtime\n"),
+    ]
+    with patch.object(connector, "_run_command", new_callable=AsyncMock) as mock_cmd:
+        mock_cmd.side_effect = sequence
+        # Extra params must be ignored -- there is no path parameter.
+        await connector.disk_usage(_TARGET, {"path": "/etc"})
+    issued = [call.args[1] for call in mock_cmd.await_args_list]
+    assert issued[0] == "df -B1 /"
+    assert issued[1] == "du -sb /var/backups"
+    assert issued[2] == "du -sb /holodeck-runtime"
+    # /etc (operator input) never reaches a command.
+    assert not any("/etc" in cmd for cmd in issued)
+
+
+@pytest.mark.asyncio
+async def test_disk_usage_isolates_failed_sub_command() -> None:
+    connector = HolodeckConnector()
+    sequence = [
+        _proc(stdout=_DF_ROOT_OK),
+        OSError("du: no such dir"),  # /var/backups du fails
+        _proc(stdout="12345\t/holodeck-runtime\n"),
+    ]
+    with patch.object(connector, "_run_command", new_callable=AsyncMock) as mock_cmd:
+        mock_cmd.side_effect = sequence
+        result = await connector.disk_usage(_TARGET, {})
+    assert result["root_fs"]["ok"] is True
+    dirs = {d["path"]: d for d in result["growth_dirs"]}
+    assert dirs["/var/backups"]["ok"] is False
+    assert dirs["/holodeck-runtime"]["ok"] is True
+
+
+def test_disk_usage_op_is_safe_read_only_no_path_param() -> None:
+    """AC: safe / no-approval / read-only tag / empty param schema (no path)."""
+    op = next(o for o in HOLODECK_OPS if o.op_id == "holodeck.disk.usage")
+    assert op.safety_level == "safe"
+    assert op.requires_approval is False
+    assert "read-only" in op.tags
+    assert op.parameter_schema.get("additionalProperties") is False
+    assert op.parameter_schema.get("properties") == {}
+
+
+def test_disk_usage_growth_dirs_are_the_expected_constant() -> None:
+    assert GROWTH_DIRS == ("/var/backups", "/holodeck-runtime")
+
+
+# ---------------------------------------------------------------------------
 # HOLODECK_OPS registration shape
 # ---------------------------------------------------------------------------
 
 
-def test_holodeck_ops_has_eight_entries() -> None:
-    """T1 canary (about) + 7 T2 read ops = 8 total."""
-    assert len(HOLODECK_OPS) == 8
+def test_holodeck_ops_has_nine_entries() -> None:
+    """T1 canary (about) + 7 T2 read ops + G3.18-T1 disk.usage = 9 total."""
+    assert len(HOLODECK_OPS) == 9
 
 
 def test_holodeck_ops_about_remains_at_index_zero() -> None:
@@ -1086,6 +1253,7 @@ def test_holodeck_ops_covers_expected_op_ids() -> None:
         "holodeck.k8s.exec",
         "holodeck.logs.tail",
         "holodeck.networking.show",
+        "holodeck.disk.usage",
     }
     assert op_ids == expected
 
@@ -1140,7 +1308,7 @@ def test_holodeck_ops_llm_instructions_mention_ssh_transport() -> None:
 
 
 def test_holodeck_ops_group_keys_include_new_groups() -> None:
-    """T2 introduces the config / pod / service / k8s / logs / networking groups."""
+    """T2 introduces config / pod / service / k8s / logs / networking; G3.18-T1 adds diagnostics."""
     group_keys = {op.group_key for op in HOLODECK_OPS if op.group_key}
     assert {
         "identity",
@@ -1150,6 +1318,7 @@ def test_holodeck_ops_group_keys_include_new_groups() -> None:
         "k8s",
         "logs",
         "networking",
+        "diagnostics",
     } == group_keys
 
 
@@ -1276,6 +1445,7 @@ def test_connector_has_all_t2_handler_methods() -> None:
         "k8s_exec",
         "logs_tail",
         "networking_show",
+        "disk_usage",
     )
     for attr in expected_attrs:
         assert callable(getattr(HolodeckConnector, attr, None)), (

--- a/docs/codebase/connectors-holodeck.md
+++ b/docs/codebase/connectors-holodeck.md
@@ -20,9 +20,11 @@ ships the `holodeck.about` canary op, the password-default + key-fallback
 auth via the inherited `SshConnector._auth_config`, the fingerprint, the
 probe, and the `_pwsh.py` PowerShell-over-SSH helper. G3.8-T2 (#854) adds
 the 7 read ops (`config.show`, `pod.list`, `pod.info`, `service.list`,
-`k8s.exec`, `logs.tail`, `networking.show`) for a final total of 8 ops
+`k8s.exec`, `logs.tail`, `networking.show`) for a total of 8 ops
 registered under `connector_id="holodeck-ssh-9.0"`. G3.8-T3 (#855) ships
-the CLI verbs + E2E acceptance suite + onboarding doc.
+the CLI verbs + E2E acceptance suite + onboarding doc. G3.18-T1 (#2153)
+appends `holodeck.disk.usage` — root-fs `df` + `du` on a fixed growth-dir
+set for pre-eviction disk diagnosis — bringing the total to 9 ops.
 
 Source: `backend/src/meho_backplane/connectors/holodeck/`.
 
@@ -34,16 +36,20 @@ Source: `backend/src/meho_backplane/connectors/holodeck/`.
   `_run_command`, and `aclose()` from the adapter. T1 shipped `fingerprint`,
   `probe`, `execute`, `about`. T2 (#854) adds the 7 read-op bound-method
   shims: `config_show`, `pod_list`, `pod_info`, `service_list`, `k8s_exec`,
-  `logs_tail`, `networking_show`.
+  `logs_tail`, `networking_show`. G3.18-T1 (#2153) adds `disk_usage`.
 
 - **Read-op handlers + parsers** (`ops_read.py`) — `holodeck_config_show`,
   `holodeck_pod_list`, `holodeck_pod_info`, `holodeck_service_list`,
-  `holodeck_k8s_exec`, `holodeck_logs_tail`, `holodeck_networking_show`.
-  Pure parsers: `parse_kubectl_command` (verb-safelist enforcement),
-  `parse_logs_tail_output` (GNU `tail` `==> path <==` header split),
-  `parse_networking_payload` (four-section composer). `KubectlSafetyError`
-  is the `ValueError` subclass the dispatcher's error envelope picks up
-  when a mutating verb slips through.
+  `holodeck_k8s_exec`, `holodeck_logs_tail`, `holodeck_networking_show`,
+  `holodeck_disk_usage`. Pure parsers: `parse_kubectl_command`
+  (verb-safelist enforcement), `parse_logs_tail_output` (GNU `tail`
+  `==> path <==` header split), `parse_networking_payload` (four-section
+  composer), `parse_disk_usage_output` (root-fs `df -B1` + per-dir
+  `du -sb` composer with per-section `ok`). `GROWTH_DIRS` is the fixed
+  code constant (`/var/backups`, `/holodeck-runtime`) the disk-usage op
+  measures — no operator path parameter. `KubectlSafetyError` is the
+  `ValueError` subclass the dispatcher's error envelope picks up when a
+  mutating verb slips through.
 
 - **`_pwsh.py` — the novel primitive.** Houses `encode_pwsh_command(script)`
   (UTF-16LE-base64 per the `-EncodedCommand` convention), `pwsh_run(connector,
@@ -138,9 +144,9 @@ Four-stage health check; each stage maps to a distinct
 
 The probe does not mutate state. `Get-Service` is read-only on Photon.
 
-### Read ops (T2 surface)
+### Read ops (T2 surface + G3.18-T1 disk.usage)
 
-The seven T2 read ops route through the dispatcher's standard
+The read ops route through the dispatcher's standard
 `call_operation` path. Each registers via `register_typed_operation()` with
 `safety_level="safe"`, `requires_approval=False`, and an
 `llm_instructions.when_to_use` blob that includes the SSH-only transport
@@ -239,6 +245,19 @@ disclosure (CLAUDE.md postulate 5 + Initiative #371).
   ok}, dhcp: {leases_text, ok}}`. Each sub-section's `ok` flips false
   when its sub-command failed or produced empty output, so a single-
   component failure doesn't blank the whole response.
+
+- **`holodeck.disk.usage`** (group `diagnostics`, G3.18-T1 #2153). Runs
+  `df -B1 /` for root-fs total/used/available bytes plus `du -sb` on each
+  dir in the fixed `GROWTH_DIRS` constant (`/var/backups`,
+  `/holodeck-runtime`). Returns `{root_fs: {total_bytes, used_bytes,
+  avail_bytes, percent_used, ok}, growth_dirs: [{path, used_bytes, ok},
+  ...]}`. `percent_used` is computed from the byte counts (not `df`'s
+  rounded `Use%`). Failure isolation mirrors `networking.show`: each
+  sub-command runs through `_safe_run_text` (SSH/OSError → `""`) and
+  `parse_disk_usage_output` flips only the empty entry's `ok`. The op
+  takes **no path parameter** — the measured dirs are a code constant, so
+  it can never become an arbitrary `du`. This is the complete
+  pre-eviction disk signal for the 74 GB root fs (VCF-9.x backup fill).
 
 ### `execute(target, op_id, params)`
 


### PR DESCRIPTION
## Summary
- Adds `holodeck.disk.usage` read op to the `holodeck-ssh-9.0` connector: reports root-fs usage (`df -B1 /`) plus `du -sb` on a **fixed** module-constant growth-dir set (`GROWTH_DIRS = /var/backups`, `/holodeck-runtime`). This is the complete pre-eviction diagnostic signal for the 74 GB root fs that fills on VCF-9.x backup accumulation (Initiative #2145).
- The op takes **no path parameter** — the measured dirs are a code constant, so it can never become an arbitrary `du`. `parameter_schema` is the empty-object schema (`additionalProperties: False`), matching `holodeck.about`. `safety_level="safe"`, `requires_approval=False`, `tags` include `read-only`, `group_key="diagnostics"`.
- Failure isolation mirrors `networking.show`: each sub-command runs through `_safe_run_text` (SSH/`OSError` → `""`) and `parse_disk_usage_output` flips only the empty entry's `ok` without blanking the others. `percent_used` is computed from the byte counts (not `df`'s rounded `Use%`) so a scheduler can poll a stable value.
- Op count for `connector_id="holodeck-ssh-9.0"` goes **8 → 9**.

## Test plan
- [x] `ruff check` — clean
- [x] `ruff format --check` — clean
- [x] `mypy` (holodeck connector) — no issues
- [x] `pytest tests/test_connectors_holodeck_ops.py tests/test_connectors_holodeck_auth.py` — 200 passed
- [x] `pytest tests/test_connectors_holodeck_e2e.py` — 18 passed (dispatches `holodeck.disk.usage` end-to-end over the recorded asyncssh fixture)
- [x] code-quality gate (`--diff`) — 0 blockers (warnings all pre-existing)
- [x] AC: op registers with `safety_level="safe"`, `requires_approval=False`, `read-only` tag
- [x] AC: `parameter_schema` has `additionalProperties: False` and no path/dir property (unit test `test_disk_usage_runs_df_and_du_no_path_param` asserts an operator-supplied `path` never reaches a command)
- [x] AC: handler returns root-fs total/used/avail + percent-used and per-dir used-bytes; a failed sub-command yields that entry `ok: false` without blanking the others
- [x] AC: op count 8 → 9; unit test asserts registration + dispatch on the asyncssh fixture (same harness as #854)
- [x] AC: `cd cli && make snapshot-openapi && make generate` run — **no diff** (connector-op registration populates the `endpoint_descriptor` DB table at lifespan startup, not the FastAPI route table, so the OpenAPI snapshot is unaffected)

## Out of scope
- Any write / remediation op (those are G3.18-T2, #2145).
- Operator-supplied paths or a generic `du` — deliberately excluded (fixed constant only).
- Scheduler wiring / alerting on the returned value — this Task only ships the pollable read.

<!-- auto-implement-issue: fresh, iteration 1 -->

Closes #2153
