### PR TITLE
fix(ui): document runbooks-UI abort CSRF gate + surface CSRF-403 and soft-failed admin lift (#2112)

### DIFF
--- a/backend/src/meho_backplane/ui/routes/runbooks/driver.py
+++ b/backend/src/meho_backplane/ui/routes/runbooks/driver.py
@@ -81,6 +81,21 @@ on the same response -- refreshes the ``meho_csrf`` cookie (the cookie/
 header desync footgun #1693). The render layer in :mod:`.driver_render`
 owns the mint + cookie refresh.
 
+Every state-changing POST here (``/next`` / ``/abort`` / ``/reassign``)
+REQUIRES the double-submit token: the ``meho_csrf`` cookie AND an
+``X-CSRF-Token`` header (or ``csrf_token`` form field). A request missing
+either half is rejected by the middleware with ``403``
+``{"detail":"csrf_token_invalid"}`` + an ``x-csrf-rejection-reason``
+header -- BY DESIGN, before this handler runs. ``/api/v1/*`` is CSRF-exempt,
+so a raw-curl repro sending a Bearer JWT but no ``meho_csrf`` cookie gets a
+``403`` on ``/ui/.../abort`` while the same call to
+``/api/v1/.../abort`` succeeds: that differential is the CSRF gate, NOT an
+RBAC/opacity difference (this abort route is on the SAME operator floor as
+REST -- see ``_abort`` below -- and a genuine assignee RBAC denial renders
+an inline HTTP-200 fragment, never a ``403``). The run-starter CAN abort
+their own run from the browser, which carries the cookie/header. Consumer
+note + repro guidance: ``docs/codebase/ui.md`` (#2112).
+
 References
 ----------
 

--- a/backend/src/meho_backplane/ui/routes/runbooks/routes.py
+++ b/backend/src/meho_backplane/ui/routes/runbooks/routes.py
@@ -381,9 +381,24 @@ async def _render_detail(
     renders (never a raw 403). A missing slug 404s for an admin and
     collapses to the restricted state for an operator -- the same
     anti-enumeration posture the REST ``show`` route uses.
+
+    Soft-fail visibility (#2112). :func:`_resolve_role` returns the resolved
+    :class:`Operator` on a clean lift (admin or plain operator) and ``None``
+    ONLY on a degraded lift -- a JWKS hiccup, a session-reload miss, a
+    malformed stored token, or a token/session identity mismatch. A genuine
+    plain operator therefore always yields a non-``None`` operator, so
+    ``operator is None`` uniquely marks "the role lift could not complete"
+    -- the exact state that used to drop a genuine ``tenant_admin`` onto the
+    restricted banner with no signal (they read it as "the promised admin
+    bypass doesn't exist"). We thread that as ``admin_lift_degraded`` so the
+    restricted view can surface a diagnostic affordance (a note + a retry)
+    instead of silently downgrading. A terminal ``session_expired`` never
+    reaches here -- :func:`_resolve_role` re-raises it to the app-level
+    re-auth redirect (#2114).
     """
     operator = await _resolve_role(session)
     is_admin = operator is not None and operator.tenant_role == TenantRole.TENANT_ADMIN
+    admin_lift_degraded = operator is None
     detail = await _resolve_detail(session, slug, version, is_admin=is_admin)
     csrf_token = mint_csrf_token(str(session.session_id))
     # The fork-on-edit affordance surfaces how many runs are still pinned to a
@@ -401,6 +416,7 @@ async def _render_detail(
         "steps_rendered": detail.steps_rendered,
         "code_css": pygments_css(),
         "is_admin": is_admin,
+        "admin_lift_degraded": admin_lift_degraded,
         "in_flight_run_count": in_flight_run_count,
         "lifecycle_error": None,
         "swap_badge": False,

--- a/backend/src/meho_backplane/ui/static/src/app/session-expiry.js
+++ b/backend/src/meho_backplane/ui/static/src/app/session-expiry.js
@@ -1,7 +1,7 @@
 // SPDX-License-Identifier: Apache-2.0
 // Copyright (c) 2026 evoila Group
 //
-// App-shell session-expiry safety net (#122).
+// App-shell session-expiry + CSRF-rejection safety net (#122, #2112).
 //
 // When a ``/ui/*`` htmx request (``hx-get`` / ``hx-post``) returns ``401``
 // mid-session, htmx 2.0.9 silently swallows it: the default
@@ -15,9 +15,28 @@
 // the ``ui.auth.errors`` handler returns the JSON 401 body rather than the
 // HTML login redirect -- the browser sees a swallowed error, not a page).
 //
-// This module is the client-side last-resort recovery path: any ``401`` on
-// an htmx request surfaces a visible banner ("your session expired -- sign
-// in again") with a button to ``/ui/auth/login?return_to=<current path>``.
+// The same swallow-on-4xx behaviour hides the CSRF middleware's ``403``
+// (#2112). A state-changing ``/ui/*`` POST whose ``meho_csrf`` double-submit
+// cookie was dropped or aged out (the browser rarely hits this because every
+// fragment render re-mints the cookie, but a stale tab or a cookie-cleared
+// session can) gets a bare ``{"detail":"csrf_token_invalid"}`` JSON body at
+// ``403`` that htmx will not swap -- so an operator aborting their own
+// runbook run saw a dead button with no message. Returning an HTML fragment
+// from the pure-ASGI middleware would not help: htmx 2.0.9 does not swap 4xx
+// bodies (``{code:"[45]..", swap:false, error:true}`` in the vendored
+// bundle). The client is the only place that can surface it. The middleware
+// stamps every CSRF rejection with an ``x-csrf-rejection-reason`` response
+// header (``missing_token`` / ``value_mismatch`` / ``signature_invalid`` /
+// ``no_session``); that header is the discriminator -- an RBAC ``403`` (e.g.
+// ``require_ui_admin`` on reassign) carries no such header and flows through
+// untouched.
+//
+// This module is the client-side last-resort recovery path:
+//   * any ``401`` -> a "your session expired -- sign in again" banner with a
+//     button to ``/ui/auth/login?return_to=<current path>``.
+//   * a ``403`` carrying ``x-csrf-rejection-reason`` -> a "your session
+//     token expired -- refresh the page and retry" banner with a reload
+//     button (a fresh render re-mints the ``meho_csrf`` cookie).
 // It is the safety net (Axis B); the server-side refresh seam (#1694, and
 // the sibling #121) reduces how *often* a 401 occurs (Axis A). Both land.
 //
@@ -25,14 +44,15 @@
 // errors) before any swap, redirect-header handling, or ``responseError``,
 // and ``preventDefault()`` on it aborts htmx's entire response processing
 // for that request (vendored htmx 2.0.9: ``Vn()`` returns early when the
-// event helper reports the default was prevented). We act ONLY on status
-// ``401`` -- every other status (a ``2xx`` swap, a ``422`` form-validation
-// re-render, a ``403`` CSRF error a form's ``hx-on::response-error`` handles)
-// flows through untouched, so legitimate non-auth responses are never
-// hijacked. Chosen over ``htmx.config.responseHandling`` (which would
-// reclassify status codes app-wide and risk the finely-tuned 4xx swap
-// behaviour the connectors/agents/kb form modals depend on -- #875, forms.py
-// 422 re-render) precisely because it is surgical: one status, one action.
+// event helper reports the default was prevented). We act ONLY on a ``401``
+// or a CSRF-rejection ``403`` -- every other status (a ``2xx`` swap, a
+// ``422`` form-validation re-render, a bare RBAC ``403`` a form's
+// ``hx-on::response-error`` handles) flows through untouched, so legitimate
+// non-auth responses are never hijacked. Chosen over
+// ``htmx.config.responseHandling`` (which would reclassify status codes
+// app-wide and risk the finely-tuned 4xx swap behaviour the
+// connectors/agents/kb form modals depend on -- #875, forms.py 422 re-render)
+// precisely because it is surgical: two narrow triggers, one action each.
 //
 // Registered via a plain ``htmx:beforeOnLoad`` listener on ``document.body``
 // (htmx events bubble to the body -- the same delegation pattern
@@ -43,7 +63,7 @@
 // first-party JS (no Alpine, no inline script) to preserve the chassis
 // "zero inline script" CSP posture, mirroring ``theme.js`` / ``modal-dialogs.js``.
 //
-// Idempotent banner: the recovery banner is created once and reused -- a
+// Idempotent banners: each recovery banner is created once and reused -- a
 // burst of failing background polls (the approvals badge, an SSE reconnect)
 // all hitting 401 must not stack N banners. ``preventDefault()`` also stops
 // the dead swap, so the operator's current view stays intact behind the
@@ -64,50 +84,106 @@
   }
 
   var BANNER_ID = "meho-session-expired-banner";
+  var CSRF_BANNER_ID = "meho-csrf-rejected-banner";
 
-  // Create (once) and reveal the recovery banner. Returns the existing node
-  // on every call after the first so repeated 401s never stack banners.
-  function showBanner() {
-    var existing = document.getElementById(BANNER_ID);
+  // The custom response header the CSRF middleware stamps on every rejection
+  // (``ui/csrf.py`` ``_forbidden_response``). Its presence -- not the bare
+  // ``403`` status -- is what distinguishes a CSRF rejection from an RBAC
+  // ``403`` (``require_ui_admin``), so this net never hijacks a genuine
+  // permission denial.
+  var CSRF_REASON_HEADER = "x-csrf-rejection-reason";
+
+  // Create (once) and reveal a fixed recovery banner. Returns the existing
+  // node on every call after the first so a burst of failing requests never
+  // stacks N banners.
+  function showBanner(id, messageText, actionText, actionHref) {
+    var existing = document.getElementById(id);
     if (existing) {
       return existing;
     }
     var banner = document.createElement("div");
-    banner.id = BANNER_ID;
+    banner.id = id;
     banner.setAttribute("role", "alert");
     banner.setAttribute("aria-live", "assertive");
     // Fixed, top-centered, above every surface (the approvals modal sits at
     // ``z-50``; the drawer sidebar at ``z-40``) so the recovery path is never
-    // occluded by whatever was on screen when the session died.
+    // occluded by whatever was on screen when the request failed.
     banner.className =
       "alert alert-error fixed top-3 left-1/2 z-[60] w-[min(36rem,calc(100vw-1.5rem))] " +
       "-translate-x-1/2 shadow-xl";
     var message = document.createElement("span");
     message.className = "flex-1";
-    message.textContent = "Your session expired — please sign in again.";
+    message.textContent = messageText;
     var action = document.createElement("a");
     action.className = "btn btn-sm";
-    action.href = loginUrl();
-    action.textContent = "Sign in";
+    action.href = actionHref;
+    action.textContent = actionText;
     banner.appendChild(message);
     banner.appendChild(action);
     document.body.appendChild(banner);
     return banner;
   }
 
-  // The single global handler. Acts ONLY on a 401; returns immediately for
-  // every other status so normal swaps and non-auth 4xx/5xx handling are
+  // Reveal the session-expiry recovery banner (a 401).
+  function showSessionExpiredBanner() {
+    return showBanner(
+      BANNER_ID,
+      "Your session expired — please sign in again.",
+      "Sign in",
+      loginUrl(),
+    );
+  }
+
+  // Reveal the CSRF-rejection recovery banner (a 403 carrying the
+  // rejection-reason header). The action reloads the current page: a fresh
+  // authenticated render re-mints the ``meho_csrf`` cookie, so the retried
+  // action then clears the double-submit check.
+  function showCsrfRejectedBanner() {
+    var here = window.location.pathname + window.location.search;
+    return showBanner(
+      CSRF_BANNER_ID,
+      "Your session token expired — refresh the page and retry.",
+      "Refresh",
+      here,
+    );
+  }
+
+  // Return the CSRF-rejection reason header if this response is one, else
+  // ``null``. ``getResponseHeader`` reads same-origin custom headers without
+  // a CORS allow-list (the console is same-origin), and returns ``null`` when
+  // the header is absent.
+  function csrfRejectionReason(xhr) {
+    if (!xhr || typeof xhr.getResponseHeader !== "function") {
+      return null;
+    }
+    return xhr.getResponseHeader(CSRF_REASON_HEADER);
+  }
+
+  // The single global handler. Acts ONLY on a 401 or a CSRF-rejection 403;
+  // returns immediately for every other status (and for a bare RBAC 403 with
+  // no rejection header) so normal swaps and non-auth 4xx/5xx handling are
   // byte-for-byte unchanged.
   function onBeforeOnLoad(event) {
     var xhr = event && event.detail && event.detail.xhr;
-    if (!xhr || xhr.status !== 401) {
+    if (!xhr) {
       return;
     }
-    // Abort htmx's response processing for this 401: no dead swap, no
-    // ``responseError`` confusion -- the operator's current view survives
-    // behind the banner.
-    event.preventDefault();
-    showBanner();
+    if (xhr.status === 401) {
+      // Abort htmx's response processing for this 401: no dead swap, no
+      // ``responseError`` confusion -- the operator's current view survives
+      // behind the banner.
+      event.preventDefault();
+      showSessionExpiredBanner();
+      return;
+    }
+    if (xhr.status === 403 && csrfRejectionReason(xhr)) {
+      // A CSRF double-submit rejection (a dropped/stale ``meho_csrf`` cookie),
+      // NOT an RBAC denial -- surface the refresh path instead of a dead
+      // control. The bare RBAC 403 (no reason header) is left untouched.
+      event.preventDefault();
+      showCsrfRejectedBanner();
+      return;
+    }
   }
 
   document.body.addEventListener("htmx:beforeOnLoad", onBeforeOnLoad);
@@ -119,7 +195,12 @@
   window.mehoSessionExpiry = {
     loginUrl: loginUrl,
     showBanner: showBanner,
+    showSessionExpiredBanner: showSessionExpiredBanner,
+    showCsrfRejectedBanner: showCsrfRejectedBanner,
+    csrfRejectionReason: csrfRejectionReason,
     onBeforeOnLoad: onBeforeOnLoad,
     BANNER_ID: BANNER_ID,
+    CSRF_BANNER_ID: CSRF_BANNER_ID,
+    CSRF_REASON_HEADER: CSRF_REASON_HEADER,
   };
 })();

--- a/backend/src/meho_backplane/ui/templates/runbooks/detail.html
+++ b/backend/src/meho_backplane/ui/templates/runbooks/detail.html
@@ -17,6 +17,12 @@
     steps_rendered -- list[{step, body_html}]: pre-rendered step bodies
                       (empty when restricted)
     is_admin       -- bool: caller is tenant_admin
+    admin_lift_degraded
+                   -- bool: the tenant-admin role lift could not complete
+                      (JWKS hiccup / session-reload miss / identity
+                      mismatch); surfaces a diagnostic note on the
+                      restricted view so a genuine admin is never silently
+                      downgraded onto the opacity banner (#2112)
     code_css       -- str: pygments CSS for highlighted step-body code
 
   Template blocks:
@@ -84,6 +90,34 @@
         </p>
       </div>
     </div>
+    {% if admin_lift_degraded %}
+      {# Soft-fail diagnostic (#2112): the tenant-admin role lift could not
+         complete for this request (a transient JWKS/session hiccup or an
+         identity mismatch), so the page fell back to the operator-restricted
+         view. Without this note a genuine tenant_admin reads the banner above
+         as "the promised admin bypass doesn't exist"; here we tell them the
+         admin view failed to resolve and offer a retry (a reload re-runs the
+         role lift). #}
+      <div role="alert" class="alert alert-info mt-3" data-testid="admin-lift-degraded">
+        <span aria-hidden="true">&#9888;</span>
+        <div>
+          <h2 class="font-semibold">Admin view could not be resolved</h2>
+          <p class="text-sm">
+            If you are a tenant administrator, the elevated view failed to
+            load for this request (a transient session or identity-provider
+            hiccup) and the page fell back to the restricted view above. This
+            is not a permission change. Reload to try resolving your admin
+            view again.
+          </p>
+          {# Plain same-page link (no inline JS) so the retry works under the
+             chassis's zero-inline-script CSP posture; a fresh GET re-runs the
+             role lift in _render_detail. #}
+          <a class="btn btn-sm mt-2" href="{{ request.url.path }}{% if request.url.query %}?{{ request.url.query }}{% endif %}">
+            Retry admin view
+          </a>
+        </div>
+      </div>
+    {% endif %}
   {% else %}
     {# ---------- Steps ---------- #}
     <div class="space-y-4">

--- a/backend/tests/test_ui_runbook_driver_opacity.py
+++ b/backend/tests/test_ui_runbook_driver_opacity.py
@@ -776,7 +776,17 @@ def test_abort_valid_reason_flips_state_and_audits() -> None:
 
 
 def test_abort_missing_csrf_rejected_403() -> None:
-    """An abort POST with no CSRF token is 403 (and no abort lands)."""
+    """An abort POST with no CSRF token is a CSRF-class 403 (no abort lands).
+
+    Pins the 403 as **CSRF-class, not RBAC-class** (#2112): the run-assignee
+    IS permitted to abort their own run (``test_abort_valid_reason_flips_...``
+    proves the browser path with a valid CSRF token succeeds). The bare
+    no-CSRF POST fails only on the double-submit-cookie middleware, which
+    stamps ``x-csrf-rejection-reason: missing_token`` -- the discriminator the
+    client-side safety net keys on. A genuine assignee RBAC denial would be an
+    inline HTTP-200 fragment (``_reassigned_away``), never a 403, so a 403
+    here can only be the CSRF gate.
+    """
     _seed_tenant(_TENANT_A, "tenant-a")
     _seed_template(tenant_id=_TENANT_A, slug="drain", body=_two_step_body())
     run_id = _start_run(tenant_id=_TENANT_A, slug="drain", assigned_to=_OPERATOR_SUB)
@@ -790,6 +800,9 @@ def test_abort_missing_csrf_rejected_403() -> None:
         )
 
     assert response.status_code == 403, response.text
+    # CSRF-class, not RBAC-class: the middleware stamps the rejection reason.
+    assert response.headers.get("x-csrf-rejection-reason") == "missing_token"
+    assert response.json() == {"detail": "csrf_token_invalid"}
     assert _run_row(run_id).state == "in_progress"
 
 

--- a/backend/tests/test_ui_runbooks_lifecycle.py
+++ b/backend/tests/test_ui_runbooks_lifecycle.py
@@ -1112,3 +1112,111 @@ def test_detail_session_expired_redirects_admin_to_reauth() -> None:
     assert response.status_code == 302, response.text
     assert response.headers["location"].startswith("/ui/auth/login?return_to=")
     assert "Step details are restricted" not in response.text
+
+
+# ---------------------------------------------------------------------------
+# Banner-bypass truthfulness + soft-fail diagnostic (#2112)
+#
+# Finding 2's real residual (per the triage against v0.19.0): the restriction
+# banner's "A tenant administrator can see them at any time" clause IS wired
+# (``_resolve_detail_admin`` -> ``restricted=False`` + full steps). The tester
+# saw the restricted banner only because their admin role lift silently
+# soft-failed. So: (a) pin the clause truthful via the real admin path, and
+# (b) surface a diagnostic when the lift degrades so a genuine admin is never
+# silently downgraded onto the restricted banner with no signal.
+# ---------------------------------------------------------------------------
+
+
+def test_detail_admin_sees_full_steps_banner_clause_truthful() -> None:
+    """A tenant_admin sees full steps -- the banner's admin-bypass clause is truthful.
+
+    Exercises the admin path end-to-end (``_resolve_detail_admin`` ->
+    ``restricted=False`` + full ``_render_steps``). The restricted notice --
+    including the "A tenant administrator can see them at any time" clause --
+    is absent because the admin is never restricted. No wording change is
+    applied: the bypass is already wired, so the clause is accurate.
+    """
+    _seed_tenant(_TENANT_A, "tenant-a")
+    # Published so the manual-body step renders on the (unrestricted) admin view.
+    _seed_template(tenant_id=_TENANT_A, slug="rotate-cert", publish=True)
+    session_id, jwks = _admin_session()
+
+    mock = respx.mock(assert_all_called=False)
+    mock.start()
+    try:
+        _mock_discovery_and_jwks(mock, jwks)
+        client = _authenticated_client(session_id)
+        response = client.get("/ui/runbooks/rotate-cert")
+    finally:
+        mock.stop()
+
+    assert response.status_code == 200, response.text
+    body = response.text
+    # The admin is NOT restricted: no opacity banner, no admin-bypass clause.
+    assert "Step details are restricted" not in body
+    assert "A tenant administrator" not in body
+    # The full steps render for the admin (the "Steps" section, not withheld).
+    assert "Steps" in body
+
+
+def test_detail_soft_failed_admin_lift_surfaces_diagnostic() -> None:
+    """A degraded admin role lift surfaces a diagnostic, not a silent downgrade.
+
+    When ``_resolve_role`` fails soft (JWKS unreachable / session-reload miss /
+    identity mismatch) it returns ``None``. A genuine plain operator instead
+    yields a non-``None`` operator, so ``None`` uniquely marks "the admin lift
+    could not complete". The restricted detail view then renders the
+    ``admin_lift_degraded`` diagnostic affordance (a note + a retry link) so a
+    real tenant_admin whose lift transiently degraded is never silently
+    dropped onto the opacity banner with no explanation (#2112).
+    """
+    _seed_tenant(_TENANT_A, "tenant-a")
+    _seed_template(tenant_id=_TENANT_A, slug="rotate-cert", publish=True)
+    session_id, _jwks = _admin_session()
+
+    client = _authenticated_client(session_id)
+    # Force the soft-fail branch: the lift returns None (as it does on a
+    # transient JWKS/session hiccup or identity mismatch).
+    with patch(f"{_RB_ROUTES}._resolve_role", AsyncMock(return_value=None)):
+        response = client.get("/ui/runbooks/rotate-cert")
+
+    assert response.status_code == 200, response.text
+    body = response.text
+    # Fell back to the restricted view (no admin verdict)...
+    assert "Step details are restricted" in body
+    # ...but with a diagnostic, NOT a silent downgrade.
+    assert 'data-testid="admin-lift-degraded"' in body
+    assert "Admin view could not be resolved" in body
+    # The retry affordance is a same-page link (CSP-safe, re-runs the lift).
+    assert 'href="/ui/runbooks/rotate-cert' in body
+
+
+def test_detail_genuine_operator_no_soft_fail_diagnostic() -> None:
+    """A genuine operator's restricted view shows NO soft-fail diagnostic.
+
+    The discriminator is sound: a clean operator lift returns a real
+    ``Operator`` (non-``None``), so ``admin_lift_degraded`` is ``False`` and
+    the diagnostic is withheld -- only a genuinely-degraded lift (``None``)
+    surfaces it. This guards against the diagnostic leaking onto every
+    plain-operator restricted view.
+    """
+    _seed_tenant(_TENANT_A, "tenant-a")
+    _seed_template(tenant_id=_TENANT_A, slug="rotate-cert", publish=True)
+    # An operator with no completed run -> restricted, but cleanly resolved.
+    session_id, jwks = _role_session(TenantRole.OPERATOR)
+
+    mock = respx.mock(assert_all_called=False)
+    mock.start()
+    try:
+        _mock_discovery_and_jwks(mock, jwks)
+        client = _authenticated_client(session_id)
+        response = client.get("/ui/runbooks/rotate-cert")
+    finally:
+        mock.stop()
+
+    assert response.status_code == 200, response.text
+    body = response.text
+    assert "Step details are restricted" in body
+    # No soft-fail diagnostic for a cleanly-resolved operator.
+    assert 'data-testid="admin-lift-degraded"' not in body
+    assert "Admin view could not be resolved" not in body

--- a/backend/tests/test_ui_templates.py
+++ b/backend/tests/test_ui_templates.py
@@ -477,12 +477,11 @@ def test_session_expiry_handler_source_carries_401_contract() -> None:
     assert "htmx:beforeOnLoad" in source
     assert 'addEventListener("htmx:beforeOnLoad"' in source
 
-    # AC #2 -- 401-only: an early-return guard keyed on the xhr status, so a
-    # 422 (or any other status) flows through untouched. Asserting both the
-    # status read and the not-401 short-circuit pins the "don't hijack 422"
-    # contract.
+    # AC #2 -- status-scoped: the handler branches on the xhr status, so a
+    # 422 (or any other status) flows through untouched. Asserting the status
+    # read plus the explicit 401 branch pins the "don't hijack 422" contract.
     assert "event.detail.xhr" in source
-    assert "xhr.status !== 401" in source
+    assert "xhr.status === 401" in source
 
     # AC #1 -- the recovery path: cancel the dead swap, show the banner, and
     # link to the login route with the current path as ``return_to``.
@@ -490,6 +489,33 @@ def test_session_expiry_handler_source_carries_401_contract() -> None:
     assert "/ui/auth/login?return_to=" in source
     assert "encodeURIComponent" in source
     assert "Your session expired" in source
+
+
+def test_session_expiry_handler_source_carries_csrf_rejection_contract() -> None:
+    """The served handler surfaces the CSRF-rejection 403 (#2112).
+
+    A state-changing ``/ui/*`` POST whose ``meho_csrf`` double-submit cookie
+    was dropped/aged-out gets a bare ``{"detail":"csrf_token_invalid"}`` 403
+    that htmx 2.0.9 does NOT swap. The same global ``htmx:beforeOnLoad`` seam
+    surfaces a refresh banner -- but ONLY for a CSRF rejection, keyed on the
+    ``x-csrf-rejection-reason`` response header the middleware stamps, so a
+    bare RBAC 403 (``require_ui_admin``, no such header) flows through
+    untouched.
+    """
+    handler = static_src_dir() / "app" / "session-expiry.js"
+    assert handler.is_file(), f"session-expiry handler missing: {handler}"
+    source = handler.read_text(encoding="utf-8")
+
+    # Keyed on the CSRF-specific header, not the bare 403 status -- this is
+    # what keeps the net off a genuine RBAC denial.
+    assert "x-csrf-rejection-reason" in source
+    assert "xhr.status === 403" in source
+    assert "getResponseHeader" in source
+
+    # The recovery path: cancel the dead swap + a refresh banner (a fresh
+    # render re-mints the meho_csrf cookie so the retry clears the check).
+    assert "event.preventDefault()" in source
+    assert "refresh the page and retry" in source
 
 
 def test_session_expiry_handler_served_as_static_asset() -> None:

--- a/docs/codebase/ui.md
+++ b/docs/codebase/ui.md
@@ -595,6 +595,50 @@ Five things land together:
    the `hx-headers` directive on the page `<body>`; classic HTML
    forms include the value in a `csrf_token` hidden field.
 
+### CSRF requirement on every `/ui/*` state-changing POST (RESTRICTIONS)
+
+**Every state-changing `/ui/*` request** (`POST` / `PATCH` / `PUT` /
+`DELETE`) — including `POST /ui/runbooks/runs/<id>/abort`,
+`POST /ui/runbooks/<slug>/publish`, `POST /ui/connectors/registry/...`, and
+every other `/ui/*` write — **requires the double-submit CSRF token**:
+
+* the `meho_csrf` cookie (minted + refreshed on every authenticated render),
+  **and**
+* an `X-CSRF-Token` request header (HTMX injects it from the page `<body>`'s
+  `hx-headers`) **or** a `csrf_token` form field (classic-form fallback).
+
+A request missing either half is rejected with **`403`**, body
+`{"detail":"csrf_token_invalid"}`, and a machine-readable
+`x-csrf-rejection-reason` response header (`missing_token` /
+`value_mismatch` / `signature_invalid` / `no_session`). See
+[`ui/csrf.py`](../../backend/src/meho_backplane/ui/csrf.py).
+
+**`/api/v1/*` is exempt** — the CSRF middleware short-circuits on any path
+outside the `/ui/` prefix (the Bearer-JWT surface has no ambient-cookie CSRF
+vector to defend). That exemption is the source of a recurring
+false-positive bug report: a **raw-curl repro that sends a Bearer JWT but no
+`meho_csrf` cookie / `X-CSRF-Token` header** gets a `403` on
+`POST /ui/runbooks/runs/<id>/abort` while the same call to
+`POST /api/v1/runbooks/runs/<id>/abort` succeeds. The differential is the
+CSRF gate, **not** an RBAC / opacity-floor difference — the `/ui` abort route
+sits on the **same operator floor as REST** (`require_ui_session`, passing
+`caller_is_admin=probe.is_tenant_admin` to the service), and a genuine
+assignee RBAC denial there renders an inline HTTP-**200** fragment, never a
+`403` (see [`runbooks/driver.py`](../../backend/src/meho_backplane/ui/routes/runbooks/driver.py)).
+So a `403` on a `/ui/*` write is **always** a CSRF rejection.
+
+**Known-repro pointer (for consumer bug reports):** a browser driving the run
+through the driver page carries the cookie + header (both re-minted on every
+fragment render), so the run-starter **can** abort their own run from the UI.
+Reproduce against the **browser path**, not raw curl; a curl repro must set
+both the `meho_csrf` cookie and the `X-CSRF-Token` header (or the
+`csrf_token` form field) to clear the gate. Filed + resolved as
+[`evoila/meho#2112`](https://github.com/evoila/meho/issues/2112). The
+client-side [`session-expiry.js`](../../backend/src/meho_backplane/ui/static/src/app/session-expiry.js)
+safety net surfaces a "session token expired — refresh the page and retry"
+banner when a real browser hits this `403` (keyed on the
+`x-csrf-rejection-reason` header), instead of leaving a dead control.
+
 The dashboard view (`GET /ui/`) renders three components per
 Initiative #337 work-item #6:
 


### PR DESCRIPTION
## Summary

- The reported `POST /ui/runbooks/runs/<id>/abort` **403 vs** `POST /api/v1/.../abort` **200** differential is a **CSRF rejection**, not RBAC/opacity. The `/ui` abort route is on the **same operator floor as REST** (`require_ui_session`, `caller_is_admin=probe.is_tenant_admin`); a genuine assignee denial there renders an inline **HTTP-200** fragment, never a 403. The only 403 source on a `/ui/*` POST is the double-submit-cookie middleware, and `/api/v1/*` is CSRF-exempt — so the raw-curl repro (Bearer JWT, no `meho_csrf` cookie) 403s on `/ui` while succeeding on `/api`. A browser carries the cookie + `X-CSRF-Token` (re-minted every render), so the run-starter **can** abort their own run from the UI today.
- Grounded against v0.19.0: Finding 2's admin-bypass **is** wired (`_resolve_detail_admin` → `restricted=False` + full steps for a `tenant_admin`), so the banner clause *"A tenant administrator can see them at any time"* is **truthful — no wording change applied**. The tester saw the restricted banner only because their admin role lift **silently soft-failed** (`_resolve_role` → `None` on a JWKS/session/identity hiccup). This PR surfaces that degradation instead of removing a correct banner.
- **Docs (AC1):** `docs/codebase/ui.md` gains a *CSRF requirement / RESTRICTIONS* section (cookie + header/form-field required; `403 csrf_token_invalid` + `x-csrf-rejection-reason` by design; `/api/v1` exempt; reproduce against the browser path, not raw curl) + a matching note in the driver-route docstring.
- **CSRF-403 surfacing (AC3):** `session-expiry.js` gains a branch on the same global `htmx:beforeOnLoad` seam that shows a *"session token expired — refresh and retry"* banner, keyed on the `x-csrf-rejection-reason` header so a bare RBAC 403 is untouched. (htmx 2.0.9 does not swap 4xx bodies, so a server-side fragment could not render — the client is the only place this surfaces.)
- **Soft-fail diagnostic (AC4):** `_render_detail` threads `admin_lift_degraded` (`operator is None` uniquely marks a degraded lift; a genuine operator yields a non-`None` `Operator`) and the restricted view renders a diagnostic note + a CSP-safe retry link, so a real `tenant_admin` is never silently dropped onto the opacity banner with no signal.

## Divergence from the ticket's top-line "Decision" (flagged for review)

The ticket's `Decision (recorded 2026-07-06)` says "**remove** the promise of an admin-bypass that isn't wired." The **code oracle contradicts that premise** — the bypass IS wired — and the ticket's own **triage section + acceptance criteria** (AC5: *"no wording change is applied (the bypass is already wired)"*) already resolve the contradiction. This PR follows the acceptance criteria (the contract): it keeps the truthful banner and fixes the **actual** residual (silent soft-fail). Removing the banner would have been a regression.

## Test plan

- [x] `ruff check` / `ruff format --check` — clean
- [x] `mypy src/.../runbooks/{routes,driver}.py` — clean
- [x] `pytest tests/test_ui_runbooks_lifecycle.py tests/test_ui_runbook_driver_opacity.py` — 45 passed
- [x] Broad CSRF/session/runbook-detail sweep — 132 passed
- [x] **AC2** — `test_abort_missing_csrf_rejected_403` now pins `x-csrf-rejection-reason: missing_token` + `{"detail":"csrf_token_invalid"}` (CSRF-class, not RBAC); `test_abort_valid_reason_flips_state_and_audits` proves assignee self-abort → 200 `abandoned` + audit row.
- [x] **AC5** — `test_detail_admin_sees_full_steps_banner_clause_truthful` (admin path → no restricted banner, full steps).
- [x] **AC4** — `test_detail_soft_failed_admin_lift_surfaces_diagnostic` (degraded lift → diagnostic) + `test_detail_genuine_operator_no_soft_fail_diagnostic` (clean operator → no diagnostic).
- [x] **AC3** — `test_session_expiry_handler_source_carries_csrf_rejection_contract` (JS content contract).
- [x] OpenAPI snapshot regenerated — **byte-identical** (no route signature/response-model change), so no `make generate` needed.

## Out of scope

- The REST-side opacity_floor violation (`#2111`).
- The runbooks-UI *authoring* defects (`#2117`) and the runbook run-state read surface — per Initiative #2150's Out-of-scope.

<!-- auto-implement-issue: fresh, iteration 1 -->

Closes #2112
