### PR TITLE
fix(topology): surface no-populator coverage gap on refresh instead of silent all-zero counts

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -106,6 +106,24 @@ connector-related release-notes line.
   generated CLI/SDK pick them up. The sibling silent-no-op case (a
   resolvable connector without topology support returning all-zero
   counts) is tracked separately in #2093. (#2092)
+
+### Fixed — topology refresh names the populator coverage gap instead of a silent all-zero no-op
+
+- `POST /api/v1/topology/refresh/{target_name}` against a target whose
+  `product` ships **no topology populator** (the connector inherits the
+  base `discover_topology` no-op — e.g. `argocd`, `vault`, `keycloak`,
+  `vrli`, `gh`, `vmware`) no longer returns an all-zero count body
+  indistinguishable from a clean populator run: the `RefreshResult` now
+  carries `no_populator_for_product` (the offending product slug) plus
+  `populated_products` (the registered products that DO refresh
+  meaningfully, e.g. `["k8s"]`). Both fields are `null` when a
+  populator ran — including a run that legitimately reconciled zero
+  changes — so a consumer tells no-op-by-design from coverage gap with
+  a single field check instead of tracing meho source. Non-breaking:
+  HTTP status stays 200 and the six counts are unchanged; the reconcile
+  (including soft-deletes of previously adopted nodes, the audit row,
+  and the broadcast event) still runs. The `meho topology refresh` CLI
+  verb appends a human-readable note when the signal is set. (#2093)
 ### Breaking changes — REST connector-ingest omitted `tenant_id` now targets the global scope
 
 - **`POST /api/v1/connectors/ingest` with no `tenant_id` in the body now ingests under the built-in / global scope (`tenant_id IS NULL`), matching the MCP tool `meho.connector.ingest`'s documented "omit = global" semantics** (#2085): previously the REST route silently resolved omission to the *caller's JWT tenant*, so a consumer following the MCP-documented body minted a caller-tenant shadow copy of an existing global row (the scope-aware dedup never matches across scopes; the v0.14.0 dogfood hit this as a 136-op duplicate). The request schema gains an optional `tenant_id` field with a documented resolution: omitted / `null` → global (tenant_admin — already the route's gate), your own tenant UUID → tenant-curated scope, any other UUID → 403. **Migration recipe:** clients that relied on the old caller-tenant default add `"tenant_id": "<your-tenant-uuid>"` to the ingest body; bodies without it now write global rows. The `meho connector ingest` CLI verb and the `/ui/connectors/registry/ingest` modal drive this route and inherit the new global default.

--- a/backend/src/meho_backplane/api/v1/topology.py
+++ b/backend/src/meho_backplane/api/v1/topology.py
@@ -577,6 +577,14 @@ async def refresh(
     registered connector supports returns 422 ``no_matching_connector``;
     a resolution tie returns 409 ``ambiguous_connector`` with the
     candidate ``(product, version, impl_id)`` triples.
+
+    A target whose connector resolves but ships **no topology
+    populator** (the base ``discover_topology`` no-op) still returns
+    200 with all-zero counts, but the body carries an explicit
+    ``no_populator_for_product`` slug plus the ``populated_products``
+    that do refresh meaningfully (#2093) — distinguishing the
+    coverage-gap no-op from a populator run that reconciled zero
+    changes (both fields null).
     """
     structlog.contextvars.bind_contextvars(
         audit_op_id=_OP_REFRESH,

--- a/backend/src/meho_backplane/topology/refresh.py
+++ b/backend/src/meho_backplane/topology/refresh.py
@@ -45,13 +45,14 @@ from decimal import Decimal
 from typing import Any
 
 import structlog
-from pydantic import BaseModel, ConfigDict
+from pydantic import BaseModel, ConfigDict, Field
 from sqlalchemy import false, or_, select, tuple_
 from sqlalchemy.ext.asyncio import AsyncSession
 
 from meho_backplane.auth.operator import Operator
 from meho_backplane.broadcast import BroadcastEvent, publish_event
 from meho_backplane.connectors.base import Connector
+from meho_backplane.connectors.registry import all_connectors_v2
 from meho_backplane.connectors.resolver import resolve_connector
 from meho_backplane.connectors.schemas import EdgeHint, NodeHint, TopologyHints
 from meho_backplane.db.engine import get_sessionmaker
@@ -91,6 +92,16 @@ class RefreshResult(BaseModel):
     one of added / updated / removed (or none, when unchanged). The same
     holds for edges. ``duration_ms`` is wall-clock for the whole
     resolve + discover + reconcile + commit cycle.
+
+    ``no_populator_for_product`` discriminates the two all-zero-count
+    no-op classes (#2093): ``None`` means the resolved connector ships a
+    topology populator (a ``discover_topology`` override) and the counts
+    reflect a real reconcile — all-zero is "populator ran clean, nothing
+    changed". A product slug means the connector inherits the base-class
+    no-op default, so the refresh was a no-op **by coverage gap**, not by
+    graph convergence; ``populated_products`` then lists the registered
+    products that DO ship a populator so a consumer can identify the gap
+    without reading meho source.
     """
 
     model_config = ConfigDict(frozen=True)
@@ -103,6 +114,24 @@ class RefreshResult(BaseModel):
     removed_nodes: int
     removed_edges: int
     duration_ms: float
+    no_populator_for_product: str | None = Field(
+        default=None,
+        description=(
+            "Set to the target's product slug when the resolved connector "
+            "has no topology populator (inherits the base-class "
+            "discover_topology no-op), so the all-zero counts are a "
+            "coverage gap rather than a clean no-op. Null when a "
+            "populator ran."
+        ),
+    )
+    populated_products: tuple[str, ...] | None = Field(
+        default=None,
+        description=(
+            "Registered products that DO ship a topology populator, "
+            "sorted. Only present alongside no_populator_for_product so "
+            "the consumer can see which products refresh meaningfully."
+        ),
+    )
 
 
 def _node_key(kind: str, name: str) -> tuple[str, str]:
@@ -868,6 +897,8 @@ async def _apply_reconcile(
     hints: TopologyHints,
     audit_id: uuid.UUID,
     started: float,
+    no_populator_for_product: str | None,
+    populated_products: tuple[str, ...] | None,
 ) -> RefreshResult:
     """Run the node + edge diff + history writes + audit write in one txn.
 
@@ -921,6 +952,8 @@ async def _apply_reconcile(
             removed_nodes=removed_nodes,
             removed_edges=removed_edges,
             duration_ms=(time.perf_counter() - started) * 1000.0,
+            no_populator_for_product=no_populator_for_product,
+            populated_products=populated_products,
         )
         await _write_audit_and_broadcast(
             session=session,
@@ -930,6 +963,42 @@ async def _apply_reconcile(
             result=result,
         )
     return result
+
+
+def _has_populator(connector_cls: type[Connector]) -> bool:
+    """Return ``True`` when *connector_cls* overrides the base populator no-op.
+
+    :meth:`Connector.discover_topology` ships a base-class default that
+    returns an empty :class:`TopologyHints` (G9.1-T2 #449) so every
+    connector stays refreshable without per-product topology work. That
+    default made a coverage gap indistinguishable from a clean no-op on
+    the wire (#2093); the identity check against the base function is
+    the discriminator. Function identity (not ``hasattr``) is the right
+    probe: an override anywhere in the MRO — including the
+    operator-aware keyword-only variant on ``KubernetesConnector`` —
+    replaces the class attribute, while auto-shim subclasses that
+    inherit the base default compare identical.
+    """
+    return connector_cls.discover_topology is not Connector.discover_topology
+
+
+def _populated_products() -> tuple[str, ...]:
+    """Sorted product slugs whose registered connector ships a populator.
+
+    Derived from the v2 registry snapshot (v1 registrations mirror into
+    v2 as ``(product, "", "")``), deduped across version/impl entries.
+    Registry state is process-local and small (tens of entries), so the
+    scan per no-populator refresh is negligible.
+    """
+    return tuple(
+        sorted(
+            {
+                product
+                for (product, _version, _impl_id), cls in all_connectors_v2().items()
+                if product and _has_populator(cls)
+            }
+        )
+    )
 
 
 async def _invoke_discover_topology(
@@ -1002,6 +1071,10 @@ async def refresh_target_topology(
 
     Returns:
         A :class:`RefreshResult` with the disjoint per-class counts.
+        When the resolved connector ships no topology populator, the
+        result additionally carries ``no_populator_for_product`` +
+        ``populated_products`` so the all-zero counts are readable as a
+        coverage gap rather than a clean no-op (#2093).
     """
     started = time.perf_counter()
     target_id: uuid.UUID = target.id
@@ -1013,6 +1086,18 @@ async def refresh_target_topology(
     connector: Connector = get_or_create_connector_instance(connector_cls)
     hints: TopologyHints = await _invoke_discover_topology(connector, target, operator)
 
+    # #2093 — discriminate the two all-zero-count no-op classes. A
+    # connector inheriting the base discover_topology no-op returns an
+    # empty snapshot every time; stamping the gap on the result (rather
+    # than skipping the reconcile) keeps the refresh semantics intact —
+    # the empty snapshot still soft-deletes stale nodes this target
+    # adopted earlier, and the audit/broadcast contract is unchanged.
+    no_populator_for_product: str | None = None
+    populated_products: tuple[str, ...] | None = None
+    if not _has_populator(connector_cls):
+        no_populator_for_product = discovered_by
+        populated_products = _populated_products()
+
     audit_id = uuid.uuid4()
     result = await _apply_reconcile(
         operator=operator,
@@ -1021,6 +1106,8 @@ async def refresh_target_topology(
         hints=hints,
         audit_id=audit_id,
         started=started,
+        no_populator_for_product=no_populator_for_product,
+        populated_products=populated_products,
     )
 
     # Transaction committed (audit row included). Broadcast is fail-open.
@@ -1049,5 +1136,6 @@ async def refresh_target_topology(
         removed_nodes=result.removed_nodes,
         removed_edges=result.removed_edges,
         duration_ms=round(result.duration_ms, 2),
+        no_populator_for_product=result.no_populator_for_product,
     )
     return result

--- a/backend/tests/test_api_v1_topology.py
+++ b/backend/tests/test_api_v1_topology.py
@@ -22,6 +22,11 @@ Coverage matrix (G9.1-T5 / Task #453 acceptance criteria):
   ``no_matching_connector`` and :class:`AmbiguousConnectorResolution`
   as 409 ``ambiguous_connector`` with candidates, not a bare
   ``text/plain`` 500 from FastAPI's default handler.
+* **refresh no-populator signal → wire** — #2093: the
+  ``no_populator_for_product`` / ``populated_products`` fields the
+  service stamps for a populator-less product pass through the
+  ``response_model`` unfiltered (and serialise as nulls when a
+  populator ran).
 * **RBAC** — every route requires ``operator`` minimum; ``read_only``
   gets 403.
 * **Unauthenticated** — every route returns 401 without a token.
@@ -517,11 +522,62 @@ def test_refresh_wraps_service_and_returns_result(client: TestClient) -> None:
     body = resp.json()
     assert body["target_id"] == str(target_id)
     assert body["added_nodes"] == 3
+    # #2093 — a populator-backed refresh serialises the no-populator
+    # signal as explicit nulls, keeping the two no-op classes
+    # discriminable on the wire.
+    assert body["no_populator_for_product"] is None
+    assert body["populated_products"] is None
     # The resolved target (not the raw name) is handed to the service.
     assert refresh.call_args.args[0].name == "vc-1"
     # resolve_target is tenant-scoped to the JWT's tenant_id.
     assert resolve.call_args.args[1] == _TENANT_ID
     assert resolve.call_args.args[2] == "vc-1"
+
+
+def test_refresh_no_populator_signal_passes_through_to_wire(client: TestClient) -> None:
+    """The #2093 coverage-gap signal survives response-model serialisation.
+
+    The service stamps ``no_populator_for_product`` + ``populated_products``
+    when the resolved connector inherits the base ``discover_topology``
+    no-op; this test pins the route's ``response_model=RefreshResult``
+    contract — the signal fields reach the JSON body unfiltered so a
+    consumer can distinguish the all-zero coverage-gap no-op from a
+    clean populator run with a single field check.
+    """
+    key, token = _token(TenantRole.OPERATOR)
+    target_id = uuid.uuid4()
+
+    class _FakeTarget:
+        id = target_id
+        name = "argocd-1"
+        product = "argocd"
+
+    result = RefreshResult(
+        target_id=target_id,
+        added_nodes=0,
+        added_edges=0,
+        updated_nodes=0,
+        updated_edges=0,
+        removed_nodes=0,
+        removed_edges=0,
+        duration_ms=1.5,
+        no_populator_for_product="argocd",
+        populated_products=("k8s",),
+    )
+    resolve = AsyncMock(return_value=_FakeTarget())
+    refresh = AsyncMock(return_value=result)
+    with (
+        respx.mock as mock_router,
+        patch("meho_backplane.api.v1.topology.resolve_target", resolve),
+        patch("meho_backplane.api.v1.topology.refresh_target_topology", refresh),
+    ):
+        _mock_discovery_and_jwks(mock_router, _public_jwks(key))
+        resp = client.post("/api/v1/topology/refresh/argocd-1", headers=_authed(token))
+    assert resp.status_code == 200, resp.text
+    body = resp.json()
+    assert body["no_populator_for_product"] == "argocd"
+    assert body["populated_products"] == ["k8s"]
+    assert body["added_nodes"] == 0
 
 
 def test_refresh_no_matching_connector_returns_structured_422(client: TestClient) -> None:

--- a/backend/tests/test_topology_refresh.py
+++ b/backend/tests/test_topology_refresh.py
@@ -250,6 +250,96 @@ async def test_second_refresh_same_hints_is_unchanged() -> None:
     assert result.updated_edges == 0
     assert result.removed_nodes == 0
     assert result.removed_edges == 0
+    # #2093 — a populator that ran clean carries NO no-populator signal:
+    # this all-zero result must stay discriminable from a coverage gap.
+    assert result.no_populator_for_product is None
+    assert result.populated_products is None
+
+
+# ---------------------------------------------------------------------------
+# No-populator signal (#2093)
+# ---------------------------------------------------------------------------
+
+
+class _NoPopulatorConnector(Connector):
+    """Connector inheriting the base ``discover_topology`` no-op default.
+
+    Stands in for the argocd / vault / keycloak / vrli / gh / vmware
+    connectors that resolve fine but ship no topology populator — the
+    class the #2093 silent-no-op reproduction drove refresh against.
+    """
+
+    product = "nopop"
+
+    async def fingerprint(self, target: Any) -> Any:  # pragma: no cover - unused
+        raise NotImplementedError
+
+    async def probe(self, target: Any) -> Any:  # pragma: no cover - unused
+        raise NotImplementedError
+
+    async def execute(
+        self, target: Any, op_id: str, params: dict[str, Any]
+    ) -> Any:  # pragma: no cover - unused
+        raise NotImplementedError
+
+
+@pytest.mark.asyncio
+async def test_no_populator_refresh_carries_explicit_signal() -> None:
+    """A populator-less product's all-zero refresh names the coverage gap.
+
+    Registers one populated product (``faketopo`` — overrides
+    ``discover_topology``) and one populator-less product (``nopop`` —
+    inherits the base no-op), then refreshes a ``nopop`` target: counts
+    stay all-zero (the base default remains the fallback) but the result
+    surfaces ``no_populator_for_product`` + the ``populated_products``
+    set, so a consumer can tell no-op-by-gap from no-op-by-design
+    without reading meho source (#2093).
+    """
+    _register_fake()
+    register_connector_v2(product="nopop", version="", impl_id="", cls=_NoPopulatorConnector)
+    tenant_id, _ = await _seed_tenant_and_target()
+
+    sessionmaker = get_sessionmaker()
+    async with sessionmaker() as session:
+        nopop_target = Target(
+            id=uuid.uuid4(),
+            tenant_id=tenant_id,
+            name="argocd-style-target",
+            aliases=[],
+            product="nopop",
+            host="nopop.example.test",
+        )
+        session.add(nopop_target)
+        await session.commit()
+        await session.refresh(nopop_target)
+
+    with patch(_PUBLISH, new=AsyncMock()):
+        result = await refresh_target_topology(nopop_target, _operator(tenant_id))
+
+    assert result.added_nodes == 0
+    assert result.added_edges == 0
+    assert result.updated_nodes == 0
+    assert result.updated_edges == 0
+    assert result.removed_nodes == 0
+    assert result.removed_edges == 0
+    assert result.no_populator_for_product == "nopop"
+    assert result.populated_products == ("faketopo",)
+
+
+@pytest.mark.asyncio
+async def test_populated_refresh_omits_signal_even_with_gaps_registered() -> None:
+    """A populator-backed refresh stays signal-free while gap products coexist."""
+    _register_fake()
+    register_connector_v2(product="nopop", version="", impl_id="", cls=_NoPopulatorConnector)
+    tenant_id, target = await _seed_tenant_and_target()
+    _FakeConnector.hints = _hints_3n2e()
+
+    with patch(_PUBLISH, new=AsyncMock()):
+        result = await refresh_target_topology(target, _operator(tenant_id))
+
+    assert result.added_nodes == 3
+    assert result.no_populator_for_product is None
+    assert result.populated_products is None
 
 
 # ---------------------------------------------------------------------------

--- a/cli/api/openapi.json
+++ b/cli/api/openapi.json
@@ -1805,7 +1805,7 @@
           "topology"
         ],
         "summary": "Refresh",
-        "description": "Rediscover *target_name*'s topology and reconcile it into the graph.\n\nWraps :func:`~meho_backplane.topology.refresh.refresh_target_topology`.\n*target_name* is resolved tenant-scoped via\n:func:`~meho_backplane.targets.resolver.resolve_target` (alias-\naware, 404 with near-misses when nothing matches) \u2014 so a principal\ncan only ever refresh a target in their own tenant and the\nreconcile writes every row under ``operator.tenant_id``.\nCross-tenant refresh is impossible: there is no path by which a\ntarget id from another tenant reaches the service.\n\nThe refresh service writes its own domain-level ``audit_log`` row\n(``op_id=\"topology.refresh\"``, ``op_class=\"read\"``, the per-target\nnode/edge counts in ``payload``) and publishes one fail-open\nbroadcast event inside its own transaction; this route binds the\nsame op identity for the chassis HTTP-level audit row so both rows\nclassify consistently.\n\nConnector-resolution failures inside the service surface as\nstructured JSON rather than a bare 500 (#2092): a ``product`` no\nregistered connector supports returns 422 ``no_matching_connector``;\na resolution tie returns 409 ``ambiguous_connector`` with the\ncandidate ``(product, version, impl_id)`` triples.",
+        "description": "Rediscover *target_name*'s topology and reconcile it into the graph.\n\nWraps :func:`~meho_backplane.topology.refresh.refresh_target_topology`.\n*target_name* is resolved tenant-scoped via\n:func:`~meho_backplane.targets.resolver.resolve_target` (alias-\naware, 404 with near-misses when nothing matches) \u2014 so a principal\ncan only ever refresh a target in their own tenant and the\nreconcile writes every row under ``operator.tenant_id``.\nCross-tenant refresh is impossible: there is no path by which a\ntarget id from another tenant reaches the service.\n\nThe refresh service writes its own domain-level ``audit_log`` row\n(``op_id=\"topology.refresh\"``, ``op_class=\"read\"``, the per-target\nnode/edge counts in ``payload``) and publishes one fail-open\nbroadcast event inside its own transaction; this route binds the\nsame op identity for the chassis HTTP-level audit row so both rows\nclassify consistently.\n\nConnector-resolution failures inside the service surface as\nstructured JSON rather than a bare 500 (#2092): a ``product`` no\nregistered connector supports returns 422 ``no_matching_connector``;\na resolution tie returns 409 ``ambiguous_connector`` with the\ncandidate ``(product, version, impl_id)`` triples.\n\nA target whose connector resolves but ships **no topology\npopulator** (the base ``discover_topology`` no-op) still returns\n200 with all-zero counts, but the body carries an explicit\n``no_populator_for_product`` slug plus the ``populated_products``\nthat do refresh meaningfully (#2093) \u2014 distinguishing the\ncoverage-gap no-op from a populator run that reconciled zero\nchanges (both fields null).",
         "operationId": "refresh_api_v1_topology_refresh__target_name__post",
         "parameters": [
           {
@@ -23761,6 +23761,21 @@
           "duration_ms": {
             "type": "number",
             "title": "Duration Ms"
+          },
+          "no_populator_for_product": {
+            "type": "string",
+            "nullable": true,
+            "title": "No Populator For Product",
+            "description": "Set to the target's product slug when the resolved connector has no topology populator (inherits the base-class discover_topology no-op), so the all-zero counts are a coverage gap rather than a clean no-op. Null when a populator ran."
+          },
+          "populated_products": {
+            "items": {
+              "type": "string"
+            },
+            "type": "array",
+            "nullable": true,
+            "title": "Populated Products",
+            "description": "Registered products that DO ship a topology populator, sorted. Only present alongside no_populator_for_product so the consumer can see which products refresh meaningfully."
           }
         },
         "type": "object",
@@ -23775,7 +23790,7 @@
           "duration_ms"
         ],
         "title": "RefreshResult",
-        "description": "Per-target reconcile outcome returned by :func:`refresh_target_topology`.\n\nCounts are disjoint per object class: a node is counted in exactly\none of added / updated / removed (or none, when unchanged). The same\nholds for edges. ``duration_ms`` is wall-clock for the whole\nresolve + discover + reconcile + commit cycle."
+        "description": "Per-target reconcile outcome returned by :func:`refresh_target_topology`.\n\nCounts are disjoint per object class: a node is counted in exactly\none of added / updated / removed (or none, when unchanged). The same\nholds for edges. ``duration_ms`` is wall-clock for the whole\nresolve + discover + reconcile + commit cycle.\n\n``no_populator_for_product`` discriminates the two all-zero-count\nno-op classes (#2093): ``None`` means the resolved connector ships a\ntopology populator (a ``discover_topology`` override) and the counts\nreflect a real reconcile \u2014 all-zero is \"populator ran clean, nothing\nchanged\". A product slug means the connector inherits the base-class\nno-op default, so the refresh was a no-op **by coverage gap**, not by\ngraph convergence; ``populated_products`` then lists the registered\nproducts that DO ship a populator so a consumer can identify the gap\nwithout reading meho source."
       },
       "RejectRequestBody": {
         "properties": {

--- a/cli/internal/api/client.gen.go
+++ b/cli/internal/api/client.gen.go
@@ -4360,15 +4360,31 @@ type ReassignRunResponse struct {
 // one of added / updated / removed (or none, when unchanged). The same
 // holds for edges. “duration_ms“ is wall-clock for the whole
 // resolve + discover + reconcile + commit cycle.
+//
+// “no_populator_for_product“ discriminates the two all-zero-count
+// no-op classes (#2093): “None“ means the resolved connector ships a
+// topology populator (a “discover_topology“ override) and the counts
+// reflect a real reconcile — all-zero is "populator ran clean, nothing
+// changed". A product slug means the connector inherits the base-class
+// no-op default, so the refresh was a no-op **by coverage gap**, not by
+// graph convergence; “populated_products“ then lists the registered
+// products that DO ship a populator so a consumer can identify the gap
+// without reading meho source.
 type RefreshResult struct {
-	AddedEdges   int                `json:"added_edges"`
-	AddedNodes   int                `json:"added_nodes"`
-	DurationMs   float32            `json:"duration_ms"`
-	RemovedEdges int                `json:"removed_edges"`
-	RemovedNodes int                `json:"removed_nodes"`
-	TargetId     openapi_types.UUID `json:"target_id"`
-	UpdatedEdges int                `json:"updated_edges"`
-	UpdatedNodes int                `json:"updated_nodes"`
+	AddedEdges int     `json:"added_edges"`
+	AddedNodes int     `json:"added_nodes"`
+	DurationMs float32 `json:"duration_ms"`
+
+	// NoPopulatorForProduct Set to the target's product slug when the resolved connector has no topology populator (inherits the base-class discover_topology no-op), so the all-zero counts are a coverage gap rather than a clean no-op. Null when a populator ran.
+	NoPopulatorForProduct *string `json:"no_populator_for_product"`
+
+	// PopulatedProducts Registered products that DO ship a topology populator, sorted. Only present alongside no_populator_for_product so the consumer can see which products refresh meaningfully.
+	PopulatedProducts *[]string          `json:"populated_products"`
+	RemovedEdges      int                `json:"removed_edges"`
+	RemovedNodes      int                `json:"removed_nodes"`
+	TargetId          openapi_types.UUID `json:"target_id"`
+	UpdatedEdges      int                `json:"updated_edges"`
+	UpdatedNodes      int                `json:"updated_nodes"`
 }
 
 // RejectRequestBody POST body for “…/reject“.

--- a/cli/internal/cmd/topology/e2e_test.go
+++ b/cli/internal/cmd/topology/e2e_test.go
@@ -65,6 +65,49 @@ func TestRefreshHappyPath(t *testing.T) {
 			t.Errorf("refresh summary missing %q in %q", want, out)
 		}
 	}
+	// #2093 — no no_populator_for_product on the wire, no coverage-gap
+	// note in the summary.
+	if strings.Contains(out, "no topology populator") {
+		t.Errorf("refresh summary carries a spurious no-populator note: %q", out)
+	}
+}
+
+// TestRefreshNoPopulatorNote — an all-zero refresh carrying the #2093
+// no_populator_for_product signal renders the coverage-gap note (and
+// the populated-products hint) instead of a bare zero-count summary a
+// consumer would misread as a clean no-op. The happy-path test above
+// covers the inverse: no signal, no note.
+func TestRefreshNoPopulatorNote(t *testing.T) {
+	product := "argocd"
+	populated := []string{"k8s"}
+	mux := http.NewServeMux()
+	mux.HandleFunc("/api/v1/topology/refresh/argocd-1", func(w http.ResponseWriter, _ *http.Request) {
+		w.Header().Set("Content-Type", "application/json")
+		_ = json.NewEncoder(w).Encode(api.RefreshResult{
+			TargetId:              mustUUID(t, fakeTargetUUID),
+			DurationMs:            1.5,
+			NoPopulatorForProduct: &product,
+			PopulatedProducts:     &populated,
+		})
+	})
+	srv := httptest.NewServer(mux)
+	defer srv.Close()
+	seedXDGAndToken(t, srv.URL)
+
+	cmd, stdout, stderr := newRunCmd(t)
+	if err := runRefresh(cmd, refreshOptions{Target: "argocd-1", BackplaneOverride: srv.URL}); err != nil {
+		t.Fatalf("runRefresh: %v; stderr=%s", err, stderr.String())
+	}
+	out := stdout.String()
+	for _, want := range []string{
+		`no topology populator`,
+		`"argocd"`,
+		"products with populators: k8s",
+	} {
+		if !strings.Contains(out, want) {
+			t.Errorf("refresh summary missing %q in %q", want, out)
+		}
+	}
 }
 
 // TestRefreshJSON — --json round-trips the raw RefreshResult shape.

--- a/cli/internal/cmd/topology/refresh.go
+++ b/cli/internal/cmd/topology/refresh.go
@@ -8,6 +8,7 @@ import (
 	"fmt"
 	"io"
 	"net/http"
+	"strings"
 
 	"github.com/spf13/cobra"
 
@@ -139,4 +140,15 @@ func printRefreshSummary(w io.Writer, target string, r *api.RefreshResult) {
 	fmt.Fprintf(w, "  nodes:  +%d  -%d  ~%d\n", r.AddedNodes, r.RemovedNodes, r.UpdatedNodes)
 	fmt.Fprintf(w, "  edges:  +%d  -%d  ~%d\n", r.AddedEdges, r.RemovedEdges, r.UpdatedEdges)
 	fmt.Fprintf(w, "  took:   %.0f ms\n", r.DurationMs)
+	// #2093 — the backend stamps no_populator_for_product when the
+	// target's connector ships no topology populator; without this
+	// note the all-zero counts above read as a clean no-op.
+	if r.NoPopulatorForProduct != nil {
+		fmt.Fprintf(w, "  note:   product %q has no topology populator — the zero counts are a coverage gap, not a clean no-op\n",
+			*r.NoPopulatorForProduct)
+		if r.PopulatedProducts != nil && len(*r.PopulatedProducts) > 0 {
+			fmt.Fprintf(w, "          products with populators: %s\n",
+				strings.Join(*r.PopulatedProducts, ", "))
+		}
+	}
 }

--- a/docs/codebase/topology.md
+++ b/docs/codebase/topology.md
@@ -165,6 +165,22 @@ reconcile + commit cycle. `target_id` echoes the refreshed target. The
 CLI `refresh` verb renders exactly these as `nodes: +A -R ~U` /
 `edges: +A -R ~U` (no fourth column) and surfaces `duration_ms`.
 
+Two nullable fields discriminate the all-zero-count no-op classes
+(#2093): `no_populator_for_product` carries the target's product slug
+when the resolved connector inherits the base-class
+`discover_topology` no-op (no populator shipped — the refresh was a
+no-op **by coverage gap**), and `populated_products` then lists the
+registered products that do override it (sorted, deduped across
+version/impl registry entries). Both are `null` when a populator ran —
+including a run that legitimately reconciled zero changes — so a
+consumer distinguishes "nothing changed" from "nothing could ever
+change" with a single field check. Populator detection is function
+identity against `Connector.discover_topology`
+(`refresh._has_populator`), which correctly classifies the
+operator-aware keyword-only override on `KubernetesConnector` and the
+auto-shim subclasses that inherit the base default. The CLI `refresh`
+verb appends a human-readable note when the signal is set.
+
 ### `TopologyNode` — frozen Pydantic v2 (read half)
 
 | Field | Type | Meaning |
@@ -216,7 +232,13 @@ separately via `resolve_node`.
 1. `resolve_connector(target)` → `get_or_create_connector_instance(cls)`
    (the same cached-singleton path the G0.6 dispatcher uses).
 2. `await connector.discover_topology(target)` → a `TopologyHints`
-   snapshot (nodes + edges, each with `properties`).
+   snapshot (nodes + edges, each with `properties`). When the resolved
+   class does **not** override the base no-op (`_has_populator` is
+   false), the eventual `RefreshResult` is stamped with
+   `no_populator_for_product` + `populated_products` (#2093); the
+   reconcile still runs on the empty snapshot — the audit/broadcast
+   contract is unchanged and stale nodes this target adopted earlier
+   still soft-delete.
 3. Open one transactional session (`sessionmaker() ... session.begin()`).
 4. `_reconcile_nodes` — diff the snapshot nodes against existing
    `graph_node` rows. The upsert decision is keyed on the **tenant-wide


### PR DESCRIPTION
## Summary

- `POST /api/v1/topology/refresh/{target_name}` for a target whose `product` ships **no topology populator** (the connector inherits the base `discover_topology` no-op — argocd / vault / keycloak / vrli / gh / vmware in the #2093 reproduction) previously returned HTTP 200 with all-zero counts byte-identical to a clean populator run, so a consumer could not tell no-op-by-design from a coverage gap. Per the decision recorded on the issue (2026-07-06), this lands **Option A**: same 200 + counts, plus an explicit structured signal.
- `RefreshResult` gains two nullable fields: `no_populator_for_product` (the offending product slug) and `populated_products` (sorted registered products whose connector overrides `discover_topology`, e.g. `["k8s"]`). Both are `null` when a populator ran — including a run that legitimately reconciled zero changes — so the two no-op classes are discriminable with a single field check.
- Detection is function identity against `Connector.discover_topology` (`_has_populator`), which correctly classifies the operator-aware keyword-only override on `KubernetesConnector` and the auto-shim subclasses that inherit the base default. The base-class no-op at `backend/src/meho_backplane/connectors/base.py` **remains the fallback** — the reconcile still runs on the empty snapshot (previously adopted stale nodes still soft-delete; audit row + broadcast contract unchanged); the gap is now surfaced, not swallowed.
- Builds on sibling #2092 (PR #2203, merged): resolver failures already map to structured 422/409 envelopes; this PR covers the remaining outcome class — a connector that resolves fine but has nothing to discover.
- CLI: regenerated OpenAPI snapshot + Go client; `meho topology refresh` human summary appends a coverage-gap note (with the populated-products hint) when the signal is set, so the human consumer sees it too, not just `--json` readers.

## Test plan

- [x] `uv run ruff check src/ tests/` — clean
- [x] `uv run ruff format --check` (touched files) — clean
- [x] `uv run mypy src/` (strict, full tree) — clean, 567 files
- [x] `uv run pytest -n 4 --dist loadscope --ignore=tests/integration tests/` — full unit suite green (see below)
- [x] AC1 — populator-less product returns the explicit signal: `test_no_populator_refresh_carries_explicit_signal` drives the real service against a registered no-override connector and asserts `no_populator_for_product == "nopop"` (all-zero counts preserved); wire-level equivalent of the issue's `curl | jq '.no_populator_for_product'` probe pinned by `test_refresh_no_populator_signal_passes_through_to_wire`
- [x] AC2 — populator that reconciles zero changes carries NO signal: `test_second_refresh_same_hints_is_unchanged` (extended) + `test_populated_refresh_omits_signal_even_with_gaps_registered`
- [x] AC3 — signal names the offending product and the populated set: asserted `("faketopo",)` / `["k8s"]` in service + route tests
- [x] AC4 — backend test exercises the populator-less path distinguishing gap from design (not merely all-zero); base-connector no-op default remains the fallback (reconcile/audit/broadcast still run)
- [x] AC5 — CLI OpenAPI snapshot regenerated (`cd cli && make snapshot-openapi && make generate`); diff contains only the two new nullable fields + docstring text
- [x] `go build ./... && go test ./... -count=1` in `cli/` — green (incl. new `TestRefreshNoPopulatorNote` + negative assertion in `TestRefreshHappyPath`); `gofmt` + `go vet` clean
- [x] `code-quality.py --diff` — 0 blockers

## Out of scope

- Shipping actual populators for argocd / vault / keycloak etc. (the richer enhancement the issue explicitly excludes).
- The `/ui` topology refresh partial (`_refresh_result.html`) still renders counts only — different surface (meho-internal #138 / G10.x); the UI receives the enriched `RefreshResult` object, so surfacing the note there is a template-only follow-up.
- Scheduler-side skip of populator-less targets (it still refreshes them; the per-refresh log line now carries `no_populator_for_product` for observability).

<!-- auto-implement-issue: fresh, iteration 1 -->

Closes #2093
