### PR TITLE
chore(deps): bump pydantic-ai-slim to v2.7.0 (takeover of #2165)

### DIFF
--- a/backend/pyproject.toml
+++ b/backend/pyproject.toml
@@ -49,7 +49,7 @@ dependencies = [
     # resolver shape can route to OpenAI SaaS / vLLM / Ollama via
     # ``OpenAIProvider(base_url=...)``. All three extras live on the
     # same pin so the version sweep stays monotonic.
-    "pydantic-ai-slim[anthropic,bedrock,openai]>=1.107.0",
+    "pydantic-ai-slim[anthropic,bedrock,openai]>=2.7.0",
     "croniter>=6.2.3",
     "markdown-it-py[linkify]>=4.2.0",
     "pygments>=2.18",

--- a/backend/tests/test_agent_openai_compat_backend.py
+++ b/backend/tests/test_agent_openai_compat_backend.py
@@ -33,6 +33,7 @@ criteria from #1077 map onto the tests as:
 from __future__ import annotations
 
 from collections.abc import Iterator
+from typing import cast
 from uuid import UUID
 
 import pytest
@@ -95,21 +96,23 @@ def _extract_profile(model: Model) -> OpenAIModelProfile:
 
     pydantic_ai exposes the profile through the ``Model.profile``
     property — the resolver wires it via the builder's ``profile=``
-    kwarg, so this reads back what was wired. ``isinstance`` rather
-    than equality so a future framework-side widening of the profile
-    return type (a subclass) still passes the test.
+    kwarg, so this reads back what was wired. As of pydantic-ai v2,
+    ``OpenAIModelProfile`` is a ``TypedDict`` (it was a dataclass in v1),
+    so it can no longer be ``isinstance``-checked; ``Model.profile`` hands
+    back a plain mapping, which we assert is a dict and read as the
+    OpenAI-specific TypedDict.
     """
     profile = model.profile
-    assert isinstance(profile, OpenAIModelProfile), profile
-    return profile
+    assert isinstance(profile, dict), profile
+    return cast(OpenAIModelProfile, profile)
 
 
 def test_openai_chat_profile_matches_openai_saas_quirks() -> None:
     """The OpenAI SaaS profile keeps strict tool defs + multi-system on."""
     profile = openai_chat_profile()
-    assert profile.openai_supports_strict_tool_definition is True
-    assert profile.openai_chat_supports_multiple_system_messages is True
-    assert profile.json_schema_transformer is None
+    assert profile["openai_supports_strict_tool_definition"] is True
+    assert profile["openai_chat_supports_multiple_system_messages"] is True
+    assert profile["json_schema_transformer"] is None
 
 
 def test_vllm_profile_disables_strict_tool_definition() -> None:
@@ -122,9 +125,9 @@ def test_vllm_profile_disables_strict_tool_definition() -> None:
     then rejects on a structural mismatch.
     """
     profile = vllm_chat_profile()
-    assert profile.openai_supports_strict_tool_definition is False
+    assert profile["openai_supports_strict_tool_definition"] is False
     # vLLM still honours multiple system messages.
-    assert profile.openai_chat_supports_multiple_system_messages is True
+    assert profile["openai_chat_supports_multiple_system_messages"] is True
 
 
 def test_ollama_profile_collapses_system_messages() -> None:
@@ -137,8 +140,8 @@ def test_ollama_profile_collapses_system_messages() -> None:
     message-assembly path does the right thing.
     """
     profile = ollama_chat_profile()
-    assert profile.openai_supports_strict_tool_definition is False
-    assert profile.openai_chat_supports_multiple_system_messages is False
+    assert profile["openai_supports_strict_tool_definition"] is False
+    assert profile["openai_chat_supports_multiple_system_messages"] is False
 
 
 def test_openai_compat_capabilities_declare_tools_streaming_no_cache() -> None:
@@ -178,7 +181,7 @@ def test_openai_compat_builder_constructs_openai_chat_model() -> None:
 
     assert isinstance(model, OpenAIChatModel)
     profile = _extract_profile(model)
-    assert profile.openai_supports_strict_tool_definition is True
+    assert profile["openai_supports_strict_tool_definition"] is True
 
 
 def test_openai_compat_builder_honours_vendor_profile_for_vllm() -> None:
@@ -202,8 +205,8 @@ def test_openai_compat_builder_honours_vendor_profile_for_vllm() -> None:
 
     assert isinstance(model, OpenAIChatModel)
     profile = _extract_profile(model)
-    assert profile.openai_supports_strict_tool_definition is False
-    assert profile.openai_chat_supports_multiple_system_messages is True
+    assert profile["openai_supports_strict_tool_definition"] is False
+    assert profile["openai_chat_supports_multiple_system_messages"] is True
 
 
 def test_openai_compat_builder_honours_vendor_profile_for_ollama() -> None:
@@ -219,8 +222,8 @@ def test_openai_compat_builder_honours_vendor_profile_for_ollama() -> None:
 
     assert isinstance(model, OpenAIChatModel)
     profile = _extract_profile(model)
-    assert profile.openai_supports_strict_tool_definition is False
-    assert profile.openai_chat_supports_multiple_system_messages is False
+    assert profile["openai_supports_strict_tool_definition"] is False
+    assert profile["openai_chat_supports_multiple_system_messages"] is False
 
 
 def test_resolver_routes_air_gapped_tenant_to_on_prem_openai_compat() -> None:
@@ -338,8 +341,8 @@ def test_default_openai_builder_picks_ollama_profile_from_base_url_hint(
 
     assert isinstance(model, OpenAIChatModel)
     profile = _extract_profile(model)
-    assert profile.openai_supports_strict_tool_definition is False
-    assert profile.openai_chat_supports_multiple_system_messages is False
+    assert profile["openai_supports_strict_tool_definition"] is False
+    assert profile["openai_chat_supports_multiple_system_messages"] is False
 
 
 def test_default_openai_builder_routes_to_openai_saas_when_no_base_url(
@@ -359,8 +362,8 @@ def test_default_openai_builder_routes_to_openai_saas_when_no_base_url(
 
     assert isinstance(model, OpenAIChatModel)
     profile = _extract_profile(model)
-    assert profile.openai_supports_strict_tool_definition is True
-    assert profile.openai_chat_supports_multiple_system_messages is True
+    assert profile["openai_supports_strict_tool_definition"] is True
+    assert profile["openai_chat_supports_multiple_system_messages"] is True
 
 
 def test_resolver_routes_default_tenant_to_openai_for_saas_only_deploy() -> None:

--- a/backend/tests/test_agent_vcf_paif_backend.py
+++ b/backend/tests/test_agent_vcf_paif_backend.py
@@ -40,6 +40,7 @@ via :mod:`respx`. Acceptance criteria from #1078 map onto the tests as:
 from __future__ import annotations
 
 from collections.abc import Iterator
+from typing import cast
 from uuid import UUID
 
 import httpx
@@ -120,10 +121,10 @@ def test_vcf_paif_chat_profile_matches_vllm_quirks() -> None:
     ``messages[]`` array verbatim; only Ollama collapses them).
     """
     profile = vcf_paif_chat_profile()
-    assert isinstance(profile, OpenAIModelProfile)
-    assert profile.openai_supports_strict_tool_definition is False
-    assert profile.openai_chat_supports_multiple_system_messages is True
-    assert profile.json_schema_transformer is None
+    assert isinstance(profile, dict)
+    assert profile["openai_supports_strict_tool_definition"] is False
+    assert profile["openai_chat_supports_multiple_system_messages"] is True
+    assert profile["json_schema_transformer"] is None
 
 
 def test_vcf_paif_capabilities_declare_tools_streaming_no_cache() -> None:
@@ -344,10 +345,10 @@ def test_paif_backend_builder_constructs_openai_chat_model_with_paif_profile() -
     model = builder()
 
     assert isinstance(model, OpenAIChatModel)
-    profile = model.profile
-    assert isinstance(profile, OpenAIModelProfile)
-    assert profile.openai_supports_strict_tool_definition is False
-    assert profile.openai_chat_supports_multiple_system_messages is True
+    profile = cast(OpenAIModelProfile, model.profile)
+    assert isinstance(profile, dict)
+    assert profile["openai_supports_strict_tool_definition"] is False
+    assert profile["openai_chat_supports_multiple_system_messages"] is True
 
 
 def test_paif_backend_builder_is_lazy_about_provider_resolution() -> None:
@@ -536,9 +537,9 @@ def test_default_paif_builder_constructs_when_settings_complete(
     model = default_vcf_paif_backend_builder()
 
     assert isinstance(model, OpenAIChatModel)
-    profile = model.profile
-    assert isinstance(profile, OpenAIModelProfile)
-    assert profile.openai_supports_strict_tool_definition is False
+    profile = cast(OpenAIModelProfile, model.profile)
+    assert isinstance(profile, dict)
+    assert profile["openai_supports_strict_tool_definition"] is False
 
 
 # ---------------------------------------------------------------------------

--- a/backend/uv.lock
+++ b/backend/uv.lock
@@ -1012,15 +1012,15 @@ wheels = [
 
 [[package]]
 name = "genai-prices"
-version = "0.0.66"
+version = "0.0.70"
 source = { registry = "https://pypi.org/simple" }
 dependencies = [
     { name = "httpx2" },
     { name = "pydantic" },
 ]
-sdist = { url = "https://files.pythonhosted.org/packages/0e/7c/c50fc8d18b283e9b56ff625d45dbe9577c676e1d16636c1011967182d813/genai_prices-0.0.66.tar.gz", hash = "sha256:f087dfe56da28a4c3933dcf846cf2b7111ba733cef674c0cbc66de80212bcd6b", size = 71130, upload-time = "2026-06-09T21:51:14.561Z" }
+sdist = { url = "https://files.pythonhosted.org/packages/08/7c/e8bdd653fb9b292a920b6568b3949176b8de98ad2f84fede2ce44bf318d9/genai_prices-0.0.70.tar.gz", hash = "sha256:62d495aa867bb360ea359866b01d89932365417ba3bd013e0ba7c1d884e09ef9", size = 81827, upload-time = "2026-07-07T18:11:03.667Z" }
 wheels = [
-    { url = "https://files.pythonhosted.org/packages/5c/87/1a36166f91906e47f430f6d4150ec6bfc0001032a363e49fc389021c0609/genai_prices-0.0.66-py3-none-any.whl", hash = "sha256:86b83f107c1cf04bb449a120cd8d4439ceb6843660d9128cde560eb511686d7b", size = 73745, upload-time = "2026-06-09T21:51:13.523Z" },
+    { url = "https://files.pythonhosted.org/packages/34/09/02ec13cb9108862a514cf05ea10ff7f18e523698606ed2976e2cbfa484fa/genai_prices-0.0.70-py3-none-any.whl", hash = "sha256:c7cb9da4944860329450b086dad402f17237b7552165fd3b61b24e291d1ddb88", size = 84312, upload-time = "2026-07-07T18:11:02.373Z" },
 ]
 
 [[package]]
@@ -1703,7 +1703,7 @@ requires-dist = [
     { name = "prometheus-client", specifier = ">=0.20" },
     { name = "pyarrow", specifier = ">=21.0.0" },
     { name = "pydantic", extras = ["email"], specifier = ">=2.13.4" },
-    { name = "pydantic-ai-slim", extras = ["anthropic", "bedrock", "openai"], specifier = ">=1.107.0" },
+    { name = "pydantic-ai-slim", extras = ["anthropic", "bedrock", "openai"], specifier = ">=2.7.0" },
     { name = "pygments", specifier = ">=2.18" },
     { name = "pyjwt", extras = ["crypto"], specifier = ">=2.13.0,<3" },
     { name = "python-frontmatter", specifier = ">=1.3.0" },
@@ -2610,7 +2610,7 @@ email = [
 
 [[package]]
 name = "pydantic-ai-slim"
-version = "1.107.0"
+version = "2.7.0"
 source = { registry = "https://pypi.org/simple" }
 dependencies = [
     { name = "genai-prices" },
@@ -2621,9 +2621,9 @@ dependencies = [
     { name = "pydantic-graph" },
     { name = "typing-inspection" },
 ]
-sdist = { url = "https://files.pythonhosted.org/packages/4c/26/ced63dfaabbc77f3beb86d59689cdea748e7ccffb6b419dbaf4780f211e8/pydantic_ai_slim-1.107.0.tar.gz", hash = "sha256:4616f689a92fcfecfecf2a7af27aca22f139a873cf6d7a8929eaeee9c0eedbb4", size = 779902, upload-time = "2026-06-10T14:53:10.574Z" }
+sdist = { url = "https://files.pythonhosted.org/packages/9a/8f/19e506cac0c29aced85cc06cc99564a3ba40e4ea8b332762f20c4ee5b1f8/pydantic_ai_slim-2.7.0.tar.gz", hash = "sha256:4b04442314de4394547b331e57d588d7dca06ed5394acc26cff34bd885002116", size = 781306, upload-time = "2026-07-09T02:08:38.198Z" }
 wheels = [
-    { url = "https://files.pythonhosted.org/packages/15/57/71044e17f931b08cc3930bc0fe5a1e1fd37fa474ae826be004729ef1cb4a/pydantic_ai_slim-1.107.0-py3-none-any.whl", hash = "sha256:1af49bbae06a6c598f72c54d4734ba377100cac493c9a05fa8e089bebeae0da6", size = 964046, upload-time = "2026-06-10T14:53:03.333Z" },
+    { url = "https://files.pythonhosted.org/packages/2a/87/a96e95db306a9f6729026ec374c5fb2bdf22022f93d501361a07c460f1bc/pydantic_ai_slim-2.7.0-py3-none-any.whl", hash = "sha256:cee9a1d40f8d1de1326603ce1c2818d37768c8fb8043b513c4473684bef3d2ca", size = 957696, upload-time = "2026-07-09T02:08:31.366Z" },
 ]
 
 [package.optional-dependencies]
@@ -2715,7 +2715,7 @@ wheels = [
 
 [[package]]
 name = "pydantic-graph"
-version = "1.107.0"
+version = "2.7.0"
 source = { registry = "https://pypi.org/simple" }
 dependencies = [
     { name = "httpx" },
@@ -2723,9 +2723,9 @@ dependencies = [
     { name = "pydantic" },
     { name = "typing-inspection" },
 ]
-sdist = { url = "https://files.pythonhosted.org/packages/dd/c3/6e8c2d13b8701041f1b3eac5deb41f25d4dbfa479a190d5c6becc23f2a49/pydantic_graph-1.107.0.tar.gz", hash = "sha256:278dd89b3e33f3a2963ac949f27a53aef705c5d883a8ce5d06d23e6e3cfbd972", size = 62564, upload-time = "2026-06-10T14:53:13.366Z" }
+sdist = { url = "https://files.pythonhosted.org/packages/fd/1c/17aab9efff0a37a50fa35d3d69c6c92afe2b602f5885e837dd359ae969c1/pydantic_graph-2.7.0.tar.gz", hash = "sha256:4e5816dba4389c18c799748479754052f624bd3ca613c391c3a418475733cd40", size = 43904, upload-time = "2026-07-09T02:08:40.401Z" }
 wheels = [
-    { url = "https://files.pythonhosted.org/packages/fc/72/621556e3f5068400d43a0375d38e5963de30256eaa5a702aba12e82ed0ff/pydantic_graph-1.107.0-py3-none-any.whl", hash = "sha256:71add94fe7e14c703977a895117c475aae6c0b02a774a036c4d00d9a63c78b00", size = 80106, upload-time = "2026-06-10T14:53:06.543Z" },
+    { url = "https://files.pythonhosted.org/packages/bc/d4/c2781175400b40d149179a4ceaaa0279c89bad70f1aa67f255d5d793297b/pydantic_graph-2.7.0-py3-none-any.whl", hash = "sha256:7ce75e8b5533f7af438b10ce6e9dbb51cf26a5a68cb5f5311325adffa75f45da", size = 51644, upload-time = "2026-07-09T02:08:34.388Z" },
 ]
 
 [[package]]


### PR DESCRIPTION
Takes over Dependabot #2165 (`pydantic-ai-slim` 1.107.0 → 2.x), which can't land on its own because the **v2 major turned `OpenAIModelProfile` from a dataclass into a `TypedDict`** — breaking the model-profile tests that used `isinstance(profile, OpenAIModelProfile)` and attribute access. Dependabot can't make the accompanying test edits, hence this manual takeover.

## Is the library upgrade production-safe?

Yes. `backend/src/meho_backplane/agent/models.py` only **constructs** `OpenAIModelProfile(...)` and passes it to pydantic-ai via `profile=`; it never `isinstance`-checks or attribute-reads a profile. `mypy src/` (strict) passes clean against v2, confirming the construction calls and `profile=` wiring still type-check. Every v2 breaking change was audited against actual usage — `Agent(tools=)`, `@agent.tool`, `UsageLimits(request_limit=)`, `RunUsage.input/output_tokens`, and the model/provider classes are all unchanged in v2.

## Changes

- **`pyproject.toml`**: pin `pydantic-ai-slim[anthropic,bedrock,openai]>=2.7.0`.
- **`uv.lock`**: regenerated — `pydantic-ai-slim`/`pydantic-graph` 1.107.0 → 2.7.0, transitive `genai-prices` 0.0.66 → 0.0.70; nothing else drifted.
- **tests** (`test_agent_openai_compat_backend.py`, `test_agent_vcf_paif_backend.py`): read the profile as a mapping (`profile["<key>"]`), assert `isinstance(profile, dict)`, and `cast()` where `Model.profile` returns the base `ModelProfile` type.

## Verification (local)

- ✅ `uv sync --frozen`
- ✅ `ruff check` + `ruff format --check` (src + tests)
- ✅ `mypy src/` strict — no issues in 567 files
- ✅ full unit suite — **9153 passed, 55 skipped, 0 failed**

The only deselected test, `test_ca_pinned_context_trusts_chaining_cert`, fails **identically on `main`** due to a macOS-local OpenSSL "Missing Authority Key Identifier" quirk — unrelated to this change; it runs fine in CI (Linux).

Closes #2165

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated a core AI dependency to a newer compatible version.

* **Tests**
  * Adjusted backend test coverage to match the updated runtime profile format.
  * Updated assertions for chat/profile behavior so compatibility checks continue to pass.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->