### PR TITLE
feat(operations): inject connector session into composite handlers (#2251)

### DIFF
--- a/backend/src/meho_backplane/connectors/vmware_rest/composites/_read.py
+++ b/backend/src/meho_backplane/connectors/vmware_rest/composites/_read.py
@@ -1,5 +1,9 @@
 # SPDX-License-Identifier: Apache-2.0
 # Copyright (c) 2026 evoila Group
+# code-quality-allow: file-size — pre-existing 7-composite handler module
+# (>1200 lines before #2251); this task only appends the direct-session
+# opt-in documentation to the existing "four reasons" note. Splitting the
+# module is I-B migration work (Initiative #2248/#2249), out of scope here.
 
 """Read-only ``vmware.composite.*`` handler functions (7 composites).
 
@@ -43,6 +47,44 @@ four load-bearing reasons (per #508's issue body + the
    httpx evades both.
 4. **Param validation** -- each sub-op's ``parameter_schema`` validates
    inbound params at dispatch time; direct httpx skips validation.
+
+Direct-session opt-in (the substrate, #2251)
+--------------------------------------------
+
+The composite handler contract also lets a handler receive the
+resolved connector instance directly, by declaring a ``connector``
+parameter alongside (or instead of) ``dispatch_child``. The dispatcher
+forwards the instance it already resolved for the composite's target
+(:func:`~meho_backplane.operations.dispatcher._resolve_connector_instance`);
+:func:`~meho_backplane.operations._branches.dispatch_composite` passes
+it only when the handler declares the parameter, so the existing
+``dispatch_child``-only handlers below are unchanged. A handler that
+opts in issues its sub-calls through the connector's own session
+(``connector._get_json`` / ``connector._post_json`` +
+``connector.mount_op_path``) with **no** ``endpoint_descriptor``
+lookup.
+
+This is the substrate the I-B migrations (Initiative #2248) build on;
+no composite in this module is migrated yet. Taking the direct path
+deliberately drops two of the four ``dispatch_child`` guarantees and
+relocates the other two:
+
+* **(2) Bounded recursion is moot** -- a direct session call cannot
+  re-enter the dispatcher, so there is no recursion to bound.
+* **(4) Per-sub-op param validation goes away** -- for a
+  code-constructed request body this is the point, not a loss:
+  re-validating a hand-built vmomi body against a persisted spec
+  schema is the schema-drift defect the two-world model (Goal #2247)
+  exists to remove.
+* **(1) Audit-tree linkage** collapses to the top-level op's own
+  audit row (the row a forensic query reads anyway); the per-sub-op
+  child rows disappear.
+* **(3) Per-sub-op policy-gate + broadcast is evaded** -- acceptable
+  for **read** composites (the top-level op is already gated), but
+  **load-bearing for write** composites whose sub-ops may be
+  approval-gated. Migrating a write composite to the direct path must
+  first resolve how the top-level policy/approval gate still covers
+  the now-internal writes (Initiative #2249, the property-3 question).
 
 Op_id contract for sub-ops
 --------------------------

--- a/backend/src/meho_backplane/operations/_branches.py
+++ b/backend/src/meho_backplane/operations/_branches.py
@@ -506,28 +506,50 @@ async def dispatch_composite(
     target: Any,
     params: dict[str, Any],
     dispatch_child: Callable[..., Awaitable[Any]],
+    connector_instance: Connector | None = None,
 ) -> Any:
     """Invoke a ``source_kind='composite'`` handler with the dispatcher seam.
 
-    Composite handlers receive ``(operator, target, params,
-    dispatch_child)``; they call ``dispatch_child(...)`` recursively for
-    sub-ops. The ``dispatch_child`` callable is built by
-    :func:`~meho_backplane.operations.composite.get_dispatch_child` and
-    wraps :func:`~meho_backplane.operations.dispatcher.dispatch` so that
-    the audit-tree linkage (``parent_audit_id_var`` contextvar -> real
-    ``audit_log.parent_audit_id`` column) and bounded-recursion guard
-    (``composite_depth_var`` contextvar checked against
-    :attr:`~meho_backplane.settings.Settings.composite_max_depth`) are
-    applied automatically -- the handler reads as plain business logic.
+    Composite handlers receive ``(operator, target, params)`` plus at
+    least one sub-call capability, chosen by which parameters the
+    handler declares:
 
-    The keyword the handler sees is ``dispatch_child`` (not raw
-    ``dispatch``); composite handlers annotate the parameter against
-    the :class:`~meho_backplane.operations.composite.DispatchChild`
-    Protocol for static type checking.
+    * ``dispatch_child`` -- the catalog-routed seam. Built by
+      :func:`~meho_backplane.operations.composite.get_dispatch_child`,
+      it wraps :func:`~meho_backplane.operations.dispatcher.dispatch`
+      so audit-tree linkage (``parent_audit_id_var`` contextvar -> the
+      real ``audit_log.parent_audit_id`` column) and the
+      bounded-recursion guard (``composite_depth_var`` checked against
+      :attr:`~meho_backplane.settings.Settings.composite_max_depth`)
+      apply automatically. Handlers annotate it against the
+      :class:`~meho_backplane.operations.composite.DispatchChild`
+      Protocol for static type checking.
+    * ``connector`` -- the direct-session substrate (#2251). The
+      resolved connector instance the dispatcher already built for
+      this composite's ``target`` (via
+      :func:`~meho_backplane.operations.dispatcher._resolve_connector_instance`).
+      A handler that opts in issues sub-calls through the connector's
+      own session (``connector._get_json`` / ``connector._post_json`` /
+      ``connector.mount_op_path``) with no ``endpoint_descriptor``
+      lookup. See ``connectors/vmware_rest/composites/_read.py``'s
+      "Why ``dispatch_child`` not direct httpx" note for which of the
+      four ``dispatch_child`` guarantees the direct path drops and why.
+
+    Both capabilities are forwarded **only when the handler declares
+    the matching parameter**, so the existing ``dispatch_child``-only
+    handlers keep their exact signature and a direct-session handler
+    can omit ``dispatch_child`` entirely. A handler may declare both
+    (e.g. a composite that recurses into another composite via
+    ``dispatch_child`` yet reads its own connector via ``connector``).
     """
-    return await handler(
-        operator=operator,
-        target=target,
-        params=params,
-        dispatch_child=dispatch_child,
-    )
+    param_names = set(inspect.signature(handler).parameters)
+    call_kwargs: dict[str, Any] = {
+        "operator": operator,
+        "target": target,
+        "params": params,
+    }
+    if "dispatch_child" in param_names:
+        call_kwargs["dispatch_child"] = dispatch_child
+    if "connector" in param_names:
+        call_kwargs["connector"] = connector_instance
+    return await handler(**call_kwargs)

--- a/backend/src/meho_backplane/operations/dispatcher.py
+++ b/backend/src/meho_backplane/operations/dispatcher.py
@@ -555,6 +555,11 @@ async def _run_source_kind_branch(
             target=target,
             params=params,
             dispatch_child=dispatch_child,
+            # Forward the instance the resolver already built for this
+            # composite's target (#2251). ``dispatch_composite`` hands it
+            # to the handler only when the handler declares a ``connector``
+            # parameter, so ``dispatch_child``-only handlers are untouched.
+            connector_instance=connector_instance,
         )
     # The DB CHECK constraint on source_kind prevents this in practice;
     # the explicit raise keeps the dispatcher's error contract honest

--- a/backend/src/meho_backplane/operations/typed_register.py
+++ b/backend/src/meho_backplane/operations/typed_register.py
@@ -446,8 +446,10 @@ type TypedOpHandler = Callable[..., Awaitable[dict[str, Any]]]
 #: ``self`` that disappears at bind time. The shape contract is
 #: enforced at registration time by
 #: :func:`validate_composite_handler_signature`, which asserts the
-#: handler exposes a ``dispatch_child`` parameter -- the only positional
-#: distinction from typed handlers.
+#: handler exposes a ``dispatch_child`` and/or a ``connector`` parameter
+#: -- the sub-call-capability distinction from typed handlers (#2251
+#: added the direct-session ``connector`` seam alongside
+#: ``dispatch_child``).
 type CompositeOpHandler = Callable[..., Awaitable[dict[str, Any]]]
 
 
@@ -576,30 +578,45 @@ def _handler_parameter_names(handler: Any) -> list[str]:
 
 
 def validate_composite_handler_signature(handler: Any) -> None:
-    """Assert *handler* accepts a ``dispatch_child`` parameter.
+    """Assert *handler* declares at least one sub-call capability.
 
-    Composite handlers receive
-    ``dispatch_child: DispatchChild`` from the dispatcher at invocation
-    time
-    (:func:`~meho_backplane.operations._branches.dispatch_composite`).
-    Registering a handler without it would surface the failure as a
-    :exc:`TypeError` at first dispatch -- late, with poor signal.
-    Checking the signature at registration time fails fast with an
-    operator-readable message and the handler's dotted path.
+    A composite is defined by *how it reaches its sub-ops*. The
+    dispatcher offers two seams
+    (:func:`~meho_backplane.operations._branches.dispatch_composite`),
+    and a composite handler opts into either or both by declaring the
+    matching parameter:
+
+    * ``dispatch_child`` -- the catalog-routed
+      :class:`~meho_backplane.operations.composite.DispatchChild`
+      callable (audit-tree linkage, bounded recursion, per-sub-op
+      policy/broadcast + param validation).
+    * ``connector`` -- the direct-session substrate (#2251): the
+      resolved connector instance, so the handler issues sub-calls
+      through the connector's own session with no ``endpoint_descriptor``
+      lookup.
+
+    A handler declaring **neither** is not a composite -- it has no way
+    to reach a sub-op -- and would surface the failure as a
+    :exc:`TypeError` at first dispatch (missing keyword), late and with
+    poor signal. Checking the signature at registration time fails fast
+    with an operator-readable message and the handler's dotted path.
 
     Raises
     ------
     HandlerSignatureError
-        Handler's parameters do not include ``dispatch_child``.
+        Handler's parameters include neither ``dispatch_child`` nor
+        ``connector``.
     """
     param_names = _handler_parameter_names(handler)
-    if "dispatch_child" not in param_names:
+    if "dispatch_child" not in param_names and "connector" not in param_names:
         module = getattr(handler, "__module__", "<unknown>")
         qualname = getattr(handler, "__qualname__", repr(handler))
         raise HandlerSignatureError(
             f"composite handler {module}.{qualname} "
             f"must accept a 'dispatch_child' parameter "
-            f"(per meho_backplane.operations.composite.DispatchChild); "
+            f"(per meho_backplane.operations.composite.DispatchChild) "
+            f"and/or a 'connector' parameter (the resolved connector "
+            f"instance, for direct-session sub-calls); "
             f"signature is ({', '.join(param_names)})"
         )
 
@@ -1140,8 +1157,9 @@ async def register_composite_operation(
     one private upsert path (:func:`_register_in_session`) -- they
     differ in (a) the column they write to ``source_kind`` (this one
     writes ``"composite"``), (b) the handler-signature contract they
-    enforce (this one rejects handlers without ``dispatch_child``),
-    and (c) the policy defaults (this one defaults
+    enforce (this one rejects handlers that declare neither
+    ``dispatch_child`` nor ``connector``), and (c) the policy defaults
+    (this one defaults
     ``safety_level="dangerous"`` and ``requires_approval=True``).
 
     Parameters
@@ -1158,11 +1176,14 @@ async def register_composite_operation(
         Must be a module-level function or bound method (closure /
         lambda / :class:`functools.partial` rejected via
         :func:`derive_handler_ref`'s contract -- shared with the typed
-        helper). The handler MUST accept a ``dispatch_child``
-        parameter; the dispatcher's composite branch
+        helper). The handler MUST accept a ``dispatch_child`` and/or a
+        ``connector`` parameter; the dispatcher's composite branch
         (:func:`~meho_backplane.operations._branches.dispatch_composite`)
-        passes a :class:`~meho_backplane.operations.composite.DispatchChild`
-        callable in by keyword. Handlers missing the parameter raise
+        passes the
+        :class:`~meho_backplane.operations.composite.DispatchChild`
+        callable and/or the resolved connector instance in by keyword,
+        matching whichever the handler declares (#2251). A handler
+        declaring neither has no way to reach a sub-op and raises
         :class:`HandlerSignatureError` at registration time -- not
         first dispatch -- so the failure surfaces in lifespan.
     summary, description, parameter_schema, response_schema, group_key, when_to_use, tags
@@ -1204,8 +1225,9 @@ async def register_composite_operation(
         bounded enum, or the ``group_key`` / ``when_to_use`` pairing
         contract is violated (see :func:`register_typed_operation`).
     HandlerSignatureError
-        Handler does not accept a ``dispatch_child`` parameter, **or**
-        the natural key is already registered with
+        Handler accepts neither a ``dispatch_child`` nor a
+        ``connector`` parameter, **or** the natural key is already
+        registered with
         ``source_kind="typed"`` -- cross-kind re-registration is
         rejected at lookup time so a dispatch-time :exc:`TypeError`
         cannot surface from an inconsistent persisted row. Subclass

--- a/backend/tests/fixtures/composites/handlers.py
+++ b/backend/tests/fixtures/composites/handlers.py
@@ -91,6 +91,23 @@ async def composite_dispatch_child_handler(
     return {"sub_status": result.status, "sub_result": result.result}
 
 
+async def composite_connector_only_handler(
+    operator: Operator,
+    target: Any,
+    params: dict[str, Any],
+    connector: Any,
+) -> dict[str, Any]:
+    """A direct-session composite -- declares ``connector``, not ``dispatch_child``.
+
+    The #2251 substrate: the dispatcher forwards the resolved connector
+    instance and the handler issues sub-calls through the connector's own
+    session. Used by the guard test asserting
+    :func:`register_composite_operation` accepts a composite that reaches
+    its sub-op via ``connector`` alone.
+    """
+    return {"ok": True, "params": params}
+
+
 class CompositeHandlerHost:
     """A class with an async composite method.
 

--- a/backend/tests/test_operations_composite.py
+++ b/backend/tests/test_operations_composite.py
@@ -194,9 +194,64 @@ class _NoOpVaultConnector(Connector):
         raise NotImplementedError
 
 
+#: Records ``(path, kwargs)`` for every ``_get_json`` the direct-session
+#: composite issues, so the test can assert the sub-call hit the
+#: connector's own session rather than the catalog dispatch path.
+_direct_session_calls: list[tuple[str, dict[str, Any]]] = []
+
+
+class _DirectSessionConnector(Connector):
+    """Resolver-satisfying connector exposing a stubbed session method.
+
+    Stands in for a real ``HttpConnector`` subclass (e.g.
+    ``VmwareRestConnector``) whose ``_get_json`` a direct-session
+    composite calls instead of routing sub-ops through ``dispatch_child``
+    (#2251). The stub records each call and returns a canned payload so
+    the test can assert the sub-call fired without any HTTP transport.
+    """
+
+    product = "directsvc"
+    version = "1.x"
+    impl_id = "directsvc"
+
+    async def fingerprint(self, target: Any, operator: Any = None) -> FingerprintResult:  # type: ignore[override]
+        raise NotImplementedError
+
+    async def probe(self, target: Any) -> ProbeResult:  # type: ignore[override]
+        raise NotImplementedError
+
+    async def execute(  # type: ignore[override]
+        self,
+        target: Any,
+        op_id: str,
+        params: dict[str, Any],
+    ) -> OperationResult:
+        raise NotImplementedError
+
+    async def _get_json(self, path: str, **kwargs: Any) -> dict[str, Any]:
+        _direct_session_calls.append((path, kwargs))
+        return {"path": path, "rows": [{"id": 1}]}
+
+
 # ---------------------------------------------------------------------------
 # Module-level handlers used as test fixtures
 # ---------------------------------------------------------------------------
+
+
+async def _direct_session_composite(
+    operator: Operator,
+    target: Any,
+    params: dict[str, Any],
+    connector: _DirectSessionConnector,
+) -> dict[str, Any]:
+    """Composite that reaches its sub-op through the connector session.
+
+    Declares ``connector`` (not ``dispatch_child``), so the dispatcher
+    forwards the resolved connector instance and the sub-call runs
+    through ``connector._get_json`` with no descriptor lookup (#2251).
+    """
+    payload = await connector._get_json(f"/inventory/{params['kind']}")
+    return {"rows": payload["rows"]}
 
 
 async def _child_handler(
@@ -611,6 +666,90 @@ async def test_dispatch_composite_two_children_produces_audit_tree(
     assert tree[parent.id].parent_audit_id is None
     for child in child_rows:
         assert tree[child.id].parent_audit_id == parent.id
+
+
+@pytest.mark.asyncio
+async def test_dispatch_composite_direct_session_bypasses_descriptor_lookup(
+    stub_embedding_service: AsyncMock,
+    session: AsyncSession,
+    captured_events: list[BroadcastEvent],
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """A ``connector``-declaring composite calls the session directly (#2251).
+
+    The handler issues its sub-call through ``connector._get_json`` with
+    no ``dispatch_child``; the dispatcher forwards the resolved connector
+    instance and no *second* ``lookup_descriptor`` (the catalog round-trip
+    a ``dispatch_child`` sub-op would trigger) occurs.
+    """
+    import meho_backplane.operations.dispatcher as dispatcher_module
+
+    _direct_session_calls.clear()
+
+    register_connector_v2(
+        product="directsvc",
+        version="",
+        impl_id="",
+        cls=_DirectSessionConnector,
+    )
+    session.add(
+        EndpointDescriptor(
+            id=uuid.uuid4(),
+            tenant_id=None,
+            product="directsvc",
+            version="1.x",
+            impl_id="directsvc",
+            op_id="directsvc.composite.inventory",
+            source_kind="composite",
+            method=None,
+            path=None,
+            handler_ref="tests.test_operations_composite._direct_session_composite",
+            summary="Direct-session composite.",
+            description="Composite that dispatches via the connector session.",
+            tags=[],
+            parameter_schema={"type": "object"},
+            response_schema=None,
+            llm_instructions=None,
+            safety_level="safe",
+            requires_approval=False,
+            is_enabled=True,
+            embedding=stub_embedding_service.encode_one.return_value,
+            custom_description=None,
+            custom_notes=None,
+            created_at=datetime.now(UTC),
+            updated_at=datetime.now(UTC),
+        )
+    )
+    await session.commit()
+
+    # Count descriptor lookups: the top-level composite op resolves one;
+    # a direct-session sub-call must resolve none (that's the whole point).
+    real_lookup = dispatcher_module.lookup_descriptor
+    lookup_calls = {"n": 0}
+
+    async def _counting_lookup(**kwargs: Any) -> Any:
+        lookup_calls["n"] += 1
+        return await real_lookup(**kwargs)
+
+    monkeypatch.setattr(dispatcher_module, "lookup_descriptor", _counting_lookup)
+
+    operator = _make_operator()
+    target = _FakeTarget(product="directsvc")
+
+    result = await dispatch(
+        operator=operator,
+        connector_id="directsvc-1.x",
+        op_id="directsvc.composite.inventory",
+        target=target,
+        params={"kind": "hosts"},
+    )
+
+    assert result.status == "ok", result.error
+    assert result.result == {"rows": [{"id": 1}]}
+    # The sub-call hit the connector's stubbed session exactly once.
+    assert _direct_session_calls == [("/inventory/hosts", {})]
+    # Only the top-level op resolved a descriptor -- the sub-call did not.
+    assert lookup_calls["n"] == 1
 
 
 @pytest.mark.asyncio

--- a/backend/tests/test_operations_composite_register.py
+++ b/backend/tests/test_operations_composite_register.py
@@ -80,6 +80,7 @@ from meho_backplane.operations import (
 from meho_backplane.settings import get_settings
 from tests.fixtures.composites.handlers import (
     CompositeHandlerHost,
+    composite_connector_only_handler,
     composite_dispatch_child_handler,
     composite_module_level_handler,
     composite_typed_shaped_handler,
@@ -420,6 +421,41 @@ async def test_register_composite_rejects_typed_shaped_handler(
         )
     # Message names the handler's dotted path so the operator can find it.
     assert "composite_typed_shaped_handler" in str(excinfo.value)
+
+
+@pytest.mark.asyncio
+async def test_register_composite_accepts_connector_only_handler(
+    stub_embedding_service: AsyncMock,
+) -> None:
+    """A direct-session composite (``connector``, no ``dispatch_child``) registers (#2251)."""
+    await register_composite_operation(
+        product="vmware",
+        version="9.0",
+        impl_id="vmware-rest",
+        op_id="vmware.composite.direct",
+        handler=composite_connector_only_handler,
+        summary="Direct-session composite.",
+        description="Reaches its sub-op through the connector session.",
+        parameter_schema={"type": "object"},
+        safety_level="safe",
+        requires_approval=False,
+        when_to_use=None,
+        embedding_service=stub_embedding_service,
+    )
+
+    sessionmaker = get_sessionmaker()
+    async with sessionmaker() as fresh:
+        row = (
+            await fresh.execute(
+                select(EndpointDescriptor).where(
+                    EndpointDescriptor.op_id == "vmware.composite.direct"
+                )
+            )
+        ).scalar_one()
+    assert row.source_kind == "composite"
+    assert row.handler_ref == (
+        "tests.fixtures.composites.handlers.composite_connector_only_handler"
+    )
 
 
 @pytest.mark.asyncio

--- a/docs/architecture/operations-substrate.md
+++ b/docs/architecture/operations-substrate.md
@@ -313,6 +313,12 @@ async def vmware_vm_create_composite(
 
 Spelling the contract as a `typing.Protocol` rather than a raw `Callable` alias gives mypy + Pyright the keyword-argument shape (`connector_id` / `op_id` / `params` / `target`) so handler call sites are structurally type-checked. The Protocol → factory split also keeps the import graph one-directional (composite handlers depend on the contract; the dispatcher depends on the handlers).
 
+### Direct-session sub-calls (`connector` seam, #2251)
+
+`dispatch_child` is not the only sub-call capability. A composite handler can instead (or additionally) declare a `connector` parameter; `dispatch_composite` then forwards the connector instance the dispatcher already resolved for the composite's `target` (via `_resolve_connector_instance`). A handler that opts in issues sub-calls through the connector's own session (`connector._get_json` / `connector._post_json` + `connector.mount_op_path`) with **no** `endpoint_descriptor` lookup — the "two-world" posture (Goal #2247) that keeps a code-shipped op's dispatch path off a mutable catalog row.
+
+Both seams are forwarded **only when the handler declares the matching parameter**, so the `dispatch_child`-only handlers above are unchanged, and the registration guard (`validate_composite_handler_signature`) accepts a handler declaring either or both. Taking the direct path deliberately drops the per-sub-op audit row, param validation, recursion bound, and policy/broadcast that `dispatch_child` provides; those trade-offs — and why per-sub-op policy stays load-bearing for *write* composites — are documented on the "Why `dispatch_child` not direct httpx" note in [`connectors/vmware_rest/composites/_read.py`](../../backend/src/meho_backplane/connectors/vmware_rest/composites/_read.py). No shipped composite uses the direct seam yet; the incremental migrations are Initiative #2248/#2249.
+
 ### `parent_audit_id` semantics
 
 The composite branch builds the `dispatch_child` callable via [`get_dispatch_child(...)`](../../backend/src/meho_backplane/operations/composite.py), passing the parent's `audit_id`. The factory closes over `parent_audit_id` and binds it on `parent_audit_id_var` for the duration of each child dispatch. The child's audit row reads the contextvar via `parent_audit_id_var.get()` and writes the UUID to its `audit_log.parent_audit_id` column.


### PR DESCRIPTION
## Summary
- Widens the composite handler contract so a handler can reach its sub-ops through the connector's **own session** instead of only the catalog-routed `dispatch_child`. This is the direct-dispatch substrate the two-world op model (Goal #2247, Initiative #2248) builds on — no composite is migrated here.
- `dispatch_composite` now inspects the handler signature and forwards `dispatch_child` and/or `connector` **only when the handler declares it**, so every existing `dispatch_child`-only handler keeps its exact signature and behaviour, and a direct-session handler can omit `dispatch_child` entirely.
- The dispatcher already resolved the connector instance for `source_kind="composite"` targets in `_resolve_connector_instance`; `_run_source_kind_branch` now forwards it to the composite branch.
- The registration guard `validate_composite_handler_signature` accepts a handler declaring either seam (was: `dispatch_child`-required); the message still names `dispatch_child` for the existing rejection tests.

## Design notes
- A direct-session handler declares `connector` and issues sub-calls via `connector._get_json` / `connector._post_json` + `connector.mount_op_path` with **no** `endpoint_descriptor` lookup.
- Trade-offs of the direct path (drops per-sub-op audit row, param validation, recursion bound, policy/broadcast — and why per-sub-op policy stays load-bearing for *write* composites) are documented on the existing "four reasons" note in `connectors/vmware_rest/composites/_read.py` (AC #3) and in `docs/architecture/operations-substrate.md`.
- Substrate stays minimal: the raw connector instance is forwarded, not a new `DirectDispatch` wrapper/DSL.

## Test plan
- [x] `ruff check` + `ruff format --check` — clean (7 files)
- [x] `mypy` — clean
- [x] `code-quality.py --diff` — exit 0
- [x] New unit test: a composite declaring `connector` dispatches its sub-call through a stubbed `connector._get_json`, asserting exactly one `lookup_descriptor` (the top-level op) and **no** second lookup for the sub-call (AC #1).
- [x] New registration test: a `connector`-only composite (no `dispatch_child`) registers successfully (AC #4 / guard widening).
- [x] `pytest test_operations_composite.py test_operations_composite_register.py test_operations_typed_register.py test_operations_dispatcher.py` — 116 passed.
- [x] `pytest tests/acceptance/test_vmware_rest_composite_dispatch.py test_connectors_vmware_rest_composites_write.py test_operations_composite_backing.py` — 31 passed, 1 skipped (existing `dispatch_child`-only handlers unchanged, AC #2).

## Out of scope
- Per-composite migrations to the direct seam (Initiative #2249) and the write-composite policy/approval question.
- The registration-time no-ingested-row invariant (#2252) and L2-apparatus retirement (#2259).

<!-- auto-implement-issue: fresh, iteration 1 -->

Closes #2251
