### PR TITLE
feat(connectors): typed vmware.host.usage — per-host quickStats/hardware/maintenance via PropertyCollector

### DIFF
--- a/backend/src/meho_backplane/connectors/vmware_rest/__init__.py
+++ b/backend/src/meho_backplane/connectors/vmware_rest/__init__.py
@@ -80,8 +80,23 @@ register_connector_v2(
 # during ``run_typed_op_registrars`` -- same lifecycle phase the typed
 # Vault ops use.
 from meho_backplane.connectors.vmware_rest import composites  # noqa: E402
+from meho_backplane.connectors.vmware_rest.typed_ops import (  # noqa: E402
+    VMWARE_TYPED_OPS,
+    register_vmware_typed_operations,
+)
+from meho_backplane.operations.typed_register import (  # noqa: E402
+    register_typed_op_registrar,
+)
+
+# Queue the typed-op upsert onto the lifespan-driven registrar list
+# (#2257). ``vmware.host.usage`` is the first vmware ``source_kind="typed"``
+# op -- a bound-method read on the connector session, independent of the
+# composite/ingested path, so it registers via its own registrar the same
+# way argocd's typed reads do.
+register_typed_op_registrar(register_vmware_typed_operations)
 
 __all__ = [
+    "VMWARE_TYPED_OPS",
     "SessionCredentials",
     "VmwareRestConnector",
     "VsphereSessionLoader",
@@ -89,4 +104,5 @@ __all__ = [
     "composites",
     "load_session_credentials_from_vault",
     "product_from_line_id",
+    "register_vmware_typed_operations",
 ]

--- a/backend/src/meho_backplane/connectors/vmware_rest/connector.py
+++ b/backend/src/meho_backplane/connectors/vmware_rest/connector.py
@@ -625,6 +625,32 @@ class VmwareRestConnector(HttpConnector):
             params=params,
         )
 
+    async def host_usage(
+        self,
+        operator: Operator,
+        target: VsphereTargetLike,
+        params: dict[str, Any],
+    ) -> dict[str, Any]:
+        """``vmware.host.usage`` -- per-host CPU/memory load + hardware + maintenance.
+
+        The first vmware **typed** op (``source_kind="typed"``): a bound
+        method the dispatcher binds to this connector instance and invokes
+        with ``(operator, target, params)`` (see
+        :func:`~meho_backplane.operations._branches.dispatch_typed`). Reads
+        per-host ``summary.quickStats`` / ``summary.hardware`` /
+        ``runtime.inMaintenanceMode`` directly on the connector session via
+        PropertyCollector -- no ``dispatch_child``, no ingested descriptor
+        -- so it works on a fresh boot with zero catalog ingest. The plain
+        REST host summary reports only liveness, not load.
+
+        Delegates to :func:`~meho_backplane.connectors.vmware_rest.typed_ops.host_usage_impl`
+        (imported lazily to keep this module off the typed-ops import at
+        class-load time). Returns ``{"hosts": [...]}``.
+        """
+        from meho_backplane.connectors.vmware_rest.typed_ops import host_usage_impl
+
+        return await host_usage_impl(self, operator, target, params)
+
     async def aclose(self) -> None:
         """Revoke every cached session before closing the httpx pool.
 

--- a/backend/src/meho_backplane/connectors/vmware_rest/typed_ops.py
+++ b/backend/src/meho_backplane/connectors/vmware_rest/typed_ops.py
@@ -1,0 +1,530 @@
+# SPDX-License-Identifier: Apache-2.0
+# Copyright (c) 2026 evoila Group
+
+"""Typed (bound-method) read ops for :class:`VmwareRestConnector`.
+
+The hand-authored vmware-rest surface has, until now, been composites
+only (``vmware.composite.*`` -- registered via
+:func:`~meho_backplane.connectors.vmware_rest.composites._register.register_vmware_composite_operations`
+and dispatched through ``dispatch_child`` against ingested L2 sub-ops).
+A composite therefore depends on the vCenter REST catalog having been
+ingested first: its ``dispatch_child`` legs resolve ``GET:/vcenter/host``
+and ``POST:/PropertyCollector/{moId}/RetrievePropertiesEx`` against
+``endpoint_descriptor`` rows that only exist after ``vcenter.yaml`` is
+ingested (the L2 pre-flight in ``composites/_preflight.py`` enforces
+exactly that).
+
+``vmware.host.usage`` is the first vmware **typed** op
+(``source_kind="typed"``). It is a bound method on
+:class:`VmwareRestConnector` that reads per-host utilisation directly
+through the connector's own authenticated session -- no ``dispatch_child``,
+no ingested descriptor -- so it works on a fresh boot with **zero catalog
+ingest**. The sibling precedent is
+:mod:`meho_backplane.connectors.argocd.ops`: metadata dataclasses here,
+thin bound-method handlers on the connector, a module-level registrar
+queued onto :func:`register_typed_op_registrar`.
+
+Why the Web-Services-API and not plain REST
+-------------------------------------------
+
+``GET /api/vcenter/host`` returns only a ``HostSummary``
+(``host`` / ``name`` / ``connection_state`` / ``power_state``) -- liveness,
+not load. Per-host CPU/memory utilisation, hardware totals, and the
+maintenance-mode flag live on the WS-API ``HostSystem`` managed object:
+
+* ``summary.quickStats`` (:class:`HostListSummaryQuickStats`) --
+  ``overallCpuUsage`` (MHz), ``overallMemoryUsage`` (MB), ``uptime`` (s).
+* ``summary.hardware`` (:class:`HostHardwareSummary`) -- ``cpuMhz``
+  (per-core MHz), ``numCpuPkgs`` / ``numCpuCores`` / ``numCpuThreads``,
+  ``memorySize`` (bytes), ``cpuModel``.
+* ``runtime.inMaintenanceMode`` (bool).
+
+Those are read via the PropertyCollector ``RetrievePropertiesEx`` vi-json
+method (singleton moId ``propertyCollector``), exactly as the
+``host.network_uplinks`` composite reads ``config.network.*`` -- but here
+the call is issued on the connector session and mounted through
+:meth:`VmwareRestConnector.mount_op_path` so it lands on ``/api`` (modern
+vCenter) or ``/rest`` (legacy / vcsim) without an ingested descriptor.
+
+Field names + units are the vim25 / VI-JSON wire contract (camelCase):
+`HostListSummaryQuickStats
+<https://developer.broadcom.com/xapis/virtual-infrastructure-json-api/latest/data-structures/HostListSummary/>`_.
+"""
+
+from __future__ import annotations
+
+from dataclasses import dataclass
+from typing import TYPE_CHECKING, Any, Literal
+
+import httpx
+import structlog
+
+from meho_backplane.auth.operator import Operator
+from meho_backplane.connectors.vmware_rest.session import VsphereTargetLike
+
+if TYPE_CHECKING:
+    from meho_backplane.connectors.vmware_rest.connector import VmwareRestConnector
+    from meho_backplane.retrieval.embedding import EmbeddingService
+
+__all__ = [
+    "VMWARE_HOST_USAGE_OP",
+    "VMWARE_TYPED_OPS",
+    "VMWARE_TYPED_WHEN_TO_USE_BY_GROUP",
+    "VmwareTypedOp",
+    "host_usage_impl",
+    "register_vmware_typed_operations",
+]
+
+_log = structlog.get_logger(__name__)
+
+# vCenter Automation REST host listing (spec-relative; mounted onto
+# /api or /rest per-target by mount_op_path).
+_LIST_HOSTS_PATH = "/vcenter/host"
+# PropertyCollector RetrievePropertiesEx against the singleton
+# ``propertyCollector`` moId. Spec-relative; mount_op_path prefixes the
+# live mount so a legacy/vcsim target (which serves only /rest) is
+# reached correctly rather than 404ing on /api.
+_RETRIEVE_PROPERTIES_PATH = "/PropertyCollector/propertyCollector/RetrievePropertiesEx"
+_HOST_SYSTEM_MO_TYPE = "HostSystem"
+
+# WS-API property paths read per host. Requesting the whole
+# ``summary.quickStats`` / ``summary.hardware`` objects (rather than
+# individual leaves) keeps the specSet small and returns every field the
+# operator-facing row surfaces in one propSet entry each.
+_PROP_QUICK_STATS = "summary.quickStats"
+_PROP_HARDWARE = "summary.hardware"
+_PROP_IN_MAINTENANCE = "runtime.inMaintenanceMode"
+_HOST_USAGE_PATH_SET = (_PROP_QUICK_STATS, _PROP_HARDWARE, _PROP_IN_MAINTENANCE)
+
+_HOST_USAGE_GROUP_KEY = "vmware-host-usage"
+
+
+@dataclass(frozen=True)
+class VmwareTypedOp:
+    """Metadata for one vmware typed op registered at lifespan startup.
+
+    Fields mirror the keyword arguments
+    :func:`~meho_backplane.operations.typed_register.register_typed_operation`
+    accepts so :func:`register_vmware_typed_operations` can splat the
+    dataclass into the helper without per-op boilerplate. ``handler_attr``
+    is the attribute name on
+    :class:`~meho_backplane.connectors.vmware_rest.connector.VmwareRestConnector`
+    exposing the async handler; the registrar resolves the bound method
+    against the class so the dispatcher's
+    :func:`~meho_backplane.operations._handler_resolve.import_handler` walk
+    recovers the callable from the persisted ``module.ClassName.method``
+    path. Mirrors
+    :class:`~meho_backplane.connectors.argocd.ops.ArgoCdOp`.
+    """
+
+    op_id: str
+    handler_attr: str
+    summary: str
+    description: str
+    parameter_schema: dict[str, Any]
+    response_schema: dict[str, Any] | None
+    group_key: str | None
+    tags: tuple[str, ...]
+    safety_level: Literal["safe", "caution", "dangerous"]
+    requires_approval: bool
+    llm_instructions: dict[str, Any] | None
+
+
+def _unwrap_value(payload: Any) -> Any:
+    """Return the inner ``value`` on a pre-7 REST envelope, else *payload*.
+
+    vSphere's Automation REST straddles a bare-array modern shape and a
+    legacy ``{"value": [...]}`` envelope (some vcsim builds). The caller
+    only wants the list either way.
+    """
+    if isinstance(payload, dict) and set(payload.keys()) == {"value"}:
+        return payload["value"]
+    return payload
+
+
+def build_host_usage_retrieve_params(host_moid: str) -> dict[str, Any]:
+    """Build the ``RetrievePropertiesEx`` request body for one host.
+
+    A single ``PropertyFilterSpec`` scoped directly to the host object
+    (no ContainerView / TraversalSpec) requesting the three utilisation
+    property paths. The singleton ``propertyCollector`` moId is carried
+    in the URL (:data:`_RETRIEVE_PROPERTIES_PATH`), so the body is just
+    the method arguments ``specSet`` + ``options`` -- the VI-JSON
+    ``RetrievePropertiesExRequestType`` shape.
+    """
+    return {
+        "specSet": [
+            {
+                "propSet": [
+                    {
+                        "type": _HOST_SYSTEM_MO_TYPE,
+                        "pathSet": list(_HOST_USAGE_PATH_SET),
+                    }
+                ],
+                "objectSet": [{"obj": {"type": _HOST_SYSTEM_MO_TYPE, "value": host_moid}}],
+            }
+        ],
+        "options": {},
+    }
+
+
+def _extract_host_props(retrieve_result: Any) -> dict[str, Any]:
+    """Flatten a single-host ``RetrievePropertiesEx`` result to name->val.
+
+    ``RetrievePropertiesEx`` returns a ``RetrieveResult`` whose
+    ``objects`` list carries one ``ObjectContent`` per queried object,
+    each with a ``propSet`` list of ``{name, val}`` pairs. For the
+    single-host query issued here the first object's propSet holds the
+    three requested paths. A bare list (some simulators / the legacy
+    ``RetrieveProperties`` shape) is tolerated too.
+    """
+    payload = _unwrap_value(retrieve_result)
+    if isinstance(payload, dict):
+        objects = payload.get("objects", [])
+    elif isinstance(payload, list):
+        objects = payload
+    else:
+        objects = []
+    prop_by_name: dict[str, Any] = {}
+    for obj in objects:
+        if not isinstance(obj, dict):
+            continue
+        for prop in obj.get("propSet", []) or []:
+            if isinstance(prop, dict) and isinstance(prop.get("name"), str):
+                prop_by_name[prop["name"]] = prop.get("val")
+    return prop_by_name
+
+
+def _int_or_none(value: Any) -> int | None:
+    """Coerce a JSON number/numeric-string to int; anything else -> None.
+
+    VI-JSON serialises the ``xsd:long`` ``memorySize`` and the ``xsd:int``
+    quickStats counters as JSON numbers, but some intermediaries render a
+    64-bit value as a JSON string. Accept both; reject bools (``True`` is
+    an ``int`` subclass in Python and must not read as ``1`` here).
+    """
+    if isinstance(value, bool):
+        return None
+    if isinstance(value, int):
+        return value
+    if isinstance(value, str):
+        try:
+            return int(value)
+        except ValueError:
+            return None
+    return None
+
+
+def _parse_quick_stats(quick_stats: Any) -> dict[str, Any]:
+    """Flatten ``HostListSummaryQuickStats`` into the operator-facing row.
+
+    ``overallCpuUsage`` is aggregated CPU consumption in MHz;
+    ``overallMemoryUsage`` is consumed physical memory in MB; ``uptime``
+    is host uptime in seconds. Absent fields (a host mid-boot, a
+    simulator that omits them) map to ``None``.
+    """
+    qs = quick_stats if isinstance(quick_stats, dict) else {}
+    return {
+        "overall_cpu_usage_mhz": _int_or_none(qs.get("overallCpuUsage")),
+        "overall_memory_usage_mb": _int_or_none(qs.get("overallMemoryUsage")),
+        "uptime_seconds": _int_or_none(qs.get("uptime")),
+    }
+
+
+def _parse_hardware(hardware: Any) -> dict[str, Any]:
+    """Flatten ``HostHardwareSummary`` totals into the operator-facing row.
+
+    ``cpuMhz`` is per-core clock speed in MHz; multiply by
+    ``num_cpu_cores`` for the host's total CPU capacity against which
+    ``overall_cpu_usage_mhz`` is the load. ``memorySize`` is total
+    physical memory in **bytes** (quickStats' ``overallMemoryUsage`` is
+    in MB -- different units, deliberately passed through raw).
+    """
+    hw = hardware if isinstance(hardware, dict) else {}
+    cpu_model = hw.get("cpuModel")
+    return {
+        "cpu_model": cpu_model if isinstance(cpu_model, str) else None,
+        "cpu_mhz": _int_or_none(hw.get("cpuMhz")),
+        "num_cpu_packages": _int_or_none(hw.get("numCpuPkgs")),
+        "num_cpu_cores": _int_or_none(hw.get("numCpuCores")),
+        "num_cpu_threads": _int_or_none(hw.get("numCpuThreads")),
+        "memory_size_bytes": _int_or_none(hw.get("memorySize")),
+    }
+
+
+def _in_maintenance_mode(value: Any) -> bool | None:
+    """Coerce ``runtime.inMaintenanceMode`` to bool; absent -> ``None``."""
+    return value if isinstance(value, bool) else None
+
+
+async def _read_host_usage_row(
+    connector: VmwareRestConnector,
+    operator: Operator,
+    target: VsphereTargetLike,
+    props_path: str,
+    host_moid: str,
+    host_name: Any,
+) -> dict[str, Any]:
+    """Build one host row: identity + best-effort quickStats/hardware detail.
+
+    The per-host WS-API property read is best-effort -- the host is
+    already identified by the REST listing, so a failed vi-json
+    ``RetrievePropertiesEx`` (a host that rejects the call, a transient
+    auth expiry) nulls the ``quick_stats`` / ``hardware`` /
+    ``in_maintenance_mode`` detail and records ``read_note`` rather than
+    sinking the whole op. Mirrors ``host.network_uplinks``' best-effort
+    per-host leg.
+    """
+    row: dict[str, Any] = {"id": host_moid, "name": host_name}
+    try:
+        props_result = await connector._post_json(
+            target,
+            props_path,
+            operator=operator,
+            json=build_host_usage_retrieve_params(host_moid),
+        )
+    except (httpx.HTTPError, RuntimeError) as exc:
+        row["quick_stats"] = None
+        row["hardware"] = None
+        row["in_maintenance_mode"] = None
+        row["read_note"] = (
+            f"host-usage property read skipped: RetrievePropertiesEx for host "
+            f"{host_moid!r} failed with {type(exc).__name__}: {exc}"
+        )
+        return row
+    props = _extract_host_props(props_result)
+    row["quick_stats"] = _parse_quick_stats(props.get(_PROP_QUICK_STATS))
+    row["hardware"] = _parse_hardware(props.get(_PROP_HARDWARE))
+    row["in_maintenance_mode"] = _in_maintenance_mode(props.get(_PROP_IN_MAINTENANCE))
+    return row
+
+
+async def host_usage_impl(
+    connector: VmwareRestConnector,
+    operator: Operator,
+    target: VsphereTargetLike,
+    params: dict[str, Any],
+) -> dict[str, Any]:
+    """Implementation of ``vmware.host.usage`` -- per-host utilisation.
+
+    Reads, directly on the connector session (no ``dispatch_child``, no
+    ingested descriptor):
+
+    1. ``GET /vcenter/host`` (mounted) -- lists hosts, optionally narrowed
+       by ``filter_hosts`` (a list of host MoRef ids). Load-bearing: a
+       failure here raises and the dispatcher records it as a
+       ``connector_error`` for the whole op.
+    2. Per host: ``POST .../PropertyCollector/propertyCollector/RetrievePropertiesEx``
+       (mounted) reading ``summary.quickStats`` (CPU+memory load),
+       ``summary.hardware`` (capacity totals), and
+       ``runtime.inMaintenanceMode``. Best-effort per host.
+
+    Both calls route through :meth:`VmwareRestConnector.mount_op_path`, so
+    the op lands on the ``/api`` (modern) or ``/rest`` (legacy / vcsim)
+    mount the target's session selected -- the same modern->legacy 404
+    fallback the session establish discovered.
+
+    Returns ``{"hosts": [{"id", "name", "quick_stats", "hardware",
+    "in_maintenance_mode"}, ...]}``.
+    """
+    filter_hosts = [h for h in (params.get("filter_hosts") or []) if isinstance(h, str)]
+    list_path = await connector.mount_op_path(target, _LIST_HOSTS_PATH, operator)
+    listing_params: dict[str, Any] = {"filter.hosts": filter_hosts} if filter_hosts else {}
+    listing = await connector._get_json(
+        target, list_path, operator=operator, params=listing_params or None
+    )
+    entries = _unwrap_value(listing)
+    if not isinstance(entries, list):
+        raise RuntimeError(
+            f"vmware.host.usage: expected a list of hosts from GET "
+            f"{_LIST_HOSTS_PATH!r}, got {type(entries).__name__}"
+        )
+
+    # Resolve the mounted RetrievePropertiesEx path once -- host-independent
+    # and idempotent (the session establish it triggers is cached).
+    props_path = await connector.mount_op_path(target, _RETRIEVE_PROPERTIES_PATH, operator)
+
+    hosts: list[dict[str, Any]] = []
+    for entry in entries:
+        if not isinstance(entry, dict):
+            continue
+        host_moid = entry.get("host")
+        if not isinstance(host_moid, str):
+            # vSphere REST returns the moid under ``host``; absence is an
+            # upstream malformation -- skip rather than abort.
+            continue
+        hosts.append(
+            await _read_host_usage_row(
+                connector, operator, target, props_path, host_moid, entry.get("name")
+            )
+        )
+    _log.info("vmware_host_usage_read", target=target.name, host_count=len(hosts))
+    return {"hosts": hosts}
+
+
+# ---------------------------------------------------------------------------
+# Op metadata + registrar
+# ---------------------------------------------------------------------------
+
+#: Curated ``when_to_use`` blurb for the host-usage group.
+#: ``register_typed_operation`` requires a non-empty string whenever
+#: ``group_key`` is set (typed_register ``_validate_when_to_use_pairing``).
+VMWARE_TYPED_WHEN_TO_USE_BY_GROUP: dict[str, str] = {
+    _HOST_USAGE_GROUP_KEY: (
+        "Use to read per-ESXi-host resource utilisation across a vCenter: "
+        "current CPU load (overall_cpu_usage_mhz) and memory load "
+        "(overall_memory_usage_mb) against each host's hardware capacity "
+        "(cpu_mhz per core x num_cpu_cores, memory_size_bytes), plus whether "
+        "the host is in maintenance mode. The right op when the question is "
+        "'which hosts are hot / near capacity?', 'how much CPU/RAM headroom "
+        "is left on this host?', or 'is this host in maintenance?' -- data the "
+        "plain vCenter REST host summary (liveness only) cannot supply. "
+        "Read-only."
+    ),
+}
+
+VMWARE_HOST_USAGE_OP = VmwareTypedOp(
+    op_id="vmware.host.usage",
+    handler_attr="host_usage",
+    summary="Per-host CPU/memory utilisation, hardware totals, and maintenance mode.",
+    description=(
+        "Returns one row per ESXi host in the vCenter with its live "
+        "utilisation and capacity: quick_stats (overall_cpu_usage_mhz, "
+        "overall_memory_usage_mb, uptime_seconds), hardware "
+        "(cpu_model, cpu_mhz per core, num_cpu_packages/cores/threads, "
+        "memory_size_bytes), and in_maintenance_mode. CPU load compares "
+        "overall_cpu_usage_mhz against cpu_mhz*num_cpu_cores; memory load "
+        "compares overall_memory_usage_mb (MB) against memory_size_bytes "
+        "(bytes -- different units). Reads the Web-Services-API "
+        "HostSystem.summary.quickStats / .hardware / runtime.inMaintenanceMode "
+        "via PropertyCollector directly on the connector session, so it "
+        "works with zero catalog ingest -- the plain REST host summary "
+        "reports only liveness, not load. Optional filter_hosts narrows to "
+        "specific host MoRef ids. safety_level=safe, read-only."
+    ),
+    parameter_schema={
+        "type": "object",
+        "properties": {
+            "filter_hosts": {
+                "type": "array",
+                "items": {"type": "string", "minLength": 1},
+                "description": (
+                    "Optional list of host MoRef ids (e.g. 'host-12') to narrow "
+                    "the report to. Omit to report every host in the vCenter."
+                ),
+            },
+        },
+        "additionalProperties": False,
+    },
+    response_schema={
+        "type": "object",
+        "properties": {
+            "hosts": {"type": "array"},
+        },
+        "additionalProperties": True,
+    },
+    group_key=_HOST_USAGE_GROUP_KEY,
+    tags=("read-only", "vmware", "vcenter", "host", "utilisation"),
+    safety_level="safe",
+    requires_approval=False,
+    llm_instructions={
+        "when_to_use": (
+            "Call when the operator asks about ESXi host load, headroom, or "
+            "capacity -- CPU/memory utilisation per host, which hosts are near "
+            "capacity, or whether a host is in maintenance mode. The plain "
+            "vCenter REST host listing gives liveness only; this op adds the "
+            "load figures."
+        ),
+        "parameter_hints": {
+            "filter_hosts": "List of host MoRef ids to narrow to; omit for all hosts.",
+        },
+        "output_shape": (
+            "{hosts: [{id, name, quick_stats: {overall_cpu_usage_mhz, "
+            "overall_memory_usage_mb, uptime_seconds}, hardware: {cpu_model, "
+            "cpu_mhz, num_cpu_packages, num_cpu_cores, num_cpu_threads, "
+            "memory_size_bytes}, in_maintenance_mode}, ...]}. When a host's "
+            "property read failed, quick_stats/hardware/in_maintenance_mode "
+            "are null and the row carries a read_note."
+        ),
+    },
+)
+
+#: The typed ops :class:`VmwareRestConnector` registers at lifespan
+#: startup. One op today (``vmware.host.usage``); the tuple shape lets
+#: future typed reads (the C2 pattern this establishes) join without
+#: touching the registrar.
+VMWARE_TYPED_OPS: tuple[VmwareTypedOp, ...] = (VMWARE_HOST_USAGE_OP,)
+
+
+async def register_vmware_typed_operations(
+    *,
+    embedding_service: EmbeddingService | None = None,
+) -> None:
+    """Upsert every op in :data:`VMWARE_TYPED_OPS` into ``endpoint_descriptor``.
+
+    Queued onto the lifespan-driven registrar list via
+    :func:`~meho_backplane.operations.typed_register.register_typed_op_registrar`
+    in this package's ``__init__``; the runner
+    (:func:`~meho_backplane.operations.typed_register.run_typed_op_registrars`)
+    invokes it after
+    :func:`~meho_backplane.connectors.registry._eager_import_connectors`
+    has walked every connector subpackage, so the descriptor rows land
+    before the first dispatch. Idempotent across pod restarts (the helper
+    skips the embedding recompute on unchanged summary / description /
+    tags). Mirrors :func:`register_vmware_composite_operations` and the
+    argocd typed-op registrar.
+
+    The ``embedding_service`` keyword-only parameter is the runner
+    contract: :func:`run_typed_op_registrars` passes the process-wide
+    :class:`EmbeddingService` (or a chassis-test stub) to every registrar,
+    so each registrar must accept the kwarg. It is forwarded to
+    :func:`register_typed_operation` (which falls back to the process-wide
+    singleton when ``None``).
+    """
+    # Lazy import: the operations package pulls in the embedding pipeline
+    # (ONNX runtime + model), which pure connector/handler unit tests
+    # should not pay. Lifespan callers have it warmed by the time this runs.
+    from meho_backplane.connectors.vmware_rest.connector import VmwareRestConnector
+    from meho_backplane.operations.typed_register import register_typed_operation
+
+    for op in VMWARE_TYPED_OPS:
+        handler = getattr(VmwareRestConnector, op.handler_attr, None)
+        if handler is None:
+            raise AttributeError(
+                f"VmwareRestConnector typed op {op.op_id!r} declares "
+                f"handler_attr={op.handler_attr!r} but the class has no such attribute"
+            )
+        when_to_use = (
+            None if op.group_key is None else VMWARE_TYPED_WHEN_TO_USE_BY_GROUP.get(op.group_key)
+        )
+        if op.group_key is not None and when_to_use is None:
+            raise ValueError(
+                f"VmwareRestConnector typed op {op.op_id!r} declares "
+                f"group_key={op.group_key!r} but no curated when_to_use exists for "
+                f"that key. Add an entry to VMWARE_TYPED_WHEN_TO_USE_BY_GROUP."
+            )
+        await register_typed_operation(
+            product=VmwareRestConnector.product,
+            version=VmwareRestConnector.version,
+            impl_id=VmwareRestConnector.impl_id,
+            op_id=op.op_id,
+            handler=handler,
+            summary=op.summary,
+            description=op.description,
+            parameter_schema=op.parameter_schema,
+            response_schema=op.response_schema,
+            group_key=op.group_key,
+            when_to_use=when_to_use,
+            tags=list(op.tags),
+            safety_level=op.safety_level,
+            requires_approval=op.requires_approval,
+            llm_instructions=op.llm_instructions,
+            embedding_service=embedding_service,
+        )
+    _log.info(
+        "vmware_typed_operations_registered",
+        count=len(VMWARE_TYPED_OPS),
+        product=VmwareRestConnector.product,
+        version=VmwareRestConnector.version,
+        impl_id=VmwareRestConnector.impl_id,
+    )

--- a/backend/tests/integration/test_connectors_vmware_rest_vcsim.py
+++ b/backend/tests/integration/test_connectors_vmware_rest_vcsim.py
@@ -31,15 +31,17 @@ dependency — respx runs in-process.
 
 from __future__ import annotations
 
+import json
 from collections.abc import AsyncIterator
 from dataclasses import dataclass, field
 from typing import Any
 from uuid import UUID, uuid4
 
+import httpx
 import pytest
 import respx
 
-from meho_backplane.auth.operator import Operator
+from meho_backplane.auth.operator import Operator, TenantRole
 from meho_backplane.connectors._shared.cache_key import target_cache_key
 from meho_backplane.connectors.schemas import AuthModel
 from meho_backplane.connectors.vmware_rest import (
@@ -77,19 +79,77 @@ ABOUT_PAYLOAD: dict[str, Any] = {
 #: connector's ``_extract_session_token`` handles that shape.
 SESSION_TOKEN: str = "integration-mock-session-token"
 
+#: ``GET /vcenter/host`` listing (vCenter Automation REST). The
+#: ``vmware.host.usage`` typed op lists hosts here, then reads per-host
+#: utilisation via PropertyCollector. Bare-array modern shape.
+HOST_LISTING: list[dict[str, Any]] = [
+    {"host": "host-11", "name": "esx-a.test.invalid", "connection_state": "CONNECTED"},
+    {"host": "host-22", "name": "esx-b.test.invalid", "connection_state": "CONNECTED"},
+]
+
+#: A ``RetrievePropertiesEx`` ``RetrieveResult`` carrying the three
+#: WS-API host-usage properties the typed op requests. The respx handler
+#: echoes the queried host's moId back into the ``obj`` so a single
+#: static body serves every per-host POST.
+_RETRIEVE_QUICK_STATS: dict[str, Any] = {
+    "overallCpuUsage": 5200,
+    "overallMemoryUsage": 131072,
+    "uptime": 1728000,
+}
+_RETRIEVE_HARDWARE: dict[str, Any] = {
+    "cpuModel": "Intel(R) Xeon(R) Gold 6248R",
+    "cpuMhz": 3000,
+    "numCpuPkgs": 2,
+    "numCpuCores": 48,
+    "numCpuThreads": 96,
+    "memorySize": 274877906944,
+}
+
+
+def _retrieve_properties_response(request: httpx.Request) -> httpx.Response:
+    """Build a ``RetrieveResult`` echoing the POSTed host moId.
+
+    The typed op issues one RetrievePropertiesEx per host with the host's
+    MoRef in ``specSet[0].objectSet[0].obj.value``; the handler reflects
+    it back so the same static quickStats/hardware body serves every host.
+    """
+    body = json.loads(request.content)
+    moid = body["specSet"][0]["objectSet"][0]["obj"]["value"]
+    return httpx.Response(
+        200,
+        json={
+            "objects": [
+                {
+                    "obj": {"type": "HostSystem", "value": moid},
+                    "propSet": [
+                        {"name": "summary.quickStats", "val": _RETRIEVE_QUICK_STATS},
+                        {"name": "summary.hardware", "val": _RETRIEVE_HARDWARE},
+                        {"name": "runtime.inMaintenanceMode", "val": moid == "host-22"},
+                    ],
+                }
+            ]
+        },
+    )
+
 
 def _register_vcenter_routes(mock: respx.MockRouter) -> None:
     """Register the modern vCenter REST surface the connector calls.
 
     ``POST /api/session`` (200 → token; the modern path succeeds so the
     connector records ``/api/session`` as the established path),
-    ``GET /api/about`` (the fingerprint probe), and ``DELETE
-    /api/session`` (the ``aclose`` revoke against the established
-    path).
+    ``GET /api/about`` (the fingerprint probe), ``DELETE /api/session``
+    (the ``aclose`` revoke against the established path), plus the
+    ``vmware.host.usage`` surface: ``GET /api/vcenter/host`` and the
+    per-host ``POST /api/PropertyCollector/propertyCollector/RetrievePropertiesEx``
+    (both mounted onto ``/api`` by :meth:`VmwareRestConnector.mount_op_path`).
     """
     mock.post("/api/session").respond(200, json=SESSION_TOKEN)
     mock.get("/api/about").respond(200, json=ABOUT_PAYLOAD)
     mock.delete("/api/session").respond(204)
+    mock.get("/api/vcenter/host").respond(200, json=HOST_LISTING)
+    mock.post("/api/PropertyCollector/propertyCollector/RetrievePropertiesEx").mock(
+        side_effect=_retrieve_properties_response
+    )
 
 
 # ---------------------------------------------------------------------------
@@ -216,3 +276,94 @@ async def test_aclose_revokes_session_against_vcsim(
     # teardown calls aclose() again — idempotent no-op on empty state.)
     assert connector._session_tokens == {}
     assert connector._clients == {}
+
+
+# ---------------------------------------------------------------------------
+# vmware.host.usage typed op (#2257) — end-to-end transport + mount routing
+# ---------------------------------------------------------------------------
+
+
+def _operator() -> Operator:
+    """Operator with a non-empty raw_jwt (the session-establish guard)."""
+    return Operator(
+        sub="op-host-usage-integration",
+        name="Host Usage Integration",
+        email=None,
+        raw_jwt="<integration-raw-jwt>",
+        tenant_id=UUID(int=0),
+        tenant_role=TenantRole.OPERATOR,
+    )
+
+
+@pytest.mark.asyncio
+async def test_host_usage_over_modern_mount_returns_per_host_utilisation(
+    vcsim_connector: tuple[VmwareRestConnector, _VcsimTarget],
+) -> None:
+    """host_usage() runs the full session → list → per-host RetrievePropertiesEx path.
+
+    The modern ``POST /api/session`` succeeds, so both the host listing
+    and the PropertyCollector call mount onto ``/api``. Exercises the real
+    connector transport (respx-intercepted) end to end — no dispatch_child,
+    no ingested descriptor.
+    """
+    connector, target = vcsim_connector
+
+    result = await connector.host_usage(_operator(), target, {})
+
+    rows = result["hosts"]
+    assert [r["id"] for r in rows] == ["host-11", "host-22"]
+    assert rows[0]["quick_stats"] == {
+        "overall_cpu_usage_mhz": 5200,
+        "overall_memory_usage_mb": 131072,
+        "uptime_seconds": 1728000,
+    }
+    assert rows[0]["hardware"]["num_cpu_cores"] == 48
+    assert rows[0]["hardware"]["memory_size_bytes"] == 274877906944
+    # The maintenance flag is echoed per host by the respx side-effect.
+    assert rows[0]["in_maintenance_mode"] is False
+    assert rows[1]["in_maintenance_mode"] is True
+
+
+@pytest.mark.asyncio
+async def test_host_usage_over_legacy_mount_routes_to_rest(
+    vcsim_target: _VcsimTarget,
+) -> None:
+    """A legacy-only target (modern /api/session 404s) mounts host.usage onto /rest.
+
+    Reproduces the vcsim / old-vCenter topology: ``POST /api/session``
+    404s, the connector falls back to the legacy
+    ``POST /rest/com/vmware/cis/session``, and every subsequent op —
+    including the typed host.usage listing + PropertyCollector call — must
+    route through ``/rest`` (not ``/api``) via ``mount_op_path``, or it
+    404s. This is the modern+legacy mount coverage the acceptance criteria
+    require.
+    """
+
+    async def _loader(_target: VsphereTargetLike, _operator: Operator) -> dict[str, str]:
+        return {"username": "user", "password": "pass"}
+
+    connector = VmwareRestConnector(session_loader=_loader)
+
+    async with respx.mock(
+        base_url=VCENTER_BASE_URL,
+        assert_all_called=False,
+        assert_all_mocked=False,
+    ) as mock:
+        # Modern session endpoint is absent (404) → legacy fallback.
+        mock.post("/api/session").respond(404)
+        mock.post("/rest/com/vmware/cis/session").respond(200, json=SESSION_TOKEN)
+        # Ops are served ONLY under the legacy /rest mount; a request to
+        # the /api mount would 404 (unmocked → respx passthrough-less).
+        mock.get("/rest/vcenter/host").respond(200, json=HOST_LISTING)
+        mock.post("/rest/PropertyCollector/propertyCollector/RetrievePropertiesEx").mock(
+            side_effect=_retrieve_properties_response
+        )
+        mock.delete("/rest/com/vmware/cis/session").respond(204)
+        try:
+            result = await connector.host_usage(_operator(), vcsim_target, {})
+        finally:
+            await connector.aclose()
+
+    rows = result["hosts"]
+    assert [r["id"] for r in rows] == ["host-11", "host-22"]
+    assert rows[0]["hardware"]["cpu_mhz"] == 3000

--- a/backend/tests/test_connectors_vmware_rest_typed_host_usage.py
+++ b/backend/tests/test_connectors_vmware_rest_typed_host_usage.py
@@ -1,0 +1,396 @@
+# SPDX-License-Identifier: Apache-2.0
+# Copyright (c) 2026 evoila Group
+
+"""Unit tests for the ``vmware.host.usage`` typed op (#2257).
+
+``vmware.host.usage`` is the first vmware ``source_kind="typed"`` op: a
+bound method on :class:`VmwareRestConnector` that reads per-host
+utilisation directly on the connector session (no ``dispatch_child``, no
+ingested descriptor), so it works on a fresh boot with zero catalog
+ingest.
+
+The handler logic is exercised against a fake connector that records
+:meth:`mount_op_path` / :meth:`_get_json` / :meth:`_post_json` calls, so
+the assertion targets are the call-shape contract (list-then-per-host,
+both calls mounted, best-effort per host) and the parse/aggregation
+contract, without a live httpx transport. The end-to-end transport +
+modern/legacy mount routing is covered by the respx integration test in
+``tests/integration/test_connectors_vmware_rest_vcsim.py``.
+"""
+
+from __future__ import annotations
+
+from dataclasses import dataclass, field
+from typing import Any
+from uuid import UUID, uuid4
+
+import httpx
+import pytest
+
+from meho_backplane.auth.operator import Operator, TenantRole
+from meho_backplane.connectors.vmware_rest.connector import VmwareRestConnector
+from meho_backplane.connectors.vmware_rest.typed_ops import (
+    VMWARE_HOST_USAGE_OP,
+    VMWARE_TYPED_OPS,
+    VMWARE_TYPED_WHEN_TO_USE_BY_GROUP,
+    build_host_usage_retrieve_params,
+    host_usage_impl,
+)
+
+# ---------------------------------------------------------------------------
+# Fixtures / doubles
+# ---------------------------------------------------------------------------
+
+
+def _make_operator() -> Operator:
+    """Synthetic operator for the typed-op handler unit tests."""
+    return Operator(
+        sub="op-host-usage",
+        name="Host Usage Test",
+        email=None,
+        raw_jwt="<test-raw-jwt>",
+        tenant_id=UUID("00000000-0000-0000-0000-00000000a0a0"),
+        tenant_role=TenantRole.OPERATOR,
+    )
+
+
+@dataclass
+class _Target:
+    name: str = "vc-test"
+    host: str = "vc.test.invalid"
+    port: int | None = 443
+    id: UUID = field(default_factory=uuid4)
+    tenant_id: UUID = field(default_factory=lambda: UUID(int=0))
+
+
+class _FakeConnector:
+    """Records the transport calls ``host_usage_impl`` makes.
+
+    Mirrors the surface of :class:`VmwareRestConnector` the handler uses:
+    :meth:`mount_op_path` (prefixes the live mount), :meth:`_get_json`
+    (the host listing), :meth:`_post_json` (per-host RetrievePropertiesEx).
+    """
+
+    def __init__(
+        self,
+        *,
+        listing: Any,
+        props_by_host: dict[str, Any] | None = None,
+        post_error: Exception | None = None,
+        mount_prefix: str = "/api",
+    ) -> None:
+        self._listing = listing
+        self._props_by_host = props_by_host or {}
+        self._post_error = post_error
+        self._mount_prefix = mount_prefix
+        self.mount_calls: list[str] = []
+        self.get_calls: list[tuple[str, dict[str, Any] | None]] = []
+        self.post_calls: list[tuple[str, dict[str, Any]]] = []
+
+    async def mount_op_path(self, target: Any, path: str, operator: Operator) -> str:
+        del target, operator
+        self.mount_calls.append(path)
+        return f"{self._mount_prefix}{path}"
+
+    async def _get_json(
+        self,
+        target: Any,
+        path: str,
+        *,
+        operator: Operator,
+        params: dict[str, Any] | None = None,
+    ) -> Any:
+        del target, operator
+        self.get_calls.append((path, params))
+        return self._listing
+
+    async def _post_json(
+        self,
+        target: Any,
+        path: str,
+        *,
+        operator: Operator,
+        json: dict[str, Any] | None = None,
+    ) -> Any:
+        del target, operator
+        assert json is not None
+        self.post_calls.append((path, json))
+        if self._post_error is not None:
+            raise self._post_error
+        moid = json["specSet"][0]["objectSet"][0]["obj"]["value"]
+        return self._props_by_host[moid]
+
+
+def _retrieve_result(moid: str, quick_stats: Any, hardware: Any, in_maint: Any) -> dict[str, Any]:
+    """Build a RetrievePropertiesEx ``RetrieveResult`` for one host."""
+    return {
+        "objects": [
+            {
+                "obj": {"type": "HostSystem", "value": moid},
+                "propSet": [
+                    {"name": "summary.quickStats", "val": quick_stats},
+                    {"name": "summary.hardware", "val": hardware},
+                    {"name": "runtime.inMaintenanceMode", "val": in_maint},
+                ],
+            }
+        ]
+    }
+
+
+_QS_FULL = {"overallCpuUsage": 4200, "overallMemoryUsage": 65536, "uptime": 864000}
+_HW_FULL = {
+    "cpuModel": "Intel(R) Xeon(R) Gold 6248R",
+    "cpuMhz": 3000,
+    "numCpuPkgs": 2,
+    "numCpuCores": 48,
+    "numCpuThreads": 96,
+    "memorySize": 274877906944,
+}
+
+
+# ---------------------------------------------------------------------------
+# Pure builders / parsers
+# ---------------------------------------------------------------------------
+
+
+def test_build_retrieve_params_shape_is_single_host_property_filter() -> None:
+    body = build_host_usage_retrieve_params("host-42")
+    assert set(body) == {"specSet", "options"}
+    assert body["options"] == {}
+    (spec,) = body["specSet"]
+    (prop_spec,) = spec["propSet"]
+    assert prop_spec["type"] == "HostSystem"
+    assert prop_spec["pathSet"] == [
+        "summary.quickStats",
+        "summary.hardware",
+        "runtime.inMaintenanceMode",
+    ]
+    (obj_spec,) = spec["objectSet"]
+    assert obj_spec["obj"] == {"type": "HostSystem", "value": "host-42"}
+
+
+# ---------------------------------------------------------------------------
+# host_usage_impl — call-shape + aggregation
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.asyncio
+async def test_host_usage_lists_then_reads_each_host_mounted() -> None:
+    listing = [
+        {"host": "host-1", "name": "esx-1"},
+        {"host": "host-2", "name": "esx-2"},
+    ]
+    props = {
+        "host-1": _retrieve_result("host-1", _QS_FULL, _HW_FULL, False),
+        "host-2": _retrieve_result("host-2", _QS_FULL, _HW_FULL, True),
+    }
+    conn = _FakeConnector(listing=listing, props_by_host=props)
+
+    out = await host_usage_impl(conn, _make_operator(), _Target(), {})
+
+    # Both the host listing and the PropertyCollector path were mounted.
+    assert conn.mount_calls[0] == "/vcenter/host"
+    assert "/PropertyCollector/propertyCollector/RetrievePropertiesEx" in conn.mount_calls
+    # The listing GET used the mounted (/api-prefixed) path.
+    assert conn.get_calls[0][0] == "/api/vcenter/host"
+    # One RetrievePropertiesEx POST per host, all against the mounted path.
+    assert len(conn.post_calls) == 2
+    assert all(
+        path == "/api/PropertyCollector/propertyCollector/RetrievePropertiesEx"
+        for path, _ in conn.post_calls
+    )
+
+    rows = out["hosts"]
+    assert [r["id"] for r in rows] == ["host-1", "host-2"]
+    assert rows[0]["name"] == "esx-1"
+    assert rows[0]["quick_stats"] == {
+        "overall_cpu_usage_mhz": 4200,
+        "overall_memory_usage_mb": 65536,
+        "uptime_seconds": 864000,
+    }
+    assert rows[0]["hardware"] == {
+        "cpu_model": "Intel(R) Xeon(R) Gold 6248R",
+        "cpu_mhz": 3000,
+        "num_cpu_packages": 2,
+        "num_cpu_cores": 48,
+        "num_cpu_threads": 96,
+        "memory_size_bytes": 274877906944,
+    }
+    assert rows[0]["in_maintenance_mode"] is False
+    assert rows[1]["in_maintenance_mode"] is True
+
+
+@pytest.mark.asyncio
+async def test_host_usage_resolves_mount_once_not_per_host() -> None:
+    """The RetrievePropertiesEx path is host-independent — mount it once."""
+    listing = [{"host": f"host-{i}", "name": f"esx-{i}"} for i in range(3)]
+    props = {
+        f"host-{i}": _retrieve_result(f"host-{i}", _QS_FULL, _HW_FULL, False) for i in range(3)
+    }
+    conn = _FakeConnector(listing=listing, props_by_host=props)
+
+    await host_usage_impl(conn, _make_operator(), _Target(), {})
+
+    # Exactly two mount calls total: the host listing + one for the
+    # per-host property path (resolved once, reused across the 3 hosts).
+    assert conn.mount_calls == [
+        "/vcenter/host",
+        "/PropertyCollector/propertyCollector/RetrievePropertiesEx",
+    ]
+
+
+@pytest.mark.asyncio
+async def test_host_usage_filter_hosts_flows_into_listing_query() -> None:
+    conn = _FakeConnector(
+        listing=[{"host": "host-1", "name": "esx-1"}],
+        props_by_host={"host-1": _retrieve_result("host-1", _QS_FULL, _HW_FULL, False)},
+    )
+
+    await host_usage_impl(conn, _make_operator(), _Target(), {"filter_hosts": ["host-1", "host-2"]})
+
+    assert conn.get_calls[0][1] == {"filter.hosts": ["host-1", "host-2"]}
+
+
+@pytest.mark.asyncio
+async def test_host_usage_no_filter_sends_no_query_params() -> None:
+    conn = _FakeConnector(
+        listing=[{"host": "host-1", "name": "esx-1"}],
+        props_by_host={"host-1": _retrieve_result("host-1", _QS_FULL, _HW_FULL, False)},
+    )
+
+    await host_usage_impl(conn, _make_operator(), _Target(), {})
+
+    assert conn.get_calls[0][1] is None
+
+
+@pytest.mark.asyncio
+async def test_host_usage_tolerates_legacy_value_envelope_on_listing() -> None:
+    conn = _FakeConnector(
+        listing={"value": [{"host": "host-1", "name": "esx-1"}]},
+        props_by_host={"host-1": _retrieve_result("host-1", _QS_FULL, _HW_FULL, False)},
+    )
+
+    out = await host_usage_impl(conn, _make_operator(), _Target(), {})
+
+    assert [r["id"] for r in out["hosts"]] == ["host-1"]
+
+
+@pytest.mark.asyncio
+async def test_host_usage_skips_malformed_listing_entries() -> None:
+    listing = [
+        "not-a-dict",
+        {"name": "no-moid"},  # missing ``host`` key
+        {"host": "host-3", "name": "esx-3"},
+    ]
+    conn = _FakeConnector(
+        listing=listing,
+        props_by_host={"host-3": _retrieve_result("host-3", _QS_FULL, _HW_FULL, False)},
+    )
+
+    out = await host_usage_impl(conn, _make_operator(), _Target(), {})
+
+    assert [r["id"] for r in out["hosts"]] == ["host-3"]
+    assert len(conn.post_calls) == 1
+
+
+@pytest.mark.asyncio
+async def test_host_usage_raises_on_non_list_listing() -> None:
+    conn = _FakeConnector(listing={"unexpected": "shape"})
+
+    with pytest.raises(RuntimeError, match="expected a list of hosts"):
+        await host_usage_impl(conn, _make_operator(), _Target(), {})
+
+
+@pytest.mark.asyncio
+async def test_host_usage_per_host_read_is_best_effort() -> None:
+    """A failed RetrievePropertiesEx nulls the detail + records read_note."""
+    conn = _FakeConnector(
+        listing=[{"host": "host-1", "name": "esx-1"}],
+        post_error=httpx.HTTPStatusError(
+            "boom", request=httpx.Request("POST", "https://vc/api"), response=httpx.Response(500)
+        ),
+    )
+
+    out = await host_usage_impl(conn, _make_operator(), _Target(), {})
+
+    (row,) = out["hosts"]
+    assert row["id"] == "host-1"
+    assert row["quick_stats"] is None
+    assert row["hardware"] is None
+    assert row["in_maintenance_mode"] is None
+    assert "read_note" in row
+    assert "RetrievePropertiesEx" in row["read_note"]
+
+
+@pytest.mark.asyncio
+async def test_host_usage_partial_props_map_to_none_fields() -> None:
+    """Absent quickStats/hardware leaves map to None, not KeyError."""
+    conn = _FakeConnector(
+        listing=[{"host": "host-1", "name": "esx-1"}],
+        props_by_host={"host-1": _retrieve_result("host-1", {}, {}, None)},
+    )
+
+    out = await host_usage_impl(conn, _make_operator(), _Target(), {})
+
+    (row,) = out["hosts"]
+    assert row["quick_stats"] == {
+        "overall_cpu_usage_mhz": None,
+        "overall_memory_usage_mb": None,
+        "uptime_seconds": None,
+    }
+    assert row["hardware"]["memory_size_bytes"] is None
+    assert row["in_maintenance_mode"] is None
+
+
+@pytest.mark.asyncio
+async def test_host_usage_coerces_numeric_string_memory_size() -> None:
+    """A 64-bit memorySize rendered as a JSON string still parses to int."""
+    conn = _FakeConnector(
+        listing=[{"host": "host-1", "name": "esx-1"}],
+        props_by_host={
+            "host-1": _retrieve_result(
+                "host-1", _QS_FULL, {**_HW_FULL, "memorySize": "274877906944"}, False
+            )
+        },
+    )
+
+    out = await host_usage_impl(conn, _make_operator(), _Target(), {})
+
+    assert out["hosts"][0]["hardware"]["memory_size_bytes"] == 274877906944
+
+
+# ---------------------------------------------------------------------------
+# Op metadata / registration contract
+# ---------------------------------------------------------------------------
+
+
+def test_host_usage_op_is_the_registered_typed_op() -> None:
+    assert VMWARE_TYPED_OPS == (VMWARE_HOST_USAGE_OP,)
+    assert VMWARE_HOST_USAGE_OP.op_id == "vmware.host.usage"
+    assert VMWARE_HOST_USAGE_OP.safety_level == "safe"
+    assert VMWARE_HOST_USAGE_OP.requires_approval is False
+
+
+def test_host_usage_handler_attr_resolves_to_a_connector_bound_method() -> None:
+    """handler_attr must name a real async method (dispatcher binds it)."""
+    handler = getattr(VmwareRestConnector, VMWARE_HOST_USAGE_OP.handler_attr, None)
+    assert handler is not None
+    assert callable(handler)
+
+
+def test_host_usage_group_has_non_empty_when_to_use() -> None:
+    """A grouped typed op needs a non-empty when_to_use (typed_register)."""
+    group_key = VMWARE_HOST_USAGE_OP.group_key
+    assert group_key is not None
+    blurb = VMWARE_TYPED_WHEN_TO_USE_BY_GROUP.get(group_key)
+    assert isinstance(blurb, str)
+    assert blurb.strip()
+
+
+def test_host_usage_handler_signature_has_no_dispatch_child() -> None:
+    """Typed handler must NOT accept dispatch_child (else it'd be a composite)."""
+    import inspect
+
+    params = inspect.signature(VmwareRestConnector.host_usage).parameters
+    assert "dispatch_child" not in params
+    assert "operator" in params

--- a/docs/codebase/connectors-vmware-rest.md
+++ b/docs/codebase/connectors-vmware-rest.md
@@ -71,6 +71,40 @@ Source: `backend/src/meho_backplane/connectors/vmware_rest/`.
   own `safety_level` + `requires_approval` so the policy posture is
   implied by the spec, not by global defaults. Idempotent on re-run
   via the body-hash skip path.
+- **Typed ops** (`typed_ops.py`, `#2257`) — the first vmware
+  `source_kind="typed"` op, `vmware.host.usage`. Unlike a composite, a
+  typed op is a **bound method** on `VmwareRestConnector`
+  (`host_usage(self, operator, target, params)`) that the dispatcher
+  binds to the resolved connector instance and calls directly — no
+  `dispatch_child`, no ingested-descriptor sub-ops, no L2 pre-flight. It
+  therefore works on a **fresh boot with zero catalog ingest**, which a
+  composite cannot (a composite's `dispatch_child` legs resolve against
+  `endpoint_descriptor` rows that only exist post-ingest). The metadata
+  lives in a frozen `VmwareTypedOp` dataclass (mirroring
+  `argocd/ops.py::ArgoCdOp`); the implementation
+  (`host_usage_impl(connector, operator, target, params)`) lists hosts
+  via `GET /vcenter/host` then, per host, reads `summary.quickStats`
+  (CPU/memory load, MHz/MB), `summary.hardware` (capacity totals:
+  `cpu_mhz` per core, core/package/thread counts, `memory_size_bytes`),
+  and `runtime.inMaintenanceMode` through a direct PropertyCollector
+  `RetrievePropertiesEx` on the connector session. Both calls are routed
+  through `mount_op_path` so they land on `/api` (modern) or `/rest`
+  (legacy/vcsim). The per-host property read is best-effort (a failed
+  read nulls the detail with a `read_note`, mirroring
+  `host_network_uplinks_composite`); the host listing is load-bearing.
+  This op is why the plain REST host summary (liveness only) is not
+  enough — `overallCpuUsage` / `overallMemoryUsage` live on the WS-API
+  `HostSystem`, not the REST resource. It establishes the vmware typed-op
+  pattern future per-host/per-VM typed reads reuse.
+- **`register_vmware_typed_operations`** (`typed_ops.py`) — async
+  registrar wrapper queued onto `run_typed_op_registrars` (via
+  `register_typed_op_registrar` in the package `__init__`, alongside the
+  composite registrar). Walks `VMWARE_TYPED_OPS`, resolves each op's
+  `handler_attr` to the connector bound method, looks the group's
+  curated `when_to_use` blurb up in `VMWARE_TYPED_WHEN_TO_USE_BY_GROUP`
+  (required for a grouped typed op), and upserts each row into
+  `endpoint_descriptor` with `source_kind="typed"` via
+  `register_typed_operation`.
 - **`VsphereTargetLike`** (`session.py`) — runtime-checkable Protocol
   capturing the minimum target shape the connector reads: `name`,
   `host`, `port`, `secret_ref`, `auth_model`. Replaced by the concrete
@@ -107,17 +141,21 @@ Source: `backend/src/meho_backplane/connectors/vmware_rest/`.
    `__init__` calls
    `register_typed_op_registrar(register_vmware_composite_operations)`
    to queue the composite-row upsert onto the lifespan's registrar
-   list.
+   list. The package `__init__` then queues
+   `register_typed_op_registrar(register_vmware_typed_operations)`
+   (`#2257`) for the typed-op rows.
 4. The registry's v2 table now resolves `(vmware, 9.0, vmware-rest)`
    to `VmwareRestConnector`. The G0.7 auto-shim's idempotency check
    (in `ensure_connector_class_registered`, once #408's pipeline lands
    in main) no-ops on subsequent ingests against the same triple.
 5. Lifespan calls `run_typed_op_registrars()`, which iterates every
-   queued registrar -- including the composite one -- and upserts the
-   15 `vmware.composite.*` rows into `endpoint_descriptor` with
+   queued registrar and upserts: the 15 `vmware.composite.*` rows with
    `source_kind="composite"` (7 reads with `safety_level="safe"` +
    `requires_approval=False`; 8 writes with `safety_level="dangerous"`
-   + `requires_approval=True`).
+   + `requires_approval=True`), plus the `vmware.host.usage` row with
+   `source_kind="typed"` (`safety_level="safe"` + `requires_approval=False`).
+   The typed row resolves and dispatches with **zero catalog ingest** —
+   it depends on no ingested descriptor.
 
 ### Per-target session
 


### PR DESCRIPTION
## Summary
- Adds `vmware.host.usage`, the first vmware `source_kind="typed"` op: a bound-method read on `VmwareRestConnector` that returns one row per ESXi host with CPU/memory load (`summary.quickStats`), hardware capacity totals (`summary.hardware`), and `runtime.inMaintenanceMode`.
- The shipped REST `HostSummary` gives liveness only; load lives on the WS-API `HostSystem`. The op lists hosts via `GET /vcenter/host` then reads those properties per host through a direct PropertyCollector `RetrievePropertiesEx` on the connector session — no `dispatch_child`, no ingested descriptor — so it works on a **fresh boot with zero catalog ingest** (a composite can't: its sub-ops resolve against `endpoint_descriptor` rows that only exist post-ingest).
- Both calls route through `mount_op_path`, landing on `/api` (modern) or `/rest` (legacy/vcsim); the per-host read is best-effort with a `read_note`.
- Registration mirrors the argocd typed-op pattern: `VmwareTypedOp` metadata dataclass + a `register_vmware_typed_operations` registrar queued onto `run_typed_op_registrars`, with a curated `when_to_use` blurb (required for a grouped typed op).

## Test plan
- [x] `ruff check` / `ruff format --check` — clean
- [x] `mypy src/meho_backplane/connectors/vmware_rest/` — no issues (13 files)
- [x] `code-quality.py --diff` — 0 blockers (4 non-blocking warnings, recorded)
- [x] New unit file `tests/test_connectors_vmware_rest_typed_host_usage.py` (15 tests): builder/parser contract, list-then-per-host call shape, mount-once, `filter_hosts` passthrough, legacy-envelope tolerance, malformed-entry skip, non-list raise, best-effort per-host failure, numeric-string coercion, op metadata + `when_to_use` + handler-signature (no `dispatch_child`).
- [x] Integration (respx) in `tests/integration/test_connectors_vmware_rest_vcsim.py`: full transport end-to-end over **modern `/api`** mount and **legacy `/rest`** mount (session 404 → legacy fallback).
- [x] Fresh-boot dispatch proven: `derive_handler_ref` → `import_handler` round-trips the bound method; `dispatch_typed` binds it and passes `operator`.
- [x] Broader vmware suite: `pytest -k vmware_rest` — 213 passed, 11 skipped.
- [x] `make snapshot-openapi` — no diff (no route/schema surface change).

## Acceptance criteria
- [x] `vmware.host.usage` dispatches typed, works on a fresh boot with zero catalog ingest; unit + respx-recorded coverage.
- [x] One row/host with quickStats (cpu+mem), hardware totals, and `inMaintenanceMode`.
- [x] PropertyCollector call routed through `mount_op_path` (modern + legacy both covered).
- [x] New vmware typed-op test file covers the op + its `when_to_use`/group metadata.
- [x] OpenAPI snapshot regenerated — unchanged.

## Out of scope
- No I-A contract-widening or I-B migrations (this is a typed op, not a composite).
- Adjacent findings (recorded, not fixed): `typed_ops.py` is 531 lines (warn >400); `host_usage_impl` 61 / `register_vmware_typed_operations` 72 lines (warn >60, mostly docstring); `_read_host_usage_row` has 6 args (PLR0913 warn). All non-blocking.

<!-- auto-implement-issue: fresh, iteration 1 -->

Closes #2257
