### PR TITLE
feat(connectors): GSM backend Phase 2 — per-operator WIF (Keycloak→GCP-STS)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -90,6 +90,24 @@ connector-related release-notes line.
 
 ## [Unreleased]
 
+### Added — GCP Secret Manager backend Phase 2 (per-operator Workload Identity Federation)
+
+- The `gsm` credential backend now supports a **per-operator** read path via
+  Keycloak→GCP-STS Workload Identity Federation. When `GSM_WIF_AUDIENCE` is
+  set, a `gsm:` read exchanges the operator's Keycloak JWT
+  (`operator.raw_jwt`) at `sts.googleapis.com` for a short-lived federated
+  token (google-auth `identity_pool.Credentials`), optionally impersonates
+  `GSM_WIF_SERVICE_ACCOUNT`, does the one `secretmanager.versions.access`,
+  and discards the token — so GCP's own audit log attributes the read to the
+  operator, mirroring Vault's per-operator JIT contract. A fresh credential
+  is minted per read (never cached). Installs that leave `GSM_WIF_AUDIENCE`
+  unset keep the Phase-1 SA-direct path unchanged. The GCP-side Workload
+  Identity Pool + OIDC provider must trust the MEHO Keycloak issuer; no
+  service-account key material is ever used. New `GSM_WIF_AUDIENCE` /
+  `GSM_WIF_POOL_ID` / `GSM_WIF_PROVIDER_ID` / `GSM_WIF_SERVICE_ACCOUNT` /
+  `GSM_WIF_SUBJECT_TOKEN_TYPE` settings; the Helm surface lands in #2231.
+  (#2232)
+
 ### Added — GCP Secret Manager credential backend (Phase 1, SA-direct)
 
 - Resolve a target's `gsm:<project>/<secret>[#field]` `secret_ref` through

--- a/backend/src/meho_backplane/connectors/_shared/gsm_creds.py
+++ b/backend/src/meho_backplane/connectors/_shared/gsm_creds.py
@@ -1,7 +1,7 @@
 # SPDX-License-Identifier: Apache-2.0
 # Copyright (c) 2026 evoila Group
 
-"""GCP Secret Manager credential backend (SA-direct, #2230).
+"""GCP Secret Manager credential backend (SA-direct + WIF, #2230 / #2232).
 
 The second :class:`~meho_backplane.connectors._shared.credential_backend.CredentialBackend`
 after Vault — registered under kind ``"gsm"`` on the #2229 resolver seam so
@@ -24,11 +24,32 @@ service-account JSON key ever enters the flow, honouring the consumer
 org's ``constraints/iam.disableServiceAccountKeyCreation`` policy the same
 way the GCloud connector does: by never using key material at all.
 
-Per-operator GCP federation (STS token exchange, #2232) is **out of
-scope** here. MEHO's own audit attribution is unaffected — the audit row
+Per-operator GCP federation — Workload Identity Federation (#2232)
+=================================================================
+
+Phase 2 adds a **per-operator** read path alongside the SA-direct one.
+When Workload Identity Federation is configured (``GSM_WIF_AUDIENCE`` set),
+a ``gsm:`` read exchanges the calling operator's validated Keycloak JWT
+(``operator.raw_jwt``) at ``sts.googleapis.com`` for a short-lived
+federated token via google-auth ``identity_pool.Credentials``, optionally
+impersonates a target SA, then does the one ``secretmanager.versions.access``
+and discards the token. This restores *GCP-layer* per-operator attribution
+— GCP's own audit log names the operator, not MEHO's platform SA — mirroring
+the Vault ``vault_client_for_operator`` JIT contract (``auth/vault.py:198``):
+a fresh credential per operation, no caching across requests.
+
+Selection is per-read: WIF configured ⇒ the operator path; WIF unconfigured
+⇒ the Phase-1 SA-direct ADC path, unchanged (no behaviour change for
+Phase-1 installs). The shared loader's empty-``raw_jwt`` fail-closed guard
+(``vault_creds._resolve_and_load``) runs *before* dispatch, so a
+system-initiated call (``raw_jwt=""`` — health probe, scheduler) never
+reaches the WIF exchange: there is no operator JWT to exchange, so it fails
+closed upstream. That guard is load-bearing for the WIF path.
+
+MEHO's own audit attribution is unchanged in both paths — the audit row
 still carries the Keycloak ``sub`` (the policy/audit seam is untouched by
-this backend). What Phase 1 does not yet have is *GCP-layer* per-operator
-attribution: every GSM read is attributed to MEHO's SA, not the operator.
+this backend). Phase 1 alone lacks *GCP-layer* per-operator attribution;
+Phase 2's WIF path is what supplies it.
 
 Ref grammar and field selection
 ===============================
@@ -64,6 +85,7 @@ from __future__ import annotations
 
 import asyncio
 import json
+from dataclasses import dataclass
 from typing import TYPE_CHECKING, Any, Protocol
 
 import structlog
@@ -94,6 +116,20 @@ _IMPERSONATION_LIFETIME = 3600
 
 #: Default version alias when the ref pins no explicit version.
 _LATEST_VERSION = "latest"
+
+#: The GCP Security Token Service endpoint the WIF path exchanges the
+#: operator JWT at (#2232). Pinned explicitly rather than deriving from
+#: google-auth's ``token_url`` default so the exchange target is auditable
+#: in this module and stable across google-auth versions.
+_STS_TOKEN_URL = "https://sts.googleapis.com/v1/token"
+
+#: Template for the IAM Credentials ``generateAccessToken`` URL google-auth's
+#: external-account flow calls to impersonate the target SA after the STS
+#: exchange. ``projects/-`` lets IAM resolve the SA's project from its email.
+_IAM_IMPERSONATION_URL_TEMPLATE = (
+    "https://iamcredentials.googleapis.com/v1/projects/-/serviceAccounts/"
+    "{service_account}:generateAccessToken"
+)
 
 
 class GcpSecretManagerReadError(Exception):
@@ -213,23 +249,132 @@ def _decode_payload(
     return {field: decoded[field]}
 
 
+class _OperatorJwtSubjectTokenSupplier:
+    """Return the operator's Keycloak JWT as the WIF STS subject token.
+
+    Implements the google-auth
+    ``google.auth.identity_pool.SubjectTokenSupplier`` interface structurally
+    (google-auth duck-types the supplier — it only calls
+    :meth:`get_subject_token` — so no import of the abstract base is needed
+    and the google imports stay lazy). One supplier is built per read and
+    holds exactly that read's operator JWT, so the exchanged subject token is
+    always the calling operator's — never a cached or shared token. The
+    supplier itself does no caching, matching the JIT contract: identity-pool
+    credentials do not cache the subject token, and a fresh
+    ``identity_pool.Credentials`` is built per read.
+    """
+
+    def __init__(self, operator_jwt: str) -> None:
+        self._operator_jwt = operator_jwt
+
+    def get_subject_token(self, context: Any, request: Any) -> str:
+        """Return the operator JWT (the ``context`` / ``request`` are unused).
+
+        ``context`` (audience + subject-token type) and ``request`` (an HTTP
+        transport) are part of the google-auth supplier signature but not
+        needed here: the subject token is the already-validated bearer JWT the
+        operator presented, forwarded bit-for-bit like the Vault OIDC login.
+        """
+        return self._operator_jwt
+
+
+@dataclass(frozen=True)
+class _WifConfig:
+    """Resolved Workload Identity Federation settings for the operator path.
+
+    Built from ``Settings`` by :func:`_resolve_wif_config`. ``audience`` is
+    the full WIF provider resource name google-auth's ``identity_pool``
+    consumes; ``pool_id`` / ``provider_id`` are the chart-facing
+    ``gsm.workloadIdentityFederation.{poolId,providerId}`` keys, checked for
+    consistency against the audience. ``service_account`` is the optional SA
+    to impersonate for the final read; empty ⇒ no impersonation.
+    """
+
+    audience: str
+    pool_id: str
+    provider_id: str
+    service_account: str
+    subject_token_type: str
+
+
+def _resolve_wif_config() -> _WifConfig | None:
+    """Return the WIF config when configured, else ``None`` (SA-direct).
+
+    WIF is "configured" when ``gsm_wif_audience`` is non-empty — that is the
+    single value google-auth strictly needs (it encodes the pool + provider).
+    An install that leaves it blank cleanly uses the Phase-1 SA-direct path,
+    so a Phase-1 deployment sees no behaviour change.
+    """
+    settings = get_settings()
+    audience = settings.gsm_wif_audience.strip()
+    if not audience:
+        return None
+    return _WifConfig(
+        audience=audience,
+        pool_id=settings.gsm_wif_pool_id.strip(),
+        provider_id=settings.gsm_wif_provider_id.strip(),
+        service_account=settings.gsm_wif_service_account.strip(),
+        subject_token_type=settings.gsm_wif_subject_token_type.strip(),
+    )
+
+
+def _assert_wif_audience_consistent(wif_config: _WifConfig, target_name: str) -> None:
+    """Fail closed when the declared pool / provider disagree with the audience.
+
+    ``gsm_wif_audience`` is the value google-auth actually uses; ``pool_id`` /
+    ``provider_id`` are the operator-facing chart keys. When either is set it
+    must appear in the audience resource name at its exact segment — a
+    mismatch is a copy-paste misconfiguration that would silently federate
+    against the wrong pool, so it raises :class:`GcpSecretManagerReadError`
+    naming the target rather than proceeding. Both empty ⇒ no check (the
+    audience alone is authoritative).
+    """
+    audience = wif_config.audience
+    pool_marker = f"/workloadIdentityPools/{wif_config.pool_id}/providers/"
+    if wif_config.pool_id and pool_marker not in audience:
+        raise GcpSecretManagerReadError(
+            f"gsm WIF config for target {target_name!r} is inconsistent: "
+            f"GSM_WIF_POOL_ID={wif_config.pool_id!r} is not the pool named in "
+            "GSM_WIF_AUDIENCE; the audience and the declared pool must match"
+        )
+    if wif_config.provider_id and not audience.endswith(f"/providers/{wif_config.provider_id}"):
+        raise GcpSecretManagerReadError(
+            f"gsm WIF config for target {target_name!r} is inconsistent: "
+            f"GSM_WIF_PROVIDER_ID={wif_config.provider_id!r} is not the provider named "
+            "in GSM_WIF_AUDIENCE; the audience and the declared provider must match"
+        )
+
+
 class GcpSecretManagerBackend:
     """Resolve ``gsm:`` refs via GCP Secret Manager under SA-direct ADC.
 
     Registered under kind ``"gsm"``. Stateless apart from the injected test
     seams, so a single shared instance serves every read.
 
-    The two injection points keep the unit tests off live GCP:
+    Selection is per-read (#2232): when Workload Identity Federation is
+    configured (``Settings.gsm_wif_audience`` set), the read runs under the
+    **operator's** identity — the operator JWT is exchanged at the GCP STS
+    for a short-lived federated token; otherwise the Phase-1 SA-direct ADC
+    path runs unchanged.
+
+    The injection points keep the unit tests off live GCP:
 
     * ``adc_loader`` replaces ``google.auth.default`` (returns
       ``(credentials, project)``), so a test supplies a fake ADC source.
     * ``client_factory`` replaces ``SecretManagerServiceClient`` (called
       with ``credentials=``), so a test returns a stub whose
       ``access_secret_version`` yields a canned payload without any RPC.
+    * ``wif_credentials_factory`` replaces the real
+      ``identity_pool.Credentials`` builder on the WIF path, so a test can
+      assert the built credentials reach the client and that a fresh one is
+      minted per read without a live STS exchange. ``None`` ⇒ the real
+      builder (:meth:`_build_wif_credentials`).
 
-    ``impersonate_sa`` overrides the settings-derived impersonation SA
-    (``None`` ⇒ read ``Settings.gsm_impersonate_sa`` at call time, matching
-    how ``vault_creds`` reads ``credential_backend`` per-call).
+    ``impersonate_sa`` overrides the settings-derived SA-direct impersonation
+    SA (``None`` ⇒ read ``Settings.gsm_impersonate_sa`` at call time, matching
+    how ``vault_creds`` reads ``credential_backend`` per-call). It applies to
+    the SA-direct path only; the WIF path's SA impersonation is driven by
+    ``Settings.gsm_wif_service_account``.
     """
 
     def __init__(
@@ -238,10 +383,12 @@ class GcpSecretManagerBackend:
         adc_loader: Callable[..., tuple[Any, Any]] | None = None,
         client_factory: Callable[..., Any] | None = None,
         impersonate_sa: str | None = None,
+        wif_credentials_factory: Callable[..., Any] | None = None,
     ) -> None:
         self._adc_loader = adc_loader
         self._client_factory = client_factory
         self._impersonate_sa = impersonate_sa
+        self._wif_credentials_factory = wif_credentials_factory
 
     async def load_secret_data(
         self,
@@ -253,19 +400,31 @@ class GcpSecretManagerBackend:
     ) -> dict[str, object]:
         """Read *secret_ref* from GCP Secret Manager and return its field dict.
 
-        ``operator`` is accepted for the
-        :class:`~meho_backplane.connectors._shared.credential_backend.CredentialBackend`
-        contract but not forwarded to GCP — Phase 1 reads under MEHO's own
-        ADC identity, not the operator's (per-operator GCP federation is
-        #2232). ``mount`` is a Vault-KV concept with no GSM analogue and is
-        ignored. The synchronous ``access_secret_version`` RPC runs off the
+        When Workload Identity Federation is configured (#2232), the read runs
+        under *operator*'s identity: ``operator.raw_jwt`` is exchanged at the
+        GCP STS for a short-lived federated token so GCP audits the read to
+        the operator. Otherwise Phase 1's SA-direct path reads under MEHO's
+        own ADC identity and ``operator`` is unused. The shared loader's
+        empty-``raw_jwt`` guard runs before dispatch, so an operator reaching
+        the WIF exchange always carries a JWT to exchange.
+
+        ``mount`` is a Vault-KV concept with no GSM analogue and is ignored.
+        The synchronous ``access_secret_version`` RPC (and the blocking
+        google-auth credential refresh / STS exchange it drives) runs off the
         event loop via ``asyncio.to_thread``, matching the hvac precedent in
         ``vault_creds``.
         """
         project, secret, version, field = _parse_gsm_ref(secret_ref, target_name=target_name)
+        wif_config = _resolve_wif_config()
 
         payload_bytes, resolved_name = await asyncio.to_thread(
-            self._access_sync, project, secret, version, target_name
+            self._access_sync,
+            project,
+            secret,
+            version,
+            target_name,
+            operator.raw_jwt,
+            wif_config,
         )
 
         secret_data = _decode_payload(
@@ -277,7 +436,8 @@ class GcpSecretManagerBackend:
         )
 
         # Non-secret attribution only: target / project / secret / the
-        # resolved version name / the requested field name. Never a value.
+        # resolved version name / the requested field name / which auth path
+        # ran (and, on WIF, the pool + provider). Never a value, never a token.
         _log.info(
             "gsm_secret_accessed",
             target=target_name,
@@ -285,6 +445,9 @@ class GcpSecretManagerBackend:
             secret_name=secret,
             version=resolved_name or version,
             field=field,
+            auth_path="wif" if wif_config is not None else "sa_direct",
+            wif_pool=wif_config.pool_id if wif_config is not None else None,
+            wif_provider=wif_config.provider_id if wif_config is not None else None,
         )
         return secret_data
 
@@ -293,21 +456,33 @@ class GcpSecretManagerBackend:
     # ------------------------------------------------------------------
 
     def _access_sync(
-        self, project: str, secret: str, version: str, target_name: str
+        self,
+        project: str,
+        secret: str,
+        version: str,
+        target_name: str,
+        operator_jwt: str,
+        wif_config: _WifConfig | None,
     ) -> tuple[bytes, str]:
         """Build credentials, access the secret version, return ``(bytes, name)``.
 
         Runs in a thread (``asyncio.to_thread``) because the google-cloud
-        client and ``google.auth`` credential refresh both perform blocking
-        transport under the hood. Access-denied, not-found, and transport
-        failures are re-raised as :class:`GcpSecretManagerReadError` with an
-        actionable message naming project / secret (AC #5) — not a bare
-        ``google.api_core`` exception.
+        client and ``google.auth`` credential refresh — including the WIF STS
+        exchange — all perform blocking transport under the hood. Credential
+        selection is per-call: *wif_config* present ⇒ the operator-context WIF
+        path (a fresh federated credential built from *operator_jwt*, never
+        cached across reads); ``None`` ⇒ the Phase-1 SA-direct ADC path.
+        Access-denied, not-found, and transport failures are re-raised as
+        :class:`GcpSecretManagerReadError` with an actionable message naming
+        project / secret (AC #5) — not a bare ``google.api_core`` exception.
         """
         import google.api_core.exceptions as gcp_exceptions
         from google.cloud import secretmanager
 
-        credentials = self._build_credentials(target_name)
+        if wif_config is not None:
+            credentials = self._build_wif_credentials(operator_jwt, target_name, wif_config)
+        else:
+            credentials = self._build_credentials(target_name)
         factory = self._client_factory or secretmanager.SecretManagerServiceClient
         client = factory(credentials=credentials)
 
@@ -380,6 +555,70 @@ class GcpSecretManagerBackend:
             target_scopes=[_GCP_CLOUD_PLATFORM_SCOPE],
             lifetime=_IMPERSONATION_LIFETIME,
         )
+
+    def _build_wif_credentials(
+        self, operator_jwt: str, target_name: str, wif_config: _WifConfig
+    ) -> Any:
+        """Build a per-operator WIF (external-account) credential (#2232).
+
+        Constructs ``google.auth.identity_pool.Credentials`` that exchange
+        *operator_jwt* at the GCP STS (``sts.googleapis.com``) for a
+        short-lived federated token against the configured Workload Identity
+        Pool + OIDC provider, optionally impersonating
+        ``wif_config.service_account`` for the final read. A **fresh**
+        credential is built on every call — never stored on the instance — so
+        the operator-scoped token is minted per operation and discarded when
+        the credential goes out of scope, matching the Vault JIT contract.
+
+        Fails closed with :class:`GcpSecretManagerReadError` when the operator
+        JWT is empty (defence in depth behind the shared loader's pre-dispatch
+        guard), when the declared pool / provider disagree with the audience
+        (a copy-paste misconfiguration), or when google-auth rejects the
+        external-account config — never a bare ``google.auth`` exception.
+        """
+        if not operator_jwt:
+            raise GcpSecretManagerReadError(
+                f"WIF operator-context read for target {target_name!r} has no operator "
+                "JWT to exchange; a system-initiated call cannot federate to GCP "
+                "(the empty-raw_jwt guard should have failed this upstream)"
+            )
+        _assert_wif_audience_consistent(wif_config, target_name)
+
+        service_account = wif_config.service_account
+        impersonation_url = (
+            _IAM_IMPERSONATION_URL_TEMPLATE.format(service_account=service_account)
+            if service_account
+            else None
+        )
+
+        if self._wif_credentials_factory is not None:
+            return self._wif_credentials_factory(
+                operator_jwt=operator_jwt,
+                wif_config=wif_config,
+                service_account_impersonation_url=impersonation_url,
+                target_name=target_name,
+            )
+
+        from google.auth import exceptions as auth_exceptions
+        from google.auth import identity_pool
+
+        supplier = _OperatorJwtSubjectTokenSupplier(operator_jwt)
+        try:
+            return identity_pool.Credentials(  # type: ignore[no-untyped-call]
+                audience=wif_config.audience,
+                subject_token_type=wif_config.subject_token_type,
+                token_url=_STS_TOKEN_URL,
+                subject_token_supplier=supplier,
+                service_account_impersonation_url=impersonation_url,
+                scopes=[_GCP_CLOUD_PLATFORM_SCOPE],
+            )
+        except (ValueError, auth_exceptions.GoogleAuthError) as exc:
+            raise GcpSecretManagerReadError(
+                f"gsm WIF config for target {target_name!r} is invalid: google-auth "
+                f"rejected the external-account credential ({type(exc).__name__}); "
+                "check GSM_WIF_AUDIENCE, GSM_WIF_SUBJECT_TOKEN_TYPE, and "
+                "GSM_WIF_SERVICE_ACCOUNT"
+            ) from exc
 
     def _resolve_impersonate_sa(self) -> str:
         """The impersonation SA — the constructor override or the setting.

--- a/backend/src/meho_backplane/settings.py
+++ b/backend/src/meho_backplane/settings.py
@@ -918,6 +918,34 @@ class Settings(BaseModel):
     # reusing the GcloudConnector impersonation chain. No effect on Vault
     # installs. Chart wiring lands with the GSM Helm surface in #2231.
     gsm_impersonate_sa: str = Field(default="")
+    # #2232 (Initiative #2227) — GCP Workload Identity Federation (WIF) for
+    # the GSM credential backend's per-operator path. When
+    # ``gsm_wif_audience`` is set, a ``gsm:`` read exchanges the operator's
+    # Keycloak JWT at ``sts.googleapis.com`` for a short-lived federated
+    # token (google-auth ``identity_pool.Credentials``) so GCP's own audit
+    # attributes ``secretmanager.versions.access`` to the operator — mirroring
+    # the Vault ``vault_client_for_operator`` JIT contract. Empty (the
+    # default) leaves the Phase-1 SA-direct ADC path untouched (no behaviour
+    # change for Phase-1 installs). ``gsm_wif_audience`` is the full WIF
+    # provider resource name google-auth consumes (``//iam.googleapis.com/
+    # projects/<number>/locations/global/workloadIdentityPools/<pool>/
+    # providers/<provider>``); it already encodes the pool + provider.
+    # ``gsm_wif_pool_id`` /
+    # ``gsm_wif_provider_id`` are the ``gsm.workloadIdentityFederation.{poolId,providerId}``
+    # chart keys, threaded through for a fail-closed consistency check
+    # against the audience (a copy-paste mismatch fails the read with an
+    # actionable error) and for non-secret log attribution.
+    # ``gsm_wif_service_account`` optionally impersonates a target SA for the
+    # final read (reusing the Phase-1 impersonation intent at the STS layer);
+    # empty skips impersonation. ``gsm_wif_subject_token_type`` is the STS
+    # subject-token type for a Keycloak OIDC JWT. Chart wiring lands in #2231.
+    gsm_wif_audience: str = Field(default="")
+    gsm_wif_pool_id: str = Field(default="")
+    gsm_wif_provider_id: str = Field(default="")
+    gsm_wif_service_account: str = Field(default="")
+    gsm_wif_subject_token_type: str = Field(
+        default="urn:ietf:params:oauth:token-type:jwt", min_length=1
+    )
     database_url: str = Field(min_length=1)
     database_pool_size: int = Field(default=10, gt=0)
     database_pool_timeout: float = Field(default=30.0, gt=0)
@@ -1471,6 +1499,19 @@ def get_settings() -> Settings:
         # Optional impersonation SA for the GSM credential backend (#2230).
         # Empty/whitespace-only ⇒ direct-ADC read (no impersonation).
         gsm_impersonate_sa=os.environ.get("GSM_IMPERSONATE_SA", "").strip(),
+        # GSM Workload Identity Federation (#2232). All optional; an empty
+        # ``GSM_WIF_AUDIENCE`` (the default) leaves the Phase-1 SA-direct path
+        # in force. ``GSM_WIF_SUBJECT_TOKEN_TYPE`` falls back to the OIDC-JWT
+        # type so a blank chart value never yields an empty (``min_length=1``
+        # rejected) token type.
+        gsm_wif_audience=os.environ.get("GSM_WIF_AUDIENCE", "").strip(),
+        gsm_wif_pool_id=os.environ.get("GSM_WIF_POOL_ID", "").strip(),
+        gsm_wif_provider_id=os.environ.get("GSM_WIF_PROVIDER_ID", "").strip(),
+        gsm_wif_service_account=os.environ.get("GSM_WIF_SERVICE_ACCOUNT", "").strip(),
+        gsm_wif_subject_token_type=(
+            os.environ.get("GSM_WIF_SUBJECT_TOKEN_TYPE", "").strip()
+            or "urn:ietf:params:oauth:token-type:jwt"
+        ),
         database_url=os.environ["DATABASE_URL"],
         database_pool_size=int(os.environ.get("DATABASE_POOL_SIZE", "10")),
         database_pool_timeout=float(

--- a/backend/tests/test_connectors_gsm_creds.py
+++ b/backend/tests/test_connectors_gsm_creds.py
@@ -29,6 +29,7 @@ What these cover:
 
 from __future__ import annotations
 
+import json
 from collections.abc import Iterator
 from dataclasses import dataclass
 from typing import Any
@@ -42,6 +43,7 @@ from meho_backplane.connectors._shared import credential_backend as cb
 from meho_backplane.connectors._shared.gsm_creds import (
     GcpSecretManagerBackend,
     GcpSecretManagerReadError,
+    _WifConfig,
 )
 from meho_backplane.connectors._shared.vault_creds import (
     load_basic_credentials,
@@ -142,8 +144,6 @@ def _adc_loader_returning(creds: Any):
 
 
 def _json_secret(**fields: str) -> bytes:
-    import json
-
     return json.dumps(fields).encode("utf-8")
 
 
@@ -568,3 +568,285 @@ async def test_dispatch_gsm_ref_end_to_end_via_load_basic_credentials(
     creds = await load_basic_credentials(target, _make_operator())
 
     assert creds == {"username": _CANARY_USERNAME, "password": _CANARY_PASSWORD}
+
+
+# ---------------------------------------------------------------------------
+# Workload Identity Federation (per-operator, #2232)
+# ---------------------------------------------------------------------------
+
+_WIF_AUDIENCE = (
+    "//iam.googleapis.com/projects/123456/locations/global/"
+    "workloadIdentityPools/meho-pool/providers/keycloak"
+)
+_OPERATOR_JWT = "operator.keycloak.jwt-canary"
+
+
+def _wif_config(
+    *,
+    audience: str = _WIF_AUDIENCE,
+    pool_id: str = "meho-pool",
+    provider_id: str = "keycloak",
+    service_account: str = "",
+    subject_token_type: str = "urn:ietf:params:oauth:token-type:jwt",
+) -> _WifConfig:
+    return _WifConfig(
+        audience=audience,
+        pool_id=pool_id,
+        provider_id=provider_id,
+        service_account=service_account,
+        subject_token_type=subject_token_type,
+    )
+
+
+class _StsResponse:
+    """A ``google.auth.transport.Response``-shaped STS reply."""
+
+    def __init__(self, body: dict[str, Any]) -> None:
+        self.status = 200
+        self.data = json.dumps(body).encode("utf-8")
+        self.headers: dict[str, str] = {}
+
+
+def _set_wif_env(monkeypatch: pytest.MonkeyPatch, **overrides: str) -> None:
+    """Pin the GSM_WIF_* env the settings factory reads, then clear the cache."""
+    env = {
+        "GSM_WIF_AUDIENCE": _WIF_AUDIENCE,
+        "GSM_WIF_POOL_ID": "meho-pool",
+        "GSM_WIF_PROVIDER_ID": "keycloak",
+    }
+    env.update(overrides)
+    for key, value in env.items():
+        if value == "":
+            monkeypatch.delenv(key, raising=False)
+        else:
+            monkeypatch.setenv(key, value)
+    get_settings.cache_clear()
+
+
+def _wif_factory_returning(sentinel: Any) -> Any:
+    """A ``wif_credentials_factory`` double recording each call's kwargs."""
+    calls: list[dict[str, Any]] = []
+
+    def factory(**kwargs: Any) -> Any:
+        calls.append(kwargs)
+        return sentinel
+
+    factory.calls = calls  # type: ignore[attr-defined]
+    return factory
+
+
+async def test_wif_builds_identity_pool_creds_and_exchanges_operator_jwt() -> None:
+    """AC1: a WIF read builds identity_pool.Credentials from the operator JWT
+    and does the STS exchange (STS endpoint mocked — no live GCP)."""
+    backend = GcpSecretManagerBackend()
+    creds = backend._build_wif_credentials(_OPERATOR_JWT, "gcp-lab-01", _wif_config())
+
+    from google.auth import identity_pool
+
+    assert isinstance(creds, identity_pool.Credentials)
+    assert creds._audience == _WIF_AUDIENCE
+
+    captured: dict[str, Any] = {}
+
+    def fake_request(url: str, method: str = "GET", body: Any = None, **_: Any) -> _StsResponse:
+        captured["url"] = url
+        captured["body"] = body
+        return _StsResponse(
+            {
+                "access_token": "federated-token-xyz",
+                "issued_token_type": "urn:ietf:params:oauth:token-type:access_token",
+                "token_type": "Bearer",
+                "expires_in": 3600,
+            }
+        )
+
+    creds.refresh(fake_request)
+
+    assert creds.token == "federated-token-xyz"
+    assert captured["url"] == "https://sts.googleapis.com/v1/token"
+    # The operator's JWT is the subject token in the STS exchange body.
+    assert _OPERATOR_JWT.encode("utf-8") in captured["body"]
+
+
+async def test_wif_selected_when_audience_configured(monkeypatch: pytest.MonkeyPatch) -> None:
+    """AC4: an install with WIF configured routes the operator-context read
+    through the WIF path, not the SA-direct ADC path."""
+    _set_wif_env(monkeypatch)
+    sentinel_creds = object()
+    wif_factory = _wif_factory_returning(sentinel_creds)
+    client = _FakeClient(payload=_json_secret(username=_CANARY_USERNAME, password=_CANARY_PASSWORD))
+    adc = _adc_loader_returning(_SourceCreds())
+    backend = GcpSecretManagerBackend(
+        adc_loader=adc,
+        client_factory=_factory_for(client),
+        wif_credentials_factory=wif_factory,
+    )
+
+    data = await backend.load_secret_data(
+        "my-project/db-creds", _make_operator(_OPERATOR_JWT), target_name="gcp-lab-01"
+    )
+
+    assert data == {"username": _CANARY_USERNAME, "password": _CANARY_PASSWORD}
+    # The WIF credential (not the ADC source) reached the client.
+    assert client.credentials is sentinel_creds
+    # The operator JWT was forwarded to the WIF builder; ADC was untouched.
+    assert wif_factory.calls[-1]["operator_jwt"] == _OPERATOR_JWT  # type: ignore[attr-defined]
+    assert adc.calls == []  # type: ignore[attr-defined]
+
+
+async def test_wif_credential_minted_fresh_per_read(monkeypatch: pytest.MonkeyPatch) -> None:
+    """AC2: a fresh federated credential is built per read — no cross-request
+    caching of the operator-scoped credential."""
+    _set_wif_env(monkeypatch)
+    built: list[object] = []
+
+    def wif_factory(**_: Any) -> object:
+        cred = object()
+        built.append(cred)
+        return cred
+
+    client = _FakeClient(payload=_json_secret(k="v"))
+    backend = GcpSecretManagerBackend(
+        client_factory=_factory_for(client),
+        wif_credentials_factory=wif_factory,
+    )
+
+    await backend.load_secret_data("p/s", _make_operator(_OPERATOR_JWT), target_name="t")
+    first = client.credentials
+    await backend.load_secret_data("p/s", _make_operator(_OPERATOR_JWT), target_name="t")
+    second = client.credentials
+
+    # Two reads → two distinct credential objects; nothing cached on the backend.
+    assert len(built) == 2
+    assert first is not second
+    assert not hasattr(backend, "_cached_wif_credentials")
+
+
+async def test_wif_impersonation_url_set_when_sa_configured() -> None:
+    """AC3: SA impersonation is applied when a service account is configured."""
+    backend = GcpSecretManagerBackend()
+    creds = backend._build_wif_credentials(
+        _OPERATOR_JWT,
+        "gcp-lab-01",
+        _wif_config(service_account="reader@my-project.iam.gserviceaccount.com"),
+    )
+
+    assert creds._service_account_impersonation_url == (
+        "https://iamcredentials.googleapis.com/v1/projects/-/serviceAccounts/"
+        "reader@my-project.iam.gserviceaccount.com:generateAccessToken"
+    )
+
+
+async def test_wif_impersonation_skipped_when_sa_absent() -> None:
+    """AC3: SA impersonation is skipped when no service account is configured."""
+    backend = GcpSecretManagerBackend()
+    creds = backend._build_wif_credentials(_OPERATOR_JWT, "gcp-lab-01", _wif_config())
+
+    assert creds._service_account_impersonation_url is None
+
+
+async def test_sa_direct_used_when_wif_not_configured(monkeypatch: pytest.MonkeyPatch) -> None:
+    """AC4: an install without WIF configured cleanly uses the Phase-1
+    SA-direct ADC path (no behaviour change)."""
+    _set_wif_env(monkeypatch, GSM_WIF_AUDIENCE="", GSM_WIF_POOL_ID="", GSM_WIF_PROVIDER_ID="")
+    source = _SourceCreds()
+    adc = _adc_loader_returning(source)
+    client = _FakeClient(payload=_json_secret(k="v"))
+    wif_factory = _wif_factory_returning(object())
+    backend = GcpSecretManagerBackend(
+        adc_loader=adc,
+        client_factory=_factory_for(client),
+        impersonate_sa="",
+        wif_credentials_factory=wif_factory,
+    )
+
+    await backend.load_secret_data("p/s", _make_operator(_OPERATOR_JWT), target_name="t")
+
+    # SA-direct ADC ran; the WIF builder was never called.
+    assert client.credentials is source
+    assert adc.calls  # type: ignore[attr-defined]
+    assert wif_factory.calls == []  # type: ignore[attr-defined]
+
+
+@pytest.mark.parametrize(
+    ("pool_id", "provider_id"),
+    [
+        ("wrong-pool", "keycloak"),
+        ("meho-pool", "wrong-provider"),
+    ],
+)
+async def test_wif_audience_pool_provider_mismatch_fails_closed(
+    pool_id: str, provider_id: str
+) -> None:
+    """AC4: a declared pool / provider that disagrees with the audience fails
+    closed with an actionable error."""
+    backend = GcpSecretManagerBackend()
+
+    with pytest.raises(GcpSecretManagerReadError) as exc:
+        backend._build_wif_credentials(
+            _OPERATOR_JWT,
+            "gcp-lab-01",
+            _wif_config(pool_id=pool_id, provider_id=provider_id),
+        )
+
+    msg = str(exc.value)
+    assert "gcp-lab-01" in msg
+    assert "inconsistent" in msg
+
+
+async def test_wif_empty_operator_jwt_fails_closed() -> None:
+    """The WIF path fails closed on an empty operator JWT (defence in depth
+    behind the shared loader's pre-dispatch guard)."""
+    backend = GcpSecretManagerBackend()
+
+    with pytest.raises(GcpSecretManagerReadError) as exc:
+        backend._build_wif_credentials("", "gcp-lab-01", _wif_config())
+
+    assert "no operator JWT" in str(exc.value)
+
+
+async def test_wif_log_event_carries_auth_path_and_no_secret(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """The WIF read logs auth_path/pool/provider attribution — never a token."""
+    _set_wif_env(monkeypatch)
+    client = _FakeClient(payload=_json_secret(username=_CANARY_USERNAME, password=_CANARY_PASSWORD))
+    backend = GcpSecretManagerBackend(
+        client_factory=_factory_for(client),
+        wif_credentials_factory=_wif_factory_returning(object()),
+    )
+
+    with capture_logs() as captured:
+        await backend.load_secret_data(
+            "my-project/db-creds", _make_operator(_OPERATOR_JWT), target_name="gcp-lab-01"
+        )
+
+    blob = repr(captured)
+    assert _OPERATOR_JWT not in blob
+    assert _CANARY_PASSWORD not in blob
+    event = next(e for e in captured if e["event"] == "gsm_secret_accessed")
+    assert event["auth_path"] == "wif"
+    assert event["wif_pool"] == "meho-pool"
+    assert event["wif_provider"] == "keycloak"
+
+
+async def test_wif_end_to_end_via_shared_loader(monkeypatch: pytest.MonkeyPatch) -> None:
+    """AC5: a gsm: ref with WIF configured resolves through the shared loader
+    end-to-end under the operator path."""
+    _set_wif_env(monkeypatch)
+    client = _FakeClient(payload=_json_secret(username=_CANARY_USERNAME, password=_CANARY_PASSWORD))
+    sentinel = object()
+    fake_backend = GcpSecretManagerBackend(
+        client_factory=_factory_for(client),
+        wif_credentials_factory=_wif_factory_returning(sentinel),
+    )
+    original = cb.CREDENTIAL_BACKEND_REGISTRY["gsm"]
+    cb.CREDENTIAL_BACKEND_REGISTRY["gsm"] = fake_backend
+    try:
+        target = _Target(secret_ref="gsm:my-project/db-creds")
+        creds = await load_basic_credentials(target, _make_operator(_OPERATOR_JWT))
+    finally:
+        cb.CREDENTIAL_BACKEND_REGISTRY["gsm"] = original
+
+    assert creds == {"username": _CANARY_USERNAME, "password": _CANARY_PASSWORD}
+    assert client.credentials is sentinel

--- a/backend/tests/test_settings.py
+++ b/backend/tests/test_settings.py
@@ -462,3 +462,77 @@ def test_gsm_impersonate_sa_reads_and_strips_env(
         assert get_settings().gsm_impersonate_sa == "reader@proj.iam.gserviceaccount.com"
     finally:
         get_settings.cache_clear()
+
+
+# ---------------------------------------------------------------------------
+# #2232 (Initiative #2227) — GSM_WIF_* Workload Identity Federation knobs
+# ---------------------------------------------------------------------------
+
+
+def test_gsm_wif_defaults_are_empty_or_oidc_jwt(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """Unset GSM_WIF_* ⇒ empty audience/pool/provider/SA (SA-direct path) and
+    the OIDC-JWT subject-token type default."""
+    _base_env(monkeypatch)
+    for key in (
+        "GSM_WIF_AUDIENCE",
+        "GSM_WIF_POOL_ID",
+        "GSM_WIF_PROVIDER_ID",
+        "GSM_WIF_SERVICE_ACCOUNT",
+        "GSM_WIF_SUBJECT_TOKEN_TYPE",
+    ):
+        monkeypatch.delenv(key, raising=False)
+    get_settings.cache_clear()
+    try:
+        settings = get_settings()
+        assert settings.gsm_wif_audience == ""
+        assert settings.gsm_wif_pool_id == ""
+        assert settings.gsm_wif_provider_id == ""
+        assert settings.gsm_wif_service_account == ""
+        assert settings.gsm_wif_subject_token_type == "urn:ietf:params:oauth:token-type:jwt"
+    finally:
+        get_settings.cache_clear()
+
+
+def test_gsm_wif_reads_and_strips_env(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """Set GSM_WIF_* values are read and surrounding whitespace stripped."""
+    _base_env(monkeypatch)
+    monkeypatch.setenv(
+        "GSM_WIF_AUDIENCE",
+        "  //iam.googleapis.com/projects/123/locations/global/"
+        "workloadIdentityPools/meho-pool/providers/keycloak \n",
+    )
+    monkeypatch.setenv("GSM_WIF_POOL_ID", " meho-pool ")
+    monkeypatch.setenv("GSM_WIF_PROVIDER_ID", " keycloak ")
+    monkeypatch.setenv("GSM_WIF_SERVICE_ACCOUNT", " reader@proj.iam.gserviceaccount.com ")
+    monkeypatch.setenv("GSM_WIF_SUBJECT_TOKEN_TYPE", " urn:ietf:params:oauth:token-type:id_token ")
+    get_settings.cache_clear()
+    try:
+        settings = get_settings()
+        assert settings.gsm_wif_audience == (
+            "//iam.googleapis.com/projects/123/locations/global/"
+            "workloadIdentityPools/meho-pool/providers/keycloak"
+        )
+        assert settings.gsm_wif_pool_id == "meho-pool"
+        assert settings.gsm_wif_provider_id == "keycloak"
+        assert settings.gsm_wif_service_account == "reader@proj.iam.gserviceaccount.com"
+        assert settings.gsm_wif_subject_token_type == "urn:ietf:params:oauth:token-type:id_token"
+    finally:
+        get_settings.cache_clear()
+
+
+def test_gsm_wif_subject_token_type_blank_falls_back_to_jwt(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """A blank GSM_WIF_SUBJECT_TOKEN_TYPE falls back to the OIDC-JWT type
+    rather than an empty (min_length=1 rejected) value."""
+    _base_env(monkeypatch)
+    monkeypatch.setenv("GSM_WIF_SUBJECT_TOKEN_TYPE", "   ")
+    get_settings.cache_clear()
+    try:
+        assert get_settings().gsm_wif_subject_token_type == "urn:ietf:params:oauth:token-type:jwt"
+    finally:
+        get_settings.cache_clear()

--- a/docs/codebase/connectors-shared-vault-creds.md
+++ b/docs/codebase/connectors-shared-vault-creds.md
@@ -252,19 +252,60 @@ it runs off the event loop via `asyncio.to_thread` (the hvac precedent).
 The structlog `gsm_secret_accessed` event carries only `target` /
 `project` / `secret_name` / resolved `version` / `field` name.
 
+**Per-operator path — Workload Identity Federation (Phase 2, #2232).**
+When `GSM_WIF_AUDIENCE` is set, a `gsm:` read runs under the **operator's**
+identity instead of MEHO's SA. The backend builds a fresh
+`google.auth.identity_pool.Credentials` (external-account) per read whose
+subject-token supplier returns `operator.raw_jwt`; google-auth exchanges
+that JWT at `https://sts.googleapis.com/v1/token` for a short-lived
+federated token against the configured Workload Identity Pool + OIDC
+provider, optionally impersonates `GSM_WIF_SERVICE_ACCOUNT` (via the IAM
+`generateAccessToken` URL) for the final read, and the token is discarded
+when the credential goes out of scope. This restores *GCP-layer*
+per-operator attribution — GCP's audit log names the operator — mirroring
+the Vault `vault_client_for_operator` JIT contract (`auth/vault.py:198`): a
+fresh credential per operation, never cached across requests. Selection is
+per-read: WIF configured ⇒ operator path; unconfigured ⇒ the Phase-1
+SA-direct path, unchanged (no behaviour change for Phase-1 installs).
+
+The settings (`GSM_WIF_*`, #2231's chart keys map onto them):
+
+- `GSM_WIF_AUDIENCE` — the full WIF provider resource name google-auth
+  consumes, `//iam.googleapis.com/projects/<number>/locations/global/workloadIdentityPools/<pool>/providers/<provider>`.
+  Non-empty ⇒ WIF enabled (the selection predicate).
+- `GSM_WIF_POOL_ID` / `GSM_WIF_PROVIDER_ID` — the operator-facing
+  `gsm.workloadIdentityFederation.{poolId,providerId}` chart keys. Checked
+  for consistency against the audience (a copy-paste mismatch fails the
+  read closed) and logged for non-secret attribution.
+- `GSM_WIF_SERVICE_ACCOUNT` — optional SA to impersonate; empty ⇒ no
+  impersonation.
+- `GSM_WIF_SUBJECT_TOKEN_TYPE` — STS subject-token type; defaults to
+  `urn:ietf:params:oauth:token-type:jwt` (Keycloak OIDC JWT).
+
+**GCP-side prerequisite.** The Workload Identity Pool + OIDC provider must
+be created out-of-band and configured to **trust the MEHO Keycloak
+issuer** (the provider's issuer URI = the Keycloak realm issuer, audience =
+the MEHO client). The impersonated SA (when set) must grant the pool
+principal `roles/iam.workloadIdentityUser`, and the SA (or the pool
+principal directly) must hold `roles/secretmanager.secretAccessor` on the
+secret. MEHO never creates key material — the federation is keyless.
+
 **Operator-JWT guard interaction.** The shared loader's empty-`raw_jwt`
 fail-closed guard (`_resolve_and_load`) still runs before dispatch, so a
-system-initiated call (`raw_jwt=""`) cannot resolve a `gsm:` ref either —
-identical to Vault today. Phase 1 deliberately keeps that guard rather than
-relaxing it for the deployment-identity backend; a future change that
-needs system-context GSM reads would move the guard into
-`VaultCredentialBackend`.
+system-initiated call (`raw_jwt=""` — health probe, scheduler) cannot
+resolve a `gsm:` ref: there is no operator JWT to exchange, so the WIF
+exchange is never reached and the call fails closed upstream. That guard is
+**load-bearing** for the WIF path; the backend also fails closed on an
+empty JWT as defence in depth. MEHO's own audit attribution is unchanged in
+both paths (the audit row carries the Keycloak `sub`).
 
 **Test seams.** The backend takes injectable `adc_loader` (replaces
-`google.auth.default`) and `client_factory` (replaces
-`SecretManagerServiceClient`) so the unit suite drives parse / decode /
-impersonation / error / no-secret-in-logs behaviour with a canned payload
-and no live GCP (`tests/test_connectors_gsm_creds.py`).
+`google.auth.default`), `client_factory` (replaces
+`SecretManagerServiceClient`), and `wif_credentials_factory` (replaces the
+real `identity_pool.Credentials` builder) so the unit suite drives parse /
+decode / impersonation / WIF-selection / STS-exchange / error /
+no-secret-in-logs behaviour with a canned payload and a mocked STS endpoint
+— no live GCP (`tests/test_connectors_gsm_creds.py`).
 
 ## Dependencies
 
@@ -282,9 +323,14 @@ and no live GCP (`tests/test_connectors_gsm_creds.py`).
   `SecretManagerServiceClient.access_secret_version(name=...)` →
   `response.payload.data` (bytes). Synchronous; wrapped in
   `asyncio.to_thread`.
-- **`google-auth`** (already a dep) — `google.auth.default()` for the ADC
+- **`google-auth`** (2.55.1 resolved) — `google.auth.default()` for the ADC
   source and `google.auth.impersonated_credentials.Credentials` for the
-  optional SA impersonation the `gsm` backend reuses from `GcloudConnector`.
+  optional SA-direct impersonation the `gsm` backend reuses from
+  `GcloudConnector`. The WIF path (#2232) uses
+  `google.auth.identity_pool.Credentials` (external-account) with a
+  duck-typed `subject_token_supplier` returning `operator.raw_jwt`,
+  `service_account_impersonation_url` for the optional target-SA
+  impersonation, and `token_url=https://sts.googleapis.com/v1/token`.
 
 ## Known issues
 


### PR DESCRIPTION
## Summary
- Adds a **per-operator** read path to the `gsm` credential backend via Keycloak→GCP-STS Workload Identity Federation, alongside the Phase-1 SA-direct path (#2230). When `GSM_WIF_AUDIENCE` is set, a `gsm:` read exchanges the operator's Keycloak JWT (`operator.raw_jwt`) at `sts.googleapis.com` for a short-lived federated token (google-auth `identity_pool.Credentials`), optionally impersonates `GSM_WIF_SERVICE_ACCOUNT`, does the one `secretmanager.versions.access`, and discards the token — restoring GCP-layer per-operator attribution and mirroring the Vault `vault_client_for_operator` JIT contract.
- **Per-read selection:** WIF configured ⇒ operator path; unconfigured ⇒ the Phase-1 SA-direct ADC path, unchanged (no behaviour change for Phase-1 installs). A **fresh** credential is minted per read (never cached across operations).
- **Fail-closed:** the shared loader's empty-`raw_jwt` guard runs before dispatch, so a system-initiated call (health probe, scheduler) never reaches the exchange — there is no operator JWT to federate. The backend also fails closed on an empty JWT (defence in depth) and on a declared pool/provider that disagrees with the audience.
- Adds `GSM_WIF_*` settings (audience / pool id / provider id / service account / subject token type). The Helm surface (`gsm.workloadIdentityFederation.*`) lands in #2231. MEHO's own audit attribution (Keycloak `sub`) is unchanged.

## Test plan
- [x] `ruff check` + `ruff format --check` — clean
- [x] `mypy src/meho_backplane/connectors/_shared/gsm_creds.py src/meho_backplane/settings.py` — clean
- [x] `pytest tests/test_connectors_gsm_creds.py tests/test_settings.py` — 91 passed (+ credential_backend/vault_creds regression sweep: 134 passed)
- [x] **AC1** — WIF read builds `identity_pool.Credentials` from `operator.raw_jwt` and drives the STS exchange (STS endpoint mocked, no live GCP): `test_wif_builds_identity_pool_creds_and_exchanges_operator_jwt`
- [x] **AC2** — fresh federated credential per read, no cross-request caching: `test_wif_credential_minted_fresh_per_read`
- [x] **AC3** — SA impersonation applied when configured / skipped when not: `test_wif_impersonation_url_set_when_sa_configured`, `test_wif_impersonation_skipped_when_sa_absent`
- [x] **AC4** — malformed/inconsistent WIF fails closed; no-WIF install uses SA-direct: `test_wif_audience_pool_provider_mismatch_fails_closed`, `test_wif_empty_operator_jwt_fails_closed`, `test_sa_direct_used_when_wif_not_configured`, `test_wif_selected_when_audience_configured`
- [x] **AC5** — chart keys wired to settings + consumed end-to-end; docs note the GCP-side WIF pool/provider trust of the Keycloak issuer: `test_wif_end_to_end_via_shared_loader`, `test_wif_log_event_carries_auth_path_and_no_secret`, `docs/codebase/connectors-shared-vault-creds.md`

## Out of scope
- The `gsm.workloadIdentityFederation.*` Helm chart keys + health probe are #2231 (in parallel); this PR owns the backend/settings/exchange logic and keeps the `settings.py` additions in a distinct block to minimize collision.
- Adjacent finding: `gsm_creds.py` is now 639 lines (mostly docstrings; every function well under the complexity/size limits) — kept as one cohesive backend module rather than split.

<!-- auto-implement-issue: fresh, iteration 1 -->

Closes #2232
