### PR TITLE
fix(connectors): carry datastore capacity via list-row fallback (#2078)

### DIFF
--- a/backend/src/meho_backplane/connectors/vmware_rest/composites/_read.py
+++ b/backend/src/meho_backplane/connectors/vmware_rest/composites/_read.py
@@ -604,8 +604,21 @@ async def datastore_usage_composite(
             )
         )
         detail_payload = _unwrap_value(detail)
-        capacity = detail_payload.get("capacity") if isinstance(detail_payload, dict) else None
-        free_space = detail_payload.get("free_space") if isinstance(detail_payload, dict) else None
+        detail_capacity = (
+            detail_payload.get("capacity") if isinstance(detail_payload, dict) else None
+        )
+        detail_free_space = (
+            detail_payload.get("free_space") if isinstance(detail_payload, dict) else None
+        )
+        # The per-datastore detail ``Datastore.Info`` is the primary source,
+        # but some vCenter builds (observed on 8.0.3 against the 9.0 spec,
+        # #2078) return a detail payload that omits/nulls ``capacity`` while
+        # still populating ``free_space``. The ``GET:/vcenter/datastore`` list
+        # row already carries both fields, so fall back to it when the detail
+        # value is absent -- otherwise the composite silently discards a
+        # capacity it already fetched, leaving %-full uncomputable.
+        capacity = detail_capacity if detail_capacity is not None else entry.get("capacity")
+        free_space = detail_free_space if detail_free_space is not None else entry.get("free_space")
         row: dict[str, Any] = {
             "id": ds_id,
             "name": entry.get("name"),

--- a/backend/src/meho_backplane/connectors/vmware_rest/composites/schemas.py
+++ b/backend/src/meho_backplane/connectors/vmware_rest/composites/schemas.py
@@ -415,13 +415,17 @@ DATASTORE_USAGE_RESPONSE_SCHEMA: dict[str, Any] = {
                     "capacity": {
                         "type": ["integer", "null"],
                         "description": (
-                            "Total capacity in bytes; ``null`` when the detail payload omits it."
+                            "Total capacity in bytes; sourced from the per-datastore "
+                            "detail payload, falling back to the listing row when the "
+                            "detail omits it. ``null`` only when neither carries it."
                         ),
                     },
                     "free_space": {
                         "type": ["integer", "null"],
                         "description": (
-                            "Free space in bytes; ``null`` when the detail payload omits it."
+                            "Free space in bytes; sourced from the per-datastore detail "
+                            "payload, falling back to the listing row when the detail "
+                            "omits it. ``null`` only when neither carries it."
                         ),
                     },
                     "vm_count": {

--- a/backend/tests/test_connectors_vmware_rest_composites_read.py
+++ b/backend/tests/test_connectors_vmware_rest_composites_read.py
@@ -508,6 +508,97 @@ async def test_datastore_usage_three_ops_per_datastore_aggregates_correctly() ->
 
 
 @pytest.mark.asyncio
+async def test_datastore_usage_capacity_falls_back_to_list_row_when_detail_omits_it() -> None:
+    """Detail without ``capacity`` (live 8.0.3 shape) -> capacity from the list row (#2078).
+
+    Some vCenter builds return a per-datastore detail ``Datastore.Info``
+    that populates ``free_space`` but omits ``capacity`` entirely. The
+    ``GET:/vcenter/datastore`` list row carries both fields, so the
+    composite must fall back to the list-row ``capacity`` rather than
+    silently emitting ``capacity: null`` (which leaves %-full
+    uncomputable, the whole reason to reach for the composite).
+    """
+    listing = [
+        {"datastore": "datastore-1", "name": "ds-1", "type": "VMFS", "capacity": 1000},
+    ]
+    sequence = [
+        _ok_result("GET:/vcenter/datastore", listing),
+        # Detail carries free_space but NO ``capacity`` key at all.
+        _ok_result("GET:/vcenter/datastore/{datastore}", {"free_space": 400, "type": "VMFS"}),
+        _ok_result("GET:/vcenter/vm", [{"name": "vm-a"}]),
+    ]
+    dispatch = _RecordingDispatchChild(sequence)
+    out = await datastore_usage_composite(
+        operator=_make_operator(),
+        target=object(),
+        params={},
+        dispatch_child=dispatch,
+    )
+    row = out["datastores"][0]
+    # capacity sourced from the list row; free_space from the detail read.
+    assert row["capacity"] == 1000
+    assert row["free_space"] == 400
+
+
+@pytest.mark.asyncio
+async def test_datastore_usage_capacity_null_when_neither_detail_nor_list_carry_it() -> None:
+    """Neither detail nor list row carries ``capacity`` -> row ``capacity`` is null (#2078).
+
+    The fallback is best-effort: with no source for capacity the row must
+    still be schema-valid (``capacity`` typed ``["integer", "null"]``) and
+    the aggregation must not crash.
+    """
+    listing = [
+        {"datastore": "datastore-1", "name": "ds-1", "type": "VMFS"},
+    ]
+    sequence = [
+        _ok_result("GET:/vcenter/datastore", listing),
+        # Detail lacks capacity; list row lacks capacity -> null, no crash.
+        _ok_result("GET:/vcenter/datastore/{datastore}", {"free_space": 400}),
+        _ok_result("GET:/vcenter/vm", []),
+    ]
+    dispatch = _RecordingDispatchChild(sequence)
+    out = await datastore_usage_composite(
+        operator=_make_operator(),
+        target=object(),
+        params={},
+        dispatch_child=dispatch,
+    )
+    row = out["datastores"][0]
+    assert row["capacity"] is None
+    assert row["free_space"] == 400
+
+
+@pytest.mark.asyncio
+async def test_datastore_usage_detail_capacity_wins_over_list_row() -> None:
+    """When the detail payload supplies ``capacity``, the detail value wins (#2078).
+
+    Guards the fallback against regressing the primary path: the list row
+    carries a stale/different capacity, but the detail read is the source
+    of truth whenever it provides the field.
+    """
+    listing = [
+        {"datastore": "datastore-1", "name": "ds-1", "type": "VMFS", "capacity": 1000},
+    ]
+    sequence = [
+        _ok_result("GET:/vcenter/datastore", listing),
+        _ok_result("GET:/vcenter/datastore/{datastore}", {"capacity": 100, "free_space": 40}),
+        _ok_result("GET:/vcenter/vm", []),
+    ]
+    dispatch = _RecordingDispatchChild(sequence)
+    out = await datastore_usage_composite(
+        operator=_make_operator(),
+        target=object(),
+        params={},
+        dispatch_child=dispatch,
+    )
+    row = out["datastores"][0]
+    # Detail's 100 wins over the list row's 1000.
+    assert row["capacity"] == 100
+    assert row["free_space"] == 40
+
+
+@pytest.mark.asyncio
 async def test_datastore_usage_filter_names_passes_through_to_listing() -> None:
     """``filter_names`` flows into the listing sub-op as ``filter.names``."""
     sequence = [_ok_result("GET:/vcenter/datastore", [])]

--- a/docs/codebase/connectors-vmware-rest.md
+++ b/docs/codebase/connectors-vmware-rest.md
@@ -378,6 +378,17 @@ recording the failing sub-op, its status, and the underlying error.
 The response schema marks `vm_count`/`vm_names` as nullable and adds the
 optional `enrichment_note` key (present only on a skipped row).
 
+`capacity`/`free_space` are read from the per-datastore detail payload
+with a **list-row fallback** (#2078): some vCenter builds (observed on an
+8.0.3 vCenter against the 9.0 spec) return a detail `Datastore.Info` that
+populates `free_space` but omits `capacity`, while the
+`GET:/vcenter/datastore` listing row carries both. The row-builder takes
+the detail value when present and falls back to `entry.get(...)` on the
+already-fetched listing row otherwise, so `capacity`/`free_space` are
+`null` only when neither source carries them — the composite no longer
+discards a capacity it already had, which is what made `%`-full
+uncomputable off the composite alone.
+
 ### Bubbling a sub-op's structured error (#1908)
 
 `CompositeSubOpError` folds the failed sub-op's most diagnostic line


### PR DESCRIPTION
## Summary
- `vmware.composite.datastore.usage` returned `capacity=null` for every datastore on some vCenter builds (observed on an 8.0.3 vCenter against the 9.0 spec): the row-builder read `capacity`/`free_space` **only** from the per-datastore detail `Datastore.Info`, so a build whose detail omits the `capacity` key (while still populating `free_space`) surfaced a null capacity — leaving `%`-full uncomputable off the composite alone.
- The load-bearing fact from the triage: the `GET:/vcenter/datastore` **listing row** already carries `capacity`/`free_space`, and the composite already fetched it. This change sources both fields from the detail payload with a **fallback to the listing row** (`entry.get(...)`) when the detail value is absent — detail still wins when present; `null` only when neither source carries it.
- No schema change: `capacity`/`free_space` are already typed `["integer","null"]`. Their schema descriptions and `docs/codebase/connectors-vmware-rest.md` are updated to reflect the detail-then-list source.

## Test plan
- [x] `ruff check` — clean (`_read.py`, `schemas.py`, test file)
- [x] `ruff format --check` — clean (3 files formatted)
- [x] `mypy src/.../composites/` — Success, no issues (7 source files)
- [x] `pytest tests/test_connectors_vmware_rest_composites_read.py` — 27 passed
- [x] `pytest -k composite` — 216 passed, 2 skipped
- [x] **AC1/AC3** new-shape: detail returns `free_space` but no `capacity` key → aggregated `capacity` sourced from the list row (non-null), `free_space` from detail — `test_datastore_usage_capacity_falls_back_to_list_row_when_detail_omits_it`
- [x] **AC2/AC4** detail-wins unchanged: existing `test_datastore_usage_three_ops_per_datastore_aggregates_correctly` passes; new `test_datastore_usage_detail_capacity_wins_over_list_row` proves detail value beats a differing list-row value
- [x] **AC5** both-missing: neither detail nor list row carries `capacity` → row `capacity` is `null`, no crash, schema-valid — `test_datastore_usage_capacity_null_when_neither_detail_nor_list_carry_it`

## Out of scope
- The vm-placement leg still best-effort-400s on 8.0 vCenters (`filter.datastores` skew) — that is the known #1908 behavior, not a new complaint.
- No FastAPI route/schema touched → no OpenAPI snapshot regen required (composite result schema is an op-result schema, not a route model).

<!-- auto-implement-issue: fresh, iteration 1 -->

Closes #2078


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved datastore usage values so capacity and free space are retained when detailed data is incomplete.
  * Prevented valid capacity information from being dropped if it is available in the datastore listing.
  * Added coverage for missing, present, and overriding capacity values to ensure consistent results.

* **Documentation**
  * Clarified how datastore usage values are sourced and when fallback values are used.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->