### PR TITLE
docs(audit): document tenant-broadcast semantics of /audit/query and /audit/show/{id} (#2084)

### DIFF
--- a/docs/architecture/audit.md
+++ b/docs/architecture/audit.md
@@ -40,7 +40,7 @@ The substrate has three consumer-facing surfaces, all dispatching through `query
 
 | Route | Filter shape | Notes |
 |---|---|---|
-| `POST /api/v1/audit/query` | Body is `AuditQueryRequest`; `since` / `until` are strings parsed at the router via `parse_duration`. Client-supplied `tenant_id` is silently dropped by Pydantic's default `extra="ignore"`. | Full-filter surface. |
+| `POST /api/v1/audit/query` | Body is `AuditQueryRequest`; `since` / `until` are strings parsed at the router via `parse_duration`. Client-supplied `tenant_id` (or any other unknown field) is rejected at 422 `extra_forbidden` — `AuditQueryRequest` sets `extra="forbid"` (G0.9-T2 #729). | Full-filter surface. |
 | `GET /api/v1/audit/who-touched/{target}` | Path param → `filters.target`; `since` query defaults to `"24h"`. | Pre-canned shortcut. |
 | `GET /api/v1/audit/my-recent` | `filters.principal = operator.sub`; `since` defaults to `"24h"`. | Pre-canned shortcut — operator can never see another operator's `my-recent` through this route. |
 | `GET /api/v1/audit/show/{audit_id}` | `filters.audit_id = <path>`, `limit=1`. Cross-tenant lookups → 404 (never 403, so existence never leaks). | Single-row fetch. |
@@ -62,9 +62,20 @@ Hand-built `inputSchema` (not `AuditQueryFilters.model_json_schema()`) because t
 The tenant-scoping invariant is enforced redundantly at two layers:
 
 1. **Substrate** — `query_audit(filters, *, tenant_id, session)` takes `tenant_id` as a mandatory keyword-only argument. `AuditQueryFilters` has no `tenant_id` field at all. The first SQL WHERE clause is always `audit_log.tenant_id = :tenant_id`; the LEFT JOIN to `targets` for `target_name` denormalization is *also* scoped on `Target.tenant_id`, so a cross-tenant `target_id` (allowed today because `audit_log.target_id` keeps no FK in v0.2 per the soft-FK discipline) resolves to `target_name=None` rather than leaking the other tenant's target name.
-2. **Surface** — every route, every CLI verb, every MCP handler pulls `tenant_id` from `operator.tenant_id` (the JWT claim resolved by `verify_jwt_and_bind` / `verify_mcp_jwt_and_bind`) and passes it into the substrate. The REST POST body's Pydantic model has no `tenant_id` field, so a client-supplied value is silently dropped. The MCP tool's `inputSchema` has `additionalProperties: false`, so an agent that tries to smuggle `tenant_id` is rejected by the dispatcher's jsonschema layer with `-32602` before reaching the handler.
+2. **Surface** — every route, every CLI verb, every MCP handler pulls `tenant_id` from `operator.tenant_id` (the JWT claim resolved by `verify_jwt_and_bind` / `verify_mcp_jwt_and_bind`) and passes it into the substrate. The REST POST body's Pydantic model has no `tenant_id` field, and a client-supplied value (like any unknown field) is rejected at 422 `extra_forbidden` per the model's `extra="forbid"` config (G0.9-T2 #729). The MCP tool's `inputSchema` has `additionalProperties: false`, so an agent that tries to smuggle `tenant_id` is rejected by the dispatcher's jsonschema layer with `-32602` before reaching the handler.
 
 There is no admin escape hatch. Cross-tenant queries are structurally impossible, by design and by code. The `show` route surfaces 404 (not 403) for cross-tenant audit-ids so a probing operator cannot even distinguish "row doesn't exist" from "row exists in another tenant".
+
+### Tenant-broadcast read surfaces ([#2084](https://github.com/evoila/meho/issues/2084))
+
+Within a tenant, the audit ledger is deliberately **not** principal-scoped. `POST /api/v1/audit/query` — with or without a `principal` filter — and `GET /api/v1/audit/show/{audit_id}` return rows for **every** principal in the calling tenant. Any `operator` or `tenant_admin` in the tenant reads all principals' audit rows (the RBAC gate on these routes is `operator`-minimum; `read_only` gets 403), and there is **no per-principal role check** on `query` / `show`: filtering on another operator's `principal` sub is a supported forensic lookup, not an escalation. Only `GET /api/v1/audit/my-recent` is self-scoped — it pins `filters.principal = operator.sub` from the JWT, so it never returns another principal's rows.
+
+This tenant-broadcast visibility is by design, on the same shelf as the `who-touched` shortcut (which likewise surfaces every principal that touched a target) and the aggregate-only broadcast posture above — and the same category-2 doc-resolution shape as the kb same-slug cross-principal write semantics (#1327, [`docs/codebase/kb.md`](../codebase/kb.md)): a forensics surface has to be readable cross-principal for the operator investigating an incident, and the principals a tenant contains (operators, the service account, `system:*` writers) are mutually trusted within that tenant. Two boundaries still hold:
+
+- **Cross-tenant isolation stays enforced.** The substrate's first WHERE clause is always `audit_log.tenant_id = :tenant_id`, and `show` surfaces 404 (never 403) on a foreign `audit_id` — see the module and `show` docstrings in [`api/v1/audit.py`](../../backend/src/meho_backplane/api/v1/audit.py).
+- **`params_hash` scrubbing keeps payloads protected.** Dispatch audit rows carry a SHA-256 hash of the canonicalised operation params ([`operations/_validate.py::compute_params_hash`](../../backend/src/meho_backplane/operations/_validate.py)); the raw params never land on the audit row in v0.2. A row visible cross-principal therefore reveals *that* an operation ran (op_id, target, status), never its sensitive argument values — the tenant-broadcast behavior is not a payload leak.
+
+If a finer role gradation lands (e.g. a `tenant_member` with limited audit visibility), this scoping decision is revisited at that point.
 
 ## Cursor pagination
 

--- a/docs/codebase/audit_query.md
+++ b/docs/codebase/audit_query.md
@@ -212,6 +212,28 @@ RBAC: the five flat / self-scoped routes (`query`, `who-touched`,
 operator-gated MCP `query_audit` tool (including its self-session-only
 `shape="tree"` path).
 
+**Tenant-broadcast read surfaces (#2084).** Within a tenant, `query` and
+`show` are principal-agnostic by design: `POST /api/v1/audit/query` (with
+or without a `principal` filter) and `GET /api/v1/audit/show/{audit_id}`
+return rows for **every** principal in the calling tenant. Any `operator`
+/ `tenant_admin` in the tenant reads all principals' audit rows — there
+is **no per-principal role check** on either route, and filtering
+`principal` on another operator's sub is a supported forensic lookup.
+Only `my-recent` stays self-scoped: it binds
+`filters.principal = operator.sub`, so the caller sees their own rows
+only. Cross-**tenant** isolation is unchanged (the substrate's first
+WHERE clause is always `audit_log.tenant_id`; `show` → 404 on a foreign
+`audit_id`, per the module and `show` docstrings in
+`backend/src/meho_backplane/api/v1/audit.py`), and dispatch rows carry
+`payload.params_hash` — a SHA-256 over the canonicalised params
+(`operations/_validate.py::compute_params_hash`) — instead of the raw
+params, so a cross-principal-visible row never exposes sensitive
+operation arguments. Same shelf as the `who-touched` shortcut and the
+aggregate-only broadcast redaction; same category-2 doc-resolution
+shape as the kb same-slug cross-principal write semantics (#1327,
+`docs/codebase/kb.md`). Revisit if a finer role gradation (e.g.
+`tenant_member`) ever lands.
+
 The cross-session **replay** route
 (`GET /api/v1/audit/sessions/{session_id}/replay`) requires
 `tenant_admin` (#1843): it takes an *arbitrary* `session_id` and


### PR DESCRIPTION
## Summary
- Documents the tenant-broadcast read semantics of the audit ledger: `POST /api/v1/audit/query` (with or without a `principal` filter) and `GET /api/v1/audit/show/{audit_id}` return rows for **every** principal in the calling tenant, with no per-principal role check; only `GET /api/v1/audit/my-recent` is self-scoped (`filters.principal = operator.sub`). Category-2 doc gap — the behavior is by design (forensics surface), but the docs were silent, so a consumer auditing cross-principal isolation could not tell defect from design (#2084, closing the #1302/#1327 trilogy).
- New "Tenant-broadcast read surfaces (#2084)" prose lands on the same shelf as the `who-touched` / aggregate-only-broadcast documentation, in both `docs/architecture/audit.md` (under Tenant boundary) and `docs/codebase/audit_query.md` (REST-surface RBAC section), stating: who sees whose rows (any `operator`/`tenant_admin` in the tenant — the routes gate at `operator`-minimum, not `tenant_admin` as the raw finding assumed), that cross-**tenant** isolation stays enforced (first WHERE clause `audit_log.tenant_id`; `show` → 404 on a foreign `audit_id`, matching the docstrings in `backend/src/meho_backplane/api/v1/audit.py`), and that `params_hash` scrubbing (`operations/_validate.py::compute_params_hash`, SHA-256 over canonicalised params; raw params never land on the audit row) keeps the visibility from being a payload leak.
- Opportunistic in-scope fix: `docs/architecture/audit.md` still claimed client-supplied `tenant_id` is "silently dropped by Pydantic's default `extra="ignore"`" — stale since G0.9-T2 #729 made `AuditQueryRequest` `extra="forbid"` (422 `extra_forbidden`). Both occurrences corrected in the touched sections.

## Test plan
- [x] `grep -ni 'every principal\|tenant-broadcast\|cross-principal' docs/architecture/audit.md docs/codebase/audit_query.md` — returns the new prose in both files (AC 1)
- [x] Prose names who-sees-whose (any `operator`/`tenant_admin` reads all principals' rows; `my-recent` self-scoped) (AC 2)
- [x] Cross-tenant statement (404 on foreign `audit_id`) diffs cleanly against the `api/v1/audit.py` module + `show` docstrings (AC 3)
- [x] `params_hash` not-a-payload-leak note present, grounded in `compute_params_hash` (AC 4)
- [x] Prose references #2084 and sits on the `who-touched` / #1327 shelf; grep verification retargeted from the non-repo `FEATURES.md` to the in-repo docs (AC 5)
- [x] `python3 .claude/hooks/code-quality.py --diff` — exit 0
- [x] pre-commit hooks (whitespace/EOF/gitleaks/conventional-commit) — passed at commit
- [x] Docs-only change: no FastAPI routes/schemas/docstrings touched → no OpenAPI snapshot regen needed

## Out of scope
- `docs/architecture/audit.md`'s Surfaces section still describes the G8.1-era four REST routes / five CLI verbs (missing `by-work-ref` + the `tenant_admin`-gated replay route that `docs/codebase/audit_query.md` fully covers) — broader drift, recorded as an adjacent finding, not entangled with the tenant-scoping prose added here.
- The replay-route inertness signal from the same trilogy (`replay-as-tree-inert-on-approval-gated-ops`) — separate signal per the issue body.

<!-- auto-implement-issue: fresh, iteration 1 -->

Closes #2084
