### PR TITLE
fix(harbor): gate harbor.robot.create behind four-eyes approval

### DIFF
--- a/backend/src/meho_backplane/connectors/harbor/ops.py
+++ b/backend/src/meho_backplane/connectors/harbor/ops.py
@@ -288,7 +288,11 @@ async def register_harbor_robot_operations(
             "Classified credential_mint: the broadcast collapses to aggregate-only "
             "so the secret never appears in the SSE feed. "
             "Non-idempotent — never auto-retried by the HttpConnector "
-            "tenacity decorator. safety_level=caution."
+            "tenacity decorator. safety_level=caution. "
+            "requires_approval=True: minting a robot credential is privilege "
+            "issuance, so it is four-eyes-gated (a second operator must approve) "
+            "for every principal kind — the non-agent policy gate keys on "
+            "requires_approval, not safety_level (#147)."
         ),
         parameter_schema=_HARBOR_ROBOT_CREATE_PARAMETER_SCHEMA,
         response_schema=_HARBOR_ROBOT_CREATE_RESPONSE_SCHEMA,
@@ -296,7 +300,15 @@ async def register_harbor_robot_operations(
         when_to_use=_HARBOR_ROBOT_WHEN_TO_USE,
         tags=["write", "credential-mint"],
         safety_level="caution",
-        requires_approval=False,
+        # Four-eyes on privilege issuance (#147). ``harbor.robot.create`` mints
+        # a fresh robot credential in its response — a credential_mint op. The
+        # non-agent policy gate (``_non_agent_verdict``) keys the verdict solely
+        # on ``requires_approval`` (not ``safety_level``), so leaving this
+        # ``False`` let a human ``tenant_admin`` mint a credential end-to-end
+        # with no second-operator approval — the credential-mint arm of the
+        # four-eyes bypass #128 set out to close. Flip to True so the dispatch
+        # parks at ``awaiting_approval`` and a second operator must approve.
+        requires_approval=True,
         llm_instructions=_HARBOR_ROBOT_CREATE_LLM_INSTRUCTIONS,
         embedding_service=embedding_service,
     )
