### PR TITLE
feat(operations): registration-time two-world dispatch invariant (#2252)

### DIFF
--- a/backend/src/meho_backplane/operations/composite_backing.py
+++ b/backend/src/meho_backplane/operations/composite_backing.py
@@ -79,6 +79,7 @@ __all__ = [
     "CompositeBacking",
     "register_composite_backing",
     "registered_composite_backing",
+    "registered_composite_backings",
     "reset_composite_backing_registry",
     "unbacked_composite_next_step",
 ]
@@ -177,6 +178,19 @@ def registered_composite_backing(composite_op_id: str) -> CompositeBacking | Non
     treats it as an ordinary op and never attaches an unbacked marker.
     """
     return _REGISTRY.get(composite_op_id)
+
+
+def registered_composite_backings() -> dict[str, CompositeBacking]:
+    """Return a snapshot copy of every registered composite backing.
+
+    A shallow copy of the process-wide registry keyed by composite op_id.
+    Consumed by the platform-wide registration-time invariant
+    (:func:`~meho_backplane.operations.composite_invariant.assert_registered_composites_have_no_ingested_dispatch`),
+    which walks every registered composite's declared ``sub_op_ids`` to
+    assert none resolve to an ``ingested`` descriptor row. Returning a copy
+    keeps the caller from mutating the live registry while iterating.
+    """
+    return dict(_REGISTRY)
 
 
 def reset_composite_backing_registry() -> None:

--- a/backend/src/meho_backplane/operations/composite_invariant.py
+++ b/backend/src/meho_backplane/operations/composite_invariant.py
@@ -1,0 +1,203 @@
+# SPDX-License-Identifier: Apache-2.0
+# Copyright (c) 2026 evoila Group
+
+"""Platform-wide registration-time invariant for the two-world op model.
+
+Goal #2247 (Initiative #2248, Task #2252). The two-world model draws one
+line: a *code-shipped* operation -- ``source_kind="typed"`` or
+``source_kind="composite"``, registered from the image at connector init --
+must never dispatch through an *ingested* ``endpoint_descriptor`` row
+(``source_kind="ingested"``, a raw L1 primitive that only lands in the DB
+when an operator runs ``meho connector ingest``). A composite whose
+correctness depends on mutable per-deploy catalog state (is the sub-op
+ingested here? enabled here? schema-matched here?) is the recurring defect
+class the Goal retires; making the sub-call directly through the
+connector's own session (Task #2251) is the compliant alternative.
+
+This module holds the enforcement. It is deliberately connector-agnostic:
+it knows nothing about github or vmware, only about the generic fact
+"``endpoint_descriptor`` row X is ``source_kind='ingested'``". Two entry
+points:
+
+* :func:`assert_no_ingested_dispatch_dependency` -- the per-op primitive.
+  Given a code-shipped op's declared ``sub_op_ids`` and its
+  ``connector_id``, it resolves each raw sub-op against the descriptor
+  table and raises :class:`IngestedDispatchDependencyError` naming the
+  offending op + sub-op if any resolve to an ``ingested`` row.
+* :func:`assert_registered_composites_have_no_ingested_dispatch` -- the
+  platform-wide sweep. It walks every composite that declared its L2
+  dependency surface via
+  :func:`~meho_backplane.operations.composite_backing.register_composite_backing`
+  and applies the primitive to each. This is where github's
+  ``gh.composite.pr_status_summary`` is folded into the one shared check
+  (its bespoke import-time ``UnbackedEnabledCompositeError`` guard is
+  retired separately in #2259); any future connector that registers a
+  backing is covered without touching this module.
+
+Timing and fail-closed shape
+----------------------------
+
+The sweep runs at the tail of
+:func:`~meho_backplane.operations.typed_register.run_typed_op_registrars`,
+so it fires during the FastAPI lifespan after every connector has
+registered its typed/composite rows -- the same crash-loud posture the
+registrar runner already takes. A violation is a *deploy* bug (a
+code-shipped op wired to a catalog row), not a runtime condition, so
+surfacing it as a lifespan crash with an actionable message is correct:
+the operator sees the offending op + ingested sub-op immediately rather
+than a mid-flight dispatch failure under request load.
+
+Why keying on the resolved ``source_kind``
+------------------------------------------
+
+The invariant deliberately does *not* enumerate raw-REST ``METHOD:/path``
+shapes or hard-code connector prefixes. It keys purely on what a declared
+sub-op *resolves to* in ``endpoint_descriptor``: a row present with
+``source_kind='ingested'`` is the violation; a row with
+``source_kind='composite'``/``'typed'`` (a registrar-guaranteed
+code-shipped op) is allowed, and a sub-op that resolves to *nothing*
+(absent on this deploy) is not this invariant's concern -- absence is the
+``composite_l2_missing`` failure class the retired apparatus handles.
+Composite-to-composite recursion sub-ops (``*.composite.*``) are skipped
+for the same reason the connector preflights skip them: they are
+guaranteed by the lifespan registrar and are never ingested primitives.
+"""
+
+from __future__ import annotations
+
+import structlog
+from sqlalchemy import select
+
+from meho_backplane.db.engine import get_sessionmaker
+from meho_backplane.db.models import EndpointDescriptor
+from meho_backplane.operations._lookup import parse_connector_id
+from meho_backplane.operations.composite_backing import registered_composite_backings
+
+__all__ = [
+    "IngestedDispatchDependencyError",
+    "assert_no_ingested_dispatch_dependency",
+    "assert_registered_composites_have_no_ingested_dispatch",
+]
+
+_log = structlog.get_logger(__name__)
+
+#: Infix marking a composite-to-composite recursion sub-op
+#: (``gh.composite.*`` / ``vmware.composite.*``). Skipped by the walk for
+#: the same reason the connector preflights and the backing-listing marker
+#: skip it: such sub-ops resolve to registrar-guaranteed
+#: ``source_kind='composite'`` rows, never ingested primitives, so they can
+#: never be the cause of an ingested-dispatch violation. Raw-REST L2
+#: primitives are ``METHOD:/path`` strings and never contain it.
+_COMPOSITE_OP_INFIX = ".composite."
+
+
+class IngestedDispatchDependencyError(RuntimeError):
+    """A code-shipped op's dispatch path resolves through an ingested row.
+
+    Raised at connector-registration time (lifespan) when a
+    ``source_kind='typed'``/``'composite'`` op declares a sub-op dependency
+    that resolves to an ``endpoint_descriptor`` row with
+    ``source_kind='ingested'``. Under the two-world model (Goal #2247) a
+    code-shipped op must be self-contained -- transport via the connector's
+    own session -- and never depend on mutable catalog state. This guard
+    fails the boot closed with the offending op + its ingested sub-op so
+    the regression cannot ship enabled-but-catalog-dependent.
+    """
+
+
+async def assert_no_ingested_dispatch_dependency(
+    *,
+    op_id: str,
+    connector_id: str,
+    sub_op_ids: tuple[str, ...],
+) -> None:
+    """Assert none of *op_id*'s declared sub-ops resolve to an ingested row.
+
+    The per-op primitive of the two-world invariant. Parses *connector_id*
+    into ``(product, version, impl_id)`` (the same triple the dispatcher
+    resolves against), then for each raw sub-op -- composite-to-composite
+    recursion (``*.composite.*``) sub-ops are skipped -- probes
+    ``endpoint_descriptor`` for a built-in / global (``tenant_id IS NULL``)
+    row carrying ``source_kind='ingested'``. Enablement is intentionally
+    *not* filtered: a code-shipped op wired to a catalog row is a violation
+    whether or not that row happens to be enabled on this deploy.
+
+    Parameters
+    ----------
+    op_id:
+        The code-shipped op whose dependency surface is being asserted --
+        named in the raised error so the operator can locate it.
+    connector_id:
+        The connector the op dispatches against (``"gh-rest-3"``), parsed
+        into the descriptor natural-key triple.
+    sub_op_ids:
+        The declared L2 sub-op ids the op dispatches into (the same tuple a
+        connector hands its preflight / backing registration).
+
+    Raises
+    ------
+    IngestedDispatchDependencyError
+        One or more declared sub-ops resolve to an ``ingested`` descriptor
+        row. The message lists every offending sub-op (not just the first).
+    """
+    raw_sub_ops = tuple(sub_op for sub_op in sub_op_ids if _COMPOSITE_OP_INFIX not in sub_op)
+    if not raw_sub_ops:
+        return
+
+    product, version, impl_id = parse_connector_id(connector_id)
+    offenders: list[str] = []
+    sessionmaker = get_sessionmaker()
+    async with sessionmaker() as session:
+        for sub_op_id in raw_sub_ops:
+            result = await session.execute(
+                select(EndpointDescriptor.id)
+                .where(
+                    EndpointDescriptor.tenant_id.is_(None),
+                    EndpointDescriptor.product == product,
+                    EndpointDescriptor.version == version,
+                    EndpointDescriptor.impl_id == impl_id,
+                    EndpointDescriptor.op_id == sub_op_id,
+                    EndpointDescriptor.source_kind == "ingested",
+                )
+                .limit(1)
+            )
+            if result.first() is not None:
+                offenders.append(sub_op_id)
+
+    if offenders:
+        raise IngestedDispatchDependencyError(
+            f"code-shipped op {op_id!r} (connector {connector_id!r}) dispatches "
+            f"through ingested endpoint_descriptor row(s) {offenders!r}; a "
+            f"typed/composite op must be self-contained (transport via the "
+            f"connector's own session), never routed through a mutable "
+            f"ingested catalog row (two-world invariant, Goal #2247). Migrate "
+            f"the sub-call to a direct-session or code-shipped (typed/composite) "
+            f"sub-op."
+        )
+
+
+async def assert_registered_composites_have_no_ingested_dispatch() -> None:
+    """Sweep every registered composite backing for ingested-dispatch violations.
+
+    The platform-wide entry point, invoked at the tail of
+    :func:`~meho_backplane.operations.typed_register.run_typed_op_registrars`
+    once every connector has registered. Walks the composite-backing
+    registry -- each entry is a composite that declared its L2 dependency
+    surface via
+    :func:`~meho_backplane.operations.composite_backing.register_composite_backing`
+    -- and applies :func:`assert_no_ingested_dispatch_dependency` to each.
+    Connector-agnostic: a connector is covered the moment it registers a
+    backing, with no per-connector wiring here.
+
+    Raises
+    ------
+    IngestedDispatchDependencyError
+        Propagated from the first composite whose declared sub-ops resolve
+        to an ingested row -- a lifespan-crashing deploy bug.
+    """
+    for composite_op_id, backing in registered_composite_backings().items():
+        await assert_no_ingested_dispatch_dependency(
+            op_id=composite_op_id,
+            connector_id=backing.connector_id,
+            sub_op_ids=backing.sub_op_ids,
+        )

--- a/backend/src/meho_backplane/operations/typed_register.py
+++ b/backend/src/meho_backplane/operations/typed_register.py
@@ -139,6 +139,9 @@ from sqlalchemy.ext.asyncio import AsyncSession
 from meho_backplane.db.engine import get_sessionmaker
 from meho_backplane.db.models import EndpointDescriptor, OperationGroup
 from meho_backplane.operations._handler_resolve import import_handler
+from meho_backplane.operations.composite_invariant import (
+    assert_registered_composites_have_no_ingested_dispatch,
+)
 from meho_backplane.operations.embed import (
     build_embedding_text,
     compute_embedding_text_hash,
@@ -406,6 +409,31 @@ async def run_typed_op_registrars(
     mirrors the schema-template amortization in ``tests/conftest.py``
     (#793/#898) — replay a once-computed artifact instead of recomputing
     it per test.
+
+    Two-world invariant (#2252)
+    ---------------------------
+
+    After the descriptor rows are in place — via a real registrar pass or
+    the amortized snapshot replay — every registered composite is swept for
+    a two-world violation
+    (:func:`~meho_backplane.operations.composite_invariant.assert_registered_composites_have_no_ingested_dispatch`):
+    a code-shipped op whose declared sub-op resolves to an ``ingested`` row
+    fails the boot closed. The sweep runs on **every** path (fresh pass and
+    replay) because the violation is a function of live descriptor state,
+    not of which registration path produced the rows.
+    """
+    await _run_typed_op_registrars(embedding_service=embedding_service)
+    await assert_registered_composites_have_no_ingested_dispatch()
+
+
+async def _run_typed_op_registrars(
+    *,
+    embedding_service: EmbeddingService | None = None,
+) -> None:
+    """Populate descriptor rows via a real registrar pass or the amortized replay.
+
+    Split from :func:`run_typed_op_registrars` so the two-world invariant
+    sweep runs on every path regardless of which branch produced the rows.
     """
     if get_settings().test_amortize_typed_op_registrars:
         fingerprint = _registrar_fingerprint()

--- a/backend/tests/test_operations_composite_invariant.py
+++ b/backend/tests/test_operations_composite_invariant.py
@@ -1,0 +1,273 @@
+# SPDX-License-Identifier: Apache-2.0
+# Copyright (c) 2026 evoila Group
+
+"""Tests for the two-world registration-time invariant (#2252).
+
+Goal #2247 / Initiative #2248. A code-shipped op (``source_kind='typed'``
+or ``'composite'``) must never dispatch through an *ingested*
+``endpoint_descriptor`` row. This module covers both faces of the
+enforcement:
+
+* :func:`assert_no_ingested_dispatch_dependency` — the per-op primitive,
+  exercised against the autouse-migrated SQLite engine with synthetic
+  descriptor rows (not gh/vmware specifically), per the task's
+  "test with a synthetic connector" acceptance criterion:
+  - a declared sub-op resolving to an ``ingested`` row -> raises, naming
+    the op + every offending sub-op;
+  - sub-ops resolving to ``composite`` / ``typed`` rows -> passes;
+  - a declared sub-op absent from the table -> passes (absence is the
+    retired ``composite_l2_missing`` class, not this invariant);
+  - ``*.composite.*`` recursion sub-ops -> skipped, never probed.
+
+* :func:`assert_registered_composites_have_no_ingested_dispatch` — the
+  platform-wide sweep over the composite-backing registry, including the
+  routing check that github's real ``gh.composite.pr_status_summary``
+  backing is folded into the shared invariant and passes on a fresh
+  deploy (no gh L2 rows ingested).
+"""
+
+from __future__ import annotations
+
+import uuid
+from collections.abc import Iterator
+from datetime import UTC, datetime
+
+import pytest
+
+from meho_backplane.db.engine import get_sessionmaker
+from meho_backplane.db.models import EndpointDescriptor
+from meho_backplane.operations import composite_backing as _backing
+from meho_backplane.operations.composite_backing import (
+    register_composite_backing,
+    registered_composite_backings,
+    reset_composite_backing_registry,
+)
+from meho_backplane.operations.composite_invariant import (
+    IngestedDispatchDependencyError,
+    assert_no_ingested_dispatch_dependency,
+    assert_registered_composites_have_no_ingested_dispatch,
+)
+from meho_backplane.settings import get_settings
+
+# Synthetic connector under test — deliberately not gh/vmware.
+_CONNECTOR_ID = "synth-1.0"
+_PRODUCT = "synth"
+_VERSION = "1.0"
+_IMPL_ID = "synth"
+
+_SUB_OP_A = "GET:/widgets"
+_SUB_OP_B = "GET:/widgets/{id}"
+_TYPED_SUB_OP = "synth.widget.list"
+
+# github's real composite surface (registered at import time by the
+# gh-rest composite package) — the routing check.
+_GH_COMPOSITE_OP_ID = "gh.composite.pr_status_summary"
+
+
+@pytest.fixture(autouse=True)
+def _required_settings_env(monkeypatch: pytest.MonkeyPatch) -> Iterator[None]:
+    """Pin env vars :class:`Settings` requires for this module."""
+    monkeypatch.setenv("KEYCLOAK_ISSUER_URL", "https://keycloak.test/realms/meho")
+    monkeypatch.setenv("KEYCLOAK_AUDIENCE", "meho-backplane")
+    monkeypatch.setenv("VAULT_ADDR", "https://vault.test")
+    get_settings.cache_clear()
+    yield
+    get_settings.cache_clear()
+
+
+@pytest.fixture(autouse=True)
+def _reset_backing_registry() -> Iterator[None]:
+    """Isolate the process-wide backing registry, restoring the import-time set.
+
+    Same discipline as :mod:`tests.test_operations_composite_backing`: clear
+    to a known synthetic surface for the test, then restore the entries the
+    gh-rest package registered at import so a sibling module relying on them
+    is not left with an empty registry.
+    """
+    saved = dict(_backing._REGISTRY)
+    reset_composite_backing_registry()
+    yield
+    reset_composite_backing_registry()
+    _backing._REGISTRY.update(saved)
+
+
+async def _seed_descriptor(*, op_id: str, source_kind: str, is_enabled: bool = True) -> None:
+    """Insert one built-in / global ``endpoint_descriptor`` row for the synthetic connector."""
+    sessionmaker = get_sessionmaker()
+    now = datetime.now(UTC)
+    async with sessionmaker() as session, session.begin():
+        session.add(
+            EndpointDescriptor(
+                id=uuid.uuid4(),
+                tenant_id=None,
+                product=_PRODUCT,
+                version=_VERSION,
+                impl_id=_IMPL_ID,
+                op_id=op_id,
+                source_kind=source_kind,
+                method=None,
+                path=None,
+                handler_ref=None,
+                summary=f"row for {op_id}",
+                description=f"row for {op_id}",
+                group_id=None,
+                tags=[],
+                parameter_schema={"type": "object"},
+                response_schema=None,
+                llm_instructions=None,
+                safety_level="safe",
+                requires_approval=False,
+                is_enabled=is_enabled,
+                embedding=None,
+                custom_description=None,
+                custom_notes=None,
+                created_at=now,
+                updated_at=now,
+            )
+        )
+
+
+# ---------------------------------------------------------------------------
+# per-op primitive: assert_no_ingested_dispatch_dependency
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.asyncio
+async def test_raises_when_sub_op_resolves_to_ingested() -> None:
+    """A declared sub-op resolving to an ``ingested`` row fails closed."""
+    await _seed_descriptor(op_id=_SUB_OP_A, source_kind="ingested")
+    with pytest.raises(IngestedDispatchDependencyError) as excinfo:
+        await assert_no_ingested_dispatch_dependency(
+            op_id="synth.composite.widget.audit",
+            connector_id=_CONNECTOR_ID,
+            sub_op_ids=(_SUB_OP_A,),
+        )
+    message = str(excinfo.value)
+    assert "synth.composite.widget.audit" in message
+    assert _SUB_OP_A in message
+
+
+@pytest.mark.asyncio
+async def test_raises_even_when_ingested_row_is_disabled() -> None:
+    """Enablement is not filtered — a disabled ingested row is still a violation."""
+    await _seed_descriptor(op_id=_SUB_OP_A, source_kind="ingested", is_enabled=False)
+    with pytest.raises(IngestedDispatchDependencyError):
+        await assert_no_ingested_dispatch_dependency(
+            op_id="synth.composite.widget.audit",
+            connector_id=_CONNECTOR_ID,
+            sub_op_ids=(_SUB_OP_A,),
+        )
+
+
+@pytest.mark.asyncio
+async def test_reports_every_offending_sub_op() -> None:
+    """The error lists all ingested sub-ops, not just the first found."""
+    await _seed_descriptor(op_id=_SUB_OP_A, source_kind="ingested")
+    await _seed_descriptor(op_id=_SUB_OP_B, source_kind="ingested")
+    with pytest.raises(IngestedDispatchDependencyError) as excinfo:
+        await assert_no_ingested_dispatch_dependency(
+            op_id="synth.composite.widget.audit",
+            connector_id=_CONNECTOR_ID,
+            sub_op_ids=(_SUB_OP_A, _SUB_OP_B),
+        )
+    message = str(excinfo.value)
+    assert _SUB_OP_A in message
+    assert _SUB_OP_B in message
+
+
+@pytest.mark.asyncio
+async def test_passes_when_sub_ops_are_code_shipped() -> None:
+    """Sub-ops resolving to ``composite`` / ``typed`` rows are allowed."""
+    await _seed_descriptor(op_id="synth.composite.widget.other", source_kind="composite")
+    await _seed_descriptor(op_id=_TYPED_SUB_OP, source_kind="typed")
+    # No raise.
+    await assert_no_ingested_dispatch_dependency(
+        op_id="synth.composite.widget.audit",
+        connector_id=_CONNECTOR_ID,
+        sub_op_ids=(_TYPED_SUB_OP,),
+    )
+
+
+@pytest.mark.asyncio
+async def test_passes_when_sub_op_absent() -> None:
+    """A sub-op with no descriptor row at all is not this invariant's concern."""
+    # Nothing seeded for _SUB_OP_A — absence is the retired composite_l2_missing class.
+    await assert_no_ingested_dispatch_dependency(
+        op_id="synth.composite.widget.audit",
+        connector_id=_CONNECTOR_ID,
+        sub_op_ids=(_SUB_OP_A,),
+    )
+
+
+@pytest.mark.asyncio
+async def test_skips_composite_recursion_sub_ops() -> None:
+    """``*.composite.*`` sub-ops are skipped even when an ingested row shares the name."""
+    # Seed an ingested row whose op_id carries the composite infix; the walk
+    # must skip it (registrar-guaranteed recursion), so no violation fires.
+    await _seed_descriptor(op_id="synth.composite.widget.other", source_kind="ingested")
+    await assert_no_ingested_dispatch_dependency(
+        op_id="synth.composite.widget.audit",
+        connector_id=_CONNECTOR_ID,
+        sub_op_ids=("synth.composite.widget.other",),
+    )
+
+
+# ---------------------------------------------------------------------------
+# platform-wide sweep + github routing
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.asyncio
+async def test_sweep_raises_for_registered_synthetic_composite() -> None:
+    """The registry sweep applies the primitive to every registered backing."""
+    await _seed_descriptor(op_id=_SUB_OP_A, source_kind="ingested")
+    register_composite_backing(
+        composite_op_id="synth.composite.widget.audit",
+        connector_id=_CONNECTOR_ID,
+        sub_op_ids=(_SUB_OP_A,),
+        catalog_command="meho connector ingest --catalog synth/1.0",
+    )
+    with pytest.raises(IngestedDispatchDependencyError):
+        await assert_registered_composites_have_no_ingested_dispatch()
+
+
+@pytest.mark.asyncio
+async def test_sweep_passes_for_code_shipped_only_registry() -> None:
+    """A registry whose composites only depend on code-shipped sub-ops passes."""
+    await _seed_descriptor(op_id=_TYPED_SUB_OP, source_kind="typed")
+    register_composite_backing(
+        composite_op_id="synth.composite.widget.audit",
+        connector_id=_CONNECTOR_ID,
+        sub_op_ids=(_TYPED_SUB_OP,),
+        catalog_command="meho connector ingest --catalog synth/1.0",
+    )
+    # No raise.
+    await assert_registered_composites_have_no_ingested_dispatch()
+
+
+@pytest.mark.asyncio
+async def test_github_real_backing_routed_through_shared_invariant() -> None:
+    """github's real composite backing is swept by the shared invariant and passes fresh.
+
+    Restores the import-time gh-rest backing (the autouse fixture cleared
+    it), then runs the platform-wide sweep with no gh L2 rows ingested —
+    the fresh-deploy state. The sweep must pass, proving github is folded
+    into the one shared check (its bespoke ``UnbackedEnabledCompositeError``
+    guard is retired separately in #2259) rather than needing per-connector
+    wiring here.
+    """
+    # Re-register github's real backing (fixture cleared the registry).
+    register_composite_backing(
+        composite_op_id=_GH_COMPOSITE_OP_ID,
+        connector_id="gh-rest-3",
+        sub_op_ids=(
+            "GET:/repos/{owner}/{repo}/pulls/{pull_number}",
+            "GET:/repos/{owner}/{repo}/commits/{ref}/check-runs",
+            "GET:/repos/{owner}/{repo}/pulls/{pull_number}/reviews",
+        ),
+        catalog_command="meho connector ingest --catalog gh/3",
+    )
+    assert _GH_COMPOSITE_OP_ID in registered_composite_backings()
+    # Fresh deploy: no gh L2 rows ingested -> the code-shipped composite is
+    # not (yet) routed through an ingested row, so the sweep passes.
+    await assert_registered_composites_have_no_ingested_dispatch()

--- a/docs/codebase/composite-ingested-dispatch-invariant.md
+++ b/docs/codebase/composite-ingested-dispatch-invariant.md
@@ -1,0 +1,77 @@
+# Two-world dispatch invariant
+
+Registration-time guard that enforces one half of the two-world operation
+model (Goal #2247): **a code-shipped operation never dispatches through an
+ingested catalog row.**
+
+## Overview
+
+`endpoint_descriptor.source_kind` partitions every operation into three
+kinds (DB CHECK, `db/models.py`):
+
+- `ingested` — raw L1 primitives from a spec (`GET:/vcenter/datastore`),
+  landed only after an operator runs `meho connector ingest`.
+- `typed` — self-contained code, transport via the connector class's own
+  session, registered at connector init.
+- `composite` — hand-authored orchestration over other code-shipped ops.
+
+A `typed`/`composite` op is *code-shipped*: it works the moment the image
+boots. Its correctness must not depend on mutable per-deploy catalog state
+(is a sub-op ingested here? enabled here? schema-matched here?). The
+invariant makes that impossible to regress: at registration, no
+code-shipped op's declared sub-op may resolve to an `ingested` row.
+
+## Key types
+
+`operations/composite_invariant.py`:
+
+- `IngestedDispatchDependencyError` — raised at connector-registration
+  (lifespan) when a code-shipped op's declared sub-op resolves to an
+  `ingested` descriptor row.
+- `assert_no_ingested_dispatch_dependency(op_id, connector_id, sub_op_ids)`
+  — the per-op primitive. Parses `connector_id` into `(product, version,
+  impl_id)`, then probes `endpoint_descriptor` for each raw sub-op; a
+  built-in/global (`tenant_id IS NULL`) row with `source_kind='ingested'`
+  is a violation. Enablement is not filtered. `*.composite.*` recursion
+  sub-ops are skipped (registrar-guaranteed, never ingested).
+- `assert_registered_composites_have_no_ingested_dispatch()` — the
+  platform-wide sweep over the composite-backing registry
+  (`operations/composite_backing.py`). Connector-agnostic: a connector is
+  covered the moment it registers a backing.
+
+## Control flow
+
+The sweep runs at the tail of `run_typed_op_registrars`
+(`operations/typed_register.py`), invoked from the FastAPI lifespan after
+every connector has registered its typed/composite rows. It runs on both
+the real registrar pass and the amortized snapshot-replay test path,
+because the verdict is a function of live descriptor state. A violation
+propagates as a lifespan crash — the same crash-loud posture the registrar
+runner already takes for a registration bug.
+
+## Why keyed on the resolved `source_kind`
+
+The invariant does not enumerate `METHOD:/path` shapes or hard-code
+connector prefixes. It keys purely on what a declared sub-op *resolves to*.
+A sub-op absent on this deploy is not this invariant's concern (absence is
+the `composite_l2_missing` failure class the retired apparatus handles); a
+sub-op resolving to `composite`/`typed` is allowed; only `ingested` is a
+violation.
+
+## Known issues / sequencing
+
+github's `gh.composite.pr_status_summary` and the vmware composites still
+declare raw ingested L2 sub-ops today; they are migrated to direct-session
+sub-calls in Initiative #2248 (task #2249). github is folded into this one
+shared check automatically because it registers a composite backing; its
+bespoke import-time `UnbackedEnabledCompositeError` guard and the vmware
+dispatch-time preflight are retired in #2259. Until #2249 lands, a deploy
+that has ingested the gh catalog would trip this invariant on reboot — the
+intended fail-closed signal that the composite must be migrated.
+
+## References
+
+- Goal #2247 (two-world op model), Initiative #2248, Task #2252.
+- `operations/composite_backing.py` — the L2-dependency registry the sweep
+  reads.
+- `connectors/github/composites/_register.py` — the gh-only guard folded in.


### PR DESCRIPTION
## Summary
- Adds a platform-wide, registration-time invariant for Goal #2247's two-world op model: **a code-shipped (`source_kind='typed'`/`'composite'`) op may never dispatch through an `ingested` `endpoint_descriptor` row.**
- New `operations/composite_invariant.py`: a per-op primitive `assert_no_ingested_dispatch_dependency(op_id, connector_id, sub_op_ids)` keyed purely on the *resolved* `source_kind` of each declared sub-op, plus a connector-agnostic sweep `assert_registered_composites_have_no_ingested_dispatch()` over the composite-backing registry.
- The sweep runs at the tail of `run_typed_op_registrars` (FastAPI lifespan) — **fail-closed at load** with an actionable message naming the offending op + its ingested sub-op.
- github's `gh.composite.pr_status_summary` is folded into the one shared check via its registered backing — no per-connector wiring, the check "does not know about github/vmware specifically." Its bespoke `UnbackedEnabledCompositeError` guard and the vmware preflight are **left in place** (retired later in #2259).
- Composite→composite recursion sub-ops (`*.composite.*`) are skipped (registrar-guaranteed); a sub-op that resolves to nothing (absent on this deploy) is **not** a violation (that's the retired `composite_l2_missing` class).

## Test plan
- [x] `ruff check` / `ruff format --check` — clean (4 files)
- [x] `mypy` — clean (3 source files)
- [x] `pytest tests/test_operations_composite_invariant.py` — 9 passed (synthetic connector, not gh/vmware)
  - fail path: declared sub-op resolving to `ingested` (enabled **and** disabled) raises, naming op + every offending sub-op
  - pass paths: sub-ops resolving to `composite`/`typed`; sub-op absent; `*.composite.*` recursion skipped
  - platform sweep raises for a synthetic registered composite; passes for a code-shipped-only registry
  - **routing:** github's real backing is swept by the shared invariant and passes on a fresh deploy
- [x] Regression: `test_operations_composite_backing`, `test_connectors_github_composites_register`, `test_connectors_github_composites_l2_preflight`, `test_operations_typed_register`, `test_operations_dispatcher` — all green
- [x] Lifespan/boot: `test_ui_chassis_smoke`, `test_api_health_failures`, `test_audit_middleware`, `test_connectors_vmware_rest_composites_register`, `test_mcp_tool_meho_status` — the sweep runs cleanly on real app boot

## Acceptance criteria
- [x] Registering a code-shipped op that dispatches an ingested sub-op fails at load, for **any** connector (synthetic-connector test)
- [x] A composite that only depends on `source_kind='composite'`/`'typed'` rows (or the connector session) passes
- [x] github's bespoke guard is routed through the shared invariant (its dedicated error/test kept, removed in #2259)
- [x] The invariant is covered by a unit test asserting both pass and fail paths

## Risks / sequencing (please weigh at merge time)
- This invariant is **fail-closed at boot**. Because github's composite still declares raw ingested L2 sub-ops until the migration in #2249, a deploy that has already run `meho connector ingest --catalog gh/3` would trip the invariant on its next reboot. That is the *intended* two-world signal ("this composite must be migrated"), but it means #2252 landing before #2249 opens a window for gh-catalog-ingested deploys. vmware is unaffected (it registers no backing, so the sweep never checks it). Consider ordering the merge relative to #2249, or accept the window per the Goal's sequencing.

## Out of scope
- Migrating gh/vmware composites off ingested dispatch (#2249) and retiring the old apparatus (#2259).
- The composite handler session-injection path (#2251, sibling in this wave).

<!-- auto-implement-issue: fresh, iteration 1 -->

Closes #2252


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added a startup-time safety check for composite and typed operations to prevent them from routing through ingested entries.

* **Bug Fixes**
  * Composite dispatch now fails closed when it depends on unsupported ingested sources, helping catch deployment issues early.
  * Improved error reporting to identify all affected composite dependencies at once.

* **Documentation**
  * Added guidance explaining the new composite dispatch rules and when the check runs.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->