### PR TITLE
feat(connectors): add vmware.composite.host.network_uplinks read composite (#2080)

### DIFF
--- a/backend/src/meho_backplane/connectors/vmware_rest/composites/__init__.py
+++ b/backend/src/meho_backplane/connectors/vmware_rest/composites/__init__.py
@@ -13,7 +13,7 @@ The chassis lifespan's
 invokes every registered registrar in registration order after
 :func:`~meho_backplane.connectors.registry._eager_import_connectors`
 has walked every ``connectors/<product>/`` subpackage, so the
-``endpoint_descriptor`` upserts for the 13 composites land before
+``endpoint_descriptor`` upserts for the 14 composites land before
 any dispatch can fire.
 
 Layout mirrors the :mod:`meho_backplane.connectors.vault` pattern: the
@@ -24,7 +24,8 @@ Schema 2020-12 parameter + response contracts.
 
 Scope:
 
-* 5 read composites (G3.1-T5 / #508) -- ``safety_level="safe"`` +
+* 6 read composites (G3.1-T5 / #508 shipped 5; #2080 adds
+  ``host.network_uplinks``) -- ``safety_level="safe"`` +
   ``requires_approval=False`` overrides.
 * 8 write composites (G3.1-T6 / #509) -- inherit T4's
   ``safety_level="dangerous"`` + ``requires_approval=True`` defaults.
@@ -43,6 +44,7 @@ from meho_backplane.connectors.vmware_rest.composites._read import (
     cluster_drs_recommendations_composite,
     datastore_usage_composite,
     event_tail_composite,
+    host_network_uplinks_composite,
     network_portgroup_audit_composite,
     performance_summary_composite,
 )
@@ -80,6 +82,7 @@ __all__ = [
     "event_tail_composite",
     "host_detach_from_vds_composite",
     "host_evacuate_composite",
+    "host_network_uplinks_composite",
     "network_portgroup_audit_composite",
     "performance_summary_composite",
     "preflight_l2_dependencies",

--- a/backend/src/meho_backplane/connectors/vmware_rest/composites/_read.py
+++ b/backend/src/meho_backplane/connectors/vmware_rest/composites/_read.py
@@ -1,7 +1,7 @@
 # SPDX-License-Identifier: Apache-2.0
 # Copyright (c) 2026 evoila Group
 
-"""Read-only ``vmware.composite.*`` handler functions (5 composites).
+"""Read-only ``vmware.composite.*`` handler functions (6 composites).
 
 Each handler is a module-level ``async def`` that takes the dispatcher's
 composite-branch keyword args ``(operator, target, params,
@@ -89,6 +89,7 @@ __all__ = [
     "cluster_drs_recommendations_composite",
     "datastore_usage_composite",
     "event_tail_composite",
+    "host_network_uplinks_composite",
     "network_portgroup_audit_composite",
     "performance_summary_composite",
 ]
@@ -124,6 +125,20 @@ _OP_LIST_DVS = "GET:/vcenter/network/distributed-switches"
 # the handler note).
 _OP_LIST_NETWORK = "GET:/vcenter/network"
 _NETWORK_TYPE_DISTRIBUTED_PORTGROUP = "DISTRIBUTED_PORTGROUP"
+# Host listing (vCenter Automation REST) + per-host property read
+# (vi-json). The pnic link-state / uplink mapping the operator wants
+# lives on the Web-Services-API ``HostSystem.config.network`` object,
+# not the plain REST host summary -- so the composite lists hosts via
+# the REST resource and then reads ``config.network.pnic`` +
+# ``config.network.proxySwitch`` per host through the PropertyCollector
+# ``RetrievePropertiesEx`` vi-json method (moId ``propertyCollector``,
+# the canonical singleton).
+_OP_LIST_HOSTS = "GET:/vcenter/host"
+_OP_RETRIEVE_PROPERTIES = "POST:/PropertyCollector/{moId}/RetrievePropertiesEx"
+_PROPERTY_COLLECTOR_MOID = "propertyCollector"
+_HOST_SYSTEM_MO_TYPE = "HostSystem"
+_HOST_NET_PROP_PNIC = "config.network.pnic"
+_HOST_NET_PROP_PROXYSWITCH = "config.network.proxySwitch"
 
 # Composite op_ids -- used by the preflight cache key. Centralised here
 # so the test-side coverage assertion (every registered composite has
@@ -134,6 +149,7 @@ _COMPOSITE_OP_ID_EVENT_TAIL = "vmware.composite.event.tail"
 _COMPOSITE_OP_ID_PERFORMANCE_SUMMARY = "vmware.composite.performance.summary"
 _COMPOSITE_OP_ID_DATASTORE_USAGE = "vmware.composite.datastore.usage"
 _COMPOSITE_OP_ID_NETWORK_PORTGROUP_AUDIT = "vmware.composite.network.portgroup.audit"
+_COMPOSITE_OP_ID_HOST_NETWORK_UPLINKS = "vmware.composite.host.network_uplinks"
 
 # Per-composite sub-op-id tuples consumed by the L2 pre-flight check
 # (G0.14-T10 / #1151). Each tuple lists the L2 raw-REST sub-ops the
@@ -161,6 +177,10 @@ _SUB_OPS_NETWORK_PORTGROUP_AUDIT: tuple[str, ...] = (
     _OP_LIST_DVS,
     _OP_LIST_NETWORK,
     _OP_LIST_VMS,
+)
+_SUB_OPS_HOST_NETWORK_UPLINKS: tuple[str, ...] = (
+    _OP_LIST_HOSTS,
+    _OP_RETRIEVE_PROPERTIES,
 )
 
 
@@ -791,3 +811,241 @@ async def network_portgroup_audit_composite(
             }
         )
     return {"portgroups": aggregated}
+
+
+def _pnic_device_from_key(pnic_key: str) -> str:
+    """Recover the device name from a WS-API physical-NIC key.
+
+    ``HostProxySwitch.pnic`` lists the uplink physical NICs as their
+    WS-API keys (``key-vim.host.PhysicalNic-vmnic3``), not their device
+    names. The device name is the trailing segment after the last
+    ``-``; when the string doesn't carry that shape (e.g. a bare device
+    name from a simulator) it is returned verbatim.
+    """
+    _, _, tail = pnic_key.rpartition("-")
+    return tail or pnic_key
+
+
+def _parse_pnic(pnic: dict[str, Any]) -> dict[str, Any]:
+    """Flatten one WS-API ``PhysicalNic`` into the operator-facing row.
+
+    ``linkSpeed`` (a ``PhysicalNicLinkInfo``) is present only when the
+    link is up -- the API omits it on a down link -- so its presence is
+    the link-state signal (``link_up``), and its ``speedMb`` / ``duplex``
+    fields carry the speed. Absent link -> ``speed_mb`` / ``duplex``
+    are ``None``.
+    """
+    link_speed = pnic.get("linkSpeed")
+    link_up = isinstance(link_speed, dict)
+    speed_mb = link_speed.get("speedMb") if isinstance(link_speed, dict) else None
+    duplex = link_speed.get("duplex") if isinstance(link_speed, dict) else None
+    return {
+        "device": pnic.get("device"),
+        "mac": pnic.get("mac"),
+        "driver": pnic.get("driver"),
+        "link_up": link_up,
+        "speed_mb": speed_mb,
+        "duplex": duplex,
+    }
+
+
+def _parse_proxy_switch(proxy_switch: dict[str, Any]) -> dict[str, Any]:
+    """Flatten one WS-API ``HostProxySwitch`` into the operator-facing row.
+
+    The proxy switch is the host-side backing of a DVS. Its ``pnic``
+    field lists the uplink physical NICs as WS-API keys; the row
+    surfaces them as device names so the operator can read which
+    physical ports back each uplink.
+    """
+    raw_uplinks = proxy_switch.get("pnic")
+    uplink_pnics: list[str] = []
+    if isinstance(raw_uplinks, list):
+        uplink_pnics = [_pnic_device_from_key(key) for key in raw_uplinks if isinstance(key, str)]
+    return {
+        "key": proxy_switch.get("key"),
+        "dvs_name": proxy_switch.get("dvsName"),
+        "dvs_uuid": proxy_switch.get("dvsUuid"),
+        "uplink_pnics": uplink_pnics,
+    }
+
+
+def _extract_host_network_props(retrieve_result: Any) -> tuple[list[Any], list[Any]]:
+    """Pull ``config.network.pnic`` + ``config.network.proxySwitch`` from RetrievePropertiesEx.
+
+    ``RetrievePropertiesEx`` returns a ``RetrieveResult`` whose
+    ``objects`` list carries one ``ObjectContent`` per queried object,
+    each with a ``propSet`` list of ``{name, val}`` pairs. For the
+    single-host query the composite issues, the first object's propSet
+    holds the two requested property paths. Returns the raw pnic and
+    proxySwitch lists (empty when absent).
+    """
+    payload = _unwrap_value(retrieve_result)
+    # RetrievePropertiesEx wraps the objects under ``objects``; a bare
+    # list (some simulators / the legacy RetrieveProperties shape) is
+    # tolerated too.
+    if isinstance(payload, dict):
+        objects = payload.get("objects", [])
+    elif isinstance(payload, list):
+        objects = payload
+    else:
+        objects = []
+    prop_by_name: dict[str, Any] = {}
+    for obj in objects:
+        if not isinstance(obj, dict):
+            continue
+        for prop in obj.get("propSet", []) or []:
+            if isinstance(prop, dict) and isinstance(prop.get("name"), str):
+                prop_by_name[prop["name"]] = prop.get("val")
+    pnics = prop_by_name.get(_HOST_NET_PROP_PNIC)
+    proxy_switches = prop_by_name.get(_HOST_NET_PROP_PROXYSWITCH)
+    return (
+        pnics if isinstance(pnics, list) else [],
+        proxy_switches if isinstance(proxy_switches, list) else [],
+    )
+
+
+def _build_retrieve_properties_params(host_moid: str) -> dict[str, Any]:
+    """Build the ``RetrievePropertiesEx`` specSet for one host's network config.
+
+    A single ``PropertyFilterSpec`` scoped directly to the host object
+    (no ContainerView / TraversalSpec) requesting the two network
+    config property paths. ``moId`` targets the ``propertyCollector``
+    singleton.
+    """
+    return {
+        "moId": _PROPERTY_COLLECTOR_MOID,
+        "specSet": [
+            {
+                "propSet": [
+                    {
+                        "type": _HOST_SYSTEM_MO_TYPE,
+                        "pathSet": [
+                            _HOST_NET_PROP_PNIC,
+                            _HOST_NET_PROP_PROXYSWITCH,
+                        ],
+                    }
+                ],
+                "objectSet": [{"obj": {"type": _HOST_SYSTEM_MO_TYPE, "value": host_moid}}],
+            }
+        ],
+        "options": {},
+    }
+
+
+async def _build_host_uplink_row(
+    host_id: str,
+    host_name: Any,
+    dispatch_child: DispatchChild,
+) -> dict[str, Any]:
+    """Build one host row: identity + best-effort pnic / proxy-switch detail.
+
+    The per-host WS-API property read is best-effort -- the host is
+    already identified by the REST listing, so a failed vi-json
+    ``RetrievePropertiesEx`` call nulls the network detail and records
+    why (``read_note``) rather than sinking the whole composite.
+    """
+    row: dict[str, Any] = {"id": host_id, "name": host_name}
+    props_result = await dispatch_child(
+        connector_id=_CONNECTOR_ID,
+        op_id=_OP_RETRIEVE_PROPERTIES,
+        params=_build_retrieve_properties_params(host_id),
+    )
+    if props_result.status == "ok":
+        raw_pnics, raw_proxy_switches = _extract_host_network_props(props_result.result)
+        row["pnics"] = [_parse_pnic(p) for p in raw_pnics if isinstance(p, dict)]
+        row["proxy_switches"] = [
+            _parse_proxy_switch(ps) for ps in raw_proxy_switches if isinstance(ps, dict)
+        ]
+    else:
+        row["pnics"] = None
+        row["proxy_switches"] = None
+        row["read_note"] = (
+            f"host-network property read skipped: sub-op "
+            f"{_OP_RETRIEVE_PROPERTIES!r} returned status="
+            f"{props_result.status!r}: {_describe_sub_op_failure(props_result)}"
+        )
+    return row
+
+
+async def host_network_uplinks_composite(
+    *,
+    operator: Operator,
+    target: Any,
+    params: dict[str, Any],
+    dispatch_child: DispatchChild,
+) -> dict[str, Any]:
+    """Per host: physical NICs (link state + speed) and their proxy-switch uplinks.
+
+    Op-id: ``vmware.composite.host.network_uplinks``.
+
+    Sub-ops dispatched:
+
+    1. ``GET:/vcenter/host`` -- list every host (optionally narrowed via
+       ``filter_hosts``). Load-bearing: a failure here sinks the
+       composite.
+    2. Per host: ``POST:/PropertyCollector/{moId}/RetrievePropertiesEx``
+       requesting ``config.network.pnic`` +
+       ``config.network.proxySwitch`` on that single HostSystem object.
+       This leg is **best-effort**: the plain REST host listing already
+       identifies the host, so when the WS-API property read errors (a
+       host that rejects the vi-json call, a transient auth expiry) the
+       row is still returned with ``pnics`` / ``proxy_switches`` set to
+       ``null`` and a ``read_note`` recording why, rather than failing
+       the whole composite.
+
+    The pnic link-state / uplink mapping is the one read that the plain
+    vSphere Automation REST surface cannot reproduce: pnic link state,
+    speed, and proxy-switch uplink association are Web-Services-API
+    ``HostNetworkInfo`` properties, so the composite reaches them via
+    the PropertyCollector vi-json method. This is what drives physical
+    switch-port-occupancy reasoning ("are we out of switch ports?").
+
+    Returns
+    -------
+    dict[str, Any]
+        ``{"hosts": [{"id": ..., "name": ..., "pnics": [...],
+        "proxy_switches": [...]}, ...]}``. Each pnic row carries
+        ``device`` / ``mac`` / ``driver`` / ``link_up`` / ``speed_mb`` /
+        ``duplex``; each proxy-switch row carries ``key`` / ``dvs_name``
+        / ``dvs_uuid`` / ``uplink_pnics`` (physical-NIC device names).
+        When the per-host property read is skipped, ``pnics`` and
+        ``proxy_switches`` are ``None`` and the row carries a
+        ``read_note``.
+    """
+    await preflight_l2_dependencies(
+        composite_op_id=_COMPOSITE_OP_ID_HOST_NETWORK_UPLINKS,
+        sub_op_ids=_SUB_OPS_HOST_NETWORK_UPLINKS,
+        connector_id=_CONNECTOR_ID,
+        tenant_id=operator.tenant_id,
+    )
+    filter_hosts: list[str] = list(params.get("filter_hosts") or [])
+
+    listing_params: dict[str, Any] = {}
+    if filter_hosts:
+        listing_params["filter.hosts"] = filter_hosts
+
+    listing = _require_ok(
+        await dispatch_child(
+            connector_id=_CONNECTOR_ID,
+            op_id=_OP_LIST_HOSTS,
+            params=listing_params,
+        )
+    )
+    entries = _unwrap_value(listing)
+    if not isinstance(entries, list):
+        raise RuntimeError(
+            f"host_network_uplinks: expected list from {_OP_LIST_HOSTS!r}, "
+            f"got {type(entries).__name__}"
+        )
+
+    aggregated: list[dict[str, Any]] = []
+    for entry in entries:
+        if not isinstance(entry, dict):
+            continue
+        host_id = entry.get("host")
+        if not isinstance(host_id, str):
+            # vSphere REST returns the moid under ``host``; absence is an
+            # upstream malformation -- skip rather than abort.
+            continue
+        aggregated.append(await _build_host_uplink_row(host_id, entry.get("name"), dispatch_child))
+    return {"hosts": aggregated}

--- a/backend/src/meho_backplane/connectors/vmware_rest/composites/_register.py
+++ b/backend/src/meho_backplane/connectors/vmware_rest/composites/_register.py
@@ -1,7 +1,7 @@
 # SPDX-License-Identifier: Apache-2.0
 # Copyright (c) 2026 evoila Group
 
-"""``register_vmware_composite_operations`` -- registrar for the 13 composites.
+"""``register_vmware_composite_operations`` -- registrar for the 14 composites.
 
 Module-level async function called from the lifespan-driven
 :func:`~meho_backplane.operations.typed_register.run_typed_op_registrars`
@@ -21,7 +21,8 @@ the source_kind="composite" persistence.
 Mixed safety posture
 --------------------
 
-The 5 read composites (T5 / #508) pass ``safety_level="safe"`` +
+The 6 read composites (T5 / #508 shipped 5; #2080 adds
+``host.network_uplinks``) pass ``safety_level="safe"`` +
 ``requires_approval=False`` -- overrides of T4's ``dangerous`` /
 ``True`` defaults. The 8 write composites (T6 / #509) inherit the T4
 defaults explicitly (pass ``"dangerous"`` / ``True`` for clarity at
@@ -40,6 +41,7 @@ from meho_backplane.connectors.vmware_rest.composites._read import (
     cluster_drs_recommendations_composite,
     datastore_usage_composite,
     event_tail_composite,
+    host_network_uplinks_composite,
     network_portgroup_audit_composite,
     performance_summary_composite,
 )
@@ -66,6 +68,8 @@ from meho_backplane.connectors.vmware_rest.composites.schemas import (
     HOST_DETACH_FROM_VDS_RESPONSE_SCHEMA,
     HOST_EVACUATE_PARAMETER_SCHEMA,
     HOST_EVACUATE_RESPONSE_SCHEMA,
+    HOST_NETWORK_UPLINKS_PARAMETER_SCHEMA,
+    HOST_NETWORK_UPLINKS_RESPONSE_SCHEMA,
     NETWORK_PORTGROUP_AUDIT_PARAMETER_SCHEMA,
     NETWORK_PORTGROUP_AUDIT_RESPONSE_SCHEMA,
     PERFORMANCE_SUMMARY_PARAMETER_SCHEMA,
@@ -169,16 +173,21 @@ _WHEN_TO_USE_BY_GROUP: dict[str, str] = {
         "parameters."
     ),
     "host": (
-        "Use for host-lifecycle write composites: evacuate every "
-        "VM off a host (recursive composite call into vm.migrate) "
-        "then enter maintenance, or detach a host from a DVS after "
-        "migrating its VM NICs off. Dangerous / approval-required; "
-        "the host_evacuate composite is the first production "
-        "composite that calls another composite. The right group "
-        "for 'safely take this host offline' workflows. Pair with "
-        "'networking' for the DVS-audit prerequisite to "
-        "host_detach_from_vds, and with 'cluster' / 'vm' for the "
-        "pre-flight reads."
+        "Use for host-level reads and host-lifecycle write "
+        "composites. Read: host.network_uplinks -- per host, the "
+        "physical NICs (link state + speed) and their proxy-switch / "
+        "uplink association, the one read the plain REST surface "
+        "cannot reproduce; the right group for 'are we out of "
+        "physical switch ports?' / 'which pnics back this DVS "
+        "uplink?'. Write (dangerous / approval-required): evacuate "
+        "every VM off a host (recursive composite call into "
+        "vm.migrate) then enter maintenance, or detach a host from a "
+        "DVS after migrating its VM NICs off; the host_evacuate "
+        "composite is the first production composite that calls "
+        "another composite. The right group for 'safely take this "
+        "host offline' workflows. Pair with 'networking' for the "
+        "DVS-audit prerequisite to host_detach_from_vds, and with "
+        "'cluster' / 'vm' for the pre-flight reads."
     ),
 }
 
@@ -312,6 +321,32 @@ _COMPOSITES: tuple[_CompositeSpec, ...] = (
         response_schema=NETWORK_PORTGROUP_AUDIT_RESPONSE_SCHEMA,
         group_key="networking",
         tags=["composite", "read-only", "networking", "portgroup"],
+        safety_level="safe",
+        requires_approval=False,
+    ),
+    _CompositeSpec(
+        op_id="vmware.composite.host.network_uplinks",
+        handler=host_network_uplinks_composite,
+        summary="Per host, physical NIC link state + speed and their proxy-switch uplinks.",
+        description=(
+            "Lists hosts via 'GET:/vcenter/host', then per host reads "
+            "'config.network.pnic' + 'config.network.proxySwitch' via the "
+            "vi-json PropertyCollector "
+            "'POST:/PropertyCollector/{moId}/RetrievePropertiesEx'. "
+            "Aggregates one row per host: each physical NIC's device / "
+            "MAC / driver / link state (up when the WS-API linkSpeed is "
+            "present) / speed, plus each proxy switch (the host-side "
+            "backing of a DVS) with its uplink pnic device names. The "
+            "pnic link-state / uplink mapping is the one read the plain "
+            "vSphere Automation REST surface cannot reproduce -- it "
+            "drives physical switch-port-occupancy reasoning ('are we "
+            "out of switch ports?'). Read-only -- never mutates host "
+            "network configuration."
+        ),
+        parameter_schema=HOST_NETWORK_UPLINKS_PARAMETER_SCHEMA,
+        response_schema=HOST_NETWORK_UPLINKS_RESPONSE_SCHEMA,
+        group_key="host",
+        tags=["composite", "read-only", "host", "networking", "pnic"],
         safety_level="safe",
         requires_approval=False,
     ),
@@ -512,8 +547,9 @@ async def register_vmware_composite_operations(
     on every lifespan startup; the skip-re-embed branch keeps that
     cheap.
 
-    Scope: 13 composites total -- 5 read (T5 / #508) +
-    8 write (T6 / #509). Each composite's ``safety_level`` +
+    Scope: 14 composites total -- 6 read (T5 / #508 shipped 5;
+    #2080 adds ``host.network_uplinks``) + 8 write (T6 / #509).
+    Each composite's ``safety_level`` +
     ``requires_approval`` come from its :class:`_CompositeSpec` row:
     reads pass ``"safe"`` / ``False``; writes pass ``"dangerous"`` /
     ``True`` (T4's defaults).

--- a/backend/src/meho_backplane/connectors/vmware_rest/composites/schemas.py
+++ b/backend/src/meho_backplane/connectors/vmware_rest/composites/schemas.py
@@ -1,7 +1,7 @@
 # SPDX-License-Identifier: Apache-2.0
 # Copyright (c) 2026 evoila Group
 
-"""JSON Schema 2020-12 parameter + response schemas for the 13 vmware-rest composites.
+"""JSON Schema 2020-12 parameter + response schemas for the 14 vmware-rest composites.
 
 Each schema is the operator-facing input contract; the dispatcher
 validates inbound ``params`` against the registered schema before
@@ -23,7 +23,7 @@ Conventions
   documentation lives on the schema's ``description`` keys; the meta-
   tools (:mod:`meho_backplane.operations.meta_tools`) surface the
   schema verbatim on ``describe_operation`` calls.
-* The 5 read composites are read-only -- the registration call site
+* The 6 read composites are read-only -- the registration call site
   pins ``safety_level="safe"`` and ``requires_approval=False`` on
   each. The 8 write composites inherit T4's
   ``safety_level="dangerous"`` + ``requires_approval=True`` defaults
@@ -49,6 +49,8 @@ __all__ = [
     "HOST_DETACH_FROM_VDS_RESPONSE_SCHEMA",
     "HOST_EVACUATE_PARAMETER_SCHEMA",
     "HOST_EVACUATE_RESPONSE_SCHEMA",
+    "HOST_NETWORK_UPLINKS_PARAMETER_SCHEMA",
+    "HOST_NETWORK_UPLINKS_RESPONSE_SCHEMA",
     "NETWORK_PORTGROUP_AUDIT_PARAMETER_SCHEMA",
     "NETWORK_PORTGROUP_AUDIT_RESPONSE_SCHEMA",
     "PERFORMANCE_SUMMARY_PARAMETER_SCHEMA",
@@ -243,6 +245,36 @@ NETWORK_PORTGROUP_AUDIT_PARAMETER_SCHEMA: dict[str, Any] = {
                 "When true, the VM aggregation includes VMs whose power "
                 "state is OFF or whose NIC is disconnected. Default "
                 "false returns only actively-connected VMs."
+            ),
+        },
+    },
+    "required": [],
+    "additionalProperties": False,
+}
+
+
+#: ``vmware.composite.host.network_uplinks`` parameter schema.
+#:
+#: Reads, per host, the physical NICs (link state + speed) and the
+#: proxy-switch / uplink association from ``config.network.pnic`` +
+#: ``config.network.proxySwitch``. Lists hosts via
+#: ``GET:/vcenter/host`` (optionally narrowed by ``filter_hosts``),
+#: then reads the two network config properties per host through the
+#: vi-json ``POST:/PropertyCollector/{moId}/RetrievePropertiesEx``
+#: sub-op. The one read the plain REST surface cannot reproduce --
+#: pnic link-state / uplink mapping is a Web-Services-API property.
+HOST_NETWORK_UPLINKS_PARAMETER_SCHEMA: dict[str, Any] = {
+    "type": "object",
+    "properties": {
+        "filter_hosts": {
+            "type": "array",
+            "items": {"type": "string", "minLength": 1},
+            "description": (
+                "Optional list of host managed-object IDs (e.g. "
+                "'host-42'). When supplied, only these hosts are "
+                "surfaced; the listing sub-op forwards them as "
+                "'filter.hosts'. Empty / absent returns every host the "
+                "operator can see."
             ),
         },
     },
@@ -511,6 +543,135 @@ NETWORK_PORTGROUP_AUDIT_RESPONSE_SCHEMA: dict[str, Any] = {
         },
     },
     "required": ["portgroups"],
+}
+
+
+#: ``vmware.composite.host.network_uplinks`` response schema.
+#:
+#: One row per host. ``pnics`` carries each physical NIC's device /
+#: MAC / driver plus its link state (``link_up`` -- derived from the
+#: presence of ``linkSpeed`` on the WS-API ``PhysicalNic``) and speed.
+#: ``proxy_switches`` carries each proxy switch (the host-side backing
+#: of a DVS) with its uplink pnic device names, so the operator can
+#: read physical switch-port occupancy per uplink.
+HOST_NETWORK_UPLINKS_RESPONSE_SCHEMA: dict[str, Any] = {
+    "type": "object",
+    "properties": {
+        "hosts": {
+            "type": "array",
+            "items": {
+                "type": "object",
+                "properties": {
+                    "id": {
+                        "type": "string",
+                        "description": "Host managed-object ID.",
+                    },
+                    "name": {
+                        "type": ["string", "null"],
+                        "description": "Host name from the listing row.",
+                    },
+                    "pnics": {
+                        "type": ["array", "null"],
+                        "items": {
+                            "type": "object",
+                            "properties": {
+                                "device": {
+                                    "type": ["string", "null"],
+                                    "description": "Physical NIC device name (e.g. 'vmnic0').",
+                                },
+                                "mac": {
+                                    "type": ["string", "null"],
+                                    "description": "MAC address of the physical NIC.",
+                                },
+                                "driver": {
+                                    "type": ["string", "null"],
+                                    "description": "Driver name backing the physical NIC.",
+                                },
+                                "link_up": {
+                                    "type": "boolean",
+                                    "description": (
+                                        "True when the WS-API ``linkSpeed`` object is "
+                                        "present (the API omits it when the link is "
+                                        "down)."
+                                    ),
+                                },
+                                "speed_mb": {
+                                    "type": ["integer", "null"],
+                                    "description": (
+                                        "Current link speed in Mb/s from "
+                                        "``linkSpeed.speedMb``; ``null`` when the link "
+                                        "is down."
+                                    ),
+                                },
+                                "duplex": {
+                                    "type": ["boolean", "null"],
+                                    "description": (
+                                        "Full-duplex flag from ``linkSpeed.duplex``; "
+                                        "``null`` when the link is down."
+                                    ),
+                                },
+                            },
+                            "required": ["device", "link_up"],
+                        },
+                        "description": (
+                            "Physical NICs on the host from "
+                            "``config.network.pnic``; ``null`` when the best-effort "
+                            "per-host property read was skipped (see ``read_note``)."
+                        ),
+                    },
+                    "proxy_switches": {
+                        "type": ["array", "null"],
+                        "items": {
+                            "type": "object",
+                            "properties": {
+                                "key": {
+                                    "type": ["string", "null"],
+                                    "description": "Proxy-switch key on the host.",
+                                },
+                                "dvs_name": {
+                                    "type": ["string", "null"],
+                                    "description": (
+                                        "Name of the DVS this proxy switch backs (``dvsName``)."
+                                    ),
+                                },
+                                "dvs_uuid": {
+                                    "type": ["string", "null"],
+                                    "description": "UUID of the backing DVS (``dvsUuid``).",
+                                },
+                                "uplink_pnics": {
+                                    "type": "array",
+                                    "items": {"type": "string"},
+                                    "description": (
+                                        "Physical-NIC device names bound to this proxy "
+                                        "switch as uplinks (from the proxy switch's "
+                                        "``pnic`` backing)."
+                                    ),
+                                },
+                            },
+                            "required": ["uplink_pnics"],
+                        },
+                        "description": (
+                            "Proxy switches on the host from "
+                            "``config.network.proxySwitch``; ``null`` when the "
+                            "best-effort per-host property read was skipped (see "
+                            "``read_note``)."
+                        ),
+                    },
+                    "read_note": {
+                        "type": "string",
+                        "description": (
+                            "Present only when the per-host property read was "
+                            "skipped; records the failing sub-op, its status, and "
+                            "the underlying error."
+                        ),
+                    },
+                },
+                "required": ["id"],
+            },
+            "description": "One row per host in scope.",
+        },
+    },
+    "required": ["hosts"],
 }
 
 

--- a/backend/tests/test_connectors_vmware_rest_composites_read.py
+++ b/backend/tests/test_connectors_vmware_rest_composites_read.py
@@ -1,7 +1,7 @@
 # SPDX-License-Identifier: Apache-2.0
 # Copyright (c) 2026 evoila Group
 
-"""Unit tests for the 5 vmware-rest read-composite handler functions.
+"""Unit tests for the 6 vmware-rest read-composite handler functions.
 
 Coverage matrix (G3.1-T5 / #508 acceptance criteria):
 
@@ -40,6 +40,7 @@ from meho_backplane.connectors.vmware_rest.composites._read import (
     cluster_drs_recommendations_composite,
     datastore_usage_composite,
     event_tail_composite,
+    host_network_uplinks_composite,
     network_portgroup_audit_composite,
     performance_summary_composite,
 )
@@ -72,6 +73,7 @@ def _prime_preflight_cache() -> Iterator[None]:
             "vmware.composite.performance.summary",
             "vmware.composite.datastore.usage",
             "vmware.composite.network.portgroup.audit",
+            "vmware.composite.host.network_uplinks",
         }
     )
     yield
@@ -838,6 +840,278 @@ async def test_network_portgroup_audit_include_disconnected_drops_power_filter()
 
 
 # ---------------------------------------------------------------------------
+# vmware.composite.host.network_uplinks
+# ---------------------------------------------------------------------------
+
+
+def _retrieve_result(pnics: list[Any], proxy_switches: list[Any]) -> dict[str, Any]:
+    """Build a RetrievePropertiesEx RetrieveResult for one host.
+
+    Mirrors the WS-API ``RetrieveResult`` shape: an ``objects`` list of
+    ``ObjectContent``, each with a ``propSet`` of ``{name, val}`` pairs
+    keyed on the requested property paths.
+    """
+    return {
+        "objects": [
+            {
+                "obj": {"type": "HostSystem", "value": "host-1"},
+                "propSet": [
+                    {"name": "config.network.pnic", "val": pnics},
+                    {"name": "config.network.proxySwitch", "val": proxy_switches},
+                ],
+            }
+        ]
+    }
+
+
+@pytest.mark.asyncio
+async def test_host_network_uplinks_lists_then_reads_props_per_host() -> None:
+    """Host listing + per-host RetrievePropertiesEx; aggregation matches the spec.
+
+    ``config.network.pnic`` flattens to device / mac / driver / link
+    state + speed; ``config.network.proxySwitch`` flattens to the DVS
+    backing with its uplink pnic device names (recovered from the
+    WS-API pnic keys).
+    """
+    listing = [
+        {"host": "host-1", "name": "esx-1"},
+        {"host": "host-2", "name": "esx-2"},
+    ]
+    props_by_host = {
+        "host-1": _retrieve_result(
+            pnics=[
+                {
+                    "device": "vmnic0",
+                    "mac": "aa:bb:cc:00:00:00",
+                    "driver": "ixgbe",
+                    "linkSpeed": {"speedMb": 10000, "duplex": True},
+                },
+                {
+                    "device": "vmnic1",
+                    "mac": "aa:bb:cc:00:00:01",
+                    "driver": "ixgbe",
+                    # No linkSpeed -> link down.
+                },
+            ],
+            proxy_switches=[
+                {
+                    "key": "key-vim.host.HostProxySwitch-1",
+                    "dvsName": "DVS-A",
+                    "dvsUuid": "50 01 aa bb",
+                    "pnic": ["key-vim.host.PhysicalNic-vmnic0"],
+                }
+            ],
+        ),
+        "host-2": _retrieve_result(pnics=[], proxy_switches=[]),
+    }
+    sequence: list[OperationResult] = [_ok_result("GET:/vcenter/host", listing)]
+    for entry in listing:
+        sequence.append(
+            _ok_result(
+                "POST:/PropertyCollector/{moId}/RetrievePropertiesEx",
+                props_by_host[entry["host"]],
+            )
+        )
+    dispatch = _RecordingDispatchChild(sequence)
+
+    out = await host_network_uplinks_composite(
+        operator=_make_operator(),
+        target=object(),
+        params={},
+        dispatch_child=dispatch,
+    )
+
+    # 1 listing + 2 hosts * 1 property read = 3 calls.
+    assert len(dispatch.calls) == 3
+    assert dispatch.calls[0]["op_id"] == "GET:/vcenter/host"
+    assert dispatch.calls[0]["params"] == {}
+    # Per-host property read targets the propertyCollector singleton and
+    # requests the two host-network config paths on the specific host.
+    prop_call = dispatch.calls[1]
+    assert prop_call["op_id"] == "POST:/PropertyCollector/{moId}/RetrievePropertiesEx"
+    assert prop_call["params"]["moId"] == "propertyCollector"
+    spec = prop_call["params"]["specSet"][0]
+    assert spec["propSet"][0]["type"] == "HostSystem"
+    assert spec["propSet"][0]["pathSet"] == [
+        "config.network.pnic",
+        "config.network.proxySwitch",
+    ]
+    assert spec["objectSet"][0]["obj"] == {"type": "HostSystem", "value": "host-1"}
+
+    hosts = out["hosts"]
+    assert len(hosts) == 2
+    h1 = hosts[0]
+    assert h1["id"] == "host-1"
+    assert h1["name"] == "esx-1"
+    assert h1["pnics"] == [
+        {
+            "device": "vmnic0",
+            "mac": "aa:bb:cc:00:00:00",
+            "driver": "ixgbe",
+            "link_up": True,
+            "speed_mb": 10000,
+            "duplex": True,
+        },
+        {
+            "device": "vmnic1",
+            "mac": "aa:bb:cc:00:00:01",
+            "driver": "ixgbe",
+            "link_up": False,
+            "speed_mb": None,
+            "duplex": None,
+        },
+    ]
+    assert h1["proxy_switches"] == [
+        {
+            "key": "key-vim.host.HostProxySwitch-1",
+            "dvs_name": "DVS-A",
+            "dvs_uuid": "50 01 aa bb",
+            "uplink_pnics": ["vmnic0"],
+        }
+    ]
+    assert "read_note" not in h1
+    # host-2: empty pnic/proxySwitch lists.
+    assert hosts[1]["pnics"] == []
+    assert hosts[1]["proxy_switches"] == []
+
+
+@pytest.mark.asyncio
+async def test_host_network_uplinks_filter_hosts_passes_through_to_listing() -> None:
+    """``filter_hosts`` flows into the host listing as ``filter.hosts``."""
+    dispatch = _RecordingDispatchChild([_ok_result("GET:/vcenter/host", [])])
+    await host_network_uplinks_composite(
+        operator=_make_operator(),
+        target=object(),
+        params={"filter_hosts": ["host-9", "host-10"]},
+        dispatch_child=dispatch,
+    )
+    assert dispatch.calls[0]["params"] == {"filter.hosts": ["host-9", "host-10"]}
+
+
+@pytest.mark.asyncio
+async def test_host_network_uplinks_property_read_is_best_effort_on_error() -> None:
+    """A failed per-host property read keeps the row; pnics/proxy_switches null + note.
+
+    The plain REST host listing has already identified the host by the
+    time the vi-json property read runs, so when that read errors the
+    host row is still returned -- pnics/proxy_switches nulled with a
+    ``read_note`` -- rather than the whole composite failing.
+    """
+    listing = [
+        {"host": "host-1", "name": "esx-1"},
+        {"host": "host-2", "name": "esx-2"},
+    ]
+    sequence = [
+        _ok_result("GET:/vcenter/host", listing),
+        # host-1: property read 400s -> best-effort skip.
+        _connector_error_result(
+            "POST:/PropertyCollector/{moId}/RetrievePropertiesEx",
+            "Client error '400 Bad Request' for url "
+            "'https://vc/sdk/vim25/PropertyCollector/propertyCollector/RetrievePropertiesEx'",
+        ),
+        # host-2: property read OK.
+        _ok_result(
+            "POST:/PropertyCollector/{moId}/RetrievePropertiesEx",
+            _retrieve_result(pnics=[], proxy_switches=[]),
+        ),
+    ]
+    dispatch = _RecordingDispatchChild(sequence)
+    out = await host_network_uplinks_composite(
+        operator=_make_operator(),
+        target=object(),
+        params={},
+        dispatch_child=dispatch,
+    )
+
+    assert len(dispatch.calls) == 3
+    rows = out["hosts"]
+    assert len(rows) == 2
+    h1 = rows[0]
+    assert h1["id"] == "host-1"
+    assert h1["pnics"] is None
+    assert h1["proxy_switches"] is None
+    assert "read_note" in h1
+    note = h1["read_note"]
+    assert "POST:/PropertyCollector/{moId}/RetrievePropertiesEx" in note
+    assert "400 Bad Request" in note
+    # host-2: enriched normally, no note.
+    assert rows[1]["pnics"] == []
+    assert "read_note" not in rows[1]
+
+
+@pytest.mark.asyncio
+async def test_host_network_uplinks_tolerates_legacy_value_envelope() -> None:
+    """A ``{"value": ...}`` envelope on the listing and property read unwraps cleanly."""
+    sequence = [
+        _ok_result("GET:/vcenter/host", {"value": [{"host": "host-1", "name": "esx-1"}]}),
+        _ok_result(
+            "POST:/PropertyCollector/{moId}/RetrievePropertiesEx",
+            {"value": _retrieve_result(pnics=[{"device": "vmnic0"}], proxy_switches=[])},
+        ),
+    ]
+    dispatch = _RecordingDispatchChild(sequence)
+    out = await host_network_uplinks_composite(
+        operator=_make_operator(),
+        target=object(),
+        params={},
+        dispatch_child=dispatch,
+    )
+    assert out["hosts"][0]["pnics"] == [
+        {
+            "device": "vmnic0",
+            "mac": None,
+            "driver": None,
+            "link_up": False,
+            "speed_mb": None,
+            "duplex": None,
+        }
+    ]
+
+
+@pytest.mark.asyncio
+async def test_host_network_uplinks_skips_malformed_listing_entries() -> None:
+    """Listing entries without a string ``host`` key are skipped silently."""
+    sequence = [
+        _ok_result(
+            "GET:/vcenter/host",
+            [
+                {"host": "host-1", "name": "good"},
+                {"name": "missing-id"},  # no ``host`` key
+                "not-a-dict",
+            ],
+        ),
+        _ok_result(
+            "POST:/PropertyCollector/{moId}/RetrievePropertiesEx",
+            _retrieve_result(pnics=[], proxy_switches=[]),
+        ),
+    ]
+    dispatch = _RecordingDispatchChild(sequence)
+    out = await host_network_uplinks_composite(
+        operator=_make_operator(),
+        target=object(),
+        params={},
+        dispatch_child=dispatch,
+    )
+    # Only the well-formed entry produces a property read + a result row.
+    assert len(out["hosts"]) == 1
+    assert out["hosts"][0]["id"] == "host-1"
+
+
+@pytest.mark.asyncio
+async def test_host_network_uplinks_raises_on_listing_error() -> None:
+    """A failed host listing surfaces as ``RuntimeError``; no per-host reads fire."""
+    dispatch = _RecordingDispatchChild([_err_result("GET:/vcenter/host", "permission denied")])
+    with pytest.raises(RuntimeError, match="returned status='error'"):
+        await host_network_uplinks_composite(
+            operator=_make_operator(),
+            target=object(),
+            params={},
+            dispatch_child=dispatch,
+        )
+    assert len(dispatch.calls) == 1
+
+
+# ---------------------------------------------------------------------------
 # Error fan-out -- a sub-op error causes the handler to raise
 # ---------------------------------------------------------------------------
 
@@ -903,7 +1177,7 @@ async def test_event_tail_raises_on_sub_op_error() -> None:
 
 @pytest.mark.asyncio
 async def test_every_composite_uses_vmware_rest_9_0_connector_id() -> None:
-    """All five handlers dispatch sub-ops against ``vmware-rest-9.0`` exclusively.
+    """All six read handlers dispatch sub-ops against ``vmware-rest-9.0`` exclusively.
 
     Load-bearing for the issue body's *Why dispatch_child not direct
     httpx* contract: the connector_id is what routes the recursive
@@ -944,6 +1218,11 @@ async def test_every_composite_uses_vmware_rest_9_0_connector_id() -> None:
                 "GET:/vcenter/network/distributed-switches": [],
                 "GET:/vcenter/network": [],
             },
+        ),
+        (
+            host_network_uplinks_composite,
+            {},
+            {"GET:/vcenter/host": []},
         ),
     )
     for handler, params, responses in handlers:

--- a/backend/tests/test_connectors_vmware_rest_composites_recursive_e2e.py
+++ b/backend/tests/test_connectors_vmware_rest_composites_recursive_e2e.py
@@ -17,7 +17,7 @@ composite, ``vmware.composite.host.evacuate`` (G3.1-T6 / #509):
 1. Register a no-op vmware connector class against
    ``(product="vmware", version="9.0", impl_id="vmware-rest")``.
 2. Register the **real** :func:`register_vmware_composite_operations`
-   runner, which lands all 13 composite rows (including ``vm.migrate``
+   runner, which lands all 14 composite rows (including ``vm.migrate``
    and ``host.evacuate``).
 3. Register the leaf typed sub-ops the recursive chain bottoms out on
    (``GET:/vcenter/vm`` listing, ``GET:/vcenter/cluster/{cluster}/drs/
@@ -367,8 +367,8 @@ async def test_host_evacuate_e2e_through_production_dispatch_builds_3_level_audi
         impl_id="vmware-rest",
         cls=_NoOpVmwareConnector,
     )
-    # Register all 13 composite rows (vm.migrate + host.evacuate are
-    # the two the test exercises; the other 11 ride along harmlessly).
+    # Register all 14 composite rows (vm.migrate + host.evacuate are
+    # the two the test exercises; the other 12 ride along harmlessly).
     await register_vmware_composite_operations(embedding_service=stub_embedding_service)
     # Register the 4 leaf typed sub-ops the recursive chain bottoms on.
     await _register_leaf_typed_ops(stub_embedding_service)

--- a/backend/tests/test_connectors_vmware_rest_composites_register.py
+++ b/backend/tests/test_connectors_vmware_rest_composites_register.py
@@ -1,7 +1,7 @@
 # SPDX-License-Identifier: Apache-2.0
 # Copyright (c) 2026 evoila Group
 
-"""Registration tests for the 5 vmware-rest read composites.
+"""Registration tests for the 6 vmware-rest read composites.
 
 Coverage matrix (G3.1-T5 / #508 acceptance criteria):
 
@@ -47,6 +47,7 @@ from meho_backplane.connectors.vmware_rest.composites import (
     cluster_drs_recommendations_composite,
     datastore_usage_composite,
     event_tail_composite,
+    host_network_uplinks_composite,
     network_portgroup_audit_composite,
     performance_summary_composite,
     register_vmware_composite_operations,
@@ -66,6 +67,7 @@ _EXPECTED_OP_IDS: tuple[str, ...] = (
     "vmware.composite.performance.summary",
     "vmware.composite.datastore.usage",
     "vmware.composite.network.portgroup.audit",
+    "vmware.composite.host.network_uplinks",
 )
 
 
@@ -86,6 +88,9 @@ _EXPECTED_HANDLER_REF_BY_OP: dict[str, str] = {
     "vmware.composite.network.portgroup.audit": (
         "meho_backplane.connectors.vmware_rest.composites._read.network_portgroup_audit_composite"
     ),
+    "vmware.composite.host.network_uplinks": (
+        "meho_backplane.connectors.vmware_rest.composites._read.host_network_uplinks_composite"
+    ),
 }
 
 
@@ -95,6 +100,7 @@ _EXPECTED_GROUP_KEY_BY_OP: dict[str, str] = {
     "vmware.composite.performance.summary": "performance",
     "vmware.composite.datastore.usage": "storage",
     "vmware.composite.network.portgroup.audit": "networking",
+    "vmware.composite.host.network_uplinks": "host",
 }
 
 
@@ -175,9 +181,10 @@ async def test_register_vmware_composite_operations_inserts_five_rows(
             .all()
         )
     assert {row.op_id for row in rows} == set(_EXPECTED_OP_IDS)
-    # Embedding service called once per composite -- 13 total after
-    # T6 (#509) shipped the 8 write composites alongside these 5.
-    assert stub_embedding_service.encode_one.call_count == 13
+    # Embedding service called once per composite -- 14 total: 6 reads
+    # (T5 #508 shipped 5; #2080 adds host.network_uplinks) + 8 writes
+    # (T6 #509).
+    assert stub_embedding_service.encode_one.call_count == 14
 
 
 @pytest.mark.asyncio
@@ -260,7 +267,7 @@ async def test_handler_ref_round_trips_to_module_level_dotted_path(
 async def test_group_resolution_lands_each_composite_in_its_named_group(
     stub_embedding_service: AsyncMock,
 ) -> None:
-    """The 5 composites land in 5 distinct groups by ``group_key``."""
+    """The 6 read composites resolve to their named ``group_key`` (host.network_uplinks -> host)."""
     await register_vmware_composite_operations(embedding_service=stub_embedding_service)
     sessionmaker = get_sessionmaker()
     async with sessionmaker() as fresh:
@@ -386,6 +393,11 @@ async def test_response_schema_persists_for_every_composite(
     )
     assert "portgroups" in dict(net_resp["properties"])
 
+    uplinks_resp: dict[str, Any] = dict(
+        by_op["vmware.composite.host.network_uplinks"].response_schema
+    )
+    assert "hosts" in dict(uplinks_resp["properties"])
+
 
 @pytest.mark.asyncio
 async def test_tags_include_composite_and_read_only(
@@ -424,15 +436,15 @@ async def test_tags_include_composite_and_read_only(
 async def test_register_vmware_composite_operations_is_idempotent(
     stub_embedding_service: AsyncMock,
 ) -> None:
-    """Running the registrar twice -> 5 read rows persist; embedding stays at 13.
+    """Running the registrar twice -> 6 read rows persist; embedding stays at 14.
 
     The second run's body-hash skip path is what holds across both
     read and write composites; this test asserts the read rows still
-    persist after the combined registrar (5 reads + 8 writes / T6).
+    persist after the combined registrar (6 reads + 8 writes / T6).
     """
     await register_vmware_composite_operations(embedding_service=stub_embedding_service)
     first_count = stub_embedding_service.encode_one.call_count
-    assert first_count == 13
+    assert first_count == 14
 
     await register_vmware_composite_operations(embedding_service=stub_embedding_service)
     # Skip-re-embed path -- second run is a no-op for the embedding
@@ -450,7 +462,7 @@ async def test_register_vmware_composite_operations_is_idempotent(
             .scalars()
             .all()
         )
-    assert len(rows) == 5
+    assert len(rows) == 6
 
 
 # ---------------------------------------------------------------------------
@@ -507,6 +519,7 @@ def test_all_handlers_are_module_level_coroutine_functions() -> None:
         performance_summary_composite,
         datastore_usage_composite,
         network_portgroup_audit_composite,
+        host_network_uplinks_composite,
     ):
         assert inspect.iscoroutinefunction(handler), f"{handler!r} is not a coroutine function"
         assert "<locals>" not in handler.__qualname__

--- a/backend/tests/test_connectors_vmware_rest_composites_write_e2e.py
+++ b/backend/tests/test_connectors_vmware_rest_composites_write_e2e.py
@@ -465,7 +465,7 @@ async def _register_leaf_typed_ops(stub_embedding_service: AsyncMock) -> None:
 
 
 async def _bootstrap_registry(stub_embedding_service: AsyncMock) -> None:
-    """Register the connector, all 13 composites, and the leaf typed ops."""
+    """Register the connector, all 14 composites, and the leaf typed ops."""
     register_connector_v2(
         product="vmware",
         version="9.0",

--- a/backend/tests/test_connectors_vmware_rest_composites_write_preview.py
+++ b/backend/tests/test_connectors_vmware_rest_composites_write_preview.py
@@ -229,7 +229,7 @@ def _reset_recorder() -> None:
 
 
 async def _bootstrap_registry(stub_embedding_service: AsyncMock) -> None:
-    """Register the connector, the 13 composites, and the listing leaves."""
+    """Register the connector, the 14 composites, and the listing leaves."""
     register_connector_v2(
         product="vmware",
         version="9.0",

--- a/backend/tests/test_connectors_vmware_rest_composites_write_register.py
+++ b/backend/tests/test_connectors_vmware_rest_composites_write_register.py
@@ -12,8 +12,9 @@ Coverage matrix (G3.1-T6 / #509 acceptance criteria):
   in ``composites/_write``.
 * Each row's ``group_key`` resolves to ``vm`` / ``host`` / ``cluster``
   per the canary's stub-LLM taxonomy.
-* Combined with #508's 5 reads, the registrar produces **13 rows**
-  total -- the Definition-of-done line in #227's body.
+* Combined with #508's 5 reads plus #2080's host.network_uplinks
+  read, the registrar produces **14 rows** total -- the
+  Definition-of-done line in #227's body.
 * Per-composite ``parameter_schema`` + ``response_schema`` persist
   with the documented required keys.
 * Module-level handler shape (no closures / partials / lambdas).
@@ -65,17 +66,19 @@ _WRITE_OP_IDS: tuple[str, ...] = (
     "vmware.composite.cluster.patch",
 )
 
-# 5 reads (T5 / #508) -- carried over so the combined-count assertion
-# does not have to import _read constants.
+# 6 reads (T5 / #508 shipped 5; #2080 adds host.network_uplinks) --
+# carried over so the combined-count assertion does not have to import
+# _read constants.
 _READ_OP_IDS: tuple[str, ...] = (
     "vmware.composite.cluster.drs_recommendations",
     "vmware.composite.event.tail",
     "vmware.composite.performance.summary",
     "vmware.composite.datastore.usage",
     "vmware.composite.network.portgroup.audit",
+    "vmware.composite.host.network_uplinks",
 )
 
-# 13 total -- the #227 G3.1 Definition-of-done line.
+# 14 total -- the #227 G3.1 Definition-of-done line.
 _ALL_OP_IDS: tuple[str, ...] = _READ_OP_IDS + _WRITE_OP_IDS
 
 
@@ -159,7 +162,7 @@ async def session() -> AsyncIterator[AsyncSession]:
 
 
 # ---------------------------------------------------------------------------
-# 8 write composites land alongside the 5 reads (13 total)
+# 8 write composites land alongside the 6 reads (14 total)
 # ---------------------------------------------------------------------------
 
 
@@ -184,10 +187,10 @@ async def test_register_vmware_composite_operations_inserts_eight_write_rows(
 
 
 @pytest.mark.asyncio
-async def test_full_registration_produces_thirteen_composite_rows(
+async def test_full_registration_produces_fourteen_composite_rows(
     stub_embedding_service: AsyncMock,
 ) -> None:
-    """5 reads (#508) + 8 writes (#509) = 13 composite rows. Definition-of-done bar."""
+    """6 reads (#508 + #2080) + 8 writes (#509) = 14 composite rows. Definition-of-done bar."""
     await register_vmware_composite_operations(embedding_service=stub_embedding_service)
     sessionmaker = get_sessionmaker()
     async with sessionmaker() as fresh:
@@ -201,7 +204,7 @@ async def test_full_registration_produces_thirteen_composite_rows(
             .all()
         )
     assert {row.op_id for row in rows} == set(_ALL_OP_IDS)
-    assert len(rows) == 13
+    assert len(rows) == 14
 
 
 @pytest.mark.asyncio
@@ -452,17 +455,17 @@ async def test_write_composite_tags_include_composite_and_write(
 
 
 @pytest.mark.asyncio
-async def test_register_vmware_composite_operations_is_idempotent_across_thirteen(
+async def test_register_vmware_composite_operations_is_idempotent_across_fourteen(
     stub_embedding_service: AsyncMock,
 ) -> None:
-    """Running the registrar twice -> 13 rows total, embedding called 13x once."""
+    """Running the registrar twice -> 14 rows total, embedding called 14x once."""
     await register_vmware_composite_operations(embedding_service=stub_embedding_service)
     first_count = stub_embedding_service.encode_one.call_count
-    assert first_count == 13
+    assert first_count == 14
 
     await register_vmware_composite_operations(embedding_service=stub_embedding_service)
     # Body-hash skip path -> second run is a no-op for the embedding
-    # pipeline; the row count stays at 13.
+    # pipeline; the row count stays at 14.
     assert stub_embedding_service.encode_one.call_count == first_count
 
     sessionmaker = get_sessionmaker()
@@ -476,7 +479,7 @@ async def test_register_vmware_composite_operations_is_idempotent_across_thirtee
             .scalars()
             .all()
         )
-    assert len(rows) == 13
+    assert len(rows) == 14
 
 
 # ---------------------------------------------------------------------------

--- a/docs/codebase/connectors-vmware-rest.md
+++ b/docs/codebase/connectors-vmware-rest.md
@@ -8,9 +8,10 @@ that dispatches ingested vCenter REST operations under the
 triple. It pairs with the G0.7 ingestion pipeline's auto-shim (which
 makes ~1,275 + ~2,195 `endpoint_descriptor` rows resolvable but not
 dispatchable) to deliver real session-authenticated calls against
-vSphere 8.5+ / ESXi 8.5+ targets, plus 13 hand-authored composites
-that orchestrate cross-spec workflows: 5 read composites
-(G3.1-T5 / `#508`) and 8 write composites (G3.1-T6 / `#509`). The
+vSphere 8.5+ / ESXi 8.5+ targets, plus 14 hand-authored composites
+that orchestrate cross-spec workflows: 6 read composites
+(G3.1-T5 / `#508` shipped 5; `#2080` added `host.network_uplinks`)
+and 8 write composites (G3.1-T6 / `#509`). The
 write composites cover every state-mutating operator workflow named
 in [#214](https://github.com/evoila/meho/issues/214) as required for
 govc-wrapper retirement.
@@ -23,16 +24,24 @@ Source: `backend/src/meho_backplane/connectors/vmware_rest/`.
   Class attributes: `product="vmware"`, `version="9.0"`,
   `impl_id="vmware-rest"`, `supported_version_range=">=8.5,<10.0"`,
   `priority=1`.
-- **Read composites** (`composites/_read.py`) — five module-level
+- **Read composites** (`composites/_read.py`) — six module-level
   `async def` handlers (`cluster_drs_recommendations_composite`,
   `event_tail_composite`, `performance_summary_composite`,
-  `datastore_usage_composite`, `network_portgroup_audit_composite`).
-  Each accepts `(operator, target, params, dispatch_child)` per the
+  `datastore_usage_composite`, `network_portgroup_audit_composite`,
+  `host_network_uplinks_composite`). Each accepts
+  `(operator, target, params, dispatch_child)` per the
   `DispatchChild` Protocol and orchestrates 1-3 sub-op dispatches
   back into the same `vmware-rest-9.0` connector. Registered with
   `safety_level="safe"` + `requires_approval=False` — read-only
   overrides of `register_composite_operation()`'s `dangerous` / `True`
-  defaults.
+  defaults. `host_network_uplinks_composite` (`#2080`) lists hosts via
+  `GET:/vcenter/host`, then per host reads `config.network.pnic` +
+  `config.network.proxySwitch` through the vi-json PropertyCollector
+  `RetrievePropertiesEx` method — the pnic link-state / uplink mapping
+  the plain REST surface cannot reproduce (drives physical
+  switch-port-occupancy reasoning); the per-host property read is
+  best-effort (a failed read nulls the network detail with a
+  `read_note` rather than sinking the composite).
 - **Write composites** (`composites/_write.py`) — eight module-level
   `async def` handlers (`vm_create_composite`, `vm_clone_composite`,
   `vm_snapshot_revert_composite`, `vm_migrate_composite`,
@@ -49,8 +58,8 @@ Source: `backend/src/meho_backplane/connectors/vmware_rest/`.
   handles the depth-2 nesting cleanly.
 - **`register_vmware_composite_operations`** (`composites/_register.py`)
   — async registrar function called from `run_typed_op_registrars` at
-  lifespan startup. Iterates a single `_COMPOSITES` tuple of 13
-  `_CompositeSpec` rows (5 read + 8 write); each row carries its
+  lifespan startup. Iterates a single `_COMPOSITES` tuple of 14
+  `_CompositeSpec` rows (6 read + 8 write); each row carries its
   own `safety_level` + `requires_approval` so the policy posture is
   implied by the spec, not by global defaults. Idempotent on re-run
   via the body-hash skip path.
@@ -97,8 +106,8 @@ Source: `backend/src/meho_backplane/connectors/vmware_rest/`.
    in main) no-ops on subsequent ingests against the same triple.
 5. Lifespan calls `run_typed_op_registrars()`, which iterates every
    queued registrar -- including the composite one -- and upserts the
-   13 `vmware.composite.*` rows into `endpoint_descriptor` with
-   `source_kind="composite"` (5 reads with `safety_level="safe"` +
+   14 `vmware.composite.*` rows into `endpoint_descriptor` with
+   `source_kind="composite"` (6 reads with `safety_level="safe"` +
    `requires_approval=False`; 8 writes with `safety_level="dangerous"`
    + `requires_approval=True`).
 
@@ -167,7 +176,7 @@ reach this method.
 
 ### Composite dispatch
 
-The 13 composites (5 reads + 8 writes) land as `source_kind="composite"`
+The 14 composites (6 reads + 8 writes) land as `source_kind="composite"`
 rows in `endpoint_descriptor`. At dispatch time:
 
 1. Dispatcher resolves `(vmware-rest-9.0, vmware.composite.<verb>)`
@@ -222,7 +231,7 @@ caller.
 
 ### L1/L2 dispatch contract + pre-flight (G0.14-T10 / #1151)
 
-The 13 composites are the **L1** surface: hand-authored aggregators
+The 14 composites are the **L1** surface: hand-authored aggregators
 each connector ships as `source_kind='composite'` descriptors. Every
 composite's body fans out to **L2** raw-REST primitives
 (`GET:/vcenter/datastore`, `POST:/vcenter/vm/{vm}/power?action=start`,
@@ -457,7 +466,7 @@ identifier fields **plus** `preview_unavailable: true` and a
 every reviewer surface that renders `proposed_effect` verbatim (REST
 `GET /api/v1/approvals`, `meho.approvals.list` / `.get`, `meho
 approvals show`), so "blast-radius unknown" is distinguishable from a
-genuinely small action. The 5 read composites register no builder —
+genuinely small action. The 6 read composites register no builder —
 they never park.
 
 ## Dependencies
@@ -506,7 +515,7 @@ they never park.
   header per `docs/vcenter-9.0/MANIFEST.md`. Two of the read
   composites (`event.tail`, `performance.summary`) call vi-json
   sub-ops; the other three call vCenter REST sub-ops only.
-- **All 13 composites shipped** — T5 (#508) ships the 5 read
+- **All 14 composites shipped** — T5 (#508) ships 5 read, #2080 adds a 6th read
   composites; T6 (#509) ships the 8 write composites. The "All ~13
   hand-authored composites land as endpoint_descriptor rows with
   source_kind='composite'" Definition-of-done line in [#227](https://github.com/evoila/meho/issues/227)


### PR DESCRIPTION
## Summary
- Adds a sixth safe/read `vmware-rest` composite, `vmware.composite.host.network_uplinks`, that returns per host the physical NICs (link state + speed) and their proxy-switch / uplink association from `config.network.pnic` + `config.network.proxySwitch` — the pnic link-state / uplink mapping the plain vSphere Automation REST surface cannot reproduce (drives physical switch-port-occupancy reasoning).
- Follows the #508 read-composite pattern exactly: registered via `register_composite_operation()` as `safety_level="safe"` / `requires_approval=False`, dispatched through `call_operation`, every sub-call routed through `dispatch_child`.
- Sub-ops: `GET:/vcenter/host` (list, load-bearing) + per host `POST:/PropertyCollector/{moId}/RetrievePropertiesEx` (moId `propertyCollector`) scoped directly to the single `HostSystem` object requesting the two network-config paths. The per-host property read is **best-effort** — a failed read nulls the network detail with a `read_note` rather than sinking the whole composite (mirrors the `datastore_usage` VM-placement enrichment leg).
- Lands in the existing `host` operation group; `_read.py`, `_register.py`, `schemas.py`, `__init__.py`, and the two composites test modules + the vmware-rest codebase doc updated for the 5→6 read / 13→14 total count.

## Test plan
- [x] `ruff check` — clean
- [x] `ruff format --check` — clean
- [x] `mypy src/…/vmware_rest/composites/` — clean
- [x] `pytest tests/test_connectors_vmware_rest_composites_read.py tests/test_connectors_vmware_rest_composites_register.py` — 41 passed
- [x] Related suites (`…_l2_preflight`, `test_operations_composite_register`, `test_g07_vsphere_canary`, `test_vmware_rest_composite_dispatch`) — 31 passed, 29 skipped (vcsim-gated)
- [x] `code-quality.py --diff` — 0 blockers
- [x] AC: op registered read-only + `source_kind="composite"` (register test); returns per-host pnic/proxy-switch schema against a fixture (handler-direct tests); schema round-trips (register test)
- [x] `cd cli && make snapshot-openapi` — OpenAPI snapshot byte-identical (composites are `endpoint_descriptor` rows, not FastAPI routes; no route/schema changed, so no `make generate` regen needed)

## Out of scope
- Sibling `host.vsan_health` is tracked separately as #2135.
- Sibling #2078 also touches `composites/_read.py`; this diff is kept tightly scoped to the new op to minimize merge conflicts.

<!-- auto-implement-issue: fresh, iteration 1 -->

Closes #2080
