### PR TITLE
feat(connectors): migrate 7 read vmware composites to direct-session dispatch (#2253)

### DIFF
--- a/backend/src/meho_backplane/connectors/vmware_rest/composites/_read.py
+++ b/backend/src/meho_backplane/connectors/vmware_rest/composites/_read.py
@@ -1,19 +1,19 @@
 # SPDX-License-Identifier: Apache-2.0
 # Copyright (c) 2026 evoila Group
 # code-quality-allow: file-size — pre-existing 7-composite handler module
-# (>1200 lines before #2251); this task only appends the direct-session
-# opt-in documentation to the existing "four reasons" note. Splitting the
-# module is I-B migration work (Initiative #2248/#2249), out of scope here.
+# (>1200 lines); #2253 migrated the sub-call mechanism in place (direct
+# session, no ingested sub-ops) without adding a new handler. Splitting
+# the module is separate refactor work, out of scope here.
 
 """Read-only ``vmware.composite.*`` handler functions (7 composites).
 
 Each handler is a module-level ``async def`` that takes the dispatcher's
-composite-branch keyword args ``(operator, target, params,
-dispatch_child)`` and returns a single aggregated dict via 2-3 calls to
-``dispatch_child`` (the
-:class:`~meho_backplane.operations.composite.DispatchChild` callable
-the dispatcher builds in
-:func:`~meho_backplane.operations.dispatcher._run_source_kind_branch`).
+composite-branch keyword args ``(operator, target, params, connector)``
+and returns a single aggregated dict built from 2-3 sub-calls issued
+**directly on the connector's own authenticated session** --
+``connector._get_json`` / ``connector._post_json`` mounted through
+``connector.mount_op_path`` -- with no ``endpoint_descriptor`` lookup
+(#2253, the I-B read migration under Initiative #2249 / Goal #2247).
 
 Why module-level functions
 --------------------------
@@ -25,66 +25,61 @@ time (``__qualname__`` containing ``<locals>``). Module-level
 ``importlib.import_module`` + chained ``getattr`` at first-dispatch
 time.
 
-Why ``dispatch_child`` not direct httpx
----------------------------------------
+Why direct session, not ``dispatch_child``
+------------------------------------------
 
-Composite handlers MUST route every sub-call through ``dispatch_child``
-rather than calling the connector's ``_request_json`` directly, for
-four load-bearing reasons (per #508's issue body + the
-:class:`DispatchChild` Protocol docstring):
+Before #2253 these read handlers routed every sub-call through
+``dispatch_child`` -- the catalog-routed dispatcher seam that resolves
+each sub-op against an ``ingested`` ``endpoint_descriptor`` row. That
+coupled every read composite to a per-deploy vCenter-catalog ingest:
+until an operator ran ``meho connector ingest --catalog vmware/9.0`` the
+``GET:/vcenter/datastore`` / ``POST:/PropertyCollector/...`` sub-ops had
+no descriptor row and the composite failed with ``composite_l2_missing``
+(consumer signal 20, ``claude-rdc-hetzner-dc#697``). The two-world op
+model (Goal #2247) removes that coupling: the handler receives the
+resolved connector instance (the ``connector`` kwarg the #2251 substrate
+added to the composite contract) and issues each sub-call on the
+connector session, so the composite works on a fresh boot with **zero
+catalog ingest**. The precedent is the ``vmware.host.usage`` typed op
+(:mod:`~meho_backplane.connectors.vmware_rest.typed_ops`), which reads
+the same ``GET:/vcenter/host`` + ``RetrievePropertiesEx`` surface
+directly on the session.
 
-1. **Audit-tree linkage** -- ``dispatch_child`` binds
-   :data:`~meho_backplane.operations._audit.parent_audit_id_var` to the
-   composite parent's audit row, so every sub-op's audit row carries
-   ``parent_audit_id`` automatically. Direct httpx breaks the chain.
-2. **Bounded recursion** -- the
-   :data:`~meho_backplane.operations.composite.composite_depth_var`
-   contextvar enforces :attr:`Settings.composite_max_depth`. A
-   misbehaving handler that recursed into another composite would be
-   caught here, not at request-volume scale.
-3. **Policy + broadcast** -- the dispatcher's policy gate (G2.x) and
-   broadcast publish (G6.x) run on every dispatched sub-op. Direct
-   httpx evades both.
-4. **Param validation** -- each sub-op's ``parameter_schema`` validates
-   inbound params at dispatch time; direct httpx skips validation.
-
-Direct-session opt-in (the substrate, #2251)
---------------------------------------------
-
-The composite handler contract also lets a handler receive the
-resolved connector instance directly, by declaring a ``connector``
-parameter alongside (or instead of) ``dispatch_child``. The dispatcher
-forwards the instance it already resolved for the composite's target
-(:func:`~meho_backplane.operations.dispatcher._resolve_connector_instance`);
-:func:`~meho_backplane.operations._branches.dispatch_composite` passes
-it only when the handler declares the parameter, so the existing
-``dispatch_child``-only handlers below are unchanged. A handler that
-opts in issues its sub-calls through the connector's own session
-(``connector._get_json`` / ``connector._post_json`` +
-``connector.mount_op_path``) with **no** ``endpoint_descriptor``
-lookup.
-
-This is the substrate the I-B migrations (Initiative #2248) build on;
-no composite in this module is migrated yet. Taking the direct path
-deliberately drops two of the four ``dispatch_child`` guarantees and
-relocates the other two:
+``dispatch_child`` gave four guarantees (per #508); the direct path
+drops two and relocates the other two, which is why it is a **read**-only
+migration:
 
 * **(2) Bounded recursion is moot** -- a direct session call cannot
   re-enter the dispatcher, so there is no recursion to bound.
 * **(4) Per-sub-op param validation goes away** -- for a
   code-constructed request body this is the point, not a loss:
   re-validating a hand-built vmomi body against a persisted spec
-  schema is the schema-drift defect the two-world model (Goal #2247)
-  exists to remove.
-* **(1) Audit-tree linkage** collapses to the top-level op's own
-  audit row (the row a forensic query reads anyway); the per-sub-op
+  schema is the schema-drift defect the two-world model exists to
+  remove.
+* **(1) Audit-tree linkage** collapses to the top-level composite op's
+  own audit row (the row a forensic query reads anyway); the per-sub-op
   child rows disappear.
 * **(3) Per-sub-op policy-gate + broadcast is evaded** -- acceptable
   for **read** composites (the top-level op is already gated), but
   **load-bearing for write** composites whose sub-ops may be
-  approval-gated. Migrating a write composite to the direct path must
-  first resolve how the top-level policy/approval gate still covers
-  the now-internal writes (Initiative #2249, the property-3 question).
+  approval-gated, so the write composites keep ``dispatch_child``.
+  Migrating a write composite to the direct path must first resolve how
+  the top-level policy/approval gate still covers the now-internal
+  writes (Initiative #2249, the property-3 question).
+
+Error handling
+--------------
+
+A load-bearing sub-op (the datastore listing, a per-datastore detail
+read, a cluster/DRS read, an event/perf query) lets an
+:exc:`httpx.HTTPError` propagate: the dispatcher's outer exception
+branch wraps it into a ``connector_error`` :class:`OperationResult` for
+the composite parent, whose ``str(exc)`` already carries the upstream
+status code + offending URL. Optional enrichment legs (per-datastore
+VM placement, per-host property read, vSAN health) degrade best-effort
+instead -- they catch the transport error, null the enriched fields,
+and record a ``read_note`` / ``enrichment_note`` rather than sinking
+the whole aggregation.
 
 Op_id contract for sub-ops
 --------------------------
@@ -117,17 +112,16 @@ shape verbatim.
 
 from __future__ import annotations
 
-from typing import Any
+from typing import TYPE_CHECKING, Any
+
+import httpx
 
 from meho_backplane.auth.operator import Operator
-from meho_backplane.connectors import OperationResult
-from meho_backplane.connectors.vmware_rest.composites._preflight import (
-    preflight_l2_dependencies,
-)
-from meho_backplane.operations.composite import DispatchChild
+
+if TYPE_CHECKING:
+    from meho_backplane.connectors.vmware_rest.connector import VmwareRestConnector
 
 __all__ = [
-    "CompositeSubOpError",
     "cluster_drs_recommendations_composite",
     "datastore_usage_composite",
     "event_tail_composite",
@@ -138,10 +132,13 @@ __all__ = [
 ]
 
 
-# Sub-op ids the handlers dispatch through. Centralised so the
-# registration tests can assert against the same constants without
-# re-spelling the paths.
-_CONNECTOR_ID = "vmware-rest-9.0"
+# Canonical ``METHOD:/path`` sub-op ids. Each handler splits the string
+# into its verb + spec-relative path, substitutes ``{var}`` path params,
+# and mounts the path onto the target's live ``/api`` (modern) / ``/rest``
+# (legacy/vcsim) prefix for the direct session call (see
+# :func:`_read_sub_op`). Centralised so the ingest-reconcile acceptance
+# guard can assert the composite hits the same canonical paths the vCenter
+# catalog would emit.
 _OP_GET_CLUSTER = "GET:/vcenter/cluster/{cluster}"
 _OP_GET_CLUSTER_DRS = "GET:/vcenter/cluster/{cluster}/drs"
 _OP_POST_QUERY_EVENTS = "POST:/EventManager/{moId}/QueryEvents"
@@ -198,26 +195,15 @@ _OP_VSAN_QUERY_HEALTH_SUMMARY = (
 _VSAN_CLUSTER_HEALTH_SYSTEM_MOID = "vsan-cluster-health-system"
 _CLUSTER_COMPUTE_RESOURCE_MO_TYPE = "ClusterComputeResource"
 
-# Composite op_ids -- used by the preflight cache key. Centralised here
-# so the test-side coverage assertion (every registered composite has
-# both a sub-op_id tuple and a preflight-cache-key constant) can read
-# them by name rather than re-spelling.
-_COMPOSITE_OP_ID_CLUSTER_DRS_RECS = "vmware.composite.cluster.drs_recommendations"
-_COMPOSITE_OP_ID_EVENT_TAIL = "vmware.composite.event.tail"
-_COMPOSITE_OP_ID_PERFORMANCE_SUMMARY = "vmware.composite.performance.summary"
-_COMPOSITE_OP_ID_DATASTORE_USAGE = "vmware.composite.datastore.usage"
-_COMPOSITE_OP_ID_NETWORK_PORTGROUP_AUDIT = "vmware.composite.network.portgroup.audit"
-_COMPOSITE_OP_ID_HOST_NETWORK_UPLINKS = "vmware.composite.host.network_uplinks"
-_COMPOSITE_OP_ID_HOST_VSAN_HEALTH = "vmware.composite.host.vsan_health"
-
-# Per-composite sub-op-id tuples consumed by the L2 pre-flight check
-# (G0.14-T10 / #1151). Each tuple lists the L2 raw-REST sub-ops the
-# composite dispatches against; the pre-flight helper walks them
-# against ``endpoint_descriptor`` before any ``dispatch_child`` call so
-# a missing-L2 deployment surfaces as a structured
-# ``composite_l2_missing`` error rather than a mid-flight ``unknown_op``
-# from a sub-op call. See ``_preflight.py`` for the design rationale
-# (Option B / lazy pre-resolve).
+# Per-composite sub-op-id tuples. Each tuple lists the raw-REST /
+# vi-json sub-ops the composite issues directly on the connector
+# session. Pre-#2253 these fed the L2 pre-flight check that guarded a
+# missing catalog ingest; the direct-session migration removed that
+# coupling (the composites no longer need ingested descriptor rows), so
+# the tuples now serve as the canonical sub-op-path manifest the
+# ingest-reconcile acceptance guard
+# (``tests/acceptance/test_portgroup_audit_op_id_reconcile.py``) checks
+# against the vCenter spec.
 _SUB_OPS_CLUSTER_DRS_RECS: tuple[str, ...] = (
     _OP_GET_CLUSTER,
     _OP_GET_CLUSTER_DRS,
@@ -262,105 +248,48 @@ def _unwrap_value(payload: Any) -> Any:
     return payload
 
 
-def _describe_sub_op_failure(result: OperationResult) -> str:
-    """Render the most diagnostic line a failed sub-op result carries.
+async def _read_sub_op(
+    connector: VmwareRestConnector,
+    target: Any,
+    operator: Operator,
+    op_id: str,
+    *,
+    path_params: dict[str, Any] | None = None,
+    query: dict[str, Any] | None = None,
+    body: Any = None,
+) -> Any:
+    """Issue one composite sub-call directly on the connector's session.
 
-    The dispatcher's structured-error builders (``operations/_errors.py``)
-    put different fields on a sub-op's ``extras`` depending on the failure
-    class:
+    Splits the canonical ``METHOD:/path`` *op_id* into its verb + spec-
+    relative path, substitutes any ``{var}`` path params, mounts the path
+    onto *target*'s live ``/api`` (modern) or ``/rest`` (legacy/vcsim)
+    prefix via :meth:`VmwareRestConnector.mount_op_path`, and dispatches
+    through the connector's own authenticated session:
+    :meth:`~meho_backplane.connectors.adapters.http.HttpConnector._get_json`
+    for ``GET`` (tenacity-retried, idempotent) or
+    :meth:`~meho_backplane.connectors.adapters.http.HttpConnector._post_json`
+    for the vi-json ``POST`` methods. No ``endpoint_descriptor`` lookup,
+    so the sub-call works on a fresh boot with zero catalog ingest.
 
-    * An upstream ``403`` / ``422`` / ``401`` / ``440`` lands a structured
-      ``http_status`` plus the upstream's own ``upstream_message`` -- the
-      single most useful diagnostic line.
-    * Every other upstream status (``400``, ``404``, ``5xx`` ...) falls
-      through to the generic ``connector_error`` builder, which keeps the
-      stringified ``httpx.HTTPStatusError`` -- ``"Client error '400 Bad
-      Request' for url 'https://.../api/vcenter/vm?filter.datastores=...'"``
-      -- under ``exception_message``. That string already carries the
-      status code *and* the offending URL, so surfacing it is what the
-      ``filter.datastores`` 400 (#1908) needed.
+    ``path_params`` substitutes the ``{var}`` placeholders (vCenter moids
+    are bare ``[A-Za-z0-9-]`` tokens, so a plain ``str.format`` matches the
+    RFC6570 simple-expansion the ingested path did). ``query`` is the
+    GET query-string bucket (``filter.*``); ``body`` is the vi-json POST
+    method-argument object (moid excluded -- it rides the path).
 
-    Prefer the structured ``http_status`` + ``upstream_message`` when the
-    builder extracted them; otherwise fall back to the capped
-    ``exception_message``; otherwise the bare ``error`` summary. The detail
-    is appended to ``error`` only when it adds information beyond it.
+    Returns the raw parsed JSON (``value``-envelope handling stays with
+    the caller's :func:`_unwrap_value`). Transport / status failures raise
+    :exc:`httpx.HTTPError`; load-bearing callers let it propagate (the
+    dispatcher's outer branch wraps it as ``connector_error`` for the
+    composite parent, whose ``str(exc)`` carries the upstream status code
+    + offending URL), best-effort callers catch it.
     """
-    extras = result.extras
-    http_status = extras.get("http_status")
-    upstream_message = extras.get("upstream_message")
-    detail = extras.get("exception_message")
-    parts: list[str] = []
-    if result.error:
-        parts.append(result.error)
-    if http_status is not None:
-        status_clause = f"HTTP {http_status}"
-        if isinstance(upstream_message, str) and upstream_message.strip():
-            status_clause = f"{status_clause}: {upstream_message}"
-        parts.append(status_clause)
-    elif isinstance(detail, str) and detail.strip() and detail != result.error:
-        parts.append(detail)
-    if not parts:
-        parts.append("<no error message>")
-    return " -- ".join(parts)
-
-
-class CompositeSubOpError(RuntimeError):
-    """A composite sub-op returned a non-OK :class:`OperationResult`.
-
-    Raised by :func:`_require_ok` when a *load-bearing* sub-op fails (the
-    datastore listing, a per-datastore detail read, an event/perf query).
-    The dispatcher's outer exception branch wraps the raised exception
-    into a ``connector_error`` :class:`OperationResult` for the composite
-    parent (``operations/_errors.py::result_connector_error``), which
-    records ``type(exc).__name__`` and the capped ``str(exc)`` under the
-    parent's ``extras``.
-
-    The pre-#1908 shape raised a bare :class:`RuntimeError` whose message
-    stopped at ``status='error'`` plus the sub-op's terse ``error``
-    summary (``connector_error: HTTPStatusError``) -- the actual status
-    code and offending URL only showed when the operator replayed the
-    sub-op by hand. This class threads the sub-op's structured failure
-    (``op_id`` / ``status`` / ``error`` / ``extras``) through as
-    attributes *and* folds the most diagnostic line
-    (:func:`_describe_sub_op_failure` -- a structured ``http_status`` +
-    upstream message, or the stringified ``HTTPStatusError`` carrying the
-    status + URL) into ``str(self)`` so it lands in the composite parent's
-    ``extras["exception_message"]`` rather than being lost.
-
-    The ``returned status='<status>'`` clause is preserved verbatim so
-    existing consumers that string-match it keep working.
-    """
-
-    def __init__(self, result: OperationResult) -> None:
-        self.op_id = result.op_id
-        self.status = result.status
-        self.sub_op_error = result.error
-        self.sub_op_extras = dict(result.extras)
-        super().__init__(
-            f"composite sub-op {result.op_id!r} returned status="
-            f"{result.status!r}: {_describe_sub_op_failure(result)}"
-        )
-
-
-def _require_ok(result: OperationResult) -> Any:
-    """Return :attr:`OperationResult.result` or raise on a non-OK status.
-
-    The composite handlers fail loudly when a *load-bearing* sub-op errors
-    -- a swallowed error would silently produce a malformed aggregation.
-    The dispatcher's outer exception branch wraps the raised
-    :class:`CompositeSubOpError` into a ``connector_error``
-    :class:`OperationResult` for the composite parent, surfacing the
-    underlying sub-op's failure (status code + URL where the sub-op
-    carried them) on ``extras["exception_message"]``.
-
-    Optional enrichment legs (e.g. the per-datastore VM-placement lookup
-    in :func:`datastore_usage_composite`) must NOT route through this
-    helper -- they degrade best-effort instead of sinking the whole
-    composite.
-    """
-    if result.status != "ok":
-        raise CompositeSubOpError(result)
-    return result.result
+    method, _, path_template = op_id.partition(":")
+    path = path_template.format(**path_params) if path_params else path_template
+    mounted = await connector.mount_op_path(target, path, operator)
+    if method == "GET":
+        return await connector._get_json(target, mounted, operator=operator, params=query or None)
+    return await connector._post_json(target, mounted, operator=operator, json=body)
 
 
 async def cluster_drs_recommendations_composite(
@@ -368,13 +297,13 @@ async def cluster_drs_recommendations_composite(
     operator: Operator,
     target: Any,
     params: dict[str, Any],
-    dispatch_child: DispatchChild,
+    connector: VmwareRestConnector,
 ) -> dict[str, Any]:
     """Read cluster summary + DRS state in one composite call.
 
     Op-id: ``vmware.composite.cluster.drs_recommendations``.
 
-    Sub-ops dispatched (sequential):
+    Sub-ops read directly on the connector session (sequential):
 
     1. ``GET:/vcenter/cluster/{cluster}`` -- cluster summary (name,
        resource pool, default host, DRS-enabled flag).
@@ -398,28 +327,14 @@ async def cluster_drs_recommendations_composite(
     cluster summary plus the DRS config -- the format/aggregation is
     what differentiates the composite from a raw GET.
     """
-    await preflight_l2_dependencies(
-        composite_op_id=_COMPOSITE_OP_ID_CLUSTER_DRS_RECS,
-        sub_op_ids=_SUB_OPS_CLUSTER_DRS_RECS,
-        connector_id=_CONNECTOR_ID,
-        tenant_id=operator.tenant_id,
-    )
     cluster_moid = params["cluster"]
     include_history = bool(params.get("include_recommendations_history", False))
 
-    cluster_result = _require_ok(
-        await dispatch_child(
-            connector_id=_CONNECTOR_ID,
-            op_id=_OP_GET_CLUSTER,
-            params={"cluster": cluster_moid},
-        )
+    cluster_result = await _read_sub_op(
+        connector, target, operator, _OP_GET_CLUSTER, path_params={"cluster": cluster_moid}
     )
-    drs_result = _require_ok(
-        await dispatch_child(
-            connector_id=_CONNECTOR_ID,
-            op_id=_OP_GET_CLUSTER_DRS,
-            params={"cluster": cluster_moid},
-        )
+    drs_result = await _read_sub_op(
+        connector, target, operator, _OP_GET_CLUSTER_DRS, path_params={"cluster": cluster_moid}
     )
     out: dict[str, Any] = {
         "cluster": _unwrap_value(cluster_result),
@@ -446,13 +361,13 @@ async def event_tail_composite(
     operator: Operator,
     target: Any,
     params: dict[str, Any],
-    dispatch_child: DispatchChild,
+    connector: VmwareRestConnector,
 ) -> dict[str, Any]:
     """Tail recent events via EventManager.QueryEvents (vi-json).
 
     Op-id: ``vmware.composite.event.tail``.
 
-    Sub-ops dispatched (sequential, single call):
+    Sub-op read directly on the connector session (single call):
 
     1. ``POST:/EventManager/{moId}/QueryEvents`` -- recent events. The
        vi-json call returns an array of event dicts; the handler caps
@@ -465,20 +380,10 @@ async def event_tail_composite(
         "moId": <str>, "max_events_applied": <int>}``. ``count`` is
         the post-cap length so operators can detect truncation.
     """
-    await preflight_l2_dependencies(
-        composite_op_id=_COMPOSITE_OP_ID_EVENT_TAIL,
-        sub_op_ids=_SUB_OPS_EVENT_TAIL,
-        connector_id=_CONNECTOR_ID,
-        tenant_id=operator.tenant_id,
-    )
     mo_id = params.get("moId", "EventManager")
     max_events = int(params.get("max_events", 100))
-    raw = _require_ok(
-        await dispatch_child(
-            connector_id=_CONNECTOR_ID,
-            op_id=_OP_POST_QUERY_EVENTS,
-            params={"moId": mo_id},
-        )
+    raw = await _read_sub_op(
+        connector, target, operator, _OP_POST_QUERY_EVENTS, path_params={"moId": mo_id}
     )
     events = _unwrap_value(raw)
     if not isinstance(events, list):
@@ -502,13 +407,13 @@ async def performance_summary_composite(
     operator: Operator,
     target: Any,
     params: dict[str, Any],
-    dispatch_child: DispatchChild,
+    connector: VmwareRestConnector,
 ) -> dict[str, Any]:
     """Summarise performance metrics for one entity via PerformanceManager (vi-json).
 
     Op-id: ``vmware.composite.performance.summary``.
 
-    Sub-ops dispatched (sequential):
+    Sub-ops read directly on the connector session (sequential):
 
     1. ``POST:/PerformanceManager/{moId}/QueryAvailablePerfMetric`` --
        discover available counter IDs for the target entity.
@@ -527,24 +432,25 @@ async def performance_summary_composite(
     gets a complete snapshot. A counter-curation flag (e.g.
     ``counter_ids``) is an explicit v0.2.next concern per the issue
     body's *Out of scope* section.
+
+    The vi-json method arguments (``entity``, ``interval_seconds``)
+    become the flat JSON request body; the ``moId`` targets the
+    PerformanceManager singleton in the path -- the same method-args-as-
+    body shape the ``vmware.host.usage`` typed op sends for
+    RetrievePropertiesEx.
     """
-    await preflight_l2_dependencies(
-        composite_op_id=_COMPOSITE_OP_ID_PERFORMANCE_SUMMARY,
-        sub_op_ids=_SUB_OPS_PERFORMANCE_SUMMARY,
-        connector_id=_CONNECTOR_ID,
-        tenant_id=operator.tenant_id,
-    )
     entity_moid = params["entity_moid"]
     perf_mgr_moid = params.get("perf_manager_moid", "PerfMgr")
     interval_s = int(params.get("interval_seconds", 20))
     max_samples = int(params.get("max_samples", 60))
 
-    available_raw = _require_ok(
-        await dispatch_child(
-            connector_id=_CONNECTOR_ID,
-            op_id=_OP_POST_QUERY_AVAILABLE_PERF_METRIC,
-            params={"moId": perf_mgr_moid, "entity": entity_moid},
-        )
+    available_raw = await _read_sub_op(
+        connector,
+        target,
+        operator,
+        _OP_POST_QUERY_AVAILABLE_PERF_METRIC,
+        path_params={"moId": perf_mgr_moid},
+        body={"entity": entity_moid},
     )
     available = _unwrap_value(available_raw)
     if not isinstance(available, list):
@@ -554,16 +460,13 @@ async def performance_summary_composite(
             f"got {type(available).__name__}"
         )
 
-    samples_raw = _require_ok(
-        await dispatch_child(
-            connector_id=_CONNECTOR_ID,
-            op_id=_OP_POST_QUERY_PERF,
-            params={
-                "moId": perf_mgr_moid,
-                "entity": entity_moid,
-                "interval_seconds": interval_s,
-            },
-        )
+    samples_raw = await _read_sub_op(
+        connector,
+        target,
+        operator,
+        _OP_POST_QUERY_PERF,
+        path_params={"moId": perf_mgr_moid},
+        body={"entity": entity_moid, "interval_seconds": interval_s},
     )
     samples = _unwrap_value(samples_raw)
     if not isinstance(samples, list):
@@ -582,24 +485,22 @@ async def performance_summary_composite(
     }
 
 
-# Pre-existing >100-line handler from G3.1-T5 #508; G0.14-T10 #1151
-# added a 6-line pre-flight call at the top and G0.27 #1908 made the
-# per-datastore VM-placement leg best-effort -- both extend an already
-# block-sized handler. Refactor (e.g. extracting the per-datastore row
-# builder) is out of scope here.
+# Pre-existing >100-line handler from G3.1-T5 #508; G0.27 #1908 made the
+# per-datastore VM-placement leg best-effort. Refactor (e.g. extracting
+# the per-datastore row builder) is out of scope here.
 # code-quality-allow: pre-existing G3.1-T5 #508 handler; #1908 best-effort enrichment only
 async def datastore_usage_composite(
     *,
     operator: Operator,
     target: Any,
     params: dict[str, Any],
-    dispatch_child: DispatchChild,
+    connector: VmwareRestConnector,
 ) -> dict[str, Any]:
     """List datastores with capacity + free + VM placement summary.
 
     Op-id: ``vmware.composite.datastore.usage``.
 
-    Sub-ops dispatched (per-datastore, sequential):
+    Sub-ops read directly on the connector session (per-datastore, sequential):
 
     1. ``GET:/vcenter/datastore`` -- list every datastore (optionally
        narrowed via ``filter.names``).
@@ -640,24 +541,14 @@ async def datastore_usage_composite(
         describing the skipped enrichment; on success the row has no
         ``enrichment_note`` key.
     """
-    await preflight_l2_dependencies(
-        composite_op_id=_COMPOSITE_OP_ID_DATASTORE_USAGE,
-        sub_op_ids=_SUB_OPS_DATASTORE_USAGE,
-        connector_id=_CONNECTOR_ID,
-        tenant_id=operator.tenant_id,
-    )
     filter_names: list[str] = list(params.get("filter_names") or [])
 
-    listing_params: dict[str, Any] = {}
+    listing_query: dict[str, Any] = {}
     if filter_names:
-        listing_params["filter.names"] = filter_names
+        listing_query["filter.names"] = filter_names
 
-    listing = _require_ok(
-        await dispatch_child(
-            connector_id=_CONNECTOR_ID,
-            op_id=_OP_LIST_DATASTORES,
-            params=listing_params,
-        )
+    listing = await _read_sub_op(
+        connector, target, operator, _OP_LIST_DATASTORES, query=listing_query
     )
     entries = _unwrap_value(listing)
     if not isinstance(entries, list):
@@ -676,12 +567,8 @@ async def datastore_usage_composite(
             # ``datastore``; absence is an upstream malformation. Skip
             # silently rather than abort the aggregation.
             continue
-        detail = _require_ok(
-            await dispatch_child(
-                connector_id=_CONNECTOR_ID,
-                op_id=_OP_GET_DATASTORE,
-                params={"datastore": ds_id},
-            )
+        detail = await _read_sub_op(
+            connector, target, operator, _OP_GET_DATASTORE, path_params={"datastore": ds_id}
         )
         detail_payload = _unwrap_value(detail)
         detail_capacity = (
@@ -711,15 +598,21 @@ async def datastore_usage_composite(
         # capacity/free/type read above already satisfies the
         # storage-usage use case, so a failure on the optional VM lookup
         # (e.g. a vCenter that 400s the ``filter.datastores`` query)
-        # nulls vm_count/vm_names and records why, rather than raising
-        # through ``_require_ok`` and sinking every datastore row.
-        vms_result = await dispatch_child(
-            connector_id=_CONNECTOR_ID,
-            op_id=_OP_LIST_VMS,
-            params={"filter.datastores": [ds_id]},
-        )
-        if vms_result.status == "ok":
-            vm_entries = _unwrap_value(vms_result.result)
+        # nulls vm_count/vm_names and records why, rather than
+        # propagating the transport error and sinking every datastore row.
+        try:
+            vms_raw = await _read_sub_op(
+                connector, target, operator, _OP_LIST_VMS, query={"filter.datastores": [ds_id]}
+            )
+        except httpx.HTTPError as exc:
+            row["vm_count"] = None
+            row["vm_names"] = None
+            row["enrichment_note"] = (
+                f"vm-placement enrichment skipped: sub-op {_OP_LIST_VMS!r} "
+                f"failed with {type(exc).__name__}: {exc}"
+            )
+        else:
+            vm_entries = _unwrap_value(vms_raw)
             if not isinstance(vm_entries, list):
                 vm_entries = []
             vm_names = [
@@ -729,35 +622,24 @@ async def datastore_usage_composite(
             ]
             row["vm_count"] = len(vm_names)
             row["vm_names"] = vm_names
-        else:
-            row["vm_count"] = None
-            row["vm_names"] = None
-            row["enrichment_note"] = (
-                f"vm-placement enrichment skipped: sub-op {_OP_LIST_VMS!r} "
-                f"returned status={vms_result.status!r}: "
-                f"{_describe_sub_op_failure(vms_result)}"
-            )
         aggregated.append(row)
     return {"datastores": aggregated}
 
 
-# Pre-existing >100-line handler from G3.1-T5 #508; G0.14-T10 #1151
-# added a 6-line pre-flight call at the top, pushing the diff-only
-# checker into block territory. Refactor is out of scope for T10
-# (the L2-dependency strategy).
-# code-quality-allow: pre-existing G3.1-T5 #508 handler, T10 added preflight only
+# Pre-existing >100-line handler from G3.1-T5 #508.
+# code-quality-allow: pre-existing G3.1-T5 #508 handler
 async def network_portgroup_audit_composite(
     *,
     operator: Operator,
     target: Any,
     params: dict[str, Any],
-    dispatch_child: DispatchChild,
+    connector: VmwareRestConnector,
 ) -> dict[str, Any]:
     """Audit distributed portgroups with parent DVS + connected-VM aggregation.
 
     Op-id: ``vmware.composite.network.portgroup.audit``.
 
-    Sub-ops dispatched:
+    Sub-ops read directly on the connector session:
 
     1. ``GET:/vcenter/network/distributed-switches`` -- list DVS
        entries (filtered to ``filter_dvs`` via the resource's
@@ -789,26 +671,14 @@ async def network_portgroup_audit_composite(
     expose a ``vds``/``distributed_switch`` field (e.g. a richer target
     or a future spec revision), ``None`` otherwise.
     """
-    await preflight_l2_dependencies(
-        composite_op_id=_COMPOSITE_OP_ID_NETWORK_PORTGROUP_AUDIT,
-        sub_op_ids=_SUB_OPS_NETWORK_PORTGROUP_AUDIT,
-        connector_id=_CONNECTOR_ID,
-        tenant_id=operator.tenant_id,
-    )
     filter_dvs = params.get("filter_dvs")
     include_disconnected = bool(params.get("include_disconnected_vms", False))
 
-    dvs_params: dict[str, Any] = {}
+    dvs_query: dict[str, Any] = {}
     if isinstance(filter_dvs, str):
-        dvs_params["filter.vdses"] = [filter_dvs]
+        dvs_query["filter.vdses"] = [filter_dvs]
 
-    dvs_listing = _require_ok(
-        await dispatch_child(
-            connector_id=_CONNECTOR_ID,
-            op_id=_OP_LIST_DVS,
-            params=dvs_params,
-        )
-    )
+    dvs_listing = await _read_sub_op(connector, target, operator, _OP_LIST_DVS, query=dvs_query)
     dvs_entries = _unwrap_value(dvs_listing)
     if not isinstance(dvs_entries, list):
         dvs_entries = []
@@ -828,15 +698,9 @@ async def network_portgroup_audit_composite(
     # standalone distributed-portgroup list endpoint. ``filter_dvs`` has
     # no analogue on this FilterSpec, so it is deliberately not threaded
     # in here (it scopes the DVS index above instead).
-    pg_params: dict[str, Any] = {"filter.types": [_NETWORK_TYPE_DISTRIBUTED_PORTGROUP]}
+    pg_query: dict[str, Any] = {"filter.types": [_NETWORK_TYPE_DISTRIBUTED_PORTGROUP]}
 
-    pg_listing = _require_ok(
-        await dispatch_child(
-            connector_id=_CONNECTOR_ID,
-            op_id=_OP_LIST_NETWORK,
-            params=pg_params,
-        )
-    )
+    pg_listing = await _read_sub_op(connector, target, operator, _OP_LIST_NETWORK, query=pg_query)
     pg_entries = _unwrap_value(pg_listing)
     if not isinstance(pg_entries, list):
         raise RuntimeError(
@@ -851,19 +715,13 @@ async def network_portgroup_audit_composite(
         pg_id = entry.get("network") or entry.get("portgroup")
         if not isinstance(pg_id, str):
             continue
-        vm_params: dict[str, Any] = {"filter.networks": [pg_id]}
+        vm_query: dict[str, Any] = {"filter.networks": [pg_id]}
         if not include_disconnected:
             # vSphere REST accepts a power-state filter; the
             # ``include_disconnected`` flag toggles it. Default is
             # active VMs only.
-            vm_params["filter.power_states"] = ["POWERED_ON"]
-        vms = _require_ok(
-            await dispatch_child(
-                connector_id=_CONNECTOR_ID,
-                op_id=_OP_LIST_VMS,
-                params=vm_params,
-            )
-        )
+            vm_query["filter.power_states"] = ["POWERED_ON"]
+        vms = await _read_sub_op(connector, target, operator, _OP_LIST_VMS, query=vm_query)
         vm_entries = _unwrap_value(vms)
         if not isinstance(vm_entries, list):
             vm_entries = []
@@ -977,16 +835,18 @@ def _extract_host_network_props(retrieve_result: Any) -> tuple[list[Any], list[A
     )
 
 
-def _build_retrieve_properties_params(host_moid: str) -> dict[str, Any]:
-    """Build the ``RetrievePropertiesEx`` specSet for one host's network config.
+def _build_retrieve_properties_body(host_moid: str) -> dict[str, Any]:
+    """Build the ``RetrievePropertiesEx`` request body for one host's network config.
 
     A single ``PropertyFilterSpec`` scoped directly to the host object
     (no ContainerView / TraversalSpec) requesting the two network
-    config property paths. ``moId`` targets the ``propertyCollector``
-    singleton.
+    config property paths. The ``propertyCollector`` singleton moId
+    rides the request path (:data:`_OP_RETRIEVE_PROPERTIES`), so the
+    body is just the ``specSet`` + ``options`` method arguments -- the
+    VI-JSON ``RetrievePropertiesExRequestType`` shape the
+    ``vmware.host.usage`` typed op sends.
     """
     return {
-        "moId": _PROPERTY_COLLECTOR_MOID,
         "specSet": [
             {
                 "propSet": [
@@ -1006,9 +866,11 @@ def _build_retrieve_properties_params(host_moid: str) -> dict[str, Any]:
 
 
 async def _build_host_uplink_row(
+    connector: VmwareRestConnector,
+    target: Any,
+    operator: Operator,
     host_id: str,
     host_name: Any,
-    dispatch_child: DispatchChild,
 ) -> dict[str, Any]:
     """Build one host row: identity + best-effort pnic / proxy-switch detail.
 
@@ -1018,25 +880,28 @@ async def _build_host_uplink_row(
     why (``read_note``) rather than sinking the whole composite.
     """
     row: dict[str, Any] = {"id": host_id, "name": host_name}
-    props_result = await dispatch_child(
-        connector_id=_CONNECTOR_ID,
-        op_id=_OP_RETRIEVE_PROPERTIES,
-        params=_build_retrieve_properties_params(host_id),
-    )
-    if props_result.status == "ok":
-        raw_pnics, raw_proxy_switches = _extract_host_network_props(props_result.result)
-        row["pnics"] = [_parse_pnic(p) for p in raw_pnics if isinstance(p, dict)]
-        row["proxy_switches"] = [
-            _parse_proxy_switch(ps) for ps in raw_proxy_switches if isinstance(ps, dict)
-        ]
-    else:
+    try:
+        props_result = await _read_sub_op(
+            connector,
+            target,
+            operator,
+            _OP_RETRIEVE_PROPERTIES,
+            path_params={"moId": _PROPERTY_COLLECTOR_MOID},
+            body=_build_retrieve_properties_body(host_id),
+        )
+    except httpx.HTTPError as exc:
         row["pnics"] = None
         row["proxy_switches"] = None
         row["read_note"] = (
             f"host-network property read skipped: sub-op "
-            f"{_OP_RETRIEVE_PROPERTIES!r} returned status="
-            f"{props_result.status!r}: {_describe_sub_op_failure(props_result)}"
+            f"{_OP_RETRIEVE_PROPERTIES!r} failed with {type(exc).__name__}: {exc}"
         )
+        return row
+    raw_pnics, raw_proxy_switches = _extract_host_network_props(props_result)
+    row["pnics"] = [_parse_pnic(p) for p in raw_pnics if isinstance(p, dict)]
+    row["proxy_switches"] = [
+        _parse_proxy_switch(ps) for ps in raw_proxy_switches if isinstance(ps, dict)
+    ]
     return row
 
 
@@ -1045,13 +910,13 @@ async def host_network_uplinks_composite(
     operator: Operator,
     target: Any,
     params: dict[str, Any],
-    dispatch_child: DispatchChild,
+    connector: VmwareRestConnector,
 ) -> dict[str, Any]:
     """Per host: physical NICs (link state + speed) and their proxy-switch uplinks.
 
     Op-id: ``vmware.composite.host.network_uplinks``.
 
-    Sub-ops dispatched:
+    Sub-ops read directly on the connector session:
 
     1. ``GET:/vcenter/host`` -- list every host (optionally narrowed via
        ``filter_hosts``). Load-bearing: a failure here sinks the
@@ -1085,25 +950,13 @@ async def host_network_uplinks_composite(
         ``proxy_switches`` are ``None`` and the row carries a
         ``read_note``.
     """
-    await preflight_l2_dependencies(
-        composite_op_id=_COMPOSITE_OP_ID_HOST_NETWORK_UPLINKS,
-        sub_op_ids=_SUB_OPS_HOST_NETWORK_UPLINKS,
-        connector_id=_CONNECTOR_ID,
-        tenant_id=operator.tenant_id,
-    )
     filter_hosts: list[str] = list(params.get("filter_hosts") or [])
 
-    listing_params: dict[str, Any] = {}
+    listing_query: dict[str, Any] = {}
     if filter_hosts:
-        listing_params["filter.hosts"] = filter_hosts
+        listing_query["filter.hosts"] = filter_hosts
 
-    listing = _require_ok(
-        await dispatch_child(
-            connector_id=_CONNECTOR_ID,
-            op_id=_OP_LIST_HOSTS,
-            params=listing_params,
-        )
-    )
+    listing = await _read_sub_op(connector, target, operator, _OP_LIST_HOSTS, query=listing_query)
     entries = _unwrap_value(listing)
     if not isinstance(entries, list):
         raise RuntimeError(
@@ -1120,7 +973,9 @@ async def host_network_uplinks_composite(
             # vSphere REST returns the moid under ``host``; absence is an
             # upstream malformation -- skip rather than abort.
             continue
-        aggregated.append(await _build_host_uplink_row(host_id, entry.get("name"), dispatch_child))
+        aggregated.append(
+            await _build_host_uplink_row(connector, target, operator, host_id, entry.get("name"))
+        )
     return {"hosts": aggregated}
 
 
@@ -1164,18 +1019,17 @@ def _parse_vsan_health_group(group: dict[str, Any]) -> dict[str, Any]:
     }
 
 
-def _build_vsan_query_health_params(cluster_moid: str) -> dict[str, Any]:
-    """Build the ``VsanQueryVcClusterHealthSummary`` argument set for one cluster.
+def _build_vsan_query_health_body(cluster_moid: str) -> dict[str, Any]:
+    """Build the ``VsanQueryVcClusterHealthSummary`` request body for one cluster.
 
-    ``moId`` targets the ``vsan-cluster-health-system`` singleton on the
-    ``/vsanHealth`` vmomi endpoint; ``cluster`` carries the target
-    cluster's MoRef (a ``ClusterComputeResource``). Every other
-    parameter of the method (``includeObjUuids`` / ``fields`` / …) is
-    optional and left to the health service's defaults so the read
-    returns the full summary.
+    The ``vsan-cluster-health-system`` singleton moId rides the request
+    path (:data:`_OP_VSAN_QUERY_HEALTH_SUMMARY`); the body carries the
+    method's ``cluster`` argument -- the target cluster's MoRef (a
+    ``ClusterComputeResource``). Every other parameter of the method
+    (``includeObjUuids`` / ``fields`` / …) is optional and left to the
+    health service's defaults so the read returns the full summary.
     """
     return {
-        "moId": _VSAN_CLUSTER_HEALTH_SYSTEM_MOID,
         "cluster": {"type": _CLUSTER_COMPUTE_RESOURCE_MO_TYPE, "value": cluster_moid},
     }
 
@@ -1185,13 +1039,13 @@ async def host_vsan_health_composite(
     operator: Operator,
     target: Any,
     params: dict[str, Any],
-    dispatch_child: DispatchChild,
+    connector: VmwareRestConnector,
 ) -> dict[str, Any]:
     """Per cluster: vSAN health-test groups + overall health status.
 
     Op-id: ``vmware.composite.host.vsan_health``.
 
-    Sub-ops dispatched:
+    Sub-op read directly on the connector session:
 
     1. ``POST:/VsanVcClusterHealthSystem/{moId}/VsanQueryVcClusterHealthSummary``
        against the ``vsan-cluster-health-system`` singleton, scoped to
@@ -1201,7 +1055,7 @@ async def host_vsan_health_composite(
        ``/vsanHealth`` endpoint that rejects the vi-json call, a
        transient auth expiry) the summary is returned with ``groups`` /
        ``overall_health`` set to ``null`` and a ``read_note`` recording
-       why, rather than raising through ``_require_ok``.
+       why, rather than propagating the transport error.
 
     vSAN health is the one read the plain vSphere Automation REST
     surface cannot reproduce: the health-test-group / overall-status
@@ -1222,36 +1076,33 @@ async def host_vsan_health_composite(
         and ``groups`` are ``null`` and the payload carries a
         ``read_note``.
     """
-    await preflight_l2_dependencies(
-        composite_op_id=_COMPOSITE_OP_ID_HOST_VSAN_HEALTH,
-        sub_op_ids=_SUB_OPS_HOST_VSAN_HEALTH,
-        connector_id=_CONNECTOR_ID,
-        tenant_id=operator.tenant_id,
-    )
     cluster_moid = params["cluster"]
 
     out: dict[str, Any] = {"cluster": cluster_moid}
-    health_result = await dispatch_child(
-        connector_id=_CONNECTOR_ID,
-        op_id=_OP_VSAN_QUERY_HEALTH_SUMMARY,
-        params=_build_vsan_query_health_params(cluster_moid),
-    )
-    if health_result.status == "ok":
-        summary = _unwrap_value(health_result.result)
-        raw_groups = summary.get("groups") if isinstance(summary, dict) else None
-        overall = summary.get("overallHealth") if isinstance(summary, dict) else None
-        out["overall_health"] = overall
-        out["groups"] = (
-            [_parse_vsan_health_group(g) for g in raw_groups if isinstance(g, dict)]
-            if isinstance(raw_groups, list)
-            else []
+    try:
+        health_result = await _read_sub_op(
+            connector,
+            target,
+            operator,
+            _OP_VSAN_QUERY_HEALTH_SUMMARY,
+            path_params={"moId": _VSAN_CLUSTER_HEALTH_SYSTEM_MOID},
+            body=_build_vsan_query_health_body(cluster_moid),
         )
-    else:
+    except httpx.HTTPError as exc:
         out["overall_health"] = None
         out["groups"] = None
         out["read_note"] = (
             f"vsan health-service read skipped: sub-op "
-            f"{_OP_VSAN_QUERY_HEALTH_SUMMARY!r} returned status="
-            f"{health_result.status!r}: {_describe_sub_op_failure(health_result)}"
+            f"{_OP_VSAN_QUERY_HEALTH_SUMMARY!r} failed with {type(exc).__name__}: {exc}"
         )
+        return out
+    summary = _unwrap_value(health_result)
+    raw_groups = summary.get("groups") if isinstance(summary, dict) else None
+    overall = summary.get("overallHealth") if isinstance(summary, dict) else None
+    out["overall_health"] = overall
+    out["groups"] = (
+        [_parse_vsan_health_group(g) for g in raw_groups if isinstance(g, dict)]
+        if isinstance(raw_groups, list)
+        else []
+    )
     return out

--- a/backend/src/meho_backplane/operations/dispatcher.py
+++ b/backend/src/meho_backplane/operations/dispatcher.py
@@ -356,14 +356,30 @@ type Dispatcher = Callable[..., Awaitable[OperationResult]]
 
 
 def _handler_requires_target(handler_ref: str) -> bool:
-    """True when *handler_ref* names a connector-bound (self-first) handler.
+    """True when *handler_ref* names a handler that reaches its connector via the target.
 
     Keys the no-target guard on **handler shape**, not just
-    ``source_kind`` — a typed/composite handler whose first parameter is
-    ``self`` is a connector method that only binds to its instance
-    *through* a resolved target, so dispatching it with ``target=None``
-    is a usage error (G0.20-T6 #1506). A module-level handler (no
-    ``self``) genuinely needs no target and must keep dispatching with
+    ``source_kind``. Two shapes reach their connector instance *through*
+    the resolved target, so dispatching them with ``target=None`` is a
+    usage error rather than a legitimate module-level no-target call:
+
+    * **Self-first (bound method)** -- a typed/composite handler whose
+      first parameter is ``self`` is a connector method that only binds
+      to its instance through a resolved target (G0.20-T6 #1506).
+    * **``connector``-declaring composite (direct-session, #2251)** -- a
+      composite handler that declares a ``connector`` parameter receives
+      the resolved connector instance the dispatcher built from the
+      target (see
+      :func:`~meho_backplane.operations._branches.dispatch_composite`).
+      With ``target=None`` the resolver produces ``connector_instance=None``,
+      which the handler would then dereference on its first
+      ``connector._get_json`` call and raise an
+      :exc:`AttributeError` deep in the handler body. Catching it here as
+      ``target_required`` gives the operator the same clear
+      omitted-argument diagnosis the self-first shape gets.
+
+    A module-level handler that declares neither (no ``self``, no
+    ``connector``) genuinely needs no target and keeps dispatching with
     ``connector_instance=None``.
 
     Mirrors the first-parameter check :func:`dispatch_typed` uses for its
@@ -379,7 +395,9 @@ def _handler_requires_target(handler_ref: str) -> bool:
     except (ImportError, TypeError):
         return False
     param_names = list(inspect.signature(handler).parameters.keys())
-    return bool(param_names) and param_names[0] == "self"
+    if param_names and param_names[0] == "self":
+        return True
+    return "connector" in param_names
 
 
 async def _resolve_connector_instance(

--- a/backend/tests/integration/test_connectors_vmware_rest_vcsim.py
+++ b/backend/tests/integration/test_connectors_vmware_rest_vcsim.py
@@ -367,3 +367,132 @@ async def test_host_usage_over_legacy_mount_routes_to_rest(
     rows = result["hosts"]
     assert [r["id"] for r in rows] == ["host-11", "host-22"]
     assert rows[0]["hardware"]["cpu_mhz"] == 3000
+
+
+# ---------------------------------------------------------------------------
+# Read composite direct-session dispatch (#2253) — end-to-end transport +
+# mount routing with ZERO ingested descriptors (fresh-boot contract)
+# ---------------------------------------------------------------------------
+
+#: ``GET /vcenter/datastore`` listing (2-datastore seed, bare modern shape).
+_DATASTORE_LISTING: list[dict[str, Any]] = [
+    {"datastore": "datastore-11", "name": "ds-a", "type": "VMFS"},
+    {"datastore": "datastore-22", "name": "ds-b", "type": "NFS"},
+]
+
+#: Per-datastore ``GET /vcenter/datastore/{ds}`` detail bodies.
+_DATASTORE_DETAIL: dict[str, dict[str, Any]] = {
+    "datastore-11": {"capacity": 1000, "free_space": 400, "type": "VMFS"},
+    "datastore-22": {"capacity": 5000, "free_space": 2500, "type": "NFS"},
+}
+
+
+def _register_datastore_composite_routes(mock: respx.MockRouter, *, mount: str) -> None:
+    """Register the datastore-usage composite's sub-op surface under *mount*.
+
+    The composite issues, directly on the session (no ingested descriptor,
+    no dispatch_child): the datastore listing, one per-datastore detail
+    GET, and one per-datastore VM-placement GET (``filter.datastores``).
+    All are mounted onto ``mount`` (``/api`` modern or ``/rest`` legacy) by
+    ``mount_op_path``.
+    """
+    mock.get(f"{mount}/vcenter/datastore").respond(200, json=_DATASTORE_LISTING)
+    for ds_id, detail in _DATASTORE_DETAIL.items():
+        mock.get(f"{mount}/vcenter/datastore/{ds_id}").respond(200, json=detail)
+    # A single VM-placement stub serves every per-datastore ``filter.datastores``
+    # query; the composite only counts names, so one VM per datastore is enough.
+    mock.get(f"{mount}/vcenter/vm").respond(200, json=[{"name": "vm-x"}])
+
+
+@pytest.mark.asyncio
+async def test_datastore_usage_composite_over_modern_mount(
+    vcsim_target: _VcsimTarget,
+) -> None:
+    """The read composite aggregates directly on the session, mounted onto /api.
+
+    Exercises the full #2253 direct-session path end to end against the
+    real connector transport (respx-intercepted): session establish ->
+    ``mount_op_path`` -> ``_get_json`` per sub-op -> aggregation. No
+    ingested ``endpoint_descriptor`` rows exist here, proving the
+    fresh-boot / zero-catalog-ingest contract.
+    """
+    from meho_backplane.connectors.vmware_rest.composites._read import (
+        datastore_usage_composite,
+    )
+
+    async def _loader(_target: VsphereTargetLike, _operator: Operator) -> dict[str, str]:
+        return {"username": "user", "password": "pass"}
+
+    connector = VmwareRestConnector(session_loader=_loader)
+
+    async with respx.mock(
+        base_url=VCENTER_BASE_URL,
+        assert_all_called=False,
+        assert_all_mocked=False,
+    ) as mock:
+        mock.post("/api/session").respond(200, json=SESSION_TOKEN)
+        _register_datastore_composite_routes(mock, mount="/api")
+        mock.delete("/api/session").respond(204)
+        try:
+            out = await datastore_usage_composite(
+                operator=_operator(),
+                target=vcsim_target,
+                params={},
+                connector=connector,
+            )
+        finally:
+            await connector.aclose()
+
+    rows = out["datastores"]
+    assert [r["id"] for r in rows] == ["datastore-11", "datastore-22"]
+    assert rows[0]["capacity"] == 1000
+    assert rows[0]["free_space"] == 400
+    assert rows[0]["vm_count"] == 1
+    assert rows[0]["vm_names"] == ["vm-x"]
+
+
+@pytest.mark.asyncio
+async def test_datastore_usage_composite_over_legacy_mount_routes_to_rest(
+    vcsim_target: _VcsimTarget,
+) -> None:
+    """A legacy-only target (modern /api/session 404s) mounts the composite onto /rest.
+
+    Reproduces the vcsim / old-vCenter topology: the modern session
+    endpoint 404s, the connector falls back to the legacy path, and every
+    composite sub-op must route through ``/rest`` via ``mount_op_path`` or
+    it 404s. This is the modern+legacy mount-fallback coverage the #2253
+    acceptance criteria require, on the composite path.
+    """
+    from meho_backplane.connectors.vmware_rest.composites._read import (
+        datastore_usage_composite,
+    )
+
+    async def _loader(_target: VsphereTargetLike, _operator: Operator) -> dict[str, str]:
+        return {"username": "user", "password": "pass"}
+
+    connector = VmwareRestConnector(session_loader=_loader)
+
+    async with respx.mock(
+        base_url=VCENTER_BASE_URL,
+        assert_all_called=False,
+        assert_all_mocked=False,
+    ) as mock:
+        # Modern session endpoint absent (404) -> legacy fallback.
+        mock.post("/api/session").respond(404)
+        mock.post("/rest/com/vmware/cis/session").respond(200, json=SESSION_TOKEN)
+        # Sub-ops served ONLY under the legacy /rest mount.
+        _register_datastore_composite_routes(mock, mount="/rest")
+        mock.delete("/rest/com/vmware/cis/session").respond(204)
+        try:
+            out = await datastore_usage_composite(
+                operator=_operator(),
+                target=vcsim_target,
+                params={},
+                connector=connector,
+            )
+        finally:
+            await connector.aclose()
+
+    rows = out["datastores"]
+    assert [r["id"] for r in rows] == ["datastore-11", "datastore-22"]
+    assert rows[1]["capacity"] == 5000

--- a/backend/tests/test_connectors_vmware_rest_composites_l2_preflight.py
+++ b/backend/tests/test_connectors_vmware_rest_composites_l2_preflight.py
@@ -46,14 +46,10 @@ from uuid import UUID
 import pytest
 
 from meho_backplane.auth.operator import Operator, TenantRole
-from meho_backplane.connectors import OperationResult
 from meho_backplane.connectors.vmware_rest.composites import _preflight
 from meho_backplane.connectors.vmware_rest.composites._preflight import (
     preflight_l2_dependencies,
     reset_preflight_cache,
-)
-from meho_backplane.connectors.vmware_rest.composites._read import (
-    datastore_usage_composite,
 )
 from meho_backplane.operations import (
     CompositeL2DependencyDisabled,
@@ -276,60 +272,13 @@ async def test_preflight_cache_per_composite_keys(monkeypatch: pytest.MonkeyPatc
     assert calls == ["GET:/vcenter/datastore", "GET:/vcenter/datastore"]
 
 
-# ---------------------------------------------------------------------------
-# Composite handler integration
-# ---------------------------------------------------------------------------
-
-
-class _UnusedDispatchChild:
-    """``dispatch_child`` stand-in that asserts it's never called.
-
-    The pre-flight should raise *before* any sub-op dispatch fires --
-    this stand-in fails the test if the composite proceeds past
-    pre-flight when a sub-op is missing.
-    """
-
-    async def __call__(
-        self,
-        *,
-        connector_id: str,
-        op_id: str,
-        params: dict[str, Any],
-        target: Any = None,
-    ) -> OperationResult:
-        raise AssertionError(
-            f"dispatch_child should never be called when preflight failed; "
-            f"got call for op_id={op_id!r}"
-        )
-
-
-@pytest.mark.asyncio
-async def test_datastore_usage_composite_raises_when_l2_missing(
-    monkeypatch: pytest.MonkeyPatch,
-) -> None:
-    """The composite handler raises before any ``dispatch_child`` call.
-
-    Acceptance criterion (issue body): the chosen option's pre-flight
-    must produce a structured error (here: the
-    :class:`CompositeL2DependencyMissing` exception) listing the missing
-    sub-ops + the catalog command before the composite touches its
-    sub-op chain.
-    """
-    _patch_lookup(monkeypatch, present=set())  # no L2 ops registered
-    with pytest.raises(CompositeL2DependencyMissing) as exc_info:
-        await datastore_usage_composite(
-            operator=_make_operator(),
-            target=object(),
-            params={},
-            dispatch_child=_UnusedDispatchChild(),
-        )
-    # Every L2 sub-op the composite declares lands in the missing set.
-    assert set(exc_info.value.missing_op_ids) == {
-        "GET:/vcenter/datastore",
-        "GET:/vcenter/datastore/{datastore}",
-        "GET:/vcenter/vm",
-    }
-    assert exc_info.value.catalog_command == "meho connector ingest --catalog vmware/9.0"
+# NOTE: the read composites migrated to direct-session dispatch (#2253),
+# so they no longer call ``preflight_l2_dependencies`` -- the pre-flight
+# helper is now exercised only by the write composites (which keep
+# ``dispatch_child``) and the direct helper-level tests above. The former
+# ``test_datastore_usage_composite_raises_when_l2_missing`` was removed
+# with that migration: the read composites deliberately work with zero
+# catalog ingest, which is the defect class #2253 closes.
 
 
 # ---------------------------------------------------------------------------

--- a/backend/tests/test_connectors_vmware_rest_composites_read.py
+++ b/backend/tests/test_connectors_vmware_rest_composites_read.py
@@ -1,42 +1,47 @@
 # SPDX-License-Identifier: Apache-2.0
 # Copyright (c) 2026 evoila Group
 
-"""Unit tests for the 6 vmware-rest read-composite handler functions.
+"""Unit tests for the 7 vmware-rest read-composite handler functions.
 
-Coverage matrix (G3.1-T5 / #508 acceptance criteria):
+Post-#2253 the read composites dispatch their sub-ops **directly on the
+connector session** -- ``connector._get_json`` / ``connector._post_json``
+mounted through ``connector.mount_op_path`` -- rather than through the
+catalog-routed ``dispatch_child`` seam. These tests therefore stub the
+connector session with a recording double and assert the call-shape
+contract: which HTTP method, against which mounted path, with what query
+/ body, in what order -- plus the aggregation the handler builds from the
+canned responses.
 
-* Per-composite: assert the correct sub-op_ids fire in the expected
-  order, with the right ``connector_id`` and ``params`` shape.
+Coverage matrix (carried over from G3.1-T5 / #508, mechanism swapped):
+
+* Per-composite: assert the correct sub-op paths fire in the expected
+  order, mounted onto the target's live prefix, with the right query /
+  body shape.
 * Aggregation correctness: the handler's returned dict matches the
-  spec sketched in #508's issue body.
+  spec sketched in #508's issue body -- byte-for-byte unchanged by the
+  dispatch-mechanism swap.
 * Envelope tolerance: ``{"value": [...]}`` (legacy) and bare lists
   (modern) both parse correctly.
-* Filter pass-through: ``filter_names`` / ``filter_dvs`` / ``moId``
-  / ``entity_moid`` flow into the sub-op params.
-* Error fan-out: a sub-op returning ``status="error"`` causes the
-  handler to raise ``RuntimeError`` (load-bearing for the dispatcher's
-  ``connector_error`` wrapping at the composite parent).
-
-Each test mocks ``dispatch_child`` as an :class:`AsyncMock`-style
-callable that returns canned ``OperationResult`` objects keyed on
-``op_id``. The handlers are invoked directly (no dispatcher in the
-loop) so the assertion target is the call-shape contract: which
-sub-ops, in what order, with what params.
+* Filter pass-through: ``filter_names`` / ``filter_dvs`` / ``moId`` /
+  ``entity_moid`` flow into the sub-op query / path / body.
+* Error fan-out: a load-bearing sub-op raising ``httpx.HTTPStatusError``
+  propagates out of the handler (the dispatcher's outer branch wraps it
+  as ``connector_error`` for the composite parent); best-effort legs
+  catch it and degrade.
+* Mount routing: every sub-op is mounted via ``mount_op_path`` so a
+  legacy/vcsim target (``/rest``) is reached correctly.
 """
 
 from __future__ import annotations
 
-from collections.abc import Iterator
 from typing import Any
 from uuid import UUID
 
+import httpx
 import pytest
 
 from meho_backplane.auth.operator import Operator, TenantRole
-from meho_backplane.connectors import OperationResult
-from meho_backplane.connectors.vmware_rest.composites import _preflight
 from meho_backplane.connectors.vmware_rest.composites._read import (
-    CompositeSubOpError,
     cluster_drs_recommendations_composite,
     datastore_usage_composite,
     event_tail_composite,
@@ -45,42 +50,6 @@ from meho_backplane.connectors.vmware_rest.composites._read import (
     network_portgroup_audit_composite,
     performance_summary_composite,
 )
-
-
-@pytest.fixture(autouse=True)
-def _prime_preflight_cache() -> Iterator[None]:
-    """Prime the L2 pre-flight cache so handler-direct tests skip the DB walk.
-
-    The handler-direct tests in this module bypass the dispatcher and call
-    the composite handlers as plain async functions. The G0.14-T10 (#1151)
-    pre-flight check would otherwise issue a
-    :func:`~meho_backplane.operations._lookup.lookup_descriptor` query
-    against an unconfigured session at the top of every handler. Priming
-    the per-process cache with each composite's op_id before the test
-    fires (and clearing it after) keeps these tests handler-direct
-    without re-shaping every fixture to stand up a DB session.
-
-    Per-composite preflight behaviour (cache miss -> DB walk; cache miss
-    on missing L2 -> structured exception) is exercised in the dedicated
-    module ``test_connectors_vmware_rest_composites_l2_preflight.py``
-    where a stub ``lookup_descriptor`` exercises both the all-present
-    and the missing-L2 code paths.
-    """
-    _preflight.reset_preflight_cache()
-    _preflight._PREFLIGHT_CACHE.update(
-        {
-            "vmware.composite.cluster.drs_recommendations",
-            "vmware.composite.event.tail",
-            "vmware.composite.performance.summary",
-            "vmware.composite.datastore.usage",
-            "vmware.composite.network.portgroup.audit",
-            "vmware.composite.host.network_uplinks",
-            "vmware.composite.host.vsan_health",
-        }
-    )
-    yield
-    _preflight.reset_preflight_cache()
-
 
 # ---------------------------------------------------------------------------
 # Helpers
@@ -99,100 +68,90 @@ def _make_operator() -> Operator:
     )
 
 
-class _RecordingDispatchChild:
-    """Lightweight ``dispatch_child`` stub that returns canned responses.
+class _RecordingConnector:
+    """Stub connector session that records sub-calls and serves canned JSON.
 
-    Avoids :class:`unittest.mock.AsyncMock` so the test reads as a plain
-    keyword-args call sequence and the matching ``DispatchChild``
-    Protocol shape is preserved (``AsyncMock.__call__`` doesn't enforce
-    keyword-only).
+    Stands in for :class:`VmwareRestConnector` on the direct-dispatch path:
+    the handlers call ``mount_op_path`` to resolve the live mount and then
+    ``_get_json`` / ``_post_json`` on the returned path. This double records
+    every call as ``{"method", "path", "query", "body"}`` and serves a
+    response keyed either by the resolved (mounted) path or, in list form,
+    sequentially -- the list form lets a test drive several calls to the
+    same path (e.g. per-portgroup ``GET /api/vcenter/vm``) with distinct
+    payloads. A canned value that is an :class:`Exception` is raised, which
+    is how the transport-failure paths are exercised.
+
+    ``mount_prefix`` selects the mount the fake ``mount_op_path`` applies
+    (``/api`` modern by default, ``/rest`` for the legacy/vcsim coverage),
+    so the tests assert the real mounted wire path.
     """
 
-    def __init__(self, responses: dict[str, Any] | list[Any]) -> None:
-        """Build a recording stub.
-
-        Parameters
-        ----------
-        responses:
-            Either a mapping of ``op_id -> result`` (the handler dispatches
-            each op once; subsequent calls reuse the same payload), or a
-            sequential list of ``OperationResult`` values returned in
-            order. The list form lets tests assert per-call payloads when
-            the same op_id is dispatched multiple times.
-        """
-        self._responses = responses
-        self._sequence_index = 0
-        self.calls: list[dict[str, Any]] = []
-
-    async def __call__(
+    def __init__(
         self,
+        responses: dict[str, Any] | list[Any],
         *,
-        connector_id: str,
-        op_id: str,
-        params: dict[str, Any],
-        target: Any = None,
-    ) -> OperationResult:
-        # Record before serving so the assertion sees the call even
-        # if the handler raises on the (canned) result.
-        self.calls.append(
-            {
-                "connector_id": connector_id,
-                "op_id": op_id,
-                "params": dict(params),
-                "target": target,
-            }
-        )
+        mount_prefix: str = "/api",
+    ) -> None:
+        self._responses = responses
+        self._seq_index = 0
+        self._mount_prefix = mount_prefix
+        self.calls: list[dict[str, Any]] = []
+        self.mount_calls: list[str] = []
+
+    async def mount_op_path(self, target: Any, path: str, operator: Operator) -> str:
+        self.mount_calls.append(path)
+        return f"{self._mount_prefix}{path}"
+
+    async def _get_json(
+        self,
+        target: Any,
+        path: str,
+        *,
+        operator: Operator,
+        params: dict[str, Any] | None = None,
+    ) -> Any:
+        self.calls.append({"method": "GET", "path": path, "query": params, "body": None})
+        return self._serve(path)
+
+    async def _post_json(
+        self,
+        target: Any,
+        path: str,
+        *,
+        operator: Operator,
+        verb: str = "POST",
+        json: dict[str, Any] | None = None,
+        data: dict[str, Any] | None = None,
+        extra_headers: dict[str, str] | None = None,
+    ) -> Any:
+        self.calls.append({"method": "POST", "path": path, "query": None, "body": json})
+        return self._serve(path)
+
+    def _serve(self, path: str) -> Any:
         if isinstance(self._responses, dict):
-            payload = self._responses[op_id]
+            payload = self._responses[path]
         else:
-            payload = self._responses[self._sequence_index]
-            self._sequence_index += 1
-        if isinstance(payload, OperationResult):
-            return payload
-        return _ok_result(op_id, payload)
+            payload = self._responses[self._seq_index]
+            self._seq_index += 1
+        if isinstance(payload, Exception):
+            raise payload
+        return payload
 
 
-def _ok_result(op_id: str, result: Any) -> OperationResult:
-    """Build an OK :class:`OperationResult` with ``result`` as the body."""
-    return OperationResult(
-        status="ok",
-        op_id=op_id,
-        result=result,
-        duration_ms=1.0,
-    )
+def _http_error(status: int, url: str) -> httpx.HTTPStatusError:
+    """Build an ``httpx.HTTPStatusError`` whose ``str`` carries status + URL.
 
-
-def _err_result(op_id: str, error: str) -> OperationResult:
-    """Build an error :class:`OperationResult` for failure-fan-out tests."""
-    return OperationResult(
-        status="error",
-        op_id=op_id,
-        error=error,
-        duration_ms=1.0,
-    )
-
-
-def _connector_error_result(op_id: str, exception_message: str) -> OperationResult:
-    """Build a generic ``connector_error`` result the dispatcher emits for a 4xx/5xx.
-
-    Mirrors
-    :func:`meho_backplane.operations._errors.result_connector_error`: the
-    terse ``error`` summary plus the stringified ``httpx.HTTPStatusError``
-    (status line + URL) stashed under ``extras["exception_message"]``.
-    This is the exact shape a ``filter.datastores`` 400 (#1908) produces,
-    where the status code + offending URL live only in the
-    ``exception_message`` string (no structured ``http_status``).
+    Mirrors the shape ``raise_for_status`` raises when the connector
+    session hits a 4xx/5xx -- the status line + offending URL the
+    composite's best-effort note / load-bearing propagation surface.
     """
-    return OperationResult(
-        status="error",
-        op_id=op_id,
-        error="connector_error: HTTPStatusError",
-        duration_ms=1.0,
-        extras={
-            "error_code": "connector_error",
-            "exception_class": "HTTPStatusError",
-            "exception_message": exception_message,
-        },
+    reason = {400: "Bad Request", 401: "Unauthorized", 403: "Forbidden"}.get(status, "Error")
+    request = httpx.Request("GET", url)
+    response = httpx.Response(status, request=request)
+    return httpx.HTTPStatusError(
+        f"Client error '{status} {reason}' for url '{url}'",
+        request=request,
+        response=response,
     )
 
 
@@ -202,14 +161,14 @@ def _connector_error_result(op_id: str, exception_message: str) -> OperationResu
 
 
 @pytest.mark.asyncio
-async def test_cluster_drs_recommendations_dispatches_summary_and_drs_in_order() -> None:
-    """Two sub-ops fire: cluster summary then DRS config, both with the cluster moid."""
+async def test_cluster_drs_recommendations_reads_summary_and_drs_in_order() -> None:
+    """Two GETs fire: cluster summary then DRS config, both mounted, cluster in path."""
     cluster_payload = {"name": "Cluster-A", "drs_enabled": True}
     drs_payload = {"enabled": True, "automation_level": "FULLY_AUTOMATED"}
-    dispatch = _RecordingDispatchChild(
+    conn = _RecordingConnector(
         {
-            "GET:/vcenter/cluster/{cluster}": cluster_payload,
-            "GET:/vcenter/cluster/{cluster}/drs": drs_payload,
+            "/api/vcenter/cluster/domain-c123": cluster_payload,
+            "/api/vcenter/cluster/domain-c123/drs": drs_payload,
         }
     )
 
@@ -217,28 +176,28 @@ async def test_cluster_drs_recommendations_dispatches_summary_and_drs_in_order()
         operator=_make_operator(),
         target=object(),
         params={"cluster": "domain-c123"},
-        dispatch_child=dispatch,
+        connector=conn,  # type: ignore[arg-type]
     )
 
-    assert [c["op_id"] for c in dispatch.calls] == [
-        "GET:/vcenter/cluster/{cluster}",
-        "GET:/vcenter/cluster/{cluster}/drs",
+    assert [(c["method"], c["path"]) for c in conn.calls] == [
+        ("GET", "/api/vcenter/cluster/domain-c123"),
+        ("GET", "/api/vcenter/cluster/domain-c123/drs"),
     ]
-    assert all(c["connector_id"] == "vmware-rest-9.0" for c in dispatch.calls)
-    assert all(c["params"] == {"cluster": "domain-c123"} for c in dispatch.calls)
-    assert out == {
-        "cluster": cluster_payload,
-        "drs": drs_payload,
-    }
+    # Both paths were mounted (spec-relative -> live prefix).
+    assert conn.mount_calls == [
+        "/vcenter/cluster/domain-c123",
+        "/vcenter/cluster/domain-c123/drs",
+    ]
+    assert out == {"cluster": cluster_payload, "drs": drs_payload}
 
 
 @pytest.mark.asyncio
 async def test_cluster_drs_recommendations_history_flag_surfaces_history_slice() -> None:
     """``include_recommendations_history=True`` surfaces ``history`` from the DRS payload."""
-    dispatch = _RecordingDispatchChild(
+    conn = _RecordingConnector(
         {
-            "GET:/vcenter/cluster/{cluster}": {"name": "Cluster-A"},
-            "GET:/vcenter/cluster/{cluster}/drs": {
+            "/api/vcenter/cluster/domain-c1": {"name": "Cluster-A"},
+            "/api/vcenter/cluster/domain-c1/drs": {
                 "enabled": True,
                 "history": [{"recommendation_id": "rec-1", "reason": "load balance"}],
             },
@@ -248,9 +207,8 @@ async def test_cluster_drs_recommendations_history_flag_surfaces_history_slice()
         operator=_make_operator(),
         target=object(),
         params={"cluster": "domain-c1", "include_recommendations_history": True},
-        dispatch_child=dispatch,
+        connector=conn,  # type: ignore[arg-type]
     )
-    assert "recommendations_history" in out
     assert out["recommendations_history"] == [
         {"recommendation_id": "rec-1", "reason": "load balance"}
     ]
@@ -259,19 +217,41 @@ async def test_cluster_drs_recommendations_history_flag_surfaces_history_slice()
 @pytest.mark.asyncio
 async def test_cluster_drs_recommendations_history_flag_default_omits_key() -> None:
     """Default ``include_recommendations_history=False`` omits the key."""
-    dispatch = _RecordingDispatchChild(
+    conn = _RecordingConnector(
         {
-            "GET:/vcenter/cluster/{cluster}": {"name": "Cluster-A"},
-            "GET:/vcenter/cluster/{cluster}/drs": {"enabled": False, "history": [1, 2]},
+            "/api/vcenter/cluster/domain-c1": {"name": "Cluster-A"},
+            "/api/vcenter/cluster/domain-c1/drs": {"enabled": False, "history": [1, 2]},
         }
     )
     out = await cluster_drs_recommendations_composite(
         operator=_make_operator(),
         target=object(),
         params={"cluster": "domain-c1"},
-        dispatch_child=dispatch,
+        connector=conn,  # type: ignore[arg-type]
     )
     assert "recommendations_history" not in out
+
+
+@pytest.mark.asyncio
+async def test_cluster_drs_recommendations_propagates_load_bearing_error() -> None:
+    """A load-bearing sub-op failure propagates as ``httpx.HTTPStatusError``.
+
+    Load-bearing for the dispatcher's outer branch: the composite parent
+    sees the failure as a structured ``connector_error`` result carrying
+    the underlying status + URL from ``str(exc)``.
+    """
+    conn = _RecordingConnector(
+        {
+            "/api/vcenter/cluster/bogus": _http_error(404, "https://vc/api/vcenter/cluster/bogus"),
+        }
+    )
+    with pytest.raises(httpx.HTTPStatusError):
+        await cluster_drs_recommendations_composite(
+            operator=_make_operator(),
+            target=object(),
+            params={"cluster": "bogus"},
+            connector=conn,  # type: ignore[arg-type]
+        )
 
 
 # ---------------------------------------------------------------------------
@@ -280,21 +260,23 @@ async def test_cluster_drs_recommendations_history_flag_default_omits_key() -> N
 
 
 @pytest.mark.asyncio
-async def test_event_tail_dispatches_query_events_with_default_mo_id() -> None:
-    """Default ``moId='EventManager'`` and ``max_events=100`` flow through."""
+async def test_event_tail_reads_query_events_with_default_mo_id() -> None:
+    """Default ``moId='EventManager'`` rides the path; ``max_events=100`` applied."""
     events_payload = [{"id": f"evt-{n}", "summary": f"event {n}"} for n in range(5)]
-    dispatch = _RecordingDispatchChild({"POST:/EventManager/{moId}/QueryEvents": events_payload})
+    conn = _RecordingConnector({"/api/EventManager/EventManager/QueryEvents": events_payload})
     out = await event_tail_composite(
         operator=_make_operator(),
         target=object(),
         params={},
-        dispatch_child=dispatch,
+        connector=conn,  # type: ignore[arg-type]
     )
-    assert len(dispatch.calls) == 1
-    only = dispatch.calls[0]
-    assert only["op_id"] == "POST:/EventManager/{moId}/QueryEvents"
-    assert only["connector_id"] == "vmware-rest-9.0"
-    assert only["params"] == {"moId": "EventManager"}
+    assert len(conn.calls) == 1
+    only = conn.calls[0]
+    assert only["method"] == "POST"
+    assert only["path"] == "/api/EventManager/EventManager/QueryEvents"
+    # QueryEvents carries no method-arg body (parity: the pre-migration
+    # dispatch passed only the moId path param).
+    assert only["body"] is None
     assert out["events"] == events_payload
     assert out["count"] == 5
     assert out["moId"] == "EventManager"
@@ -305,12 +287,12 @@ async def test_event_tail_dispatches_query_events_with_default_mo_id() -> None:
 async def test_event_tail_caps_results_to_max_events() -> None:
     """The handler caps client-side to ``max_events``."""
     events_payload = [{"id": f"evt-{n}"} for n in range(200)]
-    dispatch = _RecordingDispatchChild({"POST:/EventManager/{moId}/QueryEvents": events_payload})
+    conn = _RecordingConnector({"/api/EventManager/EventManager/QueryEvents": events_payload})
     out = await event_tail_composite(
         operator=_make_operator(),
         target=object(),
         params={"max_events": 7},
-        dispatch_child=dispatch,
+        connector=conn,  # type: ignore[arg-type]
     )
     assert len(out["events"]) == 7
     assert out["count"] == 7
@@ -318,16 +300,33 @@ async def test_event_tail_caps_results_to_max_events() -> None:
 
 
 @pytest.mark.asyncio
+async def test_event_tail_custom_mo_id_rides_the_path() -> None:
+    """A per-call ``moId`` override lands in the mounted path segment."""
+    conn = _RecordingConnector({"/api/EventManager/em-2/QueryEvents": []})
+    await event_tail_composite(
+        operator=_make_operator(),
+        target=object(),
+        params={"moId": "em-2"},
+        connector=conn,  # type: ignore[arg-type]
+    )
+    assert conn.calls[0]["path"] == "/api/EventManager/em-2/QueryEvents"
+
+
+@pytest.mark.asyncio
 async def test_event_tail_tolerates_legacy_value_envelope() -> None:
     """A ``{"value": [...]}`` envelope on the sub-op response unwraps cleanly."""
-    dispatch = _RecordingDispatchChild(
-        {"POST:/EventManager/{moId}/QueryEvents": {"value": [{"id": "evt-1"}, {"id": "evt-2"}]}}
+    conn = _RecordingConnector(
+        {
+            "/api/EventManager/EventManager/QueryEvents": {
+                "value": [{"id": "evt-1"}, {"id": "evt-2"}]
+            }
+        }
     )
     out = await event_tail_composite(
         operator=_make_operator(),
         target=object(),
         params={},
-        dispatch_child=dispatch,
+        connector=conn,  # type: ignore[arg-type]
     )
     assert out["count"] == 2
     assert out["events"] == [{"id": "evt-1"}, {"id": "evt-2"}]
@@ -336,13 +335,28 @@ async def test_event_tail_tolerates_legacy_value_envelope() -> None:
 @pytest.mark.asyncio
 async def test_event_tail_raises_on_non_list_payload() -> None:
     """Non-list payload from QueryEvents raises ``RuntimeError`` (audit-visible)."""
-    dispatch = _RecordingDispatchChild({"POST:/EventManager/{moId}/QueryEvents": {"not": "a list"}})
+    conn = _RecordingConnector({"/api/EventManager/EventManager/QueryEvents": {"not": "a list"}})
     with pytest.raises(RuntimeError, match="expected list"):
         await event_tail_composite(
             operator=_make_operator(),
             target=object(),
             params={},
-            dispatch_child=dispatch,
+            connector=conn,  # type: ignore[arg-type]
+        )
+
+
+@pytest.mark.asyncio
+async def test_event_tail_propagates_load_bearing_error() -> None:
+    """QueryEvents transport failure propagates (no aggregation)."""
+    conn = _RecordingConnector(
+        [_http_error(400, "https://vc/api/EventManager/EventManager/QueryEvents")]
+    )
+    with pytest.raises(httpx.HTTPStatusError):
+        await event_tail_composite(
+            operator=_make_operator(),
+            target=object(),
+            params={},
+            connector=conn,  # type: ignore[arg-type]
         )
 
 
@@ -352,8 +366,8 @@ async def test_event_tail_raises_on_non_list_payload() -> None:
 
 
 @pytest.mark.asyncio
-async def test_performance_summary_dispatches_two_sub_ops_in_order() -> None:
-    """QueryAvailablePerfMetric first, then QueryPerf -- both per-entity."""
+async def test_performance_summary_reads_two_sub_ops_in_order() -> None:
+    """QueryAvailablePerfMetric first, then QueryPerf -- both per-entity, method-args as body."""
     available_payload = [
         {"counterId": 1, "instance": ""},
         {"counterId": 2, "instance": "vmnic0"},
@@ -362,29 +376,26 @@ async def test_performance_summary_dispatches_two_sub_ops_in_order() -> None:
         {"counterId": 1, "value": 42},
         {"counterId": 2, "value": 100},
     ]
-    dispatch = _RecordingDispatchChild(
+    conn = _RecordingConnector(
         {
-            "POST:/PerformanceManager/{moId}/QueryAvailablePerfMetric": (available_payload),
-            "POST:/PerformanceManager/{moId}/QueryPerf": samples_payload,
+            "/api/PerformanceManager/PerfMgr/QueryAvailablePerfMetric": available_payload,
+            "/api/PerformanceManager/PerfMgr/QueryPerf": samples_payload,
         }
     )
     out = await performance_summary_composite(
         operator=_make_operator(),
         target=object(),
         params={"entity_moid": "vm-1234"},
-        dispatch_child=dispatch,
+        connector=conn,  # type: ignore[arg-type]
     )
-    assert [c["op_id"] for c in dispatch.calls] == [
-        "POST:/PerformanceManager/{moId}/QueryAvailablePerfMetric",
-        "POST:/PerformanceManager/{moId}/QueryPerf",
+    assert [c["path"] for c in conn.calls] == [
+        "/api/PerformanceManager/PerfMgr/QueryAvailablePerfMetric",
+        "/api/PerformanceManager/PerfMgr/QueryPerf",
     ]
-    # Both calls use the default PerfMgr singleton + the entity moid.
-    assert dispatch.calls[0]["params"] == {"moId": "PerfMgr", "entity": "vm-1234"}
-    assert dispatch.calls[1]["params"] == {
-        "moId": "PerfMgr",
-        "entity": "vm-1234",
-        "interval_seconds": 20,
-    }
+    # The vi-json method arguments become the flat JSON request body; the
+    # PerfMgr singleton rides the path.
+    assert conn.calls[0]["body"] == {"entity": "vm-1234"}
+    assert conn.calls[1]["body"] == {"entity": "vm-1234", "interval_seconds": 20}
     assert out == {
         "entity_moid": "vm-1234",
         "perf_manager_moid": "PerfMgr",
@@ -400,17 +411,17 @@ async def test_performance_summary_caps_samples() -> None:
     """``max_samples`` caps the sample list client-side."""
     available = [{"counterId": 1}]
     samples = [{"counterId": 1, "value": n} for n in range(150)]
-    dispatch = _RecordingDispatchChild(
+    conn = _RecordingConnector(
         {
-            "POST:/PerformanceManager/{moId}/QueryAvailablePerfMetric": available,
-            "POST:/PerformanceManager/{moId}/QueryPerf": samples,
+            "/api/PerformanceManager/PerfMgr/QueryAvailablePerfMetric": available,
+            "/api/PerformanceManager/PerfMgr/QueryPerf": samples,
         }
     )
     out = await performance_summary_composite(
         operator=_make_operator(),
         target=object(),
         params={"entity_moid": "vm-7", "max_samples": 12},
-        dispatch_child=dispatch,
+        connector=conn,  # type: ignore[arg-type]
     )
     assert len(out["samples"]) == 12
     assert out["max_samples_applied"] == 12
@@ -419,10 +430,10 @@ async def test_performance_summary_caps_samples() -> None:
 @pytest.mark.asyncio
 async def test_performance_summary_passes_through_interval_and_custom_perf_mgr() -> None:
     """Operator-supplied ``interval_seconds`` + ``perf_manager_moid`` propagate."""
-    dispatch = _RecordingDispatchChild(
+    conn = _RecordingConnector(
         {
-            "POST:/PerformanceManager/{moId}/QueryAvailablePerfMetric": [],
-            "POST:/PerformanceManager/{moId}/QueryPerf": [],
+            "/api/PerformanceManager/AltPerfMgr/QueryAvailablePerfMetric": [],
+            "/api/PerformanceManager/AltPerfMgr/QueryPerf": [],
         }
     )
     await performance_summary_composite(
@@ -433,10 +444,11 @@ async def test_performance_summary_passes_through_interval_and_custom_perf_mgr()
             "perf_manager_moid": "AltPerfMgr",
             "interval_seconds": 300,
         },
-        dispatch_child=dispatch,
+        connector=conn,  # type: ignore[arg-type]
     )
-    assert dispatch.calls[1]["params"]["moId"] == "AltPerfMgr"
-    assert dispatch.calls[1]["params"]["interval_seconds"] == 300
+    # AltPerfMgr rides the path; the interval rides the QueryPerf body.
+    assert conn.calls[1]["path"] == "/api/PerformanceManager/AltPerfMgr/QueryPerf"
+    assert conn.calls[1]["body"] == {"entity": "vm-99", "interval_seconds": 300}
 
 
 # ---------------------------------------------------------------------------
@@ -460,32 +472,30 @@ async def test_datastore_usage_three_ops_per_datastore_aggregates_correctly() ->
         "datastore-2": [{"name": "vm-c"}],
     }
 
-    sequence: list[OperationResult] = [_ok_result("GET:/vcenter/datastore", listing)]
+    sequence: list[Any] = [listing]
     for entry in listing:
-        sequence.append(
-            _ok_result("GET:/vcenter/datastore/{datastore}", detail_by_id[entry["datastore"]])
-        )
-        sequence.append(_ok_result("GET:/vcenter/vm", vms_by_ds[entry["datastore"]]))
-    dispatch = _RecordingDispatchChild(sequence)
+        sequence.append(detail_by_id[entry["datastore"]])
+        sequence.append(vms_by_ds[entry["datastore"]])
+    conn = _RecordingConnector(sequence)
 
     out = await datastore_usage_composite(
         operator=_make_operator(),
         target=object(),
         params={},
-        dispatch_child=dispatch,
+        connector=conn,  # type: ignore[arg-type]
     )
 
     # 1 listing + 2 datastores * 2 sub-ops each = 5 calls total.
-    assert len(dispatch.calls) == 5
-    assert dispatch.calls[0]["op_id"] == "GET:/vcenter/datastore"
-    # No filter -> params is empty mapping.
-    assert dispatch.calls[0]["params"] == {}
-    # Per-DS detail call includes the datastore moid.
-    assert dispatch.calls[1]["op_id"] == "GET:/vcenter/datastore/{datastore}"
-    assert dispatch.calls[1]["params"] == {"datastore": "datastore-1"}
+    assert len(conn.calls) == 5
+    assert conn.calls[0]["method"] == "GET"
+    assert conn.calls[0]["path"] == "/api/vcenter/datastore"
+    # No filter -> no query string.
+    assert conn.calls[0]["query"] is None
+    # Per-DS detail call embeds the datastore moid in the mounted path.
+    assert conn.calls[1]["path"] == "/api/vcenter/datastore/datastore-1"
     # Per-DS VM call uses ``filter.datastores`` with the moid.
-    assert dispatch.calls[2]["op_id"] == "GET:/vcenter/vm"
-    assert dispatch.calls[2]["params"] == {"filter.datastores": ["datastore-1"]}
+    assert conn.calls[2]["path"] == "/api/vcenter/vm"
+    assert conn.calls[2]["query"] == {"filter.datastores": ["datastore-1"]}
     # Final aggregated shape.
     assert out == {
         "datastores": [
@@ -513,60 +523,41 @@ async def test_datastore_usage_three_ops_per_datastore_aggregates_correctly() ->
 
 @pytest.mark.asyncio
 async def test_datastore_usage_capacity_falls_back_to_list_row_when_detail_omits_it() -> None:
-    """Detail without ``capacity`` (live 8.0.3 shape) -> capacity from the list row (#2078).
-
-    Some vCenter builds return a per-datastore detail ``Datastore.Info``
-    that populates ``free_space`` but omits ``capacity`` entirely. The
-    ``GET:/vcenter/datastore`` list row carries both fields, so the
-    composite must fall back to the list-row ``capacity`` rather than
-    silently emitting ``capacity: null`` (which leaves %-full
-    uncomputable, the whole reason to reach for the composite).
-    """
+    """Detail without ``capacity`` (live 8.0.3 shape) -> capacity from the list row (#2078)."""
     listing = [
         {"datastore": "datastore-1", "name": "ds-1", "type": "VMFS", "capacity": 1000},
     ]
     sequence = [
-        _ok_result("GET:/vcenter/datastore", listing),
+        listing,
         # Detail carries free_space but NO ``capacity`` key at all.
-        _ok_result("GET:/vcenter/datastore/{datastore}", {"free_space": 400, "type": "VMFS"}),
-        _ok_result("GET:/vcenter/vm", [{"name": "vm-a"}]),
+        {"free_space": 400, "type": "VMFS"},
+        [{"name": "vm-a"}],
     ]
-    dispatch = _RecordingDispatchChild(sequence)
+    conn = _RecordingConnector(sequence)
     out = await datastore_usage_composite(
         operator=_make_operator(),
         target=object(),
         params={},
-        dispatch_child=dispatch,
+        connector=conn,  # type: ignore[arg-type]
     )
     row = out["datastores"][0]
-    # capacity sourced from the list row; free_space from the detail read.
     assert row["capacity"] == 1000
     assert row["free_space"] == 400
 
 
 @pytest.mark.asyncio
 async def test_datastore_usage_capacity_null_when_neither_detail_nor_list_carry_it() -> None:
-    """Neither detail nor list row carries ``capacity`` -> row ``capacity`` is null (#2078).
-
-    The fallback is best-effort: with no source for capacity the row must
-    still be schema-valid (``capacity`` typed ``["integer", "null"]``) and
-    the aggregation must not crash.
-    """
+    """Neither detail nor list row carries ``capacity`` -> row ``capacity`` is null (#2078)."""
     listing = [
         {"datastore": "datastore-1", "name": "ds-1", "type": "VMFS"},
     ]
-    sequence = [
-        _ok_result("GET:/vcenter/datastore", listing),
-        # Detail lacks capacity; list row lacks capacity -> null, no crash.
-        _ok_result("GET:/vcenter/datastore/{datastore}", {"free_space": 400}),
-        _ok_result("GET:/vcenter/vm", []),
-    ]
-    dispatch = _RecordingDispatchChild(sequence)
+    sequence = [listing, {"free_space": 400}, []]
+    conn = _RecordingConnector(sequence)
     out = await datastore_usage_composite(
         operator=_make_operator(),
         target=object(),
         params={},
-        dispatch_child=dispatch,
+        connector=conn,  # type: ignore[arg-type]
     )
     row = out["datastores"][0]
     assert row["capacity"] is None
@@ -575,29 +566,19 @@ async def test_datastore_usage_capacity_null_when_neither_detail_nor_list_carry_
 
 @pytest.mark.asyncio
 async def test_datastore_usage_detail_capacity_wins_over_list_row() -> None:
-    """When the detail payload supplies ``capacity``, the detail value wins (#2078).
-
-    Guards the fallback against regressing the primary path: the list row
-    carries a stale/different capacity, but the detail read is the source
-    of truth whenever it provides the field.
-    """
+    """When the detail payload supplies ``capacity``, the detail value wins (#2078)."""
     listing = [
         {"datastore": "datastore-1", "name": "ds-1", "type": "VMFS", "capacity": 1000},
     ]
-    sequence = [
-        _ok_result("GET:/vcenter/datastore", listing),
-        _ok_result("GET:/vcenter/datastore/{datastore}", {"capacity": 100, "free_space": 40}),
-        _ok_result("GET:/vcenter/vm", []),
-    ]
-    dispatch = _RecordingDispatchChild(sequence)
+    sequence = [listing, {"capacity": 100, "free_space": 40}, []]
+    conn = _RecordingConnector(sequence)
     out = await datastore_usage_composite(
         operator=_make_operator(),
         target=object(),
         params={},
-        dispatch_child=dispatch,
+        connector=conn,  # type: ignore[arg-type]
     )
     row = out["datastores"][0]
-    # Detail's 100 wins over the list row's 1000.
     assert row["capacity"] == 100
     assert row["free_space"] == 40
 
@@ -605,41 +586,30 @@ async def test_datastore_usage_detail_capacity_wins_over_list_row() -> None:
 @pytest.mark.asyncio
 async def test_datastore_usage_filter_names_passes_through_to_listing() -> None:
     """``filter_names`` flows into the listing sub-op as ``filter.names``."""
-    sequence = [_ok_result("GET:/vcenter/datastore", [])]
-    dispatch = _RecordingDispatchChild(sequence)
+    conn = _RecordingConnector([[]])
     await datastore_usage_composite(
         operator=_make_operator(),
         target=object(),
         params={"filter_names": ["ds-prod-1", "ds-prod-2"]},
-        dispatch_child=dispatch,
+        connector=conn,  # type: ignore[arg-type]
     )
-    assert dispatch.calls[0]["params"] == {"filter.names": ["ds-prod-1", "ds-prod-2"]}
+    assert conn.calls[0]["query"] == {"filter.names": ["ds-prod-1", "ds-prod-2"]}
 
 
 @pytest.mark.asyncio
 async def test_datastore_usage_tolerates_legacy_envelope_on_listing() -> None:
     """``{"value": [...]}`` listing envelope is unwrapped."""
     sequence = [
-        _ok_result(
-            "GET:/vcenter/datastore",
-            {
-                "value": [
-                    {"datastore": "datastore-1", "name": "ds-1", "type": "VMFS"},
-                ]
-            },
-        ),
-        _ok_result(
-            "GET:/vcenter/datastore/{datastore}",
-            {"value": {"capacity": 10, "free_space": 5}},
-        ),
-        _ok_result("GET:/vcenter/vm", {"value": [{"name": "vm-x"}]}),
+        {"value": [{"datastore": "datastore-1", "name": "ds-1", "type": "VMFS"}]},
+        {"value": {"capacity": 10, "free_space": 5}},
+        {"value": [{"name": "vm-x"}]},
     ]
-    dispatch = _RecordingDispatchChild(sequence)
+    conn = _RecordingConnector(sequence)
     out = await datastore_usage_composite(
         operator=_make_operator(),
         target=object(),
         params={},
-        dispatch_child=dispatch,
+        connector=conn,  # type: ignore[arg-type]
     )
     assert out["datastores"][0]["capacity"] == 10
     assert out["datastores"][0]["vm_names"] == ["vm-x"]
@@ -649,69 +619,50 @@ async def test_datastore_usage_tolerates_legacy_envelope_on_listing() -> None:
 async def test_datastore_usage_skips_malformed_listing_entries() -> None:
     """Listing entries without a string ``datastore`` key are skipped silently."""
     sequence = [
-        _ok_result(
-            "GET:/vcenter/datastore",
-            [
-                {"datastore": "datastore-1", "name": "good"},
-                {"name": "missing-id"},  # no ``datastore`` key
-                "not-a-dict",
-            ],
-        ),
-        _ok_result("GET:/vcenter/datastore/{datastore}", {"capacity": 1}),
-        _ok_result("GET:/vcenter/vm", []),
+        [
+            {"datastore": "datastore-1", "name": "good"},
+            {"name": "missing-id"},  # no ``datastore`` key
+            "not-a-dict",
+        ],
+        {"capacity": 1},
+        [],
     ]
-    dispatch = _RecordingDispatchChild(sequence)
+    conn = _RecordingConnector(sequence)
     out = await datastore_usage_composite(
         operator=_make_operator(),
         target=object(),
         params={},
-        dispatch_child=dispatch,
+        connector=conn,  # type: ignore[arg-type]
     )
-    # Only the well-formed entry produces sub-ops + a result row.
     assert len(out["datastores"]) == 1
     assert out["datastores"][0]["id"] == "datastore-1"
 
 
 @pytest.mark.asyncio
 async def test_datastore_usage_vm_enrichment_is_best_effort_on_sub_op_error() -> None:
-    """A failed VM-placement sub-op keeps the row; vm_count/vm_names null + note (#1908).
-
-    The capacity/free/type read is load-bearing and has already succeeded
-    by the time the optional ``filter.datastores`` VM lookup runs. When
-    that lookup 400s (the version-skew filter param the issue hit), the
-    datastore row is still returned -- capacity/free/type intact -- with
-    ``vm_count``/``vm_names`` nulled and an ``enrichment_note`` recording
-    why, rather than the whole composite failing.
-    """
+    """A failed VM-placement sub-op keeps the row; vm_count/vm_names null + note (#1908)."""
     sequence = [
-        _ok_result(
-            "GET:/vcenter/datastore",
-            [
-                {"datastore": "datastore-1", "name": "ds-1", "type": "VMFS"},
-                {"datastore": "datastore-2", "name": "ds-2", "type": "NFS"},
-            ],
-        ),
+        [
+            {"datastore": "datastore-1", "name": "ds-1", "type": "VMFS"},
+            {"datastore": "datastore-2", "name": "ds-2", "type": "NFS"},
+        ],
         # datastore-1: detail OK, VM enrichment 400s -> best-effort skip.
-        _ok_result("GET:/vcenter/datastore/{datastore}", {"capacity": 100, "free_space": 40}),
-        _connector_error_result(
-            "GET:/vcenter/vm",
-            "Client error '400 Bad Request' for url "
-            "'https://vc/api/vcenter/vm?filter.datastores=datastore-1'",
-        ),
+        {"capacity": 100, "free_space": 40},
+        _http_error(400, "https://vc/api/vcenter/vm?filter.datastores=datastore-1"),
         # datastore-2: detail OK, VM enrichment OK -> fully enriched.
-        _ok_result("GET:/vcenter/datastore/{datastore}", {"capacity": 500, "free_space": 250}),
-        _ok_result("GET:/vcenter/vm", [{"name": "vm-c"}]),
+        {"capacity": 500, "free_space": 250},
+        [{"name": "vm-c"}],
     ]
-    dispatch = _RecordingDispatchChild(sequence)
+    conn = _RecordingConnector(sequence)
     out = await datastore_usage_composite(
         operator=_make_operator(),
         target=object(),
         params={},
-        dispatch_child=dispatch,
+        connector=conn,  # type: ignore[arg-type]
     )
 
     # All 5 sub-ops fired -- the failed VM leg did not short-circuit.
-    assert len(dispatch.calls) == 5
+    assert len(conn.calls) == 5
     rows = out["datastores"]
     assert len(rows) == 2
 
@@ -723,9 +674,8 @@ async def test_datastore_usage_vm_enrichment_is_best_effort_on_sub_op_error() ->
     assert ds1["type"] == "VMFS"
     assert ds1["vm_count"] is None
     assert ds1["vm_names"] is None
-    assert "enrichment_note" in ds1
-    # The note bubbles the sub-op id, its status, the 400, and the URL.
     note = ds1["enrichment_note"]
+    # The note names the sub-op, the 400, and the offending URL.
     assert "GET:/vcenter/vm" in note
     assert "400 Bad Request" in note
     assert "filter.datastores=datastore-1" in note
@@ -739,75 +689,41 @@ async def test_datastore_usage_vm_enrichment_is_best_effort_on_sub_op_error() ->
 
 
 @pytest.mark.asyncio
-async def test_datastore_usage_listing_error_bubbles_structured_detail() -> None:
-    """A load-bearing sub-op failure bubbles the sub-op's status code + URL (#1908).
-
-    Suggestion 2: the composite's failure envelope previously stopped at
-    ``connector_error: HTTPStatusError``; the actual 400 + offending URL
-    only showed on a manual replay. The raised
-    :class:`CompositeSubOpError` now folds the sub-op's diagnostic line
-    (status code + URL, from the stringified ``HTTPStatusError``) into its
-    message and exposes the sub-op's structured fields as attributes.
-    """
-    failing = _connector_error_result(
-        "GET:/vcenter/datastore",
-        "Client error '400 Bad Request' for url "
-        "'https://vc/api/vcenter/datastore?filter.names=bogus'",
+async def test_datastore_usage_listing_error_propagates() -> None:
+    """A load-bearing listing failure propagates; no per-DS calls fire."""
+    conn = _RecordingConnector(
+        [_http_error(400, "https://vc/api/vcenter/datastore?filter.names=bogus")]
     )
-    dispatch = _RecordingDispatchChild([failing])
-    with pytest.raises(CompositeSubOpError) as excinfo:
+    with pytest.raises(httpx.HTTPStatusError) as excinfo:
         await datastore_usage_composite(
             operator=_make_operator(),
             target=object(),
             params={},
-            dispatch_child=dispatch,
+            connector=conn,  # type: ignore[arg-type]
         )
     # No per-datastore calls fire after the listing fails.
-    assert len(dispatch.calls) == 1
-    exc = excinfo.value
-    # Backward-compatible substring (existing consumers string-match it).
-    assert "returned status='error'" in str(exc)
-    # The structured detail now rides the message.
-    assert "400 Bad Request" in str(exc)
-    assert "filter.names=bogus" in str(exc)
-    # And the sub-op's structured fields are addressable as attributes.
-    assert exc.op_id == "GET:/vcenter/datastore"
-    assert exc.status == "error"
-    assert exc.sub_op_extras["error_code"] == "connector_error"
+    assert len(conn.calls) == 1
+    message = str(excinfo.value)
+    assert "400 Bad Request" in message
+    assert "filter.names=bogus" in message
 
 
 @pytest.mark.asyncio
-async def test_datastore_usage_bubbles_structured_http_status_when_present() -> None:
-    """When a sub-op carried a structured ``http_status`` (403/422/auth), it bubbles too.
-
-    The generic 4xx path (400/404/5xx) carries the status + URL only in
-    ``exception_message``; the 403/422/401/440 builders instead extract a
-    structured ``http_status`` + ``upstream_message``. The bubble-up
-    prefers the structured form when it is present.
-    """
-    failing = OperationResult(
-        status="error",
-        op_id="GET:/vcenter/datastore",
-        error="connector_http_403: the upstream returned HTTP 403 Forbidden ...",
-        duration_ms=1.0,
-        extras={
-            "error_code": "connector_http_403",
-            "http_status": 403,
-            "upstream_message": "Resource not accessible by integration",
-            "permission_headers": {},
-        },
-    )
-    dispatch = _RecordingDispatchChild([failing])
-    with pytest.raises(CompositeSubOpError) as excinfo:
+async def test_datastore_usage_detail_error_propagates() -> None:
+    """A load-bearing per-datastore detail failure propagates (403)."""
+    sequence = [
+        [{"datastore": "datastore-1", "name": "ds-1"}],
+        _http_error(403, "https://vc/api/vcenter/datastore/datastore-1"),
+    ]
+    conn = _RecordingConnector(sequence)
+    with pytest.raises(httpx.HTTPStatusError) as excinfo:
         await datastore_usage_composite(
             operator=_make_operator(),
             target=object(),
             params={},
-            dispatch_child=dispatch,
+            connector=conn,  # type: ignore[arg-type]
         )
-    message = str(excinfo.value)
-    assert "HTTP 403" in message
-    assert "Resource not accessible by integration" in message
+    assert "403 Forbidden" in str(excinfo.value)
 
 
 # ---------------------------------------------------------------------------
@@ -816,14 +732,9 @@ async def test_datastore_usage_bubbles_structured_http_status_when_present() -> 
 
 
 @pytest.mark.asyncio
-async def test_network_portgroup_audit_dispatches_three_phases() -> None:
+async def test_network_portgroup_audit_reads_three_phases() -> None:
     """DVS + portgroup listings + per-portgroup VM listings aggregate to the expected shape."""
     dvs_listing = [{"vds": "dvs-1", "name": "DVS-A"}]
-    # Generic ``GET:/vcenter/network`` summaries: ``{network, name,
-    # type}``. The summary carries no parent-DVS field, so ``dvs`` is
-    # resolved best-effort and is ``None`` for the real REST shape. The
-    # first entry carries a synthetic ``vds`` field to exercise the
-    # best-effort enrichment path against the DVS index.
     pg_listing = [
         {"network": "pg-1", "name": "PG-A", "vds": "dvs-1", "type": "DISTRIBUTED_PORTGROUP"},
         {"network": "pg-2", "name": "PG-B", "type": "DISTRIBUTED_PORTGROUP"},
@@ -832,30 +743,27 @@ async def test_network_portgroup_audit_dispatches_three_phases() -> None:
         "pg-1": [{"name": "vm-pg1-a"}, {"name": "vm-pg1-b"}],
         "pg-2": [],
     }
-    sequence: list[OperationResult] = [
-        _ok_result("GET:/vcenter/network/distributed-switches", dvs_listing),
-        _ok_result("GET:/vcenter/network", pg_listing),
-    ]
+    sequence: list[Any] = [dvs_listing, pg_listing]
     for pg in pg_listing:
-        sequence.append(_ok_result("GET:/vcenter/vm", vms_per_pg[pg["network"]]))
-    dispatch = _RecordingDispatchChild(sequence)
+        sequence.append(vms_per_pg[pg["network"]])
+    conn = _RecordingConnector(sequence)
 
     out = await network_portgroup_audit_composite(
         operator=_make_operator(),
         target=object(),
         params={},
-        dispatch_child=dispatch,
+        connector=conn,  # type: ignore[arg-type]
     )
 
     # 1 + 1 + 2 portgroups = 4 calls.
-    assert len(dispatch.calls) == 4
-    assert dispatch.calls[0]["op_id"] == "GET:/vcenter/network/distributed-switches"
+    assert len(conn.calls) == 4
+    assert conn.calls[0]["path"] == "/api/vcenter/network/distributed-switches"
     # Portgroups come from the generic network resource, type-filtered.
-    assert dispatch.calls[1]["op_id"] == "GET:/vcenter/network"
-    assert dispatch.calls[1]["params"] == {"filter.types": ["DISTRIBUTED_PORTGROUP"]}
+    assert conn.calls[1]["path"] == "/api/vcenter/network"
+    assert conn.calls[1]["query"] == {"filter.types": ["DISTRIBUTED_PORTGROUP"]}
     # Per-PG VM call uses ``filter.networks`` and the default power-state filter.
-    assert dispatch.calls[2]["op_id"] == "GET:/vcenter/vm"
-    assert dispatch.calls[2]["params"] == {
+    assert conn.calls[2]["path"] == "/api/vcenter/vm"
+    assert conn.calls[2]["query"] == {
         "filter.networks": ["pg-1"],
         "filter.power_states": ["POWERED_ON"],
     }
@@ -870,7 +778,6 @@ async def test_network_portgroup_audit_dispatches_three_phases() -> None:
             "vm_names": ["vm-pg1-a", "vm-pg1-b"],
         },
         {
-            # No ``vds`` on the generic Network summary -> dvs/dvs_name None.
             "id": "pg-2",
             "name": "PG-B",
             "dvs": None,
@@ -884,52 +791,38 @@ async def test_network_portgroup_audit_dispatches_three_phases() -> None:
 
 @pytest.mark.asyncio
 async def test_network_portgroup_audit_filter_dvs_scopes_dvs_listing_only() -> None:
-    """``filter_dvs`` scopes the DVS listing; the portgroup call is type-only.
-
-    The generic ``Network`` FilterSpec has no per-DVS filter, so
-    ``filter_dvs`` cannot narrow the portgroup set server-side -- it
-    flows only into the distributed-switches ``filter.vdses`` query,
-    narrowing the DVS index (and thus the ``dvs_name`` enrichment).
-    """
-    sequence = [
-        _ok_result("GET:/vcenter/network/distributed-switches", []),
-        _ok_result("GET:/vcenter/network", []),
-    ]
-    dispatch = _RecordingDispatchChild(sequence)
+    """``filter_dvs`` scopes the DVS listing; the portgroup call is type-only."""
+    sequence = [[], []]
+    conn = _RecordingConnector(sequence)
     await network_portgroup_audit_composite(
         operator=_make_operator(),
         target=object(),
         params={"filter_dvs": "dvs-prod"},
-        dispatch_child=dispatch,
+        connector=conn,  # type: ignore[arg-type]
     )
-    assert dispatch.calls[0]["params"] == {"filter.vdses": ["dvs-prod"]}
+    assert conn.calls[0]["query"] == {"filter.vdses": ["dvs-prod"]}
     # Portgroup call is type-filtered only -- no ``filter.vdses``.
-    assert dispatch.calls[1]["params"] == {"filter.types": ["DISTRIBUTED_PORTGROUP"]}
+    assert conn.calls[1]["query"] == {"filter.types": ["DISTRIBUTED_PORTGROUP"]}
 
 
 @pytest.mark.asyncio
 async def test_network_portgroup_audit_include_disconnected_drops_power_filter() -> None:
     """``include_disconnected_vms=True`` removes the ``POWERED_ON`` filter on the VM call."""
     sequence = [
-        _ok_result("GET:/vcenter/network/distributed-switches", []),
-        _ok_result(
-            "GET:/vcenter/network",
-            [{"network": "pg-1", "name": "PG-A", "type": "DISTRIBUTED_PORTGROUP"}],
-        ),
-        _ok_result("GET:/vcenter/vm", []),
+        [],
+        [{"network": "pg-1", "name": "PG-A", "type": "DISTRIBUTED_PORTGROUP"}],
+        [],
     ]
-    dispatch = _RecordingDispatchChild(sequence)
+    conn = _RecordingConnector(sequence)
     await network_portgroup_audit_composite(
         operator=_make_operator(),
         target=object(),
         params={"include_disconnected_vms": True},
-        dispatch_child=dispatch,
+        connector=conn,  # type: ignore[arg-type]
     )
-    # VM call's params include ``filter.networks`` but NOT
-    # ``filter.power_states``.
-    vm_call = dispatch.calls[2]
-    assert "filter.networks" in vm_call["params"]
-    assert "filter.power_states" not in vm_call["params"]
+    vm_call = conn.calls[2]
+    assert "filter.networks" in vm_call["query"]
+    assert "filter.power_states" not in vm_call["query"]
 
 
 # ---------------------------------------------------------------------------
@@ -938,12 +831,7 @@ async def test_network_portgroup_audit_include_disconnected_drops_power_filter()
 
 
 def _retrieve_result(pnics: list[Any], proxy_switches: list[Any]) -> dict[str, Any]:
-    """Build a RetrievePropertiesEx RetrieveResult for one host.
-
-    Mirrors the WS-API ``RetrieveResult`` shape: an ``objects`` list of
-    ``ObjectContent``, each with a ``propSet`` of ``{name, val}`` pairs
-    keyed on the requested property paths.
-    """
+    """Build a RetrievePropertiesEx RetrieveResult for one host."""
     return {
         "objects": [
             {
@@ -959,13 +847,7 @@ def _retrieve_result(pnics: list[Any], proxy_switches: list[Any]) -> dict[str, A
 
 @pytest.mark.asyncio
 async def test_host_network_uplinks_lists_then_reads_props_per_host() -> None:
-    """Host listing + per-host RetrievePropertiesEx; aggregation matches the spec.
-
-    ``config.network.pnic`` flattens to device / mac / driver / link
-    state + speed; ``config.network.proxySwitch`` flattens to the DVS
-    backing with its uplink pnic device names (recovered from the
-    WS-API pnic keys).
-    """
+    """Host listing + per-host RetrievePropertiesEx; aggregation matches the spec."""
     listing = [
         {"host": "host-1", "name": "esx-1"},
         {"host": "host-2", "name": "esx-2"},
@@ -997,33 +879,28 @@ async def test_host_network_uplinks_lists_then_reads_props_per_host() -> None:
         ),
         "host-2": _retrieve_result(pnics=[], proxy_switches=[]),
     }
-    sequence: list[OperationResult] = [_ok_result("GET:/vcenter/host", listing)]
+    sequence: list[Any] = [listing]
     for entry in listing:
-        sequence.append(
-            _ok_result(
-                "POST:/PropertyCollector/{moId}/RetrievePropertiesEx",
-                props_by_host[entry["host"]],
-            )
-        )
-    dispatch = _RecordingDispatchChild(sequence)
+        sequence.append(props_by_host[entry["host"]])
+    conn = _RecordingConnector(sequence)
 
     out = await host_network_uplinks_composite(
         operator=_make_operator(),
         target=object(),
         params={},
-        dispatch_child=dispatch,
+        connector=conn,  # type: ignore[arg-type]
     )
 
     # 1 listing + 2 hosts * 1 property read = 3 calls.
-    assert len(dispatch.calls) == 3
-    assert dispatch.calls[0]["op_id"] == "GET:/vcenter/host"
-    assert dispatch.calls[0]["params"] == {}
-    # Per-host property read targets the propertyCollector singleton and
-    # requests the two host-network config paths on the specific host.
-    prop_call = dispatch.calls[1]
-    assert prop_call["op_id"] == "POST:/PropertyCollector/{moId}/RetrievePropertiesEx"
-    assert prop_call["params"]["moId"] == "propertyCollector"
-    spec = prop_call["params"]["specSet"][0]
+    assert len(conn.calls) == 3
+    assert conn.calls[0]["method"] == "GET"
+    assert conn.calls[0]["path"] == "/api/vcenter/host"
+    # Per-host property read targets the propertyCollector singleton (in
+    # the path) and requests the two host-network config paths (in body).
+    prop_call = conn.calls[1]
+    assert prop_call["method"] == "POST"
+    assert prop_call["path"] == "/api/PropertyCollector/propertyCollector/RetrievePropertiesEx"
+    spec = prop_call["body"]["specSet"][0]
     assert spec["propSet"][0]["type"] == "HostSystem"
     assert spec["propSet"][0]["pathSet"] == [
         "config.network.pnic",
@@ -1063,7 +940,6 @@ async def test_host_network_uplinks_lists_then_reads_props_per_host() -> None:
         }
     ]
     assert "read_note" not in h1
-    # host-2: empty pnic/proxySwitch lists.
     assert hosts[1]["pnics"] == []
     assert hosts[1]["proxy_switches"] == []
 
@@ -1071,59 +947,48 @@ async def test_host_network_uplinks_lists_then_reads_props_per_host() -> None:
 @pytest.mark.asyncio
 async def test_host_network_uplinks_filter_hosts_passes_through_to_listing() -> None:
     """``filter_hosts`` flows into the host listing as ``filter.hosts``."""
-    dispatch = _RecordingDispatchChild([_ok_result("GET:/vcenter/host", [])])
+    conn = _RecordingConnector([[]])
     await host_network_uplinks_composite(
         operator=_make_operator(),
         target=object(),
         params={"filter_hosts": ["host-9", "host-10"]},
-        dispatch_child=dispatch,
+        connector=conn,  # type: ignore[arg-type]
     )
-    assert dispatch.calls[0]["params"] == {"filter.hosts": ["host-9", "host-10"]}
+    assert conn.calls[0]["query"] == {"filter.hosts": ["host-9", "host-10"]}
 
 
 @pytest.mark.asyncio
 async def test_host_network_uplinks_property_read_is_best_effort_on_error() -> None:
-    """A failed per-host property read keeps the row; pnics/proxy_switches null + note.
-
-    The plain REST host listing has already identified the host by the
-    time the vi-json property read runs, so when that read errors the
-    host row is still returned -- pnics/proxy_switches nulled with a
-    ``read_note`` -- rather than the whole composite failing.
-    """
+    """A failed per-host property read keeps the row; pnics/proxy_switches null + note."""
     listing = [
         {"host": "host-1", "name": "esx-1"},
         {"host": "host-2", "name": "esx-2"},
     ]
     sequence = [
-        _ok_result("GET:/vcenter/host", listing),
+        listing,
         # host-1: property read 400s -> best-effort skip.
-        _connector_error_result(
-            "POST:/PropertyCollector/{moId}/RetrievePropertiesEx",
-            "Client error '400 Bad Request' for url "
-            "'https://vc/sdk/vim25/PropertyCollector/propertyCollector/RetrievePropertiesEx'",
+        _http_error(
+            400,
+            "https://vc/api/PropertyCollector/propertyCollector/RetrievePropertiesEx",
         ),
         # host-2: property read OK.
-        _ok_result(
-            "POST:/PropertyCollector/{moId}/RetrievePropertiesEx",
-            _retrieve_result(pnics=[], proxy_switches=[]),
-        ),
+        _retrieve_result(pnics=[], proxy_switches=[]),
     ]
-    dispatch = _RecordingDispatchChild(sequence)
+    conn = _RecordingConnector(sequence)
     out = await host_network_uplinks_composite(
         operator=_make_operator(),
         target=object(),
         params={},
-        dispatch_child=dispatch,
+        connector=conn,  # type: ignore[arg-type]
     )
 
-    assert len(dispatch.calls) == 3
+    assert len(conn.calls) == 3
     rows = out["hosts"]
     assert len(rows) == 2
     h1 = rows[0]
     assert h1["id"] == "host-1"
     assert h1["pnics"] is None
     assert h1["proxy_switches"] is None
-    assert "read_note" in h1
     note = h1["read_note"]
     assert "POST:/PropertyCollector/{moId}/RetrievePropertiesEx" in note
     assert "400 Bad Request" in note
@@ -1136,18 +1001,15 @@ async def test_host_network_uplinks_property_read_is_best_effort_on_error() -> N
 async def test_host_network_uplinks_tolerates_legacy_value_envelope() -> None:
     """A ``{"value": ...}`` envelope on the listing and property read unwraps cleanly."""
     sequence = [
-        _ok_result("GET:/vcenter/host", {"value": [{"host": "host-1", "name": "esx-1"}]}),
-        _ok_result(
-            "POST:/PropertyCollector/{moId}/RetrievePropertiesEx",
-            {"value": _retrieve_result(pnics=[{"device": "vmnic0"}], proxy_switches=[])},
-        ),
+        {"value": [{"host": "host-1", "name": "esx-1"}]},
+        {"value": _retrieve_result(pnics=[{"device": "vmnic0"}], proxy_switches=[])},
     ]
-    dispatch = _RecordingDispatchChild(sequence)
+    conn = _RecordingConnector(sequence)
     out = await host_network_uplinks_composite(
         operator=_make_operator(),
         target=object(),
         params={},
-        dispatch_child=dispatch,
+        connector=conn,  # type: ignore[arg-type]
     )
     assert out["hosts"][0]["pnics"] == [
         {
@@ -1165,43 +1027,36 @@ async def test_host_network_uplinks_tolerates_legacy_value_envelope() -> None:
 async def test_host_network_uplinks_skips_malformed_listing_entries() -> None:
     """Listing entries without a string ``host`` key are skipped silently."""
     sequence = [
-        _ok_result(
-            "GET:/vcenter/host",
-            [
-                {"host": "host-1", "name": "good"},
-                {"name": "missing-id"},  # no ``host`` key
-                "not-a-dict",
-            ],
-        ),
-        _ok_result(
-            "POST:/PropertyCollector/{moId}/RetrievePropertiesEx",
-            _retrieve_result(pnics=[], proxy_switches=[]),
-        ),
+        [
+            {"host": "host-1", "name": "good"},
+            {"name": "missing-id"},  # no ``host`` key
+            "not-a-dict",
+        ],
+        _retrieve_result(pnics=[], proxy_switches=[]),
     ]
-    dispatch = _RecordingDispatchChild(sequence)
+    conn = _RecordingConnector(sequence)
     out = await host_network_uplinks_composite(
         operator=_make_operator(),
         target=object(),
         params={},
-        dispatch_child=dispatch,
+        connector=conn,  # type: ignore[arg-type]
     )
-    # Only the well-formed entry produces a property read + a result row.
     assert len(out["hosts"]) == 1
     assert out["hosts"][0]["id"] == "host-1"
 
 
 @pytest.mark.asyncio
-async def test_host_network_uplinks_raises_on_listing_error() -> None:
-    """A failed host listing surfaces as ``RuntimeError``; no per-host reads fire."""
-    dispatch = _RecordingDispatchChild([_err_result("GET:/vcenter/host", "permission denied")])
-    with pytest.raises(RuntimeError, match="returned status='error'"):
+async def test_host_network_uplinks_propagates_listing_error() -> None:
+    """A failed host listing propagates; no per-host reads fire."""
+    conn = _RecordingConnector([_http_error(403, "https://vc/api/vcenter/host")])
+    with pytest.raises(httpx.HTTPStatusError):
         await host_network_uplinks_composite(
             operator=_make_operator(),
             target=object(),
             params={},
-            dispatch_child=dispatch,
+            connector=conn,  # type: ignore[arg-type]
         )
-    assert len(dispatch.calls) == 1
+    assert len(conn.calls) == 1
 
 
 # ---------------------------------------------------------------------------
@@ -1209,7 +1064,10 @@ async def test_host_network_uplinks_raises_on_listing_error() -> None:
 # ---------------------------------------------------------------------------
 
 
-_VSAN_QUERY_OP = "POST:/VsanVcClusterHealthSystem/{moId}/VsanQueryVcClusterHealthSummary"
+_VSAN_PATH = (
+    "/api/VsanVcClusterHealthSystem/vsan-cluster-health-system/VsanQueryVcClusterHealthSummary"
+)
+_VSAN_OP = "POST:/VsanVcClusterHealthSystem/{moId}/VsanQueryVcClusterHealthSummary"
 
 
 def _vsan_summary(overall: str, groups: list[Any]) -> dict[str, Any]:
@@ -1219,13 +1077,7 @@ def _vsan_summary(overall: str, groups: list[Any]) -> dict[str, Any]:
 
 @pytest.mark.asyncio
 async def test_host_vsan_health_queries_health_summary_for_cluster() -> None:
-    """One health-service query fires, scoped to the cluster; groups + tests flatten.
-
-    ``VsanClusterHealthSummary.overallHealth`` surfaces as
-    ``overall_health``; each ``VsanClusterHealthGroup`` flattens to
-    group_id / group_name / group_health plus a per-check ``tests`` list
-    (testId / testName / testHealth / testShortDescription).
-    """
+    """One health-service query fires, scoped to the cluster; groups + tests flatten."""
     summary = _vsan_summary(
         overall="green",
         groups=[
@@ -1250,26 +1102,21 @@ async def test_host_vsan_health_queries_health_summary_for_cluster() -> None:
             },
         ],
     )
-    dispatch = _RecordingDispatchChild({_VSAN_QUERY_OP: summary})
+    conn = _RecordingConnector({_VSAN_PATH: summary})
 
     out = await host_vsan_health_composite(
         operator=_make_operator(),
         target=object(),
         params={"cluster": "domain-c123"},
-        dispatch_child=dispatch,
+        connector=conn,  # type: ignore[arg-type]
     )
 
-    assert len(dispatch.calls) == 1
-    call = dispatch.calls[0]
-    assert call["op_id"] == _VSAN_QUERY_OP
-    assert call["connector_id"] == "vmware-rest-9.0"
-    # The health query targets the vsan-cluster-health-system singleton
-    # and carries the cluster MoRef.
-    assert call["params"]["moId"] == "vsan-cluster-health-system"
-    assert call["params"]["cluster"] == {
-        "type": "ClusterComputeResource",
-        "value": "domain-c123",
-    }
+    assert len(conn.calls) == 1
+    call = conn.calls[0]
+    assert call["method"] == "POST"
+    # The singleton moId rides the path; the cluster MoRef is the body arg.
+    assert call["path"] == _VSAN_PATH
+    assert call["body"] == {"cluster": {"type": "ClusterComputeResource", "value": "domain-c123"}}
 
     assert out["cluster"] == "domain-c123"
     assert out["overall_health"] == "green"
@@ -1299,49 +1146,33 @@ async def test_host_vsan_health_queries_health_summary_for_cluster() -> None:
 
 @pytest.mark.asyncio
 async def test_host_vsan_health_read_is_best_effort_on_error() -> None:
-    """A failed health-service read nulls groups/overall + records a ``read_note``.
-
-    The cluster is already identified by the ``cluster`` param, so a
-    health-service error (vSAN disabled, endpoint reject) returns the
-    payload with ``overall_health`` / ``groups`` nulled and a
-    ``read_note`` rather than raising.
-    """
-    dispatch = _RecordingDispatchChild(
-        [
-            _connector_error_result(
-                _VSAN_QUERY_OP,
-                "Client error '400 Bad Request' for url "
-                "'https://vc/vsanHealth/VsanVcClusterHealthSystem/"
-                "vsan-cluster-health-system/VsanQueryVcClusterHealthSummary'",
-            )
-        ]
+    """A failed health-service read nulls groups/overall + records a ``read_note``."""
+    conn = _RecordingConnector(
+        [_http_error(400, "https://vc" + _VSAN_PATH.replace("/api", "/vsanHealth"))]
     )
     out = await host_vsan_health_composite(
         operator=_make_operator(),
         target=object(),
         params={"cluster": "domain-c404"},
-        dispatch_child=dispatch,
+        connector=conn,  # type: ignore[arg-type]
     )
     assert out["cluster"] == "domain-c404"
     assert out["overall_health"] is None
     assert out["groups"] is None
-    assert "read_note" in out
     note = out["read_note"]
-    assert _VSAN_QUERY_OP in note
+    assert _VSAN_OP in note
     assert "400 Bad Request" in note
 
 
 @pytest.mark.asyncio
 async def test_host_vsan_health_tolerates_legacy_value_envelope() -> None:
     """A ``{"value": ...}`` envelope on the summary unwraps cleanly."""
-    dispatch = _RecordingDispatchChild(
-        [_ok_result(_VSAN_QUERY_OP, {"value": _vsan_summary(overall="red", groups=[])})]
-    )
+    conn = _RecordingConnector({_VSAN_PATH: {"value": _vsan_summary(overall="red", groups=[])}})
     out = await host_vsan_health_composite(
         operator=_make_operator(),
         target=object(),
         params={"cluster": "domain-c1"},
-        dispatch_child=dispatch,
+        connector=conn,  # type: ignore[arg-type]
     )
     assert out["overall_health"] == "red"
     assert out["groups"] == []
@@ -1350,149 +1181,85 @@ async def test_host_vsan_health_tolerates_legacy_value_envelope() -> None:
 @pytest.mark.asyncio
 async def test_host_vsan_health_tolerates_missing_groups_key() -> None:
     """A summary without a ``groups`` list degrades to an empty group list."""
-    dispatch = _RecordingDispatchChild([_ok_result(_VSAN_QUERY_OP, {"overallHealth": "green"})])
+    conn = _RecordingConnector({_VSAN_PATH: {"overallHealth": "green"}})
     out = await host_vsan_health_composite(
         operator=_make_operator(),
         target=object(),
         params={"cluster": "domain-c1"},
-        dispatch_child=dispatch,
+        connector=conn,  # type: ignore[arg-type]
     )
     assert out["overall_health"] == "green"
     assert out["groups"] == []
 
 
 # ---------------------------------------------------------------------------
-# Error fan-out -- a sub-op error causes the handler to raise
+# Mount routing (modern + legacy) + zero-catalog-ingest contract
 # ---------------------------------------------------------------------------
 
 
 @pytest.mark.asyncio
-async def test_cluster_drs_recommendations_raises_on_sub_op_error() -> None:
-    """A sub-op ``status="error"`` causes the composite to raise ``RuntimeError``.
+async def test_read_sub_ops_route_through_legacy_rest_mount() -> None:
+    """Every sub-op is mounted, so a legacy/vcsim target routes onto ``/rest``.
 
-    Load-bearing for the dispatcher's outer exception branch: the
-    composite parent sees the failure as a structured
-    ``connector_error`` result with the underlying op_id and message
-    in ``extras["exception_class"]``.
+    A target whose session established on the legacy path serves ops only
+    under ``/rest`` (not ``/api``); the composite must mount each sub-op
+    through ``mount_op_path`` or it 404s. This is the modern+legacy mount
+    coverage the acceptance criteria require, at the unit level.
     """
-    dispatch = _RecordingDispatchChild(
-        {
-            "GET:/vcenter/cluster/{cluster}": _err_result(
-                "GET:/vcenter/cluster/{cluster}", "cluster not found"
-            ),
-        }
+    listing = [{"datastore": "datastore-1", "name": "ds-1"}]
+    conn = _RecordingConnector(
+        [listing, {"capacity": 1, "free_space": 1}, []],
+        mount_prefix="/rest",
     )
-    with pytest.raises(RuntimeError, match="returned status='error'"):
-        await cluster_drs_recommendations_composite(
-            operator=_make_operator(),
-            target=object(),
-            params={"cluster": "bogus"},
-            dispatch_child=dispatch,
-        )
-
-
-@pytest.mark.asyncio
-async def test_datastore_usage_raises_on_listing_error() -> None:
-    """A failed listing surfaces as ``RuntimeError``; no per-DS calls fire."""
-    dispatch = _RecordingDispatchChild([_err_result("GET:/vcenter/datastore", "permission denied")])
-    with pytest.raises(RuntimeError, match="returned status='error'"):
-        await datastore_usage_composite(
-            operator=_make_operator(),
-            target=object(),
-            params={},
-            dispatch_child=dispatch,
-        )
-    assert len(dispatch.calls) == 1
-
-
-@pytest.mark.asyncio
-async def test_event_tail_raises_on_sub_op_error() -> None:
-    """QueryEvents error surfaces as ``RuntimeError`` (no aggregation)."""
-    dispatch = _RecordingDispatchChild(
-        [_err_result("POST:/EventManager/{moId}/QueryEvents", "vi-json transient")]
+    out = await datastore_usage_composite(
+        operator=_make_operator(),
+        target=object(),
+        params={},
+        connector=conn,  # type: ignore[arg-type]
     )
-    with pytest.raises(RuntimeError, match="returned status='error'"):
-        await event_tail_composite(
-            operator=_make_operator(),
-            target=object(),
-            params={},
-            dispatch_child=dispatch,
-        )
-
-
-# ---------------------------------------------------------------------------
-# Connector-id contract
-# ---------------------------------------------------------------------------
+    # Every recorded call lands under the legacy /rest mount.
+    assert all(c["path"].startswith("/rest/") for c in conn.calls)
+    assert conn.calls[0]["path"] == "/rest/vcenter/datastore"
+    assert out["datastores"][0]["id"] == "datastore-1"
 
 
 @pytest.mark.asyncio
-async def test_every_composite_uses_vmware_rest_9_0_connector_id() -> None:
-    """All seven read handlers dispatch sub-ops against ``vmware-rest-9.0`` exclusively.
+async def test_every_read_composite_dispatches_directly_on_the_session() -> None:
+    """All 7 read handlers reach their sub-ops via the connector session only.
 
-    Load-bearing for the issue body's *Why dispatch_child not direct
-    httpx* contract: the connector_id is what routes the recursive
-    dispatch back to :class:`VmwareRestConnector` for sub-call
-    authentication.
+    Load-bearing for the #2253 contract: no ``dispatch_child``, no
+    ingested descriptor, no L2 pre-flight -- so the composites work on a
+    fresh boot with zero catalog ingest. Each handler is exercised with a
+    minimal happy-path stub and must (a) record at least one session call
+    and (b) mount every path it hit.
     """
-    handlers: tuple[tuple[Any, dict[str, Any], dict[str, Any]], ...] = (
+    handlers: tuple[tuple[Any, dict[str, Any], list[Any]], ...] = (
         (
             cluster_drs_recommendations_composite,
             {"cluster": "c1"},
-            {
-                "GET:/vcenter/cluster/{cluster}": {},
-                "GET:/vcenter/cluster/{cluster}/drs": {},
-            },
+            [{}, {}],
         ),
-        (
-            event_tail_composite,
-            {},
-            {"POST:/EventManager/{moId}/QueryEvents": []},
-        ),
-        (
-            performance_summary_composite,
-            {"entity_moid": "vm-1"},
-            {
-                "POST:/PerformanceManager/{moId}/QueryAvailablePerfMetric": [],
-                "POST:/PerformanceManager/{moId}/QueryPerf": [],
-            },
-        ),
-        (
-            datastore_usage_composite,
-            {},
-            {"GET:/vcenter/datastore": []},
-        ),
-        (
-            network_portgroup_audit_composite,
-            {},
-            {
-                "GET:/vcenter/network/distributed-switches": [],
-                "GET:/vcenter/network": [],
-            },
-        ),
-        (
-            host_network_uplinks_composite,
-            {},
-            {"GET:/vcenter/host": []},
-        ),
+        (event_tail_composite, {}, [[]]),
+        (performance_summary_composite, {"entity_moid": "vm-1"}, [[], []]),
+        (datastore_usage_composite, {}, [[]]),
+        (network_portgroup_audit_composite, {}, [[], []]),
+        (host_network_uplinks_composite, {}, [[]]),
         (
             host_vsan_health_composite,
             {"cluster": "domain-c1"},
-            {
-                "POST:/VsanVcClusterHealthSystem/{moId}/VsanQueryVcClusterHealthSummary": (
-                    {"overallHealth": "green", "groups": []}
-                )
-            },
+            [{"overallHealth": "green", "groups": []}],
         ),
     )
     for handler, params, responses in handlers:
-        dispatch = _RecordingDispatchChild(dict(responses))
+        conn = _RecordingConnector(list(responses))
         await handler(
             operator=_make_operator(),
             target=object(),
             params=params,
-            dispatch_child=dispatch,
+            connector=conn,  # type: ignore[arg-type]
         )
-        for call in dispatch.calls:
-            assert call["connector_id"] == "vmware-rest-9.0", (
-                f"{handler.__qualname__} dispatched to {call['connector_id']}"
-            )
+        assert conn.calls, f"{handler.__qualname__} issued no session sub-calls"
+        # Every session call went through a mount resolution.
+        assert len(conn.mount_calls) == len(conn.calls), (
+            f"{handler.__qualname__} bypassed mount_op_path on a sub-op"
+        )

--- a/backend/tests/test_operations_dispatcher.py
+++ b/backend/tests/test_operations_dispatcher.py
@@ -68,6 +68,7 @@ from meho_backplane.operations import (
     register_typed_operation,
     reset_dispatcher_caches,
 )
+from meho_backplane.operations.dispatcher import _handler_requires_target
 from meho_backplane.settings import get_settings
 
 # ---------------------------------------------------------------------------
@@ -239,6 +240,24 @@ async def _module_composite_handler(
         params={"path": params.get("path", "/")},
     )
     return {"parent": "ok", "child_status": child_result.status}
+
+
+async def _module_composite_handler_connector(
+    operator: Operator,
+    target: Any,
+    params: dict[str, Any],
+    connector: Any,
+) -> dict[str, Any]:
+    """Direct-session composite handler that declares the ``connector`` kwarg.
+
+    The #2251/#2253 shape: a composite that issues its sub-calls on the
+    resolved connector instance rather than through ``dispatch_child``. It
+    reaches that instance *through* the resolved target, so
+    :func:`_handler_requires_target` must treat it like the self-first
+    shape and flag ``target=None`` as ``target_required`` (#2253
+    carry-forward) rather than forwarding ``connector=None``.
+    """
+    return {"has_connector": connector is not None}
 
 
 async def _module_handler_raises(
@@ -914,6 +933,26 @@ async def test_dispatch_module_level_handler_no_target_still_dispatches(
     assert isinstance(result.result, dict)
     assert result.result["echo"] == {"hello": "world"}
     assert result.result["target_is_none"] is True
+
+
+def test_handler_requires_target_flags_connector_declaring_composite() -> None:
+    """A ``connector``-declaring composite needs a target (#2253 carry-forward).
+
+    :func:`_handler_requires_target` keys the no-target guard on handler
+    shape. A direct-session composite reaches its connector instance
+    through the resolved target (the dispatcher builds the instance from a
+    non-None target), so dispatching it with ``target=None`` would forward
+    ``connector=None`` and ``AttributeError`` on the first
+    ``connector._get_json`` call. The guard must therefore treat it like
+    the self-first shape and return ``True`` so the caller surfaces the
+    clean ``target_required`` envelope. A ``dispatch_child``-only composite
+    and a plain module-level typed handler both stay ``False`` -- neither
+    dereferences a per-target connector instance.
+    """
+    module = "tests.test_operations_dispatcher"
+    assert _handler_requires_target(f"{module}._module_composite_handler_connector") is True
+    assert _handler_requires_target(f"{module}._module_composite_handler") is False
+    assert _handler_requires_target(f"{module}._module_handler_target_optional") is False
 
 
 @pytest.mark.asyncio

--- a/docs/codebase/connectors-vmware-rest.md
+++ b/docs/codebase/connectors-vmware-rest.md
@@ -30,12 +30,26 @@ Source: `backend/src/meho_backplane/connectors/vmware_rest/`.
   `event_tail_composite`, `performance_summary_composite`,
   `datastore_usage_composite`, `network_portgroup_audit_composite`,
   `host_network_uplinks_composite`, `host_vsan_health_composite`).
-  Each accepts `(operator, target, params, dispatch_child)` per the
-  `DispatchChild` Protocol and orchestrates 1-3 sub-op dispatches
-  back into the same `vmware-rest-9.0` connector. Registered with
-  `safety_level="safe"` + `requires_approval=False` — read-only
-  overrides of `register_composite_operation()`'s `dangerous` / `True`
-  defaults. `host_network_uplinks_composite` (`#2080`) lists hosts via
+  Since `#2253` each accepts `(operator, target, params, connector)`
+  and issues its 1-3 sub-ops **directly on the resolved connector
+  session** — `connector._get_json` / `connector._post_json` mounted
+  through `connector.mount_op_path` (`_read_sub_op`) — with **no**
+  `dispatch_child`, **no** ingested `endpoint_descriptor` lookup, and
+  **no** L2 pre-flight, so the read composites work on a fresh boot
+  with zero vCenter-catalog ingest (the `composite_l2_missing` defect
+  class, consumer signal 20, is gone for reads). The `connector` kwarg
+  is the substrate `#2251` added to the composite handler contract; the
+  dispatcher forwards the instance it already resolved for the
+  composite's target. The direct path drops two of `dispatch_child`'s
+  four `#508` guarantees (bounded recursion, per-sub-op param
+  validation) and relocates the other two (audit-tree linkage collapses
+  to the top-level composite audit row; per-sub-op policy/broadcast is
+  the top-level op's) — acceptable for **reads**, which is why the
+  write composites keep `dispatch_child` (their sub-ops may be
+  approval-gated). Registered with `safety_level="safe"` +
+  `requires_approval=False` — read-only overrides of
+  `register_composite_operation()`'s `dangerous` / `True` defaults.
+  `host_network_uplinks_composite` (`#2080`) lists hosts via
   `GET:/vcenter/host`, then per host reads `config.network.pnic` +
   `config.network.proxySwitch` through the vi-json PropertyCollector
   `RetrievePropertiesEx` method — the pnic link-state / uplink mapping
@@ -77,9 +91,10 @@ Source: `backend/src/meho_backplane/connectors/vmware_rest/`.
   (`host_usage(self, operator, target, params)`) that the dispatcher
   binds to the resolved connector instance and calls directly — no
   `dispatch_child`, no ingested-descriptor sub-ops, no L2 pre-flight. It
-  therefore works on a **fresh boot with zero catalog ingest**, which a
-  composite cannot (a composite's `dispatch_child` legs resolve against
-  `endpoint_descriptor` rows that only exist post-ingest). The metadata
+  therefore works on a **fresh boot with zero catalog ingest** — the same
+  direct-session property the 7 read composites now share (`#2253`); only
+  the **write** composites still resolve their `dispatch_child` legs
+  against `endpoint_descriptor` rows that exist post-ingest. The metadata
   lives in a frozen `VmwareTypedOp` dataclass (mirroring
   `argocd/ops.py::ArgoCdOp`); the implementation
   (`host_usage_impl(connector, operator, target, params)`) lists hosts


### PR DESCRIPTION
## Summary
- Migrates the **7 read** vmware composites (`composites/_read.py`) from `dispatch_child`-through-ingested-rows to **direct connector-session** sub-calls (`connector._get_json` / `connector._post_json` + `connector.mount_op_path`, via the new `_read_sub_op` helper), using the `connector` kwarg the #2251 substrate added. No `endpoint_descriptor` lookup, no L2 pre-flight — the reads now work on a **fresh boot with zero vCenter-catalog ingest** (the `composite_l2_missing` defect class, consumer signal 20, is gone for reads).
- Response schema + aggregation semantics are **identical** — this is a dispatch-mechanism swap only. vi-json method args become the flat request body (moid rides the path), mirroring the `vmware.host.usage` typed op. Load-bearing sub-op failures propagate as `httpx` errors (dispatcher wraps them as `connector_error`); best-effort legs (datastore VM enrichment, per-host property read, vSAN health) catch and degrade with a `read_note` / `enrichment_note`.
- **Carry-forward (from #2261 review):** `_handler_requires_target` now also flags a `connector`-declaring composite, so dispatching one with `target=None` returns a clean `target_required` error instead of forwarding `connector=None` and NPE-ing inside the handler.
- Write composites are untouched — they keep `dispatch_child` because their sub-ops may be approval-gated (property-3, Initiative #2249).

## Test plan
- [x] `ruff check` / `ruff format --check` — clean (6 files)
- [x] `mypy src/...composites/_read.py src/...operations/dispatcher.py` — clean
- [x] **Unit** (`test_connectors_vmware_rest_composites_read.py`, rewritten) — 38 passed. Stubs the connector session with a recording double keyed by mounted path; asserts method / mounted path / query / body per sub-op **and** the unchanged aggregation for all 7 composites (incl. legacy `{"value":…}` envelopes, filter pass-through, best-effort degradation, load-bearing propagation).
- [x] **Parity end-to-end** (`tests/integration/test_connectors_vmware_rest_vcsim.py`, new) — dispatches `datastore.usage` on the **real connector transport** (respx) over both `/api` (modern) and `/rest` (legacy) mounts, with **zero ingested descriptors** — proves AC #2 (per-op parity + mount fallback) and AC #3 (works with no catalog ingest).
- [x] **Carry-forward guard** (`test_operations_dispatcher.py`, new) — `_handler_requires_target` returns True for a `connector`-declaring composite, False for `dispatch_child`-only + plain module-level handlers.
- [x] Full sweep across vmware/composite/dispatcher/operations — 518 passed, 13 skipped (vcsim/DB-gated), 0 failed. Count-lines (15 composites / 7 reads) unchanged (composites stay composites).

## Out of scope
- Write-composite migration (B1/B3, Initiative #2249) — writes keep `dispatch_child`.
- The read `_SUB_OPS_*` tuples are retained as the canonical sub-op-path manifest the ingest-reconcile acceptance guard checks; the obsolete read-composite L2-preflight unit test was removed (reads no longer pre-flight).

<!-- auto-implement-issue: fresh, iteration 1 -->

Closes #2253
