### PR TITLE
fix(ui): recover the expired OAuth-callback-state raw-JSON dead-end (#2089)

### DIFF
--- a/backend/src/meho_backplane/ui/auth/errors.py
+++ b/backend/src/meho_backplane/ui/auth/errors.py
@@ -1,7 +1,7 @@
 # SPDX-License-Identifier: Apache-2.0
 # Copyright (c) 2026 evoila Group
 
-"""``session_expired`` exception handler -- HTML gets a redirect (G0.25 #1694).
+"""Recoverable-auth-state exception handler -- HTML gets a redirect.
 
 FastAPI's default :class:`HTTPException` handler renders every error
 as ``application/json``, regardless of the request's ``Accept``
@@ -16,31 +16,45 @@ This module ships the app-level exception handler
 :class:`starlette.exceptions.HTTPException` (FastAPI routes raise
 :class:`fastapi.HTTPException`, a subclass, so one registration
 covers both -- the override pattern from the FastAPI handling-errors
-guide). The handler intercepts exactly one shape:
+guide). The handler intercepts exactly two recoverable shapes, both
+only when the request ``Accept`` header names ``text/html``:
 
-* status ``401`` **and** detail
+* **Session expired** (G0.25 #1694) -- status ``401`` **and** detail
   :data:`~meho_backplane.ui.auth.refresh.SESSION_EXPIRED_DETAIL`
-  **and** path under ``/ui/`` **and** the request ``Accept`` header
-  names ``text/html``
+  **and** path under ``/ui/``. Answered with a ``302`` to
+  ``/ui/auth/login?return_to=<original path+query>`` -- the same
+  redirect contract
+  :class:`~meho_backplane.ui.auth.middleware.UISessionMiddleware` uses
+  for missing sessions -- plus a ``meho_session`` cookie clear (the row
+  is terminally dead once a refresh has failed; RFC 6749 § 6 gives the
+  BFF nothing left to present).
 
-and answers it with a ``302`` to
-``/ui/auth/login?return_to=<original path+query>`` -- the same
-redirect contract :class:`~meho_backplane.ui.auth.middleware.UISessionMiddleware`
-uses for missing sessions -- plus a ``meho_session`` cookie clear
-(the row is terminally dead once a refresh has failed; RFC 6749 § 6
-gives the BFF nothing left to present). Non-HTML callers on the same
-401 get the regular JSON body, with the cookie cleared as well.
+* **Expired callback state** (G0.29 #2089, Leg 1) -- status ``400``
+  **and** detail
+  :data:`~meho_backplane.ui.auth.routes.AUTHORIZATION_STATE_EXPIRED_DETAIL`
+  **and** path ``/ui/auth/callback``. The operator let the login
+  window lapse (``STATE_TTL``), so the ``state`` / PKCE verifier
+  expired. Answered with a ``303`` to ``/ui/auth/login`` to restart the
+  flow on one click. No cookie is touched -- the callback runs
+  pre-session. No ``return_to`` is carried: it was stashed with the
+  now-expired verifier and cannot be recovered.
+
+Non-HTML callers on either shape get the regular structured JSON body
+(the ``session_expired`` case also drops the dead cookie).
 **Everything else** -- other detail codes, other statuses, other
-paths -- delegates verbatim to
+paths, the callback's genuine IdP ``authorization_failed`` and its
+token-endpoint ``502`` -- delegates verbatim to
 :func:`fastapi.exception_handlers.http_exception_handler`, so the
 chassis-wide error contract (including ``/api/*``'s structured 401
 codes) is bit-for-bit unchanged.
 
-Scoping the interception to the ``session_expired`` detail code --
-minted only by :mod:`meho_backplane.ui.auth.refresh` -- rather than
-to "any 401 with an HTML Accept" is deliberate: blanket-redirecting
-401s would swallow real diagnostics (``signature_verification_failed``,
-``invalid_audience``) behind a login bounce loop.
+Scoping each interception to a specific detail code -- ``session_expired``
+minted only by :mod:`meho_backplane.ui.auth.refresh`,
+``authorization_state_expired`` minted only by the recoverable branch
+of :mod:`meho_backplane.ui.auth.routes` -- rather than to "any 401/400
+with an HTML Accept" is deliberate: blanket-redirecting would swallow
+real diagnostics (``signature_verification_failed``, an IdP-declined
+``authorization_failed``) behind a login bounce loop.
 
 References
 ----------
@@ -60,12 +74,23 @@ from fastapi.responses import RedirectResponse
 from starlette.exceptions import HTTPException as StarletteHTTPException
 
 from meho_backplane.ui.auth.refresh import SESSION_EXPIRED_DETAIL
-from meho_backplane.ui.auth.routes import LOGIN_PATH, clear_session_cookie
+from meho_backplane.ui.auth.routes import (
+    AUTHORIZATION_STATE_EXPIRED_DETAIL,
+    LOGIN_PATH,
+    clear_session_cookie,
+)
 
 __all__ = ["ui_session_expired_exception_handler"]
 
 
 _UI_PREFIX = "/ui/"
+
+#: Exact path of the OAuth callback handler. The recoverable
+#: callback-state interception below is scoped to this one route so a
+#: ``400 authorization_state_expired`` raised from anywhere else (there
+#: is nowhere else today, but the scoping is defence-in-depth) is left
+#: to FastAPI's stock JSON handler.
+_CALLBACK_PATH = "/ui/auth/callback"
 
 
 def _is_session_expired_ui_request(request: Request, exc: StarletteHTTPException) -> bool:
@@ -74,6 +99,24 @@ def _is_session_expired_ui_request(request: Request, exc: StarletteHTTPException
         exc.status_code == status.HTTP_401_UNAUTHORIZED
         and exc.detail == SESSION_EXPIRED_DETAIL
         and request.url.path.startswith(_UI_PREFIX)
+    )
+
+
+def _is_expired_callback_state_request(request: Request, exc: StarletteHTTPException) -> bool:
+    """True when *exc* is the recoverable expired-callback-state 400.
+
+    Matches the ``400 authorization_state_expired`` raised by
+    :func:`meho_backplane.ui.auth.routes._exchange_or_translate` on
+    ``GET /ui/auth/callback`` when the ``state`` / verifier expired or
+    mismatched (G0.29 #2089, Leg 1). Scoped to the callback path and
+    that exact detail code so the genuine IdP ``?error=`` path (which
+    raises ``authorization_failed``) and the token-endpoint-unreachable
+    502 are never swept into the login-restart affordance.
+    """
+    return (
+        exc.status_code == status.HTTP_400_BAD_REQUEST
+        and exc.detail == AUTHORIZATION_STATE_EXPIRED_DETAIL
+        and request.url.path == _CALLBACK_PATH
     )
 
 
@@ -96,30 +139,36 @@ def _login_redirect(request: Request) -> RedirectResponse:
     return response
 
 
-async def ui_session_expired_exception_handler(
-    request: Request,
-    exc: Exception,
-) -> Response:
-    """App-level handler: map ``session_expired`` 401s to a re-auth flow.
+def _login_restart_redirect() -> RedirectResponse:
+    """303 to a fresh login flow after an expired callback state.
 
-    Registered for :class:`starlette.exceptions.HTTPException` (which
-    makes this the app's HTTPException handler, period -- hence the
-    explicit delegation to FastAPI's stock
-    :func:`~fastapi.exception_handlers.http_exception_handler` for
-    every non-matching exception). The parameter is typed
-    ``Exception`` to satisfy Starlette's ``ExceptionHandler``
-    signature; the isinstance narrow below is the registration
-    contract made explicit.
+    Unlike :func:`_login_redirect`, no ``return_to`` is carried: the
+    originally-requested path was stashed in the PKCE verifier store
+    keyed on the ``state`` that just expired, so it is unrecoverable by
+    the time this handler runs. A bare ``/ui/auth/login`` restarts the
+    flow and lands the operator on the ``/ui/`` default -- the same
+    outcome a manual "start over" produces, minus the hand-navigation.
+
+    ``303 See Other`` (not 302) is the correct status for "the recovery
+    is a *new GET* on the login route": it tells the browser to follow
+    with GET regardless of the original method, and side-steps the
+    302-method-preservation ambiguity older agents carry.
     """
-    if not isinstance(exc, StarletteHTTPException):  # pragma: no cover - registration contract
-        raise exc
-    if not _is_session_expired_ui_request(request, exc):
-        return await http_exception_handler(request, exc)
+    response = RedirectResponse(url=LOGIN_PATH, status_code=status.HTTP_303_SEE_OTHER)
+    response.headers["cache-control"] = "no-store"
+    return response
 
+
+async def _handle_session_expired(request: Request, exc: StarletteHTTPException) -> Response:
+    """Map the refresh-failure 401 to a login bounce (HTML) or JSON body.
+
+    The dead session cookie is dropped in both branches -- the row is
+    terminally unloadable once refresh has failed, so the client has
+    no further use for the id.
+    """
     accept = request.headers.get("accept", "")
-    log = structlog.get_logger(__name__)
     if "text/html" in accept:
-        log.info(
+        structlog.get_logger(__name__).info(
             "ui_session_expired_redirect",
             path=request.url.path,
         )
@@ -131,3 +180,60 @@ async def ui_session_expired_exception_handler(
         response = await http_exception_handler(request, exc)
     clear_session_cookie(response)
     return response
+
+
+async def _handle_expired_callback_state(request: Request, exc: StarletteHTTPException) -> Response:
+    """Map the recoverable expired-callback-state 400 to a login restart.
+
+    HTML navigations (an operator who let the login window lapse) get a
+    ``303`` back to ``/ui/auth/login`` so the flow restarts on one click
+    instead of dead-ending on raw JSON (G0.29 #2089, Leg 1). No cookie
+    is touched -- the callback runs pre-session, so there is no
+    ``meho_session`` to clear. Non-HTML / scripted callers keep the
+    structured ``authorization_state_expired`` body.
+    """
+    accept = request.headers.get("accept", "")
+    if "text/html" in accept:
+        structlog.get_logger(__name__).info(
+            "ui_auth_callback_state_expired_restart",
+            path=request.url.path,
+        )
+        return _login_restart_redirect()
+    return await http_exception_handler(request, exc)
+
+
+async def ui_session_expired_exception_handler(
+    request: Request,
+    exc: Exception,
+) -> Response:
+    """App-level handler: map recoverable BFF auth states to a re-auth flow.
+
+    Registered for :class:`starlette.exceptions.HTTPException` (which
+    makes this the app's HTTPException handler, period -- hence the
+    explicit delegation to FastAPI's stock
+    :func:`~fastapi.exception_handlers.http_exception_handler` for
+    every non-matching exception). The parameter is typed
+    ``Exception`` to satisfy Starlette's ``ExceptionHandler``
+    signature; the isinstance narrow below is the registration
+    contract made explicit.
+
+    Two recoverable shapes are intercepted, both only for HTML
+    navigations (JSON / scripted callers keep the structured body):
+
+    * ``401 session_expired`` on ``/ui/*`` (G0.25 #1694) -- refresh
+      failed, bounce to login carrying ``return_to``.
+    * ``400 authorization_state_expired`` on ``/ui/auth/callback``
+      (G0.29 #2089) -- the login window lapsed, restart the flow.
+
+    Everything else -- other detail codes, other statuses, other paths,
+    including the ``/api/*`` structured 401 codes and the callback's
+    genuine IdP ``authorization_failed`` / token-endpoint ``502`` --
+    delegates verbatim to FastAPI's stock handler.
+    """
+    if not isinstance(exc, StarletteHTTPException):  # pragma: no cover - registration contract
+        raise exc
+    if _is_session_expired_ui_request(request, exc):
+        return await _handle_session_expired(request, exc)
+    if _is_expired_callback_state_request(request, exc):
+        return await _handle_expired_callback_state(request, exc)
+    return await http_exception_handler(request, exc)

--- a/backend/src/meho_backplane/ui/auth/routes.py
+++ b/backend/src/meho_backplane/ui/auth/routes.py
@@ -119,6 +119,7 @@ from meho_backplane.ui.auth.session_store import (
 )
 
 __all__ = [
+    "AUTHORIZATION_STATE_EXPIRED_DETAIL",
     "LOGIN_PATH",
     "SESSION_COOKIE_NAME",
     "SESSION_TTL_MARGIN_SECONDS",
@@ -154,6 +155,21 @@ SESSION_TTL_MARGIN_SECONDS: Final[int] = 60
 #: Default landing path when no ``?return_to`` is supplied on
 #: ``/ui/auth/login``. T5 (#866) lands the dashboard at ``/ui/``.
 _DEFAULT_RETURN_TO: Final[str] = "/ui/"
+
+#: Detail code for the *recoverable* callback-state failure class --
+#: an expired/mismatched ``state``, a verifier-store miss, or authlib's
+#: :class:`MismatchingStateError` on ``GET /ui/auth/callback`` (G0.29
+#: #2089, Leg 1). Distinct from the generic ``authorization_failed``
+#: used by the genuine IdP ``?error=`` path so the app-level handler in
+#: :mod:`meho_backplane.ui.auth.errors` can map *only this class* to a
+#: one-click login restart for HTML navigations, without collapsing the
+#: IdP-declined (:func:`_raise_idp_error`) or token-endpoint-unreachable
+#: (502) paths into "start over". Like ``authorization_failed`` it
+#: names a *class* of recoverable states, not the precise sub-cause --
+#: the specific failure stays in structlog only (the
+#: ``_exchange_or_translate`` log discipline), so the body still does
+#: not telegraph what an attacker probed.
+AUTHORIZATION_STATE_EXPIRED_DETAIL: Final[str] = "authorization_state_expired"
 
 
 def compute_redirect_uri() -> str:
@@ -362,10 +378,15 @@ async def _exchange_or_translate(
             detail=MISSING_CLIENT_SECRET_DETAIL,
         ) from None
     except (OAuthFlowError, MismatchingStateError, OAuthError) as exc:
-        # State mismatch / verifier-store miss / IdP-side rejection
-        # all collapse to one 400. The specific cause goes to
-        # structlog only -- telegraphing it in the body helps an
-        # attacker probe.
+        # State mismatch / verifier-store miss / expired verifier all
+        # collapse to one 400. The specific cause goes to structlog
+        # only -- telegraphing it in the body helps an attacker probe.
+        # This class is *recoverable*: a fresh /ui/auth/login round-trip
+        # succeeds. It carries a detail distinct from the IdP-declined
+        # ``authorization_failed`` (:func:`_raise_idp_error`) so the
+        # app-level handler can offer a one-click restart on HTML
+        # navigations (G0.29 #2089) without collapsing the genuine
+        # IdP error or the token-endpoint 502 into "start over".
         log.warning(
             "ui_auth_callback_rejected",
             error_class=type(exc).__name__,
@@ -373,7 +394,7 @@ async def _exchange_or_translate(
         )
         raise HTTPException(
             status_code=status.HTTP_400_BAD_REQUEST,
-            detail="authorization_failed",
+            detail=AUTHORIZATION_STATE_EXPIRED_DETAIL,
         ) from exc
     except httpx.HTTPError as exc:
         log.warning(

--- a/backend/tests/test_ui_auth_flow.py
+++ b/backend/tests/test_ui_auth_flow.py
@@ -44,6 +44,7 @@ import respx
 from cryptography.fernet import Fernet
 from fastapi import FastAPI
 from fastapi.testclient import TestClient
+from starlette.exceptions import HTTPException as StarletteHTTPException
 
 from meho_backplane.auth.jwt import clear_jwks_cache
 from meho_backplane.db.engine import get_sessionmaker, reset_engine_for_testing
@@ -54,6 +55,7 @@ from meho_backplane.ui.auth import (
     UISessionMiddleware,
     build_router,
 )
+from meho_backplane.ui.auth.errors import ui_session_expired_exception_handler
 from meho_backplane.ui.auth.flow import (
     AUTHORIZATION_FLOW_TTL_SECONDS,
     PKCEVerifierStore,
@@ -63,6 +65,7 @@ from meho_backplane.ui.auth.flow import (
     get_verifier_store,
     reset_verifier_store_for_testing,
 )
+from meho_backplane.ui.auth.routes import AUTHORIZATION_STATE_EXPIRED_DETAIL
 from meho_backplane.ui.auth.session_store import (
     create_session,
     load_session,
@@ -166,6 +169,11 @@ def _build_app(*, include_dummy_ui_route: bool = True) -> FastAPI:
     """
     app = FastAPI()
     app.add_middleware(UISessionMiddleware)
+    # Register the app-level HTTPException handler exactly as
+    # meho_backplane.main does, so the callback's recoverable-state
+    # HTML-redirect affordance (G0.29 #2089) is exercised under test
+    # rather than only in the wired-up production app.
+    app.add_exception_handler(StarletteHTTPException, ui_session_expired_exception_handler)
     app.include_router(build_router())
     if include_dummy_ui_route:
 
@@ -425,26 +433,72 @@ def test_callback_creates_session_and_sets_cookie() -> None:
     asyncio.run(_check_row())
 
 
+# Non-HTML ``Accept`` -- a scripted probe / htmx fragment fetch. The
+# recoverable-state class keeps its structured JSON body for these
+# callers (only HTML navigations get the login-restart redirect).
+_JSON_ACCEPT = {"accept": "application/json"}
+# HTML ``Accept`` -- a real browser navigating the callback URL. This
+# is the class that gets the one-click login-restart affordance.
+_HTML_ACCEPT = {"accept": "text/html,application/xhtml+xml"}
+
+
 def test_callback_rejects_unknown_state() -> None:
-    """Replay of a consumed / forged ``state`` collapses to a 400."""
+    """Replay of a consumed / forged ``state`` -> recoverable 400 (JSON caller)."""
     with respx.mock(assert_all_called=False) as mock_router:
         _mock_oidc_metadata(mock_router)
         client = TestClient(_build_app(), follow_redirects=False)
         response = client.get(
             "/ui/auth/callback?code=test-code&state=not-a-real-state",
+            headers=_JSON_ACCEPT,
         )
     assert response.status_code == 400
-    assert response.json()["detail"] == "authorization_failed"
+    # Non-HTML callers keep a structured body -- now the recoverable
+    # ``authorization_state_expired`` code (distinct from an IdP decline).
+    assert response.json()["detail"] == AUTHORIZATION_STATE_EXPIRED_DETAIL
 
 
 def test_callback_rejects_missing_state() -> None:
-    """The CSRF guard fires on a missing ``state`` -- no verifier lookup possible."""
+    """Missing ``state`` -> recoverable 400 body for a JSON caller."""
     with respx.mock(assert_all_called=False) as mock_router:
         _mock_oidc_metadata(mock_router)
         client = TestClient(_build_app(), follow_redirects=False)
-        response = client.get("/ui/auth/callback?code=test-code")
+        response = client.get("/ui/auth/callback?code=test-code", headers=_JSON_ACCEPT)
     assert response.status_code == 400
-    assert response.json()["detail"] == "authorization_failed"
+    assert response.json()["detail"] == AUTHORIZATION_STATE_EXPIRED_DETAIL
+
+
+def test_callback_expired_state_html_redirects_to_login() -> None:
+    """AC 1/2: an HTML navigation on expired ``state`` gets a 303 login restart.
+
+    The whole point of #2089 Leg 1: instead of the raw-JSON dead-end a
+    browser would render for ``{"detail": "..."}``, an operator who let
+    the login window lapse is bounced back to ``/ui/auth/login`` on one
+    click -- no hand-navigation, no cookie to clear (pre-session).
+    """
+    with respx.mock(assert_all_called=False) as mock_router:
+        _mock_oidc_metadata(mock_router)
+        client = TestClient(_build_app(), follow_redirects=False)
+        response = client.get(
+            "/ui/auth/callback?code=test-code&state=not-a-real-state",
+            headers=_HTML_ACCEPT,
+        )
+    assert response.status_code == 303
+    assert response.headers["location"] == "/ui/auth/login"
+    # No dead ``meho_session`` cookie is set -- the callback runs before
+    # any session exists, so there is nothing to clear.
+    assert SESSION_COOKIE_NAME not in response.cookies
+    # Never re-cache a redirect the browser might replay stale.
+    assert response.headers.get("cache-control") == "no-store"
+
+
+def test_callback_missing_state_html_redirects_to_login() -> None:
+    """AC 1/2: a missing-``state`` HTML navigation also restarts the login flow."""
+    with respx.mock(assert_all_called=False) as mock_router:
+        _mock_oidc_metadata(mock_router)
+        client = TestClient(_build_app(), follow_redirects=False)
+        response = client.get("/ui/auth/callback?code=test-code", headers=_HTML_ACCEPT)
+    assert response.status_code == 303
+    assert response.headers["location"] == "/ui/auth/login"
 
 
 def test_callback_propagates_idp_error_to_400() -> None:
@@ -459,15 +513,43 @@ def test_callback_propagates_idp_error_to_400() -> None:
     assert response.json()["detail"] == "authorization_failed"
 
 
+def test_callback_idp_error_html_is_not_collapsed_to_login_restart() -> None:
+    """AC 4: a genuine IdP decline is NOT swept into the "start over" affordance.
+
+    Even with an HTML ``Accept``, ``?error=access_denied`` stays a 400
+    ``authorization_failed`` JSON body -- it is distinct from the
+    recoverable expired-state class and must remain diagnosable rather
+    than looping the operator back to a login that will decline again.
+    """
+    with respx.mock(assert_all_called=False) as mock_router:
+        _mock_oidc_metadata(mock_router)
+        client = TestClient(_build_app(), follow_redirects=False)
+        response = client.get(
+            "/ui/auth/callback?error=access_denied&error_description=user-cancelled",
+            headers=_HTML_ACCEPT,
+        )
+    assert response.status_code == 400
+    assert response.json()["detail"] == "authorization_failed"
+
+
 def test_callback_502s_when_token_endpoint_unreachable() -> None:
-    """Network failure on the token endpoint surfaces as 502."""
+    """Network failure on the token endpoint surfaces as 502 (not a login restart).
+
+    AC 4: the unreachable-token-endpoint path stays a distinguishable
+    502 even for an HTML navigation -- restarting the login flow would
+    just hit the same dead token endpoint, so it must not be collapsed
+    into the recoverable "start over" affordance.
+    """
     with respx.mock(assert_all_called=False) as mock_router:
         _mock_oidc_metadata(mock_router)
         mock_router.post(_TOKEN_ENDPOINT).mock(side_effect=httpx.ConnectError("boom"))
         client = TestClient(_build_app(), follow_redirects=False)
         login_response = client.get("/ui/auth/login")
         state = parse_qs(urlparse(login_response.headers["location"]).query)["state"][0]
-        response = client.get(f"/ui/auth/callback?code=test-code&state={state}")
+        response = client.get(
+            f"/ui/auth/callback?code=test-code&state={state}",
+            headers=_HTML_ACCEPT,
+        )
     assert response.status_code == 502
     assert response.json()["detail"] == "upstream_auth_provider_unreachable"
 

--- a/docs/codebase/ui.md
+++ b/docs/codebase/ui.md
@@ -54,7 +54,7 @@ Locked decisions:
 | `meho_backplane.ui.auth.routes` | FastAPI `APIRouter` for `/ui/auth/{login,callback,logout}`. `build_router()` returns the router for T5 to mount. Callback verifies the access token through the chassis JWT chain (`verify_jwt_for_audience`) so the BFF inherits issuer / audience / sub / tenant_id / tenant_role checks. Sets `meho_session` cookie with `HttpOnly; Secure; SameSite=Strict; Path=/`. Logout revokes the session, clears the cookie, and 302s to Keycloak's `end_session_endpoint` (best-effort -- a missing endpoint falls back to a local `/ui/auth/login` redirect). |
 | `meho_backplane.ui.auth.middleware` | Pure-ASGI `UISessionMiddleware` for `/ui/*`. Loads operator identity from the session cookie on every request; 302s to login on missing/expired session. Bypasses `/ui/static/*` (chassis assets) and `/ui/auth/*` (the BFF surfaces themselves). Per-request `UISessionContext` (frozen dataclass: `session_id`, `operator_sub`, `tenant_id`, plus `tenant_slug` + `tenant_name` populated from a same-transaction `tenant` PK lookup added by G0.15-T9 #1217) lands on `request.state.ui_session`; route handlers read it via `Depends(require_ui_session)`. `require_ui_admin` (the write-route RBAC gate) loads + verifies the stored access token through `meho_backplane.ui.auth.refresh`, so expired tokens silently refresh instead of 401ing (G0.25 #1694). |
 | `meho_backplane.ui.auth.refresh` | Inline token-refresh lifecycle (G0.25 #1694). `load_fresh_session` (proactive: refresh when the row is within 60 s of `expires_at`), `verify_access_token_with_refresh` (reactive: refresh once on the JWT chain's `token_expired`, re-verify), both funnelling into `refresh_session_tokens` -- the `SELECT ... FOR UPDATE`-serialised chokepoint that POSTs the RFC 6749 § 6 refresh grant (single attempt, 5 s timeout) and rotates the row via `rotate_refresh` (RFC 9700 § 4.14). Concurrent refreshes: first wins; the loser observes the rotated pair under the lock and skips its network call. Failures log `ui_auth_token_refresh_failed` (reason: `invalid_grant` / `network_error` / `timeout` / `malformed_response`) and raise `401 session_expired`; successes log `ui_auth_token_refresh_succeeded` (session_id, old/new expires_at, time_cost_ms). No token material in logs. The refresh performs zero `Set-Cookie` operations -- `meho_session` and `meho_csrf` stay byte-identical, so in-flight pages and their CSRF tokens survive a rotation (no #1706-class cookie desync). The seam serves **token-presenting** dependencies: `require_ui_admin`, plus (G10.x #121) every per-route operator lift that re-verifies the stored access token to surface `tenant_role` / `sub` — `agents.operator`, `connectors.operator` (and the topology write gates that reuse its `lift_operator_from_session`), `memory.operator`, and the `kb` / `runbooks` / `operations` / `audit` / `keycloak` / `vault` route resolvers. Each calls `load_fresh_session` then `verify_access_token_with_refresh` (mirroring the `approvals` / `corpus` / `retrieval` precedent) rather than bare `load_session` + `verify_jwt_for_audience`, so no token-consuming `/ui/*` route 401s on an expired-but-refreshable token. The soft-fail role probes (`runbooks` / `audit` `_resolve_role`, the `agents` / `connectors` `resolve_role_probe`) keep their `try/except` → "no privileges" floor: a terminal `session_expired` from an unavailable refresh is absorbed there, never a 5xx. The dashboard-feed fix (#1696) needed no caller here — it re-pointed the tray at the existing session-gated `/ui/broadcast/stream` bridge, which reads Valkey directly under `require_ui_session` and never presents the access token. |
-| `meho_backplane.ui.auth.errors` | App-level `HTTPException` handler registered in `main.py` for the whole app (G0.25 #1694). Intercepts exactly `401 session_expired` on `/ui/*`: HTML requests (`Accept: text/html`) get `302 /ui/auth/login?return_to=<path>` + `meho_session` cookie clear; non-HTML callers keep the JSON body (cookie cleared too). Every other HTTPException delegates byte-for-byte to FastAPI's stock `http_exception_handler`, so `/api/*` 401 codes are untouched. |
+| `meho_backplane.ui.auth.errors` | App-level `HTTPException` handler registered in `main.py` for the whole app (G0.25 #1694). Intercepts two recoverable shapes, both only for HTML navigations (`Accept: text/html`): (1) `401 session_expired` on `/ui/*` (G0.25 #1694) -> `302 /ui/auth/login?return_to=<path>` + `meho_session` cookie clear; (2) `400 authorization_state_expired` on `/ui/auth/callback` (G0.29 #2089, Leg 1) -> `303 /ui/auth/login` (no cookie touched -- pre-session; no `return_to` -- it died with the expired verifier). Non-HTML callers on either shape keep the structured JSON body (the `session_expired` case also clears the dead cookie). Every other HTTPException -- including the callback's genuine IdP `authorization_failed` and its token-endpoint `502` -- delegates byte-for-byte to FastAPI's stock `http_exception_handler`, so `/api/*` 401 codes and the non-recoverable callback errors are untouched. |
 
 The Jinja2 `Environment` is a module-level singleton (constructed on
 first `get_jinja_env()` call); the template cache it holds is keyed
@@ -192,6 +192,22 @@ Round-trip shape:
    `meho_session` cookie.
 5. **302 to the original `return_to`.** Operator lands on the page
    they were originally bounced from.
+
+Expired-callback-state recovery (G0.29 #2089, Leg 1): the
+authorization round-trip has a short window (the verifier-store TTL,
+≤10 min). An operator who stepped away mid-login and completed the
+Keycloak prompt after the window lapsed returns with a valid `code`
+but a `state` whose verifier has expired. `exchange_code_for_tokens`
+raises the recoverable class (`unknown_or_expired_state` /
+`MismatchingStateError`), which the callback maps to a
+`400 authorization_state_expired` -- a detail distinct from the
+IdP-declined `authorization_failed`. For an HTML navigation the
+`meho_backplane.ui.auth.errors` handler turns that into a
+`303 /ui/auth/login` so the flow restarts on one click instead of
+dead-ending on raw JSON; non-HTML / scripted callers keep the
+structured body. The genuine IdP `?error=` path and the
+token-endpoint-unreachable `502` are NOT collapsed into "start over"
+-- restarting would just re-hit the same failure.
 
 Per-flow state custody:
 


### PR DESCRIPTION
## Summary
- Recovers issue #2089 Leg 1: an expired OAuth **callback** `state` on `GET /ui/auth/callback` no longer dead-ends on a raw-JSON `400 {"detail":"authorization_failed"}` in the browser.
- The recoverable branch of `_exchange_or_translate` (expired/mismatched `state`, verifier-store miss, `MismatchingStateError`) now raises a distinct `authorization_state_expired` detail, separate from the IdP-declined `authorization_failed`.
- The app-level handler in `ui.auth.errors` gains a second interception scoped to that detail on the callback path: an HTML navigation gets a `303 /ui/auth/login` (one-click restart, no `return_to` — it died with the expired verifier; no cookie touched — pre-session), while non-HTML / scripted callers keep the structured body.
- The genuine IdP `?error=` path (`authorization_failed`) and the token-endpoint-unreachable `502` remain distinguishable and are **not** collapsed into "start over".

## Scope note
- Legs 2 (silent token refresh, #1694 merged #1711) and 3 (401→refresh→login on token-consuming routes, #2056/#2055) already shipped — no duplicate refresh-middleware work is undertaken here.
- Sibling task **#2088** touches the same BFF session / `resolve_ui_operator` seam and is being implemented in parallel; this diff is kept scoped to the expired-callback-state path to minimize merge overlap.

## Test plan
- [x] `ruff check` — clean
- [x] `ruff format --check` — clean
- [x] `mypy src/meho_backplane/ui/auth/{errors,routes}.py` — no issues
- [x] `pytest tests/test_ui_auth_flow.py tests/test_ui_token_refresh.py` — 56 passed
- [x] AC1/AC2: `test_callback_expired_state_html_redirects_to_login` + `test_callback_missing_state_html_redirects_to_login` — HTML `Accept` → `303 /ui/auth/login`, no `meho_session` cookie, `cache-control: no-store`
- [x] AC3: `test_callback_rejects_unknown_state` / `_missing_state` updated — non-HTML callers keep a structured `authorization_state_expired` body (superseding the old raw-JSON `authorization_failed` assertions)
- [x] AC4: `test_callback_idp_error_html_is_not_collapsed_to_login_restart` + `test_callback_502s_when_token_endpoint_unreachable` (HTML `Accept`) — IdP decline stays `400 authorization_failed`, unreachable token endpoint stays `502`; neither collapsed to a login restart
- [x] `docs/codebase/ui.md` updated — `ui.auth.errors` interception table + callback narrative now cover the recovery
- [x] `cli && make snapshot-openapi` — no OpenAPI delta (callback OpenAPI contract unchanged)

## Out of scope
- Leg 2 / Leg 3 (already shipped, see Scope note).
- Sibling #2088 (parallel, same seam).

## Adjacent findings
- `backend/src/meho_backplane/ui/auth/routes.py` is 592 lines (code-quality warns >400) — pre-existing; this change adds ~18 lines. Not split here to keep the diff scoped.

<!-- auto-implement-issue: fresh, iteration 1 -->

Closes #2089
