### PR TITLE
feat(connectors): ingest the hetzner-rest connector + live Vault auth (#2079)

### DIFF
--- a/backend/src/meho_backplane/connectors/hetzner_robot/connector.py
+++ b/backend/src/meho_backplane/connectors/hetzner_robot/connector.py
@@ -80,7 +80,10 @@ import structlog
 
 from meho_backplane.auth.operator import Operator
 from meho_backplane.connectors._shared.cache_key import target_cache_key
-from meho_backplane.connectors._shared.system_operator import synthesise_system_operator
+from meho_backplane.connectors._shared.system_operator import (
+    is_system_operator,
+    synthesise_system_operator,
+)
 from meho_backplane.connectors.adapters.http import HttpConnector
 from meho_backplane.connectors.hetzner_robot.session import (
     HetznerRobotCredentialsLoader,
@@ -172,17 +175,18 @@ class HetznerRobotConnector(HttpConnector):
         """Return ``{"Authorization": "Basic ..."}`` for the request.
 
         Loads credentials from Vault on first call against *target*, caches
-        them, and reuses the cached values on subsequent calls.  ``operator``
-        is accepted for the shared HTTP auth surface (G3.9-T1) but unused —
-        :attr:`AuthModel.SHARED_SERVICE_ACCOUNT` authenticates with a
-        Vault-sourced Webservice-user credential, not the operator's OIDC
-        token.  Threading the operator into Hetzner Robot's credential loader
-        is #G3.10.
+        them, and reuses the cached values on subsequent calls.  The full
+        ``operator`` is forwarded to :meth:`_load_credentials` so the live
+        default loader (#2079) reads the per-target Vault secret under the
+        operator's identity (``vault_client_for_operator(operator)``).
+        :attr:`AuthModel.SHARED_SERVICE_ACCOUNT` selects the Vault-sourced
+        Webservice-user credential once the loader has resolved it; the
+        operator's JWT only authenticates the Vault read, not the Robot
+        request itself.
 
         Raises :exc:`NotImplementedError` if ``target.auth_model`` is anything
         other than ``shared_service_account`` or ``None``.
         """
-        del operator  # SHARED_SERVICE_ACCOUNT mode does not forward operator identity
         auth_model = getattr(target, "auth_model", None)
         if not _is_acceptable_auth_model(auth_model):
             raise NotImplementedError(
@@ -190,23 +194,34 @@ class HetznerRobotConnector(HttpConnector):
                 f"{AuthModel.SHARED_SERVICE_ACCOUNT.value!r}; target "
                 f"{target.name!r} requested auth_model={auth_model!r}"
             )
-        creds = await self._load_credentials(target)
+        creds = await self._load_credentials(target, operator)
         return {"Authorization": _basic_auth_header(creds["username"], creds["password"])}
 
-    async def _load_credentials(self, target: HetznerRobotTargetLike) -> dict[str, str]:
+    async def _load_credentials(
+        self, target: HetznerRobotTargetLike, operator: Operator
+    ) -> dict[str, str]:
         """Return the cached credentials for *target*, loading from Vault on first use.
 
         The lock serialises concurrent first-use callers for the same target.
         The loaded dict must contain ``"username"`` and ``"password"`` keys;
         missing keys raise :exc:`RuntimeError` naming the target and the missing
         key so operators can identify a misconfigured Vault path.
+
+        ``operator`` is forwarded to the :class:`HetznerRobotCredentialsLoader`
+        so the default loader reads the per-target Vault secret under the
+        operator's identity. The cache fast-path is closed to the synthesised
+        system operator (:func:`is_system_operator`): a system/operator-less
+        caller always runs the loader so its fail-closed guard applies, and can
+        never be served warm credentials a real operator primed but it could
+        not resolve itself (#1008). Real-operator behaviour is unchanged —
+        cold load → cache → reuse.
         """
         cache_key = target_cache_key(target)
         async with self._creds_lock:
             cached = self._creds_cache.get(cache_key)
-            if cached is not None:
+            if cached is not None and not is_system_operator(operator):
                 return cached
-            raw = await self._credentials_loader(target)
+            raw = await self._credentials_loader(target, operator)
             try:
                 _ = raw["username"]
                 _ = raw["password"]

--- a/backend/src/meho_backplane/connectors/hetzner_robot/session.py
+++ b/backend/src/meho_backplane/connectors/hetzner_robot/session.py
@@ -14,12 +14,19 @@ account that must be created in the Robot portal and is distinct from the
 Robot login user. Credentials are stored verbatim in Vault under the
 target's ``secret_ref`` path as ``{"username": ..., "password": ...}``.
 
+The default loader, :func:`load_credentials_from_vault`, performs the
+**live** operator-context KV-v2 read by delegating to the shared
+:func:`~meho_backplane.connectors._shared.vault_creds.load_basic_credentials`
+helper (#2079) — the same read every REST connector's default loader uses
+(harbor, vmware, sddc). The Webservice-user credential is read under the
+operator's Vault identity (``vault_client_for_operator(operator)``), so
+Vault RBAC and audit attribute the read to the operator. The loader is
+injectable so unit tests supply canned credentials and integration tests
+supply the appropriate Webservice-user pair.
+
 **Critical: IP-block protection.** Hetzner Robot blocks the source IP for
 10 minutes after 3 failed 401 responses from that IP.  Any credential
 mismatch must therefore surface as an immediate hard error — never a retry.
-The loader is injectable so unit tests supply canned credentials; the
-production path (live Vault read) is a deliberate stub until Goal #214
-lands.
 
 The :class:`HetznerRobotTargetLike` Protocol captures the minimum target
 shape the connector reads: ``name`` (per-target cache key), ``host``,
@@ -33,6 +40,9 @@ from __future__ import annotations
 
 from collections.abc import Awaitable, Callable
 from typing import Protocol, runtime_checkable
+
+from meho_backplane.auth.operator import Operator
+from meho_backplane.connectors._shared.vault_creds import load_basic_credentials
 
 __all__ = [
     "HetznerRobotCredentialsLoader",
@@ -63,7 +73,12 @@ class HetznerRobotTargetLike(Protocol):
     authenticating as the shared service account.
 
     ``secret_ref`` is the Vault path resolved to ``{"username", "password"}``.
-    ``port`` is optional — the Robot API is HTTPS/443 and
+    It is ``str | None`` to match the concrete ``Target.secret_ref`` column
+    (nullable) and the shared
+    :class:`~meho_backplane.connectors._shared.vault_creds.BasicCredentialsTargetLike`
+    the default loader forwards to; an unset ``secret_ref`` is rejected with
+    a clear error inside the loader (an unconfigured target), never a bare
+    ``KeyError``. ``port`` is optional — the Robot API is HTTPS/443 and
     :meth:`HttpConnector._base_url` already handles the ``port is None or
     443`` case correctly.
 
@@ -78,38 +93,64 @@ class HetznerRobotTargetLike(Protocol):
     name: str
     host: str
     port: int | None
-    secret_ref: str
+    secret_ref: str | None
     auth_model: str | None
 
 
-HetznerRobotCredentialsLoader = Callable[[HetznerRobotTargetLike], Awaitable[dict[str, str]]]
-"""Async callable resolving a target to ``{"username": ..., "password": ...}``.
+HetznerRobotCredentialsLoader = Callable[
+    [HetznerRobotTargetLike, Operator], Awaitable[dict[str, str]]
+]
+"""Async callable resolving a (target, operator) pair to credentials.
 
-The connector's :meth:`HetznerRobotConnector._load_credentials` invokes the
-loader exactly once per target (first-use), caching the resulting dict under
-``target.name``.  The return type is the looser ``dict[str, str]`` (not
-:class:`SessionCredentials`) because Python :class:`Protocol` instances
-aren't runtime-constructible without a matching class.
+Returns ``{"username": ..., "password": ...}``. The connector's
+:meth:`HetznerRobotConnector._load_credentials` invokes the loader exactly
+once per target (first-use), caching the resulting dict under the
+tenant-unique ``(tenant_id, id)`` cache key.  The return type is the looser
+``dict[str, str]`` (not :class:`SessionCredentials`) because Python
+:class:`Protocol` instances aren't runtime-constructible without a matching
+class.
+
+The ``operator`` parameter carries the full
+:class:`~meho_backplane.auth.operator.Operator` (frozen) so the live loader
+reads the per-target secret under the operator's identity via
+``vault_client_for_operator(operator)`` — the operator-context read every
+REST connector uses.
 """
 
 
 async def load_credentials_from_vault(
     target: HetznerRobotTargetLike,
+    operator: Operator,
 ) -> dict[str, str]:
-    """Default credential loader — Vault read by ``target.secret_ref``.
+    """Default credential loader — live operator-context Vault KV-v2 read.
 
-    Deliberate stub: the operator-context per-target Vault credential read is
-    not yet wired for the Hetzner Robot connector.  Raising
-    :exc:`NotImplementedError` here keeps the wiring shape stable — a
-    production caller without an override receives a clear error rather than
-    a silent fallback or a hallucinated credential pair.  The live read is
-    tracked under the open Goal #214 (Connector parity).
+    Reads ``target.secret_ref`` as a KV-v2 secret **under the operator's
+    identity** (the operator's validated Keycloak JWT is forwarded to Vault's
+    JWT/OIDC auth method) and returns the dedicated Webservice-user
+    ``{"username": ..., "password": ...}`` pair the connector sends as HTTP
+    Basic auth on every Robot Webservice request. Delegates to the shared
+    :func:`~meho_backplane.connectors._shared.vault_creds.load_basic_credentials`
+    helper so the read, the no-secret-in-logs discipline, and the two-phase
+    error contract are defined once for every REST connector — this loader is
+    the thin hetzner-specific entry point.
+
+    The Webservice user is **distinct from the Robot portal login user** and
+    must be created separately in the Robot portal; its credentials are stored
+    verbatim in Vault under the target's ``secret_ref``.
+
+    The error contract is the helper's:
+
+    * :class:`~meho_backplane.connectors._shared.vault_creds.VaultCredentialsReadError`
+      — read-phase failure (empty ``operator.raw_jwt`` for a system-initiated
+      call, unset ``target.secret_ref``, a malformed KV-v2 payload, or a
+      missing ``username``/``password`` field). Never a bare ``KeyError``.
+    * :class:`~meho_backplane.auth.vault.VaultClientError` (and subclasses) —
+      login-phase failure (Vault unreachable, role denied). Propagated
+      verbatim so callers can distinguish login from read.
+
+    A custom :class:`HetznerRobotCredentialsLoader` can still be injected via
+    ``credentials_loader`` on :class:`HetznerRobotConnector` (tests do exactly
+    that); this default is what production targets at rubric State 2
+    (``shared_service_account``) use.
     """
-    raise NotImplementedError(
-        "load_credentials_from_vault is a deliberate stub: the operator-context "
-        "per-target Vault credential read is not yet wired for the Hetzner Robot "
-        f"connector; target={target.name!r} secret_ref={target.secret_ref!r}. "
-        "Workaround: inject a custom credentials_loader on HetznerRobotConnector. "
-        "Tracked under open Goal #214 (Connector parity): "
-        "https://github.com/evoila/meho/issues/214"
-    )
+    return await load_basic_credentials(target, operator)

--- a/backend/src/meho_backplane/operations/ingest/specs/hetzner_robot_minimal.yaml
+++ b/backend/src/meho_backplane/operations/ingest/specs/hetzner_robot_minimal.yaml
@@ -1,0 +1,460 @@
+# SPDX-License-Identifier: Apache-2.0
+# Copyright (c) 2026 evoila Group
+#
+# Minimal, self-contained OpenAPI 3.0 description of the subset of the
+# Hetzner Robot Webservice REST API that MEHO ingests for the
+# `hetzner-rest-2026.04` connector shell (#2079, Parent goal #221).
+#
+# WHY THIS FILE EXISTS. The Hetzner Robot Webservice publishes no OpenAPI
+# document at all -- its API is documented only as HTML/Markdown at
+# https://robot.hetzner.com/doc/webservice/en.html. Without a spec the
+# `hetzner-rest-2026.04` connector registers empty (`operation_count=0`)
+# and the physical-layer infra leg (dedicated-server inventory, vSwitch
+# membership, per-server firewall, rDNS, server_addon orders) has no meho
+# path -- it stays on the local `hetzner-robot.sh` wrapper. This
+# MEHO-authored minimal spec ships as package data so
+# `meho connector ingest --product hetzner --version 2026.04
+# --impl hetzner-rest --spec <this-file>` yields dispatchable operations
+# that resolve to the hand-rolled HetznerRobotConnector.
+#
+# SCOPE. The handful of ops the local wrapper covers, per the #2079
+# acceptance criteria: list/get servers, vSwitch get + membership,
+# per-server firewall get/set, reverse DNS, and the server_addon order.
+# The read GETs (server list/get, vswitch list/get, firewall get, rdns)
+# are the ops the curated read-only core enables today
+# (connectors/hetzner_robot/core_ops.py, ROBOT_CORE_OPS); the write ops
+# (vSwitch membership POST/DELETE, firewall set, server_addon order) are
+# declared so the ingested corpus covers the full wrapper surface and the
+# G3.x write-surface curation has a descriptor to enable when it lands.
+#
+# WIRE PATHS. Robot's REST paths are flat (one resource per root segment)
+# and MUST be reproduced verbatim -- the dispatcher addresses the real
+# Webservice with the persisted `path` / `op_id` (op_id = `METHOD:path`).
+# The GET op_ids here (GET:/server, GET:/server/{server-ip},
+# GET:/vswitch, GET:/vswitch/{id}, GET:/firewall/{server-ip}, GET:/rdns)
+# match the paths cross-checked in ROBOT_CORE_OPS so the ingested rows and
+# the curated core agree on the same op_id strings.
+#
+# NO `servers` BLOCK. #1796 made the OpenAPI Server Object load-bearing --
+# the ingest parser folds a relative `servers[].url` onto every op path.
+# Robot's paths are already root-absolute (`/server`, `/vswitch`), so
+# declaring a `servers` base would double-prefix them. The base URL is the
+# per-target host (robot-ws.your-server.de) resolved at dispatch time.
+#
+# CONSTRAINTS. OpenAPI 3.0 (the parser rejects Swagger 2.0); self-contained
+# with only local `$ref`s (the parser rejects cross-document `$ref`); every
+# operation declares an `operationId`. Dry-run-parsed by the ingest test
+# with the same `parse_openapi` the live ingest uses, so a malformed spec
+# fails CI rather than 500-ing the first `--spec` ingest.
+openapi: "3.0.3"
+info:
+  title: Hetzner Robot Webservice API (MEHO minimal subset)
+  version: "2026.04"
+  description: >-
+    MEHO-authored minimal subset of the Hetzner Robot Webservice REST API.
+    Covers the dedicated-server inventory, vSwitch, per-server firewall,
+    reverse-DNS, and server_addon-order operations MEHO ingests; not a full
+    vendor spec (the vendor publishes no OpenAPI document). Authenticates
+    with HTTP Basic against the dedicated Webservice user, distinct from the
+    Robot portal login user. SPDX-License-Identifier: Apache-2.0.
+  license:
+    name: Apache-2.0
+    url: https://www.apache.org/licenses/LICENSE-2.0
+paths:
+  /server:
+    get:
+      operationId: listServers
+      summary: List dedicated servers
+      description: >-
+        List the dedicated servers owned by the account. Each entry carries
+        the server number, primary IP, product name, datacenter, and traffic
+        plan.
+      responses:
+        "200":
+          description: A list of dedicated servers.
+          content:
+            application/json:
+              schema:
+                type: array
+                items:
+                  $ref: "#/components/schemas/ServerEnvelope"
+  /server/{server-ip}:
+    get:
+      operationId: getServer
+      summary: Get one dedicated server
+      description: >-
+        Return the full detail of one dedicated server addressed by its
+        primary IP.
+      parameters:
+        - name: server-ip
+          in: path
+          required: true
+          description: The server's primary IP address.
+          schema:
+            type: string
+      responses:
+        "200":
+          description: The requested server.
+          content:
+            application/json:
+              schema:
+                $ref: "#/components/schemas/ServerEnvelope"
+  /vswitch:
+    get:
+      operationId: listVswitches
+      summary: List vSwitches
+      description: >-
+        List the vSwitches configured on the account with their VLAN and
+        member-server assignments.
+      responses:
+        "200":
+          description: A list of vSwitches.
+          content:
+            application/json:
+              schema:
+                type: array
+                items:
+                  $ref: "#/components/schemas/VswitchEnvelope"
+  /vswitch/{id}:
+    get:
+      operationId: getVswitch
+      summary: Get one vSwitch
+      description: >-
+        Return the full detail of one vSwitch by its numeric id, including
+        all member servers and their statuses.
+      parameters:
+        - name: id
+          in: path
+          required: true
+          description: The vSwitch numeric id.
+          schema:
+            type: string
+      responses:
+        "200":
+          description: The requested vSwitch.
+          content:
+            application/json:
+              schema:
+                $ref: "#/components/schemas/VswitchEnvelope"
+    post:
+      operationId: addVswitchServers
+      summary: Add servers to a vSwitch
+      description: >-
+        Add one or more dedicated servers to a vSwitch's VLAN membership.
+        The Robot Webservice expects the server IPs as form fields; the body
+        below is the JSON-schema view of those fields.
+      parameters:
+        - name: id
+          in: path
+          required: true
+          description: The vSwitch numeric id.
+          schema:
+            type: string
+      requestBody:
+        required: true
+        content:
+          application/json:
+            schema:
+              $ref: "#/components/schemas/VswitchMembershipRequest"
+      responses:
+        "200":
+          description: Membership add accepted.
+          content:
+            application/json:
+              schema:
+                $ref: "#/components/schemas/VswitchEnvelope"
+    delete:
+      operationId: removeVswitchServers
+      summary: Remove servers from a vSwitch
+      description: >-
+        Remove one or more dedicated servers from a vSwitch's VLAN
+        membership.
+      parameters:
+        - name: id
+          in: path
+          required: true
+          description: The vSwitch numeric id.
+          schema:
+            type: string
+      requestBody:
+        required: true
+        content:
+          application/json:
+            schema:
+              $ref: "#/components/schemas/VswitchMembershipRequest"
+      responses:
+        "200":
+          description: Membership remove accepted.
+          content:
+            application/json:
+              schema:
+                $ref: "#/components/schemas/VswitchEnvelope"
+  /firewall/{server-ip}:
+    get:
+      operationId: getFirewall
+      summary: Get a server's firewall
+      description: >-
+        Return the packet-filter firewall configuration applied to the
+        dedicated server addressed by its primary IP: the active status,
+        the whitelist-Hetzner-services flag, and the ordered rule set.
+      parameters:
+        - name: server-ip
+          in: path
+          required: true
+          description: The server's primary IP address.
+          schema:
+            type: string
+      responses:
+        "200":
+          description: The server's firewall configuration.
+          content:
+            application/json:
+              schema:
+                $ref: "#/components/schemas/FirewallEnvelope"
+    post:
+      operationId: setFirewall
+      summary: Set a server's firewall
+      description: >-
+        Replace the packet-filter firewall configuration for the dedicated
+        server addressed by its primary IP. The Robot Webservice expects the
+        rule set as form fields; the body below is the JSON-schema view.
+      parameters:
+        - name: server-ip
+          in: path
+          required: true
+          description: The server's primary IP address.
+          schema:
+            type: string
+      requestBody:
+        required: true
+        content:
+          application/json:
+            schema:
+              $ref: "#/components/schemas/FirewallConfig"
+      responses:
+        "200":
+          description: Firewall update accepted.
+          content:
+            application/json:
+              schema:
+                $ref: "#/components/schemas/FirewallEnvelope"
+  /rdns:
+    get:
+      operationId: listRdns
+      summary: List reverse-DNS entries
+      description: >-
+        List every reverse-DNS (PTR) entry set on the account's IPs.
+      responses:
+        "200":
+          description: A list of reverse-DNS entries.
+          content:
+            application/json:
+              schema:
+                type: array
+                items:
+                  $ref: "#/components/schemas/RdnsEnvelope"
+  /rdns/{ip}:
+    get:
+      operationId: getRdns
+      summary: Get one reverse-DNS entry
+      description: Return the reverse-DNS (PTR) entry for one IP address.
+      parameters:
+        - name: ip
+          in: path
+          required: true
+          description: The IP address whose PTR record is read.
+          schema:
+            type: string
+      responses:
+        "200":
+          description: The reverse-DNS entry.
+          content:
+            application/json:
+              schema:
+                $ref: "#/components/schemas/RdnsEnvelope"
+  /order/server_addon/transaction:
+    post:
+      operationId: orderServerAddon
+      summary: Order a server addon
+      description: >-
+        Place an order for a server addon (e.g. an additional IP, subnet, or
+        capacity upgrade) against a dedicated server. Returns the addon
+        transaction record with its id and status.
+      requestBody:
+        required: true
+        content:
+          application/json:
+            schema:
+              $ref: "#/components/schemas/ServerAddonOrderRequest"
+      responses:
+        "201":
+          description: Addon order transaction created.
+          content:
+            application/json:
+              schema:
+                $ref: "#/components/schemas/ServerAddonTransactionEnvelope"
+components:
+  schemas:
+    ServerEnvelope:
+      type: object
+      description: >-
+        The Robot Webservice wraps each server object under a ``server`` key.
+      properties:
+        server:
+          $ref: "#/components/schemas/Server"
+    Server:
+      type: object
+      description: A dedicated server inventory entry.
+      properties:
+        server_ip:
+          type: string
+        server_number:
+          type: integer
+        server_name:
+          type: string
+        product:
+          type: string
+        dc:
+          type: string
+        traffic:
+          type: string
+        status:
+          type: string
+        cancelled:
+          type: boolean
+        paid_until:
+          type: string
+    VswitchEnvelope:
+      type: object
+      description: The Robot Webservice wraps each vSwitch under a ``vswitch`` key.
+      properties:
+        vswitch:
+          $ref: "#/components/schemas/Vswitch"
+    Vswitch:
+      type: object
+      description: A vSwitch with its VLAN and member servers.
+      properties:
+        id:
+          type: integer
+        name:
+          type: string
+        vlan:
+          type: integer
+        cancelled:
+          type: boolean
+        server:
+          type: array
+          items:
+            $ref: "#/components/schemas/VswitchMember"
+    VswitchMember:
+      type: object
+      description: One member server of a vSwitch.
+      properties:
+        server_ip:
+          type: string
+        server_number:
+          type: integer
+        status:
+          type: string
+    VswitchMembershipRequest:
+      type: object
+      description: The set of server IPs to add to or remove from a vSwitch.
+      properties:
+        server:
+          type: array
+          description: The primary IPs of the servers to add or remove.
+          items:
+            type: string
+      required:
+        - server
+    FirewallEnvelope:
+      type: object
+      description: The Robot Webservice wraps the firewall under a ``firewall`` key.
+      properties:
+        firewall:
+          $ref: "#/components/schemas/FirewallConfig"
+    FirewallConfig:
+      type: object
+      description: A server's packet-filter firewall configuration.
+      properties:
+        status:
+          type: string
+          description: Active status of the firewall (e.g. active, disabled).
+        whitelist_hos:
+          type: boolean
+          description: Whether Hetzner online services are whitelisted.
+        rules:
+          $ref: "#/components/schemas/FirewallRules"
+    FirewallRules:
+      type: object
+      description: The ordered inbound/outbound rule sets.
+      properties:
+        input:
+          type: array
+          items:
+            $ref: "#/components/schemas/FirewallRule"
+        output:
+          type: array
+          items:
+            $ref: "#/components/schemas/FirewallRule"
+    FirewallRule:
+      type: object
+      description: One packet-filter rule.
+      properties:
+        name:
+          type: string
+        src_ip:
+          type: string
+        dst_ip:
+          type: string
+        dst_port:
+          type: string
+        protocol:
+          type: string
+        action:
+          type: string
+    RdnsEnvelope:
+      type: object
+      description: The Robot Webservice wraps each rDNS entry under an ``rdns`` key.
+      properties:
+        rdns:
+          $ref: "#/components/schemas/Rdns"
+    Rdns:
+      type: object
+      description: A reverse-DNS (PTR) entry.
+      properties:
+        ip:
+          type: string
+        ptr:
+          type: string
+    ServerAddonOrderRequest:
+      type: object
+      description: An order for a server addon against a dedicated server.
+      properties:
+        server_number:
+          type: integer
+          description: The server the addon is ordered for.
+        product:
+          type: string
+          description: The addon product id (e.g. an additional-IP product).
+      required:
+        - server_number
+        - product
+    ServerAddonTransactionEnvelope:
+      type: object
+      description: The Robot Webservice wraps the transaction under a ``transaction`` key.
+      properties:
+        transaction:
+          $ref: "#/components/schemas/ServerAddonTransaction"
+    ServerAddonTransaction:
+      type: object
+      description: A server-addon order transaction record.
+      properties:
+        id:
+          type: string
+        status:
+          type: string
+        server_number:
+          type: integer
+        product:
+          type: string

--- a/backend/tests/acceptance/_robot_canary_fixtures.py
+++ b/backend/tests/acceptance/_robot_canary_fixtures.py
@@ -351,8 +351,10 @@ def _param_schema_for(path: str) -> dict[str, object]:
     }
 
 
-async def _robot_credentials_loader(_target: HetznerRobotTargetLike) -> dict[str, str]:
-    """Stub credentials loader — bypasses the not-yet-wired Vault read."""
+async def _robot_credentials_loader(
+    _target: HetznerRobotTargetLike, _operator: Operator
+) -> dict[str, str]:
+    """Stub credentials loader — bypasses the live operator-context Vault read."""
     return {"username": "robot-canary-user", "password": "robot-canary-pw"}
 
 

--- a/backend/tests/test_connectors_hetzner_robot_auth.py
+++ b/backend/tests/test_connectors_hetzner_robot_auth.py
@@ -102,7 +102,7 @@ _TARGET_B = _StubTarget(
 )
 
 
-async def _stub_loader(_target: HetznerRobotTargetLike) -> dict[str, str]:
+async def _stub_loader(_target: HetznerRobotTargetLike, _operator: Operator) -> dict[str, str]:
     return {"username": "webservice-user", "password": "stub-password"}
 
 
@@ -140,16 +140,48 @@ def test_importing_package_registers_against_v2_registry() -> None:
     assert registry[key] is HetznerRobotConnector
 
 
-def test_default_credentials_loader_raises_until_g214_lands() -> None:
-    import asyncio
+@pytest.mark.asyncio
+async def test_default_loader_delegates_to_shared_vault_basic_read() -> None:
+    """The default loader delegates to the shared operator-context Vault read.
 
+    #2079 un-stubbed :func:`load_credentials_from_vault`: it now performs the
+    live operator-context KV-v2 read via the shared
+    :func:`~meho_backplane.connectors._shared.vault_creds.load_basic_credentials`
+    helper — the same read harbor / vmware / sddc use. Patch that helper and
+    assert the loader forwards ``(target, operator)`` to it verbatim and
+    returns its ``{"username", "password"}`` result.
+    """
+    from unittest.mock import AsyncMock, patch
+
+    from meho_backplane.connectors.hetzner_robot import session as robot_session
+
+    operator = _make_operator(raw_jwt="operator-jwt")
+    with patch.object(
+        robot_session,
+        "load_basic_credentials",
+        new=AsyncMock(return_value={"username": "ws-user", "password": "ws-pw"}),
+    ) as shared_read:
+        creds = await robot_session.load_credentials_from_vault(_TARGET_A, operator)
+
+    assert creds == {"username": "ws-user", "password": "ws-pw"}
+    shared_read.assert_awaited_once_with(_TARGET_A, operator)
+
+
+@pytest.mark.asyncio
+async def test_default_loader_fails_closed_for_system_operator() -> None:
+    """A system-initiated read (empty ``raw_jwt``) fails closed, never falls back.
+
+    The shared helper's fail-closed guard rejects an operator-less call before
+    Vault is touched: background/scheduled work carries ``raw_jwt=""`` and
+    cannot perform an operator-context read. The default loader surfaces that
+    as :class:`VaultCredentialsReadError` rather than a silent fallback.
+    """
+    from meho_backplane.connectors._shared.vault_creds import VaultCredentialsReadError
     from meho_backplane.connectors.hetzner_robot.session import load_credentials_from_vault
 
-    async def _check() -> None:
-        with pytest.raises(NotImplementedError, match=r"Goal #214"):
-            await load_credentials_from_vault(_TARGET_A)
-
-    asyncio.run(_check())
+    system_operator = _make_operator(raw_jwt="")
+    with pytest.raises(VaultCredentialsReadError):
+        await load_credentials_from_vault(_TARGET_A, system_operator)
 
 
 # ---------------------------------------------------------------------------
@@ -280,7 +312,9 @@ async def test_auth_headers_reuses_cached_credentials_across_calls() -> None:
     """Second auth_headers call against the same target does NOT re-invoke the loader."""
     call_count = 0
 
-    async def _counting_loader(_target: HetznerRobotTargetLike) -> dict[str, str]:
+    async def _counting_loader(
+        _target: HetznerRobotTargetLike, _operator: Operator
+    ) -> dict[str, str]:
         nonlocal call_count
         call_count += 1
         return {"username": "webservice-user", "password": "stub-password"}
@@ -304,7 +338,9 @@ async def test_per_target_isolation_keeps_credentials_separate() -> None:
     """Two targets get two distinct credential cache entries; no cross-target leakage."""
     call_log: list[str] = []
 
-    async def _tracking_loader(target: HetznerRobotTargetLike) -> dict[str, str]:
+    async def _tracking_loader(
+        target: HetznerRobotTargetLike, _operator: Operator
+    ) -> dict[str, str]:
         call_log.append(target.name)
         return {"username": f"svc-{target.name}", "password": "pass"}
 
@@ -347,7 +383,9 @@ async def test_same_name_targets_in_different_tenants_get_distinct_credentials()
     )
     call_log: list[str] = []
 
-    async def _tracking_loader(target: HetznerRobotTargetLike) -> dict[str, str]:
+    async def _tracking_loader(
+        target: HetznerRobotTargetLike, _operator: Operator
+    ) -> dict[str, str]:
         call_log.append(str(target.tenant_id))
         return {"username": f"svc-{target.tenant_id}", "password": "pass"}
 
@@ -379,8 +417,8 @@ async def test_same_name_targets_in_different_tenants_get_distinct_credentials()
 
 @pytest.mark.asyncio
 async def test_loader_missing_password_key_raises_runtime_error_naming_target() -> None:
-    async def _bad_loader(_target: HetznerRobotTargetLike) -> dict[str, str]:
-        return {"username": "webservice-user"}  # type: ignore[return-value]
+    async def _bad_loader(_target: HetznerRobotTargetLike, _operator: Operator) -> dict[str, str]:
+        return {"username": "webservice-user"}
 
     connector = HetznerRobotConnector(credentials_loader=_bad_loader)
     with pytest.raises(RuntimeError, match=r"password") as exc_info:
@@ -392,8 +430,8 @@ async def test_loader_missing_password_key_raises_runtime_error_naming_target() 
 
 @pytest.mark.asyncio
 async def test_loader_missing_username_key_raises_runtime_error_naming_target() -> None:
-    async def _bad_loader(_target: HetznerRobotTargetLike) -> dict[str, str]:
-        return {"password": "stub-password"}  # type: ignore[return-value]
+    async def _bad_loader(_target: HetznerRobotTargetLike, _operator: Operator) -> dict[str, str]:
+        return {"password": "stub-password"}
 
     connector = HetznerRobotConnector(credentials_loader=_bad_loader)
     with pytest.raises(RuntimeError, match=r"username") as exc_info:

--- a/backend/tests/test_connectors_hetzner_robot_ingest.py
+++ b/backend/tests/test_connectors_hetzner_robot_ingest.py
@@ -1,0 +1,431 @@
+# SPDX-License-Identifier: Apache-2.0
+# Copyright (c) 2026 evoila Group
+
+"""Ingest → resolve → dispatch tests for the hetzner-rest connector (#2079).
+
+The ``hetzner-rest-2026.04`` connector shell registers empty
+(``operation_count=0``); #2079 ships a MEHO-authored minimal OpenAPI spec
+(``operations/ingest/specs/hetzner_robot_minimal.yaml``) so ingesting it
+yields dispatchable operations that resolve to the hand-rolled
+:class:`~meho_backplane.connectors.hetzner_robot.HetznerRobotConnector`.
+
+The module proves the four ingest-side acceptance criteria of #2079:
+
+* the shipped spec dry-run-parses with the same ``parse_openapi`` the live
+  ingest uses (boot-safety net; malformed spec fails CI, not the first
+  ``--spec`` ingest);
+* ingesting the spec against ``product=hetzner version=2026.04
+  impl=hetzner-rest`` yields ``operation_count > 0`` and reuses the
+  hand-coded connector class (no GenericRestConnector shim shadows it);
+* the ingested ops resolve to :class:`HetznerRobotConnector` through
+  :func:`~meho_backplane.connectors.resolver.resolve_connector` rather than
+  501-ing with ``no_connector``;
+* an enabled read op returns non-empty mocked data end-to-end via
+  :func:`~meho_backplane.operations.meta_tools.call_operation` (a respx test
+  proving a successful, non-empty response — not ``connector_unsupported``).
+
+The Vault-backed target + auth wiring is covered in
+``tests/test_connectors_hetzner_robot_auth.py``; the curated read-only
+dispatch smoke over the hand-seeded canary lives in
+``tests/acceptance/test_g37_robot_dispatch_smoke.py``. This module closes
+the gap between them: it drives the *spec-ingest* path end to end.
+"""
+
+from __future__ import annotations
+
+from collections.abc import Iterator
+from importlib.resources import files
+from unittest.mock import AsyncMock
+from uuid import UUID
+
+import pytest
+import respx
+from sqlalchemy import select, update
+
+from meho_backplane.auth.operator import Operator, TenantRole
+from meho_backplane.connectors.hetzner_robot import (
+    ROBOT_CONNECTOR_ID,
+    ROBOT_IMPL_ID,
+    ROBOT_PRODUCT,
+    ROBOT_VERSION,
+    HetznerRobotConnector,
+    HetznerRobotTargetLike,
+)
+from meho_backplane.connectors.registry import (
+    all_connectors_v2,
+    clear_registry,
+    register_connector_v2,
+)
+from meho_backplane.connectors.resolver import resolve_connector
+from meho_backplane.db.engine import get_sessionmaker
+from meho_backplane.db.models import EndpointDescriptor, Target
+from meho_backplane.operations import reset_dispatcher_caches
+from meho_backplane.operations.ingest import (
+    EndpointDescriptorProto,
+    parse_openapi,
+    register_ingested_operations,
+)
+from meho_backplane.operations.meta_tools import call_operation
+from meho_backplane.settings import get_settings
+
+#: The shipped minimal spec, loaded as package data (survives into the wheel).
+_SPEC_RESOURCE = "hetzner_robot_minimal.yaml"
+
+#: Tenant the ingest/dispatch tests act under.
+_TENANT = UUID("00000000-0000-0000-0000-0000000000a9")
+
+#: RFC 6761 ``.test.invalid`` host so no real network egress fires.
+_ROBOT_HOST = "robot-ws.test.invalid"
+
+#: op_ids the spec must yield — cross-checked against ROBOT_CORE_OPS so the
+#: ingested rows and the curated read core agree on the same strings.
+_EXPECTED_READ_OP_IDS = frozenset(
+    {
+        "GET:/server",
+        "GET:/server/{server-ip}",
+        "GET:/vswitch",
+        "GET:/vswitch/{id}",
+        "GET:/firewall/{server-ip}",
+        "GET:/rdns",
+    }
+)
+
+#: The write/admin ops the spec covers for the full wrapper surface.
+_EXPECTED_WRITE_OP_IDS = frozenset(
+    {
+        "POST:/vswitch/{id}",
+        "DELETE:/vswitch/{id}",
+        "POST:/firewall/{server-ip}",
+        "POST:/order/server_addon/transaction",
+    }
+)
+
+
+def _read_shipped_spec() -> str:
+    """Return the shipped minimal spec text from package data."""
+    resource = files("meho_backplane.operations.ingest.specs").joinpath(_SPEC_RESOURCE)
+    return resource.read_text(encoding="utf-8")
+
+
+def _parse_shipped_spec() -> list[EndpointDescriptorProto]:
+    """Parse the shipped spec via the same ``parse_openapi`` the live ingest uses."""
+    operations: list[EndpointDescriptorProto] = parse_openapi(
+        f"https://specs.example.test/{_SPEC_RESOURCE}",
+        spec_source=f"spec:{_SPEC_RESOURCE}",
+        content=_read_shipped_spec(),
+    )
+    return operations
+
+
+def _make_operator() -> Operator:
+    """Return an operator with a non-empty raw_jwt (a real, non-system caller)."""
+    return Operator(
+        sub="hetzner-ingest-test",
+        name="Hetzner Ingest Test",
+        email=None,
+        raw_jwt="<hetzner-ingest-raw-jwt>",
+        tenant_id=_TENANT,
+        tenant_role=TenantRole.TENANT_ADMIN,
+    )
+
+
+@pytest.fixture(autouse=True)
+def _required_settings_env(monkeypatch: pytest.MonkeyPatch) -> Iterator[None]:
+    """Pin every env var :class:`Settings` requires for this module.
+
+    Mirrors ``test_operations_register_ingested.py``'s autouse fixture so the
+    ingest path can open the DB engine (``get_settings`` reads these).
+    """
+    monkeypatch.setenv("KEYCLOAK_ISSUER_URL", "https://keycloak.test/realms/meho")
+    monkeypatch.setenv("KEYCLOAK_AUDIENCE", "meho-backplane")
+    monkeypatch.setenv("VAULT_ADDR", "https://vault.test")
+    get_settings.cache_clear()
+    yield
+    get_settings.cache_clear()
+
+
+@pytest.fixture
+def stub_embedding_service() -> AsyncMock:
+    """An :class:`AsyncMock` standing in for the embedding service."""
+    service = AsyncMock()
+    service.encode_one.return_value = [0.25] * 384
+    service.encode.return_value = [[0.25] * 384]
+    service.dimension = 384
+    return service
+
+
+@pytest.fixture(autouse=True)
+def _clean_registry() -> Iterator[None]:
+    """Re-register HetznerRobotConnector around each test.
+
+    Sibling modules (``test_connectors_registry_v2.py``) install an autouse
+    fixture that clears the registry between tests; re-register the hetzner
+    class (versioned + wildcard, mirroring the package's own registration)
+    before each test so the ingest guard finds the hand-coded class and the
+    resolver can bind it.
+    """
+    clear_registry()
+    register_connector_v2(
+        product=HetznerRobotConnector.product,
+        version=HetznerRobotConnector.version,
+        impl_id=HetznerRobotConnector.impl_id,
+        cls=HetznerRobotConnector,
+    )
+    register_connector_v2(product="hetzner", version="", impl_id="", cls=HetznerRobotConnector)
+    yield
+    clear_registry()
+
+
+# ---------------------------------------------------------------------------
+# AC: the shipped spec parses (boot-safety net).
+# ---------------------------------------------------------------------------
+
+
+def test_shipped_spec_parses_and_covers_the_wrapper_surface() -> None:
+    """The shipped minimal spec dry-run-parses and yields the expected ops.
+
+    Exercises the same ``parse_openapi`` the live ingest and the boot-time
+    shipped-artifact validator use, so a malformed spec fails this test
+    rather than 500-ing the first ``--spec`` ingest. Asserts the read op_ids
+    match the curated ROBOT_CORE_OPS strings and every AC-required surface
+    (servers, vSwitch get + membership, firewall get/set, rDNS, server_addon
+    order) is present.
+    """
+    rows = _parse_shipped_spec()
+    op_ids = {r.op_id for r in rows}
+
+    assert len(rows) > 0
+    assert op_ids >= _EXPECTED_READ_OP_IDS, (
+        f"missing read op_ids: {sorted(_EXPECTED_READ_OP_IDS - op_ids)}"
+    )
+    assert op_ids >= _EXPECTED_WRITE_OP_IDS, (
+        f"missing write op_ids: {sorted(_EXPECTED_WRITE_OP_IDS - op_ids)}"
+    )
+    # Every op declares an operationId → a stable, non-empty op_id.
+    for row in rows:
+        method, _, path = row.op_id.partition(":")
+        assert method and path.startswith("/"), f"malformed op_id {row.op_id!r}"
+
+
+# ---------------------------------------------------------------------------
+# AC: ingesting the spec yields operation_count > 0 (and reuses the class).
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.asyncio
+async def test_ingest_shipped_spec_yields_operations(
+    stub_embedding_service: AsyncMock,
+) -> None:
+    """Ingesting the spec against the hetzner triple yields operation_count > 0.
+
+    Drives the programmatic ingest entry point
+    (:func:`register_ingested_operations`) the CLI's ``--spec`` path also
+    calls, then asserts the endpoint_descriptor rows land under
+    ``product=hetzner version=2026.04 impl_id=hetzner-rest`` — the connector
+    shell is no longer at ``operation_count=0``.
+
+    ``connector_registered`` MUST be ``False``: the ingest guard defers to
+    the hand-coded :class:`HetznerRobotConnector` already registered for the
+    triple rather than scaffolding a shadowing GenericRestConnector shim
+    (the product-identity footgun #1798 guards against).
+    """
+    operations = _parse_shipped_spec()
+
+    result = await register_ingested_operations(
+        product=ROBOT_PRODUCT,
+        version=ROBOT_VERSION,
+        impl_id=ROBOT_IMPL_ID,
+        spec_source=_SPEC_RESOURCE,
+        operations=operations,
+        embedding_service=stub_embedding_service,
+    )
+
+    assert result.inserted_count == len(operations) > 0
+    assert result.connector_registered is False, (
+        "ingest must reuse the hand-coded HetznerRobotConnector, not register a "
+        "GenericRestConnector shim that shadows it"
+    )
+
+    sessionmaker = get_sessionmaker()
+    async with sessionmaker() as session:
+        rows = (
+            (
+                await session.execute(
+                    select(EndpointDescriptor).where(
+                        EndpointDescriptor.product == ROBOT_PRODUCT,
+                        EndpointDescriptor.version == ROBOT_VERSION,
+                        EndpointDescriptor.impl_id == ROBOT_IMPL_ID,
+                    )
+                )
+            )
+            .scalars()
+            .all()
+        )
+
+    # operation_count > 0 for hetzner-rest-2026.04.
+    assert len(rows) == len(operations) > 0
+    op_ids = {row.op_id for row in rows}
+    assert op_ids >= _EXPECTED_READ_OP_IDS
+    for row in rows:
+        assert row.source_kind == "ingested"
+        assert f"spec:{_SPEC_RESOURCE}" in row.tags
+
+
+# ---------------------------------------------------------------------------
+# AC: the ingested ops resolve to HetznerRobotConnector (not no_connector).
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.asyncio
+async def test_ingested_ops_resolve_to_hetzner_connector(
+    stub_embedding_service: AsyncMock,
+) -> None:
+    """A hetzner target resolves the ingested ops to the hand-coded connector.
+
+    After ingesting the spec, a :class:`Target` with ``product="hetzner"``
+    resolves to :class:`HetznerRobotConnector` (registered under
+    ``product="hetzner"``) — the ingested descriptors reach a dispatchable
+    connector rather than 501-ing with ``no_connector``. Guards the
+    string-derived-product-identity footgun: the resolver binds the real
+    connector, not a divergent-product shim.
+    """
+    await register_ingested_operations(
+        product=ROBOT_PRODUCT,
+        version=ROBOT_VERSION,
+        impl_id=ROBOT_IMPL_ID,
+        spec_source=_SPEC_RESOURCE,
+        operations=_parse_shipped_spec(),
+        embedding_service=stub_embedding_service,
+    )
+
+    class _FakeFingerprint:
+        version = ROBOT_VERSION
+
+    class _FakeTarget:
+        product = "hetzner"
+        fingerprint = _FakeFingerprint()
+        preferred_impl_id = None
+        version = ROBOT_VERSION
+
+    resolved = resolve_connector(_FakeTarget())
+    assert resolved is HetznerRobotConnector
+
+    # The triple is dispatchable: the ingested rows key on the same triple
+    # the registered class advertises.
+    assert (ROBOT_PRODUCT, ROBOT_VERSION, ROBOT_IMPL_ID) in all_connectors_v2()
+    assert all_connectors_v2()[(ROBOT_PRODUCT, ROBOT_VERSION, ROBOT_IMPL_ID)] is (
+        HetznerRobotConnector
+    )
+
+
+# ---------------------------------------------------------------------------
+# AC: an ingested read op returns non-empty data end-to-end via call_operation.
+# ---------------------------------------------------------------------------
+
+
+async def _stub_loader(_target: HetznerRobotTargetLike, _operator: Operator) -> dict[str, str]:
+    """Injected loader — bypasses the live operator-context Vault read in test."""
+    return {"username": "webservice-user", "password": "stub-password"}
+
+
+@pytest.mark.asyncio
+async def test_ingested_read_op_returns_non_empty_via_call_operation(
+    stub_embedding_service: AsyncMock,
+) -> None:
+    """An ingested read op returns non-empty mocked data through ``call_operation``.
+
+    Ingests the spec, enables the ``GET:/server`` descriptor, seeds a
+    hetzner :class:`Target`, then dispatches the op via the agent-facing
+    :func:`call_operation` meta-tool against a respx-mocked Robot
+    Webservice. Asserts ``status='ok'`` with a non-empty result — proving
+    the ingested op reaches :class:`HetznerRobotConnector`'s HTTP transport
+    and executes, not ``connector_unsupported`` / ``no_connector``.
+
+    Runs against the autouse-migrated SQLite engine (same as the argocd /
+    nsx / keycloak E2E dispatch tests); the connector's httpx client is
+    routed to a respx-mocked Webservice, so no real network egress fires.
+    """
+    operator = _make_operator()
+    reset_dispatcher_caches()
+
+    await register_ingested_operations(
+        product=ROBOT_PRODUCT,
+        version=ROBOT_VERSION,
+        impl_id=ROBOT_IMPL_ID,
+        spec_source=_SPEC_RESOURCE,
+        operations=_parse_shipped_spec(),
+        embedding_service=stub_embedding_service,
+    )
+
+    sessionmaker = get_sessionmaker()
+    async with sessionmaker() as session:
+        # The ingest default is is_enabled=False; enable the read op so
+        # lookup_descriptor (is_enabled-filtered) finds it for dispatch.
+        await session.execute(
+            update(EndpointDescriptor)
+            .where(
+                EndpointDescriptor.product == ROBOT_PRODUCT,
+                EndpointDescriptor.version == ROBOT_VERSION,
+                EndpointDescriptor.impl_id == ROBOT_IMPL_ID,
+                EndpointDescriptor.op_id == "GET:/server",
+            )
+            .values(is_enabled=True)
+        )
+        target = Target(
+            tenant_id=_TENANT,
+            name="robot-ingest",
+            aliases=[],
+            product="hetzner",
+            host=_ROBOT_HOST,
+            port=443,
+            fqdn=None,
+            secret_ref="hetzner/robot-ingest",
+            auth_model="shared_service_account",
+            vpn_required=False,
+            extras={},
+            fingerprint={"vendor": "hetzner", "product": "robot-webservice", "reachable": True},
+            notes="seeded by test_connectors_hetzner_robot_ingest",
+        )
+        session.add(target)
+        await session.commit()
+
+    # Preseed the dispatcher's connector-instance cache with a stub-loader
+    # instance so no live Vault read fires (mirrors the argocd/nsx E2E tests).
+    from meho_backplane.operations._handler_resolve import _CONNECTOR_INSTANCE_CACHE
+
+    instance = HetznerRobotConnector(credentials_loader=_stub_loader)
+    _CONNECTOR_INSTANCE_CACHE[HetznerRobotConnector] = instance
+
+    servers = [
+        {"server": {"server_ip": "1.2.3.1", "server_number": 100001, "dc": "FSN1-DC14"}},
+        {"server": {"server_ip": "1.2.3.2", "server_number": 100002, "dc": "FSN1-DC15"}},
+    ]
+
+    try:
+        async with respx.mock(
+            base_url=f"https://{_ROBOT_HOST}",
+            assert_all_called=False,
+            assert_all_mocked=False,
+        ) as mock:
+            mock.get("/server").respond(200, json=servers)
+            result = await call_operation(
+                operator,
+                {
+                    "connector_id": ROBOT_CONNECTOR_ID,
+                    "op_id": "GET:/server",
+                    "target": {"name": "robot-ingest"},
+                    "params": {},
+                },
+            )
+    finally:
+        await instance.aclose()
+        reset_dispatcher_caches()
+
+    assert result["status"] == "ok", (
+        f"ingested GET:/server did not dispatch cleanly: "
+        f"{result.get('error')!r}; full result={result!r}"
+    )
+    # Non-empty successful response — not connector_unsupported / no_connector.
+    payload = result.get("result")
+    assert payload, f"expected a non-empty server list; got result={payload!r}"
+    assert len(payload) == len(servers)

--- a/docs/codebase/connectors-hetzner-robot.md
+++ b/docs/codebase/connectors-hetzner-robot.md
@@ -29,11 +29,15 @@ Source: `backend/src/meho_backplane/connectors/hetzner_robot/`.
   `auth_model`. No `sso_realm` field — Hetzner Robot Basic auth sends
   `username:password` directly with no realm suffix.
 - **`HetznerRobotCredentialsLoader`** (`session.py`) — async callable type
-  resolving a target to `{"username": ..., "password": ...}`. Injectable on
-  connector construction for tests and pre-G0.3 production deploys.
-- **`load_credentials_from_vault`** (`session.py`) — default loader, stubbed
-  `NotImplementedError` until Goal #214 lands the operator-context Vault
-  read path.
+  resolving a `(target, operator)` pair to `{"username": ..., "password": ...}`.
+  Injectable on connector construction for tests and integration deploys.
+- **`load_credentials_from_vault`** (`session.py`) — default loader.
+  Performs the **live** operator-context KV-v2 read by delegating to the
+  shared `_shared/vault_creds.load_basic_credentials` helper (#2079) — the
+  same read harbor / vmware / sddc use. The Webservice-user credential is
+  read under the operator's Vault identity; a system-initiated call
+  (`raw_jwt=""`) fails closed with `VaultCredentialsReadError` rather than
+  falling back.
 - **`ROBOT_CORE_GROUPS`** (`core_ops.py`) — 4 curated `RobotCoreGroup`
   entries with operator-reviewed `when_to_use` hints spanning the read-only
   core: `robot-about`, `robot-servers`, `robot-networking`, `robot-ssh-keys`.
@@ -125,16 +129,36 @@ Vault path as `{"username": ..., "password": ...}`.
 - `tenacity>=9.0` — base class retry logic (401 excluded from retry predicate)
 - `structlog` — structured logging
 
+## Spec ingest (#2079)
+
+The connector shell registers empty (`operation_count=0`); ingesting a spec
+fills the `endpoint_descriptor` table. Because the Robot Webservice publishes
+no OpenAPI document, MEHO ships a hand-authored minimal spec as package data:
+
+- **`operations/ingest/specs/hetzner_robot_minimal.yaml`** — OpenAPI 3.0
+  covering list/get servers, vSwitch get + membership, per-server firewall
+  get/set, reverse DNS, and the `server_addon` order. The GET op_ids
+  (`GET:/server`, `GET:/server/{server-ip}`, `GET:/vswitch`,
+  `GET:/vswitch/{id}`, `GET:/firewall/{server-ip}`, `GET:/rdns`) match the
+  `ROBOT_CORE_OPS` strings so the ingested rows and the curated read core
+  agree.
+- Ingest via `meho connector ingest --product hetzner --version 2026.04
+  --impl hetzner-rest --spec <this-file>`. The ingest guard defers to the
+  registered `HetznerRobotConnector` for the triple rather than scaffolding a
+  `GenericRestConnector` shim, so the ingested ops resolve to the hand-coded
+  connector (not `no_connector`). Coverage:
+  `tests/test_connectors_hetzner_robot_ingest.py`.
+
 ## Known issues / out of scope
 
-- Vault credential read stub: `load_credentials_from_vault` raises
-  `NotImplementedError` until Goal #214 lands. Inject a loader at
-  construction time for production deploys until then.
 - Env-gated automated canary: the full spec ingest against
   `IngestionPipelineService` with a real LLM stub is a follow-up to T8
   requiring the Robot spec reachable from CI.
 - Writes: server reset, vSwitch mutation, cancellation, rDNS edits are out of
-  scope for G3.7 v0.2. The `_post_form` helper is the write-path foundation.
+  scope for the read-only core. The write ops are declared in the shipped
+  minimal spec so the ingested corpus covers the full wrapper surface, but
+  only the curated read ops are enabled; the `_post_form` helper is the
+  write-path foundation for the G3.x write-surface curation.
 - Hetzner Cloud (the second Hetzner product): out of scope.
 
 ## References
@@ -142,6 +166,7 @@ Vault path as `{"username": ..., "password": ...}`.
 - Hetzner Robot Webservice docs: https://robot.hetzner.com/doc/webservice/en.html
 - G3.7-T7 skeleton issue: https://github.com/evoila/meho/issues/846
 - G3.7-T8 core-ops issue: https://github.com/evoila/meho/issues/849
+- Spec-ingest + Vault-auth wiring: https://github.com/evoila/meho/issues/2079
 - Canary runbook: [`docs/cross-repo/g37-hetzner-canary.md`](../cross-repo/g37-hetzner-canary.md)
 - Precedent: `connectors/harbor/core_ops.py` (apply_harbor_core_curation pattern)
 - Precedent: `connectors/harbor/connector.py` (HTTP Basic + loader + fingerprint/probe)


### PR DESCRIPTION
## Summary
- The `hetzner-rest-2026.04` connector shell registered empty (`operation_count=0`), leaving the physical-layer Hetzner infra leg with no meho path. The Robot Webservice publishes no OpenAPI document, so this ships a hand-authored minimal OpenAPI 3.0 spec as package data and un-stubs the Vault credential read.
- Adds `operations/ingest/specs/hetzner_robot_minimal.yaml` covering list/get servers, vSwitch get + membership, per-server firewall get/set, rDNS, and the `server_addon` order. GET op_ids match `ROBOT_CORE_OPS` so ingested rows and the curated read core agree.
- Un-stubs `load_credentials_from_vault` → live operator-context KV-v2 read via the shared `_shared/vault_creds.load_basic_credentials` helper (same read harbor/vmware/sddc use). Loader signature widens to `(target, operator)`; `auth_headers` threads the operator through with the system-operator cache carve-out, mirroring harbor. System-initiated calls (`raw_jwt=""`) fail closed.
- Ingesting the spec reuses the hand-coded `HetznerRobotConnector` (the ingest guard defers to the registered class, no `GenericRestConnector` shim), so ingested ops resolve via `resolve_connector` (not `no_connector`).

## Test plan
- [x] `ruff check` / `ruff format --check` — clean
- [x] `mypy` (hetzner dir + new test) — clean (one pre-existing `unused-ignore` on an untouched line left as adjacent finding)
- [x] `pytest tests/test_connectors_hetzner_robot_ingest.py` — 4 passed (spec parses; ingest yields operation_count>0; ingested ops resolve to HetznerRobotConnector; read op returns non-empty via `call_operation`)
- [x] `pytest tests/test_connectors_hetzner_robot_auth.py` — 29 passed (loader now `(target, operator)`; default-loader delegates to shared Vault read; system-operator fails closed)
- [x] register-ingested + resolver + resolver-shadowing + catalog + core-ops suites — 212 passed
- [x] acceptance dispatch-smoke collects + runs (pg-gated tests skip in sandbox; the 2 constant tests pass)
- [x] `code-quality.py --diff` — 0 blockers (2 pre-existing size warnings on `connector.py`)

**AC mapping**
1. Minimal spec under `specs/` covering the required surface → `test_shipped_spec_parses_and_covers_the_wrapper_surface`
2. Ingest yields `operation_count > 0` → `test_ingest_shipped_spec_yields_operations`
3. Ingested ops resolve to `HetznerRobotConnector` (not 501 `no_connector`) → `test_ingested_ops_resolve_to_hetzner_connector`
4. Vault-backed Webservice-user creds load via `load_credentials_from_vault` → `test_default_loader_delegates_to_shared_vault_basic_read` + `test_default_loader_fails_closed_for_system_operator`
5. Read op returns non-empty end-to-end via `call_operation` → `test_ingested_read_op_returns_non_empty_via_call_operation`

## Out of scope
- No catalog row / `spec_resource` entry: the AC targets the explicit `--spec` ingest path, not `--catalog` (which would drag in an ExecutionProfile + catalog registry-coverage). The spec is dry-run-parse-validated in the ingest test instead.
- Write ops (vSwitch mutation, firewall set, `server_addon` order) are declared in the spec so the ingested corpus covers the full wrapper surface, but only the curated read ops are enabled; wire-format-faithful write dispatch stays the G3.x write-surface curation's job.
- Adjacent finding: `connector.py` is 438 lines / `fingerprint` is 69 lines (pre-existing, untouched); one pre-existing `unused-ignore` at `test_connectors_hetzner_robot_auth.py:498`.

<!-- auto-implement-issue: fresh, iteration 1 -->

Closes #2079
