### PR TITLE
feat(secret): add `secret read` pipe-only raw field to stdout (#2146)

### DIFF
--- a/cli/internal/cmd/secret/read.go
+++ b/cli/internal/cmd/secret/read.go
@@ -1,0 +1,254 @@
+// SPDX-License-Identifier: Apache-2.0
+// Copyright (c) 2026 evoila Group
+
+package secret
+
+import (
+	"encoding/json"
+	"fmt"
+	"os"
+
+	"github.com/spf13/cobra"
+	"golang.org/x/term"
+
+	"github.com/evoila/meho/cli/internal/dispatch"
+	"github.com/evoila/meho/cli/internal/output"
+)
+
+// opKVRead is the canonical op_id `meho secret read` dispatches. It is
+// the same audited KV-v2 read op `meho vault kv read` uses (registered
+// by G3.3-T1 #545); `read` reuses it verbatim so the credential access
+// lands on the standard /api/v1/operations/call audit row rather than a
+// local, un-audited Vault read (#2146).
+const opKVRead = "vault.kv.read"
+
+// vaultConnectorID is the connector_id the KV-v2 read op is registered
+// against. `secret read` dispatches this op against `vault-1.x`, NOT the
+// package's own `secret-broker-1.x` (which `secret move` uses) — the read
+// is a thin client-side wrapper over the existing Vault read, deliberately
+// with no new broker op (see #2146 "Out of scope"). A package-local
+// dispatch.New is bound here because the cmd/* packages can't import one
+// another (import cycle), so the vault package's `conn` isn't reachable.
+const vaultConnectorID = "vault-1.x"
+
+// vaultConn binds the KV read op's connector_id to the shared dispatch
+// core, separate from this package's secret-broker `conn`.
+var vaultConn = dispatch.New(vaultConnectorID)
+
+// stdoutIsTTY is the injectable seam test code uses to fake the presence
+// (or absence) of a real terminal on stdout. The default implementation
+// interrogates os.Stdout's file descriptor via golang.org/x/term, the
+// canonical Go answer for "is this an interactive shell?"
+// (devops_best_practices.md §CLI conventions: raw machine-readable output
+// only when piped, never onto a live terminal). It mirrors the stdinIsTTY
+// seam in cli/internal/cmd/runbook/runbook.go, but guards stdout because
+// this verb's contract is "pipe-only": a raw secret must never hit a
+// terminal.
+var stdoutIsTTY = defaultStdoutIsTTY
+
+// defaultStdoutIsTTY returns true when stdout is a real terminal. The
+// indirection through a named function (not a literal in the stdoutIsTTY
+// var initializer) lets tests reset the var to production behaviour after
+// overriding it.
+func defaultStdoutIsTTY() bool {
+	return term.IsTerminal(int(os.Stdout.Fd()))
+}
+
+// newReadCmd returns the `meho secret read` command: the pipe-only
+// emergency credential path. It dispatches the audited vault.kv.read op,
+// extracts a single field client-side, and writes ONLY that raw value to
+// stdout — no key name, no envelope, no quoting, no trailing newline — so
+// `$(meho secret read …)` / a piped sshpass-class consumer gets exactly
+// the credential bytes and nothing else.
+func newReadCmd() *cobra.Command {
+	var (
+		targetName        string
+		field             string
+		backplaneOverride string
+	)
+	cmd := &cobra.Command{
+		Use:   "read <mount> <path>",
+		Short: "Pipe a single raw secret field to stdout (pipe-only, audited)",
+		Long: "read dispatches the audited op_id=\"vault.kv.read\" against\n" +
+			"connector_id=\"vault-1.x\" (the same op `meho vault kv read` uses),\n" +
+			"extracts the --field value client-side, and writes ONLY that raw\n" +
+			"value to stdout — no key name, no envelope, no quoting, no trailing\n" +
+			"newline. It exists for the emergency credential path: a value fed\n" +
+			"straight into `$(…)` or a pipe (e.g. an sshpass-class consumer)\n" +
+			"without the jq-against-the-envelope dance that, under incident\n" +
+			"pressure, can print the whole secret onto the terminal.\n\n" +
+			"Pipe-only: if stdout is a real terminal the command refuses,\n" +
+			"prints the refusal to stderr, and emits NO value — a fat-fingered\n" +
+			"invocation yields a refusal, not a password. Redirect or pipe\n" +
+			"stdout to use it.\n\n" +
+			"All diagnostics and errors go to stderr, so a piped consumer never\n" +
+			"consumes an error string as a secret; on any failure stdout stays\n" +
+			"empty. The read is audited server-side by vault.kv.read's standard\n" +
+			"/api/v1/operations/call audit row (mount + path); the --field name\n" +
+			"is NOT recorded (extraction is client-side).\n\n" +
+			"Exit codes mirror meho operation call: 0=ok, 1=error/denied,\n" +
+			"2=auth_expired, 3=unreachable, 4=unexpected.",
+		Example: "  meho secret read --target rdc-vault secret app/db --field password | sshpass -f /dev/stdin ssh root@host\n" +
+			"  PW=$(meho secret read --target rdc-vault secret app/db --field password)",
+		Args:          cobra.ExactArgs(2),
+		SilenceUsage:  true,
+		SilenceErrors: true,
+		RunE: func(cmd *cobra.Command, args []string) error {
+			return runRead(cmd, targetName, args[0], args[1], field, backplaneOverride)
+		},
+	}
+	cmd.Flags().StringVar(&targetName, "target", "",
+		"Vault target slug to dispatch against (resolved server-side)")
+	cmd.Flags().StringVar(&field, "field", "",
+		"key within the secret's data map whose raw value is written to stdout (required)")
+	cmd.Flags().StringVar(&backplaneOverride, "backplane", "",
+		"backplane URL (defaults to the URL from the most recent `meho login`)")
+	if err := cmd.MarkFlagRequired("field"); err != nil {
+		panic(err) // programmer error: the flag is defined directly above
+	}
+	return cmd
+}
+
+// runRead resolves the backplane, refuses on a TTY, dispatches the
+// audited vault.kv.read op, and writes the extracted raw field value to
+// stdout. Every error path writes to stderr only and leaves stdout empty.
+//
+// The --json envelope path secret move offers is deliberately absent: this
+// verb's whole contract is a bare value on stdout. An operator who wants
+// the envelope uses `meho vault kv read --json`.
+func runRead(
+	cmd *cobra.Command,
+	targetName, mount, path, field, backplaneOverride string,
+) error {
+	// Guardrail 1 — pipe-only. Refuse before dispatching so a
+	// fat-fingered interactive invocation never even fetches the
+	// credential, let alone prints it. The refusal is a plain stderr line
+	// (never --json — this verb has no --json surface) and exits non-zero
+	// with nothing on stdout.
+	if stdoutIsTTY() {
+		return output.RenderError(cmd.ErrOrStderr(), output.Unexpected(
+			"refusing to write a raw secret to a terminal; `meho secret read` is "+
+				"pipe-only — redirect or pipe stdout (e.g. `$(meho secret read …)`)",
+		), false)
+	}
+
+	backplaneURL, err := resolveBackplane(backplaneOverride)
+	if err != nil {
+		return output.RenderError(cmd.ErrOrStderr(), classifyBackplaneError(err), false)
+	}
+
+	// Same params `meho vault kv read` sends: mount + path. The field is
+	// extracted client-side, so it never crosses the wire and is not part
+	// of the audit row.
+	params := map[string]any{"mount": mount, "path": path}
+	r, err := vaultConn.Call(cmd.Context(), backplaneURL, opKVRead, targetName, params)
+	if err != nil {
+		return renderRequestError(cmd, backplaneURL, err, false)
+	}
+
+	// A non-ok dispatch (error / denied / awaiting_approval / invalid
+	// status) never yields a value. Route it through the shared render so
+	// the diagnostic lands on stderr and the exit code matches the rest of
+	// the CLI — but pin the output writer to stderr so no envelope text
+	// leaks onto the value channel.
+	if r.Status != "ok" {
+		return renderNonOKToStderr(cmd, r)
+	}
+
+	value, err := extractField(r.Result, field)
+	if err != nil {
+		return output.RenderError(cmd.ErrOrStderr(), output.Unexpected(err.Error()), false)
+	}
+
+	// The one and only thing this verb ever writes to stdout: the raw
+	// value bytes, nothing added. No key, no envelope, no quoting, no
+	// trailing newline — a piped consumer gets exactly the credential.
+	fmt.Fprint(cmd.OutOrStdout(), value)
+	return nil
+}
+
+// renderNonOKToStderr surfaces a non-ok dispatch result on stderr and
+// returns the matching exit code, without ever touching stdout. It reuses
+// the shared PrintGeneric envelope renderer (which already knows the
+// awaiting_approval + error/denied shapes) but pins its writer to stderr,
+// then maps the status to an exit code the same way dispatch.Render does.
+func renderNonOKToStderr(cmd *cobra.Command, r *dispatch.CallResult) error {
+	if r.Status == dispatch.StatusAwaitingApproval {
+		// vault.kv.read is not approval-gated, so this is not expected in
+		// practice; handle it defensively rather than mis-classifying it
+		// as an invalid status. Parked = no value, exit non-zero (unlike
+		// secret move's exit-0 park, there is nothing to hand back here).
+		fmt.Fprintf(cmd.ErrOrStderr(),
+			"meho: read parked at status=%s; no value written (%s)\n",
+			r.Status, dispatch.ParkedHint)
+		return output.RenderError(cmd.ErrOrStderr(),
+			output.Unexpected("read dispatch parked awaiting approval; no value available"), false)
+	}
+	vaultConn.PrintGeneric(cmd.ErrOrStderr(), opKVRead, r)
+	// error / denied → exit 1 via the shared sentinel; any other status is
+	// a backend contract violation → exit 4.
+	switch r.Status {
+	case "error", "denied":
+		return dispatch.ErrOpError
+	default:
+		return output.RenderError(cmd.ErrOrStderr(), output.Unexpected(fmt.Sprintf(
+			"backplane returned invalid OperationResult.status %q", r.Status)), false)
+	}
+}
+
+// extractField decodes the vault.kv.read result envelope ({data: {...},
+// version: N}) and returns the raw string value at data[field]. It fails
+// closed: a missing field, a null value, or a non-string/non-scalar value
+// is an error (written to stderr by the caller), never a partial or coerced
+// value on stdout.
+func extractField(raw json.RawMessage, field string) (string, error) {
+	if len(raw) == 0 || string(raw) == "null" {
+		return "", fmt.Errorf("read returned an empty result envelope; no %q field to extract", field)
+	}
+	var env struct {
+		Data map[string]json.RawMessage `json:"data"`
+	}
+	if err := json.Unmarshal(raw, &env); err != nil {
+		return "", fmt.Errorf("decode read result envelope: %w", err)
+	}
+	if env.Data == nil {
+		return "", fmt.Errorf("read result has no data map; cannot extract field %q", field)
+	}
+	rawVal, ok := env.Data[field]
+	if !ok {
+		return "", fmt.Errorf("field %q not present in the secret at this path", field)
+	}
+	return scalarToString(rawVal, field)
+}
+
+// scalarToString renders a single JSON scalar (string, number, or bool)
+// as its raw string form for stdout. A string yields its unquoted bytes; a
+// number or bool yields its literal JSON text (which is already the raw
+// form). A null, object, or array is rejected — those are not a single
+// credential value and must not be silently stringified onto the value
+// channel.
+func scalarToString(raw json.RawMessage, field string) (string, error) {
+	var v any
+	if err := json.Unmarshal(raw, &v); err != nil {
+		return "", fmt.Errorf("decode field %q: %w", field, err)
+	}
+	switch tv := v.(type) {
+	case string:
+		return tv, nil
+	case bool:
+		if tv {
+			return "true", nil
+		}
+		return "false", nil
+	case float64:
+		// json.Number-free path: re-render the original raw bytes rather
+		// than the float64 round-trip, so integers and large / precise
+		// numbers keep their exact source text (e.g. "12345678901234567").
+		return string(raw), nil
+	case nil:
+		return "", fmt.Errorf("field %q is null; no value to write", field)
+	default:
+		return "", fmt.Errorf("field %q is not a scalar value (got a JSON object/array); "+
+			"secret read writes single credential fields only", field)
+	}
+}

--- a/cli/internal/cmd/secret/read_test.go
+++ b/cli/internal/cmd/secret/read_test.go
@@ -1,0 +1,387 @@
+// SPDX-License-Identifier: Apache-2.0
+// Copyright (c) 2026 evoila Group
+
+package secret
+
+import (
+	"bytes"
+	"encoding/json"
+	"net/http"
+	"strings"
+	"testing"
+
+	"github.com/evoila/meho/cli/internal/dispatch"
+)
+
+// withStdoutTTY overrides the stdoutIsTTY seam for the duration of the
+// test and restores it afterwards. The default (false, "piped") is what
+// every test but the TTY-refuse test wants, so tests that need the
+// happy path don't have to touch the seam — but the production default
+// interrogates the real os.Stdout fd, which under `go test` is a pipe,
+// so it already reports false. We pin it explicitly for determinism.
+func withStdoutTTY(t *testing.T, isTTY bool) {
+	t.Helper()
+	prev := stdoutIsTTY
+	stdoutIsTTY = func() bool { return isTTY }
+	t.Cleanup(func() { stdoutIsTTY = prev })
+}
+
+// ---------- command-tree shape ----------
+
+// TestNewRootCmdHasRead — the root command must expose the `read` verb
+// alongside `move` (acceptance criterion: wired into NewRootCmd()).
+func TestNewRootCmdHasRead(t *testing.T) {
+	root := NewRootCmd()
+	got := map[string]bool{}
+	for _, sub := range root.Commands() {
+		got[sub.Name()] = true
+	}
+	if !got["read"] {
+		t.Errorf("secret root is missing the read sub-verb; has %v", got)
+	}
+}
+
+// TestReadHelpListsFlags — `meho secret read --help` must surface
+// --field and --target (acceptance criterion: --help exits 0 and shows
+// the flags). The TTY seam is irrelevant here — cobra prints help
+// before RunE runs.
+func TestReadHelpListsFlags(t *testing.T) {
+	cmd := newReadCmd()
+	var buf bytes.Buffer
+	cmd.SetOut(&buf)
+	cmd.SetErr(&buf)
+	cmd.SetArgs([]string{"--help"})
+	if err := cmd.Execute(); err != nil {
+		t.Fatalf("--help execute: %v", err)
+	}
+	out := buf.String()
+	for _, want := range []string{"--field", "--target"} {
+		if !strings.Contains(out, want) {
+			t.Errorf("read --help output missing %q\n%s", want, out)
+		}
+	}
+}
+
+// TestReadFieldRequired — --field is a required flag; the command exposes
+// no inline-value flag that would land a secret in argv.
+func TestReadFieldRequired(t *testing.T) {
+	cmd := newReadCmd()
+	flag := cmd.Flags().Lookup("field")
+	if flag == nil {
+		t.Fatalf("read is missing the --field flag")
+	}
+	if ann := flag.Annotations[cobraRequiredAnnotation]; len(ann) == 0 || ann[0] != "true" {
+		t.Errorf("--field should be marked required; annotations=%v", flag.Annotations)
+	}
+	for _, banned := range []string{"value", "secret", "password"} {
+		if cmd.Flags().Lookup(banned) != nil {
+			t.Errorf("read must NOT expose an inline --%s flag", banned)
+		}
+	}
+}
+
+// ---------- raw-value-only contract ----------
+
+// TestSecretRead — the load-bearing acceptance criterion. With a mock
+// backplane returning status=ok and result.data.<field>=<v>, stdout must
+// equal EXACTLY <v>: no key name, no envelope, no quoting, no trailing
+// newline.
+func TestSecretRead(t *testing.T) {
+	const field = "password"
+	const value = "s3cr3t-p@ss"
+
+	var captured callRequestBody
+	srv := mockBackplane(t, map[string]mockHandler{
+		"POST /api/v1/operations/call": func(w http.ResponseWriter, r *http.Request) {
+			if err := json.NewDecoder(r.Body).Decode(&captured); err != nil {
+				t.Errorf("decode body: %v", err)
+				w.WriteHeader(400)
+				return
+			}
+			writeJSON(t, w, 200, dispatch.CallResult{
+				Status: "ok", OpID: opKVRead, DurationMs: 4,
+				Result: json.RawMessage(`{"data":{"password":"s3cr3t-p@ss","other":"x"},"version":3}`),
+			})
+		},
+	})
+	defer srv.Close()
+	primeToken(t, srv.URL)
+	withStdoutTTY(t, false)
+
+	cmd := newReadCmd()
+	var out, errBuf bytes.Buffer
+	cmd.SetOut(&out)
+	cmd.SetErr(&errBuf)
+	cmd.SetArgs([]string{
+		"--target", "rdc-vault", "--field", field,
+		"--backplane", srv.URL, "secret", "app/db",
+	})
+	if err := cmd.Execute(); err != nil {
+		t.Fatalf("execute: %v (stderr=%s)", err, errBuf.String())
+	}
+
+	// Exact-match: no added bytes whatsoever.
+	if got := out.String(); got != value {
+		t.Errorf("stdout must equal exactly %q with no decoration; got %q", value, got)
+	}
+	// The verb dispatches vault.kv.read against vault-1.x, not the broker.
+	if captured.ConnectorID != vaultConnectorID {
+		t.Errorf("connector_id: got %q want %q", captured.ConnectorID, vaultConnectorID)
+	}
+	if captured.OpID != opKVRead {
+		t.Errorf("op_id: got %q want %q", captured.OpID, opKVRead)
+	}
+	// The target slug rides in the standard {"name": …} dict.
+	if captured.Target == nil || captured.Target["name"] != "rdc-vault" {
+		t.Errorf("target should carry name=rdc-vault; got %v", captured.Target)
+	}
+	// mount + path cross the wire; --field is client-side only.
+	if captured.Params["mount"] != "secret" || captured.Params["path"] != "app/db" {
+		t.Errorf("params should carry mount+path; got %v", captured.Params)
+	}
+	if _, leaked := captured.Params["field"]; leaked {
+		t.Errorf("field must NOT cross the wire (client-side extraction); got %v", captured.Params)
+	}
+}
+
+// TestSecretReadNumericField — a numeric field renders as its exact
+// source text (no float64 round-trip, no trailing newline).
+func TestSecretReadNumericField(t *testing.T) {
+	srv := mockBackplane(t, map[string]mockHandler{
+		"POST /api/v1/operations/call": func(w http.ResponseWriter, r *http.Request) {
+			writeJSON(t, w, 200, dispatch.CallResult{
+				Status: "ok", OpID: opKVRead,
+				Result: json.RawMessage(`{"data":{"port":5432},"version":1}`),
+			})
+		},
+	})
+	defer srv.Close()
+	primeToken(t, srv.URL)
+	withStdoutTTY(t, false)
+
+	cmd := newReadCmd()
+	var out, errBuf bytes.Buffer
+	cmd.SetOut(&out)
+	cmd.SetErr(&errBuf)
+	cmd.SetArgs([]string{
+		"--target", "v", "--field", "port", "--backplane", srv.URL, "secret", "p",
+	})
+	if err := cmd.Execute(); err != nil {
+		t.Fatalf("execute: %v (stderr=%s)", err, errBuf.String())
+	}
+	if got := out.String(); got != "5432" {
+		t.Errorf("numeric field: got %q want %q", got, "5432")
+	}
+}
+
+// ---------- TTY-refuse guardrail ----------
+
+// TestSecretReadRefusesTTY — with stdout a real terminal, the verb writes
+// NOTHING to stdout, writes a refusal to stderr, and exits non-zero. It
+// must refuse BEFORE any dispatch (no credential is even fetched).
+func TestSecretReadRefusesTTY(t *testing.T) {
+	dispatched := false
+	srv := mockBackplane(t, map[string]mockHandler{
+		"POST /api/v1/operations/call": func(w http.ResponseWriter, r *http.Request) {
+			dispatched = true
+			writeJSON(t, w, 200, dispatch.CallResult{
+				Status: "ok", OpID: opKVRead,
+				Result: json.RawMessage(`{"data":{"password":"leak"},"version":1}`),
+			})
+		},
+	})
+	defer srv.Close()
+	primeToken(t, srv.URL)
+	withStdoutTTY(t, true) // stdout is a terminal → must refuse
+
+	cmd := newReadCmd()
+	var out, errBuf bytes.Buffer
+	cmd.SetOut(&out)
+	cmd.SetErr(&errBuf)
+	cmd.SetArgs([]string{
+		"--target", "v", "--field", "password", "--backplane", srv.URL, "secret", "p",
+	})
+	err := cmd.Execute()
+	if err == nil {
+		t.Fatalf("expected a non-nil (non-zero exit) error on a TTY refusal")
+	}
+	if out.Len() != 0 {
+		t.Errorf("stdout must be empty on TTY refusal; got %q", out.String())
+	}
+	if !strings.Contains(errBuf.String(), "pipe-only") {
+		t.Errorf("stderr should carry the pipe-only refusal; got %q", errBuf.String())
+	}
+	if dispatched {
+		t.Errorf("the verb must refuse BEFORE dispatching — no credential should be fetched")
+	}
+}
+
+// ---------- error isolation ----------
+
+// TestSecretReadMissingField — a field absent from result.data writes
+// NOTHING to stdout, a structured error to stderr, and exits non-zero.
+func TestSecretReadMissingField(t *testing.T) {
+	srv := mockBackplane(t, map[string]mockHandler{
+		"POST /api/v1/operations/call": func(w http.ResponseWriter, r *http.Request) {
+			writeJSON(t, w, 200, dispatch.CallResult{
+				Status: "ok", OpID: opKVRead,
+				Result: json.RawMessage(`{"data":{"username":"admin"},"version":1}`),
+			})
+		},
+	})
+	defer srv.Close()
+	primeToken(t, srv.URL)
+	withStdoutTTY(t, false)
+
+	cmd := newReadCmd()
+	var out, errBuf bytes.Buffer
+	cmd.SetOut(&out)
+	cmd.SetErr(&errBuf)
+	cmd.SetArgs([]string{
+		"--target", "v", "--field", "password", "--backplane", srv.URL, "secret", "p",
+	})
+	if err := cmd.Execute(); err == nil {
+		t.Fatalf("a missing field must be a non-zero exit")
+	}
+	if out.Len() != 0 {
+		t.Errorf("stdout must be empty when the field is missing; got %q", out.String())
+	}
+	if !strings.Contains(errBuf.String(), "password") {
+		t.Errorf("stderr should name the missing field; got %q", errBuf.String())
+	}
+}
+
+// TestSecretReadDispatchError — a status=error dispatch writes NOTHING to
+// stdout, the connector error to stderr, and exits non-zero. A piped
+// consumer must never receive the error string as a secret.
+func TestSecretReadDispatchError(t *testing.T) {
+	errMsg := "vault: permission denied"
+	srv := mockBackplane(t, map[string]mockHandler{
+		"POST /api/v1/operations/call": func(w http.ResponseWriter, r *http.Request) {
+			writeJSON(t, w, 200, dispatch.CallResult{
+				Status: "error", OpID: opKVRead, Error: &errMsg,
+			})
+		},
+	})
+	defer srv.Close()
+	primeToken(t, srv.URL)
+	withStdoutTTY(t, false)
+
+	cmd := newReadCmd()
+	var out, errBuf bytes.Buffer
+	cmd.SetOut(&out)
+	cmd.SetErr(&errBuf)
+	cmd.SetArgs([]string{
+		"--target", "v", "--field", "password", "--backplane", srv.URL, "secret", "p",
+	})
+	if err := cmd.Execute(); err == nil {
+		t.Fatalf("a status=error dispatch must be a non-zero exit")
+	}
+	if out.Len() != 0 {
+		t.Errorf("stdout must be empty on a dispatch error; got %q", out.String())
+	}
+	if !strings.Contains(errBuf.String(), "permission denied") {
+		t.Errorf("stderr should carry the connector error; got %q", errBuf.String())
+	}
+}
+
+// TestSecretReadObjectFieldRejected — a field whose value is a JSON
+// object/array is not a single credential; the verb rejects it with an
+// empty stdout and a stderr error rather than stringifying it.
+func TestSecretReadObjectFieldRejected(t *testing.T) {
+	srv := mockBackplane(t, map[string]mockHandler{
+		"POST /api/v1/operations/call": func(w http.ResponseWriter, r *http.Request) {
+			writeJSON(t, w, 200, dispatch.CallResult{
+				Status: "ok", OpID: opKVRead,
+				Result: json.RawMessage(`{"data":{"nested":{"k":"v"}},"version":1}`),
+			})
+		},
+	})
+	defer srv.Close()
+	primeToken(t, srv.URL)
+	withStdoutTTY(t, false)
+
+	cmd := newReadCmd()
+	var out, errBuf bytes.Buffer
+	cmd.SetOut(&out)
+	cmd.SetErr(&errBuf)
+	cmd.SetArgs([]string{
+		"--target", "v", "--field", "nested", "--backplane", srv.URL, "secret", "p",
+	})
+	if err := cmd.Execute(); err == nil {
+		t.Fatalf("a non-scalar field must be a non-zero exit")
+	}
+	if out.Len() != 0 {
+		t.Errorf("stdout must be empty for a non-scalar field; got %q", out.String())
+	}
+	if !strings.Contains(errBuf.String(), "scalar") {
+		t.Errorf("stderr should explain the non-scalar rejection; got %q", errBuf.String())
+	}
+}
+
+// ---------- unit: extractField / scalarToString directly ----------
+
+// TestExtractFieldScalars pins the field-extraction helper's scalar
+// rendering across string / int / bool without the cobra + HTTP scaffold.
+func TestExtractFieldScalars(t *testing.T) {
+	cases := []struct {
+		name  string
+		env   string
+		field string
+		want  string
+	}{
+		{"string", `{"data":{"k":"hunter2"}}`, "k", "hunter2"},
+		{"empty-string", `{"data":{"k":""}}`, "k", ""},
+		{"int", `{"data":{"k":42}}`, "k", "42"},
+		{"bigint", `{"data":{"k":12345678901234567}}`, "k", "12345678901234567"},
+		{"bool-true", `{"data":{"k":true}}`, "k", "true"},
+		{"bool-false", `{"data":{"k":false}}`, "k", "false"},
+	}
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			got, err := extractField(json.RawMessage(tc.env), tc.field)
+			if err != nil {
+				t.Fatalf("extractField: %v", err)
+			}
+			if got != tc.want {
+				t.Errorf("got %q want %q", got, tc.want)
+			}
+		})
+	}
+}
+
+// TestExtractFieldErrors pins the failure modes: missing field, null
+// value, non-scalar value, empty envelope.
+func TestExtractFieldErrors(t *testing.T) {
+	cases := []struct {
+		name  string
+		env   string
+		field string
+	}{
+		{"missing", `{"data":{"a":"b"}}`, "k"},
+		{"null", `{"data":{"k":null}}`, "k"},
+		{"object", `{"data":{"k":{"x":1}}}`, "k"},
+		{"array", `{"data":{"k":[1,2]}}`, "k"},
+		{"no-data", `{"version":1}`, "k"},
+		{"empty", `null`, "k"},
+	}
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			if _, err := extractField(json.RawMessage(tc.env), tc.field); err == nil {
+				t.Errorf("expected an error for %s; got nil", tc.name)
+			}
+		})
+	}
+}
+
+// TestVaultConnectorFrozen pins the read verb's connector_id to the KV
+// read op's registered connector — a drift here would dispatch against
+// the wrong (or a non-existent) connector.
+func TestVaultConnectorFrozen(t *testing.T) {
+	if vaultConnectorID != "vault-1.x" {
+		t.Fatalf("vaultConnectorID drifted: got %q want vault-1.x", vaultConnectorID)
+	}
+	if opKVRead != "vault.kv.read" {
+		t.Fatalf("opKVRead drifted: got %q want vault.kv.read", opKVRead)
+	}
+}

