### PR TITLE
fix(runbooks): htmx-process Alpine-cloned editor steps so step 2+ previews fire

### DIFF
--- a/backend/src/meho_backplane/ui/templates/runbooks/editor.html
+++ b/backend/src/meho_backplane/ui/templates/runbooks/editor.html
@@ -124,12 +124,23 @@
   </div>
 
   {# ---------- Form ---------- #}
+  {#-
+    ``hx-disabled-elt`` is an inherited htmx attribute: without ``hx-disinherit``
+    every descendant htmx request (each step body's debounced preview POST)
+    would inherit the form's ``find button[type=submit]`` and resolve ``find``
+    from the textarea — which has no submit-button descendant — logging
+    ``The selector "find button[type=submit]" on hx-disabled-elt returned no
+    matches!`` once per preview POST. Disinheriting it here keeps the value on
+    the form's own submit (self, not inherited) while stopping the leak into
+    the per-step triggers.
+  -#}
   <form
     id="runbook-editor-form"
     hx-post="{{ submit_url }}"
     hx-target="#runbook-editor-form"
     hx-swap="none"
     hx-headers='{"X-CSRF-Token": "{{ csrf_token | default('') }}"}'
+    hx-disinherit="hx-disabled-elt"
     x-on:submit="syncSteps()"
     x-bind:hx-disabled-elt="validationErrors().length > 0 ? 'find button[type=submit]' : null"
   >
@@ -396,10 +407,35 @@
     document.querySelectorAll(".runbook-step-body").forEach(enhanceTextarea);
   }
 
+  // htmx only scans the DOM it renders itself. A step cloned by Alpine's
+  // ``x-for`` is inserted outside the htmx request cycle, so its per-step
+  // ``hx-post="/ui/runbooks/preview"`` trigger never binds until the node is
+  // handed to ``htmx.process``. Processing the form root is idempotent —
+  // htmx skips nodes it has already initialised — so re-running it after every
+  // step add/remove and after each HTMX settle registers the new triggers
+  // without double-binding the existing ones.
+  function processSteps() {
+    if (typeof window.htmx === "undefined") {
+      return;
+    }
+    var form = document.getElementById("runbook-editor-form");
+    if (form) {
+      window.htmx.process(form);
+    }
+  }
+
+  // Mount CodeMirror on the step bodies AND register their htmx triggers.
+  // Both must run in every rescan hook: CodeMirror gives the textarea its
+  // editor, htmx.process binds the per-step live-preview POST.
+  function rescan() {
+    scanBodies();
+    processSteps();
+  }
+
   // Initial scan once the DOM (and Alpine's x-for) has rendered, plus a
   // rescan after HTMX settles new content and after Alpine adds a step.
   function init() {
-    scanBodies();
+    rescan();
   }
   if (document.readyState !== "loading") {
     // base.html scripts are deferred, so the DOM is parsed; give Alpine a
@@ -408,11 +444,11 @@
   } else {
     document.addEventListener("DOMContentLoaded", function () { setTimeout(init, 0); });
   }
-  document.body.addEventListener("htmx:afterSettle", scanBodies);
+  document.body.addEventListener("htmx:afterSettle", rescan);
   // Re-scan when a step is added/removed (Alpine re-renders the x-for).
   document.addEventListener("click", function (e) {
     if (e.target && e.target.closest && e.target.closest("#runbook-editor-form, [x-on\\:click]")) {
-      setTimeout(scanBodies, 0);
+      setTimeout(rescan, 0);
     }
   });
 })();

--- a/backend/tests/test_ui_runbooks_editor.py
+++ b/backend/tests/test_ui_runbooks_editor.py
@@ -978,6 +978,129 @@ def test_editor_new_step_preview_uses_valid_hx_target() -> None:
     assert ".flex-wrap >> .runbook-step-preview" not in body
 
 
