### PR TITLE
fix(connectors): assert gh composite L2 backing at connector load (#2050)

### DIFF
--- a/backend/src/meho_backplane/connectors/github/composites/__init__.py
+++ b/backend/src/meho_backplane/connectors/github/composites/__init__.py
@@ -35,6 +35,7 @@ from meho_backplane.connectors.github.composites._read import (
     pr_status_summary_composite,
 )
 from meho_backplane.connectors.github.composites._register import (
+    UnbackedEnabledCompositeError,
     register_github_composite_operations,
 )
 from meho_backplane.operations.typed_register import register_typed_op_registrar
@@ -46,6 +47,7 @@ from meho_backplane.operations.typed_register import register_typed_op_registrar
 register_typed_op_registrar(register_github_composite_operations)
 
 __all__ = [
+    "UnbackedEnabledCompositeError",
     "pr_status_summary_composite",
     "preflight_l2_dependencies",
     "register_github_composite_operations",

--- a/backend/src/meho_backplane/connectors/github/composites/_register.py
+++ b/backend/src/meho_backplane/connectors/github/composites/_register.py
@@ -63,11 +63,60 @@ from meho_backplane.connectors.github.composites.schemas import (
     PR_STATUS_SUMMARY_PARAMETER_SCHEMA,
     PR_STATUS_SUMMARY_RESPONSE_SCHEMA,
 )
-from meho_backplane.operations.composite_backing import register_composite_backing
+from meho_backplane.operations.composite_backing import (
+    register_composite_backing,
+    registered_composite_backing,
+)
 from meho_backplane.operations.typed_register import register_composite_operation
 from meho_backplane.retrieval.embedding import EmbeddingService
 
-__all__ = ["register_github_composite_operations"]
+__all__ = [
+    "UnbackedEnabledCompositeError",
+    "register_github_composite_operations",
+]
+
+
+#: Infix marking a composite-to-composite recursion sub-op
+#: (``gh.composite.*``). Such sub-ops are registered by the lifespan
+#: registrar, not catalog-ingested, so they never need a backing entry --
+#: the assertion below skips a composite whose sub-ops are *all* of this
+#: form. Kept in sync with ``composite_backing._COMPOSITE_OP_INFIX`` (the
+#: presence walk skips the same shape); raw-REST L2 primitives are
+#: ``METHOD:/path`` strings and never contain it.
+_COMPOSITE_OP_INFIX = ".composite."
+
+
+class UnbackedEnabledCompositeError(RuntimeError):
+    """An enabled gh-rest composite dispatches raw L2 sub-ops with no backing.
+
+    Raised at import time (connector load) when a composite in
+    :data:`_COMPOSITES` dispatches into raw-REST L2 sub-ops but has no
+    :func:`~meho_backplane.operations.composite_backing.register_composite_backing`
+    entry, or its registered ``sub_op_ids`` drift from the spec's.
+
+    Every composite in :data:`_COMPOSITES` is an *enabled*
+    ``endpoint_descriptor`` row (``is_enabled=True``), so it surfaces on
+    the op listing as a callable hit. When its raw L2 sub-ops are not yet
+    ingested, the only thing that keeps the listing honest -- flagging the
+    hit ``unbacked`` with the catalog-ingest ``next_step`` instead of
+    advertising a working read it can't perform -- is the backing registry
+    entry the listing consults. A composite that reaches the descriptor
+    upsert without a matching backing would regress silently to the
+    pre-#1757 "enabled-but-``composite_l2_missing``" dead-end (#2050). This
+    guard fails loudly at connector load so that regression can't ship.
+    """
+
+
+def _composite_dispatches_raw_l2(spec: _CompositeSpec) -> bool:
+    """Return ``True`` when *spec* dispatches into at least one raw L2 sub-op.
+
+    A composite whose ``sub_op_ids`` are all composite-to-composite
+    recursion (``gh.composite.*``) needs no backing: its sub-ops are
+    guaranteed by the lifespan registrar, never catalog-ingested, so the
+    listing can never mark it ``unbacked``. Only composites that hit a
+    raw-REST primitive (``METHOD:/path``) need the backing safety net.
+    """
+    return any(_COMPOSITE_OP_INFIX not in sub_op for sub_op in spec.sub_op_ids)
 
 
 # Natural-key shorthand. Every gh-rest composite registers against the
@@ -159,25 +208,69 @@ _COMPOSITES: tuple[_CompositeSpec, ...] = (
 )
 
 
-# Import-time backing registration (G0.25-T6 #1757). A pure in-process
-# dict write -- no DB / embedding work -- so it runs at import (when this
-# module is first loaded, alongside the package ``__init__``'s
-# lifespan-registrar queueing), well before any request reaches the op
-# listing. This lets ``search_operations`` mark a composite ``unbacked``
-# with the catalog-ingest ``next_step`` while its L2 sub-ops are absent,
-# instead of advertising it as enabled-but-broken until the first
-# dispatch trips ``composite_l2_missing``. The ``connector_id`` +
-# ``catalog_command`` are the same values the preflight's
-# ``CompositeL2DependencyMissing`` carries, and ``sub_op_ids`` is the same
-# tuple the handler hands the preflight -- one source of truth across the
-# listing and the dispatch.
-for _spec in _COMPOSITES:
-    register_composite_backing(
-        composite_op_id=_spec.op_id,
-        connector_id=_CONNECTOR_ID,
-        sub_op_ids=_spec.sub_op_ids,
-        catalog_command=catalog_command_for_github_rest(),
-    )
+def _register_and_assert_composite_backings() -> None:
+    """Register each composite's backing, then assert the safety net holds.
+
+    Import-time (connector load). A pure in-process dict write -- no DB /
+    embedding work -- so it runs when this module is first loaded,
+    alongside the package ``__init__``'s lifespan-registrar queueing, well
+    before any request reaches the op listing.
+
+    Registration (G0.25-T6 #1757) lets ``search_operations`` mark a
+    composite ``unbacked`` with the catalog-ingest ``next_step`` while its
+    L2 sub-ops are absent, instead of advertising it as enabled-but-broken
+    until the first dispatch trips ``composite_l2_missing``. The
+    ``connector_id`` + ``catalog_command`` are the same values the
+    preflight's ``CompositeL2DependencyMissing`` carries, and
+    ``sub_op_ids`` is the same tuple the handler hands the preflight --
+    one source of truth across the listing and the dispatch.
+
+    The assertion (#2050) is the connector-load guard the listing marker
+    alone could not provide: every composite in :data:`_COMPOSITES` ships
+    *enabled* (``is_enabled=True``), so on a fresh deploy -- before any
+    ``meho connector ingest --catalog gh/3`` -- its raw L2 sub-ops are not
+    resolvable. The composite must NOT then advertise a working read it
+    can't perform; the ``unbacked`` marker keeps the listing honest, but
+    *only if* the backing was registered. This function asserts every
+    enabled composite that dispatches raw L2 sub-ops has a backing whose
+    ``sub_op_ids`` match the spec, so a future composite added without its
+    backing (or with a drifting sub-op tuple) fails loudly here rather
+    than regressing silently to the pre-#1757 dead-end. The check reads
+    the spec's own ``sub_op_ids`` -- the same single source of truth
+    (``_register.py`` spec ⇄ ``_read.py`` ``_SUB_OPS_*``) the preflight
+    and the listing marker already share -- so it asserts the wiring, not
+    the DB state (which is legitimately empty on a fresh deploy).
+    """
+    for spec in _COMPOSITES:
+        register_composite_backing(
+            composite_op_id=spec.op_id,
+            connector_id=_CONNECTOR_ID,
+            sub_op_ids=spec.sub_op_ids,
+            catalog_command=catalog_command_for_github_rest(),
+        )
+
+    for spec in _COMPOSITES:
+        if not _composite_dispatches_raw_l2(spec):
+            continue
+        backing = registered_composite_backing(spec.op_id)
+        if backing is None:
+            raise UnbackedEnabledCompositeError(
+                f"enabled composite {spec.op_id!r} dispatches raw L2 sub-ops "
+                f"{spec.sub_op_ids!r} but registered no composite backing; the op "
+                f"listing cannot mark it 'unbacked', so its first dispatch on a "
+                f"fresh deploy would dead-end at composite_l2_missing. Register "
+                f"the backing in this module's load path."
+            )
+        if backing.sub_op_ids != spec.sub_op_ids:
+            raise UnbackedEnabledCompositeError(
+                f"composite {spec.op_id!r} backing sub_op_ids {backing.sub_op_ids!r} "
+                f"drift from the spec's {spec.sub_op_ids!r}; the listing's 'unbacked' "
+                f"probe and the dispatch-time preflight would disagree on what the "
+                f"composite hits. Keep the backing and the spec on one source of truth."
+            )
+
+
+_register_and_assert_composite_backings()
 
 
 async def register_github_composite_operations(

--- a/backend/tests/test_connectors_github_composites_register.py
+++ b/backend/tests/test_connectors_github_composites_register.py
@@ -362,6 +362,137 @@ def test_importing_github_composites_registers_l2_backing() -> None:
     assert backing.catalog_command == catalog_command_for_github_rest()
 
 
+# ---------------------------------------------------------------------------
+# Connector-load assertion: an enabled composite's L2 backing must be wired
+# (#2050 -- guard against the enabled-but-composite_l2_missing regression)
+# ---------------------------------------------------------------------------
+
+
+def test_load_assertion_passes_on_the_shipped_specs() -> None:
+    """The real load path registers + asserts without raising (fresh-deploy safe).
+
+    The composite ships *enabled* with its raw L2 sub-ops uningested on a
+    fresh deploy, so the guard must assert the *backing wiring* (the
+    listing's ``unbacked`` safety net), not DB resolvability -- which is
+    legitimately empty before ``meho connector ingest --catalog gh/3``.
+    Re-running the load path is idempotent and must not raise.
+    """
+    from meho_backplane.connectors.github.composites import _register as reg
+
+    # No exception, and every raw-L2 composite has a matching backing.
+    reg._register_and_assert_composite_backings()
+
+    from meho_backplane.operations.composite_backing import registered_composite_backing
+
+    for spec in reg._COMPOSITES:
+        if not reg._composite_dispatches_raw_l2(spec):
+            continue
+        backing = registered_composite_backing(spec.op_id)
+        assert backing is not None
+        assert backing.sub_op_ids == spec.sub_op_ids
+
+
+def test_load_assertion_raises_when_enabled_raw_l2_composite_has_no_backing(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """A raw-L2 composite that reaches the upsert without a backing fails loudly.
+
+    Simulates the regression the guard exists to catch: a future composite
+    added to ``_COMPOSITES`` (or an edit that drops its backing
+    registration) would otherwise ship *enabled* on the listing with no
+    ``unbacked`` marker, dead-ending at ``composite_l2_missing`` on first
+    dispatch. Neutering the backing registration leaves the assert loop
+    with an empty registry, so the guard must raise.
+    """
+    from meho_backplane.connectors.github.composites import _register as reg
+    from meho_backplane.operations import composite_backing as backing_mod
+
+    saved = dict(backing_mod._REGISTRY)
+    backing_mod._REGISTRY.clear()
+    monkeypatch.setattr(reg, "register_composite_backing", lambda **_kwargs: None)
+    try:
+        with pytest.raises(reg.UnbackedEnabledCompositeError, match="registered no composite"):
+            reg._register_and_assert_composite_backings()
+    finally:
+        backing_mod._REGISTRY.clear()
+        backing_mod._REGISTRY.update(saved)
+
+
+def test_load_assertion_raises_on_sub_op_id_drift(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """A backing whose ``sub_op_ids`` drift from the spec fails loudly.
+
+    The listing's ``unbacked`` probe and the dispatch-time preflight both
+    read the sub-op tuple; a drift between the backing and the spec would
+    make them disagree on what the composite hits. The guard catches it at
+    connector load.
+    """
+    from meho_backplane.connectors.github.composites import _register as reg
+    from meho_backplane.operations import composite_backing as backing_mod
+
+    saved = dict(backing_mod._REGISTRY)
+    backing_mod._REGISTRY.clear()
+
+    def _register_drifting_backing(**_kwargs: object) -> None:
+        raw = next(s for s in reg._COMPOSITES if reg._composite_dispatches_raw_l2(s))
+        backing_mod.register_composite_backing(
+            composite_op_id=raw.op_id,
+            connector_id="gh-rest-3",
+            sub_op_ids=(*raw.sub_op_ids, "GET:/repos/{owner}/{repo}/extra-drift"),
+            catalog_command="meho connector ingest --catalog gh/3",
+        )
+
+    monkeypatch.setattr(reg, "register_composite_backing", _register_drifting_backing)
+    try:
+        with pytest.raises(reg.UnbackedEnabledCompositeError, match="drift"):
+            reg._register_and_assert_composite_backings()
+    finally:
+        backing_mod._REGISTRY.clear()
+        backing_mod._REGISTRY.update(saved)
+
+
+def test_load_assertion_skips_recursion_only_composite(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """A composite dispatching only ``gh.composite.*`` sub-ops needs no backing.
+
+    Composite-to-composite recursion sub-ops are guaranteed by the
+    lifespan registrar, never catalog-ingested, so the listing can never
+    mark such a composite ``unbacked`` -- the guard must skip it even with
+    an empty backing registry.
+    """
+    from meho_backplane.connectors.github.composites import _register as reg
+    from meho_backplane.operations import composite_backing as backing_mod
+
+    recursion_only = reg._CompositeSpec(
+        op_id="gh.composite.only_recursion",
+        handler=pr_status_summary_composite,
+        summary="s",
+        description="d",
+        parameter_schema={},
+        response_schema={},
+        group_key="pulls",
+        tags=["composite"],
+        safety_level="safe",
+        requires_approval=False,
+        sub_op_ids=("gh.composite.pr_status_summary",),
+    )
+    assert reg._composite_dispatches_raw_l2(recursion_only) is False
+
+    saved = dict(backing_mod._REGISTRY)
+    backing_mod._REGISTRY.clear()
+    monkeypatch.setattr(reg, "_COMPOSITES", (recursion_only,))
+    monkeypatch.setattr(reg, "register_composite_backing", lambda **_kwargs: None)
+    try:
+        # No backing registered, but the recursion-only composite is skipped,
+        # so the guard does not raise.
+        reg._register_and_assert_composite_backings()
+    finally:
+        backing_mod._REGISTRY.clear()
+        backing_mod._REGISTRY.update(saved)
+
+
 def test_handler_is_module_level_coroutine_function() -> None:
     """The handler is a plain module-level ``async def`` -- no closures / partials / lambdas.
 

--- a/docs/codebase/connectors-github.md
+++ b/docs/codebase/connectors-github.md
@@ -75,6 +75,22 @@ fully-backed composites never gain the marker. The MCP
 `search_operations` `outputSchema` carries the two fields so the agent
 transport sees the same shape.
 
+The listing marker keeps a *registered* composite honest, but nothing
+stopped a future composite from shipping **enabled** with no backing
+entry at all — it would then reappear on the listing as plainly enabled
+and dead-end at `composite_l2_missing` on first dispatch, exactly the
+pre-#1757 state. `_register.py`'s `_register_and_assert_composite_backings`
+closes that at **connector load** (#2050): after registering each
+composite's backing it asserts every enabled composite that dispatches
+raw L2 sub-ops has a backing whose `sub_op_ids` match the spec, raising
+`UnbackedEnabledCompositeError` otherwise. The check reads the spec's own
+`sub_op_ids` — the same `_register.py` spec ⇄ `_read.py` `_SUB_OPS_*`
+source of truth the preflight and the marker already share — so it
+asserts the *wiring*, not the DB state (legitimately empty on a fresh
+deploy before `meho connector ingest --catalog gh/3`). A composite added
+without its backing, or with a drifting sub-op tuple, fails loudly at
+import rather than regressing silently.
+
 Both summarisers — `_summarize_checks` and `_summarize_reviews` — are
 intentionally conservative: an unexpected payload shape collapses to
 `"unknown"` rather than guessing, and `_summarize_reviews` honours


### PR DESCRIPTION
## Summary

- The built-in `gh-rest-3` connector ships `gh.composite.pr_status_summary` **enabled**, but its three raw-REST L2 sub-ops only land after an operator runs `meho connector ingest --catalog gh/3`. On a fresh deploy the first dispatch trips `composite_l2_missing`.
- #1757 already added the listing `unbacked` marker (the op is surfaced enabled-but-unbacked with a catalog-ingest `next_step`, not as a working read) and the dispatch already returns a structured `composite_l2_missing` carrying the same catalog command — but nothing stopped a **future** composite from shipping enabled with no backing entry at all, silently regressing to the pre-#1757 dead-end.
- Adds `_register_and_assert_composite_backings` at **connector load** (import time): after registering each composite's backing it asserts every enabled composite dispatching raw L2 sub-ops has a backing whose `sub_op_ids` match the spec, raising `UnbackedEnabledCompositeError` otherwise.
- The check reads the spec's own `sub_op_ids` — the same `_register.py` spec ⇄ `_read.py` `_SUB_OPS_*` single source of truth the preflight and the marker already share — so it asserts the **wiring**, not DB state (legitimately empty on a fresh deploy before catalog ingest). This makes the enabled-but-unbacked inconsistency non-regressible **without crashing fresh deploys**, where the raw L2 ops are genuinely absent until ingest.

## Design note (amended ticket)

The ticket was amended 2026-07-05 to ratify a previously-blocked design after a prior auto-run parked it: option (a) "curate L2 in the built-in image" has no substrate (there is no lifespan/import path to seed raw-REST descriptors — that is the rejected Option-C of the preflight design and explicitly out of scope), and option (b) `is_enabled=False` makes the composite vanish from `search_operations` (the `is_enabled` filter). This PR implements the amended design: keep the composite **listed-but-disabled-with-`next_step` via the existing `unbacked` marker machinery** (`is_enabled` stays `True`), plus the connector-load assertion. The assertion is anchored on the backing **wiring** (what drives the `unbacked` safety net), not raw DB resolvability, so it holds on fresh deploys instead of crashing them.

## Test plan

- [x] `ruff check` — clean (changed files)
- [x] `ruff format --check` — clean
- [x] `mypy src/.../composites/_register.py --ignore-missing-imports` — clean
- [x] `pytest tests/test_connectors_github_composites_register.py tests/test_operations_composite_backing.py` — 24 passed (4 new: load-path passes on shipped specs; raises on missing backing; raises on sub_op_id drift; skips recursion-only composites)
- [x] `pytest tests/test_connectors_github_composites_l2_preflight.py tests/test_connectors_github_composites_read.py` — 26 passed (no collateral)
- [x] `code-quality.py --diff` — exit 0
- [x] **AC#1**: composite listed `unbacked=True` + `next_step` on a fresh deploy; dispatch surfaces structured `composite_l2_missing` with the catalog command — never a silent enabled-but-broken read (existing #1757 machinery preserved; backing tests green)
- [x] **AC#2**: connector-load assertion fails loudly when an enabled composite's `sub_op_ids` lack a resolvable backing — new tests
- [x] **AC#3**: `unbacked` marker stays truthful (backing registration preserved verbatim inside the new helper; `test_operations_composite_backing.py` unchanged and green)

## Out of scope

- Building any lifespan/import mechanism to seed built-in raw-REST L2 descriptors (option a) — no substrate exists and it is the ticket's out-of-scope "built-in connectors ship L2 curated vs. catalog-on-demand" policy.
- The generic composite-registration path (`register_composite_operation`) — vmware-rest composites deliberately do not register backings, so the guard is gh-specific at the gh composite load path.

<!-- auto-implement-issue: fresh, iteration 1 -->

Closes #2050