@@ -320,6 +332,15 @@ async def register_harbor_robot_operations(
         when_to_use=_HARBOR_ROBOT_WHEN_TO_USE,
         tags=["write", "destructive"],
         safety_level="caution",
+        # Left ungated (#147). ``harbor.robot.delete`` is a ``caution``-class
+        # ``write`` (suffix-classified) that revokes access — it does NOT mint
+        # or return any credential, so it is not part of the credential-mint
+        # bypass this Task closes. It mirrors the bind9 precedent (#129), which
+        # four-eyes-gated only the ``dangerous`` config-replacement ops and left
+        # ``caution`` ops default-allow for humans. Revoking a robot is
+        # recoverable (re-mint via ``harbor.robot.create``), so it does not clear
+        # the four-eyes bar. Gating it would also break the deliberate
+        # full-detail-broadcast contrast the credential_mint tests pin.
         requires_approval=False,
         llm_instructions=_HARBOR_ROBOT_DELETE_LLM_INSTRUCTIONS,
         embedding_service=embedding_service,

--- a/backend/tests/integration/test_connectors_harbor_container.py
+++ b/backend/tests/integration/test_connectors_harbor_container.py
@@ -101,12 +101,19 @@ from meho_backplane.connectors.registry import (
     clear_registry,
     register_connector_v2,
 )
+from meho_backplane.connectors.schemas import OperationResult
 from meho_backplane.db.engine import get_sessionmaker
 from meho_backplane.db.models import AuditLog, EndpointDescriptor, OperationGroup
+from meho_backplane.db.models import Target as TargetORM
 from meho_backplane.operations import dispatch, reset_dispatcher_caches
 from meho_backplane.operations._handler_resolve import get_or_create_connector_instance
+from meho_backplane.operations.approval_queue import (
+    approve_request,
+    resume_dispatch_after_approval,
+)
 from meho_backplane.operations.dispatcher import set_default_reducer
 from meho_backplane.operations.reducer import PassThroughReducer
+from meho_backplane.tenancy import ensure_tenant
 from tests.test_operations_dispatcher import _make_operator
 
 # ---------------------------------------------------------------------------
@@ -135,6 +142,21 @@ _TEST_PROJECT_NAME: str = "e2e-robot-test"
 _DB_ALIAS: str = "harbor-db"
 _REDIS_ALIAS: str = "redis"
 _CORE_ALIAS: str = "harbor-core"
+
+#: Tenant every operator in this module belongs to. Pinned (not random)
+#: because ``harbor.robot.create`` now parks (#147) and the parked
+#: ``ApprovalRequest.tenant_id`` FKs to ``tenant(id)`` — a random tenant
+#: would violate ``approval_request_tenant_id_fkey``. Matches the
+#: ``_make_operator`` default so operators built without an explicit
+#: ``tenant_id`` share it. The ``harbor_e2e`` fixture seeds this row via
+#: :func:`~meho_backplane.tenancy.ensure_tenant` before any dispatch.
+_HARBOR_E2E_TENANT_ID: uuid.UUID = uuid.UUID("00000000-0000-0000-0000-00000000a0a0")
+
+#: Stable id for the persisted Harbor ``Target`` the approve→resume path
+#: re-hydrates by id (``resolve_target_by_id`` is tenant-scoped, so the
+#: row's ``tenant_id`` must equal the operator's). The parked request
+#: pins ``target_id``; resume fails closed if no live row matches.
+_HARBOR_E2E_TARGET_ID: uuid.UUID = uuid.UUID("00000000-0000-0000-0000-00000000ba02")
 
 
 # ---------------------------------------------------------------------------
@@ -295,7 +317,14 @@ def _seed_harbor(base_url: str) -> None:
 
 @dataclass
 class _HarborTarget:
-    """Minimal duck-typed Target for Harbor dispatch tests."""
+    """Minimal duck-typed Target for Harbor dispatch tests.
+
+    ``id`` / ``tenant_id`` are pinned to the module constants (not random)
+    so the parked ``ApprovalRequest`` — created when ``harbor.robot.create``
+    parks (#147) — re-hydrates the persisted :class:`TargetORM` row on the
+    approve→resume path (``resolve_target_by_id`` is tenant-scoped) and its
+    ``tenant_id`` satisfies the ``tenant(id)`` FK the fixture seeds.
+    """
 
     product: str = "harbor"
     name: str = "harbor-e2e"
@@ -304,8 +333,8 @@ class _HarborTarget:
     auth_model: str = "shared_service_account"
 
     def __post_init__(self) -> None:
-        self.id = uuid.uuid4()
-        self.tenant_id = uuid.uuid4()
+        self.id = _HARBOR_E2E_TARGET_ID
+        self.tenant_id = _HARBOR_E2E_TENANT_ID
         self.preferred_impl_id: str | None = None
 
         class _FP:
@@ -372,6 +401,14 @@ async def harbor_e2e(
     host = parsed.hostname or "127.0.0.1"
     port = parsed.port or 8080
 
+    # Seed the tenant row + a durable Target the approve→resume path needs.
+    # ``harbor.robot.create`` now parks (#147); the parked ``ApprovalRequest``
+    # FKs its ``tenant_id`` to ``tenant(id)`` and the resume re-hydrates the
+    # target by id (tenant-scoped). ``pg_engine`` truncated ``tenant`` +
+    # ``targets`` and re-seeded two *other* tenants, so this fixture seeds
+    # the module tenant just-in-time and persists a matching Harbor target.
+    await _seed_harbor_tenant_and_target(host, port)
+
     instance = get_or_create_connector_instance(HarborConnector)
     instance._credentials_loader = _make_credentials_loader(  # type: ignore[misc]
         "admin", _HARBOR_ADMIN_PASSWORD
@@ -399,6 +436,89 @@ def _make_credentials_loader(username: str, password: str):  # type: ignore[no-u
         return {"username": username, "password": password}
 
     return _loader
+
+
+async def _seed_harbor_tenant_and_target(host: str, port: int) -> None:
+    """Seed the module tenant + a durable Harbor ``Target`` for resume.
+
+    Idempotent: ``ensure_tenant`` is ``INSERT ... ON CONFLICT DO NOTHING``
+    and the target insert is guarded by an existence check so re-running
+    across the module's tests (module-scoped PG container, function-scoped
+    ``harbor_e2e``) does not raise a unique violation. The persisted target
+    mirrors the ``_HarborTarget`` double's identity (``id`` / ``tenant_id``
+    / ``product`` / ``name``) so the approve→resume re-hydration resolves
+    it; ``version`` is the connector version, but connector resolution on
+    resume keys on the stored ``connector_id``, so ``host`` / ``port`` here
+    are only informational — the patched instance ``_base_url`` ignores
+    them and always targets the container.
+    """
+    async with get_sessionmaker()() as session:
+        await ensure_tenant(_HARBOR_E2E_TENANT_ID, session)
+        existing = await session.get(TargetORM, _HARBOR_E2E_TARGET_ID)
+        if existing is None:
+            session.add(
+                TargetORM(
+                    id=_HARBOR_E2E_TARGET_ID,
+                    tenant_id=_HARBOR_E2E_TENANT_ID,
+                    name="harbor-e2e",
+                    product=HARBOR_PRODUCT,
+                    version=HARBOR_VERSION,
+                    host=host,
+                    port=port,
+                    aliases=[],
+                    secret_ref="harbor/harbor-e2e",
+                    auth_model="shared_service_account",
+                )
+            )
+        await session.commit()
+
+
+async def _create_robot_via_approve_resume(
+    *,
+    target: _HarborTarget,
+    requester_sub: str,
+    approver_sub: str,
+    name: str,
+    project: str,
+    duration: int,
+) -> OperationResult:
+    """Drive ``harbor.robot.create`` through the real four-eyes approve→resume.
+
+    ``harbor.robot.create`` mints a credential and is registered
+    ``requires_approval=True`` (#147), so a lone dispatch parks at
+    ``awaiting_approval`` instead of executing. This helper reproduces the
+    production flow the unit lane exercises over HTTP ``/decide``
+    (:mod:`tests.test_broadcast_credential_mint_dispatch`), but calls the
+    shared service-layer functions ``/decide`` itself calls
+    (``approve_request`` + ``resume_dispatch_after_approval``) — avoiding an
+    OIDC/JWKS mock against a suite that must reach the live Harbor container.
+
+    Steps: dispatch as *requester_sub* → assert ``awaiting_approval`` +
+    ``approval_request_id`` → approve as a **distinct** *approver_sub*
+    (the requester≠approver guard, ``approval_allow_self_approval=False``
+    by default, enforces real four-eyes) → resume re-dispatch with
+    ``_approved=True`` (via the committed approval). Returns the resumed
+    :class:`~meho_backplane.connectors.schemas.OperationResult` (``status``
+    ``"ok"`` on success, carrying the minted ``secret``).
+    """
+    requester = _make_operator(sub=requester_sub, tenant_id=_HARBOR_E2E_TENANT_ID)
+    parked = await dispatch(
+        operator=requester,
+        connector_id=HARBOR_CONNECTOR_ID,
+        op_id="harbor.robot.create",
+        target=target,
+        params={"name": name, "project": project, "duration": duration},
+    )
+    assert parked.status == "awaiting_approval", parked.error
+    request_id = uuid.UUID(parked.extras["approval_request_id"])
+
+    approver = _make_operator(sub=approver_sub, tenant_id=_HARBOR_E2E_TENANT_ID)
+    sessionmaker = get_sessionmaker()
+    async with sessionmaker() as session:
+        request = await approve_request(session, request_id, operator=approver)
+        await session.commit()
+
+    return await resume_dispatch_after_approval(operator=approver, request=request, params=None)
 
 
 _PATH_VAR_RE = re.compile(r"\{([^{}]+)\}")
@@ -623,19 +743,24 @@ async def test_robot_create_credential_mint_classification(
     harbor_e2e: tuple[_HarborTarget, str],
     captured_events: list[BroadcastEvent],
 ) -> None:
-    """``harbor.robot.create`` returns minted secret; broadcast is credential_mint."""
+    """``harbor.robot.create`` mints a secret; broadcast is credential_mint (#147).
+
+    ``harbor.robot.create`` now parks (``requires_approval=True``, #147), so a
+    lone dispatch never executes. The minted-secret + aggregate-only broadcast
+    contract is therefore proven through the real four-eyes approve→resume
+    flow: a lone operator parks the mint, a **second** operator approves, and
+    the committed approval drives the re-dispatch that mints against the live
+    Harbor container. The executed op's result carries the secret while its
+    broadcast collapses to aggregate-only.
+    """
     target, _ = harbor_e2e
-    operator = _make_operator(sub="e2e-robot-create")
-    result = await dispatch(
-        operator=operator,
-        connector_id=HARBOR_CONNECTOR_ID,
-        op_id="harbor.robot.create",
+    result = await _create_robot_via_approve_resume(
         target=target,
-        params={
-            "name": "e2e-ci-robot",
-            "project": _TEST_PROJECT_NAME,
-            "duration": 7,
-        },
+        requester_sub="e2e-robot-create",
+        approver_sub="e2e-robot-create-approver",
+        name="e2e-ci-robot",
+        project=_TEST_PROJECT_NAME,
+        duration=7,
     )
     assert result.status == "ok", result.error
 
@@ -647,9 +772,13 @@ async def test_robot_create_credential_mint_classification(
     assert "id" in result.result, "harbor.robot.create result must include 'id'"
     assert "name" in result.result, "harbor.robot.create result must include 'name'"
 
+    # The executed (post-approval) op audits under the approver identity —
+    # the park writes an ``APPROVAL`` / ``approval.request`` row (not keyed
+    # on the op-id), so filtering on ``path == "harbor.robot.create"`` +
+    # the approver sub selects exactly the one executed dispatch row.
     await _assert_audited(
         "harbor.robot.create",
-        operator_sub="e2e-robot-create",
+        operator_sub="e2e-robot-create-approver",
         expected_op_class="credential_mint",
         expected_source_kind="typed",
         events=captured_events,
@@ -674,18 +803,16 @@ async def test_robot_delete_classified_write(
     """``harbor.robot.delete`` removes the robot; broadcast is classified write."""
     target, _ = harbor_e2e
 
-    # Create a robot to delete.
-    creator = _make_operator(sub="e2e-robot-del-setup")
-    create_result = await dispatch(
-        operator=creator,
-        connector_id=HARBOR_CONNECTOR_ID,
-        op_id="harbor.robot.create",
+    # Create a robot to delete. ``harbor.robot.create`` parks (#147), so the
+    # setup drives the same four-eyes approve→resume flow to mint it; only
+    # then is there a robot id to delete.
+    create_result = await _create_robot_via_approve_resume(
         target=target,
-        params={
-            "name": "e2e-delete-me",
-            "project": _TEST_PROJECT_NAME,
-            "duration": 7,
-        },
+        requester_sub="e2e-robot-del-setup",
+        approver_sub="e2e-robot-del-setup-approver",
+        name="e2e-delete-me",
+        project=_TEST_PROJECT_NAME,
+        duration=7,
     )
     assert create_result.status == "ok", create_result.error
     robot_id = create_result.result["id"]

--- a/backend/tests/integration/test_connectors_harbor_container.py
+++ b/backend/tests/integration/test_connectors_harbor_container.py
@@ -788,13 +788,16 @@ async def test_robot_create_credential_mint_classification(
     assert "id" in result.result, "harbor.robot.create result must include 'id'"
     assert "name" in result.result, "harbor.robot.create result must include 'name'"
 
-    # The executed (post-approval) op audits under the approver identity —
-    # the park writes an ``APPROVAL`` / ``approval.request`` row (not keyed
-    # on the op-id), so filtering on ``path == "harbor.robot.create"`` +
-    # the approver sub selects exactly the one executed dispatch row.
+    # The executed (post-approval) op audits under the *requester* identity:
+    # the resume re-dispatches as the original requester with ``_approved=True``
+    # (the committed approval is the authorization), so the executed dispatch
+    # row is keyed on the requester sub. The park writes a separate
+    # ``approval.request`` row (not keyed on the op-id), so filtering on
+    # ``path == "harbor.robot.create"`` + the requester sub selects exactly
+    # the one executed dispatch row.
     await _assert_audited(
         "harbor.robot.create",
-        operator_sub="e2e-robot-create-approver",
+        operator_sub="e2e-robot-create",
         expected_op_class="credential_mint",
         expected_source_kind="typed",
         events=captured_events,

--- a/backend/tests/integration/test_connectors_harbor_container.py
+++ b/backend/tests/integration/test_connectors_harbor_container.py
@@ -107,10 +107,7 @@ from meho_backplane.db.models import AuditLog, EndpointDescriptor, OperationGrou
 from meho_backplane.db.models import Target as TargetORM
 from meho_backplane.operations import dispatch, reset_dispatcher_caches
 from meho_backplane.operations._handler_resolve import get_or_create_connector_instance
-from meho_backplane.operations.approval_queue import (
-    approve_request,
-    resume_dispatch_after_approval,
-)
+from meho_backplane.operations.approval_queue import approve_request
 from meho_backplane.operations.dispatcher import set_default_reducer
 from meho_backplane.operations.reducer import PassThroughReducer
 from meho_backplane.tenancy import ensure_tenant
@@ -488,18 +485,30 @@ async def _create_robot_via_approve_resume(
     ``requires_approval=True`` (#147), so a lone dispatch parks at
     ``awaiting_approval`` instead of executing. This helper reproduces the
     production flow the unit lane exercises over HTTP ``/decide``
-    (:mod:`tests.test_broadcast_credential_mint_dispatch`), but calls the
-    shared service-layer functions ``/decide`` itself calls
-    (``approve_request`` + ``resume_dispatch_after_approval``) — avoiding an
-    OIDC/JWKS mock against a suite that must reach the live Harbor container.
+    (:mod:`tests.test_broadcast_credential_mint_dispatch`): it commits the
+    real approval via the shared service-layer function ``approve_request``
+    (the same one ``/decide`` calls) and then re-dispatches with
+    ``_approved=True`` against the live target — avoiding an OIDC/JWKS mock
+    against a suite that must reach the live Harbor container.
 
     Steps: dispatch as *requester_sub* → assert ``awaiting_approval`` +
     ``approval_request_id`` → approve as a **distinct** *approver_sub*
     (the requester≠approver guard, ``approval_allow_self_approval=False``
     by default, enforces real four-eyes) → resume re-dispatch with
-    ``_approved=True`` (via the committed approval). Returns the resumed
-    :class:`~meho_backplane.connectors.schemas.OperationResult` (``status``
-    ``"ok"`` on success, carrying the minted ``secret``).
+    ``_approved=True`` against the **live** ``target`` object. Returns the
+    resumed :class:`~meho_backplane.connectors.schemas.OperationResult`
+    (``status`` ``"ok"`` on success, carrying the minted ``secret``).
+
+    The resume deliberately re-dispatches against the live ``_HarborTarget``
+    fixture (mirroring the unit lane
+    :mod:`tests.test_broadcast_credential_mint_dispatch`) rather than
+    ``resume_dispatch_after_approval``. The latter re-hydrates the ``Target``
+    from its persisted DB row and re-resolves the connector by product/version;
+    the live container connector binding (base_url override + injected
+    credentials) lives on the fixture instance, not on a plain DB row, so a
+    DB-rehydrated resume resolves ``no_connector``. The committed approval is
+    the authorization; ``_approved=True`` skips the gate and executes against
+    the live Harbor container.
     """
     requester = _make_operator(sub=requester_sub, tenant_id=_HARBOR_E2E_TENANT_ID)
     parked = await dispatch(
@@ -515,10 +524,17 @@ async def _create_robot_via_approve_resume(
     approver = _make_operator(sub=approver_sub, tenant_id=_HARBOR_E2E_TENANT_ID)
     sessionmaker = get_sessionmaker()
     async with sessionmaker() as session:
-        request = await approve_request(session, request_id, operator=approver)
+        await approve_request(session, request_id, operator=approver)
         await session.commit()
 
-    return await resume_dispatch_after_approval(operator=approver, request=request, params=None)
+    return await dispatch(
+        operator=requester,
+        connector_id=HARBOR_CONNECTOR_ID,
+        op_id="harbor.robot.create",
+        target=target,
+        params={"name": name, "project": project, "duration": duration},
+        _approved=True,
+    )
 
 
 _PATH_VAR_RE = re.compile(r"\{([^{}]+)\}")

--- a/backend/tests/test_broadcast_credential_mint_dispatch.py
+++ b/backend/tests/test_broadcast_credential_mint_dispatch.py
@@ -1,79 +1,104 @@
 # SPDX-License-Identifier: Apache-2.0
 # Copyright (c) 2026 evoila Group
 
-"""G6 ``credential_mint`` classifier integration test (G3.5-T9 / #621).
+"""G6 ``credential_mint`` classifier integration test (G3.5-T9 / #621, #147).
 
-Proves the load-bearing PII guarantee for ``harbor.robot.create``:
-the G6 broadcast feed must emit **aggregate-only** — the fact that a
-robot account was minted, never the minted secret credential — while
-the :class:`~meho_backplane.connectors.schemas.OperationResult`
-returned to the caller still contains the secret.
+Proves the load-bearing PII guarantee for ``harbor.robot.create``: the
+G6 broadcast feed must emit **aggregate-only** — the fact that a robot
+account was minted, never the minted secret credential — while the
+:class:`~meho_backplane.connectors.schemas.OperationResult` returned to
+the caller still contains the secret.
 
-This mirrors :mod:`tests.test_broadcast_credential_read_dispatch` for
-the ``credential_read`` class (decision #3 precedent). The mechanism
-is identical:
+Four-eyes gating (#147)
+-----------------------
+
+``harbor.robot.create`` mints a credential in its response, so it is now
+registered ``requires_approval=True`` (#147): the non-agent policy gate
+(:func:`~meho_backplane.operations._validate._non_agent_verdict`) keys the
+verdict solely on ``requires_approval``, so a human ``tenant_admin``
+dispatching it **parks** at ``awaiting_approval`` instead of executing —
+closing the credential-mint arm of the four-eyes bypass #128. The
+redaction contract therefore can no longer be proven by a single lone
+dispatch (the op never executes). Every redaction assertion here now
+drives the op through the real **approve → resume** flow:
+
+1. dispatch as a lone operator → assert ``awaiting_approval`` +
+   ``extras["approval_request_id"]``;
+2. approve as a **second** operator via
+   ``POST /api/v1/approvals/{id}/decide`` (the self-approval guard
+   rejects the requester — real four-eyes);
+3. the ``/decide`` route re-hydrates the stored target and re-dispatches
+   with ``_approved=True`` (the committed approval is the authorization);
+4. assert ``dispatch_status == "ok"`` **and** the redacted broadcast on
+   the executed (post-approval) op.
+
+Mirrors the approve→resume harness in
+:mod:`tests.test_secret_move_approval` (HTTP ``/decide`` with a minted
+operator JWT) and :mod:`tests.test_approval_queue` (real DB ``Target``
+re-hydration).
+
+Mechanism (unchanged from #621)
+-------------------------------
 
 * :func:`~meho_backplane.broadcast.events.classify_op` returns
   ``"credential_mint"`` for ``harbor.robot.create``.
 * :func:`~meho_backplane.broadcast.events.redact_payload` collapses
   ``credential_mint`` to ``{op_class, result_status}`` — the same
   aggregate branch used for ``credential_read``.
-* The broadcast publisher is swapped for a recording stub so the
-  emitted :class:`~meho_backplane.broadcast.events.BroadcastEvent`
-  can be inspected without a Valkey container.
-* The Harbor HTTP client is intercepted by respx so the real handler
-  runs against a mock endpoint; the test does not need a live Harbor
-  instance.
-* The connector's Vault-backed credentials loader is replaced with
-  a stub so no Vault address is reached.
+* The broadcast publisher is swapped for a recording stub so the emitted
+  :class:`~meho_backplane.broadcast.events.BroadcastEvent` can be
+  inspected without a Valkey container.
+* The Harbor HTTP client is intercepted by respx so the real handler runs
+  against a mock endpoint; the test does not need a live Harbor instance.
+* The connector's Vault-backed credentials loader is replaced with a stub
+  so no Vault address is reached.
 
 Why assert by exclusion on the *serialised* event: the redacted
-``payload`` collapses to ``{op_class, result_status}``, but the
-enclosing :class:`BroadcastEvent` always carries ``op_id`` and
-``target_name``. The leak surface is the whole serialised event, not
-just ``payload`` — a regression that placed the secret in a new
-top-level field would pass a ``payload``-only assertion.
+``payload`` collapses to ``{op_class, result_status}``, but the enclosing
+:class:`BroadcastEvent` always carries ``op_id`` and ``target_name``. The
+leak surface is the whole serialised event, not just ``payload`` — a
+regression that placed the secret in a new top-level field would pass a
+``payload``-only assertion.
 
-Skip-clean: the test skips (does not fail) when
-``BROADCAST_REDIS_URL`` is unset, mirroring the ``credential_read``
-test's operator-intent guard. The publisher swap means no real Valkey
-socket is opened regardless.
+Runs unconditionally: the recording-stub publisher means no real Valkey
+socket is opened, so — like :mod:`tests.test_broadcast_credential_write_dispatch`
+— there is no ``BROADCAST_REDIS_URL`` skip guard. The prior guard (#621)
+skipped the whole suite locally, so the redaction contract was only ever
+exercised in CI; the approve→resume rework closes that gap by executing
+the op deterministically in the sandbox (AC2 of #147).
 """
 
 from __future__ import annotations
 
 import json
-import os
-import uuid
-from collections.abc import Iterator
+from collections.abc import AsyncIterator, Iterator
+from typing import Any
 from unittest.mock import AsyncMock
 from uuid import UUID
 
 import pytest
 import respx
+from fastapi.testclient import TestClient
+from sqlalchemy import select
 
 import meho_backplane.operations._audit as audit_module
-from meho_backplane.auth.operator import Operator, TenantRole
+from meho_backplane.auth.jwt import clear_jwks_cache
+from meho_backplane.auth.operator import Operator, PrincipalKind, TenantRole
 from meho_backplane.broadcast import BroadcastEvent
 from meho_backplane.connectors.harbor import HarborConnector
 from meho_backplane.connectors.harbor.ops import register_harbor_robot_operations
 from meho_backplane.connectors.harbor.session import HarborTargetLike
-from meho_backplane.connectors.registry import clear_registry, register_connector_v2
+from meho_backplane.db.engine import get_sessionmaker
+from meho_backplane.db.models import AuditLog
+from meho_backplane.db.models import Target as TargetORM
+from meho_backplane.main import app
 from meho_backplane.operations import dispatch, reset_dispatcher_caches
 from meho_backplane.operations._handler_resolve import get_or_create_connector_instance
 from meho_backplane.settings import get_settings
 
-# ---------------------------------------------------------------------------
-# Skip-clean guard
-# ---------------------------------------------------------------------------
-
-_BROADCAST_DISABLED = not (os.environ.get("BROADCAST_REDIS_URL") or "").strip()
-
-pytestmark = pytest.mark.skipif(
-    _BROADCAST_DISABLED,
-    reason="broadcast feed disabled (BROADCAST_REDIS_URL unset) — G6 "
-    "credential_mint classifier integration test skipped cleanly per #621 DoD",
-)
+from ._oidc_jwt_helpers import AUDIENCE as _AUDIENCE
+from ._oidc_jwt_helpers import ISSUER as _ISSUER
+from ._oidc_jwt_helpers import make_rsa_keypair, mint_token, mock_discovery_and_jwks, public_jwks
 
 # ---------------------------------------------------------------------------
 # Sentinel secret material
@@ -88,6 +113,21 @@ _SENTINEL_SECRET = "sntlrobotcred0zzz"
 #: the broadcast is *permitted* to carry ``op_id``, ``target_name``,
 #: and ``result_status`` (the allowed aggregate per decision #3).
 _FORBIDDEN_SUBSTRINGS: tuple[str, ...] = (_SENTINEL_SECRET,)
+
+#: Tenant every principal in this module belongs to.
+_TENANT_ID = UUID("00000000-0000-0000-0000-0000000000c9")
+
+#: Stable id for the persisted Harbor target the resume path re-hydrates.
+_TARGET_ID = UUID("00000000-0000-0000-0000-00000000ba01")
+_TARGET_NAME = "harbor-test-prod"
+_TARGET_HOST = "harbor.test.invalid"
+
+#: Harbor v2 robot endpoints the handler calls, against ``_base_url`` =
+#: ``https://<host>`` (port 443 omitted). ``robot_create`` POSTs to
+#: ``/api/v2.0/robots``; ``robot_delete`` DELETEs ``/api/v2.0/robots/{id}``.
+_ROBOTS_URL = f"https://{_TARGET_HOST}/api/v2.0/robots"
+_ROBOT_7_URL = f"https://{_TARGET_HOST}/api/v2.0/robots/7"
+
 
 # ---------------------------------------------------------------------------
 # Stub credentials loader
@@ -107,77 +147,77 @@ async def _stub_credentials_loader(
 
 
 # ---------------------------------------------------------------------------
-# Stub dispatch target
-# ---------------------------------------------------------------------------
-
-
-class _FakeFingerprint:
-    """Duck-typed fingerprint — the resolver reads only ``version``."""
-
-    def __init__(self, version: str) -> None:
-        self.version = version
-
-
-class _HarborDispatchTarget:
-    """Target stub satisfying the dispatcher's resolution + audit reads.
-
-    The dispatcher reads ``product`` / ``fingerprint.version`` /
-    ``preferred_impl_id`` (connector resolution) and ``id`` / ``name``
-    (audit row + broadcast ``target_name``). The Harbor connector reads
-    ``auth_model`` + ``name`` + ``host`` + ``port`` during auth and
-    HTTP-client setup.
-
-    ``name`` is a benign label; the broadcast event may carry it.
-    It is deliberately distinct from every forbidden sentinel so the
-    by-exclusion assertion cannot false-positive on it.
-    """
-
-    def __init__(self) -> None:
-        self.product = "harbor"
-        self.fingerprint = _FakeFingerprint(version="2.11.0")
-        self.preferred_impl_id: str | None = None
-        self.id: UUID = uuid.uuid4()
-        self.name = "harbor-test-prod"
-        self.host = "harbor.test.invalid"
-        self.port: int | None = 443
-        self.secret_ref = "harbor/harbor-test-prod"
-        self.auth_model: str | None = "shared_service_account"
-
-
-# ---------------------------------------------------------------------------
 # Fixtures
 # ---------------------------------------------------------------------------
 
 
 @pytest.fixture(autouse=True)
 def _required_settings_env(monkeypatch: pytest.MonkeyPatch) -> Iterator[None]:
-    monkeypatch.setenv("KEYCLOAK_ISSUER_URL", "https://keycloak.test/realms/meho")
-    monkeypatch.setenv("KEYCLOAK_AUDIENCE", "meho-backplane")
+    monkeypatch.setenv("KEYCLOAK_ISSUER_URL", _ISSUER)
+    monkeypatch.setenv("KEYCLOAK_AUDIENCE", _AUDIENCE)
+    monkeypatch.setenv("KEYCLOAK_JWKS_CACHE_TTL_SECONDS", "300")
+    monkeypatch.setenv("KEYCLOAK_JWT_LEEWAY_SECONDS", "30")
     monkeypatch.setenv("VAULT_ADDR", "https://vault.test")
     get_settings.cache_clear()
+    clear_jwks_cache()
     yield
     get_settings.cache_clear()
+    clear_jwks_cache()
 
 
 @pytest.fixture(autouse=True)
 def _reset_module_state() -> Iterator[None]:
-    """Reset dispatcher caches + registry; pre-seed the connector instance."""
+    """Reset dispatcher caches + patch the Harbor connector's credentials loader.
+
+    The full connector registry is populated once per worker by conftest's
+    session-scoped ``_force_import_connector_modules`` and snapshot/restored
+    per-test by ``_isolate_global_registries`` — so this fixture does NOT
+    clear + re-register a single connector. Clearing the registry down to
+    Harbor would break the ``TestClient(app)`` lifespan: the app's
+    connector-spec catalog validation fails when the other connector
+    classes are absent from the registry.
+
+    Patch the *cached* connector instance's credentials loader so no Vault
+    address is reached, both for the direct requester dispatch and for the
+    server-side re-dispatch the ``/decide`` route runs on the same cached
+    instance. ``_isolate_global_registries`` restores the instance cache
+    after the test, so the patch cannot bleed into another connector test.
+    """
     reset_dispatcher_caches()
-    clear_registry()
-    register_connector_v2(
-        product=HarborConnector.product,
-        version=HarborConnector.version,
-        impl_id=HarborConnector.impl_id,
-        cls=HarborConnector,
-    )
-    # Materialise the connector instance the dispatcher will use and patch
-    # its credentials loader. The patched instance survives in
-    # _CONNECTOR_INSTANCE_CACHE until reset_dispatcher_caches() teardown.
     instance = get_or_create_connector_instance(HarborConnector)
     instance._credentials_loader = _stub_credentials_loader  # type: ignore[attr-defined]
     yield
     reset_dispatcher_caches()
-    clear_registry()
+
+
+@pytest.fixture
+async def _persisted_harbor_target() -> AsyncIterator[UUID]:
+    """Persist a real Harbor ``Target`` the resume path re-hydrates by id.
+
+    The ``/decide`` re-dispatch loads the target from the DB
+    (:func:`~meho_backplane.targets.resolver.resolve_target_by_id`) — it
+    does not carry the request-time object — so a durable row must exist
+    or the resume fails closed. ``version`` resolves the connector;
+    ``host`` / ``port`` / ``auth_model`` / ``name`` drive the HTTP client
+    and audit ``target_name``.
+    """
+    async with get_sessionmaker()() as session:
+        session.add(
+            TargetORM(
+                id=_TARGET_ID,
+                tenant_id=_TENANT_ID,
+                name=_TARGET_NAME,
+                product="harbor",
+                version="2.11.0",
+                host=_TARGET_HOST,
+                port=443,
+                aliases=[],
+                secret_ref=f"harbor/{_TARGET_NAME}",
+                auth_model="shared_service_account",
+            )
+        )
+        await session.commit()
+    yield _TARGET_ID
 
 
 @pytest.fixture
@@ -202,19 +242,45 @@ def captured_events(monkeypatch: pytest.MonkeyPatch) -> list[BroadcastEvent]:
     return events
 
 
-def _make_operator() -> Operator:
+class _HarborDispatchTarget:
+    """Request-time target stub the *requester* dispatches against.
+
+    The dispatcher reads ``product`` / ``fingerprint.version`` /
+    ``preferred_impl_id`` (connector resolution), ``tenant_id`` / ``id``
+    (pooled-HTTP-client cache key + audit row), and ``name`` (broadcast
+    ``target_name``). ``tenant_id`` / ``id`` match the persisted row so
+    the parked ``ApprovalRequest.target_id`` re-hydrates the real
+    :class:`Target` on resume.
+    """
+
+    def __init__(self) -> None:
+        self.product = "harbor"
+        self.fingerprint = {"version": "2.11.0"}
+        self.preferred_impl_id: str | None = None
+        self.tenant_id: UUID = _TENANT_ID
+        self.id: UUID = _TARGET_ID
+        self.name = _TARGET_NAME
+        self.host = _TARGET_HOST
+        self.port: int | None = 443
+        self.secret_ref = f"harbor/{_TARGET_NAME}"
+        self.auth_model: str | None = "shared_service_account"
+
+
+def _make_operator(sub: str = "op-credential-mint-requester") -> Operator:
+    """A human (USER) operator — parks a ``requires_approval`` op, never denied."""
     return Operator(
-        sub="op-credential-mint-test",
+        sub=sub,
         name="Credential Mint Test Operator",
         email=None,
         raw_jwt="header.payload.signature",
-        tenant_id=UUID("00000000-0000-0000-0000-0000000000c9"),
+        tenant_id=_TENANT_ID,
         tenant_role=TenantRole.OPERATOR,
+        principal_kind=PrincipalKind.USER,
     )
 
 
 # ---------------------------------------------------------------------------
-# Helper
+# Helpers
 # ---------------------------------------------------------------------------
 
 
@@ -243,8 +309,128 @@ def _assert_credential_mint_aggregate(event: BroadcastEvent, op_id: str) -> None
         )
 
 
+def _mock_robot_create(mock: respx.MockRouter) -> None:
+    """Route ``POST /api/v2.0/robots`` to a minted-secret response."""
+    mock.post(_ROBOTS_URL).mock(
+        return_value=respx.MockResponse(
+            201,
+            json={
+                "id": 7,
+                "name": "robot$proj+bot",
+                "secret": _SENTINEL_SECRET,
+                "expiration_time": -1,
+            },
+        )
+    )
+
+
+async def _park_robot_create(
+    stub_embedding_service: AsyncMock,
+    *,
+    requester: Operator,
+) -> UUID:
+    """Register the ops, dispatch ``harbor.robot.create`` as *requester*, park.
+
+    Returns the pending ``approval_request_id``. Asserts the dispatch
+    parked (``awaiting_approval``) rather than executing — the #147 gate.
+    """
+    await register_harbor_robot_operations(embedding_service=stub_embedding_service)
+    parked = await dispatch(
+        operator=requester,
+        connector_id="harbor-rest-2.x",
+        op_id="harbor.robot.create",
+        target=_HarborDispatchTarget(),
+        params={"name": "bot", "project": "proj", "duration": -1},
+    )
+    assert parked.status == "awaiting_approval", parked.error
+    assert parked.extras["approval_request_id"]
+    return UUID(parked.extras["approval_request_id"])
+
+
+def _approve_via_decide(
+    request_id: UUID,
+    mock: respx.MockRouter,
+    *,
+    approver_sub: str,
+) -> dict[str, Any]:
+    """Approve *request_id* over HTTP ``/decide`` as a distinct operator.
+
+    Mocks OIDC discovery + JWKS on *mock* (the same respx router already
+    intercepting the Harbor HTTP call), mints a token for *approver_sub*
+    (≠ the requester — the self-approval guard rejects the requester), and
+    posts the decision. The route re-hydrates the stored target and
+    re-dispatches with ``_approved=True``; returns the decision-response
+    body so callers assert ``dispatch_status``.
+    """
+    key = make_rsa_keypair("kid-decider")
+    mock_discovery_and_jwks(mock, public_jwks(key))
+    token = mint_token(
+        key,
+        sub=approver_sub,
+        tenant_role=TenantRole.OPERATOR.value,
+        tenant_id=str(_TENANT_ID),
+    )
+    with TestClient(app) as client:
+        response = client.post(
+            f"/api/v1/approvals/{request_id}/decide",
+            headers={"Authorization": f"Bearer {token}"},
+            json={"decision": "approved"},
+        )
+    assert response.status_code == 200, response.text
+    return response.json()
+
+
+async def _fetch_audit_rows(op_id: str) -> list[AuditLog]:
+    """Return audit rows for *op_id*, oldest first.
+
+    ``op_id`` / ``result_status`` live inside the JSON ``payload`` column
+    (not as top-level ``AuditLog`` columns), so filter in Python after a
+    tenant-scoped load — SQLite JSON-path predicates are not portable.
+    """
+    async with get_sessionmaker()() as session:
+        result = await session.execute(
+            select(AuditLog).where(AuditLog.tenant_id == _TENANT_ID).order_by(AuditLog.occurred_at)
+        )
+        rows = list(result.scalars().all())
+    return [r for r in rows if isinstance(r.payload, dict) and r.payload.get("op_id") == op_id]
+
+
 # ---------------------------------------------------------------------------
-# credential_mint aggregate-only contract — harbor.robot.create
+# (AC1) Human dispatch parks + audit row records the needs-approval verdict
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.asyncio
+async def test_robot_create_parks_and_audits_needs_approval(
+    stub_embedding_service: AsyncMock,
+    captured_events: list[BroadcastEvent],
+    _persisted_harbor_target: UUID,
+) -> None:
+    """Dispatching ``harbor.robot.create`` as a human parks — not executes (#147).
+
+    AC1: the op returns ``awaiting_approval`` (four-eyes gate) with an
+    ``approval_request_id``, and the parked "request" audit row carries
+    ``policy_decision = "needs-approval"`` (the column landed in #130 /
+    migration 0051). No broadcast carries the (never-minted) secret.
+    """
+    requester = _make_operator()
+    request_id = await _park_robot_create(stub_embedding_service, requester=requester)
+
+    # The parked "request" audit row honestly records the gate verdict.
+    rows = await _fetch_audit_rows("harbor.robot.create")
+    request_rows = [r for r in rows if r.payload.get("result_status") == "request"]
+    assert len(request_rows) == 1
+    assert request_rows[0].policy_decision == "needs-approval"
+
+    # The op never executed, so no secret can have reached any broadcast.
+    for event in captured_events:
+        assert _SENTINEL_SECRET not in event.model_dump_json()
+
+    assert request_id  # a pending row exists to decide
+
+
+# ---------------------------------------------------------------------------
+# (AC2) credential_mint aggregate-only contract through approve → resume
 # ---------------------------------------------------------------------------
 
 
@@ -252,82 +438,77 @@ def _assert_credential_mint_aggregate(event: BroadcastEvent, op_id: str) -> None
 async def test_robot_create_broadcast_is_aggregate_only(
     stub_embedding_service: AsyncMock,
     captured_events: list[BroadcastEvent],
+    _persisted_harbor_target: UUID,
 ) -> None:
-    """``harbor.robot.create`` broadcasts only ``{op_id, target, result_status}``.
+    """``harbor.robot.create`` broadcasts only ``{op_class, result_status}``.
 
-    DoD (AC3 of #621) — the dispatch produces a broadcast event that is
-    aggregate-only: the minted secret never appears in the serialised
-    BroadcastEvent. The OperationResult returned to the caller still
-    contains the secret (proves the exclusion is a real one, not vacuous).
+    DoD (AC3 of #621, AC2 of #147) — the redaction runs against the
+    **executed** op. The requester parks the mint; a second operator
+    approves via ``/decide``; the re-dispatch mints the credential and
+    produces an aggregate-only broadcast: the minted secret never appears
+    in the serialised BroadcastEvent, while the dispatch response still
+    carries it (proves the exclusion is real, not vacuous).
     """
-    await register_harbor_robot_operations(embedding_service=stub_embedding_service)
-
-    operator = _make_operator()
-    target = _HarborDispatchTarget()
+    requester = _make_operator(sub="op-requester")
 
     with respx.mock() as mock:
-        mock.post("https://harbor.test.invalid/api/v2.0/projects/proj/robots").mock(
-            return_value=respx.MockResponse(
-                201,
-                json={
-                    "id": 7,
-                    "name": "robot$proj+bot",
-                    "secret": _SENTINEL_SECRET,
-                    "expiration_time": -1,
-                },
-            )
-        )
-        result = await dispatch(
-            operator=operator,
-            connector_id="harbor-rest-2.x",
-            op_id="harbor.robot.create",
-            target=target,
-            params={"name": "bot", "project": "proj", "duration": -1},
-        )
+        _mock_robot_create(mock)
+        request_id = await _park_robot_create(stub_embedding_service, requester=requester)
+        # Parking must not have emitted the (never-minted) secret.
+        assert not any(_SENTINEL_SECRET in e.model_dump_json() for e in captured_events)
 
-    assert result.status == "ok", result.error
-    # Caller gets the secret — proves the assertion below is a real exclusion.
-    assert result.result is not None
-    assert result.result["secret"] == _SENTINEL_SECRET  # type: ignore[index]
+        body = _approve_via_decide(request_id, mock, approver_sub="op-approver")
 
-    assert len(captured_events) == 1
-    _assert_credential_mint_aggregate(captured_events[0], "harbor.robot.create")
+    assert body["dispatch_status"] == "ok", body
+    # The re-dispatch response carries the minted secret to the caller —
+    # proves the broadcast exclusion below is a real one.
+    assert body["dispatch_result"]["secret"] == _SENTINEL_SECRET
+
+    mint_events = [e for e in captured_events if e.op_id == "harbor.robot.create"]
+    # Exactly one *executed* credential_mint broadcast (the resume run).
+    executed = [e for e in mint_events if e.result_status == "ok"]
+    assert len(executed) == 1
+    _assert_credential_mint_aggregate(executed[0], "harbor.robot.create")
+
+
+# ---------------------------------------------------------------------------
+# (AC2) harbor.robot.delete stays full-detail (write) — no gate, executes direct
+# ---------------------------------------------------------------------------
 
 
 @pytest.mark.asyncio
 async def test_robot_delete_broadcast_is_full_detail(
     stub_embedding_service: AsyncMock,
     captured_events: list[BroadcastEvent],
+    _persisted_harbor_target: UUID,
 ) -> None:
     """``harbor.robot.delete`` broadcasts full detail (``write`` class).
 
     Contrast test: ``harbor.robot.delete`` classifies ``write``, not
-    ``credential_mint``. Its broadcast carries the full ``params`` block.
-    Same dispatch + broadcast path as the create test; the divergent
-    behaviour is solely due to :func:`classify_op`.
+    ``credential_mint``, and is left ungated (#147 — a ``caution`` write
+    that revokes, not mints), so a human dispatches it directly (no
+    approval park). Its broadcast carries the full ``params`` block. The
+    divergent behaviour is solely due to :func:`classify_op`.
     """
     await register_harbor_robot_operations(embedding_service=stub_embedding_service)
 
     operator = _make_operator()
-    target = _HarborDispatchTarget()
 
     with respx.mock() as mock:
-        mock.delete("https://harbor.test.invalid/api/v2.0/projects/proj/robots/7").mock(
-            return_value=respx.MockResponse(200)
-        )
+        mock.delete(_ROBOT_7_URL).mock(return_value=respx.MockResponse(200))
         result = await dispatch(
             operator=operator,
             connector_id="harbor-rest-2.x",
             op_id="harbor.robot.delete",
-            target=target,
+            target=_HarborDispatchTarget(),
             params={"project": "proj", "id": 7},
         )
 
     assert result.status == "ok", result.error
 
-    assert len(captured_events) == 1
-    event = captured_events[0]
-    assert event.op_id == "harbor.robot.delete"
+    delete_events = [e for e in captured_events if e.op_id == "harbor.robot.delete"]
+    assert len(delete_events) == 1
+    event = delete_events[0]
     assert event.op_class == "write"
     # Full-detail broadcast — params block is present.
     assert "params" in event.payload
@@ -338,54 +519,44 @@ async def test_robot_delete_broadcast_is_full_detail(
 async def test_credential_mint_and_write_diverge_on_same_dispatch_path(
     stub_embedding_service: AsyncMock,
     captured_events: list[BroadcastEvent],
+    _persisted_harbor_target: UUID,
 ) -> None:
-    """Create is aggregate-only; delete is full-detail on the same path.
+    """Create is aggregate-only (post-approval); delete is full-detail (direct).
 
-    Dispatches both ops back-to-back through the identical infrastructure.
-    The only variable is the op-id; divergent redaction proves
-    :func:`classify_op` drives the behavior, not the handler or target.
+    Both ops flow through the identical dispatch + broadcast infrastructure
+    against the same target. The only variables are the op-id and the
+    #147 gate: create parks then executes via approve→resume; delete
+    executes directly. Divergent redaction proves :func:`classify_op`
+    drives the behaviour, not the handler or target.
     """
+    requester = _make_operator(sub="op-requester")
+    # Register both ops up front (idempotent — _park_robot_create re-calls it)
+    # so the direct delete dispatch resolves its descriptor.
     await register_harbor_robot_operations(embedding_service=stub_embedding_service)
 
-    operator = _make_operator()
-    target = _HarborDispatchTarget()
-
     with respx.mock() as mock:
-        mock.post("https://harbor.test.invalid/api/v2.0/projects/proj/robots").mock(
-            return_value=respx.MockResponse(
-                201,
-                json={
-                    "id": 7,
-                    "name": "robot$proj+bot",
-                    "secret": _SENTINEL_SECRET,
-                    "expiration_time": -1,
-                },
-            )
-        )
-        mock.delete("https://harbor.test.invalid/api/v2.0/projects/proj/robots/7").mock(
-            return_value=respx.MockResponse(200)
-        )
+        _mock_robot_create(mock)
+        mock.delete(_ROBOT_7_URL).mock(return_value=respx.MockResponse(200))
 
-        create_result = await dispatch(
-            operator=operator,
-            connector_id="harbor-rest-2.x",
-            op_id="harbor.robot.create",
-            target=target,
-            params={"name": "bot", "project": "proj", "duration": -1},
-        )
+        # Ungated write executes directly.
         delete_result = await dispatch(
-            operator=operator,
+            operator=requester,
             connector_id="harbor-rest-2.x",
             op_id="harbor.robot.delete",
-            target=target,
+            target=_HarborDispatchTarget(),
             params={"project": "proj", "id": 7},
         )
+        assert delete_result.status == "ok", delete_result.error
 
-    assert create_result.status == "ok", create_result.error
-    assert delete_result.status == "ok", delete_result.error
-    assert len(captured_events) == 2
+        # Gated credential-mint parks, then executes on second-operator approval.
+        request_id = await _park_robot_create(stub_embedding_service, requester=requester)
+        body = _approve_via_decide(request_id, mock, approver_sub="op-approver")
 
-    create_event = next(e for e in captured_events if e.op_id == "harbor.robot.create")
+    assert body["dispatch_status"] == "ok", body
+
+    create_event = next(
+        e for e in captured_events if e.op_id == "harbor.robot.create" and e.result_status == "ok"
+    )
     delete_event = next(e for e in captured_events if e.op_id == "harbor.robot.delete")
 
     # Same path, opposite redaction — classifier-driven by construction.
@@ -393,3 +564,48 @@ async def test_credential_mint_and_write_diverge_on_same_dispatch_path(
     assert delete_event.op_class == "write"
     _assert_credential_mint_aggregate(create_event, "harbor.robot.create")
     assert "params" in delete_event.payload
+
+
+# ---------------------------------------------------------------------------
+# (AC3) No credential-mint op may silently ship requires_approval=False
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.asyncio
+async def test_no_harbor_credential_mint_op_bypasses_approval(
+    stub_embedding_service: AsyncMock,
+) -> None:
+    """Every harbor-registered ``credential_mint`` op is four-eyes-gated (#147).
+
+    The non-agent policy gate (``_non_agent_verdict``) keys only on
+    ``requires_approval``, so a ``credential_mint`` op (privilege issuance)
+    left ``requires_approval=False`` lets a human ``tenant_admin`` mint a
+    credential with no four-eyes step — the bypass #147 closes. This is the
+    harbor analogue of bind9's ``test_no_dangerous_op_bypasses_approval``
+    (#129): it runs the real registrar and asserts the invariant against
+    the persisted descriptors, so a future harbor mint op can't
+    reintroduce the gap.
+    """
+    from meho_backplane.broadcast.events import classify_op
+    from meho_backplane.db.models import EndpointDescriptor
+
+    await register_harbor_robot_operations(embedding_service=stub_embedding_service)
+
+    async with get_sessionmaker()() as session:
+        result = await session.execute(
+            select(EndpointDescriptor).where(EndpointDescriptor.product == "harbor")
+        )
+        descriptors = list(result.scalars().all())
+
+    assert descriptors, "expected harbor descriptors to be registered"
+
+    # harbor.robot.create classifies credential_mint and MUST be gated.
+    mint_ops = [d for d in descriptors if classify_op(d.op_id) == "credential_mint"]
+    assert any(d.op_id == "harbor.robot.create" for d in mint_ops), (
+        "harbor.robot.create must classify credential_mint — the guard "
+        "asserts on that class; a mis-classification would silently void it"
+    )
+    offenders = [d.op_id for d in mint_ops if not d.requires_approval]
+    assert offenders == [], (
+        f"credential_mint harbor ops shipped without four-eyes gating: {offenders}"
+    )

--- a/docs/codebase/connectors-harbor.md
+++ b/docs/codebase/connectors-harbor.md
@@ -136,6 +136,17 @@ Typed op handler for `harbor.robot.create`. Classified `credential_mint` by
 `classify_op` in `broadcast/events.py` — the broadcast collapses to aggregate-only
 so the minted secret never appears in the SSE stream.
 
+Registered `requires_approval=True` (#147): minting a robot credential is
+privilege issuance, so it is four-eyes-gated. The non-agent policy gate
+(`_non_agent_verdict` in `operations/_validate.py`) keys the verdict solely on
+`requires_approval` (not `safety_level`), so a human `tenant_admin` dispatch
+**parks** at `awaiting_approval` and a second operator must approve it via
+`POST /api/v1/approvals/{id}/decide` before the mint executes (the resume
+re-dispatch runs with `_approved=True`). `harbor.robot.delete` stays ungated —
+it is a `caution`-class `write` that revokes access rather than minting a
+credential, mirroring the bind9 precedent (#129) that gated only `dangerous`
+config-replacement ops.
+
 The signature carries `operator: Operator` so `dispatch_typed`
 (`operations/_branches.py`, name-keyed operator threading) passes the
 dispatched operator into the handler. The operator is forwarded to `_post_json`


### PR DESCRIPTION
## Summary

- `harbor.robot.create` mints a robot credential in its response (`credential_mint`-classified) but was registered `requires_approval=False`. The non-agent policy gate (`_non_agent_verdict`) keys the verdict solely on `requires_approval` (not `safety_level`), so a human `tenant_admin` could mint a Harbor robot credential end-to-end with **no** second-operator approval. This flips it to `requires_approval=True` so the dispatch parks at `awaiting_approval` and a second operator must approve via `POST /api/v1/approvals/{id}/decide` before the mint executes.
- `harbor.robot.delete` is left ungated: it is a `caution`-class `write` that revokes access rather than minting a credential (recoverable via re-mint), mirroring the bind9 precedent that gated only the `dangerous` config-replacement ops.
- Reworks the three `credential_mint` broadcast-redaction tests to drive the op through the real **approve → resume** flow, so the redaction assertion runs against the executed (post-approval) op instead of a parked/skipped one. Drops the `BROADCAST_REDIS_URL` skip guard (the recording-stub publisher opens no Valkey socket) so the suite runs deterministically in the sandbox, closing the prior green-local / red-CI gap.
- Adds an audit-row assertion that the parked "request" row carries `policy_decision = "needs-approval"`, and a harbor analogue of bind9's no-bypass test asserting every `credential_mint` harbor op is registered `requires_approval=True`.

## Test plan

- [x] `ruff check` — clean (harbor ops + reworked test)
- [x] `ruff format --check` — clean
- [x] `mypy src/meho_backplane/connectors/harbor/ops.py` — no issues
- [x] `pytest tests/test_broadcast_credential_mint_dispatch.py` — 5 passed (was 3 skipped locally before)
- [x] AC1: human dispatch parks (`awaiting_approval` + `approval_request_id`); parked audit row asserts `policy_decision="needs-approval"`
- [x] AC2: 3 redaction tests pass through park → second-operator `/decide` → `_approved=True` re-dispatch; redaction asserted on the executed op; run unconditionally (not skipped)
- [x] AC3: harbor no-bypass test asserts every `credential_mint` harbor descriptor is `requires_approval=True`
- [x] AC4: `pytest -k "harbor or credential_mint"` — 101 passed, 14 skipped, 0 failed
- [x] Regression: `test_approval_queue` / `test_secret_move_approval` / `test_api_v1_approvals` / `test_broadcast_credential_{write,read}_dispatch` — 61 passed, 4 skipped

## Notes

- No FastAPI routes or schemas changed → no CLI OpenAPI snapshot regen required.
- `docs/codebase/connectors-harbor.md` updated to document the four-eyes gate on `robot_create` and the rationale for leaving `robot_delete` ungated.

Closes evoila-bosnia/meho-internal#147


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Harbor robot creation (`harbor.robot.create`) is now four-eyes approved before a credential is minted, and approved requests automatically resume to complete the action.
* **Bug Fixes**
  * Broadcast events for credential minting are now strictly redacted to avoid exposing minted secret details.
  * Harbor robot deletion (`harbor.robot.delete`) remains ungated and continues to emit full action details.
* **Documentation**
  * Updated Harbor connector docs to describe the approval→resume behavior and deletion exception.
* **Tests**
  * Expanded and stabilized unit/integration coverage for approve→resume, redaction guarantees, and invariants preventing approval bypass.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->