--- a/cli/internal/cmd/secret/secret.go
+++ b/cli/internal/cmd/secret/secret.go
@@ -9,6 +9,16 @@
 //
 //   - `meho secret move --from <kind>:<ref> --to <kind>:<ref> --reason R`
 //     → secret.move
+//   - `meho secret read --target <vault> <mount> <path> --field <f>`
+//     → vault.kv.read (client-side field extraction)
+//
+// The `read` verb is the odd one out in this tree: it does NOT dispatch
+// against the synthetic secret-broker connector. It is a thin, pipe-only
+// wrapper over the existing audited `vault.kv.read` op (connector
+// `vault-1.x`) that extracts one field client-side and writes only its raw
+// value to stdout — the emergency credential path (#2146). It binds its
+// own package-local dispatch.New("vault-1.x") in read.go, separate from
+// this package's secret-broker `conn`.
 //
 // The move is references-not-values: the operator names a `--from` and a
 // `--to` `<kind>:<ref>` reference and a `--reason`; the backplane reads
@@ -74,14 +84,17 @@ func NewRootCmd() *cobra.Command {
 			"(product=\"secret\", version=\"1.x\", impl_id=\"secret-broker\")).\n" +
 			"It dispatches through POST /api/v1/operations/call with\n" +
 			"connector_id=\"secret-broker-1.x\" pre-baked.\n\n" +
-			"The single verb today is `move`, which copies a credential from\n" +
-			"one store to another server-side. The move is\n" +
-			"references-not-values: you name a --from and --to '<kind>:<ref>'\n" +
-			"reference and a --reason; the backplane reads, transfers, and\n" +
-			"re-writes the material. The secret value is NEVER passed on the\n" +
-			"command line, so it never lands in shell history, ps output, or\n" +
-			"the op params; the response returns only the move status, the\n" +
-			"value's SHA-256, and its byte length.\n\n" +
+			"`move` copies a credential from one store to another server-side.\n" +
+			"The move is references-not-values: you name a --from and --to\n" +
+			"'<kind>:<ref>' reference and a --reason; the backplane reads,\n" +
+			"transfers, and re-writes the material. The secret value is NEVER\n" +
+			"passed on the command line, so it never lands in shell history, ps\n" +
+			"output, or the op params; the response returns only the move\n" +
+			"status, the value's SHA-256, and its byte length.\n\n" +
+			"`read` is the pipe-only emergency credential path: it dispatches\n" +
+			"the audited vault.kv.read op (connector vault-1.x, NOT the broker),\n" +
+			"extracts one --field client-side, and writes only that raw value to\n" +
+			"stdout. It refuses to run when stdout is a terminal.\n\n" +
 			"move is change-class (it requires approval): an unapproved\n" +
 			"dispatch parks at status=awaiting_approval until a human approves\n" +
 			"through the approval queue.\n\n" +
@@ -90,6 +103,7 @@ func NewRootCmd() *cobra.Command {
 		SilenceUsage: true,
 	}
 	cmd.AddCommand(newMoveCmd())
+	cmd.AddCommand(newReadCmd())
 	return cmd
 }
 