+def test_editor_processes_htmx_on_dynamically_added_steps() -> None:
+    """The editor hands Alpine-cloned steps to ``htmx.process`` (#2174).
+
+    Each step's Body textarea carries ``hx-post="/ui/runbooks/preview"``, but
+    that trigger lives inside an Alpine ``x-for`` loop. htmx only binds
+    ``hx-*`` on the DOM it renders itself, so a step added via ``+ Add step``
+    (or any step past the first on an edit) is never htmx-processed and its
+    live preview never fires. The regression before #2174 was that the editor
+    script re-mounted CodeMirror on new step bodies but never called
+    ``htmx.process`` — so only the first step (present at htmx's initial page
+    scan) produced a preview.
+
+    This asserts the fix is wired into the rendered editor script: a
+    ``htmx.process`` call plus its use in the shared rescan path that runs on
+    ``htmx:afterSettle`` and after each add/remove click.
+    """
+    _seed_tenant(_TENANT_A, "tenant-a")
+    session_id, jwks = _admin_session()
+
+    mock = respx.mock(assert_all_called=False)
+    mock.start()
+    try:
+        _mock_discovery_and_jwks(mock, jwks)
+        client = _authenticated_client(session_id)
+        response = client.get("/ui/runbooks/new")
+    finally:
+        mock.stop()
+
+    assert response.status_code == 200, response.text
+    body = response.text
+    # The dynamically-added step subtree is registered with htmx.
+    assert "htmx.process" in body
+    # The rescan path (CodeMirror + htmx.process) is bound to the settle event
+    # and the add/remove click so new steps get processed, not just the first.
+    assert "htmx:afterSettle" in body
+
+
+def test_editor_form_disinherits_disabled_elt() -> None:
+    """The editor form disinherits ``hx-disabled-elt`` so step previews are clean (#2174).
+
+    ``hx-disabled-elt`` is an inherited htmx attribute. The form binds
+    ``find button[type=submit]`` (to disable submit while validation fails);
+    without ``hx-disinherit`` every descendant step's debounced preview POST
+    inherits it and resolves ``find button[type=submit]`` against the textarea
+    — matching nothing — logging
+    ``The selector "find button[type=submit]" on hx-disabled-elt returned no
+    matches!`` once per preview POST. The form must carry
+    ``hx-disinherit="hx-disabled-elt"`` to scope the value to its own submit.
+    """
+    _seed_tenant(_TENANT_A, "tenant-a")
+    session_id, jwks = _admin_session()
+
+    mock = respx.mock(assert_all_called=False)
+    mock.start()
+    try:
+        _mock_discovery_and_jwks(mock, jwks)
+        client = _authenticated_client(session_id)
+        response = client.get("/ui/runbooks/new")
+    finally:
+        mock.stop()
+
+    assert response.status_code == 200, response.text
+    body = response.text
+    assert 'hx-disinherit="hx-disabled-elt"' in body
+
+
+def test_editor_edit_multi_step_hydrates_every_step_preview_trigger() -> None:
+    """On edit, every hydrated step carries its own preview trigger (#2174).
+
+    The ``x-for`` renders one ``_step_fields.html`` per step, but only one
+    physical set of markup is in the response — the per-step preview trigger
+    is authored once and cloned per Alpine iteration. The regression is
+    binding, not markup: the trigger and its target must be present so that
+    once the added/hydrated step is htmx-processed the second step's preview
+    fires. This edit path seeds a two-step template and asserts the per-step
+    preview trigger + target + the htmx.process wiring are all present.
+    """
+    _seed_tenant(_TENANT_A, "tenant-a")
+    two_step_body = RunbookTemplateBody(
+        title="Two step",
+        description="A two-step runbook.",
+        target_kind="k8s-node",
+        steps=[
+            ManualStep(
+                id="first",
+                title="First",
+                body="First **body**.",
+                type="manual",
+                verify=ConfirmVerify(type="confirm", prompt="First done?"),
+            ),
+            ManualStep(
+                id="second",
+                title="Second",
+                body="Second **body**.",
+                type="manual",
+                verify=ConfirmVerify(type="confirm", prompt="Second done?"),
+            ),
+        ],
+    )
+    _seed_template(tenant_id=_TENANT_A, slug="two-step", body=two_step_body)
+    session_id, jwks = _admin_session()
+
+    mock = respx.mock(assert_all_called=False)
+    mock.start()
+    try:
+        _mock_discovery_and_jwks(mock, jwks)
+        client = _authenticated_client(session_id)
+        response = client.get("/ui/runbooks/two-step/edit")
+    finally:
+        mock.stop()
+
+    assert response.status_code == 200, response.text
+    body = response.text
+    # Both hydrated steps are in the Alpine model.
+    assert "first" in body
+    assert "second" in body
+    # The per-step preview trigger + target are present, and the editor
+    # processes the cloned step subtrees with htmx so step 2+ binds too.
+    assert 'hx-post="/ui/runbooks/preview"' in body
+    assert 'hx-target="next .runbook-step-preview"' in body
+    assert "htmx.process" in body
+
+
 # ---------------------------------------------------------------------------
 # Audit op-id on UI-path template writes (#2116)
 #

--- a/docs/codebase/ui.md
+++ b/docs/codebase/ui.md
@@ -2840,6 +2840,34 @@ differential), and to a 404 for an admin. The restricted placeholder
 carries only the slug the operator typed and epoch-sentinel timestamps —
 no real template metadata leaks.
 
