### PR TITLE
fix(docs): make meho docs search apply the same capability gate as POST /api/v1/search_docs (#2109)

### DIFF
--- a/cli/README.md
+++ b/cli/README.md
@@ -157,35 +157,36 @@ Fetch failures (404 before G2.2 ships the endpoint, offline
 operators, etc.) degrade silently to "no extra commands" — the
 local-only `login` / `status` / `version` set stays usable.
 
-## Capability-gated commands
+## Add-on commands (server-gated)
 
 Some commands wrap a **tenant-provisioned add-on** rather than a
 core operation. `meho docs` (the meho-docs vendor-document add-on,
-G4.5) is the first: it compiles into every binary, but the tree is
-only usable when the tenant has the `meho-docs` capability.
+G4.5) is the first: it compiles into every binary and is always
+listed in `meho --help`.
 
-The gate reads the `capabilities` claim from the stored bearer JWT
-(the same claim the MCP registry filters tool visibility on) at
-command-tree-build time:
+There is **no client-side capability gate** (#2109). Access is decided
+server-side by the backplane, identically to `POST /api/v1/search_docs`
+— the CLI is a thin shell over the same route the REST surface exposes,
+so the same `(query, collection, tenant)` gets the same verdict on
+either surface. The backplane enforces the per-collection
+`meho-docs:<collection>` entitlement (and the operator / tenant_admin
+role on the lifecycle verbs); a caller that is not entitled to the
+named collection gets a typed 403 the CLI renders as
+`insufficient_role` (exit 5), rather than a divergent client-side
+refusal.
 
-- **Provisioned** (`meho-docs` in the claim) — `meho docs` is listed
-  in `meho --help` and `meho docs search …` runs.
-- **Unprovisioned** (claim absent / no login / unparseable token) —
-  `meho docs` is hidden from `meho --help` and every verb refuses
-  with a typed `addon_not_provisioned` error (exit 5) before any
-  network call. Fail-closed: anything that prevents resolving the
-  claim is treated as "not provisioned".
-
-The claim is read **unverified** — this is a visibility affordance,
-not a security check. The backplane re-validates the JWT and the
-add-on's federation enforces the real boundary on every call, so a
-forged capability claim can change what the CLI *shows* but not what
-the server *allows*.
+(An earlier shape decoded the bare `meho-docs` capability from the
+stored JWT and hid / refused the whole tree client-side. That gate had
+no counterpart on the REST route — which only checks the per-collection
+capability — so the two surfaces diverged. The operator decision on
+#2109 reconciled them to a single server-side gate.)
 
 ```bash
-# Mandatory binary scope: --product and --version (REQUIRE_FILTERS).
-meho docs search "nsx config maximums" --product vmware --version 9.0
-meho docs search "nsx config maximums" --product vmware --version 9.0 --json
+# Mandatory binary scope: --collection routes + gates per-collection
+# entitlement server-side. --product / --version are optional
+# refinements within a single collection.
+meho docs search "nsx config maximums" --collection vmware
+meho docs search "nsx config maximums" --collection vmware --json
 ```
 
 ## Generated client

--- a/cli/internal/cmd/docs/collections.go
+++ b/cli/internal/cmd/docs/collections.go
@@ -25,11 +25,13 @@ import (
 // `disable`, T6 #1555) mutate the doc_collections row and require
 // tenant_admin (the connector enable/disable gate).
 //
-// `provisioned` carries the meho-docs capability resolved at command-tree-
-// build time; an unprovisioned tenant gets the typed
-// `addon_not_provisioned` refusal before any network call on every verb,
-// the same gate `meho docs search` enforces.
-func newCollectionsCmd(provisioned bool) *cobra.Command {
+// There is no client-side capability gate (#2109): the tree is always
+// visible and every verb defers to server-side gating, identically to
+// `POST /api/v1/search_docs`. The backplane enforces the per-collection
+// `meho-docs:<collection>` entitlement and the tenant_admin role on the
+// lifecycle verbs, so an unentitled / under-privileged caller gets a
+// typed 403 from the route rather than a divergent client-side refusal.
+func newCollectionsCmd() *cobra.Command {
 	cmd := &cobra.Command{
 		Use:   "collections",
 		Short: "List, create, and probe / toggle doc collections",
@@ -46,14 +48,13 @@ func newCollectionsCmd(provisioned bool) *cobra.Command {
 			"built, and rebuilds serialize per project — `probe` surfaces " +
 			"that as the collection's status rather than hiding it behind a " +
 			"silent empty search result.",
-		Hidden:       !provisioned,
 		SilenceUsage: true,
 	}
-	cmd.AddCommand(newCollectionsListCmd(provisioned))
-	cmd.AddCommand(newCollectionsCreateCmd(provisioned))
-	cmd.AddCommand(newCollectionsProbeCmd(provisioned))
-	cmd.AddCommand(newCollectionsEnableCmd(provisioned))
-	cmd.AddCommand(newCollectionsDisableCmd(provisioned))
+	cmd.AddCommand(newCollectionsListCmd())
+	cmd.AddCommand(newCollectionsCreateCmd())
+	cmd.AddCommand(newCollectionsProbeCmd())
+	cmd.AddCommand(newCollectionsEnableCmd())
+	cmd.AddCommand(newCollectionsDisableCmd())
 	return cmd
 }
 
@@ -62,13 +63,9 @@ type lifecycleOptions struct {
 	CollectionKey     string
 	JSONOut           bool
 	BackplaneOverride string
-	// Provisioned carries the meho-docs capability gate. When false the
-	// verb refuses with the typed addon_not_provisioned error before
-	// touching the network.
-	Provisioned bool
 }
 
-func newCollectionsProbeCmd(provisioned bool) *cobra.Command {
+func newCollectionsProbeCmd() *cobra.Command {
 	var (
 		jsonOut           bool
 		backplaneOverride string
@@ -93,7 +90,6 @@ func newCollectionsProbeCmd(provisioned bool) *cobra.Command {
 				CollectionKey:     args[0],
 				JSONOut:           jsonOut,
 				BackplaneOverride: backplaneOverride,
-				Provisioned:       provisioned,
 			})
 		},
 	}
@@ -104,7 +100,7 @@ func newCollectionsProbeCmd(provisioned bool) *cobra.Command {
 	return cmd
 }
 
-func newCollectionsEnableCmd(provisioned bool) *cobra.Command {
+func newCollectionsEnableCmd() *cobra.Command {
 	var (
 		jsonOut           bool
 		backplaneOverride string
@@ -125,7 +121,6 @@ func newCollectionsEnableCmd(provisioned bool) *cobra.Command {
 				CollectionKey:     args[0],
 				JSONOut:           jsonOut,
 				BackplaneOverride: backplaneOverride,
-				Provisioned:       provisioned,
 			})
 		},
 	}
@@ -135,7 +130,7 @@ func newCollectionsEnableCmd(provisioned bool) *cobra.Command {
 	return cmd
 }
 
-func newCollectionsDisableCmd(provisioned bool) *cobra.Command {
+func newCollectionsDisableCmd() *cobra.Command {
 	var (
 		jsonOut           bool
 		backplaneOverride string
@@ -158,7 +153,6 @@ func newCollectionsDisableCmd(provisioned bool) *cobra.Command {
 				CollectionKey:     args[0],
 				JSONOut:           jsonOut,
 				BackplaneOverride: backplaneOverride,
-				Provisioned:       provisioned,
 			})
 		},
 	}
@@ -169,12 +163,11 @@ func newCollectionsDisableCmd(provisioned bool) *cobra.Command {
 }
 
 // gateLifecycle runs the shared pre-flight every collections verb needs:
-// the capability gate, a non-empty key, and backplane resolution. Returns
-// the resolved URL or a rendered error the caller returns directly.
+// a non-empty key and backplane resolution. Returns the resolved URL or a
+// rendered error the caller returns directly. There is no client-side
+// capability gate (#2109) — the backplane enforces entitlement + role
+// server-side, identically to the REST route.
 func gateLifecycle(cmd *cobra.Command, opts lifecycleOptions) (string, error) {
-	if !opts.Provisioned {
-		return "", errNotProvisioned(cmd, opts.JSONOut)
-	}
 	if opts.CollectionKey == "" {
 		return "", output.RenderError(
 			cmd.ErrOrStderr(),

--- a/cli/internal/cmd/docs/collections_create.go
+++ b/cli/internal/cmd/docs/collections_create.go
@@ -39,7 +39,7 @@ import (
 // Exit codes mirror the sibling collections verbs (renderHTTPStatus maps
 // 422 → unexpected with the unknown-backend-type detail, 409 → unexpected
 // with the conflict detail, 403 → insufficient_role).
-func newCollectionsCreateCmd(provisioned bool) *cobra.Command {
+func newCollectionsCreateCmd() *cobra.Command {
 	var opts createCollectionOptions
 	cmd := &cobra.Command{
 		Use:   "create <collection-key>",
@@ -67,7 +67,6 @@ func newCollectionsCreateCmd(provisioned bool) *cobra.Command {
 			if len(args) == 1 {
 				opts.CollectionKey = args[0]
 			}
-			opts.Provisioned = provisioned
 			return runCollectionCreate(cmd, opts)
 		},
 	}
@@ -104,13 +103,9 @@ type createCollectionOptions struct {
 	FromFile          string
 	JSONOut           bool
 	BackplaneOverride string
-	Provisioned       bool
 }
 
 func runCollectionCreate(cmd *cobra.Command, opts createCollectionOptions) error {
-	if !opts.Provisioned {
-		return errNotProvisioned(cmd, opts.JSONOut)
-	}
 	body, buildErr := buildCreateBody(opts)
 	if buildErr != nil {
 		return output.RenderError(cmd.ErrOrStderr(), output.Unexpected(buildErr.Error()), opts.JSONOut)

--- a/cli/internal/cmd/docs/collections_create_test.go
+++ b/cli/internal/cmd/docs/collections_create_test.go
@@ -15,22 +15,6 @@ import (
 	"github.com/evoila/meho/cli/internal/api"
 )
 
-func TestRunCollectionCreateRefusesWhenUnprovisioned(t *testing.T) {
-	cmd, _, stderr := newRunCmd(t)
-	err := runCollectionCreate(cmd, createCollectionOptions{
-		CollectionKey: "vmware",
-		Vendor:        "VMware",
-		BackendType:   "corpus-http",
-		Provisioned:   false,
-	})
-	if exitCodeOf(t, err) != 5 {
-		t.Errorf("expected exit 5 (insufficient_role family); got %d", exitCodeOf(t, err))
-	}
-	if !strings.Contains(stderr.String(), "addon_not_provisioned") {
-		t.Errorf("expected addon_not_provisioned code; got %q", stderr.String())
-	}
-}
-
 func TestBuildCreateBodyFromFlagsRequiresVendorAndBackend(t *testing.T) {
 	cases := []struct {
 		name string
@@ -140,7 +124,6 @@ func TestRunCollectionCreateHappyPath(t *testing.T) {
 		Vendor:            "VMware by Broadcom",
 		BackendType:       "corpus-http",
 		BackendRef:        `{"endpoint":"https://corpus/v1/search"}`,
-		Provisioned:       true,
 		BackplaneOverride: srv.URL,
 	})
 	if err != nil {
@@ -179,7 +162,6 @@ func TestRunCollectionCreateRendersUnknownBackend422(t *testing.T) {
 		CollectionKey:     "vmware",
 		Vendor:            "VMware",
 		BackendType:       "no-such-backend",
-		Provisioned:       true,
 		BackplaneOverride: srv.URL,
 	})
 	if exitCodeOf(t, err) != 4 {
@@ -211,7 +193,6 @@ func TestRunCollectionCreateRendersConflict409(t *testing.T) {
 		CollectionKey:     "vmware",
 		Vendor:            "VMware",
 		BackendType:       "corpus-http",
-		Provisioned:       true,
 		BackplaneOverride: srv.URL,
 	})
 	if exitCodeOf(t, err) != 4 {
@@ -223,7 +204,7 @@ func TestRunCollectionCreateRendersConflict409(t *testing.T) {
 }
 
 func TestCollectionsCreateHelpExitsZero(t *testing.T) {
-	cmd := newCollectionsCreateCmd(true)
+	cmd := newCollectionsCreateCmd()
 	cmd.SetArgs([]string{"--help"})
 	if err := cmd.Execute(); err != nil {
 		t.Fatalf("create --help: %v", err)

--- a/cli/internal/cmd/docs/collections_list.go
+++ b/cli/internal/cmd/docs/collections_list.go
@@ -27,10 +27,9 @@ import (
 // which `--collection` keys `meho docs search` will accept.
 //
 // Unlike the lifecycle verbs (probe / enable / disable, tenant_admin),
-// `list` is a read every operator may run, so its only gate is the
-// shared `meho-docs` capability — an unprovisioned tenant gets the typed
-// `addon_not_provisioned` refusal before any network call, the same gate
-// `meho docs search` enforces.
+// `list` is a read every operator may run. There is no client-side
+// capability gate (#2109): the backplane scopes the result to the
+// collections the tenant is entitled to, server-side.
 //
 // CLI shape (mirrors `meho targets list`):
 //
@@ -46,8 +45,8 @@ import (
 //   - 2   auth_expired
 //   - 3   unreachable
 //   - 4   unexpected response shape
-//   - 5   insufficient_role / addon_not_provisioned
-func newCollectionsListCmd(provisioned bool) *cobra.Command {
+//   - 5   insufficient_role
+func newCollectionsListCmd() *cobra.Command {
 	var (
 		vendor            string
 		limit             int
@@ -79,7 +78,6 @@ func newCollectionsListCmd(provisioned bool) *cobra.Command {
 				Cursor:            cursor,
 				JSONOut:           jsonOut,
 				BackplaneOverride: backplaneOverride,
-				Provisioned:       provisioned,
 			})
 		},
 	}
@@ -103,16 +101,9 @@ type listCollectionsOptions struct {
 	Cursor            string
 	JSONOut           bool
 	BackplaneOverride string
-	// Provisioned carries the meho-docs capability gate. When false the
-	// verb refuses with the typed addon_not_provisioned error before
-	// touching the network — the same pre-flight the lifecycle verbs run.
-	Provisioned bool
 }
 
 func runCollectionList(cmd *cobra.Command, opts listCollectionsOptions) error {
-	if !opts.Provisioned {
-		return errNotProvisioned(cmd, opts.JSONOut)
-	}
 	// Fail fast on out-of-range --limit. The API clamps internally
 	// (FastAPI Query(ge=1, le=500)) but an explicit zero/negative would
 	// fall through to a 422 surprise; surface the constraint here.

--- a/cli/internal/cmd/docs/collections_list_test.go
+++ b/cli/internal/cmd/docs/collections_list_test.go
@@ -14,7 +14,7 @@ import (
 )
 
 func TestCollectionsListRegisteredOnParent(t *testing.T) {
-	cmd := newCollectionsCmd(true)
+	cmd := newCollectionsCmd()
 	var found bool
 	for _, c := range cmd.Commands() {
 		if c.Name() == "list" {
@@ -26,39 +26,10 @@ func TestCollectionsListRegisteredOnParent(t *testing.T) {
 	}
 }
 
-func TestRunCollectionListRefusesWhenUnprovisioned(t *testing.T) {
-	cmd, _, stderr := newRunCmd(t)
-	err := runCollectionList(cmd, listCollectionsOptions{Provisioned: false})
-	if exitCodeOf(t, err) != 5 {
-		t.Errorf("expected exit 5 (insufficient_role family); got %d", exitCodeOf(t, err))
-	}
-	if !strings.Contains(stderr.String(), "addon_not_provisioned") {
-		t.Errorf("expected addon_not_provisioned code; got %q", stderr.String())
-	}
-}
-
-func TestRunCollectionListRefusalIsBeforeNetwork(t *testing.T) {
-	hit := false
-	srv := httptest.NewServer(http.HandlerFunc(func(http.ResponseWriter, *http.Request) {
-		hit = true
-	}))
-	defer srv.Close()
-
-	cmd, _, _ := newRunCmd(t)
-	_ = runCollectionList(cmd, listCollectionsOptions{
-		Provisioned:       false,
-		BackplaneOverride: srv.URL,
-	})
-	if hit {
-		t.Errorf("expected no HTTP call for an unprovisioned refusal")
-	}
-}
-
 func TestRunCollectionListRejectsOutOfRangeLimit(t *testing.T) {
 	cmd, _, _ := newRunCmd(t)
 	err := runCollectionList(cmd, listCollectionsOptions{
-		Provisioned: true,
-		Limit:       9000,
+		Limit: 9000,
 	})
 	if exitCodeOf(t, err) != 4 {
 		t.Errorf("expected exit 4 (unexpected_response) for out-of-range limit; got %d", exitCodeOf(t, err))
@@ -92,7 +63,6 @@ func TestRunCollectionListHappyPathTable(t *testing.T) {
 
 	cmd, stdout, stderr := newRunCmd(t)
 	err := runCollectionList(cmd, listCollectionsOptions{
-		Provisioned:       true,
 		BackplaneOverride: srv.URL,
 	})
 	if err != nil {
@@ -120,7 +90,6 @@ func TestRunCollectionListEmptyRendersNotice(t *testing.T) {
 
 	cmd, stdout, _ := newRunCmd(t)
 	err := runCollectionList(cmd, listCollectionsOptions{
-		Provisioned:       true,
 		BackplaneOverride: srv.URL,
 	})
 	if err != nil {
@@ -148,7 +117,6 @@ func TestRunCollectionListJSONOutput(t *testing.T) {
 
 	cmd, stdout, _ := newRunCmd(t)
 	err := runCollectionList(cmd, listCollectionsOptions{
-		Provisioned:       true,
 		JSONOut:           true,
 		BackplaneOverride: srv.URL,
 	})
@@ -181,7 +149,6 @@ func TestRunCollectionListForwardsVendorAndCursor(t *testing.T) {
 
 	cmd, _, _ := newRunCmd(t)
 	if err := runCollectionList(cmd, listCollectionsOptions{
-		Provisioned:       true,
 		Vendor:            "NetApp",
 		Cursor:            "vmware",
 		Limit:             25,
@@ -227,7 +194,6 @@ func TestRunCollectionListForbiddenRole403(t *testing.T) {
 
 	cmd, _, _ := newRunCmd(t)
 	err := runCollectionList(cmd, listCollectionsOptions{
-		Provisioned:       true,
 		BackplaneOverride: srv.URL,
 	})
 	if exitCodeOf(t, err) != 5 {

--- a/cli/internal/cmd/docs/collections_test.go
+++ b/cli/internal/cmd/docs/collections_test.go
@@ -13,43 +13,18 @@ import (
 	"github.com/evoila/meho/cli/internal/api"
 )
 
-func TestCollectionsCmdHiddenWhenUnprovisioned(t *testing.T) {
-	cmd := newCollectionsCmd(false)
-	if !cmd.Hidden {
-		t.Errorf("expected collections parent Hidden when unprovisioned")
+// TestCollectionsCmdAlwaysVisible asserts the collections tree carries
+// no client-side capability gate — never Hidden (#2109). Access is
+// decided server-side, identically to POST /api/v1/search_docs.
+func TestCollectionsCmdAlwaysVisible(t *testing.T) {
+	cmd := newCollectionsCmd()
+	if cmd.Hidden {
+		t.Errorf("expected collections parent always visible (no client-side capability gate)")
 	}
-}
-
-func TestRunCollectionProbeRefusesWhenUnprovisioned(t *testing.T) {
-	cmd, _, stderr := newRunCmd(t)
-	err := runCollectionProbe(cmd, lifecycleOptions{
-		CollectionKey: "vmware",
-		Provisioned:   false,
-	})
-	if exitCodeOf(t, err) != 5 {
-		t.Errorf("expected exit 5 (insufficient_role family); got %d", exitCodeOf(t, err))
-	}
-	if !strings.Contains(stderr.String(), "addon_not_provisioned") {
-		t.Errorf("expected addon_not_provisioned code; got %q", stderr.String())
-	}
-}
-
-func TestRunCollectionProbeRefusalIsBeforeNetwork(t *testing.T) {
-	// An unprovisioned refusal must short-circuit before any HTTP call.
-	hit := false
-	srv := httptest.NewServer(http.HandlerFunc(func(http.ResponseWriter, *http.Request) {
-		hit = true
-	}))
-	defer srv.Close()
-
-	cmd, _, _ := newRunCmd(t)
-	_ = runCollectionProbe(cmd, lifecycleOptions{
-		CollectionKey:     "vmware",
-		Provisioned:       false,
-		BackplaneOverride: srv.URL,
-	})
-	if hit {
-		t.Errorf("expected no HTTP call for an unprovisioned refusal")
+	for _, sub := range cmd.Commands() {
+		if sub.Hidden {
+			t.Errorf("expected collections subcommand %q always visible; got Hidden", sub.Name())
+		}
 	}
 }
 
@@ -57,7 +32,6 @@ func TestRunCollectionProbeRejectsEmptyKey(t *testing.T) {
 	cmd, _, _ := newRunCmd(t)
 	err := runCollectionProbe(cmd, lifecycleOptions{
 		CollectionKey: "",
-		Provisioned:   true,
 	})
 	if exitCodeOf(t, err) != 4 {
 		t.Errorf("expected exit 4 (unexpected_response) for empty key; got %d", exitCodeOf(t, err))
@@ -88,7 +62,6 @@ func TestRunCollectionProbeHappyPath(t *testing.T) {
 	cmd, stdout, stderr := newRunCmd(t)
 	err := runCollectionProbe(cmd, lifecycleOptions{
 		CollectionKey:     "vmware",
-		Provisioned:       true,
 		BackplaneOverride: srv.URL,
 	})
 	if err != nil {
@@ -119,7 +92,6 @@ func TestRunCollectionDisableHappyPath(t *testing.T) {
 	cmd, stdout, stderr := newRunCmd(t)
 	err := runCollectionDisable(cmd, lifecycleOptions{
 		CollectionKey:     "vmware",
-		Provisioned:       true,
 		BackplaneOverride: srv.URL,
 	})
 	if err != nil {
@@ -155,7 +127,6 @@ func TestRunCollectionEnableForbiddenTransition409(t *testing.T) {
 	cmd, _, _ := newRunCmd(t)
 	err := runCollectionEnable(cmd, lifecycleOptions{
 		CollectionKey:     "vmware",
-		Provisioned:       true,
 		BackplaneOverride: srv.URL,
 	})
 	if exitCodeOf(t, err) != 4 {
@@ -180,7 +151,6 @@ func TestRunCollectionProbeForbiddenRole403(t *testing.T) {
 	cmd, _, _ := newRunCmd(t)
 	err := runCollectionProbe(cmd, lifecycleOptions{
 		CollectionKey:     "vmware",
-		Provisioned:       true,
 		BackplaneOverride: srv.URL,
 	})
 	if exitCodeOf(t, err) != 5 {

--- a/cli/internal/cmd/docs/docs.go
+++ b/cli/internal/cmd/docs/docs.go
@@ -15,34 +15,28 @@
 //     before the round-trip. --product / --version are optional
 //     refinements within the collection.
 //
-// Gating — true-absence-when-unprovisioned (option B, the
-// compiled-in fallback). The `meho docs` tree compiles into every
-// CLI binary, but its visibility is gated on the tenant-provisioned
-// `meho-docs` capability (T1, #1519). The capability is carried in
-// the operator's JWT `capabilities` claim (the same claim the MCP
-// registry filters tool visibility on). The CLI reads that claim
-// from the stored bearer token at command-tree-build time and:
+// Gating — server-side only, CLI ↔ REST parity (#2109). The `meho
+// docs` tree compiles into every CLI binary and is always visible; it
+// carries no client-side capability pre-check. Access is decided by
+// the backplane exactly as it is for `POST /api/v1/search_docs`: the
+// per-collection `meho-docs:<collection>` entitlement is enforced
+// server-side (a miss is a 403 `not_entitled` the CLI renders as
+// `insufficient_role`). The CLI is a thin shell over the same route
+// the REST surface exposes, so the same `(query, collection, tenant)`
+// gets the same verdict on either surface.
 //
-//   - shows `meho docs` in `meho --help` only when the tenant has
-//     the `meho-docs` capability, and
-//   - refuses any invocation with a typed, non-zero
-//     "add-on not provisioned" error otherwise.
-//
-// Why decode the claim client-side rather than build a discovery
-// route: the server-driven discovery channel
-// (`discovery.Fetch` → GET /api/v1/commands) is anonymous by design
-// (it never imports internal/api or internal/auth, and it fetches
-// before login has produced a token), and its `Register` only grafts
-// *stub* commands ("not yet implemented locally") — it cannot toggle
-// the visibility of a real, compiled-in implementation per tenant. A
-// tenant-filtered manifest would contradict the discovery channel's
-// anonymous contract and require a new authenticated backend route +
-// an OpenAPI snapshot regen. The client-side claim probe is purely a
-// UX affordance: the real security boundary stays server-side (the
-// route's RBAC plus the corpus federation), so a forged capability
-// claim still cannot reach the corpus. Reading an *unverified* claim
-// to decide whether to *show* a command is safe precisely because the
-// gate never grants access on its own.
+// Why no client-side capability gate: an earlier shape read the bare
+// `meho-docs` capability out of the stored JWT and hid / refused the
+// whole tree when it was absent (option B). That gate had no
+// counterpart on the REST route (which never checks the bare
+// capability — only the per-collection one), so the two surfaces
+// diverged: a tenant entitled to a collection via REST could still hit
+// `addon_not_provisioned` on the CLI. The operator decision on #2109
+// was option A — reconcile to one server-gated op — so the client-side
+// pre-check is gone and the server is the single gate. A forged claim
+// never mattered here anyway: the CLI gate was only a visibility
+// affordance; the backplane RBAC + corpus federation always enforced
+// the real boundary.
 //
 // Like the sibling kb verb tree (G0.12-T9 #1267), every call drives
 // the generated `api.ClientWithResponses` surface directly:
@@ -54,7 +48,6 @@ package docs
 
 import (
 	"context"
-	"encoding/base64"
 	"encoding/json"
 	"errors"
 	"fmt"
@@ -65,163 +58,35 @@ import (
 	"github.com/spf13/cobra"
 
 	"github.com/evoila/meho/cli/internal/api"
-	"github.com/evoila/meho/cli/internal/auth"
 	"github.com/evoila/meho/cli/internal/output"
 )
 
-// Capability is the tenant-provisioned capability key that gates the
-// `meho docs` tree. It is the same key the backend's
-// `_extract_capabilities` surfaces on `Operator.capabilities` and
-// the MCP registry filters `search_docs` visibility on (T1, #1519),
-// kept as a single source of truth so the CLI gate and the server
-// gate agree on the string.
-const Capability = "meho-docs"
-
-// NewRootCmd returns the `meho docs` parent command, gated on the
-// `meho-docs` capability. The command tree compiles into every CLI
-// binary; `provisioned` (resolved from the stored token's JWT
-// capabilities claim) decides whether the parent is visible in
-// `meho --help` and whether its verbs run or refuse.
-//
-// When the tenant lacks the capability the parent is marked Hidden
-// and every leaf RunE short-circuits to a typed
-// `addon_not_provisioned` error (exit 5, the same family as
-// insufficient_role) before any network call. This makes the
-// command genuinely non-runnable for an unprovisioned tenant rather
-// than silently usable, while keeping the gate a UX affordance —
-// the server still enforces the real boundary.
+// NewRootCmd returns the `meho docs` parent command. The command tree
+// compiles into every CLI binary and is always visible: there is no
+// client-side capability gate (#2109). Access is decided server-side
+// by the backplane, identically to `POST /api/v1/search_docs` — the
+// per-collection `meho-docs:<collection>` entitlement is enforced on
+// the route, so an unentitled collection surfaces as a 403 the CLI
+// renders as `insufficient_role`, not a client-side refusal.
 func NewRootCmd() *cobra.Command {
-	provisioned := tenantHasDocsCapability()
-	return newRootCmdWithGate(provisioned)
-}
-
-// newRootCmdWithGate builds the `meho docs` tree with the capability
-// gate forced to a known value. Split out so tests can drive both the
-// provisioned and unprovisioned shapes without seeding a token whose
-// claim decodes to a specific capability set.
-func newRootCmdWithGate(provisioned bool) *cobra.Command {
 	cmd := &cobra.Command{
 		Use:   "docs",
-		Short: "Search the meho-docs vendor-document add-on (provisioned tenants only)",
+		Short: "Search the meho-docs vendor-document add-on",
 		Long: "Operate the meho-docs add-on — backplane-federated " +
-			"retrieval over the external vendor-document corpus. The " +
-			"add-on is a tenant-provisioned capability: when it is not " +
-			"provisioned for your tenant, `meho docs` is hidden from " +
-			"`meho --help` and every verb refuses with a typed " +
-			"`addon_not_provisioned` error. Search routes through the " +
-			"backplane so every query is audited and the mandatory " +
-			"collection scope + per-collection entitlement are enforced " +
-			"centrally.",
-		// Hidden mirrors the absence the Initiative asks for: an
-		// unprovisioned tenant should not see the command in --help.
-		// The verb-level refusal (below) closes the "hidden but still
-		// invokable" gap cobra's Hidden alone leaves open.
-		Hidden:       !provisioned,
+			"retrieval over the external vendor-document corpus. Search " +
+			"routes through the backplane so every query is audited and " +
+			"the mandatory collection scope + per-collection entitlement " +
+			"are enforced centrally, server-side. Access is gated by the " +
+			"per-collection `meho-docs:<collection>` capability the " +
+			"backplane checks on every request — the same gate " +
+			"`POST /api/v1/search_docs` applies — so a collection you " +
+			"cannot search returns a typed 403 rather than a silent or " +
+			"divergent client-side refusal.",
 		SilenceUsage: true,
 	}
-	cmd.AddCommand(newSearchCmd(provisioned))
-	cmd.AddCommand(newCollectionsCmd(provisioned))
+	cmd.AddCommand(newSearchCmd())
+	cmd.AddCommand(newCollectionsCmd())
 	return cmd
-}
-
-// errNotProvisioned is the typed refusal a docs verb returns when the
-// tenant lacks the meho-docs capability. It surfaces as
-// `addon_not_provisioned` (exit 5, the insufficient_role family) so
-// scripts can distinguish "you can't use this add-on" from a missing
-// flag (exit 4) or a transport failure (exit 3).
-func errNotProvisioned(cmd *cobra.Command, jsonOut bool) error {
-	return output.RenderError(
-		cmd.ErrOrStderr(),
-		&output.StructuredError{
-			Code: "addon_not_provisioned",
-			Detail: "the meho-docs add-on is not provisioned for your " +
-				"tenant; ask a tenant_admin to enable the `meho-docs` " +
-				"capability",
-			Exit: output.ExitInsufficientRole,
-		},
-		jsonOut,
-	)
-}
-
-// tenantHasDocsCapability reports whether the operator's stored token
-// carries the meho-docs capability in its JWT `capabilities` claim.
-//
-// Fail-closed: any failure to resolve or decode the token (no login,
-// unreadable store, malformed JWT, absent/garbage claim) returns
-// false, so the command stays hidden + refusing rather than visible.
-// This mirrors the backend's fail-closed `_extract_capabilities`
-// posture (T1, #1519): a missing/garbage capability claim must never
-// be read as a grant.
-//
-// The claim is read **unverified** — the CLI does not hold the realm
-// signing key and does not need it. This is a visibility affordance,
-// not a security check; the backplane re-validates the JWT and the
-// corpus federation enforces the real boundary on every call.
-func tenantHasDocsCapability() bool {
-	cfg, err := auth.LoadConfig()
-	if err != nil || cfg.BackplaneURL == "" {
-		return false
-	}
-	tok, err := loadStoredToken(cfg.BackplaneURL)
-	if err != nil || tok.AccessToken == "" {
-		return false
-	}
-	caps, err := capabilitiesFromJWT(tok.AccessToken)
-	if err != nil {
-		return false
-	}
-	_, ok := caps[Capability]
-	return ok
-}
-
-// loadStoredToken is the token-load seam — split out so docs_test.go
-// can stub it deterministically (the alternative, seeding a keyring /
-// file store with a token whose JWT decodes to a specific capability
-// set, is exercised in an end-to-end test, but the seam keeps the
-// gate's claim-decode logic unit-testable in isolation).
-var loadStoredToken = func(backplaneURL string) (auth.StoredToken, error) {
-	store, err := auth.NewTokenStore()
-	if err != nil {
-		return auth.StoredToken{}, err
-	}
-	service, user := auth.KeyForBackplane(backplaneURL)
-	return store.Load(service, user)
-}
-
-// capabilitiesFromJWT decodes the `capabilities` claim out of a JWT's
-// payload segment and returns it as a set. The token is parsed
-// structurally (split on '.', base64url-decode the payload) — the
-// signature is **not** verified, by design (see
-// tenantHasDocsCapability). Returns an error on any structural
-// failure so the caller can fail closed.
-//
-// The claim is read as a JSON array of strings (the shape the
-// backend's `_extract_capabilities` accepts); a claim that is absent,
-// null, or not an array yields the empty set (no error) so a token
-// minted before the capability mapper existed simply sees no
-// capabilities rather than erroring the whole gate.
-func capabilitiesFromJWT(token string) (map[string]struct{}, error) {
-	parts := strings.Split(token, ".")
-	if len(parts) != 3 {
-		return nil, errors.New("meho: token is not a JWT (expected 3 dot-separated segments)")
-	}
-	payload, err := base64.RawURLEncoding.DecodeString(parts[1])
-	if err != nil {
-		return nil, fmt.Errorf("meho: decode JWT payload: %w", err)
-	}
-	var claims struct {
-		Capabilities []string `json:"capabilities"`
-	}
-	if err := json.Unmarshal(payload, &claims); err != nil {
-		return nil, fmt.Errorf("meho: parse JWT claims: %w", err)
-	}
-	set := make(map[string]struct{}, len(claims.Capabilities))
-	for _, c := range claims.Capabilities {
-		if c != "" {
-			set[c] = struct{}{}
-		}
-	}
-	return set, nil
 }
 
 // errMissingAccessToken mirrors the kb verb tree's sentinel: the

--- a/cli/internal/cmd/docs/search.go
+++ b/cli/internal/cmd/docs/search.go
@@ -26,10 +26,9 @@ import (
 //	meho docs search <query> --collection all                    # fan-out across all
 //
 // Role: operator. Calls POST /api/v1/search_docs (T3, #1552) via the
-// shared authed client (bearer + 401-refresh). `provisioned` carries
-// the meho-docs capability gate resolved at command-tree-build time;
-// when false the verb refuses with a typed `addon_not_provisioned`
-// error before any flag validation or network call.
+// shared authed client (bearer + 401-refresh). There is no client-side
+// capability gate (#2109): access is decided server-side by the
+// backplane, identically to the REST route.
 //
 // --collection is the mandatory binary scope: it routes the query to a
 // backend and gates per-collection entitlement. The CLI fails fast on a
@@ -49,8 +48,9 @@ import (
 //   - 3   unreachable
 //   - 4   unexpected_response (missing --collection, out-of-range
 //     --limit, a 422/503 from the route)
-//   - 5   insufficient_role / addon_not_provisioned
-func newSearchCmd(provisioned bool) *cobra.Command {
+//   - 5   insufficient_role (read_only operator, or a per-collection
+//     entitlement miss the backplane 403s on)
+func newSearchCmd() *cobra.Command {
 	var (
 		collections       []string
 		product           string
@@ -89,7 +89,6 @@ func newSearchCmd(provisioned bool) *cobra.Command {
 				Changed:           cmd.Flags().Changed("limit"),
 				JSONOut:           jsonOut,
 				BackplaneOverride: backplaneOverride,
-				Provisioned:       provisioned,
 			})
 		},
 	}
@@ -128,21 +127,9 @@ type searchOptions struct {
 	Changed           bool
 	JSONOut           bool
 	BackplaneOverride string
-	// Provisioned carries the meho-docs capability gate. When false,
-	// runSearch refuses with the typed addon_not_provisioned error
-	// before touching flags or the network.
-	Provisioned bool
 }
 
 func runSearch(cmd *cobra.Command, opts searchOptions) error {
-	// Capability gate first: an unprovisioned tenant must not be able
-	// to reach the flag validation, let alone the corpus. This closes
-	// the "Hidden but still invokable" gap cobra's Hidden leaves —
-	// the command is hidden from --help AND refuses when invoked by
-	// path.
-	if !opts.Provisioned {
-		return errNotProvisioned(cmd, opts.JSONOut)
-	}
 	if opts.Query == "" {
 		return output.RenderError(
 			cmd.ErrOrStderr(),

--- a/cli/internal/cmd/docs/search_test.go
+++ b/cli/internal/cmd/docs/search_test.go
@@ -6,7 +6,6 @@ package docs
 import (
 	"bytes"
 	"context"
-	"encoding/base64"
 	"encoding/json"
 	"io"
 	"net/http"
@@ -27,24 +26,6 @@ import (
 // *float32 / *string fields on api.DocsChunk.
 func ptrFloat32(v float32) *float32 { return &v }
 func ptrStr(v string) *string       { return &v }
-
-// makeJWT builds an unsigned-looking JWT (header.payload.signature)
-// whose payload carries the given capabilities claim. The signature
-// segment is a throwaway — the CLI decodes the claim unverified, so
-// the fixture never needs a real signature.
-func makeJWT(t *testing.T, capabilities []string) string {
-	t.Helper()
-	header := base64.RawURLEncoding.EncodeToString([]byte(`{"alg":"none","typ":"JWT"}`))
-	payloadJSON, err := json.Marshal(map[string]any{
-		"sub":          "operator-1",
-		"capabilities": capabilities,
-	})
-	if err != nil {
-		t.Fatalf("marshal payload: %v", err)
-	}
-	payload := base64.RawURLEncoding.EncodeToString(payloadJSON)
-	return header + "." + payload + ".sig"
-}
 
 // newRunCmd returns a bare cobra.Command wired with capture buffers
 // and a bounded context — the harness for driving runSearch directly.
@@ -110,138 +91,60 @@ func exitCodeOf(t *testing.T, err error) int {
 	return ec.ExitCode()
 }
 
-// --- capability decode -----------------------------------------------
+// --- gate parity (#2109) ---------------------------------------------
 
-func TestCapabilitiesFromJWTExtractsClaim(t *testing.T) {
-	tok := makeJWT(t, []string{"meho-docs", "other-cap"})
-	caps, err := capabilitiesFromJWT(tok)
-	if err != nil {
-		t.Fatalf("capabilitiesFromJWT: %v", err)
-	}
-	if _, ok := caps["meho-docs"]; !ok {
-		t.Errorf("expected meho-docs in caps; got %v", caps)
-	}
-	if _, ok := caps["other-cap"]; !ok {
-		t.Errorf("expected other-cap in caps; got %v", caps)
-	}
-}
-
-func TestCapabilitiesFromJWTAbsentClaimIsEmptySet(t *testing.T) {
-	// A token with no capabilities claim decodes to the empty set
-	// (no error) — fail-closed without erroring the whole gate.
-	header := base64.RawURLEncoding.EncodeToString([]byte(`{"alg":"none"}`))
-	payload := base64.RawURLEncoding.EncodeToString([]byte(`{"sub":"x"}`))
-	caps, err := capabilitiesFromJWT(header + "." + payload + ".sig")
-	if err != nil {
-		t.Fatalf("absent claim should not error; got %v", err)
-	}
-	if len(caps) != 0 {
-		t.Errorf("expected empty set; got %v", caps)
-	}
-}
-
-func TestCapabilitiesFromJWTRejectsNonJWT(t *testing.T) {
-	if _, err := capabilitiesFromJWT("not-a-jwt"); err == nil {
-		t.Errorf("expected error for non-JWT token")
-	}
-	if _, err := capabilitiesFromJWT("a.!!!.c"); err == nil {
-		t.Errorf("expected error for undecodable payload segment")
-	}
-}
-
-func TestTenantHasDocsCapabilityProvisioned(t *testing.T) {
-	defer stubLoadStoredToken(t, makeJWT(t, []string{"meho-docs"}), nil)()
-	defer stubConfig(t, "https://bp.example")()
-	if !tenantHasDocsCapability() {
-		t.Errorf("expected provisioned tenant to report the capability")
-	}
-}
-
-func TestTenantHasDocsCapabilityUnprovisioned(t *testing.T) {
-	defer stubLoadStoredToken(t, makeJWT(t, []string{"some-other-cap"}), nil)()
-	defer stubConfig(t, "https://bp.example")()
-	if tenantHasDocsCapability() {
-		t.Errorf("expected unprovisioned tenant to lack the capability")
-	}
-}
-
-// stubLoadStoredToken swaps loadStoredToken for a deterministic value
-// and returns a cleanup restoring the production seam.
-func stubLoadStoredToken(t *testing.T, accessToken string, err error) func() {
-	t.Helper()
-	prev := loadStoredToken
-	loadStoredToken = func(string) (auth.StoredToken, error) {
-		return auth.StoredToken{AccessToken: accessToken}, err
-	}
-	return func() { loadStoredToken = prev }
-}
-
-// stubConfig writes a config.json with the given backplane URL into a
-// temp XDG home so auth.LoadConfig resolves a non-empty URL.
-func stubConfig(t *testing.T, backplaneURL string) func() {
-	t.Helper()
-	dir := t.TempDir()
-	t.Setenv("XDG_CONFIG_HOME", dir)
-	if err := auth.SaveConfigAt(
-		filepath.Join(dir, "meho", "config.json"),
-		auth.Config{BackplaneURL: backplaneURL},
-	); err != nil {
-		t.Fatalf("SaveConfigAt: %v", err)
-	}
-	return func() {}
-}
-
-// --- gating shape ----------------------------------------------------
-
-func TestNewRootCmdHiddenWhenUnprovisioned(t *testing.T) {
-	cmd := newRootCmdWithGate(false)
-	if !cmd.Hidden {
-		t.Errorf("expected docs parent Hidden when unprovisioned")
-	}
-}
-
-func TestNewRootCmdVisibleWhenProvisioned(t *testing.T) {
-	cmd := newRootCmdWithGate(true)
+// TestNewRootCmdAlwaysVisible asserts the `meho docs` tree carries no
+// client-side capability gate: it is never Hidden, so it appears in
+// `meho --help` regardless of the operator's capabilities. Access is
+// decided server-side, identically to POST /api/v1/search_docs (#2109).
+func TestNewRootCmdAlwaysVisible(t *testing.T) {
+	cmd := NewRootCmd()
 	if cmd.Hidden {
-		t.Errorf("expected docs parent visible when provisioned")
+		t.Errorf("expected docs parent always visible (no client-side capability gate)")
+	}
+	for _, sub := range cmd.Commands() {
+		if sub.Hidden {
+			t.Errorf("expected docs subcommand %q always visible; got Hidden", sub.Name())
+		}
 	}
 }
 
-func TestRunSearchRefusesWhenUnprovisioned(t *testing.T) {
-	cmd, _, stderr := newRunCmd(t)
-	err := runSearch(cmd, searchOptions{
-		Query:       "x",
-		Collections: []string{"vmware"},
-		Provisioned: false,
-	})
-	if err == nil {
-		t.Fatalf("expected refusal for unprovisioned tenant")
-	}
-	if got := exitCodeOf(t, err); got != output.ExitInsufficientRole {
-		t.Errorf("expected exit %d; got %d", output.ExitInsufficientRole, got)
-	}
-	if !strings.Contains(stderr.String(), "addon_not_provisioned") {
-		t.Errorf("expected addon_not_provisioned code; got %q", stderr.String())
-	}
-}
+// TestRunSearchNoClientSideGate asserts `meho docs search` no longer
+// short-circuits on a client-side capability pre-check: it proceeds to
+// the same network call the REST surface makes, so the server is the
+// single gate. Pointing at a running stub that would 403 an unentitled
+// collection, the CLI surfaces the *server's* verdict (insufficient_role
+// from the route's not_entitled 403) rather than a client-side
+// addon_not_provisioned refusal — proving CLI ↔ REST gate parity.
+func TestRunSearchNoClientSideGate(t *testing.T) {
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
+		// The route's per-collection entitlement miss: a structured 403
+		// with the not_entitled detail (search_docs.py ~line 260).
+		w.Header().Set("Content-Type", "application/json")
+		w.WriteHeader(http.StatusForbidden)
+		_, _ = io.WriteString(w, `{"detail":{"error":"not_entitled",`+
+			`"collection":"vmware","required_capability":"meho-docs:vmware",`+
+			`"operator_sub":"op-1","tenant_id":"t-1","message":"not entitled"}}`)
+	}))
+	defer srv.Close()
+	seedXDGAndToken(t, srv.URL, "eyJ.test.token")
 
-func TestRunSearchRefusalIsBeforeNetwork(t *testing.T) {
-	// An unprovisioned refusal must short-circuit before any HTTP
-	// call. Point at an unroutable URL: if the refusal fired first,
-	// no connection is attempted and the error is the typed refusal,
-	// not an unreachable.
 	cmd, _, stderr := newRunCmd(t)
 	err := runSearch(cmd, searchOptions{
 		Query:             "x",
 		Collections:       []string{"vmware"},
-		Provisioned:       false,
-		BackplaneOverride: "http://127.0.0.1:0",
+		BackplaneOverride: srv.URL,
 	})
 	if err == nil {
-		t.Fatalf("expected refusal")
+		t.Fatalf("expected the server's 403 to surface as an error")
 	}
-	if !strings.Contains(stderr.String(), "addon_not_provisioned") {
-		t.Errorf("expected refusal before network; got %q", stderr.String())
+	// The verdict is the server's (insufficient_role from the route),
+	// NOT a client-side addon_not_provisioned pre-check.
+	if got := exitCodeOf(t, err); got != output.ExitInsufficientRole {
+		t.Errorf("expected exit %d (server 403); got %d", output.ExitInsufficientRole, got)
+	}
+	if strings.Contains(stderr.String(), "addon_not_provisioned") {
+		t.Errorf("client-side capability gate must be gone; got %q", stderr.String())
 	}
 }
 
@@ -249,7 +152,7 @@ func TestRunSearchRefusalIsBeforeNetwork(t *testing.T) {
 
 func TestRunSearchRejectsEmptyQuery(t *testing.T) {
 	cmd, _, stderr := newRunCmd(t)
-	err := runSearch(cmd, searchOptions{Query: "", Collections: []string{"vmware"}, Provisioned: true})
+	err := runSearch(cmd, searchOptions{Query: "", Collections: []string{"vmware"}})
 	if err == nil {
 		t.Fatalf("expected error for empty query")
 	}
@@ -260,7 +163,7 @@ func TestRunSearchRejectsEmptyQuery(t *testing.T) {
 
 func TestRunSearchRejectsMissingCollection(t *testing.T) {
 	cmd, _, stderr := newRunCmd(t)
-	err := runSearch(cmd, searchOptions{Query: "x", Provisioned: true})
+	err := runSearch(cmd, searchOptions{Query: "x"})
 	if err == nil {
 		t.Fatalf("expected error for missing --collection")
 	}
@@ -274,7 +177,7 @@ func TestRunSearchRejectsMissingCollection(t *testing.T) {
 
 func TestRunSearchRejectsOutOfRangeLimit(t *testing.T) {
 	cmd, _, stderr := newRunCmd(t)
-	err := runSearch(cmd, searchOptions{Query: "x", Collections: []string{"vmware"}, Limit: 51, Provisioned: true})
+	err := runSearch(cmd, searchOptions{Query: "x", Collections: []string{"vmware"}, Limit: 51})
 	if err == nil {
 		t.Fatalf("expected error for over-budget limit")
 	}
@@ -287,7 +190,7 @@ func TestRunSearchRejectsExplicitZeroLimit(t *testing.T) {
 	cmd, _, stderr := newRunCmd(t)
 	err := runSearch(cmd, searchOptions{
 		Query: "x", Collections: []string{"vmware"},
-		Limit: 0, Changed: true, Provisioned: true,
+		Limit: 0, Changed: true,
 	})
 	if err == nil {
 		t.Fatalf("expected error for explicit --limit=0")
@@ -328,7 +231,7 @@ func TestRunSearchHappyPath(t *testing.T) {
 	cmd, stdout, stderr := newRunCmd(t)
 	err := runSearch(cmd, searchOptions{
 		Query: "nsx config maximums", Collections: []string{"vmware"}, Product: "nsx", Version: "9.0",
-		Provisioned: true, BackplaneOverride: srv.URL,
+		BackplaneOverride: srv.URL,
 	})
 	if err != nil {
 		t.Fatalf("runSearch: %v; stderr=%s", err, stderr.String())
@@ -375,7 +278,7 @@ func TestRunSearchOmitsAbsentRefinements(t *testing.T) {
 	cmd, _, stderr := newRunCmd(t)
 	if err := runSearch(cmd, searchOptions{
 		Query: "x", Collections: []string{"vmware"},
-		Provisioned: true, BackplaneOverride: srv.URL,
+		BackplaneOverride: srv.URL,
 	}); err != nil {
 		t.Fatalf("runSearch: %v; stderr=%s", err, stderr.String())
 	}
@@ -406,7 +309,7 @@ func TestRunSearchSendsLimitWhenSet(t *testing.T) {
 	cmd, _, _ := newRunCmd(t)
 	if err := runSearch(cmd, searchOptions{
 		Query: "x", Collections: []string{"vmware"},
-		Limit: 25, Provisioned: true, BackplaneOverride: srv.URL,
+		Limit: 25, BackplaneOverride: srv.URL,
 	}); err != nil {
 		t.Fatalf("runSearch: %v", err)
 	}
@@ -428,7 +331,7 @@ func TestRunSearchZeroHits(t *testing.T) {
 	cmd, stdout, _ := newRunCmd(t)
 	if err := runSearch(cmd, searchOptions{
 		Query: "obscure", Collections: []string{"vmware"},
-		Provisioned: true, BackplaneOverride: srv.URL,
+		BackplaneOverride: srv.URL,
 	}); err != nil {
 		t.Fatalf("runSearch: %v", err)
 	}
@@ -460,7 +363,7 @@ func TestRunSearchJSONHappyPath(t *testing.T) {
 	cmd, stdout, _ := newRunCmd(t)
 	if err := runSearch(cmd, searchOptions{
 		Query: "x", Collections: []string{"vmware"},
-		JSONOut: true, Provisioned: true, BackplaneOverride: srv.URL,
+		JSONOut: true, BackplaneOverride: srv.URL,
 	}); err != nil {
 		t.Fatalf("runSearch: %v", err)
 	}
@@ -492,7 +395,7 @@ func TestRunSearchRendersAbsentScoreAsDash(t *testing.T) {
 	cmd, stdout, _ := newRunCmd(t)
 	if err := runSearch(cmd, searchOptions{
 		Query: "x", Collections: []string{"vmware"},
-		Provisioned: true, BackplaneOverride: srv.URL,
+		BackplaneOverride: srv.URL,
 	}); err != nil {
 		t.Fatalf("runSearch: %v", err)
 	}
@@ -567,7 +470,7 @@ func assertStatusMapping(t *testing.T, status int, body string, wantExit int, wa
 	cmd, _, stderr := newRunCmd(t)
 	err := runSearch(cmd, searchOptions{
 		Query: "x", Collections: []string{"vmware"},
-		Provisioned: true, BackplaneOverride: srv.URL,
+		BackplaneOverride: srv.URL,
 	})
 	if err == nil {
 		t.Fatalf("expected error for HTTP %d", status)
@@ -583,7 +486,7 @@ func assertStatusMapping(t *testing.T, status int, body string, wantExit int, wa
 // --- command wiring --------------------------------------------------
 
 func TestSearchCmdRequiresExactlyOneArg(t *testing.T) {
-	cmd := newSearchCmd(true)
+	cmd := newSearchCmd()
 	var stdout, stderr bytes.Buffer
 	cmd.SetOut(&stdout)
 	cmd.SetErr(&stderr)
@@ -650,7 +553,6 @@ func TestRunSearchRejectsAllMixedWithKeys(t *testing.T) {
 	err := runSearch(cmd, searchOptions{
 		Query:       "q",
 		Collections: []string{"all", "vmware"},
-		Provisioned: true,
 	})
 	if err == nil {
 		t.Fatalf("expected error mixing 'all' with explicit keys")
@@ -681,7 +583,6 @@ func TestRunSearchFanoutRendersProvenanceColumn(t *testing.T) {
 	err := runSearch(cmd, searchOptions{
 		Query:             "q",
 		Collections:       []string{"vmware", "netapp"},
-		Provisioned:       true,
 		BackplaneOverride: srv.URL,
 	})
 	if err != nil {

--- a/cli/internal/cmd/root.go
+++ b/cli/internal/cmd/root.go
@@ -166,12 +166,11 @@ func newRootCmd() *cobra.Command {
 	// (the meho-docs add-on). One verb: `docs search` wraps the
 	// /api/v1/search_docs route (T3, #1521) for federated
 	// vendor-document retrieval. The tree compiles into every binary
-	// but is gated on the tenant-provisioned `meho-docs` capability
-	// (T1, #1519): `docs.NewRootCmd` reads the capability from the
-	// stored token's JWT claim and, when absent, marks the parent
-	// Hidden and makes every verb refuse with a typed
-	// `addon_not_provisioned` error — true absence for an
-	// unprovisioned tenant. Registered before
+	// and carries no client-side capability gate (#2109): access is
+	// decided server-side by the backplane, identically to the REST
+	// route, so the same `(query, collection, tenant)` gets the same
+	// verdict on either surface (a per-collection entitlement miss is a
+	// 403 the CLI renders as `insufficient_role`). Registered before
 	// registerDynamicSubcommands so the backplane manifest cannot
 	// shadow the built-in `docs` parent.
 	root.AddCommand(docs.NewRootCmd())

--- a/docs/codebase/docs-search.md
+++ b/docs/codebase/docs-search.md
@@ -554,48 +554,45 @@ to retrieve. CSRF double-submit gated like the search fragment.
 The operator-facing CLI verb. `meho docs search <query> --collection <c>
 [--product <p>] [--version <v>] [--limit N] [--json]` POSTs to
 `/api/v1/search_docs` via the shared generated authed client (bearer +
-lazy 401-refresh), mirrors the route's collection gate client-side (a
-missing `--collection` is rejected before the round-trip; `--product` /
-`--version` are optional refinements), maps the 403 (not entitled) / 409
-(not ready) / 422 (unknown collection) statuses, and renders the cited
-chunks as a text table or raw JSON. It consumes the generated
-`api.SearchDocsRequest` / `api.SearchDocsResponse` / `api.DocsChunk`
-types directly — no hand-typed copies of the backend schemas.
+lazy 401-refresh), fails fast on a missing `--collection` before the
+round-trip (`--product` / `--version` are optional refinements), maps
+the 403 (not entitled) / 409 (not ready) / 422 (unknown collection)
+statuses, and renders the cited chunks as a text table or raw JSON. It
+consumes the generated `api.SearchDocsRequest` / `api.SearchDocsResponse`
+/ `api.DocsChunk` types directly — no hand-typed copies of the backend
+schemas.
 
-**Gating — true absence when unprovisioned.** The `meho docs` tree
-compiles into every CLI binary, but it is gated on the tenant's
-`meho-docs` capability (the same capability T1 gates the MCP tool on).
-The CLI reads the `capabilities` claim from the stored bearer JWT at
-command-tree-build time and:
+**Gating — server-side only, CLI ↔ REST parity (#2109).** The `meho
+docs` tree compiles into every CLI binary and is **always** visible;
+it carries **no client-side capability pre-check**. Access is decided
+server-side by the backplane, identically to `POST /api/v1/search_docs`:
+the route enforces the per-collection `meho-docs:<collection>`
+entitlement (a miss is a 403 `not_entitled` the CLI renders as
+`insufficient_role`, exit 5) and the operator / tenant_admin role. The
+CLI is a thin shell over the same route the REST surface exposes, so the
+same `(query, collection, tenant)` gets the same verdict on either
+surface — the unstated CLI ↔ REST parity contract now holds by
+construction.
 
-- shows `meho docs` in `meho --help` and runs its verbs only when the
-  claim contains `meho-docs`;
-- otherwise marks the parent `Hidden` and makes every verb refuse with
-  a typed `addon_not_provisioned` error (exit 5) before any network
-  call.
+**Why the client-side gate was removed.** An earlier shape (option B)
+read the bare `meho-docs` capability out of the stored JWT at
+command-tree-build time and, when absent, marked the tree `Hidden` and
+refused every verb with a typed `addon_not_provisioned` (exit 5) before
+any network call. That gate had **no counterpart on the REST route**:
+`POST /api/v1/search_docs` never checks the bare `meho-docs` capability
+— only the per-collection `meho-docs:<collection>` one (see
+`_resolve_collection_or_http_error` → `resolve_entitled_ready_collection`).
+So the two surfaces diverged — a tenant entitled to a collection via
+REST could still hit `addon_not_provisioned` on the CLI, and a CLI-shaped
+verification probe mis-reported a contract the REST endpoint implemented
+correctly. #2109 recorded the operator decision (option A): reconcile to
+one server-gated op. The client-side pre-check (the `Capability` const,
+`tenantHasDocsCapability`, `capabilitiesFromJWT`, `errNotProvisioned`,
+and the `provisioned` / `Provisioned` plumbing) is gone; the backplane
+is the single gate. The static `required_capability="meho-docs"` gate on
+the **MCP tool** is a separate surface (tool *visibility*) and is
+unchanged — it was never part of the REST/CLI asymmetry.
 
-The claim is decoded **unverified** — the CLI holds no realm signing
-key and needs none. This is a visibility affordance, not a security
-boundary: the backplane re-validates the JWT on every request and the
-corpus federation enforces the real boundary, so a forged claim can
-change only what the CLI *shows*, never what the server *allows*.
-Reading an unverified claim is safe precisely because the gate never
-grants access on its own; it is fail-closed (no login / unreadable
-store / malformed token → not provisioned), mirroring the backend's
-fail-closed `_extract_capabilities`.
-
-**Why not the server-driven discovery channel.** True per-tenant
-absence via `discovery.Fetch` → `GET /api/v1/commands` was the
-preferred shape on paper, but the discovery channel is anonymous by
-design (it never imports `internal/api` / `internal/auth` and fetches
-before login produces a token) and its `Register` only grafts *stub*
-commands ("not yet implemented locally") — it cannot toggle the
-visibility of a real compiled-in implementation per tenant. A
-tenant-filtered manifest would contradict that anonymous contract and
-require a new authenticated backend route plus an OpenAPI snapshot
-regen. The compiled-in + claim-probe shape achieves the same operator-
-visible outcome (absent from `--help`, non-runnable) without a backend
-change.
 ### `search_docs` MCP tool (`meho_backplane.mcp.tools.docs`, T4 #1523)
 
 The agent-facing face. Registered against the G0.5 MCP registry,

--- a/docs/cross-repo/meho-docs-addon.md
+++ b/docs/cross-repo/meho-docs-addon.md
@@ -147,10 +147,12 @@ setting `JWT_CAPABILITIES_CLAIM_NAME` (default `capabilities`).
 The capability set is a **flat list of string keys**. Two kinds of key
 matter here:
 
-- **`meho-docs`** — the **add-on key**. Gates the *surface*: a tenant
-  without it never sees `search_docs` / `ask_docs` /
-  `list_doc_collections` in `tools/list` (true absence) and `meho docs`
-  is hidden from `--help`.
+- **`meho-docs`** — the **add-on key**. Gates the *MCP tool surface*: a
+  tenant without it never sees `search_docs` / `ask_docs` /
+  `list_doc_collections` in `tools/list` (true absence). It does **not**
+  gate the CLI: `meho docs` always appears in `--help` (#2109 removed the
+  client-side CLI pre-check so the CLI and `POST /api/v1/search_docs`
+  apply the same server-side gate — see below).
 - **`meho-docs:<collection_key>`** — a **per-collection entitlement key**,
   one per collection the tenant may search (e.g. `meho-docs:vmware`).
   Reuses the same capability substrate — zero new tables; the JWT parser
@@ -634,15 +636,16 @@ Every error path collapses to **one** typed `CorpusUnavailable`, which the
 
 Prove the add-on end-to-end. The contract is: an entitled collection is
 **discoverable and returns cited chunks on a provisioned, entitled tenant;
-absent (not greyed-out) on an unprovisioned or unentitled one; and every
-query is audited under `meho.docs.*` with its collection scope**.
+absent on the MCP face (true tool absence) and server-403'd on the
+REST/CLI face for an unprovisioned or unentitled one; and every query is
+audited under `meho.docs.*` with its collection scope**.
 
 ### Present + cited chunks (provisioned, entitled tenant)
 
 CLI (operator logged in as a tenant entitled to `vmware`):
 
 ```bash
-# meho docs appears in --help only when the tenant has the add-on:
+# meho docs always appears in --help (no client-side gate; #2109):
 meho --help | grep -A1 '  docs'
 
 # The entitled collection is in the catalogue:
@@ -664,29 +667,36 @@ MCP face (an agent session against the same tenant):
   `meho://docs/vmware/{product}/{version}/{chunk_id}` returns the full
   text of a hit.
 
-### Absent (unprovisioned or unentitled tenant)
+### Unprovisioned or unentitled tenant
 
-For a tenant **without** the `meho-docs` add-on, the surface tells the
-truth — it is absent, not greyed-out:
+The **CLI** carries no client-side capability gate (#2109): `meho docs`
+always appears in `--help` and every verb runs, deferring the access
+decision to the backplane — exactly as `POST /api/v1/search_docs` does.
+So an unentitled query surfaces the **server's** verdict rather than a
+client-side refusal:
 
 ```bash
-# meho docs is hidden from --help...
-meho --help | grep -c '  docs'        # -> 0
+# meho docs is always in --help (no client-side gate):
+meho --help | grep -c '  docs'        # -> 1
 
-# ...and every verb refuses with a typed error before any network call:
+# A query for a collection the tenant is not entitled to reaches the
+# route and surfaces the server's 403 (not_entitled), rendered as
+# insufficient_role (exit 5) — the same gate REST applies:
 meho docs search "anything" --collection vmware
-# -> addon_not_provisioned (exit 5): the meho-docs add-on is not
-#    provisioned for your tenant; ask a tenant_admin to enable the
-#    `meho-docs` capability
+# -> insufficient_role (exit 5): identity <sub> (tenant <id>) is not
+#    entitled to doc collection 'vmware': missing capability
+#    'meho-docs:vmware'
 ```
 
-For a tenant **with** the add-on but **without** `meho-docs:vmware`, the
-`vmware` collection is a **true absence** in the catalogue and the band
+On the **MCP face**, the base `meho-docs` add-on key still gates *tool
+visibility*: a tenant without it never sees `search_docs` / `ask_docs` /
+`list_doc_collections` in `tools/list` (true absence). For a tenant
+**with** the add-on but **without** `meho-docs:vmware`, the `vmware`
+collection is a **true absence** in the catalogue and the band
 (`list_doc_collections` does not list it), and a direct
 `search_docs(collection="vmware")` is rejected **403** / `-32602` — the
-collection exists, but the tenant is not entitled. On the MCP face, the
-add-on tools are still in `tools/list` (the base `meho-docs` gate passes);
-only the unentitled *collection* is absent.
+collection exists, but the tenant is not entitled. That per-collection
+403 is the **same** gate the REST route and the CLI apply.
 
 ### Audit row visible (who-touched)
 


### PR DESCRIPTION
## Summary
- `meho docs search` (CLI) and `POST /api/v1/search_docs` (REST) diverged: the CLI keyed visibility on a **client-side** bare-`meho-docs` capability pre-check (decoded from the stored JWT) that hid the whole `docs` tree and refused every verb with `addon_not_provisioned` (exit 5) before any network call. The REST route has **no such gate** — it only enforces the per-collection `meho-docs:<collection>` entitlement server-side. A tenant entitled to a collection via REST could still hit `addon_not_provisioned` on the CLI.
- Per the recorded operator decision on #2109 (**Option A — reconcile to one server-gated op**), this removes the client-side pre-check entirely. The `docs` tree is now always visible and every verb defers to the backplane, identically to REST: a per-collection entitlement miss surfaces as the route's `not_entitled` 403, which the CLI already renders as `insufficient_role` (exit 5). No divergent client-side gate remains.
- Removed: `Capability` const, `tenantHasDocsCapability`, `capabilitiesFromJWT`, `loadStoredToken`, `errNotProvisioned`, and the `provisioned` / `Provisioned` plumbing across the search + collections verbs. The static `required_capability="meho-docs"` gate on the **MCP tool** (a separate tool-visibility surface, explicitly out of scope in the issue) is unchanged.
- Docs updated: `docs/codebase/docs-search.md`, `docs/cross-repo/meho-docs-addon.md`, `cli/README.md`.

## Test plan
- [x] `go build ./...` (cli) — clean
- [x] `go vet ./internal/cmd/docs/` — clean
- [x] `gofmt -l` — clean
- [x] `go test ./...` (cli) — all packages pass, incl. `internal/cmd/docs`
- [x] **AC2** — CLI no longer keys on bare `meho-docs`; both surfaces defer to the per-collection server gate (verified: `docs.go` / `search.go` / `collections*.go` carry no capability pre-check).
- [x] **AC3** — parity test `TestRunSearchNoClientSideGate` asserts an unentitled-collection 403 (`not_entitled`) from the route surfaces as `insufficient_role` (exit 5), **not** a client-side `addon_not_provisioned`; `TestNewRootCmdAlwaysVisible` / `TestCollectionsCmdAlwaysVisible` assert the tree is never `Hidden`.
- [x] **AC5** — unentitled-case error envelope reconciled: the CLI surfaces the route's `not_entitled` 403 as `insufficient_role` exit 5 (pre-existing `renderHTTPStatus` mapping); `addon_not_provisioned` is gone. Documented in all three docs.

## Design note (intent vs bug)
Grounding confirmed the issue's premise exactly: the REST route (`search_docs.py` → `_resolve_collection_or_http_error` → `resolve_entitled_ready_collection`) never checks the bare `meho-docs` capability, only `meho-docs:<collection>`; the CLI's client-side bare-capability gate had no server-side counterpart. This is a real, unambiguous inconsistency with a recorded operator decision (Option A), so it was implemented rather than pushed back.

## Out of scope
- The `meho-docs` addon provisioning model (per the issue).
- MCP tool `search_docs` capability gating (separate tool-visibility surface; unchanged).

<!-- auto-implement-issue: fresh, iteration 1 -->

Closes #2109