### PR DESCRIPTION
## Summary
- Adds `meho secret read --target <vault> <mount> <path> --field <f>`: the pipe-only emergency credential path. It dispatches the **existing audited** `vault.kv.read` op (connector `vault-1.x`, not the secret-broker), extracts one `--field` client-side, and writes **only the raw value** to stdout — no key, no envelope, no quoting, no trailing newline — so `$(meho secret read …)` / a piped sshpass-class consumer gets exactly the credential bytes.
- **Guardrail 1 — pipe-only:** if stdout is a real terminal, the verb refuses *before dispatching*, prints the refusal to stderr, and emits no value. Implemented via a `stdoutIsTTY` injectable seam over `term.IsTerminal(os.Stdout.Fd())`, mirroring `runbook.go`'s `stdinIsTTY`.
- **Guardrail 2 — audited:** the read rides `vault.kv.read`'s standard `/api/v1/operations/call` audit row (mount + path). This closes the incident gap where a local un-audited Vault read never touched meho's audit plane.
- All errors/diagnostics go to **stderr**; on any failure stdout stays **empty**, so a piped consumer never consumes an error string as a secret.

## Design notes
- The `read` verb binds a package-local `dispatch.New("vault-1.x")` — separate from the package's `secret-broker-1.x` `conn` — because the `cmd/*` packages can't import one another. `--field` is extracted client-side and never crosses the wire (so it is not on the audit row; field-name + value-hash parity is deferred per Out of scope).
- `extractField` fails closed: a missing field, `null`, or a non-scalar (object/array) value is a stderr error with empty stdout, never a coerced/partial value. Numeric fields render their exact source bytes (no float64 round-trip).

