### PR TITLE
feat(connectors): read-only multi-tenant Grafana Loki connector (#2235)

### DIFF
--- a/backend/src/meho_backplane/connectors/loki/__init__.py
+++ b/backend/src/meho_backplane/connectors/loki/__init__.py
@@ -1,0 +1,112 @@
+# SPDX-License-Identifier: Apache-2.0
+# Copyright (c) 2026 evoila Group
+
+"""meho_backplane.connectors.loki -- LokiConnector package (#2235).
+
+Importing this package registers :class:`LokiConnector` against the v2
+connector registry under the natural key
+``(product="loki", version="3.x", impl_id="loki-api")`` **and** the
+``(product="loki", version="", impl_id="")`` wildcard fallback -- dual
+registration from day one per G0.15-T6 (#1215).
+
+Two-phase registration, the same shape as
+:mod:`meho_backplane.connectors.argocd.__init__` /
+:mod:`meho_backplane.connectors.pfsense.__init__`:
+
+* **Synchronous (import time)** -- the v2 registry entries land via
+  :func:`~meho_backplane.connectors.registry.register_connector_v2` below, so
+  the lookup tables are populated before the lifespan begins and a probe
+  firing during startup sees a fully-populated registry.
+  :func:`~meho_backplane.connectors.registry._eager_import_connectors`
+  discovers this subpackage by directory name, so no manual import-list edit
+  is needed elsewhere.
+
+* **Asynchronous (lifespan startup)** --
+  :func:`~meho_backplane.operations.typed_register.run_typed_op_registrars`
+  invokes :func:`register_loki_typed_operations`, which delegates to
+  :meth:`LokiConnector.register_operations` to upsert the six read-only
+  descriptors (``loki.query`` / ``loki.query_range`` / ``loki.labels`` /
+  ``loki.label_values`` / ``loki.series`` / ``loki.get``). Idempotent on
+  re-call with unchanged op text.
+
+The v1 :func:`~meho_backplane.connectors.registry.register_connector` entry
+point is intentionally **not** called: Loki has no v1 chassis history, and the
+v1 entry would land as ``("loki", "", "")`` and confuse the resolver tie-break
+ladder -- the same decision argocd, bind9, and pfSense made.
+"""
+
+from meho_backplane.connectors.loki.connector import LokiConnector, LokiTenantRequiredError
+from meho_backplane.connectors.loki.ops import (
+    LOKI_OPS,
+    LOKI_WHEN_TO_USE_BY_GROUP,
+    LokiOp,
+)
+from meho_backplane.connectors.loki.read_only import (
+    LokiReadOnlyError,
+    assert_loki_read_only,
+)
+from meho_backplane.connectors.registry import register_connector_v2
+from meho_backplane.operations.typed_register import register_typed_op_registrar
+from meho_backplane.retrieval.embedding import EmbeddingService
+
+
+async def register_loki_typed_operations(
+    *,
+    embedding_service: EmbeddingService | None = None,
+) -> None:
+    """Module-level registrar wrapper for ``LokiConnector.register_operations``.
+
+    The canonical typed-op registration pattern (G0.6-T-Refactor-Vault #390)
+    is a module-level ``async def register_xxx_typed_operations`` queued onto
+    :func:`~meho_backplane.operations.typed_register.run_typed_op_registrars`.
+    Loki implements the op walk as a classmethod on :class:`LokiConnector` so
+    the test suite can exercise it without lifespan plumbing; this wrapper is
+    the seam that lets the standard registrar mechanism drive it.
+
+    The ``embedding_service`` keyword-only parameter mirrors the argocd / bind9
+    contract: :func:`run_typed_op_registrars` passes the process-wide
+    :class:`EmbeddingService` (or a chassis-test stub) to every registrar, so
+    each registrar **must** accept the kwarg or the lifespan crashes with
+    :class:`TypeError`. The wrapper accepts-and-discards it because
+    :meth:`LokiConnector.register_operations` resolves the embedding service
+    via ``register_typed_operation``'s process-wide singleton fallback.
+    """
+    del embedding_service  # see docstring -- kwarg accepted for runner-compatibility
+    await LokiConnector.register_operations()
+
+
+# v2 entry -- the canonical resolver key. The versioned triple always wins the
+# resolver tie-break when both it and the wildcard are present.
+register_connector_v2(
+    product="loki",
+    version="3.x",
+    impl_id="loki-api",
+    cls=LokiConnector,
+)
+
+# G0.15-T6 (#1215) wildcard fallback -- a target with ``version=None`` (fresh,
+# unfingerprinted, no operator-asserted version yet) resolves to this connector
+# through the resolver's ``versioned_over_wildcard`` step rather than 501-ing
+# with ``no_connector``.
+register_connector_v2(
+    product="loki",
+    version="",
+    impl_id="",
+    cls=LokiConnector,
+)
+
+# Queue the typed-op upsert onto the lifespan-driven registrar list. The runner
+# (``run_typed_op_registrars``) iterates after ``_eager_import_connectors`` so
+# the descriptor rows land before the first dispatch.
+register_typed_op_registrar(register_loki_typed_operations)
+
+__all__ = [
+    "LOKI_OPS",
+    "LOKI_WHEN_TO_USE_BY_GROUP",
+    "LokiConnector",
+    "LokiOp",
+    "LokiReadOnlyError",
+    "LokiTenantRequiredError",
+    "assert_loki_read_only",
+    "register_loki_typed_operations",
+]

--- a/backend/src/meho_backplane/connectors/loki/connector.py
+++ b/backend/src/meho_backplane/connectors/loki/connector.py
@@ -1,0 +1,517 @@
+# SPDX-License-Identifier: Apache-2.0
+# Copyright (c) 2026 evoila Group
+
+"""LokiConnector -- read-only, multi-tenant HttpConnector for Grafana Loki (#2235).
+
+The logs half of an LGTM stack, brought inside the MEHO dispatch ->
+policy-gate -> audit seam. Registry v2 triple ``("loki", "3.x", "loki-api")``
+over the Loki HTTP API (``/loki/api/v1``, default port 3100).
+
+Design
+------
+
+* **Read-only by construction.** Every op issues a GET through
+  :meth:`~meho_backplane.connectors.adapters.http.HttpConnector._request_json`
+  (which rejects non-idempotent verbs), and the generic ``loki.get``
+  passthrough runs its path through
+  :func:`~meho_backplane.connectors.loki.read_only.assert_loki_read_only`
+  -- a GET-only, ``/loki/api/v1``-scoped gate with an explicit ``/push`` +
+  ``/delete*`` blocklist. No write op is registered.
+
+* **Multi-tenant via a per-call header.** Loki enforces tenancy with the
+  ``X-Scope-OrgID`` header when ``auth_enabled``. No other MEHO connector
+  threads a per-call tenant header, so it is modelled as an optional
+  ``tenant`` op param rendered into ``extra_headers`` on each request -- not
+  a target-level field and not part of :meth:`auth_headers` (so the
+  readiness probe and fingerprint stay tenant-free). A query issued without
+  a ``tenant`` against an ``auth_enabled`` Loki gets a ``401 "no org id"``;
+  the connector translates that into a clear
+  :class:`LokiTenantRequiredError` rather than passing the bare 401 through.
+
+* **Optional auth.** Loki is commonly reached unauthenticated via a
+  port-forward. When ``target.secret_ref`` is ``None`` the connector sends no
+  ``Authorization`` header (:meth:`auth_headers` returns ``{}``); when it is
+  set, the stored secret selects Bearer (a ``token`` field) or Basic
+  (``username`` + ``password``). This is the explicit "auth optional when
+  secret_ref is None" branch -- op execution otherwise fails closed on an
+  unresolved credential.
+
+* **Scheme.** Loki's native API is plain HTTP (the port-forward case), so the
+  connector talks ``http`` by default. A TLS-fronted Loki is reached by
+  setting ``extras={"scheme": "https"}`` on the target -- the one per-product
+  field the base ``Target`` model does not model with a column, carried in the
+  forward-compat ``extras`` bag.
+
+* **Fingerprint.** ``GET /loki/api/v1/status/buildinfo`` (version + revision)
+  plus ``GET /ready`` (readiness) plus a best-effort ``GET
+  /loki/api/v1/labels`` (label_count). All three are issued tenant-free and
+  unauthenticated, so the fingerprint works on a freshly registered target
+  before any secret is configured -- the same precedent as the argocd
+  ``/api/version`` probe.
+"""
+
+from __future__ import annotations
+
+import base64
+import time
+from datetime import UTC, datetime
+from typing import Any
+from urllib.parse import quote
+
+import httpx
+import structlog
+from tenacity import retry, retry_if_exception, stop_after_attempt, wait_exponential
+
+from meho_backplane.auth.operator import Operator
+from meho_backplane.connectors._shared.vault_creds import (
+    VaultCredentialsReadError,
+    load_vault_secret_data,
+    strip_credential_value,
+)
+from meho_backplane.connectors.adapters.http import HttpConnector
+from meho_backplane.connectors.loki.ops import LOKI_OPS, LOKI_WHEN_TO_USE_BY_GROUP
+from meho_backplane.connectors.loki.read_only import assert_loki_read_only
+from meho_backplane.connectors.schemas import (
+    FingerprintResult,
+    OperationResult,
+    ProbeResult,
+)
+
+__all__ = ["LokiConnector", "LokiTenantRequiredError"]
+
+_log = structlog.get_logger(__name__)
+
+# Forward declaration -- replaced with `from meho_backplane.targets import Target`
+# once G0.3's Target model rollout lands, mirroring the sibling connectors.
+type Target = Any
+
+_BUILDINFO_PATH = "/loki/api/v1/status/buildinfo"
+_READY_PATH = "/ready"
+_LABELS_PATH = "/loki/api/v1/labels"
+_TENANT_HEADER = "X-Scope-OrgID"
+
+
+class LokiTenantRequiredError(RuntimeError):
+    """A tenant-scoped Loki (``auth_enabled``) was queried without an org id.
+
+    Raised when a query returns ``401`` and no ``tenant`` selector was
+    supplied -- Loki answers ``"no org id"`` in that case. Surfacing an
+    actionable error (rather than the bare 401) tells the operator to pass a
+    ``tenant`` instead of chasing a credential problem. Subclasses
+    :class:`RuntimeError` so the dispatcher's ``connector_error`` branch
+    renders the message verbatim.
+    """
+
+
+def _version_retryable(exc: BaseException) -> bool:
+    """Retry the unauthenticated probe GETs on connection errors and 5xx; never 4xx.
+
+    Mirrors :func:`HttpConnector._retryable`; defined locally so the
+    fingerprint/probe path (which bypasses the base ``_request_json`` retry
+    wrapper because it sends no auth or tenant header) keeps the same
+    idempotent-GET retry semantics without reaching into the adapter's private
+    name.
+    """
+    if isinstance(exc, (httpx.ConnectError, httpx.ConnectTimeout, httpx.ReadError)):
+        return True
+    if isinstance(exc, httpx.HTTPStatusError):
+        return 500 <= exc.response.status_code < 600
+    return False
+
+
+class LokiConnector(HttpConnector):
+    """Grafana Loki read-only, multi-tenant connector over ``/loki/api/v1``.
+
+    Registry v2 triple ``("loki", "3.x", "loki-api")``. ``priority`` is set to
+    ``1`` so a future ``GenericRestConnector`` auto-shim registering the same
+    triple loses the resolver tie-break ladder.
+    """
+
+    product = "loki"
+    version = "3.x"
+    impl_id = "loki-api"
+    supported_version_range = ">=2.9,<4.0"
+    priority = 1
+
+    # ------------------------------------------------------------------
+    # Transport plumbing
+    # ------------------------------------------------------------------
+
+    def _base_url(self, target: Target) -> str:
+        """Return ``{scheme}://{host}[:{port}]`` -- HTTP by default.
+
+        Loki's native API is plaintext HTTP (the port-forward case), so the
+        default scheme is ``http``; a TLS-fronted Loki sets
+        ``extras={"scheme": "https"}`` on the target. The port is appended
+        unless it is the scheme's default (80 for http, 443 for https).
+        """
+        scheme = self._scheme(target)
+        default_port = 443 if scheme == "https" else 80
+        port = getattr(target, "port", None)
+        port_suffix = f":{port}" if port and port != default_port else ""
+        return f"{scheme}://{target.host}{port_suffix}"
+
+    @staticmethod
+    def _scheme(target: Target) -> str:
+        """Return ``"https"`` when the target's ``extras`` opts in, else ``"http"``."""
+        extras = getattr(target, "extras", None) or {}
+        return "https" if str(extras.get("scheme", "")).lower() == "https" else "http"
+
+    async def auth_headers(self, target: Target, operator: Operator) -> dict[str, str]:
+        """Return the optional ``Authorization`` header -- ``{}`` when unauthenticated.
+
+        Optional-auth branch: a target with ``secret_ref=None`` is
+        unauthenticated (the port-forward case) and gets no header. When
+        ``secret_ref`` is set, the stored KV-v2 secret selects the scheme -- a
+        ``token`` field yields Bearer; ``username`` + ``password`` yields
+        Basic. A configured-but-unusable secret (neither shape) raises
+        :class:`VaultCredentialsReadError`.
+
+        The tenant header is deliberately *not* set here -- it is per-call
+        (:meth:`_loki_get`) so the probe and fingerprint stay tenant-free.
+        """
+        if not getattr(target, "secret_ref", None):
+            return {}
+        secret = await load_vault_secret_data(target, operator)
+        token = secret.get("token")
+        if token:
+            return {"Authorization": f"Bearer {strip_credential_value(token)}"}
+        username = secret.get("username")
+        password = secret.get("password")
+        if username is not None and password is not None:
+            raw = f"{strip_credential_value(username)}:{strip_credential_value(password)}"
+            encoded = base64.b64encode(raw.encode("utf-8")).decode("ascii")
+            return {"Authorization": f"Basic {encoded}"}
+        raise VaultCredentialsReadError(
+            f"loki target {getattr(target, 'name', target)!r} has a secret_ref but its "
+            "secret carries neither a 'token' (Bearer) nor 'username'+'password' (Basic) "
+            "credential"
+        )
+
+    async def _loki_get(
+        self,
+        operator: Operator,
+        target: Target,
+        path: str,
+        *,
+        params: dict[str, Any] | None = None,
+        tenant: str | None = None,
+    ) -> dict[str, Any]:
+        """Issue a gated, optionally tenant-scoped GET and return parsed JSON.
+
+        Runs the read-only gate first (so a bad path never reaches the wire),
+        renders ``tenant`` into ``X-Scope-OrgID`` when set, and translates a
+        ``401`` on a tenant-less call into :class:`LokiTenantRequiredError`.
+        """
+        assert_loki_read_only("GET", path)
+        extra_headers = {_TENANT_HEADER: tenant} if tenant else None
+        try:
+            return await self._request_json(
+                target, "GET", path, operator=operator, params=params, extra_headers=extra_headers
+            )
+        except httpx.HTTPStatusError as exc:
+            if exc.response.status_code == 401 and tenant is None:
+                raise LokiTenantRequiredError(
+                    f"loki target {getattr(target, 'name', target)!r} returned 401 with no "
+                    "tenant supplied; this Loki has auth_enabled (multi-tenant). Pass a "
+                    "'tenant' selector so the request carries the X-Scope-OrgID header"
+                ) from exc
+            raise
+
+    @staticmethod
+    def _forward(params: dict[str, Any], keys: tuple[str, ...]) -> dict[str, Any]:
+        """Return the subset of *params* whose *keys* are present and non-None."""
+        return {k: params[k] for k in keys if params.get(k) is not None}
+
+    # ------------------------------------------------------------------
+    # Curated read ops -- each threads ``operator`` for the (optional) auth
+    # read and an optional ``tenant`` for the X-Scope-OrgID header.
+    # ------------------------------------------------------------------
+
+    async def query(
+        self, operator: Operator, target: Target, params: dict[str, Any]
+    ) -> dict[str, Any]:
+        """``loki.query`` -- ``GET /loki/api/v1/query`` (LogQL instant query)."""
+        query = {"query": params["query"], **self._forward(params, ("time", "limit", "direction"))}
+        return await self._loki_get(
+            operator, target, "/loki/api/v1/query", params=query, tenant=params.get("tenant")
+        )
+
+    async def query_range(
+        self, operator: Operator, target: Target, params: dict[str, Any]
+    ) -> dict[str, Any]:
+        """``loki.query_range`` -- ``GET /loki/api/v1/query_range`` (range query)."""
+        query = {
+            "query": params["query"],
+            **self._forward(
+                params, ("start", "end", "since", "step", "interval", "limit", "direction")
+            ),
+        }
+        return await self._loki_get(
+            operator, target, "/loki/api/v1/query_range", params=query, tenant=params.get("tenant")
+        )
+
+    async def labels(
+        self, operator: Operator, target: Target, params: dict[str, Any]
+    ) -> dict[str, Any]:
+        """``loki.labels`` -- ``GET /loki/api/v1/labels`` (known label names)."""
+        query = self._forward(params, ("start", "end", "since", "query"))
+        return await self._loki_get(
+            operator, target, _LABELS_PATH, params=query or None, tenant=params.get("tenant")
+        )
+
+    async def label_values(
+        self, operator: Operator, target: Target, params: dict[str, Any]
+    ) -> dict[str, Any]:
+        """``loki.label_values`` -- ``GET /loki/api/v1/label/{name}/values``."""
+        name = quote(str(params["name"]), safe="")
+        query = self._forward(params, ("start", "end", "since", "query"))
+        return await self._loki_get(
+            operator,
+            target,
+            f"/loki/api/v1/label/{name}/values",
+            params=query or None,
+            tenant=params.get("tenant"),
+        )
+
+    async def series(
+        self, operator: Operator, target: Target, params: dict[str, Any]
+    ) -> dict[str, Any]:
+        """``loki.series`` -- ``GET /loki/api/v1/series`` (streams matching selectors)."""
+        # httpx serialises the list value into repeated ``match[]=a&match[]=b``
+        # pairs -- exactly Loki's expected wire shape for the selector param.
+        query: dict[str, Any] = {"match[]": list(params["match"])}
+        query.update(self._forward(params, ("start", "end", "since")))
+        return await self._loki_get(
+            operator, target, "/loki/api/v1/series", params=query, tenant=params.get("tenant")
+        )
+
+    async def get_passthrough(
+        self, operator: Operator, target: Target, params: dict[str, Any]
+    ) -> dict[str, Any]:
+        """``loki.get`` -- read-only GET passthrough to any ``/loki/api/v1`` path.
+
+        The path is gated by :func:`assert_loki_read_only` inside
+        :meth:`_loki_get` (GET-only, ``/loki/api/v1``-scoped, ``/push`` +
+        ``/delete*`` blocked), so the passthrough can never mutate Loki.
+        """
+        path = str(params["path"])
+        extra = params.get("params")
+        return await self._loki_get(
+            operator,
+            target,
+            path,
+            params=extra if isinstance(extra, dict) and extra else None,
+            tenant=params.get("tenant"),
+        )
+
+    # ------------------------------------------------------------------
+    # Fingerprint / probe -- tenant-free and unauthenticated
+    # ------------------------------------------------------------------
+
+    async def _unauth_get(self, target: Target, path: str) -> httpx.Response:
+        """Retried GET with **no** auth or tenant header, returning the response.
+
+        The base :meth:`HttpConnector._get_json` always calls
+        :meth:`auth_headers`; the probe/fingerprint path must not, so it hits
+        the pooled client directly. Retry semantics match the base class:
+        idempotent GET, 3 retries on connection errors / 5xx.
+        """
+
+        @retry(
+            stop=stop_after_attempt(4),
+            wait=wait_exponential(multiplier=0.5, min=0.5, max=2.0),
+            retry=retry_if_exception(_version_retryable),
+            reraise=True,
+        )
+        async def _do_get() -> httpx.Response:
+            client = await self._http_client(target)
+            resp = await client.get(path)
+            resp.raise_for_status()
+            return resp
+
+        return await _do_get()
+
+    async def _best_effort_label_count(self, target: Target) -> int | None:
+        """Return the tenant-free label count, or ``None`` when unavailable.
+
+        ``GET /loki/api/v1/labels`` is tenant-scoped on an ``auth_enabled``
+        Loki, so a tenant-free read there 401s -- treated as "unknown" (``None``)
+        rather than a fingerprint failure.
+        """
+        try:
+            resp = await self._unauth_get(target, _LABELS_PATH)
+            payload = resp.json()
+        except (httpx.HTTPError, OSError, ValueError):
+            return None
+        data = payload.get("data") if isinstance(payload, dict) else None
+        return len(data) if isinstance(data, list) else None
+
+    async def fingerprint(
+        self, target: Target, operator: Operator | None = None
+    ) -> FingerprintResult:
+        """Canonical fingerprint from ``status/buildinfo`` + ``/ready`` + labels.
+
+        ``buildinfo`` yields ``version`` and ``revision``; ``/ready`` yields
+        the readiness flag; ``labels`` yields a best-effort ``label_count``. All
+        three are tenant-free and unauthenticated, so the fingerprint works on
+        a freshly registered target before any secret is configured. Transport
+        or status failure on ``buildinfo`` maps to ``reachable=False`` with the
+        error under ``extras``.
+        """
+        del operator  # buildinfo/ready are unauthenticated -- no per-operator read
+        probed_at = datetime.now(UTC)
+        try:
+            build_resp = await self._unauth_get(target, _BUILDINFO_PATH)
+            buildinfo = build_resp.json()
+        except (httpx.HTTPError, OSError, ValueError) as exc:
+            return FingerprintResult(
+                vendor="grafana",
+                product="loki",
+                reachable=False,
+                probed_at=probed_at,
+                probe_method=f"GET {_BUILDINFO_PATH}",
+                extras={"error": f"{type(exc).__name__}: {exc}"},
+            )
+        if not isinstance(buildinfo, dict):
+            buildinfo = {}
+        ready = await self._ready_flag(target)
+        label_count = await self._best_effort_label_count(target)
+        return FingerprintResult(
+            vendor="grafana",
+            product="loki",
+            version=buildinfo.get("version") or None,
+            reachable=True,
+            probed_at=probed_at,
+            probe_method=f"GET {_BUILDINFO_PATH}",
+            extras={
+                "revision": buildinfo.get("revision"),
+                "branch": buildinfo.get("branch"),
+                "goVersion": buildinfo.get("goVersion"),
+                "ready": ready,
+                "label_count": label_count,
+            },
+        )
+
+    async def _ready_flag(self, target: Target) -> bool:
+        """Return ``True`` when ``GET /ready`` reports the instance ready."""
+        try:
+            resp = await self._unauth_get(target, _READY_PATH)
+        except (httpx.HTTPError, OSError):
+            return False
+        return resp.status_code == 200 and "ready" in (resp.text or "").strip().lower()
+
+    async def probe(self, target: Target) -> ProbeResult:
+        """Reachability check via the tenant-free ``GET /ready``.
+
+        Loki serves ``/ready`` without an org id or credential, so it is the
+        right reachability surface: ``200 "ready"`` -> ok; a ``503`` (ingester
+        not ready) or transport error -> not ok with a structured reason.
+        """
+        start = time.monotonic()
+        probed_at = datetime.now(UTC)
+
+        def _result(ok: bool, reason: str | None) -> ProbeResult:
+            return ProbeResult(
+                ok=ok,
+                reason=reason,
+                latency_ms=(time.monotonic() - start) * 1000.0,
+                probed_at=probed_at,
+            )
+
+        try:
+            resp = await self._unauth_get(target, _READY_PATH)
+        except (httpx.HTTPError, OSError) as exc:
+            return _result(False, f"{type(exc).__name__}: {exc}")
+        if resp.status_code == 200 and "ready" in (resp.text or "").strip().lower():
+            return _result(True, None)
+        return _result(False, "not_ready")
+
+    # ------------------------------------------------------------------
+    # Registration + dispatch shim
+    # ------------------------------------------------------------------
+
+    @classmethod
+    async def register_operations(cls) -> None:
+        """Upsert every op in :data:`LOKI_OPS` into ``endpoint_descriptor``.
+
+        Called from the application lifespan (via the registrar queued in
+        :mod:`meho_backplane.connectors.loki.__init__`) after the registry has
+        eager-imported every connector module. Idempotent across pod restarts,
+        mirroring the argocd / bind9 shape.
+        """
+        from meho_backplane.operations.typed_register import register_typed_operation
+
+        for op in LOKI_OPS:
+            handler = getattr(cls, op.handler_attr, None)
+            if handler is None:
+                raise AttributeError(
+                    f"LokiConnector op {op.op_id!r} declares handler_attr="
+                    f"{op.handler_attr!r} but the class has no such attribute"
+                )
+            when_to_use: str | None
+            if op.group_key is None:
+                when_to_use = None
+            else:
+                when_to_use = LOKI_WHEN_TO_USE_BY_GROUP.get(op.group_key)
+                if when_to_use is None:
+                    raise ValueError(
+                        f"LokiConnector op {op.op_id!r} declares group_key="
+                        f"{op.group_key!r} but no curated when_to_use exists for that key. "
+                        "Add an entry to LOKI_WHEN_TO_USE_BY_GROUP in loki/ops.py."
+                    )
+            await register_typed_operation(
+                product=cls.product,
+                version=cls.version,
+                impl_id=cls.impl_id,
+                op_id=op.op_id,
+                handler=handler,
+                summary=op.summary,
+                description=op.description,
+                parameter_schema=op.parameter_schema,
+                response_schema=op.response_schema,
+                group_key=op.group_key,
+                when_to_use=when_to_use,
+                tags=list(op.tags),
+                safety_level=op.safety_level,
+                requires_approval=op.requires_approval,
+                llm_instructions=op.llm_instructions,
+            )
+        _log.info(
+            "loki_operations_registered",
+            count=len(LOKI_OPS),
+            product=cls.product,
+            version=cls.version,
+            impl_id=cls.impl_id,
+        )
+
+    async def execute(self, target: Target, op_id: str, params: dict[str, Any]) -> OperationResult:
+        """Legacy shim -- delegates to the G0.6 dispatcher.
+
+        Mirrors :meth:`ArgoCdConnector.execute`. Post-G0.6 callers
+        (``/api/v1/operations/call``, MCP ``call_operation``, the CLI verbs)
+        construct a real :class:`Operator` and call
+        :func:`meho_backplane.operations.dispatch` directly. The connector's
+        natural key encodes as ``"loki-api-3.x"`` per ``parse_connector_id``.
+        """
+        from uuid import UUID
+
+        from meho_backplane.auth.operator import TenantRole
+        from meho_backplane.operations import dispatch
+
+        operator = Operator(
+            sub="system:loki-api-connector-shim",
+            name=None,
+            email=None,
+            raw_jwt="",
+            tenant_id=UUID(int=0),
+            tenant_role=TenantRole.OPERATOR,
+        )
+        connector_id = f"{self.impl_id}-{self.version}"
+        return await dispatch(
+            operator=operator,
+            connector_id=connector_id,
+            op_id=op_id,
+            target=target,
+            params=params,
+        )

--- a/backend/src/meho_backplane/connectors/loki/ops.py
+++ b/backend/src/meho_backplane/connectors/loki/ops.py
@@ -1,0 +1,552 @@
+# SPDX-License-Identifier: Apache-2.0
+# Copyright (c) 2026 evoila Group
+
+"""Curated read ops exposed by :class:`LokiConnector` (#2235).
+
+The read core an RDC operator needs to triage the logs half of an LGTM stack
+through the same dispatch -> policy-gate -> audit seam every other connector
+uses, without reaching for ``logcli`` or raw ``curl`` against ``:3100``:
+
+* ``loki.query`` -- ``GET /loki/api/v1/query``; a LogQL instant query at a
+  single point in time.
+* ``loki.query_range`` -- ``GET /loki/api/v1/query_range``; a LogQL query over
+  a time range (the ``logcli query`` default).
+* ``loki.labels`` -- ``GET /loki/api/v1/labels``; the known label names in a
+  time span.
+* ``loki.label_values`` -- ``GET /loki/api/v1/label/{name}/values``; the values
+  a given label takes.
+* ``loki.series`` -- ``GET /loki/api/v1/series``; the streams (unique label
+  sets) matching one or more selectors.
+* ``loki.get`` -- a GET passthrough to any other read endpoint under
+  ``/loki/api/v1`` (gated by
+  :func:`~meho_backplane.connectors.loki.read_only.assert_loki_read_only`).
+
+Every op is ``safety_level="safe"`` + ``requires_approval=False`` and carries a
+``read-only`` tag -- the connector registers no write/mutating op (``push`` /
+``delete`` are blocked outright).
+
+Multi-tenancy: every op accepts an optional ``tenant`` selector that the handler
+renders into the per-call ``X-Scope-OrgID`` header. It is required only when the
+target's Loki has ``auth_enabled`` (multi-tenant); a single-tenant / auth-disabled
+Loki needs none. The dataclass + tuple shape mirrors the argocd (#1391) and
+bind9 (#367) siblings so the registration walk reads identically.
+
+Endpoint + parameter facts are pinned to the Loki HTTP API reference
+(https://grafana.com/docs/loki/latest/reference/loki-http-api/): the query
+endpoints wrap their result under ``{"status":"success","data":{...}}``; the
+metadata endpoints (``labels`` / ``label/<name>/values`` / ``series``) return
+``{"status":"success","data":[...]}``.
+"""
+
+from __future__ import annotations
+
+from dataclasses import dataclass
+from typing import Any, Literal
+
+__all__ = ["LOKI_OPS", "LOKI_WHEN_TO_USE_BY_GROUP", "LokiOp"]
+
+
+@dataclass(frozen=True)
+class LokiOp:
+    """Metadata for one Loki op the connector registers at startup.
+
+    Fields mirror the keyword arguments
+    :func:`~meho_backplane.operations.typed_register.register_typed_operation`
+    accepts so the registrar can splat the dataclass into the helper.
+    ``handler_attr`` is the async-handler attribute name on
+    :class:`~meho_backplane.connectors.loki.connector.LokiConnector`.
+    """
+
+    op_id: str
+    handler_attr: str
+    summary: str
+    description: str
+    parameter_schema: dict[str, Any]
+    response_schema: dict[str, Any] | None
+    group_key: str | None
+    tags: tuple[str, ...]
+    safety_level: Literal["safe", "caution", "dangerous"]
+    requires_approval: bool
+    llm_instructions: dict[str, Any] | None
+
+
+#: Curated ``when_to_use`` blurbs per group. ``register_typed_operation``
+#: requires a non-empty string whenever ``group_key`` is set; the registrar
+#: looks each op's ``group_key`` up here.
+LOKI_WHEN_TO_USE_BY_GROUP: dict[str, str] = {
+    "loki-query": (
+        "Use to run LogQL against Grafana Loki: an instant query at one point "
+        "in time (loki.query), a query over a time range (loki.query_range, the "
+        "usual choice for 'show me the logs / count between T1 and T2'), or a "
+        "raw GET against any other read endpoint under /loki/api/v1 "
+        "(loki.get). The right group when the question is 'what did this service "
+        "log?' or 'how many errors in the last hour?'. Read-only — no push, no "
+        "delete. Pass 'tenant' when the Loki is multi-tenant (auth_enabled)."
+    ),
+    "loki-metadata": (
+        "Use to discover what labels and streams exist in Loki before writing a "
+        "LogQL selector: list label names (loki.labels), list the values a label "
+        "takes (loki.label_values), or list the streams (unique label sets) that "
+        "match a selector (loki.series). The right group when building or "
+        "debugging a '{app=\"...\"}' matcher, or answering 'which namespaces / "
+        "pods report to this Loki?'. Read-only. Pass 'tenant' when the Loki is "
+        "multi-tenant (auth_enabled)."
+    ),
+}
+
+
+# ---------------------------------------------------------------------------
+# Shared parameter-schema fragments
+# ---------------------------------------------------------------------------
+
+#: The per-call multi-tenancy selector rendered into ``X-Scope-OrgID``.
+_TENANT_PROPERTY: dict[str, Any] = {
+    "type": "string",
+    "minLength": 1,
+    "description": (
+        "Loki tenant id, rendered into the per-call X-Scope-OrgID header. "
+        "Required when the target's Loki has auth_enabled (multi-tenant); omit "
+        "for a single-tenant or auth-disabled Loki. Pipe-separate ids "
+        "('a|b') to query across tenants."
+    ),
+}
+
+#: A LogQL query string (required by the two query ops).
+_QUERY_PROPERTY: dict[str, Any] = {
+    "type": "string",
+    "minLength": 1,
+    "pattern": "\\S",
+    "description": 'The LogQL query, e.g. \'{app="api"} |= "error"\'.',
+}
+
+#: A start/end time bound. Loki accepts RFC3339 or a Unix timestamp (seconds or
+#: nanoseconds), so both a string and an integer are allowed.
+_TIME_BOUND: dict[str, Any] = {
+    "type": ["string", "integer"],
+    "description": (
+        "A time bound as RFC3339 ('2026-07-09T00:00:00Z') or a Unix timestamp "
+        "(seconds or nanoseconds)."
+    ),
+}
+
+#: The ``direction`` enum shared by the two query ops.
+_DIRECTION_PROPERTY: dict[str, Any] = {
+    "type": "string",
+    "enum": ["forward", "backward"],
+    "description": "Sort order for returned entries (default 'backward').",
+}
+
+#: The ``limit`` cap shared by the two query ops.
+_LIMIT_PROPERTY: dict[str, Any] = {
+    "type": "integer",
+    "minimum": 1,
+    "description": "Max entries to return (Loki default 100).",
+}
+
+#: The success envelope the query endpoints return.
+_QUERY_RESPONSE_SCHEMA: dict[str, Any] = {
+    "type": "object",
+    "properties": {
+        "status": {"type": "string"},
+        "data": {"type": "object"},
+    },
+    "additionalProperties": True,
+}
+
+#: The success envelope the metadata endpoints return (data is a string array).
+_METADATA_RESPONSE_SCHEMA: dict[str, Any] = {
+    "type": "object",
+    "properties": {
+        "status": {"type": "string"},
+        "data": {"type": ["array", "null"]},
+    },
+    "additionalProperties": True,
+}
+
+
+# ---------------------------------------------------------------------------
+# loki.query
+# ---------------------------------------------------------------------------
+
+_QUERY = LokiOp(
+    op_id="loki.query",
+    handler_attr="query",
+    summary="Run a LogQL instant query against Loki at a single point in time.",
+    description=(
+        "Runs a LogQL instant query via GET /loki/api/v1/query — a query "
+        "evaluated at a single instant (the 'time' param, default now). Use for "
+        "a metric query that yields one vector (e.g. "
+        "'sum(rate({app=\"api\"}[5m]))') or a quick log peek. For 'show me the "
+        "logs between T1 and T2' prefer loki.query_range. Pass 'tenant' on a "
+        "multi-tenant Loki. safety_level=safe, read-only."
+    ),
+    parameter_schema={
+        "type": "object",
+        "properties": {
+            "query": _QUERY_PROPERTY,
+            "time": _TIME_BOUND,
+            "limit": _LIMIT_PROPERTY,
+            "direction": _DIRECTION_PROPERTY,
+            "tenant": _TENANT_PROPERTY,
+        },
+        "required": ["query"],
+        "additionalProperties": False,
+    },
+    response_schema=_QUERY_RESPONSE_SCHEMA,
+    group_key="loki-query",
+    tags=("read-only", "loki", "logql", "logs"),
+    safety_level="safe",
+    requires_approval=False,
+    llm_instructions={
+        "when_to_use": (
+            "Call for an instant LogQL evaluation at one point in time — a "
+            "single-vector metric query or a quick peek. Use loki.query_range "
+            "for anything spanning a time window."
+        ),
+        "parameter_hints": {
+            "query": "A LogQL expression.",
+            "time": "Evaluation instant (RFC3339 or Unix ts); omit for now.",
+            "tenant": "Tenant id for X-Scope-OrgID; required on multi-tenant Loki.",
+        },
+        "output_shape": (
+            "{status:'success', data:{resultType, result:[...]}}. resultType is "
+            "'streams' for a log query or 'vector'/'matrix' for a metric query."
+        ),
+    },
+)
+
+
+# ---------------------------------------------------------------------------
+# loki.query_range
+# ---------------------------------------------------------------------------
+
+_QUERY_RANGE = LokiOp(
+    op_id="loki.query_range",
+    handler_attr="query_range",
+    summary="Run a LogQL query against Loki over a time range.",
+    description=(
+        "Runs a LogQL query over a time range via GET /loki/api/v1/query_range "
+        "— the everyday 'show me the logs / the error rate between start and "
+        "end' op (what 'logcli query' issues). 'start'/'end' bound the window "
+        "(Loki defaults to the last hour); 'step' sets the resolution for a "
+        "metric query; 'direction' and 'limit' page log results. Pass 'tenant' "
+        "on a multi-tenant Loki. safety_level=safe, read-only."
+    ),
+    parameter_schema={
+        "type": "object",
+        "properties": {
+            "query": _QUERY_PROPERTY,
+            "start": _TIME_BOUND,
+            "end": _TIME_BOUND,
+            "since": {
+                "type": "string",
+                "description": (
+                    "A duration ('1h', '15m') used as the lookback when 'start' is omitted."
+                ),
+            },
+            "step": {
+                "type": "string",
+                "description": (
+                    "Query resolution step for metric queries (a duration like "
+                    "'30s' or a float of seconds)."
+                ),
+            },
+            "interval": {
+                "type": "string",
+                "description": "Return entries at most this far apart (a duration).",
+            },
+            "limit": _LIMIT_PROPERTY,
+            "direction": _DIRECTION_PROPERTY,
+            "tenant": _TENANT_PROPERTY,
+        },
+        "required": ["query"],
+        "additionalProperties": False,
+    },
+    response_schema=_QUERY_RESPONSE_SCHEMA,
+    group_key="loki-query",
+    tags=("read-only", "loki", "logql", "logs"),
+    safety_level="safe",
+    requires_approval=False,
+    llm_instructions={
+        "when_to_use": (
+            "The default log-triage op: fetch logs or a metric series across a "
+            "time window. Set start/end (or 'since' for a relative lookback) and "
+            "'limit' to bound the result."
+        ),
+        "parameter_hints": {
+            "query": "A LogQL expression.",
+            "start": "Window start (RFC3339 or Unix ts).",
+            "end": "Window end (RFC3339 or Unix ts); omit for now.",
+            "since": "Relative lookback ('1h') when start is omitted.",
+            "tenant": "Tenant id for X-Scope-OrgID; required on multi-tenant Loki.",
+        },
+        "output_shape": (
+            "{status:'success', data:{resultType, result:[...]}}. For a log "
+            "query each result entry carries 'stream' (labels) and 'values' "
+            "([[ts, line], ...])."
+        ),
+        "pagination_hint": {
+            "params": {
+                "limit": "Cap on returned entries.",
+                "start": "Advance the window start to page forward in time.",
+                "end": "Advance the window end to page backward in time.",
+            },
+            "example_next_call": {
+                "op_id": "loki.query_range",
+                "params": {"query": '{app="api"}', "start": "<last-ts>", "limit": 100},
+            },
+        },
+    },
+)
+
+
+# ---------------------------------------------------------------------------
+# loki.labels
+# ---------------------------------------------------------------------------
+
+_LABELS = LokiOp(
+    op_id="loki.labels",
+    handler_attr="labels",
+    summary="List the known label names in Loki within a time span.",
+    description=(
+        "Lists the label names Loki knows about via GET /loki/api/v1/labels, "
+        "optionally bounded by 'start'/'end' (or 'since') and narrowed by a "
+        "LogQL stream selector 'query'. The entry point for building a "
+        "selector: which label keys exist. Pass 'tenant' on a multi-tenant "
+        "Loki. safety_level=safe, read-only."
+    ),
+    parameter_schema={
+        "type": "object",
+        "properties": {
+            "start": _TIME_BOUND,
+            "end": _TIME_BOUND,
+            "since": {
+                "type": "string",
+                "description": "Relative lookback ('1h') used when 'start' is omitted.",
+            },
+            "query": {
+                "type": "string",
+                "minLength": 1,
+                "description": "Optional LogQL stream selector to narrow the labels.",
+            },
+            "tenant": _TENANT_PROPERTY,
+        },
+        "additionalProperties": False,
+    },
+    response_schema=_METADATA_RESPONSE_SCHEMA,
+    group_key="loki-metadata",
+    tags=("read-only", "loki", "labels"),
+    safety_level="safe",
+    requires_approval=False,
+    llm_instructions={
+        "when_to_use": (
+            "Call first when building a LogQL selector and you don't yet know "
+            "which label keys exist. Follow with loki.label_values to see a "
+            "label's values."
+        ),
+        "parameter_hints": {
+            "tenant": "Tenant id for X-Scope-OrgID; required on multi-tenant Loki.",
+        },
+        "output_shape": "{status:'success', data:['app', 'namespace', ...]}.",
+    },
+)
+
+
+# ---------------------------------------------------------------------------
+# loki.label_values
+# ---------------------------------------------------------------------------
+
+_LABEL_VALUES = LokiOp(
+    op_id="loki.label_values",
+    handler_attr="label_values",
+    summary="List the values a given label takes in Loki.",
+    description=(
+        "Lists the values of one label via "
+        "GET /loki/api/v1/label/{name}/values, optionally bounded by "
+        "'start'/'end' (or 'since') and narrowed by a LogQL stream selector "
+        "'query'. Use after loki.labels to enumerate a label's values (e.g. all "
+        "'namespace' values). Pass 'tenant' on a multi-tenant Loki. "
+        "safety_level=safe, read-only."
+    ),
+    parameter_schema={
+        "type": "object",
+        "properties": {
+            "name": {
+                "type": "string",
+                "minLength": 1,
+                "pattern": "\\S",
+                "description": "The label name whose values to list, e.g. 'namespace'.",
+            },
+            "start": _TIME_BOUND,
+            "end": _TIME_BOUND,
+            "since": {
+                "type": "string",
+                "description": "Relative lookback ('1h') used when 'start' is omitted.",
+            },
+            "query": {
+                "type": "string",
+                "minLength": 1,
+                "description": "Optional LogQL stream selector to narrow the values.",
+            },
+            "tenant": _TENANT_PROPERTY,
+        },
+        "required": ["name"],
+        "additionalProperties": False,
+    },
+    response_schema=_METADATA_RESPONSE_SCHEMA,
+    group_key="loki-metadata",
+    tags=("read-only", "loki", "labels"),
+    safety_level="safe",
+    requires_approval=False,
+    llm_instructions={
+        "when_to_use": (
+            "Call after loki.labels to list the concrete values of a label, so "
+            "you can pin an exact matcher like '{namespace=\"prod\"}'."
+        ),
+        "parameter_hints": {
+            "name": "The label key (from loki.labels).",
+            "tenant": "Tenant id for X-Scope-OrgID; required on multi-tenant Loki.",
+        },
+        "output_shape": "{status:'success', data:['prod', 'staging', ...]}.",
+    },
+)
+
+
+# ---------------------------------------------------------------------------
+# loki.series
+# ---------------------------------------------------------------------------
+
+_SERIES = LokiOp(
+    op_id="loki.series",
+    handler_attr="series",
+    summary="List the streams (unique label sets) matching selectors in Loki.",
+    description=(
+        "Lists the streams — unique label sets — matching one or more LogQL "
+        "selectors via GET /loki/api/v1/series. Each 'match' selector "
+        "(e.g. '{app=\"api\"}') is sent as a repeated 'match[]' query param. Use "
+        "to see exactly which streams a selector resolves to before running a "
+        "query. Pass 'tenant' on a multi-tenant Loki. safety_level=safe, "
+        "read-only."
+    ),
+    parameter_schema={
+        "type": "object",
+        "properties": {
+            "match": {
+                "type": "array",
+                "items": {"type": "string", "minLength": 1},
+                "minItems": 1,
+                "description": (
+                    "One or more LogQL stream selectors; each is sent as a "
+                    "repeated 'match[]' query param."
+                ),
+            },
+            "start": _TIME_BOUND,
+            "end": _TIME_BOUND,
+            "since": {
+                "type": "string",
+                "description": "Relative lookback ('1h') used when 'start' is omitted.",
+            },
+            "tenant": _TENANT_PROPERTY,
+        },
+        "required": ["match"],
+        "additionalProperties": False,
+    },
+    response_schema={
+        "type": "object",
+        "properties": {
+            "status": {"type": "string"},
+            "data": {"type": ["array", "null"]},
+        },
+        "additionalProperties": True,
+    },
+    group_key="loki-metadata",
+    tags=("read-only", "loki", "series"),
+    safety_level="safe",
+    requires_approval=False,
+    llm_instructions={
+        "when_to_use": (
+            "Call to resolve which concrete streams a selector matches — useful "
+            "to confirm a matcher is neither empty nor overly broad before "
+            "querying."
+        ),
+        "parameter_hints": {
+            "match": "A list of LogQL selectors (at least one).",
+            "tenant": "Tenant id for X-Scope-OrgID; required on multi-tenant Loki.",
+        },
+        "output_shape": (
+            "{status:'success', data:[{label: value, ...}, ...]} — one object per matched stream."
+        ),
+    },
+)
+
+
+# ---------------------------------------------------------------------------
+# loki.get (read-only passthrough)
+# ---------------------------------------------------------------------------
+
+_GET = LokiOp(
+    op_id="loki.get",
+    handler_attr="get_passthrough",
+    summary="GET any other read-only Loki endpoint under /loki/api/v1.",
+    description=(
+        "Issues a GET against an arbitrary Loki endpoint under /loki/api/v1 — "
+        "the escape hatch for read endpoints without a curated op (e.g. "
+        "/loki/api/v1/index/stats, /loki/api/v1/patterns). The path is gated: "
+        "only GET, only under /loki/api/v1, and the /push and /delete* surfaces "
+        "are refused outright, so the passthrough can never mutate Loki. "
+        "Optional 'params' become query parameters. Pass 'tenant' on a "
+        "multi-tenant Loki. safety_level=safe, read-only."
+    ),
+    parameter_schema={
+        "type": "object",
+        "properties": {
+            "path": {
+                "type": "string",
+                "minLength": 1,
+                "pattern": "^/loki/api/v1(/.*)?$",
+                "description": (
+                    "The read endpoint path under /loki/api/v1, e.g. "
+                    "'/loki/api/v1/index/stats'. /push and /delete* are rejected."
+                ),
+            },
+            "params": {
+                "type": "object",
+                "description": "Optional query parameters for the request.",
+                "additionalProperties": True,
+            },
+            "tenant": _TENANT_PROPERTY,
+        },
+        "required": ["path"],
+        "additionalProperties": False,
+    },
+    response_schema=None,
+    group_key="loki-query",
+    tags=("read-only", "loki", "passthrough"),
+    safety_level="safe",
+    requires_approval=False,
+    llm_instructions={
+        "when_to_use": (
+            "Use only when a needed read endpoint has no curated op. Prefer the "
+            "curated ops (query/query_range/labels/label_values/series) when they "
+            "fit. The path must be under /loki/api/v1 and cannot be push/delete."
+        ),
+        "parameter_hints": {
+            "path": "A read path under /loki/api/v1.",
+            "params": "A dict of query params.",
+            "tenant": "Tenant id for X-Scope-OrgID; required on multi-tenant Loki.",
+        },
+        "output_shape": "The endpoint's raw JSON body.",
+    },
+)
+
+
+#: The ops :class:`LokiConnector` registers at lifespan startup. Ordered
+#: query -> metadata -> passthrough to match the operator's typical drill path.
+LOKI_OPS: tuple[LokiOp, ...] = (
+    _QUERY,
+    _QUERY_RANGE,
+    _LABELS,
+    _LABEL_VALUES,
+    _SERIES,
+    _GET,
+)

--- a/backend/src/meho_backplane/connectors/loki/read_only.py
+++ b/backend/src/meho_backplane/connectors/loki/read_only.py
@@ -1,0 +1,89 @@
+# SPDX-License-Identifier: Apache-2.0
+# Copyright (c) 2026 evoila Group
+
+"""Read-only enforcement gate for the Loki connector (#2235).
+
+Loki's HTTP API mixes read verbs (``query`` / ``query_range`` / ``labels`` /
+``series``) with the ingest verb ``POST /loki/api/v1/push`` and the deletion
+verbs on ``/loki/api/v1/delete`` (``POST`` / ``PUT`` create a delete request,
+``DELETE`` cancels one, ``GET`` lists them). The connector is read-only **by
+construction** — every handler issues a GET through
+:meth:`~meho_backplane.connectors.adapters.http.HttpConnector._request_json`,
+which rejects non-idempotent verbs — but the generic ``loki.get`` passthrough
+lets a caller name an arbitrary path. This module is the belt-and-suspenders
+gate over that passthrough:
+
+* **Method gate** — only ``GET`` is permitted.
+* **Path allowlist** — the path must live under ``/loki/api/v1``.
+* **Write/delete blocklist** — any path segment equal to ``push`` or beginning
+  ``delete`` is refused, so even ``GET /loki/api/v1/delete`` (the "list delete
+  requests" read) is blocked. The blocklist is deliberately stricter than the
+  method gate: it fails closed on the whole delete surface rather than trusting
+  the verb alone.
+
+The gate is a pure function raising :class:`LokiReadOnlyError` — no I/O,
+no upstream call — so a rejected write never reaches the wire and the unit
+tests can prove rejection without a mock server.
+"""
+
+from __future__ import annotations
+
+__all__ = [
+    "LOKI_API_V1_PREFIX",
+    "LokiReadOnlyError",
+    "assert_loki_read_only",
+]
+
+#: The only wire surface the connector will reach. Every op path and the
+#: ``loki.get`` passthrough must live under this prefix (or be the bare
+#: ``/loki/api/v1`` root).
+LOKI_API_V1_PREFIX = "/loki/api/v1"
+
+
+class LokiReadOnlyError(ValueError):
+    """A requested method/path would mutate Loki state (or leaves the read surface).
+
+    Raised by :func:`assert_loki_read_only` for a non-GET method, a path
+    outside ``/loki/api/v1``, or a path whose segments target the ``push``
+    ingest or ``delete`` surface. Subclasses :class:`ValueError` so the
+    dispatcher's ``connector_error`` branch renders the message verbatim.
+    """
+
+
+def _normalize_path(path: str) -> str:
+    """Return *path* stripped of a query string and normalised to a leading ``/``."""
+    without_query = path.split("?", 1)[0].strip()
+    if not without_query.startswith("/"):
+        without_query = "/" + without_query
+    return without_query
+
+
+def assert_loki_read_only(method: str, path: str) -> None:
+    """Raise :class:`LokiReadOnlyError` unless *method*/*path* is a safe read.
+
+    A safe read is a ``GET`` whose path lives under ``/loki/api/v1`` and whose
+    segments name neither the ``push`` ingest endpoint nor any ``delete*``
+    endpoint. Case-insensitive on both the method and the blocked segments.
+    """
+    if method.upper() != "GET":
+        raise LokiReadOnlyError(
+            f"loki connector is read-only: method {method!r} is not permitted "
+            "(only GET reaches the Loki API)"
+        )
+
+    normalized = _normalize_path(path)
+    if normalized != LOKI_API_V1_PREFIX and not normalized.startswith(f"{LOKI_API_V1_PREFIX}/"):
+        raise LokiReadOnlyError(
+            f"path {path!r} is outside the allowed Loki read surface ({LOKI_API_V1_PREFIX}/...)"
+        )
+
+    # Segment-exact blocklist so a legitimate label value that merely *contains*
+    # 'push' or 'delete' as a substring is not caught, while the actual
+    # ``/push`` and ``/delete*`` endpoints (any verb) are refused.
+    for segment in normalized.split("/"):
+        lowered = segment.lower()
+        if lowered == "push" or lowered.startswith("delete"):
+            raise LokiReadOnlyError(
+                f"path {path!r} targets the Loki write/delete surface "
+                f"(segment {segment!r}); the connector is read-only"
+            )

--- a/backend/tests/test_connectors_loki.py
+++ b/backend/tests/test_connectors_loki.py
@@ -1,0 +1,577 @@
+# SPDX-License-Identifier: Apache-2.0
+# Copyright (c) 2026 evoila Group
+
+"""Tests for the Loki read-only, multi-tenant connector (#2235).
+
+Coverage matrix (per Task #2235 acceptance criteria):
+
+* **Registration** — ``loki`` resolves via ``register_connector_v2`` (versioned
+  triple + wildcard), appears in ``all_connectors_v2()`` and
+  ``registered_product_tokens()``.
+* **Read-only gate** — :func:`assert_loki_read_only` rejects non-GET, ``/push``,
+  ``/delete*`` (even ``GET /delete``), and paths outside ``/loki/api/v1``, with
+  no upstream call.
+* **Multi-tenancy** — a ``query`` with a ``tenant`` selector renders the
+  ``X-Scope-OrgID`` header; without it against an ``auth_enabled`` Loki
+  (401) the connector surfaces a tenant requirement rather than a bare 401.
+* **Readiness probe** — ``GET /ready`` succeeds without a tenant header.
+* **Live dispatch + recorded fixtures** — ``query_range`` and ``label_values``
+  (and the rest) dispatch end-to-end and return the Loki payload.
+* **Optional auth** — ``secret_ref=None`` sends no Authorization header; a
+  ``token`` secret yields Bearer; ``username``/``password`` yields Basic.
+
+respx mocks the wire; the in-process Vault fake exercises the real credential
+loader. Mirrors :mod:`tests.test_connectors_argocd_reads`.
+"""
+
+from __future__ import annotations
+
+import base64
+import uuid
+from collections.abc import AsyncIterator, Iterator
+from typing import Any
+from unittest.mock import AsyncMock
+from uuid import UUID
+
+import pytest
+import respx
+from sqlalchemy.ext.asyncio import AsyncSession
+
+from meho_backplane.auth.operator import Operator, TenantRole
+from meho_backplane.connectors.loki import (
+    LOKI_OPS,
+    LokiConnector,
+    LokiReadOnlyError,
+    LokiTenantRequiredError,
+    assert_loki_read_only,
+)
+from meho_backplane.connectors.registry import (
+    all_connectors_v2,
+    clear_registry,
+    register_connector_v2,
+    registered_product_tokens,
+)
+from meho_backplane.connectors.resolver import resolve_connector
+from meho_backplane.db.engine import get_sessionmaker
+from meho_backplane.operations import dispatch, reset_dispatcher_caches
+from meho_backplane.operations._handler_resolve import reset_handler_cache
+from meho_backplane.settings import get_settings
+
+from ._vault_fakes import install_fake_client
+
+_CANARY_TOKEN = "loki-bearer-canary-must-not-leak"
+
+_PRODUCT = "loki"
+_VERSION = "3.x"
+_IMPL_ID = "loki-api"
+_CONNECTOR_ID = "loki-api-3.x"
+
+_LOKI_HOST = "loki-reads.test.invalid"
+_LOKI_PORT = 3100
+_LOKI_BASE_URL = f"http://{_LOKI_HOST}:{_LOKI_PORT}"
+
+
+@pytest.fixture(autouse=True)
+def _settings_env(monkeypatch: pytest.MonkeyPatch) -> Iterator[None]:
+    """Pin chassis env vars Settings reads (Vault client + dispatcher)."""
+    monkeypatch.setenv("KEYCLOAK_ISSUER_URL", "https://keycloak.test/realms/meho")
+    monkeypatch.setenv("KEYCLOAK_AUDIENCE", "meho-backplane")
+    monkeypatch.setenv("VAULT_ADDR", "https://vault.test")
+    monkeypatch.setenv("VAULT_OIDC_ROLE", "meho-mcp")
+    monkeypatch.setenv("VAULT_OIDC_MOUNT_PATH", "jwt")
+    monkeypatch.setenv("VAULT_TIMEOUT_SECONDS", "5.0")
+    monkeypatch.delenv("VAULT_NAMESPACE", raising=False)
+    get_settings.cache_clear()
+    yield
+    get_settings.cache_clear()
+
+
+@pytest.fixture(autouse=True)
+def _reset_module_state() -> Iterator[None]:
+    """Reset dispatcher/handler caches + connector registry around every test."""
+    reset_dispatcher_caches()
+    reset_handler_cache()
+    clear_registry()
+    register_connector_v2(product=_PRODUCT, version=_VERSION, impl_id=_IMPL_ID, cls=LokiConnector)
+    register_connector_v2(product=_PRODUCT, version="", impl_id="", cls=LokiConnector)
+    yield
+    reset_dispatcher_caches()
+    reset_handler_cache()
+    clear_registry()
+
+
+@pytest.fixture
+def _stub_embedding(monkeypatch: pytest.MonkeyPatch) -> AsyncMock:
+    """Deterministic embedding stub so registration doesn't pull ONNX."""
+    service = AsyncMock()
+    service.encode_one.return_value = [0.1] * 384
+    service.encode.return_value = [[0.1] * 384]
+    service.dimension = 384
+
+    monkeypatch.setattr(
+        "meho_backplane.operations.typed_register.encode_endpoint_text",
+        AsyncMock(return_value=[0.1] * 384),
+    )
+    return service
+
+
+@pytest.fixture
+async def session() -> AsyncIterator[AsyncSession]:
+    """AsyncSession against the autouse-migrated per-worker SQLite engine."""
+    sessionmaker = get_sessionmaker()
+    async with sessionmaker() as s:
+        yield s
+
+
+class _LokiTarget:
+    """Target satisfying both the connector shape and the resolver shape."""
+
+    def __init__(
+        self,
+        *,
+        secret_ref: str | None = None,
+        extras: dict[str, Any] | None = None,
+    ) -> None:
+        self.product = _PRODUCT
+        self.fingerprint = type("_FP", (), {"version": _VERSION})()
+        self.preferred_impl_id: str | None = None
+        self.id: UUID = uuid.uuid4()
+        self.tenant_id: UUID = uuid.UUID("00000000-0000-0000-0000-0000000000b0")
+        self.name = "loki-reads"
+        self.host = _LOKI_HOST
+        self.port = _LOKI_PORT
+        self.secret_ref = secret_ref
+        self.auth_model = None
+        self.verify_tls = True
+        self.tls_ca_pin = None
+        self.tls_server_name = None
+        self.extras = extras or {}
+
+
+def _make_operator() -> Operator:
+    """Operator carrying a non-empty raw_jwt (the fail-closed gate passes)."""
+    return Operator(
+        sub="op-reads-loki",
+        name="Loki Reads Operator",
+        email=None,
+        raw_jwt="op.reads.loki.jwt",
+        tenant_id=UUID("00000000-0000-0000-0000-00000000b0b4"),
+        tenant_role=TenantRole.OPERATOR,
+    )
+
+
+# ---------------------------------------------------------------------------
+# Registration
+# ---------------------------------------------------------------------------
+
+
+def test_loki_resolves_versioned_and_wildcard_and_appears_in_registry() -> None:
+    """AC: loki resolves via register_connector_v2 (versioned + wildcard)."""
+    registry = all_connectors_v2()
+    assert registry[("loki", "3.x", "loki-api")] is LokiConnector
+    assert registry[("loki", "", "")] is LokiConnector
+    assert "loki" in registered_product_tokens()
+
+    # A fingerprinted target resolves to the connector; a version-less target
+    # (fresh, unfingerprinted) still resolves through the wildcard fallback.
+    assert resolve_connector(_LokiTarget()) is LokiConnector
+    fresh = _LokiTarget()
+    fresh.fingerprint = type("_FP", (), {"version": None})()
+    assert resolve_connector(fresh) is LokiConnector
+
+
+def test_every_op_is_safe_read_only_with_closed_schema() -> None:
+    """AC: no write op — every registered op is safe/read-only/no-approval."""
+    assert {op.op_id for op in LOKI_OPS} == {
+        "loki.query",
+        "loki.query_range",
+        "loki.labels",
+        "loki.label_values",
+        "loki.series",
+        "loki.get",
+    }
+    for op in LOKI_OPS:
+        assert op.safety_level == "safe", op.op_id
+        assert op.requires_approval is False, op.op_id
+        assert "read-only" in op.tags, op.op_id
+        assert op.parameter_schema.get("additionalProperties") is False, op.op_id
+
+
+# ---------------------------------------------------------------------------
+# Read-only gate — no upstream call
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.parametrize(
+    ("method", "path"),
+    [
+        ("POST", "/loki/api/v1/push"),
+        ("PUT", "/loki/api/v1/push"),
+        ("GET", "/loki/api/v1/push"),
+        ("POST", "/loki/api/v1/delete"),
+        ("DELETE", "/loki/api/v1/delete"),
+        ("GET", "/loki/api/v1/delete"),
+        ("GET", "/loki/api/v1/delete_requests"),
+        ("POST", "/loki/api/v1/query"),
+        ("GET", "/admin/api/v1/status"),
+        ("GET", "/metrics"),
+    ],
+)
+def test_read_only_gate_rejects_writes_and_off_surface(method: str, path: str) -> None:
+    """AC: /push, /delete*, non-GET, and off-surface paths are rejected."""
+    with pytest.raises(LokiReadOnlyError):
+        assert_loki_read_only(method, path)
+
+
+@pytest.mark.parametrize(
+    "path",
+    [
+        "/loki/api/v1/query",
+        "/loki/api/v1/query_range",
+        "/loki/api/v1/labels",
+        "/loki/api/v1/label/namespace/values",
+        "/loki/api/v1/series",
+        "/loki/api/v1/index/stats",
+    ],
+)
+def test_read_only_gate_accepts_reads(path: str) -> None:
+    """A GET under /loki/api/v1 that is not push/delete passes the gate."""
+    assert_loki_read_only("GET", path)  # returns None; raises on violation
+
+
+def test_read_only_gate_allows_label_value_named_like_a_write_verb() -> None:
+    """A label *value* named 'pushgateway' is a segment, not the /push endpoint."""
+    assert_loki_read_only(  # returns None; raises on violation
+        "GET", "/loki/api/v1/label/job/values?query=pushgateway"
+    )
+
+
+# ---------------------------------------------------------------------------
+# Live dispatch — each op hits the right path and returns the payload
+# ---------------------------------------------------------------------------
+
+_QUERY_RANGE_RESPONSE: dict[str, Any] = {
+    "status": "success",
+    "data": {
+        "resultType": "streams",
+        "result": [
+            {"stream": {"app": "api"}, "values": [["1720000000000000000", "boot ok"]]},
+        ],
+    },
+}
+_LABEL_VALUES_RESPONSE: dict[str, Any] = {"status": "success", "data": ["prod", "staging"]}
+_QUERY_RESPONSE: dict[str, Any] = {
+    "status": "success",
+    "data": {"resultType": "vector", "result": []},
+}
+_LABELS_RESPONSE: dict[str, Any] = {"status": "success", "data": ["app", "namespace"]}
+_SERIES_RESPONSE: dict[str, Any] = {"status": "success", "data": [{"app": "api"}]}
+
+
+async def _register_ops(_stub_embedding: AsyncMock) -> None:
+    await LokiConnector.register_operations()
+
+
+@pytest.mark.parametrize(
+    ("op_id", "params", "path", "payload"),
+    [
+        (
+            "loki.query",
+            {"query": '{app="api"}'},
+            "/loki/api/v1/query",
+            _QUERY_RESPONSE,
+        ),
+        (
+            "loki.query_range",
+            {"query": '{app="api"}', "start": "1720000000", "limit": 100},
+            "/loki/api/v1/query_range",
+            _QUERY_RANGE_RESPONSE,
+        ),
+        ("loki.labels", {}, "/loki/api/v1/labels", _LABELS_RESPONSE),
+        (
+            "loki.label_values",
+            {"name": "namespace"},
+            "/loki/api/v1/label/namespace/values",
+            _LABEL_VALUES_RESPONSE,
+        ),
+        (
+            "loki.series",
+            {"match": ['{app="api"}']},
+            "/loki/api/v1/series",
+            _SERIES_RESPONSE,
+        ),
+    ],
+)
+@pytest.mark.asyncio
+async def test_each_read_op_dispatches_live_and_returns_payload(
+    _stub_embedding: AsyncMock,
+    session: AsyncSession,
+    op_id: str,
+    params: dict[str, Any],
+    path: str,
+    payload: dict[str, Any],
+) -> None:
+    """AC: query_range + label_values (and siblings) dispatch and return the payload."""
+    await _register_ops(_stub_embedding)
+
+    async with respx.mock(base_url=_LOKI_BASE_URL, assert_all_called=False) as mock:
+        route = mock.get(path).respond(200, json=payload)
+        result = await dispatch(
+            operator=_make_operator(),
+            connector_id=_CONNECTOR_ID,
+            op_id=op_id,
+            target=_LokiTarget(),
+            params=params,
+        )
+
+    assert result.status == "ok", result.error
+    assert result.result == payload
+    assert route.called and route.call_count == 1
+    # Unauthenticated target: no Authorization header on the wire.
+    assert route.calls[0].request.headers.get("authorization") is None
+
+
+@pytest.mark.asyncio
+async def test_series_forwards_repeated_match_param(
+    _stub_embedding: AsyncMock, session: AsyncSession
+) -> None:
+    """loki.series sends each selector as a repeated match[] query param."""
+    await _register_ops(_stub_embedding)
+
+    async with respx.mock(base_url=_LOKI_BASE_URL, assert_all_called=False) as mock:
+        route = mock.get("/loki/api/v1/series").respond(200, json=_SERIES_RESPONSE)
+        result = await dispatch(
+            operator=_make_operator(),
+            connector_id=_CONNECTOR_ID,
+            op_id="loki.series",
+            target=_LokiTarget(),
+            params={"match": ['{app="api"}', '{app="web"}']},
+        )
+
+    assert result.status == "ok", result.error
+    sent = str(route.calls[0].request.url)
+    assert sent.count("match%5B%5D=") == 2 or sent.count("match[]=") == 2
+
+
+@pytest.mark.asyncio
+async def test_get_passthrough_rejects_delete_without_upstream_call(
+    _stub_embedding: AsyncMock, session: AsyncSession
+) -> None:
+    """AC: the loki.get passthrough refuses the /delete surface, no wire call."""
+    await _register_ops(_stub_embedding)
+
+    async with respx.mock(base_url=_LOKI_BASE_URL, assert_all_called=False) as mock:
+        route = mock.get("/loki/api/v1/delete").respond(200, json={})
+        result = await dispatch(
+            operator=_make_operator(),
+            connector_id=_CONNECTOR_ID,
+            op_id="loki.get",
+            target=_LokiTarget(),
+            params={"path": "/loki/api/v1/delete"},
+        )
+
+    assert result.status == "error"
+    assert not route.called
+
+
+# ---------------------------------------------------------------------------
+# Multi-tenancy — X-Scope-OrgID
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.asyncio
+async def test_query_with_tenant_sends_x_scope_orgid(
+    _stub_embedding: AsyncMock, session: AsyncSession
+) -> None:
+    """AC: a query with a tenant selector renders the X-Scope-OrgID header."""
+    await _register_ops(_stub_embedding)
+
+    async with respx.mock(base_url=_LOKI_BASE_URL, assert_all_called=False) as mock:
+        route = mock.get("/loki/api/v1/query").respond(200, json=_QUERY_RESPONSE)
+        result = await dispatch(
+            operator=_make_operator(),
+            connector_id=_CONNECTOR_ID,
+            op_id="loki.query",
+            target=_LokiTarget(),
+            params={"query": '{app="api"}', "tenant": "team-a"},
+        )
+
+    assert result.status == "ok", result.error
+    assert route.calls[0].request.headers.get("x-scope-orgid") == "team-a"
+
+
+@pytest.mark.asyncio
+async def test_query_without_tenant_surfaces_tenant_requirement_on_401(
+    _stub_embedding: AsyncMock, session: AsyncSession
+) -> None:
+    """AC: a tenant-less query against auth_enabled Loki (401) surfaces the requirement."""
+    await _register_ops(_stub_embedding)
+
+    async with respx.mock(base_url=_LOKI_BASE_URL, assert_all_called=False) as mock:
+        mock.get("/loki/api/v1/query").respond(401, text="no org id")
+        result = await dispatch(
+            operator=_make_operator(),
+            connector_id=_CONNECTOR_ID,
+            op_id="loki.query",
+            target=_LokiTarget(),
+            params={"query": '{app="api"}'},
+        )
+
+    assert result.status == "error"
+    assert result.error is not None
+    # The tenant requirement is surfaced as the dedicated error type, not a
+    # bare 401 / HTTPStatusError passthrough.
+    assert "tenantrequired" in result.error.lower().replace("_", "")
+    assert "httpstatuserror" not in result.error.lower()
+
+
+@pytest.mark.asyncio
+async def test_loki_tenant_required_error_raised_directly() -> None:
+    """The _loki_get helper raises LokiTenantRequiredError on a tenant-less 401."""
+    connector = LokiConnector()
+    try:
+        async with respx.mock(base_url=_LOKI_BASE_URL, assert_all_called=False) as mock:
+            mock.get("/loki/api/v1/query").respond(401, text="no org id")
+            with pytest.raises(LokiTenantRequiredError):
+                await connector._loki_get(
+                    _make_operator(), _LokiTarget(), "/loki/api/v1/query", params={"query": "x"}
+                )
+    finally:
+        await connector.aclose()
+
+
+# ---------------------------------------------------------------------------
+# Readiness probe — tenant-free
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.asyncio
+async def test_probe_ok_without_tenant_header() -> None:
+    """AC: GET /ready succeeds without a tenant header."""
+    connector = LokiConnector()
+    try:
+        async with respx.mock(base_url=_LOKI_BASE_URL, assert_all_called=False) as mock:
+            route = mock.get("/ready").respond(200, text="ready\n")
+            result = await connector.probe(_LokiTarget())
+    finally:
+        await connector.aclose()
+
+    assert result.ok is True
+    assert route.called
+    assert route.calls[0].request.headers.get("x-scope-orgid") is None
+
+
+@pytest.mark.asyncio
+async def test_probe_not_ready_maps_to_not_ok() -> None:
+    """A 503 from /ready maps to a non-ok probe with a structured reason."""
+    connector = LokiConnector()
+    try:
+        async with respx.mock(base_url=_LOKI_BASE_URL, assert_all_called=False) as mock:
+            mock.get("/ready").respond(503, text="Ingester not ready")
+            result = await connector.probe(_LokiTarget())
+    finally:
+        await connector.aclose()
+
+    assert result.ok is False
+    assert result.reason is not None
+
+
+@pytest.mark.asyncio
+async def test_fingerprint_from_buildinfo_ready_and_labels() -> None:
+    """fingerprint reads version+revision from buildinfo and label_count from labels."""
+    connector = LokiConnector()
+    try:
+        async with respx.mock(base_url=_LOKI_BASE_URL, assert_all_called=False) as mock:
+            mock.get("/loki/api/v1/status/buildinfo").respond(
+                200, json={"version": "3.1.0", "revision": "abc123", "branch": "HEAD"}
+            )
+            mock.get("/ready").respond(200, text="ready")
+            mock.get("/loki/api/v1/labels").respond(
+                200, json={"status": "success", "data": ["app", "namespace", "pod"]}
+            )
+            fp = await connector.fingerprint(_LokiTarget())
+    finally:
+        await connector.aclose()
+
+    assert fp.reachable is True
+    assert fp.vendor == "grafana"
+    assert fp.product == "loki"
+    assert fp.version == "3.1.0"
+    assert fp.extras["revision"] == "abc123"
+    assert fp.extras["ready"] is True
+    assert fp.extras["label_count"] == 3
+
+
+@pytest.mark.asyncio
+async def test_fingerprint_unreachable_maps_to_not_reachable() -> None:
+    """A transport failure on buildinfo maps to reachable=False with an error."""
+    connector = LokiConnector()
+    try:
+        async with respx.mock(base_url=_LOKI_BASE_URL, assert_all_called=False) as mock:
+            mock.get("/loki/api/v1/status/buildinfo").mock(
+                side_effect=__import__("httpx").ConnectError("boom")
+            )
+            fp = await connector.fingerprint(_LokiTarget())
+    finally:
+        await connector.aclose()
+
+    assert fp.reachable is False
+    assert "error" in fp.extras
+
+
+# ---------------------------------------------------------------------------
+# Optional auth — Bearer / Basic / none
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.asyncio
+async def test_auth_headers_optional_when_no_secret_ref() -> None:
+    """AC: secret_ref=None sends no Authorization header (optional auth)."""
+    connector = LokiConnector()
+    headers = await connector.auth_headers(_LokiTarget(secret_ref=None), _make_operator())
+    assert headers == {}
+
+
+@pytest.mark.asyncio
+async def test_bearer_auth_when_token_secret(
+    _stub_embedding: AsyncMock, session: AsyncSession, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    """A token secret yields an Authorization: Bearer header on the wire."""
+    await _register_ops(_stub_embedding)
+    install_fake_client(monkeypatch, secret={"token": _CANARY_TOKEN})
+
+    async with respx.mock(base_url=_LOKI_BASE_URL, assert_all_called=False) as mock:
+        route = mock.get("/loki/api/v1/labels").respond(200, json=_LABELS_RESPONSE)
+        result = await dispatch(
+            operator=_make_operator(),
+            connector_id=_CONNECTOR_ID,
+            op_id="loki.labels",
+            target=_LokiTarget(secret_ref="targets/op-reads/loki"),
+            params={},
+        )
+
+    assert result.status == "ok", result.error
+    assert route.calls[0].request.headers.get("authorization") == f"Bearer {_CANARY_TOKEN}"
+
+
+@pytest.mark.asyncio
+async def test_basic_auth_when_username_password_secret(
+    _stub_embedding: AsyncMock, session: AsyncSession, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    """A username/password secret yields an Authorization: Basic header."""
+    await _register_ops(_stub_embedding)
+    install_fake_client(monkeypatch, secret={"username": "loki-ro", "password": "s3cr3t"})
+
+    async with respx.mock(base_url=_LOKI_BASE_URL, assert_all_called=False) as mock:
+        route = mock.get("/loki/api/v1/labels").respond(200, json=_LABELS_RESPONSE)
+        result = await dispatch(
+            operator=_make_operator(),
+            connector_id=_CONNECTOR_ID,
+            op_id="loki.labels",
+            target=_LokiTarget(secret_ref="targets/op-reads/loki"),
+            params={},
+        )
+
+    assert result.status == "ok", result.error
+    expected = base64.b64encode(b"loki-ro:s3cr3t").decode("ascii")
+    assert route.calls[0].request.headers.get("authorization") == f"Basic {expected}"

--- a/cli/api/openapi.json
+++ b/cli/api/openapi.json
@@ -25386,6 +25386,7 @@
               "holodeck",
               "k8s",
               "keycloak",
+              "loki",
               "nsx",
               "pfsense",
               "sddc",

--- a/cli/internal/api/client.gen.go
+++ b/cli/internal/api/client.gen.go
@@ -332,6 +332,7 @@ const (
 	Holodeck TargetCreateProduct = "holodeck"
 	K8s      TargetCreateProduct = "k8s"
 	Keycloak TargetCreateProduct = "keycloak"
+	Loki     TargetCreateProduct = "loki"
 	Nsx      TargetCreateProduct = "nsx"
 	Pfsense  TargetCreateProduct = "pfsense"
 	Sddc     TargetCreateProduct = "sddc"

--- a/docs/codebase/connectors-loki.md
+++ b/docs/codebase/connectors-loki.md
@@ -1,0 +1,128 @@
+# Connector: loki (Grafana Loki 3.x)
+
+## Overview
+
+The `loki` connector is a hand-rolled `HttpConnector` subclass that dispatches
+read-only Grafana Loki HTTP-API operations under the
+`(product="loki", version="3.x", impl_id="loki-api")` registry triple (plus the
+`("loki", "", "")` wildcard fallback for a fresh, unfingerprinted target). It
+brings the logs half of an LGTM observability stack inside the MEHO
+dispatch → policy-gate → audit seam, so an agent can run LogQL triage through
+the same governed surface every other connector uses (#2235, under Initiative
+#2228).
+
+The connector is **read-only by construction** — every operation issues a GET,
+and the generic passthrough is gated to the `/loki/api/v1` read surface with an
+explicit `/push` + `/delete*` blocklist — and **multi-tenant** — each op accepts
+an optional `tenant` selector that renders Loki's `X-Scope-OrgID` header per
+call, while the readiness probe and fingerprint stay tenant-free.
+
+Source: `backend/src/meho_backplane/connectors/loki/`.
+
+## Key types
+
+- **`LokiConnector`** (`connector.py`) — `HttpConnector` subclass. Class
+  attributes: `product="loki"`, `version="3.x"`, `impl_id="loki-api"`,
+  `supported_version_range=">=2.9,<4.0"`, `priority=1`. The priority outranks a
+  future `GenericRestConnector` auto-shim (priority 0) if both somehow register
+  for the same triple.
+- **`LokiOp`** (`ops.py`) — frozen dataclass carrying one op's registration
+  metadata (op id, handler attr, schemas, group key, safety level, tags,
+  `llm_instructions`). `LOKI_OPS` is the tuple the registrar walks;
+  `LOKI_WHEN_TO_USE_BY_GROUP` supplies the per-group `when_to_use` blurb the
+  registration helper requires.
+- **`assert_loki_read_only` / `LokiReadOnlyError`** (`read_only.py`) — the pure
+  read-only gate (no I/O) and its violation type. Raised for a non-GET method,
+  a path outside `/loki/api/v1`, or a path whose segments name the `push`
+  ingest or any `delete*` endpoint.
+- **`LokiTenantRequiredError`** (`connector.py`) — raised when a query returns
+  `401` and no `tenant` was supplied (Loki's `auth_enabled` "no org id" case),
+  so the operator gets an actionable "pass a tenant" message rather than a bare
+  401 passthrough.
+
+## Control flow
+
+### Registration (two-phase, mirrors argocd/pfsense)
+
+- **Import time** — `loki/__init__.py` calls `register_connector_v2` twice
+  (versioned triple + wildcard). `_eager_import_connectors` discovers the
+  subpackage by directory name, so no central import-list edit is needed. The
+  connector's `product="loki"` also enters the `TargetCreate.product` OpenAPI
+  enum via `registered_product_tokens()` (regenerated CLI snapshot at
+  `cli/api/openapi.json`).
+- **Lifespan** — `register_loki_typed_operations` (queued via
+  `register_typed_op_registrar`) delegates to
+  `LokiConnector.register_operations`, which upserts the six descriptors into
+  `endpoint_descriptor`. Idempotent across restarts.
+
+### Dispatch
+
+An op dispatches through `meho_backplane.operations.dispatch`, which resolves
+the connector, runs the policy gate, validates params, and invokes the bound
+handler `(operator, target, params)`. Each read handler:
+
+1. builds the query dict from `params` (`_forward` copies present, non-None
+   keys),
+2. calls `_loki_get`, which runs `assert_loki_read_only("GET", path)` first (so
+   a bad path never reaches the wire), renders `tenant` into the
+   `X-Scope-OrgID` header when set, issues the retried GET via the base
+   `_request_json`, and translates a tenant-less `401` into
+   `LokiTenantRequiredError`.
+
+Ops: `loki.query`, `loki.query_range`, `loki.labels`, `loki.label_values`,
+`loki.series`, and the gated `loki.get` passthrough.
+
+### Auth (optional)
+
+`auth_headers` returns `{}` when `target.secret_ref is None` — the common
+unauthenticated port-forward case. When `secret_ref` is set, the stored KV-v2
+secret selects the scheme: a `token` field → `Authorization: Bearer <token>`;
+`username` + `password` → `Authorization: Basic <base64>`. A configured secret
+carrying neither shape raises `VaultCredentialsReadError`. This is the explicit
+"auth optional when `secret_ref is None`" branch — op execution otherwise fails
+closed on an unresolved credential.
+
+### Fingerprint / probe (tenant-free, unauthenticated)
+
+`fingerprint()` reads `GET /loki/api/v1/status/buildinfo` (`version`,
+`revision`, `branch`, `goVersion`), `GET /ready` (readiness flag), and a
+best-effort `GET /loki/api/v1/labels` (`label_count`, `None` when the tenant-free
+read 401s on an `auth_enabled` Loki). All three go through `_unauth_get`, which
+hits the pooled client directly (no auth, no tenant), so the fingerprint works
+on a freshly registered target before any secret exists — the argocd
+`/api/version` precedent. `probe()` uses the tenant-free `GET /ready`
+(`200 "ready"` → ok; `503`/transport error → not ok with a reason).
+
+## Dependencies
+
+- `HttpConnector` (`connectors/adapters/http.py`) — pooled `httpx.AsyncClient`,
+  retry policy, SSRF guard, TLS trust, and the `_request_json` seam whose
+  `extra_headers` carries `X-Scope-OrgID`.
+- `_shared/vault_creds.py` — `load_vault_secret_data` + `strip_credential_value`
+  for the optional Bearer/Basic credential read.
+- `operations/typed_register.py` — `register_typed_operation` and the registrar
+  queue.
+
+## Scheme
+
+Loki's native API is plaintext HTTP (the port-forward case), so `_base_url`
+defaults to `http`. A TLS-fronted Loki is reached by setting
+`extras={"scheme": "https"}` on the target — the single per-product field the
+base `Target` model does not carry as a column, held in the forward-compat
+`extras` bag. The port is appended unless it is the scheme default (80/443).
+
+## Known issues
+
+- `connector.py` (~520 lines) and `ops.py` (~550 lines) sit above the
+  code-quality warn threshold (400) but below the block threshold (600); the op
+  metadata is verbose by nature. Split if either approaches 600.
+- `label_count` in the fingerprint is best-effort: it is `None` against an
+  `auth_enabled` Loki because the tenant-free `/labels` read 401s there.
+
+## References
+
+- Loki HTTP API: <https://grafana.com/docs/loki/latest/reference/loki-http-api/>
+- Multi-tenancy (`X-Scope-OrgID`):
+  <https://grafana.com/docs/loki/latest/operations/multi-tenancy/>
+- Sibling read-only connector: `docs/codebase/connectors-argocd.md`.
+- Task #2235; Initiative #2228 (data-tier + hypervisor connector coverage).


### PR DESCRIPTION
## Summary
- Add `LokiConnector`, a read-only, multi-tenant `HttpConnector` over the Grafana Loki HTTP API (`/loki/api/v1`, :3100) under the `(product="loki", version="3.x", impl_id="loki-api")` v2 registry triple + wildcard fallback (dual registration, discovered by `_eager_import_connectors`).
- **Read-only by construction:** every op is a GET; the `loki.get` passthrough runs through `assert_loki_read_only` — a GET-only, `/loki/api/v1`-scoped gate with an explicit `/push` + `/delete*` segment blocklist — so a write never reaches the wire.
- **Multi-tenant per call:** each op takes an optional `tenant` selector rendered into the `X-Scope-OrgID` header; the readiness probe and fingerprint stay tenant-free. A tenant-less query against an `auth_enabled` Loki (401) surfaces `LokiTenantRequiredError`, not a bare 401.
- **Optional auth:** `secret_ref=None` → no `Authorization` header (the port-forward case); a `token` secret → Bearer, `username`+`password` → Basic. `fingerprint()` reads `status/buildinfo` + `/ready` + a best-effort label count, all unauthenticated so it works on a freshly registered target.
- Ops: `query`, `query_range`, `labels`, `label_values`, `series`, and the gated `get` passthrough. The new `loki` product token enters the `TargetCreate.product` enum, so the CLI OpenAPI snapshot + generated client are regenerated.

## Test plan
- [x] `ruff check` / `ruff format --check` — clean (loki package + test)
- [x] `mypy src/.../connectors/loki/` — clean
- [x] `code-quality.py --diff` — 0 blockers (2 size warnings, both < 600-line block threshold)
- [x] `pytest tests/test_connectors_loki.py` — 36 passed
- [x] `loki` resolves via `register_connector_v2` (versioned + wildcard), appears in `all_connectors_v2()` / `registered_product_tokens()`
- [x] read-only gate rejects `/push`, `/delete*` (incl. `GET /delete`), non-GET, and off-`/loki/api/v1` paths — unit test, no upstream call
- [x] a `query` with `tenant` sends `X-Scope-OrgID`; tenant-less 401 surfaces the tenant requirement
- [x] `GET /ready` probe succeeds without a tenant header
- [x] recorded-fixture coverage for `query_range` + `label_values` (and the rest); Bearer + Basic auth asserted on the wire
- [x] `pytest` registry / product-enum / ingest-catalog / connector sweep — 164 passed

## Out of scope
- Write ops (`push` / `delete`) — read-only connector by construction (a future G3.x write-surface initiative would add any).
- Sibling connectors under the initiative (rabbitmq/prometheus/postgres/mongodb/proxmox — #2233–#2238).
- `connector.py` (~520 lines) and `ops.py` (~550 lines) sit above the code-quality *warn* threshold (400) but below the *block* threshold (600); noted as adjacent findings.

<!-- auto-implement-issue: fresh, iteration 1 -->

Closes #2235
