### PR TITLE
fix(ui): attach topology graph ?selected listener before layout run (#142)

### DIFF
--- a/backend/src/meho_backplane/ui/static/src/app/topology-graph.js
+++ b/backend/src/meho_backplane/ui/static/src/app/topology-graph.js
@@ -281,14 +281,19 @@
     const selectedId = typeof selectedRaw === "string" && selectedRaw.length > 0 ? selectedRaw : null;
     const pathNodeIds = readJsonIsland("topology-graph-path-nodes") || [];
 
+    // Construct WITHOUT the ``layout`` option so no layout runs during
+    // ``cytoscape({...})``. The initial layout is run explicitly below,
+    // AFTER the ``?selected`` cross-link ``layoutstop`` listener is
+    // attached. A constructor-supplied ``layout`` with ``animate:false``
+    // completes synchronously inside the constructor call (cose-bilkent
+    // repositions nodes via cytoscape's non-animated ``layoutPositions``,
+    // which emits ``layoutstop`` in the same tick), so any listener
+    // attached on the returned instance would miss it -- the cross-link
+    // handler never fired (#142).
     const cy = window.cytoscape({
       container: container,
       elements: elements,
       style: buildStyle().concat(buildOverlayStyle()),
-      // Initial render uses the default layout shape -- fit-to-canvas
-      // + randomized starting positions so cose-bilkent finds a clean
-      // arrangement for first-seen data.
-      layout: layoutOptions("cose-bilkent", false),
       wheelSensitivity: 0.2,
       minZoom: 0.1,
       maxZoom: 4,
@@ -336,9 +341,12 @@
 
     // Cross-link from the table: if the page arrived with
     // ``?selected=<id>``, center + visually select that node + open
-    // its drawer once the layout is settled. ``layoutstop`` fires
-    // after the initial cose-bilkent pass so the node has a final
-    // position to center on.
+    // its drawer once the layout is settled. The listener MUST be
+    // registered BEFORE the initial layout runs (below): a
+    // ``animate:false`` cose-bilkent pass emits ``layoutstop`` in the
+    // same synchronous turn as ``layout.run()``, so a listener attached
+    // afterwards would never fire (#142). ``layoutstop`` gives the node
+    // a final position to center on.
     if (selectedId) {
       cy.one("layoutstop", function () {
         const node = cy.getElementById(selectedId);
@@ -349,6 +357,13 @@
         }
       });
     }
+
+    // Run the initial layout now that every init-time listener --
+    // including the ``?selected`` cross-link ``layoutstop`` handler
+    // above -- is attached. Same shape as the old constructor
+    // ``layout`` option: fit-to-canvas + randomized starting positions
+    // so cose-bilkent finds a clean arrangement for first-seen data.
+    cy.layout(layoutOptions("cose-bilkent", false)).run();
 
     // ----- G10.5-T3 (#882) polling-refresh handler -----
     //

--- a/backend/tests/test_ui_topology_graph.py
+++ b/backend/tests/test_ui_topology_graph.py
@@ -670,6 +670,68 @@ def test_graph_selected_id_round_trips_into_data_island() -> None:
     assert payload == str(node_id)
 
 
+def test_graph_selected_id_round_trips_into_show_in_table_link() -> None:
+    """``?selected=<id>`` round-trips into the "Show in table" header link (AC#4).
+
+    On arrival at ``?view=graph&selected=<id>`` the server-rendered
+    "Show in table" cross-link must already carry ``&selected=<id>`` so
+    a click takes the operator to the matching table row without a JS
+    round-trip. The client-side ``updateTableLink`` keeps it in sync on
+    subsequent taps, but the *arrival* link is a server concern.
+    """
+    _seed_tenant_row(_TENANT_A, "tenant-a")
+    node_id = _seed_node(tenant_id=_TENANT_A, kind="vm", name="vm-target")
+
+    session_id = _seed_session_sync(tenant_id=_TENANT_A)
+    with respx.mock(assert_all_called=False):
+        client = _authenticated_client(session_id)
+        response = client.get(f"/ui/topology?view=graph&selected={node_id}")
+    assert response.status_code == 200, response.text
+    assert "/ui/topology?view=table" in response.text
+    assert f"&selected={node_id}" in response.text
+
+
+def test_graph_controller_registers_layoutstop_before_running_layout() -> None:
+    """The ``?selected`` cross-link handler is attached before the initial layout.
+
+    Regression for #142: the select/center/open-drawer logic is a
+    ``cy.one("layoutstop", ...)`` listener. An ``animate:false``
+    cose-bilkent pass emits ``layoutstop`` synchronously inside the
+    ``layout.run()`` turn, so the listener MUST be registered *before*
+    the initial layout runs -- otherwise it never fires and arriving
+    at ``?view=graph&selected=<id>`` renders the graph without
+    selecting/centering/opening the node's drawer.
+
+    The pre-fix code passed ``layout: layoutOptions("cose-bilkent",
+    false)`` into the ``cytoscape({...})`` constructor (which runs the
+    layout synchronously during construction) and only attached the
+    ``cy.one("layoutstop", ...)`` listener afterwards. This test pins
+    two load-bearing source properties of the served controller:
+
+    * the constructor no longer carries an inline ``layout:`` option
+      (the layout is run explicitly afterwards), and
+    * the ``cy.one("layoutstop"`` registration precedes the
+      ``cy.layout(...).run()`` call in source order.
+    """
+    source = (static_root_dir() / "src" / "app" / "topology-graph.js").read_text(
+        encoding="utf-8",
+    )
+    # The constructor must not carry an inline ``layout:`` key -- that
+    # is what ran the layout synchronously before any listener attached.
+    assert "layout: layoutOptions(" not in source, (
+        "the cytoscape constructor must not run the layout inline; run it "
+        "explicitly after the ?selected layoutstop listener is attached (#142)"
+    )
+    # The layoutstop cross-link listener must be registered before the
+    # explicit initial ``cy.layout(...).run()`` call.
+    listener_pos = source.index('cy.one("layoutstop"')
+    run_pos = source.index('cy.layout(layoutOptions("cose-bilkent", false)).run()')
+    assert listener_pos < run_pos, (
+        "the ?selected layoutstop listener must be attached before the initial "
+        "cy.layout(...).run() so the synchronous animate:false layoutstop is caught (#142)"
+    )
+
+
 def test_graph_without_selection_emits_empty_island() -> None:
     """The selected-id island is empty when no ``?selected=`` is present."""
     _seed_tenant_row(_TENANT_A, "tenant-a")

--- a/docs/codebase/ui.md
+++ b/docs/codebase/ui.md
@@ -1344,7 +1344,17 @@ two surfaces.
   `/ui/topology?view=graph&selected=<id>`. The graph route emits the
   id into `#topology-graph-selected`; `topology-graph.js` reads it,
   centers the matching node on the first `layoutstop`, selects it,
-  and opens the same drawer.
+  and opens the same drawer. The `cy.one("layoutstop", ...)` cross-link
+  listener is registered **before** the initial `cy.layout(...).run()`
+  — the controller constructs Cytoscape *without* an inline `layout:`
+  option and runs the layout explicitly afterwards. This ordering is
+  load-bearing: an `animate:false` cose-bilkent pass emits `layoutstop`
+  synchronously inside the `run()` turn, so a listener attached after
+  the layout had already run (the pre-#142 shape, where `layout:` sat
+  on the constructor) never fired and the arriving node was never
+  selected/centered/opened. The "Show in table" header link is
+  server-rendered with `&selected=<id>` on arrival, so it round-trips
+  the selection back without waiting on the client.
 
 Both directions preserve active filters (`kind`, `q`) so the toggle
 keeps operator state.


### PR DESCRIPTION
## Summary

- Arriving at `/ui/topology?view=graph&selected=<id>` rendered the graph but never selected, centered, or opened the drawer for the node. Root cause: the `cy.one("layoutstop", ...)` cross-link handler was registered **after** the cytoscape constructor, which carried `layout: layoutOptions("cose-bilkent", false)`. With `animate:false`, cose-bilkent repositions nodes via cytoscape's non-animated `layoutPositions`, which emits `layoutstop` synchronously inside the constructor call — so the listener attached a few lines later never fired.
- Fix: construct Cytoscape **without** the inline `layout:` option, register the `?selected` cross-link `layoutstop` listener (alongside the tap + layout-switcher handlers), then run the initial layout explicitly via `cy.layout(layoutOptions("cose-bilkent", false)).run()`. The listener is now guaranteed attached before the synchronous `animate:false` `layoutstop` fires.
- Builds on #141 (merged), which put the node drawer in a visible grid beside the graph — so the drawer-open criterion is now observable on arrival.

## Test plan

- [x] `ruff check` / `ruff format --check` — clean
- [x] `mypy` — no new errors (3 pre-existing errors in `conftest.py` + the `_seed_session_sync` helper, present on base `4d1e304d`)
- [x] `pytest backend/tests/test_ui_topology_graph.py` — 26 passed (24 existing + 2 new)
- [x] **AC#1/#2** (selected node returned by `__mehoCy.elements('node:selected')`; centered): the `layoutstop` listener now fires (attached before the layout run) and calls `node.select()` + `cy.center(node)`. Pinned by `test_graph_controller_registers_layoutstop_before_running_layout` (constructor has no inline `layout:`; listener registered before `cy.layout(...).run()`).
- [x] **AC#3** (drawer opens on arrival, no extra click): handler calls `openDrawerForNode(selectedId)` → HTMX swap into the now-visible `#node-drawer` (visible via #141).
- [x] **AC#4** ("Show in table" round-trips `?selected`): server-rendered header link carries `&selected=<id>` on arrival — `test_graph_selected_id_round_trips_into_show_in_table_link`.

## Out of scope

- Node-tap selection (already works via `cy.on('tap','node')`).
- Drawer placement/visibility — landed in #141 (this Task depends on it for AC#3).

<!-- auto-implement-issue: fresh, iteration 1 -->

Closes #142
