### PR TITLE
feat(cli): add `meho login --resolve host:port:ip` split-DNS fallback (#2107)

### DIFF
--- a/cli/internal/auth/resolver.go
+++ b/cli/internal/auth/resolver.go
@@ -1,0 +1,146 @@
+// SPDX-License-Identifier: Apache-2.0
+// Copyright (c) 2026 evoila Group
+
+package auth
+
+import (
+	"context"
+	"errors"
+	"fmt"
+	"net"
+	"net/http"
+	"strings"
+)
+
+// HostOverrides maps a "host:port" key to a literal IP address, mirroring
+// the semantics of `curl --resolve <host>:<port>:<ip>`. It is the escape
+// hatch for split-DNS operator workstations where the system resolver
+// returns NXDOMAIN for the Keycloak host even though that host is
+// reachable at a known IP (VPN-pushed DNS forwarder configured for the
+// backplane name but not the Keycloak name).
+//
+// The map is keyed by the exact "host:port" pair rather than by host
+// alone so an operator can pin a single endpoint (443) without
+// accidentally short-circuiting resolution for a different port on the
+// same host. This matches curl's per-port override model.
+type HostOverrides map[string]string
+
+// ParseResolveEntries parses zero or more `host:port:ip` strings into a
+// HostOverrides map. The format is identical to `curl --resolve`:
+//
+//	kc.example.com:443:10.0.0.5
+//
+// The port is required (and must be numeric) so the override targets a
+// specific endpoint; the IP is validated as a literal IPv4 or IPv6
+// address. IPv6 addresses are accepted in either bare or bracketed form
+// on the IP side (`kc:443:[::1]` and `kc:443:::1` both resolve to `::1`),
+// with the host taken as everything before the last two colon-separated
+// fields so IPv6 literals used as the *host* are not silently mangled.
+//
+// A malformed entry is a hard error rather than a silent skip: an
+// operator who mistypes their override should learn immediately, not
+// discover at connect time that the CLI ignored the flag and fell back
+// to the broken system resolver.
+func ParseResolveEntries(entries []string) (HostOverrides, error) {
+	if len(entries) == 0 {
+		return nil, nil
+	}
+	overrides := make(HostOverrides, len(entries))
+	for _, raw := range entries {
+		host, port, ip, err := splitResolveEntry(raw)
+		if err != nil {
+			return nil, fmt.Errorf("--resolve %q: %w", raw, err)
+		}
+		overrides[net.JoinHostPort(host, port)] = ip
+	}
+	return overrides, nil
+}
+
+// splitResolveEntry parses one `host:port:ip` string. The IP field may
+// itself contain colons (IPv6), so we split off the IP as everything
+// after the last two structural colons: the trailing field is the IP and
+// the field before it is the port. Whatever remains is the host.
+func splitResolveEntry(raw string) (host, port, ip string, err error) {
+	// Find the port:ip boundary by walking from the front: host and port
+	// are the first two colon-delimited fields; the rest is the IP.
+	first := strings.IndexByte(raw, ':')
+	if first < 0 {
+		return "", "", "", errors.New("expected host:port:ip")
+	}
+	rest := raw[first+1:]
+	second := strings.IndexByte(rest, ':')
+	if second < 0 {
+		return "", "", "", errors.New("expected host:port:ip")
+	}
+	host = raw[:first]
+	port = rest[:second]
+	ip = rest[second+1:]
+
+	if host == "" {
+		return "", "", "", errors.New("host is empty")
+	}
+	if _, portErr := net.LookupPort("tcp", port); portErr != nil {
+		return "", "", "", fmt.Errorf("port %q is not a valid TCP port", port)
+	}
+	// Accept a bracketed IPv6 literal on the IP side for symmetry with
+	// how hosts are written elsewhere; strip the brackets before parsing.
+	ip = strings.TrimPrefix(strings.TrimSuffix(ip, "]"), "[")
+	if ip == "" {
+		return "", "", "", errors.New("ip is empty")
+	}
+	if net.ParseIP(ip) == nil {
+		return "", "", "", fmt.Errorf("ip %q is not a valid IP address", ip)
+	}
+	return host, port, ip, nil
+}
+
+// HTTPClientWithOverrides returns an *http.Client whose transport pins
+// the dialled address for any host:port present in overrides, leaving
+// every other connection to the system resolver. Pass a nil/empty map to
+// get http.DefaultClient unchanged — callers can therefore build the
+// client unconditionally and only pay for a custom transport when the
+// operator actually supplied a --resolve entry.
+//
+// The pin lives in Transport.DialContext, which runs *after* the URL has
+// been split into host:port but *before* name resolution. When the
+// dialled "host:port" matches an override we substitute the operator's
+// IP; the connection still carries the original Host header and SNI
+// (net/http builds those from the request URL, not from the dial
+// address), so TLS certificate validation continues to check the real
+// hostname. This is exactly `curl --resolve`'s behaviour and, crucially,
+// does NOT weaken TLS trust the way a resolver rewrite that also changed
+// SNI would.
+func HTTPClientWithOverrides(overrides HostOverrides) *http.Client {
+	if len(overrides) == 0 {
+		return http.DefaultClient
+	}
+	base, ok := http.DefaultTransport.(*http.Transport)
+	if !ok {
+		// http.DefaultTransport is always an *http.Transport in the
+		// standard library; the type assertion is defensive. If it ever
+		// isn't, fall back to the default client so login still works
+		// (minus the override) rather than panicking.
+		return http.DefaultClient
+	}
+	transport := base.Clone()
+	dialer := &net.Dialer{}
+	transport.DialContext = func(ctx context.Context, network, addr string) (net.Conn, error) {
+		if pinned, ok := overrides[addr]; ok {
+			_, port, err := net.SplitHostPort(addr)
+			if err == nil {
+				addr = net.JoinHostPort(pinned, port)
+			}
+		}
+		return dialer.DialContext(ctx, network, addr)
+	}
+	return &http.Client{Transport: transport}
+}
+
+// IsHostResolutionError reports whether err was caused by DNS name
+// resolution failing (NXDOMAIN / "no such host"). It is used to turn the
+// opaque transport error into an actionable, host-named hint that points
+// the operator at the --resolve escape hatch.
+func IsHostResolutionError(err error) bool {
+	var dnsErr *net.DNSError
+	return errors.As(err, &dnsErr)
+}

--- a/cli/internal/auth/resolver_test.go
+++ b/cli/internal/auth/resolver_test.go
@@ -1,0 +1,260 @@
+// SPDX-License-Identifier: Apache-2.0
+// Copyright (c) 2026 evoila Group
+
+package auth
+
+import (
+	"context"
+	"encoding/json"
+	"errors"
+	"net"
+	"net/http"
+	"net/http/httptest"
+	"strings"
+	"testing"
+	"time"
+
+	"golang.org/x/oauth2"
+)
+
+// TestParseResolveEntries covers the happy path plus the IPv6 and
+// bracketed-IPv6 acceptance the format promises.
+func TestParseResolveEntries(t *testing.T) {
+	cases := []struct {
+		name    string
+		in      []string
+		wantKey string
+		wantIP  string
+	}{
+		{"ipv4", []string{"kc.example.com:443:10.0.0.5"}, "kc.example.com:443", "10.0.0.5"},
+		{"ipv6-bare", []string{"kc.example.com:443:::1"}, "kc.example.com:443", "::1"},
+		{"ipv6-bracketed", []string{"kc.example.com:443:[2001:db8::1]"}, "kc.example.com:443", "2001:db8::1"},
+	}
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			got, err := ParseResolveEntries(tc.in)
+			if err != nil {
+				t.Fatalf("ParseResolveEntries(%q): %v", tc.in, err)
+			}
+			ip, ok := got[tc.wantKey]
+			if !ok {
+				t.Fatalf("no override for %q; got map %v", tc.wantKey, got)
+			}
+			if ip != tc.wantIP {
+				t.Errorf("ip = %q, want %q", ip, tc.wantIP)
+			}
+		})
+	}
+}
+
+// TestParseResolveEntriesEmpty returns a nil map (not an error) so the
+// no-flag path costs nothing.
+func TestParseResolveEntriesEmpty(t *testing.T) {
+	got, err := ParseResolveEntries(nil)
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if got != nil {
+		t.Errorf("expected nil map for empty input, got %v", got)
+	}
+}
+
+// TestParseResolveEntriesRejectsMalformed pins the fail-loud contract: a
+// mistyped override must error, not silently fall back to the broken
+// system resolver.
+func TestParseResolveEntriesRejectsMalformed(t *testing.T) {
+	cases := []struct {
+		name string
+		in   string
+		want string
+	}{
+		{"no-colons", "kc.example.com", "host:port:ip"},
+		{"only-one-colon", "kc.example.com:443", "host:port:ip"},
+		{"bad-port", "kc.example.com:notaport:10.0.0.5", "valid TCP port"},
+		{"bad-ip", "kc.example.com:443:not-an-ip", "valid IP"},
+		{"empty-host", ":443:10.0.0.5", "host is empty"},
+		{"empty-ip", "kc.example.com:443:", "ip is empty"},
+	}
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			_, err := ParseResolveEntries([]string{tc.in})
+			if err == nil {
+				t.Fatalf("expected error for %q", tc.in)
+			}
+			if !strings.Contains(err.Error(), tc.want) {
+				t.Errorf("error %q should mention %q", err, tc.want)
+			}
+			// The offending entry must be echoed so the operator knows
+			// which --resolve value to fix.
+			if !strings.Contains(err.Error(), tc.in) {
+				t.Errorf("error %q should echo the bad entry %q", err, tc.in)
+			}
+		})
+	}
+}
+
+// TestHTTPClientWithOverridesEmpty returns the default client untouched
+// when no override is supplied.
+func TestHTTPClientWithOverridesEmpty(t *testing.T) {
+	if got := HTTPClientWithOverrides(nil); got != http.DefaultClient {
+		t.Errorf("expected http.DefaultClient for nil overrides, got %p", got)
+	}
+	if got := HTTPClientWithOverrides(HostOverrides{}); got != http.DefaultClient {
+		t.Errorf("expected http.DefaultClient for empty overrides, got %p", got)
+	}
+}
+
+// TestHTTPClientWithOverridesPinsDial proves the pin actually rewrites
+// the dialled address: a request to an unresolvable phantom host with a
+// --resolve override pointing at a live httptest server must reach that
+// server. Without the pin, the phantom host would fail DNS resolution.
+func TestHTTPClientWithOverridesPinsDial(t *testing.T) {
+	var hits int
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
+		hits++
+		w.WriteHeader(http.StatusNoContent)
+	}))
+	defer srv.Close()
+
+	host, port, err := net.SplitHostPort(srv.Listener.Addr().String())
+	if err != nil {
+		t.Fatalf("split server addr: %v", err)
+	}
+
+	// A hostname that will never resolve via the system resolver.
+	const phantom = "keycloak.invalid.split-dns.test"
+	overrides, err := ParseResolveEntries([]string{
+		net.JoinHostPort(phantom, port) + ":" + host,
+	})
+	if err != nil {
+		t.Fatalf("ParseResolveEntries: %v", err)
+	}
+	client := HTTPClientWithOverrides(overrides)
+
+	req, err := http.NewRequest(http.MethodGet, "http://"+net.JoinHostPort(phantom, port)+"/", http.NoBody)
+	if err != nil {
+		t.Fatalf("new request: %v", err)
+	}
+	resp, err := client.Do(req)
+	if err != nil {
+		t.Fatalf("request via pinned client failed (the pin did not take): %v", err)
+	}
+	_ = resp.Body.Close()
+	if hits != 1 {
+		t.Errorf("server hit %d times, want 1", hits)
+	}
+}
+
+// TestHTTPClientWithOverridesLeavesOtherHosts confirms that a host NOT in
+// the override map still goes through the normal resolver — the pin is
+// per-endpoint, not a blanket rewrite.
+func TestHTTPClientWithOverridesLeavesOtherHosts(t *testing.T) {
+	overrides := HostOverrides{"kc.example.com:443": "10.0.0.5"}
+	client := HTTPClientWithOverrides(overrides)
+
+	// Dial a host that isn't pinned; it should fail on resolution, not
+	// get silently redirected to 10.0.0.5.
+	req, err := http.NewRequest(http.MethodGet, "http://other.invalid.split-dns.test:443/", http.NoBody)
+	if err != nil {
+		t.Fatalf("new request: %v", err)
+	}
+	_, err = client.Do(req)
+	if err == nil {
+		t.Fatalf("expected resolution failure for un-pinned host")
+	}
+	if !IsHostResolutionError(err) {
+		t.Errorf("expected a DNS resolution error for the un-pinned host, got %v", err)
+	}
+}
+
+// TestIsHostResolutionError distinguishes a DNS failure from an
+// arbitrary transport error.
+func TestIsHostResolutionError(t *testing.T) {
+	if !IsHostResolutionError(&net.DNSError{Err: "no such host", Name: "kc.example.com", IsNotFound: true}) {
+		t.Error("a *net.DNSError should be classified as a host-resolution error")
+	}
+	if IsHostResolutionError(errors.New("connection refused")) {
+		t.Error("a generic error must not be classified as host-resolution")
+	}
+	if IsHostResolutionError(nil) {
+		t.Error("nil must not be classified as host-resolution")
+	}
+}
+
+// TestOverrideHonouredOnDeviceAuthPOST is the AC #2 guard: the custom
+// resolver/host-pin must be honoured on the device-authorization POST
+// (and the token poll), not only on discovery. It drives the full
+// RunDeviceFlow against a Keycloak whose endpoints are addressed by a
+// phantom hostname that never resolves via the system resolver; only the
+// --resolve pin to the live httptest server makes the POSTs land. If the
+// pin were dropped anywhere in RunDeviceFlow's client threading, the
+// device-auth POST would fail DNS and this test would fail.
+func TestOverrideHonouredOnDeviceAuthPOST(t *testing.T) {
+	var deviceAuthHits, tokenHits int
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		w.Header().Set("Content-Type", "application/json")
+		switch r.URL.Path {
+		case "/auth/device":
+			deviceAuthHits++
+			_ = json.NewEncoder(w).Encode(map[string]any{
+				"device_code":      "dc",
+				"user_code":        "UC-1234",
+				"verification_uri": "https://kc/device",
+				"expires_in":       600,
+				"interval":         1,
+			})
+		case "/token":
+			tokenHits++
+			_ = json.NewEncoder(w).Encode(map[string]any{
+				"access_token": "at",
+				"token_type":   "Bearer",
+				"expires_in":   3600,
+			})
+		default:
+			http.NotFound(w, r)
+		}
+	}))
+	defer srv.Close()
+
+	_, port, err := net.SplitHostPort(srv.Listener.Addr().String())
+	if err != nil {
+		t.Fatalf("split server addr: %v", err)
+	}
+	serverHost, _, _ := net.SplitHostPort(srv.Listener.Addr().String())
+
+	// Endpoints point at a hostname the system resolver will reject.
+	const phantom = "keycloak.invalid.split-dns.test"
+	base := "http://" + net.JoinHostPort(phantom, port)
+	doc := &DiscoveryDocument{
+		Issuer:                      base + "/realms/meho",
+		DeviceAuthorizationEndpoint: base + "/auth/device",
+		TokenEndpoint:               base + "/token",
+	}
+
+	overrides, err := ParseResolveEntries([]string{
+		net.JoinHostPort(phantom, port) + ":" + serverHost,
+	})
+	if err != nil {
+		t.Fatalf("ParseResolveEntries: %v", err)
+	}
+
+	ctx, cancel := context.WithTimeout(context.Background(), 30*time.Second)
+	defer cancel()
+
+	result, err := RunDeviceFlow(ctx, doc, "meho-cli", DeviceFlowOptions{
+		HTTPClient: HTTPClientWithOverrides(overrides),
+		Prompter:   func(context.Context, *oauth2.DeviceAuthResponse) error { return nil },
+	})
+	if err != nil {
+		t.Fatalf("RunDeviceFlow with pinned client failed (pin not honoured on device-auth POST): %v", err)
+	}
+	if result.Token.AccessToken != "at" {
+		t.Errorf("access token: %q", result.Token.AccessToken)
+	}
+	if deviceAuthHits == 0 {
+		t.Error("device-authorization endpoint was never hit — the pin did not reach the device-auth POST")
+	}
+	if tokenHits == 0 {
+		t.Error("token endpoint was never hit — the pin did not reach the token poll")
+	}
+}

