### PR TITLE
fix(operations): exempt dict-of-arrays detail ops from JSONFlux list reduction (#2113)

### DIFF
--- a/backend/src/meho_backplane/operations/jsonflux_reducer.py
+++ b/backend/src/meho_backplane/operations/jsonflux_reducer.py
@@ -570,15 +570,33 @@ def _detect_collection(payload: Any) -> tuple[str | None, list[Any] | None]:
     Returns ``(envelope_key, rows)`` where ``envelope_key`` is the dict
     key the list was found under (``None`` for a bare top-level list)
     and ``rows`` is the list itself, or ``(None, None)`` when *payload*
-    carries no list-shaped collection.
+    carries no *paginable* list-shaped collection.
 
     Resolution order:
 
     1. A bare top-level ``list`` → ``(None, payload)``.
     2. A ``dict`` whose first matching :data:`_ENVELOPE_KEYS` value is a
        list → ``(key, value)``.
-    3. A ``dict`` with no known envelope key → its largest list value,
-       if any (covers vendors that wrap under a non-standard key).
+    3. A ``dict`` with no known envelope key and **exactly one**
+       list-valued field → that list (covers vendors — ``k8s.logs``,
+       and other flat-dict list ops — that wrap a single collection
+       under a non-standard key next to scalar siblings).
+
+    Single-object detail exemption (#2113)
+    --------------------------------------
+    A ``dict`` with no known envelope key that carries **more than one**
+    list-valued field is a *dict-of-arrays detail object*, not a
+    paginable collection: the sibling arrays are coordinate fields of one
+    object (``k8s.pod.info``'s ``containers`` / ``container_statuses`` /
+    ``volumes`` / ``conditions``), not pages of a single set. The
+    pre-#2113 largest-list fallback picked whichever array happened to be
+    longest (``conditions``, 5 all-``True`` rows) and discarded every
+    sibling, silently dropping the operationally critical
+    ``container_statuses``. Such payloads return ``(None, None)`` and pass
+    through verbatim — the byte-threshold check still bounds a genuinely
+    huge detail object, but it can never be truncated to a single
+    arbitrary sub-array. The single-list case (2) is untouched, so real
+    flat-dict list ops (``k8s.logs``) still reduce as before.
     """
     if isinstance(payload, list):
         return None, payload
@@ -590,13 +608,12 @@ def _detect_collection(payload: Any) -> tuple[str | None, list[Any] | None]:
         if isinstance(value, list):
             return key, value
 
-    largest_key: str | None = None
-    largest: list[Any] | None = None
-    for key, value in payload.items():
-        if isinstance(value, list) and (largest is None or len(value) > len(largest)):
-            largest_key, largest = key, value
-    if largest is not None:
-        return largest_key, largest
+    list_fields = [(key, value) for key, value in payload.items() if isinstance(value, list)]
+    if len(list_fields) == 1:
+        return list_fields[0]
+    # Zero lists → no collection. More than one list → a dict-of-arrays
+    # detail object (#2113); pass through verbatim rather than materialize
+    # one arbitrary sub-array and drop its siblings.
     return None, None
 
 

--- a/backend/src/meho_backplane/operations/jsonflux_reducer.py
+++ b/backend/src/meho_backplane/operations/jsonflux_reducer.py
@@ -159,6 +159,20 @@ _TABLE = "result"
 #: (``results``), SDDC Manager (``elements``), Vault KV (``keys``).
 _ENVELOPE_KEYS = ("value", "results", "elements", "keys", "items", "data")
 
+#: Pagination / HATEOAS metadata keys the largest-list fallback (case 3)
+#: must NOT count as a real collection field. Vendors ship these list- or
+#: object-valued siblings *alongside* the actual collection: vROps /
+#: VCF-operations wraps ``resourceList`` next to a ``links`` HATEOAS array
+#: and a ``pageInfo`` cursor block. They are transport metadata, not
+#: coordinate fields of a detail object, so excluding them before the
+#: single-vs-multi-list decision keeps a paginated collection payload
+#: (``{resourceList, pageInfo, links}``) classified as ONE real list field
+#: (still reduced) while a genuine dict-of-arrays detail object
+#: (``k8s.pod.info``: ``containers`` / ``container_statuses`` / ``volumes`` /
+#: ``conditions`` — none of them metadata) still counts >1 real list field
+#: and passes through verbatim (#2113 / #2184).
+_METADATA_LIST_KEYS = frozenset({"links", "_links", "pageInfo", "page_info"})
+
 #: Column name used when a list-of-scalars is normalized into row dicts.
 _SCALAR_COLUMN = "value"
 
@@ -577,15 +591,18 @@ def _detect_collection(payload: Any) -> tuple[str | None, list[Any] | None]:
     1. A bare top-level ``list`` → ``(None, payload)``.
     2. A ``dict`` whose first matching :data:`_ENVELOPE_KEYS` value is a
        list → ``(key, value)``.
-    3. A ``dict`` with no known envelope key and **exactly one**
-       list-valued field → that list (covers vendors — ``k8s.logs``,
-       and other flat-dict list ops — that wrap a single collection
-       under a non-standard key next to scalar siblings).
+    3. A ``dict`` with no known envelope key and **exactly one** *real*
+       list-valued field (:data:`_METADATA_LIST_KEYS` excluded) → that
+       list (covers vendors — ``k8s.logs``, and other flat-dict list ops —
+       that wrap a single collection under a non-standard key next to
+       scalar siblings, and paginated shapes like vROps'
+       ``{resourceList, pageInfo, links}`` where the only non-metadata
+       list is the collection).
 
     Single-object detail exemption (#2113)
     --------------------------------------
     A ``dict`` with no known envelope key that carries **more than one**
-    list-valued field is a *dict-of-arrays detail object*, not a
+    *real* list-valued field is a *dict-of-arrays detail object*, not a
     paginable collection: the sibling arrays are coordinate fields of one
     object (``k8s.pod.info``'s ``containers`` / ``container_statuses`` /
     ``volumes`` / ``conditions``), not pages of a single set. The
@@ -597,6 +614,19 @@ def _detect_collection(payload: Any) -> tuple[str | None, list[Any] | None]:
     huge detail object, but it can never be truncated to a single
     arbitrary sub-array. The single-list case (2) is untouched, so real
     flat-dict list ops (``k8s.logs``) still reduce as before.
+
+    HATEOAS / pagination metadata is not a collection field (#2184)
+    ---------------------------------------------------------------
+    The single-vs-multi-list count in case 3 skips
+    :data:`_METADATA_LIST_KEYS` (``links`` / ``_links`` / ``pageInfo`` /
+    ``page_info``). Without the exclusion vROps' paginated
+    ``{resourceList: [...], pageInfo: {...}, links: [{...}]}`` counted two
+    list fields (``resourceList`` + the HATEOAS ``links`` array), fell into
+    the multi-list detail exemption, and shipped a genuine large collection
+    UNREDUCED with ``handle=None``. Metadata keys never carry the payload's
+    rows, so excluding them restores single-real-list detection for
+    paginated collections while leaving the pod-info detail object (whose
+    arrays are all real coordinate fields) at >1 and still exempt.
     """
     if isinstance(payload, list):
         return None, payload
@@ -608,10 +638,18 @@ def _detect_collection(payload: Any) -> tuple[str | None, list[Any] | None]:
         if isinstance(value, list):
             return key, value
 
-    list_fields = [(key, value) for key, value in payload.items() if isinstance(value, list)]
+    # Count only *real* list fields — transport metadata (HATEOAS ``links``,
+    # a ``pageInfo`` cursor) is not a collection, so it must not tip a
+    # paginated single-collection payload into the multi-list detail
+    # exemption (#2184).
+    list_fields = [
+        (key, value)
+        for key, value in payload.items()
+        if isinstance(value, list) and key not in _METADATA_LIST_KEYS
+    ]
     if len(list_fields) == 1:
         return list_fields[0]
-    # Zero lists → no collection. More than one list → a dict-of-arrays
+    # Zero lists → no collection. More than one real list → a dict-of-arrays
     # detail object (#2113); pass through verbatim rather than materialize
     # one arbitrary sub-array and drop its siblings.
     return None, None

--- a/backend/tests/test_operations_jsonflux_reducer.py
+++ b/backend/tests/test_operations_jsonflux_reducer.py
@@ -1217,6 +1217,36 @@ def test_detect_collection_keeps_single_list_flat_dict_as_collection() -> None:
     assert rows == ["a", "b", "c"]
 
 
+def test_detect_collection_reduces_paginated_collection_with_hateoas_metadata() -> None:
+    """A ``{resourceList, pageInfo, links}`` payload still reduces (#2184).
+
+    Regression guard for the vROps / VCF-operations resource-list shape:
+    the single real collection (``resourceList``) is wrapped next to a
+    ``pageInfo`` cursor block and a HATEOAS ``links`` array. Both are
+    transport metadata, not coordinate fields of a detail object, so
+    ``_detect_collection`` must exclude them from the list-field count and
+    keep the payload classified as ONE real list field — otherwise
+    (pre-#2184) the extra ``links`` array tipped it into the #2113
+    multi-list detail exemption and a genuine large collection shipped
+    UNREDUCED with ``handle=None``. Locks in that a future change can't
+    silently re-break vROps pagination.
+    """
+    payload = {
+        "resourceList": [{"identifier": f"r-{i}", "name": f"vm-{i}"} for i in range(10)],
+        "pageInfo": {"totalCount": 10, "page": 0, "pageSize": 1000},
+        "links": [{"href": "/suite-api/api/resources", "rel": "SELF", "name": "current"}],
+    }
+
+    envelope_key, rows = _detect_collection(payload)
+
+    assert envelope_key == "resourceList", (
+        "the paginated resource list must be detected as the collection, not "
+        "exempted as a dict-of-arrays detail object because of the HATEOAS "
+        "``links`` metadata array"
+    )
+    assert rows == payload["resourceList"]
+
+
 def _large_application_pod(now: datetime) -> Any:
     """A real Deployment pod whose ``pod_info`` projection trips the reducer.
 

--- a/backend/tests/test_operations_jsonflux_reducer.py
+++ b/backend/tests/test_operations_jsonflux_reducer.py
@@ -32,6 +32,7 @@ from __future__ import annotations
 import json
 import uuid
 from collections.abc import AsyncIterator, Iterator, Mapping
+from datetime import UTC, datetime, timedelta
 from typing import Any
 from unittest.mock import AsyncMock
 
@@ -65,6 +66,7 @@ from meho_backplane.operations.dispatcher import set_default_reducer
 from meho_backplane.operations.jsonflux_reducer import (
     _TRUNCATION_MARKER,
     JsonFluxReducer,
+    _detect_collection,
     _fit_sample_to_budget,
     _query_sample,
     _sample_from_tail,
@@ -1160,6 +1162,258 @@ async def test_k8s_logs_shape_store_down_states_the_reason() -> None:
     assert drill_in.available is False
     assert drill_in.reason == "result_store_unavailable"
     assert "store" in drill_in.rationale.lower()
+
+
+# ---------------------------------------------------------------------------
+# #2113 — single-object detail ops (dict-of-arrays) must not be reduced to
+# one arbitrary sub-array. ``k8s.pod.info`` returns a flat detail object
+# whose sibling arrays (containers / container_statuses / volumes /
+# conditions) are coordinate fields, NOT pages of one collection. The
+# pre-#2113 largest-list fallback materialized ``conditions`` (the longest,
+# least useful array) and silently dropped ``container_statuses``.
+# ---------------------------------------------------------------------------
+
+
+def test_detect_collection_exempts_dict_of_arrays_detail_object() -> None:
+    """A dict with >1 list-valued field is a detail object, not a collection.
+
+    Unit-level anchor for the #2113 fix at the detection boundary: the
+    ``k8s.pod.info`` shape (several sibling arrays next to scalar fields)
+    must return ``(None, None)`` so the reducer passes it through verbatim
+    instead of picking the longest array (``conditions``) and discarding
+    ``container_statuses`` / ``containers`` / ``volumes``.
+    """
+    detail = {
+        "name": "app-pod",
+        "node": "node-1",
+        "qos_class": "Burstable",
+        "containers": [{"name": "app"}],
+        "container_statuses": [{"name": "app", "ready": True}],
+        "volumes": [{"name": "cfg"}],
+        "conditions": [{"type": "Ready", "status": "True"}, {"type": "PodScheduled"}],
+    }
+
+    envelope_key, rows = _detect_collection(detail)
+
+    assert (envelope_key, rows) == (None, None), (
+        "a dict-of-arrays detail object must not be treated as a paginable "
+        "collection — no sub-array may be selected as THE collection"
+    )
+
+
+def test_detect_collection_keeps_single_list_flat_dict_as_collection() -> None:
+    """A flat dict with exactly ONE list field is still a real collection.
+
+    The k8s.logs shape (``lines`` next to scalar siblings, no envelope
+    key) must keep flowing through the largest-list fallback so genuine
+    list ops still reduce — the #2113 fix narrows the fallback to the
+    single-list case, it does not disable it.
+    """
+    payload = {"pod": "p", "namespace": "n", "lines": ["a", "b", "c"], "truncated": False}
+
+    envelope_key, rows = _detect_collection(payload)
+
+    assert envelope_key == "lines"
+    assert rows == ["a", "b", "c"]
+
+
+def _large_application_pod(now: datetime) -> Any:
+    """A real Deployment pod whose ``pod_info`` projection trips the reducer.
+
+    Mirrors reproduction case **B** in #2113: a populated ``env`` + multi
+    container-status + several conditions, so the serialized detail clears
+    the byte threshold. Returned via the real ``pod_info`` projection so
+    the test asserts against the documented contract, not a hand-rolled
+    dict.
+    """
+    from kubernetes_asyncio.client.models import (
+        V1Container,
+        V1ContainerState,
+        V1ContainerStateRunning,
+        V1ContainerStatus,
+        V1EnvVar,
+        V1ObjectMeta,
+        V1Pod,
+        V1PodCondition,
+        V1PodSpec,
+        V1PodStatus,
+        V1Volume,
+    )
+
+    big_env = [V1EnvVar(name=f"CONFIG_KEY_{i}", value=f"value-{i}-" + "x" * 40) for i in range(60)]
+    return V1Pod(
+        metadata=V1ObjectMeta(
+            name="payments-api-7d8f9c-x2x9z",
+            namespace="payments",
+            creation_timestamp=now - timedelta(seconds=3600),
+            labels={"app": "payments-api"},
+        ),
+        spec=V1PodSpec(
+            containers=[
+                V1Container(name="payments-api", image="registry/payments-api:2.3.1", env=big_env),
+            ],
+            volumes=[V1Volume(name="cfg"), V1Volume(name="tls")],
+            node_name="rke2-meho-03",
+        ),
+        status=V1PodStatus(
+            phase="Running",
+            pod_ip="10.0.4.7",
+            qos_class="Burstable",
+            container_statuses=[
+                V1ContainerStatus(
+                    name="payments-api",
+                    image="registry/payments-api:2.3.1",
+                    image_id="sha256:abc",
+                    ready=True,
+                    restart_count=2,
+                    state=V1ContainerState(running=V1ContainerStateRunning()),
+                )
+            ],
+            conditions=[
+                V1PodCondition(type="PodReadyToStartContainers", status="True"),
+                V1PodCondition(type="Initialized", status="True"),
+                V1PodCondition(type="Ready", status="True"),
+                V1PodCondition(type="ContainersReady", status="True"),
+                V1PodCondition(type="PodScheduled", status="True"),
+            ],
+        ),
+    )
+
+
+async def test_pod_info_above_threshold_keeps_container_statuses_inline() -> None:
+    """#2113 acceptance 1+2: a big pod's ``container_statuses`` survives reduce.
+
+    A populated application pod (case B) projected via ``pod_info`` clears
+    the 4 KB byte threshold, so the pre-fix reducer collapsed it to
+    ``source_key="conditions"`` and dropped everything else. The fix
+    exempts the dict-of-arrays detail object from list reduction, so the
+    full flat object ships inline with no handle and every sibling array
+    is retrievable.
+    """
+    from meho_backplane.connectors.kubernetes.ops_workload import pod_info
+
+    now = datetime(2026, 7, 6, 12, 0, 0, tzinfo=UTC)
+    projection = pod_info(_large_application_pod(now), now=now)
+    # Guard the premise: this projection really is over the byte threshold,
+    # so we are exercising the reducing path, not the trivial small-pod one.
+    reducer = JsonFluxReducer()
+    assert len(_serialize(projection)) > reducer._byte_threshold, (
+        "test premise: the application-pod projection must exceed the byte "
+        "threshold, otherwise it never reaches the reduction boundary"
+    )
+
+    reduced, handle = await reducer.reduce(projection, None)
+
+    # The detail object passes through verbatim — no handle, no collapse.
+    assert handle is None, "a single-object detail op must not mint a list handle"
+    assert reduced is projection
+    assert "source_key" not in reduced, (
+        "the reduced response must NOT collapse to a single sub-array's "
+        "source_key (was 'conditions' pre-#2113)"
+    )
+    # Every sibling array pod_info() projects is intact.
+    for key in ("containers", "container_statuses", "volumes", "node", "qos_class"):
+        assert key in reduced, f"sibling field {key!r} was silently discarded"
+    # container_statuses carries the per-container name/image/ready/restart/state.
+    cs = reduced["container_statuses"][0]
+    assert cs["name"] == "payments-api"
+    assert cs["image"] == "registry/payments-api:2.3.1"
+    assert cs["ready"] is True
+    assert cs["restart_count"] == 2
+    assert cs["state"] == "running"
+
+
+async def test_pod_info_below_threshold_still_returns_full_object_inline() -> None:
+    """#2113 acceptance 4: the small-pod path is unchanged (full flat object).
+
+    A trivial pod (empty env, one container, no volumes) is well under the
+    threshold, so it always passed through inline. The fix must not alter
+    that: full object, no handle.
+    """
+    from kubernetes_asyncio.client.models import (
+        V1Container,
+        V1ContainerStatus,
+        V1ObjectMeta,
+        V1Pod,
+        V1PodCondition,
+        V1PodSpec,
+        V1PodStatus,
+    )
+
+    from meho_backplane.connectors.kubernetes.ops_workload import pod_info
+
+    now = datetime(2026, 7, 6, 12, 0, 0, tzinfo=UTC)
+    pod = V1Pod(
+        metadata=V1ObjectMeta(
+            name="mongo-0", namespace="db", creation_timestamp=now - timedelta(seconds=60)
+        ),
+        spec=V1PodSpec(
+            containers=[V1Container(name="mongo", image="mongo:8.0")], node_name="node-1"
+        ),
+        status=V1PodStatus(
+            phase="Running",
+            qos_class="BestEffort",
+            container_statuses=[
+                V1ContainerStatus(
+                    name="mongo",
+                    image="docker.io/library/mongo:8.0",
+                    image_id="sha256:def",
+                    ready=True,
+                    restart_count=0,
+                )
+            ],
+            conditions=[V1PodCondition(type="Ready", status="True")],
+        ),
+    )
+    projection = pod_info(pod, now=now)
+    reducer = JsonFluxReducer()
+    assert len(_serialize(projection)) <= reducer._byte_threshold
+
+    reduced, handle = await reducer.reduce(projection, None)
+
+    assert handle is None
+    assert reduced is projection
+    assert reduced["container_statuses"][0]["image"] == "docker.io/library/mongo:8.0"
+    assert reduced["qos_class"] == "BestEffort"
+
+
+def test_pod_info_docstring_documents_container_statuses_contract() -> None:
+    """#2113 acceptance 5: the projection contract the reduced path preserves.
+
+    The reduced-path response now exposes exactly what ``pod_info``'s
+    docstring promises (per-container statuses with readiness + restart
+    count + state). Pin the docstring so the contract this fix preserves
+    cannot silently drift away from the code that produces it.
+    """
+    from kubernetes_asyncio.client.models import (
+        V1ContainerState,
+        V1ContainerStateRunning,
+        V1ContainerStatus,
+    )
+
+    from meho_backplane.connectors.kubernetes.ops_workload import (
+        container_status_row,
+        pod_info,
+    )
+
+    doc = pod_info.__doc__ or ""
+    assert "Container statuses" in doc
+    assert "restartCount" in doc
+    # The row projection the contract names actually emits exactly the
+    # per-container fields #2113 asserts survive the reduced path.
+    row = container_status_row(
+        V1ContainerStatus(
+            name="c",
+            image="img:1",
+            image_id="sha256:x",
+            ready=True,
+            restart_count=3,
+            state=V1ContainerState(running=V1ContainerStateRunning()),
+        )
+    )
+    assert {"name", "image", "ready", "restart_count", "state"} <= row.keys()
+    assert row["restart_count"] == 3
+    assert row["state"] == "running"
 
 
 async def _set_shaped_handler(

--- a/docs/architecture/jsonflux.md
+++ b/docs/architecture/jsonflux.md
@@ -232,6 +232,21 @@ markdown summary, samples N rows, and returns
 `(summary_dict, ResultHandle)`. Small / scalar payloads return
 `(payload, None)` unchanged.
 
+Collection detection distinguishes a *paginable list* from a
+*dict-of-arrays detail object* (#2113). A dict with no recognized
+envelope key is only treated as a collection when it carries **exactly
+one** list-valued field (a single collection next to scalar siblings —
+`k8s.logs`'s `lines` next to `pod` / `namespace` / `truncated`). A dict
+with **more than one** list-valued field is a single detail object whose
+arrays are coordinate fields, not pages of one set (`k8s.pod.info`'s
+`containers` / `container_statuses` / `volumes` / `conditions`); it
+passes through verbatim (`(None, None)` from detection) rather than
+materializing whichever sub-array happens to be longest and discarding
+the siblings. Before #2113 the largest-list fallback picked `conditions`
+(5 all-`True` rows) for a real application pod and silently dropped
+`container_statuses` — the image / ready / restart-count / state data an
+operator actually reads.
+
 ### Constructor defaults
 
 Read off the shipped adapter

--- a/docs/architecture/jsonflux.md
+++ b/docs/architecture/jsonflux.md
@@ -235,17 +235,30 @@ markdown summary, samples N rows, and returns
 Collection detection distinguishes a *paginable list* from a
 *dict-of-arrays detail object* (#2113). A dict with no recognized
 envelope key is only treated as a collection when it carries **exactly
-one** list-valued field (a single collection next to scalar siblings —
-`k8s.logs`'s `lines` next to `pod` / `namespace` / `truncated`). A dict
-with **more than one** list-valued field is a single detail object whose
-arrays are coordinate fields, not pages of one set (`k8s.pod.info`'s
-`containers` / `container_statuses` / `volumes` / `conditions`); it
-passes through verbatim (`(None, None)` from detection) rather than
-materializing whichever sub-array happens to be longest and discarding
-the siblings. Before #2113 the largest-list fallback picked `conditions`
-(5 all-`True` rows) for a real application pod and silently dropped
-`container_statuses` — the image / ready / restart-count / state data an
-operator actually reads.
+one** *real* list-valued field (a single collection next to scalar
+siblings — `k8s.logs`'s `lines` next to `pod` / `namespace` /
+`truncated`). A dict with **more than one** *real* list-valued field is a
+single detail object whose arrays are coordinate fields, not pages of one
+set (`k8s.pod.info`'s `containers` / `container_statuses` / `volumes` /
+`conditions`); it passes through verbatim (`(None, None)` from detection)
+rather than materializing whichever sub-array happens to be longest and
+discarding the siblings. Before #2113 the largest-list fallback picked
+`conditions` (5 all-`True` rows) for a real application pod and silently
+dropped `container_statuses` — the image / ready / restart-count / state
+data an operator actually reads.
+
+The single-vs-multi count excludes pagination / HATEOAS metadata keys —
+`links`, `_links`, `pageInfo`, `page_info` (`_METADATA_LIST_KEYS`) —
+before deciding (#2184). Those siblings are transport metadata, not the
+payload's rows, so vROps / VCF-operations'
+`{resourceList: [...], pageInfo: {...}, links: [{...}]}` counts **one**
+real list field (`resourceList`) and still reduces as a collection. The
+first iteration of the #2113 fix omitted the carve-out: the HATEOAS
+`links` array made it a two-list payload, tipped it into the detail-object
+exemption, and shipped a genuine large collection (hundreds–thousands of
+monitored objects) unreduced with `handle=None`. The pod-info detail
+object is unaffected — none of its arrays are metadata keys, so it still
+counts more than one real list field and stays exempt.
 
 ### Constructor defaults
 


### PR DESCRIPTION
## Summary
- `k8s.pod.info` returns a flat detail object whose sibling arrays (`containers` / `container_statuses` / `volumes` / `conditions`) are coordinate fields of one object, not pages of a collection. When the projection cleared the JSONFlux byte threshold, the reducer's largest-list fallback picked whichever array was longest (`conditions`, 5 all-`True` rows) and materialized it into a handle while silently dropping every sibling — including `container_statuses` (image / ready / restart_count / state), the section an operator actually reads.
- **Fix chosen: exempt single-object detail ops at the reduction boundary** (`_detect_collection` in `jsonflux_reducer.py`), the general fix the issue prefers. A dict with no recognized envelope key is treated as a paginable collection only when it has **exactly one** list-valued field (the `k8s.logs` shape — `lines` next to scalars). A dict with **more than one** list-valued field is a dict-of-arrays detail object and passes through verbatim, so no sub-array can be selected as THE collection and no sibling is discarded.
- **Why this path over "preserve `container_statuses` over `conditions`":** the k8s-specific ranking is a band-aid that only helps pods and encodes connector knowledge into shared infra. The structural single-vs-multi-list distinction is principled (one collection = a list; several coordinate arrays = an object), fixes every single-object detail op at once, needs no tunable/weighting (MEHO substrate-minimalism), and provably does not regress genuine flat-dict list reduction — `k8s.logs` still reduces via the single-list branch (sibling meho-internal #134 uses the same reducer for a different, orthogonal defect and is unaffected).
- Docs updated: `docs/architecture/jsonflux.md` documents the paginable-list-vs-detail-object detection contract.

## Test plan
- [x] `ruff check` — clean (reducer + tests)
- [x] `ruff format --check` — clean
- [x] `mypy src/meho_backplane/operations/jsonflux_reducer.py` — clean
- [x] `pytest tests/test_operations_jsonflux_reducer.py` — 32 passed (6 new)
- [x] **AC1+2** `test_pod_info_above_threshold_keeps_container_statuses_inline` — a populated application pod (case B) projected via the real `pod_info`, over the byte threshold, ships the full flat object inline with **no** `source_key: "conditions"` collapse; every sibling (`containers`/`container_statuses`/`volumes`/`node`/`qos_class`) intact; `container_statuses[0]` carries name/image/ready/restart_count/state.
- [x] **AC3** fix applied at the JSONFlux reduction boundary (`_detect_collection`), not the k8s projection; unit-anchored by `test_detect_collection_exempts_dict_of_arrays_detail_object` + `test_detect_collection_keeps_single_list_flat_dict_as_collection`.
- [x] **AC4** `test_pod_info_below_threshold_still_returns_full_object_inline` — small-pod path unchanged (full flat object, no handle).
- [x] **AC5** `test_pod_info_docstring_documents_container_statuses_contract` — pins the `pod_info` docstring contract + proves `container_status_row` emits name/image/ready/restart_count/state.
- [x] No regression: `tests/test_connectors_k8s_workload.py` + `tests/test_connectors_k8s_logs.py` (67 passed); `tests/test_operations_dispatcher.py` + `test_vmware_rest_jsonflux_force_handle.py` (43 passed, 1 skipped).

## Out of scope
- No FastAPI route/schema touched → no OpenAPI regen.
- Sibling meho-internal #134 (same reducer, different defect) — untouched.

<!-- auto-implement-issue: fresh, iteration 1 -->

Closes #2113
