### PR TITLE
feat(connectors): GCP Secret Manager credential backend Phase 1 (gsm, SA-direct)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -90,6 +90,18 @@ connector-related release-notes line.
 
 ## [Unreleased]
 
+### Added — GCP Secret Manager credential backend (Phase 1, SA-direct)
+
+- Resolve a target's `gsm:<project>/<secret>[#field]` `secret_ref` through
+  a new `gsm` credential backend on the #2229 resolver seam, reading GCP
+  Secret Manager under MEHO's own GKE Workload Identity ADC (optionally
+  impersonating a configured SA via `GSM_IMPERSONATE_SA`) — a Vault-free
+  install path for GCP-native adopters. A bare ref returns the whole JSON
+  payload; a `#field` fragment selects one key. No service-account JSON
+  key is ever used (honours `constraints/iam.disableServiceAccountKeyCreation`).
+  Per-operator GCP federation and the Helm surface are deferred to #2232 /
+  #2231. (#2230)
+
 ## [0.20.0] - 2026-07-08
 
 ### Fixed — ssh-family connectors resolve `secret_ref` from Vault

--- a/backend/pyproject.toml
+++ b/backend/pyproject.toml
@@ -34,6 +34,13 @@ dependencies = [
     "python-frontmatter>=1.3.0",
     "jinja2>=3.1.6",
     "google-auth>=2.55.1",
+    # GCP Secret Manager credential backend (#2230). Reads a target's
+    # ``gsm:<project>/<secret>[#field]`` ref under MEHO's own GKE Workload
+    # Identity ADC (optionally impersonating a configured SA), reusing the
+    # google-auth ADC + impersonation chain the GcloudConnector already
+    # drives. The sync ``SecretManagerServiceClient.access_secret_version``
+    # call is run off the event loop via ``asyncio.to_thread``.
+    "google-cloud-secret-manager>=2.20.0",
     "duckdb>=1.5.4",
     "pyarrow>=21.0.0",
     "msgspec>=0.20.0",

--- a/backend/src/meho_backplane/connectors/_shared/__init__.py
+++ b/backend/src/meho_backplane/connectors/_shared/__init__.py
@@ -17,6 +17,11 @@ Exports:
   reusable operator-context Vault KV-v2 basic-credentials reader
   (G3.9-T2 #941). Every REST connector loader resolves a target's
   ``secret_ref`` to vendor credentials through it.
+* :mod:`meho_backplane.connectors._shared.gsm_creds` — the GCP Secret
+  Manager credential backend (#2230), registered under kind ``gsm`` on the
+  #2229 resolver seam. Imported here so its ``register_credential_backend``
+  call runs eagerly (as ``vault_creds`` does for ``vault``) and the ``gsm``
+  kind is present before any credential resolution.
 * :mod:`meho_backplane.connectors._shared.cache_key` — the canonical
   tenant-unique ``(tenant_id, id)`` per-target cache key (#1642). Every
   connector credential / session / client cache derives its key here so
@@ -29,9 +34,10 @@ rather than growing this package into a god-module.
 
 from meho_backplane.connectors._shared import (
     cache_key,
+    gsm_creds,
     system_operator,
     vault_creds,
     vcf_auth,
 )
 
-__all__ = ["cache_key", "system_operator", "vault_creds", "vcf_auth"]
+__all__ = ["cache_key", "gsm_creds", "system_operator", "vault_creds", "vcf_auth"]

--- a/backend/src/meho_backplane/connectors/_shared/gsm_creds.py
+++ b/backend/src/meho_backplane/connectors/_shared/gsm_creds.py
@@ -1,0 +1,400 @@
+# SPDX-License-Identifier: Apache-2.0
+# Copyright (c) 2026 evoila Group
+
+"""GCP Secret Manager credential backend (SA-direct, #2230).
+
+The second :class:`~meho_backplane.connectors._shared.credential_backend.CredentialBackend`
+after Vault — registered under kind ``"gsm"`` on the #2229 resolver seam so
+a GCP-native adopter can point a target at
+``gsm:<project-id>/<secret-name>[#field]`` and have MEHO resolve the
+credential with **no Vault**.
+
+Auth model — SA-direct under GKE Workload Identity
+==================================================
+
+Phase 1 reads Secret Manager under **MEHO's own** identity: the pod's
+Application Default Credentials (``google.auth.default()``), which on GKE
+resolve to the deployment's Workload Identity service account. An optional
+deployment-level SA (``config.gsmImpersonateSa`` / ``GSM_IMPERSONATE_SA``)
+wraps that ADC source in
+``google.auth.impersonated_credentials.Credentials`` — the exact ADC +
+impersonation chain :class:`~meho_backplane.connectors.gcloud.connector.GcloudConnector`
+already drives (``gcloud/connector.py:_fetch_token_sync``). No
+service-account JSON key ever enters the flow, honouring the consumer
+org's ``constraints/iam.disableServiceAccountKeyCreation`` policy the same
+way the GCloud connector does: by never using key material at all.
+
+Per-operator GCP federation (STS token exchange, #2232) is **out of
+scope** here. MEHO's own audit attribution is unaffected — the audit row
+still carries the Keycloak ``sub`` (the policy/audit seam is untouched by
+this backend). What Phase 1 does not yet have is *GCP-layer* per-operator
+attribution: every GSM read is attributed to MEHO's SA, not the operator.
+
+Ref grammar and field selection
+===============================
+
+The scheme-stripped store ref (the part after ``gsm:``) is
+``<project-id>/<secret-name>[/versions/<version>][#<field>]``:
+
+* bare — ``proj/secret`` — reads the **latest** version and returns the
+  whole JSON payload as the secret-field dict.
+* pinned — ``proj/secret/versions/5`` — reads that exact version.
+* ``#field`` — ``proj/secret#password`` — reads the payload, JSON-decodes
+  it, and returns just the named field (``{field: value}``). A payload
+  that is not a JSON object, or a missing field, raises a clear error —
+  mirroring the shared loader's ``_extract_fields`` contract.
+
+Both forms require the decoded payload to be a JSON **object**: the
+backend contract returns a named-field ``dict`` the shared loader's
+extraction consumes, exactly as the Vault backend returns a KV-v2 data
+dict. This keeps a GSM secret interchangeable with a Vault secret for a
+connector session builder — it reads the same ``{username, password}``
+shape regardless of store.
+
+No secret in logs
+=================
+
+The structlog event carries only ``target`` / ``project`` / ``secret`` /
+``version`` / the requested ``field`` name — never a credential value,
+matching the no-secret discipline of ``vault_creds`` (``vault_creds.py``
+logs field *names* only).
+"""
+
+from __future__ import annotations
+
+import asyncio
+import json
+from typing import TYPE_CHECKING, Any, Protocol
+
+import structlog
+
+from meho_backplane.connectors._shared.credential_backend import register_credential_backend
+from meho_backplane.settings import get_settings
+
+if TYPE_CHECKING:
+    from collections.abc import Callable
+
+    from meho_backplane.auth.operator import Operator
+
+__all__ = [
+    "GcpSecretManagerBackend",
+    "GcpSecretManagerReadError",
+]
+
+_log = structlog.get_logger(__name__)
+
+#: Full-access GCP scope the impersonated / ADC credentials request — the
+#: same scope the GCloud connector uses. Secret Manager's ``versions.access``
+#: permission is covered by ``cloud-platform``.
+_GCP_CLOUD_PLATFORM_SCOPE = "https://www.googleapis.com/auth/cloud-platform"
+
+#: Seconds an impersonated token lives — GCP's maximum for impersonated
+#: credentials, matching ``gcloud/connector.py``.
+_IMPERSONATION_LIFETIME = 3600
+
+#: Default version alias when the ref pins no explicit version.
+_LATEST_VERSION = "latest"
+
+
+class GcpSecretManagerReadError(Exception):
+    """Read-phase failure resolving a ``gsm:`` credential ref.
+
+    The GSM analogue of
+    :class:`~meho_backplane.connectors._shared.vault_creds.VaultCredentialsReadError`:
+    a distinct, actionable error raised when the ref is malformed, the ADC
+    source is empty, the project/secret is unreachable, access is denied,
+    or the payload is not a JSON object / is missing the requested field.
+    Never a bare ``google.api_core`` exception surfacing from deep in the
+    client, and never echoing a credential value — the message names the
+    project / secret / field only.
+    """
+
+
+class _SecretAccessResult(Protocol):
+    """Structural shape of ``access_secret_version``'s response payload.
+
+    Lets the unit tests hand a plain stub client back through
+    ``client_factory`` without importing the generated proto types.
+    """
+
+    @property
+    def payload(self) -> Any: ...
+
+    @property
+    def name(self) -> str: ...
+
+
+def _parse_gsm_ref(store_ref: str, *, target_name: str) -> tuple[str, str, str, str | None]:
+    """Split a scheme-stripped GSM ref into ``(project, secret, version, field)``.
+
+    Grammar: ``<project>/<secret>[/versions/<version>][#<field>]``. The
+    optional ``#field`` fragment is split on the **last** ``#`` (mirroring
+    the vault-kv broker's ``_parse_vault_ref``); ``version`` defaults to
+    ``"latest"`` when the ref pins none. A malformed ref (wrong segment
+    count, empty project/secret/version, empty field after ``#``) raises
+    :class:`GcpSecretManagerReadError` naming the target — never a bare
+    ``ValueError`` / ``IndexError``.
+    """
+    body, sep, field_part = store_ref.rpartition("#")
+    if sep:
+        field: str | None = field_part.strip()
+        path = body.strip()
+        if not path or not field:
+            raise GcpSecretManagerReadError(
+                f"target {target_name!r} has a malformed gsm secret_ref {store_ref!r}: "
+                "the '#<field>' fragment selects one JSON key and needs a non-empty "
+                "path and field (e.g. 'my-project/db-creds#password')"
+            )
+    else:
+        field = None
+        path = store_ref.strip()
+
+    segments = path.split("/")
+    if len(segments) == 2:
+        project, secret = segments
+        version = _LATEST_VERSION
+    elif len(segments) == 4 and segments[2] == "versions":
+        project, secret, _, version = segments
+    else:
+        raise GcpSecretManagerReadError(
+            f"target {target_name!r} has a malformed gsm secret_ref {store_ref!r}: "
+            "expected '<project-id>/<secret-name>[/versions/<version>][#<field>]' "
+            "(e.g. 'my-project/db-creds' or 'my-project/db-creds/versions/3#password')"
+        )
+    if not project or not secret or not version:
+        raise GcpSecretManagerReadError(
+            f"target {target_name!r} has a gsm secret_ref {store_ref!r} with an empty "
+            "project, secret name, or version segment"
+        )
+    return project, secret, version, field
+
+
+def _decode_payload(
+    payload_bytes: bytes,
+    *,
+    field: str | None,
+    target_name: str,
+    project: str,
+    secret: str,
+) -> dict[str, object]:
+    """Decode a GSM payload to the named-field dict the seam contract returns.
+
+    Both the bare and ``#field`` forms require the payload to be a JSON
+    **object**: the shared loader extracts named fields from the returned
+    dict exactly as it does for a Vault KV-v2 data dict, so a scalar / list
+    / non-JSON payload cannot satisfy the contract and raises a clear
+    error. The bare form returns the whole object; the ``#field`` form
+    returns ``{field: value}`` after asserting the field is present. The
+    error message names project / secret / field only — never the value.
+    """
+    try:
+        decoded = json.loads(payload_bytes.decode("utf-8"))
+    except (UnicodeDecodeError, json.JSONDecodeError) as exc:
+        raise GcpSecretManagerReadError(
+            f"gsm secret {project}/{secret} for target {target_name!r} is not "
+            "valid UTF-8 JSON; a MEHO credential secret must store a JSON object "
+            'of named fields (e.g. \'{"username": ..., "password": ...}\')'
+        ) from exc
+
+    if not isinstance(decoded, dict):
+        raise GcpSecretManagerReadError(
+            f"gsm secret {project}/{secret} for target {target_name!r} decoded to "
+            f"{type(decoded).__name__}, not a JSON object; a MEHO credential secret "
+            "must store a JSON object of named fields"
+        )
+
+    if field is None:
+        return decoded
+
+    if field not in decoded:
+        raise GcpSecretManagerReadError(
+            f"gsm secret {project}/{secret} for target {target_name!r} has no field {field!r}"
+        )
+    return {field: decoded[field]}
+
+
+class GcpSecretManagerBackend:
+    """Resolve ``gsm:`` refs via GCP Secret Manager under SA-direct ADC.
+
+    Registered under kind ``"gsm"``. Stateless apart from the injected test
+    seams, so a single shared instance serves every read.
+
+    The two injection points keep the unit tests off live GCP:
+
+    * ``adc_loader`` replaces ``google.auth.default`` (returns
+      ``(credentials, project)``), so a test supplies a fake ADC source.
+    * ``client_factory`` replaces ``SecretManagerServiceClient`` (called
+      with ``credentials=``), so a test returns a stub whose
+      ``access_secret_version`` yields a canned payload without any RPC.
+
+    ``impersonate_sa`` overrides the settings-derived impersonation SA
+    (``None`` ⇒ read ``Settings.gsm_impersonate_sa`` at call time, matching
+    how ``vault_creds`` reads ``credential_backend`` per-call).
+    """
+
+    def __init__(
+        self,
+        *,
+        adc_loader: Callable[..., tuple[Any, Any]] | None = None,
+        client_factory: Callable[..., Any] | None = None,
+        impersonate_sa: str | None = None,
+    ) -> None:
+        self._adc_loader = adc_loader
+        self._client_factory = client_factory
+        self._impersonate_sa = impersonate_sa
+
+    async def load_secret_data(
+        self,
+        secret_ref: str,
+        operator: Operator,
+        *,
+        target_name: str,
+        mount: str = "",
+    ) -> dict[str, object]:
+        """Read *secret_ref* from GCP Secret Manager and return its field dict.
+
+        ``operator`` is accepted for the
+        :class:`~meho_backplane.connectors._shared.credential_backend.CredentialBackend`
+        contract but not forwarded to GCP — Phase 1 reads under MEHO's own
+        ADC identity, not the operator's (per-operator GCP federation is
+        #2232). ``mount`` is a Vault-KV concept with no GSM analogue and is
+        ignored. The synchronous ``access_secret_version`` RPC runs off the
+        event loop via ``asyncio.to_thread``, matching the hvac precedent in
+        ``vault_creds``.
+        """
+        project, secret, version, field = _parse_gsm_ref(secret_ref, target_name=target_name)
+
+        payload_bytes, resolved_name = await asyncio.to_thread(
+            self._access_sync, project, secret, version, target_name
+        )
+
+        secret_data = _decode_payload(
+            payload_bytes,
+            field=field,
+            target_name=target_name,
+            project=project,
+            secret=secret,
+        )
+
+        # Non-secret attribution only: target / project / secret / the
+        # resolved version name / the requested field name. Never a value.
+        _log.info(
+            "gsm_secret_accessed",
+            target=target_name,
+            project=project,
+            secret_name=secret,
+            version=resolved_name or version,
+            field=field,
+        )
+        return secret_data
+
+    # ------------------------------------------------------------------
+    # Synchronous GCP access (runs in a worker thread)
+    # ------------------------------------------------------------------
+
+    def _access_sync(
+        self, project: str, secret: str, version: str, target_name: str
+    ) -> tuple[bytes, str]:
+        """Build credentials, access the secret version, return ``(bytes, name)``.
+
+        Runs in a thread (``asyncio.to_thread``) because the google-cloud
+        client and ``google.auth`` credential refresh both perform blocking
+        transport under the hood. Access-denied, not-found, and transport
+        failures are re-raised as :class:`GcpSecretManagerReadError` with an
+        actionable message naming project / secret (AC #5) — not a bare
+        ``google.api_core`` exception.
+        """
+        import google.api_core.exceptions as gcp_exceptions
+        from google.cloud import secretmanager
+
+        credentials = self._build_credentials(target_name)
+        factory = self._client_factory or secretmanager.SecretManagerServiceClient
+        client = factory(credentials=credentials)
+
+        name = f"projects/{project}/secrets/{secret}/versions/{version}"
+        try:
+            response: _SecretAccessResult = client.access_secret_version(name=name)
+        except gcp_exceptions.PermissionDenied as exc:
+            raise GcpSecretManagerReadError(
+                f"access denied reading gsm secret {project}/{secret} for target "
+                f"{target_name!r}: MEHO's identity lacks 'secretmanager.versions.access' "
+                "on the secret (grant roles/secretmanager.secretAccessor)"
+            ) from exc
+        except gcp_exceptions.NotFound as exc:
+            raise GcpSecretManagerReadError(
+                f"gsm secret version {name} for target {target_name!r} was not found: "
+                "check the project id, secret name, and version"
+            ) from exc
+        except gcp_exceptions.GoogleAPICallError as exc:
+            raise GcpSecretManagerReadError(
+                f"gsm secret {project}/{secret} for target {target_name!r} could not be "
+                f"read: {exc.__class__.__name__} from Secret Manager"
+            ) from exc
+
+        payload = getattr(response, "payload", None)
+        data = getattr(payload, "data", None)
+        if not isinstance(data, (bytes, bytearray)):
+            raise GcpSecretManagerReadError(
+                f"gsm secret {project}/{secret} for target {target_name!r} returned no payload data"
+            )
+        return bytes(data), str(getattr(response, "name", "") or "")
+
+    def _build_credentials(self, target_name: str) -> Any:
+        """Return ADC source credentials, optionally impersonating an SA.
+
+        ``google.auth.default()`` yields the pod's ambient ADC (GKE Workload
+        Identity on the target platform). A configured impersonation SA
+        wraps that source in ``impersonated_credentials.Credentials`` — the
+        GCloud connector's chain. Fails closed with
+        :class:`GcpSecretManagerReadError` when ADC cannot be resolved or
+        yields no credentials (AC #4).
+        """
+        import google.auth
+        from google.auth import exceptions as auth_exceptions
+
+        adc_loader = self._adc_loader or google.auth.default
+        try:
+            source_credentials, _project = adc_loader(scopes=[_GCP_CLOUD_PLATFORM_SCOPE])
+        except auth_exceptions.DefaultCredentialsError as exc:
+            raise GcpSecretManagerReadError(
+                f"no Application Default Credentials available to read gsm secrets for "
+                f"target {target_name!r}: MEHO must run under a GKE Workload Identity "
+                "service account (or have GOOGLE_APPLICATION_CREDENTIALS set to a "
+                "non-key-file credential)"
+            ) from exc
+        if source_credentials is None:
+            raise GcpSecretManagerReadError(
+                f"Application Default Credentials resolved to no credentials for target "
+                f"{target_name!r}; cannot read gsm secrets"
+            )
+
+        impersonate_sa = self._resolve_impersonate_sa()
+        if not impersonate_sa:
+            return source_credentials
+
+        import google.auth.impersonated_credentials
+
+        return google.auth.impersonated_credentials.Credentials(  # type: ignore[no-untyped-call]
+            source_credentials=source_credentials,
+            target_principal=impersonate_sa,
+            target_scopes=[_GCP_CLOUD_PLATFORM_SCOPE],
+            lifetime=_IMPERSONATION_LIFETIME,
+        )
+
+    def _resolve_impersonate_sa(self) -> str:
+        """The impersonation SA — the constructor override or the setting.
+
+        ``None`` on the instance defers to ``Settings.gsm_impersonate_sa``
+        read per-call (so a redeploy's config change is picked up without
+        re-registering the backend). An empty string means direct ADC.
+        """
+        if self._impersonate_sa is not None:
+            return self._impersonate_sa
+        return get_settings().gsm_impersonate_sa.strip()
+
+
+#: The GSM backend is stateless (test seams aside), so a single shared
+#: instance serves every read. Registered at import time under ``"gsm"``;
+#: the ``_shared`` package ``__init__`` imports this module so the kind is
+#: present before any credential resolution runs.
+register_credential_backend("gsm", GcpSecretManagerBackend())

--- a/backend/src/meho_backplane/settings.py
+++ b/backend/src/meho_backplane/settings.py
@@ -909,6 +909,15 @@ class Settings(BaseModel):
     # Vault installs. Chart wiring (``config.credentialBackend`` →
     # ``CREDENTIAL_BACKEND``) lands with the GSM Helm surface in #2231.
     credential_backend: str = Field(default="vault", min_length=1)
+    # #2230 (Initiative #2227) — optional service account the GCP Secret
+    # Manager credential backend impersonates when resolving a
+    # ``gsm:<project>/<secret>`` ref. Empty (the default) reads Secret
+    # Manager directly under the pod's own GKE Workload Identity ADC
+    # (``google.auth.default()``); a non-empty SA email wraps that ADC
+    # source in ``google.auth.impersonated_credentials`` targeting the SA,
+    # reusing the GcloudConnector impersonation chain. No effect on Vault
+    # installs. Chart wiring lands with the GSM Helm surface in #2231.
+    gsm_impersonate_sa: str = Field(default="")
     database_url: str = Field(min_length=1)
     database_pool_size: int = Field(default=10, gt=0)
     database_pool_timeout: float = Field(default=30.0, gt=0)
@@ -1459,6 +1468,9 @@ def get_settings() -> Settings:
         # ``vault`` default so a blank chart value never yields an unknown
         # ("") backend kind (``min_length=1`` on the field would reject it).
         credential_backend=(os.environ.get("CREDENTIAL_BACKEND", "").strip() or "vault"),
+        # Optional impersonation SA for the GSM credential backend (#2230).
+        # Empty/whitespace-only ⇒ direct-ADC read (no impersonation).
+        gsm_impersonate_sa=os.environ.get("GSM_IMPERSONATE_SA", "").strip(),
         database_url=os.environ["DATABASE_URL"],
         database_pool_size=int(os.environ.get("DATABASE_POOL_SIZE", "10")),
         database_pool_timeout=float(

--- a/backend/tests/test_connectors_gsm_creds.py
+++ b/backend/tests/test_connectors_gsm_creds.py
@@ -1,0 +1,570 @@
+# SPDX-License-Identifier: Apache-2.0
+# Copyright (c) 2026 evoila Group
+
+"""Unit tests for the GCP Secret Manager credential backend (#2230).
+
+These pin the **secret-free** contract of
+:class:`meho_backplane.connectors._shared.gsm_creds.GcpSecretManagerBackend`
+without any live GCP: ``google.auth.default`` is replaced through the
+backend's ``adc_loader`` seam and ``SecretManagerServiceClient`` through
+its ``client_factory`` seam, so a test supplies a canned payload and
+asserts the parse / decode / impersonation / error / no-secret-in-logs
+behaviour in-process.
+
+What these cover:
+
+* ref grammar — bare (latest), pinned ``/versions/<n>``, ``#field``
+  fragment, and malformed refs raising a clear error (not ``IndexError``);
+* a bare ref returns the whole JSON object; a ``#field`` ref returns just
+  that key; a missing field / non-JSON / non-object payload raises
+  :class:`GcpSecretManagerReadError`;
+* the read runs under ADC and wraps it in impersonated credentials only
+  when a SA is configured (constructor override or ``Settings``);
+* access-denied / not-found / transport failures surface as a distinct,
+  actionable error, never a bare ``google.api_core`` exception;
+* an empty / unresolvable ADC source fails closed;
+* no credential value reaches a structlog event;
+* the shared loader dispatches a ``gsm:`` ref to this backend end-to-end.
+"""
+
+from __future__ import annotations
+
+from collections.abc import Iterator
+from dataclasses import dataclass
+from typing import Any
+from uuid import UUID
+
+import pytest
+from structlog.testing import capture_logs
+
+from meho_backplane.auth.operator import Operator, TenantRole
+from meho_backplane.connectors._shared import credential_backend as cb
+from meho_backplane.connectors._shared.gsm_creds import (
+    GcpSecretManagerBackend,
+    GcpSecretManagerReadError,
+)
+from meho_backplane.connectors._shared.vault_creds import (
+    load_basic_credentials,
+    load_vault_secret_data,
+)
+from meho_backplane.settings import get_settings
+
+# Canary values that must never appear in a log event.
+_CANARY_PASSWORD = "p4ssw0rd-canary-must-not-leak"
+_CANARY_USERNAME = "svc-canary"
+
+
+@pytest.fixture(autouse=True)
+def _settings_env(monkeypatch: pytest.MonkeyPatch) -> Iterator[None]:
+    """Pin the chassis env vars ``get_settings`` reads and clear its cache.
+
+    The end-to-end dispatch tests reach ``get_settings()`` (for the default
+    backend + the impersonation SA), so pin the same minimal Keycloak env
+    the sibling vault-creds suite pins. ``DATABASE_URL`` is provided by the
+    autouse conftest fixture.
+    """
+    monkeypatch.setenv("KEYCLOAK_ISSUER_URL", "https://keycloak.test/realms/meho")
+    monkeypatch.setenv("KEYCLOAK_AUDIENCE", "meho-backplane")
+    monkeypatch.setenv("VAULT_ADDR", "https://vault.test")
+    monkeypatch.setenv("VAULT_OIDC_ROLE", "meho-mcp")
+    monkeypatch.setenv("VAULT_OIDC_MOUNT_PATH", "jwt")
+    monkeypatch.setenv("VAULT_TIMEOUT_SECONDS", "5.0")
+    monkeypatch.delenv("VAULT_NAMESPACE", raising=False)
+    monkeypatch.delenv("GSM_IMPERSONATE_SA", raising=False)
+    get_settings.cache_clear()
+    yield
+    get_settings.cache_clear()
+
+
+# ---------------------------------------------------------------------------
+# Test doubles for the ADC + client seams
+# ---------------------------------------------------------------------------
+
+
+class _FakePayload:
+    def __init__(self, data: bytes) -> None:
+        self.data = data
+
+
+class _FakeResponse:
+    def __init__(self, data: bytes, name: str) -> None:
+        self.payload = _FakePayload(data)
+        self.name = name
+
+
+class _FakeClient:
+    """Stub ``SecretManagerServiceClient`` — records the accessed name."""
+
+    def __init__(
+        self,
+        *,
+        payload: bytes,
+        resolved_name: str = "",
+        raises: Exception | None = None,
+    ) -> None:
+        self._payload = payload
+        self._resolved_name = resolved_name
+        self._raises = raises
+        self.credentials: Any = None
+        self.accessed_name: str | None = None
+
+    def access_secret_version(self, *, name: str) -> _FakeResponse:
+        self.accessed_name = name
+        if self._raises is not None:
+            raise self._raises
+        return _FakeResponse(self._payload, self._resolved_name)
+
+
+def _factory_for(client: _FakeClient):
+    """A ``client_factory`` that records the credentials and returns *client*."""
+
+    def factory(*, credentials: Any) -> _FakeClient:
+        client.credentials = credentials
+        return client
+
+    return factory
+
+
+class _SourceCreds:
+    """Opaque sentinel standing in for an ADC source-credentials object."""
+
+
+def _adc_loader_returning(creds: Any):
+    """An ``adc_loader`` double recording its ``scopes`` kwarg."""
+    calls: list[dict[str, Any]] = []
+
+    def loader(**kwargs: Any) -> tuple[Any, str]:
+        calls.append(kwargs)
+        return creds, "adc-project"
+
+    loader.calls = calls  # type: ignore[attr-defined]
+    return loader
+
+
+def _json_secret(**fields: str) -> bytes:
+    import json
+
+    return json.dumps(fields).encode("utf-8")
+
+
+@dataclass
+class _Target:
+    """Minimal target satisfying ``BasicCredentialsTargetLike``."""
+
+    name: str = "gcp-lab-01"
+    host: str = "gcp-lab-01.example.test"
+    secret_ref: str | None = "gsm:my-project/db-creds"
+
+
+def _make_operator(jwt: str = "op.jwt.value") -> Operator:
+    return Operator(
+        sub="test-operator",
+        name=None,
+        email=None,
+        raw_jwt=jwt,
+        tenant_id=UUID(int=0),
+        tenant_role=TenantRole.OPERATOR,
+    )
+
+
+# ---------------------------------------------------------------------------
+# Ref grammar
+# ---------------------------------------------------------------------------
+
+
+async def test_bare_ref_returns_whole_json_payload() -> None:
+    client = _FakeClient(payload=_json_secret(username=_CANARY_USERNAME, password=_CANARY_PASSWORD))
+    backend = GcpSecretManagerBackend(
+        adc_loader=_adc_loader_returning(_SourceCreds()),
+        client_factory=_factory_for(client),
+        impersonate_sa="",
+    )
+
+    data = await backend.load_secret_data(
+        "my-project/db-creds", _make_operator(), target_name="gcp-lab-01"
+    )
+
+    assert data == {"username": _CANARY_USERNAME, "password": _CANARY_PASSWORD}
+    assert client.accessed_name == "projects/my-project/secrets/db-creds/versions/latest"
+
+
+async def test_field_fragment_selects_single_key() -> None:
+    client = _FakeClient(payload=_json_secret(username=_CANARY_USERNAME, password=_CANARY_PASSWORD))
+    backend = GcpSecretManagerBackend(
+        adc_loader=_adc_loader_returning(_SourceCreds()),
+        client_factory=_factory_for(client),
+        impersonate_sa="",
+    )
+
+    data = await backend.load_secret_data(
+        "my-project/db-creds#password", _make_operator(), target_name="gcp-lab-01"
+    )
+
+    assert data == {"password": _CANARY_PASSWORD}
+
+
+async def test_pinned_version_is_addressed() -> None:
+    client = _FakeClient(payload=_json_secret(token="abc"))
+    backend = GcpSecretManagerBackend(
+        adc_loader=_adc_loader_returning(_SourceCreds()),
+        client_factory=_factory_for(client),
+        impersonate_sa="",
+    )
+
+    await backend.load_secret_data(
+        "my-project/db-creds/versions/5#token", _make_operator(), target_name="gcp-lab-01"
+    )
+
+    assert client.accessed_name == "projects/my-project/secrets/db-creds/versions/5"
+
+
+@pytest.mark.parametrize(
+    "ref",
+    [
+        "just-one-segment",
+        "proj/secret/extra",
+        "proj/secret/notversions/5",
+        "my-project/db-creds#",
+        "#password",
+        "/db-creds",
+    ],
+)
+async def test_malformed_ref_raises_clear_error(ref: str) -> None:
+    backend = GcpSecretManagerBackend(
+        adc_loader=_adc_loader_returning(_SourceCreds()),
+        client_factory=_factory_for(_FakeClient(payload=b"{}")),
+        impersonate_sa="",
+    )
+
+    with pytest.raises(GcpSecretManagerReadError) as exc:
+        await backend.load_secret_data(ref, _make_operator(), target_name="gcp-lab-01")
+
+    assert "gcp-lab-01" in str(exc.value)
+
+
+# ---------------------------------------------------------------------------
+# Payload decoding errors
+# ---------------------------------------------------------------------------
+
+
+async def test_missing_field_raises_clear_error() -> None:
+    client = _FakeClient(payload=_json_secret(username=_CANARY_USERNAME))
+    backend = GcpSecretManagerBackend(
+        adc_loader=_adc_loader_returning(_SourceCreds()),
+        client_factory=_factory_for(client),
+        impersonate_sa="",
+    )
+
+    with pytest.raises(GcpSecretManagerReadError) as exc:
+        await backend.load_secret_data(
+            "my-project/db-creds#password", _make_operator(), target_name="gcp-lab-01"
+        )
+
+    msg = str(exc.value)
+    assert "password" in msg
+    assert "my-project/db-creds" in msg
+    assert _CANARY_USERNAME not in msg
+
+
+async def test_non_json_payload_raises_clear_error() -> None:
+    client = _FakeClient(payload=b"not-json-at-all")
+    backend = GcpSecretManagerBackend(
+        adc_loader=_adc_loader_returning(_SourceCreds()),
+        client_factory=_factory_for(client),
+        impersonate_sa="",
+    )
+
+    with pytest.raises(GcpSecretManagerReadError) as exc:
+        await backend.load_secret_data(
+            "my-project/db-creds", _make_operator(), target_name="gcp-lab-01"
+        )
+
+    assert "JSON" in str(exc.value)
+
+
+async def test_non_object_json_payload_raises_clear_error() -> None:
+    client = _FakeClient(payload=b'["a", "list"]')
+    backend = GcpSecretManagerBackend(
+        adc_loader=_adc_loader_returning(_SourceCreds()),
+        client_factory=_factory_for(client),
+        impersonate_sa="",
+    )
+
+    with pytest.raises(GcpSecretManagerReadError) as exc:
+        await backend.load_secret_data(
+            "my-project/db-creds", _make_operator(), target_name="gcp-lab-01"
+        )
+
+    assert "JSON object" in str(exc.value)
+
+
+# ---------------------------------------------------------------------------
+# ADC + impersonation
+# ---------------------------------------------------------------------------
+
+
+async def test_reads_under_adc_without_impersonation() -> None:
+    source = _SourceCreds()
+    loader = _adc_loader_returning(source)
+    client = _FakeClient(payload=_json_secret(k="v"))
+    backend = GcpSecretManagerBackend(
+        adc_loader=loader,
+        client_factory=_factory_for(client),
+        impersonate_sa="",
+    )
+
+    await backend.load_secret_data(
+        "my-project/db-creds", _make_operator(), target_name="gcp-lab-01"
+    )
+
+    # No impersonation SA → the client runs under the raw ADC source, with
+    # the cloud-platform scope requested.
+    assert client.credentials is source
+    assert loader.calls[-1]["scopes"] == [  # type: ignore[attr-defined]
+        "https://www.googleapis.com/auth/cloud-platform"
+    ]
+
+
+async def test_impersonates_when_sa_configured(monkeypatch: pytest.MonkeyPatch) -> None:
+    import google.auth.impersonated_credentials
+
+    captured: dict[str, Any] = {}
+    impersonated_sentinel = object()
+
+    def _fake_impersonated(**kwargs: Any) -> Any:
+        captured.update(kwargs)
+        return impersonated_sentinel
+
+    monkeypatch.setattr(google.auth.impersonated_credentials, "Credentials", _fake_impersonated)
+
+    source = _SourceCreds()
+    client = _FakeClient(payload=_json_secret(k="v"))
+    backend = GcpSecretManagerBackend(
+        adc_loader=_adc_loader_returning(source),
+        client_factory=_factory_for(client),
+        impersonate_sa="reader@my-project.iam.gserviceaccount.com",
+    )
+
+    await backend.load_secret_data(
+        "my-project/db-creds", _make_operator(), target_name="gcp-lab-01"
+    )
+
+    assert captured["source_credentials"] is source
+    assert captured["target_principal"] == "reader@my-project.iam.gserviceaccount.com"
+    assert captured["target_scopes"] == ["https://www.googleapis.com/auth/cloud-platform"]
+    # The impersonated credentials, not the raw source, reach the client.
+    assert client.credentials is impersonated_sentinel
+
+
+async def test_impersonate_sa_read_from_settings_when_not_injected(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    import google.auth.impersonated_credentials
+
+    captured: dict[str, Any] = {}
+    monkeypatch.setattr(
+        google.auth.impersonated_credentials,
+        "Credentials",
+        lambda **kw: captured.update(kw) or object(),
+    )
+    monkeypatch.setenv("GSM_IMPERSONATE_SA", "from-settings@proj.iam.gserviceaccount.com")
+    get_settings.cache_clear()
+
+    backend = GcpSecretManagerBackend(
+        adc_loader=_adc_loader_returning(_SourceCreds()),
+        client_factory=_factory_for(_FakeClient(payload=_json_secret(k="v"))),
+        # impersonate_sa left as None → resolved from Settings per-call.
+    )
+
+    await backend.load_secret_data(
+        "my-project/db-creds", _make_operator(), target_name="gcp-lab-01"
+    )
+
+    assert captured["target_principal"] == "from-settings@proj.iam.gserviceaccount.com"
+
+
+# ---------------------------------------------------------------------------
+# Access / transport errors, fail-closed ADC
+# ---------------------------------------------------------------------------
+
+
+async def test_access_denied_surfaces_actionable_error() -> None:
+    import google.api_core.exceptions as gcp_exceptions
+
+    client = _FakeClient(
+        payload=b"{}", raises=gcp_exceptions.PermissionDenied("caller lacks access")
+    )
+    backend = GcpSecretManagerBackend(
+        adc_loader=_adc_loader_returning(_SourceCreds()),
+        client_factory=_factory_for(client),
+        impersonate_sa="",
+    )
+
+    with pytest.raises(GcpSecretManagerReadError) as exc:
+        await backend.load_secret_data(
+            "my-project/db-creds", _make_operator(), target_name="gcp-lab-01"
+        )
+
+    assert "access denied" in str(exc.value).lower()
+    assert "secretAccessor" in str(exc.value)
+
+
+async def test_not_found_surfaces_actionable_error() -> None:
+    import google.api_core.exceptions as gcp_exceptions
+
+    client = _FakeClient(payload=b"{}", raises=gcp_exceptions.NotFound("nope"))
+    backend = GcpSecretManagerBackend(
+        adc_loader=_adc_loader_returning(_SourceCreds()),
+        client_factory=_factory_for(client),
+        impersonate_sa="",
+    )
+
+    with pytest.raises(GcpSecretManagerReadError) as exc:
+        await backend.load_secret_data(
+            "my-project/db-creds", _make_operator(), target_name="gcp-lab-01"
+        )
+
+    assert "not found" in str(exc.value).lower()
+
+
+async def test_transport_error_surfaces_actionable_error() -> None:
+    import google.api_core.exceptions as gcp_exceptions
+
+    client = _FakeClient(payload=b"{}", raises=gcp_exceptions.ServiceUnavailable("backend down"))
+    backend = GcpSecretManagerBackend(
+        adc_loader=_adc_loader_returning(_SourceCreds()),
+        client_factory=_factory_for(client),
+        impersonate_sa="",
+    )
+
+    with pytest.raises(GcpSecretManagerReadError) as exc:
+        await backend.load_secret_data(
+            "my-project/db-creds", _make_operator(), target_name="gcp-lab-01"
+        )
+
+    assert "could not be" in str(exc.value).lower()
+
+
+async def test_empty_adc_fails_closed() -> None:
+    from google.auth import exceptions as auth_exceptions
+
+    def _raising_loader(**kwargs: Any) -> tuple[Any, str]:
+        raise auth_exceptions.DefaultCredentialsError("no ADC")
+
+    backend = GcpSecretManagerBackend(
+        adc_loader=_raising_loader,
+        client_factory=_factory_for(_FakeClient(payload=b"{}")),
+        impersonate_sa="",
+    )
+
+    with pytest.raises(GcpSecretManagerReadError) as exc:
+        await backend.load_secret_data(
+            "my-project/db-creds", _make_operator(), target_name="gcp-lab-01"
+        )
+
+    assert "Application Default Credentials" in str(exc.value)
+
+
+async def test_none_adc_credentials_fails_closed() -> None:
+    def _none_loader(**kwargs: Any) -> tuple[Any, str]:
+        return None, "proj"
+
+    backend = GcpSecretManagerBackend(
+        adc_loader=_none_loader,
+        client_factory=_factory_for(_FakeClient(payload=b"{}")),
+        impersonate_sa="",
+    )
+
+    with pytest.raises(GcpSecretManagerReadError):
+        await backend.load_secret_data(
+            "my-project/db-creds", _make_operator(), target_name="gcp-lab-01"
+        )
+
+
+# ---------------------------------------------------------------------------
+# No secret in logs
+# ---------------------------------------------------------------------------
+
+
+async def test_no_secret_value_in_log_events() -> None:
+    client = _FakeClient(
+        payload=_json_secret(username=_CANARY_USERNAME, password=_CANARY_PASSWORD),
+        resolved_name="projects/my-project/secrets/db-creds/versions/7",
+    )
+    backend = GcpSecretManagerBackend(
+        adc_loader=_adc_loader_returning(_SourceCreds()),
+        client_factory=_factory_for(client),
+        impersonate_sa="",
+    )
+
+    with capture_logs() as captured:
+        await backend.load_secret_data(
+            "my-project/db-creds", _make_operator(), target_name="gcp-lab-01"
+        )
+
+    blob = repr(captured)
+    assert _CANARY_PASSWORD not in blob
+    assert _CANARY_USERNAME not in blob
+    # The attribution fields are present (non-secret only).
+    event = next(e for e in captured if e["event"] == "gsm_secret_accessed")
+    assert event["project"] == "my-project"
+    assert event["secret_name"] == "db-creds"
+    assert event["target"] == "gcp-lab-01"
+
+
+# ---------------------------------------------------------------------------
+# End-to-end dispatch through the shared loader / registry
+# ---------------------------------------------------------------------------
+
+
+@pytest.fixture
+def _gsm_backend_with_fakes(
+    monkeypatch: pytest.MonkeyPatch,
+) -> Iterator[_FakeClient]:
+    """Swap the registered ``gsm`` backend for one wired to test doubles.
+
+    The real singleton is registered at import; swapping the registry entry
+    is the clean way to drive the shared-loader dispatch path against a
+    canned payload. Restored on teardown so sibling tests see the real one.
+    """
+    client = _FakeClient(payload=_json_secret(username=_CANARY_USERNAME, password=_CANARY_PASSWORD))
+    fake_backend = GcpSecretManagerBackend(
+        adc_loader=_adc_loader_returning(_SourceCreds()),
+        client_factory=_factory_for(client),
+        impersonate_sa="",
+    )
+    original = cb.CREDENTIAL_BACKEND_REGISTRY["gsm"]
+    cb.CREDENTIAL_BACKEND_REGISTRY["gsm"] = fake_backend
+    try:
+        yield client
+    finally:
+        cb.CREDENTIAL_BACKEND_REGISTRY["gsm"] = original
+
+
+async def test_gsm_backend_registered_under_gsm_kind() -> None:
+    backend = cb.resolve_credential_backend("gsm")
+    assert isinstance(backend, GcpSecretManagerBackend)
+
+
+async def test_dispatch_gsm_ref_end_to_end_via_load_vault_secret_data(
+    _gsm_backend_with_fakes: _FakeClient,
+) -> None:
+    target = _Target(secret_ref="gsm:my-project/db-creds")
+
+    data = await load_vault_secret_data(target, _make_operator())
+
+    assert data == {"username": _CANARY_USERNAME, "password": _CANARY_PASSWORD}
+    assert (
+        _gsm_backend_with_fakes.accessed_name
+        == "projects/my-project/secrets/db-creds/versions/latest"
+    )
+
+
+async def test_dispatch_gsm_ref_end_to_end_via_load_basic_credentials(
+    _gsm_backend_with_fakes: _FakeClient,
+) -> None:
+    target = _Target(secret_ref="gsm:my-project/db-creds")
+
+    creds = await load_basic_credentials(target, _make_operator())
+
+    assert creds == {"username": _CANARY_USERNAME, "password": _CANARY_PASSWORD}

--- a/backend/tests/test_connectors_vault_creds.py
+++ b/backend/tests/test_connectors_vault_creds.py
@@ -485,16 +485,20 @@ async def test_explicit_vault_scheme_resolves_identically_to_schemeless(
 async def test_unknown_scheme_raises_no_backend_error_without_touching_vault(
     monkeypatch: pytest.MonkeyPatch,
 ) -> None:
-    """A ``gsm:`` ref (backend lands in #2230) fails loudly, never a silent Vault read."""
+    """An unregistered scheme fails loudly, never a silent Vault read.
+
+    ``gsm`` is now a registered backend (#2230), so this uses a genuinely
+    unknown kind to pin the fail-closed dispatch contract.
+    """
     fake = install_fake_client(monkeypatch, secret={"username": "u", "password": "p"})
 
     with pytest.raises(UnknownCredentialBackendError) as exc:
         await load_basic_credentials(
-            _Target(secret_ref="gsm:my-project/vc-lab-01"), _make_operator()
+            _Target(secret_ref="azurekv:my-vault/vc-lab-01"), _make_operator()
         )
 
     msg = str(exc.value)
-    assert "no credential backend registered for kind 'gsm'" in msg
+    assert "no credential backend registered for kind 'azurekv'" in msg
     # Vault was never reached — dispatch failed before any login / read.
     assert fake.auth.jwt.login_calls == []
     assert fake.secrets.kv.v2.read_calls == []

--- a/backend/tests/test_settings.py
+++ b/backend/tests/test_settings.py
@@ -431,3 +431,34 @@ def test_credential_backend_blank_env_falls_back_to_vault(
         assert get_settings().credential_backend == "vault"
     finally:
         get_settings.cache_clear()
+
+
+# ---------------------------------------------------------------------------
+# #2230 (Initiative #2227) — GSM_IMPERSONATE_SA env knob
+# ---------------------------------------------------------------------------
+
+
+def test_gsm_impersonate_sa_defaults_to_empty_when_unset(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """Unset ``GSM_IMPERSONATE_SA`` → empty (direct-ADC read, no impersonation)."""
+    _base_env(monkeypatch)
+    monkeypatch.delenv("GSM_IMPERSONATE_SA", raising=False)
+    get_settings.cache_clear()
+    try:
+        assert get_settings().gsm_impersonate_sa == ""
+    finally:
+        get_settings.cache_clear()
+
+
+def test_gsm_impersonate_sa_reads_and_strips_env(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """A set ``GSM_IMPERSONATE_SA`` names the SA to impersonate; whitespace is stripped."""
+    _base_env(monkeypatch)
+    monkeypatch.setenv("GSM_IMPERSONATE_SA", "  reader@proj.iam.gserviceaccount.com \n")
+    get_settings.cache_clear()
+    try:
+        assert get_settings().gsm_impersonate_sa == "reader@proj.iam.gserviceaccount.com"
+    finally:
+        get_settings.cache_clear()

--- a/backend/uv.lock
+++ b/backend/uv.lock
@@ -1024,6 +1024,28 @@ wheels = [
 ]
 
 [[package]]
+name = "google-api-core"
+version = "2.31.0"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "google-auth" },
+    { name = "googleapis-common-protos" },
+    { name = "proto-plus" },
+    { name = "protobuf" },
+    { name = "requests" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/c6/22/155cadf1d49272a9cf48f3168c0f3874fa13397297e611a5ea00cd093880/google_api_core-2.31.0.tar.gz", hash = "sha256:2be84ee0f584c48e6bde1b36766e23348b361fb7e55e56135fc76ce1c397f9c2", size = 176492, upload-time = "2026-06-03T14:52:17.257Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/86/40/9bdbb60b03a332bd45acb8703da08bbc27d991d35286b62e42acc86d243a/google_api_core-2.31.0-py3-none-any.whl", hash = "sha256:ef79fb3784c71cbac89cbd03301ba0c8fb8ad2aa95d7f9204dd9628f7adf59ab", size = 173102, upload-time = "2026-06-03T14:51:26.729Z" },
+]
+
+[package.optional-dependencies]
+grpc = [
+    { name = "grpcio" },
+    { name = "grpcio-status" },
+]
+
+[[package]]
 name = "google-auth"
 version = "2.55.1"
 source = { registry = "https://pypi.org/simple" }
@@ -1034,6 +1056,40 @@ dependencies = [
 sdist = { url = "https://files.pythonhosted.org/packages/a3/6f/f3f4ac177c67bbee8fe8e88f2ab4f36af88c44a096e165c5217accf6e5d3/google_auth-2.55.1.tar.gz", hash = "sha256:fb2d9b730f2c9b8d326ec8d7222f21aef2ead15bf0513793d6442485d87af0a1", size = 349527, upload-time = "2026-06-25T23:39:27.182Z" }
 wheels = [
     { url = "https://files.pythonhosted.org/packages/e8/1d/f6d3ca1ad0725f2e08a1c6915640748a52de2e66596160a4d53b010cccf0/google_auth-2.55.1-py3-none-any.whl", hash = "sha256:eada68dfd52b3b81191827601e2a0c3fa12540c818534b630ddc5355769c3995", size = 252349, upload-time = "2026-06-25T23:38:52.946Z" },
+]
+
+[[package]]
+name = "google-cloud-secret-manager"
+version = "2.29.0"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "google-api-core", extra = ["grpc"] },
+    { name = "google-auth" },
+    { name = "grpc-google-iam-v1" },
+    { name = "grpcio" },
+    { name = "proto-plus" },
+    { name = "protobuf" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/d2/7c/5c88cdde9664f6c75fb68aa11e0af4309a92bef38dd38df0456ffb0f469b/google_cloud_secret_manager-2.29.0.tar.gz", hash = "sha256:ee64133af8fdb3780affb65ec6ccf10ab15a0113d8edeba388665f4be87ce1be", size = 278437, upload-time = "2026-06-03T16:13:43.149Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/b6/c2/fc3275bc42a522757cb5141d7dae51f048b93d2f5fe4574fcee5392cef03/google_cloud_secret_manager-2.29.0-py3-none-any.whl", hash = "sha256:21bac2d0adb0bb3c13c346d7223832f197c2266534528a1bf1402774e06395a3", size = 225042, upload-time = "2026-06-03T16:12:20.162Z" },
+]
+
+[[package]]
+name = "googleapis-common-protos"
+version = "1.75.0"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "protobuf" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/b5/c8/f439cffde755cffa462bfbb156278fa6f9d09119719af9814b858fd4f81f/googleapis_common_protos-1.75.0.tar.gz", hash = "sha256:53a062ff3c32552fbd62c11fe23768b78e4ddf0494d5e5fd97d3f4689c75fbbd", size = 151035, upload-time = "2026-05-07T08:04:49.423Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/e7/c8/e2645aa8ed02fd4c7a2f59d68783b65b1f3cbdfe39a6308e156509d1fee8/googleapis_common_protos-1.75.0-py3-none-any.whl", hash = "sha256:961ed60399c457ceb0ee8f285a84c870aabc9c6a832b9d37bb281b5bebde43ed", size = 300631, upload-time = "2026-05-07T08:03:30.345Z" },
+]
+
+[package.optional-dependencies]
+grpc = [
+    { name = "grpcio" },
 ]
 
 [[package]]
@@ -1090,6 +1146,75 @@ source = { registry = "https://pypi.org/simple" }
 sdist = { url = "https://files.pythonhosted.org/packages/9d/82/74f4a3310cdabfbb10da554c3a672847f1ed33c6f61dd472681ce7f1fe67/griffelib-2.0.2.tar.gz", hash = "sha256:3cf20b3bc470e83763ffbf236e0076b1211bac1bc67de13daf494640f2de707e", size = 166461, upload-time = "2026-03-27T11:34:51.091Z" }
 wheels = [
     { url = "https://files.pythonhosted.org/packages/11/8c/c9138d881c79aa0ea9ed83cbd58d5ca75624378b38cee225dcf5c42cc91f/griffelib-2.0.2-py3-none-any.whl", hash = "sha256:925c857658fb1ba40c0772c37acbc2ab650bd794d9c1b9726922e36ea4117ea1", size = 142357, upload-time = "2026-03-27T11:34:46.275Z" },
+]
+
+[[package]]
+name = "grpc-google-iam-v1"
+version = "0.14.4"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "googleapis-common-protos", extra = ["grpc"] },
+    { name = "grpcio" },
+    { name = "protobuf" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/44/4f/d098419ad0bfc06c9ce440575f05aa22d8973b6c276e86ac7890093d3c37/grpc_google_iam_v1-0.14.4.tar.gz", hash = "sha256:392b3796947ed6334e61171d9ab06bf7eb357f554e5fc7556ad7aab6d0e17038", size = 23706, upload-time = "2026-04-01T01:57:49.813Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/89/22/c2dd50c09bf679bd38173656cd4402d2511e563b33bc88f90009cf50613c/grpc_google_iam_v1-0.14.4-py3-none-any.whl", hash = "sha256:412facc320fcbd94034b4df3d557662051d4d8adfa86e0ddb4dca70a3f739964", size = 32675, upload-time = "2026-04-01T01:57:47.69Z" },
+]
+
+[[package]]
+name = "grpcio"
+version = "1.82.1"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "typing-extensions" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/90/bc/656b89387d6f4ed7e0686c7b64c2ae7e554a759aa58122c8e5fb99392c32/grpcio-1.82.1.tar.gz", hash = "sha256:707b24abd90fcb1e45bcc080577da1dbf9971d107490589b9539af8e1e77b4b5", size = 13187300, upload-time = "2026-07-08T12:36:16.588Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/dc/88/d1350bf3343a2ed87d801584e40609f6c6bd3087926eeca03de50348cf4a/grpcio-1.82.1-cp312-cp312-linux_armv7l.whl", hash = "sha256:c09bd5fa0d5b1fbd773ec349fe61441c3e4ebf168c229aa7538a820bdfad6a58", size = 6144689, upload-time = "2026-07-08T12:34:55.567Z" },
+    { url = "https://files.pythonhosted.org/packages/e6/33/71875cdecd27c24ac1385d4783a09853f01b84a825a36aec2a2bc7d0d080/grpcio-1.82.1-cp312-cp312-macosx_11_0_universal2.whl", hash = "sha256:1eae24810720734598e3e6a1a528d5de0f265fe3fc86575e9ecce424b9ec7379", size = 11952034, upload-time = "2026-07-08T12:34:58.128Z" },
+    { url = "https://files.pythonhosted.org/packages/82/b2/d9125df3d8a140dec12cc82c05b7deafedeababcff6496f28b2fd5634d10/grpcio-1.82.1-cp312-cp312-manylinux2014_aarch64.manylinux_2_17_aarch64.whl", hash = "sha256:a6bd5daf5bde7b24d7ad2cbaf8bf9eac620d96222016bb5e7ddde930dec0673f", size = 6710772, upload-time = "2026-07-08T12:35:01.33Z" },
+    { url = "https://files.pythonhosted.org/packages/88/9b/69e2d1627398b964f34437dc476a5aff5a2cc8e7f247d26272b5674b5faf/grpcio-1.82.1-cp312-cp312-manylinux2014_i686.manylinux_2_17_i686.whl", hash = "sha256:1ecfde669cb687ac020d31ff76debe5dc7a62213335f02262eb6625628da1c03", size = 7450677, upload-time = "2026-07-08T12:35:03.926Z" },
+    { url = "https://files.pythonhosted.org/packages/e4/e7/8f855ca29c294956122a2a73023655b9b02602d5111dad2b9b00e7631c68/grpcio-1.82.1-cp312-cp312-manylinux2014_x86_64.manylinux_2_17_x86_64.whl", hash = "sha256:011c8badee95734dee8bf05ce3464756a0ac3ebb8d443afd20c0e2b5e4640ad9", size = 6886855, upload-time = "2026-07-08T12:35:06.174Z" },
+    { url = "https://files.pythonhosted.org/packages/5f/f0/fa87e85f49925f44c479d07e58b051e69bcfef6b6d5fbc6749d140f6730a/grpcio-1.82.1-cp312-cp312-musllinux_1_2_aarch64.whl", hash = "sha256:b85f4564926fb23114d239392bdcae200db1e6179629edd7d7ab0ab89c96a197", size = 7501323, upload-time = "2026-07-08T12:35:08.49Z" },
+    { url = "https://files.pythonhosted.org/packages/67/55/2e0b10ae1d3ef9dcc480b91dc2158f4931fc4675d3af0a2836e39b2a744f/grpcio-1.82.1-cp312-cp312-musllinux_1_2_i686.whl", hash = "sha256:2c0c8270833395644c3fe6b6a806397955a2bc0538000a19a78b90c05a6c16e0", size = 8536899, upload-time = "2026-07-08T12:35:10.975Z" },
+    { url = "https://files.pythonhosted.org/packages/bd/95/a3d8b0431fa221efc51ee39d73595ede74ba82a43b7c4313192e580face2/grpcio-1.82.1-cp312-cp312-musllinux_1_2_x86_64.whl", hash = "sha256:2ba199205ff46c7778290fe1673c91ac8e7e45678dd5c86e9e56fa33ec8788f6", size = 7913892, upload-time = "2026-07-08T12:35:13.944Z" },
+    { url = "https://files.pythonhosted.org/packages/b8/92/f2651ec704d9852a56faef394775038afba435b50ce82ab2404d119c3355/grpcio-1.82.1-cp312-cp312-win32.whl", hash = "sha256:06127691866e295c14e84a1fb86356dd962254f6abd0da4ca4b001eea9e89438", size = 4240985, upload-time = "2026-07-08T12:35:16.048Z" },
+    { url = "https://files.pythonhosted.org/packages/96/4f/a5fe8bf0d0a1b24855f370293075c931f27de4eb55f0f158786095bf3c11/grpcio-1.82.1-cp312-cp312-win_amd64.whl", hash = "sha256:1fa3223a3a2e1db74f4c2b255189eb7ea875dfba56e221d252ee3fc7b204778e", size = 5001580, upload-time = "2026-07-08T12:35:18.689Z" },
+    { url = "https://files.pythonhosted.org/packages/1b/3e/496992d08c0aaa11272eb6228dc8ab947da01fe835de243cd00521bce4c4/grpcio-1.82.1-cp313-cp313-linux_armv7l.whl", hash = "sha256:b454a2d97bfab7565683a02345f86bd182ab69fd7c2bdb7414171e7538f266b1", size = 6146068, upload-time = "2026-07-08T12:35:21.365Z" },
+    { url = "https://files.pythonhosted.org/packages/e7/8f/f263d6f14fdba6b56cfadd91fd3e158a52682b72c6016d1f8723d435659f/grpcio-1.82.1-cp313-cp313-macosx_11_0_universal2.whl", hash = "sha256:3dde70abfc80b3be11de53ba0d601c439e7fb2afd3583ad1788d1146bec92fdc", size = 11948600, upload-time = "2026-07-08T12:35:24.312Z" },
+    { url = "https://files.pythonhosted.org/packages/8c/14/3a02e6ee49c2d85bc15eaae321e0e11ab3542cad3c5b2de121ecce0c4296/grpcio-1.82.1-cp313-cp313-manylinux2014_aarch64.manylinux_2_17_aarch64.whl", hash = "sha256:f5523099c98c292ea1ae08e617249db760c56a78f8deae879027fe7d1ffbcbf6", size = 6714591, upload-time = "2026-07-08T12:35:27.027Z" },
+    { url = "https://files.pythonhosted.org/packages/69/80/58e3738696f48ab7645347b98d8a7f93d10e00e6218388fbfcd6c9310e3d/grpcio-1.82.1-cp313-cp313-manylinux2014_i686.manylinux_2_17_i686.whl", hash = "sha256:5e5c4dc0a59b0f8490a6bdfd6fc8395b9d8ad8a8407c7d67ca7b5bba15c0877f", size = 7454995, upload-time = "2026-07-08T12:35:29.599Z" },
+    { url = "https://files.pythonhosted.org/packages/f3/6c/2557c1a889363072fbf2285ecd0e8c44860d4dbd60f017a32537c5b863e2/grpcio-1.82.1-cp313-cp313-manylinux2014_x86_64.manylinux_2_17_x86_64.whl", hash = "sha256:c40d94ba820329cc191981bc22fa6f6eed0799c6d921f3c6709521d59d4a2fd7", size = 6888621, upload-time = "2026-07-08T12:35:32.38Z" },
+    { url = "https://files.pythonhosted.org/packages/d2/66/907706ccaff1223f1e10fd5b37fc16faead43392fccb4e786e7e390ac141/grpcio-1.82.1-cp313-cp313-musllinux_1_2_aarch64.whl", hash = "sha256:4c816180e31e273caaec6f8bd86a8392499d5bbb26f41da44e3dce48bde69095", size = 7505069, upload-time = "2026-07-08T12:35:35.072Z" },
+    { url = "https://files.pythonhosted.org/packages/b3/7c/ff97b0d0f635987ee5ec80dfedafa1aad629303745d48e8637d10eec5b80/grpcio-1.82.1-cp313-cp313-musllinux_1_2_i686.whl", hash = "sha256:e31fd780b261830720cb70b0fd8f0aa51d49e75a66d7464ad2e31d4b765f2580", size = 8535384, upload-time = "2026-07-08T12:35:37.954Z" },
+    { url = "https://files.pythonhosted.org/packages/62/9e/a97fddd970a8d1588cade06eca20443761c1858b0ad6590a5c835aa18062/grpcio-1.82.1-cp313-cp313-musllinux_1_2_x86_64.whl", hash = "sha256:9d76152d7c31d7210d4a106e5d8b64da5bba5d6abf11be30e2f7b0a0c59bbcbf", size = 7910707, upload-time = "2026-07-08T12:35:40.797Z" },
+    { url = "https://files.pythonhosted.org/packages/20/e4/eaba1517888af483a88d449eb7566f0f7f63446d46f339c5891798435875/grpcio-1.82.1-cp313-cp313-win32.whl", hash = "sha256:38e9dcb5258226fb3282630b31b16a968df52c8c6ad514af540646e0a4578f8a", size = 4240363, upload-time = "2026-07-08T12:35:43.298Z" },
+    { url = "https://files.pythonhosted.org/packages/b0/42/66a98d47732e35290bef722f6149fed3709cd4cf61166f6f53a12f417302/grpcio-1.82.1-cp313-cp313-win_amd64.whl", hash = "sha256:3dbfb52c36d9511ac2b8e6c94fdde837b393ae520cc321f52a333a2deedf5a90", size = 5000980, upload-time = "2026-07-08T12:35:46.262Z" },
+    { url = "https://files.pythonhosted.org/packages/b4/cb/cf9ae9e164c6e6dc8a494faa9771763df9da150eefe19671009624d1559f/grpcio-1.82.1-cp314-cp314-linux_armv7l.whl", hash = "sha256:35f990f7784c8fd2872644f07f96ebb4d9e48e145a190ab80d0280af91a1bfb2", size = 6146901, upload-time = "2026-07-08T12:35:49.261Z" },
+    { url = "https://files.pythonhosted.org/packages/3b/2a/eccf26dbcfb7f7cab8027c5490a16c8937c5aa7a2ec20a3eab2cf7a43165/grpcio-1.82.1-cp314-cp314-macosx_11_0_universal2.whl", hash = "sha256:46536a4a1f4434df3c851b9254ff6fc7df5705b273681a15ca277d5921c178a0", size = 11954756, upload-time = "2026-07-08T12:35:52.196Z" },
+    { url = "https://files.pythonhosted.org/packages/ad/75/3b3b4a3cc9f084b026af96e1d3e539b1af29ec7f41ed0dfff3cb99cc8626/grpcio-1.82.1-cp314-cp314-manylinux2014_aarch64.manylinux_2_17_aarch64.whl", hash = "sha256:d6650a7c1ebb7921c70e12a385439a8118efb99e669fa9ed31cf25db1843937c", size = 6723087, upload-time = "2026-07-08T12:35:54.973Z" },
+    { url = "https://files.pythonhosted.org/packages/9c/8b/b0f0c9b1400a99a4da4c09b114f101b192f8f11192e76f620b8962f5d90b/grpcio-1.82.1-cp314-cp314-manylinux2014_i686.manylinux_2_17_i686.whl", hash = "sha256:b8e110c66df5204c0506d6c8787b35d48b8b699ef5aa366d6c4d67325c67fe9a", size = 7454542, upload-time = "2026-07-08T12:35:57.586Z" },
+    { url = "https://files.pythonhosted.org/packages/b7/bd/428e38868382aa193697a5aa53973f29c58e58ba4268aa0c86a2715ee58b/grpcio-1.82.1-cp314-cp314-manylinux2014_x86_64.manylinux_2_17_x86_64.whl", hash = "sha256:f853eae07235a51a27bb5d6a9a175a59ca55dc9b99edc6ce2f76f07332d333ae", size = 6889588, upload-time = "2026-07-08T12:36:00.012Z" },
+    { url = "https://files.pythonhosted.org/packages/49/ce/03e01d5e10259bf5c08ee50570cc94724e79c956f61fd2f09b341af0956c/grpcio-1.82.1-cp314-cp314-musllinux_1_2_aarch64.whl", hash = "sha256:60b0f2c95337694fc094b77d9f60f50566c84b5677393e342eb98daeee242d98", size = 7514166, upload-time = "2026-07-08T12:36:02.693Z" },
+    { url = "https://files.pythonhosted.org/packages/ff/59/278b4b600329e2ba3849f3c1ea3c820b3a01b38a7ad184ba09595e8d2733/grpcio-1.82.1-cp314-cp314-musllinux_1_2_i686.whl", hash = "sha256:b064fc444812bdaa9825d33c26f8d732d63ee6a5d78557c1faf92c98687fed27", size = 8536166, upload-time = "2026-07-08T12:36:05.349Z" },
+    { url = "https://files.pythonhosted.org/packages/44/27/7ccf2ef00f27a8e47a79d641c8ceaf7d3028c7a03d9a97b4c8a9a783c086/grpcio-1.82.1-cp314-cp314-musllinux_1_2_x86_64.whl", hash = "sha256:7d7ede11d747b4e1bd05e3bc0260e155b65a88735a895a10f6521f19b889511e", size = 7912572, upload-time = "2026-07-08T12:36:08.393Z" },
+    { url = "https://files.pythonhosted.org/packages/0d/be/33742482d2753f2d3a1b7641664b6622262d44f2f3b609f13425dd86d36f/grpcio-1.82.1-cp314-cp314-win32.whl", hash = "sha256:3d21f19838dc255ecbb79321b15ae9b98fbddff4c3d4aedb0a81bdd7f4ab572a", size = 4321856, upload-time = "2026-07-08T12:36:10.899Z" },
+    { url = "https://files.pythonhosted.org/packages/cc/67/03329c847172c78ddeb1eb9be6b444fdbc12775a84c958b27e427e7b926d/grpcio-1.82.1-cp314-cp314-win_amd64.whl", hash = "sha256:e20f1edbb15f99e3128ec86433f9785fd5a451d8f115e74fe0056134f092a9d5", size = 5141114, upload-time = "2026-07-08T12:36:13.595Z" },
+]
+
+[[package]]
+name = "grpcio-status"
+version = "1.81.1"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "googleapis-common-protos" },
+    { name = "grpcio" },
+    { name = "protobuf" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/32/26/0aa9168c87882381fd810d140c279a2490ed6aee655f0515d6f56c5ca404/grpcio_status-1.81.1.tar.gz", hash = "sha256:9389a03e746017b10f0630c064289201458f3ce01f5d7ef4b0bebc1ef6cf82ad", size = 13923, upload-time = "2026-06-11T12:58:48.636Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/e5/5e/5abfec5f7e89d3b7993d57cfb025ca5f968a2c18656d7fcda2b6919440b9/grpcio_status-1.81.1-py3-none-any.whl", hash = "sha256:08072fa9995f4a95c647fc6f4f85e2411573d00087bcabdf30f260114338f232", size = 14638, upload-time = "2026-06-11T12:58:31.982Z" },
 ]
 
 [[package]]
@@ -1634,6 +1759,7 @@ dependencies = [
     { name = "fastapi" },
     { name = "fastembed" },
     { name = "google-auth" },
+    { name = "google-cloud-secret-manager" },
     { name = "httpx" },
     { name = "hvac" },
     { name = "jinja2" },
@@ -1689,6 +1815,7 @@ requires-dist = [
     { name = "fastapi", specifier = ">=0.139.0,<0.140" },
     { name = "fastembed", specifier = ">=0.7,<1.0" },
     { name = "google-auth", specifier = ">=2.55.1" },
+    { name = "google-cloud-secret-manager", specifier = ">=2.20.0" },
     { name = "httpx", specifier = ">=0.27" },
     { name = "hvac", specifier = ">=2.4.0" },
     { name = "jinja2", specifier = ">=3.1.6" },
@@ -2470,6 +2597,18 @@ wheels = [
     { url = "https://files.pythonhosted.org/packages/88/fb/46dad6c0ae49ed230ab1b16c890c2b6314e2403e6c412976f4a72d64a527/propcache-0.5.2-cp314-cp314t-win_amd64.whl", hash = "sha256:d447bb0b3054be5818458fbb171208b1d9ff11eba14e18ca18b90cbb45767370", size = 47764, upload-time = "2026-05-08T21:02:07.353Z" },
     { url = "https://files.pythonhosted.org/packages/e7/c4/a47d0a63aa309d10d59ede6e9d4cff03a344a79d1f0f4cd0cd74997b53e0/propcache-0.5.2-cp314-cp314t-win_arm64.whl", hash = "sha256:fe67a3d11cd9b4efabfa45c3d00ffba2b26811442a73a581a94b67c2b5faccf6", size = 41140, upload-time = "2026-05-08T21:02:09.065Z" },
     { url = "https://files.pythonhosted.org/packages/3a/ed/1cdcab6ba3d6ab7feca11fc14f0eeea80755bb53ef4e892079f31b10a25f/propcache-0.5.2-py3-none-any.whl", hash = "sha256:be1ddfcbb376e3de5d2e2db1d58d6d67463e6b4f9f040c000de8e300295465fe", size = 14036, upload-time = "2026-05-08T21:02:10.673Z" },
+]
+
+[[package]]
+name = "proto-plus"
+version = "1.28.1"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "protobuf" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/87/44/767757fd2cdd4a60d7e4440d9f7b491d6131103d313638d2c03e06c268fb/proto_plus-1.28.1.tar.gz", hash = "sha256:832e68e7fe064cf90ab153b6e5eb935b27891bb89aaeb68b115e9b702f6cb168", size = 57166, upload-time = "2026-07-08T17:04:02.367Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/6a/34/2f2b57dbfd145b995a29847a16b0903fce5ef6ad3c7aad740a609c5d3678/proto_plus-1.28.1-py3-none-any.whl", hash = "sha256:6660f5f1970874bdcfc3088b435188a36a37bd3596668f7d726417c4ae8cfbed", size = 50408, upload-time = "2026-07-08T17:03:34.532Z" },
 ]
 
 [[package]]

--- a/docs/codebase/connectors-shared-vault-creds.md
+++ b/docs/codebase/connectors-shared-vault-creds.md
@@ -25,9 +25,11 @@ registry. A schemeless ref (`targets/<id>`) resolves through the
 deployment default (`config.credentialBackend` / `CREDENTIAL_BACKEND`,
 default `vault`) and an explicit `vault:targets/<id>` ref resolves
 identically — both dispatch to `VaultCredentialBackend`, today's KV-v2
-read, byte-for-byte. An unknown scheme (`gsm:` before #2230 registers the
-GSM backend) raises `UnknownCredentialBackendError` instead of a silent
-Vault attempt. The seam is the target-credential analogue of the
+read, byte-for-byte. A `gsm:<project>/<secret>[#field]` ref resolves
+through `GcpSecretManagerBackend` (#2230, see `## GCP Secret Manager
+backend (gsm)` below); any other unknown scheme raises
+`UnknownCredentialBackendError` instead of a silent Vault attempt. The
+seam is the target-credential analogue of the
 `SECRET_ENDPOINT_REGISTRY` the `secret.move` broker already uses; the two
 are separate registries because they serve different contracts (the
 broker moves one opaque value; a credential backend returns a named-field
@@ -206,6 +208,64 @@ Chart wiring (`config.credentialBackend` → `CREDENTIAL_BACKEND` in the
 Helm configmap) lands with the GSM Helm surface in #2231; the setting is
 already read here so a value flows the moment the chart exposes it.
 
+## GCP Secret Manager backend (gsm)
+
+`backend/src/meho_backplane/connectors/_shared/gsm_creds.py` registers
+`GcpSecretManagerBackend` under kind `gsm` (#2230, Initiative #2227) — the
+second backend on the seam, so a GCP-native adopter runs Vault-free. The
+`_shared` package `__init__` imports the module so the `register_credential_backend("gsm", ...)`
+call runs eagerly, exactly as `vault_creds` does for `vault`.
+
+**Auth model — SA-direct under GKE Workload Identity (Phase 1).** The read
+runs under MEHO's *own* identity: the pod's Application Default Credentials
+(`google.auth.default()`), which on GKE resolve to the deployment's
+Workload Identity service account. A configured deployment-level SA
+(`GSM_IMPERSONATE_SA` / `Settings.gsm_impersonate_sa`, empty by default)
+wraps that ADC source in `google.auth.impersonated_credentials.Credentials`
+targeting the SA — the same ADC + impersonation chain `GcloudConnector`
+drives (`gcloud/connector.py:_fetch_token_sync`). No service-account JSON
+key ever enters the flow, honouring `constraints/iam.disableServiceAccountKeyCreation`
+by never using key material. Per-operator GCP federation (STS token
+exchange) is #2232, out of scope here; MEHO's audit still attributes to
+the Keycloak `sub` (the policy/audit seam is untouched), so Phase 1 loses
+only *GCP-layer* per-operator attribution.
+
+**Ref grammar.** The scheme-stripped store ref is
+`<project-id>/<secret-name>[/versions/<version>][#<field>]`:
+
+- bare `proj/secret` — reads the **latest** version, returns the whole
+  JSON object as the field dict.
+- pinned `proj/secret/versions/5` — reads that exact version.
+- `#field` — `proj/secret#password` — returns just `{field: value}`.
+
+Both forms require the decoded payload to be a JSON **object** (the seam
+contract returns a named-field dict the loader's `_extract_fields`
+consumes, exactly as the Vault backend returns a KV-v2 data dict) — a
+non-JSON / non-object payload, or a missing field, raises
+`GcpSecretManagerReadError`. That error type is the GSM analogue of
+`VaultCredentialsReadError`: distinct and actionable, raised on a
+malformed ref, an empty/unresolvable ADC source, access-denied
+(`PermissionDenied`), not-found (`NotFound`), or a transport failure —
+never a bare `google.api_core` exception, never echoing a value. The
+`SecretManagerServiceClient.access_secret_version` call is synchronous, so
+it runs off the event loop via `asyncio.to_thread` (the hvac precedent).
+The structlog `gsm_secret_accessed` event carries only `target` /
+`project` / `secret_name` / resolved `version` / `field` name.
+
+**Operator-JWT guard interaction.** The shared loader's empty-`raw_jwt`
+fail-closed guard (`_resolve_and_load`) still runs before dispatch, so a
+system-initiated call (`raw_jwt=""`) cannot resolve a `gsm:` ref either —
+identical to Vault today. Phase 1 deliberately keeps that guard rather than
+relaxing it for the deployment-identity backend; a future change that
+needs system-context GSM reads would move the guard into
+`VaultCredentialBackend`.
+
+**Test seams.** The backend takes injectable `adc_loader` (replaces
+`google.auth.default`) and `client_factory` (replaces
+`SecretManagerServiceClient`) so the unit suite drives parse / decode /
+impersonation / error / no-secret-in-logs behaviour with a canned payload
+and no live GCP (`tests/test_connectors_gsm_creds.py`).
+
 ## Dependencies
 
 - **`hvac`** (2.4.0 resolved) — `client.secrets.kv.v2.read_secret_version`
@@ -218,6 +278,13 @@ already read here so a value flows the moment the chart exposes it.
 - **`meho_backplane.auth.operator.Operator`** — the frozen request-scoped
   operator whose `raw_jwt` is forwarded to Vault.
 - **`structlog`** — the `vault_basic_credentials_loaded` event.
+- **`google-cloud-secret-manager`** (2.29.0 resolved) — the `gsm` backend's
+  `SecretManagerServiceClient.access_secret_version(name=...)` →
+  `response.payload.data` (bytes). Synchronous; wrapped in
+  `asyncio.to_thread`.
+- **`google-auth`** (already a dep) — `google.auth.default()` for the ADC
+  source and `google.auth.impersonated_credentials.Credentials` for the
+  optional SA impersonation the `gsm` backend reuses from `GcloudConnector`.
 
 ## Known issues
 


### PR DESCRIPTION
## Summary

- Registers a second credential backend, `gsm`, on the #2229 resolver seam so a GCP-native adopter can resolve a target's `gsm:<project>/<secret>[#field]` `secret_ref` with **no Vault** — the smallest change that unblocks a Vault-free GCP install (#2227).
- `GcpSecretManagerBackend` reads GCP Secret Manager under MEHO's own GKE Workload Identity ADC (`google.auth.default()`), optionally impersonating a configured SA (`GSM_IMPERSONATE_SA`) via `google.auth.impersonated_credentials` — the exact ADC + impersonation chain `GcloudConnector` already drives, and never a service-account JSON key (honours `constraints/iam.disableServiceAccountKeyCreation`).
- A bare ref returns the whole JSON-object payload; `#field` selects one key; a pinned `/versions/<n>` addresses an exact version. The sync `access_secret_version` RPC runs off the event loop via `asyncio.to_thread` (hvac precedent).
- Attribution still flows via the Keycloak `sub` — the policy/audit seam is untouched. Per-operator GCP federation (#2232) and the Helm surface (#2231) are out of scope.

## Design notes

- The `_shared` package `__init__` imports `gsm_creds` so its `register_credential_backend("gsm", ...)` runs eagerly, exactly as `vault_creds` does for `vault`.
- All failure modes (malformed ref, non-JSON / non-object payload, missing field, empty/unresolvable ADC, `PermissionDenied`, `NotFound`, transport error) raise a distinct, actionable `GcpSecretManagerReadError` — never a bare `google.api_core` exception, never echoing a value. The `gsm_secret_accessed` structlog event carries only `target` / `project` / `secret_name` / `version` / `field` name.
- The shared loader's empty-`raw_jwt` fail-closed guard still runs before dispatch, so system-initiated calls cannot resolve a `gsm:` ref either — identical to Vault today. Phase 1 deliberately keeps that guard rather than relaxing it for the deployment-identity backend.

## Test plan

- [x] `ruff check` — clean (changed files)
- [x] `ruff format --check` — clean
- [x] `mypy src/meho_backplane/connectors/_shared/gsm_creds.py src/meho_backplane/settings.py` — clean
- [x] `code-quality.py --diff` — 0 blockers
- [x] `pytest tests/test_connectors_gsm_creds.py tests/test_settings.py tests/test_connectors_vault_creds.py tests/test_connectors_credential_backend.py` — 120 passed
- [x] `import google.cloud.secretmanager` works (dep added to `backend/pyproject.toml` + `uv.lock`, resolved 2.29.0)
- [x] `gsm:proj/secret` resolves the whole JSON payload; `gsm:proj/secret#password` selects the `password` key; missing field / non-JSON raises a clear error
- [x] read runs under mocked `google.auth.default()` (no live GCP); impersonates when a SA is configured (constructor or `Settings`)
- [x] no secret value in any log event (asserted via `capture_logs`)
- [x] access-denied / not-found / transport failure surface a distinct actionable error; `gsm:` dispatch succeeds end-to-end via `load_basic_credentials` / `load_vault_secret_data` with a mocked backend
- [x] app import smoke (`import meho_backplane.main`) clean; registry shows kinds `['gsm', 'vault']`

## Out of scope

- WIF / STS per-operator token exchange (#2232).
- Helm surface / chart wiring for `CREDENTIAL_BACKEND` + `GSM_IMPERSONATE_SA` (#2231).

## Adjacent findings

- `gsm_creds.py` is 401 lines (code-quality warn threshold 400, mostly module docstring) — a warning, not a blocker; left as-is.
- `settings.py` is 1642 lines (pre-existing warn) — untouched debt, not this task's concern.

<!-- auto-implement-issue: fresh, iteration 1 -->

Closes #2230
