### PR TITLE
feat(connectors): add holodeck approval-gated remediation writes (G3.18-T2 #2154)

### DIFF
--- a/backend/src/meho_backplane/connectors/holodeck/connector.py
+++ b/backend/src/meho_backplane/connectors/holodeck/connector.py
@@ -1,5 +1,12 @@
 # SPDX-License-Identifier: Apache-2.0
 # Copyright (c) 2026 evoila Group
+#
+# code-quality-allow: pre-existing legacy debt not introduced by this task.
+# On main the module was already 723 lines (> 600) with fingerprint (109) /
+# probe (111, C901 14) over budget; G3.18-T2 (#2154) only appends three
+# small write-op shims + the WRITE_OPS wiring. Splitting the connector or
+# refactoring fingerprint/probe is out of scope for an approval-gated write
+# addition and would balloon the review surface; tracked separately.
 
 """HolodeckConnector -- typed SSH-transport connector for VMware Holodeck 9.0.
 
@@ -63,6 +70,9 @@ from meho_backplane.auth.operator import Operator
 from meho_backplane.connectors.adapters.ssh import SshConnector
 from meho_backplane.connectors.holodeck._pwsh import PwshRunError, pwsh_run
 from meho_backplane.connectors.holodeck.ops import HOLODECK_OPS
+from meho_backplane.connectors.holodeck.ops_write import (
+    HOLODECK_WHEN_TO_USE_WRITE_BY_GROUP,
+)
 from meho_backplane.connectors.schemas import (
     FingerprintResult,
     OperationResult,
@@ -174,6 +184,11 @@ _WHEN_TO_USE_BY_GROUP: dict[str, str] = {
         "drill-in. Transport: plain SSH for vtysh + dhcpd.leases; "
         "pwsh-over-SSH for the DNS zone summary."
     ),
+    # G3.18-T2 (#2154) approval-gated remediation write groups. The keys
+    # carry a ``-write`` suffix so they never collide with the read-op
+    # group keys above; the blurbs are the single source of truth in
+    # ``ops_write`` and are merged in here for the registration walk.
+    **HOLODECK_WHEN_TO_USE_WRITE_BY_GROUP,
 }
 
 
@@ -574,6 +589,57 @@ class HolodeckConnector(SshConnector):
         )
 
         return await _holodeck_networking_show(self, target, params)
+
+    async def k8s_pods_gc(
+        self,
+        target: Target,
+        params: dict[str, Any],
+    ) -> dict[str, Any]:
+        """Bound-method shim for ``holodeck.k8s.pods.gc`` (G3.18-T2 #2154).
+
+        **Approval-gated write.** Delegates to
+        :func:`~meho_backplane.connectors.holodeck.ops_write.holodeck_k8s_pods_gc`;
+        runs only on the ``_approved=True`` resume path.
+        """
+        from meho_backplane.connectors.holodeck.ops_write import (
+            holodeck_k8s_pods_gc as _holodeck_k8s_pods_gc,
+        )
+
+        return await _holodeck_k8s_pods_gc(self, target, params)
+
+    async def backups_prune(
+        self,
+        target: Target,
+        params: dict[str, Any],
+    ) -> dict[str, Any]:
+        """Bound-method shim for ``holodeck.backups.prune`` (G3.18-T2 #2154).
+
+        **Approval-gated write.** Delegates to
+        :func:`~meho_backplane.connectors.holodeck.ops_write.holodeck_backups_prune`;
+        runs only on the ``_approved=True`` resume path.
+        """
+        from meho_backplane.connectors.holodeck.ops_write import (
+            holodeck_backups_prune as _holodeck_backups_prune,
+        )
+
+        return await _holodeck_backups_prune(self, target, params)
+
+    async def images_import(
+        self,
+        target: Target,
+        params: dict[str, Any],
+    ) -> dict[str, Any]:
+        """Bound-method shim for ``holodeck.images.import`` (G3.18-T2 #2154).
+
+        **Approval-gated write.** Delegates to
+        :func:`~meho_backplane.connectors.holodeck.ops_write.holodeck_images_import`;
+        runs only on the ``_approved=True`` resume path.
+        """
+        from meho_backplane.connectors.holodeck.ops_write import (
+            holodeck_images_import as _holodeck_images_import,
+        )
+
+        return await _holodeck_images_import(self, target, params)
 
     @classmethod
     async def register_operations(cls) -> None:

--- a/backend/src/meho_backplane/connectors/holodeck/ops.py
+++ b/backend/src/meho_backplane/connectors/holodeck/ops.py
@@ -150,10 +150,16 @@ def _holodeck_ops() -> tuple[HolodeckOp, ...]:
     read ops from :mod:`meho_backplane.connectors.holodeck.ops_read`.
     Mirrors :func:`meho_backplane.connectors.pfsense.ops._pfsense_ops`
     and :func:`meho_backplane.connectors.bind9.ops._bind9_ops`.
+
+    G3.18-T2 (#2154) appends the 3 approval-gated remediation write ops
+    (:data:`~meho_backplane.connectors.holodeck.ops_write.WRITE_OPS`:
+    ``holodeck.k8s.pods.gc`` / ``holodeck.backups.prune`` /
+    ``holodeck.images.import``) onto the tuple -- 12 ops total.
     """
     from meho_backplane.connectors.holodeck.ops_read import READ_OPS
+    from meho_backplane.connectors.holodeck.ops_write import WRITE_OPS
 
-    return (_HOLODECK_ABOUT_OP, *READ_OPS)
+    return (_HOLODECK_ABOUT_OP, *READ_OPS, *WRITE_OPS)
 
 
 #: The ops :class:`HolodeckConnector` registers at lifespan startup.

--- a/backend/src/meho_backplane/connectors/holodeck/ops_write.py
+++ b/backend/src/meho_backplane/connectors/holodeck/ops_write.py
@@ -1,0 +1,595 @@
+# SPDX-License-Identifier: Apache-2.0
+# Copyright (c) 2026 evoila Group
+
+"""Approval-gated remediation write ops for :class:`HolodeckConnector` (G3.18-T2 #2154).
+
+G3.8 (#371) shipped the connector plus 8 read ops; every one is
+``requires_approval=False`` and read-only -- ``holodeck.k8s.exec``
+re-validates its verb against a read-only safelist, so ``kubectl delete``
+cannot pass. The VCF-9.x backup-fill outage (Initiative #2145) needed three
+narrow writes the connector could not express, so recovery fell back to
+local root SSH with no MEHO audit row. This module closes that gap with
+three **tightly bounded** remediation writes:
+
+==============================  ===========  =========================================
+op_id                           safety       action
+==============================  ===========  =========================================
+``holodeck.k8s.pods.gc``        dangerous    ``kubectl delete pods --field-selector
+                                             status.phase=<Failed|Succeeded>`` only
+``holodeck.backups.prune``      dangerous    delete backups under ``/var/backups``,
+                                             keep newest ``keep_newest``
+``holodeck.images.import``      dangerous    ``ctr -n k8s.io images import <tar>``
+==============================  ===========  =========================================
+
+Approval routing (load-bearing)
+===============================
+
+Every op registers ``requires_approval=True``. The dispatcher's policy gate
+(:func:`~meho_backplane.operations._validate.policy_gate`) routes a
+``USER``-principal dispatch of a ``requires_approval`` op to the human
+approve-queue (``needs-approval``) -- G11.7-T1 (#1401) -- rather than
+hard-denying it, and floors an agent dispatch to ``needs-approval``
+regardless of safety level. The handler bodies below therefore run only on
+the ``_approved=True`` resume path, after a human approves the parked
+request. The audit row is written by the dispatcher on that execute path
+(the same ``DISPATCH`` ``AuditLog`` row every op gets). The
+``requires_approval=True`` descriptor flag is the only thing the connector
+controls, and it is what engages the queue.
+
+Bounding posture (reject-before-compose)
+=========================================
+
+Each handler validates its inputs against a fixed allowlist and refuses any
+value that escapes the allowed prefix / pattern **before** composing the
+shell command, then :func:`shlex.quote`-quotes every interpolated token.
+This mirrors the read-op ``_COMPONENT_SAFE_RE`` / ``parse_kubectl_command``
+posture: the substrate is dumb (a single unchained command), the bound is a
+positive allowlist, and the reject happens before any SSH traffic. No
+operator-supplied value ever reaches ``self._run_command`` without passing a
+bound.
+
+``kubectl delete`` field-selector note
+=======================================
+
+``kubectl``'s ``--field-selector`` supports only ``=`` / ``==`` / ``!=`` --
+**not** the set-based ``in (Failed,Succeeded)`` form (that operator exists
+only for label ``--selector``; see the kubectl reference). The issue table's
+``status.phase in (Failed,Succeeded)`` shorthand is therefore realised as
+one equality delete per terminal phase, run in sequence, which yields the
+same bound: only ``Failed`` and ``Succeeded`` pods are ever targeted, and
+there is no name or label surface to widen it. Reference:
+https://kubernetes.io/docs/reference/kubectl/generated/kubectl_delete/ .
+
+References
+----------
+
+* Task: https://github.com/evoila/meho/issues/2154
+* Parent initiative: https://github.com/evoila/meho/issues/2145
+* Write-op mold: argocd ``ops_write.py`` (#1405), keycloak (#1406).
+* Approval routing: ``policy_gate`` / G11.7-T1 #1401.
+* Path-safety precedent: ``_COMPONENT_SAFE_RE`` (``ops_read.py``).
+* ``shlex.quote``:
+  https://docs.python.org/3/library/shlex.html#shlex.quote
+* ``ctr images import``: ``ctr -n k8s.io images import <tar>`` (containerd
+  CLI; the ``-n k8s.io`` namespace makes the image visible to kubelet).
+* OS command-injection defence (never build commands via string concat of
+  untrusted input):
+  https://cheatsheetseries.owasp.org/cheatsheets/OS_Command_Injection_Defense_Cheat_Sheet.html
+"""
+
+from __future__ import annotations
+
+import posixpath
+import re
+import shlex
+from typing import TYPE_CHECKING, Any
+
+from meho_backplane.connectors.holodeck.ops import SSH_TRANSPORT_NOTE, HolodeckOp
+
+if TYPE_CHECKING:
+    from meho_backplane.connectors.holodeck.connector import HolodeckConnector
+
+__all__ = [
+    "HOLODECK_WHEN_TO_USE_WRITE_BY_GROUP",
+    "WRITE_OPS",
+    "HolodeckWriteSafetyError",
+    "holodeck_backups_prune",
+    "holodeck_images_import",
+    "holodeck_k8s_pods_gc",
+]
+
+
+# ---------------------------------------------------------------------------
+# Bounds
+# ---------------------------------------------------------------------------
+
+#: The only pod ``status.phase`` values ``holodeck.k8s.pods.gc`` may target.
+#: Both are terminal (the pod has run to completion / failure); deleting them
+#: reclaims garbage without touching a live workload. ``Running`` /
+#: ``Pending`` / ``Unknown`` are deliberately absent and rejected.
+_TERMINAL_POD_PHASES: tuple[str, ...] = ("Failed", "Succeeded")
+_TERMINAL_POD_PHASE_SET: frozenset[str] = frozenset(_TERMINAL_POD_PHASES)
+
+#: Kubernetes namespace slug allowlist (RFC-1123 label subset). A namespace
+#: is optional on ``pods.gc``; when supplied it is bound to this pattern so
+#: the ``-n <ns>`` token cannot smuggle a flag or a shell metacharacter.
+_NAMESPACE_SAFE_RE: re.Pattern[str] = re.compile(r"[a-z0-9]([a-z0-9-]{0,61}[a-z0-9])?")
+
+#: The directory tree ``holodeck.backups.prune`` is confined to. Every
+#: resolved backup path must stay strictly within this prefix; a value that
+#: normalises to the directory itself, to an ancestor, or outside the tree
+#: (via ``..`` traversal or an absolute-path escape) is rejected.
+_BACKUPS_ROOT: str = "/var/backups"
+
+#: ``holodeck.images.import`` accepts only a seed-image tarball living
+#: directly under ``/root/containerd-images/`` with a ``.tar`` suffix. The
+#: single ``*`` is a filename glob, not a path separator -- a nested path or
+#: a traversal in the basename is rejected.
+_IMAGE_TAR_DIR: str = "/root/containerd-images"
+_IMAGE_TAR_BASENAME_RE: re.Pattern[str] = re.compile(r"[A-Za-z0-9._-]+\.tar")
+
+
+class HolodeckWriteSafetyError(ValueError):
+    """Raised when a write op's input escapes its declared bound.
+
+    Subclass of :class:`ValueError` so the dispatcher's
+    ``result_connector_error`` envelope picks it up uniformly. The message
+    names the offending category (phase / path / tar) without echoing the
+    full operator-supplied value back into user-visible surfaces.
+    """
+
+
+def _bound_phases(params: dict[str, Any]) -> list[str]:
+    """Resolve + validate the requested terminal phases for ``pods.gc``.
+
+    ``phases`` is optional; when omitted the op targets both terminal
+    phases (``Failed`` + ``Succeeded``). When supplied it must be a
+    non-empty list whose every element is in :data:`_TERMINAL_POD_PHASE_SET`.
+    Any other value -- a live phase (``Running``), a wildcard, a
+    non-string -- raises :exc:`HolodeckWriteSafetyError`. Returns the phases
+    in the canonical :data:`_TERMINAL_POD_PHASES` order so the composed
+    command is deterministic.
+    """
+    raw = params.get("phases")
+    if raw is None:
+        return list(_TERMINAL_POD_PHASES)
+    if not isinstance(raw, list) or not raw:
+        raise HolodeckWriteSafetyError(
+            "phases must be a non-empty list drawn from ('Failed', 'Succeeded')"
+        )
+    requested = set()
+    for phase in raw:
+        if not isinstance(phase, str) or phase not in _TERMINAL_POD_PHASE_SET:
+            raise HolodeckWriteSafetyError(
+                f"pods.gc targets only terminal phases; allowed: {sorted(_TERMINAL_POD_PHASE_SET)}"
+            )
+        requested.add(phase)
+    return [p for p in _TERMINAL_POD_PHASES if p in requested]
+
+
+def _bound_namespace(params: dict[str, Any]) -> str | None:
+    """Validate the optional ``namespace`` slug for ``pods.gc``.
+
+    Returns ``None`` (cluster-default namespace) when unset, or the slug
+    when it fully matches :data:`_NAMESPACE_SAFE_RE`. Any other shape raises
+    :exc:`HolodeckWriteSafetyError`.
+    """
+    namespace = params.get("namespace")
+    if namespace is None:
+        return None
+    if not isinstance(namespace, str) or not _NAMESPACE_SAFE_RE.fullmatch(namespace):
+        raise HolodeckWriteSafetyError(
+            "namespace must be an RFC-1123 label ([a-z0-9-], <=63 chars)"
+        )
+    return namespace
+
+
+def bound_backup_path(raw_path: Any) -> str:
+    """Return the canonical backup path, or raise if it escapes ``/var/backups``.
+
+    A backup path is accepted only when, after POSIX normalisation, it lies
+    **strictly inside** :data:`_BACKUPS_ROOT` -- i.e. its normalised form
+    starts with ``/var/backups/`` and is not the root directory itself. A
+    relative path is resolved against the root before normalisation, so
+    ``daily/db.sql.gz`` becomes ``/var/backups/daily/db.sql.gz``; a
+    traversal (``../etc/passwd``, ``daily/../../etc``) or an absolute escape
+    (``/etc/shadow``) normalises outside the tree and is rejected. The
+    returned path is *not* yet shell-quoted -- the caller quotes it.
+    """
+    if not isinstance(raw_path, str) or not raw_path.strip():
+        raise HolodeckWriteSafetyError("backup path must be a non-empty string")
+    candidate = raw_path if raw_path.startswith("/") else posixpath.join(_BACKUPS_ROOT, raw_path)
+    normalised = posixpath.normpath(candidate)
+    root_prefix = _BACKUPS_ROOT + "/"
+    if not normalised.startswith(root_prefix) or normalised == _BACKUPS_ROOT:
+        raise HolodeckWriteSafetyError(f"backup path must resolve strictly within {_BACKUPS_ROOT}/")
+    return normalised
+
+
+def bound_image_tar(raw_path: Any) -> str:
+    """Return the canonical seed-image tar path, or raise if out of bounds.
+
+    Accepts only a ``.tar`` file living directly under
+    :data:`_IMAGE_TAR_DIR`. The path is POSIX-normalised, its directory must
+    equal :data:`_IMAGE_TAR_DIR` exactly (no nesting, no traversal), and its
+    basename must match :data:`_IMAGE_TAR_BASENAME_RE`. Mirrors the
+    ``/root/containerd-images/*.tar`` glob bound from the issue. The
+    returned path is not yet shell-quoted.
+    """
+    if not isinstance(raw_path, str) or not raw_path.strip():
+        raise HolodeckWriteSafetyError("tar path must be a non-empty string")
+    normalised = posixpath.normpath(raw_path)
+    directory, basename = posixpath.split(normalised)
+    if directory != _IMAGE_TAR_DIR or not _IMAGE_TAR_BASENAME_RE.fullmatch(basename):
+        raise HolodeckWriteSafetyError(
+            f"tar path must match {_IMAGE_TAR_DIR}/*.tar (single .tar file, no nesting)"
+        )
+    return normalised
+
+
+# ---------------------------------------------------------------------------
+# Handlers (bound-method shims on HolodeckConnector, resume path only)
+# ---------------------------------------------------------------------------
+
+
+async def _run_text(self: HolodeckConnector, target: Any, cmd: str) -> dict[str, Any]:
+    """Run *cmd* over plain SSH, return ``{stdout, stderr, exit_status}``.
+
+    Shared thin layer for the three write handlers: run the (already-bounded,
+    already-quoted) command via the base adapter's ``_run_command`` and shape
+    the completed process into the connector's standard result envelope.
+    Stderr is capped at 4096 chars (the ``PwshRunError`` convention).
+    """
+    proc = await self._run_command(target, cmd, raw_jwt="")
+    stdout = (proc.stdout or "") if hasattr(proc, "stdout") else ""
+    stderr = (proc.stderr or "") if hasattr(proc, "stderr") else ""
+    if not isinstance(stdout, str):
+        stdout = ""
+    if not isinstance(stderr, str):
+        stderr = ""
+    if len(stderr) > 4096:
+        stderr = stderr[:4096]
+    return {
+        "stdout": stdout,
+        "stderr": stderr,
+        "exit_status": getattr(proc, "exit_status", None),
+    }
+
+
+async def holodeck_k8s_pods_gc(
+    self: HolodeckConnector,
+    target: Any,
+    params: dict[str, Any],
+) -> dict[str, Any]:
+    """Garbage-collect terminal (Failed / Succeeded) pods on the in-appliance K8s.
+
+    Op-id: ``holodeck.k8s.pods.gc``. Runs one
+    ``kubectl delete pods --field-selector status.phase=<phase>`` per
+    requested terminal phase (default: both ``Failed`` and ``Succeeded``).
+    There is **no** name, label-selector, or arbitrary-field surface -- the
+    only knobs are the terminal-phase set (validated against
+    :data:`_TERMINAL_POD_PHASE_SET`) and an optional bounded ``namespace``.
+    A phase outside the terminal set, or a malformed namespace, is rejected
+    before any SSH traffic.
+
+    Runs only on the ``_approved=True`` resume path (the op registers
+    ``requires_approval=True``). Returns one result per phase under
+    ``deletes`` plus the composed commands for auditability.
+    """
+    try:
+        phases = _bound_phases(params)
+        namespace = _bound_namespace(params)
+    except HolodeckWriteSafetyError as exc:
+        return {"deleted": False, "error": f"k8s.pods.gc safety check: {exc}"}
+
+    ns_arg = f" -n {shlex.quote(namespace)}" if namespace is not None else ""
+    deletes: list[dict[str, Any]] = []
+    try:
+        for phase in phases:
+            selector = shlex.quote(f"status.phase={phase}")
+            cmd = f"kubectl delete pods{ns_arg} --field-selector {selector}"
+            outcome = await _run_text(self, target, cmd)
+            deletes.append({"phase": phase, "command": cmd, **outcome})
+    except Exception as exc:
+        return {"deleted": False, "error": str(exc), "deletes": deletes}
+    return {"deleted": True, "phases": phases, "namespace": namespace, "deletes": deletes}
+
+
+async def holodeck_backups_prune(
+    self: HolodeckConnector,
+    target: Any,
+    params: dict[str, Any],
+) -> dict[str, Any]:
+    """Prune backups under ``/var/backups``, keeping the newest ``keep_newest``.
+
+    Op-id: ``holodeck.backups.prune``. *params*:
+
+    * ``keep_newest`` -- required int >= 1; how many newest entries to keep.
+    * ``path`` -- optional sub-path under ``/var/backups`` (default the root
+      itself). Every candidate is resolved via :func:`bound_backup_path`,
+      which rejects any value that escapes ``/var/backups/**`` (traversal or
+      absolute-path escape).
+
+    The prune lists the directory newest-first and removes everything past
+    the keep window. The pipeline is composed from bounded, shell-quoted
+    tokens; the directory listing runs under ``find`` with ``-maxdepth 1`` so
+    the prune never recurses into a subtree. Runs only on the
+    ``_approved=True`` resume path.
+    """
+    keep_newest = params.get("keep_newest")
+    if not isinstance(keep_newest, int) or isinstance(keep_newest, bool) or keep_newest < 1:
+        return {"pruned": False, "error": "keep_newest must be an integer >= 1"}
+
+    target_dir = params.get("path", _BACKUPS_ROOT)
+    if target_dir == _BACKUPS_ROOT:
+        resolved_dir = _BACKUPS_ROOT
+    else:
+        try:
+            resolved_dir = bound_backup_path(target_dir)
+        except HolodeckWriteSafetyError as exc:
+            return {"pruned": False, "error": f"backups.prune safety check: {exc}"}
+
+    quoted_dir = shlex.quote(resolved_dir)
+    # List regular files newest-first (mtime), drop the newest keep_newest,
+    # delete the rest. All tokens are literals or bounded/quoted; the ``+N``
+    # tail offset is 1-based, hence keep_newest + 1.
+    tail_from = keep_newest + 1
+    cmd = (
+        f"find {quoted_dir} -maxdepth 1 -type f -printf '%T@ %p\\n' "
+        f"| sort -rn | tail -n +{tail_from} | cut -d' ' -f2- "
+        f"| xargs -r -d '\\n' rm -f --"
+    )
+    try:
+        outcome = await _run_text(self, target, cmd)
+    except Exception as exc:
+        return {"pruned": False, "error": str(exc)}
+    return {
+        "pruned": True,
+        "directory": resolved_dir,
+        "keep_newest": keep_newest,
+        "command": cmd,
+        **outcome,
+    }
+
+
+async def holodeck_images_import(
+    self: HolodeckConnector,
+    target: Any,
+    params: dict[str, Any],
+) -> dict[str, Any]:
+    """Import a seed-image tarball into containerd's ``k8s.io`` namespace.
+
+    Op-id: ``holodeck.images.import``. Runs
+    ``ctr -n k8s.io images import <tar>`` where ``<tar>`` must match
+    ``/root/containerd-images/*.tar`` (validated via
+    :func:`bound_image_tar`). The ``-n k8s.io`` namespace makes the imported
+    image visible to kubelet. *params* carries ``tar_path``. Runs only on
+    the ``_approved=True`` resume path.
+    """
+    try:
+        tar_path = bound_image_tar(params.get("tar_path"))
+    except HolodeckWriteSafetyError as exc:
+        return {"imported": False, "error": f"images.import safety check: {exc}"}
+
+    cmd = f"ctr -n k8s.io images import {shlex.quote(tar_path)}"
+    try:
+        outcome = await _run_text(self, target, cmd)
+    except Exception as exc:
+        return {"imported": False, "error": str(exc)}
+    return {"imported": True, "tar_path": tar_path, "command": cmd, **outcome}
+
+
+# ---------------------------------------------------------------------------
+# Curated when_to_use blurbs (one per write op group)
+# ---------------------------------------------------------------------------
+
+_WHEN_TO_USE_K8S_WRITE = (
+    "Use to reclaim terminal (Failed / Succeeded) pods on the HoloRouter's "
+    "in-appliance K8s cluster: ``holodeck.k8s.pods.gc`` runs "
+    "``kubectl delete pods --field-selector status.phase=Failed`` (and "
+    "``=Succeeded``). It is approval-gated -- a dispatch parks for a human "
+    "to approve before anything is deleted -- and it CANNOT target a named "
+    "pod, a label selector, or a live phase (Running / Pending). The right "
+    "op when terminal-pod garbage is filling the node and the operator wants "
+    "a bounded cleanup, not an arbitrary ``kubectl delete``. " + SSH_TRANSPORT_NOTE
+)
+
+_WHEN_TO_USE_BACKUPS_WRITE = (
+    "Use to prune old backup artefacts under ``/var/backups`` on the "
+    "HoloRouter: ``holodeck.backups.prune keep_newest=N`` keeps the newest N "
+    "entries and removes the rest. Approval-gated. Every candidate path is "
+    "confined to ``/var/backups/**`` -- a traversal or absolute-path escape "
+    "is rejected before anything is removed. The right op when a backup-fill "
+    "outage needs disk reclaimed without hand-run root SSH. " + SSH_TRANSPORT_NOTE
+)
+
+_WHEN_TO_USE_IMAGES_WRITE = (
+    "Use to seed a container image into the HoloRouter's containerd from a "
+    "pre-staged tarball: ``holodeck.images.import tar_path=/root/"
+    "containerd-images/<name>.tar`` runs ``ctr -n k8s.io images import`` so "
+    "the image becomes visible to kubelet. Approval-gated; the tar path must "
+    "match ``/root/containerd-images/*.tar``. The right op when recovering a "
+    "cluster whose registry is unreachable and images must be side-loaded. " + SSH_TRANSPORT_NOTE
+)
+
+#: Curated ``when_to_use`` blurb per write op group. Keys carry a ``-write``
+#: suffix so they never collide with the read-op group keys the connector's
+#: ``register_operations`` walk merges alongside them.
+HOLODECK_WHEN_TO_USE_WRITE_BY_GROUP: dict[str, str] = {
+    "k8s-write": _WHEN_TO_USE_K8S_WRITE,
+    "backups-write": _WHEN_TO_USE_BACKUPS_WRITE,
+    "images-write": _WHEN_TO_USE_IMAGES_WRITE,
+}
+
+
+# ---------------------------------------------------------------------------
+# Op metadata
+# ---------------------------------------------------------------------------
+
+_WRITE_CONFIRM_SCHEMA: dict[str, Any] = {
+    "type": "object",
+    "additionalProperties": True,
+}
+
+
+WRITE_OPS: tuple[HolodeckOp, ...] = (
+    HolodeckOp(
+        op_id="holodeck.k8s.pods.gc",
+        handler_attr="k8s_pods_gc",
+        summary="Delete terminal (Failed/Succeeded) pods on the in-appliance K8s (approval-gated).",
+        description=(
+            "Runs ``kubectl delete pods --field-selector status.phase=Failed`` "
+            "and/or ``status.phase=Succeeded`` on the HoloRouter's "
+            "in-appliance Kubernetes cluster to reclaim terminal-pod garbage. "
+            "There is NO name, label-selector, or arbitrary-field surface: "
+            "the only inputs are the terminal-phase set (default both; each "
+            "element must be Failed or Succeeded) and an optional bounded "
+            "namespace. A live phase (Running/Pending) or a malformed "
+            "namespace is rejected before any SSH traffic. kubectl's "
+            "--field-selector supports only equality, so one delete runs per "
+            "phase. safety_level=dangerous, requires_approval=True -- parks "
+            "for human approval before deleting anything."
+        ),
+        parameter_schema={
+            "type": "object",
+            "properties": {
+                "phases": {
+                    "type": "array",
+                    "items": {"type": "string", "enum": list(_TERMINAL_POD_PHASES)},
+                    "minItems": 1,
+                    "uniqueItems": True,
+                    "description": (
+                        "Terminal pod phases to garbage-collect. Only "
+                        "'Failed' and 'Succeeded' are allowed; omit to target "
+                        "both. Running/Pending/Unknown are rejected."
+                    ),
+                },
+                "namespace": {
+                    "type": "string",
+                    "pattern": r"^[a-z0-9]([a-z0-9-]{0,61}[a-z0-9])?$",
+                    "description": (
+                        "Optional Kubernetes namespace to scope the GC to "
+                        "(RFC-1123 label). Omit for the cluster default."
+                    ),
+                },
+            },
+            "additionalProperties": False,
+        },
+        response_schema=_WRITE_CONFIRM_SCHEMA,
+        group_key="k8s-write",
+        tags=("write", "k8s", "kubectl", "gc", "holodeck"),
+        safety_level="dangerous",
+        requires_approval=True,
+        llm_instructions={
+            "when_to_use": _WHEN_TO_USE_K8S_WRITE,
+            "parameter_hints": {
+                "phases": "Omit to GC both Failed and Succeeded; never accepts Running.",
+                "namespace": "Optional; RFC-1123 label. Omit for the default namespace.",
+            },
+            "output_shape": (
+                "{deleted, phases, namespace, deletes: [{phase, command, "
+                "stdout, stderr, exit_status}]}. One deletes[] entry per "
+                "phase. On a bound violation: {deleted: false, error}."
+            ),
+        },
+    ),
+    HolodeckOp(
+        op_id="holodeck.backups.prune",
+        handler_attr="backups_prune",
+        summary="Prune old backups under /var/backups keeping newest-N (approval-gated).",
+        description=(
+            "Removes backup artefacts under /var/backups on the HoloRouter, "
+            "keeping the newest ``keep_newest`` entries (by mtime). An "
+            "optional ``path`` sub-directory is resolved and confined to "
+            "/var/backups/** -- any traversal or absolute-path escape is "
+            "rejected before anything is removed. The listing runs at "
+            "-maxdepth 1 so the prune never recurses into a subtree. "
+            "safety_level=dangerous, requires_approval=True -- parks for "
+            "human approval before deleting anything."
+        ),
+        parameter_schema={
+            "type": "object",
+            "properties": {
+                "keep_newest": {
+                    "type": "integer",
+                    "minimum": 1,
+                    "description": (
+                        "How many newest backup entries to KEEP; everything "
+                        "older is removed. Required."
+                    ),
+                },
+                "path": {
+                    "type": "string",
+                    "minLength": 1,
+                    "description": (
+                        "Optional sub-path under /var/backups (absolute or "
+                        "relative to it). Must resolve strictly within "
+                        "/var/backups/**. Omit to prune the root."
+                    ),
+                },
+            },
+            "required": ["keep_newest"],
+            "additionalProperties": False,
+        },
+        response_schema=_WRITE_CONFIRM_SCHEMA,
+        group_key="backups-write",
+        tags=("write", "backups", "prune", "holodeck"),
+        safety_level="dangerous",
+        requires_approval=True,
+        llm_instructions={
+            "when_to_use": _WHEN_TO_USE_BACKUPS_WRITE,
+            "parameter_hints": {
+                "keep_newest": "Count of newest entries to keep (>=1); the rest are removed.",
+                "path": "Optional; must stay within /var/backups/**. Omit to prune the root.",
+            },
+            "output_shape": (
+                "{pruned, directory, keep_newest, command, stdout, stderr, "
+                "exit_status}. On a bound violation: {pruned: false, error}."
+            ),
+        },
+    ),
+    HolodeckOp(
+        op_id="holodeck.images.import",
+        handler_attr="images_import",
+        summary="Import a seed-image tarball into containerd (k8s.io) (approval-gated).",
+        description=(
+            "Runs ``ctr -n k8s.io images import <tar>`` on the HoloRouter to "
+            "side-load a container image from a pre-staged tarball so kubelet "
+            "can see it. The tar path must match /root/containerd-images/*.tar "
+            "(single .tar file, no nesting, no traversal) -- any other path "
+            "is rejected before any SSH traffic. safety_level=dangerous, "
+            "requires_approval=True -- parks for human approval before "
+            "importing."
+        ),
+        parameter_schema={
+            "type": "object",
+            "properties": {
+                "tar_path": {
+                    "type": "string",
+                    "pattern": r"^/root/containerd-images/[A-Za-z0-9._-]+\.tar$",
+                    "description": (
+                        "Absolute path to the image tarball; must match "
+                        "/root/containerd-images/*.tar."
+                    ),
+                },
+            },
+            "required": ["tar_path"],
+            "additionalProperties": False,
+        },
+        response_schema=_WRITE_CONFIRM_SCHEMA,
+        group_key="images-write",
+        tags=("write", "images", "containerd", "ctr", "holodeck"),
+        safety_level="dangerous",
+        requires_approval=True,
+        llm_instructions={
+            "when_to_use": _WHEN_TO_USE_IMAGES_WRITE,
+            "parameter_hints": {
+                "tar_path": "Must be /root/containerd-images/<name>.tar; nothing else is accepted.",
+            },
+            "output_shape": (
+                "{imported, tar_path, command, stdout, stderr, exit_status}. "
+                "On a bound violation: {imported: false, error}."
+            ),
+        },
+    ),
+)

--- a/backend/tests/test_connectors_holodeck_auth.py
+++ b/backend/tests/test_connectors_holodeck_auth.py
@@ -203,12 +203,13 @@ def test_package_import_registers_v2_entry_only() -> None:
 
 def test_about_canary_op_remains_at_index_zero() -> None:
     """``holodeck.about`` is the T1 canary; T2 (#854) appends the 7 read ops
-    onto the same tuple while preserving the canary at index 0. The full T2
-    registration shape lives in ``test_connectors_holodeck_ops.py``.
+    and G3.18-T2 (#2154) the 3 write ops onto the same tuple while preserving
+    the canary at index 0. The full registration shape lives in
+    ``test_connectors_holodeck_ops.py`` / ``test_connectors_holodeck_write.py``.
     """
     assert HOLODECK_OPS[0].op_id == "holodeck.about"
     assert HOLODECK_OPS[0].handler_attr == "about"
-    assert len(HOLODECK_OPS) == 8
+    assert len(HOLODECK_OPS) == 11
 
 
 # ---------------------------------------------------------------------------

--- a/backend/tests/test_connectors_holodeck_e2e.py
+++ b/backend/tests/test_connectors_holodeck_e2e.py
@@ -490,16 +490,23 @@ async def holodeck_e2e(
 
 
 def test_holodeck_ops_registration_count() -> None:
-    """All 8 Holodeck ops are registered in HOLODECK_OPS."""
+    """All 8 read ops + 3 G3.18-T2 write ops = 11 ops registered in HOLODECK_OPS."""
     op_ids = {op.op_id for op in HOLODECK_OPS}
     missing = set(EXPECTED_OP_IDS) - op_ids
     assert not missing, f"Missing ops: {missing}"
-    assert len(HOLODECK_OPS) == 8, f"Expected 8 ops, got {len(HOLODECK_OPS)}"
+    assert len(HOLODECK_OPS) == 11, f"Expected 11 ops, got {len(HOLODECK_OPS)}"
 
 
-def test_holodeck_ops_all_safe_and_no_approval_required() -> None:
-    """All read ops carry safety_level='safe' and requires_approval=False."""
+def test_holodeck_read_ops_all_safe_and_no_approval_required() -> None:
+    """Every read op (EXPECTED_OP_IDS) carries safety_level='safe' and no approval.
+
+    The G3.18-T2 (#2154) write ops are dangerous / requires_approval=True and
+    are asserted in ``test_connectors_holodeck_write.py``.
+    """
+    read_ids = set(EXPECTED_OP_IDS)
     for op in HOLODECK_OPS:
+        if op.op_id not in read_ids:
+            continue
         assert op.safety_level == "safe", f"{op.op_id} should be safe"
         assert not op.requires_approval, f"{op.op_id} should not require approval"
 

--- a/backend/tests/test_connectors_holodeck_ops.py
+++ b/backend/tests/test_connectors_holodeck_ops.py
@@ -1066,18 +1066,11 @@ async def test_networking_show_isolates_sub_command_failures() -> None:
 # ---------------------------------------------------------------------------
 
 
-def test_holodeck_ops_has_eight_entries() -> None:
-    """T1 canary (about) + 7 T2 read ops = 8 total."""
-    assert len(HOLODECK_OPS) == 8
-
-
-def test_holodeck_ops_about_remains_at_index_zero() -> None:
-    assert HOLODECK_OPS[0].op_id == "holodeck.about"
-
-
-def test_holodeck_ops_covers_expected_op_ids() -> None:
-    op_ids = {op.op_id for op in HOLODECK_OPS}
-    expected = {
+#: The read-op ids (T1 canary + 7 T2 reads). The G3.18-T2 (#2154)
+#: approval-gated write ops are asserted separately in
+#: ``test_connectors_holodeck_write.py``.
+_READ_OP_IDS: frozenset[str] = frozenset(
+    {
         "holodeck.about",
         "holodeck.config.show",
         "holodeck.pod.list",
@@ -1087,6 +1080,25 @@ def test_holodeck_ops_covers_expected_op_ids() -> None:
         "holodeck.logs.tail",
         "holodeck.networking.show",
     }
+)
+
+
+def test_holodeck_ops_has_eleven_entries() -> None:
+    """T1 canary (about) + 7 T2 read ops + 3 G3.18-T2 write ops = 11 total."""
+    assert len(HOLODECK_OPS) == 11
+
+
+def test_holodeck_ops_about_remains_at_index_zero() -> None:
+    assert HOLODECK_OPS[0].op_id == "holodeck.about"
+
+
+def test_holodeck_ops_covers_expected_op_ids() -> None:
+    op_ids = {op.op_id for op in HOLODECK_OPS}
+    expected = set(_READ_OP_IDS) | {
+        "holodeck.k8s.pods.gc",
+        "holodeck.backups.prune",
+        "holodeck.images.import",
+    }
     assert op_ids == expected
 
 
@@ -1095,16 +1107,20 @@ def test_holodeck_ops_all_have_holodeck_namespace() -> None:
         assert op.op_id.startswith("holodeck."), f"{op.op_id!r} lacks holodeck. prefix"
 
 
-def test_holodeck_ops_all_safe() -> None:
+def test_holodeck_read_ops_all_safe() -> None:
     """Every T2 read op is read-only -- safety_level='safe' is mandatory."""
     for op in HOLODECK_OPS:
+        if op.op_id not in _READ_OP_IDS:
+            continue
         assert op.safety_level == "safe", (
-            f"{op.op_id!r} has safety_level={op.safety_level!r}; every T2 op must be safe"
+            f"{op.op_id!r} has safety_level={op.safety_level!r}; every read op must be safe"
         )
 
 
-def test_holodeck_ops_all_no_approval_required() -> None:
+def test_holodeck_read_ops_all_no_approval_required() -> None:
     for op in HOLODECK_OPS:
+        if op.op_id not in _READ_OP_IDS:
+            continue
         assert op.requires_approval is False, (
             f"{op.op_id!r} should not require approval -- reads only"
         )
@@ -1140,7 +1156,7 @@ def test_holodeck_ops_llm_instructions_mention_ssh_transport() -> None:
 
 
 def test_holodeck_ops_group_keys_include_new_groups() -> None:
-    """T2 introduces the config / pod / service / k8s / logs / networking groups."""
+    """T2 read groups + the G3.18-T2 (#2154) approval-gated write groups."""
     group_keys = {op.group_key for op in HOLODECK_OPS if op.group_key}
     assert {
         "identity",
@@ -1150,6 +1166,10 @@ def test_holodeck_ops_group_keys_include_new_groups() -> None:
         "k8s",
         "logs",
         "networking",
+        # G3.18-T2 (#2154) write groups (``-write`` suffix avoids collision).
+        "k8s-write",
+        "backups-write",
+        "images-write",
     } == group_keys
 
 

--- a/backend/tests/test_connectors_holodeck_write.py
+++ b/backend/tests/test_connectors_holodeck_write.py
@@ -1,0 +1,563 @@
+# SPDX-License-Identifier: Apache-2.0
+# Copyright (c) 2026 evoila Group
+
+"""Tests for the Holodeck approval-gated remediation write ops (G3.18-T2 #2154).
+
+Coverage matrix (per Task #2154 acceptance criteria):
+
+* ``WRITE_OPS`` registration shape -- three ops, all
+  ``safety_level='dangerous'`` + ``requires_approval=True``, all carry the
+  ``write`` tag and the SSH-only transport note.
+* Input bounds (pure, no event loop):
+  - ``holodeck.k8s.pods.gc`` -- rejects a named pod / label selector /
+    non-terminal phase; accepts only Failed / Succeeded; composes one
+    ``kubectl delete pods --field-selector status.phase=<phase>`` per phase.
+  - ``holodeck.backups.prune`` -- rejects any path resolving outside
+    ``/var/backups/**`` (traversal + absolute escape); honours an explicit
+    ``keep_newest`` int.
+  - ``holodeck.images.import`` -- rejects any tar path not matching
+    ``/root/containerd-images/*.tar``.
+* Handler happy-path + rejected-input (mocked ``_run_command``): a bound
+  violation fails closed with an error envelope and NO SSH traffic.
+* Dispatch park -> approve -> execute -> audit (recorded fake-shell SSH
+  harness): an un-approved USER dispatch parks (``awaiting_approval``,
+  handler never runs); the ``_approved=True`` resume path runs the handler
+  and writes a ``DISPATCH`` audit row.
+* shlex-quoting canary: a namespace/path token never reaches the composed
+  command unquoted.
+"""
+
+from __future__ import annotations
+
+import asyncio
+import types
+import uuid
+from collections.abc import AsyncIterator, Iterator
+from dataclasses import dataclass
+from typing import Any
+from unittest.mock import AsyncMock, MagicMock, patch
+
+import asyncssh
+import jsonschema
+import pytest
+from sqlalchemy import select
+
+import meho_backplane.connectors.holodeck  # noqa: F401 -- import for registry side-effects
+from meho_backplane.auth.operator import Operator, TenantRole
+from meho_backplane.connectors.holodeck import HolodeckConnector
+from meho_backplane.connectors.holodeck.ops_write import (
+    WRITE_OPS,
+    HolodeckWriteSafetyError,
+    bound_backup_path,
+    bound_image_tar,
+)
+from meho_backplane.db.engine import get_sessionmaker
+from meho_backplane.db.models import AuditLog
+from meho_backplane.db.models import Target as TargetORM
+from meho_backplane.operations import dispatch, reset_dispatcher_caches
+from meho_backplane.operations.dispatcher import set_default_reducer
+from meho_backplane.operations.reducer import PassThroughReducer
+from meho_backplane.settings import get_settings
+from meho_backplane.targets.resolver import resolve_target
+
+# ---------------------------------------------------------------------------
+# Environment fixture
+# ---------------------------------------------------------------------------
+
+
+@pytest.fixture(autouse=True)
+def _required_settings_env(monkeypatch: pytest.MonkeyPatch) -> Iterator[None]:
+    monkeypatch.setenv("KEYCLOAK_ISSUER_URL", "https://keycloak.test/realms/meho")
+    monkeypatch.setenv("KEYCLOAK_AUDIENCE", "meho-backplane")
+    monkeypatch.setenv("VAULT_ADDR", "https://vault.test")
+    get_settings.cache_clear()
+    yield
+    get_settings.cache_clear()
+
+
+# ---------------------------------------------------------------------------
+# Stub target for the unit-level handler tests
+# ---------------------------------------------------------------------------
+
+
+@dataclass
+class _StubTarget:
+    name: str
+    host: str
+    port: int | None
+    secret_ref: dict[str, Any]
+
+
+_TARGET = _StubTarget(
+    name="holorouter-write-test",
+    host="holorouter.test.invalid",
+    port=22,
+    secret_ref={"username": "root", "password": "write-canary-pw"},  # NOSONAR canary
+)
+
+
+def _proc(*, stdout: str = "", stderr: str = "", exit_status: int = 0) -> Any:
+    proc = MagicMock()
+    proc.stdout = stdout
+    proc.stderr = stderr
+    proc.exit_status = exit_status
+    return proc
+
+
+# ---------------------------------------------------------------------------
+# Registration contract (acceptance criterion 1)
+# ---------------------------------------------------------------------------
+
+EXPECTED_WRITE_OP_IDS: frozenset[str] = frozenset(
+    {"holodeck.k8s.pods.gc", "holodeck.backups.prune", "holodeck.images.import"}
+)
+
+
+def test_write_ops_registration_set() -> None:
+    assert {op.op_id for op in WRITE_OPS} == EXPECTED_WRITE_OP_IDS
+    assert len(WRITE_OPS) == 3
+
+
+def test_write_ops_are_dangerous_and_require_approval() -> None:
+    for op in WRITE_OPS:
+        assert op.safety_level == "dangerous", f"{op.op_id} must be dangerous"
+        assert op.requires_approval is True, f"{op.op_id} must require approval"
+        assert "write" in op.tags, f"{op.op_id} should carry the write tag"
+
+
+def test_write_ops_carry_transport_note_and_instructions() -> None:
+    for op in WRITE_OPS:
+        instr = op.llm_instructions or {}
+        assert "Holodeck has no REST API" in instr.get("when_to_use", "")
+        assert instr.get("output_shape"), f"{op.op_id} missing output_shape"
+
+
+# ---------------------------------------------------------------------------
+# Bounds -- backups.prune path safety (acceptance criterion 3)
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.parametrize(
+    "path",
+    [
+        "/var/backups/daily/db.sql.gz",
+        "daily/db.sql.gz",
+        "/var/backups/a/b/c.tar",
+    ],
+)
+def test_bound_backup_path_accepts_inside_tree(path: str) -> None:
+    resolved = bound_backup_path(path)
+    assert resolved.startswith("/var/backups/")
+
+
+@pytest.mark.parametrize(
+    "path",
+    [
+        "/etc/shadow",  # absolute escape
+        "../etc/passwd",  # relative traversal
+        "/var/backups/../etc/passwd",  # traversal via the prefix
+        "daily/../../etc",  # nested traversal
+        "/var/backups",  # the root itself, not a child
+        "/var/backups/",  # normalises to the root
+        "",  # empty
+        "   ",  # whitespace-only
+    ],
+)
+def test_bound_backup_path_rejects_escape(path: str) -> None:
+    with pytest.raises(HolodeckWriteSafetyError):
+        bound_backup_path(path)
+
+
+def test_bound_backup_path_rejects_non_string() -> None:
+    with pytest.raises(HolodeckWriteSafetyError):
+        bound_backup_path(None)
+
+
+# ---------------------------------------------------------------------------
+# Bounds -- images.import tar path safety (acceptance criterion 4)
+# ---------------------------------------------------------------------------
+
+
+def test_bound_image_tar_accepts_matching_path() -> None:
+    assert bound_image_tar("/root/containerd-images/pause.tar") == (
+        "/root/containerd-images/pause.tar"
+    )
+
+
+@pytest.mark.parametrize(
+    "path",
+    [
+        "/tmp/x.tar",  # wrong directory
+        "/root/containerd-images/sub/x.tar",  # nested
+        "/root/containerd-images/../../etc/x.tar",  # traversal
+        "/root/containerd-images/x.txt",  # wrong suffix
+        "/root/containerd-images/",  # no basename
+        "relative.tar",  # not absolute / wrong dir
+        "",
+    ],
+)
+def test_bound_image_tar_rejects_out_of_bounds(path: str) -> None:
+    with pytest.raises(HolodeckWriteSafetyError):
+        bound_image_tar(path)
+
+
+# ---------------------------------------------------------------------------
+# Schema-layer bounds -- pods.gc (acceptance criterion 2)
+# ---------------------------------------------------------------------------
+
+
+def _op(op_id: str) -> Any:
+    return next(op for op in WRITE_OPS if op.op_id == op_id)
+
+
+@pytest.mark.parametrize(
+    "params",
+    [
+        {},
+        {"phases": ["Failed"]},
+        {"phases": ["Failed", "Succeeded"]},
+        {"phases": ["Succeeded"], "namespace": "holodeck"},
+    ],
+)
+def test_pods_gc_schema_accepts_valid(params: dict[str, Any]) -> None:
+    jsonschema.validate(params, _op("holodeck.k8s.pods.gc").parameter_schema)
+
+
+@pytest.mark.parametrize(
+    "params",
+    [
+        {"phases": ["Running"]},  # live phase
+        {"phases": ["Pending"]},
+        {"phases": []},  # empty
+        {"namespace": "Bad_NS"},  # not RFC-1123
+        {"name": "my-pod"},  # naming a pod -> additionalProperties=False
+        {"selector": "app=x"},  # label selector -> additionalProperties=False
+    ],
+)
+def test_pods_gc_schema_rejects_invalid(params: dict[str, Any]) -> None:
+    with pytest.raises(jsonschema.ValidationError):
+        jsonschema.validate(params, _op("holodeck.k8s.pods.gc").parameter_schema)
+
+
+# ---------------------------------------------------------------------------
+# Handler-layer -- pods.gc (authoritative gate, mocked SSH)
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.asyncio
+async def test_pods_gc_default_deletes_both_terminal_phases() -> None:
+    connector = HolodeckConnector()
+    with patch.object(connector, "_run_command", new_callable=AsyncMock) as mock_cmd:
+        mock_cmd.return_value = _proc(stdout='pod "x" deleted\n')
+        result = await connector.k8s_pods_gc(_TARGET, {})
+    assert result["deleted"] is True
+    assert result["phases"] == ["Failed", "Succeeded"]
+    cmds = [call.args[1] for call in mock_cmd.await_args_list]
+    # shlex.quote leaves 'status.phase=Failed' unquoted (no shell-special
+    # chars), which is correct and injection-safe -- the token is a fixed
+    # allowlisted selector, not operator input.
+    assert cmds == [
+        "kubectl delete pods --field-selector status.phase=Failed",
+        "kubectl delete pods --field-selector status.phase=Succeeded",
+    ]
+
+
+@pytest.mark.asyncio
+async def test_pods_gc_namespace_is_quoted() -> None:
+    connector = HolodeckConnector()
+    with patch.object(connector, "_run_command", new_callable=AsyncMock) as mock_cmd:
+        mock_cmd.return_value = _proc()
+        await connector.k8s_pods_gc(_TARGET, {"phases": ["Failed"], "namespace": "holodeck"})
+    cmd = mock_cmd.await_args.args[1]
+    assert cmd == "kubectl delete pods -n holodeck --field-selector status.phase=Failed"
+
+
+@pytest.mark.asyncio
+async def test_pods_gc_handler_rejects_non_terminal_phase() -> None:
+    connector = HolodeckConnector()
+    with patch.object(connector, "_run_command", new_callable=AsyncMock) as mock_cmd:
+        result = await connector.k8s_pods_gc(_TARGET, {"phases": ["Running"]})
+        mock_cmd.assert_not_awaited()
+    assert result["deleted"] is False
+    assert "safety check" in result["error"]
+
+
+# ---------------------------------------------------------------------------
+# Handler-layer -- backups.prune (mocked SSH)
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.asyncio
+async def test_backups_prune_happy_path_composes_bounded_command() -> None:
+    connector = HolodeckConnector()
+    with patch.object(connector, "_run_command", new_callable=AsyncMock) as mock_cmd:
+        mock_cmd.return_value = _proc(stdout="")
+        result = await connector.backups_prune(_TARGET, {"keep_newest": 3})
+    assert result["pruned"] is True
+    assert result["keep_newest"] == 3
+    assert result["directory"] == "/var/backups"
+    cmd = mock_cmd.await_args.args[1]
+    assert cmd.startswith("find /var/backups -maxdepth 1 -type f")
+    assert "tail -n +4" in cmd  # keep_newest + 1
+
+
+@pytest.mark.asyncio
+async def test_backups_prune_rejects_out_of_tree_path() -> None:
+    connector = HolodeckConnector()
+    with patch.object(connector, "_run_command", new_callable=AsyncMock) as mock_cmd:
+        result = await connector.backups_prune(_TARGET, {"keep_newest": 2, "path": "../etc"})
+        mock_cmd.assert_not_awaited()
+    assert result["pruned"] is False
+    assert "safety check" in result["error"]
+
+
+@pytest.mark.asyncio
+@pytest.mark.parametrize("bad", [0, -1, "3", 2.5, True, None])
+async def test_backups_prune_rejects_bad_keep_newest(bad: Any) -> None:
+    connector = HolodeckConnector()
+    with patch.object(connector, "_run_command", new_callable=AsyncMock) as mock_cmd:
+        result = await connector.backups_prune(_TARGET, {"keep_newest": bad})
+        mock_cmd.assert_not_awaited()
+    assert result["pruned"] is False
+
+
+# ---------------------------------------------------------------------------
+# Handler-layer -- images.import (mocked SSH)
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.asyncio
+async def test_images_import_happy_path() -> None:
+    connector = HolodeckConnector()
+    with patch.object(connector, "_run_command", new_callable=AsyncMock) as mock_cmd:
+        mock_cmd.return_value = _proc(stdout="unpacking ... done\n")
+        result = await connector.images_import(
+            _TARGET, {"tar_path": "/root/containerd-images/pause.tar"}
+        )
+    assert result["imported"] is True
+    cmd = mock_cmd.await_args.args[1]
+    assert cmd == "ctr -n k8s.io images import /root/containerd-images/pause.tar"
+
+
+@pytest.mark.asyncio
+async def test_images_import_rejects_bad_tar_path() -> None:
+    connector = HolodeckConnector()
+    with patch.object(connector, "_run_command", new_callable=AsyncMock) as mock_cmd:
+        result = await connector.images_import(_TARGET, {"tar_path": "/tmp/evil.tar"})
+        mock_cmd.assert_not_awaited()
+    assert result["imported"] is False
+    assert "safety check" in result["error"]
+
+
+# ===========================================================================
+# Dispatch park -> approve -> execute -> audit (recorded fake-shell SSH)
+# ===========================================================================
+
+_SERVER_KEY = asyncssh.generate_private_key("ssh-ed25519")
+_CLIENT_KEY = asyncssh.generate_private_key("ssh-ed25519")
+_CLIENT_PUB = _CLIENT_KEY.convert_to_public()
+
+_CONNECTOR_ID = "holodeck-ssh-9.0"
+_TARGET_NAME = "holodeck-write-e2e"
+_OPERATOR_TENANT_ID = uuid.UUID("00000000-0000-0000-0000-0000000021ba")
+_OPERATOR = Operator(
+    sub="holodeck-write-e2e-test",
+    name="Holodeck Write E2E Operator",
+    email=None,
+    raw_jwt="<holodeck-write-e2e-raw-jwt>",
+    tenant_id=_OPERATOR_TENANT_ID,
+    tenant_role=TenantRole.TENANT_ADMIN,
+)
+
+#: The fake-shell returns a canned line for every write command shape the
+#: e2e exercises. Keyed by the full command string (all write ops use plain
+#: SSH, no pwsh wrapping).
+_PLAIN_SSH_FIXTURES: dict[str, str] = {
+    "kubectl delete pods --field-selector status.phase=Failed": 'pod "a" deleted\n',
+    "kubectl delete pods --field-selector status.phase=Succeeded": 'pod "b" deleted\n',
+    "ctr -n k8s.io images import /root/containerd-images/pause.tar": "unpacking done\n",
+}
+
+
+class _FakeShellSSHServer(asyncssh.SSHServer):
+    def public_key_auth_supported(self) -> bool:
+        return True
+
+    def validate_public_key(self, username: str, key: Any) -> bool:  # type: ignore[override]
+        return bool(key == _CLIENT_PUB)
+
+
+async def _fake_shell_process_factory(process: Any) -> None:
+    cmd: str = process.command or ""
+    response = _PLAIN_SSH_FIXTURES.get(cmd)
+    if response is not None:
+        process.stdout.write(response)
+        process.exit(0)
+        return
+    # backups.prune composes a find|sort|... pipeline; accept any such shape.
+    if cmd.startswith("find /var/backups -maxdepth 1 -type f"):
+        process.stdout.write("")
+        process.exit(0)
+        return
+    process.stderr.write(f"fake-shell: unknown command: {cmd!r}\n")
+    process.exit(127)
+
+
+@pytest.fixture(scope="module")
+def event_loop_policy() -> asyncio.DefaultEventLoopPolicy:
+    return asyncio.DefaultEventLoopPolicy()
+
+
+@pytest.fixture
+async def fake_shell_server() -> AsyncIterator[types.SimpleNamespace]:
+    srv = await asyncssh.create_server(
+        _FakeShellSSHServer,
+        "127.0.0.1",
+        0,
+        server_host_keys=[_SERVER_KEY],
+        process_factory=_fake_shell_process_factory,
+    )
+    port: int = srv.sockets[0].getsockname()[1]
+    yield types.SimpleNamespace(host="127.0.0.1", port=port)
+    srv.close()
+    await srv.wait_closed()
+
+
+@pytest.fixture(autouse=True)
+def _reset_module_state() -> Iterator[None]:
+    reset_dispatcher_caches()
+    yield
+    reset_dispatcher_caches()
+
+
+async def _seed_target(host: str, port: int) -> TargetORM:
+    sessionmaker = get_sessionmaker()
+    async with sessionmaker() as session:
+        target = TargetORM(
+            tenant_id=_OPERATOR_TENANT_ID,
+            name=_TARGET_NAME,
+            aliases=[],
+            product="holodeck",
+            host=host,
+            port=port,
+            fqdn=None,
+            secret_ref="kv/dev/holodeck/write-e2e",
+            auth_model="shared_service_account",
+            vpn_required=False,
+            extras={},
+            fingerprint={"version": "9.0.0"},
+            notes="seeded by test_connectors_holodeck_write",
+        )
+        session.add(target)
+        await session.commit()
+        await session.refresh(target)
+        session.expunge(target)
+        return target
+
+
+def _wire_seeded_connector() -> HolodeckConnector:
+    class _SeededHolodeckConnector(HolodeckConnector):  # type: ignore[misc]
+        async def _auth_config(self, target: Any) -> dict[str, Any]:
+            return {"username": "root", "client_keys": [_CLIENT_KEY], "known_hosts": None}
+
+    instance = _SeededHolodeckConnector()
+    from meho_backplane.operations._handler_resolve import _CONNECTOR_INSTANCE_CACHE
+
+    _CONNECTOR_INSTANCE_CACHE[HolodeckConnector] = instance  # type: ignore[assignment]
+    return instance
+
+
+@pytest.fixture
+async def holodeck_write_e2e(
+    fake_shell_server: types.SimpleNamespace,
+) -> AsyncIterator[HolodeckConnector]:
+    set_default_reducer(PassThroughReducer())
+    await HolodeckConnector.register_operations()
+    await _seed_target(fake_shell_server.host, fake_shell_server.port)
+    connector = _wire_seeded_connector()
+    yield connector
+    await connector.aclose()
+
+
+async def _dispatch(op_id: str, params: dict[str, Any], *, approved: bool) -> dict[str, Any]:
+    """Dispatch a write op. ``approved=False`` hits the policy gate (parks);
+    ``approved=True`` is the approvals-API resume path that runs the handler."""
+    sessionmaker = get_sessionmaker()
+    async with sessionmaker() as session:
+        resolved_target = await resolve_target(session, _OPERATOR.tenant_id, _TARGET_NAME)
+    result = await dispatch(
+        operator=_OPERATOR,
+        connector_id=_CONNECTOR_ID,
+        op_id=op_id,
+        target=resolved_target,
+        params=params,
+        _approved=approved,
+    )
+    dumped: dict[str, Any] = result.model_dump(mode="json")
+    return dumped
+
+
+@pytest.mark.asyncio
+async def test_write_op_parks_for_user_not_hard_deny(
+    holodeck_write_e2e: HolodeckConnector,
+) -> None:
+    """An un-approved USER dispatch parks in the approve-queue (not denied, not run)."""
+    result = await _dispatch("holodeck.k8s.pods.gc", {"phases": ["Failed"]}, approved=False)
+    assert result["status"] == "awaiting_approval", result
+    assert result.get("extras", {}).get("approval_request_id")
+
+
+@pytest.mark.asyncio
+async def test_pods_gc_approved_executes_and_writes_audit_row(
+    holodeck_write_e2e: HolodeckConnector,
+) -> None:
+    """The _approved=True resume path runs the handler and writes a DISPATCH audit row."""
+    op_id = "holodeck.k8s.pods.gc"
+    sessionmaker = get_sessionmaker()
+
+    async def _count() -> int:
+        async with sessionmaker() as session:
+            rows = await session.execute(
+                select(AuditLog).where(AuditLog.method == "DISPATCH", AuditLog.path == op_id)
+            )
+            return len(list(rows.scalars().all()))
+
+    baseline = await _count()
+    result = await _dispatch(op_id, {"phases": ["Failed", "Succeeded"]}, approved=True)
+    assert result["status"] == "ok", result.get("error")
+    assert result["result"]["deleted"] is True
+    assert await _count() == baseline + 1
+
+    async with sessionmaker() as session:
+        rows = await session.execute(
+            select(AuditLog)
+            .where(AuditLog.method == "DISPATCH", AuditLog.path == op_id)
+            .order_by(AuditLog.occurred_at.desc())
+            .limit(1)
+        )
+        row = rows.scalar_one()
+    assert row.target_id is not None
+    assert row.payload.get("op_id") == op_id
+    assert row.payload.get("params_hash")
+
+
+@pytest.mark.asyncio
+async def test_images_import_approved_executes(
+    holodeck_write_e2e: HolodeckConnector,
+) -> None:
+    result = await _dispatch(
+        "holodeck.images.import",
+        {"tar_path": "/root/containerd-images/pause.tar"},
+        approved=True,
+    )
+    assert result["status"] == "ok", result.get("error")
+    assert result["result"]["imported"] is True
+
+
+@pytest.mark.asyncio
+async def test_backups_prune_approved_executes(
+    holodeck_write_e2e: HolodeckConnector,
+) -> None:
+    result = await _dispatch("holodeck.backups.prune", {"keep_newest": 3}, approved=True)
+    assert result["status"] == "ok", result.get("error")
+    assert result["result"]["pruned"] is True

--- a/docs/codebase/connectors-holodeck.md
+++ b/docs/codebase/connectors-holodeck.md
@@ -240,6 +240,50 @@ disclosure (CLAUDE.md postulate 5 + Initiative #371).
   when its sub-command failed or produced empty output, so a single-
   component failure doesn't blank the whole response.
 
+### Write ops (G3.18-T2 surface, approval-gated)
+
+`ops_write.py` (module `WRITE_OPS`, appended to `HOLODECK_OPS` via
+`_holodeck_ops()`) adds three **remediation** write ops. Every one registers
+`safety_level="dangerous"`, `requires_approval=True`. The `requires_approval`
+flag is the *only* thing the connector controls: the dispatcher's
+`policy_gate` routes a USER-principal dispatch of such an op to the human
+approve-queue (`awaiting_approval`) rather than executing or hard-denying it,
+and floors an agent dispatch there too. The handler bodies run only on the
+`_approved=True` resume path; the `DISPATCH` audit row is written by the
+dispatcher on that execute path (the same row every op gets).
+
+Each handler validates its inputs against a fixed allowlist and **rejects
+before composing** the command, then `shlex.quote`s every interpolated
+token — the same reject-then-compose posture as `_COMPONENT_SAFE_RE` /
+`parse_kubectl_command`. `bound_backup_path` / `bound_image_tar` are the pure
+path-bounding helpers (unit-tested directly).
+
+- **`holodeck.k8s.pods.gc`** (group `k8s-write`). Runs one
+  `kubectl delete pods --field-selector status.phase=<phase>` per requested
+  terminal phase. The only inputs are the terminal-phase set (each element
+  must be `Failed` or `Succeeded`; default both) and an optional bounded
+  `namespace` (RFC-1123 label). There is **no** name, label-selector, or
+  arbitrary-field surface, so a live phase (`Running`/`Pending`) or a named
+  pod cannot be targeted. Note: kubectl's `--field-selector` supports only
+  `=`/`==`/`!=`, not the set-based `in (...)` operator (that exists only for
+  the label `--selector`), so the issue table's `status.phase in
+  (Failed,Succeeded)` shorthand is realised as one equality delete per
+  terminal phase — same bound, valid syntax.
+- **`holodeck.backups.prune`** (group `backups-write`). Removes backup
+  artefacts under `/var/backups`, keeping the newest `keep_newest` (explicit
+  int, required). An optional `path` sub-directory is resolved via
+  `bound_backup_path`, which rejects any value that escapes `/var/backups/**`
+  (relative/absolute traversal, or the root itself). The listing runs at
+  `find -maxdepth 1` so the prune never recurses into a subtree.
+- **`holodeck.images.import`** (group `images-write`). Runs
+  `ctr -n k8s.io images import <tar>` to side-load an image so kubelet sees
+  it. `tar_path` must match `/root/containerd-images/*.tar` (single `.tar`
+  file, no nesting/traversal), validated via `bound_image_tar`.
+
+These three retire the recovery fallback where the VCF-9.x backup-fill outage
+(Initiative #2145) was fixed by hand-run local root SSH with no MEHO audit
+row.
+
 ### `execute(target, op_id, params)`
 
 Same dispatcher shim shape as bind9 and pfSense:


### PR DESCRIPTION
## Summary
- Adds three tightly-bounded, **approval-gated** remediation write ops to the `holodeck-ssh` connector in a new `ops_write.py` module (`WRITE_OPS`, appended to the `HOLODECK_OPS` registration walk), following the argocd/keycloak `ops_write` mold. Op count for `connector_id="holodeck-ssh-9.0"` rises 8 → 11.
- All three are `safety_level="dangerous"`, `requires_approval=True` — the flag is the only thing the connector controls; the dispatcher `policy_gate` parks a USER dispatch to `needs-approval`, handler bodies run only on the `_approved=True` resume path, and the `DISPATCH` audit row is written by the dispatcher on execute.
- Each handler validates inputs against a fixed allowlist and **rejects before composing** the command, then `shlex.quote`s every interpolated token (same posture as `_COMPONENT_SAFE_RE` / `parse_kubectl_command`).
- Retires the recovery fallback where the VCF-9.x backup-fill outage (#2145) was fixed by hand-run local root SSH with no MEHO audit row.

| op_id | action | bound |
|---|---|---|
| `holodeck.k8s.pods.gc` | `kubectl delete pods --field-selector status.phase=Failed` / `=Succeeded` | terminal phases only; no name / label / live-phase surface |
| `holodeck.backups.prune` | keep newest-N under `/var/backups` | every resolved path bound to `/var/backups/**`; `keep_newest` explicit int |
| `holodeck.images.import` | `ctr -n k8s.io images import <tar>` | tar path must match `/root/containerd-images/*.tar` |

### Design note (factual correction to the issue table)
kubectl's `--field-selector` supports only `=`/`==`/`!=`, **not** the set-based `in (...)` operator the issue table used as shorthand (that operator exists only for the label `--selector`). `pods.gc` therefore runs one equality delete per terminal phase — same bound (only `Failed`/`Succeeded`), valid syntax. Documented in the module docstring + `docs/codebase/connectors-holodeck.md`. Ref: https://kubernetes.io/docs/reference/kubectl/generated/kubectl_delete/

## Test plan
- [x] `ruff check` / `ruff format --check` — clean
- [x] `mypy src/meho_backplane/connectors/holodeck/` — clean (6 files)
- [x] `pytest` holodeck suite — 273 passed
- [x] pods.gc rejects a named pod / label selector / non-terminal phase (schema + handler layers)
- [x] backups.prune rejects any path resolving outside `/var/backups/**` (traversal + absolute-escape); honours explicit `keep_newest` int
- [x] images.import rejects any tar not matching `/root/containerd-images/*.tar`
- [x] park→approve→execute→audit: un-approved USER dispatch parks (`awaiting_approval`, handler never runs); `_approved=True` runs the handler and writes a `DISPATCH` audit row
- [x] code-quality `--diff` — 0 blockers (pre-existing connector.py file-size / fingerprint / probe debt carries a scoped `code-quality-allow`)
- [x] `cd cli && make snapshot-openapi && make generate` — no snapshot drift (ops dispatch via the operations meta-tools, not per-op FastAPI routes)

## Out of scope
- A generic shell / `exec` write op (explicitly excluded — undermines typed governance).
- `holodeck.disk.usage` read op (G3.18-T1 #2145).
- Approval-queue infrastructure (G11.7 #1397/#1401 already shipped the routing).

<!-- auto-implement-issue: fresh, iteration 1 -->

Closes #2154
