### PR TITLE
fix(connectors): resolve ssh secret_ref from Vault, not as embedded dict (#2155)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -90,6 +90,28 @@ connector-related release-notes line.
 
 ## [Unreleased]
 
+### Fixed — ssh-family connectors resolve `secret_ref` from Vault
+
+- **The SSH adapter now resolves `target.secret_ref` (a Vault KV-v2 path
+  string) through the operator-context Vault read, instead of consuming
+  the column as if it were the already-materialized secret dict**
+  (#2155): every ssh-family op (`holodeck-ssh`, `bind9-ssh`,
+  `pfsense-ssh`) failed in ~5ms against any real registered target with
+  `AttributeError: 'str' object has no attribute 'get'` — the adapter
+  implemented the documented "bind9 anti-shape" and never resolved the
+  Vault path at all. `SshConnector._auth_config` now reads the secret
+  via `_shared.vault_creds.load_vault_secret_data` under the request
+  operator's identity (the same seam the REST connector loaders use),
+  the operator is threaded through every ssh-family op handler +
+  `_run_command` / `pwsh_run` / the bind9 sudo-password lookup, and
+  operator-less paths (`probe()`, readiness) fail closed at Vault.
+  pfSense's key-only refusal is preserved. `holodeck.k8s.exec` now
+  surfaces auth/transport failures as a `connector_error` (mirroring
+  `holodeck.about`) rather than swallowing them into a `status: "ok"`
+  envelope with empty stdout. The `secret_ref` example in
+  `docs/cross-repo/holodeck-onboarding.md` is corrected to a
+  mount-relative path inside the meho-readable `secret/meho/*` subtree.
+
 ### Fixed — runbook run list surfaces the failed step state
 
 - **`GET /api/v1/runbooks/runs` (and `meho.runbook.list_runs`) now

--- a/backend/src/meho_backplane/connectors/adapters/ssh.py
+++ b/backend/src/meho_backplane/connectors/adapters/ssh.py
@@ -6,14 +6,33 @@
 Every SSH-based connector (bind9, pfsense, Holodeck, etc.) inherits
 :class:`SshConnector` and overrides ``fingerprint``, ``probe``, and
 ``execute``. Auth is centralised — vendor connectors do not override
-``_auth_config``.
+``_auth_config`` (pfSense narrows it to key-only, but the Vault
+resolution itself stays here).
 
-**Auth flavours.** ``_auth_config`` reads ``target.secret_ref``:
+**Credential resolution.** ``target.secret_ref`` is a Vault KV-v2 path
+**string** (``Target.secret_ref`` is ``str | None``; the DB column is
+``Text``) — *not* an embedded credential dict (the bind9 anti-shape;
+see :mod:`meho_backplane.connectors._shared.vault_creds`). ``_auth_config``
+resolves the path to the secret's data dict via
+:func:`~meho_backplane.connectors._shared.vault_creds.load_vault_secret_data`
+under the request operator's identity — the same operator-context read
+every REST connector loader performs. ``load_vault_secret_data`` (not
+``load_basic_credentials``) because the SSH auth contract is
+*either/or*: a key-only secret legitimately has no ``password`` and a
+password-only secret no ``ssh_private_key``, while the named-fields
+loader requires every requested field to be present. Operator-less
+callers (readiness probe, ``probe()``) fall back to
+:func:`~meho_backplane.connectors._shared.system_operator.synthesise_system_operator`,
+whose placeholder JWT the live Vault JWT/OIDC auth method rejects —
+system-initiated calls cannot read per-target vendor credentials
+(fail-closed carve-out).
 
-* **Key auth (preferred):** ``secret_ref`` carries a ``ssh_private_key``
+**Auth flavours.** From the resolved secret data dict:
+
+* **Key auth (preferred):** the secret carries a ``ssh_private_key``
   field (PEM-encoded text) plus ``username``; the key is parsed via
   ``asyncssh.import_private_key`` and passed as ``client_keys``.
-* **Password auth (fallback):** ``secret_ref`` carries ``username`` and
+* **Password auth (fallback):** the secret carries ``username`` and
   ``password``; used when ``ssh_private_key`` is absent.
 * **Missing credentials:** raises :exc:`ValueError` immediately so callers
   fail fast rather than hitting an opaque asyncssh auth error.
@@ -43,7 +62,13 @@ from typing import Any
 import asyncssh
 import structlog
 
+from meho_backplane.auth.operator import Operator
 from meho_backplane.connectors._shared.cache_key import target_cache_key
+from meho_backplane.connectors._shared.system_operator import synthesise_system_operator
+from meho_backplane.connectors._shared.vault_creds import (
+    load_vault_secret_data,
+    strip_credential_value,
+)
 from meho_backplane.connectors.base import Connector
 from meho_backplane.connectors.schemas import FingerprintResult
 
@@ -94,30 +119,58 @@ class SshConnector(Connector):
         # in parallel. Keyed on the same tenant-unique tuple as the pool.
         self._connect_locks: dict[tuple[str, str], asyncio.Lock] = {}
 
-    async def _auth_config(self, target: Target) -> dict[str, Any]:
-        """Extract auth kwargs from ``target.secret_ref``.
+    async def _resolve_secret(self, target: Target, operator: Operator | None) -> dict[str, Any]:
+        """Resolve ``target.secret_ref`` (a Vault KV-v2 path string) to the secret dict.
+
+        The single Vault seam for the SSH family — auth
+        (:meth:`_auth_config`) and any per-op credential need (the bind9
+        sudo password) resolve through here so tests and callers have one
+        place to stub. ``operator=None`` (readiness probe, ``probe()``)
+        falls back to the synthesised system operator, whose placeholder
+        JWT the live Vault JWT/OIDC auth method rejects — preserving the
+        "system-initiated calls cannot read per-target vendor
+        credentials" carve-out.
+
+        Raises
+        ------
+        meho_backplane.connectors._shared.vault_creds.VaultCredentialsReadError
+            Read-phase failure: unset ``secret_ref``, API-path-shaped
+            ``secret_ref``, empty operator JWT, malformed KV-v2 payload.
+        meho_backplane.auth.vault.VaultClientError
+            Login-phase failure (Vault unreachable, role/JWT denied —
+            including the synthesised system operator's placeholder JWT).
+        """
+        resolved = operator if operator is not None else synthesise_system_operator()
+        return await load_vault_secret_data(target, resolved)
+
+    async def _auth_config(
+        self, target: Target, operator: Operator | None = None
+    ) -> dict[str, Any]:
+        """Resolve ``target.secret_ref`` from Vault and derive auth kwargs.
 
         Returns ``{username, client_keys=[key]}`` for key auth, or
         ``{username, password}`` for password auth. Raises :exc:`ValueError`
-        when neither ``ssh_private_key`` nor ``password`` is present.
-
-        T5 (VaultConnector) will replace the direct dict access with a
-        Vault fetch once it lands; the auth-selection logic stays here.
+        when the resolved secret carries neither ``ssh_private_key`` nor
+        ``password``; Vault resolution failures propagate per
+        :meth:`_resolve_secret`'s two-phase error contract.
         """
-        secret: dict[str, Any] = getattr(target, "secret_ref", {}) or {}
-        username: str = secret.get("username", "root")
-        private_key_text: str | None = secret.get("ssh_private_key")
-        if private_key_text:
-            key = asyncssh.import_private_key(private_key_text)
+        secret = await self._resolve_secret(target, operator)
+        username: str = strip_credential_value(secret.get("username", "root"))
+        private_key_raw = secret.get("ssh_private_key")
+        if private_key_raw:
+            key = asyncssh.import_private_key(strip_credential_value(private_key_raw))
             return {"username": username, "client_keys": [key]}
-        password: str | None = secret.get("password")
-        if password:
-            return {"username": username, "password": password}
+        password_raw = secret.get("password")
+        if password_raw:
+            return {"username": username, "password": strip_credential_value(password_raw)}
         raise ValueError(
-            f"target '{target.name}': secret_ref must include ssh_private_key or password"
+            f"target '{target.name}': the Vault secret at secret_ref must include "
+            "ssh_private_key or password"
         )
 
-    async def _connect(self, target: Target, raw_jwt: str) -> asyncssh.SSHClientConnection:
+    async def _connect(
+        self, target: Target, operator: Operator | None = None
+    ) -> asyncssh.SSHClientConnection:
         """Return a live SSH connection for *target*.
 
         Fast path (no lock): returns the cached connection when it is open
@@ -155,7 +208,7 @@ class SshConnector(Connector):
                     await conn.wait_closed()
                 del self._connections[cache_key]
 
-            auth_kwargs = await self._auth_config(target)
+            auth_kwargs = await self._auth_config(target, operator)
             conn = await asyncssh.connect(
                 target.host,
                 port=target.port or 22,
@@ -173,14 +226,17 @@ class SshConnector(Connector):
         target: Target,
         cmd: str,
         *,
-        raw_jwt: str,
+        operator: Operator | None = None,
         timeout: float = 30.0,
     ) -> asyncssh.SSHCompletedProcess:
         """Run *cmd* on *target* via the pooled SSH connection.
 
+        ``operator`` is threaded to :meth:`_connect` → :meth:`_auth_config`
+        for the operator-context Vault credential read on a pool miss;
+        ``None`` fails closed at Vault per :meth:`_resolve_secret`.
         Raises :exc:`asyncio.TimeoutError` when *timeout* is exceeded.
         """
-        conn = await self._connect(target, raw_jwt)
+        conn = await self._connect(target, operator)
         result = await asyncio.wait_for(conn.run(cmd, check=False), timeout=timeout)
         logger.info(
             "ssh_command_executed",

--- a/backend/src/meho_backplane/connectors/bind9/_atomic.py
+++ b/backend/src/meho_backplane/connectors/bind9/_atomic.py
@@ -195,6 +195,7 @@ from dataclasses import dataclass
 from typing import TYPE_CHECKING, Any, Literal
 
 if TYPE_CHECKING:
+    from meho_backplane.auth.operator import Operator
     from meho_backplane.connectors.bind9.connector import Bind9Connector
 
 __all__ = [
@@ -786,11 +787,14 @@ def _interpret_pipeline_result(
     )
 
 
+# code-quality-allow: pre-existing 129-line staging/rollback primitive; the
+# length is the parameter-contract docstring for a safety-critical DDL-apply
+# seam, not logic complexity — refactor is out of scope for the #2155 fix.
 async def atomic_apply(
     connector: Bind9Connector,
     target: Any,
     *,
-    raw_jwt: str,
+    operator: Operator | None = None,
     sudo_password: str,
     audit_slice_path: str,
     zone_name: str = "",
@@ -827,9 +831,10 @@ async def atomic_apply(
         :meth:`~Bind9Connector._remote_bash_with_sudo`.
     target
         The remote bind9 target.
-    raw_jwt, sudo_password
+    operator, sudo_password
         Forwarded to ``_remote_bash_with_sudo``. The sudo password
-        invariants (no newlines / NUL) apply.
+        invariants (no newlines / NUL) apply; *operator* drives the
+        operator-context Vault credential read on an SSH pool miss.
     audit_slice_path
         The file the operation semantically edits (the affected
         zonefile, the primary config fragment, etc.). Used for
@@ -910,7 +915,7 @@ async def atomic_apply(
     proc = await connector._remote_bash_with_sudo(
         target,
         full_script,
-        raw_jwt=raw_jwt,
+        operator=operator,
         sudo_password=sudo_password,
         timeout=90.0,
     )

--- a/backend/src/meho_backplane/connectors/bind9/connector.py
+++ b/backend/src/meho_backplane/connectors/bind9/connector.py
@@ -71,6 +71,8 @@ import asyncssh
 import structlog
 
 from meho_backplane.auth.operator import Operator
+from meho_backplane.auth.vault import VaultClientError
+from meho_backplane.connectors._shared.vault_creds import VaultCredentialsReadError
 from meho_backplane.connectors.adapters.ssh import SshConnector
 from meho_backplane.connectors.bind9.ops import BIND9_OPS
 from meho_backplane.connectors.schemas import (
@@ -269,7 +271,7 @@ class Bind9Connector(SshConnector):
         target: Target,
         script: str,
         *,
-        raw_jwt: str,
+        operator: Operator | None = None,
         sudo_password: str,
         timeout: float = 60.0,
     ) -> asyncssh.SSHCompletedProcess:
@@ -337,9 +339,10 @@ class Bind9Connector(SshConnector):
             multiple lines, shell variables, and pipes. Must not
             include the sudo password -- the helper streams that
             separately via *sudo_password*.
-        raw_jwt
-            Forwarded to :meth:`_connect` for auth-context
-            propagation; unused by the helper itself.
+        operator
+            Forwarded to :meth:`_connect` for the operator-context
+            Vault credential read on an SSH pool miss; unused by the
+            helper itself.
         sudo_password
             The password sudo will read from stdin. Streamed as the
             first stdin line; never logged, never present in argv.
@@ -379,7 +382,7 @@ class Bind9Connector(SshConnector):
                 "sudo_password must be a single line: newline / carriage-return / NUL "
                 "characters would smuggle additional bash commands onto stdin"
             )
-        conn = await self._connect(target, raw_jwt)
+        conn = await self._connect(target, operator)
         # New wire shape (#697 fix): script bytes first, password
         # last, EOF immediately after. ``head -c <N>`` on the remote
         # reads exactly the script's byte count via unbuffered
@@ -441,32 +444,46 @@ class Bind9Connector(SshConnector):
         :meth:`~meho_backplane.connectors.adapters.ssh.SshConnector._assert_reachable`
         guard surface the failure consistently from ``about`` (#986).
 
-        ``operator`` exists for ABC parity (G0.16-T4 #1306) — bind9
-        authenticates via SSH key, not Vault OIDC, so the route operator
-        plays no role here.
+        ``operator`` is threaded to the SSH adapter's ``_auth_config``,
+        which resolves ``target.secret_ref`` (a Vault KV-v2 path string)
+        under the operator's identity on an SSH pool miss (#2155).
+        ``None`` (background callers) fails closed at Vault and maps to
+        ``reachable=False``.
         """
-        del operator  # unused — SSH key auth, no Vault credential read
         probed_at = datetime.now(UTC)
 
+        # Catch tuple: transport failures plus credential-resolution
+        # failures (ValueError — secret carries neither key nor
+        # password; VaultClientError / VaultCredentialsReadError — the
+        # two-phase Vault contract). An unresolvable credential is an
+        # unreachable target, not an unhandled exception (#986).
         try:
-            named_proc = await self._run_command(target, "named -v", raw_jwt="")
+            named_proc = await self._run_command(target, "named -v", operator=operator)
             banner_raw = (named_proc.stdout or "") if hasattr(named_proc, "stdout") else ""
             banner = banner_raw.strip() if isinstance(banner_raw, str) else ""
             version_triple = parse_named_version(banner)
 
-            os_proc = await self._run_command(target, "cat /etc/os-release", raw_jwt="")
+            os_proc = await self._run_command(target, "cat /etc/os-release", operator=operator)
             os_raw = (os_proc.stdout or "") if hasattr(os_proc, "stdout") else ""
             os_content = os_raw if isinstance(os_raw, str) else ""
             os_identifier: str | None = None
             if os_proc.exit_status == 0 and os_content.strip():
                 os_identifier = parse_os_release(os_content)
             if os_identifier is None:
-                debian_proc = await self._run_command(target, "cat /etc/debian_version", raw_jwt="")
+                debian_proc = await self._run_command(
+                    target, "cat /etc/debian_version", operator=operator
+                )
                 debian_raw = (debian_proc.stdout or "") if hasattr(debian_proc, "stdout") else ""
                 debian_content = debian_raw.strip() if isinstance(debian_raw, str) else ""
                 if debian_proc.exit_status == 0 and debian_content:
                     os_identifier = f"debian {debian_content}"
-        except (OSError, asyncssh.Error) as exc:
+        except (
+            OSError,
+            asyncssh.Error,
+            ValueError,
+            VaultClientError,
+            VaultCredentialsReadError,
+        ) as exc:
             _log.warning(
                 "bind9_fingerprint_unreachable",
                 target=getattr(target, "name", None),
@@ -557,13 +574,19 @@ class Bind9Connector(SshConnector):
         # first. asyncssh raises ``OSError`` from the underlying
         # socket layer when TCP itself fails.
         try:
-            await self._connect(target, raw_jwt="")
+            await self._connect(target)
         except asyncssh.PermissionDenied:
             return _result(False, "auth_failed")
         except asyncssh.DisconnectError:
             return _result(False, "ssh_handshake_failed")
         except OSError:
             return _result(False, "tcp_unreachable")
+        except (ValueError, VaultClientError, VaultCredentialsReadError):
+            # Credential-resolution failure: ``probe()`` carries no
+            # operator, so the Vault read runs under the synthesised
+            # system operator and fails closed — an auth configuration
+            # problem, not a network problem.
+            return _result(False, "auth_failed")
 
         # Post-connect commands are guarded: a connection drop, an
         # ``asyncssh.Error``, or a timeout after a successful handshake
@@ -578,7 +601,7 @@ class Bind9Connector(SshConnector):
             # exact match so a different binary that happens to contain
             # ``named`` in its argv (``named.conf`` editor, etc.) does
             # not produce a false positive.
-            pgrep_proc = await self._run_command(target, "pgrep -x named", raw_jwt="")
+            pgrep_proc = await self._run_command(target, "pgrep -x named")
             if pgrep_proc.exit_status != 0:
                 return _result(False, "named_not_running")
 
@@ -587,9 +610,7 @@ class Bind9Connector(SshConnector):
             # non-zero exit means the config does not parse, which is the
             # "named is running but the config it would load on reload is
             # broken" failure mode operators most care about.
-            checkconf_proc = await self._run_command(
-                target, "named-checkconf -p > /dev/null", raw_jwt=""
-            )
+            checkconf_proc = await self._run_command(target, "named-checkconf -p > /dev/null")
         except (OSError, asyncssh.Error):
             return _result(False, "command_failed")
         if checkconf_proc.exit_status != 0:
@@ -601,6 +622,7 @@ class Bind9Connector(SshConnector):
         self,
         target: Target,
         params: dict[str, Any],
+        operator: Operator | None = None,
     ) -> dict[str, Any]:
         """Return the bind9 nameserver's product / version / OS snapshot.
 
@@ -628,7 +650,7 @@ class Bind9Connector(SshConnector):
         carrying empty/None identity fields (#986).
         """
         del params  # declared empty in schema; intentionally ignored
-        result = await self.fingerprint(target)
+        result = await self.fingerprint(target, operator)
         self._assert_reachable(result)
         return {
             "vendor": result.vendor,
@@ -643,6 +665,7 @@ class Bind9Connector(SshConnector):
         self,
         target: Target,
         params: dict[str, Any],
+        operator: Operator | None = None,
     ) -> dict[str, Any]:
         """Bound-method shim for the ``bind9.zone.list`` op (G3.4-T2 #588).
 
@@ -661,36 +684,39 @@ class Bind9Connector(SshConnector):
             bind9_zone_list as _bind9_zone_list,
         )
 
-        return await _bind9_zone_list(self, target, params)
+        return await _bind9_zone_list(self, target, params, operator)
 
     async def bind9_zone_read(
         self,
         target: Target,
         params: dict[str, Any],
+        operator: Operator | None = None,
     ) -> dict[str, Any]:
         """Bound-method shim for the ``bind9.zone.read`` op (G3.4-T2 #588)."""
         from meho_backplane.connectors.bind9.ops_zone import (
             bind9_zone_read as _bind9_zone_read,
         )
 
-        return await _bind9_zone_read(self, target, params)
+        return await _bind9_zone_read(self, target, params, operator)
 
     async def bind9_record_get(
         self,
         target: Target,
         params: dict[str, Any],
+        operator: Operator | None = None,
     ) -> dict[str, Any]:
         """Bound-method shim for the ``bind9.record.get`` op (G3.4-T2 #588)."""
         from meho_backplane.connectors.bind9.ops_record import (
             bind9_record_get as _bind9_record_get,
         )
 
-        return await _bind9_record_get(self, target, params)
+        return await _bind9_record_get(self, target, params, operator)
 
     async def bind9_record_add(
         self,
         target: Target,
         params: dict[str, Any],
+        operator: Operator | None = None,
     ) -> dict[str, Any]:
         """Bound-method shim for the ``bind9.record.add`` op (G3.4-T3 #589).
 
@@ -702,36 +728,39 @@ class Bind9Connector(SshConnector):
             bind9_record_add as _bind9_record_add,
         )
 
-        return await _bind9_record_add(self, target, params)
+        return await _bind9_record_add(self, target, params, operator)
 
     async def bind9_record_remove(
         self,
         target: Target,
         params: dict[str, Any],
+        operator: Operator | None = None,
     ) -> dict[str, Any]:
         """Bound-method shim for the ``bind9.record.remove`` op (G3.4-T3 #589)."""
         from meho_backplane.connectors.bind9.ops_record import (
             bind9_record_remove as _bind9_record_remove,
         )
 
-        return await _bind9_record_remove(self, target, params)
+        return await _bind9_record_remove(self, target, params, operator)
 
     async def bind9_config_show(
         self,
         target: Target,
         params: dict[str, Any],
+        operator: Operator | None = None,
     ) -> dict[str, Any]:
         """Bound-method shim for the ``bind9.config.show`` op (G3.4-T2 #588)."""
         from meho_backplane.connectors.bind9.ops_config import (
             bind9_config_show as _bind9_config_show,
         )
 
-        return await _bind9_config_show(self, target, params)
+        return await _bind9_config_show(self, target, params, operator)
 
     async def bind9_config_apply_file(
         self,
         target: Target,
         params: dict[str, Any],
+        operator: Operator | None = None,
     ) -> dict[str, Any]:
         """Bound-method shim for ``bind9.config.apply_file`` (G3.4-T4 #590).
 
@@ -743,12 +772,13 @@ class Bind9Connector(SshConnector):
             bind9_config_apply_file as _bind9_config_apply_file,
         )
 
-        return await _bind9_config_apply_file(self, target, params)
+        return await _bind9_config_apply_file(self, target, params, operator)
 
     async def bind9_config_apply_views(
         self,
         target: Target,
         params: dict[str, Any],
+        operator: Operator | None = None,
     ) -> dict[str, Any]:
         """Bound-method shim for ``bind9.config.apply_views`` (G3.4-T4 #590).
 
@@ -760,12 +790,13 @@ class Bind9Connector(SshConnector):
             bind9_config_apply_views as _bind9_config_apply_views,
         )
 
-        return await _bind9_config_apply_views(self, target, params)
+        return await _bind9_config_apply_views(self, target, params, operator)
 
     async def bind9_config_backup(
         self,
         target: Target,
         params: dict[str, Any],
+        operator: Operator | None = None,
     ) -> dict[str, Any]:
         """Bound-method shim for ``bind9.config.backup`` (G3.4-T4 #590).
 
@@ -778,12 +809,13 @@ class Bind9Connector(SshConnector):
             bind9_config_backup as _bind9_config_backup,
         )
 
-        return await _bind9_config_backup(self, target, params)
+        return await _bind9_config_backup(self, target, params, operator)
 
     async def bind9_config_reload(
         self,
         target: Target,
         params: dict[str, Any],
+        operator: Operator | None = None,
     ) -> dict[str, Any]:
         """Bound-method shim for ``bind9.config.reload`` (G3.4-T4 #590).
 
@@ -796,7 +828,7 @@ class Bind9Connector(SshConnector):
             bind9_config_reload as _bind9_config_reload,
         )
 
-        return await _bind9_config_reload(self, target, params)
+        return await _bind9_config_reload(self, target, params, operator)
 
     @classmethod
     async def register_operations(cls) -> None:

--- a/backend/src/meho_backplane/connectors/bind9/ops_config.py
+++ b/backend/src/meho_backplane/connectors/bind9/ops_config.py
@@ -109,10 +109,12 @@ from typing import TYPE_CHECKING, Any
 
 import structlog.contextvars
 
+from meho_backplane.connectors._shared.vault_creds import strip_credential_value
 from meho_backplane.connectors.bind9._atomic import atomic_apply
 from meho_backplane.connectors.bind9.ops import Bind9Op
 
 if TYPE_CHECKING:
+    from meho_backplane.auth.operator import Operator
     from meho_backplane.connectors.bind9.connector import Bind9Connector
 
 __all__ = [
@@ -221,6 +223,7 @@ async def bind9_config_show(
     connector: Bind9Connector,
     target: Any,
     params: dict[str, Any],
+    operator: Operator | None = None,
 ) -> dict[str, Any]:
     """Handler for ``bind9.config.show``.
 
@@ -242,7 +245,7 @@ async def bind9_config_show(
     a rejection.
     """
     requested: str = params["path"]
-    fingerprint = await connector.fingerprint(target)
+    fingerprint = await connector.fingerprint(target, operator)
     # The fingerprint extras carry the absolute ``named.conf`` path; the
     # *directory* of that file is the bind config root. The fallback
     # ``/etc/bind`` is the Debian-family default, which is the only
@@ -262,7 +265,7 @@ async def bind9_config_show(
     # spaces, ...); the ensure_path_under_root filter rejected control
     # bytes already, so the resulting quoted form is safe to splice
     # into the SSH command line.
-    proc = await connector._run_command(target, f"cat {shlex.quote(resolved)}", raw_jwt="")
+    proc = await connector._run_command(target, f"cat {shlex.quote(resolved)}", operator=operator)
     stdout = (proc.stdout or "") if hasattr(proc, "stdout") else ""
     content = stdout if isinstance(stdout, str) else ""
 
@@ -410,7 +413,9 @@ def pack_views_tar(
 # ---------------------------------------------------------------------------
 
 
-async def _resolve_bind_root(connector: Bind9Connector, target: Any) -> str:
+async def _resolve_bind_root(
+    connector: Bind9Connector, target: Any, operator: Operator | None = None
+) -> str:
     """Return the absolute bind config root for *target*.
 
     Mirrors :func:`bind9_config_show`'s fingerprint-driven lookup.
@@ -418,7 +423,7 @@ async def _resolve_bind_root(connector: Bind9Connector, target: Any) -> str:
     the same way: read the fingerprint, take the directory part of
     ``extras["named_conf_path"]``, fall back to ``/etc/bind``.
     """
-    fingerprint = await connector.fingerprint(target)
+    fingerprint = await connector.fingerprint(target, operator)
     named_conf_path = fingerprint.extras.get("named_conf_path") or "/etc/bind/named.conf"
     if not isinstance(named_conf_path, str):
         raise ConfigPathRejectedError(
@@ -427,26 +432,30 @@ async def _resolve_bind_root(connector: Bind9Connector, target: Any) -> str:
     return posixpath.dirname(named_conf_path) or "/etc/bind"
 
 
-def _sudo_password_for_target(target: Any) -> str:
-    """Read the sudo password from the target's ``secret_ref``.
+async def _sudo_password_for_target(
+    connector: Bind9Connector, target: Any, operator: Operator | None = None
+) -> str:
+    """Resolve the sudo password from the target's Vault secret.
 
-    Re-uses the contract from
-    :mod:`meho_backplane.connectors.bind9.ops_record` -- the secret
-    keys (``sudo_password`` then ``password``) and the
-    :class:`ValueError` on missing-credential surface are identical.
-    Hoisted here as well so the config-write handlers don't take a
-    cross-module import dependency on a private helper.
+    Resolves ``target.secret_ref`` (a Vault KV-v2 path string) through
+    the SSH adapter's
+    :meth:`~meho_backplane.connectors.adapters.ssh.SshConnector._resolve_secret`
+    under the operator's identity — the same seam SSH auth uses — and
+    extracts ``sudo_password`` (falling back to ``password``, the
+    documented reuse of the SSH login credential). Re-uses the contract
+    from :mod:`meho_backplane.connectors.bind9.ops_record` -- the secret
+    keys and the :class:`ValueError` on missing-credential surface are
+    identical. Hoisted here as well so the config-write handlers don't
+    take a cross-module import dependency on a private helper.
     """
-    secret_ref = getattr(target, "secret_ref", None) or {}
-    if not isinstance(secret_ref, dict):
-        raise ValueError(f"target.secret_ref must be a dict; got {type(secret_ref).__name__}")
-    password = secret_ref.get("sudo_password") or secret_ref.get("password")
+    secret = await connector._resolve_secret(target, operator)
+    password = secret.get("sudo_password") or secret.get("password")
     if not password:
         raise ValueError(
-            "target.secret_ref carries no sudo_password / password; "
+            "the target's Vault secret carries no sudo_password / password; "
             "bind9 config-write ops require a sudo credential"
         )
-    return str(password)
+    return strip_credential_value(password)
 
 
 # Global-atomic-apply warning every write op surfaces in its description
@@ -475,6 +484,7 @@ async def bind9_config_apply_file(
     connector: Bind9Connector,
     target: Any,
     params: dict[str, Any],
+    operator: Operator | None = None,
 ) -> dict[str, Any]:
     """Handler for ``bind9.config.apply_file`` -- atomic single-fragment write.
 
@@ -500,9 +510,9 @@ async def bind9_config_apply_file(
     requested: str = params["path"]
     content: str = params["content"]
 
-    bind_root = await _resolve_bind_root(connector, target)
+    bind_root = await _resolve_bind_root(connector, target, operator)
     resolved_path = ensure_path_under_root(requested, bind_root)
-    sudo_password = _sudo_password_for_target(target)
+    sudo_password = await _sudo_password_for_target(connector, target, operator)
 
     # Verify predicate: the live-loaded config must still parse. A
     # bad fragment that passes the staged-tree parse but breaks the
@@ -513,7 +523,7 @@ async def bind9_config_apply_file(
     apply_result = await atomic_apply(
         connector,
         target,
-        raw_jwt="",
+        operator=operator,
         sudo_password=sudo_password,
         audit_slice_path=resolved_path,
         # zone_name="" -- this is a config write, not a zonefile write.
@@ -625,6 +635,7 @@ async def bind9_config_apply_views(
     connector: Bind9Connector,
     target: Any,
     params: dict[str, Any],
+    operator: Operator | None = None,
 ) -> dict[str, Any]:
     """Handler for ``bind9.config.apply_views`` -- atomic multi-file tree write.
 
@@ -674,7 +685,7 @@ async def bind9_config_apply_views(
     if not files:
         raise ValueError("bind9.config.apply_views requires a non-empty 'files' mapping")
 
-    bind_root = await _resolve_bind_root(connector, target)
+    bind_root = await _resolve_bind_root(connector, target, operator)
     # Pack first so a traversal input fails the op pre-stage with the
     # structured ConfigPathRejectedError -- no remote IO past the
     # fingerprint call.
@@ -708,7 +719,7 @@ async def bind9_config_apply_views(
     else:
         primary_path = resolved_paths[0]
 
-    sudo_password = _sudo_password_for_target(target)
+    sudo_password = await _sudo_password_for_target(connector, target, operator)
 
     # Verify predicate: prefer a representative dig if the caller named
     # one; otherwise fall back to the "config still parses live" check.
@@ -725,7 +736,7 @@ async def bind9_config_apply_views(
     apply_result = await atomic_apply(
         connector,
         target,
-        raw_jwt="",
+        operator=operator,
         sudo_password=sudo_password,
         audit_slice_path=primary_path,
         zone_name="",  # multi-file config-write; no SOA-bump rollback.
@@ -881,6 +892,7 @@ async def bind9_config_backup(
     connector: Bind9Connector,
     target: Any,
     params: dict[str, Any],
+    operator: Operator | None = None,
 ) -> dict[str, Any]:
     """Handler for ``bind9.config.backup``.
 
@@ -909,8 +921,8 @@ async def bind9_config_backup(
     ``rm`` if the backup is unwanted).
     """
     tag: str | None = params.get("tag")
-    sudo_password = _sudo_password_for_target(target)
-    bind_root = await _resolve_bind_root(connector, target)
+    sudo_password = await _sudo_password_for_target(connector, target, operator)
+    bind_root = await _resolve_bind_root(connector, target, operator)
 
     # Compose the filename. ``time.strftime`` returns a localtime-zoned
     # timestamp -- but we want UTC so backups across timezones sort
@@ -990,7 +1002,7 @@ async def bind9_config_backup(
     proc = await connector._remote_bash_with_sudo(
         target,
         script,
-        raw_jwt="",
+        operator=operator,
         sudo_password=sudo_password,
         timeout=120.0,
     )
@@ -1119,6 +1131,7 @@ async def bind9_config_reload(
     connector: Bind9Connector,
     target: Any,
     params: dict[str, Any],
+    operator: Operator | None = None,
 ) -> dict[str, Any]:
     """Handler for ``bind9.config.reload``.
 
@@ -1147,7 +1160,7 @@ async def bind9_config_reload(
     not the cause).
     """
     del params  # declared empty in schema; intentionally ignored
-    sudo_password = _sudo_password_for_target(target)
+    sudo_password = await _sudo_password_for_target(connector, target, operator)
 
     # ``rndc reload`` is one positional command; the wrapper captures
     # stdout + stderr + exit so the result envelope can carry whichever
@@ -1182,7 +1195,7 @@ async def bind9_config_reload(
     proc = await connector._remote_bash_with_sudo(
         target,
         script,
-        raw_jwt="",
+        operator=operator,
         sudo_password=sudo_password,
         timeout=60.0,
     )

--- a/backend/src/meho_backplane/connectors/bind9/ops_record.py
+++ b/backend/src/meho_backplane/connectors/bind9/ops_record.py
@@ -73,10 +73,12 @@ import dns.rdatatype
 import dns.zone
 import structlog.contextvars
 
+from meho_backplane.connectors._shared.vault_creds import strip_credential_value
 from meho_backplane.connectors.bind9._atomic import atomic_apply
 from meho_backplane.connectors.bind9.ops import Bind9Op
 
 if TYPE_CHECKING:
+    from meho_backplane.auth.operator import Operator
     from meho_backplane.connectors.bind9.connector import Bind9Connector
 
 __all__ = [
@@ -255,6 +257,7 @@ async def bind9_record_get(
     connector: Bind9Connector,
     target: Any,
     params: dict[str, Any],
+    operator: Operator | None = None,
 ) -> dict[str, Any]:
     """Handler for ``bind9.record.get``.
 
@@ -292,7 +295,7 @@ async def bind9_record_get(
     # +noall +answer trims the wire output to only the answer
     # section so the parser sees a bounded payload.
     cmd = f"dig @localhost {shlex.quote(fqdn)} {record_type} +noall +answer +nocomments"
-    proc = await connector._run_command(target, cmd, raw_jwt="")
+    proc = await connector._run_command(target, cmd, operator=operator)
     stdout = (proc.stdout or "") if hasattr(proc, "stdout") else ""
     output = stdout if isinstance(stdout, str) else ""
     rows = parse_dig_answer(output)
@@ -486,6 +489,7 @@ async def _resolve_zone_via_checkconf(
     connector: Bind9Connector,
     target: Any,
     fqdn: str,
+    operator: Operator | None = None,
 ) -> tuple[str, str]:
     """Locate (zone_name, zonefile_path) for *fqdn* via ``named-checkconf -p``.
 
@@ -502,7 +506,7 @@ async def _resolve_zone_via_checkconf(
     )
 
     cmd = "named-checkconf -p"
-    proc = await connector._run_command(target, cmd, raw_jwt="")
+    proc = await connector._run_command(target, cmd, operator=operator)
     output = _require_zero_exit(proc, command=cmd)
     rows = parse_named_checkconf_zones(output)
     zone_names = [row["name"] for row in rows]
@@ -671,6 +675,7 @@ async def _resolve_zone_and_path(
     *,
     fqdn: str,
     explicit_zone: str | None,
+    operator: Operator | None = None,
 ) -> tuple[str, str]:
     """Return ``(zone_name, zonefile_path)`` for *fqdn*.
 
@@ -681,15 +686,18 @@ async def _resolve_zone_and_path(
     """
     if explicit_zone is not None:
         zone_name = explicit_zone.rstrip(".")
-        zonefile_path = await _resolve_zonefile_path_for_zone(connector, target, zone_name)
+        zonefile_path = await _resolve_zonefile_path_for_zone(
+            connector, target, zone_name, operator
+        )
         return zone_name, zonefile_path
-    return await _resolve_zone_via_checkconf(connector, target, fqdn)
+    return await _resolve_zone_via_checkconf(connector, target, fqdn, operator)
 
 
 async def _read_zonefile_text(
     connector: Bind9Connector,
     target: Any,
     zonefile_path: str,
+    operator: Operator | None = None,
 ) -> str:
     """Read the current zonefile text via ``cat`` (no sudo needed).
 
@@ -705,7 +713,7 @@ async def _read_zonefile_text(
     # cause (the file isn't readable). Route through the typed surface
     # so the dispatcher's connector_error envelope carries the actual
     # remote exit status + stderr.
-    cat_proc = await connector._run_command(target, cmd, raw_jwt="")
+    cat_proc = await connector._run_command(target, cmd, operator=operator)
     return _require_zero_exit(cat_proc, command=cmd)
 
 
@@ -713,6 +721,7 @@ async def bind9_record_add(
     connector: Bind9Connector,
     target: Any,
     params: dict[str, Any],
+    operator: Operator | None = None,
 ) -> dict[str, Any]:
     """Handler for ``bind9.record.add`` -- atomic A/AAAA record write.
 
@@ -752,11 +761,11 @@ async def bind9_record_add(
         )
     _validate_ip_for_type(ip, record_type)
 
-    sudo_password = _sudo_password_from_target(target)
+    sudo_password = await _sudo_password_from_target(connector, target, operator)
     zone_name, zonefile_path = await _resolve_zone_and_path(
-        connector, target, fqdn=fqdn, explicit_zone=explicit_zone
+        connector, target, fqdn=fqdn, explicit_zone=explicit_zone, operator=operator
     )
-    current_text = await _read_zonefile_text(connector, target, zonefile_path)
+    current_text = await _read_zonefile_text(connector, target, zonefile_path, operator)
 
     try:
         new_text = _add_record_to_zonefile(
@@ -783,7 +792,7 @@ async def bind9_record_add(
     apply_result = await atomic_apply(
         connector,
         target,
-        raw_jwt="",
+        operator=operator,
         sudo_password=sudo_password,
         audit_slice_path=zonefile_path,
         zone_name=zone_name,
@@ -817,6 +826,7 @@ async def bind9_record_remove(
     connector: Bind9Connector,
     target: Any,
     params: dict[str, Any],
+    operator: Operator | None = None,
 ) -> dict[str, Any]:
     """Handler for ``bind9.record.remove`` -- atomic A/AAAA record remove.
 
@@ -830,11 +840,11 @@ async def bind9_record_remove(
     fqdn: str = params["fqdn"]
     explicit_zone: str | None = params.get("zone")
 
-    sudo_password = _sudo_password_from_target(target)
+    sudo_password = await _sudo_password_from_target(connector, target, operator)
     zone_name, zonefile_path = await _resolve_zone_and_path(
-        connector, target, fqdn=fqdn, explicit_zone=explicit_zone
+        connector, target, fqdn=fqdn, explicit_zone=explicit_zone, operator=operator
     )
-    current_text = await _read_zonefile_text(connector, target, zonefile_path)
+    current_text = await _read_zonefile_text(connector, target, zonefile_path, operator)
 
     try:
         new_text = _remove_record_from_zonefile(
@@ -859,7 +869,7 @@ async def bind9_record_remove(
     apply_result = await atomic_apply(
         connector,
         target,
-        raw_jwt="",
+        operator=operator,
         sudo_password=sudo_password,
         audit_slice_path=zonefile_path,
         zone_name=zone_name,
@@ -886,6 +896,7 @@ async def _resolve_zonefile_path_for_zone(
     connector: Bind9Connector,
     target: Any,
     zone_name: str,
+    operator: Operator | None = None,
 ) -> str:
     """Look up the zonefile path for an explicit ``--zone`` arg.
 
@@ -899,7 +910,7 @@ async def _resolve_zonefile_path_for_zone(
     )
 
     cmd = "named-checkconf -p"
-    proc = await connector._run_command(target, cmd, raw_jwt="")
+    proc = await connector._run_command(target, cmd, operator=operator)
     output = _require_zero_exit(proc, command=cmd)
     try:
         return _resolve_zonefile_path(output, zone_name)
@@ -909,29 +920,32 @@ async def _resolve_zonefile_path_for_zone(
         raise ZoneResolutionError("unresolvable", fqdn=zone_name) from exc
 
 
-def _sudo_password_from_target(target: Any) -> str:
-    """Read the sudo password from the target's ``secret_ref``.
+async def _sudo_password_from_target(
+    connector: Bind9Connector, target: Any, operator: Operator | None = None
+) -> str:
+    """Resolve the sudo password from the target's Vault secret.
 
-    The :class:`Target` schema (v0.2) stores SSH credentials on a
-    target's ``secret_ref`` dict; the sudo password reuses the SSH
-    password by default (consumer-wrapper convention). A future iter
-    may key on a dedicated ``sudo_password`` field; the lookup here
-    falls back to ``password`` so existing target rows keep working.
+    ``target.secret_ref`` is a Vault KV-v2 path string (#2155);
+    resolution goes through the SSH adapter's
+    :meth:`~meho_backplane.connectors.adapters.ssh.SshConnector._resolve_secret`
+    under the operator's identity — the same seam SSH auth uses. The
+    sudo password reuses the SSH password by default
+    (consumer-wrapper convention): the lookup keys on a dedicated
+    ``sudo_password`` field first and falls back to ``password`` so
+    existing Vault secrets keep working.
 
     Raises :class:`ValueError` if no password is configured -- the
     safe-sudo primitive's invariant requires a non-empty single-line
     string and the connector cannot legitimately proceed otherwise.
     """
-    secret_ref = getattr(target, "secret_ref", None) or {}
-    if not isinstance(secret_ref, dict):
-        raise ValueError(f"target.secret_ref must be a dict; got {type(secret_ref).__name__}")
-    password = secret_ref.get("sudo_password") or secret_ref.get("password")
+    secret = await connector._resolve_secret(target, operator)
+    password = secret.get("sudo_password") or secret.get("password")
     if not password:
         raise ValueError(
-            "target.secret_ref carries no sudo_password / password; "
+            "the target's Vault secret carries no sudo_password / password; "
             "bind9 write ops require a sudo credential"
         )
-    return str(password)
+    return strip_credential_value(password)
 
 
 # ---------------------------------------------------------------------------

--- a/backend/src/meho_backplane/connectors/bind9/ops_zone.py
+++ b/backend/src/meho_backplane/connectors/bind9/ops_zone.py
@@ -100,6 +100,7 @@ import dns.zone
 from meho_backplane.connectors.bind9.ops import Bind9Op
 
 if TYPE_CHECKING:
+    from meho_backplane.auth.operator import Operator
     from meho_backplane.connectors.bind9.connector import Bind9Connector
 
 __all__ = [
@@ -304,6 +305,7 @@ async def bind9_zone_list(
     connector: Bind9Connector,
     target: Any,
     params: dict[str, Any],
+    operator: Operator | None = None,
 ) -> dict[str, Any]:
     """Handler for ``bind9.zone.list``.
 
@@ -313,7 +315,7 @@ async def bind9_zone_list(
     reducer-side-handle decision.
     """
     del params  # schema declares the param object empty
-    proc = await connector._run_command(target, "named-checkconf -p", raw_jwt="")
+    proc = await connector._run_command(target, "named-checkconf -p", operator=operator)
     stdout = (proc.stdout or "") if hasattr(proc, "stdout") else ""
     output = stdout if isinstance(stdout, str) else ""
     rows = parse_named_checkconf_zones(output)
@@ -348,6 +350,7 @@ async def bind9_zone_read(
     connector: Bind9Connector,
     target: Any,
     params: dict[str, Any],
+    operator: Operator | None = None,
 ) -> dict[str, Any]:
     """Handler for ``bind9.zone.read``.
 
@@ -376,7 +379,7 @@ async def bind9_zone_read(
     # named-checkconf invocation ``bind9.zone.list`` uses; cheap on
     # bind9 (parse-only, no zone transfer), so a duplicate call is
     # acceptable in v0.2.
-    checkconf = await connector._run_command(target, "named-checkconf -p", raw_jwt="")
+    checkconf = await connector._run_command(target, "named-checkconf -p", operator=operator)
     checkconf_stdout = (checkconf.stdout or "") if hasattr(checkconf, "stdout") else ""
     checkconf_output = checkconf_stdout if isinstance(checkconf_stdout, str) else ""
     zonefile_path = _resolve_zonefile_path(checkconf_output, zone_name)
@@ -394,7 +397,7 @@ async def bind9_zone_read(
     # a load-bearing safety primitive (the safe-sudo primitive in
     # :mod:`connector` carries that role for write paths).
     quoted_path = "'" + zonefile_path.replace("'", "'\\''") + "'"
-    cat_proc = await connector._run_command(target, f"cat {quoted_path}", raw_jwt="")
+    cat_proc = await connector._run_command(target, f"cat {quoted_path}", operator=operator)
     cat_stdout = (cat_proc.stdout or "") if hasattr(cat_proc, "stdout") else ""
     zonefile_text = cat_stdout if isinstance(cat_stdout, str) else ""
 

--- a/backend/src/meho_backplane/connectors/holodeck/_pwsh.py
+++ b/backend/src/meho_backplane/connectors/holodeck/_pwsh.py
@@ -142,11 +142,15 @@ def encode_pwsh_command(script: str) -> str:
     return base64.b64encode(script.encode("utf-16-le")).decode("ascii")
 
 
+# code-quality-allow: pre-existing ~101-line helper; the length is the
+# parameter-contract + encoding-convention docstring, not logic complexity —
+# the #2155 operator-threading param is a minimal, out-of-scope-to-refactor add.
 async def pwsh_run(
     connector: Any,
     target: Any,
     script: str,
     *,
+    operator: Any = None,
     depth: int = PWSH_DEFAULT_DEPTH,
     timeout: float = 30.0,
 ) -> Any:
@@ -169,6 +173,9 @@ async def pwsh_run(
         for deep cmdlet outputs); the helper does not append the
         conversion itself because some ops construct multi-statement
         scripts where only the final pipeline produces the JSON.
+    operator
+        Forwarded to ``_run_command`` for the operator-context Vault
+        credential read on an SSH pool miss; ``None`` fails closed.
     depth
         Advisory — surfaced as the recommended ``-Depth`` value via
         :data:`PWSH_DEFAULT_DEPTH`. The helper itself does not rewrite
@@ -194,7 +201,7 @@ async def pwsh_run(
     encoded = encode_pwsh_command(script)
     cmd = f"pwsh -NoProfile -NonInteractive -EncodedCommand {encoded}"
 
-    proc = await connector._run_command(target, cmd, raw_jwt="", timeout=timeout)
+    proc = await connector._run_command(target, cmd, operator=operator, timeout=timeout)
 
     stdout: str = (proc.stdout or "") if hasattr(proc, "stdout") else ""
     stderr: str = (proc.stderr or "") if hasattr(proc, "stderr") else ""

--- a/backend/src/meho_backplane/connectors/holodeck/connector.py
+++ b/backend/src/meho_backplane/connectors/holodeck/connector.py
@@ -67,6 +67,8 @@ import asyncssh
 import structlog
 
 from meho_backplane.auth.operator import Operator
+from meho_backplane.auth.vault import VaultClientError
+from meho_backplane.connectors._shared.vault_creds import VaultCredentialsReadError
 from meho_backplane.connectors.adapters.ssh import SshConnector
 from meho_backplane.connectors.holodeck._pwsh import PwshRunError, pwsh_run
 from meho_backplane.connectors.holodeck.ops import HOLODECK_OPS
@@ -259,19 +261,35 @@ class HolodeckConnector(SshConnector):
         interpolate ``target.secret_ref`` fields into the PowerShell
         text.
 
-        ``operator`` exists for ABC parity (G0.16-T4 #1306) — Holodeck
-        authenticates via SSH key, not Vault OIDC, so the route operator
-        plays no role here.
+        ``operator`` is threaded to the SSH adapter's
+        :meth:`~meho_backplane.connectors.adapters.ssh.SshConnector._auth_config`,
+        which resolves ``target.secret_ref`` (a Vault KV-v2 path string)
+        under the operator's identity on an SSH pool miss (#2155).
+        ``None`` (background callers) fails closed at Vault and maps to
+        ``reachable=False``.
         """
-        del operator  # unused — SSH key auth, no Vault credential read
         probed_at = datetime.now(UTC)
 
         # Phase 1: read /etc/photon-release. Failure here is a hard
         # fingerprint failure -- there's no Photon-less Holodeck shape
-        # to fall back to.
+        # to fall back to. The catch tuple covers the transport
+        # (OSError / asyncssh.Error) plus the credential-resolution
+        # failures _auth_config raises: the two-phase Vault contract
+        # (VaultClientError login-phase, VaultCredentialsReadError
+        # read-phase) and ValueError (secret carries neither key nor
+        # password) — an unresolvable credential is an unreachable
+        # target, not an unhandled exception (#986 discipline).
         try:
-            photon_proc = await self._run_command(target, "cat /etc/photon-release", raw_jwt="")
-        except (OSError, asyncssh.Error) as exc:
+            photon_proc = await self._run_command(
+                target, "cat /etc/photon-release", operator=operator
+            )
+        except (
+            OSError,
+            asyncssh.Error,
+            ValueError,
+            VaultClientError,
+            VaultCredentialsReadError,
+        ) as exc:
             _log.warning(
                 "holodeck_fingerprint_unreachable",
                 target=getattr(target, "name", None),
@@ -299,6 +317,7 @@ class HolodeckConnector(SshConnector):
                 self,
                 target,
                 "Get-HoloDeckConfig | ConvertTo-Json -Compress",
+                operator=operator,
             )
         except PwshRunError as exc:
             _log.warning(
@@ -386,18 +405,22 @@ class HolodeckConnector(SshConnector):
 
         # Order matters: PermissionDenied (subclass of DisconnectError)
         # must be caught before DisconnectError; OSError is the TCP-
-        # level failure. ValueError from _auth_config (missing
-        # credentials) folds into ssh_auth_failed -- the operator's
-        # remediation is the same as for a rejected password.
+        # level failure. Credential-resolution failures fold into
+        # ssh_auth_failed: ValueError (secret carries neither key nor
+        # password) and the Vault two-phase errors (VaultClientError /
+        # VaultCredentialsReadError). ``probe()`` carries no operator,
+        # so the Vault read runs under the synthesised system operator
+        # and fails closed — the operator's remediation is the same as
+        # for a rejected password: check the target's Vault secret.
         try:
-            await self._connect(target, raw_jwt="")
+            await self._connect(target)
         except asyncssh.PermissionDenied:
             return _result(False, "ssh_auth_failed")
         except asyncssh.DisconnectError:
             return _result(False, "ssh_auth_failed")
         except OSError:
             return _result(False, "tcp_unreachable")
-        except ValueError:
+        except (ValueError, VaultClientError, VaultCredentialsReadError):
             return _result(False, "ssh_auth_failed")
 
         # Photon health: ``/etc/photon-release`` must produce non-empty
@@ -405,7 +428,7 @@ class HolodeckConnector(SshConnector):
         # repointed the Holodeck target's Vault secret at a stock
         # Linux box) or a degraded appliance image.
         try:
-            photon_proc = await self._run_command(target, "cat /etc/photon-release", raw_jwt="")
+            photon_proc = await self._run_command(target, "cat /etc/photon-release")
         except (OSError, asyncssh.Error):
             return _result(False, "ssh_auth_failed")
         photon_raw = (photon_proc.stdout or "") if hasattr(photon_proc, "stdout") else ""
@@ -457,6 +480,7 @@ class HolodeckConnector(SshConnector):
         self,
         target: Target,
         params: dict[str, Any],
+        operator: Operator | None = None,
     ) -> dict[str, Any]:
         """Return the Holodeck appliance's product/version/Photon snapshot.
 
@@ -471,7 +495,7 @@ class HolodeckConnector(SshConnector):
         verbatim into ``OperationResult.result``.
         """
         del params  # declared empty in schema; intentionally ignored
-        result = await self.fingerprint(target)
+        result = await self.fingerprint(target, operator)
         return {
             "vendor": result.vendor,
             "product": result.product,
@@ -485,6 +509,7 @@ class HolodeckConnector(SshConnector):
         self,
         target: Target,
         params: dict[str, Any],
+        operator: Operator | None = None,
     ) -> dict[str, Any]:
         """Bound-method shim for ``holodeck.config.show`` (G3.8-T2 #854).
 
@@ -495,12 +520,13 @@ class HolodeckConnector(SshConnector):
             holodeck_config_show as _holodeck_config_show,
         )
 
-        return await _holodeck_config_show(self, target, params)
+        return await _holodeck_config_show(self, target, params, operator)
 
     async def pod_list(
         self,
         target: Target,
         params: dict[str, Any],
+        operator: Operator | None = None,
     ) -> dict[str, Any]:
         """Bound-method shim for ``holodeck.pod.list`` (G3.8-T2 #854).
 
@@ -516,12 +542,13 @@ class HolodeckConnector(SshConnector):
             holodeck_pod_list as _holodeck_pod_list,
         )
 
-        return await _holodeck_pod_list(self, target, params)
+        return await _holodeck_pod_list(self, target, params, operator)
 
     async def pod_info(
         self,
         target: Target,
         params: dict[str, Any],
+        operator: Operator | None = None,
     ) -> dict[str, Any]:
         """Bound-method shim for ``holodeck.pod.info`` (G3.8-T2 #854).
 
@@ -532,12 +559,13 @@ class HolodeckConnector(SshConnector):
             holodeck_pod_info as _holodeck_pod_info,
         )
 
-        return await _holodeck_pod_info(self, target, params)
+        return await _holodeck_pod_info(self, target, params, operator)
 
     async def service_list(
         self,
         target: Target,
         params: dict[str, Any],
+        operator: Operator | None = None,
     ) -> dict[str, Any]:
         """Bound-method shim for ``holodeck.service.list`` (G3.8-T2 #854).
 
@@ -548,12 +576,13 @@ class HolodeckConnector(SshConnector):
             holodeck_service_list as _holodeck_service_list,
         )
 
-        return await _holodeck_service_list(self, target, params)
+        return await _holodeck_service_list(self, target, params, operator)
 
     async def k8s_exec(
         self,
         target: Target,
         params: dict[str, Any],
+        operator: Operator | None = None,
     ) -> dict[str, Any]:
         """Bound-method shim for ``holodeck.k8s.exec`` (G3.8-T2 #854).
 
@@ -567,12 +596,13 @@ class HolodeckConnector(SshConnector):
             holodeck_k8s_exec as _holodeck_k8s_exec,
         )
 
-        return await _holodeck_k8s_exec(self, target, params)
+        return await _holodeck_k8s_exec(self, target, params, operator)
 
     async def logs_tail(
         self,
         target: Target,
         params: dict[str, Any],
+        operator: Operator | None = None,
     ) -> dict[str, Any]:
         """Bound-method shim for ``holodeck.logs.tail`` (G3.8-T2 #854).
 
@@ -583,12 +613,13 @@ class HolodeckConnector(SshConnector):
             holodeck_logs_tail as _holodeck_logs_tail,
         )
 
-        return await _holodeck_logs_tail(self, target, params)
+        return await _holodeck_logs_tail(self, target, params, operator)
 
     async def networking_show(
         self,
         target: Target,
         params: dict[str, Any],
+        operator: Operator | None = None,
     ) -> dict[str, Any]:
         """Bound-method shim for ``holodeck.networking.show`` (G3.8-T2 #854).
 
@@ -599,12 +630,13 @@ class HolodeckConnector(SshConnector):
             holodeck_networking_show as _holodeck_networking_show,
         )
 
-        return await _holodeck_networking_show(self, target, params)
+        return await _holodeck_networking_show(self, target, params, operator)
 
     async def disk_usage(
         self,
         target: Target,
         params: dict[str, Any],
+        operator: Operator | None = None,
     ) -> dict[str, Any]:
         """Bound-method shim for ``holodeck.disk.usage`` (G3.18-T1 #2153).
 
@@ -615,12 +647,13 @@ class HolodeckConnector(SshConnector):
             holodeck_disk_usage as _holodeck_disk_usage,
         )
 
-        return await _holodeck_disk_usage(self, target, params)
+        return await _holodeck_disk_usage(self, target, params, operator)
 
     async def k8s_pods_gc(
         self,
         target: Target,
         params: dict[str, Any],
+        operator: Operator | None = None,
     ) -> dict[str, Any]:
         """Bound-method shim for ``holodeck.k8s.pods.gc`` (G3.18-T2 #2154).
 
@@ -632,12 +665,13 @@ class HolodeckConnector(SshConnector):
             holodeck_k8s_pods_gc as _holodeck_k8s_pods_gc,
         )
 
-        return await _holodeck_k8s_pods_gc(self, target, params)
+        return await _holodeck_k8s_pods_gc(self, target, params, operator)
 
     async def backups_prune(
         self,
         target: Target,
         params: dict[str, Any],
+        operator: Operator | None = None,
     ) -> dict[str, Any]:
         """Bound-method shim for ``holodeck.backups.prune`` (G3.18-T2 #2154).
 
@@ -649,12 +683,13 @@ class HolodeckConnector(SshConnector):
             holodeck_backups_prune as _holodeck_backups_prune,
         )
 
-        return await _holodeck_backups_prune(self, target, params)
+        return await _holodeck_backups_prune(self, target, params, operator)
 
     async def images_import(
         self,
         target: Target,
         params: dict[str, Any],
+        operator: Operator | None = None,
     ) -> dict[str, Any]:
         """Bound-method shim for ``holodeck.images.import`` (G3.18-T2 #2154).
 
@@ -666,7 +701,7 @@ class HolodeckConnector(SshConnector):
             holodeck_images_import as _holodeck_images_import,
         )
 
-        return await _holodeck_images_import(self, target, params)
+        return await _holodeck_images_import(self, target, params, operator)
 
     @classmethod
     async def register_operations(cls) -> None:

--- a/backend/src/meho_backplane/connectors/holodeck/ops_read.py
+++ b/backend/src/meho_backplane/connectors/holodeck/ops_read.py
@@ -131,6 +131,7 @@ from meho_backplane.connectors.holodeck._pwsh import PwshRunError, pwsh_run
 from meho_backplane.connectors.holodeck.ops import SSH_TRANSPORT_NOTE, HolodeckOp
 
 if TYPE_CHECKING:
+    from meho_backplane.auth.operator import Operator
     from meho_backplane.connectors.holodeck.connector import HolodeckConnector
 
 __all__ = [
@@ -684,6 +685,7 @@ async def holodeck_config_show(
     self: HolodeckConnector,
     target: Any,
     params: dict[str, Any],
+    operator: Operator | None = None,
 ) -> dict[str, Any]:
     """Return the Holodeck configuration dict from ``Get-HoloDeckConfig``.
 
@@ -695,7 +697,7 @@ async def holodeck_config_show(
     del params  # declared empty; intentionally ignored
     script = "Get-HoloDeckConfig | ConvertTo-Json -Depth 4 -Compress"
     try:
-        payload = await pwsh_run(self, target, script)
+        payload = await pwsh_run(self, target, script, operator=operator)
     except PwshRunError as exc:
         return {"config": None, "error": str(exc)}
     return {"config": payload}
@@ -705,6 +707,7 @@ async def holodeck_pod_list(
     self: HolodeckConnector,
     target: Any,
     params: dict[str, Any],
+    operator: Operator | None = None,
 ) -> dict[str, Any]:
     """Return the active Holodeck nested-pod inventory.
 
@@ -722,7 +725,7 @@ async def holodeck_pod_list(
     del params  # declared empty; intentionally ignored
     script = "Get-HoloDeckPod | ConvertTo-Json -Depth 4"
     try:
-        payload = await pwsh_run(self, target, script)
+        payload = await pwsh_run(self, target, script, operator=operator)
     except PwshRunError as exc:
         return {"rows": [], "total": 0, "error": str(exc)}
     rows = _normalise_pwsh_json_array(payload)
@@ -733,6 +736,7 @@ async def holodeck_pod_info(
     self: HolodeckConnector,
     target: Any,
     params: dict[str, Any],
+    operator: Operator | None = None,
 ) -> dict[str, Any]:
     """Return the per-pod detail dict for *pod_id*.
 
@@ -755,7 +759,7 @@ async def holodeck_pod_info(
     quoted_id = pod_id.replace("'", "''")
     script = f"Get-HoloDeckPod -Id '{quoted_id}' | ConvertTo-Json -Depth 4"
     try:
-        payload = await pwsh_run(self, target, script)
+        payload = await pwsh_run(self, target, script, operator=operator)
     except PwshRunError as exc:
         return {"pod": None, "error": str(exc)}
     return {"pod": payload}
@@ -765,6 +769,7 @@ async def holodeck_service_list(
     self: HolodeckConnector,
     target: Any,
     params: dict[str, Any],
+    operator: Operator | None = None,
 ) -> dict[str, Any]:
     """Return Photon services with the ``Holo*`` prefix and their status.
 
@@ -783,7 +788,7 @@ async def holodeck_service_list(
         "Select-Object Name,Status,DisplayName | ConvertTo-Json -Depth 4"
     )
     try:
-        payload = await pwsh_run(self, target, script)
+        payload = await pwsh_run(self, target, script, operator=operator)
     except PwshRunError as exc:
         return {"rows": [], "total": 0, "error": str(exc)}
     rows = _normalise_pwsh_json_array(payload)
@@ -794,6 +799,7 @@ async def holodeck_k8s_exec(
     self: HolodeckConnector,
     target: Any,
     params: dict[str, Any],
+    operator: Operator | None = None,
 ) -> dict[str, Any]:
     """Forward a **read-only** ``kubectl`` command to the in-appliance K8s.
 
@@ -846,16 +852,12 @@ async def holodeck_k8s_exec(
         }
     # The command is operator-supplied; run it verbatim via the pooled
     # SSH connection. The base adapter's ``_run_command`` already
-    # bounds the wall clock at 30s by default.
-    try:
-        proc = await self._run_command(target, raw_command, raw_jwt="")
-    except Exception as exc:
-        return {
-            "stdout": "",
-            "stderr": "",
-            "exit_status": None,
-            "error": str(exc),
-        }
+    # bounds the wall clock at 30s by default. Auth / transport
+    # failures propagate to the dispatcher's ``connector_error``
+    # branch (mirroring ``holodeck.about``) — swallowing them into a
+    # ``status="ok"`` envelope with empty stdout invites an agent to
+    # act on hollow output (#2155).
+    proc = await self._run_command(target, raw_command, operator=operator)
     stdout = (proc.stdout or "") if hasattr(proc, "stdout") else ""
     stderr = (proc.stderr or "") if hasattr(proc, "stderr") else ""
     if not isinstance(stdout, str):
@@ -877,6 +879,7 @@ async def holodeck_logs_tail(
     self: HolodeckConnector,
     target: Any,
     params: dict[str, Any],
+    operator: Operator | None = None,
 ) -> dict[str, Any]:
     """Tail ``/holodeck-runtime/logs/<component>*.log`` for *N* lines.
 
@@ -927,7 +930,7 @@ async def holodeck_logs_tail(
         }
     cmd = f"tail -n {lines_raw} /holodeck-runtime/logs/{component}*.log"
     try:
-        proc = await self._run_command(target, cmd, raw_jwt="")
+        proc = await self._run_command(target, cmd, operator=operator)
     except Exception as exc:
         return {
             "files": [],
@@ -946,6 +949,7 @@ async def holodeck_networking_show(
     self: HolodeckConnector,
     target: Any,
     params: dict[str, Any],
+    operator: Operator | None = None,
 ) -> dict[str, Any]:
     """Compose the FRR/BGP + DNS + DHCP networking snapshot.
 
@@ -974,18 +978,19 @@ async def holodeck_networking_show(
     """
     del params  # declared empty; intentionally ignored
 
-    bgp_text = await _safe_run_text(self, target, "vtysh -c 'show bgp summary'")
-    routes_text = await _safe_run_text(self, target, "vtysh -c 'show ip route'")
+    bgp_text = await _safe_run_text(self, target, "vtysh -c 'show bgp summary'", operator)
+    routes_text = await _safe_run_text(self, target, "vtysh -c 'show ip route'", operator)
     dns_zones_payload: Any
     try:
         dns_zones_payload = await pwsh_run(
             self,
             target,
             "Get-DnsServerZone | Select-Object ZoneName,ZoneType | ConvertTo-Json -Depth 4",
+            operator=operator,
         )
     except PwshRunError:
         dns_zones_payload = None
-    dhcp_text = await _safe_run_text(self, target, "cat /var/lib/dhcp/dhcpd.leases")
+    dhcp_text = await _safe_run_text(self, target, "cat /var/lib/dhcp/dhcpd.leases", operator)
 
     return parse_networking_payload(
         bgp_text=bgp_text,
@@ -999,6 +1004,7 @@ async def holodeck_disk_usage(
     self: HolodeckConnector,
     target: Any,
     params: dict[str, Any],
+    operator: Operator | None = None,
 ) -> dict[str, Any]:
     """Report root-fs usage plus the fixed growth-dir set.
 
@@ -1028,10 +1034,10 @@ async def holodeck_disk_usage(
     """
     del params  # declared empty; intentionally ignored
 
-    df_root_text = await _safe_run_text(self, target, "df -B1 /")
+    df_root_text = await _safe_run_text(self, target, "df -B1 /", operator)
     dir_usages: list[tuple[str, str]] = []
     for path in GROWTH_DIRS:
-        du_text = await _safe_run_text(self, target, f"du -sb {shlex.quote(path)}")
+        du_text = await _safe_run_text(self, target, f"du -sb {shlex.quote(path)}", operator)
         dir_usages.append((path, du_text))
 
     return parse_disk_usage_output(df_root_text=df_root_text, dir_usages=dir_usages)
@@ -1076,6 +1082,7 @@ async def _safe_run_text(
     self: HolodeckConnector,
     target: Any,
     cmd: str,
+    operator: Operator | None = None,
 ) -> str:
     """Run *cmd* via plain SSH, return stdout text; failures -> empty string.
 
@@ -1086,7 +1093,7 @@ async def _safe_run_text(
     sub-section's ``ok`` to ``False`` when the input is empty.
     """
     try:
-        proc = await self._run_command(target, cmd, raw_jwt="")
+        proc = await self._run_command(target, cmd, operator=operator)
     except Exception:
         return ""
     stdout = (proc.stdout or "") if hasattr(proc, "stdout") else ""

--- a/backend/src/meho_backplane/connectors/holodeck/ops_write.py
+++ b/backend/src/meho_backplane/connectors/holodeck/ops_write.py
@@ -87,6 +87,7 @@ from typing import TYPE_CHECKING, Any
 from meho_backplane.connectors.holodeck.ops import SSH_TRANSPORT_NOTE, HolodeckOp
 
 if TYPE_CHECKING:
+    from meho_backplane.auth.operator import Operator
     from meho_backplane.connectors.holodeck.connector import HolodeckConnector
 
 __all__ = [
@@ -232,7 +233,12 @@ def bound_image_tar(raw_path: Any) -> str:
 # ---------------------------------------------------------------------------
 
 
-async def _run_text(self: HolodeckConnector, target: Any, cmd: str) -> dict[str, Any]:
+async def _run_text(
+    self: HolodeckConnector,
+    target: Any,
+    cmd: str,
+    operator: Operator | None = None,
+) -> dict[str, Any]:
     """Run *cmd* over plain SSH, return ``{stdout, stderr, exit_status}``.
 
     Shared thin layer for the three write handlers: run the (already-bounded,
@@ -240,7 +246,7 @@ async def _run_text(self: HolodeckConnector, target: Any, cmd: str) -> dict[str,
     the completed process into the connector's standard result envelope.
     Stderr is capped at 4096 chars (the ``PwshRunError`` convention).
     """
-    proc = await self._run_command(target, cmd, raw_jwt="")
+    proc = await self._run_command(target, cmd, operator=operator)
     stdout = (proc.stdout or "") if hasattr(proc, "stdout") else ""
     stderr = (proc.stderr or "") if hasattr(proc, "stderr") else ""
     if not isinstance(stdout, str):
@@ -260,6 +266,7 @@ async def holodeck_k8s_pods_gc(
     self: HolodeckConnector,
     target: Any,
     params: dict[str, Any],
+    operator: Operator | None = None,
 ) -> dict[str, Any]:
     """Garbage-collect terminal (Failed / Succeeded) pods on the in-appliance K8s.
 
@@ -288,7 +295,7 @@ async def holodeck_k8s_pods_gc(
         for phase in phases:
             selector = shlex.quote(f"status.phase={phase}")
             cmd = f"kubectl delete pods{ns_arg} --field-selector {selector}"
-            outcome = await _run_text(self, target, cmd)
+            outcome = await _run_text(self, target, cmd, operator)
             deletes.append({"phase": phase, "command": cmd, **outcome})
     except Exception as exc:
         return {"deleted": False, "error": str(exc), "deletes": deletes}
@@ -299,6 +306,7 @@ async def holodeck_backups_prune(
     self: HolodeckConnector,
     target: Any,
     params: dict[str, Any],
+    operator: Operator | None = None,
 ) -> dict[str, Any]:
     """Prune backups under ``/var/backups``, keeping the newest ``keep_newest``.
 
@@ -340,7 +348,7 @@ async def holodeck_backups_prune(
         f"| xargs -r -d '\\n' rm -f --"
     )
     try:
-        outcome = await _run_text(self, target, cmd)
+        outcome = await _run_text(self, target, cmd, operator)
     except Exception as exc:
         return {"pruned": False, "error": str(exc)}
     return {
@@ -356,6 +364,7 @@ async def holodeck_images_import(
     self: HolodeckConnector,
     target: Any,
     params: dict[str, Any],
+    operator: Operator | None = None,
 ) -> dict[str, Any]:
     """Import a seed-image tarball into containerd's ``k8s.io`` namespace.
 
@@ -373,7 +382,7 @@ async def holodeck_images_import(
 
     cmd = f"ctr -n k8s.io images import {shlex.quote(tar_path)}"
     try:
-        outcome = await _run_text(self, target, cmd)
+        outcome = await _run_text(self, target, cmd, operator)
     except Exception as exc:
         return {"imported": False, "error": str(exc)}
     return {"imported": True, "tar_path": tar_path, "command": cmd, **outcome}

--- a/backend/src/meho_backplane/connectors/pfsense/connector.py
+++ b/backend/src/meho_backplane/connectors/pfsense/connector.py
@@ -53,6 +53,11 @@ import asyncssh
 import structlog
 
 from meho_backplane.auth.operator import Operator
+from meho_backplane.auth.vault import VaultClientError
+from meho_backplane.connectors._shared.vault_creds import (
+    VaultCredentialsReadError,
+    strip_credential_value,
+)
 from meho_backplane.connectors.adapters.ssh import SshConnector
 from meho_backplane.connectors.pfsense.ops import PFSENSE_OPS
 from meho_backplane.connectors.schemas import (
@@ -205,7 +210,9 @@ class PfSenseConnector(SshConnector):
     version = "2.7"
     impl_id = "pfsense-ssh"
 
-    async def _auth_config(self, target: Target) -> dict[str, Any]:
+    async def _auth_config(
+        self, target: Target, operator: Operator | None = None
+    ) -> dict[str, Any]:
         """Require ``ssh_private_key`` -- reject password auth.
 
         Overrides :meth:`SshConnector._auth_config` to enforce the
@@ -214,20 +221,27 @@ class PfSenseConnector(SshConnector):
         be used for SSH sessions. Password-based SSH on pfSense opens
         the console menu and hangs rather than providing a shell.
 
-        Raises :exc:`ValueError` when ``ssh_private_key`` is absent,
-        with a message directing the operator to configure SSH key
-        auth on the pfSense WebGUI and store the key in the target's
-        Vault secret under ``ssh_private_key``.
+        The secret itself resolves through the base adapter's
+        :meth:`~meho_backplane.connectors.adapters.ssh.SshConnector._resolve_secret`
+        (``target.secret_ref`` is a Vault KV-v2 path string read under
+        the operator's identity, #2155); only the key-only selection
+        policy lives here.
+
+        Raises :exc:`ValueError` when the resolved secret has no
+        ``ssh_private_key``, with a message directing the operator to
+        configure SSH key auth on the pfSense WebGUI and store the key
+        in the target's Vault secret under ``ssh_private_key``.
         """
-        secret: dict[str, Any] = getattr(target, "secret_ref", {}) or {}
-        username: str = secret.get("username", "admin")
-        private_key_text: str | None = secret.get("ssh_private_key")
-        if private_key_text:
-            key = asyncssh.import_private_key(private_key_text)
+        secret = await self._resolve_secret(target, operator)
+        username = strip_credential_value(secret.get("username", "admin"))
+        private_key_raw = secret.get("ssh_private_key")
+        if private_key_raw:
+            key = asyncssh.import_private_key(strip_credential_value(private_key_raw))
             return {"username": username, "client_keys": [key]}
         raise ValueError(
             f"target '{getattr(target, 'name', target)!r}': pfSense connector requires "
-            f"ssh_private_key in secret_ref — password auth is not supported. "
+            f"ssh_private_key in the target's Vault secret — password auth is not "
+            f"supported. "
             f"The 'password' field in the Vault secret is the WebGUI break-glass "
             f"credential; configure SSH public-key auth on the pfSense WebGUI "
             f"(System > User Manager > admin > Authorized SSH Keys) and store the "
@@ -256,16 +270,28 @@ class PfSenseConnector(SshConnector):
         ``probe_method="ssh: cat /etc/version"`` mirrors the bind9
         sibling's ``probe_method="ssh: named -v"`` convention.
 
-        ``operator`` exists for ABC parity (G0.16-T4 #1306) — pfSense
-        authenticates via SSH key, not Vault OIDC, so the route operator
-        plays no role here.
+        ``operator`` is threaded to the SSH adapter's ``_auth_config``,
+        which resolves ``target.secret_ref`` (a Vault KV-v2 path string)
+        under the operator's identity on an SSH pool miss (#2155).
+        ``None`` (background callers) fails closed at Vault and maps to
+        ``reachable=False``.
         """
-        del operator  # unused — SSH key auth, no Vault credential read
         probed_at = datetime.now(UTC)
 
+        # Catch tuple: transport failures plus credential-resolution
+        # failures (ValueError — key missing from the resolved secret;
+        # VaultClientError / VaultCredentialsReadError — the two-phase
+        # Vault contract). An unresolvable credential is an unreachable
+        # target, not an unhandled exception (#986 discipline).
         try:
-            proc = await self._run_command(target, "cat /etc/version", raw_jwt="")
-        except (OSError, asyncssh.Error) as exc:
+            proc = await self._run_command(target, "cat /etc/version", operator=operator)
+        except (
+            OSError,
+            asyncssh.Error,
+            ValueError,
+            VaultClientError,
+            VaultCredentialsReadError,
+        ) as exc:
             _log.warning(
                 "pfsense_fingerprint_unreachable",
                 target=getattr(target, "name", None),
@@ -346,19 +372,22 @@ class PfSenseConnector(SshConnector):
 
         # Order matters: PermissionDenied (subclass of DisconnectError)
         # must be caught before DisconnectError; OSError is the TCP-
-        # level failure. ValueError from _auth_config (missing key)
-        # maps to auth_failed as well -- it's an auth configuration
-        # problem, not a network problem.
+        # level failure. Credential-resolution failures map to
+        # auth_failed: ValueError (no ssh_private_key in the resolved
+        # secret) and the Vault two-phase errors (VaultClientError /
+        # VaultCredentialsReadError) -- ``probe()`` carries no operator,
+        # so the Vault read runs under the synthesised system operator
+        # and fails closed. Auth configuration problems, not network
+        # problems.
         try:
-            conn = await self._connect(target, raw_jwt="")
+            conn = await self._connect(target)
         except asyncssh.PermissionDenied:
             return _result(False, "auth_failed")
         except asyncssh.DisconnectError:
             return _result(False, "ssh_handshake_failed")
         except OSError:
             return _result(False, "tcp_unreachable")
-        except ValueError:
-            # _auth_config raised: missing ssh_private_key.
+        except (ValueError, VaultClientError, VaultCredentialsReadError):
             return _result(False, "auth_failed")
 
         del conn  # connection is pooled; _run_command will reuse it
@@ -378,7 +407,7 @@ class PfSenseConnector(SshConnector):
         # an ``OSError`` subclass so ``_run_command``'s ``asyncio.wait_for``
         # expiry is covered.
         try:
-            version_proc = await self._run_command(target, "cat /etc/version", raw_jwt="")
+            version_proc = await self._run_command(target, "cat /etc/version")
         except (OSError, asyncssh.Error):
             return _result(False, "command_failed")
         stdout = (version_proc.stdout or "") if hasattr(version_proc, "stdout") else ""
@@ -392,6 +421,7 @@ class PfSenseConnector(SshConnector):
         self,
         target: Target,
         params: dict[str, Any],
+        operator: Operator | None = None,
     ) -> dict[str, Any]:
         """Return the pfSense firewall's product/version/build snapshot.
 
@@ -411,7 +441,7 @@ class PfSenseConnector(SshConnector):
         carrying empty/None identity fields (#986).
         """
         del params  # declared empty in schema; intentionally ignored
-        result = await self.fingerprint(target)
+        result = await self.fingerprint(target, operator)
         self._assert_reachable(result)
         return {
             "vendor": result.vendor,
@@ -425,6 +455,7 @@ class PfSenseConnector(SshConnector):
         self,
         target: Target,
         params: dict[str, Any],
+        operator: Operator | None = None,
     ) -> dict[str, Any]:
         """Bound-method shim for ``pfsense.version`` (G3.7-T2 #847).
 
@@ -438,12 +469,13 @@ class PfSenseConnector(SshConnector):
             pfsense_version as _pfsense_version,
         )
 
-        return await _pfsense_version(self, target, params)
+        return await _pfsense_version(self, target, params, operator)
 
     async def firewall_rules(
         self,
         target: Target,
         params: dict[str, Any],
+        operator: Operator | None = None,
     ) -> dict[str, Any]:
         """Bound-method shim for ``pfsense.firewall.rules`` (G3.7-T2 #847).
 
@@ -454,12 +486,13 @@ class PfSenseConnector(SshConnector):
             pfsense_firewall_rules as _pfsense_firewall_rules,
         )
 
-        return await _pfsense_firewall_rules(self, target, params)
+        return await _pfsense_firewall_rules(self, target, params, operator)
 
     async def firewall_state(
         self,
         target: Target,
         params: dict[str, Any],
+        operator: Operator | None = None,
     ) -> dict[str, Any]:
         """Bound-method shim for ``pfsense.firewall.state`` (G3.7-T2 #847).
 
@@ -475,12 +508,13 @@ class PfSenseConnector(SshConnector):
             pfsense_firewall_state as _pfsense_firewall_state,
         )
 
-        return await _pfsense_firewall_state(self, target, params)
+        return await _pfsense_firewall_state(self, target, params, operator)
 
     async def nat_rules(
         self,
         target: Target,
         params: dict[str, Any],
+        operator: Operator | None = None,
     ) -> dict[str, Any]:
         """Bound-method shim for ``pfsense.nat.rules`` (G3.7-T2 #847).
 
@@ -491,12 +525,13 @@ class PfSenseConnector(SshConnector):
             pfsense_nat_rules as _pfsense_nat_rules,
         )
 
-        return await _pfsense_nat_rules(self, target, params)
+        return await _pfsense_nat_rules(self, target, params, operator)
 
     async def interface_list(
         self,
         target: Target,
         params: dict[str, Any],
+        operator: Operator | None = None,
     ) -> dict[str, Any]:
         """Bound-method shim for ``pfsense.interface.list`` (G3.7-T2 #847).
 
@@ -507,12 +542,13 @@ class PfSenseConnector(SshConnector):
             pfsense_interface_list as _pfsense_interface_list,
         )
 
-        return await _pfsense_interface_list(self, target, params)
+        return await _pfsense_interface_list(self, target, params, operator)
 
     async def gateway_list(
         self,
         target: Target,
         params: dict[str, Any],
+        operator: Operator | None = None,
     ) -> dict[str, Any]:
         """Bound-method shim for ``pfsense.gateway.list`` (G3.7-T2 #847).
 
@@ -523,12 +559,13 @@ class PfSenseConnector(SshConnector):
             pfsense_gateway_list as _pfsense_gateway_list,
         )
 
-        return await _pfsense_gateway_list(self, target, params)
+        return await _pfsense_gateway_list(self, target, params, operator)
 
     async def config_show(
         self,
         target: Target,
         params: dict[str, Any],
+        operator: Operator | None = None,
     ) -> dict[str, Any]:
         """Bound-method shim for ``pfsense.config.show`` (G3.7-T2 #847).
 
@@ -539,7 +576,7 @@ class PfSenseConnector(SshConnector):
             pfsense_config_show as _pfsense_config_show,
         )
 
-        return await _pfsense_config_show(self, target, params)
+        return await _pfsense_config_show(self, target, params, operator)
 
     @classmethod
     async def register_operations(cls) -> None:

--- a/backend/src/meho_backplane/connectors/pfsense/ops_read.py
+++ b/backend/src/meho_backplane/connectors/pfsense/ops_read.py
@@ -67,6 +67,7 @@ from defusedxml.ElementTree import ParseError, fromstring
 from meho_backplane.connectors.pfsense.ops import PfSenseOp
 
 if TYPE_CHECKING:
+    from meho_backplane.auth.operator import Operator
     from meho_backplane.connectors.pfsense.connector import PfSenseConnector
 
 __all__ = [
@@ -478,6 +479,7 @@ async def pfsense_version(
     self: PfSenseConnector,
     target: Any,
     params: dict[str, Any],
+    operator: Operator | None = None,
 ) -> dict[str, Any]:
     """Return pfSense version details from ``/etc/version``.
 
@@ -490,7 +492,7 @@ async def pfsense_version(
     del params  # declared empty; intentionally ignored
     from meho_backplane.connectors.pfsense.connector import parse_pfsense_version
 
-    proc = await self._run_command(target, "cat /etc/version", raw_jwt="")
+    proc = await self._run_command(target, "cat /etc/version", operator=operator)
     stdout = (proc.stdout or "") if hasattr(proc, "stdout") else ""
     content = stdout if isinstance(stdout, str) else ""
     if not content.strip() or proc.exit_status != 0:
@@ -507,6 +509,7 @@ async def pfsense_firewall_rules(
     self: PfSenseConnector,
     target: Any,
     params: dict[str, Any],
+    operator: Operator | None = None,
 ) -> dict[str, Any]:
     """Return the active pfSense firewall ruleset from ``pfctl -sr``.
 
@@ -515,7 +518,7 @@ async def pfsense_firewall_rules(
     optional direction, and the full unparsed rule line.
     """
     del params  # declared empty; intentionally ignored
-    proc = await self._run_command(target, "pfctl -sr", raw_jwt="")
+    proc = await self._run_command(target, "pfctl -sr", operator=operator)
     stdout = (proc.stdout or "") if hasattr(proc, "stdout") else ""
     content = stdout if isinstance(stdout, str) else ""
     if proc.exit_status != 0 and not content.strip():
@@ -528,6 +531,7 @@ async def pfsense_firewall_state(
     self: PfSenseConnector,
     target: Any,
     params: dict[str, Any],
+    operator: Operator | None = None,
 ) -> dict[str, Any]:
     """Return the active pfSense state table from ``pfctl -ss``.
 
@@ -541,7 +545,7 @@ async def pfsense_firewall_state(
     through unchanged.
     """
     del params  # declared empty; intentionally ignored
-    proc = await self._run_command(target, "pfctl -ss", raw_jwt="")
+    proc = await self._run_command(target, "pfctl -ss", operator=operator)
     stdout = (proc.stdout or "") if hasattr(proc, "stdout") else ""
     content = stdout if isinstance(stdout, str) else ""
     if proc.exit_status != 0 and not content.strip():
@@ -554,6 +558,7 @@ async def pfsense_nat_rules(
     self: PfSenseConnector,
     target: Any,
     params: dict[str, Any],
+    operator: Operator | None = None,
 ) -> dict[str, Any]:
     """Return the active pfSense NAT ruleset from ``pfctl -sn``.
 
@@ -563,7 +568,7 @@ async def pfsense_nat_rules(
     and the full unparsed rule line.
     """
     del params  # declared empty; intentionally ignored
-    proc = await self._run_command(target, "pfctl -sn", raw_jwt="")
+    proc = await self._run_command(target, "pfctl -sn", operator=operator)
     stdout = (proc.stdout or "") if hasattr(proc, "stdout") else ""
     content = stdout if isinstance(stdout, str) else ""
     if proc.exit_status != 0 and not content.strip():
@@ -576,6 +581,7 @@ async def pfsense_interface_list(
     self: PfSenseConnector,
     target: Any,
     params: dict[str, Any],
+    operator: Operator | None = None,
 ) -> dict[str, Any]:
     """Return the pfSense interface list from ``ifconfig -a``.
 
@@ -585,7 +591,7 @@ async def pfsense_interface_list(
     ``status``, and ``media`` fields.
     """
     del params  # declared empty; intentionally ignored
-    proc = await self._run_command(target, "ifconfig -a", raw_jwt="")
+    proc = await self._run_command(target, "ifconfig -a", operator=operator)
     stdout = (proc.stdout or "") if hasattr(proc, "stdout") else ""
     content = stdout if isinstance(stdout, str) else ""
     if proc.exit_status != 0 and not content.strip():
@@ -598,6 +604,7 @@ async def pfsense_gateway_list(
     self: PfSenseConnector,
     target: Any,
     params: dict[str, Any],
+    operator: Operator | None = None,
 ) -> dict[str, Any]:
     """Return the pfSense gateway list from ``/cf/conf/config.xml``.
 
@@ -608,7 +615,7 @@ async def pfsense_gateway_list(
     ``descr``, and ``defaultgw`` (bool).
     """
     del params  # declared empty; intentionally ignored
-    proc = await self._run_command(target, "cat /cf/conf/config.xml", raw_jwt="")
+    proc = await self._run_command(target, "cat /cf/conf/config.xml", operator=operator)
     stdout = (proc.stdout or "") if hasattr(proc, "stdout") else ""
     content = stdout if isinstance(stdout, str) else ""
     if proc.exit_status != 0 and not content.strip():
@@ -625,6 +632,7 @@ async def pfsense_config_show(
     self: PfSenseConnector,
     target: Any,
     params: dict[str, Any],
+    operator: Operator | None = None,
 ) -> dict[str, Any]:
     """Return the full pfSense configuration from ``/cf/conf/config.xml``.
 
@@ -636,7 +644,7 @@ async def pfsense_config_show(
     use ``pfsense.gateway.list`` for structured gateway data.
     """
     del params  # declared empty; intentionally ignored
-    proc = await self._run_command(target, "cat /cf/conf/config.xml", raw_jwt="")
+    proc = await self._run_command(target, "cat /cf/conf/config.xml", operator=operator)
     stdout = (proc.stdout or "") if hasattr(proc, "stdout") else ""
     content = stdout if isinstance(stdout, str) else ""
     if proc.exit_status != 0 and not content.strip():

--- a/backend/tests/_ssh_vault_stub.py
+++ b/backend/tests/_ssh_vault_stub.py
@@ -1,0 +1,59 @@
+# SPDX-License-Identifier: Apache-2.0
+# Copyright (c) 2026 evoila Group
+
+"""Test stub for the SSH adapter's Vault secret resolution (#2155).
+
+``SshConnector._resolve_secret`` resolves ``target.secret_ref`` — a Vault
+KV-v2 **path string** — via an operator-context Vault read
+(``_shared/vault_creds.load_vault_secret_data``). Unit and container
+tests have no Vault; this stub reroutes the resolution to an in-memory
+registry keyed by the path string, preserving the string-shaped
+``secret_ref`` contract end to end. A target carrying the pre-#2155
+anti-shape (an embedded credential dict) fails loudly here, exactly as
+the real loader's precondition guard would.
+"""
+
+from __future__ import annotations
+
+import contextlib
+from collections.abc import Iterator
+from typing import Any
+from unittest.mock import patch
+
+from meho_backplane.connectors._shared.vault_creds import VaultCredentialsReadError
+from meho_backplane.connectors.adapters.ssh import SshConnector
+
+__all__ = ["stub_ssh_vault_secrets"]
+
+
+@contextlib.contextmanager
+def stub_ssh_vault_secrets(
+    secrets: dict[str, dict[str, Any]],
+) -> Iterator[dict[str, dict[str, Any]]]:
+    """Patch ``SshConnector._resolve_secret`` to read from *secrets*.
+
+    *secrets* maps a KV-v2 path string (the value a target carries in
+    ``secret_ref``) to the secret's data dict. Mutating the yielded
+    mapping mid-test is supported — resolution reads it live.
+
+    Raises :class:`VaultCredentialsReadError` from the patched seam for
+    a non-string / empty ``secret_ref`` (the unconfigured-target and
+    anti-shape cases) and for a path with no registered secret, so
+    callers exercise the same error surface the real loader produces.
+    """
+
+    async def _resolve(self: SshConnector, target: Any, operator: Any = None) -> dict[str, Any]:
+        del self, operator  # registry lookup — identity plays no role in tests
+        ref = getattr(target, "secret_ref", None)
+        if not isinstance(ref, str) or not ref:
+            raise VaultCredentialsReadError(
+                f"target {getattr(target, 'name', target)!r} has no usable secret_ref: "
+                f"expected a Vault KV-v2 path string, got {type(ref).__name__}"
+            )
+        data = secrets.get(ref)
+        if data is None:
+            raise VaultCredentialsReadError(f"no stubbed Vault secret registered at {ref!r}")
+        return dict(data)
+
+    with patch.object(SshConnector, "_resolve_secret", _resolve):
+        yield secrets

--- a/backend/tests/integration/test_connectors_bind9_container.py
+++ b/backend/tests/integration/test_connectors_bind9_container.py
@@ -45,11 +45,11 @@ import time
 from collections.abc import Iterator
 from dataclasses import dataclass
 from pathlib import Path
-from typing import Any
 
 import pytest
 
 from meho_backplane.connectors.bind9 import Bind9Connector
+from tests._ssh_vault_stub import stub_ssh_vault_secrets
 
 # ---------------------------------------------------------------------------
 # Docker availability -- mirrors tests/integration/conftest.py heuristic
@@ -76,7 +76,11 @@ class _Bind9Target:
     name: str
     host: str
     port: int | None
-    secret_ref: dict[str, Any]
+    # A Vault KV-v2 path STRING (#2155). This lane has no Vault, so the
+    # autouse ``_container_vault_secrets`` fixture routes
+    # ``SshConnector._resolve_secret`` through an in-memory registry that
+    # returns the container-local credentials.
+    secret_ref: str
     # The SSH connection pool keys on ``target_cache_key`` (``(tenant_id,
     # id)``); a double missing either field raises ``AttributeError`` the
     # moment it reaches the pool. This testcontainers lane is the only one
@@ -88,6 +92,31 @@ class _Bind9Target:
     def __post_init__(self) -> None:
         if not self.id:
             self.id = f"id-{self.name}"
+
+
+#: The container-local root password. The bind9 container's sshd + sudo
+#: both accept it; the write-op tests pass it explicitly to
+#: ``_remote_bash_with_sudo`` and the auth path resolves it from the
+#: stubbed Vault secret.
+_CONTAINER_PASSWORD: str = "testpw"  # NOSONAR -- container-local, torn down per module
+
+#: KV-v2 path the container target carries in ``secret_ref``; the autouse
+#: fixture registers the resolved credential dict under it.
+_CONTAINER_SECRET_PATH: str = "meho/testing/bind9/container"
+
+
+@pytest.fixture(autouse=True)
+def _container_vault_secrets() -> Iterator[None]:
+    """Route ``SshConnector._resolve_secret`` to the container credentials.
+
+    The container lane exercises the real SSH pool but has no Vault; the
+    stub returns the same ``{username, password}`` the pre-#2155 embedded
+    ``secret_ref`` dict carried.
+    """
+    with stub_ssh_vault_secrets(
+        {_CONTAINER_SECRET_PATH: {"username": "root", "password": _CONTAINER_PASSWORD}}
+    ):
+        yield
 
 
 # ---------------------------------------------------------------------------
@@ -231,7 +260,7 @@ def bind9_container_target() -> Iterator[_Bind9Target]:
                 name="bind9-test",
                 host=host,
                 port=port,
-                secret_ref={"username": "root", "password": "testpw"},  # NOSONAR -- container-local
+                secret_ref=_CONTAINER_SECRET_PATH,
             )
             yield target
         finally:
@@ -485,7 +514,7 @@ async def _checksum_bind_tree(connector: Bind9Connector, target: _Bind9Target) -
         "print(h.hexdigest())\n"
     )
     cmd = f"python3 -c {shlex.quote(probe_script)}"
-    proc = await connector._run_command(target, cmd, raw_jwt="")
+    proc = await connector._run_command(target, cmd, operator=None)
     exit_status = getattr(proc, "exit_status", 0)
     stdout = (proc.stdout or "") if hasattr(proc, "stdout") else ""
     digest = stdout.strip() if isinstance(stdout, str) else ""
@@ -634,8 +663,7 @@ async def test_atomic_apply_rollback_on_dig_verify_failure_leaves_tree_unchanged
             await atomic_apply(
                 connector,
                 bind9_container_target,
-                raw_jwt="",
-                sudo_password=str(bind9_container_target.secret_ref["password"]),
+                sudo_password=_CONTAINER_PASSWORD,
                 audit_slice_path="/etc/bind/db.evba.lab",
                 zone_name="evba.lab",
                 # Stage a syntactically valid zonefile so checkzone passes
@@ -699,8 +727,7 @@ async def test_atomic_apply_rollback_on_checkzone_failure_leaves_tree_unchanged(
             await atomic_apply(
                 connector,
                 bind9_container_target,
-                raw_jwt="",
-                sudo_password=str(bind9_container_target.secret_ref["password"]),
+                sudo_password=_CONTAINER_PASSWORD,
                 audit_slice_path="/etc/bind/db.evba.lab",
                 zone_name="evba.lab",
                 # Garbage zonefile -- named-checkzone refuses to load
@@ -783,7 +810,7 @@ async def test_config_backup_against_real_bind9_creates_archive(
         # robust if the path schema ever picks up a wider character
         # class (e.g. tag pattern relaxed in a future op).
         cmd = f"ls -1 {shlex.quote(result['path'])}"
-        proc = await connector._run_command(bind9_container_target, cmd, raw_jwt="")
+        proc = await connector._run_command(bind9_container_target, cmd, operator=None)
         ls_stderr = getattr(proc, "stderr", "")
         assert proc.exit_status == 0, (
             f"backup file missing: ls exit={proc.exit_status} stderr={ls_stderr!r}"
@@ -879,7 +906,7 @@ async def test_config_apply_views_against_real_bind9_lands_multi_file_tree(
         assert "/etc/bind/named.conf.smoke" in result["files"]
         # The fragment we deposited must be on disk -- cat it back.
         cat_proc = await connector._run_command(
-            bind9_container_target, "cat /etc/bind/named.conf.smoke", raw_jwt=""
+            bind9_container_target, "cat /etc/bind/named.conf.smoke"
         )
         assert cat_proc.exit_status == 0
         assert "smoke fragment" in (cat_proc.stdout or "")

--- a/backend/tests/integration/test_g3_4_bind9_e2e.py
+++ b/backend/tests/integration/test_g3_4_bind9_e2e.py
@@ -359,7 +359,7 @@ class _SeededBind9Connector(Bind9Connector):  # type: ignore[misc]
         super().__init__()
         self._test_creds = creds
 
-    async def _auth_config(self, target: Any) -> dict[str, Any]:
+    async def _auth_config(self, target: Any, operator: Any = None) -> dict[str, Any]:
         return {"username": self._test_creds.username, "password": self._test_creds.password}
 
 
@@ -552,14 +552,16 @@ async def bind9_e2e(
     _hr._CONNECTOR_INSTANCE_CACHE[Bind9Connector] = seeded_connector
 
     # Phase 7 — short-circuit the sudo-password resolvers. These are
-    # free functions on the ops_config / ops_record modules; the
-    # production resolver reads `target.secret_ref` as a dict, which
-    # it no longer is. Returning the container's password directly
-    # is the cleanest seam.
+    # module-level async helpers on ops_config / ops_record; the
+    # production resolver reads `target.secret_ref` (a Vault KV-v2 path
+    # string, #2155) via an operator-context Vault read, and this
+    # integration container has no Vault. Returning the container's
+    # password directly is the cleanest seam. The stub mirrors the
+    # production signature: async, ``(connector, target, operator=None)``.
     from meho_backplane.connectors.bind9 import ops_config as _ops_config
     from meho_backplane.connectors.bind9 import ops_record as _ops_record
 
-    def _container_sudo_password(_target: Any) -> str:
+    async def _container_sudo_password(_connector: Any, _target: Any, _operator: Any = None) -> str:
         return creds.password
 
     monkeypatch.setattr(_ops_config, "_sudo_password_for_target", _container_sudo_password)
@@ -729,7 +731,7 @@ async def _checksum_bind_tree(connector: Bind9Connector, target: _Bind9Target) -
         "print(h.hexdigest())\n"
     )
     cmd = f"python3 -c {shlex.quote(probe_script)}"
-    proc = await connector._run_command(target, cmd, raw_jwt="")
+    proc = await connector._run_command(target, cmd)
     exit_status = getattr(proc, "exit_status", 0)
     stdout = (proc.stdout or "") if hasattr(proc, "stdout") else ""
     digest = stdout.strip() if isinstance(stdout, str) else ""

--- a/backend/tests/test_connectors_bind9.py
+++ b/backend/tests/test_connectors_bind9.py
@@ -114,14 +114,16 @@ class _StubTarget:
     name: str
     host: str
     port: int | None
-    secret_ref: dict[str, Any]
+    # A Vault KV-v2 path STRING (#2155). ``_connect`` / ``_run_command``
+    # are mocked in this suite, so the path is never resolved.
+    secret_ref: str
 
 
 _TARGET = _StubTarget(
     name="vcf-router-bind9",
     host="bind9.test.invalid",
     port=22,
-    secret_ref={"username": "root", "password": "irrelevant-for-mocked-tests"},  # NOSONAR
+    secret_ref="meho/testing/bind9/vcf-router-bind9",
 )
 
 
@@ -287,7 +289,6 @@ async def test_remote_bash_with_sudo_argv_holds_byte_count_streams_password_via_
         result = await connector._remote_bash_with_sudo(
             _TARGET,
             script,
-            raw_jwt="jwt",
             sudo_password="super-secret-password",  # NOSONAR
         )
     assert result.exit_status == 0
@@ -355,7 +356,6 @@ async def test_remote_bash_with_sudo_rejects_multiline_password(
         await connector._remote_bash_with_sudo(
             _TARGET,
             "echo body",
-            raw_jwt="jwt",
             sudo_password=injection_shape,
         )
     # Defense-in-depth: validation must run before any wire IO, so the
@@ -380,7 +380,6 @@ async def test_remote_bash_with_sudo_does_not_log_password(
         await connector._remote_bash_with_sudo(
             _TARGET,
             "rndc reload",
-            raw_jwt="jwt",
             sudo_password=secret,
         )
 
@@ -411,7 +410,6 @@ async def test_remote_bash_with_sudo_does_not_log_script_body(
         await connector._remote_bash_with_sudo(
             _TARGET,
             script,
-            raw_jwt="jwt",
             sudo_password="pwd",  # NOSONAR
         )
 
@@ -443,7 +441,7 @@ def test_remote_bash_with_sudo_signature_makes_misordering_unrepresentable() -> 
     # ``sudo_password`` is keyword-only -- the leading ``*,`` enforces
     # this. A caller cannot accidentally swap script and password.
     assert params["sudo_password"].kind == inspect.Parameter.KEYWORD_ONLY
-    assert params["raw_jwt"].kind == inspect.Parameter.KEYWORD_ONLY
+    assert params["operator"].kind == inspect.Parameter.KEYWORD_ONLY
 
 
 def test_sudo_is_only_referenced_via_the_safe_primitive() -> None:

--- a/backend/tests/test_connectors_bind9_atomic.py
+++ b/backend/tests/test_connectors_bind9_atomic.py
@@ -58,6 +58,7 @@ from meho_backplane.connectors.bind9.ops_record import (
     resolve_zone_for_fqdn,
 )
 from meho_backplane.settings import get_settings
+from tests._ssh_vault_stub import stub_ssh_vault_secrets
 
 # ---------------------------------------------------------------------------
 # Env fixture -- mirrors test_connectors_bind9.py
@@ -76,7 +77,20 @@ def _required_settings_env(monkeypatch: pytest.MonkeyPatch) -> Iterator[None]:
 
 # ---------------------------------------------------------------------------
 # Stub target + completed-process helper
+#
+# ``secret_ref`` is a Vault KV-v2 path STRING (#2155). The record-write
+# handlers resolve the sudo password through
+# ``SshConnector._resolve_secret``, which the autouse ``_vault_secrets``
+# fixture routes through the in-memory registry below.
 # ---------------------------------------------------------------------------
+
+_VAULT_SECRETS: dict[str, dict[str, Any]] = {}
+
+
+@pytest.fixture(autouse=True)
+def _vault_secrets() -> Iterator[None]:
+    with stub_ssh_vault_secrets(_VAULT_SECRETS):
+        yield
 
 
 @dataclass
@@ -84,14 +98,22 @@ class _StubTarget:
     name: str
     host: str
     port: int | None
-    secret_ref: dict[str, Any]
+    # A Vault KV-v2 path STRING (#2155) — resolved through the stubbed
+    # ``_resolve_secret`` seam against the module registry.
+    secret_ref: str
 
 
-_TARGET = _StubTarget(
-    name="bind9-test",
+def _target_with_secret(name: str, secret: dict[str, Any], *, host: str, port: int | None) -> Any:
+    secret_path = f"meho/testing/bind9/{name}"
+    _VAULT_SECRETS[secret_path] = secret
+    return _StubTarget(name=name, host=host, port=port, secret_ref=secret_path)
+
+
+_TARGET = _target_with_secret(
+    "bind9-atomic",
+    {"username": "root", "password": "test-sudo-pwd"},  # NOSONAR -- unit-test stub
     host="bind9.test.invalid",
     port=22,
-    secret_ref={"username": "root", "password": "test-sudo-pwd"},  # NOSONAR -- unit-test stub
 )
 
 
@@ -817,7 +839,6 @@ class TestAtomicApplyStageFailureBranch:
             await atomic_apply(
                 connector,
                 _TARGET,
-                raw_jwt="",
                 sudo_password="pw",  # NOSONAR
                 audit_slice_path="/etc/bind/db.evba.lab",
                 zone_name="evba.lab",
@@ -1036,7 +1057,6 @@ class TestAtomicApplySuccessPath:
             result = await atomic_apply(
                 connector,
                 _TARGET,
-                raw_jwt="",
                 sudo_password="pw",  # NOSONAR -- unit test
                 audit_slice_path="/etc/bind/db.evba.lab",
                 zone_name="evba.lab",
@@ -1068,7 +1088,6 @@ class TestAtomicApplySuccessPath:
             await atomic_apply(
                 connector,
                 _TARGET,
-                raw_jwt="",
                 sudo_password="pw",  # NOSONAR
                 audit_slice_path="/etc/bind/db.evba.lab",
                 zone_name="evba.lab",
@@ -1100,7 +1119,6 @@ class TestAtomicApplySuccessPath:
             await atomic_apply(
                 connector,
                 _TARGET,
-                raw_jwt="",
                 sudo_password="pw",  # NOSONAR
                 audit_slice_path="/etc/bind/db.evba.lab",
                 zone_name="evba.lab",
@@ -1149,7 +1167,6 @@ class TestAtomicApplyRollbackBranches:
             await atomic_apply(
                 connector,
                 _TARGET,
-                raw_jwt="",
                 sudo_password="pw",  # NOSONAR
                 audit_slice_path="/etc/bind/db.evba.lab",
                 zone_name="evba.lab",
@@ -1181,7 +1198,6 @@ class TestAtomicApplyRollbackBranches:
             await atomic_apply(
                 connector,
                 _TARGET,
-                raw_jwt="",
                 sudo_password="pw",  # NOSONAR
                 audit_slice_path="/etc/bind/db.evba.lab",
                 zone_name="evba.lab",
@@ -1212,7 +1228,6 @@ class TestAtomicApplyRollbackBranches:
             await atomic_apply(
                 connector,
                 _TARGET,
-                raw_jwt="",
                 sudo_password="pw",  # NOSONAR
                 audit_slice_path="/etc/bind/db.evba.lab",
                 zone_name="evba.lab",
@@ -1440,12 +1455,9 @@ class TestRecordAddHandler:
 
     async def test_target_without_password_rejects(self) -> None:
         connector = Bind9Connector()
-        bad_target = _StubTarget(
-            name="t",
-            host="h",
-            port=22,
-            secret_ref={"username": "root"},  # no password
-        )
+        bad_target = _target_with_secret(
+            "no-password", {"username": "root"}, host="h", port=22
+        )  # no password in the resolved secret
         with (
             patch.object(connector, "_run_command", AsyncMock()),
             pytest.raises(ValueError, match="sudo_password"),

--- a/backend/tests/test_connectors_bind9_config.py
+++ b/backend/tests/test_connectors_bind9_config.py
@@ -68,6 +68,7 @@ from meho_backplane.connectors.bind9.ops_config import (
 )
 from meho_backplane.connectors.schemas import FingerprintResult
 from meho_backplane.settings import get_settings
+from tests._ssh_vault_stub import stub_ssh_vault_secrets
 
 # ---------------------------------------------------------------------------
 # Env fixture -- mirrors test_connectors_bind9_atomic.py
@@ -86,7 +87,20 @@ def _required_settings_env(monkeypatch: pytest.MonkeyPatch) -> Iterator[None]:
 
 # ---------------------------------------------------------------------------
 # Stub target + completed-process helper
+#
+# ``secret_ref`` is a Vault KV-v2 path STRING (#2155). The sudo-password
+# path resolves it through ``SshConnector._resolve_secret``, which the
+# autouse ``_vault_secrets`` fixture routes through the in-memory
+# registry below.
 # ---------------------------------------------------------------------------
+
+_VAULT_SECRETS: dict[str, dict[str, Any]] = {}
+
+
+@pytest.fixture(autouse=True)
+def _vault_secrets() -> Iterator[None]:
+    with stub_ssh_vault_secrets(_VAULT_SECRETS):
+        yield
 
 
 @dataclass
@@ -94,14 +108,22 @@ class _StubTarget:
     name: str
     host: str
     port: int | None
-    secret_ref: dict[str, Any]
+    # A Vault KV-v2 path STRING (#2155) — resolved through the stubbed
+    # ``_resolve_secret`` seam against the module registry.
+    secret_ref: str
 
 
-_TARGET = _StubTarget(
-    name="bind9-test",
+def _target_with_secret(name: str, secret: dict[str, Any], *, host: str, port: int | None) -> Any:
+    secret_path = f"meho/testing/bind9/{name}"
+    _VAULT_SECRETS[secret_path] = secret
+    return _StubTarget(name=name, host=host, port=port, secret_ref=secret_path)
+
+
+_TARGET = _target_with_secret(
+    "bind9-test",
+    {"username": "root", "password": "test-sudo-pwd"},  # NOSONAR -- unit-test stub
     host="bind9.test.invalid",
     port=22,
-    secret_ref={"username": "root", "password": "test-sudo-pwd"},  # NOSONAR -- unit-test stub
 )
 
 
@@ -330,11 +352,8 @@ class TestApplyFile:
     async def test_missing_sudo_password_raises(self) -> None:
         """target with no password -> ValueError, no remote IO."""
         connector = Bind9Connector()
-        bare_target = _StubTarget(
-            name="bare",
-            host="bare.invalid",
-            port=22,
-            secret_ref={"username": "root"},
+        bare_target = _target_with_secret(
+            "bare", {"username": "root"}, host="bare.invalid", port=22
         )
         with (
             patch.object(

--- a/backend/tests/test_connectors_bind9_reads.py
+++ b/backend/tests/test_connectors_bind9_reads.py
@@ -91,14 +91,16 @@ class _StubTarget:
     name: str
     host: str
     port: int | None
-    secret_ref: dict[str, Any]
+    # A Vault KV-v2 path STRING (#2155) — resolved through the stubbed
+    # ``_resolve_secret`` seam against the module registry.
+    secret_ref: str
 
 
 _TARGET = _StubTarget(
     name="bind9-test",
     host="bind9.test.invalid",
     port=22,
-    secret_ref={"username": "root", "password": "irrelevant"},  # NOSONAR
+    secret_ref="meho/testing/bind9/bind9-reads",
 )
 
 

--- a/backend/tests/test_connectors_holodeck_auth.py
+++ b/backend/tests/test_connectors_holodeck_auth.py
@@ -60,6 +60,7 @@ from meho_backplane.connectors.holodeck._pwsh import PwshRunError
 from meho_backplane.connectors.holodeck.connector import parse_photon_version
 from meho_backplane.connectors.registry import clear_registry
 from meho_backplane.settings import get_settings
+from tests._ssh_vault_stub import stub_ssh_vault_secrets
 
 # ---------------------------------------------------------------------------
 # Environment fixtures
@@ -87,7 +88,9 @@ class _StubTarget:
     name: str
     host: str
     port: int | None
-    secret_ref: dict[str, Any]
+    # A Vault KV-v2 path STRING (#2155) — resolved through the stubbed
+    # ``_resolve_secret`` seam against the module registry below.
+    secret_ref: str
     # The SSH connection pool keys on ``target_cache_key`` (``(tenant_id,
     # id)``); a double missing either field hits ``AttributeError`` at the
     # pool (evoila/meho#1682). ``id`` defaults off ``name`` so distinct
@@ -98,6 +101,18 @@ class _StubTarget:
     def __post_init__(self) -> None:
         if not self.id:
             self.id = f"id-{self.name}"
+
+
+#: Path → secret-data registry the autouse ``_vault_secrets`` fixture
+#: routes ``SshConnector._resolve_secret`` through.
+_VAULT_SECRETS: dict[str, dict[str, Any]] = {}
+
+
+@pytest.fixture(autouse=True)
+def _vault_secrets() -> Iterator[None]:
+    _VAULT_SECRETS.clear()
+    with stub_ssh_vault_secrets(_VAULT_SECRETS):
+        yield
 
 
 # Canary credentials the secret-leak assertions key on. The fake
@@ -112,31 +127,27 @@ _FAKE_KEY_FOOTER = "-----END " + "OPENSSH PRIVATE KEY" + "-----"
 _CANARY_PRIVATE_KEY = f"{_FAKE_KEY_HEADER}\nFAKE-CANARY-KEY-BODY\n{_FAKE_KEY_FOOTER}\n"
 
 
-def _password_target(name: str = "holorouter-pw") -> _StubTarget:
+def _target_with_secret(name: str, secret: dict[str, Any]) -> _StubTarget:
+    secret_path = f"meho/testing/holodeck/{name}"
+    _VAULT_SECRETS[secret_path] = secret
     return _StubTarget(
         name=name,
         host=f"{name}.test.invalid",
         port=22,
-        secret_ref={"username": "root", "password": _CANARY_PASSWORD},
+        secret_ref=secret_path,
     )
+
+
+def _password_target(name: str = "holorouter-pw") -> _StubTarget:
+    return _target_with_secret(name, {"username": "root", "password": _CANARY_PASSWORD})
 
 
 def _key_target(name: str = "holorouter-key") -> _StubTarget:
-    return _StubTarget(
-        name=name,
-        host=f"{name}.test.invalid",
-        port=22,
-        secret_ref={"username": "root", "ssh_private_key": _CANARY_PRIVATE_KEY},
-    )
+    return _target_with_secret(name, {"username": "root", "ssh_private_key": _CANARY_PRIVATE_KEY})
 
 
 def _no_cred_target(name: str = "holorouter-empty") -> _StubTarget:
-    return _StubTarget(
-        name=name,
-        host=f"{name}.test.invalid",
-        port=22,
-        secret_ref={"username": "root"},
-    )
+    return _target_with_secret(name, {"username": "root"})
 
 
 def _completed_process(*, stdout: str = "", stderr: str = "", exit_status: int = 0) -> Any:
@@ -262,7 +273,9 @@ async def test_auth_config_key_preferred_when_present() -> None:
     stub_key = MagicMock(name="stub-private-key")
     with patch("asyncssh.import_private_key", return_value=stub_key) as imp:
         auth = await connector._auth_config(_key_target())
-    imp.assert_called_once_with(_CANARY_PRIVATE_KEY)
+    # ``strip_credential_value`` trims the surrounding whitespace before
+    # the key reaches asyncssh (#1474); internal newlines are preserved.
+    imp.assert_called_once_with(_CANARY_PRIVATE_KEY.strip())
     assert auth == {"username": "root", "client_keys": [stub_key]}
     assert "password" not in auth
 
@@ -288,8 +301,8 @@ async def test_per_target_connection_isolation() -> None:
     target_a = _password_target("holorouter-a")
     target_b = _password_target("holorouter-b")
     with patch("asyncssh.connect", new=AsyncMock(side_effect=[conn_a, conn_b])):
-        a = await connector._connect(target_a, raw_jwt="")
-        b = await connector._connect(target_b, raw_jwt="")
+        a = await connector._connect(target_a)
+        b = await connector._connect(target_b)
     assert a is conn_a
     assert b is conn_b
     assert a is not b

--- a/backend/tests/test_connectors_holodeck_e2e.py
+++ b/backend/tests/test_connectors_holodeck_e2e.py
@@ -445,7 +445,7 @@ def _wire_seeded_connector(host: str, port: int) -> HolodeckConnector:
     class _SeededHolodeckConnector(HolodeckConnector):  # type: ignore[misc]
         """Subclass that injects the test client key into _auth_config."""
 
-        async def _auth_config(self, target: Any) -> dict[str, Any]:
+        async def _auth_config(self, target: Any, operator: Any = None) -> dict[str, Any]:
             return {
                 "username": "root",
                 "client_keys": [_CLIENT_KEY],

--- a/backend/tests/test_connectors_holodeck_ops.py
+++ b/backend/tests/test_connectors_holodeck_ops.py
@@ -68,6 +68,7 @@ from meho_backplane.connectors.holodeck.ops_read import (
     parse_networking_payload,
 )
 from meho_backplane.settings import get_settings
+from tests._ssh_vault_stub import stub_ssh_vault_secrets
 
 # ---------------------------------------------------------------------------
 # Environment fixture (settings cache requires the env vars to resolve)
@@ -102,19 +103,35 @@ class _StubTarget:
     name: str
     host: str
     port: int | None
-    secret_ref: dict[str, Any]
+    # A Vault KV-v2 path STRING (#2155). The canary credentials live in
+    # the stubbed Vault registry (see ``_vault_secrets`` below), so any
+    # code path that actually resolves the secret would surface the
+    # canaries — which the leak assertions then catch.
+    secret_ref: str
 
+
+_TARGET_SECRET_PATH = "meho/testing/holodeck/holorouter-test"
 
 _TARGET = _StubTarget(
     name="holorouter-test",
     host="holorouter.test.invalid",
     port=22,
-    secret_ref={
-        "username": "root",
-        "password": _CANARY_PASSWORD,
-        "ssh_private_key": _CANARY_SSH_KEY,
-    },
+    secret_ref=_TARGET_SECRET_PATH,
 )
+
+
+@pytest.fixture(autouse=True)
+def _vault_secrets() -> Iterator[None]:
+    with stub_ssh_vault_secrets(
+        {
+            _TARGET_SECRET_PATH: {
+                "username": "root",
+                "password": _CANARY_PASSWORD,
+                "ssh_private_key": _CANARY_SSH_KEY,
+            }
+        }
+    ):
+        yield
 
 
 def _proc(*, stdout: str = "", stderr: str = "", exit_status: int = 0) -> Any:
@@ -783,14 +800,20 @@ async def test_k8s_exec_truncates_long_stderr_at_4096_chars() -> None:
 
 
 @pytest.mark.asyncio
-async def test_k8s_exec_returns_envelope_on_ssh_failure() -> None:
-    """SSH connect/run exceptions land in the ``error`` field, not propagated."""
+async def test_k8s_exec_propagates_ssh_failure_as_connector_error() -> None:
+    """SSH connect/run exceptions propagate to the dispatcher (#2155 AC).
+
+    The pre-#2155 handler swallowed auth/transport failures into a
+    ``status="ok"`` envelope with empty stdout and ``result.error`` — an
+    agent reading ``status=ok`` would act on hollow output. The handler
+    now lets the exception escape so the dispatcher's ``connector_error``
+    branch reports a non-ok op, mirroring ``holodeck.about``.
+    """
     connector = HolodeckConnector()
     with patch.object(connector, "_run_command", new_callable=AsyncMock) as mock_cmd:
         mock_cmd.side_effect = OSError("connection refused")
-        result = await connector.k8s_exec(_TARGET, {"command": "kubectl get pods"})
-    assert result["exit_status"] is None
-    assert "connection refused" in result["error"]
+        with pytest.raises(OSError, match="connection refused"):
+            await connector.k8s_exec(_TARGET, {"command": "kubectl get pods"})
 
 
 # ---------------------------------------------------------------------------

--- a/backend/tests/test_connectors_holodeck_pwsh.py
+++ b/backend/tests/test_connectors_holodeck_pwsh.py
@@ -73,18 +73,17 @@ class _StubTarget:
     name: str
     host: str
     port: int | None
-    secret_ref: dict[str, Any]
+    # A Vault KV-v2 path STRING (#2155). The connector in this suite is
+    # a MagicMock, so the path is never resolved — it exists to keep the
+    # target shape contract-honest.
+    secret_ref: str
 
 
 _TARGET = _StubTarget(
     name="holorouter-lab",
     host="holorouter.test.invalid",
     port=22,
-    secret_ref={
-        "username": "root",
-        # Canary password the secret-leak assertions key on.
-        "password": "holodeck-canary-password-xyz",  # NOSONAR
-    },
+    secret_ref="meho/testing/holodeck/holorouter-lab",
 )
 
 
@@ -205,8 +204,10 @@ async def test_pwsh_run_calls_run_command_with_encoded_command_argv() -> None:
     assert target_arg is _TARGET
     expected_encoded = encode_pwsh_command(script)
     assert cmd_arg == (f"pwsh -NoProfile -NonInteractive -EncodedCommand {expected_encoded}")
-    # raw_jwt / timeout are forwarded as kwargs.
-    assert kwargs.get("raw_jwt") == ""
+    # operator / timeout are forwarded as kwargs; no operator threaded
+    # here, so the helper forwards None (fails closed at Vault in prod).
+    assert "operator" in kwargs
+    assert kwargs.get("operator") is None
     assert "timeout" in kwargs
 
 

--- a/backend/tests/test_connectors_holodeck_write.py
+++ b/backend/tests/test_connectors_holodeck_write.py
@@ -85,14 +85,16 @@ class _StubTarget:
     name: str
     host: str
     port: int | None
-    secret_ref: dict[str, Any]
+    # A Vault KV-v2 path STRING (#2155). The unit-level handler tests
+    # patch ``_run_command``, so the path is never resolved.
+    secret_ref: str
 
 
 _TARGET = _StubTarget(
     name="holorouter-write-test",
     host="holorouter.test.invalid",
     port=22,
-    secret_ref={"username": "root", "password": "write-canary-pw"},  # NOSONAR canary
+    secret_ref="meho/testing/holodeck/holorouter-write-test",
 )
 
 
@@ -457,7 +459,7 @@ async def _seed_target(host: str, port: int) -> TargetORM:
 
 def _wire_seeded_connector() -> HolodeckConnector:
     class _SeededHolodeckConnector(HolodeckConnector):  # type: ignore[misc]
-        async def _auth_config(self, target: Any) -> dict[str, Any]:
+        async def _auth_config(self, target: Any, operator: Any = None) -> dict[str, Any]:
             return {"username": "root", "client_keys": [_CLIENT_KEY], "known_hosts": None}
 
     instance = _SeededHolodeckConnector()

--- a/backend/tests/test_connectors_pfsense_auth.py
+++ b/backend/tests/test_connectors_pfsense_auth.py
@@ -55,6 +55,7 @@ from meho_backplane.connectors.pfsense import PFSENSE_OPS, PfSenseConnector
 from meho_backplane.connectors.pfsense.connector import parse_pfsense_version
 from meho_backplane.connectors.registry import clear_registry, register_connector_v2
 from meho_backplane.settings import get_settings
+from tests._ssh_vault_stub import stub_ssh_vault_secrets
 
 # ---------------------------------------------------------------------------
 # Environment + registry fixtures
@@ -82,7 +83,9 @@ class _StubTarget:
     name: str
     host: str
     port: int | None
-    secret_ref: dict[str, Any]
+    # A Vault KV-v2 path STRING (#2155) — resolved through the stubbed
+    # ``_resolve_secret`` seam against the module registry below.
+    secret_ref: str
     # The SSH connection pool keys on ``target_cache_key`` (``(tenant_id,
     # id)``); a double missing either field hits ``AttributeError`` at the
     # pool (evoila/meho#1682). ``id`` defaults off ``name`` so distinct
@@ -95,32 +98,42 @@ class _StubTarget:
             self.id = f"id-{self.name}"
 
 
-_KEY_TARGET = _StubTarget(
-    name="pfsense-lab",
-    host="pfsense.test.invalid",
-    port=22,
-    secret_ref={
-        "username": "admin",
-        "ssh_private_key": None,  # replaced per-test with a real key
-    },
-)
+#: Path → secret-data registry the autouse ``_vault_secrets`` fixture
+#: routes ``SshConnector._resolve_secret`` through. Populated at module
+#: definition (for the shared targets below) and by ``_target_with_secret``
+#: inside tests; never cleared per-test so module-level targets stay
+#: resolvable.
+_VAULT_SECRETS: dict[str, dict[str, Any]] = {}
 
-_PASSWORD_ONLY_TARGET = _StubTarget(
-    name="pfsense-password-only",
-    host="pfsense.test.invalid",
-    port=22,
-    secret_ref={
+
+@pytest.fixture(autouse=True)
+def _vault_secrets() -> Iterator[None]:
+    with stub_ssh_vault_secrets(_VAULT_SECRETS):
+        yield
+
+
+def _target_with_secret(
+    name: str, secret: dict[str, Any], *, host: str | None = None, port: int | None = 22
+) -> _StubTarget:
+    secret_path = f"meho/testing/pfsense/{name}"
+    _VAULT_SECRETS[secret_path] = secret
+    return _StubTarget(
+        name=name,
+        host=host if host is not None else "pfsense.test.invalid",
+        port=port,
+        secret_ref=secret_path,
+    )
+
+
+_PASSWORD_ONLY_TARGET = _target_with_secret(
+    "pfsense-password-only",
+    {
         "username": "admin",
         "password": "webgui-breakglass",  # NOSONAR -- test only
     },
 )
 
-_NO_CREDS_TARGET = _StubTarget(
-    name="pfsense-no-creds",
-    host="pfsense.test.invalid",
-    port=22,
-    secret_ref={"username": "admin"},
-)
+_NO_CREDS_TARGET = _target_with_secret("pfsense-no-creds", {"username": "admin"})
 
 
 def _completed_process(stdout: str = "", exit_status: int = 0) -> Any:
@@ -206,12 +219,7 @@ async def test_auth_config_key_auth_returns_client_keys() -> None:
     private_key = asyncssh.generate_private_key("ssh-ed25519")
     pem = private_key.export_private_key().decode()
 
-    target = _StubTarget(
-        name="pfsense-key",
-        host="pfsense.test.invalid",
-        port=22,
-        secret_ref={"username": "admin", "ssh_private_key": pem},
-    )
+    target = _target_with_secret("pfsense-key", {"username": "admin", "ssh_private_key": pem})
     connector = PfSenseConnector()
     auth = await connector._auth_config(target)
     assert auth["username"] == "admin"
@@ -249,12 +257,9 @@ async def test_auth_config_defaults_username_to_admin() -> None:
     private_key = asyncssh.generate_private_key("ssh-ed25519")
     pem = private_key.export_private_key().decode()
 
-    target = _StubTarget(
-        name="pfsense-no-user",
-        host="pfsense.test.invalid",
-        port=None,
-        secret_ref={"ssh_private_key": pem},  # no "username"
-    )
+    target = _target_with_secret(
+        "pfsense-no-user", {"ssh_private_key": pem}, port=None
+    )  # no "username" in the secret
     connector = PfSenseConnector()
     auth = await connector._auth_config(target)
     assert auth["username"] == "admin"
@@ -322,12 +327,7 @@ async def test_fingerprint_parses_canonical_etc_version() -> None:
     """``/etc/version`` with version+build+kernel → canonical FingerprintResult."""
     private_key = asyncssh.generate_private_key("ssh-ed25519")
     pem = private_key.export_private_key().decode()
-    target = _StubTarget(
-        name="pfsense-fp",
-        host="pfsense.test.invalid",
-        port=22,
-        secret_ref={"username": "admin", "ssh_private_key": pem},
-    )
+    target = _target_with_secret("pfsense-fp", {"username": "admin", "ssh_private_key": pem})
 
     connector = PfSenseConnector()
     run_mock = AsyncMock(
@@ -347,11 +347,10 @@ async def test_fingerprint_parses_canonical_etc_version() -> None:
 
 async def test_fingerprint_unreachable_on_os_error() -> None:
     """``OSError`` from ``_run_command`` → ``reachable=False`` + ``extras["error"]``."""
-    target = _StubTarget(
-        name="pfsense-unreachable",
+    target = _target_with_secret(
+        "pfsense-unreachable",
+        {"username": "admin", "ssh_private_key": "fake"},
         host="dead.test.invalid",
-        port=22,
-        secret_ref={"username": "admin", "ssh_private_key": "fake"},
     )
     connector = PfSenseConnector()
     with patch.object(
@@ -370,11 +369,10 @@ async def test_fingerprint_unreachable_on_os_error() -> None:
 
 async def test_fingerprint_unreachable_on_ssh_error() -> None:
     """``asyncssh.Error`` from ``_run_command`` → ``reachable=False``."""
-    target = _StubTarget(
-        name="pfsense-ssh-error",
+    target = _target_with_secret(
+        "pfsense-ssh-error",
+        {"username": "admin", "ssh_private_key": "fake"},
         host="broken.test.invalid",
-        port=22,
-        secret_ref={"username": "admin", "ssh_private_key": "fake"},
     )
     connector = PfSenseConnector()
     perm_denied = asyncssh.PermissionDenied(reason="publickey auth failed")
@@ -600,17 +598,11 @@ async def test_per_target_connection_isolation() -> None:
     private_key = asyncssh.generate_private_key("ssh-ed25519")
     pem = private_key.export_private_key().decode()
 
-    target_a = _StubTarget(
-        name="pfsense-a",
-        host="pfsense-a.test.invalid",
-        port=22,
-        secret_ref={"username": "admin", "ssh_private_key": pem},
+    target_a = _target_with_secret(
+        "pfsense-a", {"username": "admin", "ssh_private_key": pem}, host="pfsense-a.test.invalid"
     )
-    target_b = _StubTarget(
-        name="pfsense-b",
-        host="pfsense-b.test.invalid",
-        port=22,
-        secret_ref={"username": "admin", "ssh_private_key": pem},
+    target_b = _target_with_secret(
+        "pfsense-b", {"username": "admin", "ssh_private_key": pem}, host="pfsense-b.test.invalid"
     )
 
     conn_a = MagicMock(name="conn_a")
@@ -638,8 +630,8 @@ async def test_per_target_connection_isolation() -> None:
             AsyncMock(return_value={"username": "admin", "client_keys": []}),
         ),
     ):
-        got_a = await connector._connect(target_a, raw_jwt="")
-        got_b = await connector._connect(target_b, raw_jwt="")
+        got_a = await connector._connect(target_a)
+        got_b = await connector._connect(target_b)
 
     assert got_a is conn_a
     assert got_b is conn_b

--- a/backend/tests/test_connectors_pfsense_e2e.py
+++ b/backend/tests/test_connectors_pfsense_e2e.py
@@ -324,7 +324,7 @@ def _wire_seeded_connector(host: str, port: int) -> PfSenseConnector:
     class _SeededPfSenseConnector(PfSenseConnector):  # type: ignore[misc]
         """Subclass that injects the test client key into _auth_config."""
 
-        async def _auth_config(self, target: Any) -> dict[str, Any]:
+        async def _auth_config(self, target: Any, operator: Any = None) -> dict[str, Any]:
             return {
                 "username": "admin",
                 "client_keys": [_CLIENT_KEY],

--- a/backend/tests/test_connectors_pfsense_ops.py
+++ b/backend/tests/test_connectors_pfsense_ops.py
@@ -84,14 +84,16 @@ class _StubTarget:
     name: str
     host: str
     port: int | None
-    secret_ref: dict[str, Any]
+    # A Vault KV-v2 path STRING (#2155). ``_run_command`` is mocked in
+    # this suite, so the path is never resolved.
+    secret_ref: str
 
 
 _TARGET = _StubTarget(
     name="pfsense-test",
     host="pfsense.test.invalid",
     port=22,
-    secret_ref={"username": "admin", "ssh_private_key": "dummy-key"},
+    secret_ref="meho/testing/pfsense/pfsense-test",
 )
 
 
@@ -443,7 +445,7 @@ async def test_pfsense_version_returns_structured_version() -> None:
     with patch.object(connector, "_run_command", new_callable=AsyncMock) as mock_cmd:
         mock_cmd.return_value = _proc(version_content)
         result = await connector.get_version(_TARGET, {})
-    mock_cmd.assert_awaited_once_with(_TARGET, "cat /etc/version", raw_jwt="")
+    mock_cmd.assert_awaited_once_with(_TARGET, "cat /etc/version", operator=None)
     assert result["version"] == "2.7.2-RELEASE"
     assert result["kernel"] == "FreeBSD 14.1-RELEASE-p5"
     assert "error" not in result or result.get("error") is None
@@ -471,7 +473,7 @@ async def test_pfsense_firewall_rules_runs_pfctl_sr() -> None:
     with patch.object(connector, "_run_command", new_callable=AsyncMock) as mock_cmd:
         mock_cmd.return_value = _proc(pfctl_output)
         result = await connector.firewall_rules(_TARGET, {})
-    mock_cmd.assert_awaited_once_with(_TARGET, "pfctl -sr", raw_jwt="")
+    mock_cmd.assert_awaited_once_with(_TARGET, "pfctl -sr", operator=None)
     assert result["total"] == 2
     assert result["rows"][0]["action"] == "pass"
     assert result["rows"][1]["action"] == "block"
@@ -503,7 +505,7 @@ async def test_pfsense_firewall_state_runs_pfctl_ss() -> None:
     with patch.object(connector, "_run_command", new_callable=AsyncMock) as mock_cmd:
         mock_cmd.return_value = _proc(state_output)
         result = await connector.firewall_state(_TARGET, {})
-    mock_cmd.assert_awaited_once_with(_TARGET, "pfctl -ss", raw_jwt="")
+    mock_cmd.assert_awaited_once_with(_TARGET, "pfctl -ss", operator=None)
     assert result["total"] == 2
     assert result["rows"][0]["proto"] == "tcp"
     assert result["rows"][1]["proto"] == "udp"
@@ -532,7 +534,7 @@ async def test_pfsense_nat_rules_runs_pfctl_sn() -> None:
     with patch.object(connector, "_run_command", new_callable=AsyncMock) as mock_cmd:
         mock_cmd.return_value = _proc(nat_output)
         result = await connector.nat_rules(_TARGET, {})
-    mock_cmd.assert_awaited_once_with(_TARGET, "pfctl -sn", raw_jwt="")
+    mock_cmd.assert_awaited_once_with(_TARGET, "pfctl -sn", operator=None)
     assert result["total"] == 1
     assert result["rows"][0]["action"] == "nat"
 
@@ -548,7 +550,7 @@ async def test_pfsense_interface_list_runs_ifconfig_a() -> None:
     with patch.object(connector, "_run_command", new_callable=AsyncMock) as mock_cmd:
         mock_cmd.return_value = _proc(_IFCONFIG_SAMPLE)
         result = await connector.interface_list(_TARGET, {})
-    mock_cmd.assert_awaited_once_with(_TARGET, "ifconfig -a", raw_jwt="")
+    mock_cmd.assert_awaited_once_with(_TARGET, "ifconfig -a", operator=None)
     assert result["total"] == 2
     names = [r["name"] for r in result["rows"]]
     assert "em0" in names
@@ -576,7 +578,7 @@ async def test_pfsense_gateway_list_reads_config_xml() -> None:
     with patch.object(connector, "_run_command", new_callable=AsyncMock) as mock_cmd:
         mock_cmd.return_value = _proc(_CONFIG_XML_WITH_GATEWAYS)
         result = await connector.gateway_list(_TARGET, {})
-    mock_cmd.assert_awaited_once_with(_TARGET, "cat /cf/conf/config.xml", raw_jwt="")
+    mock_cmd.assert_awaited_once_with(_TARGET, "cat /cf/conf/config.xml", operator=None)
     assert result["total"] == 2
     names = [r["name"] for r in result["rows"]]
     assert "WAN_DHCP" in names
@@ -604,7 +606,7 @@ async def test_pfsense_config_show_returns_xml_and_length() -> None:
     with patch.object(connector, "_run_command", new_callable=AsyncMock) as mock_cmd:
         mock_cmd.return_value = _proc(xml_content)
         result = await connector.config_show(_TARGET, {})
-    mock_cmd.assert_awaited_once_with(_TARGET, "cat /cf/conf/config.xml", raw_jwt="")
+    mock_cmd.assert_awaited_once_with(_TARGET, "cat /cf/conf/config.xml", operator=None)
     assert result["config_xml"] == xml_content
     assert result["length"] == len(xml_content)
 

--- a/backend/tests/test_connectors_ssh_adapter.py
+++ b/backend/tests/test_connectors_ssh_adapter.py
@@ -3,21 +3,30 @@
 
 """Tests for SshConnector adapter (G0.2-T4).
 
-Coverage matrix (per Task #243 acceptance criteria + review findings):
+Coverage matrix (per Task #243 acceptance criteria + review findings,
+extended by #2155's Vault-path ``secret_ref`` contract):
 
 * ``SshConnector`` class exists and is importable from the adapters package.
 * Abstract class cannot be instantiated directly (ABC enforcement).
 * A concrete subclass with all three ABC methods can connect and execute
-  commands against an in-process asyncssh server.
+  commands against an in-process asyncssh server — with ``secret_ref``
+  carrying a Vault KV-v2 **path string** resolved through the
+  ``_resolve_secret`` seam (#2155; the embedded-dict shape is the
+  bind9 anti-shape and is rejected).
 * Per-target connection pool: same ``target.name`` reuses the same
   connection object; different names get distinct connections.
 * Idle TTL eviction: connection idle past ``_POOL_TTL_S`` is replaced on
   next ``_connect`` call.
-* Key auth path: ``target.secret_ref`` with ``ssh_private_key`` uses the
-  private key for authentication.
-* Password auth path: ``target.secret_ref`` with ``password`` (no
+* Key auth path: the resolved Vault secret with ``ssh_private_key`` uses
+  the private key for authentication.
+* Password auth path: the resolved Vault secret with ``password`` (no
   ``ssh_private_key``) uses password authentication as fallback.
 * Missing credentials: ``_auth_config`` raises ``ValueError`` immediately.
+* Dict-shaped ``secret_ref`` (the pre-#2155 anti-shape) fails with
+  ``VaultCredentialsReadError`` — never ``AttributeError``.
+* ``_resolve_secret`` routes through ``load_vault_secret_data`` with the
+  threaded operator, and falls back to the synthesised system operator
+  (fail-closed at Vault) when no operator is threaded.
 * Connection failure (wrong host / refused port) surfaces as a
   connect-time error from ``_connect``, not a command-time error.
 * Command timeout: ``_run_command(..., timeout=N)`` raises
@@ -32,12 +41,15 @@ from __future__ import annotations
 import asyncio
 import time
 import types
+from collections.abc import Iterator
 from typing import Any
 from unittest.mock import MagicMock, patch
 
 import asyncssh
 import pytest
 
+from meho_backplane.connectors._shared.system_operator import SYSTEM_OPERATOR_SUB
+from meho_backplane.connectors._shared.vault_creds import VaultCredentialsReadError
 from meho_backplane.connectors.adapters import SshConnector
 from meho_backplane.connectors.adapters.ssh import _POOL_TTL_S
 from meho_backplane.connectors.adapters.ssh import SshConnector as _SshConnectorDirect
@@ -46,6 +58,7 @@ from meho_backplane.connectors.schemas import (
     OperationResult,
     ProbeResult,
 )
+from tests._ssh_vault_stub import stub_ssh_vault_secrets
 
 # ---------------------------------------------------------------------------
 # Shared key material (generated once per test session)
@@ -112,7 +125,22 @@ async def ssh_server() -> Any:
 
 # ---------------------------------------------------------------------------
 # Target builder helpers
+#
+# ``secret_ref`` is a Vault KV-v2 path STRING (#2155). The builders
+# register the secret payload under a per-name path in the live
+# ``_VAULT_SECRETS`` registry the ``vault_secrets`` fixture routes
+# ``SshConnector._resolve_secret`` through.
 # ---------------------------------------------------------------------------
+
+_VAULT_SECRETS: dict[str, dict[str, Any]] = {}
+
+
+@pytest.fixture
+def vault_secrets() -> Iterator[dict[str, dict[str, Any]]]:
+    """Route the adapter's Vault resolution through the in-memory registry."""
+    _VAULT_SECRETS.clear()
+    with stub_ssh_vault_secrets(_VAULT_SECRETS) as registry:
+        yield registry
 
 
 def _password_target(
@@ -129,13 +157,15 @@ def _password_target(
     # field hits ``AttributeError`` at the pool (evoila/meho#1682). Derive
     # a distinct ``id`` from ``name`` so distinct-name targets in the same
     # tenant land on distinct pool keys by default.
+    secret_path = f"meho/testing/ssh/{tenant_id}/{name}"
+    _VAULT_SECRETS[secret_path] = {"username": username, "password": _PASSWORD}
     return types.SimpleNamespace(
         name=name,
         host=host,
         port=port,
         id=target_id if target_id is not None else f"id-{name}",
         tenant_id=tenant_id,
-        secret_ref={"username": username, "password": _PASSWORD},
+        secret_ref=secret_path,
     )
 
 
@@ -149,13 +179,15 @@ def _key_target(
     tenant_id: str = "00000000-0000-0000-0000-000000000000",
 ) -> Any:
     private_key_pem = _CLIENT_KEY.export_private_key("pkcs8-pem").decode()
+    secret_path = f"meho/testing/ssh/{tenant_id}/{name}"
+    _VAULT_SECRETS[secret_path] = {"username": username, "ssh_private_key": private_key_pem}
     return types.SimpleNamespace(
         name=name,
         host=host,
         port=port,
         id=target_id if target_id is not None else f"id-{name}",
         tenant_id=tenant_id,
-        secret_ref={"username": username, "ssh_private_key": private_key_pem},
+        secret_ref=secret_path,
     )
 
 
@@ -173,7 +205,7 @@ class _ConcreteSshConnector(SshConnector):
         raise NotImplementedError
 
     async def probe(self, target: Any) -> ProbeResult:  # type: ignore[override]
-        result = await self._run_command(target, "echo ok", raw_jwt="jwt")
+        result = await self._run_command(target, "echo ok")
         from datetime import UTC, datetime
 
         return ProbeResult(
@@ -212,12 +244,14 @@ def test_concrete_subclass_instantiates() -> None:
 
 
 @pytest.mark.asyncio
-async def test_password_auth_connects_and_runs_command(ssh_server: Any) -> None:
-    """Password auth path: secret_ref with username+password."""
+async def test_password_auth_connects_and_runs_command(
+    ssh_server: Any, vault_secrets: dict[str, dict[str, Any]]
+) -> None:
+    """Password auth path: the resolved Vault secret carries username+password."""
     conn = _ConcreteSshConnector()
     target = _password_target(host=ssh_server.host, port=ssh_server.port)
 
-    result = await conn._run_command(target, "echo ok", raw_jwt="jwt")
+    result = await conn._run_command(target, "echo ok")
 
     assert result.exit_status == 0
     assert result.stdout is not None
@@ -226,19 +260,21 @@ async def test_password_auth_connects_and_runs_command(ssh_server: Any) -> None:
 
 
 @pytest.mark.asyncio
-async def test_key_auth_connects_and_runs_command(ssh_server: Any) -> None:
-    """Key auth path: secret_ref with ssh_private_key uses key authentication."""
+async def test_key_auth_connects_and_runs_command(
+    ssh_server: Any, vault_secrets: dict[str, dict[str, Any]]
+) -> None:
+    """Key auth path: the resolved Vault secret with ssh_private_key uses key auth."""
     conn = _ConcreteSshConnector()
     target = _key_target(host=ssh_server.host, port=ssh_server.port)
 
-    result = await conn._run_command(target, "echo ok", raw_jwt="jwt")
+    result = await conn._run_command(target, "echo ok")
 
     assert result.exit_status == 0
     await conn.aclose()
 
 
 @pytest.mark.asyncio
-async def test_probe_via_echo_ok(ssh_server: Any) -> None:
+async def test_probe_via_echo_ok(ssh_server: Any, vault_secrets: dict[str, dict[str, Any]]) -> None:
     """Concrete subclass: probe() works via _run_command('echo ok')."""
     conn = _ConcreteSshConnector()
     target = _password_target(host=ssh_server.host, port=ssh_server.port)
@@ -255,13 +291,15 @@ async def test_probe_via_echo_ok(ssh_server: Any) -> None:
 
 
 @pytest.mark.asyncio
-async def test_same_target_reuses_connection(ssh_server: Any) -> None:
+async def test_same_target_reuses_connection(
+    ssh_server: Any, vault_secrets: dict[str, dict[str, Any]]
+) -> None:
     """Two _connect calls for the same target return the identical connection object."""
     conn = _ConcreteSshConnector()
     target = _password_target(name="pool-test", host=ssh_server.host, port=ssh_server.port)
 
-    ssh_a = await conn._connect(target, "jwt")
-    ssh_b = await conn._connect(target, "jwt")
+    ssh_a = await conn._connect(target)
+    ssh_b = await conn._connect(target)
 
     assert ssh_a is ssh_b
     assert len(conn._connections) == 1
@@ -269,14 +307,16 @@ async def test_same_target_reuses_connection(ssh_server: Any) -> None:
 
 
 @pytest.mark.asyncio
-async def test_different_targets_get_different_connections(ssh_server: Any) -> None:
+async def test_different_targets_get_different_connections(
+    ssh_server: Any, vault_secrets: dict[str, dict[str, Any]]
+) -> None:
     """Each distinct target gets its own SSHClientConnection."""
     conn = _ConcreteSshConnector()
     target_a = _password_target(name="srv-a", host=ssh_server.host, port=ssh_server.port)
     target_b = _password_target(name="srv-b", host=ssh_server.host, port=ssh_server.port)
 
-    ssh_a = await conn._connect(target_a, "jwt")
-    ssh_b = await conn._connect(target_b, "jwt")
+    ssh_a = await conn._connect(target_a)
+    ssh_b = await conn._connect(target_b)
 
     assert ssh_a is not ssh_b
     # Pool is keyed on the tenant-unique ``(tenant_id, id)`` tuple.
@@ -286,7 +326,9 @@ async def test_different_targets_get_different_connections(ssh_server: Any) -> N
 
 
 @pytest.mark.asyncio
-async def test_same_name_different_tenant_get_distinct_connections(ssh_server: Any) -> None:
+async def test_same_name_different_tenant_get_distinct_connections(
+    ssh_server: Any, vault_secrets: dict[str, dict[str, Any]]
+) -> None:
     """Cross-tenant misrouting regression for the SSH pool (evoila/meho#1682).
 
     Two targets both named ``edge-router`` owned by different tenants
@@ -302,31 +344,33 @@ async def test_same_name_different_tenant_get_distinct_connections(ssh_server: A
         name="edge-router", host=ssh_server.host, port=ssh_server.port, tenant_id="tenant-b"
     )
 
-    ssh_a = await conn._connect(target_a, "jwt")
-    ssh_b = await conn._connect(target_b, "jwt")
+    ssh_a = await conn._connect(target_a)
+    ssh_b = await conn._connect(target_b)
 
     assert ssh_a is not ssh_b
     assert len(conn._connections) == 2
     assert (target_a.tenant_id, target_a.id) in conn._connections
     assert (target_b.tenant_id, target_b.id) in conn._connections
     # Re-fetching B's connection returns B's, not A's (no first-writer bleed).
-    assert await conn._connect(target_b, "jwt") is ssh_b
+    assert await conn._connect(target_b) is ssh_b
     await conn.aclose()
 
 
 @pytest.mark.asyncio
-async def test_closed_connection_triggers_reconnect(ssh_server: Any) -> None:
+async def test_closed_connection_triggers_reconnect(
+    ssh_server: Any, vault_secrets: dict[str, dict[str, Any]]
+) -> None:
     """A closed cached connection is replaced on next _connect call."""
     conn = _ConcreteSshConnector()
     target = _password_target(name="reconnect-test", host=ssh_server.host, port=ssh_server.port)
 
-    ssh_first = await conn._connect(target, "jwt")
+    ssh_first = await conn._connect(target)
     ssh_first.close()
     await ssh_first.wait_closed()
 
     assert ssh_first.is_closed()
 
-    ssh_second = await conn._connect(target, "jwt")
+    ssh_second = await conn._connect(target)
     assert ssh_second is not ssh_first
     assert not ssh_second.is_closed()
     await conn.aclose()
@@ -338,17 +382,12 @@ async def test_closed_connection_triggers_reconnect(ssh_server: Any) -> None:
 
 
 @pytest.mark.asyncio
-async def test_connect_failure_raises_at_connect_time() -> None:
+async def test_connect_failure_raises_at_connect_time(
+    vault_secrets: dict[str, dict[str, Any]],
+) -> None:
     """Connection failure raises from _connect, not from a later conn.run() call."""
     conn = _ConcreteSshConnector()
-    target = types.SimpleNamespace(
-        name="bad-host",
-        host="unreachable.internal",
-        port=22,
-        id="id-bad-host",
-        tenant_id="00000000-0000-0000-0000-000000000000",
-        secret_ref={"username": "u", "password": "p"},  # NOSONAR
-    )
+    target = _password_target(name="bad-host", host="unreachable.internal", username="u")
 
     # asyncssh.connect raises OSError on TCP failure; mock it so the test
     # doesn't depend on network behaviour or firewall rules on the test host.
@@ -356,11 +395,11 @@ async def test_connect_failure_raises_at_connect_time() -> None:
         raise OSError("Connection refused")
 
     with patch("asyncssh.connect", side_effect=_refuse), pytest.raises(OSError):
-        await conn._connect(target, "jwt")
+        await conn._connect(target)
 
     # _run_command calls _connect; the error must surface before run() is called.
     with patch("asyncssh.connect", side_effect=_refuse), pytest.raises(OSError):
-        await conn._run_command(target, "echo ok", raw_jwt="jwt")
+        await conn._run_command(target, "echo ok")
 
 
 # ---------------------------------------------------------------------------
@@ -387,12 +426,14 @@ async def test_run_command_timeout_raises_asyncio_timeout_error() -> None:
         port=22,
         id="id-timeout-target",
         tenant_id="00000000-0000-0000-0000-000000000000",
-        secret_ref={"username": "u", "password": "p"},  # NOSONAR
+        # Pooled connection is pre-seeded below, so the Vault resolution
+        # never runs — the path string is deliberately unregistered.
+        secret_ref="meho/testing/ssh/unused-timeout-path",
     )
     conn._connections[(target.tenant_id, target.id)] = (mock_conn, time.monotonic())
 
     with pytest.raises(asyncio.TimeoutError):
-        await conn._run_command(target, "sleep 60", raw_jwt="jwt", timeout=0.05)
+        await conn._run_command(target, "sleep 60", timeout=0.05)
 
 
 # ---------------------------------------------------------------------------
@@ -401,14 +442,16 @@ async def test_run_command_timeout_raises_asyncio_timeout_error() -> None:
 
 
 @pytest.mark.asyncio
-async def test_aclose_closes_all_connections_and_empties_pool(ssh_server: Any) -> None:
+async def test_aclose_closes_all_connections_and_empties_pool(
+    ssh_server: Any, vault_secrets: dict[str, dict[str, Any]]
+) -> None:
     """aclose() calls close()+wait_closed() on every pooled connection."""
     conn = _ConcreteSshConnector()
     target_a = _password_target(name="ac-a", host=ssh_server.host, port=ssh_server.port)
     target_b = _password_target(name="ac-b", host=ssh_server.host, port=ssh_server.port)
 
-    await conn._connect(target_a, "jwt")
-    await conn._connect(target_b, "jwt")
+    await conn._connect(target_a)
+    await conn._connect(target_b)
     assert len(conn._connections) == 2
 
     await conn.aclose()
@@ -425,12 +468,14 @@ async def test_aclose_idempotent_on_empty_pool() -> None:
 
 
 @pytest.mark.asyncio
-async def test_aclose_skips_already_closed_connections(ssh_server: Any) -> None:
+async def test_aclose_skips_already_closed_connections(
+    ssh_server: Any, vault_secrets: dict[str, dict[str, Any]]
+) -> None:
     """aclose() does not call wait_closed() on connections that are already closed."""
     conn = _ConcreteSshConnector()
     target = _password_target(name="pre-closed", host=ssh_server.host, port=ssh_server.port)
 
-    ssh = await conn._connect(target, "jwt")
+    ssh = await conn._connect(target)
     # Close manually before aclose()
     ssh.close()
     await ssh.wait_closed()
@@ -445,17 +490,21 @@ async def test_aclose_skips_already_closed_connections(ssh_server: Any) -> None:
 # ---------------------------------------------------------------------------
 
 
+def _target_with_secret(name: str, secret: dict[str, Any]) -> Any:
+    """Register *secret* at a per-name Vault path and return a matching target."""
+    secret_path = f"meho/testing/ssh/cfg/{name}"
+    _VAULT_SECRETS[secret_path] = secret
+    return types.SimpleNamespace(name=name, host="h", port=22, secret_ref=secret_path)
+
+
 @pytest.mark.asyncio
-async def test_auth_config_key_auth_returns_client_keys() -> None:
+async def test_auth_config_key_auth_returns_client_keys(
+    vault_secrets: dict[str, dict[str, Any]],
+) -> None:
     """_auth_config picks key auth when ssh_private_key is present."""
     conn = _ConcreteSshConnector()
     private_pem = _CLIENT_KEY.export_private_key("pkcs8-pem").decode()
-    target = types.SimpleNamespace(
-        name="key-cfg",
-        host="h",
-        port=22,
-        secret_ref={"username": "alice", "ssh_private_key": private_pem},
-    )
+    target = _target_with_secret("key-cfg", {"username": "alice", "ssh_private_key": private_pem})
 
     cfg = await conn._auth_config(target)
 
@@ -466,15 +515,12 @@ async def test_auth_config_key_auth_returns_client_keys() -> None:
 
 
 @pytest.mark.asyncio
-async def test_auth_config_password_auth_fallback() -> None:
+async def test_auth_config_password_auth_fallback(
+    vault_secrets: dict[str, dict[str, Any]],
+) -> None:
     """_auth_config falls back to password when ssh_private_key is absent."""
     conn = _ConcreteSshConnector()
-    target = types.SimpleNamespace(
-        name="pwd-cfg",
-        host="h",
-        port=22,
-        secret_ref={"username": "bob", "password": _PASSWORD},
-    )
+    target = _target_with_secret("pwd-cfg", {"username": "bob", "password": _PASSWORD})
 
     cfg = await conn._auth_config(target)
 
@@ -484,15 +530,12 @@ async def test_auth_config_password_auth_fallback() -> None:
 
 
 @pytest.mark.asyncio
-async def test_auth_config_defaults_username_to_root() -> None:
-    """_auth_config defaults username to 'root' when not set in secret_ref."""
+async def test_auth_config_defaults_username_to_root(
+    vault_secrets: dict[str, dict[str, Any]],
+) -> None:
+    """_auth_config defaults username to 'root' when the secret has no username."""
     conn = _ConcreteSshConnector()
-    target = types.SimpleNamespace(
-        name="no-user",
-        host="h",
-        port=22,
-        secret_ref={"password": _PASSWORD},
-    )
+    target = _target_with_secret("no-user", {"password": _PASSWORD})
 
     cfg = await conn._auth_config(target)
 
@@ -500,18 +543,116 @@ async def test_auth_config_defaults_username_to_root() -> None:
 
 
 @pytest.mark.asyncio
-async def test_auth_config_raises_when_no_credentials() -> None:
+async def test_auth_config_strips_credential_whitespace(
+    vault_secrets: dict[str, dict[str, Any]],
+) -> None:
+    """A trailing newline on a Vault secret field never reaches asyncssh (#1474)."""
+    conn = _ConcreteSshConnector()
+    target = _target_with_secret(
+        "trailing-newline", {"username": "carol\n", "password": _PASSWORD + "\n"}
+    )
+
+    cfg = await conn._auth_config(target)
+
+    assert cfg["username"] == "carol"
+    assert cfg["password"] == _PASSWORD
+
+
+@pytest.mark.asyncio
+async def test_auth_config_raises_when_no_credentials(
+    vault_secrets: dict[str, dict[str, Any]],
+) -> None:
     """_auth_config raises ValueError immediately when neither key nor password is present."""
     conn = _ConcreteSshConnector()
-    target = types.SimpleNamespace(
-        name="no-creds",
-        host="h",
-        port=22,
-        secret_ref={"username": "alice"},
-    )
+    target = _target_with_secret("no-creds", {"username": "alice"})
 
     with pytest.raises(ValueError, match="ssh_private_key or password"):
         await conn._auth_config(target)
+
+
+# ---------------------------------------------------------------------------
+# Vault-path secret_ref contract (#2155)
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.asyncio
+async def test_dict_secret_ref_anti_shape_fails_closed_not_attributeerror(
+    vault_secrets: dict[str, dict[str, Any]],
+) -> None:
+    """The pre-#2155 embedded-dict secret_ref fails with the loader's error.
+
+    The live-deploy failure this task fixes was ``AttributeError: 'str'
+    object has no attribute 'get'`` — the adapter consumed the Vault
+    path string as an already-materialized dict. The inverse (a target
+    row still carrying an embedded dict) must fail closed through the
+    credential-read error surface, never an ``AttributeError``.
+    """
+    conn = _ConcreteSshConnector()
+    target = types.SimpleNamespace(
+        name="anti-shape",
+        host="h",
+        port=22,
+        secret_ref={"username": "u", "password": "p"},  # NOSONAR — the anti-shape under test
+    )
+
+    with pytest.raises(VaultCredentialsReadError):
+        await conn._auth_config(target)
+
+
+@pytest.mark.asyncio
+async def test_resolve_secret_threads_operator_to_vault_loader() -> None:
+    """_resolve_secret forwards the threaded operator to load_vault_secret_data."""
+    conn = _ConcreteSshConnector()
+    target = types.SimpleNamespace(
+        name="op-thread", host="h", port=22, secret_ref="meho/targets/op-thread"
+    )
+    operator = types.SimpleNamespace(sub="operator:alice", raw_jwt="jwt-abc")
+    seen: dict[str, Any] = {}
+
+    async def _fake_loader(t: Any, op: Any, **_kwargs: Any) -> dict[str, Any]:
+        seen["target"] = t
+        seen["operator"] = op
+        return {"username": "alice", "password": "pw"}  # NOSONAR — canned test payload
+
+    with patch(
+        "meho_backplane.connectors.adapters.ssh.load_vault_secret_data",
+        side_effect=_fake_loader,
+    ):
+        secret = await conn._resolve_secret(target, operator)  # type: ignore[arg-type]
+
+    assert secret == {"username": "alice", "password": "pw"}
+    assert seen["target"] is target
+    assert seen["operator"] is operator
+
+
+@pytest.mark.asyncio
+async def test_resolve_secret_without_operator_uses_synthesised_system_operator() -> None:
+    """No threaded operator → the synthesised system operator (fails closed at Vault).
+
+    ``probe()`` and readiness paths carry no operator; the adapter must
+    not invent one. The synthesised system operator's placeholder JWT is
+    rejected by the live Vault JWT/OIDC login, preserving the
+    "system-initiated calls cannot read per-target vendor credentials"
+    carve-out — asserted here by checking the greppable system ``sub``
+    reaches the loader.
+    """
+    conn = _ConcreteSshConnector()
+    target = types.SimpleNamespace(
+        name="system-fallback", host="h", port=22, secret_ref="meho/targets/system"
+    )
+    seen: dict[str, Any] = {}
+
+    async def _fake_loader(t: Any, op: Any, **_kwargs: Any) -> dict[str, Any]:
+        seen["operator"] = op
+        return {"password": "pw"}  # NOSONAR — canned test payload
+
+    with patch(
+        "meho_backplane.connectors.adapters.ssh.load_vault_secret_data",
+        side_effect=_fake_loader,
+    ):
+        await conn._resolve_secret(target, None)
+
+    assert seen["operator"].sub == SYSTEM_OPERATOR_SUB
 
 
 # ---------------------------------------------------------------------------
@@ -520,12 +661,14 @@ async def test_auth_config_raises_when_no_credentials() -> None:
 
 
 @pytest.mark.asyncio
-async def test_idle_ttl_evicts_stale_connection(ssh_server: Any) -> None:
+async def test_idle_ttl_evicts_stale_connection(
+    ssh_server: Any, vault_secrets: dict[str, dict[str, Any]]
+) -> None:
     """Connection idle past _POOL_TTL_S is evicted and replaced on next _connect."""
     conn = _ConcreteSshConnector()
     target = _password_target(name="ttl-test", host=ssh_server.host, port=ssh_server.port)
 
-    ssh_first = await conn._connect(target, "jwt")
+    ssh_first = await conn._connect(target)
 
     # Backdate last_used to simulate idle expiry.
     conn._connections[(target.tenant_id, target.id)] = (
@@ -533,7 +676,7 @@ async def test_idle_ttl_evicts_stale_connection(ssh_server: Any) -> None:
         time.monotonic() - _POOL_TTL_S - 1.0,
     )
 
-    ssh_second = await conn._connect(target, "jwt")
+    ssh_second = await conn._connect(target)
 
     assert ssh_second is not ssh_first
     assert not ssh_second.is_closed()

--- a/docs/codebase/connectors-holodeck.md
+++ b/docs/codebase/connectors-holodeck.md
@@ -82,8 +82,14 @@ Source: `backend/src/meho_backplane/connectors/holodeck/`.
 
 ### Auth (inherited from `SshConnector._auth_config`)
 
-`_auth_config` is called by the base `SshConnector._connect` method before
-opening any TCP connection. It inspects `target.secret_ref`:
+`_auth_config(target, operator)` is called by the base
+`SshConnector._connect` method before opening any TCP connection.
+`target.secret_ref` is a Vault KV-v2 **path string** (never an embedded
+credential dict — the "bind9 anti-shape"); `_auth_config` first resolves
+it to the secret's data dict via the adapter's `_resolve_secret`
+(`_shared/vault_creds.load_vault_secret_data`, an operator-context read
+under the calling operator's Vault identity — #2155), then selects the
+auth flavour from the resolved dict:
 
 1. `ssh_private_key` present → parse via `asyncssh.import_private_key`,
    return `{username, client_keys=[key]}`. This is the key-preferred path
@@ -93,7 +99,15 @@ opening any TCP connection. It inspects `target.secret_ref`:
    `{username, password}`. This is the **default** path for the HoloRouter
    OVA, which ships with root password auth enabled.
 3. Neither set → `ValueError` (the base adapter's standard message). The
-   probe folds this into `ssh_auth_failed`.
+   probe folds this into `ssh_auth_failed`, together with the Vault
+   two-phase errors (`VaultClientError` / `VaultCredentialsReadError`).
+
+The operator is threaded from the dispatcher into every op handler
+(`dispatch_typed` passes it by signature-name introspection) down to
+`_run_command` / `pwsh_run`. Operator-less paths (`probe()`, readiness)
+fall back to the synthesised system operator, whose placeholder JWT
+Vault rejects — system-initiated calls cannot read per-target vendor
+credentials.
 
 The Holodeck connector intentionally does **not** override `_auth_config`.
 The inversion vs pfSense (key-only) is encoded in pfSense's override; the

--- a/docs/codebase/connectors-pfsense.md
+++ b/docs/codebase/connectors-pfsense.md
@@ -27,7 +27,9 @@ Source: `backend/src/meho_backplane/connectors/pfsense/`.
   `probe`, `execute`, `about`, and the 7 T2 read-op bound-method shims.
 
 - **`_auth_config()` override** — the load-bearing auth constraint. Requires
-  `ssh_private_key` in `target.secret_ref`; raises `ValueError` with a message
+  `ssh_private_key` in the target's **Vault secret** (`target.secret_ref` is a
+  KV-v2 path string resolved via the base adapter's `_resolve_secret`, #2155);
+  raises `ValueError` with a message
   naming the WebGUI break-glass credential when the key is absent. The
   `password` field in the Vault secret is the pfSense WebGUI break-glass
   credential and must never be used for SSH auth — pfSense's `admin` account
@@ -52,8 +54,10 @@ Source: `backend/src/meho_backplane/connectors/pfsense/`.
 
 ### Auth
 
-`_auth_config` is called by the `SshConnector._connect` method before opening
-any TCP connection. It inspects `target.secret_ref`:
+`_auth_config(target, operator)` is called by the `SshConnector._connect`
+method before opening any TCP connection. It resolves `target.secret_ref`
+(a Vault KV-v2 path string) to the secret's data dict via the base
+adapter's `_resolve_secret` (operator-context Vault read, #2155), then:
 
 1. `ssh_private_key` present → parse via `asyncssh.import_private_key`, return
    `{username, client_keys=[key]}`.

--- a/docs/codebase/connectors-shared-vault-creds.md
+++ b/docs/codebase/connectors-shared-vault-creds.md
@@ -46,7 +46,9 @@ dispatcher's `connector_error` branch.
   401/`unauthorized_client` that reads like a permissions/realm problem
   (#1474). `_extract_fields` applies it to every field, so every
   `load_basic_credentials` consumer is covered at once; the payload-shape
-  discriminators that use `load_vault_secret_data` (keycloak / gh-rest) call
+  discriminators that use `load_vault_secret_data` (keycloak / gh-rest, and
+  the SSH adapter's `_resolve_secret` — key-vs-password selection plus the
+  bind9 sudo password, #2155) call
   it directly on the fields they pluck. Only surrounding whitespace is
   trimmed — internal whitespace is preserved.
 - **`VaultCredentialsReadError`** — read-phase failure (empty JWT, unset

--- a/docs/cross-repo/holodeck-onboarding.md
+++ b/docs/cross-repo/holodeck-onboarding.md
@@ -118,9 +118,25 @@ required of operators today.
 
 The shipped connector's auth model is `shared_service_account` over
 either SSH password auth (the HoloRouter OVA default) or SSH key auth.
-The credential is stored in Vault at a per-host path under the operator
-tenant's KV-v2 mount, then materialized onto the target row's
-`secret_ref` column.
+The credential is stored in Vault at a per-host path under the
+KV-v2 mount; the target row's `secret_ref` column carries that **path
+string** (never the credential itself — the connector resolves the
+path under the calling operator's Vault identity on every SSH
+connect).
+
+Two constraints on the path (both break credential resolution when
+violated):
+
+1. **Mount-relative — no `secret/` prefix.** `secret_ref` is the
+   logical KV-v2 path relative to the mount. Vault's KV-v2 API
+   inserts the `/data/` segment itself, so a value that embeds the
+   mount (`secret/…`) double-resolves to `secret/data/secret/…` and
+   404s.
+2. **Inside the meho-readable subtree.** The backplane's Vault policy
+   grants operators read on `secret/meho/*` only (see
+   [vault-provisioning.md](vault-provisioning.md)) — stage the secret
+   under `meho/…` or the resolution fails with a Vault permission
+   error.
 
 ### Password auth (the v0.2 default)
 
@@ -129,7 +145,7 @@ typically have not installed SSH keys on the appliance.
 
 ```console
 $ meho vault kv put --target rdc-vault secret \
-    rdc-hetzner-dc/holodeck/holorouter-01 \
+    meho/rdc-hetzner-dc/holodeck/holorouter-01 \
     --data @holodeck_secret_ref.json
 ```
 
@@ -171,7 +187,9 @@ targets:
     product: holodeck
     host: 10.5.20.1
     port: 22
-    secret_ref: secret/rdc-hetzner-dc/holodeck/holorouter-01
+    # Mount-relative KV-v2 path inside the meho-readable subtree —
+    # no `secret/` prefix (see "Target + auth model" above).
+    secret_ref: meho/rdc-hetzner-dc/holodeck/holorouter-01
     auth_model: shared_service_account
 ```
 


### PR DESCRIPTION
## Summary

- Every ssh-family op (`holodeck-ssh`, `bind9-ssh`, `pfsense-ssh`) failed in ~5ms against any real registered target with `AttributeError: 'str' object has no attribute 'get'`: `SshConnector._auth_config` consumed `target.secret_ref` — a Vault KV-v2 path **string** (Text column) — as if it were the already-materialized secret dict, implementing the documented "bind9 anti-shape" and never resolving the Vault path at all.
- `_auth_config` now resolves the path via a new `_resolve_secret` seam over `_shared.vault_creds.load_vault_secret_data` under the request operator's identity — the same operator-context read the REST connector loaders use (`load_vault_secret_data`, not `load_basic_credentials`, because SSH auth is either/or: a key-only secret has no `password` and vice-versa). pfSense's key-only refusal is preserved on top.
- The operator is threaded from the dispatcher's `dispatch_typed` (by signature-name introspection) through every ssh-family op handler, `_run_command`, `pwsh_run`, and the bind9 sudo-password lookup. Operator-less paths (`probe()`, readiness) fall back to the synthesised system operator, whose placeholder JWT Vault rejects — preserving the fail-closed "system-initiated calls cannot read per-target vendor credentials" carve-out.
- `holodeck.k8s.exec` now lets auth/transport failures propagate to the dispatcher's `connector_error` branch (mirroring `holodeck.about`) instead of swallowing them into a `status: "ok"` envelope with empty stdout.
- The `secret_ref` example in `docs/cross-repo/holodeck-onboarding.md` is corrected to a mount-relative path inside the meho-readable `secret/meho/*` subtree (dropping the `secret/` mount prefix that would double-resolve to a 404 and land outside the readable subtree).

## Acceptance criteria

- [x] **`ssh.py::_auth_config` resolves `target.secret_ref` (a Vault path string) via the shared Vault loader instead of treating the column as a dict; pfsense key-only refusal preserved.** — `_resolve_secret` → `load_vault_secret_data`; `_auth_config` selects key/password from the resolved dict. `strip_credential_value` applied to every field. pfSense override resolves through the same seam then enforces key-only. Verified: `test_connectors_ssh_adapter.py`, `test_connectors_pfsense_auth.py`.
- [x] **Every ssh-family op dispatches against a real Vault-path target without `AttributeError`; covered by a test registering a target with a string `secret_ref`.** — string `secret_ref` is the contract end-to-end via `tests/_ssh_vault_stub.py`; `test_dict_secret_ref_anti_shape_fails_closed_not_attributeerror` proves the inverse fails with `VaultCredentialsReadError`, never `AttributeError`. Holodeck write-E2E (full park→approve→execute→audit dispatcher path) passes.
- [x] **`holodeck.k8s.exec` surfaces auth/transport failures as `connector_error` (not `status: "ok"` with empty stdout).** — handler no longer catches around `_run_command`; `test_k8s_exec_propagates_ssh_failure_as_connector_error`.
- [x] **Fix the `secret_ref` example in `holodeck-onboarding.md` (drop `secret/` prefix; stage inside `secret/meho/*`).** — example + registration YAML + a new constraints note updated.

## Test plan

- [x] `ruff check` — clean
- [x] `ruff format --check` — clean
- [x] `mypy src/meho_backplane/` — 567 files, no issues
- [x] `code-quality.py --diff` — 0 blockers (2 docstring-dominated pre-existing over-100-line functions carry `# code-quality-allow` markers; all other warnings are pre-existing file-size debt on connector files this PR did not create)
- [x] `pytest` (all touched files) — **599 passed** across `test_connectors_{ssh_adapter,holodeck_*,pfsense_*,bind9*}.py`
- [x] `pytest tests/integration/test_connectors_bind9_container.py --collect-only` — 20 tests collect (Docker-gated; runs in CI where the container is provisioned)

## Out of scope

- The generic Vault secret-materialization contract (`secret_ref` as a path string) is correct and stays — this fixes only the ssh adapter's mis-consumption of it.
- No new ssh-family ops/connectors — this restores the existing surface against real targets. This fix is a prerequisite for the SSH cluster-node OS-lifecycle ops (#2172).

<!-- auto-implement-issue: fresh, iteration 1 -->

Closes #2155
