### PR TITLE
docs(connectors): document the Swagger 2.0 → OpenAPI 3.x ingest on-ramp (VCFA worked example)

### DIFF
--- a/docs/codebase/connectors-vcf-automation.md
+++ b/docs/codebase/connectors-vcf-automation.md
@@ -312,6 +312,24 @@ payload per plane.
   Operators who need that string call the wrapper directly; the curated
   ingest in #836 will route through the structured `/cloudapi/*` and
   `/iaas/api/*` paths instead.
+- The VCFA tenant/consumption plane's only *vendor-published*
+  machine-readable surface is the 8 **Swagger 2.0** fragments vendored
+  under [`vmware/vra-sdk-go`
+  `swagger/`](https://github.com/vmware/vra-sdk-go/tree/v0.6.5/swagger)
+  (`vra-project.json` … `vra-iaas.json`); the provider/management plane
+  ships no swagger artifact at all. The ingest parser is
+  OpenAPI-3.x-only by decision (#2090, reaffirming #1532) and rejects
+  native 2.0 with a structured `UnsupportedSpecError` naming the
+  conversion on-ramp — convert with `swagger2openapi` /
+  `converter.swagger.io` first, then ingest the 3.x output (see the
+  ["Product ships only Swagger
+  2.0"](../cross-repo/connector-ingestion.md#product-ships-only-swagger-20)
+  runbook section, which uses VCFA as the worked example). This is
+  **orthogonal to the curated 11-op read core**: `VCFA_CORE_OPS` is
+  sourced from the OpenAPI-3.x `vcf-automation-9.0/cloudapi.yaml` +
+  `iaas.yaml` documents, so lighting up the core never touches the
+  vra-sdk-go 2.0 fragments — converting them only *widens* the surface
+  beyond the curated core.
 - `--resolve`-style DNS override (consumer-wrapper-only) has no direct
   httpx equivalent in the connector — operators are expected to make the
   appliance's FQDN resolvable on the meho-backplane host (typical: split-DNS
@@ -326,6 +344,9 @@ payload per plane.
   (skeleton — this Task); [G3.6-T11 #836](https://github.com/evoila/meho/issues/836)
   (dual-plane spec ingestion + read ops); [G3.6-T12 #840](https://github.com/evoila/meho/issues/840)
   (CLI verbs + E2E + onboarding doc).
+- Swagger-2.0 on-ramp decision: [#2090](https://github.com/evoila/meho/issues/2090)
+  (parser stays OpenAPI-3.x-only; convert vra-sdk-go fragments
+  out-of-band — see Known issues above).
 - Parent Initiative: [G3.6 #369](https://github.com/evoila/meho/issues/369).
 - Parent Goal: [G3 #214](https://github.com/evoila/meho/issues/214).
 - Adapter dependency: [G0.2 #223](https://github.com/evoila/meho/issues/223)

--- a/docs/codebase/spec-ingestion.md
+++ b/docs/codebase/spec-ingestion.md
@@ -1762,10 +1762,14 @@ Both delegate to `ReviewService.delete_connector`
   converters are Node/web-service tools (`swagger2openapi`/oas-kit,
   `converter.swagger.io`), and an in-house converter is a large
   correctness surface the review queue can't backstop, so the
-  documented decision (#1532) is to reject-with-remedy rather than
-  convert in-process. The `harbor/2.x` catalog row and
+  documented decision (#1532, reaffirmed for the VCF Automation case
+  in #2090) is to reject-with-remedy rather than convert in-process.
+  The product-agnostic convert-then-ingest runbook lives at
+  [`connector-ingestion.md` § "Product ships only Swagger 2.0"](../cross-repo/connector-ingestion.md#product-ships-only-swagger-20)
+  (VCF Automation's vra-sdk-go fragments are the worked example);
+  the `harbor/2.x` catalog row and
   [`harbor-onboarding.md`](../cross-repo/harbor-onboarding.md#spec-ingest-swagger-20--openapi-3x-conversion)
-  carry the operator-facing conversion runbook for the exemplar
+  carry the Harbor-specific conversion runbook for the other exemplar
   2.0-only surface.
 * **`$ref` drill-down rejected.** Refs that walk into a component's
   sub-tree (`#/components/schemas/X/properties/y`,

--- a/docs/cross-repo/connector-ingestion.md
+++ b/docs/cross-repo/connector-ingestion.md
@@ -109,7 +109,65 @@ Authoring tips:
 - Give each operation a `summary` and `description` — these feed the LLM grouping pass and the agent's `when_to_use` retrieval, so a one-line `summary` is worth more than a bare path.
 - A bad path-param shape or a malformed `$ref` surfaces under `--dry-run` before any DB write; iterate on the file until the dry-run op count matches what you intended.
 
-> **Why not auto-derive the spec?** Parsing vendor HTML/Markdown into OpenAPI, or deriving ops from a typed client, is a deliberately **deferred** capability ([initiative #1529 out-of-scope](https://github.com/evoila/meho/issues/1529)). A small hand-authored spec is the cheaper answer than an HTML→OpenAPI inference engine — author the ops you need, not the vendor's whole surface. Conform to [OpenAPI 3.0.3](https://spec.openapis.org/oas/v3.0.3.html) or [3.1.1](https://spec.openapis.org/oas/v3.1.1.html); the parser rejects Swagger 2.0 with a conversion-path remedy (see [`connector-catalog.md`](connector-catalog.md)).
+> **Why not auto-derive the spec?** Parsing vendor HTML/Markdown into OpenAPI, or deriving ops from a typed client, is a deliberately **deferred** capability ([initiative #1529 out-of-scope](https://github.com/evoila/meho/issues/1529)). A small hand-authored spec is the cheaper answer than an HTML→OpenAPI inference engine — author the ops you need, not the vendor's whole surface. Conform to [OpenAPI 3.0.3](https://spec.openapis.org/oas/v3.0.3.html) or [3.1.1](https://spec.openapis.org/oas/v3.1.1.html); the parser rejects Swagger 2.0 with a conversion-path remedy (see [the next section](#product-ships-only-swagger-20)).
+
+#### Product ships only Swagger 2.0
+
+Some products publish a machine-readable spec, but only as **Swagger
+2.0** (a.k.a. OpenAPI 2.0 — the root key is `swagger: "2.0"` instead
+of `openapi: 3.x.y`). The ingest parser is OpenAPI-3.x-only **by
+decision** (#2090, reaffirming #1532): it does not convert 2.0
+in-process, because the maintained 2.0→3.0 converters are
+Node/web-service tools and a hand-rolled Python converter is a large
+correctness surface the operator review queue can't backstop.
+Handing ingest a native 2.0 document is rejected with a structured
+`UnsupportedSpecError` whose message names this exact on-ramp (the
+`_SWAGGER_2_CONVERSION_REMEDIATION` string in
+`backend/src/meho_backplane/operations/ingest/openapi.py`, shipped in
+#1542).
+
+The supported path is **convert once out-of-band, then ingest the 3.x
+output** like any other spec:
+
+```bash
+# Option A — swagger2openapi CLI (Node; the de-facto oas-kit converter)
+npx swagger2openapi swagger.json -o openapi3.yaml
+
+# Option B — the hosted converter (no local Node toolchain)
+curl -sS https://converter.swagger.io/api/convert \
+  -H 'Content-Type: application/json' \
+  --data-binary @swagger.json -o openapi3.json
+```
+
+The conversion is lossless for the request/response surface ingest
+consumes (`parameters[in=body]` → `requestBody`, `definitions` →
+`components.schemas`); the converted document goes through the same
+`--dry-run` → ingest → review → enable pipeline as a native 3.x spec.
+
+Worked example — **VCF Automation** (the live 2.0-only case, #2090):
+VMware ships no OpenAPI-3.x appliance spec for the VCFA
+tenant/consumption plane; the only machine-readable surface is the
+8 Swagger 2.0 fragments vendored under
+[`vmware/vra-sdk-go` `swagger/`](https://github.com/vmware/vra-sdk-go/tree/v0.6.5/swagger)
+(`vra-project.json`, `vra-iaas.json`, …). Each fragment converts and
+dry-runs individually:
+
+```bash
+npx swagger2openapi vra-iaas.json -o vra-iaas-openapi3.yaml
+meho connector ingest \
+  --product vcfa --version 9.0 --impl vcfa-rest \
+  --spec file:///abs/path/vra-iaas-openapi3.yaml \
+  --dry-run
+```
+
+Note this only **widens** VCF Automation's surface: the connector's
+curated 11-op read core is sourced from OpenAPI-3.x documents
+(`cloudapi.yaml` + `iaas.yaml`) and works without any 2.0
+conversion — see
+[`connectors-vcf-automation.md`](../codebase/connectors-vcf-automation.md).
+The other shipped exemplar is Harbor 2.x, whose product-specific
+conversion runbook lives in
+[`harbor-onboarding.md`](harbor-onboarding.md#spec-ingest-swagger-20--openapi-3x-conversion).
 
 Validate the spec before committing to a tenant-wide ingestion:
 


### PR DESCRIPTION
## Summary
- Records the #2090 decision as docs: the ingest parser stays **OpenAPI-3.x-only** (option (b) — reaffirming the #1532 posture); no in-process 2.0→3.x converter is added, matching the "dumb substrate, smart agent" line.
- Adds a product-agnostic **"Product ships only Swagger 2.0"** section to the operator ingest runbook (`docs/cross-repo/connector-ingestion.md`): convert once out-of-band (`npx swagger2openapi` or `converter.swagger.io`), then ingest the 3.x output through the unchanged dry-run → review → enable pipeline. VCF Automation's 8 `vmware/vra-sdk-go` `swagger/` fragments (verified present at `v0.6.5`) are the worked example; Harbor's product-specific runbook is cross-linked.
- The section cross-references the already-shipped structured `UnsupportedSpecError` remediation (`_SWAGGER_2_CONVERSION_REMEDIATION`, PR #1542) — the DX sub-issue is closed out **by reference**, not re-implemented.
- `docs/codebase/connectors-vcf-automation.md` gains a Known-issues entry confirming the curated 11-op read core (`VCFA_CORE_OPS`, sourced from the OpenAPI-3.x `cloudapi.yaml`/`iaas.yaml`) is **orthogonal** to the Swagger-2.0 fragments — conversion widens VCFA's surface, it does not gate the core. `docs/codebase/spec-ingestion.md`'s Known-issues bullet now points at the new generic runbook section and notes the #2090 reaffirmation.

## Test plan
- [x] Docs-only diff (3 files under `docs/`) — no parser, route, or schema changes, so no CLI OpenAPI snapshot regen needed.
- [x] `uv run pytest tests/test_operations_ingest_openapi.py -k swagger` — 2 passed (`test_unsupported_swagger_2_raises` asserts the shipped remediation names `swagger2openapi` + `converter.swagger.io`; `test_read_spec_info_version_rejects_swagger_2`) — proves no code path parses native 2.0 and the structured error stands.
- [x] `.claude/hooks/code-quality.py --diff` — exit 0.
- [x] Anchor check: `#product-ships-only-swagger-20` matches the new `#### Product ships only Swagger 2.0` heading; `harbor-onboarding.md#spec-ingest-swagger-20--openapi-3x-conversion` is the pre-existing anchor.
- [x] AC "decision recorded": issue body carries the 2026-07-06 decision; docs now state it with #2090/#1532 cross-refs.
- [x] AC "on-ramp documented as the supported path": new runbook section + VCFA worked example.
- [x] AC "DX not re-implemented": zero code changes; #1542 remediation referenced as shipped.
- [x] AC "VCFA core orthogonality confirmed": stated in `connectors-vcf-automation.md` Known issues + runbook section.

## Out of scope
- Building an in-process 2.0→3.x converter (explicitly rejected by the recorded decision).
- Sibling initiative tasks #2085 / #2092 / #2093 / #2110 (other ingest/dispatch contract fixes).
- Adjacent finding (not edited): `openapi.py`'s module docstring documents the 3.x-only decision citing #1532 only; adding a #2090 cross-ref there was skipped to keep this PR docs-only.

<!-- auto-implement-issue: fresh, iteration 1 -->

Closes #2090
