### PR TITLE
ci: allow MIT-0 in the Python dependency license gate

### DIFF
--- a/.github/workflows/dependency-license-check.yml
+++ b/.github/workflows/dependency-license-check.yml
@@ -138,6 +138,14 @@ jobs:
         # OSI-approved (https://opensource.org/license/cnri-python). Allowing
         # the exact emitted expression keeps the gate specific rather than
         # broadening to either arm alone or to bare ``CNRI-Python``.
+        #
+        # ``MIT-0``: cffi 2.1.0 (2026-07, transitive via cryptography and
+        # friends) switched its PEP 639 expression to MIT-0 (MIT No
+        # Attribution) — MIT with the attribution requirement removed, OSI-
+        # approved (https://opensource.org/license/mit-0), strictly more
+        # permissive than MIT which this list already allows. This job
+        # fresh-installs (ignoring uv.lock), so the gate broke on every
+        # dep-touching PR the day cffi 2.1.0 released.
         run: >
           pip-licenses --format=plain --ignore-packages py_rust_stemmers fastembed tiktoken --allow-only="
           Apache Software License;
@@ -146,6 +154,7 @@ jobs:
           Apache License 2.0;
           MIT License;
           MIT;
+          MIT-0;
           BSD License;
           BSD-2-Clause;
           BSD-3-Clause;


### PR DESCRIPTION
## Why

The `Python License Check` job fresh-installs backend deps (ignoring `uv.lock`), and cffi 2.1.0 (released this week, transitive via cryptography) switched its PEP 639 license expression to **MIT-0** — MIT No Attribution, OSI-approved, strictly more permissive than the already-allowed MIT. Since its release every dep-touching PR fails this required-for-dep-PRs lane (first seen on #2196, run 28836048596; dependabot runs from two days ago still passed).

## What

One allow-list entry (`MIT-0;`) plus the house-style comment block documenting the exact emitted expression, per the file's existing convention of allowing exact expressions rather than broadening.

Out-of-band CI unblock for the in-flight hardening PR train; no application code touched.

🤖 Generated with [Claude Code](https://claude.com/claude-code)