## Test plan
- [x] `gofmt -l` — clean; `go vet ./internal/cmd/secret/` — clean
- [x] `go test ./internal/cmd/secret/... -race` — pass (raw-value-only, TTY-refuse, missing-field, dispatch-error, non-scalar-reject, numeric, extract-helper unit tables)
- [x] `go run ./cmd/meho secret read --help` — exits 0, shows `--field` + `--target`
- [x] `go test ./...` (whole CLI module) — all packages `ok`
- [x] `--help` / raw-value-only / TTY-refuse / error-isolation acceptance criteria all covered by Go tests

> Note: `make -C cli test` uses `go test -race -cover`; the sandbox Go toolchain lacks the `covdata` tool so the coverage post-step errors *after* every package reports `ok`. Plain `go test ./...` is green. CI's toolchain has `covdata`.

## Out of scope
- Server-side `secret.read` broker op for field-name + value-hash audit parity (deferred — needs its own security review).
- Any new backend op, REST route, or connector registration; MCP/agent surface (operator-only, postulate 5); non-Vault stores.

## No OpenAPI / generated-client change
This Task reuses the `vault.kv.read` route unchanged. `git status --porcelain` for `cli/api/openapi.json` and `cli/internal/api/client.gen.go` is **clean** — no snapshot regen required.

<!-- auto-implement-issue: fresh, iteration 1 -->

Closes #2146