--- a/cli/internal/cmd/login.go
+++ b/cli/internal/cmd/login.go
@@ -10,6 +10,7 @@ import (
 	"fmt"
 	"io"
 	"net/http"
+	"net/url"
 
 	"github.com/spf13/cobra"
 	"golang.org/x/oauth2"
@@ -33,6 +34,7 @@ func newLoginCmd() *cobra.Command {
 		clientIDOverride  string
 		scopes            []string
 		insecureAllowHTTP bool
+		resolveEntries    []string
 	)
 
 	cmd := &cobra.Command{
@@ -58,7 +60,16 @@ func newLoginCmd() *cobra.Command {
 			"issuer and the public device-code client_id. Pass --issuer and/or " +
 			"--client-id to skip discovery or override either half (e.g. when " +
 			"the backplane URL isn't reachable on the operator's network but " +
-			"the IdP is).",
+			"the IdP is).\n\n" +
+			"Split-DNS escape hatch: on workstations where the system resolver " +
+			"can reach the backplane host but returns NXDOMAIN for the Keycloak " +
+			"host (a common VPN split-DNS quirk), pass --resolve " +
+			"<host>:<port>:<ip> to pin that host to a known IP for the duration " +
+			"of the flow. The format mirrors `curl --resolve`; repeat the flag " +
+			"for multiple hosts. The pinned IP is only used at connect time — " +
+			"the original hostname is still sent as the TLS SNI and Host header, " +
+			"so certificate validation is unchanged. Example: " +
+			"`meho login https://<backplane> --resolve kc.example.com:443:10.0.0.5`.",
 		Args:         cobra.ExactArgs(1),
 		SilenceUsage: true,
 		RunE: func(cmd *cobra.Command, args []string) error {
@@ -71,6 +82,19 @@ func newLoginCmd() *cobra.Command {
 			if err != nil {
 				return err
 			}
+
+			// Parse any --resolve host:port:ip overrides and build the
+			// HTTP client the whole flow shares. When no override is
+			// supplied this is http.DefaultClient, so the common path is
+			// unchanged; when one is, the same pinned-dial transport is
+			// threaded through auth-config discovery, OIDC discovery, and
+			// the device-code/token endpoints alike (AC #2 — the knob
+			// must reach every call site, not just discovery).
+			overrides, err := auth.ParseResolveEntries(resolveEntries)
+			if err != nil {
+				return err
+			}
+			httpClient := auth.HTTPClientWithOverrides(overrides)
 
 			// Discovery and auth-config fetches honour the ambient
 			// `cmd.Context()` deadline: those are short, bounded HTTP
@@ -91,14 +115,19 @@ func newLoginCmd() *cobra.Command {
 			// firewall) but the IdP is — meho login can still
 			// complete by skipping discovery via both --issuer and
 			// --client-id.
-			cfg, err := resolveAuthConfig(parentCtx, http.DefaultClient, backplaneURL, issuerOverride, clientIDOverride)
+			cfg, err := resolveAuthConfig(parentCtx, httpClient, backplaneURL, issuerOverride, clientIDOverride)
 			if err != nil {
 				return err
 			}
 
-			doc, err := auth.FetchDiscoveryFromRealm(parentCtx, http.DefaultClient, cfg.Issuer)
+			doc, err := auth.FetchDiscoveryFromRealm(parentCtx, httpClient, cfg.Issuer)
 			if err != nil {
-				return err
+				// OIDC discovery hits the Keycloak host, not the
+				// backplane. A DNS failure here is the split-DNS case
+				// the --resolve flag exists for; name the host that
+				// failed (distinct from the backplane-side auth-config
+				// error above) and point at the escape hatch.
+				return hintKeycloakResolution(err, cfg.Issuer)
 			}
 
 			store, err := auth.NewTokenStore()
@@ -123,13 +152,16 @@ func newLoginCmd() *cobra.Command {
 			defer cancelFlow()
 
 			result, err := auth.RunDeviceFlow(flowCtx, doc, cfg.ClientID, auth.DeviceFlowOptions{
-				HTTPClient:    http.DefaultClient,
+				HTTPClient:    httpClient,
 				Scopes:        scopes,
 				Prompter:      prompter,
 				ParentContext: parentCtx,
 			})
 			if err != nil {
-				return err
+				// The device-authorization and token endpoints also live
+				// on the Keycloak host, so the same split-DNS hint
+				// applies to a resolution failure here.
+				return hintKeycloakResolution(err, cfg.Issuer)
 			}
 
 			stored := auth.ConvertOAuthToken(result.Token, backplaneURL, result.Issuer, cfg.ClientID)
@@ -166,7 +198,37 @@ func newLoginCmd() *cobra.Command {
 	cmd.Flags().BoolVar(&insecureAllowHTTP, "insecure-allow-http", false,
 		"permit a plaintext http:// backplane URL for a localhost backplane only "+
 			"(local-dev convenience; the bearer token is sent in the clear — never use against a remote host)")
+	cmd.Flags().StringSliceVar(&resolveEntries, "resolve", nil,
+		"pin a host to an IP for the flow, mirroring `curl --resolve <host>:<port>:<ip>` "+
+			"(split-DNS escape hatch when the Keycloak host doesn't resolve). Repeat for multiple hosts. "+
+			"TLS SNI/Host use the real hostname, so certificate validation is unaffected")
 	return cmd
+}
+
+// hintKeycloakResolution rewraps err when it was caused by DNS
+// resolution failing against the Keycloak host. The bare transport error
+// ("no such host") does not tell the operator which of the two hosts in
+// play — the backplane (which resolved fine, it's how we got the issuer)
+// or Keycloak — is unreachable, nor how to work around it. This hint
+// names the Keycloak host explicitly (distinct from the backplane-side
+// auth-config discovery failure, which is worded around --issuer /
+// --client-id) and points at the --resolve escape hatch. Any error that
+// is not a resolution failure is returned unchanged so the existing
+// device-flow classification (expired_token, access_denied, timeouts)
+// still reaches the operator verbatim.
+func hintKeycloakResolution(err error, issuer string) error {
+	if err == nil || !auth.IsHostResolutionError(err) {
+		return err
+	}
+	host := issuer
+	if u, parseErr := url.Parse(issuer); parseErr == nil && u.Host != "" {
+		host = u.Hostname()
+	}
+	return fmt.Errorf(
+		"could not resolve the Keycloak host %q (the backplane resolved fine; this is a split-DNS gap): %w; "+
+			"pass --resolve %s:443:<keycloak-ip> to pin it to a known IP for this login (mirrors `curl --resolve`)",
+		host, err, host,
+	)
 }
 
 // authConfig is what either the backplane discovery endpoint or the

--- a/cli/internal/cmd/login_test.go
+++ b/cli/internal/cmd/login_test.go
@@ -7,6 +7,8 @@ import (
 	"bytes"
 	"context"
 	"encoding/json"
+	"errors"
+	"net"
 	"net/http"
 	"net/http/httptest"
 	"os"
@@ -212,10 +214,69 @@ func TestResolveAuthConfigDiscoveryFailureMentionsFlags(t *testing.T) {
 func TestLoginCommandHelpListsFlags(t *testing.T) {
 	cmd := newLoginCmd()
 	out := cmd.UsageString()
-	for _, want := range []string{"--issuer", "--client-id", "--scope"} {
+	for _, want := range []string{"--issuer", "--client-id", "--scope", "--resolve"} {
 		if !strings.Contains(out, want) {
 			t.Errorf("usage missing flag %s:\n%s", want, out)
 		}
+	}
+}
+
+// TestLoginCommandHelpDocumentsResolve pins the discoverability half of
+// #2107 (AC #5): the operator-facing help (both --help usage and the
+// long text) must name the --resolve escape hatch so a dogfooder hitting
+// the split-DNS failure grepping the help output finds the workaround.
+func TestLoginCommandHelpDocumentsResolve(t *testing.T) {
+	cmd := newLoginCmd()
+	if out := cmd.UsageString(); !strings.Contains(out, "--resolve") {
+		t.Errorf("usage missing --resolve flag:\n%s", out)
+	}
+	long := cmd.Long
+	for _, want := range []string{"--resolve", "split-DNS", "curl --resolve"} {
+		if !strings.Contains(long, want) {
+			t.Errorf("login long help should mention %q; got:\n%s", want, long)
+		}
+	}
+}
+
+// TestHintKeycloakResolutionNamesHostAndFlag is the AC #3 guard: when the
+// Keycloak host fails to resolve, the surfaced error names the Keycloak
+// host (not the backplane) and points at the --resolve knob. The message
+// must be distinct from the backplane-side auth-config discovery failure
+// (which is worded around --issuer / --client-id).
+func TestHintKeycloakResolutionNamesHostAndFlag(t *testing.T) {
+	dnsErr := &net.DNSError{Err: "no such host", Name: "kc.example.com", IsNotFound: true}
+	err := hintKeycloakResolution(dnsErr, "https://kc.example.com/realms/meho")
+	if err == nil {
+		t.Fatal("expected a wrapped error for a DNS resolution failure")
+	}
+	got := err.Error()
+	for _, want := range []string{"kc.example.com", "--resolve", "split-DNS"} {
+		if !strings.Contains(got, want) {
+			t.Errorf("error should mention %q so the operator can recover; got: %v", want, got)
+		}
+	}
+	// Distinct from the backplane discovery failure: it must NOT steer
+	// the operator at --issuer / --client-id (that's the backplane path).
+	if strings.Contains(got, "--issuer") {
+		t.Errorf("Keycloak-resolution hint should not mention --issuer (that's the backplane path); got: %v", got)
+	}
+	// The underlying DNS error stays unwrappable for callers/tests.
+	if !errors.Is(err, dnsErr) {
+		t.Errorf("hintKeycloakResolution should wrap the original error; errors.Is failed")
+	}
+}
+
+// TestHintKeycloakResolutionPassesThroughNonDNSErrors confirms the hint
+// is surgical: a non-resolution error (expired device code, timeout,
+// access_denied) is returned unchanged so the existing device-flow
+// classification still reaches the operator verbatim.
+func TestHintKeycloakResolutionPassesThroughNonDNSErrors(t *testing.T) {
+	orig := errors.New("meho: device code expired before authorisation; rerun `meho login`")
+	if got := hintKeycloakResolution(orig, "https://kc.example.com/realms/meho"); got != orig {
+		t.Errorf("non-DNS error should pass through unchanged; got: %v", got)
+	}
+	if got := hintKeycloakResolution(nil, "https://kc"); got != nil {
+		t.Errorf("nil error should pass through as nil; got: %v", got)
 	}
 }
 

--- a/docs/codebase/cli.md
+++ b/docs/codebase/cli.md
@@ -163,6 +163,8 @@ cli/
     ├── auth/
     │   ├── devicecode.go      # OAuth 2.0 device-code flow + OIDC discovery.
     │   ├── devicecode_test.go # httptest-driven flow + discovery tests.
+    │   ├── resolver.go        # --resolve host:port:ip parsing + pinned-dial http.Client (split-DNS escape hatch, #2107).
+    │   ├── resolver_test.go   # parse matrix + pinned-dial proof + AC#2 device-auth-POST honours-pin test.
     │   ├── store.go           # TokenStore interface + keyring/file backends.
     │   ├── store_test.go      # file-fallback round-trip + 0600-mode test.
     │   ├── config.go          # backplane-URL config file ($XDG/meho/config.json).
@@ -172,8 +174,8 @@ cli/
     │   ├── root_test.go       # built-in command surface + dynamic-graft test.
     │   ├── version.go         # `meho version` subcommand.
     │   ├── version_test.go    # output-contract test.
-    │   ├── login.go           # `meho login` subcommand + auth-config discovery + config persistence + post-login memory-migration nudge (T5 #612).
-    │   ├── login_test.go      # override-resolution + help-flag + post-login nudge tests.
+    │   ├── login.go           # `meho login` subcommand + auth-config discovery + --resolve split-DNS pin (#2107) + config persistence + post-login memory-migration nudge (T5 #612).
+    │   ├── login_test.go      # override-resolution + help-flag + --resolve help/hint (#2107) + post-login nudge tests.
     │   ├── status.go          # `meho status` subcommand + --json + URL resolver.
     │   ├── status_test.go     # happy/JSON/no-creds/unreachable/401/redaction tests.
     │   ├── audit/            # G8.1-T3 #467 — `meho audit …` verb tree.
@@ -425,6 +427,38 @@ Authorization Grant (RFC 8628). End-to-end shape:
      other half. TLS-discovery failures additionally point at the
      "install your deployment's root CA in your system trust store"
      remediation for internal-CA deployments.
+   * **Split-DNS escape hatch (`--resolve`).** On operator
+     workstations where the system resolver reaches the backplane
+     host but returns NXDOMAIN for the Keycloak host — the normal
+     VPN split-DNS topology, where the pushed DNS forwarder knows the
+     backplane name but not the Keycloak name — `--resolve
+     <host>:<port>:<ip>` pins that host to a known IP for the
+     duration of the flow. The format and semantics mirror `curl
+     --resolve` (repeatable; per-host:port). Implemented in
+     `internal/auth/resolver.go`: `ParseResolveEntries` validates the
+     `host:port:ip` triples (port must be a valid TCP port, IP a
+     literal address; a malformed entry is a hard error, not a silent
+     skip), and `HTTPClientWithOverrides` builds an `http.Client`
+     whose cloned `http.DefaultTransport.DialContext` substitutes the
+     pinned IP at connect time. The pin only rewrites the dialled
+     address — net/http still derives the TLS SNI and `Host` header
+     from the request URL's real hostname, so certificate validation
+     is unchanged (this is exactly why `curl --resolve` is TLS-safe
+     and an SNI-rewriting resolver hack is not). The same client is
+     threaded through auth-config discovery, OIDC discovery, and the
+     device-code/token endpoints, so the pin reaches every call site,
+     not just discovery. When no `--resolve` is supplied the client is
+     `http.DefaultClient` unchanged.
+   * **Keycloak-resolution hint.** When OIDC discovery or the
+     device-auth POST fails specifically because the Keycloak host
+     doesn't resolve (`*net.DNSError`), `hintKeycloakResolution` in
+     `login.go` rewraps the opaque "no such host" error into one that
+     names the Keycloak host (distinct from the backplane-side
+     auth-config failure, which is worded around `--issuer` /
+     `--client-id`) and suggests the `--resolve` knob. Non-resolution
+     errors (expired device code, access_denied, timeouts) pass
+     through unchanged so the existing device-flow classification is
+     preserved.
 2. **OIDC discovery.** The CLI fetches
    `<issuer>/.well-known/openid-configuration` to learn the
    `device_authorization_endpoint` and `token_endpoint`. If the


### PR DESCRIPTION
## Summary
- `meho login` drove auth-config discovery, OIDC discovery, and the device-code/token endpoints through `http.DefaultClient`, so split-DNS operator workstations (backplane host resolves, Keycloak host NXDOMAIN — the normal VPN-DNS-push topology) hit a bare "could not resolve host" with no CLI-native workaround.
- Adds `meho login --resolve <host>:<port>:<ip>` (Option A from the issue), mirroring `curl --resolve`: pins a host to a known IP at connect time only, so TLS SNI/Host still use the real hostname and certificate validation is unchanged.
- The pinned-dial `http.Client` is threaded through **all three** login call sites (auth-config discovery, OIDC discovery, device-code/token), so the knob reaches the device-auth POST — not just discovery.
- When the Keycloak host fails DNS resolution, the error now **names the Keycloak host** and points at `--resolve` (Option C), distinct from the backplane-side auth-config discovery failure (worded around `--issuer`/`--client-id`).

## Implementation
- `cli/internal/auth/resolver.go` — `ParseResolveEntries` (fail-loud validation of `host:port:ip` triples, IPv6-aware), `HTTPClientWithOverrides` (cloned `DefaultTransport.DialContext` pin; no override → `http.DefaultClient` unchanged), `IsHostResolutionError` (`*net.DNSError` classifier).
- `cli/internal/cmd/login.go` — `--resolve` flag + long-help docs; builds the shared client; `hintKeycloakResolution` rewraps DNS failures on the Keycloak-facing calls. Non-resolution errors (expired code, access_denied, timeouts) pass through unchanged.
- `docs/codebase/cli.md` — login-flow section documents the escape hatch and the TLS-safe rationale.

## Test plan
- [x] `go build ./...` — clean
- [x] `go vet ./internal/auth/... ./internal/cmd/` — clean
- [x] `gofmt -l` on all changed files — clean
- [x] `go test ./...` — all pass
- [x] AC #1 flag registration + `meho login --help` lists `--resolve` — `TestLoginCommandHelpListsFlags`, `TestLoginCommandHelpDocumentsResolve`
- [x] AC #2 pin honoured on the device-auth POST (not just discovery) — `TestOverrideHonouredOnDeviceAuthPOST` (phantom Keycloak host, only the `--resolve` pin makes the POSTs land), plus `TestHTTPClientWithOverridesPinsDial`
- [x] AC #3 error names the Keycloak host + `--resolve`, distinct from the backplane failure — `TestHintKeycloakResolutionNamesHostAndFlag`, `TestHintKeycloakResolutionPassesThroughNonDNSErrors`
- [x] AC #4 the manual `--resolve <kc>:443:<ip>` repro path is the code path implemented; automated analog is the pinned-dial test
- [x] AC #5 documented in `--help` long text and `docs/codebase/cli.md`

## Out of scope
- Option B (`--dns-server` alternate-resolver flag) — the issue frames A/B as "and/or"; A fully resolves the reported failure with the smallest blast radius and no resolver plumbing.
- TLS-trust gap (`--insecure-skip-tls-verify` for login) — separate concern per the issue's Out-of-scope.

<!-- auto-implement-issue: fresh, iteration 1 -->

Closes #2107
