### PR TITLE
feat(connectors): scheme-dispatched target-credential resolver seam (#2229)

### DIFF
--- a/backend/src/meho_backplane/connectors/_shared/credential_backend.py
+++ b/backend/src/meho_backplane/connectors/_shared/credential_backend.py
@@ -1,0 +1,214 @@
+# SPDX-License-Identifier: Apache-2.0
+# Copyright (c) 2026 evoila Group
+
+"""Backend-agnostic target-credential resolution seam.
+
+Every REST connector resolves a target's ``secret_ref`` to vendor
+credentials through :mod:`meho_backplane.connectors._shared.vault_creds`.
+That path was hard-wired to a single store (Vault KV-v2). This module
+adds the **dispatch seam** so a second credential store (GCP Secret
+Manager, #2230) can be added without touching a single connector: a
+kind-keyed registry maps a ``secret_ref`` scheme to a
+:class:`CredentialBackend`, and the loaders in ``vault_creds`` dispatch on
+that scheme instead of always reading Vault.
+
+It is the direct analogue — on the **target credential-read** path — of
+the :data:`~meho_backplane.connectors.secret.endpoints.SECRET_ENDPOINT_REGISTRY`
+seam the ``secret.move`` broker already uses. The two serve different
+contracts (the broker moves one opaque value and reports only its
+SHA-256; a credential backend returns a named-field secret payload a
+connector session builder consumes), so they are deliberately separate
+registries — but the shape is intentionally the same: a
+:func:`~typing.runtime_checkable` :class:`~typing.Protocol`, a
+kind-string → implementation registry, a duplicate-kind guard, and a
+scheme-splitting helper.
+
+Scheme dispatch, zero migration
+===============================
+
+A ``secret_ref`` is either **schemeless** (today's bare KV-v2 logical
+path, ``targets/<id>``) or **scheme-prefixed** (``<kind>:<ref>``). A
+schemeless ref resolves via the deployment's *default* backend
+(``config.credentialBackend`` / ``CREDENTIAL_BACKEND``, default
+``"vault"``), so every existing install — which stores bare paths and
+runs Vault — is unaffected. An explicit ``vault:targets/<id>`` resolves
+identically to the schemeless form. An unknown scheme (``gsm:...`` before
+#2230 registers it) raises :class:`UnknownCredentialBackendError` naming
+the kind and the registered kinds, rather than silently attempting a
+Vault read of a nonsensical path.
+
+The scheme split is intentionally conservative: a colon is treated as a
+scheme separator **only** when the segment before the first colon is a
+bare scheme token (a leading letter followed by letters / digits /
+``+`` / ``.`` / ``-``, no slash). A logical KV-v2 path never carries such
+a prefix, so a path that happens to contain a colon deeper in a segment
+is left schemeless rather than mis-split.
+
+No secret in this module
+========================
+
+Nothing here reads or holds a credential value — this is pure routing.
+The concrete backend (:class:`~...vault_creds.VaultCredentialBackend`)
+owns the read and the same no-secret-in-logs discipline the rest of the
+credential path enforces.
+"""
+
+from __future__ import annotations
+
+import re
+from typing import TYPE_CHECKING, Protocol, runtime_checkable
+
+if TYPE_CHECKING:
+    from meho_backplane.auth.operator import Operator
+
+__all__ = [
+    "CREDENTIAL_BACKEND_REGISTRY",
+    "DEFAULT_CREDENTIAL_BACKEND",
+    "CredentialBackend",
+    "UnknownCredentialBackendError",
+    "register_credential_backend",
+    "resolve_credential_backend",
+    "split_credential_ref",
+]
+
+#: The backend kind schemeless ``secret_ref`` values resolve through when
+#: ``config.credentialBackend`` / ``CREDENTIAL_BACKEND`` is unset. ``vault``
+#: keeps every existing install on today's Vault KV-v2 read with no config
+#: change — the zero-migration default.
+DEFAULT_CREDENTIAL_BACKEND: str = "vault"
+
+#: A bare scheme token: a leading letter then letters / digits / ``+`` /
+#: ``.`` / ``-`` (loosely RFC 3986 scheme shape, minus the ``:``). A
+#: ``secret_ref`` prefix matching this before the first colon is treated
+#: as a backend kind; anything else (notably a path segment with a slash)
+#: leaves the ref schemeless.
+_SCHEME_TOKEN = re.compile(r"^[a-zA-Z][a-zA-Z0-9+.\-]*$")
+
+
+@runtime_checkable
+class CredentialBackend(Protocol):
+    """Structural contract a credential store adapter satisfies.
+
+    A backend resolves a store-specific ``secret_ref`` (the part *after*
+    the ``<kind>:`` scheme, or the whole schemeless ref) plus the
+    request-scoped :class:`~meho_backplane.auth.operator.Operator` to the
+    secret's raw field payload — a plain ``dict[str, object]`` of the
+    named fields stored for the target. Field extraction, whitespace
+    normalisation, and the no-secret structlog event stay in the shared
+    loader, so a new backend only implements the store read.
+
+    Because this is a :func:`~typing.runtime_checkable`
+    :class:`~typing.Protocol`, an adapter need only define
+    :meth:`load_secret_data` and register itself via
+    :func:`register_credential_backend` — no base class.
+    """
+
+    async def load_secret_data(
+        self,
+        secret_ref: str,
+        operator: Operator,
+        *,
+        target_name: str,
+        mount: str,
+    ) -> dict[str, object]:
+        """Read the store secret at *secret_ref* and return its field dict.
+
+        Parameters
+        ----------
+        secret_ref
+            The store-specific reference (scheme already stripped by the
+            dispatcher). For the Vault backend this is the logical KV-v2
+            path; for a future backend it is that store's address form.
+        operator
+            The request-scoped operator. A backend that performs an
+            operator-context read (Vault JWT/OIDC) forwards
+            ``operator.raw_jwt``; a backend that reads under a
+            deployment identity (GSM SA-direct, #2230) may ignore it.
+        target_name
+            Names the target in error messages — never a credential value.
+        mount
+            A Vault-KV concept threaded through the shared loader's
+            existing ``mount=`` parameter. Backends that have no mount
+            concept (GSM) ignore it.
+
+        Returns a flat ``{field: value}`` dict. Raises a store-specific
+        error (the Vault backend raises ``VaultCredentialsReadError`` /
+        ``VaultClientError``) when the ref is missing, malformed, or
+        unreadable — never a bare ``KeyError``, never echoing a value.
+        """
+        ...
+
+
+class UnknownCredentialBackendError(Exception):
+    """No backend is registered for a ``secret_ref``'s resolved kind.
+
+    Raised by :func:`resolve_credential_backend` when a scheme
+    (``gsm:`` before #2230) — or a ``config.credentialBackend`` value —
+    names a kind absent from :data:`CREDENTIAL_BACKEND_REGISTRY`. Mirrors
+    the actionable, distinct-from-read-phase contract of
+    ``VaultCredentialsReadError``: the message names the unknown kind and
+    the registered kinds so the misconfiguration is fixable at a glance,
+    and the dispatch fails loudly instead of falling through to a silent
+    Vault read.
+    """
+
+
+#: Kind-string → :class:`CredentialBackend` registry. Populated at import
+#: time: each backend module calls :func:`register_credential_backend` for
+#: the kind it serves (``vault_creds`` registers ``"vault"`` at import; a
+#: future GSM module registers ``"gsm"``). The shared loader reads it to
+#: resolve a parsed kind to the backend that performs the store read. No
+#: loader change is needed to add a backend.
+CREDENTIAL_BACKEND_REGISTRY: dict[str, CredentialBackend] = {}
+
+
+def register_credential_backend(kind: str, backend: CredentialBackend) -> None:
+    """Register *backend* as the resolver for ``secret_ref`` kind *kind*.
+
+    Called once per backend at import time. Re-registering an existing
+    kind raises :class:`ValueError` — two backends claiming one kind is a
+    wiring bug that should fail the eager-import pass loudly rather than
+    silently shadowing one with the other (same posture as
+    ``register_secret_endpoint``).
+    """
+    if kind in CREDENTIAL_BACKEND_REGISTRY:
+        raise ValueError(
+            f"credential backend kind {kind!r} is already registered "
+            f"(by {CREDENTIAL_BACKEND_REGISTRY[kind]!r}); kinds must be unique"
+        )
+    CREDENTIAL_BACKEND_REGISTRY[kind] = backend
+
+
+def resolve_credential_backend(kind: str) -> CredentialBackend:
+    """Return the backend registered for *kind* or raise a clear error.
+
+    Raises :class:`UnknownCredentialBackendError` naming the unknown kind
+    and the registered kinds when no backend serves *kind*.
+    """
+    backend = CREDENTIAL_BACKEND_REGISTRY.get(kind)
+    if backend is None:
+        known = ", ".join(sorted(CREDENTIAL_BACKEND_REGISTRY)) or "(none)"
+        raise UnknownCredentialBackendError(
+            f"no credential backend registered for kind {kind!r}; registered kinds: {known}"
+        )
+    return backend
+
+
+def split_credential_ref(secret_ref: str, *, default_backend: str) -> tuple[str, str]:
+    """Split *secret_ref* into ``(kind, store_ref)``.
+
+    A ``<kind>:<ref>`` value with a bare scheme token before the first
+    colon (and a non-empty remainder) splits into that kind and the
+    remainder. Everything else — no colon, an empty remainder, or a
+    prefix that is not a bare scheme token (e.g. a path segment with a
+    slash) — is schemeless and resolves through *default_backend* with the
+    ref passed through verbatim.
+
+    * ``"targets/vc-01"`` → ``(default_backend, "targets/vc-01")``
+    * ``"vault:targets/vc-01"`` → ``("vault", "targets/vc-01")``
+    * ``"gsm:proj/secret#pw"`` → ``("gsm", "proj/secret#pw")``
+    """
+    kind, sep, rest = secret_ref.partition(":")
+    if sep and rest and _SCHEME_TOKEN.match(kind):
+        return kind, rest
+    return default_backend, secret_ref

--- a/backend/src/meho_backplane/connectors/_shared/vault_creds.py
+++ b/backend/src/meho_backplane/connectors/_shared/vault_creds.py
@@ -77,11 +77,18 @@ import structlog
 
 from meho_backplane.auth.operator import Operator
 from meho_backplane.auth.vault import vault_client_for_operator
+from meho_backplane.connectors._shared.credential_backend import (
+    register_credential_backend,
+    resolve_credential_backend,
+    split_credential_ref,
+)
+from meho_backplane.settings import get_settings
 
 __all__ = [
     "DEFAULT_BASIC_CREDENTIAL_FIELDS",
     "DEFAULT_KV_MOUNT",
     "BasicCredentialsTargetLike",
+    "VaultCredentialBackend",
     "VaultCredentialsReadError",
     "load_basic_credentials",
     "load_vault_secret_data",
@@ -216,48 +223,25 @@ def _is_api_path_shaped(secret_ref: str) -> bool:
     return len(segments) >= 2 and segments[1] == "data"
 
 
-def _resolve_secret_ref(target: BasicCredentialsTargetLike, operator: Operator) -> str:
-    """Validate the pre-read preconditions and return the KV-v2 path.
+def _require_secret_ref(target: BasicCredentialsTargetLike) -> str:
+    """Return *target*'s stripped ``secret_ref`` or raise if unconfigured.
 
-    Three fail-closed guards, all raising :class:`VaultCredentialsReadError`
-    *before* Vault is touched:
+    The one **backend-agnostic** precondition — every credential backend
+    needs a ref to resolve — so it runs in the shared loader before the
+    scheme is split and the backend is dispatched. A target with
+    ``secret_ref=None`` is unconfigured → :class:`VaultCredentialsReadError`.
+    The stripped value is returned so trailing whitespace never slips into
+    the scheme split or the downstream store read.
 
-    * empty ``operator.raw_jwt`` — an operator-context read requires an
-      authenticated operator. System-initiated calls (topology scheduler,
-      readiness probe) carry ``raw_jwt=""`` and must error here rather
-      than silently falling back to a backplane identity (the decision's
-      system-call carve-out).
-    * unset ``target.secret_ref`` — the target is unconfigured.
-    * API-path-shaped ``secret_ref`` — a value embedding the mount or the
-      ``/data/`` API segment (``secret/data/…``, ``kv/data/…``,
-      ``data/…``). hvac inserts ``/data/`` itself, so such a value
-      silently double-resolves to a 404; we reject it with an actionable
-      error rather than guessing operator intent (no auto-stripping).
-
-    Returns the stripped ``secret_ref`` path so trailing whitespace never
-    slips into the hvac call.
+    Backend-specific guards (the operator-JWT carve-out, the Vault KV-v2
+    API-path shape check) live in the resolved backend, not here — a
+    non-Vault backend does not share them.
     """
-    if not operator.raw_jwt:
-        raise VaultCredentialsReadError(
-            "operator-context credential read requires an authenticated operator; "
-            f"target={target.name!r} has no operator JWT (system-initiated calls "
-            "cannot read per-target vendor credentials)"
-        )
     if not target.secret_ref:
         raise VaultCredentialsReadError(
-            f"target {target.name!r} has no secret_ref configured; cannot read "
-            "its basic credentials from Vault"
+            f"target {target.name!r} has no secret_ref configured; cannot resolve its credentials"
         )
-    secret_ref = target.secret_ref.strip()
-    if _is_api_path_shaped(secret_ref):
-        raise VaultCredentialsReadError(
-            f"target {target.name!r} has a KV-v2 API-path-shaped secret_ref "
-            f"{secret_ref!r}; secret_ref must be the logical KV-v2 path relative "
-            "to the mount (e.g. 'targets/<id>'). Drop the 'secret/data/' / "
-            "'kv/data/' / 'data/' prefix — Vault adds the '/data/' segment for "
-            "KV-v2 reads, so a prefixed value double-resolves to a 404."
-        )
-    return secret_ref
+    return target.secret_ref.strip()
 
 
 def _extract_fields(
@@ -286,6 +270,122 @@ def _extract_fields(
             )
         credentials[field] = strip_credential_value(secret_data[field])
     return credentials
+
+
+class VaultCredentialBackend:
+    """The Vault KV-v2 credential backend — today's behaviour, unchanged.
+
+    Registered under kind ``"vault"`` (and the schemeless default), so a
+    schemeless ``targets/<id>`` ref and an explicit ``vault:targets/<id>``
+    ref resolve through exactly this read. It owns the Vault-specific
+    fail-closed guard:
+
+    * API-path-shaped ``secret_ref`` — a value embedding the mount or the
+      ``/data/`` API segment (``secret/data/…``, ``kv/data/…``,
+      ``data/…``). hvac inserts ``/data/`` itself, so such a value
+      silently double-resolves to a 404; reject it with an actionable
+      error rather than guessing operator intent (no auto-stripping).
+      This is a KV-v2 wire-format concern, so it stays on the Vault path
+      only (AC #4).
+
+    The empty-``raw_jwt`` operator-context precondition is **not** here:
+    it runs once in the shared loader (:func:`_resolve_and_load`) before
+    the backend is dispatched, matching today's ordering (the guard fires
+    before any settings read or store access). It reflects the
+    operator-context Vault model that is the only backend today; a future
+    backend that reads under a deployment identity would relax it there.
+    """
+
+    async def load_secret_data(
+        self,
+        secret_ref: str,
+        operator: Operator,
+        *,
+        target_name: str,
+        mount: str = DEFAULT_KV_MOUNT,
+    ) -> dict[str, object]:
+        """Read *secret_ref* as a KV-v2 secret under *operator*'s identity.
+
+        Applies the API-path guard, opens
+        :func:`~meho_backplane.auth.vault.vault_client_for_operator`
+        (JWT/OIDC login forwarding ``operator.raw_jwt``), reads the secret
+        off the event loop (``asyncio.to_thread`` — hvac is synchronous),
+        and structurally unwraps the nested ``data["data"]`` to the flat
+        secret-field dict.
+        """
+        if _is_api_path_shaped(secret_ref):
+            raise VaultCredentialsReadError(
+                f"target {target_name!r} has a KV-v2 API-path-shaped secret_ref "
+                f"{secret_ref!r}; secret_ref must be the logical KV-v2 path relative "
+                "to the mount (e.g. 'targets/<id>'). Drop the 'secret/data/' / "
+                "'kv/data/' / 'data/' prefix — Vault adds the '/data/' segment for "
+                "KV-v2 reads, so a prefixed value double-resolves to a 404."
+            )
+
+        async with vault_client_for_operator(operator) as client:
+            payload = await asyncio.to_thread(
+                client.secrets.kv.v2.read_secret_version,
+                path=secret_ref,
+                mount_point=mount,
+                raise_on_deleted_version=False,
+            )
+
+        return _structural_unwrap(payload, target_name=target_name)
+
+
+#: The Vault backend is stateless, so a single shared instance serves every
+#: read. Registered at import time under ``"vault"``; ``vault_creds`` is
+#: imported by every connector session module, so the kind is always
+#: present before any credential resolution runs.
+register_credential_backend("vault", VaultCredentialBackend())
+
+
+async def _resolve_and_load(
+    target: BasicCredentialsTargetLike,
+    operator: Operator,
+    *,
+    mount: str,
+) -> tuple[str, dict[str, object]]:
+    """Resolve *target*'s ``secret_ref`` to its secret-field dict via dispatch.
+
+    The shared backend-agnostic path both public loaders funnel through:
+
+    1. Enforce the operator-context precondition (empty ``operator.raw_jwt``
+       fails closed) and require a configured ``secret_ref``. Both run
+       before any settings read or store access, matching today's ordering
+       — a system-initiated call fails closed without needing chassis
+       configuration.
+    2. Split the scheme — schemeless refs resolve through the deployment
+       default (``config.credentialBackend`` / ``CREDENTIAL_BACKEND``,
+       default ``vault``); an explicit ``<kind>:`` prefix selects that
+       backend.
+    3. Dispatch to the resolved backend (:class:`UnknownCredentialBackendError`
+       on an unregistered kind) to read the store secret.
+
+    Returns ``(store_ref, secret_data)`` — the scheme-stripped store ref
+    is handed back so the caller can name it in a missing-field error.
+    """
+    # Operator-context precondition. System-initiated calls (topology
+    # scheduler, readiness probe, the runbook verify dispatch's synthetic
+    # operator) carry ``raw_jwt=""`` and must fail closed rather than
+    # silently fall back to a backplane identity — the decision's
+    # system-call carve-out. Runs before the settings read / dispatch so a
+    # system operator fails closed without needing chassis config, exactly
+    # as before the seam. Reflects the operator-context model of today's
+    # only backend (Vault); a deployment-identity backend would relax it.
+    if not operator.raw_jwt:
+        raise VaultCredentialsReadError(
+            "operator-context credential read requires an authenticated operator; "
+            f"target={target.name!r} has no operator JWT (system-initiated calls "
+            "cannot read per-target vendor credentials)"
+        )
+    ref = _require_secret_ref(target)
+    kind, store_ref = split_credential_ref(ref, default_backend=get_settings().credential_backend)
+    backend = resolve_credential_backend(kind)
+    secret_data = await backend.load_secret_data(
+        store_ref, operator, target_name=target.name, mount=mount
+    )
+    return store_ref, secret_data
 
 
 async def load_basic_credentials(
@@ -349,20 +449,14 @@ async def load_basic_credentials(
         rejected the JWT for the role). Propagated verbatim so callers
         can distinguish login-phase from read-phase failure.
     """
-    # Fail-closed precondition guards (empty JWT / unset secret_ref) run
-    # before Vault is touched; returns the stripped KV-v2 path.
-    path = _resolve_secret_ref(target, operator)
-
-    async with vault_client_for_operator(operator) as client:
-        payload = await asyncio.to_thread(
-            client.secrets.kv.v2.read_secret_version,
-            path=path,
-            mount_point=mount,
-            raise_on_deleted_version=False,
-        )
-
-    secret_data = _structural_unwrap(payload, target_name=target.name)
-    credentials = _extract_fields(secret_data, fields, target_name=target.name, secret_ref=path)
+    # Scheme-dispatched resolution: the unset-secret_ref guard runs before
+    # any backend is touched, then the ref's scheme (schemeless/``vault:``
+    # → the Vault KV-v2 read) selects the backend. ``store_ref`` is the
+    # scheme-stripped ref, named in a missing-field error.
+    store_ref, secret_data = await _resolve_and_load(target, operator, mount=mount)
+    credentials = _extract_fields(
+        secret_data, fields, target_name=target.name, secret_ref=store_ref
+    )
 
     # Log only non-secret attribution: target / host / the field *names*
     # requested — never a credential value. The returned dict is
@@ -412,17 +506,7 @@ async def load_vault_secret_data(
     read-phase precondition / unwrap failures raise
     :class:`VaultCredentialsReadError`.
     """
-    path = _resolve_secret_ref(target, operator)
-
-    async with vault_client_for_operator(operator) as client:
-        payload = await asyncio.to_thread(
-            client.secrets.kv.v2.read_secret_version,
-            path=path,
-            mount_point=mount,
-            raise_on_deleted_version=False,
-        )
-
-    secret_data = _structural_unwrap(payload, target_name=target.name)
+    _store_ref, secret_data = await _resolve_and_load(target, operator, mount=mount)
 
     # Log only the field-name set (no values). Sorted for a stable log
     # shape that diff-friendly observability tooling can pattern-match

--- a/backend/src/meho_backplane/settings.py
+++ b/backend/src/meho_backplane/settings.py
@@ -899,6 +899,16 @@ class Settings(BaseModel):
     vault_namespace: str | None = None
     vault_timeout_seconds: float = Field(default=10.0, gt=0)
     vault_scheduler_token: str = Field(default="", repr=False)
+    # #2229 (Initiative #2227) — names the credential backend a schemeless
+    # target ``secret_ref`` resolves through. ``vault`` (the default) keeps
+    # every existing install on today's Vault KV-v2 read with no config
+    # change: a schemeless ``targets/<id>`` ref and an explicit
+    # ``vault:targets/<id>`` ref both dispatch to the Vault backend. A
+    # scheme-prefixed ref (``gsm:<project>/<secret>`` once #2230 registers
+    # the GSM backend) overrides this per-target. Setting it is a no-op for
+    # Vault installs. Chart wiring (``config.credentialBackend`` →
+    # ``CREDENTIAL_BACKEND``) lands with the GSM Helm surface in #2231.
+    credential_backend: str = Field(default="vault", min_length=1)
     database_url: str = Field(min_length=1)
     database_pool_size: int = Field(default=10, gt=0)
     database_pool_timeout: float = Field(default=30.0, gt=0)
@@ -1445,6 +1455,10 @@ def get_settings() -> Settings:
             os.environ.get("VAULT_TIMEOUT_SECONDS", "10.0"),
         ),
         vault_scheduler_token=os.environ.get("VAULT_SCHEDULER_TOKEN", "").strip(),
+        # Empty / whitespace-only ``CREDENTIAL_BACKEND`` falls back to the
+        # ``vault`` default so a blank chart value never yields an unknown
+        # ("") backend kind (``min_length=1`` on the field would reject it).
+        credential_backend=(os.environ.get("CREDENTIAL_BACKEND", "").strip() or "vault"),
         database_url=os.environ["DATABASE_URL"],
         database_pool_size=int(os.environ.get("DATABASE_POOL_SIZE", "10")),
         database_pool_timeout=float(

--- a/backend/tests/test_connectors_credential_backend.py
+++ b/backend/tests/test_connectors_credential_backend.py
@@ -1,0 +1,166 @@
+# SPDX-License-Identifier: Apache-2.0
+# Copyright (c) 2026 evoila Group
+
+"""Unit tests for the backend-agnostic credential-resolution seam.
+
+These pin the pure routing layer in
+:mod:`meho_backplane.connectors._shared.credential_backend` — the scheme
+split, the kind-keyed registry, and the unknown-kind error — independent
+of any store read. The Vault-backed dispatch (schemeless / ``vault:`` →
+today's KV-v2 read) and the unknown-scheme rejection *through the loader*
+are covered in ``test_connectors_vault_creds.py``.
+"""
+
+from __future__ import annotations
+
+from collections.abc import Iterator
+
+import pytest
+
+from meho_backplane.auth.operator import Operator
+from meho_backplane.connectors._shared.credential_backend import (
+    CREDENTIAL_BACKEND_REGISTRY,
+    CredentialBackend,
+    UnknownCredentialBackendError,
+    register_credential_backend,
+    resolve_credential_backend,
+    split_credential_ref,
+)
+
+
+class _FakeBackend:
+    """A minimal :class:`CredentialBackend` for registry tests."""
+
+    async def load_secret_data(
+        self,
+        secret_ref: str,
+        operator: Operator,
+        *,
+        target_name: str,
+        mount: str,
+    ) -> dict[str, object]:
+        return {"seen_ref": secret_ref}
+
+
+@pytest.fixture
+def _clean_kind() -> Iterator[str]:
+    """Yield a throwaway registry kind and remove it after the test.
+
+    The registry is process-global (populated at import time by every
+    backend module), so a test that registers a kind must clean up or it
+    poisons sibling tests with a duplicate-registration ``ValueError``.
+    """
+    kind = "test-fake-backend"
+    try:
+        yield kind
+    finally:
+        CREDENTIAL_BACKEND_REGISTRY.pop(kind, None)
+
+
+# ---------------------------------------------------------------------------
+# Scheme split
+# ---------------------------------------------------------------------------
+
+
+def test_schemeless_ref_resolves_through_default_backend() -> None:
+    """A bare KV-v2 path has no scheme → the deployment default backend."""
+    assert split_credential_ref("targets/vc-01", default_backend="vault") == (
+        "vault",
+        "targets/vc-01",
+    )
+
+
+def test_explicit_vault_scheme_is_split_off() -> None:
+    """``vault:targets/vc-01`` → kind ``vault`` + the schemeless remainder."""
+    assert split_credential_ref("vault:targets/vc-01", default_backend="vault") == (
+        "vault",
+        "targets/vc-01",
+    )
+
+
+def test_gsm_scheme_is_split_off_with_field_fragment() -> None:
+    """An unregistered scheme still splits; the remainder keeps its ``#field``."""
+    assert split_credential_ref("gsm:proj/secret#pw", default_backend="vault") == (
+        "gsm",
+        "proj/secret#pw",
+    )
+
+
+def test_default_backend_selects_schemeless_target() -> None:
+    """``config.credentialBackend`` (the *default_backend* arg) routes schemeless refs.
+
+    Proves AC #4 at the split layer: with the default set to ``gsm``, a
+    schemeless ref resolves through ``gsm`` — a Vault install (default
+    ``vault``) keeps routing schemeless refs to Vault, so the setting is a
+    no-op there.
+    """
+    assert split_credential_ref("targets/vc-01", default_backend="gsm") == (
+        "gsm",
+        "targets/vc-01",
+    )
+
+
+@pytest.mark.parametrize(
+    "ref",
+    [
+        "vsphere/vcenter-a:8443",  # colon deeper in a slashed segment
+        "targets/data-center-01",  # no colon at all
+        "vault:",  # empty remainder — not a scheme split
+        ":targets/x",  # empty kind — not a scheme split
+    ],
+)
+def test_non_scheme_colons_stay_schemeless(ref: str) -> None:
+    """A colon that isn't a ``<bare-token>:<non-empty>`` prefix is left in place.
+
+    The split treats a colon as a scheme separator only when the segment
+    before it is a bare scheme token (leading letter, no slash) *and* the
+    remainder is non-empty. Anything else resolves through the default
+    backend with the ref passed through verbatim, so a logical KV-v2 path
+    that happens to contain a colon is never mis-split.
+    """
+    assert split_credential_ref(ref, default_backend="vault") == ("vault", ref)
+
+
+# ---------------------------------------------------------------------------
+# Registry: register / resolve / unknown
+# ---------------------------------------------------------------------------
+
+
+def test_vault_kind_is_registered_at_import() -> None:
+    """Importing the credential path registers the built-in ``vault`` backend."""
+    # ``vault_creds`` registers ``"vault"`` at import; importing the loader
+    # module here guarantees the side effect has run.
+    import meho_backplane.connectors._shared.vault_creds  # noqa: F401
+
+    backend = resolve_credential_backend("vault")
+    assert isinstance(backend, CredentialBackend)
+
+
+def test_register_and_resolve_roundtrip(_clean_kind: str) -> None:
+    """A registered backend resolves back by its kind."""
+    backend = _FakeBackend()
+    register_credential_backend(_clean_kind, backend)
+    assert resolve_credential_backend(_clean_kind) is backend
+
+
+def test_duplicate_registration_raises(_clean_kind: str) -> None:
+    """Re-registering a kind is a wiring bug → ``ValueError``, not silent shadow."""
+    register_credential_backend(_clean_kind, _FakeBackend())
+    with pytest.raises(ValueError, match="already registered"):
+        register_credential_backend(_clean_kind, _FakeBackend())
+
+
+def test_resolve_unknown_kind_raises_with_actionable_message() -> None:
+    """An unregistered kind raises naming the kind and the registered kinds."""
+    with pytest.raises(UnknownCredentialBackendError) as exc:
+        resolve_credential_backend("definitely-not-registered")
+
+    msg = str(exc.value)
+    assert "no credential backend registered for kind 'definitely-not-registered'" in msg
+    # The registered kinds are listed so the misconfig is fixable at a glance.
+    assert "vault" in msg
+
+
+def test_fake_backend_satisfies_protocol_structurally() -> None:
+    """The runtime-checkable Protocol accepts any class with ``load_secret_data``."""
+    assert isinstance(_FakeBackend(), CredentialBackend)

--- a/backend/tests/test_connectors_vault_creds.py
+++ b/backend/tests/test_connectors_vault_creds.py
@@ -41,6 +41,9 @@ from structlog.testing import capture_logs
 
 from meho_backplane.auth.operator import Operator, TenantRole
 from meho_backplane.auth.vault import VaultRoleDeniedError
+from meho_backplane.connectors._shared.credential_backend import (
+    UnknownCredentialBackendError,
+)
 from meho_backplane.connectors._shared.vault_creds import (
     DEFAULT_BASIC_CREDENTIAL_FIELDS,
     DEFAULT_KV_MOUNT,
@@ -445,3 +448,70 @@ async def test_no_secret_value_in_log_events(
     serialised = repr(captured)
     assert _CANARY_PASSWORD not in serialised
     assert _CANARY_USERNAME not in serialised
+
+
+# ---------------------------------------------------------------------------
+# Scheme dispatch (#2229) — vault: / schemeless are today's behaviour;
+# an unknown scheme fails loudly instead of a silent Vault attempt.
+# ---------------------------------------------------------------------------
+
+
+async def test_explicit_vault_scheme_resolves_identically_to_schemeless(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """``vault:targets/<id>`` reads the same KV-v2 path as the schemeless form.
+
+    The scheme is stripped before the read, so the Vault call addresses
+    the bare logical path — byte-for-byte the schemeless behaviour.
+    """
+    fake = install_fake_client(
+        monkeypatch,
+        secret={"username": _CANARY_USERNAME, "password": _CANARY_PASSWORD},
+    )
+
+    creds = await load_basic_credentials(
+        _Target(secret_ref="vault:targets/vc-lab-01"), _make_operator("op.jwt")
+    )
+
+    assert creds == {"username": _CANARY_USERNAME, "password": _CANARY_PASSWORD}
+    # The scheme is stripped: the read addresses the logical path, not
+    # ``vault:targets/vc-lab-01``.
+    assert fake.secrets.kv.v2.read_calls[-1] == {
+        "path": "targets/vc-lab-01",
+        "mount_point": DEFAULT_KV_MOUNT,
+    }
+
+
+async def test_unknown_scheme_raises_no_backend_error_without_touching_vault(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """A ``gsm:`` ref (backend lands in #2230) fails loudly, never a silent Vault read."""
+    fake = install_fake_client(monkeypatch, secret={"username": "u", "password": "p"})
+
+    with pytest.raises(UnknownCredentialBackendError) as exc:
+        await load_basic_credentials(
+            _Target(secret_ref="gsm:my-project/vc-lab-01"), _make_operator()
+        )
+
+    msg = str(exc.value)
+    assert "no credential backend registered for kind 'gsm'" in msg
+    # Vault was never reached — dispatch failed before any login / read.
+    assert fake.auth.jwt.login_calls == []
+    assert fake.secrets.kv.v2.read_calls == []
+
+
+async def test_explicit_vault_scheme_still_enforces_api_path_guard(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """The KV-v2 API-path guard stays on the vault-kind path (AC #4).
+
+    ``vault:secret/data/foo`` strips to ``secret/data/foo`` — an
+    API-path-shaped ref — and is rejected by the Vault backend's guard.
+    """
+    fake = install_fake_client(monkeypatch, secret={"username": "u", "password": "p"})
+
+    with pytest.raises(VaultCredentialsReadError) as exc:
+        await load_basic_credentials(_Target(secret_ref="vault:secret/data/foo"), _make_operator())
+
+    assert "API-path-shaped secret_ref" in str(exc.value)
+    assert fake.secrets.kv.v2.read_calls == []

--- a/backend/tests/test_settings.py
+++ b/backend/tests/test_settings.py
@@ -380,3 +380,54 @@ def test_vault_tenant_scope_prefix_rejects_malformed_templates(raw: str) -> None
             vault_kv_tenant_scope_prefix=raw,
         )
     assert "VAULT_KV_TENANT_SCOPE_PREFIX" in str(exc_info.value)
+
+
+# ---------------------------------------------------------------------------
+# #2229 (Initiative #2227) — CREDENTIAL_BACKEND env knob
+# ---------------------------------------------------------------------------
+
+
+def test_credential_backend_defaults_to_vault_when_unset(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """Unset ``CREDENTIAL_BACKEND`` → ``vault`` (zero migration for existing installs)."""
+    _base_env(monkeypatch)
+    monkeypatch.delenv("CREDENTIAL_BACKEND", raising=False)
+    get_settings.cache_clear()
+    try:
+        assert get_settings().credential_backend == "vault"
+    finally:
+        get_settings.cache_clear()
+
+
+def test_credential_backend_reads_env_override(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """A set ``CREDENTIAL_BACKEND`` names the schemeless default backend."""
+    _base_env(monkeypatch)
+    monkeypatch.setenv("CREDENTIAL_BACKEND", "gsm")
+    get_settings.cache_clear()
+    try:
+        assert get_settings().credential_backend == "gsm"
+    finally:
+        get_settings.cache_clear()
+
+
+@pytest.mark.parametrize("raw", ["", "   ", "\n"])
+def test_credential_backend_blank_env_falls_back_to_vault(
+    monkeypatch: pytest.MonkeyPatch,
+    raw: str,
+) -> None:
+    """A blank / whitespace-only value falls back to ``vault``, never an empty kind.
+
+    A blank chart value must not yield an unknown ("") backend kind — the
+    ``min_length=1`` field would reject it and every credential read would
+    fail. The env loader coerces blank to the ``vault`` default.
+    """
+    _base_env(monkeypatch)
+    monkeypatch.setenv("CREDENTIAL_BACKEND", raw)
+    get_settings.cache_clear()
+    try:
+        assert get_settings().credential_backend == "vault"
+    finally:
+        get_settings.cache_clear()

--- a/docs/codebase/connectors-shared-vault-creds.md
+++ b/docs/codebase/connectors-shared-vault-creds.md
@@ -17,6 +17,22 @@ auth method, giving per-operator RBAC (templated ACL policy) and
 per-operator audit (Vault attributes the read to the operator's Identity
 entity) through the single `meho-mcp` role.
 
+Since #2229 (Initiative #2227) the loaders no longer read Vault directly.
+They resolve the target's `secret_ref` through a **backend-agnostic
+dispatch seam** (`connectors/_shared/credential_backend.py`): a
+`secret_ref` scheme selects a `CredentialBackend` from a kind-keyed
+registry. A schemeless ref (`targets/<id>`) resolves through the
+deployment default (`config.credentialBackend` / `CREDENTIAL_BACKEND`,
+default `vault`) and an explicit `vault:targets/<id>` ref resolves
+identically — both dispatch to `VaultCredentialBackend`, today's KV-v2
+read, byte-for-byte. An unknown scheme (`gsm:` before #2230 registers the
+GSM backend) raises `UnknownCredentialBackendError` instead of a silent
+Vault attempt. The seam is the target-credential analogue of the
+`SECRET_ENDPOINT_REGISTRY` the `secret.move` broker already uses; the two
+are separate registries because they serve different contracts (the
+broker moves one opaque value; a credential backend returns a named-field
+payload). See `## Credential-backend dispatch seam` below.
+
 The helper reuses the lower-level primitive
 `meho_backplane.auth.vault.vault_client_for_operator` + hvac's
 `read_secret_version` — **not** the `vault.kv.read` op handler. The op
@@ -66,6 +82,12 @@ dispatcher's `connector_error` branch.
 - **`DEFAULT_BASIC_CREDENTIAL_FIELDS = ("username", "password")`** — the
   basic-credentials field names a vendor session-establish call needs;
   shared so loaders and tests have one source of truth.
+- **`VaultCredentialBackend`** — the `CredentialBackend` for kind
+  `vault`, registered at import under `"vault"` (and the schemeless
+  default). Its `load_secret_data(secret_ref, operator, *, target_name,
+  mount)` holds the KV-v2 API-path guard, the operator-context Vault read,
+  and the structural unwrap. The loaders dispatch to it; direct callers
+  should keep using `load_basic_credentials` / `load_vault_secret_data`.
 
 ## Control flow
 
@@ -73,43 +95,60 @@ dispatcher's `connector_error` branch.
    system-initiated call — topology scheduler, readiness probe, the
    runbook verify dispatch's synthetic operator built by
    `runbooks/run_service.py::_build_operator_for_dispatch`), raise
-   `VaultCredentialsReadError` *before* touching Vault. The decision's
-   system-call carve-out: such calls cannot perform an operator-context
-   read and must error, never silently fall back to a backplane identity.
+   `VaultCredentialsReadError` *before* touching Vault — and before the
+   scheme is split or `get_settings()` is read (`_resolve_and_load`). The
+   decision's system-call carve-out: such calls cannot perform an
+   operator-context read and must error, never silently fall back to a
+   backplane identity. This operator-context precondition lives in the
+   shared dispatch, not in a backend, so it fires before any settings /
+   store access exactly as before the seam; it reflects the
+   operator-context model of today's only backend (Vault), and a future
+   deployment-identity backend (GSM SA-direct, #2230) would relax it.
    Synthetic operators must carry `raw_jwt=""` — a non-empty placeholder
    would sail past this guard and forward an invalid string to Vault's
    JWT/OIDC login (a live network round-trip before rejection).
 2. **Reject unset `secret_ref`.** A target with `secret_ref=None` is
-   unconfigured → `VaultCredentialsReadError`.
-3. **Reject an API-path-shaped `secret_ref`.** `secret_ref` must be the
-   *logical* KV-v2 path relative to the mount — hvac builds the wire URL
-   as `/{mount_point}/data/{path}` and inserts the `/data/` segment
-   itself. A value embedding the mount or that segment (`secret/data/…`,
-   `kv/data/…`, leading `data/…`) double-resolves to a 404, so the guard
-   (`_is_api_path_shaped`) rejects it with a `VaultCredentialsReadError`
-   naming the target and the logical-path fix — no auto-stripping. The
-   predicate is *specific*: it trips only when the first path segment is
-   `data` or the second is `data`, so a logical segment legitimately
-   named `data` deeper in the path (`targets/data-center-01/host`) stays
-   valid.
-4. **Read under operator identity.** `async with
+   unconfigured → `VaultCredentialsReadError` (`_require_secret_ref`);
+   the value is stripped for the scheme split and read.
+3. **Split the scheme and dispatch.** `split_credential_ref` resolves the
+   ref to `(kind, store_ref)`: a schemeless ref uses the deployment
+   default (`config.credentialBackend`, default `vault`), an explicit
+   `<kind>:` prefix selects that kind, and `resolve_credential_backend`
+   maps the kind to a `CredentialBackend` (`UnknownCredentialBackendError`
+   on an unregistered kind). Everything below runs inside the resolved
+   backend; for the Vault backend:
+4. **Reject an API-path-shaped `secret_ref` (Vault backend only).**
+   `secret_ref` must be the *logical* KV-v2 path relative to the mount —
+   hvac builds the wire URL as `/{mount_point}/data/{path}` and inserts
+   the `/data/` segment itself. A value embedding the mount or that
+   segment (`secret/data/…`, `kv/data/…`, leading `data/…`)
+   double-resolves to a 404, so the guard (`_is_api_path_shaped`) rejects
+   it with a `VaultCredentialsReadError` naming the target and the
+   logical-path fix — no auto-stripping. The predicate is *specific*: it
+   trips only when the first path segment is `data` or the second is
+   `data`, so a logical segment legitimately named `data` deeper in the
+   path (`targets/data-center-01/host`) stays valid. This is a KV-v2
+   wire-format concern, so it stays on the Vault path only.
+5. **Read under operator identity.** `async with
    vault_client_for_operator(operator) as client:` performs the JWT/OIDC
    login, then `await asyncio.to_thread(client.secrets.kv.v2.\
    read_secret_version, path=..., mount_point=mount,
    raise_on_deleted_version=False)`. Login-phase failures
    (`VaultUnreachableError` / `VaultRoleDeniedError`) propagate verbatim.
    The per-request Vault token is revoked on context exit.
-5. **Structural unwrap.** KV-v2's GET returns `{"data": {"data":
+6. **Structural unwrap.** KV-v2's GET returns `{"data": {"data":
    {<secret kv>}, "metadata": {...}}}`; the secret content is the nested
    `data["data"]` (the same double-unwrap `vault/ops.py:308` performs). A
    malformed payload raises `VaultCredentialsReadError`, not a bare
-   `KeyError`.
-6. **Extract fields.** For each name in `fields`, a missing key raises
+   `KeyError`. This is the backend's return value — the shared loader
+   takes it from here.
+7. **Extract fields.** For each name in `fields`, a missing key raises
    `VaultCredentialsReadError` naming the target + the missing field +
-   the `secret_ref`. Present values pass through `strip_credential_value`
-   (coerced to `str`, surrounding whitespace stripped) so a trailing
-   newline never rides into a vendor auth header / token body (#1474).
-7. **Log non-secret attribution only.** A single
+   the `store_ref` (the scheme-stripped ref). Present values pass through
+   `strip_credential_value` (coerced to `str`, surrounding whitespace
+   stripped) so a trailing newline never rides into a vendor auth header /
+   token body (#1474).
+8. **Log non-secret attribution only.** A single
    `vault_basic_credentials_loaded` structlog event carries `target` /
    `host` / the requested field *names* — never a value. The returned
    dict is ephemeral in-memory state and must not enter any log event,
@@ -118,6 +157,54 @@ dispatcher's `connector_error` branch.
    a module-level proxy so `structlog.testing.capture_logs` can reach the
    event under the production `cache_logger_on_first_use=True` config —
    same precedent as `meho_backplane.auth.rbac.require_role`.
+
+## Credential-backend dispatch seam
+
+`backend/src/meho_backplane/connectors/_shared/credential_backend.py` is
+the pure routing layer the loaders funnel through (#2229, Initiative
+#2227). It holds no secret and performs no read — it only maps a
+`secret_ref` scheme to the backend that reads.
+
+- **`CredentialBackend`** — a `runtime_checkable typing.Protocol`. A
+  backend implements `async load_secret_data(secret_ref, operator, *,
+  target_name, mount) -> dict[str, object]`, returning the store secret's
+  raw field dict. Field extraction, whitespace normalisation, and the
+  no-secret structlog event stay in the shared loader, so a new backend
+  only implements the store read. `mount` is a Vault-KV concept threaded
+  through the loader's existing `mount=` parameter; a backend with no
+  mount concept (GSM, #2230) ignores it.
+- **`CREDENTIAL_BACKEND_REGISTRY` + `register_credential_backend(kind,
+  backend)`** — kind-string → backend registry, populated at import time
+  (`vault_creds` registers `"vault"`). A duplicate kind raises
+  `ValueError` (a wiring bug should fail the eager-import pass loudly),
+  mirroring `register_secret_endpoint`.
+- **`resolve_credential_backend(kind)`** — returns the backend or raises
+  **`UnknownCredentialBackendError`** naming the unknown kind and the
+  registered kinds. Distinct from `VaultCredentialsReadError` (a config
+  error, not a read-phase failure) but with the same actionable posture.
+- **`split_credential_ref(secret_ref, *, default_backend)`** — splits a
+  ref into `(kind, store_ref)`. A colon is a scheme separator only when
+  the segment before it is a bare scheme token (leading letter, no slash)
+  and the remainder is non-empty; everything else is schemeless and
+  resolves through `default_backend`. A logical KV-v2 path never carries
+  such a prefix, so a path with a colon deeper in a segment is never
+  mis-split.
+- **`DEFAULT_CREDENTIAL_BACKEND = "vault"`** — the schemeless default when
+  `config.credentialBackend` / `CREDENTIAL_BACKEND` is unset (mirrored by
+  `Settings.credential_backend`, default `vault`). Zero migration: every
+  existing install stores bare paths and runs Vault, so nothing changes.
+
+This is the target-credential analogue of
+`connectors/secret/endpoints.py`'s `SECRET_ENDPOINT_REGISTRY` (the
+`secret.move` broker seam). The two are intentionally separate registries:
+the broker moves one opaque value and reports only its SHA-256
+(`SecretEndpoint.read_secret` → `SecretMaterial`), while a credential
+backend returns a named-field payload a connector session builder
+consumes. Same shape, different contract.
+
+Chart wiring (`config.credentialBackend` → `CREDENTIAL_BACKEND` in the
+Helm configmap) lands with the GSM Helm surface in #2231; the setting is
+already read here so a value flows the moment the chart exposes it.
 
 ## Dependencies
 
@@ -174,6 +261,10 @@ dispatcher's `connector_error` branch.
 
 ## References
 
+- Dispatch seam Task: https://github.com/evoila/meho/issues/2229
+- Pluggable-backend Initiative: https://github.com/evoila/meho/issues/2227
+- Prior-art seam: `backend/src/meho_backplane/connectors/secret/endpoints.py`
+  (`SECRET_ENDPOINT_REGISTRY`, the `secret.move` broker).
 - Task: https://github.com/evoila/meho/issues/941
 - Credential whitespace strip: https://github.com/evoila/meho/issues/1474
 - Shape guard: https://github.com/evoila/meho/issues/989


### PR DESCRIPTION
## Summary

- Adds a **backend-agnostic target-credential resolution seam** so a second credential store (GCP Secret Manager, #2230) can be added without touching any connector. The shared loaders (`load_basic_credentials` / `load_vault_secret_data`) now dispatch on the `secret_ref` scheme instead of always reading Vault.
- New `connectors/_shared/credential_backend.py`: a `runtime_checkable` `CredentialBackend` Protocol, a kind-keyed `CREDENTIAL_BACKEND_REGISTRY` (+ `register_credential_backend` / `resolve_credential_backend`), a conservative `split_credential_ref`, and `UnknownCredentialBackendError`. This is the target-credential analogue of the `secret.move` broker's `SECRET_ENDPOINT_REGISTRY` (separate registry — different contract).
- `VaultCredentialBackend` (registered under `vault` at import) holds today's KV-v2 read + the API-path-shape guard, so **schemeless `targets/<id>` and explicit `vault:targets/<id>` refs resolve byte-for-byte identically** — zero migration. An unknown scheme (`gsm:…`) raises a clear "no credential backend registered for kind 'gsm'" error instead of a silent Vault attempt (the GSM backend lands in #2230).
- `config.credentialBackend` / `CREDENTIAL_BACKEND` (new `Settings.credential_backend`, default `vault`) selects the schemeless default; a blank value coerces to `vault`. No GSM code here — backwards-compatible seam only.

The operator-context precondition (empty `operator.raw_jwt` fails closed) stays in the shared loader and fires before any settings read or store access — preserving today's ordering so a system-initiated call fails closed without needing chassis config. The KV-v2 API-path guard moves onto the vault-kind path only (AC #4).

## Test plan

- [x] `ruff check` / `ruff format --check` — clean
- [x] `mypy` (changed source) — clean
- [x] code-quality `--diff` — 0 blockers (3 pre-existing size warnings)
- [x] **AC #1** schemeless ref resolves via Vault, all existing credread unit + fixture tests pass unchanged — full unit suite green (`pytest tests/ --ignore=tests/integration`)
- [x] **AC #2** `vault:targets/<id>` resolves identically to schemeless — new `test_explicit_vault_scheme_resolves_identically_to_schemeless` (read addresses the stripped logical path)
- [x] **AC #3** unknown scheme `gsm:` raises "no credential backend registered for kind 'gsm'", Vault never touched — new `test_unknown_scheme_raises_no_backend_error_without_touching_vault`
- [x] **AC #4** `config.credentialBackend` default `vault`, no-op for Vault installs; API-path guard vault-only — new settings tests + `test_default_backend_selects_schemeless_target` + `test_explicit_vault_scheme_still_enforces_api_path_guard`
- [x] **AC #5** new dispatch-table + unknown-scheme coverage (`test_connectors_credential_backend.py`); connector-registry assertions still pass; no CLI OpenAPI snapshot change (no route/schema touched)

## Out of scope

- GSM backend (`gsm:<project>/<secret>[#field]` resolver + `google-cloud-secret-manager` dep) — #2230.
- Helm `config.credentialBackend` → `CREDENTIAL_BACKEND` configmap wiring + `values.schema.json` — lands with the GSM Helm surface in #2231. The setting is already read, so a value flows the moment the chart exposes it.
- Adjacent (recorded, not addressed): `vault_creds.py` is now 521 lines and `settings.py` 1630 lines (pre-existing size warnings from the code-quality gate).

<!-- auto-implement-issue: fresh, iteration 1 -->

Closes #2229


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added support for routing credential lookups through a backend-based scheme, with a default Vault path and optional scheme-based selection.
  * Introduced a new settings option to choose the credential backend.
* **Bug Fixes**
  * Improved handling of empty or whitespace-only backend settings so they safely fall back to the default.
  * Added clearer errors when an unknown credential backend is requested.
* **Documentation**
  * Updated connector docs to reflect the new credential lookup flow and backend selection behavior.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->