### PR TITLE
feat(connectors): add vmware.composite.host.vsan_health read composite (#2135)

### DIFF
--- a/backend/src/meho_backplane/connectors/vmware_rest/composites/__init__.py
+++ b/backend/src/meho_backplane/connectors/vmware_rest/composites/__init__.py
@@ -13,7 +13,7 @@ The chassis lifespan's
 invokes every registered registrar in registration order after
 :func:`~meho_backplane.connectors.registry._eager_import_connectors`
 has walked every ``connectors/<product>/`` subpackage, so the
-``endpoint_descriptor`` upserts for the 14 composites land before
+``endpoint_descriptor`` upserts for the 15 composites land before
 any dispatch can fire.
 
 Layout mirrors the :mod:`meho_backplane.connectors.vault` pattern: the
@@ -24,9 +24,9 @@ Schema 2020-12 parameter + response contracts.
 
 Scope:
 
-* 6 read composites (G3.1-T5 / #508 shipped 5; #2080 adds
-  ``host.network_uplinks``) -- ``safety_level="safe"`` +
-  ``requires_approval=False`` overrides.
+* 7 read composites (G3.1-T5 / #508 shipped 5; #2080 adds
+  ``host.network_uplinks``; #2135 adds ``host.vsan_health``) --
+  ``safety_level="safe"`` + ``requires_approval=False`` overrides.
 * 8 write composites (G3.1-T6 / #509) -- inherit T4's
   ``safety_level="dangerous"`` + ``requires_approval=True`` defaults.
   The 8 cover every state-mutating workflow Goal #214 names as
@@ -45,6 +45,7 @@ from meho_backplane.connectors.vmware_rest.composites._read import (
     datastore_usage_composite,
     event_tail_composite,
     host_network_uplinks_composite,
+    host_vsan_health_composite,
     network_portgroup_audit_composite,
     performance_summary_composite,
 )
@@ -83,6 +84,7 @@ __all__ = [
     "host_detach_from_vds_composite",
     "host_evacuate_composite",
     "host_network_uplinks_composite",
+    "host_vsan_health_composite",
     "network_portgroup_audit_composite",
     "performance_summary_composite",
     "preflight_l2_dependencies",

--- a/backend/src/meho_backplane/connectors/vmware_rest/composites/_read.py
+++ b/backend/src/meho_backplane/connectors/vmware_rest/composites/_read.py
@@ -1,7 +1,7 @@
 # SPDX-License-Identifier: Apache-2.0
 # Copyright (c) 2026 evoila Group
 
-"""Read-only ``vmware.composite.*`` handler functions (6 composites).
+"""Read-only ``vmware.composite.*`` handler functions (7 composites).
 
 Each handler is a module-level ``async def`` that takes the dispatcher's
 composite-branch keyword args ``(operator, target, params,
@@ -90,6 +90,7 @@ __all__ = [
     "datastore_usage_composite",
     "event_tail_composite",
     "host_network_uplinks_composite",
+    "host_vsan_health_composite",
     "network_portgroup_audit_composite",
     "performance_summary_composite",
 ]
@@ -139,6 +140,21 @@ _PROPERTY_COLLECTOR_MOID = "propertyCollector"
 _HOST_SYSTEM_MO_TYPE = "HostSystem"
 _HOST_NET_PROP_PNIC = "config.network.pnic"
 _HOST_NET_PROP_PROXYSWITCH = "config.network.proxySwitch"
+# vSAN health is a health-service-only read: the plain vSphere
+# Automation REST surface exposes no vSAN health resource. It is served
+# by the dedicated ``/vsanHealth`` vmomi endpoint, whose
+# ``VsanVcClusterHealthSystem`` managed object (the singleton moId
+# ``vsan-cluster-health-system``) answers
+# ``VsanQueryVcClusterHealthSummary`` at cluster grain -- the ``govc
+# vsan.health.*`` equivalent. The method takes the target cluster's
+# MoRef and returns a ``VsanClusterHealthSummary`` carrying an
+# ``overallHealth`` colour plus a ``groups`` list of health-test groups
+# (each group -> ``groupTests`` list of individual checks).
+_OP_VSAN_QUERY_HEALTH_SUMMARY = (
+    "POST:/VsanVcClusterHealthSystem/{moId}/VsanQueryVcClusterHealthSummary"
+)
+_VSAN_CLUSTER_HEALTH_SYSTEM_MOID = "vsan-cluster-health-system"
+_CLUSTER_COMPUTE_RESOURCE_MO_TYPE = "ClusterComputeResource"
 
 # Composite op_ids -- used by the preflight cache key. Centralised here
 # so the test-side coverage assertion (every registered composite has
@@ -150,6 +166,7 @@ _COMPOSITE_OP_ID_PERFORMANCE_SUMMARY = "vmware.composite.performance.summary"
 _COMPOSITE_OP_ID_DATASTORE_USAGE = "vmware.composite.datastore.usage"
 _COMPOSITE_OP_ID_NETWORK_PORTGROUP_AUDIT = "vmware.composite.network.portgroup.audit"
 _COMPOSITE_OP_ID_HOST_NETWORK_UPLINKS = "vmware.composite.host.network_uplinks"
+_COMPOSITE_OP_ID_HOST_VSAN_HEALTH = "vmware.composite.host.vsan_health"
 
 # Per-composite sub-op-id tuples consumed by the L2 pre-flight check
 # (G0.14-T10 / #1151). Each tuple lists the L2 raw-REST sub-ops the
@@ -182,6 +199,7 @@ _SUB_OPS_HOST_NETWORK_UPLINKS: tuple[str, ...] = (
     _OP_LIST_HOSTS,
     _OP_RETRIEVE_PROPERTIES,
 )
+_SUB_OPS_HOST_VSAN_HEALTH: tuple[str, ...] = (_OP_VSAN_QUERY_HEALTH_SUMMARY,)
 
 
 def _unwrap_value(payload: Any) -> Any:
@@ -1062,3 +1080,136 @@ async def host_network_uplinks_composite(
             continue
         aggregated.append(await _build_host_uplink_row(host_id, entry.get("name"), dispatch_child))
     return {"hosts": aggregated}
+
+
+def _parse_vsan_health_test(test: dict[str, Any]) -> dict[str, Any]:
+    """Flatten one WS-API ``VsanClusterHealthTest`` into the operator-facing row.
+
+    A single health check inside a group: ``testId`` /``testName`` /
+    ``testHealth`` (the ``green`` / ``yellow`` / ``red`` colour) plus the
+    short human-readable description. The vSAN health-service owns the
+    inner colour vocabulary; the composite passes it through verbatim.
+    """
+    return {
+        "test_id": test.get("testId"),
+        "test_name": test.get("testName"),
+        "test_health": test.get("testHealth"),
+        "test_short_description": test.get("testShortDescription"),
+    }
+
+
+def _parse_vsan_health_group(group: dict[str, Any]) -> dict[str, Any]:
+    """Flatten one WS-API ``VsanClusterHealthGroup`` into the operator-facing row.
+
+    A group buckets related health checks (network, physical disk,
+    cluster, data, …). ``groupHealth`` is the group-level roll-up
+    colour; ``groupTests`` is the per-check list flattened via
+    :func:`_parse_vsan_health_test`. A missing / non-list ``groupTests``
+    degrades to an empty list rather than raising -- the group-level
+    colour is still meaningful on its own.
+    """
+    raw_tests = group.get("groupTests")
+    tests = (
+        [_parse_vsan_health_test(t) for t in raw_tests if isinstance(t, dict)]
+        if isinstance(raw_tests, list)
+        else []
+    )
+    return {
+        "group_id": group.get("groupId"),
+        "group_name": group.get("groupName"),
+        "group_health": group.get("groupHealth"),
+        "tests": tests,
+    }
+
+
+def _build_vsan_query_health_params(cluster_moid: str) -> dict[str, Any]:
+    """Build the ``VsanQueryVcClusterHealthSummary`` argument set for one cluster.
+
+    ``moId`` targets the ``vsan-cluster-health-system`` singleton on the
+    ``/vsanHealth`` vmomi endpoint; ``cluster`` carries the target
+    cluster's MoRef (a ``ClusterComputeResource``). Every other
+    parameter of the method (``includeObjUuids`` / ``fields`` / …) is
+    optional and left to the health service's defaults so the read
+    returns the full summary.
+    """
+    return {
+        "moId": _VSAN_CLUSTER_HEALTH_SYSTEM_MOID,
+        "cluster": {"type": _CLUSTER_COMPUTE_RESOURCE_MO_TYPE, "value": cluster_moid},
+    }
+
+
+async def host_vsan_health_composite(
+    *,
+    operator: Operator,
+    target: Any,
+    params: dict[str, Any],
+    dispatch_child: DispatchChild,
+) -> dict[str, Any]:
+    """Per cluster: vSAN health-test groups + overall health status.
+
+    Op-id: ``vmware.composite.host.vsan_health``.
+
+    Sub-ops dispatched:
+
+    1. ``POST:/VsanVcClusterHealthSystem/{moId}/VsanQueryVcClusterHealthSummary``
+       against the ``vsan-cluster-health-system`` singleton, scoped to
+       the target cluster's MoRef. This leg is **best-effort**: the
+       cluster is already identified by the ``cluster`` param, so when
+       the health-service read errors (a cluster with vSAN disabled, a
+       ``/vsanHealth`` endpoint that rejects the vi-json call, a
+       transient auth expiry) the summary is returned with ``groups`` /
+       ``overall_health`` set to ``null`` and a ``read_note`` recording
+       why, rather than raising through ``_require_ok``.
+
+    vSAN health is the one read the plain vSphere Automation REST
+    surface cannot reproduce: the health-test-group / overall-status
+    roll-up lives on the ``/vsanHealth`` vmomi service, so the composite
+    reaches it via the ``VsanVcClusterHealthSystem`` managed object --
+    the ``govc vsan.health.*`` equivalent. It drives cluster-health
+    triage ('is vSAN healthy?' / 'which health group is red?').
+
+    Returns
+    -------
+    dict[str, Any]
+        ``{"cluster": <moid>, "overall_health": <colour|null>,
+        "groups": [{"group_id": ..., "group_name": ...,
+        "group_health": ..., "tests": [{"test_id": ...,
+        "test_name": ..., "test_health": ...,
+        "test_short_description": ...}, ...]}, ...]}``. When the
+        best-effort health-service read is skipped, ``overall_health``
+        and ``groups`` are ``null`` and the payload carries a
+        ``read_note``.
+    """
+    await preflight_l2_dependencies(
+        composite_op_id=_COMPOSITE_OP_ID_HOST_VSAN_HEALTH,
+        sub_op_ids=_SUB_OPS_HOST_VSAN_HEALTH,
+        connector_id=_CONNECTOR_ID,
+        tenant_id=operator.tenant_id,
+    )
+    cluster_moid = params["cluster"]
+
+    out: dict[str, Any] = {"cluster": cluster_moid}
+    health_result = await dispatch_child(
+        connector_id=_CONNECTOR_ID,
+        op_id=_OP_VSAN_QUERY_HEALTH_SUMMARY,
+        params=_build_vsan_query_health_params(cluster_moid),
+    )
+    if health_result.status == "ok":
+        summary = _unwrap_value(health_result.result)
+        raw_groups = summary.get("groups") if isinstance(summary, dict) else None
+        overall = summary.get("overallHealth") if isinstance(summary, dict) else None
+        out["overall_health"] = overall
+        out["groups"] = (
+            [_parse_vsan_health_group(g) for g in raw_groups if isinstance(g, dict)]
+            if isinstance(raw_groups, list)
+            else []
+        )
+    else:
+        out["overall_health"] = None
+        out["groups"] = None
+        out["read_note"] = (
+            f"vsan health-service read skipped: sub-op "
+            f"{_OP_VSAN_QUERY_HEALTH_SUMMARY!r} returned status="
+            f"{health_result.status!r}: {_describe_sub_op_failure(health_result)}"
+        )
+    return out

--- a/backend/src/meho_backplane/connectors/vmware_rest/composites/_register.py
+++ b/backend/src/meho_backplane/connectors/vmware_rest/composites/_register.py
@@ -1,7 +1,7 @@
 # SPDX-License-Identifier: Apache-2.0
 # Copyright (c) 2026 evoila Group
 
-"""``register_vmware_composite_operations`` -- registrar for the 14 composites.
+"""``register_vmware_composite_operations`` -- registrar for the 15 composites.
 
 Module-level async function called from the lifespan-driven
 :func:`~meho_backplane.operations.typed_register.run_typed_op_registrars`
@@ -21,10 +21,11 @@ the source_kind="composite" persistence.
 Mixed safety posture
 --------------------
 
-The 6 read composites (T5 / #508 shipped 5; #2080 adds
-``host.network_uplinks``) pass ``safety_level="safe"`` +
-``requires_approval=False`` -- overrides of T4's ``dangerous`` /
-``True`` defaults. The 8 write composites (T6 / #509) inherit the T4
+The 7 read composites (T5 / #508 shipped 5; #2080 adds
+``host.network_uplinks``; #2135 adds ``host.vsan_health``) pass
+``safety_level="safe"`` + ``requires_approval=False`` -- overrides of
+T4's ``dangerous`` / ``True`` defaults. The 8 write composites (T6 /
+#509) inherit the T4
 defaults explicitly (pass ``"dangerous"`` / ``True`` for clarity at
 the call site; the helper would default to those values anyway).
 Each :class:`_CompositeSpec` row carries its own ``safety_level`` +
@@ -42,6 +43,7 @@ from meho_backplane.connectors.vmware_rest.composites._read import (
     datastore_usage_composite,
     event_tail_composite,
     host_network_uplinks_composite,
+    host_vsan_health_composite,
     network_portgroup_audit_composite,
     performance_summary_composite,
 )
@@ -70,6 +72,8 @@ from meho_backplane.connectors.vmware_rest.composites.schemas import (
     HOST_EVACUATE_RESPONSE_SCHEMA,
     HOST_NETWORK_UPLINKS_PARAMETER_SCHEMA,
     HOST_NETWORK_UPLINKS_RESPONSE_SCHEMA,
+    HOST_VSAN_HEALTH_PARAMETER_SCHEMA,
+    HOST_VSAN_HEALTH_RESPONSE_SCHEMA,
     NETWORK_PORTGROUP_AUDIT_PARAMETER_SCHEMA,
     NETWORK_PORTGROUP_AUDIT_RESPONSE_SCHEMA,
     PERFORMANCE_SUMMARY_PARAMETER_SCHEMA,
@@ -179,7 +183,11 @@ _WHEN_TO_USE_BY_GROUP: dict[str, str] = {
         "uplink association, the one read the plain REST surface "
         "cannot reproduce; the right group for 'are we out of "
         "physical switch ports?' / 'which pnics back this DVS "
-        "uplink?'. Write (dangerous / approval-required): evacuate "
+        "uplink?'. Read: host.vsan_health -- per cluster, the vSAN "
+        "health-test groups + overall status from the vSAN "
+        "health-service ('is vSAN healthy?' / 'which health group is "
+        "red?'), the govc vsan.health equivalent. Write (dangerous / "
+        "approval-required): evacuate "
         "every VM off a host (recursive composite call into "
         "vm.migrate) then enter maintenance, or detach a host from a "
         "DVS after migrating its VM NICs off; the host_evacuate "
@@ -347,6 +355,35 @@ _COMPOSITES: tuple[_CompositeSpec, ...] = (
         response_schema=HOST_NETWORK_UPLINKS_RESPONSE_SCHEMA,
         group_key="host",
         tags=["composite", "read-only", "host", "networking", "pnic"],
+        safety_level="safe",
+        requires_approval=False,
+    ),
+    _CompositeSpec(
+        op_id="vmware.composite.host.vsan_health",
+        handler=host_vsan_health_composite,
+        summary="Per cluster, vSAN health-test groups + overall health status.",
+        description=(
+            "Queries the vSAN health-service vmomi method "
+            "'POST:/VsanVcClusterHealthSystem/{moId}/"
+            "VsanQueryVcClusterHealthSummary' against the "
+            "'vsan-cluster-health-system' singleton, scoped to the "
+            "target cluster's MoRef. Returns the cluster-wide "
+            "'overall_health' colour plus the health-test 'groups' list "
+            "(each group with its own roll-up colour + per-check tests: "
+            "id / name / colour / short description). vSAN health is the "
+            "one read the plain vSphere Automation REST surface cannot "
+            "reproduce -- it lives on the dedicated '/vsanHealth' vmomi "
+            "endpoint -- so the composite is the 'govc vsan.health.*' "
+            "equivalent, driving cluster-health triage ('is vSAN "
+            "healthy?' / 'which health group is red?'). Best-effort: a "
+            "cluster with vSAN disabled or a rejected health-service "
+            "call returns null groups + a read_note rather than failing. "
+            "Read-only -- never mutates vSAN configuration."
+        ),
+        parameter_schema=HOST_VSAN_HEALTH_PARAMETER_SCHEMA,
+        response_schema=HOST_VSAN_HEALTH_RESPONSE_SCHEMA,
+        group_key="host",
+        tags=["composite", "read-only", "host", "vsan", "health"],
         safety_level="safe",
         requires_approval=False,
     ),
@@ -547,8 +584,9 @@ async def register_vmware_composite_operations(
     on every lifespan startup; the skip-re-embed branch keeps that
     cheap.
 
-    Scope: 14 composites total -- 6 read (T5 / #508 shipped 5;
-    #2080 adds ``host.network_uplinks``) + 8 write (T6 / #509).
+    Scope: 15 composites total -- 7 read (T5 / #508 shipped 5;
+    #2080 adds ``host.network_uplinks``; #2135 adds
+    ``host.vsan_health``) + 8 write (T6 / #509).
     Each composite's ``safety_level`` +
     ``requires_approval`` come from its :class:`_CompositeSpec` row:
     reads pass ``"safe"`` / ``False``; writes pass ``"dangerous"`` /

--- a/backend/src/meho_backplane/connectors/vmware_rest/composites/schemas.py
+++ b/backend/src/meho_backplane/connectors/vmware_rest/composites/schemas.py
@@ -1,7 +1,7 @@
 # SPDX-License-Identifier: Apache-2.0
 # Copyright (c) 2026 evoila Group
 
-"""JSON Schema 2020-12 parameter + response schemas for the 14 vmware-rest composites.
+"""JSON Schema 2020-12 parameter + response schemas for the 15 vmware-rest composites.
 
 Each schema is the operator-facing input contract; the dispatcher
 validates inbound ``params`` against the registered schema before
@@ -23,7 +23,7 @@ Conventions
   documentation lives on the schema's ``description`` keys; the meta-
   tools (:mod:`meho_backplane.operations.meta_tools`) surface the
   schema verbatim on ``describe_operation`` calls.
-* The 6 read composites are read-only -- the registration call site
+* The 7 read composites are read-only -- the registration call site
   pins ``safety_level="safe"`` and ``requires_approval=False`` on
   each. The 8 write composites inherit T4's
   ``safety_level="dangerous"`` + ``requires_approval=True`` defaults
@@ -51,6 +51,8 @@ __all__ = [
     "HOST_EVACUATE_RESPONSE_SCHEMA",
     "HOST_NETWORK_UPLINKS_PARAMETER_SCHEMA",
     "HOST_NETWORK_UPLINKS_RESPONSE_SCHEMA",
+    "HOST_VSAN_HEALTH_PARAMETER_SCHEMA",
+    "HOST_VSAN_HEALTH_RESPONSE_SCHEMA",
     "NETWORK_PORTGROUP_AUDIT_PARAMETER_SCHEMA",
     "NETWORK_PORTGROUP_AUDIT_RESPONSE_SCHEMA",
     "PERFORMANCE_SUMMARY_PARAMETER_SCHEMA",
@@ -279,6 +281,31 @@ HOST_NETWORK_UPLINKS_PARAMETER_SCHEMA: dict[str, Any] = {
         },
     },
     "required": [],
+    "additionalProperties": False,
+}
+
+
+#: ``vmware.composite.host.vsan_health`` parameter schema.
+#:
+#: Surfaces per-cluster vSAN health via the health-service vmomi method
+#: ``VsanQueryVcClusterHealthSummary`` on the
+#: ``vsan-cluster-health-system`` singleton. vSAN health is a
+#: cluster-scoped read (the ``govc vsan.health.*`` equivalent), so the
+#: composite requires the target cluster's managed-object ID.
+HOST_VSAN_HEALTH_PARAMETER_SCHEMA: dict[str, Any] = {
+    "type": "object",
+    "properties": {
+        "cluster": {
+            "type": "string",
+            "minLength": 1,
+            "description": (
+                "Managed-object ID of the vSAN cluster to check (e.g. "
+                "'domain-c123'). The composite scopes the health-service "
+                "query to this ClusterComputeResource MoRef."
+            ),
+        },
+    },
+    "required": ["cluster"],
     "additionalProperties": False,
 }
 
@@ -676,6 +703,102 @@ HOST_NETWORK_UPLINKS_RESPONSE_SCHEMA: dict[str, Any] = {
         },
     },
     "required": ["hosts"],
+}
+
+
+#: ``vmware.composite.host.vsan_health`` response schema.
+#:
+#: Captures the ``VsanClusterHealthSummary`` aggregation: the
+#: cluster-level ``overall_health`` colour plus the health-test
+#: ``groups`` list (each group with its own roll-up colour + per-check
+#: ``tests``). When the best-effort health-service read is skipped,
+#: ``overall_health`` and ``groups`` are ``null`` and a ``read_note``
+#: records why. The vSAN health-service owns the colour vocabulary
+#: (``green`` / ``yellow`` / ``red`` / ``unknown`` / ``info``); it is
+#: passed through verbatim.
+HOST_VSAN_HEALTH_RESPONSE_SCHEMA: dict[str, Any] = {
+    "type": "object",
+    "properties": {
+        "cluster": {
+            "type": "string",
+            "description": "Managed-object ID of the cluster the summary was read for.",
+        },
+        "overall_health": {
+            "type": ["string", "null"],
+            "description": (
+                "Cluster-wide vSAN health roll-up colour from "
+                "``VsanClusterHealthSummary.overallHealth``; ``null`` when "
+                "the best-effort health-service read was skipped (see "
+                "``read_note``)."
+            ),
+        },
+        "groups": {
+            "type": ["array", "null"],
+            "items": {
+                "type": "object",
+                "properties": {
+                    "group_id": {
+                        "type": ["string", "null"],
+                        "description": "Health-group identifier (``groupId``).",
+                    },
+                    "group_name": {
+                        "type": ["string", "null"],
+                        "description": "Human-readable group name (``groupName``).",
+                    },
+                    "group_health": {
+                        "type": ["string", "null"],
+                        "description": "Group-level roll-up colour (``groupHealth``).",
+                    },
+                    "tests": {
+                        "type": "array",
+                        "items": {
+                            "type": "object",
+                            "properties": {
+                                "test_id": {
+                                    "type": ["string", "null"],
+                                    "description": "Health-test identifier (``testId``).",
+                                },
+                                "test_name": {
+                                    "type": ["string", "null"],
+                                    "description": "Human-readable test name (``testName``).",
+                                },
+                                "test_health": {
+                                    "type": ["string", "null"],
+                                    "description": "Per-test colour (``testHealth``).",
+                                },
+                                "test_short_description": {
+                                    "type": ["string", "null"],
+                                    "description": (
+                                        "Short human-readable description "
+                                        "(``testShortDescription``)."
+                                    ),
+                                },
+                            },
+                            "required": [],
+                        },
+                        "description": (
+                            "Individual health checks in this group from ``groupTests``."
+                        ),
+                    },
+                },
+                "required": ["tests"],
+            },
+            "description": (
+                "Health-test groups from ``VsanClusterHealthSummary.groups``; "
+                "``null`` when the best-effort health-service read was skipped "
+                "(see ``read_note``)."
+            ),
+        },
+        "read_note": {
+            "type": "string",
+            "description": (
+                "Present only when the health-service read was skipped; "
+                "records the failing sub-op, its status, and the underlying "
+                "error."
+            ),
+        },
+    },
+    "required": ["cluster"],
 }
 
 

--- a/backend/tests/test_connectors_vmware_rest_composites_read.py
+++ b/backend/tests/test_connectors_vmware_rest_composites_read.py
@@ -41,6 +41,7 @@ from meho_backplane.connectors.vmware_rest.composites._read import (
     datastore_usage_composite,
     event_tail_composite,
     host_network_uplinks_composite,
+    host_vsan_health_composite,
     network_portgroup_audit_composite,
     performance_summary_composite,
 )
@@ -74,6 +75,7 @@ def _prime_preflight_cache() -> Iterator[None]:
             "vmware.composite.datastore.usage",
             "vmware.composite.network.portgroup.audit",
             "vmware.composite.host.network_uplinks",
+            "vmware.composite.host.vsan_health",
         }
     )
     yield
@@ -1203,6 +1205,163 @@ async def test_host_network_uplinks_raises_on_listing_error() -> None:
 
 
 # ---------------------------------------------------------------------------
+# vmware.composite.host.vsan_health
+# ---------------------------------------------------------------------------
+
+
+_VSAN_QUERY_OP = "POST:/VsanVcClusterHealthSystem/{moId}/VsanQueryVcClusterHealthSummary"
+
+
+def _vsan_summary(overall: str, groups: list[Any]) -> dict[str, Any]:
+    """Build a ``VsanClusterHealthSummary`` payload for one cluster."""
+    return {"overallHealth": overall, "groups": groups}
+
+
+@pytest.mark.asyncio
+async def test_host_vsan_health_queries_health_summary_for_cluster() -> None:
+    """One health-service query fires, scoped to the cluster; groups + tests flatten.
+
+    ``VsanClusterHealthSummary.overallHealth`` surfaces as
+    ``overall_health``; each ``VsanClusterHealthGroup`` flattens to
+    group_id / group_name / group_health plus a per-check ``tests`` list
+    (testId / testName / testHealth / testShortDescription).
+    """
+    summary = _vsan_summary(
+        overall="green",
+        groups=[
+            {
+                "groupId": "com.vmware.vsan.health.test.network",
+                "groupName": "Network",
+                "groupHealth": "green",
+                "groupTests": [
+                    {
+                        "testId": "com.vmware.vsan.health.test.hostconnectivity",
+                        "testName": "vSAN cluster partition",
+                        "testHealth": "green",
+                        "testShortDescription": "Checks host connectivity.",
+                    },
+                ],
+            },
+            {
+                "groupId": "com.vmware.vsan.health.test.physicaldisks",
+                "groupName": "Physical disk",
+                "groupHealth": "yellow",
+                "groupTests": [],
+            },
+        ],
+    )
+    dispatch = _RecordingDispatchChild({_VSAN_QUERY_OP: summary})
+
+    out = await host_vsan_health_composite(
+        operator=_make_operator(),
+        target=object(),
+        params={"cluster": "domain-c123"},
+        dispatch_child=dispatch,
+    )
+
+    assert len(dispatch.calls) == 1
+    call = dispatch.calls[0]
+    assert call["op_id"] == _VSAN_QUERY_OP
+    assert call["connector_id"] == "vmware-rest-9.0"
+    # The health query targets the vsan-cluster-health-system singleton
+    # and carries the cluster MoRef.
+    assert call["params"]["moId"] == "vsan-cluster-health-system"
+    assert call["params"]["cluster"] == {
+        "type": "ClusterComputeResource",
+        "value": "domain-c123",
+    }
+
+    assert out["cluster"] == "domain-c123"
+    assert out["overall_health"] == "green"
+    assert out["groups"] == [
+        {
+            "group_id": "com.vmware.vsan.health.test.network",
+            "group_name": "Network",
+            "group_health": "green",
+            "tests": [
+                {
+                    "test_id": "com.vmware.vsan.health.test.hostconnectivity",
+                    "test_name": "vSAN cluster partition",
+                    "test_health": "green",
+                    "test_short_description": "Checks host connectivity.",
+                },
+            ],
+        },
+        {
+            "group_id": "com.vmware.vsan.health.test.physicaldisks",
+            "group_name": "Physical disk",
+            "group_health": "yellow",
+            "tests": [],
+        },
+    ]
+    assert "read_note" not in out
+
+
+@pytest.mark.asyncio
+async def test_host_vsan_health_read_is_best_effort_on_error() -> None:
+    """A failed health-service read nulls groups/overall + records a ``read_note``.
+
+    The cluster is already identified by the ``cluster`` param, so a
+    health-service error (vSAN disabled, endpoint reject) returns the
+    payload with ``overall_health`` / ``groups`` nulled and a
+    ``read_note`` rather than raising.
+    """
+    dispatch = _RecordingDispatchChild(
+        [
+            _connector_error_result(
+                _VSAN_QUERY_OP,
+                "Client error '400 Bad Request' for url "
+                "'https://vc/vsanHealth/VsanVcClusterHealthSystem/"
+                "vsan-cluster-health-system/VsanQueryVcClusterHealthSummary'",
+            )
+        ]
+    )
+    out = await host_vsan_health_composite(
+        operator=_make_operator(),
+        target=object(),
+        params={"cluster": "domain-c404"},
+        dispatch_child=dispatch,
+    )
+    assert out["cluster"] == "domain-c404"
+    assert out["overall_health"] is None
+    assert out["groups"] is None
+    assert "read_note" in out
+    note = out["read_note"]
+    assert _VSAN_QUERY_OP in note
+    assert "400 Bad Request" in note
+
+
+@pytest.mark.asyncio
+async def test_host_vsan_health_tolerates_legacy_value_envelope() -> None:
+    """A ``{"value": ...}`` envelope on the summary unwraps cleanly."""
+    dispatch = _RecordingDispatchChild(
+        [_ok_result(_VSAN_QUERY_OP, {"value": _vsan_summary(overall="red", groups=[])})]
+    )
+    out = await host_vsan_health_composite(
+        operator=_make_operator(),
+        target=object(),
+        params={"cluster": "domain-c1"},
+        dispatch_child=dispatch,
+    )
+    assert out["overall_health"] == "red"
+    assert out["groups"] == []
+
+
+@pytest.mark.asyncio
+async def test_host_vsan_health_tolerates_missing_groups_key() -> None:
+    """A summary without a ``groups`` list degrades to an empty group list."""
+    dispatch = _RecordingDispatchChild([_ok_result(_VSAN_QUERY_OP, {"overallHealth": "green"})])
+    out = await host_vsan_health_composite(
+        operator=_make_operator(),
+        target=object(),
+        params={"cluster": "domain-c1"},
+        dispatch_child=dispatch,
+    )
+    assert out["overall_health"] == "green"
+    assert out["groups"] == []
+
+
+# ---------------------------------------------------------------------------
 # Error fan-out -- a sub-op error causes the handler to raise
 # ---------------------------------------------------------------------------
 
@@ -1268,7 +1427,7 @@ async def test_event_tail_raises_on_sub_op_error() -> None:
 
 @pytest.mark.asyncio
 async def test_every_composite_uses_vmware_rest_9_0_connector_id() -> None:
-    """All six read handlers dispatch sub-ops against ``vmware-rest-9.0`` exclusively.
+    """All seven read handlers dispatch sub-ops against ``vmware-rest-9.0`` exclusively.
 
     Load-bearing for the issue body's *Why dispatch_child not direct
     httpx* contract: the connector_id is what routes the recursive
@@ -1314,6 +1473,15 @@ async def test_every_composite_uses_vmware_rest_9_0_connector_id() -> None:
             host_network_uplinks_composite,
             {},
             {"GET:/vcenter/host": []},
+        ),
+        (
+            host_vsan_health_composite,
+            {"cluster": "domain-c1"},
+            {
+                "POST:/VsanVcClusterHealthSystem/{moId}/VsanQueryVcClusterHealthSummary": (
+                    {"overallHealth": "green", "groups": []}
+                )
+            },
         ),
     )
     for handler, params, responses in handlers:

--- a/backend/tests/test_connectors_vmware_rest_composites_recursive_e2e.py
+++ b/backend/tests/test_connectors_vmware_rest_composites_recursive_e2e.py
@@ -17,7 +17,7 @@ composite, ``vmware.composite.host.evacuate`` (G3.1-T6 / #509):
 1. Register a no-op vmware connector class against
    ``(product="vmware", version="9.0", impl_id="vmware-rest")``.
 2. Register the **real** :func:`register_vmware_composite_operations`
-   runner, which lands all 14 composite rows (including ``vm.migrate``
+   runner, which lands all 15 composite rows (including ``vm.migrate``
    and ``host.evacuate``).
 3. Register the leaf typed sub-ops the recursive chain bottoms out on
    (``GET:/vcenter/vm`` listing, ``GET:/vcenter/cluster/{cluster}/drs/
@@ -367,8 +367,8 @@ async def test_host_evacuate_e2e_through_production_dispatch_builds_3_level_audi
         impl_id="vmware-rest",
         cls=_NoOpVmwareConnector,
     )
-    # Register all 14 composite rows (vm.migrate + host.evacuate are
-    # the two the test exercises; the other 12 ride along harmlessly).
+    # Register all 15 composite rows (vm.migrate + host.evacuate are
+    # the two the test exercises; the other 13 ride along harmlessly).
     await register_vmware_composite_operations(embedding_service=stub_embedding_service)
     # Register the 4 leaf typed sub-ops the recursive chain bottoms on.
     await _register_leaf_typed_ops(stub_embedding_service)

--- a/backend/tests/test_connectors_vmware_rest_composites_register.py
+++ b/backend/tests/test_connectors_vmware_rest_composites_register.py
@@ -48,6 +48,7 @@ from meho_backplane.connectors.vmware_rest.composites import (
     datastore_usage_composite,
     event_tail_composite,
     host_network_uplinks_composite,
+    host_vsan_health_composite,
     network_portgroup_audit_composite,
     performance_summary_composite,
     register_vmware_composite_operations,
@@ -68,6 +69,7 @@ _EXPECTED_OP_IDS: tuple[str, ...] = (
     "vmware.composite.datastore.usage",
     "vmware.composite.network.portgroup.audit",
     "vmware.composite.host.network_uplinks",
+    "vmware.composite.host.vsan_health",
 )
 
 
@@ -91,6 +93,9 @@ _EXPECTED_HANDLER_REF_BY_OP: dict[str, str] = {
     "vmware.composite.host.network_uplinks": (
         "meho_backplane.connectors.vmware_rest.composites._read.host_network_uplinks_composite"
     ),
+    "vmware.composite.host.vsan_health": (
+        "meho_backplane.connectors.vmware_rest.composites._read.host_vsan_health_composite"
+    ),
 }
 
 
@@ -101,6 +106,7 @@ _EXPECTED_GROUP_KEY_BY_OP: dict[str, str] = {
     "vmware.composite.datastore.usage": "storage",
     "vmware.composite.network.portgroup.audit": "networking",
     "vmware.composite.host.network_uplinks": "host",
+    "vmware.composite.host.vsan_health": "host",
 }
 
 
@@ -181,10 +187,10 @@ async def test_register_vmware_composite_operations_inserts_five_rows(
             .all()
         )
     assert {row.op_id for row in rows} == set(_EXPECTED_OP_IDS)
-    # Embedding service called once per composite -- 14 total: 6 reads
-    # (T5 #508 shipped 5; #2080 adds host.network_uplinks) + 8 writes
-    # (T6 #509).
-    assert stub_embedding_service.encode_one.call_count == 14
+    # Embedding service called once per composite -- 15 total: 7 reads
+    # (T5 #508 shipped 5; #2080 adds host.network_uplinks; #2135 adds
+    # host.vsan_health) + 8 writes (T6 #509).
+    assert stub_embedding_service.encode_one.call_count == 15
 
 
 @pytest.mark.asyncio
@@ -267,7 +273,7 @@ async def test_handler_ref_round_trips_to_module_level_dotted_path(
 async def test_group_resolution_lands_each_composite_in_its_named_group(
     stub_embedding_service: AsyncMock,
 ) -> None:
-    """The 6 read composites resolve to their named ``group_key`` (host.network_uplinks -> host)."""
+    """The 7 read composites resolve to their named ``group_key`` (vsan_health -> host)."""
     await register_vmware_composite_operations(embedding_service=stub_embedding_service)
     sessionmaker = get_sessionmaker()
     async with sessionmaker() as fresh:
@@ -398,6 +404,9 @@ async def test_response_schema_persists_for_every_composite(
     )
     assert "hosts" in dict(uplinks_resp["properties"])
 
+    vsan_resp: dict[str, Any] = dict(by_op["vmware.composite.host.vsan_health"].response_schema)
+    assert {"cluster", "overall_health", "groups"} <= set(dict(vsan_resp["properties"]))
+
 
 @pytest.mark.asyncio
 async def test_tags_include_composite_and_read_only(
@@ -436,15 +445,15 @@ async def test_tags_include_composite_and_read_only(
 async def test_register_vmware_composite_operations_is_idempotent(
     stub_embedding_service: AsyncMock,
 ) -> None:
-    """Running the registrar twice -> 6 read rows persist; embedding stays at 14.
+    """Running the registrar twice -> 7 read rows persist; embedding stays at 15.
 
     The second run's body-hash skip path is what holds across both
     read and write composites; this test asserts the read rows still
-    persist after the combined registrar (6 reads + 8 writes / T6).
+    persist after the combined registrar (7 reads + 8 writes / T6).
     """
     await register_vmware_composite_operations(embedding_service=stub_embedding_service)
     first_count = stub_embedding_service.encode_one.call_count
-    assert first_count == 14
+    assert first_count == 15
 
     await register_vmware_composite_operations(embedding_service=stub_embedding_service)
     # Skip-re-embed path -- second run is a no-op for the embedding
@@ -462,7 +471,7 @@ async def test_register_vmware_composite_operations_is_idempotent(
             .scalars()
             .all()
         )
-    assert len(rows) == 6
+    assert len(rows) == 7
 
 
 # ---------------------------------------------------------------------------
@@ -520,6 +529,7 @@ def test_all_handlers_are_module_level_coroutine_functions() -> None:
         datastore_usage_composite,
         network_portgroup_audit_composite,
         host_network_uplinks_composite,
+        host_vsan_health_composite,
     ):
         assert inspect.iscoroutinefunction(handler), f"{handler!r} is not a coroutine function"
         assert "<locals>" not in handler.__qualname__

--- a/backend/tests/test_connectors_vmware_rest_composites_write_e2e.py
+++ b/backend/tests/test_connectors_vmware_rest_composites_write_e2e.py
@@ -465,7 +465,7 @@ async def _register_leaf_typed_ops(stub_embedding_service: AsyncMock) -> None:
 
 
 async def _bootstrap_registry(stub_embedding_service: AsyncMock) -> None:
-    """Register the connector, all 14 composites, and the leaf typed ops."""
+    """Register the connector, all 15 composites, and the leaf typed ops."""
     register_connector_v2(
         product="vmware",
         version="9.0",

--- a/backend/tests/test_connectors_vmware_rest_composites_write_preview.py
+++ b/backend/tests/test_connectors_vmware_rest_composites_write_preview.py
@@ -229,7 +229,7 @@ def _reset_recorder() -> None:
 
 
 async def _bootstrap_registry(stub_embedding_service: AsyncMock) -> None:
-    """Register the connector, the 14 composites, and the listing leaves."""
+    """Register the connector, the 15 composites, and the listing leaves."""
     register_connector_v2(
         product="vmware",
         version="9.0",

--- a/backend/tests/test_connectors_vmware_rest_composites_write_register.py
+++ b/backend/tests/test_connectors_vmware_rest_composites_write_register.py
@@ -13,8 +13,8 @@ Coverage matrix (G3.1-T6 / #509 acceptance criteria):
 * Each row's ``group_key`` resolves to ``vm`` / ``host`` / ``cluster``
   per the canary's stub-LLM taxonomy.
 * Combined with #508's 5 reads plus #2080's host.network_uplinks
-  read, the registrar produces **14 rows** total -- the
-  Definition-of-done line in #227's body.
+  and #2135's host.vsan_health reads, the registrar produces **15
+  rows** total -- the Definition-of-done line in #227's body.
 * Per-composite ``parameter_schema`` + ``response_schema`` persist
   with the documented required keys.
 * Module-level handler shape (no closures / partials / lambdas).
@@ -66,9 +66,9 @@ _WRITE_OP_IDS: tuple[str, ...] = (
     "vmware.composite.cluster.patch",
 )
 
-# 6 reads (T5 / #508 shipped 5; #2080 adds host.network_uplinks) --
-# carried over so the combined-count assertion does not have to import
-# _read constants.
+# 7 reads (T5 / #508 shipped 5; #2080 adds host.network_uplinks;
+# #2135 adds host.vsan_health) -- carried over so the combined-count
+# assertion does not have to import _read constants.
 _READ_OP_IDS: tuple[str, ...] = (
     "vmware.composite.cluster.drs_recommendations",
     "vmware.composite.event.tail",
@@ -76,9 +76,10 @@ _READ_OP_IDS: tuple[str, ...] = (
     "vmware.composite.datastore.usage",
     "vmware.composite.network.portgroup.audit",
     "vmware.composite.host.network_uplinks",
+    "vmware.composite.host.vsan_health",
 )
 
-# 14 total -- the #227 G3.1 Definition-of-done line.
+# 15 total -- the #227 G3.1 Definition-of-done line.
 _ALL_OP_IDS: tuple[str, ...] = _READ_OP_IDS + _WRITE_OP_IDS
 
 
@@ -187,10 +188,10 @@ async def test_register_vmware_composite_operations_inserts_eight_write_rows(
 
 
 @pytest.mark.asyncio
-async def test_full_registration_produces_fourteen_composite_rows(
+async def test_full_registration_produces_fifteen_composite_rows(
     stub_embedding_service: AsyncMock,
 ) -> None:
-    """6 reads (#508 + #2080) + 8 writes (#509) = 14 composite rows. Definition-of-done bar."""
+    """7 reads (#508 + #2080 + #2135) + 8 writes (#509) = 15 rows. Definition-of-done bar."""
     await register_vmware_composite_operations(embedding_service=stub_embedding_service)
     sessionmaker = get_sessionmaker()
     async with sessionmaker() as fresh:
@@ -204,7 +205,7 @@ async def test_full_registration_produces_fourteen_composite_rows(
             .all()
         )
     assert {row.op_id for row in rows} == set(_ALL_OP_IDS)
-    assert len(rows) == 14
+    assert len(rows) == 15
 
 
 @pytest.mark.asyncio
@@ -455,17 +456,17 @@ async def test_write_composite_tags_include_composite_and_write(
 
 
 @pytest.mark.asyncio
-async def test_register_vmware_composite_operations_is_idempotent_across_fourteen(
+async def test_register_vmware_composite_operations_is_idempotent_across_fifteen(
     stub_embedding_service: AsyncMock,
 ) -> None:
-    """Running the registrar twice -> 14 rows total, embedding called 14x once."""
+    """Running the registrar twice -> 15 rows total, embedding called 15x once."""
     await register_vmware_composite_operations(embedding_service=stub_embedding_service)
     first_count = stub_embedding_service.encode_one.call_count
-    assert first_count == 14
+    assert first_count == 15
 
     await register_vmware_composite_operations(embedding_service=stub_embedding_service)
     # Body-hash skip path -> second run is a no-op for the embedding
-    # pipeline; the row count stays at 14.
+    # pipeline; the row count stays at 15.
     assert stub_embedding_service.encode_one.call_count == first_count
 
     sessionmaker = get_sessionmaker()
@@ -479,7 +480,7 @@ async def test_register_vmware_composite_operations_is_idempotent_across_fourtee
             .scalars()
             .all()
         )
-    assert len(rows) == 14
+    assert len(rows) == 15
 
 
 # ---------------------------------------------------------------------------

--- a/docs/codebase/connectors-vmware-rest.md
+++ b/docs/codebase/connectors-vmware-rest.md
@@ -8,10 +8,11 @@ that dispatches ingested vCenter REST operations under the
 triple. It pairs with the G0.7 ingestion pipeline's auto-shim (which
 makes ~1,275 + ~2,195 `endpoint_descriptor` rows resolvable but not
 dispatchable) to deliver real session-authenticated calls against
-vSphere 8.5+ / ESXi 8.5+ targets, plus 14 hand-authored composites
-that orchestrate cross-spec workflows: 6 read composites
-(G3.1-T5 / `#508` shipped 5; `#2080` added `host.network_uplinks`)
-and 8 write composites (G3.1-T6 / `#509`). The
+vSphere 8.5+ / ESXi 8.5+ targets, plus 15 hand-authored composites
+that orchestrate cross-spec workflows: 7 read composites
+(G3.1-T5 / `#508` shipped 5; `#2080` added `host.network_uplinks`;
+`#2135` added `host.vsan_health`) and 8 write composites
+(G3.1-T6 / `#509`). The
 write composites cover every state-mutating operator workflow named
 in [#214](https://github.com/evoila/meho/issues/214) as required for
 govc-wrapper retirement.
@@ -24,12 +25,12 @@ Source: `backend/src/meho_backplane/connectors/vmware_rest/`.
   Class attributes: `product="vmware"`, `version="9.0"`,
   `impl_id="vmware-rest"`, `supported_version_range=">=8.5,<10.0"`,
   `priority=1`.
-- **Read composites** (`composites/_read.py`) — six module-level
+- **Read composites** (`composites/_read.py`) — seven module-level
   `async def` handlers (`cluster_drs_recommendations_composite`,
   `event_tail_composite`, `performance_summary_composite`,
   `datastore_usage_composite`, `network_portgroup_audit_composite`,
-  `host_network_uplinks_composite`). Each accepts
-  `(operator, target, params, dispatch_child)` per the
+  `host_network_uplinks_composite`, `host_vsan_health_composite`).
+  Each accepts `(operator, target, params, dispatch_child)` per the
   `DispatchChild` Protocol and orchestrates 1-3 sub-op dispatches
   back into the same `vmware-rest-9.0` connector. Registered with
   `safety_level="safe"` + `requires_approval=False` — read-only
@@ -42,6 +43,13 @@ Source: `backend/src/meho_backplane/connectors/vmware_rest/`.
   switch-port-occupancy reasoning); the per-host property read is
   best-effort (a failed read nulls the network detail with a
   `read_note` rather than sinking the composite).
+  `host_vsan_health_composite` (`#2135`) queries the vSAN
+  health-service vmomi method `VsanQueryVcClusterHealthSummary` on the
+  `vsan-cluster-health-system` singleton, scoped to the target
+  cluster's MoRef — the `govc vsan.health.*` equivalent, returning the
+  cluster-wide `overall_health` colour plus the health-test `groups`
+  list. It is likewise best-effort (a failed health-service read nulls
+  `groups` / `overall_health` with a `read_note`).
 - **Write composites** (`composites/_write.py`) — eight module-level
   `async def` handlers (`vm_create_composite`, `vm_clone_composite`,
   `vm_snapshot_revert_composite`, `vm_migrate_composite`,
@@ -58,8 +66,8 @@ Source: `backend/src/meho_backplane/connectors/vmware_rest/`.
   handles the depth-2 nesting cleanly.
 - **`register_vmware_composite_operations`** (`composites/_register.py`)
   — async registrar function called from `run_typed_op_registrars` at
-  lifespan startup. Iterates a single `_COMPOSITES` tuple of 14
-  `_CompositeSpec` rows (6 read + 8 write); each row carries its
+  lifespan startup. Iterates a single `_COMPOSITES` tuple of 15
+  `_CompositeSpec` rows (7 read + 8 write); each row carries its
   own `safety_level` + `requires_approval` so the policy posture is
   implied by the spec, not by global defaults. Idempotent on re-run
   via the body-hash skip path.
@@ -106,8 +114,8 @@ Source: `backend/src/meho_backplane/connectors/vmware_rest/`.
    in main) no-ops on subsequent ingests against the same triple.
 5. Lifespan calls `run_typed_op_registrars()`, which iterates every
    queued registrar -- including the composite one -- and upserts the
-   14 `vmware.composite.*` rows into `endpoint_descriptor` with
-   `source_kind="composite"` (6 reads with `safety_level="safe"` +
+   15 `vmware.composite.*` rows into `endpoint_descriptor` with
+   `source_kind="composite"` (7 reads with `safety_level="safe"` +
    `requires_approval=False`; 8 writes with `safety_level="dangerous"`
    + `requires_approval=True`).
 
@@ -176,7 +184,7 @@ reach this method.
 
 ### Composite dispatch
 
-The 14 composites (6 reads + 8 writes) land as `source_kind="composite"`
+The 15 composites (7 reads + 8 writes) land as `source_kind="composite"`
 rows in `endpoint_descriptor`. At dispatch time:
 
 1. Dispatcher resolves `(vmware-rest-9.0, vmware.composite.<verb>)`
@@ -231,7 +239,7 @@ caller.
 
 ### L1/L2 dispatch contract + pre-flight (G0.14-T10 / #1151)
 
-The 14 composites are the **L1** surface: hand-authored aggregators
+The 15 composites are the **L1** surface: hand-authored aggregators
 each connector ships as `source_kind='composite'` descriptors. Every
 composite's body fans out to **L2** raw-REST primitives
 (`GET:/vcenter/datastore`, `POST:/vcenter/vm/{vm}/power?action=start`,
@@ -477,7 +485,7 @@ identifier fields **plus** `preview_unavailable: true` and a
 every reviewer surface that renders `proposed_effect` verbatim (REST
 `GET /api/v1/approvals`, `meho.approvals.list` / `.get`, `meho
 approvals show`), so "blast-radius unknown" is distinguishable from a
-genuinely small action. The 6 read composites register no builder —
+genuinely small action. The 7 read composites register no builder —
 they never park.
 
 ## Dependencies
@@ -526,9 +534,9 @@ they never park.
   header per `docs/vcenter-9.0/MANIFEST.md`. Two of the read
   composites (`event.tail`, `performance.summary`) call vi-json
   sub-ops; the other three call vCenter REST sub-ops only.
-- **All 14 composites shipped** — T5 (#508) ships 5 read, #2080 adds a 6th read
-  composites; T6 (#509) ships the 8 write composites. The "All ~13
-  hand-authored composites land as endpoint_descriptor rows with
+- **All 15 composites shipped** — T5 (#508) ships 5 read, #2080 adds a 6th read,
+  #2135 adds a 7th read (`host.vsan_health`); T6 (#509) ships the 8 write
+  composites. The "All hand-authored composites land as endpoint_descriptor rows with
   source_kind='composite'" Definition-of-done line in [#227](https://github.com/evoila/meho/issues/227)
   is fully ticked.
 - **`vm.clone` task polling is wall-clock bounded** — the composite


### PR DESCRIPTION
## Summary
- Adds `vmware.composite.host.vsan_health`, a seventh safe/read `vmware-rest` composite that surfaces per-cluster vSAN health (health-test groups + overall status) from the vSAN health-service API — the `govc vsan.health.*` equivalent, the one read the plain vSphere Automation REST surface cannot reproduce.
- Follows the #508 pattern with the just-merged `host.network_uplinks` (#2080) as the structural template: same `host` group, same `_CompositeSpec` mold, same best-effort read with `read_note`.
- Queries `VsanQueryVcClusterHealthSummary` on the `vsan-cluster-health-system` singleton scoped to the target cluster's `ClusterComputeResource` MoRef; returns `{cluster, overall_health, groups: [{group_id, group_name, group_health, tests: [...]}]}`. Best-effort: a vSAN-disabled cluster or a rejected health-service call nulls `groups`/`overall_health` with a `read_note` rather than sinking the composite.
- Registered `safety_level="safe"` + `requires_approval=False` via `register_composite_operation()`; dispatches through the shared registrar. Bumps the registered composite total 14 → 15 (7 read + 8 write) across every count-bearing test and doc.

## Test plan
- [x] `ruff check` — clean (composites + touched tests)
- [x] `ruff format --check` — clean (reformatted `_read.py` + `schemas.py`)
- [x] `mypy src/.../composites/` — Success, no issues (7 files)
- [x] `code-quality.py --diff` — 0 blockers (7 pre-existing/warn-level warnings, matching sibling handlers)
- [x] `pytest test_connectors_vmware_rest_composites_read.py` — 37 passed (4 new vsan_health tests: happy path, best-effort-on-error, legacy-envelope, missing-groups)
- [x] `pytest test_connectors_vmware_rest_composites_write_register.py test_connectors_vmware_rest_composites_register.py` — 22 passed (all 14→15 count assertions updated in one pass, incl. write_register's three `== 14`→15 + both "fourteen"→"fifteen" test renames)
- [x] `pytest` write_e2e / write_preview / recursive_e2e / l2_ingest_reconcile / l2_preflight / typed_connectors_metadata / acceptance dispatch — 64 passed, 1 skipped
- [x] `pytest` g07 canary + composite substrate — 31 passed, 28 skipped (govc-parity benchmark untouched)

### Acceptance criteria
- [x] Registered as safe/read via `register_composite_operation()`, dispatches through `call_operation` — `test_every_composite_row_uses_safe_no_approval_overrides`
- [x] Returns structured vSAN health summary (groups + overall status) — `test_host_vsan_health_queries_health_summary_for_cluster`
- [x] Test asserts registered read-only + expected schema against a fixture — read + register tests
- [x] CLI OpenAPI snapshot: n/a — composites register into `endpoint_descriptor` at runtime, not as FastAPI routes; no route/schema change (mirrors #2080, which also touched no snapshot)

## Out of scope
- `_preflight.py` carries a stale "13 composites" prose reference (should read 14 pre-change) — pre-existing drift left behind by #2080, not caused by this change. Left untouched per the count-bookkeeping directive (it's a doc aside, not a count-bearing assertion, and it's already at 13). Adjacent finding.

<!-- auto-implement-issue: fresh, iteration 1 -->

Closes #2135
