### PR TITLE
fix(operations): serialize JSONFlux inline sample once, bound it by bytes (#134)

### DIFF
--- a/backend/src/meho_backplane/connectors/schemas.py
+++ b/backend/src/meho_backplane/connectors/schemas.py
@@ -442,6 +442,16 @@ class ResultHandle(BaseModel):
     :attr:`FingerprintResult.extras` / :attr:`OperationResult.extras`
     pattern).
 
+    ``sample_rows`` is the **single** home of the inline preview (#134):
+    the reducer carries the bounded sample here and nowhere else. The
+    sibling inline ``OperationResult.result`` summary reports the preview
+    *count* (``sample_rows_returned``) but does not duplicate the rows, so
+    an object-heavy list op ships one bounded copy of the sample rather
+    than two. The reducer sizes ``sample_rows`` to a serialized-byte budget
+    (``jsonflux_sample_byte_budget``), not only a row count, so the preview
+    stays inline-consumable regardless of per-row object size; the full set
+    is reachable via ``result_query`` (see ``fetch_more.drill_in``).
+
     ``fetch_more`` is the G0.15-T8 self-documenting drill-in / pagination
     envelope -- every handle the reducer mints carries it so an agent
     reading the response can answer *"how do I get more rows"* without a

--- a/backend/src/meho_backplane/operations/jsonflux_reducer.py
+++ b/backend/src/meho_backplane/operations/jsonflux_reducer.py
@@ -15,6 +15,17 @@ markdown, frozen into a JSON Schema, and addressed by a
 :class:`~meho_backplane.connectors.schemas.ResultHandle` carrying a
 bounded sample so no agent ever sees the full set inline.
 
+The inline sample is serialized **exactly once** (#134). It lives only
+on :attr:`ResultHandle.sample_rows`; the compact inline ``summary`` the
+reducer returns alongside the handle carries the *count* of preview rows
+(``sample_rows_returned``) but not a second full copy of them. It is
+bounded by *serialized bytes* (``jsonflux_sample_byte_budget`` setting,
+default 4 KB), not only by row count -- an object-heavy list op whose
+rows are tens of KB each is shrunk (fewer rows, values truncated as a
+last resort) so the reduced envelope stays under a ceiling independent
+of per-row object size. The full set is untouched and stays reachable
+via the spill + ``result_query``.
+
 Why ``QueryEngine`` directly, not ``JsonFlux``
 ==============================================
 
@@ -275,18 +286,22 @@ class JsonFluxReducer:
         ttl_seconds: int = 3600,
         store: ResultHandleStore | None = None,
         max_spill_rows: int | None = None,
+        sample_byte_budget: int | None = None,
     ) -> None:
         self._row_threshold = row_threshold
         self._byte_threshold = byte_threshold
         self._sample_size = sample_size
         self._ttl_seconds = ttl_seconds
-        # ``store`` / ``max_spill_rows`` default to ``None`` so the
-        # production singleton (installed via ``set_default_reducer``)
-        # resolves both lazily at reduce time -- the store from the shared
-        # broadcast Valkey client, the cap from settings. Tests inject a
-        # fake store + explicit cap to exercise the spill path in-process.
+        # ``store`` / ``max_spill_rows`` / ``sample_byte_budget`` default
+        # to ``None`` so the production singleton (installed via
+        # ``set_default_reducer``) resolves them lazily at reduce time --
+        # the store from the shared broadcast Valkey client, the row cap
+        # and the sample byte budget from settings. Tests inject a fake
+        # store + explicit caps to exercise the spill / budget paths
+        # in-process.
         self._store = store
         self._max_spill_rows = max_spill_rows
+        self._sample_byte_budget = sample_byte_budget
 
     async def reduce(
         self,
@@ -486,6 +501,17 @@ class JsonFluxReducer:
         persisted -- the handle's drill-in branch flips to
         ``available=True`` pointing at ``result_query`` -- or the skip
         reason the unavailable branch surfaces verbatim (#1629).
+
+        The inline sample is serialized **exactly once** (#134): it lives
+        only on :attr:`ResultHandle.sample_rows` -- the audit hoist
+        (``sample_rows_returned``) and every connector e2e assertion read
+        it there -- and the inline ``summary`` no longer carries a
+        byte-identical ``sample`` copy. Before this change the same
+        ``sample_rows`` list was placed into *both* the handle and the
+        summary, so an object-heavy list op shipped two full copies of a
+        large preview and overflowed the MCP token ceiling. The sample is
+        additionally shrunk to fit :attr:`_sample_byte_budget` so its
+        serialized size is bounded independently of per-row object size.
         """
         total_rows = materialized.total_rows
         fetch_more = _build_fetch_more(
@@ -495,7 +521,9 @@ class JsonFluxReducer:
             spill_outcome=spill_outcome,
             ttl_seconds=self._ttl_seconds,
         )
-        sample_rows = materialized.sample_rows
+        sample_rows = _fit_sample_to_budget(
+            materialized.sample_rows, self._resolve_sample_byte_budget()
+        )
         handle = ResultHandle(
             handle_id=materialized.handle_id,
             summary_md=(
@@ -507,14 +535,33 @@ class JsonFluxReducer:
             ttl_seconds=self._ttl_seconds,
             fetch_more=fetch_more,
         )
-        summary = {
+        # The inline summary is the compact reduced view. It deliberately
+        # does NOT carry a ``sample`` -- the bounded preview lives once on
+        # ``handle.sample_rows`` (#134). ``sample_bytes`` records the
+        # serialized size the reducer bounded the preview to, so an agent
+        # reading the summary knows a preview exists and where to find it
+        # without re-measuring the handle.
+        summary: dict[str, Any] = {
             "row_count": total_rows,
             "total": total_rows,
-            "sample": sample_rows,
+            "sample_rows_returned": len(sample_rows),
+            "sample_bytes": len(_serialize(sample_rows)) if sample_rows else 0,
         }
         if envelope_key is not None:
             summary["source_key"] = envelope_key
         return summary, handle
+
+    def _resolve_sample_byte_budget(self) -> int:
+        """Byte budget for the inline sample, resolved lazily from settings.
+
+        Mirrors the ``_max_spill_rows`` lazy-resolution pattern: an
+        explicit constructor value (tests) wins; otherwise the production
+        singleton reads ``jsonflux_sample_byte_budget`` from settings once
+        per reduce through :func:`get_settings`'s cache.
+        """
+        if self._sample_byte_budget is not None:
+            return self._sample_byte_budget
+        return get_settings().jsonflux_sample_byte_budget
 
 
 def _detect_collection(payload: Any) -> tuple[str | None, list[Any] | None]:
@@ -666,6 +713,79 @@ def _serialize(payload: Any) -> bytes:
         return msgspec.json.encode(payload)
     except (TypeError, msgspec.EncodeError):
         return str(payload).encode("utf-8", "replace")
+
+
+#: Marker appended to a value that :func:`_truncate_row_values` shortened,
+#: so a reader can tell the inline preview clipped a field rather than the
+#: op returning a short value. The full value is still reachable via the
+#: spilled handle + ``result_query``.
+_TRUNCATION_MARKER = "…[truncated]"
+
+
+def _fit_sample_to_budget(
+    sample_rows: list[dict[str, Any]], byte_budget: int
+) -> list[dict[str, Any]]:
+    """Shrink *sample_rows* so its serialized JSON fits *byte_budget* (#134).
+
+    ``sample_size`` bounds the sample by *row count* only, so a handful of
+    object-heavy rows (tens of KB each) still overflow the MCP token
+    ceiling. This bounds the sample by *serialized bytes* independently of
+    per-row object size, in two stages:
+
+    1. **Drop rows** from the tail until the serialized sample fits the
+       budget, but never below one row -- a reduced set must still carry a
+       real preview, and full fidelity stays reachable via the spill +
+       ``result_query``.
+    2. If a **single** row still exceeds the budget, truncate that row's
+       oversized string values (:func:`_truncate_row_values`) so even one
+       pathologically large object cannot blow the ceiling.
+
+    An empty input returns empty. The returned rows are fresh dicts (the
+    caller freezes them into the handle); the materialized ``full_rows``
+    spilled for read-back are untouched, so recovery is byte-for-byte
+    unchanged.
+    """
+    if not sample_rows:
+        return []
+    budget = max(byte_budget, 1)
+
+    rows = list(sample_rows)
+    while len(rows) > 1 and len(_serialize(rows)) > budget:
+        rows = rows[:-1]
+
+    if len(_serialize(rows)) <= budget:
+        return rows
+
+    # One row still over budget: truncate its oversized string values.
+    return [_truncate_row_values(rows[0], budget)]
+
+
+def _truncate_row_values(row: dict[str, Any], byte_budget: int) -> dict[str, Any]:
+    """Return *row* with oversized string values clipped to fit *byte_budget*.
+
+    Distributes the budget across the row's string-valued fields and clips
+    each to an equal share (leaving non-string values -- ints, nested
+    objects -- intact, since the object-heavy overflow this guards against
+    is dominated by long string blobs). Clipped values carry
+    :data:`_TRUNCATION_MARKER` so the clip is visible; the untruncated
+    value is recoverable via ``result_query``. This is the last-resort
+    branch: it only runs when a single row already exceeds the whole
+    budget, which a well-behaved op never hits.
+    """
+    string_keys = [key for key, value in row.items() if isinstance(value, str)]
+    if not string_keys:
+        return dict(row)
+    # Per-field character allowance. ``byte_budget`` is a byte bound and
+    # characters are >= 1 byte, so clipping to this many characters keeps
+    # the row's string payload under budget with headroom for the JSON
+    # structure (keys, quotes, non-string fields).
+    per_field_chars = max(byte_budget // (len(string_keys) * 2), 1)
+    truncated = dict(row)
+    for key in string_keys:
+        value = row[key]
+        if len(value.encode("utf-8")) > per_field_chars:
+            truncated[key] = value[:per_field_chars] + _TRUNCATION_MARKER
+    return truncated
 
 
 def _build_fetch_more(

--- a/backend/src/meho_backplane/settings.py
+++ b/backend/src/meho_backplane/settings.py
@@ -385,6 +385,21 @@ class Settings(BaseModel):
         genuinely larger sets raise it via
         ``RESULT_HANDLE_MAX_SPILL_ROWS``. Read once per reduce through
         :func:`get_settings`'s cache.
+    jsonflux_sample_byte_budget:
+        Upper bound, in serialized JSON bytes, on the inline sample the
+        JSONFlux reducer carries on a reduced ``ResultHandle`` (#134).
+        ``sample_size`` alone bounds the sample by *row count*, which lets
+        an object-heavy list op (rows of tens of KB each) overflow the MCP
+        result token ceiling even though the ``result_query`` handle works.
+        The reducer sizes the inline sample to fit this budget: it drops
+        rows (never below one) and, if a single row still exceeds the
+        budget, truncates that row's oversized field values — full fidelity
+        stays reachable via the spill + ``result_query``. Default 4096
+        mirrors ``byte_threshold`` (the bytes above which a payload
+        materializes at all): the inline preview stays roughly the size of
+        the smallest payload that would trigger reduction. Operators tune it
+        via ``JSONFLUX_SAMPLE_BYTE_BUDGET``. Read once per reduce through
+        :func:`get_settings`'s cache.
     composite_max_depth:
         Hard cap on the recursion depth a composite operation
         (``source_kind='composite'``) may reach via successive
@@ -891,6 +906,7 @@ class Settings(BaseModel):
     )
     broadcast_retention_hours: int = Field(default=24, gt=0)
     result_handle_max_spill_rows: int = Field(default=10000, gt=0)
+    jsonflux_sample_byte_budget: int = Field(default=4096, gt=0)
     composite_max_depth: int = Field(default=8, gt=0)
     agent_invoke_max_depth: int = Field(default=4, gt=0)
     topology_refresh_interval_seconds: int = Field(default=3600, gt=0)
@@ -1427,6 +1443,9 @@ def get_settings() -> Settings:
         ),
         result_handle_max_spill_rows=int(
             os.environ.get("RESULT_HANDLE_MAX_SPILL_ROWS", "10000"),
+        ),
+        jsonflux_sample_byte_budget=int(
+            os.environ.get("JSONFLUX_SAMPLE_BYTE_BUDGET", "4096"),
         ),
         composite_max_depth=int(
             os.environ.get("COMPOSITE_MAX_DEPTH", "8"),

--- a/backend/tests/test_operations_jsonflux_reducer.py
+++ b/backend/tests/test_operations_jsonflux_reducer.py
@@ -63,9 +63,12 @@ from meho_backplane.operations import (
 )
 from meho_backplane.operations.dispatcher import set_default_reducer
 from meho_backplane.operations.jsonflux_reducer import (
+    _TRUNCATION_MARKER,
     JsonFluxReducer,
+    _fit_sample_to_budget,
     _query_sample,
     _sample_from_tail,
+    _serialize,
 )
 from meho_backplane.operations.reducer import PassThroughReducer, Reducer
 from meho_backplane.settings import get_settings
@@ -107,8 +110,9 @@ async def test_materialize_handle_for_large_set() -> None:
       per column, typed (``id`` → string, ``count`` → integer).
     * ``sample_rows`` is a bounded non-empty slice of real rows.
     * ``summary_md`` mentions the row count and is non-empty.
-    * the inlined summary carries ``row_count`` and the bounded
-      ``sample`` — never the full raw list.
+    * the inlined summary carries ``row_count`` and the sample *count*
+      (``sample_rows_returned``) — never the full raw list, and never a
+      duplicate copy of the sample rows (#134).
     """
     reducer = JsonFluxReducer(sample_size=5)
     rows = [{"id": f"seg-{i}", "name": f"canary-{i}", "count": i} for i in range(60)]
@@ -146,10 +150,14 @@ async def test_materialize_handle_for_large_set() -> None:
     # ttl_seconds carries the configured default.
     assert handle.ttl_seconds == 3600
 
-    # The inlined summary is the reduced view, not the raw 60-row list.
+    # The inlined summary is the reduced view, not the raw 60-row list. The
+    # inline sample is serialized once — it lives on ``handle.sample_rows``,
+    # not duplicated into the summary (#134); the summary reports its count.
     assert isinstance(reduced, dict)
     assert reduced["row_count"] == 60
-    assert len(reduced["sample"]) <= 5
+    assert "sample" not in reduced
+    assert reduced["sample_rows_returned"] == len(handle.sample_rows)
+    assert 0 < reduced["sample_rows_returned"] <= 5
     assert "results" not in reduced
 
 
@@ -200,6 +208,101 @@ async def test_materialize_handle_for_under_row_over_byte_threshold() -> None:
     assert isinstance(reduced, dict)
     assert reduced["row_count"] == 5
     assert "value" not in reduced
+
+
+# ---------------------------------------------------------------------------
+# Single-serialization + byte-bounded inline sample (#134)
+# ---------------------------------------------------------------------------
+
+
+async def test_inline_sample_lives_in_exactly_one_location() -> None:
+    """The sample is carried once — on ``handle.sample_rows``, not the summary.
+
+    #134 acceptance criterion 1: a reduced ``call_operation`` envelope must
+    not carry the inline sample in *both* ``result.sample`` and
+    ``handle.sample_rows`` as full copies. The reducer keeps the preview on
+    ``handle.sample_rows`` (the audit hoist + every connector e2e reads it
+    there) and the compact summary reports only its *count*.
+    """
+    reducer = JsonFluxReducer(sample_size=5)
+    rows = [{"id": f"seg-{i}", "name": f"canary-{i}"} for i in range(60)]
+
+    reduced, handle = await reducer.reduce({"results": rows}, None)
+
+    assert handle is not None
+    # The handle carries the sample.
+    assert handle.sample_rows is not None and len(handle.sample_rows) > 0
+    # The summary does NOT duplicate it — no ``sample`` key at all.
+    assert "sample" not in reduced
+    # It reports the count instead, and the count agrees with the handle.
+    assert reduced["sample_rows_returned"] == len(handle.sample_rows)
+
+
+async def test_inline_sample_stays_under_byte_budget_independent_of_row_size() -> None:
+    """The reduced envelope size is bounded by bytes, independent of ``K`` (#134).
+
+    #134 acceptance criterion 2: given ``N`` rows each ~``K`` bytes where a
+    fixed 5-row sample would blow the budget, the serialized sample stays
+    under a fixed ceiling regardless of ``K`` — the row count shrinks as
+    ``K`` grows, never below one. Feed 8 KB and 50 KB rows and assert the
+    same ceiling holds for both while the sample row count drops.
+    """
+    budget = 4096
+
+    async def _sample_for_row_size(blob_bytes: int) -> list[dict[str, Any]]:
+        reducer = JsonFluxReducer(sample_size=5, sample_byte_budget=budget)
+        rows = [{"id": f"row-{i}", "blob": "x" * blob_bytes} for i in range(60)]
+        _reduced, handle = await reducer.reduce({"results": rows}, None)
+        assert handle is not None and handle.sample_rows is not None
+        return [dict(row) for row in handle.sample_rows]
+
+    sample_8k = await _sample_for_row_size(8 * 1024)
+    sample_50k = await _sample_for_row_size(50 * 1024)
+
+    # Each row alone exceeds the budget, so the sample shrinks to a single
+    # row whose oversized ``blob`` is truncated to fit — but never empty.
+    for sample in (sample_8k, sample_50k):
+        assert len(sample) >= 1
+        serialized = len(_serialize(sample))
+        assert serialized <= budget, (
+            f"serialized sample ({serialized} bytes) must stay under the "
+            f"{budget}-byte budget regardless of per-row size"
+        )
+    # A larger per-row size cannot produce a larger serialized sample.
+    assert len(_serialize(sample_50k)) <= budget
+    assert len(_serialize(sample_8k)) <= budget
+
+
+def test_fit_sample_to_budget_drops_rows_then_truncates() -> None:
+    """``_fit_sample_to_budget`` shrinks by rows first, then truncates values.
+
+    Three regimes, all bounded by the budget:
+
+    * a sample already under budget is returned unchanged;
+    * a multi-row sample over budget drops rows down toward one;
+    * a single row over budget has its oversized string values truncated
+      (marked with :data:`_TRUNCATION_MARKER`) rather than dropped to zero.
+    """
+    # Under budget — unchanged.
+    small = [{"k": "v"}, {"k": "w"}]
+    assert _fit_sample_to_budget(small, 4096) == small
+
+    # Multi-row over budget — rows drop, result fits, never below one.
+    fat_rows = [{"id": i, "blob": "x" * 2000} for i in range(5)]
+    fitted = _fit_sample_to_budget(fat_rows, 4096)
+    assert 1 <= len(fitted) < len(fat_rows)
+    assert len(_serialize(fitted)) <= 4096
+
+    # A single row larger than the whole budget — truncated, not emptied.
+    huge = [{"id": "only", "blob": "x" * 20000}]
+    clipped = _fit_sample_to_budget(huge, 4096)
+    assert len(clipped) == 1
+    assert clipped[0]["id"] == "only"
+    assert clipped[0]["blob"].endswith(_TRUNCATION_MARKER)
+    assert len(_serialize(clipped)) <= 4096
+
+    # Empty input stays empty.
+    assert _fit_sample_to_budget([], 4096) == []
 
 
 # ---------------------------------------------------------------------------
@@ -306,8 +409,10 @@ async def test_reduce_tail_op_samples_most_recent_lines() -> None:
 
     assert handle is not None
     assert handle.total_rows == 495
-    # The inline sample is the five MOST-RECENT lines, chronological.
-    sample_values = [row["value"] for row in reduced["sample"]]
+    # The inline sample lives once on ``handle.sample_rows`` (#134) and is
+    # the five MOST-RECENT lines, chronological.
+    assert handle.sample_rows is not None
+    sample_values = [dict(row)["value"] for row in handle.sample_rows]
     assert sample_values == [
         "line-490",
         "line-491",
@@ -315,9 +420,9 @@ async def test_reduce_tail_op_samples_most_recent_lines() -> None:
         "line-493",
         "line-494",
     ]
-    # The handle's sample_rows preview agrees with the inlined summary.
-    assert handle.sample_rows is not None
-    assert [dict(row)["value"] for row in handle.sample_rows] == sample_values
+    # The summary reports the preview count, not a duplicate copy.
+    assert "sample" not in reduced
+    assert reduced["sample_rows_returned"] == len(handle.sample_rows)
 
 
 async def test_reduce_without_ordering_hint_keeps_oldest_first_sample() -> None:
@@ -330,10 +435,11 @@ async def test_reduce_without_ordering_hint_keeps_oldest_first_sample() -> None:
     lines = [f"line-{i:03d}" for i in range(495)]
     payload = {"lines": lines}
 
-    reduced, handle = await reducer.reduce(payload, None, {"op_id": "k8s.logs"})
+    _reduced, handle = await reducer.reduce(payload, None, {"op_id": "k8s.logs"})
 
     assert handle is not None
-    sample_values = [row["value"] for row in reduced["sample"]]
+    assert handle.sample_rows is not None
+    sample_values = [dict(row)["value"] for row in handle.sample_rows]
     assert sample_values == [
         "line-000",
         "line-001",
@@ -707,6 +813,7 @@ class _FakeStore:
     def __init__(self) -> None:
         self.spills: list[dict[str, Any]] = []
         self._rows: dict[tuple[str, str], list[dict[str, Any]]] = {}
+        self._totals: dict[tuple[str, str], int] = {}
 
     async def spill(
         self,
@@ -733,7 +840,38 @@ class _FakeStore:
             }
         )
         self._rows[(str(tenant_id), str(handle_id))] = stored
+        self._totals[(str(tenant_id), str(handle_id))] = total_rows
         return bool(stored)
+
+    async def fetch_window(
+        self,
+        *,
+        tenant_id: Any,
+        operator_sub: str,
+        handle_id: Any,
+        offset: int,
+        limit: int,
+    ) -> dict[str, Any] | None:
+        """Serve a spilled window back, mirroring the real store's contract.
+
+        Returns the ``[offset : offset+limit]`` slice plus ``total_rows`` /
+        ``stored_rows`` / ``truncated`` so a test can page the spilled
+        handle end-to-end and confirm recovery is unaffected by the inline
+        sample's byte-budgeting (#134).
+        """
+        key = (str(tenant_id), str(handle_id))
+        rows = self._rows.get(key)
+        if rows is None:
+            return None
+        stored = len(rows)
+        total = self._totals[key]
+        window = rows[max(offset, 0) : max(offset, 0) + limit] if limit > 0 else []
+        return {
+            "rows": window,
+            "total_rows": total,
+            "stored_rows": stored,
+            "truncated": stored < total,
+        }
 
 
 async def test_reduce_spills_full_rows_and_flips_drill_in_available() -> None:
@@ -776,6 +914,50 @@ async def test_reduce_spills_full_rows_and_flips_drill_in_available() -> None:
     assert drill_in.example_call["args"]["handle_id"] == str(handle.handle_id)
     assert drill_in.expires_at is not None
     assert "result_query" in drill_in.rationale
+
+
+async def test_recovery_unchanged_when_inline_sample_is_byte_bounded() -> None:
+    """Byte-budgeting the inline sample leaves the spilled full set intact (#134).
+
+    #134 acceptance criterion 4: the recovery path is untouched. Even when
+    the inline sample is shrunk / truncated to fit the byte budget, the
+    **full** object-heavy rows are spilled verbatim; paging the handle to
+    its last row via the store returns the row byte-for-byte, with
+    ``total_rows`` correct and ``truncated=False`` (no cap applied).
+    """
+    store = _FakeStore()
+    reducer = JsonFluxReducer(
+        sample_size=5, sample_byte_budget=4096, store=store, max_spill_rows=10000
+    )
+    # Object-heavy rows: each ~8 KB, so the inline sample must shrink+truncate.
+    rows = [{"id": f"row-{i}", "blob": f"{i}-" + "x" * 8000} for i in range(60)]
+    context = {
+        "op_id": "k8s.apps.list",
+        "operator_sub": "op-a",
+        "tenant_id": "00000000-0000-0000-0000-00000000a0a0",
+    }
+
+    _reduced, handle = await reducer.reduce({"results": rows}, None, context)
+
+    assert handle is not None
+    # The inline sample was byte-bounded (a single truncated row).
+    assert handle.sample_rows is not None
+    assert len(_serialize([dict(r) for r in handle.sample_rows])) <= 4096
+
+    # The FULL, un-truncated rows were spilled — recovery is unaffected.
+    window = await store.fetch_window(
+        tenant_id=context["tenant_id"],
+        operator_sub="op-a",
+        handle_id=handle.handle_id,
+        offset=59,
+        limit=1,
+    )
+    assert window is not None
+    assert window["total_rows"] == 60
+    assert window["truncated"] is False
+    # The last row round-trips byte-for-byte — the spill is full fidelity,
+    # NOT the truncated inline preview.
+    assert window["rows"] == [{"id": "row-59", "blob": "59-" + "x" * 8000}]
 
 
 async def test_reduce_without_tenant_skips_spill_and_stays_unavailable() -> None:
@@ -849,7 +1031,9 @@ async def test_reduce_store_rejection_reports_result_store_unavailable() -> None
 
     assert handle is not None
     assert reduced["row_count"] == 60
-    assert len(reduced["sample"]) == 5, "the inline sample must still ship"
+    assert handle.sample_rows is not None and len(handle.sample_rows) == 5, (
+        "the inline sample must still ship"
+    )
     drill_in = handle.fetch_more.drill_in
     assert drill_in.available is False
     assert drill_in.reason == "result_store_unavailable"
@@ -932,9 +1116,9 @@ async def test_k8s_logs_shape_with_tenant_context_spills_and_pages() -> None:
     assert reduced["row_count"] == 300
     assert reduced["total"] == 300
     assert reduced["source_key"] == "lines"
-    assert len(reduced["sample"]) == 5
+    assert handle.sample_rows is not None and len(handle.sample_rows) == 5
     # Tail ordering: the sample is the five most-recent lines.
-    assert reduced["sample"][-1]["value"].endswith("log line 299")
+    assert dict(handle.sample_rows[-1])["value"].endswith("log line 299")
     # The full 300 rows were spilled and the drill-in teaches the page-back.
     assert len(store.spills) == 1
     assert store.spills[0]["stored_rows"] == 300
@@ -971,7 +1155,7 @@ async def test_k8s_logs_shape_store_down_states_the_reason() -> None:
 
     assert handle is not None
     assert reduced["row_count"] == 300
-    assert len(reduced["sample"]) == 5
+    assert handle.sample_rows is not None and len(handle.sample_rows) == 5
     drill_in = handle.fetch_more.drill_in
     assert drill_in.available is False
     assert drill_in.reason == "result_store_unavailable"

--- a/backend/tests/test_vault_kv_list_jsonflux.py
+++ b/backend/tests/test_vault_kv_list_jsonflux.py
@@ -287,9 +287,11 @@ async def test_kv_list_over_threshold_returns_sample_and_handle(
     * ``handle.sample_rows`` is a bounded non-empty slice — the seed a
       future ``result_query(handle, ...)`` pages from.
     * :attr:`OperationResult.result` carries the reduced summary
-      (``sample`` + ``total``), **not** the raw >50-key list — the
-      agent never sees the full set inline (DoD: "no agent-visible raw
-      list larger than threshold for this op").
+      (the sample *count* + ``total``), **not** the raw >50-key list —
+      the agent never sees the full set inline (DoD: "no agent-visible
+      raw list larger than threshold for this op"). The sample rows
+      themselves live once on ``handle.sample_rows`` (#134), not
+      duplicated onto the summary.
     """
     big_keys = [f"secret-{i}" for i in range(_THRESHOLD + 75)]  # 125 keys, well over
     install_fake_client(monkeypatch, keys=big_keys)
@@ -351,12 +353,18 @@ async def test_kv_list_over_threshold_returns_sample_and_handle(
     assert isinstance(result.result, dict)
     assert result.result.get("total") == len(big_keys)
     assert result.result.get("row_count") == len(big_keys)
-    assert [row["value"] for row in result.result.get("sample", [])] == big_keys[:_SAMPLE_SIZE]
+    # The sample rows are carried once on the handle (#134); the summary
+    # reports only their count, not a duplicate copy.
+    assert "sample" not in result.result, (
+        "the inline sample must not be duplicated onto the result summary (#134)"
+    )
+    assert handle.sample_rows is not None
+    assert [dict(row)["value"] for row in handle.sample_rows] == big_keys[:_SAMPLE_SIZE]
+    assert result.result.get("sample_rows_returned") == len(handle.sample_rows)
     assert "keys" not in result.result, (
         "the raw inline key list must not survive on the result envelope once a handle is produced"
     )
-    inlined_rows = result.result.get("sample", [])
-    assert len(inlined_rows) <= _THRESHOLD, (
+    assert len(handle.sample_rows) <= _THRESHOLD, (
         f"no agent-visible list larger than the threshold may be inlined; "
-        f"got {len(inlined_rows)} rows on the result envelope"
+        f"got {len(handle.sample_rows)} sample rows"
     )

--- a/docs/architecture/jsonflux.md
+++ b/docs/architecture/jsonflux.md
@@ -243,10 +243,32 @@ Read off the shipped adapter
 | `byte_threshold` | `4096` | Materialize when the serialized payload exceeds this many bytes, even if under `row_threshold`. |
 | `sample_size` | `5` | Rows surfaced inline on the `ResultHandle.sample_rows` preview and in the markdown summary. `0` returns no sample. |
 | `ttl_seconds` | `3600` | Lifetime stamped onto `ResultHandle.ttl_seconds` for the backing store. |
+| `sample_byte_budget` | settings `jsonflux_sample_byte_budget` (default `4096`) | Upper bound, in serialized JSON bytes, on the inline sample (#134). The reducer shrinks the sample — fewer rows (never below one), then truncated values as a last resort — so it fits this budget regardless of per-row object size. Resolved lazily from settings when the constructor arg is `None`. |
 
-All four are keyword-only. The defaults match v0.1-spec §4 (50 rows /
+All are keyword-only. The threshold defaults match v0.1-spec §4 (50 rows /
 4 KB). Empty collections never materialize — a 0-row handle carries no
 information a pass-through doesn't.
+
+### The inline sample is serialized once (#134)
+
+The reducer carries the bounded preview in **exactly one** place:
+`ResultHandle.sample_rows`. The compact `summary` dict it returns
+alongside the handle (mapped to `OperationResult.result`) reports the
+preview count (`sample_rows_returned`) and its serialized size
+(`sample_bytes`) but does **not** duplicate the rows. Previously the same
+`sample_rows` list was placed into *both* the handle and the summary's
+`sample` key, so a reduced `call_operation` envelope shipped two
+byte-identical copies of a large preview — measured at 91.7 % of a
+277 KB envelope for a 23-row object-heavy list op — overflowing the MCP
+result token ceiling even though the `result_query` handle worked.
+
+The preview is bounded by serialized bytes (`sample_byte_budget`), not
+only by `sample_size` rows: an object-heavy list (rows of tens of KB) is
+shrunk to fit the budget so the reduced envelope stays under a ceiling
+independent of per-row object size. The `handle.sample_rows` audit hoist
+(`sample_rows_returned`) and the connector e2e assertions that read
+`handle.sample_rows` are unchanged; the full set is untouched and stays
+reachable via the spill + `result_query`.
 
 ### `fetch_more` envelope (G0.15-T8, #1219)
 


### PR DESCRIPTION
## Summary
- The JSONFlux reducer placed the same `sample_rows` list into **both** `ResultHandle.sample_rows` and the inline summary's `sample` key, and bounded it only by row count (`sample_size=5`). For object-heavy list ops each row is a full unprojected object, so five heavy rows shipped **twice** overflowed the MCP result token ceiling even though the `result_query` handle worked (measured: 91.7% of a 277 KB envelope was the two byte-identical copies).
- **Serialize the inline sample exactly once** — it now lives only on `handle.sample_rows`; the compact summary reports the preview *count* (`sample_rows_returned`) instead of a duplicate copy.
- **Bound the sample by serialized bytes** via a new named setting `jsonflux_sample_byte_budget` (default `4096`, mirroring `byte_threshold`): the reducer drops rows toward one, then truncates a single oversized row's string values as a last resort, so the reduced envelope stays under a ceiling **independent of per-row object size**.
- Recovery (`result_query` / the spilled full set) is untouched.

### Design note — de-dup direction inverted from the ticket's default
The ticket's recommended default was to drop `handle.sample_rows`. Grep showed a **handle-side consumer exists** — `dispatcher._handle_metadata_for_audit` hoists `len(handle.sample_rows)` into the audit `sample_rows_returned` — plus ~19 connector e2e/acceptance test files assert on `handle.sample_rows`. Per the ticket's own escape clause ("If a handle-only consumer exists, invert the choice"), this keeps the handle-side copy and drops the summary duplicate (which had **zero** production consumers), giving the lower-blast-radius single-serialization.

## Test plan
- [x] `ruff check` — clean
- [x] `ruff format --check` — clean
- [x] `mypy` — clean
- [x] `uv run pytest tests/ -k "jsonflux or reducer"` — 71 passed, 7 skipped
- [x] `tests/test_settings.py`, `test_operations_reducer.py`, `test_ui_operations.py`, `test_ui_vault.py` — 110 passed
- [x] **AC1** single location — `test_inline_sample_lives_in_exactly_one_location`: summary has no `sample`; handle carries it.
- [x] **AC2** byte-budget independence — `test_inline_sample_stays_under_byte_budget_independent_of_row_size` (8 KB & 50 KB rows, same ceiling, row count shrinks ≥1) + `test_fit_sample_to_budget_drops_rows_then_truncates`.
- [x] **AC3** named setting — `jsonflux_sample_byte_budget` in `settings.py` + referenced in `jsonflux_reducer.py`, default documented in the field description.
- [x] **AC4** recovery unchanged — `test_recovery_unchanged_when_inline_sample_is_byte_bounded`: pages the spilled handle to the last row, `total_rows=60`, `truncated=False`, row byte-for-byte.
- [x] **AC6** docstrings/docs — `JsonFluxReducer` module docstring, `ResultHandle` docstring, and `docs/architecture/jsonflux.md` updated.

## Out of scope
- MCP `call_operation` serializer / transport (confirmed pure pass-through).
- Vendor-specific field projection (k8s `managedFields`) — follow-up via a connector hint, not this Task.
- Sample ordering (head vs tail) — unchanged.

<!-- auto-implement-issue: fresh, iteration 1 -->

Closes evoila-bosnia/meho-internal#134
