### PR TITLE
feat(connectors): migration 0052 — retire the registered-stub-twin vcf-logs orphan 0049 missed

### DIFF
--- a/backend/alembic/versions/0052_retire_registered_stub_twin_vcf_logs_orphan.py
+++ b/backend/alembic/versions/0052_retire_registered_stub_twin_vcf_logs_orphan.py
@@ -1,0 +1,239 @@
+# SPDX-License-Identifier: Apache-2.0
+# Copyright (c) 2026 evoila Group
+
+"""Retire the vcf-logs orphan ``0049`` missed (0-row registered stub twin).
+
+Revision ID: 0052
+Revises: 0051
+Create Date: 2026-07-06
+
+Initiative #2065 (G0.29 v0.19.0 closed-loop dogfood hardening), Task #2068.
+The forward complement of migration ``0049`` (#2001 / PR #2015): the
+same long-product ``vcf-logs`` ingest orphan, retired for the case
+``0049``'s live-twin ``EXISTS`` probe could not reach.
+
+Why this migration exists
+-------------------------
+
+Migration ``0049`` retires a long-product orphan
+(``product='vcf-logs'``, ``impl_id='vrli-rest-…'``) only when a
+short-product twin already exists **on the same per-op / per-group
+natural key** -- its guard is a correlated ``EXISTS`` on
+``endpoint_descriptor`` / ``operation_group`` requiring the short twin
+to carry a matching ``op_id`` / ``group_key`` at the **same version**.
+
+On the RDC v0.19.0 upgrade (#2068 finding) the orphan survived anyway.
+The canonical short representation (``vrli``) is registered via the
+**class-side v2 connector registry**, not by an ingest -- so it carries
+**zero** ``endpoint_descriptor`` / ``operation_group`` rows, and it sits
+at a **divergent version** (``9.0`` vs the orphan's ``9.0.2``).
+``0049``'s per-op ``EXISTS`` probe therefore matches nothing and retires
+nothing, leaving the 136-op orphan in place through every upgrade. That
+orphan is exactly the undeletable review-shadow dead weight ``0049`` and
+#1910 set out to clear: non-dispatchable (dispatch keys on the short
+``parse_connector_id``-derived product) and unreachable by
+``meho.connector.delete`` (which resolves a divergent-product row to
+``ConnectorNotFoundError``, #1910).
+
+Fix shape -- key on the orphan's OWN attributes, not a DB twin
+--------------------------------------------------------------
+
+The critical correction over ``0049`` (and over this task's own earlier
+draft, which prescribed a looser connector-grain DB twin probe): the
+retire predicate must **NOT depend on any DB-visible short twin**. A
+class-registry short connector has no ``endpoint_descriptor`` /
+``operation_group`` rows, so *any* ``EXISTS`` probe against those tables
+-- ``0049``'s per-op correlation or a connector-grain one -- returns
+false for a 0-row stub and retires nothing, re-encoding the exact miss.
+
+Instead the predicate keys entirely on the orphan row itself:
+
+* ``tenant_id IS NULL`` -- built-in / global rows only. Tenant-scoped
+  rows are operator-owned (#1699 NULL/UUID-namespace contract) and are
+  **never** deleted. Same boundary ``0049`` / ``0038`` drew.
+* ``product = '<long>'`` -- the row still carries the pre-#1677 registry
+  spelling (one of the six ``_PRODUCT_SPLITS`` long products).
+* ``impl_id = '<short>' OR impl_id LIKE '<short>-%'`` --
+  ``parse_connector_id``'s first-hyphen-segment rule
+  (``operations/_lookup.py:57``) in portable SQL. This scopes the
+  DELETE to rows the dispatcher *would* resolve under the short
+  spelling, so a ``product='vcf-logs'`` row whose ``impl_id`` derives
+  some *other*, non-split product is left alone -- impl_id-family
+  scoping, identical to ``0049``.
+
+There is deliberately **no** ``EXISTS`` clause.
+
+Why retiring without a DB twin is safe
+--------------------------------------
+
+The short product for each split in ``_PRODUCT_SPLITS`` is a **registered
+connector class** in the v2 registry -- the live, dispatchable
+representation of that connector, present regardless of whether it has
+ingested any operation rows yet. The dispatch / query surface
+(:func:`~meho_backplane.operations._lookup.connector_exists`,
+``count_known_ops``, ``list_operation_groups``) keys on the short
+``parse_connector_id``-derived product, so a long-product orphan whose
+``impl_id`` derives a known-split short product is **always**
+non-dispatchable and is **never** the sole *live* representation of that
+connector -- the registered short class is. Retiring it therefore loses
+no reachable data. This class-registry invariant is what ``0049``'s
+per-op DB probe tried and failed to approximate; keying on the orphan's
+own ``impl_id`` states it directly.
+
+Relationship to ``0049``'s twin-less guard
+------------------------------------------
+
+``0049`` deliberately preserved a *twin-less* long row on the theory it
+might be the only representation of an operation (``0038`` would rewrite
+it on the write side). That caution is correct only for a long product
+**outside** ``_PRODUCT_SPLITS``. For a long product **inside** the split
+map, the short target is a registered connector class by construction,
+so "no DB twin rows" means "not yet ingested under the short spelling",
+**not** "no live representation". This migration retires exactly that
+in-split subset; anything outside the split map is untouched (there is
+no such row in the built-in set, but the impl_id/product scoping makes
+the boundary explicit).
+
+Idempotency
+-----------
+
+Self-idempotent: once the orphan rows are gone the predicate matches
+nothing, so a re-run or a stamp-back replay is a no-op. No
+``updated_at`` to bump on a DELETE. ``endpoint_descriptor`` and
+``operation_group`` are retired under the same predicate, so a
+connector's descriptors and groups go together.
+
+Reversibility contract
+----------------------
+
+``downgrade()`` is a documented no-op, same rationale as ``0049`` /
+``0038``: the retired rows were never dispatchable and carried no
+operator value; the registered short class served every dispatch /
+review probe. Recreating them would re-introduce the undeletable
+``vcf-logs`` shadow. No DDL runs in ``upgrade()``, so there is nothing to
+undo at the schema layer; production rollback is image-revert under the
+additive-only forward-compat contract (``docs/codebase/migrations.md``).
+
+Fix shape -- Alembic data migration
+-----------------------------------
+
+Same self-contained shape as ``0011`` / ``0038`` / ``0046`` / ``0047``
+/ ``0049``: lightweight :func:`sa.table` / :func:`sa.column` shims
+mirror only the columns the migration touches, no ORM imports (replay
+safety), each statement executes via ``op.get_bind()``. No UUID bind
+params are written (DELETE by text predicates only), so the
+``docs/codebase/migrations.md`` UUID-binding rule does not apply.
+
+Cross-references
+----------------
+
+* Task #2068 / Initiative #2065 -- this cleanup.
+* Migration ``0049`` / #2001 / PR #2015 -- the retire whose per-op
+  ``EXISTS`` twin probe this completes for the 0-row registered stub.
+* Issue #1910 -- the original dogfood finding (stale ``vcf-logs`` row +
+  undeletability).
+* Migrations ``0038`` / #1701, ``0047`` / #1814 -- the backfill and
+  ``targets.product`` reconciliation this operation-row cleanup follows.
+* :func:`~meho_backplane.operations._lookup.parse_connector_id`
+  (``operations/_lookup.py:57``) -- the product-derivation rule the
+  impl_id predicate mirrors.
+* :mod:`tests.test_migration_0052_retire_registered_stub_twin_vcf_logs_orphan`
+  -- the behavioural contract, incl. the 0-row registered-stub-twin case
+  a naive DB-``EXISTS``-twin implementation MUST fail.
+"""
+
+from __future__ import annotations
+
+from collections.abc import Sequence
+
+import sqlalchemy as sa
+from alembic import op
+
+# revision identifiers, used by Alembic.
+revision: str = "0052"
+down_revision: str | None = "0051"
+branch_labels: str | Sequence[str] | None = None
+depends_on: str | Sequence[str] | None = None
+
+
+#: Every known long->short product split, as ``(long_product,
+#: short_product)``. Snapshot of ``_PRODUCT_SPLITS`` in migration
+#: ``0049`` (:mod:`...0049...` at ``:192``), which in turn snapshots
+#: ``0038``'s mapping. The impl_id predicate is *derived* from the short
+#: product (:func:`~meho_backplane.operations._lookup.parse_connector_id`
+#: derives the product from the first hyphen-segment of ``impl_id``).
+_PRODUCT_SPLITS: tuple[tuple[str, str], ...] = (
+    ("hetzner-robot", "hetzner"),
+    ("sddc-manager", "sddc"),
+    ("vcf-automation", "vcfa"),
+    ("vcf-fleet", "fleet"),
+    ("vcf-logs", "vrli"),
+    ("vcf-operations", "vrops"),
+)
+
+
+def _retire_table(*, table_name: str) -> None:
+    """Issue one guarded DELETE per product split against *table_name*.
+
+    Unlike ``0049``'s ``_retire_table``, there is no ``op_discriminator``
+    and no correlated twin subquery: the predicate keys solely on the
+    orphan row's own ``tenant_id`` / ``product`` / ``impl_id``. Retiring
+    is safe because the short product for each split is a registered
+    connector class (the live representation), so a ``tenant_id IS NULL``
+    long orphan whose ``impl_id`` derives a known-split short product is
+    never the sole live copy -- see the module docstring.
+
+    One statement per split keeps the SQL log attributable (same
+    auditability call as ``0038`` / ``0049``); the built-in row volume is
+    small.
+    """
+    shim = sa.table(
+        table_name,
+        sa.column("tenant_id", sa.Uuid()),
+        sa.column("product", sa.Text()),
+        sa.column("impl_id", sa.Text()),
+    )
+    bind = op.get_bind()
+
+    for long_product, short_product in _PRODUCT_SPLITS:
+        stmt = sa.delete(shim).where(
+            shim.c.tenant_id.is_(None),
+            shim.c.product == long_product,
+            # First-hyphen-segment rule from ``parse_connector_id``: the
+            # dispatcher resolves this row under ``short_product`` exactly
+            # when ``impl_id`` is the short product itself or starts with
+            # ``"<short>-"``. Scopes the DELETE to rows genuinely tied to
+            # a known split; a foreign-impl_id row is left alone.
+            sa.or_(
+                shim.c.impl_id == short_product,
+                shim.c.impl_id.like(f"{short_product}-%"),
+            ),
+        )
+        bind.execute(stmt)
+
+
+def upgrade() -> None:
+    """Retire the in-split long-product orphan rows, twin or no twin.
+
+    Both row surfaces the dispatch/query layer reads --
+    ``endpoint_descriptor`` and ``operation_group`` -- are retired under
+    the same predicate so a connector's orphaned descriptors and groups
+    are removed together, leaving the registered short connector class as
+    the sole live representation.
+    """
+    _retire_table(table_name="endpoint_descriptor")
+    _retire_table(table_name="operation_group")
+
+
+def downgrade() -> None:
+    """No-op by design.
+
+    The retired rows were never dispatchable (that is the defect this
+    migration fixes) and carried no operator value -- the registered
+    short connector class served every dispatch / review probe.
+    Recreating them would re-introduce the undeletable ``vcf-logs``
+    shadow. No DDL runs in ``upgrade()``, so there is nothing to undo at
+    the schema layer. Same documented-no-op shape as ``0049`` / ``0038``.
+    """
+    # Intentionally empty -- see docstring. The function stays defined so
+    # ``alembic downgrade -1`` resolves the symbol cleanly.

