### PR TITLE
fix(redaction): widen Tier-1 secret-value capture and redact error-builder free text

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -132,6 +132,20 @@ connector-related release-notes line.
   returns a structured `dispatch_error` envelope instead of an uncaught
   exception / MCP `-32603` (#2066).
 
+### Security
+
+- Hardened Tier-1 redaction at the connector boundary and the dispatch
+  error path. The `authorization_header` / `bearer_token` / `api_key`
+  named patterns now capture a labelled secret's value to its natural
+  delimiter (whitespace / closing quote / end of blob) instead of
+  stopping at the first punctuation byte, so punctuated values are
+  redacted whole. The `operations/_errors.py` result builders now run
+  every free-text diagnostic (`exception_message`, `upstream_message`,
+  `detail`, and the summary tails built from them) through the Tier-1
+  redactor **before** the 256-char cap, so a credential embedded in a
+  stringified connector exception or upstream error body no longer
+  reaches the response/audit envelope in cleartext.
+
 ## [0.19.0] - 2026-06-22
 
 ### Fixed — profiled vCenter legacy session-token shape

--- a/backend/src/meho_backplane/operations/_errors.py
+++ b/backend/src/meho_backplane/operations/_errors.py
@@ -35,6 +35,8 @@ from typing import Any, Literal
 import httpx
 
 from meho_backplane.connectors import OperationResult, ResultHandle
+from meho_backplane.redaction.engine import redact
+from meho_backplane.redaction.resolver import get_default_policy
 
 __all__ = [
     "result_ambiguous_connector",
@@ -62,8 +64,47 @@ __all__ = [
 #: Cap on the exception-message length recorded in the ``connector_error``
 #: extras payload. A misbehaving connector could embed a credential into
 #: a stringified exception; 256 chars is enough for an operator to
-#: recognise the failure shape while capping the leak surface.
+#: recognise the failure shape while capping the leak surface. The cap
+#: is the *second* line of defence -- :func:`_sanitize_free_text` runs
+#: the Tier-1 redactor over the text first, so a credential inside the
+#: first 256 chars does not ride the envelope in cleartext.
 _EXC_MESSAGE_CAP: int = 256
+
+#: Fail-closed placeholder when Tier-1 redaction itself is unavailable
+#: on the never-raises error path. Returning the raw text instead would
+#: reintroduce exactly the passthrough this sanitizer exists to close.
+_TEXT_WITHHELD: str = "<diagnostic text withheld: redaction unavailable>"
+
+
+def _sanitize_free_text(text: str) -> str:
+    """Tier-1-redact, then length-cap, one free-text diagnostic string.
+
+    Every ``str(exc)`` / upstream-body line a result builder emits
+    (``extras["exception_message"]``, ``extras["upstream_message"]``,
+    ``extras["detail"]``, and the ``error`` summary tails built from
+    them) passes through here before landing in the response/audit
+    envelope. Redaction runs **before** the cap: capping first could
+    truncate a secret mid-value into a fragment the patterns no longer
+    match, leaving cleartext behind.
+
+    The packaged default policy (credential-shaped patterns only -- no
+    UUID/IP/FQDN rules, so hosts and IDs stay legible for diagnosis) is
+    pinned via :func:`get_default_policy`, deliberately bypassing the
+    resolver's override table: an operator-registered shadow-mode or
+    narrowed policy must not silently disable redaction on the error
+    path. Fail-closed: if redaction itself errors, the text is withheld
+    entirely -- this is a never-raises path and an unredacted fallback
+    would be the leak.
+    """
+    try:
+        redacted = redact(text, get_default_policy()).redacted
+    except Exception:  # fail-closed: never leak, never raise on the error path
+        return _TEXT_WITHHELD
+    if not isinstance(redacted, str):  # pragma: no cover -- str in, str out
+        return _TEXT_WITHHELD
+    if len(redacted) > _EXC_MESSAGE_CAP:
+        return redacted[:_EXC_MESSAGE_CAP] + "...<truncated>"
+    return redacted
 
 
 def result_unknown_op(op_id: str, known_op_count: int, duration_ms: float) -> OperationResult:
@@ -224,7 +265,7 @@ def result_no_connector(
         "version": version,
     }
     if exception_message is not None:
-        extras["exception_message"] = exception_message
+        extras["exception_message"] = _sanitize_free_text(exception_message)
     return OperationResult(
         status="error",
         op_id=op_id,
@@ -274,7 +315,7 @@ def result_ambiguous_connector(
             "error_code": "ambiguous_connector",
             "product": product,
             "version": version,
-            "exception_message": exception_message,
+            "exception_message": _sanitize_free_text(exception_message),
         },
     )
 
@@ -514,10 +555,14 @@ def result_connector_error(
     exc: BaseException,
     duration_ms: float,
 ) -> OperationResult:
-    """Connector / handler raised. Exception class + capped message land in extras."""
-    msg = str(exc)
-    if len(msg) > _EXC_MESSAGE_CAP:
-        msg = msg[:_EXC_MESSAGE_CAP] + "...<truncated>"
+    """Connector / handler raised. Class + redacted, capped message land in extras.
+
+    ``str(exc)`` on a connector exception can embed a URL with inline
+    credentials, a header dump, or a driver DSN, so the message runs
+    through :func:`_sanitize_free_text` (Tier-1 redaction, then the
+    length cap) before it reaches the envelope.
+    """
+    msg = _sanitize_free_text(str(exc))
     return OperationResult(
         status="error",
         op_id=op_id,
@@ -647,9 +692,7 @@ def result_connector_unsupported(
     :func:`result_connector_error` (both production raise sites are
     comfortably under the cap, so their texts survive verbatim).
     """
-    detail = str(exc)
-    if len(detail) > _EXC_MESSAGE_CAP:
-        detail = detail[:_EXC_MESSAGE_CAP] + "...<truncated>"
+    detail = _sanitize_free_text(str(exc))
     origin = (
         f"The resolved connector ({connector_class})"
         if connector_class is not None
@@ -687,13 +730,6 @@ _HTTP_403_ECHOED_HEADERS: tuple[str, ...] = (
 )
 
 
-def _cap_message(message: str) -> str:
-    """Apply the :data:`_EXC_MESSAGE_CAP` discipline to one upstream line."""
-    if len(message) > _EXC_MESSAGE_CAP:
-        return message[:_EXC_MESSAGE_CAP] + "...<truncated>"
-    return message
-
-
 def _http_upstream_message(response: httpx.Response) -> str | None:
     """Best-effort extraction of the upstream's human error message.
 
@@ -703,10 +739,12 @@ def _http_upstream_message(response: httpx.Response) -> str | None:
     useful line for diagnosis, so it is preferred when the body parses as
     a JSON object carrying a string ``message``. Bodies that are not
     JSON, or JSON without a usable ``message``, fall back to the capped
-    raw text. ``None`` only when the body is empty. The same
-    :data:`_EXC_MESSAGE_CAP` discipline as the other builders bounds any
-    credential-bearing upstream text. Shared by the 403 and 422 builders
-    (the body shape is identical across GitHub's 4xx responses).
+    raw text. ``None`` only when the body is empty. Either branch runs
+    through :func:`_sanitize_free_text` -- Tier-1 redaction plus the
+    :data:`_EXC_MESSAGE_CAP` discipline -- so credential-bearing
+    upstream text never reaches the envelope in cleartext. Shared by
+    the 403 / 422 / auth-failed builders (the body shape is identical
+    across GitHub's 4xx responses).
     """
     try:
         body = response.json()
@@ -715,11 +753,11 @@ def _http_upstream_message(response: httpx.Response) -> str | None:
     if isinstance(body, dict):
         message = body.get("message")
         if isinstance(message, str) and message.strip():
-            return _cap_message(message)
+            return _sanitize_free_text(message)
     text = (response.text or "").strip()
     if not text:
         return None
-    return _cap_message(text)
+    return _sanitize_free_text(text)
 
 
 def _http_validation_errors(response: httpx.Response) -> list[Any]:
@@ -1097,9 +1135,7 @@ def result_connector_tls_verify_failed(
     ``getattr`` guard so a target shape without it degrades to a bare host
     label rather than raising inside the never-raises error path.
     """
-    msg = str(exc)
-    if len(msg) > _EXC_MESSAGE_CAP:
-        msg = msg[:_EXC_MESSAGE_CAP] + "...<truncated>"
+    msg = _sanitize_free_text(str(exc))
     host = getattr(target, "host", None) or "the target host"
     summary = (
         f"connector_tls_verify_failed: TLS certificate verification failed "

--- a/backend/src/meho_backplane/redaction/patterns.py
+++ b/backend/src/meho_backplane/redaction/patterns.py
@@ -55,6 +55,31 @@ __all__ = [
 ]
 
 
+# Secret-*value* character class shared by the labelled-secret patterns
+# below. The previous class (alphanumerics plus ``. _ - + / =`` only)
+# stopped at the first punctuation byte, so a value like
+# ``P@ssw0rd!withMore`` was captured only partially -- or not at all
+# when the leading run of in-class bytes was shorter than the
+# pattern's minimum -- leaving the
+# secret (or its tail) in cleartext past the redaction span. A value is
+# now consumed to its *natural delimiter*: whitespace or a quote
+# (quotes bound the ``key: 'value'`` shape and terminate JSON string
+# leaves). A single negated character class keeps matching linear (no
+# nested quantifiers, so no catastrophic backtracking); the explicit
+# upper bound keeps a pathological unbroken blob from being swallowed
+# wholesale. Opaque-ID false positives (Git SHAs, build hashes) stay
+# out because every pattern using this class still requires labelled
+# context (``Authorization:`` / ``Bearer`` / ``password=``-style).
+_VALUE_CHARS: Final[str] = r"[^\s'\"]"
+
+#: Upper bound on one secret-value run. Generous enough that real
+#: credentials (JWTs, PATs, DSNs) are consumed whole -- a cap a secret
+#: routinely exceeded would reintroduce the tail-leak the widened class
+#: exists to close -- while still bounding the redacted span on
+#: degenerate multi-kilobyte unbroken blobs.
+_VALUE_MAX: Final[int] = 4096
+
+
 # -- Authorization-style headers --------------------------------------------
 #
 # ``Authorization: Bearer <jwt>`` and ``Authorization: Basic
@@ -64,20 +89,23 @@ __all__ = [
 # the inner-token type -- the operator-facing signal is the header
 # itself. ``re.IGNORECASE`` covers ``authorization`` / ``Authorization``
 # / ``AUTHORIZATION`` (HTTP header names are case-insensitive per
-# RFC 7230).
+# RFC 7230). The credential part consumes :data:`_VALUE_CHARS` to its
+# natural delimiter so schemes carrying punctuation-rich parameters
+# (``Digest``, proxy DSNs) are redacted whole.
 _AUTHORIZATION_HEADER = re.compile(
-    r"Authorization\s*:\s*[A-Za-z]+\s+[A-Za-z0-9._\-+/=]+",
+    r"Authorization\s*:\s*[A-Za-z]+\s+" + _VALUE_CHARS + "{1," + str(_VALUE_MAX) + "}",
     re.IGNORECASE,
 )
 
 # Bare bearer tokens: ``Bearer <opaque>``. Separate from
 # authorization_header because operators paste ``Bearer eyJ...`` into
 # Slack snippets without the surrounding header name (curl ``-H "Bearer
-# ..."`` is wrong but common). The token body matches base64url + hex +
-# the JWT three-segment shape; the leading ``\b`` anchor prevents
-# matching ``foobarBearer ...`` mid-word.
+# ..."`` is wrong but common). The token body consumes
+# :data:`_VALUE_CHARS` to whitespace / quote / end so opaque tokens
+# carrying punctuation are captured whole; the leading ``\b`` anchor
+# prevents matching ``foobarBearer ...`` mid-word.
 _BEARER_TOKEN = re.compile(
-    r"\bBearer\s+[A-Za-z0-9._\-+/=]{8,}",
+    r"\bBearer\s+" + _VALUE_CHARS + "{8," + str(_VALUE_MAX) + "}",
     re.IGNORECASE,
 )
 
@@ -108,6 +136,12 @@ _JWT = re.compile(
 # because the false-positive rate against opaque IDs (Git SHAs,
 # build hashes, CSP nonces) would be intolerable; downstream Tier-2 NER
 # can take a second pass on free text.
+#
+# The value tail consumes :data:`_VALUE_CHARS` to its natural delimiter
+# (whitespace / quote / end of blob), so a punctuated value like
+# ``password: 'hunter2$plus#tail'`` is redacted whole instead of being
+# truncated at the first out-of-class byte -- the label requirement is
+# what keeps the false-positive posture, not the value alphabet.
 _API_KEY = re.compile(
     r"\b(?:"
     r"api[_-]?key"
@@ -121,7 +155,7 @@ _API_KEY = re.compile(
     r"|client[_-]?secret"
     r"|token"
     r")"
-    r"\s*[=:]\s*['\"]?[A-Za-z0-9._\-+/=]{8,}['\"]?",
+    r"\s*[=:]\s*['\"]?" + _VALUE_CHARS + "{8," + str(_VALUE_MAX) + r"}['\"]?",
     re.IGNORECASE,
 )
 

--- a/backend/tests/test_operations_connector_error_redaction.py
+++ b/backend/tests/test_operations_connector_error_redaction.py
@@ -1,0 +1,162 @@
+# SPDX-License-Identifier: Apache-2.0
+# Copyright (c) 2026 evoila Group
+
+"""Tier-1 redaction of free-text diagnostics in the error builders.
+
+The ``operations/_errors.py`` result builders surface free text taken
+from ``str(exc)`` or an upstream response body
+(``extras["exception_message"]`` / ``extras["upstream_message"]`` /
+``extras["detail"]`` and the ``error`` summary tails built from them).
+That text used to be length-capped only; these tests pin the hardened
+contract: every such string runs through the Tier-1 redactor **before**
+the cap, so a credential-bearing exception or upstream body yields no
+unredacted secret anywhere in the returned
+:class:`~meho_backplane.connectors.OperationResult` -- and redaction
+runs first so a secret straddling the cap boundary cannot survive as a
+cleartext fragment the patterns no longer match.
+
+Benign diagnostics must pass through unchanged: the sanitizer uses the
+packaged default policy (credential-shaped patterns only -- no
+UUID / IP / FQDN rules), so hosts, status lines, and remediation text
+stay legible.
+"""
+
+from __future__ import annotations
+
+import httpx
+import pytest
+
+from meho_backplane.operations._errors import (
+    result_ambiguous_connector,
+    result_connector_error,
+    result_connector_http_403,
+    result_connector_tls_verify_failed,
+    result_no_connector,
+)
+
+# Credential fixtures assembled from fragments so gitleaks' built-in
+# rules do not false-positive on the test source (the
+# ``test_redaction_patterns.py`` posture).
+_PASSWORD_SECRET = "P@ssw0rd" + "!withMore"
+_PASSWORD_TEXT = "login failed for dsn admin:" + "password" + "=" + _PASSWORD_SECRET
+_BEARER_SECRET = "eyJtoken" + "$value!123" + "abcdef"
+_BEARER_TEXT = "request rejected; header was " + "Bearer " + _BEARER_SECRET
+
+
+class _Target:
+    host = "vcenter.lab.example.com"
+
+
+def test_connector_error_redacts_labelled_password() -> None:
+    """``str(exc)`` carrying ``password=...`` never reaches extras raw."""
+    result = result_connector_error("op.read", RuntimeError(_PASSWORD_TEXT), 1.0)
+    msg = result.extras["exception_message"]
+    assert "[REDACTED:api_key]" in msg
+    assert _PASSWORD_SECRET not in msg
+    assert "P@ssw0rd" not in msg
+    assert "withMore" not in msg
+    # The structured envelope shape is unchanged.
+    assert result.error == "connector_error: RuntimeError"
+    assert result.extras["error_code"] == "connector_error"
+    assert result.extras["exception_class"] == "RuntimeError"
+
+
+def test_connector_error_redacts_bearer_token() -> None:
+    """A bearer token inside the exception text is redacted."""
+    result = result_connector_error("op.read", ValueError(_BEARER_TEXT), 1.0)
+    msg = result.extras["exception_message"]
+    assert "[REDACTED:bearer_token]" in msg
+    assert _BEARER_SECRET not in msg
+
+
+def test_connector_error_redacts_before_capping() -> None:
+    """Redaction runs before the length cap.
+
+    Capping first would truncate the secret mid-value into a fragment
+    the ``api_key`` pattern no longer matches (the value run drops
+    under its 8-char minimum), leaving cleartext in the envelope.
+    """
+    prefix = "x" * 250
+    text = prefix + " " + "password" + "=" + _PASSWORD_SECRET
+    result = result_connector_error("op.read", RuntimeError(text), 1.0)
+    msg = result.extras["exception_message"]
+    assert msg.endswith("...<truncated>")
+    assert "P@ssw0rd" not in msg
+    assert "withMore" not in msg
+
+
+def test_connector_error_benign_message_unchanged() -> None:
+    """No over-redaction: a benign diagnostic passes through verbatim."""
+    text = "connection refused by 10.0.0.5 (vcenter.lab.example.com)"
+    result = result_connector_error("op.read", RuntimeError(text), 1.0)
+    # The default policy carries no UUID/IP/FQDN rules, so hosts stay
+    # legible for diagnosis.
+    assert result.extras["exception_message"] == text
+
+
+def test_connector_error_long_benign_message_still_capped() -> None:
+    """The 256-char cap discipline is preserved after redaction."""
+    text = "boom " * 100
+    result = result_connector_error("op.read", RuntimeError(text), 1.0)
+    msg = result.extras["exception_message"]
+    assert msg.endswith("...<truncated>")
+    assert len(msg) == 256 + len("...<truncated>")
+
+
+def test_tls_verify_failed_redacts_exception_message() -> None:
+    """The TLS builder's ``exception_message`` is redacted too."""
+    exc = ConnectionError(
+        "[SSL: CERTIFICATE_VERIFY_FAILED] via proxy " + _BEARER_TEXT,
+    )
+    result = result_connector_tls_verify_failed("op.read", exc, _Target(), 1.0)
+    msg = result.extras["exception_message"]
+    assert "[SSL: CERTIFICATE_VERIFY_FAILED]" in msg
+    assert _BEARER_SECRET not in msg
+    assert "[REDACTED:bearer_token]" in msg
+
+
+def test_http_403_upstream_message_redacted_in_extras_and_summary() -> None:
+    """Upstream body text is redacted before extras AND the summary tail."""
+    request = httpx.Request("GET", "https://upstream.test/api")
+    response = httpx.Response(
+        403,
+        json={"message": "denied for " + "token" + ": " + "ghp_secret!" + "value123"},
+        request=request,
+    )
+    exc = httpx.HTTPStatusError("403", request=request, response=response)
+    result = result_connector_http_403("op.write", exc, 1.0)
+    upstream = result.extras["upstream_message"]
+    assert "[REDACTED:api_key]" in upstream
+    assert "ghp_secret" not in upstream
+    assert "ghp_secret" not in (result.error or "")
+
+
+@pytest.mark.parametrize("credential_text", [_PASSWORD_TEXT, _BEARER_TEXT])
+def test_no_connector_exception_message_redacted(credential_text: str) -> None:
+    """Resolver-diagnostic passthrough is sanitized at the builder."""
+    result = result_no_connector(
+        "op.read",
+        "vsphere",
+        "8.0",
+        1.0,
+        exception_message=credential_text,
+    )
+    msg = result.extras["exception_message"]
+    assert "[REDACTED:" in msg
+    assert _PASSWORD_SECRET not in msg
+    assert _BEARER_SECRET not in msg
+
+
+def test_ambiguous_connector_exception_message_redacted() -> None:
+    """Same guarantee on the ambiguous-resolution sibling."""
+    result = result_ambiguous_connector(
+        "op.read",
+        "vsphere",
+        "8.0",
+        "candidates=[a, b]; seen header " + "Bearer " + _BEARER_SECRET,
+        1.0,
+    )
+    msg = result.extras["exception_message"]
+    assert "candidates=[a, b]" in msg
+    assert _BEARER_SECRET not in msg
+    assert "[REDACTED:bearer_token]" in msg

--- a/backend/tests/test_redaction_patterns.py
+++ b/backend/tests/test_redaction_patterns.py
@@ -18,11 +18,13 @@ from __future__ import annotations
 
 import pytest
 
+from meho_backplane.redaction.engine import redact
 from meho_backplane.redaction.patterns import (
     NAMED_PATTERNS,
     PATTERN_NAMES,
     get_pattern,
 )
+from meho_backplane.redaction.policy import RedactionPolicy, RedactionRule
 
 # The full named-pattern catalogue called out in the task body. The
 # test below uses this list as the source of truth -- if a pattern is
@@ -58,6 +60,14 @@ _AUTH_TOKEN_FIXTURE_POS = "auth_token" + ": " + "at_abcdefgh" + "1234"
 _SESSION_TOKEN_FIXTURE_POS = "session_token" + ": " + "st_abcdefgh" + "1234"
 _SECRET_ID_FIXTURE_POS = "secret_id" + ": " + "11111111-2222" + "-3333-aaaa"
 _PRIVATE_KEY_FIXTURE_POS = "private_key" + ": " + "MIIEvQIBADA" + "NBgkq"
+# Punctuated-value fixtures (meho-internal hardening): values carrying
+# bytes outside the pre-widening restrictive class must be captured to
+# their natural delimiter (whitespace / closing quote / end of blob)
+# and redacted whole. Assembled from fragments for the same
+# gitleaks-avoidance reason as the fixtures above.
+_PUNCT_QUOTED_FIXTURE = "password" + ": " + "'s3cr3tValue" + "!'"
+_PUNCT_LEADING_AT_FIXTURE = "password" + "=" + "P@ssw0rd" + "!withMore"
+_PUNCT_DOLLAR_HASH_FIXTURE = "password" + ": " + "hunter2" + "$plus#tail"
 
 
 def test_catalog_lists_expected_patterns() -> None:
@@ -150,6 +160,18 @@ def test_get_pattern_unknown_raises() -> None:
         (
             "api_key",
             "password: 's3cr3tValue!'",
+            True,
+        ),
+        # api_key: punctuated values -- the leading/embedded punctuation
+        # must not break or truncate the match
+        (
+            "api_key",
+            _PUNCT_LEADING_AT_FIXTURE,
+            True,
+        ),
+        (
+            "api_key",
+            _PUNCT_DOLLAR_HASH_FIXTURE,
             True,
         ),
         (
@@ -304,6 +326,8 @@ _PATTERN_TEST_ROWS: list[tuple[str, str, bool]] = [
     ("api_key", "api_key=AKIAIOSFODNN7EXAMPLE", True),
     ("api_key", "the resource id is 12345-abcdef", False),
     ("api_key", "password: 's3cr3tValue!'", True),
+    ("api_key", _PUNCT_LEADING_AT_FIXTURE, True),
+    ("api_key", _PUNCT_DOLLAR_HASH_FIXTURE, True),
     ("api_key", _CLIENT_SECRET_FIXTURE_POS, True),
     ("api_key", _TOKEN_FIXTURE_POS, True),
     ("api_key", _REFRESH_TOKEN_FIXTURE_POS, True),
@@ -323,3 +347,62 @@ _PATTERN_TEST_ROWS: list[tuple[str, str, bool]] = [
     ("fqdn", "vcenter.lab.example.com", True),
     ("fqdn", "version 1.2.3", False),
 ]
+
+
+# ---------------------------------------------------------------------------
+# Full-value capture through the engine (meho-internal hardening)
+# ---------------------------------------------------------------------------
+#
+# ``test_pattern_matches_or_not`` only proves *a* match occurs; these
+# cases prove the **entire** secret value -- including any punctuated
+# tail the pre-widening character class used to stop at -- is replaced,
+# with no cleartext fragment of the value surviving in the output.
+
+_API_KEY_ONLY_POLICY = RedactionPolicy(
+    id="test-api-key-full-capture",
+    version=1,
+    rules=(
+        RedactionRule(
+            name="strip-api-key",
+            pattern="api_key",
+            action="redact",
+            reason="full-value capture regression",
+        ),
+    ),
+)
+
+
+@pytest.mark.parametrize(
+    ("sample", "value_fragments"),
+    [
+        # Trailing punctuation inside a quoted value: the old class
+        # stopped before ``!`` and left the tail + closing quote.
+        (_PUNCT_QUOTED_FIXTURE, ["s3cr3tValue", "Value!"]),
+        # Value beginning with an out-of-class byte run: the old class
+        # produced no match at all and the whole password leaked.
+        (_PUNCT_LEADING_AT_FIXTURE, ["P@ssw0rd", "ssw0rd!withMore", "withMore"]),
+        # ``$`` / ``#`` mid-value: the old class produced no match on
+        # the 7-char leading run and the whole value leaked.
+        (_PUNCT_DOLLAR_HASH_FIXTURE, ["hunter2", "$plus", "#tail", "plus", "tail"]),
+    ],
+)
+def test_punctuated_secret_value_fully_redacted(
+    sample: str,
+    value_fragments: list[str],
+) -> None:
+    """The whole punctuated value is replaced -- no cleartext fragment."""
+    payload = "dispatch failed for " + sample + " during login"
+    result = redact(payload, _API_KEY_ONLY_POLICY)
+    redacted = result.redacted
+    assert isinstance(redacted, str)
+    assert "[REDACTED:api_key]" in redacted
+    for fragment in value_fragments:
+        assert fragment not in redacted, (
+            f"cleartext fragment {fragment!r} of the secret value survived redaction: {redacted!r}"
+        )
+    # The non-secret context around the match is preserved -- the
+    # widened class must not swallow neighbouring prose.
+    assert redacted.startswith("dispatch failed for ")
+    assert redacted.endswith(" during login")
+    assert len(result.manifest) == 1
+    assert result.manifest[0].pattern == "api_key"

--- a/docs/codebase/error-message-shape.md
+++ b/docs/codebase/error-message-shape.md
@@ -193,6 +193,22 @@ leaking — the operator just needs to be reminded. The gold-standard
 operator set that env var; it does **not** name the resolved
 client-id value the Vault render produced.
 
+**Free-text diagnostics from the dispatch error builders are Tier-1
+redacted, then capped.** Every free-text field the
+`operations/_errors.py` builders emit from a `str(exc)` or an
+upstream response body — `extras.exception_message`,
+`extras.upstream_message`, `extras.detail`, and the `error` summary
+tails built from them — passes through `_sanitize_free_text`: a
+Tier-1 redaction pass with the packaged default policy
+(credential-shaped patterns only, so hosts / statuses / remediation
+prose stay legible), then the `_EXC_MESSAGE_CAP=256` truncation.
+Where the rows below say "capped" for these fields, read
+"redacted, then capped": the cap alone is a length bound, not a
+secrecy bound — a credential inside the first 256 chars used to ride
+the envelope verbatim. Redaction runs first so a secret straddling
+the cap boundary cannot survive truncation as a cleartext fragment
+the patterns no longer match. See `docs/codebase/redaction.md`.
+
 ## When the response is intentionally bare
 
 A handful of errors stay deliberately code-only because the

--- a/docs/codebase/redaction.md
+++ b/docs/codebase/redaction.md
@@ -127,11 +127,32 @@ production traffic cannot reach that branch.
 | `ipv6` | Full + compressed RFC 5952 forms |
 | `fqdn` | ≥2 labels with non-numeric TLD start |
 
+The secret-*value* part of `authorization_header`, `bearer_token`,
+and `api_key` consumes any non-whitespace, non-quote byte
+(`patterns.py::_VALUE_CHARS`, bounded by `_VALUE_MAX`): the value is
+captured to its natural delimiter — whitespace, closing quote, or end
+of blob. The earlier alphanumeric-plus-`. _ - + / =` class stopped at
+the first punctuation byte, so a value like `P@ssw0rd!withMore` was
+matched only partially (tail leaked) or not at all (whole value
+leaked). The labelled-context requirement, not the value alphabet, is
+what keeps opaque IDs (Git SHAs, build hashes) from false-positiving.
+
 Calibration notes (over-match vs under-match) are inline in
 `patterns.py`. The Tier-1 posture deliberately leans toward
 **over-redaction**: a false positive on a benign UUID is recoverable
 via a scoped rule, but a missed secret is the failure the parent goal
 (#800) cannot accept.
+
+Beyond the connector-*result* boundary, the dispatch **error
+builders** (`operations/_errors.py`) route every free-text diagnostic
+they emit — `extras.exception_message`, `extras.upstream_message`,
+`extras.detail`, and the `error` summary tails built from them —
+through `_sanitize_free_text`: a Tier-1 pass with the packaged
+default policy (pinned via `get_default_policy()`, deliberately
+bypassing the resolver override table so a registered shadow-mode
+policy cannot disable it), followed by the 256-char cap. Redaction
+runs **before** the cap so a secret straddling the cap boundary
+cannot survive truncation as an unmatchable cleartext fragment.
 
 ## Action semantics
 


### PR DESCRIPTION
## Summary

- **Tier-1 patterns capture labelled secret values to their natural delimiter.** The `authorization_header`, `bearer_token`, and `api_key` named patterns previously constrained the secret-*value* run to a restrictive character class (alphanumerics plus `. _ - + / =`), which bounded the match at the first byte outside that class. The value run is now a single negated class (`[^\s'"]`, shared `_VALUE_CHARS` constant, bounded by `_VALUE_MAX=4096`), so a value is consumed whole up to whitespace, a closing quote, or end of blob. Linear-scan matching is preserved (one bounded class quantifier, no nested quantifiers); the labelled-context requirement — not the value alphabet — continues to keep opaque IDs (Git SHAs, build hashes, `version 1.2.3`) from matching, and all existing negative-control fixtures pass unchanged.
- **Dispatch error builders route free-text diagnostics through the Tier-1 redactor.** `operations/_errors.py` now funnels every free-text diagnostic it emits from a `str(exc)` or upstream response body — `extras.exception_message` (`result_connector_error`, `result_connector_tls_verify_failed`, `result_no_connector`, `result_ambiguous_connector`), `extras.upstream_message` (403/422/auth-failed via the shared `_http_upstream_message` extractor, which also feeds the `error` summary tails), and `extras.detail` (`result_connector_unsupported`) — through a new `_sanitize_free_text` helper: a Tier-1 pass with the packaged default policy (credential-shaped patterns only, so hosts/statuses stay legible for diagnosis), followed by the existing `_EXC_MESSAGE_CAP=256` truncation. Redaction deliberately runs **before** the cap so truncation can never split a value into a fragment the patterns no longer match. The helper pins `get_default_policy()` (not the resolver override table), so a registered shadow-mode/narrowed policy cannot disable it, and it fails closed — if redaction itself is unavailable, the text is withheld rather than passed through.
- Docs updated (`docs/codebase/redaction.md`, `docs/codebase/error-message-shape.md`) and a `### Security` CHANGELOG entry added.

## Test plan

- [x] `uv run ruff check src/ tests/` — clean; `uv run ruff format --check src/ tests/` — clean
- [x] `uv run mypy src/` — clean (564 files)
- [x] New engine-level regression `test_punctuated_secret_value_fully_redacted` (3 punctuated fixtures through `redact()`): the **entire** value including its punctuated tail is replaced, surrounding prose preserved, exactly one manifest entry
- [x] Two new `api_key` positive rows in the pattern matrix (`_PUNCT_LEADING_AT_FIXTURE`, `_PUNCT_DOLLAR_HASH_FIXTURE`)
- [x] New `backend/tests/test_operations_connector_error_redaction.py`: credential-bearing `str(exc)` / upstream body yields no unredacted value in the returned `OperationResult` for `result_connector_error`, TLS, 403, `no_connector`, `ambiguous_connector`; redact-before-cap ordering pinned; benign diagnostics pass through verbatim; long benign text still capped
- [x] `git grep -nE "A-Za-z0-9\._" backend/src/meho_backplane/redaction/patterns.py` — no occurrences
- [x] `uv run pytest tests/test_redaction_patterns.py tests/test_redaction_engine.py tests/test_redaction_middleware.py tests/test_redaction_roundtrip_fixtures.py tests/test_redaction_shadow_mode.py tests/test_redaction_policy.py tests/test_redaction_resolver.py tests/test_operations_connector_error_redaction.py` — 128 passed, 1 skipped
- [x] `uv run pytest tests/test_operations_dispatcher.py tests/test_operations_connector_unsupported.py tests/test_operations_connector_auth_failed.py tests/test_operations_connector_http_403.py tests/test_operations_connector_tls_verify_failed.py tests/test_dispatcher_redaction_integration.py tests/test_connectors_keycloak_redaction.py tests/test_redaction_presidio.py tests/test_redaction_roundtrip_meta.py` — 124 passed, 6 skipped
- [x] Full backend unit suite (`uv run pytest tests/ -q`) — 9017 passed, 419 skipped, exit 0

## Out of scope

- Tier-2 (Presidio/NER) changes — Tier-1 regex + error-builder surface only.
- Running Tier-1 over dispatch broadcast payloads and a classifier-coverage lint (sibling task, later wave).
- `_EXC_MESSAGE_CAP` semantics and the structured-error envelope shape — unchanged.
- The `/api/v1/targets/{name}/probe` route's own `_PROBE_EXC_MESSAGE_CAP` fingerprint-failure path (route-boundary sibling of this surface) — noted as an adjacent finding.

<!-- auto-implement-issue: fresh, iteration 1 -->

Closes evoila-bosnia/meho-internal#150
