### PR TITLE
feat(deploy): Helm gsm.* surface + backend-agnostic /api/v1/health federation proof

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -102,6 +102,25 @@ connector-related release-notes line.
   Per-operator GCP federation and the Helm surface are deferred to #2232 /
   #2231. (#2230)
 
+### Added — Helm `gsm.*` surface + backend-agnostic `/api/v1/health` federation proof
+
+- Deploy a **Vault-free, GCP-native** install: the chart gains a top-level
+  `gsm.*` block (`enabled`, `project`, and inert Phase-2 (#2232)
+  `workloadIdentityFederation.{poolId,providerId,serviceAccount}` stubs)
+  plus `config.credentialBackend` / `config.gsmProject` /
+  `config.gsmImpersonateSa`, rendered into the backplane env as
+  `CREDENTIAL_BACKEND` / `GSM_PROJECT` / `GSM_IMPERSONATE_SA`.
+  `values.schema.json` now requires `vault.address` **only when**
+  `config.credentialBackend: vault` and requires `gsm.enabled: true` +
+  `gsm.project` when it is `gsm`, so a GSM-only overlay passes schema
+  validation with a blank Vault address (see
+  `deploy/values-examples/values-gsm-example.yaml`). (#2231)
+- The `GET /api/v1/health` federation proof is now **backend-agnostic**:
+  it dispatches on `config.credentialBackend` — a Vault install keeps the
+  unchanged `vault.kv.read` path (zero migration), while a GSM install
+  reads its probe secret (`gsm:<project>/meho-test-federation`) through the
+  credential-backend seam and reports the same `vault` status shape. (#2231)
+
 ## [0.20.0] - 2026-07-08
 
 ### Fixed — ssh-family connectors resolve `secret_ref` from Vault

--- a/backend/src/meho_backplane/api/v1/health.py
+++ b/backend/src/meho_backplane/api/v1/health.py
@@ -55,6 +55,25 @@ is the only error class operators routinely chase against this endpoint.
 Detail strings deliberately surface only exception class names, never
 their messages, so a misconfigured Vault role can't leak operator-
 controllable URL substrings into a successful 200 response.
+
+Backend-agnostic federation proof (#2231)
+=========================================
+
+The four-step chain above describes the Vault deployment — the default
+and, until #2230, the only credential backend. The proof is now
+dispatched on ``config.credentialBackend`` / ``CREDENTIAL_BACKEND``: a
+Vault install takes the unchanged ``vault.kv.read`` path
+(:func:`_probe_vault_federation`, zero migration); any other backend
+(``gsm`` on a GCP-native install) reads its designated probe secret
+through the credential-backend seam (:func:`_probe_backend_federation`).
+Either way the response shape is identical — the ``vault`` field carries
+whichever backend's federation status — so the CLI ``meho status`` and
+the ``meho.status`` MCP tool render a GSM install exactly as they render
+a Vault one. The ``gsm`` probe reads under MEHO's own deployment identity
+(SA-direct, #2230), so its probe secret is reachable without the
+per-operator Vault tenant-scope exemption in
+:data:`~meho_backplane.connectors.vault.tenant_scope.PLATFORM_EXEMPT_PATHS`
+(that guard is on the Vault op path only).
 """
 
 from __future__ import annotations
@@ -67,13 +86,26 @@ from pydantic import BaseModel, ConfigDict
 
 from meho_backplane.auth.operator import Operator, TenantRole
 from meho_backplane.auth.rbac import require_role
+from meho_backplane.connectors._shared.credential_backend import (
+    UnknownCredentialBackendError,
+    resolve_credential_backend,
+    split_credential_ref,
+)
 from meho_backplane.db.migrations import db_migration_probe
 from meho_backplane.mcp.schemas import PROTOCOL_VERSION
 from meho_backplane.mcp.server import mcp_session_id_capture_mode
 from meho_backplane.middleware import verify_jwt_and_bind
 from meho_backplane.operations import dispatch
+from meho_backplane.settings import get_settings
 
 __all__ = ["build_health_response", "router"]
+
+#: Vault backend kind — the schemeless default (``config.credentialBackend`` /
+#: ``CREDENTIAL_BACKEND`` default). When the deployment runs on Vault the
+#: federation proof takes the unchanged :func:`_probe_vault_federation`
+#: dispatch path; any other backend routes through the credential-backend
+#: seam (:func:`_probe_backend_federation`).
+_VAULT_BACKEND_KIND: str = "vault"
 
 #: Hardcoded path inside the Vault KV v2 mount used to prove the
 #: federation chain. The path is provisioned by the consumer (see
@@ -82,6 +114,20 @@ __all__ = ["build_health_response", "router"]
 #: which secret to read is explicitly out of scope for v0.1; product
 #: routes added post-Goal-2 will read different paths.
 _FEDERATION_PROOF_PATH: str = "meho/test/federation"
+
+#: GCP Secret Manager secret name the GSM-backend federation proof reads
+#: under ``Settings.gsm_project`` (``config.gsmProject`` / ``GSM_PROJECT``).
+#: The GSM analogue of :data:`_FEDERATION_PROOF_PATH` — hyphenated because
+#: Secret Manager secret ids are ``[A-Za-z0-9_-]`` (no ``/``). A GSM-only
+#: install provisions ``projects/<gsm_project>/secrets/meho-test-federation``
+#: with a JSON-object value (e.g. ``{"ok": "true"}``) so the seam read
+#: returns a field dict, exactly as the Vault probe reads a KV-v2 secret.
+_FEDERATION_PROOF_GSM_SECRET: str = "meho-test-federation"
+
+#: Target name threaded into the credential-backend seam for the probe read;
+#: it never names a credential value, only labels the read in error/log
+#: strings (the backend contract's ``target_name``).
+_FEDERATION_PROOF_TARGET_NAME: str = "health-federation-proof"
 
 
 class OperatorIdentity(BaseModel):
@@ -100,13 +146,21 @@ class OperatorIdentity(BaseModel):
 
 
 class VaultStatus(BaseModel):
-    """Vault federation-chain status.
+    """Federation-chain status for the deployment's credential backend.
 
-    ``reachable`` is true when the OIDC login succeeded (TCP + TLS +
-    JWT forward all worked). ``read_ok`` is true when the test secret
-    read succeeded against the resulting Vault token. ``detail`` carries
-    a short structured string for the CLI to render on failure paths —
-    never an unbounded exception message.
+    The field is named ``vault`` on :class:`HealthResponse` for wire
+    compatibility (it predates the credential-backend seam), but the value
+    reflects whichever backend ``config.credentialBackend`` selects: the
+    Vault OIDC-login + KV read on a Vault install, or the configured
+    backend's probe-secret read (``gsm:<project>/<probe-secret>`` on a GSM
+    install) through the credential-backend seam.
+
+    ``reachable`` is true when the backend was reached — on Vault, the OIDC
+    login succeeded (TCP + TLS + JWT forward); on a seam backend, the store
+    was addressable (config resolved, backend registered). ``read_ok`` is
+    true when the probe secret read succeeded. ``detail`` carries a short
+    structured string for the CLI to render on failure paths — a class name
+    or error code, never an unbounded exception message or a secret value.
     """
 
     model_config = ConfigDict(frozen=True)
@@ -313,6 +367,107 @@ async def _probe_vault_federation(
     return VaultStatus(reachable=True, read_ok=False, detail=f"read_failed: {exc_type}")
 
 
+def _federation_probe_ref(backend_kind: str) -> str | None:
+    """Build the scheme-prefixed probe ref for a non-Vault *backend_kind*.
+
+    Returns a ``<kind>:<store-ref>`` value the credential-backend seam
+    resolves, or ``None`` when the backend has no probe convention or is
+    not configured enough to address one (e.g. ``gsm`` without
+    ``GSM_PROJECT`` set). ``None`` maps to a ``config_error`` status rather
+    than a spurious store read against an empty project.
+
+    * ``gsm`` → ``gsm:<gsm_project>/meho-test-federation`` (latest version),
+      or ``None`` when ``Settings.gsm_project`` is unset.
+    """
+    if backend_kind == "gsm":
+        project = get_settings().gsm_project.strip()
+        if not project:
+            return None
+        return f"gsm:{project}/{_FEDERATION_PROOF_GSM_SECRET}"
+    return None
+
+
+async def _probe_backend_federation(
+    operator: Operator,
+    log: Any,
+    backend_kind: str,
+) -> VaultStatus:
+    """Run the federation proof through the credential-backend seam.
+
+    The non-Vault path (``config.credentialBackend != "vault"``): resolve
+    the backend registered for *backend_kind* on the #2229 seam and read
+    its designated probe secret. Success / failure map onto the same
+    :class:`VaultStatus` axes the Vault dispatch path uses, so the
+    ``/api/v1/health`` response shape is identical regardless of backend.
+
+    The read forwards *operator* to satisfy the seam contract; a
+    deployment-identity backend (GSM SA-direct, #2230) reads under MEHO's
+    own identity and ignores it, so the GSM probe secret is reachable
+    without a per-operator tenant-scope exemption (the Vault tenant-scope
+    guard is not on this path — see
+    :data:`~meho_backplane.connectors.vault.tenant_scope.PLATFORM_EXEMPT_PATHS`).
+
+    Never raises: the module's never-a-5xx contract holds by mapping every
+    failure axis (unconfigured probe, unknown backend kind, store read
+    error) to a :class:`VaultStatus` with ``read_ok=False`` and a class-
+    name / error-code ``detail`` that never echoes a secret value.
+    """
+    ref = _federation_probe_ref(backend_kind)
+    if ref is None:
+        log.warning("federation_health_probe_unconfigured", backend=backend_kind)
+        return VaultStatus(
+            reachable=False,
+            read_ok=False,
+            detail=f"config_error: {backend_kind}",
+        )
+
+    kind, store_ref = split_credential_ref(ref, default_backend=backend_kind)
+    try:
+        backend = resolve_credential_backend(kind)
+    except UnknownCredentialBackendError:
+        log.warning("federation_health_unknown_backend", backend=kind)
+        return VaultStatus(reachable=False, read_ok=False, detail=f"unknown_backend: {kind}")
+
+    try:
+        await backend.load_secret_data(
+            store_ref,
+            operator,
+            target_name=_FEDERATION_PROOF_TARGET_NAME,
+            mount="",
+        )
+    except Exception as exc:
+        # Never-a-5xx contract: any backend read failure (missing secret,
+        # denied access, ADC error, malformed payload) surfaces as
+        # read_ok=False with the exception class name, exactly as the Vault
+        # dispatch path renders its read-phase failures. Only the class name
+        # is surfaced — never the message, so operator-controllable
+        # substrings can't leak into a 200 response body.
+        exc_type = type(exc).__name__
+        log.warning("federation_health_backend_read_failed", backend=kind, exc_type=exc_type)
+        return VaultStatus(reachable=True, read_ok=False, detail=f"read_failed: {exc_type}")
+
+    log.info("federation_health_ok", backend=kind)
+    return VaultStatus(reachable=True, read_ok=True, detail="ok")
+
+
+async def _probe_federation(operator: Operator, log: Any) -> VaultStatus:
+    """Dispatch the federation proof to the deployment's credential backend.
+
+    On Vault (the default, ``config.credentialBackend == "vault"``) this is
+    the unchanged :func:`_probe_vault_federation` dispatch path — same
+    ``vault.kv.read`` op, same audit / policy-gate / broadcast, zero
+    migration. Any other backend routes through
+    :func:`_probe_backend_federation` over the credential-backend seam.
+
+    ``_probe_vault_federation`` is resolved as a module global so existing
+    tests that monkeypatch it keep working through this dispatcher.
+    """
+    backend_kind = get_settings().credential_backend
+    if backend_kind == _VAULT_BACKEND_KIND:
+        return await _probe_vault_federation(operator, log)
+    return await _probe_backend_federation(operator, log, backend_kind)
+
+
 async def build_health_response(operator: Operator) -> HealthResponse:
     """Assemble the :class:`HealthResponse` for a validated operator.
 
@@ -326,7 +481,7 @@ async def build_health_response(operator: Operator) -> HealthResponse:
     resolved.
     """
     log = structlog.get_logger()
-    vault_status = await _probe_vault_federation(operator, log)
+    vault_status = await _probe_federation(operator, log)
     db_probe_result = await db_migration_probe()
     return HealthResponse(
         operator=OperatorIdentity(

--- a/backend/src/meho_backplane/connectors/vault/tenant_scope.py
+++ b/backend/src/meho_backplane/connectors/vault/tenant_scope.py
@@ -91,6 +91,13 @@ _SYSTEM_TENANT_ID: UUID = UUID(int=0)
 #: glob — so a caller cannot smuggle a tenant escape through it. A
 #: regression test pins this equal to the health route's
 #: ``_FEDERATION_PROOF_PATH`` rendered onto the default ``secret`` mount.
+#:
+#: This guard is Vault-specific: it only runs on the ``vault.kv.*`` op path.
+#: The #2231 backend-agnostic federation proof reads a non-Vault backend's
+#: probe secret (``gsm:<project>/<probe-secret>``) through the
+#: credential-backend seam, which never traverses this guard — the GSM
+#: backend reads under MEHO's own deployment identity, not a per-operator
+#: tenant scope, so its probe secret is reachable without an entry here.
 PLATFORM_EXEMPT_PATHS: frozenset[str] = frozenset({"secret/meho/test/federation"})
 
 

--- a/backend/src/meho_backplane/settings.py
+++ b/backend/src/meho_backplane/settings.py
@@ -918,6 +918,14 @@ class Settings(BaseModel):
     # reusing the GcloudConnector impersonation chain. No effect on Vault
     # installs. Chart wiring lands with the GSM Helm surface in #2231.
     gsm_impersonate_sa: str = Field(default="")
+    # #2231 (Initiative #2227) — the GCP project the GSM credential backend
+    # reads under when a ``secret_ref`` (or the ``/api/v1/health`` federation
+    # probe) names no explicit project. Empty (the default) is correct for
+    # every Vault install; a ``gsm``-backend install sets it via
+    # ``config.gsmProject`` → ``GSM_PROJECT`` so the health federation proof
+    # can address ``gsm:<project>/<probe-secret>`` without a hard-coded
+    # project. No effect on Vault installs.
+    gsm_project: str = Field(default="")
     database_url: str = Field(min_length=1)
     database_pool_size: int = Field(default=10, gt=0)
     database_pool_timeout: float = Field(default=30.0, gt=0)
@@ -1471,6 +1479,11 @@ def get_settings() -> Settings:
         # Optional impersonation SA for the GSM credential backend (#2230).
         # Empty/whitespace-only ⇒ direct-ADC read (no impersonation).
         gsm_impersonate_sa=os.environ.get("GSM_IMPERSONATE_SA", "").strip(),
+        # GCP project the GSM backend + health federation probe read under
+        # (#2231). Empty is correct for Vault installs; a gsm-backend install
+        # sets it via ``config.gsmProject``. Whitespace is stripped so a
+        # blank chart value round-trips as empty.
+        gsm_project=os.environ.get("GSM_PROJECT", "").strip(),
         database_url=os.environ["DATABASE_URL"],
         database_pool_size=int(os.environ.get("DATABASE_POOL_SIZE", "10")),
         database_pool_timeout=float(

--- a/backend/tests/test_api_v1_health_gsm.py
+++ b/backend/tests/test_api_v1_health_gsm.py
@@ -1,0 +1,189 @@
+# SPDX-License-Identifier: Apache-2.0
+# Copyright (c) 2026 evoila Group
+
+"""Backend-agnostic federation-proof tests for ``GET /api/v1/health`` (#2231).
+
+The federation proof is dispatched on ``config.credentialBackend`` /
+``CREDENTIAL_BACKEND``: a Vault install takes the unchanged
+``vault.kv.read`` path (covered by ``test_api_v1_health.py`` /
+``test_api_v1_health_split.py``); any other backend reads its designated
+probe secret through the credential-backend seam. This suite pins the
+non-Vault path — the ``gsm`` backend — at the
+:func:`~meho_backplane.api.v1.health._probe_federation` boundary, so it
+needs no live GCP, no DB, and no JWT round-trip: the seam's
+``resolve_credential_backend`` is patched to a fake backend and the
+returned :class:`~meho_backplane.api.v1.health.VaultStatus` is asserted
+against each failure axis (healthy read, read error, unconfigured probe,
+unknown backend kind). The never-a-5xx contract holds — every axis is a
+structured status, never a raised exception.
+"""
+
+from __future__ import annotations
+
+from collections.abc import Iterator
+from uuid import UUID
+
+import pytest
+import structlog
+
+from meho_backplane.api.v1 import health as health_module
+from meho_backplane.api.v1.health import VaultStatus, _probe_federation
+from meho_backplane.auth.operator import Operator, TenantRole
+from meho_backplane.connectors._shared.credential_backend import (
+    UnknownCredentialBackendError,
+)
+from meho_backplane.settings import get_settings
+
+
+@pytest.fixture(autouse=True)
+def _settings_env(monkeypatch: pytest.MonkeyPatch) -> Iterator[None]:
+    """Pin the chassis-required env vars; individual tests set backend knobs."""
+    monkeypatch.setenv("KEYCLOAK_ISSUER_URL", "https://keycloak.test/realms/meho")
+    monkeypatch.setenv("KEYCLOAK_AUDIENCE", "meho-backplane")
+    monkeypatch.setenv("VAULT_ADDR", "https://vault.test")
+    monkeypatch.delenv("VAULT_NAMESPACE", raising=False)
+    monkeypatch.delenv("CREDENTIAL_BACKEND", raising=False)
+    monkeypatch.delenv("GSM_PROJECT", raising=False)
+    get_settings.cache_clear()
+    yield
+    get_settings.cache_clear()
+
+
+def _operator() -> Operator:
+    """A minimal OPERATOR-rank principal for the probe under test."""
+    return Operator(
+        sub="op-alice",
+        name="Alice",
+        email="alice@example.com",
+        raw_jwt="header.payload.sig",
+        tenant_id=UUID(int=1),
+        tenant_role=TenantRole.OPERATOR,
+    )
+
+
+class _RecordingBackend:
+    """Fake credential backend recording the ref it was asked to read."""
+
+    def __init__(self, *, result: dict[str, object] | None = None, error: Exception | None = None):
+        self._result = result if result is not None else {"ok": "true"}
+        self._error = error
+        self.calls: list[tuple[str, str, str]] = []
+
+    async def load_secret_data(
+        self,
+        secret_ref: str,
+        operator: Operator,
+        *,
+        target_name: str,
+        mount: str = "",
+    ) -> dict[str, object]:
+        self.calls.append((secret_ref, target_name, mount))
+        if self._error is not None:
+            raise self._error
+        return self._result
+
+
+async def test_gsm_backend_federation_reports_healthy(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """A GSM install reads ``gsm:<project>/meho-test-federation`` and reports healthy."""
+    monkeypatch.setenv("CREDENTIAL_BACKEND", "gsm")
+    monkeypatch.setenv("GSM_PROJECT", "my-gcp-project")
+    get_settings.cache_clear()
+
+    backend = _RecordingBackend(result={"ok": "true"})
+    monkeypatch.setattr(health_module, "resolve_credential_backend", lambda _kind: backend)
+
+    status = await _probe_federation(_operator(), structlog.get_logger())
+
+    assert status == VaultStatus(reachable=True, read_ok=True, detail="ok")
+    # The seam is handed the scheme-stripped store ref, the probe target
+    # name, and an empty mount (a Vault-KV concept the GSM backend ignores).
+    assert backend.calls == [("my-gcp-project/meho-test-federation", "health-federation-proof", "")]
+
+
+async def test_gsm_backend_read_error_never_5xx(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """A backend read failure surfaces as read_ok=False + a class-name detail, never a raise."""
+    from meho_backplane.connectors._shared.gsm_creds import GcpSecretManagerReadError
+
+    monkeypatch.setenv("CREDENTIAL_BACKEND", "gsm")
+    monkeypatch.setenv("GSM_PROJECT", "my-gcp-project")
+    get_settings.cache_clear()
+
+    backend = _RecordingBackend(error=GcpSecretManagerReadError("secret projects/... not found"))
+    monkeypatch.setattr(health_module, "resolve_credential_backend", lambda _kind: backend)
+
+    status = await _probe_federation(_operator(), structlog.get_logger())
+
+    assert status == VaultStatus(
+        reachable=True, read_ok=False, detail="read_failed: GcpSecretManagerReadError"
+    )
+    # Detail carries only the exception class name — never the message, so an
+    # operator-controllable substring can't leak into a 200 response body.
+    assert "not found" not in (status.detail or "")
+
+
+async def test_gsm_backend_unconfigured_project_reports_config_error(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """``CREDENTIAL_BACKEND=gsm`` without ``GSM_PROJECT`` fails config-side, not a store read."""
+    monkeypatch.setenv("CREDENTIAL_BACKEND", "gsm")
+    monkeypatch.delenv("GSM_PROJECT", raising=False)
+    get_settings.cache_clear()
+
+    # resolve must never be reached — the probe ref is unbuildable first.
+    def _fail(_kind: str) -> object:  # pragma: no cover - asserts non-invocation
+        raise AssertionError("resolve_credential_backend must not run when project is unset")
+
+    monkeypatch.setattr(health_module, "resolve_credential_backend", _fail)
+
+    status = await _probe_federation(_operator(), structlog.get_logger())
+
+    assert status == VaultStatus(reachable=False, read_ok=False, detail="config_error: gsm")
+
+
+async def test_unknown_backend_kind_reports_unknown_backend(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """An unregistered backend kind surfaces as reachable=False + ``unknown_backend``."""
+    monkeypatch.setenv("CREDENTIAL_BACKEND", "gsm")
+    monkeypatch.setenv("GSM_PROJECT", "my-gcp-project")
+    get_settings.cache_clear()
+
+    def _unknown(_kind: str) -> object:
+        raise UnknownCredentialBackendError("no credential backend registered for kind 'gsm'")
+
+    monkeypatch.setattr(health_module, "resolve_credential_backend", _unknown)
+
+    status = await _probe_federation(_operator(), structlog.get_logger())
+
+    assert status == VaultStatus(reachable=False, read_ok=False, detail="unknown_backend: gsm")
+
+
+async def test_vault_backend_takes_the_unchanged_dispatch_path(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """The default (``vault``) backend routes to the unchanged ``_probe_vault_federation``."""
+    monkeypatch.setenv("CREDENTIAL_BACKEND", "vault")
+    get_settings.cache_clear()
+
+    calls: list[str] = []
+
+    async def _fake_vault_probe(operator: Operator, log: object) -> VaultStatus:
+        calls.append(operator.sub)
+        return VaultStatus(reachable=True, read_ok=True, detail="version=7")
+
+    monkeypatch.setattr(health_module, "_probe_vault_federation", _fake_vault_probe)
+    # A GSM read must never be attempted on the Vault path.
+    monkeypatch.setattr(
+        health_module,
+        "resolve_credential_backend",
+        lambda _kind: (_ for _ in ()).throw(AssertionError("seam must not run on the vault path")),
+    )
+
+    status = await _probe_federation(_operator(), structlog.get_logger())
+
+    assert status == VaultStatus(reachable=True, read_ok=True, detail="version=7")
+    assert calls == ["op-alice"]

--- a/backend/tests/test_settings.py
+++ b/backend/tests/test_settings.py
@@ -462,3 +462,34 @@ def test_gsm_impersonate_sa_reads_and_strips_env(
         assert get_settings().gsm_impersonate_sa == "reader@proj.iam.gserviceaccount.com"
     finally:
         get_settings.cache_clear()
+
+
+# ---------------------------------------------------------------------------
+# #2231 (Initiative #2227) — GSM_PROJECT env knob
+# ---------------------------------------------------------------------------
+
+
+def test_gsm_project_defaults_to_empty_when_unset(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """Unset ``GSM_PROJECT`` → empty (correct for every Vault install)."""
+    _base_env(monkeypatch)
+    monkeypatch.delenv("GSM_PROJECT", raising=False)
+    get_settings.cache_clear()
+    try:
+        assert get_settings().gsm_project == ""
+    finally:
+        get_settings.cache_clear()
+
+
+def test_gsm_project_reads_and_strips_env(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """A set ``GSM_PROJECT`` names the GCP project the GSM backend reads under; stripped."""
+    _base_env(monkeypatch)
+    monkeypatch.setenv("GSM_PROJECT", "  my-gcp-project \n")
+    get_settings.cache_clear()
+    try:
+        assert get_settings().gsm_project == "my-gcp-project"
+    finally:
+        get_settings.cache_clear()

--- a/cli/api/openapi.json
+++ b/cli/api/openapi.json
@@ -26317,7 +26317,7 @@
           "read_ok"
         ],
         "title": "VaultStatus",
-        "description": "Vault federation-chain status.\n\n``reachable`` is true when the OIDC login succeeded (TCP + TLS +\nJWT forward all worked). ``read_ok`` is true when the test secret\nread succeeded against the resulting Vault token. ``detail`` carries\na short structured string for the CLI to render on failure paths \u2014\nnever an unbounded exception message."
+        "description": "Federation-chain status for the deployment's credential backend.\n\nThe field is named ``vault`` on :class:`HealthResponse` for wire\ncompatibility (it predates the credential-backend seam), but the value\nreflects whichever backend ``config.credentialBackend`` selects: the\nVault OIDC-login + KV read on a Vault install, or the configured\nbackend's probe-secret read (``gsm:<project>/<probe-secret>`` on a GSM\ninstall) through the credential-backend seam.\n\n``reachable`` is true when the backend was reached \u2014 on Vault, the OIDC\nlogin succeeded (TCP + TLS + JWT forward); on a seam backend, the store\nwas addressable (config resolved, backend registered). ``read_ok`` is\ntrue when the probe secret read succeeded. ``detail`` carries a short\nstructured string for the CLI to render on failure paths \u2014 a class name\nor error code, never an unbounded exception message or a secret value."
       },
       "_AnnotateEdgeRequest": {
         "properties": {

--- a/cli/internal/api/client.gen.go
+++ b/cli/internal/api/client.gen.go
@@ -3591,13 +3591,21 @@ type HealthResponse struct {
 	// it for downstream Vault forward-auth only.
 	Operator OperatorIdentity `json:"operator"`
 
-	// Vault Vault federation-chain status.
+	// Vault Federation-chain status for the deployment's credential backend.
 	//
-	// ``reachable`` is true when the OIDC login succeeded (TCP + TLS +
-	// JWT forward all worked). ``read_ok`` is true when the test secret
-	// read succeeded against the resulting Vault token. ``detail`` carries
-	// a short structured string for the CLI to render on failure paths —
-	// never an unbounded exception message.
+	// The field is named ``vault`` on :class:`HealthResponse` for wire
+	// compatibility (it predates the credential-backend seam), but the value
+	// reflects whichever backend ``config.credentialBackend`` selects: the
+	// Vault OIDC-login + KV read on a Vault install, or the configured
+	// backend's probe-secret read (``gsm:<project>/<probe-secret>`` on a GSM
+	// install) through the credential-backend seam.
+	//
+	// ``reachable`` is true when the backend was reached — on Vault, the OIDC
+	// login succeeded (TCP + TLS + JWT forward); on a seam backend, the store
+	// was addressable (config resolved, backend registered). ``read_ok`` is
+	// true when the probe secret read succeeded. ``detail`` carries a short
+	// structured string for the CLI to render on failure paths — a class name
+	// or error code, never an unbounded exception message or a secret value.
 	Vault VaultStatus `json:"vault"`
 }
 
@@ -6027,13 +6035,21 @@ type ValidationError_Loc_Item struct {
 	union json.RawMessage
 }
 
-// VaultStatus Vault federation-chain status.
+// VaultStatus Federation-chain status for the deployment's credential backend.
 //
-// “reachable“ is true when the OIDC login succeeded (TCP + TLS +
-// JWT forward all worked). “read_ok“ is true when the test secret
-// read succeeded against the resulting Vault token. “detail“ carries
-// a short structured string for the CLI to render on failure paths —
-// never an unbounded exception message.
+// The field is named “vault“ on :class:`HealthResponse` for wire
+// compatibility (it predates the credential-backend seam), but the value
+// reflects whichever backend “config.credentialBackend“ selects: the
+// Vault OIDC-login + KV read on a Vault install, or the configured
+// backend's probe-secret read (“gsm:<project>/<probe-secret>“ on a GSM
+// install) through the credential-backend seam.
+//
+// “reachable“ is true when the backend was reached — on Vault, the OIDC
+// login succeeded (TCP + TLS + JWT forward); on a seam backend, the store
+// was addressable (config resolved, backend registered). “read_ok“ is
+// true when the probe secret read succeeded. “detail“ carries a short
+// structured string for the CLI to render on failure paths — a class name
+// or error code, never an unbounded exception message or a secret value.
 type VaultStatus struct {
 	Detail    *string `json:"detail"`
 	Reachable bool    `json:"reachable"`

--- a/deploy/charts/meho/templates/configmap.yaml
+++ b/deploy/charts/meho/templates/configmap.yaml
@@ -53,6 +53,16 @@ data:
   VAULT_OIDC_ROLE: {{ .Values.config.vaultOidcRole | quote }}
   VAULT_OIDC_MOUNT_PATH: {{ .Values.config.vaultOidcMountPath | quote }}
   VAULT_TIMEOUT_SECONDS: {{ .Values.config.vaultTimeoutSeconds | quote }}
+  # Credential backend surface (Initiative #2227). `CREDENTIAL_BACKEND`
+  # names the store a schemeless target `secret_ref` and the
+  # `/api/v1/health` federation proof resolve through (`vault` default,
+  # `gsm` for a GCP-native install). `GSM_PROJECT` / `GSM_IMPERSONATE_SA`
+  # are read by the GSM backend (`connectors/_shared/gsm_creds.py`) and are
+  # harmless empty strings on a Vault install. The env-var names are the
+  # backplane's contract (`backend/src/meho_backplane/settings.py`).
+  CREDENTIAL_BACKEND: {{ .Values.config.credentialBackend | quote }}
+  GSM_PROJECT: {{ .Values.config.gsmProject | quote }}
+  GSM_IMPERSONATE_SA: {{ .Values.config.gsmImpersonateSa | quote }}
   DATABASE_POOL_SIZE: {{ .Values.config.databasePoolSize | quote }}
   DATABASE_POOL_TIMEOUT: {{ .Values.config.databasePoolTimeout | quote }}
   # G0.4-T2 (#259) — retrieval substrate fastembed model + on-disk cache

--- a/deploy/charts/meho/values.schema.json
+++ b/deploy/charts/meho/values.schema.json
@@ -188,10 +188,10 @@
         "keycloakAudience",
         "keycloakJwksCacheTtlSeconds",
         "keycloakJwtLeewaySeconds",
-        "vaultAddr",
         "vaultOidcRole",
         "vaultOidcMountPath",
         "vaultTimeoutSeconds",
+        "credentialBackend",
         "databasePoolSize",
         "databasePoolTimeout",
         "retrievalEmbeddingModel",
@@ -208,10 +208,26 @@
         },
         "keycloakJwksCacheTtlSeconds": { "type": "string", "pattern": "^[0-9]+$" },
         "keycloakJwtLeewaySeconds": { "type": "string", "pattern": "^[0-9]+$" },
-        "vaultAddr": { "type": "string", "format": "uri", "minLength": 1 },
+        "vaultAddr": {
+          "type": "string",
+          "description": "Vault address rendered as `VAULT_ADDR`. Required (non-empty, `uri`) when `config.credentialBackend: vault` — enforced by the root-level `allOf` — so a `gsm` install may leave it blank (the field still renders, harmlessly empty, until the backplane makes VAULT_ADDR optional in #2232)."
+        },
         "vaultOidcRole": { "type": "string", "minLength": 1 },
         "vaultOidcMountPath": { "type": "string", "minLength": 1 },
         "vaultTimeoutSeconds": { "type": "string", "pattern": "^[0-9]+(\\.[0-9]+)?$" },
+        "credentialBackend": {
+          "type": "string",
+          "enum": ["vault", "gsm"],
+          "description": "Credential backend a schemeless target `secret_ref` and the `/api/v1/health` federation proof resolve through (Initiative #2227), rendered as the `CREDENTIAL_BACKEND` env var. `vault` (default) keeps the Vault KV-v2 read — the health proof reads `secret/meho/test/federation` — and the root-level `allOf` then requires a non-empty `vault.address`. `gsm` selects the GCP Secret Manager backend for a Vault-free install — the health proof reads `gsm:<config.gsmProject>/meho-test-federation` — and the `allOf` then requires `gsm.enabled: true` with a non-empty `gsm.project`. Constrained to the registered backend kinds so a typo fails at install rather than yielding an unknown backend at runtime."
+        },
+        "gsmProject": {
+          "type": "string",
+          "description": "GCP project id the GSM credential backend + health federation proof read secrets under (Initiative #2227), rendered as `GSM_PROJECT`. Empty is correct for every Vault install (the field is harmless and unused). Required-in-practice for a `gsm` install; the operator-facing top-level `gsm.project` carries the schema-required declaration, this is the value the backplane actually reads at runtime (typically identical)."
+        },
+        "gsmImpersonateSa": {
+          "type": "string",
+          "description": "Optional service account email the GSM backend impersonates when reading Secret Manager (Initiative #2227), rendered as `GSM_IMPERSONATE_SA`. Empty (default) reads directly under the pod's GKE Workload Identity ADC; a non-empty value wraps that ADC source in impersonated credentials (the GcloudConnector chain). No service-account JSON key is ever used. Harmless empty on a Vault install."
+        },
         "databasePoolSize": { "type": "string", "pattern": "^[0-9]+$" },
         "databasePoolTimeout": { "type": "string", "pattern": "^[0-9]+(\\.[0-9]+)?$" },
         "retrievalEmbeddingModel": {
@@ -266,13 +282,11 @@
     "vault": {
       "type": "object",
       "additionalProperties": false,
-      "required": ["address"],
+      "description": "Vault credential backend. `address` is required (non-empty, `uri`) only when `config.credentialBackend: vault` — enforced by the root-level `allOf` conditional — so a `gsm` install may leave it blank. The block itself is always present (it ships safe-by-default values); the conditional gates the strictness.",
       "properties": {
         "address": {
           "type": "string",
-          "minLength": 1,
-          "format": "uri",
-          "description": "Vault address — required."
+          "description": "Vault address. Required (non-empty, `uri`-shaped) when `config.credentialBackend: vault`; may be empty on a `gsm` (Vault-free) install. The conditional requirement lives in the root-level `allOf`."
         },
         "authMethod": {
           "type": "string",
@@ -285,6 +299,41 @@
           "required": ["kv"],
           "properties": {
             "kv": { "type": "string", "minLength": 1 }
+          }
+        }
+      }
+    },
+    "gsm": {
+      "type": "object",
+      "additionalProperties": false,
+      "description": "GCP Secret Manager credential backend (Initiative #2227). Mirrors the `vault` block: an operator-facing top-level declaration the schema validates, paired with the runtime `config.gsmProject` / `config.gsmImpersonateSa` env values. `project` is required (non-empty) and `enabled` must be `true` only when `config.credentialBackend: gsm` — enforced by the root-level `allOf`. `workloadIdentityFederation` is an inert Phase-2 (#2232) stub: declared so a GSM adopter can pin the shape, but no template consumes it yet.",
+      "required": ["enabled"],
+      "properties": {
+        "enabled": {
+          "type": "boolean",
+          "description": "Whether the deployment uses the GSM credential backend. Must be `true` when `config.credentialBackend: gsm`; the schema leaves it unconstrained (default `false`) otherwise so a Vault install carries the block inert."
+        },
+        "project": {
+          "type": "string",
+          "description": "GCP project id hosting the MEHO target credentials and the `meho-test-federation` health-probe secret. Required (non-empty) when `config.credentialBackend: gsm`. Typically identical to `config.gsmProject` (the value the backplane reads at runtime)."
+        },
+        "workloadIdentityFederation": {
+          "type": "object",
+          "additionalProperties": false,
+          "description": "Workload Identity Federation parameters for per-operator GCP token exchange. Phase-2 stub (#2232) — declared but not consumed by any template; the SA-direct Phase-1 backend ignores it. All fields optional and empty by default.",
+          "properties": {
+            "poolId": {
+              "type": "string",
+              "description": "Workload Identity pool id (Phase-2 stub, #2232)."
+            },
+            "providerId": {
+              "type": "string",
+              "description": "Workload Identity provider id within the pool (Phase-2 stub, #2232)."
+            },
+            "serviceAccount": {
+              "type": "string",
+              "description": "Service account the federated identity impersonates (Phase-2 stub, #2232)."
+            }
           }
         }
       }
@@ -780,6 +829,61 @@
       }
     }
   },
+  "allOf": [
+    {
+      "description": "When `config.credentialBackend` is `vault` (the default), the deployment reads credentials + the health federation proof from Vault, so `vault.address` must be a non-empty `uri`. A `gsm` install skips this and may leave `vault.address` blank.",
+      "if": {
+        "properties": {
+          "config": {
+            "properties": { "credentialBackend": { "const": "vault" } },
+            "required": ["credentialBackend"]
+          }
+        },
+        "required": ["config"]
+      },
+      "then": {
+        "properties": {
+          "vault": {
+            "required": ["address"],
+            "properties": {
+              "address": { "type": "string", "minLength": 1, "format": "uri" }
+            }
+          },
+          "config": {
+            "required": ["vaultAddr"],
+            "properties": {
+              "vaultAddr": { "type": "string", "minLength": 1, "format": "uri" }
+            }
+          }
+        },
+        "required": ["vault", "config"]
+      }
+    },
+    {
+      "description": "When `config.credentialBackend` is `gsm`, the deployment reads credentials + the health federation proof from GCP Secret Manager, so `gsm.enabled` must be `true` and `gsm.project` a non-empty project id. This lets a GSM-only install pass with a blank `vault.address`, while rejecting a `gsm` selection that never enabled or configured the GSM block.",
+      "if": {
+        "properties": {
+          "config": {
+            "properties": { "credentialBackend": { "const": "gsm" } },
+            "required": ["credentialBackend"]
+          }
+        },
+        "required": ["config"]
+      },
+      "then": {
+        "properties": {
+          "gsm": {
+            "required": ["enabled", "project"],
+            "properties": {
+              "enabled": { "const": true },
+              "project": { "type": "string", "minLength": 1 }
+            }
+          }
+        },
+        "required": ["gsm"]
+      }
+    }
+  ],
   "definitions": {
     "httpProbe": {
       "type": "object",

--- a/deploy/charts/meho/values.yaml
+++ b/deploy/charts/meho/values.yaml
@@ -195,6 +195,30 @@ config:
   vaultOidcRole: "meho-mcp"
   vaultOidcMountPath: "jwt"
   vaultTimeoutSeconds: "10.0"
+  # Credential backend a schemeless target `secret_ref` (and the
+  # `/api/v1/health` federation proof) resolves through (#2227). `vault`
+  # (the default) keeps every existing install on today's Vault KV-v2 read
+  # with no change — a schemeless `targets/<id>` ref and an explicit
+  # `vault:targets/<id>` ref both dispatch to the Vault backend, and the
+  # health proof reads `secret/meho/test/federation` unchanged. Set to
+  # `gsm` for a GCP-native, Vault-free install: schemeless refs then
+  # resolve through GCP Secret Manager and the health proof reads
+  # `gsm:<gsmProject>/meho-test-federation`. Rendered as `CREDENTIAL_BACKEND`.
+  # The schema requires `vault.address` only when this is `vault`, and
+  # requires `gsm.enabled: true` + `gsm.project` when this is `gsm`.
+  credentialBackend: "vault"
+  # GCP project the GSM credential backend + health federation proof read
+  # secrets under (#2227). Empty is correct for every Vault install; a
+  # `gsm`-backend install sets it to the project hosting the MEHO target
+  # credentials + the `meho-test-federation` probe secret. Rendered as
+  # `GSM_PROJECT`. Typically mirrors the top-level `gsm.project`.
+  gsmProject: ""
+  # Optional service account the GSM backend impersonates when reading
+  # Secret Manager (#2227). Empty (the default) reads directly under the
+  # pod's own GKE Workload Identity ADC; a non-empty SA email wraps that
+  # ADC source in impersonated credentials (the GcloudConnector chain). No
+  # service-account JSON key is ever used. Rendered as `GSM_IMPERSONATE_SA`.
+  gsmImpersonateSa: ""
   databasePoolSize: "10"
   databasePoolTimeout: "30.0"
   # MCP audience binding (G0.8-T4 #633). The `/mcp` router is mounted
@@ -359,6 +383,36 @@ vault:
     # -- KV v2 mount + base path for operator secrets. Federation-proof reads
     # happen under `<paths.kv>/test/federation` (see backend health.py).
     kv: secret/meho
+
+# GCP Secret Manager credential backend (Initiative #2227). Mirrors the
+# `vault.*` block: a top-level operator-facing declaration that the schema
+# validates (required when `config.credentialBackend: gsm`), paired with
+# the runtime `config.gsmProject` / `config.gsmImpersonateSa` env values the
+# backplane reads. A Vault install leaves this at `enabled: false` and the
+# block is inert.
+gsm:
+  # -- Whether the deployment uses the GSM credential backend. Set true
+  # together with `config.credentialBackend: gsm` for a Vault-free,
+  # GCP-native install. When false (the default) the block is inert and the
+  # schema does not require `project`.
+  enabled: false
+  # -- GCP project id hosting the MEHO target credentials and the
+  # `meho-test-federation` health-probe secret. Required (non-empty) when
+  # `gsm.enabled: true`. Typically the same value as `config.gsmProject`
+  # (which is the value the backplane actually reads at runtime).
+  project: ""
+  # -- Workload Identity Federation parameters for per-operator GCP token
+  # exchange. STUB for Phase 2 (#2232) — declared so a GSM adopter can pin
+  # the shape now, but NO template consumes these yet and the SA-direct
+  # Phase 1 backend ignores them. Leave empty until #2232 wires the STS
+  # token-exchange path.
+  workloadIdentityFederation:
+    # -- Workload Identity **pool** id (Phase 2 stub, #2232).
+    poolId: ""
+    # -- Workload Identity **provider** id within the pool (Phase 2 stub).
+    providerId: ""
+    # -- Service account the federated identity impersonates (Phase 2 stub).
+    serviceAccount: ""
 
 keycloak:
   # -- Keycloak issuer URL — MUST be set; empty fails the schema. The JWT

--- a/deploy/values-examples/README.md
+++ b/deploy/values-examples/README.md
@@ -23,6 +23,7 @@ request.
 | File | Targets | Backed by |
 | --- | --- | --- |
 | [`values-rdc-example.yaml`](./values-rdc-example.yaml) | The RDC Hetzner lab (`*.evba.lab` hosts, rke2-infra ingress-nginx, cluster-internal Postgres + Vault + Keycloak). | The actual, private file lives in [`evoila-bosnia/claude-rdc-hetzner-dc`](https://github.com/evoila-bosnia/claude-rdc-hetzner-dc)'s `manifests/meho/values-rdc.yaml`; this file is the sanitized template for other Vault-+-Keycloak-+-Postgres-shaped labs. |
+| [`values-gsm-example.yaml`](./values-gsm-example.yaml) | A **Vault-free, GCP-native** install (Initiative #2227) — credentials + the `/api/v1/health` federation proof resolve through GCP Secret Manager (`config.credentialBackend: gsm`) instead of Vault. `vault.address` is left blank; the schema requires it only when `credentialBackend: vault`. | The GSM SA-direct backend (#2230). Per-operator GCP token exchange (Workload Identity Federation) is Phase 2 (#2232); the `gsm.workloadIdentityFederation.*` keys are inert stubs until then. |
 
 ## Using `values-rdc-example.yaml`
 

--- a/deploy/values-examples/values-gsm-example.yaml
+++ b/deploy/values-examples/values-gsm-example.yaml
@@ -1,0 +1,75 @@
+# SPDX-License-Identifier: Apache-2.0
+# Copyright (c) 2026 evoila Group
+#
+# Minimal GSM-backend (Vault-free) chart-values example — Initiative #2227.
+#
+# This is the GCP-native counterpart to values-rdc-example.yaml: it selects
+# the GCP Secret Manager credential backend (config.credentialBackend: gsm)
+# so target credentials and the /api/v1/health federation proof resolve
+# through Secret Manager instead of Vault. `vault.address` / `config.vaultAddr`
+# are deliberately left blank — the root-level conditional in
+# values.schema.json requires them ONLY when config.credentialBackend is
+# `vault`, so a GSM install passes schema validation without a Vault address.
+#
+# Prerequisites on the GCP side:
+#   * MEHO runs under a GKE Workload Identity service account (no SA JSON
+#     keys — config.gsmImpersonateSa optionally impersonates a reader SA).
+#   * The federation-proof secret exists:
+#       projects/<gsmProject>/secrets/meho-test-federation
+#     with a JSON-object value (e.g. {"ok":"true"}). The health deep-check
+#     reads `gsm:<gsmProject>/meho-test-federation` to prove the chain.
+#   * Per-target credential secrets are stored as JSON objects and referenced
+#     from targets via `gsm:<project>/<secret>[#field]` secret_refs.
+#
+# NOTE: the SA-direct GSM backend is Phase 1 (#2230). Per-operator GCP
+# token exchange (Workload Identity Federation) is Phase 2 (#2232); the
+# gsm.workloadIdentityFederation.* keys below are inert stubs until then.
+#
+# Replace every value marked "# CHANGE ME" before applying.
+
+image:
+  # An immutable tag from the image pipeline — never :latest / :main.
+  tag: "v0.1.0" # CHANGE ME
+
+ingress:
+  enabled: true
+  host: meho.gsm.example # CHANGE ME
+  tls:
+    enabled: true
+    secretName: meho-tls # CHANGE ME
+
+postgres:
+  host: postgres.gsm.example # CHANGE ME
+  credentialsSecret: meho-postgres # CHANGE ME (Secret holding DATABASE_URL at key `url`)
+
+keycloak:
+  issuer: https://keycloak.gsm.example/realms/meho # CHANGE ME
+  audience: meho-backplane
+
+config:
+  keycloakIssuerUrl: https://keycloak.gsm.example/realms/meho # CHANGE ME (must match keycloak.issuer)
+  keycloakAudience: meho-backplane
+  # --- GSM credential backend (Initiative #2227) ---
+  credentialBackend: gsm
+  gsmProject: my-gcp-project # CHANGE ME (project hosting MEHO secrets + the probe secret)
+  # Optional: impersonate a dedicated reader SA instead of reading directly
+  # under the pod's Workload Identity ADC. Leave "" for direct ADC.
+  gsmImpersonateSa: "" # e.g. meho-secret-reader@my-gcp-project.iam.gserviceaccount.com
+
+gsm:
+  enabled: true
+  project: my-gcp-project # CHANGE ME (typically identical to config.gsmProject)
+  # Phase-2 (#2232) Workload Identity Federation stubs — declared but inert.
+  workloadIdentityFederation:
+    poolId: ""
+    providerId: ""
+    serviceAccount: ""
+
+networkPolicy:
+  enabled: true
+  postgresCIDR: 10.0.1.0/24 # CHANGE ME
+  # Vault egress is unused on a GSM install, but the CIDR is still required
+  # by the schema when networkPolicy.enabled is true. Point it at a harmless
+  # unused subnet (no Vault egress rule is exercised without a Vault backend).
+  vaultCIDR: 10.0.2.0/24 # CHANGE ME (unused on GSM; kept to satisfy the schema)
+  keycloakCIDR: 10.0.3.0/24 # CHANGE ME

--- a/docs/codebase/connectors-shared-vault-creds.md
+++ b/docs/codebase/connectors-shared-vault-creds.md
@@ -204,9 +204,16 @@ the broker moves one opaque value and reports only its SHA-256
 backend returns a named-field payload a connector session builder
 consumes. Same shape, different contract.
 
-Chart wiring (`config.credentialBackend` → `CREDENTIAL_BACKEND` in the
-Helm configmap) lands with the GSM Helm surface in #2231; the setting is
-already read here so a value flows the moment the chart exposes it.
+Chart wiring landed with the GSM Helm surface (#2231): the configmap
+renders `config.credentialBackend` → `CREDENTIAL_BACKEND`, `config.gsmProject`
+→ `GSM_PROJECT`, and `config.gsmImpersonateSa` → `GSM_IMPERSONATE_SA`, and
+`values.schema.json` requires `vault.address` only when
+`credentialBackend: vault` (a `gsm` install passes with a blank Vault
+address). The same `credential_backend` setting also drives the
+`GET /api/v1/health` federation proof: `vault` keeps the unchanged
+`vault.kv.read` dispatch, while `gsm` reads
+`gsm:<gsmProject>/meho-test-federation` through this seam
+(`api/v1/health.py:_probe_backend_federation`).
 
 ## GCP Secret Manager backend (gsm)
 

--- a/docs/codebase/devops.md
+++ b/docs/codebase/devops.md
@@ -312,9 +312,9 @@ values overlay:
 | `ingress.host` | Per-environment; no generic placeholder is correct. Required only when `ingress.enabled: true` (the default) — relaxed when ingress is disabled |
 | `ingress.tls.secretName` | Per-environment Secret name (cert-manager-managed or pre-provisioned). Required only when both `ingress.enabled` and `ingress.tls.enabled` are true |
 | `postgres.credentialsSecret` | Per-environment Secret holding `DATABASE_URL` (ESO-synced from Vault in production) |
-| `vault.address` | Per-environment Vault endpoint |
+| `vault.address` | Per-environment Vault endpoint. Required only when `config.credentialBackend: vault` (the default) — a `gsm` install leaves it blank (#2231) |
 | `keycloak.issuer` | Per-environment Keycloak issuer URL |
-| `config.keycloakIssuerUrl` / `config.keycloakAudience` / `config.vaultAddr` | ConfigMap env-var mirrors of the above (`backend/src/meho_backplane/settings.py` contract) |
+| `config.keycloakIssuerUrl` / `config.keycloakAudience` / `config.vaultAddr` | ConfigMap env-var mirrors of the above (`backend/src/meho_backplane/settings.py` contract). `config.vaultAddr` is required-when-`credentialBackend: vault`, like `vault.address` |
 | `config.backplaneUrl` / `config.mcpResourceUri` | G0.8-T4 (#633). Blank by design: for the common ingress-fronted deploy the chart derives `BACKPLANE_URL=https://<ingress.host>` (scheme follows `ingress.tls.enabled`) and `MCP_RESOURCE_URI=${BACKPLANE_URL}/mcp` via the `meho.backplaneUrl` / `meho.mcpResourceUri` helpers, so the `/mcp` audience resolves without operator action. Set explicitly only when the public URL differs from the Ingress host, or for a non-default MCP mount. When neither resolves (no ingress, nothing set) the backend fails loudly at startup with the remediation rather than serving a dark `/mcp` (`_assert_mcp_resource_uri_configured` in `main.py`). The operator must still add a matching Keycloak `oidc-audience-mapper` — see `docs/cross-repo/mcp-client-setup.md` Step 1 |
 | `networkPolicy.{postgres,vault,keycloak}CIDR` | Per-environment subnet for each upstream. Required only when `networkPolicy.enabled: true` (the default) — relaxed when networkPolicy is disabled |
 
@@ -342,11 +342,13 @@ them).
 | `ingress.host` | string (`hostname`) | External hostname the chart publishes. Required only when `ingress.enabled: true` (default); skipped when ingress is disabled. |
 | `ingress.tls.secretName` | string | TLS Secret (cert-manager-managed or pre-provisioned). Required only when both `ingress.enabled` and `ingress.tls.enabled` are true. |
 | `postgres.credentialsSecret` | string | Kubernetes Secret holding `DATABASE_URL` at key `url`. |
-| `vault.address` | string (`uri`) | Vault endpoint, e.g. `https://vault.example.org`. |
+| `vault.address` | string (`uri`) | Vault endpoint, e.g. `https://vault.example.org`. Required only when `config.credentialBackend: vault` (the default); a `gsm` install leaves it blank (#2231). |
 | `keycloak.issuer` | string (`uri`) | Keycloak issuer URL (used for `iss` validation + JWKS discovery). |
 | `config.keycloakIssuerUrl` | string | ConfigMap mirror of the above; consumed by the backplane env. |
 | `config.keycloakAudience` | string | Keycloak client ID fronting the backplane. |
-| `config.vaultAddr` | string (`uri`) | ConfigMap mirror of `vault.address`. |
+| `config.vaultAddr` | string (`uri`) | ConfigMap mirror of `vault.address`. Required-when-`credentialBackend: vault`, like `vault.address`. |
+| `config.credentialBackend` | enum `vault` \| `gsm` | Credential backend a schemeless target `secret_ref` and the `/api/v1/health` federation proof resolve through (#2227). Default `vault` (rendered `CREDENTIAL_BACKEND`). `vault` requires `vault.address` + `config.vaultAddr`; `gsm` requires `gsm.enabled: true` + `gsm.project` (root-level `allOf` conditional). |
+| `gsm.enabled` / `gsm.project` | boolean / string | GSM credential backend (#2227). Required (`enabled: true` + non-empty `project`) only when `config.credentialBackend: gsm`; inert on a Vault install. Runtime values the backplane reads are `config.gsmProject` (`GSM_PROJECT`) + optional `config.gsmImpersonateSa` (`GSM_IMPERSONATE_SA`). The `gsm.workloadIdentityFederation.*` keys are inert Phase-2 (#2232) stubs. See `deploy/values-examples/values-gsm-example.yaml`. |
 | `networkPolicy.postgresCIDR` | CIDR (IPv4) | Egress CIDR; pattern-validated. Required only when `networkPolicy.enabled: true` (default). |
 | `networkPolicy.vaultCIDR` | CIDR (IPv4) | Same. |
 | `networkPolicy.keycloakCIDR` | CIDR (IPv4) | Same. |


### PR DESCRIPTION
## Summary

- Adds the Helm `gsm.*` chart surface + `config.gsm*` env wiring for a **Vault-free, GCP-native** MEHO install, mirroring the existing `config.vault*` + `vault.*` split, and makes the `GET /api/v1/health` federation proof **backend-agnostic** (Initiative #2227, builds on the #2230 GSM backend).
- `values.schema.json` now requires `vault.address` (+ `config.vaultAddr`) **only when** `config.credentialBackend: vault`, and requires `gsm.enabled: true` + non-empty `gsm.project` when it is `gsm` — so a GSM-only overlay passes schema validation with a blank Vault address.
- The health federation proof dispatches on `Settings.credential_backend`: `vault` keeps the unchanged `vault.kv.read` path (zero migration); `gsm` reads `gsm:<gsmProject>/meho-test-federation` through the credential-backend seam and reports the same `vault` status shape (never a 5xx).
- Scoped to Helm + health + a new `Settings.gsm_project` — **`gsm_creds.py` is untouched** to reduce collision with the parallel #2232.

## What changed

- **Chart**: top-level `gsm` block (`enabled`, `project`, inert Phase-2 (#2232) `workloadIdentityFederation.{poolId,providerId,serviceAccount}` stubs); `config.credentialBackend` / `config.gsmProject` / `config.gsmImpersonateSa` rendered into the configmap as `CREDENTIAL_BACKEND` / `GSM_PROJECT` / `GSM_IMPERSONATE_SA`; root-level `allOf` conditionals in `values.schema.json`; new `deploy/values-examples/values-gsm-example.yaml`.
- **Backend**: `api/v1/health.py` gains `_probe_federation` (dispatcher) + `_probe_backend_federation` (seam read); `Settings.gsm_project` (`GSM_PROJECT`); tenant-scope docstring notes GSM reads structurally bypass the Vault per-operator guard.
- **CLI**: regenerated OpenAPI snapshot + Go client (only the `VaultStatus` schema description changed).
- **Docs**: `devops.md` + `connectors-shared-vault-creds.md` updated; CHANGELOG entry.

## Test plan

- [x] `helm lint` + `helm template` pass for a **GSM-only** values file (blank `vault.address`) **and** the unchanged Vault-only + CI default-override paths.
- [x] `values.schema.json` rejects `credentialBackend: gsm` without `gsm.enabled`/`gsm.project`, rejects `credentialBackend: vault` with empty `vault.address`, and rejects an unknown backend kind (enum); accepts each backend alone.
- [x] `helm template` renders `CREDENTIAL_BACKEND` / `GSM_PROJECT` / `GSM_IMPERSONATE_SA` onto the configmap.
- [x] `/api/v1/health` federation proof returns healthy against `gsm:<project>/meho-test-federation` on a GSM install (mocked backend) and stays green on Vault — new `tests/test_api_v1_health_gsm.py` (5 tests); existing health + tenant-scope + settings + gsm_creds suites updated, not deleted (212 passed).
- [x] `ruff check` / `ruff format --check` / `mypy` clean on changed files; `code-quality.py --diff` 0 blockers; CLI `go build ./...` OK.

## Out of scope

- The WIF STS token-exchange logic (#2232) — only inert chart stub keys added here.
- Making the backplane boot without `VAULT_ADDR` at all (settings still requires the env until #2232); this PR delivers the chart surface + schema + health-probe dispatch.

Closes #2231
