### PR TITLE
feat(operations): reusable seam to gate direct-session write sub-ops (#2254)

### DIFF
--- a/backend/src/meho_backplane/connectors/vmware_rest/composites/_read.py
+++ b/backend/src/meho_backplane/connectors/vmware_rest/composites/_read.py
@@ -82,9 +82,18 @@ relocates the other two:
 * **(3) Per-sub-op policy-gate + broadcast is evaded** -- acceptable
   for **read** composites (the top-level op is already gated), but
   **load-bearing for write** composites whose sub-ops may be
-  approval-gated. Migrating a write composite to the direct path must
-  first resolve how the top-level policy/approval gate still covers
-  the now-internal writes (Initiative #2249, the property-3 question).
+  approval-gated. A write composite on the direct path re-applies the
+  gate per governed sub-call through the reusable seam
+  :func:`~meho_backplane.operations.composite.enforce_subop_policy`
+  (Task #2254): the handler calls it before each direct write sub-call
+  with the sub-op's declared ``safety_level`` / ``requires_approval``,
+  and returns the seam's ``awaiting_approval`` / ``denied``
+  :class:`OperationResult` verbatim when the gate does not clear -- so
+  an approval-gated sub-op still queues instead of executing. The
+  curated composite's own top-level ``requires_approval`` remains the
+  primary governing decision (Initiative #2249); the seam guarantees no
+  internal write drops below the governance it had under
+  ``dispatch_child``.
 
 Op_id contract for sub-ops
 --------------------------

--- a/backend/src/meho_backplane/operations/composite.py
+++ b/backend/src/meho_backplane/operations/composite.py
@@ -88,6 +88,7 @@ References
 
 from __future__ import annotations
 
+import time
 import uuid
 from contextvars import ContextVar
 from typing import TYPE_CHECKING, Any, Protocol
@@ -106,6 +107,7 @@ __all__ = [
     "CompositeRecursionLimitExceeded",
     "DispatchChild",
     "composite_depth_var",
+    "enforce_subop_policy",
     "get_dispatch_child",
 ]
 
@@ -493,3 +495,123 @@ def get_dispatch_child(
             parent_audit_id_var.reset(audit_token)
 
     return _dispatch_child
+
+
+async def enforce_subop_policy(
+    *,
+    operator: Operator,
+    connector_id: str,
+    op_id: str,
+    safety_level: str,
+    requires_approval: bool,
+    target: Any,
+    params: dict[str, Any],
+) -> OperationResult | None:
+    """Re-apply the dispatcher policy/approval gate around a direct-session sub-op.
+
+    The reusable seam that keeps property 3 of #508's four
+    ``dispatch_child`` guarantees when a write composite migrates to the
+    direct-session path (Task #2254, Initiative #2249). A direct handler
+    bypasses :func:`~meho_backplane.operations.dispatcher.dispatch`, so a
+    now-internal write sub-op that is itself ``requires_approval`` /
+    ``dangerous`` would otherwise execute un-gated. The handler calls
+    this **before** each governed direct write sub-call with the sub-op's
+    declared policy facts; it re-runs the *same*
+    :func:`~meho_backplane.operations._validate.policy_gate` the
+    dispatcher runs, against an in-memory
+    :class:`~meho_backplane.db.models.EndpointDescriptor` built from those
+    facts (never persisted — two-world purity, Goal #2247):
+
+    * ``auto-execute`` → returns ``None``; the handler proceeds with its
+      direct ``connector._post_json(...)`` call.
+    * ``needs-approval`` → writes a durable
+      :class:`~meho_backplane.db.models.ApprovalRequest` for the sub-op
+      via :func:`~meho_backplane.operations.approval_queue.create_pending_request`
+      and returns an ``awaiting_approval`` :class:`OperationResult`. The
+      handler returns it verbatim, and the dispatcher passes a
+      handler-returned :class:`OperationResult` straight through, so the
+      write **queues** instead of executing.
+    * ``deny`` → returns a ``denied`` :class:`OperationResult`; the write
+      never runs.
+
+    The seam ships the mechanism only; it does not execute the sub-op or
+    write its audit row (the top-level composite op owns the row that
+    attributes the writes). The chosen model, the rejected
+    "top-level-sufficiency" alternative, and the call-site example are
+    documented in ``docs/architecture/operations-substrate.md`` under
+    "Preserving write-composite policy on the direct path".
+    """
+    # Lazy imports: this module is imported by the dispatcher, so a
+    # top-level import of the policy/approval machinery (which imports
+    # back into the operations package) would risk an import cycle.
+    # Deferring to call time mirrors the pattern used by
+    # ``get_dispatch_child`` above and ``_handle_needs_approval`` in the
+    # dispatcher.
+    from meho_backplane.agent.invoke import current_agent_run_id_var
+    from meho_backplane.db.engine import get_sessionmaker
+    from meho_backplane.db.models import EndpointDescriptor, PermissionVerdict
+    from meho_backplane.operations._errors import (
+        result_awaiting_approval,
+        result_denied,
+    )
+    from meho_backplane.operations._lookup import parse_connector_id
+    from meho_backplane.operations._validate import compute_params_hash, policy_gate
+    from meho_backplane.operations.approval_queue import (
+        create_pending_request,
+        publish_approval_event,
+    )
+
+    started = time.monotonic()
+    product, version, impl_id = parse_connector_id(connector_id)
+
+    # An in-memory descriptor carrying only the policy-relevant fields.
+    # Never added to a session — it exists solely to feed ``policy_gate``
+    # the sub-op's declared governance, exactly as a persisted descriptor
+    # would for a ``dispatch()`` call.
+    descriptor = EndpointDescriptor(
+        product=product,
+        version=version,
+        impl_id=impl_id,
+        op_id=op_id,
+        source_kind="composite",
+        safety_level=safety_level,
+        requires_approval=requires_approval,
+        parameter_schema={},
+    )
+
+    verdict, reason = await policy_gate(operator=operator, descriptor=descriptor, target=target)
+    if verdict is PermissionVerdict.AUTO_EXECUTE:
+        return None
+
+    duration_ms = (time.monotonic() - started) * 1000.0
+    if verdict is PermissionVerdict.NEEDS_APPROVAL:
+        params_hash = compute_params_hash(params)
+        run_id = current_agent_run_id_var.get()
+        sessionmaker = get_sessionmaker()
+        async with sessionmaker() as session:
+            request = await create_pending_request(
+                session,
+                operator=operator,
+                connector_id=connector_id,
+                op_id=op_id,
+                target=target,
+                params=params,
+                params_hash=params_hash,
+                run_id=run_id,
+            )
+            await session.commit()
+        # Publish AFTER commit so a broadcast can never outlive a failed
+        # transaction; the helper is fail-open, so a broadcast outage
+        # does not block the durable decision.
+        await publish_approval_event(
+            tenant_id=operator.tenant_id,
+            request=request,
+            decision="pending",
+            principal_sub=operator.sub,
+            audit_id=request._audit_id,  # type: ignore[attr-defined]
+        )
+        return result_awaiting_approval(op_id, request.id, duration_ms)
+
+    # DENY, or any unexpected verdict — fail closed: the sub-op never
+    # runs. Only an explicit AUTO_EXECUTE clears the gate.
+    return result_denied(op_id, reason or "policy denied", duration_ms)

--- a/backend/tests/test_operations_subop_policy_gate.py
+++ b/backend/tests/test_operations_subop_policy_gate.py
@@ -1,0 +1,188 @@
+# SPDX-License-Identifier: Apache-2.0
+# Copyright (c) 2026 evoila Group
+
+"""Tests for :func:`meho_backplane.operations.composite.enforce_subop_policy`.
+
+Task #2254 (Initiative #2249, Goal #2247). The seam re-applies the
+dispatcher's policy/approval gate around a direct-session write sub-op so
+a write composite that has migrated off ``dispatch_child`` keeps property
+3 of #508's four guarantees — a now-internal write sub-op that is itself
+approval-gated still queues for approval instead of executing.
+
+Coverage
+--------
+
+* **queues on needs-approval** -- a ``requires_approval`` sub-op routed
+  through the seam writes a durable pending :class:`ApprovalRequest` and
+  returns an ``awaiting_approval`` result (the hard acceptance gate).
+* **proceeds on auto-execute** -- a ``safe`` / non-approval sub-op
+  returns ``None`` so the handler runs its direct session call.
+* **denies without lowering governance** -- a ``dangerous`` sub-op with
+  no grant (agent principal) returns ``denied``; the write never runs.
+* **two-world purity** -- the seam never persists an
+  :class:`EndpointDescriptor` row for the synthetic sub-op descriptor.
+"""
+
+from __future__ import annotations
+
+import uuid
+from collections.abc import AsyncIterator, Iterator
+
+import pytest
+from sqlalchemy import func, select
+from sqlalchemy.ext.asyncio import AsyncSession
+
+from meho_backplane.auth.operator import Operator, PrincipalKind, TenantRole
+from meho_backplane.db.engine import get_sessionmaker
+from meho_backplane.db.models import (
+    ApprovalRequest,
+    ApprovalRequestStatus,
+    EndpointDescriptor,
+)
+from meho_backplane.operations.composite import enforce_subop_policy
+from meho_backplane.settings import get_settings
+
+_TENANT_ID = uuid.UUID("00000000-0000-0000-0000-0000000024a4")
+_CONNECTOR_ID = "vmware-rest-9.0"
+_SUB_OP_ID = "POST:/vcenter/vm"
+_SUB_PARAMS = {"spec": {"name": "vm-under-test", "guest_OS": "OTHER"}}
+
+
+@pytest.fixture(autouse=True)
+def _required_settings_env(monkeypatch: pytest.MonkeyPatch) -> Iterator[None]:
+    """Pin every env var :class:`Settings` requires."""
+    monkeypatch.setenv("KEYCLOAK_ISSUER_URL", "https://keycloak.test/realms/meho")
+    monkeypatch.setenv("KEYCLOAK_AUDIENCE", "meho-backplane")
+    monkeypatch.setenv("VAULT_ADDR", "https://vault.test")
+    get_settings.cache_clear()
+    yield
+    get_settings.cache_clear()
+
+
+@pytest.fixture
+async def session() -> AsyncIterator[AsyncSession]:
+    """Open a session against the autouse-migrated SQLite engine."""
+    sessionmaker = get_sessionmaker()
+    async with sessionmaker() as s:
+        yield s
+
+
+def _operator(
+    *,
+    principal_kind: PrincipalKind = PrincipalKind.USER,
+    role: TenantRole = TenantRole.OPERATOR,
+) -> Operator:
+    return Operator(
+        sub="ops-operator-sub",
+        name="Ops Operator",
+        email=None,
+        raw_jwt="<test-raw-jwt>",
+        tenant_id=_TENANT_ID,
+        tenant_role=role,
+        principal_kind=principal_kind,
+    )
+
+
+@pytest.mark.asyncio
+async def test_gated_subop_queues_for_approval(session: AsyncSession) -> None:
+    """A ``requires_approval`` write sub-op queues instead of executing.
+
+    The hard acceptance gate for #2254: an approval-gated sub-op called
+    via the direct-session seam produces a durable pending
+    :class:`ApprovalRequest` and returns ``awaiting_approval`` — the
+    handler returns that verbatim, so no write happens.
+    """
+    result = await enforce_subop_policy(
+        operator=_operator(),
+        connector_id=_CONNECTOR_ID,
+        op_id=_SUB_OP_ID,
+        safety_level="dangerous",
+        requires_approval=True,
+        target=None,
+        params=_SUB_PARAMS,
+    )
+
+    # The seam signalled "do not execute" by returning a result.
+    assert result is not None
+    assert result.status == "awaiting_approval"
+    assert result.op_id == _SUB_OP_ID
+    request_id = uuid.UUID(result.extras["approval_request_id"])
+
+    # A durable pending approval row was written for the sub-op.
+    row = await session.get(ApprovalRequest, request_id)
+    assert row is not None
+    assert row.op_id == _SUB_OP_ID
+    assert row.connector_id == _CONNECTOR_ID
+    assert row.status == ApprovalRequestStatus.PENDING.value
+    assert row.params == _SUB_PARAMS
+    assert row.principal_sub == "ops-operator-sub"
+
+
+@pytest.mark.asyncio
+async def test_safe_subop_auto_executes(session: AsyncSession) -> None:
+    """A ``safe`` non-approval sub-op clears the gate (returns ``None``)."""
+    result = await enforce_subop_policy(
+        operator=_operator(),
+        connector_id=_CONNECTOR_ID,
+        op_id="GET:/vcenter/vm",
+        safety_level="safe",
+        requires_approval=False,
+        target=None,
+        params={"filter.names": ["vm-under-test"]},
+    )
+    assert result is None
+
+    # No approval row was created for an auto-execute verdict.
+    count = await session.scalar(select(func.count()).select_from(ApprovalRequest))
+    assert count == 0
+
+
+@pytest.mark.asyncio
+async def test_dangerous_subop_denied_for_agent_without_grant(
+    session: AsyncSession,
+) -> None:
+    """A ``dangerous`` sub-op with no grant denies — governance not lowered.
+
+    For an agent principal the ``dangerous`` safety default is ``deny``.
+    The seam surfaces that as a ``denied`` result the handler returns
+    verbatim, so the write never runs and the sub-op cannot execute at a
+    lower governance level than it had through ``dispatch_child``.
+    """
+    result = await enforce_subop_policy(
+        operator=_operator(principal_kind=PrincipalKind.AGENT),
+        connector_id=_CONNECTOR_ID,
+        op_id="DELETE:/vcenter/vm/{vm}",
+        safety_level="dangerous",
+        requires_approval=False,
+        target=None,
+        params={"vm": "vm-42"},
+    )
+    assert result is not None
+    assert result.status == "denied"
+    assert result.op_id == "DELETE:/vcenter/vm/{vm}"
+
+    # No pending row: a deny is not a park.
+    count = await session.scalar(select(func.count()).select_from(ApprovalRequest))
+    assert count == 0
+
+
+@pytest.mark.asyncio
+async def test_seam_persists_no_descriptor_row(session: AsyncSession) -> None:
+    """The synthetic sub-op descriptor is never written to the catalog.
+
+    Two-world purity (Goal #2247): the in-memory descriptor exists only
+    to feed ``policy_gate`` the sub-op's declared governance; it must not
+    land as an ``endpoint_descriptor`` row.
+    """
+    before = await session.scalar(select(func.count()).select_from(EndpointDescriptor))
+    await enforce_subop_policy(
+        operator=_operator(),
+        connector_id=_CONNECTOR_ID,
+        op_id=_SUB_OP_ID,
+        safety_level="dangerous",
+        requires_approval=True,
+        target=None,
+        params=_SUB_PARAMS,
+    )
+    after = await session.scalar(select(func.count()).select_from(EndpointDescriptor))
+    assert after == before

--- a/docs/architecture/operations-substrate.md
+++ b/docs/architecture/operations-substrate.md
@@ -319,6 +319,35 @@ Spelling the contract as a `typing.Protocol` rather than a raw `Callable` alias 
 
 Both seams are forwarded **only when the handler declares the matching parameter**, so the `dispatch_child`-only handlers above are unchanged, and the registration guard (`validate_composite_handler_signature`) accepts a handler declaring either or both. Taking the direct path deliberately drops the per-sub-op audit row, param validation, recursion bound, and policy/broadcast that `dispatch_child` provides; those trade-offs — and why per-sub-op policy stays load-bearing for *write* composites — are documented on the "Why `dispatch_child` not direct httpx" note in [`connectors/vmware_rest/composites/_read.py`](../../backend/src/meho_backplane/connectors/vmware_rest/composites/_read.py). No shipped composite uses the direct seam yet; the incremental migrations are Initiative #2248/#2249.
 
+### Preserving write-composite policy on the direct path (`enforce_subop_policy`, #2254)
+
+The direct seam drops property 3 of `dispatch_child` — the per-sub-op policy-gate + approval-queue check. For a **read** composite that is fine (the top-level op is already gated). For a **write** composite it is load-bearing: a now-internal write sub-op may itself be `dangerous` / `requires_approval`, and executing it un-gated would regress the governance it had through `dispatch_child`.
+
+[`enforce_subop_policy(...)`](../../backend/src/meho_backplane/operations/composite.py) is the reusable seam that closes the gap. A direct-session write handler calls it **before** each governed sub-call, passing the sub-op's declared policy facts:
+
+```python
+gate = await enforce_subop_policy(
+    operator=operator,
+    connector_id="vmware-rest-9.0",
+    op_id="POST:/vcenter/vm",
+    safety_level="dangerous",
+    requires_approval=True,
+    target=target,
+    params=create_body,
+)
+if gate is not None:
+    return gate  # awaiting_approval / denied — do NOT run the write
+vm = await connector._post_json(target, "/vcenter/vm", operator=operator, json=create_body)
+```
+
+It re-runs the **same** `policy_gate` the dispatcher runs, against an in-memory `EndpointDescriptor` built from those facts (never persisted — that keeps the code-shipped op's dispatch path off a mutable catalog row). The verdict maps to:
+
+- **auto-execute** → returns `None`; the handler proceeds with its direct session call.
+- **needs-approval** → writes a durable `ApprovalRequest` for the sub-op via the public `create_pending_request` and returns an `awaiting_approval` `OperationResult`. The handler returns it verbatim, and the dispatcher passes a handler-returned `OperationResult` straight through (`_run_source_kind_branch` → `isinstance(branch_result, OperationResult)`), so the write **queues** instead of executing.
+- **deny** → returns a `denied` `OperationResult`; the write never runs.
+
+**Chosen model vs the rejected one.** All 8 vmware write composites are already `dangerous` + `requires_approval` at the **top-level op**, so the composite's own gate — which `dispatch()` runs before the handler body — is the *primary* governing decision, matching the RFC's "curated composite is the reviewed unit" framing (Goal #2247). The **rejected** alternative was to rely on that top-level decision *alone* ("top-level sufficiency"): simpler, but it silently collapses per-sub-op approval granularity — a composite that is itself auto-execute yet fans out to one approval-gated write sub-op would execute that write with no approval. `enforce_subop_policy` is the dumb-substrate complement (a plain function with no DSL/config framework, reusing `policy_gate` + the approval queue verbatim) that **guarantees** no internal write sub-op executes below the governance it had under `dispatch_child`. It ships the mechanism only; the 8 write composites consume it during their migration (Initiative #2249, #2256).
+
 ### `parent_audit_id` semantics
 
 The composite branch builds the `dispatch_child` callable via [`get_dispatch_child(...)`](../../backend/src/meho_backplane/operations/composite.py), passing the parent's `audit_id`. The factory closes over `parent_audit_id` and binds it on `parent_audit_id_var` for the duration of each child dispatch. The child's audit row reads the contextvar via `parent_audit_id_var.get()` and writes the UUID to its `audit_log.parent_audit_id` column.


### PR DESCRIPTION
## Summary

- Adds `enforce_subop_policy(...)` in `operations/composite.py` — a reusable seam that re-applies the dispatcher's `policy_gate` + approval-queue around a **direct-session** write sub-op, so a write composite that has migrated off `dispatch_child` (the #2251 substrate) keeps property 3 of #508's four guarantees.
- Mechanism only: settles the one genuine open design point of Goal #2247 (property 3 for write composites) and unblocks the 8-write-composite migration (#2256). **No composite is migrated here.**
- Documents the chosen model vs the rejected alternative in `docs/architecture/operations-substrate.md`; the vmware `_read.py` "four reasons" note now points at the seam.

## Design decision

**Chosen — an explicit reusable internal-gate seam.** The handler calls `enforce_subop_policy(...)` before each governed direct write sub-call with the sub-op's declared policy facts (`op_id` / `safety_level` / `requires_approval`). It re-runs the *same* `policy_gate` the dispatcher runs, against an in-memory `EndpointDescriptor` built from those facts (never persisted — keeps the code-shipped op's dispatch path off a mutable catalog row, per the two-world posture). Verdict mapping:

- `auto-execute` → returns `None`; the handler proceeds with `connector._post_json(...)`.
- `needs-approval` → writes a durable `ApprovalRequest` via the public `create_pending_request`, returns `awaiting_approval`. The handler returns it verbatim and the dispatcher passes a handler-returned `OperationResult` straight through, so the write **queues** instead of executing.
- `deny` → returns `denied`; the write never runs.

**Rejected — "top-level sufficiency" alone.** All 8 vmware write composites are already `dangerous` + `requires_approval` at the top-level op, so the composite's own gate is the primary governing decision (the curated workflow is the reviewed unit). But relying on that *alone* silently collapses per-sub-op approval granularity — a composite that is itself auto-execute yet fans out to one approval-gated write sub-op would execute that write with no approval (the property-3 regression #2247's trade-off note calls out). The seam is the dumb-substrate complement (a plain function, no DSL/config framework, reusing `policy_gate` + the approval queue verbatim) that **guarantees** no internal write sub-op executes below the governance it had under `dispatch_child`.

## Acceptance criteria

- [x] Chosen model documented with rationale vs the rejected option — `operations-substrate.md` + the seam docstring + the `_read.py` note.
- [x] A write composite whose top-level op is `requires_approval=True` still queues end-to-end — pre-existing dispatcher behavior, proven for all 8 composites by `test_connectors_vmware_rest_composites_write_e2e.py` (top-level `awaiting_approval` park).
- [x] No internal write sub-op executes at a lower governance level than via `dispatch_child` — `test_gated_subop_queues_for_approval` (approval-gated sub-op queues a durable `ApprovalRequest` instead of executing) + `test_dangerous_subop_denied_for_agent_without_grant` (dangerous sub-op denied).
- [x] Mechanism is reusable by all 8 write composites — a general operations-layer helper, not composite-specific; #2256 consumes it.

## Test plan

- [x] `ruff check` / `ruff format --check` — clean
- [x] `mypy operations/composite.py` — clean
- [x] `pytest tests/test_operations_subop_policy_gate.py` — 4 passed (queues / auto-executes / denies / persists-no-descriptor)
- [x] Regression: `test_operations_composite*`, `test_approval_queue`, `test_connectors_vmware_rest_composites_read/write/write_e2e`, `test_operations_dispatcher` — all green

## Out of scope

- Migrating the 8 write composites to direct-session dispatch (that is #2256, which consumes this seam).
- Read-composite migration (#2253) and the enforcement invariant / apparatus deletion (I-A, #2248).

<!-- auto-implement-issue: fresh, iteration 1 -->

Closes #2254


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added per-step approval checks for direct write operations, so actions now respect governance even when they bypass the normal execution path.
  * Automatic execution still works for safe operations, while approval-required actions now create a pending approval request and surface the approval status.

* **Bug Fixes**
  * Prevented unsafe direct write actions from running without the proper approval or from incorrectly skipping policy checks.

* **Documentation**
  * Clarified how direct-session write handling works and how approval outcomes are determined.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->