+### Editor step-body preview (dynamic HTMX processing)
+
+Each step in the authoring editor (`editor.html` + `_step_fields.html`) is
+rendered inside an Alpine `<template x-for="(step, idx) in steps">` loop, and
+every step's Body textarea carries a debounced
+`hx-post="/ui/runbooks/preview"` that swaps the sibling
+`.runbook-step-preview` pane. htmx only binds `hx-*` attributes on DOM it
+renders itself; a step cloned by Alpine's `x-for` (a `+ Add step` click, or
+any step beyond the first on an edit) is inserted outside the htmx request
+cycle, so its preview trigger never binds until the node is handed to
+`htmx.process`. The `{% block scripts %}` init therefore runs a `rescan()`
+(CodeMirror mount **plus** `htmx.process` on the form root) on first render,
+on every `htmx:afterSettle`, and after each add/remove/reorder click.
+Processing the form root is idempotent — htmx skips nodes it has already
+initialised — so re-running it never double-binds the existing steps' preview
+POSTs. Without this every step after the first was inert (#2174; the first
+step worked only because it was present at htmx's initial page scan).
+
+`hx-disabled-elt` is an **inherited** htmx attribute, so the form's
+`x-bind:hx-disabled-elt="… ? 'find button[type=submit]' : null"` (which
+disables the submit button while client-side validation fails) would leak into
+each descendant preview POST — the textarea would resolve `find
+button[type=submit]` against itself, match nothing, and log
+`The selector "find button[type=submit]" on hx-disabled-elt returned no
+matches!` once per preview POST. The form carries
+`hx-disinherit="hx-disabled-elt"` to keep the value on its own submit while
+stopping the leak into the per-step triggers.
+
 ### Lifecycle fragment + HTMX wiring
 
 Each publish / deprecate action posts via HTMX. On the **detail** page it


### PR DESCRIPTION
## Summary

- The runbook authoring editor's per-step live Markdown preview only fired for the first step; steps added via **+ Add step** (and any step past the first on an edit) never rendered a preview and issued no `POST /ui/runbooks/preview`.
- Root cause: each step's Body textarea carries `hx-post="/ui/runbooks/preview"`, but the step markup lives inside an Alpine `<template x-for>` loop. htmx only binds `hx-*` on DOM it renders itself, so Alpine-cloned steps were never htmx-processed. The editor script re-mounted CodeMirror on new bodies but never called `htmx.process`.
- Fix: a `processSteps()` helper hands the form root to `htmx.process` (idempotent — htmx skips already-initialised nodes), folded into a shared `rescan()` that runs on first render, on every `htmx:afterSettle`, and after each add/remove click.
- Also scoped the form's inherited `hx-disabled-elt`: it bound `find button[type=submit]` and, being inherited, leaked into each descendant preview POST — the textarea resolved `find` against itself, matched nothing, and logged `The selector "find button[type=submit]" on hx-disabled-elt returned no matches!` once per preview. `hx-disinherit="hx-disabled-elt"` keeps the value on the form's own submit while stopping the per-step leak.

## Test plan

- [x] `pytest tests/test_ui_runbooks_editor.py` — 22 passed (3 new: htmx.process wiring on `/new`, `hx-disinherit` on the form, multi-step `/edit` hydration carrying the per-step trigger + processing)
- [x] `pytest tests/test_ui_runbooks_{acceptance,lifecycle,list}.py` — 48 passed (no surface regression)
- [x] `ruff check` / `ruff format --check` — clean
- [x] `mypy` (src gate) — Success, 567 files
- [x] `code-quality.py --diff` — exit 0
- [x] Acceptance: each step's Body fires its own debounced preview including added steps (htmx.process on new subtrees); the `hx-disabled-elt … no matches` warning scoped away; test confirms wiring for step 2+ on `/new` and `/edit`

## Framework research

- htmx 2.0.9 (vendored, `VENDOR.md`): `htmx.process(elt)` takes an **Element** and enables htmx behavior on content added outside the normal request cycle (htmx.org/api). `hx-disabled-elt` is an inherited attribute; `hx-disinherit="hx-disabled-elt"` on a parent stops descendants from inheriting it while the parent still applies it to itself (htmx.org/attributes/hx-disinherit). `window.htmx` global guard mirrors the existing idiom in `topology-graph.js` / `broadcast-feed.js`.

## Out of scope

- The already-fixed #2117 "defect 1" (`closest()` invalid `>>` selector on the first step) — distinct root cause.

<!-- auto-implement-issue: fresh, iteration 1 -->

Closes #2174