--- a/backend/tests/test_migration_0049_retire_stale_vcf_logs_orphan_rows.py
+++ b/backend/tests/test_migration_0049_retire_stale_vcf_logs_orphan_rows.py
@@ -413,6 +413,14 @@ def test_twin_less_long_row_preserved(
     is present. A twin-less long row is left for ``0038``'s rewrite (the
     write-side path); deleting it would lose the only copy of that
     operation.
+
+    Pinned to ``0049``'s own revision (not ``head``): this asserts
+    ``0049``'s intermediate contract. Migration ``0052`` (#2068)
+    deliberately supersedes it -- for an in-split long product the short
+    target is a registered connector class, so a "twin-less" in-split row
+    is not the sole *live* representation and ``0052`` retires it. Running
+    to ``head`` would therefore (correctly) delete this row; pinning keeps
+    the ``0049``-level assertion honest and revision-scoped.
     """
     cfg, sync_url = alembic_cfg
     command.upgrade(cfg, "0048")
@@ -432,7 +440,7 @@ def test_twin_less_long_row_preserved(
         group_key="system",
     )
 
-    command.upgrade(cfg, "head")
+    command.upgrade(cfg, "0049")
 
     for table, row_id in (
         ("endpoint_descriptor", lone_descriptor),

--- a/backend/tests/test_migration_0052_retire_registered_stub_twin_vcf_logs_orphan.py
+++ b/backend/tests/test_migration_0052_retire_registered_stub_twin_vcf_logs_orphan.py
@@ -1,0 +1,587 @@
+# SPDX-License-Identifier: Apache-2.0
+# Copyright (c) 2026 evoila Group
+
+"""Behavioural tests for ``0052_retire_registered_stub_twin_vcf_logs_orphan``.
+
+Initiative #2065 (G0.29 v0.19.0 closed-loop dogfood hardening), Task #2068.
+The forward complement of migration ``0049`` (#2001 / PR #2015): it
+retires the long-product ``vcf-logs`` ingest orphan for the case
+``0049``'s per-op ``EXISTS`` twin probe could not reach -- a
+short-product representation that is a **0-row class-registry stub at a
+divergent version**.
+
+Revision pin
+------------
+
+Every test drives the forward pass with ``command.upgrade(cfg, "0052")``
+(this migration's own revision), NOT ``"head"``. Pinning keeps the
+contract stable against future sibling migrations and avoids the
+stamp-back replay footgun. The idempotency test replays via
+``stamp("0051") -> upgrade("0052")``.
+
+The load-bearing case
+---------------------
+
+:func:`test_retire_with_zero_row_registered_stub_twin_at_divergent_version`
+seeds **only** the long orphan -- no ``endpoint_descriptor`` /
+``operation_group`` short-twin rows at all -- mirroring a short product
+that is registered purely via the v2 connector *class* registry. A naive
+DB-``EXISTS``-twin implementation (``0049``'s shape, or any connector-
+grain probe against these tables) matches zero rows and retires nothing,
+so it MUST fail this test. This migration keys on the orphan's own
+``impl_id`` and retires it.
+
+Sync-test constraint: ``alembic.command.upgrade`` drives env.py's async
+cookbook through ``asyncio.run``, so test functions stay sync and the
+dispatch-probe test wraps its async probe in its own ``asyncio.run``
+with an engine-cache reset on each side. Mirrors
+:mod:`tests.test_migration_0049_retire_stale_vcf_logs_orphan_rows`.
+"""
+
+from __future__ import annotations
+
+import asyncio
+from collections.abc import Iterator
+from pathlib import Path
+from typing import Final
+from uuid import UUID, uuid4
+
+import pytest
+from alembic import command
+from alembic.config import Config
+from sqlalchemy import create_engine as sa_create_engine
+from sqlalchemy import text
+
+from meho_backplane.db.engine import dispose_engine, reset_engine_for_testing
+from meho_backplane.db.migrations import alembic_config
+from meho_backplane.operations._lookup import (
+    connector_exists,
+    count_known_ops,
+    parse_connector_id,
+)
+from meho_backplane.settings import get_settings
+
+#: This migration's own revision -- the forward-pass target (NOT ``head``).
+_THIS_REVISION: Final[str] = "0052"
+#: The immediately preceding head this migration revises.
+_DOWN_REVISION: Final[str] = "0051"
+
+#: The six long->short splits the migration retires, as
+#: ``(long_product, impl_id, short_product)``. Mirrors ``_PRODUCT_SPLITS``
+#: inside migration 0052 (which snapshots 0049 / 0038's mapping). The
+#: ``impl_id`` here derives ``short_product`` via ``parse_connector_id``.
+_SPLITS: Final[list[tuple[str, str, str]]] = [
+    ("hetzner-robot", "hetzner-rest", "hetzner"),
+    ("sddc-manager", "sddc-rest", "sddc"),
+    ("vcf-automation", "vcfa-rest", "vcfa"),
+    ("vcf-fleet", "fleet-rest", "fleet"),
+    ("vcf-logs", "vrli-rest", "vrli"),
+    ("vcf-operations", "vrops-rest", "vrops"),
+]
+
+#: The orphan's divergent version (``9.0.2``) vs the registered stub's
+#: base version (``9.0``) -- the version mismatch that broke 0049's probe.
+_ORPHAN_VERSION: Final[str] = "9.0.2"
+_STUB_VERSION: Final[str] = "9.0"
+
+#: Stable seed timestamp -- lets assertions tell "row untouched" apart.
+_SEED_TS: Final[str] = "2026-01-01T00:00:00+00:00"
+
+
+@pytest.fixture
+def alembic_cfg(
+    monkeypatch: pytest.MonkeyPatch,
+    tmp_path: Path,
+) -> Iterator[tuple[Config, str]]:
+    """Pin env, reset caches, return an Alembic config + sync URL.
+
+    Same harness as
+    :mod:`tests.test_migration_0049_retire_stale_vcf_logs_orphan_rows`:
+    sync fixture (``alembic.command`` calls ``asyncio.run`` internally),
+    per-test SQLite file under ``tmp_path``, settings + engine caches
+    reset on both sides so the alembic env and the dispatch probes read
+    *this* ``DATABASE_URL``.
+    """
+    db_path = tmp_path / "migration_0052.db"
+    async_url = f"sqlite+aiosqlite:///{db_path}"
+    sync_url = f"sqlite:///{db_path}"
+    monkeypatch.setenv("DATABASE_URL", async_url)
+    monkeypatch.setenv("KEYCLOAK_ISSUER_URL", "https://keycloak.test/realms/meho")
+    monkeypatch.setenv("KEYCLOAK_AUDIENCE", "meho-backplane")
+    monkeypatch.setenv("VAULT_ADDR", "https://vault.test")
+    get_settings.cache_clear()
+    reset_engine_for_testing()
+
+    cfg = alembic_config()
+    cfg.set_main_option("sqlalchemy.url", async_url)
+    try:
+        yield cfg, sync_url
+    finally:
+        get_settings.cache_clear()
+        reset_engine_for_testing()
+
+
+def _insert_descriptor_row(
+    sync_url: str,
+    *,
+    tenant_id: UUID | None,
+    product: str,
+    impl_id: str,
+    op_id: str,
+    version: str = _ORPHAN_VERSION,
+) -> UUID:
+    """Insert one minimal ``endpoint_descriptor`` row at the migration base.
+
+    Raw SQL (not the ORM) keeps the seed pinned to the schema the
+    migration runs against. Columns with SQLite server defaults from
+    migration 0005 (``tags``, ``parameter_schema``, ``safety_level``,
+    ``requires_approval``, ``is_enabled``) are omitted; ``is_enabled``
+    defaults to 1, which the ``count_known_ops`` probe relies on. UUID
+    binds use ``.hex`` per ``docs/codebase/migrations.md``.
+    """
+    row_id = uuid4()
+    sync_eng = sa_create_engine(sync_url)
+    try:
+        with sync_eng.begin() as conn:
+            conn.execute(
+                text(
+                    """
+                    INSERT INTO endpoint_descriptor (
+                        id, tenant_id, product, version, impl_id, op_id,
+                        source_kind, created_at, updated_at
+                    ) VALUES (
+                        :id, :tenant_id, :product, :version, :impl_id, :op_id,
+                        'ingested', :ts, :ts
+                    )
+                    """,
+                ),
+                {
+                    "id": row_id.hex,
+                    "tenant_id": tenant_id.hex if tenant_id is not None else None,
+                    "product": product,
+                    "version": version,
+                    "impl_id": impl_id,
+                    "op_id": op_id,
+                    "ts": _SEED_TS,
+                },
+            )
+    finally:
+        sync_eng.dispose()
+    return row_id
+
+
+def _insert_group_row(
+    sync_url: str,
+    *,
+    tenant_id: UUID | None,
+    product: str,
+    impl_id: str,
+    group_key: str,
+    version: str = _ORPHAN_VERSION,
+) -> UUID:
+    """Insert one minimal ``operation_group`` row at the migration base."""
+    row_id = uuid4()
+    sync_eng = sa_create_engine(sync_url)
+    try:
+        with sync_eng.begin() as conn:
+            conn.execute(
+                text(
+                    """
+                    INSERT INTO operation_group (
+                        id, tenant_id, product, version, impl_id, group_key,
+                        name, when_to_use, review_status, created_at, updated_at
+                    ) VALUES (
+                        :id, :tenant_id, :product, :version, :impl_id, :group_key,
+                        :name, 'seeded for 0052 retire test', 'enabled', :ts, :ts
+                    )
+                    """,
+                ),
+                {
+                    "id": row_id.hex,
+                    "tenant_id": tenant_id.hex if tenant_id is not None else None,
+                    "product": product,
+                    "version": version,
+                    "impl_id": impl_id,
+                    "group_key": group_key,
+                    "name": group_key.title(),
+                    "ts": _SEED_TS,
+                },
+            )
+    finally:
+        sync_eng.dispose()
+    return row_id
+
+
+def _row_exists(sync_url: str, table: str, row_id: UUID) -> bool:
+    """Return whether a row with ``row_id`` is still present in ``table``."""
+    sync_eng = sa_create_engine(sync_url)
+    try:
+        with sync_eng.connect() as conn:
+            count = conn.execute(
+                text(f"SELECT COUNT(*) FROM {table} WHERE id = :id"),
+                {"id": row_id.hex},
+            ).scalar_one()
+            return int(count) == 1
+    finally:
+        sync_eng.dispose()
+
+
+def _read_updated_at(sync_url: str, table: str, row_id: UUID) -> str:
+    """Return ``updated_at`` for one row, as a string."""
+    sync_eng = sa_create_engine(sync_url)
+    try:
+        with sync_eng.connect() as conn:
+            row = conn.execute(
+                text(f"SELECT updated_at FROM {table} WHERE id = :id"),
+                {"id": row_id.hex},
+            ).one()
+            return str(row.updated_at)
+    finally:
+        sync_eng.dispose()
+
+
+def _count_by_product(sync_url: str, table: str, product: str) -> int:
+    """Return ``COUNT(*)`` for one product on one table."""
+    sync_eng = sa_create_engine(sync_url)
+    try:
+        with sync_eng.connect() as conn:
+            count = conn.execute(
+                text(f"SELECT COUNT(*) FROM {table} WHERE product = :product"),
+                {"product": product},
+            ).scalar_one()
+            return int(count)
+    finally:
+        sync_eng.dispose()
+
+
+def test_retire_with_zero_row_registered_stub_twin_at_divergent_version(
+    alembic_cfg: tuple[Config, str],
+) -> None:
+    """The case ``0049`` missed: retire with NO DB-visible short twin.
+
+    The short (``vrli``) representation is a v2 class-registry stub with
+    **zero** ``endpoint_descriptor`` / ``operation_group`` rows, sitting
+    at a divergent version (``9.0`` vs the orphan's ``9.0.2``). ``0049``'s
+    per-op ``EXISTS`` probe -- and any connector-grain DB twin probe --
+    matches nothing here and would retire nothing.
+
+    A naive DB-``EXISTS``-twin implementation MUST fail this test: it
+    would leave both orphan rows in place.
+    """
+    cfg, sync_url = alembic_cfg
+    command.upgrade(cfg, _DOWN_REVISION)
+
+    # Seed ONLY the long orphan -- no short-product descriptor/group rows.
+    orphan_descriptor = _insert_descriptor_row(
+        sync_url,
+        tenant_id=None,
+        product="vcf-logs",
+        impl_id="vrli-rest",
+        op_id="GET:/api/v2/version",
+        version=_ORPHAN_VERSION,
+    )
+    orphan_group = _insert_group_row(
+        sync_url,
+        tenant_id=None,
+        product="vcf-logs",
+        impl_id="vrli-rest",
+        group_key="system",
+        version=_ORPHAN_VERSION,
+    )
+
+    command.upgrade(cfg, _THIS_REVISION)
+
+    assert not _row_exists(sync_url, "endpoint_descriptor", orphan_descriptor), (
+        "the orphan descriptor must be retired even with a 0-row registered "
+        "stub twin at a divergent version -- keyed on its own impl_id, not a "
+        "DB twin (the 0049 miss)"
+    )
+    assert not _row_exists(sync_url, "operation_group", orphan_group), (
+        "the orphan group must be retired under the same impl_id predicate"
+    )
+
+
+def test_retire_with_full_twin_still_retires(
+    alembic_cfg: tuple[Config, str],
+) -> None:
+    """The case ``0049`` already handled: full per-op short twin present.
+
+    A short twin carrying the same ``op_id`` / ``group_key`` is present.
+    This migration still retires the long orphan (keyed on impl_id) and
+    leaves the short twin untouched -- parity with ``0049`` on its own
+    happy path.
+    """
+    cfg, sync_url = alembic_cfg
+    command.upgrade(cfg, _DOWN_REVISION)
+
+    orphan_descriptor = _insert_descriptor_row(
+        sync_url,
+        tenant_id=None,
+        product="vcf-logs",
+        impl_id="vrli-rest",
+        op_id="GET:/api/v2/version",
+        version=_ORPHAN_VERSION,
+    )
+    twin_descriptor = _insert_descriptor_row(
+        sync_url,
+        tenant_id=None,
+        product="vrli",
+        impl_id="vrli-rest",
+        op_id="GET:/api/v2/version",
+        version=_STUB_VERSION,
+    )
+    orphan_group = _insert_group_row(
+        sync_url,
+        tenant_id=None,
+        product="vcf-logs",
+        impl_id="vrli-rest",
+        group_key="system",
+        version=_ORPHAN_VERSION,
+    )
+    twin_group = _insert_group_row(
+        sync_url,
+        tenant_id=None,
+        product="vrli",
+        impl_id="vrli-rest",
+        group_key="system",
+        version=_STUB_VERSION,
+    )
+
+    command.upgrade(cfg, _THIS_REVISION)
+
+    for table, orphan_id, twin_id in (
+        ("endpoint_descriptor", orphan_descriptor, twin_descriptor),
+        ("operation_group", orphan_group, twin_group),
+    ):
+        assert not _row_exists(sync_url, table, orphan_id), (
+            f"the long-product {table} orphan must be retired"
+        )
+        assert _row_exists(sync_url, table, twin_id), (
+            f"the live short-product {table} twin must survive untouched"
+        )
+        assert _read_updated_at(sync_url, table, twin_id) == _SEED_TS, (
+            f"the surviving {table} twin must not be touched"
+        )
+
+
+def test_all_six_splits_retire_without_a_twin(
+    alembic_cfg: tuple[Config, str],
+) -> None:
+    """SQL-level: every long-product orphan retires with no short twin.
+
+    One orphan per split, seeded with NO short-product rows (the
+    registered-stub-twin shape). Post-migration every long-product count
+    is 0 on both tables.
+    """
+    cfg, sync_url = alembic_cfg
+    command.upgrade(cfg, _DOWN_REVISION)
+
+    for long_product, impl_id, _short_product in _SPLITS:
+        _insert_descriptor_row(
+            sync_url,
+            tenant_id=None,
+            product=long_product,
+            impl_id=impl_id,
+            op_id="GET:/api/v2/version",
+            version=_ORPHAN_VERSION,
+        )
+        _insert_group_row(
+            sync_url,
+            tenant_id=None,
+            product=long_product,
+            impl_id=impl_id,
+            group_key="system",
+            version=_ORPHAN_VERSION,
+        )
+
+    command.upgrade(cfg, _THIS_REVISION)
+
+    for long_product, _, _ in _SPLITS:
+        for table in ("endpoint_descriptor", "operation_group"):
+            assert _count_by_product(sync_url, table, long_product) == 0, (
+                f"no {table} row may remain under {long_product!r} after retire"
+            )
+
+
+def test_foreign_impl_id_rows_preserved(
+    alembic_cfg: tuple[Config, str],
+) -> None:
+    """The retire follows ``parse_connector_id``, not a blanket product match.
+
+    A ``product='vcf-logs'`` row whose ``impl_id`` first-hyphen-segment
+    is not ``vrli`` derives some other product, so the dispatcher would
+    not resolve it under ``vrli`` -- it is left alone (impl_id-family
+    scoping), even absent any twin.
+    """
+    cfg, sync_url = alembic_cfg
+    command.upgrade(cfg, _DOWN_REVISION)
+
+    foreign_impl = _insert_descriptor_row(
+        sync_url,
+        tenant_id=None,
+        product="vcf-logs",
+        impl_id="custom-rest",
+        op_id="GET:/api/v2/version",
+        version=_ORPHAN_VERSION,
+    )
+
+    command.upgrade(cfg, _THIS_REVISION)
+
+    assert _row_exists(sync_url, "endpoint_descriptor", foreign_impl), (
+        "a vcf-logs row whose impl_id derives a non-split product must be "
+        "preserved (impl_id-family scoping)"
+    )
+
+
+def test_tenant_scoped_rows_preserved(
+    alembic_cfg: tuple[Config, str],
+) -> None:
+    """``tenant_id IS NOT NULL`` rows are operator-owned and never deleted.
+
+    Even a tenant-scoped ``vcf-logs`` / ``vrli-rest`` row -- one that
+    would match the product + impl_id predicate on the NULL-tenant side
+    -- is out of scope (#1699 scoping contract).
+    """
+    cfg, sync_url = alembic_cfg
+    command.upgrade(cfg, _DOWN_REVISION)
+
+    tenant_id = uuid4()
+    tenant_descriptor = _insert_descriptor_row(
+        sync_url,
+        tenant_id=tenant_id,
+        product="vcf-logs",
+        impl_id="vrli-rest",
+        op_id="GET:/api/v2/version",
+        version=_ORPHAN_VERSION,
+    )
+    tenant_group = _insert_group_row(
+        sync_url,
+        tenant_id=tenant_id,
+        product="vcf-logs",
+        impl_id="vrli-rest",
+        group_key="system",
+        version=_ORPHAN_VERSION,
+    )
+
+    command.upgrade(cfg, _THIS_REVISION)
+
+    for table, row_id in (
+        ("endpoint_descriptor", tenant_descriptor),
+        ("operation_group", tenant_group),
+    ):
+        assert _row_exists(sync_url, table, row_id), (
+            f"tenant-scoped {table} row must never be deleted"
+        )
+
+
+def test_re_running_migration_is_idempotent(
+    alembic_cfg: tuple[Config, str],
+) -> None:
+    """Replaying ``upgrade()`` on a cleaned DB deletes nothing further.
+
+    Stamp-back replay pinned to this migration's own revision
+    (``stamp("0051") -> upgrade("0052")``), never ``head`` -- so future
+    schema migrations cannot leak into the replay.
+    """
+    cfg, sync_url = alembic_cfg
+    command.upgrade(cfg, _DOWN_REVISION)
+
+    orphan = _insert_descriptor_row(
+        sync_url,
+        tenant_id=None,
+        product="vcf-logs",
+        impl_id="vrli-rest",
+        op_id="GET:/api/v2/version",
+        version=_ORPHAN_VERSION,
+    )
+    # A tenant row that must survive both passes untouched.
+    survivor_tenant = uuid4()
+    survivor = _insert_descriptor_row(
+        sync_url,
+        tenant_id=survivor_tenant,
+        product="vcf-logs",
+        impl_id="vrli-rest",
+        op_id="GET:/api/v2/version",
+        version=_ORPHAN_VERSION,
+    )
+
+    command.upgrade(cfg, _THIS_REVISION)
+    assert not _row_exists(sync_url, "endpoint_descriptor", orphan)  # first pass landed
+    assert _row_exists(sync_url, "endpoint_descriptor", survivor)
+
+    command.stamp(cfg, _DOWN_REVISION)
+    command.upgrade(cfg, _THIS_REVISION)
+
+    assert not _row_exists(sync_url, "endpoint_descriptor", orphan), (
+        "the orphan stays gone on replay"
+    )
+    assert _row_exists(sync_url, "endpoint_descriptor", survivor), (
+        "the tenant survivor must persist across an idempotent replay"
+    )
+    assert _read_updated_at(sync_url, "endpoint_descriptor", survivor) == _SEED_TS, (
+        "a no-op replay must not disturb the surviving row"
+    )
+
+
+def test_live_short_representation_dispatches_post_migration(
+    alembic_cfg: tuple[Config, str],
+) -> None:
+    """Dispatch parity: the short spelling still resolves its ingested ops.
+
+    Seeds the invisible long orphan plus short-spelling ``vrli`` op rows
+    (standing in for a short representation that HAS ingested ops -- the
+    strongest dispatch-parity check). After the migration the orphan is
+    gone and the short product still resolves and counts its enabled ops.
+    """
+    cfg, sync_url = alembic_cfg
+    command.upgrade(cfg, _DOWN_REVISION)
+
+    for op_id in ("GET:/api/v2/version", "GET:/api/v2/events"):
+        _insert_descriptor_row(
+            sync_url,
+            tenant_id=None,
+            product="vcf-logs",
+            impl_id="vrli-rest",
+            op_id=op_id,
+            version=_STUB_VERSION,
+        )
+        _insert_descriptor_row(
+            sync_url,
+            tenant_id=None,
+            product="vrli",
+            impl_id="vrli-rest",
+            op_id=op_id,
+            version=_STUB_VERSION,
+        )
+
+    product, version, impl_id = parse_connector_id("vrli-rest-9.0")
+    assert (product, version, impl_id) == ("vrli", "9.0", "vrli-rest")
+
+    async def _probe() -> tuple[bool, int]:
+        reset_engine_for_testing()
+        try:
+            probe_tenant = uuid4()
+            exists = await connector_exists(
+                tenant_id=probe_tenant,
+                product=product,
+                version=version,
+                impl_id=impl_id,
+            )
+            known = await count_known_ops(
+                tenant_id=probe_tenant,
+                product=product,
+                version=version,
+                impl_id=impl_id,
+            )
+            return exists, known
+        finally:
+            await dispose_engine()
+
+    command.upgrade(cfg, _THIS_REVISION)
+
+    exists_after, known_after = asyncio.run(_probe())
+    assert exists_after is True, "the live short representation must still resolve"
+    assert known_after == 2, "both enabled ops on the short spelling must still count"
+    assert _count_by_product(sync_url, "endpoint_descriptor", "vcf-logs") == 0, (
+        "the long orphans are gone"
+    )


### PR DESCRIPTION
## Summary

- Adds data-only Alembic migration `0052` (revises head `0051`) that retires the stale long-product `vcf-logs` ingest orphan that migration `0049` (#2001 / PR #2015) missed — the case where the short (`vrli`) representation is a **0-row v2 class-registry stub at a divergent version** (`9.0` vs the orphan's `9.0.2`), so `0049`'s per-op `EXISTS` twin probe matched nothing and the 136-op orphan survived every upgrade (the #2068 finding; the #1910 review-shadow dead weight).
- The retire predicate keys on the orphan's **OWN** attributes — `tenant_id IS NULL` + a `_PRODUCT_SPLITS` long product + the `parse_connector_id` first-hyphen-segment `impl_id` rule (`operations/_lookup.py:57`) — with **no** DB-visible twin probe. Any `EXISTS` probe against `endpoint_descriptor`/`operation_group` returns false for a 0-row stub and would re-encode the exact `0049` miss; keying on `impl_id` is safe because each split's short product is a registered connector *class* (the live representation), so an in-split long orphan is never the sole live copy.
- Preserves `0049`'s other guards: tenant rows never deleted; `impl_id`-family scoping (a `vcf-logs` row whose `impl_id` derives a non-split product is left alone); `endpoint_descriptor` and `operation_group` retired together; `downgrade()` a documented no-op.

## Test plan

- [x] `ruff check` — clean (migration + both test files)
- [x] `ruff format --check` — clean
- [x] `mypy alembic/versions/0052_*.py --ignore-missing-imports` — no issues
- [x] `pytest tests/test_migration_0052_*.py` — 7 passed
- [x] `pytest tests/test_migration_0049_*.py` — 8 passed (regression; `test_twin_less_long_row_preserved` re-pinned to `upgrade("0049")` since `0052` deliberately supersedes that intermediate contract for the in-split subset)
- [x] Load-bearing discriminator proven: temporarily patching `0052` to a naive DB-`EXISTS`-twin implementation (0049's shape) makes `test_retire_with_zero_row_registered_stub_twin_at_divergent_version` **FAIL** — the test genuinely rejects the wrong implementation
- [x] `alembic heads` → single head `0052`; full chain `upgrade head` / `downgrade -1` / re-`upgrade head` clean on fresh SQLite
- [x] `code-quality.py --diff` — exit 0

### Acceptance criteria

- [x] In-split `vcf-logs` orphan retired even with a 0-row `registered` class-registry stub twin at a divergent version — predicate keys on the orphan's own `impl_id`, not a DB twin
- [x] `product='vcf-logs'` row whose `impl_id` derives a non-split product is preserved
- [x] Tenant-scoped (`tenant_id IS NOT NULL`) rows never deleted
- [x] Self-idempotent (stamp-back replay is a no-op); `downgrade()` no-op
- [x] Migration test pinned to its own revision (`stamp("0051") → upgrade("0052")`), covers the missed case + full-twin + non-split-impl_id + tenant + idempotency + dispatch parity

## Out of scope

- A `product` selector on `connector delete` (the #1910 reachability gap) — orthogonal.
- Re-running / amending `0049` (merged #2015) — `0052` is the forward complement.

<!-- auto-implement-issue: fresh, iteration 1 -->

Closes #2068


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Removed leftover orphan records from long-form `vcf-logs` entries during upgrade, helping keep related data consistent.
  * Preserved valid rows that belong to other tenants or unrelated identifier families.
  * Ensured the cleanup is safe to run multiple times without changing the final result.

* **Tests**
  * Added coverage for the migration’s cleanup behavior, retention rules, and idempotency.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->